### PR TITLE
avoid spurious lifetime diagnostic in async generic case

### DIFF
--- a/compiler/rustc_borrowck/src/region_infer/mod.rs
+++ b/compiler/rustc_borrowck/src/region_infer/mod.rs
@@ -594,6 +594,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
         // result in basically the exact same error being reported to
         // the user. Avoid that.
         let mut deduplicate_errors = FxIndexSet::default();
+        let mut failed_type_tests = Vec::new();
 
         for type_test in &self.type_tests {
             debug!("check_type_test: {:?}", type_test);
@@ -616,6 +617,28 @@ impl<'tcx> RegionInferenceContext<'tcx> {
 
             // Type-test failed. Report the error.
             let erased_generic_kind = infcx.tcx.erase_and_anonymize_regions(type_test.generic_kind);
+            failed_type_tests.push((erased_generic_kind, type_test));
+        }
+
+        let static_scc = self.constraint_sccs.scc(self.universal_regions().fr_static);
+        let static_bound_errors: FxIndexSet<_> = failed_type_tests
+            .iter()
+            .filter_map(|&(erased_generic_kind, type_test)| {
+                if self.constraint_sccs.scc(type_test.lower_bound) == static_scc {
+                    Some((erased_generic_kind, type_test.span))
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        // If `G: 'static` failed at this span, then same-span `G: 'a` failures are weaker.
+        for (erased_generic_kind, type_test) in failed_type_tests {
+            if self.constraint_sccs.scc(type_test.lower_bound) != static_scc
+                && static_bound_errors.contains(&(erased_generic_kind, type_test.span))
+            {
+                continue;
+            }
 
             // Skip duplicate-ish errors.
             if deduplicate_errors.insert((

--- a/compiler/rustc_borrowck/src/region_infer/mod.rs
+++ b/compiler/rustc_borrowck/src/region_infer/mod.rs
@@ -589,6 +589,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
         // result in basically the exact same error being reported to
         // the user. Avoid that.
         let mut deduplicate_errors = FxIndexSet::default();
+        let mut failed_type_tests = Vec::new();
 
         for type_test in &self.type_tests {
             debug!("check_type_test: {:?}", type_test);
@@ -609,8 +610,40 @@ impl<'tcx> RegionInferenceContext<'tcx> {
                 continue;
             }
 
-            // Type-test failed. Report the error.
+            // Type-test failed. Collect it so we can suppress redundant errors below.
             let erased_generic_kind = infcx.tcx.erase_and_anonymize_regions(type_test.generic_kind);
+            failed_type_tests.push((erased_generic_kind, type_test));
+        }
+
+        // An async body can produce both `G: 'static` and `G: 'a` type-test failures at
+        // the same span, as in `tests/ui/async-await/spurious-static-bound-issue-115376.rs`.
+        // Reporting the weaker bound adds a redundant diagnostic and suggests a lifetime
+        // bound that cannot fix the missing `G: 'static` requirement. Keep the `'static`
+        // error and suppress weaker failures for the same erased generic kind and span.
+        // This is a diagnostic heuristic, using the same erasure as deduplication below.
+        //
+        // Collect all failed `'static` bounds before reporting errors so suppression does
+        // not depend on the order of the type tests. Compare SCCs because a lower-bound
+        // region can be equivalent to `'static` without being `fr_static` itself.
+        let static_scc = self.constraint_sccs.scc(self.universal_regions().fr_static);
+        let static_bound_errors: FxIndexSet<_> = failed_type_tests
+            .iter()
+            .filter_map(|&(erased_generic_kind, type_test)| {
+                if self.constraint_sccs.scc(type_test.lower_bound) == static_scc {
+                    Some((erased_generic_kind, type_test.span))
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        // If `G: 'static` failed at this span, then same-span `G: 'a` failures are weaker.
+        for (erased_generic_kind, type_test) in failed_type_tests {
+            if self.constraint_sccs.scc(type_test.lower_bound) != static_scc
+                && static_bound_errors.contains(&(erased_generic_kind, type_test.span))
+            {
+                continue;
+            }
 
             // Skip duplicate-ish errors.
             if deduplicate_errors.insert((

--- a/tests/ui/async-await/spurious-static-bound-issue-115376.rs
+++ b/tests/ui/async-await/spurious-static-bound-issue-115376.rs
@@ -1,0 +1,8 @@
+//@ edition: 2021
+
+async fn test<T>(_: &u8) {
+    let _: &'static T;
+    //~^ ERROR the parameter type `T` may not live long enough
+}
+
+fn main() {}

--- a/tests/ui/async-await/spurious-static-bound-issue-115376.stderr
+++ b/tests/ui/async-await/spurious-static-bound-issue-115376.stderr
@@ -1,0 +1,17 @@
+error[E0310]: the parameter type `T` may not live long enough
+  --> $DIR/spurious-static-bound-issue-115376.rs:4:12
+   |
+LL |     let _: &'static T;
+   |            ^^^^^^^^^^
+   |            |
+   |            the parameter type `T` must be valid for the static lifetime...
+   |            ...so that the type `T` will meet its required lifetime bounds
+   |
+help: consider adding an explicit lifetime bound
+   |
+LL | async fn test<T: 'static>(_: &u8) {
+   |                +++++++++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0310`.

--- a/tests/ui/borrowck/unconstrained-closure-lifetime-generic.rs
+++ b/tests/ui/borrowck/unconstrained-closure-lifetime-generic.rs
@@ -14,7 +14,6 @@ impl Foo {
         //~| ERROR the parameter type `impl for<'a> Fn(&'a usize) -> Box<I>` may not live long enough
         //~| ERROR the parameter type `I` may not live long enough
         //~| ERROR the parameter type `I` may not live long enough
-        //~| ERROR the parameter type `I` may not live long enough
         //~| ERROR `f` does not live long enough
     }
 }

--- a/tests/ui/borrowck/unconstrained-closure-lifetime-generic.stderr
+++ b/tests/ui/borrowck/unconstrained-closure-lifetime-generic.stderr
@@ -84,19 +84,6 @@ help: consider adding an explicit lifetime bound
 LL |     pub fn ack<I: 'static>(&mut self, f: impl for<'a> Fn(&'a usize) -> Box<I>) {
    |                 +++++++++
 
-error[E0311]: the parameter type `I` may not live long enough
-  --> $DIR/unconstrained-closure-lifetime-generic.rs:10:35
-   |
-LL |     pub fn ack<I>(&mut self, f: impl for<'a> Fn(&'a usize) -> Box<I>) {
-   |                   --------- the parameter type `I` must be valid for the anonymous lifetime defined here...
-LL |         self.bar = Box::new(|baz| Box::new(f(baz)));
-   |                                   ^^^^^^^^^^^^^^^^ ...so that the type `I` will meet its required lifetime bounds
-   |
-help: consider adding an explicit lifetime bound
-   |
-LL |     pub fn ack<'a, I: 'a>(&'a mut self, f: impl for<'a> Fn(&'a usize) -> Box<I>) {
-   |                +++  ++++   ++
-
 error[E0597]: `f` does not live long enough
   --> $DIR/unconstrained-closure-lifetime-generic.rs:10:44
    |
@@ -113,7 +100,7 @@ LL |     }
    |
    = note: due to object lifetime defaults, `Box<dyn for<'a> Fn(&'a usize) -> Box<(dyn Any + 'a)>>` actually means `Box<(dyn for<'a> Fn(&'a usize) -> Box<(dyn Any + 'a)> + 'static)>`
 
-error: aborting due to 8 previous errors
+error: aborting due to 7 previous errors
 
-Some errors have detailed explanations: E0310, E0311, E0597.
+Some errors have detailed explanations: E0310, E0597.
 For more information about an error, try `rustc --explain E0310`.


### PR DESCRIPTION
Fixes rust-lang/rust#115376.

Issue rust-lang/rust#115376 reports duplicate lifetime diagnostics for a small async generic example where rustc already emits the real `T: 'static` error. Additionally, it emits diagnostics requiring the same generic type to outlive a shorter anonymous lifetime

My PR keeps the real static-bound diagnostic and filters same-span weaker type-test diagnostics for the same generic when the failed `G: 'static` bound already covers them. New regression test verifies that the async example emits only the real E0310 diagnostic. One existing borrowck test was updated for the same diagnostic cleanup