### PR TITLE
Fix wrong rounding behaviour about div_euclid with fma operation.

### DIFF
--- a/library/core/src/num/f128.rs
+++ b/library/core/src/num/f128.rs
@@ -1867,11 +1867,21 @@ impl f128 {
     #[unstable(feature = "f128", issue = "116909")]
     #[must_use = "method returns a new number and does not mutate the original value"]
     pub fn div_euclid(self, rhs: f128) -> f128 {
-        let q = (self / rhs).trunc();
-        if self % rhs < 0.0 {
-            return if rhs > 0.0 { q - 1.0 } else { q + 1.0 };
+        // Use floor() directly as the initial guess (Euclidean division
+        // with positive divisor is the same as floor division).
+        let q = (self / rhs).floor();
+        // Compute b * q - a with a single rounding error.
+        let diff = rhs.mul_add(q, -self);
+        if diff > 0.0 { // take care of NaN: NaN > 0.0 is false, keeping the return result.
+            if rhs > 0.0 {
+                // q was one unit too high – move down to the next representable value.
+                q.next_down().floor()
+            } else {
+                q.next_up().ceil()
+            }
+        } else {
+            q
         }
-        q
     }
 
     /// Calculates the least nonnegative remainder of `self` when

--- a/library/core/src/num/f16.rs
+++ b/library/core/src/num/f16.rs
@@ -1853,11 +1853,21 @@ impl f16 {
     #[unstable(feature = "f16", issue = "116909")]
     #[must_use = "method returns a new number and does not mutate the original value"]
     pub fn div_euclid(self, rhs: f16) -> f16 {
-        let q = (self / rhs).trunc();
-        if self % rhs < 0.0 {
-            return if rhs > 0.0 { q - 1.0 } else { q + 1.0 };
+        // Use floor() directly as the initial guess (Euclidean division
+        // with positive divisor is the same as floor division).
+        let q = (self / rhs).floor();
+        // Compute b * q - a with a single rounding error.
+        let diff = rhs.mul_add(q, -self);
+        if diff > 0.0 { // take care of NaN: NaN > 0.0 is false, keeping the return result.
+            if rhs > 0.0 {
+                // q was one unit too high – move down to the next representable value.
+                q.next_down().floor()
+            } else {
+                q.next_up().ceil()
+            }
+        } else {
+            q
         }
-        q
     }
 
     /// Calculates the least nonnegative remainder of `self` when

--- a/library/core/src/num/f32.rs
+++ b/library/core/src/num/f32.rs
@@ -2007,11 +2007,21 @@ pub mod math {
     #[unstable(feature = "core_float_math", issue = "137578")]
     #[must_use = "method returns a new number and does not mutate the original value"]
     pub fn div_euclid(x: f32, rhs: f32) -> f32 {
-        let q = trunc(x / rhs);
-        if x % rhs < 0.0 {
-            return if rhs > 0.0 { q - 1.0 } else { q + 1.0 };
+        // Use floor() directly as the initial guess (Euclidean division
+        // with positive divisor is the same as floor division).
+        let q = (x / rhs).floor();
+        // Compute b * q - a with a single rounding error.
+        let diff = rhs.mul_add(q, -x);
+        if diff > 0.0 { // take care of NaN: NaN > 0.0 is false, keeping the return result.
+            if rhs > 0.0 {
+                // q was one unit too high – move down to the next representable value.
+                q.next_down().floor()
+            } else {
+                q.next_up().ceil()
+            }
+        } else {
+            q
         }
-        q
     }
 
     /// Experimental version of `rem_euclid` in `core`. See [`f32::rem_euclid`] for details.

--- a/library/core/src/num/f64.rs
+++ b/library/core/src/num/f64.rs
@@ -1987,11 +1987,21 @@ pub mod math {
     #[unstable(feature = "core_float_math", issue = "137578")]
     #[must_use = "method returns a new number and does not mutate the original value"]
     pub fn div_euclid(x: f64, rhs: f64) -> f64 {
-        let q = trunc(x / rhs);
-        if x % rhs < 0.0 {
-            return if rhs > 0.0 { q - 1.0 } else { q + 1.0 };
+        // Use floor() directly as the initial guess (Euclidean division
+        // with positive divisor is the same as floor division).
+        let q = (x / rhs).floor();
+        // Compute b * q - a with a single rounding error.
+        let diff = rhs.mul_add(q, -x);
+        if diff > 0.0 { // take care of NaN: NaN > 0.0 is false, keeping the return result.
+            if rhs > 0.0 {
+                // q was one unit too high – move down to the next representable value.
+                q.next_down().floor()
+            } else {
+                q.next_up().ceil()
+            }
+        } else {
+            q
         }
-        q
     }
 
     /// Experimental version of `rem_euclid` in `core`. See [`f64::rem_euclid`] for details.

--- a/library/coretests/tests/num/floats.rs
+++ b/library/coretests/tests/num/floats.rs
@@ -995,6 +995,22 @@ float_test! {
 }
 
 float_test! {
+    name: div_rem_euclid,
+    attrs: {
+        const: #[cfg(false)],
+        // Miri only uses softfloats here, so that always works
+        f16: #[cfg(any(miri, target_has_reliable_f16_math))],
+        f128: #[cfg(any(miri, target_has_reliable_f128_math))],
+    },
+    test {
+        assert_approx_eq!(flt(11.0).div_euclid(flt(2.2)) * flt(2.2) + flt(11.0).rem_euclid(flt(2.2)), flt(11.0));
+        assert_approx_eq!(flt(12.0).div_euclid(flt(2.4)) * flt(2.4) + flt(12.0).rem_euclid(flt(2.4)), flt(12.0));
+        assert_approx_eq!(flt(13.0).div_euclid(flt(2.6)) * flt(2.6) + flt(13.0).rem_euclid(flt(2.6)), flt(13.0));
+        assert_approx_eq!(flt(14.0).div_euclid(flt(2.8)) * flt(2.8) + flt(14.0).rem_euclid(flt(2.8)), flt(14.0));
+    }
+}
+
+float_test! {
     name: floor,
     attrs: {
         // Miri only uses softfloats here, so that always works


### PR DESCRIPTION
Fixes 107904. Code are written manually and PR summarized by deepseek V4.

(Since my English is not very well, the rest of PR are generated by deepseek.)

## Problem

`f32::div_euclid` and `f64::div_euclid` can return an incorrect quotient when the
intermediate division `a / b` is rounded by the hardware to a value that
crosses an integer boundary. This happens because the current implementation
uses `(a / b).trunc()` as the initial guess and then adjusts based on the
remainder sign. If `a / b` is already wrong by one unit in the last place
(especially near multiples of 1.0), the final result may be off by 1.

### Minimal example

```rust
let a = 11.0f32;
let b = 2.2f32;
// 2.2f32 is actually slightly larger than 2.2, so a / b ≈ 4.99999989...
// which is rounded to 5.0 by the default round-ties-to-even mode.
assert_eq!(a.div_euclid(b), 5.0); // wrong, mathematical quotient is 4
```

The true Euclidean quotient (floor division for positive b) should be 4.0.

## Proposed Solution

Replace the naive `(a / b).trunc()` step with a guarded computation that
detects and corrects this specific rounding error.

For `f32` the new implementation is:

```
    pub fn div_euclid(x: f32, rhs: f32) -> f32 {
        // Use floor() directly as the initial guess (Euclidean division
        // with positive divisor is the same as floor division).
        let q = (x / rhs).floor();
        // Compute b * q - a with a single rounding error.
        let diff = rhs.mul_add(q, -x);
        if diff > 0.0 { // take care of NaN: NaN > 0.0 is false, keeping the return result.
            if rhs > 0.0 {
                // q was one unit too high – move down to the next representable value.
                q.next_down().floor()
            } else {
                q.next_up().ceil()
            }
        } else {
            q
        }
    }
```

Things are similar to other float types.

Why this works:

* `diff = b * q - a` is computed with a single rounding (via mul_add).
*  If `q` is truly less than or equal to `a / b`, then `diff <= 0.0`.
*  If `q` is one integer above the true quotient, `diff > 0.0` and we adjust `q` by moving one floating-point unit towards zero before reapplying the rounding (`.floor()` or `.ceil()` as appropriate).