### PR TITLE
Added `PhantomPinned` diagnostic item and prevented dead field warning on `PhantomPinned`

### DIFF
--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -1023,6 +1023,7 @@ pub auto trait Unpin {}
 // will likely eventually be deprecated, and all new code should be using `UnsafePinned` instead.
 #[stable(feature = "pin", since = "1.33.0")]
 #[derive(Debug, Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[rustc_diagnostic_item = "PhantomPinned"]
 pub struct PhantomPinned;
 
 #[stable(feature = "pin", since = "1.33.0")]

--- a/src/tools/clippy/clippy_lints/src/missing_fields_in_debug.rs
+++ b/src/tools/clippy/clippy_lints/src/missing_fields_in_debug.rs
@@ -185,6 +185,7 @@ fn check_struct<'tcx>(
         .filter_map(|field| {
             if field_accesses.contains(&field.ident.name)
                 || field.ty.basic_res().is_lang_item(cx, LangItem::PhantomData)
+                || field.ty.basic_res().is_diag_item(cx, sym::PhantomPinned)
             {
                 None
             } else {

--- a/src/tools/clippy/clippy_lints/src/pub_underscore_fields.rs
+++ b/src/tools/clippy/clippy_lints/src/pub_underscore_fields.rs
@@ -3,6 +3,7 @@ use clippy_config::types::PubUnderscoreFieldsBehaviour;
 use clippy_utils::attrs::is_doc_hidden;
 use clippy_utils::diagnostics::span_lint_hir_and_then;
 use clippy_utils::res::{MaybeDef, MaybeResPath};
+use clippy_utils::sym::PhantomPinned;
 use rustc_hir::{FieldDef, Item, ItemKind, LangItem};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_session::impl_lint_pass;
@@ -75,8 +76,9 @@ impl<'tcx> LateLintPass<'tcx> for PubUnderscoreFields {
             if field.ident.as_str().starts_with('_') && is_visible(field)
                 // We ignore fields that have `#[doc(hidden)]`.
                 && !is_doc_hidden(cx.tcx.hir_attrs(field.hir_id))
-                // We ignore fields that are `PhantomData`.
+                // We ignore fields that are `PhantomData` and `PhantomPinned`.
                 && !field.ty.basic_res().is_lang_item(cx, LangItem::PhantomData)
+                && !field.ty.basic_res().is_diag_item(cx, PhantomPinned)
             {
                 span_lint_hir_and_then(
                     cx,

--- a/src/tools/clippy/clippy_utils/src/sym.rs
+++ b/src/tools/clippy/clippy_utils/src/sym.rs
@@ -100,6 +100,7 @@ generate! {
     Path,
     PathBuf,
     PathLookup,
+    PhantomPinned,
     RangeBounds,
     RefCellRef,
     RefCellRefMut,

--- a/src/tools/clippy/tests/ui-toml/pub_underscore_fields/pub_underscore_fields.all_pub_fields.stderr
+++ b/src/tools/clippy/tests/ui-toml/pub_underscore_fields/pub_underscore_fields.all_pub_fields.stderr
@@ -9,7 +9,7 @@ LL |         pub _b: u8,
    = help: to override `-D warnings` add `#[allow(clippy::pub_underscore_fields)]`
 
 error: field marked as public but also inferred as unused because it's prefixed with `_`
-  --> tests/ui-toml/pub_underscore_fields/pub_underscore_fields.rs:23:13
+  --> tests/ui-toml/pub_underscore_fields/pub_underscore_fields.rs:24:13
    |
 LL |             pub(in crate::inner) _f: Option<()>,
    |             ^^^^^^^^^^^^^^^^^^^^^^^
@@ -17,7 +17,7 @@ LL |             pub(in crate::inner) _f: Option<()>,
    = help: consider removing the underscore, or making the field private
 
 error: field marked as public but also inferred as unused because it's prefixed with `_`
-  --> tests/ui-toml/pub_underscore_fields/pub_underscore_fields.rs:28:13
+  --> tests/ui-toml/pub_underscore_fields/pub_underscore_fields.rs:29:13
    |
 LL |             pub _g: String,
    |             ^^^^^^
@@ -25,7 +25,7 @@ LL |             pub _g: String,
    = help: consider removing the underscore, or making the field private
 
 error: field marked as public but also inferred as unused because it's prefixed with `_`
-  --> tests/ui-toml/pub_underscore_fields/pub_underscore_fields.rs:36:9
+  --> tests/ui-toml/pub_underscore_fields/pub_underscore_fields.rs:37:9
    |
 LL |         pub _a: usize,
    |         ^^^^^^
@@ -33,7 +33,7 @@ LL |         pub _a: usize,
    = help: consider removing the underscore, or making the field private
 
 error: field marked as public but also inferred as unused because it's prefixed with `_`
-  --> tests/ui-toml/pub_underscore_fields/pub_underscore_fields.rs:44:9
+  --> tests/ui-toml/pub_underscore_fields/pub_underscore_fields.rs:45:9
    |
 LL |         pub _c: i64,
    |         ^^^^^^
@@ -41,7 +41,7 @@ LL |         pub _c: i64,
    = help: consider removing the underscore, or making the field private
 
 error: field marked as public but also inferred as unused because it's prefixed with `_`
-  --> tests/ui-toml/pub_underscore_fields/pub_underscore_fields.rs:48:9
+  --> tests/ui-toml/pub_underscore_fields/pub_underscore_fields.rs:49:9
    |
 LL |         pub _e: Option<u8>,
    |         ^^^^^^
@@ -49,7 +49,7 @@ LL |         pub _e: Option<u8>,
    = help: consider removing the underscore, or making the field private
 
 error: field marked as public but also inferred as unused because it's prefixed with `_`
-  --> tests/ui-toml/pub_underscore_fields/pub_underscore_fields.rs:62:9
+  --> tests/ui-toml/pub_underscore_fields/pub_underscore_fields.rs:63:9
    |
 LL |         pub(crate) _b: Option<String>,
    |         ^^^^^^^^^^^^^

--- a/src/tools/clippy/tests/ui-toml/pub_underscore_fields/pub_underscore_fields.rs
+++ b/src/tools/clippy/tests/ui-toml/pub_underscore_fields/pub_underscore_fields.rs
@@ -4,7 +4,7 @@
 
 #![warn(clippy::pub_underscore_fields)]
 
-use std::marker::PhantomData;
+use std::marker::{PhantomData, PhantomPinned};
 
 pub mod inner {
     use std::marker;
@@ -15,6 +15,7 @@ pub mod inner {
         //~^ pub_underscore_fields
         _c: i32,
         pub _mark: marker::PhantomData<u8>,
+        pub _pinned: marker::PhantomPinned,
     }
 
     mod inner2 {
@@ -68,6 +69,7 @@ fn main() {
         r#pub: bool,
         _pub: String,
         pub(crate) _mark: PhantomData<u8>,
+        pub(crate) _pinned: PhantomPinned,
     }
 
     // shouldn't warn when `#[allow]` is used on field level

--- a/src/tools/clippy/tests/ui/missing_fields_in_debug.rs
+++ b/src/tools/clippy/tests/ui/missing_fields_in_debug.rs
@@ -2,7 +2,7 @@
 #![warn(clippy::missing_fields_in_debug)]
 
 use std::fmt;
-use std::marker::PhantomData;
+use std::marker::{PhantomData, PhantomPinned};
 use std::ops::Deref;
 use std::thread::LocalKey;
 
@@ -179,16 +179,18 @@ mod comment1175473620 {
 }
 
 // https://github.com/rust-lang/rust-clippy/pull/10616#discussion_r1175488757
-// PhantomData is an exception and does not need to be included
-struct WithPD {
+// https://github.com/rust-lang/rust/issues/154888
+// PhantomData & PhantomPinned are exceptions and do not need to be included
+struct WithPDPP {
     a: u8,
     b: u8,
     c: PhantomData<String>,
+    d: PhantomPinned,
 }
 
-impl fmt::Debug for WithPD {
+impl fmt::Debug for WithPDPP {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("WithPD")
+        f.debug_struct("WithPDPP")
             .field("a", &self.a)
             .field("b", &self.b)
             .finish()


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/157782)*
<!-- homu-ignore:end -->

This PR closes rust-lang/rust#154888. See rust-lang/rust#154978 and in [clippy#17056](https://github.com/rust-lang/rust-clippy/pull/17056) for prior history on working on this issue.

From discussing with clippy team, we thought it'd be appropriate to use a diagnostic item attribute to mark `PhantomPinned` and prevent dead field warnings from being emitted in `missing_fields_in_debug.rs` and `pub_underscore_fields.rs`.

If you want me to do the clippy changes separately within the clippy repository, I can do that.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
