### PR TITLE
Make parallel frontend CI job compile tests in parallel

### DIFF
--- a/src/ci/docker/host-x86_64/optional-x86_64-gnu-parallel-frontend/Dockerfile
+++ b/src/ci/docker/host-x86_64/optional-x86_64-gnu-parallel-frontend/Dockerfile
@@ -35,4 +35,4 @@ ENV RUST_CONFIGURE_ARGS \
 ENV RUST_TEST_THREADS 1
 
 # Build the toolchain with multiple parallel frontend threads and then run tests
-ENV SCRIPT python3 ../x.py --stage 2 test --set rust.parallel-frontend-threads=4 -- --parallel-frontend-threads=4 --iteration-count=2
+ENV SCRIPT python3 ../x.py --stage 2 test --set rust.parallel-frontend-threads=4 "--" --parallel-frontend-threads=4 --iteration-count=2

--- a/src/ci/docker/host-x86_64/optional-x86_64-gnu-parallel-frontend/Dockerfile
+++ b/src/ci/docker/host-x86_64/optional-x86_64-gnu-parallel-frontend/Dockerfile
@@ -31,6 +31,8 @@ ENV RUST_CONFIGURE_ARGS \
  --enable-compiler-docs \
  --set llvm.libzstd=true
 
+# Compile each test sequentially to achieve max thread utilization by a single rustc process
+ENV RUST_TEST_THREADS 1
+
 # Build the toolchain with multiple parallel frontend threads and then run tests
-# Tests are still compiled serially at the moment (intended to be changed in follow-ups).
-ENV SCRIPT python3 ../x.py --stage 2 test --set rust.parallel-frontend-threads=4
+ENV SCRIPT python3 ../x.py --stage 2 test --set rust.parallel-frontend-threads=4 -- --parallel-frontend-threads=4 --iteration-count=2


### PR DESCRIPTION
It is time to have a CI job to catch parallel frontend issues for tests. This PR sets `RUST_TEST_THREADS` to 1 to sequentially execute each test to achieve max thread utilization by a single rustc process. Then `iteration-count` option is set to 2 to repeat each test since parallel frontend issues usually don't reproduce reliably.

try-job: optional-x86_64-gnu-parallel-frontend