### PR TITLE
std: correctly report file size on UWP

### DIFF
--- a/library/std/src/sys/fs/windows.rs
+++ b/library/std/src/sys/fs/windows.rs
@@ -597,7 +597,7 @@ impl File {
                 (&raw mut info) as *mut c_void,
                 size as u32,
             ))?;
-            attr.file_size = info.AllocationSize as u64;
+            attr.file_size = info.EndOfFile as u64;
             attr.number_of_links = Some(info.NumberOfLinks);
             if attr.attributes & c::FILE_ATTRIBUTE_REPARSE_POINT != 0 {
                 let mut attr_tag: c::FILE_ATTRIBUTE_TAG_INFO = mem::zeroed();


### PR DESCRIPTION
UWP uses [`GetFileInformationByHandleEx`](https://learn.microsoft.com/en-us/windows/desktop/api/winbase/nf-winbase-getfileinformationbyhandleex) instead of [GetFileInformationByHandle](https://learn.microsoft.com/en-us/windows/desktop/api/fileapi/nf-fileapi-getfileinformationbyhandle), but uses the wrong field to determine file size – `EndOfFile` is a different field than `AllocationSize`. [`file_size`](https://doc.rust-lang.org/nightly/std/os/windows/fs/trait.MetadataExt.html#tymethod.file_size) should report the length of the file, not its size on disk, and only `EndOfFile` reports the former (c.f. https://learn.microsoft.com/en-us/windows/win32/api/FileAPI/nf-fileapi-setendoffile#remarks):

> Each file stream has the following:
> * File size: the size of the data in a file, to the byte.
> * Allocation size: the size of the space that is allocated for a file on a disk, which is always an even multiple of the cluster size.
> * Valid data length: the length of the data in a file that is actually written, to the byte. This value is always less than or equal to the file size.

r? @ChrisDenton