### PR TITLE
fix unused_braces suggestion for wildcard assignment

### DIFF
--- a/compiler/rustc_lint/src/unused.rs
+++ b/compiler/rustc_lint/src/unused.rs
@@ -1,4 +1,5 @@
 use rustc_ast::util::{classify, parser};
+use rustc_ast::visit::{self, Visitor};
 use rustc_ast::{self as ast, ExprKind, FnRetTy, HasAttrs as _, StmtKind};
 use rustc_data_structures::fx::FxHashMap;
 use rustc_errors::MultiSpan;
@@ -64,6 +65,7 @@ enum UnusedDelimsCtx {
     FunctionArg,
     MethodArg,
     AssignedValue,
+    AssignedValueWithWildcard,
     AssignedValueLetElse,
     IfCond,
     WhileCond,
@@ -85,9 +87,9 @@ impl From<UnusedDelimsCtx> for &'static str {
         match ctx {
             UnusedDelimsCtx::FunctionArg => "function argument",
             UnusedDelimsCtx::MethodArg => "method argument",
-            UnusedDelimsCtx::AssignedValue | UnusedDelimsCtx::AssignedValueLetElse => {
-                "assigned value"
-            }
+            UnusedDelimsCtx::AssignedValue
+            | UnusedDelimsCtx::AssignedValueWithWildcard
+            | UnusedDelimsCtx::AssignedValueLetElse => "assigned value",
             UnusedDelimsCtx::IfCond => "`if` condition",
             UnusedDelimsCtx::WhileCond => "`while` condition",
             UnusedDelimsCtx::ForIterExpr => "`for` iterator expression",
@@ -102,6 +104,29 @@ impl From<UnusedDelimsCtx> for &'static str {
             UnusedDelimsCtx::ClosureBody => "closure body",
         }
     }
+}
+
+fn expr_contains_underscore(expr: &ast::Expr) -> bool {
+    struct UnderscoreVisitor {
+        found: bool,
+    }
+
+    impl<'ast> Visitor<'ast> for UnderscoreVisitor {
+        fn visit_expr(&mut self, expr: &'ast ast::Expr) {
+            if self.found {
+                return;
+            }
+            if matches!(expr.kind, ast::ExprKind::Underscore) {
+                self.found = true;
+            } else {
+                visit::walk_expr(self, expr);
+            }
+        }
+    }
+
+    let mut visitor = UnderscoreVisitor { found: false };
+    visitor.visit_expr(expr);
+    visitor.found
 }
 
 /// Used by both `UnusedParens` and `UnusedBraces` to prevent code duplication.
@@ -412,7 +437,15 @@ trait UnusedDelimLint {
 
             Index(_, ref value, _) => (value, UnusedDelimsCtx::IndexExpr, false, None, None, false),
 
-            Assign(_, ref value, _) | AssignOp(.., ref value) => {
+            Assign(ref lhs, ref value, _) => {
+                let ctx = if expr_contains_underscore(lhs) {
+                    UnusedDelimsCtx::AssignedValueWithWildcard
+                } else {
+                    UnusedDelimsCtx::AssignedValue
+                };
+                (value, ctx, false, None, None, false)
+            }
+            AssignOp(.., ref value) => {
                 (value, UnusedDelimsCtx::AssignedValue, false, None, None, false)
             }
             // either function/method call, or something this lint doesn't care about
@@ -1072,6 +1105,7 @@ impl UnusedDelimLint for UnusedBraces {
                     && (ctx != UnusedDelimsCtx::AnonConst
                         || (matches!(expr.kind, ast::ExprKind::Lit(_))
                             && !expr.span.from_expansion()))
+                    && ctx != UnusedDelimsCtx::AssignedValueWithWildcard
                     && ctx != UnusedDelimsCtx::ClosureBody
                     && !cx.sess().source_map().is_multiline(value.span)
                     && value.attrs.is_empty()

--- a/compiler/rustc_lint/src/unused.rs
+++ b/compiler/rustc_lint/src/unused.rs
@@ -1,4 +1,5 @@
 use rustc_ast::util::{classify, parser};
+use rustc_ast::visit::{self, Visitor};
 use rustc_ast::{self as ast, ExprKind, FnRetTy, ForLoop, HasAttrs as _, StmtKind};
 use rustc_data_structures::fx::FxHashMap;
 use rustc_errors::MultiSpan;
@@ -64,6 +65,7 @@ enum UnusedDelimsCtx {
     FunctionArg,
     MethodArg,
     AssignedValue,
+    AssignedValueWithWildcard,
     AssignedValueLetElse,
     IfCond,
     WhileCond,
@@ -85,9 +87,9 @@ impl From<UnusedDelimsCtx> for &'static str {
         match ctx {
             UnusedDelimsCtx::FunctionArg => "function argument",
             UnusedDelimsCtx::MethodArg => "method argument",
-            UnusedDelimsCtx::AssignedValue | UnusedDelimsCtx::AssignedValueLetElse => {
-                "assigned value"
-            }
+            UnusedDelimsCtx::AssignedValue
+            | UnusedDelimsCtx::AssignedValueWithWildcard
+            | UnusedDelimsCtx::AssignedValueLetElse => "assigned value",
             UnusedDelimsCtx::IfCond => "`if` condition",
             UnusedDelimsCtx::WhileCond => "`while` condition",
             UnusedDelimsCtx::ForIterExpr => "`for` iterator expression",
@@ -102,6 +104,32 @@ impl From<UnusedDelimsCtx> for &'static str {
             UnusedDelimsCtx::ClosureBody => "closure body",
         }
     }
+}
+
+fn expr_contains_wildcard(expr: &ast::Expr) -> bool {
+    struct WildcardVisitor {
+        found: bool,
+    }
+
+    impl<'ast> Visitor<'ast> for WildcardVisitor {
+        fn visit_expr(&mut self, expr: &'ast ast::Expr) {
+            if self.found {
+                return;
+            }
+            match &expr.kind {
+                ast::ExprKind::Underscore
+                | ast::ExprKind::Range(None, None, ast::RangeLimits::HalfOpen) => self.found = true,
+                ast::ExprKind::Struct(expr) if matches!(expr.rest, ast::StructRest::Rest(_)) => {
+                    self.found = true;
+                }
+                _ => visit::walk_expr(self, expr),
+            }
+        }
+    }
+
+    let mut visitor = WildcardVisitor { found: false };
+    visitor.visit_expr(expr);
+    visitor.found
 }
 
 /// Used by both `UnusedParens` and `UnusedBraces` to prevent code duplication.
@@ -412,7 +440,15 @@ trait UnusedDelimLint {
 
             Index(_, ref value, _) => (value, UnusedDelimsCtx::IndexExpr, false, None, None, false),
 
-            Assign(_, ref value, _) | AssignOp(.., ref value) => {
+            Assign(ref lhs, ref value, _) => {
+                let ctx = if expr_contains_wildcard(lhs) {
+                    UnusedDelimsCtx::AssignedValueWithWildcard
+                } else {
+                    UnusedDelimsCtx::AssignedValue
+                };
+                (value, ctx, false, None, None, false)
+            }
+            AssignOp(.., ref value) => {
                 (value, UnusedDelimsCtx::AssignedValue, false, None, None, false)
             }
             // either function/method call, or something this lint doesn't care about
@@ -1101,6 +1137,7 @@ impl UnusedDelimLint for UnusedBraces {
                     && (ctx != UnusedDelimsCtx::AnonConst
                         || (matches!(expr.kind, ast::ExprKind::Lit(_))
                             && !expr.span.from_expansion()))
+                    && ctx != UnusedDelimsCtx::AssignedValueWithWildcard
                     && ctx != UnusedDelimsCtx::ClosureBody
                     && !cx.sess().source_map().is_multiline(value.span)
                     && value.attrs.is_empty()

--- a/tests/ui/lint/unused/unused-braces-wildcard-assignment-issue-116536.rs
+++ b/tests/ui/lint/unused/unused-braces-wildcard-assignment-issue-116536.rs
@@ -1,0 +1,21 @@
+//@ check-pass
+
+#![deny(unused_braces)]
+
+struct Error;
+struct NotCopy;
+
+fn wildcard_assignment_moves_value() {
+    let e = NotCopy;
+    _ = { e };
+}
+
+fn tuple_wildcard_assignment_moves_value() {
+    let e = (NotCopy, Error);
+    (_, Error) = { e };
+}
+
+fn main() {
+    wildcard_assignment_moves_value();
+    tuple_wildcard_assignment_moves_value();
+}

--- a/tests/ui/lint/unused/unused-braces-wildcard-assignment-issue-116536.rs
+++ b/tests/ui/lint/unused/unused-braces-wildcard-assignment-issue-116536.rs
@@ -1,0 +1,72 @@
+//@ run-pass
+
+#![deny(unused_braces)]
+
+use std::cell::Cell;
+
+struct Error;
+struct NotCopy;
+
+struct DropCounter<'a>(&'a Cell<usize>);
+
+impl Drop for DropCounter<'_> {
+    fn drop(&mut self) {
+        self.0.set(self.0.get() + 1);
+    }
+}
+
+struct Pair<'a> {
+    first: DropCounter<'a>,
+    _second: DropCounter<'a>,
+}
+
+fn wildcard_assignment_moves_value() {
+    let e = NotCopy;
+    _ = { e };
+}
+
+fn tuple_wildcard_assignment_moves_value() {
+    let e = (NotCopy, Error);
+    (_, Error) = { e };
+}
+
+fn main() {
+    wildcard_assignment_moves_value();
+    tuple_wildcard_assignment_moves_value();
+
+    let drops = Cell::new(0);
+
+    let e = (DropCounter(&drops), DropCounter(&drops));
+    (..) = { e };
+    assert_eq!(drops.get(), 2);
+
+    let e = [DropCounter(&drops), DropCounter(&drops)];
+    [..] = { e };
+    assert_eq!(drops.get(), 4);
+
+    let e = (Error, DropCounter(&drops));
+    (Error, ..) = { e };
+    assert_eq!(drops.get(), 5);
+
+    let first;
+    let e = [DropCounter(&drops), DropCounter(&drops)];
+    [first, ..] = { e };
+    assert_eq!(drops.get(), 6);
+    drop(first);
+    assert_eq!(drops.get(), 7);
+
+    let e = (Error, [DropCounter(&drops), DropCounter(&drops)]);
+    (Error, [..]) = { e };
+    assert_eq!(drops.get(), 9);
+
+    let e = Pair { first: DropCounter(&drops), _second: DropCounter(&drops) };
+    Pair { .. } = { e };
+    assert_eq!(drops.get(), 11);
+
+    let first;
+    let e = Pair { first: DropCounter(&drops), _second: DropCounter(&drops) };
+    Pair { first, .. } = { e };
+    assert_eq!(drops.get(), 12);
+    drop(first);
+    assert_eq!(drops.get(), 13);
+}


### PR DESCRIPTION
Fixes rust-lang/rust#116536.

The `unused_braces` lint could suggest removing braces from wildcard assignments like:

```rust
_ = { e };
```

producing:

```rust
_ = e;
```

These are not equivalent: `_ = { e };` moves/drops `e`, while `_ = e;` does not. This PR suppresses `unused_braces` for assignment RHS blocks when the assignment LHS contains `_`.

ui regression test covers both the simple wildcard assignment case and a tuple destructuring assignment case