### PR TITLE
Do not mark BPF `extern C` returns as `zeroext`

### DIFF
--- a/compiler/rustc_target/src/callconv/bpf.rs
+++ b/compiler/rustc_target/src/callconv/bpf.rs
@@ -6,8 +6,6 @@ use crate::callconv::{ArgAbi, FnAbi};
 fn classify_ret<Ty>(ret: &mut ArgAbi<'_, Ty>) {
     if ret.layout.is_aggregate() || ret.layout.size.bits() > 64 {
         ret.make_indirect();
-    } else {
-        ret.extend_integer_width_to(32);
     }
 }
 

--- a/tests/codegen-llvm/bpf-abi-extern-narrow-ret.rs
+++ b/tests/codegen-llvm/bpf-abi-extern-narrow-ret.rs
@@ -1,0 +1,50 @@
+//@ add-minicore
+//@ needs-llvm-components: bpf
+//@ compile-flags: --target bpfel-unknown-none
+
+#![feature(no_core)]
+#![crate_type = "lib"]
+#![no_core]
+
+extern crate minicore;
+use minicore::*;
+
+unsafe extern "C" {
+    fn c_ret_u8() -> u8;
+    fn c_ret_u16() -> u16;
+    fn c_ret_i8() -> i8;
+    fn c_ret_i16() -> i16;
+}
+
+// CHECK-LABEL: define {{.*}} @observe_u8(
+// CHECK: call noundef i8 @c_ret_u8()
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn observe_u8() -> u64 {
+    c_ret_u8() as u64
+}
+
+// CHECK-LABEL: define {{.*}} @observe_u16(
+// CHECK: call noundef i16 @c_ret_u16()
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn observe_u16() -> u64 {
+    c_ret_u16() as u64
+}
+
+// CHECK-LABEL: define {{.*}} @observe_i8(
+// CHECK: call noundef i8 @c_ret_i8()
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn observe_i8() -> i64 {
+    c_ret_i8() as i64
+}
+
+// CHECK-LABEL: define {{.*}} @observe_i16(
+// CHECK: call noundef i16 @c_ret_i16()
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn observe_i16() -> i64 {
+    c_ret_i16() as i64
+}
+
+// CHECK: declare noundef i8 @c_ret_u8()
+// CHECK: declare noundef i16 @c_ret_u16()
+// CHECK: declare noundef i8 @c_ret_i8()
+// CHECK: declare noundef i16 @c_ret_i16()

--- a/tests/codegen-llvm/bpf-abi-extern-narrow-ret.rs
+++ b/tests/codegen-llvm/bpf-abi-extern-narrow-ret.rs
@@ -17,34 +17,34 @@ unsafe extern "C" {
 }
 
 // CHECK-LABEL: define {{.*}} @observe_u8(
-// CHECK: call noundef i8 @c_ret_u8()
+// CHECK: call {{(noundef )?}}i8 @c_ret_u8()
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn observe_u8() -> u64 {
     c_ret_u8() as u64
 }
 
 // CHECK-LABEL: define {{.*}} @observe_u16(
-// CHECK: call noundef i16 @c_ret_u16()
+// CHECK: call {{(noundef )?}}i16 @c_ret_u16()
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn observe_u16() -> u64 {
     c_ret_u16() as u64
 }
 
 // CHECK-LABEL: define {{.*}} @observe_i8(
-// CHECK: call noundef i8 @c_ret_i8()
+// CHECK: call {{(noundef )?}}i8 @c_ret_i8()
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn observe_i8() -> i64 {
     c_ret_i8() as i64
 }
 
 // CHECK-LABEL: define {{.*}} @observe_i16(
-// CHECK: call noundef i16 @c_ret_i16()
+// CHECK: call {{(noundef )?}}i16 @c_ret_i16()
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn observe_i16() -> i64 {
     c_ret_i16() as i64
 }
 
-// CHECK: declare noundef i8 @c_ret_u8()
-// CHECK: declare noundef i16 @c_ret_u16()
-// CHECK: declare noundef i8 @c_ret_i8()
-// CHECK: declare noundef i16 @c_ret_i16()
+// CHECK: declare {{(noundef )?}}i8 @c_ret_u8()
+// CHECK: declare {{(noundef )?}}i16 @c_ret_u16()
+// CHECK: declare {{(noundef )?}}i8 @c_ret_i8()
+// CHECK: declare {{(noundef )?}}i16 @c_ret_i16()


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/158028 