### PR TITLE
Enable `symbol_intern_string_literal` lint for rustdoc

### DIFF
--- a/compiler/rustc_lint/src/internal.rs
+++ b/compiler/rustc_lint/src/internal.rs
@@ -369,7 +369,12 @@ declare_tool_lint! {
     report_in_external_macro: true
 }
 
-declare_lint_pass!(TypeIr => [DIRECT_USE_OF_RUSTC_TYPE_IR, NON_GLOB_IMPORT_OF_TYPE_IR_INHERENT, USAGE_OF_TYPE_IR_INHERENT, USAGE_OF_TYPE_IR_TRAITS]);
+declare_lint_pass!(TypeIr => [
+    DIRECT_USE_OF_RUSTC_TYPE_IR,
+    NON_GLOB_IMPORT_OF_TYPE_IR_INHERENT,
+    USAGE_OF_TYPE_IR_INHERENT,
+    USAGE_OF_TYPE_IR_TRAITS
+]);
 
 impl<'tcx> LateLintPass<'tcx> for TypeIr {
     fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx hir::Expr<'tcx>) {
@@ -561,8 +566,6 @@ fn is_span_ctxt_call(cx: &LateContext<'_>, expr: &hir::Expr<'_>) -> bool {
 declare_tool_lint! {
     /// The `symbol_intern_string_literal` detects `Symbol::intern` being called on a string literal
     pub rustc::SYMBOL_INTERN_STRING_LITERAL,
-    // rustc_driver crates out of the compiler can't/shouldn't add preinterned symbols;
-    // bootstrap will deny this manually
     Allow,
     "Forbid uses of string literals in `Symbol::intern`, suggesting preinterning instead",
     report_in_external_macro: true

--- a/compiler/rustc_lint/src/lib.rs
+++ b/compiler/rustc_lint/src/lib.rs
@@ -665,6 +665,10 @@ fn register_builtins(store: &mut LintStore) {
 fn register_internals(store: &mut LintStore) {
     store.register_lints(&LintPassImpl::lint_vec());
     store.register_early_pass(|| Box::new(LintPassImpl));
+    store.register_lints(&ImplicitSysrootCrateImport::lint_vec());
+    store.register_early_pass(|| Box::new(ImplicitSysrootCrateImport));
+    store.register_lints(&BadUseOfFindAttr::lint_vec());
+    store.register_early_pass(|| Box::new(BadUseOfFindAttr));
     store.register_lints(&DefaultHashTypes::lint_vec());
     store.register_late_mod_pass(|_| Box::new(DefaultHashTypes));
     store.register_lints(&QueryStability::lint_vec());
@@ -681,10 +685,6 @@ fn register_internals(store: &mut LintStore) {
     store.register_late_mod_pass(|_| Box::new(SpanUseEqCtxt));
     store.register_lints(&SymbolInternStringLiteral::lint_vec());
     store.register_late_mod_pass(|_| Box::new(SymbolInternStringLiteral));
-    store.register_lints(&ImplicitSysrootCrateImport::lint_vec());
-    store.register_early_pass(|| Box::new(ImplicitSysrootCrateImport));
-    store.register_lints(&BadUseOfFindAttr::lint_vec());
-    store.register_early_pass(|| Box::new(BadUseOfFindAttr));
     store.register_lints(&RustcMustMatchExhaustively::lint_vec());
     store.register_late_pass(|_| Box::new(RustcMustMatchExhaustively));
     store.register_group(
@@ -692,21 +692,38 @@ fn register_internals(store: &mut LintStore) {
         "rustc::internal",
         None,
         vec![
+            // Early pass: LintPassImpl
+            LintId::of(LINT_PASS_IMPL_WITHOUT_MACRO),
+            // Early pass: ImplicitSysrootCrateImport
+            LintId::of(IMPLICIT_SYSROOT_CRATE_IMPORT),
+            // Early pass: BadUseOfFindAttr
+            LintId::of(BAD_USE_OF_FIND_ATTR),
+            // Late pass: DefaultHashTypes
             LintId::of(DEFAULT_HASH_TYPES),
+            // Late pass: QueryStability
             LintId::of(POTENTIAL_QUERY_INSTABILITY),
             LintId::of(UNTRACKED_QUERY_INFORMATION),
+            // Late pass: TyTyKind
             LintId::of(USAGE_OF_TY_TYKIND),
-            LintId::of(DISALLOWED_PASS_BY_REF),
-            LintId::of(LINT_PASS_IMPL_WITHOUT_MACRO),
             LintId::of(USAGE_OF_QUALIFIED_TY),
+            // Late pass: TypeIr
+            LintId::of(DIRECT_USE_OF_RUSTC_TYPE_IR),
             LintId::of(NON_GLOB_IMPORT_OF_TYPE_IR_INHERENT),
             LintId::of(USAGE_OF_TYPE_IR_INHERENT),
             LintId::of(USAGE_OF_TYPE_IR_TRAITS),
+            // Late pass: BadOptAccess
             LintId::of(BAD_OPT_ACCESS),
+            // Late pass: DisallowedPassByRef
+            LintId::of(DISALLOWED_PASS_BY_REF),
+            // Late pass: SpanUseEqCtxt
             LintId::of(SPAN_USE_EQ_CTXT),
-            LintId::of(DIRECT_USE_OF_RUSTC_TYPE_IR),
-            LintId::of(IMPLICIT_SYSROOT_CRATE_IMPORT),
-            LintId::of(BAD_USE_OF_FIND_ATTR),
+            // Late pass: SymbolInternStringLiteral
+            // Note: this one is not included in rustc::internal because rustc_driver crates
+            // outside the compiler can't/shouldn't add preinterned symbols. For rustc itself,
+            // bootstrap enables this lint manually.
+            // LintId::of(SYMBOL_INTERN_STRING_LITERAL),
+            //
+            // Late pass: RustcMustMatchExhaustively
             LintId::of(RUSTC_MUST_MATCH_EXHAUSTIVELY),
         ],
     );

--- a/compiler/rustc_lint/src/lib.rs
+++ b/compiler/rustc_lint/src/lib.rs
@@ -720,7 +720,8 @@ fn register_internals(store: &mut LintStore) {
             // Late pass: SymbolInternStringLiteral
             // Note: this one is not included in rustc::internal because rustc_driver crates
             // outside the compiler can't/shouldn't add preinterned symbols. For rustc itself,
-            // bootstrap enables this lint manually.
+            // bootstrap enables this lint manually. For rustdoc,
+            // `warn(symbol_intern_string_literal)` is used.
             // LintId::of(SYMBOL_INTERN_STRING_LITERAL),
             //
             // Late pass: RustcMustMatchExhaustively

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -878,6 +878,8 @@ symbols! {
         //   to be detected if it accidentally does get used.
         empty: "",
         empty_braces: "{}",
+        empty_brackets: "[]",
+        empty_parens: "()",
         enable,
         end,
         entry_nops,
@@ -1696,6 +1698,7 @@ symbols! {
         return_address,
         return_position_impl_trait_in_trait,
         return_type_notation,
+        right_arrow: "->",
         riscv32,
         riscv64,
         riscv_target_feature,

--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -323,7 +323,7 @@ pub(crate) fn name_from_pat(p: &hir::Pat<'_>) -> Symbol {
             warn!(
                 "tried to get argument name from PatKind::Expr, which is silly in function arguments"
             );
-            return Symbol::intern("()");
+            return sym::empty_parens;
         }
         PatKind::Slice(begin, mid, end) => {
             fn print_pat(pat: &Pat<'_>, wild: bool) -> impl Display {

--- a/src/librustdoc/html/render/search_index.rs
+++ b/src/librustdoc/html/render/search_index.rs
@@ -1787,7 +1787,7 @@ pub(crate) fn build_index(
                 RenderTypeId::Primitive(PrimitiveType::Array | PrimitiveType::Slice) => {
                     insert_into_map(
                         ItemType::Primitive,
-                        &[Symbol::intern("[]")],
+                        &[sym::empty_brackets],
                         None,
                         false,
                         serialized_index,
@@ -1798,7 +1798,7 @@ pub(crate) fn build_index(
                     // typeNameIdOfArrayOrSlice
                     insert_into_map(
                         ItemType::Primitive,
-                        &[Symbol::intern("()")],
+                        &[sym::empty_parens],
                         None,
                         false,
                         serialized_index,
@@ -1809,7 +1809,7 @@ pub(crate) fn build_index(
                 RenderTypeId::Primitive(PrimitiveType::Fn) => {
                     insert_into_map(
                         ItemType::Primitive,
-                        &[Symbol::intern("->")],
+                        &[sym::right_arrow],
                         None,
                         false,
                         serialized_index,
@@ -1823,7 +1823,7 @@ pub(crate) fn build_index(
                 {
                     insert_into_map(
                         ItemType::Primitive,
-                        &[Symbol::intern("->")],
+                        &[sym::right_arrow],
                         None,
                         false,
                         serialized_index,

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -16,6 +16,7 @@
 #![feature(variant_count)]
 #![recursion_limit = "256"]
 #![warn(rustc::internal)]
+#![warn(rustc::symbol_intern_string_literal)]
 // tidy-alphabetical-end
 
 // N.B. these need `extern crate` even in 2018 edition


### PR DESCRIPTION
Details in individual commits.

r? @Urgau
