### PR TITLE
Keep generic suggestion for macro-expanded missing-type items

### DIFF
--- a/compiler/rustc_hir_analysis/src/collect/type_of.rs
+++ b/compiler/rustc_hir_analysis/src/collect/type_of.rs
@@ -437,6 +437,15 @@ fn infer_placeholder_type<'tcx>(
     let guar = cx
         .dcx()
         .try_steal_modify_and_emit_err(ty_span, StashKey::ItemNoType, |err| {
+            // HACK(#69396): A macro can expand to several missing-type items that all
+            // collide on one stashed `(span, ItemNoType)` diagnostic. They can infer
+            // different types, so there is no single concrete type to suggest, and which
+            // one wins the steal is not even stable under the parallel front-end. Keep the
+            // parser's generic suggestion instead. The fallback arm below additionally
+            // checks `is_empty` for explicit `_` spans.
+            if ty_span.from_expansion() {
+                return;
+            }
             if !ty.references_error() {
                 // Only suggest adding `:` if it was missing (and suggested by parsing diagnostic).
                 let colon = if ty_span == item_ident.span.shrink_to_hi() { ":" } else { "" };

--- a/tests/ui/consts/const-item-no-type/in-macro.rs
+++ b/tests/ui/consts/const-item-no-type/in-macro.rs
@@ -8,7 +8,6 @@ macro_rules! suite {
         )*
     }
 }
-//@ ignore-parallel-frontend  different infer type: bool
 suite! {
     len;
     is_empty;

--- a/tests/ui/consts/const-item-no-type/in-macro.stderr
+++ b/tests/ui/consts/const-item-no-type/in-macro.stderr
@@ -17,7 +17,7 @@ error: missing type for `const` item
   --> $DIR/in-macro.rs:4:20
    |
 LL |               const A = "A".$fn();
-   |                      ^ help: provide a type for the constant: `: usize`
+   |                      ^
 ...
 LL | / suite! {
 LL | |     len;
@@ -26,6 +26,10 @@ LL | | }
    | |_- in this macro invocation
    |
    = note: this error originates in the macro `suite` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: provide a type for the item
+   |
+LL |             const A: <type> = "A".$fn();
+   |                    ++++++++
 
 error[E0121]: missing type for item
   --> $DIR/in-macro.rs:4:20


### PR DESCRIPTION
Fixes rust-lang/rust#157659

If a macro expands to a few missing-type items on the same span (think a `$()*` repeat of `const A = ...;`), they all land on the same stashed `ItemNoType` diagnostic. Only one item gets to steal it and stamp in its own inferred type, and under the parallel front-end which one wins is basically a coin flip. So the suggested type flips between runs: the original repro kept bouncing between `usize` and `bool`.

There isn't really a "right" type to show here anyway, imo. The items can infer different types, so there's no single one to suggest. When the placeholder span comes from a macro I now skip the inferred-type suggestion and keep the parser's generic `<type>` one instead. The fallback arm a few lines down already does the same thing, so it lines up.

Output is deterministic now, so `in-macro` no longer needs `ignore-parallel-frontend`. Checked it by hashing the stderr over a couple hundred `-Z threads=8` runs (all identical) and the touched ui dirs still pass.
