### PR TITLE
Rollup of 10 pull requests

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,6 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
+    // Open a PR to migrate the config when Renovate deprecates syntax
+    ":configMigration",
     // Refresh lock files on the first day of each month
     // (still gated by dashboard approval for now)
     ":maintainLockFilesMonthly",

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
+    "config:recommended",
     // Refresh lock files on the first day of each month
     // (still gated by dashboard approval for now)
     ":maintainLockFilesMonthly",
@@ -8,8 +9,6 @@
     // (e.g. `v4`) to the full SemVer version (e.g. `v4.1.2`)
     "helpers:pinGitHubActionDigestsToSemver"
   ],
-  // Let Renovatebot keep an opened issue that tracks our dependencies
-  "dependencyDashboard": true,
   // Require manual approval from the Dependency Dashboard before opening PRs
   "dependencyDashboardApproval": true,
   "packageRules": [

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
+    // Refresh lock files on the first day of each month
+    // (still gated by dashboard approval for now)
+    ":maintainLockFilesMonthly",
     // Pin GitHub Actions to their commit SHA digests, resolving floating tags
     // (e.g. `v4`) to the full SemVer version (e.g. `v4.1.2`)
     "helpers:pinGitHubActionDigestsToSemver"

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -9,6 +9,13 @@
   "dependencyDashboard": true,
   // Require manual approval from the Dependency Dashboard before opening PRs
   "dependencyDashboardApproval": true,
+  "packageRules": [
+    {
+      // No dashboard approval necessary for GitHub Actions updates
+      "matchManagers": ["github-actions"],
+      "dependencyDashboardApproval": false
+    }
+  ],
   // Don't manage dependencies inside subtrees. They are updated upstream and
   // synced in. See `src/doc/rustc-dev-guide/src/external-repos.md` for the list.
   "ignorePaths": [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -785,6 +785,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.17",
+]
+
+[[package]]
 name = "codespan-reporting"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1329,6 +1338,18 @@ checksum = "9abf33c656a7256451ebb7d0082c5a471820c31269e49d807c538c252352186e"
 dependencies = [
  "stable_deref_trait",
 ]
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "ena"
@@ -3053,6 +3074,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
 dependencies = [
  "portable-atomic",
+]
+
+[[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "serde",
 ]
 
 [[package]]
@@ -4978,7 +5011,7 @@ dependencies = [
 name = "rustdoc-json-types"
 version = "0.1.0"
 dependencies = [
- "bincode",
+ "postcard",
  "rkyv",
  "rustc-hash 2.1.1",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5554,9 +5554,9 @@ dependencies = [
 
 [[package]]
 name = "thin-vec"
-version = "0.2.15"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da322882471314edc77fa5232c587bcb87c9df52bfd0d7d4826f8868ead61899"
+checksum = "b0f7e269b48f0a7dd0146680fa24b50cc67fc0373f086a5b2f99bd084639b482"
 
 [[package]]
 name = "thiserror"

--- a/compiler/rustc_ast/Cargo.toml
+++ b/compiler/rustc_ast/Cargo.toml
@@ -15,6 +15,6 @@ rustc_macros = { path = "../rustc_macros" }
 rustc_serialize = { path = "../rustc_serialize" }
 rustc_span = { path = "../rustc_span" }
 smallvec = { version = "1.8.1", features = ["union", "may_dangle"] }
-thin-vec = "0.2.15"
+thin-vec = "0.2.18"
 tracing = "0.1"
 # tidy-alphabetical-end

--- a/compiler/rustc_ast_lowering/Cargo.toml
+++ b/compiler/rustc_ast_lowering/Cargo.toml
@@ -22,6 +22,6 @@ rustc_session = { path = "../rustc_session" }
 rustc_span = { path = "../rustc_span" }
 rustc_target = { path = "../rustc_target" }
 smallvec = { version = "1.8.1", features = ["union", "may_dangle"] }
-thin-vec = "0.2.15"
+thin-vec = "0.2.18"
 tracing = "0.1"
 # tidy-alphabetical-end

--- a/compiler/rustc_ast_passes/Cargo.toml
+++ b/compiler/rustc_ast_passes/Cargo.toml
@@ -18,5 +18,5 @@ rustc_macros = { path = "../rustc_macros" }
 rustc_session = { path = "../rustc_session" }
 rustc_span = { path = "../rustc_span" }
 rustc_target = { path = "../rustc_target" }
-thin-vec = "0.2.15"
+thin-vec = "0.2.18"
 # tidy-alphabetical-end

--- a/compiler/rustc_ast_pretty/Cargo.toml
+++ b/compiler/rustc_ast_pretty/Cargo.toml
@@ -13,5 +13,5 @@ rustc_span = { path = "../rustc_span" }
 
 [dev-dependencies]
 # tidy-alphabetical-start
-thin-vec = "0.2.15"
+thin-vec = "0.2.18"
 # tidy-alphabetical-end

--- a/compiler/rustc_attr_parsing/Cargo.toml
+++ b/compiler/rustc_attr_parsing/Cargo.toml
@@ -20,5 +20,5 @@ rustc_parse_format = { path = "../rustc_parse_format" }
 rustc_session = { path = "../rustc_session" }
 rustc_span = { path = "../rustc_span" }
 rustc_target = { path = "../rustc_target" }
-thin-vec = "0.2.15"
+thin-vec = "0.2.18"
 # tidy-alphabetical-end

--- a/compiler/rustc_borrowck/src/region_infer/values.rs
+++ b/compiler/rustc_borrowck/src/region_infer/values.rs
@@ -9,7 +9,7 @@ use rustc_middle::bug;
 use rustc_middle::mir::{BasicBlock, Location};
 use rustc_middle::ty::{self, RegionVid};
 use rustc_mir_dataflow::points::{DenseLocationMap, PointIndex};
-use tracing::debug;
+use tracing::{debug, instrument};
 
 use crate::BorrowIndex;
 use crate::polonius::LiveLoans;
@@ -116,37 +116,43 @@ impl LivenessValues {
     /// Records `region` as being live at the given `location`.
     pub(crate) fn add_location(&mut self, region: RegionVid, location: Location) {
         let point = self.location_map.point_from_location(location);
+        // This is a debug assert despite being cheap because it drops
+        // the current `point_in_range()` uses to 0 when debugging is off.
+        debug_assert!(
+            self.location_map.point_in_range(point),
+            "Tried inserting region {region:?} whose location {location:?} does not belong to this body!"
+        );
         debug!("LivenessValues::add_location(region={:?}, location={:?})", region, location);
         match &mut self.live_regions {
             LiveRegions::AtPoints(points) => {
                 points.insert(region, point);
             }
 
-            LiveRegions::InBody(live_regions) if self.location_map.point_in_range(point) => {
+            LiveRegions::InBody(live_regions) => {
                 live_regions.insert(region);
             }
-
-            LiveRegions::InBody(_) => (),
         };
     }
 
     /// Records `region` as being live at all the given `points`.
     pub(crate) fn add_points(&mut self, region: RegionVid, points: &IntervalSet<PointIndex>) {
+        debug_assert!(
+            points.iter().all(|point| self.location_map.point_in_range(point)),
+            "Tried inserting region {region:?} with some points not belonging to this body!"
+        );
         debug!("LivenessValues::add_points(region={:?}, points={:?})", region, points);
         match &mut self.live_regions {
             LiveRegions::AtPoints(these_points) => {
                 these_points.union_row(region, points);
             }
-            LiveRegions::InBody(live_regions)
-                if points.iter().any(|point| self.location_map.point_in_range(point)) =>
-            {
+            LiveRegions::InBody(live_regions) => {
                 live_regions.insert(region);
             }
-            LiveRegions::InBody(_) => (),
         };
     }
 
     /// Records `region` as being live at all the control-flow points.
+    #[instrument(skip(self))]
     pub(crate) fn add_all_points(&mut self, region: RegionVid) {
         match &mut self.live_regions {
             LiveRegions::AtPoints(points) => points.insert_all_into_row(region),
@@ -172,10 +178,7 @@ impl LivenessValues {
 
     /// Returns an iterator of all the points where `region` is live.
     fn live_points(&self, region: RegionVid) -> impl Iterator<Item = PointIndex> {
-        self.point_liveness(region)
-            .into_iter()
-            .flat_map(|set| set.iter())
-            .take_while(|&p| self.location_map.point_in_range(p))
+        self.point_liveness(region).into_iter().flat_map(|set| set.iter())
     }
 
     /// For debugging purposes, returns a pretty-printed string of the points where the `region` is
@@ -343,11 +346,10 @@ impl<'tcx, N: Idx> RegionValues<'tcx, N> {
 
     /// Returns the locations contained within a given region `r`.
     pub(crate) fn locations_outlived_by(&self, r: N) -> impl Iterator<Item = Location> {
-        self.points.row(r).into_iter().flat_map(move |set| {
-            set.iter()
-                .take_while(move |&p| self.location_map.point_in_range(p))
-                .map(move |p| self.location_map.to_location(p))
-        })
+        self.points
+            .row(r)
+            .into_iter()
+            .flat_map(move |set| set.iter().map(move |p| self.location_map.to_location(p)))
     }
 
     /// Returns just the universal regions that are contained in a given region's value.
@@ -413,11 +415,7 @@ pub(crate) fn pretty_print_points(
     points: impl IntoIterator<Item = PointIndex>,
 ) -> String {
     pretty_print_region_elements(
-        points
-            .into_iter()
-            .take_while(|&p| location_map.point_in_range(p))
-            .map(|p| location_map.to_location(p))
-            .map(RegionElement::Location),
+        points.into_iter().map(|p| location_map.to_location(p)).map(RegionElement::Location),
     )
 }
 

--- a/compiler/rustc_builtin_macros/Cargo.toml
+++ b/compiler/rustc_builtin_macros/Cargo.toml
@@ -29,7 +29,7 @@ rustc_session = { path = "../rustc_session" }
 rustc_span = { path = "../rustc_span" }
 rustc_target = { path = "../rustc_target" }
 smallvec = { version = "1.8.1", features = ["union", "may_dangle"] }
-thin-vec = "0.2.15"
+thin-vec = "0.2.18"
 tracing = "0.1"
 # tidy-alphabetical-end
 

--- a/compiler/rustc_data_structures/Cargo.toml
+++ b/compiler/rustc_data_structures/Cargo.toml
@@ -30,7 +30,7 @@ smallvec = { version = "1.8.1", features = [
 ] }
 stacker = "0.1.17"
 tempfile = "3.2"
-thin-vec = "0.2.15"
+thin-vec = "0.2.18"
 tracing = "0.1"
 # tidy-alphabetical-end
 

--- a/compiler/rustc_expand/Cargo.toml
+++ b/compiler/rustc_expand/Cargo.toml
@@ -30,6 +30,6 @@ rustc_session = { path = "../rustc_session" }
 rustc_span = { path = "../rustc_span" }
 scoped-tls = "1.0"
 smallvec = { version = "1.8.1", features = ["union", "may_dangle"] }
-thin-vec = "0.2.15"
+thin-vec = "0.2.18"
 tracing = "0.1"
 # tidy-alphabetical-end

--- a/compiler/rustc_hir/Cargo.toml
+++ b/compiler/rustc_hir/Cargo.toml
@@ -23,6 +23,6 @@ rustc_serialize = { path = "../rustc_serialize" }
 rustc_span = { path = "../rustc_span" }
 rustc_target = { path = "../rustc_target" }
 smallvec = { version = "1.8.1", features = ["union", "may_dangle"] }
-thin-vec = "0.2.15"
+thin-vec = "0.2.18"
 tracing = "0.1"
 # tidy-alphabetical-end

--- a/compiler/rustc_hir_typeck/src/expr_use_visitor.rs
+++ b/compiler/rustc_hir_typeck/src/expr_use_visitor.rs
@@ -727,7 +727,8 @@ impl<'tcx, Cx: TypeInformationCtxt<'tcx>, D: Delegate<'tcx>> ExprUseVisitor<'tcx
         let typeck_results = self.cx.typeck_results();
         let adjustments = typeck_results.expr_adjustments(expr);
         let mut place_with_id = self.cat_expr_unadjusted(expr)?;
-        for adjustment in adjustments {
+        for (adjustment_index, adjustment) in adjustments.iter().enumerate() {
+            let is_last_adjustment = adjustment_index + 1 == adjustments.len();
             debug!("walk_adjustment expr={:?} adj={:?}", expr, adjustment);
             match adjustment.kind {
                 adjustment::Adjust::NeverToAny | adjustment::Adjust::Pointer(_) => {
@@ -752,13 +753,13 @@ impl<'tcx, Cx: TypeInformationCtxt<'tcx>, D: Delegate<'tcx>> ExprUseVisitor<'tcx
                     self.walk_autoref(expr, &place_with_id, autoref);
                 }
 
-                adjustment::Adjust::GenericReborrow(_reborrow) => {
-                    // To build an expression as a place expression, it needs to be a field
-                    // projection or deref at the outmost layer. So it is field projection or deref
-                    // on an adjusted value. But this means that adjustment is applied on a
-                    // subexpression that is not the final operand/rvalue for function call or
-                    // assignment. This is a contradiction.
-                    unreachable!("Reborrow trait usage during adjustment walk");
+                adjustment::Adjust::GenericReborrow(mutability) if is_last_adjustment => {
+                    let bk = ty::BorrowKind::from_mutbl(mutability);
+                    self.delegate.borrow_mut().borrow(&place_with_id, place_with_id.hir_id, bk);
+                }
+
+                adjustment::Adjust::GenericReborrow(_) => {
+                    span_bug!(expr.span, "generic reborrow adjustment must be terminal");
                 }
             }
             place_with_id = self.cat_expr_adjusted(expr, place_with_id, adjustment)?;

--- a/compiler/rustc_infer/Cargo.toml
+++ b/compiler/rustc_infer/Cargo.toml
@@ -17,6 +17,6 @@ rustc_middle = { path = "../rustc_middle" }
 rustc_span = { path = "../rustc_span" }
 rustc_type_ir = { path = "../rustc_type_ir" }
 smallvec = { version = "1.8.1", features = ["union", "may_dangle"] }
-thin-vec = "0.2.15"
+thin-vec = "0.2.18"
 tracing = "0.1"
 # tidy-alphabetical-end

--- a/compiler/rustc_metadata/src/rmeta/decoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder.rs
@@ -1274,6 +1274,10 @@ impl CrateMetadata {
     /// including both proper items and reexports.
     /// Module here is understood in name resolution sense - it can be a `mod` item,
     /// or a crate root, or an enum, or a trait.
+    ///
+    /// # Panics
+    ///
+    /// May panic if the provided `id` does not refer to a module.
     fn get_module_children(&self, tcx: TyCtxt<'_>, id: DefIndex) -> impl Iterator<Item = ModChild> {
         gen move {
             if let Some(data) = &self.root.proc_macro_data {
@@ -1287,7 +1291,9 @@ impl CrateMetadata {
             } else {
                 // Iterate over all children.
                 let non_reexports = self.root.tables.module_children_non_reexports.get(self, id);
-                for child_index in non_reexports.unwrap().decode((self, tcx)) {
+                let non_reexports =
+                    non_reexports.expect("provided `DefIndex` must refer to a module-like item");
+                for child_index in non_reexports.decode((self, tcx)) {
                     yield self.get_mod_child(tcx, child_index);
                 }
 

--- a/compiler/rustc_middle/Cargo.toml
+++ b/compiler/rustc_middle/Cargo.toml
@@ -33,7 +33,7 @@ rustc_target = { path = "../rustc_target" }
 rustc_thread_pool = { path = "../rustc_thread_pool" }
 rustc_type_ir = { path = "../rustc_type_ir" }
 smallvec = { version = "1.8.1", features = ["union", "may_dangle"] }
-thin-vec = "0.2.15"
+thin-vec = "0.2.18"
 tracing = "0.1"
 # tidy-alphabetical-end
 

--- a/compiler/rustc_middle/src/queries.rs
+++ b/compiler/rustc_middle/src/queries.rs
@@ -2161,6 +2161,15 @@ rustc_queries! {
         desc { "fetching what a crate is named" }
         separate_provide_extern
     }
+
+    /// Iterates over all named children of the given module,
+    /// including both proper items and reexports.
+    /// Module here is understood in name resolution sense - it can be a `mod` item,
+    /// or a crate root, or an enum, or a trait.
+    ///
+    /// # Panics
+    ///
+    /// May panic if the provided `id` does not refer to a module.
     query module_children(def_id: DefId) -> &'tcx [ModChild] {
         desc { "collecting child items of module `{}`", tcx.def_path_str(def_id) }
         separate_provide_extern

--- a/compiler/rustc_middle/src/thir/visit.rs
+++ b/compiler/rustc_middle/src/thir/visit.rs
@@ -187,7 +187,9 @@ pub fn walk_expr<'thir, 'tcx: 'thir, V: Visitor<'thir, 'tcx>>(
         }
         ThreadLocalRef(_) => {}
         Yield { value } => visitor.visit_expr(&visitor.thir()[value]),
-        Reborrow { source, mutability: _, target: _ } => visitor.visit_expr(&visitor.thir()[source]),
+        Reborrow { source, mutability: _, target: _ } => {
+            visitor.visit_expr(&visitor.thir()[source])
+        }
     }
 }
 

--- a/compiler/rustc_middle/src/thir/visit.rs
+++ b/compiler/rustc_middle/src/thir/visit.rs
@@ -187,7 +187,7 @@ pub fn walk_expr<'thir, 'tcx: 'thir, V: Visitor<'thir, 'tcx>>(
         }
         ThreadLocalRef(_) => {}
         Yield { value } => visitor.visit_expr(&visitor.thir()[value]),
-        Reborrow { source, .. } => visitor.visit_expr(&visitor.thir()[source]),
+        Reborrow { source, mutability: _, target: _ } => visitor.visit_expr(&visitor.thir()[source]),
     }
 }
 

--- a/compiler/rustc_middle/src/thir/visit.rs
+++ b/compiler/rustc_middle/src/thir/visit.rs
@@ -187,7 +187,7 @@ pub fn walk_expr<'thir, 'tcx: 'thir, V: Visitor<'thir, 'tcx>>(
         }
         ThreadLocalRef(_) => {}
         Yield { value } => visitor.visit_expr(&visitor.thir()[value]),
-        Reborrow { .. } => {}
+        Reborrow { source, .. } => visitor.visit_expr(&visitor.thir()[source]),
     }
 }
 

--- a/compiler/rustc_mir_dataflow/src/points.rs
+++ b/compiler/rustc_mir_dataflow/src/points.rs
@@ -31,7 +31,8 @@ impl DenseLocationMap {
         for (bb, bb_data) in body.basic_blocks.iter_enumerated() {
             basic_blocks.extend((0..=bb_data.statements.len()).map(|_| bb));
         }
-
+        // Invariant: no block is preceded by more than all statements.
+        debug_assert!(*statements_before_block.iter().max().unwrap() < num_points);
         Self { statements_before_block, basic_blocks, num_points }
     }
 
@@ -42,10 +43,14 @@ impl DenseLocationMap {
     }
 
     /// Converts a `Location` into a `PointIndex`. O(1).
+    /// [[`Self::point_in_range()`]] guaranteed for the returned index.
     #[inline]
     pub fn point_from_location(&self, location: Location) -> PointIndex {
         let Location { block, statement_index } = location;
         let start_index = self.statements_before_block[block];
+        // Note the invariant in [`Self::new()`]; if the indexing
+        // operation above did not panic then this holds by construction.
+        debug_assert!(start_index < self.num_points);
         PointIndex::new(start_index + statement_index)
     }
 

--- a/compiler/rustc_parse/Cargo.toml
+++ b/compiler/rustc_parse/Cargo.toml
@@ -17,7 +17,7 @@ rustc_lexer = { path = "../rustc_lexer" }
 rustc_macros = { path = "../rustc_macros" }
 rustc_session = { path = "../rustc_session" }
 rustc_span = { path = "../rustc_span" }
-thin-vec = "0.2.15"
+thin-vec = "0.2.18"
 tracing = "0.1"
 unicode-normalization = "0.1.25"
 unicode-width = "0.2.2"

--- a/compiler/rustc_resolve/Cargo.toml
+++ b/compiler/rustc_resolve/Cargo.toml
@@ -26,6 +26,6 @@ rustc_middle = { path = "../rustc_middle" }
 rustc_session = { path = "../rustc_session" }
 rustc_span = { path = "../rustc_span" }
 smallvec = { version = "1.8.1", features = ["union", "may_dangle"] }
-thin-vec = "0.2.15"
+thin-vec = "0.2.18"
 tracing = "0.1"
 # tidy-alphabetical-end

--- a/compiler/rustc_serialize/Cargo.toml
+++ b/compiler/rustc_serialize/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2024"
 indexmap = "2.0.0"
 rustc_hashes = { path = "../rustc_hashes" }
 smallvec = { version = "1.8.1", features = ["union", "may_dangle"] }
-thin-vec = "0.2.15"
+thin-vec = "0.2.18"
 # tidy-alphabetical-end
 
 [dev-dependencies]

--- a/compiler/rustc_trait_selection/Cargo.toml
+++ b/compiler/rustc_trait_selection/Cargo.toml
@@ -19,6 +19,6 @@ rustc_session = { path = "../rustc_session" }
 rustc_span = { path = "../rustc_span" }
 rustc_transmute = { path = "../rustc_transmute", features = ["rustc"] }
 smallvec = { version = "1.8.1", features = ["union", "may_dangle"] }
-thin-vec = "0.2.15"
+thin-vec = "0.2.18"
 tracing = "0.1"
 # tidy-alphabetical-end

--- a/compiler/rustc_type_ir/Cargo.toml
+++ b/compiler/rustc_type_ir/Cargo.toml
@@ -23,7 +23,7 @@ rustc_type_ir_macros = { path = "../rustc_type_ir_macros" }
 smallvec = { version = "1.8.1", default-features = false, features = [
     "const_generics",
 ] }
-thin-vec = "0.2.15"
+thin-vec = "0.2.18"
 tracing = "0.1"
 # tidy-alphabetical-end
 

--- a/library/alloc/src/task.rs
+++ b/library/alloc/src/task.rs
@@ -39,7 +39,7 @@ use crate::sync::Arc;
 ///
 /// # Memory Ordering
 ///
-/// To avoid missed wakeups, all runtimes must adhere to the requirement described for [`Waker::wake`].
+/// To avoid missed wakeups, all executors must adhere to the requirement described for [`Waker::wake`].
 ///
 /// # Examples
 ///

--- a/library/alloc/src/task.rs
+++ b/library/alloc/src/task.rs
@@ -37,6 +37,10 @@ use crate::sync::Arc;
 ///      link ../../std/task/struct.Waker.html#impl-From%3CArc%3CW,+Global%3E%3E-for-Waker
 ///      without getting a link-checking error in CI. -->
 ///
+/// # Memory Ordering
+///
+/// To avoid missed wakeups, all runtimes must adhere to the requirement described for [`Waker::wake`].
+///
 /// # Examples
 ///
 /// A basic `block_on` function that takes a future and runs it to completion on

--- a/library/core/src/task/wake.rs
+++ b/library/core/src/task/wake.rs
@@ -434,7 +434,7 @@ impl Waker {
     ///
     /// To avoid missed wakeups, runtimes must ensure that for any call to `wake`,
     /// there is a subsequent call to `poll` such that the call to `wake()` _happens-before_
-    /// the beginning of the invocation of `poll`. 
+    /// the beginning of the invocation of `poll`.
     /// In particular, this means that if a task self-wakes (invokes `wake` on itself during `poll`),
     /// then the `poll` must be invoked again because the call to `wake` _happens-after_ the beginning
     /// of the current invocation of `poll`.

--- a/library/core/src/task/wake.rs
+++ b/library/core/src/task/wake.rs
@@ -432,6 +432,13 @@ impl Waker {
     /// executor’s choice which task to run and the executor may choose to run the
     /// current task again.
     ///
+    /// To avoid missed wakeups, runtimes must ensure that for any call to `wake`,
+    /// there is a subsequent call to `poll` such that the `wake()` return _happens-before_
+    /// the beginning of the invocation of `poll`. 
+    /// In particular, this means that if a task self-wakes (invokes `wake` on itself during `poll`),
+    /// then the `poll` must be invoked again because the call to `wake` _happens-after_ the beginning
+    /// of the current invocation of `poll`.
+    ///
     /// [`poll()`]: crate::future::Future::poll
     #[inline]
     #[stable(feature = "futures_api", since = "1.36.0")]

--- a/library/core/src/task/wake.rs
+++ b/library/core/src/task/wake.rs
@@ -421,7 +421,7 @@ impl Waker {
     /// As long as the executor keeps running and the task is not finished,
     /// it is guaranteed that each invocation of [`wake()`](Self::wake) (or
     /// [`wake_by_ref()`](Self::wake_by_ref)) will be followed by at least one
-    /// [`poll()`] of the task to which this `Waker` belongs, and the call to
+    /// [`poll()`] of the task to which this `Waker` belongs, such that the call to
     /// [`wake()`](Self::wake) (or [`wake_by_ref()`](Self::wake_by_ref)) _happens-before_
     /// the beginning of the invocation of [`poll()`]. This makes it possible to temporarily
     /// yield to other tasks while running potentially unbounded processing loops.

--- a/library/core/src/task/wake.rs
+++ b/library/core/src/task/wake.rs
@@ -432,7 +432,7 @@ impl Waker {
     /// executor’s choice which task to run and the executor may choose to run the
     /// current task again.
     ///
-    /// To avoid missed wakeups, runtimes must ensure that for any call to
+    /// To avoid missed wakeups, executors must ensure that for any call to
     /// `wake`, there is a subsequent call to `poll` such that the call to
     /// `wake()` _happens-before_ the beginning of the invocation of `poll`. In
     /// particular, this means that if a task self-wakes (invokes `wake` on

--- a/library/core/src/task/wake.rs
+++ b/library/core/src/task/wake.rs
@@ -432,12 +432,13 @@ impl Waker {
     /// executor’s choice which task to run and the executor may choose to run the
     /// current task again.
     ///
-    /// To avoid missed wakeups, runtimes must ensure that for any call to `wake`,
-    /// there is a subsequent call to `poll` such that the call to `wake()` _happens-before_
-    /// the beginning of the invocation of `poll`.
-    /// In particular, this means that if a task self-wakes (invokes `wake` on itself during `poll`),
-    /// then the `poll` must be invoked again because the call to `wake` _happens-after_ the beginning
-    /// of the current invocation of `poll`.
+    /// To avoid missed wakeups, runtimes must ensure that for any call to
+    /// `wake`, there is a subsequent call to `poll` such that the call to
+    /// `wake()` _happens-before_ the beginning of the invocation of `poll`. In
+    /// particular, this means that if a task self-wakes (invokes `wake` on
+    /// itself during `poll`), then the `poll` must be invoked again because the
+    /// call to `wake` _happens-after_ the beginning of the current invocation
+    /// of `poll`.
     ///
     /// [`poll()`]: crate::future::Future::poll
     #[inline]

--- a/library/core/src/task/wake.rs
+++ b/library/core/src/task/wake.rs
@@ -418,27 +418,20 @@ unsafe impl Sync for Waker {}
 impl Waker {
     /// Wakes up the task associated with this `Waker`.
     ///
-    /// As long as the executor keeps running and the task is not finished, it is
-    /// guaranteed that each invocation of [`wake()`](Self::wake) (or
+    /// As long as the executor keeps running and the task is not finished,
+    /// it is guaranteed that each invocation of [`wake()`](Self::wake) (or
     /// [`wake_by_ref()`](Self::wake_by_ref)) will be followed by at least one
-    /// [`poll()`] of the task to which this `Waker` belongs. This makes
-    /// it possible to temporarily yield to other tasks while running potentially
-    /// unbounded processing loops.
+    /// [`poll()`] of the task to which this `Waker` belongs, and the call to
+    /// [`wake()`](Self::wake) (or [`wake_by_ref()`](Self::wake_by_ref)) _happens-before_
+    /// the beginning of the invocation of [`poll()`]. This makes it possible to temporarily
+    /// yield to other tasks while running potentially unbounded processing loops.
     ///
     /// Note that the above implies that multiple wake-ups may be coalesced into a
-    /// single [`poll()`] invocation by the runtime.
+    /// single [`poll()`] invocation by the executor.
     ///
     /// Also note that yielding to competing tasks is not guaranteed: it is the
     /// executor’s choice which task to run and the executor may choose to run the
     /// current task again.
-    ///
-    /// To avoid missed wakeups, executors must ensure that for any call to
-    /// `wake`, there is a subsequent call to `poll` such that the call to
-    /// `wake()` _happens-before_ the beginning of the invocation of `poll`. In
-    /// particular, this means that if a task self-wakes (invokes `wake` on
-    /// itself during `poll`), then the `poll` must be invoked again because the
-    /// call to `wake` _happens-after_ the beginning of the current invocation
-    /// of `poll`.
     ///
     /// [`poll()`]: crate::future::Future::poll
     #[inline]

--- a/library/core/src/task/wake.rs
+++ b/library/core/src/task/wake.rs
@@ -433,7 +433,7 @@ impl Waker {
     /// current task again.
     ///
     /// To avoid missed wakeups, runtimes must ensure that for any call to `wake`,
-    /// there is a subsequent call to `poll` such that the `wake()` return _happens-before_
+    /// there is a subsequent call to `poll` such that the `wake()` _happens-before_
     /// the beginning of the invocation of `poll`. 
     /// In particular, this means that if a task self-wakes (invokes `wake` on itself during `poll`),
     /// then the `poll` must be invoked again because the call to `wake` _happens-after_ the beginning

--- a/library/core/src/task/wake.rs
+++ b/library/core/src/task/wake.rs
@@ -433,7 +433,7 @@ impl Waker {
     /// current task again.
     ///
     /// To avoid missed wakeups, runtimes must ensure that for any call to `wake`,
-    /// there is a subsequent call to `poll` such that the `wake()` _happens-before_
+    /// there is a subsequent call to `poll` such that the call to `wake()` _happens-before_
     /// the beginning of the invocation of `poll`. 
     /// In particular, this means that if a task self-wakes (invokes `wake` on itself during `poll`),
     /// then the `poll` must be invoked again because the call to `wake` _happens-after_ the beginning

--- a/library/proc_macro/src/lib.rs
+++ b/library/proc_macro/src/lib.rs
@@ -197,6 +197,7 @@ impl fmt::Display for EscapeError {
 /// Errors returned when trying to retrieve a literal unescaped value.
 #[unstable(feature = "proc_macro_value", issue = "136652")]
 #[derive(Debug, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum ConversionErrorKind {
     /// The literal failed to be escaped, take a look at [`EscapeError`] for more information.
     FailedToUnescape(EscapeError),

--- a/library/std/src/net/tcp.rs
+++ b/library/std/src/net/tcp.rs
@@ -878,16 +878,20 @@ impl TcpListener {
     ///
     /// # Errors
     ///
-    /// Some errors returned by this function relate to a single incoming
-    /// connection that failed before it could be accepted, such as one aborted
-    /// by the peer ([`ConnectionAborted`]). Such an error does not indicate a
-    /// problem with the listener itself, which remains usable. Code serving a
-    /// long-lived listener will usually want to log the error and continue
-    /// accepting connections rather than treat it as fatal. Which errors can
-    /// occur this way is platform-specific.
+    /// Some errors this function returns do not indicate a problem with the
+    /// listener itself, and a program serving a long-lived listener will
+    /// usually want to handle them and keep accepting connections rather than
+    /// treat them as fatal. These include, but are not limited to:
     ///
-    /// On Unix, [`Interrupted`] errors are retried internally rather than being
-    /// returned.
+    /// - An error specific to a single incoming connection that failed before
+    ///   it could be accepted, such as one aborted by the peer
+    ///   ([`ConnectionAborted`]). A later call may succeed immediately.
+    /// - An error from reaching the per-process or system-wide open file
+    ///   descriptor limit. The call can be retried once other file descriptors
+    ///   have been closed, typically after a short delay.
+    ///
+    /// Which errors can occur is platform-specific. On Unix, [`Interrupted`]
+    /// errors are retried internally rather than being returned.
     ///
     /// [`ConnectionAborted`]: io::ErrorKind::ConnectionAborted
     /// [`Interrupted`]: io::ErrorKind::Interrupted

--- a/library/std/src/net/tcp.rs
+++ b/library/std/src/net/tcp.rs
@@ -876,6 +876,22 @@ impl TcpListener {
     /// is established. When established, the corresponding [`TcpStream`] and the
     /// remote peer's address will be returned.
     ///
+    /// # Errors
+    ///
+    /// Some errors returned by this function relate to a single incoming
+    /// connection that failed before it could be accepted, such as one aborted
+    /// by the peer ([`ConnectionAborted`]). Such an error does not indicate a
+    /// problem with the listener itself, which remains usable. Code serving a
+    /// long-lived listener will usually want to log the error and continue
+    /// accepting connections rather than treat it as fatal. Which errors can
+    /// occur this way is platform-specific.
+    ///
+    /// On Unix, [`Interrupted`] errors are retried internally rather than being
+    /// returned.
+    ///
+    /// [`ConnectionAborted`]: io::ErrorKind::ConnectionAborted
+    /// [`Interrupted`]: io::ErrorKind::Interrupted
+    ///
     /// # Examples
     ///
     /// ```no_run
@@ -901,6 +917,11 @@ impl TcpListener {
     /// The returned iterator will never return [`None`] and will also not yield
     /// the peer's [`SocketAddr`] structure. Iterating over it is equivalent to
     /// calling [`TcpListener::accept`] in a loop.
+    ///
+    /// # Errors
+    ///
+    /// Each connection yielded by the iterator can fail for the same reasons as
+    /// [`TcpListener::accept`]; see its documentation for details.
     ///
     /// # Examples
     ///
@@ -936,6 +957,11 @@ impl TcpListener {
     /// The returned iterator will never return [`None`] and will also not yield
     /// the peer's [`SocketAddr`] structure. Iterating over it is equivalent to
     /// calling [`TcpListener::accept`] in a loop.
+    ///
+    /// # Errors
+    ///
+    /// Each connection yielded by the iterator can fail for the same reasons as
+    /// [`TcpListener::accept`]; see its documentation for details.
     ///
     /// # Examples
     ///

--- a/library/std/src/net/tcp.rs
+++ b/library/std/src/net/tcp.rs
@@ -889,11 +889,14 @@ impl TcpListener {
     /// - An error from reaching the per-process or system-wide open file
     ///   descriptor limit. The call can be retried once other file descriptors
     ///   have been closed, typically after a short delay.
+    /// - An error from failing to allocate memory while accepting a connection
+    ///   ([`OutOfMemory`]).
     ///
     /// Which errors can occur is platform-specific. On Unix, [`Interrupted`]
     /// errors are retried internally rather than being returned.
     ///
     /// [`ConnectionAborted`]: io::ErrorKind::ConnectionAborted
+    /// [`OutOfMemory`]: io::ErrorKind::OutOfMemory
     /// [`Interrupted`]: io::ErrorKind::Interrupted
     ///
     /// # Examples

--- a/src/rustdoc-json-types/Cargo.toml
+++ b/src/rustdoc-json-types/Cargo.toml
@@ -18,4 +18,4 @@ rkyv = { version = "0.8", optional = true }
 
 [dev-dependencies]
 serde_json = "1.0"
-bincode = "1"
+postcard = { version = "1", default-features = false, features = ["alloc"] }

--- a/src/rustdoc-json-types/tests.rs
+++ b/src/rustdoc-json-types/tests.rs
@@ -13,9 +13,9 @@ fn test_struct_info_roundtrip() {
     let de_s = serde_json::from_str(&struct_json).unwrap();
     assert_eq!(s, de_s);
 
-    // Bincode
-    let encoded: Vec<u8> = bincode::serialize(&s).unwrap();
-    let decoded: ItemEnum = bincode::deserialize(&encoded).unwrap();
+    // Postcard
+    let encoded: Vec<u8> = postcard::to_allocvec(&s).unwrap();
+    let decoded: ItemEnum = postcard::from_bytes(&encoded).unwrap();
     assert_eq!(s, decoded);
 }
 
@@ -33,9 +33,9 @@ fn test_union_info_roundtrip() {
     let de_u = serde_json::from_str(&union_json).unwrap();
     assert_eq!(u, de_u);
 
-    // Bincode
-    let encoded: Vec<u8> = bincode::serialize(&u).unwrap();
-    let decoded: ItemEnum = bincode::deserialize(&encoded).unwrap();
+    // Postcard
+    let encoded: Vec<u8> = postcard::to_allocvec(&u).unwrap();
+    let decoded: ItemEnum = postcard::from_bytes(&encoded).unwrap();
     assert_eq!(u, decoded);
 }
 
@@ -59,7 +59,7 @@ mod rkyv {
     /// A test to exercise the (de)serialization roundtrip for a representative selection of types,
     /// covering most of the rkyv-specific attributes we had to had.
     fn test_rkyv_roundtrip() {
-        // Standard derives: a plain struct and union, mirroring the existing serde/bincode tests.
+        // Standard derives: a plain struct and union, mirroring the existing serde/postcard tests.
         let s = ItemEnum::Struct(Struct {
             generics: Generics { params: vec![], where_predicates: vec![] },
             kind: StructKind::Plain { fields: vec![Id(1), Id(2)], has_stripped_fields: false },

--- a/tests/ui/reborrow/generic-reborrow-expr-use-visitor-closure.rs
+++ b/tests/ui/reborrow/generic-reborrow-expr-use-visitor-closure.rs
@@ -1,0 +1,34 @@
+//@ check-pass
+
+#![feature(reborrow)]
+
+use std::marker::{CoerceShared, Reborrow};
+
+#[allow(unused)]
+struct CustomMut<'a, T>(&'a mut T);
+impl<'a, T> Reborrow for CustomMut<'a, T> {}
+impl<'a, T> CoerceShared<CustomRef<'a, T>> for CustomMut<'a, T> {}
+
+#[allow(unused)]
+struct CustomRef<'a, T>(&'a T);
+impl<'a, T> Clone for CustomRef<'a, T> {
+    fn clone(&self) -> Self {
+        Self(self.0)
+    }
+}
+impl<'a, T> Copy for CustomRef<'a, T> {}
+
+fn takes_mut(_: CustomMut<'_, ()>) {}
+fn takes_shared(_: CustomRef<'_, ()>) {}
+
+fn main() {
+    let a = CustomMut(&mut ());
+
+    let mut f = || {
+        takes_mut(a);
+        takes_shared(a);
+    };
+
+    f();
+    f();
+}

--- a/tests/ui/reborrow/generic-reborrow-expr-use-visitor.rs
+++ b/tests/ui/reborrow/generic-reborrow-expr-use-visitor.rs
@@ -1,0 +1,32 @@
+//@ check-pass
+
+#![feature(reborrow)]
+
+use std::marker::{CoerceShared, Reborrow};
+
+#[allow(unused)]
+struct CustomMut<'a, T>(&'a mut T);
+impl<'a, T> Reborrow for CustomMut<'a, T> {}
+impl<'a, T> CoerceShared<CustomRef<'a, T>> for CustomMut<'a, T> {}
+
+#[allow(unused)]
+struct CustomRef<'a, T>(&'a T);
+impl<'a, T> Clone for CustomRef<'a, T> {
+    fn clone(&self) -> Self {
+        Self(self.0)
+    }
+}
+impl<'a, T> Copy for CustomRef<'a, T> {}
+
+fn takes_mut(_: CustomMut<'_, ()>) {}
+fn takes_shared(_: CustomRef<'_, ()>) {}
+
+fn main() {
+    let a = CustomMut(&mut ());
+
+    takes_mut(a);
+    takes_mut(a);
+
+    takes_shared(a);
+    takes_shared(a);
+}

--- a/tests/ui/reborrow/reborrow-source-unsafety.rs
+++ b/tests/ui/reborrow/reborrow-source-unsafety.rs
@@ -1,0 +1,28 @@
+// Regression test for rust-lang/rust#158033.
+
+#![feature(reborrow)]
+#![allow(dead_code)]
+#![deny(unsafe_code)]
+
+use std::marker::Reborrow;
+
+struct Thing<'a> {
+    field: &'a mut usize,
+}
+
+impl<'a> Reborrow for Thing<'a> {}
+
+fn takes(_: Thing<'_>) {}
+
+fn main() {
+    let mut x = 0;
+    let thing = Thing { field: &mut x };
+    let y = 123usize;
+
+    takes({
+        let p: *const usize = &y;
+        std::hint::black_box(std::ptr::read(p));
+        //~^ ERROR call to unsafe function `std::ptr::read` is unsafe
+        thing
+    });
+}

--- a/tests/ui/reborrow/reborrow-source-unsafety.stderr
+++ b/tests/ui/reborrow/reborrow-source-unsafety.stderr
@@ -1,0 +1,11 @@
+error[E0133]: call to unsafe function `std::ptr::read` is unsafe and requires unsafe function or block
+  --> $DIR/reborrow-source-unsafety.rs:24:30
+   |
+LL |         std::hint::black_box(std::ptr::read(p));
+   |                              ^^^^^^^^^^^^^^^^^ call to unsafe function
+   |
+   = note: consult the function's documentation for information on how to avoid undefined behavior
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0133`.


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#158026 (`RegionValues`: disable unnecessary range check)
 - rust-lang/rust#156795 (Handle generic reborrow in expression-use adjustment walking)
 - rust-lang/rust#157694 (Enhance documentation on wake call memory ordering)
 - rust-lang/rust#157935 (Make `proc_macro::ConversionErrorKind` non exhaustive)
 - rust-lang/rust#158002 (Replace `unwrap` with `expect` in `get_module_children`)
 - rust-lang/rust#158034 (Fix reborrow source expression visits)
 - rust-lang/rust#158072 (Bump thin-vec to 0.2.18 to address RUSTSEC-2026-0103)
 - rust-lang/rust#158074 (Document transient connection errors from TcpListener::accept)
 - rust-lang/rust#158077 (rustdoc-json-types: Replace bincode dev-dependency with postcard)
 - rust-lang/rust#158086 (renovate: Loosen dashboard approval and adopt recommended config)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=158026,156795,157694,157935,158002,158034,158072,158074,158077,158086)
<!-- homu-ignore:end -->

