### PR TITLE
tidy: revisions inherit global directives

### DIFF
--- a/src/tools/tidy/src/target_specific_tests.rs
+++ b/src/tools/tidy/src/target_specific_tests.rs
@@ -13,7 +13,9 @@ const COMPILE_FLAGS_HEADER: &str = "compile-flags:";
 
 #[derive(Default, Debug)]
 struct RevisionInfo<'a> {
+    /// Target architecture specified with `--target=`
     target_arch: Option<Option<&'a str>>,
+    /// LLVM components configured with `//@ needs-llvm-components: ...`
     llvm_components: Option<Vec<&'a str>>,
 }
 
@@ -59,6 +61,22 @@ pub fn check(tests_path: &Path, tidy_ctx: TidyCtx) {
             .is_ok_and(|rest| rest.starts_with("run-make") || rest.starts_with("run-make-cargo"))
         {
             return;
+        }
+
+        // Directives without an explicit revision. These are inherited by all revisions.
+        let global = header_map.remove(&None).unwrap_or_default();
+
+        if header_map.is_empty() {
+            // `//@ revisions` is not used.
+            header_map.insert(None, global);
+        } else {
+            // Make all revisions inherit global directives.
+            for info in header_map.values_mut() {
+                info.target_arch = info.target_arch.or(global.target_arch);
+                if let Some(components) = &global.llvm_components {
+                    info.llvm_components.get_or_insert_with(Vec::new).extend(components);
+                }
+            }
         }
 
         for (rev, RevisionInfo { target_arch, llvm_components }) in &header_map {

--- a/tests/assembly-llvm/c-variadic/mips.rs
+++ b/tests/assembly-llvm/c-variadic/mips.rs
@@ -2,12 +2,10 @@
 //@ assembly-output: emit-asm
 //
 //@ revisions: MIPS MIPS64 MIPS64EL
+//@ needs-llvm-components: mips
 //@ [MIPS] compile-flags: -Copt-level=3 --target mips-unknown-linux-gnu
-//@ [MIPS] needs-llvm-components: mips
 //@ [MIPS64] compile-flags: -Copt-level=3 --target mipsisa64r6-unknown-linux-gnuabi64
-//@ [MIPS64] needs-llvm-components: mips
 //@ [MIPS64EL] compile-flags: -Copt-level=3 --target mips64el-unknown-linux-gnuabi64
-//@ [MIPS64EL] needs-llvm-components: mips
 #![feature(c_variadic, no_core, lang_items, intrinsics, rustc_attrs, asm_experimental_arch)]
 #![no_core]
 #![crate_type = "lib"]


### PR DESCRIPTION
specifically `needs-llvm-components`

Based on this function, directives apply to a revision also when the directive is defined "globally".

https://github.com/rust-lang/rust/blob/89a99936d9e76a50e8df622e7242190841fd871b/src/tools/compiletest/src/directives/line.rs#L100-L102

But `tidy` did not take that into account.

I'm not sure how to test this.

r? jieyouxu 
