### PR TITLE
enabling instrumentation for stage 3 compilers

### DIFF
--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -1297,7 +1297,7 @@ pub fn rustc_cargo(
         panic!("Cannot use and generate PGO profiles at the same time");
     }
     let is_collecting = if let Some(path) = &builder.config.rust_profile_generate {
-        if build_compiler.stage == 1 {
+        if build_compiler.stage >= 1 {
             cargo.rustflag(&format!("-Cprofile-generate={path}"));
             // Apparently necessary to avoid overflowing the counters during
             // a Cargo build profile
@@ -1307,7 +1307,7 @@ pub fn rustc_cargo(
             false
         }
     } else if let Some(path) = &builder.config.rust_profile_use {
-        if build_compiler.stage == 1 {
+        if build_compiler.stage >= 1 {
             cargo.rustflag(&format!("-Cprofile-use={path}"));
             if builder.is_verbose() {
                 cargo.rustflag("-Cllvm-args=-pgo-warn-missing-function");


### PR DESCRIPTION
This commit allows users to instrument their stage 3 compilers.

This PR is a revival of the following PR: https://github.com/rust-lang/rust/pull/101744

The aim is to break up the PR into smaller chunks and merge these changes in piecemeal. The PR here is to allow  us to instrument stage 3 rust compilers as stage 3 instrumentation is part of how we create profiles for guided optimization later on.

