### PR TITLE
Make `char::is_default_ignorable` unstably public

### DIFF
--- a/library/core/src/char/methods.rs
+++ b/library/core/src/char/methods.rs
@@ -1241,7 +1241,8 @@ impl char {
     ///
     /// Basic usage:
     ///
-    /// ```ignore(private)
+    /// ```
+    /// #![feature(default_ignorable)]
     /// assert!('\u{AD}'.is_default_ignorable()); // SOFT HYPHEN
     /// assert!('\u{115F}'.is_default_ignorable()); // HANGUL CHOSEONG FILLER
     /// assert!('\u{200B}'.is_default_ignorable()); // ZERO WIDTH SPACE
@@ -1252,9 +1253,11 @@ impl char {
     /// assert!(!'\n'.is_default_ignorable());
     /// assert!(!'\0'.is_default_ignorable());
     /// assert!(!'q'.is_default_ignorable());
+    /// ```
     #[must_use]
+    #[unstable(feature = "default_ignorable", issue = "160583")]
     #[inline]
-    fn is_default_ignorable(self) -> bool {
+    pub fn is_default_ignorable(self) -> bool {
         self > '\u{AC}' && unicode::Default_Ignorable_Code_Point(self)
     }
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->


Similar to https://github.com/rust-lang/rust/pull/154849; this function is used in the implementation of `char::escape_debug()`, and there's no reason to force crates to duplicate a data table that std has to ship anyway.

I'll add a tracking issue if this is approved.

(I'll do the other data tables from https://github.com/rust-lang/rust/pull/155527 in separate PRs.)

@rustbot label A-Unicode T-libs-api

Tracking issue: rust-lang/rust#160583

r? @Mark-Simulacrum