### PR TITLE
perf: Inline some hot functions in FnDecl

### DIFF
--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -4084,7 +4084,8 @@ impl FnDeclFlags {
     /// argument, and no splatting.
     /// To modify these flags, use the `set_*` methods, for readability.
     // FIXME: use Default instead when that trait is const stable.
-    pub const fn default() -> Self {
+    #[inline]
+    pub fn default() -> Self {
         Self { flags: 0, splatted: 0 }
             .set_implicit_self(ImplicitSelfKind::None)
             .set_lifetime_elision_allowed(false)
@@ -4094,7 +4095,8 @@ impl FnDeclFlags {
 
     /// Set the implicit self kind.
     #[must_use = "this method does not modify the receiver"]
-    pub const fn set_implicit_self(mut self, implicit_self: ImplicitSelfKind) -> Self {
+    #[inline]
+    pub fn set_implicit_self(mut self, implicit_self: ImplicitSelfKind) -> Self {
         self.flags &= !Self::IMPLICIT_SELF_MASK;
 
         match implicit_self {
@@ -4110,7 +4112,8 @@ impl FnDeclFlags {
 
     /// Set the C-style variadic argument flag.
     #[must_use = "this method does not modify the receiver"]
-    pub const fn set_c_variadic(mut self, c_variadic: bool) -> Self {
+    #[inline]
+    pub fn set_c_variadic(mut self, c_variadic: bool) -> Self {
         if c_variadic {
             self.flags |= Self::C_VARIADIC_FLAG;
         } else {
@@ -4122,7 +4125,8 @@ impl FnDeclFlags {
 
     /// Set the lifetime elision allowed flag.
     #[must_use = "this method does not modify the receiver"]
-    pub const fn set_lifetime_elision_allowed(mut self, allowed: bool) -> Self {
+    #[inline]
+    pub fn set_lifetime_elision_allowed(mut self, allowed: bool) -> Self {
         if allowed {
             self.flags |= Self::LIFETIME_ELISION_ALLOWED_FLAG;
         } else {
@@ -4135,7 +4139,8 @@ impl FnDeclFlags {
     /// Set the splatted argument index.
     /// The number of function arguments is used for error checking.
     #[must_use = "this method does not modify the receiver"]
-    pub const fn set_splatted(
+    #[inline]
+    pub fn set_splatted(
         mut self,
         splatted: Option<u16>,
         args_len: usize,
@@ -4161,14 +4166,16 @@ impl FnDeclFlags {
 
     /// Set "no splatted arguments" for the function declaration.
     #[must_use = "this method does not modify the receiver"]
-    pub const fn set_no_splatted_args(mut self) -> Self {
+    #[inline]
+    pub fn set_no_splatted_args(mut self) -> Self {
         self.splatted = Self::NO_SPLATTED_ARG_INDEX;
 
         self
     }
 
     /// Get the implicit self kind.
-    pub const fn implicit_self(self) -> ImplicitSelfKind {
+    #[inline]
+    pub fn implicit_self(self) -> ImplicitSelfKind {
         match self.flags & Self::IMPLICIT_SELF_MASK {
             0 => ImplicitSelfKind::None,
             1 => ImplicitSelfKind::Imm,
@@ -4180,17 +4187,20 @@ impl FnDeclFlags {
     }
 
     /// Do the function arguments end with a C-style variadic argument?
-    pub const fn c_variadic(self) -> bool {
+    #[inline]
+    pub fn c_variadic(self) -> bool {
         self.flags & Self::C_VARIADIC_FLAG != 0
     }
 
     /// Is lifetime elision allowed?
-    pub const fn lifetime_elision_allowed(self) -> bool {
+    #[inline]
+    pub fn lifetime_elision_allowed(self) -> bool {
         self.flags & Self::LIFETIME_ELISION_ALLOWED_FLAG != 0
     }
 
     /// Get the splatted argument index, if any.
-    pub const fn splatted(self) -> Option<u16> {
+    #[inline]
+    pub fn splatted(self) -> Option<u16> {
         if self.splatted == Self::NO_SPLATTED_ARG_INDEX { None } else { Some(self.splatted) }
     }
 }
@@ -4228,22 +4238,29 @@ impl<'hir> FnDecl<'hir> {
         None
     }
 
+    #[inline]
     pub fn implicit_self(&self) -> ImplicitSelfKind {
         self.fn_decl_kind.implicit_self()
     }
 
+    #[inline]
     pub fn c_variadic(&self) -> bool {
         self.fn_decl_kind.c_variadic()
     }
 
+    #[inline]
     pub fn lifetime_elision_allowed(&self) -> bool {
         self.fn_decl_kind.lifetime_elision_allowed()
     }
 
+    #[inline]
     pub fn splatted(&self) -> Option<u16> {
         self.fn_decl_kind.splatted()
     }
 
+    /// Returns a dummy FnDecl with the given span, no inputs, no output, and lifetime elision
+    /// allowed.
+    #[inline]
     pub fn dummy(span: Span) -> Self {
         Self {
             inputs: &[],
@@ -4271,6 +4288,7 @@ pub enum ImplicitSelfKind {
 
 impl ImplicitSelfKind {
     /// Does this represent an implicit self?
+    #[inline]
     pub fn has_implicit_self(&self) -> bool {
         !matches!(*self, ImplicitSelfKind::None)
     }


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

This PR tries to fix a perf regression in 1 primary benchmark introduced by rust-lang/rust#157699, by inlining some hot functions.

Regression details: https://github.com/rust-lang/rust/pull/157699#issuecomment-4716030411