### PR TITLE
Document the behaviour of BTreeMap::extend

### DIFF
--- a/library/alloc/src/collections/btree/map.rs
+++ b/library/alloc/src/collections/btree/map.rs
@@ -2556,6 +2556,9 @@ impl<K: Ord, V> FromIterator<(K, V)> for BTreeMap<K, V> {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<K: Ord, V, A: Allocator + Clone> Extend<(K, V)> for BTreeMap<K, V, A> {
+    /// Add all elements from `iter` to this map by calling [`BTreeMap::insert`]
+    /// in a loop. Its return value is ignored. This means duplicate elements
+    /// will be overwritten.
     #[inline]
     fn extend<T: IntoIterator<Item = (K, V)>>(&mut self, iter: T) {
         iter.into_iter().for_each(move |(k, v)| {
@@ -2573,6 +2576,9 @@ impl<K: Ord, V, A: Allocator + Clone> Extend<(K, V)> for BTreeMap<K, V, A> {
 impl<'a, K: Ord + Copy, V: Copy, A: Allocator + Clone> Extend<(&'a K, &'a V)>
     for BTreeMap<K, V, A>
 {
+    /// Add all elements from `iter` to this map by calling [`BTreeMap::insert`]
+    /// in a loop. Its return value is ignored. This means duplicate elements
+    /// will be overwritten. Keys and values are copied.
     fn extend<I: IntoIterator<Item = (&'a K, &'a V)>>(&mut self, iter: I) {
         self.extend(iter.into_iter().map(|(&key, &value)| (key, value)));
     }

--- a/library/std/src/collections/hash/map.rs
+++ b/library/std/src/collections/hash/map.rs
@@ -3027,6 +3027,9 @@ where
     S: BuildHasher,
     A: Allocator,
 {
+    /// Add all elements from `iter` to this map by calling [`HashMap::insert`]
+    /// in a loop. Its return value is ignored. This means duplicate elements
+    /// will be overwritten.
     #[inline]
     fn extend<T: IntoIterator<Item = (K, V)>>(&mut self, iter: T) {
         self.base.extend(iter)
@@ -3051,6 +3054,9 @@ where
     S: BuildHasher,
     A: Allocator,
 {
+    /// Add all elements from `iter` to this map by calling [`HashMap::insert`]
+    /// in a loop. Its return value is ignored. This means duplicate elements
+    /// will be overwritten. Keys and values are copied.
     #[inline]
     fn extend<T: IntoIterator<Item = (&'a K, &'a V)>>(&mut self, iter: T) {
         self.base.extend(iter)


### PR DESCRIPTION
It was unclear from the existing documentation how duplicate elements would be handled.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

No AI was used for this PR.