### PR TITLE
tests: adapt two tests for LLVM 23 changes

### DIFF
--- a/tests/codegen-llvm/issues/issue-118306.rs
+++ b/tests/codegen-llvm/issues/issue-118306.rs
@@ -1,5 +1,8 @@
 //@ compile-flags: -Copt-level=3
 //@ only-x86_64
+//@ revisions: LLVM22 LLVM23
+//@ [LLVM22] max-llvm-major-version: 22
+//@ [LLVM23] min-llvm-version: 23
 
 // Test for #118306.
 // Make sure we don't create `br` or `select` instructions.
@@ -11,9 +14,13 @@ pub fn branchy(input: u64) -> u64 {
     // CHECK-LABEL: @branchy(
     // CHECK-NEXT:  start:
     // CHECK-NEXT:    [[_2:%.*]] = and i64 [[INPUT:%.*]], 3
-    // CHECK-NEXT:    [[SWITCH_GEP:%.*]] = getelementptr inbounds{{( nuw)?}} {{\[4 x i64\]|i64|\[8 x i8\]}}, ptr @switch.table.branchy{{(, i64 0)?}}, i64 [[_2]]
-    // CHECK-NEXT:    [[SWITCH_LOAD:%.*]] = load i64, ptr [[SWITCH_GEP]]
-    // CHECK-NEXT:    ret i64 [[SWITCH_LOAD]]
+    // LLVM22-NEXT:   [[SWITCH_GEP:%.*]] = getelementptr inbounds{{( nuw)?}} {{\[4 x i64\]|i64|\[8 x i8\]}}, ptr @switch.table.branchy{{(, i64 0)?}}, i64 [[_2]]
+    // LLVM22-NEXT:   [[SWITCH_LOAD:%.*]] = load i64, ptr [[SWITCH_GEP]]
+    // LLVM22-NEXT:   ret i64 [[SWITCH_LOAD]]
+    // LLVM23-NEXT:   [[SWITCH_GEP:%.*]] = getelementptr inbounds{{( nuw)?}} i8, ptr @switch.table.branchy, i64 [[_2]]
+    // LLVM23-NEXT:   [[SWITCH_LOAD:%.*]] = load i8, ptr [[SWITCH_GEP]], align 1
+    // LLVM23-NEXT:   [[SWITCH_EXT:%.*]] = zext i8 [[SWITCH_LOAD]] to i64
+    // LLVM23-NEXT:   ret i64 [[SWITCH_EXT]]
     match input % 4 {
         1 | 2 => 1,
         3 => 2,

--- a/tests/codegen-llvm/pow_known_base.rs
+++ b/tests/codegen-llvm/pow_known_base.rs
@@ -1,4 +1,7 @@
 //@ compile-flags: -Copt-level=3
+//@ revisions: LLVM22 LLVM23
+//@ [LLVM22] max-llvm-major-version: 22
+//@ [LLVM23] min-llvm-version: 23
 // Test that `pow` can use a faster implementation when `base` is a
 // known power of two
 
@@ -21,11 +24,16 @@ pub fn pow2(exp: u32) -> u32 {
 pub fn pow4(exp: u32) -> u32 {
     // CHECK: %[[ICMP1:.+]] = icmp slt i32 %exp, 0
     // CHECK: %[[SHIFT_AMOUNT:.+]] = shl i32 %exp, 1
-    // CHECK: %[[ICMP2:.+]] = icmp ult i32 %[[SHIFT_AMOUNT]], 32
-    // CHECK: %[[POW:.+]] = shl nuw i32 1, %[[SHIFT_AMOUNT]]
-    // CHECK: %[[SEL:.+]] = select i1 %[[ICMP2]], i32 %[[POW]], i32 0
-    // CHECK: %[[RET:.+]] = select i1 %[[ICMP1]], i32 0, i32 %[[SEL]]
-    // CHECK: ret i32 %[[RET]]
+    // LLVM22: %[[ICMP2:.+]] = icmp ult i32 %[[SHIFT_AMOUNT]], 32
+    // LLVM22: %[[POW:.+]] = shl nuw i32 1, %[[SHIFT_AMOUNT]]
+    // LLVM22: %[[SEL:.+]] = select i1 %[[ICMP2]], i32 %[[POW]], i32 0
+    // LLVM22: %[[RET:.+]] = select i1 %[[ICMP1]], i32 0, i32 %[[SEL]]
+    // LLVM22: ret i32 %[[RET]]
+    // LLVM23: %[[ICMP2:.+]] = icmp ugt i32 %[[SHIFT_AMOUNT]], 31
+    // LLVM23: %[[POW:.+]] = shl nuw i32 1, %[[SHIFT_AMOUNT]]
+    // LLVM23: %[[COND:.+]] = or i1 %[[ICMP1]], %[[ICMP2]]
+    // LLVM23: %[[RET:.+]] = select i1 %[[COND]], i32 0, i32 %[[POW]]
+    // LLVM23: ret i32 %[[RET]]
     4u32.pow(exp)
 }
 
@@ -35,11 +43,16 @@ pub fn pow4(exp: u32) -> u32 {
 pub fn pow16(exp: u32) -> u32 {
     // CHECK: %[[ICMP1:.+]] = icmp ugt i32 %exp, 1073741823
     // CHECK: %[[SHIFT_AMOUNT:.+]] = shl i32 %exp, 2
-    // CHECK: %[[ICMP2:.+]] = icmp ult i32 %[[SHIFT_AMOUNT]], 32
-    // CHECK: %[[POW:.+]] = shl nuw i32 1, %[[SHIFT_AMOUNT]]
-    // CHECK: %[[SEL:.+]] = select i1 %[[ICMP2]], i32 %[[POW]], i32 0
-    // CHECK: %[[RET:.+]] = select i1 %[[ICMP1]], i32 0, i32 %[[SEL]]
-    // CHECK: ret i32 %[[RET]]
+    // LLVM22: %[[ICMP2:.+]] = icmp ult i32 %[[SHIFT_AMOUNT]], 32
+    // LLVM22: %[[POW:.+]] = shl nuw i32 1, %[[SHIFT_AMOUNT]]
+    // LLVM22: %[[SEL:.+]] = select i1 %[[ICMP2]], i32 %[[POW]], i32 0
+    // LLVM22: %[[RET:.+]] = select i1 %[[ICMP1]], i32 0, i32 %[[SEL]]
+    // LLVM22: ret i32 %[[RET]]
+    // LLVM23: %[[ICMP2:.+]] = icmp ugt i32 %[[SHIFT_AMOUNT]], 31
+    // LLVM23: %[[POW:.+]] = shl nuw i32 1, %[[SHIFT_AMOUNT]]
+    // LLVM23: %[[COND:.+]] = or i1 %[[ICMP1]], %[[ICMP2]]
+    // LLVM23: %[[RET:.+]] = select i1 %[[COND]], i32 0, i32 %[[POW]]
+    // LLVM23: ret i32 %[[RET]]
     16u32.pow(exp)
 }
 


### PR DESCRIPTION
LLVM 23 recently changed SimplifyCFG to avoid integer lookup tables, and that perturbed these two tests in ways that look harmless to me.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
