### PR TITLE
Clarify `Vec::dedup_by` behavior and example docs

### DIFF
--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -2626,14 +2626,12 @@ impl<T, A: Allocator> Vec<T, A> {
         self.dedup_by(|a, b| key(a) == key(b))
     }
 
-    /// Removes all but the first of consecutive elements in the vector satisfying a given equality
-    /// relation.
-    ///
-    /// The `same_bucket` function is passed references to two elements from the vector and
-    /// must determine if the elements compare equal. The elements are passed in opposite order
-    /// from their order in the slice, so if `same_bucket(a, b)` returns `true`, `a` is removed.
+    /// Removes consecutive elements for which `same_bucket` returns `true`,
+    /// keeping the first element of each consecutive group.
     ///
     /// If the vector is sorted, this removes all duplicates.
+    ///
+    /// Note: `same_bucket` does not need to be an equivalence relation.
     ///
     /// # Examples
     ///
@@ -2642,6 +2640,8 @@ impl<T, A: Allocator> Vec<T, A> {
     ///
     /// vec.dedup_by(|a, b| a.eq_ignore_ascii_case(b));
     ///
+    /// // "Bar" is removed because it compares equal to the preceding element
+    /// // ignoring ASCII case.
     /// assert_eq!(vec, ["foo", "bar", "baz", "bar"]);
     /// ```
     #[stable(feature = "dedup_by", since = "1.16.0")]


### PR DESCRIPTION

Fixes rust-lang/rust#157959

This PR simplifies the `Vec::dedup_by` documentation by removing the
reversed-argument-order explanation and describing the observable
behavior directly.

Previously, the docs explained `dedup_by` in terms of the internal
argument order passed to `same_bucket`:

```rust
/// Removes all but the first of consecutive elements in the vector satisfying
/// a given equality relation.
///
/// The `same_bucket` function is passed references to two elements from the
/// vector and must determine if the elements compare equal. The elements are
/// passed in opposite order from their order in the slice, so if
/// `same_bucket(a, b)` returns `true`, `a` is removed.
```

While technically correct, this made it unnecessarily difficult to
reason about which element is retained.

The updated wording instead describes the behavior directly:

```rust
/// Removes all but the first of consecutive elements for which
/// `same_bucket` returns `true`.
```

This PR also:

* clarifies that `same_bucket` does not need to be an equivalence relation,
* and expands the example comment to explicitly explain why `"Bar"` is removed in:

```rust
vec.dedup_by(|a, b| a.eq_ignore_ascii_case(b));
```

**Is this a breaking change?**

No. This PR only updates documentation and examples.

**Example of the previous confusion**

Previously, readers had to combine:

```rust
same_bucket(a, b) == true => a is removed
```

with:

```text
The elements are passed in opposite order from their order in the slice
```

to infer which consecutive element survives.

The new wording avoids that mental reversal step and focuses on the
observable result instead.

