### PR TITLE
Fix ICE \Unexpected node Synthetic\ in diagnostic_hir_wf_check

### DIFF
--- a/compiler/rustc_hir_analysis/src/hir_wf_check.rs
+++ b/compiler/rustc_hir_analysis/src/hir_wf_check.rs
@@ -189,6 +189,9 @@ pub(super) fn diagnostic_hir_wf_check<'tcx>(
                     vec![]
                 }
             }
+            // Synthetic nodes are created by query feeding for items like RPITIT
+            // opaque types that have no corresponding HIR type to walk.
+            hir::Node::Synthetic => vec![],
             ref node => bug!("Unexpected node {:?}", node),
         },
         WellFormedLoc::Param { function: _, param_idx } => {

--- a/tests/ui/impl-trait/in-trait/unexpected-node-synthetic-2-issue-148630.rs
+++ b/tests/ui/impl-trait/in-trait/unexpected-node-synthetic-2-issue-148630.rs
@@ -1,0 +1,21 @@
+// Regression test for #148630 (simpler reproduction).
+
+#![feature(unboxed_closures)]
+
+trait Tr {}
+trait Foo {
+    fn foo() -> impl Sized
+    //~^ ERROR expected a `FnOnce<&'a i32>` closure, found `()`
+    //~| ERROR expected a `FnOnce<&'a i32>` closure, found `()`
+    //~| ERROR expected a `FnOnce<&'a i32>` closure, found `()`
+    //~| ERROR expected a `FnOnce<&'a i32>` closure, found `()`
+    //~| ERROR expected a `FnOnce<&'a i32>` closure, found `()`
+    //~| ERROR expected a `FnOnce<&'a i32>` closure, found `()`
+    //~| ERROR expected a `FnOnce<&'a i32>` closure, found `()`
+    where
+        for<'a> <() as FnOnce<&'a i32>>::Output: Tr,
+    {
+    }
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/in-trait/unexpected-node-synthetic-2-issue-148630.stderr
+++ b/tests/ui/impl-trait/in-trait/unexpected-node-synthetic-2-issue-148630.stderr
@@ -1,0 +1,65 @@
+error[E0277]: expected a `FnOnce<&'a i32>` closure, found `()`
+  --> $DIR/unexpected-node-synthetic-2-issue-148630.rs:7:17
+   |
+LL |     fn foo() -> impl Sized
+   |                 ^^^^^^^^^^ expected an `FnOnce<&'a i32>` closure, found `()`
+   |
+   = help: the trait `for<'a> FnOnce<&'a i32>` is not implemented for `()`
+
+error[E0277]: expected a `FnOnce<&'a i32>` closure, found `()`
+  --> $DIR/unexpected-node-synthetic-2-issue-148630.rs:7:17
+   |
+LL |     fn foo() -> impl Sized
+   |                 ^^^^^^^^^^ expected an `FnOnce<&'a i32>` closure, found `()`
+   |
+   = help: the trait `for<'a> FnOnce<&'a i32>` is not implemented for `()`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0277]: expected a `FnOnce<&'a i32>` closure, found `()`
+  --> $DIR/unexpected-node-synthetic-2-issue-148630.rs:7:5
+   |
+LL | /     fn foo() -> impl Sized
+...  |
+LL | |     where
+LL | |         for<'a> <() as FnOnce<&'a i32>>::Output: Tr,
+   | |____________________________________________________^ expected an `FnOnce<&'a i32>` closure, found `()`
+   |
+   = help: the trait `for<'a> FnOnce<&'a i32>` is not implemented for `()`
+
+error[E0277]: expected a `FnOnce<&'a i32>` closure, found `()`
+  --> $DIR/unexpected-node-synthetic-2-issue-148630.rs:7:17
+   |
+LL |     fn foo() -> impl Sized
+   |                 ^^^^^^^^^^ expected an `FnOnce<&'a i32>` closure, found `()`
+   |
+   = help: the trait `for<'a> FnOnce<&'a i32>` is not implemented for `()`
+
+error[E0277]: expected a `FnOnce<&'a i32>` closure, found `()`
+  --> $DIR/unexpected-node-synthetic-2-issue-148630.rs:7:22
+   |
+LL |     fn foo() -> impl Sized
+   |                      ^^^^^ expected an `FnOnce<&'a i32>` closure, found `()`
+   |
+   = help: the trait `for<'a> FnOnce<&'a i32>` is not implemented for `()`
+
+error[E0277]: expected a `FnOnce<&'a i32>` closure, found `()`
+  --> $DIR/unexpected-node-synthetic-2-issue-148630.rs:7:17
+   |
+LL |     fn foo() -> impl Sized
+   |                 ^^^^^^^^^^ expected an `FnOnce<&'a i32>` closure, found `()`
+   |
+   = help: the trait `for<'a> FnOnce<&'a i32>` is not implemented for `()`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0277]: expected a `FnOnce<&'a i32>` closure, found `()`
+  --> $DIR/unexpected-node-synthetic-2-issue-148630.rs:7:17
+   |
+LL |     fn foo() -> impl Sized
+   |                 ^^^^^^^^^^ expected an `FnOnce<&'a i32>` closure, found `()`
+   |
+   = help: the trait `for<'a> FnOnce<&'a i32>` is not implemented for `()`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 7 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/impl-trait/in-trait/unexpected-node-synthetic-issue-148630.rs
+++ b/tests/ui/impl-trait/in-trait/unexpected-node-synthetic-issue-148630.rs
@@ -1,0 +1,23 @@
+// Regression test for #148630.
+
+#![feature(unboxed_closures)]
+
+use std::future::Future;
+
+trait Foo {
+    fn foo() -> impl Sized
+    //~^ ERROR expected a `FnOnce(&'a mut i32)` closure, found `(dyn Foo + 'static)`
+    //~| ERROR expected a `FnOnce(&'a mut i32)` closure, found `(dyn Foo + 'static)`
+    //~| ERROR expected a `FnOnce(&'a mut i32)` closure, found `(dyn Foo + 'static)`
+    //~| ERROR expected a `FnOnce(&'a mut i32)` closure, found `(dyn Foo + 'static)`
+    //~| ERROR expected a `FnOnce(&'a mut i32)` closure, found `(dyn Foo + 'static)`
+    //~| ERROR expected a `FnOnce(&'a mut i32)` closure, found `(dyn Foo + 'static)`
+    //~| ERROR expected a `FnOnce(&'a mut i32)` closure, found `(dyn Foo + 'static)`
+    where
+        for<'a> <dyn Foo as FnOnce<(&'a mut i32,)>>::Output: Future<Output = ()> + 'a,
+        //~^ ERROR the trait `Foo` is not dyn compatible [E0038]
+    {
+    }
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/in-trait/unexpected-node-synthetic-issue-148630.stderr
+++ b/tests/ui/impl-trait/in-trait/unexpected-node-synthetic-issue-148630.stderr
@@ -1,0 +1,89 @@
+error[E0277]: expected a `FnOnce(&'a mut i32)` closure, found `(dyn Foo + 'static)`
+  --> $DIR/unexpected-node-synthetic-issue-148630.rs:8:17
+   |
+LL |     fn foo() -> impl Sized
+   |                 ^^^^^^^^^^ expected an `FnOnce(&'a mut i32)` closure, found `(dyn Foo + 'static)`
+   |
+   = help: the trait `for<'a> FnOnce(&'a mut i32)` is not implemented for `(dyn Foo + 'static)`
+
+error[E0277]: expected a `FnOnce(&'a mut i32)` closure, found `(dyn Foo + 'static)`
+  --> $DIR/unexpected-node-synthetic-issue-148630.rs:8:17
+   |
+LL |     fn foo() -> impl Sized
+   |                 ^^^^^^^^^^ expected an `FnOnce(&'a mut i32)` closure, found `(dyn Foo + 'static)`
+   |
+   = help: the trait `for<'a> FnOnce(&'a mut i32)` is not implemented for `(dyn Foo + 'static)`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0277]: expected a `FnOnce(&'a mut i32)` closure, found `(dyn Foo + 'static)`
+  --> $DIR/unexpected-node-synthetic-issue-148630.rs:8:5
+   |
+LL | /     fn foo() -> impl Sized
+...  |
+LL | |     where
+LL | |         for<'a> <dyn Foo as FnOnce<(&'a mut i32,)>>::Output: Future<Output = ()> + 'a,
+   | |______________________________________________________________________________________^ expected an `FnOnce(&'a mut i32)` closure, found `(dyn Foo + 'static)`
+   |
+   = help: the trait `for<'a> FnOnce(&'a mut i32)` is not implemented for `(dyn Foo + 'static)`
+
+error[E0277]: expected a `FnOnce(&'a mut i32)` closure, found `(dyn Foo + 'static)`
+  --> $DIR/unexpected-node-synthetic-issue-148630.rs:8:17
+   |
+LL |     fn foo() -> impl Sized
+   |                 ^^^^^^^^^^ expected an `FnOnce(&'a mut i32)` closure, found `(dyn Foo + 'static)`
+   |
+   = help: the trait `for<'a> FnOnce(&'a mut i32)` is not implemented for `(dyn Foo + 'static)`
+
+error[E0038]: the trait `Foo` is not dyn compatible
+  --> $DIR/unexpected-node-synthetic-issue-148630.rs:17:84
+   |
+LL |         for<'a> <dyn Foo as FnOnce<(&'a mut i32,)>>::Output: Future<Output = ()> + 'a,
+   |                                                                                    ^^ `Foo` is not dyn compatible
+   |
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
+  --> $DIR/unexpected-node-synthetic-issue-148630.rs:8:8
+   |
+LL | trait Foo {
+   |       --- this trait is not dyn compatible...
+LL |     fn foo() -> impl Sized
+   |        ^^^ ...because associated function `foo` has no `self` parameter
+help: consider turning `foo` into a method by giving it a `&self` argument
+   |
+LL |     fn foo(&self) -> impl Sized
+   |            +++++
+help: alternatively, consider constraining `foo` so it does not apply to trait objects
+   |
+LL |         for<'a> <dyn Foo as FnOnce<(&'a mut i32,)>>::Output: Future<Output = ()> + 'a, Self: Sized
+   |                                                                                        +++++++++++
+
+error[E0277]: expected a `FnOnce(&'a mut i32)` closure, found `(dyn Foo + 'static)`
+  --> $DIR/unexpected-node-synthetic-issue-148630.rs:8:22
+   |
+LL |     fn foo() -> impl Sized
+   |                      ^^^^^ expected an `FnOnce(&'a mut i32)` closure, found `(dyn Foo + 'static)`
+   |
+   = help: the trait `for<'a> FnOnce(&'a mut i32)` is not implemented for `(dyn Foo + 'static)`
+
+error[E0277]: expected a `FnOnce(&'a mut i32)` closure, found `(dyn Foo + 'static)`
+  --> $DIR/unexpected-node-synthetic-issue-148630.rs:8:17
+   |
+LL |     fn foo() -> impl Sized
+   |                 ^^^^^^^^^^ expected an `FnOnce(&'a mut i32)` closure, found `(dyn Foo + 'static)`
+   |
+   = help: the trait `for<'a> FnOnce(&'a mut i32)` is not implemented for `(dyn Foo + 'static)`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0277]: expected a `FnOnce(&'a mut i32)` closure, found `(dyn Foo + 'static)`
+  --> $DIR/unexpected-node-synthetic-issue-148630.rs:8:17
+   |
+LL |     fn foo() -> impl Sized
+   |                 ^^^^^^^^^^ expected an `FnOnce(&'a mut i32)` closure, found `(dyn Foo + 'static)`
+   |
+   = help: the trait `for<'a> FnOnce(&'a mut i32)` is not implemented for `(dyn Foo + 'static)`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 8 previous errors
+
+Some errors have detailed explanations: E0038, E0277.
+For more information about an error, try `rustc --explain E0038`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Fixes rust-lang/rust#148630

`diagnostic_hir_wf_check` panics on `Node::Synthetic` when walking HIR types for WF error span refinement. RPITIT opaque types produce synthetic HIR nodes via query feeding and have no real HIR type to walk.

handle `Node::Synthetic` by returning an empty type list so the function returns `None` and the primary WF error is preserved with its original span. this is consistent with how other code handles synthetic nodes (e.g. `reachable.rs`, `hir/mod.rs`).

Added two regression tests from the issue.