### PR TITLE
mir-opt: add BoolChainOpt pass scaffold to fold pure bool && chains

### DIFF
--- a/compiler/rustc_mir_transform/src/bool_chain_opt.rs
+++ b/compiler/rustc_mir_transform/src/bool_chain_opt.rs
@@ -1,0 +1,56 @@
+//! Folds chains of `&&` over pure boolean expressions into `BitAnd` BinOps,
+//! eliminating the phi nodes that LLVM cannot optimize away.
+
+use crate::MirPass;
+use rustc_middle::mir::*;
+use rustc_middle::ty::{self, TyCtxt};
+
+pub(crate) struct BoolChainOpt;
+
+impl<'tcx> MirPass<'tcx> for BoolChainOpt {
+    fn is_enabled(&self, sess: &rustc_session::Session) -> bool {
+        sess.mir_opt_level() >= 2
+    }
+
+    fn is_required(&self) -> bool {
+        false
+    }
+
+    fn run_pass(&self, tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
+        let typing_env = ty::TypingEnv::post_analysis(tcx, body.source.def_id());
+
+        for (_bb, data) in body.basic_blocks.iter_enumerated() {
+            let TerminatorKind::SwitchInt { discr, targets } = &data.terminator().kind else {
+                continue;
+            };
+
+            if targets.all_targets().len() != 2 {
+                continue;
+            }
+
+            let place = match discr {
+                Operand::Copy(p) | Operand::Move(p) => p,
+                _ => continue,
+            };
+
+            if !place.projection.is_empty() {
+                continue;
+            }
+
+            let local = place.local;
+            let local_ty = body.local_decls[local].ty;
+            if !local_ty.is_bool() {
+                continue;
+            }
+
+            let all_storage = data.statements.iter().all(|s| {
+                matches!(s.kind, StatementKind::StorageLive(_) | StatementKind::StorageDead(_))
+            });
+            if !all_storage {
+                continue;
+            }
+        }
+
+        let _ = typing_env;
+    }
+}

--- a/compiler/rustc_mir_transform/src/lib.rs
+++ b/compiler/rustc_mir_transform/src/lib.rs
@@ -36,6 +36,7 @@ use std::sync::LazyLock;
 
 use pass_manager::{self as pm, Lint, MirLint, MirPass, WithMinOptLevel};
 
+mod bool_chain_opt;
 mod check_pointers;
 mod cost_checker;
 mod cross_crate_inline;
@@ -750,6 +751,7 @@ pub(crate) fn run_optimization_passes<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'
             // optimizations. This invalidates CFG caches, so avoid putting between
             // `ReferencePropagation` and `GVN` which both use the dominator tree.
             &instsimplify::InstSimplify::AfterSimplifyCfg,
+                &bool_chain_opt::BoolChainOpt,
             // After `InstSimplify-after-simplifycfg` with `-Zub_checks=false`, simplify
             // ```
             // _13 = const false;

--- a/tests/mir-opt/bool_chain_opt.rs
+++ b/tests/mir-opt/bool_chain_opt.rs
@@ -1,0 +1,16 @@
+// MIR opt test: verifica que chains de && sobre bools puros
+// são folded em BitAnd, eliminando phi nodes.
+//
+// EMIT_MIR bool_chain_opt.eq.BoolChainOpt.diff
+
+pub struct S {
+    pub a: u32,
+    pub b: u32,
+    pub c: u32,
+    pub d: u32,
+}
+
+// EMIT_MIR bool_chain_opt.eq.BoolChainOpt.diff
+pub fn eq(x: &S, y: &S) -> bool {
+    x.a == y.a && x.b == y.b && x.c == y.c && x.d == y.d
+}


### PR DESCRIPTION
Add initial scaffolding for a MIR optimization pass that detects chains
of `&&` operators over pure boolean expressions and prepares to fold them
into `BitAnd` BinOps, eliminating phi nodes that LLVM cannot optimize away.

## Motivation

When `a && b && c && d` is lowered to MIR, each operand gets its own
`BasicBlock` with a `SwitchInt` terminator. This produces phi nodes in
LLVM IR that `mem2reg` and `instcombine` cannot eliminate, because the
short-circuit CFG structure prevents LLVM from proving side-effect-freedom.

Clang compiles equivalent C++ to a flat sequence of `and i1` instructions
that LLVM can vectorize with SSE2/AVX2. Rust produces a chain of branches.

## What this PR does

- Adds `compiler/rustc_mir_transform/src/bool_chain_opt.rs` with the pass
  skeleton: detects `SwitchInt` blocks over pure `bool` locals with no
  side-effecting statements
- Registers the pass after `InstSimplify::AfterSimplifyCfg` at mir-opt level 2
- Adds `tests/mir-opt/bool_chain_opt.rs` as the test fixture

The rewrite logic (emitting `BinOp(BitAnd, ...)`) will follow in the next
commit once the detection is reviewed and confirmed correct.

## Related

Fixes rust-lang/rust#83623

r? @nikic