### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/compiler/rustc_hir_typeck/src/expr_use_visitor.rs
+++ b/compiler/rustc_hir_typeck/src/expr_use_visitor.rs
@@ -727,7 +727,8 @@ impl<'tcx, Cx: TypeInformationCtxt<'tcx>, D: Delegate<'tcx>> ExprUseVisitor<'tcx
         let typeck_results = self.cx.typeck_results();
         let adjustments = typeck_results.expr_adjustments(expr);
         let mut place_with_id = self.cat_expr_unadjusted(expr)?;
-        for adjustment in adjustments {
+        for (adjustment_index, adjustment) in adjustments.iter().enumerate() {
+            let is_last_adjustment = adjustment_index + 1 == adjustments.len();
             debug!("walk_adjustment expr={:?} adj={:?}", expr, adjustment);
             match adjustment.kind {
                 adjustment::Adjust::NeverToAny | adjustment::Adjust::Pointer(_) => {
@@ -752,13 +753,13 @@ impl<'tcx, Cx: TypeInformationCtxt<'tcx>, D: Delegate<'tcx>> ExprUseVisitor<'tcx
                     self.walk_autoref(expr, &place_with_id, autoref);
                 }
 
-                adjustment::Adjust::GenericReborrow(_reborrow) => {
-                    // To build an expression as a place expression, it needs to be a field
-                    // projection or deref at the outmost layer. So it is field projection or deref
-                    // on an adjusted value. But this means that adjustment is applied on a
-                    // subexpression that is not the final operand/rvalue for function call or
-                    // assignment. This is a contradiction.
-                    unreachable!("Reborrow trait usage during adjustment walk");
+                adjustment::Adjust::GenericReborrow(mutability) if is_last_adjustment => {
+                    let bk = ty::BorrowKind::from_mutbl(mutability);
+                    self.delegate.borrow_mut().borrow(&place_with_id, place_with_id.hir_id, bk);
+                }
+
+                adjustment::Adjust::GenericReborrow(_) => {
+                    span_bug!(expr.span, "generic reborrow adjustment must be terminal");
                 }
             }
             place_with_id = self.cat_expr_adjusted(expr, place_with_id, adjustment)?;

--- a/compiler/rustc_middle/src/thir/visit.rs
+++ b/compiler/rustc_middle/src/thir/visit.rs
@@ -187,7 +187,9 @@ pub fn walk_expr<'thir, 'tcx: 'thir, V: Visitor<'thir, 'tcx>>(
         }
         ThreadLocalRef(_) => {}
         Yield { value } => visitor.visit_expr(&visitor.thir()[value]),
-        Reborrow { source, mutability: _, target: _ } => visitor.visit_expr(&visitor.thir()[source]),
+        Reborrow { source, mutability: _, target: _ } => {
+            visitor.visit_expr(&visitor.thir()[source])
+        }
     }
 }
 

--- a/compiler/rustc_middle/src/thir/visit.rs
+++ b/compiler/rustc_middle/src/thir/visit.rs
@@ -187,7 +187,7 @@ pub fn walk_expr<'thir, 'tcx: 'thir, V: Visitor<'thir, 'tcx>>(
         }
         ThreadLocalRef(_) => {}
         Yield { value } => visitor.visit_expr(&visitor.thir()[value]),
-        Reborrow { source, .. } => visitor.visit_expr(&visitor.thir()[source]),
+        Reborrow { source, mutability: _, target: _ } => visitor.visit_expr(&visitor.thir()[source]),
     }
 }
 

--- a/compiler/rustc_middle/src/thir/visit.rs
+++ b/compiler/rustc_middle/src/thir/visit.rs
@@ -187,7 +187,7 @@ pub fn walk_expr<'thir, 'tcx: 'thir, V: Visitor<'thir, 'tcx>>(
         }
         ThreadLocalRef(_) => {}
         Yield { value } => visitor.visit_expr(&visitor.thir()[value]),
-        Reborrow { .. } => {}
+        Reborrow { source, .. } => visitor.visit_expr(&visitor.thir()[source]),
     }
 }
 

--- a/library/std/src/net/tcp.rs
+++ b/library/std/src/net/tcp.rs
@@ -878,16 +878,20 @@ impl TcpListener {
     ///
     /// # Errors
     ///
-    /// Some errors returned by this function relate to a single incoming
-    /// connection that failed before it could be accepted, such as one aborted
-    /// by the peer ([`ConnectionAborted`]). Such an error does not indicate a
-    /// problem with the listener itself, which remains usable. Code serving a
-    /// long-lived listener will usually want to log the error and continue
-    /// accepting connections rather than treat it as fatal. Which errors can
-    /// occur this way is platform-specific.
+    /// Some errors this function returns do not indicate a problem with the
+    /// listener itself, and a program serving a long-lived listener will
+    /// usually want to handle them and keep accepting connections rather than
+    /// treat them as fatal. These include, but are not limited to:
     ///
-    /// On Unix, [`Interrupted`] errors are retried internally rather than being
-    /// returned.
+    /// - An error specific to a single incoming connection that failed before
+    ///   it could be accepted, such as one aborted by the peer
+    ///   ([`ConnectionAborted`]). A later call may succeed immediately.
+    /// - An error from reaching the per-process or system-wide open file
+    ///   descriptor limit. The call can be retried once other file descriptors
+    ///   have been closed, typically after a short delay.
+    ///
+    /// Which errors can occur is platform-specific. On Unix, [`Interrupted`]
+    /// errors are retried internally rather than being returned.
     ///
     /// [`ConnectionAborted`]: io::ErrorKind::ConnectionAborted
     /// [`Interrupted`]: io::ErrorKind::Interrupted

--- a/library/std/src/net/tcp.rs
+++ b/library/std/src/net/tcp.rs
@@ -876,6 +876,22 @@ impl TcpListener {
     /// is established. When established, the corresponding [`TcpStream`] and the
     /// remote peer's address will be returned.
     ///
+    /// # Errors
+    ///
+    /// Some errors returned by this function relate to a single incoming
+    /// connection that failed before it could be accepted, such as one aborted
+    /// by the peer ([`ConnectionAborted`]). Such an error does not indicate a
+    /// problem with the listener itself, which remains usable. Code serving a
+    /// long-lived listener will usually want to log the error and continue
+    /// accepting connections rather than treat it as fatal. Which errors can
+    /// occur this way is platform-specific.
+    ///
+    /// On Unix, [`Interrupted`] errors are retried internally rather than being
+    /// returned.
+    ///
+    /// [`ConnectionAborted`]: io::ErrorKind::ConnectionAborted
+    /// [`Interrupted`]: io::ErrorKind::Interrupted
+    ///
     /// # Examples
     ///
     /// ```no_run
@@ -901,6 +917,11 @@ impl TcpListener {
     /// The returned iterator will never return [`None`] and will also not yield
     /// the peer's [`SocketAddr`] structure. Iterating over it is equivalent to
     /// calling [`TcpListener::accept`] in a loop.
+    ///
+    /// # Errors
+    ///
+    /// Each connection yielded by the iterator can fail for the same reasons as
+    /// [`TcpListener::accept`]; see its documentation for details.
     ///
     /// # Examples
     ///
@@ -936,6 +957,11 @@ impl TcpListener {
     /// The returned iterator will never return [`None`] and will also not yield
     /// the peer's [`SocketAddr`] structure. Iterating over it is equivalent to
     /// calling [`TcpListener::accept`] in a loop.
+    ///
+    /// # Errors
+    ///
+    /// Each connection yielded by the iterator can fail for the same reasons as
+    /// [`TcpListener::accept`]; see its documentation for details.
     ///
     /// # Examples
     ///

--- a/library/std/src/net/tcp.rs
+++ b/library/std/src/net/tcp.rs
@@ -889,11 +889,14 @@ impl TcpListener {
     /// - An error from reaching the per-process or system-wide open file
     ///   descriptor limit. The call can be retried once other file descriptors
     ///   have been closed, typically after a short delay.
+    /// - An error from failing to allocate memory while accepting a connection
+    ///   ([`OutOfMemory`]).
     ///
     /// Which errors can occur is platform-specific. On Unix, [`Interrupted`]
     /// errors are retried internally rather than being returned.
     ///
     /// [`ConnectionAborted`]: io::ErrorKind::ConnectionAborted
+    /// [`OutOfMemory`]: io::ErrorKind::OutOfMemory
     /// [`Interrupted`]: io::ErrorKind::Interrupted
     ///
     /// # Examples

--- a/tests/ui/reborrow/generic-reborrow-expr-use-visitor-closure.rs
+++ b/tests/ui/reborrow/generic-reborrow-expr-use-visitor-closure.rs
@@ -1,0 +1,34 @@
+//@ check-pass
+
+#![feature(reborrow)]
+
+use std::marker::{CoerceShared, Reborrow};
+
+#[allow(unused)]
+struct CustomMut<'a, T>(&'a mut T);
+impl<'a, T> Reborrow for CustomMut<'a, T> {}
+impl<'a, T> CoerceShared<CustomRef<'a, T>> for CustomMut<'a, T> {}
+
+#[allow(unused)]
+struct CustomRef<'a, T>(&'a T);
+impl<'a, T> Clone for CustomRef<'a, T> {
+    fn clone(&self) -> Self {
+        Self(self.0)
+    }
+}
+impl<'a, T> Copy for CustomRef<'a, T> {}
+
+fn takes_mut(_: CustomMut<'_, ()>) {}
+fn takes_shared(_: CustomRef<'_, ()>) {}
+
+fn main() {
+    let a = CustomMut(&mut ());
+
+    let mut f = || {
+        takes_mut(a);
+        takes_shared(a);
+    };
+
+    f();
+    f();
+}

--- a/tests/ui/reborrow/generic-reborrow-expr-use-visitor.rs
+++ b/tests/ui/reborrow/generic-reborrow-expr-use-visitor.rs
@@ -1,0 +1,32 @@
+//@ check-pass
+
+#![feature(reborrow)]
+
+use std::marker::{CoerceShared, Reborrow};
+
+#[allow(unused)]
+struct CustomMut<'a, T>(&'a mut T);
+impl<'a, T> Reborrow for CustomMut<'a, T> {}
+impl<'a, T> CoerceShared<CustomRef<'a, T>> for CustomMut<'a, T> {}
+
+#[allow(unused)]
+struct CustomRef<'a, T>(&'a T);
+impl<'a, T> Clone for CustomRef<'a, T> {
+    fn clone(&self) -> Self {
+        Self(self.0)
+    }
+}
+impl<'a, T> Copy for CustomRef<'a, T> {}
+
+fn takes_mut(_: CustomMut<'_, ()>) {}
+fn takes_shared(_: CustomRef<'_, ()>) {}
+
+fn main() {
+    let a = CustomMut(&mut ());
+
+    takes_mut(a);
+    takes_mut(a);
+
+    takes_shared(a);
+    takes_shared(a);
+}

--- a/tests/ui/reborrow/reborrow-source-unsafety.rs
+++ b/tests/ui/reborrow/reborrow-source-unsafety.rs
@@ -1,0 +1,28 @@
+// Regression test for rust-lang/rust#158033.
+
+#![feature(reborrow)]
+#![allow(dead_code)]
+#![deny(unsafe_code)]
+
+use std::marker::Reborrow;
+
+struct Thing<'a> {
+    field: &'a mut usize,
+}
+
+impl<'a> Reborrow for Thing<'a> {}
+
+fn takes(_: Thing<'_>) {}
+
+fn main() {
+    let mut x = 0;
+    let thing = Thing { field: &mut x };
+    let y = 123usize;
+
+    takes({
+        let p: *const usize = &y;
+        std::hint::black_box(std::ptr::read(p));
+        //~^ ERROR call to unsafe function `std::ptr::read` is unsafe
+        thing
+    });
+}

--- a/tests/ui/reborrow/reborrow-source-unsafety.stderr
+++ b/tests/ui/reborrow/reborrow-source-unsafety.stderr
@@ -1,0 +1,11 @@
+error[E0133]: call to unsafe function `std::ptr::read` is unsafe and requires unsafe function or block
+  --> $DIR/reborrow-source-unsafety.rs:24:30
+   |
+LL |         std::hint::black_box(std::ptr::read(p));
+   |                              ^^^^^^^^^^^^^^^^^ call to unsafe function
+   |
+   = note: consult the function's documentation for information on how to avoid undefined behavior
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0133`.


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#156795 (Handle generic reborrow in expression-use adjustment walking)
 - rust-lang/rust#158034 (Fix reborrow source expression visits)
 - rust-lang/rust#158074 (Document transient connection errors from TcpListener::accept)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=156795,158034,158074)
<!-- homu-ignore:end -->

