### PR TITLE
trait-system: Recover deferred closure calls after errors

### DIFF
--- a/compiler/rustc_hir_typeck/src/callee.rs
+++ b/compiler/rustc_hir_typeck/src/callee.rs
@@ -9,11 +9,11 @@ use rustc_hir::{self as hir, HirId, LangItem, find_attr};
 use rustc_hir_analysis::autoderef::Autoderef;
 use rustc_infer::infer::BoundRegionConversionTime;
 use rustc_infer::traits::{Obligation, ObligationCause, ObligationCauseCode};
+use rustc_middle::bug;
 use rustc_middle::ty::adjustment::{
     Adjust, Adjustment, AllowTwoPhase, AutoBorrow, AutoBorrowMutability,
 };
 use rustc_middle::ty::{self, FnSig, GenericArgsRef, Ty, TyCtxt, TypeVisitableExt, Unnormalized};
-use rustc_middle::{bug, span_bug};
 use rustc_span::def_id::LocalDefId;
 use rustc_span::{Ident, Span, sym};
 use rustc_target::spec::{AbiMap, AbiMapping};
@@ -1161,11 +1161,16 @@ impl<'a, 'tcx> DeferredCallResolution<'tcx> {
                 );
             }
             None => {
-                span_bug!(
-                    self.call_expr.span,
-                    "Expected to find a suitable `Fn`/`FnMut`/`FnOnce` implementation for `{}`",
-                    self.closure_ty
-                )
+                let guar = fcx.tainted_by_errors().unwrap_or_else(|| {
+                    fcx.dcx().span_delayed_bug(
+                        self.call_expr.span,
+                        format!(
+                            "Expected to find a suitable `Fn`/`FnMut`/`FnOnce` implementation for `{}`",
+                            self.closure_ty
+                        ),
+                    )
+                });
+                fcx.write_resolution(self.call_expr.hir_id, Err(guar));
             }
         }
     }

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
@@ -2555,6 +2555,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         err.children.clear();
 
         let mut span = obligation.cause.span;
+        let mut is_async_fn_return = false;
         if let DefKind::Closure = self.tcx.def_kind(obligation.cause.body_id)
             && let parent = self.tcx.local_parent(obligation.cause.body_id)
             && let DefKind::Fn | DefKind::AssocFn = self.tcx.def_kind(parent)
@@ -2570,9 +2571,18 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             // and
             // async fn foo() -> dyn Display Box<dyn { .. }>
             span = fn_sig.decl.output.span();
+            is_async_fn_return = true;
             err.span(span);
         }
         let body = self.tcx.hir_body_owned_by(obligation.cause.body_id);
+
+        if !is_async_fn_return
+            && let Node::Expr(hir::Expr { kind: hir::ExprKind::Closure(closure), .. }) =
+                self.tcx.hir_node_by_def_id(obligation.cause.body_id)
+            && matches!(closure.fn_decl.output, hir::FnRetTy::DefaultReturn(_))
+        {
+            return true;
+        }
 
         let mut visitor = ReturnsVisitor::default();
         visitor.visit_body(&body);

--- a/tests/ui/traits/next-solver/deferred-closure-call-recovery-issue-157951.rs
+++ b/tests/ui/traits/next-solver/deferred-closure-call-recovery-issue-157951.rs
@@ -1,0 +1,10 @@
+//@ compile-flags: -Znext-solver=globally
+//@ check-fail
+
+fn main() {
+    let f = |f: dyn Fn()| f;
+    //~^ ERROR the size for values of type `(dyn Fn() + 'static)` cannot be known at compilation time
+    //~| ERROR return type cannot be a trait object without pointer indirection
+    f();
+    //~^ ERROR this function takes 1 argument but 0 arguments were supplied
+}

--- a/tests/ui/traits/next-solver/deferred-closure-call-recovery-issue-157951.stderr
+++ b/tests/ui/traits/next-solver/deferred-closure-call-recovery-issue-157951.stderr
@@ -1,0 +1,39 @@
+error[E0277]: the size for values of type `(dyn Fn() + 'static)` cannot be known at compilation time
+  --> $DIR/deferred-closure-call-recovery-issue-157951.rs:5:17
+   |
+LL |     let f = |f: dyn Fn()| f;
+   |                 ^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `(dyn Fn() + 'static)`
+   = help: unsized fn params are gated as an unstable feature
+help: function arguments must have a statically known size, borrowed types always have a known size
+   |
+LL |     let f = |f: &dyn Fn()| f;
+   |                 +
+
+error[E0746]: return type cannot be a trait object without pointer indirection
+  --> $DIR/deferred-closure-call-recovery-issue-157951.rs:5:27
+   |
+LL |     let f = |f: dyn Fn()| f;
+   |                           ^ doesn't have a size known at compile-time
+
+error[E0057]: this function takes 1 argument but 0 arguments were supplied
+  --> $DIR/deferred-closure-call-recovery-issue-157951.rs:8:5
+   |
+LL |     f();
+   |     ^-- argument #1 of type `(dyn Fn() + 'static)` is missing
+   |
+note: closure defined here
+  --> $DIR/deferred-closure-call-recovery-issue-157951.rs:5:13
+   |
+LL |     let f = |f: dyn Fn()| f;
+   |             ^^^^^^^^^^^^^
+help: provide the argument
+   |
+LL |     f(/* (dyn Fn() + 'static) */);
+   |       ++++++++++++++++++++++++++
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0057, E0277, E0746.
+For more information about an error, try `rustc --explain E0057`.


### PR DESCRIPTION
fixes rust-lang/rust#157951

this already reported the right errors, then typeck kept going and hit the deferred closure call path. that path assumed it could always find a fn trait impl after closure kind inference. with this repro, the earlier errors mean that lookup can fail, so it should recover instead of iceing.

i think keeping this as recovery is the least surprising fix here. the compiler has already told the user what's wrong, so turning the later invariant into another hard failure doesn't buy much.

also drops the weird e0746 help for this closure case. there's no written ret ty to edit, so suggestions like \impl f\ or \ox<dyn box::new(f)>\ were just noise. added the next-solver ui test for the repro.