### PR TITLE
trait solver: Resolve region vars in max universe

### DIFF
--- a/compiler/rustc_type_ir/src/region_constraint.rs
+++ b/compiler/rustc_type_ir/src/region_constraint.rs
@@ -1013,6 +1013,10 @@ impl<'a, Infcx: InferCtxtLike<Interner = I>, I: Interner> TypeVisitor<I>
         match t.kind() {
             TyKind::Placeholder(p) => self.max_universe = self.max_universe.max(p.universe),
             TyKind::Infer(InferTy::TyVar(inf)) => {
+                // Unlike `visit_region`, we don't resolve the variable first: callers
+                // computing assumptions bail on any non-region inference variable
+                // before reaching here, so a type infer var is always unresolved and
+                // has a universe.
                 let u = self.infcx.universe_of_ty(inf).unwrap();
                 debug!("var {inf:?} in universe {u:?}");
                 self.max_universe = self.max_universe.max(u);
@@ -1025,6 +1029,8 @@ impl<'a, Infcx: InferCtxtLike<Interner = I>, I: Interner> TypeVisitor<I>
         match c.kind() {
             ConstKind::Placeholder(p) => self.max_universe = self.max_universe.max(p.universe),
             ConstKind::Infer(rustc_type_ir::InferConst::Var(inf)) => {
+                // See the comment in `visit_ty`: a const infer var is always
+                // unresolved here, so unlike a region it needs no resolving first.
                 let u = self.infcx.universe_of_ct(inf).unwrap();
                 debug!("var {inf:?} in universe {u:?}");
                 self.max_universe = self.max_universe.max(u);
@@ -1037,9 +1043,20 @@ impl<'a, Infcx: InferCtxtLike<Interner = I>, I: Interner> TypeVisitor<I>
         match r.kind() {
             RegionKind::RePlaceholder(p) => self.max_universe = self.max_universe.max(p.universe),
             RegionKind::ReVar(var) => {
-                let u = self.infcx.universe_of_lt(var).unwrap();
-                debug!("var {var:?} in universe {u:?}");
-                self.max_universe = self.max_universe.max(u);
+                // The variable may already have been unified with another region.
+                // `universe_of_lt` returns `None` for a resolved variable, so resolve
+                // it first and inspect whatever it points at.
+                match self.infcx.opportunistic_resolve_lt_var(var).kind() {
+                    RegionKind::RePlaceholder(p) => {
+                        self.max_universe = self.max_universe.max(p.universe)
+                    }
+                    RegionKind::ReVar(var) => {
+                        let u = self.infcx.universe_of_lt(var).unwrap();
+                        debug!("var {var:?} in universe {u:?}");
+                        self.max_universe = self.max_universe.max(u);
+                    }
+                    _ => (),
+                }
             }
             _ => (),
         }

--- a/compiler/rustc_type_ir/src/region_constraint.rs
+++ b/compiler/rustc_type_ir/src/region_constraint.rs
@@ -1039,19 +1039,17 @@ impl<'a, Infcx: InferCtxtLike<Interner = I>, I: Interner> TypeVisitor<I>
     fn visit_region(&mut self, r: I::Region) {
         match r.kind() {
             RegionKind::RePlaceholder(p) => self.max_universe = self.max_universe.max(p.universe),
-            RegionKind::ReVar(var) => {
-                match self.infcx.opportunistic_resolve_lt_var(var).kind() {
-                    RegionKind::RePlaceholder(p) => {
-                        self.max_universe = self.max_universe.max(p.universe)
-                    }
-                    RegionKind::ReVar(var) => {
-                        let u = self.infcx.universe_of_lt(var).unwrap();
-                        debug!("var {var:?} in universe {u:?}");
-                        self.max_universe = self.max_universe.max(u);
-                    }
-                    _ => (),
+            RegionKind::ReVar(var) => match self.infcx.opportunistic_resolve_lt_var(var).kind() {
+                RegionKind::RePlaceholder(p) => {
+                    self.max_universe = self.max_universe.max(p.universe)
                 }
-            }
+                RegionKind::ReVar(var) => {
+                    let u = self.infcx.universe_of_lt(var).unwrap();
+                    debug!("var {var:?} in universe {u:?}");
+                    self.max_universe = self.max_universe.max(u);
+                }
+                _ => (),
+            },
             _ => (),
         }
     }

--- a/compiler/rustc_type_ir/src/region_constraint.rs
+++ b/compiler/rustc_type_ir/src/region_constraint.rs
@@ -978,11 +978,14 @@ pub fn regions_outlived_by_placeholder<I: Interner>(
 }
 
 /// The largest universe a variable or placeholder was from in `t`
-pub fn max_universe<Infcx: InferCtxtLike<Interner = I>, I: Interner, T: TypeVisitable<I>>(
+pub fn max_universe<Infcx: InferCtxtLike<Interner = I>, I: Interner, T: TypeFoldable<I>>(
     infcx: &Infcx,
     t: T,
 ) -> UniverseIndex {
     let mut visitor = MaxUniverse::new(infcx);
+    // `max_universe` is also used while rewriting constraints to lower universes,
+    // so do not rely on callers having already resolved non-region infer vars.
+    let t = infcx.resolve_vars_if_possible(t);
     t.visit_with(&mut visitor);
     visitor.max_universe()
 }
@@ -1013,10 +1016,6 @@ impl<'a, Infcx: InferCtxtLike<Interner = I>, I: Interner> TypeVisitor<I>
         match t.kind() {
             TyKind::Placeholder(p) => self.max_universe = self.max_universe.max(p.universe),
             TyKind::Infer(InferTy::TyVar(inf)) => {
-                // Unlike `visit_region`, we don't resolve the variable first: callers
-                // computing assumptions bail on any non-region inference variable
-                // before reaching here, so a type infer var is always unresolved and
-                // has a universe.
                 let u = self.infcx.universe_of_ty(inf).unwrap();
                 debug!("var {inf:?} in universe {u:?}");
                 self.max_universe = self.max_universe.max(u);
@@ -1029,8 +1028,6 @@ impl<'a, Infcx: InferCtxtLike<Interner = I>, I: Interner> TypeVisitor<I>
         match c.kind() {
             ConstKind::Placeholder(p) => self.max_universe = self.max_universe.max(p.universe),
             ConstKind::Infer(rustc_type_ir::InferConst::Var(inf)) => {
-                // See the comment in `visit_ty`: a const infer var is always
-                // unresolved here, so unlike a region it needs no resolving first.
                 let u = self.infcx.universe_of_ct(inf).unwrap();
                 debug!("var {inf:?} in universe {u:?}");
                 self.max_universe = self.max_universe.max(u);
@@ -1043,9 +1040,6 @@ impl<'a, Infcx: InferCtxtLike<Interner = I>, I: Interner> TypeVisitor<I>
         match r.kind() {
             RegionKind::RePlaceholder(p) => self.max_universe = self.max_universe.max(p.universe),
             RegionKind::ReVar(var) => {
-                // The variable may already have been unified with another region.
-                // `universe_of_lt` returns `None` for a resolved variable, so resolve
-                // it first and inspect whatever it points at.
                 match self.infcx.opportunistic_resolve_lt_var(var).kind() {
                     RegionKind::RePlaceholder(p) => {
                         self.max_universe = self.max_universe.max(p.universe)

--- a/tests/ui/assumptions_on_binders/resolved-region-var-max-universe.rs
+++ b/tests/ui/assumptions_on_binders/resolved-region-var-max-universe.rs
@@ -1,0 +1,26 @@
+//@ compile-flags: -Zassumptions-on-binders -Znext-solver=globally
+
+// Regression test for an ICE in the `MaxUniverse` region visitor. When computing
+// the max universe of a region constraint, a `ReVar` term could already have been
+// unified with another region. `universe_of_lt` returns `None` for such a resolved
+// variable, so the visitor used to `unwrap()` `None` and panic. It now resolves the
+// variable before inspecting its universe.
+
+#![feature(min_generic_const_args, inherent_associated_types, generic_const_items)]
+
+struct Parent<'a> {
+    a: &'a str,
+}
+
+impl<'a> Parent<'a> {
+    type const CT<T: 'a>: usize = 0;
+}
+
+fn check/*<T>*/()
+where
+    [(); Parent::CT::<T>]:,
+    //~^ ERROR cannot find type `T` in this scope
+{
+}
+
+fn main() {}

--- a/tests/ui/assumptions_on_binders/resolved-region-var-max-universe.rs
+++ b/tests/ui/assumptions_on_binders/resolved-region-var-max-universe.rs
@@ -3,8 +3,10 @@
 // Regression test for an ICE in the `MaxUniverse` region visitor. When computing
 // the max universe of a region constraint, a `ReVar` term could already have been
 // unified with another region. `universe_of_lt` returns `None` for such a resolved
-// variable, so the visitor used to `unwrap()` `None` and panic. It now resolves the
-// variable before inspecting its universe.
+// variable, so the visitor used to `unwrap()` `None` and panic.
+//
+// The missing `T` in `check` is intentional. It makes HIR ty lowering emit an
+// error while still leaving behind the region constraint that used to ICE.
 
 #![feature(min_generic_const_args, inherent_associated_types, generic_const_items)]
 
@@ -16,7 +18,7 @@ impl<'a> Parent<'a> {
     type const CT<T: 'a>: usize = 0;
 }
 
-fn check/*<T>*/()
+fn check()
 where
     [(); Parent::CT::<T>]:,
     //~^ ERROR cannot find type `T` in this scope

--- a/tests/ui/assumptions_on_binders/resolved-region-var-max-universe.stderr
+++ b/tests/ui/assumptions_on_binders/resolved-region-var-max-universe.stderr
@@ -1,12 +1,12 @@
 error[E0425]: cannot find type `T` in this scope
-  --> $DIR/resolved-region-var-max-universe.rs:21:23
+  --> $DIR/resolved-region-var-max-universe.rs:23:23
    |
 LL |     [(); Parent::CT::<T>]:,
    |                       ^ not found in this scope
    |
 help: you might be missing a type parameter
    |
-LL | fn check<T>/*<T>*/()
+LL | fn check<T>()
    |         +++
 
 error: aborting due to 1 previous error

--- a/tests/ui/assumptions_on_binders/resolved-region-var-max-universe.stderr
+++ b/tests/ui/assumptions_on_binders/resolved-region-var-max-universe.stderr
@@ -1,0 +1,14 @@
+error[E0425]: cannot find type `T` in this scope
+  --> $DIR/resolved-region-var-max-universe.rs:21:23
+   |
+LL |     [(); Parent::CT::<T>]:,
+   |                       ^ not found in this scope
+   |
+help: you might be missing a type parameter
+   |
+LL | fn check<T>/*<T>*/()
+   |         +++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0425`.


### PR DESCRIPTION
Fixes rust-lang/rust#157862

The ICE comes from computing the max universe of a region constraint after a region var has already been unified with something else. In that state, asking universe_of_lt directly can hit None and panic.

This makes the region visitor opportunistically resolve ReVars first, then inspect the resolved region. Type and const infer vars stay as-is because this path already bails on non-region inference before it needs more structure from them.