### PR TITLE
test `carryless_mul` codegen

### DIFF
--- a/src/tools/compiletest/src/directives/directive_names.rs
+++ b/src/tools/compiletest/src/directives/directive_names.rs
@@ -250,6 +250,7 @@ pub(crate) const KNOWN_DIRECTIVE_NAMES: &[&str] = &[
     "only-powerpc",
     "only-riscv32",
     "only-riscv64",
+    "only-riscv64gc-unknown-linux-gnu",
     "only-rustc_abi-x86-sse2",
     "only-s390x",
     "only-sparc",

--- a/tests/assembly-llvm/carryless-mul.rs
+++ b/tests/assembly-llvm/carryless-mul.rs
@@ -1,0 +1,126 @@
+// Checks that the `carryless_mul` / `widening_carryless_mul` operations lower to
+// the architectures' native carry-less (polynomial) multiply instructions.
+//
+// - Rust to LLVM IR: https://godbolt.org/z/sM914e4fo
+// - LLVM IR to assembly: https://godbolt.org/z/5Y7naa4cY
+//
+//@revisions: x86_64 aarch64 riscv64
+//@assembly-output: emit-asm
+//@min-llvm-version: 23
+//@compile-flags: -C opt-level=3
+//
+//@[x86_64] compile-flags: -C target-feature=+pclmulqdq,+avx2 -Cllvm-args=-x86-asm-syntax=intel
+//@[x86_64] only-x86_64-unknown-linux-gnu
+//
+//@[aarch64] compile-flags: -C target-feature=+aes
+//@[aarch64] only-aarch64-unknown-linux-gnu
+//
+//@[riscv64] compile-flags: -C target-feature=+zknd,+zbc
+//@[riscv64] only-riscv64gc-unknown-linux-gnu
+
+#![feature(uint_carryless_mul)]
+#![crate_type = "lib"]
+
+#[unsafe(no_mangle)]
+fn carryless_mul_u8(a: u8, b: u8) -> u8 {
+    // CHECK-LABEL: carryless_mul_u8:
+    // x86_64: pclmulqdq
+    // aarch64: pmul
+    // riscv64: clmul
+    a.carryless_mul(b)
+}
+
+#[unsafe(no_mangle)]
+fn widening_carryless_mul_u8(a: u8, b: u8) -> u16 {
+    // CHECK-LABEL: widening_carryless_mul_u8:
+    // x86_64: pclmulqdq
+    // aarch64: pmull
+    // riscv64: clmul
+    a.widening_carryless_mul(b)
+}
+
+#[unsafe(no_mangle)]
+fn carryless_mul_u16(a: u16, b: u16) -> u16 {
+    // CHECK-LABEL: carryless_mul_u16:
+    // x86_64: pclmulqdq
+    // aarch64: pmull
+    // riscv64: clmul
+    a.carryless_mul(b)
+}
+
+#[unsafe(no_mangle)]
+fn widening_carryless_mul_u16(a: u16, b: u16) -> u32 {
+    // CHECK-LABEL: widening_carryless_mul_u16:
+    // x86_64: pclmulqdq
+    // aarch64: pmull
+    // riscv64: clmul
+    a.widening_carryless_mul(b)
+}
+
+#[unsafe(no_mangle)]
+fn carryless_mul_u32(a: u32, b: u32) -> u32 {
+    // CHECK-LABEL: carryless_mul_u32:
+    // x86_64: pclmulqdq
+    // aarch64: pmull
+    // riscv64: clmul
+    a.carryless_mul(b)
+}
+
+#[unsafe(no_mangle)]
+fn widening_carryless_mul_u32(a: u32, b: u32) -> u64 {
+    // CHECK-LABEL: widening_carryless_mul_u32:
+    // x86_64: pclmulqdq
+    // aarch64: pmull
+    // riscv64: slli
+    // riscv64: slli
+    // riscv64: clmulh
+    a.widening_carryless_mul(b)
+}
+
+#[unsafe(no_mangle)]
+fn carryless_mul_u64(a: u64, b: u64) -> u64 {
+    // CHECK-LABEL: carryless_mul_u64:
+    // x86_64: pclmulqdq
+    // aarch64: pmull
+    // riscv64: clmul
+    a.carryless_mul(b)
+}
+
+#[unsafe(no_mangle)]
+fn widening_carryless_mul_u64(a: u64, b: u64) -> u128 {
+    // CHECK-LABEL: widening_carryless_mul_u64:
+    //
+    // x86_64: pclmulqdq
+    // x86_64: vpextrq
+    //
+    // aarch64: rbit
+    // aarch64: pmull
+    // aarch64: pmull
+    //
+    // riscv64: clmul
+    // riscv64: clmulh
+    a.widening_carryless_mul(b)
+}
+
+#[unsafe(no_mangle)]
+fn carryless_mul_u128(a: u128, b: u128) -> u128 {
+    // CHECK-LABEL: carryless_mul_u128:
+    //
+    // x86_64: pclmulqdq
+    // x86_64: pclmulqdq
+    // x86_64: pclmulqdq
+    // x86_64: xor
+    //
+    // aarch64: pmull
+    // aarch64: pmull
+    // aarch64: pmull
+    // aarch64: eor
+    //
+    // riscv64: clmul
+    // riscv64: clmul
+    // riscv64: clmulh
+    // riscv64: xor
+    // riscv64: clmul
+    // riscv64: xor
+    a.carryless_mul(b)
+}


### PR DESCRIPTION
tracking issue: https://github.com/rust-lang/rust/issues/152080

Test the codegen of `carryless_mul` with LLVM 23, which has custom lowerings for x86_64, aarch64 and riscv64.

- Rust to LLVM IR: https://godbolt.org/z/sM914e4fo
- LLVM IR to assembly: https://godbolt.org/z/5Y7naa4cY

You can also see that the default expansion (when there is no special intruction available) is quite large still... 

- manual https://godbolt.org/z/hbEe3WMdW (based on https://github.com/rust-lang/rust/pull/152132#discussion_r2772245464)
- LLVM https://godbolt.org/z/577Wb9E99

So LLVM default over 3X the number of instructions for the 64-bit and 128-bit case.