### PR TITLE
feat: avoid a `index == 0` test in `is_char_boundary`

### DIFF
--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -372,11 +372,12 @@ impl str {
     #[rustc_const_stable(feature = "const_is_char_boundary", since = "1.86.0")]
     #[inline]
     pub const fn is_char_boundary(&self, index: usize) -> bool {
-        // 0 is always ok.
+        // Since str is valid UTF-8, 0 is always ok.
         // Test for 0 explicitly so that it can optimize out the check
         // easily and skip reading string data for that case.
         // Note that optimizing `self.get(..index)` relies on this.
-        if index == 0 {
+        let is_start = index == 0;
+        if crate::intrinsics::is_val_statically_known(is_start) && is_start {
             return true;
         }
 
@@ -424,7 +425,11 @@ impl str {
         if index >= self.len() {
             return self.len();
         }
-        if self.as_bytes()[index].is_utf8_char_boundary() {
+        // Since str is valid UTF-8, 0 is always ok.
+        let is_start = index == 0;
+        if (crate::intrinsics::is_val_statically_known(is_start) && is_start)
+            || self.as_bytes()[index].is_utf8_char_boundary()
+        {
             return index;
         }
         // Unlike `ceil_char_boundary`, the loop is unrolled manually to prevent the compiler from

--- a/library/core/src/str/traits.rs
+++ b/library/core/src/str/traits.rs
@@ -125,6 +125,7 @@ const unsafe impl SliceIndex<str> for ops::RangeFull {
 const fn check_range(slice: &str, range: crate::range::Range<usize>) -> bool {
     let crate::range::Range { start, end } = range;
     let bytes = slice.as_bytes();
+    let is_start = start == 0;
 
     if start > end || end > slice.len() {
         return false;
@@ -136,13 +137,17 @@ const fn check_range(slice: &str, range: crate::range::Range<usize>) -> bool {
     }
 
     // SAFETY:
-    // `start > end || end > slice.len()` is false, so `start <= end <= slice.len()` is true.
+    // `start > end || end > slice.len()` is false, so `0 <= start <= end <= slice.len()` is true.
     // `start == slice.len()` is false, so `start < slice.len()` is also true.
+    // If `slice` is empty, we have `0 <= start <= end <= 0`, so `start == end == 0`, but `start < slice.len()`. Thus `slice` is non-empty.
     //
     // No need to check for `end == 0`, because if `end == 0` is true then `start == slice.len()`
     // would also be true, which is already handled above.
+    //
+    // No need to check for `start == 0`, because `slice[0]` is in-range, and valid UTF-8.
     unsafe {
-        (start == 0 || bytes.as_ptr().add(start).read().is_utf8_char_boundary())
+        ((crate::intrinsics::is_val_statically_known(is_start) && is_start)
+            || bytes.as_ptr().add(start).read().is_utf8_char_boundary())
             && (end == slice.len() || bytes.as_ptr().add(end).read().is_utf8_char_boundary())
     }
 }

--- a/tests/codegen-llvm/str-range-indexing.rs
+++ b/tests/codegen-llvm/str-range-indexing.rs
@@ -18,49 +18,48 @@ macro_rules! tests {
     };
 }
 
-// 7 comparisons required:
+// 6 comparisons required:
 // start <= end && end <= len
-// && (start == len ||
-// (  (start == 0   || bytes[start] >= -0x40)
-// && (end   == len || bytes[end] >= -0x40)))
+// && (start == len || bytes[start] >= -0x40)
+// && (end   == len || bytes[end] >= -0x40)
 
 // CHECK-LABEL: @get_range
-// CHECK-COUNT-7: %{{.+}} = icmp
+// CHECK-COUNT-6: %{{.+}} = icmp
 // CHECK-NOT: %{{.+}} = icmp
 // CHECK: ret
 
 // CHECK-LABEL: @index_range
-// CHECK-COUNT-7: %{{.+}} = icmp
+// CHECK-COUNT-6: %{{.+}} = icmp
 // CHECK-NOT: %{{.+}} = icmp
 // CHECK: ret
 tests!(Range<usize>, get_range, index_range);
 
-// 7 comparisons required:
+// 6 comparisons required:
 // end < len && start <= end + 1
-// && (start == 0 || start   >= len || bytes[start]   >= -0x40)
-// && (              end + 1 >= len || bytes[end + 1] >= -0x40)
+// && (start   >= len || bytes[start]   >= -0x40)
+// && (end + 1 >= len || bytes[end + 1] >= -0x40)
 
 // CHECK-LABEL: @get_range_inclusive
-// CHECK-COUNT-7: %{{.+}} = icmp
+// CHECK-COUNT-6: %{{.+}} = icmp
 // CHECK-NOT: %{{.+}} = icmp
 // CHECK: ret
 
 // CHECK-LABEL: @index_range_inclusive
-// CHECK-COUNT-7: %{{.+}} = icmp
+// CHECK-COUNT-6: %{{.+}} = icmp
 // CHECK-NOT: %{{.+}} = icmp
 // CHECK: ret
 tests!(RangeInclusive<usize>, get_range_inclusive, index_range_inclusive);
 
-// 4 comparisons required:
-// end == 0 || (end >= len && end == len) || bytes[end] >= -0x40
+// 3 comparisons required:
+// (end >= len && end == len) || bytes[end] >= -0x40
 
 // CHECK-LABEL: @get_range_to
-// CHECK-COUNT-4: %{{.+}} = icmp
+// CHECK-COUNT-3: %{{.+}} = icmp
 // CHECK-NOT: %{{.+}} = icmp
 // CHECK: ret
 
 // CHECK-LABEL: @index_range_to
-// CHECK-COUNT-4: %{{.+}} = icmp
+// CHECK-COUNT-3: %{{.+}} = icmp
 // CHECK-NOT: %{{.+}} = icmp
 // CHECK: ret
 tests!(RangeTo<usize>, get_range_to, index_range_to);
@@ -79,16 +78,16 @@ tests!(RangeTo<usize>, get_range_to, index_range_to);
 // CHECK: ret
 tests!(RangeToInclusive<usize>, get_range_to_inclusive, index_range_to_inclusive);
 
-// 4 comparisons required:
-// start == 0 || (start >= len && start == len) || bytes[start] >= -0x40)
+// 3 comparisons required:
+// (start >= len && start == len) || bytes[start] >= -0x40)
 
 // CHECK-LABEL: @get_range_from
-// CHECK-COUNT-4: %{{.+}} = icmp
+// CHECK-COUNT-3: %{{.+}} = icmp
 // CHECK-NOT: %{{.+}} = icmp
 // CHECK: ret
 
 // CHECK-LABEL: @index_range_from
-// CHECK-COUNT-4: %{{.+}} = icmp
+// CHECK-COUNT-3: %{{.+}} = icmp
 // CHECK-NOT: %{{.+}} = icmp
 // CHECK: ret
 tests!(RangeFrom<usize>, get_range_from, index_range_from);


### PR DESCRIPTION
When substringing, stdlib special case `index == 0` in order to optimize `&s[..end]`. Using [`is_val_statically_known`](https://doc.rust-lang.org/1.96.0/std/intrinsics/fn.is_val_statically_known.html) in order to avoid this check in the general `&[start..end]` case.

Drawback: `is_val_statically_known` is not implemented for the Cranelift backend, so perfs there might degrade.