### PR TITLE
Lower paths to functions in const args as ConstKind::Error

### DIFF
--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
@@ -2935,8 +2935,19 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             Res::Def(DefKind::Static { .. }, _) => {
                 span_bug!(span, "use of bare `static` ConstArgKind::Path's not yet supported")
             }
+            Res::Def(DefKind::AssocFn, def_id) => {
+                self.dcx().span_delayed_bug(span, "function items cannot be used as const args");
+                let parent_args = ty::GenericArgs::identity_for_item(tcx, tcx.parent(def_id));
+                let args = self.lower_generic_args_of_assoc_item(
+                    span,
+                    def_id,
+                    path.segments.last().unwrap(),
+                    parent_args,
+                );
+                Const::zero_sized(tcx, Ty::new_fn_def(tcx, def_id, args))
+            }
             // FIXME(const_generics): create real const to allow fn items as const paths
-            Res::Def(DefKind::Fn | DefKind::AssocFn, did) => {
+            Res::Def(DefKind::Fn, did) => {
                 self.dcx().span_delayed_bug(span, "function items cannot be used as const args");
                 let args = self.lower_generic_args_of_path_segment(
                     span,

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
@@ -2935,53 +2935,17 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             Res::Def(DefKind::Static { .. }, _) => {
                 span_bug!(span, "use of bare `static` ConstArgKind::Path's not yet supported")
             }
-            Res::Def(DefKind::AssocFn, def_id) => {
-                self.dcx().span_delayed_bug(span, "function items cannot be used as const args");
-                let parent_args = ty::GenericArgs::identity_for_item(tcx, tcx.parent(def_id));
-                let args = self.lower_generic_args_of_assoc_item(
-                    span,
-                    def_id,
-                    path.segments.last().unwrap(),
-                    parent_args,
-                );
-                Const::zero_sized(tcx, Ty::new_fn_def(tcx, def_id, args))
+            // FIXME(const_generics): create real consts to allow fn items as const paths.
+            // Lowering these to recovered `FnDef` consts currently interacts poorly with WF
+            // checking: WF of a `FnDef` walks the function signature, so a signature that mentions
+            // the same function item as a const arg can recurse until it overflows/segfaults.
+            Res::Def(DefKind::Fn | DefKind::AssocFn, _) => {
+                let guar = self
+                    .dcx()
+                    .struct_span_err(span, "function items cannot be used as const args")
+                    .emit();
+                Const::new_error(tcx, guar)
             }
-            // FIXME(const_generics): create real const to allow fn items as const paths
-            Res::Def(DefKind::Fn, did) => {
-                self.dcx().span_delayed_bug(span, "function items cannot be used as const args");
-                let args = self.lower_generic_args_of_path_segment(
-                    span,
-                    did,
-                    path.segments.last().unwrap(),
-                );
-
-                if self.tcx().generics_of(did).own_synthetic_params_count() == 0 {
-                    // FIXME(156581): actually instantiate the binder correctly (turbofishing/fndef changes)
-                    ty::Const::zero_sized(tcx, Ty::new_fn_def(tcx, did, ty::Binder::dummy(args)))
-                } else {
-                    let tcx = self.tcx();
-                    let generics = tcx.generics_of(did);
-
-                    // Use infer tys for synthetic params; otherwise the impl header's trait ref may
-                    // contain callee-owned synthetic params and fail when instantiated with impl args.
-                    // See issue #155834
-                    let args = args.iter().enumerate().map(|(index, arg)| {
-                        let param = generics.param_at(index, tcx);
-                        if param.kind.is_synthetic() {
-                            self.ty_infer(Some(param), span).into()
-                        } else {
-                            arg
-                        }
-                    });
-
-                    // FIXME(156581): actually instantiate the binder correctly (turbofishing/fndef changes)
-                    ty::Const::zero_sized(
-                        tcx,
-                        Ty::new_fn_def(tcx, did, ty::Binder::dummy(args.collect::<Box<_>>())),
-                    )
-                }
-            }
-
             // Exhaustive match to be clear about what exactly we're considering to be
             // an invalid Res for a const path.
             res @ (Res::Def(

--- a/compiler/rustc_trait_selection/src/traits/wf.rs
+++ b/compiler/rustc_trait_selection/src/traits/wf.rs
@@ -830,13 +830,8 @@ impl<'a, 'tcx> TypeVisitor<TyCtxt<'tcx>> for WfPredicates<'a, 'tcx> {
                 // perfect and there may be ways to abuse the fact that we
                 // ignore requirements with escaping bound vars. That's a
                 // more general issue however.
-                // If this is the item whose signature is currently being checked,
-                // its output is already on the WF stack. Walking it again can
-                // recurse through recovery consts that mention the same fn item.
-                if did.as_local() != Some(self.body_def_id) {
-                    let fn_sig = tcx.fn_sig(did).instantiate(tcx, args).skip_norm_wip();
-                    fn_sig.output().skip_binder().visit_with(self);
-                }
+                let fn_sig = tcx.fn_sig(did).instantiate(tcx, args).skip_norm_wip();
+                fn_sig.output().skip_binder().visit_with(self);
 
                 let obligations = self.nominal_obligations(did, args);
                 self.out.extend(obligations);

--- a/compiler/rustc_trait_selection/src/traits/wf.rs
+++ b/compiler/rustc_trait_selection/src/traits/wf.rs
@@ -830,8 +830,13 @@ impl<'a, 'tcx> TypeVisitor<TyCtxt<'tcx>> for WfPredicates<'a, 'tcx> {
                 // perfect and there may be ways to abuse the fact that we
                 // ignore requirements with escaping bound vars. That's a
                 // more general issue however.
-                let fn_sig = tcx.fn_sig(did).instantiate(tcx, args).skip_norm_wip();
-                fn_sig.output().skip_binder().visit_with(self);
+                // If this is the item whose signature is currently being checked,
+                // its output is already on the WF stack. Walking it again can
+                // recurse through recovery consts that mention the same fn item.
+                if did.as_local() != Some(self.body_def_id) {
+                    let fn_sig = tcx.fn_sig(did).instantiate(tcx, args).skip_norm_wip();
+                    fn_sig.output().skip_binder().visit_with(self);
+                }
 
                 let obligations = self.nominal_obligations(did, args);
                 self.out.extend(obligations);

--- a/tests/crashes/138088.rs
+++ b/tests/crashes/138088.rs
@@ -1,5 +1,0 @@
-//@ known-bug: #138088
-#![feature(min_generic_const_args)]
-trait Bar {
-    fn x(&self) -> [i32; core::direct_const_arg!(Bar::x)];
-}

--- a/tests/ui/const-generics/fn-item-as-const-arg-137084.rs
+++ b/tests/ui/const-generics/fn-item-as-const-arg-137084.rs
@@ -7,8 +7,7 @@
 fn a<const b: i32>() {}
 fn d(e: &String) {
     a::<d>
-    //~^ ERROR mismatched types
-    //~| ERROR the constant `d` is not of type `i32`
+    //~^ ERROR function items cannot be used as const args
 }
 
 fn main() {}

--- a/tests/ui/const-generics/fn-item-as-const-arg-137084.stderr
+++ b/tests/ui/const-generics/fn-item-as-const-arg-137084.stderr
@@ -1,35 +1,8 @@
-error[E0308]: mismatched types
-  --> $DIR/fn-item-as-const-arg-137084.rs:9:5
-   |
-LL | fn a<const b: i32>() {}
-   | -------------------- function `a` defined here
-LL | fn d(e: &String) {
-LL |     a::<d>
-   |     ^^^^^^ expected `()`, found fn item
-   |
-   = note: expected unit type `()`
-                found fn item `fn() {a::<d>}`
-help: try adding a return type
-   |
-LL | fn d(e: &String) -> fn() {
-   |                  +++++++
-help: use parentheses to call this function
-   |
-LL |     a::<d>()
-   |           ++
-
-error: the constant `d` is not of type `i32`
+error: function items cannot be used as const args
   --> $DIR/fn-item-as-const-arg-137084.rs:9:9
    |
 LL |     a::<d>
-   |         ^ expected `i32`, found fn item
-   |
-note: required by a const generic parameter in `a`
-  --> $DIR/fn-item-as-const-arg-137084.rs:7:6
-   |
-LL | fn a<const b: i32>() {}
-   |      ^^^^^^^^^^^^ required by this const generic parameter in `a`
+   |         ^
 
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/const-generics/ice-151186-fn-ptr-in-where-clause.rs
+++ b/tests/ui/const-generics/ice-151186-fn-ptr-in-where-clause.rs
@@ -11,6 +11,6 @@ trait MyTrait<const F: fn() -> ()> {}
 fn foo<'a>(x: &'a ()) -> &'a () { x }
 
 impl<T> Maybe<T> for T where T: MyTrait<{ foo }> {}
-//~^ ERROR the constant `foo` is not of type `fn()`
+//~^ ERROR function items cannot be used as const args
 
 fn main() {}

--- a/tests/ui/const-generics/ice-151186-fn-ptr-in-where-clause.stderr
+++ b/tests/ui/const-generics/ice-151186-fn-ptr-in-where-clause.stderr
@@ -1,3 +1,9 @@
+error: function items cannot be used as const args
+  --> $DIR/ice-151186-fn-ptr-in-where-clause.rs:13:43
+   |
+LL | impl<T> Maybe<T> for T where T: MyTrait<{ foo }> {}
+   |                                           ^^^
+
 error: using function pointers as const generic parameters is forbidden
   --> $DIR/ice-151186-fn-ptr-in-where-clause.rs:8:24
    |
@@ -5,18 +11,6 @@ LL | trait MyTrait<const F: fn() -> ()> {}
    |                        ^^^^^^^^^^
    |
    = note: the only supported types are integers, `bool`, and `char`
-
-error: the constant `foo` is not of type `fn()`
-  --> $DIR/ice-151186-fn-ptr-in-where-clause.rs:13:33
-   |
-LL | impl<T> Maybe<T> for T where T: MyTrait<{ foo }> {}
-   |                                 ^^^^^^^^^^^^^^^^ expected fn pointer, found fn item
-   |
-note: required by a const generic parameter in `MyTrait`
-  --> $DIR/ice-151186-fn-ptr-in-where-clause.rs:8:15
-   |
-LL | trait MyTrait<const F: fn() -> ()> {}
-   |               ^^^^^^^^^^^^^^^^^^^ required by this const generic parameter in `MyTrait`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/mgca/bad-impl-trait-with-apit.rs
+++ b/tests/ui/const-generics/mgca/bad-impl-trait-with-apit.rs
@@ -6,7 +6,7 @@
 trait Trait {}
 
 impl<'t> Trait for [(); N] {}
-//~^ ERROR the placeholder `_` is not allowed within types on item signatures for implementations
+//~^ ERROR function items cannot be used as const args
 
 fn N(arg: impl Trait) {}
 

--- a/tests/ui/const-generics/mgca/bad-impl-trait-with-apit.stderr
+++ b/tests/ui/const-generics/mgca/bad-impl-trait-with-apit.stderr
@@ -1,9 +1,8 @@
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for implementations
+error: function items cannot be used as const args
   --> $DIR/bad-impl-trait-with-apit.rs:8:25
    |
 LL | impl<'t> Trait for [(); N] {}
-   |                         ^ not allowed in type signatures
+   |                         ^
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0121`.

--- a/tests/ui/const-generics/mgca/missing_generic_params.rs
+++ b/tests/ui/const-generics/mgca/missing_generic_params.rs
@@ -11,6 +11,6 @@
 #![allow(incomplete_features)]
 trait Trait {}
 impl Trait for [(); N] {}
-//~^ ERROR: missing generics for function `N`
+//~^ ERROR function items cannot be used as const args
 fn N<T>() {}
 pub fn main() {}

--- a/tests/ui/const-generics/mgca/missing_generic_params.stderr
+++ b/tests/ui/const-generics/mgca/missing_generic_params.stderr
@@ -1,19 +1,8 @@
-error[E0107]: missing generics for function `N`
+error: function items cannot be used as const args
   --> $DIR/missing_generic_params.rs:13:21
    |
 LL | impl Trait for [(); N] {}
-   |                     ^ expected 1 generic argument
-   |
-note: function defined here, with 1 generic parameter: `T`
-  --> $DIR/missing_generic_params.rs:15:4
-   |
-LL | fn N<T>() {}
-   |    ^ -
-help: add missing generic argument
-   |
-LL | impl Trait for [(); N<T>] {}
-   |                      +++
+   |                     ^
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0107`.

--- a/tests/ui/const-generics/mgca/size-of-generic-ptr-in-array-len.rs
+++ b/tests/ui/const-generics/mgca/size-of-generic-ptr-in-array-len.rs
@@ -4,7 +4,8 @@
 
 fn foo<T>() {
     [0; size_of::<*mut T>()];
-    //~^ ERROR: complex const arguments must be placed inside of a `const` block
+    //~^ ERROR function items cannot be used as const args
+    //~| ERROR tuple constructor with invalid base path
     [0; const { size_of::<*mut T>() }];
     //~^ ERROR: generic parameters may not be used in const operations
     [0; const { size_of::<*mut i32>() }];

--- a/tests/ui/const-generics/mgca/size-of-generic-ptr-in-array-len.stderr
+++ b/tests/ui/const-generics/mgca/size-of-generic-ptr-in-array-len.stderr
@@ -1,16 +1,22 @@
-error: complex const arguments must be placed inside of a `const` block
+error: function items cannot be used as const args
+  --> $DIR/size-of-generic-ptr-in-array-len.rs:6:9
+   |
+LL |     [0; size_of::<*mut T>()];
+   |         ^^^^^^^^^^^^^^^^^
+
+error: tuple constructor with invalid base path
   --> $DIR/size-of-generic-ptr-in-array-len.rs:6:9
    |
 LL |     [0; size_of::<*mut T>()];
    |         ^^^^^^^^^^^^^^^^^^^
 
 error: generic parameters may not be used in const operations
-  --> $DIR/size-of-generic-ptr-in-array-len.rs:8:32
+  --> $DIR/size-of-generic-ptr-in-array-len.rs:9:32
    |
 LL |     [0; const { size_of::<*mut T>() }];
    |                                ^
    |
    = help: add `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
-error: aborting due to 2 previous errors
+error: aborting due to 3 previous errors
 

--- a/tests/ui/const-generics/mgca/synth-gen-arg-ice-158152.rs
+++ b/tests/ui/const-generics/mgca/synth-gen-arg-ice-158152.rs
@@ -4,7 +4,7 @@ trait A<T> {}
 trait Trait<const N: usize> {}
 
 impl A<[usize; fn_item]> for () {}
-//~^ ERROR: the placeholder `_` is not allowed within types on item signatures for implementations
+//~^ ERROR function items cannot be used as const args
 
 fn fn_item(_: impl Trait<usize>) {}
 //~^ ERROR: type provided when a constant was expected

--- a/tests/ui/const-generics/mgca/synth-gen-arg-ice-158152.stderr
+++ b/tests/ui/const-generics/mgca/synth-gen-arg-ice-158152.stderr
@@ -1,8 +1,8 @@
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for implementations
+error: function items cannot be used as const args
   --> $DIR/synth-gen-arg-ice-158152.rs:6:16
    |
 LL | impl A<[usize; fn_item]> for () {}
-   |                ^^^^^^^ not allowed in type signatures
+   |                ^^^^^^^
 
 error[E0747]: type provided when a constant was expected
   --> $DIR/synth-gen-arg-ice-158152.rs:9:26
@@ -17,5 +17,4 @@ LL | fn fn_item(_: impl Trait<{ usize }>) {}
 
 error: aborting due to 2 previous errors
 
-Some errors have detailed explanations: E0121, E0747.
-For more information about an error, try `rustc --explain E0121`.
+For more information about this error, try `rustc --explain E0747`.

--- a/tests/ui/const-generics/mgca/trait-assoc-fn-as-const-arg.rs
+++ b/tests/ui/const-generics/mgca/trait-assoc-fn-as-const-arg.rs
@@ -1,10 +1,9 @@
 #![feature(min_generic_const_args)]
 
-// Regression test for #138088. assoc functions cannot be lowered as const
-// args, and this should emit a regular diagnostic instead of ICEing.
+// Regression test for #138088.
 trait Bar {
     fn x(&self) -> [i32; Bar::x];
-    //~^ ERROR the constant `<Self as Bar>::x` is not of type `usize`
+    //~^ ERROR cycle detected when evaluating type-level constant
 }
 
 fn main() {}

--- a/tests/ui/const-generics/mgca/trait-assoc-fn-as-const-arg.rs
+++ b/tests/ui/const-generics/mgca/trait-assoc-fn-as-const-arg.rs
@@ -1,0 +1,10 @@
+#![feature(min_generic_const_args)]
+
+// Regression test for #138088. assoc functions cannot be lowered as const
+// args, and this should emit a regular diagnostic instead of ICEing.
+trait Bar {
+    fn x(&self) -> [i32; Bar::x];
+    //~^ ERROR the constant `<Self as Bar>::x` is not of type `usize`
+}
+
+fn main() {}

--- a/tests/ui/const-generics/mgca/trait-assoc-fn-as-const-arg.stderr
+++ b/tests/ui/const-generics/mgca/trait-assoc-fn-as-const-arg.stderr
@@ -1,0 +1,10 @@
+error: the constant `<Self as Bar>::x` is not of type `usize`
+  --> $DIR/trait-assoc-fn-as-const-arg.rs:6:20
+   |
+LL |     fn x(&self) -> [i32; Bar::x];
+   |                    ^^^^^^^^^^^^^ expected `usize`, found fn item
+   |
+   = note: the length of array `[i32; <Self as Bar>::x]` must be type `usize`
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/const-generics/mgca/trait-assoc-fn-as-const-arg.stderr
+++ b/tests/ui/const-generics/mgca/trait-assoc-fn-as-const-arg.stderr
@@ -1,10 +1,19 @@
-error: the constant `<Self as Bar>::x` is not of type `usize`
-  --> $DIR/trait-assoc-fn-as-const-arg.rs:6:20
+error[E0391]: cycle detected when evaluating type-level constant
+  --> $DIR/trait-assoc-fn-as-const-arg.rs:5:26
    |
 LL |     fn x(&self) -> [i32; Bar::x];
-   |                    ^^^^^^^^^^^^^ expected `usize`, found fn item
+   |                          ^^^^^^
    |
-   = note: the length of array `[i32; <Self as Bar>::x]` must be type `usize`
+   = note: ...which requires const-evaluating + checking `Bar::x::{constant#0}`...
+   = note: ...which requires const-evaluating + checking `Bar::x::{constant#0}`...
+   = note: ...which requires checking if `Bar::x::{constant#0}` is a trivial const...
+   = note: ...which requires building MIR for `Bar::x::{constant#0}`...
+   = note: ...which requires match-checking `Bar::x::{constant#0}`...
+   = note: ...which requires type-checking `Bar::x::{constant#0}`...
+   = note: ...which again requires evaluating type-level constant, completing the cycle
+   = note: cycle used when checking that `Bar::x` is well-formed
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error: aborting due to 1 previous error
 
+For more information about this error, try `rustc --explain E0391`.

--- a/tests/ui/const-generics/mgca/tuple_ctor_erroneous.rs
+++ b/tests/ui/const-generics/mgca/tuple_ctor_erroneous.rs
@@ -32,7 +32,8 @@ fn test_errors<const N: usize>() {
     //~| ERROR tuple constructor with invalid base path
 
     accepts_point::<{ non_ctor(N, N) }>();
-    //~^ ERROR complex const arguments must be placed inside of a `const` block
+    //~^ ERROR function items cannot be used as const args
+    //~| ERROR tuple constructor with invalid base path
 
     accepts_point::<{ CONST_ITEM(N, N) }>();
     //~^ ERROR tuple constructor with invalid base path

--- a/tests/ui/const-generics/mgca/tuple_ctor_erroneous.stderr
+++ b/tests/ui/const-generics/mgca/tuple_ctor_erroneous.stderr
@@ -27,20 +27,26 @@ error: tuple constructor with invalid base path
 LL |     accepts_point::<{ UnresolvedIdent(N, N) }>();
    |                       ^^^^^^^^^^^^^^^^^^^^^
 
-error: complex const arguments must be placed inside of a `const` block
+error: function items cannot be used as const args
+  --> $DIR/tuple_ctor_erroneous.rs:34:23
+   |
+LL |     accepts_point::<{ non_ctor(N, N) }>();
+   |                       ^^^^^^^^
+
+error: tuple constructor with invalid base path
   --> $DIR/tuple_ctor_erroneous.rs:34:23
    |
 LL |     accepts_point::<{ non_ctor(N, N) }>();
    |                       ^^^^^^^^^^^^^^
 
 error: tuple constructor with invalid base path
-  --> $DIR/tuple_ctor_erroneous.rs:37:23
+  --> $DIR/tuple_ctor_erroneous.rs:38:23
    |
 LL |     accepts_point::<{ CONST_ITEM(N, N) }>();
    |                       ^^^^^^^^^^^^^^^^
 
 error: the constant `Point` is not of type `Point`
-  --> $DIR/tuple_ctor_erroneous.rs:40:23
+  --> $DIR/tuple_ctor_erroneous.rs:41:23
    |
 LL |     accepts_point::<{ Point }>();
    |                       ^^^^^ expected `Point`, found struct constructor
@@ -52,7 +58,7 @@ LL | fn accepts_point<const P: Point>() {}
    |                  ^^^^^^^^^^^^^^ required by this const generic parameter in `accepts_point`
 
 error: the constant `MyEnum::<u32>::Variant` is not of type `MyEnum<u32>`
-  --> $DIR/tuple_ctor_erroneous.rs:43:22
+  --> $DIR/tuple_ctor_erroneous.rs:44:22
    |
 LL |     accepts_enum::<{ MyEnum::Variant::<u32> }>();
    |                      ^^^^^^^^^^^^^^^^^^^^^^ expected `MyEnum<u32>`, found enum constructor
@@ -63,6 +69,6 @@ note: required by a const generic parameter in `accepts_enum`
 LL | fn accepts_enum<const E: MyEnum<u32>>() {}
    |                 ^^^^^^^^^^^^^^^^^^^^ required by this const generic parameter in `accepts_enum`
 
-error: aborting due to 8 previous errors
+error: aborting due to 9 previous errors
 
 For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/const-generics/mgca/unexpected-fn-item-in-array.rs
+++ b/tests/ui/const-generics/mgca/unexpected-fn-item-in-array.rs
@@ -5,7 +5,7 @@
 trait A<T> {}
 
 impl A<[usize; fn_item]> for () {}
-//~^ ERROR the constant `fn_item` is not of type `usize`
+//~^ ERROR function items cannot be used as const args
 
 fn fn_item() {}
 

--- a/tests/ui/const-generics/mgca/unexpected-fn-item-in-array.stderr
+++ b/tests/ui/const-generics/mgca/unexpected-fn-item-in-array.stderr
@@ -1,10 +1,8 @@
-error: the constant `fn_item` is not of type `usize`
-  --> $DIR/unexpected-fn-item-in-array.rs:7:6
+error: function items cannot be used as const args
+  --> $DIR/unexpected-fn-item-in-array.rs:7:16
    |
 LL | impl A<[usize; fn_item]> for () {}
-   |      ^^^^^^^^^^^^^^^^^^^ expected `usize`, found fn item
-   |
-   = note: the length of array `[usize; fn_item]` must be type `usize`
+   |                ^^^^^^^
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/157962)*
<!-- homu-ignore:end -->

closes: rust-lang/rust#138088

Lowering these to recovered `FnDef` consts currently interacts poorly with WF checking: WF of a `FnDef` walks the function signature, so a signature that mentions the same function item as a const arg can recurse until it overflows/segfaults. So, for now we are emitting ConstKind::Error

r? @BoxyUwU 