### PR TITLE
Don't emit `unused_parens` suggestion for proc-macro-synthesized parens around bounds

### DIFF
--- a/compiler/rustc_lint/src/unused.rs
+++ b/compiler/rustc_lint/src/unused.rs
@@ -937,21 +937,28 @@ impl EarlyLintPass for UnusedParens {
                             && !dyn2015_exception
                         {
                             let s = poly_trait_ref.span;
-                            let spans = (!s.from_expansion()).then(|| {
-                                (
+                            // Check that the span really is wrapped in single-byte ASCII parens
+                            // before trimming a byte off each end, in case a macro does weird
+                            // things with spans or parser recovery produced multibyte parens.
+                            if !s.from_expansion()
+                                && let Ok(snippet) = cx.sess().source_map().span_to_snippet(s)
+                                && snippet.starts_with('(')
+                                && snippet.ends_with(')')
+                            {
+                                let spans = Some((
                                     s.with_hi(s.lo() + rustc_span::BytePos(1)),
                                     s.with_lo(s.hi() - rustc_span::BytePos(1)),
-                                )
-                            });
+                                ));
 
-                            self.emit_unused_delims(
-                                cx,
-                                poly_trait_ref.span,
-                                spans,
-                                "type",
-                                (false, false),
-                                false,
-                            );
+                                self.emit_unused_delims(
+                                    cx,
+                                    poly_trait_ref.span,
+                                    spans,
+                                    "type",
+                                    (false, false),
+                                    false,
+                                );
+                            }
                         }
                     }
                 }

--- a/tests/ui/lint/unused/auxiliary/unused-parens-bound-proc-macro.rs
+++ b/tests/ui/lint/unused/auxiliary/unused-parens-bound-proc-macro.rs
@@ -1,0 +1,32 @@
+extern crate proc_macro;
+
+use proc_macro::{Group, Span, TokenStream, TokenTree};
+
+// Recursively overwrite the span of every token (including group delimiters)
+// with `span`.
+fn respan(span: Span, stream: TokenStream) -> TokenStream {
+    stream
+        .into_iter()
+        .map(|tt| match tt {
+            TokenTree::Group(group) => {
+                let mut group = Group::new(group.delimiter(), respan(span, group.stream()));
+                group.set_span(span);
+                TokenTree::Group(group)
+            }
+            mut tt => {
+                tt.set_span(span);
+                tt
+            }
+        })
+        .collect()
+}
+
+/// Emits `const _: &dyn (Send) = &();` with every token carrying the span of the
+/// macro's first input token. The parenthesized trait-object bound is therefore
+/// reported at a span that does not actually contain parentheses in the source.
+#[proc_macro]
+pub fn emit_parenthesized_bound(input: TokenStream) -> TokenStream {
+    let span = input.into_iter().next().unwrap().span();
+    let code: TokenStream = "const _: &dyn (Send) = &();".parse().unwrap();
+    respan(span, code)
+}

--- a/tests/ui/lint/unused/unused-parens-trait-obj-proc-macro-144378.rs
+++ b/tests/ui/lint/unused/unused-parens-trait-obj-proc-macro-144378.rs
@@ -1,0 +1,25 @@
+//@ check-pass
+//@ edition: 2021
+//@ proc-macro: unused-parens-bound-proc-macro.rs
+
+// Regression test for #144378.
+//
+// A proc-macro can synthesize parentheses around a trait-object bound while
+// reusing a span from its input. That span does not actually point at the
+// parentheses, so the `unused_parens` lint must not blindly trim its first and
+// last byte: doing so produced an invalid suggestion (e.g. turning a field
+// `val: u8` into `al: u`) and, when the reused span started or ended on a
+// multibyte character, ICEd by slicing through that character.
+
+#![deny(unused_parens)]
+#![allow(uncommon_codepoints)]
+
+extern crate unused_parens_bound_proc_macro;
+
+// The generated `&dyn (Send)` reuses the span of the identifier `é`, whose
+// first byte is the start of a two-byte character. Before the fix, trimming one
+// byte off the front of that span sliced through `é` and ICEd; now the lint is
+// skipped because the source span is not wrapped in parentheses.
+unused_parens_bound_proc_macro::emit_parenthesized_bound!(é);
+
+fn main() {}


### PR DESCRIPTION
Supersedes rust-lang/rust#157662, which got auto closed after I force pushed the branch and github won't let me reopen it. Fixes rust-lang/rust#144378.

When the unused_parens lint removes the parentheses around a trait bound, it assumed the bound's span starts and ends with those parentheses, so it just trimmed one byte off each end to build the suggestion. That isn't always true. A proc macro can give the bound a span that doesn't point at parentheses at all, and then trimming a byte produces a broken suggestion, or crashes when that byte lands in the middle of a multibyte character.

So now we only remove the parens when the source text at that span actually starts with `(` and ends with `)`. That also handles the unicode parens case you mentioned, since `（` isn't an ASCII `(` and just gets skipped.

I added a test that reproduces the crash with a proc macro.

r? @mejrs
