### PR TITLE
Make `char::is_private_use` and `char::is_assigned` unstably public

### DIFF
--- a/library/core/src/char/methods.rs
+++ b/library/core/src/char/methods.rs
@@ -1139,8 +1139,9 @@ impl char {
     /// [`UnicodeData.txt`]: https://www.unicode.org/Public/UCD/latest/ucd/UnicodeData.txt
     ///
     #[must_use]
+    #[unstable(feature = "char_unassigned_private_use", issue = "none")]
     #[inline]
-    const fn is_private_use(self) -> bool {
+    pub const fn is_private_use(self) -> bool {
         // According to
         // https://www.unicode.org/policies/stability_policy.html#Property_Value,
         // the set of codepoints in `Co` will never change.

--- a/library/core/src/char/methods.rs
+++ b/library/core/src/char/methods.rs
@@ -495,7 +495,7 @@ impl char {
                 || args.escape_grapheme_extender && self.is_grapheme_extender()
                 || self.is_default_ignorable()
                 || self.is_format_control()
-                || self.is_unassigned() =>
+                || !self.is_assigned() =>
             {
                 EscapeDebug::unicode(self)
             }
@@ -1177,54 +1177,56 @@ impl char {
         self > '\u{AC}' && unicode::Cf(self)
     }
 
-    /// Returns `true` if this `char` has not yet been assigned a meaning by Unicode, as of
+    /// Returns `true` if this `char` has been assigned a meaning by Unicode, as of
     /// [`UNICODE_VERSION`].
     ///
     /// [`UNICODE_VERSION`]: Self::UNICODE_VERSION
-    ///
-    /// These characters may have a meaning assigned in the future,
-    /// except for the 66 [noncharacters] which will never be assigned a meaning.
-    ///
-    /// [noncharacters]: https://www.unicode.org/faq/private_use#noncharacters
     ///
     /// Many of Unicode's [stability policies] apply only to assigned characters.
     ///
     /// [stability policies]: https://www.unicode.org/policies/stability_policy.html
     ///
-    /// Unassigned characters (code points with the general category of `Cn`) are [described] in Chapter 4
-    /// (Character Properties) of the Unicode Standard, and [specified] in the Unicode Character Database
-    /// by their exclusion from [`UnicodeData.txt`].
+    /// Currently unassigned characters (characters for which this method returns `false`)
+    /// may have a meaning assigned in a future version of Unicode,
+    /// except for the 66 [noncharacters] which will never be assigned a meaning.
     ///
-    /// [described]: https://www.unicode.org/versions/latest/core-spec/chapter-4/#G134153
-    /// [specified]: https://www.unicode.org/reports/tr44/#GC_Values_Table
+    /// [noncharacters]: https://www.unicode.org/faq/private_use.html#noncharacters
+    ///
+    /// A character is considered assigned if it is present in [`UnicodeData.txt`].
+    /// Unassigned characters have general category `Cn`, as [described] in Chapter 4
+    /// (Character Properties) of the Unicode Standard.
+    ///
     /// [`UnicodeData.txt`]: https://www.unicode.org/Public/UCD/latest/ucd/UnicodeData.txt
+    /// [described]: https://www.unicode.org/versions/latest/core-spec/chapter-4/#G134153
     ///
     /// # Examples
     ///
     /// Basic usage:
     ///
-    /// ```ignore(private)
-    /// assert!('\u{FFFE}'.is_unassigned()); // noncharacter, will never be assigned
+    /// ```
+    /// #![feature(char_unassigned_private_use)]
+    /// assert!('γ'.is_assigned()); // once a character is assigned, it stays assigned forever
+    /// assert!(!'\u{FFFE}'.is_assigned()); // noncharacter, will never be assigned
     ///
-    /// //assert!('\u{7AAAA}'.is_unassigned()); // not currently assigned, but may be in the future,
-    ///                                         // so we shouldn't rely on the current status
-    ///
-    /// assert!(!'γ'.is_unassigned()); // once a character is assigned, it stays assigned forever
+    /// // Not currently assigned, but may be in the future,
+    /// // so we shouldn't rely on the current status
+    /// /* assert!(!'\u{7AAAA}'.is_assigned()); */
     /// ```
     #[must_use]
+    #[unstable(feature = "char_unassigned_private_use", issue = "none")]
     #[inline]
-    fn is_unassigned(self) -> bool {
+    pub fn is_assigned(self) -> bool {
         match self {
-            '\0'..='\u{377}' => false,
-            '\u{378}'..='\u{3FFFD}' => unicode::Cn_planes_0_3(self),
+            '\0'..='\u{377}' => true,
+            '\u{378}'..='\u{3FFFD}' => !unicode::Cn_planes_0_3(self),
             // Assigned character ranges in planes 4 and above.
             // `src/tools/unicode-table-generator/src/main.rs` asserts that this is correct
             '\u{E0001}'
             | '\u{E0020}'..='\u{E007F}'
             | '\u{E0100}'..='\u{E01EF}'
             | '\u{F0000}'..='\u{FFFFD}'
-            | '\u{100000}'..='\u{10FFFD}' => false,
-            _ => true,
+            | '\u{100000}'..='\u{10FFFD}' => true,
+            _ => false,
         }
     }
 

--- a/library/core/src/char/methods.rs
+++ b/library/core/src/char/methods.rs
@@ -1139,7 +1139,7 @@ impl char {
     /// [`UnicodeData.txt`]: https://www.unicode.org/Public/UCD/latest/ucd/UnicodeData.txt
     ///
     #[must_use]
-    #[unstable(feature = "char_unassigned_private_use", issue = "none")]
+    #[unstable(feature = "char_unassigned_private_use", issue = "158322")]
     #[inline]
     pub const fn is_private_use(self) -> bool {
         // According to
@@ -1213,7 +1213,7 @@ impl char {
     /// /* assert!(!'\u{7AAAA}'.is_assigned()); */
     /// ```
     #[must_use]
-    #[unstable(feature = "char_unassigned_private_use", issue = "none")]
+    #[unstable(feature = "char_unassigned_private_use", issue = "158322")]
     #[inline]
     pub fn is_assigned(self) -> bool {
         match self {


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

See also https://github.com/rust-lang/rust/pull/157944, https://github.com/rust-lang/rust/pull/154849. These functions are used in the implementation of `char::escape_debug()`, and there's no reason to force crates to duplicate data tables that std has to ship anyway. `is_assigned` is especially useful because crates relying on the stability guarantees of the other Unicode methods in `char` may wish to reject unassigned characters where those guarantees do not hold.

I'll add a tracking issue if this is approved.

The `is_assigned` vs `is_unassigned` bikeshed probably needs libs-API review before merging?

@rustbot label A-Unicode T-libs-api

r? @Mark-Simulacrum