### PR TITLE
Improve `NumBufferTrait` associated items

### DIFF
--- a/library/core/src/fmt/num.rs
+++ b/library/core/src/fmt/num.rs
@@ -758,7 +758,7 @@ impl u128 {
     /// ```
     #[stable(feature = "int_format_into", since = "CURRENT_RUSTC_VERSION")]
     pub fn format_into(self, buf: &mut NumBuffer<Self>) -> &str {
-        let diff = buf.capacity() - U128_MAX_DEC_N;
+        let diff = buf.buf.len() - U128_MAX_DEC_N;
         // FIXME: Once const generics are better, use `NumberBufferTrait::BUF_SIZE` as generic const
         // for `fmt_u128_inner`.
         //
@@ -790,7 +790,7 @@ impl i128 {
     /// ```
     #[stable(feature = "int_format_into", since = "CURRENT_RUSTC_VERSION")]
     pub fn format_into(self, buf: &mut NumBuffer<Self>) -> &str {
-        let diff = buf.capacity() - U128_MAX_DEC_N;
+        let diff = buf.buf.len() - U128_MAX_DEC_N;
         // FIXME: Once const generics are better, use `NumberBufferTrait::BUF_SIZE` as generic const
         // for `fmt_u128_inner`.
         //

--- a/library/core/src/fmt/num_buffer.rs
+++ b/library/core/src/fmt/num_buffer.rs
@@ -3,9 +3,12 @@ use crate::mem::MaybeUninit;
 /// Trait used to describe the maximum number of digits in decimal base of the implemented integer.
 #[unstable(feature = "fmt_internals", issue = "none")]
 pub trait NumBufferTrait {
-    /// Maximum number of digits in decimal base of the implemented integer.
+    /// Used for initializing the `NumberBuffer` value.
     #[unstable(feature = "fmt_internals", issue = "none")]
-    const BUF_SIZE: usize;
+    const DEFAULT: Self::Buf;
+    /// The actual underlying type.
+    #[unstable(feature = "fmt_internals", issue = "none")]
+    type Buf: AsRef<[MaybeUninit<u8>]> + AsMut<[MaybeUninit<u8>]>;
 }
 
 macro_rules! impl_NumBufferTrait {
@@ -14,11 +17,13 @@ macro_rules! impl_NumBufferTrait {
             #[stable(feature = "int_format_into", since = "CURRENT_RUSTC_VERSION")]
             impl NumBufferTrait for $signed {
                 // `+ 2` and not `+ 1` to include the `-` character.
-                const BUF_SIZE: usize = $signed::MAX.ilog(10) as usize + 2;
+                const DEFAULT: Self::Buf = [MaybeUninit::<u8>::uninit(); $signed::MAX.ilog(10) as usize + 2];
+                type Buf = [MaybeUninit<u8>; $signed::MAX.ilog(10) as usize + 2];
             }
             #[stable(feature = "int_format_into", since = "CURRENT_RUSTC_VERSION")]
             impl NumBufferTrait for $unsigned {
-                const BUF_SIZE: usize = $unsigned::MAX.ilog(10) as usize + 1;
+                const DEFAULT: Self::Buf = [MaybeUninit::<u8>::uninit(); $unsigned::MAX.ilog(10) as usize + 1];
+                type Buf = [MaybeUninit<u8>; $unsigned::MAX.ilog(10) as usize + 1];
             }
         )*
     }
@@ -52,9 +57,7 @@ impl_NumBufferTrait! {
 /// ```
 #[stable(feature = "int_format_into", since = "CURRENT_RUSTC_VERSION")]
 pub struct NumBuffer<T: NumBufferTrait> {
-    // FIXME: Once const generics feature is working, use `T::BUF_SIZE` instead of 40.
-    pub(crate) buf: [MaybeUninit<u8>; 40],
-    // FIXME: Remove this field once we can actually use `T`.
+    pub(crate) buf: T::Buf,
     phantom: core::marker::PhantomData<T>,
 }
 
@@ -72,10 +75,6 @@ impl<T: NumBufferTrait> NumBuffer<T> {
     #[rustc_const_stable(feature = "int_format_into", since = "CURRENT_RUSTC_VERSION")]
     pub const fn new() -> Self {
         // FIXME: Once const generics feature is working, use `T::BUF_SIZE` instead of 40.
-        NumBuffer { buf: [MaybeUninit::<u8>::uninit(); 40], phantom: core::marker::PhantomData }
-    }
-
-    pub(crate) const fn capacity(&self) -> usize {
-        self.buf.len()
+        NumBuffer { buf: T::DEFAULT, phantom: core::marker::PhantomData }
     }
 }


### PR DESCRIPTION
It allows for `NumBuffer::buf` size to depend on the integer instead of being the same for all integers.

The idea was suggested by @Amanieu (thanks a lot!).

r? @Amanieu 