### PR TITLE
c-variadic: initialize the copied `VaList` in const-eval

### DIFF
--- a/compiler/rustc_const_eval/src/interpret/intrinsics.rs
+++ b/compiler/rustc_const_eval/src/interpret/intrinsics.rs
@@ -725,13 +725,19 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
 
             sym::va_copy => {
                 let va_list = self.deref_pointer(&args[0])?;
+
                 let key_mplace = self.va_list_key_field(&va_list)?;
                 let key = self.read_pointer(&key_mplace)?;
 
                 let varargs = self.get_ptr_va_list(key)?;
                 let copy_key = self.va_list_ptr(varargs.clone());
 
-                let copy_key_mplace = self.va_list_key_field(dest)?;
+                // Zero the destination VaList, so it is fully initialized.
+                let dest = self.force_allocation(dest)?;
+                let zeros = std::iter::repeat_n(0u8, dest.layout.size.bytes_usize());
+                self.write_bytes_ptr(dest.ptr(), zeros)?;
+
+                let copy_key_mplace = self.va_list_key_field(&dest)?;
                 self.write_pointer(copy_key, &copy_key_mplace)?;
             }
 

--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -3641,6 +3641,10 @@ pub const unsafe fn va_arg<T: VaArgSafe>(ap: &mut VaList<'_>) -> T;
 #[rustc_intrinsic]
 #[rustc_nounwind]
 pub const fn va_copy<'f>(src: &VaList<'f>) -> VaList<'f> {
+    // This fallback body exploits the fact that our codegen backends all just use
+    // a plain memcpy to duplicate VaList. This assumption is wrong for Miri.
+    assert!(!cfg!(miri), "fallback body is incorrect under Miri");
+
     src.duplicate()
 }
 

--- a/src/tools/miri/tests/pass/c-variadic.rs
+++ b/src/tools/miri/tests/pass/c-variadic.rs
@@ -1,3 +1,4 @@
+//@run-native
 #![feature(c_variadic)]
 
 use std::ffi::{CStr, VaList, c_char, c_double, c_int, c_long};
@@ -105,6 +106,63 @@ fn various_types() {
     }
 }
 
+fn clone() {
+    if cfg!(force_intrinsic_fallback) {
+        // Skip this test when we use the fallback bodies. The fallback body does
+        // not hook into the Miri allocation bookkeeping for variable argument lists
+        // and would would falsely report UB.
+        return;
+    }
+
+    unsafe extern "C" fn clone_the_va_list(args: ...) {
+        // The implicit `drop` will catch a `VaList` that isn't properly initialized.
+        let _ = args.clone();
+    }
+
+    unsafe { clone_the_va_list(1i32, 2i32) }
+}
+
+fn clone_and_advance() {
+    if cfg!(force_intrinsic_fallback) {
+        // Skip this test when we use the fallback bodies. The fallback body does
+        // not hook into the Miri allocation bookkeeping for variable argument lists
+        // and would would falsely report UB.
+        return;
+    }
+
+    unsafe extern "C" fn variadic(mut a: ...) {
+        unsafe {
+            let mut b = a.clone();
+            assert_eq!(a.next_arg::<i32>(), 1i32);
+            assert_eq!(b.next_arg::<i32>(), 1i32);
+
+            assert_eq!(a.next_arg::<i32>(), 2i32);
+
+            let mut c = a.clone();
+            let mut d = b.clone();
+
+            assert_eq!(a.next_arg::<i32>(), 3i32);
+            assert_eq!(b.next_arg::<i32>(), 2i32);
+            assert_eq!(c.next_arg::<i32>(), 3i32);
+            assert_eq!(d.next_arg::<i32>(), 2i32);
+
+            assert_eq!(c.next_arg::<i32>(), 4i32);
+            assert_eq!(a.next_arg::<i32>(), 4i32);
+
+            drop(c);
+            drop(a);
+
+            assert_eq!(d.next_arg::<i32>(), 3i32);
+            assert_eq!(d.next_arg::<i32>(), 4i32);
+
+            assert_eq!(b.next_arg::<i32>(), 3i32);
+            assert_eq!(b.next_arg::<i32>(), 4i32);
+        }
+    }
+
+    unsafe { variadic(1i32, 2i32, 3i32, 4i32) }
+}
+
 fn main() {
     ignores_arguments();
     echo();
@@ -112,4 +170,6 @@ fn main() {
     forward_by_ref();
     nested();
     various_types();
+    clone();
+    clone_and_advance();
 }


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/157977)*
<!-- homu-ignore:end -->

Properly initialize the result of `VaList::clone` in `rustc_const_eval`.

r? RalfJung
cc @theemathas 