### PR TITLE
Outline part of `evaluate_goal_raw` into its own `#[cold]` function

### DIFF
--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
@@ -590,6 +590,16 @@ where
             ));
         }
 
+        self.evaluate_goal_cold(source, goal)
+    }
+
+    #[cold]
+    #[inline(never)]
+    pub(super) fn evaluate_goal_cold(
+        &mut self,
+        source: GoalSource,
+        goal: Goal<I, I::Predicate>,
+    ) -> Result<(NestedNormalizationGoals<I>, GoalEvaluation<I>), NoSolutionOrRerunNonErased> {
         // We only care about one entry per `OpaqueTypeKey` here,
         // so we only canonicalize the lookup table and ignore
         // duplicate entries.


### PR DESCRIPTION
implements https://github.com/rust-lang/rust/pull/77041 for the new trait solver