### PR TITLE
Rollup of 2 pull requests

### DIFF
--- a/compiler/rustc_attr_parsing/src/session_diagnostics.rs
+++ b/compiler/rustc_attr_parsing/src/session_diagnostics.rs
@@ -344,6 +344,10 @@ pub(crate) struct InvalidTarget {
         "this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!"
     )]
     pub previously_accepted: bool,
+    #[note(
+        "placing this attribute on a macro invocation does nothing even if the macro expands to what would be a valid target for the attribute"
+    )]
+    pub on_macro_call: bool,
 }
 
 #[derive(Subdiagnostic)]

--- a/compiler/rustc_attr_parsing/src/target_checking.rs
+++ b/compiler/rustc_attr_parsing/src/target_checking.rs
@@ -129,6 +129,7 @@ impl<'sess> AttributeParser<'sess> {
 
         let allowed_targets = allowed_targets.allowed_targets();
         let (applied, only) = allowed_targets_applied(allowed_targets, cx.target, cx.features);
+
         let diag = InvalidTarget {
             span: cx.attr_span.clone(),
             name: cx.attr_path.clone(),
@@ -138,6 +139,7 @@ impl<'sess> AttributeParser<'sess> {
             attribute_args,
             help: Self::target_checking_help(attribute_args, cx),
             previously_accepted: matches!(result, AllowedResult::Warn),
+            on_macro_call: matches!(cx.target, Target::MacroCall),
         };
 
         match result {

--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -2751,19 +2751,21 @@ pub fn symlink_metadata<P: AsRef<Path>>(path: P) -> io::Result<Metadata> {
 ///
 /// # Platform-specific behavior
 ///
-/// This function currently corresponds to the `rename` function on Unix
-/// and the `MoveFileExW` or `SetFileInformationByHandle` function on Windows.
+/// This function currently corresponds to the [rename] function on Unix, and
+/// `MoveFileExW` with a fallback to `SetFileInformationByHandle` on Windows.
+/// The exact behavior differs:
 ///
-/// Because of this, the behavior when both `from` and `to` exist differs. On
-/// Unix, if `from` is a directory, `to` must also be an (empty) directory. If
-/// `from` is not a directory, `to` must also be not a directory. The behavior
-/// on Windows is the same on Windows 10 1607 and higher if `FileRenameInfoEx`
-/// is supported by the filesystem; otherwise, `from` can be anything, but
-/// `to` must *not* be a directory.
+/// - If `to` does not exist, `from` can be anything.
+/// - On Unix, when `from` is a directory and `to` exists, `to` must be an empty directory.
+/// - On Unix, when `from` is not a directory and `to` exists, `to` may not be a directory.
+/// - On Windows 10 version 1607 and above, the behavior is the same as Unix if the
+///   filesystem supports  `FileRenameInfoEx`.
+/// - Otherwise on Windows, `from` can be anything but `to` must not be a directory.
 ///
 /// Note that, this [may change in the future][changes].
 ///
 /// [changes]: io#platform-specific-behavior
+/// [rename]: https://pubs.opengroup.org/onlinepubs/9799919799/functions/rename.html
 ///
 /// # Errors
 ///

--- a/tests/ui/attributes/attr-on-mac-call.stderr
+++ b/tests/ui/attributes/attr-on-mac-call.stderr
@@ -5,6 +5,7 @@ LL |     #[sanitize(address = "off")]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: `#[sanitize]` can be applied to crates, functions, impl blocks, modules, and statics
+   = note: placing this attribute on a macro invocation does nothing even if the macro expands to what would be a valid target for the attribute
 
 error: crate-level attribute should be an inner attribute: add an exclamation mark: `#![register_tool]`
   --> $DIR/attr-on-mac-call.rs:110:5
@@ -26,6 +27,7 @@ LL |     #[export_name = "x"]
    |
    = help: `#[export_name]` can be applied to functions and statics
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: placing this attribute on a macro invocation does nothing even if the macro expands to what would be a valid target for the attribute
 note: the lint level is defined here
   --> $DIR/attr-on-mac-call.rs:3:9
    |
@@ -40,6 +42,7 @@ LL |     #[unsafe(naked)]
    |
    = help: `#[naked]` can only be applied to functions
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: placing this attribute on a macro invocation does nothing even if the macro expands to what would be a valid target for the attribute
 
 warning: `#[track_caller]` attribute cannot be used on macro calls
   --> $DIR/attr-on-mac-call.rs:14:5
@@ -49,6 +52,7 @@ LL |     #[track_caller]
    |
    = help: `#[track_caller]` can only be applied to functions
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: placing this attribute on a macro invocation does nothing even if the macro expands to what would be a valid target for the attribute
 
 warning: `#[used]` attribute cannot be used on macro calls
   --> $DIR/attr-on-mac-call.rs:17:5
@@ -58,6 +62,7 @@ LL |     #[used]
    |
    = help: `#[used]` can only be applied to statics
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: placing this attribute on a macro invocation does nothing even if the macro expands to what would be a valid target for the attribute
 
 warning: `#[target_feature]` attribute cannot be used on macro calls
   --> $DIR/attr-on-mac-call.rs:20:5
@@ -67,6 +72,7 @@ LL |     #[target_feature(enable = "x")]
    |
    = help: `#[target_feature]` can only be applied to functions
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: placing this attribute on a macro invocation does nothing even if the macro expands to what would be a valid target for the attribute
 
 warning: `#[deprecated]` attribute cannot be used on macro calls
   --> $DIR/attr-on-mac-call.rs:23:5
@@ -76,6 +82,7 @@ LL |     #[deprecated]
    |
    = help: `#[deprecated]` can be applied to associated consts, associated types, constants, crates, data types, enum variants, foreign statics, functions, inherent impl blocks, macro defs, modules, statics, struct fields, traits, type aliases, and use statements
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: placing this attribute on a macro invocation does nothing even if the macro expands to what would be a valid target for the attribute
 
 warning: `#[inline]` attribute cannot be used on macro calls
   --> $DIR/attr-on-mac-call.rs:26:5
@@ -85,6 +92,7 @@ LL |     #[inline]
    |
    = help: `#[inline]` can only be applied to functions
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: placing this attribute on a macro invocation does nothing even if the macro expands to what would be a valid target for the attribute
 
 warning: `#[link_name]` attribute cannot be used on macro calls
   --> $DIR/attr-on-mac-call.rs:29:5
@@ -94,6 +102,7 @@ LL |     #[link_name = "x"]
    |
    = help: `#[link_name]` can be applied to foreign functions and foreign statics
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: placing this attribute on a macro invocation does nothing even if the macro expands to what would be a valid target for the attribute
 
 warning: `#[link_section]` attribute cannot be used on macro calls
   --> $DIR/attr-on-mac-call.rs:32:5
@@ -103,6 +112,7 @@ LL |     #[link_section = "__TEXT,__text"]
    |
    = help: `#[link_section]` can be applied to functions and statics
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: placing this attribute on a macro invocation does nothing even if the macro expands to what would be a valid target for the attribute
 
 warning: `#[link_ordinal]` attribute cannot be used on macro calls
   --> $DIR/attr-on-mac-call.rs:35:5
@@ -112,6 +122,7 @@ LL |     #[link_ordinal(42)]
    |
    = help: `#[link_ordinal]` can be applied to foreign functions and foreign statics
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: placing this attribute on a macro invocation does nothing even if the macro expands to what would be a valid target for the attribute
 
 warning: `#[non_exhaustive]` attribute cannot be used on macro calls
   --> $DIR/attr-on-mac-call.rs:38:5
@@ -121,6 +132,7 @@ LL |     #[non_exhaustive]
    |
    = help: `#[non_exhaustive]` can be applied to data types and enum variants
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: placing this attribute on a macro invocation does nothing even if the macro expands to what would be a valid target for the attribute
 
 warning: `#[proc_macro]` attribute cannot be used on macro calls
   --> $DIR/attr-on-mac-call.rs:41:5
@@ -130,6 +142,7 @@ LL |     #[proc_macro]
    |
    = help: `#[proc_macro]` can only be applied to functions
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: placing this attribute on a macro invocation does nothing even if the macro expands to what would be a valid target for the attribute
 
 warning: `#[cold]` attribute cannot be used on macro calls
   --> $DIR/attr-on-mac-call.rs:44:5
@@ -139,6 +152,7 @@ LL |     #[cold]
    |
    = help: `#[cold]` can only be applied to functions
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: placing this attribute on a macro invocation does nothing even if the macro expands to what would be a valid target for the attribute
 
 warning: `#[no_mangle]` attribute cannot be used on macro calls
   --> $DIR/attr-on-mac-call.rs:47:5
@@ -148,6 +162,7 @@ LL |     #[no_mangle]
    |
    = help: `#[no_mangle]` can be applied to functions and statics
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: placing this attribute on a macro invocation does nothing even if the macro expands to what would be a valid target for the attribute
 
 warning: `#[deprecated]` attribute cannot be used on macro calls
   --> $DIR/attr-on-mac-call.rs:50:5
@@ -157,6 +172,7 @@ LL |     #[deprecated]
    |
    = help: `#[deprecated]` can be applied to associated consts, associated types, constants, crates, data types, enum variants, foreign statics, functions, inherent impl blocks, macro defs, modules, statics, struct fields, traits, type aliases, and use statements
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: placing this attribute on a macro invocation does nothing even if the macro expands to what would be a valid target for the attribute
 
 warning: `#[automatically_derived]` attribute cannot be used on macro calls
   --> $DIR/attr-on-mac-call.rs:53:5
@@ -166,6 +182,7 @@ LL |     #[automatically_derived]
    |
    = help: `#[automatically_derived]` can only be applied to trait impl blocks
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: placing this attribute on a macro invocation does nothing even if the macro expands to what would be a valid target for the attribute
 
 warning: `#[macro_use]` attribute cannot be used on macro calls
   --> $DIR/attr-on-mac-call.rs:56:5
@@ -175,6 +192,7 @@ LL |     #[macro_use]
    |
    = help: `#[macro_use]` can be applied to extern crates and modules
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: placing this attribute on a macro invocation does nothing even if the macro expands to what would be a valid target for the attribute
 
 warning: `#[must_use]` attribute cannot be used on macro calls
   --> $DIR/attr-on-mac-call.rs:59:5
@@ -184,6 +202,7 @@ LL |     #[must_use]
    |
    = help: `#[must_use]` can be applied to data types, functions, and traits
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: placing this attribute on a macro invocation does nothing even if the macro expands to what would be a valid target for the attribute
 
 warning: `#[no_implicit_prelude]` attribute cannot be used on macro calls
   --> $DIR/attr-on-mac-call.rs:62:5
@@ -193,6 +212,7 @@ LL |     #[no_implicit_prelude]
    |
    = help: `#[no_implicit_prelude]` can be applied to crates and modules
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: placing this attribute on a macro invocation does nothing even if the macro expands to what would be a valid target for the attribute
 
 warning: `#[path]` attribute cannot be used on macro calls
   --> $DIR/attr-on-mac-call.rs:65:5
@@ -202,6 +222,7 @@ LL |     #[path = ""]
    |
    = help: `#[path]` can only be applied to modules
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: placing this attribute on a macro invocation does nothing even if the macro expands to what would be a valid target for the attribute
 
 warning: `#[ignore]` attribute cannot be used on macro calls
   --> $DIR/attr-on-mac-call.rs:68:5
@@ -211,6 +232,7 @@ LL |     #[ignore]
    |
    = help: `#[ignore]` can only be applied to functions
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: placing this attribute on a macro invocation does nothing even if the macro expands to what would be a valid target for the attribute
 
 warning: `#[should_panic]` attribute cannot be used on macro calls
   --> $DIR/attr-on-mac-call.rs:71:5
@@ -220,6 +242,7 @@ LL |     #[should_panic]
    |
    = help: `#[should_panic]` can only be applied to functions
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: placing this attribute on a macro invocation does nothing even if the macro expands to what would be a valid target for the attribute
 
 warning: `#[link_name]` attribute cannot be used on macro calls
   --> $DIR/attr-on-mac-call.rs:74:5
@@ -229,6 +252,7 @@ LL |     #[link_name = "x"]
    |
    = help: `#[link_name]` can be applied to foreign functions and foreign statics
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: placing this attribute on a macro invocation does nothing even if the macro expands to what would be a valid target for the attribute
 
 warning: `#[repr()]` attribute cannot be used on macro calls
   --> $DIR/attr-on-mac-call.rs:81:5
@@ -238,6 +262,7 @@ LL |     #[repr()]
    |
    = help: `#[repr()]` can only be applied to data types
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: placing this attribute on a macro invocation does nothing even if the macro expands to what would be a valid target for the attribute
 
 warning: unused attribute
   --> $DIR/attr-on-mac-call.rs:81:5
@@ -255,6 +280,7 @@ LL |     #[repr(u8)]
    |
    = help: `#[repr(u8)]` can only be applied to enums
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: placing this attribute on a macro invocation does nothing even if the macro expands to what would be a valid target for the attribute
 
 warning: `#[repr(align(...))]` attribute cannot be used on macro calls
   --> $DIR/attr-on-mac-call.rs:90:5
@@ -264,6 +290,7 @@ LL |     #[repr(align(8))]
    |
    = help: `#[repr(align(...))]` can only be applied to data types
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: placing this attribute on a macro invocation does nothing even if the macro expands to what would be a valid target for the attribute
 
 warning: `#[repr(packed)]` attribute cannot be used on macro calls
   --> $DIR/attr-on-mac-call.rs:94:5
@@ -273,6 +300,7 @@ LL |     #[repr(packed)]
    |
    = help: `#[repr(packed)]` can only be applied to data types
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: placing this attribute on a macro invocation does nothing even if the macro expands to what would be a valid target for the attribute
 
 warning: `#[repr(C)]` attribute cannot be used on macro calls
   --> $DIR/attr-on-mac-call.rs:98:5
@@ -282,6 +310,7 @@ LL |     #[repr(C)]
    |
    = help: `#[repr(C)]` can only be applied to data types
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: placing this attribute on a macro invocation does nothing even if the macro expands to what would be a valid target for the attribute
 
 warning: `#[repr(Rust)]` attribute cannot be used on macro calls
   --> $DIR/attr-on-mac-call.rs:102:5
@@ -291,6 +320,7 @@ LL |     #[repr(Rust)]
    |
    = help: `#[repr(Rust)]` can only be applied to data types
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: placing this attribute on a macro invocation does nothing even if the macro expands to what would be a valid target for the attribute
 
 warning: `#[repr(simd)]` attribute cannot be used on macro calls
   --> $DIR/attr-on-mac-call.rs:106:5
@@ -300,6 +330,7 @@ LL |     #[repr(simd)]
    |
    = help: `#[repr(simd)]` can only be applied to structs
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: placing this attribute on a macro invocation does nothing even if the macro expands to what would be a valid target for the attribute
 
 error: aborting due to 2 previous errors; 31 warnings emitted
 

--- a/tests/ui/feature-gates/feature-gate-check-nested-macro-invocation.stderr
+++ b/tests/ui/feature-gates/feature-gate-check-nested-macro-invocation.stderr
@@ -21,6 +21,7 @@ LL | foo!();
    | ------ in this macro invocation
    |
    = help: `#[allow_internal_unstable]` can be applied to functions and macro defs
+   = note: placing this attribute on a macro invocation does nothing even if the macro expands to what would be a valid target for the attribute
    = note: this error originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors

--- a/tests/ui/lint/inert-attr-macro.stderr
+++ b/tests/ui/lint/inert-attr-macro.stderr
@@ -6,6 +6,7 @@ LL |     #[inline] foo!();
    |
    = help: `#[inline]` can only be applied to functions
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: placing this attribute on a macro invocation does nothing even if the macro expands to what would be a valid target for the attribute
 note: the lint level is defined here
   --> $DIR/inert-attr-macro.rs:3:9
    |
@@ -33,6 +34,7 @@ LL |     #[allow(warnings)] #[inline] foo!();
    |
    = help: `#[inline]` can only be applied to functions
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: placing this attribute on a macro invocation does nothing even if the macro expands to what would be a valid target for the attribute
 
 warning: 3 warnings emitted
 

--- a/tests/ui/lint/unused/unused_attributes-must_use.stderr
+++ b/tests/ui/lint/unused/unused_attributes-must_use.stderr
@@ -6,6 +6,7 @@ LL | #[must_use]
    |
    = help: `#[must_use]` can be applied to data types, functions, and traits
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: placing this attribute on a macro invocation does nothing even if the macro expands to what would be a valid target for the attribute
 note: the lint level is defined here
   --> $DIR/unused_attributes-must_use.rs:4:9
    |

--- a/tests/ui/pin-ergonomics/pin_v2-attr.stderr
+++ b/tests/ui/pin-ergonomics/pin_v2-attr.stderr
@@ -5,6 +5,7 @@ LL | #[pin_v2]
    | ^^^^^^^^^
    |
    = help: `#[pin_v2]` can only be applied to data types
+   = note: placing this attribute on a macro invocation does nothing even if the macro expands to what would be a valid target for the attribute
 
 error: allow, cfg, cfg_attr, deny, expect, forbid, and warn are the only allowed built-in attributes in function parameters
   --> $DIR/pin_v2-attr.rs:84:12


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#149267 (fix: clarify that fs::rename on unix accepts targets that don't exist)
 - rust-lang/rust#158106 (Expand diagnostic for attributes on macro calls)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=149267,158106)
<!-- homu-ignore:end -->

