### PR TITLE
Remove `has_delayed_lints` optimization

### DIFF
--- a/compiler/rustc_ast_lowering/src/item.rs
+++ b/compiler/rustc_ast_lowering/src/item.rs
@@ -227,7 +227,6 @@ impl<'hir> LoweringContext<'_, 'hir> {
             kind,
             vis_span,
             span: self.lower_span(i.span),
-            has_delayed_lints: !self.delayed_lints.is_empty(),
             eii: find_attr!(attrs, EiiImpls(..) | EiiDeclaration(..)),
         };
         self.arena.alloc(item)
@@ -700,7 +699,6 @@ impl<'hir> LoweringContext<'_, 'hir> {
                             kind,
                             vis_span,
                             span: this.lower_span(use_tree.span()),
-                            has_delayed_lints: !this.delayed_lints.is_empty(),
                             eii: find_attr!(attrs, EiiImpls(..) | EiiDeclaration(..)),
                         };
                         hir::OwnerNode::Item(this.arena.alloc(item))
@@ -788,7 +786,6 @@ impl<'hir> LoweringContext<'_, 'hir> {
             kind,
             vis_span: self.lower_span(i.vis.span),
             span: self.lower_span(i.span),
-            has_delayed_lints: !self.delayed_lints.is_empty(),
         };
         self.arena.alloc(item)
     }
@@ -1087,7 +1084,6 @@ impl<'hir> LoweringContext<'_, 'hir> {
             kind,
             span: self.lower_span(i.span),
             defaultness,
-            has_delayed_lints: !self.delayed_lints.is_empty(),
         };
         self.arena.alloc(item)
     }
@@ -1304,7 +1300,6 @@ impl<'hir> LoweringContext<'_, 'hir> {
             impl_kind,
             kind,
             span,
-            has_delayed_lints: !self.delayed_lints.is_empty(),
         };
         self.arena.alloc(item)
     }

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -3280,7 +3280,6 @@ pub struct TraitItem<'hir> {
     pub kind: TraitItemKind<'hir>,
     pub span: Span,
     pub defaultness: Defaultness,
-    pub has_delayed_lints: bool,
 }
 
 macro_rules! expect_methods_self_kind {
@@ -3384,7 +3383,6 @@ pub struct ImplItem<'hir> {
     pub kind: ImplItemKind<'hir>,
     pub impl_kind: ImplItemImplKind,
     pub span: Span,
-    pub has_delayed_lints: bool,
 }
 
 #[derive(Debug, Clone, Copy, StableHash)]
@@ -4560,7 +4558,6 @@ pub struct Item<'hir> {
     pub kind: ItemKind<'hir>,
     pub span: Span,
     pub vis_span: Span,
-    pub has_delayed_lints: bool,
     /// hint to speed up collection: true if the item is a static or function and has
     /// either an `EiiImpls` or `EiiExternTarget` attribute
     pub eii: bool,
@@ -4955,7 +4952,6 @@ pub struct ForeignItem<'hir> {
     pub owner_id: OwnerId,
     pub span: Span,
     pub vis_span: Span,
-    pub has_delayed_lints: bool,
 }
 
 impl ForeignItem<'_> {
@@ -5467,7 +5463,7 @@ mod size_asserts {
     static_assert_size!(Expr<'_>, 64);
     static_assert_size!(ExprKind<'_>, 48);
     static_assert_size!(FnDecl<'_>, 40);
-    static_assert_size!(ForeignItem<'_>, 96);
+    static_assert_size!(ForeignItem<'_>, 88);
     static_assert_size!(ForeignItemKind<'_>, 56);
     static_assert_size!(GenericArg<'_>, 16);
     static_assert_size!(GenericBound<'_>, 64);

--- a/compiler/rustc_hir/src/intravisit.rs
+++ b/compiler/rustc_hir/src/intravisit.rs
@@ -530,7 +530,7 @@ pub fn walk_param<'v, V: Visitor<'v>>(visitor: &mut V, param: &'v Param<'v>) -> 
 }
 
 pub fn walk_item<'v, V: Visitor<'v>>(visitor: &mut V, item: &'v Item<'v>) -> V::Result {
-    let Item { owner_id: _, kind, span: _, vis_span: _, has_delayed_lints: _, eii: _ } = item;
+    let Item { owner_id: _, kind, span: _, vis_span: _, eii: _ } = item;
     try_visit!(visitor.visit_id(item.hir_id()));
     match *kind {
         ItemKind::ExternCrate(orig_name, ident) => {
@@ -660,8 +660,7 @@ pub fn walk_foreign_item<'v, V: Visitor<'v>>(
     visitor: &mut V,
     foreign_item: &'v ForeignItem<'v>,
 ) -> V::Result {
-    let ForeignItem { ident, kind, owner_id: _, span: _, vis_span: _, has_delayed_lints: _ } =
-        foreign_item;
+    let ForeignItem { ident, kind, owner_id: _, span: _, vis_span: _ } = foreign_item;
     try_visit!(visitor.visit_id(foreign_item.hir_id()));
     try_visit!(visitor.visit_ident(*ident));
 
@@ -1258,15 +1257,7 @@ pub fn walk_trait_item<'v, V: Visitor<'v>>(
     visitor: &mut V,
     trait_item: &'v TraitItem<'v>,
 ) -> V::Result {
-    let TraitItem {
-        ident,
-        generics,
-        ref defaultness,
-        ref kind,
-        span,
-        owner_id: _,
-        has_delayed_lints: _,
-    } = *trait_item;
+    let TraitItem { ident, generics, ref defaultness, ref kind, span, owner_id: _ } = *trait_item;
     let hir_id = trait_item.hir_id();
     try_visit!(visitor.visit_ident(ident));
     try_visit!(visitor.visit_generics(&generics));
@@ -1308,15 +1299,8 @@ pub fn walk_impl_item<'v, V: Visitor<'v>>(
     visitor: &mut V,
     impl_item: &'v ImplItem<'v>,
 ) -> V::Result {
-    let ImplItem {
-        owner_id: _,
-        ident,
-        ref generics,
-        ref impl_kind,
-        ref kind,
-        span: _,
-        has_delayed_lints: _,
-    } = *impl_item;
+    let ImplItem { owner_id: _, ident, ref generics, ref impl_kind, ref kind, span: _ } =
+        *impl_item;
 
     try_visit!(visitor.visit_ident(ident));
     try_visit!(visitor.visit_generics(generics));

--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -1065,7 +1065,7 @@ impl<'a, 'tcx> Diagnostic<'a, ()> for DiagCallback<'tcx> {
 }
 
 pub fn emit_delayed_lints(tcx: TyCtxt<'_>) {
-    for owner_id in tcx.hir_crate_items(()).delayed_lint_items() {
+    for owner_id in tcx.hir_crate_items(()).owners() {
         if let Some(delayed_lints) = tcx.opt_ast_lowering_delayed_lints(owner_id) {
             for lint in delayed_lints.steal() {
                 tcx.emit_node_span_lint(
@@ -1131,28 +1131,6 @@ fn run_required_analyses(tcx: TyCtxt<'_>) {
     });
 
     sess.time("emit_ast_lowering_delayed_lints", || {
-        // Sanity check in debug mode that all lints are really noticed and we really will emit
-        // them all in the loop right below.
-        //
-        // During ast lowering, when creating items, foreign items, trait items and impl items,
-        // we store in them whether they have any lints in their owner node that should be
-        // picked up by `hir_crate_items`. However, theoretically code can run between that
-        // boolean being inserted into the item and the owner node being created. We don't want
-        // any new lints to be emitted there (you have to really try to manage that but still),
-        // but this check is there to catch that.
-        #[cfg(debug_assertions)]
-        {
-            let hir_items = tcx.hir_crate_items(());
-            for owner_id in hir_items.owners() {
-                if let Some(delayed_lints) = tcx.opt_ast_lowering_delayed_lints(owner_id)
-                    && !delayed_lints.borrow().is_empty()
-                {
-                    // Assert that delayed_lint_items also picked up this item to have lints.
-                    assert!(hir_items.delayed_lint_items().any(|i| i == owner_id));
-                }
-            }
-        }
-
         emit_delayed_lints(tcx);
     });
 

--- a/compiler/rustc_middle/src/hir/map.rs
+++ b/compiler/rustc_middle/src/hir/map.rs
@@ -1287,7 +1287,6 @@ pub(super) fn hir_module_items(tcx: TyCtxt<'_>, module_id: LocalModDefId) -> Mod
         body_owners: body_owners.into_boxed_slice(),
         opaques: opaques.into_boxed_slice(),
         nested_bodies: nested_bodies.into_boxed_slice(),
-        delayed_lint_items: Box::new([]),
         eiis: eiis.into_boxed_slice(),
     }
 }
@@ -1310,18 +1309,9 @@ pub(crate) fn hir_crate_items(tcx: TyCtxt<'_>, _: ()) -> ModuleItems {
         body_owners,
         opaques,
         nested_bodies,
-        mut delayed_lint_items,
         eiis,
         ..
     } = collector;
-
-    // The crate could have delayed lints too, but would not be picked up by the visitor.
-    // The `delayed_lint_items` list is smart - it only contains items which we know from
-    // earlier passes is guaranteed to contain lints. It's a little harder to determine that
-    // for sure here, so we simply always add the crate to the list. If it has no lints,
-    // we'll discover that later. The cost of this should be low, there's only one crate
-    // after all compared to the many items we have we wouldn't want to iterate over later.
-    delayed_lint_items.push(CRATE_OWNER_ID);
 
     ModuleItems {
         add_root: true,
@@ -1333,7 +1323,6 @@ pub(crate) fn hir_crate_items(tcx: TyCtxt<'_>, _: ()) -> ModuleItems {
         body_owners: body_owners.into_boxed_slice(),
         opaques: opaques.into_boxed_slice(),
         nested_bodies: nested_bodies.into_boxed_slice(),
-        delayed_lint_items: delayed_lint_items.into_boxed_slice(),
         eiis: eiis.into_boxed_slice(),
     }
 }
@@ -1351,7 +1340,6 @@ struct ItemCollector<'tcx> {
     body_owners: Vec<LocalDefId>,
     opaques: Vec<LocalDefId>,
     nested_bodies: Vec<LocalDefId>,
-    delayed_lint_items: Vec<OwnerId>,
     eiis: Vec<LocalDefId>,
 }
 
@@ -1368,7 +1356,6 @@ impl<'tcx> ItemCollector<'tcx> {
             body_owners: Vec::default(),
             opaques: Vec::default(),
             nested_bodies: Vec::default(),
-            delayed_lint_items: Vec::default(),
             eiis: Vec::default(),
         }
     }
@@ -1387,9 +1374,6 @@ impl<'hir> Visitor<'hir> for ItemCollector<'hir> {
         }
 
         self.items.push(item.item_id());
-        if self.crate_collector && item.has_delayed_lints {
-            self.delayed_lint_items.push(item.item_id().owner_id);
-        }
 
         if let ItemKind::Static(..) | ItemKind::Fn { .. } | ItemKind::Macro(..) = &item.kind
             && item.eii
@@ -1411,9 +1395,6 @@ impl<'hir> Visitor<'hir> for ItemCollector<'hir> {
 
     fn visit_foreign_item(&mut self, item: &'hir ForeignItem<'hir>) {
         self.foreign_items.push(item.foreign_item_id());
-        if self.crate_collector && item.has_delayed_lints {
-            self.delayed_lint_items.push(item.foreign_item_id().owner_id);
-        }
         intravisit::walk_foreign_item(self, item)
     }
 
@@ -1447,9 +1428,6 @@ impl<'hir> Visitor<'hir> for ItemCollector<'hir> {
         }
 
         self.trait_items.push(item.trait_item_id());
-        if self.crate_collector && item.has_delayed_lints {
-            self.delayed_lint_items.push(item.trait_item_id().owner_id);
-        }
 
         intravisit::walk_trait_item(self, item)
     }
@@ -1460,9 +1438,6 @@ impl<'hir> Visitor<'hir> for ItemCollector<'hir> {
         }
 
         self.impl_items.push(item.impl_item_id());
-        if self.crate_collector && item.has_delayed_lints {
-            self.delayed_lint_items.push(item.impl_item_id().owner_id);
-        }
 
         intravisit::walk_impl_item(self, item)
     }

--- a/compiler/rustc_middle/src/hir/mod.rs
+++ b/compiler/rustc_middle/src/hir/mod.rs
@@ -36,8 +36,6 @@ pub struct ModuleItems {
     opaques: Box<[LocalDefId]>,
     body_owners: Box<[LocalDefId]>,
     nested_bodies: Box<[LocalDefId]>,
-    // only filled with hir_crate_items, not with hir_module_items
-    delayed_lint_items: Box<[OwnerId]>,
 
     /// Statics and functions with an `EiiImpls` or `EiiExternTarget` attribute
     eiis: Box<[LocalDefId]>,
@@ -56,10 +54,6 @@ impl ModuleItems {
 
     pub fn trait_items(&self) -> impl Iterator<Item = TraitItemId> {
         self.trait_items.iter().copied()
-    }
-
-    pub fn delayed_lint_items(&self) -> impl Iterator<Item = OwnerId> {
-        self.delayed_lint_items.iter().copied()
     }
 
     pub fn eiis(&self) -> impl Iterator<Item = LocalDefId> {

--- a/tests/incremental/hashes/function_interfaces.rs
+++ b/tests/incremental/hashes/function_interfaces.rs
@@ -275,9 +275,9 @@ pub fn inline_never() {}
 pub fn no_mangle() {}
 
 #[cfg(not(any(bpass1,bpass4)))]
-#[rustc_clean(cfg = "bpass2", except="hir_owner")] // dirty because of stashed UNSAFE_CODE lint
+#[rustc_clean(cfg = "bpass2")]
 #[rustc_clean(cfg = "bpass3")]
-#[rustc_clean(cfg = "bpass5", except="hir_owner")] // dirty because of stashed UNSAFE_CODE lint
+#[rustc_clean(cfg = "bpass5")]
 #[rustc_clean(cfg = "bpass6")]
 #[unsafe(no_mangle)]
 pub fn no_mangle() {}

--- a/tests/incremental/hashes/inherent_impls.rs
+++ b/tests/incremental/hashes/inherent_impls.rs
@@ -645,9 +645,9 @@ impl Foo {
 // Add #[no_mangle] to Method --------------------------------------------------
 #[cfg(any(bpass1,bpass4))]
 impl Foo {
-    //-------------------------------------------------------------------------------------------
     //--------------------------
-    //-------------------------------------------------------------------------------------------
+    //--------------------------
+    //--------------------------
     //--------------------------
     //------------------
     pub fn add_no_mangle_to_method(&self) { }
@@ -659,9 +659,9 @@ impl Foo {
 #[rustc_clean(cfg="bpass5")]
 #[rustc_clean(cfg="bpass6")]
 impl Foo {
-    #[rustc_clean(cfg="bpass2", except="hir_owner")] // dirty because of stashed UNSAFE_CODE lint
+    #[rustc_clean(cfg="bpass2")]
     #[rustc_clean(cfg="bpass3")]
-    #[rustc_clean(cfg="bpass5", except="hir_owner")] // dirty because of stashed UNSAFE_CODE lint
+    #[rustc_clean(cfg="bpass5")]
     #[rustc_clean(cfg="bpass6")]
     #[unsafe(no_mangle)]
     pub fn add_no_mangle_to_method(&self) { }

--- a/tests/incremental/hashes/statics.rs
+++ b/tests/incremental/hashes/statics.rs
@@ -62,9 +62,9 @@ static STATIC_LINKAGE: u8 = 0;
 static STATIC_NO_MANGLE: u8 = 0;
 
 #[cfg(not(any(bpass1,bpass4)))]
-#[rustc_clean(cfg="bpass2", except="hir_owner")] // dirty because of stashed UNSAFE_CODE lint
+#[rustc_clean(cfg="bpass2")]
 #[rustc_clean(cfg="bpass3")]
-#[rustc_clean(cfg="bpass5", except="hir_owner")] // dirty because of stashed UNSAFE_CODE lint
+#[rustc_clean(cfg="bpass5")]
 #[rustc_clean(cfg="bpass6")]
 #[unsafe(no_mangle)]
 static STATIC_NO_MANGLE: u8 = 0;

--- a/tests/incremental/hashes/trait_impls.rs
+++ b/tests/incremental/hashes/trait_impls.rs
@@ -565,9 +565,9 @@ trait AddNoMangleToMethod {
 
 #[cfg(any(bpass1,bpass4))]
 impl AddNoMangleToMethod for Foo {
-    //-------------------------------------------------------------------------------------------
     //--------------------------
-    //-------------------------------------------------------------------------------------------
+    //--------------------------
+    //--------------------------
     //--------------------------
     //------------------
     fn add_no_mangle_to_method(&self) { }
@@ -579,9 +579,9 @@ impl AddNoMangleToMethod for Foo {
 #[rustc_clean(cfg="bpass5")]
 #[rustc_clean(cfg="bpass6")]
 impl AddNoMangleToMethod for Foo {
-    #[rustc_clean(cfg="bpass2", except="hir_owner")] // dirty because of stashed UNSAFE_CODE lint
+    #[rustc_clean(cfg="bpass2")]
     #[rustc_clean(cfg="bpass3")]
-    #[rustc_clean(cfg="bpass5", except="hir_owner")] // dirty because of stashed UNSAFE_CODE lint
+    #[rustc_clean(cfg="bpass5")]
     #[rustc_clean(cfg="bpass6")]
     #[unsafe(no_mangle)]
     fn add_no_mangle_to_method(&self) { }

--- a/tests/rustdoc-ui/doc-cfg-check-cfg.cfg_empty.stderr
+++ b/tests/rustdoc-ui/doc-cfg-check-cfg.cfg_empty.stderr
@@ -1,4 +1,14 @@
 warning: unexpected `cfg` condition name: `foo`
+  --> $DIR/doc-cfg-check-cfg.rs:12:12
+   |
+LL | #![doc(cfg(foo))]
+   |            ^^^
+   |
+   = help: to expect this configuration use `--check-cfg=cfg(foo)`
+   = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
+   = note: `#[warn(unexpected_cfgs)]` on by default
+
+warning: unexpected `cfg` condition name: `foo`
   --> $DIR/doc-cfg-check-cfg.rs:15:11
    |
 LL | #[doc(cfg(foo))]
@@ -6,22 +16,12 @@ LL | #[doc(cfg(foo))]
    |
    = help: to expect this configuration use `--check-cfg=cfg(foo)`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
-   = note: `#[warn(unexpected_cfgs)]` on by default
 
 warning: unexpected `cfg` condition name: `foo`
   --> $DIR/doc-cfg-check-cfg.rs:19:11
    |
 LL | #[doc(cfg(foo))]
    |           ^^^
-   |
-   = help: to expect this configuration use `--check-cfg=cfg(foo)`
-   = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
-
-warning: unexpected `cfg` condition name: `foo`
-  --> $DIR/doc-cfg-check-cfg.rs:12:12
-   |
-LL | #![doc(cfg(foo))]
-   |            ^^^
    |
    = help: to expect this configuration use `--check-cfg=cfg(foo)`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration

--- a/tests/rustdoc-ui/lints/doc-attr-2.stderr
+++ b/tests/rustdoc-ui/lints/doc-attr-2.stderr
@@ -1,14 +1,20 @@
 error: unknown `doc` attribute `as_ptr`
-  --> $DIR/doc-attr-2.rs:5:7
+  --> $DIR/doc-attr-2.rs:2:8
    |
-LL | #[doc(as_ptr)]
-   |       ^^^^^^
+LL | #![doc(as_ptr)]
+   |        ^^^^^^
    |
 note: the lint level is defined here
   --> $DIR/doc-attr-2.rs:1:9
    |
 LL | #![deny(invalid_doc_attributes)]
    |         ^^^^^^^^^^^^^^^^^^^^^^
+
+error: unknown `doc` attribute `as_ptr`
+  --> $DIR/doc-attr-2.rs:5:7
+   |
+LL | #[doc(as_ptr)]
+   |       ^^^^^^
 
 error: unknown `doc` attribute `foo::bar`
   --> $DIR/doc-attr-2.rs:9:7
@@ -21,12 +27,6 @@ error: unknown `doc` attribute `crate::bar::baz`
    |
 LL | #[doc(foo::bar, crate::bar::baz = "bye")]
    |                 ^^^^^^^^^^^^^^^
-
-error: unknown `doc` attribute `as_ptr`
-  --> $DIR/doc-attr-2.rs:2:8
-   |
-LL | #![doc(as_ptr)]
-   |        ^^^^^^
 
 error: aborting due to 4 previous errors
 

--- a/tests/rustdoc-ui/lints/invalid-doc-attr-3.stderr
+++ b/tests/rustdoc-ui/lints/invalid-doc-attr-3.stderr
@@ -1,8 +1,8 @@
 error: didn't expect any arguments here
-  --> $DIR/invalid-doc-attr-3.rs:10:14
+  --> $DIR/invalid-doc-attr-3.rs:3:29
    |
-LL | #[doc(hidden = true)]
-   |              ^^^^^^
+LL | #![doc(test(no_crate_inject = 1))]
+   |                             ^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 note: the lint level is defined here
@@ -10,6 +10,22 @@ note: the lint level is defined here
    |
 LL | #![deny(invalid_doc_attributes)]
    |         ^^^^^^^^^^^^^^^^^^^^^^
+
+error: malformed `doc` attribute input
+  --> $DIR/invalid-doc-attr-3.rs:6:1
+   |
+LL | #![doc(test(attr = 1))]
+   | ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+
+error: didn't expect any arguments here
+  --> $DIR/invalid-doc-attr-3.rs:10:14
+   |
+LL | #[doc(hidden = true)]
+   |              ^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 error: didn't expect any arguments here
   --> $DIR/invalid-doc-attr-3.rs:13:13
@@ -32,22 +48,6 @@ error: malformed `doc` attribute input
    |
 LL | #[doc = 1]
    |         ^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-
-error: didn't expect any arguments here
-  --> $DIR/invalid-doc-attr-3.rs:3:29
-   |
-LL | #![doc(test(no_crate_inject = 1))]
-   |                             ^^^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-
-error: malformed `doc` attribute input
-  --> $DIR/invalid-doc-attr-3.rs:6:1
-   |
-LL | #![doc(test(attr = 1))]
-   | ^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 

--- a/tests/ui/attributes/doc-attr.stderr
+++ b/tests/ui/attributes/doc-attr.stderr
@@ -1,14 +1,20 @@
 error: unknown `doc` attribute `as_ptr`
-  --> $DIR/doc-attr.rs:6:7
+  --> $DIR/doc-attr.rs:3:8
    |
-LL | #[doc(as_ptr)]
-   |       ^^^^^^
+LL | #![doc(as_ptr)]
+   |        ^^^^^^
    |
 note: the lint level is defined here
   --> $DIR/doc-attr.rs:1:9
    |
 LL | #![deny(invalid_doc_attributes)]
    |         ^^^^^^^^^^^^^^^^^^^^^^
+
+error: unknown `doc` attribute `as_ptr`
+  --> $DIR/doc-attr.rs:6:7
+   |
+LL | #[doc(as_ptr)]
+   |       ^^^^^^
 
 error: expected this to be of the form `... = "..."`
   --> $DIR/doc-attr.rs:10:7
@@ -45,12 +51,6 @@ error: unknown `doc` attribute `crate::bar::baz`
    |
 LL | #[doc(foo::bar, crate::bar::baz = "bye")]
    |                 ^^^^^^^^^^^^^^^
-
-error: unknown `doc` attribute `as_ptr`
-  --> $DIR/doc-attr.rs:3:8
-   |
-LL | #![doc(as_ptr)]
-   |        ^^^^^^
 
 error: aborting due to 7 previous errors
 

--- a/tests/ui/attributes/malformed-no-std.stderr
+++ b/tests/ui/attributes/malformed-no-std.stderr
@@ -118,23 +118,6 @@ note: this attribute does not have an `!`, which means it is applied to this ext
 LL | extern crate core;
    | ^^^^^^^^^^^^^^^^^^
 
-error: crate-level attribute should be an inner attribute: add an exclamation mark: `#![no_std]`
-  --> $DIR/malformed-no-std.rs:21:1
-   |
-LL | #[no_std]
-   | ^^^^^^^^^
-   |
-note: this attribute does not have an `!`, which means it is applied to this extern crate
-  --> $DIR/malformed-no-std.rs:26:1
-   |
-LL | extern crate core;
-   | ^^^^^^^^^^^^^^^^^^
-note: the lint level is defined here
-  --> $DIR/malformed-no-std.rs:20:8
-   |
-LL | #[deny(unused_attributes)]
-   |        ^^^^^^^^^^^^^^^^^
-
 warning: unused attribute
   --> $DIR/malformed-no-std.rs:5:1
    |
@@ -159,6 +142,23 @@ note: attribute also specified here
    |
 LL | #![no_std = "foo"]
    | ^^^^^^^^^^^^^^^^^^
+
+error: crate-level attribute should be an inner attribute: add an exclamation mark: `#![no_std]`
+  --> $DIR/malformed-no-std.rs:21:1
+   |
+LL | #[no_std]
+   | ^^^^^^^^^
+   |
+note: this attribute does not have an `!`, which means it is applied to this extern crate
+  --> $DIR/malformed-no-std.rs:26:1
+   |
+LL | extern crate core;
+   | ^^^^^^^^^^^^^^^^^^
+note: the lint level is defined here
+  --> $DIR/malformed-no-std.rs:20:8
+   |
+LL | #[deny(unused_attributes)]
+   |        ^^^^^^^^^^^^^^^^^
 
 error: aborting due to 10 previous errors; 2 warnings emitted
 

--- a/tests/ui/extern/extern-no-mangle.stderr
+++ b/tests/ui/extern/extern-no-mangle.stderr
@@ -1,5 +1,5 @@
-warning: `#[no_mangle]` attribute cannot be used on foreign statics
-  --> $DIR/extern-no-mangle.rs:11:5
+warning: `#[no_mangle]` attribute cannot be used on statements
+  --> $DIR/extern-no-mangle.rs:24:5
    |
 LL |     #[no_mangle]
    |     ^^^^^^^^^^^^
@@ -12,6 +12,15 @@ note: the lint level is defined here
 LL | #![warn(unused_attributes)]
    |         ^^^^^^^^^^^^^^^^^
 
+warning: `#[no_mangle]` attribute cannot be used on foreign statics
+  --> $DIR/extern-no-mangle.rs:11:5
+   |
+LL |     #[no_mangle]
+   |     ^^^^^^^^^^^^
+   |
+   = help: `#[no_mangle]` can be applied to functions and statics
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+
 warning: `#[no_mangle]` attribute cannot be used on foreign functions
   --> $DIR/extern-no-mangle.rs:16:5
    |
@@ -19,15 +28,6 @@ LL |     #[no_mangle]
    |     ^^^^^^^^^^^^
    |
    = help: `#[no_mangle]` can be applied to functions with a body and statics
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-
-warning: `#[no_mangle]` attribute cannot be used on statements
-  --> $DIR/extern-no-mangle.rs:24:5
-   |
-LL |     #[no_mangle]
-   |     ^^^^^^^^^^^^
-   |
-   = help: `#[no_mangle]` can be applied to functions and statics
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: 3 warnings emitted

--- a/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs-error.stderr
+++ b/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs-error.stderr
@@ -305,6 +305,23 @@ help: remove the `#[no_mangle]` attribute
 LL - #![no_mangle]
    |
 
+warning: unused attribute
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:16:1
+   |
+LL | #![repr()]
+   | ^^^^^^^^^^ help: remove this attribute
+   |
+   = note: using `repr` with an empty list has no effect
+
+warning: `#[no_mangle]` attribute cannot be used on crates
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:24:1
+   |
+LL | #![no_mangle]
+   | ^^^^^^^^^^^^^
+   |
+   = help: `#[no_mangle]` can be applied to functions and statics
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+
 error: valid forms for the attribute are `#[inline(always)]`, `#[inline(never)]`, and `#[inline]`
   --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:43:5
    |
@@ -340,23 +357,6 @@ LL |     #[no_link]
    |     ^^^^^^^^^^
    |
    = help: `#[no_link]` can only be applied to extern crates
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-
-warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:16:1
-   |
-LL | #![repr()]
-   | ^^^^^^^^^^ help: remove this attribute
-   |
-   = note: using `repr` with an empty list has no effect
-
-warning: `#[no_mangle]` attribute cannot be used on crates
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:24:1
-   |
-LL | #![no_mangle]
-   | ^^^^^^^^^^^^^
-   |
-   = help: `#[no_mangle]` can be applied to functions and statics
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 error: aborting due to 37 previous errors; 6 warnings emitted

--- a/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs.stderr
+++ b/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs.stderr
@@ -207,6 +207,87 @@ note: the lint level is defined here
 LL | #![warn(unused_attributes, unknown_lints)]
    |         ^^^^^^^^^^^^^^^^^
 
+warning: `#[macro_use]` attribute cannot be used on crates
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:45:1
+   |
+LL | #![macro_use]
+   | ^^^^^^^^^^^^^
+   |
+   = help: `#[macro_use]` can be applied to extern crates and modules
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+
+warning: `#[should_panic]` attribute cannot be used on crates
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:51:1
+   |
+LL | #![should_panic]
+   | ^^^^^^^^^^^^^^^^
+   |
+   = help: `#[should_panic]` can only be applied to functions
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+
+warning: `#[ignore]` attribute cannot be used on crates
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:55:1
+   |
+LL | #![ignore]
+   | ^^^^^^^^^^
+   |
+   = help: `#[ignore]` can only be applied to functions
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+
+warning: `#[proc_macro_derive]` attribute cannot be used on crates
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:63:1
+   |
+LL | #![proc_macro_derive(Test)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[proc_macro_derive]` can only be applied to functions
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+
+warning: `#[cold]` attribute cannot be used on crates
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:68:1
+   |
+LL | #![cold]
+   | ^^^^^^^^
+   |
+   = help: `#[cold]` can only be applied to functions
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+
+warning: `#[link]` attribute cannot be used on crates
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:72:1
+   |
+LL | #![link(name = "x")]
+   | ^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[link]` can only be applied to foreign modules
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+
+warning: `#[link_name]` attribute cannot be used on crates
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:76:1
+   |
+LL | #![link_name = "1900"]
+   | ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[link_name]` can be applied to foreign functions and foreign statics
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+
+warning: `#[link_section]` attribute cannot be used on crates
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:81:1
+   |
+LL | #![link_section = ",1800"]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[link_section]` can be applied to functions and statics
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+
+warning: `#[must_use]` attribute cannot be used on crates
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:86:1
+   |
+LL | #![must_use]
+   | ^^^^^^^^^^^^
+   |
+   = help: `#[must_use]` can be applied to data types, functions, and traits
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+
 warning: `#[macro_use]` attribute cannot be used on functions
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:193:5
    |
@@ -439,24 +520,6 @@ LL |     #[no_mangle] impl S { }
    |     ^^^^^^^^^^^^
    |
    = help: `#[no_mangle]` can be applied to functions and statics
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-
-warning: `#[no_mangle]` attribute cannot be used on required trait methods
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:362:9
-   |
-LL |         #[no_mangle] fn foo();
-   |         ^^^^^^^^^^^^
-   |
-   = help: `#[no_mangle]` can be applied to functions with a body and statics
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-
-warning: `#[no_mangle]` attribute cannot be used on provided trait methods
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:368:9
-   |
-LL |         #[no_mangle] fn bar() {}
-   |         ^^^^^^^^^^^^
-   |
-   = help: `#[no_mangle]` can be applied to functions, inherent methods, statics, and trait methods in impl blocks
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[should_panic]` attribute cannot be used on modules
@@ -851,15 +914,6 @@ LL |     #[link_section = ",1800"]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: `#[link_section]` can be applied to functions and statics
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-
-warning: `#[link_section]` attribute cannot be used on required trait methods
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:661:9
-   |
-LL |         #[link_section = ",1800"]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = help: `#[link_section]` can be applied to functions with a body and statics
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[link]` attribute cannot be used on modules
@@ -1512,85 +1566,31 @@ note: this attribute does not have an `!`, which means it is applied to this imp
 LL |     #[type_length_limit="0100"] impl S { }
    |                                 ^^^^^^^^^^
 
-warning: `#[macro_use]` attribute cannot be used on crates
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:45:1
+warning: `#[no_mangle]` attribute cannot be used on required trait methods
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:362:9
    |
-LL | #![macro_use]
-   | ^^^^^^^^^^^^^
+LL |         #[no_mangle] fn foo();
+   |         ^^^^^^^^^^^^
    |
-   = help: `#[macro_use]` can be applied to extern crates and modules
+   = help: `#[no_mangle]` can be applied to functions with a body and statics
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[should_panic]` attribute cannot be used on crates
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:51:1
+warning: `#[no_mangle]` attribute cannot be used on provided trait methods
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:368:9
    |
-LL | #![should_panic]
-   | ^^^^^^^^^^^^^^^^
+LL |         #[no_mangle] fn bar() {}
+   |         ^^^^^^^^^^^^
    |
-   = help: `#[should_panic]` can only be applied to functions
+   = help: `#[no_mangle]` can be applied to functions, inherent methods, statics, and trait methods in impl blocks
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[ignore]` attribute cannot be used on crates
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:55:1
+warning: `#[link_section]` attribute cannot be used on required trait methods
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:661:9
    |
-LL | #![ignore]
-   | ^^^^^^^^^^
+LL |         #[link_section = ",1800"]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[ignore]` can only be applied to functions
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-
-warning: `#[proc_macro_derive]` attribute cannot be used on crates
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:63:1
-   |
-LL | #![proc_macro_derive(Test)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = help: `#[proc_macro_derive]` can only be applied to functions
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-
-warning: `#[cold]` attribute cannot be used on crates
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:68:1
-   |
-LL | #![cold]
-   | ^^^^^^^^
-   |
-   = help: `#[cold]` can only be applied to functions
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-
-warning: `#[link]` attribute cannot be used on crates
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:72:1
-   |
-LL | #![link(name = "x")]
-   | ^^^^^^^^^^^^^^^^^^^^
-   |
-   = help: `#[link]` can only be applied to foreign modules
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-
-warning: `#[link_name]` attribute cannot be used on crates
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:76:1
-   |
-LL | #![link_name = "1900"]
-   | ^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = help: `#[link_name]` can be applied to foreign functions and foreign statics
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-
-warning: `#[link_section]` attribute cannot be used on crates
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:81:1
-   |
-LL | #![link_section = ",1800"]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = help: `#[link_section]` can be applied to functions and statics
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-
-warning: `#[must_use]` attribute cannot be used on crates
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:86:1
-   |
-LL | #![must_use]
-   | ^^^^^^^^^^^^
-   |
-   = help: `#[must_use]` can be applied to data types, functions, and traits
+   = help: `#[link_section]` can be applied to functions with a body and statics
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: 170 warnings emitted

--- a/tests/ui/feature-gates/issue-43106-gating-of-macro_use.stderr
+++ b/tests/ui/feature-gates/issue-43106-gating-of-macro_use.stderr
@@ -34,6 +34,16 @@ LL -     #[macro_use = "2700"] struct S;
 LL +     #[macro_use] struct S;
    |
 
+warning: `#[macro_use]` attribute cannot be used on crates
+  --> $DIR/issue-43106-gating-of-macro_use.rs:6:1
+   |
+LL | #![macro_use(my_macro)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[macro_use]` can be applied to extern crates and modules
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: requested on the command line with `-W unused-attributes`
+
 warning: `#[macro_use]` attribute cannot be used on structs
   --> $DIR/issue-43106-gating-of-macro_use.rs:17:5
    |
@@ -42,7 +52,6 @@ LL |     #[macro_use = "2700"] struct S;
    |
    = help: `#[macro_use]` can be applied to extern crates and modules
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: requested on the command line with `-W unused-attributes`
 
 warning: `#[macro_use]` attribute cannot be used on functions
   --> $DIR/issue-43106-gating-of-macro_use.rs:22:5
@@ -67,15 +76,6 @@ warning: `#[macro_use]` attribute cannot be used on inherent impl blocks
    |
 LL |     #[macro_use] impl S { }
    |     ^^^^^^^^^^^^
-   |
-   = help: `#[macro_use]` can be applied to extern crates and modules
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-
-warning: `#[macro_use]` attribute cannot be used on crates
-  --> $DIR/issue-43106-gating-of-macro_use.rs:6:1
-   |
-LL | #![macro_use(my_macro)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: `#[macro_use]` can be applied to extern crates and modules
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!

--- a/tests/ui/lint/lint-unsafe-code.stderr
+++ b/tests/ui/lint/lint-unsafe-code.stderr
@@ -109,22 +109,6 @@ LL | #[no_mangle] static FOO: u32 = 5;
    |
    = note: the linker's behavior with multiple libraries exporting duplicate symbol names is undefined and Rust cannot provide guarantees when you manually override them
 
-error: usage of the unsafe `#[no_mangle]` attribute
-  --> $DIR/lint-unsafe-code.rs:48:7
-   |
-LL |     #[no_mangle] fn foo() {}
-   |       ^^^^^^^^^
-   |
-   = note: the linker's behavior with multiple libraries exporting duplicate symbol names is undefined and Rust cannot provide guarantees when you manually override them
-
-error: usage of the unsafe `#[no_mangle]` attribute
-  --> $DIR/lint-unsafe-code.rs:52:7
-   |
-LL |     #[no_mangle] fn foo() {}
-   |       ^^^^^^^^^
-   |
-   = note: the linker's behavior with multiple libraries exporting duplicate symbol names is undefined and Rust cannot provide guarantees when you manually override them
-
 error: usage of the unsafe `#[export_name]` attribute
   --> $DIR/lint-unsafe-code.rs:55:3
    |
@@ -156,22 +140,6 @@ LL | #[link_section = "__TEXT,__text"] static UWU: u32 = 5;
    |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: the program's behavior with overridden link sections on items is unpredictable and Rust cannot provide guarantees when you manually override them
-
-error: usage of the unsafe `#[export_name]` attribute
-  --> $DIR/lint-unsafe-code.rs:64:7
-   |
-LL |     #[export_name = "bar"] fn bar() {}
-   |       ^^^^^^^^^^^^^^^^^^^
-   |
-   = note: the linker's behavior with multiple libraries exporting duplicate symbol names is undefined and Rust cannot provide guarantees when you manually override them
-
-error: usage of the unsafe `#[export_name]` attribute
-  --> $DIR/lint-unsafe-code.rs:68:7
-   |
-LL |     #[export_name = "bar"] fn foo() {}
-   |       ^^^^^^^^^^^^^^^^^^^
-   |
-   = note: the linker's behavior with multiple libraries exporting duplicate symbol names is undefined and Rust cannot provide guarantees when you manually override them
 
 error: usage of the unsafe `#[no_mangle]` attribute
   --> $DIR/lint-unsafe-code.rs:28:11
@@ -229,18 +197,66 @@ LL | #[unsafe(naked)] fn naked1() { naked_asm!("halt") }
    |
    = note: the `#[naked]` attribute adds the safety obligation that the function's body must respect the function’s calling convention, uphold its signature, and either return or diverge (i.e., not fall through past the end of the assembly code).
 
-error: usage of the unsafe `#[naked]` attribute
-  --> $DIR/lint-unsafe-code.rs:144:14
+error: usage of the unsafe `#[force_target_feature]` attribute
+  --> $DIR/lint-unsafe-code.rs:168:10
    |
-LL |     #[unsafe(naked)] fn naked2() { naked_asm!("halt") }
-   |              ^^^^^
+LL | #[unsafe(force_target_feature(enable = "avx2"))] fn force_target_feature() { }
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: the `#[naked]` attribute adds the safety obligation that the function's body must respect the function’s calling convention, uphold its signature, and either return or diverge (i.e., not fall through past the end of the assembly code).
+   = note: a function with the signature of the function the attribute is applied to must only be callable if the force-enabled features are guaranteed to be present
 
 error: usage of the unsafe `#[naked]` attribute
   --> $DIR/lint-unsafe-code.rs:149:14
    |
 LL |     #[unsafe(naked)] fn naked3() { naked_asm!("halt") }
+   |              ^^^^^
+   |
+   = note: the `#[naked]` attribute adds the safety obligation that the function's body must respect the function’s calling convention, uphold its signature, and either return or diverge (i.e., not fall through past the end of the assembly code).
+
+error: usage of the unsafe `#[force_target_feature]` attribute
+  --> $DIR/lint-unsafe-code.rs:178:14
+   |
+LL |     #[unsafe(force_target_feature(enable = "avx2"))] fn force_target_feature() { }
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: a function with the signature of the function the attribute is applied to must only be callable if the force-enabled features are guaranteed to be present
+
+error: usage of the unsafe `#[no_mangle]` attribute
+  --> $DIR/lint-unsafe-code.rs:48:7
+   |
+LL |     #[no_mangle] fn foo() {}
+   |       ^^^^^^^^^
+   |
+   = note: the linker's behavior with multiple libraries exporting duplicate symbol names is undefined and Rust cannot provide guarantees when you manually override them
+
+error: usage of the unsafe `#[no_mangle]` attribute
+  --> $DIR/lint-unsafe-code.rs:52:7
+   |
+LL |     #[no_mangle] fn foo() {}
+   |       ^^^^^^^^^
+   |
+   = note: the linker's behavior with multiple libraries exporting duplicate symbol names is undefined and Rust cannot provide guarantees when you manually override them
+
+error: usage of the unsafe `#[export_name]` attribute
+  --> $DIR/lint-unsafe-code.rs:64:7
+   |
+LL |     #[export_name = "bar"] fn bar() {}
+   |       ^^^^^^^^^^^^^^^^^^^
+   |
+   = note: the linker's behavior with multiple libraries exporting duplicate symbol names is undefined and Rust cannot provide guarantees when you manually override them
+
+error: usage of the unsafe `#[export_name]` attribute
+  --> $DIR/lint-unsafe-code.rs:68:7
+   |
+LL |     #[export_name = "bar"] fn foo() {}
+   |       ^^^^^^^^^^^^^^^^^^^
+   |
+   = note: the linker's behavior with multiple libraries exporting duplicate symbol names is undefined and Rust cannot provide guarantees when you manually override them
+
+error: usage of the unsafe `#[naked]` attribute
+  --> $DIR/lint-unsafe-code.rs:144:14
+   |
+LL |     #[unsafe(naked)] fn naked2() { naked_asm!("halt") }
    |              ^^^^^
    |
    = note: the `#[naked]` attribute adds the safety obligation that the function's body must respect the function’s calling convention, uphold its signature, and either return or diverge (i.e., not fall through past the end of the assembly code).
@@ -252,6 +268,22 @@ LL |     #[unsafe(naked)] fn naked4() { naked_asm!("halt") }
    |              ^^^^^
    |
    = note: the `#[naked]` attribute adds the safety obligation that the function's body must respect the function’s calling convention, uphold its signature, and either return or diverge (i.e., not fall through past the end of the assembly code).
+
+error: usage of the unsafe `#[force_target_feature]` attribute
+  --> $DIR/lint-unsafe-code.rs:173:14
+   |
+LL |     #[unsafe(force_target_feature(enable = "avx2"))] fn force_target_feature() { }
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: a function with the signature of the function the attribute is applied to must only be callable if the force-enabled features are guaranteed to be present
+
+error: usage of the unsafe `#[force_target_feature]` attribute
+  --> $DIR/lint-unsafe-code.rs:182:14
+   |
+LL |     #[unsafe(force_target_feature(enable = "avx2"))] fn force_target_feature() { }
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: a function with the signature of the function the attribute is applied to must only be callable if the force-enabled features are guaranteed to be present
 
 error: usage of the unsafe `#[ffi_pure]` attribute
   --> $DIR/lint-unsafe-code.rs:159:14
@@ -268,38 +300,6 @@ LL |     #[unsafe(ffi_const)]
    |              ^^^^^^^^^
    |
    = note: `#[ffi_const]` functions shall have no effects except for its return value, which can only depend on the values of the function parameters, and is not affected by changes to the observable state of the program.
-
-error: usage of the unsafe `#[force_target_feature]` attribute
-  --> $DIR/lint-unsafe-code.rs:168:10
-   |
-LL | #[unsafe(force_target_feature(enable = "avx2"))] fn force_target_feature() { }
-   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: a function with the signature of the function the attribute is applied to must only be callable if the force-enabled features are guaranteed to be present
-
-error: usage of the unsafe `#[force_target_feature]` attribute
-  --> $DIR/lint-unsafe-code.rs:173:14
-   |
-LL |     #[unsafe(force_target_feature(enable = "avx2"))] fn force_target_feature() { }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: a function with the signature of the function the attribute is applied to must only be callable if the force-enabled features are guaranteed to be present
-
-error: usage of the unsafe `#[force_target_feature]` attribute
-  --> $DIR/lint-unsafe-code.rs:178:14
-   |
-LL |     #[unsafe(force_target_feature(enable = "avx2"))] fn force_target_feature() { }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: a function with the signature of the function the attribute is applied to must only be callable if the force-enabled features are guaranteed to be present
-
-error: usage of the unsafe `#[force_target_feature]` attribute
-  --> $DIR/lint-unsafe-code.rs:182:14
-   |
-LL |     #[unsafe(force_target_feature(enable = "avx2"))] fn force_target_feature() { }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: a function with the signature of the function the attribute is applied to must only be callable if the force-enabled features are guaranteed to be present
 
 error: aborting due to 38 previous errors
 

--- a/tests/ui/lint/unused/empty-attributes.stderr
+++ b/tests/ui/lint/unused/empty-attributes.stderr
@@ -44,6 +44,14 @@ LL | #![forbid()]
    = note: attribute `forbid` with an empty list has no effect
 
 error: unused attribute
+  --> $DIR/empty-attributes.rs:7:1
+   |
+LL | #![feature()]
+   | ^^^^^^^^^^^^^ help: remove this attribute
+   |
+   = note: using `feature` with an empty list has no effect
+
+error: unused attribute
   --> $DIR/empty-attributes.rs:9:1
    |
 LL | #[repr()]
@@ -58,14 +66,6 @@ LL | #[target_feature()]
    | ^^^^^^^^^^^^^^^^^^^ help: remove this attribute
    |
    = note: using `target_feature` with an empty list has no effect
-
-error: unused attribute
-  --> $DIR/empty-attributes.rs:7:1
-   |
-LL | #![feature()]
-   | ^^^^^^^^^^^^^ help: remove this attribute
-   |
-   = note: using `feature` with an empty list has no effect
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/lint/unused/unused-attr-duplicate.stderr
+++ b/tests/ui/lint/unused/unused-attr-duplicate.stderr
@@ -17,6 +17,95 @@ LL | #![deny(unused_attributes)]
    |         ^^^^^^^^^^^^^^^^^
 
 error: unused attribute
+  --> $DIR/unused-attr-duplicate.rs:14:1
+   |
+LL | #![crate_name = "unused_attr_duplicate2"]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
+   |
+note: attribute also specified here
+  --> $DIR/unused-attr-duplicate.rs:13:1
+   |
+LL | #![crate_name = "unused_attr_duplicate"]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: unused attribute
+  --> $DIR/unused-attr-duplicate.rs:21:1
+   |
+LL | #![recursion_limit = "256"]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
+   |
+note: attribute also specified here
+  --> $DIR/unused-attr-duplicate.rs:20:1
+   |
+LL | #![recursion_limit = "128"]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+
+error: unused attribute
+  --> $DIR/unused-attr-duplicate.rs:24:1
+   |
+LL | #![type_length_limit = "1"]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
+   |
+note: attribute also specified here
+  --> $DIR/unused-attr-duplicate.rs:23:1
+   |
+LL | #![type_length_limit = "1048576"]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+
+error: unused attribute
+  --> $DIR/unused-attr-duplicate.rs:27:1
+   |
+LL | #![no_std]
+   | ^^^^^^^^^^ help: remove this attribute
+   |
+note: attribute also specified here
+  --> $DIR/unused-attr-duplicate.rs:26:1
+   |
+LL | #![no_std]
+   | ^^^^^^^^^^
+
+error: unused attribute
+  --> $DIR/unused-attr-duplicate.rs:29:1
+   |
+LL | #![no_implicit_prelude]
+   | ^^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
+   |
+note: attribute also specified here
+  --> $DIR/unused-attr-duplicate.rs:28:1
+   |
+LL | #![no_implicit_prelude]
+   | ^^^^^^^^^^^^^^^^^^^^^^^
+
+error: unused attribute
+  --> $DIR/unused-attr-duplicate.rs:31:1
+   |
+LL | #![windows_subsystem = "windows"]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
+   |
+note: attribute also specified here
+  --> $DIR/unused-attr-duplicate.rs:30:1
+   |
+LL | #![windows_subsystem = "console"]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+
+error: unused attribute
+  --> $DIR/unused-attr-duplicate.rs:34:1
+   |
+LL | #![no_builtins]
+   | ^^^^^^^^^^^^^^^ help: remove this attribute
+   |
+note: attribute also specified here
+  --> $DIR/unused-attr-duplicate.rs:33:1
+   |
+LL | #![no_builtins]
+   | ^^^^^^^^^^^^^^^
+
+error: unused attribute
   --> $DIR/unused-attr-duplicate.rs:37:1
    |
 LL | #[no_link]
@@ -165,19 +254,6 @@ LL | #[track_caller]
    | ^^^^^^^^^^^^^^^
 
 error: unused attribute
-  --> $DIR/unused-attr-duplicate.rs:94:5
-   |
-LL |     #[link_name = "rust_dbg_extern_identity_u32"]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
-   |
-note: attribute also specified here
-  --> $DIR/unused-attr-duplicate.rs:93:5
-   |
-LL |     #[link_name = "this_does_not_exist"]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-
-error: unused attribute
   --> $DIR/unused-attr-duplicate.rs:100:1
    |
 LL | #[export_name = "exported_symbol_name2"]
@@ -228,93 +304,17 @@ LL | #[link_section = "__TEXT,__text"]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 error: unused attribute
-  --> $DIR/unused-attr-duplicate.rs:14:1
+  --> $DIR/unused-attr-duplicate.rs:94:5
    |
-LL | #![crate_name = "unused_attr_duplicate2"]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
+LL |     #[link_name = "rust_dbg_extern_identity_u32"]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
    |
 note: attribute also specified here
-  --> $DIR/unused-attr-duplicate.rs:13:1
+  --> $DIR/unused-attr-duplicate.rs:93:5
    |
-LL | #![crate_name = "unused_attr_duplicate"]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     #[link_name = "this_does_not_exist"]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-error: unused attribute
-  --> $DIR/unused-attr-duplicate.rs:21:1
-   |
-LL | #![recursion_limit = "256"]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
-   |
-note: attribute also specified here
-  --> $DIR/unused-attr-duplicate.rs:20:1
-   |
-LL | #![recursion_limit = "128"]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-
-error: unused attribute
-  --> $DIR/unused-attr-duplicate.rs:24:1
-   |
-LL | #![type_length_limit = "1"]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
-   |
-note: attribute also specified here
-  --> $DIR/unused-attr-duplicate.rs:23:1
-   |
-LL | #![type_length_limit = "1048576"]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-
-error: unused attribute
-  --> $DIR/unused-attr-duplicate.rs:27:1
-   |
-LL | #![no_std]
-   | ^^^^^^^^^^ help: remove this attribute
-   |
-note: attribute also specified here
-  --> $DIR/unused-attr-duplicate.rs:26:1
-   |
-LL | #![no_std]
-   | ^^^^^^^^^^
-
-error: unused attribute
-  --> $DIR/unused-attr-duplicate.rs:29:1
-   |
-LL | #![no_implicit_prelude]
-   | ^^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
-   |
-note: attribute also specified here
-  --> $DIR/unused-attr-duplicate.rs:28:1
-   |
-LL | #![no_implicit_prelude]
-   | ^^^^^^^^^^^^^^^^^^^^^^^
-
-error: unused attribute
-  --> $DIR/unused-attr-duplicate.rs:31:1
-   |
-LL | #![windows_subsystem = "windows"]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
-   |
-note: attribute also specified here
-  --> $DIR/unused-attr-duplicate.rs:30:1
-   |
-LL | #![windows_subsystem = "console"]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-
-error: unused attribute
-  --> $DIR/unused-attr-duplicate.rs:34:1
-   |
-LL | #![no_builtins]
-   | ^^^^^^^^^^^^^^^ help: remove this attribute
-   |
-note: attribute also specified here
-  --> $DIR/unused-attr-duplicate.rs:33:1
-   |
-LL | #![no_builtins]
-   | ^^^^^^^^^^^^^^^
 
 error: aborting due to 25 previous errors
 

--- a/tests/ui/lint/unused/unused_attributes-must_use.stderr
+++ b/tests/ui/lint/unused/unused_attributes-must_use.stderr
@@ -76,15 +76,6 @@ LL | #[must_use]
    = help: `#[must_use]` can be applied to data types, functions, and traits
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-error: `#[must_use]` attribute cannot be used on foreign statics
-  --> $DIR/unused_attributes-must_use.rs:59:5
-   |
-LL |     #[must_use]
-   |     ^^^^^^^^^^^
-   |
-   = help: `#[must_use]` can be applied to data types, functions, and traits
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-
 error: `#[must_use]` attribute cannot be used on type aliases
   --> $DIR/unused_attributes-must_use.rs:73:1
    |
@@ -103,24 +94,6 @@ LL | fn qux<#[must_use] T>(_: T) {}
    = help: `#[must_use]` can be applied to data types, functions, and traits
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-error: `#[must_use]` attribute cannot be used on associated consts
-  --> $DIR/unused_attributes-must_use.rs:82:5
-   |
-LL |     #[must_use]
-   |     ^^^^^^^^^^^
-   |
-   = help: `#[must_use]` can be applied to data types, functions, and traits
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-
-error: `#[must_use]` attribute cannot be used on associated types
-  --> $DIR/unused_attributes-must_use.rs:85:5
-   |
-LL |     #[must_use]
-   |     ^^^^^^^^^^^
-   |
-   = help: `#[must_use]` can be applied to data types, functions, and traits
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-
 error: `#[must_use]` attribute cannot be used on trait impl blocks
   --> $DIR/unused_attributes-must_use.rs:95:1
    |
@@ -128,15 +101,6 @@ LL | #[must_use]
    | ^^^^^^^^^^^
    |
    = help: `#[must_use]` can be applied to data types, functions, and traits
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-
-error: `#[must_use]` attribute cannot be used on trait methods in impl blocks
-  --> $DIR/unused_attributes-must_use.rs:100:5
-   |
-LL |     #[must_use]
-   |     ^^^^^^^^^^^
-   |
-   = help: `#[must_use]` can be applied to data types, foreign functions, functions, inherent methods, provided trait methods, required trait methods, and traits
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 error: `#[must_use]` attribute cannot be used on trait aliases
@@ -198,6 +162,42 @@ error: `#[must_use]` attribute cannot be used on pattern fields
    |
 LL |     let PatternField { #[must_use] foo } = s;
    |                        ^^^^^^^^^^^
+   |
+   = help: `#[must_use]` can be applied to data types, functions, and traits
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+
+error: `#[must_use]` attribute cannot be used on associated consts
+  --> $DIR/unused_attributes-must_use.rs:82:5
+   |
+LL |     #[must_use]
+   |     ^^^^^^^^^^^
+   |
+   = help: `#[must_use]` can be applied to data types, functions, and traits
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+
+error: `#[must_use]` attribute cannot be used on associated types
+  --> $DIR/unused_attributes-must_use.rs:85:5
+   |
+LL |     #[must_use]
+   |     ^^^^^^^^^^^
+   |
+   = help: `#[must_use]` can be applied to data types, functions, and traits
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+
+error: `#[must_use]` attribute cannot be used on trait methods in impl blocks
+  --> $DIR/unused_attributes-must_use.rs:100:5
+   |
+LL |     #[must_use]
+   |     ^^^^^^^^^^^
+   |
+   = help: `#[must_use]` can be applied to data types, foreign functions, functions, inherent methods, provided trait methods, required trait methods, and traits
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+
+error: `#[must_use]` attribute cannot be used on foreign statics
+  --> $DIR/unused_attributes-must_use.rs:59:5
+   |
+LL |     #[must_use]
+   |     ^^^^^^^^^^^
    |
    = help: `#[must_use]` can be applied to data types, functions, and traits
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!

--- a/tests/ui/rfcs/rfc-2565-param-attrs/param-attrs-builtin-attrs.stderr
+++ b/tests/ui/rfcs/rfc-2565-param-attrs/param-attrs-builtin-attrs.stderr
@@ -402,6 +402,60 @@ LL |     #[no_mangle] b: i32,
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[must_use]` attribute cannot be used on function params
+  --> $DIR/param-attrs-builtin-attrs.rs:195:9
+   |
+LL |         #[must_use]
+   |         ^^^^^^^^^^^
+   |
+   = help: `#[must_use]` can be applied to data types, functions, and traits
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+
+warning: `#[no_mangle]` attribute cannot be used on function params
+  --> $DIR/param-attrs-builtin-attrs.rs:201:9
+   |
+LL |         #[no_mangle] b: i32
+   |         ^^^^^^^^^^^^
+   |
+   = help: `#[no_mangle]` can be applied to functions and statics
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+
+warning: `#[must_use]` attribute cannot be used on function params
+  --> $DIR/param-attrs-builtin-attrs.rs:131:9
+   |
+LL |         #[must_use]
+   |         ^^^^^^^^^^^
+   |
+   = help: `#[must_use]` can be applied to data types, functions, and traits
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+
+warning: `#[no_mangle]` attribute cannot be used on function params
+  --> $DIR/param-attrs-builtin-attrs.rs:137:9
+   |
+LL |         #[no_mangle] b: i32,
+   |         ^^^^^^^^^^^^
+   |
+   = help: `#[no_mangle]` can be applied to functions and statics
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+
+warning: `#[must_use]` attribute cannot be used on function params
+  --> $DIR/param-attrs-builtin-attrs.rs:150:9
+   |
+LL |         #[must_use]
+   |         ^^^^^^^^^^^
+   |
+   = help: `#[must_use]` can be applied to data types, functions, and traits
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+
+warning: `#[no_mangle]` attribute cannot be used on function params
+  --> $DIR/param-attrs-builtin-attrs.rs:156:9
+   |
+LL |         #[no_mangle] b: i32,
+   |         ^^^^^^^^^^^^
+   |
+   = help: `#[no_mangle]` can be applied to functions and statics
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+
+warning: `#[must_use]` attribute cannot be used on function params
   --> $DIR/param-attrs-builtin-attrs.rs:64:9
    |
 LL |         #[must_use]
@@ -456,42 +510,6 @@ LL |         #[no_mangle] b: i32,
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[must_use]` attribute cannot be used on function params
-  --> $DIR/param-attrs-builtin-attrs.rs:131:9
-   |
-LL |         #[must_use]
-   |         ^^^^^^^^^^^
-   |
-   = help: `#[must_use]` can be applied to data types, functions, and traits
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-
-warning: `#[no_mangle]` attribute cannot be used on function params
-  --> $DIR/param-attrs-builtin-attrs.rs:137:9
-   |
-LL |         #[no_mangle] b: i32,
-   |         ^^^^^^^^^^^^
-   |
-   = help: `#[no_mangle]` can be applied to functions and statics
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-
-warning: `#[must_use]` attribute cannot be used on function params
-  --> $DIR/param-attrs-builtin-attrs.rs:150:9
-   |
-LL |         #[must_use]
-   |         ^^^^^^^^^^^
-   |
-   = help: `#[must_use]` can be applied to data types, functions, and traits
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-
-warning: `#[no_mangle]` attribute cannot be used on function params
-  --> $DIR/param-attrs-builtin-attrs.rs:156:9
-   |
-LL |         #[no_mangle] b: i32,
-   |         ^^^^^^^^^^^^
-   |
-   = help: `#[no_mangle]` can be applied to functions and statics
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-
-warning: `#[must_use]` attribute cannot be used on function params
   --> $DIR/param-attrs-builtin-attrs.rs:174:9
    |
 LL |         #[must_use]
@@ -504,24 +522,6 @@ warning: `#[no_mangle]` attribute cannot be used on function params
   --> $DIR/param-attrs-builtin-attrs.rs:180:9
    |
 LL |         #[no_mangle] b: i32,
-   |         ^^^^^^^^^^^^
-   |
-   = help: `#[no_mangle]` can be applied to functions and statics
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-
-warning: `#[must_use]` attribute cannot be used on function params
-  --> $DIR/param-attrs-builtin-attrs.rs:195:9
-   |
-LL |         #[must_use]
-   |         ^^^^^^^^^^^
-   |
-   = help: `#[must_use]` can be applied to data types, functions, and traits
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-
-warning: `#[no_mangle]` attribute cannot be used on function params
-  --> $DIR/param-attrs-builtin-attrs.rs:201:9
-   |
-LL |         #[no_mangle] b: i32
    |         ^^^^^^^^^^^^
    |
    = help: `#[no_mangle]` can be applied to functions and statics


### PR DESCRIPTION
Keeping track of `has_delayed_lints` doesn't seem to have a perf effect anymore so let's not make the code more complicated than needed. These flags were previously used so we don't have to iterate over all hir owners, but iterating over all hir owners seems fast enough

cc @jdonszelmann 