### PR TITLE
renovate: Loosen dashboard approval and adopt recommended config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,6 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
+    // Open a PR to migrate the config when Renovate deprecates syntax
+    ":configMigration",
     // Refresh lock files on the first day of each month
     // (still gated by dashboard approval for now)
     ":maintainLockFilesMonthly",

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
+    "config:recommended",
     // Refresh lock files on the first day of each month
     // (still gated by dashboard approval for now)
     ":maintainLockFilesMonthly",
@@ -8,8 +9,6 @@
     // (e.g. `v4`) to the full SemVer version (e.g. `v4.1.2`)
     "helpers:pinGitHubActionDigestsToSemver"
   ],
-  // Let Renovatebot keep an opened issue that tracks our dependencies
-  "dependencyDashboard": true,
   // Require manual approval from the Dependency Dashboard before opening PRs
   "dependencyDashboardApproval": true,
   "packageRules": [

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
+    // Refresh lock files on the first day of each month
+    // (still gated by dashboard approval for now)
+    ":maintainLockFilesMonthly",
     // Pin GitHub Actions to their commit SHA digests, resolving floating tags
     // (e.g. `v4`) to the full SemVer version (e.g. `v4.1.2`)
     "helpers:pinGitHubActionDigestsToSemver"

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -9,6 +9,13 @@
   "dependencyDashboard": true,
   // Require manual approval from the Dependency Dashboard before opening PRs
   "dependencyDashboardApproval": true,
+  "packageRules": [
+    {
+      // No dashboard approval necessary for GitHub Actions updates
+      "matchManagers": ["github-actions"],
+      "dependencyDashboardApproval": false
+    }
+  ],
   // Don't manage dependencies inside subtrees. They are updated upstream and
   // synced in. See `src/doc/rustc-dev-guide/src/external-repos.md` for the list.
   "ignorePaths": [


### PR DESCRIPTION
Follow-up tweaks to the Renovate config now that the GitHub Actions setup has proven stable.

- GitHub Actions updates no longer need Dependency Dashboard approval. The gate was added while we dialed in the config, and the `github-actions` manager now works well enough for those PRs to open on their own. Everything else still requires approval.
- Monthly lock file maintenance is now enabled. It stays behind dashboard approval for the time being.
- The config extends [`config:recommended`](https://docs.renovatebot.com/presets-config/#configrecommended), which brings changelog links, sensible grouping, `replacements` and `workarounds`. That makes the previously explicit `dependencyDashboard: true` redundant, so it's gone.
- Config migration PRs are enabled so Renovate can keep the config up to date as options get deprecated.
