### PR TITLE
std: sys: xous: clamp condvar wait_timeout instead of truncating

### DIFF
--- a/library/std/src/sys/sync/condvar/xous.rs
+++ b/library/std/src/sys/sync/condvar/xous.rs
@@ -124,11 +124,9 @@ impl Condvar {
     }
 
     pub unsafe fn wait_timeout(&self, mutex: &Mutex, dur: Duration) -> bool {
-        let mut millis = dur.as_millis() as usize;
-        // Ensure we don't wait for 0 ms, which would cause us to wait forever
-        if millis == 0 {
-            millis = 1;
-        }
+        // A value of zero indicates an indefinite wait, so clamp the number of
+        // milliseconds to the representable range and avoid waiting forever.
+        let millis = usize::max(dur.as_millis().try_into().unwrap_or(usize::MAX), 1);
         self.wait_ms(mutex, millis)
     }
 }


### PR DESCRIPTION
dur.as_millis() (u128) was cast straight to usize, so on 32-bit xous any timeout over ~49 days truncated, and an exact multiple of 2^32 ms became 0 and then 1ms via the "don't wait forever" guard. Saturate the conversion, matching sys/sync/thread_parking/xous.rs.