### PR TITLE
LLVM 23: Adapt codegen test to moved assume

### DIFF
--- a/tests/codegen-llvm/issues/issue-107681-unwrap_unchecked.rs
+++ b/tests/codegen-llvm/issues/issue-107681-unwrap_unchecked.rs
@@ -1,4 +1,6 @@
 //@ compile-flags: -Copt-level=3
+//@ filecheck-flags: --implicit-check-not 'br {{.*}}' --implicit-check-not 'select'
+//@ min-llvm-version: 22
 
 // Test for #107681.
 // Make sure we don't create `br` or `select` instructions.
@@ -11,10 +13,8 @@ use std::slice::Iter;
 #[no_mangle]
 pub unsafe fn foo(x: &mut Copied<Iter<'_, u32>>) -> u32 {
     // CHECK-LABEL: @foo(
-    // CHECK-NOT: br {{.*}}
-    // CHECK-NOT: select
-    // CHECK: [[RET:%.*]] = load i32, ptr
-    // CHECK-NEXT: assume
-    // CHECK-NEXT: ret i32 [[RET]]
+    // CHECK: [[INNER:%.*]] = load ptr, ptr %x
+    // CHECK: [[RET:%.*]] = load i32, ptr [[INNER]]
+    // CHECK: ret i32 [[RET]]
     x.next().unwrap_unchecked()
 }


### PR DESCRIPTION
I wasn't completely sure what the important part of this test is - based on the "Make sure we don't create `br` or `select` instructions" comment I assume it's that the `load` is followed ~immediately by the `ret`, and that the presence or absence of the `assume` doesn't really matter (it's been moved up a few lines to before the `load`):

```ll
; Function Attrs
define noundef i32 @foo(ptr noalias nofree noundef align 8 captures(none) dereferenceable(16) %x) unnamed_addr #0 { 
start
 %_6 = load ptr, ptr %x, align 8, !nonnull !4, !noundef !4 
 %0 = getelementptr inbounds nuw i8, ptr %x, i64 8 
 %_7 = load ptr, ptr %0, align 8, !nonnull !4, !noundef !4 
 %_8 = icmp ne ptr %_6, %_7 
 tail call void @llvm.assume(i1 %_8) 
 %_14 = getelementptr inbounds nuw i8, ptr %_6, i64 4 
 store ptr %_14, ptr %x, align 8 
 %_4 = load i32, ptr %_6, align 4, !noundef !4 
 ret i32 %_4 
} 
 ```

@rustbot label llvm-main

[original CI failure](https://buildkite.com/llvm-project/rust-llvm-integrate-prototype/builds/46608/list?sid=019ed950-c81f-466d-a3bc-2064e6a26719&tab=output)