### PR TITLE
Create experimental test job `aarch64-apple-macos-26` for evaluating `macos-26` runner images

### DIFF
--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -26,6 +26,10 @@ runners:
     os: macos-15 # macOS 15 Arm64
     <<: *base-job
 
+  - &job-macos-26
+    os: macos-26 # macOS 26 Arm64
+    <<: *base-job
+
   - &job-windows
     os: windows-2025
     <<: *base-job

--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -559,6 +559,28 @@ auto:
       MACOSX_STD_DEPLOYMENT_TARGET: 11.0
     <<: *job-macos-15
 
+  # EXPERIMENT(#157687): we will try to run `aarch64-apple`-equivalent workload
+  # on `macos-26` runner images in parallel to evaluate the running times, since
+  # previous attempts have timed out multiple times. Remove/revert this job if
+  # this hangs or times out, or if it becomes the slowest Merge CI job, and let
+  # T-infra know.
+  - name: aarch64-apple-macos-26
+    doc_url: https://github.com/rust-lang/rust/issues/157687
+    env:
+      SCRIPT: >
+        ./x.py --stage 2 test --host=aarch64-apple-darwin --target=aarch64-apple-darwin &&
+        ./x.py --stage 2 test --host=aarch64-apple-darwin --target=aarch64-apple-darwin src/tools/cargo
+      RUST_CONFIGURE_ARGS: >-
+        --enable-sanitizers
+        --enable-profiler
+        --set rust.jemalloc
+      DEVELOPER_DIR: /Applications/Xcode_26.2.app/Contents/Developer
+      # Aarch64 tooling only needs to support macOS 11.0 and up as nothing else
+      # supports the hardware, so only need to test it there.
+      MACOSX_DEPLOYMENT_TARGET: 11.0
+      MACOSX_STD_DEPLOYMENT_TARGET: 11.0
+    <<: *job-macos-26
+
   ######################
   #  Windows Builders  #
   ######################

--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -22,7 +22,7 @@ runners:
     os: ubuntu-24.04-16core-64gb
     <<: *base-job
 
-  - &job-macos
+  - &job-macos-15
     os: macos-15 # macOS 15 Arm64
     <<: *base-job
 
@@ -476,7 +476,7 @@ auto:
       DEVELOPER_DIR: /Applications/Xcode_26.2.app/Contents/Developer
       DIST_REQUIRE_ALL_TOOLS: 1
       CODEGEN_BACKENDS: llvm,cranelift
-    <<: *job-macos
+    <<: *job-macos-15
 
   - name: dist-apple-various
     env:
@@ -513,7 +513,7 @@ auto:
       MACOSX_DEPLOYMENT_TARGET: 10.12
       MACOSX_STD_DEPLOYMENT_TARGET: 10.12
       DEVELOPER_DIR: /Applications/Xcode_26.2.app/Contents/Developer
-    <<: *job-macos
+    <<: *job-macos-15
 
   - name: dist-aarch64-apple
     env:
@@ -537,7 +537,7 @@ auto:
       DEVELOPER_DIR: /Applications/Xcode_26.2.app/Contents/Developer
       DIST_REQUIRE_ALL_TOOLS: 1
       CODEGEN_BACKENDS: llvm,cranelift
-    <<: *job-macos
+    <<: *job-macos-15
 
   - name: aarch64-apple
     env:
@@ -553,7 +553,7 @@ auto:
       # supports the hardware, so only need to test it there.
       MACOSX_DEPLOYMENT_TARGET: 11.0
       MACOSX_STD_DEPLOYMENT_TARGET: 11.0
-    <<: *job-macos
+    <<: *job-macos-15
 
   ######################
   #  Windows Builders  #


### PR DESCRIPTION
## Summary

Add a new experimental `aarch64-apple-macos-26` test job which runs `aarch64-apple`-equivalent workloads on `macos-26` runner image, to evalute the running time of using `macos-26` runner images over multiple Merge CI runs.

This experiment is tracked by rust-lang/rust#157687.

> [!NOTE]
>
> If this test job hangs, times out, becomes the new slowest job, or produces other issues, please revert this PR and let @jieyouxu know.

## Additional context

See:

* https://github.com/rust-lang/rust/issues/157687
* [#t-infra > GHA macos-26 slowness](https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/GHA.20macos-26.20slowness/with/601617248)

r? infra-ci