### PR TITLE
Check raw pointer pointee layout during codegen

### DIFF
--- a/compiler/rustc_middle/src/ty/layout.rs
+++ b/compiler/rustc_middle/src/ty/layout.rs
@@ -1033,7 +1033,16 @@ where
         let optimize = tcx.sess.opts.optimize != OptLevel::No;
 
         let pointee_info = match *this.ty.kind() {
-            ty::RawPtr(_, _) | ty::FnPtr(..) if offset.bytes() == 0 => {
+            ty::RawPtr(pointee, _) if offset.bytes() == 0 => {
+                // Raw pointers do not promise dereferenceability or alignment, but
+                // codegen still needs to force layout checking for the pointee type.
+                tcx.layout_of(typing_env.as_query_input(pointee)).ok().map(|_| PointeeInfo {
+                    safe: None,
+                    size: Size::ZERO,
+                    align: Align::ONE,
+                })
+            }
+            ty::FnPtr(..) if offset.bytes() == 0 => {
                 Some(PointeeInfo { safe: None, size: Size::ZERO, align: Align::ONE })
             }
             ty::Ref(_, ty, mt) if offset.bytes() == 0 => {

--- a/tests/ui/codegen/normalization-overflow/raw-ptr-recursive-layout-issue-157047.rs
+++ b/tests/ui/codegen/normalization-overflow/raw-ptr-recursive-layout-issue-157047.rs
@@ -1,0 +1,29 @@
+//~ ERROR queries overflow the depth limit!
+// Check that optimized codegen still diagnoses layout recursion hidden behind
+// a raw pointer argument.
+//@ build-fail
+//@ compile-flags: -O
+
+use std::marker::PhantomData;
+
+trait Chain {
+    type Next;
+}
+
+impl<T> Chain for T {
+    type Next = Thing<Option<T>>;
+}
+
+struct Thing<T: Chain>(T::Next, PhantomData<T>);
+
+#[inline(never)]
+fn dummy<T>(_: T) {}
+
+fn make_ptr<T: Chain>() {
+    let x: *const Thing<T> = unsafe { std::mem::transmute(1_usize) };
+    dummy(x);
+}
+
+fn main() {
+    make_ptr::<i32>();
+}

--- a/tests/ui/codegen/normalization-overflow/raw-ptr-recursive-layout-issue-157047.stderr
+++ b/tests/ui/codegen/normalization-overflow/raw-ptr-recursive-layout-issue-157047.stderr
@@ -1,0 +1,7 @@
+error: queries overflow the depth limit!
+   |
+   = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`raw_ptr_recursive_layout_issue_157047`)
+   = note: query depth increased by 130 when computing layout of `Thing<i32>`
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/157724)*
<!-- homu-ignore:end -->

Fixes rust-lang/rust#157047.

Raw pointers do not imply dereferenceability, so the pointee size and alignment metadata can remain conservative. However, when codegen asks for pointee information, we still need to check that computing the pointee layout would succeed.

This restores the layout validation that catches infinitely recursive pointee types in optimized builds, while preserving the conservative raw-pointer metadata behavior from rust-lang/rust#150447.