### PR TITLE
Stop using a fn pointer to normalize_fn_sig inside TypeErrCtxt

### DIFF
--- a/compiler/rustc_hir_typeck/src/fn_ctxt/mod.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/mod.rs
@@ -197,25 +197,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     pub(crate) fn err_ctxt(&'a self) -> TypeErrCtxt<'a, 'tcx> {
         TypeErrCtxt {
             infcx: &self.infcx,
+            param_env: Some(self.param_env),
             typeck_results: Some(self.typeck_results.borrow()),
             diverging_fallback_has_occurred: self.diverging_fallback_has_occurred.get(),
-            normalize_fn_sig: Box::new(|fn_sig| {
-                if fn_sig.skip_normalization().has_escaping_bound_vars() {
-                    return fn_sig.skip_normalization();
-                }
-                self.probe(|_| {
-                    let ocx = ObligationCtxt::new(self);
-                    let normalized_fn_sig =
-                        ocx.normalize(&ObligationCause::dummy(), self.param_env, fn_sig);
-                    if ocx.evaluate_obligations_error_on_ambiguity().is_empty() {
-                        let normalized_fn_sig = self.resolve_vars_if_possible(normalized_fn_sig);
-                        if !normalized_fn_sig.has_infer() {
-                            return normalized_fn_sig;
-                        }
-                    }
-                    fn_sig.skip_normalization()
-                })
-            }),
             autoderef_steps: Box::new(|ty| {
                 let mut autoderef = self.autoderef(DUMMY_SP, ty).silence_errors();
                 let mut steps = vec![];

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/mod.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/mod.rs
@@ -80,7 +80,8 @@ use crate::infer::relate::{self, RelateResult, TypeRelation};
 use crate::infer::{InferCtxt, InferCtxtExt as _, TypeTrace, ValuePairs};
 use crate::solve::deeply_normalize_for_diagnostics;
 use crate::traits::{
-    MatchExpressionArmCause, Obligation, ObligationCause, ObligationCauseCode, specialization_graph,
+    MatchExpressionArmCause, Obligation, ObligationCause, ObligationCauseCode, ObligationCtxt,
+    specialization_graph,
 };
 
 mod note_and_explain;
@@ -113,6 +114,31 @@ fn escape_literal(s: &str) -> String {
 }
 
 impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
+    fn normalize_fn_sig(
+        &self,
+        fn_sig: Unnormalized<'tcx, ty::PolyFnSig<'tcx>>,
+    ) -> ty::PolyFnSig<'tcx> {
+        let Some(param_env) = self.param_env else {
+            return fn_sig.skip_normalization();
+        };
+
+        if fn_sig.skip_normalization().has_escaping_bound_vars() {
+            return fn_sig.skip_normalization();
+        }
+
+        self.probe(|_| {
+            let ocx = ObligationCtxt::new(self);
+            let normalized_fn_sig = ocx.normalize(&ObligationCause::dummy(), param_env, fn_sig);
+            if ocx.evaluate_obligations_error_on_ambiguity().is_empty() {
+                let normalized_fn_sig = self.resolve_vars_if_possible(normalized_fn_sig);
+                if !normalized_fn_sig.has_infer() {
+                    return normalized_fn_sig;
+                }
+            }
+            fn_sig.skip_normalization()
+        })
+    }
+
     // [Note-Type-error-reporting]
     // An invariant is that anytime the expected or actual type is Error (the special
     // error type, meaning that an error occurred when typechecking this expression),
@@ -758,18 +784,18 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
     /// Given two `fn` signatures highlight only sub-parts that are different.
     fn cmp_fn_sig(
         &self,
-        sig1: &ty::PolyFnSig<'tcx>,
+        sig1: ty::PolyFnSig<'tcx>,
         fn_def1: Option<(DefId, Option<&'tcx [ty::GenericArg<'tcx>]>)>,
-        sig2: &ty::PolyFnSig<'tcx>,
+        sig2: ty::PolyFnSig<'tcx>,
         fn_def2: Option<(DefId, Option<&'tcx [ty::GenericArg<'tcx>]>)>,
     ) -> (DiagStyledString, DiagStyledString) {
-        let sig1 = &(self.normalize_fn_sig)(Unnormalized::new_wip(*sig1));
-        let sig2 = &(self.normalize_fn_sig)(Unnormalized::new_wip(*sig2));
+        let sig1 = self.normalize_fn_sig(Unnormalized::new_wip(sig1));
+        let sig2 = self.normalize_fn_sig(Unnormalized::new_wip(sig2));
 
         let get_lifetimes = |sig| {
             use rustc_hir::def::Namespace;
             let (sig, reg) = ty::print::FmtPrinter::new(self.tcx, Namespace::TypeNS)
-                .name_all_regions(sig, WrapBinderMode::ForAll)
+                .name_all_regions(&sig, WrapBinderMode::ForAll)
                 .unwrap();
             let lts: Vec<String> =
                 reg.into_items().map(|(_, kind)| kind.to_string()).into_sorted_stable_ord();
@@ -1282,26 +1308,21 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             (ty::FnDef(did1, args1), ty::FnDef(did2, args2)) => {
                 let sig1 = self.tcx.fn_sig(*did1).instantiate(self.tcx, args1).skip_norm_wip();
                 let sig2 = self.tcx.fn_sig(*did2).instantiate(self.tcx, args2).skip_norm_wip();
-                self.cmp_fn_sig(
-                    &sig1,
-                    Some((*did1, Some(args1))),
-                    &sig2,
-                    Some((*did2, Some(args2))),
-                )
+                self.cmp_fn_sig(sig1, Some((*did1, Some(args1))), sig2, Some((*did2, Some(args2))))
             }
 
             (ty::FnDef(did1, args1), ty::FnPtr(sig_tys2, hdr2)) => {
                 let sig1 = self.tcx.fn_sig(*did1).instantiate(self.tcx, args1).skip_norm_wip();
-                self.cmp_fn_sig(&sig1, Some((*did1, Some(args1))), &sig_tys2.with(*hdr2), None)
+                self.cmp_fn_sig(sig1, Some((*did1, Some(args1))), sig_tys2.with(*hdr2), None)
             }
 
             (ty::FnPtr(sig_tys1, hdr1), ty::FnDef(did2, args2)) => {
                 let sig2 = self.tcx.fn_sig(*did2).instantiate(self.tcx, args2).skip_norm_wip();
-                self.cmp_fn_sig(&sig_tys1.with(*hdr1), None, &sig2, Some((*did2, Some(args2))))
+                self.cmp_fn_sig(sig_tys1.with(*hdr1), None, sig2, Some((*did2, Some(args2))))
             }
 
             (ty::FnPtr(sig_tys1, hdr1), ty::FnPtr(sig_tys2, hdr2)) => {
-                self.cmp_fn_sig(&sig_tys1.with(*hdr1), None, &sig_tys2.with(*hdr2), None)
+                self.cmp_fn_sig(sig_tys1.with(*hdr1), None, sig_tys2.with(*hdr2), None)
             }
 
             _ => {
@@ -2082,7 +2103,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     (None, None)
                 };
 
-                Some(self.cmp_fn_sig(&exp_found.expected, fn_def1, &exp_found.found, fn_def2))
+                Some(self.cmp_fn_sig(exp_found.expected, fn_def1, exp_found.found, fn_def2))
             }
         }
     }

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/suggest.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/suggest.rs
@@ -412,13 +412,13 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
         match (expected_inner.kind(), found_inner.kind()) {
             (ty::FnPtr(sig_tys, hdr), ty::FnDef(did, args)) => {
                 let sig = sig_tys.with(*hdr);
-                let expected_sig = &(self.normalize_fn_sig)(Unnormalized::new_wip(sig));
+                let expected_sig = self.normalize_fn_sig(Unnormalized::new_wip(sig));
                 let found_sig =
-                    &(self.normalize_fn_sig)(self.tcx.fn_sig(*did).instantiate(self.tcx, args));
+                    self.normalize_fn_sig(self.tcx.fn_sig(*did).instantiate(self.tcx, args));
 
                 let fn_name = self.tcx.def_path_str_with_args(*did, args);
 
-                if !self.same_type_modulo_infer(*found_sig, *expected_sig)
+                if !self.same_type_modulo_infer(found_sig, expected_sig)
                     || !sig.is_suggestable(self.tcx, true)
                     || self.tcx.intrinsic(*did).is_some()
                 {
@@ -450,15 +450,15 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
             }
             (ty::FnDef(did1, args1), ty::FnDef(did2, args2)) => {
                 let expected_sig =
-                    &(self.normalize_fn_sig)(self.tcx.fn_sig(*did1).instantiate(self.tcx, args1));
+                    self.normalize_fn_sig(self.tcx.fn_sig(*did1).instantiate(self.tcx, args1));
                 let found_sig =
-                    &(self.normalize_fn_sig)(self.tcx.fn_sig(*did2).instantiate(self.tcx, args2));
+                    self.normalize_fn_sig(self.tcx.fn_sig(*did2).instantiate(self.tcx, args2));
 
-                if self.same_type_modulo_infer(*expected_sig, *found_sig) {
+                if self.same_type_modulo_infer(expected_sig, found_sig) {
                     diag.subdiagnostic(FnUniqTypes);
                 }
 
-                if !self.same_type_modulo_infer(*found_sig, *expected_sig)
+                if !self.same_type_modulo_infer(found_sig, expected_sig)
                     || !found_sig.is_suggestable(self.tcx, true)
                     || !expected_sig.is_suggestable(self.tcx, true)
                     || self.tcx.intrinsic(*did1).is_some()
@@ -470,7 +470,7 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
                 let fn_name = self.tcx.def_path_str_with_args(*did2, args2);
 
                 let Some(span) = span else {
-                    diag.subdiagnostic(FnConsiderCastingBoth { sig: *expected_sig });
+                    diag.subdiagnostic(FnConsiderCastingBoth { sig: expected_sig });
                     return;
                 };
 
@@ -478,14 +478,14 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
                     FunctionPointerSuggestion::CastBothRef {
                         span,
                         fn_name,
-                        found_sig: *found_sig,
-                        expected_sig: *expected_sig,
+                        found_sig,
+                        expected_sig,
                     }
                 } else {
                     FunctionPointerSuggestion::CastBoth {
                         span: span.shrink_to_hi(),
-                        found_sig: *found_sig,
-                        expected_sig: *expected_sig,
+                        found_sig,
+                        expected_sig,
                     }
                 };
 
@@ -493,10 +493,10 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
             }
             (ty::FnDef(did, args), ty::FnPtr(sig_tys, hdr)) => {
                 let expected_sig =
-                    &(self.normalize_fn_sig)(self.tcx.fn_sig(*did).instantiate(self.tcx, args));
-                let found_sig = &(self.normalize_fn_sig)(Unnormalized::new_wip(sig_tys.with(*hdr)));
+                    self.normalize_fn_sig(self.tcx.fn_sig(*did).instantiate(self.tcx, args));
+                let found_sig = self.normalize_fn_sig(Unnormalized::new_wip(sig_tys.with(*hdr)));
 
-                if !self.same_type_modulo_infer(*found_sig, *expected_sig) {
+                if !self.same_type_modulo_infer(found_sig, expected_sig) {
                     return;
                 }
 

--- a/compiler/rustc_trait_selection/src/error_reporting/mod.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/mod.rs
@@ -5,7 +5,7 @@ use rustc_infer::infer::InferCtxt;
 use rustc_infer::traits::PredicateObligations;
 use rustc_macros::extension;
 use rustc_middle::bug;
-use rustc_middle::ty::{self, Ty, Unnormalized};
+use rustc_middle::ty::{self, Ty};
 
 pub mod infer;
 pub mod traits;
@@ -19,12 +19,10 @@ pub mod traits;
 /// methods which should not be used during the happy path.
 pub struct TypeErrCtxt<'a, 'tcx> {
     pub infcx: &'a InferCtxt<'tcx>,
+    pub param_env: Option<ty::ParamEnv<'tcx>>,
 
     pub typeck_results: Option<std::cell::Ref<'a, ty::TypeckResults<'tcx>>>,
     pub diverging_fallback_has_occurred: bool,
-
-    pub normalize_fn_sig:
-        Box<dyn Fn(Unnormalized<'tcx, ty::PolyFnSig<'tcx>>) -> ty::PolyFnSig<'tcx> + 'a>,
 
     pub autoderef_steps: Box<dyn Fn(Ty<'tcx>) -> Vec<(Ty<'tcx>, PredicateObligations<'tcx>)> + 'a>,
 }
@@ -36,9 +34,9 @@ impl<'tcx> InferCtxt<'tcx> {
     fn err_ctxt(&self) -> TypeErrCtxt<'_, 'tcx> {
         TypeErrCtxt {
             infcx: self,
+            param_env: None,
             typeck_results: None,
             diverging_fallback_has_occurred: false,
-            normalize_fn_sig: Box::new(|fn_sig| fn_sig.skip_normalization()),
             autoderef_steps: Box::new(|ty| {
                 debug_assert!(false, "shouldn't be using autoderef_steps outside of typeck");
                 vec![(ty, PredicateObligations::new())]


### PR DESCRIPTION
Part of https://github.com/rust-lang/rust/issues/127492

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
