### PR TITLE
renovate: Pin GitHub Action digests to SemVer

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,8 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    // Pin GitHub Actions to their commit SHA digests
-    "helpers:pinGitHubActionDigests"
+    // Pin GitHub Actions to their commit SHA digests, resolving floating tags
+    // (e.g. `v4`) to the full SemVer version (e.g. `v4.1.2`)
+    "helpers:pinGitHubActionDigestsToSemver"
   ],
   // Let Renovatebot keep an opened issue that tracks our dependencies
   "dependencyDashboard": true,


### PR DESCRIPTION
Switches the `helpers:pinGitHubActionDigests` preset to `helpers:pinGitHubActionDigestsToSemver`. This resolves floating tags (e.g. `v4`) to a full SemVer version behind the digest and tracks SemVer releases instead of floating tags.

r? @marcoieni 