### PR TITLE
Improve GPU codegen by defaulting to immediate-abort

### DIFF
--- a/compiler/rustc_target/src/spec/targets/amdgcn_amd_amdhsa.rs
+++ b/compiler/rustc_target/src/spec/targets/amdgcn_amd_amdhsa.rs
@@ -28,7 +28,7 @@ pub(crate) fn target() -> Target {
             max_atomic_width: Some(64),
 
             // Unwinding on GPUs is not useful.
-            panic_strategy: PanicStrategy::Abort,
+            panic_strategy: PanicStrategy::ImmediateAbort,
 
             // amdgpu backend does not support libcalls.
             no_builtins: true,

--- a/compiler/rustc_target/src/spec/targets/nvptx64_nvidia_cuda.rs
+++ b/compiler/rustc_target/src/spec/targets/nvptx64_nvidia_cuda.rs
@@ -33,7 +33,7 @@ pub(crate) fn target() -> Target {
             max_atomic_width: Some(64),
 
             // Unwinding on CUDA is neither feasible nor useful.
-            panic_strategy: PanicStrategy::Abort,
+            panic_strategy: PanicStrategy::ImmediateAbort,
 
             // Needed to use `dylib` and `bin` crate types and the linker.
             dynamic_linking: true,


### PR DESCRIPTION
When looking at the IR of some GPU benchmarks, we noticed that even with panic=abort we ended up with quite a lot of extra IR from the panic machinery. With `panic=immediate-abort`, those become simple branches to a trap call:
```
     1 panic:                                            ; preds = %bb2
  217    tail call void @llvm.trap()
     1   unreachable
     2 
```
We mostly see it being generated from bounds checks.

Specifying immediate-abort by hand is quite annoying.
1) you need to enable the experimental cargo feature for panic-abort. That for example means your stable cargo won't understand your project anymore and refuse even simple commands like `cargo clean`.
2) You need an extra (semi-hard to find) feature for build std `-Zbuild-std=core,panic_abort` 
3) (might be offload specific) we don't necessarily want immediate-abort on the host, so specifying immediate-abort as panic strategy in your Cargo.toml has undesired side-effects.

The only benefit of abort over immediate-abort is the ability to hook in your own panic handler. I think that's a rarely needed feature on GPUs, so we should prioritize better codegen, especially if it's so annoying to specify by hand otherwise.


@Flakebi @kjetilkjeka @kulst are you ok with this as target maintainers?

r? @saethlin 