### PR TITLE
don't ice on non-lifetime binders under `-Zassumptions-on-binders`

### DIFF
--- a/compiler/rustc_type_ir/src/region_constraint.rs
+++ b/compiler/rustc_type_ir/src/region_constraint.rs
@@ -654,8 +654,18 @@ fn pull_region_outlives_constraints_out_of_universe<
     use RegionConstraint::*;
     match constraint {
         Ambiguity | PlaceholderTyOutlives(..) | AliasTyOutlivesViaEnv(..) => {
-            assert!(max_universe(infcx, constraint.clone()) < u);
-            constraint
+            // With only lifetime binders the rewrite step lowers these constraints out of `u`
+            // (or destructures them), so we expect `max_universe < u` here. A non-lifetime
+            // binder (`for<T>`) instead introduces a placeholder type in `u`, which
+            // `PlaceholderReplacer` (region-only, see its `fold_region`) cannot pull out,
+            // leaving e.g. `<!T as Trait>::Assoc: 'r` stranded in `u`. The assumptions-on-binders
+            // machinery is region-outlives-only and can't decide such a constraint, so report
+            // ambiguity rather than ICE.
+            if max_universe(infcx, constraint.clone()) < u {
+                constraint
+            } else {
+                RegionConstraint::Ambiguity
+            }
         }
         RegionOutlives(region_1, region_2) => {
             let region_1_u = max_universe(infcx, region_1);

--- a/compiler/rustc_type_ir/src/region_constraint.rs
+++ b/compiler/rustc_type_ir/src/region_constraint.rs
@@ -654,18 +654,8 @@ fn pull_region_outlives_constraints_out_of_universe<
     use RegionConstraint::*;
     match constraint {
         Ambiguity | PlaceholderTyOutlives(..) | AliasTyOutlivesViaEnv(..) => {
-            // With only lifetime binders the rewrite step lowers these constraints out of `u`
-            // (or destructures them), so we expect `max_universe < u` here. A non-lifetime
-            // binder (`for<T>`) instead introduces a placeholder type in `u`, which
-            // `PlaceholderReplacer` (region-only, see its `fold_region`) cannot pull out,
-            // leaving e.g. `<!T as Trait>::Assoc: 'r` stranded in `u`. The assumptions-on-binders
-            // machinery is region-outlives-only and can't decide such a constraint, so report
-            // ambiguity rather than ICE.
-            if max_universe(infcx, constraint.clone()) < u {
-                constraint
-            } else {
-                RegionConstraint::Ambiguity
-            }
+            assert!(max_universe(infcx, constraint.clone()) < u);
+            constraint
         }
         RegionOutlives(region_1, region_2) => {
             let region_1_u = max_universe(infcx, region_1);
@@ -850,7 +840,15 @@ fn rewrite_type_outlives_constraints_in_universe_for_eager_placeholder_handling<
                     escaping_outlives,
                     I::BoundVarKinds::from_vars(infcx.cx(), bound_vars),
                 );
-                candidates.push(RegionConstraint::AliasTyOutlivesViaEnv(bound_outlives));
+                let candidate = RegionConstraint::AliasTyOutlivesViaEnv(bound_outlives);
+                if max_universe(infcx, candidate.clone()) < u {
+                    candidates.push(candidate);
+                } else {
+                    // `PlaceholderReplacer` only folds regions. A non-lifetime binder can leave
+                    // a placeholder type in `u`, so this type-outlives constraint cannot be
+                    // handled by the region-outlives-only eager placeholder machinery.
+                    candidates.push(Ambiguity);
+                }
             }
 
             let assumptions = match assumptions {
@@ -895,12 +893,17 @@ fn rewrite_type_outlives_constraints_in_universe_for_eager_placeholder_handling<
 
                 // while we did skip the binder, bound vars aren't in any universe so
                 // this can't be an escaping bound var
-                candidates.extend(
-                    regions_outliving(escaping_r, assumptions, infcx.cx())
-                        .filter(|r2| max_universe(infcx, *r2) < u)
-                        .map(|r2| AliasTyOutlivesViaEnv(bound_alias.map_bound(|alias| (alias, r2))))
-                        .collect::<Vec<_>>(),
-                );
+                for r2 in regions_outliving(escaping_r, assumptions, infcx.cx())
+                    .filter(|r2| max_universe(infcx, *r2) < u)
+                {
+                    let candidate =
+                        AliasTyOutlivesViaEnv(bound_alias.map_bound(|alias| (alias, r2)));
+                    if max_universe(infcx, candidate.clone()) < u {
+                        candidates.push(candidate);
+                    } else {
+                        candidates.push(Ambiguity);
+                    }
+                }
             }
 
             // I'm not convinced our handling here is *complete* so for now

--- a/tests/ui/assumptions_on_binders/non_lifetime_binder_alias_outlives.rs
+++ b/tests/ui/assumptions_on_binders/non_lifetime_binder_alias_outlives.rs
@@ -1,0 +1,21 @@
+//@ compile-flags: -Znext-solver -Zassumptions-on-binders
+
+// Regression test for #157778.
+//
+// A non-lifetime binder (`for<T>`) introduces a placeholder *type* in universe `u`. The
+// resulting alias-outlives constraint `<!T as Trait>::Assoc: 'r` stays in `u` because the
+// region-only rewrite (`PlaceholderReplacer` only folds regions) cannot pull a type
+// placeholder out of `u`. This used to trip an `assert!(max_universe < u)` and ICE in
+// `pull_region_outlives_constraints_out_of_universe`. The assumptions-on-binders machinery
+// is region-outlives-only, so we now report ambiguity instead of panicking.
+
+#![feature(non_lifetime_binders)]
+
+trait Trait {
+    type Assoc;
+    type Ref //~ ERROR cannot satisfy `<T as Trait>::Assoc: 'static`
+    where
+        for<T> T: Trait<Assoc: 'static>;
+}
+
+fn main() {}

--- a/tests/ui/assumptions_on_binders/non_lifetime_binder_alias_outlives.stderr
+++ b/tests/ui/assumptions_on_binders/non_lifetime_binder_alias_outlives.stderr
@@ -1,0 +1,20 @@
+error[E0284]: type annotations needed: cannot satisfy `<T as Trait>::Assoc: 'static`
+  --> $DIR/non_lifetime_binder_alias_outlives.rs:16:5
+   |
+LL | /     type Ref
+LL | |     where
+LL | |         for<T> T: Trait<Assoc: 'static>;
+   | |________________________________________^ cannot satisfy `<T as Trait>::Assoc: 'static`
+   |
+note: required by a bound in `Trait::Ref`
+  --> $DIR/non_lifetime_binder_alias_outlives.rs:18:32
+   |
+LL |     type Ref
+   |          --- required by a bound in this associated type
+LL |     where
+LL |         for<T> T: Trait<Assoc: 'static>;
+   |                                ^^^^^^^ required by this bound in `Trait::Ref`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0284`.


### PR DESCRIPTION
fixes rust-lang/rust#157778

w/ `-Znext-solver=globally -Zassumptions-on-binders` and a non-lifetime binder we hit `assert!(max_universe < u)` in `pull_region_outlives_constraints_out_of_universe` and ICE.

the machinery here is region-outlives only, but a `for<T>` binder leaves a placeholder type in universe `u` that the region-only rewrite can't pull out, so an alias outlives like `<!T as Trait>::Assoc: 'r` reaches that assert still in `u`. just report ambiguity in that case, same as the `None => Ambiguity` bails right next to it — now it errors normally (E0284) instead of ICEing.

r? @lcnr
