### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,6 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
+    // Open a PR to migrate the config when Renovate deprecates syntax
+    ":configMigration",
     // Refresh lock files on the first day of each month
     // (still gated by dashboard approval for now)
     ":maintainLockFilesMonthly",

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
+    "config:recommended",
     // Refresh lock files on the first day of each month
     // (still gated by dashboard approval for now)
     ":maintainLockFilesMonthly",
@@ -8,8 +9,6 @@
     // (e.g. `v4`) to the full SemVer version (e.g. `v4.1.2`)
     "helpers:pinGitHubActionDigestsToSemver"
   ],
-  // Let Renovatebot keep an opened issue that tracks our dependencies
-  "dependencyDashboard": true,
   // Require manual approval from the Dependency Dashboard before opening PRs
   "dependencyDashboardApproval": true,
   "packageRules": [

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
+    // Refresh lock files on the first day of each month
+    // (still gated by dashboard approval for now)
+    ":maintainLockFilesMonthly",
     // Pin GitHub Actions to their commit SHA digests, resolving floating tags
     // (e.g. `v4`) to the full SemVer version (e.g. `v4.1.2`)
     "helpers:pinGitHubActionDigestsToSemver"

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -9,6 +9,13 @@
   "dependencyDashboard": true,
   // Require manual approval from the Dependency Dashboard before opening PRs
   "dependencyDashboardApproval": true,
+  "packageRules": [
+    {
+      // No dashboard approval necessary for GitHub Actions updates
+      "matchManagers": ["github-actions"],
+      "dependencyDashboardApproval": false
+    }
+  ],
   // Don't manage dependencies inside subtrees. They are updated upstream and
   // synced in. See `src/doc/rustc-dev-guide/src/external-repos.md` for the list.
   "ignorePaths": [

--- a/compiler/rustc_borrowck/src/region_infer/values.rs
+++ b/compiler/rustc_borrowck/src/region_infer/values.rs
@@ -9,7 +9,7 @@ use rustc_middle::bug;
 use rustc_middle::mir::{BasicBlock, Location};
 use rustc_middle::ty::{self, RegionVid};
 use rustc_mir_dataflow::points::{DenseLocationMap, PointIndex};
-use tracing::debug;
+use tracing::{debug, instrument};
 
 use crate::BorrowIndex;
 use crate::polonius::LiveLoans;
@@ -116,37 +116,43 @@ impl LivenessValues {
     /// Records `region` as being live at the given `location`.
     pub(crate) fn add_location(&mut self, region: RegionVid, location: Location) {
         let point = self.location_map.point_from_location(location);
+        // This is a debug assert despite being cheap because it drops
+        // the current `point_in_range()` uses to 0 when debugging is off.
+        debug_assert!(
+            self.location_map.point_in_range(point),
+            "Tried inserting region {region:?} whose location {location:?} does not belong to this body!"
+        );
         debug!("LivenessValues::add_location(region={:?}, location={:?})", region, location);
         match &mut self.live_regions {
             LiveRegions::AtPoints(points) => {
                 points.insert(region, point);
             }
 
-            LiveRegions::InBody(live_regions) if self.location_map.point_in_range(point) => {
+            LiveRegions::InBody(live_regions) => {
                 live_regions.insert(region);
             }
-
-            LiveRegions::InBody(_) => (),
         };
     }
 
     /// Records `region` as being live at all the given `points`.
     pub(crate) fn add_points(&mut self, region: RegionVid, points: &IntervalSet<PointIndex>) {
+        debug_assert!(
+            points.iter().all(|point| self.location_map.point_in_range(point)),
+            "Tried inserting region {region:?} with some points not belonging to this body!"
+        );
         debug!("LivenessValues::add_points(region={:?}, points={:?})", region, points);
         match &mut self.live_regions {
             LiveRegions::AtPoints(these_points) => {
                 these_points.union_row(region, points);
             }
-            LiveRegions::InBody(live_regions)
-                if points.iter().any(|point| self.location_map.point_in_range(point)) =>
-            {
+            LiveRegions::InBody(live_regions) => {
                 live_regions.insert(region);
             }
-            LiveRegions::InBody(_) => (),
         };
     }
 
     /// Records `region` as being live at all the control-flow points.
+    #[instrument(skip(self))]
     pub(crate) fn add_all_points(&mut self, region: RegionVid) {
         match &mut self.live_regions {
             LiveRegions::AtPoints(points) => points.insert_all_into_row(region),
@@ -172,10 +178,7 @@ impl LivenessValues {
 
     /// Returns an iterator of all the points where `region` is live.
     fn live_points(&self, region: RegionVid) -> impl Iterator<Item = PointIndex> {
-        self.point_liveness(region)
-            .into_iter()
-            .flat_map(|set| set.iter())
-            .take_while(|&p| self.location_map.point_in_range(p))
+        self.point_liveness(region).into_iter().flat_map(|set| set.iter())
     }
 
     /// For debugging purposes, returns a pretty-printed string of the points where the `region` is
@@ -343,11 +346,10 @@ impl<'tcx, N: Idx> RegionValues<'tcx, N> {
 
     /// Returns the locations contained within a given region `r`.
     pub(crate) fn locations_outlived_by(&self, r: N) -> impl Iterator<Item = Location> {
-        self.points.row(r).into_iter().flat_map(move |set| {
-            set.iter()
-                .take_while(move |&p| self.location_map.point_in_range(p))
-                .map(move |p| self.location_map.to_location(p))
-        })
+        self.points
+            .row(r)
+            .into_iter()
+            .flat_map(move |set| set.iter().map(move |p| self.location_map.to_location(p)))
     }
 
     /// Returns just the universal regions that are contained in a given region's value.
@@ -413,11 +415,7 @@ pub(crate) fn pretty_print_points(
     points: impl IntoIterator<Item = PointIndex>,
 ) -> String {
     pretty_print_region_elements(
-        points
-            .into_iter()
-            .take_while(|&p| location_map.point_in_range(p))
-            .map(|p| location_map.to_location(p))
-            .map(RegionElement::Location),
+        points.into_iter().map(|p| location_map.to_location(p)).map(RegionElement::Location),
     )
 }
 

--- a/compiler/rustc_hir_typeck/src/expr_use_visitor.rs
+++ b/compiler/rustc_hir_typeck/src/expr_use_visitor.rs
@@ -727,7 +727,8 @@ impl<'tcx, Cx: TypeInformationCtxt<'tcx>, D: Delegate<'tcx>> ExprUseVisitor<'tcx
         let typeck_results = self.cx.typeck_results();
         let adjustments = typeck_results.expr_adjustments(expr);
         let mut place_with_id = self.cat_expr_unadjusted(expr)?;
-        for adjustment in adjustments {
+        for (adjustment_index, adjustment) in adjustments.iter().enumerate() {
+            let is_last_adjustment = adjustment_index + 1 == adjustments.len();
             debug!("walk_adjustment expr={:?} adj={:?}", expr, adjustment);
             match adjustment.kind {
                 adjustment::Adjust::NeverToAny | adjustment::Adjust::Pointer(_) => {
@@ -752,13 +753,13 @@ impl<'tcx, Cx: TypeInformationCtxt<'tcx>, D: Delegate<'tcx>> ExprUseVisitor<'tcx
                     self.walk_autoref(expr, &place_with_id, autoref);
                 }
 
-                adjustment::Adjust::GenericReborrow(_reborrow) => {
-                    // To build an expression as a place expression, it needs to be a field
-                    // projection or deref at the outmost layer. So it is field projection or deref
-                    // on an adjusted value. But this means that adjustment is applied on a
-                    // subexpression that is not the final operand/rvalue for function call or
-                    // assignment. This is a contradiction.
-                    unreachable!("Reborrow trait usage during adjustment walk");
+                adjustment::Adjust::GenericReborrow(mutability) if is_last_adjustment => {
+                    let bk = ty::BorrowKind::from_mutbl(mutability);
+                    self.delegate.borrow_mut().borrow(&place_with_id, place_with_id.hir_id, bk);
+                }
+
+                adjustment::Adjust::GenericReborrow(_) => {
+                    span_bug!(expr.span, "generic reborrow adjustment must be terminal");
                 }
             }
             place_with_id = self.cat_expr_adjusted(expr, place_with_id, adjustment)?;

--- a/compiler/rustc_middle/src/thir/visit.rs
+++ b/compiler/rustc_middle/src/thir/visit.rs
@@ -187,7 +187,9 @@ pub fn walk_expr<'thir, 'tcx: 'thir, V: Visitor<'thir, 'tcx>>(
         }
         ThreadLocalRef(_) => {}
         Yield { value } => visitor.visit_expr(&visitor.thir()[value]),
-        Reborrow { source, mutability: _, target: _ } => visitor.visit_expr(&visitor.thir()[source]),
+        Reborrow { source, mutability: _, target: _ } => {
+            visitor.visit_expr(&visitor.thir()[source])
+        }
     }
 }
 

--- a/compiler/rustc_middle/src/thir/visit.rs
+++ b/compiler/rustc_middle/src/thir/visit.rs
@@ -187,7 +187,7 @@ pub fn walk_expr<'thir, 'tcx: 'thir, V: Visitor<'thir, 'tcx>>(
         }
         ThreadLocalRef(_) => {}
         Yield { value } => visitor.visit_expr(&visitor.thir()[value]),
-        Reborrow { source, .. } => visitor.visit_expr(&visitor.thir()[source]),
+        Reborrow { source, mutability: _, target: _ } => visitor.visit_expr(&visitor.thir()[source]),
     }
 }
 

--- a/compiler/rustc_middle/src/thir/visit.rs
+++ b/compiler/rustc_middle/src/thir/visit.rs
@@ -187,7 +187,7 @@ pub fn walk_expr<'thir, 'tcx: 'thir, V: Visitor<'thir, 'tcx>>(
         }
         ThreadLocalRef(_) => {}
         Yield { value } => visitor.visit_expr(&visitor.thir()[value]),
-        Reborrow { .. } => {}
+        Reborrow { source, .. } => visitor.visit_expr(&visitor.thir()[source]),
     }
 }
 

--- a/compiler/rustc_mir_dataflow/src/points.rs
+++ b/compiler/rustc_mir_dataflow/src/points.rs
@@ -31,7 +31,8 @@ impl DenseLocationMap {
         for (bb, bb_data) in body.basic_blocks.iter_enumerated() {
             basic_blocks.extend((0..=bb_data.statements.len()).map(|_| bb));
         }
-
+        // Invariant: no block is preceded by more than all statements.
+        debug_assert!(*statements_before_block.iter().max().unwrap() < num_points);
         Self { statements_before_block, basic_blocks, num_points }
     }
 
@@ -42,10 +43,14 @@ impl DenseLocationMap {
     }
 
     /// Converts a `Location` into a `PointIndex`. O(1).
+    /// [[`Self::point_in_range()`]] guaranteed for the returned index.
     #[inline]
     pub fn point_from_location(&self, location: Location) -> PointIndex {
         let Location { block, statement_index } = location;
         let start_index = self.statements_before_block[block];
+        // Note the invariant in [`Self::new()`]; if the indexing
+        // operation above did not panic then this holds by construction.
+        debug_assert!(start_index < self.num_points);
         PointIndex::new(start_index + statement_index)
     }
 

--- a/library/alloc/src/task.rs
+++ b/library/alloc/src/task.rs
@@ -39,7 +39,7 @@ use crate::sync::Arc;
 ///
 /// # Memory Ordering
 ///
-/// To avoid missed wakeups, all runtimes must adhere to the requirement described for [`Waker::wake`].
+/// To avoid missed wakeups, all executors must adhere to the requirement described for [`Waker::wake`].
 ///
 /// # Examples
 ///

--- a/library/alloc/src/task.rs
+++ b/library/alloc/src/task.rs
@@ -37,6 +37,10 @@ use crate::sync::Arc;
 ///      link ../../std/task/struct.Waker.html#impl-From%3CArc%3CW,+Global%3E%3E-for-Waker
 ///      without getting a link-checking error in CI. -->
 ///
+/// # Memory Ordering
+///
+/// To avoid missed wakeups, all runtimes must adhere to the requirement described for [`Waker::wake`].
+///
 /// # Examples
 ///
 /// A basic `block_on` function that takes a future and runs it to completion on

--- a/library/core/src/task/wake.rs
+++ b/library/core/src/task/wake.rs
@@ -434,7 +434,7 @@ impl Waker {
     ///
     /// To avoid missed wakeups, runtimes must ensure that for any call to `wake`,
     /// there is a subsequent call to `poll` such that the call to `wake()` _happens-before_
-    /// the beginning of the invocation of `poll`. 
+    /// the beginning of the invocation of `poll`.
     /// In particular, this means that if a task self-wakes (invokes `wake` on itself during `poll`),
     /// then the `poll` must be invoked again because the call to `wake` _happens-after_ the beginning
     /// of the current invocation of `poll`.

--- a/library/core/src/task/wake.rs
+++ b/library/core/src/task/wake.rs
@@ -432,6 +432,13 @@ impl Waker {
     /// executor’s choice which task to run and the executor may choose to run the
     /// current task again.
     ///
+    /// To avoid missed wakeups, runtimes must ensure that for any call to `wake`,
+    /// there is a subsequent call to `poll` such that the `wake()` return _happens-before_
+    /// the beginning of the invocation of `poll`. 
+    /// In particular, this means that if a task self-wakes (invokes `wake` on itself during `poll`),
+    /// then the `poll` must be invoked again because the call to `wake` _happens-after_ the beginning
+    /// of the current invocation of `poll`.
+    ///
     /// [`poll()`]: crate::future::Future::poll
     #[inline]
     #[stable(feature = "futures_api", since = "1.36.0")]

--- a/library/core/src/task/wake.rs
+++ b/library/core/src/task/wake.rs
@@ -421,7 +421,7 @@ impl Waker {
     /// As long as the executor keeps running and the task is not finished,
     /// it is guaranteed that each invocation of [`wake()`](Self::wake) (or
     /// [`wake_by_ref()`](Self::wake_by_ref)) will be followed by at least one
-    /// [`poll()`] of the task to which this `Waker` belongs, and the call to
+    /// [`poll()`] of the task to which this `Waker` belongs, such that the call to
     /// [`wake()`](Self::wake) (or [`wake_by_ref()`](Self::wake_by_ref)) _happens-before_
     /// the beginning of the invocation of [`poll()`]. This makes it possible to temporarily
     /// yield to other tasks while running potentially unbounded processing loops.

--- a/library/core/src/task/wake.rs
+++ b/library/core/src/task/wake.rs
@@ -432,7 +432,7 @@ impl Waker {
     /// executor’s choice which task to run and the executor may choose to run the
     /// current task again.
     ///
-    /// To avoid missed wakeups, runtimes must ensure that for any call to
+    /// To avoid missed wakeups, executors must ensure that for any call to
     /// `wake`, there is a subsequent call to `poll` such that the call to
     /// `wake()` _happens-before_ the beginning of the invocation of `poll`. In
     /// particular, this means that if a task self-wakes (invokes `wake` on

--- a/library/core/src/task/wake.rs
+++ b/library/core/src/task/wake.rs
@@ -432,12 +432,13 @@ impl Waker {
     /// executor’s choice which task to run and the executor may choose to run the
     /// current task again.
     ///
-    /// To avoid missed wakeups, runtimes must ensure that for any call to `wake`,
-    /// there is a subsequent call to `poll` such that the call to `wake()` _happens-before_
-    /// the beginning of the invocation of `poll`.
-    /// In particular, this means that if a task self-wakes (invokes `wake` on itself during `poll`),
-    /// then the `poll` must be invoked again because the call to `wake` _happens-after_ the beginning
-    /// of the current invocation of `poll`.
+    /// To avoid missed wakeups, runtimes must ensure that for any call to
+    /// `wake`, there is a subsequent call to `poll` such that the call to
+    /// `wake()` _happens-before_ the beginning of the invocation of `poll`. In
+    /// particular, this means that if a task self-wakes (invokes `wake` on
+    /// itself during `poll`), then the `poll` must be invoked again because the
+    /// call to `wake` _happens-after_ the beginning of the current invocation
+    /// of `poll`.
     ///
     /// [`poll()`]: crate::future::Future::poll
     #[inline]

--- a/library/core/src/task/wake.rs
+++ b/library/core/src/task/wake.rs
@@ -418,27 +418,20 @@ unsafe impl Sync for Waker {}
 impl Waker {
     /// Wakes up the task associated with this `Waker`.
     ///
-    /// As long as the executor keeps running and the task is not finished, it is
-    /// guaranteed that each invocation of [`wake()`](Self::wake) (or
+    /// As long as the executor keeps running and the task is not finished,
+    /// it is guaranteed that each invocation of [`wake()`](Self::wake) (or
     /// [`wake_by_ref()`](Self::wake_by_ref)) will be followed by at least one
-    /// [`poll()`] of the task to which this `Waker` belongs. This makes
-    /// it possible to temporarily yield to other tasks while running potentially
-    /// unbounded processing loops.
+    /// [`poll()`] of the task to which this `Waker` belongs, and the call to
+    /// [`wake()`](Self::wake) (or [`wake_by_ref()`](Self::wake_by_ref)) _happens-before_
+    /// the beginning of the invocation of [`poll()`]. This makes it possible to temporarily
+    /// yield to other tasks while running potentially unbounded processing loops.
     ///
     /// Note that the above implies that multiple wake-ups may be coalesced into a
-    /// single [`poll()`] invocation by the runtime.
+    /// single [`poll()`] invocation by the executor.
     ///
     /// Also note that yielding to competing tasks is not guaranteed: it is the
     /// executor’s choice which task to run and the executor may choose to run the
     /// current task again.
-    ///
-    /// To avoid missed wakeups, executors must ensure that for any call to
-    /// `wake`, there is a subsequent call to `poll` such that the call to
-    /// `wake()` _happens-before_ the beginning of the invocation of `poll`. In
-    /// particular, this means that if a task self-wakes (invokes `wake` on
-    /// itself during `poll`), then the `poll` must be invoked again because the
-    /// call to `wake` _happens-after_ the beginning of the current invocation
-    /// of `poll`.
     ///
     /// [`poll()`]: crate::future::Future::poll
     #[inline]

--- a/library/core/src/task/wake.rs
+++ b/library/core/src/task/wake.rs
@@ -433,7 +433,7 @@ impl Waker {
     /// current task again.
     ///
     /// To avoid missed wakeups, runtimes must ensure that for any call to `wake`,
-    /// there is a subsequent call to `poll` such that the `wake()` return _happens-before_
+    /// there is a subsequent call to `poll` such that the `wake()` _happens-before_
     /// the beginning of the invocation of `poll`. 
     /// In particular, this means that if a task self-wakes (invokes `wake` on itself during `poll`),
     /// then the `poll` must be invoked again because the call to `wake` _happens-after_ the beginning

--- a/library/core/src/task/wake.rs
+++ b/library/core/src/task/wake.rs
@@ -433,7 +433,7 @@ impl Waker {
     /// current task again.
     ///
     /// To avoid missed wakeups, runtimes must ensure that for any call to `wake`,
-    /// there is a subsequent call to `poll` such that the `wake()` _happens-before_
+    /// there is a subsequent call to `poll` such that the call to `wake()` _happens-before_
     /// the beginning of the invocation of `poll`. 
     /// In particular, this means that if a task self-wakes (invokes `wake` on itself during `poll`),
     /// then the `poll` must be invoked again because the call to `wake` _happens-after_ the beginning

--- a/library/std/src/net/tcp.rs
+++ b/library/std/src/net/tcp.rs
@@ -878,16 +878,20 @@ impl TcpListener {
     ///
     /// # Errors
     ///
-    /// Some errors returned by this function relate to a single incoming
-    /// connection that failed before it could be accepted, such as one aborted
-    /// by the peer ([`ConnectionAborted`]). Such an error does not indicate a
-    /// problem with the listener itself, which remains usable. Code serving a
-    /// long-lived listener will usually want to log the error and continue
-    /// accepting connections rather than treat it as fatal. Which errors can
-    /// occur this way is platform-specific.
+    /// Some errors this function returns do not indicate a problem with the
+    /// listener itself, and a program serving a long-lived listener will
+    /// usually want to handle them and keep accepting connections rather than
+    /// treat them as fatal. These include, but are not limited to:
     ///
-    /// On Unix, [`Interrupted`] errors are retried internally rather than being
-    /// returned.
+    /// - An error specific to a single incoming connection that failed before
+    ///   it could be accepted, such as one aborted by the peer
+    ///   ([`ConnectionAborted`]). A later call may succeed immediately.
+    /// - An error from reaching the per-process or system-wide open file
+    ///   descriptor limit. The call can be retried once other file descriptors
+    ///   have been closed, typically after a short delay.
+    ///
+    /// Which errors can occur is platform-specific. On Unix, [`Interrupted`]
+    /// errors are retried internally rather than being returned.
     ///
     /// [`ConnectionAborted`]: io::ErrorKind::ConnectionAborted
     /// [`Interrupted`]: io::ErrorKind::Interrupted

--- a/library/std/src/net/tcp.rs
+++ b/library/std/src/net/tcp.rs
@@ -876,6 +876,22 @@ impl TcpListener {
     /// is established. When established, the corresponding [`TcpStream`] and the
     /// remote peer's address will be returned.
     ///
+    /// # Errors
+    ///
+    /// Some errors returned by this function relate to a single incoming
+    /// connection that failed before it could be accepted, such as one aborted
+    /// by the peer ([`ConnectionAborted`]). Such an error does not indicate a
+    /// problem with the listener itself, which remains usable. Code serving a
+    /// long-lived listener will usually want to log the error and continue
+    /// accepting connections rather than treat it as fatal. Which errors can
+    /// occur this way is platform-specific.
+    ///
+    /// On Unix, [`Interrupted`] errors are retried internally rather than being
+    /// returned.
+    ///
+    /// [`ConnectionAborted`]: io::ErrorKind::ConnectionAborted
+    /// [`Interrupted`]: io::ErrorKind::Interrupted
+    ///
     /// # Examples
     ///
     /// ```no_run
@@ -901,6 +917,11 @@ impl TcpListener {
     /// The returned iterator will never return [`None`] and will also not yield
     /// the peer's [`SocketAddr`] structure. Iterating over it is equivalent to
     /// calling [`TcpListener::accept`] in a loop.
+    ///
+    /// # Errors
+    ///
+    /// Each connection yielded by the iterator can fail for the same reasons as
+    /// [`TcpListener::accept`]; see its documentation for details.
     ///
     /// # Examples
     ///
@@ -936,6 +957,11 @@ impl TcpListener {
     /// The returned iterator will never return [`None`] and will also not yield
     /// the peer's [`SocketAddr`] structure. Iterating over it is equivalent to
     /// calling [`TcpListener::accept`] in a loop.
+    ///
+    /// # Errors
+    ///
+    /// Each connection yielded by the iterator can fail for the same reasons as
+    /// [`TcpListener::accept`]; see its documentation for details.
     ///
     /// # Examples
     ///

--- a/library/std/src/net/tcp.rs
+++ b/library/std/src/net/tcp.rs
@@ -889,11 +889,14 @@ impl TcpListener {
     /// - An error from reaching the per-process or system-wide open file
     ///   descriptor limit. The call can be retried once other file descriptors
     ///   have been closed, typically after a short delay.
+    /// - An error from failing to allocate memory while accepting a connection
+    ///   ([`OutOfMemory`]).
     ///
     /// Which errors can occur is platform-specific. On Unix, [`Interrupted`]
     /// errors are retried internally rather than being returned.
     ///
     /// [`ConnectionAborted`]: io::ErrorKind::ConnectionAborted
+    /// [`OutOfMemory`]: io::ErrorKind::OutOfMemory
     /// [`Interrupted`]: io::ErrorKind::Interrupted
     ///
     /// # Examples

--- a/tests/ui/reborrow/generic-reborrow-expr-use-visitor-closure.rs
+++ b/tests/ui/reborrow/generic-reborrow-expr-use-visitor-closure.rs
@@ -1,0 +1,34 @@
+//@ check-pass
+
+#![feature(reborrow)]
+
+use std::marker::{CoerceShared, Reborrow};
+
+#[allow(unused)]
+struct CustomMut<'a, T>(&'a mut T);
+impl<'a, T> Reborrow for CustomMut<'a, T> {}
+impl<'a, T> CoerceShared<CustomRef<'a, T>> for CustomMut<'a, T> {}
+
+#[allow(unused)]
+struct CustomRef<'a, T>(&'a T);
+impl<'a, T> Clone for CustomRef<'a, T> {
+    fn clone(&self) -> Self {
+        Self(self.0)
+    }
+}
+impl<'a, T> Copy for CustomRef<'a, T> {}
+
+fn takes_mut(_: CustomMut<'_, ()>) {}
+fn takes_shared(_: CustomRef<'_, ()>) {}
+
+fn main() {
+    let a = CustomMut(&mut ());
+
+    let mut f = || {
+        takes_mut(a);
+        takes_shared(a);
+    };
+
+    f();
+    f();
+}

--- a/tests/ui/reborrow/generic-reborrow-expr-use-visitor.rs
+++ b/tests/ui/reborrow/generic-reborrow-expr-use-visitor.rs
@@ -1,0 +1,32 @@
+//@ check-pass
+
+#![feature(reborrow)]
+
+use std::marker::{CoerceShared, Reborrow};
+
+#[allow(unused)]
+struct CustomMut<'a, T>(&'a mut T);
+impl<'a, T> Reborrow for CustomMut<'a, T> {}
+impl<'a, T> CoerceShared<CustomRef<'a, T>> for CustomMut<'a, T> {}
+
+#[allow(unused)]
+struct CustomRef<'a, T>(&'a T);
+impl<'a, T> Clone for CustomRef<'a, T> {
+    fn clone(&self) -> Self {
+        Self(self.0)
+    }
+}
+impl<'a, T> Copy for CustomRef<'a, T> {}
+
+fn takes_mut(_: CustomMut<'_, ()>) {}
+fn takes_shared(_: CustomRef<'_, ()>) {}
+
+fn main() {
+    let a = CustomMut(&mut ());
+
+    takes_mut(a);
+    takes_mut(a);
+
+    takes_shared(a);
+    takes_shared(a);
+}

--- a/tests/ui/reborrow/reborrow-source-unsafety.rs
+++ b/tests/ui/reborrow/reborrow-source-unsafety.rs
@@ -1,0 +1,28 @@
+// Regression test for rust-lang/rust#158033.
+
+#![feature(reborrow)]
+#![allow(dead_code)]
+#![deny(unsafe_code)]
+
+use std::marker::Reborrow;
+
+struct Thing<'a> {
+    field: &'a mut usize,
+}
+
+impl<'a> Reborrow for Thing<'a> {}
+
+fn takes(_: Thing<'_>) {}
+
+fn main() {
+    let mut x = 0;
+    let thing = Thing { field: &mut x };
+    let y = 123usize;
+
+    takes({
+        let p: *const usize = &y;
+        std::hint::black_box(std::ptr::read(p));
+        //~^ ERROR call to unsafe function `std::ptr::read` is unsafe
+        thing
+    });
+}

--- a/tests/ui/reborrow/reborrow-source-unsafety.stderr
+++ b/tests/ui/reborrow/reborrow-source-unsafety.stderr
@@ -1,0 +1,11 @@
+error[E0133]: call to unsafe function `std::ptr::read` is unsafe and requires unsafe function or block
+  --> $DIR/reborrow-source-unsafety.rs:24:30
+   |
+LL |         std::hint::black_box(std::ptr::read(p));
+   |                              ^^^^^^^^^^^^^^^^^ call to unsafe function
+   |
+   = note: consult the function's documentation for information on how to avoid undefined behavior
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0133`.


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#158026 (`RegionValues`: disable unnecessary range check)
 - rust-lang/rust#156795 (Handle generic reborrow in expression-use adjustment walking)
 - rust-lang/rust#157694 (Enhance documentation on wake call memory ordering)
 - rust-lang/rust#158034 (Fix reborrow source expression visits)
 - rust-lang/rust#158074 (Document transient connection errors from TcpListener::accept)
 - rust-lang/rust#158086 (renovate: Loosen dashboard approval and adopt recommended config)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=158026,156795,157694,158034,158074,158086)
<!-- homu-ignore:end -->

