### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -89,7 +89,7 @@ fn pre_expansion_lint<'a>(
     features: &Features,
     lint_store: &LintStore,
     registered_tools: &RegisteredTools,
-    check_node: impl EarlyCheckNode<'a>,
+    check_node: EarlyCheckNode<'a>,
     node_name: Symbol,
 ) {
     sess.prof.generic_activity_with_arg("pre_AST_expansion_lint_checks", node_name.as_str()).run(
@@ -122,7 +122,8 @@ impl LintStoreExpand for LintStoreExpandImpl<'_> {
         items: &[Box<ast::Item>],
         name: Symbol,
     ) {
-        pre_expansion_lint(sess, features, self.0, registered_tools, (node_id, attrs, items), name);
+        let check_node = EarlyCheckNode::LoadedMod(node_id, attrs, items);
+        pre_expansion_lint(sess, features, self.0, registered_tools, check_node, name);
     }
 }
 
@@ -141,13 +142,12 @@ fn configure_and_expand(
     let features = tcx.features();
     let lint_store = unerased_lint_store(sess);
     let crate_name = tcx.crate_name(LOCAL_CRATE);
-    let lint_check_node = (&krate, pre_configured_attrs);
     pre_expansion_lint(
         sess,
         features,
         lint_store,
         tcx.registered_tools(()),
-        lint_check_node,
+        EarlyCheckNode::CrateRoot(&krate, pre_configured_attrs),
         crate_name,
     );
     rustc_builtin_macros::register_builtin_macros(resolver);
@@ -480,7 +480,7 @@ fn early_lint_checks(tcx: TyCtxt<'_>, (): ()) {
         tcx.registered_tools(()),
         Some(lint_buffer),
         rustc_lint::BuiltinCombinedEarlyLintPass::new(),
-        (&*krate, &*krate.attrs),
+        EarlyCheckNode::CrateRoot(&*krate, &*krate.attrs),
     )
 }
 

--- a/compiler/rustc_lint/src/early.rs
+++ b/compiler/rustc_lint/src/early.rs
@@ -27,7 +27,7 @@ macro_rules! lint_callback { ($cx:expr, $f:ident, $($args:expr),*) => ({
 
 /// Implements the AST traversal for early lint passes. `T` provides the
 /// `check_*` methods.
-pub struct EarlyContextAndPass<'ecx, T: EarlyLintPass> {
+struct EarlyContextAndPass<'ecx, T: EarlyLintPass> {
     context: EarlyContext<'ecx>,
     pass: T,
 }
@@ -276,36 +276,36 @@ crate::early_lint_methods!(impl_early_lint_pass, []);
 
 /// Early lints work on different nodes - either on the crate root, or on freshly loaded modules.
 /// This trait generalizes over those nodes.
-pub trait EarlyCheckNode<'a>: Copy {
-    fn id(self) -> ast::NodeId;
-    fn attrs(self) -> &'a [ast::Attribute];
-    fn check<'ecx, T: EarlyLintPass>(self, cx: &mut EarlyContextAndPass<'ecx, T>);
+pub enum EarlyCheckNode<'a> {
+    CrateRoot(&'a ast::Crate, &'a [ast::Attribute]),
+    LoadedMod(ast::NodeId, &'a [ast::Attribute], &'a [Box<ast::Item>]),
 }
 
-impl<'a> EarlyCheckNode<'a> for (&'a ast::Crate, &'a [ast::Attribute]) {
-    fn id(self) -> ast::NodeId {
-        ast::CRATE_NODE_ID
+impl<'a> EarlyCheckNode<'a> {
+    fn id(&self) -> ast::NodeId {
+        match self {
+            EarlyCheckNode::CrateRoot(_crate, _attrs) => ast::CRATE_NODE_ID,
+            EarlyCheckNode::LoadedMod(id, _attrs, _items) => *id,
+        }
     }
-    fn attrs(self) -> &'a [ast::Attribute] {
-        self.1
+    fn attrs(&self) -> &'a [ast::Attribute] {
+        match self {
+            EarlyCheckNode::CrateRoot(_crate, attrs) => attrs,
+            EarlyCheckNode::LoadedMod(_id, attrs, _items) => attrs,
+        }
     }
-    fn check<'ecx, T: EarlyLintPass>(self, cx: &mut EarlyContextAndPass<'ecx, T>) {
-        lint_callback!(cx, check_crate, self.0);
-        ast_visit::walk_crate(cx, self.0);
-        lint_callback!(cx, check_crate_post, self.0);
-    }
-}
-
-impl<'a> EarlyCheckNode<'a> for (ast::NodeId, &'a [ast::Attribute], &'a [Box<ast::Item>]) {
-    fn id(self) -> ast::NodeId {
-        self.0
-    }
-    fn attrs(self) -> &'a [ast::Attribute] {
-        self.1
-    }
-    fn check<'ecx, T: EarlyLintPass>(self, cx: &mut EarlyContextAndPass<'ecx, T>) {
-        walk_list!(cx, visit_attribute, self.1);
-        walk_list!(cx, visit_item, self.2);
+    fn check<'ecx, T: EarlyLintPass>(&self, cx: &mut EarlyContextAndPass<'ecx, T>) {
+        match self {
+            EarlyCheckNode::CrateRoot(crate_, _attrs) => {
+                lint_callback!(cx, check_crate, crate_);
+                ast_visit::walk_crate(cx, crate_);
+                lint_callback!(cx, check_crate_post, crate_);
+            }
+            EarlyCheckNode::LoadedMod(_id, attrs, items) => {
+                walk_list!(cx, visit_attribute, *attrs);
+                walk_list!(cx, visit_item, *items);
+            }
+        }
     }
 }
 
@@ -317,7 +317,7 @@ pub fn check_ast_node<'a>(
     registered_tools: &RegisteredTools,
     lint_buffer: Option<LintBuffer>,
     builtin_lints: impl EarlyLintPass + 'static,
-    check_node: impl EarlyCheckNode<'a>,
+    check_node: EarlyCheckNode<'a>,
 ) {
     let context = EarlyContext::new(
         sess,
@@ -345,7 +345,7 @@ pub fn check_ast_node<'a>(
 
 fn check_ast_node_inner<'a, T: EarlyLintPass>(
     sess: &Session,
-    check_node: impl EarlyCheckNode<'a>,
+    check_node: EarlyCheckNode<'a>,
     context: EarlyContext<'_>,
     pass: T,
 ) {

--- a/library/alloc/src/collections/btree/map.rs
+++ b/library/alloc/src/collections/btree/map.rs
@@ -2594,7 +2594,8 @@ impl<K: Hash, V: Hash, A: Allocator + Clone> Hash for BTreeMap<K, V, A> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<K, V> Default for BTreeMap<K, V> {
+#[rustc_const_unstable(feature = "const_default", issue = "143894")]
+const impl<K, V> Default for BTreeMap<K, V> {
     /// Creates an empty `BTreeMap`.
     fn default() -> BTreeMap<K, V> {
         BTreeMap::new()

--- a/library/alloctests/lib.rs
+++ b/library/alloctests/lib.rs
@@ -20,6 +20,7 @@
 #![feature(const_alloc_error)]
 #![feature(const_cmp)]
 #![feature(const_convert)]
+#![feature(const_default)]
 #![feature(const_destruct)]
 #![feature(const_heap)]
 #![feature(const_option_ops)]

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -5296,7 +5296,6 @@ impl<T> [T] {
     /// # Examples
     /// Basic usage:
     /// ```
-    /// #![feature(substr_range)]
     /// use core::range::Range;
     ///
     /// let nums = &[0, 5, 10, 0, 0, 5];
@@ -5311,7 +5310,7 @@ impl<T> [T] {
     /// assert_eq!(iter.next(), Some(Range { start: 5, end: 6 }));
     /// ```
     #[must_use]
-    #[unstable(feature = "substr_range", issue = "126769")]
+    #[stable(feature = "substr_range", since = "CURRENT_RUSTC_VERSION")]
     pub fn subslice_range(&self, subslice: &[T]) -> Option<core::range::Range<usize>> {
         if T::IS_ZST {
             panic!("elements are zero-sized");

--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -3111,7 +3111,6 @@ impl str {
     ///
     /// # Examples
     /// ```
-    /// #![feature(substr_range)]
     /// use core::range::Range;
     ///
     /// let data = "a, b, b, a";
@@ -3123,7 +3122,7 @@ impl str {
     /// assert_eq!(iter.next(), Some(Range { start: 9, end: 10 }));
     /// ```
     #[must_use]
-    #[unstable(feature = "substr_range", issue = "126769")]
+    #[stable(feature = "substr_range", since = "CURRENT_RUSTC_VERSION")]
     pub fn substr_range(&self, substr: &str) -> Option<Range<usize>> {
         self.as_bytes().subslice_range(substr.as_bytes())
     }

--- a/src/bootstrap/src/lib.rs
+++ b/src/bootstrap/src/lib.rs
@@ -2120,6 +2120,8 @@ impl Compiler {
 }
 
 fn envify(s: &str) -> String {
+    // Converting foo-bar to FOO_BAR is a fairly idomatic mapping to an environment variable name.
+    // We also convert '.' to '_' to fix https://github.com/rust-lang/rust/issues/158090
     s.chars()
         .map(|c| match c {
             '-' | '.' => '_',

--- a/src/bootstrap/src/lib.rs
+++ b/src/bootstrap/src/lib.rs
@@ -2122,7 +2122,7 @@ impl Compiler {
 fn envify(s: &str) -> String {
     s.chars()
         .map(|c| match c {
-            '-' => '_',
+            '-' | '.' => '_',
             c => c,
         })
         .flat_map(|c| c.to_uppercase())

--- a/tests/ui/traits/const-traits/const-traits-alloc.rs
+++ b/tests/ui/traits/const-traits/const-traits-alloc.rs
@@ -5,5 +5,8 @@
 const STRING: String = Default::default();
 // alloc::vec
 const VEC: Vec<()> = Default::default();
+// alloc::collections::btree::map::BTreeMap
+use std::collections::BTreeMap;
+const BTREE: BTreeMap<(), ()> = Default::default();
 
 fn main() {}


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#157878 (`impl [const] Default for BTreeMap`)
 - rust-lang/rust#141266 (Stabilize `substr_range` and `subslice_range`)
 - rust-lang/rust#158109 (Change `EarlyCheckNode` from a trait to an enum.)
 - rust-lang/rust#158118 (Convert '.' to '_' in bootstrap envify)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=157878,141266,158109,158118)
<!-- homu-ignore:end -->

