### PR TITLE
Deny partial `-Z stack-protector` by default in all editions

### DIFF
--- a/compiler/rustc_session/src/options/mitigation_coverage.rs
+++ b/compiler/rustc_session/src/options/mitigation_coverage.rs
@@ -203,7 +203,9 @@ denied_partial_mitigations! {
     enum DeniedPartialMitigationKind {
         // The mitigation name should match the option name in rustc_session::options,
         // to allow for resetting the mitigation
-        (StackProtector, "stack-protector", EditionFuture, self.stack_protector()),
+
+        // stack-protector is an unstable option, so it can be denied-partial
+        (StackProtector, "stack-protector", Edition2015, self.stack_protector()),
         (ControlFlowGuard, "control-flow-guard", EditionFuture, self.opts.cg.control_flow_guard == CFGuard::Checks)
     }
 }

--- a/tests/assembly-llvm/stack-protector/stack-protector-heuristics-effect-2.rs
+++ b/tests/assembly-llvm/stack-protector/stack-protector-heuristics-effect-2.rs
@@ -7,7 +7,7 @@
 //@ [all] compile-flags: -Z stack-protector=all
 //@ [strong] compile-flags: -Z stack-protector=strong
 //@ [none] compile-flags: -Z stack-protector=none
-//@ compile-flags: -C opt-level=2 -Z merge-functions=disabled
+//@ compile-flags: -C opt-level=2 -Z merge-functions=disabled -Z allow-partial-mitigations=stack-protector
 
 #![crate_type = "lib"]
 #![allow(internal_features)]

--- a/tests/assembly-llvm/stack-protector/stack-protector-heuristics-effect-windows-32bit-2.rs
+++ b/tests/assembly-llvm/stack-protector/stack-protector-heuristics-effect-windows-32bit-2.rs
@@ -6,7 +6,7 @@
 //@ [all] compile-flags: -Z stack-protector=all
 //@ [strong] compile-flags: -Z stack-protector=strong
 //@ [none] compile-flags: -Z stack-protector=none
-//@ compile-flags: -C opt-level=2 -Z merge-functions=disabled
+//@ compile-flags: -Z allow-partial-mitigations=stack-protector -C opt-level=2 -Z merge-functions=disabled
 
 #![crate_type = "lib"]
 #![allow(internal_features)]

--- a/tests/assembly-llvm/stack-protector/stack-protector-heuristics-effect-windows-32bit.rs
+++ b/tests/assembly-llvm/stack-protector/stack-protector-heuristics-effect-windows-32bit.rs
@@ -7,7 +7,7 @@
 //@ [strong] compile-flags: -Z stack-protector=strong
 //@ [basic] compile-flags: -Z stack-protector=basic
 //@ [none] compile-flags: -Z stack-protector=none
-//@ compile-flags: -C opt-level=2 -Z merge-functions=disabled -Cpanic=abort -Cdebuginfo=1
+//@ compile-flags: -Z allow-partial-mitigations=stack-protector -C opt-level=2 -Z merge-functions=disabled -Cpanic=abort -Cdebuginfo=1
 
 #![crate_type = "lib"]
 #![allow(internal_features)]

--- a/tests/assembly-llvm/stack-protector/stack-protector-heuristics-effect-windows-64bit-2.rs
+++ b/tests/assembly-llvm/stack-protector/stack-protector-heuristics-effect-windows-64bit-2.rs
@@ -6,7 +6,7 @@
 //@ [all] compile-flags: -Z stack-protector=all
 //@ [strong] compile-flags: -Z stack-protector=strong
 //@ [none] compile-flags: -Z stack-protector=none
-//@ compile-flags: -C opt-level=2 -Z merge-functions=disabled
+//@ compile-flags: -Z allow-partial-mitigations=stack-protector -C opt-level=2 -Z merge-functions=disabled
 
 #![crate_type = "lib"]
 #![feature(unsized_fn_params)]

--- a/tests/assembly-llvm/stack-protector/stack-protector-heuristics-effect-windows-64bit.rs
+++ b/tests/assembly-llvm/stack-protector/stack-protector-heuristics-effect-windows-64bit.rs
@@ -7,7 +7,7 @@
 //@ [strong] compile-flags: -Z stack-protector=strong
 //@ [basic] compile-flags: -Z stack-protector=basic
 //@ [none] compile-flags: -Z stack-protector=none
-//@ compile-flags: -C opt-level=2 -Z merge-functions=disabled -Cpanic=abort
+//@ compile-flags: -Z allow-partial-mitigations=stack-protector -C opt-level=2 -Z merge-functions=disabled -Cpanic=abort
 
 #![crate_type = "lib"]
 #![feature(unsized_fn_params)]

--- a/tests/assembly-llvm/stack-protector/stack-protector-heuristics-effect.rs
+++ b/tests/assembly-llvm/stack-protector/stack-protector-heuristics-effect.rs
@@ -8,7 +8,7 @@
 //@ [strong] compile-flags: -Z stack-protector=strong
 //@ [basic] compile-flags: -Z stack-protector=basic
 //@ [none] compile-flags: -Z stack-protector=none
-//@ compile-flags: -C opt-level=2 -Z merge-functions=disabled
+//@ compile-flags: -C opt-level=2 -Z merge-functions=disabled -Z allow-partial-mitigations=stack-protector
 
 // NOTE: the heuristics for stack smash protection inappropriately rely on types in LLVM IR,
 // despite those types having no semantic meaning. This means that the `basic` and `strong`

--- a/tests/assembly-llvm/stack-protector/stack-protector-safe-stack.rs
+++ b/tests/assembly-llvm/stack-protector/stack-protector-safe-stack.rs
@@ -8,7 +8,7 @@
 //@ [safestack] compile-flags: -Z stack-protector=none -Z sanitizer=safestack
 //@ [safestack_strong] compile-flags: -Z stack-protector=strong -Z sanitizer=safestack
 //@ [safestack_all] compile-flags: -Z stack-protector=all -Z sanitizer=safestack
-//@ compile-flags: -C opt-level=2 -Z merge-functions=disabled --target x86_64-unknown-linux-gnu
+//@ compile-flags: -Z allow-partial-mitigations=stack-protector -C opt-level=2 -Z merge-functions=disabled --target x86_64-unknown-linux-gnu
 //@ needs-llvm-components: x86
 
 #![feature(unsized_fn_params)]

--- a/tests/assembly-llvm/stack-protector/stack-protector-target-support.rs
+++ b/tests/assembly-llvm/stack-protector/stack-protector-target-support.rs
@@ -173,7 +173,7 @@
 //@ [r84] needs-llvm-components: x86
 //@ [r85] compile-flags: --target x86_64-unknown-redox
 //@ [r85] needs-llvm-components: x86
-//@ compile-flags: -Z stack-protector=all -Cpanic=abort
+//@ compile-flags: -Z allow-partial-mitigations=stack-protector -Z stack-protector=all -Cpanic=abort
 //@ compile-flags: -C opt-level=2
 
 #![crate_type = "lib"]

--- a/tests/codegen-llvm/stack-protector.rs
+++ b/tests/codegen-llvm/stack-protector.rs
@@ -1,8 +1,8 @@
 //@ revisions: all strong basic none
 //@ ignore-nvptx64 stack protector not supported
-//@ [all] compile-flags: -Z stack-protector=all
-//@ [strong] compile-flags: -Z stack-protector=strong
-//@ [basic] compile-flags: -Z stack-protector=basic
+//@ [all] compile-flags: -Z stack-protector=all -Z allow-partial-mitigations=stack-protector
+//@ [strong] compile-flags: -Z stack-protector=strong -Z allow-partial-mitigations=stack-protector
+//@ [basic] compile-flags: -Z stack-protector=basic -Z allow-partial-mitigations=stack-protector
 
 #![crate_type = "lib"]
 

--- a/tests/ui/abi/stack-protector.rs
+++ b/tests/ui/abi/stack-protector.rs
@@ -1,7 +1,7 @@
 //@ run-pass
 //@ only-x86_64-unknown-linux-gnu
 //@ revisions: ssp no-ssp
-//@ [ssp] compile-flags: -Z stack-protector=all
+//@ [ssp] compile-flags: -Z stack-protector=all -Z allow-partial-mitigations=stack-protector
 //@ compile-flags: -C opt-level=2
 //@ compile-flags: -g
 //@ ignore-backends: gcc

--- a/tests/ui/allow-partial-mitigations/err-allow-partial-mitigations-current-edition.control-flow-2024-explicit-deny.stderr
+++ b/tests/ui/allow-partial-mitigations/err-allow-partial-mitigations-current-edition.control-flow-2024-explicit-deny.stderr
@@ -1,5 +1,5 @@
 error: your program uses the crate `std`, that is not compiled with `control-flow-guard` enabled
-  --> $DIR/err-allow-partial-mitigations-current-edition.rs:18:1
+  --> $DIR/err-allow-partial-mitigations-current-edition.rs:26:1
    |
 LL | fn main() {}
    | ^
@@ -8,7 +8,7 @@ LL | fn main() {}
    = help: it is possible to disable `-Z allow-partial-mitigations=control-flow-guard` via `-Z deny-partial-mitigations=control-flow-guard`
 
 error: your program uses the crate `core`, that is not compiled with `control-flow-guard` enabled
-  --> $DIR/err-allow-partial-mitigations-current-edition.rs:18:1
+  --> $DIR/err-allow-partial-mitigations-current-edition.rs:26:1
    |
 LL | fn main() {}
    | ^
@@ -17,7 +17,7 @@ LL | fn main() {}
    = help: it is possible to disable `-Z allow-partial-mitigations=control-flow-guard` via `-Z deny-partial-mitigations=control-flow-guard`
 
 error: your program uses the crate `alloc`, that is not compiled with `control-flow-guard` enabled
-  --> $DIR/err-allow-partial-mitigations-current-edition.rs:18:1
+  --> $DIR/err-allow-partial-mitigations-current-edition.rs:26:1
    |
 LL | fn main() {}
    | ^
@@ -26,7 +26,7 @@ LL | fn main() {}
    = help: it is possible to disable `-Z allow-partial-mitigations=control-flow-guard` via `-Z deny-partial-mitigations=control-flow-guard`
 
 error: your program uses the crate `compiler_builtins`, that is not compiled with `control-flow-guard` enabled
-  --> $DIR/err-allow-partial-mitigations-current-edition.rs:18:1
+  --> $DIR/err-allow-partial-mitigations-current-edition.rs:26:1
    |
 LL | fn main() {}
    | ^
@@ -35,7 +35,7 @@ LL | fn main() {}
    = help: it is possible to disable `-Z allow-partial-mitigations=control-flow-guard` via `-Z deny-partial-mitigations=control-flow-guard`
 
 error: your program uses the crate `unwind/libc`, that is not compiled with `control-flow-guard` enabled
-  --> $DIR/err-allow-partial-mitigations-current-edition.rs:18:1
+  --> $DIR/err-allow-partial-mitigations-current-edition.rs:26:1
    |
 LL | fn main() {}
    | ^

--- a/tests/ui/allow-partial-mitigations/err-allow-partial-mitigations-current-edition.rs
+++ b/tests/ui/allow-partial-mitigations/err-allow-partial-mitigations-current-edition.rs
@@ -1,5 +1,5 @@
 // ignore-tidy-linelength
-//@ revisions: control-flow-2024-explicit-deny
+//@ revisions: control-flow-2024-explicit-deny stack-protector-2024 stack-protector-2024-allow-deny-reset-by-mitigation stack-protector-2024-deny-reset-by-mitigation
 //@ check-fail
 //@ ignore-nvptx64 stack protector is not supported
 //@ ignore-wasm32-unknown-unknown stack protector is not supported
@@ -14,6 +14,14 @@
 
 //@ [control-flow-2024-explicit-deny] compile-flags: -C control-flow-guard=on -Z deny-partial-mitigations=control-flow-guard
 
+// check that explicit deny of stack-protector works in edition 2024
+//@ [stack-protector-2024-deny-reset-by-mitigation] compile-flags: -Z deny-partial-mitigations=stack-protector -Z stack-protector=all
+
+// check that this is the case even if there was an "allow" then a "deny"
+//@ [stack-protector-2024-allow-deny-reset-by-mitigation] compile-flags: -Z unstable-options -Z allow-partial-mitigations=stack-protector -Z deny-partial-mitigations=stack-protector -Z stack-protector=all
+
+// check that stack-protector is partial-denied in edition 2024
+//@ [stack-protector-2024] compile-flags: -Z stack-protector=all
 
 fn main() {}
 //~^ ERROR that is not compiled with

--- a/tests/ui/allow-partial-mitigations/err-allow-partial-mitigations-current-edition.stack-protector-2024-allow-deny-reset-by-mitigation.stderr
+++ b/tests/ui/allow-partial-mitigations/err-allow-partial-mitigations-current-edition.stack-protector-2024-allow-deny-reset-by-mitigation.stderr
@@ -1,0 +1,47 @@
+error: your program uses the crate `std`, that is not compiled with `stack-protector=all` enabled
+  --> $DIR/err-allow-partial-mitigations-current-edition.rs:26:1
+   |
+LL | fn main() {}
+   | ^
+   |
+   = note: recompile `std` with `stack-protector=all` enabled, or use `-Z allow-partial-mitigations=stack-protector` to allow creating an artifact that has the mitigation partially enabled
+   = help: it is possible to disable `-Z allow-partial-mitigations=stack-protector` via `-Z deny-partial-mitigations=stack-protector`
+
+error: your program uses the crate `core`, that is not compiled with `stack-protector=all` enabled
+  --> $DIR/err-allow-partial-mitigations-current-edition.rs:26:1
+   |
+LL | fn main() {}
+   | ^
+   |
+   = note: recompile `core` with `stack-protector=all` enabled, or use `-Z allow-partial-mitigations=stack-protector` to allow creating an artifact that has the mitigation partially enabled
+   = help: it is possible to disable `-Z allow-partial-mitigations=stack-protector` via `-Z deny-partial-mitigations=stack-protector`
+
+error: your program uses the crate `alloc`, that is not compiled with `stack-protector=all` enabled
+  --> $DIR/err-allow-partial-mitigations-current-edition.rs:26:1
+   |
+LL | fn main() {}
+   | ^
+   |
+   = note: recompile `alloc` with `stack-protector=all` enabled, or use `-Z allow-partial-mitigations=stack-protector` to allow creating an artifact that has the mitigation partially enabled
+   = help: it is possible to disable `-Z allow-partial-mitigations=stack-protector` via `-Z deny-partial-mitigations=stack-protector`
+
+error: your program uses the crate `compiler_builtins`, that is not compiled with `stack-protector=all` enabled
+  --> $DIR/err-allow-partial-mitigations-current-edition.rs:26:1
+   |
+LL | fn main() {}
+   | ^
+   |
+   = note: recompile `compiler_builtins` with `stack-protector=all` enabled, or use `-Z allow-partial-mitigations=stack-protector` to allow creating an artifact that has the mitigation partially enabled
+   = help: it is possible to disable `-Z allow-partial-mitigations=stack-protector` via `-Z deny-partial-mitigations=stack-protector`
+
+error: your program uses the crate `unwind/libc`, that is not compiled with `stack-protector=all` enabled
+  --> $DIR/err-allow-partial-mitigations-current-edition.rs:26:1
+   |
+LL | fn main() {}
+   | ^
+   |
+   = note: recompile `unwind/libc` with `stack-protector=all` enabled, or use `-Z allow-partial-mitigations=stack-protector` to allow creating an artifact that has the mitigation partially enabled
+   = help: it is possible to disable `-Z allow-partial-mitigations=stack-protector` via `-Z deny-partial-mitigations=stack-protector`
+
+error: aborting due to 5 previous errors
+

--- a/tests/ui/allow-partial-mitigations/err-allow-partial-mitigations-current-edition.stack-protector-2024-deny-reset-by-mitigation.stderr
+++ b/tests/ui/allow-partial-mitigations/err-allow-partial-mitigations-current-edition.stack-protector-2024-deny-reset-by-mitigation.stderr
@@ -1,0 +1,47 @@
+error: your program uses the crate `std`, that is not compiled with `stack-protector=all` enabled
+  --> $DIR/err-allow-partial-mitigations-current-edition.rs:26:1
+   |
+LL | fn main() {}
+   | ^
+   |
+   = note: recompile `std` with `stack-protector=all` enabled, or use `-Z allow-partial-mitigations=stack-protector` to allow creating an artifact that has the mitigation partially enabled
+   = help: it is possible to disable `-Z allow-partial-mitigations=stack-protector` via `-Z deny-partial-mitigations=stack-protector`
+
+error: your program uses the crate `core`, that is not compiled with `stack-protector=all` enabled
+  --> $DIR/err-allow-partial-mitigations-current-edition.rs:26:1
+   |
+LL | fn main() {}
+   | ^
+   |
+   = note: recompile `core` with `stack-protector=all` enabled, or use `-Z allow-partial-mitigations=stack-protector` to allow creating an artifact that has the mitigation partially enabled
+   = help: it is possible to disable `-Z allow-partial-mitigations=stack-protector` via `-Z deny-partial-mitigations=stack-protector`
+
+error: your program uses the crate `alloc`, that is not compiled with `stack-protector=all` enabled
+  --> $DIR/err-allow-partial-mitigations-current-edition.rs:26:1
+   |
+LL | fn main() {}
+   | ^
+   |
+   = note: recompile `alloc` with `stack-protector=all` enabled, or use `-Z allow-partial-mitigations=stack-protector` to allow creating an artifact that has the mitigation partially enabled
+   = help: it is possible to disable `-Z allow-partial-mitigations=stack-protector` via `-Z deny-partial-mitigations=stack-protector`
+
+error: your program uses the crate `compiler_builtins`, that is not compiled with `stack-protector=all` enabled
+  --> $DIR/err-allow-partial-mitigations-current-edition.rs:26:1
+   |
+LL | fn main() {}
+   | ^
+   |
+   = note: recompile `compiler_builtins` with `stack-protector=all` enabled, or use `-Z allow-partial-mitigations=stack-protector` to allow creating an artifact that has the mitigation partially enabled
+   = help: it is possible to disable `-Z allow-partial-mitigations=stack-protector` via `-Z deny-partial-mitigations=stack-protector`
+
+error: your program uses the crate `unwind/libc`, that is not compiled with `stack-protector=all` enabled
+  --> $DIR/err-allow-partial-mitigations-current-edition.rs:26:1
+   |
+LL | fn main() {}
+   | ^
+   |
+   = note: recompile `unwind/libc` with `stack-protector=all` enabled, or use `-Z allow-partial-mitigations=stack-protector` to allow creating an artifact that has the mitigation partially enabled
+   = help: it is possible to disable `-Z allow-partial-mitigations=stack-protector` via `-Z deny-partial-mitigations=stack-protector`
+
+error: aborting due to 5 previous errors
+

--- a/tests/ui/allow-partial-mitigations/err-allow-partial-mitigations-current-edition.stack-protector-2024.stderr
+++ b/tests/ui/allow-partial-mitigations/err-allow-partial-mitigations-current-edition.stack-protector-2024.stderr
@@ -1,0 +1,47 @@
+error: your program uses the crate `std`, that is not compiled with `stack-protector=all` enabled
+  --> $DIR/err-allow-partial-mitigations-current-edition.rs:26:1
+   |
+LL | fn main() {}
+   | ^
+   |
+   = note: recompile `std` with `stack-protector=all` enabled, or use `-Z allow-partial-mitigations=stack-protector` to allow creating an artifact that has the mitigation partially enabled
+   = help: it is possible to disable `-Z allow-partial-mitigations=stack-protector` via `-Z deny-partial-mitigations=stack-protector`
+
+error: your program uses the crate `core`, that is not compiled with `stack-protector=all` enabled
+  --> $DIR/err-allow-partial-mitigations-current-edition.rs:26:1
+   |
+LL | fn main() {}
+   | ^
+   |
+   = note: recompile `core` with `stack-protector=all` enabled, or use `-Z allow-partial-mitigations=stack-protector` to allow creating an artifact that has the mitigation partially enabled
+   = help: it is possible to disable `-Z allow-partial-mitigations=stack-protector` via `-Z deny-partial-mitigations=stack-protector`
+
+error: your program uses the crate `alloc`, that is not compiled with `stack-protector=all` enabled
+  --> $DIR/err-allow-partial-mitigations-current-edition.rs:26:1
+   |
+LL | fn main() {}
+   | ^
+   |
+   = note: recompile `alloc` with `stack-protector=all` enabled, or use `-Z allow-partial-mitigations=stack-protector` to allow creating an artifact that has the mitigation partially enabled
+   = help: it is possible to disable `-Z allow-partial-mitigations=stack-protector` via `-Z deny-partial-mitigations=stack-protector`
+
+error: your program uses the crate `compiler_builtins`, that is not compiled with `stack-protector=all` enabled
+  --> $DIR/err-allow-partial-mitigations-current-edition.rs:26:1
+   |
+LL | fn main() {}
+   | ^
+   |
+   = note: recompile `compiler_builtins` with `stack-protector=all` enabled, or use `-Z allow-partial-mitigations=stack-protector` to allow creating an artifact that has the mitigation partially enabled
+   = help: it is possible to disable `-Z allow-partial-mitigations=stack-protector` via `-Z deny-partial-mitigations=stack-protector`
+
+error: your program uses the crate `unwind/libc`, that is not compiled with `stack-protector=all` enabled
+  --> $DIR/err-allow-partial-mitigations-current-edition.rs:26:1
+   |
+LL | fn main() {}
+   | ^
+   |
+   = note: recompile `unwind/libc` with `stack-protector=all` enabled, or use `-Z allow-partial-mitigations=stack-protector` to allow creating an artifact that has the mitigation partially enabled
+   = help: it is possible to disable `-Z allow-partial-mitigations=stack-protector` via `-Z deny-partial-mitigations=stack-protector`
+
+error: aborting due to 5 previous errors
+

--- a/tests/ui/allow-partial-mitigations/ok-allow-partial-mitigations-current-edition.rs
+++ b/tests/ui/allow-partial-mitigations/ok-allow-partial-mitigations-current-edition.rs
@@ -1,5 +1,5 @@
 // ignore-tidy-linelength
-//@ revisions: control-flow-guard-2024-default control-flow-guard-2024-deny-reset-by-mitigation stack-protector-2024-deny-reset-by-mitigation stack-protector-2024-allow-deny-reset-by-mitigation
+//@ revisions: control-flow-guard-2024-default control-flow-guard-2024-deny-reset-by-mitigation stack-protector-2024-explicit-allow
 //@ check-pass
 //@ ignore-nvptx64 stack protector is not supported
 //@ ignore-wasm32-unknown-unknown stack protector is not supported
@@ -15,11 +15,7 @@
 // test that -C control-flow-guard=on resets -Z deny-partial-mitigations=control-flow-guard
 //@ [control-flow-guard-2024-deny-reset-by-mitigation] compile-flags: -Z deny-partial-mitigations=control-flow-guard -C control-flow-guard=on
 
-// same but for stack-protector, to match the stack-protector-future-deny-reset-by-mitigation test in
-// err-allow-partial-mitigations-1-error (which has the same args but on edition=future).
-//@ [stack-protector-2024-deny-reset-by-mitigation] compile-flags: -Z deny-partial-mitigations=stack-protector -Z stack-protector=all
-
-// check that this is the case even if there was an "allow" then a "deny"
-//@ [stack-protector-2024-allow-deny-reset-by-mitigation] compile-flags: -Z unstable-options -Z allow-partial-mitigations=stack-protector -Z deny-partial-mitigations=stack-protector -Z stack-protector=all
+// also test that stack protector is fine in edition 2024 with an explicit allow
+//@ [stack-protector-2024-explicit-allow] compile-flags: -Z stack-protector=all -Z allow-partial-mitigations=stack-protector
 
 fn main() {}


### PR DESCRIPTION
This enables RFC 3855 for stack-protector. With this PR, uses of stack-protector that only have it enabled for a subset of the crates within a process need to pass `-Z allow-partial-mitigations=stack-protector` as well.

This was not done in rust-lang/rust#149357 to allow for a smooth transition period.

cc the stack-protector tracking issue at rust-lang/rust#114903.

r? @rcvalle (do we need any special protocol for the breaking change?)