### PR TITLE
make test succeed on targets lacking a personality

### DIFF
--- a/tests/ui/error-codes/E0152-duplicate-lang-items.rs
+++ b/tests/ui/error-codes/E0152-duplicate-lang-items.rs
@@ -3,15 +3,15 @@
 //!
 //! Issue: <https://github.com/rust-lang/rust/issues/31788>
 
-//@ normalize-stderr: "loaded from .*libstd-.*.rmeta" -> "loaded from SYSROOT/libstd-*.rmeta"
+//@ normalize-stderr: "loaded from \$.*libcore-.*.rmeta" -> "loaded from SYSROOT/libcore-*.rmeta"
 //@ dont-require-annotations: NOTE
 
 #![feature(lang_items)]
 
-#[lang = "eh_personality"]
-fn personality() {
-    //~^ ERROR: found duplicate lang item `eh_personality`
-    //~| NOTE first defined in crate `std`
+#[lang = "panic_fmt"]
+fn panic_fmt() -> ! {
+    //~^ ERROR: found duplicate lang item `panic_fmt`
+    //~| NOTE first defined in crate `core`
     loop {}
 }
 

--- a/tests/ui/error-codes/E0152-duplicate-lang-items.stderr
+++ b/tests/ui/error-codes/E0152-duplicate-lang-items.stderr
@@ -1,15 +1,15 @@
-error[E0152]: found duplicate lang item `eh_personality`
+error[E0152]: found duplicate lang item `panic_fmt`
   --> $DIR/E0152-duplicate-lang-items.rs:12:1
    |
-LL | / fn personality() {
+LL | / fn panic_fmt() -> ! {
 LL | |
 LL | |
 LL | |     loop {}
 LL | | }
    | |_^
    |
-   = note: the lang item is first defined in crate `std` (which `E0152_duplicate_lang_items` depends on)
-   = note: first definition in `std` loaded from SYSROOT/libstd-*.rmeta
+   = note: the lang item is first defined in crate `core` (which `std` depends on)
+   = note: first definition in `core` loaded from SYSROOT/libcore-*.rmeta
    = note: second definition in the local crate (`E0152_duplicate_lang_items`)
 
 error: aborting due to 1 previous error


### PR DESCRIPTION
Not all targets have `eh_personality` lang item set (see library/std/src/sys/personality/mod.rs), so change test to use a more available lang item.