### PR TITLE
[AArch64] FEAT_SVE implies FEAT_FP16

### DIFF
--- a/compiler/rustc_target/src/target_features.rs
+++ b/compiler/rustc_target/src/target_features.rs
@@ -354,7 +354,7 @@ static AARCH64_FEATURES: &[(&str, Stability, ImpliedFeatures)] = &[
     // exist together: https://developer.arm.com/documentation/102340/0100/New-features-in-SVE2
     //
     // "For backwards compatibility, Neon and VFP are required in the latest architectures."
-    ("sve", Stable, &["neon"]),
+    ("sve", Stable, &["neon", "fp16"]),
     // FEAT_SVE_B16B16 (SVE or SME Z-targeting instructions)
     ("sve-b16b16", Unstable(sym::aarch64_unstable_target_feature), &["bf16"]),
     // FEAT_SVE2


### PR DESCRIPTION
LLVM also recognises this: https://github.com/llvm/llvm-project/blob/825950238fffb9549b7fd81700bb241e1473c866/llvm/lib/Target/AArch64/AArch64Features.td#L158
