### PR TITLE
Avoid uploading package-version on forced-channel jobs

### DIFF
--- a/src/ci/scripts/upload-artifacts.sh
+++ b/src/ci/scripts/upload-artifacts.sh
@@ -30,7 +30,11 @@ fi
 # For nightly and beta this isn't strictly necessary as just trying both is
 # enough, but stable builds produce artifacts with a version (e.g.,
 # rust-src-1.92.0.tar.xz) which can't be easily guessed otherwise.
-channel=$(releaseChannel)
+#
+# This intentionally does not respect RUST_CI_OVERRIDE_RELEASE_CHANNEL because
+# we want a single channel across all runners; otherwise depending on which
+# finishes first we might have different output artifacts.
+channel=$(cat "${ci_dir}/channel")
 if [[ "$channel" = "stable" ]]; then
     # On stable, artifacts use the version number. See rust_package_vers in
     # src/bootstrap/src/lib.rs.


### PR DESCRIPTION
This caused Crater to fail when installing the toolchain for commit 057ed8ba87418a77d5758f2d5e13f84b89b197e9, because it assumed the toolchain files would have package-version 1.98.0 (instead of nightly).

This adjusts the code to always upload based on the canonical channel instead of the override.

See also notes on Zulip - [#t-infra > Crater maybe stuck? @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/Crater.20maybe.20stuck.3F/near/605209994)