### PR TITLE
bootstrap: fix inverted success check in PowerShell download fallback

### DIFF
--- a/src/bootstrap/src/core/download.rs
+++ b/src/bootstrap/src/core/download.rs
@@ -1093,7 +1093,7 @@ fn download_http_with_retries(
                     ),
                 ]).run_capture_stdout(exec_ctx);
 
-                if powershell.is_failure() {
+                if powershell.is_success() {
                     return;
                 }
 


### PR DESCRIPTION
When curl fails on Windows and bootstrap falls back to PowerShell for downloads, the success/failure check is inverted: the code returns early on failure (`is_failure()`) and prints "spurious failure, trying again" on success, then exits with code 1 after three successful downloads.

This was introduced in rust-lang/rust#141909 during the `ExecutionContext` refactoring. The original code used `self.try_run(...)` which returned `bool` (true = success). The refactoring changed the return type to `CommandOutput` but used `is_failure()` for the early-return check, inverting the logic.

The fix changes the check from `is_failure()` to `is_success()`, restoring the original behavior: return early when the download succeeds, retry when it fails.