### PR TITLE
Fix unstable fingerprints ICE in evaluate_obligation during incremental compilation

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -1118,12 +1118,26 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             self.insert_evaluation_cache(param_env, fresh_trait_pred, dep_node, result);
             stack.cache().on_completion(stack.dfn);
         } else if let Some(_guar) = self.infcx.tainted_by_errors() {
-            // When an error has occurred, we allow global caching of results even if they
+            // When an error has occurred, we allow caching of results even if they
             // appear stack-dependent. This prevents exponential re-evaluation of cycles
             // in the presence of errors, avoiding compiler hangs like #150907.
             // This is safe because compilation will fail anyway.
-            debug!("CACHE MISS (tainted by errors)");
-            self.insert_evaluation_cache(param_env, fresh_trait_pred, dep_node, result);
+            //
+            // However, we must only insert into the *local* evaluation cache
+            // (per-InferCtxt), not the global cache (per-TyCtxt). The global cache
+            // is persisted across incremental compilation sessions, and storing
+            // stack-dependent results there can cause unstable fingerprints (ICH
+            // verification failures), since the same query may produce a different
+            // result in a subsequent session without the same evaluation stack
+            // context. See #157854.
+            debug!("CACHE MISS (tainted by errors, local only)");
+            if !result.is_stack_dependent() {
+                self.infcx.evaluation_cache.insert(
+                    (param_env, fresh_trait_pred),
+                    dep_node,
+                    result,
+                );
+            }
             stack.cache().on_completion(stack.dfn);
         } else {
             debug!("PROVISIONAL");

--- a/tests/incremental/evaluate_obligation_incr_cache_issue_157854.rs
+++ b/tests/incremental/evaluate_obligation_incr_cache_issue_157854.rs
@@ -1,0 +1,34 @@
+// Regression test for #157854.
+//
+// An ICE ("Found unstable fingerprints for evaluate_obligation") occurred during
+// incremental compilation when:
+// 1. The first compilation succeeds, caching `evaluate_obligation` results.
+// 2. A subsequent compilation introduces an error, causing the inference context
+//    to become "tainted by errors".
+// 3. The tainted-by-errors path in trait evaluation cached stack-dependent
+//    (cycle-participant) results into the *global* evaluation cache.
+// 4. During incremental verification, the fingerprint of the globally cached
+//    result didn't match the recomputed one, triggering the ICH assertion.
+//
+// The fix ensures that when caching under the tainted-by-errors path, only the
+// local (per-InferCtxt) cache is used, not the global (per-TyCtxt) cache that
+// feeds into incremental compilation.
+
+//@ revisions: rpass1 bfail2
+
+struct S(&'static Box<S>);
+
+trait I<T> {}
+impl<F: Fn()> I<()> for F {}
+impl<F: Fn(T), T: Sync> I<(T,)> for F {}
+
+fn f<T>(_: impl I<T>) {}
+
+fn main() {
+    #[cfg(rpass1)]
+    f(|_: S| {});
+
+    #[cfg(bfail2)]
+    f(|_: S| { foo; });
+    //[bfail2]~^ ERROR cannot find value `foo` in this scope
+}


### PR DESCRIPTION
### Description
This PR resolves an Internal Compiler Error (ICE) where incremental compilation fails with `"Found unstable fingerprints for evaluate_obligation"`.

### Root Cause
PR rust-lang/rust#155355 introduced a performance optimization to prevent exponential re-evaluation of trait selection cycles when errors occur. It allowed results that appeared stack-dependent (cycle participants) to be cached globally if the inference context was "tainted by errors" (`self.infcx.tainted_by_errors().is_some()`).

However, caching stack-dependent results in the **global** evaluation cache (`tcx.evaluation_cache`) means these results persist across incremental compilation sessions. Since the result of a stack-dependent query depends on the active evaluation stack at the time, its fingerprint can vary depending on when/how it is evaluated in subsequent sessions, violating Incremental Compilation Hash (ICH) invariants and causing the verification panic.

### Fix
Instead of inserting the results into the global cache via `self.insert_evaluation_cache`, we insert them only into the **local** evaluation cache (`self.infcx.evaluation_cache`) when tainted by errors. 

This:
- ✅ Still prevents compiler hangs and exponential cycles within a single compilation session (as the local cache is reused across the session).
- ✅ Prevents polluting the global/cross-session cache with stack-dependent results.
- ✅ Resolves the incremental compilation unstable fingerprints ICE.

### Regression Test
Added a new incremental compilation test under `tests/incremental/evaluate_obligation_incr_cache_issue_157854.rs` which compiles successfully in `rpass1` and then triggers a compile error in `bfail2` to ensure that the compiler successfully reports the error without crashing on unstable fingerprints.

Fixes rust-lang/rust#157854
