### PR TITLE
Fix incorrect low-surrogate range

### DIFF
--- a/library/std/src/sys/stdio/windows.rs
+++ b/library/std/src/sys/stdio/windows.rs
@@ -222,7 +222,7 @@ fn write_valid_utf8_to_console(handle: c::HANDLE, utf8: &str) -> io::Result<usiz
         // write the missing surrogate out now.
         // Buffering it would mean we have to lie about the number of bytes written.
         let first_code_unit_remaining = utf16[written];
-        if matches!(first_code_unit_remaining, 0xDCEE..=0xDFFF) {
+        if matches!(first_code_unit_remaining, 0xDC00..=0xDFFF) {
             // low surrogate
             // We just hope this works, and give up otherwise
             let _ = write_u16s(handle, &utf16[written..written + 1]);
@@ -234,7 +234,7 @@ fn write_valid_utf8_to_console(handle: c::HANDLE, utf8: &str) -> io::Result<usiz
             count += match ch {
                 0x0000..=0x007F => 1,
                 0x0080..=0x07FF => 2,
-                0xDCEE..=0xDFFF => 1, // Low surrogate. We already counted 3 bytes for the other.
+                0xDC00..=0xDFFF => 1, // Low surrogate. We already counted 3 bytes for the other.
                 _ => 3,
             };
         }


### PR DESCRIPTION
UTF-16 encodes code points outside of the 16-bit range using a pair of 16-bit code units: the high and low surrogate. The high surrogate is in the range `0xD800..=0xDBFF` and the low surrogate is in the range `0xDC00..=0xDFFF`. However, this code erroneously has the range start at `0xDCEE`. See https://en.wikipedia.org/wiki/UTF-16#Code_points_from_U+010000_to_U+10FFFF

I'd guess the reason this bug went unnoticed for 7 years is that the fallback path it lives in is very unlikely to be reached in practice.