### PR TITLE
Move proc-macro dlopen from proc-macro-srv to rustc_metadata

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/linker.rs
+++ b/compiler/rustc_codegen_ssa/src/back/linker.rs
@@ -1862,7 +1862,7 @@ fn exported_symbols_for_proc_macro_crate(tcx: TyCtxt<'_>) -> Vec<(String, Symbol
     }
 
     let stable_crate_id = tcx.stable_crate_id(LOCAL_CRATE);
-    let proc_macro_decls_name = tcx.sess.generate_proc_macro_decls_symbol(stable_crate_id);
+    let proc_macro_decls_name = rustc_session::generate_proc_macro_decls_symbol(stable_crate_id);
 
     vec![(proc_macro_decls_name, SymbolExportKind::Data)]
 }

--- a/compiler/rustc_metadata/src/creader.rs
+++ b/compiler/rustc_metadata/src/creader.rs
@@ -1,10 +1,8 @@
 //! Validates all used crates and extern libraries and loads their metadata
 
 use std::collections::BTreeMap;
-use std::error::Error;
 use std::path::Path;
 use std::str::FromStr;
-use std::time::Duration;
 use std::{cmp, env, iter};
 
 use rustc_ast::expand::allocator::{ALLOC_ERROR_HANDLER, AllocatorKind, global_fn_name};
@@ -15,7 +13,6 @@ use rustc_data_structures::svh::Svh;
 use rustc_data_structures::sync::{self, FreezeReadGuard, FreezeWriteGuard};
 use rustc_data_structures::unord::UnordMap;
 use rustc_expand::base::SyntaxExtension;
-use rustc_fs_util::try_canonicalize;
 use rustc_hir as hir;
 use rustc_hir::def_id::{CrateNum, LOCAL_CRATE, LocalDefId, StableCrateId};
 use rustc_hir::definitions::Definitions;
@@ -951,27 +948,7 @@ impl CStore {
         path: &Path,
         stable_crate_id: StableCrateId,
     ) -> Result<&'static [ProcMacroClient], CrateError> {
-        let sym_name = rustc_session::generate_proc_macro_decls_symbol(stable_crate_id);
-        debug!("trying to dlsym proc_macros {} for symbol `{}`", path.display(), sym_name);
-
-        unsafe {
-            // FIXME(bjorn3) this depends on the unstable slice memory layout
-            let result = load_symbol_from_dylib::<*const &[ProcMacroClient]>(path, &sym_name);
-            match result {
-                Ok(result) => {
-                    debug!("loaded dlsym proc_macros {} for symbol `{}`", path.display(), sym_name);
-                    Ok(*result)
-                }
-                Err(err) => {
-                    debug!(
-                        "failed to dlsym proc_macros {} for symbol `{}`",
-                        path.display(),
-                        sym_name
-                    );
-                    Err(err.into())
-                }
-            }
-        }
+        Ok(crate::host_dylib::dlsym_proc_macros(path, stable_crate_id)?)
     }
 
     fn inject_panic_runtime(&mut self, tcx: TyCtxt<'_>, krate: &ast::Crate) {
@@ -1407,118 +1384,4 @@ fn fn_spans(krate: &ast::Crate, name: Symbol) -> Vec<Span> {
     let mut f = Finder { name, spans: Vec::new() };
     visit::walk_crate(&mut f, krate);
     f.spans
-}
-
-fn format_dlopen_err(e: &(dyn std::error::Error + 'static)) -> String {
-    e.sources().map(|e| format!(": {e}")).collect()
-}
-
-fn attempt_load_dylib(path: &Path) -> Result<libloading::Library, libloading::Error> {
-    #[cfg(target_os = "aix")]
-    if let Some(ext) = path.extension()
-        && ext.eq("a")
-    {
-        // On AIX, we ship all libraries as .a big_af archive
-        // the expected format is lib<name>.a(libname.so) for the actual
-        // dynamic library
-        let library_name = path.file_stem().expect("expect a library name");
-        let mut archive_member = std::ffi::OsString::from("a(");
-        archive_member.push(library_name);
-        archive_member.push(".so)");
-        let new_path = path.with_extension(archive_member);
-
-        // On AIX, we need RTLD_MEMBER to dlopen an archived shared
-        let flags = libc::RTLD_LAZY | libc::RTLD_LOCAL | libc::RTLD_MEMBER;
-        return unsafe { libloading::os::unix::Library::open(Some(&new_path), flags) }
-            .map(|lib| lib.into());
-    }
-
-    unsafe { libloading::Library::new(&path) }
-}
-
-// On Windows the compiler would sometimes intermittently fail to open the
-// proc-macro DLL with `Error::LoadLibraryExW`. It is suspected that something in the
-// system still holds a lock on the file, so we retry a few times before calling it
-// an error.
-fn load_dylib(path: &Path, max_attempts: usize) -> Result<libloading::Library, String> {
-    assert!(max_attempts > 0);
-
-    let mut last_error = None;
-
-    for attempt in 0..max_attempts {
-        debug!("Attempt to load proc-macro `{}`.", path.display());
-        match attempt_load_dylib(path) {
-            Ok(lib) => {
-                if attempt > 0 {
-                    debug!(
-                        "Loaded proc-macro `{}` after {} attempts.",
-                        path.display(),
-                        attempt + 1
-                    );
-                }
-                return Ok(lib);
-            }
-            Err(err) => {
-                // Only try to recover from this specific error.
-                if !matches!(err, libloading::Error::LoadLibraryExW { .. }) {
-                    debug!("Failed to load proc-macro `{}`. Not retrying", path.display());
-                    let err = format_dlopen_err(&err);
-                    // We include the path of the dylib in the error ourselves, so
-                    // if it's in the error, we strip it.
-                    if let Some(err) = err.strip_prefix(&format!(": {}", path.display())) {
-                        return Err(err.to_string());
-                    }
-                    return Err(err);
-                }
-
-                last_error = Some(err);
-                std::thread::sleep(Duration::from_millis(100));
-                debug!("Failed to load proc-macro `{}`. Retrying.", path.display());
-            }
-        }
-    }
-
-    debug!("Failed to load proc-macro `{}` even after {} attempts.", path.display(), max_attempts);
-
-    let last_error = last_error.unwrap();
-    let message = if let Some(src) = last_error.source() {
-        format!("{} ({src}) (retried {max_attempts} times)", format_dlopen_err(&last_error))
-    } else {
-        format!("{} (retried {max_attempts} times)", format_dlopen_err(&last_error))
-    };
-    Err(message)
-}
-
-pub enum DylibError {
-    DlOpen(String, String),
-    DlSym(String, String),
-}
-
-impl From<DylibError> for CrateError {
-    fn from(err: DylibError) -> CrateError {
-        match err {
-            DylibError::DlOpen(path, err) => CrateError::DlOpen(path, err),
-            DylibError::DlSym(path, err) => CrateError::DlSym(path, err),
-        }
-    }
-}
-
-pub unsafe fn load_symbol_from_dylib<T: Copy>(
-    path: &Path,
-    sym_name: &str,
-) -> Result<T, DylibError> {
-    // Make sure the path contains a / or the linker will search for it.
-    let path = try_canonicalize(path).unwrap();
-    let lib =
-        load_dylib(&path, 5).map_err(|err| DylibError::DlOpen(path.display().to_string(), err))?;
-
-    let sym = unsafe { lib.get::<T>(sym_name.as_bytes()) }
-        .map_err(|err| DylibError::DlSym(path.display().to_string(), format_dlopen_err(&err)))?;
-
-    // Intentionally leak the dynamic library. We can't ever unload it
-    // since the library can make things that will live arbitrarily long.
-    let sym = unsafe { sym.into_raw() };
-    std::mem::forget(lib);
-
-    Ok(*sym)
 }

--- a/compiler/rustc_metadata/src/creader.rs
+++ b/compiler/rustc_metadata/src/creader.rs
@@ -653,7 +653,7 @@ impl CStore {
                 None => (&source, &crate_root),
             };
             let dlsym_dylib = dlsym_source.dylib.as_ref().expect("no dylib for a proc-macro crate");
-            Some(self.dlsym_proc_macros(tcx.sess, dlsym_dylib, dlsym_root.stable_crate_id())?)
+            Some(self.dlsym_proc_macros(dlsym_dylib, dlsym_root.stable_crate_id())?)
         } else {
             None
         };
@@ -948,11 +948,10 @@ impl CStore {
 
     fn dlsym_proc_macros(
         &self,
-        sess: &Session,
         path: &Path,
         stable_crate_id: StableCrateId,
     ) -> Result<&'static [ProcMacroClient], CrateError> {
-        let sym_name = sess.generate_proc_macro_decls_symbol(stable_crate_id);
+        let sym_name = rustc_session::generate_proc_macro_decls_symbol(stable_crate_id);
         debug!("trying to dlsym proc_macros {} for symbol `{}`", path.display(), sym_name);
 
         unsafe {

--- a/compiler/rustc_metadata/src/host_dylib.rs
+++ b/compiler/rustc_metadata/src/host_dylib.rs
@@ -1,0 +1,147 @@
+use std::error::Error;
+use std::path::Path;
+use std::time::Duration;
+
+use rustc_fs_util::try_canonicalize;
+use rustc_proc_macro::bridge::client::Client as ProcMacroClient;
+use rustc_session::StableCrateId;
+use tracing::debug;
+
+use crate::locator::CrateError;
+
+fn format_dlopen_err(e: &(dyn std::error::Error + 'static)) -> String {
+    e.sources().map(|e| format!(": {e}")).collect()
+}
+
+fn attempt_load_dylib(path: &Path) -> Result<libloading::Library, libloading::Error> {
+    #[cfg(target_os = "aix")]
+    if let Some(ext) = path.extension()
+        && ext.eq("a")
+    {
+        // On AIX, we ship all libraries as .a big_af archive
+        // the expected format is lib<name>.a(libname.so) for the actual
+        // dynamic library
+        let library_name = path.file_stem().expect("expect a library name");
+        let mut archive_member = std::ffi::OsString::from("a(");
+        archive_member.push(library_name);
+        archive_member.push(".so)");
+        let new_path = path.with_extension(archive_member);
+
+        // On AIX, we need RTLD_MEMBER to dlopen an archived shared
+        let flags = libc::RTLD_LAZY | libc::RTLD_LOCAL | libc::RTLD_MEMBER;
+        return unsafe { libloading::os::unix::Library::open(Some(&new_path), flags) }
+            .map(|lib| lib.into());
+    }
+
+    unsafe { libloading::Library::new(&path) }
+}
+
+// On Windows the compiler would sometimes intermittently fail to open the
+// proc-macro DLL with `Error::LoadLibraryExW`. It is suspected that something in the
+// system still holds a lock on the file, so we retry a few times before calling it
+// an error.
+fn load_dylib(path: &Path, max_attempts: usize) -> Result<libloading::Library, String> {
+    assert!(max_attempts > 0);
+
+    let mut last_error = None;
+
+    for attempt in 0..max_attempts {
+        debug!("Attempt to load proc-macro `{}`.", path.display());
+        match attempt_load_dylib(path) {
+            Ok(lib) => {
+                if attempt > 0 {
+                    debug!(
+                        "Loaded proc-macro `{}` after {} attempts.",
+                        path.display(),
+                        attempt + 1
+                    );
+                }
+                return Ok(lib);
+            }
+            Err(err) => {
+                // Only try to recover from this specific error.
+                if !matches!(err, libloading::Error::LoadLibraryExW { .. }) {
+                    debug!("Failed to load proc-macro `{}`. Not retrying", path.display());
+                    let err = format_dlopen_err(&err);
+                    // We include the path of the dylib in the error ourselves, so
+                    // if it's in the error, we strip it.
+                    if let Some(err) = err.strip_prefix(&format!(": {}", path.display())) {
+                        return Err(err.to_string());
+                    }
+                    return Err(err);
+                }
+
+                last_error = Some(err);
+                std::thread::sleep(Duration::from_millis(100));
+                debug!("Failed to load proc-macro `{}`. Retrying.", path.display());
+            }
+        }
+    }
+
+    debug!("Failed to load proc-macro `{}` even after {} attempts.", path.display(), max_attempts);
+
+    let last_error = last_error.unwrap();
+    let message = if let Some(src) = last_error.source() {
+        format!("{} ({src}) (retried {max_attempts} times)", format_dlopen_err(&last_error))
+    } else {
+        format!("{} (retried {max_attempts} times)", format_dlopen_err(&last_error))
+    };
+    Err(message)
+}
+
+pub enum DylibError {
+    DlOpen(String, String),
+    DlSym(String, String),
+}
+
+impl From<DylibError> for CrateError {
+    fn from(err: DylibError) -> CrateError {
+        match err {
+            DylibError::DlOpen(path, err) => CrateError::DlOpen(path, err),
+            DylibError::DlSym(path, err) => CrateError::DlSym(path, err),
+        }
+    }
+}
+
+pub unsafe fn load_symbol_from_dylib<T: Copy>(
+    path: &Path,
+    sym_name: &str,
+) -> Result<T, DylibError> {
+    // Make sure the path contains a / or the linker will search for it.
+    let path = try_canonicalize(path).unwrap();
+    let lib =
+        load_dylib(&path, 5).map_err(|err| DylibError::DlOpen(path.display().to_string(), err))?;
+
+    let sym = unsafe { lib.get::<T>(sym_name.as_bytes()) }
+        .map_err(|err| DylibError::DlSym(path.display().to_string(), format_dlopen_err(&err)))?;
+
+    // Intentionally leak the dynamic library. We can't ever unload it
+    // since the library can make things that will live arbitrarily long.
+    let sym = unsafe { sym.into_raw() };
+    std::mem::forget(lib);
+
+    Ok(*sym)
+}
+
+pub(crate) fn dlsym_proc_macros(
+    path: &Path,
+    stable_crate_id: StableCrateId,
+) -> Result<&'static [ProcMacroClient], DylibError> {
+    let sym_name = rustc_session::generate_proc_macro_decls_symbol(stable_crate_id);
+    debug!("trying to dlsym proc_macros {} for symbol `{}`", path.display(), sym_name);
+
+    unsafe {
+        // FIXME(bjorn3) this depends on the unstable slice memory layout
+        let result = crate::load_symbol_from_dylib::<*const &[ProcMacroClient]>(path, &sym_name);
+        match result {
+            Ok(result) => {
+                debug!("loaded dlsym proc_macros {} for symbol `{}`", path.display(), sym_name);
+                Ok(*result)
+            }
+            Err(err) => {
+                debug!("failed to dlsym proc_macros {} for symbol `{}`", path.display(), sym_name);
+                Err(err.into())
+            }
+        }
+    }
+}

--- a/compiler/rustc_metadata/src/lib.rs
+++ b/compiler/rustc_metadata/src/lib.rs
@@ -17,6 +17,7 @@ pub use rmeta::provide;
 mod dependency_format;
 mod eii;
 mod foreign_modules;
+mod host_dylib;
 mod native_libs;
 mod rmeta;
 
@@ -25,8 +26,8 @@ pub mod errors;
 pub mod fs;
 pub mod locator;
 
-pub use creader::{DylibError, load_symbol_from_dylib};
 pub use fs::{METADATA_FILENAME, emit_wrapper_file};
+pub use host_dylib::{DylibError, load_symbol_from_dylib};
 pub use native_libs::{
     NativeLibSearchFallback, find_native_static_library, try_find_native_dynamic_library,
     try_find_native_static_library, walk_native_lib_search_dirs,

--- a/compiler/rustc_metadata/src/locator.rs
+++ b/compiler/rustc_metadata/src/locator.rs
@@ -213,7 +213,7 @@
 //! metadata::locator or metadata::creader for all the juicy details!
 
 use std::borrow::Cow;
-use std::io::{Result as IoResult, Write};
+use std::io::{self, Result as IoResult, Write};
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::{cmp, fmt};
@@ -224,6 +224,7 @@ use rustc_data_structures::owned_slice::{OwnedSlice, slice_owned};
 use rustc_data_structures::svh::Svh;
 use rustc_errors::{DiagArgValue, IntoDiagArg};
 use rustc_fs_util::try_canonicalize;
+use rustc_proc_macro::bridge::client::Client as ProcMacroClient;
 use rustc_session::cstore::CrateSource;
 use rustc_session::filesearch::FileSearch;
 use rustc_session::search_paths::PathKind;
@@ -821,7 +822,7 @@ fn get_metadata_section<'p>(
     crate_name: Option<Symbol>,
 ) -> Result<MetadataBlob, MetadataError<'p>> {
     if !filename.exists() {
-        return Err(MetadataError::NotPresent(filename.into()));
+        return Err(MetadataError::NotPresent(filename));
     }
     let raw_bytes = match flavor {
         CrateFlavor::Rlib => {
@@ -978,18 +979,29 @@ fn get_flavor_from_path(path: &Path) -> CrateFlavor {
     }
 }
 
-/// A function to get information about all macros inside a proc-macro crate.
+/// A function to fetch about all macros inside a proc-macro crate.
 ///
 /// Used by rust-analyzer-proc-macro-srv.
-pub fn get_proc_macro_info<'p>(
+pub fn get_proc_macros(
     target: &Target,
-    path: &'p Path,
+    path: &Path,
     metadata_loader: &dyn MetadataLoader,
     cfg_version: &'static str,
-) -> Result<Vec<ProcMacroKind>, MetadataError<'p>> {
+) -> IoResult<Vec<(ProcMacroClient, ProcMacroKind)>> {
     let metadata =
-        get_metadata_section(target, CrateFlavor::Dylib, path, metadata_loader, cfg_version, None)?;
-    Ok(metadata.get_proc_macro_info())
+        get_metadata_section(target, CrateFlavor::Dylib, path, metadata_loader, cfg_version, None)
+            .map_err(|err| io::Error::other(err.to_string()))?;
+    let stable_crate_id = metadata.get_root().stable_crate_id();
+
+    let clients = crate::host_dylib::dlsym_proc_macros(path, stable_crate_id).map_err(|err| {
+        let (crate::DylibError::DlOpen(path, err) | crate::DylibError::DlSym(path, err)) = err;
+        io::Error::other(format!("{path}{err}"))
+    })?;
+
+    let proc_macro_info = metadata.get_proc_macro_info();
+    assert_eq!(proc_macro_info.len(), clients.len());
+
+    Ok(clients.into_iter().copied().zip(proc_macro_info).collect())
 }
 
 // ------------------------------------------ Error reporting -------------------------------------
@@ -1039,9 +1051,9 @@ pub(crate) enum CrateError {
 }
 
 #[derive(Debug)]
-pub enum MetadataError<'a> {
+pub(crate) enum MetadataError<'a> {
     /// The file was missing.
-    NotPresent(Cow<'a, Path>),
+    NotPresent(&'a Path),
     /// The file was present and invalid.
     LoadFailure(String),
     /// The file was present, but compiled with a different rustc version.

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -416,10 +416,6 @@ impl Session {
         self.target.debuginfo_kind == DebuginfoKind::Dwarf
     }
 
-    pub fn generate_proc_macro_decls_symbol(&self, stable_crate_id: StableCrateId) -> String {
-        format!("__rustc_proc_macro_decls_{:08x}__", stable_crate_id.as_u64())
-    }
-
     pub fn target_filesearch(&self) -> &filesearch::FileSearch {
         &self.target_filesearch
     }
@@ -1138,6 +1134,10 @@ pub fn build_session(
     validate_commandline_args_with_session_available(&sess);
 
     sess
+}
+
+pub fn generate_proc_macro_decls_symbol(stable_crate_id: StableCrateId) -> String {
+    format!("__rustc_proc_macro_decls_{:08x}__", stable_crate_id.as_u64())
 }
 
 /// Validate command line arguments with a `Session`.

--- a/compiler/rustc_symbol_mangling/src/lib.rs
+++ b/compiler/rustc_symbol_mangling/src/lib.rs
@@ -165,7 +165,7 @@ fn compute_symbol_name<'tcx>(
     if let Some(def_id) = def_id.as_local() {
         if tcx.proc_macro_decls_static(()) == Some(def_id) {
             let stable_crate_id = tcx.stable_crate_id(LOCAL_CRATE);
-            return tcx.sess.generate_proc_macro_decls_symbol(stable_crate_id);
+            return rustc_session::generate_proc_macro_decls_symbol(stable_crate_id);
         }
     }
 

--- a/src/tools/rust-analyzer/Cargo.lock
+++ b/src/tools/rust-analyzer/Cargo.lock
@@ -90,7 +90,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "miniz_oxide",
- "object 0.37.3",
+ "object",
  "rustc-demangle",
  "windows-link",
 ]
@@ -1417,16 +1417,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
-name = "libloading"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
-dependencies = [
- "cfg-if",
- "windows-link",
-]
-
-[[package]]
 name = "libmimalloc-sys"
 version = "0.1.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1590,15 +1580,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
-name = "memmap2"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1755,15 +1736,6 @@ name = "objc2-encode"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
-
-[[package]]
-name = "object"
-version = "0.36.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "object"
@@ -1992,11 +1964,7 @@ version = "0.0.0"
 dependencies = [
  "expect-test",
  "intern",
- "libc",
- "libloading",
  "line-index 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "memmap2",
- "object 0.36.7",
  "paths",
  "proc-macro-test",
  "span",

--- a/src/tools/rust-analyzer/Cargo.toml
+++ b/src/tools/rust-analyzer/Cargo.toml
@@ -116,17 +116,8 @@ expect-test = "1.5.1"
 indexmap = { version = "2.9.0", features = ["serde"] }
 itertools = "0.14.0"
 libc = "0.2.172"
-libloading = "0.8.8"
-memmap2 = "0.9.5"
 nohash-hasher = "0.2.0"
 oorandom = "11.1.5"
-object = { version = "0.36.7", default-features = false, features = [
-    "std",
-    "read_core",
-    "elf",
-    "macho",
-    "pe",
-] }
 postcard = { version = "1.1.3", features = ["alloc"] }
 process-wrap = { version = "9.1.0", features = ["std"] }
 pulldown-cmark-to-cmark = "10.0.4"

--- a/src/tools/rust-analyzer/crates/proc-macro-srv/Cargo.toml
+++ b/src/tools/rust-analyzer/crates/proc-macro-srv/Cargo.toml
@@ -13,9 +13,6 @@ rust-version.workspace = true
 doctest = false
 
 [dependencies]
-object.workspace = true
-libloading.workspace = true
-memmap2.workspace = true
 temp-dir.workspace = true
 
 paths.workspace = true
@@ -23,9 +20,6 @@ paths.workspace = true
 span = { path = "../span", version = "0.0.0", default-features = false}
 intern.workspace = true
 
-
-[target.'cfg(unix)'.dependencies]
-libc.workspace = true
 
 [dev-dependencies]
 expect-test.workspace = true

--- a/src/tools/rust-analyzer/crates/proc-macro-srv/src/dylib.rs
+++ b/src/tools/rust-analyzer/crates/proc-macro-srv/src/dylib.rs
@@ -4,22 +4,18 @@ mod proc_macros;
 
 use rustc_codegen_ssa::back::metadata::DefaultMetadataLoader;
 use rustc_interface::util::rustc_version_str;
-use rustc_metadata::locator::MetadataError;
 use rustc_proc_macro::bridge;
 use rustc_session::config::host_tuple;
 use rustc_target::spec::{Target, TargetTuple};
 use std::path::Path;
-use std::{fmt, fs, io, time::SystemTime};
+use std::{fs, io, time::SystemTime};
 use temp_dir::TempDir;
 
-use libloading::Library;
-use object::Object;
 use paths::{Utf8Path, Utf8PathBuf};
 
 use crate::{
     PanicMessage, ProcMacroClientHandle, ProcMacroKind, ProcMacroSrvSpan, TrackedEnv,
-    dylib::proc_macros::{ProcMacroClients, ProcMacros},
-    token_stream::TokenStream,
+    dylib::proc_macros::ProcMacros, token_stream::TokenStream,
 };
 
 pub(crate) struct Expander {
@@ -28,10 +24,7 @@ pub(crate) struct Expander {
 }
 
 impl Expander {
-    pub(crate) fn new(
-        temp_dir: &TempDir,
-        lib: &Utf8Path,
-    ) -> Result<Expander, LoadProcMacroDylibError> {
+    pub(crate) fn new(temp_dir: &TempDir, lib: &Utf8Path) -> io::Result<Expander> {
         // Some libraries for dynamic loading require canonicalized path even when it is
         // already absolute
         let lib = lib.canonicalize_utf8()?;
@@ -78,61 +71,17 @@ impl Expander {
     }
 }
 
-#[derive(Debug)]
-pub enum LoadProcMacroDylibError {
-    Io(io::Error),
-    LibLoading(libloading::Error),
-    MetadataError(MetadataError<'static>),
-}
-
-impl fmt::Display for LoadProcMacroDylibError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Io(e) => e.fmt(f),
-            Self::LibLoading(e) => e.fmt(f),
-            Self::MetadataError(e) => e.fmt(f),
-        }
-    }
-}
-
-impl From<io::Error> for LoadProcMacroDylibError {
-    fn from(e: io::Error) -> Self {
-        LoadProcMacroDylibError::Io(e)
-    }
-}
-
-impl From<libloading::Error> for LoadProcMacroDylibError {
-    fn from(e: libloading::Error) -> Self {
-        LoadProcMacroDylibError::LibLoading(e)
-    }
-}
-
-impl From<MetadataError<'_>> for LoadProcMacroDylibError {
-    fn from(e: MetadataError<'_>) -> Self {
-        LoadProcMacroDylibError::MetadataError(match e {
-            MetadataError::NotPresent(path) => MetadataError::NotPresent(path.into_owned().into()),
-            MetadataError::LoadFailure(err) => MetadataError::LoadFailure(err),
-            MetadataError::VersionMismatch { expected_version, found_version } => {
-                MetadataError::VersionMismatch { expected_version, found_version }
-            }
-        })
-    }
-}
-
 struct ProcMacroLibrary {
-    // this contains references to the library, so make sure this drops before _lib
     proc_macros: ProcMacros,
-    // Hold on to the library so it doesn't unload
-    _lib: Library,
 }
 
 impl ProcMacroLibrary {
-    fn open(path: &Utf8Path) -> Result<Self, LoadProcMacroDylibError> {
-        let proc_macro_kinds = rustc_span::create_default_session_globals_then(|| {
+    fn open(path: &Utf8Path) -> io::Result<Self> {
+        let proc_macros = rustc_span::create_default_session_globals_then(|| {
             let (target, _) =
                 Target::search(&TargetTuple::from_tuple(host_tuple()), Path::new(""), false)
                     .unwrap();
-            rustc_metadata::locator::get_proc_macro_info(
+            rustc_metadata::locator::get_proc_macros(
                 &target,
                 path.as_ref(),
                 &DefaultMetadataLoader,
@@ -140,61 +89,8 @@ impl ProcMacroLibrary {
             )
         })?;
 
-        let file = fs::File::open(path)?;
-        #[allow(clippy::undocumented_unsafe_blocks)] // FIXME
-        let file = unsafe { memmap2::Mmap::map(&file) }?;
-        let obj = object::File::parse(&*file)
-            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
-        let symbol_name =
-            find_registrar_symbol(&obj).map_err(invalid_data_err)?.ok_or_else(|| {
-                invalid_data_err(format!("Cannot find registrar symbol in file {path}"))
-            })?;
-
-        // SAFETY: We have verified the validity of the dylib as a proc-macro library
-        let lib = unsafe { load_library(path) }.map_err(invalid_data_err)?;
-        // SAFETY: We have verified the validity of the dylib as a proc-macro library
-        // The 'static lifetime is a lie, it's actually the lifetime of the library but unavoidable
-        // due to self-referentiality
-        // But we make sure that we do not drop it before the symbol is dropped
-        let proc_macros =
-            unsafe { lib.get::<&'static &'static ProcMacroClients>(symbol_name.as_bytes()) };
-        match proc_macros {
-            Ok(proc_macros) => Ok(ProcMacroLibrary {
-                proc_macros: ProcMacros::new(*proc_macros, proc_macro_kinds),
-                _lib: lib,
-            }),
-            Err(e) => Err(e.into()),
-        }
+        Ok(ProcMacroLibrary { proc_macros: ProcMacros::new(proc_macros) })
     }
-}
-
-fn invalid_data_err(e: impl Into<Box<dyn std::error::Error + Send + Sync>>) -> io::Error {
-    io::Error::new(io::ErrorKind::InvalidData, e)
-}
-
-fn is_derive_registrar_symbol(symbol: &str) -> bool {
-    const NEW_REGISTRAR_SYMBOL: &str = "_rustc_proc_macro_decls_";
-    symbol.contains(NEW_REGISTRAR_SYMBOL)
-}
-
-fn find_registrar_symbol(obj: &object::File<'_>) -> object::Result<Option<String>> {
-    Ok(obj
-        .exports()?
-        .into_iter()
-        .map(|export| export.name())
-        .filter_map(|sym| String::from_utf8(sym.into()).ok())
-        .find(|sym| is_derive_registrar_symbol(sym))
-        .map(|sym| {
-            // From MacOS docs:
-            // https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/dlsym.3.html
-            // Unlike other dyld API's, the symbol name passed to dlsym() must NOT be
-            // prepended with an underscore.
-            if cfg!(target_os = "macos") && sym.starts_with('_') {
-                sym[1..].to_owned()
-            } else {
-                sym
-            }
-        }))
 }
 
 /// Copy the dylib to temp directory to prevent locking in Windows
@@ -232,55 +128,4 @@ fn ensure_file_with_lock_free_access(
     path: &Utf8Path,
 ) -> io::Result<Utf8PathBuf> {
     Ok(path.to_owned())
-}
-
-/// Loads dynamic library in platform dependent manner.
-///
-/// For unix, you have to use RTLD_DEEPBIND flag to escape problems described
-/// [here](https://github.com/fedochet/rust-proc-macro-panic-inside-panic-expample)
-/// and [here](https://github.com/rust-lang/rust/issues/60593).
-///
-/// Usage of RTLD_DEEPBIND
-/// [here](https://github.com/fedochet/rust-proc-macro-panic-inside-panic-expample/issues/1)
-///
-/// It seems that on Windows that behaviour is default, so we do nothing in that case.
-///
-/// # Safety
-///
-/// The caller is responsible for ensuring that the path is valid proc-macro library
-#[cfg(windows)]
-unsafe fn load_library(file: &Utf8Path) -> Result<Library, libloading::Error> {
-    // SAFETY: The caller is responsible for ensuring that the path is valid proc-macro library
-    unsafe { Library::new(file) }
-}
-
-/// Loads dynamic library in platform dependent manner.
-///
-/// For unix, you have to use RTLD_DEEPBIND flag to escape problems described
-/// [here](https://github.com/fedochet/rust-proc-macro-panic-inside-panic-expample)
-/// and [here](https://github.com/rust-lang/rust/issues/60593).
-///
-/// Usage of RTLD_DEEPBIND
-/// [here](https://github.com/fedochet/rust-proc-macro-panic-inside-panic-expample/issues/1)
-///
-/// It seems that on Windows that behaviour is default, so we do nothing in that case.
-///
-/// # Safety
-///
-/// The caller is responsible for ensuring that the path is valid proc-macro library
-#[cfg(unix)]
-unsafe fn load_library(file: &Utf8Path) -> Result<Library, libloading::Error> {
-    // not defined by POSIX, different values on mips vs other targets
-    #[cfg(target_env = "gnu")]
-    use libc::RTLD_DEEPBIND;
-    use libloading::os::unix::Library as UnixLibrary;
-    // defined by POSIX
-    use libloading::os::unix::RTLD_NOW;
-
-    // MUSL and bionic don't have it..
-    #[cfg(not(target_env = "gnu"))]
-    const RTLD_DEEPBIND: std::os::raw::c_int = 0x0;
-
-    // SAFETY: The caller is responsible for ensuring that the path is valid proc-macro library
-    unsafe { UnixLibrary::open(Some(file), RTLD_NOW | RTLD_DEEPBIND).map(|lib| lib.into()) }
 }

--- a/src/tools/rust-analyzer/crates/proc-macro-srv/src/dylib/proc_macros.rs
+++ b/src/tools/rust-analyzer/crates/proc-macro-srv/src/dylib/proc_macros.rs
@@ -4,9 +4,6 @@ use crate::{
 };
 use rustc_proc_macro::bridge;
 
-#[repr(transparent)]
-pub(crate) struct ProcMacroClients([bridge::client::Client]);
-
 impl From<bridge::PanicMessage> for crate::PanicMessage {
     fn from(p: bridge::PanicMessage) -> Self {
         Self { message: p.into_string() }
@@ -17,10 +14,9 @@ pub(crate) struct ProcMacros(Vec<(bridge::client::Client, rustc_metadata::ProcMa
 
 impl ProcMacros {
     pub(super) fn new(
-        clients: &ProcMacroClients,
-        kinds: Vec<rustc_metadata::ProcMacroKind>,
+        macros: Vec<(bridge::client::Client, rustc_metadata::ProcMacroKind)>,
     ) -> Self {
-        ProcMacros(clients.0.iter().copied().zip(kinds).collect::<Vec<_>>())
+        ProcMacros(macros)
     }
 
     pub(crate) fn expand<'a, S: ProcMacroSrvSpan>(

--- a/src/tools/rust-analyzer/crates/proc-macro-srv/src/lib.rs
+++ b/src/tools/rust-analyzer/crates/proc-macro-srv/src/lib.rs
@@ -10,9 +10,10 @@
 
 #![cfg(feature = "in-rust-tree")]
 #![feature(proc_macro_internals, proc_macro_diagnostic, proc_macro_span, rustc_private)]
-#![expect(unreachable_pub, internal_features, clippy::disallowed_types, clippy::print_stderr)]
+#![expect(internal_features, clippy::disallowed_types, clippy::print_stderr)]
 #![allow(unused_features, unused_crate_dependencies)]
 #![deny(deprecated_safe, clippy::undocumented_unsafe_blocks)]
+#![cfg_attr(test, expect(unreachable_pub))]
 
 extern crate rustc_codegen_ssa;
 extern crate rustc_driver as _;


### PR DESCRIPTION
This will make it easier to change how proc-macros are implemented on the rustc side. For example allowing support for wasm proc-macros without duplicating the implementation between proc-macro-srv and rustc.