### PR TITLE
Extract all instance shim variants into new `ShimKind` enum

### DIFF
--- a/compiler/rustc_codegen_cranelift/src/abi/mod.rs
+++ b/compiler/rustc_codegen_cranelift/src/abi/mod.rs
@@ -16,9 +16,9 @@ use rustc_abi::{CanonAbi, ExternAbi, X86Call};
 use rustc_codegen_ssa::base::is_call_from_compiler_builtins_to_upstream_monomorphization;
 use rustc_codegen_ssa::errors::CompilerBuiltinsCannotCall;
 use rustc_middle::middle::codegen_fn_attrs::CodegenFnAttrFlags;
-use rustc_middle::ty::TypeVisitableExt;
 use rustc_middle::ty::layout::FnAbiOf;
 use rustc_middle::ty::print::with_no_trimmed_paths;
+use rustc_middle::ty::{ShimKind, TypeVisitableExt};
 use rustc_session::Session;
 use rustc_span::Spanned;
 use rustc_target::callconv::{FnAbi, PassMode};
@@ -467,7 +467,7 @@ pub(crate) fn codegen_terminator_call<'tcx>(
             }
             // We don't need AsyncDropGlueCtorShim here because it is not `noop func`,
             // it is `func returning noop future`
-            InstanceKind::DropGlue(_, None) => {
+            InstanceKind::Shim(ShimKind::DropGlue(_, None)) => {
                 // empty drop glue - a nop.
                 let dest = target.expect("Non terminating drop_in_place_real???");
                 let ret_block = fx.get_block(dest);
@@ -725,7 +725,7 @@ pub(crate) fn codegen_drop<'tcx>(
     let ret_block = fx.get_block(target);
 
     // AsyncDropGlueCtorShim can't be here
-    if let ty::InstanceKind::DropGlue(_, None) = drop_instance.def {
+    if let ty::InstanceKind::Shim(ty::ShimKind::DropGlue(_, None)) = drop_instance.def {
         // we don't actually need to drop anything
         fx.bcx.ins().jump(ret_block, &[]);
     } else {

--- a/compiler/rustc_codegen_cranelift/src/constant.rs
+++ b/compiler/rustc_codegen_cranelift/src/constant.rs
@@ -53,7 +53,7 @@ pub(crate) fn codegen_tls_ref<'tcx>(
 ) -> CValue<'tcx> {
     let tls_ptr = if !def_id.is_local() && fx.tcx.needs_thread_local_shim(def_id) {
         let instance = ty::Instance {
-            def: ty::InstanceKind::Shim(ty::ShimKind::ThreadLocalShim(def_id)),
+            def: ty::InstanceKind::Shim(ty::ShimKind::ThreadLocal(def_id)),
             args: ty::GenericArgs::empty(),
         };
         let func_ref = fx.get_function_ref(instance);

--- a/compiler/rustc_codegen_cranelift/src/constant.rs
+++ b/compiler/rustc_codegen_cranelift/src/constant.rs
@@ -53,7 +53,7 @@ pub(crate) fn codegen_tls_ref<'tcx>(
 ) -> CValue<'tcx> {
     let tls_ptr = if !def_id.is_local() && fx.tcx.needs_thread_local_shim(def_id) {
         let instance = ty::Instance {
-            def: ty::InstanceKind::ThreadLocalShim(def_id),
+            def: ty::InstanceKind::Shim(ty::ShimKind::ThreadLocalShim(def_id)),
             args: ty::GenericArgs::empty(),
         };
         let func_ref = fx.get_function_ref(instance);

--- a/compiler/rustc_codegen_ssa/src/back/symbol_export.rs
+++ b/compiler/rustc_codegen_ssa/src/back/symbol_export.rs
@@ -361,7 +361,7 @@ fn exported_generic_symbols_provider_local<'tcx>(
                     }
                 }
                 MonoItem::Fn(Instance {
-                    def: InstanceKind::Shim(ShimKind::AsyncDropGlueCtorShim(_, ty)),
+                    def: InstanceKind::Shim(ShimKind::AsyncDropGlueCtor(_, ty)),
                     args,
                 }) => {
                     // A little sanity-check
@@ -586,7 +586,7 @@ pub(crate) fn symbol_name_for_instance_in_crate<'tcx>(
             rustc_symbol_mangling::symbol_name_for_instance_in_crate(
                 tcx,
                 ty::Instance {
-                    def: ty::InstanceKind::Shim(ty::ShimKind::ThreadLocalShim(def_id)),
+                    def: ty::InstanceKind::Shim(ty::ShimKind::ThreadLocal(def_id)),
                     args: ty::GenericArgs::empty(),
                 },
                 instantiating_crate,

--- a/compiler/rustc_codegen_ssa/src/back/symbol_export.rs
+++ b/compiler/rustc_codegen_ssa/src/back/symbol_export.rs
@@ -11,7 +11,9 @@ use rustc_middle::middle::exported_symbols::{
     ExportedSymbol, SymbolExportInfo, SymbolExportKind, SymbolExportLevel,
 };
 use rustc_middle::query::LocalCrate;
-use rustc_middle::ty::{self, GenericArgKind, GenericArgsRef, Instance, SymbolName, Ty, TyCtxt};
+use rustc_middle::ty::{
+    self, GenericArgKind, GenericArgsRef, Instance, ShimKind, SymbolName, Ty, TyCtxt,
+};
 use rustc_middle::util::Providers;
 use rustc_session::config::CrateType;
 use rustc_span::Span;
@@ -332,7 +334,10 @@ fn exported_generic_symbols_provider_local<'tcx>(
                         ));
                     }
                 }
-                MonoItem::Fn(Instance { def: InstanceKind::DropGlue(_, Some(ty)), args }) => {
+                MonoItem::Fn(Instance {
+                    def: InstanceKind::Shim(ShimKind::DropGlue(_, Some(ty))),
+                    args,
+                }) => {
                     // A little sanity-check
                     assert_eq!(args.non_erasable_generics().next(), Some(GenericArgKind::Type(ty)));
 
@@ -356,7 +361,7 @@ fn exported_generic_symbols_provider_local<'tcx>(
                     }
                 }
                 MonoItem::Fn(Instance {
-                    def: InstanceKind::AsyncDropGlueCtorShim(_, ty),
+                    def: InstanceKind::Shim(ShimKind::AsyncDropGlueCtorShim(_, ty)),
                     args,
                 }) => {
                     // A little sanity-check
@@ -371,7 +376,10 @@ fn exported_generic_symbols_provider_local<'tcx>(
                         },
                     ));
                 }
-                MonoItem::Fn(Instance { def: InstanceKind::AsyncDropGlue(def, ty), args: _ }) => {
+                MonoItem::Fn(Instance {
+                    def: InstanceKind::Shim(ShimKind::AsyncDropGlue(def, ty)),
+                    args: _,
+                }) => {
                     symbols.push((
                         ExportedSymbol::AsyncDropGlue(def, ty),
                         SymbolExportInfo {
@@ -578,7 +586,7 @@ pub(crate) fn symbol_name_for_instance_in_crate<'tcx>(
             rustc_symbol_mangling::symbol_name_for_instance_in_crate(
                 tcx,
                 ty::Instance {
-                    def: ty::InstanceKind::ThreadLocalShim(def_id),
+                    def: ty::InstanceKind::Shim(ty::ShimKind::ThreadLocalShim(def_id)),
                     args: ty::GenericArgs::empty(),
                 },
                 instantiating_crate,

--- a/compiler/rustc_codegen_ssa/src/mir/block.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/block.rs
@@ -618,7 +618,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
         let ty = self.monomorphize(ty);
         let drop_fn = Instance::resolve_drop_glue(bx.tcx(), ty);
 
-        if let ty::InstanceKind::DropGlue(_, None) = drop_fn.def {
+        if let ty::InstanceKind::Shim(ty::ShimKind::DropGlue(_, None)) = drop_fn.def {
             // we don't actually need to drop anything.
             return helper.funclet_br(self, bx, target, mergeable_succ, &[]);
         }
@@ -934,7 +934,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                 match instance.def {
                     // We don't need AsyncDropGlueCtorShim here because it is not `noop func`,
                     // it is `func returning noop future`
-                    ty::InstanceKind::DropGlue(_, None) => {
+                    ty::InstanceKind::Shim(ty::ShimKind::DropGlue(_, None)) => {
                         // Empty drop glue; a no-op.
                         let target = target.unwrap();
                         return helper.funclet_br(self, bx, target, mergeable_succ, &[]);

--- a/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
@@ -665,7 +665,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                 let static_ = if !def_id.is_local() && bx.cx().tcx().needs_thread_local_shim(def_id)
                 {
                     let instance = ty::Instance {
-                        def: ty::InstanceKind::Shim(ty::ShimKind::ThreadLocalShim(def_id)),
+                        def: ty::InstanceKind::Shim(ty::ShimKind::ThreadLocal(def_id)),
                         args: ty::GenericArgs::empty(),
                     };
                     let fn_ptr = bx.get_fn_addr(instance);

--- a/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
@@ -665,7 +665,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                 let static_ = if !def_id.is_local() && bx.cx().tcx().needs_thread_local_shim(def_id)
                 {
                     let instance = ty::Instance {
-                        def: ty::InstanceKind::ThreadLocalShim(def_id),
+                        def: ty::InstanceKind::Shim(ty::ShimKind::ThreadLocalShim(def_id)),
                         args: ty::GenericArgs::empty(),
                     };
                     let fn_ptr = bx.get_fn_addr(instance);

--- a/compiler/rustc_const_eval/src/interpret/call.rs
+++ b/compiler/rustc_const_eval/src/interpret/call.rs
@@ -428,7 +428,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         // Determine whether this is a non-capturing closure. That's relevant as their first
         // argument can be skipped (and that's the only kind of argument skipping we allow).
         let is_non_capturing_closure =
-            (matches!(instance.def, ty::InstanceKind::ClosureOnceShim { .. })
+            (matches!(instance.def, ty::InstanceKind::Shim(ty::ShimKind::ClosureOnceShim { .. }))
                 || self.tcx.is_closure_like(def_id))
                 && {
                     let arg = &callee_fn_abi.args[0];
@@ -652,18 +652,18 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                     interp_ok(())
                 }
             }
-            ty::InstanceKind::VTableShim(..)
-            | ty::InstanceKind::ReifyShim(..)
-            | ty::InstanceKind::ClosureOnceShim { .. }
-            | ty::InstanceKind::ConstructCoroutineInClosureShim { .. }
-            | ty::InstanceKind::FnPtrShim(..)
-            | ty::InstanceKind::DropGlue(..)
-            | ty::InstanceKind::CloneShim(..)
-            | ty::InstanceKind::FnPtrAddrShim(..)
-            | ty::InstanceKind::ThreadLocalShim(..)
-            | ty::InstanceKind::AsyncDropGlueCtorShim(..)
-            | ty::InstanceKind::AsyncDropGlue(..)
-            | ty::InstanceKind::FutureDropPollShim(..)
+            ty::InstanceKind::Shim(ty::ShimKind::VTableShim(..))
+            | ty::InstanceKind::Shim(ty::ShimKind::ReifyShim(..))
+            | ty::InstanceKind::Shim(ty::ShimKind::ClosureOnceShim { .. })
+            | ty::InstanceKind::Shim(ty::ShimKind::ConstructCoroutineInClosureShim { .. })
+            | ty::InstanceKind::Shim(ty::ShimKind::FnPtrShim(..))
+            | ty::InstanceKind::Shim(ty::ShimKind::DropGlue(..))
+            | ty::InstanceKind::Shim(ty::ShimKind::CloneShim(..))
+            | ty::InstanceKind::Shim(ty::ShimKind::FnPtrAddrShim(..))
+            | ty::InstanceKind::Shim(ty::ShimKind::ThreadLocalShim(..))
+            | ty::InstanceKind::Shim(ty::ShimKind::AsyncDropGlueCtorShim(..))
+            | ty::InstanceKind::Shim(ty::ShimKind::AsyncDropGlue(..))
+            | ty::InstanceKind::Shim(ty::ShimKind::FutureDropPollShim(..))
             | ty::InstanceKind::Item(_) => {
                 // We need MIR for this fn.
                 // Note that this can be an intrinsic, if we are executing its fallback body.

--- a/compiler/rustc_const_eval/src/interpret/call.rs
+++ b/compiler/rustc_const_eval/src/interpret/call.rs
@@ -428,7 +428,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         // Determine whether this is a non-capturing closure. That's relevant as their first
         // argument can be skipped (and that's the only kind of argument skipping we allow).
         let is_non_capturing_closure =
-            (matches!(instance.def, ty::InstanceKind::Shim(ty::ShimKind::ClosureOnceShim { .. }))
+            (matches!(instance.def, ty::InstanceKind::Shim(ty::ShimKind::ClosureOnce { .. }))
                 || self.tcx.is_closure_like(def_id))
                 && {
                     let arg = &callee_fn_abi.args[0];
@@ -652,18 +652,18 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                     interp_ok(())
                 }
             }
-            ty::InstanceKind::Shim(ty::ShimKind::VTableShim(..))
-            | ty::InstanceKind::Shim(ty::ShimKind::ReifyShim(..))
-            | ty::InstanceKind::Shim(ty::ShimKind::ClosureOnceShim { .. })
-            | ty::InstanceKind::Shim(ty::ShimKind::ConstructCoroutineInClosureShim { .. })
-            | ty::InstanceKind::Shim(ty::ShimKind::FnPtrShim(..))
+            ty::InstanceKind::Shim(ty::ShimKind::VTable(..))
+            | ty::InstanceKind::Shim(ty::ShimKind::Reify(..))
+            | ty::InstanceKind::Shim(ty::ShimKind::ClosureOnce { .. })
+            | ty::InstanceKind::Shim(ty::ShimKind::ConstructCoroutineInClosure { .. })
+            | ty::InstanceKind::Shim(ty::ShimKind::FnPtr(..))
             | ty::InstanceKind::Shim(ty::ShimKind::DropGlue(..))
-            | ty::InstanceKind::Shim(ty::ShimKind::CloneShim(..))
-            | ty::InstanceKind::Shim(ty::ShimKind::FnPtrAddrShim(..))
-            | ty::InstanceKind::Shim(ty::ShimKind::ThreadLocalShim(..))
-            | ty::InstanceKind::Shim(ty::ShimKind::AsyncDropGlueCtorShim(..))
+            | ty::InstanceKind::Shim(ty::ShimKind::Clone(..))
+            | ty::InstanceKind::Shim(ty::ShimKind::FnPtrAddr(..))
+            | ty::InstanceKind::Shim(ty::ShimKind::ThreadLocal(..))
+            | ty::InstanceKind::Shim(ty::ShimKind::AsyncDropGlueCtor(..))
             | ty::InstanceKind::Shim(ty::ShimKind::AsyncDropGlue(..))
-            | ty::InstanceKind::Shim(ty::ShimKind::FutureDropPollShim(..))
+            | ty::InstanceKind::Shim(ty::ShimKind::FutureDropPoll(..))
             | ty::InstanceKind::Item(_) => {
                 // We need MIR for this fn.
                 // Note that this can be an intrinsic, if we are executing its fallback body.

--- a/compiler/rustc_const_eval/src/interpret/step.rs
+++ b/compiler/rustc_const_eval/src/interpret/step.rs
@@ -607,7 +607,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                         enter_trace_span!(M, resolve::resolve_drop_glue, ty = ?place.layout.ty);
                     Instance::resolve_drop_glue(*self.tcx, place.layout.ty)
                 };
-                if let ty::InstanceKind::DropGlue(_, None) = instance.def {
+                if let ty::InstanceKind::Shim(ty::ShimKind::DropGlue(_, None)) = instance.def {
                     // This is the branch we enter if and only if the dropped type has no drop glue
                     // whatsoever. This can happen as a result of monomorphizing a drop of a
                     // generic. In order to make sure that generic and non-generic code behaves

--- a/compiler/rustc_middle/src/middle/codegen_fn_attrs.rs
+++ b/compiler/rustc_middle/src/middle/codegen_fn_attrs.rs
@@ -8,7 +8,7 @@ use rustc_span::Symbol;
 use rustc_target::spec::SanitizerSet;
 
 use crate::mono::Visibility;
-use crate::ty::{InstanceKind, TyCtxt};
+use crate::ty::{InstanceKind, ShimKind, TyCtxt};
 
 impl<'tcx> TyCtxt<'tcx> {
     pub fn codegen_instance_attrs(
@@ -33,7 +33,7 @@ impl<'tcx> TyCtxt<'tcx> {
         //
         // A `ClosureOnceShim` with the track_caller attribute does not have a symbol,
         // and therefore can be skipped here.
-        if let InstanceKind::ReifyShim(_, _) = instance_kind
+        if let InstanceKind::Shim(ShimKind::ReifyShim(_, _)) = instance_kind
             && attrs.flags.contains(CodegenFnAttrFlags::TRACK_CALLER)
         {
             if attrs.flags.contains(CodegenFnAttrFlags::NO_MANGLE) {
@@ -54,8 +54,11 @@ impl<'tcx> TyCtxt<'tcx> {
         }
 
         // Ensure closure shims have the optimization properties of their closure applied to them.
-        if let InstanceKind::ClosureOnceShim { call_once: _, closure, track_caller: _ } =
-            instance_kind
+        if let InstanceKind::Shim(ShimKind::ClosureOnceShim {
+            call_once: _,
+            closure,
+            track_caller: _,
+        }) = instance_kind
         {
             let closure_attrs = self.codegen_fn_attrs(closure);
             attrs.to_mut().optimize = closure_attrs.optimize;

--- a/compiler/rustc_middle/src/middle/codegen_fn_attrs.rs
+++ b/compiler/rustc_middle/src/middle/codegen_fn_attrs.rs
@@ -33,7 +33,7 @@ impl<'tcx> TyCtxt<'tcx> {
         //
         // A `ClosureOnceShim` with the track_caller attribute does not have a symbol,
         // and therefore can be skipped here.
-        if let InstanceKind::Shim(ShimKind::ReifyShim(_, _)) = instance_kind
+        if let InstanceKind::Shim(ShimKind::Reify(_, _)) = instance_kind
             && attrs.flags.contains(CodegenFnAttrFlags::TRACK_CALLER)
         {
             if attrs.flags.contains(CodegenFnAttrFlags::NO_MANGLE) {
@@ -54,7 +54,7 @@ impl<'tcx> TyCtxt<'tcx> {
         }
 
         // Ensure closure shims have the optimization properties of their closure applied to them.
-        if let InstanceKind::Shim(ShimKind::ClosureOnceShim {
+        if let InstanceKind::Shim(ShimKind::ClosureOnce {
             call_once: _,
             closure,
             track_caller: _,

--- a/compiler/rustc_middle/src/middle/exported_symbols.rs
+++ b/compiler/rustc_middle/src/middle/exported_symbols.rs
@@ -75,7 +75,7 @@ impl<'tcx> ExportedSymbol<'tcx> {
                 tcx.symbol_name(ty::Instance::resolve_async_drop_in_place_poll(tcx, def_id, ty))
             }
             ExportedSymbol::ThreadLocalShim(def_id) => tcx.symbol_name(ty::Instance {
-                def: ty::InstanceKind::Shim(ty::ShimKind::ThreadLocalShim(def_id)),
+                def: ty::InstanceKind::Shim(ty::ShimKind::ThreadLocal(def_id)),
                 args: ty::GenericArgs::empty(),
             }),
             ExportedSymbol::NoDefId(symbol_name) => symbol_name,

--- a/compiler/rustc_middle/src/middle/exported_symbols.rs
+++ b/compiler/rustc_middle/src/middle/exported_symbols.rs
@@ -75,7 +75,7 @@ impl<'tcx> ExportedSymbol<'tcx> {
                 tcx.symbol_name(ty::Instance::resolve_async_drop_in_place_poll(tcx, def_id, ty))
             }
             ExportedSymbol::ThreadLocalShim(def_id) => tcx.symbol_name(ty::Instance {
-                def: ty::InstanceKind::ThreadLocalShim(def_id),
+                def: ty::InstanceKind::Shim(ty::ShimKind::ThreadLocalShim(def_id)),
                 args: ty::GenericArgs::empty(),
             }),
             ExportedSymbol::NoDefId(symbol_name) => symbol_name,

--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -127,10 +127,6 @@ impl<'tcx> MirSource<'tcx> {
         MirSource { instance: InstanceKind::Item(def_id), promoted: None }
     }
 
-    pub fn from_instance(instance: InstanceKind<'tcx>) -> Self {
-        MirSource { instance, promoted: None }
-    }
-
     pub fn from_shim(shim: ShimKind<'tcx>) -> Self {
         MirSource { instance: InstanceKind::Shim(shim), promoted: None }
     }

--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -32,8 +32,8 @@ use crate::mir::interpret::{AllocRange, Scalar};
 use crate::ty::codec::{TyDecoder, TyEncoder};
 use crate::ty::print::{FmtPrinter, Printer, pretty_print_const, with_no_trimmed_paths};
 use crate::ty::{
-    self, GenericArg, GenericArgsRef, Instance, InstanceKind, List, Ty, TyCtxt, TypeVisitableExt,
-    TypingEnv, UserTypeAnnotationIndex,
+    self, GenericArg, GenericArgsRef, Instance, InstanceKind, List, ShimKind, Ty, TyCtxt,
+    TypeVisitableExt, TypingEnv, UserTypeAnnotationIndex,
 };
 
 mod basic_blocks;
@@ -129,6 +129,10 @@ impl<'tcx> MirSource<'tcx> {
 
     pub fn from_instance(instance: InstanceKind<'tcx>) -> Self {
         MirSource { instance, promoted: None }
+    }
+
+    pub fn from_shim(shim: ShimKind<'tcx>) -> Self {
+        MirSource { instance: InstanceKind::Shim(shim), promoted: None }
     }
 
     #[inline]

--- a/compiler/rustc_middle/src/mir/pretty.rs
+++ b/compiler/rustc_middle/src/mir/pretty.rs
@@ -218,7 +218,7 @@ impl<'a, 'tcx> MirDumper<'a, 'tcx> {
         // All drop shims have the same DefId, so we have to add the type
         // to get unique file names.
         let shim_disambiguator = match source.instance {
-            ty::InstanceKind::DropGlue(_, Some(ty)) => {
+            ty::InstanceKind::Shim(ty::ShimKind::DropGlue(_, Some(ty))) => {
                 // Unfortunately, pretty-printed types are not very filename-friendly.
                 // We do some filtering.
                 let mut s = ".".to_owned();
@@ -229,7 +229,7 @@ impl<'a, 'tcx> MirDumper<'a, 'tcx> {
                 }));
                 s
             }
-            ty::InstanceKind::AsyncDropGlueCtorShim(_, ty) => {
+            ty::InstanceKind::Shim(ty::ShimKind::AsyncDropGlueCtorShim(_, ty)) => {
                 let mut s = ".".to_owned();
                 s.extend(ty.to_string().chars().filter_map(|c| match c {
                     ' ' => None,
@@ -238,7 +238,7 @@ impl<'a, 'tcx> MirDumper<'a, 'tcx> {
                 }));
                 s
             }
-            ty::InstanceKind::AsyncDropGlue(_, ty) => {
+            ty::InstanceKind::Shim(ty::ShimKind::AsyncDropGlue(_, ty)) => {
                 let ty::Coroutine(_, args) = ty.kind() else {
                     bug!();
                 };
@@ -251,7 +251,7 @@ impl<'a, 'tcx> MirDumper<'a, 'tcx> {
                 }));
                 s
             }
-            ty::InstanceKind::FutureDropPollShim(_, proxy_cor, impl_cor) => {
+            ty::InstanceKind::Shim(ty::ShimKind::FutureDropPollShim(_, proxy_cor, impl_cor)) => {
                 let mut s = ".".to_owned();
                 s.extend(proxy_cor.to_string().chars().filter_map(|c| match c {
                     ' ' => None,

--- a/compiler/rustc_middle/src/mir/pretty.rs
+++ b/compiler/rustc_middle/src/mir/pretty.rs
@@ -229,7 +229,7 @@ impl<'a, 'tcx> MirDumper<'a, 'tcx> {
                 }));
                 s
             }
-            ty::InstanceKind::Shim(ty::ShimKind::AsyncDropGlueCtorShim(_, ty)) => {
+            ty::InstanceKind::Shim(ty::ShimKind::AsyncDropGlueCtor(_, ty)) => {
                 let mut s = ".".to_owned();
                 s.extend(ty.to_string().chars().filter_map(|c| match c {
                     ' ' => None,
@@ -251,7 +251,7 @@ impl<'a, 'tcx> MirDumper<'a, 'tcx> {
                 }));
                 s
             }
-            ty::InstanceKind::Shim(ty::ShimKind::FutureDropPollShim(_, proxy_cor, impl_cor)) => {
+            ty::InstanceKind::Shim(ty::ShimKind::FutureDropPoll(_, proxy_cor, impl_cor)) => {
                 let mut s = ".".to_owned();
                 s.extend(proxy_cor.to_string().chars().filter_map(|c| match c {
                     ' ' => None,

--- a/compiler/rustc_middle/src/mir/visit.rs
+++ b/compiler/rustc_middle/src/mir/visit.rs
@@ -347,27 +347,27 @@ macro_rules! make_mir_visitor {
                         ty::InstanceKind::Item(_def_id) => {}
 
                         ty::InstanceKind::Intrinsic(_def_id)
-                        | ty::InstanceKind::Shim(ty::ShimKind::VTableShim(_def_id))
-                        | ty::InstanceKind::Shim(ty::ShimKind::ReifyShim(_def_id, _))
+                        | ty::InstanceKind::Shim(ty::ShimKind::VTable(_def_id))
+                        | ty::InstanceKind::Shim(ty::ShimKind::Reify(_def_id, _))
                         | ty::InstanceKind::Virtual(_def_id, _)
-                        | ty::InstanceKind::Shim(ty::ShimKind::ThreadLocalShim(_def_id))
-                        | ty::InstanceKind::Shim(ty::ShimKind::ClosureOnceShim { call_once: _def_id, closure: _, track_caller: _ })
-                        | ty::InstanceKind::Shim(ty::ShimKind::ConstructCoroutineInClosureShim {
+                        | ty::InstanceKind::Shim(ty::ShimKind::ThreadLocal(_def_id))
+                        | ty::InstanceKind::Shim(ty::ShimKind::ClosureOnce { call_once: _def_id, closure: _, track_caller: _ })
+                        | ty::InstanceKind::Shim(ty::ShimKind::ConstructCoroutineInClosure {
                             coroutine_closure_def_id: _def_id,
                             receiver_by_ref: _,
                         })
                         | ty::InstanceKind::Shim(ty::ShimKind::DropGlue(_def_id, None)) => {}
 
-                        ty::InstanceKind::Shim(ty::ShimKind::FnPtrShim(_def_id, ty))
+                        ty::InstanceKind::Shim(ty::ShimKind::FnPtr(_def_id, ty))
                         | ty::InstanceKind::Shim(ty::ShimKind::DropGlue(_def_id, Some(ty)))
-                        | ty::InstanceKind::Shim(ty::ShimKind::CloneShim(_def_id, ty))
-                        | ty::InstanceKind::Shim(ty::ShimKind::FnPtrAddrShim(_def_id, ty))
+                        | ty::InstanceKind::Shim(ty::ShimKind::Clone(_def_id, ty))
+                        | ty::InstanceKind::Shim(ty::ShimKind::FnPtrAddr(_def_id, ty))
                         | ty::InstanceKind::Shim(ty::ShimKind::AsyncDropGlue(_def_id, ty))
-                        | ty::InstanceKind::Shim(ty::ShimKind::AsyncDropGlueCtorShim(_def_id, ty)) => {
+                        | ty::InstanceKind::Shim(ty::ShimKind::AsyncDropGlueCtor(_def_id, ty)) => {
                             // FIXME(eddyb) use a better `TyContext` here.
                             self.visit_ty($(& $mutability)? *ty, TyContext::Location(location));
                         }
-                        ty::InstanceKind::Shim(ty::ShimKind::FutureDropPollShim(_def_id, proxy_ty, impl_ty)) => {
+                        ty::InstanceKind::Shim(ty::ShimKind::FutureDropPoll(_def_id, proxy_ty, impl_ty)) => {
                             self.visit_ty($(& $mutability)? *proxy_ty, TyContext::Location(location));
                             self.visit_ty($(& $mutability)? *impl_ty, TyContext::Location(location));
                         }

--- a/compiler/rustc_middle/src/mir/visit.rs
+++ b/compiler/rustc_middle/src/mir/visit.rs
@@ -347,27 +347,27 @@ macro_rules! make_mir_visitor {
                         ty::InstanceKind::Item(_def_id) => {}
 
                         ty::InstanceKind::Intrinsic(_def_id)
-                        | ty::InstanceKind::VTableShim(_def_id)
-                        | ty::InstanceKind::ReifyShim(_def_id, _)
+                        | ty::InstanceKind::Shim(ty::ShimKind::VTableShim(_def_id))
+                        | ty::InstanceKind::Shim(ty::ShimKind::ReifyShim(_def_id, _))
                         | ty::InstanceKind::Virtual(_def_id, _)
-                        | ty::InstanceKind::ThreadLocalShim(_def_id)
-                        | ty::InstanceKind::ClosureOnceShim { call_once: _def_id, closure: _, track_caller: _ }
-                        | ty::InstanceKind::ConstructCoroutineInClosureShim {
+                        | ty::InstanceKind::Shim(ty::ShimKind::ThreadLocalShim(_def_id))
+                        | ty::InstanceKind::Shim(ty::ShimKind::ClosureOnceShim { call_once: _def_id, closure: _, track_caller: _ })
+                        | ty::InstanceKind::Shim(ty::ShimKind::ConstructCoroutineInClosureShim {
                             coroutine_closure_def_id: _def_id,
                             receiver_by_ref: _,
-                        }
-                        | ty::InstanceKind::DropGlue(_def_id, None) => {}
+                        })
+                        | ty::InstanceKind::Shim(ty::ShimKind::DropGlue(_def_id, None)) => {}
 
-                        ty::InstanceKind::FnPtrShim(_def_id, ty)
-                        | ty::InstanceKind::DropGlue(_def_id, Some(ty))
-                        | ty::InstanceKind::CloneShim(_def_id, ty)
-                        | ty::InstanceKind::FnPtrAddrShim(_def_id, ty)
-                        | ty::InstanceKind::AsyncDropGlue(_def_id, ty)
-                        | ty::InstanceKind::AsyncDropGlueCtorShim(_def_id, ty) => {
+                        ty::InstanceKind::Shim(ty::ShimKind::FnPtrShim(_def_id, ty))
+                        | ty::InstanceKind::Shim(ty::ShimKind::DropGlue(_def_id, Some(ty)))
+                        | ty::InstanceKind::Shim(ty::ShimKind::CloneShim(_def_id, ty))
+                        | ty::InstanceKind::Shim(ty::ShimKind::FnPtrAddrShim(_def_id, ty))
+                        | ty::InstanceKind::Shim(ty::ShimKind::AsyncDropGlue(_def_id, ty))
+                        | ty::InstanceKind::Shim(ty::ShimKind::AsyncDropGlueCtorShim(_def_id, ty)) => {
                             // FIXME(eddyb) use a better `TyContext` here.
                             self.visit_ty($(& $mutability)? *ty, TyContext::Location(location));
                         }
-                        ty::InstanceKind::FutureDropPollShim(_def_id, proxy_ty, impl_ty) => {
+                        ty::InstanceKind::Shim(ty::ShimKind::FutureDropPollShim(_def_id, proxy_ty, impl_ty)) => {
                             self.visit_ty($(& $mutability)? *proxy_ty, TyContext::Location(location));
                             self.visit_ty($(& $mutability)? *impl_ty, TyContext::Location(location));
                         }

--- a/compiler/rustc_middle/src/mono.rs
+++ b/compiler/rustc_middle/src/mono.rs
@@ -22,7 +22,7 @@ use tracing::debug;
 use crate::dep_graph::dep_node::{make_compile_codegen_unit, make_compile_mono_item};
 use crate::dep_graph::{DepNode, WorkProduct, WorkProductId};
 use crate::middle::codegen_fn_attrs::CodegenFnAttrFlags;
-use crate::ty::{self, GenericArgs, Instance, InstanceKind, SymbolName, Ty, TyCtxt};
+use crate::ty::{self, GenericArgs, Instance, InstanceKind, ShimKind, SymbolName, Ty, TyCtxt};
 
 /// Describes how a monomorphization will be instantiated in object files.
 #[derive(PartialEq)]
@@ -173,7 +173,7 @@ impl<'tcx> MonoItem<'tcx> {
         // incrementality (which wants small CGUs with as many things GloballyShared as possible).
         // The heuristics implemented here do better than a completely naive approach in the
         // compiler benchmark suite, but there is no reason to believe they are optimal.
-        if let InstanceKind::DropGlue(_, Some(ty)) = instance.def {
+        if let InstanceKind::Shim(ShimKind::DropGlue(_, Some(ty))) = instance.def {
             if tcx.sess.opts.optimize == OptLevel::No {
                 return InstantiationMode::GloballyShared { may_conflict: false };
             }
@@ -523,20 +523,20 @@ impl<'tcx> CodegenUnit<'tcx> {
             match item {
                 MonoItem::Fn(ref instance) => match instance.def {
                     InstanceKind::Item(def) => def.as_local().map(|_| def),
-                    InstanceKind::VTableShim(..)
-                    | InstanceKind::ReifyShim(..)
-                    | InstanceKind::Intrinsic(..)
-                    | InstanceKind::FnPtrShim(..)
+                    InstanceKind::Intrinsic(..)
                     | InstanceKind::Virtual(..)
-                    | InstanceKind::ClosureOnceShim { .. }
-                    | InstanceKind::ConstructCoroutineInClosureShim { .. }
-                    | InstanceKind::DropGlue(..)
-                    | InstanceKind::CloneShim(..)
-                    | InstanceKind::ThreadLocalShim(..)
-                    | InstanceKind::FnPtrAddrShim(..)
-                    | InstanceKind::AsyncDropGlue(..)
-                    | InstanceKind::FutureDropPollShim(..)
-                    | InstanceKind::AsyncDropGlueCtorShim(..) => None,
+                    | InstanceKind::Shim(ShimKind::VTableShim(..))
+                    | InstanceKind::Shim(ShimKind::ReifyShim(..))
+                    | InstanceKind::Shim(ShimKind::FnPtrShim(..))
+                    | InstanceKind::Shim(ShimKind::ClosureOnceShim { .. })
+                    | InstanceKind::Shim(ShimKind::ConstructCoroutineInClosureShim { .. })
+                    | InstanceKind::Shim(ShimKind::DropGlue(..))
+                    | InstanceKind::Shim(ShimKind::CloneShim(..))
+                    | InstanceKind::Shim(ShimKind::ThreadLocalShim(..))
+                    | InstanceKind::Shim(ShimKind::FnPtrAddrShim(..))
+                    | InstanceKind::Shim(ShimKind::AsyncDropGlue(..))
+                    | InstanceKind::Shim(ShimKind::FutureDropPollShim(..))
+                    | InstanceKind::Shim(ShimKind::AsyncDropGlueCtorShim(..)) => None,
                 },
                 MonoItem::Static(def_id) => def_id.as_local().map(|_| def_id),
                 MonoItem::GlobalAsm(item_id) => Some(item_id.owner_id.def_id.to_def_id()),

--- a/compiler/rustc_middle/src/mono.rs
+++ b/compiler/rustc_middle/src/mono.rs
@@ -525,18 +525,18 @@ impl<'tcx> CodegenUnit<'tcx> {
                     InstanceKind::Item(def) => def.as_local().map(|_| def),
                     InstanceKind::Intrinsic(..)
                     | InstanceKind::Virtual(..)
-                    | InstanceKind::Shim(ShimKind::VTableShim(..))
-                    | InstanceKind::Shim(ShimKind::ReifyShim(..))
-                    | InstanceKind::Shim(ShimKind::FnPtrShim(..))
-                    | InstanceKind::Shim(ShimKind::ClosureOnceShim { .. })
-                    | InstanceKind::Shim(ShimKind::ConstructCoroutineInClosureShim { .. })
+                    | InstanceKind::Shim(ShimKind::VTable(..))
+                    | InstanceKind::Shim(ShimKind::Reify(..))
+                    | InstanceKind::Shim(ShimKind::FnPtr(..))
+                    | InstanceKind::Shim(ShimKind::ClosureOnce { .. })
+                    | InstanceKind::Shim(ShimKind::ConstructCoroutineInClosure { .. })
                     | InstanceKind::Shim(ShimKind::DropGlue(..))
-                    | InstanceKind::Shim(ShimKind::CloneShim(..))
-                    | InstanceKind::Shim(ShimKind::ThreadLocalShim(..))
-                    | InstanceKind::Shim(ShimKind::FnPtrAddrShim(..))
+                    | InstanceKind::Shim(ShimKind::Clone(..))
+                    | InstanceKind::Shim(ShimKind::ThreadLocal(..))
+                    | InstanceKind::Shim(ShimKind::FnPtrAddr(..))
                     | InstanceKind::Shim(ShimKind::AsyncDropGlue(..))
-                    | InstanceKind::Shim(ShimKind::FutureDropPollShim(..))
-                    | InstanceKind::Shim(ShimKind::AsyncDropGlueCtorShim(..)) => None,
+                    | InstanceKind::Shim(ShimKind::FutureDropPoll(..))
+                    | InstanceKind::Shim(ShimKind::AsyncDropGlueCtor(..)) => None,
                 },
                 MonoItem::Static(def_id) => def_id.as_local().map(|_| def_id),
                 MonoItem::GlobalAsm(item_id) => Some(item_id.owner_id.def_id.to_def_id()),

--- a/compiler/rustc_middle/src/queries.rs
+++ b/compiler/rustc_middle/src/queries.rs
@@ -1400,10 +1400,10 @@ rustc_queries! {
     }
 
     /// Generates a MIR body for the shim.
-    query mir_shims(key: ty::InstanceKind<'tcx>) -> &'tcx mir::Body<'tcx> {
+    query mir_shims(key: ty::ShimKind<'tcx>) -> &'tcx mir::Body<'tcx> {
         arena_cache
         desc {
-            "generating MIR shim for `{}`, instance={:?}",
+            "generating MIR shim for `{}`, kind={:?}",
             tcx.def_path_str(key.def_id()),
             key
         }

--- a/compiler/rustc_middle/src/query/keys.rs
+++ b/compiler/rustc_middle/src/query/keys.rs
@@ -63,6 +63,12 @@ impl QueryKey for () {
     }
 }
 
+impl<'tcx> QueryKey for ty::ShimKind<'tcx> {
+    fn default_span(&self, tcx: TyCtxt<'_>) -> Span {
+        tcx.def_span(self.def_id())
+    }
+}
+
 impl<'tcx> QueryKey for ty::InstanceKind<'tcx> {
     fn default_span(&self, tcx: TyCtxt<'_>) -> Span {
         tcx.def_span(self.def_id())

--- a/compiler/rustc_middle/src/ty/instance.rs
+++ b/compiler/rustc_middle/src/ty/instance.rs
@@ -75,6 +75,22 @@ pub enum InstanceKind<'tcx> {
     /// caller.
     Intrinsic(DefId),
 
+    /// Dynamic dispatch to `<dyn Trait as Trait>::fn`.
+    ///
+    /// This `InstanceKind` may have a callable MIR as the default implementation.
+    /// Calls to `Virtual` instances must be codegen'd as virtual calls through the vtable.
+    /// *This means we might not know exactly what is being called.*
+    ///
+    /// If this is reified to a `fn` pointer, a `ReifyShim` is used (see `ReifyShim` above for more
+    /// details on that).
+    Virtual(DefId, usize),
+
+    Shim(ShimKind<'tcx>),
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
+#[derive(TyEncodable, TyDecodable, StableHash, TypeFoldable, TypeVisitable, Lift)]
+pub enum ShimKind<'tcx> {
     /// `<T as Trait>::method` where `method` receives unsizeable `self: Self` (part of the
     /// `unsized_fn_params` feature).
     ///
@@ -105,16 +121,6 @@ pub enum InstanceKind<'tcx> {
     ///
     /// `DefId` is `FnTrait::call_*`.
     FnPtrShim(DefId, Ty<'tcx>),
-
-    /// Dynamic dispatch to `<dyn Trait as Trait>::fn`.
-    ///
-    /// This `InstanceKind` may have a callable MIR as the default implementation.
-    /// Calls to `Virtual` instances must be codegen'd as virtual calls through the vtable.
-    /// *This means we might not know exactly what is being called.*
-    ///
-    /// If this is reified to a `fn` pointer, a `ReifyShim` is used (see `ReifyShim` above for more
-    /// details on that).
-    Virtual(DefId, usize),
 
     /// `<[FnMut/Fn closure] as FnOnce>::call_once`.
     ///
@@ -228,10 +234,12 @@ impl<'tcx> Instance<'tcx> {
             InstanceKind::Item(def) => tcx
                 .upstream_monomorphizations_for(def)
                 .and_then(|monos| monos.get(&self.args).cloned()),
-            InstanceKind::DropGlue(_, Some(_)) => tcx.upstream_drop_glue_for(self.args),
-            InstanceKind::AsyncDropGlue(_, _) => None,
-            InstanceKind::FutureDropPollShim(_, _, _) => None,
-            InstanceKind::AsyncDropGlueCtorShim(_, _) => {
+            InstanceKind::Shim(ShimKind::DropGlue(_, Some(_))) => {
+                tcx.upstream_drop_glue_for(self.args)
+            }
+            InstanceKind::Shim(ShimKind::AsyncDropGlue(_, _)) => None,
+            InstanceKind::Shim(ShimKind::FutureDropPollShim(_, _, _)) => None,
+            InstanceKind::Shim(ShimKind::AsyncDropGlueCtorShim(_, _)) => {
                 tcx.upstream_async_drop_glue_for(self.args)
             }
             _ => None,
@@ -244,45 +252,18 @@ impl<'tcx> InstanceKind<'tcx> {
     pub fn def_id(self) -> DefId {
         match self {
             InstanceKind::Item(def_id)
-            | InstanceKind::VTableShim(def_id)
-            | InstanceKind::ReifyShim(def_id, _)
-            | InstanceKind::FnPtrShim(def_id, _)
             | InstanceKind::Virtual(def_id, _)
-            | InstanceKind::Intrinsic(def_id)
-            | InstanceKind::ThreadLocalShim(def_id)
-            | InstanceKind::ClosureOnceShim { call_once: def_id, closure: _, track_caller: _ }
-            | ty::InstanceKind::ConstructCoroutineInClosureShim {
-                coroutine_closure_def_id: def_id,
-                receiver_by_ref: _,
-            }
-            | InstanceKind::DropGlue(def_id, _)
-            | InstanceKind::CloneShim(def_id, _)
-            | InstanceKind::FnPtrAddrShim(def_id, _)
-            | InstanceKind::FutureDropPollShim(def_id, _, _)
-            | InstanceKind::AsyncDropGlue(def_id, _)
-            | InstanceKind::AsyncDropGlueCtorShim(def_id, _) => def_id,
+            | InstanceKind::Intrinsic(def_id) => def_id,
+            InstanceKind::Shim(shim) => shim.def_id(),
         }
     }
 
     /// Returns the `DefId` of instances which might not require codegen locally.
     pub fn def_id_if_not_guaranteed_local_codegen(self) -> Option<DefId> {
         match self {
-            ty::InstanceKind::Item(def) => Some(def),
-            ty::InstanceKind::DropGlue(def_id, Some(_))
-            | InstanceKind::AsyncDropGlueCtorShim(def_id, _)
-            | InstanceKind::AsyncDropGlue(def_id, _)
-            | InstanceKind::FutureDropPollShim(def_id, ..)
-            | InstanceKind::ThreadLocalShim(def_id) => Some(def_id),
-            InstanceKind::VTableShim(..)
-            | InstanceKind::ReifyShim(..)
-            | InstanceKind::FnPtrShim(..)
-            | InstanceKind::Virtual(..)
-            | InstanceKind::Intrinsic(..)
-            | InstanceKind::ClosureOnceShim { .. }
-            | ty::InstanceKind::ConstructCoroutineInClosureShim { .. }
-            | InstanceKind::DropGlue(..)
-            | InstanceKind::CloneShim(..)
-            | InstanceKind::FnPtrAddrShim(..) => None,
+            InstanceKind::Item(def) => Some(def),
+            InstanceKind::Virtual(..) | InstanceKind::Intrinsic(..) => None,
+            InstanceKind::Shim(shim) => shim.def_id_if_not_guaranteed_local_codegen(),
         }
     }
 
@@ -293,31 +274,28 @@ impl<'tcx> InstanceKind<'tcx> {
     /// `generates_cgu_internal_copy` for more information.
     pub fn requires_inline(&self, tcx: TyCtxt<'tcx>) -> bool {
         use rustc_hir::definitions::DefPathData;
-        let def_id = match *self {
-            ty::InstanceKind::Item(def) => def,
-            ty::InstanceKind::DropGlue(_, Some(ty)) => return ty.is_array(),
-            ty::InstanceKind::AsyncDropGlueCtorShim(_, ty) => return ty.is_coroutine(),
-            ty::InstanceKind::FutureDropPollShim(_, _, _) => return false,
-            ty::InstanceKind::AsyncDropGlue(_, _) => return false,
-            ty::InstanceKind::ThreadLocalShim(_) => return false,
-            _ => return true,
-        };
-        matches!(
-            tcx.def_key(def_id).disambiguated_data.data,
-            DefPathData::Ctor | DefPathData::Closure
-        )
+        match *self {
+            InstanceKind::Item(def_id) => matches!(
+                tcx.def_key(def_id).disambiguated_data.data,
+                DefPathData::Ctor | DefPathData::Closure
+            ),
+            InstanceKind::Shim(shim) => shim.requires_inline(),
+            InstanceKind::Virtual(..) | InstanceKind::Intrinsic(..) => true,
+        }
     }
 
     pub fn requires_caller_location(&self, tcx: TyCtxt<'_>) -> bool {
         match *self {
             InstanceKind::Item(def_id)
             | InstanceKind::Virtual(def_id, _)
-            | InstanceKind::VTableShim(def_id) => {
+            | InstanceKind::Shim(ShimKind::VTableShim(def_id)) => {
                 tcx.body_codegen_attrs(def_id).flags.contains(CodegenFnAttrFlags::TRACK_CALLER)
             }
-            InstanceKind::ClosureOnceShim { call_once: _, closure: _, track_caller } => {
-                track_caller
-            }
+            InstanceKind::Shim(ShimKind::ClosureOnceShim {
+                call_once: _,
+                closure: _,
+                track_caller,
+            }) => track_caller,
             _ => false,
         }
     }
@@ -330,22 +308,79 @@ impl<'tcx> InstanceKind<'tcx> {
     /// body should perform necessary instantiations.
     pub fn has_polymorphic_mir_body(&self) -> bool {
         match *self {
-            InstanceKind::CloneShim(..)
-            | InstanceKind::ThreadLocalShim(..)
-            | InstanceKind::FnPtrAddrShim(..)
-            | InstanceKind::FnPtrShim(..)
-            | InstanceKind::DropGlue(_, Some(_))
-            | InstanceKind::FutureDropPollShim(..)
-            | InstanceKind::AsyncDropGlue(_, _) => false,
-            InstanceKind::AsyncDropGlueCtorShim(_, _) => false,
-            InstanceKind::ClosureOnceShim { .. }
-            | InstanceKind::ConstructCoroutineInClosureShim { .. }
-            | InstanceKind::DropGlue(..)
-            | InstanceKind::Item(_)
-            | InstanceKind::Intrinsic(..)
-            | InstanceKind::ReifyShim(..)
-            | InstanceKind::Virtual(..)
-            | InstanceKind::VTableShim(..) => true,
+            InstanceKind::Item(_) | InstanceKind::Intrinsic(..) | InstanceKind::Virtual(..) => true,
+            InstanceKind::Shim(shim) => shim.has_polymorphic_mir_body(),
+        }
+    }
+}
+
+impl<'tcx> ShimKind<'tcx> {
+    #[inline]
+    pub fn def_id(self) -> DefId {
+        match self {
+            ShimKind::VTableShim(def_id)
+            | ShimKind::ReifyShim(def_id, _)
+            | ShimKind::FnPtrShim(def_id, _)
+            | ShimKind::ThreadLocalShim(def_id)
+            | ShimKind::ClosureOnceShim { call_once: def_id, closure: _, track_caller: _ }
+            | ShimKind::ConstructCoroutineInClosureShim {
+                coroutine_closure_def_id: def_id,
+                receiver_by_ref: _,
+            }
+            | ShimKind::DropGlue(def_id, _)
+            | ShimKind::CloneShim(def_id, _)
+            | ShimKind::FnPtrAddrShim(def_id, _)
+            | ShimKind::FutureDropPollShim(def_id, _, _)
+            | ShimKind::AsyncDropGlue(def_id, _)
+            | ShimKind::AsyncDropGlueCtorShim(def_id, _) => def_id,
+        }
+    }
+
+    /// Returns the `DefId` of instances which might not require codegen locally.
+    pub fn def_id_if_not_guaranteed_local_codegen(self) -> Option<DefId> {
+        match self {
+            ShimKind::DropGlue(def_id, Some(_))
+            | ShimKind::AsyncDropGlueCtorShim(def_id, _)
+            | ShimKind::AsyncDropGlue(def_id, _)
+            | ShimKind::FutureDropPollShim(def_id, ..)
+            | ShimKind::ThreadLocalShim(def_id) => Some(def_id),
+            ShimKind::VTableShim(..)
+            | ShimKind::ReifyShim(..)
+            | ShimKind::FnPtrShim(..)
+            | ShimKind::ClosureOnceShim { .. }
+            | ShimKind::ConstructCoroutineInClosureShim { .. }
+            | ShimKind::DropGlue(..)
+            | ShimKind::CloneShim(..)
+            | ShimKind::FnPtrAddrShim(..) => None,
+        }
+    }
+
+    pub fn requires_inline(&self) -> bool {
+        match self {
+            ShimKind::DropGlue(_, Some(ty)) => ty.is_array(),
+            ShimKind::AsyncDropGlueCtorShim(_, ty) => ty.is_coroutine(),
+            ShimKind::FutureDropPollShim(_, _, _) => false,
+            ShimKind::AsyncDropGlue(_, _) => false,
+            ShimKind::ThreadLocalShim(_) => false,
+            _ => true,
+        }
+    }
+
+    pub fn has_polymorphic_mir_body(&self) -> bool {
+        match *self {
+            ShimKind::CloneShim(..)
+            | ShimKind::ThreadLocalShim(..)
+            | ShimKind::FnPtrAddrShim(..)
+            | ShimKind::FnPtrShim(..)
+            | ShimKind::DropGlue(_, Some(_))
+            | ShimKind::FutureDropPollShim(..)
+            | ShimKind::AsyncDropGlue(_, _) => false,
+            ShimKind::AsyncDropGlueCtorShim(_, _) => false,
+            ShimKind::ClosureOnceShim { .. }
+            | ShimKind::ConstructCoroutineInClosureShim { .. }
+            | ShimKind::DropGlue(..)
+            | ShimKind::ReifyShim(..)
+            | ShimKind::VTableShim(..) => true,
         }
     }
 }
@@ -416,7 +451,11 @@ fn resolve_async_drop_poll<'tcx>(mut cor_ty: Ty<'tcx>) -> Instance<'tcx> {
                 continue;
             } else {
                 return Instance {
-                    def: ty::InstanceKind::FutureDropPollShim(poll_def_id, first_cor, cor_ty),
+                    def: ty::InstanceKind::Shim(ShimKind::FutureDropPollShim(
+                        poll_def_id,
+                        first_cor,
+                        cor_ty,
+                    )),
                     args: proxy_args,
                 };
             }
@@ -426,12 +465,16 @@ fn resolve_async_drop_poll<'tcx>(mut cor_ty: Ty<'tcx>) -> Instance<'tcx> {
             };
             if first_cor != cor_ty {
                 return Instance {
-                    def: ty::InstanceKind::FutureDropPollShim(poll_def_id, first_cor, cor_ty),
+                    def: ty::InstanceKind::Shim(ShimKind::FutureDropPollShim(
+                        poll_def_id,
+                        first_cor,
+                        cor_ty,
+                    )),
                     args: proxy_args,
                 };
             } else {
                 return Instance {
-                    def: ty::InstanceKind::AsyncDropGlue(poll_def_id, cor_ty),
+                    def: ty::InstanceKind::Shim(ShimKind::AsyncDropGlue(poll_def_id, cor_ty)),
                     args: child_args,
                 };
             }
@@ -599,11 +642,11 @@ impl<'tcx> Instance<'tcx> {
             match resolved.def {
                 InstanceKind::Item(def) if resolved.def.requires_caller_location(tcx) => {
                     debug!(" => fn pointer created for function with #[track_caller]");
-                    resolved.def = InstanceKind::ReifyShim(def, reason);
+                    resolved.def = InstanceKind::Shim(ShimKind::ReifyShim(def, reason));
                 }
                 InstanceKind::Virtual(def_id, _) => {
                     debug!(" => fn pointer created for virtual call");
-                    resolved.def = InstanceKind::ReifyShim(def_id, reason);
+                    resolved.def = InstanceKind::Shim(ShimKind::ReifyShim(def_id, reason));
                 }
                 _ if tcx.sess.is_sanitizer_kcfi_enabled() => {
                     // Reify `::call`-like method implementations
@@ -611,7 +654,10 @@ impl<'tcx> Instance<'tcx> {
                         // Reroute through a reify via the *unresolved* instance. The resolved one can't
                         // be directly reified because it's closure-like. The reify can handle the
                         // unresolved instance.
-                        resolved = Instance { def: InstanceKind::ReifyShim(def_id, reason), args }
+                        resolved = Instance {
+                            def: InstanceKind::Shim(ShimKind::ReifyShim(def_id, reason)),
+                            args,
+                        }
                     // Reify `Trait::method` implementations if the trait is dyn-compatible.
                     } else if let Some(assoc) = tcx.opt_associated_item(def_id)
                         && let AssocContainer::Trait | AssocContainer::TraitImpl(Ok(_)) =
@@ -620,7 +666,8 @@ impl<'tcx> Instance<'tcx> {
                     {
                         // If this function could also go in a vtable, we need to `ReifyShim` it with
                         // KCFI because it can only attach one type per function.
-                        resolved.def = InstanceKind::ReifyShim(resolved.def_id(), reason)
+                        resolved.def =
+                            InstanceKind::Shim(ShimKind::ReifyShim(resolved.def_id(), reason))
                     }
                 }
                 _ => {}
@@ -645,7 +692,7 @@ impl<'tcx> Instance<'tcx> {
 
         if is_vtable_shim {
             debug!(" => associated item with unsizeable self: Self");
-            return Instance { def: InstanceKind::VTableShim(def_id), args };
+            return Instance { def: InstanceKind::Shim(ShimKind::VTableShim(def_id)), args };
         }
 
         let mut resolved = Instance::expect_resolve(tcx, typing_env, def_id, args, span);
@@ -688,19 +735,22 @@ impl<'tcx> Instance<'tcx> {
                         // Create a shim for the `FnOnce/FnMut/Fn` method we are calling
                         // - unlike functions, invoking a closure always goes through a
                         // trait.
-                        resolved = Instance { def: InstanceKind::ReifyShim(def_id, reason), args };
+                        resolved = Instance {
+                            def: InstanceKind::Shim(ShimKind::ReifyShim(def_id, reason)),
+                            args,
+                        };
                     } else {
                         debug!(
                             " => vtable fn pointer created for function with #[track_caller]: {:?}",
                             def
                         );
-                        resolved.def = InstanceKind::ReifyShim(def, reason);
+                        resolved.def = InstanceKind::Shim(ShimKind::ReifyShim(def, reason));
                     }
                 }
             }
             InstanceKind::Virtual(def_id, _) => {
                 debug!(" => vtable fn pointer created for virtual call");
-                resolved.def = InstanceKind::ReifyShim(def_id, reason)
+                resolved.def = InstanceKind::Shim(ShimKind::ReifyShim(def_id, reason))
             }
             _ => {}
         }
@@ -770,8 +820,11 @@ impl<'tcx> Instance<'tcx> {
             .def_id;
         let track_caller =
             tcx.codegen_fn_attrs(closure_did).flags.contains(CodegenFnAttrFlags::TRACK_CALLER);
-        let def =
-            ty::InstanceKind::ClosureOnceShim { call_once, closure: closure_did, track_caller };
+        let def = ty::InstanceKind::Shim(ShimKind::ClosureOnceShim {
+            call_once,
+            closure: closure_did,
+            track_caller,
+        });
 
         let self_ty = Ty::new_closure(tcx, closure_did, args);
 

--- a/compiler/rustc_middle/src/ty/instance.rs
+++ b/compiler/rustc_middle/src/ty/instance.rs
@@ -96,7 +96,7 @@ pub enum ShimKind<'tcx> {
     ///
     /// The generated shim will take `Self` via `*mut Self` - conceptually this is `&owned Self` -
     /// and dereference the argument to call the original function.
-    VTableShim(DefId),
+    VTable(DefId),
 
     /// `fn()` pointer where the function itself cannot be turned into a pointer.
     ///
@@ -115,12 +115,12 @@ pub enum ShimKind<'tcx> {
     ///
     /// This field will only be populated if we are compiling in a mode that needs these shims
     /// to be separable, currently only when KCFI is enabled.
-    ReifyShim(DefId, Option<ReifyReason>),
+    Reify(DefId, Option<ReifyReason>),
 
     /// `<fn() as FnTrait>::call_*` (generated `FnTrait` implementation for `fn()` pointers).
     ///
     /// `DefId` is `FnTrait::call_*`.
-    FnPtrShim(DefId, Ty<'tcx>),
+    FnPtr(DefId, Ty<'tcx>),
 
     /// `<[FnMut/Fn closure] as FnOnce>::call_once`.
     ///
@@ -128,14 +128,14 @@ pub enum ShimKind<'tcx> {
     ///
     /// This generates a body that will just borrow the (owned) self type,
     /// and dispatch to the `FnMut::call_mut` instance for the closure.
-    ClosureOnceShim { call_once: DefId, closure: DefId, track_caller: bool },
+    ClosureOnce { call_once: DefId, closure: DefId, track_caller: bool },
 
     /// `<[FnMut/Fn coroutine-closure] as FnOnce>::call_once`
     ///
     /// The body generated here differs significantly from the `ClosureOnceShim`,
     /// since we need to generate a distinct coroutine type that will move the
     /// closure's upvars *out* of the closure.
-    ConstructCoroutineInClosureShim {
+    ConstructCoroutineInClosure {
         coroutine_closure_def_id: DefId,
         // Whether the generated MIR body takes the coroutine by-ref. This is
         // because the signature of `<{async fn} as FnMut>::call_mut` is:
@@ -148,10 +148,10 @@ pub enum ShimKind<'tcx> {
     /// Compiler-generated accessor for thread locals which returns a reference to the thread local
     /// the `DefId` defines. This is used to export thread locals from dylibs on platforms lacking
     /// native support.
-    ThreadLocalShim(DefId),
+    ThreadLocal(DefId),
 
     /// Proxy shim for async drop of future (def_id, proxy_cor_ty, impl_cor_ty)
-    FutureDropPollShim(DefId, Ty<'tcx>, Ty<'tcx>),
+    FutureDropPoll(DefId, Ty<'tcx>, Ty<'tcx>),
 
     /// `core::ptr::drop_glue::<T>`.
     ///
@@ -168,20 +168,20 @@ pub enum ShimKind<'tcx> {
     /// Additionally, arrays, tuples, and closures get a `Clone` shim even if they aren't `Copy`.
     ///
     /// The `DefId` is for `Clone::clone`, the `Ty` is the type `T` with the builtin `Clone` impl.
-    CloneShim(DefId, Ty<'tcx>),
+    Clone(DefId, Ty<'tcx>),
 
     /// Compiler-generated `<T as FnPtr>::addr` implementation.
     ///
     /// Automatically generated for all potentially higher-ranked `fn(I) -> R` types.
     ///
     /// The `DefId` is for `FnPtr::addr`, the `Ty` is the type `T`.
-    FnPtrAddrShim(DefId, Ty<'tcx>),
+    FnPtrAddr(DefId, Ty<'tcx>),
 
     /// `core::future::async_drop::async_drop_in_place::<'_, T>`.
     ///
     /// The `DefId` is for `core::future::async_drop::async_drop_in_place`, the `Ty`
     /// is the type `T`.
-    AsyncDropGlueCtorShim(DefId, Ty<'tcx>),
+    AsyncDropGlueCtor(DefId, Ty<'tcx>),
 
     /// `core::future::async_drop::async_drop_in_place::<'_, T>::{closure}`.
     ///
@@ -238,8 +238,8 @@ impl<'tcx> Instance<'tcx> {
                 tcx.upstream_drop_glue_for(self.args)
             }
             InstanceKind::Shim(ShimKind::AsyncDropGlue(_, _)) => None,
-            InstanceKind::Shim(ShimKind::FutureDropPollShim(_, _, _)) => None,
-            InstanceKind::Shim(ShimKind::AsyncDropGlueCtorShim(_, _)) => {
+            InstanceKind::Shim(ShimKind::FutureDropPoll(_, _, _)) => None,
+            InstanceKind::Shim(ShimKind::AsyncDropGlueCtor(_, _)) => {
                 tcx.upstream_async_drop_glue_for(self.args)
             }
             _ => None,
@@ -288,10 +288,10 @@ impl<'tcx> InstanceKind<'tcx> {
         match *self {
             InstanceKind::Item(def_id)
             | InstanceKind::Virtual(def_id, _)
-            | InstanceKind::Shim(ShimKind::VTableShim(def_id)) => {
+            | InstanceKind::Shim(ShimKind::VTable(def_id)) => {
                 tcx.body_codegen_attrs(def_id).flags.contains(CodegenFnAttrFlags::TRACK_CALLER)
             }
-            InstanceKind::Shim(ShimKind::ClosureOnceShim {
+            InstanceKind::Shim(ShimKind::ClosureOnce {
                 call_once: _,
                 closure: _,
                 track_caller,
@@ -318,21 +318,21 @@ impl<'tcx> ShimKind<'tcx> {
     #[inline]
     pub fn def_id(self) -> DefId {
         match self {
-            ShimKind::VTableShim(def_id)
-            | ShimKind::ReifyShim(def_id, _)
-            | ShimKind::FnPtrShim(def_id, _)
-            | ShimKind::ThreadLocalShim(def_id)
-            | ShimKind::ClosureOnceShim { call_once: def_id, closure: _, track_caller: _ }
-            | ShimKind::ConstructCoroutineInClosureShim {
+            ShimKind::VTable(def_id)
+            | ShimKind::Reify(def_id, _)
+            | ShimKind::FnPtr(def_id, _)
+            | ShimKind::ThreadLocal(def_id)
+            | ShimKind::ClosureOnce { call_once: def_id, closure: _, track_caller: _ }
+            | ShimKind::ConstructCoroutineInClosure {
                 coroutine_closure_def_id: def_id,
                 receiver_by_ref: _,
             }
             | ShimKind::DropGlue(def_id, _)
-            | ShimKind::CloneShim(def_id, _)
-            | ShimKind::FnPtrAddrShim(def_id, _)
-            | ShimKind::FutureDropPollShim(def_id, _, _)
+            | ShimKind::Clone(def_id, _)
+            | ShimKind::FnPtrAddr(def_id, _)
+            | ShimKind::FutureDropPoll(def_id, _, _)
             | ShimKind::AsyncDropGlue(def_id, _)
-            | ShimKind::AsyncDropGlueCtorShim(def_id, _) => def_id,
+            | ShimKind::AsyncDropGlueCtor(def_id, _) => def_id,
         }
     }
 
@@ -340,47 +340,47 @@ impl<'tcx> ShimKind<'tcx> {
     pub fn def_id_if_not_guaranteed_local_codegen(self) -> Option<DefId> {
         match self {
             ShimKind::DropGlue(def_id, Some(_))
-            | ShimKind::AsyncDropGlueCtorShim(def_id, _)
+            | ShimKind::AsyncDropGlueCtor(def_id, _)
             | ShimKind::AsyncDropGlue(def_id, _)
-            | ShimKind::FutureDropPollShim(def_id, ..)
-            | ShimKind::ThreadLocalShim(def_id) => Some(def_id),
-            ShimKind::VTableShim(..)
-            | ShimKind::ReifyShim(..)
-            | ShimKind::FnPtrShim(..)
-            | ShimKind::ClosureOnceShim { .. }
-            | ShimKind::ConstructCoroutineInClosureShim { .. }
+            | ShimKind::FutureDropPoll(def_id, ..)
+            | ShimKind::ThreadLocal(def_id) => Some(def_id),
+            ShimKind::VTable(..)
+            | ShimKind::Reify(..)
+            | ShimKind::FnPtr(..)
+            | ShimKind::ClosureOnce { .. }
+            | ShimKind::ConstructCoroutineInClosure { .. }
             | ShimKind::DropGlue(..)
-            | ShimKind::CloneShim(..)
-            | ShimKind::FnPtrAddrShim(..) => None,
+            | ShimKind::Clone(..)
+            | ShimKind::FnPtrAddr(..) => None,
         }
     }
 
     pub fn requires_inline(&self) -> bool {
         match self {
             ShimKind::DropGlue(_, Some(ty)) => ty.is_array(),
-            ShimKind::AsyncDropGlueCtorShim(_, ty) => ty.is_coroutine(),
-            ShimKind::FutureDropPollShim(_, _, _) => false,
+            ShimKind::AsyncDropGlueCtor(_, ty) => ty.is_coroutine(),
+            ShimKind::FutureDropPoll(_, _, _) => false,
             ShimKind::AsyncDropGlue(_, _) => false,
-            ShimKind::ThreadLocalShim(_) => false,
+            ShimKind::ThreadLocal(_) => false,
             _ => true,
         }
     }
 
     pub fn has_polymorphic_mir_body(&self) -> bool {
         match *self {
-            ShimKind::CloneShim(..)
-            | ShimKind::ThreadLocalShim(..)
-            | ShimKind::FnPtrAddrShim(..)
-            | ShimKind::FnPtrShim(..)
+            ShimKind::Clone(..)
+            | ShimKind::ThreadLocal(..)
+            | ShimKind::FnPtrAddr(..)
+            | ShimKind::FnPtr(..)
             | ShimKind::DropGlue(_, Some(_))
-            | ShimKind::FutureDropPollShim(..)
+            | ShimKind::FutureDropPoll(..)
             | ShimKind::AsyncDropGlue(_, _) => false,
-            ShimKind::AsyncDropGlueCtorShim(_, _) => false,
-            ShimKind::ClosureOnceShim { .. }
-            | ShimKind::ConstructCoroutineInClosureShim { .. }
+            ShimKind::AsyncDropGlueCtor(_, _) => false,
+            ShimKind::ClosureOnce { .. }
+            | ShimKind::ConstructCoroutineInClosure { .. }
             | ShimKind::DropGlue(..)
-            | ShimKind::ReifyShim(..)
-            | ShimKind::VTableShim(..) => true,
+            | ShimKind::Reify(..)
+            | ShimKind::VTable(..) => true,
         }
     }
 }
@@ -451,7 +451,7 @@ fn resolve_async_drop_poll<'tcx>(mut cor_ty: Ty<'tcx>) -> Instance<'tcx> {
                 continue;
             } else {
                 return Instance {
-                    def: ty::InstanceKind::Shim(ShimKind::FutureDropPollShim(
+                    def: ty::InstanceKind::Shim(ShimKind::FutureDropPoll(
                         poll_def_id,
                         first_cor,
                         cor_ty,
@@ -465,7 +465,7 @@ fn resolve_async_drop_poll<'tcx>(mut cor_ty: Ty<'tcx>) -> Instance<'tcx> {
             };
             if first_cor != cor_ty {
                 return Instance {
-                    def: ty::InstanceKind::Shim(ShimKind::FutureDropPollShim(
+                    def: ty::InstanceKind::Shim(ShimKind::FutureDropPoll(
                         poll_def_id,
                         first_cor,
                         cor_ty,
@@ -642,11 +642,11 @@ impl<'tcx> Instance<'tcx> {
             match resolved.def {
                 InstanceKind::Item(def) if resolved.def.requires_caller_location(tcx) => {
                     debug!(" => fn pointer created for function with #[track_caller]");
-                    resolved.def = InstanceKind::Shim(ShimKind::ReifyShim(def, reason));
+                    resolved.def = InstanceKind::Shim(ShimKind::Reify(def, reason));
                 }
                 InstanceKind::Virtual(def_id, _) => {
                     debug!(" => fn pointer created for virtual call");
-                    resolved.def = InstanceKind::Shim(ShimKind::ReifyShim(def_id, reason));
+                    resolved.def = InstanceKind::Shim(ShimKind::Reify(def_id, reason));
                 }
                 _ if tcx.sess.is_sanitizer_kcfi_enabled() => {
                     // Reify `::call`-like method implementations
@@ -655,7 +655,7 @@ impl<'tcx> Instance<'tcx> {
                         // be directly reified because it's closure-like. The reify can handle the
                         // unresolved instance.
                         resolved = Instance {
-                            def: InstanceKind::Shim(ShimKind::ReifyShim(def_id, reason)),
+                            def: InstanceKind::Shim(ShimKind::Reify(def_id, reason)),
                             args,
                         }
                     // Reify `Trait::method` implementations if the trait is dyn-compatible.
@@ -667,7 +667,7 @@ impl<'tcx> Instance<'tcx> {
                         // If this function could also go in a vtable, we need to `ReifyShim` it with
                         // KCFI because it can only attach one type per function.
                         resolved.def =
-                            InstanceKind::Shim(ShimKind::ReifyShim(resolved.def_id(), reason))
+                            InstanceKind::Shim(ShimKind::Reify(resolved.def_id(), reason))
                     }
                 }
                 _ => {}
@@ -692,7 +692,7 @@ impl<'tcx> Instance<'tcx> {
 
         if is_vtable_shim {
             debug!(" => associated item with unsizeable self: Self");
-            return Instance { def: InstanceKind::Shim(ShimKind::VTableShim(def_id)), args };
+            return Instance { def: InstanceKind::Shim(ShimKind::VTable(def_id)), args };
         }
 
         let mut resolved = Instance::expect_resolve(tcx, typing_env, def_id, args, span);
@@ -736,7 +736,7 @@ impl<'tcx> Instance<'tcx> {
                         // - unlike functions, invoking a closure always goes through a
                         // trait.
                         resolved = Instance {
-                            def: InstanceKind::Shim(ShimKind::ReifyShim(def_id, reason)),
+                            def: InstanceKind::Shim(ShimKind::Reify(def_id, reason)),
                             args,
                         };
                     } else {
@@ -744,13 +744,13 @@ impl<'tcx> Instance<'tcx> {
                             " => vtable fn pointer created for function with #[track_caller]: {:?}",
                             def
                         );
-                        resolved.def = InstanceKind::Shim(ShimKind::ReifyShim(def, reason));
+                        resolved.def = InstanceKind::Shim(ShimKind::Reify(def, reason));
                     }
                 }
             }
             InstanceKind::Virtual(def_id, _) => {
                 debug!(" => vtable fn pointer created for virtual call");
-                resolved.def = InstanceKind::Shim(ShimKind::ReifyShim(def_id, reason))
+                resolved.def = InstanceKind::Shim(ShimKind::Reify(def_id, reason))
             }
             _ => {}
         }
@@ -820,7 +820,7 @@ impl<'tcx> Instance<'tcx> {
             .def_id;
         let track_caller =
             tcx.codegen_fn_attrs(closure_did).flags.contains(CodegenFnAttrFlags::TRACK_CALLER);
-        let def = ty::InstanceKind::Shim(ShimKind::ClosureOnceShim {
+        let def = ty::InstanceKind::Shim(ShimKind::ClosureOnce {
             call_once,
             closure: closure_did,
             track_caller,

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -85,7 +85,7 @@ pub use self::context::{
     CtxtInterners, CurrentGcx, FreeRegionInfo, GlobalCtxt, Lift, TyCtxt, TyCtxtFeed, tls,
 };
 pub use self::fold::*;
-pub use self::instance::{Instance, InstanceKind, ReifyReason};
+pub use self::instance::{Instance, InstanceKind, ReifyReason, ShimKind};
 pub(crate) use self::list::RawList;
 pub use self::list::{List, ListWithCachedTypeInfo};
 pub use self::opaque_types::OpaqueTypeKey;
@@ -1802,20 +1802,9 @@ impl<'tcx> TyCtxt<'tcx> {
                     _ => self.optimized_mir(def),
                 }
             }
-            ty::InstanceKind::VTableShim(..)
-            | ty::InstanceKind::ReifyShim(..)
-            | ty::InstanceKind::Intrinsic(..)
-            | ty::InstanceKind::FnPtrShim(..)
-            | ty::InstanceKind::Virtual(..)
-            | ty::InstanceKind::ClosureOnceShim { .. }
-            | ty::InstanceKind::ConstructCoroutineInClosureShim { .. }
-            | ty::InstanceKind::FutureDropPollShim(..)
-            | ty::InstanceKind::DropGlue(..)
-            | ty::InstanceKind::CloneShim(..)
-            | ty::InstanceKind::ThreadLocalShim(..)
-            | ty::InstanceKind::FnPtrAddrShim(..)
-            | ty::InstanceKind::AsyncDropGlueCtorShim(..)
-            | ty::InstanceKind::AsyncDropGlue(..) => self.mir_shims(instance),
+            ty::InstanceKind::Intrinsic(..) => bug!("intrinsics have no instance MIR"),
+            ty::InstanceKind::Virtual(..) => bug!("virtual dispatches have no instance MIR"),
+            ty::InstanceKind::Shim(shim) => self.mir_shims(shim),
         };
 
         assert!(
@@ -1941,7 +1930,7 @@ impl<'tcx> TyCtxt<'tcx> {
         if args[0].has_placeholders() || args[0].has_non_region_param() {
             return Err(self.layout_error(LayoutError::TooGeneric(ty())));
         }
-        let instance = InstanceKind::AsyncDropGlue(def_id, Ty::new_coroutine(self, def_id, args));
+        let instance = ShimKind::AsyncDropGlue(def_id, Ty::new_coroutine(self, def_id, args));
         self.mir_shims(instance)
             .coroutine_layout_raw()
             .ok_or_else(|| self.layout_error(LayoutError::Unknown(ty())))

--- a/compiler/rustc_middle/src/ty/print/mod.rs
+++ b/compiler/rustc_middle/src/ty/print/mod.rs
@@ -381,29 +381,27 @@ impl<'tcx, P: Printer<'tcx> + std::fmt::Write> Print<P> for ty::Instance<'tcx> {
 impl<'tcx, P: Printer<'tcx> + std::fmt::Write> Print<P> for ty::ShimKind<'tcx> {
     fn print(&self, cx: &mut P) -> Result<(), PrintError> {
         match self {
-            ty::ShimKind::VTableShim(_) => cx.write_str("shim(vtable)"),
-            ty::ShimKind::ReifyShim(_, None) => cx.write_str("shim(reify)"),
-            ty::ShimKind::ReifyShim(_, Some(ty::ReifyReason::FnPtr)) => {
+            ty::ShimKind::VTable(_) => cx.write_str("shim(vtable)"),
+            ty::ShimKind::Reify(_, None) => cx.write_str("shim(reify)"),
+            ty::ShimKind::Reify(_, Some(ty::ReifyReason::FnPtr)) => {
                 cx.write_str("shim(reify-fnptr)")
             }
-            ty::ShimKind::ReifyShim(_, Some(ty::ReifyReason::Vtable)) => {
+            ty::ShimKind::Reify(_, Some(ty::ReifyReason::Vtable)) => {
                 cx.write_str("shim(reify-vtable)")
             }
-            ty::ShimKind::ThreadLocalShim(_) => cx.write_str("shim(tls)"),
-            ty::ShimKind::FnPtrShim(_, ty) => cx.write_str(&format!("shim({ty})")),
-            ty::ShimKind::ClosureOnceShim { .. } => cx.write_str("shim"),
-            ty::ShimKind::ConstructCoroutineInClosureShim { .. } => cx.write_str("shim"),
+            ty::ShimKind::ThreadLocal(_) => cx.write_str("shim(tls)"),
+            ty::ShimKind::FnPtr(_, ty) => cx.write_str(&format!("shim({ty})")),
+            ty::ShimKind::ClosureOnce { .. } => cx.write_str("shim"),
+            ty::ShimKind::ConstructCoroutineInClosure { .. } => cx.write_str("shim"),
             ty::ShimKind::DropGlue(_, None) => cx.write_str("shim(None)"),
             ty::ShimKind::DropGlue(_, Some(ty)) => cx.write_str(&format!("shim(Some({ty}))")),
-            ty::ShimKind::CloneShim(_, ty) => cx.write_str(&format!("shim({ty})")),
-            ty::ShimKind::FnPtrAddrShim(_, ty) => cx.write_str(&format!("shim({ty})")),
-            ty::ShimKind::FutureDropPollShim(_, proxy_ty, impl_ty) => {
+            ty::ShimKind::Clone(_, ty) => cx.write_str(&format!("shim({ty})")),
+            ty::ShimKind::FnPtrAddr(_, ty) => cx.write_str(&format!("shim({ty})")),
+            ty::ShimKind::FutureDropPoll(_, proxy_ty, impl_ty) => {
                 cx.write_str(&format!("dropshim({proxy_ty}-{impl_ty})"))
             }
             ty::ShimKind::AsyncDropGlue(_, ty) => cx.write_str(&format!("shim({ty})")),
-            ty::ShimKind::AsyncDropGlueCtorShim(_, ty) => {
-                cx.write_str(&format!("shim(Some({ty}))"))
-            }
+            ty::ShimKind::AsyncDropGlueCtor(_, ty) => cx.write_str(&format!("shim(Some({ty}))")),
         }
     }
 }

--- a/compiler/rustc_middle/src/ty/print/mod.rs
+++ b/compiler/rustc_middle/src/ty/print/mod.rs
@@ -367,35 +367,44 @@ impl<'tcx, P: Printer<'tcx> + std::fmt::Write> Print<P> for ty::Instance<'tcx> {
         cx.print_def_path(self.def_id(), self.args)?;
         match self.def {
             ty::InstanceKind::Item(_) => {}
-            ty::InstanceKind::VTableShim(_) => cx.write_str(" - shim(vtable)")?,
-            ty::InstanceKind::ReifyShim(_, None) => cx.write_str(" - shim(reify)")?,
-            ty::InstanceKind::ReifyShim(_, Some(ty::ReifyReason::FnPtr)) => {
-                cx.write_str(" - shim(reify-fnptr)")?
-            }
-            ty::InstanceKind::ReifyShim(_, Some(ty::ReifyReason::Vtable)) => {
-                cx.write_str(" - shim(reify-vtable)")?
-            }
-            ty::InstanceKind::ThreadLocalShim(_) => cx.write_str(" - shim(tls)")?,
             ty::InstanceKind::Intrinsic(_) => cx.write_str(" - intrinsic")?,
             ty::InstanceKind::Virtual(_, num) => cx.write_str(&format!(" - virtual#{num}"))?,
-            ty::InstanceKind::FnPtrShim(_, ty) => cx.write_str(&format!(" - shim({ty})"))?,
-            ty::InstanceKind::ClosureOnceShim { .. } => cx.write_str(" - shim")?,
-            ty::InstanceKind::ConstructCoroutineInClosureShim { .. } => cx.write_str(" - shim")?,
-            ty::InstanceKind::DropGlue(_, None) => cx.write_str(" - shim(None)")?,
-            ty::InstanceKind::DropGlue(_, Some(ty)) => {
-                cx.write_str(&format!(" - shim(Some({ty}))"))?
+            ty::InstanceKind::Shim(shim) => {
+                cx.write_str(" - ")?;
+                shim.print(cx)?;
             }
-            ty::InstanceKind::CloneShim(_, ty) => cx.write_str(&format!(" - shim({ty})"))?,
-            ty::InstanceKind::FnPtrAddrShim(_, ty) => cx.write_str(&format!(" - shim({ty})"))?,
-            ty::InstanceKind::FutureDropPollShim(_, proxy_ty, impl_ty) => {
-                cx.write_str(&format!(" - dropshim({proxy_ty}-{impl_ty})"))?
-            }
-            ty::InstanceKind::AsyncDropGlue(_, ty) => cx.write_str(&format!(" - shim({ty})"))?,
-            ty::InstanceKind::AsyncDropGlueCtorShim(_, ty) => {
-                cx.write_str(&format!(" - shim(Some({ty}))"))?
-            }
-        };
+        }
         Ok(())
+    }
+}
+
+impl<'tcx, P: Printer<'tcx> + std::fmt::Write> Print<P> for ty::ShimKind<'tcx> {
+    fn print(&self, cx: &mut P) -> Result<(), PrintError> {
+        match self {
+            ty::ShimKind::VTableShim(_) => cx.write_str("shim(vtable)"),
+            ty::ShimKind::ReifyShim(_, None) => cx.write_str("shim(reify)"),
+            ty::ShimKind::ReifyShim(_, Some(ty::ReifyReason::FnPtr)) => {
+                cx.write_str("shim(reify-fnptr)")
+            }
+            ty::ShimKind::ReifyShim(_, Some(ty::ReifyReason::Vtable)) => {
+                cx.write_str("shim(reify-vtable)")
+            }
+            ty::ShimKind::ThreadLocalShim(_) => cx.write_str("shim(tls)"),
+            ty::ShimKind::FnPtrShim(_, ty) => cx.write_str(&format!("shim({ty})")),
+            ty::ShimKind::ClosureOnceShim { .. } => cx.write_str("shim"),
+            ty::ShimKind::ConstructCoroutineInClosureShim { .. } => cx.write_str("shim"),
+            ty::ShimKind::DropGlue(_, None) => cx.write_str("shim(None)"),
+            ty::ShimKind::DropGlue(_, Some(ty)) => cx.write_str(&format!("shim(Some({ty}))")),
+            ty::ShimKind::CloneShim(_, ty) => cx.write_str(&format!("shim({ty})")),
+            ty::ShimKind::FnPtrAddrShim(_, ty) => cx.write_str(&format!("shim({ty})")),
+            ty::ShimKind::FutureDropPollShim(_, proxy_ty, impl_ty) => {
+                cx.write_str(&format!("dropshim({proxy_ty}-{impl_ty})"))
+            }
+            ty::ShimKind::AsyncDropGlue(_, ty) => cx.write_str(&format!("shim({ty})")),
+            ty::ShimKind::AsyncDropGlueCtorShim(_, ty) => {
+                cx.write_str(&format!("shim(Some({ty}))"))
+            }
+        }
     }
 }
 

--- a/compiler/rustc_mir_transform/src/coroutine/by_move_body.rs
+++ b/compiler/rustc_mir_transform/src/coroutine/by_move_body.rs
@@ -223,8 +223,10 @@ pub(crate) fn coroutine_by_move_body_def_id<'tcx>(
         None,
         &mut PerParentDisambiguatorState::new(parent_def_id),
     );
-    by_move_body.source =
-        mir::MirSource::from_instance(InstanceKind::Item(body_def.def_id().to_def_id()));
+    by_move_body.source = mir::MirSource {
+        instance: InstanceKind::Item(body_def.def_id().to_def_id()),
+        promoted: None,
+    };
 
     if let Some(dumper) = MirDumper::new(tcx, "built", &by_move_body) {
         dumper.set_disambiguator(&"after").dump_mir(&by_move_body);

--- a/compiler/rustc_mir_transform/src/coroutine/drop.rs
+++ b/compiler/rustc_mir_transform/src/coroutine/drop.rs
@@ -206,7 +206,7 @@ pub(super) fn create_coroutine_drop_shim<'tcx>(
     // Update the body's def to become the drop glue.
     let coroutine_instance = body.source.instance;
     let drop_glue = tcx.require_lang_item(LangItem::DropGlue, body.span);
-    let drop_instance = InstanceKind::DropGlue(drop_glue, Some(coroutine_ty));
+    let drop_instance = InstanceKind::Shim(ShimKind::DropGlue(drop_glue, Some(coroutine_ty)));
 
     // Temporary change MirSource to coroutine's instance so that dump_mir produces more sensible
     // filename.

--- a/compiler/rustc_mir_transform/src/coroutine/mod.rs
+++ b/compiler/rustc_mir_transform/src/coroutine/mod.rs
@@ -71,7 +71,7 @@ use rustc_index::{Idx, IndexVec, indexvec};
 use rustc_middle::mir::visit::{MutVisitor, MutatingUseContext, PlaceContext, Visitor};
 use rustc_middle::mir::*;
 use rustc_middle::ty::{
-    self, CoroutineArgs, CoroutineArgsExt, GenericArgsRef, InstanceKind, Ty, TyCtxt,
+    self, CoroutineArgs, CoroutineArgsExt, GenericArgsRef, InstanceKind, ShimKind, Ty, TyCtxt,
 };
 use rustc_middle::{bug, span_bug};
 use rustc_mir_dataflow::impls::always_storage_live_locals;

--- a/compiler/rustc_mir_transform/src/inline.rs
+++ b/compiler/rustc_mir_transform/src/inline.rs
@@ -746,14 +746,14 @@ fn check_mir_is_available<'tcx, I: Inliner<'tcx>>(
             return Err("implementation limitation -- HACK for dropping polymorphic type");
         }
         InstanceKind::Shim(ShimKind::AsyncDropGlue(_, ty))
-        | InstanceKind::Shim(ShimKind::AsyncDropGlueCtorShim(_, ty)) => {
+        | InstanceKind::Shim(ShimKind::AsyncDropGlueCtor(_, ty)) => {
             return if ty.still_further_specializable() {
                 Err("still needs substitution")
             } else {
                 Ok(())
             };
         }
-        InstanceKind::Shim(ShimKind::FutureDropPollShim(_, ty, ty2)) => {
+        InstanceKind::Shim(ShimKind::FutureDropPoll(_, ty, ty2)) => {
             return if ty.still_further_specializable() || ty2.still_further_specializable() {
                 Err("still needs substitution")
             } else {
@@ -765,15 +765,15 @@ fn check_mir_is_available<'tcx, I: Inliner<'tcx>>(
         // not get any optimizations run on it. Any subsequent inlining may cause cycles, but we
         // do not need to catch this here, we can wait until the inliner decides to continue
         // inlining a second time.
-        InstanceKind::Shim(ShimKind::VTableShim(_))
-        | InstanceKind::Shim(ShimKind::ReifyShim(..))
-        | InstanceKind::Shim(ShimKind::FnPtrShim(..))
-        | InstanceKind::Shim(ShimKind::ClosureOnceShim { .. })
-        | InstanceKind::Shim(ShimKind::ConstructCoroutineInClosureShim { .. })
+        InstanceKind::Shim(ShimKind::VTable(_))
+        | InstanceKind::Shim(ShimKind::Reify(..))
+        | InstanceKind::Shim(ShimKind::FnPtr(..))
+        | InstanceKind::Shim(ShimKind::ClosureOnce { .. })
+        | InstanceKind::Shim(ShimKind::ConstructCoroutineInClosure { .. })
         | InstanceKind::Shim(ShimKind::DropGlue(..))
-        | InstanceKind::Shim(ShimKind::CloneShim(..))
-        | InstanceKind::Shim(ShimKind::ThreadLocalShim(..))
-        | InstanceKind::Shim(ShimKind::FnPtrAddrShim(..)) => return Ok(()),
+        | InstanceKind::Shim(ShimKind::Clone(..))
+        | InstanceKind::Shim(ShimKind::ThreadLocal(..))
+        | InstanceKind::Shim(ShimKind::FnPtrAddr(..)) => return Ok(()),
     }
 
     if inliner.tcx().is_constructor(callee_def_id) {
@@ -1374,7 +1374,7 @@ fn try_instance_mir<'tcx>(
     instance: InstanceKind<'tcx>,
 ) -> Result<&'tcx Body<'tcx>, &'static str> {
     if let ty::InstanceKind::Shim(ty::ShimKind::DropGlue(_, Some(ty)))
-    | ty::InstanceKind::Shim(ty::ShimKind::AsyncDropGlueCtorShim(_, ty)) = instance
+    | ty::InstanceKind::Shim(ty::ShimKind::AsyncDropGlueCtor(_, ty)) = instance
         && let ty::Adt(def, args) = ty.kind()
     {
         let fields = def.all_fields();

--- a/compiler/rustc_mir_transform/src/inline.rs
+++ b/compiler/rustc_mir_transform/src/inline.rs
@@ -15,7 +15,7 @@ use rustc_middle::middle::codegen_fn_attrs::CodegenFnAttrs;
 use rustc_middle::mir::visit::*;
 use rustc_middle::mir::*;
 use rustc_middle::ty::{
-    self, Instance, InstanceKind, Ty, TyCtxt, TypeFlags, TypeVisitableExt, Unnormalized,
+    self, Instance, InstanceKind, ShimKind, Ty, TyCtxt, TypeFlags, TypeVisitableExt, Unnormalized,
 };
 use rustc_session::config::{DebugInfo, OptLevel};
 use rustc_span::Spanned;
@@ -739,18 +739,21 @@ fn check_mir_is_available<'tcx, I: Inliner<'tcx>>(
         // the correct param-env for types being dropped. Stall resolving
         // the MIR for this instance until all of its const params are
         // substituted.
-        InstanceKind::DropGlue(_, Some(ty)) if ty.has_type_flags(TypeFlags::HAS_CT_PARAM) => {
+        InstanceKind::Shim(ShimKind::DropGlue(_, Some(ty)))
+            if ty.has_type_flags(TypeFlags::HAS_CT_PARAM) =>
+        {
             debug!("still needs substitution");
             return Err("implementation limitation -- HACK for dropping polymorphic type");
         }
-        InstanceKind::AsyncDropGlue(_, ty) | InstanceKind::AsyncDropGlueCtorShim(_, ty) => {
+        InstanceKind::Shim(ShimKind::AsyncDropGlue(_, ty))
+        | InstanceKind::Shim(ShimKind::AsyncDropGlueCtorShim(_, ty)) => {
             return if ty.still_further_specializable() {
                 Err("still needs substitution")
             } else {
                 Ok(())
             };
         }
-        InstanceKind::FutureDropPollShim(_, ty, ty2) => {
+        InstanceKind::Shim(ShimKind::FutureDropPollShim(_, ty, ty2)) => {
             return if ty.still_further_specializable() || ty2.still_further_specializable() {
                 Err("still needs substitution")
             } else {
@@ -762,15 +765,15 @@ fn check_mir_is_available<'tcx, I: Inliner<'tcx>>(
         // not get any optimizations run on it. Any subsequent inlining may cause cycles, but we
         // do not need to catch this here, we can wait until the inliner decides to continue
         // inlining a second time.
-        InstanceKind::VTableShim(_)
-        | InstanceKind::ReifyShim(..)
-        | InstanceKind::FnPtrShim(..)
-        | InstanceKind::ClosureOnceShim { .. }
-        | InstanceKind::ConstructCoroutineInClosureShim { .. }
-        | InstanceKind::DropGlue(..)
-        | InstanceKind::CloneShim(..)
-        | InstanceKind::ThreadLocalShim(..)
-        | InstanceKind::FnPtrAddrShim(..) => return Ok(()),
+        InstanceKind::Shim(ShimKind::VTableShim(_))
+        | InstanceKind::Shim(ShimKind::ReifyShim(..))
+        | InstanceKind::Shim(ShimKind::FnPtrShim(..))
+        | InstanceKind::Shim(ShimKind::ClosureOnceShim { .. })
+        | InstanceKind::Shim(ShimKind::ConstructCoroutineInClosureShim { .. })
+        | InstanceKind::Shim(ShimKind::DropGlue(..))
+        | InstanceKind::Shim(ShimKind::CloneShim(..))
+        | InstanceKind::Shim(ShimKind::ThreadLocalShim(..))
+        | InstanceKind::Shim(ShimKind::FnPtrAddrShim(..)) => return Ok(()),
     }
 
     if inliner.tcx().is_constructor(callee_def_id) {
@@ -1370,8 +1373,8 @@ fn try_instance_mir<'tcx>(
     tcx: TyCtxt<'tcx>,
     instance: InstanceKind<'tcx>,
 ) -> Result<&'tcx Body<'tcx>, &'static str> {
-    if let ty::InstanceKind::DropGlue(_, Some(ty)) | ty::InstanceKind::AsyncDropGlueCtorShim(_, ty) =
-        instance
+    if let ty::InstanceKind::Shim(ty::ShimKind::DropGlue(_, Some(ty)))
+    | ty::InstanceKind::Shim(ty::ShimKind::AsyncDropGlueCtorShim(_, ty)) = instance
         && let ty::Adt(def, args) = ty.kind()
     {
         let fields = def.all_fields();

--- a/compiler/rustc_mir_transform/src/inline/cycle.rs
+++ b/compiler/rustc_mir_transform/src/inline/cycle.rs
@@ -26,24 +26,24 @@ fn should_recurse<'tcx>(tcx: TyCtxt<'tcx>, callee: ty::Instance<'tcx>) -> bool {
         // These have MIR and if that MIR is inlined, instantiated and then inlining is run
         // again, a function item can end up getting inlined. Thus we'll be able to cause
         // a cycle that way
-        InstanceKind::Shim(ShimKind::VTableShim(_))
-        | InstanceKind::Shim(ShimKind::ReifyShim(..))
-        | InstanceKind::Shim(ShimKind::FnPtrShim(..))
-        | InstanceKind::Shim(ShimKind::ClosureOnceShim { .. })
-        | InstanceKind::Shim(ShimKind::ConstructCoroutineInClosureShim { .. })
-        | InstanceKind::Shim(ShimKind::ThreadLocalShim { .. })
-        | InstanceKind::Shim(ShimKind::CloneShim(..)) => {}
+        InstanceKind::Shim(ShimKind::VTable(_))
+        | InstanceKind::Shim(ShimKind::Reify(..))
+        | InstanceKind::Shim(ShimKind::FnPtr(..))
+        | InstanceKind::Shim(ShimKind::ClosureOnce { .. })
+        | InstanceKind::Shim(ShimKind::ConstructCoroutineInClosure { .. })
+        | InstanceKind::Shim(ShimKind::ThreadLocal { .. })
+        | InstanceKind::Shim(ShimKind::Clone(..)) => {}
 
         // This shim does not call any other functions, thus there can be no recursion.
-        InstanceKind::Shim(ShimKind::FnPtrAddrShim(..)) => return false,
+        InstanceKind::Shim(ShimKind::FnPtrAddr(..)) => return false,
 
         // FIXME: A not fully instantiated drop shim can cause ICEs if one attempts to
         // have its MIR built. Likely oli-obk just screwed up the `ParamEnv`s, so this
         // needs some more analysis.
         InstanceKind::Shim(ShimKind::DropGlue(..))
-        | InstanceKind::Shim(ShimKind::FutureDropPollShim(..))
+        | InstanceKind::Shim(ShimKind::FutureDropPoll(..))
         | InstanceKind::Shim(ShimKind::AsyncDropGlue(..))
-        | InstanceKind::Shim(ShimKind::AsyncDropGlueCtorShim(..)) => {
+        | InstanceKind::Shim(ShimKind::AsyncDropGlueCtor(..)) => {
             if callee.has_param() {
                 return false;
             }

--- a/compiler/rustc_mir_transform/src/inline/cycle.rs
+++ b/compiler/rustc_mir_transform/src/inline/cycle.rs
@@ -4,7 +4,7 @@ use rustc_data_structures::unord::UnordSet;
 use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_hir::limit::Limit;
 use rustc_middle::mir::TerminatorKind;
-use rustc_middle::ty::{self, GenericArgsRef, InstanceKind, TyCtxt, TypeVisitableExt};
+use rustc_middle::ty::{self, GenericArgsRef, InstanceKind, ShimKind, TyCtxt, TypeVisitableExt};
 use rustc_span::sym;
 use tracing::{instrument, trace};
 
@@ -26,24 +26,24 @@ fn should_recurse<'tcx>(tcx: TyCtxt<'tcx>, callee: ty::Instance<'tcx>) -> bool {
         // These have MIR and if that MIR is inlined, instantiated and then inlining is run
         // again, a function item can end up getting inlined. Thus we'll be able to cause
         // a cycle that way
-        InstanceKind::VTableShim(_)
-        | InstanceKind::ReifyShim(..)
-        | InstanceKind::FnPtrShim(..)
-        | InstanceKind::ClosureOnceShim { .. }
-        | InstanceKind::ConstructCoroutineInClosureShim { .. }
-        | InstanceKind::ThreadLocalShim { .. }
-        | InstanceKind::CloneShim(..) => {}
+        InstanceKind::Shim(ShimKind::VTableShim(_))
+        | InstanceKind::Shim(ShimKind::ReifyShim(..))
+        | InstanceKind::Shim(ShimKind::FnPtrShim(..))
+        | InstanceKind::Shim(ShimKind::ClosureOnceShim { .. })
+        | InstanceKind::Shim(ShimKind::ConstructCoroutineInClosureShim { .. })
+        | InstanceKind::Shim(ShimKind::ThreadLocalShim { .. })
+        | InstanceKind::Shim(ShimKind::CloneShim(..)) => {}
 
         // This shim does not call any other functions, thus there can be no recursion.
-        InstanceKind::FnPtrAddrShim(..) => return false,
+        InstanceKind::Shim(ShimKind::FnPtrAddrShim(..)) => return false,
 
         // FIXME: A not fully instantiated drop shim can cause ICEs if one attempts to
         // have its MIR built. Likely oli-obk just screwed up the `ParamEnv`s, so this
         // needs some more analysis.
-        InstanceKind::DropGlue(..)
-        | InstanceKind::FutureDropPollShim(..)
-        | InstanceKind::AsyncDropGlue(..)
-        | InstanceKind::AsyncDropGlueCtorShim(..) => {
+        InstanceKind::Shim(ShimKind::DropGlue(..))
+        | InstanceKind::Shim(ShimKind::FutureDropPollShim(..))
+        | InstanceKind::Shim(ShimKind::AsyncDropGlue(..))
+        | InstanceKind::Shim(ShimKind::AsyncDropGlueCtorShim(..)) => {
             if callee.has_param() {
                 return false;
             }

--- a/compiler/rustc_mir_transform/src/shim.rs
+++ b/compiler/rustc_mir_transform/src/shim.rs
@@ -31,16 +31,15 @@ pub(super) fn provide(providers: &mut Providers) {
     providers.mir_shims = make_shim;
 }
 
-fn make_shim<'tcx>(tcx: TyCtxt<'tcx>, instance: ty::InstanceKind<'tcx>) -> Body<'tcx> {
-    debug!("make_shim({:?})", instance);
+fn make_shim<'tcx>(tcx: TyCtxt<'tcx>, shim: ty::ShimKind<'tcx>) -> Body<'tcx> {
+    debug!("make_shim({:?})", shim);
 
-    let mut result = match instance {
-        ty::InstanceKind::Item(..) => bug!("item {:?} passed to make_shim", instance),
-        ty::InstanceKind::VTableShim(def_id) => {
+    let mut result = match shim {
+        ty::ShimKind::VTableShim(def_id) => {
             let adjustment = Adjustment::Deref { source: DerefSource::MutPtr };
-            build_call_shim(tcx, instance, Some(adjustment), CallKind::Direct(def_id))
+            build_call_shim(tcx, shim, Some(adjustment), CallKind::Direct(def_id))
         }
-        ty::InstanceKind::FnPtrShim(def_id, ty) => {
+        ty::ShimKind::FnPtrShim(def_id, ty) => {
             let trait_ = tcx.parent(def_id);
             // Supports `Fn` or `async Fn` traits.
             let adjustment = match tcx
@@ -53,17 +52,17 @@ fn make_shim<'tcx>(tcx: TyCtxt<'tcx>, instance: ty::InstanceKind<'tcx>) -> Body<
                 None => bug!("fn pointer {:?} is not an fn", ty),
             };
 
-            build_call_shim(tcx, instance, Some(adjustment), CallKind::Indirect(ty))
+            build_call_shim(tcx, shim, Some(adjustment), CallKind::Indirect(ty))
         }
         // We are generating a call back to our def-id, which the
         // codegen backend knows to turn to an actual call, be it
         // a virtual call, or a direct call to a function for which
         // indirect calls must be codegen'd differently than direct ones
         // (such as `#[track_caller]`).
-        ty::InstanceKind::ReifyShim(def_id, _) => {
-            build_call_shim(tcx, instance, None, CallKind::Direct(def_id))
+        ty::ShimKind::ReifyShim(def_id, _) => {
+            build_call_shim(tcx, shim, None, CallKind::Direct(def_id))
         }
-        ty::InstanceKind::ClosureOnceShim { call_once: _, closure: _, track_caller: _ } => {
+        ty::ShimKind::ClosureOnceShim { call_once: _, closure: _, track_caller: _ } => {
             let fn_mut = tcx.require_lang_item(LangItem::FnMut, DUMMY_SP);
             let call_mut = tcx
                 .associated_items(fn_mut)
@@ -72,15 +71,15 @@ fn make_shim<'tcx>(tcx: TyCtxt<'tcx>, instance: ty::InstanceKind<'tcx>) -> Body<
                 .unwrap()
                 .def_id;
 
-            build_call_shim(tcx, instance, Some(Adjustment::RefMut), CallKind::Direct(call_mut))
+            build_call_shim(tcx, shim, Some(Adjustment::RefMut), CallKind::Direct(call_mut))
         }
 
-        ty::InstanceKind::ConstructCoroutineInClosureShim {
+        ty::ShimKind::ConstructCoroutineInClosureShim {
             coroutine_closure_def_id,
             receiver_by_ref,
         } => build_construct_coroutine_by_move_shim(tcx, coroutine_closure_def_id, receiver_by_ref),
 
-        ty::InstanceKind::DropGlue(def_id, ty) => {
+        ty::ShimKind::DropGlue(def_id, ty) => {
             // FIXME(#91576): Drop shims for coroutines aren't subject to the MIR passes at the end
             // of this function. Is this intentional?
             if let Some(&ty::Coroutine(coroutine_def_id, args)) = ty.map(Ty::kind) {
@@ -110,7 +109,7 @@ fn make_shim<'tcx>(tcx: TyCtxt<'tcx>, instance: ty::InstanceKind<'tcx>) -> Body<
 
                 let mut body =
                     EarlyBinder::bind(body.clone()).instantiate(tcx, args).skip_norm_wip();
-                debug!("make_shim({:?}) = {:?}", instance, body);
+                debug!("make_shim({:?}) = {:?}", shim, body);
 
                 pm::run_passes(
                     tcx,
@@ -129,10 +128,10 @@ fn make_shim<'tcx>(tcx: TyCtxt<'tcx>, instance: ty::InstanceKind<'tcx>) -> Body<
 
             build_drop_shim(tcx, def_id, ty, ty::TypingEnv::post_analysis(tcx, def_id))
         }
-        ty::InstanceKind::ThreadLocalShim(..) => build_thread_local_shim(tcx, instance),
-        ty::InstanceKind::CloneShim(def_id, ty) => build_clone_shim(tcx, def_id, ty),
-        ty::InstanceKind::FnPtrAddrShim(def_id, ty) => build_fn_ptr_addr_shim(tcx, def_id, ty),
-        ty::InstanceKind::FutureDropPollShim(def_id, proxy_ty, impl_ty) => {
+        ty::ShimKind::ThreadLocalShim(..) => build_thread_local_shim(tcx, shim),
+        ty::ShimKind::CloneShim(def_id, ty) => build_clone_shim(tcx, def_id, ty),
+        ty::ShimKind::FnPtrAddrShim(def_id, ty) => build_fn_ptr_addr_shim(tcx, def_id, ty),
+        ty::ShimKind::FutureDropPollShim(def_id, proxy_ty, impl_ty) => {
             let mut body =
                 async_destructor_ctor::build_future_drop_poll_shim(tcx, def_id, proxy_ty, impl_ty);
 
@@ -148,10 +147,10 @@ fn make_shim<'tcx>(tcx: TyCtxt<'tcx>, instance: ty::InstanceKind<'tcx>) -> Body<
                 pm::Optimizations::Allowed,
             );
             run_optimization_passes(tcx, &mut body);
-            debug!("make_shim({:?}) = {:?}", instance, body);
+            debug!("make_shim({:?}) = {:?}", shim, body);
             return body;
         }
-        ty::InstanceKind::AsyncDropGlue(def_id, ty) => {
+        ty::ShimKind::AsyncDropGlue(def_id, ty) => {
             let mut body = async_destructor_ctor::build_async_drop_shim(tcx, def_id, ty);
 
             // Main pass required here is StateTransform to convert sync drop ladder
@@ -170,23 +169,17 @@ fn make_shim<'tcx>(tcx: TyCtxt<'tcx>, instance: ty::InstanceKind<'tcx>) -> Body<
                 Some(MirPhase::Runtime(RuntimePhase::PostCleanup)),
             );
             run_optimization_passes(tcx, &mut body);
-            debug!("make_shim({:?}) = {:?}", instance, body);
+            debug!("make_shim({:?}) = {:?}", shim, body);
             return body;
         }
 
-        ty::InstanceKind::AsyncDropGlueCtorShim(def_id, ty) => {
+        ty::ShimKind::AsyncDropGlueCtorShim(def_id, ty) => {
             let body = async_destructor_ctor::build_async_destructor_ctor_shim(tcx, def_id, ty);
-            debug!("make_shim({:?}) = {:?}", instance, body);
+            debug!("make_shim({:?}) = {:?}", shim, body);
             return body;
         }
-        ty::InstanceKind::Virtual(..) => {
-            bug!("InstanceKind::Virtual ({:?}) is for direct calls only", instance)
-        }
-        ty::InstanceKind::Intrinsic(_) => {
-            bug!("creating shims from intrinsics ({:?}) is unsupported", instance)
-        }
     };
-    debug!("make_shim({:?}) = untransformed {:?}", instance, result);
+    debug!("make_shim({:?}) = untransformed {:?}", shim, result);
 
     deref_finder(tcx, &mut result, false);
 
@@ -211,7 +204,7 @@ fn make_shim<'tcx>(tcx: TyCtxt<'tcx>, instance: ty::InstanceKind<'tcx>) -> Body<
         Some(MirPhase::Runtime(RuntimePhase::Optimized)),
     );
 
-    debug!("make_shim({:?}) = {:?}", instance, result);
+    debug!("make_shim({:?}) = {:?}", shim, result);
 
     result
 }
@@ -300,7 +293,7 @@ pub fn build_drop_shim<'tcx>(
     }
     block(&mut blocks, TerminatorKind::Return);
 
-    let source = MirSource::from_instance(ty::InstanceKind::DropGlue(def_id, ty));
+    let source = MirSource::from_shim(ty::ShimKind::DropGlue(def_id, ty));
     let mut body =
         new_body(source, blocks, local_decls_for_sig(&sig, span), sig.inputs().len(), span);
 
@@ -480,11 +473,8 @@ impl<'a, 'tcx> DropElaborator<'a, 'tcx> for DropShimElaborator<'a, 'tcx> {
     }
 }
 
-fn build_thread_local_shim<'tcx>(
-    tcx: TyCtxt<'tcx>,
-    instance: ty::InstanceKind<'tcx>,
-) -> Body<'tcx> {
-    let def_id = instance.def_id();
+fn build_thread_local_shim<'tcx>(tcx: TyCtxt<'tcx>, shim: ty::ShimKind<'tcx>) -> Body<'tcx> {
+    let def_id = shim.def_id();
 
     let span = tcx.def_span(def_id);
     let source_info = SourceInfo::outermost(span);
@@ -502,7 +492,7 @@ fn build_thread_local_shim<'tcx>(
     )]);
 
     new_body(
-        MirSource::from_instance(instance),
+        MirSource::from_shim(shim),
         blocks,
         IndexVec::from_raw(vec![LocalDecl::new(tcx.thread_local_ptr_ty(def_id), span)]),
         0,
@@ -565,7 +555,7 @@ impl<'tcx> CloneShimBuilder<'tcx> {
     }
 
     fn into_mir(self) -> Body<'tcx> {
-        let source = MirSource::from_instance(ty::InstanceKind::CloneShim(
+        let source = MirSource::from_shim(ty::ShimKind::CloneShim(
             self.def_id,
             self.sig.inputs_and_output[0],
         ));
@@ -776,14 +766,14 @@ impl<'tcx> CloneShimBuilder<'tcx> {
 #[instrument(level = "debug", skip(tcx), ret)]
 fn build_call_shim<'tcx>(
     tcx: TyCtxt<'tcx>,
-    instance: ty::InstanceKind<'tcx>,
+    shim: ty::ShimKind<'tcx>,
     rcvr_adjustment: Option<Adjustment>,
     call_kind: CallKind<'tcx>,
 ) -> Body<'tcx> {
     // `FnPtrShim` contains the fn pointer type that a call shim is being built for - this is used
     // to instantiate into the signature of the shim. It is not necessary for users of this
     // MIR body to perform further instantiations (see `InstanceKind::has_polymorphic_mir_body`).
-    let (sig_args, untuple_args) = if let ty::InstanceKind::FnPtrShim(_, ty) = instance {
+    let (sig_args, untuple_args) = if let ty::ShimKind::FnPtrShim(_, ty) = shim {
         let sig = tcx.instantiate_bound_regions_with_erased(ty.fn_sig(tcx));
 
         let untuple_args = sig.inputs();
@@ -796,12 +786,12 @@ fn build_call_shim<'tcx>(
         (None, None)
     };
 
-    let def_id = instance.def_id();
+    let def_id = shim.def_id();
 
     let sig = tcx.fn_sig(def_id);
     let sig = sig.map_bound(|sig| tcx.instantiate_bound_regions_with_erased(sig));
 
-    assert_eq!(sig_args.is_some(), !instance.has_polymorphic_mir_body());
+    assert_eq!(sig_args.is_some(), !shim.has_polymorphic_mir_body());
     let mut sig = if let Some(sig_args) = sig_args {
         sig.instantiate(tcx, &sig_args).skip_norm_wip()
     } else {
@@ -830,14 +820,14 @@ fn build_call_shim<'tcx>(
                 DerefSource::MutRef => Ty::new_mut_ref(tcx, tcx.lifetimes.re_erased, fnty),
                 DerefSource::MutPtr => Ty::new_mut_ptr(tcx, fnty),
             },
-            Adjustment::RefMut => bug!("`RefMut` is never used with indirect calls: {instance:?}"),
+            Adjustment::RefMut => bug!("`RefMut` is never used with indirect calls: {shim:?}"),
         };
         sig.inputs_and_output = tcx.mk_type_list(&inputs_and_output);
     }
 
     // FIXME: Avoid having to adjust the signature both here and in
     // `fn_sig_for_fn_abi`.
-    if let ty::InstanceKind::VTableShim(..) = instance {
+    if let ty::ShimKind::VTableShim(..) = shim {
         // Modify fn(self, ...) to fn(self: *mut Self, ...)
         let mut inputs_and_output = sig.inputs_and_output.to_vec();
         let self_arg = &mut inputs_and_output[0];
@@ -995,7 +985,7 @@ fn build_call_shim<'tcx>(
     }
 
     let mut body =
-        new_body(MirSource::from_instance(instance), blocks, local_decls, sig.inputs().len(), span);
+        new_body(MirSource::from_shim(shim), blocks, local_decls, sig.inputs().len(), span);
 
     if let ExternAbi::RustCall = sig.abi() {
         body.spread_arg = Some(Local::new(sig.inputs().len()));
@@ -1119,7 +1109,7 @@ fn build_fn_ptr_addr_shim<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId, self_ty: Ty<'t
         Some(Terminator { source_info, kind: TerminatorKind::Return, attributes: ThinVec::new() }),
         false,
     );
-    let source = MirSource::from_instance(ty::InstanceKind::FnPtrAddrShim(def_id, self_ty));
+    let source = MirSource::from_shim(ty::ShimKind::FnPtrAddrShim(def_id, self_ty));
     new_body(source, IndexVec::from_elem_n(start_block, 1), locals, sig.inputs().len(), span)
 }
 
@@ -1218,7 +1208,7 @@ fn build_construct_coroutine_by_move_shim<'tcx>(
         false,
     );
 
-    let source = MirSource::from_instance(ty::InstanceKind::ConstructCoroutineInClosureShim {
+    let source = MirSource::from_shim(ty::ShimKind::ConstructCoroutineInClosureShim {
         coroutine_closure_def_id,
         receiver_by_ref,
     });

--- a/compiler/rustc_mir_transform/src/shim.rs
+++ b/compiler/rustc_mir_transform/src/shim.rs
@@ -35,11 +35,11 @@ fn make_shim<'tcx>(tcx: TyCtxt<'tcx>, shim: ty::ShimKind<'tcx>) -> Body<'tcx> {
     debug!("make_shim({:?})", shim);
 
     let mut result = match shim {
-        ty::ShimKind::VTableShim(def_id) => {
+        ty::ShimKind::VTable(def_id) => {
             let adjustment = Adjustment::Deref { source: DerefSource::MutPtr };
             build_call_shim(tcx, shim, Some(adjustment), CallKind::Direct(def_id))
         }
-        ty::ShimKind::FnPtrShim(def_id, ty) => {
+        ty::ShimKind::FnPtr(def_id, ty) => {
             let trait_ = tcx.parent(def_id);
             // Supports `Fn` or `async Fn` traits.
             let adjustment = match tcx
@@ -59,10 +59,10 @@ fn make_shim<'tcx>(tcx: TyCtxt<'tcx>, shim: ty::ShimKind<'tcx>) -> Body<'tcx> {
         // a virtual call, or a direct call to a function for which
         // indirect calls must be codegen'd differently than direct ones
         // (such as `#[track_caller]`).
-        ty::ShimKind::ReifyShim(def_id, _) => {
+        ty::ShimKind::Reify(def_id, _) => {
             build_call_shim(tcx, shim, None, CallKind::Direct(def_id))
         }
-        ty::ShimKind::ClosureOnceShim { call_once: _, closure: _, track_caller: _ } => {
+        ty::ShimKind::ClosureOnce { call_once: _, closure: _, track_caller: _ } => {
             let fn_mut = tcx.require_lang_item(LangItem::FnMut, DUMMY_SP);
             let call_mut = tcx
                 .associated_items(fn_mut)
@@ -74,10 +74,9 @@ fn make_shim<'tcx>(tcx: TyCtxt<'tcx>, shim: ty::ShimKind<'tcx>) -> Body<'tcx> {
             build_call_shim(tcx, shim, Some(Adjustment::RefMut), CallKind::Direct(call_mut))
         }
 
-        ty::ShimKind::ConstructCoroutineInClosureShim {
-            coroutine_closure_def_id,
-            receiver_by_ref,
-        } => build_construct_coroutine_by_move_shim(tcx, coroutine_closure_def_id, receiver_by_ref),
+        ty::ShimKind::ConstructCoroutineInClosure { coroutine_closure_def_id, receiver_by_ref } => {
+            build_construct_coroutine_by_move_shim(tcx, coroutine_closure_def_id, receiver_by_ref)
+        }
 
         ty::ShimKind::DropGlue(def_id, ty) => {
             // FIXME(#91576): Drop shims for coroutines aren't subject to the MIR passes at the end
@@ -128,10 +127,10 @@ fn make_shim<'tcx>(tcx: TyCtxt<'tcx>, shim: ty::ShimKind<'tcx>) -> Body<'tcx> {
 
             build_drop_shim(tcx, def_id, ty, ty::TypingEnv::post_analysis(tcx, def_id))
         }
-        ty::ShimKind::ThreadLocalShim(..) => build_thread_local_shim(tcx, shim),
-        ty::ShimKind::CloneShim(def_id, ty) => build_clone_shim(tcx, def_id, ty),
-        ty::ShimKind::FnPtrAddrShim(def_id, ty) => build_fn_ptr_addr_shim(tcx, def_id, ty),
-        ty::ShimKind::FutureDropPollShim(def_id, proxy_ty, impl_ty) => {
+        ty::ShimKind::ThreadLocal(..) => build_thread_local_shim(tcx, shim),
+        ty::ShimKind::Clone(def_id, ty) => build_clone_shim(tcx, def_id, ty),
+        ty::ShimKind::FnPtrAddr(def_id, ty) => build_fn_ptr_addr_shim(tcx, def_id, ty),
+        ty::ShimKind::FutureDropPoll(def_id, proxy_ty, impl_ty) => {
             let mut body =
                 async_destructor_ctor::build_future_drop_poll_shim(tcx, def_id, proxy_ty, impl_ty);
 
@@ -173,7 +172,7 @@ fn make_shim<'tcx>(tcx: TyCtxt<'tcx>, shim: ty::ShimKind<'tcx>) -> Body<'tcx> {
             return body;
         }
 
-        ty::ShimKind::AsyncDropGlueCtorShim(def_id, ty) => {
+        ty::ShimKind::AsyncDropGlueCtor(def_id, ty) => {
             let body = async_destructor_ctor::build_async_destructor_ctor_shim(tcx, def_id, ty);
             debug!("make_shim({:?}) = {:?}", shim, body);
             return body;
@@ -555,10 +554,8 @@ impl<'tcx> CloneShimBuilder<'tcx> {
     }
 
     fn into_mir(self) -> Body<'tcx> {
-        let source = MirSource::from_shim(ty::ShimKind::CloneShim(
-            self.def_id,
-            self.sig.inputs_and_output[0],
-        ));
+        let source =
+            MirSource::from_shim(ty::ShimKind::Clone(self.def_id, self.sig.inputs_and_output[0]));
         new_body(source, self.blocks, self.local_decls, self.sig.inputs().len(), self.span)
     }
 
@@ -773,7 +770,7 @@ fn build_call_shim<'tcx>(
     // `FnPtrShim` contains the fn pointer type that a call shim is being built for - this is used
     // to instantiate into the signature of the shim. It is not necessary for users of this
     // MIR body to perform further instantiations (see `InstanceKind::has_polymorphic_mir_body`).
-    let (sig_args, untuple_args) = if let ty::ShimKind::FnPtrShim(_, ty) = shim {
+    let (sig_args, untuple_args) = if let ty::ShimKind::FnPtr(_, ty) = shim {
         let sig = tcx.instantiate_bound_regions_with_erased(ty.fn_sig(tcx));
 
         let untuple_args = sig.inputs();
@@ -827,7 +824,7 @@ fn build_call_shim<'tcx>(
 
     // FIXME: Avoid having to adjust the signature both here and in
     // `fn_sig_for_fn_abi`.
-    if let ty::ShimKind::VTableShim(..) = shim {
+    if let ty::ShimKind::VTable(..) = shim {
         // Modify fn(self, ...) to fn(self: *mut Self, ...)
         let mut inputs_and_output = sig.inputs_and_output.to_vec();
         let self_arg = &mut inputs_and_output[0];
@@ -1109,7 +1106,7 @@ fn build_fn_ptr_addr_shim<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId, self_ty: Ty<'t
         Some(Terminator { source_info, kind: TerminatorKind::Return, attributes: ThinVec::new() }),
         false,
     );
-    let source = MirSource::from_shim(ty::ShimKind::FnPtrAddrShim(def_id, self_ty));
+    let source = MirSource::from_shim(ty::ShimKind::FnPtrAddr(def_id, self_ty));
     new_body(source, IndexVec::from_elem_n(start_block, 1), locals, sig.inputs().len(), span)
 }
 
@@ -1208,7 +1205,7 @@ fn build_construct_coroutine_by_move_shim<'tcx>(
         false,
     );
 
-    let source = MirSource::from_shim(ty::ShimKind::ConstructCoroutineInClosureShim {
+    let source = MirSource::from_shim(ty::ShimKind::ConstructCoroutineInClosure {
         coroutine_closure_def_id,
         receiver_by_ref,
     });

--- a/compiler/rustc_mir_transform/src/shim/async_destructor_ctor.rs
+++ b/compiler/rustc_mir_transform/src/shim/async_destructor_ctor.rs
@@ -106,7 +106,7 @@ pub(super) fn build_async_drop_shim<'tcx>(
     );
     block(&mut blocks, TerminatorKind::Return);
 
-    let source = MirSource::from_instance(ty::InstanceKind::AsyncDropGlue(def_id, ty));
+    let source = MirSource::from_shim(ty::ShimKind::AsyncDropGlue(def_id, ty));
     let mut body =
         new_body(source, blocks, local_decls_for_sig(&sig, span), sig.inputs().len(), span);
 
@@ -175,17 +175,17 @@ pub(super) fn build_future_drop_poll_shim<'tcx>(
     proxy_ty: Ty<'tcx>,
     impl_ty: Ty<'tcx>,
 ) -> Body<'tcx> {
-    let instance = ty::InstanceKind::FutureDropPollShim(def_id, proxy_ty, impl_ty);
+    let shim = ty::ShimKind::FutureDropPollShim(def_id, proxy_ty, impl_ty);
     let ty::Coroutine(coroutine_def_id, _) = impl_ty.kind() else {
-        bug!("build_future_drop_poll_shim not for coroutine impl type: ({:?})", instance);
+        bug!("build_future_drop_poll_shim not for coroutine impl type: ({:?})", shim);
     };
 
     let span = tcx.def_span(def_id);
 
     if tcx.is_async_drop_in_place_coroutine(*coroutine_def_id) {
-        build_adrop_for_adrop_shim(tcx, proxy_ty, impl_ty, span, instance)
+        build_adrop_for_adrop_shim(tcx, proxy_ty, impl_ty, span, shim)
     } else {
-        build_adrop_for_coroutine_shim(tcx, proxy_ty, impl_ty, span, instance)
+        build_adrop_for_coroutine_shim(tcx, proxy_ty, impl_ty, span, shim)
     }
 }
 
@@ -198,16 +198,16 @@ fn build_adrop_for_coroutine_shim<'tcx>(
     proxy_ty: Ty<'tcx>,
     impl_ty: Ty<'tcx>,
     span: Span,
-    instance: ty::InstanceKind<'tcx>,
+    shim: ty::ShimKind<'tcx>,
 ) -> Body<'tcx> {
     let ty::Coroutine(coroutine_def_id, impl_args) = impl_ty.kind() else {
-        bug!("build_adrop_for_coroutine_shim not for coroutine impl type: ({:?})", instance);
+        bug!("build_adrop_for_coroutine_shim not for coroutine impl type: ({:?})", shim);
     };
     let source_info = SourceInfo::outermost(span);
     let body = tcx.optimized_mir(*coroutine_def_id).future_drop_poll().unwrap();
     let mut body: Body<'tcx> =
         EarlyBinder::bind(body.clone()).instantiate(tcx, impl_args).skip_norm_wip();
-    body.source.instance = instance;
+    body.source.instance = ty::InstanceKind::Shim(shim);
     body.phase = MirPhase::Runtime(RuntimePhase::Initial);
     body.var_debug_info.clear();
 
@@ -291,7 +291,7 @@ fn build_adrop_for_adrop_shim<'tcx>(
     proxy_ty: Ty<'tcx>,
     impl_ty: Ty<'tcx>,
     span: Span,
-    instance: ty::InstanceKind<'tcx>,
+    shim: ty::ShimKind<'tcx>,
 ) -> Body<'tcx> {
     let source_info = SourceInfo::outermost(span);
     let proxy_ref = Ty::new_mut_ref(tcx, tcx.lifetimes.re_erased, proxy_ty);
@@ -413,7 +413,7 @@ fn build_adrop_for_adrop_shim<'tcx>(
         false,
     ));
 
-    let source = MirSource::from_instance(instance);
+    let source = MirSource::from_shim(shim);
     let mut body = new_body(source, blocks, locals, sig.inputs().len(), span);
     body.phase = MirPhase::Runtime(RuntimePhase::Initial);
     return body;

--- a/compiler/rustc_mir_transform/src/shim/async_destructor_ctor.rs
+++ b/compiler/rustc_mir_transform/src/shim/async_destructor_ctor.rs
@@ -175,7 +175,7 @@ pub(super) fn build_future_drop_poll_shim<'tcx>(
     proxy_ty: Ty<'tcx>,
     impl_ty: Ty<'tcx>,
 ) -> Body<'tcx> {
-    let shim = ty::ShimKind::FutureDropPollShim(def_id, proxy_ty, impl_ty);
+    let shim = ty::ShimKind::FutureDropPoll(def_id, proxy_ty, impl_ty);
     let ty::Coroutine(coroutine_def_id, _) = impl_ty.kind() else {
         bug!("build_future_drop_poll_shim not for coroutine impl type: ({:?})", shim);
     };

--- a/compiler/rustc_monomorphize/src/collector.rs
+++ b/compiler/rustc_monomorphize/src/collector.rs
@@ -226,8 +226,8 @@ use rustc_middle::query::TyCtxtAt;
 use rustc_middle::ty::adjustment::{CustomCoerceUnsized, PointerCoercion};
 use rustc_middle::ty::layout::ValidityRequirement;
 use rustc_middle::ty::{
-    self, GenericArgs, GenericParamDefKind, Instance, InstanceKind, Ty, TyCtxt, TypeFoldable,
-    TypeVisitable, TypeVisitableExt, TypeVisitor, Unnormalized, VtblEntry,
+    self, GenericArgs, GenericParamDefKind, Instance, InstanceKind, ShimKind, Ty, TyCtxt,
+    TypeFoldable, TypeVisitable, TypeVisitableExt, TypeVisitor, Unnormalized, VtblEntry,
 };
 use rustc_middle::util::Providers;
 use rustc_middle::{bug, span_bug};
@@ -447,7 +447,7 @@ fn collect_items_rec<'tcx>(
                     used_items.push(respan(
                         starting_item.span,
                         MonoItem::Fn(Instance {
-                            def: InstanceKind::ThreadLocalShim(def_id),
+                            def: InstanceKind::Shim(ShimKind::ThreadLocalShim(def_id)),
                             args: GenericArgs::empty(),
                         }),
                     ));
@@ -1013,10 +1013,10 @@ fn visit_instance_use<'tcx>(
                 bug!("{:?} being reified", instance);
             }
         }
-        ty::InstanceKind::ThreadLocalShim(..) => {
+        ty::InstanceKind::Shim(ty::ShimKind::ThreadLocalShim(..)) => {
             bug!("{:?} being reified", instance);
         }
-        ty::InstanceKind::DropGlue(_, None) => {
+        ty::InstanceKind::Shim(ty::ShimKind::DropGlue(_, None)) => {
             // Don't need to emit noop drop glue if we are calling directly.
             //
             // Note that we also optimize away the call to visit_instance_use in vtable construction
@@ -1025,18 +1025,18 @@ fn visit_instance_use<'tcx>(
                 output.push(create_fn_mono_item(tcx, instance, source));
             }
         }
-        ty::InstanceKind::DropGlue(_, Some(_))
-        | ty::InstanceKind::FutureDropPollShim(..)
-        | ty::InstanceKind::AsyncDropGlue(_, _)
-        | ty::InstanceKind::AsyncDropGlueCtorShim(_, _)
-        | ty::InstanceKind::VTableShim(..)
-        | ty::InstanceKind::ReifyShim(..)
-        | ty::InstanceKind::ClosureOnceShim { .. }
-        | ty::InstanceKind::ConstructCoroutineInClosureShim { .. }
-        | ty::InstanceKind::Item(..)
-        | ty::InstanceKind::FnPtrShim(..)
-        | ty::InstanceKind::CloneShim(..)
-        | ty::InstanceKind::FnPtrAddrShim(..) => {
+        ty::InstanceKind::Item(..)
+        | ty::InstanceKind::Shim(ty::ShimKind::DropGlue(_, Some(_)))
+        | ty::InstanceKind::Shim(ty::ShimKind::FutureDropPollShim(..))
+        | ty::InstanceKind::Shim(ty::ShimKind::AsyncDropGlue(_, _))
+        | ty::InstanceKind::Shim(ty::ShimKind::AsyncDropGlueCtorShim(_, _))
+        | ty::InstanceKind::Shim(ty::ShimKind::VTableShim(..))
+        | ty::InstanceKind::Shim(ty::ShimKind::ReifyShim(..))
+        | ty::InstanceKind::Shim(ty::ShimKind::ClosureOnceShim { .. })
+        | ty::InstanceKind::Shim(ty::ShimKind::ConstructCoroutineInClosureShim { .. })
+        | ty::InstanceKind::Shim(ty::ShimKind::FnPtrShim(..))
+        | ty::InstanceKind::Shim(ty::ShimKind::CloneShim(..))
+        | ty::InstanceKind::Shim(ty::ShimKind::FnPtrAddrShim(..)) => {
             output.push(create_fn_mono_item(tcx, instance, source));
         }
     }

--- a/compiler/rustc_monomorphize/src/collector.rs
+++ b/compiler/rustc_monomorphize/src/collector.rs
@@ -447,7 +447,7 @@ fn collect_items_rec<'tcx>(
                     used_items.push(respan(
                         starting_item.span,
                         MonoItem::Fn(Instance {
-                            def: InstanceKind::Shim(ShimKind::ThreadLocalShim(def_id)),
+                            def: InstanceKind::Shim(ShimKind::ThreadLocal(def_id)),
                             args: GenericArgs::empty(),
                         }),
                     ));
@@ -1013,7 +1013,7 @@ fn visit_instance_use<'tcx>(
                 bug!("{:?} being reified", instance);
             }
         }
-        ty::InstanceKind::Shim(ty::ShimKind::ThreadLocalShim(..)) => {
+        ty::InstanceKind::Shim(ty::ShimKind::ThreadLocal(..)) => {
             bug!("{:?} being reified", instance);
         }
         ty::InstanceKind::Shim(ty::ShimKind::DropGlue(_, None)) => {
@@ -1027,16 +1027,16 @@ fn visit_instance_use<'tcx>(
         }
         ty::InstanceKind::Item(..)
         | ty::InstanceKind::Shim(ty::ShimKind::DropGlue(_, Some(_)))
-        | ty::InstanceKind::Shim(ty::ShimKind::FutureDropPollShim(..))
+        | ty::InstanceKind::Shim(ty::ShimKind::FutureDropPoll(..))
         | ty::InstanceKind::Shim(ty::ShimKind::AsyncDropGlue(_, _))
-        | ty::InstanceKind::Shim(ty::ShimKind::AsyncDropGlueCtorShim(_, _))
-        | ty::InstanceKind::Shim(ty::ShimKind::VTableShim(..))
-        | ty::InstanceKind::Shim(ty::ShimKind::ReifyShim(..))
-        | ty::InstanceKind::Shim(ty::ShimKind::ClosureOnceShim { .. })
-        | ty::InstanceKind::Shim(ty::ShimKind::ConstructCoroutineInClosureShim { .. })
-        | ty::InstanceKind::Shim(ty::ShimKind::FnPtrShim(..))
-        | ty::InstanceKind::Shim(ty::ShimKind::CloneShim(..))
-        | ty::InstanceKind::Shim(ty::ShimKind::FnPtrAddrShim(..)) => {
+        | ty::InstanceKind::Shim(ty::ShimKind::AsyncDropGlueCtor(_, _))
+        | ty::InstanceKind::Shim(ty::ShimKind::VTable(..))
+        | ty::InstanceKind::Shim(ty::ShimKind::Reify(..))
+        | ty::InstanceKind::Shim(ty::ShimKind::ClosureOnce { .. })
+        | ty::InstanceKind::Shim(ty::ShimKind::ConstructCoroutineInClosure { .. })
+        | ty::InstanceKind::Shim(ty::ShimKind::FnPtr(..))
+        | ty::InstanceKind::Shim(ty::ShimKind::Clone(..))
+        | ty::InstanceKind::Shim(ty::ShimKind::FnPtrAddr(..)) => {
             output.push(create_fn_mono_item(tcx, instance, source));
         }
     }

--- a/compiler/rustc_monomorphize/src/partitioning.rs
+++ b/compiler/rustc_monomorphize/src/partitioning.rs
@@ -115,7 +115,7 @@ use rustc_middle::mono::{
     MonoItemPartitions, Visibility,
 };
 use rustc_middle::ty::print::{characteristic_def_id_of_type, with_no_trimmed_paths};
-use rustc_middle::ty::{self, InstanceKind, TyCtxt};
+use rustc_middle::ty::{self, InstanceKind, ShimKind, TyCtxt};
 use rustc_middle::util::Providers;
 use rustc_session::CodegenUnits;
 use rustc_session::config::{DumpMonoStatsFormat, SwitchWithOptPath};
@@ -630,20 +630,22 @@ fn characteristic_def_id_of_mono_item<'tcx>(
         MonoItem::Fn(instance) => {
             let def_id = match instance.def {
                 ty::InstanceKind::Item(def) => def,
-                ty::InstanceKind::VTableShim(..)
-                | ty::InstanceKind::ReifyShim(..)
-                | ty::InstanceKind::FnPtrShim(..)
-                | ty::InstanceKind::ClosureOnceShim { .. }
-                | ty::InstanceKind::ConstructCoroutineInClosureShim { .. }
-                | ty::InstanceKind::Intrinsic(..)
-                | ty::InstanceKind::DropGlue(..)
+                ty::InstanceKind::Intrinsic(..)
                 | ty::InstanceKind::Virtual(..)
-                | ty::InstanceKind::CloneShim(..)
-                | ty::InstanceKind::ThreadLocalShim(..)
-                | ty::InstanceKind::FnPtrAddrShim(..)
-                | ty::InstanceKind::FutureDropPollShim(..)
-                | ty::InstanceKind::AsyncDropGlue(..)
-                | ty::InstanceKind::AsyncDropGlueCtorShim(..) => return None,
+                | ty::InstanceKind::Shim(ty::ShimKind::VTableShim(..))
+                | ty::InstanceKind::Shim(ty::ShimKind::ReifyShim(..))
+                | ty::InstanceKind::Shim(ty::ShimKind::FnPtrShim(..))
+                | ty::InstanceKind::Shim(ty::ShimKind::ClosureOnceShim { .. })
+                | ty::InstanceKind::Shim(ty::ShimKind::ConstructCoroutineInClosureShim {
+                    ..
+                })
+                | ty::InstanceKind::Shim(ty::ShimKind::DropGlue(..))
+                | ty::InstanceKind::Shim(ty::ShimKind::CloneShim(..))
+                | ty::InstanceKind::Shim(ty::ShimKind::ThreadLocalShim(..))
+                | ty::InstanceKind::Shim(ty::ShimKind::FnPtrAddrShim(..))
+                | ty::InstanceKind::Shim(ty::ShimKind::FutureDropPollShim(..))
+                | ty::InstanceKind::Shim(ty::ShimKind::AsyncDropGlue(..))
+                | ty::InstanceKind::Shim(ty::ShimKind::AsyncDropGlueCtorShim(..)) => return None,
             };
 
             // If this is a method, we want to put it into the same module as
@@ -794,27 +796,27 @@ fn mono_item_visibility<'tcx>(
 
     let def_id = match instance.def {
         InstanceKind::Item(def_id)
-        | InstanceKind::DropGlue(def_id, Some(_))
-        | InstanceKind::FutureDropPollShim(def_id, _, _)
-        | InstanceKind::AsyncDropGlue(def_id, _)
-        | InstanceKind::AsyncDropGlueCtorShim(def_id, _) => def_id,
+        | InstanceKind::Shim(ShimKind::DropGlue(def_id, Some(_)))
+        | InstanceKind::Shim(ShimKind::FutureDropPollShim(def_id, _, _))
+        | InstanceKind::Shim(ShimKind::AsyncDropGlue(def_id, _))
+        | InstanceKind::Shim(ShimKind::AsyncDropGlueCtorShim(def_id, _)) => def_id,
 
         // We match the visibility of statics here
-        InstanceKind::ThreadLocalShim(def_id) => {
+        InstanceKind::Shim(ShimKind::ThreadLocalShim(def_id)) => {
             return static_visibility(tcx, can_be_internalized, def_id);
         }
 
         // These are all compiler glue and such, never exported, always hidden.
-        InstanceKind::VTableShim(..)
-        | InstanceKind::ReifyShim(..)
-        | InstanceKind::FnPtrShim(..)
+        InstanceKind::Shim(ShimKind::VTableShim(..))
+        | InstanceKind::Shim(ShimKind::ReifyShim(..))
+        | InstanceKind::Shim(ShimKind::FnPtrShim(..))
         | InstanceKind::Virtual(..)
         | InstanceKind::Intrinsic(..)
-        | InstanceKind::ClosureOnceShim { .. }
-        | InstanceKind::ConstructCoroutineInClosureShim { .. }
-        | InstanceKind::DropGlue(..)
-        | InstanceKind::CloneShim(..)
-        | InstanceKind::FnPtrAddrShim(..) => return Visibility::Hidden,
+        | InstanceKind::Shim(ShimKind::ClosureOnceShim { .. })
+        | InstanceKind::Shim(ShimKind::ConstructCoroutineInClosureShim { .. })
+        | InstanceKind::Shim(ShimKind::DropGlue(..))
+        | InstanceKind::Shim(ShimKind::CloneShim(..))
+        | InstanceKind::Shim(ShimKind::FnPtrAddrShim(..)) => return Visibility::Hidden,
     };
 
     // Both the `start_fn` lang item and `main` itself should not be exported,
@@ -1331,8 +1333,8 @@ pub(crate) fn provide(providers: &mut Providers) {
             // "Normal" functions size estimate: the number of
             // statements, plus one for the terminator.
             InstanceKind::Item(..)
-            | InstanceKind::DropGlue(..)
-            | InstanceKind::AsyncDropGlueCtorShim(..) => {
+            | InstanceKind::Shim(ShimKind::DropGlue(..))
+            | InstanceKind::Shim(ShimKind::AsyncDropGlueCtorShim(..)) => {
                 let mir = tcx.instance_mir(instance.def);
                 mir.basic_blocks
                     .iter()

--- a/compiler/rustc_monomorphize/src/partitioning.rs
+++ b/compiler/rustc_monomorphize/src/partitioning.rs
@@ -632,20 +632,18 @@ fn characteristic_def_id_of_mono_item<'tcx>(
                 ty::InstanceKind::Item(def) => def,
                 ty::InstanceKind::Intrinsic(..)
                 | ty::InstanceKind::Virtual(..)
-                | ty::InstanceKind::Shim(ty::ShimKind::VTableShim(..))
-                | ty::InstanceKind::Shim(ty::ShimKind::ReifyShim(..))
-                | ty::InstanceKind::Shim(ty::ShimKind::FnPtrShim(..))
-                | ty::InstanceKind::Shim(ty::ShimKind::ClosureOnceShim { .. })
-                | ty::InstanceKind::Shim(ty::ShimKind::ConstructCoroutineInClosureShim {
-                    ..
-                })
+                | ty::InstanceKind::Shim(ty::ShimKind::VTable(..))
+                | ty::InstanceKind::Shim(ty::ShimKind::Reify(..))
+                | ty::InstanceKind::Shim(ty::ShimKind::FnPtr(..))
+                | ty::InstanceKind::Shim(ty::ShimKind::ClosureOnce { .. })
+                | ty::InstanceKind::Shim(ty::ShimKind::ConstructCoroutineInClosure { .. })
                 | ty::InstanceKind::Shim(ty::ShimKind::DropGlue(..))
-                | ty::InstanceKind::Shim(ty::ShimKind::CloneShim(..))
-                | ty::InstanceKind::Shim(ty::ShimKind::ThreadLocalShim(..))
-                | ty::InstanceKind::Shim(ty::ShimKind::FnPtrAddrShim(..))
-                | ty::InstanceKind::Shim(ty::ShimKind::FutureDropPollShim(..))
+                | ty::InstanceKind::Shim(ty::ShimKind::Clone(..))
+                | ty::InstanceKind::Shim(ty::ShimKind::ThreadLocal(..))
+                | ty::InstanceKind::Shim(ty::ShimKind::FnPtrAddr(..))
+                | ty::InstanceKind::Shim(ty::ShimKind::FutureDropPoll(..))
                 | ty::InstanceKind::Shim(ty::ShimKind::AsyncDropGlue(..))
-                | ty::InstanceKind::Shim(ty::ShimKind::AsyncDropGlueCtorShim(..)) => return None,
+                | ty::InstanceKind::Shim(ty::ShimKind::AsyncDropGlueCtor(..)) => return None,
             };
 
             // If this is a method, we want to put it into the same module as
@@ -797,26 +795,26 @@ fn mono_item_visibility<'tcx>(
     let def_id = match instance.def {
         InstanceKind::Item(def_id)
         | InstanceKind::Shim(ShimKind::DropGlue(def_id, Some(_)))
-        | InstanceKind::Shim(ShimKind::FutureDropPollShim(def_id, _, _))
+        | InstanceKind::Shim(ShimKind::FutureDropPoll(def_id, _, _))
         | InstanceKind::Shim(ShimKind::AsyncDropGlue(def_id, _))
-        | InstanceKind::Shim(ShimKind::AsyncDropGlueCtorShim(def_id, _)) => def_id,
+        | InstanceKind::Shim(ShimKind::AsyncDropGlueCtor(def_id, _)) => def_id,
 
         // We match the visibility of statics here
-        InstanceKind::Shim(ShimKind::ThreadLocalShim(def_id)) => {
+        InstanceKind::Shim(ShimKind::ThreadLocal(def_id)) => {
             return static_visibility(tcx, can_be_internalized, def_id);
         }
 
         // These are all compiler glue and such, never exported, always hidden.
-        InstanceKind::Shim(ShimKind::VTableShim(..))
-        | InstanceKind::Shim(ShimKind::ReifyShim(..))
-        | InstanceKind::Shim(ShimKind::FnPtrShim(..))
+        InstanceKind::Shim(ShimKind::VTable(..))
+        | InstanceKind::Shim(ShimKind::Reify(..))
+        | InstanceKind::Shim(ShimKind::FnPtr(..))
         | InstanceKind::Virtual(..)
         | InstanceKind::Intrinsic(..)
-        | InstanceKind::Shim(ShimKind::ClosureOnceShim { .. })
-        | InstanceKind::Shim(ShimKind::ConstructCoroutineInClosureShim { .. })
+        | InstanceKind::Shim(ShimKind::ClosureOnce { .. })
+        | InstanceKind::Shim(ShimKind::ConstructCoroutineInClosure { .. })
         | InstanceKind::Shim(ShimKind::DropGlue(..))
-        | InstanceKind::Shim(ShimKind::CloneShim(..))
-        | InstanceKind::Shim(ShimKind::FnPtrAddrShim(..)) => return Visibility::Hidden,
+        | InstanceKind::Shim(ShimKind::Clone(..))
+        | InstanceKind::Shim(ShimKind::FnPtrAddr(..)) => return Visibility::Hidden,
     };
 
     // Both the `start_fn` lang item and `main` itself should not be exported,
@@ -1334,7 +1332,7 @@ pub(crate) fn provide(providers: &mut Providers) {
             // statements, plus one for the terminator.
             InstanceKind::Item(..)
             | InstanceKind::Shim(ShimKind::DropGlue(..))
-            | InstanceKind::Shim(ShimKind::AsyncDropGlueCtorShim(..)) => {
+            | InstanceKind::Shim(ShimKind::AsyncDropGlueCtor(..)) => {
                 let mir = tcx.instance_mir(instance.def);
                 mir.basic_blocks
                     .iter()

--- a/compiler/rustc_public/src/unstable/convert/stable/ty.rs
+++ b/compiler/rustc_public/src/unstable/convert/stable/ty.rs
@@ -990,18 +990,7 @@ impl<'tcx> Stable<'tcx> for ty::Instance<'tcx> {
             ty::InstanceKind::Virtual(_def_id, idx) => {
                 crate::mir::mono::InstanceKind::Virtual { idx }
             }
-            ty::InstanceKind::VTableShim(..)
-            | ty::InstanceKind::ReifyShim(..)
-            | ty::InstanceKind::FnPtrAddrShim(..)
-            | ty::InstanceKind::ClosureOnceShim { .. }
-            | ty::InstanceKind::ConstructCoroutineInClosureShim { .. }
-            | ty::InstanceKind::ThreadLocalShim(..)
-            | ty::InstanceKind::DropGlue(..)
-            | ty::InstanceKind::CloneShim(..)
-            | ty::InstanceKind::FnPtrShim(..)
-            | ty::InstanceKind::FutureDropPollShim(..)
-            | ty::InstanceKind::AsyncDropGlue(..)
-            | ty::InstanceKind::AsyncDropGlueCtorShim(..) => crate::mir::mono::InstanceKind::Shim,
+            ty::InstanceKind::Shim(..) => crate::mir::mono::InstanceKind::Shim,
         };
         crate::mir::mono::Instance { def, kind }
     }

--- a/compiler/rustc_public_bridge/src/context/impls.rs
+++ b/compiler/rustc_public_bridge/src/context/impls.rs
@@ -645,7 +645,7 @@ impl<'tcx, B: Bridge> CompilerCtxt<'tcx, B> {
 
     /// Check if this is an empty DropGlue shim.
     pub fn is_empty_drop_shim(&self, instance: ty::Instance<'tcx>) -> bool {
-        matches!(instance.def, ty::InstanceKind::DropGlue(_, None))
+        matches!(instance.def, ty::InstanceKind::Shim(ty::ShimKind::DropGlue(_, None)))
     }
 
     /// Convert a non-generic crate item into an instance.

--- a/compiler/rustc_sanitizers/src/cfi/typeid/itanium_cxx_abi/transform.rs
+++ b/compiler/rustc_sanitizers/src/cfi/typeid/itanium_cxx_abi/transform.rs
@@ -310,7 +310,7 @@ pub(crate) fn transform_instance<'tcx>(
     // FIXME: account for async-drop-glue
     if (matches!(instance.def, ty::InstanceKind::Virtual(..))
         && tcx.is_lang_item(instance.def_id(), LangItem::DropGlue))
-        || matches!(instance.def, ty::InstanceKind::DropGlue(..))
+        || matches!(instance.def, ty::InstanceKind::Shim(ty::ShimKind::DropGlue(..)))
     {
         // Adjust the type ids of DropGlues
         //
@@ -364,7 +364,7 @@ pub(crate) fn transform_instance<'tcx>(
             tcx.types.unit
         };
         instance.args = tcx.mk_args_trait(self_ty, instance.args.into_iter().skip(1));
-    } else if let ty::InstanceKind::VTableShim(def_id) = instance.def
+    } else if let ty::InstanceKind::Shim(ty::ShimKind::VTableShim(def_id)) = instance.def
         && let Some(trait_id) = tcx.trait_of_assoc(def_id)
     {
         // Adjust the type ids of VTableShims to the type id expected in the call sites for the
@@ -461,7 +461,8 @@ pub(crate) fn transform_instance<'tcx>(
 
 fn default_or_shim<'tcx>(tcx: TyCtxt<'tcx>, instance: Instance<'tcx>) -> Option<DefId> {
     match instance.def {
-        ty::InstanceKind::Item(def_id) | ty::InstanceKind::FnPtrShim(def_id, _) => {
+        ty::InstanceKind::Item(def_id)
+        | ty::InstanceKind::Shim(ty::ShimKind::FnPtrShim(def_id, _)) => {
             tcx.opt_associated_item(def_id).map(|item| item.def_id)
         }
         _ => None,

--- a/compiler/rustc_sanitizers/src/cfi/typeid/itanium_cxx_abi/transform.rs
+++ b/compiler/rustc_sanitizers/src/cfi/typeid/itanium_cxx_abi/transform.rs
@@ -364,7 +364,7 @@ pub(crate) fn transform_instance<'tcx>(
             tcx.types.unit
         };
         instance.args = tcx.mk_args_trait(self_ty, instance.args.into_iter().skip(1));
-    } else if let ty::InstanceKind::Shim(ty::ShimKind::VTableShim(def_id)) = instance.def
+    } else if let ty::InstanceKind::Shim(ty::ShimKind::VTable(def_id)) = instance.def
         && let Some(trait_id) = tcx.trait_of_assoc(def_id)
     {
         // Adjust the type ids of VTableShims to the type id expected in the call sites for the
@@ -461,8 +461,7 @@ pub(crate) fn transform_instance<'tcx>(
 
 fn default_or_shim<'tcx>(tcx: TyCtxt<'tcx>, instance: Instance<'tcx>) -> Option<DefId> {
     match instance.def {
-        ty::InstanceKind::Item(def_id)
-        | ty::InstanceKind::Shim(ty::ShimKind::FnPtrShim(def_id, _)) => {
+        ty::InstanceKind::Item(def_id) | ty::InstanceKind::Shim(ty::ShimKind::FnPtr(def_id, _)) => {
             tcx.opt_associated_item(def_id).map(|item| item.def_id)
         }
         _ => None,

--- a/compiler/rustc_sanitizers/src/kcfi/typeid/mod.rs
+++ b/compiler/rustc_sanitizers/src/kcfi/typeid/mod.rs
@@ -6,7 +6,7 @@
 
 use std::hash::Hasher;
 
-use rustc_middle::ty::{Instance, InstanceKind, ReifyReason, Ty, TyCtxt};
+use rustc_middle::ty::{Instance, InstanceKind, ReifyReason, ShimKind, Ty, TyCtxt};
 use rustc_target::callconv::FnAbi;
 use twox_hash::XxHash64;
 
@@ -46,7 +46,8 @@ pub fn typeid_for_instance<'tcx>(
     //
     // This was implemented for KCFI support in #123106 and #123052 (which introduced the
     // ReifyReason). The tracking issue for KCFI support for Rust is #123479.
-    if matches!(instance.def, InstanceKind::ReifyShim(_, Some(ReifyReason::FnPtr))) {
+    if matches!(instance.def, InstanceKind::Shim(ShimKind::ReifyShim(_, Some(ReifyReason::FnPtr))))
+    {
         options.insert(TypeIdOptions::USE_CONCRETE_SELF);
     }
     // A KCFI type metadata identifier is a 32-bit constant produced by taking the lower half of the

--- a/compiler/rustc_sanitizers/src/kcfi/typeid/mod.rs
+++ b/compiler/rustc_sanitizers/src/kcfi/typeid/mod.rs
@@ -46,8 +46,7 @@ pub fn typeid_for_instance<'tcx>(
     //
     // This was implemented for KCFI support in #123106 and #123052 (which introduced the
     // ReifyReason). The tracking issue for KCFI support for Rust is #123479.
-    if matches!(instance.def, InstanceKind::Shim(ShimKind::ReifyShim(_, Some(ReifyReason::FnPtr))))
-    {
+    if matches!(instance.def, InstanceKind::Shim(ShimKind::Reify(_, Some(ReifyReason::FnPtr)))) {
         options.insert(TypeIdOptions::USE_CONCRETE_SELF);
     }
     // A KCFI type metadata identifier is a 32-bit constant produced by taking the lower half of the

--- a/compiler/rustc_symbol_mangling/src/legacy.rs
+++ b/compiler/rustc_symbol_mangling/src/legacy.rs
@@ -63,8 +63,8 @@ pub(super) fn mangle<'tcx>(
     p.print_def_path(
         def_id,
         if let ty::InstanceKind::Shim(ty::ShimKind::DropGlue(_, _))
-        | ty::InstanceKind::Shim(ty::ShimKind::AsyncDropGlueCtorShim(_, _))
-        | ty::InstanceKind::Shim(ty::ShimKind::FutureDropPollShim(_, _, _)) = instance.def
+        | ty::InstanceKind::Shim(ty::ShimKind::AsyncDropGlueCtor(_, _))
+        | ty::InstanceKind::Shim(ty::ShimKind::FutureDropPoll(_, _, _)) = instance.def
         {
             // Add the name of the dropped type to the symbol name
             &*instance.args
@@ -81,13 +81,13 @@ pub(super) fn mangle<'tcx>(
     .unwrap();
 
     match instance.def {
-        ty::InstanceKind::Shim(ty::ShimKind::ThreadLocalShim(..)) => {
+        ty::InstanceKind::Shim(ty::ShimKind::ThreadLocal(..)) => {
             p.write_str("{{tls-shim}}").unwrap();
         }
-        ty::InstanceKind::Shim(ty::ShimKind::VTableShim(..)) => {
+        ty::InstanceKind::Shim(ty::ShimKind::VTable(..)) => {
             p.write_str("{{vtable-shim}}").unwrap();
         }
-        ty::InstanceKind::Shim(ty::ShimKind::ReifyShim(_, reason)) => {
+        ty::InstanceKind::Shim(ty::ShimKind::Reify(_, reason)) => {
             p.write_str("{{reify-shim").unwrap();
             match reason {
                 Some(ReifyReason::FnPtr) => p.write_str("-fnptr").unwrap(),
@@ -98,7 +98,7 @@ pub(super) fn mangle<'tcx>(
         }
         // FIXME(async_closures): This shouldn't be needed when we fix
         // `Instance::ty`/`Instance::def_id`.
-        ty::InstanceKind::Shim(ty::ShimKind::ConstructCoroutineInClosureShim {
+        ty::InstanceKind::Shim(ty::ShimKind::ConstructCoroutineInClosure {
             receiver_by_ref,
             ..
         }) => {
@@ -108,7 +108,7 @@ pub(super) fn mangle<'tcx>(
         _ => {}
     }
 
-    if let ty::InstanceKind::Shim(ty::ShimKind::FutureDropPollShim(..)) = instance.def {
+    if let ty::InstanceKind::Shim(ty::ShimKind::FutureDropPoll(..)) = instance.def {
         let _ = p.write_str("{{drop-shim}}");
     }
 

--- a/compiler/rustc_symbol_mangling/src/legacy.rs
+++ b/compiler/rustc_symbol_mangling/src/legacy.rs
@@ -62,13 +62,13 @@ pub(super) fn mangle<'tcx>(
     let mut p = LegacySymbolMangler { tcx, path: SymbolPath::new(), keep_within_component: false };
     p.print_def_path(
         def_id,
-        if let ty::InstanceKind::DropGlue(_, _)
-        | ty::InstanceKind::AsyncDropGlueCtorShim(_, _)
-        | ty::InstanceKind::FutureDropPollShim(_, _, _) = instance.def
+        if let ty::InstanceKind::Shim(ty::ShimKind::DropGlue(_, _))
+        | ty::InstanceKind::Shim(ty::ShimKind::AsyncDropGlueCtorShim(_, _))
+        | ty::InstanceKind::Shim(ty::ShimKind::FutureDropPollShim(_, _, _)) = instance.def
         {
             // Add the name of the dropped type to the symbol name
             &*instance.args
-        } else if let ty::InstanceKind::AsyncDropGlue(_, ty) = instance.def {
+        } else if let ty::InstanceKind::Shim(ty::ShimKind::AsyncDropGlue(_, ty)) = instance.def {
             let ty::Coroutine(_, cor_args) = ty.kind() else {
                 bug!();
             };
@@ -81,13 +81,13 @@ pub(super) fn mangle<'tcx>(
     .unwrap();
 
     match instance.def {
-        ty::InstanceKind::ThreadLocalShim(..) => {
+        ty::InstanceKind::Shim(ty::ShimKind::ThreadLocalShim(..)) => {
             p.write_str("{{tls-shim}}").unwrap();
         }
-        ty::InstanceKind::VTableShim(..) => {
+        ty::InstanceKind::Shim(ty::ShimKind::VTableShim(..)) => {
             p.write_str("{{vtable-shim}}").unwrap();
         }
-        ty::InstanceKind::ReifyShim(_, reason) => {
+        ty::InstanceKind::Shim(ty::ShimKind::ReifyShim(_, reason)) => {
             p.write_str("{{reify-shim").unwrap();
             match reason {
                 Some(ReifyReason::FnPtr) => p.write_str("-fnptr").unwrap(),
@@ -98,14 +98,17 @@ pub(super) fn mangle<'tcx>(
         }
         // FIXME(async_closures): This shouldn't be needed when we fix
         // `Instance::ty`/`Instance::def_id`.
-        ty::InstanceKind::ConstructCoroutineInClosureShim { receiver_by_ref, .. } => {
+        ty::InstanceKind::Shim(ty::ShimKind::ConstructCoroutineInClosureShim {
+            receiver_by_ref,
+            ..
+        }) => {
             p.write_str(if receiver_by_ref { "{{by-move-shim}}" } else { "{{by-ref-shim}}" })
                 .unwrap();
         }
         _ => {}
     }
 
-    if let ty::InstanceKind::FutureDropPollShim(..) = instance.def {
+    if let ty::InstanceKind::Shim(ty::ShimKind::FutureDropPollShim(..)) = instance.def {
         let _ = p.write_str("{{drop-shim}}");
     }
 

--- a/compiler/rustc_symbol_mangling/src/v0.rs
+++ b/compiler/rustc_symbol_mangling/src/v0.rs
@@ -49,27 +49,27 @@ pub(super) fn mangle<'tcx>(
 
     // Append `::{shim:...#0}` to shims that can coexist with a non-shim instance.
     let shim_kind = match instance.def {
-        ty::InstanceKind::Shim(ty::ShimKind::ThreadLocalShim(_)) => Some("tls"),
-        ty::InstanceKind::Shim(ty::ShimKind::VTableShim(_)) => Some("vtable"),
-        ty::InstanceKind::Shim(ty::ShimKind::ReifyShim(_, None)) => Some("reify"),
-        ty::InstanceKind::Shim(ty::ShimKind::ReifyShim(_, Some(ReifyReason::FnPtr))) => {
+        ty::InstanceKind::Shim(ty::ShimKind::ThreadLocal(_)) => Some("tls"),
+        ty::InstanceKind::Shim(ty::ShimKind::VTable(_)) => Some("vtable"),
+        ty::InstanceKind::Shim(ty::ShimKind::Reify(_, None)) => Some("reify"),
+        ty::InstanceKind::Shim(ty::ShimKind::Reify(_, Some(ReifyReason::FnPtr))) => {
             Some("reify_fnptr")
         }
-        ty::InstanceKind::Shim(ty::ShimKind::ReifyShim(_, Some(ReifyReason::Vtable))) => {
+        ty::InstanceKind::Shim(ty::ShimKind::Reify(_, Some(ReifyReason::Vtable))) => {
             Some("reify_vtable")
         }
 
         // FIXME(async_closures): This shouldn't be needed when we fix
         // `Instance::ty`/`Instance::def_id`.
-        ty::InstanceKind::Shim(ty::ShimKind::ConstructCoroutineInClosureShim {
+        ty::InstanceKind::Shim(ty::ShimKind::ConstructCoroutineInClosure {
             receiver_by_ref: true,
             ..
         }) => Some("by_move"),
-        ty::InstanceKind::Shim(ty::ShimKind::ConstructCoroutineInClosureShim {
+        ty::InstanceKind::Shim(ty::ShimKind::ConstructCoroutineInClosure {
             receiver_by_ref: false,
             ..
         }) => Some("by_ref"),
-        ty::InstanceKind::Shim(ty::ShimKind::FutureDropPollShim(_, _, _)) => Some("drop"),
+        ty::InstanceKind::Shim(ty::ShimKind::FutureDropPoll(_, _, _)) => Some("drop"),
         _ => None,
     };
 

--- a/compiler/rustc_symbol_mangling/src/v0.rs
+++ b/compiler/rustc_symbol_mangling/src/v0.rs
@@ -49,25 +49,31 @@ pub(super) fn mangle<'tcx>(
 
     // Append `::{shim:...#0}` to shims that can coexist with a non-shim instance.
     let shim_kind = match instance.def {
-        ty::InstanceKind::ThreadLocalShim(_) => Some("tls"),
-        ty::InstanceKind::VTableShim(_) => Some("vtable"),
-        ty::InstanceKind::ReifyShim(_, None) => Some("reify"),
-        ty::InstanceKind::ReifyShim(_, Some(ReifyReason::FnPtr)) => Some("reify_fnptr"),
-        ty::InstanceKind::ReifyShim(_, Some(ReifyReason::Vtable)) => Some("reify_vtable"),
+        ty::InstanceKind::Shim(ty::ShimKind::ThreadLocalShim(_)) => Some("tls"),
+        ty::InstanceKind::Shim(ty::ShimKind::VTableShim(_)) => Some("vtable"),
+        ty::InstanceKind::Shim(ty::ShimKind::ReifyShim(_, None)) => Some("reify"),
+        ty::InstanceKind::Shim(ty::ShimKind::ReifyShim(_, Some(ReifyReason::FnPtr))) => {
+            Some("reify_fnptr")
+        }
+        ty::InstanceKind::Shim(ty::ShimKind::ReifyShim(_, Some(ReifyReason::Vtable))) => {
+            Some("reify_vtable")
+        }
 
         // FIXME(async_closures): This shouldn't be needed when we fix
         // `Instance::ty`/`Instance::def_id`.
-        ty::InstanceKind::ConstructCoroutineInClosureShim { receiver_by_ref: true, .. } => {
-            Some("by_move")
-        }
-        ty::InstanceKind::ConstructCoroutineInClosureShim { receiver_by_ref: false, .. } => {
-            Some("by_ref")
-        }
-        ty::InstanceKind::FutureDropPollShim(_, _, _) => Some("drop"),
+        ty::InstanceKind::Shim(ty::ShimKind::ConstructCoroutineInClosureShim {
+            receiver_by_ref: true,
+            ..
+        }) => Some("by_move"),
+        ty::InstanceKind::Shim(ty::ShimKind::ConstructCoroutineInClosureShim {
+            receiver_by_ref: false,
+            ..
+        }) => Some("by_ref"),
+        ty::InstanceKind::Shim(ty::ShimKind::FutureDropPollShim(_, _, _)) => Some("drop"),
         _ => None,
     };
 
-    if let ty::InstanceKind::AsyncDropGlue(_, ty) = instance.def {
+    if let ty::InstanceKind::Shim(ty::ShimKind::AsyncDropGlue(_, ty)) = instance.def {
         let ty::Coroutine(_, cor_args) = ty.kind() else {
             bug!();
         };

--- a/compiler/rustc_ty_utils/src/abi.rs
+++ b/compiler/rustc_ty_utils/src/abi.rs
@@ -38,7 +38,7 @@ fn fn_sig_for_fn_abi<'tcx>(
     instance: ty::Instance<'tcx>,
     typing_env: ty::TypingEnv<'tcx>,
 ) -> ty::FnSig<'tcx> {
-    if let InstanceKind::Shim(ShimKind::ThreadLocalShim(..)) = instance.def {
+    if let InstanceKind::Shim(ShimKind::ThreadLocal(..)) = instance.def {
         return tcx.mk_fn_sig_safe_rust_abi([], tcx.thread_local_ptr_ty(instance.def_id()));
     }
 
@@ -50,7 +50,7 @@ fn fn_sig_for_fn_abi<'tcx>(
             );
 
             // Modify `fn(self, ...)` to `fn(self: *mut Self, ...)`.
-            if let ty::InstanceKind::Shim(ty::ShimKind::VTableShim(..)) = instance.def {
+            if let ty::InstanceKind::Shim(ty::ShimKind::VTable(..)) = instance.def {
                 let mut inputs_and_output = sig.inputs_and_output.to_vec();
                 inputs_and_output[0] = Ty::new_mut_ptr(tcx, inputs_and_output[0]);
                 sig.inputs_and_output = tcx.mk_type_list(&inputs_and_output);
@@ -82,7 +82,7 @@ fn fn_sig_for_fn_abi<'tcx>(
             // a separate def-id for these bodies.
             let mut coroutine_kind = args.as_coroutine_closure().kind();
 
-            let env_ty = if let InstanceKind::Shim(ShimKind::ConstructCoroutineInClosureShim {
+            let env_ty = if let InstanceKind::Shim(ShimKind::ConstructCoroutineInClosure {
                 receiver_by_ref,
                 ..
             }) = instance.def
@@ -266,7 +266,7 @@ impl<'tcx> FnAbiDesc<'tcx> {
         let ty::PseudoCanonicalInput { typing_env, value: (instance, extra_args) } = query;
         let is_virtual_call = matches!(instance.def, ty::InstanceKind::Virtual(..));
         let is_tls_shim_call =
-            matches!(instance.def, ty::InstanceKind::Shim(ty::ShimKind::ThreadLocalShim(_)));
+            matches!(instance.def, ty::InstanceKind::Shim(ty::ShimKind::ThreadLocal(_)));
         Self {
             layout_cx: LayoutCx::new(tcx, typing_env),
             sig: tcx.normalize_erasing_regions(

--- a/compiler/rustc_ty_utils/src/abi.rs
+++ b/compiler/rustc_ty_utils/src/abi.rs
@@ -10,7 +10,7 @@ use rustc_middle::query::Providers;
 use rustc_middle::ty::layout::{
     FnAbiError, HasTyCtxt, HasTypingEnv, LayoutCx, LayoutOf, TyAndLayout, fn_can_unwind,
 };
-use rustc_middle::ty::{self, InstanceKind, Ty, TyCtxt, Unnormalized};
+use rustc_middle::ty::{self, InstanceKind, ShimKind, Ty, TyCtxt, Unnormalized};
 use rustc_span::DUMMY_SP;
 use rustc_span::def_id::DefId;
 use rustc_target::callconv::{
@@ -38,7 +38,7 @@ fn fn_sig_for_fn_abi<'tcx>(
     instance: ty::Instance<'tcx>,
     typing_env: ty::TypingEnv<'tcx>,
 ) -> ty::FnSig<'tcx> {
-    if let InstanceKind::ThreadLocalShim(..) = instance.def {
+    if let InstanceKind::Shim(ShimKind::ThreadLocalShim(..)) = instance.def {
         return tcx.mk_fn_sig_safe_rust_abi([], tcx.thread_local_ptr_ty(instance.def_id()));
     }
 
@@ -50,7 +50,7 @@ fn fn_sig_for_fn_abi<'tcx>(
             );
 
             // Modify `fn(self, ...)` to `fn(self: *mut Self, ...)`.
-            if let ty::InstanceKind::VTableShim(..) = instance.def {
+            if let ty::InstanceKind::Shim(ty::ShimKind::VTableShim(..)) = instance.def {
                 let mut inputs_and_output = sig.inputs_and_output.to_vec();
                 inputs_and_output[0] = Ty::new_mut_ptr(tcx, inputs_and_output[0]);
                 sig.inputs_and_output = tcx.mk_type_list(&inputs_and_output);
@@ -82,22 +82,23 @@ fn fn_sig_for_fn_abi<'tcx>(
             // a separate def-id for these bodies.
             let mut coroutine_kind = args.as_coroutine_closure().kind();
 
-            let env_ty =
-                if let InstanceKind::ConstructCoroutineInClosureShim { receiver_by_ref, .. } =
-                    instance.def
-                {
-                    coroutine_kind = ty::ClosureKind::FnOnce;
+            let env_ty = if let InstanceKind::Shim(ShimKind::ConstructCoroutineInClosureShim {
+                receiver_by_ref,
+                ..
+            }) = instance.def
+            {
+                coroutine_kind = ty::ClosureKind::FnOnce;
 
-                    // Implementations of `FnMut` and `Fn` for coroutine-closures
-                    // still take their receiver by ref.
-                    if receiver_by_ref {
-                        Ty::new_imm_ref(tcx, tcx.lifetimes.re_erased, coroutine_ty)
-                    } else {
-                        coroutine_ty
-                    }
+                // Implementations of `FnMut` and `Fn` for coroutine-closures
+                // still take their receiver by ref.
+                if receiver_by_ref {
+                    Ty::new_imm_ref(tcx, tcx.lifetimes.re_erased, coroutine_ty)
                 } else {
-                    tcx.closure_env_ty(coroutine_ty, coroutine_kind, tcx.lifetimes.re_erased)
-                };
+                    coroutine_ty
+                }
+            } else {
+                tcx.closure_env_ty(coroutine_ty, coroutine_kind, tcx.lifetimes.re_erased)
+            };
 
             let sig = tcx.instantiate_bound_regions_with_erased(sig);
 
@@ -264,7 +265,8 @@ impl<'tcx> FnAbiDesc<'tcx> {
     ) -> Self {
         let ty::PseudoCanonicalInput { typing_env, value: (instance, extra_args) } = query;
         let is_virtual_call = matches!(instance.def, ty::InstanceKind::Virtual(..));
-        let is_tls_shim_call = matches!(instance.def, ty::InstanceKind::ThreadLocalShim(_));
+        let is_tls_shim_call =
+            matches!(instance.def, ty::InstanceKind::Shim(ty::ShimKind::ThreadLocalShim(_)));
         Self {
             layout_cx: LayoutCx::new(tcx, typing_env),
             sig: tcx.normalize_erasing_regions(

--- a/compiler/rustc_ty_utils/src/instance.rs
+++ b/compiler/rustc_ty_utils/src/instance.rs
@@ -83,10 +83,10 @@ fn resolve_instance_raw<'tcx>(
                     _ => return Ok(None),
                 }
                 debug!(" => nontrivial async drop glue ctor");
-                ty::InstanceKind::Shim(ty::ShimKind::AsyncDropGlueCtorShim(def_id, ty))
+                ty::InstanceKind::Shim(ty::ShimKind::AsyncDropGlueCtor(def_id, ty))
             } else {
                 debug!(" => trivial async drop glue ctor");
-                ty::InstanceKind::Shim(ty::ShimKind::AsyncDropGlueCtorShim(def_id, ty))
+                ty::InstanceKind::Shim(ty::ShimKind::AsyncDropGlueCtor(def_id, ty))
             }
         } else if tcx.is_async_drop_in_place_coroutine(def_id) {
             let ty = args.type_at(0);
@@ -280,10 +280,7 @@ fn resolve_associated_item<'tcx>(
                     };
 
                     Some(Instance {
-                        def: ty::InstanceKind::Shim(ty::ShimKind::CloneShim(
-                            trait_item_id,
-                            self_ty,
-                        )),
+                        def: ty::InstanceKind::Shim(ty::ShimKind::Clone(trait_item_id, self_ty)),
                         args: rcvr_args,
                     })
                 } else {
@@ -300,7 +297,7 @@ fn resolve_associated_item<'tcx>(
                         return Ok(None);
                     }
                     Some(Instance {
-                        def: ty::InstanceKind::Shim(ty::ShimKind::FnPtrAddrShim(
+                        def: ty::InstanceKind::Shim(ty::ShimKind::FnPtrAddr(
                             trait_item_id,
                             self_ty,
                         )),
@@ -333,7 +330,7 @@ fn resolve_associated_item<'tcx>(
                         Some(Instance::resolve_closure(tcx, closure_def_id, args, target_kind))
                     }
                     ty::FnDef(..) | ty::FnPtr(..) => Some(Instance {
-                        def: ty::InstanceKind::Shim(ty::ShimKind::FnPtrShim(
+                        def: ty::InstanceKind::Shim(ty::ShimKind::FnPtr(
                             trait_item_id,
                             rcvr_args.type_at(0),
                         )),
@@ -350,7 +347,7 @@ fn resolve_associated_item<'tcx>(
                         } else {
                             Some(Instance {
                                 def: ty::InstanceKind::Shim(
-                                    ty::ShimKind::ConstructCoroutineInClosureShim {
+                                    ty::ShimKind::ConstructCoroutineInClosure {
                                         coroutine_closure_def_id,
                                         receiver_by_ref: target_kind != ty::ClosureKind::FnOnce,
                                     },
@@ -375,7 +372,7 @@ fn resolve_associated_item<'tcx>(
                             // construct a new body that has the right return types.
                             Some(Instance {
                                 def: ty::InstanceKind::Shim(
-                                    ty::ShimKind::ConstructCoroutineInClosureShim {
+                                    ty::ShimKind::ConstructCoroutineInClosure {
                                         coroutine_closure_def_id,
                                         receiver_by_ref: false,
                                     },
@@ -390,7 +387,7 @@ fn resolve_associated_item<'tcx>(
                         Some(Instance::resolve_closure(tcx, closure_def_id, args, target_kind))
                     }
                     ty::FnDef(..) | ty::FnPtr(..) => Some(Instance {
-                        def: ty::InstanceKind::Shim(ty::ShimKind::FnPtrShim(
+                        def: ty::InstanceKind::Shim(ty::ShimKind::FnPtr(
                             trait_item_id,
                             rcvr_args.type_at(0),
                         )),

--- a/compiler/rustc_ty_utils/src/instance.rs
+++ b/compiler/rustc_ty_utils/src/instance.rs
@@ -38,16 +38,16 @@ fn resolve_instance_raw<'tcx>(
         } else if tcx.is_lang_item(def_id, LangItem::DropGlue) {
             let ty = args.type_at(0);
 
-            if ty.needs_drop(tcx, typing_env) {
+            let shim = if ty.needs_drop(tcx, typing_env) {
                 debug!(" => nontrivial drop glue");
                 match *ty.kind() {
                     ty::Coroutine(coroutine_def_id, ..) => {
                         // FIXME: sync drop of coroutine with async drop (generate both versions?)
                         // Currently just ignored
                         if tcx.optimized_mir(coroutine_def_id).coroutine_drop_async().is_some() {
-                            ty::InstanceKind::DropGlue(def_id, None)
+                            ty::ShimKind::DropGlue(def_id, None)
                         } else {
-                            ty::InstanceKind::DropGlue(def_id, Some(ty))
+                            ty::ShimKind::DropGlue(def_id, Some(ty))
                         }
                     }
                     ty::Closure(..)
@@ -57,14 +57,15 @@ fn resolve_instance_raw<'tcx>(
                     | ty::Dynamic(..)
                     | ty::Array(..)
                     | ty::Slice(..)
-                    | ty::UnsafeBinder(..) => ty::InstanceKind::DropGlue(def_id, Some(ty)),
+                    | ty::UnsafeBinder(..) => ty::ShimKind::DropGlue(def_id, Some(ty)),
                     // Drop shims can only be built from ADTs.
                     _ => return Ok(None),
                 }
             } else {
                 debug!(" => trivial drop glue");
-                ty::InstanceKind::DropGlue(def_id, None)
-            }
+                ty::ShimKind::DropGlue(def_id, None)
+            };
+            ty::InstanceKind::Shim(shim)
         } else if tcx.is_lang_item(def_id, LangItem::AsyncDropInPlace) {
             let ty = args.type_at(0);
 
@@ -82,14 +83,14 @@ fn resolve_instance_raw<'tcx>(
                     _ => return Ok(None),
                 }
                 debug!(" => nontrivial async drop glue ctor");
-                ty::InstanceKind::AsyncDropGlueCtorShim(def_id, ty)
+                ty::InstanceKind::Shim(ty::ShimKind::AsyncDropGlueCtorShim(def_id, ty))
             } else {
                 debug!(" => trivial async drop glue ctor");
-                ty::InstanceKind::AsyncDropGlueCtorShim(def_id, ty)
+                ty::InstanceKind::Shim(ty::ShimKind::AsyncDropGlueCtorShim(def_id, ty))
             }
         } else if tcx.is_async_drop_in_place_coroutine(def_id) {
             let ty = args.type_at(0);
-            ty::InstanceKind::AsyncDropGlue(def_id, ty)
+            ty::InstanceKind::Shim(ty::ShimKind::AsyncDropGlue(def_id, ty))
         } else {
             debug!(" => free item");
             ty::InstanceKind::Item(def_id)
@@ -279,7 +280,10 @@ fn resolve_associated_item<'tcx>(
                     };
 
                     Some(Instance {
-                        def: ty::InstanceKind::CloneShim(trait_item_id, self_ty),
+                        def: ty::InstanceKind::Shim(ty::ShimKind::CloneShim(
+                            trait_item_id,
+                            self_ty,
+                        )),
                         args: rcvr_args,
                     })
                 } else {
@@ -296,7 +300,10 @@ fn resolve_associated_item<'tcx>(
                         return Ok(None);
                     }
                     Some(Instance {
-                        def: ty::InstanceKind::FnPtrAddrShim(trait_item_id, self_ty),
+                        def: ty::InstanceKind::Shim(ty::ShimKind::FnPtrAddrShim(
+                            trait_item_id,
+                            self_ty,
+                        )),
                         args: rcvr_args,
                     })
                 } else {
@@ -326,7 +333,10 @@ fn resolve_associated_item<'tcx>(
                         Some(Instance::resolve_closure(tcx, closure_def_id, args, target_kind))
                     }
                     ty::FnDef(..) | ty::FnPtr(..) => Some(Instance {
-                        def: ty::InstanceKind::FnPtrShim(trait_item_id, rcvr_args.type_at(0)),
+                        def: ty::InstanceKind::Shim(ty::ShimKind::FnPtrShim(
+                            trait_item_id,
+                            rcvr_args.type_at(0),
+                        )),
                         args: rcvr_args,
                     }),
                     ty::CoroutineClosure(coroutine_closure_def_id, args) => {
@@ -339,10 +349,12 @@ fn resolve_associated_item<'tcx>(
                             Some(Instance::new_raw(coroutine_closure_def_id, args))
                         } else {
                             Some(Instance {
-                                def: ty::InstanceKind::ConstructCoroutineInClosureShim {
-                                    coroutine_closure_def_id,
-                                    receiver_by_ref: target_kind != ty::ClosureKind::FnOnce,
-                                },
+                                def: ty::InstanceKind::Shim(
+                                    ty::ShimKind::ConstructCoroutineInClosureShim {
+                                        coroutine_closure_def_id,
+                                        receiver_by_ref: target_kind != ty::ClosureKind::FnOnce,
+                                    },
+                                ),
                                 args,
                             })
                         }
@@ -362,10 +374,12 @@ fn resolve_associated_item<'tcx>(
                             // If we're computing `AsyncFnOnce` for a by-ref closure then
                             // construct a new body that has the right return types.
                             Some(Instance {
-                                def: ty::InstanceKind::ConstructCoroutineInClosureShim {
-                                    coroutine_closure_def_id,
-                                    receiver_by_ref: false,
-                                },
+                                def: ty::InstanceKind::Shim(
+                                    ty::ShimKind::ConstructCoroutineInClosureShim {
+                                        coroutine_closure_def_id,
+                                        receiver_by_ref: false,
+                                    },
+                                ),
                                 args,
                             })
                         } else {
@@ -376,7 +390,10 @@ fn resolve_associated_item<'tcx>(
                         Some(Instance::resolve_closure(tcx, closure_def_id, args, target_kind))
                     }
                     ty::FnDef(..) | ty::FnPtr(..) => Some(Instance {
-                        def: ty::InstanceKind::FnPtrShim(trait_item_id, rcvr_args.type_at(0)),
+                        def: ty::InstanceKind::Shim(ty::ShimKind::FnPtrShim(
+                            trait_item_id,
+                            rcvr_args.type_at(0),
+                        )),
                         args: rcvr_args,
                     }),
                     _ => bug!(


### PR DESCRIPTION
They tend to have similar handling -- e.g., they should be the only
input to the `mir_shims` query -- so it's cleaner to group them
together. This will also make potential future refactorings easier, such
as only carrying `GenericArgsRef` for instances that actually use it
(e.g., `Item`) but not others (e.g., `CloneShim`).

cc https://rust-lang.zulipchat.com/#narrow/channel/131828-t-compiler/topic/moving.20ty.3A.3AInstance.2Eargs.20into.20ty.3A.3AInstanceKind.20variants
r? @oli-obk 