### PR TITLE
Don't escape U+FF9E and U+FF9F in `escape_debug_ext`

### DIFF
--- a/library/core/src/char/methods.rs
+++ b/library/core/src/char/methods.rs
@@ -486,8 +486,11 @@ impl char {
             '\r' => EscapeDebug::backslash(ascii::Char::SmallR),
             '\0' => EscapeDebug::backslash(ascii::Char::Digit0),
 
-            // ASCII fast path
-            '\x20'..='\x7E' => EscapeDebug::printable(self),
+            // ASCII fast path,
+            // plus U+FF9E HALFWIDTH KATAKANA VOICED SOUND MARK
+            // and U+FF9F HALFWIDTH KATAKANA SEMI-VOICED SOUND MARK
+            // which should not be escaped despite being grapheme extenders.
+            '\x20'..='\x7E' | '\u{FF9E}' | '\u{FF9F}' => EscapeDebug::printable(self),
 
             _ if self.is_control()
                 || self.is_private_use()

--- a/library/core/src/char/methods.rs
+++ b/library/core/src/char/methods.rs
@@ -2427,10 +2427,13 @@ impl char {
 
 pub(crate) struct EscapeDebugExtArgs {
     /// Escape Grapheme Extender codepoints?
-    /// (Note that this excludes
+    ///
+    /// Note that this excludes
     /// U+FF9E HALFWIDTH KATAKANA VOICED SOUND MARK
     /// and U+FF9F HALFWIDTH KATAKANA SEMI-VOICED SOUND MARK,
-    /// which are never escaped.)
+    /// which are never escaped, as graphically
+    /// they are not combining. See <https://github.com/microsoft/terminal/issues/18087>
+    /// for background on these characters.
     pub(crate) escape_grapheme_extender: bool,
 
     /// Escape single quotes?

--- a/library/core/src/char/methods.rs
+++ b/library/core/src/char/methods.rs
@@ -2427,6 +2427,10 @@ impl char {
 
 pub(crate) struct EscapeDebugExtArgs {
     /// Escape Grapheme Extender codepoints?
+    /// (Note that this excludes
+    /// U+FF9E HALFWIDTH KATAKANA VOICED SOUND MARK
+    /// and U+FF9F HALFWIDTH KATAKANA SEMI-VOICED SOUND MARK,
+    /// which are never escaped.)
     pub(crate) escape_grapheme_extender: bool,
 
     /// Escape single quotes?

--- a/library/coretests/tests/char.rs
+++ b/library/coretests/tests/char.rs
@@ -299,6 +299,8 @@ fn test_escape_debug() {
     assert_eq!(string('\u{200b}'), "\\u{200b}"); // zero width space
     assert_eq!(string('\u{e000}'), "\\u{e000}"); // private use 1
     assert_eq!(string('\u{100000}'), "\\u{100000}"); // private use 2
+    assert_eq!(string('\u{ff9e}'), "\u{ff9e}"); // halfwidth dakuten
+    assert_eq!(string('\u{ff9f}'), "\u{ff9f}"); // halfwidth handakuten
 }
 
 #[test]


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/158057)*
<!-- homu-ignore:end -->

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

The two characters `ﾞ` U+FF9E HALFWIDTH KATAKANA VOICED SOUND MARK and `ﾟ` U+FF9F HALFWIDTH KATAKANA SEMI-VOICED SOUND MARK are the odd ones out when it comes to grapheme extenders, in that *graphically* they are not combining at all. See https://github.com/microsoft/terminal/issues/18087 for more background on these characters.

I think this needs FCP? It affects `char::escape_debug`, and various `Debug` impls for characters and strings.

@rustbot labels T-libs-api needs-fcp A-Unicode