### PR TITLE
`suspicious_double_ref_op`: report unadjusted return type

### DIFF
--- a/compiler/rustc_lint/src/noop_method_call.rs
+++ b/compiler/rustc_lint/src/noop_method_call.rs
@@ -145,6 +145,8 @@ impl<'tcx> LateLintPass<'tcx> for NoopMethodCall {
                 },
             );
         } else {
+            // Report the method call's return type before adjustments required by its parent.
+            let unadjusted_expr_ty = cx.typeck_results().expr_ty(expr);
             match name {
                 // If `type_of(x) == T` and `x.borrow()` is used to get `&T`,
                 // then that should be allowed
@@ -152,12 +154,12 @@ impl<'tcx> LateLintPass<'tcx> for NoopMethodCall {
                 sym::noop_method_clone => cx.emit_span_lint(
                     SUSPICIOUS_DOUBLE_REF_OP,
                     span,
-                    SuspiciousDoubleRefCloneDiag { ty: expr_ty },
+                    SuspiciousDoubleRefCloneDiag { ty: unadjusted_expr_ty },
                 ),
                 sym::noop_method_deref => cx.emit_span_lint(
                     SUSPICIOUS_DOUBLE_REF_OP,
                     span,
-                    SuspiciousDoubleRefDerefDiag { ty: expr_ty },
+                    SuspiciousDoubleRefDerefDiag { ty: unadjusted_expr_ty },
                 ),
                 _ => return,
             }

--- a/tests/ui/lint/suspicious-double-ref-op.rs
+++ b/tests/ui/lint/suspicious-double-ref-op.rs
@@ -1,6 +1,7 @@
 #![deny(suspicious_double_ref_op, noop_method_call)]
 
 use std::borrow::Borrow;
+use std::io::Write;
 use std::ops::Deref;
 
 struct PlainType<T>(T);
@@ -25,6 +26,15 @@ pub static STRS: LazyLock<&str> = LazyLock::new(|| "First");
 fn rust_clippy_issue_9272() {
     let str = STRS.clone();
     println!("{str}")
+}
+
+// https://github.com/rust-lang/rust/issues/146227
+fn method_receiver_adjustment(file: &std::fs::File, double_ref: &&std::fs::File) {
+    let _ = file.clone().write(&[]);
+    //~^ ERROR using `.clone()` on a double reference, which returns `&File`
+
+    let _ = double_ref.deref().write(&[]);
+    //~^ ERROR using `.deref()` on a double reference, which returns `&File`
 }
 
 fn main() {

--- a/tests/ui/lint/suspicious-double-ref-op.stderr
+++ b/tests/ui/lint/suspicious-double-ref-op.stderr
@@ -10,13 +10,13 @@ note: the lint level is defined here
 LL | #![deny(suspicious_double_ref_op, noop_method_call)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: using `.clone()` on a double reference, which returns `&mut &File` instead of cloning the inner type
+error: using `.clone()` on a double reference, which returns `&File` instead of cloning the inner type
   --> $DIR/suspicious-double-ref-op.rs:33:17
    |
 LL |     let _ = file.clone().write(&[]);
    |                 ^^^^^^^^
 
-error: using `.deref()` on a double reference, which returns `&mut &File` instead of dereferencing the inner type
+error: using `.deref()` on a double reference, which returns `&File` instead of dereferencing the inner type
   --> $DIR/suspicious-double-ref-op.rs:36:23
    |
 LL |     let _ = double_ref.deref().write(&[]);

--- a/tests/ui/lint/suspicious-double-ref-op.stderr
+++ b/tests/ui/lint/suspicious-double-ref-op.stderr
@@ -1,5 +1,5 @@
 error: using `.clone()` on a double reference, which returns `&Vec<i32>` instead of cloning the inner type
-  --> $DIR/suspicious-double-ref-op.rs:14:23
+  --> $DIR/suspicious-double-ref-op.rs:15:23
    |
 LL |     let z: &Vec<_> = y.clone();
    |                       ^^^^^^^^
@@ -10,23 +10,35 @@ note: the lint level is defined here
 LL | #![deny(suspicious_double_ref_op, noop_method_call)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^
 
+error: using `.clone()` on a double reference, which returns `&mut &File` instead of cloning the inner type
+  --> $DIR/suspicious-double-ref-op.rs:33:17
+   |
+LL |     let _ = file.clone().write(&[]);
+   |                 ^^^^^^^^
+
+error: using `.deref()` on a double reference, which returns `&mut &File` instead of dereferencing the inner type
+  --> $DIR/suspicious-double-ref-op.rs:36:23
+   |
+LL |     let _ = double_ref.deref().write(&[]);
+   |                       ^^^^^^^^
+
 error: using `.clone()` on a double reference, which returns `&CloneType<u32>` instead of cloning the inner type
-  --> $DIR/suspicious-double-ref-op.rs:32:63
+  --> $DIR/suspicious-double-ref-op.rs:42:63
    |
 LL |     let clone_type_ref_clone: &CloneType<u32> = clone_type_ref.clone();
    |                                                               ^^^^^^^^
 
 error: using `.deref()` on a double reference, which returns `&PlainType<u32>` instead of dereferencing the inner type
-  --> $DIR/suspicious-double-ref-op.rs:36:63
+  --> $DIR/suspicious-double-ref-op.rs:46:63
    |
 LL |     let non_deref_type_deref: &PlainType<u32> = non_deref_type.deref();
    |                                                               ^^^^^^^^
 
 error: using `.clone()` on a double reference, which returns `&str` instead of cloning the inner type
-  --> $DIR/suspicious-double-ref-op.rs:40:44
+  --> $DIR/suspicious-double-ref-op.rs:50:44
    |
 LL |     let _v: Vec<&str> = xs.iter().map(|x| x.clone()).collect(); // could use `*x` instead
    |                                            ^^^^^^^^
 
-error: aborting due to 4 previous errors
+error: aborting due to 6 previous errors
 


### PR DESCRIPTION
`suspicious_double_ref_op` uses the adjusted expression type to distinguish a no-op call from a double-reference operation. When the result is used as another method's receiver, that type can include the parent method's receiver adjustment.

For example, `file.clone().write(&[])` reports that `clone` returns `&mut &File`, even though it returns `&File`.

This PR continues to use the adjusted type for lint classification, but now uses the method call's unadjusted type in the diagnostic. The same issue affects `.deref()`, so the regression test covers both operations.

Fixes rust-lang/rust#146227