### PR TITLE
fix unresolved import suggestion before outer attributes

### DIFF
--- a/tests/ui/resolve/suggest-import-before-outer-attrs-issue-69733.fixed
+++ b/tests/ui/resolve/suggest-import-before-outer-attrs-issue-69733.fixed
@@ -1,0 +1,13 @@
+//@ edition:2015
+//@ run-rustfix
+//@ compile-flags: -Adead_code
+
+use std::path::Path;
+
+#[derive(Debug)]
+struct Symbol;
+
+type Ident = Path;
+//~^ ERROR cannot find type `Path` in this scope
+
+fn main() {}

--- a/tests/ui/resolve/suggest-import-before-outer-attrs-issue-69733.rs
+++ b/tests/ui/resolve/suggest-import-before-outer-attrs-issue-69733.rs
@@ -1,0 +1,11 @@
+//@ edition:2015
+//@ run-rustfix
+//@ compile-flags: -Adead_code
+
+#[derive(Debug)]
+struct Symbol;
+
+type Ident = Path;
+//~^ ERROR cannot find type `Path` in this scope
+
+fn main() {}

--- a/tests/ui/resolve/suggest-import-before-outer-attrs-issue-69733.stderr
+++ b/tests/ui/resolve/suggest-import-before-outer-attrs-issue-69733.stderr
@@ -1,0 +1,14 @@
+error[E0425]: cannot find type `Path` in this scope
+  --> $DIR/suggest-import-before-outer-attrs-issue-69733.rs:8:14
+   |
+LL | type Ident = Path;
+   |              ^^^^ not found in this scope
+   |
+help: consider importing this struct
+   |
+LL + use std::path::Path;
+   |
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0425`.


### PR DESCRIPTION
Fixes rust-lang/rust#69733.

Issue rust-lang/rust#69733 reports an invalid import suggestion where rustc could insert a new `use ...;` item between an outer attribute and the item it annotates. This invalid import suggestion produces broken code.

My PR adds a `run-rustfix` UI regression test for that. The fixed output verifies that the suggested import is inserted before the leading outer attribute