### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,8 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    // Pin GitHub Actions to their commit SHA digests
-    "helpers:pinGitHubActionDigests"
+    // Pin GitHub Actions to their commit SHA digests, resolving floating tags
+    // (e.g. `v4`) to the full SemVer version (e.g. `v4.1.2`)
+    "helpers:pinGitHubActionDigestsToSemver"
   ],
   // Let Renovatebot keep an opened issue that tracks our dependencies
   "dependencyDashboard": true,

--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -173,7 +173,8 @@ macro_rules! declare_features {
             pub fn incomplete(&self, feature: Symbol) -> bool {
                 match feature {
                     $(
-                        sym::$feature => status_to_enum!($status) == FeatureStatus::Incomplete,
+                        // Match guard to avoid duplicating `cannot find $feature in module sym` error.
+                        f if f == sym::$feature => status_to_enum!($status) == FeatureStatus::Incomplete,
                     )*
                     _ if self.enabled_features.contains(&feature) => {
                         // Accepted/removed features and library features aren't in this file but
@@ -189,7 +190,8 @@ macro_rules! declare_features {
             pub fn internal(&self, feature: Symbol) -> bool {
                 match feature {
                     $(
-                        sym::$feature => status_to_enum!($status) == FeatureStatus::Internal,
+                       // Match guard to avoid duplicating `cannot find $feature in module sym` error.
+                       f if f == sym::$feature => status_to_enum!($status) == FeatureStatus::Internal,
                     )*
                     _ if self.enabled_features.contains(&feature) => {
                         // This could be accepted/removed, or a libs feature.

--- a/src/tools/tidy/src/target_specific_tests.rs
+++ b/src/tools/tidy/src/target_specific_tests.rs
@@ -13,7 +13,9 @@ const COMPILE_FLAGS_HEADER: &str = "compile-flags:";
 
 #[derive(Default, Debug)]
 struct RevisionInfo<'a> {
+    /// Target architecture specified with `--target=`
     target_arch: Option<Option<&'a str>>,
+    /// LLVM components configured with `//@ needs-llvm-components: ...`
     llvm_components: Option<Vec<&'a str>>,
 }
 
@@ -59,6 +61,22 @@ pub fn check(tests_path: &Path, tidy_ctx: TidyCtx) {
             .is_ok_and(|rest| rest.starts_with("run-make") || rest.starts_with("run-make-cargo"))
         {
             return;
+        }
+
+        // Directives without an explicit revision. These are inherited by all revisions.
+        let global = header_map.remove(&None).unwrap_or_default();
+
+        if header_map.is_empty() {
+            // `//@ revisions` is not used.
+            header_map.insert(None, global);
+        } else {
+            // Make all revisions inherit global directives.
+            for info in header_map.values_mut() {
+                info.target_arch = info.target_arch.or(global.target_arch);
+                if let Some(components) = &global.llvm_components {
+                    info.llvm_components.get_or_insert_with(Vec::new).extend(components);
+                }
+            }
         }
 
         for (rev, RevisionInfo { target_arch, llvm_components }) in &header_map {

--- a/tests/assembly-llvm/c-variadic/mips.rs
+++ b/tests/assembly-llvm/c-variadic/mips.rs
@@ -2,12 +2,10 @@
 //@ assembly-output: emit-asm
 //
 //@ revisions: MIPS MIPS64 MIPS64EL
+//@ needs-llvm-components: mips
 //@ [MIPS] compile-flags: -Copt-level=3 --target mips-unknown-linux-gnu
-//@ [MIPS] needs-llvm-components: mips
 //@ [MIPS64] compile-flags: -Copt-level=3 --target mipsisa64r6-unknown-linux-gnuabi64
-//@ [MIPS64] needs-llvm-components: mips
 //@ [MIPS64EL] compile-flags: -Copt-level=3 --target mips64el-unknown-linux-gnuabi64
-//@ [MIPS64EL] needs-llvm-components: mips
 #![feature(c_variadic, no_core, lang_items, intrinsics, rustc_attrs, asm_experimental_arch)]
 #![no_core]
 #![crate_type = "lib"]


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#157931 (Improve `declare_features!` macro error)
 - rust-lang/rust#157992 (tidy: revisions inherit global directives)
 - rust-lang/rust#158010 (renovate: Pin GitHub Action digests to SemVer)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=157931,157992,158010)
<!-- homu-ignore:end -->

