### PR TITLE
rustdoc: Don't strip hidden items in `AliasedNonLocalStripper`

### DIFF
--- a/src/librustdoc/passes/strip_aliased_non_local.rs
+++ b/src/librustdoc/passes/strip_aliased_non_local.rs
@@ -47,9 +47,8 @@ impl DocFolder for NonLocalStripper<'_> {
         // FIXME(#125009): Not-local should probably consider same Cargo workspace
         if let Some(def_id) = i.def_id()
             && !def_id.is_local()
-            && (i.is_doc_hidden()
-                // Default to *not* stripping items with inherited visibility.
-                || i.visibility(self.tcx).is_some_and(|viz| viz != Visibility::Public))
+            // Default to *not* stripping items with inherited visibility.
+            && i.visibility(self.tcx).is_some_and(|viz| viz != Visibility::Public)
         {
             return Some(strip_item(i));
         }

--- a/tests/rustdoc-html/auxiliary/cross_crate_generic_typedef.rs
+++ b/tests/rustdoc-html/auxiliary/cross_crate_generic_typedef.rs
@@ -1,5 +1,7 @@
 pub struct InlineOne<A> {
-   pub inline: A
+   pub inline: A,
+   #[doc(hidden)]
+   pub hidden: A,
 }
 
 pub type InlineU64 = InlineOne<u64>;
@@ -7,4 +9,6 @@ pub type InlineU64 = InlineOne<u64>;
 pub enum GenericEnum<T> {
    Variant(T),
    Variant2(T, T),
+   #[doc(hidden)]
+   Hidden(T),
 }

--- a/tests/rustdoc-html/typedef-inner-variants-document-hidden.rs
+++ b/tests/rustdoc-html/typedef-inner-variants-document-hidden.rs
@@ -1,0 +1,26 @@
+// Regression test for <https://github.com/rust-lang/rust/issues/144969>.
+
+//@ compile-flags: -Z unstable-options --document-hidden-items
+//@ aux-build:cross_crate_generic_typedef.rs
+
+#![crate_name = "document_hidden_aliased_items"]
+
+extern crate cross_crate_generic_typedef;
+
+use std::collections::BTreeMap;
+
+//@ has 'document_hidden_aliased_items/type.InlineU64.html'
+//@ count - '//*[@class="structfield section-header"]' 2
+//@ has - '//pre[@class="rust item-decl"]//code' 'pub hidden'
+//@ count - '//pre[@class="rust item-decl"]//code' '/* private fields */' 0
+pub type InlineU64 = cross_crate_generic_typedef::InlineOne<u64>;
+
+//@ has 'document_hidden_aliased_items/type.InlineEnum.html'
+//@ count - '//*[@class="variant"]' 3
+//@ has - '//pre[@class="rust item-decl"]//code' 'Hidden'
+//@ count - '//pre[@class="rust item-decl"]//code' '// some variants omitted' 0
+pub type InlineEnum = cross_crate_generic_typedef::GenericEnum<i32>;
+
+//@ has 'document_hidden_aliased_items/type.PrivateFields.html'
+//@ has - '//*[@class="rust item-decl"]/code' 'struct PrivateFields { /* private fields */ }'
+pub type PrivateFields = BTreeMap<u32, String>;

--- a/tests/rustdoc-html/typedef-inner-variants.rs
+++ b/tests/rustdoc-html/typedef-inner-variants.rs
@@ -116,6 +116,7 @@ pub type HighlyGenericAABB<A, B> = HighlyGenericStruct<A, A, B, B>;
 //@ count - '//*[@id="aliased-type"]' 1
 //@ count - '//*[@id="variants"]' 0
 //@ count - '//*[@id="fields"]' 1
+//@ has - '//pre[@class="rust item-decl"]//code' '/* private fields */'
 pub use cross_crate_generic_typedef::InlineU64;
 
 //@ has 'inner_variants/type.InlineEnum.html'
@@ -123,4 +124,5 @@ pub use cross_crate_generic_typedef::InlineU64;
 //@ count - '//*[@id="variants"]' 1
 //@ count - '//*[@id="fields"]' 0
 //@ count - '//*[@class="variant"]' 2
+//@ has - '//pre[@class="rust item-decl"]//code' '// some variants omitted'
 pub type InlineEnum = cross_crate_generic_typedef::GenericEnum<i32>;


### PR DESCRIPTION
`AliasedNonLocalStripper` currently strips non-local aliased items that are either non-public or `#[doc(hidden)]`.

The hidden items are subsequently processed by the `strip-hidden` pass. Because they have already been wrapped as stripped items, that pass removes them instead of retaining them as placeholders. As a result, cross-crate aliased types omit `/* private fields */` and `// some variants omitted`.

Handling `#[doc(hidden)]` in `AliasedNonLocalStripper` also means that `--document-hidden-items` cannot display those public fields and variants.

This PR leaves hidden-item handling to `strip-hidden`, while `AliasedNonLocalStripper` continues to unconditionally hide non-public items from external types.

Fixes rust-lang/rust#144969.

r? @GuillaumeGomez 