### PR TITLE
Reject `impl const Trait` since the right syntax is `const impl Trait` now

### DIFF
--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -659,7 +659,7 @@ impl<'a> Parser<'a> {
         defaultness: Defaultness,
         is_reuse: bool,
     ) -> PResult<'a, ItemKind> {
-        let mut constness = self.parse_constness(Case::Sensitive);
+        let constness = self.parse_constness(Case::Sensitive);
         let safety = self.parse_safety(Case::Sensitive);
         self.expect_keyword(exp!(Impl))?;
 
@@ -673,11 +673,6 @@ impl<'a> Parser<'a> {
             generics.span = self.prev_token.span.shrink_to_hi();
             generics
         };
-
-        if let Const::No = constness {
-            // FIXME(const_trait_impl): disallow `impl const Trait`
-            constness = self.parse_constness(Case::Sensitive);
-        }
 
         if let Const::Yes(span) = constness {
             self.psess.gated_spans.gate(sym::const_trait_impl, span);

--- a/library/alloc/src/vec/partial_eq.rs
+++ b/library/alloc/src/vec/partial_eq.rs
@@ -6,7 +6,7 @@ use crate::borrow::Cow;
 macro_rules! __impl_slice_eq1 {
     ($($const:ident, )? [$($vars:tt)*] $lhs:ty, $rhs:ty $(where $ty:ty: $bound:ident)?, $(#[$stability:meta])+ ) => {
         $(#[$stability])+
-        impl<T, U, $($vars)*> $($const)? PartialEq<$rhs> for $lhs
+        $($const)? impl<T, U, $($vars)*> PartialEq<$rhs> for $lhs
         where
             T: $([$const])? PartialEq<U>,
             $($ty: $bound)?

--- a/library/core/src/ascii/ascii_char.rs
+++ b/library/core/src/ascii/ascii_char.rs
@@ -1165,7 +1165,7 @@ macro_rules! into_int_impl {
         $(
             #[unstable(feature = "ascii_char", issue = "110998")]
             #[rustc_const_unstable(feature = "const_convert", issue = "143773")]
-            impl const From<AsciiChar> for $ty {
+            const impl From<AsciiChar> for $ty {
                 #[inline]
                 fn from(chr: AsciiChar) -> $ty {
                     chr as u8 as $ty

--- a/library/core/src/clone.rs
+++ b/library/core/src/clone.rs
@@ -710,7 +710,7 @@ mod impls {
             $(
                 #[stable(feature = "rust1", since = "1.0.0")]
                 #[rustc_const_unstable(feature = "const_clone", issue = "142757")]
-                impl const Clone for $t {
+                const impl Clone for $t {
                     #[inline(always)]
                     fn clone(&self) -> Self {
                         *self
@@ -720,7 +720,7 @@ mod impls {
                 #[doc(hidden)]
                 #[unstable(feature = "trivial_clone", issue = "none")]
                 #[rustc_const_unstable(feature = "const_clone", issue = "142757")]
-                unsafe impl const TrivialClone for $t {}
+                const unsafe impl TrivialClone for $t {}
             )*
         }
     }

--- a/library/core/src/cmp.rs
+++ b/library/core/src/cmp.rs
@@ -1873,7 +1873,7 @@ mod impls {
         ($($t:ty)*) => ($(
             #[stable(feature = "rust1", since = "1.0.0")]
             #[rustc_const_unstable(feature = "const_cmp", issue = "143800")]
-            impl const PartialEq for $t {
+            const impl PartialEq for $t {
                 #[inline]
                 fn eq(&self, other: &Self) -> bool { *self == *other }
                 #[inline]
@@ -1903,7 +1903,7 @@ mod impls {
         ($($t:ty)*) => ($(
             #[stable(feature = "rust1", since = "1.0.0")]
             #[rustc_const_unstable(feature = "const_cmp", issue = "143800")]
-            impl const Eq for $t {}
+            const impl Eq for $t {}
         )*)
     }
 
@@ -1952,7 +1952,7 @@ mod impls {
         ($($t:ty)*) => ($(
             #[stable(feature = "rust1", since = "1.0.0")]
             #[rustc_const_unstable(feature = "const_cmp", issue = "143800")]
-            impl const PartialOrd for $t {
+            const impl PartialOrd for $t {
                 #[inline]
                 fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
                     match (*self <= *other, *self >= *other) {
@@ -1994,7 +1994,7 @@ mod impls {
         ($($t:ty)*) => ($(
             #[stable(feature = "rust1", since = "1.0.0")]
             #[rustc_const_unstable(feature = "const_cmp", issue = "143800")]
-            impl const PartialOrd for $t {
+            const impl PartialOrd for $t {
                 #[inline]
                 fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
                     Some(crate::intrinsics::three_way_compare(*self, *other))
@@ -2005,7 +2005,7 @@ mod impls {
 
             #[stable(feature = "rust1", since = "1.0.0")]
             #[rustc_const_unstable(feature = "const_cmp", issue = "143800")]
-            impl const Ord for $t {
+            const impl Ord for $t {
                 #[inline]
                 fn cmp(&self, other: &Self) -> Ordering {
                     crate::intrinsics::three_way_compare(*self, *other)

--- a/library/core/src/cmp/bytewise.rs
+++ b/library/core/src/cmp/bytewise.rs
@@ -24,7 +24,7 @@ pub(crate) const unsafe trait BytewiseEq<Rhs = Self>:
 
 macro_rules! is_bytewise_comparable {
     ($($t:ty),+ $(,)?) => {$(
-        unsafe impl const BytewiseEq for $t {}
+        const unsafe impl BytewiseEq for $t {}
     )+};
 }
 

--- a/library/core/src/convert/num.rs
+++ b/library/core/src/convert/num.rs
@@ -34,7 +34,7 @@ macro_rules! impl_from_bool {
     ($($int:ty)*) => {$(
         #[stable(feature = "from_bool", since = "1.28.0")]
         #[rustc_const_unstable(feature = "const_convert", issue = "143773")]
-        impl const From<bool> for $int {
+        const impl From<bool> for $int {
             /// Converts from [`bool`] to
             #[doc = concat!("[`", stringify!($int), "`]")]
             /// , by turning `false` into `0` and `true` into `1`.
@@ -63,7 +63,7 @@ macro_rules! impl_from {
     ($small:ty => $large:ty, $(#[$attrs:meta]),+) => {
         $(#[$attrs])+
         #[rustc_const_unstable(feature = "const_convert", issue = "143773")]
-        impl const From<$small> for $large {
+        const impl From<$small> for $large {
             #[doc = concat!("Converts from [`", stringify!($small), "`] to [`", stringify!($large), "`] losslessly.")]
             #[inline(always)]
             fn from(small: $small) -> Self {
@@ -185,7 +185,7 @@ macro_rules! impl_float_from_bool {
     ) => {
         #[stable(feature = "float_from_bool", since = "1.68.0")]
         #[rustc_const_unstable(feature = "const_convert", issue = "143773")]
-            impl const From<bool> for $float {
+            const impl From<bool> for $float {
             #[doc = concat!("Converts a [`bool`] to [`", stringify!($float),"`] losslessly.")]
             /// The resulting value is positive `0.0` for `false` and `1.0` for `true` values.
             ///
@@ -238,7 +238,7 @@ macro_rules! impl_try_from_unbounded {
     ($source:ty => $($target:ty),+) => {$(
         #[stable(feature = "try_from", since = "1.34.0")]
         #[rustc_const_unstable(feature = "const_convert", issue = "143773")]
-        impl const TryFrom<$source> for $target {
+        const impl TryFrom<$source> for $target {
             type Error = TryFromIntError;
 
             /// Tries to create the target number type from a source
@@ -257,7 +257,7 @@ macro_rules! impl_try_from_lower_bounded {
     ($source:ty => $($target:ty),+) => {$(
         #[stable(feature = "try_from", since = "1.34.0")]
         #[rustc_const_unstable(feature = "const_convert", issue = "143773")]
-        impl const TryFrom<$source> for $target {
+        const impl TryFrom<$source> for $target {
             type Error = TryFromIntError;
 
             /// Tries to create the target number type from a source
@@ -280,7 +280,7 @@ macro_rules! impl_try_from_upper_bounded {
     ($source:ty => $($target:ty),+) => {$(
         #[stable(feature = "try_from", since = "1.34.0")]
         #[rustc_const_unstable(feature = "const_convert", issue = "143773")]
-        impl const TryFrom<$source> for $target {
+        const impl TryFrom<$source> for $target {
             type Error = TryFromIntError;
 
             /// Tries to create the target number type from a source
@@ -303,7 +303,7 @@ macro_rules! impl_try_from_both_bounded {
     ($source:ty => $($target:ty),+) => {$(
         #[stable(feature = "try_from", since = "1.34.0")]
         #[rustc_const_unstable(feature = "const_convert", issue = "143773")]
-        impl const TryFrom<$source> for $target {
+        const impl TryFrom<$source> for $target {
             type Error = TryFromIntError;
 
             /// Tries to create the target number type from a source
@@ -330,7 +330,7 @@ macro_rules! impl_try_from_integer_for_bool {
     ($signedness:ident $($int:ty)+) => {$(
         #[stable(feature = "bool_try_from_int", since = "1.95.0")]
         #[rustc_const_unstable(feature = "const_convert", issue = "143773")]
-        impl const TryFrom<$int> for bool {
+        const impl TryFrom<$int> for bool {
             type Error = TryFromIntError;
 
             /// Tries to create a bool from an integer type.
@@ -585,7 +585,7 @@ macro_rules! impl_nonzero_int_try_from_nonzero_int {
     ($source:ty => $($target:ty),+) => {$(
         #[stable(feature = "nzint_try_from_nzint_conv", since = "1.49.0")]
         #[rustc_const_unstable(feature = "const_convert", issue = "143773")]
-        impl const TryFrom<NonZero<$source>> for NonZero<$target> {
+        const impl TryFrom<NonZero<$source>> for NonZero<$target> {
             type Error = TryFromIntError;
 
             // Rustdocs on the impl block show a "[+] show undocumented items" toggle.
@@ -674,7 +674,7 @@ macro_rules! impl_int_cast {
     ($Src:ty as [$($Dst:ty),*]) => {$(
         #[unstable(feature = "integer_casts", issue = "157388")]
         #[rustc_const_unstable(feature = "integer_casts", issue = "157388")]
-        impl const CheckedCastFromInt<$Src> for $Dst {
+        const impl CheckedCastFromInt<$Src> for $Dst {
             #[inline]
             fn checked_cast_from(value: $Src) -> Option<Self> {
                 value.try_into().ok()
@@ -698,7 +698,7 @@ macro_rules! impl_int_cast {
 
         #[unstable(feature = "integer_casts", issue = "157388")]
         #[rustc_const_unstable(feature = "integer_casts", issue = "157388")]
-        impl const BoundedCastFromInt<$Src> for $Dst {
+        const impl BoundedCastFromInt<$Src> for $Dst {
             #[inline(always)]
             fn wrapping_cast_from(value: $Src) -> Self {
                 value as Self

--- a/library/core/src/internal_macros.rs
+++ b/library/core/src/internal_macros.rs
@@ -3,7 +3,7 @@
 macro_rules! forward_ref_unop {
     (impl $imp:ident, $method:ident for $t:ty, $(#[$attr:meta])+) => {
         $(#[$attr])+
-        impl const $imp for &$t {
+        const impl $imp for &$t {
             type Output = <$t as $imp>::Output;
 
             #[inline]
@@ -19,7 +19,7 @@ macro_rules! forward_ref_unop {
 macro_rules! forward_ref_binop {
     (impl $imp:ident, $method:ident for $t:ty, $u:ty, $(#[$attr:meta])+) => {
         $(#[$attr])+
-        impl const $imp<$u> for &$t {
+        const impl $imp<$u> for &$t {
             type Output = <$t as $imp<$u>>::Output;
 
             #[inline]
@@ -30,7 +30,7 @@ macro_rules! forward_ref_binop {
         }
 
         $(#[$attr])+
-        impl const $imp<&$u> for $t {
+        const impl $imp<&$u> for $t {
             type Output = <$t as $imp<$u>>::Output;
 
             #[inline]
@@ -41,7 +41,7 @@ macro_rules! forward_ref_binop {
         }
 
         $(#[$attr])+
-        impl const $imp<&$u> for &$t {
+        const impl $imp<&$u> for &$t {
             type Output = <$t as $imp<$u>>::Output;
 
             #[inline]
@@ -58,7 +58,7 @@ macro_rules! forward_ref_binop {
 macro_rules! forward_ref_op_assign {
     (impl $imp:ident, $method:ident for $t:ty, $u:ty, $(#[$attr:meta])+) => {
         $(#[$attr])+
-        impl const $imp<&$u> for $t {
+        const impl $imp<&$u> for $t {
             #[inline]
             #[track_caller]
             fn $method(&mut self, other: &$u) {

--- a/library/core/src/intrinsics/fallback.rs
+++ b/library/core/src/intrinsics/fallback.rs
@@ -21,7 +21,7 @@ pub const trait CarryingMulAdd: Copy + 'static {
 macro_rules! impl_carrying_mul_add_by_widening {
     ($($t:ident $u:ident $w:ident,)+) => {$(
         #[rustc_const_unstable(feature = "core_intrinsics_fallbacks", issue = "none")]
-        impl const CarryingMulAdd for $t {
+        const impl CarryingMulAdd for $t {
             type Unsigned = $u;
             #[inline]
             fn carrying_mul_add(self, a: Self, b: Self, c: Self) -> ($u, $t) {
@@ -127,7 +127,7 @@ macro_rules! zero {
 macro_rules! impl_disjoint_bitor {
     ($($t:ident,)+) => {$(
         #[rustc_const_unstable(feature = "core_intrinsics_fallbacks", issue = "none")]
-        impl const DisjointBitOr for $t {
+        const impl DisjointBitOr for $t {
             #[cfg_attr(miri, track_caller)]
             #[inline]
             unsafe fn disjoint_bitor(self, other: Self) -> Self {
@@ -161,7 +161,7 @@ pub const trait FunnelShift: Copy + 'static {
 macro_rules! impl_funnel_shifts {
     ($($type:ident),*) => {$(
         #[rustc_const_unstable(feature = "core_intrinsics_fallbacks", issue = "none")]
-        impl const FunnelShift for $type {
+        const impl FunnelShift for $type {
             #[cfg_attr(miri, track_caller)]
             #[inline]
             unsafe fn unchecked_funnel_shl(self, rhs: Self, shift: u32) -> Self {
@@ -229,7 +229,7 @@ pub const trait CarrylessMul: Copy + 'static {
 macro_rules! impl_carryless_mul{
     ($($type:ident),*) => {$(
         #[rustc_const_unstable(feature = "core_intrinsics_fallbacks", issue = "none")]
-        impl const CarrylessMul for $type {
+        const impl CarrylessMul for $type {
             #[inline]
             fn carryless_mul(self, rhs: Self) -> Self {
                 let mut result = 0;

--- a/library/core/src/iter/range.rs
+++ b/library/core/src/iter/range.rs
@@ -263,7 +263,7 @@ macro_rules! step_integer_impls {
             #[allow(unreachable_patterns)]
             #[unstable(feature = "step_trait", issue = "42168")]
             #[rustc_const_unstable(feature = "step_trait", issue = "42168")]
-            impl const Step for $u_narrower {
+            const impl Step for $u_narrower {
                 step_identical_methods!();
                 step_unsigned_methods!();
 
@@ -298,7 +298,7 @@ macro_rules! step_integer_impls {
             #[allow(unreachable_patterns)]
             #[unstable(feature = "step_trait", issue = "42168")]
             #[rustc_const_unstable(feature = "step_trait", issue = "42168")]
-            impl const Step for $i_narrower {
+            const impl Step for $i_narrower {
                 step_identical_methods!();
                 step_signed_methods!($u_narrower);
 
@@ -365,7 +365,7 @@ macro_rules! step_integer_impls {
             #[allow(unreachable_patterns)]
             #[unstable(feature = "step_trait", issue = "42168")]
             #[rustc_const_unstable(feature = "step_trait", issue = "42168")]
-            impl const Step for $u_wider {
+            const impl Step for $u_wider {
                 step_identical_methods!();
                 step_unsigned_methods!();
 
@@ -396,7 +396,7 @@ macro_rules! step_integer_impls {
             #[allow(unreachable_patterns)]
             #[unstable(feature = "step_trait", issue = "42168")]
             #[rustc_const_unstable(feature = "step_trait", issue = "42168")]
-            impl const Step for $i_wider {
+            const impl Step for $i_wider {
                 step_identical_methods!();
                 step_signed_methods!($u_wider);
 
@@ -514,7 +514,7 @@ macro_rules! step_nonzero_impls {
             #[allow(unreachable_patterns)]
             #[unstable(feature = "step_trait", reason = "recently redesigned", issue = "42168")]
             #[rustc_const_unstable(feature = "step_trait", issue = "42168")]
-            impl const Step for NonZero<$narrower> {
+            const impl Step for NonZero<$narrower> {
                 step_nonzero_identical_methods!($narrower);
 
                 #[inline]
@@ -540,7 +540,7 @@ macro_rules! step_nonzero_impls {
             #[allow(unreachable_patterns)]
             #[unstable(feature = "step_trait", reason = "recently redesigned", issue = "42168")]
             #[rustc_const_unstable(feature = "step_trait", issue = "42168")]
-            impl const Step for NonZero<$wider> {
+            const impl Step for NonZero<$wider> {
                 step_nonzero_identical_methods!($wider);
 
                 #[inline]

--- a/library/core/src/net/ip_addr.rs
+++ b/library/core/src/net/ip_addr.rs
@@ -2468,7 +2468,7 @@ macro_rules! bitop_impls {
     )*) => {
         $(
             $(#[$attr])*
-            impl const $BitOpAssign for $ty {
+            const impl $BitOpAssign for $ty {
                 fn $bitop_assign(&mut self, rhs: $ty) {
                     let mut idx = 0;
                     while idx < self.octets.len() {
@@ -2479,14 +2479,14 @@ macro_rules! bitop_impls {
             }
 
             $(#[$attr])*
-            impl const $BitOpAssign<&'_ $ty> for $ty {
+            const impl $BitOpAssign<&'_ $ty> for $ty {
                 fn $bitop_assign(&mut self, rhs: &'_ $ty) {
                     self.$bitop_assign(*rhs);
                 }
             }
 
             $(#[$attr])*
-            impl const $BitOp for $ty {
+            const impl $BitOp for $ty {
                 type Output = $ty;
 
                 #[inline]
@@ -2497,7 +2497,7 @@ macro_rules! bitop_impls {
             }
 
             $(#[$attr])*
-            impl const $BitOp<&'_ $ty> for $ty {
+            const impl $BitOp<&'_ $ty> for $ty {
                 type Output = $ty;
 
                 #[inline]
@@ -2508,7 +2508,7 @@ macro_rules! bitop_impls {
             }
 
             $(#[$attr])*
-            impl const $BitOp<$ty> for &'_ $ty {
+            const impl $BitOp<$ty> for &'_ $ty {
                 type Output = $ty;
 
                 #[inline]
@@ -2520,7 +2520,7 @@ macro_rules! bitop_impls {
             }
 
             $(#[$attr])*
-            impl const $BitOp<&'_ $ty> for &'_ $ty {
+            const impl $BitOp<&'_ $ty> for &'_ $ty {
                 type Output = $ty;
 
                 #[inline]

--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -1587,7 +1587,7 @@ macro_rules! from_str_int_impl {
     ($signedness:ident $($int_ty:ty)+) => {$(
         #[stable(feature = "rust1", since = "1.0.0")]
         #[rustc_const_unstable(feature = "const_convert", issue = "143773")]
-        impl const FromStr for $int_ty {
+        const impl FromStr for $int_ty {
             type Err = ParseIntError;
 
             /// Parses an integer from a string slice with decimal digits.

--- a/library/core/src/num/saturating.rs
+++ b/library/core/src/num/saturating.rs
@@ -214,7 +214,7 @@ macro_rules! saturating_impl {
     ($($t:ty)*) => ($(
         #[stable(feature = "saturating_int_impl", since = "1.74.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
-        impl const Add for Saturating<$t> {
+        const impl Add for Saturating<$t> {
             type Output = Saturating<$t>;
 
             #[inline]
@@ -228,7 +228,7 @@ macro_rules! saturating_impl {
 
         #[stable(feature = "saturating_int_impl", since = "1.74.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
-        impl const AddAssign for Saturating<$t> {
+        const impl AddAssign for Saturating<$t> {
             #[inline]
             fn add_assign(&mut self, other: Saturating<$t>) {
                 *self = *self + other;
@@ -240,7 +240,7 @@ macro_rules! saturating_impl {
 
         #[stable(feature = "saturating_int_assign_impl", since = "1.74.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
-        impl const AddAssign<$t> for Saturating<$t> {
+        const impl AddAssign<$t> for Saturating<$t> {
             #[inline]
             fn add_assign(&mut self, other: $t) {
                 *self = *self + Saturating(other);
@@ -252,7 +252,7 @@ macro_rules! saturating_impl {
 
         #[stable(feature = "saturating_int_impl", since = "1.74.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
-        impl const Sub for Saturating<$t> {
+        const impl Sub for Saturating<$t> {
             type Output = Saturating<$t>;
 
             #[inline]
@@ -266,7 +266,7 @@ macro_rules! saturating_impl {
 
         #[stable(feature = "saturating_int_impl", since = "1.74.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
-        impl const SubAssign for Saturating<$t> {
+        const impl SubAssign for Saturating<$t> {
             #[inline]
             fn sub_assign(&mut self, other: Saturating<$t>) {
                 *self = *self - other;
@@ -278,7 +278,7 @@ macro_rules! saturating_impl {
 
         #[stable(feature = "saturating_int_assign_impl", since = "1.74.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
-        impl const SubAssign<$t> for Saturating<$t> {
+        const impl SubAssign<$t> for Saturating<$t> {
             #[inline]
             fn sub_assign(&mut self, other: $t) {
                 *self = *self - Saturating(other);
@@ -290,7 +290,7 @@ macro_rules! saturating_impl {
 
         #[stable(feature = "saturating_int_impl", since = "1.74.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
-        impl const Mul for Saturating<$t> {
+        const impl Mul for Saturating<$t> {
             type Output = Saturating<$t>;
 
             #[inline]
@@ -304,7 +304,7 @@ macro_rules! saturating_impl {
 
         #[stable(feature = "saturating_int_impl", since = "1.74.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
-        impl const MulAssign for Saturating<$t> {
+        const impl MulAssign for Saturating<$t> {
             #[inline]
             fn mul_assign(&mut self, other: Saturating<$t>) {
                 *self = *self * other;
@@ -316,7 +316,7 @@ macro_rules! saturating_impl {
 
         #[stable(feature = "saturating_int_assign_impl", since = "1.74.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
-        impl const MulAssign<$t> for Saturating<$t> {
+        const impl MulAssign<$t> for Saturating<$t> {
             #[inline]
             fn mul_assign(&mut self, other: $t) {
                 *self = *self * Saturating(other);
@@ -343,7 +343,7 @@ macro_rules! saturating_impl {
         /// ```
         #[stable(feature = "saturating_int_impl", since = "1.74.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
-        impl const Div for Saturating<$t> {
+        const impl Div for Saturating<$t> {
             type Output = Saturating<$t>;
 
             #[inline]
@@ -357,7 +357,7 @@ macro_rules! saturating_impl {
 
         #[stable(feature = "saturating_int_impl", since = "1.74.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
-        impl const DivAssign for Saturating<$t> {
+        const impl DivAssign for Saturating<$t> {
             #[inline]
             fn div_assign(&mut self, other: Saturating<$t>) {
                 *self = *self / other;
@@ -369,7 +369,7 @@ macro_rules! saturating_impl {
 
         #[stable(feature = "saturating_int_assign_impl", since = "1.74.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
-        impl const DivAssign<$t> for Saturating<$t> {
+        const impl DivAssign<$t> for Saturating<$t> {
             #[inline]
             fn div_assign(&mut self, other: $t) {
                 *self = *self / Saturating(other);
@@ -381,7 +381,7 @@ macro_rules! saturating_impl {
 
         #[stable(feature = "saturating_int_impl", since = "1.74.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
-        impl const Rem for Saturating<$t> {
+        const impl Rem for Saturating<$t> {
             type Output = Saturating<$t>;
 
             #[inline]
@@ -395,7 +395,7 @@ macro_rules! saturating_impl {
 
         #[stable(feature = "saturating_int_impl", since = "1.74.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
-        impl const RemAssign for Saturating<$t> {
+        const impl RemAssign for Saturating<$t> {
             #[inline]
             fn rem_assign(&mut self, other: Saturating<$t>) {
                 *self = *self % other;
@@ -407,7 +407,7 @@ macro_rules! saturating_impl {
 
         #[stable(feature = "saturating_int_assign_impl", since = "1.74.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
-        impl const RemAssign<$t> for Saturating<$t> {
+        const impl RemAssign<$t> for Saturating<$t> {
             #[inline]
             fn rem_assign(&mut self, other: $t) {
                 *self = *self % Saturating(other);
@@ -419,7 +419,7 @@ macro_rules! saturating_impl {
 
         #[stable(feature = "saturating_int_impl", since = "1.74.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
-        impl const Not for Saturating<$t> {
+        const impl Not for Saturating<$t> {
             type Output = Saturating<$t>;
 
             #[inline]
@@ -433,7 +433,7 @@ macro_rules! saturating_impl {
 
         #[stable(feature = "saturating_int_impl", since = "1.74.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
-        impl const BitXor for Saturating<$t> {
+        const impl BitXor for Saturating<$t> {
             type Output = Saturating<$t>;
 
             #[inline]
@@ -447,7 +447,7 @@ macro_rules! saturating_impl {
 
         #[stable(feature = "saturating_int_impl", since = "1.74.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
-        impl const BitXorAssign for Saturating<$t> {
+        const impl BitXorAssign for Saturating<$t> {
             #[inline]
             fn bitxor_assign(&mut self, other: Saturating<$t>) {
                 *self = *self ^ other;
@@ -459,7 +459,7 @@ macro_rules! saturating_impl {
 
         #[stable(feature = "saturating_int_assign_impl", since = "1.74.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
-        impl const BitXorAssign<$t> for Saturating<$t> {
+        const impl BitXorAssign<$t> for Saturating<$t> {
             #[inline]
             fn bitxor_assign(&mut self, other: $t) {
                 *self = *self ^ Saturating(other);
@@ -471,7 +471,7 @@ macro_rules! saturating_impl {
 
         #[stable(feature = "saturating_int_impl", since = "1.74.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
-        impl const BitOr for Saturating<$t> {
+        const impl BitOr for Saturating<$t> {
             type Output = Saturating<$t>;
 
             #[inline]
@@ -485,7 +485,7 @@ macro_rules! saturating_impl {
 
         #[stable(feature = "saturating_int_impl", since = "1.74.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
-        impl const BitOrAssign for Saturating<$t> {
+        const impl BitOrAssign for Saturating<$t> {
             #[inline]
             fn bitor_assign(&mut self, other: Saturating<$t>) {
                 *self = *self | other;
@@ -497,7 +497,7 @@ macro_rules! saturating_impl {
 
         #[stable(feature = "saturating_int_assign_impl", since = "1.74.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
-        impl const BitOrAssign<$t> for Saturating<$t> {
+        const impl BitOrAssign<$t> for Saturating<$t> {
             #[inline]
             fn bitor_assign(&mut self, other: $t) {
                 *self = *self | Saturating(other);
@@ -509,7 +509,7 @@ macro_rules! saturating_impl {
 
         #[stable(feature = "saturating_int_impl", since = "1.74.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
-        impl const BitAnd for Saturating<$t> {
+        const impl BitAnd for Saturating<$t> {
             type Output = Saturating<$t>;
 
             #[inline]
@@ -523,7 +523,7 @@ macro_rules! saturating_impl {
 
         #[stable(feature = "saturating_int_impl", since = "1.74.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
-        impl const BitAndAssign for Saturating<$t> {
+        const impl BitAndAssign for Saturating<$t> {
             #[inline]
             fn bitand_assign(&mut self, other: Saturating<$t>) {
                 *self = *self & other;
@@ -535,7 +535,7 @@ macro_rules! saturating_impl {
 
         #[stable(feature = "saturating_int_assign_impl", since = "1.74.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
-        impl const BitAndAssign<$t> for Saturating<$t> {
+        const impl BitAndAssign<$t> for Saturating<$t> {
             #[inline]
             fn bitand_assign(&mut self, other: $t) {
                 *self = *self & Saturating(other);
@@ -1001,7 +1001,7 @@ macro_rules! saturating_int_impl_signed {
 
         #[stable(feature = "saturating_int_impl", since = "1.74.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
-        impl const Neg for Saturating<$t> {
+        const impl Neg for Saturating<$t> {
             type Output = Self;
             #[inline]
             fn neg(self) -> Self {

--- a/library/core/src/num/traits.rs
+++ b/library/core/src/num/traits.rs
@@ -41,7 +41,7 @@ macro_rules! impl_truncate {
 
         #[unstable(feature = "num_internals", reason = "internal implementation detail", issue = "none")]
         #[rustc_const_unstable(feature = "integer_widen_truncate", issue = "154330")]
-        impl const TruncateTarget<$to> for $from {
+        const impl TruncateTarget<$to> for $from {
             #[inline]
             fn internal_truncate(self) -> $to {
                 self as _
@@ -88,7 +88,7 @@ macro_rules! impl_widen {
 
         #[unstable(feature = "num_internals", reason = "internal implementation detail", issue = "none")]
         #[rustc_const_unstable(feature = "integer_widen_truncate", issue = "154330")]
-        impl const WidenTarget<$to> for $from {
+        const impl WidenTarget<$to> for $from {
             fn internal_widen(self) -> $to {
                 self as _
             }

--- a/library/core/src/num/wrapping.rs
+++ b/library/core/src/num/wrapping.rs
@@ -231,7 +231,7 @@ macro_rules! wrapping_impl {
     ($($t:ty)*) => ($(
         #[stable(feature = "rust1", since = "1.0.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
-        impl const Add for Wrapping<$t> {
+        const impl Add for Wrapping<$t> {
             type Output = Wrapping<$t>;
 
             #[inline]
@@ -245,7 +245,7 @@ macro_rules! wrapping_impl {
 
         #[stable(feature = "op_assign_traits", since = "1.8.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
-        impl const AddAssign for Wrapping<$t> {
+        const impl AddAssign for Wrapping<$t> {
             #[inline]
             fn add_assign(&mut self, other: Wrapping<$t>) {
                 *self = *self + other;
@@ -257,7 +257,7 @@ macro_rules! wrapping_impl {
 
         #[stable(feature = "wrapping_int_assign_impl", since = "1.60.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
-        impl const AddAssign<$t> for Wrapping<$t> {
+        const impl AddAssign<$t> for Wrapping<$t> {
             #[inline]
             fn add_assign(&mut self, other: $t) {
                 *self = *self + Wrapping(other);
@@ -269,7 +269,7 @@ macro_rules! wrapping_impl {
 
         #[stable(feature = "rust1", since = "1.0.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
-        impl const Sub for Wrapping<$t> {
+        const impl Sub for Wrapping<$t> {
             type Output = Wrapping<$t>;
 
             #[inline]
@@ -283,7 +283,7 @@ macro_rules! wrapping_impl {
 
         #[stable(feature = "op_assign_traits", since = "1.8.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
-        impl const SubAssign for Wrapping<$t> {
+        const impl SubAssign for Wrapping<$t> {
             #[inline]
             fn sub_assign(&mut self, other: Wrapping<$t>) {
                 *self = *self - other;
@@ -295,7 +295,7 @@ macro_rules! wrapping_impl {
 
         #[stable(feature = "wrapping_int_assign_impl", since = "1.60.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
-        impl const SubAssign<$t> for Wrapping<$t> {
+        const impl SubAssign<$t> for Wrapping<$t> {
             #[inline]
             fn sub_assign(&mut self, other: $t) {
                 *self = *self - Wrapping(other);
@@ -307,7 +307,7 @@ macro_rules! wrapping_impl {
 
         #[stable(feature = "rust1", since = "1.0.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
-        impl const Mul for Wrapping<$t> {
+        const impl Mul for Wrapping<$t> {
             type Output = Wrapping<$t>;
 
             #[inline]
@@ -321,7 +321,7 @@ macro_rules! wrapping_impl {
 
         #[stable(feature = "op_assign_traits", since = "1.8.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
-        impl const MulAssign for Wrapping<$t> {
+        const impl MulAssign for Wrapping<$t> {
             #[inline]
             fn mul_assign(&mut self, other: Wrapping<$t>) {
                 *self = *self * other;
@@ -333,7 +333,7 @@ macro_rules! wrapping_impl {
 
         #[stable(feature = "wrapping_int_assign_impl", since = "1.60.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
-        impl const MulAssign<$t> for Wrapping<$t> {
+        const impl MulAssign<$t> for Wrapping<$t> {
             #[inline]
             fn mul_assign(&mut self, other: $t) {
                 *self = *self * Wrapping(other);
@@ -345,7 +345,7 @@ macro_rules! wrapping_impl {
 
         #[stable(feature = "wrapping_div", since = "1.3.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
-        impl const Div for Wrapping<$t> {
+        const impl Div for Wrapping<$t> {
             type Output = Wrapping<$t>;
 
             #[inline]
@@ -359,7 +359,7 @@ macro_rules! wrapping_impl {
 
         #[stable(feature = "op_assign_traits", since = "1.8.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
-        impl const DivAssign for Wrapping<$t> {
+        const impl DivAssign for Wrapping<$t> {
             #[inline]
             fn div_assign(&mut self, other: Wrapping<$t>) {
                 *self = *self / other;
@@ -371,7 +371,7 @@ macro_rules! wrapping_impl {
 
         #[stable(feature = "wrapping_int_assign_impl", since = "1.60.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
-        impl const DivAssign<$t> for Wrapping<$t> {
+        const impl DivAssign<$t> for Wrapping<$t> {
             #[inline]
             fn div_assign(&mut self, other: $t) {
                 *self = *self / Wrapping(other);
@@ -383,7 +383,7 @@ macro_rules! wrapping_impl {
 
         #[stable(feature = "wrapping_impls", since = "1.7.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
-        impl const Rem for Wrapping<$t> {
+        const impl Rem for Wrapping<$t> {
             type Output = Wrapping<$t>;
 
             #[inline]
@@ -397,7 +397,7 @@ macro_rules! wrapping_impl {
 
         #[stable(feature = "op_assign_traits", since = "1.8.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
-        impl const RemAssign for Wrapping<$t> {
+        const impl RemAssign for Wrapping<$t> {
             #[inline]
             fn rem_assign(&mut self, other: Wrapping<$t>) {
                 *self = *self % other;
@@ -409,7 +409,7 @@ macro_rules! wrapping_impl {
 
         #[stable(feature = "wrapping_int_assign_impl", since = "1.60.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
-        impl const RemAssign<$t> for Wrapping<$t> {
+        const impl RemAssign<$t> for Wrapping<$t> {
             #[inline]
             fn rem_assign(&mut self, other: $t) {
                 *self = *self % Wrapping(other);
@@ -421,7 +421,7 @@ macro_rules! wrapping_impl {
 
         #[stable(feature = "rust1", since = "1.0.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
-        impl const Not for Wrapping<$t> {
+        const impl Not for Wrapping<$t> {
             type Output = Wrapping<$t>;
 
             #[inline]
@@ -435,7 +435,7 @@ macro_rules! wrapping_impl {
 
         #[stable(feature = "rust1", since = "1.0.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
-        impl const BitXor for Wrapping<$t> {
+        const impl BitXor for Wrapping<$t> {
             type Output = Wrapping<$t>;
 
             #[inline]
@@ -449,7 +449,7 @@ macro_rules! wrapping_impl {
 
         #[stable(feature = "op_assign_traits", since = "1.8.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
-        impl const BitXorAssign for Wrapping<$t> {
+        const impl BitXorAssign for Wrapping<$t> {
             #[inline]
             fn bitxor_assign(&mut self, other: Wrapping<$t>) {
                 *self = *self ^ other;
@@ -461,7 +461,7 @@ macro_rules! wrapping_impl {
 
         #[stable(feature = "wrapping_int_assign_impl", since = "1.60.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
-        impl const BitXorAssign<$t> for Wrapping<$t> {
+        const impl BitXorAssign<$t> for Wrapping<$t> {
             #[inline]
             fn bitxor_assign(&mut self, other: $t) {
                 *self = *self ^ Wrapping(other);
@@ -473,7 +473,7 @@ macro_rules! wrapping_impl {
 
         #[stable(feature = "rust1", since = "1.0.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
-        impl const BitOr for Wrapping<$t> {
+        const impl BitOr for Wrapping<$t> {
             type Output = Wrapping<$t>;
 
             #[inline]
@@ -487,7 +487,7 @@ macro_rules! wrapping_impl {
 
         #[stable(feature = "op_assign_traits", since = "1.8.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
-        impl const BitOrAssign for Wrapping<$t> {
+        const impl BitOrAssign for Wrapping<$t> {
             #[inline]
             fn bitor_assign(&mut self, other: Wrapping<$t>) {
                 *self = *self | other;
@@ -499,7 +499,7 @@ macro_rules! wrapping_impl {
 
         #[stable(feature = "wrapping_int_assign_impl", since = "1.60.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
-        impl const BitOrAssign<$t> for Wrapping<$t> {
+        const impl BitOrAssign<$t> for Wrapping<$t> {
             #[inline]
             fn bitor_assign(&mut self, other: $t) {
                 *self = *self | Wrapping(other);
@@ -511,7 +511,7 @@ macro_rules! wrapping_impl {
 
         #[stable(feature = "rust1", since = "1.0.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
-        impl const BitAnd for Wrapping<$t> {
+        const impl BitAnd for Wrapping<$t> {
             type Output = Wrapping<$t>;
 
             #[inline]
@@ -525,7 +525,7 @@ macro_rules! wrapping_impl {
 
         #[stable(feature = "op_assign_traits", since = "1.8.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
-        impl const BitAndAssign for Wrapping<$t> {
+        const impl BitAndAssign for Wrapping<$t> {
             #[inline]
             fn bitand_assign(&mut self, other: Wrapping<$t>) {
                 *self = *self & other;
@@ -537,7 +537,7 @@ macro_rules! wrapping_impl {
 
         #[stable(feature = "wrapping_int_assign_impl", since = "1.60.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
-        impl const BitAndAssign<$t> for Wrapping<$t> {
+        const impl BitAndAssign<$t> for Wrapping<$t> {
             #[inline]
             fn bitand_assign(&mut self, other: $t) {
                 *self = *self & Wrapping(other);
@@ -549,7 +549,7 @@ macro_rules! wrapping_impl {
 
         #[stable(feature = "wrapping_neg", since = "1.10.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
-        impl const Neg for Wrapping<$t> {
+        const impl Neg for Wrapping<$t> {
             type Output = Self;
             #[inline]
             fn neg(self) -> Self {

--- a/library/core/src/ops/arith.rs
+++ b/library/core/src/ops/arith.rs
@@ -95,7 +95,7 @@ macro_rules! add_impl {
     ($($t:ty)*) => ($(
         #[stable(feature = "rust1", since = "1.0.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
-        impl const Add for $t {
+        const impl Add for $t {
             type Output = $t;
 
             #[inline]
@@ -207,7 +207,7 @@ macro_rules! sub_impl {
     ($($t:ty)*) => ($(
         #[stable(feature = "rust1", since = "1.0.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
-        impl const Sub for $t {
+        const impl Sub for $t {
             type Output = $t;
 
             #[inline]
@@ -341,7 +341,7 @@ macro_rules! mul_impl {
     ($($t:ty)*) => ($(
         #[stable(feature = "rust1", since = "1.0.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
-        impl const Mul for $t {
+        const impl Mul for $t {
             type Output = $t;
 
             #[inline]
@@ -485,7 +485,7 @@ macro_rules! div_impl_integer {
         #[doc = $panic]
         #[stable(feature = "rust1", since = "1.0.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
-        impl const Div for $t {
+        const impl Div for $t {
             type Output = $t;
 
             #[inline]
@@ -508,7 +508,7 @@ macro_rules! div_impl_float {
     ($($t:ty)*) => ($(
         #[stable(feature = "rust1", since = "1.0.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
-        impl const Div for $t {
+        const impl Div for $t {
             type Output = $t;
 
             #[inline]
@@ -594,7 +594,7 @@ macro_rules! rem_impl_integer {
         #[doc = $panic]
         #[stable(feature = "rust1", since = "1.0.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
-        impl const Rem for $t {
+        const impl Rem for $t {
             type Output = $t;
 
             #[inline]
@@ -632,7 +632,7 @@ macro_rules! rem_impl_float {
         /// ```
         #[stable(feature = "rust1", since = "1.0.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
-        impl const Rem for $t {
+        const impl Rem for $t {
             type Output = $t;
 
             #[inline]
@@ -710,7 +710,7 @@ macro_rules! neg_impl {
     ($($t:ty)*) => ($(
         #[stable(feature = "rust1", since = "1.0.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
-        impl const Neg for $t {
+        const impl Neg for $t {
             type Output = $t;
 
             #[inline]
@@ -783,7 +783,7 @@ macro_rules! add_assign_impl {
     ($($t:ty)+) => ($(
         #[stable(feature = "op_assign_traits", since = "1.8.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
-        impl const AddAssign for $t {
+        const impl AddAssign for $t {
             #[inline]
             #[track_caller]
             #[rustc_inherit_overflow_checks]
@@ -854,7 +854,7 @@ macro_rules! sub_assign_impl {
     ($($t:ty)+) => ($(
         #[stable(feature = "op_assign_traits", since = "1.8.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
-        impl const SubAssign for $t {
+        const impl SubAssign for $t {
             #[inline]
             #[track_caller]
             #[rustc_inherit_overflow_checks]
@@ -916,7 +916,7 @@ macro_rules! mul_assign_impl {
     ($($t:ty)+) => ($(
         #[stable(feature = "op_assign_traits", since = "1.8.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
-        impl const MulAssign for $t {
+        const impl MulAssign for $t {
             #[inline]
             #[track_caller]
             #[rustc_inherit_overflow_checks]
@@ -978,7 +978,7 @@ macro_rules! div_assign_impl {
     ($($t:ty)+) => ($(
         #[stable(feature = "op_assign_traits", since = "1.8.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
-        impl const DivAssign for $t {
+        const impl DivAssign for $t {
             #[inline]
             #[track_caller]
             fn div_assign(&mut self, other: $t) { *self /= other }
@@ -1043,7 +1043,7 @@ macro_rules! rem_assign_impl {
     ($($t:ty)+) => ($(
         #[stable(feature = "op_assign_traits", since = "1.8.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
-        impl const RemAssign for $t {
+        const impl RemAssign for $t {
             #[inline]
             #[track_caller]
             fn rem_assign(&mut self, other: $t) { *self %= other }

--- a/library/core/src/ops/bit.rs
+++ b/library/core/src/ops/bit.rs
@@ -56,7 +56,7 @@ macro_rules! not_impl {
     ($($t:ty)*) => ($(
         #[stable(feature = "rust1", since = "1.0.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
-        impl const Not for $t {
+        const impl Not for $t {
             type Output = $t;
 
             #[inline]
@@ -171,7 +171,7 @@ macro_rules! bitand_impl {
     ($($t:ty)*) => ($(
         #[stable(feature = "rust1", since = "1.0.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
-        impl const BitAnd for $t {
+        const impl BitAnd for $t {
             type Output = $t;
 
             #[inline]
@@ -275,7 +275,7 @@ macro_rules! bitor_impl {
     ($($t:ty)*) => ($(
         #[stable(feature = "rust1", since = "1.0.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
-        impl const BitOr for $t {
+        const impl BitOr for $t {
             type Output = $t;
 
             #[inline]
@@ -379,7 +379,7 @@ macro_rules! bitxor_impl {
     ($($t:ty)*) => ($(
         #[stable(feature = "rust1", since = "1.0.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
-        impl const BitXor for $t {
+        const impl BitXor for $t {
             type Output = $t;
 
             #[inline]
@@ -743,7 +743,7 @@ macro_rules! bitand_assign_impl {
     ($($t:ty)+) => ($(
         #[stable(feature = "op_assign_traits", since = "1.8.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
-        impl const BitAndAssign for $t {
+        const impl BitAndAssign for $t {
             #[inline]
             fn bitand_assign(&mut self, other: $t) { *self &= other }
         }
@@ -818,7 +818,7 @@ macro_rules! bitor_assign_impl {
     ($($t:ty)+) => ($(
         #[stable(feature = "op_assign_traits", since = "1.8.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
-        impl const BitOrAssign for $t {
+        const impl BitOrAssign for $t {
             #[inline]
             fn bitor_assign(&mut self, other: $t) { *self |= other }
         }
@@ -893,7 +893,7 @@ macro_rules! bitxor_assign_impl {
     ($($t:ty)+) => ($(
         #[stable(feature = "op_assign_traits", since = "1.8.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
-        impl const BitXorAssign for $t {
+        const impl BitXorAssign for $t {
             #[inline]
             fn bitxor_assign(&mut self, other: $t) { *self ^= other }
         }

--- a/library/core/src/pat.rs
+++ b/library/core/src/pat.rs
@@ -44,7 +44,7 @@ macro_rules! impl_range_pat {
     ($($ty:ty,)*) => {
         $(
             #[rustc_const_unstable(feature = "pattern_type_range_trait", issue = "123646")]
-            impl const RangePattern for $ty {
+            const impl RangePattern for $ty {
                 const MIN: $ty = <$ty>::MIN;
                 const MAX: $ty = <$ty>::MAX;
                 fn sub_one(self) -> Self {

--- a/library/core/src/sync/atomic.rs
+++ b/library/core/src/sync/atomic.rs
@@ -2593,7 +2593,7 @@ macro_rules! atomic_int {
 
         #[$stable_from]
         #[rustc_const_unstable(feature = "const_convert", issue = "143773")]
-        impl const From<$int_type> for $atomic_type {
+        const impl From<$int_type> for $atomic_type {
             #[doc = concat!("Converts an `", stringify!($int_type), "` into an `", stringify!($atomic_type), "`.")]
             #[inline]
             fn from(v: $int_type) -> Self { Self::new(v) }

--- a/library/core/src/tuple.rs
+++ b/library/core/src/tuple.rs
@@ -25,7 +25,7 @@ macro_rules! tuple_impls {
             $($T)+ @
             #[stable(feature = "rust1", since = "1.0.0")]
             #[rustc_const_unstable(feature = "const_cmp", issue = "143800")]
-            impl<$($T: [const] PartialEq),+> const PartialEq for ($($T,)+) {
+            const impl<$($T: [const] PartialEq),+> PartialEq for ($($T,)+) {
                 #[inline]
                 fn eq(&self, other: &($($T,)+)) -> bool {
                     $( ${ignore($T)} self.${index()} == other.${index()} )&&+
@@ -41,7 +41,7 @@ macro_rules! tuple_impls {
             $($T)+ @
             #[stable(feature = "rust1", since = "1.0.0")]
             #[rustc_const_unstable(feature = "const_cmp", issue = "143800")]
-            impl<$($T: [const] Eq),+> const Eq for ($($T,)+)
+            const impl<$($T: [const] Eq),+> Eq for ($($T,)+)
             {}
         }
 
@@ -63,7 +63,7 @@ macro_rules! tuple_impls {
             $($T)+ @
             #[stable(feature = "rust1", since = "1.0.0")]
             #[rustc_const_unstable(feature = "const_cmp", issue = "143800")]
-            impl<$($T: [const] PartialOrd),+> const PartialOrd for ($($T,)+)
+            const impl<$($T: [const] PartialOrd),+> PartialOrd for ($($T,)+)
             {
                 #[inline]
                 fn partial_cmp(&self, other: &($($T,)+)) -> Option<Ordering> {
@@ -108,7 +108,7 @@ macro_rules! tuple_impls {
             $($T)+ @
             #[stable(feature = "rust1", since = "1.0.0")]
             #[rustc_const_unstable(feature = "const_cmp", issue = "143800")]
-            impl<$($T: [const] Ord),+> const Ord for ($($T,)+)
+            const impl<$($T: [const] Ord),+> Ord for ($($T,)+)
             {
                 #[inline]
                 fn cmp(&self, other: &($($T,)+)) -> Ordering {
@@ -121,7 +121,7 @@ macro_rules! tuple_impls {
             $($T)+ @
             #[stable(feature = "rust1", since = "1.0.0")]
             #[rustc_const_unstable(feature = "const_default", issue = "143894")]
-            impl<$($T: [const] Default),+> const Default for ($($T,)+) {
+            const impl<$($T: [const] Default),+> Default for ($($T,)+) {
                 #[inline]
                 fn default() -> ($($T,)+) {
                     ($({ let x: $T = Default::default(); x},)+)

--- a/library/stdarch/crates/core_arch/src/loongarch64/simd.rs
+++ b/library/stdarch/crates/core_arch/src/loongarch64/simd.rs
@@ -18,7 +18,7 @@ pub(super) const trait SimdExt: Sized {
 macro_rules! impl_simd_ext {
     ($v:ident, $e:ty) => {
         #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
-        impl const SimdExt for crate::core_arch::simd::$v {
+        const impl SimdExt for crate::core_arch::simd::$v {
             type Elem = $e;
 
             #[inline(always)]

--- a/library/stdarch/crates/core_arch/src/simd.rs
+++ b/library/stdarch/crates/core_arch/src/simd.rs
@@ -88,7 +88,7 @@ impl<T: SimdElement, const N: usize> Clone for Simd<T, N> {
 
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
 #[rustfmt::skip] // FIXME: https://github.com/rust-lang/stdarch/pull/2133#issuecomment-4524350350
-impl<T: SimdElement, const N: usize> const crate::cmp::PartialEq for Simd<T, N> {
+const impl<T: SimdElement, const N: usize> crate::cmp::PartialEq for Simd<T, N> {
     #[inline]
     fn eq(&self, other: &Self) -> bool {
         self.as_array() == other.as_array()
@@ -301,7 +301,7 @@ impl<T: SimdElement, const N: usize> Clone for SimdM<T, N> {
 
 #[rustc_const_unstable(feature = "stdarch_const_helpers", issue = "none")]
 #[rustfmt::skip] // FIXME: https://github.com/rust-lang/stdarch/pull/2133#issuecomment-4524350350
-impl<T: SimdElement, const N: usize> const crate::cmp::PartialEq for SimdM<T, N> {
+const impl<T: SimdElement, const N: usize> crate::cmp::PartialEq for SimdM<T, N> {
     #[inline]
     fn eq(&self, other: &Self) -> bool {
         self.as_array() == other.as_array()

--- a/src/tools/rustfmt/tests/source/impls.rs
+++ b/src/tools/rustfmt/tests/source/impls.rs
@@ -170,7 +170,7 @@ impl<'a, 'b, 'c> SomeThing<Something> for (&'a mut SomethingLong, &'b mut Someth
 impl<'seq1, 'seq2, 'body, 'scope, Channel> Adc12< Dual, MasterRunningDma<'seq1, 'body, 'scope, Channel>, SlaveRunningDma<'seq2, 'body, 'scope>, > where Channel: DmaChannel, {}
 
 // #4084
-impl     const       std::default::Default for Struct {
+const      impl            std::default::Default for Struct {
     #[inline]
     fn default() -> Self {
         Self { f: 12.5 }

--- a/src/tools/rustfmt/tests/source/type.rs
+++ b/src/tools/rustfmt/tests/source/type.rs
@@ -146,7 +146,7 @@ trait T: [   const ] Super {}
 
 const fn not_quite_const<S: [  const  ]  T>() -> i32 { <S as T>::CONST }
 
-impl     const T for U {}
+const         impl      T for U {}
 
 fn apit(_: impl [   const ] T) {}
 

--- a/tests/auxiliary/minisimd.rs
+++ b/tests/auxiliary/minisimd.rs
@@ -170,20 +170,20 @@ impl<T, const N: usize> PackedSimd<T, N> {
 
 macro_rules! impl_traits {
     ($($const_:ident)?) => {
-        impl<T: $([$const_])? PartialEq, const N: usize> $($const_)? PartialEq for Simd<T, N> {
+        $($const_)? impl<T: $([$const_])? PartialEq, const N: usize> PartialEq for Simd<T, N> {
             fn eq(&self, other: &Self) -> bool {
                 self.as_array() == other.as_array()
             }
         }
 
-        impl<T, const N: usize> $($const_)? core::ops::Index<usize> for Simd<T, N> {
+        $($const_)? impl<T, const N: usize> core::ops::Index<usize> for Simd<T, N> {
             type Output = T;
             fn index(&self, i: usize) -> &T {
                 &self.as_array()[i]
             }
         }
 
-        impl<T: $([$const_])? PartialEq, const N: usize> $($const_)? PartialEq for PackedSimd<T, N>
+        $($const_)? impl<T: $([$const_])? PartialEq, const N: usize> PartialEq for PackedSimd<T, N>
         {
             fn eq(&self, other: &Self) -> bool {
                 self.as_array() == other.as_array()

--- a/tests/rustdoc-html/constant/const-trait-and-impl-methods.rs
+++ b/tests/rustdoc-html/constant/const-trait-and-impl-methods.rs
@@ -20,7 +20,7 @@ pub struct NonConstImpl {}
 //@ !has - '//*[@id="method.required"]' 'const'
 //@ has - '//*[@id="method.defaulted"]' 'fn defaulted()'
 //@ !has - '//*[@id="method.defaulted"]' 'const'
-impl const Tr for ConstImpl {
+const impl Tr for ConstImpl {
     fn required() {}
 }
 

--- a/tests/rustdoc-html/constant/rfc-2632-const-trait-impl.rs
+++ b/tests/rustdoc-html/constant/rfc-2632-const-trait-impl.rs
@@ -36,7 +36,7 @@ pub const trait Tr<T> {
 //@ has - '//section[@id="impl-Tr%3CT%3E-for-T"]/h3[@class="code-header"]/a[@class="trait"]' 'Fn'
 //@ !has - '//section[@id="impl-Tr%3CT%3E-for-T"]/h3[@class="code-header"]/span[@class="where"]' '[const]'
 //@ has - '//section[@id="impl-Tr%3CT%3E-for-T"]/h3[@class="code-header"]/div[@class="where"]' ': Fn'
-impl<T: /* [const] */ Fn() /* + [const] Destruct */> const Tr<T> for T
+const impl<T: /* [const] */ Fn() /* + [const] Destruct */> Tr<T> for T
 where
     Option<T>: /* [const] */ Fn() /* + [const] Destruct */,
 {

--- a/tests/ui/const-generics/const_trait_fn-issue-88433.rs
+++ b/tests/ui/const-generics/const_trait_fn-issue-88433.rs
@@ -11,7 +11,7 @@ const trait Func<T> {
 
 struct Closure;
 
-impl const Func<&usize> for Closure {
+const impl Func<&usize> for Closure {
     type Output = usize;
 
     fn call_once(self, arg: &usize) -> Self::Output {

--- a/tests/ui/const-generics/issues/issue-88119.rs
+++ b/tests/ui/const-generics/issues/issue-88119.rs
@@ -6,7 +6,7 @@ const trait ConstName {
     const NAME_BYTES: &'static [u8];
 }
 
-impl const ConstName for u8 {
+const impl ConstName for u8 {
     const NAME_BYTES: &'static [u8] = b"u8";
 }
 
@@ -14,14 +14,14 @@ const fn name_len<T: ?Sized + ConstName>() -> usize {
     T::NAME_BYTES.len()
 }
 
-impl<T: ?Sized + ConstName> const ConstName for &T
+const impl<T: ?Sized + ConstName> ConstName for &T
 where
     [(); name_len::<T>()]:,
 {
     const NAME_BYTES: &'static [u8] = b"&T";
 }
 
-impl<T: ?Sized + ConstName> const ConstName for &mut T
+const impl<T: ?Sized + ConstName> ConstName for &mut T
 where
     [(); name_len::<T>()]:,
 {

--- a/tests/ui/const-generics/issues/issue-98629.rs
+++ b/tests/ui/const-generics/issues/issue-98629.rs
@@ -4,12 +4,13 @@ const trait Trait {
     const N: usize;
 }
 
-impl const Trait for i32 {}
+const impl Trait for i32 {}
 //~^ ERROR not all trait items implemented, missing: `N`
 
 fn f()
 where
     [(); <i32 as Trait>::N]:,
-{}
+{
+}
 
 fn main() {}

--- a/tests/ui/const-generics/issues/issue-98629.stderr
+++ b/tests/ui/const-generics/issues/issue-98629.stderr
@@ -4,7 +4,7 @@ error[E0046]: not all trait items implemented, missing: `N`
 LL |     const N: usize;
    |     -------------- `N` from trait
 ...
-LL | impl const Trait for i32 {}
+LL | const impl Trait for i32 {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^ missing `N` in implementation
 
 error: aborting due to 1 previous error

--- a/tests/ui/consts/const-closure-in-trait-impl.rs
+++ b/tests/ui/consts/const-closure-in-trait-impl.rs
@@ -12,7 +12,7 @@ const trait T {
 
 struct S;
 
-impl const T for S {
+const impl T for S {
     fn a(&mut self, f: impl [const] Fn() + [const] Destruct) {
         f()
     }

--- a/tests/ui/consts/const-try.rs
+++ b/tests/ui/consts/const-try.rs
@@ -15,13 +15,13 @@ use std::ops::{ControlFlow, FromResidual, Residual, Try};
 struct TryMe;
 struct Error;
 
-impl const FromResidual<Error> for TryMe {
+const impl FromResidual<Error> for TryMe {
     fn from_residual(residual: Error) -> Self {
         TryMe
     }
 }
 
-impl const Try for TryMe {
+const impl Try for TryMe {
     type Output = ();
     type Residual = Error;
     fn from_output(output: Self::Output) -> Self {

--- a/tests/ui/consts/drop-impl-nonconst-drop-field.rs
+++ b/tests/ui/consts/drop-impl-nonconst-drop-field.rs
@@ -12,20 +12,20 @@ impl Drop for NotConstDrop {
 struct ConstDrop(NotConstDrop);
 //~^ ERROR: `NotConstDrop` does not implement `[const] Destruct`
 
-impl const Drop for ConstDrop {
+const impl Drop for ConstDrop {
     fn drop(&mut self) {}
 }
 
 struct ConstDrop2<T>(T);
 //~^ ERROR:  `T` does not implement `[const] Destruct`
 
-impl<T> const Drop for ConstDrop2<T> {
+const impl<T> Drop for ConstDrop2<T> {
     fn drop(&mut self) {}
 }
 
 struct ConstDrop3<T>(T);
 
-impl<T: [const] Destruct> const Drop for ConstDrop3<T> {
+const impl<T: [const] Destruct> Drop for ConstDrop3<T> {
     fn drop(&mut self) {}
 }
 

--- a/tests/ui/consts/drop-impl-nonconst-drop-field.stderr
+++ b/tests/ui/consts/drop-impl-nonconst-drop-field.stderr
@@ -7,7 +7,7 @@ LL | struct ConstDrop(NotConstDrop);
 note: required for this `Drop` impl
   --> $DIR/drop-impl-nonconst-drop-field.rs:15:1
    |
-LL | impl const Drop for ConstDrop {
+LL | const impl Drop for ConstDrop {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0367]: `T` does not implement `[const] Destruct`
@@ -19,12 +19,12 @@ LL | struct ConstDrop2<T>(T);
 note: required for this `Drop` impl
   --> $DIR/drop-impl-nonconst-drop-field.rs:22:1
    |
-LL | impl<T> const Drop for ConstDrop2<T> {
+LL | const impl<T> Drop for ConstDrop2<T> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: consider restricting type parameter `T` with unstable trait `Destruct`
    |
-LL | impl<T: [const] Destruct> const Drop for ConstDrop2<T> {
-   |       ++++++++++++++++++
+LL | const impl<T: [const] Destruct> Drop for ConstDrop2<T> {
+   |             ++++++++++++++++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/consts/promoted-const-drop.rs
+++ b/tests/ui/consts/promoted-const-drop.rs
@@ -2,7 +2,7 @@
 
 struct A();
 
-impl const Drop for A {
+const impl Drop for A {
     fn drop(&mut self) {}
 }
 

--- a/tests/ui/consts/promoted_const_call.rs
+++ b/tests/ui/consts/promoted_const_call.rs
@@ -1,9 +1,15 @@
 #![feature(const_trait_impl, const_destruct)]
 
 struct Panic;
-impl const Drop for Panic { fn drop(&mut self) { panic!(); } }
+const impl Drop for Panic {
+    fn drop(&mut self) {
+        panic!();
+    }
+}
 
-pub const fn id<T>(x: T) -> T { x }
+pub const fn id<T>(x: T) -> T {
+    x
+}
 pub const C: () = {
     let _: &'static _ = &id(&Panic);
     //~^ ERROR: temporary value dropped while borrowed

--- a/tests/ui/consts/promoted_const_call.stderr
+++ b/tests/ui/consts/promoted_const_call.stderr
@@ -1,24 +1,4 @@
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/promoted_const_call.rs:8:26
-   |
-LL |     let _: &'static _ = &id(&Panic);
-   |            ----------    ^^^^^^^^^^ creates a temporary value which is freed while still in use
-   |            |
-   |            type annotation requires that borrow lasts for `'static`
-...
-LL | };
-   | - temporary value is freed at the end of this statement
-
-error[E0716]: temporary value dropped while borrowed
-  --> $DIR/promoted_const_call.rs:8:30
-   |
-LL |     let _: &'static _ = &id(&Panic);
-   |            ----------        ^^^^^ - temporary value is freed at the end of this statement
-   |            |                 |
-   |            |                 creates a temporary value which is freed while still in use
-   |            type annotation requires that borrow lasts for `'static`
-
-error[E0716]: temporary value dropped while borrowed
   --> $DIR/promoted_const_call.rs:14:26
    |
 LL |     let _: &'static _ = &id(&Panic);
@@ -26,7 +6,7 @@ LL |     let _: &'static _ = &id(&Panic);
    |            |
    |            type annotation requires that borrow lasts for `'static`
 ...
-LL | }
+LL | };
    | - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
@@ -39,7 +19,27 @@ LL |     let _: &'static _ = &id(&Panic);
    |            type annotation requires that borrow lasts for `'static`
 
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/promoted_const_call.rs:17:26
+  --> $DIR/promoted_const_call.rs:20:26
+   |
+LL |     let _: &'static _ = &id(&Panic);
+   |            ----------    ^^^^^^^^^^ creates a temporary value which is freed while still in use
+   |            |
+   |            type annotation requires that borrow lasts for `'static`
+...
+LL | }
+   | - temporary value is freed at the end of this statement
+
+error[E0716]: temporary value dropped while borrowed
+  --> $DIR/promoted_const_call.rs:20:30
+   |
+LL |     let _: &'static _ = &id(&Panic);
+   |            ----------        ^^^^^ - temporary value is freed at the end of this statement
+   |            |                 |
+   |            |                 creates a temporary value which is freed while still in use
+   |            type annotation requires that borrow lasts for `'static`
+
+error[E0716]: temporary value dropped while borrowed
+  --> $DIR/promoted_const_call.rs:23:26
    |
 LL |     let _: &'static _ = &&(Panic, 0).1;
    |            ----------    ^^^^^^^^^^^^^ creates a temporary value which is freed while still in use
@@ -50,7 +50,7 @@ LL | }
    | - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/promoted_const_call.rs:17:27
+  --> $DIR/promoted_const_call.rs:23:27
    |
 LL |     let _: &'static _ = &&(Panic, 0).1;
    |            ----------     ^^^^^^^^^^ creates a temporary value which is freed while still in use

--- a/tests/ui/consts/trait_alias.rs
+++ b/tests/ui/consts/trait_alias.rs
@@ -12,8 +12,8 @@ const trait Baz {
     fn baz(&self) {}
 }
 
-impl const Bar for () {}
-impl const Baz for () {}
+const impl Bar for () {}
+const impl Baz for () {}
 
 const trait Foo = [const] Bar + Baz;
 

--- a/tests/ui/consts/trait_alias_method_call.rs
+++ b/tests/ui/consts/trait_alias_method_call.rs
@@ -11,14 +11,13 @@ mod foo {
         fn baz(&self) {}
     }
 
-    impl const Bar for () {}
-    impl const Baz for () {}
+    const impl Bar for () {}
+    const impl Baz for () {}
 
     pub const trait Foo = [const] Bar + Baz;
 }
 
 use foo::Foo as _;
-
 
 const _: () = {
     // Ok via `[const] Bar` on `Foo`

--- a/tests/ui/diagnostic_namespace/on_const/misplaced_attr.rs
+++ b/tests/ui/diagnostic_namespace/on_const/misplaced_attr.rs
@@ -7,7 +7,7 @@ pub struct Foo;
 
 #[diagnostic::on_const(message = "tadaa", note = "boing")]
 //~^ ERROR: `#[diagnostic::on_const]` can only be applied to non-const trait implementations
-impl const PartialEq for Foo {
+const impl PartialEq for Foo {
     fn eq(&self, _other: &Foo) -> bool {
         true
     }

--- a/tests/ui/diagnostic_namespace/on_const/misplaced_attr.stderr
+++ b/tests/ui/diagnostic_namespace/on_const/misplaced_attr.stderr
@@ -4,7 +4,7 @@ error: `#[diagnostic::on_const]` can only be applied to non-const trait implemen
 LL | #[diagnostic::on_const(message = "tadaa", note = "boing")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 LL |
-LL | impl const PartialEq for Foo {
+LL | const impl PartialEq for Foo {
    | ---------------------------- this is a const trait implementation
    |
 note: the lint level is defined here

--- a/tests/ui/generic-const-items/const-trait-impl.rs
+++ b/tests/ui/generic-const-items/const-trait-impl.rs
@@ -15,13 +15,14 @@ const trait Create {
     fn create() -> Self;
 }
 
-impl const Create for i32 {
+const impl Create for i32 {
     fn create() -> i32 {
         4096
     }
 }
 
-trait Mod { // doesn't need to be a const trait
+// doesn't need to be a const trait
+trait Mod {
     const CREATE<T: const Create>: T;
 }
 

--- a/tests/ui/macros/stringify.rs
+++ b/tests/ui/macros/stringify.rs
@@ -491,7 +491,7 @@ fn test_item() {
     c1!(item, [ pub impl Struct {} ], "pub impl Struct {}");
     c1!(item, [ impl<T> Struct<T> {} ], "impl<T> Struct<T> {}");
     c1!(item, [ pub impl Trait for Struct {} ], "pub impl Trait for Struct {}");
-    c1!(item, [ impl<T> const Trait for T {} ], "impl<T> const Trait for T {}");
+    c1!(item, [ const impl<T> Trait for T {} ], "const impl<T> Trait for T {}");
 
     // ItemKind::MacCall
     c1!(item, [ mac!(); ], "mac!();");

--- a/tests/ui/parser/const-recover-semi-issue-151149.fixed
+++ b/tests/ui/parser/const-recover-semi-issue-151149.fixed
@@ -7,7 +7,7 @@ const trait ConstDefault {
     fn const_default() -> Self;
 }
 
-impl const ConstDefault for u8 {
+const impl ConstDefault for u8 {
     fn const_default() -> Self { 0 }
 }
 

--- a/tests/ui/parser/const-recover-semi-issue-151149.rs
+++ b/tests/ui/parser/const-recover-semi-issue-151149.rs
@@ -7,7 +7,7 @@ const trait ConstDefault {
     fn const_default() -> Self;
 }
 
-impl const ConstDefault for u8 {
+const impl ConstDefault for u8 {
     fn const_default() -> Self { 0 }
 }
 

--- a/tests/ui/parser/impls-nested-within-fns-semantic-1.rs
+++ b/tests/ui/parser/impls-nested-within-fns-semantic-1.rs
@@ -8,7 +8,7 @@ const trait Trait {
     fn required();
 }
 
-impl const Trait for () {
+const impl Trait for () {
     fn required() {
         pub struct Type;
 

--- a/tests/ui/stability-attribute/missing-const-stability.rs
+++ b/tests/ui/stability-attribute/missing-const-stability.rs
@@ -26,7 +26,7 @@ pub const trait Bar {
     fn fun();
 }
 #[stable(feature = "stable", since = "1.0.0")]
-impl const Bar for Foo {
+const impl Bar for Foo {
     // ok because all users must enable `const_trait_impl`
     fn fun() {}
 }

--- a/tests/ui/structs/default-field-values/support.rs
+++ b/tests/ui/structs/default-field-values/support.rs
@@ -31,7 +31,7 @@ pub const trait ConstDefault {
     fn value() -> Self;
 }
 
-impl const ConstDefault for i32 {
+const impl ConstDefault for i32 {
     fn value() -> i32 {
         101
     }
@@ -63,7 +63,7 @@ const fn foo() -> i32 {
     42
 }
 
-fn main () {
+fn main() {
     let x = Foo { .. };
     let y = Foo::default();
     let z = Foo { baz: 1, .. };
@@ -81,6 +81,7 @@ fn main () {
     assert!(matches!(Bar::Foo { bar: S, baz: 1 }, z));
 
     let x = Qux::<i32, 4, i32> { .. };
+    #[rustfmt::skip]
     assert!(matches!(
         Qux::<i32, 4, i32> {
             bar: S,

--- a/tests/ui/traits/const-traits/assoc-type.rs
+++ b/tests/ui/traits/const-traits/assoc-type.rs
@@ -9,7 +9,7 @@ const trait Add<Rhs = Self> {
     fn add(self, other: Rhs) -> Self::Output;
 }
 
-impl const Add for i32 {
+const impl Add for i32 {
     type Output = Self;
 
     fn add(self, other: Self) -> Self::Output {
@@ -31,7 +31,7 @@ const trait Foo {
     type Bar: [const] Add;
 }
 
-impl const Foo for NonConstAdd {
+const impl Foo for NonConstAdd {
     type Bar = NonConstAdd;
     //~^ ERROR the trait bound `NonConstAdd: [const] Add` is not satisfied
 }
@@ -40,7 +40,7 @@ const trait Baz {
     type Qux: Add;
 }
 
-impl const Baz for NonConstAdd {
+const impl Baz for NonConstAdd {
     type Qux = NonConstAdd; // OK
 }
 

--- a/tests/ui/traits/const-traits/auxiliary/cross-crate.rs
+++ b/tests/ui/traits/const-traits/auxiliary/cross-crate.rs
@@ -9,15 +9,11 @@ pub const trait MyTrait {
 pub struct NonConst;
 
 impl MyTrait for NonConst {
-    fn func(self) {
-
-    }
+    fn func(self) {}
 }
 
 pub struct Const;
 
-impl const MyTrait for Const {
-    fn func(self) {
-
-    }
+const impl MyTrait for Const {
+    fn func(self) {}
 }

--- a/tests/ui/traits/const-traits/auxiliary/minicore.rs
+++ b/tests/ui/traits/const-traits/auxiliary/minicore.rs
@@ -12,7 +12,7 @@
     fundamental,
     marker_trait_attr,
     const_trait_impl,
-    const_destruct,
+    const_destruct
 )]
 #![allow(internal_features, incomplete_features)]
 #![no_std]
@@ -41,7 +41,7 @@ pub const trait Add<Rhs = Self> {
     fn add(self, rhs: Rhs) -> Self::Output;
 }
 
-impl const Add for i32 {
+const impl Add for i32 {
     type Output = i32;
     fn add(self, rhs: i32) -> i32 {
         loop {}
@@ -170,7 +170,7 @@ pub const unsafe trait SliceIndex<T: PointeeSized> {
     fn index(self, slice: &T) -> &Self::Output;
 }
 
-impl<T, I> const Index<I> for [T]
+const impl<T, I> Index<I> for [T]
 where
     I: [const] SliceIndex<[T]>,
 {
@@ -182,7 +182,7 @@ where
     }
 }
 
-impl<T, I, const N: usize> const Index<I> for [T; N]
+const impl<T, I, const N: usize> Index<I> for [T; N]
 where
     [T]: [const] Index<I>,
 {
@@ -210,7 +210,7 @@ pub const trait Deref {
     fn deref(&self) -> &Self::Target;
 }
 
-impl<T: MetaSized> const Deref for &T {
+const impl<T: MetaSized> Deref for &T {
     type Target = T;
 
     fn deref(&self) -> &T {
@@ -218,7 +218,7 @@ impl<T: MetaSized> const Deref for &T {
     }
 }
 
-impl<T: MetaSized> const Deref for &mut T {
+const impl<T: MetaSized> Deref for &mut T {
     type Target = T;
 
     fn deref(&self) -> &T {
@@ -269,7 +269,7 @@ pub const trait From<T>: Sized {
     fn from(value: T) -> Self;
 }
 
-impl<T, U> const Into<U> for T
+const impl<T, U> Into<U> for T
 where
     U: [const] From<T>,
 {
@@ -278,7 +278,7 @@ where
     }
 }
 
-impl<T> const From<T> for T {
+const impl<T> From<T> for T {
     fn from(t: T) -> T {
         t
     }
@@ -306,7 +306,7 @@ pub const trait PartialEq<Rhs: PointeeSized = Self>: PointeeSized {
     }
 }
 
-impl<A: PointeeSized, B: PointeeSized> const PartialEq<&B> for &A
+const impl<A: PointeeSized, B: PointeeSized> PartialEq<&B> for &A
 where
     A: [const] PartialEq<B>,
 {
@@ -327,7 +327,7 @@ pub const trait Not {
     fn not(self) -> Self::Output;
 }
 
-impl const Not for bool {
+const impl Not for bool {
     type Output = bool;
     fn not(self) -> bool {
         !self
@@ -387,14 +387,14 @@ impl<T> Option<T> {
     }
 }
 
-impl<P: [const] Deref> const Deref for Pin<P> {
+const impl<P: [const] Deref> Deref for Pin<P> {
     type Target = P::Target;
     fn deref(&self) -> &P::Target {
         Pin::get_ref(Pin::as_ref(self))
     }
 }
 
-impl<T> const Deref for Option<T> {
+const impl<T> Deref for Option<T> {
     type Target = T;
     fn deref(&self) -> &T {
         loop {}

--- a/tests/ui/traits/const-traits/auxiliary/staged-api.rs
+++ b/tests/ui/traits/const-traits/auxiliary/staged-api.rs
@@ -14,7 +14,7 @@ pub struct Unstable;
 
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_const_unstable(feature = "unstable", issue = "none")]
-impl const MyTrait for Unstable {
+const impl MyTrait for Unstable {
     fn func() {}
 }
 
@@ -31,6 +31,6 @@ pub struct Unstable2;
 
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_const_unstable(feature = "unstable2", issue = "none")]
-impl const MyTrait for Unstable2 {
+const impl MyTrait for Unstable2 {
     fn func() {}
 }

--- a/tests/ui/traits/const-traits/call-const-trait-method-fail.rs
+++ b/tests/ui/traits/const-traits/call-const-trait-method-fail.rs
@@ -5,7 +5,7 @@ pub const trait Plus {
     fn plus(self, rhs: Self) -> Self;
 }
 
-impl const Plus for i32 {
+const impl Plus for i32 {
     fn plus(self, rhs: Self) -> Self {
         self + rhs
     }

--- a/tests/ui/traits/const-traits/call-const-trait-method-pass.rs
+++ b/tests/ui/traits/const-traits/call-const-trait-method-pass.rs
@@ -3,7 +3,7 @@
 
 struct Int(i32);
 
-impl const std::ops::Add for Int {
+const impl std::ops::Add for Int {
     type Output = Int;
 
     fn add(self, rhs: Self) -> Self {
@@ -11,7 +11,7 @@ impl const std::ops::Add for Int {
     }
 }
 
-impl const PartialEq for Int {
+const impl PartialEq for Int {
     fn eq(&self, rhs: &Self) -> bool {
         self.0 == rhs.0
     }
@@ -24,7 +24,7 @@ pub const trait Plus {
     fn plus(self, rhs: Self) -> Self;
 }
 
-impl const Plus for i32 {
+const impl Plus for i32 {
     fn plus(self, rhs: Self) -> Self {
         self + rhs
     }

--- a/tests/ui/traits/const-traits/call-generic-in-impl.rs
+++ b/tests/ui/traits/const-traits/call-generic-in-impl.rs
@@ -5,7 +5,7 @@ const trait MyPartialEq {
     fn eq(&self, other: &Self) -> bool;
 }
 
-impl<T: [const] PartialEq> const MyPartialEq for T {
+const impl<T: [const] PartialEq> MyPartialEq for T {
     fn eq(&self, other: &Self) -> bool {
         PartialEq::eq(self, other)
     }

--- a/tests/ui/traits/const-traits/call-generic-method-chain.rs
+++ b/tests/ui/traits/const-traits/call-generic-method-chain.rs
@@ -7,7 +7,7 @@
 
 struct S;
 
-impl const PartialEq for S {
+const impl PartialEq for S {
     fn eq(&self, _: &S) -> bool {
         true
     }

--- a/tests/ui/traits/const-traits/call-generic-method-dup-bound.rs
+++ b/tests/ui/traits/const-traits/call-generic-method-dup-bound.rs
@@ -5,7 +5,7 @@
 
 struct S;
 
-impl const PartialEq for S {
+const impl PartialEq for S {
     fn eq(&self, _: &S) -> bool {
         true
     }

--- a/tests/ui/traits/const-traits/call-generic-method-pass.rs
+++ b/tests/ui/traits/const-traits/call-generic-method-pass.rs
@@ -7,7 +7,7 @@
 
 struct S;
 
-impl const PartialEq for S {
+const impl PartialEq for S {
     fn eq(&self, _: &S) -> bool {
         true
     }

--- a/tests/ui/traits/const-traits/conditionally-const-and-const-params.rs
+++ b/tests/ui/traits/const-traits/conditionally-const-and-const-params.rs
@@ -16,7 +16,7 @@ const trait Add42 {
     fn add(a: usize) -> usize;
 }
 
-impl const Add42 for () {
+const impl Add42 for () {
     fn add(a: usize) -> usize {
         a + 42
     }

--- a/tests/ui/traits/const-traits/conditionally-const-assoc-fn-in-trait-impl.rs
+++ b/tests/ui/traits/const-traits/conditionally-const-assoc-fn-in-trait-impl.rs
@@ -7,7 +7,7 @@ const trait Main {
     fn compute<T: [const] Aux>() -> u32;
 }
 
-impl const Main for () {
+const impl Main for () {
     fn compute<T: [const] Aux>() -> u32 {
         T::generate()
     }
@@ -17,7 +17,7 @@ const trait Aux {
     fn generate() -> u32;
 }
 
-impl const Aux for () {
+const impl Aux for () {
     fn generate() -> u32 { 1024 }
 }
 

--- a/tests/ui/traits/const-traits/conditionally-const-in-anon-const.rs
+++ b/tests/ui/traits/const-traits/conditionally-const-in-anon-const.rs
@@ -3,7 +3,7 @@
 struct S;
 const trait Trait<const N: u32> {}
 
-impl const Trait<0> for () {}
+const impl Trait<0> for () {}
 
 const fn f<
     T: Trait<
@@ -19,7 +19,9 @@ const fn f<
             0
         },
     >,
->(x: &T) {
+>(
+    x: &T,
+) {
     // Should be allowed here
     let y: &impl [const] Trait<0> = x;
 }

--- a/tests/ui/traits/const-traits/conditionally-const-trait-bound-assoc-tys.rs
+++ b/tests/ui/traits/const-traits/conditionally-const-trait-bound-assoc-tys.rs
@@ -6,7 +6,7 @@ const trait Trait {
     type Assoc<T: [const] Bound>;
 }
 
-impl const Trait for () {
+const impl Trait for () {
     type Assoc<T: [const] Bound> = T;
 }
 

--- a/tests/ui/traits/const-traits/const-and-non-const-impl.rs
+++ b/tests/ui/traits/const-traits/const-and-non-const-impl.rs
@@ -2,7 +2,7 @@
 
 pub struct Int(i32);
 
-impl const std::ops::Add for i32 {
+const impl std::ops::Add for i32 {
     //~^ ERROR only traits defined in the current crate can be implemented for primitive types
     type Output = Self;
 
@@ -19,7 +19,7 @@ impl std::ops::Add for Int {
     }
 }
 
-impl const std::ops::Add for Int {
+const impl std::ops::Add for Int {
     //~^ ERROR conflicting implementations of trait
     type Output = Self;
 

--- a/tests/ui/traits/const-traits/const-and-non-const-impl.stderr
+++ b/tests/ui/traits/const-traits/const-and-non-const-impl.stderr
@@ -4,13 +4,13 @@ error[E0119]: conflicting implementations of trait `Add` for type `Int`
 LL | impl std::ops::Add for Int {
    | -------------------------- first implementation here
 ...
-LL | impl const std::ops::Add for Int {
+LL | const impl std::ops::Add for Int {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `Int`
 
 error[E0117]: only traits defined in the current crate can be implemented for primitive types
   --> $DIR/const-and-non-const-impl.rs:5:1
    |
-LL | impl const std::ops::Add for i32 {
+LL | const impl std::ops::Add for i32 {
    | ^^^^^^^^^^^-------------^^^^^---
    |            |                 |
    |            |                 `i32` is not defined in the current crate

--- a/tests/ui/traits/const-traits/const-bound-on-not-const-associated-fn.rs
+++ b/tests/ui/traits/const-traits/const-bound-on-not-const-associated-fn.rs
@@ -13,7 +13,7 @@ trait OtherTrait {
 
 struct MyStruct<T>(T);
 
-impl const MyTrait for u32 {
+const impl MyTrait for u32 {
     fn do_something(&self) {}
 }
 

--- a/tests/ui/traits/const-traits/const-check-fns-in-const-impl.rs
+++ b/tests/ui/traits/const-traits/const-check-fns-in-const-impl.rs
@@ -9,9 +9,11 @@ const trait T {
 
 fn non_const() {}
 
-impl const T for S {
-    fn foo() { non_const() }
-    //~^ ERROR cannot call non-const function
+const impl T for S {
+    fn foo() {
+        non_const()
+        //~^ ERROR cannot call non-const function
+    }
 }
 
 fn main() {}

--- a/tests/ui/traits/const-traits/const-check-fns-in-const-impl.stderr
+++ b/tests/ui/traits/const-traits/const-check-fns-in-const-impl.stderr
@@ -1,8 +1,8 @@
 error[E0015]: cannot call non-const function `non_const` in constant functions
-  --> $DIR/const-check-fns-in-const-impl.rs:13:16
+  --> $DIR/const-check-fns-in-const-impl.rs:14:9
    |
-LL |     fn foo() { non_const() }
-   |                ^^^^^^^^^^^
+LL |         non_const()
+   |         ^^^^^^^^^^^
    |
 note: function `non_const` is not const
   --> $DIR/const-check-fns-in-const-impl.rs:10:1

--- a/tests/ui/traits/const-traits/const-closure-trait-method.rs
+++ b/tests/ui/traits/const-traits/const-closure-trait-method.rs
@@ -7,8 +7,10 @@ const trait Tr {
     fn a(self) -> i32;
 }
 
-impl const Tr for () {
-    fn a(self) -> i32 { 42 }
+const impl Tr for () {
+    fn a(self) -> i32 {
+        42
+    }
 }
 
 const fn need_const_closure<T: [const] FnOnce(()) -> i32>(x: T) -> i32 {

--- a/tests/ui/traits/const-traits/const-cond-for-rpitit.rs
+++ b/tests/ui/traits/const-traits/const-cond-for-rpitit.rs
@@ -11,7 +11,10 @@ pub const trait Foo {
 pub const trait Bar {}
 
 struct A<T>(T);
-impl<T> const Foo for A<T> where A<T>: [const] Bar {
+const impl<T> Foo for A<T>
+where
+    A<T>: [const] Bar,
+{
     fn method(self) -> impl [const] Bar {
         self
     }

--- a/tests/ui/traits/const-traits/const-default-method-bodies.rs
+++ b/tests/ui/traits/const-traits/const-default-method-bodies.rs
@@ -16,7 +16,7 @@ impl ConstDefaultFn for NonConstImpl {
     fn b(self) {}
 }
 
-impl const ConstDefaultFn for ConstImpl {
+const impl ConstDefaultFn for ConstImpl {
     fn b(self) {}
 }
 

--- a/tests/ui/traits/const-traits/const-drop-fail-2.precise.stderr
+++ b/tests/ui/traits/const-traits/const-drop-fail-2.precise.stderr
@@ -7,10 +7,10 @@ LL | const _: () = check::<ConstDropImplWithBounds<NonTrivialDrop>>(
 note: required for `ConstDropImplWithBounds<NonTrivialDrop>` to implement `const Drop`
   --> $DIR/const-drop-fail-2.rs:24:26
    |
-LL | impl<T: [const] A> const Drop for ConstDropImplWithBounds<T> {
-   |         ---------        ^^^^     ^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |         |
-   |         unsatisfied trait bound introduced here
+LL | const impl<T: [const] A> Drop for ConstDropImplWithBounds<T> {
+   |               ---------  ^^^^     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |               |
+   |               unsatisfied trait bound introduced here
 note: required by a bound in `check`
   --> $DIR/const-drop-fail-2.rs:20:19
    |

--- a/tests/ui/traits/const-traits/const-drop-fail-2.rs
+++ b/tests/ui/traits/const-traits/const-drop-fail-2.rs
@@ -21,7 +21,7 @@ const fn check<T: [const] Destruct>(_: T) {}
 
 struct ConstDropImplWithBounds<T: A>(PhantomData<T>);
 
-impl<T: [const] A> const Drop for ConstDropImplWithBounds<T> {
+const impl<T: [const] A> Drop for ConstDropImplWithBounds<T> {
     fn drop(&mut self) {
         T::a();
     }
@@ -34,7 +34,7 @@ const _: () = check::<ConstDropImplWithBounds<NonTrivialDrop>>(
 
 struct ConstDropImplWithNonConstBounds<T: A>(PhantomData<T>);
 
-impl<T: [const] A> const Drop for ConstDropImplWithNonConstBounds<T> {
+const impl<T: [const] A> Drop for ConstDropImplWithNonConstBounds<T> {
     fn drop(&mut self) {
         T::a();
     }

--- a/tests/ui/traits/const-traits/const-drop-fail-2.stock.stderr
+++ b/tests/ui/traits/const-traits/const-drop-fail-2.stock.stderr
@@ -7,10 +7,10 @@ LL | const _: () = check::<ConstDropImplWithBounds<NonTrivialDrop>>(
 note: required for `ConstDropImplWithBounds<NonTrivialDrop>` to implement `const Drop`
   --> $DIR/const-drop-fail-2.rs:24:26
    |
-LL | impl<T: [const] A> const Drop for ConstDropImplWithBounds<T> {
-   |         ---------        ^^^^     ^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |         |
-   |         unsatisfied trait bound introduced here
+LL | const impl<T: [const] A> Drop for ConstDropImplWithBounds<T> {
+   |               ---------  ^^^^     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |               |
+   |               unsatisfied trait bound introduced here
 note: required by a bound in `check`
   --> $DIR/const-drop-fail-2.rs:20:19
    |

--- a/tests/ui/traits/const-traits/const-drop-fail.new_precise.stderr
+++ b/tests/ui/traits/const-traits/const-drop-fail.new_precise.stderr
@@ -7,7 +7,7 @@ LL | struct ConstImplWithDropGlue(NonTrivialDrop);
 note: required for this `Drop` impl
   --> $DIR/const-drop-fail.rs:22:1
    |
-LL | impl const Drop for ConstImplWithDropGlue {
+LL | const impl Drop for ConstImplWithDropGlue {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `NonTrivialDrop: const Destruct` is not satisfied

--- a/tests/ui/traits/const-traits/const-drop-fail.new_stock.stderr
+++ b/tests/ui/traits/const-traits/const-drop-fail.new_stock.stderr
@@ -7,7 +7,7 @@ LL | struct ConstImplWithDropGlue(NonTrivialDrop);
 note: required for this `Drop` impl
   --> $DIR/const-drop-fail.rs:22:1
    |
-LL | impl const Drop for ConstImplWithDropGlue {
+LL | const impl Drop for ConstImplWithDropGlue {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `NonTrivialDrop: const Destruct` is not satisfied

--- a/tests/ui/traits/const-traits/const-drop-fail.old_precise.stderr
+++ b/tests/ui/traits/const-traits/const-drop-fail.old_precise.stderr
@@ -7,7 +7,7 @@ LL | struct ConstImplWithDropGlue(NonTrivialDrop);
 note: required for this `Drop` impl
   --> $DIR/const-drop-fail.rs:22:1
    |
-LL | impl const Drop for ConstImplWithDropGlue {
+LL | const impl Drop for ConstImplWithDropGlue {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `NonTrivialDrop: const Destruct` is not satisfied

--- a/tests/ui/traits/const-traits/const-drop-fail.old_stock.stderr
+++ b/tests/ui/traits/const-traits/const-drop-fail.old_stock.stderr
@@ -7,7 +7,7 @@ LL | struct ConstImplWithDropGlue(NonTrivialDrop);
 note: required for this `Drop` impl
   --> $DIR/const-drop-fail.rs:22:1
    |
-LL | impl const Drop for ConstImplWithDropGlue {
+LL | const impl Drop for ConstImplWithDropGlue {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `NonTrivialDrop: const Destruct` is not satisfied

--- a/tests/ui/traits/const-traits/const-drop-fail.rs
+++ b/tests/ui/traits/const-traits/const-drop-fail.rs
@@ -19,7 +19,7 @@ impl Drop for NonTrivialDrop {
 struct ConstImplWithDropGlue(NonTrivialDrop);
 //~^ ERROR: `NonTrivialDrop` does not implement `[const] Destruct`
 
-impl const Drop for ConstImplWithDropGlue {
+const impl Drop for ConstImplWithDropGlue {
     fn drop(&mut self) {}
 }
 

--- a/tests/ui/traits/const-traits/const-drop.rs
+++ b/tests/ui/traits/const-traits/const-drop.rs
@@ -10,7 +10,7 @@ use std::marker::Destruct;
 
 struct S<'a>(&'a mut u8);
 
-impl<'a> const Drop for S<'a> {
+const impl<'a> Drop for S<'a> {
     fn drop(&mut self) {
         *self.0 += 1;
     }
@@ -42,7 +42,7 @@ mod t {
     pub fn foo() {}
     pub struct ConstDrop;
 
-    impl const Drop for ConstDrop {
+    const impl Drop for ConstDrop {
         fn drop(&mut self) {}
     }
 
@@ -52,7 +52,7 @@ mod t {
     pub const trait SomeTrait {
         fn foo();
     }
-    impl const SomeTrait for () {
+    const impl SomeTrait for () {
         fn foo() {}
     }
     // non-const impl
@@ -62,7 +62,7 @@ mod t {
 
     pub struct ConstDropWithBound<T: const SomeTrait>(pub core::marker::PhantomData<T>);
 
-    impl<T: const SomeTrait> const Drop for ConstDropWithBound<T> {
+    const impl<T: const SomeTrait> Drop for ConstDropWithBound<T> {
         fn drop(&mut self) {
             T::foo();
         }
@@ -70,7 +70,7 @@ mod t {
 
     pub struct ConstDropWithNonconstBound<T: SomeTrait>(pub core::marker::PhantomData<T>);
 
-    impl<T: SomeTrait> const Drop for ConstDropWithNonconstBound<T> {
+    const impl<T: SomeTrait> Drop for ConstDropWithNonconstBound<T> {
         fn drop(&mut self) {
             // Note: we DON'T use the `T: SomeTrait` bound
         }

--- a/tests/ui/traits/const-traits/const-impl-requires-const-trait.rs
+++ b/tests/ui/traits/const-traits/const-impl-requires-const-trait.rs
@@ -3,7 +3,7 @@
 
 pub trait A {}
 
-impl const A for () {}
+const impl A for () {}
 //~^ ERROR: const `impl` for trait `A` which is not `const`
 
 fn main() {}

--- a/tests/ui/traits/const-traits/const-impl-requires-const-trait.stderr
+++ b/tests/ui/traits/const-traits/const-impl-requires-const-trait.stderr
@@ -1,7 +1,7 @@
 error: const `impl` for trait `A` which is not `const`
   --> $DIR/const-impl-requires-const-trait.rs:6:12
    |
-LL | impl const A for () {}
+LL | const impl A for () {}
    |            ^ this trait is not `const`
    |
    = note: marking a trait with `const` ensures all default method bodies are `const`

--- a/tests/ui/traits/const-traits/const-impl-trait.rs
+++ b/tests/ui/traits/const-traits/const-impl-trait.rs
@@ -20,7 +20,7 @@ const trait Foo {
     fn huh() -> impl [const] PartialEq + [const] Destruct + Copy;
 }
 
-impl const Foo for () {
+const impl Foo for () {
     fn huh() -> impl [const] PartialEq + [const] Destruct + Copy {
         123
     }
@@ -37,7 +37,7 @@ const _: () = {
 
 const trait T {}
 struct S;
-impl const T for S {}
+const impl T for S {}
 
 const fn rpit() -> impl [const] T {
     S

--- a/tests/ui/traits/const-traits/const-opaque.rs
+++ b/tests/ui/traits/const-traits/const-opaque.rs
@@ -8,12 +8,12 @@ const trait Foo {
     fn method(&self);
 }
 
-impl<T: [const] Foo> const Foo for (T,) {
+const impl<T: [const] Foo> Foo for (T,) {
     fn method(&self) {}
 }
 
 #[cfg(yes)]
-impl const Foo for () {
+const impl Foo for () {
     fn method(&self) {}
 }
 

--- a/tests/ui/traits/const-traits/const-trait-async-assoc-fn.rs
+++ b/tests/ui/traits/const-traits/const-trait-async-assoc-fn.rs
@@ -3,16 +3,16 @@
 
 const trait Tr {
     async fn ft1() {}
-//~^ ERROR async functions are not allowed in `const` traits
+    //~^ ERROR async functions are not allowed in `const` traits
 }
 
 const trait Tr2 {
     fn f() -> impl std::future::Future<Output = ()>;
 }
 
-impl const Tr2 for () {
+const impl Tr2 for () {
     async fn f() {}
-//~^ ERROR async functions are not allowed in `const` trait impls
+    //~^ ERROR async functions are not allowed in `const` trait impls
 }
 
 fn main() {}

--- a/tests/ui/traits/const-traits/const-trait-async-assoc-fn.stderr
+++ b/tests/ui/traits/const-traits/const-trait-async-assoc-fn.stderr
@@ -9,8 +9,8 @@ LL |     async fn ft1() {}
 error: async functions are not allowed in `const` trait impls
   --> $DIR/const-trait-async-assoc-fn.rs:14:5
    |
-LL | impl const Tr2 for () {
-   |      ----- associated functions of `const` cannot be declared `async`
+LL | const impl Tr2 for () {
+   | ----- associated functions of `const` cannot be declared `async`
 LL |     async fn f() {}
    |     ^^^^^
 

--- a/tests/ui/traits/const-traits/const-trait-impl-parameter-mismatch.rs
+++ b/tests/ui/traits/const-traits/const-trait-impl-parameter-mismatch.rs
@@ -14,7 +14,7 @@ const trait Main {
     fn compute<T: [const] Aux>() -> u32;
 }
 
-impl const Main for () {
+const impl Main for () {
     fn compute<'x>() -> u32 {
         //~^ ERROR associated function `compute` has 0 type parameters but its trait declaration has 1 type parameter
         0
@@ -23,7 +23,7 @@ impl const Main for () {
 
 const trait Aux {}
 
-impl const Aux for () {}
+const impl Aux for () {}
 
 fn main() {
     const _: u32 = <()>::compute::<()>();

--- a/tests/ui/traits/const-traits/const_derives/derive-const-use.rs
+++ b/tests/ui/traits/const-traits/const_derives/derive-const-use.rs
@@ -3,12 +3,16 @@
 
 pub struct A;
 
-impl const Default for A {
-    fn default() -> A { A }
+const impl Default for A {
+    fn default() -> A {
+        A
+    }
 }
 
-impl const PartialEq for A {
-    fn eq(&self, _: &A) -> bool { true }
+const impl PartialEq for A {
+    fn eq(&self, _: &A) -> bool {
+        true
+    }
 }
 
 #[derive_const(Default, PartialEq)]

--- a/tests/ui/traits/const-traits/do-not-const-check-override.rs
+++ b/tests/ui/traits/const-traits/do-not-const-check-override.rs
@@ -5,11 +5,12 @@
 
 const trait Foo {
     #[rustc_do_not_const_check]
-    fn into_iter(&self) { println!("FEAR ME!") }
+    fn into_iter(&self) {
+        println!("FEAR ME!")
+    }
 }
 
-
-impl const Foo for () {
+const impl Foo for () {
     fn into_iter(&self) {
         // ^_^
     }

--- a/tests/ui/traits/const-traits/dont-observe-host.rs
+++ b/tests/ui/traits/const-traits/dont-observe-host.rs
@@ -7,7 +7,7 @@ const trait Trait {
     fn method() {}
 }
 
-impl const Trait for () {}
+const impl Trait for () {}
 
 fn main() {
     let mut x = const {

--- a/tests/ui/traits/const-traits/dont-prefer-param-env-for-infer-self-ty.rs
+++ b/tests/ui/traits/const-traits/dont-prefer-param-env-for-infer-self-ty.rs
@@ -4,7 +4,7 @@
 
 const trait Foo {}
 
-impl<T> const Foo for (T,) where T: [const] Foo {}
+const impl<T> Foo for (T,) where T: [const] Foo {}
 
 const fn needs_const_foo(_: impl [const] Foo + Copy) {}
 

--- a/tests/ui/traits/const-traits/drop-manually-drop.rs
+++ b/tests/ui/traits/const-traits/drop-manually-drop.rs
@@ -15,7 +15,7 @@ impl Drop for Moose {
 
 struct ConstDropper<T>(ManuallyDrop<T>);
 
-impl<T> const Drop for ConstDropper<T> {
+const impl<T> Drop for ConstDropper<T> {
     fn drop(&mut self) {}
 }
 

--- a/tests/ui/traits/const-traits/effect-param-infer.rs
+++ b/tests/ui/traits/const-traits/effect-param-infer.rs
@@ -9,6 +9,6 @@ pub const trait Foo<Rhs: ?Sized = Self> {
     /* stuff */
 }
 
-impl const Foo for () {}
+const impl Foo for () {}
 
 fn main() {}

--- a/tests/ui/traits/const-traits/enforce-deref-on-adjust.rs
+++ b/tests/ui/traits/const-traits/enforce-deref-on-adjust.rs
@@ -12,7 +12,7 @@ impl Foo {
     const fn call(&self) {}
 }
 
-impl<T> const Deref for Wrap<T> {
+const impl<T> Deref for Wrap<T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {

--- a/tests/ui/traits/const-traits/eval-bad-signature.rs
+++ b/tests/ui/traits/const-traits/eval-bad-signature.rs
@@ -12,7 +12,7 @@ const fn get_value<T: [const] Value>() -> u32 {
 
 struct FortyTwo;
 
-impl const Value for FortyTwo {
+const impl Value for FortyTwo {
     fn value() -> i64 {
         //~^ ERROR method `value` has an incompatible type for trait
         42

--- a/tests/ui/traits/const-traits/feature-gate.rs
+++ b/tests/ui/traits/const-traits/feature-gate.rs
@@ -6,7 +6,7 @@
 
 struct S;
 const trait T {} //[stock]~ ERROR const trait impls are experimental
-impl const T for S {}
+const impl T for S {}
 //[stock]~^ ERROR const trait impls are experimental
 
 const fn f<A: [const] T>() {} //[stock]~ ERROR const trait impls are experimental

--- a/tests/ui/traits/const-traits/feature-gate.stock.stderr
+++ b/tests/ui/traits/const-traits/feature-gate.stock.stderr
@@ -9,10 +9,10 @@ LL | const trait T {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: const trait impls are experimental
-  --> $DIR/feature-gate.rs:9:6
+  --> $DIR/feature-gate.rs:9:1
    |
-LL | impl const T for S {}
-   |      ^^^^^
+LL | const impl T for S {}
+   | ^^^^^
    |
    = note: see issue #143874 <https://github.com/rust-lang/rust/issues/143874> for more information
    = help: add `#![feature(const_trait_impl)]` to the crate attributes to enable

--- a/tests/ui/traits/const-traits/generic-bound.rs
+++ b/tests/ui/traits/const-traits/generic-bound.rs
@@ -13,7 +13,7 @@ impl<T> Clone for S<T> {
     }
 }
 
-impl<T> const std::ops::Add for S<T> {
+const impl<T> std::ops::Add for S<T> {
     type Output = Self;
 
     fn add(self, _: Self) -> Self {

--- a/tests/ui/traits/const-traits/hir-const-check.rs
+++ b/tests/ui/traits/const-traits/hir-const-check.rs
@@ -10,7 +10,7 @@ pub const trait MyTrait {
     fn method(&self) -> Option<()>;
 }
 
-impl const MyTrait for () {
+const impl MyTrait for () {
     fn method(&self) -> Option<()> {
         Some(())?;
         None

--- a/tests/ui/traits/const-traits/ice-119717-constant-lifetime.rs
+++ b/tests/ui/traits/const-traits/ice-119717-constant-lifetime.rs
@@ -3,7 +3,7 @@
 
 use std::ops::FromResidual;
 
-impl<T> const FromResidual for T {
+const impl<T> FromResidual for T {
     //~^ ERROR type parameter `T` must be used as an argument to some local type
     fn from_residual(t: T) -> _ {
         //~^ ERROR the placeholder `_` is not allowed

--- a/tests/ui/traits/const-traits/ice-119717-constant-lifetime.stderr
+++ b/tests/ui/traits/const-traits/ice-119717-constant-lifetime.stderr
@@ -1,8 +1,8 @@
 error[E0210]: type parameter `T` must be used as an argument to some local type (e.g., `MyStruct<T>`)
-  --> $DIR/ice-119717-constant-lifetime.rs:6:6
+  --> $DIR/ice-119717-constant-lifetime.rs:6:12
    |
-LL | impl<T> const FromResidual for T {
-   |      ^ uncovered type parameter
+LL | const impl<T> FromResidual for T {
+   |            ^ uncovered type parameter
    |
    = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter

--- a/tests/ui/traits/const-traits/ice-124857-combine-effect-const-infer-vars.rs
+++ b/tests/ui/traits/const-traits/ice-124857-combine-effect-const-infer-vars.rs
@@ -4,9 +4,9 @@
 
 const trait Foo {}
 
-impl const Foo for i32 {}
+const impl Foo for i32 {}
 
-impl<T> const Foo for T where T: [const] Foo {}
+const impl<T> Foo for T where T: [const] Foo {}
 //~^ ERROR conflicting implementations of trait `Foo` for type `i32`
 
 fn main() {}

--- a/tests/ui/traits/const-traits/ice-124857-combine-effect-const-infer-vars.stderr
+++ b/tests/ui/traits/const-traits/ice-124857-combine-effect-const-infer-vars.stderr
@@ -1,10 +1,10 @@
 error[E0119]: conflicting implementations of trait `Foo` for type `i32`
   --> $DIR/ice-124857-combine-effect-const-infer-vars.rs:9:1
    |
-LL | impl const Foo for i32 {}
+LL | const impl Foo for i32 {}
    | ---------------------- first implementation here
 LL |
-LL | impl<T> const Foo for T where T: [const] Foo {}
+LL | const impl<T> Foo for T where T: [const] Foo {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `i32`
 
 error: aborting due to 1 previous error

--- a/tests/ui/traits/const-traits/ice-126148-failed-to-normalize.rs
+++ b/tests/ui/traits/const-traits/ice-126148-failed-to-normalize.rs
@@ -5,16 +5,16 @@ use std::ops::{FromResidual, Residual, Try};
 struct TryMe;
 struct Error;
 
-impl const FromResidual<Error> for TryMe {}
+const impl FromResidual<Error> for TryMe {}
 //~^ ERROR not all trait items implemented
 
-impl const Try for TryMe {
+const impl Try for TryMe {
     //~^ ERROR not all trait items implemented
     type Output = ();
     type Residual = Error;
 }
 
-impl const Residual<()> for Error {
+const impl Residual<()> for Error {
     type TryType = TryMe;
 }
 

--- a/tests/ui/traits/const-traits/ice-126148-failed-to-normalize.stderr
+++ b/tests/ui/traits/const-traits/ice-126148-failed-to-normalize.stderr
@@ -1,7 +1,7 @@
 error[E0046]: not all trait items implemented, missing: `from_residual`
   --> $DIR/ice-126148-failed-to-normalize.rs:8:1
    |
-LL | impl const FromResidual<Error> for TryMe {}
+LL | const impl FromResidual<Error> for TryMe {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `from_residual` in implementation
    |
    = help: implement the missing item: `fn from_residual(_: Error) -> Self { todo!() }`
@@ -9,7 +9,7 @@ LL | impl const FromResidual<Error> for TryMe {}
 error[E0046]: not all trait items implemented, missing: `from_output`, `branch`
   --> $DIR/ice-126148-failed-to-normalize.rs:11:1
    |
-LL | impl const Try for TryMe {
+LL | const impl Try for TryMe {
    | ^^^^^^^^^^^^^^^^^^^^^^^^ missing `from_output`, `branch` in implementation
    |
    = help: implement the missing item: `fn from_output(_: <Self as Try>::Output) -> Self { todo!() }`

--- a/tests/ui/traits/const-traits/impl-with-default-fn-fail.rs
+++ b/tests/ui/traits/const-traits/impl-with-default-fn-fail.rs
@@ -8,9 +8,8 @@ const trait Tr {
 
 struct S;
 
-impl const Tr for u16 {
+const impl Tr for u16 {
     fn default() {}
 } //~^^ ERROR not all trait items implemented
-
 
 fn main() {}

--- a/tests/ui/traits/const-traits/impl-with-default-fn-fail.stderr
+++ b/tests/ui/traits/const-traits/impl-with-default-fn-fail.stderr
@@ -4,7 +4,7 @@ error[E0046]: not all trait items implemented, missing: `req`
 LL |     fn req(&self);
    |     -------------- `req` from trait
 ...
-LL | impl const Tr for u16 {
+LL | const impl Tr for u16 {
    | ^^^^^^^^^^^^^^^^^^^^^ missing `req` in implementation
 
 error: aborting due to 1 previous error

--- a/tests/ui/traits/const-traits/impl-with-default-fn-pass.rs
+++ b/tests/ui/traits/const-traits/impl-with-default-fn-pass.rs
@@ -8,16 +8,16 @@ const trait Tr {
     fn default() {}
 }
 
-impl const Tr for u8 {
+const impl Tr for u8 {
     fn req(&self) {}
 }
 
 macro_rules! impl_tr {
     ($ty: ty) => {
-        impl const Tr for $ty {
+        const impl Tr for $ty {
             fn req(&self) {}
         }
-    }
+    };
 }
 
 impl_tr!(u64);

--- a/tests/ui/traits/const-traits/inherent-impl-const-bounds.rs
+++ b/tests/ui/traits/const-traits/inherent-impl-const-bounds.rs
@@ -6,12 +6,14 @@ struct S;
 const trait A {}
 const trait B {}
 
-impl const A for S {}
-impl const B for S {}
+const impl A for S {}
+const impl B for S {}
 
 impl S {
-    const fn a<T: [const] A>() where T: [const] B {
-
+    const fn a<T: [const] A>()
+    where
+        T: [const] B,
+    {
     }
 }
 

--- a/tests/ui/traits/const-traits/inherent-impl.rs
+++ b/tests/ui/traits/const-traits/inherent-impl.rs
@@ -6,8 +6,8 @@
 struct S;
 trait T {}
 
-impl const S {}
+const impl S {}
 
-impl const dyn T {}
+const impl dyn T {}
 
 fn main() {}

--- a/tests/ui/traits/const-traits/issue-100222.rs
+++ b/tests/ui/traits/const-traits/issue-100222.rs
@@ -5,8 +5,14 @@
 #![allow(incomplete_features)]
 #![feature(const_trait_impl, associated_type_defaults)]
 
-#[cfg(any(yn, yy))] pub const trait Index { type Output; }
-#[cfg(not(any(yn, yy)))] pub trait Index { type Output; }
+#[cfg(any(yn, yy))]
+pub const trait Index {
+    type Output;
+}
+#[cfg(not(any(yn, yy)))]
+pub trait Index {
+    type Output;
+}
 
 #[cfg(any(ny, yy))]
 pub const trait IndexMut
@@ -33,7 +39,7 @@ impl Index for () {
 }
 
 #[cfg(not(any(nn, yn)))]
-impl const IndexMut for <() as Index>::Output {
+const impl IndexMut for <() as Index>::Output {
     const C: <Self as Index>::Output = ();
     type Assoc = <Self as Index>::Output;
     fn foo(&mut self, x: <Self as Index>::Output) -> <Self as Index>::Output

--- a/tests/ui/traits/const-traits/issue-102156.rs
+++ b/tests/ui/traits/const-traits/issue-102156.rs
@@ -8,7 +8,7 @@ use core::convert::{From, TryFrom};
 
 use std::pin::Pin;
 use std::alloc::Allocator;
-impl<T: ?Sized, A: Allocator> const From<Box<T, A>> for Pin<Box<T, A>>
+const impl<T: ?Sized, A: Allocator> From<Box<T, A>> for Pin<Box<T, A>>
 where
     A: 'static,
 {}

--- a/tests/ui/traits/const-traits/issue-79450.rs
+++ b/tests/ui/traits/const-traits/issue-79450.rs
@@ -12,7 +12,7 @@ const trait Tr {
 
 struct S;
 
-impl const Tr for S {
+const impl Tr for S {
     fn req(&self) {}
 }
 

--- a/tests/ui/traits/const-traits/issue-92230-wf-super-trait-env.rs
+++ b/tests/ui/traits/const-traits/issue-92230-wf-super-trait-env.rs
@@ -8,7 +8,7 @@
 pub const trait Super {}
 pub const trait Sub: Super {}
 
-impl<A> const Super for &A where A: [const] Super {}
-impl<A> const Sub for &A where A: [const] Sub {}
+const impl<A> Super for &A where A: [const] Super {}
+const impl<A> Sub for &A where A: [const] Sub {}
 
 fn main() {}

--- a/tests/ui/traits/const-traits/item-bound-entailment-fails.rs
+++ b/tests/ui/traits/const-traits/item-bound-entailment-fails.rs
@@ -11,16 +11,16 @@ const trait Bar {}
 struct N<T>(T);
 impl<T> Bar for N<T> where T: Bar {}
 struct C<T>(T);
-impl<T> const Bar for C<T> where T: [const] Bar {}
+const impl<T> Bar for C<T> where T: [const] Bar {}
 
-impl const Foo for u32 {
+const impl Foo for u32 {
     type Assoc<T> = N<T>
     //~^ ERROR the trait bound `N<T>: [const] Bar` is not satisfied
     where
         T: [const] Bar;
 }
 
-impl const Foo for i32 {
+const impl Foo for i32 {
     type Assoc<T> = C<T>
     //~^ ERROR the trait bound `T: [const] Bar` is not satisfied
     where

--- a/tests/ui/traits/const-traits/item-bound-entailment-fails.stderr
+++ b/tests/ui/traits/const-traits/item-bound-entailment-fails.stderr
@@ -23,7 +23,7 @@ LL |     type Assoc<T> = C<T>
 note: required for `C<T>` to implement `[const] Bar`
   --> $DIR/item-bound-entailment-fails.rs:14:15
    |
-LL | impl<T> const Bar for C<T> where T: [const] Bar {}
+LL | const impl<T> Bar for C<T> where T: [const] Bar {}
    |               ^^^     ^^^^          ----------- unsatisfied trait bound introduced here
 note: required by a bound in `Foo::Assoc`
   --> $DIR/item-bound-entailment-fails.rs:5:20

--- a/tests/ui/traits/const-traits/item-bound-entailment.rs
+++ b/tests/ui/traits/const-traits/item-bound-entailment.rs
@@ -13,7 +13,7 @@ const trait Bar {}
 struct N<T>(T);
 impl<T> Bar for N<T> where T: Bar {}
 struct C<T>(T);
-impl<T> const Bar for C<T> where T: [const] Bar {}
+const impl<T> Bar for C<T> where T: [const] Bar {}
 
 impl Foo for u32 {
     type Assoc<T> = N<T>
@@ -21,7 +21,7 @@ impl Foo for u32 {
         T: Bar;
 }
 
-impl const Foo for i32 {
+const impl Foo for i32 {
     type Assoc<T> = C<T>
     where
         T: [const] Bar;

--- a/tests/ui/traits/const-traits/minicore-drop-fail.rs
+++ b/tests/ui/traits/const-traits/minicore-drop-fail.rs
@@ -19,7 +19,7 @@ const trait Foo {}
 impl Foo for () {}
 
 struct Conditional<T: Foo>(T);
-impl<T> const Drop for Conditional<T> where T: [const] Foo + [const] Destruct {
+const impl<T> Drop for Conditional<T> where T: [const] Foo + [const] Destruct {
     fn drop(&mut self) {}
 }
 

--- a/tests/ui/traits/const-traits/minicore-drop-without-feature-gate.rs
+++ b/tests/ui/traits/const-traits/minicore-drop-without-feature-gate.rs
@@ -13,7 +13,7 @@ extern crate minicore;
 use minicore::*;
 
 struct ConstDrop;
-impl const Drop for ConstDrop {
+const impl Drop for ConstDrop {
     fn drop(&mut self) {}
 }
 

--- a/tests/ui/traits/const-traits/minicore-works.rs
+++ b/tests/ui/traits/const-traits/minicore-works.rs
@@ -11,7 +11,7 @@ extern crate minicore;
 use minicore::*;
 
 struct Custom;
-impl const Add for Custom {
+const impl Add for Custom {
     type Output = ();
     fn add(self, _other: Self) {}
 }

--- a/tests/ui/traits/const-traits/non-const-op-in-closure-in-const.rs
+++ b/tests/ui/traits/const-traits/non-const-op-in-closure-in-const.rs
@@ -6,7 +6,10 @@ const trait Convert<T> {
     fn to(self) -> T;
 }
 
-impl<A, B> const Convert<B> for A where B: [const] From<A> {
+const impl<A, B> Convert<B> for A
+where
+    B: [const] From<A>,
+{
     fn to(self) -> B {
         B::from(self)
     }

--- a/tests/ui/traits/const-traits/overlap-const-with-nonconst.min_spec.stderr
+++ b/tests/ui/traits/const-traits/overlap-const-with-nonconst.min_spec.stderr
@@ -1,7 +1,7 @@
 error[E0119]: conflicting implementations of trait `Foo` for type `(_,)`
   --> $DIR/overlap-const-with-nonconst.rs:20:1
    |
-LL | / impl<T> const Foo for T
+LL | / const impl<T> Foo for T
 LL | | where
 LL | |     T: [const] Bar,
    | |___________________- first implementation here

--- a/tests/ui/traits/const-traits/overlap-const-with-nonconst.rs
+++ b/tests/ui/traits/const-traits/overlap-const-with-nonconst.rs
@@ -5,12 +5,12 @@
 #![cfg_attr(min_spec, feature(min_specialization))]
 
 const trait Bar {}
-impl<T> const Bar for T {}
+const impl<T> Bar for T {}
 
 const trait Foo {
     fn method(&self);
 }
-impl<T> const Foo for T
+const impl<T> Foo for T
 where
     T: [const] Bar,
 {
@@ -18,7 +18,7 @@ where
 }
 // specializing impl:
 impl<T> Foo for (T,) {
-//~^ ERROR conflicting implementations
+    //~^ ERROR conflicting implementations
     fn method(&self) {
         println!("hi");
     }

--- a/tests/ui/traits/const-traits/overlap-const-with-nonconst.spec.stderr
+++ b/tests/ui/traits/const-traits/overlap-const-with-nonconst.spec.stderr
@@ -1,7 +1,7 @@
 error[E0119]: conflicting implementations of trait `Foo` for type `(_,)`
   --> $DIR/overlap-const-with-nonconst.rs:20:1
    |
-LL | / impl<T> const Foo for T
+LL | / const impl<T> Foo for T
 LL | | where
 LL | |     T: [const] Bar,
    | |___________________- first implementation here

--- a/tests/ui/traits/const-traits/partial/no-const-callers.rs
+++ b/tests/ui/traits/const-traits/partial/no-const-callers.rs
@@ -6,17 +6,17 @@ const trait A {
     fn b() { println!("hi"); }
 }
 
-impl const A for () {
+const impl A for () {
     fn a() {}
 }
 
-impl const A for u8 {
+const impl A for u8 {
     fn a() {}
     fn b() { println!("hello"); }
     //~^ ERROR: cannot call non-const function
 }
 
-impl const A for i8 {
+const impl A for i8 {
     fn a() {}
     fn b() {}
 }

--- a/tests/ui/traits/const-traits/predicate-entailment-fails.rs
+++ b/tests/ui/traits/const-traits/predicate-entailment-fails.rs
@@ -2,7 +2,7 @@
 #![feature(const_trait_impl)]
 
 const trait Bar {}
-impl const Bar for () {}
+const impl Bar for () {}
 
 
 const trait TildeConst {
@@ -31,7 +31,7 @@ impl NeverConst for i32 {
     fn foo<T>() where T: const Bar {}
     //~^ ERROR impl has stricter requirements than trait
 }
-impl const NeverConst for u32 {
+const impl NeverConst for u32 {
     type Bar<T> = () where T: [const] Bar;
     //~^ ERROR impl has stricter requirements than trait
 

--- a/tests/ui/traits/const-traits/predicate-entailment-passes.rs
+++ b/tests/ui/traits/const-traits/predicate-entailment-passes.rs
@@ -4,7 +4,7 @@
 #![feature(const_trait_impl)]
 
 const trait Bar {}
-impl const Bar for () {}
+const impl Bar for () {}
 
 const trait TildeConst {
     fn foo<T>() where T: [const] Bar;
@@ -20,7 +20,7 @@ const trait AlwaysConst {
 impl AlwaysConst for i32 {
     fn foo<T>() where T: Bar {}
 }
-impl const AlwaysConst for u32 {
+const impl AlwaysConst for u32 {
     fn foo<T>() where T: [const] Bar {}
 }
 

--- a/tests/ui/traits/const-traits/rustc-impl-const-stability.rs
+++ b/tests/ui/traits/const-traits/rustc-impl-const-stability.rs
@@ -11,7 +11,7 @@ pub struct Data {
 
 #[stable(feature = "potato", since = "1.27.0")]
 #[rustc_const_unstable(feature = "data_foo", issue = "none")]
-impl const Default for Data {
+const impl Default for Data {
     fn default() -> Data {
         Data { _data: 0xbeef }
     }

--- a/tests/ui/traits/const-traits/self-receiver-type-mismatch.rs
+++ b/tests/ui/traits/const-traits/self-receiver-type-mismatch.rs
@@ -10,7 +10,7 @@ const trait Func {
 
 struct Cls;
 
-impl const Func for Cls {
+const impl Func for Cls {
     fn trigger(&self, a: usize) -> usize {
         //~^ ERROR method `trigger` has 2 parameters but the declaration in trait `Func::trigger` has 1
         0

--- a/tests/ui/traits/const-traits/span-bug-issue-121418.rs
+++ b/tests/ui/traits/const-traits/span-bug-issue-121418.rs
@@ -3,7 +3,7 @@
 struct S;
 trait T {}
 
-impl const dyn T {
+const impl dyn T {
     pub const fn new() -> std::sync::Mutex<dyn T> {}
     //~^ ERROR mismatched types
     //~| ERROR cannot be known at compilation time

--- a/tests/ui/traits/const-traits/span-bug-issue-121418.stderr
+++ b/tests/ui/traits/const-traits/span-bug-issue-121418.stderr
@@ -1,8 +1,8 @@
 error: redundant `const` fn marker in const impl
   --> $DIR/span-bug-issue-121418.rs:7:9
    |
-LL | impl const dyn T {
-   |      ----- this declares all associated functions implicitly const
+LL | const impl dyn T {
+   | ----- this declares all associated functions implicitly const
 LL |     pub const fn new() -> std::sync::Mutex<dyn T> {}
    |         ^^^^^^ help: remove the `const`
 

--- a/tests/ui/traits/const-traits/spec-effectvar-ice.rs
+++ b/tests/ui/traits/const-traits/spec-effectvar-ice.rs
@@ -7,10 +7,10 @@ trait Specialize {}
 
 trait Foo {}
 
-impl<T> const Foo for T {}
+const impl<T> Foo for T {}
 //~^ error: const `impl` for trait `Foo` which is not `const`
 
-impl<T> const Foo for T where T: const Specialize {}
+const impl<T> Foo for T where T: const Specialize {}
 //~^ error: const `impl` for trait `Foo` which is not `const`
 //~| error: `const` can only be applied to `const` traits
 //~| error: specialization impl does not specialize any associated items

--- a/tests/ui/traits/const-traits/spec-effectvar-ice.stderr
+++ b/tests/ui/traits/const-traits/spec-effectvar-ice.stderr
@@ -1,7 +1,7 @@
 error: const `impl` for trait `Foo` which is not `const`
   --> $DIR/spec-effectvar-ice.rs:10:15
    |
-LL | impl<T> const Foo for T {}
+LL | const impl<T> Foo for T {}
    |               ^^^ this trait is not `const`
    |
    = note: marking a trait with `const` ensures all default method bodies are `const`
@@ -14,7 +14,7 @@ LL | const trait Foo {}
 error: const `impl` for trait `Foo` which is not `const`
   --> $DIR/spec-effectvar-ice.rs:13:15
    |
-LL | impl<T> const Foo for T where T: const Specialize {}
+LL | const impl<T> Foo for T where T: const Specialize {}
    |               ^^^ this trait is not `const`
    |
    = note: marking a trait with `const` ensures all default method bodies are `const`
@@ -27,7 +27,7 @@ LL | const trait Foo {}
 error: `const` can only be applied to `const` traits
   --> $DIR/spec-effectvar-ice.rs:13:34
    |
-LL | impl<T> const Foo for T where T: const Specialize {}
+LL | const impl<T> Foo for T where T: const Specialize {}
    |                                  ^^^^^ can't be applied to `Specialize`
    |
 help: mark `Specialize` as `const` to allow it to have `const` implementations
@@ -38,19 +38,19 @@ LL | const trait Specialize {}
 error: specialization impl does not specialize any associated items
   --> $DIR/spec-effectvar-ice.rs:13:1
    |
-LL | impl<T> const Foo for T where T: const Specialize {}
+LL | const impl<T> Foo for T where T: const Specialize {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: impl is a specialization of this impl
   --> $DIR/spec-effectvar-ice.rs:10:1
    |
-LL | impl<T> const Foo for T {}
+LL | const impl<T> Foo for T {}
    | ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: cannot specialize on trait `Specialize`
   --> $DIR/spec-effectvar-ice.rs:13:34
    |
-LL | impl<T> const Foo for T where T: const Specialize {}
+LL | const impl<T> Foo for T where T: const Specialize {}
    |                                  ^^^^^^^^^^^^^^^^
 
 error: aborting due to 5 previous errors

--- a/tests/ui/traits/const-traits/specialization/const-default-bound-non-const-specialized-bound.rs
+++ b/tests/ui/traits/const-traits/specialization/const-default-bound-non-const-specialized-bound.rs
@@ -14,7 +14,7 @@ const trait Bar {
     fn bar();
 }
 
-impl<T> const Bar for T
+const impl<T> Bar for T
 where
     T: [const] Foo,
 {
@@ -33,14 +33,14 @@ const trait Baz {
     fn baz();
 }
 
-impl<T> const Baz for T
+const impl<T> Baz for T
 where
     T: [const] Foo,
 {
     default fn baz() {}
 }
 
-impl<T> const Baz for T //~ ERROR conflicting implementations of trait `Baz`
+const impl<T> Baz for T //~ ERROR conflicting implementations of trait `Baz`
 where
     T: Foo,
     T: Specialize,

--- a/tests/ui/traits/const-traits/specialization/const-default-bound-non-const-specialized-bound.stderr
+++ b/tests/ui/traits/const-traits/specialization/const-default-bound-non-const-specialized-bound.stderr
@@ -1,7 +1,7 @@
 error[E0119]: conflicting implementations of trait `Bar`
   --> $DIR/const-default-bound-non-const-specialized-bound.rs:24:1
    |
-LL | / impl<T> const Bar for T
+LL | / const impl<T> Bar for T
 LL | | where
 LL | |     T: [const] Foo,
    | |___________________- first implementation here
@@ -15,12 +15,12 @@ LL | |     T: Specialize,
 error[E0119]: conflicting implementations of trait `Baz`
   --> $DIR/const-default-bound-non-const-specialized-bound.rs:43:1
    |
-LL | / impl<T> const Baz for T
+LL | / const impl<T> Baz for T
 LL | | where
 LL | |     T: [const] Foo,
    | |___________________- first implementation here
 ...
-LL | / impl<T> const Baz for T
+LL | / const impl<T> Baz for T
 LL | | where
 LL | |     T: Foo,
 LL | |     T: Specialize,

--- a/tests/ui/traits/const-traits/specialization/const-default-const-specialized.rs
+++ b/tests/ui/traits/const-traits/specialization/const-default-const-specialized.rs
@@ -14,7 +14,7 @@ const fn get_value<T: [const] Value>() -> u32 {
     T::value()
 }
 
-impl<T> const Value for T {
+const impl<T> Value for T {
     default fn value() -> u32 {
         0
     }
@@ -22,7 +22,7 @@ impl<T> const Value for T {
 
 struct FortyTwo;
 
-impl const Value for FortyTwo {
+const impl Value for FortyTwo {
     fn value() -> u32 {
         42
     }

--- a/tests/ui/traits/const-traits/specialization/const-default-impl-non-const-specialized-impl.min_spec.stderr
+++ b/tests/ui/traits/const-traits/specialization/const-default-impl-non-const-specialized-impl.min_spec.stderr
@@ -1,7 +1,7 @@
 error[E0119]: conflicting implementations of trait `Value` for type `FortyTwo`
   --> $DIR/const-default-impl-non-const-specialized-impl.rs:20:1
    |
-LL | impl<T> const Value for T {
+LL | const impl<T> Value for T {
    | ------------------------- first implementation here
 ...
 LL | impl Value for FortyTwo {

--- a/tests/ui/traits/const-traits/specialization/const-default-impl-non-const-specialized-impl.rs
+++ b/tests/ui/traits/const-traits/specialization/const-default-impl-non-const-specialized-impl.rs
@@ -9,7 +9,7 @@ const trait Value {
     fn value() -> u32;
 }
 
-impl<T> const Value for T {
+const impl<T> Value for T {
     default fn value() -> u32 {
         0
     }

--- a/tests/ui/traits/const-traits/specialization/const-default-impl-non-const-specialized-impl.spec.stderr
+++ b/tests/ui/traits/const-traits/specialization/const-default-impl-non-const-specialized-impl.spec.stderr
@@ -1,7 +1,7 @@
 error[E0119]: conflicting implementations of trait `Value` for type `FortyTwo`
   --> $DIR/const-default-impl-non-const-specialized-impl.rs:20:1
    |
-LL | impl<T> const Value for T {
+LL | const impl<T> Value for T {
    | ------------------------- first implementation here
 ...
 LL | impl Value for FortyTwo {

--- a/tests/ui/traits/const-traits/specialization/default-keyword.rs
+++ b/tests/ui/traits/const-traits/specialization/default-keyword.rs
@@ -7,7 +7,7 @@ const trait Foo {
     fn foo();
 }
 
-impl const Foo for u32 {
+const impl Foo for u32 {
     default fn foo() {}
 }
 

--- a/tests/ui/traits/const-traits/specialization/issue-95187-same-trait-bound-different-constness.rs
+++ b/tests/ui/traits/const-traits/specialization/issue-95187-same-trait-bound-different-constness.rs
@@ -24,7 +24,7 @@ where
     default fn bar() {}
 }
 
-impl<T> const Bar for T
+const impl<T> Bar for T
 where
     T: [const] Foo,
     T: Specialize,
@@ -36,14 +36,14 @@ const trait Baz {
     fn baz();
 }
 
-impl<T> const Baz for T
+const impl<T> Baz for T
 where
     T: Foo,
 {
     default fn baz() {}
 }
 
-impl<T> const Baz for T
+const impl<T> Baz for T
 where
     T: [const] Foo,
     T: Specialize,

--- a/tests/ui/traits/const-traits/specialization/non-const-default-const-specialized.rs
+++ b/tests/ui/traits/const-traits/specialization/non-const-default-const-specialized.rs
@@ -23,7 +23,7 @@ impl<T> Value for T {
 
 struct FortyTwo;
 
-impl const Value for FortyTwo {
+const impl Value for FortyTwo {
     fn value() -> u32 {
         42
     }

--- a/tests/ui/traits/const-traits/specialization/pass.rs
+++ b/tests/ui/traits/const-traits/specialization/pass.rs
@@ -10,37 +10,37 @@ pub const unsafe trait Sup {
 #[rustc_specialization_trait]
 pub const unsafe trait Sub: [const] Sup {}
 
-unsafe impl const Sup for u8 {
+const unsafe impl Sup for u8 {
     default fn foo() -> u32 {
         1
     }
 }
 
-unsafe impl const Sup for () {
+const unsafe impl Sup for () {
     fn foo() -> u32 {
         42
     }
 }
 
-unsafe impl const Sub for () {}
+const unsafe impl Sub for () {}
 
 pub const trait A {
     fn a() -> u32;
 }
 
-impl<T: [const] Default> const A for T {
+const impl<T: [const] Default> A for T {
     default fn a() -> u32 {
         2
     }
 }
 
-impl<T: [const] Default + [const] Sup> const A for T {
+const impl<T: [const] Default + [const] Sup> A for T {
     default fn a() -> u32 {
         3
     }
 }
 
-impl<T: [const] Default + [const] Sub> const A for T {
+const impl<T: [const] Default + [const] Sub> A for T {
     fn a() -> u32 {
         T::foo()
     }

--- a/tests/ui/traits/const-traits/specialization/specialize-on-conditionally-const.rs
+++ b/tests/ui/traits/const-traits/specialization/specialize-on-conditionally-const.rs
@@ -14,11 +14,11 @@ const trait Foo {
     fn foo();
 }
 
-impl<T> const Foo for T {
+const impl<T> Foo for T {
     default fn foo() {}
 }
 
-impl<T> const Foo for T
+const impl<T> Foo for T
 where
     T: [const] Specialize,
 {
@@ -29,14 +29,14 @@ const trait Bar {
     fn bar() {}
 }
 
-impl<T> const Bar for T
+const impl<T> Bar for T
 where
     T: [const] Foo,
 {
     default fn bar() {}
 }
 
-impl<T> const Bar for T
+const impl<T> Bar for T
 where
     T: [const] Foo,
     T: [const] Specialize,

--- a/tests/ui/traits/const-traits/specialization/specializing-constness-2.rs
+++ b/tests/ui/traits/const-traits/specialization/specializing-constness-2.rs
@@ -4,7 +4,7 @@
 #[rustc_specialization_trait]
 pub const trait Sup {}
 
-impl const Sup for () {}
+const impl Sup for () {}
 
 pub const trait A {
     fn a() -> u32;
@@ -16,7 +16,7 @@ impl<T: Default> A for T {
     }
 }
 
-impl<T: Default + [const] Sup> const A for T {
+const impl<T: Default + [const] Sup> A for T {
     fn a() -> u32 {
         3
     }

--- a/tests/ui/traits/const-traits/specialization/specializing-constness.rs
+++ b/tests/ui/traits/const-traits/specialization/specializing-constness.rs
@@ -3,7 +3,7 @@
 #[rustc_specialization_trait]
 pub const trait Sup {}
 
-impl const Sup for () {}
+const impl Sup for () {}
 
 pub const trait A {
     fn a() -> u32;
@@ -11,7 +11,7 @@ pub const trait A {
 
 pub const trait Spec {}
 
-impl<T: [const] Spec> const A for T {
+const impl<T: [const] Spec> A for T {
     default fn a() -> u32 {
         2
     }

--- a/tests/ui/traits/const-traits/specialization/specializing-constness.stderr
+++ b/tests/ui/traits/const-traits/specialization/specializing-constness.stderr
@@ -1,7 +1,7 @@
 error[E0119]: conflicting implementations of trait `A`
   --> $DIR/specializing-constness.rs:20:1
    |
-LL | impl<T: [const] Spec> const A for T {
+LL | const impl<T: [const] Spec> A for T {
    | ----------------------------------- first implementation here
 ...
 LL | impl<T: Spec + Sup> A for T {

--- a/tests/ui/traits/const-traits/staged-api.rs
+++ b/tests/ui/traits/const-traits/staged-api.rs
@@ -18,7 +18,7 @@ pub struct Foo;
 
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_const_unstable(feature = "local_feature", issue = "none")]
-impl const MyTrait for Foo {
+const impl MyTrait for Foo {
     fn func() {}
 }
 
@@ -93,26 +93,26 @@ const trait U {}
 const trait S {}
 
 // implied stable
-impl const U for u8 {}
+const impl U for u8 {}
 //~^ ERROR const stability on the impl does not match the const stability on the trait
 
 #[rustc_const_stable(since = "0.0.0", feature = "beef2")]
-impl const U for u16 {}
+const impl U for u16 {}
 //~^ ERROR const stability on the impl does not match the const stability on the trait
 //~| ERROR trait implementations cannot be const stable yet
 
 #[rustc_const_unstable(feature = "beef", issue = "none")]
-impl const U for u32 {}
+const impl U for u32 {}
 
 // implied stable
-impl const S for u8 {}
+const impl S for u8 {}
 
 #[rustc_const_stable(since = "0.0.0", feature = "beef2")]
-impl const S for u16 {}
+const impl S for u16 {}
 //~^ ERROR trait implementations cannot be const stable yet
 
 #[rustc_const_unstable(feature = "beef", issue = "none")]
-impl const S for u32 {}
+const impl S for u32 {}
 //~^ ERROR const stability on the impl does not match the const stability on the trait
 
 fn main() {}

--- a/tests/ui/traits/const-traits/staged-api.stderr
+++ b/tests/ui/traits/const-traits/staged-api.stderr
@@ -1,13 +1,13 @@
 error: const stability on the impl does not match the const stability on the trait
   --> $DIR/staged-api.rs:96:1
    |
-LL | impl const U for u8 {}
+LL | const impl U for u8 {}
    | ^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this impl is (implicitly) stable...
   --> $DIR/staged-api.rs:96:1
    |
-LL | impl const U for u8 {}
+LL | const impl U for u8 {}
    | ^^^^^^^^^^^^^^^^^^^^^^
 note: ...but the trait is unstable
   --> $DIR/staged-api.rs:90:13
@@ -18,7 +18,7 @@ LL | const trait U {}
 error: trait implementations cannot be const stable yet
   --> $DIR/staged-api.rs:100:1
    |
-LL | impl const U for u16 {}
+LL | const impl U for u16 {}
    | ^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #143874 <https://github.com/rust-lang/rust/issues/143874> for more information
@@ -26,13 +26,13 @@ LL | impl const U for u16 {}
 error: const stability on the impl does not match the const stability on the trait
   --> $DIR/staged-api.rs:100:1
    |
-LL | impl const U for u16 {}
+LL | const impl U for u16 {}
    | ^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this impl is (implicitly) stable...
   --> $DIR/staged-api.rs:100:1
    |
-LL | impl const U for u16 {}
+LL | const impl U for u16 {}
    | ^^^^^^^^^^^^^^^^^^^^^^^
 note: ...but the trait is unstable
   --> $DIR/staged-api.rs:90:13
@@ -43,7 +43,7 @@ LL | const trait U {}
 error: trait implementations cannot be const stable yet
   --> $DIR/staged-api.rs:111:1
    |
-LL | impl const S for u16 {}
+LL | const impl S for u16 {}
    | ^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #143874 <https://github.com/rust-lang/rust/issues/143874> for more information
@@ -51,13 +51,13 @@ LL | impl const S for u16 {}
 error: const stability on the impl does not match the const stability on the trait
   --> $DIR/staged-api.rs:115:1
    |
-LL | impl const S for u32 {}
+LL | const impl S for u32 {}
    | ^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this impl is unstable...
   --> $DIR/staged-api.rs:115:1
    |
-LL | impl const S for u32 {}
+LL | const impl S for u32 {}
    | ^^^^^^^^^^^^^^^^^^^^^^^
 note: ...but the trait is stable
   --> $DIR/staged-api.rs:93:13

--- a/tests/ui/traits/const-traits/super-traits-fail.rs
+++ b/tests/ui/traits/const-traits/super-traits-fail.rs
@@ -12,7 +12,7 @@ impl Foo for S {
     fn a(&self) {}
 }
 
-impl const Bar for S {}
+const impl Bar for S {}
 //~^ ERROR the trait bound
 
 fn main() {}

--- a/tests/ui/traits/const-traits/super-traits-fail.stderr
+++ b/tests/ui/traits/const-traits/super-traits-fail.stderr
@@ -1,7 +1,7 @@
 error[E0277]: the trait bound `S: [const] Foo` is not satisfied
   --> $DIR/super-traits-fail.rs:15:20
    |
-LL | impl const Bar for S {}
+LL | const impl Bar for S {}
    |                    ^
    |
 help: make the `impl` of trait `Foo` `const`

--- a/tests/ui/traits/const-traits/super-traits.rs
+++ b/tests/ui/traits/const-traits/super-traits.rs
@@ -9,11 +9,11 @@ const trait Foo {
 const trait Bar: [const] Foo {}
 
 struct S;
-impl const Foo for S {
+const impl Foo for S {
     fn a(&self) {}
 }
 
-impl const Bar for S {}
+const impl Bar for S {}
 
 const fn foo<T: [const] Bar>(t: &T) {
     t.a();

--- a/tests/ui/traits/const-traits/syntactical-unstable.rs
+++ b/tests/ui/traits/const-traits/syntactical-unstable.rs
@@ -25,7 +25,7 @@ const fn rpit() -> impl [const] MyTrait { Local }
 //~^ ERROR use of unstable const library feature `unstable`
 
 struct Local;
-impl const MyTrait for Local {
+const impl MyTrait for Local {
 //~^ ERROR use of unstable const library feature `unstable`
     fn func() {}
 }

--- a/tests/ui/traits/const-traits/syntactical-unstable.stderr
+++ b/tests/ui/traits/const-traits/syntactical-unstable.stderr
@@ -45,7 +45,7 @@ LL | const fn rpit() -> impl [const] MyTrait { Local }
 error[E0658]: use of unstable const library feature `unstable`
   --> $DIR/syntactical-unstable.rs:28:12
    |
-LL | impl const MyTrait for Local {
+LL | const impl MyTrait for Local {
    |            ^^^^^^^ trait is not stable as const yet
    |
    = help: add `#![feature(unstable)]` to the crate attributes to enable

--- a/tests/ui/traits/const-traits/trait-default-body-stability.rs
+++ b/tests/ui/traits/const-traits/trait-default-body-stability.rs
@@ -17,7 +17,7 @@ pub struct T;
 
 #[stable(feature = "foo", since = "1.0")]
 #[rustc_const_unstable(feature = "const_t_try", issue = "none")]
-impl const Try for T {
+const impl Try for T {
     type Output = T;
     type Residual = T;
 
@@ -32,13 +32,13 @@ impl const Try for T {
 
 #[stable(feature = "foo", since = "1.0")]
 #[rustc_const_unstable(feature = "const_t_try", issue = "none")]
-impl const Residual<T> for T {
+const impl Residual<T> for T {
     type TryType = T;
 }
 
 #[stable(feature = "foo", since = "1.0")]
 #[rustc_const_unstable(feature = "const_t_try", issue = "none")]
-impl const FromResidual for T {
+const impl FromResidual for T {
     fn from_residual(t: T) -> T {
         t
     }

--- a/tests/ui/traits/const-traits/trait-fn-const.rs
+++ b/tests/ui/traits/const-traits/trait-fn-const.rs
@@ -5,7 +5,7 @@ const trait Trait {
     const fn fun(); //~ ERROR functions in traits cannot be declared const
 }
 
-impl const Trait for () {
+const impl Trait for () {
     const fn fun() {} //~ ERROR functions in trait impls cannot be declared const
 }
 

--- a/tests/ui/traits/const-traits/trait-fn-const.stderr
+++ b/tests/ui/traits/const-traits/trait-fn-const.stderr
@@ -12,8 +12,8 @@ LL |     const fn fun();
 error[E0379]: functions in trait impls cannot be declared const
   --> $DIR/trait-fn-const.rs:9:5
    |
-LL | impl const Trait for () {
-   |      ----- this declares all associated functions implicitly const
+LL | const impl Trait for () {
+   | ----- this declares all associated functions implicitly const
 LL |     const fn fun() {}
    |     ^^^^^-
    |     |

--- a/tests/ui/traits/const-traits/trait-where-clause-run.rs
+++ b/tests/ui/traits/const-traits/trait-where-clause-run.rs
@@ -24,13 +24,13 @@ impl Bar for NonConst {
 
 impl Foo for NonConst {}
 
-impl const Bar for Const {
+const impl Bar for Const {
     fn bar() -> u8 {
         4
     }
 }
 
-impl const Foo for Const {}
+const impl Foo for Const {}
 
 fn main() {
     const ANS1: u8 = Const::foo();

--- a/tests/ui/traits/const-traits/variance.rs
+++ b/tests/ui/traits/const-traits/variance.rs
@@ -4,7 +4,7 @@
 
 const trait Foo {}
 
-impl const Foo for () {}
+const impl Foo for () {}
 
 fn foo<'a: 'a>() -> impl const Foo {}
 //~^ ERROR ['a: *]

--- a/tests/ui/traits/next-solver/canonical/effect-var.rs
+++ b/tests/ui/traits/next-solver/canonical/effect-var.rs
@@ -9,11 +9,14 @@ const trait Foo {
 
 trait Bar {}
 
-impl const Foo for i32 {
+const impl Foo for i32 {
     fn foo() {}
 }
 
-impl<T> const Foo for T where T: Bar {
+const impl<T> Foo for T
+where
+    T: Bar,
+{
     fn foo() {}
 }
 

--- a/tests/ui/unpretty/exhaustive.rs
+++ b/tests/ui/unpretty/exhaustive.rs
@@ -543,7 +543,7 @@ mod items {
         impl () {}
         impl<T> () {}
         impl Default for () {}
-        impl<T> const Default for () {}
+        const impl<T> Default for () {}
     }
 
     /// ItemKind::MacCall


### PR DESCRIPTION
I also let some smaller rustfmting of ui tests through, as rustfmt immediately formats `impl const Trait` to `const impl Trait`. This is also the reason I expect that this change will break very little nightly users, so we don't even need to add some helpful diagnostic.

r? @fee1-dead 