### PR TITLE
Panic on zkVM argv and env overflows

### DIFF
--- a/library/std/src/sys/args/zkvm.rs
+++ b/library/std/src/sys/args/zkvm.rs
@@ -16,11 +16,14 @@ fn get_args() -> Vec<&'static OsStr> {
         // Get the size of the argument then the data.
         let arg_len = unsafe { abi::sys_argv(ptr::null_mut(), 0, i) };
 
-        let arg_len_words = (arg_len + WORD_SIZE - 1) / WORD_SIZE;
+        let arg_len_rounded =
+            arg_len.checked_next_multiple_of(WORD_SIZE).expect("argument length overflowed");
+        assert!(arg_len_rounded <= isize::MAX as usize, "argument length is too large");
+        let arg_len_words = arg_len_rounded / WORD_SIZE;
         let words = unsafe { abi::sys_alloc_words(arg_len_words) };
 
         let arg_len2 = unsafe { abi::sys_argv(words, arg_len_words, i) };
-        debug_assert_eq!(arg_len, arg_len2);
+        assert_eq!(arg_len, arg_len2);
 
         let arg_bytes = unsafe { slice::from_raw_parts(words.cast(), arg_len) };
         args.push(unsafe { OsStr::from_encoded_bytes_unchecked(arg_bytes) });

--- a/library/std/src/sys/env/zkvm.rs
+++ b/library/std/src/sys/env/zkvm.rs
@@ -15,11 +15,14 @@ pub fn getenv(varname: &OsStr) -> Option<OsString> {
         return None;
     }
 
-    let nwords = (nbytes + WORD_SIZE - 1) / WORD_SIZE;
+    let nbytes_rounded =
+        nbytes.checked_next_multiple_of(WORD_SIZE).expect("environment variable length overflowed");
+    assert!(nbytes_rounded <= isize::MAX as usize, "environment variable length is too large");
+    let nwords = nbytes_rounded / WORD_SIZE;
     let words = unsafe { abi::sys_alloc_words(nwords) };
 
     let nbytes2 = unsafe { abi::sys_getenv(words, nwords, varname.as_ptr(), varname.len()) };
-    debug_assert_eq!(nbytes, nbytes2);
+    assert_eq!(nbytes, nbytes2);
 
     // Convert to OsString.
     //


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/158016 

I'm not sure if the trade-of is worth, waiting for other people opinions on that. My take was that because this overflow is directly impacted from the host it should be avoided at all cost since this overflow can ultimately [lead](https://github.com/kevin-valerio/rust/blob/3c7aec82934f59d0990088ec6b0c9937edc9df90/library/std/src/sys/env/zkvm.rs#L32) to `slice::from_raw_parts(ptr, len)` with the huge length