### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/compiler/rustc_attr_parsing/src/attributes/codegen_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/codegen_attrs.rs
@@ -1,5 +1,7 @@
 use rustc_feature::AttributeStability;
-use rustc_hir::attrs::{CoverageAttrKind, OptimizeAttr, RtsanSetting, SanitizerSet, UsedBy};
+use rustc_hir::attrs::{
+    CoverageAttrKind, InstrumentFnAttr, OptimizeAttr, RtsanSetting, SanitizerSet, UsedBy,
+};
 use rustc_session::errors::feature_err;
 use rustc_span::edition::Edition::Edition2024;
 
@@ -572,6 +574,44 @@ impl CombineAttributeParser for ForceTargetFeatureParser {
         args: &ArgParser,
     ) -> impl IntoIterator<Item = Self::Item> {
         parse_tf_attribute(cx, args)
+    }
+}
+
+pub(crate) struct InstrumentFnParser;
+
+impl SingleAttributeParser for InstrumentFnParser {
+    const PATH: &[Symbol] = &[sym::instrument_fn];
+    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
+        Allow(Target::Fn),
+        Allow(Target::Method(MethodKind::Inherent)),
+        Allow(Target::Method(MethodKind::Trait { body: true })),
+        Allow(Target::Method(MethodKind::TraitImpl)),
+    ]);
+    const TEMPLATE: AttributeTemplate = template!(NameValueStr: "on|off");
+    const STABILITY: AttributeStability = unstable!(instrument_fn);
+
+    fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
+        let instrument = match args {
+            ArgParser::NameValue(nv) => match nv.value_as_str() {
+                Some(sym::on) => Some(AttributeKind::InstrumentFn(InstrumentFnAttr::On)),
+                Some(sym::off) => Some(AttributeKind::InstrumentFn(InstrumentFnAttr::Off)),
+                _ => {
+                    cx.adcx()
+                        .expected_specific_argument_strings(nv.value_span, &[sym::on, sym::off]);
+                    None
+                }
+            },
+            ArgParser::List(l) => {
+                cx.adcx().expected_single_argument(l.span, l.len());
+                None
+            }
+            ArgParser::NoArgs => {
+                let span = cx.attr_span;
+                cx.adcx().expected_specific_argument_strings(span, &[sym::on, sym::off]);
+                None
+            }
+        };
+        instrument
     }
 }
 

--- a/compiler/rustc_attr_parsing/src/context.rs
+++ b/compiler/rustc_attr_parsing/src/context.rs
@@ -189,6 +189,7 @@ attribute_parsers!(
         Single<IgnoreParser>,
         Single<InlineParser>,
         Single<InstructionSetParser>,
+        Single<InstrumentFnParser>,
         Single<LangParser>,
         Single<LinkNameParser>,
         Single<LinkOrdinalParser>,

--- a/compiler/rustc_codegen_llvm/src/attributes.rs
+++ b/compiler/rustc_codegen_llvm/src/attributes.rs
@@ -3,7 +3,8 @@ use rustc_hir::attrs::{InlineAttr, InstructionSetAttr, OptimizeAttr, RtsanSettin
 use rustc_hir::def_id::DefId;
 use rustc_hir::find_attr;
 use rustc_middle::middle::codegen_fn_attrs::{
-    CodegenFnAttrFlags, CodegenFnAttrs, PatchableFunctionEntry, SanitizerFnAttrs, TargetFeature,
+    CodegenFnAttrFlags, CodegenFnAttrs, InstrumentFnAttr, PatchableFunctionEntry, SanitizerFnAttrs,
+    TargetFeature,
 };
 use rustc_middle::ty::{self, Instance, TyCtxt};
 use rustc_session::config::{BranchProtection, FunctionReturn, OptLevel, PAuthKey, PacRet};
@@ -210,35 +211,59 @@ fn function_return_attr<'ll>(cx: &SimpleCx<'ll>, sess: &Session) -> Option<&'ll 
 fn instrument_function_attr<'ll>(
     cx: &SimpleCx<'ll>,
     sess: &Session,
+    instrument_fn: InstrumentFnAttr,
 ) -> SmallVec<[&'ll Attribute; 4]> {
     let mut attrs = SmallVec::new();
     if sess.opts.unstable_opts.instrument_mcount {
         // Similar to `clang -pg` behavior. Handled by the
         // `post-inline-ee-instrument` LLVM pass.
 
-        // The function name varies on platforms.
-        // See test/CodeGen/mcount.c in clang.
-        let mcount_name = match &sess.target.llvm_mcount_intrinsic {
-            Some(llvm_mcount_intrinsic) => llvm_mcount_intrinsic.as_ref(),
-            None => sess.target.mcount.as_ref(),
+        let instrument_entry = match instrument_fn {
+            InstrumentFnAttr::Default | InstrumentFnAttr::On => true,
+            InstrumentFnAttr::Off => false,
         };
 
-        attrs.push(llvm::CreateAttrStringValue(
-            cx.llcx,
-            "instrument-function-entry-inlined",
-            mcount_name,
-        ));
+        if instrument_entry {
+            // The function name varies on platforms.
+            // See test/CodeGen/mcount.c in clang.
+            let mcount_name = match &sess.target.llvm_mcount_intrinsic {
+                Some(llvm_mcount_intrinsic) => llvm_mcount_intrinsic.as_ref(),
+                None => sess.target.mcount.as_ref(),
+            };
+
+            attrs.push(llvm::CreateAttrStringValue(
+                cx.llcx,
+                "instrument-function-entry-inlined",
+                mcount_name,
+            ));
+        }
     }
     if let Some(options) = &sess.opts.unstable_opts.instrument_xray {
         // XRay instrumentation is similar to __cyg_profile_func_{enter,exit}.
         // Function prologue and epilogue are instrumented with NOP sleds,
         // a runtime library later replaces them with detours into tracing code.
-        if options.always {
-            attrs.push(llvm::CreateAttrStringValue(cx.llcx, "function-instrument", "xray-always"));
+
+        let mut never = options.never;
+        let mut always = options.always;
+
+        // always and never may be overridden by the #[instrument_fn = ...] attribute.
+        match instrument_fn {
+            InstrumentFnAttr::Default => {}
+            InstrumentFnAttr::On => {
+                always = true;
+            }
+            InstrumentFnAttr::Off => {
+                never = true;
+            }
         }
-        if options.never {
+
+        if never {
             attrs.push(llvm::CreateAttrStringValue(cx.llcx, "function-instrument", "xray-never"));
         }
+        if always {
+            attrs.push(llvm::CreateAttrStringValue(cx.llcx, "function-instrument", "xray-always"));
+        }
+
         if options.ignore_loops {
             attrs.push(llvm::CreateAttrString(cx.llcx, "xray-ignore-loops"));
         }
@@ -442,7 +467,7 @@ pub(crate) fn llfn_attrs_from_instance<'ll, 'tcx>(
     // FIXME: none of these functions interact with source level attributes.
     to_add.extend(frame_pointer_type_attr(cx, sess));
     to_add.extend(function_return_attr(cx, sess));
-    to_add.extend(instrument_function_attr(cx, sess));
+    to_add.extend(instrument_function_attr(cx, sess, codegen_fn_attrs.instrument_fn));
     to_add.extend(nojumptables_attr(cx, sess));
     to_add.extend(probestack_attr(cx, tcx));
     to_add.extend(stackprotector_attr(cx, sess));

--- a/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
+++ b/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
@@ -1,13 +1,14 @@
 use rustc_abi::{Align, ExternAbi};
 use rustc_hir::attrs::{
-    AttributeKind, EiiImplResolution, InlineAttr, Linkage, RtsanSetting, UsedBy,
+    AttributeKind, EiiImplResolution, InlineAttr, InstrumentFnAttr as HirInstrumentFnAttr, Linkage,
+    RtsanSetting, UsedBy,
 };
 use rustc_hir::def::DefKind;
 use rustc_hir::def_id::{DefId, LOCAL_CRATE, LocalDefId};
 use rustc_hir::{self as hir, Attribute, find_attr};
 use rustc_macros::Diagnostic;
 use rustc_middle::middle::codegen_fn_attrs::{
-    CodegenFnAttrFlags, CodegenFnAttrs, PatchableFunctionEntry, SanitizerFnAttrs,
+    CodegenFnAttrFlags, CodegenFnAttrs, InstrumentFnAttr, PatchableFunctionEntry, SanitizerFnAttrs,
 };
 use rustc_middle::mono::Visibility;
 use rustc_middle::query::Providers;
@@ -292,6 +293,12 @@ fn process_builtin_attrs(
             AttributeKind::PatchableFunctionEntry { prefix, entry } => {
                 codegen_fn_attrs.patchable_function_entry =
                     Some(PatchableFunctionEntry::from_prefix_and_entry(*prefix, *entry));
+            }
+            AttributeKind::InstrumentFn(instrument_fn) => {
+                codegen_fn_attrs.instrument_fn = match instrument_fn {
+                    HirInstrumentFnAttr::On => InstrumentFnAttr::On,
+                    HirInstrumentFnAttr::Off => InstrumentFnAttr::Off,
+                };
             }
             _ => {}
         }

--- a/compiler/rustc_feature/src/builtin_attrs.rs
+++ b/compiler/rustc_feature/src/builtin_attrs.rs
@@ -219,6 +219,12 @@ pub static BUILTIN_ATTRIBUTES: &[Symbol] = &[
     // - https://github.com/rust-lang/rust/pull/156816
     sym::unroll,
 
+    // `#[instrument_fn = "on|off"]` to insert or inhibit instrumentation function
+    // calls inside a function, usually around the prologue.
+    //
+    // - https://github.com/rust-lang/rust/issues/157081
+    sym::instrument_fn,
+
     // ==========================================================================
     // Internal attributes: Stability, deprecation, and unsafe:
     // ==========================================================================

--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -595,6 +595,8 @@ declare_features! (
     (unstable, import_trait_associated_functions, "1.86.0", Some(134691)),
     /// Allows associated types in inherent impls.
     (incomplete, inherent_associated_types, "1.52.0", Some(8995)),
+    /// Enable #[instrument_fn] on function.
+    (unstable, instrument_fn, "CURRENT_RUSTC_VERSION", Some(157081)),
     /// Allows using `pointer` and `reference` in intra-doc links
     (unstable, intra_doc_pointers, "1.51.0", Some(80896)),
     /// lahfsahf target feature on x86.

--- a/compiler/rustc_hir/src/attrs/data_structures.rs
+++ b/compiler/rustc_hir/src/attrs/data_structures.rs
@@ -143,6 +143,14 @@ pub enum InstructionSetAttr {
     ArmT32,
 }
 
+#[derive(Copy, Clone, PartialEq, Encodable, Decodable, Debug, Eq, StableHash, PrintAttribute)]
+pub enum InstrumentFnAttr {
+    /// `#[instrument_fn = "on"]`
+    On,
+    /// `#[instrument_fn = "off"]`
+    Off,
+}
+
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Default, PrintAttribute)]
 #[derive(Encodable, Decodable, StableHash)]
 pub enum OptimizeAttr {
@@ -1067,6 +1075,9 @@ pub enum AttributeKind {
 
     /// Represents `#[instruction_set]`
     InstructionSet(InstructionSetAttr),
+
+    /// Represents `#[instrument_fn]`
+    InstrumentFn(InstrumentFnAttr),
 
     /// Represents `#[lang]`
     Lang(LangItem),

--- a/compiler/rustc_hir/src/attrs/encode_cross_crate.rs
+++ b/compiler/rustc_hir/src/attrs/encode_cross_crate.rs
@@ -50,6 +50,7 @@ impl AttributeKind {
             Ignore { .. } => No,
             Inline(..) => No,
             InstructionSet(..) => No,
+            InstrumentFn(..) => No,
             Lang(..) => Yes,
             Link(..) => No,
             LinkName { .. } => Yes, // Needed for rustdoc

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -5408,6 +5408,16 @@ impl<'hir> Node<'hir> {
         }
     }
 
+    /// For expressions, patterns, and types return the path if it's a path expr/pat/ty.
+    pub fn path(self) -> Option<&'hir QPath<'hir>> {
+        match self {
+            Node::Ty(Ty { kind: TyKind::Path(path), .. })
+            | Node::Expr(Expr { kind: ExprKind::Path(path), .. })
+            | Node::PatExpr(PatExpr { kind: PatExprKind::Path(path), .. }) => Some(path),
+            _ => None,
+        }
+    }
+
     expect_methods_self! {
         expect_param,         &'hir Param<'hir>,        Node::Param(n),        n;
         expect_item,          &'hir Item<'hir>,         Node::Item(n),         n;

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/dyn_trait.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/dyn_trait.rs
@@ -599,19 +599,8 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
         let tcx = self.tcx();
         let [poly_trait_ref, ..] = hir_bounds else { return None };
 
-        let in_path = match tcx.parent_hir_node(hir_id) {
-            hir::Node::Ty(hir::Ty {
-                kind: hir::TyKind::Path(hir::QPath::TypeRelative(qself, _)),
-                ..
-            })
-            | hir::Node::Expr(hir::Expr {
-                kind: hir::ExprKind::Path(hir::QPath::TypeRelative(qself, _)),
-                ..
-            })
-            | hir::Node::PatExpr(hir::PatExpr {
-                kind: hir::PatExprKind::Path(hir::QPath::TypeRelative(qself, _)),
-                ..
-            }) if qself.hir_id == hir_id => true,
+        let in_path = match tcx.parent_hir_node(hir_id).path() {
+            Some(hir::QPath::TypeRelative(qself, _)) if qself.hir_id == hir_id => true,
             _ => false,
         };
         let needs_bracket = in_path

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
@@ -3509,9 +3509,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
         let fn_ty = tcx.mk_fn_sig(input_tys, output_ty, fn_sig_kind);
         let fn_ptr_ty = ty::Binder::bind_with_vars(fn_ty, bound_vars);
 
-        if let hir::Node::Ty(hir::Ty { kind: hir::TyKind::FnPtr(fn_ptr_ty), span, .. }) =
-            tcx.hir_node(hir_id)
-        {
+        if let Some(hir::Ty { kind: hir::TyKind::FnPtr(fn_ptr_ty), span, .. }) = hir_ty {
             check_abi(tcx, hir_id, *span, fn_ptr_ty.abi);
         }
 

--- a/compiler/rustc_hir_typeck/src/lib.rs
+++ b/compiler/rustc_hir_typeck/src/lib.rs
@@ -317,33 +317,11 @@ fn extend_err_with_const_context(
         // FIXME: support method calls too.
         hir::Node::AnonConst(anon)
             if let hir::Node::ConstArg(parent) = tcx.parent_hir_node(anon.hir_id)
-                && let hir::Node::Expr(expr) = tcx.parent_hir_node(parent.hir_id)
-                && let hir::ExprKind::Path(path) = expr.kind
+                && let Some(path) = tcx.parent_hir_node(parent.hir_id).path()
                 && let hir::QPath::Resolved(_, path) = path
                 && let Res::Def(_, def_id) = path.res =>
         {
-            // `foo<N>()` in expression context, point at `foo`'s const parameter.
-            if let Some(i) =
-                path.segments.iter().last().and_then(|segment| segment.args).and_then(|args| {
-                    args.args.iter().position(|arg| {
-                        matches!(arg, hir::GenericArg::Const(arg) if arg.hir_id == parent.hir_id)
-                    })
-                })
-            {
-                let generics = tcx.generics_of(def_id);
-                let param = &generics.param_at(i, tcx);
-                let sp = tcx.def_span(param.def_id);
-                err.span_note(sp, "expected because of the type of the const parameter");
-            }
-        }
-        hir::Node::AnonConst(anon)
-            if let hir::Node::ConstArg(parent) = tcx.parent_hir_node(anon.hir_id)
-                && let hir::Node::Ty(ty) = tcx.parent_hir_node(parent.hir_id)
-                && let hir::TyKind::Path(path) = ty.kind
-                && let hir::QPath::Resolved(_, path) = path
-                && let Res::Def(_, def_id) = path.res =>
-        {
-            // `Foo<N>` in type context, point at `Foo`'s const parameter.
+            // `foo<N>()`, point at the const parameter in the definition of `foo`.
             if let Some(i) =
                 path.segments.iter().last().and_then(|segment| segment.args).and_then(|args| {
                     args.args.iter().position(|arg| {

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -2284,23 +2284,45 @@ declare_lint! {
     ///
     /// ### Explanation
     ///
-    /// If a `struct` contains a reference, such as `&'a T`, the compiler
-    /// requires that `T` outlives the lifetime `'a`. This historically
-    /// required writing an explicit lifetime bound to indicate this
-    /// requirement. However, this can be overly explicit, causing clutter and
-    /// unnecessary complexity. The language was changed to automatically
-    /// infer the bound if it is not specified. Specifically, if the struct
-    /// contains a reference, directly or indirectly, to `T` with lifetime
-    /// `'x`, then it will infer that `T: 'x` is a requirement.
-    ///
-    /// This lint is "allow" by default because it can be noisy for existing
-    /// code that already had these requirements. This is a stylistic choice,
-    /// as it is still valid to explicitly state the bound. It also has some
-    /// false positives that can cause confusion.
+    /// If a struct, enum or union contains a reference, such as `&'a T`,
+    /// the compiler requires that `T` outlives the lifetime `'a`.
+    /// This historically required writing an explicit lifetime bound to indicate this requirement.
+    /// However, this can be overly explicit, causing clutter and unnecessary complexity.
+    /// The language was changed to automatically infer some classes of lifetime bounds
+    /// if they are not specified.
+    /// Specifically, if a struct, enum or union contains a reference, directly or indirectly,
+    /// to `T` with lifetime `'x` and `'x` refers to a lifetime parameter,
+    /// then it will infer that `T: 'x` is a requirement.
     ///
     /// See [RFC 2093] for more details.
     ///
+    /// > [!WARNING]
+    /// > Implicit lifetime bounds are not semantically equivalent to explicit ones since the latter
+    /// > may affect the implicit lifetime bound of trait object types that are passed as arguments
+    /// > to the overarching struct, enum or union.
+    /// > Rephrased, they participate in [trait object lifetime defaulting][TOLD].
+    /// >
+    /// > Consider the following piece of code where removing bound `T: 'a` would lead to a lifetime
+    /// > error in function `scope`:
+    /// >
+    /// > ```rust,no_run
+    /// > struct Ref<'a, T: ?Sized + 'a>(&'a T);
+    /// >
+    /// > fn scope() {
+    /// >     let buf = String::new();
+    /// >     let str = buf.as_str();
+    /// >     render(Ref(&str));
+    /// > }
+    /// >
+    /// > fn render(_: Ref<dyn std::fmt::Display>) {}
+    /// > ```
+    /// >
+    /// > Consequently, removing explicit outlives-bounds on type parameters of publicly reachable types
+    /// > constitutes a **breaking change** if the lifetime refers to a lifetime parameter and
+    /// > the type parameter is not bounded by `Sized` (thereby admitting trait object types).
+    ///
     /// [RFC 2093]: https://github.com/rust-lang/rfcs/blob/master/text/2093-infer-outlives.md
+    /// [TOLD]: https://doc.rust-lang.org/reference/lifetime-elision.html#default-trait-object-lifetimes
     pub EXPLICIT_OUTLIVES_REQUIREMENTS,
     Allow,
     "outlives requirements can be inferred"

--- a/compiler/rustc_middle/src/middle/codegen_fn_attrs.rs
+++ b/compiler/rustc_middle/src/middle/codegen_fn_attrs.rs
@@ -117,6 +117,24 @@ pub struct CodegenFnAttrs {
     pub objc_class: Option<Symbol>,
     /// The `#[rustc_objc_selector = "..."]` attribute.
     pub objc_selector: Option<Symbol>,
+    /// The `#[instrument_fn]` attribute.
+    pub instrument_fn: InstrumentFnAttr,
+}
+
+#[derive(Copy, Clone, TyEncodable, TyDecodable, StableHash, Debug)]
+pub enum InstrumentFnAttr {
+    /// Always instrument function
+    On,
+    /// Never instrument function
+    Off,
+    /// Instrument based on command line options, if any.
+    Default,
+}
+
+const impl Default for InstrumentFnAttr {
+    fn default() -> Self {
+        InstrumentFnAttr::Default
+    }
 }
 
 #[derive(Copy, Clone, Debug, TyEncodable, TyDecodable, StableHash, PartialEq, Eq)]
@@ -244,6 +262,7 @@ impl CodegenFnAttrs {
             patchable_function_entry: None,
             objc_class: None,
             objc_selector: None,
+            instrument_fn: InstrumentFnAttr::default(),
         }
     }
 

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -280,6 +280,7 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
             AttributeKind::Fundamental => (),
             AttributeKind::Ignore { .. } => (),
             AttributeKind::InstructionSet(..) => (),
+            AttributeKind::InstrumentFn(..) => (),
             AttributeKind::Lang(..) => (),
             AttributeKind::LinkName { .. } => (),
             AttributeKind::LinkOrdinal { .. } => (),

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1122,6 +1122,7 @@ symbols! {
         inout,
         inputs,
         instruction_set,
+        instrument_fn,
         integer_: "integer", // underscore to avoid clashing with the function `sym::integer` below
         integral,
         internal,

--- a/library/core/src/ops/unsize.rs
+++ b/library/core/src/ops/unsize.rs
@@ -39,7 +39,10 @@ pub trait CoerceUnsized<T: PointeeSized>: Sized {
 
 // &mut T -> &mut U
 #[unstable(feature = "coerce_unsized", issue = "18598")]
-impl<'a, T: PointeeSized + Unsize<U>, U: PointeeSized> CoerceUnsized<&'a mut U> for &'a mut T {}
+impl<'a, 'b: 'a, T: PointeeSized + Unsize<U>, U: PointeeSized> CoerceUnsized<&'a mut U>
+    for &'b mut T
+{
+}
 // &mut T -> &U
 #[unstable(feature = "coerce_unsized", issue = "18598")]
 impl<'a, 'b: 'a, T: PointeeSized + Unsize<U>, U: PointeeSized> CoerceUnsized<&'a U> for &'b mut T {}

--- a/library/core/src/random.rs
+++ b/library/core/src/random.rs
@@ -4,13 +4,13 @@ use crate::ops::RangeFull;
 
 /// A source of randomness.
 #[unstable(feature = "random", issue = "130703")]
-pub trait RandomSource {
+pub trait Rng {
     /// Fills `bytes` with random bytes.
     ///
     /// Note that calling `fill_bytes` multiple times is not equivalent to calling `fill_bytes` once
-    /// with a larger buffer. A `RandomSource` is allowed to return different bytes for those two
-    /// cases. For instance, this allows a `RandomSource` to generate a word at a time and throw
-    /// part of it away if not needed.
+    /// with a larger buffer. An `Rng` is allowed to return different bytes for those two cases. For
+    /// instance, this allows an `Rng` to generate a word at a time and throw part of it away if not
+    /// needed.
     fn fill_bytes(&mut self, bytes: &mut [u8]);
 }
 
@@ -18,17 +18,17 @@ pub trait RandomSource {
 #[unstable(feature = "random", issue = "130703")]
 pub trait Distribution<T> {
     /// Samples a random value from the distribution, using the specified random source.
-    fn sample(&self, source: &mut (impl RandomSource + ?Sized)) -> T;
+    fn sample(&self, source: &mut (impl Rng + ?Sized)) -> T;
 }
 
 impl<T, DT: Distribution<T>> Distribution<T> for &DT {
-    fn sample(&self, source: &mut (impl RandomSource + ?Sized)) -> T {
+    fn sample(&self, source: &mut (impl Rng + ?Sized)) -> T {
         (*self).sample(source)
     }
 }
 
 impl Distribution<bool> for RangeFull {
-    fn sample(&self, source: &mut (impl RandomSource + ?Sized)) -> bool {
+    fn sample(&self, source: &mut (impl Rng + ?Sized)) -> bool {
         let byte: u8 = RangeFull.sample(source);
         byte & 1 == 1
     }
@@ -37,7 +37,7 @@ impl Distribution<bool> for RangeFull {
 macro_rules! impl_primitive {
     ($t:ty) => {
         impl Distribution<$t> for RangeFull {
-            fn sample(&self, source: &mut (impl RandomSource + ?Sized)) -> $t {
+            fn sample(&self, source: &mut (impl Rng + ?Sized)) -> $t {
                 let mut bytes = (0 as $t).to_ne_bytes();
                 source.fill_bytes(&mut bytes);
                 <$t>::from_ne_bytes(bytes)

--- a/library/std/src/random.rs
+++ b/library/std/src/random.rs
@@ -5,7 +5,7 @@ pub use core::random::*;
 
 use crate::sys::random as sys;
 
-/// The default random source.
+/// The system random number generator.
 ///
 /// This asks the system for random data suitable for cryptographic purposes
 /// such as key generation. If security is a concern, consult the platform
@@ -16,7 +16,7 @@ use crate::sys::random as sys;
 /// security is not a concern,  consider using an alternative random number
 /// generator (potentially seeded from this one).
 ///
-/// If you need to fill a buffer with random bytes, use `DefaultRandomSource.fill_bytes(&mut buf)`.
+/// If you need to fill a buffer with random bytes, use `SystemRng.fill_bytes(&mut buf)`.
 ///
 /// # Underlying sources
 ///
@@ -59,10 +59,10 @@ use crate::sys::random as sys;
 #[doc(alias = "getrandom", alias = "getentropy", alias = "arc4random")]
 #[derive(Default, Debug, Clone, Copy)]
 #[unstable(feature = "random", issue = "130703")]
-pub struct DefaultRandomSource;
+pub struct SystemRng;
 
 #[unstable(feature = "random", issue = "130703")]
-impl RandomSource for DefaultRandomSource {
+impl Rng for SystemRng {
     fn fill_bytes(&mut self, bytes: &mut [u8]) {
         sys::fill_bytes(bytes)
     }
@@ -70,9 +70,9 @@ impl RandomSource for DefaultRandomSource {
 
 /// Generates a random value from a distribution, using the default random source.
 ///
-/// This is a convenience function for `dist.sample(&mut DefaultRandomSource)` and will sample
-/// according to the same distribution as the underlying [`Distribution`] trait implementation. See
-/// [`DefaultRandomSource`] for more information about how randomness is sourced.
+/// This is a convenience function for `dist.sample(&mut SystemRng)` and will sample according to
+/// the same distribution as the underlying [`Distribution`] trait implementation. See [`SystemRng`]
+/// for more information about how randomness is sourced.
 ///
 /// # Examples
 ///
@@ -95,5 +95,5 @@ impl RandomSource for DefaultRandomSource {
 /// [version 4/variant 1 UUID]: https://en.wikipedia.org/wiki/Universally_unique_identifier#Version_4_(random)
 #[unstable(feature = "random", issue = "130703")]
 pub fn random<T>(dist: impl Distribution<T>) -> T {
-    dist.sample(&mut DefaultRandomSource)
+    dist.sample(&mut SystemRng)
 }

--- a/library/std/src/sys/random/arc4random.rs
+++ b/library/std/src/sys/random/arc4random.rs
@@ -3,11 +3,11 @@
 //! Contrary to its name, `arc4random` doesn't actually use the horribly-broken
 //! RC4 cypher anymore, at least not on modern systems, but rather something
 //! like ChaCha20 with continual reseeding from the OS. That makes it an ideal
-//! source of large quantities of cryptographically secure data, which is exactly
-//! what we need for `DefaultRandomSource`. Unfortunately, it's not available
-//! on all UNIX systems, most notably Linux (until recently, but it's just a
-//! wrapper for `getrandom`. Since we need to hook into `getrandom` directly
-//! for `HashMap` keys anyway, we just keep our version).
+//! source of large quantities of cryptographically secure data, which is
+//! exactly what we need for `SystemRng`. Unfortunately, it's not available on
+//! all UNIX systems, most notably Linux (until recently, but it's just a
+//! wrapper for `getrandom`. Since we need to hook into `getrandom` directly for
+//! `HashMap` keys anyway, we just keep our version).
 
 #[cfg(not(any(
     target_os = "haiku",

--- a/library/std/src/sys/random/linux.rs
+++ b/library/std/src/sys/random/linux.rs
@@ -23,11 +23,11 @@
 //!
 //! One additional consideration to make is that the non-blocking pool is not
 //! always initialized during early boot. We want the best quality of randomness
-//! for the output of `DefaultRandomSource` so we simply wait until it is
-//! initialized. When `HashMap` keys however, this represents a potential source
-//! of deadlocks, as the additional entropy may only be generated once the
-//! program makes forward progress. In that case, we just use the best random
-//! data the system has available at the time.
+//! for the output of `SystemRng` so we simply wait until it is initialized.
+//! When `HashMap` keys however, this represents a potential source of
+//! deadlocks, as the additional entropy may only be generated once the program
+//! makes forward progress. In that case, we just use the best random data the
+//! system has available at the time.
 //!
 //! So in conclusion, we always want the output of the non-blocking pool, but
 //! may need to wait until it is initialized. The default behavior of `getrandom`

--- a/tests/codegen-llvm/instrument_fn.rs
+++ b/tests/codegen-llvm/instrument_fn.rs
@@ -1,0 +1,49 @@
+// Verify the #[instrument_fn] applies the correct LLVM IR function attributes.
+//
+//@ revisions:XRAY MCOUNT
+//@ add-minicore
+//@ compile-flags: -Copt-level=0
+//@ [XRAY] compile-flags: -Zinstrument-xray --target=x86_64-unknown-linux-gnu
+//@ [XRAY] needs-llvm-components: x86
+//@ [MCOUNT] compile-flags: -Zinstrument-mcount
+
+#![feature(no_core)]
+#![crate_type = "lib"]
+#![feature(instrument_fn)]
+#![no_core]
+
+extern crate minicore;
+use minicore::*;
+
+#[no_mangle]
+// CHECK: define {{.*}}void @instrument_default() {{.*}} [[DFLT_ATTR:#[0-9]+]]
+fn instrument_default() {}
+
+#[no_mangle]
+#[instrument_fn = "off"]
+// CHECK: define {{.*}}void @instrument_off() {{.*}} [[OFF_ATTR:#[0-9]+]]
+fn instrument_off() {}
+
+#[no_mangle]
+#[instrument_fn = "on"]
+// MCOUNT: define {{.*}}void @instrument_on() {{.*}} [[DFLT_ATTR]]
+// XRAY: define void @instrument_on() {{.*}} [[ON_ATTR:#[0-9]+]]
+fn instrument_on() {}
+
+// MCOUNT: attributes [[DFLT_ATTR]] {{.*}} "instrument-function-entry-inlined"=
+// MCOUNT-NOT: attributes [[OFF_ATTR]] {{.*}} "instrument-function-entry-inlined"=
+
+// XRAY-NOT: attributes [[DFLT_ATTR]] {{.*}} "function-instrument"="xray-always"
+// XRAY-NOT: attributes [[DFLT_ATTR]] {{.*}} "function-instrument"="xray-never"
+// XRAY-NOT: attributes [[DFLT_ATTR]] {{.*}} "xray-skip-exit"
+// XRAY-NOT: attributes [[DFLT_ATTR]] {{.*}} "xray-skip-entry"
+
+// XRAY-NOT: attributes [[OFF_ATTR]] {{.*}} "function-instrument"="xray-always"
+// XRAY:     attributes [[OFF_ATTR]] {{.*}} "function-instrument"="xray-never"
+// XRAY-NOT: attributes [[OFF_ATTR]] {{.*}} "xray-skip-exit"
+// XRAY-NOT: attributes [[OFF_ATTR]] {{.*}} "xray-skip-entry"
+
+// XRAY:     attributes [[ON_ATTR]] {{.*}} "function-instrument"="xray-always"
+// XRAY-NOT: attributes [[ON_ATTR]] {{.*}} "function-instrument"="xray-never"
+// XRAY-NOT: attributes [[ON_ATTR]] {{.*}} "xray-skip-exit"
+// XRAY-NOT: attributes [[ON_ATTR]] {{.*}} "xray-skip-entry"

--- a/tests/run-make/cdylib-export-c-library-symbols/rmake.rs
+++ b/tests/run-make/cdylib-export-c-library-symbols/rmake.rs
@@ -7,7 +7,9 @@
 //@ ignore-apple
 // Reason: the compiled binary is executed
 
-use run_make_support::{build_native_static_lib, cc, dynamic_lib_name, is_darwin, llvm_nm, rustc};
+use run_make_support::{
+    build_native_static_lib, cc, dynamic_lib_name, is_aix, is_darwin, llvm_nm, rustc,
+};
 
 fn main() {
     cc().input("foo.c").arg("-c").out_exe("foo.o").run();
@@ -27,6 +29,11 @@ fn main() {
             .input(dynamic_lib_name("foo_export"))
             .run()
             .assert_stdout_contains("T _my_function");
+    } else if is_aix() {
+        let out = llvm_nm()
+            .input(dynamic_lib_name("foo_export"))
+            .run()
+            .assert_stdout_contains("T .my_function");
     } else {
         let out = llvm_nm()
             .input(dynamic_lib_name("foo_export"))

--- a/tests/run-make/incremental-finalize-fail/rmake.rs
+++ b/tests/run-make/incremental-finalize-fail/rmake.rs
@@ -87,6 +87,8 @@ fn find_proc_macro_dylib(name: &str) -> PathBuf {
         "dylib"
     } else if cfg!(target_os = "windows") {
         "dll"
+    } else if cfg!(target_os = "aix") {
+        "a"
     } else {
         "so"
     };

--- a/tests/ui/attributes/instrument_fn.rs
+++ b/tests/ui/attributes/instrument_fn.rs
@@ -1,0 +1,51 @@
+#![feature(instrument_fn)]
+#![instrument_fn = "off"] //~ ERROR attribute cannot be used on
+
+#[instrument_fn = "on"] //~ ERROR attribute cannot be used on
+struct F;
+
+#[instrument_fn = "on"] //~ ERROR attribute cannot be used on
+mod module {}
+
+#[instrument_fn = "on"] //~ ERROR attribute cannot be used on
+impl F {
+    #[instrument_fn = "off"]
+    fn no_instrument_fn(self, x: u32) -> u32 {
+        #[instrument_fn = "off"] //~ ERROR attribute cannot be used on
+        //~^ ERROR attributes on expressions are experimental
+        x * 2
+    }
+}
+
+#[instrument_fn = "off"] //~ ERROR attribute cannot be used on
+trait Foo {
+    #[instrument_fn = "off"] //~ ERROR attribute cannot be used on
+    fn bar();
+
+    #[instrument_fn = "off"]
+    fn baz() {}
+}
+
+impl Foo for F {
+    #[instrument_fn = "off"]
+    fn bar() {}
+}
+
+#[instrument_fn = "on"]
+fn main() {}
+
+#[instrument_fn(entry = "on")] //~ ERROR malformed
+fn instrument_fn_list() {}
+
+#[instrument_fn] //~ ERROR malformed
+fn instrument_fn_noarg() {}
+
+#[instrument_fn = 1] //~ ERROR malformed
+fn instrument_fn_invalid_opt() {}
+
+fn instrument_closure() {
+    let _x = #[instrument_fn = "on"]
+    || {};
+    //~^^ ERROR attribute cannot be used on
+    //~^^^ ERROR attributes on expressions are experimental
+}

--- a/tests/ui/attributes/instrument_fn.stderr
+++ b/tests/ui/attributes/instrument_fn.stderr
@@ -1,0 +1,127 @@
+error[E0658]: attributes on expressions are experimental
+  --> $DIR/instrument_fn.rs:14:9
+   |
+LL |         #[instrument_fn = "off"]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
+   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: attributes on expressions are experimental
+  --> $DIR/instrument_fn.rs:47:14
+   |
+LL |     let _x = #[instrument_fn = "on"]
+   |              ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
+   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: `#[instrument_fn]` attribute cannot be used on crates
+  --> $DIR/instrument_fn.rs:2:1
+   |
+LL | #![instrument_fn = "off"]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[instrument_fn]` can only be applied to functions
+
+error: `#[instrument_fn]` attribute cannot be used on structs
+  --> $DIR/instrument_fn.rs:4:1
+   |
+LL | #[instrument_fn = "on"]
+   | ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[instrument_fn]` can only be applied to functions
+
+error: `#[instrument_fn]` attribute cannot be used on modules
+  --> $DIR/instrument_fn.rs:7:1
+   |
+LL | #[instrument_fn = "on"]
+   | ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[instrument_fn]` can only be applied to functions
+
+error: `#[instrument_fn]` attribute cannot be used on inherent impl blocks
+  --> $DIR/instrument_fn.rs:10:1
+   |
+LL | #[instrument_fn = "on"]
+   | ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[instrument_fn]` can only be applied to functions
+
+error: `#[instrument_fn]` attribute cannot be used on expressions
+  --> $DIR/instrument_fn.rs:14:9
+   |
+LL |         #[instrument_fn = "off"]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[instrument_fn]` can only be applied to functions
+
+error: `#[instrument_fn]` attribute cannot be used on traits
+  --> $DIR/instrument_fn.rs:20:1
+   |
+LL | #[instrument_fn = "off"]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[instrument_fn]` can only be applied to functions
+
+error: `#[instrument_fn]` attribute cannot be used on required trait methods
+  --> $DIR/instrument_fn.rs:22:5
+   |
+LL |     #[instrument_fn = "off"]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[instrument_fn]` can only be applied to functions with a body
+
+error[E0805]: malformed `instrument_fn` attribute input
+  --> $DIR/instrument_fn.rs:37:1
+   |
+LL | #[instrument_fn(entry = "on")]
+   | ^^^^^^^^^^^^^^^--------------^
+   |                |
+   |                expected a single argument here
+   |
+help: must be of the form
+   |
+LL - #[instrument_fn(entry = "on")]
+LL + #[instrument_fn = "on|off"]
+   |
+
+error[E0539]: malformed `instrument_fn` attribute input
+  --> $DIR/instrument_fn.rs:40:1
+   |
+LL | #[instrument_fn]
+   | ^^^^^^^^^^^^^^^^ valid arguments are "on" or "off"
+   |
+help: must be of the form
+   |
+LL | #[instrument_fn = "on|off"]
+   |                 ++++++++++
+
+error[E0539]: malformed `instrument_fn` attribute input
+  --> $DIR/instrument_fn.rs:43:1
+   |
+LL | #[instrument_fn = 1]
+   | ^^^^^^^^^^^^^^^^^^-^
+   |                   |
+   |                   valid arguments are "on" or "off"
+   |
+help: must be of the form
+   |
+LL - #[instrument_fn = 1]
+LL + #[instrument_fn = "on|off"]
+   |
+
+error: `#[instrument_fn]` attribute cannot be used on closures
+  --> $DIR/instrument_fn.rs:47:14
+   |
+LL |     let _x = #[instrument_fn = "on"]
+   |              ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[instrument_fn]` can be applied to functions and methods
+
+error: aborting due to 13 previous errors
+
+Some errors have detailed explanations: E0539, E0658, E0805.
+For more information about an error, try `rustc --explain E0539`.

--- a/tests/ui/coercion/unsize-lifetime-shrinking.rs
+++ b/tests/ui/coercion/unsize-lifetime-shrinking.rs
@@ -1,0 +1,253 @@
+// Even though a type being invariant prevents shortening lifetimes via subtyping,
+// unsize coercions may shorten lifetimes through an invariant type,
+// but only if the appropriate CoerceUnsized impl allows it to.
+
+use std::cell::{Cell, Ref, RefMut};
+
+struct Thing;
+trait Trait {}
+impl Trait for Thing {}
+trait Sub: Trait {}
+impl Sub for Thing {}
+
+//////////////////////////////////////////////////
+
+// &T -> &U has a CoerceUnsized impl that allows shortening lifetimes
+
+// Check that unsize-coercion works if the lifetime doesn't change.
+fn ref_to_ref_same_lifetime<'a>(x: Cell<&'a Thing>) -> Cell<&'a (dyn Trait + 'static)> {
+    x
+}
+
+// Sized-to-Sized unsize coercions aren't a thing, so this can't shorten the lifetime.
+fn ref_to_ref_sized_to_sized<'a: 'b, 'b>(x: Cell<&'a Thing>) -> Cell<&'b Thing> {
+    x
+}
+//~^^ ERROR lifetime may not live long enough
+
+// Sized-to-dyn unsize coercions can shorten the lifetime
+// if the CoerceUnsized impl allows it to.
+fn ref_to_ref_sized_to_dyn<'a: 'b, 'b>(x: Cell<&'a Thing>) -> Cell<&'b (dyn Trait + 'static)> {
+    x
+}
+
+// Trait upcasting is an unsize coercion.
+fn ref_to_ref_upcast<'a: 'b, 'b>(
+    x: Cell<&'a (dyn Sub + 'static)>,
+) -> Cell<&'b (dyn Trait + 'static)> {
+    x
+}
+
+// An "identity" coercion from a trait object to itself is an unsize coercion.
+fn ref_to_ref_dyn_same<'a: 'b, 'b>(
+    x: Cell<&'a (dyn Trait + 'static)>,
+) -> Cell<&'b (dyn Trait + 'static)> {
+    x
+}
+
+// An unsize coercion can, surprisingly, shorten the lifetime inside a trait object.
+// This ignores whether CoerceUnsized allows shortening lifetimes or not,
+// since the lifetime-shortening is done "inside" Unsize, not CoerceUnsized.
+fn ref_to_ref_shorten_in_dyn<'a>(x: Cell<&'a (dyn Trait + 'static)>) -> Cell<&'a (dyn Trait + 'a)> {
+    x
+}
+
+//////////////////////////////////////////////////
+
+// &mut T -> &U has a CoerceUnsized impl that allows shortening lifetimes
+
+// Check that unsize-coercion works if the lifetime doesn't change.
+fn mut_to_ref_same_lifetime<'a>(x: Cell<&'a mut Thing>) -> Cell<&'a (dyn Trait + 'static)> {
+    x
+}
+
+// Sized-to-Sized unsize coercions aren't a thing, so this can't shorten the lifetime.
+fn mut_to_ref_sized_to_sized<'a: 'b, 'b>(x: Cell<&'a mut Thing>) -> Cell<&'b Thing> {
+    x
+}
+//~^^ ERROR mismatched types
+
+// Sized-to-dyn unsize coercions can shorten the lifetime
+// if the CoerceUnsized impl allows it to.
+fn mut_to_ref_sized_to_dyn<'a: 'b, 'b>(x: Cell<&'a mut Thing>) -> Cell<&'b (dyn Trait + 'static)> {
+    x
+}
+
+// Trait upcasting is an unsize coercion.
+fn mut_to_ref_upcast<'a: 'b, 'b>(
+    x: Cell<&'a mut (dyn Sub + 'static)>,
+) -> Cell<&'b (dyn Trait + 'static)> {
+    x
+}
+
+// An "identity" coercion from a trait object to itself is an unsize coercion.
+fn mut_to_ref_dyn_same<'a: 'b, 'b>(
+    x: Cell<&'a mut (dyn Trait + 'static)>,
+) -> Cell<&'b (dyn Trait + 'static)> {
+    x
+}
+
+// An unsize coercion can, surprisingly, shorten the lifetime inside a trait object.
+// This ignores whether CoerceUnsized allows shortening lifetimes or not,
+// since the lifetime-shortening is done "inside" Unsize, not CoerceUnsized.
+fn mut_to_ref_shorten_in_dyn<'a>(
+    x: Cell<&'a mut (dyn Trait + 'static)>,
+) -> Cell<&'a (dyn Trait + 'a)> {
+    x
+}
+
+//////////////////////////////////////////////////
+
+// &mut T -> &mut U has a CoerceUnsized impl that does not allow shortening lifetimes.
+// This may change in the future.
+
+// Check that unsize-coercion works if the lifetime doesn't change.
+fn mut_to_mut_same_lifetime<'a>(x: Cell<&'a mut Thing>) -> Cell<&'a mut (dyn Trait + 'static)> {
+    x
+}
+
+// Sized-to-Sized unsize coercions aren't a thing, so this can't shorten the lifetime.
+fn mut_to_mut_sized_to_sized<'a: 'b, 'b>(x: Cell<&'a mut Thing>) -> Cell<&'b mut Thing> {
+    x
+}
+//~^^ ERROR lifetime may not live long enough
+
+// Sized-to-dyn unsize coercions can shorten the lifetime
+// if the CoerceUnsized impl allows it to.
+fn mut_to_mut_sized_to_dyn<'a: 'b, 'b>(
+    x: Cell<&'a mut Thing>,
+) -> Cell<&'b mut (dyn Trait + 'static)> {
+    x
+}
+//~^^ ERROR lifetime may not live long enough
+
+// Trait upcasting is an unsize coercion.
+fn mut_to_mut_upcast<'a: 'b, 'b>(
+    x: Cell<&'a mut (dyn Sub + 'static)>,
+) -> Cell<&'b mut (dyn Trait + 'static)> {
+    x
+}
+//~^^ ERROR lifetime may not live long enough
+
+// An "identity" coercion from a trait object to itself is an unsize coercion.
+fn mut_to_mut_dyn_same<'a: 'b, 'b>(
+    x: Cell<&'a mut (dyn Trait + 'static)>,
+) -> Cell<&'b mut (dyn Trait + 'static)> {
+    x
+}
+//~^^ ERROR lifetime may not live long enough
+
+// An unsize coercion can, surprisingly, shorten the lifetime inside a trait object.
+// This ignores whether CoerceUnsized allows shortening lifetimes or not,
+// since the lifetime-shortening is done "inside" Unsize, not CoerceUnsized.
+fn mut_to_mut_shorten_in_dyn<'a>(
+    x: Cell<&'a mut (dyn Trait + 'static)>,
+) -> Cell<&'a mut (dyn Trait + 'a)> {
+    x
+}
+
+//////////////////////////////////////////////////
+
+// Ref<T> -> Ref<U> has a CoerceUnsized impl that does not allow shortening lifetimes.
+// This may change in the future.
+
+// Check that unsize-coercion works if the lifetime doesn't change.
+fn cell_ref_same_lifetime<'a>(x: Cell<Ref<'a, Thing>>) -> Cell<Ref<'a, dyn Trait + 'static>> {
+    x
+}
+
+// Sized-to-Sized unsize coercions aren't a thing, so this can't shorten the lifetime.
+fn cell_ref_sized_to_sized<'a: 'b, 'b>(x: Cell<Ref<'a, Thing>>) -> Cell<Ref<'b, Thing>> {
+    x
+}
+//~^^ ERROR lifetime may not live long enough
+
+// Sized-to-dyn unsize coercions can shorten the lifetime
+// if the CoerceUnsized impl allows it to.
+fn cell_ref_sized_to_dyn<'a: 'b, 'b>(
+    x: Cell<Ref<'a, Thing>>,
+) -> Cell<Ref<'b, dyn Trait + 'static>> {
+    x
+}
+//~^^ ERROR lifetime may not live long enough
+
+// Trait upcasting is an unsize coercion.
+fn cell_ref_upcast<'a: 'b, 'b>(
+    x: Cell<Ref<'a, dyn Sub + 'static>>,
+) -> Cell<Ref<'b, dyn Trait + 'static>> {
+    x
+}
+//~^^ ERROR lifetime may not live long enough
+
+// An "identity" coercion from a trait object to itself is an unsize coercion.
+fn cell_ref_dyn_same<'a: 'b, 'b>(
+    x: Cell<Ref<'a, dyn Trait + 'static>>,
+) -> Cell<Ref<'b, dyn Trait + 'static>> {
+    x
+}
+//~^^ ERROR lifetime may not live long enough
+
+// An unsize coercion can, surprisingly, shorten the lifetime inside a trait object.
+// This ignores whether CoerceUnsized allows shortening lifetimes or not,
+// since the lifetime-shortening is done "inside" Unsize, not CoerceUnsized.
+fn cell_ref_shorten_in_dyn<'a>(
+    x: Cell<Ref<'a, dyn Trait + 'static>>,
+) -> Cell<Ref<'a, dyn Trait + 'a>> {
+    x
+}
+
+//////////////////////////////////////////////////
+
+// RefMut<T> -> RefMut<U> has a CoerceUnsized impl that does not allow shortening lifetimes.
+// This may change in the future.
+
+// Check that unsize-coercion works if the lifetime doesn't change.
+fn cell_ref_mut_same_lifetime<'a>(
+    x: Cell<RefMut<'a, Thing>>,
+) -> Cell<RefMut<'a, dyn Trait + 'static>> {
+    x
+}
+
+// Sized-to-Sized unsize coercions aren't a thing, so this can't shorten the lifetime.
+fn cell_ref_mut_sized_to_sized<'a: 'b, 'b>(x: Cell<RefMut<'a, Thing>>) -> Cell<RefMut<'b, Thing>> {
+    x
+}
+//~^^ ERROR lifetime may not live long enough
+
+// Sized-to-dyn unsize coercions can shorten the lifetime
+// if the CoerceUnsized impl allows it to.
+fn cell_ref_mut_sized_to_dyn<'a: 'b, 'b>(
+    x: Cell<RefMut<'a, Thing>>,
+) -> Cell<RefMut<'b, dyn Trait + 'static>> {
+    x
+}
+//~^^ ERROR lifetime may not live long enough
+
+// Trait upcasting is an unsize coercion.
+fn cell_ref_mut_upcast<'a: 'b, 'b>(
+    x: Cell<RefMut<'a, dyn Sub + 'static>>,
+) -> Cell<RefMut<'b, dyn Trait + 'static>> {
+    x
+}
+//~^^ ERROR lifetime may not live long enough
+
+// An "identity" coercion from a trait object to itself is an unsize coercion.
+fn cell_ref_mut_dyn_same<'a: 'b, 'b>(
+    x: Cell<RefMut<'a, dyn Trait + 'static>>,
+) -> Cell<RefMut<'b, dyn Trait + 'static>> {
+    x
+}
+//~^^ ERROR lifetime may not live long enough
+
+// An unsize coercion can, surprisingly, shorten the lifetime inside a trait object.
+// This ignores whether CoerceUnsized allows shortening lifetimes or not,
+// since the lifetime-shortening is done "inside" Unsize, not CoerceUnsized.
+fn cell_ref_mut_shorten_in_dyn<'a>(
+    x: Cell<RefMut<'a, dyn Trait + 'static>>,
+) -> Cell<RefMut<'a, dyn Trait + 'a>> {
+    x
+}
+
+//////////////////////////////////////////////////
+
+fn main() {}

--- a/tests/ui/coercion/unsize-lifetime-shrinking.rs
+++ b/tests/ui/coercion/unsize-lifetime-shrinking.rs
@@ -98,8 +98,7 @@ fn mut_to_ref_shorten_in_dyn<'a>(
 
 //////////////////////////////////////////////////
 
-// &mut T -> &mut U has a CoerceUnsized impl that does not allow shortening lifetimes.
-// This may change in the future.
+// &mut T -> &mut U has a CoerceUnsized impl that allows shortening lifetimes
 
 // Check that unsize-coercion works if the lifetime doesn't change.
 fn mut_to_mut_same_lifetime<'a>(x: Cell<&'a mut Thing>) -> Cell<&'a mut (dyn Trait + 'static)> {
@@ -119,7 +118,6 @@ fn mut_to_mut_sized_to_dyn<'a: 'b, 'b>(
 ) -> Cell<&'b mut (dyn Trait + 'static)> {
     x
 }
-//~^^ ERROR lifetime may not live long enough
 
 // Trait upcasting is an unsize coercion.
 fn mut_to_mut_upcast<'a: 'b, 'b>(
@@ -127,7 +125,6 @@ fn mut_to_mut_upcast<'a: 'b, 'b>(
 ) -> Cell<&'b mut (dyn Trait + 'static)> {
     x
 }
-//~^^ ERROR lifetime may not live long enough
 
 // An "identity" coercion from a trait object to itself is an unsize coercion.
 fn mut_to_mut_dyn_same<'a: 'b, 'b>(
@@ -135,7 +132,6 @@ fn mut_to_mut_dyn_same<'a: 'b, 'b>(
 ) -> Cell<&'b mut (dyn Trait + 'static)> {
     x
 }
-//~^^ ERROR lifetime may not live long enough
 
 // An unsize coercion can, surprisingly, shorten the lifetime inside a trait object.
 // This ignores whether CoerceUnsized allows shortening lifetimes or not,

--- a/tests/ui/coercion/unsize-lifetime-shrinking.stderr
+++ b/tests/ui/coercion/unsize-lifetime-shrinking.stderr
@@ -1,0 +1,218 @@
+error[E0308]: mismatched types
+  --> $DIR/unsize-lifetime-shrinking.rs:66:5
+   |
+LL | fn mut_to_ref_sized_to_sized<'a: 'b, 'b>(x: Cell<&'a mut Thing>) -> Cell<&'b Thing> {
+   |                                                                     --------------- expected `Cell<&'b Thing>` because of return type
+LL |     x
+   |     ^ types differ in mutability
+   |
+   = note: expected struct `Cell<&'b Thing>`
+              found struct `Cell<&'a mut Thing>`
+
+error: lifetime may not live long enough
+  --> $DIR/unsize-lifetime-shrinking.rs:24:5
+   |
+LL | fn ref_to_ref_sized_to_sized<'a: 'b, 'b>(x: Cell<&'a Thing>) -> Cell<&'b Thing> {
+   |                              --      -- lifetime `'b` defined here
+   |                              |
+   |                              lifetime `'a` defined here
+LL |     x
+   |     ^ function was supposed to return data with lifetime `'a` but it is returning data with lifetime `'b`
+   |
+   = help: consider adding the following bound: `'b: 'a`
+   = note: requirement occurs because of the type `Cell<&Thing>`, which makes the generic argument `&Thing` invariant
+   = note: the struct `Cell<T>` is invariant over the parameter `T`
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
+
+error: lifetime may not live long enough
+  --> $DIR/unsize-lifetime-shrinking.rs:111:5
+   |
+LL | fn mut_to_mut_sized_to_sized<'a: 'b, 'b>(x: Cell<&'a mut Thing>) -> Cell<&'b mut Thing> {
+   |                              --      -- lifetime `'b` defined here
+   |                              |
+   |                              lifetime `'a` defined here
+LL |     x
+   |     ^ function was supposed to return data with lifetime `'a` but it is returning data with lifetime `'b`
+   |
+   = help: consider adding the following bound: `'b: 'a`
+   = note: requirement occurs because of the type `Cell<&mut Thing>`, which makes the generic argument `&mut Thing` invariant
+   = note: the struct `Cell<T>` is invariant over the parameter `T`
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
+
+error: lifetime may not live long enough
+  --> $DIR/unsize-lifetime-shrinking.rs:120:5
+   |
+LL | fn mut_to_mut_sized_to_dyn<'a: 'b, 'b>(
+   |                            --      -- lifetime `'b` defined here
+   |                            |
+   |                            lifetime `'a` defined here
+...
+LL |     x
+   |     ^ function was supposed to return data with lifetime `'a` but it is returning data with lifetime `'b`
+   |
+   = help: consider adding the following bound: `'b: 'a`
+   = note: requirement occurs because of the type `Cell<&mut dyn Trait>`, which makes the generic argument `&mut dyn Trait` invariant
+   = note: the struct `Cell<T>` is invariant over the parameter `T`
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
+
+error: lifetime may not live long enough
+  --> $DIR/unsize-lifetime-shrinking.rs:128:5
+   |
+LL | fn mut_to_mut_upcast<'a: 'b, 'b>(
+   |                      --      -- lifetime `'b` defined here
+   |                      |
+   |                      lifetime `'a` defined here
+...
+LL |     x
+   |     ^ function was supposed to return data with lifetime `'a` but it is returning data with lifetime `'b`
+   |
+   = help: consider adding the following bound: `'b: 'a`
+   = note: requirement occurs because of the type `Cell<&mut dyn Trait>`, which makes the generic argument `&mut dyn Trait` invariant
+   = note: the struct `Cell<T>` is invariant over the parameter `T`
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
+
+error: lifetime may not live long enough
+  --> $DIR/unsize-lifetime-shrinking.rs:136:5
+   |
+LL | fn mut_to_mut_dyn_same<'a: 'b, 'b>(
+   |                        --      -- lifetime `'b` defined here
+   |                        |
+   |                        lifetime `'a` defined here
+...
+LL |     x
+   |     ^ function was supposed to return data with lifetime `'a` but it is returning data with lifetime `'b`
+   |
+   = help: consider adding the following bound: `'b: 'a`
+   = note: requirement occurs because of the type `Cell<&mut dyn Trait>`, which makes the generic argument `&mut dyn Trait` invariant
+   = note: the struct `Cell<T>` is invariant over the parameter `T`
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
+
+error: lifetime may not live long enough
+  --> $DIR/unsize-lifetime-shrinking.rs:161:5
+   |
+LL | fn cell_ref_sized_to_sized<'a: 'b, 'b>(x: Cell<Ref<'a, Thing>>) -> Cell<Ref<'b, Thing>> {
+   |                            --      -- lifetime `'b` defined here
+   |                            |
+   |                            lifetime `'a` defined here
+LL |     x
+   |     ^ function was supposed to return data with lifetime `'a` but it is returning data with lifetime `'b`
+   |
+   = help: consider adding the following bound: `'b: 'a`
+   = note: requirement occurs because of the type `Cell<Ref<'_, Thing>>`, which makes the generic argument `Ref<'_, Thing>` invariant
+   = note: the struct `Cell<T>` is invariant over the parameter `T`
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
+
+error: lifetime may not live long enough
+  --> $DIR/unsize-lifetime-shrinking.rs:170:5
+   |
+LL | fn cell_ref_sized_to_dyn<'a: 'b, 'b>(
+   |                          --      -- lifetime `'b` defined here
+   |                          |
+   |                          lifetime `'a` defined here
+...
+LL |     x
+   |     ^ function was supposed to return data with lifetime `'a` but it is returning data with lifetime `'b`
+   |
+   = help: consider adding the following bound: `'b: 'a`
+   = note: requirement occurs because of the type `Cell<Ref<'_, dyn Trait>>`, which makes the generic argument `Ref<'_, dyn Trait>` invariant
+   = note: the struct `Cell<T>` is invariant over the parameter `T`
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
+
+error: lifetime may not live long enough
+  --> $DIR/unsize-lifetime-shrinking.rs:178:5
+   |
+LL | fn cell_ref_upcast<'a: 'b, 'b>(
+   |                    --      -- lifetime `'b` defined here
+   |                    |
+   |                    lifetime `'a` defined here
+...
+LL |     x
+   |     ^ function was supposed to return data with lifetime `'a` but it is returning data with lifetime `'b`
+   |
+   = help: consider adding the following bound: `'b: 'a`
+   = note: requirement occurs because of the type `Cell<Ref<'_, dyn Trait>>`, which makes the generic argument `Ref<'_, dyn Trait>` invariant
+   = note: the struct `Cell<T>` is invariant over the parameter `T`
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
+
+error: lifetime may not live long enough
+  --> $DIR/unsize-lifetime-shrinking.rs:186:5
+   |
+LL | fn cell_ref_dyn_same<'a: 'b, 'b>(
+   |                      --      -- lifetime `'b` defined here
+   |                      |
+   |                      lifetime `'a` defined here
+...
+LL |     x
+   |     ^ function was supposed to return data with lifetime `'a` but it is returning data with lifetime `'b`
+   |
+   = help: consider adding the following bound: `'b: 'a`
+   = note: requirement occurs because of the type `Cell<Ref<'_, dyn Trait>>`, which makes the generic argument `Ref<'_, dyn Trait>` invariant
+   = note: the struct `Cell<T>` is invariant over the parameter `T`
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
+
+error: lifetime may not live long enough
+  --> $DIR/unsize-lifetime-shrinking.rs:213:5
+   |
+LL | fn cell_ref_mut_sized_to_sized<'a: 'b, 'b>(x: Cell<RefMut<'a, Thing>>) -> Cell<RefMut<'b, Thing>> {
+   |                                --      -- lifetime `'b` defined here
+   |                                |
+   |                                lifetime `'a` defined here
+LL |     x
+   |     ^ function was supposed to return data with lifetime `'a` but it is returning data with lifetime `'b`
+   |
+   = help: consider adding the following bound: `'b: 'a`
+   = note: requirement occurs because of the type `Cell<RefMut<'_, Thing>>`, which makes the generic argument `RefMut<'_, Thing>` invariant
+   = note: the struct `Cell<T>` is invariant over the parameter `T`
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
+
+error: lifetime may not live long enough
+  --> $DIR/unsize-lifetime-shrinking.rs:222:5
+   |
+LL | fn cell_ref_mut_sized_to_dyn<'a: 'b, 'b>(
+   |                              --      -- lifetime `'b` defined here
+   |                              |
+   |                              lifetime `'a` defined here
+...
+LL |     x
+   |     ^ function was supposed to return data with lifetime `'a` but it is returning data with lifetime `'b`
+   |
+   = help: consider adding the following bound: `'b: 'a`
+   = note: requirement occurs because of the type `Cell<RefMut<'_, dyn Trait>>`, which makes the generic argument `RefMut<'_, dyn Trait>` invariant
+   = note: the struct `Cell<T>` is invariant over the parameter `T`
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
+
+error: lifetime may not live long enough
+  --> $DIR/unsize-lifetime-shrinking.rs:230:5
+   |
+LL | fn cell_ref_mut_upcast<'a: 'b, 'b>(
+   |                        --      -- lifetime `'b` defined here
+   |                        |
+   |                        lifetime `'a` defined here
+...
+LL |     x
+   |     ^ function was supposed to return data with lifetime `'a` but it is returning data with lifetime `'b`
+   |
+   = help: consider adding the following bound: `'b: 'a`
+   = note: requirement occurs because of the type `Cell<RefMut<'_, dyn Trait>>`, which makes the generic argument `RefMut<'_, dyn Trait>` invariant
+   = note: the struct `Cell<T>` is invariant over the parameter `T`
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
+
+error: lifetime may not live long enough
+  --> $DIR/unsize-lifetime-shrinking.rs:238:5
+   |
+LL | fn cell_ref_mut_dyn_same<'a: 'b, 'b>(
+   |                          --      -- lifetime `'b` defined here
+   |                          |
+   |                          lifetime `'a` defined here
+...
+LL |     x
+   |     ^ function was supposed to return data with lifetime `'a` but it is returning data with lifetime `'b`
+   |
+   = help: consider adding the following bound: `'b: 'a`
+   = note: requirement occurs because of the type `Cell<RefMut<'_, dyn Trait>>`, which makes the generic argument `RefMut<'_, dyn Trait>` invariant
+   = note: the struct `Cell<T>` is invariant over the parameter `T`
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
+
+error: aborting due to 14 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/coercion/unsize-lifetime-shrinking.stderr
+++ b/tests/ui/coercion/unsize-lifetime-shrinking.stderr
@@ -25,7 +25,7 @@ LL |     x
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
 error: lifetime may not live long enough
-  --> $DIR/unsize-lifetime-shrinking.rs:111:5
+  --> $DIR/unsize-lifetime-shrinking.rs:110:5
    |
 LL | fn mut_to_mut_sized_to_sized<'a: 'b, 'b>(x: Cell<&'a mut Thing>) -> Cell<&'b mut Thing> {
    |                              --      -- lifetime `'b` defined here
@@ -40,55 +40,7 @@ LL |     x
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
 error: lifetime may not live long enough
-  --> $DIR/unsize-lifetime-shrinking.rs:120:5
-   |
-LL | fn mut_to_mut_sized_to_dyn<'a: 'b, 'b>(
-   |                            --      -- lifetime `'b` defined here
-   |                            |
-   |                            lifetime `'a` defined here
-...
-LL |     x
-   |     ^ function was supposed to return data with lifetime `'a` but it is returning data with lifetime `'b`
-   |
-   = help: consider adding the following bound: `'b: 'a`
-   = note: requirement occurs because of the type `Cell<&mut dyn Trait>`, which makes the generic argument `&mut dyn Trait` invariant
-   = note: the struct `Cell<T>` is invariant over the parameter `T`
-   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
-
-error: lifetime may not live long enough
-  --> $DIR/unsize-lifetime-shrinking.rs:128:5
-   |
-LL | fn mut_to_mut_upcast<'a: 'b, 'b>(
-   |                      --      -- lifetime `'b` defined here
-   |                      |
-   |                      lifetime `'a` defined here
-...
-LL |     x
-   |     ^ function was supposed to return data with lifetime `'a` but it is returning data with lifetime `'b`
-   |
-   = help: consider adding the following bound: `'b: 'a`
-   = note: requirement occurs because of the type `Cell<&mut dyn Trait>`, which makes the generic argument `&mut dyn Trait` invariant
-   = note: the struct `Cell<T>` is invariant over the parameter `T`
-   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
-
-error: lifetime may not live long enough
-  --> $DIR/unsize-lifetime-shrinking.rs:136:5
-   |
-LL | fn mut_to_mut_dyn_same<'a: 'b, 'b>(
-   |                        --      -- lifetime `'b` defined here
-   |                        |
-   |                        lifetime `'a` defined here
-...
-LL |     x
-   |     ^ function was supposed to return data with lifetime `'a` but it is returning data with lifetime `'b`
-   |
-   = help: consider adding the following bound: `'b: 'a`
-   = note: requirement occurs because of the type `Cell<&mut dyn Trait>`, which makes the generic argument `&mut dyn Trait` invariant
-   = note: the struct `Cell<T>` is invariant over the parameter `T`
-   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
-
-error: lifetime may not live long enough
-  --> $DIR/unsize-lifetime-shrinking.rs:161:5
+  --> $DIR/unsize-lifetime-shrinking.rs:157:5
    |
 LL | fn cell_ref_sized_to_sized<'a: 'b, 'b>(x: Cell<Ref<'a, Thing>>) -> Cell<Ref<'b, Thing>> {
    |                            --      -- lifetime `'b` defined here
@@ -103,7 +55,7 @@ LL |     x
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
 error: lifetime may not live long enough
-  --> $DIR/unsize-lifetime-shrinking.rs:170:5
+  --> $DIR/unsize-lifetime-shrinking.rs:166:5
    |
 LL | fn cell_ref_sized_to_dyn<'a: 'b, 'b>(
    |                          --      -- lifetime `'b` defined here
@@ -119,7 +71,7 @@ LL |     x
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
 error: lifetime may not live long enough
-  --> $DIR/unsize-lifetime-shrinking.rs:178:5
+  --> $DIR/unsize-lifetime-shrinking.rs:174:5
    |
 LL | fn cell_ref_upcast<'a: 'b, 'b>(
    |                    --      -- lifetime `'b` defined here
@@ -135,7 +87,7 @@ LL |     x
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
 error: lifetime may not live long enough
-  --> $DIR/unsize-lifetime-shrinking.rs:186:5
+  --> $DIR/unsize-lifetime-shrinking.rs:182:5
    |
 LL | fn cell_ref_dyn_same<'a: 'b, 'b>(
    |                      --      -- lifetime `'b` defined here
@@ -151,7 +103,7 @@ LL |     x
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
 error: lifetime may not live long enough
-  --> $DIR/unsize-lifetime-shrinking.rs:213:5
+  --> $DIR/unsize-lifetime-shrinking.rs:209:5
    |
 LL | fn cell_ref_mut_sized_to_sized<'a: 'b, 'b>(x: Cell<RefMut<'a, Thing>>) -> Cell<RefMut<'b, Thing>> {
    |                                --      -- lifetime `'b` defined here
@@ -166,7 +118,7 @@ LL |     x
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
 error: lifetime may not live long enough
-  --> $DIR/unsize-lifetime-shrinking.rs:222:5
+  --> $DIR/unsize-lifetime-shrinking.rs:218:5
    |
 LL | fn cell_ref_mut_sized_to_dyn<'a: 'b, 'b>(
    |                              --      -- lifetime `'b` defined here
@@ -182,7 +134,7 @@ LL |     x
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
 error: lifetime may not live long enough
-  --> $DIR/unsize-lifetime-shrinking.rs:230:5
+  --> $DIR/unsize-lifetime-shrinking.rs:226:5
    |
 LL | fn cell_ref_mut_upcast<'a: 'b, 'b>(
    |                        --      -- lifetime `'b` defined here
@@ -198,7 +150,7 @@ LL |     x
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
 error: lifetime may not live long enough
-  --> $DIR/unsize-lifetime-shrinking.rs:238:5
+  --> $DIR/unsize-lifetime-shrinking.rs:234:5
    |
 LL | fn cell_ref_mut_dyn_same<'a: 'b, 'b>(
    |                          --      -- lifetime `'b` defined here
@@ -213,6 +165,6 @@ LL |     x
    = note: the struct `Cell<T>` is invariant over the parameter `T`
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
-error: aborting due to 14 previous errors
+error: aborting due to 11 previous errors
 
 For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/feature-gates/feature-gate-instrument-fn.rs
+++ b/tests/ui/feature-gates/feature-gate-instrument-fn.rs
@@ -1,0 +1,13 @@
+//@ add-minicore
+//@ compile-flags: --crate-type=rlib
+#![no_core]
+#![feature(no_core)]
+
+extern crate minicore;
+use minicore::*;
+
+#[instrument_fn = "on"] //~ ERROR attribute is an experimental feature
+fn instrumented_fn() {}
+
+#[instrument_fn = "off"] //~ ERROR attribute is an experimental feature
+fn not_instrumented_fn() {}

--- a/tests/ui/feature-gates/feature-gate-instrument-fn.stderr
+++ b/tests/ui/feature-gates/feature-gate-instrument-fn.stderr
@@ -1,0 +1,23 @@
+error[E0658]: the `#[instrument_fn]` attribute is an experimental feature
+  --> $DIR/feature-gate-instrument-fn.rs:9:1
+   |
+LL | #[instrument_fn = "on"]
+   | ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #157081 <https://github.com/rust-lang/rust/issues/157081> for more information
+   = help: add `#![feature(instrument_fn)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: the `#[instrument_fn]` attribute is an experimental feature
+  --> $DIR/feature-gate-instrument-fn.rs:12:1
+   |
+LL | #[instrument_fn = "off"]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #157081 <https://github.com/rust-lang/rust/issues/157081> for more information
+   = help: add `#![feature(instrument_fn)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0658`.


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#157681 (Add instrument_fn attribute)
 - rust-lang/rust#149219 (Allow shortening lifetime in CoerceUnsized for &mut)
 - rust-lang/rust#157539 (Rename `RandomSource` -> `Rng`, `DefaultRandomSource` -> `SystemRng`)
 - rust-lang/rust#157980 (Some minor cleanups around hir ty/pat/expr)
 - rust-lang/rust#157988 (Fix incremental-finalize-fail proc macro test on AIX)
 - rust-lang/rust#157989 (run-make: handle AIX symbol cdylib export test)
 - rust-lang/rust#157998 (Add big disclaimer to the description of lint `explicit_outlives_requirements`)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=157681,149219,157539,157980,157988,157989,157998)
<!-- homu-ignore:end -->

