### PR TITLE
Distinguish `repr(C)` ZSTs from others in ABI compatibility rules

### DIFF
--- a/library/core/src/primitive_docs.rs
+++ b/library/core/src/primitive_docs.rs
@@ -1847,6 +1847,7 @@ mod prim_ref {}
 ///   - Alignment 1
 ///   - Not `repr(C)`
 ///   - Not a `repr(transparent)` wrapper around a type that fails to satisfy these conditions
+///   - Not an array whose element type fails to satisfy these conditions
 /// - A `repr(transparent)` type is ABI-compatible with its unique field that does not have trivial ABI
 ///   (as defined above). If there is no such field, the type has trivial ABI.
 /// - A `repr(transparent)` type `T` is ABI-compatible with its unique non-trivial field, i.e., the

--- a/library/core/src/primitive_docs.rs
+++ b/library/core/src/primitive_docs.rs
@@ -1841,7 +1841,14 @@ mod prim_ref {}
 ///   call will be valid ABI-wise. The callee receives the result of transmuting the function pointer
 ///   from `fn()` to `fn(i32)`; that transmutation is itself a well-defined operation, it's just
 ///   almost certainly UB to later call that function pointer.)
-/// - Any two types with size 0 and alignment 1 are ABI-compatible.
+/// - Any two types fulfilling all the following conditions are ABI-compatible;
+///   such types are said to have "trivial ABI":
+///   - Size 0
+///   - Alignment 1
+///   - Not `repr(C)`
+///   - Not a `repr(transparent)` wrapper around a type that fails to satisfy these conditions
+/// - A `repr(transparent)` type is ABI-compatible with its unique field that does not have trivial ABI
+///   (as defined above). If there is no such field, the type has trivial ABI.
 /// - A `repr(transparent)` type `T` is ABI-compatible with its unique non-trivial field, i.e., the
 ///   unique field that doesn't have size 0 and alignment 1 (if there is such a field).
 /// - `i32` is ABI-compatible with `NonZero<i32>`, and similar for all other integer types.

--- a/library/core/src/primitive_docs.rs
+++ b/library/core/src/primitive_docs.rs
@@ -1846,7 +1846,7 @@ mod prim_ref {}
 ///   - It has size 0.
 ///   - It has alignment 1.
 ///   - One of the following apply:
-///     - It is a `repr(Rust)` (implicitly or explicitly, possibly with additional flags such as `packed`) `struct`, `enum`, `union` (regardless of its fields).
+///     - It is a `repr(Rust)` (implicitly or explicitly, possibly with additional modifiers such as `packed`) `struct`, `enum`, `union` (regardless of its fields).
 ///     - It is a [tuple][prim_tuple] (regardless of its fields, and including [`()`][prim_unit]).
 ///     - It is a `repr(transparent)` `struct`, `enum`, or `union`, and all fields have trivial ABI.
 ///     - It is an array, and its element type has trivial ABI. (This requirement applies even to arrays of length 0.)

--- a/library/core/src/primitive_docs.rs
+++ b/library/core/src/primitive_docs.rs
@@ -1853,7 +1853,7 @@ mod prim_ref {}
 ///     - It is [the never type `!`][prim_never].
 ///     - It is a function item type or closure type.
 /// - A `repr(transparent)` type is ABI-compatible with its unique field that does not have trivial ABI
-///   (as defined above), if such a field exists.
+///   (as defined above), if such a field exists. (Note that if no such field exists, then the `repr(transparent)` type itself has trivial ABI, so the case above applies.)
 /// - `i32` is ABI-compatible with `NonZero<i32>`, and similar for all other integer types.
 /// - If `T` is guaranteed to be subject to the [null pointer
 ///   optimization](option/index.html#representation), and `E` is an enum satisfying the following

--- a/library/core/src/primitive_docs.rs
+++ b/library/core/src/primitive_docs.rs
@@ -1849,7 +1849,7 @@ mod prim_ref {}
 ///     - It is a `repr(Rust)` (implicitly or explicitly, possibly with additional flags such as `packed`) `struct`, `enum`, `union` (regardless of its fields).
 ///     - It is a [tuple][prim_tuple] (regardless of its fields, and including [`()`][prim_unit]).
 ///     - It is a `repr(transparent)` `struct`, `enum`, or `union`, and all fields have trivial ABI.
-///     - It is an array, and its element type has trivial ABI. (Arrays of length 0 are not exempt from this requirement.)
+///     - It is an array, and its element type has trivial ABI. (This requirement applies even to arrays of length 0.)
 ///     - It is [the never type `!`][prim_never].
 ///     - It is a function item type or closure type.
 /// - A `repr(transparent)` type is ABI-compatible with its unique field that does not have trivial ABI

--- a/library/core/src/primitive_docs.rs
+++ b/library/core/src/primitive_docs.rs
@@ -1846,8 +1846,8 @@ mod prim_ref {}
 ///   - Size 0
 ///   - Alignment 1
 ///   - Not `repr(C)`
-///   - Not a `repr(transparent)` wrapper around a type that fails to satisfy these conditions
-///   - Not an array whose element type fails to satisfy these conditions
+///   - If `repr(transparent)`, all field types must have trivial ABI
+///   - If an array, the element type must have trivial ABI
 /// - A `repr(transparent)` type is ABI-compatible with its unique field that does not have trivial ABI
 ///   (as defined above). If there is no such field, the type has trivial ABI.
 /// - A `repr(transparent)` type `T` is ABI-compatible with its unique non-trivial field, i.e., the

--- a/library/core/src/primitive_docs.rs
+++ b/library/core/src/primitive_docs.rs
@@ -1848,6 +1848,8 @@ mod prim_ref {}
 ///   - Not `repr(C)`
 ///   - If `repr(transparent)`, all field types must have trivial ABI
 ///   - If an array, the element type must have trivial ABI
+///   - Note: additional conditions may be added in future versions of Rust,
+///     to exclude types newly introduced in those versions
 /// - A `repr(transparent)` type is ABI-compatible with its unique field that does not have trivial ABI
 ///   (as defined above). If there is no such field, the type has trivial ABI.
 /// - A `repr(transparent)` type `T` is ABI-compatible with its unique non-trivial field, i.e., the

--- a/library/core/src/primitive_docs.rs
+++ b/library/core/src/primitive_docs.rs
@@ -1843,17 +1843,17 @@ mod prim_ref {}
 ///   almost certainly UB to later call that function pointer.)
 /// - Any two types fulfilling all the following conditions are ABI-compatible;
 ///   such types are said to have "trivial ABI":
-///   - Size 0
-///   - Alignment 1
-///   - Not `repr(C)`
-///   - If `repr(transparent)`, all field types must have trivial ABI
-///   - If an array, the element type must have trivial ABI
-///   - Note: additional conditions may be added in future versions of Rust,
-///     to exclude types newly introduced in those versions
+///   - It has size 0.
+///   - It has alignment 1.
+///   - One of the following apply:
+///     - It is a `repr(Rust)` (implicitly or explicitly, possibly with additional flags such as `packed`) `struct`, `enum`, `union` (regardless of its fields).
+///     - It is a [tuple][prim_tuple] (regardless of its fields, and including [`()`][prim_unit]).
+///     - It is a `repr(transparent)` `struct`, `enum`, or `union`, and all fields have trivial ABI.
+///     - It is an array, and its element type has trivial ABI. (Arrays of length 0 are not exempt from this requirement.)
+///     - It is [the never type `!`][prim_never].
+///     - It is a function item type or closure type.
 /// - A `repr(transparent)` type is ABI-compatible with its unique field that does not have trivial ABI
-///   (as defined above). If there is no such field, the type has trivial ABI.
-/// - A `repr(transparent)` type `T` is ABI-compatible with its unique non-trivial field, i.e., the
-///   unique field that doesn't have size 0 and alignment 1 (if there is such a field).
+///   (as defined above), if such a field exists.
 /// - `i32` is ABI-compatible with `NonZero<i32>`, and similar for all other integer types.
 /// - If `T` is guaranteed to be subject to the [null pointer
 ///   optimization](option/index.html#representation), and `E` is an enum satisfying the following


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/157973)*
<!-- homu-ignore:end -->

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

FCP: https://github.com/rust-lang/rust/pull/157973#issuecomment-4984495034

(Split out from compiler implementation in https://github.com/rust-lang/rust/pull/156112)

Some C ABIs pass and return ZSTs by pointer. But `()` should never be returned by pointer, as it must match `void`. To account for this, we have to weaken the present guarantee of "any two types with size 0 and alignment 1 are ABI-compatible" to exclude `repr(C)`.

[t-lang nomination summary comment](https://github.com/rust-lang/rust/pull/157973#issuecomment-4866823377)

Fixes rust-lang/unsafe-code-guidelines#552; see also rust-lang/rust#78586, rust-lang/rust#155299.
Also related to https://github.com/rust-lang/rust/pull/155984.

@rustbot label T-lang A-ABI needs-fcp