### PR TITLE
Suggest installing `rust-src` when standard library source is unavailable

### DIFF
--- a/compiler/rustc_errors/src/annotate_snippet_emitter_writer.rs
+++ b/compiler/rustc_errors/src/annotate_snippet_emitter_writer.rs
@@ -10,6 +10,7 @@ use std::fmt::Debug;
 use std::io;
 use std::io::Write;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use annotate_snippets::renderer::DEFAULT_TERM_WIDTH;
 use annotate_snippets::{AnnotationKind, Group, Origin, Padding, Patch, Renderer, Snippet};
@@ -47,6 +48,9 @@ pub struct AnnotateSnippetEmitter {
     track_diagnostics: bool,
     terminal_url: TerminalUrl,
     theme: OutputTheme,
+    /// Whether we've already suggested installing `rust-src`. Shown at most once per compile.
+    #[setters(skip)]
+    rust_src_hint_shown: AtomicBool,
 }
 
 impl Debug for AnnotateSnippetEmitter {
@@ -136,6 +140,7 @@ impl AnnotateSnippetEmitter {
             track_diagnostics: false,
             terminal_url: TerminalUrl::No,
             theme: OutputTheme::Ascii,
+            rust_src_hint_shown: AtomicBool::new(false),
         }
     }
 
@@ -220,6 +225,7 @@ impl AnnotateSnippetEmitter {
                         group,
                         &annotation_level,
                     );
+                    self.maybe_suggest_rust_src(&file.name, sm, &mut group);
                     // If this is the last annotation for a file, and
                     // this is the last file, and the first child is a
                     // "secondary" message, we need to add padding
@@ -288,6 +294,7 @@ impl AnnotateSnippetEmitter {
                         group,
                         &level,
                     );
+                    self.maybe_suggest_rust_src(&file.name, sm, &mut group);
                 }
             }
         }
@@ -569,6 +576,29 @@ impl AnnotateSnippetEmitter {
         } else {
             None
         }
+    }
+
+    /// If `file_name` is a remapped standard-library source (so its source isn't available
+    /// locally), append a one-time `help` telling the user to install `rust-src`. Shown at most
+    /// once per compile session (tracked via `self.rust_src_hint_shown`).
+    fn maybe_suggest_rust_src<'a>(
+        &self,
+        file_name: &FileName,
+        sm: &Arc<SourceMap>,
+        group: &mut Group<'a>,
+    ) {
+        if self.rust_src_hint_shown.load(Ordering::Relaxed)
+            || !sm.filename_for_diagnostics(file_name).starts_with("/rustc/")
+        {
+            return;
+        }
+        self.rust_src_hint_shown.store(true, Ordering::Relaxed);
+        // `Group::element` consumes `self`, so swap in a cheap placeholder to take ownership.
+        let owned = std::mem::replace(group, Group::with_level(annotate_snippets::Level::HELP));
+        *group = owned.element(annotate_snippets::Level::HELP.message(
+            "the source code for the standard library is not available; \
+             run `rustup component add rust-src` to make it available",
+        ));
     }
 
     fn unannotated_messages<'a>(

--- a/compiler/rustc_span/src/lib.rs
+++ b/compiler/rustc_span/src/lib.rs
@@ -563,6 +563,14 @@ impl<'a> FileNameDisplay<'a> {
             _ => Cow::from(self.to_string()),
         }
     }
+
+    /// Returns whether the displayed file name starts with `prefix`.
+    ///
+    /// Avoids allocating in the common case of a valid-UTF-8 path, where
+    /// `to_string_lossy` borrows rather than allocates.
+    pub fn starts_with(&self, prefix: &str) -> bool {
+        self.to_string_lossy().starts_with(prefix)
+    }
 }
 
 impl FileName {

--- a/tests/ui/errors/suggest-rust-src.rs
+++ b/tests/ui/errors/suggest-rust-src.rs
@@ -1,0 +1,27 @@
+// When a diagnostic points into the standard library but its source isn't
+// available locally, rustc can't render the snippet. In that case it should
+// suggest installing the `rust-src` component. See #156402.
+//
+// We simulate the "std source unavailable" situation (as happens with a `rustup`
+// toolchain that doesn't have `rust-src` installed) by remapping the rust-src
+// base and disabling translation back to the local path.
+//@ compile-flags: -Z simulate-remapped-rust-src-base=/rustc/FAKE_PREFIX -Z translate-remapped-path-to-local-path=no
+//
+// The line:col of the remapped std path is volatile, so normalise it. (The
+// `$SRC_DIR` normalisation doesn't kick in because the path is remapped.)
+//@ normalize-stderr: ".rs:\d+:\d+" -> ".rs:LL:COL"
+
+use std::thread;
+
+struct Worker {
+    thread: thread::JoinHandle<()>,
+}
+
+impl Drop for Worker {
+    fn drop(&mut self) {
+        self.thread.join().unwrap();
+        //~^ ERROR cannot move out of `self.thread` which is behind a mutable reference
+    }
+}
+
+fn main() {}

--- a/tests/ui/errors/suggest-rust-src.stderr
+++ b/tests/ui/errors/suggest-rust-src.stderr
@@ -1,0 +1,15 @@
+error[E0507]: cannot move out of `self.thread` which is behind a mutable reference
+  --> $DIR/suggest-rust-src.rs:LL:COL
+   |
+LL |         self.thread.join().unwrap();
+   |         ^^^^^^^^^^^ ------ `self.thread` moved due to this method call
+   |         |
+   |         move occurs because `self.thread` has type `JoinHandle<()>`, which does not implement the `Copy` trait
+   |
+note: `JoinHandle::<T>::join` takes ownership of the receiver `self`, which moves `self.thread`
+  --> $SRC_DIR/std/src/thread/join_handle.rs:LL:COL
+   = help: the source code for the standard library is not available; run `rustup component add rust-src` to make it available
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0507`.


### PR DESCRIPTION
### Why

  A lot of diagnostics point at a span *inside* the standard library e.g. `required by a bound in `std::iter::Iterator::sum``, or `JoinHandle::join takes ownership of the receiver`. For toolchains installed via `rustup` std is shipped with its paths remapped to `/rustc/<hash>/library/...` and the source itself is **not** included unless the `rust-src` component is installed.

So when an error references std, rustc tries to render that span, can't find the source on disk, and falls back to printing just the bare remapped path with no code:

```
  error[E0277]: a value of type String cannot be made by summing an iterator ...
   --> src/main.rs:2:20
    ...
  note: required by a bound in std::iter::Iterator::sum
   --> /rustc/<hash>/library/core/src/iter/traits/iterator.rs:3669:4
```

For the user this is a dead end: the path doesn't exist locally, there's no surrounding code. It *is* fixable: `rustup component add rust-src` makes the source available, after which the same diagnostic renders the real std snippet. But that capability is
invisible. This PR closes that discoverability gap by suggesting it at exactly  the moment it would help.

Closes rust-lang/rust#156402

