### PR TITLE
remove AliasTy::def_id()

### DIFF
--- a/compiler/rustc_hir_analysis/src/check/compare_impl_item/refine.rs
+++ b/compiler/rustc_hir_analysis/src/check/compare_impl_item/refine.rs
@@ -83,15 +83,15 @@ pub(crate) fn check_refining_return_position_impl_trait_in_trait<'tcx>(
 
     for trait_projection in collector.types.into_iter().rev() {
         let impl_opaque_args = trait_projection.args.rebase_onto(tcx, trait_m.def_id, impl_m_args);
-        let hidden_ty = hidden_tys[&trait_projection.kind.def_id()]
-            .instantiate(tcx, impl_opaque_args)
-            .skip_norm_wip();
+        let hidden_ty =
+            hidden_tys[&trait_projection.kind].instantiate(tcx, impl_opaque_args).skip_norm_wip();
 
         // If the hidden type is not an opaque, then we have "refined" the trait signature.
-        let ty::Alias(
-            impl_opaque @ ty::AliasTy { kind: ty::Opaque { def_id: impl_opaque_def_id }, .. },
-        ) = *hidden_ty.kind()
-        else {
+        let impl_opaque = if let ty::Alias(alias) = *hidden_ty.kind()
+            && let Some(impl_opaque) = alias.try_to_opaque()
+        {
+            impl_opaque
+        } else {
             report_mismatched_rpitit_signature(
                 tcx,
                 trait_m_sig_with_self_for_diag,
@@ -105,7 +105,7 @@ pub(crate) fn check_refining_return_position_impl_trait_in_trait<'tcx>(
 
         // This opaque also needs to be from the impl method -- otherwise,
         // it's a refinement to a TAIT.
-        if !tcx.hir_get_if_local(impl_opaque_def_id).is_some_and(|node| {
+        if !tcx.hir_get_if_local(impl_opaque.kind).is_some_and(|node| {
             matches!(
                 node.expect_opaque_ty().origin,
                 hir::OpaqueTyOrigin::AsyncFn { parent, .. }  | hir::OpaqueTyOrigin::FnReturn { parent, .. }
@@ -124,13 +124,13 @@ pub(crate) fn check_refining_return_position_impl_trait_in_trait<'tcx>(
         }
 
         trait_bounds.extend(
-            tcx.item_bounds(trait_projection.kind.def_id())
+            tcx.item_bounds(trait_projection.kind)
                 .iter_instantiated(tcx, trait_projection.args)
                 .map(Unnormalized::skip_norm_wip),
         );
         impl_bounds.extend(elaborate(
             tcx,
-            tcx.explicit_item_bounds(impl_opaque_def_id)
+            tcx.explicit_item_bounds(impl_opaque.kind)
                 .iter_instantiated_copied(tcx, impl_opaque.args)
                 .map(Unnormalized::skip_norm_wip),
         ));
@@ -231,7 +231,7 @@ pub(crate) fn check_refining_return_position_impl_trait_in_trait<'tcx>(
     // is literally unrepresentable in the type system; however, we may be
     // promising stronger outlives guarantees if we capture *fewer* regions.
     for (trait_projection, impl_opaque) in pairs {
-        let impl_variances = tcx.variances_of(impl_opaque.kind.def_id());
+        let impl_variances = tcx.variances_of(impl_opaque.kind);
         let impl_captures: FxIndexSet<_> = impl_opaque
             .args
             .iter()
@@ -240,7 +240,7 @@ pub(crate) fn check_refining_return_position_impl_trait_in_trait<'tcx>(
             .map(|(arg, _)| arg)
             .collect();
 
-        let trait_variances = tcx.variances_of(trait_projection.kind.def_id());
+        let trait_variances = tcx.variances_of(trait_projection.kind);
         let mut trait_captures = FxIndexSet::default();
         for (arg, variance) in trait_projection.args.iter().zip_eq(trait_variances) {
             if *variance != ty::Invariant {
@@ -252,7 +252,7 @@ pub(crate) fn check_refining_return_position_impl_trait_in_trait<'tcx>(
         if !trait_captures.iter().all(|arg| impl_captures.contains(arg)) {
             report_mismatched_rpitit_captures(
                 tcx,
-                impl_opaque.kind.def_id().expect_local(),
+                impl_opaque.kind.expect_local(),
                 trait_captures,
                 is_internal,
             );
@@ -262,18 +262,19 @@ pub(crate) fn check_refining_return_position_impl_trait_in_trait<'tcx>(
 
 struct ImplTraitInTraitCollector<'tcx> {
     tcx: TyCtxt<'tcx>,
-    types: FxIndexSet<ty::AliasTy<'tcx>>,
+    types: FxIndexSet<ty::ProjectionAliasTy<'tcx>>,
 }
 
 impl<'tcx> TypeVisitor<TyCtxt<'tcx>> for ImplTraitInTraitCollector<'tcx> {
     fn visit_ty(&mut self, ty: Ty<'tcx>) {
-        if let ty::Alias(proj @ ty::AliasTy { kind: ty::Projection { def_id }, .. }) = *ty.kind()
-            && self.tcx.is_impl_trait_in_trait(def_id)
+        if let ty::Alias(alias) = *ty.kind()
+            && let Some(proj) = alias.try_to_projection()
+            && self.tcx.is_impl_trait_in_trait(proj.kind)
         {
             if self.types.insert(proj) {
                 for (pred, _) in self
                     .tcx
-                    .explicit_item_bounds(def_id)
+                    .explicit_item_bounds(proj.kind)
                     .iter_instantiated_copied(self.tcx, proj.args)
                     .map(Unnormalized::skip_norm_wip)
                 {

--- a/compiler/rustc_hir_analysis/src/check/mod.rs
+++ b/compiler/rustc_hir_analysis/src/check/mod.rs
@@ -89,7 +89,6 @@ use rustc_middle::ty::error::{ExpectedFound, TypeError};
 use rustc_middle::ty::print::with_types_for_signature;
 use rustc_middle::ty::{
     self, GenericArgs, GenericArgsRef, OutlivesPredicate, Region, Ty, TyCtxt, TypingMode,
-    Unnormalized,
 };
 use rustc_middle::{bug, span_bug};
 use rustc_session::errors::feature_err;
@@ -487,21 +486,12 @@ fn fn_sig_suggestion<'tcx>(
     let mut output = sig.output();
 
     let asyncness = if tcx.asyncness(assoc.def_id).is_async() {
-        output = if let ty::Alias(alias_ty) = *output.kind()
-            && let Some(output) = tcx
-                .explicit_item_self_bounds(alias_ty.kind.def_id())
-                .iter_instantiated_copied(tcx, alias_ty.args)
-                .map(Unnormalized::skip_norm_wip)
-                .find_map(|(bound, _)| {
-                    bound.as_projection_clause()?.no_bound_vars()?.term.as_type()
-                }) {
-            output
-        } else {
+        output = tcx.get_impl_future_output_ty(output).unwrap_or_else(|| {
             span_bug!(
                 ident.span,
                 "expected async fn to have `impl Future` output, but it returns {output}"
             )
-        };
+        });
         "async "
     } else {
         ""

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
@@ -1359,7 +1359,11 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
         )? {
             TypeRelativePath::AssocItem(alias_term) => {
                 let alias_ty = alias_term.expect_ty();
-                let def_id = alias_ty.kind.def_id();
+                let def_id = match alias_ty.kind {
+                    ty::AliasTyKind::Projection { def_id } => def_id,
+                    ty::AliasTyKind::Inherent { def_id } => def_id,
+                    kind => bug!("expected projection or inherent alias, got {kind:?}"),
+                };
                 let ty = alias_ty.to_ty(tcx);
                 let ty = self.check_param_uses_if_mcg(ty, span, false);
                 Ok((ty, tcx.def_kind(def_id), def_id))

--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -2910,7 +2910,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         base: &'tcx hir::Expr<'tcx>,
         ty: Ty<'tcx>,
     ) {
-        let Some(output_ty) = self.err_ctxt().get_impl_future_output_ty(ty) else {
+        let Some(output_ty) = self.tcx.get_impl_future_output_ty(ty) else {
             err.span_label(field_ident.span, "unknown field");
             return;
         };

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
@@ -1351,7 +1351,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     .instantiate_bound_regions_with_erased(Binder::bind_with_vars(ty, bound_vars));
                 let ty = match self.tcx.asyncness(fn_id) {
                     ty::Asyncness::Yes => {
-                        self.err_ctxt().get_impl_future_output_ty(ty).unwrap_or_else(|| {
+                        self.tcx.get_impl_future_output_ty(ty).unwrap_or_else(|| {
                             span_bug!(
                                 fn_decl.output.span(),
                                 "failed to get output type of async function"

--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -3878,7 +3878,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         span: Span,
         return_type: Option<Ty<'tcx>>,
     ) {
-        let Some(output_ty) = self.err_ctxt().get_impl_future_output_ty(ty) else { return };
+        let Some(output_ty) = self.tcx.get_impl_future_output_ty(ty) else { return };
         let output_ty = self.resolve_vars_if_possible(output_ty);
         let method_exists =
             self.method_exists_for_diagnostic(item_name, output_ty, call.hir_id, return_type);

--- a/compiler/rustc_infer/src/infer/context.rs
+++ b/compiler/rustc_infer/src/infer/context.rs
@@ -380,7 +380,7 @@ impl<'tcx> rustc_type_ir::InferCtxtLike for InferCtxt<'tcx> {
             .map(|(k, h)| (k, h.ty))
             .collect()
     }
-    fn opaques_with_sub_unified_hidden_type(&self, ty: ty::TyVid) -> Vec<ty::AliasTy<'tcx>> {
+    fn opaques_with_sub_unified_hidden_type(&self, ty: ty::TyVid) -> Vec<ty::OpaqueAliasTy<'tcx>> {
         self.opaques_with_sub_unified_hidden_type(ty)
     }
 

--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -1111,7 +1111,10 @@ impl<'tcx> InferCtxt<'tcx> {
     /// Searches for an opaque type key whose hidden type is related to `ty_vid`.
     ///
     /// This only checks for a subtype relation, it does not require equality.
-    pub fn opaques_with_sub_unified_hidden_type(&self, ty_vid: TyVid) -> Vec<ty::AliasTy<'tcx>> {
+    pub fn opaques_with_sub_unified_hidden_type(
+        &self,
+        ty_vid: TyVid,
+    ) -> Vec<ty::OpaqueAliasTy<'tcx>> {
         // Avoid accidentally allowing more code to compile with the old solver.
         if !self.next_trait_solver() {
             return vec![];
@@ -1129,9 +1132,9 @@ impl<'tcx> InferCtxt<'tcx> {
                 if let ty::Infer(ty::TyVar(hidden_vid)) = *hidden_ty.ty.kind() {
                     let opaque_sub_vid = type_variables.sub_unification_table_root_var(hidden_vid);
                     if opaque_sub_vid == ty_sub_vid {
-                        return Some(ty::AliasTy::new_from_args(
+                        return Some(ty::OpaqueAliasTy::new_opaque_from_args(
                             self.tcx,
-                            ty::Opaque { def_id: key.def_id.into() },
+                            key.def_id.into(),
                             key.args,
                         ));
                     }

--- a/compiler/rustc_infer/src/infer/outlives/for_liveness.rs
+++ b/compiler/rustc_infer/src/infer/outlives/for_liveness.rs
@@ -59,8 +59,14 @@ where
             ty::Alias(ty::AliasTy { kind, args, .. }) => {
                 let tcx = self.tcx;
                 let param_env = self.param_env;
+                let def_id = match kind {
+                    ty::AliasTyKind::Projection { def_id }
+                    | ty::AliasTyKind::Inherent { def_id }
+                    | ty::AliasTyKind::Opaque { def_id }
+                    | ty::AliasTyKind::Free { def_id } => def_id,
+                };
                 let outlives_bounds: Vec<_> = tcx
-                    .item_bounds(kind.def_id())
+                    .item_bounds(def_id)
                     .iter_instantiated(tcx, args)
                     .map(Unnormalized::skip_norm_wip)
                     .chain(param_env.caller_bounds())

--- a/compiler/rustc_infer/src/infer/outlives/verify.rs
+++ b/compiler/rustc_infer/src/infer/outlives/verify.rs
@@ -236,8 +236,7 @@ impl<'cx, 'tcx> VerifyBoundCx<'cx, 'tcx> {
                 // And therefore we can safely use structural equality for alias types.
                 (GenericKind::Param(p1), ty::Param(p2)) if p1 == p2 => {}
                 (GenericKind::Placeholder(p1), ty::Placeholder(p2)) if p1 == p2 => {}
-                (GenericKind::Alias(a1), ty::Alias(a2)) if a1.kind.def_id() == a2.kind.def_id() => {
-                }
+                (GenericKind::Alias(a1), ty::Alias(a2)) if a1.kind == a2.kind => {}
                 _ => return None,
             }
 

--- a/compiler/rustc_middle/src/query/keys.rs
+++ b/compiler/rustc_middle/src/query/keys.rs
@@ -385,7 +385,12 @@ fn def_id_of_type_cached<'a>(ty: Ty<'a>, visited: &mut SsoHashSet<Ty<'a>>) -> Op
         | ty::CoroutineWitness(def_id, _)
         | ty::Foreign(def_id) => Some(def_id),
 
-        ty::Alias(alias) => Some(alias.kind.def_id()),
+        ty::Alias(alias) => match alias.kind {
+            ty::AliasTyKind::Projection { def_id }
+            | ty::AliasTyKind::Inherent { def_id }
+            | ty::AliasTyKind::Opaque { def_id }
+            | ty::AliasTyKind::Free { def_id } => Some(def_id),
+        },
 
         ty::Bool
         | ty::Char

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -2704,6 +2704,39 @@ impl<'tcx> TyCtxt<'tcx> {
         self.opt_rpitit_info(def_id).is_some()
     }
 
+    pub fn get_impl_future_output_ty(self, ty: Ty<'tcx>) -> Option<Ty<'tcx>> {
+        let (def_id, args) = match *ty.kind() {
+            ty::Alias(ty::AliasTy { kind: ty::Opaque { def_id }, args, .. }) => (def_id, args),
+            ty::Alias(ty::AliasTy { kind: ty::Projection { def_id }, args, .. })
+                if self.is_impl_trait_in_trait(def_id) =>
+            {
+                (def_id, args)
+            }
+            _ => return None,
+        };
+
+        let future_trait = self.require_lang_item(LangItem::Future, DUMMY_SP);
+        let item_def_id = self.associated_item_def_ids(future_trait)[0];
+
+        self.explicit_item_self_bounds(def_id)
+            .iter_instantiated_copied(self, args)
+            .map(ty::Unnormalized::skip_norm_wip)
+            .find_map(|(predicate, _)| {
+                predicate
+                    .kind()
+                    .map_bound(|kind| match kind {
+                        ty::ClauseKind::Projection(projection_predicate)
+                            if projection_predicate.def_id() == item_def_id =>
+                        {
+                            projection_predicate.term.as_type()
+                        }
+                        _ => None,
+                    })
+                    .no_bound_vars()
+                    .flatten()
+            })
+    }
+
     /// Named module children from all kinds of items, including imports.
     /// In addition to regular items this list also includes struct and variant constructors, and
     /// items inside `extern {}` blocks because all of them introduce names into parent module.

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -104,11 +104,12 @@ pub use self::region::{
     EarlyParamRegion, LateParamRegion, LateParamRegionKind, Region, RegionKind, RegionVid,
 };
 pub use self::sty::{
-    AliasTy, AliasTyKind, Article, Binder, BoundConst, BoundRegion, BoundRegionKind, BoundTy,
-    BoundTyKind, BoundVariableKind, CanonicalPolyFnSig, CoroutineArgsExt, EarlyBinder, FnSig,
-    FnSigKind, InlineConstArgs, InlineConstArgsParts, ParamConst, ParamTy, PlaceholderConst,
-    PlaceholderRegion, PlaceholderType, PolyFnSig, TyKind, TypeAndMut, TypingMode,
-    TypingModeEqWrapper, Unnormalized, UpvarArgs,
+    Alias, AliasTy, AliasTyKind, Article, Binder, BoundConst, BoundRegion, BoundRegionKind,
+    BoundTy, BoundTyKind, BoundVariableKind, CanonicalPolyFnSig, CoroutineArgsExt, EarlyBinder,
+    FnSig, FnSigKind, FreeAliasTy, InherentAliasTy, InlineConstArgs, InlineConstArgsParts,
+    OpaqueAliasTy, ParamConst, ParamTy, PlaceholderConst, PlaceholderRegion, PlaceholderType,
+    PolyFnSig, ProjectionAliasTy, TyKind, TypeAndMut, TypingMode, TypingModeEqWrapper,
+    Unnormalized, UpvarArgs,
 };
 pub use self::trait_def::TraitDef;
 pub use self::typeck_results::{

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -1369,10 +1369,14 @@ pub trait PrettyPrinter<'tcx>: Printer<'tcx> + fmt::Write {
                 self.tcx().opt_rpitit_info(def_id)
             && let ty::Alias(alias_ty) =
                 self.tcx().fn_sig(fn_def_id).skip_binder().output().skip_binder().kind()
-            && alias_ty.kind.def_id() == def_id
+            && let Some(projection_ty) = alias_ty.try_to_projection()
+            && projection_ty.kind == def_id
             && let generics = self.tcx().generics_of(fn_def_id)
             // FIXME(return_type_notation): We only support lifetime params for now.
-            && generics.own_params.iter().all(|param| matches!(param.kind, ty::GenericParamDefKind::Lifetime))
+            && generics
+                .own_params
+                .iter()
+                .all(|param| matches!(param.kind, ty::GenericParamDefKind::Lifetime))
         {
             let num_args = generics.count();
             Some((fn_def_id, &args[..num_args]))

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -38,6 +38,11 @@ pub type TyKind<'tcx> = ir::TyKind<TyCtxt<'tcx>>;
 pub type TypeAndMut<'tcx> = ir::TypeAndMut<TyCtxt<'tcx>>;
 pub type AliasTy<'tcx> = ir::AliasTy<TyCtxt<'tcx>>;
 pub type AliasTyKind<'tcx> = ir::AliasTyKind<TyCtxt<'tcx>>;
+pub type Alias<'tcx, K> = ir::Alias<TyCtxt<'tcx>, K>;
+pub type ProjectionAliasTy<'tcx> = ir::ProjectionAliasTy<TyCtxt<'tcx>>;
+pub type InherentAliasTy<'tcx> = ir::InherentAliasTy<TyCtxt<'tcx>>;
+pub type OpaqueAliasTy<'tcx> = ir::OpaqueAliasTy<TyCtxt<'tcx>>;
+pub type FreeAliasTy<'tcx> = ir::FreeAliasTy<TyCtxt<'tcx>>;
 pub type FnSig<'tcx> = ir::FnSig<TyCtxt<'tcx>>;
 pub type FnSigKind<'tcx> = ir::FnSigKind<TyCtxt<'tcx>>;
 pub type Binder<'tcx, T> = ir::Binder<TyCtxt<'tcx>, T>;
@@ -477,12 +482,22 @@ impl<'tcx> Ty<'tcx> {
 
     #[inline]
     pub fn new_alias(tcx: TyCtxt<'tcx>, alias_ty: ty::AliasTy<'tcx>) -> Ty<'tcx> {
-        debug_assert_matches!(
-            (alias_ty.kind, tcx.def_kind(alias_ty.kind.def_id())),
-            (ty::Opaque { .. }, DefKind::OpaqueTy)
-                | (ty::Projection { .. } | ty::Inherent { .. }, DefKind::AssocTy)
-                | (ty::Free { .. }, DefKind::TyAlias)
-        );
+        if cfg!(debug_assertions) {
+            match alias_ty.kind {
+                ty::AliasTyKind::Projection { def_id } => {
+                    debug_assert_matches!(tcx.def_kind(def_id), DefKind::AssocTy)
+                }
+                ty::AliasTyKind::Inherent { def_id } => {
+                    debug_assert_matches!(tcx.def_kind(def_id), DefKind::AssocTy)
+                }
+                ty::AliasTyKind::Opaque { def_id } => {
+                    debug_assert_matches!(tcx.def_kind(def_id), DefKind::OpaqueTy)
+                }
+                ty::AliasTyKind::Free { def_id } => {
+                    debug_assert_matches!(tcx.def_kind(def_id), DefKind::TyAlias)
+                }
+            }
+        }
         Ty::new(tcx, Alias(alias_ty))
     }
 

--- a/compiler/rustc_next_trait_solver/src/solve/assembly/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/assembly/mod.rs
@@ -741,7 +741,7 @@ where
         candidates: &mut Vec<Candidate<I>>,
         consider_self_bounds: AliasBoundKind,
     ) -> Result<(), RerunNonErased> {
-        let alias_ty = match self_ty.kind() {
+        let (alias_ty, def_id) = match self_ty.kind() {
             ty::Bool
             | ty::Char
             | ty::Int(_)
@@ -789,9 +789,12 @@ where
                 return Ok(());
             }
 
-            ty::Alias(
-                alias_ty @ AliasTy { kind: ty::Projection { .. } | ty::Opaque { .. }, .. },
-            ) => alias_ty,
+            ty::Alias(alias_ty @ AliasTy { kind: ty::Projection { def_id }, .. }) => {
+                (alias_ty, def_id.into())
+            }
+            ty::Alias(alias_ty @ AliasTy { kind: ty::Opaque { def_id }, .. }) => {
+                (alias_ty, def_id.into())
+            }
             ty::Alias(AliasTy { kind: ty::Inherent { .. } | ty::Free { .. }, .. }) => {
                 self.cx().delay_bug(format!("could not normalize {self_ty:?}, it is not WF"));
                 return Ok(());
@@ -802,7 +805,7 @@ where
             AliasBoundKind::SelfBounds => {
                 for assumption in self
                     .cx()
-                    .item_self_bounds(alias_ty.kind.def_id())
+                    .item_self_bounds(def_id)
                     .iter_instantiated(self.cx(), alias_ty.args)
                     .map(Unnormalized::skip_norm_wip)
                 {
@@ -818,7 +821,7 @@ where
             AliasBoundKind::NonSelfBounds => {
                 for assumption in self
                     .cx()
-                    .item_non_self_bounds(alias_ty.kind.def_id())
+                    .item_non_self_bounds(def_id)
                     .iter_instantiated(self.cx(), alias_ty.args)
                     .map(Unnormalized::skip_norm_wip)
                 {
@@ -835,12 +838,12 @@ where
 
         candidates.extend(G::consider_additional_alias_assumptions(self, goal, alias_ty));
 
-        if !matches!(alias_ty.kind, ty::Projection { .. }) {
+        let Some(projection_ty) = alias_ty.try_to_projection() else {
             return Ok(());
-        }
+        };
 
         // Recurse on the self type of the projection.
-        match self.structurally_normalize_ty(goal.param_env, alias_ty.self_ty()) {
+        match self.structurally_normalize_ty(goal.param_env, projection_ty.projection_self_ty()) {
             Ok(next_self_ty) => self.assemble_alias_bound_candidates_recur(
                 next_self_ty,
                 goal,
@@ -1072,12 +1075,12 @@ where
             return Ok(());
         }
 
-        for &alias_ty in &opaque_types {
-            debug!("self ty is sub unified with {alias_ty:?}");
+        for &opaque_ty in &opaque_types {
+            debug!("self ty is sub unified with {opaque_ty:?}");
 
             struct ReplaceOpaque<I: Interner> {
                 cx: I,
-                alias_ty: ty::AliasTy<I>,
+                opaque_ty: ty::OpaqueAliasTy<I>,
                 self_ty: I::Ty,
             }
             impl<I: Interner> TypeFolder<I> for ReplaceOpaque<I> {
@@ -1085,8 +1088,10 @@ where
                     self.cx
                 }
                 fn fold_ty(&mut self, ty: I::Ty) -> I::Ty {
-                    if let ty::Alias(alias_ty) = ty.kind() {
-                        if alias_ty == self.alias_ty {
+                    if let ty::Alias(alias_ty) = ty.kind()
+                        && let Some(opaque_ty) = alias_ty.try_to_opaque()
+                    {
+                        if opaque_ty == self.opaque_ty {
                             return self.self_ty;
                         }
                     }
@@ -1103,12 +1108,12 @@ where
             // in a `?x: Trait<u32>` alias-bound candidate.
             for item_bound in self
                 .cx()
-                .item_self_bounds(alias_ty.kind.def_id())
-                .iter_instantiated(self.cx(), alias_ty.args)
+                .item_self_bounds(opaque_ty.kind.into())
+                .iter_instantiated(self.cx(), opaque_ty.args)
                 .map(Unnormalized::skip_norm_wip)
             {
                 let assumption =
-                    item_bound.fold_with(&mut ReplaceOpaque { cx: self.cx(), alias_ty, self_ty });
+                    item_bound.fold_with(&mut ReplaceOpaque { cx: self.cx(), opaque_ty, self_ty });
                 candidates.extend(G::probe_and_match_goal_against_assumption(
                     self,
                     CandidateSource::AliasBound(AliasBoundKind::SelfBounds),

--- a/compiler/rustc_next_trait_solver/src/solve/effect_goals.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/effect_goals.rs
@@ -86,17 +86,24 @@ where
         let cx = ecx.cx();
         let mut candidates = vec![];
 
-        if !ecx.cx().alias_has_const_conditions(alias_ty.kind.def_id()) {
+        let def_id = match alias_ty.kind {
+            ty::AliasTyKind::Projection { def_id } => def_id.into(),
+            ty::AliasTyKind::Inherent { def_id } => def_id.into(),
+            ty::AliasTyKind::Opaque { def_id } => def_id.into(),
+            ty::AliasTyKind::Free { def_id } => def_id.into(),
+        };
+
+        if !ecx.cx().alias_has_const_conditions(def_id) {
             return vec![];
         }
 
         for clause in elaborate::elaborate(
             cx,
-            cx.explicit_implied_const_bounds(alias_ty.kind.def_id())
-                .iter_instantiated(cx, alias_ty.args)
-                .map(|trait_ref| {
+            cx.explicit_implied_const_bounds(def_id).iter_instantiated(cx, alias_ty.args).map(
+                |trait_ref| {
                     trait_ref.to_host_effect_clause(cx, goal.predicate.constness).skip_norm_wip()
-                }),
+                },
+            ),
         ) {
             candidates.extend(Self::probe_and_match_goal_against_assumption(
                 ecx,
@@ -107,16 +114,16 @@ where
                     // Const conditions must hold for the implied const bound to hold.
                     ecx.add_goals(
                         GoalSource::AliasBoundConstCondition,
-                        cx.const_conditions(alias_ty.kind.def_id())
-                            .iter_instantiated(cx, alias_ty.args)
-                            .map(|trait_ref| {
+                        cx.const_conditions(def_id).iter_instantiated(cx, alias_ty.args).map(
+                            |trait_ref| {
                                 goal.with(
                                     cx,
                                     trait_ref
                                         .to_host_effect_clause(cx, goal.predicate.constness)
                                         .skip_norm_wip(),
                                 )
-                            }),
+                            },
+                        ),
                     );
                     ecx.evaluate_added_goals_and_make_canonical_response(Certainty::Yes)
                 },

--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
@@ -1578,7 +1578,7 @@ where
     pub(crate) fn opaques_with_sub_unified_hidden_type(
         &self,
         self_ty: I::Ty,
-    ) -> Vec<ty::AliasTy<I>> {
+    ) -> Vec<ty::OpaqueAliasTy<I>> {
         if let ty::Infer(ty::TyVar(vid)) = self_ty.kind() {
             self.delegate.opaques_with_sub_unified_hidden_type(vid)
         } else {

--- a/compiler/rustc_public/src/unstable/convert/stable/ty.rs
+++ b/compiler/rustc_public/src/unstable/convert/stable/ty.rs
@@ -32,10 +32,14 @@ impl<'tcx> Stable<'tcx> for ty::AliasTy<'tcx> {
         cx: &CompilerCtxt<'cx, BridgeTys>,
     ) -> Self::T {
         let ty::AliasTy { args, kind, .. } = self;
-        crate::ty::AliasTy {
-            def_id: tables.alias_def(kind.def_id()),
-            args: args.stable(tables, cx),
-        }
+        // rustc_public must change its API once we introduce a variant without a def_id.
+        let def_id = match *kind {
+            ty::AliasTyKind::Projection { def_id }
+            | ty::AliasTyKind::Inherent { def_id }
+            | ty::AliasTyKind::Opaque { def_id }
+            | ty::AliasTyKind::Free { def_id } => def_id,
+        };
+        crate::ty::AliasTy { def_id: tables.alias_def(def_id), args: args.stable(tables, cx) }
     }
 }
 

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/mod.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/mod.rs
@@ -56,7 +56,6 @@ use rustc_errors::{Applicability, Diag, DiagStyledString, IntoDiagArg, StringPar
 use rustc_hir::attrs::diagnostic::{CustomDiagnostic, Directive, FormatArgs};
 use rustc_hir::def_id::{CRATE_DEF_ID, DefId};
 use rustc_hir::intravisit::Visitor;
-use rustc_hir::lang_items::LangItem;
 use rustc_hir::{self as hir, find_attr};
 use rustc_infer::infer::DefineOpaqueTypes;
 use rustc_macros::extension;
@@ -205,40 +204,6 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             param_env,
             err,
         )
-    }
-
-    pub fn get_impl_future_output_ty(&self, ty: Ty<'tcx>) -> Option<Ty<'tcx>> {
-        let (def_id, args) = match *ty.kind() {
-            ty::Alias(ty::AliasTy { kind: ty::Opaque { def_id }, args, .. }) => (def_id, args),
-            ty::Alias(ty::AliasTy { kind, args, .. })
-                if self.tcx.is_impl_trait_in_trait(kind.def_id()) =>
-            {
-                (kind.def_id(), args)
-            }
-            _ => return None,
-        };
-
-        let future_trait = self.tcx.require_lang_item(LangItem::Future, DUMMY_SP);
-        let item_def_id = self.tcx.associated_item_def_ids(future_trait)[0];
-
-        self.tcx
-            .explicit_item_self_bounds(def_id)
-            .iter_instantiated_copied(self.tcx, args)
-            .map(Unnormalized::skip_norm_wip)
-            .find_map(|(predicate, _)| {
-                predicate
-                    .kind()
-                    .map_bound(|kind| match kind {
-                        ty::ClauseKind::Projection(projection_predicate)
-                            if projection_predicate.def_id() == item_def_id =>
-                        {
-                            projection_predicate.term.as_type()
-                        }
-                        _ => None,
-                    })
-                    .no_bound_vars()
-                    .flatten()
-            })
     }
 
     /// Adds a note if the types come from similarly named crates

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/nice_region_error/util.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/nice_region_error/util.rs
@@ -126,12 +126,13 @@ impl<'a, 'tcx> NiceRegionError<'a, 'tcx> {
         region_def_id: DefId,
         hir_sig: &hir::FnSig<'_>,
     ) -> Option<Span> {
-        let fn_ty = self.tcx().type_of(scope_def_id).instantiate_identity().skip_norm_wip();
+        let tcx = self.tcx();
+        let fn_ty = tcx.type_of(scope_def_id).instantiate_identity().skip_norm_wip();
         if let ty::FnDef(_, _) = fn_ty.kind() {
-            let ret_ty = fn_ty.fn_sig(self.tcx()).output();
+            let ret_ty = fn_ty.fn_sig(tcx).output();
             let span = hir_sig.decl.output.span();
             let future_output = if hir_sig.header.is_async() {
-                ret_ty.map_bound(|ty| self.cx.get_impl_future_output_ty(ty)).transpose()
+                ret_ty.map_bound(|ty| tcx.get_impl_future_output_ty(ty)).transpose()
             } else {
                 None
             };

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/note_and_explain.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/note_and_explain.rs
@@ -627,19 +627,19 @@ impl<T> Trait<T> for X {
         diag: &mut Diag<'_>,
         msg: impl Fn() -> String,
         body_owner_def_id: Option<DefId>,
-        proj_ty: ty::AliasTy<'tcx>,
+        alias_ty: ty::AliasTy<'tcx>,
         ty: Ty<'tcx>,
     ) -> bool {
         let tcx = self.tcx;
         // FIXME(inherent_associated_types): Extend this to support `ty::Inherent`, too.
-        if !matches!(proj_ty.kind, ty::AliasTyKind::Projection { .. }) {
+        let Some(proj_ty) = alias_ty.try_to_projection() else {
             return false;
-        }
+        };
         let Some(body_owner_def_id) = body_owner_def_id else {
             return false;
         };
-        let assoc = tcx.associated_item(proj_ty.kind.def_id());
-        let (trait_ref, assoc_args) = proj_ty.trait_ref_and_own_args(tcx);
+        let assoc = tcx.associated_item(proj_ty.kind);
+        let (trait_ref, assoc_args) = alias_ty.trait_ref_and_own_args(tcx);
         let Some(item) = tcx.hir_get_if_local(body_owner_def_id) else {
             return false;
         };
@@ -648,7 +648,7 @@ impl<T> Trait<T> for X {
         };
         // Get the `DefId` for the type parameter corresponding to `A` in `<A as T>::Foo`.
         // This will also work for `impl Trait`.
-        let ty::Param(param_ty) = *proj_ty.self_ty().kind() else {
+        let ty::Param(param_ty) = *alias_ty.self_ty().kind() else {
             return false;
         };
         let generics = tcx.generics_of(body_owner_def_id);
@@ -684,7 +684,7 @@ impl<T> Trait<T> for X {
             _ => return false,
         };
         let parent = tcx.hir_get_parent_item(hir_id).def_id;
-        self.suggest_constraint(diag, msg, Some(parent.into()), proj_ty, ty)
+        self.suggest_constraint(diag, msg, Some(parent.into()), alias_ty, ty)
     }
 
     /// An associated type was expected and a different type was found.
@@ -719,6 +719,10 @@ impl<T> Trait<T> for X {
             return;
         }
 
+        let (ty::Projection { def_id } | ty::Inherent { def_id }) = proj_ty.kind else {
+            panic!("expected projection or inherent alias, found {:?}", proj_ty.kind);
+        };
+
         let msg = || {
             format!(
                 "consider constraining the associated type `{}` to `{}`",
@@ -746,9 +750,9 @@ impl<T> Trait<T> for X {
             let point_at_assoc_fn = if callable_scope
                 && self.point_at_methods_that_satisfy_associated_type(
                     diag,
-                    tcx.parent(proj_ty.kind.def_id()),
+                    tcx.parent(def_id),
                     current_method_ident,
-                    proj_ty.kind.def_id(),
+                    def_id,
                     values.expected,
                 ) {
                 // If we find a suitable associated function that returns the expected type, we
@@ -821,7 +825,11 @@ fn foo(&self) -> Self::T { String::new() }
     ) -> bool {
         let tcx = self.tcx;
 
-        let assoc = tcx.associated_item(proj_ty.kind.def_id());
+        let (ty::Projection { def_id } | ty::Inherent { def_id }) = proj_ty.kind else {
+            panic!("expected projection or inherent alias, found {:?}", proj_ty.kind);
+        };
+
+        let assoc = tcx.associated_item(def_id);
         if let ty::Alias(ty::AliasTy { kind: ty::Opaque { def_id }, .. }) =
             *proj_ty.self_ty().kind()
         {

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/suggest.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/suggest.rs
@@ -190,8 +190,8 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
         }
 
         let subdiag = match (
-            self.get_impl_future_output_ty(exp_found.expected),
-            self.get_impl_future_output_ty(exp_found.found),
+            self.tcx.get_impl_future_output_ty(exp_found.expected),
+            self.tcx.get_impl_future_output_ty(exp_found.found),
         ) {
             (Some(exp), Some(found)) if self.same_type_modulo_infer(exp, found) => match cause
                 .code()

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
@@ -128,7 +128,7 @@ pub fn suggest_restriction<'tcx, G: EmissionGuarantee>(
     msg: &str,
     err: &mut Diag<'_, G>,
     fn_sig: Option<&hir::FnSig<'_>>,
-    projection: Option<ty::AliasTy<'_>>,
+    projection: Option<ty::ProjectionAliasTy<'_>>,
     trait_pred: ty::PolyTraitPredicate<'tcx>,
     // When we are dealing with a trait, `super_traits` will be `Some`:
     // Given `trait T: A + B + C {}`
@@ -140,11 +140,8 @@ pub fn suggest_restriction<'tcx, G: EmissionGuarantee>(
     if hir_generics.where_clause_span.from_expansion()
         || hir_generics.where_clause_span.desugaring_kind().is_some()
         || projection.is_some_and(|projection| {
-            (tcx.is_impl_trait_in_trait(projection.kind.def_id())
-                && !tcx.features().return_type_notation())
-                || tcx
-                    .lookup_stability(projection.kind.def_id())
-                    .is_some_and(|stab| stab.is_unstable())
+            (tcx.is_impl_trait_in_trait(projection.kind) && !tcx.features().return_type_notation())
+                || tcx.lookup_stability(projection.kind).is_some_and(|stab| stab.is_unstable())
         })
     {
         return;
@@ -152,7 +149,7 @@ pub fn suggest_restriction<'tcx, G: EmissionGuarantee>(
     let generics = tcx.generics_of(item_id);
     // Given `fn foo(t: impl Trait)` where `Trait` requires assoc type `A`...
     if let Some((param, bound_str, fn_sig)) =
-        fn_sig.zip(projection).and_then(|(sig, p)| match *p.self_ty().kind() {
+        fn_sig.zip(projection).and_then(|(sig, p)| match *p.projection_self_ty().kind() {
             // Shenanigans to get the `Trait` from the `impl Trait`.
             ty::Param(param) => {
                 let param_def = generics.type_param(param, tcx);
@@ -479,8 +476,12 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         let self_ty = trait_pred.skip_binder().self_ty();
         let (param_ty, projection) = match *self_ty.kind() {
             ty::Param(_) => (true, None),
-            ty::Alias(projection @ ty::AliasTy { kind: ty::Projection { .. }, .. }) => {
-                (false, Some(projection))
+            ty::Alias(alias) => {
+                if let Some(projection) = alias.try_to_projection() {
+                    (false, Some(projection))
+                } else {
+                    (false, None)
+                }
             }
             _ => (false, None),
         };

--- a/compiler/rustc_trait_selection/src/traits/effects.rs
+++ b/compiler/rustc_trait_selection/src/traits/effects.rs
@@ -218,7 +218,7 @@ fn evaluate_host_effect_from_conditionally_const_item_bounds<'tcx>(
                     if candidate.is_some() {
                         return Err(EvaluationFailure::Ambiguous);
                     } else {
-                        candidate = Some((data, alias_ty));
+                        candidate = Some((data, alias_ty, def_id));
                     }
                 }
             }
@@ -231,12 +231,11 @@ fn evaluate_host_effect_from_conditionally_const_item_bounds<'tcx>(
         consider_ty = alias_ty.self_ty();
     }
 
-    if let Some((data, alias_ty)) = candidate {
+    if let Some((data, alias_ty, def_id)) = candidate {
         Ok(match_candidate(selcx, obligation, data, true, |selcx, nested| {
             // An alias bound only holds if we also check the const conditions
             // of the alias, so we need to register those, too.
-            let const_conditions =
-                tcx.const_conditions(alias_ty.kind.def_id()).instantiate(tcx, alias_ty.args);
+            let const_conditions = tcx.const_conditions(def_id).instantiate(tcx, alias_ty.args);
             let const_conditions: Vec<_> = const_conditions
                 .into_iter()
                 .map(|(trait_ref, span)| {

--- a/compiler/rustc_ty_utils/src/ty.rs
+++ b/compiler/rustc_ty_utils/src/ty.rs
@@ -223,18 +223,14 @@ impl<'tcx> TypeVisitor<TyCtxt<'tcx>> for ImplTraitInTraitFinder<'_, 'tcx> {
     }
 
     fn visit_ty(&mut self, ty: Ty<'tcx>) {
-        if let ty::Alias(
-            unshifted_alias_ty @ ty::AliasTy {
-                kind: ty::Projection { def_id: unshifted_alias_ty_def_id },
-                ..
-            },
-        ) = *ty.kind()
+        if let ty::Alias(unshifted_alias_ty) = *ty.kind()
+            && let Some(unshifted_alias_ty) = unshifted_alias_ty.try_to_projection()
             && let Some(
                 ty::ImplTraitInTraitData::Trait { fn_def_id, .. }
                 | ty::ImplTraitInTraitData::Impl { fn_def_id, .. },
-            ) = self.tcx.opt_rpitit_info(unshifted_alias_ty_def_id)
+            ) = self.tcx.opt_rpitit_info(unshifted_alias_ty.kind)
             && fn_def_id == self.fn_def_id
-            && self.seen.insert(unshifted_alias_ty_def_id)
+            && self.seen.insert(unshifted_alias_ty.kind)
         {
             // We have entered some binders as we've walked into the
             // bounds of the RPITIT. Shift these binders back out when
@@ -259,14 +255,14 @@ impl<'tcx> TypeVisitor<TyCtxt<'tcx>> for ImplTraitInTraitFinder<'_, 'tcx> {
             // strategy, then just reinterpret the associated type like an opaque :^)
             let default_ty = self
                 .tcx
-                .type_of(shifted_alias_ty.kind.def_id())
+                .type_of(shifted_alias_ty.kind)
                 .instantiate(self.tcx, shifted_alias_ty.args)
                 .skip_norm_wip();
 
             self.predicates.push(
                 ty::Binder::bind_with_vars(
                     ty::ProjectionPredicate {
-                        projection_term: shifted_alias_ty.into(),
+                        projection_term: shifted_alias_ty.projection_to_alias_ty().into(),
                         term: default_ty.into(),
                     },
                     self.bound_vars,
@@ -280,7 +276,7 @@ impl<'tcx> TypeVisitor<TyCtxt<'tcx>> for ImplTraitInTraitFinder<'_, 'tcx> {
             // easier to just do this.
             for bound in self
                 .tcx
-                .item_bounds(unshifted_alias_ty_def_id)
+                .item_bounds(unshifted_alias_ty.kind)
                 .iter_instantiated(self.tcx, unshifted_alias_ty.args)
                 .map(Unnormalized::skip_norm_wip)
             {

--- a/compiler/rustc_type_ir/src/infer_ctxt.rs
+++ b/compiler/rustc_type_ir/src/infer_ctxt.rs
@@ -502,7 +502,10 @@ pub trait InferCtxtLike: Sized {
         &self,
         prev_entries: Self::OpaqueTypeStorageEntries,
     ) -> Vec<(ty::OpaqueTypeKey<Self::Interner>, <Self::Interner as Interner>::Ty)>;
-    fn opaques_with_sub_unified_hidden_type(&self, ty: TyVid) -> Vec<ty::AliasTy<Self::Interner>>;
+    fn opaques_with_sub_unified_hidden_type(
+        &self,
+        ty: TyVid,
+    ) -> Vec<ty::OpaqueAliasTy<Self::Interner>>;
 
     fn register_hidden_type_in_storage(
         &self,

--- a/compiler/rustc_type_ir/src/lib.rs
+++ b/compiler/rustc_type_ir/src/lib.rs
@@ -81,7 +81,7 @@ pub use predicate_kind::*;
 pub use region_kind::*;
 pub use rustc_ast_ir::{FloatTy, IntTy, Movability, Mutability, Pinnedness, UintTy};
 use rustc_type_ir_macros::GenericTypeVisitable;
-pub use ty::{Alias, AliasTerm, AliasTy, UnevaluatedConst};
+pub use ty::{Alias, *};
 pub use ty_info::*;
 pub use ty_kind::*;
 pub use unnormalized::Unnormalized;

--- a/compiler/rustc_type_ir/src/outlives.rs
+++ b/compiler/rustc_type_ir/src/outlives.rs
@@ -264,7 +264,14 @@ pub fn declared_bounds_from_definition<I: Interner>(
     cx: I,
     alias_ty: AliasTy<I>,
 ) -> impl Iterator<Item = I::Region> {
-    let bounds = cx.item_self_bounds(alias_ty.kind.def_id());
+    let def_id = match alias_ty.kind {
+        ty::AliasTyKind::Projection { def_id } => def_id.into(),
+        ty::AliasTyKind::Inherent { def_id } => def_id.into(),
+        ty::AliasTyKind::Opaque { def_id } => def_id.into(),
+        ty::AliasTyKind::Free { def_id } => def_id.into(),
+    };
+
+    let bounds = cx.item_self_bounds(def_id);
     bounds
         .iter_instantiated(cx, alias_ty.args)
         .map(Unnormalized::skip_norm_wip)

--- a/compiler/rustc_type_ir/src/relate.rs
+++ b/compiler/rustc_type_ir/src/relate.rs
@@ -213,7 +213,7 @@ impl<I: Interner> Relate<I> for ty::AliasTy<I> {
         a: ty::AliasTy<I>,
         b: ty::AliasTy<I>,
     ) -> RelateResult<I, ty::AliasTy<I>> {
-        if a.kind.def_id() != b.kind.def_id() {
+        if a.kind != b.kind {
             Err(TypeError::ProjectionMismatched(ExpectedFound::new(a.kind.into(), b.kind.into())))
         } else {
             let cx = relation.cx();

--- a/compiler/rustc_type_ir/src/ty/alias.rs
+++ b/compiler/rustc_type_ir/src/ty/alias.rs
@@ -53,4 +53,8 @@ impl<I: Interner, K: Copy> Alias<I, K> {
 
 pub type AliasTerm<I> = Alias<I, AliasTermKind<I>>;
 pub type AliasTy<I> = Alias<I, AliasTyKind<I>>;
+pub type ProjectionAliasTy<I> = Alias<I, <I as Interner>::TraitAssocTyId>;
+pub type InherentAliasTy<I> = Alias<I, <I as Interner>::InherentAssocTyId>;
+pub type OpaqueAliasTy<I> = Alias<I, <I as Interner>::OpaqueTyId>;
+pub type FreeAliasTy<I> = Alias<I, <I as Interner>::FreeTyAliasId>;
 pub type UnevaluatedConst<I> = Alias<I, UnevaluatedConstKind<I>>;

--- a/compiler/rustc_type_ir/src/ty/mod.rs
+++ b/compiler/rustc_type_ir/src/ty/mod.rs
@@ -1,3 +1,3 @@
 mod alias;
 
-pub use alias::{Alias, AliasTerm, AliasTy, UnevaluatedConst};
+pub use alias::*;

--- a/compiler/rustc_type_ir/src/ty_kind.rs
+++ b/compiler/rustc_type_ir/src/ty_kind.rs
@@ -20,7 +20,10 @@ use crate::inherent::*;
 use crate::ty::AliasTy;
 #[cfg(feature = "nightly")]
 use crate::visit::TypeVisitable;
-use crate::{self as ty, BoundVarIndexKind, FloatTy, IntTy, Interner, UintTy};
+use crate::{
+    self as ty, BoundVarIndexKind, FloatTy, FreeAliasTy, InherentAliasTy, IntTy, Interner,
+    OpaqueAliasTy, ProjectionAliasTy, UintTy,
+};
 
 mod closure;
 
@@ -75,12 +78,31 @@ impl<I: Interner> AliasTyKind<I> {
         }
     }
 
-    pub fn def_id(self) -> I::DefId {
+    pub fn try_to_projection(self) -> Option<I::TraitAssocTyId> {
         match self {
-            AliasTyKind::Projection { def_id } => def_id.into(),
-            AliasTyKind::Inherent { def_id } => def_id.into(),
-            AliasTyKind::Opaque { def_id } => def_id.into(),
-            AliasTyKind::Free { def_id } => def_id.into(),
+            AliasTyKind::Projection { def_id } => Some(def_id),
+            _ => None,
+        }
+    }
+
+    pub fn try_to_inherent(self) -> Option<I::InherentAssocTyId> {
+        match self {
+            AliasTyKind::Inherent { def_id } => Some(def_id),
+            _ => None,
+        }
+    }
+
+    pub fn try_to_opaque(self) -> Option<I::OpaqueTyId> {
+        match self {
+            AliasTyKind::Opaque { def_id } => Some(def_id),
+            _ => None,
+        }
+    }
+
+    pub fn try_to_free(self) -> Option<I::FreeTyAliasId> {
+        match self {
+            AliasTyKind::Free { def_id } => Some(def_id),
+            _ => None,
         }
     }
 }
@@ -430,7 +452,15 @@ impl<I: Interner> fmt::Debug for TyKind<I> {
 
 impl<I: Interner> AliasTy<I> {
     pub fn new_from_args(interner: I, kind: AliasTyKind<I>, args: I::GenericArgs) -> AliasTy<I> {
-        interner.debug_assert_args_compatible(kind.def_id(), args);
+        if cfg!(debug_assertions) {
+            let def_id = match kind {
+                AliasTyKind::Projection { def_id } => def_id.into(),
+                AliasTyKind::Inherent { def_id } => def_id.into(),
+                AliasTyKind::Opaque { def_id } => def_id.into(),
+                AliasTyKind::Free { def_id } => def_id.into(),
+            };
+            interner.debug_assert_args_compatible(def_id, args);
+        }
         AliasTy { kind, args, _use_alias_new_instead: () }
     }
 
@@ -451,9 +481,67 @@ impl<I: Interner> AliasTy<I> {
     pub fn to_ty(self, interner: I) -> I::Ty {
         Ty::new_alias(interner, self)
     }
+
+    pub fn try_to_projection(self) -> Option<ProjectionAliasTy<I>> {
+        self.kind.try_to_projection().map(|kind| ty::Alias {
+            kind,
+            args: self.args,
+            _use_alias_new_instead: (),
+        })
+    }
+
+    pub fn try_to_inherent(self) -> Option<InherentAliasTy<I>> {
+        self.kind.try_to_inherent().map(|kind| ty::Alias {
+            kind,
+            args: self.args,
+            _use_alias_new_instead: (),
+        })
+    }
+
+    pub fn try_to_opaque(self) -> Option<OpaqueAliasTy<I>> {
+        self.kind.try_to_opaque().map(|kind| ty::Alias {
+            kind,
+            args: self.args,
+            _use_alias_new_instead: (),
+        })
+    }
+
+    pub fn try_to_free(self) -> Option<FreeAliasTy<I>> {
+        self.kind.try_to_free().map(|kind| ty::Alias {
+            kind,
+            args: self.args,
+            _use_alias_new_instead: (),
+        })
+    }
+}
+
+impl<I: Interner> ProjectionAliasTy<I> {
+    pub fn new_projection_from_args(
+        interner: I,
+        kind: I::TraitAssocTyId,
+        args: I::GenericArgs,
+    ) -> Self {
+        interner.debug_assert_args_compatible(kind.into(), args);
+        Self { kind, args, _use_alias_new_instead: () }
+    }
+
+    pub fn projection_to_alias_ty(self) -> AliasTy<I> {
+        AliasTy {
+            kind: AliasTyKind::Projection { def_id: self.kind },
+            args: self.args,
+            _use_alias_new_instead: (),
+        }
+    }
+
+    #[track_caller]
+    pub fn projection_self_ty(self) -> I::Ty {
+        self.args.type_at(0)
+    }
 }
 
 /// The following methods work only with (trait) associated type projections.
+// FIXME: Migrate these to the impl on ProjectionAliasTy (by making callers use `try_to_projection`
+// or similar when they guard for projections)
 impl<I: Interner> AliasTy<I> {
     #[track_caller]
     pub fn self_ty(self) -> I::Ty {
@@ -495,6 +583,55 @@ impl<I: Interner> AliasTy<I> {
     /// as well.
     pub fn trait_ref(self, interner: I) -> ty::TraitRef<I> {
         self.trait_ref_and_own_args(interner).0
+    }
+}
+
+impl<I: Interner> InherentAliasTy<I> {
+    pub fn new_inherent_from_args(
+        interner: I,
+        kind: I::InherentAssocTyId,
+        args: I::GenericArgs,
+    ) -> Self {
+        interner.debug_assert_args_compatible(kind.into(), args);
+        Self { kind, args, _use_alias_new_instead: () }
+    }
+
+    pub fn inherent_to_alias_ty(self) -> AliasTy<I> {
+        AliasTy {
+            kind: AliasTyKind::Inherent { def_id: self.kind },
+            args: self.args,
+            _use_alias_new_instead: (),
+        }
+    }
+}
+
+impl<I: Interner> OpaqueAliasTy<I> {
+    pub fn new_opaque_from_args(interner: I, kind: I::OpaqueTyId, args: I::GenericArgs) -> Self {
+        interner.debug_assert_args_compatible(kind.into(), args);
+        Self { kind, args, _use_alias_new_instead: () }
+    }
+
+    pub fn opaque_to_alias_ty(self) -> AliasTy<I> {
+        AliasTy {
+            kind: AliasTyKind::Opaque { def_id: self.kind },
+            args: self.args,
+            _use_alias_new_instead: (),
+        }
+    }
+}
+
+impl<I: Interner> FreeAliasTy<I> {
+    pub fn new_free_from_args(interner: I, kind: I::FreeTyAliasId, args: I::GenericArgs) -> Self {
+        interner.debug_assert_args_compatible(kind.into(), args);
+        Self { kind, args, _use_alias_new_instead: () }
+    }
+
+    pub fn free_to_alias_ty(self) -> AliasTy<I> {
+        AliasTy {
+            kind: AliasTyKind::Free { def_id: self.kind },
+            args: self.args,
+            _use_alias_new_instead: (),
+        }
     }
 }
 

--- a/src/tools/clippy/clippy_lints/src/functions/must_use.rs
+++ b/src/tools/clippy/clippy_lints/src/functions/must_use.rs
@@ -4,7 +4,6 @@ use rustc_errors::Applicability;
 use rustc_hir::def::Res;
 use rustc_hir::def_id::DefIdSet;
 use rustc_hir::{self as hir, Attribute, QPath, find_attr};
-use rustc_infer::infer::TyCtxtInferExt;
 use rustc_lint::{LateContext, LintContext};
 use rustc_middle::ty::{self, Ty};
 use rustc_span::{Span, sym};
@@ -16,7 +15,6 @@ use clippy_utils::ty::is_must_use_ty;
 use clippy_utils::visitors::for_each_expr_without_closures;
 use clippy_utils::{is_entrypoint_fn, return_ty, trait_ref_of_method};
 use rustc_span::Symbol;
-use rustc_trait_selection::error_reporting::InferCtxtErrorExt;
 
 use core::ops::ControlFlow;
 
@@ -166,8 +164,7 @@ fn check_needless_must_use(
     } else if reason.is_none() && is_must_use_ty(cx, return_ty(cx, item_id)) {
         // Ignore async functions unless Future::Output type is a must_use type
         if sig.header.is_async() {
-            let infcx = cx.tcx.infer_ctxt().build(cx.typing_mode());
-            if let Some(future_ty) = infcx.err_ctxt().get_impl_future_output_ty(return_ty(cx, item_id))
+            if let Some(future_ty) = cx.tcx.get_impl_future_output_ty(return_ty(cx, item_id))
                 && !is_must_use_ty(cx, future_ty)
             {
                 return;

--- a/src/tools/clippy/clippy_lints/src/functions/result.rs
+++ b/src/tools/clippy/clippy_lints/src/functions/result.rs
@@ -2,12 +2,10 @@ use clippy_utils::msrvs::{self, Msrv};
 use clippy_utils::res::MaybeDef;
 use rustc_errors::Diag;
 use rustc_hir as hir;
-use rustc_infer::infer::TyCtxtInferExt as _;
 use rustc_lint::{LateContext, LintContext};
 use rustc_middle::ty::{self, Ty};
 use rustc_span::def_id::DefIdSet;
 use rustc_span::{Span, sym};
-use rustc_trait_selection::error_reporting::InferCtxtErrorExt as _;
 
 use clippy_utils::diagnostics::{span_lint_and_help, span_lint_and_then};
 use clippy_utils::ty::{AdtVariantInfo, approx_ty_size};
@@ -32,12 +30,7 @@ fn result_err_ty<'tcx>(
 
         // for async functions, peel through `impl Future<Output = T>` to get `T`
         if cx.tcx.ty_is_opaque_future(ty)
-            && let Some(future_output_ty) = cx
-                .tcx
-                .infer_ctxt()
-                .build(cx.typing_mode())
-                .err_ctxt()
-                .get_impl_future_output_ty(ty)
+            && let Some(future_output_ty) = cx.tcx.get_impl_future_output_ty(ty)
         {
             ty = future_output_ty;
         }

--- a/src/tools/clippy/clippy_lints/src/len_without_is_empty.rs
+++ b/src/tools/clippy/clippy_lints/src/len_without_is_empty.rs
@@ -149,8 +149,11 @@ fn check_trait_items(cx: &LateContext<'_>, visited_trait: &Item<'_>, ident: Iden
 }
 
 fn extract_future_output<'tcx>(cx: &LateContext<'tcx>, ty: Ty<'tcx>) -> Option<&'tcx PathSegment<'tcx>> {
-    if let ty::Alias(alias_ty) = ty.kind()
-        && let Some(Node::OpaqueTy(opaque)) = cx.tcx.hir_get_if_local(alias_ty.kind.def_id())
+    if let ty::Alias(ty::AliasTy {
+        kind: ty::Opaque { def_id },
+        ..
+    }) = *ty.kind()
+        && let Some(Node::OpaqueTy(opaque)) = cx.tcx.hir_get_if_local(def_id)
         && let OpaqueTyOrigin::AsyncFn { .. } = opaque.origin
         && let [GenericBound::Trait(trait_ref)] = &opaque.bounds
         && let Some(segment) = trait_ref.trait_ref.path.segments.last()

--- a/src/tools/clippy/clippy_lints/src/methods/needless_collect.rs
+++ b/src/tools/clippy/clippy_lints/src/methods/needless_collect.rs
@@ -247,11 +247,7 @@ fn iterates_same_ty<'tcx>(cx: &LateContext<'tcx>, iter_ty: Ty<'tcx>, collect_ty:
         && let Some(into_iter_item_proj) = make_projection(cx.tcx, into_iter_trait, sym::Item, [collect_ty])
         && let Ok(into_iter_item_ty) = cx.tcx.try_normalize_erasing_regions(
             cx.typing_env(),
-            Unnormalized::new_wip(Ty::new_projection_from_args(
-                cx.tcx,
-                into_iter_item_proj.kind.def_id(),
-                into_iter_item_proj.args,
-            )),
+            Unnormalized::new_wip(Ty::new_alias(cx.tcx, into_iter_item_proj)),
         )
     {
         iter_item_ty == into_iter_item_ty

--- a/src/tools/clippy/clippy_lints/src/no_effect.rs
+++ b/src/tools/clippy/clippy_lints/src/no_effect.rs
@@ -9,11 +9,9 @@ use rustc_hir::{
     BinOpKind, BlockCheckMode, Expr, ExprKind, HirId, HirIdMap, ItemKind, LocalSource, Node, PatKind, Stmt, StmtKind,
     StructTailExpr, UnsafeSource, is_range_literal,
 };
-use rustc_infer::infer::TyCtxtInferExt as _;
 use rustc_lint::{LateContext, LateLintPass, LintContext};
 use rustc_session::impl_lint_pass;
 use rustc_span::Span;
-use rustc_trait_selection::error_reporting::InferCtxtErrorExt;
 use std::ops::Deref;
 
 declare_clippy_lint! {
@@ -162,12 +160,7 @@ impl NoEffect {
 
                                 // Remove `impl Future<Output = T>` to get `T`
                                 if cx.tcx.ty_is_opaque_future(ret_ty)
-                                    && let Some(true_ret_ty) = cx
-                                        .tcx
-                                        .infer_ctxt()
-                                        .build(cx.typing_mode())
-                                        .err_ctxt()
-                                        .get_impl_future_output_ty(ret_ty)
+                                    && let Some(true_ret_ty) = cx.tcx.get_impl_future_output_ty(ret_ty)
                                 {
                                     ret_ty = true_ret_ty;
                                 }

--- a/src/tools/clippy/clippy_utils/src/ty/mod.rs
+++ b/src/tools/clippy/clippy_utils/src/ty/mod.rs
@@ -20,8 +20,9 @@ use rustc_middle::ty::adjustment::{Adjust, Adjustment, DerefAdjustKind};
 use rustc_middle::ty::layout::ValidityRequirement;
 use rustc_middle::ty::{
     self, AdtDef, AliasTy, AssocItem, AssocTag, Binder, BoundRegion, BoundVarIndexKind, FnSig, GenericArg,
-    GenericArgKind, GenericArgsRef, IntTy, Region, RegionKind, TraitRef, Ty, TyCtxt, TypeSuperVisitable, TypeVisitable,
-    TypeVisitableExt, TypeVisitor, UintTy, Unnormalized, Upcast, VariantDef, VariantDiscr,
+    GenericArgKind, GenericArgsRef, IntTy, ProjectionAliasTy, Region, RegionKind, TraitRef, Ty, TyCtxt,
+    TypeSuperVisitable, TypeVisitable, TypeVisitableExt, TypeVisitor, UintTy, Unnormalized, Upcast, VariantDef,
+    VariantDiscr,
 };
 use rustc_span::symbol::Ident;
 use rustc_span::{DUMMY_SP, Span, Symbol};
@@ -669,12 +670,7 @@ pub fn ty_sig<'tcx>(cx: &LateContext<'tcx>, ty: Ty<'tcx>) -> Option<ExprFnSig<'t
                 _ => None,
             }
         },
-        ty::Alias(
-            proj @ AliasTy {
-                kind: ty::Projection { .. },
-                ..
-            },
-        ) => match cx
+        ty::Alias(alias) if let Some(proj) = alias.try_to_projection() => match cx
             .tcx
             .try_normalize_erasing_regions(cx.typing_env(), Unnormalized::new_wip(ty))
         {
@@ -728,14 +724,14 @@ fn sig_from_bounds<'tcx>(
     inputs.map(|ty| ExprFnSig::Trait(ty, output, predicates_id))
 }
 
-fn sig_for_projection<'tcx>(cx: &LateContext<'tcx>, ty: AliasTy<'tcx>) -> Option<ExprFnSig<'tcx>> {
+fn sig_for_projection<'tcx>(cx: &LateContext<'tcx>, ty: ProjectionAliasTy<'tcx>) -> Option<ExprFnSig<'tcx>> {
     let mut inputs = None;
     let mut output = None;
     let lang_items = cx.tcx.lang_items();
 
     for (pred, _) in cx
         .tcx
-        .explicit_item_bounds(ty.kind.def_id())
+        .explicit_item_bounds(ty.kind)
         .iter_instantiated_copied(cx.tcx, ty.args)
         .map(Unnormalized::skip_norm_wip)
     {
@@ -1097,10 +1093,7 @@ pub fn make_normalized_projection<'tcx>(
             );
             return None;
         }
-        match tcx.try_normalize_erasing_regions(
-            typing_env,
-            Unnormalized::new_wip(Ty::new_projection_from_args(tcx, ty.kind.def_id(), ty.args)),
-        ) {
+        match tcx.try_normalize_erasing_regions(typing_env, Unnormalized::new_wip(Ty::new_alias(tcx, ty))) {
             Ok(ty) => Some(ty),
             Err(e) => {
                 debug_assert!(false, "failed to normalize type `{ty}`: {e:#?}");
@@ -1254,10 +1247,7 @@ pub fn make_normalized_projection_with_regions<'tcx>(
         }
         let cause = ObligationCause::dummy();
         let (infcx, param_env) = tcx.infer_ctxt().build_with_typing_env(typing_env);
-        match infcx
-            .at(&cause, param_env)
-            .query_normalize(Ty::new_projection_from_args(tcx, ty.kind.def_id(), ty.args))
-        {
+        match infcx.at(&cause, param_env).query_normalize(Ty::new_alias(tcx, ty)) {
             Ok(ty) => Some(ty.value),
             Err(e) => {
                 debug_assert!(false, "failed to normalize type `{ty}`: {e:#?}");


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/158013)*
<!-- homu-ignore:end -->

this is part of https://github.com/rust-lang/rust/issues/156181

as well as part of https://github.com/rust-lang/rust/issues/152245

this immediately uses [the recently-introduced `Alias<>` type](https://github.com/rust-lang/rust/pull/156538) to narrow the kinds of aliases allowed in various places in code

fyi @lcnr

r? @BoxyUwU