### PR TITLE
rustc_public: make sure hidden fields have their accessors

### DIFF
--- a/compiler/rustc_public/src/ty.rs
+++ b/compiler/rustc_public/src/ty.rs
@@ -895,6 +895,11 @@ impl VariantDef {
     pub fn fields(&self) -> Vec<FieldDef> {
         with(|cx| cx.variant_fields(*self))
     }
+
+    /// Returns the variant index.
+    pub fn idx(&self) -> VariantIdx {
+        self.idx
+    }
 }
 
 crate_def_with_ty! {

--- a/compiler/rustc_public/src/ty.rs
+++ b/compiler/rustc_public/src/ty.rs
@@ -900,6 +900,11 @@ impl VariantDef {
     pub fn idx(&self) -> VariantIdx {
         self.idx
     }
+
+    /// Returns the `AdtDef` which this variant comes from.
+    pub fn adt_def(&self) -> AdtDef {
+        self.adt_def
+    }
 }
 
 crate_def_with_ty! {


### PR DESCRIPTION
Per [the discussion](https://rust-lang.zulipchat.com/#narrow/channel/320896-project-rustc-public/topic/Do.20we.20want.20DefId.20to.20be.20publicly.20visible.20in.20our.20def.20wrappers.3F/with/600656013), we should make sure hidden fields have their corresponding accessors.