### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_lint/src/noop_method_call.rs
+++ b/compiler/rustc_lint/src/noop_method_call.rs
@@ -145,6 +145,8 @@ impl<'tcx> LateLintPass<'tcx> for NoopMethodCall {
                 },
             );
         } else {
+            // Report the method call's return type before adjustments required by its parent.
+            let unadjusted_expr_ty = cx.typeck_results().expr_ty(expr);
             match name {
                 // If `type_of(x) == T` and `x.borrow()` is used to get `&T`,
                 // then that should be allowed
@@ -152,12 +154,12 @@ impl<'tcx> LateLintPass<'tcx> for NoopMethodCall {
                 sym::noop_method_clone => cx.emit_span_lint(
                     SUSPICIOUS_DOUBLE_REF_OP,
                     span,
-                    SuspiciousDoubleRefCloneDiag { ty: expr_ty },
+                    SuspiciousDoubleRefCloneDiag { ty: unadjusted_expr_ty },
                 ),
                 sym::noop_method_deref => cx.emit_span_lint(
                     SUSPICIOUS_DOUBLE_REF_OP,
                     span,
-                    SuspiciousDoubleRefDerefDiag { ty: expr_ty },
+                    SuspiciousDoubleRefDerefDiag { ty: unadjusted_expr_ty },
                 ),
                 _ => return,
             }

--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -1621,6 +1621,7 @@ pub unsafe fn float_to_int_unchecked<Float: bounds::FloatPrimitive, Int: Copy>(v
 /// Float addition that allows optimizations based on algebraic rules.
 ///
 /// Stabilized as [`f16::algebraic_add`], [`f32::algebraic_add`], [`f64::algebraic_add`] and [`f128::algebraic_add`].
+#[rustc_intrinsic_const_stable_indirect]
 #[rustc_nounwind]
 #[rustc_intrinsic]
 pub const fn fadd_algebraic<T: bounds::FloatPrimitive>(a: T, b: T) -> T;
@@ -1628,6 +1629,7 @@ pub const fn fadd_algebraic<T: bounds::FloatPrimitive>(a: T, b: T) -> T;
 /// Float subtraction that allows optimizations based on algebraic rules.
 ///
 /// Stabilized as [`f16::algebraic_sub`], [`f32::algebraic_sub`], [`f64::algebraic_sub`] and [`f128::algebraic_sub`].
+#[rustc_intrinsic_const_stable_indirect]
 #[rustc_nounwind]
 #[rustc_intrinsic]
 pub const fn fsub_algebraic<T: bounds::FloatPrimitive>(a: T, b: T) -> T;
@@ -1635,6 +1637,7 @@ pub const fn fsub_algebraic<T: bounds::FloatPrimitive>(a: T, b: T) -> T;
 /// Float multiplication that allows optimizations based on algebraic rules.
 ///
 /// Stabilized as [`f16::algebraic_mul`], [`f32::algebraic_mul`], [`f64::algebraic_mul`] and [`f128::algebraic_mul`].
+#[rustc_intrinsic_const_stable_indirect]
 #[rustc_nounwind]
 #[rustc_intrinsic]
 pub const fn fmul_algebraic<T: bounds::FloatPrimitive>(a: T, b: T) -> T;
@@ -1642,6 +1645,7 @@ pub const fn fmul_algebraic<T: bounds::FloatPrimitive>(a: T, b: T) -> T;
 /// Float division that allows optimizations based on algebraic rules.
 ///
 /// Stabilized as [`f16::algebraic_div`], [`f32::algebraic_div`], [`f64::algebraic_div`] and [`f128::algebraic_div`].
+#[rustc_intrinsic_const_stable_indirect]
 #[rustc_nounwind]
 #[rustc_intrinsic]
 pub const fn fdiv_algebraic<T: bounds::FloatPrimitive>(a: T, b: T) -> T;
@@ -1649,6 +1653,7 @@ pub const fn fdiv_algebraic<T: bounds::FloatPrimitive>(a: T, b: T) -> T;
 /// Float remainder that allows optimizations based on algebraic rules.
 ///
 /// Stabilized as [`f16::algebraic_rem`], [`f32::algebraic_rem`], [`f64::algebraic_rem`] and [`f128::algebraic_rem`].
+#[rustc_intrinsic_const_stable_indirect]
 #[rustc_nounwind]
 #[rustc_intrinsic]
 pub const fn frem_algebraic<T: bounds::FloatPrimitive>(a: T, b: T) -> T;

--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -2054,7 +2054,8 @@ pub const fn rotate_right<T: [const] fallback::FunnelShift>(x: T, shift: u32) ->
     unsafe { unchecked_funnel_shr(x, x, shift % (mem::size_of::<T>() as u32 * 8)) }
 }
 
-/// Returns (a + b) mod 2<sup>N</sup>, where N is the width of T in bits.
+/// Wrapping (modular) addition. Computes `a + b`,
+/// wrapping around at the boundary of the type.
 ///
 /// Note that, unlike most intrinsics, this is safe to call;
 /// it does not require an `unsafe` block.
@@ -2068,7 +2069,8 @@ pub const fn rotate_right<T: [const] fallback::FunnelShift>(x: T, shift: u32) ->
 #[rustc_nounwind]
 #[rustc_intrinsic]
 pub const fn wrapping_add<T: Copy>(a: T, b: T) -> T;
-/// Returns (a - b) mod 2<sup>N</sup>, where N is the width of T in bits.
+/// Wrapping (modular) subtraction. Computes `a - b`,
+/// wrapping around at the boundary of the type.
 ///
 /// Note that, unlike most intrinsics, this is safe to call;
 /// it does not require an `unsafe` block.
@@ -2082,7 +2084,8 @@ pub const fn wrapping_add<T: Copy>(a: T, b: T) -> T;
 #[rustc_nounwind]
 #[rustc_intrinsic]
 pub const fn wrapping_sub<T: Copy>(a: T, b: T) -> T;
-/// Returns (a * b) mod 2<sup>N</sup>, where N is the width of T in bits.
+/// Wrapping (modular) multiplication. Computes `a *
+/// b`, wrapping around at the boundary of the type.
 ///
 /// Note that, unlike most intrinsics, this is safe to call;
 /// it does not require an `unsafe` block.

--- a/library/core/src/num/f128.rs
+++ b/library/core/src/num/f128.rs
@@ -1552,8 +1552,8 @@ impl f128 {
     ///
     /// See [algebraic operators](primitive@f32#algebraic-operators) for more info.
     #[must_use = "method returns a new number and does not mutate the original value"]
-    #[unstable(feature = "float_algebraic", issue = "136469")]
-    #[rustc_const_unstable(feature = "float_algebraic", issue = "136469")]
+    #[unstable(feature = "f128", issue = "116909")]
+    #[rustc_const_unstable(feature = "f128", issue = "116909")]
     #[inline]
     pub const fn algebraic_add(self, rhs: f128) -> f128 {
         intrinsics::fadd_algebraic(self, rhs)
@@ -1563,8 +1563,8 @@ impl f128 {
     ///
     /// See [algebraic operators](primitive@f32#algebraic-operators) for more info.
     #[must_use = "method returns a new number and does not mutate the original value"]
-    #[unstable(feature = "float_algebraic", issue = "136469")]
-    #[rustc_const_unstable(feature = "float_algebraic", issue = "136469")]
+    #[unstable(feature = "f128", issue = "116909")]
+    #[rustc_const_unstable(feature = "f128", issue = "116909")]
     #[inline]
     pub const fn algebraic_sub(self, rhs: f128) -> f128 {
         intrinsics::fsub_algebraic(self, rhs)
@@ -1574,8 +1574,8 @@ impl f128 {
     ///
     /// See [algebraic operators](primitive@f32#algebraic-operators) for more info.
     #[must_use = "method returns a new number and does not mutate the original value"]
-    #[unstable(feature = "float_algebraic", issue = "136469")]
-    #[rustc_const_unstable(feature = "float_algebraic", issue = "136469")]
+    #[unstable(feature = "f128", issue = "116909")]
+    #[rustc_const_unstable(feature = "f128", issue = "116909")]
     #[inline]
     pub const fn algebraic_mul(self, rhs: f128) -> f128 {
         intrinsics::fmul_algebraic(self, rhs)
@@ -1585,8 +1585,8 @@ impl f128 {
     ///
     /// See [algebraic operators](primitive@f32#algebraic-operators) for more info.
     #[must_use = "method returns a new number and does not mutate the original value"]
-    #[unstable(feature = "float_algebraic", issue = "136469")]
-    #[rustc_const_unstable(feature = "float_algebraic", issue = "136469")]
+    #[unstable(feature = "f128", issue = "116909")]
+    #[rustc_const_unstable(feature = "f128", issue = "116909")]
     #[inline]
     pub const fn algebraic_div(self, rhs: f128) -> f128 {
         intrinsics::fdiv_algebraic(self, rhs)
@@ -1596,8 +1596,8 @@ impl f128 {
     ///
     /// See [algebraic operators](primitive@f32#algebraic-operators) for more info.
     #[must_use = "method returns a new number and does not mutate the original value"]
-    #[unstable(feature = "float_algebraic", issue = "136469")]
-    #[rustc_const_unstable(feature = "float_algebraic", issue = "136469")]
+    #[unstable(feature = "f128", issue = "116909")]
+    #[rustc_const_unstable(feature = "f128", issue = "116909")]
     #[inline]
     pub const fn algebraic_rem(self, rhs: f128) -> f128 {
         intrinsics::frem_algebraic(self, rhs)

--- a/library/core/src/num/f16.rs
+++ b/library/core/src/num/f16.rs
@@ -1538,8 +1538,8 @@ impl f16 {
     ///
     /// See [algebraic operators](primitive@f32#algebraic-operators) for more info.
     #[must_use = "method returns a new number and does not mutate the original value"]
-    #[unstable(feature = "float_algebraic", issue = "136469")]
-    #[rustc_const_unstable(feature = "float_algebraic", issue = "136469")]
+    #[unstable(feature = "f16", issue = "116909")]
+    #[rustc_const_unstable(feature = "f16", issue = "116909")]
     #[inline]
     pub const fn algebraic_add(self, rhs: f16) -> f16 {
         intrinsics::fadd_algebraic(self, rhs)
@@ -1549,8 +1549,8 @@ impl f16 {
     ///
     /// See [algebraic operators](primitive@f32#algebraic-operators) for more info.
     #[must_use = "method returns a new number and does not mutate the original value"]
-    #[unstable(feature = "float_algebraic", issue = "136469")]
-    #[rustc_const_unstable(feature = "float_algebraic", issue = "136469")]
+    #[unstable(feature = "f16", issue = "116909")]
+    #[rustc_const_unstable(feature = "f16", issue = "116909")]
     #[inline]
     pub const fn algebraic_sub(self, rhs: f16) -> f16 {
         intrinsics::fsub_algebraic(self, rhs)
@@ -1560,8 +1560,8 @@ impl f16 {
     ///
     /// See [algebraic operators](primitive@f32#algebraic-operators) for more info.
     #[must_use = "method returns a new number and does not mutate the original value"]
-    #[unstable(feature = "float_algebraic", issue = "136469")]
-    #[rustc_const_unstable(feature = "float_algebraic", issue = "136469")]
+    #[unstable(feature = "f16", issue = "116909")]
+    #[rustc_const_unstable(feature = "f16", issue = "116909")]
     #[inline]
     pub const fn algebraic_mul(self, rhs: f16) -> f16 {
         intrinsics::fmul_algebraic(self, rhs)
@@ -1571,8 +1571,8 @@ impl f16 {
     ///
     /// See [algebraic operators](primitive@f32#algebraic-operators) for more info.
     #[must_use = "method returns a new number and does not mutate the original value"]
-    #[unstable(feature = "float_algebraic", issue = "136469")]
-    #[rustc_const_unstable(feature = "float_algebraic", issue = "136469")]
+    #[unstable(feature = "f16", issue = "116909")]
+    #[rustc_const_unstable(feature = "f16", issue = "116909")]
     #[inline]
     pub const fn algebraic_div(self, rhs: f16) -> f16 {
         intrinsics::fdiv_algebraic(self, rhs)
@@ -1582,8 +1582,8 @@ impl f16 {
     ///
     /// See [algebraic operators](primitive@f32#algebraic-operators) for more info.
     #[must_use = "method returns a new number and does not mutate the original value"]
-    #[unstable(feature = "float_algebraic", issue = "136469")]
-    #[rustc_const_unstable(feature = "float_algebraic", issue = "136469")]
+    #[unstable(feature = "f16", issue = "116909")]
+    #[rustc_const_unstable(feature = "f16", issue = "116909")]
     #[inline]
     pub const fn algebraic_rem(self, rhs: f16) -> f16 {
         intrinsics::frem_algebraic(self, rhs)

--- a/library/core/src/num/f32.rs
+++ b/library/core/src/num/f32.rs
@@ -1694,8 +1694,8 @@ impl f32 {
     ///
     /// See [algebraic operators](primitive@f32#algebraic-operators) for more info.
     #[must_use = "method returns a new number and does not mutate the original value"]
-    #[unstable(feature = "float_algebraic", issue = "136469")]
-    #[rustc_const_unstable(feature = "float_algebraic", issue = "136469")]
+    #[stable(feature = "float_algebraic", since = "CURRENT_RUSTC_VERSION")]
+    #[rustc_const_stable(feature = "float_algebraic", since = "CURRENT_RUSTC_VERSION")]
     #[inline]
     pub const fn algebraic_add(self, rhs: f32) -> f32 {
         intrinsics::fadd_algebraic(self, rhs)
@@ -1705,8 +1705,8 @@ impl f32 {
     ///
     /// See [algebraic operators](primitive@f32#algebraic-operators) for more info.
     #[must_use = "method returns a new number and does not mutate the original value"]
-    #[unstable(feature = "float_algebraic", issue = "136469")]
-    #[rustc_const_unstable(feature = "float_algebraic", issue = "136469")]
+    #[stable(feature = "float_algebraic", since = "CURRENT_RUSTC_VERSION")]
+    #[rustc_const_stable(feature = "float_algebraic", since = "CURRENT_RUSTC_VERSION")]
     #[inline]
     pub const fn algebraic_sub(self, rhs: f32) -> f32 {
         intrinsics::fsub_algebraic(self, rhs)
@@ -1716,8 +1716,8 @@ impl f32 {
     ///
     /// See [algebraic operators](primitive@f32#algebraic-operators) for more info.
     #[must_use = "method returns a new number and does not mutate the original value"]
-    #[unstable(feature = "float_algebraic", issue = "136469")]
-    #[rustc_const_unstable(feature = "float_algebraic", issue = "136469")]
+    #[stable(feature = "float_algebraic", since = "CURRENT_RUSTC_VERSION")]
+    #[rustc_const_stable(feature = "float_algebraic", since = "CURRENT_RUSTC_VERSION")]
     #[inline]
     pub const fn algebraic_mul(self, rhs: f32) -> f32 {
         intrinsics::fmul_algebraic(self, rhs)
@@ -1727,8 +1727,8 @@ impl f32 {
     ///
     /// See [algebraic operators](primitive@f32#algebraic-operators) for more info.
     #[must_use = "method returns a new number and does not mutate the original value"]
-    #[unstable(feature = "float_algebraic", issue = "136469")]
-    #[rustc_const_unstable(feature = "float_algebraic", issue = "136469")]
+    #[stable(feature = "float_algebraic", since = "CURRENT_RUSTC_VERSION")]
+    #[rustc_const_stable(feature = "float_algebraic", since = "CURRENT_RUSTC_VERSION")]
     #[inline]
     pub const fn algebraic_div(self, rhs: f32) -> f32 {
         intrinsics::fdiv_algebraic(self, rhs)
@@ -1738,8 +1738,8 @@ impl f32 {
     ///
     /// See [algebraic operators](primitive@f32#algebraic-operators) for more info.
     #[must_use = "method returns a new number and does not mutate the original value"]
-    #[unstable(feature = "float_algebraic", issue = "136469")]
-    #[rustc_const_unstable(feature = "float_algebraic", issue = "136469")]
+    #[stable(feature = "float_algebraic", since = "CURRENT_RUSTC_VERSION")]
+    #[rustc_const_stable(feature = "float_algebraic", since = "CURRENT_RUSTC_VERSION")]
     #[inline]
     pub const fn algebraic_rem(self, rhs: f32) -> f32 {
         intrinsics::frem_algebraic(self, rhs)

--- a/library/core/src/num/f64.rs
+++ b/library/core/src/num/f64.rs
@@ -1674,8 +1674,8 @@ impl f64 {
     ///
     /// See [algebraic operators](primitive@f32#algebraic-operators) for more info.
     #[must_use = "method returns a new number and does not mutate the original value"]
-    #[unstable(feature = "float_algebraic", issue = "136469")]
-    #[rustc_const_unstable(feature = "float_algebraic", issue = "136469")]
+    #[stable(feature = "float_algebraic", since = "CURRENT_RUSTC_VERSION")]
+    #[rustc_const_stable(feature = "float_algebraic", since = "CURRENT_RUSTC_VERSION")]
     #[inline]
     pub const fn algebraic_add(self, rhs: f64) -> f64 {
         intrinsics::fadd_algebraic(self, rhs)
@@ -1685,8 +1685,8 @@ impl f64 {
     ///
     /// See [algebraic operators](primitive@f32#algebraic-operators) for more info.
     #[must_use = "method returns a new number and does not mutate the original value"]
-    #[unstable(feature = "float_algebraic", issue = "136469")]
-    #[rustc_const_unstable(feature = "float_algebraic", issue = "136469")]
+    #[stable(feature = "float_algebraic", since = "CURRENT_RUSTC_VERSION")]
+    #[rustc_const_stable(feature = "float_algebraic", since = "CURRENT_RUSTC_VERSION")]
     #[inline]
     pub const fn algebraic_sub(self, rhs: f64) -> f64 {
         intrinsics::fsub_algebraic(self, rhs)
@@ -1696,8 +1696,8 @@ impl f64 {
     ///
     /// See [algebraic operators](primitive@f32#algebraic-operators) for more info.
     #[must_use = "method returns a new number and does not mutate the original value"]
-    #[unstable(feature = "float_algebraic", issue = "136469")]
-    #[rustc_const_unstable(feature = "float_algebraic", issue = "136469")]
+    #[stable(feature = "float_algebraic", since = "CURRENT_RUSTC_VERSION")]
+    #[rustc_const_stable(feature = "float_algebraic", since = "CURRENT_RUSTC_VERSION")]
     #[inline]
     pub const fn algebraic_mul(self, rhs: f64) -> f64 {
         intrinsics::fmul_algebraic(self, rhs)
@@ -1707,8 +1707,8 @@ impl f64 {
     ///
     /// See [algebraic operators](primitive@f32#algebraic-operators) for more info.
     #[must_use = "method returns a new number and does not mutate the original value"]
-    #[unstable(feature = "float_algebraic", issue = "136469")]
-    #[rustc_const_unstable(feature = "float_algebraic", issue = "136469")]
+    #[stable(feature = "float_algebraic", since = "CURRENT_RUSTC_VERSION")]
+    #[rustc_const_stable(feature = "float_algebraic", since = "CURRENT_RUSTC_VERSION")]
     #[inline]
     pub const fn algebraic_div(self, rhs: f64) -> f64 {
         intrinsics::fdiv_algebraic(self, rhs)
@@ -1718,8 +1718,8 @@ impl f64 {
     ///
     /// See [algebraic operators](primitive@f32#algebraic-operators) for more info.
     #[must_use = "method returns a new number and does not mutate the original value"]
-    #[unstable(feature = "float_algebraic", issue = "136469")]
-    #[rustc_const_unstable(feature = "float_algebraic", issue = "136469")]
+    #[stable(feature = "float_algebraic", since = "CURRENT_RUSTC_VERSION")]
+    #[rustc_const_stable(feature = "float_algebraic", since = "CURRENT_RUSTC_VERSION")]
     #[inline]
     pub const fn algebraic_rem(self, rhs: f64) -> f64 {
         intrinsics::frem_algebraic(self, rhs)

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -1374,8 +1374,6 @@ macro_rules! nonzero_integer {
             /// # Examples
             ///
             /// ```
-            /// #![feature(nonzero_from_str_radix)]
-            ///
             /// # use std::num::NonZero;
             /// #
             /// # fn main() { test().unwrap(); }
@@ -1388,13 +1386,12 @@ macro_rules! nonzero_integer {
             /// Trailing space returns error:
             ///
             /// ```
-            /// #![feature(nonzero_from_str_radix)]
-            ///
             /// # use std::num::NonZero;
             /// #
             #[doc = concat!("assert!(NonZero::<", stringify!($Int), ">::from_str_radix(\"1 \", 10).is_err());")]
             /// ```
-            #[unstable(feature = "nonzero_from_str_radix", issue = "152193")]
+            #[stable(feature = "nonzero_from_str_radix", since = "CURRENT_RUSTC_VERSION")]
+            #[rustc_const_stable(feature = "nonzero_from_str_radix", since = "CURRENT_RUSTC_VERSION")]
             #[inline]
             pub const fn from_str_radix(src: &str, radix: u32) -> Result<Self, ParseIntError> {
                 Self::from_ascii_radix(src.as_bytes(), radix)

--- a/library/core/src/primitive_docs.rs
+++ b/library/core/src/primitive_docs.rs
@@ -1341,7 +1341,6 @@ mod prim_f16 {}
 /// For example:
 ///
 /// ```
-/// # #![feature(float_algebraic)]
 /// # #![allow(unused_assignments)]
 /// # let mut x: f32 = 0.0;
 /// # let a: f32 = 1.0;
@@ -1360,7 +1359,7 @@ mod prim_f16 {}
 /// # let b: f32 = 2.0;
 /// # let c: f32 = 3.0;
 /// # let d: f32 = 4.0;
-/// x = a + b + c + d; // As written
+/// x = ((a + b) + c) + d; // As written
 /// x = (a + c) + (b + d); // Reordered to shorten critical path and enable vectorization
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/library/coretests/tests/lib.rs
+++ b/library/coretests/tests/lib.rs
@@ -52,7 +52,6 @@
 #![feature(extern_types)]
 #![feature(f16)]
 #![feature(f128)]
-#![feature(float_algebraic)]
 #![feature(float_exact_integer_constants)]
 #![feature(float_gamma)]
 #![feature(float_minimum_maximum)]

--- a/library/coretests/tests/lib.rs
+++ b/library/coretests/tests/lib.rs
@@ -91,7 +91,6 @@
 #![feature(never_type)]
 #![feature(next_index)]
 #![feature(non_exhaustive_omitted_patterns_lint)]
-#![feature(nonzero_from_str_radix)]
 #![feature(num_internals)]
 #![feature(numfmt)]
 #![feature(one_sided_range)]

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -336,7 +336,6 @@
 #![feature(exact_size_is_empty)]
 #![feature(exclusive_wrapper)]
 #![feature(extend_one)]
-#![feature(float_algebraic)]
 #![feature(float_gamma)]
 #![feature(float_minimum_maximum)]
 #![feature(fmt_internals)]

--- a/tests/codegen-llvm/float/algebraic.rs
+++ b/tests/codegen-llvm/float/algebraic.rs
@@ -6,7 +6,6 @@
 #![crate_type = "lib"]
 #![feature(f16)]
 #![feature(f128)]
-#![feature(float_algebraic)]
 
 // CHECK-LABEL: @f16_algebraic_add
 #[no_mangle]

--- a/tests/ui/lint/suspicious-double-ref-op.rs
+++ b/tests/ui/lint/suspicious-double-ref-op.rs
@@ -1,6 +1,7 @@
 #![deny(suspicious_double_ref_op, noop_method_call)]
 
 use std::borrow::Borrow;
+use std::io::Write;
 use std::ops::Deref;
 
 struct PlainType<T>(T);
@@ -25,6 +26,15 @@ pub static STRS: LazyLock<&str> = LazyLock::new(|| "First");
 fn rust_clippy_issue_9272() {
     let str = STRS.clone();
     println!("{str}")
+}
+
+// https://github.com/rust-lang/rust/issues/146227
+fn method_receiver_adjustment(file: &std::fs::File, double_ref: &&std::fs::File) {
+    let _ = file.clone().write(&[]);
+    //~^ ERROR using `.clone()` on a double reference, which returns `&File`
+
+    let _ = double_ref.deref().write(&[]);
+    //~^ ERROR using `.deref()` on a double reference, which returns `&File`
 }
 
 fn main() {

--- a/tests/ui/lint/suspicious-double-ref-op.stderr
+++ b/tests/ui/lint/suspicious-double-ref-op.stderr
@@ -10,13 +10,13 @@ note: the lint level is defined here
 LL | #![deny(suspicious_double_ref_op, noop_method_call)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: using `.clone()` on a double reference, which returns `&mut &File` instead of cloning the inner type
+error: using `.clone()` on a double reference, which returns `&File` instead of cloning the inner type
   --> $DIR/suspicious-double-ref-op.rs:33:17
    |
 LL |     let _ = file.clone().write(&[]);
    |                 ^^^^^^^^
 
-error: using `.deref()` on a double reference, which returns `&mut &File` instead of dereferencing the inner type
+error: using `.deref()` on a double reference, which returns `&File` instead of dereferencing the inner type
   --> $DIR/suspicious-double-ref-op.rs:36:23
    |
 LL |     let _ = double_ref.deref().write(&[]);

--- a/tests/ui/lint/suspicious-double-ref-op.stderr
+++ b/tests/ui/lint/suspicious-double-ref-op.stderr
@@ -1,5 +1,5 @@
 error: using `.clone()` on a double reference, which returns `&Vec<i32>` instead of cloning the inner type
-  --> $DIR/suspicious-double-ref-op.rs:14:23
+  --> $DIR/suspicious-double-ref-op.rs:15:23
    |
 LL |     let z: &Vec<_> = y.clone();
    |                       ^^^^^^^^
@@ -10,23 +10,35 @@ note: the lint level is defined here
 LL | #![deny(suspicious_double_ref_op, noop_method_call)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^
 
+error: using `.clone()` on a double reference, which returns `&mut &File` instead of cloning the inner type
+  --> $DIR/suspicious-double-ref-op.rs:33:17
+   |
+LL |     let _ = file.clone().write(&[]);
+   |                 ^^^^^^^^
+
+error: using `.deref()` on a double reference, which returns `&mut &File` instead of dereferencing the inner type
+  --> $DIR/suspicious-double-ref-op.rs:36:23
+   |
+LL |     let _ = double_ref.deref().write(&[]);
+   |                       ^^^^^^^^
+
 error: using `.clone()` on a double reference, which returns `&CloneType<u32>` instead of cloning the inner type
-  --> $DIR/suspicious-double-ref-op.rs:32:63
+  --> $DIR/suspicious-double-ref-op.rs:42:63
    |
 LL |     let clone_type_ref_clone: &CloneType<u32> = clone_type_ref.clone();
    |                                                               ^^^^^^^^
 
 error: using `.deref()` on a double reference, which returns `&PlainType<u32>` instead of dereferencing the inner type
-  --> $DIR/suspicious-double-ref-op.rs:36:63
+  --> $DIR/suspicious-double-ref-op.rs:46:63
    |
 LL |     let non_deref_type_deref: &PlainType<u32> = non_deref_type.deref();
    |                                                               ^^^^^^^^
 
 error: using `.clone()` on a double reference, which returns `&str` instead of cloning the inner type
-  --> $DIR/suspicious-double-ref-op.rs:40:44
+  --> $DIR/suspicious-double-ref-op.rs:50:44
    |
 LL |     let _v: Vec<&str> = xs.iter().map(|x| x.clone()).collect(); // could use `*x` instead
    |                                            ^^^^^^^^
 
-error: aborting due to 4 previous errors
+error: aborting due to 6 previous errors
 


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#157899 (Update LLVM to 22.1.7)
 - rust-lang/rust#157029 (stabilize feature `float_algebraic`)
 - rust-lang/rust#157872 (`suspicious_double_ref_op`: report unadjusted return type)
 - rust-lang/rust#157877 (Stabilize `nonzero_from_str_radix`)
 - rust-lang/rust#157900 (Update intrinsics wrapping documentation)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=157899,157029,157872,157877,157900)
<!-- homu-ignore:end -->

