### PR TITLE
Document transient connection errors from TcpListener::accept

### DIFF
--- a/library/std/src/net/tcp.rs
+++ b/library/std/src/net/tcp.rs
@@ -878,16 +878,20 @@ impl TcpListener {
     ///
     /// # Errors
     ///
-    /// Some errors returned by this function relate to a single incoming
-    /// connection that failed before it could be accepted, such as one aborted
-    /// by the peer ([`ConnectionAborted`]). Such an error does not indicate a
-    /// problem with the listener itself, which remains usable. Code serving a
-    /// long-lived listener will usually want to log the error and continue
-    /// accepting connections rather than treat it as fatal. Which errors can
-    /// occur this way is platform-specific.
+    /// Some errors this function returns do not indicate a problem with the
+    /// listener itself, and a program serving a long-lived listener will
+    /// usually want to handle them and keep accepting connections rather than
+    /// treat them as fatal. These include, but are not limited to:
     ///
-    /// On Unix, [`Interrupted`] errors are retried internally rather than being
-    /// returned.
+    /// - An error specific to a single incoming connection that failed before
+    ///   it could be accepted, such as one aborted by the peer
+    ///   ([`ConnectionAborted`]). A later call may succeed immediately.
+    /// - An error from reaching the per-process or system-wide open file
+    ///   descriptor limit. The call can be retried once other file descriptors
+    ///   have been closed, typically after a short delay.
+    ///
+    /// Which errors can occur is platform-specific. On Unix, [`Interrupted`]
+    /// errors are retried internally rather than being returned.
     ///
     /// [`ConnectionAborted`]: io::ErrorKind::ConnectionAborted
     /// [`Interrupted`]: io::ErrorKind::Interrupted

--- a/library/std/src/net/tcp.rs
+++ b/library/std/src/net/tcp.rs
@@ -876,6 +876,22 @@ impl TcpListener {
     /// is established. When established, the corresponding [`TcpStream`] and the
     /// remote peer's address will be returned.
     ///
+    /// # Errors
+    ///
+    /// Some errors returned by this function relate to a single incoming
+    /// connection that failed before it could be accepted, such as one aborted
+    /// by the peer ([`ConnectionAborted`]). Such an error does not indicate a
+    /// problem with the listener itself, which remains usable. Code serving a
+    /// long-lived listener will usually want to log the error and continue
+    /// accepting connections rather than treat it as fatal. Which errors can
+    /// occur this way is platform-specific.
+    ///
+    /// On Unix, [`Interrupted`] errors are retried internally rather than being
+    /// returned.
+    ///
+    /// [`ConnectionAborted`]: io::ErrorKind::ConnectionAborted
+    /// [`Interrupted`]: io::ErrorKind::Interrupted
+    ///
     /// # Examples
     ///
     /// ```no_run
@@ -901,6 +917,11 @@ impl TcpListener {
     /// The returned iterator will never return [`None`] and will also not yield
     /// the peer's [`SocketAddr`] structure. Iterating over it is equivalent to
     /// calling [`TcpListener::accept`] in a loop.
+    ///
+    /// # Errors
+    ///
+    /// Each connection yielded by the iterator can fail for the same reasons as
+    /// [`TcpListener::accept`]; see its documentation for details.
     ///
     /// # Examples
     ///
@@ -936,6 +957,11 @@ impl TcpListener {
     /// The returned iterator will never return [`None`] and will also not yield
     /// the peer's [`SocketAddr`] structure. Iterating over it is equivalent to
     /// calling [`TcpListener::accept`] in a loop.
+    ///
+    /// # Errors
+    ///
+    /// Each connection yielded by the iterator can fail for the same reasons as
+    /// [`TcpListener::accept`]; see its documentation for details.
     ///
     /// # Examples
     ///

--- a/library/std/src/net/tcp.rs
+++ b/library/std/src/net/tcp.rs
@@ -889,11 +889,14 @@ impl TcpListener {
     /// - An error from reaching the per-process or system-wide open file
     ///   descriptor limit. The call can be retried once other file descriptors
     ///   have been closed, typically after a short delay.
+    /// - An error from failing to allocate memory while accepting a connection
+    ///   ([`OutOfMemory`]).
     ///
     /// Which errors can occur is platform-specific. On Unix, [`Interrupted`]
     /// errors are retried internally rather than being returned.
     ///
     /// [`ConnectionAborted`]: io::ErrorKind::ConnectionAborted
+    /// [`OutOfMemory`]: io::ErrorKind::OutOfMemory
     /// [`Interrupted`]: io::ErrorKind::Interrupted
     ///
     /// # Examples


### PR DESCRIPTION
`TcpListener::accept` can return an error that belongs to a single incoming
connection, not to the listener, for example a connection aborted by the peer
before it could be accepted (`ConnectionAborted`). The listener stays usable, so
a server looping over connections usually wants to log the error and keep
accepting rather than treat it as fatal. This was not documented, and the
`incoming` example treated every error as a failed connection.

This implements the libs-team decision in rust-lang/rust#142557: document these transient
errors instead of changing `accept` to retry them, since retrying would hide
errors that some callers want to observe.

Changes:
- Add an `# Errors` section to `accept` describing this behavior, without
  listing specific error codes since some may be more permanent than others.
- Note that `Interrupted` errors are retried internally on Unix.
- Add the same pointer to `incoming` and `into_incoming`, which are `accept`
  in a loop.

Addresses rust-lang/rust#142557.

r? rust-lang/libs
