### PR TITLE
Stabilize `#[my_macro] mod foo;` (part of `proc_macro_hygiene`)

### DIFF
--- a/compiler/rustc_expand/src/expand.rs
+++ b/compiler/rustc_expand/src/expand.rs
@@ -5,7 +5,7 @@ use std::{iter, mem, slice};
 
 use rustc_ast::mut_visit::*;
 use rustc_ast::tokenstream::TokenStream;
-use rustc_ast::visit::{self, AssocCtxt, Visitor, VisitorResult, try_visit, walk_list};
+use rustc_ast::visit::{AssocCtxt, Visitor, VisitorResult, try_visit, walk_list};
 use rustc_ast::{
     self as ast, AssocItemKind, AstNodeWrapper, AttrArgs, AttrItemKind, AttrStyle, AttrVec,
     DUMMY_NODE_ID, DelegationSource, DelegationSuffixes, EarlyParsedAttribute, ExprKind,
@@ -20,7 +20,7 @@ use rustc_attr_parsing::{
 };
 use rustc_data_structures::flat_map_in_place::FlatMapInPlace;
 use rustc_data_structures::stack::ensure_sufficient_stack;
-use rustc_errors::{PResult, msg};
+use rustc_errors::PResult;
 use rustc_feature::Features;
 use rustc_hir::Target;
 use rustc_hir::def::MacroKinds;
@@ -29,7 +29,6 @@ use rustc_parse::parser::{
     AllowConstBlockItems, AttemptLocalParseRecovery, CommaRecoveryMode, ForceCollect, Parser,
     RecoverColon, RecoverComma, Recovery, token_descr,
 };
-use rustc_session::Session;
 use rustc_session::errors::feature_err;
 use rustc_session::lint::builtin::{UNUSED_ATTRIBUTES, UNUSED_DOC_COMMENTS};
 use rustc_span::hygiene::SyntaxContext;
@@ -770,7 +769,6 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
             }
             InvocationKind::Attr { attr, pos, mut item, derives } => {
                 if let Some(expander) = ext.as_attr() {
-                    self.gate_proc_macro_input(&item);
                     self.gate_proc_macro_attr_item(span, &item);
                     let tokens = match &item {
                         // FIXME: Collect tokens and use them instead of generating
@@ -904,9 +902,6 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
             InvocationKind::Derive { path, item, is_const } => match ext {
                 SyntaxExtensionKind::Derive(expander)
                 | SyntaxExtensionKind::LegacyDerive(expander) => {
-                    if let SyntaxExtensionKind::Derive(..) = ext {
-                        self.gate_proc_macro_input(&item);
-                    }
                     // The `MetaItem` representing the trait to derive can't
                     // have an unsafe around it (as of now).
                     let meta = ast::MetaItem {
@@ -1041,37 +1036,6 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
             format!("custom attributes cannot be applied to {kind}"),
         )
         .emit();
-    }
-
-    fn gate_proc_macro_input(&self, annotatable: &Annotatable) {
-        struct GateProcMacroInput<'a> {
-            sess: &'a Session,
-        }
-
-        impl<'ast, 'a> Visitor<'ast> for GateProcMacroInput<'a> {
-            fn visit_item(&mut self, item: &'ast ast::Item) {
-                match &item.kind {
-                    ItemKind::Mod(_, _, mod_kind)
-                        if !matches!(mod_kind, ModKind::Loaded(_, Inline::Yes, _)) =>
-                    {
-                        feature_err(
-                            self.sess,
-                            sym::proc_macro_hygiene,
-                            item.span,
-                            msg!("file modules in proc macro input are unstable"),
-                        )
-                        .emit();
-                    }
-                    _ => {}
-                }
-
-                visit::walk_item(self, item);
-            }
-        }
-
-        if !self.cx.ecfg.features.proc_macro_hygiene() {
-            annotatable.visit_with(&mut GateProcMacroInput { sess: self.cx.sess });
-        }
     }
 
     fn parse_ast_fragment(

--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -688,7 +688,7 @@ declare_features! (
     (unstable, powerpc_target_feature, "1.27.0", Some(150255)),
     /// The prfchw target feature on x86.
     (unstable, prfchw_target_feature, "1.78.0", Some(150256)),
-    /// Allows macro attributes on expressions, statements and non-inline modules.
+    /// Allows macro attributes on expressions and statements.
     (unstable, proc_macro_hygiene, "1.30.0", Some(54727)),
     /// Allows the use of raw-dylibs on ELF platforms
     (incomplete, raw_dylib_elf, "1.87.0", Some(135694)),

--- a/tests/ui/proc-macro/attributes-on-modules-fail.rs
+++ b/tests/ui/proc-macro/attributes-on-modules-fail.rs
@@ -17,31 +17,4 @@ type A = X; //~ ERROR cannot find type `X` in this scope
 #[derive(Copy)] //~ ERROR `derive` may only be applied to `struct`s, `enum`s and `union`s
 mod n {}
 
-#[empty_attr]
-mod module; //~ ERROR file modules in proc macro input are unstable
-
-#[empty_attr]
-mod outer {
-    mod inner; //~ ERROR file modules in proc macro input are unstable
-
-    mod inner_inline {} // OK
-}
-
-#[derive(Empty)]
-struct S {
-    field: [u8; {
-        #[path = "outer/inner.rs"]
-        mod inner; //~ ERROR file modules in proc macro input are unstable
-        mod inner_inline {} // OK
-        0
-    }],
-}
-
-#[identity_attr]
-fn f() {
-    #[path = "outer/inner.rs"]
-    mod inner; //~ ERROR file modules in proc macro input are unstable
-    mod inner_inline {} // OK
-}
-
 fn main() {}

--- a/tests/ui/proc-macro/attributes-on-modules-fail.stderr
+++ b/tests/ui/proc-macro/attributes-on-modules-fail.stderr
@@ -6,46 +6,6 @@ LL | #[derive(Copy)]
 LL | mod n {}
    | -------- not a `struct`, `enum` or `union`
 
-error[E0658]: file modules in proc macro input are unstable
-  --> $DIR/attributes-on-modules-fail.rs:21:1
-   |
-LL | mod module;
-   | ^^^^^^^^^^^
-   |
-   = note: see issue #54727 <https://github.com/rust-lang/rust/issues/54727> for more information
-   = help: add `#![feature(proc_macro_hygiene)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
-error[E0658]: file modules in proc macro input are unstable
-  --> $DIR/attributes-on-modules-fail.rs:25:5
-   |
-LL |     mod inner;
-   |     ^^^^^^^^^^
-   |
-   = note: see issue #54727 <https://github.com/rust-lang/rust/issues/54727> for more information
-   = help: add `#![feature(proc_macro_hygiene)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
-error[E0658]: file modules in proc macro input are unstable
-  --> $DIR/attributes-on-modules-fail.rs:34:9
-   |
-LL |         mod inner;
-   |         ^^^^^^^^^^
-   |
-   = note: see issue #54727 <https://github.com/rust-lang/rust/issues/54727> for more information
-   = help: add `#![feature(proc_macro_hygiene)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
-error[E0658]: file modules in proc macro input are unstable
-  --> $DIR/attributes-on-modules-fail.rs:43:5
-   |
-LL |     mod inner;
-   |     ^^^^^^^^^^
-   |
-   = note: see issue #54727 <https://github.com/rust-lang/rust/issues/54727> for more information
-   = help: add `#![feature(proc_macro_hygiene)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
 error[E0425]: cannot find type `Y` in this scope
   --> $DIR/attributes-on-modules-fail.rs:11:14
    |
@@ -68,7 +28,7 @@ help: consider importing this struct
 LL + use m::X;
    |
 
-error: aborting due to 7 previous errors
+error: aborting due to 3 previous errors
 
-Some errors have detailed explanations: E0425, E0658, E0774.
+Some errors have detailed explanations: E0425, E0774.
 For more information about an error, try `rustc --explain E0425`.

--- a/tests/ui/proc-macro/auxiliary/expect-modules.rs
+++ b/tests/ui/proc-macro/auxiliary/expect-modules.rs
@@ -1,0 +1,41 @@
+/// Macros that assert that certain `mod` items are present in their input.
+
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+
+#[proc_macro_attribute]
+pub fn expect_mod_item(_attrs: TokenStream, item: TokenStream) -> TokenStream {
+    let s = item.to_string();
+
+    assert_eq!(s, "mod module;");
+
+    item
+}
+
+#[proc_macro_attribute]
+pub fn expect_mods_attr(_attrs: TokenStream, item: TokenStream) -> TokenStream {
+    let s = item.to_string();
+
+    assert_contains(&s, "mod attr_outlined;");
+    assert_contains(&s, "mod attr_inline {}");
+
+    item
+}
+
+#[proc_macro_derive(ExpectModsDerive)]
+pub fn expect_mods_derive(item: TokenStream) -> TokenStream {
+    let s = item.to_string();
+
+    assert_contains(&s, "mod derive_outlined;");
+    assert_contains(&s, "mod derive_inline {}");
+
+    TokenStream::new()
+}
+
+#[track_caller]
+fn assert_contains(s: &str, needle: &str) {
+    if !s.contains(needle) {
+        panic!("{needle:?} not found in:\n---\n{s}\n---\n");
+    }
+}

--- a/tests/ui/proc-macro/inner-attr-file-mod.rs
+++ b/tests/ui/proc-macro/inner-attr-file-mod.rs
@@ -9,8 +9,7 @@ extern crate test_macros;
 
 #[deny(unused_attributes)]
 mod module_with_attrs;
-//~^ ERROR file modules in proc macro input are unstable
-//~| ERROR custom inner attributes are unstable
+//~^ ERROR custom inner attributes are unstable
 
 fn main() {}
 

--- a/tests/ui/proc-macro/inner-attr-file-mod.stderr
+++ b/tests/ui/proc-macro/inner-attr-file-mod.stderr
@@ -18,16 +18,6 @@ LL | #![print_attr]
    = help: add `#![feature(custom_inner_attributes)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: file modules in proc macro input are unstable
-  --> $DIR/inner-attr-file-mod.rs:11:1
-   |
-LL | mod module_with_attrs;
-   | ^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #54727 <https://github.com/rust-lang/rust/issues/54727> for more information
-   = help: add `#![feature(proc_macro_hygiene)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
 error[E0658]: custom inner attributes are unstable
   --> $DIR/inner-attr-file-mod.rs:11:1
    |
@@ -38,6 +28,6 @@ LL | mod module_with_attrs;
    = help: add `#![feature(custom_inner_attributes)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error: aborting due to 4 previous errors
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/proc-macro/module.rs
+++ b/tests/ui/proc-macro/module.rs
@@ -1,1 +1,4 @@
-//@ ignore-auxiliary (used by `./attributes-on-modules-fail.rs`)
+//@ ignore-auxiliary (used by `./attributes-on-modules-fail.rs` and `modules-in-input.rs`)
+
+// An item that can be referenced to verify the module has been properly loaded.
+pub const fn hello() {}

--- a/tests/ui/proc-macro/modules-in-input.rs
+++ b/tests/ui/proc-macro/modules-in-input.rs
@@ -1,0 +1,47 @@
+//@ check-pass
+//@ proc-macro: expect-modules.rs
+//@ reference: macro.invocation.attr.mod
+
+// Verifies how module items are represented in proc macro input.
+
+#[macro_use]
+extern crate expect_modules;
+
+#[expect_modules::expect_mod_item]
+mod module;
+
+fn check() {
+    module::hello();
+}
+
+#[expect_modules::expect_mods_attr]
+mod outer {
+    #[path = "../module.rs"]
+    mod attr_outlined;
+    mod attr_inline {}
+
+    fn check() {
+        attr_outlined::hello();
+    }
+}
+
+#[expect_modules::expect_mods_attr]
+fn foo() {
+    #[path = "module.rs"]
+    mod attr_outlined;
+    mod attr_inline {}
+    attr_outlined::hello();
+}
+
+#[derive(expect_modules::ExpectModsDerive)]
+struct Foo(
+    [u8; {
+        #[path = "module.rs"]
+        mod derive_outlined;
+        mod derive_inline {}
+        derive_outlined::hello();
+        0
+    }],
+);
+
+fn main() {}

--- a/tests/ui/proc-macro/unsafe-mod.rs
+++ b/tests/ui/proc-macro/unsafe-mod.rs
@@ -1,8 +1,6 @@
 //@ run-pass
 //@ proc-macro: macro-only-syntax.rs
 
-#![feature(proc_macro_hygiene)]
-
 extern crate macro_only_syntax;
 
 #[macro_only_syntax::expect_unsafe_mod]


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/157857)*
<!-- homu-ignore:end -->

# Stabilization report

## Summary

Allow `mod foo;` (an "outlined" module) in the input of attribute and derive (proc) macros.

Tracking:

- https://github.com/rust-lang/rust/issues/54727
    - The `proc_macro_hygiene` feature covers multiple related features. This PR proposes only a partial stabilization

Reference PRs:

- https://github.com/rust-lang/reference/pull/2284

### What is stabilized

> Describe each behavior being stabilized and give a short example of code that will now be accepted.

Currently, `mod foo;` (an outlined / non-inline) module is explicitly rejected in the input of derive and attribute (proc) macros.

This PR removes the check, allowing `mod foo;`.

The module is provided to the macro as it is written in the source code, that is in its "not-yet-loaded" form without a body.

```rust
// The following was previously rejected and will now compile.

#[my_proc_macro]
mod foo;

#[my_proc_macro]
fn bar() {
    #[path = "foo.rs"]
    mod foo;
}

#[derive(MyTrait)]
struct Foo([u8; {
    #[path = "foo.rs"]
    mod foo;
    0
}]);
```

### What isn't stabilized

> Describe any parts of the feature not being stabilized. Talk about what we might want to do later and what doors are being left open for that. If what we're not stabilizing might lead to surprises for users, talk about that in particular.

The remaining parts of `proc_macro_hygiene` are not stabilized (specifically, attribute macros in places where they aren't currently allowed).

## Design

### Reference

> What updates are needed to the Reference? Link to each PR. If the Reference is missing content needed for describing this feature, discuss that.

https://github.com/rust-lang/reference/pull/2284

### RFC history

> What RFCs have been accepted for this feature?

This feature has not been explicitly specified by any RFC.

- Ahead of the `proc_macro` stabilization, `#[my_macro] mod foo;` specifically was feature gated.
- As a side effect of https://github.com/rust-lang/rust/pull/52319, the (unstable) behavior changed:
    - Before that PR, `mod foo;` was actually provided to macros as the loaded `mod foo { ... }`
    - After that PR, `mod foo;` was provided to macros as-is.
- In 2019 (after the `proc_macro` stabilization, https://github.com/rust-lang/rust/pull/66078 made `mod foo` _**anywhere**_ in the input to derive or attribute proc macros unstable.
    - Before that PR, only proc macros directly applied to `mod foo;` were unstable.

### Answers to unresolved questions

> What questions were left unresolved by the RFC? How have they been answered? Link to any relevant lang decisions.

N/A

### Post-RFC changes

> What other user-visible changes have occurred since the RFC was accepted? Describe both changes that the lang team accepted (and link to those decisions) as well as changes that are being presented to the team for the first time in this stabilization report.

See the RFC history above.

### Key points

> What decisions have been most difficult and what behaviors to be stabilized have proved most contentious? Summarize the major arguments on all sides and link to earlier documents and discussions.

The main design decision is whether outlined modules should be passed to proc macros with or without their body.

Arguments in favor of "without their body":

- (To the best of my knowledge) the current compiler architecture makes "without their body" the natural choice.
    - To [quote](https://github.com/rust-lang/rust/issues/54727#issuecomment-4643290397) @petrochenkov, "it's clear that the current behavior of `#[my_macro] mod foo;` (the "not-yet-loaded" version of the module is passed to the macro) is natural to the current setup, stable and is not going to change".
- At least I would be somewhat surprised to see a macro (which is operating on the AST) able to see or affect code outside the current file. I would assume by default that they get as input exactly what I have written.
- Function-like procedural macros operate on arbitrary token trees. `mod foo;` in their input is not even recognized by the compiler and thus not expanded. Attribute and derive proc macros also receiving the unexpanded `mod foo;` in their input makes the two consistent.
- Other syntactic constructs, e.g. other macros like `inlcude!("foo.rs")`, are also not expanded before being passed to proc macros. Providing modules without their body would be consistent with that.
- Providing `mod foo;` to proc macros with its body would (as far as I know) be the only case where a proc macro would not get exactly what is written in the source code as its input.

Arguments in favor of "with their body":

- `#[my_macro] mod foo;` and `#[my_macro] mod foo {}` would have different behavior, which means that in the presence of proc macros, migrating an inline module to an outlined one would no longer be a purely syntactic change, but could affect the behavior of the proc macro.
- `#[my_macro] mod foo;` and `#![my_macro]` in `foo.rs` ([currently unstable](https://github.com/rust-lang/rust/issues/54726)) would have different behavior.
    - Other attributes already have different behaviors depending on whether they are applied as inner vs outer attributes. For example `#[cfg(false)]` on a module as an outer attribute means the corresponding file can be missig or have syntax errors, while using it as an inner attribute requires the file to be syntactically valid.
- Some macros may need access to (or change) the module body to function properly.

### Nightly extensions

> Are there extensions to this feature that remain unstable? How do we know that we are not accidentally committing to those?

No.

### Doors closed

> What doors does this stabilization close for later changes to the language? E.g., does this stabilization make any other RFCs, lang experiments, or known in-flight proposals more difficult or impossible to do later?

None.

If, in the future, there is a desire to make the module body of outlined modules available to proc macros, there are multiple ways to add that in a backward-compatible way (e.g. an explicit opt-in during the proc macro registration, or an API in the `proc_macro` crate).

## Feedback

### Call for testing

> Has a "call for testing" been done? If so, what feedback was received?

No.

### Nightly use

> Do any known nightly users use this feature? Counting instances of `#![feature(FEATURE_NAME)]` on GitHub with grep might be informative.

Searching Github [produces](https://github.com/search?q=%22feature%28proc_macro_hygiene%29%22+language%3ARust+&type=code) 4.4k files. Reviewing the first page of results shows many repositories that haven't been updated in multiple years, so it is unclear which part of the `proc_macro_hygiene` feature they actually use (other parts of the feature were previously stabilized).

## Implementation

### Major parts

> Summarize the major parts of the implementation and provide links into the code and to relevant PRs.

The restriction is currently implemented as an explicit visitor of the proc macro input, rejecting outlined modules. The visitor is removed in this PR.

### Coverage

> Summarize the test coverage of this feature.

See the test changes attached to this PR. The added tests explicitly verify that proc macros receive `mod foo;` as an input without its body, to ensure that the behavior doesn't unintentionally change in the future.

### Outstanding bugs

> What outstanding bugs involve this feature? List them. Should any block the stabilization? Discuss why or why not.

None.

### Outstanding FIXMEs

> What FIXMEs are still in the code for that feature and why is it OK to leave them there?

None.

### Tool changes

> What changes must be made to our other tools to support this feature. Has this work been done? Link to any relevant PRs and issues.

Generally none. The feature is a minor addition to the inputs that (proc) macros accept, and should not require special handling in any of the tools.

rust-analyzer has some existing limitations around handling modules transformed by proc macros (e.g. (on stable) auto-complete does not work if a proc macro transforms `mod foo {}` to `mod foo;`). It works fine for simple case where the the proc macro leaves the `mod foo;` mostly unmodified.

### Breaking changes

> If this stabilization represents a known breaking change, link to the crater report, the analysis of the crater report, and to all PRs we've made to ecosystem projects affected by this breakage. Discuss any limitations of what we're able to know about or to fix.

N/A: The feature is not expected to cause any breakage.

## Type system, opsem

N/A: This feature only affects the AST, not type checking.

## Common interactions

### Temporaries

> Does this feature introduce new expressions that can produce temporaries? What are the scopes of those temporaries?

No.

### Drop order

> Does this feature raise questions about the order in which we should drop values? Talk about the decisions made here and how they're consistent with our earlier decisions.

No.

### Pre-expansion / post-expansion

> Does this feature raise questions about what should be accepted pre-expansion (e.g. in code covered by `#[cfg(false)]`) versus what should be accepted post-expansion? What decisions were made about this?

No. (At least nothing that doesn't equally apply to existing stable proc macros).

### Edition hygiene

> If this feature is gated on an edition, how do we decide, in the context of the edition hygiene of tokens, whether to accept or reject code. E.g., what token do we use to decide?

N/A: Not gated on an edition.

### SemVer implications

> Does this feature create any new ways in which library authors must take care to prevent breaking downstreams when making minor-version releases? Describe these. Are these new hazards "major" or "minor" according to [RFC 1105](https://rust-lang.github.io/rfcs/1105-api-evolution.html)?

No.

### Exposing other features

> Are there any other unstable features whose behavior may be exposed by this feature in any way? What features present the highest risk of that?

No.

## History

> List issues and PRs that are important for understanding how we got here.

See the RFC History section above.

## Acknowledgments

> Summarize contributors to the feature by name for recognition and so that those people are notified about the stabilization. Does anyone who worked on this _not_ think it should be stabilized right now? We'd like to hear about that if so.

- @alexcrichton for the work towards the initial proc-macro expansion.
- @petrochenkov for significant work on hygiene and expansion since then.

## Open items

> List any known items that have not yet been completed and that should be before this is stabilized.

None.

---

r? @petrochenkov for an initial review (feel free to edit the stabilization report if you like)
