### PR TITLE
Add new ambiguity error for tools

### DIFF
--- a/compiler/rustc_resolve/src/ident.rs
+++ b/compiler/rustc_resolve/src/ident.rs
@@ -109,7 +109,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             ScopeSet::All(ns)
             | ScopeSet::Module(ns, _)
             | ScopeSet::ModuleAndExternPrelude(ns, _) => (ns, None),
-            ScopeSet::ExternPrelude => (TypeNS, None),
+            ScopeSet::AttrParent | ScopeSet::ExternPrelude => (TypeNS, None),
             ScopeSet::Macro(macro_kind) => (MacroNS, Some(macro_kind)),
         };
         let module = match scope_set {
@@ -124,6 +124,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         let mut scope = match ns {
             _ if module_only || module_and_extern_prelude => Scope::ModuleNonGlobs(module, None),
             _ if extern_prelude => Scope::ExternPreludeItems,
+            _ if matches!(scope_set, ScopeSet::AttrParent) => Scope::ToolPrelude,
             TypeNS | ValueNS => Scope::ModuleNonGlobs(module, None),
             MacroNS => Scope::DeriveHelpers(parent_scope.expansion),
         };
@@ -156,7 +157,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 Scope::ExternPreludeItems | Scope::ExternPreludeFlags => {
                     use_prelude || module_and_extern_prelude || extern_prelude
                 }
-                Scope::ToolPrelude => use_prelude,
+                Scope::ToolPrelude => true,
                 Scope::StdLibPrelude => use_prelude || ns == MacroNS,
                 Scope::BuiltinTypes => true,
             };
@@ -222,8 +223,8 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 Scope::BuiltinAttrs => break, // nowhere else to search
                 Scope::ExternPreludeItems => Scope::ExternPreludeFlags,
                 Scope::ExternPreludeFlags if module_and_extern_prelude || extern_prelude => break,
-                Scope::ExternPreludeFlags => Scope::ToolPrelude,
-                Scope::ToolPrelude => Scope::StdLibPrelude,
+                Scope::ExternPreludeFlags => Scope::StdLibPrelude,
+                Scope::ToolPrelude => Scope::ModuleNonGlobs(module, None),
                 Scope::StdLibPrelude => match ns {
                     TypeNS => Scope::BuiltinTypes,
                     ValueNS => break, // nowhere else to search
@@ -424,7 +425,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             ScopeSet::All(ns)
             | ScopeSet::Module(ns, _)
             | ScopeSet::ModuleAndExternPrelude(ns, _) => (ns, None),
-            ScopeSet::ExternPrelude => (TypeNS, None),
+            ScopeSet::AttrParent | ScopeSet::ExternPrelude => (TypeNS, None),
             ScopeSet::Macro(macro_kind) => (MacroNS, Some(macro_kind)),
         };
         let derive_fallback_lint_id = match finalize {
@@ -720,7 +721,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                     None => Err(Determinacy::Determined),
                 }
             }
-            Scope::ToolPrelude => match self.registered_tool_decls.get(&ident) {
+            Scope::ToolPrelude => match self.registered_tool_decls.get(&ident.name) {
                 Some(decl) => Ok(*decl),
                 None => Err(Determinacy::Determined),
             },
@@ -839,6 +840,10 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
 
         let ambiguity_error_kind = if is_builtin(innermost_res) || is_builtin(res) {
             Some(AmbiguityKind::BuiltinAttr)
+        } else if matches!(innermost_scope, Scope::ToolPrelude)
+            || matches!(scope, Scope::ToolPrelude)
+        {
+            Some(AmbiguityKind::ToolAttr)
         } else if innermost_res == derive_helper_compat {
             Some(AmbiguityKind::DeriveHelper)
         } else if res == derive_helper_compat && innermost_res != derive_helper {
@@ -1947,7 +1952,13 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             } else {
                 self.reborrow().resolve_ident_in_scope_set(
                     ident,
-                    ScopeSet::All(ns),
+                    if opt_ns == Some(MacroNS) && !is_last {
+                        // Resolving parent scope for MacroNS (where all attributes belong to, even
+                        // for tool or built-in macros).
+                        ScopeSet::AttrParent
+                    } else {
+                        ScopeSet::All(ns)
+                    },
                     parent_scope,
                     finalize,
                     ignore_decl,

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -145,7 +145,11 @@ enum Scope<'ra> {
 #[derive(Clone, Copy, Debug)]
 enum ScopeSet<'ra> {
     /// All scopes with the given namespace.
+    ///
+    /// Registered attribute tools are not included; they're available with `AttrParent` only.
     All(Namespace),
+    /// Scopes when resolving for parent scopes for attributes. This is `All` plus registered attribute tools.
+    AttrParent,
     /// Two scopes inside a module, for non-glob and glob bindings.
     Module(Namespace, Module<'ra>),
     /// A module, then extern prelude (used for mixed 2015-2018 mode in macros).
@@ -1082,6 +1086,7 @@ struct DelayedVisResolutionError<'ra> {
 #[derive(Clone, Copy, PartialEq, Debug)]
 enum AmbiguityKind {
     BuiltinAttr,
+    ToolAttr,
     DeriveHelper,
     MacroRulesVsModularized,
     GlobVsOuter,
@@ -1094,6 +1099,7 @@ impl AmbiguityKind {
     fn descr(self) -> &'static str {
         match self {
             AmbiguityKind::BuiltinAttr => "a name conflict with a builtin attribute",
+            AmbiguityKind::ToolAttr => "a name conflict with a tool attribute",
             AmbiguityKind::DeriveHelper => "a name conflict with a derive helper attribute",
             AmbiguityKind::MacroRulesVsModularized => {
                 "a conflict between a `macro_rules` name and a non-`macro_rules` name from another module"
@@ -1423,7 +1429,7 @@ pub struct Resolver<'ra, 'tcx> {
     dummy_decl: Decl<'ra>,
     builtin_type_decls: FxHashMap<Symbol, Decl<'ra>>,
     builtin_attr_decls: FxHashMap<Symbol, Decl<'ra>>,
-    registered_tool_decls: FxHashMap<IdentKey, Decl<'ra>>,
+    registered_tool_decls: FxHashMap<Symbol, Decl<'ra>>,
     macro_names: FxHashSet<IdentKey> = default::fx_hash_set(),
     builtin_macros: FxHashMap<Symbol, SyntaxExtensionKind> = default::fx_hash_map(),
     registered_tools: &'tcx RegisteredTools,
@@ -1845,7 +1851,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 .map(|&ident| {
                     let res = Res::ToolMod;
                     let decl = arenas.new_pub_def_decl(res, ident.span, LocalExpnId::ROOT);
-                    (IdentKey::new(ident), decl)
+                    (ident.name, decl)
                 })
                 .collect(),
             registered_tools,

--- a/tests/ui/diagnostic_namespace/existing_proc_macros.rs
+++ b/tests/ui/diagnostic_namespace/existing_proc_macros.rs
@@ -1,4 +1,3 @@
-//@ check-pass
 //@ proc-macro: proc-macro-helper.rs
 
 extern crate proc_macro_helper;
@@ -16,7 +15,7 @@ mod test2 {
         pub use proc_macro_helper::diagnostic as on_unimplemented;
     }
 
-    #[diagnostic::on_unimplemented]
+    #[diagnostic::on_unimplemented(message = "")] //~ ERROR: ambiguous
     trait Foo {}
 }
 

--- a/tests/ui/diagnostic_namespace/existing_proc_macros.stderr
+++ b/tests/ui/diagnostic_namespace/existing_proc_macros.stderr
@@ -1,0 +1,20 @@
+error[E0659]: `diagnostic` is ambiguous
+  --> $DIR/existing_proc_macros.rs:18:7
+   |
+LL |     #[diagnostic::on_unimplemented(message = "")]
+   |       ^^^^^^^^^^ ambiguous name
+   |
+   = note: ambiguous because of a name conflict with a tool attribute
+   = note: `diagnostic` could refer to a tool module
+note: `diagnostic` could also refer to the module defined here
+  --> $DIR/existing_proc_macros.rs:14:5
+   |
+LL | /     mod diagnostic {
+LL | |         pub use proc_macro_helper::diagnostic as on_unimplemented;
+LL | |     }
+   | |_____^
+   = help: use `self::diagnostic` to refer to this module unambiguously
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0659`.

--- a/tests/ui/resolve/prelude-order.rs
+++ b/tests/ui/resolve/prelude-order.rs
@@ -13,10 +13,10 @@
 Type:
 | ...... |  tool  | extern | macro  | lang   | libs |
 |   tool |    N/A |                   mirror
-| extern | extern |    N/A |             universe
+| extern |      † |    N/A |             universe
 |  macro |    N/A |    N/A |    N/A |
-|   lang |   tool | extern |    N/A |   N/A  |
-|   libs |   tool | extern |    N/A |   X    |  N/A |
+|   lang |      † | extern |    N/A |   N/A  |
+|   libs |      † | extern |    N/A |   X    |  N/A |
 
 Macro:
 | ...... |  tool  | extern | macro  | lang   | libs |
@@ -28,7 +28,7 @@ Macro:
 
 Value: N/A. Only libs has items in the value namespace.
 
-† ambiguous
+† ambiguous if used as attributes
 X don't care (controlled namespace with no overlap)
 
 * Types are tested with `#[name::inner]`. Macros are tested with `#[name]`.
@@ -59,15 +59,15 @@ extern crate macro_helpers as _;
 /* lang and libs implicitly in scope */
 
 // tool/extern -> extern
-#[type_ns::inner] //~ ERROR cannot find `inner` in `type_ns`
+#[type_ns::inner] //~ ERROR ambiguous
 fn t1() {}
 
 // tool/lang -> tool
-#[i8::inner] // ok
+#[i8::inner] //~ ERROR ambiguous
 fn t2() {}
 
 // tool/libs -> tool
-#[Sync::not_real] // ok
+#[Sync::not_real] //~ ERROR ambiguous
 fn t3() {}
 
 // extern/lang -> extern

--- a/tests/ui/resolve/prelude-order.stderr
+++ b/tests/ui/resolve/prelude-order.stderr
@@ -1,9 +1,3 @@
-error[E0433]: cannot find `inner` in `type_ns`
-  --> $DIR/prelude-order.rs:62:12
-   |
-LL | #[type_ns::inner]
-   |            ^^^^^ could not find `inner` in `type_ns`
-
 error[E0433]: cannot find `inner` in `usize`
   --> $DIR/prelude-order.rs:74:10
    |
@@ -20,6 +14,54 @@ help: consider importing this enum instead
    |
 LL + use std::option::Option;
    |
+
+error[E0659]: `type_ns` is ambiguous
+  --> $DIR/prelude-order.rs:62:3
+   |
+LL | #[type_ns::inner]
+   |   ^^^^^^^ ambiguous name
+   |
+   = note: ambiguous because of a name conflict with a tool attribute
+note: `type_ns` could refer to the tool module defined here
+  --> $DIR/prelude-order.rs:46:18
+   |
+LL | #![register_tool(type_ns)] // extern prelude. type.
+   |                  ^^^^^^^
+note: `type_ns` could also refer to the crate imported here
+  --> $DIR/prelude-order.rs:51:1
+   |
+LL | extern crate macro_helpers as type_ns; // tool prelude. type.
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = help: use `crate::type_ns` to refer to this crate unambiguously
+
+error[E0659]: `i8` is ambiguous
+  --> $DIR/prelude-order.rs:66:3
+   |
+LL | #[i8::inner]
+   |   ^^ ambiguous name
+   |
+   = note: ambiguous because of a name conflict with a tool attribute
+   = note: `i8` could refer to a builtin type
+note: `i8` could also refer to the tool module defined here
+  --> $DIR/prelude-order.rs:47:18
+   |
+LL | #![register_tool(i8)]      // lang   prelude. type.
+   |                  ^^
+
+error[E0659]: `Sync` is ambiguous
+  --> $DIR/prelude-order.rs:70:3
+   |
+LL | #[Sync::not_real]
+   |   ^^^^ ambiguous name
+   |
+   = note: ambiguous because of a name conflict with a tool attribute
+note: `Sync` could refer to the tool module defined here
+  --> $DIR/prelude-order.rs:48:18
+   |
+LL | #![register_tool(Sync)]    // libs   prelude. type.
+   |                  ^^^^
+note: `Sync` could also refer to a trait from prelude
+  --> $SRC_DIR/std/src/prelude/mod.rs:LL:COL
 
 error[E0308]: mismatched types
   --> $DIR/prelude-order.rs:83:1
@@ -41,7 +83,7 @@ LL | #[global_allocator]
    |
    = note: this error originates in the attribute macro `global_allocator` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 5 previous errors
+error: aborting due to 7 previous errors
 
-Some errors have detailed explanations: E0308, E0433, E0573.
+Some errors have detailed explanations: E0308, E0433, E0573, E0659.
 For more information about an error, try `rustc --explain E0308`.

--- a/tests/ui/resolve/tool-import.rs
+++ b/tests/ui/resolve/tool-import.rs
@@ -1,8 +1,7 @@
 //@ edition: 2018
 
 use clippy::time::Instant;
-//~^ ERROR: cannot find module `clippy`
-//~| NOTE: `clippy` is a tool module
+//~^ ERROR: cannot find module or crate `clippy`
 
 fn main() {
     Instant::now();

--- a/tests/ui/resolve/tool-import.stderr
+++ b/tests/ui/resolve/tool-import.stderr
@@ -1,8 +1,10 @@
-error[E0433]: cannot find module `clippy` in this scope
+error[E0433]: cannot find module or crate `clippy` in this scope
   --> $DIR/tool-import.rs:3:5
    |
 LL | use clippy::time::Instant;
-   |     ^^^^^^ `clippy` is a tool module, not a module
+   |     ^^^^^^ use of unresolved module or unlinked crate `clippy`
+   |
+   = help: you might be missing a crate named `clippy`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/rust-2018/uniform-paths/auxiliary/cross-crate.rs
+++ b/tests/ui/rust-2018/uniform-paths/auxiliary/cross-crate.rs
@@ -2,4 +2,3 @@
 
 pub use ignore as built_in_attr;
 pub use u8 as built_in_type;
-pub use rustfmt as tool_mod;

--- a/tests/ui/rust-2018/uniform-paths/cross-crate.rs
+++ b/tests/ui/rust-2018/uniform-paths/cross-crate.rs
@@ -5,8 +5,6 @@ extern crate cross_crate;
 use cross_crate::*;
 
 #[built_in_attr] //~ ERROR cannot use a built-in attribute through an import
-#[tool_mod::skip] //~ ERROR cannot use a tool module through an import
-                  //~| ERROR cannot use a tool module through an import
 fn main() {
     let _: built_in_type; // OK
 }

--- a/tests/ui/rust-2018/uniform-paths/cross-crate.stderr
+++ b/tests/ui/rust-2018/uniform-paths/cross-crate.stderr
@@ -10,30 +10,5 @@ note: the built-in attribute imported here
 LL | use cross_crate::*;
    |     ^^^^^^^^^^^^^^
 
-error: cannot use a tool module through an import
-  --> $DIR/cross-crate.rs:8:3
-   |
-LL | #[tool_mod::skip]
-   |   ^^^^^^^^
-   |
-note: the tool module imported here
-  --> $DIR/cross-crate.rs:5:5
-   |
-LL | use cross_crate::*;
-   |     ^^^^^^^^^^^^^^
-
-error: cannot use a tool module through an import
-  --> $DIR/cross-crate.rs:8:3
-   |
-LL | #[tool_mod::skip]
-   |   ^^^^^^^^
-   |
-note: the tool module imported here
-  --> $DIR/cross-crate.rs:5:5
-   |
-LL | use cross_crate::*;
-   |     ^^^^^^^^^^^^^^
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-error: aborting due to 3 previous errors
+error: aborting due to 1 previous error
 

--- a/tests/ui/rust-2018/uniform-paths/prelude-fail-2.rs
+++ b/tests/ui/rust-2018/uniform-paths/prelude-fail-2.rs
@@ -6,16 +6,6 @@ mod builtin {
     pub use inline as imported_inline;
 }
 
-// Tool module
-use rustfmt as imported_rustfmt;
-mod tool_mod {
-    pub use rustfmt as imported_rustfmt;
-}
-
 #[imported_inline] //~ ERROR cannot use a built-in attribute through an import
 #[builtin::imported_inline] //~ ERROR cannot use a built-in attribute through an import
-#[imported_rustfmt::skip] //~ ERROR cannot use a tool module through an import
-                          //~| ERROR cannot use a tool module through an import
-#[tool_mod::imported_rustfmt::skip] //~ ERROR cannot use a tool module through an import
-                                    //~| ERROR cannot use a tool module through an import
 fn main() {}

--- a/tests/ui/rust-2018/uniform-paths/prelude-fail-2.stderr
+++ b/tests/ui/rust-2018/uniform-paths/prelude-fail-2.stderr
@@ -1,5 +1,5 @@
 error: cannot use a built-in attribute through an import
-  --> $DIR/prelude-fail-2.rs:15:3
+  --> $DIR/prelude-fail-2.rs:9:3
    |
 LL | #[imported_inline]
    |   ^^^^^^^^^^^^^^^
@@ -11,60 +11,10 @@ LL | use inline as imported_inline;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: cannot use a built-in attribute through an import
-  --> $DIR/prelude-fail-2.rs:16:3
+  --> $DIR/prelude-fail-2.rs:10:3
    |
 LL | #[builtin::imported_inline]
    |   ^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: cannot use a tool module through an import
-  --> $DIR/prelude-fail-2.rs:17:3
-   |
-LL | #[imported_rustfmt::skip]
-   |   ^^^^^^^^^^^^^^^^
-   |
-note: the tool module imported here
-  --> $DIR/prelude-fail-2.rs:10:5
-   |
-LL | use rustfmt as imported_rustfmt;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: cannot use a tool module through an import
-  --> $DIR/prelude-fail-2.rs:19:13
-   |
-LL | #[tool_mod::imported_rustfmt::skip]
-   |             ^^^^^^^^^^^^^^^^
-   |
-note: the tool module imported here
-  --> $DIR/prelude-fail-2.rs:12:13
-   |
-LL |     pub use rustfmt as imported_rustfmt;
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: cannot use a tool module through an import
-  --> $DIR/prelude-fail-2.rs:17:3
-   |
-LL | #[imported_rustfmt::skip]
-   |   ^^^^^^^^^^^^^^^^
-   |
-note: the tool module imported here
-  --> $DIR/prelude-fail-2.rs:10:5
-   |
-LL | use rustfmt as imported_rustfmt;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-error: cannot use a tool module through an import
-  --> $DIR/prelude-fail-2.rs:19:13
-   |
-LL | #[tool_mod::imported_rustfmt::skip]
-   |             ^^^^^^^^^^^^^^^^
-   |
-note: the tool module imported here
-  --> $DIR/prelude-fail-2.rs:12:13
-   |
-LL |     pub use rustfmt as imported_rustfmt;
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-error: aborting due to 6 previous errors
+error: aborting due to 2 previous errors
 

--- a/tests/ui/rust-2018/uniform-paths/prelude-fail.rs
+++ b/tests/ui/rust-2018/uniform-paths/prelude-fail.rs
@@ -1,5 +1,8 @@
 //@ edition:2018
 
+// Tool
+use rustfmt as imported_rustfmt; //~ ERROR unresolved import `rustfmt`
+
 // Tool attribute
 use rustfmt::skip as imported_rustfmt_skip; //~ ERROR unresolved import `rustfmt`
 

--- a/tests/ui/rust-2018/uniform-paths/prelude-fail.stderr
+++ b/tests/ui/rust-2018/uniform-paths/prelude-fail.stderr
@@ -1,9 +1,19 @@
 error[E0432]: unresolved import `rustfmt`
   --> $DIR/prelude-fail.rs:4:5
    |
-LL | use rustfmt::skip as imported_rustfmt_skip;
-   |     ^^^^^^^ `rustfmt` is a tool module, not a module
+LL | use rustfmt as imported_rustfmt;
+   |     -------^^^^^^^^^^^^^^^^^^^^
+   |     |
+   |     no external crate `rustfmt`
 
-error: aborting due to 1 previous error
+error[E0432]: unresolved import `rustfmt`
+  --> $DIR/prelude-fail.rs:7:5
+   |
+LL | use rustfmt::skip as imported_rustfmt_skip;
+   |     ^^^^^^^ use of unresolved module or unlinked crate `rustfmt`
+   |
+   = help: you might be missing a crate named `rustfmt`
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0432`.

--- a/tests/ui/tool-attributes/tool-attributes-misplaced-1.rs
+++ b/tests/ui/tool-attributes/tool-attributes-misplaced-1.rs
@@ -1,5 +1,5 @@
-type A = rustfmt; //~ ERROR expected type, found tool module `rustfmt`
-type B = rustfmt::skip; //~ ERROR expected type, found tool attribute `rustfmt::skip`
+type A = rustfmt; //~ ERROR cannot find type `rustfmt`
+type B = rustfmt::skip; //~ ERROR cannot find module or crate `rustfmt`
 
 #[derive(rustfmt)] //~ ERROR cannot find derive macro `rustfmt` in this scope
                    //~| ERROR cannot find derive macro `rustfmt` in this scope
@@ -11,8 +11,8 @@ fn check() {}
 
 #[rustfmt::skip] // OK
 fn main() {
-    rustfmt; //~ ERROR expected value, found tool module `rustfmt`
+    rustfmt; //~ ERROR cannot find value `rustfmt`
     rustfmt!(); //~ ERROR cannot find macro `rustfmt` in this scope
 
-    rustfmt::skip; //~ ERROR expected value, found tool attribute `rustfmt::skip`
+    rustfmt::skip; //~ ERROR cannot find module or crate `rustfmt`
 }

--- a/tests/ui/tool-attributes/tool-attributes-misplaced-1.stderr
+++ b/tests/ui/tool-attributes/tool-attributes-misplaced-1.stderr
@@ -24,31 +24,35 @@ error: cannot find macro `rustfmt` in this scope
 LL |     rustfmt!();
    |     ^^^^^^^
 
-error[E0573]: expected type, found tool module `rustfmt`
+error[E0425]: cannot find type `rustfmt` in this scope
   --> $DIR/tool-attributes-misplaced-1.rs:1:10
    |
 LL | type A = rustfmt;
-   |          ^^^^^^^ not a type
+   |          ^^^^^^^ not found in this scope
 
-error[E0573]: expected type, found tool attribute `rustfmt::skip`
-  --> $DIR/tool-attributes-misplaced-1.rs:2:10
-   |
-LL | type B = rustfmt::skip;
-   |          ^^^^^^^^^^^^^ not a type
-
-error[E0423]: expected value, found tool module `rustfmt`
+error[E0425]: cannot find value `rustfmt` in this scope
   --> $DIR/tool-attributes-misplaced-1.rs:14:5
    |
 LL |     rustfmt;
-   |     ^^^^^^^ not a value
+   |     ^^^^^^^ not found in this scope
 
-error[E0423]: expected value, found tool attribute `rustfmt::skip`
+error[E0433]: cannot find module or crate `rustfmt` in this scope
   --> $DIR/tool-attributes-misplaced-1.rs:17:5
    |
 LL |     rustfmt::skip;
-   |     ^^^^^^^^^^^^^ not a value
+   |     ^^^^^^^ use of unresolved module or unlinked crate `rustfmt`
+   |
+   = help: you might be missing a crate named `rustfmt`
+
+error[E0433]: cannot find module or crate `rustfmt` in this scope
+  --> $DIR/tool-attributes-misplaced-1.rs:2:10
+   |
+LL | type B = rustfmt::skip;
+   |          ^^^^^^^ use of unresolved module or unlinked crate `rustfmt`
+   |
+   = help: you might be missing a crate named `rustfmt`
 
 error: aborting due to 8 previous errors
 
-Some errors have detailed explanations: E0423, E0573.
-For more information about an error, try `rustc --explain E0423`.
+Some errors have detailed explanations: E0425, E0433.
+For more information about an error, try `rustc --explain E0425`.

--- a/tests/ui/tool-attributes/tool-attributes-shadowing.rs
+++ b/tests/ui/tool-attributes/tool-attributes-shadowing.rs
@@ -1,4 +1,4 @@
 mod rustfmt {}
 
-#[rustfmt::skip] //~ ERROR: cannot find `skip` in `rustfmt`
+#[rustfmt::skip] //~ ERROR: ambiguous
 fn main() {}

--- a/tests/ui/tool-attributes/tool-attributes-shadowing.stderr
+++ b/tests/ui/tool-attributes/tool-attributes-shadowing.stderr
@@ -1,9 +1,18 @@
-error[E0433]: cannot find `skip` in `rustfmt`
-  --> $DIR/tool-attributes-shadowing.rs:3:12
+error[E0659]: `rustfmt` is ambiguous
+  --> $DIR/tool-attributes-shadowing.rs:3:3
    |
 LL | #[rustfmt::skip]
-   |            ^^^^ could not find `skip` in `rustfmt`
+   |   ^^^^^^^ ambiguous name
+   |
+   = note: ambiguous because of a name conflict with a tool attribute
+   = note: `rustfmt` could refer to a tool module
+note: `rustfmt` could also refer to the module defined here
+  --> $DIR/tool-attributes-shadowing.rs:1:1
+   |
+LL | mod rustfmt {}
+   | ^^^^^^^^^^^^^^
+   = help: use `crate::rustfmt` to refer to this module unambiguously
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0433`.
+For more information about this error, try `rustc --explain E0659`.


### PR DESCRIPTION
Tracking issue: https://github.com/rust-lang/rust/issues/66079

This implements the resolution changes of RFC 3808.

A new ambiguity error is added, and the tool attributes is no longer being affected by `#[no_implicit_prelude]` per the RFC. This is a breaking change.

To avoid widespread ambiguity errors, the attribute tools are only resolved if they are resolved as part of macro path (this could be further split to just attribute macros, but at which point we are kind of adding a new type of namespace?

Mark as draft until the implementation detail is agreed and a crater run is conducted.

r? @petrochenkov
