### PR TITLE
Update comments and add tests for `-Zrandomize-layout` for some guaranteed ZSTs

### DIFF
--- a/compiler/rustc_abi/src/layout.rs
+++ b/compiler/rustc_abi/src/layout.rs
@@ -1124,6 +1124,10 @@ impl<Cx: HasDataLayout> LayoutCalculator<Cx> {
             // If `-Z randomize-layout` was enabled for the type definition we can shuffle
             // the field ordering to try and catch some code making assumptions about layouts
             // we don't guarantee.
+            // In the future, we might do more than shuffle field order (e.g. introduce extra padding),
+            // but never for `repr(Rust)` structs with only zero-sized fields or single-variant
+            // `repr(Rust)` enums with only zero-sized fields, which must remain zero-sized as per
+            // T-lang decision https://github.com/rust-lang/reference/pull/2262
             if repr.can_randomize_type_layout() && cfg!(feature = "randomize") {
                 #[cfg(feature = "randomize")]
                 {

--- a/compiler/rustc_abi/src/layout.rs
+++ b/compiler/rustc_abi/src/layout.rs
@@ -1125,9 +1125,10 @@ impl<Cx: HasDataLayout> LayoutCalculator<Cx> {
             // the field ordering to try and catch some code making assumptions about layouts
             // we don't guarantee.
             // In the future, we might do more than shuffle field order (e.g. introduce extra padding),
-            // but never for `repr(Rust)` structs with only zero-sized fields or single-variant
-            // `repr(Rust)` enums with only zero-sized fields, which must remain zero-sized as per
-            // T-lang decision https://github.com/rust-lang/reference/pull/2262
+            // but never for `repr(Rust)` structs with only zero-sized fields, single-variant
+            // `repr(Rust)` enums with only zero-sized fields, or zero-variant `repr(Rust)` enums,
+            // which must remain zero-sized as per T-lang decisions in
+            // https://github.com/rust-lang/reference/pull/2262 and https://github.com/rust-lang/reference/pull/2293
             if repr.can_randomize_type_layout() && cfg!(feature = "randomize") {
                 #[cfg(feature = "randomize")]
                 {

--- a/compiler/rustc_abi/src/lib.rs
+++ b/compiler/rustc_abi/src/lib.rs
@@ -91,9 +91,9 @@ bitflags! {
         /// Other flags can still inhibit reordering and thus randomization.
         /// The seed stored in `ReprOptions.field_shuffle_seed`.
         ///
-        /// `repr(Rust)` structs with only zero-sized fields and single-variant `repr(Rust)` enums with only
-        /// zero-sized fields must remain zero-sized as per T-lang decision
-        /// https://github.com/rust-lang/reference/pull/2262
+        /// `repr(Rust)` structs with only zero-sized fields, single-variant `repr(Rust)` enums with only
+        /// zero-sized fields, and zero-variant `repr(Rust)` enums must remain zero-sized as per
+        /// T-lang decisions in https://github.com/rust-lang/reference/pull/2262 and https://github.com/rust-lang/reference/pull/2293
         const RANDOMIZE_LAYOUT   = 1 << 4;
         /// If true, the type is always passed indirectly by non-Rustic ABIs.
         /// See [`TyAndLayout::pass_indirectly_in_non_rustic_abis`] for details.

--- a/compiler/rustc_abi/src/lib.rs
+++ b/compiler/rustc_abi/src/lib.rs
@@ -90,6 +90,10 @@ bitflags! {
         /// If true, the type's crate has opted into layout randomization.
         /// Other flags can still inhibit reordering and thus randomization.
         /// The seed stored in `ReprOptions.field_shuffle_seed`.
+        ///
+        /// `repr(Rust)` structs with only zero-sized fields and single-variant `repr(Rust)` enums with only
+        /// zero-sized fields must remain zero-sized as per T-lang decision
+        /// https://github.com/rust-lang/reference/pull/2262
         const RANDOMIZE_LAYOUT   = 1 << 4;
         /// If true, the type is always passed indirectly by non-Rustic ABIs.
         /// See [`TyAndLayout::pass_indirectly_in_non_rustic_abis`] for details.

--- a/tests/ui/layout/randomize.rs
+++ b/tests/ui/layout/randomize.rs
@@ -67,6 +67,8 @@ pub struct ZstFieldsStruct {
     d: [(); 42],
 }
 #[allow(dead_code)]
+pub enum EmptyEnum {}
+#[allow(dead_code)]
 pub enum SingleUnitVariantEnum { A }
 #[allow(dead_code)]
 pub enum SingleZstFieldTupleVariantEnum { A((), [u64; 0], [u8; 0], [(); 42]) }
@@ -87,6 +89,7 @@ const _: () = {
     assert!(size_of::<EmptyStruct>() == 0);
     assert!(size_of::<ZstFieldsTupleStruct>() == 0);
     assert!(size_of::<ZstFieldsStruct>() == 0);
+    assert!(size_of::<EmptyEnum>() == 0);
     assert!(size_of::<SingleUnitVariantEnum>() == 0);
     assert!(size_of::<SingleZstFieldTupleVariantEnum>() == 0);
     assert!(size_of::<SingleZstFieldVariantEnum>() == 0);

--- a/tests/ui/layout/randomize.rs
+++ b/tests/ui/layout/randomize.rs
@@ -49,6 +49,49 @@ const _: () = {
     assert!(std::mem::offset_of!(Result::<&usize, ()>, Ok.0) == 0);
 };
 
+// these types only have their size checked, they're never constructed.
+// these repr(Rust) types must remain zero-sized.
+#[allow(dead_code)]
+pub struct UnitStruct;
+#[allow(dead_code)]
+pub struct EmptyTupleStruct();
+#[allow(dead_code)]
+pub struct EmptyStruct {}
+#[allow(dead_code)]
+pub struct ZstFieldsTupleStruct((), [u64; 0], [u8; 0], [(); 42]);
+#[allow(dead_code)]
+pub struct ZstFieldsStruct {
+    a: (),
+    b: [u64; 0],
+    c: [u8; 0],
+    d: [(); 42],
+}
+#[allow(dead_code)]
+pub enum SingleUnitVariantEnum { A }
+#[allow(dead_code)]
+pub enum SingleZstFieldTupleVariantEnum { A((), [u64; 0], [u8; 0], [(); 42]) }
+#[allow(dead_code)]
+pub enum SingleZstFieldVariantEnum {
+    A {
+        a: (),
+        b: [u64; 0],
+        c: [u8; 0],
+        d: [(); 42],
+    }
+}
+
+// all these types must remain zero-sized.
+const _: () = {
+    assert!(size_of::<UnitStruct>() == 0);
+    assert!(size_of::<EmptyTupleStruct>() == 0);
+    assert!(size_of::<EmptyStruct>() == 0);
+    assert!(size_of::<ZstFieldsTupleStruct>() == 0);
+    assert!(size_of::<ZstFieldsStruct>() == 0);
+    assert!(size_of::<SingleUnitVariantEnum>() == 0);
+    assert!(size_of::<SingleZstFieldTupleVariantEnum>() == 0);
+    assert!(size_of::<SingleZstFieldVariantEnum>() == 0);
+};
+
 #[allow(dead_code)]
 struct Unsizable<T: ?Sized>(usize, T);
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

See https://github.com/rust-lang/reference/pull/2262 . T-lang wants to make some additional guarantees about zero-sized `repr(Rust)` structs and enums, that changes to `-Zrandomize-layout` could theoretically break in the future. This PR adds comments to `-Zrandomize-layout`'s implementation and tests to `tests/ui/layout/randomize.rs` to prevent breaking those guarantees.

First commit is the guarantees that T-lang already FCP'd in https://github.com/rust-lang/reference/pull/2262 . 
Second commit is an additional guarantee (that zero-variant repr(Rust) enums are ZSTs) that's at https://github.com/rust-lang/reference/pull/2293 (FCP now completed)


