### PR TITLE
Slightly improve diagnostic impl+output for uncovered type parameters

### DIFF
--- a/compiler/rustc_hir_analysis/src/coherence/orphan.rs
+++ b/compiler/rustc_hir_analysis/src/coherence/orphan.rs
@@ -31,7 +31,21 @@ pub(crate) fn orphan_check_impl(
         Err(err) => match orphan_check(tcx, impl_def_id, OrphanCheckMode::Compat) {
             Ok(()) => match err {
                 OrphanCheckErr::UncoveredTyParams(uncovered_ty_params) => {
-                    lint_uncovered_ty_params(tcx, uncovered_ty_params, impl_def_id)
+                    let hir_id = tcx.local_def_id_to_hir_id(impl_def_id);
+
+                    for param_def_id in uncovered_ty_params.uncovered {
+                        let ident = tcx.item_ident(param_def_id);
+
+                        tcx.emit_node_span_lint(
+                            UNCOVERED_PARAM_IN_PROJECTION,
+                            hir_id,
+                            ident.span,
+                            diagnostics::UncoveredTyParam {
+                                param: ident,
+                                local_ty: uncovered_ty_params.local_ty,
+                            },
+                        );
+                    }
                 }
                 OrphanCheckErr::NonLocalInputType(_) => {
                     bug!("orphanck: shouldn't've gotten non-local input tys in compat mode")
@@ -458,53 +472,15 @@ fn emit_orphan_check_error<'tcx>(
             diag.emit()
         }
         traits::OrphanCheckErr::UncoveredTyParams(UncoveredTyParams { uncovered, local_ty }) => {
-            let mut reported = None;
+            let mut guar = None;
             for param_def_id in uncovered {
-                let name = tcx.item_ident(param_def_id);
-                let span = name.span;
-
-                reported.get_or_insert(match local_ty {
-                    Some(local_type) => tcx.dcx().emit_err(diagnostics::TyParamFirstLocal {
-                        span,
-                        note: (),
-                        param: name,
-                        local_type,
-                    }),
-                    None => {
-                        tcx.dcx().emit_err(diagnostics::TyParamSome { span, note: (), param: name })
-                    }
-                });
+                guar.get_or_insert(tcx.dcx().emit_err(diagnostics::UncoveredTyParam {
+                    param: tcx.item_ident(param_def_id),
+                    local_ty,
+                }));
             }
-            reported.unwrap() // FIXME(fmease): This is very likely reachable.
+            guar.unwrap()
         }
-    }
-}
-
-fn lint_uncovered_ty_params<'tcx>(
-    tcx: TyCtxt<'tcx>,
-    UncoveredTyParams { uncovered, local_ty }: UncoveredTyParams<TyCtxt<'tcx>, FxIndexSet<DefId>>,
-    impl_def_id: LocalDefId,
-) {
-    let hir_id = tcx.local_def_id_to_hir_id(impl_def_id);
-
-    for param_def_id in uncovered {
-        let span = tcx.def_ident_span(param_def_id).unwrap();
-        let name = tcx.item_ident(param_def_id);
-
-        match local_ty {
-            Some(local_type) => tcx.emit_node_span_lint(
-                UNCOVERED_PARAM_IN_PROJECTION,
-                hir_id,
-                span,
-                diagnostics::TyParamFirstLocalLint { span, note: (), param: name, local_type },
-            ),
-            None => tcx.emit_node_span_lint(
-                UNCOVERED_PARAM_IN_PROJECTION,
-                hir_id,
-                span,
-                diagnostics::TyParamSomeLint { span, note: (), param: name },
-            ),
-        };
     }
 }
 

--- a/compiler/rustc_hir_analysis/src/diagnostics.rs
+++ b/compiler/rustc_hir_analysis/src/diagnostics.rs
@@ -1474,72 +1474,6 @@ pub struct NoFieldOnType<'tcx> {
     pub field: Ident,
 }
 
-// FIXME(fmease): Deduplicate:
-
-#[derive(Diagnostic)]
-#[diag("type parameter `{$param}` must be covered by another type when it appears before the first local type (`{$local_type}`)", code = E0210)]
-#[note(
-    "implementing a foreign trait is only possible if at least one of the types for which it is implemented is local, and no uncovered type parameters appear before that first local type"
-)]
-pub(crate) struct TyParamFirstLocal<'tcx> {
-    #[primary_span]
-    #[label(
-        "type parameter `{$param}` must be covered by another type when it appears before the first local type (`{$local_type}`)"
-    )]
-    pub span: Span,
-    #[note(
-        "in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`, where `T0` is the first and `Tn` is the last"
-    )]
-    pub note: (),
-    pub param: Ident,
-    pub local_type: Ty<'tcx>,
-}
-
-#[derive(Diagnostic)]
-#[diag("type parameter `{$param}` must be covered by another type when it appears before the first local type (`{$local_type}`)", code = E0210)]
-#[note(
-    "implementing a foreign trait is only possible if at least one of the types for which it is implemented is local, and no uncovered type parameters appear before that first local type"
-)]
-pub(crate) struct TyParamFirstLocalLint<'tcx> {
-    #[label(
-        "type parameter `{$param}` must be covered by another type when it appears before the first local type (`{$local_type}`)"
-    )]
-    pub span: Span,
-    #[note(
-        "in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`, where `T0` is the first and `Tn` is the last"
-    )]
-    pub note: (),
-    pub param: Ident,
-    pub local_type: Ty<'tcx>,
-}
-
-#[derive(Diagnostic)]
-#[diag("type parameter `{$param}` must be used as the type parameter for some local type (e.g., `MyStruct<{$param}>`)", code = E0210)]
-#[note(
-    "implementing a foreign trait is only possible if at least one of the types for which it is implemented is local"
-)]
-pub(crate) struct TyParamSome {
-    #[primary_span]
-    #[label("type parameter `{$param}` must be used as the type parameter for some local type")]
-    pub span: Span,
-    #[note("only traits defined in the current crate can be implemented for a type parameter")]
-    pub note: (),
-    pub param: Ident,
-}
-
-#[derive(Diagnostic)]
-#[diag("type parameter `{$param}` must be used as the type parameter for some local type (e.g., `MyStruct<{$param}>`)", code = E0210)]
-#[note(
-    "implementing a foreign trait is only possible if at least one of the types for which it is implemented is local"
-)]
-pub(crate) struct TyParamSomeLint {
-    #[label("type parameter `{$param}` must be used as the type parameter for some local type")]
-    pub span: Span,
-    #[note("only traits defined in the current crate can be implemented for a type parameter")]
-    pub note: (),
-    pub param: Ident,
-}
-
 #[derive(Diagnostic)]
 pub(crate) enum OnlyCurrentTraits {
     #[diag("only traits defined in the current crate can be implemented for types defined outside of the crate", code = E0117)]
@@ -2023,4 +1957,45 @@ pub(crate) struct PinV2OnPacked {
     #[note("`{$adt_name}` is marked `#[pin_v2]` here")]
     pub pin_v2_span: Option<Span>,
     pub adt_name: Symbol,
+}
+
+pub(crate) struct UncoveredTyParam<'tcx> {
+    pub(crate) param: Ident,
+    pub(crate) local_ty: Option<Ty<'tcx>>,
+}
+
+impl<G: EmissionGuarantee> Diagnostic<'_, G> for UncoveredTyParam<'_> {
+    fn into_diag(self, dcx: DiagCtxtHandle<'_>, level: Level) -> Diag<'_, G> {
+        let Self { param, local_ty } = self;
+
+        let mut diag = Diag::new(dcx, level, "").with_span(param.span);
+        if diag.is_error() {
+            diag.code(E0210);
+        }
+
+        let note = "implementing a foreign trait is only possible if at least one of the types for which it is implemented is local";
+        if let Some(local_ty) = local_ty {
+            let msg = format!(
+                "type parameter `{param}` must be covered by another type when it appears before the first local type (`{local_ty}`)"
+            );
+            diag.primary_message(msg.clone());
+            diag.span_label(param.span, msg);
+            diag.note(format!(
+                "{note}, and no uncovered type parameters appear before that first local type"
+            ));
+            diag.note("in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`, where `T0` is the first and `Tn` is the last");
+        } else {
+            let msg = format!(
+                "type parameter `{param}` must be used as the type parameter for some local type"
+            );
+            diag.primary_message(format!("{msg} (e.g., `MyStruct<{param}>`)"));
+            diag.span_label(param.span, msg);
+            diag.note(note);
+            diag.note(
+                "only traits defined in the current crate can be implemented for a type parameter",
+            );
+        }
+
+        diag
+    }
 }

--- a/compiler/rustc_hir_analysis/src/diagnostics.rs
+++ b/compiler/rustc_hir_analysis/src/diagnostics.rs
@@ -1968,28 +1968,37 @@ impl<G: EmissionGuarantee> Diagnostic<'_, G> for UncoveredTyParam<'_> {
     fn into_diag(self, dcx: DiagCtxtHandle<'_>, level: Level) -> Diag<'_, G> {
         let Self { param, local_ty } = self;
 
-        let mut diag = Diag::new(dcx, level, "").with_span(param.span);
+        let mut diag = Diag::new(dcx, level, "")
+            .with_span(param.span)
+            .with_span_label(param.span, "uncovered type parameter");
         if diag.is_error() {
             diag.code(E0210);
         }
 
-        let note = "implementing a foreign trait is only possible if at least one of the types for which it is implemented is local";
+        let note = "\
+            implementing a foreign trait is only possible if \
+            at least one of the types for which it is implemented is local";
+
         if let Some(local_ty) = local_ty {
-            let msg = format!(
-                "type parameter `{param}` must be covered by another type when it appears before the first local type (`{local_ty}`)"
-            );
-            diag.primary_message(msg.clone());
-            diag.span_label(param.span, msg);
-            diag.note(format!(
-                "{note}, and no uncovered type parameters appear before that first local type"
+            diag.primary_message(format!(
+                "type parameter `{param}` must be covered by another type when \
+                 it appears before the first local type (`{local_ty}`)"
             ));
-            diag.note("in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`, where `T0` is the first and `Tn` is the last");
-        } else {
-            let msg = format!(
-                "type parameter `{param}` must be used as the type parameter for some local type"
+
+            diag.note(format!(
+                "{note},\nand no uncovered type parameters appear before that first local type"
+            ));
+            diag.note(
+                "in this case, 'before' refers to the following order: \
+                 `impl<..> ForeignTrait<T1, ..., Tn> for T0`,\n\
+                 where `T0` is the first and `Tn` is the last",
             );
-            diag.primary_message(format!("{msg} (e.g., `MyStruct<{param}>`)"));
-            diag.span_label(param.span, msg);
+        } else {
+            diag.primary_message(format!(
+                "type parameter `{param}` must be used as an argument to \
+                 some local type (e.g., `MyStruct<{param}>`)"
+            ));
+
             diag.note(note);
             diag.note(
                 "only traits defined in the current crate can be implemented for a type parameter",

--- a/tests/ui/coercion/invalid-blanket-coerce-unsized-impl.rs
+++ b/tests/ui/coercion/invalid-blanket-coerce-unsized-impl.rs
@@ -5,7 +5,7 @@
 #![feature(coerce_unsized)]
 
 impl<A> std::ops::CoerceUnsized<A> for A {}
-//~^ ERROR type parameter `A` must be used as the type parameter for some local type
+//~^ ERROR type parameter `A` must be used as an argument to some local type
 //~| ERROR the trait `CoerceUnsized` may only be implemented for a coercion between structures
 
 const C: usize = 1;

--- a/tests/ui/coercion/invalid-blanket-coerce-unsized-impl.stderr
+++ b/tests/ui/coercion/invalid-blanket-coerce-unsized-impl.stderr
@@ -1,8 +1,8 @@
-error[E0210]: type parameter `A` must be used as the type parameter for some local type (e.g., `MyStruct<A>`)
+error[E0210]: type parameter `A` must be used as an argument to some local type (e.g., `MyStruct<A>`)
   --> $DIR/invalid-blanket-coerce-unsized-impl.rs:7:6
    |
 LL | impl<A> std::ops::CoerceUnsized<A> for A {}
-   |      ^ type parameter `A` must be used as the type parameter for some local type
+   |      ^ uncovered type parameter
    |
    = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter

--- a/tests/ui/coherence/coherence-all-remote.stderr
+++ b/tests/ui/coherence/coherence-all-remote.stderr
@@ -1,8 +1,8 @@
-error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
+error[E0210]: type parameter `T` must be used as an argument to some local type (e.g., `MyStruct<T>`)
   --> $DIR/coherence-all-remote.rs:6:6
    |
 LL | impl<T> Remote1<T> for isize { }
-   |      ^ type parameter `T` must be used as the type parameter for some local type
+   |      ^ uncovered type parameter
    |
    = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter

--- a/tests/ui/coherence/coherence-bigint-param.stderr
+++ b/tests/ui/coherence/coherence-bigint-param.stderr
@@ -2,10 +2,12 @@ error[E0210]: type parameter `T` must be covered by another type when it appears
   --> $DIR/coherence-bigint-param.rs:8:6
    |
 LL | impl<T> Remote1<BigInt> for T { }
-   |      ^ type parameter `T` must be covered by another type when it appears before the first local type (`BigInt`)
+   |      ^ uncovered type parameter
    |
-   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local, and no uncovered type parameters appear before that first local type
-   = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`, where `T0` is the first and `Tn` is the last
+   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local,
+           and no uncovered type parameters appear before that first local type
+   = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`,
+           where `T0` is the first and `Tn` is the last
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/coherence/coherence-cross-crate-conflict.stderr
+++ b/tests/ui/coherence/coherence-cross-crate-conflict.stderr
@@ -1,8 +1,8 @@
-error[E0210]: type parameter `A` must be used as the type parameter for some local type (e.g., `MyStruct<A>`)
+error[E0210]: type parameter `A` must be used as an argument to some local type (e.g., `MyStruct<A>`)
   --> $DIR/coherence-cross-crate-conflict.rs:9:6
    |
 LL | impl<A> Foo for A {
-   |      ^ type parameter `A` must be used as the type parameter for some local type
+   |      ^ uncovered type parameter
    |
    = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter

--- a/tests/ui/coherence/coherence-lone-type-parameter.stderr
+++ b/tests/ui/coherence/coherence-lone-type-parameter.stderr
@@ -1,8 +1,8 @@
-error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
+error[E0210]: type parameter `T` must be used as an argument to some local type (e.g., `MyStruct<T>`)
   --> $DIR/coherence-lone-type-parameter.rs:6:6
    |
 LL | impl<T> Remote for T { }
-   |      ^ type parameter `T` must be used as the type parameter for some local type
+   |      ^ uncovered type parameter
    |
    = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter

--- a/tests/ui/coherence/impl[t]-foreign-for-fundamental[t].rs
+++ b/tests/ui/coherence/impl[t]-foreign-for-fundamental[t].rs
@@ -8,8 +8,7 @@ use std::rc::Rc;
 struct Local;
 
 impl<T> Remote for Box<T> {
-    //~^ ERROR type parameter `T` must be used as the type parameter for
-    // | some local type (e.g., `MyStruct<T>`)
+    //~^ ERROR type parameter `T` must be used as an argument to some local type
 }
 
 fn main() {}

--- a/tests/ui/coherence/impl[t]-foreign-for-fundamental[t].stderr
+++ b/tests/ui/coherence/impl[t]-foreign-for-fundamental[t].stderr
@@ -1,8 +1,8 @@
-error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
+error[E0210]: type parameter `T` must be used as an argument to some local type (e.g., `MyStruct<T>`)
   --> $DIR/impl[t]-foreign-for-fundamental[t].rs:10:6
    |
 LL | impl<T> Remote for Box<T> {
-   |      ^ type parameter `T` must be used as the type parameter for some local type
+   |      ^ uncovered type parameter
    |
    = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter

--- a/tests/ui/coherence/impl[t]-foreign[foreign]-for-fundamental[t].rs
+++ b/tests/ui/coherence/impl[t]-foreign[foreign]-for-fundamental[t].rs
@@ -8,11 +8,11 @@ use std::rc::Rc;
 struct Local;
 
 impl<T> Remote1<u32> for Box<T> {
-    //~^ ERROR type parameter `T` must be used as the type parameter for some local type
+    //~^ ERROR type parameter `T` must be used as an argument to some local type
 }
 
 impl<'a, T> Remote1<u32> for &'a T {
-    //~^ ERROR type parameter `T` must be used as the type parameter for some local type
+    //~^ ERROR type parameter `T` must be used as an argument to some local type
 }
 
 fn main() {}

--- a/tests/ui/coherence/impl[t]-foreign[foreign]-for-fundamental[t].stderr
+++ b/tests/ui/coherence/impl[t]-foreign[foreign]-for-fundamental[t].stderr
@@ -1,17 +1,17 @@
-error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
+error[E0210]: type parameter `T` must be used as an argument to some local type (e.g., `MyStruct<T>`)
   --> $DIR/impl[t]-foreign[foreign]-for-fundamental[t].rs:10:6
    |
 LL | impl<T> Remote1<u32> for Box<T> {
-   |      ^ type parameter `T` must be used as the type parameter for some local type
+   |      ^ uncovered type parameter
    |
    = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter
 
-error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
+error[E0210]: type parameter `T` must be used as an argument to some local type (e.g., `MyStruct<T>`)
   --> $DIR/impl[t]-foreign[foreign]-for-fundamental[t].rs:14:10
    |
 LL | impl<'a, T> Remote1<u32> for &'a T {
-   |          ^ type parameter `T` must be used as the type parameter for some local type
+   |          ^ uncovered type parameter
    |
    = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter

--- a/tests/ui/coherence/impl[t]-foreign[foreign]-for-t.rs
+++ b/tests/ui/coherence/impl[t]-foreign[foreign]-for-t.rs
@@ -8,7 +8,7 @@ use std::rc::Rc;
 struct Local;
 
 impl<T> Remote1<u32> for T {
-    //~^ ERROR type parameter `T` must be used as the type parameter for some local type
+    //~^ ERROR type parameter `T` must be used as an argument to some local type
 }
 
 fn main() {}

--- a/tests/ui/coherence/impl[t]-foreign[foreign]-for-t.stderr
+++ b/tests/ui/coherence/impl[t]-foreign[foreign]-for-t.stderr
@@ -1,8 +1,8 @@
-error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
+error[E0210]: type parameter `T` must be used as an argument to some local type (e.g., `MyStruct<T>`)
   --> $DIR/impl[t]-foreign[foreign]-for-t.rs:10:6
    |
 LL | impl<T> Remote1<u32> for T {
-   |      ^ type parameter `T` must be used as the type parameter for some local type
+   |      ^ uncovered type parameter
    |
    = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter

--- a/tests/ui/coherence/impl[t]-foreign[fundamental[t]]-for-foreign.rs
+++ b/tests/ui/coherence/impl[t]-foreign[fundamental[t]]-for-foreign.rs
@@ -8,11 +8,11 @@ use std::rc::Rc;
 struct Local;
 
 impl<T> Remote1<Box<T>> for u32 {
-    //~^ ERROR type parameter `T` must be used as the type parameter for some local type
+    //~^ ERROR type parameter `T` must be used as an argument to some local type
 }
 
 impl<'a, T> Remote1<&'a T> for u32 {
-    //~^ ERROR type parameter `T` must be used as the type parameter for some local type
+    //~^ ERROR type parameter `T` must be used as an argument to some local type
 }
 
 fn main() {}

--- a/tests/ui/coherence/impl[t]-foreign[fundamental[t]]-for-foreign.stderr
+++ b/tests/ui/coherence/impl[t]-foreign[fundamental[t]]-for-foreign.stderr
@@ -1,17 +1,17 @@
-error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
+error[E0210]: type parameter `T` must be used as an argument to some local type (e.g., `MyStruct<T>`)
   --> $DIR/impl[t]-foreign[fundamental[t]]-for-foreign.rs:10:6
    |
 LL | impl<T> Remote1<Box<T>> for u32 {
-   |      ^ type parameter `T` must be used as the type parameter for some local type
+   |      ^ uncovered type parameter
    |
    = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter
 
-error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
+error[E0210]: type parameter `T` must be used as an argument to some local type (e.g., `MyStruct<T>`)
   --> $DIR/impl[t]-foreign[fundamental[t]]-for-foreign.rs:14:10
    |
 LL | impl<'a, T> Remote1<&'a T> for u32 {
-   |          ^ type parameter `T` must be used as the type parameter for some local type
+   |          ^ uncovered type parameter
    |
    = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter

--- a/tests/ui/coherence/impl[t]-foreign[fundamental[t]]-for-fundamental[t].rs
+++ b/tests/ui/coherence/impl[t]-foreign[fundamental[t]]-for-fundamental[t].rs
@@ -8,10 +8,10 @@ use std::rc::Rc;
 struct Local;
 
 impl<'a, T> Remote1<Box<T>> for &'a T {
-    //~^ ERROR type parameter `T` must be used as the type parameter for some local type
+    //~^ ERROR type parameter `T` must be used as an argument to some local type
 }
 impl<'a, T> Remote1<&'a T> for Box<T> {
-    //~^ ERROR type parameter `T` must be used as the type parameter for some local type
+    //~^ ERROR type parameter `T` must be used as an argument to some local type
 }
 
 fn main() {}

--- a/tests/ui/coherence/impl[t]-foreign[fundamental[t]]-for-fundamental[t].stderr
+++ b/tests/ui/coherence/impl[t]-foreign[fundamental[t]]-for-fundamental[t].stderr
@@ -1,17 +1,17 @@
-error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
+error[E0210]: type parameter `T` must be used as an argument to some local type (e.g., `MyStruct<T>`)
   --> $DIR/impl[t]-foreign[fundamental[t]]-for-fundamental[t].rs:10:10
    |
 LL | impl<'a, T> Remote1<Box<T>> for &'a T {
-   |          ^ type parameter `T` must be used as the type parameter for some local type
+   |          ^ uncovered type parameter
    |
    = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter
 
-error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
+error[E0210]: type parameter `T` must be used as an argument to some local type (e.g., `MyStruct<T>`)
   --> $DIR/impl[t]-foreign[fundamental[t]]-for-fundamental[t].rs:13:10
    |
 LL | impl<'a, T> Remote1<&'a T> for Box<T> {
-   |          ^ type parameter `T` must be used as the type parameter for some local type
+   |          ^ uncovered type parameter
    |
    = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter

--- a/tests/ui/coherence/impl[t]-foreign[fundamental[t]]-for-t.rs
+++ b/tests/ui/coherence/impl[t]-foreign[fundamental[t]]-for-t.rs
@@ -8,10 +8,10 @@ use std::rc::Rc;
 struct Local;
 
 impl<T> Remote1<Box<T>> for T {
-    //~^ ERROR type parameter `T` must be used as the type parameter for some local type
+    //~^ ERROR type parameter `T` must be used as an argument to some local type
 }
 impl<'a, T> Remote1<&'a T> for T {
-    //~^ ERROR type parameter `T` must be used as the type parameter for some local type
+    //~^ ERROR type parameter `T` must be used as an argument to some local type
 }
 
 fn main() {}

--- a/tests/ui/coherence/impl[t]-foreign[fundamental[t]]-for-t.stderr
+++ b/tests/ui/coherence/impl[t]-foreign[fundamental[t]]-for-t.stderr
@@ -1,17 +1,17 @@
-error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
+error[E0210]: type parameter `T` must be used as an argument to some local type (e.g., `MyStruct<T>`)
   --> $DIR/impl[t]-foreign[fundamental[t]]-for-t.rs:10:6
    |
 LL | impl<T> Remote1<Box<T>> for T {
-   |      ^ type parameter `T` must be used as the type parameter for some local type
+   |      ^ uncovered type parameter
    |
    = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter
 
-error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
+error[E0210]: type parameter `T` must be used as an argument to some local type (e.g., `MyStruct<T>`)
   --> $DIR/impl[t]-foreign[fundamental[t]]-for-t.rs:13:10
    |
 LL | impl<'a, T> Remote1<&'a T> for T {
-   |          ^ type parameter `T` must be used as the type parameter for some local type
+   |          ^ uncovered type parameter
    |
    = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter

--- a/tests/ui/coherence/impl[t]-foreign[fundamental[t]_local]-for-foreign.stderr
+++ b/tests/ui/coherence/impl[t]-foreign[fundamental[t]_local]-for-foreign.stderr
@@ -2,19 +2,23 @@ error[E0210]: type parameter `T` must be covered by another type when it appears
   --> $DIR/impl[t]-foreign[fundamental[t]_local]-for-foreign.rs:10:6
    |
 LL | impl<T> Remote2<Box<T>, Local> for u32 {
-   |      ^ type parameter `T` must be covered by another type when it appears before the first local type (`Local`)
+   |      ^ uncovered type parameter
    |
-   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local, and no uncovered type parameters appear before that first local type
-   = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`, where `T0` is the first and `Tn` is the last
+   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local,
+           and no uncovered type parameters appear before that first local type
+   = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`,
+           where `T0` is the first and `Tn` is the last
 
 error[E0210]: type parameter `T` must be covered by another type when it appears before the first local type (`Local`)
   --> $DIR/impl[t]-foreign[fundamental[t]_local]-for-foreign.rs:14:10
    |
 LL | impl<'a, T> Remote2<&'a T, Local> for u32 {
-   |          ^ type parameter `T` must be covered by another type when it appears before the first local type (`Local`)
+   |          ^ uncovered type parameter
    |
-   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local, and no uncovered type parameters appear before that first local type
-   = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`, where `T0` is the first and `Tn` is the last
+   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local,
+           and no uncovered type parameters appear before that first local type
+   = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`,
+           where `T0` is the first and `Tn` is the last
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/coherence/impl[t]-foreign[local]-for-fundamental[t].stderr
+++ b/tests/ui/coherence/impl[t]-foreign[local]-for-fundamental[t].stderr
@@ -2,19 +2,23 @@ error[E0210]: type parameter `T` must be covered by another type when it appears
   --> $DIR/impl[t]-foreign[local]-for-fundamental[t].rs:10:6
    |
 LL | impl<T> Remote1<Local> for Box<T> {
-   |      ^ type parameter `T` must be covered by another type when it appears before the first local type (`Local`)
+   |      ^ uncovered type parameter
    |
-   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local, and no uncovered type parameters appear before that first local type
-   = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`, where `T0` is the first and `Tn` is the last
+   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local,
+           and no uncovered type parameters appear before that first local type
+   = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`,
+           where `T0` is the first and `Tn` is the last
 
 error[E0210]: type parameter `T` must be covered by another type when it appears before the first local type (`Local`)
   --> $DIR/impl[t]-foreign[local]-for-fundamental[t].rs:14:6
    |
 LL | impl<T> Remote1<Local> for &T {
-   |      ^ type parameter `T` must be covered by another type when it appears before the first local type (`Local`)
+   |      ^ uncovered type parameter
    |
-   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local, and no uncovered type parameters appear before that first local type
-   = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`, where `T0` is the first and `Tn` is the last
+   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local,
+           and no uncovered type parameters appear before that first local type
+   = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`,
+           where `T0` is the first and `Tn` is the last
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/coherence/impl[t]-foreign[local]-for-t.stderr
+++ b/tests/ui/coherence/impl[t]-foreign[local]-for-t.stderr
@@ -2,10 +2,12 @@ error[E0210]: type parameter `T` must be covered by another type when it appears
   --> $DIR/impl[t]-foreign[local]-for-t.rs:10:6
    |
 LL | impl<T> Remote1<Local> for T {
-   |      ^ type parameter `T` must be covered by another type when it appears before the first local type (`Local`)
+   |      ^ uncovered type parameter
    |
-   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local, and no uncovered type parameters appear before that first local type
-   = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`, where `T0` is the first and `Tn` is the last
+   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local,
+           and no uncovered type parameters appear before that first local type
+   = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`,
+           where `T0` is the first and `Tn` is the last
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/coherence/impl[t]-foreign[t]-for-foreign.rs
+++ b/tests/ui/coherence/impl[t]-foreign[t]-for-foreign.rs
@@ -8,7 +8,7 @@ use std::rc::Rc;
 struct Local;
 
 impl<T> Remote1<T> for u32 {
-    //~^ ERROR type parameter `T` must be used as the type parameter for some local type
+    //~^ ERROR type parameter `T` must be used as an argument to some local type
 }
 
 fn main() {}

--- a/tests/ui/coherence/impl[t]-foreign[t]-for-foreign.stderr
+++ b/tests/ui/coherence/impl[t]-foreign[t]-for-foreign.stderr
@@ -1,8 +1,8 @@
-error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
+error[E0210]: type parameter `T` must be used as an argument to some local type (e.g., `MyStruct<T>`)
   --> $DIR/impl[t]-foreign[t]-for-foreign.rs:10:6
    |
 LL | impl<T> Remote1<T> for u32 {
-   |      ^ type parameter `T` must be used as the type parameter for some local type
+   |      ^ uncovered type parameter
    |
    = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter

--- a/tests/ui/coherence/impl[t]-foreign[t]-for-fundamental.rs
+++ b/tests/ui/coherence/impl[t]-foreign[t]-for-fundamental.rs
@@ -8,11 +8,11 @@ use std::rc::Rc;
 struct Local;
 
 impl<T> Remote1<T> for Box<T> {
-    //~^ ERROR type parameter `T` must be used as the type parameter for some local type
+    //~^ ERROR type parameter `T` must be used as an argument to some local type
 }
 
 impl<'a, A, B> Remote1<A> for &'a B {
-    //~^ ERROR type parameter `B` must be used as the type parameter for some local type
+    //~^ ERROR type parameter `B` must be used as an argument to some local type
 }
 
 fn main() {}

--- a/tests/ui/coherence/impl[t]-foreign[t]-for-fundamental.stderr
+++ b/tests/ui/coherence/impl[t]-foreign[t]-for-fundamental.stderr
@@ -1,17 +1,17 @@
-error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
+error[E0210]: type parameter `T` must be used as an argument to some local type (e.g., `MyStruct<T>`)
   --> $DIR/impl[t]-foreign[t]-for-fundamental.rs:10:6
    |
 LL | impl<T> Remote1<T> for Box<T> {
-   |      ^ type parameter `T` must be used as the type parameter for some local type
+   |      ^ uncovered type parameter
    |
    = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter
 
-error[E0210]: type parameter `B` must be used as the type parameter for some local type (e.g., `MyStruct<B>`)
+error[E0210]: type parameter `B` must be used as an argument to some local type (e.g., `MyStruct<B>`)
   --> $DIR/impl[t]-foreign[t]-for-fundamental.rs:14:13
    |
 LL | impl<'a, A, B> Remote1<A> for &'a B {
-   |             ^ type parameter `B` must be used as the type parameter for some local type
+   |             ^ uncovered type parameter
    |
    = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter

--- a/tests/ui/coherence/impl[t]-foreign[t]-for-t.rs
+++ b/tests/ui/coherence/impl[t]-foreign[t]-for-t.rs
@@ -8,7 +8,7 @@ use std::rc::Rc;
 struct Local;
 
 impl<T> Remote1<T> for T {
-    //~^ ERROR type parameter `T` must be used as the type parameter for some local type
+    //~^ ERROR type parameter `T` must be used as an argument to some local type
 }
 
 fn main() {}

--- a/tests/ui/coherence/impl[t]-foreign[t]-for-t.stderr
+++ b/tests/ui/coherence/impl[t]-foreign[t]-for-t.stderr
@@ -1,8 +1,8 @@
-error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
+error[E0210]: type parameter `T` must be used as an argument to some local type (e.g., `MyStruct<T>`)
   --> $DIR/impl[t]-foreign[t]-for-t.rs:10:6
    |
 LL | impl<T> Remote1<T> for T {
-   |      ^ type parameter `T` must be used as the type parameter for some local type
+   |      ^ uncovered type parameter
    |
    = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter

--- a/tests/ui/coherence/orphan-check-alias.classic.stderr
+++ b/tests/ui/coherence/orphan-check-alias.classic.stderr
@@ -2,10 +2,12 @@ warning: type parameter `T` must be covered by another type when it appears befo
   --> $DIR/orphan-check-alias.rs:21:6
    |
 LL | impl<T> foreign::Trait2<B, T> for <T as Id>::Assoc {
-   |      ^ type parameter `T` must be covered by another type when it appears before the first local type (`B`)
+   |      ^ uncovered type parameter
    |
-   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local, and no uncovered type parameters appear before that first local type
-   = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`, where `T0` is the first and `Tn` is the last
+   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local,
+           and no uncovered type parameters appear before that first local type
+   = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`,
+           where `T0` is the first and `Tn` is the last
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #124559 <https://github.com/rust-lang/rust/issues/124559>
    = note: `#[warn(uncovered_param_in_projection)]` (part of `#[warn(future_incompatible)]`) on by default

--- a/tests/ui/coherence/orphan-check-alias.classic.stderr
+++ b/tests/ui/coherence/orphan-check-alias.classic.stderr
@@ -1,4 +1,4 @@
-warning[E0210]: type parameter `T` must be covered by another type when it appears before the first local type (`B`)
+warning: type parameter `T` must be covered by another type when it appears before the first local type (`B`)
   --> $DIR/orphan-check-alias.rs:21:6
    |
 LL | impl<T> foreign::Trait2<B, T> for <T as Id>::Assoc {
@@ -12,4 +12,3 @@ LL | impl<T> foreign::Trait2<B, T> for <T as Id>::Assoc {
 
 warning: 1 warning emitted
 
-For more information about this error, try `rustc --explain E0210`.

--- a/tests/ui/coherence/orphan-check-alias.next.stderr
+++ b/tests/ui/coherence/orphan-check-alias.next.stderr
@@ -2,10 +2,12 @@ warning: type parameter `T` must be covered by another type when it appears befo
   --> $DIR/orphan-check-alias.rs:21:6
    |
 LL | impl<T> foreign::Trait2<B, T> for <T as Id>::Assoc {
-   |      ^ type parameter `T` must be covered by another type when it appears before the first local type (`B`)
+   |      ^ uncovered type parameter
    |
-   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local, and no uncovered type parameters appear before that first local type
-   = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`, where `T0` is the first and `Tn` is the last
+   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local,
+           and no uncovered type parameters appear before that first local type
+   = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`,
+           where `T0` is the first and `Tn` is the last
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #124559 <https://github.com/rust-lang/rust/issues/124559>
    = note: `#[warn(uncovered_param_in_projection)]` (part of `#[warn(future_incompatible)]`) on by default

--- a/tests/ui/coherence/orphan-check-alias.next.stderr
+++ b/tests/ui/coherence/orphan-check-alias.next.stderr
@@ -1,4 +1,4 @@
-warning[E0210]: type parameter `T` must be covered by another type when it appears before the first local type (`B`)
+warning: type parameter `T` must be covered by another type when it appears before the first local type (`B`)
   --> $DIR/orphan-check-alias.rs:21:6
    |
 LL | impl<T> foreign::Trait2<B, T> for <T as Id>::Assoc {
@@ -12,4 +12,3 @@ LL | impl<T> foreign::Trait2<B, T> for <T as Id>::Assoc {
 
 warning: 1 warning emitted
 
-For more information about this error, try `rustc --explain E0210`.

--- a/tests/ui/coherence/orphan-check-diagnostics.rs
+++ b/tests/ui/coherence/orphan-check-diagnostics.rs
@@ -9,6 +9,6 @@ use orphan_check_diagnostics::RemoteTrait;
 trait LocalTrait { fn dummy(&self) { } }
 
 impl<T> RemoteTrait for T where T: LocalTrait {}
-//~^ ERROR type parameter `T` must be used as the type parameter for some local type
+//~^ ERROR type parameter `T` must be used as an argument to some local type
 
 fn main() {}

--- a/tests/ui/coherence/orphan-check-diagnostics.stderr
+++ b/tests/ui/coherence/orphan-check-diagnostics.stderr
@@ -1,8 +1,8 @@
-error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
+error[E0210]: type parameter `T` must be used as an argument to some local type (e.g., `MyStruct<T>`)
   --> $DIR/orphan-check-diagnostics.rs:11:6
    |
 LL | impl<T> RemoteTrait for T where T: LocalTrait {}
-   |      ^ type parameter `T` must be used as the type parameter for some local type
+   |      ^ uncovered type parameter
    |
    = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter

--- a/tests/ui/coherence/orphan-check-opaque-types-not-covering.stderr
+++ b/tests/ui/coherence/orphan-check-opaque-types-not-covering.stderr
@@ -2,19 +2,23 @@ error[E0210]: type parameter `T` must be covered by another type when it appears
   --> $DIR/orphan-check-opaque-types-not-covering.rs:15:6
    |
 LL | impl<T> foreign::Trait0<Local, T, ()> for Identity<T> {}
-   |      ^ type parameter `T` must be covered by another type when it appears before the first local type (`Local`)
+   |      ^ uncovered type parameter
    |
-   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local, and no uncovered type parameters appear before that first local type
-   = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`, where `T0` is the first and `Tn` is the last
+   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local,
+           and no uncovered type parameters appear before that first local type
+   = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`,
+           where `T0` is the first and `Tn` is the last
 
 error[E0210]: type parameter `T` must be covered by another type when it appears before the first local type (`Local`)
   --> $DIR/orphan-check-opaque-types-not-covering.rs:25:6
    |
 LL | impl<T> foreign::Trait1<Local, T> for Opaque<T> {}
-   |      ^ type parameter `T` must be covered by another type when it appears before the first local type (`Local`)
+   |      ^ uncovered type parameter
    |
-   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local, and no uncovered type parameters appear before that first local type
-   = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`, where `T0` is the first and `Tn` is the last
+   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local,
+           and no uncovered type parameters appear before that first local type
+   = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`,
+           where `T0` is the first and `Tn` is the last
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/coherence/orphan-check-projections-not-covering-ambiguity.classic.stderr
+++ b/tests/ui/coherence/orphan-check-projections-not-covering-ambiguity.classic.stderr
@@ -2,10 +2,12 @@ warning: type parameter `T` must be covered by another type when it appears befo
   --> $DIR/orphan-check-projections-not-covering-ambiguity.rs:25:6
    |
 LL | impl<T> foreign::Trait1<Local, T> for <T as Project>::Output {}
-   |      ^ type parameter `T` must be covered by another type when it appears before the first local type (`Local`)
+   |      ^ uncovered type parameter
    |
-   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local, and no uncovered type parameters appear before that first local type
-   = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`, where `T0` is the first and `Tn` is the last
+   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local,
+           and no uncovered type parameters appear before that first local type
+   = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`,
+           where `T0` is the first and `Tn` is the last
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #124559 <https://github.com/rust-lang/rust/issues/124559>
    = note: `#[warn(uncovered_param_in_projection)]` (part of `#[warn(future_incompatible)]`) on by default

--- a/tests/ui/coherence/orphan-check-projections-not-covering-ambiguity.classic.stderr
+++ b/tests/ui/coherence/orphan-check-projections-not-covering-ambiguity.classic.stderr
@@ -1,4 +1,4 @@
-warning[E0210]: type parameter `T` must be covered by another type when it appears before the first local type (`Local`)
+warning: type parameter `T` must be covered by another type when it appears before the first local type (`Local`)
   --> $DIR/orphan-check-projections-not-covering-ambiguity.rs:25:6
    |
 LL | impl<T> foreign::Trait1<Local, T> for <T as Project>::Output {}
@@ -12,4 +12,3 @@ LL | impl<T> foreign::Trait1<Local, T> for <T as Project>::Output {}
 
 warning: 1 warning emitted
 
-For more information about this error, try `rustc --explain E0210`.

--- a/tests/ui/coherence/orphan-check-projections-not-covering-ambiguity.next.stderr
+++ b/tests/ui/coherence/orphan-check-projections-not-covering-ambiguity.next.stderr
@@ -2,10 +2,12 @@ warning: type parameter `T` must be covered by another type when it appears befo
   --> $DIR/orphan-check-projections-not-covering-ambiguity.rs:25:6
    |
 LL | impl<T> foreign::Trait1<Local, T> for <T as Project>::Output {}
-   |      ^ type parameter `T` must be covered by another type when it appears before the first local type (`Local`)
+   |      ^ uncovered type parameter
    |
-   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local, and no uncovered type parameters appear before that first local type
-   = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`, where `T0` is the first and `Tn` is the last
+   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local,
+           and no uncovered type parameters appear before that first local type
+   = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`,
+           where `T0` is the first and `Tn` is the last
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #124559 <https://github.com/rust-lang/rust/issues/124559>
    = note: `#[warn(uncovered_param_in_projection)]` (part of `#[warn(future_incompatible)]`) on by default

--- a/tests/ui/coherence/orphan-check-projections-not-covering-ambiguity.next.stderr
+++ b/tests/ui/coherence/orphan-check-projections-not-covering-ambiguity.next.stderr
@@ -1,4 +1,4 @@
-warning[E0210]: type parameter `T` must be covered by another type when it appears before the first local type (`Local`)
+warning: type parameter `T` must be covered by another type when it appears before the first local type (`Local`)
   --> $DIR/orphan-check-projections-not-covering-ambiguity.rs:25:6
    |
 LL | impl<T> foreign::Trait1<Local, T> for <T as Project>::Output {}
@@ -12,4 +12,3 @@ LL | impl<T> foreign::Trait1<Local, T> for <T as Project>::Output {}
 
 warning: 1 warning emitted
 
-For more information about this error, try `rustc --explain E0210`.

--- a/tests/ui/coherence/orphan-check-projections-not-covering-multiple-params.classic.stderr
+++ b/tests/ui/coherence/orphan-check-projections-not-covering-multiple-params.classic.stderr
@@ -1,4 +1,4 @@
-warning[E0210]: type parameter `T` must be covered by another type when it appears before the first local type (`LocalTy`)
+warning: type parameter `T` must be covered by another type when it appears before the first local type (`LocalTy`)
   --> $DIR/orphan-check-projections-not-covering-multiple-params.rs:17:6
    |
 LL | impl<T, U> foreign::Trait0<LocalTy, T, U> for <() as Trait<T, U>>::Assoc {}
@@ -10,7 +10,7 @@ LL | impl<T, U> foreign::Trait0<LocalTy, T, U> for <() as Trait<T, U>>::Assoc {}
    = note: for more information, see issue #124559 <https://github.com/rust-lang/rust/issues/124559>
    = note: `#[warn(uncovered_param_in_projection)]` (part of `#[warn(future_incompatible)]`) on by default
 
-warning[E0210]: type parameter `U` must be covered by another type when it appears before the first local type (`LocalTy`)
+warning: type parameter `U` must be covered by another type when it appears before the first local type (`LocalTy`)
   --> $DIR/orphan-check-projections-not-covering-multiple-params.rs:17:9
    |
 LL | impl<T, U> foreign::Trait0<LocalTy, T, U> for <() as Trait<T, U>>::Assoc {}
@@ -23,4 +23,3 @@ LL | impl<T, U> foreign::Trait0<LocalTy, T, U> for <() as Trait<T, U>>::Assoc {}
 
 warning: 2 warnings emitted
 
-For more information about this error, try `rustc --explain E0210`.

--- a/tests/ui/coherence/orphan-check-projections-not-covering-multiple-params.classic.stderr
+++ b/tests/ui/coherence/orphan-check-projections-not-covering-multiple-params.classic.stderr
@@ -2,10 +2,12 @@ warning: type parameter `T` must be covered by another type when it appears befo
   --> $DIR/orphan-check-projections-not-covering-multiple-params.rs:17:6
    |
 LL | impl<T, U> foreign::Trait0<LocalTy, T, U> for <() as Trait<T, U>>::Assoc {}
-   |      ^ type parameter `T` must be covered by another type when it appears before the first local type (`LocalTy`)
+   |      ^ uncovered type parameter
    |
-   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local, and no uncovered type parameters appear before that first local type
-   = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`, where `T0` is the first and `Tn` is the last
+   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local,
+           and no uncovered type parameters appear before that first local type
+   = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`,
+           where `T0` is the first and `Tn` is the last
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #124559 <https://github.com/rust-lang/rust/issues/124559>
    = note: `#[warn(uncovered_param_in_projection)]` (part of `#[warn(future_incompatible)]`) on by default
@@ -14,10 +16,12 @@ warning: type parameter `U` must be covered by another type when it appears befo
   --> $DIR/orphan-check-projections-not-covering-multiple-params.rs:17:9
    |
 LL | impl<T, U> foreign::Trait0<LocalTy, T, U> for <() as Trait<T, U>>::Assoc {}
-   |         ^ type parameter `U` must be covered by another type when it appears before the first local type (`LocalTy`)
+   |         ^ uncovered type parameter
    |
-   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local, and no uncovered type parameters appear before that first local type
-   = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`, where `T0` is the first and `Tn` is the last
+   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local,
+           and no uncovered type parameters appear before that first local type
+   = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`,
+           where `T0` is the first and `Tn` is the last
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #124559 <https://github.com/rust-lang/rust/issues/124559>
 

--- a/tests/ui/coherence/orphan-check-projections-not-covering-multiple-params.next.stderr
+++ b/tests/ui/coherence/orphan-check-projections-not-covering-multiple-params.next.stderr
@@ -1,4 +1,4 @@
-warning[E0210]: type parameter `T` must be covered by another type when it appears before the first local type (`LocalTy`)
+warning: type parameter `T` must be covered by another type when it appears before the first local type (`LocalTy`)
   --> $DIR/orphan-check-projections-not-covering-multiple-params.rs:17:6
    |
 LL | impl<T, U> foreign::Trait0<LocalTy, T, U> for <() as Trait<T, U>>::Assoc {}
@@ -10,7 +10,7 @@ LL | impl<T, U> foreign::Trait0<LocalTy, T, U> for <() as Trait<T, U>>::Assoc {}
    = note: for more information, see issue #124559 <https://github.com/rust-lang/rust/issues/124559>
    = note: `#[warn(uncovered_param_in_projection)]` (part of `#[warn(future_incompatible)]`) on by default
 
-warning[E0210]: type parameter `U` must be covered by another type when it appears before the first local type (`LocalTy`)
+warning: type parameter `U` must be covered by another type when it appears before the first local type (`LocalTy`)
   --> $DIR/orphan-check-projections-not-covering-multiple-params.rs:17:9
    |
 LL | impl<T, U> foreign::Trait0<LocalTy, T, U> for <() as Trait<T, U>>::Assoc {}
@@ -23,4 +23,3 @@ LL | impl<T, U> foreign::Trait0<LocalTy, T, U> for <() as Trait<T, U>>::Assoc {}
 
 warning: 2 warnings emitted
 
-For more information about this error, try `rustc --explain E0210`.

--- a/tests/ui/coherence/orphan-check-projections-not-covering-multiple-params.next.stderr
+++ b/tests/ui/coherence/orphan-check-projections-not-covering-multiple-params.next.stderr
@@ -2,10 +2,12 @@ warning: type parameter `T` must be covered by another type when it appears befo
   --> $DIR/orphan-check-projections-not-covering-multiple-params.rs:17:6
    |
 LL | impl<T, U> foreign::Trait0<LocalTy, T, U> for <() as Trait<T, U>>::Assoc {}
-   |      ^ type parameter `T` must be covered by another type when it appears before the first local type (`LocalTy`)
+   |      ^ uncovered type parameter
    |
-   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local, and no uncovered type parameters appear before that first local type
-   = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`, where `T0` is the first and `Tn` is the last
+   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local,
+           and no uncovered type parameters appear before that first local type
+   = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`,
+           where `T0` is the first and `Tn` is the last
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #124559 <https://github.com/rust-lang/rust/issues/124559>
    = note: `#[warn(uncovered_param_in_projection)]` (part of `#[warn(future_incompatible)]`) on by default
@@ -14,10 +16,12 @@ warning: type parameter `U` must be covered by another type when it appears befo
   --> $DIR/orphan-check-projections-not-covering-multiple-params.rs:17:9
    |
 LL | impl<T, U> foreign::Trait0<LocalTy, T, U> for <() as Trait<T, U>>::Assoc {}
-   |         ^ type parameter `U` must be covered by another type when it appears before the first local type (`LocalTy`)
+   |         ^ uncovered type parameter
    |
-   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local, and no uncovered type parameters appear before that first local type
-   = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`, where `T0` is the first and `Tn` is the last
+   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local,
+           and no uncovered type parameters appear before that first local type
+   = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`,
+           where `T0` is the first and `Tn` is the last
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #124559 <https://github.com/rust-lang/rust/issues/124559>
 

--- a/tests/ui/coherence/orphan-check-projections-not-covering.classic.stderr
+++ b/tests/ui/coherence/orphan-check-projections-not-covering.classic.stderr
@@ -2,10 +2,12 @@ warning: type parameter `T` must be covered by another type when it appears befo
   --> $DIR/orphan-check-projections-not-covering.rs:22:6
    |
 LL | impl<T> foreign::Trait0<Local, T, ()> for <T as Identity>::Output {}
-   |      ^ type parameter `T` must be covered by another type when it appears before the first local type (`Local`)
+   |      ^ uncovered type parameter
    |
-   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local, and no uncovered type parameters appear before that first local type
-   = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`, where `T0` is the first and `Tn` is the last
+   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local,
+           and no uncovered type parameters appear before that first local type
+   = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`,
+           where `T0` is the first and `Tn` is the last
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #124559 <https://github.com/rust-lang/rust/issues/124559>
    = note: `#[warn(uncovered_param_in_projection)]` (part of `#[warn(future_incompatible)]`) on by default
@@ -14,10 +16,12 @@ warning: type parameter `T` must be covered by another type when it appears befo
   --> $DIR/orphan-check-projections-not-covering.rs:27:6
    |
 LL | impl<T> foreign::Trait0<<T as Identity>::Output, Local, T> for Option<T> {}
-   |      ^ type parameter `T` must be covered by another type when it appears before the first local type (`Local`)
+   |      ^ uncovered type parameter
    |
-   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local, and no uncovered type parameters appear before that first local type
-   = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`, where `T0` is the first and `Tn` is the last
+   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local,
+           and no uncovered type parameters appear before that first local type
+   = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`,
+           where `T0` is the first and `Tn` is the last
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #124559 <https://github.com/rust-lang/rust/issues/124559>
 
@@ -25,10 +29,12 @@ warning: type parameter `T` must be covered by another type when it appears befo
   --> $DIR/orphan-check-projections-not-covering.rs:40:6
    |
 LL | impl<T: Deferred> foreign::Trait1<Local, T> for <T as Deferred>::Output {}
-   |      ^ type parameter `T` must be covered by another type when it appears before the first local type (`Local`)
+   |      ^ uncovered type parameter
    |
-   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local, and no uncovered type parameters appear before that first local type
-   = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`, where `T0` is the first and `Tn` is the last
+   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local,
+           and no uncovered type parameters appear before that first local type
+   = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`,
+           where `T0` is the first and `Tn` is the last
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #124559 <https://github.com/rust-lang/rust/issues/124559>
 

--- a/tests/ui/coherence/orphan-check-projections-not-covering.classic.stderr
+++ b/tests/ui/coherence/orphan-check-projections-not-covering.classic.stderr
@@ -1,4 +1,4 @@
-warning[E0210]: type parameter `T` must be covered by another type when it appears before the first local type (`Local`)
+warning: type parameter `T` must be covered by another type when it appears before the first local type (`Local`)
   --> $DIR/orphan-check-projections-not-covering.rs:22:6
    |
 LL | impl<T> foreign::Trait0<Local, T, ()> for <T as Identity>::Output {}
@@ -10,7 +10,7 @@ LL | impl<T> foreign::Trait0<Local, T, ()> for <T as Identity>::Output {}
    = note: for more information, see issue #124559 <https://github.com/rust-lang/rust/issues/124559>
    = note: `#[warn(uncovered_param_in_projection)]` (part of `#[warn(future_incompatible)]`) on by default
 
-warning[E0210]: type parameter `T` must be covered by another type when it appears before the first local type (`Local`)
+warning: type parameter `T` must be covered by another type when it appears before the first local type (`Local`)
   --> $DIR/orphan-check-projections-not-covering.rs:27:6
    |
 LL | impl<T> foreign::Trait0<<T as Identity>::Output, Local, T> for Option<T> {}
@@ -21,7 +21,7 @@ LL | impl<T> foreign::Trait0<<T as Identity>::Output, Local, T> for Option<T> {}
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #124559 <https://github.com/rust-lang/rust/issues/124559>
 
-warning[E0210]: type parameter `T` must be covered by another type when it appears before the first local type (`Local`)
+warning: type parameter `T` must be covered by another type when it appears before the first local type (`Local`)
   --> $DIR/orphan-check-projections-not-covering.rs:40:6
    |
 LL | impl<T: Deferred> foreign::Trait1<Local, T> for <T as Deferred>::Output {}
@@ -34,4 +34,3 @@ LL | impl<T: Deferred> foreign::Trait1<Local, T> for <T as Deferred>::Output {}
 
 warning: 3 warnings emitted
 
-For more information about this error, try `rustc --explain E0210`.

--- a/tests/ui/coherence/orphan-check-projections-not-covering.next.stderr
+++ b/tests/ui/coherence/orphan-check-projections-not-covering.next.stderr
@@ -2,10 +2,12 @@ warning: type parameter `T` must be covered by another type when it appears befo
   --> $DIR/orphan-check-projections-not-covering.rs:22:6
    |
 LL | impl<T> foreign::Trait0<Local, T, ()> for <T as Identity>::Output {}
-   |      ^ type parameter `T` must be covered by another type when it appears before the first local type (`Local`)
+   |      ^ uncovered type parameter
    |
-   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local, and no uncovered type parameters appear before that first local type
-   = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`, where `T0` is the first and `Tn` is the last
+   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local,
+           and no uncovered type parameters appear before that first local type
+   = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`,
+           where `T0` is the first and `Tn` is the last
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #124559 <https://github.com/rust-lang/rust/issues/124559>
    = note: `#[warn(uncovered_param_in_projection)]` (part of `#[warn(future_incompatible)]`) on by default
@@ -14,10 +16,12 @@ warning: type parameter `T` must be covered by another type when it appears befo
   --> $DIR/orphan-check-projections-not-covering.rs:27:6
    |
 LL | impl<T> foreign::Trait0<<T as Identity>::Output, Local, T> for Option<T> {}
-   |      ^ type parameter `T` must be covered by another type when it appears before the first local type (`Local`)
+   |      ^ uncovered type parameter
    |
-   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local, and no uncovered type parameters appear before that first local type
-   = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`, where `T0` is the first and `Tn` is the last
+   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local,
+           and no uncovered type parameters appear before that first local type
+   = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`,
+           where `T0` is the first and `Tn` is the last
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #124559 <https://github.com/rust-lang/rust/issues/124559>
 
@@ -25,10 +29,12 @@ warning: type parameter `T` must be covered by another type when it appears befo
   --> $DIR/orphan-check-projections-not-covering.rs:40:6
    |
 LL | impl<T: Deferred> foreign::Trait1<Local, T> for <T as Deferred>::Output {}
-   |      ^ type parameter `T` must be covered by another type when it appears before the first local type (`Local`)
+   |      ^ uncovered type parameter
    |
-   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local, and no uncovered type parameters appear before that first local type
-   = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`, where `T0` is the first and `Tn` is the last
+   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local,
+           and no uncovered type parameters appear before that first local type
+   = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`,
+           where `T0` is the first and `Tn` is the last
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #124559 <https://github.com/rust-lang/rust/issues/124559>
 

--- a/tests/ui/coherence/orphan-check-projections-not-covering.next.stderr
+++ b/tests/ui/coherence/orphan-check-projections-not-covering.next.stderr
@@ -1,4 +1,4 @@
-warning[E0210]: type parameter `T` must be covered by another type when it appears before the first local type (`Local`)
+warning: type parameter `T` must be covered by another type when it appears before the first local type (`Local`)
   --> $DIR/orphan-check-projections-not-covering.rs:22:6
    |
 LL | impl<T> foreign::Trait0<Local, T, ()> for <T as Identity>::Output {}
@@ -10,7 +10,7 @@ LL | impl<T> foreign::Trait0<Local, T, ()> for <T as Identity>::Output {}
    = note: for more information, see issue #124559 <https://github.com/rust-lang/rust/issues/124559>
    = note: `#[warn(uncovered_param_in_projection)]` (part of `#[warn(future_incompatible)]`) on by default
 
-warning[E0210]: type parameter `T` must be covered by another type when it appears before the first local type (`Local`)
+warning: type parameter `T` must be covered by another type when it appears before the first local type (`Local`)
   --> $DIR/orphan-check-projections-not-covering.rs:27:6
    |
 LL | impl<T> foreign::Trait0<<T as Identity>::Output, Local, T> for Option<T> {}
@@ -21,7 +21,7 @@ LL | impl<T> foreign::Trait0<<T as Identity>::Output, Local, T> for Option<T> {}
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #124559 <https://github.com/rust-lang/rust/issues/124559>
 
-warning[E0210]: type parameter `T` must be covered by another type when it appears before the first local type (`Local`)
+warning: type parameter `T` must be covered by another type when it appears before the first local type (`Local`)
   --> $DIR/orphan-check-projections-not-covering.rs:40:6
    |
 LL | impl<T: Deferred> foreign::Trait1<Local, T> for <T as Deferred>::Output {}
@@ -34,4 +34,3 @@ LL | impl<T: Deferred> foreign::Trait1<Local, T> for <T as Deferred>::Output {}
 
 warning: 3 warnings emitted
 
-For more information about this error, try `rustc --explain E0210`.

--- a/tests/ui/coherence/orphan-check-projections-unsat-bounds.classic.stderr
+++ b/tests/ui/coherence/orphan-check-projections-unsat-bounds.classic.stderr
@@ -2,10 +2,12 @@ warning: type parameter `T` must be covered by another type when it appears befo
   --> $DIR/orphan-check-projections-unsat-bounds.rs:28:6
    |
 LL | impl<T> foreign::Trait1<LocalTy, T> for <Wrapper<T> as Discard>::Output
-   |      ^ type parameter `T` must be covered by another type when it appears before the first local type (`LocalTy`)
+   |      ^ uncovered type parameter
    |
-   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local, and no uncovered type parameters appear before that first local type
-   = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`, where `T0` is the first and `Tn` is the last
+   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local,
+           and no uncovered type parameters appear before that first local type
+   = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`,
+           where `T0` is the first and `Tn` is the last
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #124559 <https://github.com/rust-lang/rust/issues/124559>
    = note: `#[warn(uncovered_param_in_projection)]` (part of `#[warn(future_incompatible)]`) on by default

--- a/tests/ui/coherence/orphan-check-projections-unsat-bounds.classic.stderr
+++ b/tests/ui/coherence/orphan-check-projections-unsat-bounds.classic.stderr
@@ -1,4 +1,4 @@
-warning[E0210]: type parameter `T` must be covered by another type when it appears before the first local type (`LocalTy`)
+warning: type parameter `T` must be covered by another type when it appears before the first local type (`LocalTy`)
   --> $DIR/orphan-check-projections-unsat-bounds.rs:28:6
    |
 LL | impl<T> foreign::Trait1<LocalTy, T> for <Wrapper<T> as Discard>::Output
@@ -12,4 +12,3 @@ LL | impl<T> foreign::Trait1<LocalTy, T> for <Wrapper<T> as Discard>::Output
 
 warning: 1 warning emitted
 
-For more information about this error, try `rustc --explain E0210`.

--- a/tests/ui/coherence/orphan-check-projections-unsat-bounds.next.stderr
+++ b/tests/ui/coherence/orphan-check-projections-unsat-bounds.next.stderr
@@ -2,10 +2,12 @@ warning: type parameter `T` must be covered by another type when it appears befo
   --> $DIR/orphan-check-projections-unsat-bounds.rs:28:6
    |
 LL | impl<T> foreign::Trait1<LocalTy, T> for <Wrapper<T> as Discard>::Output
-   |      ^ type parameter `T` must be covered by another type when it appears before the first local type (`LocalTy`)
+   |      ^ uncovered type parameter
    |
-   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local, and no uncovered type parameters appear before that first local type
-   = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`, where `T0` is the first and `Tn` is the last
+   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local,
+           and no uncovered type parameters appear before that first local type
+   = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`,
+           where `T0` is the first and `Tn` is the last
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #124559 <https://github.com/rust-lang/rust/issues/124559>
    = note: `#[warn(uncovered_param_in_projection)]` (part of `#[warn(future_incompatible)]`) on by default

--- a/tests/ui/coherence/orphan-check-projections-unsat-bounds.next.stderr
+++ b/tests/ui/coherence/orphan-check-projections-unsat-bounds.next.stderr
@@ -1,4 +1,4 @@
-warning[E0210]: type parameter `T` must be covered by another type when it appears before the first local type (`LocalTy`)
+warning: type parameter `T` must be covered by another type when it appears before the first local type (`LocalTy`)
   --> $DIR/orphan-check-projections-unsat-bounds.rs:28:6
    |
 LL | impl<T> foreign::Trait1<LocalTy, T> for <Wrapper<T> as Discard>::Output
@@ -12,4 +12,3 @@ LL | impl<T> foreign::Trait1<LocalTy, T> for <Wrapper<T> as Discard>::Output
 
 warning: 1 warning emitted
 
-For more information about this error, try `rustc --explain E0210`.

--- a/tests/ui/coherence/orphan-check-weak-aliases-not-covering.stderr
+++ b/tests/ui/coherence/orphan-check-weak-aliases-not-covering.stderr
@@ -2,10 +2,12 @@ error[E0210]: type parameter `T` must be covered by another type when it appears
   --> $DIR/orphan-check-weak-aliases-not-covering.rs:13:6
    |
 LL | impl<T> foreign::Trait1<Local, T> for Identity<T> {}
-   |      ^ type parameter `T` must be covered by another type when it appears before the first local type (`Local`)
+   |      ^ uncovered type parameter
    |
-   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local, and no uncovered type parameters appear before that first local type
-   = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`, where `T0` is the first and `Tn` is the last
+   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local,
+           and no uncovered type parameters appear before that first local type
+   = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`,
+           where `T0` is the first and `Tn` is the last
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/error-codes/e0119/issue-28981.stderr
+++ b/tests/ui/error-codes/e0119/issue-28981.stderr
@@ -1,8 +1,8 @@
-error[E0210]: type parameter `Foo` must be used as the type parameter for some local type (e.g., `MyStruct<Foo>`)
+error[E0210]: type parameter `Foo` must be used as an argument to some local type (e.g., `MyStruct<Foo>`)
   --> $DIR/issue-28981.rs:5:6
    |
 LL | impl<Foo> Deref for Foo { }
-   |      ^^^ type parameter `Foo` must be used as the type parameter for some local type
+   |      ^^^ uncovered type parameter
    |
    = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter

--- a/tests/ui/issues/issue-41974.stderr
+++ b/tests/ui/issues/issue-41974.stderr
@@ -1,8 +1,8 @@
-error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
+error[E0210]: type parameter `T` must be used as an argument to some local type (e.g., `MyStruct<T>`)
   --> $DIR/issue-41974.rs:7:6
    |
 LL | impl<T> Drop for T where T: A {
-   |      ^ type parameter `T` must be used as the type parameter for some local type
+   |      ^ uncovered type parameter
    |
    = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter

--- a/tests/ui/specialization/fuzzed/fuzzing-ice-134905.rs
+++ b/tests/ui/specialization/fuzzed/fuzzing-ice-134905.rs
@@ -15,7 +15,7 @@ where
 
 trait Check {}
 impl<'a, T> Eq for T where <T as Iterate<'a>>::Ty: Valid {}
-//~^ ERROR type parameter `T` must be used as the type parameter for some local type
+//~^ ERROR type parameter `T` must be used as an argument to some local type
 
 trait Valid {}
 

--- a/tests/ui/specialization/fuzzed/fuzzing-ice-134905.stderr
+++ b/tests/ui/specialization/fuzzed/fuzzing-ice-134905.stderr
@@ -15,11 +15,11 @@ note: required by a bound in `Iterate::Ty`
 LL |     type Ty: Valid;
    |              ^^^^^ required by this bound in `Iterate::Ty`
 
-error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
+error[E0210]: type parameter `T` must be used as an argument to some local type (e.g., `MyStruct<T>`)
   --> $DIR/fuzzing-ice-134905.rs:17:10
    |
 LL | impl<'a, T> Eq for T where <T as Iterate<'a>>::Ty: Valid {}
-   |          ^ type parameter `T` must be used as the type parameter for some local type
+   |          ^ uncovered type parameter
    |
    = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter

--- a/tests/ui/specialization/issue-43037.current.stderr
+++ b/tests/ui/specialization/issue-43037.current.stderr
@@ -1,8 +1,8 @@
-error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
+error[E0210]: type parameter `T` must be used as an argument to some local type (e.g., `MyStruct<T>`)
   --> $DIR/issue-43037.rs:19:6
    |
 LL | impl<T> From<<A<T> as Z>::Assoc> for T {}
-   |      ^ type parameter `T` must be used as the type parameter for some local type
+   |      ^ uncovered type parameter
    |
    = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter

--- a/tests/ui/specialization/issue-43037.negative.stderr
+++ b/tests/ui/specialization/issue-43037.negative.stderr
@@ -1,8 +1,8 @@
-error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
+error[E0210]: type parameter `T` must be used as an argument to some local type (e.g., `MyStruct<T>`)
   --> $DIR/issue-43037.rs:19:6
    |
 LL | impl<T> From<<A<T> as Z>::Assoc> for T {}
-   |      ^ type parameter `T` must be used as the type parameter for some local type
+   |      ^ uncovered type parameter
    |
    = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter

--- a/tests/ui/specialization/issue-43037.rs
+++ b/tests/ui/specialization/issue-43037.rs
@@ -17,6 +17,6 @@ impl<T: X> Z for A<T> {
 
 // this impl is invalid, but causes an ICE anyway
 impl<T> From<<A<T> as Z>::Assoc> for T {}
-//~^ ERROR type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
+//~^ ERROR type parameter `T` must be used as an argument to some local type (e.g., `MyStruct<T>`)
 
 fn main() {}

--- a/tests/ui/stability-attribute/generics-default-stability-where.rs
+++ b/tests/ui/stability-attribute/generics-default-stability-where.rs
@@ -5,7 +5,7 @@ extern crate unstable_generic_param;
 use unstable_generic_param::*;
 
 impl<T> Trait3<usize> for T where T: Trait2<usize> { //~ ERROR use of unstable library feature `unstable_default`
-//~^ ERROR `T` must be used as the type parameter for some local type
+//~^ ERROR `T` must be used as an argument to some local type
     fn foo() -> usize { T::foo() }
 }
 

--- a/tests/ui/stability-attribute/generics-default-stability-where.stderr
+++ b/tests/ui/stability-attribute/generics-default-stability-where.stderr
@@ -7,11 +7,11 @@ LL | impl<T> Trait3<usize> for T where T: Trait2<usize> {
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
+error[E0210]: type parameter `T` must be used as an argument to some local type (e.g., `MyStruct<T>`)
   --> $DIR/generics-default-stability-where.rs:7:6
    |
 LL | impl<T> Trait3<usize> for T where T: Trait2<usize> {
-   |      ^ type parameter `T` must be used as the type parameter for some local type
+   |      ^ uncovered type parameter
    |
    = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter

--- a/tests/ui/traits/const-traits/ice-119717-constant-lifetime.rs
+++ b/tests/ui/traits/const-traits/ice-119717-constant-lifetime.rs
@@ -4,7 +4,7 @@
 use std::ops::FromResidual;
 
 impl<T> const FromResidual for T {
-    //~^ ERROR type parameter `T` must be used as the type parameter for some local type
+    //~^ ERROR type parameter `T` must be used as an argument to some local type
     fn from_residual(t: T) -> _ {
         //~^ ERROR the placeholder `_` is not allowed
         t

--- a/tests/ui/traits/const-traits/ice-119717-constant-lifetime.stderr
+++ b/tests/ui/traits/const-traits/ice-119717-constant-lifetime.stderr
@@ -1,8 +1,8 @@
-error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
+error[E0210]: type parameter `T` must be used as an argument to some local type (e.g., `MyStruct<T>`)
   --> $DIR/ice-119717-constant-lifetime.rs:6:6
    |
 LL | impl<T> const FromResidual for T {
-   |      ^ type parameter `T` must be used as the type parameter for some local type
+   |      ^ uncovered type parameter
    |
    = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter

--- a/tests/ui/traits/dispatch-from-dyn-blanket-impl.rs
+++ b/tests/ui/traits/dispatch-from-dyn-blanket-impl.rs
@@ -4,7 +4,7 @@
 #![feature(dispatch_from_dyn)]
 
 impl<T> std::ops::DispatchFromDyn<T> for T {}
-//~^ ERROR type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
+//~^ ERROR type parameter `T` must be used as an argument to some local type (e.g., `MyStruct<T>`)
 //~| ERROR the trait `DispatchFromDyn` may only be implemented for a coercion between structures
 
 fn main() {}

--- a/tests/ui/traits/dispatch-from-dyn-blanket-impl.stderr
+++ b/tests/ui/traits/dispatch-from-dyn-blanket-impl.stderr
@@ -1,8 +1,8 @@
-error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
+error[E0210]: type parameter `T` must be used as an argument to some local type (e.g., `MyStruct<T>`)
   --> $DIR/dispatch-from-dyn-blanket-impl.rs:6:6
    |
 LL | impl<T> std::ops::DispatchFromDyn<T> for T {}
-   |      ^ type parameter `T` must be used as the type parameter for some local type
+   |      ^ uncovered type parameter
    |
    = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter

--- a/tests/ui/type-alias-impl-trait/incoherent-assoc-imp-trait.stderr
+++ b/tests/ui/type-alias-impl-trait/incoherent-assoc-imp-trait.stderr
@@ -1,8 +1,8 @@
-error[E0210]: type parameter `F` must be used as the type parameter for some local type (e.g., `MyStruct<F>`)
+error[E0210]: type parameter `F` must be used as an argument to some local type (e.g., `MyStruct<F>`)
   --> $DIR/incoherent-assoc-imp-trait.rs:10:6
    |
 LL | impl<F> FnOnce<()> for &F {
-   |      ^ type parameter `F` must be used as the type parameter for some local type
+   |      ^ uncovered type parameter
    |
    = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter


### PR DESCRIPTION
Split out of PR rust-lang/rust#135910. No behavioral changes.

See individual commit messages for details.