### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/archive.rs
+++ b/compiler/rustc_codegen_ssa/src/back/archive.rs
@@ -1,18 +1,16 @@
+use std::env;
 use std::error::Error;
 use std::ffi::OsString;
 use std::fs::{self, File};
 use std::io::{self, BufWriter, Write};
 use std::path::{Path, PathBuf};
-use std::{env, mem};
 
 use ar_archive_writer::{
     ArchiveKind, COFFShortExport, MachineTypes, NewArchiveMember, write_archive_to_stream,
 };
 pub use ar_archive_writer::{DEFAULT_OBJECT_READER, ObjectReader};
 use object::read::archive::{ArchiveFile, ArchiveKind as ObjectArchiveKind};
-use object::read::elf::Sym as _;
-use object::read::macho::{FatArch, Nlist};
-use object::{Endianness, elf, macho};
+use object::read::macho::FatArch;
 use rustc_data_structures::fx::{FxHashSet, FxIndexSet};
 use rustc_data_structures::memmap::Mmap;
 use rustc_fs_util::TempDirBuilder;
@@ -24,6 +22,7 @@ use tracing::trace;
 
 use super::metadata::{create_compressed_metadata_file, search_for_section};
 use super::rmeta_link;
+use super::symbol_edit::apply_hide;
 use crate::common;
 // Public for ArchiveBuilderBuilder::extract_bundled_libs
 pub use crate::errors::ExtractBundledLibsError;
@@ -670,154 +669,4 @@ impl<'a> ArArchiveBuilder<'a> {
 
 fn io_error_context(context: &str, err: io::Error) -> io::Error {
     io::Error::new(io::ErrorKind::Other, format!("{context}: {err}"))
-}
-
-// We use the `object` crate for the read-only pass over ELF/Mach-O object files
-// because its `Sym`/`Nlist` traits provide clean access to symbol properties without
-// manual byte parsing. However, `object` does not expose mutable views into the data,
-// so we cannot use it to modify symbol fields in place. Instead, the read-only pass
-// collects byte-level patches (offset + new value), and the write pass
-// (`apply_patches`) applies them to a copy of the byte buffer without any ELF/Mach-O
-// parsing — similar to how linker relocations work.
-
-/// A byte-level patch collected in the read-only pass and applied in the write pass.
-struct Patch {
-    offset: usize,
-    value: u8,
-}
-
-/// Apply a list of byte patches to `data`, returning the (possibly modified) bytes.
-fn apply_patches(data: &[u8], patches: &[Patch]) -> Vec<u8> {
-    let mut buf = data.to_vec();
-    for p in patches {
-        buf[p.offset] = p.value;
-    }
-    buf
-}
-
-// ---------------------------------------------------------------------------
-// ELF hide – read-only pass uses `object` crate, write pass uses `Patch` list
-// ---------------------------------------------------------------------------
-
-fn elf_hide_patches_impl<'data, Elf: object::read::elf::FileHeader<Endian = Endianness>>(
-    data: &'data [u8],
-    st_other_offset: usize,
-    exported: &FxHashSet<String>,
-) -> Option<Vec<Patch>>
-where
-    u64: From<Elf::Word>,
-{
-    let header = Elf::parse(data).ok()?;
-    let endian = header.endian().ok()?;
-    let sections = header.sections(endian, data).ok()?;
-    let symtab = sections.symbols(endian, data, elf::SHT_SYMTAB).ok()?;
-
-    let data_ptr = data.as_ptr() as usize;
-    let strings = symtab.strings();
-    let mut patches = Vec::new();
-
-    for sym in symtab.iter() {
-        let binding = sym.st_bind();
-        if binding != elf::STB_GLOBAL && binding != elf::STB_WEAK {
-            continue;
-        }
-        if sym.is_undefined(endian) {
-            continue;
-        }
-        let Ok(name_bytes) = sym.name(endian, strings) else { continue };
-        let Ok(name) = str::from_utf8(name_bytes) else { continue };
-        if !exported.contains(name) {
-            let sym_addr = sym as *const Elf::Sym as usize;
-            let offset = sym_addr - data_ptr + st_other_offset;
-            let new_vis = (sym.st_other() & !0x03) | elf::STV_HIDDEN;
-            patches.push(Patch { offset, value: new_vis });
-        }
-    }
-
-    Some(patches)
-}
-
-// ---------------------------------------------------------------------------
-// Mach-O hide – same architecture: read-only pass via `object`, write via patches
-// ---------------------------------------------------------------------------
-
-fn macho_hide_patches_impl<'data, Mach: object::read::macho::MachHeader<Endian = Endianness>>(
-    data: &'data [u8],
-    n_type_offset: usize,
-    exported: &FxHashSet<String>,
-) -> Option<Vec<Patch>> {
-    let header = Mach::parse(data, 0).ok()?;
-    let endian = header.endian().ok()?;
-    let mut commands = header.load_commands(endian, data, 0).ok()?;
-
-    let symtab_cmd = loop {
-        let cmd = commands.next().ok()??;
-        if let Some(st) = cmd.symtab().ok().flatten() {
-            break st;
-        }
-    };
-    let symtab: object::read::macho::SymbolTable<'_, Mach, &_> =
-        symtab_cmd.symbols(endian, data).ok()?;
-
-    let data_ptr = data.as_ptr() as usize;
-    let strings = symtab.strings();
-    let mut patches = Vec::new();
-
-    for nlist in symtab.iter() {
-        if nlist.is_stab() {
-            continue;
-        }
-        if nlist.is_undefined() {
-            continue;
-        }
-        if nlist.n_type() & macho::N_EXT == 0 {
-            continue;
-        }
-        let Ok(name_bytes) = nlist.name(endian, strings) else { continue };
-        let Ok(name) = str::from_utf8(name_bytes) else { continue };
-        let name = name.strip_prefix('_').unwrap_or(name);
-        if !exported.contains(name) {
-            let nlist_addr = nlist as *const Mach::Nlist as usize;
-            let offset = nlist_addr - data_ptr + n_type_offset;
-            patches.push(Patch { offset, value: nlist.n_type() | macho::N_PEXT });
-        }
-    }
-
-    Some(patches)
-}
-
-// ---------------------------------------------------------------------------
-// Unified dispatch: top-level detection via `object::File::parse`
-// ---------------------------------------------------------------------------
-
-fn hide_patches(data: &[u8], exported: &FxHashSet<String>) -> Option<Vec<Patch>> {
-    let file = object::File::parse(data).ok()?;
-    match file {
-        object::File::Elf64(_) => elf_hide_patches_impl::<elf::FileHeader64<Endianness>>(
-            data,
-            mem::offset_of!(elf::Sym64<Endianness>, st_other),
-            exported,
-        ),
-        object::File::Elf32(_) => elf_hide_patches_impl::<elf::FileHeader32<Endianness>>(
-            data,
-            mem::offset_of!(elf::Sym32<Endianness>, st_other),
-            exported,
-        ),
-        object::File::MachO64(_) => macho_hide_patches_impl::<macho::MachHeader64<Endianness>>(
-            data,
-            mem::offset_of!(macho::Nlist64<Endianness>, n_type),
-            exported,
-        ),
-        object::File::MachO32(_) => macho_hide_patches_impl::<macho::MachHeader32<Endianness>>(
-            data,
-            mem::offset_of!(macho::Nlist32<Endianness>, n_type),
-            exported,
-        ),
-        _ => None,
-    }
-}
-
-fn apply_hide(data: &[u8], exported: &FxHashSet<String>) -> Vec<u8> {
-    let patches = hide_patches(data, exported).unwrap_or_default();
-    apply_patches(data, &patches)
 }

--- a/compiler/rustc_codegen_ssa/src/back/mod.rs
+++ b/compiler/rustc_codegen_ssa/src/back/mod.rs
@@ -11,6 +11,7 @@ pub mod lto;
 pub mod metadata;
 pub mod rmeta_link;
 pub(crate) mod rpath;
+mod symbol_edit;
 pub mod symbol_export;
 pub mod write;
 

--- a/compiler/rustc_codegen_ssa/src/back/symbol_edit.rs
+++ b/compiler/rustc_codegen_ssa/src/back/symbol_edit.rs
@@ -1,0 +1,156 @@
+// We use the `object` crate for the read-only pass over ELF/Mach-O object files
+// because its `Sym`/`Nlist` traits provide clean access to symbol properties without
+// manual byte parsing. However, `object` does not expose mutable views into the data,
+// so we cannot use it to modify symbol fields in place. Instead, the read-only pass
+// collects byte-level patches (offset + new value), and the write pass
+// (`apply_patches`) applies them to a copy of the byte buffer without any ELF/Mach-O
+// parsing — similar to how linker relocations work.
+
+use std::mem;
+
+use object::read::elf::Sym as _;
+use object::read::macho::Nlist;
+use object::{Endianness, elf, macho};
+use rustc_data_structures::fx::FxHashSet;
+
+/// A byte-level patch collected in the read-only pass and applied in the write pass.
+struct Patch {
+    offset: usize,
+    value: u8,
+}
+
+/// Apply a list of byte patches to `data`, returning the (possibly modified) bytes.
+fn apply_patches(data: &[u8], patches: &[Patch]) -> Vec<u8> {
+    let mut buf = data.to_vec();
+    for p in patches {
+        buf[p.offset] = p.value;
+    }
+    buf
+}
+
+// ---------------------------------------------------------------------------
+// ELF hide – read-only pass uses `object` crate, write pass uses `Patch` list
+// ---------------------------------------------------------------------------
+
+fn elf_hide_patches_impl<'data, Elf: object::read::elf::FileHeader<Endian = Endianness>>(
+    data: &'data [u8],
+    st_other_offset: usize,
+    exported: &FxHashSet<String>,
+) -> Option<Vec<Patch>>
+where
+    u64: From<Elf::Word>,
+{
+    let header = Elf::parse(data).ok()?;
+    let endian = header.endian().ok()?;
+    let sections = header.sections(endian, data).ok()?;
+    let symtab = sections.symbols(endian, data, elf::SHT_SYMTAB).ok()?;
+
+    let data_ptr = data.as_ptr() as usize;
+    let strings = symtab.strings();
+    let mut patches = Vec::new();
+
+    for sym in symtab.iter() {
+        let binding = sym.st_bind();
+        if binding != elf::STB_GLOBAL && binding != elf::STB_WEAK {
+            continue;
+        }
+        if sym.is_undefined(endian) {
+            continue;
+        }
+        let Ok(name_bytes) = sym.name(endian, strings) else { continue };
+        let Ok(name) = str::from_utf8(name_bytes) else { continue };
+        if !exported.contains(name) {
+            let sym_addr = sym as *const Elf::Sym as usize;
+            let offset = sym_addr - data_ptr + st_other_offset;
+            let new_vis = (sym.st_other() & !0x03) | elf::STV_HIDDEN;
+            patches.push(Patch { offset, value: new_vis });
+        }
+    }
+
+    Some(patches)
+}
+
+// ---------------------------------------------------------------------------
+// Mach-O hide – same architecture: read-only pass via `object`, write via patches
+// ---------------------------------------------------------------------------
+
+fn macho_hide_patches_impl<'data, Mach: object::read::macho::MachHeader<Endian = Endianness>>(
+    data: &'data [u8],
+    n_type_offset: usize,
+    exported: &FxHashSet<String>,
+) -> Option<Vec<Patch>> {
+    let header = Mach::parse(data, 0).ok()?;
+    let endian = header.endian().ok()?;
+    let mut commands = header.load_commands(endian, data, 0).ok()?;
+
+    let symtab_cmd = loop {
+        let cmd = commands.next().ok()??;
+        if let Some(st) = cmd.symtab().ok().flatten() {
+            break st;
+        }
+    };
+    let symtab: object::read::macho::SymbolTable<'_, Mach, &_> =
+        symtab_cmd.symbols(endian, data).ok()?;
+
+    let data_ptr = data.as_ptr() as usize;
+    let strings = symtab.strings();
+    let mut patches = Vec::new();
+
+    for nlist in symtab.iter() {
+        if nlist.is_stab() {
+            continue;
+        }
+        if nlist.is_undefined() {
+            continue;
+        }
+        if nlist.n_type() & macho::N_EXT == 0 {
+            continue;
+        }
+        let Ok(name_bytes) = nlist.name(endian, strings) else { continue };
+        let Ok(name) = str::from_utf8(name_bytes) else { continue };
+        let name = name.strip_prefix('_').unwrap_or(name);
+        if !exported.contains(name) {
+            let nlist_addr = nlist as *const Mach::Nlist as usize;
+            let offset = nlist_addr - data_ptr + n_type_offset;
+            patches.push(Patch { offset, value: nlist.n_type() | macho::N_PEXT });
+        }
+    }
+
+    Some(patches)
+}
+
+// ---------------------------------------------------------------------------
+// Unified dispatch: top-level detection via `object::File::parse`
+// ---------------------------------------------------------------------------
+
+fn hide_patches(data: &[u8], exported: &FxHashSet<String>) -> Option<Vec<Patch>> {
+    let file = object::File::parse(data).ok()?;
+    match file {
+        object::File::Elf64(_) => elf_hide_patches_impl::<elf::FileHeader64<Endianness>>(
+            data,
+            mem::offset_of!(elf::Sym64<Endianness>, st_other),
+            exported,
+        ),
+        object::File::Elf32(_) => elf_hide_patches_impl::<elf::FileHeader32<Endianness>>(
+            data,
+            mem::offset_of!(elf::Sym32<Endianness>, st_other),
+            exported,
+        ),
+        object::File::MachO64(_) => macho_hide_patches_impl::<macho::MachHeader64<Endianness>>(
+            data,
+            mem::offset_of!(macho::Nlist64<Endianness>, n_type),
+            exported,
+        ),
+        object::File::MachO32(_) => macho_hide_patches_impl::<macho::MachHeader32<Endianness>>(
+            data,
+            mem::offset_of!(macho::Nlist32<Endianness>, n_type),
+            exported,
+        ),
+        _ => None,
+    }
+}
+
+pub(super) fn apply_hide(data: &[u8], exported: &FxHashSet<String>) -> Vec<u8> {
+    let patches = hide_patches(data, exported).unwrap_or_default();
+    apply_patches(data, &patches)
+}

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -1122,6 +1122,9 @@ fn should_encode_mir(
                     && reachable_set.contains(&def_id)
                     && (tcx.generics_of(def_id).requires_monomorphization(tcx)
                         || tcx.cross_crate_inlinable(def_id)));
+            // Comptime fns do not have optimized MIR at all.
+            let opt =
+                opt && !matches!(tcx.constness(def_id), hir::Constness::Const { always: true });
             // The function has a `const` modifier or is in a `const trait`.
             let is_const_fn = tcx.is_const_fn(def_id.to_def_id());
             (is_const_fn, opt)

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -1789,6 +1789,14 @@ impl<'tcx> TyCtxt<'tcx> {
                     | DefKind::Ctor(..)
                     | DefKind::AnonConst
                     | DefKind::InlineConst => self.mir_for_ctfe(def),
+                    DefKind::Fn | DefKind::AssocFn
+                        if matches!(
+                            self.constness(def),
+                            hir::Constness::Const { always: true }
+                        ) =>
+                    {
+                        self.mir_for_ctfe(def)
+                    }
                     // If the caller wants `mir_for_ctfe` of a function they should not be using
                     // `instance_mir`, so we'll assume const fn also wants the optimized version.
                     _ => self.optimized_mir(def),

--- a/compiler/rustc_mir_transform/src/cross_crate_inline.rs
+++ b/compiler/rustc_mir_transform/src/cross_crate_inline.rs
@@ -1,7 +1,7 @@
 use rustc_hir::attrs::InlineAttr;
 use rustc_hir::def::DefKind;
 use rustc_hir::def_id::LocalDefId;
-use rustc_hir::find_attr;
+use rustc_hir::{self as hir, find_attr};
 use rustc_middle::bug;
 use rustc_middle::mir::visit::Visitor;
 use rustc_middle::mir::*;
@@ -41,6 +41,12 @@ fn cross_crate_inlinable(tcx: TyCtxt<'_>, def_id: LocalDefId) -> bool {
         // bodies even when the backend would implement something better, we stop
         // the MIR inliner from ever inlining an intrinsic.
         return true;
+    }
+
+    if let hir::Constness::Const { always: true } = tcx.constness(def_id) {
+        // Comptime functions only exist during const eval and can never be passed
+        // to codegen. The const eval MIR pipeline also doesn't inline anything at all.
+        return false;
     }
 
     // Obey source annotations first; this is important because it means we can use

--- a/compiler/rustc_mir_transform/src/deduce_param_attrs.rs
+++ b/compiler/rustc_mir_transform/src/deduce_param_attrs.rs
@@ -9,6 +9,7 @@
 //! after `optimized_mir`! We check for things that are *not* guaranteed to be preserved by MIR
 //! transforms, such as which local variables happen to be mutated.
 
+use rustc_hir as hir;
 use rustc_hir::def_id::LocalDefId;
 use rustc_index::IndexVec;
 use rustc_middle::middle::deduced_param_attrs::{DeducedParamAttrs, UsageSummary};
@@ -202,6 +203,12 @@ pub(super) fn deduced_param_attrs<'tcx>(
 
     // Don't deduce any attributes for functions that have no MIR.
     if !tcx.is_mir_available(def_id) {
+        return &[];
+    }
+
+    if let hir::Constness::Const { always: true } = tcx.constness(def_id) {
+        // Comptime functions only exist during const eval and can never be passed
+        // to codegen.
         return &[];
     }
 

--- a/compiler/rustc_mir_transform/src/lib.rs
+++ b/compiler/rustc_mir_transform/src/lib.rs
@@ -511,7 +511,18 @@ fn inner_mir_for_ctfe(tcx: TyCtxt<'_>, def: LocalDefId) -> Body<'_> {
     };
 
     let mut body = remap_mir_for_const_eval_select(tcx, body, hir::Constness::Const { always });
-    pm::run_passes(tcx, &mut body, &[&ctfe_limit::CtfeLimit], None, pm::Optimizations::Allowed);
+    // FIXME(reflection): probably need to look at this for comptime closures
+    let passes: &[&dyn MirPass<'_>] = if matches!(tcx.def_kind(def), DefKind::Fn | DefKind::AssocFn)
+        && matches!(tcx.constness(def), hir::Constness::Const { always: true })
+    {
+        // Need to generate mentioned items, as all functions are expected to have them, but for const
+        // fns we just look at the optimized MIR, which generates it. For comptime fns, there is no
+        // optimized MIR.
+        &[&ctfe_limit::CtfeLimit, &mentioned_items::MentionedItems]
+    } else {
+        &[&ctfe_limit::CtfeLimit]
+    };
+    pm::run_passes(tcx, &mut body, passes, None, pm::Optimizations::Allowed);
 
     body
 }

--- a/library/alloc/src/collections/btree/map/entry.rs
+++ b/library/alloc/src/collections/btree/map/entry.rs
@@ -165,9 +165,42 @@ impl<'a, K: Ord, V, A: Allocator + Clone> Entry<'a, K, V, A> {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn or_insert_with<F: FnOnce() -> V>(self, default: F) -> &'a mut V {
+        self.or_try_insert_with(|| Result::<_, !>::Ok(default())).unwrap()
+    }
+
+    /// Ensures a value is in the entry by inserting the result of a fallible default function
+    /// if empty, and returns a mutable reference to the value in the entry.
+    ///
+    /// This method works identically to [`or_insert_with`] except that the default function
+    /// should return a `Result` and, in the case of an error, the error is propagated.
+    ///
+    /// [`or_insert_with`]: Self::or_insert_with
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(try_entry)]
+    /// # fn main() -> Result<(), std::num::ParseIntError> {
+    /// use std::collections::BTreeMap;
+    ///
+    /// let mut map: BTreeMap<&str, usize> = BTreeMap::new();
+    /// let value = "42";
+    ///
+    /// map.entry("poneyland").or_try_insert_with(|| value.parse())?;
+    ///
+    /// assert_eq!(map["poneyland"], 42);
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[inline]
+    #[unstable(feature = "try_entry", issue = "157354")]
+    pub fn or_try_insert_with<F: FnOnce() -> Result<V, E>, E>(
+        self,
+        default: F,
+    ) -> Result<&'a mut V, E> {
         match self {
-            Occupied(entry) => entry.into_mut(),
-            Vacant(entry) => entry.insert(default()),
+            Occupied(entry) => Ok(entry.into_mut()),
+            Vacant(entry) => Ok(entry.insert(default()?)),
         }
     }
 
@@ -193,11 +226,44 @@ impl<'a, K: Ord, V, A: Allocator + Clone> Entry<'a, K, V, A> {
     #[inline]
     #[stable(feature = "or_insert_with_key", since = "1.50.0")]
     pub fn or_insert_with_key<F: FnOnce(&K) -> V>(self, default: F) -> &'a mut V {
+        self.or_try_insert_with_key(|k| Result::<_, !>::Ok(default(k))).into_ok()
+    }
+
+    /// Ensures a value is in the entry by inserting, if empty, the result of the default function.
+    /// This method allows for generating key-derived values for insertion by providing the default
+    /// function a reference to the key that was moved during the `entry(key)` method call.
+    ///
+    /// This method works identically to [`or_insert_with_key`] except that the default function
+    /// should return a `Result` and, in the case of an error, the error is propagated.
+    ///
+    /// [`or_insert_with_key`]: Self::or_insert_with_key
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(try_entry)]
+    /// # fn main() -> Result<(), std::num::ParseIntError> {
+    /// use std::collections::BTreeMap;
+    ///
+    /// let mut map: BTreeMap<&str, usize> = BTreeMap::new();
+    ///
+    /// map.entry("42").or_try_insert_with_key(|key| key.parse())?;
+    ///
+    /// assert_eq!(map["42"], 42);
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[inline]
+    #[unstable(feature = "try_entry", issue = "157354")]
+    pub fn or_try_insert_with_key<F: FnOnce(&K) -> Result<V, E>, E>(
+        self,
+        default: F,
+    ) -> Result<&'a mut V, E> {
         match self {
-            Occupied(entry) => entry.into_mut(),
+            Occupied(entry) => Ok(entry.into_mut()),
             Vacant(entry) => {
-                let value = default(entry.key());
-                entry.insert(value)
+                let value = default(entry.key())?;
+                Ok(entry.insert(value))
             }
         }
     }

--- a/library/alloctests/lib.rs
+++ b/library/alloctests/lib.rs
@@ -51,6 +51,7 @@
 #![feature(trusted_random_access)]
 #![feature(try_reserve_kind)]
 #![feature(try_trait_v2)]
+#![feature(unwrap_infallible)]
 #![feature(wtf8_internals)]
 // tidy-alphabetical-end
 //

--- a/library/core/src/any.rs
+++ b/library/core/src/any.rs
@@ -785,9 +785,8 @@ impl TypeId {
     /// ```
     #[unstable(feature = "type_info", issue = "146922")]
     #[rustc_const_unstable(feature = "type_info", issue = "146922")]
-    pub const fn trait_info_of<
-        T: ptr::Pointee<Metadata = ptr::DynMetadata<T>> + ?Sized + 'static,
-    >(
+    #[rustc_comptime]
+    pub fn trait_info_of<T: ptr::Pointee<Metadata = ptr::DynMetadata<T>> + ?Sized + 'static>(
         self,
     ) -> Option<TraitImpl<T>> {
         // SAFETY: The vtable was obtained for `T`, so it is guaranteed to be `DynMetadata<T>`.
@@ -812,7 +811,8 @@ impl TypeId {
     /// ```
     #[unstable(feature = "type_info", issue = "146922")]
     #[rustc_const_unstable(feature = "type_info", issue = "146922")]
-    pub const fn trait_info_of_trait_type_id(
+    #[rustc_comptime]
+    pub fn trait_info_of_trait_type_id(
         self,
         trait_represented_by_type_id: TypeId,
     ) -> Option<TraitImpl<*const ()>> {

--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -2874,11 +2874,12 @@ pub const unsafe fn size_of_val<T: ?Sized>(ptr: *const T) -> usize;
 pub const unsafe fn align_of_val<T: ?Sized>(ptr: *const T) -> usize;
 
 #[rustc_intrinsic]
+#[rustc_comptime]
 #[unstable(feature = "core_intrinsics", issue = "none")]
 /// Check if a type represented by a `TypeId` implements a trait represented by a `TypeId`.
 /// It can only be called at compile time, the backends do
 /// not implement it. If it implements the trait the dyn metadata gets returned for vtable access.
-pub const fn type_id_vtable(
+pub fn type_id_vtable(
     _id: crate::any::TypeId,
     _trait: crate::any::TypeId,
 ) -> Option<ptr::DynMetadata<*const ()>> {

--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -2923,7 +2923,8 @@ pub const fn type_name<T: ?Sized>() -> &'static str;
 #[rustc_nounwind]
 #[unstable(feature = "core_intrinsics", issue = "none")]
 #[rustc_intrinsic]
-pub const fn type_id<T: ?Sized>() -> crate::any::TypeId;
+#[rustc_comptime]
+pub fn type_id<T: ?Sized>() -> crate::any::TypeId;
 
 /// Tests (at compile-time) if two [`crate::any::TypeId`] instances identify the
 /// same type. This is necessary because at const-eval time the actual discriminating
@@ -2945,7 +2946,8 @@ pub const fn type_id_eq(a: crate::any::TypeId, b: crate::any::TypeId) -> bool {
 /// The more user-friendly version of this intrinsic is [`core::any::TypeId::size`].
 #[rustc_intrinsic]
 #[unstable(feature = "core_intrinsics", issue = "none")]
-pub const fn size_of_type_id(_id: crate::any::TypeId) -> Option<usize> {
+#[rustc_comptime]
+pub fn size_of_type_id(_id: crate::any::TypeId) -> Option<usize> {
     panic!("`TypeId::size` can only be called at compile-time")
 }
 
@@ -2954,7 +2956,8 @@ pub const fn size_of_type_id(_id: crate::any::TypeId) -> Option<usize> {
 /// The more user-friendly version of this intrinsic is [`core::any::TypeId::variants`].
 #[rustc_intrinsic]
 #[unstable(feature = "core_intrinsics", issue = "none")]
-pub const fn type_id_variants(_id: crate::any::TypeId) -> usize {
+#[rustc_comptime]
+pub fn type_id_variants(_id: crate::any::TypeId) -> usize {
     panic!("`TypeId::variants` can only be called at compile-time")
 }
 
@@ -2963,7 +2966,8 @@ pub const fn type_id_variants(_id: crate::any::TypeId) -> usize {
 /// The more user-friendly version of this intrinsic is [`core::any::TypeId::fields`].
 #[rustc_intrinsic]
 #[unstable(feature = "core_intrinsics", issue = "none")]
-pub const fn type_id_fields(_id: crate::any::TypeId, _variant_index: usize) -> usize {
+#[rustc_comptime]
+pub fn type_id_fields(_id: crate::any::TypeId, _variant_index: usize) -> usize {
     panic!("`TypeId::fields` can only be called at compile-time")
 }
 
@@ -2974,7 +2978,8 @@ pub const fn type_id_fields(_id: crate::any::TypeId, _variant_index: usize) -> u
 /// [`FieldRepresentingType`]: crate::field::FieldRepresentingType
 #[rustc_intrinsic]
 #[unstable(feature = "core_intrinsics", issue = "none")]
-pub const fn type_id_field_representing_type(
+#[rustc_comptime]
+pub fn type_id_field_representing_type(
     _id: crate::any::TypeId,
     _variant_index: usize,
     _field_index: usize,
@@ -2989,7 +2994,8 @@ pub const fn type_id_field_representing_type(
 /// [`FieldRepresentingType`]: crate::field::FieldRepresentingType
 #[rustc_intrinsic]
 #[unstable(feature = "core_intrinsics", issue = "none")]
-pub const fn field_representing_type_actual_type_id(
+#[rustc_comptime]
+pub fn field_representing_type_actual_type_id(
     _frt_type_id: crate::any::TypeId,
 ) -> crate::any::TypeId {
     panic!("`FieldId::type_id` can only be called at compile-time")

--- a/library/core/src/mem/type_info.rs
+++ b/library/core/src/mem/type_info.rs
@@ -374,7 +374,8 @@ impl TypeId {
     /// ```
     #[unstable(feature = "type_info", issue = "146922")]
     #[rustc_const_unstable(feature = "type_info", issue = "146922")]
-    pub const fn size(self) -> Option<usize> {
+    #[rustc_comptime]
+    pub fn size(self) -> Option<usize> {
         intrinsics::size_of_type_id(self)
     }
 
@@ -399,7 +400,8 @@ impl TypeId {
     /// ```
     #[unstable(feature = "type_info", issue = "146922")]
     #[rustc_const_unstable(feature = "type_info", issue = "146922")]
-    pub const fn variants(self) -> usize {
+    #[rustc_comptime]
+    pub fn variants(self) -> usize {
         intrinsics::type_id_variants(self)
     }
 
@@ -461,7 +463,8 @@ impl TypeId {
     /// ```
     #[unstable(feature = "type_info", issue = "146922")]
     #[rustc_const_unstable(feature = "type_info", issue = "146922")]
-    pub const fn fields(self, variant_index: usize) -> usize {
+    #[rustc_comptime]
+    pub fn fields(self, variant_index: usize) -> usize {
         intrinsics::type_id_fields(self, variant_index)
     }
 
@@ -527,7 +530,8 @@ impl TypeId {
     /// ```
     #[unstable(feature = "type_info", issue = "146922")]
     #[rustc_const_unstable(feature = "type_info", issue = "146922")]
-    pub const fn field(self, variant_index: usize, field_index: usize) -> FieldId {
+    #[rustc_comptime]
+    pub fn field(self, variant_index: usize, field_index: usize) -> FieldId {
         FieldId {
             frt_type_id: intrinsics::type_id_field_representing_type(
                 self,
@@ -571,7 +575,8 @@ impl FieldId {
     /// ```
     #[unstable(feature = "type_info", issue = "146922")]
     #[rustc_const_unstable(feature = "type_info", issue = "146922")]
-    pub const fn type_id(self) -> TypeId {
+    #[rustc_comptime]
+    pub fn type_id(self) -> TypeId {
         intrinsics::field_representing_type_actual_type_id(self.frt_type_id)
     }
 }

--- a/library/std/src/collections/hash/map.rs
+++ b/library/std/src/collections/hash/map.rs
@@ -2552,7 +2552,7 @@ impl<'a, K, V, A: Allocator> Entry<'a, K, V, A> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(try_entry)]
+    /// #![feature(try_entry)]
     /// # fn main() -> Result<(), std::num::ParseIntError> {
     /// use std::collections::HashMap;
     ///
@@ -2566,7 +2566,7 @@ impl<'a, K, V, A: Allocator> Entry<'a, K, V, A> {
     /// # }
     /// ```
     #[inline]
-    #[unstable(feature = "try_entry", issue = "none")]
+    #[unstable(feature = "try_entry", issue = "157354")]
     pub fn or_try_insert_with<F: FnOnce() -> Result<V, E>, E>(
         self,
         default: F,
@@ -2598,7 +2598,7 @@ impl<'a, K, V, A: Allocator> Entry<'a, K, V, A> {
     #[inline]
     #[stable(feature = "or_insert_with_key", since = "1.50.0")]
     pub fn or_insert_with_key<F: FnOnce(&K) -> V>(self, default: F) -> &'a mut V {
-        self.or_try_insert_with_key(|k| Result::<_, !>::Ok(default(k))).unwrap()
+        self.or_try_insert_with_key(|k| Result::<_, !>::Ok(default(k))).into_ok()
     }
 
     /// Ensures a value is in the entry by inserting, if empty, the result of the default function.
@@ -2613,7 +2613,7 @@ impl<'a, K, V, A: Allocator> Entry<'a, K, V, A> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(try_entry)]
+    /// #![feature(try_entry)]
     /// # fn main() -> Result<(), std::num::ParseIntError> {
     /// use std::collections::HashMap;
     ///
@@ -2626,7 +2626,7 @@ impl<'a, K, V, A: Allocator> Entry<'a, K, V, A> {
     /// # }
     /// ```
     #[inline]
-    #[unstable(feature = "try_entry", issue = "none")]
+    #[unstable(feature = "try_entry", issue = "157354")]
     pub fn or_try_insert_with_key<F: FnOnce(&K) -> Result<V, E>, E>(
         self,
         default: F,

--- a/library/std/src/collections/hash/map.rs
+++ b/library/std/src/collections/hash/map.rs
@@ -2538,9 +2538,42 @@ impl<'a, K, V, A: Allocator> Entry<'a, K, V, A> {
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn or_insert_with<F: FnOnce() -> V>(self, default: F) -> &'a mut V {
+        self.or_try_insert_with(|| Result::<_, !>::Ok(default())).unwrap()
+    }
+
+    /// Ensures a value is in the entry by inserting the result of a fallible default function
+    /// if empty, and returns a mutable reference to the value in the entry.
+    ///
+    /// This method works identically to [`or_insert_with`] except that the default function
+    /// should return a `Result` and, in the case of an error, the error is propagated.
+    ///
+    /// [`or_insert_with`]: Self::or_insert_with
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #![feature(try_entry)]
+    /// # fn main() -> Result<(), std::num::ParseIntError> {
+    /// use std::collections::HashMap;
+    ///
+    /// let mut map: HashMap<&str, usize> = HashMap::new();
+    /// let value = "42";
+    ///
+    /// map.entry("poneyland").or_try_insert_with(|| value.parse())?;
+    ///
+    /// assert_eq!(map["poneyland"], 42);
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[inline]
+    #[unstable(feature = "try_entry", issue = "none")]
+    pub fn or_try_insert_with<F: FnOnce() -> Result<V, E>, E>(
+        self,
+        default: F,
+    ) -> Result<&'a mut V, E> {
         match self {
-            Occupied(entry) => entry.into_mut(),
-            Vacant(entry) => entry.insert(default()),
+            Occupied(entry) => Ok(entry.into_mut()),
+            Vacant(entry) => Ok(entry.insert(default()?)),
         }
     }
 
@@ -2565,11 +2598,44 @@ impl<'a, K, V, A: Allocator> Entry<'a, K, V, A> {
     #[inline]
     #[stable(feature = "or_insert_with_key", since = "1.50.0")]
     pub fn or_insert_with_key<F: FnOnce(&K) -> V>(self, default: F) -> &'a mut V {
+        self.or_try_insert_with_key(|k| Result::<_, !>::Ok(default(k))).unwrap()
+    }
+
+    /// Ensures a value is in the entry by inserting, if empty, the result of the default function.
+    /// This method allows for generating key-derived values for insertion by providing the default
+    /// function a reference to the key that was moved during the `entry(key)` method call.
+    ///
+    /// This method works identically to [`or_insert_with_key`] except that the default function
+    /// should return a `Result` and, in the case of an error, the error is propagated.
+    ///
+    /// [`or_insert_with_key`]: Self::or_insert_with_key
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #![feature(try_entry)]
+    /// # fn main() -> Result<(), std::num::ParseIntError> {
+    /// use std::collections::HashMap;
+    ///
+    /// let mut map: HashMap<&str, usize> = HashMap::new();
+    ///
+    /// map.entry("42").or_try_insert_with_key(|key| key.parse())?;
+    ///
+    /// assert_eq!(map["42"], 42);
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[inline]
+    #[unstable(feature = "try_entry", issue = "none")]
+    pub fn or_try_insert_with_key<F: FnOnce(&K) -> Result<V, E>, E>(
+        self,
+        default: F,
+    ) -> Result<&'a mut V, E> {
         match self {
-            Occupied(entry) => entry.into_mut(),
+            Occupied(entry) => Ok(entry.into_mut()),
             Vacant(entry) => {
-                let value = default(entry.key());
-                entry.insert(value)
+                let value = default(entry.key())?;
+                Ok(entry.insert(value))
             }
         }
     }

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -312,6 +312,7 @@
 #![feature(try_blocks)]
 #![feature(try_trait_v2)]
 #![feature(type_alias_impl_trait)]
+#![feature(unwrap_infallible)]
 // tidy-alphabetical-end
 //
 // Library features (core):

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -347,23 +347,23 @@ target | std | host | notes
 [`loongarch32-unknown-none-softfloat`](platform-support/loongarch-none.md) | * |  | LoongArch32 Bare-metal (ILP32S ABI)
 [`m68k-unknown-linux-gnu`](platform-support/m68k-unknown-linux-gnu.md) | ? |  | Motorola 680x0 Linux
 [`m68k-unknown-none-elf`](platform-support/m68k-unknown-none-elf.md) |  |  | Motorola 680x0
-`mips-unknown-linux-gnu` | ✓ | ✓ | MIPS Linux (kernel 4.4, glibc 2.23)
-`mips-unknown-linux-musl` | ✓ |  | MIPS Linux with musl 1.2.5
-`mips-unknown-linux-uclibc` | ✓ |  | MIPS Linux with uClibc
-[`mips64-openwrt-linux-musl`](platform-support/mips64-openwrt-linux-musl.md) | ? |  | MIPS64 for OpenWrt Linux musl 1.2.5
-`mips64-unknown-linux-gnuabi64` | ✓ | ✓ | MIPS64 Linux, N64 ABI (kernel 4.4, glibc 2.23)
-[`mips64-unknown-linux-muslabi64`](platform-support/mips64-unknown-linux-muslabi64.md) | ✓ | ✓ | MIPS64 Linux, N64 ABI, musl 1.2.5
-`mips64el-unknown-linux-gnuabi64` | ✓ | ✓ | MIPS64 (little endian) Linux, N64 ABI (kernel 4.4, glibc 2.23)
-`mips64el-unknown-linux-muslabi64` | ✓ |  | MIPS64 (little endian) Linux, N64 ABI, musl 1.2.5
-`mipsel-sony-psp` | * |  | MIPS (LE) Sony PlayStation Portable (PSP)
-[`mipsel-sony-psx`](platform-support/mipsel-sony-psx.md) | * |  | MIPS (LE) Sony PlayStation 1 (PSX)
-[`mipsel-unknown-linux-gnu`](platform-support/mipsel-unknown-linux-gnu.md) | ✓ | ✓ | MIPS (little endian) Linux (kernel 4.4, glibc 2.23)
-`mipsel-unknown-linux-musl` | ✓ |  | MIPS (little endian) Linux with musl 1.2.5
-`mipsel-unknown-linux-uclibc` | ✓ |  | MIPS (LE) Linux with uClibc
-[`mipsel-unknown-netbsd`](platform-support/netbsd.md) | ✓ | ✓ | 32-bit MIPS (LE), requires mips32 cpu support
-`mipsel-unknown-none` | * |  | Bare MIPS (LE) softfloat
-[`mips-mti-none-elf`](platform-support/mips-mti-none-elf.md) | * |  | Bare MIPS32r2 (BE) softfloat
-[`mipsel-mti-none-elf`](platform-support/mips-mti-none-elf.md) | * |  | Bare MIPS32r2 (LE) softfloat
+`mips-unknown-linux-gnu` | ✓ | ✓ | MIPS Linux (kernel 4.4, glibc 2.23) [^snan-inverted]
+`mips-unknown-linux-musl` | ✓ |  | MIPS Linux with musl 1.2.5 [^snan-inverted]
+`mips-unknown-linux-uclibc` | ✓ |  | MIPS Linux with uClibc [^snan-inverted]
+[`mips64-openwrt-linux-musl`](platform-support/mips64-openwrt-linux-musl.md) | ? |  | MIPS64 for OpenWrt Linux musl 1.2.5 [^snan-inverted]
+`mips64-unknown-linux-gnuabi64` | ✓ | ✓ | MIPS64 Linux, N64 ABI (kernel 4.4, glibc 2.23) [^snan-inverted]
+[`mips64-unknown-linux-muslabi64`](platform-support/mips64-unknown-linux-muslabi64.md) | ✓ | ✓ | MIPS64 Linux, N64 ABI, musl 1.2.5 [^snan-inverted]
+`mips64el-unknown-linux-gnuabi64` | ✓ | ✓ | MIPS64 (little endian) Linux, N64 ABI (kernel 4.4, glibc 2.23) [^snan-inverted]
+`mips64el-unknown-linux-muslabi64` | ✓ |  | MIPS64 (little endian) Linux, N64 ABI, musl 1.2.5 [^snan-inverted]
+`mipsel-sony-psp` | * |  | MIPS (LE) Sony PlayStation Portable (PSP) [^snan-inverted]
+[`mipsel-sony-psx`](platform-support/mipsel-sony-psx.md) | * |  | MIPS (LE) Sony PlayStation 1 (PSX) [^snan-inverted]
+[`mipsel-unknown-linux-gnu`](platform-support/mipsel-unknown-linux-gnu.md) | ✓ | ✓ | MIPS (little endian) Linux (kernel 4.4, glibc 2.23) [^snan-inverted]
+`mipsel-unknown-linux-musl` | ✓ |  | MIPS (little endian) Linux with musl 1.2.5 [^snan-inverted]
+`mipsel-unknown-linux-uclibc` | ✓ |  | MIPS (LE) Linux with uClibc [^snan-inverted]
+[`mipsel-unknown-netbsd`](platform-support/netbsd.md) | ✓ | ✓ | 32-bit MIPS (LE), requires mips32 cpu support [^snan-inverted]
+`mipsel-unknown-none` | * |  | Bare MIPS (LE) softfloat [^snan-inverted]
+[`mips-mti-none-elf`](platform-support/mips-mti-none-elf.md) | * |  | Bare MIPS32r2 (BE) softfloat [^snan-inverted]
+[`mipsel-mti-none-elf`](platform-support/mips-mti-none-elf.md) | * |  | Bare MIPS32r2 (LE) softfloat [^snan-inverted]
 [`mipsisa32r6-unknown-linux-gnu`](platform-support/mips-release-6.md) | ? |  | 32-bit MIPS Release 6 Big Endian
 [`mipsisa32r6el-unknown-linux-gnu`](platform-support/mips-release-6.md) | ? |  | 32-bit MIPS Release 6 Little Endian
 [`mipsisa64r6-unknown-linux-gnuabi64`](platform-support/mips-release-6.md) | ? |  | 64-bit MIPS Release 6 Big Endian
@@ -472,3 +472,7 @@ target | std | host | notes
 
 [runs on NVIDIA GPUs]: https://github.com/japaric-archived/nvptx#targets
 [the AMD GPU]: https://llvm.org/docs/AMDGPUUsage.html#processors
+
+[^snan-inverted]: On these targets, the treatment of floating-point NaN values is non-compliant. The bit representation for signaling NaNs is inverted compared to [what Rust expects](../std/primitive.f32.html). This means that operations that are expected to return a quiet NaN may return a signaling NaN. See [issue #68925][snan-issue].
+
+[snan-issue]: https://github.com/rust-lang/rust/issues/68925

--- a/tests/ui/reflection/reflection_methods_in_runtime_code.rs
+++ b/tests/ui/reflection/reflection_methods_in_runtime_code.rs
@@ -1,0 +1,10 @@
+//@run-fail
+
+#![feature(type_info)]
+
+trait Trait {}
+
+fn main() {
+    // Test the (lack of) usability of comptime fns in runtime code.
+    std::any::TypeId::of::<[u8; usize::MAX]>().trait_info_of::<dyn Trait>();
+}

--- a/tests/ui/reflection/reflection_methods_in_runtime_code.rs
+++ b/tests/ui/reflection/reflection_methods_in_runtime_code.rs
@@ -1,5 +1,3 @@
-//@run-fail
-
 #![feature(type_info)]
 
 trait Trait {}
@@ -7,4 +5,5 @@ trait Trait {}
 fn main() {
     // Test the (lack of) usability of comptime fns in runtime code.
     std::any::TypeId::of::<[u8; usize::MAX]>().trait_info_of::<dyn Trait>();
+    //~^ ERROR: comptime fns can only be called at compile time
 }

--- a/tests/ui/reflection/reflection_methods_in_runtime_code.stderr
+++ b/tests/ui/reflection/reflection_methods_in_runtime_code.stderr
@@ -1,0 +1,8 @@
+error: comptime fns can only be called at compile time
+  --> $DIR/reflection_methods_in_runtime_code.rs:7:5
+   |
+LL |     std::any::TypeId::of::<[u8; usize::MAX]>().trait_info_of::<dyn Trait>();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/157693)*
<!-- homu-ignore:end -->

Successful merges:

 - rust-lang/rust#157647 (Start using comptime for reflection intrinsics and their wrapper functions)
 - rust-lang/rust#157288 (platform support: add SNaN erratum to MIPS targets)
 - rust-lang/rust#157355 (Add `or_try_*` variants for `HashMap` and `BTreeMap` Entry APIs)
 - rust-lang/rust#157691 (Move symbol hiding code to a new file)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=157647,157288,157355,157691)
<!-- homu-ignore:end -->

