### PR TITLE
Fix too-short variance slice in `variances_of` cycle recovery

### DIFF
--- a/compiler/rustc_query_impl/src/handle_cycle_error.rs
+++ b/compiler/rustc_query_impl/src/handle_cycle_error.rs
@@ -104,7 +104,7 @@ pub(crate) fn variances_of<'tcx>(
     err: Diag<'_>,
 ) -> &'tcx [ty::Variance] {
     let _guar = err.delay_as_bug();
-    let n = tcx.generics_of(def_id).own_params.len();
+    let n = tcx.generics_of(def_id).count();
     tcx.arena.alloc_from_iter(iter::repeat_n(ty::Bivariant, n))
 }
 


### PR DESCRIPTION
This changes the cycle-error fallback in `variances_of` to size the slice the same way the provider does in [`variance/solve.rs:117`](https://github.com/rust-lang/rust/blob/32ea3615cc027bcb8fd720c7511ffb484f6223a3/compiler/rustc_hir_analysis/src/variance/solve.rs#L117). 


This can otherwise ICE under the parallel frontend in `relate_args_with_variances` for items that inherit their generics from a parent (like a tuple struct constructor). See https://github.com/rust-lang/rust/issues/154560#issuecomment-4749155547