### PR TITLE
doc: Document NonNull pointer ABI compatibility

### DIFF
--- a/library/core/src/ptr/non_null.rs
+++ b/library/core/src/ptr/non_null.rs
@@ -49,6 +49,10 @@ use crate::{fmt, hash, intrinsics, mem, ptr};
 ///
 /// # Representation
 ///
+/// `NonNull<T>` is guaranteed to be ABI-compatible with `*const T`,
+/// `*mut T`, `&T`, `&mut T`, and `Box<T, Global>` for all `T`, but its
+/// pointer must not be null.
+///
 /// Thanks to the [null pointer optimization],
 /// `NonNull<T>` and `Option<NonNull<T>>`
 /// are guaranteed to have the same size and alignment:


### PR DESCRIPTION
It intends to fix rust-lang/rust#157741 

`NonNull<T>` is already documented in the primitive ABI compatibility docs as ABI-compatible with raw pointers, but its own representation section only mentioned the `Option<NonNull<T>>` size/alignment guarantee.

This updates the `NonNull` docs to state directly that `NonNull<T>` has the same ABI as `*mut T`,... .
Except for the non-null validity requirement. This makes the guarantee easier to find from the `NonNull` page itself.


