### PR TITLE
Rename typing modes to better describe real usage

### DIFF
--- a/compiler/rustc_borrowck/src/lib.rs
+++ b/compiler/rustc_borrowck/src/lib.rs
@@ -650,7 +650,7 @@ pub(crate) struct BorrowckInferCtxt<'tcx> {
 
 impl<'tcx> BorrowckInferCtxt<'tcx> {
     pub(crate) fn new(tcx: TyCtxt<'tcx>, def_id: LocalDefId, root_def_id: LocalDefId) -> Self {
-        let typing_mode = if tcx.use_typing_mode_borrowck() {
+        let typing_mode = if tcx.use_typing_mode_post_typeck_until_borrowck() {
             TypingMode::borrowck(tcx, def_id)
         } else {
             TypingMode::analysis_in_body(tcx, def_id)

--- a/compiler/rustc_borrowck/src/region_infer/opaque_types/mod.rs
+++ b/compiler/rustc_borrowck/src/region_infer/opaque_types/mod.rs
@@ -261,8 +261,8 @@ fn collect_defining_uses<'tcx>(
             DefiningScopeKind::MirBorrowck,
         ) {
             // A non-defining use. This is a hard error on stable and gets ignored
-            // with `TypingMode::Borrowck`.
-            if infcx.tcx.use_typing_mode_borrowck() {
+            // with `TypingMode::PostTypeckUntilBorrowck`.
+            if infcx.tcx.use_typing_mode_post_typeck_until_borrowck() {
                 match err {
                     NonDefiningUseReason::Tainted(guar) => add_hidden_type(
                         infcx.tcx,
@@ -327,7 +327,7 @@ fn compute_definition_site_hidden_types_from_defining_uses<'tcx>(
                     // If we're using the next solver, the unconstrained region may be resolved by a
                     // fully defining use from another body.
                     // So we don't generate error eagerly here.
-                    if rcx.infcx.tcx.use_typing_mode_borrowck() {
+                    if rcx.infcx.tcx.use_typing_mode_post_typeck_until_borrowck() {
                         unconstrained_hidden_type_errors.push(UnexpectedHiddenRegion {
                             def_id,
                             hidden_type,
@@ -366,7 +366,7 @@ fn compute_definition_site_hidden_types_from_defining_uses<'tcx>(
         // the hidden type becomes the opaque type itself. In this case, this was an opaque
         // usage of the opaque type and we can ignore it. This check is mirrored in typeck's
         // writeback.
-        if !rcx.infcx.tcx.use_typing_mode_borrowck() {
+        if !rcx.infcx.tcx.use_typing_mode_post_typeck_until_borrowck() {
             if let &ty::Alias(ty::AliasTy { kind: ty::Opaque { def_id }, args, .. }) =
                 hidden_type.ty.skip_binder().kind()
                 && def_id == opaque_type_key.def_id.to_def_id()
@@ -540,7 +540,7 @@ pub(crate) fn apply_definition_site_hidden_types<'tcx>(
     let mut errors = Vec::new();
     for &(key, hidden_type) in opaque_types {
         let Some(expected) = hidden_types.get(&key.def_id) else {
-            if !tcx.use_typing_mode_borrowck() {
+            if !tcx.use_typing_mode_post_typeck_until_borrowck() {
                 if let &ty::Alias(ty::AliasTy { kind: ty::Opaque { def_id }, args, .. }) =
                     hidden_type.ty.kind()
                     && def_id == key.def_id.to_def_id()

--- a/compiler/rustc_const_eval/src/check_consts/qualifs.rs
+++ b/compiler/rustc_const_eval/src/check_consts/qualifs.rs
@@ -102,7 +102,7 @@ impl Qualif for HasMutInterior {
         let freeze_def_id = cx.tcx.require_lang_item(LangItem::Freeze, cx.body.span);
         let did = cx.body.source.def_id().expect_local();
 
-        let typing_env = if cx.tcx.use_typing_mode_borrowck() {
+        let typing_env = if cx.tcx.use_typing_mode_post_typeck_until_borrowck() {
             cx.typing_env
         } else {
             ty::TypingEnv::new(cx.typing_env.param_env, TypingMode::analysis_in_body(cx.tcx, did))

--- a/compiler/rustc_const_eval/src/const_eval/eval_queries.rs
+++ b/compiler/rustc_const_eval/src/const_eval/eval_queries.rs
@@ -41,9 +41,9 @@ fn retry_codegen_mode_with_postanalysis<'tcx, K: TypeVisitable<TyCtxt<'tcx>>, V>
             }
         }
         ty::TypingMode::Coherence
-        | ty::TypingMode::Analysis { .. }
-        | ty::TypingMode::Borrowck { .. }
-        | ty::TypingMode::PostBorrowckAnalysis { .. }
+        | ty::TypingMode::Typeck { .. }
+        | ty::TypingMode::PostTypeckUntilBorrowck { .. }
+        | ty::TypingMode::PostBorrowck { .. }
         | ty::TypingMode::PostAnalysis => {}
     }
 

--- a/compiler/rustc_const_eval/src/lib.rs
+++ b/compiler/rustc_const_eval/src/lib.rs
@@ -32,9 +32,9 @@ fn assert_typing_mode(typing_mode: ty::TypingMode<'_>) {
             // Const eval always happens in PostAnalysis or Codegen mode. See the comment in
             // `InterpCx::new` for more details.
             ty::TypingMode::Coherence
-            | ty::TypingMode::Analysis { .. }
-            | ty::TypingMode::Borrowck { .. }
-            | ty::TypingMode::PostBorrowckAnalysis { .. } => bug!(
+            | ty::TypingMode::Typeck { .. }
+            | ty::TypingMode::PostTypeckUntilBorrowck { .. }
+            | ty::TypingMode::PostBorrowck { .. } => bug!(
                 "Const eval should always happens in PostAnalysis or Codegen mode. See the comment on `assert_typing_mode` for more details."
             ),
         }

--- a/compiler/rustc_hir_analysis/src/check/check.rs
+++ b/compiler/rustc_hir_analysis/src/check/check.rs
@@ -317,7 +317,7 @@ fn check_opaque_meets_bounds<'tcx>(
     };
     let param_env = tcx.param_env(defining_use_anchor);
 
-    // FIXME(#132279): Once `PostBorrowckAnalysis` is supported in the old solver, this branch should be removed.
+    // FIXME(#132279): Once `PostBorrowck` is supported in the old solver, this branch should be removed.
     let infcx = tcx.infer_ctxt().build(if tcx.next_trait_solver_globally() {
         TypingMode::post_borrowck_analysis(tcx, defining_use_anchor)
     } else {
@@ -2321,7 +2321,7 @@ pub(super) fn check_coroutine_obligations(
         }
     } else {
         // We're not checking region constraints here, so we can simply drop the
-        // added opaque type uses in `TypingMode::Borrowck`.
+        // added opaque type uses in `TypingMode::PostTypeckUntilBorrowck`.
         let _ = infcx.take_opaque_types();
     }
 
@@ -2338,7 +2338,7 @@ pub(super) fn check_potentially_region_dependent_goals<'tcx>(
     let typeck_results = tcx.typeck(def_id);
     let param_env = tcx.param_env(def_id);
 
-    // We use `TypingMode::Borrowck` as we want to use the opaque types computed by HIR typeck.
+    // We use `TypingMode::PostTypeckUntilBorrowck` as we want to use the opaque types computed by HIR typeck.
     let typing_mode = TypingMode::borrowck(tcx, def_id);
     let infcx = tcx.infer_ctxt().ignoring_regions().build(typing_mode);
     let ocx = ObligationCtxt::new_with_diagnostics(&infcx);

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
@@ -657,12 +657,12 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         self.select_obligations_where_possible(|_| {});
 
         let defining_opaque_types_and_generators = match self.typing_mode() {
-            ty::TypingMode::Analysis { defining_opaque_types_and_generators } => {
+            ty::TypingMode::Typeck { defining_opaque_types_and_generators } => {
                 defining_opaque_types_and_generators
             }
             ty::TypingMode::Coherence
-            | ty::TypingMode::Borrowck { .. }
-            | ty::TypingMode::PostBorrowckAnalysis { .. }
+            | ty::TypingMode::PostTypeckUntilBorrowck { .. }
+            | ty::TypingMode::PostBorrowck { .. }
             | ty::TypingMode::PostAnalysis
             | ty::TypingMode::Codegen => {
                 bug!()

--- a/compiler/rustc_hir_typeck/src/opaque_types.rs
+++ b/compiler/rustc_hir_typeck/src/opaque_types.rs
@@ -99,12 +99,12 @@ impl<'tcx> FnCtxt<'_, 'tcx> {
 
         let tcx = self.tcx;
         let defining_opaque_types_and_generators = match self.typing_mode() {
-            ty::TypingMode::Analysis { defining_opaque_types_and_generators } => {
+            ty::TypingMode::Typeck { defining_opaque_types_and_generators } => {
                 defining_opaque_types_and_generators
             }
             ty::TypingMode::Coherence
-            | ty::TypingMode::Borrowck { .. }
-            | ty::TypingMode::PostBorrowckAnalysis { .. }
+            | ty::TypingMode::PostTypeckUntilBorrowck { .. }
+            | ty::TypingMode::PostBorrowck { .. }
             | ty::TypingMode::PostAnalysis
             | ty::TypingMode::Codegen => {
                 bug!()

--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -342,19 +342,19 @@ impl<'tcx> Drop for InferCtxt<'tcx> {
         let mut inner = self.inner.borrow_mut();
         let opaque_type_storage = &mut inner.opaque_type_storage;
 
-        // No need for the drop bomb when we're in TypingMode::Borrowck, and the InferCtxt doesn't consider regions.
-        // This is okay since in `Borrowck`, the only reason we care about opaques is in relation to regions.
-        // In some places *after* typeck, like in lints we use `TypingMode::Borrowck`
-        // to prevent defining opaque types and we simply don't care about regions.
+        // No need for the drop bomb when we're in `TypingMode::PostTypeckUntilBorrowck`, and the `InferCtxt`
+        // doesn't consider regions. This is okay since in borrowck, the only reason we care about opaques is
+        // in relation to regions. In some places *after* typeck that aren't borrowck, like in lints we use
+        // `TypingMode::PostTypeckUntilBorrowck` to prevent defining opaque types and we simply don't care about regions.
         match self.typing_mode_raw() {
             TypingMode::Coherence
-            | TypingMode::Analysis { .. }
-            | TypingMode::PostBorrowckAnalysis { .. }
+            | TypingMode::Typeck { .. }
+            | TypingMode::PostBorrowck { .. }
             | TypingMode::PostAnalysis
             | TypingMode::Codegen => {}
             // In erased mode, the opaque type storage is always empty
             TypingMode::ErasedNotCoherence(..) => {}
-            TypingMode::Borrowck { .. } => {
+            TypingMode::PostTypeckUntilBorrowck { .. } => {
                 if !self.considering_regions {
                     return;
                 }
@@ -1146,17 +1146,15 @@ impl<'tcx> InferCtxt<'tcx> {
     pub fn can_define_opaque_ty(&self, id: impl Into<DefId>) -> bool {
         debug_assert!(!self.next_trait_solver());
         match self.typing_mode_raw().assert_not_erased() {
-            TypingMode::Analysis {
-                defining_opaque_types_and_generators: defining_opaque_types,
-            }
-            | TypingMode::Borrowck { defining_opaque_types } => {
+            TypingMode::Typeck { defining_opaque_types_and_generators: defining_opaque_types }
+            | TypingMode::PostTypeckUntilBorrowck { defining_opaque_types } => {
                 id.into().as_local().is_some_and(|def_id| defining_opaque_types.contains(&def_id))
             }
             // FIXME(#132279): This function is quite weird in post-analysis
             // and post-borrowck analysis mode. We may need to modify its uses
-            // to support PostBorrowckAnalysis in the old solver as well.
+            // to support PostBorrowck in the old solver as well.
             TypingMode::Coherence
-            | TypingMode::PostBorrowckAnalysis { .. }
+            | TypingMode::PostBorrowck { .. }
             | TypingMode::PostAnalysis
             | TypingMode::Codegen => false,
         }
@@ -1482,12 +1480,12 @@ impl<'tcx> InferCtxt<'tcx> {
             // to handle them without proper canonicalization. This means we may cause cycle
             // errors and fail to reveal opaques while inside of bodies. We should rename this
             // function and require explicit comments on all use-sites in the future.
-            ty::TypingMode::Analysis { defining_opaque_types_and_generators: _ }
-            | ty::TypingMode::Borrowck { defining_opaque_types: _ } => {
+            ty::TypingMode::Typeck { defining_opaque_types_and_generators: _ }
+            | ty::TypingMode::PostTypeckUntilBorrowck { defining_opaque_types: _ } => {
                 TypingMode::non_body_analysis()
             }
             mode @ (ty::TypingMode::Coherence
-            | ty::TypingMode::PostBorrowckAnalysis { .. }
+            | ty::TypingMode::PostBorrowck { .. }
             | ty::TypingMode::PostAnalysis
             | ty::TypingMode::Codegen) => mode,
             ty::TypingMode::ErasedNotCoherence(MayBeErased) => unreachable!(),

--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -343,7 +343,7 @@ impl<'tcx> Drop for InferCtxt<'tcx> {
         let opaque_type_storage = &mut inner.opaque_type_storage;
 
         // No need for the drop bomb when we're in `TypingMode::PostTypeckUntilBorrowck`, and the `InferCtxt`
-        // doesn't consider regions. This is okay since in borrowck, the only reason we care about opaques is
+        // doesn't consider regions. This is okay since after typeck, the only reason we care about opaques is
         // in relation to regions. In some places *after* typeck that aren't borrowck, like in lints we use
         // `TypingMode::PostTypeckUntilBorrowck` to prevent defining opaque types and we simply don't care about regions.
         match self.typing_mode_raw() {

--- a/compiler/rustc_infer/src/infer/opaque_types/mod.rs
+++ b/compiler/rustc_infer/src/infer/opaque_types/mod.rs
@@ -238,7 +238,7 @@ impl<'tcx> InferCtxt<'tcx> {
                 // our trait.
                 goals.push(Goal::new(tcx, param_env, ty::PredicateKind::Ambiguous));
             }
-            ty::TypingMode::Analysis { .. } => {
+            ty::TypingMode::Typeck { .. } => {
                 let prev = self
                     .inner
                     .borrow_mut()
@@ -254,7 +254,7 @@ impl<'tcx> InferCtxt<'tcx> {
                     );
                 }
             }
-            ty::TypingMode::Borrowck { .. } => {
+            ty::TypingMode::PostTypeckUntilBorrowck { .. } => {
                 let prev = self
                     .inner
                     .borrow_mut()
@@ -283,7 +283,7 @@ impl<'tcx> InferCtxt<'tcx> {
                         .map(|obligation| obligation.as_goal()),
                 );
             }
-            mode @ (ty::TypingMode::PostBorrowckAnalysis { .. }
+            mode @ (ty::TypingMode::PostBorrowck { .. }
             | ty::TypingMode::PostAnalysis
             | ty::TypingMode::Codegen) => {
                 bug!("insert hidden type in {mode:?}")

--- a/compiler/rustc_lint/src/context.rs
+++ b/compiler/rustc_lint/src/context.rs
@@ -643,7 +643,7 @@ impl<'tcx> LateContext<'tcx> {
     /// building a new `InferCtxt`.
     pub fn typing_mode(&self) -> TypingMode<'tcx> {
         if let Some(body_id) = self.enclosing_body
-            && self.tcx.use_typing_mode_borrowck()
+            && self.tcx.use_typing_mode_post_typeck_until_borrowck()
         {
             let def_id = self.tcx.hir_enclosing_body_owner(body_id.hir_id);
             TypingMode::borrowck(self.tcx, def_id)

--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -413,7 +413,7 @@ impl<'tcx> Body<'tcx> {
     }
 
     pub fn typing_env(&self, tcx: TyCtxt<'tcx>) -> TypingEnv<'tcx> {
-        if tcx.use_typing_mode_borrowck() {
+        if tcx.use_typing_mode_post_typeck_until_borrowck() {
             match self.phase {
                 MirPhase::Built if let Some(def_id) = self.source.def_id().as_local() => {
                     TypingEnv::new(

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -2697,8 +2697,9 @@ impl<'tcx> TyCtxt<'tcx> {
     }
 
     #[allow(rustc::bad_opt_access)]
-    pub fn use_typing_mode_borrowck(self) -> bool {
-        self.next_trait_solver_globally() || self.sess.opts.unstable_opts.typing_mode_borrowck
+    pub fn use_typing_mode_post_typeck_until_borrowck(self) -> bool {
+        self.next_trait_solver_globally()
+            || self.sess.opts.unstable_opts.typing_mode_post_typeck_until_borrowck
     }
 
     pub fn assumptions_on_binders(self) -> bool {

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -1127,9 +1127,9 @@ impl<'tcx> TypingEnv<'tcx> {
         let TypingEnv { typing_mode, param_env } = self;
         match typing_mode.0.assert_not_erased() {
             TypingMode::Coherence
-            | TypingMode::Analysis { .. }
-            | TypingMode::Borrowck { .. }
-            | TypingMode::PostBorrowckAnalysis { .. } => {}
+            | TypingMode::Typeck { .. }
+            | TypingMode::PostTypeckUntilBorrowck { .. }
+            | TypingMode::PostBorrowck { .. } => {}
             TypingMode::PostAnalysis | TypingMode::Codegen => return self,
         }
 
@@ -1143,9 +1143,9 @@ impl<'tcx> TypingEnv<'tcx> {
         let TypingEnv { typing_mode, param_env } = self;
         match typing_mode.0.assert_not_erased() {
             TypingMode::Coherence
-            | TypingMode::Analysis { .. }
-            | TypingMode::Borrowck { .. }
-            | TypingMode::PostBorrowckAnalysis { .. }
+            | TypingMode::Typeck { .. }
+            | TypingMode::PostTypeckUntilBorrowck { .. }
+            | TypingMode::PostBorrowck { .. }
             | TypingMode::PostAnalysis => {}
             TypingMode::Codegen => return self,
         }

--- a/compiler/rustc_mir_transform/src/elaborate_drop.rs
+++ b/compiler/rustc_mir_transform/src/elaborate_drop.rs
@@ -782,9 +782,9 @@ where
                 match self.elaborator.typing_env().typing_mode().assert_not_erased() {
                     ty::TypingMode::PostAnalysis | ty::TypingMode::Codegen => {}
                     ty::TypingMode::Coherence
-                    | ty::TypingMode::Analysis { .. }
-                    | ty::TypingMode::Borrowck { .. }
-                    | ty::TypingMode::PostBorrowckAnalysis { .. } => {
+                    | ty::TypingMode::Typeck { .. }
+                    | ty::TypingMode::PostTypeckUntilBorrowck { .. }
+                    | ty::TypingMode::PostBorrowck { .. } => {
                         bug!()
                     }
                 }

--- a/compiler/rustc_next_trait_solver/src/solve/assembly/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/assembly/mod.rs
@@ -481,9 +481,9 @@ where
                 // See trait-system-refactor-initiative#226 for some ideas here.
                 let assemble_impls = match self.typing_mode() {
                     TypingMode::Coherence => true,
-                    TypingMode::Analysis { .. }
-                    | TypingMode::Borrowck { .. }
-                    | TypingMode::PostBorrowckAnalysis { .. }
+                    TypingMode::Typeck { .. }
+                    | TypingMode::PostTypeckUntilBorrowck { .. }
+                    | TypingMode::PostBorrowck { .. }
                     | TypingMode::PostAnalysis
                     | TypingMode::Codegen
                     | TypingMode::ErasedNotCoherence(MayBeErased) => !candidates.iter().any(|c| {
@@ -1054,10 +1054,10 @@ where
         let self_ty = goal.predicate.self_ty();
         // We only use this hack during HIR typeck.
         let opaque_types = match self.typing_mode() {
-            TypingMode::Analysis { .. } => self.opaques_with_sub_unified_hidden_type(self_ty),
+            TypingMode::Typeck { .. } => self.opaques_with_sub_unified_hidden_type(self_ty),
             TypingMode::Coherence
-            | TypingMode::Borrowck { .. }
-            | TypingMode::PostBorrowckAnalysis { .. }
+            | TypingMode::PostTypeckUntilBorrowck { .. }
+            | TypingMode::PostBorrowck { .. }
             | TypingMode::PostAnalysis
             | TypingMode::Codegen => vec![],
             TypingMode::ErasedNotCoherence(MayBeErased) => {

--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
@@ -777,20 +777,20 @@ where
             ) => RerunDecision::Yes,
             (
                 RerunCondition::OpaqueInStorage(defids),
-                TypingMode::PostBorrowckAnalysis { defined_opaque_types: opaques }
-                | TypingMode::Analysis { defining_opaque_types_and_generators: opaques }
-                | TypingMode::Borrowck { defining_opaque_types: opaques },
+                TypingMode::PostBorrowck { defined_opaque_types: opaques }
+                | TypingMode::Typeck { defining_opaque_types_and_generators: opaques }
+                | TypingMode::PostTypeckUntilBorrowck { defining_opaque_types: opaques },
             ) => opaque_in_storage(opaques, defids),
             // =============================
-            (RerunCondition::AnyOpaqueHasInferAsHidden, TypingMode::Analysis { .. }) => {
+            (RerunCondition::AnyOpaqueHasInferAsHidden, TypingMode::Typeck { .. }) => {
                 any_opaque_has_infer_as_hidden()
             }
             (
                 RerunCondition::AnyOpaqueHasInferAsHidden,
-                TypingMode::PostBorrowckAnalysis { .. }
+                TypingMode::PostBorrowck { .. }
                 | TypingMode::PostAnalysis
                 | TypingMode::Codegen
-                | TypingMode::Borrowck { .. },
+                | TypingMode::PostTypeckUntilBorrowck { .. },
             ) => RerunDecision::No,
             // =============================
             (
@@ -799,7 +799,7 @@ where
             ) => RerunDecision::No,
             (
                 RerunCondition::OpaqueInStorageOrAnyOpaqueHasInferAsHidden(defids),
-                TypingMode::Analysis { defining_opaque_types_and_generators: opaques },
+                TypingMode::Typeck { defining_opaque_types_and_generators: opaques },
             ) => {
                 if let RerunDecision::Yes = any_opaque_has_infer_as_hidden() {
                     RerunDecision::Yes
@@ -811,8 +811,8 @@ where
             }
             (
                 RerunCondition::OpaqueInStorageOrAnyOpaqueHasInferAsHidden(defids),
-                TypingMode::PostBorrowckAnalysis { defined_opaque_types: opaques }
-                | TypingMode::Borrowck { defining_opaque_types: opaques },
+                TypingMode::PostBorrowck { defined_opaque_types: opaques }
+                | TypingMode::PostTypeckUntilBorrowck { defining_opaque_types: opaques },
             ) => opaque_in_storage(opaques, defids),
         };
 

--- a/compiler/rustc_next_trait_solver/src/solve/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/mod.rs
@@ -397,9 +397,9 @@ where
             TypingMode::Coherence | TypingMode::PostAnalysis | TypingMode::Codegen => false,
             // During analysis, opaques are rigid unless they may be defined by
             // the current body.
-            TypingMode::Analysis { defining_opaque_types_and_generators: non_rigid_opaques }
-            | TypingMode::Borrowck { defining_opaque_types: non_rigid_opaques }
-            | TypingMode::PostBorrowckAnalysis { defined_opaque_types: non_rigid_opaques } => {
+            TypingMode::Typeck { defining_opaque_types_and_generators: non_rigid_opaques }
+            | TypingMode::PostTypeckUntilBorrowck { defining_opaque_types: non_rigid_opaques }
+            | TypingMode::PostBorrowck { defined_opaque_types: non_rigid_opaques } => {
                 !def_id.as_local().is_some_and(|def_id| non_rigid_opaques.contains(&def_id.into()))
             }
         }

--- a/compiler/rustc_next_trait_solver/src/solve/normalizes_to/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/normalizes_to/mod.rs
@@ -322,9 +322,9 @@ where
                                 .map_err(Into::into);
                         }
                         // Outside of coherence, we treat the associated item as rigid instead.
-                        ty::TypingMode::Analysis { .. }
-                        | ty::TypingMode::Borrowck { .. }
-                        | ty::TypingMode::PostBorrowckAnalysis { .. }
+                        ty::TypingMode::Typeck { .. }
+                        | ty::TypingMode::PostTypeckUntilBorrowck { .. }
+                        | ty::TypingMode::PostBorrowck { .. }
                         | ty::TypingMode::PostAnalysis
                         | ty::TypingMode::Codegen => {
                             ecx.structurally_instantiate_normalizes_to_term(

--- a/compiler/rustc_next_trait_solver/src/solve/normalizes_to/opaque_types.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/normalizes_to/opaque_types.rs
@@ -41,10 +41,8 @@ where
                 self.evaluate_added_goals_and_make_canonical_response(Certainty::Yes)
                     .map_err(Into::into)
             }
-            TypingMode::Analysis {
-                defining_opaque_types_and_generators: defining_opaque_types,
-            }
-            | TypingMode::Borrowck { defining_opaque_types } => {
+            TypingMode::Typeck { defining_opaque_types_and_generators: defining_opaque_types }
+            | TypingMode::PostTypeckUntilBorrowck { defining_opaque_types } => {
                 let Some(def_id) = def_id
                     .as_local()
                     .filter(|&def_id| defining_opaque_types.contains(&def_id.into()))
@@ -86,8 +84,8 @@ where
                     // inference variables. In borrowck we instead use the type
                     // computed in HIR typeck as the initial value.
                     match self.typing_mode().assert_not_erased() {
-                        TypingMode::Analysis { .. } => {}
-                        TypingMode::Borrowck { .. } => {
+                        TypingMode::Typeck { .. } => {}
+                        TypingMode::PostTypeckUntilBorrowck { .. } => {
                             let actual = cx
                                 .type_of_opaque_hir_typeck(def_id)
                                 .instantiate(cx, opaque_ty.args)
@@ -99,7 +97,7 @@ where
                             self.eq(goal.param_env, expected, actual)?;
                         }
                         TypingMode::Coherence
-                        | TypingMode::PostBorrowckAnalysis { .. }
+                        | TypingMode::PostBorrowck { .. }
                         | TypingMode::PostAnalysis
                         | TypingMode::Codegen => unreachable!(),
                     }
@@ -114,7 +112,7 @@ where
                 self.evaluate_added_goals_and_make_canonical_response(Certainty::Yes)
                     .map_err(Into::into)
             }
-            TypingMode::PostBorrowckAnalysis { defined_opaque_types } => {
+            TypingMode::PostBorrowck { defined_opaque_types } => {
                 let Some(def_id) = opaque_ty
                     .def_id()
                     .as_local()

--- a/compiler/rustc_next_trait_solver/src/solve/search_graph.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/search_graph.rs
@@ -68,9 +68,9 @@ where
                 TypingMode::Coherence => {
                     response_no_constraints(cx, input, Certainty::overflow(false))
                 }
-                TypingMode::Analysis { .. }
-                | TypingMode::Borrowck { .. }
-                | TypingMode::PostBorrowckAnalysis { .. }
+                TypingMode::Typeck { .. }
+                | TypingMode::PostTypeckUntilBorrowck { .. }
+                | TypingMode::PostBorrowck { .. }
                 | TypingMode::PostAnalysis
                 | TypingMode::Codegen
                 | TypingMode::ErasedNotCoherence(MayBeErased) => {

--- a/compiler/rustc_next_trait_solver/src/solve/trait_goals.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/trait_goals.rs
@@ -1590,9 +1590,7 @@ where
     ) -> Option<Result<Candidate<I>, NoSolutionOrRerunNonErased>> {
         if let ty::Coroutine(def_id, _) = self_ty.kind() {
             match self.typing_mode() {
-                TypingMode::Analysis {
-                    defining_opaque_types_and_generators: stalled_generators,
-                } => {
+                TypingMode::Typeck { defining_opaque_types_and_generators: stalled_generators } => {
                     if def_id.as_local().is_some_and(|def_id| stalled_generators.contains(&def_id))
                     {
                         return Some(self.forced_ambiguity(MaybeInfo {
@@ -1613,8 +1611,8 @@ where
                 TypingMode::Coherence
                 | TypingMode::PostAnalysis
                 | TypingMode::Codegen
-                | TypingMode::Borrowck { defining_opaque_types: _ }
-                | TypingMode::PostBorrowckAnalysis { defined_opaque_types: _ } => {}
+                | TypingMode::PostTypeckUntilBorrowck { defining_opaque_types: _ }
+                | TypingMode::PostBorrowck { defined_opaque_types: _ } => {}
             }
         }
 

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -2737,9 +2737,9 @@ written to standard error output)"),
         "in diagnostics, use heuristics to shorten paths referring to items"),
     tune_cpu: Option<String> = (None, parse_opt_string, [TRACKED],
         "select processor to schedule for (`rustc --print target-cpus` for details)"),
-    #[rustc_lint_opt_deny_field_access("use `TyCtxt::use_typing_mode_borrowck` instead of this field")]
-    typing_mode_borrowck: bool = (false, parse_bool, [TRACKED],
-        "enable `TypingMode::Borrowck`, changing the way opaque types are handled during MIR borrowck"),
+    #[rustc_lint_opt_deny_field_access("use `TyCtxt::use_typing_mode_post_typeck` instead of this field")]
+    typing_mode_post_typeck_until_borrowck: bool = (false, parse_bool, [TRACKED],
+        "enable `TypingMode::PostTypeckUntilBorrowck`, changing the way opaque types are handled during MIR borrowck"),
     #[rustc_lint_opt_deny_field_access("use `Session::ub_checks` instead of this field")]
     ub_checks: Option<bool> = (None, parse_opt_bool, [TRACKED],
         "emit runtime checks for Undefined Behavior (default: -Cdebug-assertions)"),

--- a/compiler/rustc_trait_selection/src/solve/delegate.rs
+++ b/compiler/rustc_trait_selection/src/solve/delegate.rs
@@ -338,9 +338,9 @@ impl<'tcx> rustc_next_trait_solver::delegate::SolverDelegate for SolverDelegate<
             // get a result which isn't correct for all monomorphizations.
             match typing_mode {
                 TypingMode::Coherence
-                | TypingMode::Analysis { .. }
-                | TypingMode::Borrowck { .. }
-                | TypingMode::PostBorrowckAnalysis { .. } => false,
+                | TypingMode::Typeck { .. }
+                | TypingMode::PostTypeckUntilBorrowck { .. }
+                | TypingMode::PostBorrowck { .. } => false,
                 TypingMode::PostAnalysis | TypingMode::Codegen => {
                     let poly_trait_ref = self.resolve_vars_if_possible(goal_trait_ref);
                     !poly_trait_ref.still_further_specializable()

--- a/compiler/rustc_trait_selection/src/solve/fulfill.rs
+++ b/compiler/rustc_trait_selection/src/solve/fulfill.rs
@@ -320,12 +320,12 @@ where
         infcx: &InferCtxt<'tcx>,
     ) -> PredicateObligations<'tcx> {
         let stalled_coroutines = match infcx.typing_mode_raw().assert_not_erased() {
-            TypingMode::Analysis { defining_opaque_types_and_generators } => {
+            TypingMode::Typeck { defining_opaque_types_and_generators } => {
                 defining_opaque_types_and_generators
             }
             TypingMode::Coherence
-            | TypingMode::Borrowck { defining_opaque_types: _ }
-            | TypingMode::PostBorrowckAnalysis { defined_opaque_types: _ }
+            | TypingMode::PostTypeckUntilBorrowck { defining_opaque_types: _ }
+            | TypingMode::PostBorrowck { defined_opaque_types: _ }
             | TypingMode::PostAnalysis
             | TypingMode::Codegen => return Default::default(),
         };

--- a/compiler/rustc_trait_selection/src/traits/fulfill.rs
+++ b/compiler/rustc_trait_selection/src/traits/fulfill.rs
@@ -172,12 +172,12 @@ where
         infcx: &InferCtxt<'tcx>,
     ) -> PredicateObligations<'tcx> {
         let stalled_coroutines = match infcx.typing_mode_raw().assert_not_erased() {
-            TypingMode::Analysis { defining_opaque_types_and_generators } => {
+            TypingMode::Typeck { defining_opaque_types_and_generators } => {
                 defining_opaque_types_and_generators
             }
             TypingMode::Coherence
-            | TypingMode::Borrowck { defining_opaque_types: _ }
-            | TypingMode::PostBorrowckAnalysis { defined_opaque_types: _ }
+            | TypingMode::PostTypeckUntilBorrowck { defining_opaque_types: _ }
+            | TypingMode::PostBorrowck { defined_opaque_types: _ }
             | TypingMode::PostAnalysis
             | TypingMode::Codegen => return Default::default(),
         };

--- a/compiler/rustc_trait_selection/src/traits/normalize.rs
+++ b/compiler/rustc_trait_selection/src/traits/normalize.rs
@@ -140,9 +140,9 @@ pub(super) fn needs_normalization<'tcx, T: TypeVisitable<TyCtxt<'tcx>>>(
     match infcx.typing_mode_raw().assert_not_erased() {
         // FIXME(#132279): We likely want to reveal opaques during post borrowck analysis
         TypingMode::Coherence
-        | TypingMode::Analysis { .. }
-        | TypingMode::Borrowck { .. }
-        | TypingMode::PostBorrowckAnalysis { .. } => flags.remove(ty::TypeFlags::HAS_TY_OPAQUE),
+        | TypingMode::Typeck { .. }
+        | TypingMode::PostTypeckUntilBorrowck { .. }
+        | TypingMode::PostBorrowck { .. } => flags.remove(ty::TypeFlags::HAS_TY_OPAQUE),
         TypingMode::PostAnalysis | TypingMode::Codegen => {}
     }
 
@@ -412,9 +412,9 @@ impl<'a, 'b, 'tcx> TypeFolder<TyCtxt<'tcx>> for AssocTypeNormalizer<'a, 'b, 'tcx
                 match self.selcx.typing_mode() {
                     // FIXME(#132279): We likely want to reveal opaques during post borrowck analysis
                     TypingMode::Coherence
-                    | TypingMode::Analysis { .. }
-                    | TypingMode::Borrowck { .. }
-                    | TypingMode::PostBorrowckAnalysis { .. } => ty.super_fold_with(self),
+                    | TypingMode::Typeck { .. }
+                    | TypingMode::PostTypeckUntilBorrowck { .. }
+                    | TypingMode::PostBorrowck { .. } => ty.super_fold_with(self),
                     TypingMode::PostAnalysis | TypingMode::Codegen => {
                         let recursion_limit = self.cx().recursion_limit();
                         if !recursion_limit.value_within_limit(self.depth) {

--- a/compiler/rustc_trait_selection/src/traits/project.rs
+++ b/compiler/rustc_trait_selection/src/traits/project.rs
@@ -955,9 +955,9 @@ fn assemble_candidates_from_impls<'cx, 'tcx>(
                             // get a result which isn't correct for all monomorphizations.
                             match selcx.typing_mode() {
                                 TypingMode::Coherence
-                                | TypingMode::Analysis { .. }
-                                | TypingMode::Borrowck { .. }
-                                | TypingMode::PostBorrowckAnalysis { .. } => {
+                                | TypingMode::Typeck { .. }
+                                | TypingMode::PostTypeckUntilBorrowck { .. }
+                                | TypingMode::PostBorrowck { .. } => {
                                     debug!(
                                         assoc_ty = ?selcx.tcx().def_path_str(node_item.item.def_id),
                                         ?obligation.predicate,

--- a/compiler/rustc_trait_selection/src/traits/query/normalize.rs
+++ b/compiler/rustc_trait_selection/src/traits/query/normalize.rs
@@ -216,9 +216,9 @@ impl<'a, 'tcx> FallibleTypeFolder<TyCtxt<'tcx>> for QueryNormalizer<'a, 'tcx> {
                 // Only normalize `impl Trait` outside of type inference, usually in codegen.
                 match self.infcx.typing_mode_raw().assert_not_erased() {
                     TypingMode::Coherence
-                    | TypingMode::Analysis { .. }
-                    | TypingMode::Borrowck { .. }
-                    | TypingMode::PostBorrowckAnalysis { .. } => ty.try_super_fold_with(self)?,
+                    | TypingMode::Typeck { .. }
+                    | TypingMode::PostTypeckUntilBorrowck { .. }
+                    | TypingMode::PostBorrowck { .. } => ty.try_super_fold_with(self)?,
 
                     TypingMode::PostAnalysis | TypingMode::Codegen => {
                         let args = data.args.try_fold_with(self)?;

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -1481,9 +1481,9 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         let obligation = &stack.obligation;
         match self.typing_mode() {
             TypingMode::Coherence => {}
-            TypingMode::Analysis { .. }
-            | TypingMode::Borrowck { .. }
-            | TypingMode::PostBorrowckAnalysis { .. }
+            TypingMode::Typeck { .. }
+            | TypingMode::PostTypeckUntilBorrowck { .. }
+            | TypingMode::PostBorrowck { .. }
             | TypingMode::PostAnalysis
             | TypingMode::Codegen => return Ok(()),
         }
@@ -1529,16 +1529,14 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             // However, if we disqualify *all* goals from being cached, perf suffers.
             // This is likely fixed by better caching in general in the new solver.
             // See: <https://github.com/rust-lang/rust/issues/132064>.
-            TypingMode::Analysis {
-                defining_opaque_types_and_generators: defining_opaque_types,
-            }
-            | TypingMode::Borrowck { defining_opaque_types } => {
+            TypingMode::Typeck { defining_opaque_types_and_generators: defining_opaque_types }
+            | TypingMode::PostTypeckUntilBorrowck { defining_opaque_types } => {
                 defining_opaque_types.is_empty()
                     || (!pred.has_opaque_types() && !pred.has_coroutines())
             }
             // The hidden types of `defined_opaque_types` is not local to the current
             // inference context, so we can freely move this to the global cache.
-            TypingMode::PostBorrowckAnalysis { .. } => true,
+            TypingMode::PostBorrowck { .. } => true,
             // The global cache is only used if there are no opaque types in
             // the defining scope or we're outside of analysis.
             //
@@ -2906,14 +2904,14 @@ impl<'tcx> SelectionContext<'_, 'tcx> {
 
     pub(super) fn should_stall_coroutine(&self, def_id: DefId) -> bool {
         match self.typing_mode() {
-            TypingMode::Analysis { defining_opaque_types_and_generators: stalled_generators } => {
+            TypingMode::Typeck { defining_opaque_types_and_generators: stalled_generators } => {
                 def_id.as_local().is_some_and(|def_id| stalled_generators.contains(&def_id))
             }
             TypingMode::Coherence
             | TypingMode::PostAnalysis
             | TypingMode::Codegen
-            | TypingMode::Borrowck { defining_opaque_types: _ }
-            | TypingMode::PostBorrowckAnalysis { defined_opaque_types: _ } => false,
+            | TypingMode::PostTypeckUntilBorrowck { defining_opaque_types: _ }
+            | TypingMode::PostBorrowck { defined_opaque_types: _ } => false,
         }
     }
 }

--- a/compiler/rustc_traits/src/coroutine_witnesses.rs
+++ b/compiler/rustc_traits/src/coroutine_witnesses.rs
@@ -49,9 +49,9 @@ fn compute_assumptions<'tcx>(
     def_id: DefId,
     bound_tys: &'tcx ty::List<Ty<'tcx>>,
 ) -> &'tcx ty::List<ty::ArgOutlivesPredicate<'tcx>> {
-    let infcx = tcx.infer_ctxt().build(ty::TypingMode::Analysis {
-        defining_opaque_types_and_generators: ty::List::empty(),
-    });
+    let infcx = tcx
+        .infer_ctxt()
+        .build(ty::TypingMode::Typeck { defining_opaque_types_and_generators: ty::List::empty() });
     with_replaced_escaping_bound_vars(&infcx, &mut vec![None], bound_tys, |bound_tys| {
         let param_env = tcx.param_env(def_id);
         let ocx = ObligationCtxt::new(&infcx);

--- a/compiler/rustc_ty_utils/src/instance.rs
+++ b/compiler/rustc_ty_utils/src/instance.rs
@@ -157,9 +157,9 @@ fn resolve_associated_item<'tcx>(
                 // get a result which isn't correct for all monomorphizations.
                 match typing_env.typing_mode().assert_not_erased() {
                     ty::TypingMode::Coherence
-                    | ty::TypingMode::Analysis { .. }
-                    | ty::TypingMode::Borrowck { .. }
-                    | ty::TypingMode::PostBorrowckAnalysis { .. } => false,
+                    | ty::TypingMode::Typeck { .. }
+                    | ty::TypingMode::PostTypeckUntilBorrowck { .. }
+                    | ty::TypingMode::PostBorrowck { .. } => false,
                     ty::TypingMode::PostAnalysis | ty::TypingMode::Codegen => {
                         !trait_ref.still_further_specializable()
                     }

--- a/compiler/rustc_ty_utils/src/layout.rs
+++ b/compiler/rustc_ty_utils/src/layout.rs
@@ -77,9 +77,9 @@ fn layout_of<'tcx>(
             };
         }
         ty::TypingMode::Coherence
-        | ty::TypingMode::Analysis { .. }
-        | ty::TypingMode::Borrowck { .. }
-        | ty::TypingMode::PostBorrowckAnalysis { .. }
+        | ty::TypingMode::Typeck { .. }
+        | ty::TypingMode::PostTypeckUntilBorrowck { .. }
+        | ty::TypingMode::PostBorrowck { .. }
         | ty::TypingMode::ErasedNotCoherence(_)
         | ty::TypingMode::PostAnalysis => {}
     }
@@ -540,9 +540,9 @@ fn layout_of_uncached<'tcx>(
             match cx.typing_env.typing_mode() {
                 ty::TypingMode::Codegen => {}
                 ty::TypingMode::Coherence
-                | ty::TypingMode::Analysis { .. }
-                | ty::TypingMode::Borrowck { .. }
-                | ty::TypingMode::PostBorrowckAnalysis { .. }
+                | ty::TypingMode::Typeck { .. }
+                | ty::TypingMode::PostTypeckUntilBorrowck { .. }
+                | ty::TypingMode::PostBorrowck { .. }
                 | ty::TypingMode::ErasedNotCoherence(_)
                 | ty::TypingMode::PostAnalysis => {
                     return Err(error(cx, LayoutError::TooGeneric(ty)));

--- a/compiler/rustc_type_ir/src/infer_ctxt.rs
+++ b/compiler/rustc_type_ir/src/infer_ctxt.rs
@@ -107,12 +107,11 @@ pub enum TypingMode<I: Interner, S: TypingModeErasedStatus = MayBeErased> {
     /// }
     /// ```
     Typeck { defining_opaque_types_and_generators: I::LocalDefIds },
-    /// `PostTypeckUntilBorrowck` is used after `Typeck` has finished, up to
-    /// and including borrowck. This is the behavior that's used mainly in borrowck,
-    /// but, for example, also in late lints and other analyses while building MIR.
-    /// The behavior of `PostTypeckUntilBorrowck` is identical to `TypingMode::Typeck`
-    /// except that the initial value for opaque types is the type computed during
-    /// HIR typeck with unique unconstrained region inference variables.
+    /// `PostTypeckUntilBorrowck` is used after `Typeck` has finished, up to and including borrowck,
+    /// for anything that accesses typeck results. This is the behavior that's used mainly in borrowck,
+    /// but, for example, also in late lints and other analyses while building MIR. The behavior of
+    /// `PostTypeckUntilBorrowck` is identical to `TypingMode::Typeck` except that the initial value for
+    /// opaque types is the type computed during HIR typeck with unique unconstrained region inference variables.
     ///
     /// This is currently only used by the new solver as it results in new
     /// non-universal defining uses of opaque types, which is a breaking change.

--- a/compiler/rustc_type_ir/src/infer_ctxt.rs
+++ b/compiler/rustc_type_ir/src/infer_ctxt.rs
@@ -77,7 +77,8 @@ pub enum TypingMode<I: Interner, S: TypingModeErasedStatus = MayBeErased> {
     /// We also have to be careful when generalizing aliases inside of higher-ranked
     /// types to not unnecessarily constrain any inference variables.
     Coherence,
-    /// Analysis includes type inference, checking that items are well-formed, and
+    /// Typeck is the typing mode mainly used in `rustc_hir_typeck` and related crate.
+    /// It includes type inference, checking that items are well-formed, and
     /// pretty much everything else which may emit proper type errors to the user.
     ///
     /// We only normalize opaque types which may get defined by the current body,
@@ -105,21 +106,24 @@ pub enum TypingMode<I: Interner, S: TypingModeErasedStatus = MayBeErased> {
     ///     let x: <() as Assoc>::Output = true;
     /// }
     /// ```
-    Analysis { defining_opaque_types_and_generators: I::LocalDefIds },
-    /// The behavior during MIR borrowck is identical to `TypingMode::Analysis`
+    Typeck { defining_opaque_types_and_generators: I::LocalDefIds },
+    /// `PostTypeckUntilBorrowck` is used after `Typeck` has finished, up to
+    /// and including borrowck. This is the behavior that's used mainly in borrowck,
+    /// but, for example, also in late lints and other analyses while building MIR.
+    /// The behavior of `PostTypeckUntilBorrowck` is identical to `TypingMode::Typeck`
     /// except that the initial value for opaque types is the type computed during
     /// HIR typeck with unique unconstrained region inference variables.
     ///
-    /// This is currently only used with by the new solver as it results in new
+    /// This is currently only used by the new solver as it results in new
     /// non-universal defining uses of opaque types, which is a breaking change.
     /// See tests/ui/impl-trait/non-defining-use/as-projection-term.rs.
-    Borrowck { defining_opaque_types: I::LocalDefIds },
+    PostTypeckUntilBorrowck { defining_opaque_types: I::LocalDefIds },
     /// Any analysis after borrowck for a given body should be able to use all the
     /// hidden types defined by borrowck, without being able to define any new ones.
     ///
     /// This is currently only used by the new solver, but should be implemented in
     /// the old solver as well.
-    PostBorrowckAnalysis { defined_opaque_types: I::LocalDefIds },
+    PostBorrowck { defined_opaque_types: I::LocalDefIds },
     /// After analysis, mostly during MIR optimizations, we're able to
     /// reveal all opaque types. As the hidden type should *never* be observable
     /// directly by the user, this should not be used by checks which may expose
@@ -171,16 +175,16 @@ impl<I: Interner> PartialEq for TypingModeEqWrapper<I> {
         match (self.0, other.0) {
             (TypingMode::Coherence, TypingMode::Coherence) => true,
             (
-                TypingMode::Analysis { defining_opaque_types_and_generators: l },
-                TypingMode::Analysis { defining_opaque_types_and_generators: r },
+                TypingMode::Typeck { defining_opaque_types_and_generators: l },
+                TypingMode::Typeck { defining_opaque_types_and_generators: r },
             ) => l == r,
             (
-                TypingMode::Borrowck { defining_opaque_types: l },
-                TypingMode::Borrowck { defining_opaque_types: r },
+                TypingMode::PostTypeckUntilBorrowck { defining_opaque_types: l },
+                TypingMode::PostTypeckUntilBorrowck { defining_opaque_types: r },
             ) => l == r,
             (
-                TypingMode::PostBorrowckAnalysis { defined_opaque_types: l },
-                TypingMode::PostBorrowckAnalysis { defined_opaque_types: r },
+                TypingMode::PostBorrowck { defined_opaque_types: l },
+                TypingMode::PostBorrowck { defined_opaque_types: r },
             ) => l == r,
             (TypingMode::PostAnalysis, TypingMode::PostAnalysis) => true,
             (TypingMode::Codegen, TypingMode::Codegen) => true,
@@ -190,9 +194,9 @@ impl<I: Interner> PartialEq for TypingModeEqWrapper<I> {
             ) => true,
             (
                 TypingMode::Coherence
-                | TypingMode::Analysis { .. }
-                | TypingMode::Borrowck { .. }
-                | TypingMode::PostBorrowckAnalysis { .. }
+                | TypingMode::Typeck { .. }
+                | TypingMode::PostTypeckUntilBorrowck { .. }
+                | TypingMode::PostBorrowck { .. }
                 | TypingMode::PostAnalysis
                 | TypingMode::Codegen
                 | TypingMode::ErasedNotCoherence(MayBeErased),
@@ -213,9 +217,9 @@ impl<I: Interner, S: TypingModeErasedStatus> TypingMode<I, S> {
     pub fn is_coherence(&self) -> bool {
         match self {
             TypingMode::Coherence => true,
-            TypingMode::Analysis { .. }
-            | TypingMode::Borrowck { .. }
-            | TypingMode::PostBorrowckAnalysis { .. }
+            TypingMode::Typeck { .. }
+            | TypingMode::PostTypeckUntilBorrowck { .. }
+            | TypingMode::PostBorrowck { .. }
             | TypingMode::PostAnalysis
             | TypingMode::Codegen
             | TypingMode::ErasedNotCoherence(_) => false,
@@ -231,9 +235,9 @@ impl<I: Interner, S: TypingModeErasedStatus> TypingMode<I, S> {
         match self {
             TypingMode::ErasedNotCoherence(_) => true,
             TypingMode::Coherence
-            | TypingMode::Analysis { .. }
-            | TypingMode::Borrowck { .. }
-            | TypingMode::PostBorrowckAnalysis { .. }
+            | TypingMode::Typeck { .. }
+            | TypingMode::PostTypeckUntilBorrowck { .. }
+            | TypingMode::PostBorrowck { .. }
             | TypingMode::PostAnalysis
             | TypingMode::Codegen => false,
         }
@@ -248,14 +252,14 @@ impl<I: Interner> TypingMode<I, MayBeErased> {
     pub fn assert_not_erased(self) -> TypingMode<I, CantBeErased> {
         match self {
             TypingMode::Coherence => TypingMode::Coherence,
-            TypingMode::Analysis { defining_opaque_types_and_generators } => {
-                TypingMode::Analysis { defining_opaque_types_and_generators }
+            TypingMode::Typeck { defining_opaque_types_and_generators } => {
+                TypingMode::Typeck { defining_opaque_types_and_generators }
             }
-            TypingMode::Borrowck { defining_opaque_types } => {
-                TypingMode::Borrowck { defining_opaque_types }
+            TypingMode::PostTypeckUntilBorrowck { defining_opaque_types } => {
+                TypingMode::PostTypeckUntilBorrowck { defining_opaque_types }
             }
-            TypingMode::PostBorrowckAnalysis { defined_opaque_types } => {
-                TypingMode::PostBorrowckAnalysis { defined_opaque_types }
+            TypingMode::PostBorrowck { defined_opaque_types } => {
+                TypingMode::PostBorrowck { defined_opaque_types }
             }
             TypingMode::PostAnalysis => TypingMode::PostAnalysis,
             TypingMode::Codegen => TypingMode::Codegen,
@@ -269,11 +273,11 @@ impl<I: Interner> TypingMode<I, MayBeErased> {
 impl<I: Interner> TypingMode<I, CantBeErased> {
     /// Analysis outside of a body does not define any opaque types.
     pub fn non_body_analysis() -> TypingMode<I> {
-        TypingMode::Analysis { defining_opaque_types_and_generators: Default::default() }
+        TypingMode::Typeck { defining_opaque_types_and_generators: Default::default() }
     }
 
     pub fn typeck_for_body(cx: I, body_def_id: I::LocalDefId) -> TypingMode<I> {
-        TypingMode::Analysis {
+        TypingMode::Typeck {
             defining_opaque_types_and_generators: cx
                 .opaque_types_and_coroutines_defined_by(body_def_id),
         }
@@ -285,7 +289,7 @@ impl<I: Interner> TypingMode<I, CantBeErased> {
     /// FIXME: This will be removed because it's generally not correct to define
     /// opaques outside of HIR typeck.
     pub fn analysis_in_body(cx: I, body_def_id: I::LocalDefId) -> TypingMode<I> {
-        TypingMode::Analysis {
+        TypingMode::Typeck {
             defining_opaque_types_and_generators: cx.opaque_types_defined_by(body_def_id),
         }
     }
@@ -295,7 +299,7 @@ impl<I: Interner> TypingMode<I, CantBeErased> {
         if defining_opaque_types.is_empty() {
             TypingMode::non_body_analysis()
         } else {
-            TypingMode::Borrowck { defining_opaque_types }
+            TypingMode::PostTypeckUntilBorrowck { defining_opaque_types }
         }
     }
 
@@ -304,7 +308,7 @@ impl<I: Interner> TypingMode<I, CantBeErased> {
         if defined_opaque_types.is_empty() {
             TypingMode::non_body_analysis()
         } else {
-            TypingMode::PostBorrowckAnalysis { defined_opaque_types }
+            TypingMode::PostBorrowck { defined_opaque_types }
         }
     }
 }
@@ -313,14 +317,14 @@ impl<I: Interner> From<TypingMode<I, CantBeErased>> for TypingMode<I, MayBeErase
     fn from(value: TypingMode<I, CantBeErased>) -> Self {
         match value {
             TypingMode::Coherence => TypingMode::Coherence,
-            TypingMode::Analysis { defining_opaque_types_and_generators } => {
-                TypingMode::Analysis { defining_opaque_types_and_generators }
+            TypingMode::Typeck { defining_opaque_types_and_generators } => {
+                TypingMode::Typeck { defining_opaque_types_and_generators }
             }
-            TypingMode::Borrowck { defining_opaque_types } => {
-                TypingMode::Borrowck { defining_opaque_types }
+            TypingMode::PostTypeckUntilBorrowck { defining_opaque_types } => {
+                TypingMode::PostTypeckUntilBorrowck { defining_opaque_types }
             }
-            TypingMode::PostBorrowckAnalysis { defined_opaque_types } => {
-                TypingMode::PostBorrowckAnalysis { defined_opaque_types }
+            TypingMode::PostBorrowck { defined_opaque_types } => {
+                TypingMode::PostBorrowck { defined_opaque_types }
             }
             TypingMode::PostAnalysis => TypingMode::PostAnalysis,
             TypingMode::Codegen => TypingMode::Codegen,
@@ -543,9 +547,9 @@ where
 
     match infcx.typing_mode_raw().assert_not_erased() {
         TypingMode::Coherence
-        | TypingMode::Analysis { .. }
-        | TypingMode::Borrowck { .. }
-        | TypingMode::PostBorrowckAnalysis { .. }
+        | TypingMode::Typeck { .. }
+        | TypingMode::PostTypeckUntilBorrowck { .. }
+        | TypingMode::PostBorrowck { .. }
         | TypingMode::PostAnalysis => infcx.cx().features().feature_bound_holds_in_crate(symbol),
         TypingMode::Codegen => true,
     }

--- a/compiler/rustc_type_ir/src/region_constraint.rs
+++ b/compiler/rustc_type_ir/src/region_constraint.rs
@@ -898,10 +898,10 @@ fn rewrite_type_outlives_constraints_in_universe_for_eager_placeholder_handling<
             // in coherence
             match infcx.typing_mode_raw() {
                 TypingMode::Coherence => candidates.push(RegionConstraint::Ambiguity),
-                TypingMode::Analysis { .. }
+                TypingMode::Typeck { .. }
                 | TypingMode::ErasedNotCoherence { .. }
-                | TypingMode::Borrowck { .. }
-                | TypingMode::PostBorrowckAnalysis { .. }
+                | TypingMode::PostTypeckUntilBorrowck { .. }
+                | TypingMode::PostBorrowck { .. }
                 | TypingMode::PostAnalysis
                 | TypingMode::Codegen => (),
             };

--- a/compiler/rustc_type_ir/src/relate/combine.rs
+++ b/compiler/rustc_type_ir/src/relate/combine.rs
@@ -140,9 +140,9 @@ where
                     relation.register_predicates([ty::Binder::dummy(ty::PredicateKind::Ambiguous)]);
                     Ok(a)
                 }
-                TypingMode::Analysis { .. }
-                | TypingMode::Borrowck { .. }
-                | TypingMode::PostBorrowckAnalysis { .. }
+                TypingMode::Typeck { .. }
+                | TypingMode::PostTypeckUntilBorrowck { .. }
+                | TypingMode::PostBorrowck { .. }
                 | TypingMode::PostAnalysis
                 | TypingMode::Codegen => structurally_relate_tys(relation, a, b),
             }

--- a/compiler/rustc_type_ir/src/solve/mod.rs
+++ b/compiler/rustc_type_ir/src/solve/mod.rs
@@ -145,7 +145,7 @@ impl<T: Copy + Debug + Hash + Eq> AsRef<[T]> for SmallCopyList<T> {
 /// | never                   | no    | no                                                                                                                   |
 /// | always                  | yes   | yes                                                                                                                  |
 /// | [defid in storage]      | no    | only if any of the defids in the list is in the opaque type storage OR if TypingMode::PostAnalysis                   |
-/// | opaque with hidden type | no    | only if any of the opaques in the opaque type storage has a hidden type in this list AND if TypingMode::Analysis |
+/// | opaque with hidden type | no    | only if any of the opaques in the opaque type storage has a hidden type in this list AND if TypingMode::Typeck       |
 ///
 /// - "bail" is implemented with [`should_bail`](Self::should_bail).
 ///   If true, we're abandoning our attempt to canonicalize in [`TypingMode::ErasedNotCoherence`],
@@ -161,14 +161,14 @@ impl<T: Copy + Debug + Hash + Eq> AsRef<[T]> for SmallCopyList<T> {
 pub enum RerunCondition<I: Interner> {
     Never,
 
-    /// Note that this only reruns according to the condition *if* we are in [`TypingMode::Analysis`].
+    /// Note that this only reruns according to the condition *if* we are in [`TypingMode::Typeck`].
     AnyOpaqueHasInferAsHidden,
     /// Note: unconditionally reruns in postanalysis
     OpaqueInStorage(SmallCopyList<I::LocalDefId>),
 
     /// Merges [`Self::AnyOpaqueHasInferAsHidden`] and [`Self::OpaqueInStorage`].
     /// Note that just like the unmerged [`Self::OpaqueInStorage`], that part of the
-    /// condition only matters in [`TypingMode::Analysis`]
+    /// condition only matters in [`TypingMode::Typeck`]
     OpaqueInStorageOrAnyOpaqueHasInferAsHidden(SmallCopyList<I::LocalDefId>),
 
     Always,

--- a/tests/ui/traits/next-solver/non-wf-candidate-behind-stalled-coroutine-1.rs
+++ b/tests/ui/traits/next-solver/non-wf-candidate-behind-stalled-coroutine-1.rs
@@ -9,7 +9,7 @@
 // This previously caused an ICE due to a non–well-formed opaque type
 // in a coroutine witness failing the leak check in the next-solver.
 //
-// In `TypingMode::Analysis`, the problematic type is hidden behind a
+// In `TypingMode::Typeck`, the problematic type is hidden behind a
 // stalled coroutine candidate. However, in later passes (e.g. MIR
 // validation), we eagerly normalize it. The candidate that was
 // previously accepted as a solution then fails the leak check, resulting

--- a/tests/ui/traits/next-solver/non-wf-candidate-behind-stalled-coroutine-2.rs
+++ b/tests/ui/traits/next-solver/non-wf-candidate-behind-stalled-coroutine-2.rs
@@ -9,7 +9,7 @@
 // This previously caused an ICE due to a non–well-formed opaque type
 // in a coroutine witness failing the leak check in the next-solver.
 //
-// In `TypingMode::Analysis`, the problematic type is hidden behind a
+// In `TypingMode::Typeck`, the problematic type is hidden behind a
 // stalled coroutine candidate. However, in later passes (e.g. MIR
 // validation), we eagerly normalize it. The candidate that was
 // previously accepted as a solution then fails the leak check, resulting

--- a/tests/ui/traits/next-solver/non-wf-candidate-behind-stalled-coroutine-3.rs
+++ b/tests/ui/traits/next-solver/non-wf-candidate-behind-stalled-coroutine-3.rs
@@ -9,7 +9,7 @@
 // This previously caused an ICE due to a non–well-formed opaque type
 // in a coroutine witness failing the leak check in the next-solver.
 //
-// In `TypingMode::Analysis`, the problematic type is hidden behind a
+// In `TypingMode::Typeck`, the problematic type is hidden behind a
 // stalled coroutine candidate. However, in later passes (e.g. MIR
 // validation), we eagerly normalize it. The candidate that was
 // previously accepted as a solution then fails the leak check, resulting


### PR DESCRIPTION
r? @lcnr

cc: @BoxyUwU 

Lcnr and I brainstormed these names before RustWeek, but I never got to actually changing it. As for rationale:

- `Coherence`: stays the same
- `Analysis`: given that basically all of type checking is analyzing code, this didn't feel so accurate. It's now called `Typeck` to signify that it's mainly used during `hir_typeck`.
- `Borrowck`: this is the one that actually started the discussion about renaming. Borrowck is used in quite a few places now that are *not* Borrowck, simply to avoid making inference progress on opaque types. It's renamed to `PostTypeckUntilBorrowck`, since its used after `Typeck`.
- `PostBorrowckAnalysis` is now simply called `PostBorrowck`, since it's supposed to be used after borrowck finishes.
- `PostAnalysis` stays the same, it's the typing mode used after all type analysis finished
- There's now also a new `Codegen` typing mode. It's unchanged too.

To preempt some questions, I mainly did this rename through normal editor renames. I then also did a search with various regexes over ever occurence of `//.*Analysis` and `//.*Borrowck` and `PostBorrowck`, and some more similar regexes to make sure as many comments as possible are updated, if not all.

Notably, this PR does not update RustAnlayzer to use the same names yet.

Warning: this PR may be somewhat conflicty :/