### PR TITLE
Some minor cleanups around hir ty/pat/expr

### DIFF
--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -5408,6 +5408,16 @@ impl<'hir> Node<'hir> {
         }
     }
 
+    /// For expressions, patterns, and types return the path if it's a path expr/pat/ty.
+    pub fn path(self) -> Option<&'hir QPath<'hir>> {
+        match self {
+            Node::Ty(Ty { kind: TyKind::Path(path), .. })
+            | Node::Expr(Expr { kind: ExprKind::Path(path), .. })
+            | Node::PatExpr(PatExpr { kind: PatExprKind::Path(path), .. }) => Some(path),
+            _ => None,
+        }
+    }
+
     expect_methods_self! {
         expect_param,         &'hir Param<'hir>,        Node::Param(n),        n;
         expect_item,          &'hir Item<'hir>,         Node::Item(n),         n;

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/dyn_trait.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/dyn_trait.rs
@@ -599,19 +599,8 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
         let tcx = self.tcx();
         let [poly_trait_ref, ..] = hir_bounds else { return None };
 
-        let in_path = match tcx.parent_hir_node(hir_id) {
-            hir::Node::Ty(hir::Ty {
-                kind: hir::TyKind::Path(hir::QPath::TypeRelative(qself, _)),
-                ..
-            })
-            | hir::Node::Expr(hir::Expr {
-                kind: hir::ExprKind::Path(hir::QPath::TypeRelative(qself, _)),
-                ..
-            })
-            | hir::Node::PatExpr(hir::PatExpr {
-                kind: hir::PatExprKind::Path(hir::QPath::TypeRelative(qself, _)),
-                ..
-            }) if qself.hir_id == hir_id => true,
+        let in_path = match tcx.parent_hir_node(hir_id).path() {
+            Some(hir::QPath::TypeRelative(qself, _)) if qself.hir_id == hir_id => true,
             _ => false,
         };
         let needs_bracket = in_path

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
@@ -3509,9 +3509,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
         let fn_ty = tcx.mk_fn_sig(input_tys, output_ty, fn_sig_kind);
         let fn_ptr_ty = ty::Binder::bind_with_vars(fn_ty, bound_vars);
 
-        if let hir::Node::Ty(hir::Ty { kind: hir::TyKind::FnPtr(fn_ptr_ty), span, .. }) =
-            tcx.hir_node(hir_id)
-        {
+        if let Some(hir::Ty { kind: hir::TyKind::FnPtr(fn_ptr_ty), span, .. }) = hir_ty {
             check_abi(tcx, hir_id, *span, fn_ptr_ty.abi);
         }
 

--- a/compiler/rustc_hir_typeck/src/lib.rs
+++ b/compiler/rustc_hir_typeck/src/lib.rs
@@ -317,33 +317,11 @@ fn extend_err_with_const_context(
         // FIXME: support method calls too.
         hir::Node::AnonConst(anon)
             if let hir::Node::ConstArg(parent) = tcx.parent_hir_node(anon.hir_id)
-                && let hir::Node::Expr(expr) = tcx.parent_hir_node(parent.hir_id)
-                && let hir::ExprKind::Path(path) = expr.kind
+                && let Some(path) = tcx.parent_hir_node(parent.hir_id).path()
                 && let hir::QPath::Resolved(_, path) = path
                 && let Res::Def(_, def_id) = path.res =>
         {
-            // `foo<N>()` in expression context, point at `foo`'s const parameter.
-            if let Some(i) =
-                path.segments.iter().last().and_then(|segment| segment.args).and_then(|args| {
-                    args.args.iter().position(|arg| {
-                        matches!(arg, hir::GenericArg::Const(arg) if arg.hir_id == parent.hir_id)
-                    })
-                })
-            {
-                let generics = tcx.generics_of(def_id);
-                let param = &generics.param_at(i, tcx);
-                let sp = tcx.def_span(param.def_id);
-                err.span_note(sp, "expected because of the type of the const parameter");
-            }
-        }
-        hir::Node::AnonConst(anon)
-            if let hir::Node::ConstArg(parent) = tcx.parent_hir_node(anon.hir_id)
-                && let hir::Node::Ty(ty) = tcx.parent_hir_node(parent.hir_id)
-                && let hir::TyKind::Path(path) = ty.kind
-                && let hir::QPath::Resolved(_, path) = path
-                && let Res::Def(_, def_id) = path.res =>
-        {
-            // `Foo<N>` in type context, point at `Foo`'s const parameter.
+            // `foo<N>()`, point at the const parameter in the definition of `foo`.
             if let Some(i) =
                 path.segments.iter().last().and_then(|segment| segment.args).and_then(|args| {
                     args.args.iter().position(|arg| {


### PR DESCRIPTION
Just some avenues for deduplication that I noticed. Also makes sure we handle all three everywhere instead of just ty/expr like the diagnostic code previously did.