### PR TITLE
Refactor libproc_macro: remove * imports

### DIFF
--- a/library/proc_macro/src/bridge/client.rs
+++ b/library/proc_macro/src/bridge/client.rs
@@ -1,8 +1,14 @@
 //! Client-side types.
 
 use std::cell::RefCell;
+use std::ops::{Bound, Range};
+use std::sync::Once;
+use std::{fmt, mem, panic};
 
-use super::*;
+use crate::bridge::{
+    ApiTags, BridgeConfig, Buffer, Decode, Diagnostic, Encode, ExpnGlobals, Literal, PanicMessage,
+    TokenTree, closure, handle,
+};
 
 pub(crate) struct TokenStream {
     handle: handle::Handle,

--- a/library/proc_macro/src/bridge/mod.rs
+++ b/library/proc_macro/src/bridge/mod.rs
@@ -99,6 +99,8 @@ mod handle;
 #[macro_use]
 #[forbid(unsafe_code)]
 mod rpc;
+#[forbid(unsafe_code)]
+mod panic_message;
 #[allow(unsafe_code)]
 mod selfless_reify;
 #[forbid(unsafe_code)]
@@ -107,7 +109,7 @@ pub mod server;
 mod symbol;
 
 use buffer::Buffer;
-pub use rpc::PanicMessage;
+pub use panic_message::PanicMessage;
 use rpc::{Decode, Encode};
 
 /// Configuration for establishing an active connection between a server and a

--- a/library/proc_macro/src/bridge/mod.rs
+++ b/library/proc_macro/src/bridge/mod.rs
@@ -9,9 +9,8 @@
 #![deny(unsafe_code)]
 
 use std::hash::Hash;
+use std::marker;
 use std::ops::{Bound, Range};
-use std::sync::Once;
-use std::{fmt, marker, mem, panic, thread};
 
 use crate::{Delimiter, Level};
 

--- a/library/proc_macro/src/bridge/panic_message.rs
+++ b/library/proc_macro/src/bridge/panic_message.rs
@@ -1,0 +1,71 @@
+use std::any::Any;
+
+use crate::bridge::{Buffer, Decode, Encode};
+
+/// Simplified version of panic payloads, ignoring
+/// types other than `&'static str` and `String`.
+pub enum PanicMessage {
+    StaticStr(&'static str),
+    String(String),
+    Unknown,
+}
+
+impl From<Box<dyn Any + Send>> for PanicMessage {
+    fn from(payload: Box<dyn Any + Send + 'static>) -> Self {
+        if let Some(s) = payload.downcast_ref::<&'static str>() {
+            return PanicMessage::StaticStr(s);
+        }
+        if let Ok(s) = payload.downcast::<String>() {
+            return PanicMessage::String(*s);
+        }
+        PanicMessage::Unknown
+    }
+}
+
+impl From<PanicMessage> for Box<dyn Any + Send> {
+    fn from(val: PanicMessage) -> Self {
+        match val {
+            PanicMessage::StaticStr(s) => Box::new(s),
+            PanicMessage::String(s) => Box::new(s),
+            PanicMessage::Unknown => {
+                struct UnknownPanicMessage;
+                Box::new(UnknownPanicMessage)
+            }
+        }
+    }
+}
+
+impl PanicMessage {
+    pub fn as_str(&self) -> Option<&str> {
+        match self {
+            PanicMessage::StaticStr(s) => Some(s),
+            PanicMessage::String(s) => Some(s),
+            PanicMessage::Unknown => None,
+        }
+    }
+
+    pub fn into_string(self) -> Option<String> {
+        match self {
+            PanicMessage::StaticStr(s) => Some(s.into()),
+            PanicMessage::String(s) => Some(s),
+            PanicMessage::Unknown => None,
+        }
+    }
+}
+
+impl<S> Encode<S> for PanicMessage {
+    #[inline]
+    fn encode(self, w: &mut Buffer, s: &mut S) {
+        self.as_str().encode(w, s);
+    }
+}
+
+impl<S> Decode<'_, '_, S> for PanicMessage {
+    #[inline]
+    fn decode(r: &mut &[u8], s: &mut S) -> Self {
+        match Option::<String>::decode(r, s) {
+            Some(s) => PanicMessage::String(s),
+            None => PanicMessage::Unknown,
+        }
+    }
+}

--- a/library/proc_macro/src/bridge/rpc.rs
+++ b/library/proc_macro/src/bridge/rpc.rs
@@ -1,6 +1,5 @@
 //! Serialization for client-server communication.
 
-use std::any::Any;
 use std::io::Write;
 use std::num::NonZero;
 
@@ -257,73 +256,5 @@ impl<'a, S, T: for<'s> Decode<'a, 's, S>> Decode<'a, '_, S> for Vec<T> {
             vec.push(T::decode(r, s));
         }
         vec
-    }
-}
-
-/// Simplified version of panic payloads, ignoring
-/// types other than `&'static str` and `String`.
-pub enum PanicMessage {
-    StaticStr(&'static str),
-    String(String),
-    Unknown,
-}
-
-impl From<Box<dyn Any + Send>> for PanicMessage {
-    fn from(payload: Box<dyn Any + Send + 'static>) -> Self {
-        if let Some(s) = payload.downcast_ref::<&'static str>() {
-            return PanicMessage::StaticStr(s);
-        }
-        if let Ok(s) = payload.downcast::<String>() {
-            return PanicMessage::String(*s);
-        }
-        PanicMessage::Unknown
-    }
-}
-
-impl From<PanicMessage> for Box<dyn Any + Send> {
-    fn from(val: PanicMessage) -> Self {
-        match val {
-            PanicMessage::StaticStr(s) => Box::new(s),
-            PanicMessage::String(s) => Box::new(s),
-            PanicMessage::Unknown => {
-                struct UnknownPanicMessage;
-                Box::new(UnknownPanicMessage)
-            }
-        }
-    }
-}
-
-impl PanicMessage {
-    pub fn as_str(&self) -> Option<&str> {
-        match self {
-            PanicMessage::StaticStr(s) => Some(s),
-            PanicMessage::String(s) => Some(s),
-            PanicMessage::Unknown => None,
-        }
-    }
-
-    pub fn into_string(self) -> Option<String> {
-        match self {
-            PanicMessage::StaticStr(s) => Some(s.into()),
-            PanicMessage::String(s) => Some(s),
-            PanicMessage::Unknown => None,
-        }
-    }
-}
-
-impl<S> Encode<S> for PanicMessage {
-    #[inline]
-    fn encode(self, w: &mut Buffer, s: &mut S) {
-        self.as_str().encode(w, s);
-    }
-}
-
-impl<S> Decode<'_, '_, S> for PanicMessage {
-    #[inline]
-    fn decode(r: &mut &[u8], s: &mut S) -> Self {
-        match Option::<String>::decode(r, s) {
-            Some(s) => PanicMessage::String(s),
-            None => PanicMessage::Unknown,
-        }
     }
 }

--- a/library/proc_macro/src/bridge/server.rs
+++ b/library/proc_macro/src/bridge/server.rs
@@ -1,10 +1,16 @@
 //! Server-side traits.
 
 use std::cell::Cell;
+use std::hash::Hash;
+use std::ops::{Bound, Range};
 use std::sync::atomic::AtomicU32;
 use std::sync::mpsc;
+use std::{panic, thread};
 
-use super::*;
+use crate::bridge::{
+    ApiTags, BridgeConfig, Buffer, Decode, Diagnostic, Encode, ExpnGlobals, Literal, Mark, Marked,
+    PanicMessage, TokenTree, client, handle,
+};
 
 pub(super) struct HandleStore<S: Server> {
     token_stream: handle::OwnedStore<MarkedTokenStream<S>>,

--- a/library/proc_macro/src/bridge/symbol.rs
+++ b/library/proc_macro/src/bridge/symbol.rs
@@ -10,9 +10,10 @@
 //! proc_macro, this module should probably be removed or simplified.
 
 use std::cell::RefCell;
+use std::fmt;
 use std::num::NonZero;
 
-use super::*;
+use crate::bridge::{Buffer, Decode, Encode, Mark, arena, client, fxhash, server};
 
 /// Handle for a symbol string stored within the Interner.
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]


### PR DESCRIPTION
This factors out (and goes a bit further) some of the work from https://github.com/rust-lang/rust/pull/157590 which I think can/should be merged independently of the wasm proc macros strategy, since it just makes it easier to read code in the bridge. It was confusing to get warnings/errors when commenting code that looked unused but was actually pulled in due to the `*` imports from other modules.

This also factors the panic message into a separate module since it's not really related to `rpc` in a direct sense.

Best reviewed by-commit.

r? bjorn3 since you've probably at least glanced at this code recently, but happy to re-roll if you'd prefer.