### PR TITLE
Point to the unstable segment of an import path instead of to the whole path

### DIFF
--- a/compiler/rustc_expand/src/base.rs
+++ b/compiler/rustc_expand/src/base.rs
@@ -1376,7 +1376,7 @@ impl<'a> ExtCtxt<'a> {
     pub fn std_path(&self, components: &[Symbol]) -> Vec<Ident> {
         let def_site = self.with_def_site_ctxt(DUMMY_SP);
         iter::once(Ident::new(kw::DollarCrate, def_site))
-            .chain(components.iter().map(|&s| Ident::with_dummy_span(s)))
+            .chain(components.iter().map(|&s| Ident::new(s, def_site)))
             .collect()
     }
     pub fn def_site_path(&self, components: &[Symbol]) -> Vec<Ident> {

--- a/compiler/rustc_passes/src/stability.rs
+++ b/compiler/rustc_passes/src/stability.rs
@@ -818,7 +818,7 @@ impl<'tcx> Visitor<'tcx> for Checker<'tcx> {
                                 self.tcx.check_stability_allow_unstable(
                                     def_id,
                                     None,
-                                    path.span,
+                                    path_segment.ident.span,
                                     None,
                                     if is_unstable_reexport(self.tcx, id) {
                                         AllowUnstable::Yes

--- a/tests/ui/feature-gates/feature-gate-io_error_kind_in_core.stderr
+++ b/tests/ui/feature-gates/feature-gate-io_error_kind_in_core.stderr
@@ -1,8 +1,8 @@
 error[E0658]: use of unstable library feature `core_io`
-  --> $DIR/feature-gate-io_error_kind_in_core.rs:6:5
+  --> $DIR/feature-gate-io_error_kind_in_core.rs:6:11
    |
 LL | use core::io::ErrorKind as ErrorKindFromCore;
-   |     ^^^^^^^^^^^^^^^^^^^
+   |           ^^
    |
    = note: see issue #154046 <https://github.com/rust-lang/rust/issues/154046> for more information
    = help: add `#![feature(core_io)]` to the crate attributes to enable

--- a/tests/ui/lint/lint-output-format.stderr
+++ b/tests/ui/lint/lint-output-format.stderr
@@ -8,10 +8,10 @@ LL | extern crate lint_output_format;
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature `unstable_test_feature`
-  --> $DIR/lint-output-format.rs:7:26
+  --> $DIR/lint-output-format.rs:7:5
    |
 LL | use lint_output_format::{foo, bar};
-   |                          ^^^
+   |     ^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date

--- a/tests/ui/lint/lint-stability.stderr
+++ b/tests/ui/lint/lint-stability.stderr
@@ -335,7 +335,7 @@ error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability.rs:194:9
    |
 LL |         unstable_mod::deprecated();
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
@@ -362,7 +362,7 @@ error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability.rs:198:17
    |
 LL |         let _ = Unstable::StableVariant;
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^
+   |                 ^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date

--- a/tests/ui/stability-attribute/allowed-through-unstable.stderr
+++ b/tests/ui/stability-attribute/allowed-through-unstable.stderr
@@ -7,10 +7,10 @@ LL | use allowed_through_unstable_core::unstable_module::OldStableTraitAllowedTh
    = note: `#[warn(deprecated)]` on by default
 
 error[E0658]: use of unstable library feature `unstable_test_feature`
-  --> $DIR/allowed-through-unstable.rs:9:5
+  --> $DIR/allowed-through-unstable.rs:9:36
    |
 LL | use allowed_through_unstable_core::unstable_module::NewStableTraitNotAllowedThroughUnstable;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                    ^^^^^^^^^^^^^^^
    |
    = note: see issue #1 <https://github.com/rust-lang/rust/issues/1> for more information
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable

--- a/tests/ui/stability-attribute/stable-in-unstable.stderr
+++ b/tests/ui/stability-attribute/stable-in-unstable.stderr
@@ -9,40 +9,40 @@ LL |     use stable_in_unstable_core::new_unstable_module;
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature `unstable_test_feature`
-  --> $DIR/stable-in-unstable.rs:17:9
+  --> $DIR/stable-in-unstable.rs:17:34
    |
 LL |     use stable_in_unstable_core::new_unstable_module::OldTrait;
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                  ^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #1 <https://github.com/rust-lang/rust/issues/1> for more information
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature `unstable_test_feature`
-  --> $DIR/stable-in-unstable.rs:29:9
+  --> $DIR/stable-in-unstable.rs:29:34
    |
 LL |     use stable_in_unstable_core::new_unstable_module::OldTrait;
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                  ^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #1 <https://github.com/rust-lang/rust/issues/1> for more information
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature `unstable_test_feature`
-  --> $DIR/stable-in-unstable.rs:39:10
+  --> $DIR/stable-in-unstable.rs:39:35
    |
 LL |     impl stable_in_unstable_core::new_unstable_module::OldTrait for LocalType {}
-   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                   ^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #1 <https://github.com/rust-lang/rust/issues/1> for more information
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature `unstable_test_feature`
-  --> $DIR/stable-in-unstable.rs:49:56
+  --> $DIR/stable-in-unstable.rs:49:34
    |
 LL |     use stable_in_unstable_core::new_unstable_module::{OldTrait};
-   |                                                        ^^^^^^^^
+   |                                  ^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #1 <https://github.com/rust-lang/rust/issues/1> for more information
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable


### PR DESCRIPTION
Brought to you by me being confused why a stable item reported an instability error.