### PR TITLE
Remove ?Sized bound from Idx in Index and IndexMut

### DIFF
--- a/library/core/src/ops/index.rs
+++ b/library/core/src/ops/index.rs
@@ -56,7 +56,7 @@
 #[doc(alias = "[")]
 #[doc(alias = "[]")]
 #[rustc_const_unstable(feature = "const_index", issue = "143775")]
-pub const trait Index<Idx: ?Sized> {
+pub const trait Index<Idx> {
     /// The returned type after indexing.
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_diagnostic_item = "IndexOutput"]
@@ -167,7 +167,7 @@ see chapter in The Book <https://doc.rust-lang.org/book/ch08-02-strings.html#ind
 #[doc(alias = "]")]
 #[doc(alias = "[]")]
 #[rustc_const_unstable(feature = "const_index", issue = "143775")]
-pub const trait IndexMut<Idx: ?Sized>: [const] Index<Idx> {
+pub const trait IndexMut<Idx>: [const] Index<Idx> {
     /// Performs the mutable indexing (`container[index]`) operation.
     ///
     /// # Panics


### PR DESCRIPTION
`Idx: ?Sized` is useless because the trait methods pass the index by value, so it's impossible to impl with an unsized Idx type.

Removing this makes it a little easier for learners to understand the intent of the Index and IndexMut traits.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
