### PR TITLE
Use the target checking infrastructure for the diagnostic attributes

### DIFF
--- a/compiler/rustc_attr_parsing/src/attributes/diagnostic/do_not_recommend.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/diagnostic/do_not_recommend.rs
@@ -1,16 +1,14 @@
 use rustc_feature::AttributeStability;
 use rustc_hir::Target;
 use rustc_hir::attrs::AttributeKind;
-use rustc_session::lint::builtin::{
-    MALFORMED_DIAGNOSTIC_ATTRIBUTES, MISPLACED_DIAGNOSTIC_ATTRIBUTES,
-};
+use rustc_session::lint::builtin::MALFORMED_DIAGNOSTIC_ATTRIBUTES;
 use rustc_span::{Symbol, sym};
 
+use crate::attributes::prelude::Allow;
 use crate::attributes::{OnDuplicate, SingleAttributeParser};
 use crate::context::AcceptContext;
-use crate::diagnostics::IncorrectDoNotRecommendLocation;
 use crate::parser::ArgParser;
-use crate::target_checking::{ALL_TARGETS, AllowedTargets};
+use crate::target_checking::AllowedTargets;
 use crate::{AttributeTemplate, template};
 
 pub(crate) struct DoNotRecommendParser;
@@ -18,7 +16,8 @@ impl SingleAttributeParser for DoNotRecommendParser {
     const PATH: &[Symbol] = &[sym::diagnostic, sym::do_not_recommend];
     const ON_DUPLICATE: OnDuplicate = OnDuplicate::Warn;
     // "Allowed" on any target, noop on all but trait impls
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(ALL_TARGETS);
+    const ALLOWED_TARGETS: AllowedTargets =
+        AllowedTargets::AllowListWarnRest(&[Allow(Target::Impl { of_trait: true })]);
     const TEMPLATE: AttributeTemplate = template!(Word /*doesn't matter */);
     const STABILITY: AttributeStability = AttributeStability::Stable;
 
@@ -30,16 +29,6 @@ impl SingleAttributeParser for DoNotRecommendParser {
                 crate::diagnostics::DoNotRecommendDoesNotExpectArgs,
                 attr_span,
             );
-        }
-
-        if !matches!(cx.target, Target::Impl { of_trait: true }) {
-            let target_span = cx.target_span;
-            cx.emit_lint(
-                MISPLACED_DIAGNOSTIC_ATTRIBUTES,
-                IncorrectDoNotRecommendLocation { target_span },
-                attr_span,
-            );
-            return None;
         }
 
         Some(AttributeKind::DoNotRecommend)

--- a/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_const.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_const.rs
@@ -1,10 +1,8 @@
 use rustc_feature::AttributeStability;
 use rustc_hir::attrs::diagnostic::Directive;
-use rustc_session::lint::builtin::MISPLACED_DIAGNOSTIC_ATTRIBUTES;
 
 use crate::attributes::diagnostic::*;
 use crate::attributes::prelude::*;
-use crate::diagnostics::DiagnosticOnConstOnlyForTraitImpls;
 #[derive(Default)]
 pub(crate) struct OnConstParser {
     span: Option<Span>,
@@ -26,18 +24,6 @@ impl AttributeParser for OnConstParser {
             let span = cx.attr_span;
             this.span = Some(span);
 
-            // FIXME(mejrs) no constness field on `Target`,
-            // so non-constness is still checked in check_attr.rs
-            if !matches!(cx.target, Target::Impl { of_trait: true }) {
-                let target_span = cx.target_span;
-                cx.emit_lint(
-                    MISPLACED_DIAGNOSTIC_ATTRIBUTES,
-                    DiagnosticOnConstOnlyForTraitImpls { target_span },
-                    span,
-                );
-                return;
-            }
-
             let mode = Mode::DiagnosticOnConst;
 
             let Some(items) = parse_list(cx, args, mode) else { return };
@@ -51,7 +37,11 @@ impl AttributeParser for OnConstParser {
 
     // "Allowed" on all targets; noop on anything but non-const trait impls;
     // this linted on in parser.
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(ALL_TARGETS);
+    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowListWarnRest(&[
+        // FIXME(mejrs) no constness field on `Target`,
+        // so non-constness is still checked in check_attr.rs
+        Allow(Target::Impl { of_trait: true }),
+    ]);
 
     fn finalize(self, _cx: &FinalizeContext<'_, '_>) -> Option<AttributeKind> {
         if let Some(span) = self.span {

--- a/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_move.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_move.rs
@@ -1,14 +1,12 @@
 use rustc_feature::AttributeStability;
 use rustc_hir::attrs::AttributeKind;
-use rustc_session::lint::builtin::MISPLACED_DIAGNOSTIC_ATTRIBUTES;
 use rustc_span::sym;
 
 use crate::attributes::diagnostic::*;
 use crate::attributes::prelude::*;
 use crate::context::AcceptContext;
-use crate::diagnostics::DiagnosticOnMoveOnlyForAdt;
 use crate::parser::ArgParser;
-use crate::target_checking::{ALL_TARGETS, AllowedTargets};
+use crate::target_checking::AllowedTargets;
 use crate::template;
 
 #[derive(Default)]
@@ -28,11 +26,6 @@ impl OnMoveParser {
         let span = cx.attr_span;
         self.span = Some(span);
 
-        if !matches!(cx.target, Target::Enum | Target::Struct | Target::Union) {
-            cx.emit_lint(MISPLACED_DIAGNOSTIC_ATTRIBUTES, DiagnosticOnMoveOnlyForAdt, span);
-            return;
-        }
-
         let Some(items) = parse_list(cx, args, mode) else { return };
 
         if let Some(directive) = parse_directive_items(cx, mode, items.mixed(), true) {
@@ -50,8 +43,11 @@ impl AttributeParser for OnMoveParser {
         },
     )];
 
-    // "Allowed" for all targets but noop if used on not-adt.
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(ALL_TARGETS);
+    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowListWarnRest(&[
+        Allow(Target::Enum),
+        Allow(Target::Struct),
+        Allow(Target::Union),
+    ]);
 
     fn finalize(self, _cx: &FinalizeContext<'_, '_>) -> Option<AttributeKind> {
         if let Some(_span) = self.span {

--- a/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_type_error.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_type_error.rs
@@ -1,14 +1,12 @@
 use rustc_hir::attrs::AttributeKind;
-use rustc_lint_defs::builtin::MISPLACED_DIAGNOSTIC_ATTRIBUTES;
 use rustc_span::sym;
 
 use crate::attributes::AttributeStability;
 use crate::attributes::diagnostic::*;
 use crate::attributes::prelude::*;
 use crate::context::AcceptContext;
-use crate::diagnostics::DiagnosticOnTypeErrorOnlyForAdt;
 use crate::parser::ArgParser;
-use crate::target_checking::{ALL_TARGETS, AllowedTargets};
+use crate::target_checking::AllowedTargets;
 use crate::template;
 
 #[derive(Default)]
@@ -25,11 +23,6 @@ impl OnTypeErrorParser {
 
         let span = cx.attr_span;
         self.span = Some(span);
-
-        if !matches!(cx.target, Target::Enum | Target::Struct | Target::Union) {
-            cx.emit_lint(MISPLACED_DIAGNOSTIC_ATTRIBUTES, DiagnosticOnTypeErrorOnlyForAdt, span);
-            return;
-        }
 
         let Some(items) = parse_list(cx, args, mode) else { return };
 
@@ -49,7 +42,11 @@ impl AttributeParser for OnTypeErrorParser {
         },
     )];
 
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(ALL_TARGETS);
+    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowListWarnRest(&[
+        Allow(Target::Enum),
+        Allow(Target::Struct),
+        Allow(Target::Union),
+    ]);
 
     fn finalize(self, _cx: &FinalizeContext<'_, '_>) -> Option<AttributeKind> {
         if let Some(span) = self.span {

--- a/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_unimplemented.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_unimplemented.rs
@@ -1,10 +1,8 @@
 use rustc_feature::AttributeStability;
 use rustc_hir::attrs::diagnostic::Directive;
-use rustc_session::lint::builtin::MISPLACED_DIAGNOSTIC_ATTRIBUTES;
 
 use crate::attributes::diagnostic::*;
 use crate::attributes::prelude::*;
-use crate::diagnostics::DiagnosticOnUnimplementedOnlyForTraits;
 
 #[derive(Default)]
 pub(crate) struct OnUnimplementedParser {
@@ -16,15 +14,6 @@ impl OnUnimplementedParser {
     fn parse<'sess>(&mut self, cx: &mut AcceptContext<'_, 'sess>, args: &ArgParser, mode: Mode) {
         let span = cx.attr_span;
         self.span = Some(span);
-
-        if !matches!(cx.target, Target::Trait) {
-            cx.emit_lint(
-                MISPLACED_DIAGNOSTIC_ATTRIBUTES,
-                DiagnosticOnUnimplementedOnlyForTraits,
-                span,
-            );
-            return;
-        }
 
         let Some(items) = parse_list(cx, args, mode) else { return };
 
@@ -56,8 +45,8 @@ impl AttributeParser for OnUnimplementedParser {
             },
         ),
     ];
-    //FIXME attribute is not parsed for non-traits but diagnostics are issued in `check_attr.rs`
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(ALL_TARGETS);
+    const ALLOWED_TARGETS: AllowedTargets =
+        AllowedTargets::AllowListWarnRest(&[Allow(Target::Trait)]);
 
     fn finalize(self, _cx: &FinalizeContext<'_, '_>) -> Option<AttributeKind> {
         if let Some(_span) = self.span {

--- a/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_unknown.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_unknown.rs
@@ -1,11 +1,8 @@
 use rustc_feature::AttributeStability;
 use rustc_hir::attrs::diagnostic::Directive;
-use rustc_session::lint::builtin::MISPLACED_DIAGNOSTIC_ATTRIBUTES;
 
-use crate::ShouldEmit;
 use crate::attributes::diagnostic::*;
 use crate::attributes::prelude::*;
-use crate::diagnostics::DiagnosticOnUnknownInvalidTarget;
 
 #[derive(Default)]
 pub(crate) struct OnUnknownParser {
@@ -25,20 +22,6 @@ impl OnUnknownParser {
         let span = cx.attr_span;
         self.span = Some(span);
 
-        // At early parsing we get passed `Target::Crate` regardless of the item we're on.
-        // Therefore, only do target checking if we can emit.
-        let early = matches!(cx.should_emit, ShouldEmit::Nothing);
-
-        if !early && !matches!(cx.target, Target::Use | Target::Mod | Target::Crate) {
-            let target_span = cx.target_span;
-            cx.emit_lint(
-                MISPLACED_DIAGNOSTIC_ATTRIBUTES,
-                DiagnosticOnUnknownInvalidTarget { target_span },
-                span,
-            );
-            return;
-        }
-
         let Some(items) = parse_list(cx, args, mode) else { return };
 
         if let Some(directive) = parse_directive_items(cx, mode, items.mixed(), true) {
@@ -57,7 +40,11 @@ impl AttributeParser for OnUnknownParser {
         },
     )];
     // "Allowed" for all targets, but noop for all but use statements.
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(ALL_TARGETS);
+    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowListWarnRest(&[
+        Allow(Target::Use),
+        Allow(Target::Mod),
+        Allow(Target::Crate),
+    ]);
 
     fn finalize(self, _cx: &FinalizeContext<'_, '_>) -> Option<AttributeKind> {
         if let Some(_span) = self.span {

--- a/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_unmatched_args.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_unmatched_args.rs
@@ -1,10 +1,8 @@
 use rustc_feature::AttributeStability;
 use rustc_hir::attrs::diagnostic::Directive;
-use rustc_session::lint::builtin::MISPLACED_DIAGNOSTIC_ATTRIBUTES;
 
 use crate::attributes::diagnostic::*;
 use crate::attributes::prelude::*;
-use crate::diagnostics::DiagnosticOnUnmatchedArgsOnlyForMacros;
 
 #[derive(Default)]
 pub(crate) struct OnUnmatchedArgsParser {
@@ -25,15 +23,6 @@ impl AttributeParser for OnUnmatchedArgsParser {
             let span = cx.attr_span;
             this.span = Some(span);
 
-            if !matches!(cx.target, Target::MacroDef) {
-                cx.emit_lint(
-                    MISPLACED_DIAGNOSTIC_ATTRIBUTES,
-                    DiagnosticOnUnmatchedArgsOnlyForMacros,
-                    span,
-                );
-                return;
-            }
-
             let mode = Mode::DiagnosticOnUnmatchedArgs;
             let Some(items) = parse_list(cx, args, mode) else { return };
 
@@ -44,7 +33,8 @@ impl AttributeParser for OnUnmatchedArgsParser {
         },
     )];
 
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(ALL_TARGETS);
+    const ALLOWED_TARGETS: AllowedTargets =
+        AllowedTargets::AllowListWarnRest(&[Allow(Target::MacroDef)]);
 
     fn finalize(self, _cx: &FinalizeContext<'_, '_>) -> Option<AttributeKind> {
         if let Some(_span) = self.span {

--- a/compiler/rustc_attr_parsing/src/diagnostics.rs
+++ b/compiler/rustc_attr_parsing/src/diagnostics.rs
@@ -280,45 +280,6 @@ pub(crate) struct UnknownCrateTypesSuggestion {
 }
 
 #[derive(Diagnostic)]
-#[diag("`#[diagnostic::on_const]` can only be applied to non-const trait implementations")]
-pub(crate) struct DiagnosticOnConstOnlyForTraitImpls {
-    #[label("not a trait implementation")]
-    pub target_span: Span,
-}
-
-#[derive(Diagnostic)]
-#[diag("`#[diagnostic::on_move]` can only be applied to enums, structs or unions")]
-pub(crate) struct DiagnosticOnMoveOnlyForAdt;
-
-#[derive(Diagnostic)]
-#[diag("`#[diagnostic::on_unimplemented]` can only be applied to trait definitions")]
-pub(crate) struct DiagnosticOnUnimplementedOnlyForTraits;
-
-#[derive(Diagnostic)]
-#[diag(
-    "`#[diagnostic::on_unknown]` can only be applied to `use` statements and module declarations"
-)]
-pub(crate) struct DiagnosticOnUnknownInvalidTarget {
-    #[label("not an import or module")]
-    pub target_span: Span,
-}
-
-#[derive(Diagnostic)]
-#[diag("`#[diagnostic::on_unmatched_args]` can only be applied to macro definitions")]
-pub(crate) struct DiagnosticOnUnmatchedArgsOnlyForMacros;
-
-#[derive(Diagnostic)]
-#[diag("`#[diagnostic::on_type_error]` can only be applied to enums, structs or unions")]
-pub(crate) struct DiagnosticOnTypeErrorOnlyForAdt;
-
-#[derive(Diagnostic)]
-#[diag("`#[diagnostic::do_not_recommend]` can only be placed on trait implementations")]
-pub(crate) struct IncorrectDoNotRecommendLocation {
-    #[label("not a trait implementation")]
-    pub target_span: Span,
-}
-
-#[derive(Diagnostic)]
 #[diag("malformed `doc` attribute input")]
 #[warning(
     "this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!"

--- a/compiler/rustc_attr_parsing/src/target_checking.rs
+++ b/compiler/rustc_attr_parsing/src/target_checking.rs
@@ -129,6 +129,7 @@ impl<'sess> AttributeParser<'sess> {
 
         let allowed_targets = allowed_targets.allowed_targets();
         let (applied, only) = allowed_targets_applied(allowed_targets, cx.target, cx.features);
+        let is_diagnostic_attr = cx.attr_path.segments[0] == sym::diagnostic;
 
         let diag = InvalidTarget {
             span: cx.attr_span.clone(),
@@ -138,7 +139,7 @@ impl<'sess> AttributeParser<'sess> {
             applied: DiagArgValue::StrListSepByAnd(applied.into_iter().map(Cow::Owned).collect()),
             attribute_args,
             help: Self::target_checking_help(attribute_args, cx),
-            previously_accepted: matches!(result, AllowedResult::Warn),
+            previously_accepted: matches!(result, AllowedResult::Warn) && !is_diagnostic_attr,
             on_macro_call: matches!(cx.target, Target::MacroCall),
         };
 
@@ -156,6 +157,8 @@ impl<'sess> AttributeParser<'sess> {
                     .contains(&cx.target)
                 {
                     rustc_session::lint::builtin::USELESS_DEPRECATED
+                } else if is_diagnostic_attr {
+                    rustc_session::lint::builtin::MISPLACED_DIAGNOSTIC_ATTRIBUTES
                 } else {
                     rustc_session::lint::builtin::UNUSED_ATTRIBUTES
                 };

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/on_unimplemented.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/on_unimplemented.rs
@@ -40,6 +40,11 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
         if trait_pred.polarity() != ty::PredicatePolarity::Positive {
             return CustomDiagnostic::default();
         }
+        // This is needed as `on_unimplemented` is currently not allowed on trait aliases,
+        // but the "not allowed" is a warning, and this check ensures the attribute has no effect
+        if self.tcx.is_trait_alias(trait_pred.def_id()) {
+            return CustomDiagnostic::default();
+        }
         let (filter_options, format_args) =
             self.on_unimplemented_components(trait_pred, obligation, long_ty_path);
         if let Some(command) = find_attr!(self.tcx, trait_pred.def_id(), OnUnimplemented {directive, ..} => directive.as_deref()).flatten() {

--- a/tests/ui/diagnostic_namespace/do_not_recommend/incorrect-locations.current.stderr
+++ b/tests/ui/diagnostic_namespace/do_not_recommend/incorrect-locations.current.stderr
@@ -1,85 +1,75 @@
-warning: `#[diagnostic::do_not_recommend]` can only be placed on trait implementations
+warning: `#[diagnostic::do_not_recommend]` attribute cannot be used on constants
   --> $DIR/incorrect-locations.rs:7:1
    |
 LL | #[diagnostic::do_not_recommend]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-LL |
-LL | const CONST: () = ();
-   | --------------------- not a trait implementation
    |
+   = help: `#[diagnostic::do_not_recommend]` can only be applied to trait impl blocks
    = note: `#[warn(misplaced_diagnostic_attributes)]` (part of `#[warn(unknown_or_malformed_diagnostic_attributes)]`) on by default
 
-warning: `#[diagnostic::do_not_recommend]` can only be placed on trait implementations
+warning: `#[diagnostic::do_not_recommend]` attribute cannot be used on statics
   --> $DIR/incorrect-locations.rs:11:1
    |
 LL | #[diagnostic::do_not_recommend]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-LL |
-LL | static STATIC: () = ();
-   | ----------------------- not a trait implementation
+   |
+   = help: `#[diagnostic::do_not_recommend]` can only be applied to trait impl blocks
 
-warning: `#[diagnostic::do_not_recommend]` can only be placed on trait implementations
+warning: `#[diagnostic::do_not_recommend]` attribute cannot be used on type aliases
   --> $DIR/incorrect-locations.rs:15:1
    |
 LL | #[diagnostic::do_not_recommend]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-LL |
-LL | type Type = ();
-   | --------------- not a trait implementation
+   |
+   = help: `#[diagnostic::do_not_recommend]` can only be applied to trait impl blocks
 
-warning: `#[diagnostic::do_not_recommend]` can only be placed on trait implementations
+warning: `#[diagnostic::do_not_recommend]` attribute cannot be used on enums
   --> $DIR/incorrect-locations.rs:19:1
    |
 LL | #[diagnostic::do_not_recommend]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-LL |
-LL | enum Enum {}
-   | ------------ not a trait implementation
+   |
+   = help: `#[diagnostic::do_not_recommend]` can only be applied to trait impl blocks
 
-warning: `#[diagnostic::do_not_recommend]` can only be placed on trait implementations
+warning: `#[diagnostic::do_not_recommend]` attribute cannot be used on inherent impl blocks
   --> $DIR/incorrect-locations.rs:23:1
    |
 LL | #[diagnostic::do_not_recommend]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-LL |
-LL | impl Enum {}
-   | ------------ not a trait implementation
+   |
+   = help: `#[diagnostic::do_not_recommend]` can only be applied to trait impl blocks
 
-warning: `#[diagnostic::do_not_recommend]` can only be placed on trait implementations
+warning: `#[diagnostic::do_not_recommend]` attribute cannot be used on foreign modules
   --> $DIR/incorrect-locations.rs:27:1
    |
 LL | #[diagnostic::do_not_recommend]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-LL |
-LL | extern "C" {}
-   | ------------- not a trait implementation
+   |
+   = help: `#[diagnostic::do_not_recommend]` can only be applied to trait impl blocks
 
-warning: `#[diagnostic::do_not_recommend]` can only be placed on trait implementations
+warning: `#[diagnostic::do_not_recommend]` attribute cannot be used on functions
   --> $DIR/incorrect-locations.rs:31:1
    |
 LL | #[diagnostic::do_not_recommend]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-LL |
-LL | fn fun() {}
-   | ----------- not a trait implementation
+   |
+   = help: `#[diagnostic::do_not_recommend]` can only be applied to trait impl blocks
 
-warning: `#[diagnostic::do_not_recommend]` can only be placed on trait implementations
+warning: `#[diagnostic::do_not_recommend]` attribute cannot be used on structs
   --> $DIR/incorrect-locations.rs:35:1
    |
 LL | #[diagnostic::do_not_recommend]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-LL |
-LL | struct Struct {}
-   | ---------------- not a trait implementation
+   |
+   = help: `#[diagnostic::do_not_recommend]` can only be applied to trait impl blocks
 
-warning: `#[diagnostic::do_not_recommend]` can only be placed on trait implementations
+warning: `#[diagnostic::do_not_recommend]` attribute cannot be used on traits
   --> $DIR/incorrect-locations.rs:39:1
    |
 LL | #[diagnostic::do_not_recommend]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-LL |
-LL | trait Trait {}
-   | -------------- not a trait implementation
+   |
+   = help: `#[diagnostic::do_not_recommend]` can only be applied to trait impl blocks
 
 warning: 9 warnings emitted
 

--- a/tests/ui/diagnostic_namespace/do_not_recommend/incorrect-locations.next.stderr
+++ b/tests/ui/diagnostic_namespace/do_not_recommend/incorrect-locations.next.stderr
@@ -1,85 +1,75 @@
-warning: `#[diagnostic::do_not_recommend]` can only be placed on trait implementations
+warning: `#[diagnostic::do_not_recommend]` attribute cannot be used on constants
   --> $DIR/incorrect-locations.rs:7:1
    |
 LL | #[diagnostic::do_not_recommend]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-LL |
-LL | const CONST: () = ();
-   | --------------------- not a trait implementation
    |
+   = help: `#[diagnostic::do_not_recommend]` can only be applied to trait impl blocks
    = note: `#[warn(misplaced_diagnostic_attributes)]` (part of `#[warn(unknown_or_malformed_diagnostic_attributes)]`) on by default
 
-warning: `#[diagnostic::do_not_recommend]` can only be placed on trait implementations
+warning: `#[diagnostic::do_not_recommend]` attribute cannot be used on statics
   --> $DIR/incorrect-locations.rs:11:1
    |
 LL | #[diagnostic::do_not_recommend]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-LL |
-LL | static STATIC: () = ();
-   | ----------------------- not a trait implementation
+   |
+   = help: `#[diagnostic::do_not_recommend]` can only be applied to trait impl blocks
 
-warning: `#[diagnostic::do_not_recommend]` can only be placed on trait implementations
+warning: `#[diagnostic::do_not_recommend]` attribute cannot be used on type aliases
   --> $DIR/incorrect-locations.rs:15:1
    |
 LL | #[diagnostic::do_not_recommend]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-LL |
-LL | type Type = ();
-   | --------------- not a trait implementation
+   |
+   = help: `#[diagnostic::do_not_recommend]` can only be applied to trait impl blocks
 
-warning: `#[diagnostic::do_not_recommend]` can only be placed on trait implementations
+warning: `#[diagnostic::do_not_recommend]` attribute cannot be used on enums
   --> $DIR/incorrect-locations.rs:19:1
    |
 LL | #[diagnostic::do_not_recommend]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-LL |
-LL | enum Enum {}
-   | ------------ not a trait implementation
+   |
+   = help: `#[diagnostic::do_not_recommend]` can only be applied to trait impl blocks
 
-warning: `#[diagnostic::do_not_recommend]` can only be placed on trait implementations
+warning: `#[diagnostic::do_not_recommend]` attribute cannot be used on inherent impl blocks
   --> $DIR/incorrect-locations.rs:23:1
    |
 LL | #[diagnostic::do_not_recommend]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-LL |
-LL | impl Enum {}
-   | ------------ not a trait implementation
+   |
+   = help: `#[diagnostic::do_not_recommend]` can only be applied to trait impl blocks
 
-warning: `#[diagnostic::do_not_recommend]` can only be placed on trait implementations
+warning: `#[diagnostic::do_not_recommend]` attribute cannot be used on foreign modules
   --> $DIR/incorrect-locations.rs:27:1
    |
 LL | #[diagnostic::do_not_recommend]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-LL |
-LL | extern "C" {}
-   | ------------- not a trait implementation
+   |
+   = help: `#[diagnostic::do_not_recommend]` can only be applied to trait impl blocks
 
-warning: `#[diagnostic::do_not_recommend]` can only be placed on trait implementations
+warning: `#[diagnostic::do_not_recommend]` attribute cannot be used on functions
   --> $DIR/incorrect-locations.rs:31:1
    |
 LL | #[diagnostic::do_not_recommend]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-LL |
-LL | fn fun() {}
-   | ----------- not a trait implementation
+   |
+   = help: `#[diagnostic::do_not_recommend]` can only be applied to trait impl blocks
 
-warning: `#[diagnostic::do_not_recommend]` can only be placed on trait implementations
+warning: `#[diagnostic::do_not_recommend]` attribute cannot be used on structs
   --> $DIR/incorrect-locations.rs:35:1
    |
 LL | #[diagnostic::do_not_recommend]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-LL |
-LL | struct Struct {}
-   | ---------------- not a trait implementation
+   |
+   = help: `#[diagnostic::do_not_recommend]` can only be applied to trait impl blocks
 
-warning: `#[diagnostic::do_not_recommend]` can only be placed on trait implementations
+warning: `#[diagnostic::do_not_recommend]` attribute cannot be used on traits
   --> $DIR/incorrect-locations.rs:39:1
    |
 LL | #[diagnostic::do_not_recommend]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-LL |
-LL | trait Trait {}
-   | -------------- not a trait implementation
+   |
+   = help: `#[diagnostic::do_not_recommend]` can only be applied to trait impl blocks
 
 warning: 9 warnings emitted
 

--- a/tests/ui/diagnostic_namespace/do_not_recommend/incorrect-locations.rs
+++ b/tests/ui/diagnostic_namespace/do_not_recommend/incorrect-locations.rs
@@ -5,39 +5,39 @@
 //@ reference: attributes.diagnostic.do_not_recommend.allowed-positions
 
 #[diagnostic::do_not_recommend]
-//~^WARN `#[diagnostic::do_not_recommend]` can only be placed
+//~^WARN cannot be used on
 const CONST: () = ();
 
 #[diagnostic::do_not_recommend]
-//~^WARN `#[diagnostic::do_not_recommend]` can only be placed
+//~^WARN cannot be used on
 static STATIC: () = ();
 
 #[diagnostic::do_not_recommend]
-//~^WARN `#[diagnostic::do_not_recommend]` can only be placed
+//~^WARN cannot be used on
 type Type = ();
 
 #[diagnostic::do_not_recommend]
-//~^WARN `#[diagnostic::do_not_recommend]` can only be placed
+//~^WARN cannot be used on
 enum Enum {}
 
 #[diagnostic::do_not_recommend]
-//~^WARN `#[diagnostic::do_not_recommend]` can only be placed
+//~^WARN cannot be used on
 impl Enum {}
 
 #[diagnostic::do_not_recommend]
-//~^WARN `#[diagnostic::do_not_recommend]` can only be placed
+//~^WARN cannot be used on
 extern "C" {}
 
 #[diagnostic::do_not_recommend]
-//~^WARN `#[diagnostic::do_not_recommend]` can only be placed
+//~^WARN cannot be used on
 fn fun() {}
 
 #[diagnostic::do_not_recommend]
-//~^WARN `#[diagnostic::do_not_recommend]` can only be placed
+//~^WARN cannot be used on
 struct Struct {}
 
 #[diagnostic::do_not_recommend]
-//~^WARN `#[diagnostic::do_not_recommend]` can only be placed
+//~^WARN cannot be used on
 trait Trait {}
 
 #[diagnostic::do_not_recommend]

--- a/tests/ui/diagnostic_namespace/on_const/misplaced_attr.rs
+++ b/tests/ui/diagnostic_namespace/on_const/misplaced_attr.rs
@@ -2,7 +2,7 @@
 #![deny(misplaced_diagnostic_attributes)]
 
 #[diagnostic::on_const(message = "tadaa", note = "boing")]
-//~^ ERROR: `#[diagnostic::on_const]` can only be applied to non-const trait implementations
+//~^ ERROR: cannot be used on
 pub struct Foo;
 
 #[diagnostic::on_const(message = "tadaa", note = "boing")]
@@ -14,7 +14,7 @@ const impl PartialEq for Foo {
 }
 
 #[diagnostic::on_const(message = "tadaa", note = "boing")]
-//~^ ERROR: `#[diagnostic::on_const]` can only be applied to non-const trait implementations
+//~^ ERROR: cannot be used on
 impl Foo {
     fn eq(&self, _other: &Foo) -> bool {
         true
@@ -23,7 +23,7 @@ impl Foo {
 
 impl PartialOrd for Foo {
     #[diagnostic::on_const(message = "tadaa", note = "boing")]
-    //~^ ERROR: `#[diagnostic::on_const]` can only be applied to non-const trait implementations
+    //~^ ERROR: cannot be used on
     fn partial_cmp(&self, other: &Foo) -> Option<std::cmp::Ordering> {
         None
     }

--- a/tests/ui/diagnostic_namespace/on_const/misplaced_attr.stderr
+++ b/tests/ui/diagnostic_namespace/on_const/misplaced_attr.stderr
@@ -13,38 +13,29 @@ note: the lint level is defined here
 LL | #![deny(misplaced_diagnostic_attributes)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: `#[diagnostic::on_const]` can only be applied to non-const trait implementations
+error: `#[diagnostic::on_const]` attribute cannot be used on structs
   --> $DIR/misplaced_attr.rs:4:1
    |
 LL | #[diagnostic::on_const(message = "tadaa", note = "boing")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-LL |
-LL | pub struct Foo;
-   | --------------- not a trait implementation
+   |
+   = help: `#[diagnostic::on_const]` can only be applied to trait impl blocks
 
-error: `#[diagnostic::on_const]` can only be applied to non-const trait implementations
+error: `#[diagnostic::on_const]` attribute cannot be used on inherent impl blocks
   --> $DIR/misplaced_attr.rs:16:1
    |
-LL |   #[diagnostic::on_const(message = "tadaa", note = "boing")]
-   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-LL |
-LL | / impl Foo {
-LL | |     fn eq(&self, _other: &Foo) -> bool {
-LL | |         true
-LL | |     }
-LL | | }
-   | |_- not a trait implementation
+LL | #[diagnostic::on_const(message = "tadaa", note = "boing")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[diagnostic::on_const]` can only be applied to trait impl blocks
 
-error: `#[diagnostic::on_const]` can only be applied to non-const trait implementations
+error: `#[diagnostic::on_const]` attribute cannot be used on trait methods in impl blocks
   --> $DIR/misplaced_attr.rs:25:5
    |
-LL |       #[diagnostic::on_const(message = "tadaa", note = "boing")]
-   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-LL |
-LL | /     fn partial_cmp(&self, other: &Foo) -> Option<std::cmp::Ordering> {
-LL | |         None
-LL | |     }
-   | |_____- not a trait implementation
+LL |     #[diagnostic::on_const(message = "tadaa", note = "boing")]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[diagnostic::on_const]` can only be applied to trait impl blocks
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/diagnostic_namespace/on_move/report_warning_on_non_adt.rs
+++ b/tests/ui/diagnostic_namespace/on_move/report_warning_on_non_adt.rs
@@ -7,7 +7,7 @@
 struct Foo;
 
 #[diagnostic::on_move(
-//~^WARN `#[diagnostic::on_move]` can only be applied to enums, structs or unions
+//~^WARN `#[diagnostic::on_move]` attribute cannot be used on traits
     message = "Foo",
     label = "Bar",
 )]

--- a/tests/ui/diagnostic_namespace/on_move/report_warning_on_non_adt.stderr
+++ b/tests/ui/diagnostic_namespace/on_move/report_warning_on_non_adt.stderr
@@ -1,4 +1,4 @@
-warning: `#[diagnostic::on_move]` can only be applied to enums, structs or unions
+warning: `#[diagnostic::on_move]` attribute cannot be used on traits
   --> $DIR/report_warning_on_non_adt.rs:9:1
    |
 LL | / #[diagnostic::on_move(
@@ -8,6 +8,7 @@ LL | |     label = "Bar",
 LL | | )]
    | |__^
    |
+   = help: `#[diagnostic::on_move]` can only be applied to data types
    = note: `#[warn(misplaced_diagnostic_attributes)]` (part of `#[warn(unknown_or_malformed_diagnostic_attributes)]`) on by default
 
 error[E0382]: Foo

--- a/tests/ui/diagnostic_namespace/on_type_error/report_warning_on_non_adt.rs
+++ b/tests/ui/diagnostic_namespace/on_type_error/report_warning_on_non_adt.rs
@@ -1,30 +1,30 @@
 #![feature(diagnostic_on_type_error)]
 
 #[diagnostic::on_type_error(note = "custom on_type_error note: not an ADT")]
-//~^ WARN `#[diagnostic::on_type_error]` can only be applied to enums, structs or unions
+//~^ WARN cannot be used on
 fn function() {}
 
 #[diagnostic::on_type_error(note = "custom on_type_error note: not an ADT")]
-//~^ WARN `#[diagnostic::on_type_error]` can only be applied to enums, structs or unions
+//~^ WARN cannot be used on
 static STATIC: i32 = 0;
 
 #[diagnostic::on_type_error(note = "custom on_type_error note: not an ADT")]
-//~^ WARN `#[diagnostic::on_type_error]` can only be applied to enums, structs or unions
+//~^ WARN cannot be used on
 mod module {}
 
 #[diagnostic::on_type_error(note = "custom on_type_error note: not an ADT")]
-//~^ WARN `#[diagnostic::on_type_error]` can only be applied to enums, structs or unions
+//~^ WARN cannot be used on
 trait Trait {}
 
 #[diagnostic::on_type_error(note = "custom on_type_error note: not an ADT")]
-//~^ WARN `#[diagnostic::on_type_error]` can only be applied to enums, structs or unions
+//~^ WARN cannot be used on
 type TypeAlias = i32;
 
 struct SomeStruct;
 
 impl SomeStruct {
     #[diagnostic::on_type_error(note = "custom on_type_error note: not an ADT")]
-    //~^ WARN `#[diagnostic::on_type_error]` can only be applied to enums, structs or unions
+    //~^ WARN cannot be used on
     fn method() {}
 }
 

--- a/tests/ui/diagnostic_namespace/on_type_error/report_warning_on_non_adt.stderr
+++ b/tests/ui/diagnostic_namespace/on_type_error/report_warning_on_non_adt.stderr
@@ -1,40 +1,51 @@
-warning: `#[diagnostic::on_type_error]` can only be applied to enums, structs or unions
+warning: `#[diagnostic::on_type_error]` attribute cannot be used on functions
   --> $DIR/report_warning_on_non_adt.rs:3:1
    |
 LL | #[diagnostic::on_type_error(note = "custom on_type_error note: not an ADT")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
+   = help: `#[diagnostic::on_type_error]` can only be applied to data types
    = note: `#[warn(misplaced_diagnostic_attributes)]` (part of `#[warn(unknown_or_malformed_diagnostic_attributes)]`) on by default
 
-warning: `#[diagnostic::on_type_error]` can only be applied to enums, structs or unions
+warning: `#[diagnostic::on_type_error]` attribute cannot be used on statics
   --> $DIR/report_warning_on_non_adt.rs:7:1
    |
 LL | #[diagnostic::on_type_error(note = "custom on_type_error note: not an ADT")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[diagnostic::on_type_error]` can only be applied to data types
 
-warning: `#[diagnostic::on_type_error]` can only be applied to enums, structs or unions
+warning: `#[diagnostic::on_type_error]` attribute cannot be used on modules
   --> $DIR/report_warning_on_non_adt.rs:11:1
    |
 LL | #[diagnostic::on_type_error(note = "custom on_type_error note: not an ADT")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[diagnostic::on_type_error]` can only be applied to data types
 
-warning: `#[diagnostic::on_type_error]` can only be applied to enums, structs or unions
+warning: `#[diagnostic::on_type_error]` attribute cannot be used on traits
   --> $DIR/report_warning_on_non_adt.rs:15:1
    |
 LL | #[diagnostic::on_type_error(note = "custom on_type_error note: not an ADT")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[diagnostic::on_type_error]` can only be applied to data types
 
-warning: `#[diagnostic::on_type_error]` can only be applied to enums, structs or unions
+warning: `#[diagnostic::on_type_error]` attribute cannot be used on type aliases
   --> $DIR/report_warning_on_non_adt.rs:19:1
    |
 LL | #[diagnostic::on_type_error(note = "custom on_type_error note: not an ADT")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[diagnostic::on_type_error]` can only be applied to data types
 
-warning: `#[diagnostic::on_type_error]` can only be applied to enums, structs or unions
+warning: `#[diagnostic::on_type_error]` attribute cannot be used on inherent methods
   --> $DIR/report_warning_on_non_adt.rs:26:5
    |
 LL |     #[diagnostic::on_type_error(note = "custom on_type_error note: not an ADT")]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[diagnostic::on_type_error]` can only be applied to data types
 
 error[E0308]: mismatched types
   --> $DIR/report_warning_on_non_adt.rs:38:25

--- a/tests/ui/diagnostic_namespace/on_unimplemented/do_not_accept_options_of_the_internal_rustc_attribute.rs
+++ b/tests/ui/diagnostic_namespace/on_unimplemented/do_not_accept_options_of_the_internal_rustc_attribute.rs
@@ -20,7 +20,7 @@ trait Foo<T> {}
 trait Bar {}
 
 #[diagnostic::on_unimplemented(message = "Not allowed to apply it on a impl")]
-//~^WARN #[diagnostic::on_unimplemented]` can only be applied to trait definitions
+//~^WARN cannot be used on
 impl Bar for i32 {}
 
 // cannot use special rustc_on_unimplement symbols

--- a/tests/ui/diagnostic_namespace/on_unimplemented/do_not_accept_options_of_the_internal_rustc_attribute.stderr
+++ b/tests/ui/diagnostic_namespace/on_unimplemented/do_not_accept_options_of_the_internal_rustc_attribute.stderr
@@ -152,12 +152,13 @@ LL | #[diagnostic::on_unimplemented = "Message"]
    |
    = help: only `message`, `note` and `label` are allowed as options
 
-warning: `#[diagnostic::on_unimplemented]` can only be applied to trait definitions
+warning: `#[diagnostic::on_unimplemented]` attribute cannot be used on trait impl blocks
   --> $DIR/do_not_accept_options_of_the_internal_rustc_attribute.rs:22:1
    |
 LL | #[diagnostic::on_unimplemented(message = "Not allowed to apply it on a impl")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
+   = help: `#[diagnostic::on_unimplemented]` can only be applied to traits
    = note: `#[warn(misplaced_diagnostic_attributes)]` (part of `#[warn(unknown_or_malformed_diagnostic_attributes)]`) on by default
 
 warning: format specifiers are not permitted in diagnostic attributes

--- a/tests/ui/diagnostic_namespace/on_unimplemented/do_not_fail_parsing_on_invalid_options_1.rs
+++ b/tests/ui/diagnostic_namespace/on_unimplemented/do_not_fail_parsing_on_invalid_options_1.rs
@@ -5,7 +5,7 @@
 trait Foo {}
 
 #[diagnostic::on_unimplemented(message = "Baz")]
-//~^WARN `#[diagnostic::on_unimplemented]` can only be applied to trait definitions
+//~^WARN cannot be used on
 struct Bar {}
 
 #[diagnostic::on_unimplemented(message = "Boom", unsupported = "Bar")]

--- a/tests/ui/diagnostic_namespace/on_unimplemented/do_not_fail_parsing_on_invalid_options_1.stderr
+++ b/tests/ui/diagnostic_namespace/on_unimplemented/do_not_fail_parsing_on_invalid_options_1.stderr
@@ -16,12 +16,13 @@ LL | #[diagnostic::on_unimplemented(unsupported = "foo")]
    = help: only `message`, `note` and `label` are allowed as options
    = note: `#[warn(malformed_diagnostic_attributes)]` (part of `#[warn(unknown_or_malformed_diagnostic_attributes)]`) on by default
 
-warning: `#[diagnostic::on_unimplemented]` can only be applied to trait definitions
+warning: `#[diagnostic::on_unimplemented]` attribute cannot be used on structs
   --> $DIR/do_not_fail_parsing_on_invalid_options_1.rs:7:1
    |
 LL | #[diagnostic::on_unimplemented(message = "Baz")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
+   = help: `#[diagnostic::on_unimplemented]` can only be applied to traits
    = note: `#[warn(misplaced_diagnostic_attributes)]` (part of `#[warn(unknown_or_malformed_diagnostic_attributes)]`) on by default
 
 warning: malformed `diagnostic::on_unimplemented` attribute

--- a/tests/ui/diagnostic_namespace/on_unimplemented/on_impl_trait.rs
+++ b/tests/ui/diagnostic_namespace/on_unimplemented/on_impl_trait.rs
@@ -6,7 +6,7 @@
 trait Test {}
 
 #[diagnostic::on_unimplemented(message = "blah", label = "blah", note = "blah")]
-//~^ WARN `#[diagnostic::on_unimplemented]` can only be applied to trait definitions
+//~^ WARN cannot be used on
 trait Alias = Test;
 
 // Use trait alias as bound on type parameter.

--- a/tests/ui/diagnostic_namespace/on_unimplemented/on_impl_trait.stderr
+++ b/tests/ui/diagnostic_namespace/on_unimplemented/on_impl_trait.stderr
@@ -1,9 +1,10 @@
-warning: `#[diagnostic::on_unimplemented]` can only be applied to trait definitions
+warning: `#[diagnostic::on_unimplemented]` attribute cannot be used on trait aliases
   --> $DIR/on_impl_trait.rs:8:1
    |
 LL | #[diagnostic::on_unimplemented(message = "blah", label = "blah", note = "blah")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
+   = help: `#[diagnostic::on_unimplemented]` can only be applied to traits
    = note: `#[warn(misplaced_diagnostic_attributes)]` (part of `#[warn(unknown_or_malformed_diagnostic_attributes)]`) on by default
 
 error[E0277]: the trait bound `{integer}: Alias` is not satisfied

--- a/tests/ui/diagnostic_namespace/on_unknown/incorrect_locations.rs
+++ b/tests/ui/diagnostic_namespace/on_unknown/incorrect_locations.rs
@@ -3,47 +3,47 @@
 #![feature(diagnostic_on_unknown)]
 
 #[diagnostic::on_unknown(message = "foo")]
-//~^WARN `#[diagnostic::on_unknown]` can only be applied to `use` statements and module declarations
+//~^WARN cannot be used on
 extern crate std as other_std;
 
 #[diagnostic::on_unknown(message = "foo")]
-//~^WARN `#[diagnostic::on_unknown]` can only be applied to `use` statements and module declarations
+//~^WARN cannot be used on
 const CONST: () = ();
 
 #[diagnostic::on_unknown(message = "foo")]
-//~^WARN `#[diagnostic::on_unknown]` can only be applied to `use` statements and module declarations
+//~^WARN cannot be used on
 static STATIC: () = ();
 
 #[diagnostic::on_unknown(message = "foo")]
-//~^WARN `#[diagnostic::on_unknown]` can only be applied to `use` statements and module declarations
+//~^WARN cannot be used on
 type Type = ();
 
 #[diagnostic::on_unknown(message = "foo")]
-//~^WARN `#[diagnostic::on_unknown]` can only be applied to `use` statements and module declarations
+//~^WARN cannot be used on
 enum Enum {}
 
 #[diagnostic::on_unknown(message = "foo")]
-//~^WARN `#[diagnostic::on_unknown]` can only be applied to `use` statements and module declarations
+//~^WARN cannot be used on
 impl Enum {}
 
 #[diagnostic::on_unknown(message = "foo")]
-//~^WARN `#[diagnostic::on_unknown]` can only be applied to `use` statements and module declarations
+//~^WARN cannot be used on
 extern "C" {}
 
 #[diagnostic::on_unknown(message = "foo")]
-//~^WARN `#[diagnostic::on_unknown]` can only be applied to `use` statements and module declarations
+//~^WARN cannot be used on
 fn fun() {}
 
 #[diagnostic::on_unknown(message = "foo")]
-//~^WARN `#[diagnostic::on_unknown]` can only be applied to `use` statements and module declarations
+//~^WARN cannot be used on
 struct Struct {}
 
 #[diagnostic::on_unknown(message = "foo")]
-//~^WARN `#[diagnostic::on_unknown]` can only be applied to `use` statements and module declarations
+//~^WARN cannot be used on
 trait Trait {}
 
 #[diagnostic::on_unknown(message = "foo")]
-//~^WARN `#[diagnostic::on_unknown]` can only be applied to `use` statements and module declarations
+//~^WARN cannot be used on
 impl Trait for i32 {}
 
 #[diagnostic::on_unknown(message = "foo")]

--- a/tests/ui/diagnostic_namespace/on_unknown/incorrect_locations.stderr
+++ b/tests/ui/diagnostic_namespace/on_unknown/incorrect_locations.stderr
@@ -1,103 +1,91 @@
-warning: `#[diagnostic::on_unknown]` can only be applied to `use` statements and module declarations
+warning: `#[diagnostic::on_unknown]` attribute cannot be used on extern crates
   --> $DIR/incorrect_locations.rs:5:1
    |
 LL | #[diagnostic::on_unknown(message = "foo")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-LL |
-LL | extern crate std as other_std;
-   | ------------------------------ not an import or module
    |
+   = help: `#[diagnostic::on_unknown]` can be applied to crates, modules, and use statements
    = note: `#[warn(misplaced_diagnostic_attributes)]` (part of `#[warn(unknown_or_malformed_diagnostic_attributes)]`) on by default
 
-warning: `#[diagnostic::on_unknown]` can only be applied to `use` statements and module declarations
+warning: `#[diagnostic::on_unknown]` attribute cannot be used on constants
   --> $DIR/incorrect_locations.rs:9:1
    |
 LL | #[diagnostic::on_unknown(message = "foo")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-LL |
-LL | const CONST: () = ();
-   | --------------------- not an import or module
+   |
+   = help: `#[diagnostic::on_unknown]` can be applied to crates, modules, and use statements
 
-warning: `#[diagnostic::on_unknown]` can only be applied to `use` statements and module declarations
+warning: `#[diagnostic::on_unknown]` attribute cannot be used on statics
   --> $DIR/incorrect_locations.rs:13:1
    |
 LL | #[diagnostic::on_unknown(message = "foo")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-LL |
-LL | static STATIC: () = ();
-   | ----------------------- not an import or module
+   |
+   = help: `#[diagnostic::on_unknown]` can be applied to crates, modules, and use statements
 
-warning: `#[diagnostic::on_unknown]` can only be applied to `use` statements and module declarations
+warning: `#[diagnostic::on_unknown]` attribute cannot be used on type aliases
   --> $DIR/incorrect_locations.rs:17:1
    |
 LL | #[diagnostic::on_unknown(message = "foo")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-LL |
-LL | type Type = ();
-   | --------------- not an import or module
+   |
+   = help: `#[diagnostic::on_unknown]` can be applied to crates, modules, and use statements
 
-warning: `#[diagnostic::on_unknown]` can only be applied to `use` statements and module declarations
+warning: `#[diagnostic::on_unknown]` attribute cannot be used on enums
   --> $DIR/incorrect_locations.rs:21:1
    |
 LL | #[diagnostic::on_unknown(message = "foo")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-LL |
-LL | enum Enum {}
-   | ------------ not an import or module
+   |
+   = help: `#[diagnostic::on_unknown]` can be applied to crates, modules, and use statements
 
-warning: `#[diagnostic::on_unknown]` can only be applied to `use` statements and module declarations
+warning: `#[diagnostic::on_unknown]` attribute cannot be used on inherent impl blocks
   --> $DIR/incorrect_locations.rs:25:1
    |
 LL | #[diagnostic::on_unknown(message = "foo")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-LL |
-LL | impl Enum {}
-   | ------------ not an import or module
+   |
+   = help: `#[diagnostic::on_unknown]` can be applied to crates, modules, and use statements
 
-warning: `#[diagnostic::on_unknown]` can only be applied to `use` statements and module declarations
+warning: `#[diagnostic::on_unknown]` attribute cannot be used on foreign modules
   --> $DIR/incorrect_locations.rs:29:1
    |
 LL | #[diagnostic::on_unknown(message = "foo")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-LL |
-LL | extern "C" {}
-   | ------------- not an import or module
+   |
+   = help: `#[diagnostic::on_unknown]` can be applied to crates, modules, and use statements
 
-warning: `#[diagnostic::on_unknown]` can only be applied to `use` statements and module declarations
+warning: `#[diagnostic::on_unknown]` attribute cannot be used on functions
   --> $DIR/incorrect_locations.rs:33:1
    |
 LL | #[diagnostic::on_unknown(message = "foo")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-LL |
-LL | fn fun() {}
-   | ----------- not an import or module
+   |
+   = help: `#[diagnostic::on_unknown]` can be applied to crates, modules, and use statements
 
-warning: `#[diagnostic::on_unknown]` can only be applied to `use` statements and module declarations
+warning: `#[diagnostic::on_unknown]` attribute cannot be used on structs
   --> $DIR/incorrect_locations.rs:37:1
    |
 LL | #[diagnostic::on_unknown(message = "foo")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-LL |
-LL | struct Struct {}
-   | ---------------- not an import or module
+   |
+   = help: `#[diagnostic::on_unknown]` can be applied to crates, modules, and use statements
 
-warning: `#[diagnostic::on_unknown]` can only be applied to `use` statements and module declarations
+warning: `#[diagnostic::on_unknown]` attribute cannot be used on traits
   --> $DIR/incorrect_locations.rs:41:1
    |
 LL | #[diagnostic::on_unknown(message = "foo")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-LL |
-LL | trait Trait {}
-   | -------------- not an import or module
+   |
+   = help: `#[diagnostic::on_unknown]` can be applied to crates, modules, and use statements
 
-warning: `#[diagnostic::on_unknown]` can only be applied to `use` statements and module declarations
+warning: `#[diagnostic::on_unknown]` attribute cannot be used on trait impl blocks
   --> $DIR/incorrect_locations.rs:45:1
    |
 LL | #[diagnostic::on_unknown(message = "foo")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-LL |
-LL | impl Trait for i32 {}
-   | --------------------- not an import or module
+   |
+   = help: `#[diagnostic::on_unknown]` can be applied to crates, modules, and use statements
 
 warning: 11 warnings emitted
 

--- a/tests/ui/diagnostic_namespace/on_unknown/incorrect_unstable_positions.rs
+++ b/tests/ui/diagnostic_namespace/on_unknown/incorrect_unstable_positions.rs
@@ -6,6 +6,6 @@
 
 fn main() {
     #[diagnostic::on_unknown(message = "anonymous block")]
-    //~^ WARN `#[diagnostic::on_unknown]` can only be applied to `use` statements and module declarations
+    //~^ WARN cannot be used on
     {}
 }

--- a/tests/ui/diagnostic_namespace/on_unknown/incorrect_unstable_positions.stderr
+++ b/tests/ui/diagnostic_namespace/on_unknown/incorrect_unstable_positions.stderr
@@ -1,12 +1,10 @@
-warning: `#[diagnostic::on_unknown]` can only be applied to `use` statements and module declarations
+warning: `#[diagnostic::on_unknown]` attribute cannot be used on expressions
   --> $DIR/incorrect_unstable_positions.rs:8:5
    |
 LL |     #[diagnostic::on_unknown(message = "anonymous block")]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-LL |
-LL |     {}
-   |     -- not an import or module
    |
+   = help: `#[diagnostic::on_unknown]` can be applied to crates, modules, and use statements
    = note: `#[warn(misplaced_diagnostic_attributes)]` (part of `#[warn(unknown_or_malformed_diagnostic_attributes)]`) on by default
 
 warning: 1 warning emitted

--- a/tests/ui/diagnostic_namespace/on_unmatched_args/report_warning_on_non_macro.rs
+++ b/tests/ui/diagnostic_namespace/on_unmatched_args/report_warning_on_non_macro.rs
@@ -2,7 +2,7 @@
 #![feature(diagnostic_on_unmatched_args)]
 
 #[diagnostic::on_unmatched_args(message = "not allowed here")]
-//~^ WARN `#[diagnostic::on_unmatched_args]` can only be applied to macro definitions
+//~^ WARN cannot be used on
 struct Foo;
 
 fn main() {

--- a/tests/ui/diagnostic_namespace/on_unmatched_args/report_warning_on_non_macro.stderr
+++ b/tests/ui/diagnostic_namespace/on_unmatched_args/report_warning_on_non_macro.stderr
@@ -1,9 +1,10 @@
-warning: `#[diagnostic::on_unmatched_args]` can only be applied to macro definitions
+warning: `#[diagnostic::on_unmatched_args]` attribute cannot be used on structs
   --> $DIR/report_warning_on_non_macro.rs:4:1
    |
 LL | #[diagnostic::on_unmatched_args(message = "not allowed here")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
+   = help: `#[diagnostic::on_unmatched_args]` can only be applied to macro defs
    = note: `#[warn(misplaced_diagnostic_attributes)]` (part of `#[warn(unknown_or_malformed_diagnostic_attributes)]`) on by default
 
 warning: 1 warning emitted


### PR DESCRIPTION
The goal of this is a few things:
* Make the diagnostic attributes' target checking cleaner and more declarative, making it harder to make mistakes here
* Make progress towards removing the `ALL_TARGETS` list

r? @mejrs