### PR TITLE
Replace `unwrap` with `expect` in `get_module_children`

### DIFF
--- a/compiler/rustc_metadata/src/rmeta/decoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder.rs
@@ -1274,6 +1274,10 @@ impl CrateMetadata {
     /// including both proper items and reexports.
     /// Module here is understood in name resolution sense - it can be a `mod` item,
     /// or a crate root, or an enum, or a trait.
+    ///
+    /// # Panics
+    ///
+    /// May panic if the provided `id` does not refer to a module.
     fn get_module_children(&self, tcx: TyCtxt<'_>, id: DefIndex) -> impl Iterator<Item = ModChild> {
         gen move {
             if let Some(data) = &self.root.proc_macro_data {
@@ -1287,7 +1291,9 @@ impl CrateMetadata {
             } else {
                 // Iterate over all children.
                 let non_reexports = self.root.tables.module_children_non_reexports.get(self, id);
-                for child_index in non_reexports.unwrap().decode((self, tcx)) {
+                let non_reexports =
+                    non_reexports.expect("provided `DefIndex` must refer to a module-like item");
+                for child_index in non_reexports.decode((self, tcx)) {
                     yield self.get_mod_child(tcx, child_index);
                 }
 

--- a/compiler/rustc_middle/src/queries.rs
+++ b/compiler/rustc_middle/src/queries.rs
@@ -2161,6 +2161,15 @@ rustc_queries! {
         desc { "fetching what a crate is named" }
         separate_provide_extern
     }
+
+    /// Iterates over all named children of the given module,
+    /// including both proper items and reexports.
+    /// Module here is understood in name resolution sense - it can be a `mod` item,
+    /// or a crate root, or an enum, or a trait.
+    ///
+    /// # Panics
+    ///
+    /// May panic if the provided `id` does not refer to a module.
     query module_children(def_id: DefId) -> &'tcx [ModChild] {
         desc { "collecting child items of module `{}`", tcx.def_path_str(def_id) }
         separate_provide_extern


### PR DESCRIPTION
# Objective

I ran into an ICE I ran into while developing rust-lang/rust-clippy#17252 that stems from `rustc_metadata::rmeta::decoder::CrateMetadata::get_module_children` calling `unwrap`. The local value `non_reexports` can be `None` when the passed in `DefIndex` is for a non-module-like item. The documentation for `get_module_children` *implies* that it must only be called with module-like item indices, however the use of `unwrap` makes diagnosing the ICE trickier than it has to be. Additionally, this behaviour is not documented on `TyCtxt::module_children`.

## Solution

- Switched from an `Option::unwrap` to a `Option::expect`
- Added panic documentation to `get_module_children`
- Replicated documentation for `TyCtxt::module_children`

---

## Notes

* No AI tooling of any kind was used during the creation of this PR.
* Please see [Zulip](https://rust-lang.zulipchat.com/#narrow/channel/122651-general/topic/.E2.9C.94.20.60rustc.60.20ICE.20from.20.60TyCtxt.3A.3Amodule_children.60/with/603700184) for some discussion.
* Please see this [failed Clippy CI run](https://github.com/rust-lang/rust-clippy/actions/runs/27596428127/job/81587609898#step:5:1) for an example of the ICE caused.
