### PR TITLE
Clarify that pointers are not always compared by their addresses

### DIFF
--- a/library/core/src/ptr/const_ptr.rs
+++ b/library/core/src/ptr/const_ptr.rs
@@ -1584,7 +1584,12 @@ impl<T, const N: usize> *const [T; N] {
     }
 }
 
-/// Pointer equality is by address, as produced by the [`<*const T>::addr`](pointer::addr) method.
+/// Pointers to [`Sized`] types are compared by their addresses, as produced by the
+/// [`<*const T>::addr`](pointer::addr) method.
+/// Pointers to [dynamically sized types] additionally have their metadata compared.
+/// See [`core::ptr::eq`] for more information about metadata comparisons.
+///
+/// [dynamically sized types]: https://doc.rust-lang.org/reference/dynamically-sized-types.html
 #[stable(feature = "rust1", since = "1.0.0")]
 #[diagnostic::on_const(
     message = "pointers cannot be reliably compared during const eval",
@@ -1606,7 +1611,12 @@ impl<T: PointeeSized> PartialEq for *const T {
 )]
 impl<T: PointeeSized> Eq for *const T {}
 
-/// Pointer comparison is by address, as produced by the `[`<*const T>::addr`](pointer::addr)` method.
+/// Pointers to [`Sized`] types are compared by their addresses, as produced by the
+/// [`<*const T>::addr`](pointer::addr) method.
+/// Pointers to [dynamically sized types] additionally have their metadata compared.
+/// See [`core::ptr::eq`] for more information about metadata comparisons.
+///
+/// [dynamically sized types]: https://doc.rust-lang.org/reference/dynamically-sized-types.html
 #[stable(feature = "rust1", since = "1.0.0")]
 #[diagnostic::on_const(
     message = "pointers cannot be reliably compared during const eval",
@@ -1626,7 +1636,12 @@ impl<T: PointeeSized> Ord for *const T {
     }
 }
 
-/// Pointer comparison is by address, as produced by the `[`<*const T>::addr`](pointer::addr)` method.
+/// Pointers to [`Sized`] types are compared by their addresses, as produced by the
+/// [`<*const T>::addr`](pointer::addr) method.
+/// Pointers to [dynamically sized types] additionally have their metadata compared.
+/// See [`core::ptr::eq`] for more information about metadata comparisons.
+///
+/// [dynamically sized types]: https://doc.rust-lang.org/reference/dynamically-sized-types.html
 #[stable(feature = "rust1", since = "1.0.0")]
 #[diagnostic::on_const(
     message = "pointers cannot be reliably compared during const eval",

--- a/library/core/src/ptr/mut_ptr.rs
+++ b/library/core/src/ptr/mut_ptr.rs
@@ -2025,7 +2025,12 @@ impl<T, const N: usize> *mut [T; N] {
     }
 }
 
-/// Pointer equality is by address, as produced by the [`<*mut T>::addr`](pointer::addr) method.
+/// Pointers to [`Sized`] types are compared by their addresses, as produced by the
+/// [`<*mut T>::addr`](pointer::addr) method.
+/// Pointers to [dynamically sized types] additionally have their metadata compared.
+/// See [`core::ptr::eq`] for more information about metadata comparisons.
+///
+/// [dynamically sized types]: https://doc.rust-lang.org/reference/dynamically-sized-types.html
 #[stable(feature = "rust1", since = "1.0.0")]
 #[diagnostic::on_const(
     message = "pointers cannot be reliably compared during const eval",
@@ -2047,7 +2052,12 @@ impl<T: PointeeSized> PartialEq for *mut T {
 )]
 impl<T: PointeeSized> Eq for *mut T {}
 
-/// Pointer comparison is by address, as produced by the [`<*mut T>::addr`](pointer::addr) method.
+/// Pointers to [`Sized`] types are compared by their addresses, as produced by the
+/// [`<*mut T>::addr`](pointer::addr) method.
+/// Pointers to [dynamically sized types] additionally have their metadata compared.
+/// See [`core::ptr::eq`] for more information about metadata comparisons.
+///
+/// [dynamically sized types]: https://doc.rust-lang.org/reference/dynamically-sized-types.html
 #[stable(feature = "rust1", since = "1.0.0")]
 #[diagnostic::on_const(
     message = "pointers cannot be reliably compared during const eval",
@@ -2067,7 +2077,12 @@ impl<T: PointeeSized> Ord for *mut T {
     }
 }
 
-/// Pointer comparison is by address, as produced by the [`<*mut T>::addr`](pointer::addr) method.
+/// Pointers to [`Sized`] types are compared by their addresses, as produced by the
+/// [`<*mut T>::addr`](pointer::addr) method.
+/// Pointers to [dynamically sized types] additionally have their metadata compared.
+/// See [`core::ptr::eq`] for more information about metadata comparisons.
+///
+/// [dynamically sized types]: https://doc.rust-lang.org/reference/dynamically-sized-types.html
 #[stable(feature = "rust1", since = "1.0.0")]
 #[diagnostic::on_const(
     message = "pointers cannot be reliably compared during const eval",

--- a/library/core/src/ptr/non_null.rs
+++ b/library/core/src/ptr/non_null.rs
@@ -1642,6 +1642,12 @@ impl<T: PointeeSized> fmt::Pointer for NonNull<T> {
 #[stable(feature = "nonnull", since = "1.25.0")]
 impl<T: PointeeSized> Eq for NonNull<T> {}
 
+/// Pointers to [`Sized`] types are compared by their addresses, as produced by the
+/// [`NonNull::addr`] method.
+/// Pointers to [dynamically sized types] additionally have their metadata compared.
+/// See [`core::ptr::eq`] for more information about metadata comparisons.
+///
+/// [dynamically sized types]: https://doc.rust-lang.org/reference/dynamically-sized-types.html
 #[stable(feature = "nonnull", since = "1.25.0")]
 impl<T: PointeeSized> PartialEq for NonNull<T> {
     #[inline]
@@ -1651,6 +1657,12 @@ impl<T: PointeeSized> PartialEq for NonNull<T> {
     }
 }
 
+/// Pointers to [`Sized`] types are compared by their addresses, as produced by the
+/// [`NonNull::addr`] method.
+/// Pointers to [dynamically sized types] additionally have their metadata compared.
+/// See [`core::ptr::eq`] for more information about metadata comparisons.
+///
+/// [dynamically sized types]: https://doc.rust-lang.org/reference/dynamically-sized-types.html
 #[stable(feature = "nonnull", since = "1.25.0")]
 impl<T: PointeeSized> Ord for NonNull<T> {
     #[inline]
@@ -1660,6 +1672,12 @@ impl<T: PointeeSized> Ord for NonNull<T> {
     }
 }
 
+/// Pointers to [`Sized`] types are compared by their addresses, as produced by the
+/// [`NonNull::addr`] method.
+/// Pointers to [dynamically sized types] additionally have their metadata compared.
+/// See [`core::ptr::eq`] for more information about metadata comparisons.
+///
+/// [dynamically sized types]: https://doc.rust-lang.org/reference/dynamically-sized-types.html
 #[stable(feature = "nonnull", since = "1.25.0")]
 impl<T: PointeeSized> PartialOrd for NonNull<T> {
     #[inline]


### PR DESCRIPTION
This makes the doc comments on pointer types correctly clarify that for fat pointers, their metadata is compared as well for equality and ordering operations.  Additionally adds this documentation to the `NonNull` type.  This makes the documentation match the [reference](https://doc.rust-lang.org/beta/reference/types/pointer.html#r-type.pointer.raw.cmp)

Fixes rust-lang/rust#157640
Supersedes rust-lang/rust#136364 which missed this qualification