### PR TITLE
Require `#[pin_v2]` for explicit pin-projection patterns

### DIFF
--- a/compiler/rustc_hir_typeck/src/pat.rs
+++ b/compiler/rustc_hir_typeck/src/pat.rs
@@ -544,21 +544,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             {
                 debug!("scrutinee ty {expected:?} is a pinned reference, inserting pin deref");
 
-                // if the inner_ty is an ADT, make sure that it can be structurally pinned
-                // (i.e., it is `#[pin_v2]`).
-                if let Some(adt) = inner_ty.ty_adt_def()
-                    && !adt.is_pin_project()
-                    && !adt.is_pin()
-                {
-                    let def_span: Option<Span> = self.tcx.hir_span_if_local(adt.did());
-                    let sugg_span = def_span.map(|span| span.shrink_to_lo());
-                    self.dcx().emit_err(crate::errors::ProjectOnNonPinProjectType {
-                        span: pat.span,
-                        def_span,
-                        sugg_span,
-                    });
-                }
-
                 // Use the old pat info to keep `current_depth` to its old value.
                 let new_pat_info =
                     self.adjust_pat_info(Pinnedness::Pinned, inner_mutability, old_pat_info);
@@ -1523,6 +1508,39 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         Ok(ResolvedPat { ty: pat_ty, kind: ResolvedPatKind::Struct { variant } })
     }
 
+    /// Reject pin-projection through a type that isn't structurally pinnable.
+    ///
+    /// Destructuring an ADT underneath a `&pin` reference projects its fields as pinned references.
+    /// This is only sound if the type opted into structural pinning with `#[pin_v2]`; otherwise it
+    /// would let safe code form a `Pin<&mut Field>` for a type that should never be pinned, breaking
+    /// the `Pin` guarantee (see #157634).
+    ///
+    /// This covers both explicit (`&pin mut`/`&pin const`) and implicit (match-ergonomics)
+    /// projection. `max_pinnedness` is only set for `&pin mut`, so the implicit shared (`&pin
+    /// const`) case is instead recognized through its pinned binding mode, hence both are checked.
+    fn check_pin_projection(
+        &self,
+        pat: &'tcx Pat<'tcx>,
+        pat_ty: Ty<'tcx>,
+        pat_info: PatInfo<'tcx>,
+    ) {
+        let through_pin = pat_info.max_pinnedness == PinnednessCap::Pinned
+            || matches!(pat_info.binding_mode, ByRef::Yes(Pinnedness::Pinned, _));
+        if through_pin
+            && let Some(adt) = pat_ty.ty_adt_def()
+            && !adt.is_pin_project()
+            && !adt.is_pin()
+        {
+            let def_span: Option<Span> = self.tcx.hir_span_if_local(adt.did());
+            let sugg_span = def_span.map(|span| span.shrink_to_lo());
+            self.dcx().emit_err(crate::errors::ProjectOnNonPinProjectType {
+                span: pat.span,
+                def_span,
+                sugg_span,
+            });
+        }
+    }
+
     fn check_pat_struct(
         &self,
         pat: &'tcx Pat<'tcx>,
@@ -1533,6 +1551,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         expected: Ty<'tcx>,
         pat_info: PatInfo<'tcx>,
     ) -> Ty<'tcx> {
+        self.check_pin_projection(pat, pat_ty, pat_info);
+
         // Type-check the path.
         let had_err = self.demand_eqtype_pat(pat.span, expected, pat_ty, &pat_info.top_info);
 
@@ -1791,6 +1811,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         expected: Ty<'tcx>,
         pat_info: PatInfo<'tcx>,
     ) -> Ty<'tcx> {
+        self.check_pin_projection(pat, pat_ty, pat_info);
+
         let tcx = self.tcx;
         let on_error = |e| {
             for pat in subpats {

--- a/tests/ui/pin-ergonomics/auxiliary/non_pin_project.rs
+++ b/tests/ui/pin-ergonomics/auxiliary/non_pin_project.rs
@@ -1,0 +1,3 @@
+// A plain, non-`#[pin_v2]` type defined in another crate, so it has no local span in the
+// downstream crate that projects through it.
+pub struct Foreign<T>(pub T);

--- a/tests/ui/pin-ergonomics/pin-pattern-foreign-non-pin-project.rs
+++ b/tests/ui/pin-ergonomics/pin-pattern-foreign-non-pin-project.rs
@@ -1,0 +1,22 @@
+//@ edition:2024
+//@ aux-build:non_pin_project.rs
+#![feature(pin_ergonomics)]
+#![allow(incomplete_features)]
+
+// Regression test for #157634, exercising the diagnostic good-practice raised in the #157542
+// review: the projection error must be emitted even when the projected-through type comes from
+// another crate and therefore has no local span. `ProjectOnNonPinProjectType` carries its
+// `def_span`/`sugg_span` as `Option<Span>`, so for a foreign type the "type defined here" note
+// and the `#[pin_v2]` suggestion are dropped rather than suppressing the error itself.
+
+extern crate non_pin_project;
+
+use non_pin_project::Foreign;
+use std::pin::Pin;
+
+fn project<T>(p: Pin<&mut Foreign<T>>) {
+    let &pin mut Foreign(ref pin mut _x) = p;
+    //~^ ERROR cannot project on type that is not `#[pin_v2]`
+}
+
+fn main() {}

--- a/tests/ui/pin-ergonomics/pin-pattern-foreign-non-pin-project.stderr
+++ b/tests/ui/pin-ergonomics/pin-pattern-foreign-non-pin-project.stderr
@@ -1,0 +1,8 @@
+error: cannot project on type that is not `#[pin_v2]`
+  --> $DIR/pin-pattern-foreign-non-pin-project.rs:18:18
+   |
+LL |     let &pin mut Foreign(ref pin mut _x) = p;
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/pin-ergonomics/pin-pattern-non-pin-project.rs
+++ b/tests/ui/pin-ergonomics/pin-pattern-non-pin-project.rs
@@ -1,0 +1,61 @@
+//@ edition:2024
+#![feature(pin_ergonomics)]
+#![allow(incomplete_features)]
+
+// Regression test for #157634.
+//
+// The implicit pin-projection (via match ergonomics) is only allowed on `#[pin_v2]` types, but
+// the explicit `&pin mut` / `ref pin` pattern forms used to project through *any* type. That is
+// unsound: it lets safe code form a `Pin<&mut Field>` for a type that never opted into structural
+// pinning, breaking the `Pin` guarantee. Check that the explicit forms are now gated the same way
+// as the implicit one.
+
+use std::pin::Pin;
+
+struct NotPinProject<T>(T);
+
+struct NotPinProjectStruct<T> {
+    x: T,
+}
+
+enum NotPinProjectEnum<T> {
+    Tuple(T),
+    Struct { x: T },
+}
+
+fn tuple_struct<T>(p: Pin<&mut NotPinProject<T>>) {
+    let &pin mut NotPinProject(ref pin mut _x) = p;
+    //~^ ERROR cannot project on type that is not `#[pin_v2]`
+}
+
+fn struct_field<T>(p: Pin<&mut NotPinProjectStruct<T>>) {
+    let &pin mut NotPinProjectStruct { x: ref pin mut _x } = p;
+    //~^ ERROR cannot project on type that is not `#[pin_v2]`
+}
+
+fn shared<T>(p: Pin<&NotPinProject<T>>) {
+    let &pin const NotPinProject(ref pin const _x) = p;
+    //~^ ERROR cannot project on type that is not `#[pin_v2]`
+}
+
+fn enum_tuple<T>(p: Pin<&mut NotPinProjectEnum<T>>) {
+    if let &pin mut NotPinProjectEnum::Tuple(ref pin mut _x) = p {}
+    //~^ ERROR cannot project on type that is not `#[pin_v2]`
+}
+
+fn enum_struct<T>(p: Pin<&mut NotPinProjectEnum<T>>) {
+    if let &pin mut NotPinProjectEnum::Struct { x: ref pin mut _x } = p {}
+    //~^ ERROR cannot project on type that is not `#[pin_v2]`
+}
+
+// The exact shape from the issue: `Thing` unconditionally implements `Unpin`, so it must not be
+// possible to project a pinned reference to one of its fields.
+struct Thing<T>(T);
+impl<T> Unpin for Thing<T> {}
+
+fn issue_157634<T>(pinned_thing: Pin<&mut Thing<Option<T>>>) {
+    let &pin mut Thing(ref pin mut _pinned_option) = pinned_thing;
+    //~^ ERROR cannot project on type that is not `#[pin_v2]`
+}
+
+fn main() {}

--- a/tests/ui/pin-ergonomics/pin-pattern-non-pin-project.stderr
+++ b/tests/ui/pin-ergonomics/pin-pattern-non-pin-project.stderr
@@ -1,0 +1,104 @@
+error: cannot project on type that is not `#[pin_v2]`
+  --> $DIR/pin-pattern-non-pin-project.rs:27:18
+   |
+LL |     let &pin mut NotPinProject(ref pin mut _x) = p;
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: type defined here
+  --> $DIR/pin-pattern-non-pin-project.rs:15:1
+   |
+LL | struct NotPinProject<T>(T);
+   | ^^^^^^^^^^^^^^^^^^^^^^^
+help: add `#[pin_v2]` here
+   |
+LL + #[pin_v2]
+LL | struct NotPinProject<T>(T);
+   |
+
+error: cannot project on type that is not `#[pin_v2]`
+  --> $DIR/pin-pattern-non-pin-project.rs:32:18
+   |
+LL |     let &pin mut NotPinProjectStruct { x: ref pin mut _x } = p;
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: type defined here
+  --> $DIR/pin-pattern-non-pin-project.rs:17:1
+   |
+LL | struct NotPinProjectStruct<T> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: add `#[pin_v2]` here
+   |
+LL + #[pin_v2]
+LL | struct NotPinProjectStruct<T> {
+   |
+
+error: cannot project on type that is not `#[pin_v2]`
+  --> $DIR/pin-pattern-non-pin-project.rs:37:20
+   |
+LL |     let &pin const NotPinProject(ref pin const _x) = p;
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: type defined here
+  --> $DIR/pin-pattern-non-pin-project.rs:15:1
+   |
+LL | struct NotPinProject<T>(T);
+   | ^^^^^^^^^^^^^^^^^^^^^^^
+help: add `#[pin_v2]` here
+   |
+LL + #[pin_v2]
+LL | struct NotPinProject<T>(T);
+   |
+
+error: cannot project on type that is not `#[pin_v2]`
+  --> $DIR/pin-pattern-non-pin-project.rs:42:21
+   |
+LL |     if let &pin mut NotPinProjectEnum::Tuple(ref pin mut _x) = p {}
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: type defined here
+  --> $DIR/pin-pattern-non-pin-project.rs:21:1
+   |
+LL | enum NotPinProjectEnum<T> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+help: add `#[pin_v2]` here
+   |
+LL + #[pin_v2]
+LL | enum NotPinProjectEnum<T> {
+   |
+
+error: cannot project on type that is not `#[pin_v2]`
+  --> $DIR/pin-pattern-non-pin-project.rs:47:21
+   |
+LL |     if let &pin mut NotPinProjectEnum::Struct { x: ref pin mut _x } = p {}
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: type defined here
+  --> $DIR/pin-pattern-non-pin-project.rs:21:1
+   |
+LL | enum NotPinProjectEnum<T> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+help: add `#[pin_v2]` here
+   |
+LL + #[pin_v2]
+LL | enum NotPinProjectEnum<T> {
+   |
+
+error: cannot project on type that is not `#[pin_v2]`
+  --> $DIR/pin-pattern-non-pin-project.rs:57:18
+   |
+LL |     let &pin mut Thing(ref pin mut _pinned_option) = pinned_thing;
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: type defined here
+  --> $DIR/pin-pattern-non-pin-project.rs:53:1
+   |
+LL | struct Thing<T>(T);
+   | ^^^^^^^^^^^^^^^
+help: add `#[pin_v2]` here
+   |
+LL + #[pin_v2]
+LL | struct Thing<T>(T);
+   |
+
+error: aborting due to 6 previous errors
+

--- a/tests/ui/pin-ergonomics/user-type-projection.rs
+++ b/tests/ui/pin-ergonomics/user-type-projection.rs
@@ -9,6 +9,7 @@
 // Historically, this could occur when the code handling those projections did not know
 // about `&pin` patterns, and incorrectly treated them as plain `&`/`&mut` patterns instead.
 
+#[pin_v2]
 struct Data {
     x: u32
 }


### PR DESCRIPTION
Fixes rust-lang/rust#157634

The `#[pin_v2]` projection check only ran for the implicit projection (the match-ergonomics one, gated on `default_binding_modes`). The explicit `&pin mut` / `ref pin` patterns went straight through `check_pat_ref` into the tuple-struct/struct paths with no check at all, so you could pin-project through a type that never opted into structural pinning and pull a `Pin<&mut Field>` out of it. that breaks the `Pin` guarantee: the repro in the issue pins a `!Unpin` field of an `Unpin` wrapper and then moves it.

there were a few ways to fix this (i laid them out [here](https://github.com/rust-lang/rust/issues/157615#issuecomment-4654044292)), but only approach 1, gating the explicit path on `#[pin_v2]` too, actually closes it since the hole isn't packed-specific. theemathas landed on the same one in rust-lang/rust#157615, so that's what i went with.

instead of duplicating the check i moved it to the destructuring site (`check_pin_projection`, called from `check_pat_struct` and `check_pat_tuple_struct`), so one check now covers both the implicit and explicit projections. one subtlety that bit me: `max_pinnedness` is only set for `&pin mut`, not for the implicit `&pin const`, so the gate also looks at the pinned binding mode to catch the shared case.

tests cover tuple-struct / struct / enum / shared projections plus the issue's exact repro. there's also a foreign-type one so the error still fires (just without the "type defined here" note + suggestion) when the projected-through type has no local span. the diagnostic already carries those as `Option<Span>`, same good practice mejrs raised on rust-lang/rust#157542, so figured it makes sense to lock it in with a test.

lmk if you'd rather keep the check separate per-path instead of centralized.

cc @theemathas @mejrs
