### PR TITLE
perf: add missing #[inline] to hot trivial methods

### DIFF
--- a/compiler/rustc_ast/src/token.rs
+++ b/compiler/rustc_ast/src/token.rs
@@ -866,6 +866,7 @@ impl Token {
     }
 
     /// Returns `true` if the token is an identifier.
+    #[inline]
     pub fn is_ident(&self) -> bool {
         self.ident().is_some()
     }
@@ -918,6 +919,7 @@ impl Token {
     }
 
     /// Returns `true` if the token is a given keyword, `kw`.
+    #[inline]
     pub fn is_keyword(&self, kw: Symbol) -> bool {
         self.is_non_raw_ident_where(|id| id.name == kw)
     }
@@ -980,6 +982,7 @@ impl Token {
     }
 
     /// Returns `true` if the token is a non-raw identifier for which `pred` holds.
+    #[inline]
     pub fn is_non_raw_ident_where(&self, pred: impl FnOnce(Ident) -> bool) -> bool {
         match self.ident() {
             Some((id, IdentIsRaw::No)) => pred(id),

--- a/compiler/rustc_ast_ir/src/visit.rs
+++ b/compiler/rustc_ast_ir/src/visit.rs
@@ -16,9 +16,13 @@ impl VisitorResult for () {
     #[cfg(not(feature = "nightly"))]
     type Residual = core::convert::Infallible;
 
+    #[inline]
     fn output() -> Self {}
+    #[inline]
     fn from_residual(_: Self::Residual) -> Self {}
+    #[inline]
     fn from_branch(_: ControlFlow<Self::Residual>) -> Self {}
+    #[inline]
     fn branch(self) -> ControlFlow<Self::Residual> {
         ControlFlow::Continue(())
     }
@@ -27,15 +31,19 @@ impl VisitorResult for () {
 impl<T> VisitorResult for ControlFlow<T> {
     type Residual = T;
 
+    #[inline]
     fn output() -> Self {
         ControlFlow::Continue(())
     }
+    #[inline]
     fn from_residual(residual: Self::Residual) -> Self {
         ControlFlow::Break(residual)
     }
+    #[inline]
     fn from_branch(b: Self) -> Self {
         b
     }
+    #[inline]
     fn branch(self) -> Self {
         self
     }
@@ -44,18 +52,22 @@ impl<T> VisitorResult for ControlFlow<T> {
 impl<E> VisitorResult for Result<(), E> {
     type Residual = E;
 
+    #[inline]
     fn output() -> Self {
         Ok(())
     }
+    #[inline]
     fn from_residual(residual: Self::Residual) -> Self {
         Err(residual)
     }
+    #[inline]
     fn from_branch(b: ControlFlow<Self::Residual>) -> Self {
         match b {
             ControlFlow::Continue(()) => Ok(()),
             ControlFlow::Break(e) => Err(e),
         }
     }
+    #[inline]
     fn branch(self) -> ControlFlow<Self::Residual> {
         match self {
             Ok(()) => ControlFlow::Continue(()),

--- a/compiler/rustc_index_macros/src/newtype.rs
+++ b/compiler/rustc_index_macros/src/newtype.rs
@@ -101,12 +101,14 @@ impl Parse for Newtype {
             quote! {
                 #gate_rustc_only
                 impl<D: ::rustc_serialize::Decoder> ::rustc_serialize::Decodable<D> for #name {
+                    #[inline]
                     fn decode(d: &mut D) -> Self {
                         Self::from_u32(d.read_u32())
                     }
                 }
                 #gate_rustc_only
                 impl<E: ::rustc_serialize::Encoder> ::rustc_serialize::Encodable<E> for #name {
+                    #[inline]
                     fn encode(&self, e: &mut E) {
                         e.emit_u32(self.as_u32());
                     }
@@ -138,11 +140,13 @@ impl Parse for Newtype {
                     }
                 }
                 impl ::std::cmp::Ord for #name {
+                    #[inline]
                     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
                         self.as_u32().cmp(&other.as_u32())
                     }
                 }
                 impl ::std::cmp::PartialOrd for #name {
+                    #[inline]
                     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
                         self.as_u32().partial_cmp(&other.as_u32())
                     }
@@ -156,6 +160,7 @@ impl Parse for Newtype {
             quote! {
                 #gate_rustc_only
                 impl ::rustc_data_structures::stable_hash::StableHash for #name {
+                    #[inline]
                     fn stable_hash<
                         __Hcx: ::rustc_data_structures::stable_hash::StableHashCtxt
                     >(
@@ -340,6 +345,7 @@ impl Parse for Newtype {
             impl ::std::cmp::Eq for #name {}
 
             impl ::std::cmp::PartialEq for #name {
+                #[inline]
                 fn eq(&self, other: &Self) -> bool {
                     self.as_u32().eq(&other.as_u32())
                 }
@@ -349,6 +355,7 @@ impl Parse for Newtype {
             impl ::std::marker::StructuralPartialEq for #name {}
 
             impl ::std::hash::Hash for #name {
+                #[inline]
                 fn hash<H: ::std::hash::Hasher>(&self, state: &mut H) {
                     self.as_u32().hash(state)
                 }

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -82,7 +82,8 @@ macro_rules! empty_proc_macro {
 
 macro_rules! encoder_methods {
     ($($name:ident($ty:ty);)*) => {
-        $(fn $name(&mut self, value: $ty) {
+        $(#[inline]
+        fn $name(&mut self, value: $ty) {
             self.opaque.$name(value)
         })*
     }

--- a/compiler/rustc_middle/src/query/on_disk_cache.rs
+++ b/compiler/rustc_middle/src/query/on_disk_cache.rs
@@ -972,8 +972,8 @@ impl<'a, 'tcx> TyEncoder<'tcx> for CacheEncoder<'a, 'tcx> {
 
 macro_rules! encoder_methods {
     ($($name:ident($ty:ty);)*) => {
-        #[inline]
-        $(fn $name(&mut self, value: $ty) {
+        $(#[inline]
+        fn $name(&mut self, value: $ty) {
             self.encoder.$name(value)
         })*
     }


### PR DESCRIPTION
This marks trivial but very hot methods `#[inline]` so they can be inlined across crate boundaries (found by profiling with callgrind)