### PR TITLE
Make `proc_macro::ConversionErrorKind` non exhaustive

### DIFF
--- a/library/proc_macro/src/lib.rs
+++ b/library/proc_macro/src/lib.rs
@@ -197,6 +197,7 @@ impl fmt::Display for EscapeError {
 /// Errors returned when trying to retrieve a literal unescaped value.
 #[unstable(feature = "proc_macro_value", issue = "136652")]
 #[derive(Debug, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum ConversionErrorKind {
     /// The literal failed to be escaped, take a look at [`EscapeError`] for more information.
     FailedToUnescape(EscapeError),


### PR DESCRIPTION
Needed for https://github.com/rust-lang/rust/pull/151973.

r? @traviscross 