### PR TITLE
rustc_llvm: Emit module summaries when using -Clto=fat

### DIFF
--- a/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
@@ -924,7 +924,15 @@ extern "C" LLVMRustResult LLVMRustOptimize(
       MPM.addPass(ThinLTOBitcodeWriterPass(
           ThinLTODataOS, ThinLTOSummaryBufferRef ? &ThinLinkDataOS : nullptr));
     } else {
-      MPM.addPass(BitcodeWriterPass(ThinLTODataOS));
+      // Force Full LTO summary for embedded bitcode under Fat LTO.
+      //
+      // Note the bitcode writer will only emit the full LTO block ID if the "ThinLTO"
+      // metadata is defined and explicitly set to zero. Otherwise, the thin LTO block
+      // ID will be emitted.
+      auto *Zero = ConstantInt::get(Type::getInt32Ty(TheModule->getContext()), 0);
+      TheModule->addModuleFlag(Module::Error, "ThinLTO", Zero);
+      MPM.addPass(BitcodeWriterPass(ThinLTODataOS, /*ShouldPreserveUseListOrder=*/false,
+                                    /*EmitSummaryIndex=*/true));
     }
     *ThinLTOBufferRef = ThinLTOBuffer.release();
     if (ThinLTOSummaryBufferRef) {
@@ -1442,23 +1450,32 @@ extern "C" LLVMRustBuffer *LLVMRustModuleSerialize(LLVMModuleRef M,
   {
     auto OS = raw_string_ostream(Ret->data);
     {
+      PassBuilder PB;
+      LoopAnalysisManager LAM;
+      FunctionAnalysisManager FAM;
+      CGSCCAnalysisManager CGAM;
+      ModuleAnalysisManager MAM;
+      PB.registerModuleAnalyses(MAM);
+      PB.registerCGSCCAnalyses(CGAM);
+      PB.registerFunctionAnalyses(FAM);
+      PB.registerLoopAnalyses(LAM);
+      PB.crossRegisterProxies(LAM, FAM, CGAM, MAM);
+
+      ModulePassManager MPM;
       if (is_thin) {
-        PassBuilder PB;
-        LoopAnalysisManager LAM;
-        FunctionAnalysisManager FAM;
-        CGSCCAnalysisManager CGAM;
-        ModuleAnalysisManager MAM;
-        PB.registerModuleAnalyses(MAM);
-        PB.registerCGSCCAnalyses(CGAM);
-        PB.registerFunctionAnalyses(FAM);
-        PB.registerLoopAnalyses(LAM);
-        PB.crossRegisterProxies(LAM, FAM, CGAM, MAM);
-        ModulePassManager MPM;
         MPM.addPass(ThinLTOBitcodeWriterPass(OS, nullptr));
-        MPM.run(*unwrap(M), MAM);
       } else {
-        WriteBitcodeToFile(*unwrap(M), OS);
+        // Force Full LTO summary for embedded bitcode under Fat LTO.
+        //
+        // Note the bitcode writer will only emit the full LTO block ID if the "ThinLTO"
+        // metadata is defined and explicitly set to zero. Otherwise, the thin LTO block
+        // ID will be emitted.
+        auto *Zero = ConstantInt::get(Type::getInt32Ty(unwrap(M)->getContext()), 0);
+        unwrap(M)->addModuleFlag(Module::Error, "ThinLTO", Zero);
+        MPM.addPass(BitcodeWriterPass(OS, /*ShouldPreserveUseListOrder=*/false,
+                                      /*EmitSummaryIndex=*/true));
       }
+      MPM.run(*unwrap(M), MAM);
     }
   }
   return Ret.release();

--- a/tests/run-make/fat-lto-module-summary/foo.rs
+++ b/tests/run-make/fat-lto-module-summary/foo.rs
@@ -1,0 +1,1 @@
+pub fn foo() {}

--- a/tests/run-make/fat-lto-module-summary/rmake.rs
+++ b/tests/run-make/fat-lto-module-summary/rmake.rs
@@ -1,0 +1,10 @@
+use run_make_support::{llvm_bcanalyzer, rustc};
+
+fn main() {
+    rustc().input("foo.rs").crate_type("lib").arg("-Clto=fat").arg("--emit=llvm-bc").run();
+
+    llvm_bcanalyzer()
+        .input("foo.bc")
+        .run()
+        .assert_stdout_contains("FULL_LTO_GLOBALVAL_SUMMARY_BLOCK");
+}


### PR DESCRIPTION
Currently, module summaries are only emitted with thin lto. If we would link full/fat lto'd rust code against lto'd c++ code built with CFI (or WPD), those passes would fail during the link step because the participating rust modules are missing module summaries. Rust code does not know at compile-time if it would be participating in some special link which may require module summaries, so this PR ensures module summaries are unconditionally emitted for full/fat lto, just like with thin lto.

The WriteBitcodeToFile function just invokes the normal BitcodeWriterPass under the hood, but doesn't provide a way to set the argument for emitting module summaries. So this patch just adds the pass directly and sets that argument.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
