### PR TITLE
Move uninhabited unreachable code lint to rustc_mir_transform

### DIFF
--- a/compiler/rustc_mir_build/src/builder/mod.rs
+++ b/compiler/rustc_mir_build/src/builder/mod.rs
@@ -28,7 +28,7 @@ use rustc_data_structures::fx::FxHashMap;
 use rustc_data_structures::sorted_map::SortedIndexMultiMap;
 use rustc_errors::ErrorGuaranteed;
 use rustc_hir::def::DefKind;
-use rustc_hir::def_id::{DefId, LocalDefId};
+use rustc_hir::def_id::LocalDefId;
 use rustc_hir::{self as hir, BindingMode, ByRef, HirId, ItemLocalId, Node, find_attr};
 use rustc_index::bit_set::GrowableBitSet;
 use rustc_index::{Idx, IndexSlice, IndexVec};
@@ -39,12 +39,10 @@ use rustc_middle::mir::*;
 use rustc_middle::thir::{self, ExprId, LocalVarId, Param, ParamId, PatKind, Thir};
 use rustc_middle::ty::{self, ScalarInt, Ty, TyCtxt, TypeVisitableExt, TypingMode};
 use rustc_middle::{bug, span_bug};
-use rustc_session::lint;
 use rustc_span::{Span, Symbol};
 
 use crate::builder::expr::as_place::PlaceBuilder;
 use crate::builder::scope::{DropKind, LintLevel};
-use crate::diagnostics;
 
 pub(crate) fn closure_saved_names_of_captured_variables<'tcx>(
     tcx: TyCtxt<'tcx>,
@@ -172,7 +170,6 @@ struct Builder<'a, 'tcx> {
 
     def_id: LocalDefId,
     hir_id: HirId,
-    parent_module: DefId,
     check_overflow: bool,
     fn_span: Span,
     arg_count: usize,
@@ -546,7 +543,6 @@ fn construct_fn<'tcx>(
         return_block.unit()
     });
 
-    builder.lint_and_remove_uninhabited();
     let mut body = builder.finish();
 
     body.spread_arg = if abi == ExternAbi::RustCall {
@@ -603,8 +599,6 @@ fn construct_const<'a, 'tcx>(
     builder.cfg.terminate(block, source_info, TerminatorKind::Return);
 
     builder.build_drop_trees();
-
-    builder.lint_and_remove_uninhabited();
     builder.finish()
 }
 
@@ -774,7 +768,6 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             param_env,
             def_id: def,
             hir_id,
-            parent_module: tcx.parent_module(hir_id).to_def_id(),
             check_overflow,
             cfg: CFG { basic_blocks: IndexVec::new() },
             fn_span: span,
@@ -822,123 +815,6 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
 
         let writer = pretty::MirWriter::new(self.tcx);
         writer.write_mir_fn(&body, &mut std::io::stdout()).unwrap();
-    }
-
-    fn lint_and_remove_uninhabited(&mut self) {
-        let mut lints = vec![];
-
-        for bbdata in self.cfg.basic_blocks.iter_mut() {
-            let term = bbdata.terminator_mut();
-            let TerminatorKind::Call { ref mut target, destination, .. } = term.kind else {
-                continue;
-            };
-            let Some(target_bb) = *target else { continue };
-
-            let ty = destination.ty(&self.local_decls, self.tcx).ty;
-            let ty_is_inhabited = ty.is_inhabited_from(
-                self.tcx,
-                self.parent_module,
-                self.infcx.typing_env(self.param_env),
-            );
-            if !ty_is_inhabited {
-                // Unreachable code warnings are already emitted during type checking.
-                // However, during type checking, full type information is being
-                // calculated but not yet available, so the check for diverging
-                // expressions due to uninhabited result types is pretty crude and
-                // only checks whether ty.is_never(). Here, we have full type
-                // information available and can issue warnings for less obviously
-                // uninhabited types (e.g. empty enums). The check above is used so
-                // that we do not emit the same warning twice if the uninhabited type
-                // is indeed `!`.
-                if !ty.is_never()
-                    && matches!(self.tcx.def_kind(self.def_id), DefKind::Fn | DefKind::AssocFn)
-                // check if the function's return type is inhabited
-                // this was added here because of this regression
-                // https://github.com/rust-lang/rust/issues/149571
-                    && self
-                        .tcx
-                        .fn_sig(self.def_id).instantiate_identity().skip_binder()
-                        .output()
-                        .is_inhabited_from(
-                            self.tcx,
-                            self.parent_module,
-                            self.infcx.typing_env(self.param_env),
-                        )
-                {
-                    lints.push((target_bb, ty, term.source_info.span));
-                }
-
-                // The presence or absence of a return edge affects control-flow sensitive
-                // MIR checks and ultimately whether code is accepted or not. We can only
-                // omit the return edge if a return type is visibly uninhabited to a module
-                // that makes the call.
-                *target = None;
-            }
-        }
-
-        /// Starting at a target unreachable block, find some user code to lint as unreachable
-        fn find_unreachable_code_from(
-            bb: BasicBlock,
-            bbs: &IndexVec<BasicBlock, BasicBlockData<'_>>,
-        ) -> Option<(SourceInfo, &'static str)> {
-            let bb = &bbs[bb];
-            for stmt in &bb.statements {
-                match &stmt.kind {
-                    // Ignore the implicit `()` return place assignment for unit functions/blocks
-                    StatementKind::Assign((_, Rvalue::Use(Operand::Constant(const_), _)))
-                        if const_.ty().is_unit() =>
-                    {
-                        continue;
-                    }
-                    // Ignore return value plumbing. After a call returning a non-`!`
-                    // uninhabited type, a tail expression can be unreachable while
-                    // still being needed to satisfy the surrounding return type.
-                    StatementKind::Assign((place, _)) if place.as_local() == Some(RETURN_PLACE) => {
-                        continue;
-                    }
-                    StatementKind::StorageLive(_) | StatementKind::StorageDead(_) => {
-                        continue;
-                    }
-                    StatementKind::FakeRead(..) => return Some((stmt.source_info, "definition")),
-                    _ => return Some((stmt.source_info, "expression")),
-                }
-            }
-
-            let term = bb.terminator();
-            match term.kind {
-                // No user code in this bb, and our goto target may be reachable via other paths
-                TerminatorKind::Goto { .. } | TerminatorKind::Return => None,
-                _ => Some((term.source_info, "expression")),
-            }
-        }
-
-        for (target_bb, orig_ty, orig_span) in lints {
-            if orig_span.in_external_macro(self.tcx.sess.source_map()) {
-                continue;
-            }
-
-            let Some((target_loc, descr)) =
-                find_unreachable_code_from(target_bb, &self.cfg.basic_blocks)
-            else {
-                continue;
-            };
-            let lint_root = self.source_scopes[target_loc.scope]
-                .local_data
-                .as_ref()
-                .unwrap_crate_local()
-                .lint_root;
-            self.tcx.emit_node_span_lint(
-                lint::builtin::UNREACHABLE_CODE,
-                lint_root,
-                target_loc.span,
-                diagnostics::UnreachableDueToUninhabited {
-                    expr: target_loc.span,
-                    orig: orig_span,
-                    descr,
-                    ty: orig_ty,
-                },
-            );
-        }
     }
 
     fn finish(self) -> Body<'tcx> {

--- a/compiler/rustc_mir_build/src/diagnostics.rs
+++ b/compiler/rustc_mir_build/src/diagnostics.rs
@@ -794,18 +794,6 @@ pub(crate) struct WantedConstant {
 }
 
 #[derive(Diagnostic)]
-#[diag("unreachable {$descr}")]
-pub(crate) struct UnreachableDueToUninhabited<'desc, 'tcx> {
-    pub descr: &'desc str,
-    #[label("unreachable {$descr}")]
-    pub expr: Span,
-    #[label("any code following this expression is unreachable")]
-    #[note("this expression has type `{$ty}`, which is uninhabited")]
-    pub orig: Span,
-    pub ty: Ty<'tcx>,
-}
-
-#[derive(Diagnostic)]
 #[diag("constant pattern cannot depend on generic parameters", code = E0158)]
 pub(crate) struct ConstPatternDependsOnGenericParameter {
     #[primary_span]

--- a/compiler/rustc_mir_transform/src/errors.rs
+++ b/compiler/rustc_mir_transform/src/errors.rs
@@ -5,7 +5,7 @@ use rustc_errors::{
 };
 use rustc_macros::{Diagnostic, Subdiagnostic};
 use rustc_middle::mir::AssertKind;
-use rustc_middle::ty::TyCtxt;
+use rustc_middle::ty::{Ty, TyCtxt};
 use rustc_session::lint::{self, Lint};
 use rustc_span::def_id::DefId;
 use rustc_span::{Ident, Span, Symbol};
@@ -161,6 +161,18 @@ pub(crate) struct FnItemRef {
     pub span: Span,
     pub sugg: String,
     pub ident: Ident,
+}
+
+#[derive(Diagnostic)]
+#[diag("unreachable {$descr}")]
+pub(crate) struct UnreachableDueToUninhabited<'desc, 'tcx> {
+    pub descr: &'desc str,
+    #[label("unreachable {$descr}")]
+    pub expr: Span,
+    #[label("any code following this expression is unreachable")]
+    #[note("this expression has type `{$ty}`, which is uninhabited")]
+    pub orig: Span,
+    pub ty: Ty<'tcx>,
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_mir_transform/src/lib.rs
+++ b/compiler/rustc_mir_transform/src/lib.rs
@@ -158,6 +158,7 @@ declare_passes! {
     mod jump_threading : JumpThreading;
     mod known_panics_lint : KnownPanicsLint;
     mod large_enums : EnumSizeOpt;
+    mod lint_and_remove_uninhabited : LintAndRemoveUninhabited;
     mod lower_intrinsics : LowerIntrinsics;
     mod lower_slice_len : LowerSliceLenCalls;
     mod match_branches : MatchBranchSimplification;
@@ -406,6 +407,9 @@ fn mir_built(tcx: TyCtxt<'_>, def: LocalDefId) -> &Steal<Body<'_>> {
         tcx,
         &mut body,
         &[
+            // This used to be part of MIR building,
+            // now done separately to separate concerns.
+            &lint_and_remove_uninhabited::LintAndRemoveUninhabited,
             // MIR-level lints.
             &Lint(check_inline::CheckForceInline),
             &Lint(check_call_recursion::CheckCallRecursion),

--- a/compiler/rustc_mir_transform/src/lint_and_remove_uninhabited.rs
+++ b/compiler/rustc_mir_transform/src/lint_and_remove_uninhabited.rs
@@ -1,0 +1,125 @@
+use rustc_hir::def::DefKind;
+use rustc_middle::mir::*;
+use rustc_middle::ty::TyCtxt;
+use rustc_session::lint::builtin::UNREACHABLE_CODE;
+
+use crate::errors::UnreachableDueToUninhabited;
+
+/// Lint unreachable code due to uninhabited values from function calls,
+/// and remove return edges from those calls.
+pub(super) struct LintAndRemoveUninhabited;
+
+impl<'tcx> crate::MirPass<'tcx> for LintAndRemoveUninhabited {
+    #[tracing::instrument(level = "debug", skip_all)]
+    fn run_pass(&self, tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
+        let def_id = body.source.def_id().expect_local();
+        tracing::debug!(?def_id);
+        let parent_module = tcx.parent_module_from_def_id(def_id).to_def_id();
+        let typing_env = body.typing_env(tcx);
+
+        // check if the function's return type is inhabited
+        // this was added here because of this regression
+        // https://github.com/rust-lang/rust/issues/149571
+        let return_ty_is_inhabited = matches!(tcx.def_kind(def_id), DefKind::Fn | DefKind::AssocFn)
+            && body.local_decls[RETURN_PLACE].ty.is_inhabited_from(tcx, parent_module, typing_env);
+
+        let mut lints = vec![];
+        for bbdata in body.basic_blocks.as_mut() {
+            let term = bbdata.terminator_mut();
+            let TerminatorKind::Call { ref mut target, destination, .. } = term.kind else {
+                continue;
+            };
+            let Some(target_bb) = *target else { continue };
+
+            let ty = destination.ty(&body.local_decls, tcx).ty;
+            let ty_is_inhabited = ty.is_inhabited_from(tcx, parent_module, typing_env);
+            if !ty_is_inhabited {
+                // Unreachable code warnings are already emitted during type checking.
+                // However, during type checking, full type information is being
+                // calculated but not yet available, so the check for diverging
+                // expressions due to uninhabited result types is pretty crude and
+                // only checks whether ty.is_never(). Here, we have full type
+                // information available and can issue warnings for less obviously
+                // uninhabited types (e.g. empty enums). The check above is used so
+                // that we do not emit the same warning twice if the uninhabited type
+                // is indeed `!`.
+                if !ty.is_never() && return_ty_is_inhabited {
+                    lints.push((target_bb, ty, term.source_info.span));
+                }
+
+                // The presence or absence of a return edge affects control-flow sensitive
+                // MIR checks and ultimately whether code is accepted or not. We can only
+                // omit the return edge if a return type is visibly uninhabited to a module
+                // that makes the call.
+                *target = None;
+            }
+        }
+
+        for (target_bb, orig_ty, orig_span) in lints {
+            if orig_span.in_external_macro(tcx.sess.source_map()) {
+                continue;
+            }
+
+            let Some((target_loc, descr)) = find_unreachable_code_from(target_bb, body) else {
+                continue;
+            };
+            let lint_root = body.source_scopes[target_loc.scope]
+                .local_data
+                .as_ref()
+                .unwrap_crate_local()
+                .lint_root;
+            tcx.emit_node_span_lint(
+                UNREACHABLE_CODE,
+                lint_root,
+                target_loc.span,
+                UnreachableDueToUninhabited {
+                    expr: target_loc.span,
+                    orig: orig_span,
+                    descr,
+                    ty: orig_ty,
+                },
+            );
+        }
+    }
+
+    fn is_required(&self) -> bool {
+        true
+    }
+}
+
+/// Starting at a target unreachable block, find some user code to lint as unreachable
+#[tracing::instrument(level = "debug", skip(body), ret)]
+fn find_unreachable_code_from<'tcx>(
+    bb: BasicBlock,
+    body: &Body<'tcx>,
+) -> Option<(SourceInfo, &'static str)> {
+    let bb = &body.basic_blocks[bb];
+    for stmt in &bb.statements {
+        match &stmt.kind {
+            // Ignore the implicit `()` return place assignment for unit functions/blocks
+            StatementKind::Assign((_, Rvalue::Use(Operand::Constant(const_), _)))
+                if const_.ty().is_unit() =>
+            {
+                continue;
+            }
+            // Ignore return value plumbing. After a call returning a non-`!`
+            // uninhabited type, a tail expression can be unreachable while
+            // still being needed to satisfy the surrounding return type.
+            StatementKind::Assign((place, _)) if place.as_local() == Some(RETURN_PLACE) => {
+                continue;
+            }
+            StatementKind::StorageLive(_) | StatementKind::StorageDead(_) => {
+                continue;
+            }
+            StatementKind::FakeRead(..) => return Some((stmt.source_info, "definition")),
+            _ => return Some((stmt.source_info, "expression")),
+        }
+    }
+
+    let term = bb.terminator();
+    match term.kind {
+        // No user code in this bb, and our goto target may be reachable via other paths
+        TerminatorKind::Goto { .. } | TerminatorKind::Return => None,
+        _ => Some((term.source_info, "expression")),
+    }
+}

--- a/tests/mir-opt/building/issue_101867.main.built.after.mir
+++ b/tests/mir-opt/building/issue_101867.main.built.after.mir
@@ -32,7 +32,7 @@ fn main() -> () {
     bb1: {
         StorageLive(_3);
         StorageLive(_4);
-        _4 = std::rt::begin_panic::<&str>(const "explicit panic") -> bb8;
+        _4 = std::rt::begin_panic::<&str>(const "explicit panic") -> [return: bb2, unwind: bb8];
     }
 
     bb2: {

--- a/tests/mir-opt/building/user_type_annotations.let_else.built.after.mir
+++ b/tests/mir-opt/building/user_type_annotations.let_else.built.after.mir
@@ -35,7 +35,7 @@ fn let_else() -> () {
     }
 
     bb1: {
-        _1 = core::panicking::panic(const "internal error: entered unreachable code") -> bb6;
+        _1 = core::panicking::panic(const "internal error: entered unreachable code") -> [return: bb2, unwind: bb6];
     }
 
     bb2: {

--- a/tests/mir-opt/building/user_type_annotations.let_else_bindless.built.after.mir
+++ b/tests/mir-opt/building/user_type_annotations.let_else_bindless.built.after.mir
@@ -29,7 +29,7 @@ fn let_else_bindless() -> () {
     }
 
     bb1: {
-        _1 = core::panicking::panic(const "internal error: entered unreachable code") -> bb6;
+        _1 = core::panicking::panic(const "internal error: entered unreachable code") -> [return: bb2, unwind: bb6];
     }
 
     bb2: {

--- a/tests/mir-opt/issue_72181_1.main.built.after.mir
+++ b/tests/mir-opt/issue_72181_1.main.built.after.mir
@@ -19,7 +19,7 @@ fn main() -> () {
         StorageLive(_2);
         StorageLive(_3);
         _3 = ();
-        _2 = std::intrinsics::transmute::<(), Void>(move _3) -> bb4;
+        _2 = std::intrinsics::transmute::<(), Void>(move _3) -> [return: bb1, unwind: bb4];
     }
 
     bb1: {
@@ -29,7 +29,7 @@ fn main() -> () {
         StorageLive(_4);
         StorageLive(_5);
         _5 = move _2;
-        _4 = f(move _5) -> bb4;
+        _4 = f(move _5) -> [return: bb2, unwind: bb4];
     }
 
     bb2: {

--- a/tests/mir-opt/issue_99325.main.built.after.32bit.mir
+++ b/tests/mir-opt/issue_99325.main.built.after.32bit.mir
@@ -132,7 +132,7 @@ fn main() -> () {
         _19 = &(*_20);
         StorageLive(_21);
         _21 = Option::<Arguments<'_>>::None;
-        _15 = core::panicking::assert_failed::<&[u8], &[u8; 4]>(move _16, move _17, move _19, move _21) -> bb23;
+        _15 = core::panicking::assert_failed::<&[u8], &[u8; 4]>(move _16, move _17, move _19, move _21) -> [return: bb7, unwind: bb23];
     }
 
     bb7: {
@@ -236,7 +236,7 @@ fn main() -> () {
         _39 = &(*_40);
         StorageLive(_41);
         _41 = Option::<Arguments<'_>>::None;
-        _35 = core::panicking::assert_failed::<&[u8], &[u8; 4]>(move _36, move _37, move _39, move _41) -> bb23;
+        _35 = core::panicking::assert_failed::<&[u8], &[u8; 4]>(move _36, move _37, move _39, move _41) -> [return: bb18, unwind: bb23];
     }
 
     bb18: {

--- a/tests/mir-opt/issue_99325.main.built.after.64bit.mir
+++ b/tests/mir-opt/issue_99325.main.built.after.64bit.mir
@@ -132,7 +132,7 @@ fn main() -> () {
         _19 = &(*_20);
         StorageLive(_21);
         _21 = Option::<Arguments<'_>>::None;
-        _15 = core::panicking::assert_failed::<&[u8], &[u8; 4]>(move _16, move _17, move _19, move _21) -> bb23;
+        _15 = core::panicking::assert_failed::<&[u8], &[u8; 4]>(move _16, move _17, move _19, move _21) -> [return: bb7, unwind: bb23];
     }
 
     bb7: {
@@ -236,7 +236,7 @@ fn main() -> () {
         _39 = &(*_40);
         StorageLive(_41);
         _41 = Option::<Arguments<'_>>::None;
-        _35 = core::panicking::assert_failed::<&[u8], &[u8; 4]>(move _36, move _37, move _39, move _41) -> bb23;
+        _35 = core::panicking::assert_failed::<&[u8], &[u8; 4]>(move _36, move _37, move _39, move _41) -> [return: bb18, unwind: bb23];
     }
 
     bb18: {

--- a/tests/ui/mir/lint/storage-live.stderr
+++ b/tests/ui/mir/lint/storage-live.stderr
@@ -1,4 +1,4 @@
-error: internal compiler error: broken MIR in Item(DefId(0:8 ~ storage_live[HASH]::multiple_storage)) (after pass CheckForceInline) at bb0[1]:
+error: internal compiler error: broken MIR in Item(DefId(0:8 ~ storage_live[HASH]::multiple_storage)) (after pass LintAndRemoveUninhabited) at bb0[1]:
                                 StorageLive(_1) which already has storage here
   --> $DIR/storage-live.rs:22:13
    |


### PR DESCRIPTION
This method is post-processes the built MIR to remove uninhabited function return edges and linting over them. It does not use the rest of the MIR building infrastructure, and does not need to live in the same crate.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
