### PR TITLE
Expose more info about ADTs and functions in rustc_public

### DIFF
--- a/compiler/rustc_public/src/compiler_interface.rs
+++ b/compiler/rustc_public/src/compiler_interface.rs
@@ -17,11 +17,11 @@ use crate::mir::mono::{Instance, InstanceDef, StaticDef};
 use crate::mir::{BinOp, Body, Place, UnOp};
 use crate::target::{MachineInfo, MachineSize};
 use crate::ty::{
-    AdtDef, AdtKind, Allocation, Asyncness, ClosureDef, ClosureKind, Constness, CoroutineDef,
-    Discr, FieldDef, FnDef, ForeignDef, ForeignItemKind, ForeignModule, ForeignModuleDef,
-    GenericArgs, GenericPredicates, Generics, ImplDef, ImplTrait, IntrinsicDef, LineInfo, MirConst,
-    PolyFnSig, RigidTy, Span, TraitDecl, TraitDef, TraitRef, Ty, TyConst, TyConstId, TyKind,
-    UintTy, VariantDef, VariantIdx, VtblEntry,
+    AdtDef, AdtKind, Allocation, AssocItem, Asyncness, ClosureDef, ClosureKind, Constness,
+    CoroutineDef, Discr, FieldDef, FnDef, ForeignDef, ForeignItemKind, ForeignModule,
+    ForeignModuleDef, GenericArgs, GenericPredicates, Generics, ImplDef, ImplTrait, IntrinsicDef,
+    LineInfo, MirConst, PolyFnSig, RigidTy, Span, TraitDecl, TraitDef, TraitRef, Ty, TyConst,
+    TyConstId, TyKind, UintTy, VariantDef, VariantIdx, VtblEntry,
 };
 use crate::unstable::{RustcInternal, Stable, new_item_kind};
 use crate::{
@@ -207,6 +207,14 @@ impl<'tcx> CompilerInterface<'tcx> {
         self.with_cx(|tables, cx| {
             let did = tables[def_id];
             cx.generics_of(did).stable(tables, cx)
+        })
+    }
+
+    /// Retrieve the inherent implementations for this ADT.
+    pub(crate) fn inherent_impls(&self, adt: AdtDef) -> Vec<ImplDef> {
+        self.with_cx(|tables, cx| {
+            let def_id = tables[adt.0];
+            cx.inherent_impls(def_id).iter().map(|&did| tables.impl_def(did)).collect()
         })
     }
 
@@ -818,6 +826,14 @@ impl<'tcx> CompilerInterface<'tcx> {
             let un_op = un_op.internal(tables, cx.tcx);
             let arg = arg.internal(tables, cx.tcx);
             cx.unop_ty(un_op, arg).stable(tables, cx)
+        })
+    }
+
+    /// Get the associated item of a definition if it is one.
+    pub(crate) fn associated_item(&self, def_id: DefId) -> Option<AssocItem> {
+        self.with_cx(|tables, cx| {
+            let did = tables[def_id];
+            cx.associated_item(did).map(|assoc| assoc.stable(tables, cx))
         })
     }
 

--- a/compiler/rustc_public/src/ty.rs
+++ b/compiler/rustc_public/src/ty.rs
@@ -727,6 +727,16 @@ impl FnDef {
         let kind = self.ty().kind();
         kind.fn_sig().unwrap()
     }
+
+    /// Get the generics of this function definition.
+    pub fn generics_of(&self) -> Generics {
+        with(|cx| cx.generics_of(self.0))
+    }
+
+    /// Get the associated item information if this function is one.
+    pub fn associated_item(&self) -> Option<AssocItem> {
+        with(|cx| cx.associated_item(self.0))
+    }
 }
 
 crate_def_with_ty! {
@@ -863,6 +873,16 @@ impl AdtDef {
     pub fn discriminant_for_variant(&self, idx: VariantIdx) -> Discr {
         with(|cx| cx.adt_discr_for_variant(*self, idx))
     }
+
+    /// Get the generics of this ADT definition.
+    pub fn generics_of(&self) -> Generics {
+        with(|cx| cx.generics_of(self.0))
+    }
+
+    /// Retrieve the inherent implementations for this ADT.
+    pub fn inherent_impls(&self) -> Vec<ImplDef> {
+        with(|cx| cx.inherent_impls(*self))
+    }
 }
 
 pub struct Discr {
@@ -970,7 +990,7 @@ crate_def_with_ty! {
     pub ConstDef;
 }
 
-crate_def! {
+crate_def_with_ty! {
     /// A trait impl definition.
     #[derive(Serialize)]
     pub ImplDef;
@@ -984,6 +1004,11 @@ impl ImplDef {
 
     pub fn associated_items(&self) -> AssocItems {
         with(|cx| cx.associated_items(self.def_id()))
+    }
+
+    /// Get the generics of this implementation.
+    pub fn generics_of(&self) -> Generics {
+        with(|cx| cx.generics_of(self.0))
     }
 }
 

--- a/compiler/rustc_public_bridge/src/context/impls.rs
+++ b/compiler/rustc_public_bridge/src/context/impls.rs
@@ -201,6 +201,11 @@ impl<'tcx, B: Bridge> CompilerCtxt<'tcx, B> {
         self.tcx.trait_impls_in_crate(crate_num).iter().map(|impl_def_id| *impl_def_id).collect()
     }
 
+    /// Returns the inherent implementations of the given definition.
+    pub fn inherent_impls(&self, def_id: DefId) -> Vec<DefId> {
+        self.tcx.inherent_impls(def_id).iter().copied().collect()
+    }
+
     pub fn trait_impl(&self, impl_def: DefId) -> EarlyBinder<'tcx, TraitRef<'tcx>> {
         self.tcx.impl_trait_ref(impl_def)
     }
@@ -776,6 +781,11 @@ impl<'tcx, B: Bridge> CompilerCtxt<'tcx, B> {
                 .collect()
         };
         assoc_items
+    }
+
+    /// Returns the associated item of the given `DefId`, or `None` if it is not an associated item.
+    pub fn associated_item(&self, def_id: DefId) -> Option<AssocItem> {
+        self.tcx.opt_associated_item(def_id)
     }
 
     /// Get all vtable entries of a trait.

--- a/tests/ui-fulldeps/rustc_public/check_alias.rs
+++ b/tests/ui-fulldeps/rustc_public/check_alias.rs
@@ -1,0 +1,74 @@
+//@ run-pass
+//! Test that alias type conversion (projection/opaque types) works and returns TyKind::Alias.
+
+//@ ignore-stage1
+//@ ignore-cross-compile
+//@ ignore-remote
+//@ edition: 2021
+
+#![feature(rustc_private)]
+
+extern crate rustc_middle;
+
+extern crate rustc_driver;
+extern crate rustc_interface;
+#[macro_use]
+extern crate rustc_public;
+
+use rustc_public::CrateDef;
+use rustc_public::ty::{TyKind, AliasKind};
+use std::ops::ControlFlow;
+
+const CRATE_NAME: &str = "crate_alias";
+
+fn test_alias() -> ControlFlow<()> {
+    let local_crate = rustc_public::local_crate();
+    let fn_defs = local_crate.fn_defs();
+    let alias_fn = fn_defs
+        .iter()
+        .find(|f| f.trimmed_name().as_str() == "alias_fn")
+        .expect("Failed to find alias_fn");
+    let fn_sig = alias_fn.fn_sig().skip_binder();
+    let inputs = fn_sig.inputs();
+    assert_eq!(inputs.len(), 1);
+    let input_ty = &inputs[0];
+    match input_ty.kind() {
+        TyKind::Alias(alias_kind, alias_ty) => {
+            assert_eq!(alias_kind, AliasKind::Projection);
+            assert_eq!(alias_ty.def_id.trimmed_name().as_str(), "MyTrait::Assoc");
+        }
+        _ => panic!("Expected TyKind::Alias for input type, found {:?}", input_ty),
+    }
+
+    ControlFlow::Continue(())
+}
+
+fn main() {
+    let path = "alias.rs";
+    generate_input(&path).unwrap();
+    let args = &[
+        "rustc".to_string(),
+        "--crate-type=lib".to_string(),
+        "--crate-name".to_string(),
+        CRATE_NAME.to_string(),
+        path.to_string(),
+    ];
+    run!(args, test_alias).unwrap();
+}
+
+fn generate_input(path: &str) -> std::io::Result<()> {
+    std::fs::write(
+        path,
+        r#"
+        pub trait MyTrait {
+            type Assoc;
+        }
+
+        impl MyTrait for i32 {
+            type Assoc = bool;
+        }
+
+        pub fn alias_fn<T: MyTrait>(val: T::Assoc) {}
+    "#
+    )
+}

--- a/tests/ui-fulldeps/rustc_public/check_generics.rs
+++ b/tests/ui-fulldeps/rustc_public/check_generics.rs
@@ -1,0 +1,76 @@
+//@ run-pass
+//! Test that users are able to retrieve generic parameters from various definitions.
+
+//@ ignore-stage1
+//@ ignore-cross-compile
+//@ ignore-remote
+//@ edition: 2021
+
+#![feature(rustc_private)]
+
+extern crate rustc_middle;
+
+extern crate rustc_driver;
+extern crate rustc_interface;
+#[macro_use]
+extern crate rustc_public;
+
+use rustc_public::CrateDef;
+use rustc_public::ty::GenericParamDefKind;
+use std::ops::ControlFlow;
+
+const CRATE_NAME: &str = "crate_generics";
+
+fn test_generics() -> ControlFlow<()> {
+    let local_crate = rustc_public::local_crate();
+
+    // Check ADT generics
+    let adts = local_crate.adts();
+    let my_struct =
+        adts.iter().find(|adt| adt.trimmed_name() == "MyStruct").expect("Failed to find MyStruct");
+    let adt_generics = my_struct.generics_of();
+    assert_eq!(adt_generics.params.len(), 1);
+    assert_eq!(adt_generics.params[0].name.as_str(), "T");
+    match &adt_generics.params[0].kind {
+        GenericParamDefKind::Type { .. } => {}
+        _ => panic!("Expected type parameter"),
+    }
+
+    // Check Fn generics
+    let fn_defs = local_crate.fn_defs();
+    let my_fn = fn_defs
+        .iter()
+        .find(|f| f.trimmed_name().as_str() == "my_fn")
+        .expect("Failed to find my_fn");
+    let fn_generics = my_fn.generics_of();
+    assert_eq!(fn_generics.params.len(), 1);
+    assert_eq!(fn_generics.params[0].name.as_str(), "U");
+
+    ControlFlow::Continue(())
+}
+
+fn main() {
+    let path = "generics.rs";
+    generate_input(&path).unwrap();
+    let args = &[
+        "rustc".to_string(),
+        "--crate-type=lib".to_string(),
+        "--crate-name".to_string(),
+        CRATE_NAME.to_string(),
+        path.to_string(),
+    ];
+    run!(args, test_generics).unwrap();
+}
+
+fn generate_input(path: &str) -> std::io::Result<()> {
+    std::fs::write(
+        path,
+        r#"
+        pub struct MyStruct<T> {
+            value: T,
+        }
+
+        pub fn my_fn<U>() {}
+    "#
+    )
+}

--- a/tests/ui-fulldeps/rustc_public/check_inherent_impls.rs
+++ b/tests/ui-fulldeps/rustc_public/check_inherent_impls.rs
@@ -1,0 +1,206 @@
+//@ run-pass
+//! Test that users can retrieve information about inherent implementations and their self types.
+
+//@ ignore-stage1
+//@ ignore-cross-compile
+//@ ignore-remote
+//@ edition: 2021
+
+#![feature(rustc_private)]
+
+extern crate rustc_middle;
+
+extern crate rustc_driver;
+extern crate rustc_interface;
+#[macro_use]
+extern crate rustc_public;
+
+use rustc_public::{CrateDef, CrateDefType};
+use rustc_public::ty::{TyKind, RigidTy, FnDef, GenericArgKind, GenericArgs};
+use std::io::Write;
+use std::ops::ControlFlow;
+
+const CRATE_NAME: &str = "inherent_impl_test";
+
+/// This function uses the Stable MIR APIs to get information about the test crate.
+fn test_inherent_impls() -> ControlFlow<()> {
+    let local_crate = rustc_public::local_crate();
+    let adts = local_crate.adts();
+
+    let my_struct =
+        adts.iter().find(|adt| adt.trimmed_name() == "MyStruct").expect("Failed to find MyStruct");
+    let adt_generics = my_struct.generics_of();
+    assert_eq!(adt_generics.params.len(), 1);
+    assert_eq!(adt_generics.params[0].name.as_str(), "T");
+
+    let impls = my_struct.inherent_impls();
+    assert_eq!(impls.len(), 2, "Expected 2 inherent impls for MyStruct, found {:?}", impls);
+
+    // We expect one generic impl `impl<T> MyStruct<T>` and one specialized impl `impl
+    // MyStruct<i32>` The order might not be guaranteed, so we check both.
+    let mut found_generic = false;
+    let mut found_specialized = false;
+    let mut generic_impl = None;
+    let mut specialized_impl_self_ty = None;
+
+    for impl_def in impls {
+        let self_ty = impl_def.ty();
+        let assoc_items = impl_def.associated_items();
+        assert_eq!(assoc_items.len(), 2, "Expected 2 methods in impl, found {:?}", assoc_items);
+
+        let method = assoc_items.iter().find(|m| {
+            match &m.kind {
+                rustc_public::ty::AssocKind::Fn { name, .. } => !name.as_str().contains("param"),
+                _ => false,
+            }
+        }).unwrap();
+
+        let generic_method = assoc_items.iter().find(|m| {
+            match &m.kind {
+                rustc_public::ty::AssocKind::Fn { name, .. } => name.as_str().contains("param"),
+                _ => false,
+            }
+        }).unwrap();
+
+        let method_name = match &method.kind {
+            rustc_public::ty::AssocKind::Fn { name, .. } => name.as_str(),
+            _ => unreachable!(),
+        };
+
+        let method_fn = FnDef(method.def_id.def_id());
+        let assoc_info =
+            method_fn.associated_item().expect("Expected associated item info for method");
+        assert_eq!(assoc_info.def_id, method.def_id);
+
+        let generic_method_name = match &generic_method.kind {
+            rustc_public::ty::AssocKind::Fn { name, .. } => name.as_str(),
+            _ => unreachable!(),
+        };
+
+        let generic_method_fn = FnDef(generic_method.def_id.def_id());
+        let generic_assoc_info = generic_method_fn
+            .associated_item()
+            .expect("Expected associated item info for generic method");
+        assert_eq!(generic_assoc_info.def_id, generic_method.def_id);
+
+        match self_ty.kind() {
+            TyKind::RigidTy(RigidTy::Adt(adt_def, args)) => {
+                assert_eq!(adt_def, *my_struct);
+                assert_eq!(args.0.len(), 1);
+
+                let arg = &args.0[0];
+                match arg {
+                    rustc_public::ty::GenericArgKind::Type(ty) => {
+                        match ty.kind() {
+                            TyKind::Param(param_ty) => {
+                                // This is Child<T>
+                                assert_eq!(param_ty.name, "T");
+                                assert_eq!(method_name, "generic_method");
+                                assert_eq!(generic_method_name, "generic_method_with_param");
+                                found_generic = true;
+                                generic_impl = Some(impl_def.clone());
+
+                                // Check generics of the generic impl block
+                                let generics = impl_def.generics_of();
+                                assert_eq!(generics.params.len(), 1);
+                                assert_eq!(generics.params[0].name.as_str(), "T");
+
+                                // Check generics of the method, which is not generic.
+                                let method_generics = method_fn.generics_of();
+                                assert_eq!(method_generics.params.len(), 0);
+
+                                let generic_method_generics = generic_method_fn.generics_of();
+                                assert_eq!(generic_method_generics.params.len(), 1);
+                                assert_eq!(generic_method_generics.params[0].name.as_str(), "U");
+                            }
+                            TyKind::RigidTy(RigidTy::Int(rustc_public::ty::IntTy::I32)) => {
+                                // This is Child<i32>
+                                assert_eq!(method_name, "specialized_method");
+                                assert_eq!(generic_method_name, "specialized_method_with_param");
+                                found_specialized = true;
+                                specialized_impl_self_ty = Some(self_ty.clone());
+
+                                // Check generics of the specialized impl block (none)
+                                let generics = impl_def.generics_of();
+                                assert_eq!(generics.params.len(), 0);
+
+                                // Check generics of the method
+                                let method_generics = method_fn.generics_of();
+                                assert_eq!(method_generics.params.len(), 0);
+
+                                let generic_method_generics = generic_method_fn.generics_of();
+                                assert_eq!(generic_method_generics.params.len(), 1);
+                                assert_eq!(generic_method_generics.params[0].name.as_str(), "U");
+                            }
+                            _ => panic!("Unexpected generic argument type: {:?}", ty),
+                        }
+                    }
+                    _ => panic!("Unexpected generic argument: {:?}", arg),
+                }
+            }
+            _ => panic!("Unexpected self type: {:?}", self_ty),
+        }
+    }
+
+    assert!(found_generic, "Failed to find generic impl");
+    assert!(found_specialized, "Failed to find specialized impl");
+
+    let generic_impl = generic_impl.expect("Failed to find generic impl");
+    let specialized_self_ty =
+        specialized_impl_self_ty.expect("Failed to find specialized impl self ty");
+
+    let i32_ty = match specialized_self_ty.kind() {
+        TyKind::RigidTy(RigidTy::Adt(_, args)) => {
+            match &args.0[0] {
+                rustc_public::ty::GenericArgKind::Type(t) => t.clone(),
+                _ => unreachable!(),
+            }
+        }
+        _ => unreachable!(),
+    };
+
+    let args = GenericArgs(vec![GenericArgKind::Type(i32_ty)]);
+    let instantiated_ty = generic_impl.ty_with_args(&args);
+    assert_eq!(instantiated_ty, specialized_self_ty);
+
+    ControlFlow::Continue(())
+}
+
+/// This test will generate and analyze a dummy crate using the stable mir.
+fn main() {
+    let path = "inherent_impls.rs";
+    generate_input(&path).unwrap();
+    let args = &[
+        "rustc".to_string(),
+        "--crate-type=lib".to_string(),
+        "--crate-name".to_string(),
+        CRATE_NAME.to_string(),
+        path.to_string(),
+    ];
+    run!(args, test_inherent_impls).unwrap();
+}
+
+fn generate_input(path: &str) -> std::io::Result<()> {
+    let mut file = std::fs::File::create(path)?;
+    write!(
+        file,
+        r#"
+        pub struct MyStruct<T> {{
+            value: T,
+        }}
+
+        // Generic impl
+        impl<T> MyStruct<T> {{
+            pub fn generic_method(&self) {{}}
+            pub fn generic_method_with_param<U>(&self) {{}}
+        }}
+
+        // Specialized impl
+        impl MyStruct<i32> {{
+            pub fn specialized_method(&self) {{}}
+            pub fn specialized_method_with_param<U>(&self) {{}}
+        }}
+    "#
+    )?;
+    Ok(())
+}

--- a/tests/ui-fulldeps/rustc_public/check_trait_queries.rs
+++ b/tests/ui-fulldeps/rustc_public/check_trait_queries.rs
@@ -15,7 +15,7 @@ extern crate rustc_interface;
 #[macro_use]
 extern crate rustc_public;
 
-use rustc_public::CrateDef;
+use rustc_public::{CrateDef, CrateDefType};
 use std::collections::HashSet;
 use std::io::Write;
 use std::ops::ControlFlow;
@@ -26,8 +26,30 @@ const CRATE_NAME: &str = "trait_test";
 fn test_traits() -> ControlFlow<()> {
     let local_crate = rustc_public::local_crate();
     let local_traits = local_crate.trait_decls();
-    assert_eq!(local_traits.len(), 1, "Expected `Max` trait, but found {:?}", local_traits);
-    assert_eq!(&local_traits[0].trimmed_name(), "Max");
+    assert_eq!(
+        local_traits.len(),
+        2,
+        "Expected `Max` and `TraitWithAssoc` traits, but found {:?}", local_traits,
+    );
+
+    let trait_with_assoc = local_traits
+        .iter()
+        .find(|t| t.trimmed_name() == "TraitWithAssoc")
+        .expect("Failed to find TraitWithAssoc");
+    let trait_items = trait_with_assoc.associated_items();
+    assert_eq!(trait_items.len(), 3);
+    let has_type = trait_items
+        .iter()
+        .any(|item| matches!(&item.kind, rustc_public::ty::AssocKind::Type { .. }));
+    let has_const = trait_items
+        .iter()
+        .any(|item| matches!(&item.kind, rustc_public::ty::AssocKind::Const { .. }));
+    let has_fn = trait_items
+        .iter()
+        .any(|item| matches!(&item.kind, rustc_public::ty::AssocKind::Fn { .. }));
+    assert!(has_type);
+    assert!(has_const);
+    assert!(has_fn);
 
     let local_impls = local_crate.trait_impls();
     let impl_names =
@@ -41,6 +63,37 @@ fn test_traits() -> ControlFlow<()> {
     assert_impl(&impl_names, "<Positive as TryFrom<u64>>");
     assert_impl(&impl_names, "<u64 as Max>");
     assert_impl(&impl_names, "<impl From<Positive> for u64>");
+    assert_impl(&impl_names, "<u64 as TraitWithAssoc>");
+
+    let impl_with_assoc = local_impls
+        .iter()
+        .find(|t| t.trimmed_name() == "<u64 as TraitWithAssoc>")
+        .expect("Failed to find <u64 as TraitWithAssoc>");
+    let impl_items = impl_with_assoc.associated_items();
+    assert_eq!(impl_items.len(), 3);
+    let has_type = impl_items
+        .iter()
+        .any(|item| matches!(&item.kind, rustc_public::ty::AssocKind::Type { .. }));
+    let has_const = impl_items
+        .iter()
+        .any(|item| matches!(&item.kind, rustc_public::ty::AssocKind::Const { .. }));
+    let has_fn = impl_items
+        .iter()
+        .any(|item| matches!(&item.kind, rustc_public::ty::AssocKind::Fn { .. }));
+    assert!(has_type);
+    assert!(has_const);
+    assert!(has_fn);
+
+    // Verify ImplDef::ty() returns the self type (u64)
+    let self_ty = impl_with_assoc.ty();
+    assert!(
+        matches!(
+            self_ty.kind(),
+            rustc_public::ty::TyKind::RigidTy(
+                rustc_public::ty::RigidTy::Uint(rustc_public::ty::UintTy::U64)
+            ),
+        ),
+    );
 
     let all_traits = rustc_public::all_trait_decls();
     assert!(all_traits.len() > local_traits.len());
@@ -113,6 +166,20 @@ fn generate_input(path: &str) -> std::io::Result<()> {
 
         impl Max for Positive {{
             fn is_max(&self) -> bool {{ self.0.is_max() }}
+        }}
+
+        pub trait TraitWithAssoc {{
+            type AssocType;
+            const ASSOC_CONST: i32;
+            fn assoc_fn() -> Self::AssocType;
+        }}
+
+        impl TraitWithAssoc for u64 {{
+            type AssocType = String;
+            const ASSOC_CONST: i32 = 42;
+            fn assoc_fn() -> Self::AssocType {{
+                "hello".to_string()
+            }}
         }}
 
     "#


### PR DESCRIPTION
This allows users of `rustc_public` to do more complex navigation through data structures by exposing the following info:

* `AdtDef::generics_of` - Get the generics for the ADT.
* `AdtDef::inherent_impls` - Get all the impls for the ADT.
* `FnDef::associated_item` - Get the trait or impl block that contains the function if it exists.
* `FnDef::generics_of` - get the generics for a given function.
* `ImplDef::generics_of` - Get the generics for the impl block.
* `ImplDef` implements `CrateDefType` - figure out the type of the impl block with `CrateDefType::ty()` or get the normalized type with `CrateDefType::ty_with_args()`.

This was partially written with the help of Gemini, but I reviewed the code it generated.