### PR TITLE
Initialize directly in `From<T> for OnceLock<T>`

### DIFF
--- a/library/std/src/sync/once_lock.rs
+++ b/library/std/src/sync/once_lock.rs
@@ -656,10 +656,10 @@ impl<T> From<T> for OnceLock<T> {
     /// ```
     #[inline]
     fn from(value: T) -> Self {
-        let cell = Self::new();
-        match cell.set(value) {
-            Ok(()) => cell,
-            Err(_) => unreachable!(),
+        OnceLock {
+            once: Once::new_complete(),
+            value: UnsafeCell::new(MaybeUninit::new(value)),
+            _marker: PhantomData,
         }
     }
 }


### PR DESCRIPTION
There's no need to jump through all the hoops of `set` when we are
creating a new `OnceLock` from scratch.
