### PR TITLE
rustdoc-json-types: Replace bincode dev-dependency with postcard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -785,6 +785,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.17",
+]
+
+[[package]]
 name = "codespan-reporting"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1329,6 +1338,18 @@ checksum = "9abf33c656a7256451ebb7d0082c5a471820c31269e49d807c538c252352186e"
 dependencies = [
  "stable_deref_trait",
 ]
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "ena"
@@ -3053,6 +3074,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
 dependencies = [
  "portable-atomic",
+]
+
+[[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "serde",
 ]
 
 [[package]]
@@ -4978,7 +5011,7 @@ dependencies = [
 name = "rustdoc-json-types"
 version = "0.1.0"
 dependencies = [
- "bincode",
+ "postcard",
  "rkyv",
  "rustc-hash 2.1.1",
  "serde",

--- a/src/rustdoc-json-types/Cargo.toml
+++ b/src/rustdoc-json-types/Cargo.toml
@@ -18,4 +18,4 @@ rkyv = { version = "0.8", optional = true }
 
 [dev-dependencies]
 serde_json = "1.0"
-bincode = "1"
+postcard = { version = "1", default-features = false, features = ["alloc"] }

--- a/src/rustdoc-json-types/tests.rs
+++ b/src/rustdoc-json-types/tests.rs
@@ -13,9 +13,9 @@ fn test_struct_info_roundtrip() {
     let de_s = serde_json::from_str(&struct_json).unwrap();
     assert_eq!(s, de_s);
 
-    // Bincode
-    let encoded: Vec<u8> = bincode::serialize(&s).unwrap();
-    let decoded: ItemEnum = bincode::deserialize(&encoded).unwrap();
+    // Postcard
+    let encoded: Vec<u8> = postcard::to_allocvec(&s).unwrap();
+    let decoded: ItemEnum = postcard::from_bytes(&encoded).unwrap();
     assert_eq!(s, decoded);
 }
 
@@ -33,9 +33,9 @@ fn test_union_info_roundtrip() {
     let de_u = serde_json::from_str(&union_json).unwrap();
     assert_eq!(u, de_u);
 
-    // Bincode
-    let encoded: Vec<u8> = bincode::serialize(&u).unwrap();
-    let decoded: ItemEnum = bincode::deserialize(&encoded).unwrap();
+    // Postcard
+    let encoded: Vec<u8> = postcard::to_allocvec(&u).unwrap();
+    let decoded: ItemEnum = postcard::from_bytes(&encoded).unwrap();
     assert_eq!(u, decoded);
 }
 
@@ -59,7 +59,7 @@ mod rkyv {
     /// A test to exercise the (de)serialization roundtrip for a representative selection of types,
     /// covering most of the rkyv-specific attributes we had to had.
     fn test_rkyv_roundtrip() {
-        // Standard derives: a plain struct and union, mirroring the existing serde/bincode tests.
+        // Standard derives: a plain struct and union, mirroring the existing serde/postcard tests.
         let s = ItemEnum::Struct(Struct {
             generics: Generics { params: vec![], where_predicates: vec![] },
             kind: StructKind::Plain { fields: vec![Id(1), Id(2)], has_stripped_fields: false },


### PR DESCRIPTION
bincode is flagged as unmaintained by [RUSTSEC-2025-0141](https://rustsec.org/advisories/RUSTSEC-2025-0141), and the advisory covers the entire crate with no patched version available. The only use in `rustdoc-json-types` was the binary serde roundtrip in the type tests.

[postcard](https://crates.io/crates/postcard) is a maintained serde-based binary serialization format that covers the same roundtrip testing need.

bincode is still pulled in transitively by the miri subtree (via `ipc-channel`), which needs to be [addressed upstream](https://github.com/rust-lang/miri/pull/5115).

### Related

- https://github.com/rust-lang/miri/pull/5115