### PR TITLE
fix macro attribute feature-gate span

### DIFF
--- a/compiler/rustc_expand/src/mbe/macro_rules.rs
+++ b/compiler/rustc_expand/src/mbe/macro_rules.rs
@@ -469,13 +469,7 @@ fn expand_macro_attr(
     let is_local = node_id != DUMMY_NODE_ID;
 
     if !is_local && !cx.ecfg.features.macro_attr() {
-        return Err(feature_err(
-            cx.sess,
-            sym::macro_attr,
-            sp,
-            "`macro_rules!` attributes are unstable",
-        )
-        .emit());
+        feature_err(cx.sess, sym::macro_attr, sp, "`macro_rules!` attributes are unstable").emit();
     }
 
     if cx.trace_macros() {

--- a/compiler/rustc_expand/src/mbe/macro_rules.rs
+++ b/compiler/rustc_expand/src/mbe/macro_rules.rs
@@ -468,6 +468,16 @@ fn expand_macro_attr(
     // whereas macros from an external crate have a dummy id.
     let is_local = node_id != DUMMY_NODE_ID;
 
+    if !is_local && !cx.ecfg.features.macro_attr() {
+        return Err(feature_err(
+            cx.sess,
+            sym::macro_attr,
+            sp,
+            "`macro_rules!` attributes are unstable",
+        )
+        .emit());
+    }
+
     if cx.trace_macros() {
         let msg = format!(
             "expanding `#[{name}({})] {}`",
@@ -752,7 +762,7 @@ pub fn compile_declarative_macro(
         }
         let (args, is_derive) = if p.eat_keyword_noexpect(sym::attr) {
             kinds |= MacroKinds::ATTR;
-            if !features.macro_attr() {
+            if is_defined_in_current_crate(node_id) && !features.macro_attr() {
                 feature_err(sess, sym::macro_attr, span, "`macro_rules!` attributes are unstable")
                     .emit();
             }

--- a/tests/ui/macros/auxiliary/macro_attr_feature_gate.rs
+++ b/tests/ui/macros/auxiliary/macro_attr_feature_gate.rs
@@ -1,0 +1,8 @@
+#![feature(macro_attr)]
+
+#[macro_export]
+macro_rules! identity {
+    attr() { $item:item } => {
+        $item
+    };
+}

--- a/tests/ui/macros/macro-attr-feature-gate-cross-crate.rs
+++ b/tests/ui/macros/macro-attr-feature-gate-cross-crate.rs
@@ -1,0 +1,8 @@
+//@ aux-build:macro_attr_feature_gate.rs
+#![crate_type = "lib"]
+
+extern crate macro_attr_feature_gate as foo;
+
+#[foo::identity]
+//~^ ERROR `macro_rules!` attributes are unstable
+fn main() {}

--- a/tests/ui/macros/macro-attr-feature-gate-cross-crate.stderr
+++ b/tests/ui/macros/macro-attr-feature-gate-cross-crate.stderr
@@ -1,0 +1,13 @@
+error[E0658]: `macro_rules!` attributes are unstable
+  --> $DIR/macro-attr-feature-gate-cross-crate.rs:6:1
+   |
+LL | #[foo::identity]
+   | ^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #143547 <https://github.com/rust-lang/rust/issues/143547> for more information
+   = help: add `#![feature(macro_attr)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0658`.


### PR DESCRIPTION
Fixes rust-lang/rust#147135.

Issue rust-lang/rust#147135 reports a misleading feature-gate diagnostic for cross-crate `macro_rules!` macro attributes. This misleading  feature-gate diagnostic causes rustc to point at the macro definition instead of user’s attribute call site.

My PR makes sure externally defined `macro_rules!` attributes are gated at the invocation span. Regression test verifies that the primary error points at the downstream `#[foo::identity]` attribute use