### PR TITLE
Configure Renovate for GitHub Actions

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,5 +3,19 @@
   // Let Renovatebot keep an opened issue that tracks our dependencies
   "dependencyDashboard": true,
   // Require manual approval from the Dependency Dashboard before opening PRs
-  "dependencyDashboardApproval": true
+  "dependencyDashboardApproval": true,
+  // Don't manage dependencies inside subtrees. They are updated upstream and
+  // synced in. See `src/doc/rustc-dev-guide/src/external-repos.md` for the list.
+  "ignorePaths": [
+    "compiler/rustc_codegen_cranelift/**",
+    "compiler/rustc_codegen_gcc/**",
+    "library/compiler-builtins/**",
+    "library/portable-simd/**",
+    "library/stdarch/**",
+    "src/doc/rustc-dev-guide/**",
+    "src/tools/clippy/**",
+    "src/tools/miri/**",
+    "src/tools/rust-analyzer/**",
+    "src/tools/rustfmt/**"
+  ]
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,5 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    // Pin GitHub Actions to their commit SHA digests
+    "helpers:pinGitHubActionDigests"
+  ],
   // Let Renovatebot keep an opened issue that tracks our dependencies
   "dependencyDashboard": true,
   // Require manual approval from the Dependency Dashboard before opening PRs

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,12 +3,5 @@
   // Let Renovatebot keep an opened issue that tracks our dependencies
   "dependencyDashboard": true,
   // Disable "normal" package updates
-  "enabledManagers": [],
-  // Update lockfiles once per week
-  "lockFileMaintenance": {
-    "enabled": true,
-    "schedule": [
-      "before 5am on Tuesday"
-    ]
-  }
+  "enabledManagers": []
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,6 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   // Let Renovatebot keep an opened issue that tracks our dependencies
   "dependencyDashboard": true,
-  // Disable "normal" package updates
-  "enabledManagers": []
+  // Require manual approval from the Dependency Dashboard before opening PRs
+  "dependencyDashboardApproval": true
 }


### PR DESCRIPTION
This sets up Renovate to keep our GitHub Actions pinned to commit SHAs and up to date, as a follow-up to rust-lang/rust#155089 where we pinned them by hand. The actual pinning is handled by the `helpers:pinGitHubActionDigests` preset.

For now every update has to be approved from the Dependency Dashboard before Renovate opens a PR. I expect this to be temporary while we get the config right, since it lets us preview what Renovate wants to do without flooding the PR list. Once the pinning and the update PRs look correct, we can drop the approval requirement for the github-actions manager and let those flow through automatically.

Renovate also skips the subtree paths, since those tools are maintained in their own repositories and synced back in, and rust-lang/rust#134127 showed what happens when it starts editing them directly. The lockfile maintenance job is gone as well, since it was broken anyway.

r? @marcoieni