### PR TITLE
delegation: refactor delegation list expansions so they have `LocalExpnId`

### DIFF
--- a/compiler/rustc_ast_lowering/src/item.rs
+++ b/compiler/rustc_ast_lowering/src/item.rs
@@ -259,7 +259,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
             hir_id,
             &i.attrs,
             i.span,
-            Target::from_ast_item(i),
+            Target::from_item_kind(&i.kind),
             &extra_hir_attributes,
         );
 

--- a/compiler/rustc_expand/src/expand.rs
+++ b/compiler/rustc_expand/src/expand.rs
@@ -1,3 +1,4 @@
+use std::marker::PhantomData;
 use std::path::PathBuf;
 use std::rc::Rc;
 use std::sync::Arc;
@@ -375,6 +376,58 @@ pub struct Invocation {
     pub expansion_data: ExpansionData,
 }
 
+pub enum DelegationAst {
+    Item(Box<ast::Item>),
+    AssocItem(Box<ast::AssocItem>, ast::visit::AssocCtxt),
+}
+
+impl DelegationAst {
+    pub fn span(&self) -> Span {
+        match self {
+            DelegationAst::AssocItem(item, _) => item.span,
+            DelegationAst::Item(item) => item.span,
+        }
+    }
+
+    pub fn span_mut(&mut self) -> &mut Span {
+        match self {
+            DelegationAst::AssocItem(item, _) => &mut item.span,
+            DelegationAst::Item(item) => &mut item.span,
+        }
+    }
+
+    pub fn delegation(&self) -> &ast::DelegationMac {
+        match self {
+            DelegationAst::AssocItem(item, _) => match &item.kind {
+                AssocItemKind::DelegationMac(d) => d,
+                _ => unreachable!(),
+            },
+            DelegationAst::Item(item) => match &item.kind {
+                ItemKind::DelegationMac(d) => &d,
+                _ => unreachable!(),
+            },
+        }
+    }
+
+    pub fn attrs(&self) -> &ast::AttrVec {
+        match self {
+            DelegationAst::AssocItem(item, _) => &item.attrs,
+            DelegationAst::Item(item) => &item.attrs,
+        }
+    }
+
+    pub fn vis(&self) -> &ast::Visibility {
+        match self {
+            DelegationAst::AssocItem(item, _) => &item.vis,
+            DelegationAst::Item(item) => &item.vis,
+        }
+    }
+
+    pub fn from_glob(&self) -> bool {
+        matches!(self.delegation().suffixes, DelegationSuffixes::Glob { .. })
+    }
+}
+
 pub enum InvocationKind {
     Bang {
         mac: Box<ast::MacCall>,
@@ -393,10 +446,8 @@ pub enum InvocationKind {
         is_const: bool,
         item: Annotatable,
     },
-    GlobDelegation {
-        item: Box<ast::AssocItem>,
-        /// Whether this is a trait impl or an inherent impl
-        of_trait: bool,
+    Delegation {
+        ast: DelegationAst,
     },
 }
 
@@ -425,7 +476,7 @@ impl Invocation {
             InvocationKind::Bang { span, .. } => *span,
             InvocationKind::Attr { attr, .. } => attr.span,
             InvocationKind::Derive { path, .. } => path.span,
-            InvocationKind::GlobDelegation { item, .. } => item.span,
+            InvocationKind::Delegation { ast, .. } => ast.span(),
         }
     }
 
@@ -434,7 +485,7 @@ impl Invocation {
             InvocationKind::Bang { span, .. } => span,
             InvocationKind::Attr { attr, .. } => &mut attr.span,
             InvocationKind::Derive { path, .. } => &mut path.span,
-            InvocationKind::GlobDelegation { item, .. } => &mut item.span,
+            InvocationKind::Delegation { ast, .. } => ast.span_mut(),
         }
     }
 }
@@ -968,36 +1019,97 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
                 }
                 _ => unreachable!(),
             },
-            InvocationKind::GlobDelegation { item, of_trait } => {
-                let AssocItemKind::DelegationMac(deleg) = &item.kind else { unreachable!() };
-                let suffixes = match ext {
-                    SyntaxExtensionKind::GlobDelegation(expander) => match expander.expand(self.cx)
-                    {
-                        ExpandResult::Ready(suffixes) => suffixes,
-                        ExpandResult::Retry(()) => {
-                            // Reassemble the original invocation for retrying.
-                            return ExpandResult::Retry(Invocation {
-                                kind: InvocationKind::GlobDelegation { item, of_trait },
-                                ..invoc
-                            });
+            InvocationKind::Delegation { ast } => {
+                let deleg = ast.delegation();
+                let suffixes = match ast.from_glob() {
+                    true => match ext {
+                        SyntaxExtensionKind::GlobDelegation(expander) => {
+                            match expander.expand(self.cx) {
+                                ExpandResult::Ready(suffixes) => suffixes,
+                                ExpandResult::Retry(()) => {
+                                    // Reassemble the original invocation for retrying.
+                                    return ExpandResult::Retry(Invocation {
+                                        kind: InvocationKind::Delegation { ast },
+                                        ..invoc
+                                    });
+                                }
+                            }
                         }
+                        SyntaxExtensionKind::Bang(..) => {
+                            let msg = "expanded a dummy glob delegation";
+                            let guar = self.cx.dcx().span_delayed_bug(span, msg);
+                            return ExpandResult::Ready(fragment_kind.dummy(span, guar));
+                        }
+                        _ => unreachable!(),
                     },
-                    SyntaxExtensionKind::Bang(..) => {
-                        let msg = "expanded a dummy glob delegation";
-                        let guar = self.cx.dcx().span_delayed_bug(span, msg);
-                        return ExpandResult::Ready(fragment_kind.dummy(span, guar));
+                    false => {
+                        let DelegationSuffixes::List(suffixes) = &deleg.suffixes else {
+                            unreachable!()
+                        };
+
+                        suffixes.to_vec()
                     }
-                    _ => unreachable!(),
                 };
 
-                type Node = AstNodeWrapper<Box<ast::AssocItem>, ImplItemTag>;
-                let single_delegations = build_single_delegations::<Node>(
-                    self.cx, deleg, &item, &suffixes, item.span, true,
-                );
-                // `-Zmacro-stats` ignores these because they don't seem important.
-                fragment_kind.expect_from_annotatables(single_delegations.map(|item| {
-                    Annotatable::AssocItem(Box::new(item), AssocCtxt::Impl { of_trait })
-                }))
+                let ast = &ast;
+                match ast {
+                    &DelegationAst::AssocItem(_, assoc_context) => {
+                        struct Data<'a> {
+                            ast: &'a DelegationAst,
+                            fragment_kind: AstFragmentKind,
+                            assoc_context: ast::visit::AssocCtxt,
+                        }
+
+                        struct Builder<TTag>(PhantomData<TTag>);
+
+                        impl<TTag> Builder<TTag>
+                        where
+                            AstNodeWrapper<Box<ast::AssocItem>, TTag>:
+                                InvocationCollectorNode<ItemKind = ast::AssocItemKind>,
+                        {
+                            fn build(
+                                ecx: &ExtCtxt<'_>,
+                                suffixes: &[(Ident, Option<Ident>)],
+                                data: Data<'_>,
+                            ) -> AstFragment {
+                                let single_delegations =
+                                    build_single_delegations::<
+                                        AstNodeWrapper<Box<ast::AssocItem>, TTag>,
+                                    >(ecx, data.ast, suffixes);
+
+                                // `-Zmacro-stats` ignores these because they don't seem important.
+                                data.fragment_kind.expect_from_annotatables(single_delegations.map(
+                                    |item| {
+                                        Annotatable::AssocItem(Box::new(item), data.assoc_context)
+                                    },
+                                ))
+                            }
+                        }
+
+                        let data = Data { assoc_context, ast, fragment_kind };
+                        let suffixes = &suffixes;
+
+                        match assoc_context {
+                            ast::visit::AssocCtxt::Impl { of_trait } => match of_trait {
+                                true => Builder::<TraitImplItemTag>::build(self.cx, suffixes, data),
+                                false => Builder::<ImplItemTag>::build(self.cx, suffixes, data),
+                            },
+                            ast::visit::AssocCtxt::Trait => {
+                                Builder::<TraitItemTag>::build(self.cx, suffixes, data)
+                            }
+                        }
+                    }
+                    DelegationAst::Item(_) => {
+                        type Node = AstNodeWrapper<Box<ast::Item>, ItemTag>;
+                        let single_delegations =
+                            build_single_delegations::<Node>(self.cx, &ast, &suffixes);
+
+                        // `-Zmacro-stats` ignores these because they don't seem important.
+                        fragment_kind.expect_from_annotatables(
+                            single_delegations.map(|item| Annotatable::Item(Box::new(item))),
+                        )
+                    }
+                }
             }
         })
     }
@@ -1277,12 +1389,6 @@ trait InvocationCollectorNode: HasAttrs + HasNodeId + Sized {
     fn delegation_item_kind(_deleg: Box<ast::Delegation>) -> Self::ItemKind {
         unreachable!()
     }
-    fn from_item(_item: ast::Item<Self::ItemKind>) -> Self {
-        unreachable!()
-    }
-    fn flatten_outputs(_outputs: impl Iterator<Item = Self::OutputTy>) -> Self::OutputTy {
-        unreachable!()
-    }
     fn pre_flat_map_node_collect_attr(_cfg: &StripUnconfigured<'_>, _attr: &ast::Attribute) {}
     fn post_flat_map_node_collect_bang(_output: &mut Self::OutputTy, _add_semicolon: AddSemicolon) {
     }
@@ -1339,12 +1445,6 @@ impl InvocationCollectorNode for Box<ast::Item> {
     }
     fn delegation_item_kind(deleg: Box<ast::Delegation>) -> Self::ItemKind {
         ItemKind::Delegation(deleg)
-    }
-    fn from_item(item: ast::Item<Self::ItemKind>) -> Self {
-        Box::new(item)
-    }
-    fn flatten_outputs(items: impl Iterator<Item = Self::OutputTy>) -> Self::OutputTy {
-        items.flatten().collect()
     }
     fn wrap_flat_map_node_walk_flat_map(
         mut node: Self,
@@ -1462,7 +1562,7 @@ impl InvocationCollectorNode for Box<ast::Item> {
     }
 
     fn as_target(&self) -> Target {
-        Target::from_ast_item(self)
+        Target::from_item_kind(&self.kind)
     }
 }
 
@@ -1498,12 +1598,6 @@ impl InvocationCollectorNode for AstNodeWrapper<Box<ast::AssocItem>, TraitItemTa
     }
     fn delegation_item_kind(deleg: Box<ast::Delegation>) -> Self::ItemKind {
         AssocItemKind::Delegation(deleg)
-    }
-    fn from_item(item: ast::Item<Self::ItemKind>) -> Self {
-        AstNodeWrapper::new(Box::new(item), TraitItemTag)
-    }
-    fn flatten_outputs(items: impl Iterator<Item = Self::OutputTy>) -> Self::OutputTy {
-        items.flatten().collect()
     }
     fn as_target(&self) -> Target {
         Target::from_assoc_item_kind(&self.wrapped.kind, AssocCtxt::Trait)
@@ -1543,14 +1637,46 @@ impl InvocationCollectorNode for AstNodeWrapper<Box<ast::AssocItem>, ImplItemTag
     fn delegation_item_kind(deleg: Box<ast::Delegation>) -> Self::ItemKind {
         AssocItemKind::Delegation(deleg)
     }
-    fn from_item(item: ast::Item<Self::ItemKind>) -> Self {
-        AstNodeWrapper::new(Box::new(item), ImplItemTag)
-    }
-    fn flatten_outputs(items: impl Iterator<Item = Self::OutputTy>) -> Self::OutputTy {
-        items.flatten().collect()
-    }
     fn as_target(&self) -> Target {
         Target::from_assoc_item_kind(&self.wrapped.kind, AssocCtxt::Impl { of_trait: false })
+    }
+}
+
+struct ItemTag;
+impl InvocationCollectorNode for AstNodeWrapper<Box<ast::Item>, ItemTag> {
+    type OutputTy = SmallVec<[Box<ast::Item>; 1]>;
+    type ItemKind = ItemKind;
+    const KIND: AstFragmentKind = AstFragmentKind::Items;
+    fn to_annotatable(self) -> Annotatable {
+        Annotatable::Item(self.wrapped)
+    }
+    fn fragment_to_output(fragment: AstFragment) -> Self::OutputTy {
+        fragment.make_items()
+    }
+    fn walk_flat_map(self, collector: &mut InvocationCollector<'_, '_>) -> Self::OutputTy {
+        walk_flat_map_item(collector, self.wrapped)
+    }
+    fn is_mac_call(&self) -> bool {
+        matches!(self.wrapped.kind, ItemKind::MacCall(..))
+    }
+    fn take_mac_call(self) -> (Box<ast::MacCall>, ast::AttrVec, AddSemicolon) {
+        let item = self.wrapped;
+        match item.kind {
+            ItemKind::MacCall(mac) => (mac, item.attrs, AddSemicolon::No),
+            _ => unreachable!(),
+        }
+    }
+    fn delegation(&self) -> Option<(&ast::DelegationMac, &ast::Item<Self::ItemKind>)> {
+        match &self.wrapped.kind {
+            ItemKind::DelegationMac(deleg) => Some((deleg, &self.wrapped)),
+            _ => None,
+        }
+    }
+    fn delegation_item_kind(deleg: Box<ast::Delegation>) -> Self::ItemKind {
+        ItemKind::Delegation(deleg)
+    }
+    fn as_target(&self) -> Target {
+        Target::from_item_kind(&self.wrapped.kind)
     }
 }
 
@@ -1586,12 +1712,6 @@ impl InvocationCollectorNode for AstNodeWrapper<Box<ast::AssocItem>, TraitImplIt
     }
     fn delegation_item_kind(deleg: Box<ast::Delegation>) -> Self::ItemKind {
         AssocItemKind::Delegation(deleg)
-    }
-    fn from_item(item: ast::Item<Self::ItemKind>) -> Self {
-        AstNodeWrapper::new(Box::new(item), TraitImplItemTag)
-    }
-    fn flatten_outputs(items: impl Iterator<Item = Self::OutputTy>) -> Self::OutputTy {
-        items.flatten().collect()
     }
     fn as_target(&self) -> Target {
         Target::from_assoc_item_kind(&self.wrapped.kind, AssocCtxt::Impl { of_trait: true })
@@ -1828,12 +1948,6 @@ impl InvocationCollectorNode for ast::Stmt {
     fn delegation_item_kind(deleg: Box<ast::Delegation>) -> Self::ItemKind {
         ItemKind::Delegation(deleg)
     }
-    fn from_item(item: ast::Item<Self::ItemKind>) -> Self {
-        ast::Stmt { id: ast::DUMMY_NODE_ID, span: item.span, kind: StmtKind::Item(Box::new(item)) }
-    }
-    fn flatten_outputs(items: impl Iterator<Item = Self::OutputTy>) -> Self::OutputTy {
-        items.flatten().collect()
-    }
     fn post_flat_map_node_collect_bang(stmts: &mut Self::OutputTy, add_semicolon: AddSemicolon) {
         // If this is a macro invocation with a semicolon, then apply that
         // semicolon to the final statement produced by expansion.
@@ -2035,30 +2149,30 @@ impl InvocationCollectorNode for AstNodeWrapper<ast::Expr, MethodReceiverTag> {
     }
 }
 
-fn build_single_delegations<'a, Node: InvocationCollectorNode>(
+fn build_single_delegations<Node: InvocationCollectorNode>(
     ecx: &ExtCtxt<'_>,
-    deleg: &'a ast::DelegationMac,
-    item: &'a ast::Item<Node::ItemKind>,
-    suffixes: &'a [(Ident, Option<Ident>)],
-    item_span: Span,
-    from_glob: bool,
-) -> impl Iterator<Item = ast::Item<Node::ItemKind>> + 'a {
+    ast: &DelegationAst,
+    suffixes: &[(Ident, Option<Ident>)],
+) -> impl Iterator<Item = ast::Item<Node::ItemKind>> {
+    let glob = ast.from_glob();
+
     if suffixes.is_empty() {
         // Report an error for now, to avoid keeping stem for resolution and
         // stability checks.
-        let kind = String::from(if from_glob { "glob" } else { "list" });
-        ecx.dcx().emit_err(EmptyDelegationMac { span: item.span, kind });
+        let kind = String::from(if glob { "glob" } else { "list" });
+        ecx.dcx().emit_err(EmptyDelegationMac { span: ast.span(), kind });
     }
 
+    let deleg = ast.delegation();
     suffixes.iter().map(move |&(ident, rename)| {
         let mut path = deleg.prefix.clone();
         path.segments.push(ast::PathSegment { ident, id: ast::DUMMY_NODE_ID, args: None });
 
         ast::Item {
-            attrs: item.attrs.clone(),
+            attrs: ast.attrs().clone(),
             id: ast::DUMMY_NODE_ID,
-            span: if from_glob { item_span } else { ident.span },
-            vis: item.vis.clone(),
+            span: if glob { ast.span() } else { ident.span },
+            vis: ast.vis().clone(),
             kind: Node::delegation_item_kind(Box::new(ast::Delegation {
                 id: ast::DUMMY_NODE_ID,
                 qself: deleg.qself.clone(),
@@ -2066,7 +2180,7 @@ fn build_single_delegations<'a, Node: InvocationCollectorNode>(
                 ident: rename.unwrap_or(ident),
                 rename,
                 body: deleg.body.clone(),
-                source: if from_glob {
+                source: if glob {
                     ast::DelegationSource::Glob
                 } else {
                     ast::DelegationSource::List
@@ -2146,7 +2260,7 @@ impl<'a, 'b> InvocationCollector<'a, 'b> {
 
     fn collect(&mut self, fragment_kind: AstFragmentKind, kind: InvocationKind) -> AstFragment {
         let expn_id = LocalExpnId::fresh_empty();
-        if matches!(kind, InvocationKind::GlobDelegation { .. }) {
+        if matches!(kind, InvocationKind::Delegation { ref ast } if ast.from_glob()) {
             // In resolver we need to know which invocation ids are delegations early,
             // before their `ExpnData` is filled.
             self.cx.resolver.register_glob_delegation(expn_id);
@@ -2183,13 +2297,8 @@ impl<'a, 'b> InvocationCollector<'a, 'b> {
         self.collect(kind, InvocationKind::Attr { attr, pos, item, derives })
     }
 
-    fn collect_glob_delegation(
-        &mut self,
-        item: Box<ast::AssocItem>,
-        of_trait: bool,
-        kind: AstFragmentKind,
-    ) -> AstFragment {
-        self.collect(kind, InvocationKind::GlobDelegation { item, of_trait })
+    fn collect_delegation(&mut self, ast: DelegationAst, kind: AstFragmentKind) -> AstFragment {
+        self.collect(kind, InvocationKind::Delegation { ast })
     }
 
     /// If `item` is an attribute invocation, remove the attribute and return it together with
@@ -2386,14 +2495,28 @@ impl<'a, 'b> InvocationCollector<'a, 'b> {
                     Node::post_flat_map_node_collect_bang(&mut res, add_semicolon);
                     res
                 }
-                None if let Some((deleg, item)) = node.delegation() => {
-                    let DelegationSuffixes::List(suffixes) = &deleg.suffixes else {
+                None if let Some((deleg, _)) = node.delegation() => match deleg.suffixes {
+                    DelegationSuffixes::List { .. } => {
+                        let ast = match node.to_annotatable() {
+                            Annotatable::AssocItem(item, assoc_context) => {
+                                DelegationAst::AssocItem(item, assoc_context)
+                            }
+                            Annotatable::Item(item) => DelegationAst::Item(item),
+                            _ => unreachable!(),
+                        };
+
+                        self.collect_delegation(ast, Node::KIND).make_ast::<Node>()
+                    }
+                    DelegationSuffixes::Glob { .. } => {
                         let traitless_qself =
                             matches!(&deleg.qself, Some(qself) if qself.position == 0);
-                        let (item, of_trait) = match node.to_annotatable() {
-                            Annotatable::AssocItem(item, AssocCtxt::Impl { of_trait }) => {
-                                (item, of_trait)
-                            }
+
+                        let (item, assoc_context) = match node.to_annotatable() {
+                            Annotatable::AssocItem(
+                                item,
+                                assoc_context @ AssocCtxt::Impl { .. },
+                            ) => (item, assoc_context),
+
                             ann @ (Annotatable::Item(_)
                             | Annotatable::AssocItem(..)
                             | Annotatable::Stmt(_)) => {
@@ -2403,24 +2526,20 @@ impl<'a, 'b> InvocationCollector<'a, 'b> {
                             }
                             _ => unreachable!(),
                         };
+
                         if traitless_qself {
                             let span = item.span;
                             self.cx.dcx().emit_err(GlobDelegationTraitlessQpath { span });
                             return Default::default();
                         }
-                        return self
-                            .collect_glob_delegation(item, of_trait, Node::KIND)
-                            .make_ast::<Node>();
-                    };
 
-                    let single_delegations = build_single_delegations::<Node>(
-                        self.cx, deleg, item, suffixes, item.span, false,
-                    );
-                    Node::flatten_outputs(single_delegations.map(|item| {
-                        let mut item = Node::from_item(item);
-                        assign_id!(self, item.node_id_mut(), || item.walk_flat_map(self))
-                    }))
-                }
+                        self.collect_delegation(
+                            DelegationAst::AssocItem(item, assoc_context),
+                            Node::KIND,
+                        )
+                        .make_ast::<Node>()
+                    }
+                },
                 None => {
                     match Node::wrap_flat_map_node_walk_flat_map(node, self, |mut node, this| {
                         assign_id!(this, node.node_id_mut(), || node.walk_flat_map(this))

--- a/compiler/rustc_hir/src/target.rs
+++ b/compiler/rustc_hir/src/target.rs
@@ -161,8 +161,8 @@ impl Target {
         }
     }
 
-    pub fn from_ast_item(item: &ast::Item) -> Target {
-        match item.kind {
+    pub fn from_item_kind(kind: &ast::ItemKind) -> Target {
+        match kind {
             ast::ItemKind::ExternCrate(..) => Target::ExternCrate,
             ast::ItemKind::Use(..) => Target::Use,
             ast::ItemKind::Static { .. } => Target::Static,
@@ -178,7 +178,7 @@ impl Target {
             ast::ItemKind::Union(..) => Target::Union,
             ast::ItemKind::Trait(..) => Target::Trait,
             ast::ItemKind::TraitAlias(..) => Target::TraitAlias,
-            ast::ItemKind::Impl(ref i) => Target::Impl { of_trait: i.of_trait.is_some() },
+            ast::ItemKind::Impl(i) => Target::Impl { of_trait: i.of_trait.is_some() },
             ast::ItemKind::MacCall(..) => Target::MacroCall,
             ast::ItemKind::MacroDef(..) => Target::MacroDef,
             ast::ItemKind::Delegation(..) => Target::Delegation { mac: false },

--- a/compiler/rustc_resolve/src/macros.rs
+++ b/compiler/rustc_resolve/src/macros.rs
@@ -272,11 +272,22 @@ impl<'ra, 'tcx> ResolverExpand for Resolver<'ra, 'tcx> {
             }
             InvocationKind::Bang { ref mac, .. } => (&mac.path, MacroKind::Bang),
             InvocationKind::Derive { ref path, .. } => (path, MacroKind::Derive),
-            InvocationKind::GlobDelegation { ref item, .. } => {
-                let ast::AssocItemKind::DelegationMac(deleg) = &item.kind else { unreachable!() };
-                let DelegationSuffixes::Glob(star_span) = deleg.suffixes else { unreachable!() };
-                deleg_impl = Some((self.invocation_parent(invoc_id), star_span));
-                // It is sufficient to consider glob delegation a bang macro for now.
+            InvocationKind::Delegation { ref ast } => {
+                let deleg = ast.delegation();
+                let from_glob = ast.from_glob();
+
+                let span = match from_glob {
+                    true => {
+                        let DelegationSuffixes::Glob(star_span) = deleg.suffixes else {
+                            unreachable!()
+                        };
+
+                        star_span
+                    }
+                    false => deleg.prefix.segments.last().map_or(DUMMY_SP, |s| s.span()),
+                };
+
+                deleg_impl = Some((self.invocation_parent(invoc_id), span, from_glob));
                 (&deleg.prefix, MacroKind::Bang)
             }
         };
@@ -580,7 +591,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         parent_scope: &ParentScope<'ra>,
         node_id: NodeId,
         force: bool,
-        deleg_impl: Option<(LocalDefId, Span)>,
+        deleg_impl: Option<(LocalDefId, Span, bool)>,
         invoc_in_mod_inert_attr: Option<LocalDefId>,
         suggestion_span: Option<Span>,
     ) -> Result<(&'ra Arc<SyntaxExtension>, Res), Indeterminate> {
@@ -589,7 +600,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             kind,
             parent_scope,
             force,
-            deleg_impl,
+            deleg_impl.map(|(a, b, _)| (a, b)),
             invoc_in_mod_inert_attr.map(|def_id| (def_id, node_id)),
             None,
             suggestion_span,
@@ -600,9 +611,9 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             Err(Determinacy::Undetermined) => return Err(Indeterminate),
         };
 
-        // Everything below is irrelevant to glob delegation, take a shortcut.
-        if deleg_impl.is_some() {
-            if !matches!(res, Res::Err | Res::Def(DefKind::Trait, _)) {
+        // Everything below is irrelevant to glob/list delegation, take a shortcut.
+        if let Some((_, _, glob)) = deleg_impl {
+            if glob && !matches!(res, Res::Err | Res::Def(DefKind::Trait, _)) {
                 self.dcx().emit_err(MacroExpectedFound {
                     span: path.span,
                     expected: "trait",

--- a/tests/ui/delegation/bad-resolve.rs
+++ b/tests/ui/delegation/bad-resolve.rs
@@ -40,6 +40,7 @@ impl Trait for S {
 
 mod prefix {}
 reuse unresolved_prefix::{a, b, c}; //~ ERROR cannot find module or crate `unresolved_prefix`
+//~^ ERROR: cannot find module or crate `unresolved_prefix` in this scope
 reuse prefix::{self, super, crate}; //~ ERROR `crate` in paths can only be used in start position
 //~^ ERROR expected function, found module `prefix::self`
 

--- a/tests/ui/delegation/bad-resolve.stderr
+++ b/tests/ui/delegation/bad-resolve.stderr
@@ -1,3 +1,9 @@
+error[E0433]: cannot find module or crate `unresolved_prefix` in this scope
+  --> $DIR/bad-resolve.rs:42:7
+   |
+LL | reuse unresolved_prefix::{a, b, c};
+   |       ^^^^^^^^^^^^^^^^^ use of unresolved module or unlinked crate `unresolved_prefix`
+
 error[E0324]: item `C` is an associated method, which doesn't match its trait `Trait`
   --> $DIR/bad-resolve.rs:23:5
    |
@@ -83,7 +89,7 @@ LL +     reuse Trait::foo { self.0 }
    |
 
 error[E0423]: expected function, found module `prefix::self`
-  --> $DIR/bad-resolve.rs:43:7
+  --> $DIR/bad-resolve.rs:44:7
    |
 LL | reuse prefix::{self, super, crate};
    |       ^^^^^^ not a function
@@ -106,12 +112,12 @@ LL | reuse unresolved_prefix::{a, b, c};
    = help: you might be missing a crate named `unresolved_prefix`
 
 error[E0433]: `crate` in paths can only be used in start position
-  --> $DIR/bad-resolve.rs:43:29
+  --> $DIR/bad-resolve.rs:44:29
    |
 LL | reuse prefix::{self, super, crate};
    |                             ^^^^^ can only be used in path start position
 
-error: aborting due to 13 previous errors
+error: aborting due to 14 previous errors
 
 Some errors have detailed explanations: E0046, E0324, E0407, E0423, E0425, E0433, E0575, E0576.
 For more information about an error, try `rustc --explain E0046`.

--- a/tests/ui/delegation/delegation-first-arg.stderr
+++ b/tests/ui/delegation/delegation-first-arg.stderr
@@ -5,16 +5,16 @@ LL |     reuse <S as Trait>::static_empty { self.0 }
    |                                      ^^^^^^^^^^
 
 error: delegation's target expression is specified for function with no params
-  --> $DIR/delegation-first-arg.rs:61:83
-   |
-LL |     reuse trait_to_reuse::{value, r#ref, mut_ref, static_empty, static_one_param} { self.0 }
-   |                                                                                   ^^^^^^^^^^
-
-error: delegation's target expression is specified for function with no params
   --> $DIR/delegation-first-arg.rs:76:23
    |
 LL | reuse to_reuse::empty { self + 1 }
    |                       ^^^^^^^^^^^^
+
+error: delegation's target expression is specified for function with no params
+  --> $DIR/delegation-first-arg.rs:61:83
+   |
+LL |     reuse trait_to_reuse::{value, r#ref, mut_ref, static_empty, static_one_param} { self.0 }
+   |                                                                                   ^^^^^^^^^^
 
 error: delegation's target expression is specified for function with no params
   --> $DIR/delegation-first-arg.rs:82:60


### PR DESCRIPTION
This PR refactors delegation's list and glob expansions such that they both use the same engine thus both having `LocalExpnId` which can be then used to properly emit diagnostic about unused target expression for list delegations.

Third part of rust-lang/rust#156798, tests will be adjusted after rust-lang/rust#157601 is merged.
Part of rust-lang/rust#118212.
r? @petrochenkov