### PR TITLE
Region inference: Simplify initialisation of region values

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/find_use.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/find_use.rs
@@ -35,7 +35,7 @@ impl<'a, 'tcx> UseFinder<'a, 'tcx> {
 
         queue.push_back(self.start_point);
         while let Some(p) = queue.pop_front() {
-            if !self.regioncx.region_contains(self.region_vid, p) {
+            if !self.regioncx.region_contains_point(self.region_vid, p) {
                 continue;
             }
 

--- a/compiler/rustc_borrowck/src/region_infer/mod.rs
+++ b/compiler/rustc_borrowck/src/region_infer/mod.rs
@@ -364,17 +364,16 @@ impl<'tcx> RegionInferenceContext<'tcx> {
         let mut scc_values =
             RegionValues::new(location_map, universal_regions.len(), placeholder_indices);
 
-        // Initializes the region variables for each universally
-        // quantified region (lifetime parameter). The first N variables
-        // always correspond to the regions appearing in the function
-        // signature (both named and anonymous) and in where-clauses.
+        // Initializes the region variables with their initial live points.
         for (region, definition) in definitions.iter_enumerated() {
             let scc = constraint_sccs.scc(region);
 
+            // For each universally quantified region (lifetime parameter). The
+            // first N variables always correspond to the regions appearing in the
+            // function signature (both named and anonymous) and in where-clauses.
             match definition.origin {
+                // For each free, universally quantified region X:
                 NllRegionVariableOrigin::FreeRegion => {
-                    // For each free, universally quantified region X:
-
                     // Add all nodes in the CFG to liveness constraints
                     liveness_constraints.add_all_points(region);
 
@@ -383,22 +382,23 @@ impl<'tcx> RegionInferenceContext<'tcx> {
                 }
 
                 NllRegionVariableOrigin::Placeholder(placeholder) => {
-                    scc_values.add_placeholder(scc, placeholder)
+                    scc_values.add_placeholder(scc, placeholder);
                 }
 
                 NllRegionVariableOrigin::Existential { .. } => {
                     // For existential, regions, nothing to do.
                 }
             }
-        }
 
-        for (region, liveness) in liveness_constraints.regions_and_liveness() {
             // Initially copy the liveness constraints of any region that
             // has them, setting `scc_values[scc(region)] |= liveness_constraints[region]`.
             //
-            // These values will later be propagated during [`Self::propagate_constraints()`]
-            scc_values.merge_liveness(constraint_sccs.scc(region), liveness);
-            // Note: this includes the liveness values we just initialised above!
+            // These values will later be propagated during [`Self::propagate_constraints()`].
+            // The values include any live-at-all-points constraints added above
+            // for free regions.
+            if let Some(liveness) = liveness_constraints.point_liveness(region) {
+                scc_values.merge_liveness(scc, liveness)
+            }
         }
 
         Self {
@@ -556,7 +556,8 @@ impl<'tcx> RegionInferenceContext<'tcx> {
         // To propagate constraints, we walk the DAG induced by the
         // SCC. For each SCC `A`, we visit its successors and compute
         // their values, then we union all those values to get our
-        // own.
+        // own. This one-shot approach works because iteration is in
+        // dependency order. I.e. a chain A: B: C will visit C, B, A.
         for scc_a in self.constraint_sccs.all_sccs() {
             // Walk each SCC `B` such that `A: B`...
             for &scc_b in self.constraint_sccs.successors(scc_a) {

--- a/compiler/rustc_borrowck/src/region_infer/mod.rs
+++ b/compiler/rustc_borrowck/src/region_infer/mod.rs
@@ -30,7 +30,7 @@ use crate::diagnostics::{RegionErrorKind, RegionErrors, UniverseInfo};
 use crate::handle_placeholders::{LoweredConstraints, RegionTracker};
 use crate::polonius::LiveLoans;
 use crate::polonius::legacy::PoloniusOutput;
-use crate::region_infer::values::{LivenessValues, RegionElement, RegionValues, ToElementIndex};
+use crate::region_infer::values::{LivenessValues, RegionElement, RegionValues};
 use crate::type_check::Locations;
 use crate::type_check::free_region_relations::UniversalRegionRelations;
 use crate::universal_regions::UniversalRegions;
@@ -379,12 +379,11 @@ impl<'tcx> RegionInferenceContext<'tcx> {
                     liveness_constraints.add_all_points(region);
 
                     // Add `end(X)` into the set for X.
-                    scc_values.add_element(scc, region);
+                    scc_values.add_free_region(scc, region);
                 }
 
                 NllRegionVariableOrigin::Placeholder(placeholder) => {
-                    // Placeholder region variables contain their placeholder.
-                    scc_values.add_element(scc, placeholder);
+                    scc_values.add_placeholder(scc, placeholder)
                 }
 
                 NllRegionVariableOrigin::Existential { .. } => {
@@ -444,9 +443,9 @@ impl<'tcx> RegionInferenceContext<'tcx> {
     /// Returns `true` if the region `r` contains the point `p`.
     ///
     /// Panics if called before `solve()` executes,
-    pub(crate) fn region_contains(&self, r: RegionVid, p: impl ToElementIndex<'tcx>) -> bool {
+    pub(crate) fn region_contains_point(&self, r: RegionVid, p: Location) -> bool {
         let scc = self.constraint_sccs.scc(r);
-        self.scc_values.contains(scc, p)
+        self.scc_values.contains_point(scc, p)
     }
 
     /// Returns the lowest statement index in `start..=end` which is not contained by `r`.
@@ -1592,10 +1591,10 @@ impl<'tcx> RegionInferenceContext<'tcx> {
         &self.definitions[r]
     }
 
-    /// Check if the SCC of `r` contains `upper`.
+    /// Check if the SCC of `r` contains `upper`, a free region.
     pub(crate) fn upper_bound_in_region_scc(&self, r: RegionVid, upper: RegionVid) -> bool {
         let r_scc = self.constraint_sccs.scc(r);
-        self.scc_values.contains(r_scc, upper)
+        self.scc_values.contains_free_region(r_scc, upper)
     }
 
     pub(crate) fn universal_regions(&self) -> &UniversalRegions<'tcx> {

--- a/compiler/rustc_borrowck/src/region_infer/mod.rs
+++ b/compiler/rustc_borrowck/src/region_infer/mod.rs
@@ -345,7 +345,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
             outlives_constraints,
             scc_annotations,
             type_tests,
-            liveness_constraints,
+            mut liveness_constraints,
             universe_causes,
             placeholder_indices,
         } = lowered_constraints;
@@ -364,12 +364,45 @@ impl<'tcx> RegionInferenceContext<'tcx> {
         let mut scc_values =
             RegionValues::new(location_map, universal_regions.len(), placeholder_indices);
 
-        for region in liveness_constraints.regions() {
+        // Initializes the region variables for each universally
+        // quantified region (lifetime parameter). The first N variables
+        // always correspond to the regions appearing in the function
+        // signature (both named and anonymous) and in where-clauses.
+        for (region, definition) in definitions.iter_enumerated() {
             let scc = constraint_sccs.scc(region);
-            scc_values.merge_liveness(scc, region, &liveness_constraints);
+
+            match definition.origin {
+                NllRegionVariableOrigin::FreeRegion => {
+                    // For each free, universally quantified region X:
+
+                    // Add all nodes in the CFG to liveness constraints
+                    liveness_constraints.add_all_points(region);
+
+                    // Add `end(X)` into the set for X.
+                    scc_values.add_element(scc, region);
+                }
+
+                NllRegionVariableOrigin::Placeholder(placeholder) => {
+                    // Placeholder region variables contain their placeholder.
+                    scc_values.add_element(scc, placeholder);
+                }
+
+                NllRegionVariableOrigin::Existential { .. } => {
+                    // For existential, regions, nothing to do.
+                }
+            }
         }
 
-        let mut result = Self {
+        for (region, liveness) in liveness_constraints.regions_and_liveness() {
+            // Initially copy the liveness constraints of any region that
+            // has them, setting `scc_values[scc(region)] |= liveness_constraints[region]`.
+            //
+            // These values will later be propagated during [`Self::propagate_constraints()`]
+            scc_values.merge_liveness(constraint_sccs.scc(region), liveness);
+            // Note: this includes the liveness values we just initialised above!
+        }
+
+        Self {
             definitions,
             liveness_constraints,
             constraints: outlives_constraints,
@@ -380,90 +413,6 @@ impl<'tcx> RegionInferenceContext<'tcx> {
             scc_values,
             type_tests,
             universal_region_relations,
-        };
-
-        result.init_free_and_bound_regions();
-
-        result
-    }
-
-    /// Initializes the region variables for each universally
-    /// quantified region (lifetime parameter). The first N variables
-    /// always correspond to the regions appearing in the function
-    /// signature (both named and anonymous) and where-clauses. This
-    /// function iterates over those regions and initializes them with
-    /// minimum values.
-    ///
-    /// For example:
-    /// ```ignore (illustrative)
-    /// fn foo<'a, 'b>( /* ... */ ) where 'a: 'b { /* ... */ }
-    /// ```
-    /// would initialize two variables like so:
-    /// ```ignore (illustrative)
-    /// R0 = { CFG, R0 } // 'a
-    /// R1 = { CFG, R0, R1 } // 'b
-    /// ```
-    /// Here, R0 represents `'a`, and it contains (a) the entire CFG
-    /// and (b) any universally quantified regions that it outlives,
-    /// which in this case is just itself. R1 (`'b`) in contrast also
-    /// outlives `'a` and hence contains R0 and R1.
-    ///
-    /// This bit of logic also handles invalid universe relations
-    /// for higher-kinded types.
-    ///
-    /// We Walk each SCC `A` and `B` such that `A: B`
-    /// and ensure that universe(A) can see universe(B).
-    ///
-    /// This serves to enforce the 'empty/placeholder' hierarchy
-    /// (described in more detail on `RegionKind`):
-    ///
-    /// ```ignore (illustrative)
-    /// static -----+
-    ///   |         |
-    /// empty(U0) placeholder(U1)
-    ///   |      /
-    /// empty(U1)
-    /// ```
-    ///
-    /// In particular, imagine we have variables R0 in U0 and R1
-    /// created in U1, and constraints like this;
-    ///
-    /// ```ignore (illustrative)
-    /// R1: !1 // R1 outlives the placeholder in U1
-    /// R1: R0 // R1 outlives R0
-    /// ```
-    ///
-    /// Here, we wish for R1 to be `'static`, because it
-    /// cannot outlive `placeholder(U1)` and `empty(U0)` any other way.
-    ///
-    /// Thanks to this loop, what happens is that the `R1: R0`
-    /// constraint has lowered the universe of `R1` to `U0`, which in turn
-    /// means that the `R1: !1` constraint here will cause
-    /// `R1` to become `'static`.
-    fn init_free_and_bound_regions(&mut self) {
-        for variable in self.definitions.indices() {
-            let scc = self.constraint_sccs.scc(variable);
-
-            match self.definitions[variable].origin {
-                NllRegionVariableOrigin::FreeRegion => {
-                    // For each free, universally quantified region X:
-
-                    // Add all nodes in the CFG to liveness constraints
-                    self.liveness_constraints.add_all_points(variable);
-                    self.scc_values.add_all_points(scc);
-
-                    // Add `end(X)` into the set for X.
-                    self.scc_values.add_element(scc, variable);
-                }
-
-                NllRegionVariableOrigin::Placeholder(placeholder) => {
-                    self.scc_values.add_element(scc, placeholder);
-                }
-
-                NllRegionVariableOrigin::Existential { .. } => {
-                    // For existential, regions, nothing to do.
-                }
-            }
         }
     }
 

--- a/compiler/rustc_borrowck/src/region_infer/opaque_types/region_ctxt.rs
+++ b/compiler/rustc_borrowck/src/region_infer/opaque_types/region_ctxt.rs
@@ -78,11 +78,11 @@ impl<'a, 'tcx> RegionCtxt<'a, 'tcx> {
         let placeholder_indices = Default::default();
         let mut scc_values =
             RegionValues::new(location_map, universal_regions.len(), placeholder_indices);
-        for variable in definitions.indices() {
+        for (variable, definition) in definitions.iter_enumerated() {
             let scc = constraint_sccs.scc(variable);
-            match definitions[variable].origin {
+            match definition.origin {
                 NllRegionVariableOrigin::FreeRegion => {
-                    scc_values.add_element(scc, variable);
+                    scc_values.add_free_region(scc, variable);
                 }
                 _ => {}
             }

--- a/compiler/rustc_borrowck/src/region_infer/values.rs
+++ b/compiler/rustc_borrowck/src/region_infer/values.rs
@@ -95,11 +95,10 @@ impl LivenessValues {
         }
     }
 
-    /// Iterate through each region that has a value in this set.
-    pub(crate) fn regions_and_liveness(
-        &self,
-    ) -> impl Iterator<Item = (RegionVid, &IntervalSet<PointIndex>)> {
-        self.points().iter_enumerated()
+    /// Get the liveness status of a region `r`, if any.
+    /// Panics if liveness data is not tracked for any region.
+    pub(crate) fn point_liveness(&self, region: RegionVid) -> Option<&IntervalSet<PointIndex>> {
+        self.points().row(region)
     }
 
     /// Iterate through each region that has a value in this set.
@@ -168,13 +167,12 @@ impl LivenessValues {
     /// [`point`][rustc_mir_dataflow::points::PointIndex].
     #[inline]
     pub(crate) fn is_live_at_point(&self, region: RegionVid, point: PointIndex) -> bool {
-        self.points().row(region).is_some_and(|r| r.contains(point))
+        self.point_liveness(region).is_some_and(|r| r.contains(point))
     }
 
     /// Returns an iterator of all the points where `region` is live.
     fn live_points(&self, region: RegionVid) -> impl Iterator<Item = PointIndex> {
-        self.points()
-            .row(region)
+        self.point_liveness(region)
             .into_iter()
             .flat_map(|set| set.iter())
             .take_while(|&p| self.location_map.point_in_range(p))

--- a/compiler/rustc_borrowck/src/region_infer/values.rs
+++ b/compiler/rustc_borrowck/src/region_infer/values.rs
@@ -96,8 +96,10 @@ impl LivenessValues {
     }
 
     /// Iterate through each region that has a value in this set.
-    pub(crate) fn regions(&self) -> impl Iterator<Item = RegionVid> {
-        self.points().rows()
+    pub(crate) fn regions_and_liveness(
+        &self,
+    ) -> impl Iterator<Item = (RegionVid, &IntervalSet<PointIndex>)> {
+        self.points().iter_enumerated()
     }
 
     /// Iterate through each region that has a value in this set.
@@ -303,11 +305,6 @@ impl<'tcx, N: Idx> RegionValues<'tcx, N> {
         elem.add_to_row(self, r)
     }
 
-    /// Adds all the control-flow points to the values for `r`.
-    pub(crate) fn add_all_points(&mut self, r: N) {
-        self.points.insert_all_into_row(r);
-    }
-
     /// Adds all elements in `r_from` to `r_to` (because e.g., `r_to:
     /// r_from`).
     pub(crate) fn add_region(&mut self, r_to: N, r_from: N) -> bool {
@@ -337,13 +334,9 @@ impl<'tcx, N: Idx> RegionValues<'tcx, N> {
         Some(first_unset.index() - block.index())
     }
 
-    /// `self[to] |= values[from]`, essentially: that is, take all the
-    /// elements for the region `from` from `values` and add them to
-    /// the region `to` in `self`.
-    pub(crate) fn merge_liveness(&mut self, to: N, from: RegionVid, values: &LivenessValues) {
-        if let Some(set) = values.points().row(from) {
-            self.points.union_row(to, set);
-        }
+    /// Merge a row of liveness into our points.
+    pub(crate) fn merge_liveness(&mut self, to: N, liveness: &IntervalSet<PointIndex>) {
+        self.points.union_row(to, liveness);
     }
 
     /// Returns `true` if `sup_region` contains all the CFG points that

--- a/compiler/rustc_borrowck/src/region_infer/values.rs
+++ b/compiler/rustc_borrowck/src/region_infer/values.rs
@@ -298,24 +298,12 @@ impl<'tcx, N: Idx> RegionValues<'tcx, N> {
         }
     }
 
-    /// Adds the given element to the value for the given region. Returns whether
-    /// the element is newly added (i.e., was not already present).
-    pub(crate) fn add_element(&mut self, r: N, elem: impl ToElementIndex<'tcx>) -> bool {
-        debug!("add(r={:?}, elem={:?})", r, elem);
-        elem.add_to_row(self, r)
-    }
-
     /// Adds all elements in `r_from` to `r_to` (because e.g., `r_to:
     /// r_from`).
     pub(crate) fn add_region(&mut self, r_to: N, r_from: N) -> bool {
         self.points.union_rows(r_from, r_to)
             | self.free_regions.union_rows(r_from, r_to)
             | self.placeholders.union_rows(r_from, r_to)
-    }
-
-    /// Returns `true` if the region `r` contains the given element.
-    pub(crate) fn contains(&self, r: N, elem: impl ToElementIndex<'tcx>) -> bool {
-        elem.contained_in_row(self, r)
     }
 
     /// Returns the lowest statement index in `start..=end` which is not contained by `r`.
@@ -398,47 +386,26 @@ impl<'tcx, N: Idx> RegionValues<'tcx, N> {
     pub(crate) fn region_value_str(&self, r: N) -> String {
         pretty_print_region_elements(self.elements_contained_in(r))
     }
-}
 
-pub(crate) trait ToElementIndex<'tcx>: Debug + Copy {
-    fn add_to_row<N: Idx>(self, values: &mut RegionValues<'tcx, N>, row: N) -> bool;
-
-    fn contained_in_row<N: Idx>(self, values: &RegionValues<'tcx, N>, row: N) -> bool;
-}
-
-impl ToElementIndex<'_> for Location {
-    fn add_to_row<N: Idx>(self, values: &mut RegionValues<'_, N>, row: N) -> bool {
-        let index = values.location_map.point_from_location(self);
-        values.points.insert(row, index)
+    /// Add a the free region with rvid `region` to SCC `scc`
+    pub(crate) fn add_free_region(&mut self, scc: N, region: RegionVid) {
+        self.free_regions.insert(scc, region);
     }
 
-    fn contained_in_row<N: Idx>(self, values: &RegionValues<'_, N>, row: N) -> bool {
-        let index = values.location_map.point_from_location(self);
-        values.points.contains(row, index)
-    }
-}
-
-impl ToElementIndex<'_> for RegionVid {
-    fn add_to_row<N: Idx>(self, values: &mut RegionValues<'_, N>, row: N) -> bool {
-        values.free_regions.insert(row, self)
+    pub(crate) fn add_placeholder(&mut self, scc: N, placeholder: ty::PlaceholderRegion<'tcx>) {
+        let index = self.placeholder_indices.lookup_index(placeholder);
+        self.placeholders.insert(scc, index);
     }
 
-    fn contained_in_row<N: Idx>(self, values: &RegionValues<'_, N>, row: N) -> bool {
-        values.free_regions.contains(row, self)
-    }
-}
-
-impl<'tcx> ToElementIndex<'tcx> for ty::PlaceholderRegion<'tcx> {
-    fn add_to_row<N: Idx>(self, values: &mut RegionValues<'tcx, N>, row: N) -> bool {
-        let placeholder: ty::PlaceholderRegion<'tcx> = self.into();
-        let index = values.placeholder_indices.lookup_index(placeholder);
-        values.placeholders.insert(row, index)
+    /// Determine if `scc` contains the CFG point `p`.
+    pub(crate) fn contains_point(&self, scc: N, p: Location) -> bool {
+        let index = self.location_map.point_from_location(p);
+        self.points.contains(scc, index)
     }
 
-    fn contained_in_row<N: Idx>(self, values: &RegionValues<'tcx, N>, row: N) -> bool {
-        let placeholder: ty::PlaceholderRegion<'tcx> = self.into();
-        let index = values.placeholder_indices.lookup_index(placeholder);
-        values.placeholders.contains(row, index)
+    /// Determine if `scc` contains the free region `free_region`.
+    pub(crate) fn contains_free_region(&self, scc: N, free_region: RegionVid) -> bool {
+        self.free_regions.contains(scc, free_region)
     }
 }
 

--- a/compiler/rustc_index/src/interval.rs
+++ b/compiler/rustc_index/src/interval.rs
@@ -370,6 +370,10 @@ impl<R: Idx, C: Step + Idx> SparseIntervalMatrix<R, C> {
         self.rows.get(row)
     }
 
+    pub fn iter_enumerated(&self) -> impl Iterator<Item = (R, &IntervalSet<C>)> {
+        self.rows.iter_enumerated()
+    }
+
     fn ensure_row(&mut self, row: R) -> &mut IntervalSet<C> {
         self.rows.ensure_contains_elem(row, || IntervalSet::new(self.column_size))
     }


### PR DESCRIPTION
This PR simplifies the initialisation of region values in `region_infer`

- `RegionInferenceContext::init_free_and_bound_regions()` is inlined into `::new()` and pulled to before initial SCC values are assigned
- A couple of iteration-then-index patterns are changed into `iter_enumerated()`-style patterns
- Some leftover code comments are removed and revised to actually describe the initialisation
- Free regions are now marked as live everywhere in liveness constraints, then copied to scc_values upon initialisation, avoiding performing that logic twice
- The trait used to index into SCC values goes away and the relevant methods are monomorphised and static-dispatched. This makes it easier to follow what's going on where, and possibly also shows a potential optimiser how insanely inline:able those methods are since they are used in exactly one place with exactly one type of value (though maybe it already saw that).

It should do strictly less work, but almost all of it would only happen on free regions, and there shouldn't be large numbers of those. Depending on the cleverness of the optimiser most of the option/some checks should have been compiled away anyway.

The key advantage as I see it is clearer flow: first liveness constraints are set up, then initial values are initialised, then region inference is ready to run.