### PR TITLE
Don't suggest a binding rename for qualified path patterns

### DIFF
--- a/compiler/rustc_hir_typeck/src/pat.rs
+++ b/compiler/rustc_hir_typeck/src/pat.rs
@@ -304,7 +304,7 @@ struct ResolvedPat<'tcx> {
 
 #[derive(Clone, Copy, Debug)]
 enum ResolvedPatKind<'tcx> {
-    Path { res: Res, pat_res: Res, segments: &'tcx [hir::PathSegment<'tcx>] },
+    Path { res: Res, pat_res: Res, segments: &'tcx [hir::PathSegment<'tcx>], lone_ident: bool },
     Struct { variant: &'tcx VariantDef },
     TupleStruct { res: Res, variant: &'tcx VariantDef },
 }
@@ -1617,10 +1617,16 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             _ => bug!("unexpected pattern resolution: {:?}", res),
         }
 
+        let lone_ident =
+            matches!(qpath, hir::QPath::Resolved(None, path) if path.segments.len() == 1);
+
         // Find the type of the path pattern, for later checking.
         let (pat_ty, pat_res) =
             self.instantiate_value_path(segments, opt_ty, res, span, span, path_id);
-        Ok(ResolvedPat { ty: pat_ty, kind: ResolvedPatKind::Path { res, pat_res, segments } })
+        Ok(ResolvedPat {
+            ty: pat_ty,
+            kind: ResolvedPatKind::Path { res, pat_res, segments, lone_ident },
+        })
     }
 
     fn check_pat_path(
@@ -1674,7 +1680,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         pat_span: Span,
         resolved_pat: &ResolvedPat<'tcx>,
     ) {
-        let ResolvedPatKind::Path { res, pat_res, segments } = resolved_pat.kind else {
+        let ResolvedPatKind::Path { res, pat_res, segments, lone_ident } = resolved_pat.kind else {
             span_bug!(pat_span, "unexpected resolution for path pattern: {resolved_pat:?}");
         };
 
@@ -1690,15 +1696,17 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             && e.suggestions.len() == 0
         {
             e.span_label(span, format!("{} defined here", res.descr()));
-            e.span_label(
-                pat_span,
-                format!(
-                    "`{}` is interpreted as {} {}, not a new binding",
-                    ident,
-                    res.article(),
-                    res.descr(),
-                ),
-            );
+            if lone_ident {
+                e.span_label(
+                    pat_span,
+                    format!(
+                        "`{}` is interpreted as {} {}, not a new binding",
+                        ident,
+                        res.article(),
+                        res.descr(),
+                    ),
+                );
+            }
             match self.tcx.parent_hir_node(hir_id) {
                 hir::Node::PatField(..) => {
                     e.span_suggestion_verbose(
@@ -1737,7 +1745,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                 consider using a range pattern like `min ..= max` in the match block";
                             e.note(msg);
                         }
-                    } else {
+                    } else if lone_ident {
                         let msg = "introduce a new binding instead";
                         let sugg = format!("other_{}", ident.as_str().to_lowercase());
                         e.span_suggestion_verbose(

--- a/tests/ui/match/assoc-const-pattern-binding-suggestion.rs
+++ b/tests/ui/match/assoc-const-pattern-binding-suggestion.rs
@@ -1,0 +1,24 @@
+struct Scrutinee;
+
+struct Inherent;
+impl Inherent {
+    const K: i32 = 0;
+}
+
+const FREE: i32 = 0;
+
+fn qualified(source: Scrutinee) {
+    match source {
+        Inherent::K => {} //~ ERROR mismatched types
+        _ => {}
+    }
+}
+
+fn lone_ident(source: Scrutinee) {
+    match source {
+        FREE => {} //~ ERROR mismatched types
+        _ => {}
+    }
+}
+
+fn main() {}

--- a/tests/ui/match/assoc-const-pattern-binding-suggestion.stderr
+++ b/tests/ui/match/assoc-const-pattern-binding-suggestion.stderr
@@ -1,0 +1,34 @@
+error[E0308]: mismatched types
+  --> $DIR/assoc-const-pattern-binding-suggestion.rs:12:9
+   |
+LL |     const K: i32 = 0;
+   |     ------------ associated constant defined here
+...
+LL |     match source {
+   |           ------ this expression has type `Scrutinee`
+LL |         Inherent::K => {}
+   |         ^^^^^^^^^^^ expected `Scrutinee`, found `i32`
+
+error[E0308]: mismatched types
+  --> $DIR/assoc-const-pattern-binding-suggestion.rs:19:9
+   |
+LL | const FREE: i32 = 0;
+   | --------------- constant defined here
+...
+LL |     match source {
+   |           ------ this expression has type `Scrutinee`
+LL |         FREE => {}
+   |         ^^^^
+   |         |
+   |         expected `Scrutinee`, found `i32`
+   |         `FREE` is interpreted as a constant, not a new binding
+   |
+help: introduce a new binding instead
+   |
+LL -         FREE => {}
+LL +         other_free => {}
+   |
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Fixes rust-lang/rust#153926.

When a pattern is a qualified path like `Owner::K` whose type doesn't match the scrutinee, rustc was labelling it "`K` is interpreted as an associated constant, not a new binding" and suggesting `Owner::other_k`. A multi-segment path can never be a binding, so the label is irrelevant and the suggestion is always wrong. This only emits that label and suggestion for a lone identifier now; qualified paths just get the type mismatch.