### PR TITLE
Fix incremental-finalize-fail proc macro test on AIX

### DIFF
--- a/tests/run-make/incremental-finalize-fail/rmake.rs
+++ b/tests/run-make/incremental-finalize-fail/rmake.rs
@@ -87,6 +87,8 @@ fn find_proc_macro_dylib(name: &str) -> PathBuf {
         "dylib"
     } else if cfg!(target_os = "windows") {
         "dll"
+    } else if cfg!(target_os = "aix") {
+        "a"
     } else {
         "so"
     };


### PR DESCRIPTION
This patch updates `incremental-finalize-fail` on AIX by making the test's proc-macro lookup to use the `.a` extension.

The test previously assumed that non-macOS, non-Windows targets produce a `.so` proc-macro artifact. On AIX, the artifact is `libpoison.a`, which causes the test to fail as it isn't able to find the proc-macro dylib for poison.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
