### PR TITLE
proc_macro: preserve file module spans for inner attrs

### DIFF
--- a/compiler/rustc_expand/src/expand.rs
+++ b/compiler/rustc_expand/src/expand.rs
@@ -791,10 +791,18 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
                                     )
                                 ) =>
                         {
-                            rustc_parse::fake_token_stream_for_item(&self.cx.sess.psess, item_inner)
+                            rustc_parse::fake_token_stream_for_item(
+                                &self.cx.sess.psess,
+                                item_inner,
+                                Some(&attr),
+                            )
                         }
                         Annotatable::Item(item_inner) if item_inner.tokens.is_none() => {
-                            rustc_parse::fake_token_stream_for_item(&self.cx.sess.psess, item_inner)
+                            rustc_parse::fake_token_stream_for_item(
+                                &self.cx.sess.psess,
+                                item_inner,
+                                None,
+                            )
                         }
                         // When a function has EII implementations attached (via `eii_impls`),
                         // use fake tokens so the pretty-printer re-emits the EII attribute
@@ -806,7 +814,11 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
                             if matches!(&item_inner.kind,
                                 ItemKind::Fn(f) if !f.eii_impls.is_empty()) =>
                         {
-                            rustc_parse::fake_token_stream_for_item(&self.cx.sess.psess, item_inner)
+                            rustc_parse::fake_token_stream_for_item(
+                                &self.cx.sess.psess,
+                                item_inner,
+                                None,
+                            )
                         }
                         Annotatable::ForeignItem(item_inner) if item_inner.tokens.is_none() => {
                             rustc_parse::fake_token_stream_for_foreign_item(

--- a/compiler/rustc_parse/src/lib.rs
+++ b/compiler/rustc_parse/src/lib.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 
 use rustc_ast as ast;
 use rustc_ast::token;
-use rustc_ast::tokenstream::TokenStream;
+use rustc_ast::tokenstream::{DelimSpacing, DelimSpan, Spacing, TokenStream, TokenTree};
 use rustc_ast_pretty::pprust;
 use rustc_errors::{Diag, EmissionGuarantee, FatalError, PResult, pluralize};
 pub use rustc_lexer::UNICODE_VERSION;
@@ -251,10 +251,75 @@ pub fn parse_in<'a, T>(
     Ok(result)
 }
 
-pub fn fake_token_stream_for_item(psess: &ParseSess, item: &ast::Item) -> TokenStream {
+pub fn fake_token_stream_for_item(
+    psess: &ParseSess,
+    item: &ast::Item,
+    attr_to_exclude: Option<&ast::Attribute>,
+) -> TokenStream {
+    if let Some(tokens) = fake_token_stream_for_file_mod(psess, item, attr_to_exclude) {
+        return tokens;
+    }
+
     let source = pprust::item_to_string(item);
     let filename = FileName::macro_expansion_source_code(&source);
     unwrap_or_emit_fatal(source_str_to_stream(psess, filename, source, Some(item.span)))
+}
+
+fn fake_token_stream_for_file_mod(
+    psess: &ParseSess,
+    item: &ast::Item,
+    attr_to_exclude: Option<&ast::Attribute>,
+) -> Option<TokenStream> {
+    let ast::ItemKind::Mod(_, _, ast::ModKind::Loaded(_, ast::Inline::No { .. }, spans)) =
+        &item.kind
+    else {
+        return None;
+    };
+
+    let attr = attr_to_exclude.expect("file modules must have an attribute to exclude");
+    assert_eq!(attr.style, ast::AttrStyle::Inner);
+
+    let mut body_tts = Vec::new();
+    body_tts.extend(lex_token_trees_for_span(psess, spans.inner_span.until(attr.span))?);
+    body_tts.extend(lex_token_trees_for_span(
+        psess,
+        attr.span.between(spans.inner_span.shrink_to_hi()),
+    )?);
+
+    let mut wrapper_tts = Vec::new();
+    for attr in item.attrs.iter().filter(|attr| attr.style == ast::AttrStyle::Outer) {
+        wrapper_tts.extend(attr.token_trees());
+    }
+    wrapper_tts.extend(lex_token_trees_for_span(psess, item.span)?);
+    let Some(TokenTree::Token(semi, _)) = wrapper_tts.pop() else {
+        return None;
+    };
+    if semi.kind != token::Semi {
+        return None;
+    }
+    wrapper_tts.push(TokenTree::Delimited(
+        DelimSpan::from_single(semi.span),
+        DelimSpacing::new(Spacing::Alone, Spacing::Alone),
+        token::Delimiter::Brace,
+        TokenStream::new(body_tts),
+    ));
+
+    Some(TokenStream::new(wrapper_tts))
+}
+
+fn lex_token_trees_for_span(
+    psess: &ParseSess,
+    span: Span,
+) -> Option<impl Iterator<Item = TokenTree>> {
+    let src = psess.source_map().span_to_snippet(span).ok()?;
+    let stream = unwrap_or_emit_fatal(lexer::lex_token_trees(
+        psess,
+        &src,
+        span.lo(),
+        None,
+        StripTokens::Nothing,
+    ));
+    Some((0..).map_while(move |index| stream.get(index).cloned()))
 }
 
 pub fn fake_token_stream_for_foreign_item(

--- a/tests/ui/proc-macro/auxiliary/inner_attr_file_mod_diagnostics_child.rs
+++ b/tests/ui/proc-macro/auxiliary/inner_attr_file_mod_diagnostics_child.rs
@@ -1,0 +1,5 @@
+#![test_macros::identity_attr]
+
+pub fn f() {
+    g()
+}

--- a/tests/ui/proc-macro/inner-attr-file-mod-diagnostics.rs
+++ b/tests/ui/proc-macro/inner-attr-file-mod-diagnostics.rs
@@ -1,0 +1,13 @@
+//@ proc-macro: test-macros.rs
+//@ edition:2024
+
+#![feature(custom_inner_attributes)]
+
+extern crate test_macros;
+
+#[path = "auxiliary/inner_attr_file_mod_diagnostics_child.rs"]
+pub mod child;
+
+fn main() {}
+
+//~? ERROR cannot find function `g` in this scope

--- a/tests/ui/proc-macro/inner-attr-file-mod-diagnostics.stderr
+++ b/tests/ui/proc-macro/inner-attr-file-mod-diagnostics.stderr
@@ -1,0 +1,9 @@
+error[E0425]: cannot find function `g` in this scope
+  --> $DIR/auxiliary/inner_attr_file_mod_diagnostics_child.rs:4:5
+   |
+LL |     g()
+   |     ^ not found in this scope
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/proc-macro/inner-attr-file-mod.rs
+++ b/tests/ui/proc-macro/inner-attr-file-mod.rs
@@ -9,9 +9,9 @@ extern crate test_macros;
 
 #[deny(unused_attributes)]
 mod module_with_attrs;
-//~^ ERROR custom inner attributes are unstable
 
 fn main() {}
 
+//~? ERROR custom inner attributes are unstable
 //~? ERROR custom inner attributes are unstable
 //~? ERROR inner macro attributes are unstable

--- a/tests/ui/proc-macro/inner-attr-file-mod.stderr
+++ b/tests/ui/proc-macro/inner-attr-file-mod.stderr
@@ -19,14 +19,15 @@ LL | #![print_attr]
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: custom inner attributes are unstable
-  --> $DIR/inner-attr-file-mod.rs:11:1
+  --> $DIR/module_with_attrs.rs:3:4
    |
-LL | mod module_with_attrs;
-   | ^^^^^^^^^^^^^^^^^^^^^^
+LL | #![rustfmt::skip]
+   |    ^^^^^^^^^^^^^
    |
    = note: see issue #54726 <https://github.com/rust-lang/rust/issues/54726> for more information
    = help: add `#![feature(custom_inner_attributes)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/proc-macro/inner-attr-file-mod.stdout
+++ b/tests/ui/proc-macro/inner-attr-file-mod.stdout
@@ -1,38 +1,39 @@
-PRINT-ATTR INPUT (DISPLAY): #[deny(unused_attributes)] mod module_with_attrs { #![rustfmt::skip] }
+PRINT-ATTR INPUT (DISPLAY): #[deny(unused_attributes)] mod module_with_attrs{ #![rustfmt::skip] }
+PRINT-ATTR RE-COLLECTED (DISPLAY): #[deny(unused_attributes)] mod module_with_attrs { #![rustfmt::skip] }
 PRINT-ATTR DEEP-RE-COLLECTED (DISPLAY): #[deny(unused_attributes)] mod module_with_attrs { #! [rustfmt :: skip] }
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Punct {
         ch: '#',
         spacing: Alone,
-        span: $DIR/inner-attr-file-mod.rs:11:1: 11:23 (#0),
+        span: $DIR/inner-attr-file-mod.rs:10:1: 10:2 (#0),
     },
     Group {
         delimiter: Bracket,
         stream: TokenStream [
             Ident {
                 ident: "deny",
-                span: $DIR/inner-attr-file-mod.rs:11:1: 11:23 (#0),
+                span: $DIR/inner-attr-file-mod.rs:10:3: 10:7 (#0),
             },
             Group {
                 delimiter: Parenthesis,
                 stream: TokenStream [
                     Ident {
                         ident: "unused_attributes",
-                        span: $DIR/inner-attr-file-mod.rs:11:1: 11:23 (#0),
+                        span: $DIR/inner-attr-file-mod.rs:10:8: 10:25 (#0),
                     },
                 ],
-                span: $DIR/inner-attr-file-mod.rs:11:1: 11:23 (#0),
+                span: $DIR/inner-attr-file-mod.rs:10:7: 10:26 (#0),
             },
         ],
-        span: $DIR/inner-attr-file-mod.rs:11:1: 11:23 (#0),
+        span: $DIR/inner-attr-file-mod.rs:10:2: 10:27 (#0),
     },
     Ident {
         ident: "mod",
-        span: $DIR/inner-attr-file-mod.rs:11:1: 11:23 (#0),
+        span: $DIR/inner-attr-file-mod.rs:11:1: 11:4 (#0),
     },
     Ident {
         ident: "module_with_attrs",
-        span: $DIR/inner-attr-file-mod.rs:11:1: 11:23 (#0),
+        span: $DIR/inner-attr-file-mod.rs:11:5: 11:22 (#0),
     },
     Group {
         delimiter: Brace,
@@ -40,38 +41,38 @@ PRINT-ATTR INPUT (DEBUG): TokenStream [
             Punct {
                 ch: '#',
                 spacing: Joint,
-                span: $DIR/inner-attr-file-mod.rs:11:1: 11:23 (#0),
+                span: $DIR/module_with_attrs.rs:3:1: 3:2 (#0),
             },
             Punct {
                 ch: '!',
                 spacing: Alone,
-                span: $DIR/inner-attr-file-mod.rs:11:1: 11:23 (#0),
+                span: $DIR/module_with_attrs.rs:3:2: 3:3 (#0),
             },
             Group {
                 delimiter: Bracket,
                 stream: TokenStream [
                     Ident {
                         ident: "rustfmt",
-                        span: $DIR/inner-attr-file-mod.rs:11:1: 11:23 (#0),
+                        span: $DIR/module_with_attrs.rs:3:4: 3:11 (#0),
                     },
                     Punct {
                         ch: ':',
                         spacing: Joint,
-                        span: $DIR/inner-attr-file-mod.rs:11:1: 11:23 (#0),
+                        span: $DIR/module_with_attrs.rs:3:11: 3:12 (#0),
                     },
                     Punct {
                         ch: ':',
                         spacing: Alone,
-                        span: $DIR/inner-attr-file-mod.rs:11:1: 11:23 (#0),
+                        span: $DIR/module_with_attrs.rs:3:12: 3:13 (#0),
                     },
                     Ident {
                         ident: "skip",
-                        span: $DIR/inner-attr-file-mod.rs:11:1: 11:23 (#0),
+                        span: $DIR/module_with_attrs.rs:3:13: 3:17 (#0),
                     },
                 ],
-                span: $DIR/inner-attr-file-mod.rs:11:1: 11:23 (#0),
+                span: $DIR/module_with_attrs.rs:3:3: 3:18 (#0),
             },
         ],
-        span: $DIR/inner-attr-file-mod.rs:11:1: 11:23 (#0),
+        span: $DIR/inner-attr-file-mod.rs:11:22: 11:23 (#0),
     },
 ]


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/158046)*
<!-- homu-ignore:end -->

fixes rust-lang/rust#157881

out-of-line mods with custom inner attrs were sending proc macros a pretty-printed module wrapper. the awkward bit: tokens inside the module picked up the span from the parent mod foo;, so later diags pointed at the decl instead of the file where the code actually came from.

this keeps the wrapper synthetic, but puts the loaded file body back into the token stream with its own spans. it also skips the attr currently being expanded, so we don't replay it by accident. added a small ui repro too, plus the older span-debug output changed because those spans are now real.

imo this is the least annoying fix for now. fwiw, it keeps the old fake-wrapper path instead of trying to make full token capture for file mods happen in this PR.