### PR TITLE
mips: set llvm_args -mno-check-zero-division for all mips targets

### DIFF
--- a/compiler/rustc_target/src/spec/targets/mips64_openwrt_linux_musl.rs
+++ b/compiler/rustc_target/src/spec/targets/mips64_openwrt_linux_musl.rs
@@ -2,7 +2,7 @@
 
 use rustc_abi::Endian;
 
-use crate::spec::{Arch, CfgAbi, LlvmAbi, Target, TargetMetadata, TargetOptions, base};
+use crate::spec::{Arch, CfgAbi, LlvmAbi, Target, TargetMetadata, TargetOptions, base, cvs};
 
 pub(crate) fn target() -> Target {
     let mut base = base::linux_musl::opts();
@@ -28,6 +28,7 @@ pub(crate) fn target() -> Target {
             endian: Endian::Big,
             mcount: "_mcount".into(),
             llvm_abiname: LlvmAbi::N64,
+            llvm_args: cvs!["-mno-check-zero-division"],
             ..base
         },
     }

--- a/compiler/rustc_target/src/spec/targets/mips64_unknown_linux_gnuabi64.rs
+++ b/compiler/rustc_target/src/spec/targets/mips64_unknown_linux_gnuabi64.rs
@@ -1,6 +1,6 @@
 use rustc_abi::Endian;
 
-use crate::spec::{Arch, CfgAbi, LlvmAbi, Target, TargetMetadata, TargetOptions, base};
+use crate::spec::{Arch, CfgAbi, LlvmAbi, Target, TargetMetadata, TargetOptions, base, cvs};
 
 pub(crate) fn target() -> Target {
     Target {
@@ -23,6 +23,7 @@ pub(crate) fn target() -> Target {
             max_atomic_width: Some(64),
             mcount: "_mcount".into(),
             llvm_abiname: LlvmAbi::N64,
+            llvm_args: cvs!["-mno-check-zero-division"],
 
             ..base::linux_gnu::opts()
         },

--- a/compiler/rustc_target/src/spec/targets/mips64_unknown_linux_muslabi64.rs
+++ b/compiler/rustc_target/src/spec/targets/mips64_unknown_linux_muslabi64.rs
@@ -1,6 +1,6 @@
 use rustc_abi::Endian;
 
-use crate::spec::{Arch, CfgAbi, LlvmAbi, Target, TargetMetadata, TargetOptions, base};
+use crate::spec::{Arch, CfgAbi, LlvmAbi, Target, TargetMetadata, TargetOptions, base, cvs};
 
 pub(crate) fn target() -> Target {
     let mut base = base::linux_musl::opts();
@@ -24,6 +24,7 @@ pub(crate) fn target() -> Target {
             endian: Endian::Big,
             mcount: "_mcount".into(),
             llvm_abiname: LlvmAbi::N64,
+            llvm_args: cvs!["-mno-check-zero-division"],
             ..base
         },
     }

--- a/compiler/rustc_target/src/spec/targets/mips64el_unknown_linux_gnuabi64.rs
+++ b/compiler/rustc_target/src/spec/targets/mips64el_unknown_linux_gnuabi64.rs
@@ -1,4 +1,4 @@
-use crate::spec::{Arch, CfgAbi, LlvmAbi, Target, TargetMetadata, TargetOptions, base};
+use crate::spec::{Arch, CfgAbi, LlvmAbi, Target, TargetMetadata, TargetOptions, base, cvs};
 
 pub(crate) fn target() -> Target {
     Target {
@@ -20,6 +20,7 @@ pub(crate) fn target() -> Target {
             max_atomic_width: Some(64),
             mcount: "_mcount".into(),
             llvm_abiname: LlvmAbi::N64,
+            llvm_args: cvs!["-mno-check-zero-division"],
 
             ..base::linux_gnu::opts()
         },

--- a/compiler/rustc_target/src/spec/targets/mips64el_unknown_linux_muslabi64.rs
+++ b/compiler/rustc_target/src/spec/targets/mips64el_unknown_linux_muslabi64.rs
@@ -1,4 +1,4 @@
-use crate::spec::{Arch, CfgAbi, LlvmAbi, Target, TargetMetadata, TargetOptions, base};
+use crate::spec::{Arch, CfgAbi, LlvmAbi, Target, TargetMetadata, TargetOptions, base, cvs};
 
 pub(crate) fn target() -> Target {
     let mut base = base::linux_musl::opts();
@@ -21,6 +21,7 @@ pub(crate) fn target() -> Target {
             cfg_abi: CfgAbi::Abi64,
             mcount: "_mcount".into(),
             llvm_abiname: LlvmAbi::N64,
+            llvm_args: cvs!["-mno-check-zero-division"],
             ..base
         },
     }

--- a/compiler/rustc_target/src/spec/targets/mips_mti_none_elf.rs
+++ b/compiler/rustc_target/src/spec/targets/mips_mti_none_elf.rs
@@ -2,7 +2,7 @@ use rustc_abi::Endian;
 
 use crate::spec::{
     Arch, Cc, LinkerFlavor, Lld, LlvmAbi, PanicStrategy, RelocModel, Target, TargetMetadata,
-    TargetOptions,
+    TargetOptions, cvs,
 };
 
 pub(crate) fn target() -> Target {
@@ -26,6 +26,7 @@ pub(crate) fn target() -> Target {
             cpu: "mips32r2".into(),
 
             llvm_abiname: LlvmAbi::O32,
+            llvm_args: cvs!["-mno-check-zero-division"],
             max_atomic_width: Some(32),
 
             features: "+mips32r2,+soft-float,+noabicalls".into(),

--- a/compiler/rustc_target/src/spec/targets/mips_unknown_linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/targets/mips_unknown_linux_gnu.rs
@@ -1,6 +1,6 @@
 use rustc_abi::Endian;
 
-use crate::spec::{Arch, LlvmAbi, Target, TargetMetadata, TargetOptions, base};
+use crate::spec::{Arch, LlvmAbi, Target, TargetMetadata, TargetOptions, base, cvs};
 
 pub(crate) fn target() -> Target {
     Target {
@@ -19,6 +19,7 @@ pub(crate) fn target() -> Target {
             cpu: "mips32r2".into(),
             features: "+mips32r2,+fpxx,+nooddspreg".into(),
             llvm_abiname: LlvmAbi::O32,
+            llvm_args: cvs!["-mno-check-zero-division"],
             max_atomic_width: Some(32),
             mcount: "_mcount".into(),
 

--- a/compiler/rustc_target/src/spec/targets/mips_unknown_linux_musl.rs
+++ b/compiler/rustc_target/src/spec/targets/mips_unknown_linux_musl.rs
@@ -1,6 +1,6 @@
 use rustc_abi::Endian;
 
-use crate::spec::{Arch, LlvmAbi, Target, TargetMetadata, TargetOptions, base};
+use crate::spec::{Arch, LlvmAbi, Target, TargetMetadata, TargetOptions, base, cvs};
 
 pub(crate) fn target() -> Target {
     let mut base = base::linux_musl::opts();
@@ -21,6 +21,7 @@ pub(crate) fn target() -> Target {
         options: TargetOptions {
             endian: Endian::Big,
             llvm_abiname: LlvmAbi::O32,
+            llvm_args: cvs!["-mno-check-zero-division"],
             mcount: "_mcount".into(),
             ..base
         },

--- a/compiler/rustc_target/src/spec/targets/mips_unknown_linux_uclibc.rs
+++ b/compiler/rustc_target/src/spec/targets/mips_unknown_linux_uclibc.rs
@@ -1,6 +1,6 @@
 use rustc_abi::Endian;
 
-use crate::spec::{Arch, LlvmAbi, Target, TargetMetadata, TargetOptions, base};
+use crate::spec::{Arch, LlvmAbi, Target, TargetMetadata, TargetOptions, base, cvs};
 
 pub(crate) fn target() -> Target {
     Target {
@@ -19,6 +19,7 @@ pub(crate) fn target() -> Target {
             cpu: "mips32r2".into(),
             features: "+mips32r2,+soft-float".into(),
             llvm_abiname: LlvmAbi::O32,
+            llvm_args: cvs!["-mno-check-zero-division"],
             max_atomic_width: Some(32),
             mcount: "_mcount".into(),
 

--- a/compiler/rustc_target/src/spec/targets/mipsel_mti_none_elf.rs
+++ b/compiler/rustc_target/src/spec/targets/mipsel_mti_none_elf.rs
@@ -2,7 +2,7 @@ use rustc_abi::Endian;
 
 use crate::spec::{
     Arch, Cc, LinkerFlavor, Lld, LlvmAbi, PanicStrategy, RelocModel, Target, TargetMetadata,
-    TargetOptions,
+    TargetOptions, cvs,
 };
 
 pub(crate) fn target() -> Target {
@@ -26,6 +26,7 @@ pub(crate) fn target() -> Target {
             cpu: "mips32r2".into(),
 
             llvm_abiname: LlvmAbi::O32,
+            llvm_args: cvs!["-mno-check-zero-division"],
             max_atomic_width: Some(32),
 
             features: "+mips32r2,+soft-float,+noabicalls".into(),

--- a/compiler/rustc_target/src/spec/targets/mipsel_unknown_linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/targets/mipsel_unknown_linux_gnu.rs
@@ -1,4 +1,4 @@
-use crate::spec::{Arch, LlvmAbi, Target, TargetMetadata, TargetOptions, base};
+use crate::spec::{Arch, LlvmAbi, Target, TargetMetadata, TargetOptions, base, cvs};
 
 pub(crate) fn target() -> Target {
     Target {
@@ -17,6 +17,7 @@ pub(crate) fn target() -> Target {
             cpu: "mips32r2".into(),
             features: "+mips32r2,+fpxx,+nooddspreg".into(),
             llvm_abiname: LlvmAbi::O32,
+            llvm_args: cvs!["-mno-check-zero-division"],
             max_atomic_width: Some(32),
             mcount: "_mcount".into(),
 

--- a/compiler/rustc_target/src/spec/targets/mipsel_unknown_linux_musl.rs
+++ b/compiler/rustc_target/src/spec/targets/mipsel_unknown_linux_musl.rs
@@ -1,4 +1,4 @@
-use crate::spec::{Arch, LlvmAbi, Target, TargetMetadata, TargetOptions, base};
+use crate::spec::{Arch, LlvmAbi, Target, TargetMetadata, TargetOptions, base, cvs};
 
 pub(crate) fn target() -> Target {
     let mut base = base::linux_musl::opts();
@@ -16,6 +16,11 @@ pub(crate) fn target() -> Target {
         pointer_width: 32,
         data_layout: "e-m:m-p:32:32-i8:8:32-i16:16:32-i64:64-n32-S64".into(),
         arch: Arch::Mips,
-        options: TargetOptions { llvm_abiname: LlvmAbi::O32, mcount: "_mcount".into(), ..base },
+        options: TargetOptions {
+            llvm_abiname: LlvmAbi::O32,
+            llvm_args: cvs!["-mno-check-zero-division"],
+            mcount: "_mcount".into(),
+            ..base
+        },
     }
 }

--- a/compiler/rustc_target/src/spec/targets/mipsel_unknown_linux_uclibc.rs
+++ b/compiler/rustc_target/src/spec/targets/mipsel_unknown_linux_uclibc.rs
@@ -1,4 +1,4 @@
-use crate::spec::{Arch, LlvmAbi, Target, TargetMetadata, TargetOptions, base};
+use crate::spec::{Arch, LlvmAbi, Target, TargetMetadata, TargetOptions, base, cvs};
 
 pub(crate) fn target() -> Target {
     Target {
@@ -17,6 +17,7 @@ pub(crate) fn target() -> Target {
             cpu: "mips32r2".into(),
             features: "+mips32r2,+soft-float".into(),
             llvm_abiname: LlvmAbi::O32,
+            llvm_args: cvs!["-mno-check-zero-division"],
             max_atomic_width: Some(32),
             mcount: "_mcount".into(),
 

--- a/compiler/rustc_target/src/spec/targets/mipsel_unknown_netbsd.rs
+++ b/compiler/rustc_target/src/spec/targets/mipsel_unknown_netbsd.rs
@@ -1,6 +1,6 @@
 use rustc_abi::Endian;
 
-use crate::spec::{Arch, LlvmAbi, Target, TargetMetadata, TargetOptions, base};
+use crate::spec::{Arch, LlvmAbi, Target, TargetMetadata, TargetOptions, base, cvs};
 
 pub(crate) fn target() -> Target {
     let mut base = base::netbsd::opts();
@@ -21,6 +21,7 @@ pub(crate) fn target() -> Target {
         options: TargetOptions {
             features: "+soft-float".into(),
             llvm_abiname: LlvmAbi::O32,
+            llvm_args: cvs!["-mno-check-zero-division"],
             mcount: "__mcount".into(),
             endian: Endian::Little,
             ..base

--- a/compiler/rustc_target/src/spec/targets/mipsel_unknown_none.rs
+++ b/compiler/rustc_target/src/spec/targets/mipsel_unknown_none.rs
@@ -4,7 +4,7 @@
 
 use crate::spec::{
     Arch, Cc, LinkerFlavor, Lld, LlvmAbi, PanicStrategy, RelocModel, Target, TargetMetadata,
-    TargetOptions,
+    TargetOptions, cvs,
 };
 
 pub(crate) fn target() -> Target {
@@ -25,6 +25,7 @@ pub(crate) fn target() -> Target {
             cpu: "mips32r2".into(),
             features: "+mips32r2,+soft-float,+noabicalls".into(),
             llvm_abiname: LlvmAbi::O32,
+            llvm_args: cvs!["-mno-check-zero-division"],
             max_atomic_width: Some(32),
             linker: Some("rust-lld".into()),
             panic_strategy: PanicStrategy::Abort,

--- a/compiler/rustc_target/src/spec/targets/mipsisa32r6_unknown_linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/targets/mipsisa32r6_unknown_linux_gnu.rs
@@ -1,6 +1,6 @@
 use rustc_abi::Endian;
 
-use crate::spec::{Arch, LlvmAbi, Target, TargetMetadata, TargetOptions, base};
+use crate::spec::{Arch, LlvmAbi, Target, TargetMetadata, TargetOptions, base, cvs};
 
 pub(crate) fn target() -> Target {
     Target {
@@ -19,6 +19,7 @@ pub(crate) fn target() -> Target {
             cpu: "mips32r6".into(),
             features: "+mips32r6".into(),
             llvm_abiname: LlvmAbi::O32,
+            llvm_args: cvs!["-mno-check-zero-division"],
             max_atomic_width: Some(32),
             mcount: "_mcount".into(),
 

--- a/compiler/rustc_target/src/spec/targets/mipsisa32r6el_unknown_linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/targets/mipsisa32r6el_unknown_linux_gnu.rs
@@ -1,4 +1,4 @@
-use crate::spec::{Arch, LlvmAbi, Target, TargetMetadata, TargetOptions, base};
+use crate::spec::{Arch, LlvmAbi, Target, TargetMetadata, TargetOptions, base, cvs};
 
 pub(crate) fn target() -> Target {
     Target {
@@ -17,6 +17,7 @@ pub(crate) fn target() -> Target {
             cpu: "mips32r6".into(),
             features: "+mips32r6".into(),
             llvm_abiname: LlvmAbi::O32,
+            llvm_args: cvs!["-mno-check-zero-division"],
             max_atomic_width: Some(32),
             mcount: "_mcount".into(),
 

--- a/compiler/rustc_target/src/spec/targets/mipsisa64r6_unknown_linux_gnuabi64.rs
+++ b/compiler/rustc_target/src/spec/targets/mipsisa64r6_unknown_linux_gnuabi64.rs
@@ -1,6 +1,6 @@
 use rustc_abi::Endian;
 
-use crate::spec::{Arch, CfgAbi, LlvmAbi, Target, TargetMetadata, TargetOptions, base};
+use crate::spec::{Arch, CfgAbi, LlvmAbi, Target, TargetMetadata, TargetOptions, base, cvs};
 
 pub(crate) fn target() -> Target {
     Target {
@@ -23,6 +23,7 @@ pub(crate) fn target() -> Target {
             max_atomic_width: Some(64),
             mcount: "_mcount".into(),
             llvm_abiname: LlvmAbi::N64,
+            llvm_args: cvs!["-mno-check-zero-division"],
 
             ..base::linux_gnu::opts()
         },

--- a/compiler/rustc_target/src/spec/targets/mipsisa64r6el_unknown_linux_gnuabi64.rs
+++ b/compiler/rustc_target/src/spec/targets/mipsisa64r6el_unknown_linux_gnuabi64.rs
@@ -1,4 +1,4 @@
-use crate::spec::{Arch, CfgAbi, LlvmAbi, Target, TargetMetadata, TargetOptions, base};
+use crate::spec::{Arch, CfgAbi, LlvmAbi, Target, TargetMetadata, TargetOptions, base, cvs};
 
 pub(crate) fn target() -> Target {
     Target {
@@ -20,6 +20,7 @@ pub(crate) fn target() -> Target {
             max_atomic_width: Some(64),
             mcount: "_mcount".into(),
             llvm_abiname: LlvmAbi::N64,
+            llvm_args: cvs!["-mno-check-zero-division"],
 
             ..base::linux_gnu::opts()
         },

--- a/tests/assembly-llvm/mips-div-no-trap.rs
+++ b/tests/assembly-llvm/mips-div-no-trap.rs
@@ -1,0 +1,124 @@
+// Test that there's no conditional trap for zero divisor for all mips
+// targets by default.  Division by zero is defined as panic so the trap is
+// redundant.
+//
+//@ add-minicore
+//@ assembly-output: emit-asm
+//
+// See https://github.com/llvm/llvm-project/pull/204386.
+//@ compile-flags: -Copt-level=3
+//
+//@ revisions: mips64el-unknown-linux-gnuabi64
+//@[mips64el-unknown-linux-gnuabi64] compile-flags: --target=mips64el-unknown-linux-gnuabi64
+//@[mips64el-unknown-linux-gnuabi64] needs-llvm-components: mips
+//@[mips64el-unknown-linux-gnuabi64] filecheck-flags: --check-prefix NOTRAP
+//@ revisions: mips64el-unknown-linux-muslabi64
+//@[mips64el-unknown-linux-muslabi64] compile-flags: --target=mips64el-unknown-linux-muslabi64
+//@[mips64el-unknown-linux-muslabi64] needs-llvm-components: mips
+//@[mips64el-unknown-linux-muslabi64] filecheck-flags: --check-prefix NOTRAP
+//@ revisions: mips64-openwrt-linux-musl
+//@[mips64-openwrt-linux-musl] compile-flags: --target=mips64-openwrt-linux-musl
+//@[mips64-openwrt-linux-musl] needs-llvm-components: mips
+//@[mips64-openwrt-linux-musl] filecheck-flags: --check-prefix NOTRAP
+//@ revisions: mips64-unknown-linux-gnuabi64
+//@[mips64-unknown-linux-gnuabi64] compile-flags: --target=mips64-unknown-linux-gnuabi64
+//@[mips64-unknown-linux-gnuabi64] needs-llvm-components: mips
+//@[mips64-unknown-linux-gnuabi64] filecheck-flags: --check-prefix NOTRAP
+//@ revisions: mips64-unknown-linux-muslabi64
+//@[mips64-unknown-linux-muslabi64] compile-flags: --target=mips64-unknown-linux-muslabi64
+//@[mips64-unknown-linux-muslabi64] needs-llvm-components: mips
+//@[mips64-unknown-linux-muslabi64] filecheck-flags: --check-prefix NOTRAP
+//@ revisions: mipsel-mti-none-elf
+//@[mipsel-mti-none-elf] compile-flags: --target=mipsel-mti-none-elf
+//@[mipsel-mti-none-elf] needs-llvm-components: mips
+//@[mipsel-mti-none-elf] filecheck-flags: --check-prefix NOTRAP
+//@ revisions: mipsel-sony-psp
+//@[mipsel-sony-psp] compile-flags: --target=mipsel-sony-psp
+//@[mipsel-sony-psp] needs-llvm-components: mips
+//@[mipsel-sony-psp] filecheck-flags: --check-prefix NOTRAP
+//@ revisions: mipsel-sony-psx
+//@[mipsel-sony-psx] compile-flags: --target=mipsel-sony-psx
+//@[mipsel-sony-psx] needs-llvm-components: mips
+//@[mipsel-sony-psx] filecheck-flags: --check-prefix NOTRAP
+//@ revisions: mipsel-unknown-linux-gnu
+//@[mipsel-unknown-linux-gnu] compile-flags: --target=mipsel-unknown-linux-gnu
+//@[mipsel-unknown-linux-gnu] needs-llvm-components: mips
+//@[mipsel-unknown-linux-gnu] filecheck-flags: --check-prefix NOTRAP
+//@ revisions: mipsel-unknown-linux-musl
+//@[mipsel-unknown-linux-musl] compile-flags: --target=mipsel-unknown-linux-musl
+//@[mipsel-unknown-linux-musl] needs-llvm-components: mips
+//@[mipsel-unknown-linux-musl] filecheck-flags: --check-prefix NOTRAP
+//@ revisions: mipsel-unknown-linux-uclibc
+//@[mipsel-unknown-linux-uclibc] compile-flags: --target=mipsel-unknown-linux-uclibc
+//@[mipsel-unknown-linux-uclibc] needs-llvm-components: mips
+//@[mipsel-unknown-linux-uclibc] filecheck-flags: --check-prefix NOTRAP
+//@ revisions: mipsel-unknown-netbsd
+//@[mipsel-unknown-netbsd] compile-flags: --target=mipsel-unknown-netbsd
+//@[mipsel-unknown-netbsd] needs-llvm-components: mips
+//@[mipsel-unknown-netbsd] filecheck-flags: --check-prefix NOTRAP
+//@ revisions: mipsel-unknown-none
+//@[mipsel-unknown-none] compile-flags: --target=mipsel-unknown-none
+//@[mipsel-unknown-none] needs-llvm-components: mips
+//@[mipsel-unknown-none] filecheck-flags: --check-prefix NOTRAP
+//@ revisions: mipsisa32r6el-unknown-linux-gnu
+//@[mipsisa32r6el-unknown-linux-gnu] compile-flags: --target=mipsisa32r6el-unknown-linux-gnu
+//@[mipsisa32r6el-unknown-linux-gnu] needs-llvm-components: mips
+//@[mipsisa32r6el-unknown-linux-gnu] filecheck-flags: --check-prefix NOTRAP
+//@ revisions: mipsisa32r6-unknown-linux-gnu
+//@[mipsisa32r6-unknown-linux-gnu] compile-flags: --target=mipsisa32r6-unknown-linux-gnu
+//@[mipsisa32r6-unknown-linux-gnu] needs-llvm-components: mips
+//@[mipsisa32r6-unknown-linux-gnu] filecheck-flags: --check-prefix NOTRAP
+//@ revisions: mipsisa64r6el-unknown-linux-gnuabi64
+//@[mipsisa64r6el-unknown-linux-gnuabi64] compile-flags: --target=mipsisa64r6el-unknown-linux-gnuabi64
+//@[mipsisa64r6el-unknown-linux-gnuabi64] needs-llvm-components: mips
+//@[mipsisa64r6el-unknown-linux-gnuabi64] filecheck-flags: --check-prefix NOTRAP
+//@ revisions: mipsisa64r6-unknown-linux-gnuabi64
+//@[mipsisa64r6-unknown-linux-gnuabi64] compile-flags: --target=mipsisa64r6-unknown-linux-gnuabi64
+//@[mipsisa64r6-unknown-linux-gnuabi64] needs-llvm-components: mips
+//@[mipsisa64r6-unknown-linux-gnuabi64] filecheck-flags: --check-prefix NOTRAP
+//@ revisions: mips-mti-none-elf
+//@[mips-mti-none-elf] compile-flags: --target=mips-mti-none-elf
+//@[mips-mti-none-elf] needs-llvm-components: mips
+//@[mips-mti-none-elf] filecheck-flags: --check-prefix NOTRAP
+//@ revisions: mips-unknown-linux-gnu
+//@[mips-unknown-linux-gnu] compile-flags: --target=mips-unknown-linux-gnu
+//@[mips-unknown-linux-gnu] needs-llvm-components: mips
+//@[mips-unknown-linux-gnu] filecheck-flags: --check-prefix NOTRAP
+//@ revisions: mips-unknown-linux-musl
+//@[mips-unknown-linux-musl] compile-flags: --target=mips-unknown-linux-musl
+//@[mips-unknown-linux-musl] needs-llvm-components: mips
+//@[mips-unknown-linux-musl] filecheck-flags: --check-prefix NOTRAP
+//@ revisions: mips-unknown-linux-uclibc
+//@[mips-unknown-linux-uclibc] compile-flags: --target=mips-unknown-linux-uclibc
+//@[mips-unknown-linux-uclibc] needs-llvm-components: mips
+//@[mips-unknown-linux-uclibc] filecheck-flags: --check-prefix NOTRAP
+//
+//@ revisions: TRAP
+//@[TRAP] compile-flags: --target=mips64el-unknown-linux-gnuabi64 -C llvm-args=-mno-check-zero-division=0
+//@[TRAP] needs-llvm-components: mips
+
+#![crate_type = "lib"]
+#![feature(no_core, intrinsics)]
+#![no_core]
+
+extern crate minicore;
+
+#[rustc_intrinsic]
+pub unsafe fn unchecked_div<T>(x: T, y: T) -> T;
+
+#[rustc_intrinsic]
+pub fn abort() -> !;
+
+// NOTRAP-NOT: teq
+// TRAP: teq
+#[no_mangle]
+pub fn div_i32(a: i32, b: i32) -> i32 {
+    match a {
+        0 => abort(),
+        -1 => match b {
+            -2147483648 => abort(),
+            _ => unsafe { unchecked_div(a, b) },
+        },
+        _ => unsafe { unchecked_div(a, b) },
+    }
+}


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/157873)*
<!-- homu-ignore:end -->

In rust interger divide by zero is defined to panic, thus the inserted conditional trap should never trigger as the program should have panicked if the divisor is zero.

So disable the insertion of the redundant conditional trap.