### PR TITLE
std: unconditionally use `preadv`/`pwritev` on AArch64 macOS

### DIFF
--- a/library/std/src/sys/fd/unix.rs
+++ b/library/std/src/sys/fd/unix.rs
@@ -38,7 +38,10 @@ use crate::io::{self, BorrowedCursor, IoSlice, IoSliceMut, Read};
 use crate::os::fd::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, OwnedFd, RawFd};
 #[cfg(all(target_os = "android", target_pointer_width = "64"))]
 use crate::sys::pal::weak::syscall;
-#[cfg(any(all(target_os = "android", target_pointer_width = "32"), target_vendor = "apple"))]
+#[cfg(any(
+    all(target_os = "android", target_pointer_width = "32"),
+    all(target_vendor = "apple", not(all(target_os = "macos", target_arch = "aarch64")))
+))]
 use crate::sys::pal::weak::weak;
 use crate::sys::{AsInner, FromInner, IntoInner, cvt};
 
@@ -219,6 +222,7 @@ impl FileDesc {
         target_os = "linux",
         target_os = "netbsd",
         target_os = "openbsd", // OpenBSD 2.7
+        all(target_os = "macos", target_arch = "aarch64"),
     ))]
     pub fn read_vectored_at(&self, bufs: &mut [IoSliceMut<'_>], offset: u64) -> io::Result<usize> {
         let ret = cvt(unsafe {
@@ -307,14 +311,15 @@ impl FileDesc {
 
     // We support old MacOS, iOS, watchOS, tvOS and visionOS. `preadv` was added in the following
     // Apple OS versions:
-    // ios 14.0
-    // tvos 14.0
-    // macos 11.0
-    // watchos 7.0
+    // iOS 14.0
+    // tvOS 14.0
+    // macOS 11.0
+    // watchOS 7.0
     //
-    // These versions may be newer than the minimum supported versions of OS's we support so we must
-    // use "weak" linking.
-    #[cfg(target_vendor = "apple")]
+    // Since macOS 11.0 is also the first version with AArch64 support, we can
+    // `preadv` unconditionally there. But on all other targets we must use
+    // "weak" linking.
+    #[cfg(all(target_vendor = "apple", not(all(target_os = "macos", target_arch = "aarch64"))))]
     pub fn read_vectored_at(&self, bufs: &mut [IoSliceMut<'_>], offset: u64) -> io::Result<usize> {
         weak!(
             fn preadv(
@@ -426,6 +431,7 @@ impl FileDesc {
         target_os = "linux",
         target_os = "netbsd",
         target_os = "openbsd", // OpenBSD 2.7
+        all(target_os = "macos", target_arch = "aarch64"),
     ))]
     pub fn write_vectored_at(&self, bufs: &[IoSlice<'_>], offset: u64) -> io::Result<usize> {
         let ret = cvt(unsafe {
@@ -514,14 +520,15 @@ impl FileDesc {
 
     // We support old MacOS, iOS, watchOS, tvOS and visionOS. `pwritev` was added in the following
     // Apple OS versions:
-    // ios 14.0
-    // tvos 14.0
-    // macos 11.0
-    // watchos 7.0
+    // iOS 14.0
+    // tvOS 14.0
+    // macOS 11.0
+    // watchOS 7.0
     //
-    // These versions may be newer than the minimum supported versions of OS's we support so we must
-    // use "weak" linking.
-    #[cfg(target_vendor = "apple")]
+    // Since macOS 11.0 is also the first version with AArch64 support, we can
+    // `pwritev` unconditionally there. But on all other targets we must use
+    // "weak" linking.
+    #[cfg(all(target_vendor = "apple", not(all(target_os = "macos", target_arch = "aarch64")),))]
     pub fn write_vectored_at(&self, bufs: &[IoSlice<'_>], offset: u64) -> io::Result<usize> {
         weak!(
             fn pwritev(


### PR DESCRIPTION
The stars happened to line up perfectly: macOS 11.0 was the first version to support ARM, and also the first version with `preadv`/`pwritev`. Thus we don't need to use weak linkage if the target is `aarch64-apple-darwin`.