### PR TITLE
Improve `declare_features!` macro error

### DIFF
--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -173,7 +173,8 @@ macro_rules! declare_features {
             pub fn incomplete(&self, feature: Symbol) -> bool {
                 match feature {
                     $(
-                        sym::$feature => status_to_enum!($status) == FeatureStatus::Incomplete,
+                        // Match guard to avoid duplicating `cannot find $feature in module sym` error.
+                        f if f == sym::$feature => status_to_enum!($status) == FeatureStatus::Incomplete,
                     )*
                     _ if self.enabled_features.contains(&feature) => {
                         // Accepted/removed features and library features aren't in this file but
@@ -189,7 +190,8 @@ macro_rules! declare_features {
             pub fn internal(&self, feature: Symbol) -> bool {
                 match feature {
                     $(
-                        sym::$feature => status_to_enum!($status) == FeatureStatus::Internal,
+                       // Match guard to avoid duplicating `cannot find $feature in module sym` error.
+                       f if f == sym::$feature => status_to_enum!($status) == FeatureStatus::Internal,
                     )*
                     _ if self.enabled_features.contains(&feature) => {
                         // This could be accepted/removed, or a libs feature.


### PR DESCRIPTION
I got mildly annoyed when I went to add a new feature, and the fix for this is relatively simple.

Current error:
```
error[E0425]: cannot find value `better_rust` in module `sym`                                                                                                                                                                                                                           
   --> compiler\rustc_feature\src\unstable.rs:240:16
    |
157 |                 name: sym::$feature,
    |                            -------- due to this macro variable
...
240 |     (internal, better_rust, "2.0.0", None),
    |                ^^^^^^^^^^^ not found in `sym`

For more information about this error, try `rustc --explain E0425`
```

Previous error:
```
error[E0425]: cannot find value `better_rust` in module `sym`                                                                                                                                                                                                                           
   --> compiler\rustc_feature\src\unstable.rs:240:16
    |
157 |                 name: sym::$feature,
    |                            -------- due to this macro variable
...
240 |     (internal, better_rust, "2.0.0", None),
    |                ^^^^^^^^^^^ not found in `sym`

error[E0531]: cannot find unit struct, unit variant or constant `better_rust` in module `sym`
   --> compiler\rustc_feature\src\unstable.rs:240:16
    |
157 |                 name: sym::$feature,
    |                            -------- due to this macro variable
...
240 |     (internal, better_rust, "2.0.0", None),
    |                ^^^^^^^^^^^ not found in `sym`

Some errors have detailed explanations: E0425, E0531.
```
