### PR TITLE
resolve: Partially revert "Remove a special case for dummy imports"

### DIFF
--- a/compiler/rustc_resolve/src/imports.rs
+++ b/compiler/rustc_resolve/src/imports.rs
@@ -628,6 +628,15 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             module.underscore_disambiguator.get()
         });
         self.update_local_resolution(module, key, orig_ident_span, |this, resolution| {
+            if res == Res::Err
+                && let Some(old_decl) = resolution.best_decl()
+                && old_decl.res() != Res::Err
+            {
+                // Do not override real declarations with `Res::Err`s from error recovery.
+                // FIXME: this special case shouldn't be necessary, but removing it triggers an ICE
+                // due to some other issues (#157406, tests/ui/imports/dummy-import-ice.rs).
+                return Ok(());
+            }
             if decl.is_glob_import() {
                 resolution.glob_decl = Some(match resolution.glob_decl {
                     Some(old_decl) => this.select_glob_decl(old_decl, decl),

--- a/tests/ui/imports/auxiliary/dummy-import-ice-macro.rs
+++ b/tests/ui/imports/auxiliary/dummy-import-ice-macro.rs
@@ -1,0 +1,15 @@
+extern crate proc_macro;
+use proc_macro::TokenStream;
+
+#[proc_macro]
+pub fn my_macro(_: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    r"
+        use own::*;
+        mod own {
+            pub use super::submodule::*;
+            pub use super::ambiguous;
+        }
+    "
+    .parse()
+    .unwrap()
+}

--- a/tests/ui/imports/dummy-import-ice.rs
+++ b/tests/ui/imports/dummy-import-ice.rs
@@ -1,0 +1,20 @@
+// Regression test for issue #157406.
+
+//@ check-pass
+//@ proc-macro: dummy-import-ice-macro.rs
+
+extern crate dummy_import_ice_macro;
+
+pub fn foo() {
+    ambiguous();
+}
+
+mod submodule {
+    pub fn ambiguous() {}
+}
+
+pub mod ambiguous {}
+
+dummy_import_ice_macro::my_macro!();
+
+fn main() {}

--- a/tests/ui/imports/issue-56125.rs
+++ b/tests/ui/imports/issue-56125.rs
@@ -15,7 +15,7 @@ mod m2 {
 mod m3 {
     mod empty {}
     use empty::issue_56125; //~ ERROR unresolved import `empty::issue_56125`
-    use issue_56125::*;
+    use issue_56125::*; //~ ERROR `issue_56125` is ambiguous
 }
 
 fn main() {}

--- a/tests/ui/imports/issue-56125.stderr
+++ b/tests/ui/imports/issue-56125.stderr
@@ -56,7 +56,24 @@ LL |     use issue_56125::non_last_segment::non_last_segment::*;
    = help: consider adding an explicit import of `issue_56125` to disambiguate
    = help: or use `self::issue_56125` to refer to this module unambiguously
 
-error: aborting due to 3 previous errors
+error[E0659]: `issue_56125` is ambiguous
+  --> $DIR/issue-56125.rs:18:9
+   |
+LL |     use issue_56125::*;
+   |         ^^^^^^^^^^^ ambiguous name
+   |
+   = note: ambiguous because of a conflict between a name from a glob import and an outer scope during import or macro resolution
+   = note: `issue_56125` could refer to a crate passed with `--extern`
+   = help: use `::issue_56125` to refer to this crate unambiguously
+note: `issue_56125` could also refer to the module imported here
+  --> $DIR/issue-56125.rs:18:9
+   |
+LL |     use issue_56125::*;
+   |         ^^^^^^^^^^^^^^
+   = help: consider adding an explicit import of `issue_56125` to disambiguate
+   = help: or use `self::issue_56125` to refer to this module unambiguously
+
+error: aborting due to 4 previous errors
 
 Some errors have detailed explanations: E0432, E0659.
 For more information about an error, try `rustc --explain E0432`.

--- a/tests/ui/imports/shadow-glob-module-resolution-2.rs
+++ b/tests/ui/imports/shadow-glob-module-resolution-2.rs
@@ -14,5 +14,7 @@ use a::*;
 use e as b;
 //~^ ERROR: unresolved import `e`
 use b::c::D as e;
+//~^ ERROR: cannot determine resolution for the import
+//~| ERROR: cannot determine resolution for the import
 
 fn main() { }

--- a/tests/ui/imports/shadow-glob-module-resolution-2.stderr
+++ b/tests/ui/imports/shadow-glob-module-resolution-2.stderr
@@ -1,3 +1,17 @@
+error: cannot determine resolution for the import
+  --> $DIR/shadow-glob-module-resolution-2.rs:16:5
+   |
+LL | use b::c::D as e;
+   |     ^^^^^^^^^^^^
+
+error: cannot determine resolution for the import
+  --> $DIR/shadow-glob-module-resolution-2.rs:16:5
+   |
+LL | use b::c::D as e;
+   |     ^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
 error[E0432]: unresolved import `e`
   --> $DIR/shadow-glob-module-resolution-2.rs:14:5
    |
@@ -12,6 +26,6 @@ LL - use e as b;
 LL + use a as b;
    |
 
-error: aborting due to 1 previous error
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0432`.

--- a/tests/ui/imports/shadow-glob-module-resolution-4.rs
+++ b/tests/ui/imports/shadow-glob-module-resolution-4.rs
@@ -12,6 +12,8 @@ use e as b;
 
 use b::C as e;
 //~^ ERROR: unresolved import `b::C`
+//~| ERROR: cannot determine resolution for the import
+//~| ERROR: cannot determine resolution for the import
 
 fn e() {}
 

--- a/tests/ui/imports/shadow-glob-module-resolution-4.stderr
+++ b/tests/ui/imports/shadow-glob-module-resolution-4.stderr
@@ -1,9 +1,23 @@
+error: cannot determine resolution for the import
+  --> $DIR/shadow-glob-module-resolution-4.rs:13:5
+   |
+LL | use b::C as e;
+   |     ^^^^^^^^^
+
+error: cannot determine resolution for the import
+  --> $DIR/shadow-glob-module-resolution-4.rs:13:5
+   |
+LL | use b::C as e;
+   |     ^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
 error[E0432]: unresolved import `b::C`
   --> $DIR/shadow-glob-module-resolution-4.rs:13:5
    |
 LL | use b::C as e;
    |     ^^^^^^^^^
 
-error: aborting due to 1 previous error
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0432`.


### PR DESCRIPTION
Reverts a part of https://github.com/rust-lang/rust/pull/154435/changes/b0b1ebe636907fb6f915b39afafbbd6d05e2226b and fixes https://github.com/rust-lang/rust/issues/157406.

r? @jackh726 