### PR TITLE
rustc book: Update wasm32-wasip1-threads's maintainers list

### DIFF
--- a/src/doc/rustc/src/platform-support/wasm32-wasip1-threads.md
+++ b/src/doc/rustc/src/platform-support/wasm32-wasip1-threads.md
@@ -19,7 +19,6 @@ with native multi threading capabilities.
 ## Target maintainers
 
 [@g0djan](https://github.com/g0djan)
-[@abrown](https://github.com/abrown)
 [@loganek](https://github.com/loganek)
 
 ## Requirements


### PR DESCRIPTION
@abrown has
[commented](https://github.com/rust-lang/rust/pull/157644#issuecomment-4733114952) that he is no longer maintaining the target.

Update the target maintainers list accordingly.

r? abrown
