### PR TITLE
Preserve track_caller for by-value dyn vtable shims

### DIFF
--- a/compiler/rustc_middle/src/ty/instance.rs
+++ b/compiler/rustc_middle/src/ty/instance.rs
@@ -310,7 +310,9 @@ impl<'tcx> InstanceKind<'tcx> {
 
     pub fn requires_caller_location(&self, tcx: TyCtxt<'_>) -> bool {
         match *self {
-            InstanceKind::Item(def_id) | InstanceKind::Virtual(def_id, _) => {
+            InstanceKind::Item(def_id)
+            | InstanceKind::Virtual(def_id, _)
+            | InstanceKind::VTableShim(def_id) => {
                 tcx.body_codegen_attrs(def_id).flags.contains(CodegenFnAttrFlags::TRACK_CALLER)
             }
             InstanceKind::ClosureOnceShim { call_once: _, closure: _, track_caller } => {

--- a/tests/ui/unsized-locals/track-caller-vtable-shim.rs
+++ b/tests/ui/unsized-locals/track-caller-vtable-shim.rs
@@ -1,0 +1,21 @@
+//@ run-pass
+
+#![feature(unsized_fn_params)]
+#![allow(internal_features)]
+
+trait TrackedByValue {
+    #[track_caller]
+    fn consume(self, expected_line: u32);
+}
+
+impl TrackedByValue for u8 {
+    fn consume(self, expected_line: u32) {
+        assert_eq!(self, 7);
+        assert_eq!(std::panic::Location::caller().line(), expected_line);
+    }
+}
+
+fn main() {
+    let obj = Box::new(7_u8) as Box<dyn TrackedByValue>;
+    obj.consume(line!());
+}


### PR DESCRIPTION
Fixes rust-lang/rust#157964