### PR TITLE
bootstrap: fix panic when repo path contains spaces by switching to CARGO_ENCODED_RUSTFLAGS

### DIFF
--- a/src/bootstrap/src/core/builder/cargo.rs
+++ b/src/bootstrap/src/core/builder/cargo.rs
@@ -465,6 +465,13 @@ impl From<Cargo> for BootstrapCommand {
 
         cargo.command.args(cargo.args);
 
+        // Always unset the plain RUSTFLAGS/RUSTDOCFLAGS so that downstream
+        // tools (e.g. build.rs scripts) see only the encoded form. Any flags
+        // from the caller's environment have already been folded into the
+        // Rustflags struct via `propagate_cargo_env`.
+        cargo.command.env_remove("RUSTFLAGS");
+        cargo.command.env_remove("RUSTDOCFLAGS");
+
         let rustflags = &cargo.rustflags.0;
         if !rustflags.is_empty() {
             cargo.command.env("CARGO_ENCODED_RUSTFLAGS", rustflags);

--- a/src/bootstrap/src/core/builder/cargo.rs
+++ b/src/bootstrap/src/core/builder/cargo.rs
@@ -464,7 +464,7 @@ impl From<Cargo> for BootstrapCommand {
 
         let rustdocflags = &cargo.rustdocflags.0;
         if !rustdocflags.is_empty() {
-            cargo.command.env("RUSTDOCFLAGS", rustdocflags.join(" "));
+            cargo.command.env("CARGO_ENCODED_RUSTDOCFLAGS", rustdocflags.join("\x1f"));
         }
 
         let encoded_hostflags = cargo.hostflags.encode();

--- a/src/bootstrap/src/core/builder/cargo.rs
+++ b/src/bootstrap/src/core/builder/cargo.rs
@@ -14,18 +14,18 @@ use crate::{
     RemapScheme, TargetSelection, command, prepare_behaviour_dump_dir, t,
 };
 
-/// Represents flag values in `String` form with whitespace delimiter to pass it to the compiler
-/// later.
+/// Represents flag values passed to the compiler, stored as individual arguments to support
+/// values that contain spaces (such as paths from `llvm-config --libdir`).
 ///
 /// `-Z crate-attr` flags will be applied recursively on the target code using the
 /// `rustc_parse::parser::Parser`. See `rustc_builtin_macros::cmdline_attrs::inject` for more
 /// information.
 #[derive(Debug, Clone)]
-struct Rustflags(String, TargetSelection);
+struct Rustflags(Vec<String>, TargetSelection);
 
 impl Rustflags {
     fn new(target: TargetSelection) -> Rustflags {
-        Rustflags(String::new(), target)
+        Rustflags(Vec::new(), target)
     }
 
     /// By default, cargo will pick up on various variables in the environment. However, bootstrap
@@ -51,11 +51,9 @@ impl Rustflags {
     }
 
     fn arg(&mut self, arg: &str) -> &mut Self {
-        assert_eq!(arg.split(' ').count(), 1);
-        if !self.0.is_empty() {
-            self.0.push(' ');
+        if !arg.is_empty() {
+            self.0.push(arg.to_owned());
         }
-        self.0.push_str(arg);
         self
     }
 
@@ -459,12 +457,14 @@ impl From<Cargo> for BootstrapCommand {
 
         let rustflags = &cargo.rustflags.0;
         if !rustflags.is_empty() {
-            cargo.command.env("RUSTFLAGS", rustflags);
+            // CARGO_ENCODED_RUSTFLAGS uses \x1f (unit separator) as delimiter, which allows
+            // individual flags to contain spaces (e.g. paths from `llvm-config --libdir`).
+            cargo.command.env("CARGO_ENCODED_RUSTFLAGS", rustflags.join("\x1f"));
         }
 
         let rustdocflags = &cargo.rustdocflags.0;
         if !rustdocflags.is_empty() {
-            cargo.command.env("RUSTDOCFLAGS", rustdocflags);
+            cargo.command.env("RUSTDOCFLAGS", rustdocflags.join(" "));
         }
 
         let encoded_hostflags = cargo.hostflags.encode();
@@ -1181,8 +1181,9 @@ impl Builder<'_> {
         if (mode == Mode::ToolRustcPrivate || mode == Mode::Codegen)
             && let Some(llvm_config) = self.llvm_config(target)
         {
-            let llvm_libdir =
+            let llvm_libdir_raw =
                 command(llvm_config).cached().arg("--libdir").run_capture_stdout(self).stdout();
+            let llvm_libdir = llvm_libdir_raw.trim();
             if target.is_msvc() {
                 rustflags.arg(&format!("-Clink-arg=-LIBPATH:{llvm_libdir}"));
             } else {

--- a/src/bootstrap/src/core/builder/cargo.rs
+++ b/src/bootstrap/src/core/builder/cargo.rs
@@ -14,18 +14,21 @@ use crate::{
     RemapScheme, TargetSelection, command, prepare_behaviour_dump_dir, t,
 };
 
-/// Represents flag values passed to the compiler, stored as individual arguments to support
-/// values that contain spaces (such as paths from `llvm-config --libdir`).
+/// Represents flag values in `String` form with a `\x1f` delimiter to pass to the compiler later.
+///
+/// Flags are emitted via `CARGO_ENCODED_RUSTFLAGS` / `CARGO_ENCODED_RUSTDOCFLAGS`,
+/// which use `\x1f` (ASCII Unit Separator) as the delimiter and therefore allow spaces
+/// within individual flag values (e.g. paths from `llvm-config --libdir`).
 ///
 /// `-Z crate-attr` flags will be applied recursively on the target code using the
 /// `rustc_parse::parser::Parser`. See `rustc_builtin_macros::cmdline_attrs::inject` for more
 /// information.
 #[derive(Debug, Clone)]
-struct Rustflags(Vec<String>, TargetSelection);
+struct Rustflags(String, TargetSelection);
 
 impl Rustflags {
     fn new(target: TargetSelection) -> Rustflags {
-        Rustflags(Vec::new(), target)
+        Rustflags(String::new(), target)
     }
 
     /// By default, cargo will pick up on various variables in the environment. However, bootstrap
@@ -51,8 +54,15 @@ impl Rustflags {
     }
 
     fn arg(&mut self, arg: &str) -> &mut Self {
+        assert!(
+            !arg.contains('\x1f'),
+            "rustflag must not contain the ASCII unit separator (\\x1f): {arg:?}"
+        );
         if !arg.is_empty() {
-            self.0.push(arg.to_owned());
+            if !self.0.is_empty() {
+                self.0.push('\x1f');
+            }
+            self.0.push_str(arg);
         }
         self
     }
@@ -457,14 +467,12 @@ impl From<Cargo> for BootstrapCommand {
 
         let rustflags = &cargo.rustflags.0;
         if !rustflags.is_empty() {
-            // CARGO_ENCODED_RUSTFLAGS uses \x1f (unit separator) as delimiter, which allows
-            // individual flags to contain spaces (e.g. paths from `llvm-config --libdir`).
-            cargo.command.env("CARGO_ENCODED_RUSTFLAGS", rustflags.join("\x1f"));
+            cargo.command.env("CARGO_ENCODED_RUSTFLAGS", rustflags);
         }
 
         let rustdocflags = &cargo.rustdocflags.0;
         if !rustdocflags.is_empty() {
-            cargo.command.env("CARGO_ENCODED_RUSTDOCFLAGS", rustdocflags.join("\x1f"));
+            cargo.command.env("CARGO_ENCODED_RUSTDOCFLAGS", rustdocflags);
         }
 
         let encoded_hostflags = cargo.hostflags.encode();

--- a/src/tools/miri/tests/ui.rs
+++ b/src/tools/miri/tests/ui.rs
@@ -182,8 +182,9 @@ fn miri_config(
                         .map(Into::into)
                         .collect(),
                     envs: vec![
-                        // Reset `RUSTFLAGS` to work around <https://github.com/rust-lang/rust/pull/119574#issuecomment-1876878344>.
+                        // Reset `RUSTFLAGS`/`CARGO_ENCODED_RUSTFLAGS` to work around <https://github.com/rust-lang/rust/pull/119574#issuecomment-1876878344>.
                         ("RUSTFLAGS".into(), None),
+                        ("CARGO_ENCODED_RUSTFLAGS".into(), None),
                         // Reset `MIRIFLAGS` because it caused trouble in the past and should not be needed.
                         ("MIRIFLAGS".into(), None),
                         // Allow `cargo miri build`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/158073)*
<!-- homu-ignore:end -->

Fixes rust-lang/rust#158052 
Closes: https://github.com/rust-lang/rust/pull/156096

  ## Problem

  `./x build` panics with a cryptic assertion error when the repository is
  checked out under a directory path containing spaces (e.g.
  `/Users/foo/Open Source/rust`):

  thread 'main' panicked at src/bootstrap/src/core/builder/cargo.rs:54:9:
  assertion left == right failed
    left: 2
   right: 1

  The root cause: when building tools in `ToolRustcPrivate` or `Codegen`
  mode, bootstrap calls `llvm-config --libdir` and passes the result as a
  `-Clink-arg=-L<path>` rustflag. The `Rustflags::arg()` method asserted
  that arguments contain no spaces, but if the repo path has a space the
  libdir path inherits it and the assertion fires. The error gives no hint
  that the path is the problem.

  A secondary bug: `llvm-config --libdir` output has a trailing newline
  that was previously stripped accidentally by `RUSTFLAGS` whitespace
  splitting. Nothing was trimming it explicitly.

  ## Fix

  Two changes in `src/bootstrap/src/core/builder/cargo.rs`:

  1. **Switch `RUSTFLAGS` → `CARGO_ENCODED_RUSTFLAGS`**: Change
     `Rustflags` to store args as `Vec<String>` and join with `\x1f`
     (ASCII unit separator) when setting the env var. Cargo's
     `CARGO_ENCODED_RUSTFLAGS` (stable since Cargo 1.55) uses `\x1f` as
     delimiter, which never appears in filesystem paths, so paths with
     spaces are handled correctly. The space-based assertion in `arg()` is
     removed.

  2. **Trim `llvm-config --libdir` output**: Explicitly `.trim()` the
     captured stdout so the trailing newline is not included in the linker
     search path.

  `RUSTDOCFLAGS` is left as-is (space-joined) since no llvm paths are
  added to rustdocflags.

cc: @Kobzol 