### PR TITLE
c-variadic: test that we use equality up to free lifetimes

### DIFF
--- a/src/tools/miri/tests/pass/c-variadic.rs
+++ b/src/tools/miri/tests/pass/c-variadic.rs
@@ -106,6 +106,20 @@ fn various_types() {
     }
 }
 
+fn equal_up_to_free_lifetime() {
+    // Types are considered equal up to free lifetimes: `*const &'static str`
+    // is the same as `*const &'a str`.
+    // Bound lifetimes (using e.g. `for<'_>`) are different.
+    #[expect(improper_ctypes_definitions)]
+    pub unsafe extern "C" fn foo(mut args: ...) -> &'static str {
+        unsafe { *args.next_arg::<*const &'static str>() }
+    }
+
+    let data = String::from("abc");
+    let x: &str = data.as_str();
+    assert_eq!(unsafe { foo(&raw const x) }, "abc");
+}
+
 fn clone() {
     if cfg!(force_intrinsic_fallback) {
         // Skip this test when we use the fallback bodies. The fallback body does
@@ -170,6 +184,7 @@ fn main() {
     forward_by_ref();
     nested();
     various_types();
+    equal_up_to_free_lifetime();
     clone();
     clone_and_advance();
 }

--- a/tests/ui/consts/const-eval/c-variadic-fail.rs
+++ b/tests/ui/consts/const-eval/c-variadic-fail.rs
@@ -119,6 +119,15 @@ unsafe fn read_cast_pointer() {
     //~^ ERROR requested `*const u8` is incompatible with next argument of type `usize`
 }
 
+unsafe fn read_cast_lifetime() {
+    // The types are equal up to free lifetimes.
+    const { read_as::<*const &'static i32>(std::ptr::dangling::<&i32>()) };
+
+    // Bound lifetimes do matter.
+    const { read_as::<*const fn(&'static ())>(std::ptr::dangling::<for<'a> fn(&'a ())>()) };
+    //~^ ERROR va_arg type mismatch: requested `*const fn(&())` is incompatible with next argument of type `*const for<'a> fn(&'a ())`
+}
+
 fn use_after_free() {
     const unsafe extern "C" fn helper(ap: ...) -> [u8; size_of::<VaList>()] {
         unsafe { std::mem::transmute(ap) }
@@ -196,6 +205,7 @@ fn main() {
         read_too_many();
         read_cast_numeric();
         read_cast_pointer();
+        read_cast_lifetime();
         manual_copy_read();
         manual_copy_drop();
         manual_copy_forget();

--- a/tests/ui/consts/const-eval/c-variadic-fail.stderr
+++ b/tests/ui/consts/const-eval/c-variadic-fail.stderr
@@ -390,8 +390,36 @@ LL |     const { read_as::<*const u8>(1usize) };
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
+error[E0080]: va_arg type mismatch: requested `*const fn(&())` is incompatible with next argument of type `*const for<'a> fn(&'a ())`
+  --> $DIR/c-variadic-fail.rs:127:13
+   |
+LL |     const { read_as::<*const fn(&'static ())>(std::ptr::dangling::<for<'a> fn(&'a ())>()) };
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `read_cast_lifetime::{constant#1}` failed inside this call
+   |
+note: inside `read_as::<*const fn(&())>`
+  --> $DIR/c-variadic-fail.rs:37:5
+   |
+LL |     ap.next_arg::<T>()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `VaList::<'_>::next_arg::<*const fn(&())>`
+  --> $SRC_DIR/core/src/ffi/va_list.rs:LL:COL
+
+note: erroneous constant encountered
+  --> $DIR/c-variadic-fail.rs:127:5
+   |
+LL |     const { read_as::<*const fn(&'static ())>(std::ptr::dangling::<for<'a> fn(&'a ())>()) };
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+note: erroneous constant encountered
+  --> $DIR/c-variadic-fail.rs:127:5
+   |
+LL |     const { read_as::<*const fn(&'static ())>(std::ptr::dangling::<for<'a> fn(&'a ())>()) };
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
 error[E0080]: memory access failed: ALLOC0 has been freed, so this pointer is dangling
-  --> $DIR/c-variadic-fail.rs:131:13
+  --> $DIR/c-variadic-fail.rs:140:13
    |
 LL |             ap.next_arg::<i32>();
    |             ^^^^^^^^^^^^^^^^^^^^ evaluation of `use_after_free::{constant#0}` failed inside this call
@@ -400,7 +428,7 @@ note: inside `VaList::<'_>::next_arg::<i32>`
   --> $SRC_DIR/core/src/ffi/va_list.rs:LL:COL
 
 note: erroneous constant encountered
-  --> $DIR/c-variadic-fail.rs:127:5
+  --> $DIR/c-variadic-fail.rs:136:5
    |
 LL | /     const {
 LL | |         unsafe {
@@ -411,7 +439,7 @@ LL | |     };
    | |_____^
 
 note: erroneous constant encountered
-  --> $DIR/c-variadic-fail.rs:127:5
+  --> $DIR/c-variadic-fail.rs:136:5
    |
 LL | /     const {
 LL | |         unsafe {
@@ -424,13 +452,13 @@ LL | |     };
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0080]: using ALLOC1 as variable argument list pointer but it does not point to a variable argument list
-  --> $DIR/c-variadic-fail.rs:153:22
+  --> $DIR/c-variadic-fail.rs:162:22
    |
 LL |     const { unsafe { helper(1, 2, 3) } };
    |                      ^^^^^^^^^^^^^^^ evaluation of `manual_copy_drop::{constant#0}` failed inside this call
    |
 note: inside `manual_copy_drop::helper`
-  --> $DIR/c-variadic-fail.rs:150:9
+  --> $DIR/c-variadic-fail.rs:159:9
    |
 LL |         drop(ap);
    |         ^^^^^^^^
@@ -442,13 +470,13 @@ note: inside `<VaList<'_> as Drop>::drop`
   --> $SRC_DIR/core/src/ffi/va_list.rs:LL:COL
 
 note: erroneous constant encountered
-  --> $DIR/c-variadic-fail.rs:153:5
+  --> $DIR/c-variadic-fail.rs:162:5
    |
 LL |     const { unsafe { helper(1, 2, 3) } };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 note: erroneous constant encountered
-  --> $DIR/c-variadic-fail.rs:153:5
+  --> $DIR/c-variadic-fail.rs:162:5
    |
 LL |     const { unsafe { helper(1, 2, 3) } };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -456,13 +484,13 @@ LL |     const { unsafe { helper(1, 2, 3) } };
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0080]: using ALLOC2 as variable argument list pointer but it does not point to a variable argument list
-  --> $DIR/c-variadic-fail.rs:169:22
+  --> $DIR/c-variadic-fail.rs:178:22
    |
 LL |     const { unsafe { helper(1, 2, 3) } };
    |                      ^^^^^^^^^^^^^^^ evaluation of `manual_copy_forget::{constant#0}` failed inside this call
    |
 note: inside `manual_copy_forget::helper`
-  --> $DIR/c-variadic-fail.rs:166:9
+  --> $DIR/c-variadic-fail.rs:175:9
    |
 LL |         drop(ap);
    |         ^^^^^^^^
@@ -474,13 +502,13 @@ note: inside `<VaList<'_> as Drop>::drop`
   --> $SRC_DIR/core/src/ffi/va_list.rs:LL:COL
 
 note: erroneous constant encountered
-  --> $DIR/c-variadic-fail.rs:169:5
+  --> $DIR/c-variadic-fail.rs:178:5
    |
 LL |     const { unsafe { helper(1, 2, 3) } };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 note: erroneous constant encountered
-  --> $DIR/c-variadic-fail.rs:169:5
+  --> $DIR/c-variadic-fail.rs:178:5
    |
 LL |     const { unsafe { helper(1, 2, 3) } };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -488,13 +516,13 @@ LL |     const { unsafe { helper(1, 2, 3) } };
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0080]: using ALLOC3 as variable argument list pointer but it does not point to a variable argument list
-  --> $DIR/c-variadic-fail.rs:182:22
+  --> $DIR/c-variadic-fail.rs:191:22
    |
 LL |     const { unsafe { helper(1, 2, 3) } };
    |                      ^^^^^^^^^^^^^^^ evaluation of `manual_copy_read::{constant#0}` failed inside this call
    |
 note: inside `manual_copy_read::helper`
-  --> $DIR/c-variadic-fail.rs:179:17
+  --> $DIR/c-variadic-fail.rs:188:17
    |
 LL |         let _ = ap.next_arg::<i32>();
    |                 ^^^^^^^^^^^^^^^^^^^^
@@ -502,13 +530,13 @@ note: inside `VaList::<'_>::next_arg::<i32>`
   --> $SRC_DIR/core/src/ffi/va_list.rs:LL:COL
 
 note: erroneous constant encountered
-  --> $DIR/c-variadic-fail.rs:182:5
+  --> $DIR/c-variadic-fail.rs:191:5
    |
 LL |     const { unsafe { helper(1, 2, 3) } };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 note: erroneous constant encountered
-  --> $DIR/c-variadic-fail.rs:182:5
+  --> $DIR/c-variadic-fail.rs:191:5
    |
 LL |     const { unsafe { helper(1, 2, 3) } };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -516,7 +544,7 @@ LL |     const { unsafe { helper(1, 2, 3) } };
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0080]: pointer not dereferenceable: pointer must point to some allocation, but got null pointer
-  --> $DIR/c-variadic-fail.rs:190:5
+  --> $DIR/c-variadic-fail.rs:199:5
    |
 LL |     }
    |     ^ evaluation of `drop_of_invalid::{constant#0}` failed inside this call
@@ -527,7 +555,7 @@ note: inside `<VaList<'_> as Drop>::drop`
   --> $SRC_DIR/core/src/ffi/va_list.rs:LL:COL
 
 note: erroneous constant encountered
-  --> $DIR/c-variadic-fail.rs:187:5
+  --> $DIR/c-variadic-fail.rs:196:5
    |
 LL | /     const {
 LL | |         let mut invalid: MaybeUninit<VaList> = MaybeUninit::zeroed();
@@ -536,7 +564,7 @@ LL | |     }
    | |_____^
 
 note: erroneous constant encountered
-  --> $DIR/c-variadic-fail.rs:187:5
+  --> $DIR/c-variadic-fail.rs:196:5
    |
 LL | /     const {
 LL | |         let mut invalid: MaybeUninit<VaList> = MaybeUninit::zeroed();
@@ -546,6 +574,6 @@ LL | |     }
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error: aborting due to 19 previous errors
+error: aborting due to 20 previous errors
 
 For more information about this error, try `rustc --explain E0080`.


### PR DESCRIPTION
tracking issue: https://github.com/rust-lang/rust/issues/44930

Test that we use equality up to free lifetimes, and correctly consider `for<'a> &'a` to be different from `&'static`. I'm not sure if I'm missing any type subtleties here? Because it seems like the current implementation already has the behavior that we want. (and that `==` on `Ty` has this behavior).

Also see https://github.com/rust-lang/rust/pull/155697#issuecomment-4666457403 and https://github.com/rust-lang/rust/pull/155697#issuecomment-4730822126.

cc @theemathas 
r? RalfJung,lcnr