### PR TITLE
Use the direct `From` in `Clone for OnceLock<T>`

### DIFF
--- a/library/std/src/sync/once_lock.rs
+++ b/library/std/src/sync/once_lock.rs
@@ -626,14 +626,7 @@ impl<T: fmt::Debug> fmt::Debug for OnceLock<T> {
 impl<T: Clone> Clone for OnceLock<T> {
     #[inline]
     fn clone(&self) -> OnceLock<T> {
-        let cell = Self::new();
-        if let Some(value) = self.get() {
-            match cell.set(value.clone()) {
-                Ok(()) => (),
-                Err(_) => unreachable!(),
-            }
-        }
-        cell
+        self.get().cloned().map_or_default(Self::from)
     }
 }
 


### PR DESCRIPTION
This is a followup to rust-lang/rust#158101 as again, the complexity of `set` is not necessary here, especially because we can now use that direct `From`.

r? tgross35