### PR TITLE
Remove useless `#[doc(hidden)]` from `ZipImpl`

### DIFF
--- a/library/core/src/iter/adapters/zip.rs
+++ b/library/core/src/iter/adapters/zip.rs
@@ -125,7 +125,6 @@ where
 }
 
 // Zip specialization trait
-#[doc(hidden)]
 trait ZipImpl<A, B> {
     type Item;
     fn new(a: A, b: B) -> Self;
@@ -204,7 +203,6 @@ macro_rules! zip_impl_general_defaults {
 }
 
 // General Zip impl
-#[doc(hidden)]
 impl<A, B> ZipImpl<A, B> for Zip<A, B>
 where
     A: Iterator,
@@ -247,7 +245,6 @@ where
     }
 }
 
-#[doc(hidden)]
 impl<A, B> ZipImpl<A, B> for Zip<A, B>
 where
     A: TrustedRandomAccessNoCoerce + Iterator,
@@ -288,7 +285,6 @@ where
     }
 }
 
-#[doc(hidden)]
 impl<A, B> ZipImpl<A, B> for Zip<A, B>
 where
     A: TrustedRandomAccess + Iterator,


### PR DESCRIPTION
The `ZipImpl` trait is private, so the `#[doc(hidden)]` is unneccessary.

The `#[doc(hidden)]` was already there when the trait was created in [`a8f2e9b` (#33090)](https://github.com/rust-lang/rust/pull/33090/changes/a8f2e9b3597b4ff5dc6230c327b35a2b0e7122c1). This seems to have been an oversight.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
