### PR TITLE
bootstrap: fix panic on empty CPU list in build metrics

### DIFF
--- a/src/bootstrap/src/utils/metrics.rs
+++ b/src/bootstrap/src/utils/metrics.rs
@@ -170,7 +170,11 @@ impl BuildMetrics {
 
         let system_stats = JsonInvocationSystemStats {
             cpu_threads_count: system.cpus().len(),
-            cpu_model: system.cpus()[0].brand().into(),
+            cpu_model: system
+                .cpus()
+                .first()
+                .map(|cpu| cpu.brand().to_owned())
+                .unwrap_or_else(|| "unknown".to_owned()),
 
             memory_total_bytes: system.total_memory(),
         };


### PR DESCRIPTION
`system.cpus()[0]` panics with an index-out-of-bounds error when `sysinfo` cannot detect any CPUs, which can happen in Docker containers with cgroup restrictions, minimal VMs, or CI runners with unusual configurations.

This replaces the unchecked index with `.first()` and a fallback to `"unknown"`, matching the resilience of the adjacent `cpu_threads_count` field which already handles the empty case correctly by reporting `0`.

The original code was introduced in 70cdd7efc3ab (2022-06-04) as part of the build metrics system added in rust-lang/rust#93717.