### PR TITLE
run-make: handle AIX symbol cdylib export test

### DIFF
--- a/tests/run-make/cdylib-export-c-library-symbols/rmake.rs
+++ b/tests/run-make/cdylib-export-c-library-symbols/rmake.rs
@@ -7,7 +7,9 @@
 //@ ignore-apple
 // Reason: the compiled binary is executed
 
-use run_make_support::{build_native_static_lib, cc, dynamic_lib_name, is_darwin, llvm_nm, rustc};
+use run_make_support::{
+    build_native_static_lib, cc, dynamic_lib_name, is_aix, is_darwin, llvm_nm, rustc,
+};
 
 fn main() {
     cc().input("foo.c").arg("-c").out_exe("foo.o").run();
@@ -27,6 +29,11 @@ fn main() {
             .input(dynamic_lib_name("foo_export"))
             .run()
             .assert_stdout_contains("T _my_function");
+    } else if is_aix() {
+        let out = llvm_nm()
+            .input(dynamic_lib_name("foo_export"))
+            .run()
+            .assert_stdout_contains("T .my_function");
     } else {
         let out = llvm_nm()
             .input(dynamic_lib_name("foo_export"))


### PR DESCRIPTION
The cdylib export-symbols test was checking for `T my_function` on all non-Darwin targets, but AIX prints the exported symbol as `T .my_function`.

This patch updates the test to account for the AIX behavior so the test validates the actual exported symbol correctly.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
