### PR TITLE
Add instrument_fn attribute

### DIFF
--- a/compiler/rustc_attr_parsing/src/attributes/codegen_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/codegen_attrs.rs
@@ -1,5 +1,7 @@
 use rustc_feature::AttributeStability;
-use rustc_hir::attrs::{CoverageAttrKind, OptimizeAttr, RtsanSetting, SanitizerSet, UsedBy};
+use rustc_hir::attrs::{
+    CoverageAttrKind, InstrumentFnAttr, OptimizeAttr, RtsanSetting, SanitizerSet, UsedBy,
+};
 use rustc_session::errors::feature_err;
 use rustc_span::edition::Edition::Edition2024;
 
@@ -572,6 +574,44 @@ impl CombineAttributeParser for ForceTargetFeatureParser {
         args: &ArgParser,
     ) -> impl IntoIterator<Item = Self::Item> {
         parse_tf_attribute(cx, args)
+    }
+}
+
+pub(crate) struct InstrumentFnParser;
+
+impl SingleAttributeParser for InstrumentFnParser {
+    const PATH: &[Symbol] = &[sym::instrument_fn];
+    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
+        Allow(Target::Fn),
+        Allow(Target::Method(MethodKind::Inherent)),
+        Allow(Target::Method(MethodKind::Trait { body: true })),
+        Allow(Target::Method(MethodKind::TraitImpl)),
+    ]);
+    const TEMPLATE: AttributeTemplate = template!(NameValueStr: "on|off");
+    const STABILITY: AttributeStability = unstable!(instrument_fn);
+
+    fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
+        let instrument = match args {
+            ArgParser::NameValue(nv) => match nv.value_as_str() {
+                Some(sym::on) => Some(AttributeKind::InstrumentFn(InstrumentFnAttr::On)),
+                Some(sym::off) => Some(AttributeKind::InstrumentFn(InstrumentFnAttr::Off)),
+                _ => {
+                    cx.adcx()
+                        .expected_specific_argument_strings(nv.value_span, &[sym::on, sym::off]);
+                    None
+                }
+            },
+            ArgParser::List(l) => {
+                cx.adcx().expected_single_argument(l.span, l.len());
+                None
+            }
+            ArgParser::NoArgs => {
+                let span = cx.attr_span;
+                cx.adcx().expected_specific_argument_strings(span, &[sym::on, sym::off]);
+                None
+            }
+        };
+        instrument
     }
 }
 

--- a/compiler/rustc_attr_parsing/src/context.rs
+++ b/compiler/rustc_attr_parsing/src/context.rs
@@ -189,6 +189,7 @@ attribute_parsers!(
         Single<IgnoreParser>,
         Single<InlineParser>,
         Single<InstructionSetParser>,
+        Single<InstrumentFnParser>,
         Single<LangParser>,
         Single<LinkNameParser>,
         Single<LinkOrdinalParser>,

--- a/compiler/rustc_codegen_llvm/src/attributes.rs
+++ b/compiler/rustc_codegen_llvm/src/attributes.rs
@@ -3,7 +3,8 @@ use rustc_hir::attrs::{InlineAttr, InstructionSetAttr, OptimizeAttr, RtsanSettin
 use rustc_hir::def_id::DefId;
 use rustc_hir::find_attr;
 use rustc_middle::middle::codegen_fn_attrs::{
-    CodegenFnAttrFlags, CodegenFnAttrs, PatchableFunctionEntry, SanitizerFnAttrs, TargetFeature,
+    CodegenFnAttrFlags, CodegenFnAttrs, InstrumentFnAttr, PatchableFunctionEntry, SanitizerFnAttrs,
+    TargetFeature,
 };
 use rustc_middle::ty::{self, Instance, TyCtxt};
 use rustc_session::config::{BranchProtection, FunctionReturn, OptLevel, PAuthKey, PacRet};
@@ -210,35 +211,59 @@ fn function_return_attr<'ll>(cx: &SimpleCx<'ll>, sess: &Session) -> Option<&'ll 
 fn instrument_function_attr<'ll>(
     cx: &SimpleCx<'ll>,
     sess: &Session,
+    instrument_fn: InstrumentFnAttr,
 ) -> SmallVec<[&'ll Attribute; 4]> {
     let mut attrs = SmallVec::new();
     if sess.opts.unstable_opts.instrument_mcount {
         // Similar to `clang -pg` behavior. Handled by the
         // `post-inline-ee-instrument` LLVM pass.
 
-        // The function name varies on platforms.
-        // See test/CodeGen/mcount.c in clang.
-        let mcount_name = match &sess.target.llvm_mcount_intrinsic {
-            Some(llvm_mcount_intrinsic) => llvm_mcount_intrinsic.as_ref(),
-            None => sess.target.mcount.as_ref(),
+        let instrument_entry = match instrument_fn {
+            InstrumentFnAttr::Default | InstrumentFnAttr::On => true,
+            InstrumentFnAttr::Off => false,
         };
 
-        attrs.push(llvm::CreateAttrStringValue(
-            cx.llcx,
-            "instrument-function-entry-inlined",
-            mcount_name,
-        ));
+        if instrument_entry {
+            // The function name varies on platforms.
+            // See test/CodeGen/mcount.c in clang.
+            let mcount_name = match &sess.target.llvm_mcount_intrinsic {
+                Some(llvm_mcount_intrinsic) => llvm_mcount_intrinsic.as_ref(),
+                None => sess.target.mcount.as_ref(),
+            };
+
+            attrs.push(llvm::CreateAttrStringValue(
+                cx.llcx,
+                "instrument-function-entry-inlined",
+                mcount_name,
+            ));
+        }
     }
     if let Some(options) = &sess.opts.unstable_opts.instrument_xray {
         // XRay instrumentation is similar to __cyg_profile_func_{enter,exit}.
         // Function prologue and epilogue are instrumented with NOP sleds,
         // a runtime library later replaces them with detours into tracing code.
-        if options.always {
-            attrs.push(llvm::CreateAttrStringValue(cx.llcx, "function-instrument", "xray-always"));
+
+        let mut never = options.never;
+        let mut always = options.always;
+
+        // always and never may be overridden by the #[instrument_fn = ...] attribute.
+        match instrument_fn {
+            InstrumentFnAttr::Default => {}
+            InstrumentFnAttr::On => {
+                always = true;
+            }
+            InstrumentFnAttr::Off => {
+                never = true;
+            }
         }
-        if options.never {
+
+        if never {
             attrs.push(llvm::CreateAttrStringValue(cx.llcx, "function-instrument", "xray-never"));
         }
+        if always {
+            attrs.push(llvm::CreateAttrStringValue(cx.llcx, "function-instrument", "xray-always"));
+        }
+
         if options.ignore_loops {
             attrs.push(llvm::CreateAttrString(cx.llcx, "xray-ignore-loops"));
         }
@@ -442,7 +467,7 @@ pub(crate) fn llfn_attrs_from_instance<'ll, 'tcx>(
     // FIXME: none of these functions interact with source level attributes.
     to_add.extend(frame_pointer_type_attr(cx, sess));
     to_add.extend(function_return_attr(cx, sess));
-    to_add.extend(instrument_function_attr(cx, sess));
+    to_add.extend(instrument_function_attr(cx, sess, codegen_fn_attrs.instrument_fn));
     to_add.extend(nojumptables_attr(cx, sess));
     to_add.extend(probestack_attr(cx, tcx));
     to_add.extend(stackprotector_attr(cx, sess));

--- a/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
+++ b/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
@@ -1,13 +1,14 @@
 use rustc_abi::{Align, ExternAbi};
 use rustc_hir::attrs::{
-    AttributeKind, EiiImplResolution, InlineAttr, Linkage, RtsanSetting, UsedBy,
+    AttributeKind, EiiImplResolution, InlineAttr, InstrumentFnAttr as HirInstrumentFnAttr, Linkage,
+    RtsanSetting, UsedBy,
 };
 use rustc_hir::def::DefKind;
 use rustc_hir::def_id::{DefId, LOCAL_CRATE, LocalDefId};
 use rustc_hir::{self as hir, Attribute, find_attr};
 use rustc_macros::Diagnostic;
 use rustc_middle::middle::codegen_fn_attrs::{
-    CodegenFnAttrFlags, CodegenFnAttrs, PatchableFunctionEntry, SanitizerFnAttrs,
+    CodegenFnAttrFlags, CodegenFnAttrs, InstrumentFnAttr, PatchableFunctionEntry, SanitizerFnAttrs,
 };
 use rustc_middle::mono::Visibility;
 use rustc_middle::query::Providers;
@@ -292,6 +293,12 @@ fn process_builtin_attrs(
             AttributeKind::PatchableFunctionEntry { prefix, entry } => {
                 codegen_fn_attrs.patchable_function_entry =
                     Some(PatchableFunctionEntry::from_prefix_and_entry(*prefix, *entry));
+            }
+            AttributeKind::InstrumentFn(instrument_fn) => {
+                codegen_fn_attrs.instrument_fn = match instrument_fn {
+                    HirInstrumentFnAttr::On => InstrumentFnAttr::On,
+                    HirInstrumentFnAttr::Off => InstrumentFnAttr::Off,
+                };
             }
             _ => {}
         }

--- a/compiler/rustc_feature/src/builtin_attrs.rs
+++ b/compiler/rustc_feature/src/builtin_attrs.rs
@@ -219,6 +219,12 @@ pub static BUILTIN_ATTRIBUTES: &[Symbol] = &[
     // - https://github.com/rust-lang/rust/pull/156816
     sym::unroll,
 
+    // `#[instrument_fn = "on|off"]` to insert or inhibit instrumentation function
+    // calls inside a function, usually around the prologue.
+    //
+    // - https://github.com/rust-lang/rust/issues/157081
+    sym::instrument_fn,
+
     // ==========================================================================
     // Internal attributes: Stability, deprecation, and unsafe:
     // ==========================================================================

--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -595,6 +595,8 @@ declare_features! (
     (unstable, import_trait_associated_functions, "1.86.0", Some(134691)),
     /// Allows associated types in inherent impls.
     (incomplete, inherent_associated_types, "1.52.0", Some(8995)),
+    /// Enable #[instrument_fn] on function.
+    (unstable, instrument_fn, "CURRENT_RUSTC_VERSION", Some(157081)),
     /// Allows using `pointer` and `reference` in intra-doc links
     (unstable, intra_doc_pointers, "1.51.0", Some(80896)),
     /// lahfsahf target feature on x86.

--- a/compiler/rustc_hir/src/attrs/data_structures.rs
+++ b/compiler/rustc_hir/src/attrs/data_structures.rs
@@ -143,6 +143,14 @@ pub enum InstructionSetAttr {
     ArmT32,
 }
 
+#[derive(Copy, Clone, PartialEq, Encodable, Decodable, Debug, Eq, StableHash, PrintAttribute)]
+pub enum InstrumentFnAttr {
+    /// `#[instrument_fn = "on"]`
+    On,
+    /// `#[instrument_fn = "off"]`
+    Off,
+}
+
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Default, PrintAttribute)]
 #[derive(Encodable, Decodable, StableHash)]
 pub enum OptimizeAttr {
@@ -1067,6 +1075,9 @@ pub enum AttributeKind {
 
     /// Represents `#[instruction_set]`
     InstructionSet(InstructionSetAttr),
+
+    /// Represents `#[instrument_fn]`
+    InstrumentFn(InstrumentFnAttr),
 
     /// Represents `#[lang]`
     Lang(LangItem),

--- a/compiler/rustc_hir/src/attrs/encode_cross_crate.rs
+++ b/compiler/rustc_hir/src/attrs/encode_cross_crate.rs
@@ -50,6 +50,7 @@ impl AttributeKind {
             Ignore { .. } => No,
             Inline(..) => No,
             InstructionSet(..) => No,
+            InstrumentFn(..) => No,
             Lang(..) => Yes,
             Link(..) => No,
             LinkName { .. } => Yes, // Needed for rustdoc

--- a/compiler/rustc_middle/src/middle/codegen_fn_attrs.rs
+++ b/compiler/rustc_middle/src/middle/codegen_fn_attrs.rs
@@ -117,6 +117,24 @@ pub struct CodegenFnAttrs {
     pub objc_class: Option<Symbol>,
     /// The `#[rustc_objc_selector = "..."]` attribute.
     pub objc_selector: Option<Symbol>,
+    /// The `#[instrument_fn]` attribute.
+    pub instrument_fn: InstrumentFnAttr,
+}
+
+#[derive(Copy, Clone, TyEncodable, TyDecodable, StableHash, Debug)]
+pub enum InstrumentFnAttr {
+    /// Always instrument function
+    On,
+    /// Never instrument function
+    Off,
+    /// Instrument based on command line options, if any.
+    Default,
+}
+
+const impl Default for InstrumentFnAttr {
+    fn default() -> Self {
+        InstrumentFnAttr::Default
+    }
 }
 
 #[derive(Copy, Clone, Debug, TyEncodable, TyDecodable, StableHash, PartialEq, Eq)]
@@ -244,6 +262,7 @@ impl CodegenFnAttrs {
             patchable_function_entry: None,
             objc_class: None,
             objc_selector: None,
+            instrument_fn: InstrumentFnAttr::default(),
         }
     }
 

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -280,6 +280,7 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
             AttributeKind::Fundamental => (),
             AttributeKind::Ignore { .. } => (),
             AttributeKind::InstructionSet(..) => (),
+            AttributeKind::InstrumentFn(..) => (),
             AttributeKind::Lang(..) => (),
             AttributeKind::LinkName { .. } => (),
             AttributeKind::LinkOrdinal { .. } => (),

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1122,6 +1122,7 @@ symbols! {
         inout,
         inputs,
         instruction_set,
+        instrument_fn,
         integer_: "integer", // underscore to avoid clashing with the function `sym::integer` below
         integral,
         internal,

--- a/tests/codegen-llvm/instrument_fn.rs
+++ b/tests/codegen-llvm/instrument_fn.rs
@@ -1,0 +1,49 @@
+// Verify the #[instrument_fn] applies the correct LLVM IR function attributes.
+//
+//@ revisions:XRAY MCOUNT
+//@ add-minicore
+//@ compile-flags: -Copt-level=0
+//@ [XRAY] compile-flags: -Zinstrument-xray --target=x86_64-unknown-linux-gnu
+//@ [XRAY] needs-llvm-components: x86
+//@ [MCOUNT] compile-flags: -Zinstrument-mcount
+
+#![feature(no_core)]
+#![crate_type = "lib"]
+#![feature(instrument_fn)]
+#![no_core]
+
+extern crate minicore;
+use minicore::*;
+
+#[no_mangle]
+// CHECK: define {{.*}}void @instrument_default() {{.*}} [[DFLT_ATTR:#[0-9]+]]
+fn instrument_default() {}
+
+#[no_mangle]
+#[instrument_fn = "off"]
+// CHECK: define {{.*}}void @instrument_off() {{.*}} [[OFF_ATTR:#[0-9]+]]
+fn instrument_off() {}
+
+#[no_mangle]
+#[instrument_fn = "on"]
+// MCOUNT: define {{.*}}void @instrument_on() {{.*}} [[DFLT_ATTR]]
+// XRAY: define void @instrument_on() {{.*}} [[ON_ATTR:#[0-9]+]]
+fn instrument_on() {}
+
+// MCOUNT: attributes [[DFLT_ATTR]] {{.*}} "instrument-function-entry-inlined"=
+// MCOUNT-NOT: attributes [[OFF_ATTR]] {{.*}} "instrument-function-entry-inlined"=
+
+// XRAY-NOT: attributes [[DFLT_ATTR]] {{.*}} "function-instrument"="xray-always"
+// XRAY-NOT: attributes [[DFLT_ATTR]] {{.*}} "function-instrument"="xray-never"
+// XRAY-NOT: attributes [[DFLT_ATTR]] {{.*}} "xray-skip-exit"
+// XRAY-NOT: attributes [[DFLT_ATTR]] {{.*}} "xray-skip-entry"
+
+// XRAY-NOT: attributes [[OFF_ATTR]] {{.*}} "function-instrument"="xray-always"
+// XRAY:     attributes [[OFF_ATTR]] {{.*}} "function-instrument"="xray-never"
+// XRAY-NOT: attributes [[OFF_ATTR]] {{.*}} "xray-skip-exit"
+// XRAY-NOT: attributes [[OFF_ATTR]] {{.*}} "xray-skip-entry"
+
+// XRAY:     attributes [[ON_ATTR]] {{.*}} "function-instrument"="xray-always"
+// XRAY-NOT: attributes [[ON_ATTR]] {{.*}} "function-instrument"="xray-never"
+// XRAY-NOT: attributes [[ON_ATTR]] {{.*}} "xray-skip-exit"
+// XRAY-NOT: attributes [[ON_ATTR]] {{.*}} "xray-skip-entry"

--- a/tests/ui/attributes/instrument_fn.rs
+++ b/tests/ui/attributes/instrument_fn.rs
@@ -1,0 +1,51 @@
+#![feature(instrument_fn)]
+#![instrument_fn = "off"] //~ ERROR attribute cannot be used on
+
+#[instrument_fn = "on"] //~ ERROR attribute cannot be used on
+struct F;
+
+#[instrument_fn = "on"] //~ ERROR attribute cannot be used on
+mod module {}
+
+#[instrument_fn = "on"] //~ ERROR attribute cannot be used on
+impl F {
+    #[instrument_fn = "off"]
+    fn no_instrument_fn(self, x: u32) -> u32 {
+        #[instrument_fn = "off"] //~ ERROR attribute cannot be used on
+        //~^ ERROR attributes on expressions are experimental
+        x * 2
+    }
+}
+
+#[instrument_fn = "off"] //~ ERROR attribute cannot be used on
+trait Foo {
+    #[instrument_fn = "off"] //~ ERROR attribute cannot be used on
+    fn bar();
+
+    #[instrument_fn = "off"]
+    fn baz() {}
+}
+
+impl Foo for F {
+    #[instrument_fn = "off"]
+    fn bar() {}
+}
+
+#[instrument_fn = "on"]
+fn main() {}
+
+#[instrument_fn(entry = "on")] //~ ERROR malformed
+fn instrument_fn_list() {}
+
+#[instrument_fn] //~ ERROR malformed
+fn instrument_fn_noarg() {}
+
+#[instrument_fn = 1] //~ ERROR malformed
+fn instrument_fn_invalid_opt() {}
+
+fn instrument_closure() {
+    let _x = #[instrument_fn = "on"]
+    || {};
+    //~^^ ERROR attribute cannot be used on
+    //~^^^ ERROR attributes on expressions are experimental
+}

--- a/tests/ui/attributes/instrument_fn.stderr
+++ b/tests/ui/attributes/instrument_fn.stderr
@@ -1,0 +1,127 @@
+error[E0658]: attributes on expressions are experimental
+  --> $DIR/instrument_fn.rs:14:9
+   |
+LL |         #[instrument_fn = "off"]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
+   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: attributes on expressions are experimental
+  --> $DIR/instrument_fn.rs:47:14
+   |
+LL |     let _x = #[instrument_fn = "on"]
+   |              ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
+   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: `#[instrument_fn]` attribute cannot be used on crates
+  --> $DIR/instrument_fn.rs:2:1
+   |
+LL | #![instrument_fn = "off"]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[instrument_fn]` can only be applied to functions
+
+error: `#[instrument_fn]` attribute cannot be used on structs
+  --> $DIR/instrument_fn.rs:4:1
+   |
+LL | #[instrument_fn = "on"]
+   | ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[instrument_fn]` can only be applied to functions
+
+error: `#[instrument_fn]` attribute cannot be used on modules
+  --> $DIR/instrument_fn.rs:7:1
+   |
+LL | #[instrument_fn = "on"]
+   | ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[instrument_fn]` can only be applied to functions
+
+error: `#[instrument_fn]` attribute cannot be used on inherent impl blocks
+  --> $DIR/instrument_fn.rs:10:1
+   |
+LL | #[instrument_fn = "on"]
+   | ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[instrument_fn]` can only be applied to functions
+
+error: `#[instrument_fn]` attribute cannot be used on expressions
+  --> $DIR/instrument_fn.rs:14:9
+   |
+LL |         #[instrument_fn = "off"]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[instrument_fn]` can only be applied to functions
+
+error: `#[instrument_fn]` attribute cannot be used on traits
+  --> $DIR/instrument_fn.rs:20:1
+   |
+LL | #[instrument_fn = "off"]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[instrument_fn]` can only be applied to functions
+
+error: `#[instrument_fn]` attribute cannot be used on required trait methods
+  --> $DIR/instrument_fn.rs:22:5
+   |
+LL |     #[instrument_fn = "off"]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[instrument_fn]` can only be applied to functions with a body
+
+error[E0805]: malformed `instrument_fn` attribute input
+  --> $DIR/instrument_fn.rs:37:1
+   |
+LL | #[instrument_fn(entry = "on")]
+   | ^^^^^^^^^^^^^^^--------------^
+   |                |
+   |                expected a single argument here
+   |
+help: must be of the form
+   |
+LL - #[instrument_fn(entry = "on")]
+LL + #[instrument_fn = "on|off"]
+   |
+
+error[E0539]: malformed `instrument_fn` attribute input
+  --> $DIR/instrument_fn.rs:40:1
+   |
+LL | #[instrument_fn]
+   | ^^^^^^^^^^^^^^^^ valid arguments are "on" or "off"
+   |
+help: must be of the form
+   |
+LL | #[instrument_fn = "on|off"]
+   |                 ++++++++++
+
+error[E0539]: malformed `instrument_fn` attribute input
+  --> $DIR/instrument_fn.rs:43:1
+   |
+LL | #[instrument_fn = 1]
+   | ^^^^^^^^^^^^^^^^^^-^
+   |                   |
+   |                   valid arguments are "on" or "off"
+   |
+help: must be of the form
+   |
+LL - #[instrument_fn = 1]
+LL + #[instrument_fn = "on|off"]
+   |
+
+error: `#[instrument_fn]` attribute cannot be used on closures
+  --> $DIR/instrument_fn.rs:47:14
+   |
+LL |     let _x = #[instrument_fn = "on"]
+   |              ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[instrument_fn]` can be applied to functions and methods
+
+error: aborting due to 13 previous errors
+
+Some errors have detailed explanations: E0539, E0658, E0805.
+For more information about an error, try `rustc --explain E0539`.

--- a/tests/ui/feature-gates/feature-gate-instrument-fn.rs
+++ b/tests/ui/feature-gates/feature-gate-instrument-fn.rs
@@ -1,0 +1,13 @@
+//@ add-minicore
+//@ compile-flags: --crate-type=rlib
+#![no_core]
+#![feature(no_core)]
+
+extern crate minicore;
+use minicore::*;
+
+#[instrument_fn = "on"] //~ ERROR attribute is an experimental feature
+fn instrumented_fn() {}
+
+#[instrument_fn = "off"] //~ ERROR attribute is an experimental feature
+fn not_instrumented_fn() {}

--- a/tests/ui/feature-gates/feature-gate-instrument-fn.stderr
+++ b/tests/ui/feature-gates/feature-gate-instrument-fn.stderr
@@ -1,0 +1,23 @@
+error[E0658]: the `#[instrument_fn]` attribute is an experimental feature
+  --> $DIR/feature-gate-instrument-fn.rs:9:1
+   |
+LL | #[instrument_fn = "on"]
+   | ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #157081 <https://github.com/rust-lang/rust/issues/157081> for more information
+   = help: add `#![feature(instrument_fn)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: the `#[instrument_fn]` attribute is an experimental feature
+  --> $DIR/feature-gate-instrument-fn.rs:12:1
+   |
+LL | #[instrument_fn = "off"]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #157081 <https://github.com/rust-lang/rust/issues/157081> for more information
+   = help: add `#![feature(instrument_fn)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0658`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/157681)*
<!-- homu-ignore:end -->

This attribute enables or disables function instrumentation when using `-Zinstrument-xray` or `-Zinstrument-mcount`.

It supports the following usage:

`#[instrument_fn = "on|off"]`

For XRay, "on" is equivalent to always instrument, and "off" is equivalent to never instrumenting.

For mcount, "on" has no effect. "off" disables instrumentation of the function.

This is tracked by rust-lang/rust#157081, and related to the pending rfc rust-lang/rfcs#3917, and earlier as part mcp rust-lang/compiler-team#561
