### PR TITLE
interpret: avoid computing layout of sized raw pointee

### DIFF
--- a/compiler/rustc_const_eval/src/interpret/validity.rs
+++ b/compiler/rustc_const_eval/src/interpret/validity.rs
@@ -925,7 +925,7 @@ impl<'rt, 'tcx, M: Machine<'tcx>> ValidityVisitor<'rt, 'tcx, M> {
                 }
                 interp_ok(true)
             }
-            ty::RawPtr(..) => {
+            ty::RawPtr(pointee, ..) => {
                 let ptr = self.read_immediate(value, ExpectedKind::RawPtr)?;
                 if self.reset_provenance_and_padding {
                     self.reset_pointer_provenance(value, &ptr)?;
@@ -933,8 +933,12 @@ impl<'rt, 'tcx, M: Machine<'tcx>> ValidityVisitor<'rt, 'tcx, M> {
                     self.add_data_range_place(value);
                 }
 
-                let place = self.ecx.imm_ptr_to_mplace(&ptr)?;
-                if place.layout.is_unsized() {
+                if !pointee.is_sized(*self.ecx.tcx, self.ecx.typing_env) {
+                    // Raw pointers to unsized types need to have their metadata checked.
+                    // We avoid creating this place for sized types to match codegen: those types
+                    // might actually be invalid (i.e., too big)!
+                    let place = self.ecx.imm_ptr_to_mplace(&ptr)?;
+                    assert!(place.layout.is_unsized());
                     self.check_wide_ptr_meta(place.meta(), place.layout)?;
                 }
                 interp_ok(true)

--- a/src/tools/miri/tests/pass/too-big-type-behind-raw-ptr.rs
+++ b/src/tools/miri/tests/pass/too-big-type-behind-raw-ptr.rs
@@ -1,0 +1,10 @@
+//! Regression test for <https://github.com/rust-lang/rust/issues/157654#issuecomment-4679655886>:
+//! the type behind a raw pointer should never have its layout computed.
+
+//@compile-flags: -Zmiri-permissive-provenance
+
+const PTR_BITS_MINUS_1: usize = std::mem::size_of::<*const ()>() * 8 - 1;
+
+fn main() {
+    std::hint::black_box(0 as *const [u64; 1 << PTR_BITS_MINUS_1]);
+}

--- a/tests/ui/layout/issue-unsized-tail-restatic-ice-122488.rs
+++ b/tests/ui/layout/issue-unsized-tail-restatic-ice-122488.rs
@@ -5,7 +5,7 @@ use std::ops::Deref;
 struct ArenaSet<U: Deref, V: ?Sized = <U as Deref>::Target>(V, U);
 //~^ ERROR the size for values of type `V` cannot be known at compilation time
 
-const DATA: *const ArenaSet<Vec<u8>> = std::ptr::null_mut();
+const DATA: &ArenaSet<Vec<u8>> = unsafe { &* std::ptr::null_mut() };
 //~^ ERROR the type `ArenaSet<Vec<u8>, [u8]>` has an unknown layout
 
 pub fn main() {}

--- a/tests/ui/layout/issue-unsized-tail-restatic-ice-122488.stderr
+++ b/tests/ui/layout/issue-unsized-tail-restatic-ice-122488.stderr
@@ -23,10 +23,10 @@ LL | struct ArenaSet<U: Deref, V: ?Sized = <U as Deref>::Target>(Box<V>, U);
    |                                                             ++++ +
 
 error[E0080]: the type `ArenaSet<Vec<u8>, [u8]>` has an unknown layout
-  --> $DIR/issue-unsized-tail-restatic-ice-122488.rs:8:1
+  --> $DIR/issue-unsized-tail-restatic-ice-122488.rs:8:43
    |
-LL | const DATA: *const ArenaSet<Vec<u8>> = std::ptr::null_mut();
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `DATA` failed here
+LL | const DATA: &ArenaSet<Vec<u8>> = unsafe { &* std::ptr::null_mut() };
+   |                                           ^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `DATA` failed here
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/sized/stack-overflow-trait-infer-98842.stderr
+++ b/tests/ui/sized/stack-overflow-trait-infer-98842.stderr
@@ -7,11 +7,8 @@ LL | struct Foo(<&'static Foo as ::core::ops::Deref>::Target);
 note: ...which requires computing layout of `<&'static Foo as core::ops::deref::Deref>::Target`...
   --> $SRC_DIR/core/src/ops/deref.rs:LL:COL
    = note: ...which again requires computing layout of `Foo`, completing the cycle
-note: cycle used when const-evaluating + checking `_`
-  --> $DIR/stack-overflow-trait-infer-98842.rs:13:1
-   |
-LL | const _: *const Foo = 0 as _;
-   | ^^^^^^^^^^^^^^^^^^^
+note: cycle used when computing layout of `<&'static Foo as core::ops::deref::Deref>::Target`
+  --> $SRC_DIR/core/src/ops/deref.rs:LL:COL
    = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error: aborting due to 1 previous error


### PR DESCRIPTION
This lets the [example](https://github.com/rust-lang/rust/issues/157654#issuecomment-4679655886) by @theemathas work in Miri.