### PR TITLE
update `asm_experimental_reg` comments

### DIFF
--- a/src/doc/unstable-book/src/language-features/asm-experimental-reg.md
+++ b/src/doc/unstable-book/src/language-features/asm-experimental-reg.md
@@ -1,4 +1,4 @@
-# `asm_experimental_arch`
+# `asm_experimental_reg`
 
 The tracking issue for this feature is: [#133416]
 

--- a/tests/ui/asm/s390x/bad-reg.rs
+++ b/tests/ui/asm/s390x/bad-reg.rs
@@ -68,13 +68,13 @@ fn f() {
 
         // vreg
         asm!("", out("v0") _); // always ok
-        asm!("", in("v0") v); // requires vector & asm_experimental_reg
+        asm!("", in("v0") v);
         //[s390x]~^ ERROR register class `vreg` requires the `vector` target feature
-        asm!("", out("v0") v); // requires vector & asm_experimental_reg
+        asm!("", out("v0") v);
         //[s390x]~^ ERROR register class `vreg` requires the `vector` target feature
-        asm!("", in("v0") x); // requires vector & asm_experimental_reg
+        asm!("", in("v0") x);
         //[s390x]~^ ERROR register class `vreg` requires the `vector` target feature
-        asm!("", out("v0") x); // requires vector & asm_experimental_reg
+        asm!("", out("v0") x);
         //[s390x]~^ ERROR register class `vreg` requires the `vector` target feature
         asm!("", in("v0") b);
         //[s390x]~^ ERROR register class `vreg` requires the `vector` target feature
@@ -82,14 +82,14 @@ fn f() {
         asm!("", out("v0") b);
         //[s390x]~^ ERROR register class `vreg` requires the `vector` target feature
         //[s390x_vector]~^^ ERROR type `u8` cannot be used with this register class
-        asm!("/* {} */", in(vreg) v); // requires vector & asm_experimental_reg
+        asm!("/* {} */", in(vreg) v);
         //[s390x]~^ ERROR register class `vreg` requires the `vector` target feature
-        asm!("/* {} */", in(vreg) x); // requires vector & asm_experimental_reg
+        asm!("/* {} */", in(vreg) x);
         //[s390x]~^ ERROR register class `vreg` requires the `vector` target feature
         asm!("/* {} */", in(vreg) b);
         //[s390x]~^ ERROR register class `vreg` requires the `vector` target feature
         //[s390x_vector]~^^ ERROR type `u8` cannot be used with this register class
-        asm!("/* {} */", out(vreg) _); // requires vector & asm_experimental_reg
+        asm!("/* {} */", out(vreg) _);
         //[s390x]~^ ERROR register class `vreg` requires the `vector` target feature
 
         // Clobber-only registers

--- a/tests/ui/asm/s390x/bad-reg.s390x.stderr
+++ b/tests/ui/asm/s390x/bad-reg.s390x.stderr
@@ -279,25 +279,25 @@ LL |         asm!("", out("v16") _, out("f16") _);
 error: register class `vreg` requires the `vector` target feature
   --> $DIR/bad-reg.rs:71:18
    |
-LL |         asm!("", in("v0") v); // requires vector & asm_experimental_reg
+LL |         asm!("", in("v0") v);
    |                  ^^^^^^^^^^
 
 error: register class `vreg` requires the `vector` target feature
   --> $DIR/bad-reg.rs:73:18
    |
-LL |         asm!("", out("v0") v); // requires vector & asm_experimental_reg
+LL |         asm!("", out("v0") v);
    |                  ^^^^^^^^^^^
 
 error: register class `vreg` requires the `vector` target feature
   --> $DIR/bad-reg.rs:75:18
    |
-LL |         asm!("", in("v0") x); // requires vector & asm_experimental_reg
+LL |         asm!("", in("v0") x);
    |                  ^^^^^^^^^^
 
 error: register class `vreg` requires the `vector` target feature
   --> $DIR/bad-reg.rs:77:18
    |
-LL |         asm!("", out("v0") x); // requires vector & asm_experimental_reg
+LL |         asm!("", out("v0") x);
    |                  ^^^^^^^^^^^
 
 error: register class `vreg` requires the `vector` target feature
@@ -315,13 +315,13 @@ LL |         asm!("", out("v0") b);
 error: register class `vreg` requires the `vector` target feature
   --> $DIR/bad-reg.rs:85:26
    |
-LL |         asm!("/* {} */", in(vreg) v); // requires vector & asm_experimental_reg
+LL |         asm!("/* {} */", in(vreg) v);
    |                          ^^^^^^^^^^
 
 error: register class `vreg` requires the `vector` target feature
   --> $DIR/bad-reg.rs:87:26
    |
-LL |         asm!("/* {} */", in(vreg) x); // requires vector & asm_experimental_reg
+LL |         asm!("/* {} */", in(vreg) x);
    |                          ^^^^^^^^^^
 
 error: register class `vreg` requires the `vector` target feature
@@ -333,7 +333,7 @@ LL |         asm!("/* {} */", in(vreg) b);
 error: register class `vreg` requires the `vector` target feature
   --> $DIR/bad-reg.rs:92:26
    |
-LL |         asm!("/* {} */", out(vreg) _); // requires vector & asm_experimental_reg
+LL |         asm!("/* {} */", out(vreg) _);
    |                          ^^^^^^^^^^^
 
 error: type `i32` cannot be used with this register class


### PR DESCRIPTION
Trivial bit of cleanup.

For s390x the vector registers are now stable, so `asm_experimental_reg` is no longer needed. That they need the target feature is already part of the ERROR assertion.

In the unstable book the title was incorrect.


