### PR TITLE
Stabilize `local_key_cell_update`

### DIFF
--- a/library/std/src/thread/local.rs
+++ b/library/std/src/thread/local.rs
@@ -631,7 +631,6 @@ impl<T: 'static> LocalKey<Cell<T>> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(local_key_cell_update)]
     /// use std::cell::Cell;
     ///
     /// thread_local! {
@@ -641,7 +640,7 @@ impl<T: 'static> LocalKey<Cell<T>> {
     /// X.update(|x| x + 1);
     /// assert_eq!(X.get(), 6);
     /// ```
-    #[unstable(feature = "local_key_cell_update", issue = "143989")]
+    #[stable(feature = "local_key_cell_update", since = "CURRENT_RUSTC_VERSION")]
     pub fn update(&'static self, f: impl FnOnce(T) -> T)
     where
         T: Copy,

--- a/library/std/src/thread/local.rs
+++ b/library/std/src/thread/local.rs
@@ -620,6 +620,14 @@ impl<T: 'static> LocalKey<Cell<T>> {
 
     /// Updates the contained value using a function.
     ///
+    /// This will lazily initialize the value if this thread has not referenced
+    /// this key yet.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the key currently has its destructor running,
+    /// and it **may** panic if the destructor has previously been run for this thread.
+    ///
     /// # Examples
     ///
     /// ```


### PR DESCRIPTION
Newly stable API:

```rust
impl<T: 'static> LocalKey<Cell<T>> {
    pub fn update(&'static self, f: impl FnOnce(T) -> T)
    where
        T: Copy;
}
```

This matches the signature on `Cell`.

Closes: https://www.github.com/rust-lang/rust/issues/143989 (Tracking issue)