### PR TITLE
Revert "Add expansion info to implied bounds"

### DIFF
--- a/compiler/rustc_hir_analysis/src/check/check.rs
+++ b/compiler/rustc_hir_analysis/src/check/check.rs
@@ -24,7 +24,7 @@ use rustc_middle::ty::{
     TypeVisitable, TypeVisitableExt, Unnormalized, fold_regions,
 };
 use rustc_session::lint::builtin::UNINHABITED_STATIC;
-use rustc_span::{DesugaringKind, sym};
+use rustc_span::sym;
 use rustc_target::spec::{AbiMap, AbiMapping};
 use rustc_trait_selection::error_reporting::InferCtxtErrorExt;
 use rustc_trait_selection::traits;
@@ -2117,9 +2117,7 @@ fn check_type_alias_type_params_are_used<'tcx>(tcx: TyCtxt<'tcx>, def_id: LocalD
             // * check for emptiness to detect lone user-written `?Sized` bounds
             // * compare the param span to the pred span to detect lone user-written `Sized` bounds
             let has_explicit_bounds = bounded_params.is_empty()
-                || (*bounded_params).get(&param.index).is_some_and(|&&pred_sp| {
-                    !pred_sp.is_desugaring(DesugaringKind::DefaultBound { def: param.def_id })
-                });
+                || (*bounded_params).get(&param.index).is_some_and(|&&pred_sp| pred_sp != span);
             let const_param_help = !has_explicit_bounds;
 
             let mut diag = tcx.dcx().create_err(diagnostics::UnusedGenericParameter {

--- a/compiler/rustc_hir_analysis/src/collect/item_bounds.rs
+++ b/compiler/rustc_hir_analysis/src/collect/item_bounds.rs
@@ -58,16 +58,14 @@ fn associated_type_bounds<'tcx>(
                     &mut bounds,
                     item_ty,
                     hir_bounds,
-                    &[],
-                    ImpliedBoundsContext::AssociatedType(assoc_item_def_id),
+                    ImpliedBoundsContext::AssociatedTypeOrImplTrait,
                     span,
                 );
                 icx.lowerer().add_default_traits(
                     &mut bounds,
                     item_ty,
                     hir_bounds,
-                    &[],
-                    ImpliedBoundsContext::AssociatedType(assoc_item_def_id),
+                    ImpliedBoundsContext::AssociatedTypeOrImplTrait,
                     span,
                 );
 
@@ -386,16 +384,14 @@ fn opaque_type_bounds<'tcx>(
                     &mut bounds,
                     item_ty,
                     hir_bounds,
-                    &[],
-                    ImpliedBoundsContext::ImplTrait,
+                    ImpliedBoundsContext::AssociatedTypeOrImplTrait,
                     span,
                 );
                 icx.lowerer().add_default_traits(
                     &mut bounds,
                     item_ty,
                     hir_bounds,
-                    &[],
-                    ImpliedBoundsContext::ImplTrait,
+                    ImpliedBoundsContext::AssociatedTypeOrImplTrait,
                     span,
                 );
             }

--- a/compiler/rustc_hir_analysis/src/collect/predicates_of.rs
+++ b/compiler/rustc_hir_analysis/src/collect/predicates_of.rs
@@ -200,7 +200,6 @@ fn gather_explicit_predicates_of(tcx: TyCtxt<'_>, def_id: LocalDefId) -> ty::Gen
             &mut bounds,
             tcx.types.self_param,
             self_bounds,
-            &[],
             ImpliedBoundsContext::TraitDef(def_id),
             span,
         );
@@ -208,7 +207,6 @@ fn gather_explicit_predicates_of(tcx: TyCtxt<'_>, def_id: LocalDefId) -> ty::Gen
             &mut bounds,
             tcx.types.self_param,
             self_bounds,
-            &[],
             ImpliedBoundsContext::TraitDef(def_id),
             span,
         );
@@ -241,16 +239,14 @@ fn gather_explicit_predicates_of(tcx: TyCtxt<'_>, def_id: LocalDefId) -> ty::Gen
                     &mut bounds,
                     param_ty,
                     &[],
-                    hir_generics.predicates,
-                    ImpliedBoundsContext::TyParam(param.def_id),
+                    ImpliedBoundsContext::TyParam(param.def_id, hir_generics.predicates),
                     param.span,
                 );
                 icx.lowerer().add_default_traits(
                     &mut bounds,
                     param_ty,
                     &[],
-                    hir_generics.predicates,
-                    ImpliedBoundsContext::TyParam(param.def_id),
+                    ImpliedBoundsContext::TyParam(param.def_id, hir_generics.predicates),
                     param.span,
                 );
                 trace!(?bounds);
@@ -696,7 +692,6 @@ pub(super) fn implied_predicates_with_filter<'tcx>(
                 &mut bounds,
                 self_param_ty,
                 superbounds,
-                &[],
                 ImpliedBoundsContext::TraitDef(trait_def_id),
                 item.span,
             );
@@ -704,7 +699,6 @@ pub(super) fn implied_predicates_with_filter<'tcx>(
                 &mut bounds,
                 self_param_ty,
                 superbounds,
-                &[],
                 ImpliedBoundsContext::TraitDef(trait_def_id),
                 item.span,
             );
@@ -1000,16 +994,14 @@ impl<'tcx> ItemCtxt<'tcx> {
                             &mut bounds,
                             param_ty,
                             &[],
-                            hir_generics.predicates,
-                            ImpliedBoundsContext::TyParam(param.def_id),
+                            ImpliedBoundsContext::TyParam(param.def_id, hir_generics.predicates),
                             param.span,
                         );
                         self.lowerer().add_default_traits(
                             &mut bounds,
                             param_ty,
                             &[],
-                            hir_generics.predicates,
-                            ImpliedBoundsContext::TyParam(param.def_id),
+                            ImpliedBoundsContext::TyParam(param.def_id, hir_generics.predicates),
                             param.span,
                         );
                     }

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/bounds.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/bounds.rs
@@ -12,7 +12,7 @@ use rustc_middle::ty::{
     self as ty, IsSuggestable, Ty, TyCtxt, TypeSuperVisitable, TypeVisitable, TypeVisitableExt,
     TypeVisitor, Upcast,
 };
-use rustc_span::{DesugaringKind, ErrorGuaranteed, Ident, Span, kw};
+use rustc_span::{ErrorGuaranteed, Ident, Span, kw};
 use rustc_trait_selection::traits;
 use tracing::{debug, instrument};
 
@@ -25,17 +25,17 @@ use crate::hir_ty_lowering::{
 #[derive(Debug, Default)]
 struct CollectedBound {
     /// `Trait`
-    positive: Option<Span>,
+    positive: bool,
     /// `?Trait`
-    maybe: Option<Span>,
+    maybe: bool,
     /// `!Trait`
-    negative: Option<Span>,
+    negative: bool,
 }
 
 impl CollectedBound {
     /// Returns `true` if any of `Trait`, `?Trait` or `!Trait` were encountered.
     fn any(&self) -> bool {
-        self.positive.is_some() || self.maybe.is_some() || self.negative.is_some()
+        self.positive || self.maybe || self.negative
     }
 }
 
@@ -59,8 +59,7 @@ impl CollectedSizednessBounds {
 
 fn search_bounds_for<'tcx>(
     hir_bounds: &'tcx [hir::GenericBound<'tcx>],
-    where_bounds: &'tcx [hir::WherePredicate<'tcx>],
-    context: ImpliedBoundsContext,
+    context: ImpliedBoundsContext<'tcx>,
     mut f: impl FnMut(&'tcx PolyTraitRef<'tcx>),
 ) {
     let mut search_bounds = |hir_bounds: &'tcx [hir::GenericBound<'tcx>]| {
@@ -74,8 +73,8 @@ fn search_bounds_for<'tcx>(
     };
 
     search_bounds(hir_bounds);
-    if let ImpliedBoundsContext::TyParam(self_ty) = context {
-        for clause in where_bounds {
+    if let ImpliedBoundsContext::TyParam(self_ty, where_clause) = context {
+        for clause in where_clause {
             if let hir::WherePredicateKind::BoundPredicate(pred) = clause.kind
                 && pred.is_param_bound(self_ty.to_def_id())
             {
@@ -87,20 +86,19 @@ fn search_bounds_for<'tcx>(
 
 fn collect_bounds<'a, 'tcx>(
     hir_bounds: &'a [hir::GenericBound<'tcx>],
-    where_bounds: &'tcx [hir::WherePredicate<'tcx>],
-    context: ImpliedBoundsContext,
+    context: ImpliedBoundsContext<'tcx>,
     target_did: DefId,
 ) -> CollectedBound {
     let mut collect_into = CollectedBound::default();
-    search_bounds_for(hir_bounds, where_bounds, context, |ptr| {
+    search_bounds_for(hir_bounds, context, |ptr| {
         if !matches!(ptr.trait_ref.path.res, Res::Def(DefKind::Trait, did) if did == target_did) {
             return;
         }
 
         match ptr.modifiers.polarity {
-            hir::BoundPolarity::Maybe(_) => collect_into.maybe = Some(ptr.span),
-            hir::BoundPolarity::Negative(_) => collect_into.negative = Some(ptr.span),
-            hir::BoundPolarity::Positive => collect_into.positive = Some(ptr.span),
+            hir::BoundPolarity::Maybe(_) => collect_into.maybe = true,
+            hir::BoundPolarity::Negative(_) => collect_into.negative = true,
+            hir::BoundPolarity::Positive => collect_into.positive = true,
         }
     });
     collect_into
@@ -109,18 +107,17 @@ fn collect_bounds<'a, 'tcx>(
 fn collect_sizedness_bounds<'tcx>(
     tcx: TyCtxt<'tcx>,
     hir_bounds: &'tcx [hir::GenericBound<'tcx>],
-    where_bounds: &'tcx [hir::WherePredicate<'tcx>],
-    context: ImpliedBoundsContext,
+    context: ImpliedBoundsContext<'tcx>,
     span: Span,
 ) -> CollectedSizednessBounds {
     let sized_did = tcx.require_lang_item(hir::LangItem::Sized, span);
-    let sized = collect_bounds(hir_bounds, where_bounds, context, sized_did);
+    let sized = collect_bounds(hir_bounds, context, sized_did);
 
     let meta_sized_did = tcx.require_lang_item(hir::LangItem::MetaSized, span);
-    let meta_sized = collect_bounds(hir_bounds, where_bounds, context, meta_sized_did);
+    let meta_sized = collect_bounds(hir_bounds, context, meta_sized_did);
 
     let pointee_sized_did = tcx.require_lang_item(hir::LangItem::PointeeSized, span);
-    let pointee_sized = collect_bounds(hir_bounds, where_bounds, context, pointee_sized_did);
+    let pointee_sized = collect_bounds(hir_bounds, context, pointee_sized_did);
 
     CollectedSizednessBounds { sized, meta_sized, pointee_sized }
 }
@@ -153,8 +150,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
         bounds: &mut Vec<(ty::Clause<'tcx>, Span)>,
         self_ty: Ty<'tcx>,
         hir_bounds: &'tcx [hir::GenericBound<'tcx>],
-        where_bounds: &'tcx [hir::WherePredicate<'tcx>],
-        context: ImpliedBoundsContext,
+        context: ImpliedBoundsContext<'tcx>,
         span: Span,
     ) {
         let tcx = self.tcx();
@@ -181,15 +177,13 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                     return;
                 }
             }
-            ImpliedBoundsContext::TyParam(..)
-            | ImpliedBoundsContext::AssociatedType(..)
-            | ImpliedBoundsContext::TraitObject
-            | ImpliedBoundsContext::TraitAscription
-            | ImpliedBoundsContext::ImplTrait => {}
+            ImpliedBoundsContext::TyParam(..) | ImpliedBoundsContext::AssociatedTypeOrImplTrait => {
+            }
         }
-        let collected = collect_sizedness_bounds(tcx, hir_bounds, where_bounds, context, span);
-        if let Some(span) = collected.sized.maybe.or(collected.sized.negative)
-            && collected.sized.positive.is_none()
+
+        let collected = collect_sizedness_bounds(tcx, hir_bounds, context, span);
+        if (collected.sized.maybe || collected.sized.negative)
+            && !collected.sized.positive
             && !collected.meta_sized.any()
             && !collected.pointee_sized.any()
         {
@@ -197,21 +191,6 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             // other explicit ones) - this can happen for trait aliases as well as bounds.
             add_trait_bound(tcx, bounds, self_ty, meta_sized_did, span);
         } else if !collected.any() {
-            let span = match context {
-                ImpliedBoundsContext::TraitDef(def)
-                | ImpliedBoundsContext::TyParam(def)
-                | ImpliedBoundsContext::AssociatedType(def) => {
-                    self.tcx().with_stable_hashing_context(|hcx| {
-                        span.mark_with_reason(
-                            None,
-                            DesugaringKind::DefaultBound { def: def.into() },
-                            span.edition(),
-                            hcx,
-                        )
-                    })
-                }
-                _ => span,
-            };
             match context {
                 ImpliedBoundsContext::TraitDef(..) => {
                     // If there are no explicit sizedness bounds on a trait then add a default
@@ -219,10 +198,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                     add_trait_bound(tcx, bounds, self_ty, meta_sized_did, span);
                 }
                 ImpliedBoundsContext::TyParam(..)
-                | ImpliedBoundsContext::AssociatedType(..)
-                | ImpliedBoundsContext::TraitObject
-                | ImpliedBoundsContext::TraitAscription
-                | ImpliedBoundsContext::ImplTrait => {
+                | ImpliedBoundsContext::AssociatedTypeOrImplTrait => {
                     // If there are no explicit sizedness bounds on a parameter then add a default
                     // `Sized` bound.
                     let sized_did = tcx.require_lang_item(hir::LangItem::Sized, span);
@@ -237,20 +213,11 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
         bounds: &mut Vec<(ty::Clause<'tcx>, Span)>,
         self_ty: Ty<'tcx>,
         hir_bounds: &[hir::GenericBound<'tcx>],
-        where_bounds: &'tcx [hir::WherePredicate<'tcx>],
-        context: ImpliedBoundsContext,
+        context: ImpliedBoundsContext<'tcx>,
         span: Span,
     ) {
         self.tcx().default_traits().iter().for_each(|default_trait| {
-            self.add_default_trait(
-                *default_trait,
-                bounds,
-                self_ty,
-                hir_bounds,
-                where_bounds,
-                context,
-                span,
-            );
+            self.add_default_trait(*default_trait, bounds, self_ty, hir_bounds, context, span);
         });
     }
 
@@ -263,8 +230,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
         bounds: &mut Vec<(ty::Clause<'tcx>, Span)>,
         self_ty: Ty<'tcx>,
         hir_bounds: &[hir::GenericBound<'tcx>],
-        where_bounds: &'tcx [hir::WherePredicate<'tcx>],
-        context: ImpliedBoundsContext,
+        context: ImpliedBoundsContext<'tcx>,
         span: Span,
     ) {
         let tcx = self.tcx();
@@ -278,7 +244,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
         }
 
         if let Some(trait_did) = tcx.lang_items().get(trait_)
-            && self.should_add_default_traits(trait_did, hir_bounds, where_bounds, context)
+            && self.should_add_default_traits(trait_did, hir_bounds, context)
         {
             add_trait_bound(tcx, bounds, self_ty, trait_did, span);
         }
@@ -289,10 +255,9 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
         &self,
         trait_def_id: DefId,
         hir_bounds: &'a [hir::GenericBound<'tcx>],
-        where_bounds: &'tcx [hir::WherePredicate<'tcx>],
-        context: ImpliedBoundsContext,
+        context: ImpliedBoundsContext<'tcx>,
     ) -> bool {
-        let collected = collect_bounds(hir_bounds, where_bounds, context, trait_def_id);
+        let collected = collect_bounds(hir_bounds, context, trait_def_id);
         !find_attr!(self.tcx(), crate, RustcNoImplicitBounds) && !collected.any()
     }
 

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/dyn_trait.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/dyn_trait.rs
@@ -83,8 +83,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                 .iter()
                 .map(|&trait_ref| hir::GenericBound::Trait(trait_ref))
                 .collect::<Vec<_>>(),
-            &[],
-            ImpliedBoundsContext::TraitObject,
+            ImpliedBoundsContext::AssociatedTypeOrImplTrait,
             span,
         );
 

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
@@ -59,17 +59,14 @@ use crate::{NoVariantNamed, check_c_variadic_abi};
 /// The context in which an implied bound is being added to a item being lowered (i.e. a sizedness
 /// trait or a default trait)
 #[derive(Clone, Copy)]
-pub(crate) enum ImpliedBoundsContext {
+pub(crate) enum ImpliedBoundsContext<'tcx> {
     /// An implied bound is added to a trait definition (i.e. a new supertrait), used when adding
     /// a default `MetaSized` supertrait
     TraitDef(LocalDefId),
     /// An implied bound is added to a type parameter
-    TyParam(LocalDefId),
-    /// Associated type bounds
-    AssociatedType(LocalDefId),
-    ImplTrait,
-    TraitObject,
-    TraitAscription,
+    TyParam(LocalDefId, &'tcx [hir::WherePredicate<'tcx>]),
+    /// An implied bound being added in any other context
+    AssociatedTypeOrImplTrait,
 }
 
 /// A path segment that is semantically allowed to have generic arguments.
@@ -3133,8 +3130,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                     &mut bounds,
                     self_ty,
                     hir_bounds,
-                    &[],
-                    ImpliedBoundsContext::TraitAscription,
+                    ImpliedBoundsContext::AssociatedTypeOrImplTrait,
                     hir_ty.span,
                 );
                 self.register_trait_ascription_bounds(bounds, hir_ty.hir_id, hir_ty.span);

--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -34,8 +34,8 @@ use rustc_middle::ty::print::{
 use rustc_middle::ty::{self, GenericArgKind, IsSuggestable, Ty, TyCtxt, TypeVisitableExt};
 use rustc_span::def_id::DefIdSet;
 use rustc_span::{
-    DUMMY_SP, DesugaringKind, ErrorGuaranteed, ExpnKind, FileName, Ident, MacroKind, Span, Symbol,
-    edit_distance, kw, sym,
+    DUMMY_SP, ErrorGuaranteed, ExpnKind, FileName, Ident, MacroKind, Span, Symbol, edit_distance,
+    kw, sym,
 };
 use rustc_trait_selection::error_reporting::traits::DefIdOrName;
 use rustc_trait_selection::infer::InferCtxtExt;
@@ -1952,8 +1952,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             _ => false,
                         }
                     });
-                    if sized_pred && let Some(DesugaringKind::DefaultBound { def }) = cause_span.desugaring_kind() {
-                        if let Some(param) = generics.params.iter().find(|p| p.def_id.to_def_id() == def) {
+                    for param in generics.params {
+                        if param.span == cause_span && sized_pred {
                             let (sp, sugg) = match param.colon_span {
                                 Some(sp) => (sp.shrink_to_hi(), " ?Sized +"),
                                 None => (param.span.shrink_to_hi(), ": ?Sized"),

--- a/compiler/rustc_span/src/hygiene.rs
+++ b/compiler/rustc_span/src/hygiene.rs
@@ -926,20 +926,9 @@ impl SyntaxContext {
                 | DesugaringKind::WhileLoop
                 | DesugaringKind::OpaqueTy
                 | DesugaringKind::Async
-                | DesugaringKind::DefaultBound { .. }
                 | DesugaringKind::Await,
             ) => false,
-            ExpnKind::AstPass(_)
-            | ExpnKind::Desugaring(
-                DesugaringKind::BoundModifier
-                | DesugaringKind::QuestionMark
-                | DesugaringKind::TryBlock
-                | DesugaringKind::Contract
-                | DesugaringKind::RangeExpr
-                | DesugaringKind::PatTyRange
-                | DesugaringKind::FormatLiteral { .. }
-                | DesugaringKind::YeetExpr,
-            ) => true, // well, it's "external"
+            ExpnKind::AstPass(_) | ExpnKind::Desugaring(_) => true, // well, it's "external"
             ExpnKind::Macro(MacroKind::Bang, _) => {
                 // Dummy span for the `def_site` means it's an external macro.
                 expn_data.def_site.is_dummy() || sm.is_imported(expn_data.def_site)
@@ -1236,13 +1225,6 @@ pub enum DesugaringKind {
         source: bool,
     },
     RangeExpr,
-    /// Implicit `Sized` or `MetaSized` bounds. The actual source location points to just the
-    /// param or item for which the implicit bound was generated.
-    DefaultBound {
-        /// The definition this implied bound was added to.
-        /// So far only supports params, but may be used for super trait bounds and assoc ty bounds in the future
-        def: DefId,
-    },
 }
 
 impl DesugaringKind {
@@ -1265,7 +1247,6 @@ impl DesugaringKind {
                 "expression that expanded into a format string literal"
             }
             DesugaringKind::RangeExpr => "range expression",
-            DesugaringKind::DefaultBound { .. } => "implied bound",
         }
     }
 
@@ -1286,7 +1267,6 @@ impl DesugaringKind {
             DesugaringKind::PatTyRange => value == "PatTyRange",
             DesugaringKind::FormatLiteral { .. } => value == "FormatLiteral",
             DesugaringKind::RangeExpr => value == "RangeExpr",
-            DesugaringKind::DefaultBound { .. } => value == "ImpliedBound",
         }
     }
 }

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
@@ -3571,7 +3571,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     }
                 }
                 let mut a = "a";
-                let mut this = "this bound".to_owned();
+                let mut this = "this bound";
                 let mut note = None;
                 let mut help = None;
                 if let ty::PredicateKind::Clause(clause) = predicate.kind().skip_binder() {
@@ -3598,14 +3598,16 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                                 tcx.visible_parent_map(()).get(&def_id).is_some()
                             };
                             if tcx.is_lang_item(def_id, LangItem::Sized) {
-                                if let Some(DesugaringKind::DefaultBound { def }) =
-                                    span.desugaring_kind()
+                                // Check if this is an implicit bound, even in foreign crates.
+                                if tcx
+                                    .generics_of(item_def_id)
+                                    .own_params
+                                    .iter()
+                                    .any(|param| tcx.def_span(param.def_id) == span)
                                 {
                                     a = "an implicit `Sized`";
-                                    this = format!(
-                                        "the implicit `Sized` requirement on this {}",
-                                        tcx.def_kind(def).descr(def)
-                                    );
+                                    this =
+                                        "the implicit `Sized` requirement on this type parameter";
                                 }
                                 if let Some(hir::Node::TraitItem(hir::TraitItem {
                                     generics,
@@ -4215,8 +4217,12 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                             // implicit, mention it as such.
                             if let Some(pred) = predicate.as_trait_clause()
                                 && self.tcx.is_lang_item(pred.def_id(), LangItem::Sized)
-                                && let Some(DesugaringKind::DefaultBound { .. }) =
-                                    data.span.desugaring_kind()
+                                && self
+                                    .tcx
+                                    .generics_of(data.impl_or_alias_def_id)
+                                    .own_params
+                                    .iter()
+                                    .any(|param| self.tcx.def_span(param.def_id) == data.span)
                             {
                                 spans.push_span_label(
                                     data.span,
@@ -5906,11 +5912,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         let sized_trait = self.tcx.lang_items().sized_trait();
         debug!(?generics.params);
         debug!(?generics.predicates);
-        let Some(DesugaringKind::DefaultBound { def }) = span.desugaring_kind() else {
-            return;
-        };
-        let Some(param) = generics.params.iter().find(|param| param.def_id.to_def_id() == def)
-        else {
+        let Some(param) = generics.params.iter().find(|param| param.span == span) else {
             return;
         };
         // Check that none of the explicit trait bounds is `Sized`. Assume that an explicit

--- a/tests/incremental/explicit_supertraits_containing_assoc_item.rs
+++ b/tests/incremental/explicit_supertraits_containing_assoc_item.rs
@@ -1,0 +1,19 @@
+//@ revisions: cpass1 cpass2
+//@ edition: 2024
+// regression test for https://github.com/rust-lang/rust/issues/158093
+
+trait Super {
+    type Assoc;
+}
+
+trait Sub: Super {}
+
+impl<T: ?Sized> Super for T {
+    type Assoc = i32;
+}
+
+fn illegal(x: &dyn Sub<Assoc = impl Sized>) -> &dyn Super<Assoc = impl Sized> {
+    x
+}
+
+fn main() {}

--- a/tests/ui/associated-types/issue-63593.current.stderr
+++ b/tests/ui/associated-types/issue-63593.current.stderr
@@ -4,11 +4,11 @@ error[E0277]: the size for values of type `Self` cannot be known at compilation 
 LL |     type This = Self;
    |                 ^^^^ doesn't have a size known at compile-time
    |
-note: required by an implicit `Sized` bound in `MyTrait::This`
+note: required by a bound in `MyTrait::This`
   --> $DIR/issue-63593.rs:13:5
    |
 LL |     type This = Self;
-   |     ^^^^^^^^^^^^^^^^^ required by the implicit `Sized` requirement on this associated type in `MyTrait::This`
+   |     ^^^^^^^^^^^^^^^^^ required by this bound in `MyTrait::This`
 help: consider further restricting `Self`
    |
 LL | trait MyTrait: Sized {

--- a/tests/ui/associated-types/issue-63593.next.stderr
+++ b/tests/ui/associated-types/issue-63593.next.stderr
@@ -4,11 +4,11 @@ error[E0277]: the size for values of type `Self` cannot be known at compilation 
 LL |     type This = Self;
    |                 ^^^^ doesn't have a size known at compile-time
    |
-note: required by an implicit `Sized` bound in `MyTrait::This`
+note: required by a bound in `MyTrait::This`
   --> $DIR/issue-63593.rs:13:5
    |
 LL |     type This = Self;
-   |     ^^^^^^^^^^^^^^^^^ required by the implicit `Sized` requirement on this associated type in `MyTrait::This`
+   |     ^^^^^^^^^^^^^^^^^ required by this bound in `MyTrait::This`
 help: consider further restricting `Self`
    |
 LL | trait MyTrait: Sized {

--- a/tests/ui/box/into-boxed-slice-fail.stderr
+++ b/tests/ui/box/into-boxed-slice-fail.stderr
@@ -7,7 +7,7 @@ LL |     let _ = Box::into_boxed_slice(boxed_slice);
    |             required by a bound introduced by this call
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by an implicit `Sized` bound in `Box::<T, A>::into_boxed_slice`
+note: required by a bound in `Box::<T, A>::into_boxed_slice`
   --> $SRC_DIR/alloc/src/boxed.rs:LL:COL
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
@@ -28,7 +28,7 @@ LL |     let _ = Box::into_boxed_slice(boxed_trait);
    |             required by a bound introduced by this call
    |
    = help: the trait `Sized` is not implemented for `dyn Debug`
-note: required by an implicit `Sized` bound in `Box::<T, A>::into_boxed_slice`
+note: required by a bound in `Box::<T, A>::into_boxed_slice`
   --> $SRC_DIR/alloc/src/boxed.rs:LL:COL
 
 error[E0277]: the size for values of type `dyn Debug` cannot be known at compilation time

--- a/tests/ui/closures/unsized_value_move.stderr
+++ b/tests/ui/closures/unsized_value_move.stderr
@@ -7,7 +7,7 @@ LL |     (|| Box::new(*(&[0][..])))();
    |         required by a bound introduced by this call
    |
    = help: the trait `Sized` is not implemented for `[{integer}]`
-note: required by an implicit `Sized` bound in `Box::<T>::new`
+note: required by a bound in `Box::<T>::new`
   --> $SRC_DIR/alloc/src/boxed.rs:LL:COL
 help: references are always `Sized`, even if they point to unsized data; consider not dereferencing the expression
    |

--- a/tests/ui/coherence/deep-bad-copy-reason.rs
+++ b/tests/ui/coherence/deep-bad-copy-reason.rs
@@ -14,7 +14,6 @@ pub struct ListS<T> {
 pub struct Interned<'a, T>(&'a T);
 //~^ NOTE: required by an implicit `Sized`
 //~| NOTE: required by the implicit `Sized`
-//~| NOTE: in this expansion of desugaring of implied bound
 
 impl<'a, T> Clone for Interned<'a, T> {
     fn clone(&self) -> Self {

--- a/tests/ui/coherence/deep-bad-copy-reason.stderr
+++ b/tests/ui/coherence/deep-bad-copy-reason.stderr
@@ -1,5 +1,5 @@
 error[E0204]: the trait `Copy` cannot be implemented for this type
-  --> $DIR/deep-bad-copy-reason.rs:39:24
+  --> $DIR/deep-bad-copy-reason.rs:38:24
    |
 LL | pub struct List<'tcx, T>(Interned<'tcx, ListS<T>>);
    |                          ------------------------ this field does not implement `Copy`
@@ -8,13 +8,13 @@ LL | impl<'tcx, T> Copy for List<'tcx, T> {}
    |                        ^^^^^^^^^^^^^
    |
 note: the `Copy` impl for `Interned<'tcx, ListS<T>>` requires that `OpaqueListContents: Sized`
-  --> $DIR/deep-bad-copy-reason.rs:27:26
+  --> $DIR/deep-bad-copy-reason.rs:26:26
    |
 LL | pub struct List<'tcx, T>(Interned<'tcx, ListS<T>>);
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the size for values of type `OpaqueListContents` cannot be known at compilation time
-  --> $DIR/deep-bad-copy-reason.rs:27:26
+  --> $DIR/deep-bad-copy-reason.rs:26:26
    |
 LL | pub struct List<'tcx, T>(Interned<'tcx, ListS<T>>);
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time

--- a/tests/ui/const-generics/unused-type-param-suggestion.rs
+++ b/tests/ui/const-generics/unused-type-param-suggestion.rs
@@ -1,4 +1,4 @@
-#![crate_type = "lib"]
+#![crate_type="lib"]
 
 struct S<N>;
 //~^ ERROR type parameter `N` is never used
@@ -25,3 +25,4 @@ type C<N: Sized> = ();
 type D<N: ?Sized> = ();
 //~^ ERROR type parameter `N` is never used
 //~| HELP consider removing `N`
+//~| HELP if you intended `N` to be a const parameter

--- a/tests/ui/const-generics/unused-type-param-suggestion.stderr
+++ b/tests/ui/const-generics/unused-type-param-suggestion.stderr
@@ -47,6 +47,7 @@ LL | type D<N: ?Sized> = ();
    |        ^ unused type parameter
    |
    = help: consider removing `N` or referring to it in the body of the type alias
+   = help: if you intended `N` to be a const parameter, use `const N: /* Type */` instead
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/drop/dropck-normalize-errors.nll.stderr
+++ b/tests/ui/drop/dropck-normalize-errors.nll.stderr
@@ -47,11 +47,11 @@ note: required because it appears within the type `BDecoder`
    |
 LL | pub struct BDecoder {
    |            ^^^^^^^^
-note: required by an implicit `Sized` bound in `Decode::Decoder`
+note: required by a bound in `Decode::Decoder`
   --> $DIR/dropck-normalize-errors.rs:8:5
    |
 LL |     type Decoder;
-   |     ^^^^^^^^^^^^^ required by the implicit `Sized` requirement on this associated type in `Decode::Decoder`
+   |     ^^^^^^^^^^^^^ required by this bound in `Decode::Decoder`
 help: consider relaxing the implicit `Sized` restriction
    |
 LL |     type Decoder: ?Sized;

--- a/tests/ui/drop/dropck-normalize-errors.polonius.stderr
+++ b/tests/ui/drop/dropck-normalize-errors.polonius.stderr
@@ -47,11 +47,11 @@ note: required because it appears within the type `BDecoder`
    |
 LL | pub struct BDecoder {
    |            ^^^^^^^^
-note: required by an implicit `Sized` bound in `Decode::Decoder`
+note: required by a bound in `Decode::Decoder`
   --> $DIR/dropck-normalize-errors.rs:8:5
    |
 LL |     type Decoder;
-   |     ^^^^^^^^^^^^^ required by the implicit `Sized` requirement on this associated type in `Decode::Decoder`
+   |     ^^^^^^^^^^^^^ required by this bound in `Decode::Decoder`
 help: consider relaxing the implicit `Sized` restriction
    |
 LL |     type Decoder: ?Sized;

--- a/tests/ui/dst/dst-rvalue.stderr
+++ b/tests/ui/dst/dst-rvalue.stderr
@@ -7,7 +7,7 @@ LL |     let _x: Box<str> = Box::new(*"hello world");
    |                        required by a bound introduced by this call
    |
    = help: the trait `Sized` is not implemented for `str`
-note: required by an implicit `Sized` bound in `Box::<T>::new`
+note: required by a bound in `Box::<T>::new`
   --> $SRC_DIR/alloc/src/boxed.rs:LL:COL
 help: references are always `Sized`, even if they point to unsized data; consider not dereferencing the expression
    |
@@ -24,7 +24,7 @@ LL |     let _x: Box<[isize]> = Box::new(*array);
    |                            required by a bound introduced by this call
    |
    = help: the trait `Sized` is not implemented for `[isize]`
-note: required by an implicit `Sized` bound in `Box::<T>::new`
+note: required by a bound in `Box::<T>::new`
   --> $SRC_DIR/alloc/src/boxed.rs:LL:COL
 help: references are always `Sized`, even if they point to unsized data; consider not dereferencing the expression
    |

--- a/tests/ui/dyn-compatibility/assoc_type_bounds_implicit_sized.stderr
+++ b/tests/ui/dyn-compatibility/assoc_type_bounds_implicit_sized.stderr
@@ -5,11 +5,11 @@ LL |     type Item = dyn Trait;
    |                 ^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `(dyn Trait + 'static)`
-note: required by an implicit `Sized` bound in `TraitWithAType::Item`
+note: required by a bound in `TraitWithAType::Item`
   --> $DIR/assoc_type_bounds_implicit_sized.rs:4:5
    |
 LL |     type Item;
-   |     ^^^^^^^^^^ required by the implicit `Sized` requirement on this associated type in `TraitWithAType::Item`
+   |     ^^^^^^^^^^ required by this bound in `TraitWithAType::Item`
 help: consider relaxing the implicit `Sized` restriction
    |
 LL |     type Item: ?Sized;

--- a/tests/ui/extern/extern-types-unsized.stderr
+++ b/tests/ui/extern/extern-types-unsized.stderr
@@ -67,10 +67,10 @@ LL |     assert_sized::<Bar<A>>();
    |
    = help: the nightly-only, unstable trait `MetaSized` is not implemented for `A`
 note: required by a bound in `Bar`
-  --> $DIR/extern-types-unsized.rs:14:15
+  --> $DIR/extern-types-unsized.rs:14:12
    |
 LL | struct Bar<T: ?Sized> {
-   |               ^^^^^^ required by this bound in `Bar`
+   |            ^ required by this bound in `Bar`
 
 error[E0277]: the size for values of type `A` cannot be known at compilation time
   --> $DIR/extern-types-unsized.rs:32:20
@@ -102,10 +102,10 @@ LL |     assert_sized::<Bar<Bar<A>>>();
    |
    = help: the nightly-only, unstable trait `MetaSized` is not implemented for `A`
 note: required by a bound in `Bar`
-  --> $DIR/extern-types-unsized.rs:14:15
+  --> $DIR/extern-types-unsized.rs:14:12
    |
 LL | struct Bar<T: ?Sized> {
-   |               ^^^^^^ required by this bound in `Bar`
+   |            ^ required by this bound in `Bar`
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/generic-associated-types/issue-119942-unsatisified-gat-bound-during-assoc-ty-selection.stderr
+++ b/tests/ui/generic-associated-types/issue-119942-unsatisified-gat-bound-during-assoc-ty-selection.stderr
@@ -5,11 +5,11 @@ LL |     type Pointer<T> = dyn Deref<Target = T>;
    |                       ^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `(dyn Deref<Target = T> + 'static)`
-note: required by an implicit `Sized` bound in `PointerFamily::Pointer`
+note: required by a bound in `PointerFamily::Pointer`
   --> $DIR/issue-119942-unsatisified-gat-bound-during-assoc-ty-selection.rs:4:5
    |
 LL |     type Pointer<T>: Deref<Target = T>;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by the implicit `Sized` requirement on this associated type in `PointerFamily::Pointer`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `PointerFamily::Pointer`
 help: consider relaxing the implicit `Sized` restriction
    |
 LL |     type Pointer<T>: Deref<Target = T> + ?Sized;

--- a/tests/ui/generic-associated-types/issue-74816.current.stderr
+++ b/tests/ui/generic-associated-types/issue-74816.current.stderr
@@ -20,11 +20,11 @@ error[E0277]: the size for values of type `Self` cannot be known at compilation 
 LL |     type Associated: Trait1 = Self;
    |                               ^^^^ doesn't have a size known at compile-time
    |
-note: required by an implicit `Sized` bound in `Trait2::Associated`
+note: required by a bound in `Trait2::Associated`
   --> $DIR/issue-74816.rs:12:5
    |
 LL |     type Associated: Trait1 = Self;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by the implicit `Sized` requirement on this associated type in `Trait2::Associated`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `Trait2::Associated`
 help: consider further restricting `Self`
    |
 LL | trait Trait2: Sized {

--- a/tests/ui/generic-associated-types/issue-74816.next.stderr
+++ b/tests/ui/generic-associated-types/issue-74816.next.stderr
@@ -20,11 +20,11 @@ error[E0277]: the size for values of type `Self` cannot be known at compilation 
 LL |     type Associated: Trait1 = Self;
    |                               ^^^^ doesn't have a size known at compile-time
    |
-note: required by an implicit `Sized` bound in `Trait2::Associated`
+note: required by a bound in `Trait2::Associated`
   --> $DIR/issue-74816.rs:12:5
    |
 LL |     type Associated: Trait1 = Self;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by the implicit `Sized` requirement on this associated type in `Trait2::Associated`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `Trait2::Associated`
 help: consider further restricting `Self`
    |
 LL | trait Trait2: Sized {

--- a/tests/ui/impl-trait/in-trait/refine-resolution-errors.stderr
+++ b/tests/ui/impl-trait/in-trait/refine-resolution-errors.stderr
@@ -13,11 +13,11 @@ LL |
 LL |     type Assoc = T;
    |                  ^ doesn't have a size known at compile-time
    |
-note: required by an implicit `Sized` bound in `Mirror::Assoc`
+note: required by a bound in `Mirror::Assoc`
   --> $DIR/refine-resolution-errors.rs:7:5
    |
 LL |     type Assoc;
-   |     ^^^^^^^^^^^ required by the implicit `Sized` requirement on this associated type in `Mirror::Assoc`
+   |     ^^^^^^^^^^^ required by this bound in `Mirror::Assoc`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - impl<T: ?Sized> Mirror for () {

--- a/tests/ui/sized-hierarchy/overflow.current.stderr
+++ b/tests/ui/sized-hierarchy/overflow.current.stderr
@@ -8,9 +8,9 @@ note: required for `Box<Element>` to implement `ParseTokens`
   --> $DIR/overflow.rs:13:31
    |
 LL | impl<T: ParseTokens + ?Sized> ParseTokens for Box<T> {
-   |                       ------  ^^^^^^^^^^^     ^^^^^^
-   |                       |
-   |                       unsatisfied trait bound introduced here
+   |      -                        ^^^^^^^^^^^     ^^^^^^
+   |      |
+   |      unsatisfied trait bound introduced here
    = note: 1 redundant requirement hidden
    = note: required for `Box<Box<Element>>` to implement `ParseTokens`
 

--- a/tests/ui/trait-bounds/enum-unit-variant-trait-bound.stderr
+++ b/tests/ui/trait-bounds/enum-unit-variant-trait-bound.stderr
@@ -5,7 +5,7 @@ LL |     let _ = Option::<[u8]>::None;
    |                      ^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by an implicit `Sized` bound in `None`
+note: required by a bound in `None`
   --> $SRC_DIR/core/src/option.rs:LL:COL
 
 error: aborting due to 1 previous error

--- a/tests/ui/trait-bounds/suggest-maybe-sized-bound.stderr
+++ b/tests/ui/trait-bounds/suggest-maybe-sized-bound.stderr
@@ -22,11 +22,11 @@ LL |         type P<X> = [u8];
    |                     ^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by an implicit `Sized` bound in `main::Trait::P`
+note: required by a bound in `main::Trait::P`
   --> $DIR/suggest-maybe-sized-bound.rs:13:9
    |
 LL |         type P<X>;
-   |         ^^^^^^^^^^ required by the implicit `Sized` requirement on this associated type in `Trait::P`
+   |         ^^^^^^^^^^ required by this bound in `Trait::P`
 help: consider relaxing the implicit `Sized` restriction
    |
 LL |         type P<X>: ?Sized;

--- a/tests/ui/traits/cycle-cache-err-60010.stderr
+++ b/tests/ui/traits/cycle-cache-err-60010.stderr
@@ -80,11 +80,11 @@ note: required because it appears within the type `SalsaStorage`
    |
 LL | struct SalsaStorage {
    |        ^^^^^^^^^^^^
-note: required by an implicit `Sized` bound in `Database::Storage`
+note: required by a bound in `Database::Storage`
   --> $DIR/cycle-cache-err-60010.rs:7:5
    |
 LL |     type Storage;
-   |     ^^^^^^^^^^^^^ required by the implicit `Sized` requirement on this associated type in `Database::Storage`
+   |     ^^^^^^^^^^^^^ required by this bound in `Database::Storage`
 help: consider relaxing the implicit `Sized` restriction
    |
 LL |     type Storage: ?Sized;

--- a/tests/ui/traits/normalize/unconstrained-projection-normalization-2.current.stderr
+++ b/tests/ui/traits/normalize/unconstrained-projection-normalization-2.current.stderr
@@ -22,11 +22,11 @@ LL |
 LL |     type Assoc = T;
    |                  ^ doesn't have a size known at compile-time
    |
-note: required by an implicit `Sized` bound in `Every::Assoc`
+note: required by a bound in `Every::Assoc`
   --> $DIR/unconstrained-projection-normalization-2.rs:12:5
    |
 LL |     type Assoc;
-   |     ^^^^^^^^^^^ required by the implicit `Sized` requirement on this associated type in `Every::Assoc`
+   |     ^^^^^^^^^^^ required by this bound in `Every::Assoc`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - impl<T: ?Sized> Every for Thing {

--- a/tests/ui/traits/normalize/unconstrained-projection-normalization-2.next.stderr
+++ b/tests/ui/traits/normalize/unconstrained-projection-normalization-2.next.stderr
@@ -22,11 +22,11 @@ LL |
 LL |     type Assoc = T;
    |                  ^ doesn't have a size known at compile-time
    |
-note: required by an implicit `Sized` bound in `Every::Assoc`
+note: required by a bound in `Every::Assoc`
   --> $DIR/unconstrained-projection-normalization-2.rs:12:5
    |
 LL |     type Assoc;
-   |     ^^^^^^^^^^^ required by the implicit `Sized` requirement on this associated type in `Every::Assoc`
+   |     ^^^^^^^^^^^ required by this bound in `Every::Assoc`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - impl<T: ?Sized> Every for Thing {

--- a/tests/ui/traits/normalize/unconstrained-projection-normalization.current.stderr
+++ b/tests/ui/traits/normalize/unconstrained-projection-normalization.current.stderr
@@ -22,11 +22,11 @@ LL |
 LL |     type Assoc = T;
    |                  ^ doesn't have a size known at compile-time
    |
-note: required by an implicit `Sized` bound in `Every::Assoc`
+note: required by a bound in `Every::Assoc`
   --> $DIR/unconstrained-projection-normalization.rs:11:5
    |
 LL |     type Assoc;
-   |     ^^^^^^^^^^^ required by the implicit `Sized` requirement on this associated type in `Every::Assoc`
+   |     ^^^^^^^^^^^ required by this bound in `Every::Assoc`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - impl<T: ?Sized> Every for Thing {

--- a/tests/ui/traits/normalize/unconstrained-projection-normalization.next.stderr
+++ b/tests/ui/traits/normalize/unconstrained-projection-normalization.next.stderr
@@ -22,11 +22,11 @@ LL |
 LL |     type Assoc = T;
    |                  ^ doesn't have a size known at compile-time
    |
-note: required by an implicit `Sized` bound in `Every::Assoc`
+note: required by a bound in `Every::Assoc`
   --> $DIR/unconstrained-projection-normalization.rs:11:5
    |
 LL |     type Assoc;
-   |     ^^^^^^^^^^^ required by the implicit `Sized` requirement on this associated type in `Every::Assoc`
+   |     ^^^^^^^^^^^ required by this bound in `Every::Assoc`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - impl<T: ?Sized> Every for Thing {


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/158122)*
<!-- homu-ignore:end -->

This reverts PR https://github.com/rust-lang/rust/pull/157702 because it causes an ICE and a significant perf regression. This PR also adds a regression test for the ICE.

r? ghost
cc @oli-obk @estebank @davidtwco 

Fixes https://github.com/rust-lang/rust/issues/158093
