### PR TITLE
Add f128 portable SIMD support

### DIFF
--- a/library/portable-simd/crates/core_simd/src/alias.rs
+++ b/library/portable-simd/crates/core_simd/src/alias.rs
@@ -93,6 +93,16 @@ alias! {
         i64x64 64
     }
 
+    i128 = {
+        i128x1 1
+        i128x2 2
+        i128x4 4
+        i128x8 8
+        i128x16 16
+        i128x32 32
+        i128x64 64
+    }
+
     isize = {
         isizex1 1
         isizex2 2
@@ -143,6 +153,16 @@ alias! {
         u64x64 64
     }
 
+    u128 = {
+        u128x1 1
+        u128x2 2
+        u128x4 4
+        u128x8 8
+        u128x16 16
+        u128x32 32
+        u128x64 64
+    }
+
     usize = {
         usizex1 1
         usizex2 2
@@ -181,6 +201,16 @@ alias! {
         f64x16 16
         f64x32 32
         f64x64 64
+    }
+
+    f128 = {
+        f128x1 1
+        f128x2 2
+        f128x4 4
+        f128x8 8
+        f128x16 16
+        f128x32 32
+        f128x64 64
     }
 }
 
@@ -223,6 +253,16 @@ mask_alias! {
         mask64x16 16
         mask64x32 32
         mask64x64 64
+    }
+
+    i128 : "128-bit" = {
+        mask128x1 1
+        mask128x2 2
+        mask128x4 4
+        mask128x8 8
+        mask128x16 16
+        mask128x32 32
+        mask128x64 64
     }
 
     isize : "pointer-sized" = {

--- a/library/portable-simd/crates/core_simd/src/cast.rs
+++ b/library/portable-simd/crates/core_simd/src/cast.rs
@@ -26,6 +26,9 @@ impl SimdCast for i32 {}
 unsafe impl Sealed for i64 {}
 impl SimdCast for i64 {}
 // Safety: primitive number types can be cast to other primitive number types
+unsafe impl Sealed for i128 {}
+impl SimdCast for i128 {}
+// Safety: primitive number types can be cast to other primitive number types
 unsafe impl Sealed for isize {}
 impl SimdCast for isize {}
 // Safety: primitive number types can be cast to other primitive number types
@@ -41,6 +44,9 @@ impl SimdCast for u32 {}
 unsafe impl Sealed for u64 {}
 impl SimdCast for u64 {}
 // Safety: primitive number types can be cast to other primitive number types
+unsafe impl Sealed for u128 {}
+impl SimdCast for u128 {}
+// Safety: primitive number types can be cast to other primitive number types
 unsafe impl Sealed for usize {}
 impl SimdCast for usize {}
 // Safety: primitive number types can be cast to other primitive number types
@@ -52,3 +58,6 @@ impl SimdCast for f32 {}
 // Safety: primitive number types can be cast to other primitive number types
 unsafe impl Sealed for f64 {}
 impl SimdCast for f64 {}
+// Safety: primitive number types can be cast to other primitive number types
+unsafe impl Sealed for f128 {}
+impl SimdCast for f128 {}

--- a/library/portable-simd/crates/core_simd/src/lib.rs
+++ b/library/portable-simd/crates/core_simd/src/lib.rs
@@ -2,6 +2,7 @@
 #![feature(
     convert_float_to_int,
     f16,
+    f128,
     core_intrinsics,
     decl_macro,
     repr_simd,

--- a/library/portable-simd/crates/core_simd/src/masks.rs
+++ b/library/portable-simd/crates/core_simd/src/masks.rs
@@ -27,7 +27,7 @@ macro_rules! impl_fix_endianness {
     }
 }
 
-impl_fix_endianness! { u8, u16, u32, u64 }
+impl_fix_endianness! { u8, u16, u32, u64, u128 }
 
 mod sealed {
     use super::*;
@@ -46,7 +46,7 @@ mod sealed {
         fn eq(self, other: Self) -> bool;
 
         fn to_usize(self) -> usize;
-        fn max_unsigned() -> u64;
+        fn max_unsigned() -> u128;
 
         type Unsigned: SimdElement;
 
@@ -90,8 +90,8 @@ macro_rules! impl_element {
             }
 
             #[inline]
-            fn max_unsigned() -> u64 {
-                <$unsigned>::MAX as u64
+            fn max_unsigned() -> u128 {
+                <$unsigned>::MAX as u128
             }
 
             type Unsigned = $unsigned;
@@ -109,6 +109,7 @@ impl_element! { i8, u8 }
 impl_element! { i16, u16 }
 impl_element! { i32, u32 }
 impl_element! { i64, u64 }
+impl_element! { i128, u128 }
 impl_element! { isize, usize }
 
 /// A SIMD vector mask for `N` elements of width specified by `Element`.
@@ -662,8 +663,9 @@ macro_rules! impl_from {
         )*
     }
 }
-impl_from! { i8 => i16, i32, i64, isize }
-impl_from! { i16 => i32, i64, isize, i8 }
-impl_from! { i32 => i64, isize, i8, i16 }
-impl_from! { i64 => isize, i8, i16, i32 }
-impl_from! { isize => i8, i16, i32, i64 }
+impl_from! { i8 => i16, i32, i64, i128, isize }
+impl_from! { i16 => i32, i64, i128, isize, i8 }
+impl_from! { i32 => i64, i128, isize, i8, i16 }
+impl_from! { i64 => i128, isize, i8, i16, i32 }
+impl_from! { i128 => isize, i8, i16, i32, i64 }
+impl_from! { isize => i8, i16, i32, i64, i128 }

--- a/library/portable-simd/crates/core_simd/src/ops.rs
+++ b/library/portable-simd/crates/core_simd/src/ops.rs
@@ -184,7 +184,7 @@ macro_rules! for_base_ops {
 // Integers can always accept add, mul, sub, bitand, bitor, and bitxor.
 // For all of these operations, simd_* intrinsics apply wrapping logic.
 for_base_ops! {
-    T = (i8, i16, i32, i64, isize, u8, u16, u32, u64, usize);
+    T = (i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize);
     type Lhs = Simd<T, N>;
     type Rhs = Simd<T, N>;
     type Output = Self;
@@ -245,7 +245,7 @@ for_base_ops! {
 // We don't need any special precautions here:
 // Floats always accept arithmetic ops, but may become NaN.
 for_base_ops! {
-    T = (f16, f32, f64);
+    T = (f16, f32, f64, f128);
     type Lhs = Simd<T, N>;
     type Rhs = Simd<T, N>;
     type Output = Self;

--- a/library/portable-simd/crates/core_simd/src/ops/shift_scalar.rs
+++ b/library/portable-simd/crates/core_simd/src/ops/shift_scalar.rs
@@ -51,4 +51,4 @@ macro_rules! impl_splatted_shifts {
 
 // In the past there were inference issues when generically splatting arguments.
 // Enumerate them instead.
-impl_splatted_shifts! { i8, i16, i32, i64, isize, u8, u16, u32, u64, usize }
+impl_splatted_shifts! { i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize }

--- a/library/portable-simd/crates/core_simd/src/ops/unary.rs
+++ b/library/portable-simd/crates/core_simd/src/ops/unary.rs
@@ -25,6 +25,8 @@ neg! {
 
     impl<const N: usize> Neg for Simd<f64, N>
 
+    impl<const N: usize> Neg for Simd<f128, N>
+
     impl<const N: usize> Neg for Simd<i8, N>
 
     impl<const N: usize> Neg for Simd<i16, N>
@@ -32,6 +34,8 @@ neg! {
     impl<const N: usize> Neg for Simd<i32, N>
 
     impl<const N: usize> Neg for Simd<i64, N>
+
+    impl<const N: usize> Neg for Simd<i128, N>
 
     impl<const N: usize> Neg for Simd<isize, N>
 }
@@ -61,6 +65,8 @@ not! {
 
     impl<const N: usize> Not for Simd<i64, N>
 
+    impl<const N: usize> Not for Simd<i128, N>
+
     impl<const N: usize> Not for Simd<isize, N>
 
     impl<const N: usize> Not for Simd<u8, N>
@@ -70,6 +76,8 @@ not! {
     impl<const N: usize> Not for Simd<u32, N>
 
     impl<const N: usize> Not for Simd<u64, N>
+
+    impl<const N: usize> Not for Simd<u128, N>
 
     impl<const N: usize> Not for Simd<usize, N>
 }

--- a/library/portable-simd/crates/core_simd/src/simd/cmp/eq.rs
+++ b/library/portable-simd/crates/core_simd/src/simd/cmp/eq.rs
@@ -42,7 +42,7 @@ macro_rules! impl_number {
     }
 }
 
-impl_number! { f16, f32, f64, u8, u16, u32, u64, usize, i8, i16, i32, i64, isize }
+impl_number! { f16, f32, f64, f128, u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize }
 
 macro_rules! impl_mask {
     { $($integer:ty),* } => {
@@ -69,7 +69,7 @@ macro_rules! impl_mask {
     }
 }
 
-impl_mask! { i8, i16, i32, i64, isize }
+impl_mask! { i8, i16, i32, i64, i128, isize }
 
 impl<T, const N: usize> SimdPartialEq for Simd<*const T, N> {
     type Mask = Mask<isize, N>;

--- a/library/portable-simd/crates/core_simd/src/simd/cmp/ord.rs
+++ b/library/portable-simd/crates/core_simd/src/simd/cmp/ord.rs
@@ -105,7 +105,7 @@ macro_rules! impl_integer {
     }
 }
 
-impl_integer! { u8, u16, u32, u64, usize, i8, i16, i32, i64, isize }
+impl_integer! { u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize }
 
 macro_rules! impl_float {
     { $($float:ty),* } => {
@@ -144,7 +144,7 @@ macro_rules! impl_float {
     }
 }
 
-impl_float! { f16, f32, f64 }
+impl_float! { f16, f32, f64, f128 }
 
 macro_rules! impl_mask {
     { $($integer:ty),* } => {
@@ -206,7 +206,7 @@ macro_rules! impl_mask {
     }
 }
 
-impl_mask! { i8, i16, i32, i64, isize }
+impl_mask! { i8, i16, i32, i64, i128, isize }
 
 impl<T, const N: usize> SimdPartialOrd for Simd<*const T, N> {
     #[inline]

--- a/library/portable-simd/crates/core_simd/src/simd/num/float.rs
+++ b/library/portable-simd/crates/core_simd/src/simd/num/float.rs
@@ -444,4 +444,9 @@ macro_rules! impl_trait {
     }
 }
 
-impl_trait! { f16 { bits: u16, mask: i16 }, f32 { bits: u32, mask: i32 }, f64 { bits: u64, mask: i64 } }
+impl_trait! {
+    f16 { bits: u16, mask: i16 },
+    f32 { bits: u32, mask: i32 },
+    f64 { bits: u64, mask: i64 },
+    f128 { bits: u128, mask: i128 }
+}

--- a/library/portable-simd/crates/core_simd/src/simd/num/int.rs
+++ b/library/portable-simd/crates/core_simd/src/simd/num/int.rs
@@ -400,4 +400,4 @@ macro_rules! impl_trait {
     }
 }
 
-impl_trait! { i8 (u8), i16 (u16), i32 (u32), i64 (u64), isize (usize) }
+impl_trait! { i8 (u8), i16 (u16), i32 (u32), i64 (u64), i128 (u128), isize (usize) }

--- a/library/portable-simd/crates/core_simd/src/simd/num/uint.rs
+++ b/library/portable-simd/crates/core_simd/src/simd/num/uint.rs
@@ -253,4 +253,4 @@ macro_rules! impl_trait {
     }
 }
 
-impl_trait! { u8 (i8), u16 (i16), u32 (i32), u64 (i64), usize (isize) }
+impl_trait! { u8 (i8), u16 (i16), u32 (i32), u64 (i64), u128 (i128), usize (isize) }

--- a/library/portable-simd/crates/core_simd/src/simd/prelude.rs
+++ b/library/portable-simd/crates/core_simd/src/simd/prelude.rs
@@ -28,6 +28,10 @@ pub use super::{f64x1, f64x2, f64x4, f64x8, f64x16, f64x32, f64x64};
 
 #[rustfmt::skip]
 #[doc(no_inline)]
+pub use super::{f128x1, f128x2, f128x4, f128x8, f128x16, f128x32, f128x64};
+
+#[rustfmt::skip]
+#[doc(no_inline)]
 pub use super::{i8x1, i8x2, i8x4, i8x8, i8x16, i8x32, i8x64};
 
 #[rustfmt::skip]
@@ -41,6 +45,10 @@ pub use super::{i32x1, i32x2, i32x4, i32x8, i32x16, i32x32, i32x64};
 #[rustfmt::skip]
 #[doc(no_inline)]
 pub use super::{i64x1, i64x2, i64x4, i64x8, i64x16, i64x32, i64x64};
+
+#[rustfmt::skip]
+#[doc(no_inline)]
+pub use super::{i128x1, i128x2, i128x4, i128x8, i128x16, i128x32, i128x64};
 
 #[rustfmt::skip]
 #[doc(no_inline)]
@@ -64,6 +72,10 @@ pub use super::{u64x1, u64x2, u64x4, u64x8, u64x16, u64x32, u64x64};
 
 #[rustfmt::skip]
 #[doc(no_inline)]
+pub use super::{u128x1, u128x2, u128x4, u128x8, u128x16, u128x32, u128x64};
+
+#[rustfmt::skip]
+#[doc(no_inline)]
 pub use super::{usizex1, usizex2, usizex4, usizex8, usizex16, usizex32, usizex64};
 
 #[rustfmt::skip]
@@ -81,6 +93,10 @@ pub use super::{mask32x1, mask32x2, mask32x4, mask32x8, mask32x16, mask32x32, ma
 #[rustfmt::skip]
 #[doc(no_inline)]
 pub use super::{mask64x1, mask64x2, mask64x4, mask64x8, mask64x16, mask64x32, mask64x64};
+
+#[rustfmt::skip]
+#[doc(no_inline)]
+pub use super::{mask128x1, mask128x2, mask128x4, mask128x8, mask128x16, mask128x32, mask128x64};
 
 #[rustfmt::skip]
 #[doc(no_inline)]

--- a/library/portable-simd/crates/core_simd/src/vector.rs
+++ b/library/portable-simd/crates/core_simd/src/vector.rs
@@ -1104,6 +1104,13 @@ unsafe impl SimdElement for u64 {
     type Mask = i64;
 }
 
+impl Sealed for u128 {}
+
+// Safety: u128 is a valid SIMD element type, and is supported by this API
+unsafe impl SimdElement for u128 {
+    type Mask = i128;
+}
+
 impl Sealed for usize {}
 
 // Safety: usize is a valid SIMD element type, and is supported by this API
@@ -1139,6 +1146,13 @@ unsafe impl SimdElement for i64 {
     type Mask = i64;
 }
 
+impl Sealed for i128 {}
+
+// Safety: i128 is a valid SIMD element type, and is supported by this API
+unsafe impl SimdElement for i128 {
+    type Mask = i128;
+}
+
 impl Sealed for isize {}
 
 // Safety: isize is a valid SIMD element type, and is supported by this API
@@ -1165,6 +1179,13 @@ impl Sealed for f64 {}
 // Safety: f64 is a valid SIMD element type, and is supported by this API
 unsafe impl SimdElement for f64 {
     type Mask = i64;
+}
+
+impl Sealed for f128 {}
+
+// Safety: f128 is a valid SIMD element type, and is supported by this API
+unsafe impl SimdElement for f128 {
+    type Mask = i128;
 }
 
 impl<T> Sealed for *const T {}
@@ -1207,10 +1228,10 @@ where
     M: MaskElement,
 {
     let index = lane_indices::<N>();
-    let max_value: u64 = M::max_unsigned();
+    let max_value: u128 = M::max_unsigned();
     macro_rules! case {
         ($ty:ty) => {
-            if N < <$ty>::MAX as usize && max_value as $ty as u64 == max_value {
+            if N < <$ty>::MAX as usize && max_value as $ty as u128 == max_value {
                 return index.cast().simd_lt(Simd::splat(len.min(N) as $ty)).cast();
             }
         };

--- a/library/portable-simd/crates/core_simd/tests/f128_ops.rs
+++ b/library/portable-simd/crates/core_simd/tests/f128_ops.rs
@@ -1,0 +1,44 @@
+#![feature(f128)]
+#![feature(portable_simd)]
+
+use core_simd::simd::{
+    Select, Simd,
+    cmp::{SimdPartialEq, SimdPartialOrd},
+    f128x2, mask128x2, u128x2,
+    num::SimdFloat,
+};
+
+#[test]
+fn f128_vectors_support_basic_ops() {
+    let a = f128x2::from_array([1.0f128, 4.0]);
+    let b = f128x2::from_array([2.0f128, 8.0]);
+
+    assert_eq!((a + b).to_array(), [3.0f128, 12.0]);
+    assert_eq!((b - a).to_array(), [1.0f128, 4.0]);
+    assert_eq!((a * b).to_array(), [2.0f128, 32.0]);
+    assert_eq!((b / a).to_array(), [2.0f128, 2.0]);
+    assert_eq!((-a).to_array(), [-1.0f128, -4.0]);
+
+    let mask = a.simd_lt(b);
+    assert_eq!(mask.to_array(), [true, true]);
+    assert_eq!(mask.select(a, b).to_array(), a.to_array());
+    assert_eq!(a.simd_min(b).to_array(), a.to_array());
+    assert_eq!(b.simd_max(a).to_array(), b.to_array());
+    assert!(a.simd_ne(b).all());
+}
+
+#[test]
+fn f128_vectors_expose_u128_bits() {
+    let one = f128x2::splat(1.0);
+    let bits: Simd<u128, 2> = one.to_bits();
+    assert_eq!(f128x2::from_bits(bits).to_array(), one.to_array());
+    assert_eq!(bits & u128x2::splat(u128::MAX), bits);
+}
+
+#[test]
+fn i128_masks_support_public_mask_api() {
+    let mask = mask128x2::from_array([true, false]);
+    assert_eq!(mask.to_array(), [true, false]);
+    assert_eq!(mask.to_bitmask(), 0b01);
+    assert_eq!(mask128x2::from_bitmask(0b10).to_array(), [false, true]);
+}

--- a/library/portable-simd/crates/std_float/src/lib.rs
+++ b/library/portable-simd/crates/std_float/src/lib.rs
@@ -3,6 +3,7 @@
     feature(core_intrinsics),
     feature(portable_simd),
     feature(f16),
+    feature(f128),
     allow(internal_features)
 )]
 #[cfg(not(feature = "as_crate"))]
@@ -173,6 +174,7 @@ pub trait StdFloat: Sealed + Sized {
 impl<const N: usize> Sealed for Simd<f16, N> {}
 impl<const N: usize> Sealed for Simd<f32, N> {}
 impl<const N: usize> Sealed for Simd<f64, N> {}
+impl<const N: usize> Sealed for Simd<f128, N> {}
 
 impl<const N: usize> StdFloat for Simd<f16, N> {
     #[inline]
@@ -189,6 +191,13 @@ impl<const N: usize> StdFloat for Simd<f32, N> {
 }
 
 impl<const N: usize> StdFloat for Simd<f64, N> {
+    #[inline]
+    fn fract(self) -> Self {
+        self - self.trunc()
+    }
+}
+
+impl<const N: usize> StdFloat for Simd<f128, N> {
     #[inline]
     fn fract(self) -> Self {
         self - self.trunc()


### PR DESCRIPTION
Tracking: https://github.com/rust-lang/rust/issues/125440

This wires `f128` through portable-simd's scalar element support. It adds the `f128` feature, `SimdElement` and cast plumbing, numeric/comparison/arithmetic trait impls, 128-bit integer and mask backing types, and public aliases/prelude exports needed by `Simd<f128, N>`.

The added coverage exercises basic `f128` vector arithmetic, comparisons, select/min/max/ne, `to_bits`/`from_bits`, and `mask128x2` conversion APIs.

Validation:

- `git diff --check`
- `rustc --crate-name core_simd crates\core_simd\src\lib.rs --crate-type=lib --edition=2024`
- `rustc --test crates\core_simd\tests\f128_ops.rs --edition=2024 --emit=metadata`
- `rustc --crate-name std_float crates\std_float\src\lib.rs --crate-type=lib --edition=2024 --cfg "feature=\"as_crate\"" --emit=metadata`

The local Cargo path did not reach project compilation: `cargo test -p core_simd --test f128_ops` failed while unpacking `autocfg v1.5.0` in the Cargo cache with Windows `os error 87`. This environment also does not have `cargo fmt`/`rustfmt` installed.