### PR TITLE
ci: switch `job-windows` from `windows-2025` => `windows-2025-vs2026` runner images

### DIFF
--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -27,7 +27,7 @@ runners:
     <<: *base-job
 
   - &job-windows
-    os: windows-2025
+    os: windows-2025-vs2026
     <<: *base-job
 
   - &job-windows-8c


### PR DESCRIPTION
See announcement: <https://github.com/actions/runner-images/issues/14017>.

Affects jobs:

* `x86_64-msvc-1`
* `x86_64-msvc-2`
* `i686-msvc-1`
* `i686-msvc-2`
* `x86_64-msvc-ext1`
* `x86_64-msvc-ext2`
* `x86_64-msvc-ext3`
* `x86_64-mingw-1`
* `x86_64-mingw-2`
* `dist-i686-msvc`
* `dist-i686-mingw`
* `dist-x86_64-mingw`
* `dist-x86_64-llvm-mingw`
* `dist-x86_64-msvc-alt`

---

try-job: x86_64-msvc-1
try-job: x86_64-msvc-2
try-job: i686-msvc-1
try-job: i686-msvc-2
try-job: x86_64-msvc-ext1
try-job: x86_64-msvc-ext2
try-job: x86_64-msvc-ext3
try-job: x86_64-mingw-1
try-job: x86_64-mingw-2
try-job: dist-i686-msvc
try-job: dist-i686-mingw
try-job: dist-x86_64-mingw
try-job: dist-x86_64-llvm-mingw
try-job: dist-x86_64-msvc-alt