### PR TITLE
Avoid `&raw` recovery ICE after trailing comma

### DIFF
--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -1304,8 +1304,10 @@ impl<'a> Parser<'a> {
         let err_span = self.prev_token.span.to(self.token.span);
         let mut args = thin_vec![self.mk_expr_err(err_span, guar)];
         while !self.token.kind.is_close_delim_or_eof() {
-            if self.eat(exp!(Comma)) && !self.token.kind.is_close_delim_or_eof() {
-                args.push(self.mk_expr_err(self.prev_token.span.shrink_to_hi(), guar));
+            if self.eat(exp!(Comma)) {
+                if !self.token.kind.is_close_delim_or_eof() {
+                    args.push(self.mk_expr_err(self.prev_token.span.shrink_to_hi(), guar));
+                }
             } else {
                 self.parse_token_tree();
             }

--- a/tests/ui/parser/recover/raw-no-const-mut-trailing-comma.rs
+++ b/tests/ui/parser/recover/raw-no-const-mut-trailing-comma.rs
@@ -1,0 +1,7 @@
+// Regression test for https://github.com/rust-lang/rust/issues/157950.
+
+fn main() {
+    takes_raw_ptr_args(&raw x,)
+    //~^ ERROR expected one of
+    //~| ERROR cannot find function `takes_raw_ptr_args` in this scope
+}

--- a/tests/ui/parser/recover/raw-no-const-mut-trailing-comma.stderr
+++ b/tests/ui/parser/recover/raw-no-const-mut-trailing-comma.stderr
@@ -1,0 +1,22 @@
+error: expected one of `!`, `)`, `,`, `.`, `::`, `?`, `const`, `mut`, `{`, or an operator, found `x`
+  --> $DIR/raw-no-const-mut-trailing-comma.rs:4:29
+   |
+LL |     takes_raw_ptr_args(&raw x,)
+   |                             ^ expected one of 10 possible tokens
+   |
+help: `&raw` must be followed by `const` or `mut` to be a raw reference expression
+   |
+LL |     takes_raw_ptr_args(&raw const x,)
+   |                             +++++
+LL |     takes_raw_ptr_args(&raw mut x,)
+   |                             +++
+
+error[E0425]: cannot find function `takes_raw_ptr_args` in this scope
+  --> $DIR/raw-no-const-mut-trailing-comma.rs:4:5
+   |
+LL |     takes_raw_ptr_args(&raw x,)
+   |     ^^^^^^^^^^^^^^^^^^ not found in this scope
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0425`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Fixes rust-lang/rust#157950

This is a follow up to rust-lang/rust#157888.

For `&raw x,)`, recovery first skips `x`, then consumes the trailing comma. The old condition then fell through to `parse_token_tree()` when the next token was `)`, which causes an ICE.