### PR TITLE
Use constant for detecting thin pointer formatting

### DIFF
--- a/library/core/src/fmt/mod.rs
+++ b/library/core/src/fmt/mod.rs
@@ -3000,7 +3000,7 @@ impl<T: PointeeSized> Pointer for *const T {
         // metadata type to reduce the amount of codegen work needed for each distinct type.
         let ptr: *const T = *self;
         let ptr_addr = ptr.expose_provenance();
-        if <<T as core::ptr::Pointee>::Metadata as core::unit::IsUnit>::is_unit() {
+        if <<T as core::ptr::Pointee>::Metadata as core::unit::IsUnit>::IS_UNIT {
             pointer_fmt_inner(ptr_addr, f)
         } else {
             wide_pointer_fmt_inner(ptr_addr, &core::ptr::metadata(ptr), f)

--- a/library/core/src/unit.rs
+++ b/library/core/src/unit.rs
@@ -1,3 +1,5 @@
+use crate::intrinsics::type_id;
+
 /// Collapses all unit items from an iterator into one.
 ///
 /// This is more useful when combined with higher-level abstractions, like
@@ -19,17 +21,10 @@ impl FromIterator<()> for () {
 }
 
 pub(crate) trait IsUnit {
-    fn is_unit() -> bool;
+    const IS_UNIT: bool;
 }
 
 impl<T: ?Sized> IsUnit for T {
-    default fn is_unit() -> bool {
-        false
-    }
-}
-
-impl IsUnit for () {
-    fn is_unit() -> bool {
-        true
-    }
+    // `type_id` erases lifetimes, but that's OK here because "is it ()" never depends on lifetimes
+    const IS_UNIT: bool = type_id::<Self>() == type_id::<()>();
 }


### PR DESCRIPTION
This allows codegen to prune the unnecessary side of the `if` for each pointer type during monomorphization. In release builds, LLVM can clean it up, but it's better to not emit unnecessary code in the first place.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
