### PR TITLE
std: sys: solid: clamp connect_timeout tv_sec instead of truncating

### DIFF
--- a/library/std/src/sys/net/connection/socket/solid.rs
+++ b/library/std/src/sys/net/connection/socket/solid.rs
@@ -142,8 +142,13 @@ impl Socket {
             return Err(io::Error::ZERO_TIMEOUT);
         }
 
-        let mut timeout =
-            netc::timeval { tv_sec: timeout.as_secs() as _, tv_usec: timeout.subsec_micros() as _ };
+        let secs = if timeout.as_secs() > netc::c_long::MAX as u64 {
+            netc::c_long::MAX
+        } else {
+            timeout.as_secs() as netc::c_long
+        };
+
+        let mut timeout = netc::timeval { tv_sec: secs, tv_usec: timeout.subsec_micros() as _ };
         if timeout.tv_sec == 0 && timeout.tv_usec == 0 {
             timeout.tv_usec = 1;
         }


### PR DESCRIPTION
connect_timeout cast timeout.as_secs() (u64) straight to tv_sec, which is c_long (i32 on 32-bit Solid), so timeouts over ~68 years truncated to a wrong or negative value. Clamp to c_long::MAX, matching set_timeout in the same file.