### PR TITLE
filter out derive helper attributes during ast lowering but keeping them for rustdoc

### DIFF
--- a/compiler/rustc_attr_parsing/src/interface.rs
+++ b/compiler/rustc_attr_parsing/src/interface.rs
@@ -292,6 +292,11 @@ impl<'sess> AttributeParser<'sess> {
         mut emit_lint: impl FnMut(LintId, MultiSpan, EmitAttribute),
     ) -> Vec<Attribute> {
         let mut attributes = Vec::new();
+        // We store the attributes we intend to discard at the end of this function in order to
+        // check they are applied to the right target and error out if necessary. In practice, we
+        // end up dropping only derive attributes and derive helpers, both being fully processed
+        // at macro expansion.
+        let mut dropped_attributes = Vec::new();
         let mut attr_paths: Vec<RefPathParser<'_>> = Vec::new();
         let mut early_parsed_state = EarlyParsedState::default();
 
@@ -452,7 +457,19 @@ impl<'sess> AttributeParser<'sess> {
                             self.check_invalid_crate_level_attr_item(&attr, inner_span);
                         }
 
-                        attributes.push(Attribute::Unparsed(Box::new(attr)));
+                        let attr = Attribute::Unparsed(Box::new(attr));
+
+                        if self.sess.opts.actually_rustdoc
+                            || self.tools.is_some_and(|t| t.iter().any(|i| i.name == parts[0]))
+                            // FIXME: this can be removed once #152369 has been merged.
+                            // https://github.com/rust-lang/rust/pull/152369
+                            || [sym::allow, sym::deny, sym::expect, sym::forbid, sym::warn]
+                                .contains(&parts[0])
+                        {
+                            attributes.push(attr);
+                        } else {
+                            dropped_attributes.push(attr);
+                        }
                     };
                 }
             }
@@ -476,7 +493,7 @@ impl<'sess> AttributeParser<'sess> {
         }
 
         if !matches!(self.should_emit, ShouldEmit::Nothing) && target == Target::WherePredicate {
-            self.check_invalid_where_predicate_attrs(attributes.iter());
+            self.check_invalid_where_predicate_attrs(attributes.iter().chain(&dropped_attributes));
         }
 
         attributes

--- a/compiler/rustc_attr_parsing/src/interface.rs
+++ b/compiler/rustc_attr_parsing/src/interface.rs
@@ -461,8 +461,8 @@ impl<'sess> AttributeParser<'sess> {
 
                         if self.sess.opts.actually_rustdoc
                             || self.tools.is_some_and(|t| t.iter().any(|i| i.name == parts[0]))
-                            // FIXME: this can be removed once #152369 has been merged.
-                            // https://github.com/rust-lang/rust/pull/152369
+                            // FIXME: this can be removed once #155691 has been merged.
+                            // https://github.com/rust-lang/rust/pull/155691
                             || [sym::allow, sym::deny, sym::expect, sym::forbid, sym::warn]
                                 .contains(&parts[0])
                         {


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/157896)*
<!-- homu-ignore:end -->

Relands rust-lang/rust#153102  with an actually_doc guard so that derive helper attributes are preserved in rustdoc JSON output. When running normally, they are dropped into dropped_attributes as before

The problem: @scrabsha 's  original implementation dropped derive helper attributes during AST lowering, which is correct for normal compilation. However, rustdoc json relies on these attributes to expose them to tooling (BuFFI). This caused a regression reported in rust-lang/rust#157107 which was fixed by reverting PR in rust-lang/rust#157150

The fix: Before dropping an attribute into dropped_attributes, check self.sess.opts.actually_rustdoc. If rustdoc is running, keep the attribute so it appears in the JSON output. Otherwise drop it as before.

r? @JonathanBrouwer 
cc @scrabsha 