### PR TITLE
Guarantee 8 bytes of alignment of RawWakerVTable

### DIFF
--- a/library/core/src/task/wake.rs
+++ b/library/core/src/task/wake.rs
@@ -90,6 +90,8 @@ impl RawWaker {
 /// pointers to *different* functions can compare equal (since identical functions can be
 /// deduplicated within a codegen unit).
 ///
+/// This struct is guaranteed to be aligned to at least 8 bytes.
+///
 /// # Thread safety
 /// If the [`RawWaker`] will be used to construct a [`Waker`] then
 /// these functions must all be thread-safe (even though [`RawWaker`] is
@@ -106,6 +108,7 @@ impl RawWaker {
 #[stable(feature = "futures_api", since = "1.36.0")]
 #[allow(unpredictable_function_pointer_comparisons)]
 #[derive(PartialEq, Copy, Clone, Debug)]
+#[repr(align(8))] // For bit-stuffing pointers we guarantee align >= 8.
 pub struct RawWakerVTable {
     /// This function will be called when the [`RawWaker`] gets cloned, e.g. when
     /// the [`Waker`] in which the [`RawWaker`] is stored gets cloned.

--- a/library/core/src/task/wake.rs
+++ b/library/core/src/task/wake.rs
@@ -90,6 +90,8 @@ impl RawWaker {
 /// pointers to *different* functions can compare equal (since identical functions can be
 /// deduplicated within a codegen unit).
 ///
+/// This struct is guaranteed to be aligned to at least 8 bytes.
+///
 /// # Thread safety
 /// If the [`RawWaker`] will be used to construct a [`Waker`] then
 /// these functions must all be thread-safe (even though [`RawWaker`] is
@@ -106,6 +108,8 @@ impl RawWaker {
 #[stable(feature = "futures_api", since = "1.36.0")]
 #[allow(unpredictable_function_pointer_comparisons)]
 #[derive(PartialEq, Copy, Clone, Debug)]
+// For bit-stuffing pointers we guarantee align >= 8.
+#[repr(align(8))]
 pub struct RawWakerVTable {
     /// This function will be called when the [`RawWaker`] gets cloned, e.g. when
     /// the [`Waker`] in which the [`RawWaker`] is stored gets cloned.


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/158186)*
<!-- homu-ignore:end -->

This is similar to an earlier PR I made for `Thread::into_raw`: https://github.com/rust-lang/rust/pull/143859.

When using `AtomicPtr` for synchronization it's incredibly useful when you've got a couple bits you can stuff metadata in. By guaranteeing that `RawWakerVTable` is aligned to 8 bytes everyone can use the bottom 3 bits to signal other things, such as a critical section, etc. In particular, this can be used to portably implement an `AtomicWaker` which is always two pointers in size, no more.

On almost all platforms the align is already 8 bytes, and on other platforms it might cause an infinitesimal increase in size. This guarantee is thus very useful and costs us essentially nothing.

---

r? libs-api

Like last time since this adds a guarantee this probably needs a FCP.