### PR TITLE
Do not use desugared local names in tail_expr_drop_order diagnostics

### DIFF
--- a/compiler/rustc_mir_transform/src/lint_tail_expr_drop_order.rs
+++ b/compiler/rustc_mir_transform/src/lint_tail_expr_drop_order.rs
@@ -466,6 +466,7 @@ fn collect_user_names(body: &Body<'_>) -> FxIndexMap<Local, Symbol> {
     for var_debug_info in &body.var_debug_info {
         if let mir::VarDebugInfoContents::Place(place) = &var_debug_info.value
             && let Some(local) = place.local_or_deref_local()
+            && !body.local_decls[local].from_compiler_desugaring()
         {
             names.entry(local).or_insert(var_debug_info.name);
         }

--- a/tests/ui/drop/tail_expr_drop_order-on-coroutine-unwind.rs
+++ b/tests/ui/drop/tail_expr_drop_order-on-coroutine-unwind.rs
@@ -26,3 +26,18 @@ async fn retry_db() -> Result<(), Drop> {
 }
 
 fn main() {}
+
+// Regression test for https://github.com/rust-lang/rust/issues/136206:
+// a user-written binding named `__awaitee` is still a user-visible name.
+impl Drop {
+    fn get(&self) -> u8 {
+        0
+    }
+}
+
+fn user_written_awaitee() -> u8 {
+    let __awaitee = Drop;
+    __awaitee.get() + Drop.get()
+    //~^ ERROR relative drop order changing in Rust 2024
+    //~| WARNING this changes meaning in Rust 2024
+}

--- a/tests/ui/drop/tail_expr_drop_order-on-coroutine-unwind.stderr
+++ b/tests/ui/drop/tail_expr_drop_order-on-coroutine-unwind.stderr
@@ -4,14 +4,14 @@ error: relative drop order changing in Rust 2024
 LL |         match func().await {
    |               ^^^^^^^-----
    |               |      |
-   |               |      this value will be stored in a temporary; let us call it `#3`
-   |               |      up until Edition 2021 `#3` is dropped last but will be dropped earlier in Edition 2024
-   |               |      this value will be stored in a temporary; let us call it `#1`
-   |               |      `#1` will be dropped later as of Edition 2024
-   |               this value will be stored in a temporary; let us call it `#2`
-   |               up until Edition 2021 `#2` is dropped last but will be dropped earlier in Edition 2024
-   |               `__awaitee` calls a custom destructor
-   |               `__awaitee` will be dropped later as of Edition 2024
+   |               |      this value will be stored in a temporary; let us call it `#4`
+   |               |      up until Edition 2021 `#4` is dropped last but will be dropped earlier in Edition 2024
+   |               |      this value will be stored in a temporary; let us call it `#2`
+   |               |      `#2` will be dropped later as of Edition 2024
+   |               this value will be stored in a temporary; let us call it `#3`
+   |               up until Edition 2021 `#3` is dropped last but will be dropped earlier in Edition 2024
+   |               this value will be stored in a temporary; let us call it `#1`
+   |               `#1` will be dropped later as of Edition 2024
 ...
 LL |             Err(e) => {}
    |                 -
@@ -22,12 +22,12 @@ LL |         }
 LL |     }
    |     - now the temporary value is dropped here, before the local variables in the block or statement
    |
-note: `#2` invokes this custom destructor
+note: `#3` invokes this custom destructor
   --> $DIR/tail_expr_drop_order-on-coroutine-unwind.rs:9:1
    |
 LL | impl std::ops::Drop for Drop {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: `#1` invokes this custom destructor
+note: `#2` invokes this custom destructor
   --> $DIR/tail_expr_drop_order-on-coroutine-unwind.rs:9:1
    |
 LL | impl std::ops::Drop for Drop {

--- a/tests/ui/drop/tail_expr_drop_order-on-coroutine-unwind.stderr
+++ b/tests/ui/drop/tail_expr_drop_order-on-coroutine-unwind.stderr
@@ -46,5 +46,36 @@ note: the lint level is defined here
 LL | #![deny(tail_expr_drop_order)]
    |         ^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 1 previous error
+error: relative drop order changing in Rust 2024
+  --> $DIR/tail_expr_drop_order-on-coroutine-unwind.rs:40:23
+   |
+LL |     let __awaitee = Drop;
+   |         ---------
+   |         |
+   |         `__awaitee` calls a custom destructor
+   |         `__awaitee` will be dropped later as of Edition 2024
+LL |     __awaitee.get() + Drop.get()
+   |                       ^^^^
+   |                       |
+   |                       this value will be stored in a temporary; let us call it `#1`
+   |                       up until Edition 2021 `#1` is dropped last but will be dropped earlier in Edition 2024
+...
+LL | }
+   | - now the temporary value is dropped here, before the local variables in the block or statement
+   |
+note: `#1` invokes this custom destructor
+  --> $DIR/tail_expr_drop_order-on-coroutine-unwind.rs:9:1
+   |
+LL | impl std::ops::Drop for Drop {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: `__awaitee` invokes this custom destructor
+  --> $DIR/tail_expr_drop_order-on-coroutine-unwind.rs:9:1
+   |
+LL | impl std::ops::Drop for Drop {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: most of the time, changing drop order is harmless; inspect the `impl Drop`s for side effects like releasing locks or sending messages
+   = warning: this changes meaning in Rust 2024
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-tail-expr-scope.html>
+
+error: aborting due to 2 previous errors
 


### PR DESCRIPTION
`tail_expr_drop_order` labels values using names from `body.var_debug_info`.
That works for user-written bindings, but `.await` lowering also introduces a synthetic `__awaitee` binding for debuginfo. This can leak into the user-facing lint diagnostic.

This PR filters collected diagnostic names through `LocalDecl::from_compiler_desugaring()`, so compiler-generated locals fall back to the existing `#N` temporary labels. This does not change async lowering or the `__awaitee` debuginfo name itself.

A user-written binding named `__awaitee` is still treated as user-written and is still shown by name.

Fixes rust-lang/rust#136206