### PR TITLE
Rollup of 2 pull requests

### DIFF
--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -235,6 +235,7 @@ pub(crate) fn create_config(
         // it's unclear whether these should be part of rustdoc directly (#77364)
         rustc_lint::builtin::MISSING_DOCS.name.to_string(),
         rustc_lint::builtin::INVALID_DOC_ATTRIBUTES.name.to_string(),
+        rustc_lint::builtin::UNUSED_DOC_COMMENTS.name.to_string(),
         // these are definitely not part of rustdoc, but we want to warn on them anyway.
         rustc_lint::builtin::RENAMED_AND_REMOVED_LINTS.name.to_string(),
         rustc_lint::builtin::UNKNOWN_LINTS.name.to_string(),

--- a/tests/rustdoc-ui/check-doc-alias-attr-location.rs
+++ b/tests/rustdoc-ui/check-doc-alias-attr-location.rs
@@ -4,6 +4,8 @@ pub trait Foo {
     fn foo() -> Self::X;
 }
 
+// FIXME(#96009): Don't emit `unused_doc_comments` here, we already emit an error anyway.
+//~v WARN
 #[doc(alias = "foo")] //~ ERROR
 extern "C" {}
 

--- a/tests/rustdoc-ui/check-doc-alias-attr-location.stderr
+++ b/tests/rustdoc-ui/check-doc-alias-attr-location.stderr
@@ -1,26 +1,37 @@
+warning: unused doc comment
+  --> $DIR/check-doc-alias-attr-location.rs:9:1
+   |
+LL | #[doc(alias = "foo")]
+   | ^^^^^^^^^^^^^^^^^^^^^
+LL | extern "C" {}
+   | ------------- rustdoc does not generate documentation for extern blocks
+   |
+   = help: use `//` for a plain comment
+   = note: `#[warn(unused_doc_comments)]` (part of `#[warn(unused)]`) on by default
+
 error: `#[doc(alias = "...")]` isn't allowed on foreign module
-  --> $DIR/check-doc-alias-attr-location.rs:7:15
+  --> $DIR/check-doc-alias-attr-location.rs:9:15
    |
 LL | #[doc(alias = "foo")]
    |               ^^^^^
 
 error: `#[doc(alias = "...")]` isn't allowed on implementation block
-  --> $DIR/check-doc-alias-attr-location.rs:10:15
+  --> $DIR/check-doc-alias-attr-location.rs:12:15
    |
 LL | #[doc(alias = "bar")]
    |               ^^^^^
 
 error: `#[doc(alias = "...")]` isn't allowed on implementation block
-  --> $DIR/check-doc-alias-attr-location.rs:16:15
+  --> $DIR/check-doc-alias-attr-location.rs:18:15
    |
 LL | #[doc(alias = "foobar")]
    |               ^^^^^^^^
 
 error: `#[doc(alias = "...")]` isn't allowed on type alias in implementation block
-  --> $DIR/check-doc-alias-attr-location.rs:18:19
+  --> $DIR/check-doc-alias-attr-location.rs:20:19
    |
 LL |     #[doc(alias = "assoc")]
    |                   ^^^^^^^
 
-error: aborting due to 4 previous errors
+error: aborting due to 4 previous errors; 1 warning emitted
 

--- a/tests/rustdoc-ui/lints/unused-doc-comments.rs
+++ b/tests/rustdoc-ui/lints/unused-doc-comments.rs
@@ -1,0 +1,10 @@
+// Ensure that lint `unused_doc_comments` also gets emitted by rustdoc, not just by rustc.
+//@ check-pass
+
+pub fn f</** */T>() { //~ WARN unused doc comment
+    /** */ let (); //~ WARN unused doc comment
+}
+
+macro_rules! m { () => { pub fn g() {} } }
+
+/** */ m!(); //~ WARN unused doc comment

--- a/tests/rustdoc-ui/lints/unused-doc-comments.stderr
+++ b/tests/rustdoc-ui/lints/unused-doc-comments.stderr
@@ -1,0 +1,27 @@
+warning: unused doc comment
+  --> $DIR/unused-doc-comments.rs:10:1
+   |
+LL | /** */ m!();
+   | ^^^^^^ rustdoc does not generate documentation for macro invocations
+   |
+   = help: to document an item produced by a macro, the macro must produce the documentation as part of its expansion
+   = note: `#[warn(unused_doc_comments)]` (part of `#[warn(unused)]`) on by default
+
+warning: unused doc comment
+  --> $DIR/unused-doc-comments.rs:4:10
+   |
+LL | pub fn f</** */T>() {
+   |          ^^^^^^- rustdoc does not generate documentation for generic parameters
+   |
+   = help: use `/* */` for a plain comment
+
+warning: unused doc comment
+  --> $DIR/unused-doc-comments.rs:5:5
+   |
+LL |     /** */ let ();
+   |     ^^^^^^ ------- rustdoc does not generate documentation for statements
+   |
+   = help: use `/* */` for a plain comment
+
+warning: 3 warnings emitted
+

--- a/tests/ui/error-codes/E0152-duplicate-lang-items.rs
+++ b/tests/ui/error-codes/E0152-duplicate-lang-items.rs
@@ -3,15 +3,15 @@
 //!
 //! Issue: <https://github.com/rust-lang/rust/issues/31788>
 
-//@ normalize-stderr: "loaded from .*libstd-.*.rmeta" -> "loaded from SYSROOT/libstd-*.rmeta"
+//@ normalize-stderr: "loaded from \$.*libcore-.*.rmeta" -> "loaded from SYSROOT/libcore-*.rmeta"
 //@ dont-require-annotations: NOTE
 
 #![feature(lang_items)]
 
-#[lang = "eh_personality"]
-fn personality() {
-    //~^ ERROR: found duplicate lang item `eh_personality`
-    //~| NOTE first defined in crate `std`
+#[lang = "panic_fmt"]
+fn panic_fmt() -> ! {
+    //~^ ERROR: found duplicate lang item `panic_fmt`
+    //~| NOTE first defined in crate `core`
     loop {}
 }
 

--- a/tests/ui/error-codes/E0152-duplicate-lang-items.stderr
+++ b/tests/ui/error-codes/E0152-duplicate-lang-items.stderr
@@ -1,15 +1,15 @@
-error[E0152]: found duplicate lang item `eh_personality`
+error[E0152]: found duplicate lang item `panic_fmt`
   --> $DIR/E0152-duplicate-lang-items.rs:12:1
    |
-LL | / fn personality() {
+LL | / fn panic_fmt() -> ! {
 LL | |
 LL | |
 LL | |     loop {}
 LL | | }
    | |_^
    |
-   = note: the lang item is first defined in crate `std` (which `E0152_duplicate_lang_items` depends on)
-   = note: first definition in `std` loaded from SYSROOT/libstd-*.rmeta
+   = note: the lang item is first defined in crate `core` (which `std` depends on)
+   = note: first definition in `core` loaded from SYSROOT/libcore-*.rmeta
    = note: second definition in the local crate (`E0152_duplicate_lang_items`)
 
 error: aborting due to 1 previous error


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#141000 (rustdoc: Also run lint `unused_doc_comments`)
 - rust-lang/rust#157826 (make test succeed on targets lacking a personality)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=141000,157826)
<!-- homu-ignore:end -->

