### PR TITLE
fix(rustc_codegen_ssa): Use cg_operand for Freeze check

### DIFF
--- a/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
@@ -43,7 +43,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                 // If this is storing a &Freeze reference with a retag, record that it's not
                 // possible to perform writes through the stored pointer.
                 let flags = if let ty::Ref(_, pointee_ty, Mutability::Not) =
-                    operand.ty(self.mir, self.cx.tcx()).kind()
+                    cg_operand.layout.ty.kind()
                     && with_retag.yes()
                     && pointee_ty.is_freeze(self.cx.tcx(), self.cx.typing_env())
                 {

--- a/tests/ui/generics/ssa-rval-monomorphization-issue-157922.rs
+++ b/tests/ui/generics/ssa-rval-monomorphization-issue-157922.rs
@@ -1,0 +1,25 @@
+//@ build-pass
+// (codegen test)
+//
+// Ensure that the "freeze" check on stores works correctly in generic functions.
+// Regression test for [#157922](https://github.com/rust-lang/rust/issues/157922).
+
+pub trait Field {
+    type Value;
+}
+
+pub struct S<const P: u8>;
+
+impl<const P: u8> Field for S<P> {
+    type Value = ();
+}
+
+pub struct Foo<F: Field>(F::Value);
+
+fn f<const P: u8>(a: &Foo<S<P>>) {
+    let _f = if 1 > 0 { a } else { a };
+}
+
+pub fn main() {
+    f(&Foo::<S<7>>(()));
+}


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Hi, this is my first contribution, so please forgive my incorrect conventions...
I found that rust-lang/rust#157922 is simple issue.

Fixes https://github.com/rust-lang/rust/issues/157922

## Cause of issue

In `rustc_codegen_ssa/src/mir/rvalue.rs`, `Freeze` check is called for non-monomorphized operand pointee type of `RValue`.
Before this method call, there is already called `codegen_operand` method for the operand, so I use this for `Freeze` check.