### PR TITLE
Avoid `&raw` call recovery inside nested delimiters

### DIFF
--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -1278,10 +1278,14 @@ impl<'a> Parser<'a> {
             None
         };
         let open_paren = self.token.span;
+        let call_depth = self.token_cursor.stack.len();
 
         let seq = match self.parse_expr_paren_seq() {
             Ok(args) => Ok(self.mk_expr(lo.to(self.prev_token.span), self.mk_call(fun, args))),
-            Err(err) if self.is_expected_raw_ref_mut() => {
+            Err(err)
+                if self.is_expected_raw_ref_mut()
+                    && self.token_cursor.stack.len() == call_depth =>
+            {
                 let guar = err.emit();
                 // Preserve the call expression so later passes can still diagnose the callee,
                 // while treating the malformed `&raw <expr>` argument as an error expression.
@@ -1299,9 +1303,8 @@ impl<'a> Parser<'a> {
     fn recover_raw_ref_call_args(&mut self, guar: ErrorGuaranteed) -> ThinVec<Box<Expr>> {
         let err_span = self.prev_token.span.to(self.token.span);
         let mut args = thin_vec![self.mk_expr_err(err_span, guar)];
-        while self.token != token::Eof && self.token != token::CloseParen {
-            if self.eat(exp!(Comma)) && self.token != token::Eof && self.token != token::CloseParen
-            {
+        while !self.token.kind.is_close_delim_or_eof() {
+            if self.eat(exp!(Comma)) && !self.token.kind.is_close_delim_or_eof() {
                 args.push(self.mk_expr_err(self.prev_token.span.shrink_to_hi(), guar));
             } else {
                 self.parse_token_tree();

--- a/tests/ui/parser/recover/raw-no-const-mut-nested-call-arg.rs
+++ b/tests/ui/parser/recover/raw-no-const-mut-nested-call-arg.rs
@@ -1,0 +1,6 @@
+// Regression test for https://github.com/rust-lang/rust/issues/157853.
+
+fn main() {
+    Test([&raw 2])
+    //~^ ERROR expected one of
+}

--- a/tests/ui/parser/recover/raw-no-const-mut-nested-call-arg.stderr
+++ b/tests/ui/parser/recover/raw-no-const-mut-nested-call-arg.stderr
@@ -1,0 +1,15 @@
+error: expected one of `!`, `,`, `.`, `::`, `;`, `?`, `]`, `const`, `mut`, `{`, or an operator, found `2`
+  --> $DIR/raw-no-const-mut-nested-call-arg.rs:4:16
+   |
+LL |     Test([&raw 2])
+   |                ^ expected one of 11 possible tokens
+   |
+help: `&raw` must be followed by `const` or `mut` to be a raw reference expression
+   |
+LL |     Test([&raw const 2])
+   |                +++++
+LL |     Test([&raw mut 2])
+   |                +++
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Fixes rust-lang/rust#157853

The `&raw <expr>` recovery is only valid for malformed raw refs directly in the call argument list. When it handled the nested array case, it tried to skip tokens until the call's ), reached the nested ], and could ICE in parse_token_tree.

This PR scopes the call-argument recovery to the call's delimiter depth and makes the recovery loop stop before any closing delimiter or EOF.