### PR TITLE
Extend capabilities of `TypeFoldable_Generic`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4892,6 +4892,7 @@ dependencies = [
 name = "rustc_type_ir_macros"
 version = "0.0.0"
 dependencies = [
+ "indexmap",
  "proc-macro2",
  "quote",
  "syn",

--- a/compiler/rustc_type_ir_macros/Cargo.toml
+++ b/compiler/rustc_type_ir_macros/Cargo.toml
@@ -11,6 +11,7 @@ nightly = []
 
 [dependencies]
 # tidy-alphabetical-start
+indexmap = "2.4.0"
 proc-macro2 = "1"
 quote = "1"
 syn = { version = "2.0.9", features = ["full", "visit-mut"] }

--- a/compiler/rustc_type_ir_macros/src/lib.rs
+++ b/compiler/rustc_type_ir_macros/src/lib.rs
@@ -1,3 +1,4 @@
+use indexmap::IndexSet;
 use quote::{ToTokens, quote};
 use syn::visit_mut::VisitMut;
 use syn::{Attribute, parse_quote};
@@ -17,10 +18,23 @@ decl_derive!(
     [GenericTypeVisitable] => customizable_type_visitable_derive
 );
 
-struct LiftedTy {
+struct TransformedTy {
     ty: syn::Type,
-    generic_parameter_bounds: Vec<syn::Ident>,
+    generic_parameter_bounds: IndexSet<syn::Ident>,
 }
+
+enum TypeParameterPath {
+    Interner,
+    GenericParameter(syn::Ident),
+}
+
+enum TypeParameterTransform {
+    Continue,
+    Stop,
+}
+
+type TypeParameterVisitor =
+    fn(TypeParameterPath, &mut syn::TypePath, &mut IndexSet<syn::Ident>) -> TypeParameterTransform;
 
 fn has_ignore_attr(attrs: &[Attribute], name: &'static str, meta: &'static str) -> bool {
     let mut ignored = false;
@@ -91,6 +105,9 @@ fn type_foldable_derive(mut s: synstructure::Structure<'_>) -> proc_macro2::Toke
 
     s.add_where_predicate(parse_quote! { I: Interner });
     s.add_bounds(synstructure::AddBounds::Fields);
+    let generic_parameters =
+        s.ast().generics.type_params().map(|ty| ty.ident.clone()).collect::<Vec<_>>();
+    let mut generic_parameter_bounds = IndexSet::new();
     s.bind_with(|_| synstructure::BindStyle::Move);
     let body_try_fold = s.each_variant(|vi| {
         let bindings = vi.bindings();
@@ -101,6 +118,12 @@ fn type_foldable_derive(mut s: synstructure::Structure<'_>) -> proc_macro2::Toke
             if has_ignore_attr(&bind.ast().attrs, "type_foldable", "identity") {
                 bind.to_token_stream()
             } else {
+                for param in
+                    type_foldable_generic_parameters(bind.ast().ty.clone(), &generic_parameters)
+                {
+                    generic_parameter_bounds.insert(param);
+                }
+
                 quote! {
                     ::rustc_type_ir::TypeFoldable::try_fold_with(#bind, __folder)?
                 }
@@ -129,6 +152,9 @@ fn type_foldable_derive(mut s: synstructure::Structure<'_>) -> proc_macro2::Toke
     // to generate code for them.
     s.filter(|bi| !has_ignore_attr(&bi.ast().attrs, "type_foldable", "identity"));
     s.add_bounds(synstructure::AddBounds::Fields);
+    for param in generic_parameter_bounds {
+        s.add_where_predicate(parse_quote! { #param: ::rustc_type_ir::TypeFoldable<I> });
+    }
     s.bound_impl(
         quote!(::rustc_type_ir::TypeFoldable<I>),
         quote! {
@@ -147,6 +173,19 @@ fn type_foldable_derive(mut s: synstructure::Structure<'_>) -> proc_macro2::Toke
             }
         },
     )
+}
+
+fn type_foldable_generic_parameters(
+    ty: syn::Type,
+    generic_parameters: &[syn::Ident],
+) -> IndexSet<syn::Ident> {
+    transform_type_parameters(ty, generic_parameters, |path, _, generic_parameter_bounds| {
+        if let TypeParameterPath::GenericParameter(param) = path {
+            generic_parameter_bounds.insert(param);
+        }
+        TypeParameterTransform::Continue
+    })
+    .generic_parameter_bounds
 }
 
 /// `Lift_Generic` is specialised for structs/enums parameterised by an interner
@@ -251,40 +290,72 @@ fn is_type_phantom(ty: &syn::Type) -> bool {
     get_first_path_segment(ty).is_some_and(|segment| segment.ident == "PhantomData")
 }
 
-fn lift(mut ty: syn::Type, generic_parameters: &[syn::Ident]) -> LiftedTy {
-    struct ItoJ<'a> {
+fn lift(ty: syn::Type, generic_parameters: &[syn::Ident]) -> TransformedTy {
+    transform_type_parameters(ty, generic_parameters, |path, ty, generic_parameter_bounds| {
+        match path {
+            TypeParameterPath::Interner => {
+                *ty.path.segments.first_mut().unwrap() = parse_quote! { J };
+                TypeParameterTransform::Continue
+            }
+            TypeParameterPath::GenericParameter(param) => {
+                generic_parameter_bounds.insert(param.clone());
+                *ty = parse_quote! { <#param as ::rustc_type_ir::lift::Lift<J>>::Lifted };
+                TypeParameterTransform::Stop
+            }
+        }
+    })
+}
+
+fn transform_type_parameters(
+    mut ty: syn::Type,
+    generic_parameters: &[syn::Ident],
+    visit: TypeParameterVisitor,
+) -> TransformedTy {
+    struct TypeParameterTransformer<'a> {
         generic_parameters: &'a [syn::Ident],
-        generic_parameter_bounds: Vec<syn::Ident>,
+        generic_parameter_bounds: IndexSet<syn::Ident>,
+        visit: TypeParameterVisitor,
     }
 
-    impl VisitMut for ItoJ<'_> {
+    impl VisitMut for TypeParameterTransformer<'_> {
         fn visit_type_path_mut(&mut self, i: &mut syn::TypePath) {
-            if i.qself.is_none() {
+            let path = if i.qself.is_none() {
                 let segments_len = i.path.segments.len();
-                if let Some(first) = i.path.segments.first_mut() {
-                    // Turn paths from `I` into `J`
+                i.path.segments.first().and_then(|first| {
                     if first.ident == "I" {
-                        *first = parse_quote! { J };
+                        Some(TypeParameterPath::Interner)
                     } else if segments_len == 1
                         && matches!(first.arguments, syn::PathArguments::None)
-                        && self.generic_parameters.iter().any(|param| first.ident == *param)
+                        && self.generic_parameters.contains(&first.ident)
                     {
-                        let ident = first.ident.clone();
-                        if !self.generic_parameter_bounds.iter().any(|param| *param == ident) {
-                            self.generic_parameter_bounds.push(ident.clone());
-                        }
-
-                        *i = parse_quote! { <#ident as ::rustc_type_ir::lift::Lift<J>>::Lifted };
-                        return;
+                        Some(TypeParameterPath::GenericParameter(first.ident.clone()))
+                    } else {
+                        None
                     }
+                })
+            } else {
+                None
+            };
+
+            if let Some(path) = path {
+                if let TypeParameterTransform::Stop =
+                    (self.visit)(path, i, &mut self.generic_parameter_bounds)
+                {
+                    return;
                 }
             }
+
             syn::visit_mut::visit_type_path_mut(self, i);
         }
     }
-    let mut visitor = ItoJ { generic_parameters, generic_parameter_bounds: Vec::new() };
+
+    let mut visitor = TypeParameterTransformer {
+        generic_parameters,
+        generic_parameter_bounds: IndexSet::new(),
+        visit,
+    };
     visitor.visit_type_mut(&mut ty);
-    LiftedTy { ty, generic_parameter_bounds: visitor.generic_parameter_bounds }
+    TransformedTy { ty, generic_parameter_bounds: visitor.generic_parameter_bounds }
 }
 
 #[cfg(not(feature = "nightly"))]


### PR DESCRIPTION
Split from https://github.com/rust-lang/rust/pull/156538.

- Lets `TypeFoldable_Generic` derive structural folding for types with extra generic parameters by adding the necessary `T: TypeFoldable<I>` bounds automatically
- Means in https://github.com/rust-lang/rust/pull/156538 we can remove the manual `TypeFoldable` implementation for `NormalizesTo`
- Refactors shared traversal logic between `Lift_Generic` and `TypeFoldable_Generic` into a shared helper with a callback.

r? @lcnr