### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
       run_type: ${{ steps.jobs.outputs.run_type }}
     steps:
       - name: Checkout the source code
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Test citool
         # Only test citool on the auto branch, to reduce latency of the calculate matrix job
         # on PR/try builds.
@@ -117,7 +117,7 @@ jobs:
         run: git config --global core.autocrlf false
 
       - name: checkout the source code
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 2
 
@@ -315,7 +315,7 @@ jobs:
     environment: ${{ (github.repository == 'rust-lang/rust' && 'bors') || '' }}
     steps:
       - name: checkout the source code
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 2
       # Publish the toolstate if an auto build succeeds (just before push to the default branch)

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: checkout the source code
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           submodules: recursive
       - name: install the bootstrap toolchain
@@ -91,7 +91,7 @@ jobs:
       pull-requests: write
     steps:
       - name: checkout the source code
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: download Cargo.lock from update job
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -29,7 +29,7 @@ jobs:
       # Needed to write to the ghcr.io registry
       packages: write
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
 

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -15,7 +15,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           # Make sure that we have enough commits to find the parent merge commit.
           # Since all merges should be through merge commits, fetching two commits

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -785,6 +785,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.17",
+]
+
+[[package]]
 name = "codespan-reporting"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1329,6 +1338,18 @@ checksum = "9abf33c656a7256451ebb7d0082c5a471820c31269e49d807c538c252352186e"
 dependencies = [
  "stable_deref_trait",
 ]
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "ena"
@@ -3053,6 +3074,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
 dependencies = [
  "portable-atomic",
+]
+
+[[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "serde",
 ]
 
 [[package]]
@@ -4978,7 +5011,7 @@ dependencies = [
 name = "rustdoc-json-types"
 version = "0.1.0"
 dependencies = [
- "bincode",
+ "postcard",
  "rkyv",
  "rustc-hash 2.1.1",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5554,9 +5554,9 @@ dependencies = [
 
 [[package]]
 name = "thin-vec"
-version = "0.2.15"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da322882471314edc77fa5232c587bcb87c9df52bfd0d7d4826f8868ead61899"
+checksum = "b0f7e269b48f0a7dd0146680fa24b50cc67fc0373f086a5b2f99bd084639b482"
 
 [[package]]
 name = "thiserror"

--- a/compiler/rustc_ast/Cargo.toml
+++ b/compiler/rustc_ast/Cargo.toml
@@ -15,6 +15,6 @@ rustc_macros = { path = "../rustc_macros" }
 rustc_serialize = { path = "../rustc_serialize" }
 rustc_span = { path = "../rustc_span" }
 smallvec = { version = "1.8.1", features = ["union", "may_dangle"] }
-thin-vec = "0.2.15"
+thin-vec = "0.2.18"
 tracing = "0.1"
 # tidy-alphabetical-end

--- a/compiler/rustc_ast_lowering/Cargo.toml
+++ b/compiler/rustc_ast_lowering/Cargo.toml
@@ -22,6 +22,6 @@ rustc_session = { path = "../rustc_session" }
 rustc_span = { path = "../rustc_span" }
 rustc_target = { path = "../rustc_target" }
 smallvec = { version = "1.8.1", features = ["union", "may_dangle"] }
-thin-vec = "0.2.15"
+thin-vec = "0.2.18"
 tracing = "0.1"
 # tidy-alphabetical-end

--- a/compiler/rustc_ast_passes/Cargo.toml
+++ b/compiler/rustc_ast_passes/Cargo.toml
@@ -18,5 +18,5 @@ rustc_macros = { path = "../rustc_macros" }
 rustc_session = { path = "../rustc_session" }
 rustc_span = { path = "../rustc_span" }
 rustc_target = { path = "../rustc_target" }
-thin-vec = "0.2.15"
+thin-vec = "0.2.18"
 # tidy-alphabetical-end

--- a/compiler/rustc_ast_pretty/Cargo.toml
+++ b/compiler/rustc_ast_pretty/Cargo.toml
@@ -13,5 +13,5 @@ rustc_span = { path = "../rustc_span" }
 
 [dev-dependencies]
 # tidy-alphabetical-start
-thin-vec = "0.2.15"
+thin-vec = "0.2.18"
 # tidy-alphabetical-end

--- a/compiler/rustc_attr_parsing/Cargo.toml
+++ b/compiler/rustc_attr_parsing/Cargo.toml
@@ -20,5 +20,5 @@ rustc_parse_format = { path = "../rustc_parse_format" }
 rustc_session = { path = "../rustc_session" }
 rustc_span = { path = "../rustc_span" }
 rustc_target = { path = "../rustc_target" }
-thin-vec = "0.2.15"
+thin-vec = "0.2.18"
 # tidy-alphabetical-end

--- a/compiler/rustc_builtin_macros/Cargo.toml
+++ b/compiler/rustc_builtin_macros/Cargo.toml
@@ -29,7 +29,7 @@ rustc_session = { path = "../rustc_session" }
 rustc_span = { path = "../rustc_span" }
 rustc_target = { path = "../rustc_target" }
 smallvec = { version = "1.8.1", features = ["union", "may_dangle"] }
-thin-vec = "0.2.15"
+thin-vec = "0.2.18"
 tracing = "0.1"
 # tidy-alphabetical-end
 

--- a/compiler/rustc_data_structures/Cargo.toml
+++ b/compiler/rustc_data_structures/Cargo.toml
@@ -30,7 +30,7 @@ smallvec = { version = "1.8.1", features = [
 ] }
 stacker = "0.1.17"
 tempfile = "3.2"
-thin-vec = "0.2.15"
+thin-vec = "0.2.18"
 tracing = "0.1"
 # tidy-alphabetical-end
 

--- a/compiler/rustc_expand/Cargo.toml
+++ b/compiler/rustc_expand/Cargo.toml
@@ -30,6 +30,6 @@ rustc_session = { path = "../rustc_session" }
 rustc_span = { path = "../rustc_span" }
 scoped-tls = "1.0"
 smallvec = { version = "1.8.1", features = ["union", "may_dangle"] }
-thin-vec = "0.2.15"
+thin-vec = "0.2.18"
 tracing = "0.1"
 # tidy-alphabetical-end

--- a/compiler/rustc_hir/Cargo.toml
+++ b/compiler/rustc_hir/Cargo.toml
@@ -23,6 +23,6 @@ rustc_serialize = { path = "../rustc_serialize" }
 rustc_span = { path = "../rustc_span" }
 rustc_target = { path = "../rustc_target" }
 smallvec = { version = "1.8.1", features = ["union", "may_dangle"] }
-thin-vec = "0.2.15"
+thin-vec = "0.2.18"
 tracing = "0.1"
 # tidy-alphabetical-end

--- a/compiler/rustc_infer/Cargo.toml
+++ b/compiler/rustc_infer/Cargo.toml
@@ -17,6 +17,6 @@ rustc_middle = { path = "../rustc_middle" }
 rustc_span = { path = "../rustc_span" }
 rustc_type_ir = { path = "../rustc_type_ir" }
 smallvec = { version = "1.8.1", features = ["union", "may_dangle"] }
-thin-vec = "0.2.15"
+thin-vec = "0.2.18"
 tracing = "0.1"
 # tidy-alphabetical-end

--- a/compiler/rustc_metadata/src/rmeta/decoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder.rs
@@ -1274,6 +1274,10 @@ impl CrateMetadata {
     /// including both proper items and reexports.
     /// Module here is understood in name resolution sense - it can be a `mod` item,
     /// or a crate root, or an enum, or a trait.
+    ///
+    /// # Panics
+    ///
+    /// May panic if the provided `id` does not refer to a module.
     fn get_module_children(&self, tcx: TyCtxt<'_>, id: DefIndex) -> impl Iterator<Item = ModChild> {
         gen move {
             if let Some(data) = &self.root.proc_macro_data {
@@ -1287,7 +1291,9 @@ impl CrateMetadata {
             } else {
                 // Iterate over all children.
                 let non_reexports = self.root.tables.module_children_non_reexports.get(self, id);
-                for child_index in non_reexports.unwrap().decode((self, tcx)) {
+                let non_reexports =
+                    non_reexports.expect("provided `DefIndex` must refer to a module-like item");
+                for child_index in non_reexports.decode((self, tcx)) {
                     yield self.get_mod_child(tcx, child_index);
                 }
 

--- a/compiler/rustc_middle/Cargo.toml
+++ b/compiler/rustc_middle/Cargo.toml
@@ -33,7 +33,7 @@ rustc_target = { path = "../rustc_target" }
 rustc_thread_pool = { path = "../rustc_thread_pool" }
 rustc_type_ir = { path = "../rustc_type_ir" }
 smallvec = { version = "1.8.1", features = ["union", "may_dangle"] }
-thin-vec = "0.2.15"
+thin-vec = "0.2.18"
 tracing = "0.1"
 # tidy-alphabetical-end
 

--- a/compiler/rustc_middle/src/queries.rs
+++ b/compiler/rustc_middle/src/queries.rs
@@ -2161,6 +2161,15 @@ rustc_queries! {
         desc { "fetching what a crate is named" }
         separate_provide_extern
     }
+
+    /// Iterates over all named children of the given module,
+    /// including both proper items and reexports.
+    /// Module here is understood in name resolution sense - it can be a `mod` item,
+    /// or a crate root, or an enum, or a trait.
+    ///
+    /// # Panics
+    ///
+    /// May panic if the provided `id` does not refer to a module.
     query module_children(def_id: DefId) -> &'tcx [ModChild] {
         desc { "collecting child items of module `{}`", tcx.def_path_str(def_id) }
         separate_provide_extern

--- a/compiler/rustc_parse/Cargo.toml
+++ b/compiler/rustc_parse/Cargo.toml
@@ -17,7 +17,7 @@ rustc_lexer = { path = "../rustc_lexer" }
 rustc_macros = { path = "../rustc_macros" }
 rustc_session = { path = "../rustc_session" }
 rustc_span = { path = "../rustc_span" }
-thin-vec = "0.2.15"
+thin-vec = "0.2.18"
 tracing = "0.1"
 unicode-normalization = "0.1.25"
 unicode-width = "0.2.2"

--- a/compiler/rustc_resolve/Cargo.toml
+++ b/compiler/rustc_resolve/Cargo.toml
@@ -26,6 +26,6 @@ rustc_middle = { path = "../rustc_middle" }
 rustc_session = { path = "../rustc_session" }
 rustc_span = { path = "../rustc_span" }
 smallvec = { version = "1.8.1", features = ["union", "may_dangle"] }
-thin-vec = "0.2.15"
+thin-vec = "0.2.18"
 tracing = "0.1"
 # tidy-alphabetical-end

--- a/compiler/rustc_serialize/Cargo.toml
+++ b/compiler/rustc_serialize/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2024"
 indexmap = "2.0.0"
 rustc_hashes = { path = "../rustc_hashes" }
 smallvec = { version = "1.8.1", features = ["union", "may_dangle"] }
-thin-vec = "0.2.15"
+thin-vec = "0.2.18"
 # tidy-alphabetical-end
 
 [dev-dependencies]

--- a/compiler/rustc_trait_selection/Cargo.toml
+++ b/compiler/rustc_trait_selection/Cargo.toml
@@ -19,6 +19,6 @@ rustc_session = { path = "../rustc_session" }
 rustc_span = { path = "../rustc_span" }
 rustc_transmute = { path = "../rustc_transmute", features = ["rustc"] }
 smallvec = { version = "1.8.1", features = ["union", "may_dangle"] }
-thin-vec = "0.2.15"
+thin-vec = "0.2.18"
 tracing = "0.1"
 # tidy-alphabetical-end

--- a/compiler/rustc_type_ir/Cargo.toml
+++ b/compiler/rustc_type_ir/Cargo.toml
@@ -23,7 +23,7 @@ rustc_type_ir_macros = { path = "../rustc_type_ir_macros" }
 smallvec = { version = "1.8.1", default-features = false, features = [
     "const_generics",
 ] }
-thin-vec = "0.2.15"
+thin-vec = "0.2.18"
 tracing = "0.1"
 # tidy-alphabetical-end
 

--- a/library/proc_macro/src/lib.rs
+++ b/library/proc_macro/src/lib.rs
@@ -197,6 +197,7 @@ impl fmt::Display for EscapeError {
 /// Errors returned when trying to retrieve a literal unescaped value.
 #[unstable(feature = "proc_macro_value", issue = "136652")]
 #[derive(Debug, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum ConversionErrorKind {
     /// The literal failed to be escaped, take a look at [`EscapeError`] for more information.
     FailedToUnescape(EscapeError),

--- a/src/rustdoc-json-types/Cargo.toml
+++ b/src/rustdoc-json-types/Cargo.toml
@@ -18,4 +18,4 @@ rkyv = { version = "0.8", optional = true }
 
 [dev-dependencies]
 serde_json = "1.0"
-bincode = "1"
+postcard = { version = "1", default-features = false, features = ["alloc"] }

--- a/src/rustdoc-json-types/tests.rs
+++ b/src/rustdoc-json-types/tests.rs
@@ -13,9 +13,9 @@ fn test_struct_info_roundtrip() {
     let de_s = serde_json::from_str(&struct_json).unwrap();
     assert_eq!(s, de_s);
 
-    // Bincode
-    let encoded: Vec<u8> = bincode::serialize(&s).unwrap();
-    let decoded: ItemEnum = bincode::deserialize(&encoded).unwrap();
+    // Postcard
+    let encoded: Vec<u8> = postcard::to_allocvec(&s).unwrap();
+    let decoded: ItemEnum = postcard::from_bytes(&encoded).unwrap();
     assert_eq!(s, decoded);
 }
 
@@ -33,9 +33,9 @@ fn test_union_info_roundtrip() {
     let de_u = serde_json::from_str(&union_json).unwrap();
     assert_eq!(u, de_u);
 
-    // Bincode
-    let encoded: Vec<u8> = bincode::serialize(&u).unwrap();
-    let decoded: ItemEnum = bincode::deserialize(&encoded).unwrap();
+    // Postcard
+    let encoded: Vec<u8> = postcard::to_allocvec(&u).unwrap();
+    let decoded: ItemEnum = postcard::from_bytes(&encoded).unwrap();
     assert_eq!(u, decoded);
 }
 
@@ -59,7 +59,7 @@ mod rkyv {
     /// A test to exercise the (de)serialization roundtrip for a representative selection of types,
     /// covering most of the rkyv-specific attributes we had to had.
     fn test_rkyv_roundtrip() {
-        // Standard derives: a plain struct and union, mirroring the existing serde/bincode tests.
+        // Standard derives: a plain struct and union, mirroring the existing serde/postcard tests.
         let s = ItemEnum::Struct(Struct {
             generics: Generics { params: vec![], where_predicates: vec![] },
             kind: StructKind::Plain { fields: vec![Id(1), Id(2)], has_stripped_fields: false },


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#157935 (Make `proc_macro::ConversionErrorKind` non exhaustive)
 - rust-lang/rust#158002 (Replace `unwrap` with `expect` in `get_module_children`)
 - rust-lang/rust#158071 (Update actions/checkout action to v6)
 - rust-lang/rust#158072 (Bump thin-vec to 0.2.18 to address RUSTSEC-2026-0103)
 - rust-lang/rust#158077 (rustdoc-json-types: Replace bincode dev-dependency with postcard)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=157935,158002,158071,158072,158077)
<!-- homu-ignore:end -->

