### PR TITLE
ensure the new solver bootstraps on CI

### DIFF
--- a/src/ci/docker/host-x86_64/x86_64-gnu-next-trait-solver-polonius/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-next-trait-solver-polonius/Dockerfile
@@ -25,5 +25,5 @@ RUN sh /scripts/sccache.sh
 
 ENV RUST_CONFIGURE_ARGS="--build=x86_64-unknown-linux-gnu"
 
-COPY scripts/x86_64-gnu-pre-stabilization.sh /scripts/
-ENV SCRIPT="/scripts/x86_64-gnu-pre-stabilization.sh"
+COPY scripts/x86_64-gnu-next-trait-solver-polonius.sh /scripts/
+ENV SCRIPT="/scripts/x86_64-gnu-next-trait-solver-polonius.sh"

--- a/src/ci/docker/scripts/x86_64-gnu-next-trait-solver-polonius.sh
+++ b/src/ci/docker/scripts/x86_64-gnu-next-trait-solver-polonius.sh
@@ -5,11 +5,11 @@ set -ex
 # This script tests features intended to be stabilized in 2026. We want to
 # ensure they don't regress until then.
 
-# 1. For the new trait solver, we want to:
+# 1. For the next trait solver, we want to:
 # - ensure it can build the standard library
 # - ensure it actually bootstraps
 #
-# We test both by building the _stage 2_ library with the new solver enabled
+# We test both by building the _stage 2_ library with the next solver enabled
 # at stage 1 via rustflags.
 
 RUSTFLAGS_NOT_BOOTSTRAP="-Znext-solver=globally" ../x build library --stage 2

--- a/src/ci/docker/scripts/x86_64-gnu-pre-stabilization.sh
+++ b/src/ci/docker/scripts/x86_64-gnu-pre-stabilization.sh
@@ -7,10 +7,12 @@ set -ex
 
 # 1. For the new trait solver, we want to:
 # - ensure it can build the standard library
+# - ensure it actually bootstraps
 #
-# FIXME: we also need to ensure it actually bootstraps.
+# We test both by building the _stage 2_ library with the new solver enabled
+# at stage 1 via rustflags.
 
-RUSTFLAGS_NOT_BOOTSTRAP="-Znext-solver=globally" ../x build library --stage 1
+RUSTFLAGS_NOT_BOOTSTRAP="-Znext-solver=globally" ../x build library --stage 2
 
 # 2. For the polonius alpha, we run the UI tests under the polonius
 # compare-mode.

--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -159,8 +159,8 @@ pr:
   
   # This job tests features we want to stabilize soon, to ensure they don't
   # regress.
-  - name: x86_64-gnu-pre-stabilization
-    doc_url: https://rustc-dev-guide.rust-lang.org/tests/pre-stabilization-ci-job.html
+  - name: x86_64-gnu-next-trait-solver-polonius
+    doc_url: https://rustc-dev-guide.rust-lang.org/tests/x86_64-gnu-next-trait-solver-polonius-ci-job.html
     env:
       CODEGEN_BACKENDS: llvm
     <<: *job-linux-4c


### PR DESCRIPTION
With https://github.com/rust-lang/rust/pull/158040, the new solver should now be able to bootstrap, and this PR ensures on CI it doesn't regress. This is part of the plan in https://github.com/rust-lang/rust/issues/157780 until stabilization.

This renames the job as well to something hopefully clearer, from `x86_64-gnu-pre-stabilization` to `x86_64-gnu-next-trait-solver-polonius`. And thus, also needs https://github.com/rust-lang/rustc-dev-guide/pull/2904 to have the correct `doc_url`.

r? kobzol