### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -905,6 +905,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "tempfile",
  "tracing",
  "tracing-subscriber",
  "unified-diff",

--- a/compiler/rustc_ast_lowering/src/item.rs
+++ b/compiler/rustc_ast_lowering/src/item.rs
@@ -227,7 +227,6 @@ impl<'hir> LoweringContext<'_, 'hir> {
             kind,
             vis_span,
             span: self.lower_span(i.span),
-            has_delayed_lints: !self.delayed_lints.is_empty(),
             eii: find_attr!(attrs, EiiImpls(..) | EiiDeclaration(..)),
         };
         self.arena.alloc(item)
@@ -700,7 +699,6 @@ impl<'hir> LoweringContext<'_, 'hir> {
                             kind,
                             vis_span,
                             span: this.lower_span(use_tree.span()),
-                            has_delayed_lints: !this.delayed_lints.is_empty(),
                             eii: find_attr!(attrs, EiiImpls(..) | EiiDeclaration(..)),
                         };
                         hir::OwnerNode::Item(this.arena.alloc(item))
@@ -788,7 +786,6 @@ impl<'hir> LoweringContext<'_, 'hir> {
             kind,
             vis_span: self.lower_span(i.vis.span),
             span: self.lower_span(i.span),
-            has_delayed_lints: !self.delayed_lints.is_empty(),
         };
         self.arena.alloc(item)
     }
@@ -1087,7 +1084,6 @@ impl<'hir> LoweringContext<'_, 'hir> {
             kind,
             span: self.lower_span(i.span),
             defaultness,
-            has_delayed_lints: !self.delayed_lints.is_empty(),
         };
         self.arena.alloc(item)
     }
@@ -1304,7 +1300,6 @@ impl<'hir> LoweringContext<'_, 'hir> {
             impl_kind,
             kind,
             span,
-            has_delayed_lints: !self.delayed_lints.is_empty(),
         };
         self.arena.alloc(item)
     }

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -3280,7 +3280,6 @@ pub struct TraitItem<'hir> {
     pub kind: TraitItemKind<'hir>,
     pub span: Span,
     pub defaultness: Defaultness,
-    pub has_delayed_lints: bool,
 }
 
 macro_rules! expect_methods_self_kind {
@@ -3384,7 +3383,6 @@ pub struct ImplItem<'hir> {
     pub kind: ImplItemKind<'hir>,
     pub impl_kind: ImplItemImplKind,
     pub span: Span,
-    pub has_delayed_lints: bool,
 }
 
 #[derive(Debug, Clone, Copy, StableHash)]
@@ -4560,7 +4558,6 @@ pub struct Item<'hir> {
     pub kind: ItemKind<'hir>,
     pub span: Span,
     pub vis_span: Span,
-    pub has_delayed_lints: bool,
     /// hint to speed up collection: true if the item is a static or function and has
     /// either an `EiiImpls` or `EiiExternTarget` attribute
     pub eii: bool,
@@ -4955,7 +4952,6 @@ pub struct ForeignItem<'hir> {
     pub owner_id: OwnerId,
     pub span: Span,
     pub vis_span: Span,
-    pub has_delayed_lints: bool,
 }
 
 impl ForeignItem<'_> {
@@ -5467,7 +5463,7 @@ mod size_asserts {
     static_assert_size!(Expr<'_>, 64);
     static_assert_size!(ExprKind<'_>, 48);
     static_assert_size!(FnDecl<'_>, 40);
-    static_assert_size!(ForeignItem<'_>, 96);
+    static_assert_size!(ForeignItem<'_>, 88);
     static_assert_size!(ForeignItemKind<'_>, 56);
     static_assert_size!(GenericArg<'_>, 16);
     static_assert_size!(GenericBound<'_>, 64);

--- a/compiler/rustc_hir/src/intravisit.rs
+++ b/compiler/rustc_hir/src/intravisit.rs
@@ -530,7 +530,7 @@ pub fn walk_param<'v, V: Visitor<'v>>(visitor: &mut V, param: &'v Param<'v>) -> 
 }
 
 pub fn walk_item<'v, V: Visitor<'v>>(visitor: &mut V, item: &'v Item<'v>) -> V::Result {
-    let Item { owner_id: _, kind, span: _, vis_span: _, has_delayed_lints: _, eii: _ } = item;
+    let Item { owner_id: _, kind, span: _, vis_span: _, eii: _ } = item;
     try_visit!(visitor.visit_id(item.hir_id()));
     match *kind {
         ItemKind::ExternCrate(orig_name, ident) => {
@@ -660,8 +660,7 @@ pub fn walk_foreign_item<'v, V: Visitor<'v>>(
     visitor: &mut V,
     foreign_item: &'v ForeignItem<'v>,
 ) -> V::Result {
-    let ForeignItem { ident, kind, owner_id: _, span: _, vis_span: _, has_delayed_lints: _ } =
-        foreign_item;
+    let ForeignItem { ident, kind, owner_id: _, span: _, vis_span: _ } = foreign_item;
     try_visit!(visitor.visit_id(foreign_item.hir_id()));
     try_visit!(visitor.visit_ident(*ident));
 
@@ -1258,15 +1257,7 @@ pub fn walk_trait_item<'v, V: Visitor<'v>>(
     visitor: &mut V,
     trait_item: &'v TraitItem<'v>,
 ) -> V::Result {
-    let TraitItem {
-        ident,
-        generics,
-        ref defaultness,
-        ref kind,
-        span,
-        owner_id: _,
-        has_delayed_lints: _,
-    } = *trait_item;
+    let TraitItem { ident, generics, ref defaultness, ref kind, span, owner_id: _ } = *trait_item;
     let hir_id = trait_item.hir_id();
     try_visit!(visitor.visit_ident(ident));
     try_visit!(visitor.visit_generics(&generics));
@@ -1308,15 +1299,8 @@ pub fn walk_impl_item<'v, V: Visitor<'v>>(
     visitor: &mut V,
     impl_item: &'v ImplItem<'v>,
 ) -> V::Result {
-    let ImplItem {
-        owner_id: _,
-        ident,
-        ref generics,
-        ref impl_kind,
-        ref kind,
-        span: _,
-        has_delayed_lints: _,
-    } = *impl_item;
+    let ImplItem { owner_id: _, ident, ref generics, ref impl_kind, ref kind, span: _ } =
+        *impl_item;
 
     try_visit!(visitor.visit_ident(ident));
     try_visit!(visitor.visit_generics(generics));

--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -181,7 +181,7 @@ fn configure_and_expand(
         if cfg!(windows) {
             old_path = env::var_os("PATH").unwrap_or(old_path);
             let mut new_path = Vec::from_iter(
-                sess.host_filesearch().search_paths(PathKind::All).map(|p| p.dir.clone()),
+                sess.host_filesearch().search_paths(PathKind::Native).map(|p| p.dir.clone()),
             );
             for path in env::split_paths(&old_path) {
                 if !new_path.contains(&path) {

--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -1065,7 +1065,7 @@ impl<'a, 'tcx> Diagnostic<'a, ()> for DiagCallback<'tcx> {
 }
 
 pub fn emit_delayed_lints(tcx: TyCtxt<'_>) {
-    for owner_id in tcx.hir_crate_items(()).delayed_lint_items() {
+    for owner_id in tcx.hir_crate_items(()).owners() {
         if let Some(delayed_lints) = tcx.opt_ast_lowering_delayed_lints(owner_id) {
             for lint in delayed_lints.steal() {
                 tcx.emit_node_span_lint(
@@ -1131,28 +1131,6 @@ fn run_required_analyses(tcx: TyCtxt<'_>) {
     });
 
     sess.time("emit_ast_lowering_delayed_lints", || {
-        // Sanity check in debug mode that all lints are really noticed and we really will emit
-        // them all in the loop right below.
-        //
-        // During ast lowering, when creating items, foreign items, trait items and impl items,
-        // we store in them whether they have any lints in their owner node that should be
-        // picked up by `hir_crate_items`. However, theoretically code can run between that
-        // boolean being inserted into the item and the owner node being created. We don't want
-        // any new lints to be emitted there (you have to really try to manage that but still),
-        // but this check is there to catch that.
-        #[cfg(debug_assertions)]
-        {
-            let hir_items = tcx.hir_crate_items(());
-            for owner_id in hir_items.owners() {
-                if let Some(delayed_lints) = tcx.opt_ast_lowering_delayed_lints(owner_id)
-                    && !delayed_lints.borrow().is_empty()
-                {
-                    // Assert that delayed_lint_items also picked up this item to have lints.
-                    assert!(hir_items.delayed_lint_items().any(|i| i == owner_id));
-                }
-            }
-        }
-
         emit_delayed_lints(tcx);
     });
 

--- a/compiler/rustc_middle/src/hir/map.rs
+++ b/compiler/rustc_middle/src/hir/map.rs
@@ -1287,7 +1287,6 @@ pub(super) fn hir_module_items(tcx: TyCtxt<'_>, module_id: LocalModDefId) -> Mod
         body_owners: body_owners.into_boxed_slice(),
         opaques: opaques.into_boxed_slice(),
         nested_bodies: nested_bodies.into_boxed_slice(),
-        delayed_lint_items: Box::new([]),
         eiis: eiis.into_boxed_slice(),
     }
 }
@@ -1310,18 +1309,9 @@ pub(crate) fn hir_crate_items(tcx: TyCtxt<'_>, _: ()) -> ModuleItems {
         body_owners,
         opaques,
         nested_bodies,
-        mut delayed_lint_items,
         eiis,
         ..
     } = collector;
-
-    // The crate could have delayed lints too, but would not be picked up by the visitor.
-    // The `delayed_lint_items` list is smart - it only contains items which we know from
-    // earlier passes is guaranteed to contain lints. It's a little harder to determine that
-    // for sure here, so we simply always add the crate to the list. If it has no lints,
-    // we'll discover that later. The cost of this should be low, there's only one crate
-    // after all compared to the many items we have we wouldn't want to iterate over later.
-    delayed_lint_items.push(CRATE_OWNER_ID);
 
     ModuleItems {
         add_root: true,
@@ -1333,7 +1323,6 @@ pub(crate) fn hir_crate_items(tcx: TyCtxt<'_>, _: ()) -> ModuleItems {
         body_owners: body_owners.into_boxed_slice(),
         opaques: opaques.into_boxed_slice(),
         nested_bodies: nested_bodies.into_boxed_slice(),
-        delayed_lint_items: delayed_lint_items.into_boxed_slice(),
         eiis: eiis.into_boxed_slice(),
     }
 }
@@ -1351,7 +1340,6 @@ struct ItemCollector<'tcx> {
     body_owners: Vec<LocalDefId>,
     opaques: Vec<LocalDefId>,
     nested_bodies: Vec<LocalDefId>,
-    delayed_lint_items: Vec<OwnerId>,
     eiis: Vec<LocalDefId>,
 }
 
@@ -1368,7 +1356,6 @@ impl<'tcx> ItemCollector<'tcx> {
             body_owners: Vec::default(),
             opaques: Vec::default(),
             nested_bodies: Vec::default(),
-            delayed_lint_items: Vec::default(),
             eiis: Vec::default(),
         }
     }
@@ -1387,9 +1374,6 @@ impl<'hir> Visitor<'hir> for ItemCollector<'hir> {
         }
 
         self.items.push(item.item_id());
-        if self.crate_collector && item.has_delayed_lints {
-            self.delayed_lint_items.push(item.item_id().owner_id);
-        }
 
         if let ItemKind::Static(..) | ItemKind::Fn { .. } | ItemKind::Macro(..) = &item.kind
             && item.eii
@@ -1411,9 +1395,6 @@ impl<'hir> Visitor<'hir> for ItemCollector<'hir> {
 
     fn visit_foreign_item(&mut self, item: &'hir ForeignItem<'hir>) {
         self.foreign_items.push(item.foreign_item_id());
-        if self.crate_collector && item.has_delayed_lints {
-            self.delayed_lint_items.push(item.foreign_item_id().owner_id);
-        }
         intravisit::walk_foreign_item(self, item)
     }
 
@@ -1447,9 +1428,6 @@ impl<'hir> Visitor<'hir> for ItemCollector<'hir> {
         }
 
         self.trait_items.push(item.trait_item_id());
-        if self.crate_collector && item.has_delayed_lints {
-            self.delayed_lint_items.push(item.trait_item_id().owner_id);
-        }
 
         intravisit::walk_trait_item(self, item)
     }
@@ -1460,9 +1438,6 @@ impl<'hir> Visitor<'hir> for ItemCollector<'hir> {
         }
 
         self.impl_items.push(item.impl_item_id());
-        if self.crate_collector && item.has_delayed_lints {
-            self.delayed_lint_items.push(item.impl_item_id().owner_id);
-        }
 
         intravisit::walk_impl_item(self, item)
     }

--- a/compiler/rustc_middle/src/hir/mod.rs
+++ b/compiler/rustc_middle/src/hir/mod.rs
@@ -36,8 +36,6 @@ pub struct ModuleItems {
     opaques: Box<[LocalDefId]>,
     body_owners: Box<[LocalDefId]>,
     nested_bodies: Box<[LocalDefId]>,
-    // only filled with hir_crate_items, not with hir_module_items
-    delayed_lint_items: Box<[OwnerId]>,
 
     /// Statics and functions with an `EiiImpls` or `EiiExternTarget` attribute
     eiis: Box<[LocalDefId]>,
@@ -56,10 +54,6 @@ impl ModuleItems {
 
     pub fn trait_items(&self) -> impl Iterator<Item = TraitItemId> {
         self.trait_items.iter().copied()
-    }
-
-    pub fn delayed_lint_items(&self) -> impl Iterator<Item = OwnerId> {
-        self.delayed_lint_items.iter().copied()
     }
 
     pub fn eiis(&self) -> impl Iterator<Item = LocalDefId> {

--- a/compiler/rustc_middle/src/ty/context/impl_interner.rs
+++ b/compiler/rustc_middle/src/ty/context/impl_interner.rs
@@ -5,7 +5,7 @@ use std::{debug_assert_matches, fmt};
 
 use rustc_errors::ErrorGuaranteed;
 use rustc_hir as hir;
-use rustc_hir::def::{CtorKind, CtorOf, DefKind};
+use rustc_hir::def::{CtorKind, DefKind};
 use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_hir::lang_items::LangItem;
 use rustc_span::{DUMMY_SP, Span, Symbol};
@@ -437,7 +437,7 @@ impl<'tcx> Interner for TyCtxt<'tcx> {
     fn fn_is_const(self, def_id: DefId) -> bool {
         debug_assert_matches!(
             self.def_kind(def_id),
-            DefKind::Fn | DefKind::AssocFn | DefKind::Ctor(CtorOf::Struct, CtorKind::Fn)
+            DefKind::Fn | DefKind::AssocFn | DefKind::Ctor(_, CtorKind::Fn)
         );
         self.is_conditionally_const(def_id)
     }

--- a/src/bootstrap/Cargo.toml
+++ b/src/bootstrap/Cargo.toml
@@ -7,7 +7,7 @@ default-run = "bootstrap"
 
 [features]
 build-metrics = ["dep:sysinfo", "build_helper/metrics"]
-tracing = ["dep:tracing", "dep:tracing-chrome", "dep:tracing-subscriber", "dep:chrono", "dep:tempfile"]
+tracing = ["dep:tracing", "dep:tracing-chrome", "dep:tracing-subscriber", "dep:chrono"]
 
 [lib]
 path = "src/lib.rs"
@@ -55,6 +55,7 @@ termcolor = "1.4"
 toml = "0.5"
 walkdir = "2.4"
 xz2 = "0.1"
+tempfile = "3.15.0"
 
 # Dependencies needed by the build-metrics feature
 sysinfo = { version = "0.39.2", default-features = false, optional = true, features = ["system"] }
@@ -64,7 +65,6 @@ chrono = { version = "0.4", default-features = false, optional = true, features 
 tracing = { version = "0.1", optional = true, features = ["attributes"] }
 tracing-chrome = { version = "0.7", optional = true }
 tracing-subscriber = { version = "0.3", optional = true, features = ["env-filter", "fmt", "registry", "std"] }
-tempfile = { version = "3.15.0", optional = true }
 
 [target.'cfg(windows)'.dependencies.junction]
 version = "1.3.0"
@@ -83,7 +83,6 @@ features = [
 
 [dev-dependencies]
 pretty_assertions = "1.4"
-tempfile = "3.15.0"
 insta = "1.43"
 
 # We care a lot about bootstrap's compile times, so don't include debuginfo for

--- a/src/bootstrap/src/bin/rustc.rs
+++ b/src/bootstrap/src/bin/rustc.rs
@@ -20,6 +20,7 @@ use std::path::{Path, PathBuf};
 use std::process::{Child, Command};
 use std::time::Instant;
 
+use arg_file_command::ArgFileCommand;
 use shared_helpers::{
     dylib_path, dylib_path_var, exe, maybe_dump, parse_rustc_stage, parse_rustc_verbose,
     parse_value_from_args,
@@ -27,6 +28,9 @@ use shared_helpers::{
 
 #[path = "../utils/shared_helpers.rs"]
 mod shared_helpers;
+
+#[path = "../../../build_helper/src/arg_file_command.rs"]
+mod arg_file_command;
 
 #[path = "../utils/proc_macro_deps.rs"]
 mod proc_macro_deps;
@@ -112,11 +116,11 @@ fn main() {
 
     let mut cmd = match env::var_os("RUSTC_WRAPPER_REAL") {
         Some(wrapper) if !wrapper.is_empty() => {
-            let mut cmd = Command::new(wrapper);
+            let mut cmd = ArgFileCommand::new(wrapper);
             cmd.arg(rustc_driver);
             cmd
         }
-        _ => Command::new(rustc_driver),
+        _ => ArgFileCommand::new(rustc_driver),
     };
     cmd.args(&args).env(dylib_path_var(), env::join_paths(&dylib_path).unwrap());
 
@@ -271,6 +275,7 @@ fn main() {
         eprintln!("{prefix} libdir: {libdir:?}");
     }
 
+    let (mut cmd, arg_file) = cmd.build().unwrap();
     maybe_dump(format!("stage{}-rustc", stage + 1), &cmd);
 
     let start = Instant::now();
@@ -280,6 +285,8 @@ fn main() {
         let status = child.wait().expect(&errmsg);
         (child, status)
     };
+
+    drop(arg_file);
 
     if (env::var_os("RUSTC_PRINT_STEP_TIMINGS").is_some()
         || env::var_os("RUSTC_PRINT_STEP_RUSAGE").is_some())

--- a/src/bootstrap/src/bin/rustdoc.rs
+++ b/src/bootstrap/src/bin/rustdoc.rs
@@ -4,8 +4,8 @@
 
 use std::env;
 use std::path::PathBuf;
-use std::process::Command;
 
+use arg_file_command::ArgFileCommand;
 use shared_helpers::{
     dylib_path, dylib_path_var, maybe_dump, parse_rustc_stage, parse_rustc_verbose,
     parse_value_from_args,
@@ -13,6 +13,9 @@ use shared_helpers::{
 
 #[path = "../utils/shared_helpers.rs"]
 mod shared_helpers;
+
+#[path = "../../../build_helper/src/arg_file_command.rs"]
+mod arg_file_command;
 
 fn main() {
     let args = env::args_os().skip(1).collect::<Vec<_>>();
@@ -31,7 +34,7 @@ fn main() {
     let mut dylib_path = dylib_path();
     dylib_path.insert(0, PathBuf::from(libdir.clone()));
 
-    let mut cmd = Command::new(rustdoc);
+    let mut cmd = ArgFileCommand::new(rustdoc);
 
     if target.is_some() {
         // The stage0 compiler has a special sysroot distinct from what we
@@ -81,6 +84,7 @@ fn main() {
         }
     }
 
+    let (mut cmd, arg_file) = cmd.build().unwrap();
     maybe_dump(format!("stage{}-rustdoc", stage + 1), &cmd);
 
     if verbose > 1 {
@@ -94,7 +98,10 @@ fn main() {
         eprintln!("libdir: {libdir:?}");
     }
 
-    std::process::exit(match cmd.status() {
+    let status = cmd.status();
+    drop(arg_file);
+
+    std::process::exit(match status {
         Ok(s) => s.code().unwrap_or(1),
         Err(e) => panic!("\n\nfailed to run {cmd:?}: {e}\n\n"),
     })

--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -2666,8 +2666,8 @@ pub fn run_cargo(
 ) -> Vec<PathBuf> {
     // `target_root_dir` looks like $dir/$target/release
     let target_root_dir = stamp.path().parent().unwrap();
-    // `target_deps_dir` looks like $dir/$target/release/deps
-    let target_deps_dir = target_root_dir.join("deps");
+    // `target_build_dir` looks like $dir/$target/release/build
+    let target_build_dir = target_root_dir.join("build");
     // `host_root_dir` looks like $dir/release
     let host_root_dir = target_root_dir
         .parent()
@@ -2738,7 +2738,7 @@ pub fn run_cargo(
 
             // If this was output in the `deps` dir then this is a precise file
             // name (hash included) so we start tracking it.
-            if filename.starts_with(&target_deps_dir) {
+            if filename.starts_with(&target_build_dir) {
                 deps.push((filename.to_path_buf(), DependencyType::Target));
                 continue;
             }
@@ -2773,11 +2773,18 @@ pub fn run_cargo(
 
     // Ok now we need to actually find all the files listed in `toplevel`. We've
     // got a list of prefix/extensions and we basically just need to find the
-    // most recent file in the `deps` folder corresponding to each one.
-    let contents = target_deps_dir
+    // most recent file in the `build` folder corresponding to each one.
+    //
+    // Cargo's build folder is structured as `build/<pkg>/<hash>/out/<artifacts>` so
+    // we need to traverse multiple directory layers to get to actual files.
+    let read_dir = |path: &Path| path.read_dir().ok().into_iter().flatten().filter_map(Result::ok);
+    let contents = target_build_dir
         .read_dir()
-        .unwrap_or_else(|e| panic!("Couldn't read {}: {}", target_deps_dir.display(), e))
-        .map(|e| t!(e))
+        .unwrap_or_else(|e| panic!("Couldn't read {}: {}", target_build_dir.display(), e))
+        .map(|e| e.unwrap())
+        .flat_map(|e| read_dir(&e.path()))
+        .flat_map(|e| read_dir(&e.path()))
+        .flat_map(|e| read_dir(&e.path()))
         .map(|e| (e.path(), e.file_name().into_string().unwrap(), t!(e.metadata())))
         .collect::<Vec<_>>();
     for (prefix, extension, expected_len) in toplevel {

--- a/src/bootstrap/src/core/build_steps/tool.rs
+++ b/src/bootstrap/src/core/build_steps/tool.rs
@@ -1628,8 +1628,9 @@ impl Builder<'_> {
         //
         // Notably this munges the dynamic library lookup path to point to the
         // right location to run `compiler`.
-        let mut lib_paths: Vec<PathBuf> =
-            discover_out_dirs(self.cargo_out(compiler, Mode::ToolBootstrap, *host).join("build"));
+        let mut lib_paths: Vec<PathBuf> = discover_out_dirs_with_dylibs(
+            self.cargo_out(compiler, Mode::ToolBootstrap, *host).join("build"),
+        );
 
         // On MSVC a tool may invoke a C compiler (e.g., compiletest in run-make
         // mode) and that C compiler may need some extra PATH modification. Do
@@ -1659,18 +1660,21 @@ impl Builder<'_> {
 }
 
 /// Gets all of the `out` dirs in a given Cargo `build-dir/<profile>/build` dir.
-fn discover_out_dirs(dir: PathBuf) -> Vec<PathBuf> {
+fn discover_out_dirs_with_dylibs(dir: PathBuf) -> Vec<PathBuf> {
     if !dir.exists() {
         return Vec::new();
     }
-
     let read_dir = |path: &Path| path.read_dir().ok().into_iter().flatten().filter_map(Result::ok);
+    let has_dylib = |path: &Path| {
+        read_dir(path)
+            .any(|e| e.path().extension().is_some_and(|ext| ext == std::env::consts::DLL_EXTENSION))
+    };
     dir.read_dir()
         .unwrap_or_else(|e| panic!("Couldn't read {}: {}", dir.display(), e))
         .map(|e| e.unwrap())
         .flat_map(|e| read_dir(&e.path()))
         .flat_map(|e| read_dir(&e.path()))
         .map(|e| e.path())
-        .filter(|path| path.ends_with("out"))
+        .filter(|path| path.ends_with("out") && has_dylib(path))
         .collect::<Vec<_>>()
 }

--- a/src/bootstrap/src/core/build_steps/tool.rs
+++ b/src/bootstrap/src/core/build_steps/tool.rs
@@ -10,7 +10,7 @@
 //! return `ToolBuildResult` and should never prepare `cargo` invocations manually.
 
 use std::ffi::OsStr;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::{env, fs};
 
 use crate::core::build_steps::compile::is_lto_stage;
@@ -1629,7 +1629,7 @@ impl Builder<'_> {
         // Notably this munges the dynamic library lookup path to point to the
         // right location to run `compiler`.
         let mut lib_paths: Vec<PathBuf> =
-            vec![self.cargo_out(compiler, Mode::ToolBootstrap, *host).join("deps")];
+            discover_out_dirs(self.cargo_out(compiler, Mode::ToolBootstrap, *host).join("build"));
 
         // On MSVC a tool may invoke a C compiler (e.g., compiletest in run-make
         // mode) and that C compiler may need some extra PATH modification. Do
@@ -1656,4 +1656,21 @@ impl Builder<'_> {
 
         cmd
     }
+}
+
+/// Gets all of the `out` dirs in a given Cargo `build-dir/<profile>/build` dir.
+fn discover_out_dirs(dir: PathBuf) -> Vec<PathBuf> {
+    if !dir.exists() {
+        return Vec::new();
+    }
+
+    let read_dir = |path: &Path| path.read_dir().ok().into_iter().flatten().filter_map(Result::ok);
+    dir.read_dir()
+        .unwrap_or_else(|e| panic!("Couldn't read {}: {}", dir.display(), e))
+        .map(|e| e.unwrap())
+        .flat_map(|e| read_dir(&e.path()))
+        .flat_map(|e| read_dir(&e.path()))
+        .map(|e| e.path())
+        .filter(|path| path.ends_with("out"))
+        .collect::<Vec<_>>()
 }

--- a/src/bootstrap/src/core/builder/cargo.rs
+++ b/src/bootstrap/src/core/builder/cargo.rs
@@ -595,6 +595,8 @@ impl Builder<'_> {
 
         let mut hostflags = HostFlags::default();
 
+        cargo.env("CARGO_UNSTABLE_BUILD_DIR_NEW_LAYOUT", "true");
+
         // Codegen backends are not yet tracked by -Zbinary-dep-depinfo,
         // so we need to explicitly clear out if they've been updated.
         for backend in self.codegen_backends(compiler) {

--- a/src/build_helper/src/arg_file_command.rs
+++ b/src/build_helper/src/arg_file_command.rs
@@ -1,0 +1,121 @@
+//! This module is explictly not `mod`ed as it's shared across multiple crates
+//! like bootstrap and compiletest via `#[path]` moduled declarations.
+//! It's important to keep this file isolated from the rest of build_helper so it can be compiled
+//! without build_helper.
+
+// Roughly match the `std::process::Command` API
+#![allow(dead_code, unreachable_pub)]
+
+use std::ffi::{OsStr, OsString};
+use std::io::Write;
+use std::path::Path;
+use std::process::{Command, CommandEnvs};
+
+use tempfile::NamedTempFile;
+
+/// A wrapper around [`Command`] that adds support for arg files.
+/// This is useful as we have some commands that can get very long and at times
+/// hit the OS limit (usually Windows)
+///
+/// This implementation is based off the `ProcessBuilder` implementation in Cargo
+/// but simplified.
+///
+/// NOTE: In most scenarios we want to avoid arg files as it makes debugging more complicated
+///       so we try to avoid it if the command is not close to the OS limit.
+#[derive(Debug)]
+pub struct ArgFileCommand {
+    command: Command,
+    args: Vec<OsString>,
+}
+
+impl ArgFileCommand {
+    pub fn new<S: AsRef<OsStr>>(program: S) -> Self {
+        let command = Command::new(program);
+        Self { command, args: Vec::new() }
+    }
+    pub fn arg<S: AsRef<OsStr>>(&mut self, arg: S) -> &mut Self {
+        self.args.push(arg.as_ref().to_os_string());
+        self
+    }
+
+    pub fn args<I, S>(&mut self, args: I) -> &mut Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<OsStr>,
+    {
+        self.args.extend(args.into_iter().map(|s| s.as_ref().to_os_string()));
+        self
+    }
+
+    pub fn env<K, V>(&mut self, key: K, val: V) -> &mut Self
+    where
+        K: AsRef<OsStr>,
+        V: AsRef<OsStr>,
+    {
+        self.command.env(key, val);
+        self
+    }
+
+    pub fn get_envs(&self) -> CommandEnvs<'_> {
+        self.command.get_envs()
+    }
+
+    pub fn env_remove<K: AsRef<OsStr>>(&mut self, key: K) -> &mut Self {
+        self.command.env_remove(key);
+        self
+    }
+
+    pub fn current_dir<P: AsRef<Path>>(&mut self, dir: P) -> &mut Self {
+        self.command.current_dir(dir);
+        self
+    }
+
+    pub fn stdin(&mut self, stdin: std::process::Stdio) -> &mut Self {
+        self.command.stdin(stdin);
+        self
+    }
+
+    pub fn build(mut self) -> std::io::Result<(Command, Option<NamedTempFile>)> {
+        // On Windows there is a hard limit of ~32KB, so we cut off at 30KB to
+        // give some buffer just incase.
+        #[cfg(windows)]
+        let threshold: usize = 30 * 1024;
+        // On unix the limit is defined by ARG_MAX. If its not explicitly set we set it to 1MB
+        // which is fairly large but lower than the ~2MB that it defaults to on most systems.
+        #[cfg(unix)]
+        let threshold: usize =
+            std::env::var("ARG_MAX").ok().and_then(|v| v.parse().ok()).unwrap_or(1024 * 1024);
+
+        let total_arg_len: usize = self.args.iter().map(|a| a.len() + 1).sum();
+        if total_arg_len <= threshold {
+            self.command.args(self.args);
+            return Ok((self.command, None));
+        }
+
+        let mut tmp = tempfile::Builder::new().prefix("bootstrap-argfile.").tempfile()?;
+
+        let mut arg = OsString::from("@");
+        arg.push(tmp.path());
+        self.command.arg(arg);
+
+        let mut buf = Vec::with_capacity(total_arg_len);
+        for arg in &self.args {
+            let arg = arg.to_str().ok_or_else(|| {
+                std::io::Error::other(format!(
+                    "argument for argfile contains invalid UTF-8 characters: `{}`",
+                    arg.to_string_lossy()
+                ))
+            })?;
+            if arg.contains('\n') {
+                return Err(std::io::Error::other(format!(
+                    "argument for argfile contains newlines: `{arg}`"
+                )));
+            }
+            writeln!(buf, "{arg}")?;
+        }
+        tmp.write_all(&buf)?;
+        tmp.flush()?;
+
+        Ok((self.command, Some(tmp)))
+    }
+}

--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -2,7 +2,12 @@
 # dynamically in CI from ci.yml.
 runners:
   - &base-job
-    env: { }
+    env:
+      # This force enables the new Cargo build-dir layout for all CI jobs.
+      # The new layout will become the default soon so we enable it on everything
+      # to catch issues as soon as possible.
+      # See: https://github.com/rust-lang/cargo/issues/15010
+      CARGO_UNSTABLE_BUILD_DIR_NEW_LAYOUT: true
 
   - &job-linux-4c
     os: ubuntu-24.04

--- a/src/tools/compiletest/Cargo.toml
+++ b/src/tools/compiletest/Cargo.toml
@@ -31,6 +31,7 @@ rustfix = "0.8.1"
 semver = { version = "1.0.23", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+tempfile = "3.23.0"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3.3", default-features = false, features = ["ansi", "env-filter", "fmt", "parking_lot", "smallvec"] }
 unified-diff = "0.2.1"

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -23,7 +23,7 @@ use crate::errors::{Error, ErrorKind, load_errors};
 use crate::output_capture::ConsoleOut;
 use crate::read2::{Truncated, read2_abbreviated};
 use crate::runtest::compute_diff::{DiffLine, diff_by_lines, make_diff, write_diff};
-use crate::util::{Utf8PathBufExt, add_dylib_path, static_regex};
+use crate::util::{ArgFileCommand, Utf8PathBufExt, add_dylib_path, static_regex};
 use crate::{json, stamp_file_path};
 
 // Helper modules that implement test running logic for each test suite.
@@ -383,7 +383,7 @@ impl<'test> TestCx<'test> {
         }
     }
 
-    /// Runs a [`Command`] and waits for it to finish, then converts its exit
+    /// Runs a [`ArgFileCommand`] and waits for it to finish, then converts its exit
     /// status and output streams into a [`ProcRes`].
     ///
     /// The command might have succeeded or failed; it is the caller's
@@ -393,7 +393,8 @@ impl<'test> TestCx<'test> {
     /// Panics if the command couldn't be executed at all
     /// (e.g. because the executable could not be found).
     #[must_use = "caller should check whether the command succeeded"]
-    fn run_command_to_procres(&self, cmd: &mut Command) -> ProcRes {
+    fn run_command_to_procres(&self, cmd: ArgFileCommand) -> ProcRes {
+        let (mut cmd, _arg_file) = cmd.build().unwrap();
         let output = cmd
             .output()
             .unwrap_or_else(|e| self.fatal(&format!("failed to exec `{cmd:?}` because: {e}")));

--- a/src/tools/compiletest/src/runtest/coverage.rs
+++ b/src/tools/compiletest/src/runtest/coverage.rs
@@ -8,7 +8,7 @@ use glob::glob;
 
 use crate::common::{TestSuite, UI_COVERAGE, UI_COVERAGE_MAP};
 use crate::runtest::{Emit, ProcRes, TestCx, WillExecute};
-use crate::util::static_regex;
+use crate::util::{ArgFileCommand, static_regex};
 
 impl<'test> TestCx<'test> {
     fn coverage_dump_path(&self) -> &Utf8Path {
@@ -27,9 +27,9 @@ impl<'test> TestCx<'test> {
         }
         drop(proc_res);
 
-        let mut dump_command = Command::new(coverage_dump_path);
+        let mut dump_command = ArgFileCommand::new(coverage_dump_path);
         dump_command.arg(llvm_ir_path);
-        let proc_res = self.run_command_to_procres(&mut dump_command);
+        let proc_res = self.run_command_to_procres(dump_command);
         if !proc_res.status.success() {
             self.fatal_proc_rec("coverage-dump failed!", &proc_res);
         }
@@ -227,7 +227,11 @@ impl<'test> TestCx<'test> {
         }
     }
 
-    fn run_llvm_tool(&self, name: &str, configure_cmd_fn: impl FnOnce(&mut Command)) -> ProcRes {
+    fn run_llvm_tool(
+        &self,
+        name: &str,
+        configure_cmd_fn: impl FnOnce(&mut ArgFileCommand),
+    ) -> ProcRes {
         let tool_path = self
             .config
             .llvm_bin_dir
@@ -235,10 +239,10 @@ impl<'test> TestCx<'test> {
             .expect("this test expects the LLVM bin dir to be available")
             .join(name);
 
-        let mut cmd = Command::new(tool_path);
+        let mut cmd = ArgFileCommand::new(tool_path);
         configure_cmd_fn(&mut cmd);
 
-        self.run_command_to_procres(&mut cmd)
+        self.run_command_to_procres(cmd)
     }
 
     fn normalize_coverage_output(&self, coverage: &str) -> Result<String, String> {

--- a/src/tools/compiletest/src/runtest/debuginfo.rs
+++ b/src/tools/compiletest/src/runtest/debuginfo.rs
@@ -8,6 +8,7 @@ use tracing::debug;
 use super::debugger::DebuggerCommands;
 use super::{Debugger, Emit, ProcRes, TestCx, Truncated, WillExecute};
 use crate::debuggers::extract_gdb_version;
+use crate::util::ArgFileCommand;
 
 impl TestCx<'_> {
     pub(super) fn run_debuginfo_test(&self) {
@@ -468,7 +469,7 @@ impl TestCx<'_> {
         // make sure `PATH` points to all the dlls necessary to run the debugee
         let path = prepend_to_path(&self.config.target_run_lib_path);
 
-        let mut cmd = Command::new(lldb);
+        let mut cmd = ArgFileCommand::new(lldb);
         cmd.arg("--one-line")
             .arg("script --language python -- import lldb_batchmode; lldb_batchmode.main()")
             .env("LLDB_BATCHMODE_TARGET_PATH", test_executable)
@@ -477,7 +478,7 @@ impl TestCx<'_> {
             .env("PYTHONPATH", pythonpath)
             .env("PATH", path);
 
-        self.run_command_to_procres(&mut cmd)
+        self.run_command_to_procres(cmd)
     }
 }
 

--- a/src/tools/compiletest/src/runtest/js_doc.rs
+++ b/src/tools/compiletest/src/runtest/js_doc.rs
@@ -1,6 +1,5 @@
-use std::process::Command;
-
 use super::{DocKind, TestCx};
+use crate::util::ArgFileCommand;
 
 impl TestCx<'_> {
     pub(super) fn run_rustdoc_js_test(&self) {
@@ -10,18 +9,18 @@ impl TestCx<'_> {
             self.document(&out_dir, DocKind::Html);
 
             let file_stem = self.testpaths.file.file_stem().expect("no file stem");
-            let res = self.run_command_to_procres(
-                Command::new(&nodejs)
-                    .arg(self.config.src_root.join("src/tools/rustdoc-js/tester.js"))
-                    .arg("--doc-folder")
-                    .arg(out_dir)
-                    .arg("--crate-name")
-                    .arg(file_stem.replace("-", "_"))
-                    .arg("--test-file")
-                    .arg(self.testpaths.file.with_extension("js"))
-                    .arg("--revision")
-                    .arg(self.revision.unwrap_or_default()),
-            );
+
+            let mut cmd = ArgFileCommand::new(&nodejs);
+            cmd.arg(self.config.src_root.join("src/tools/rustdoc-js/tester.js"))
+                .arg("--doc-folder")
+                .arg(out_dir)
+                .arg("--crate-name")
+                .arg(file_stem.replace("-", "_"))
+                .arg("--test-file")
+                .arg(self.testpaths.file.with_extension("js"))
+                .arg("--revision")
+                .arg(self.revision.unwrap_or_default());
+            let res = self.run_command_to_procres(cmd);
             if !res.status.success() {
                 self.fatal_proc_rec("rustdoc-js test failed!", &res);
             }

--- a/src/tools/compiletest/src/runtest/run_make.rs
+++ b/src/tools/compiletest/src/runtest/run_make.rs
@@ -1,3 +1,4 @@
+use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
 use std::{env, fs};
 
@@ -66,8 +67,8 @@ impl TestCx<'_> {
         // build/<target_triple>/
         // ├── bootstrap-tools/
         // │   ├── <host_triple>/release/librun_make_support.rlib   // <- support rlib itself
-        // │   ├── <host_triple>/release/deps/                      // <- deps
-        // │   └── release/deps/                                    // <- deps of deps
+        // │   ├── <host_triple>/release/build/<pkg>/<hash>/out     // <- deps
+        // │   └── release/build/<pkg>/<hash>/out                   // <- deps of deps
         // ```
         //
         // FIXME(jieyouxu): there almost certainly is a better way to do this (specifically how the
@@ -77,8 +78,8 @@ impl TestCx<'_> {
         let support_host_path = tools_bin.join(&self.config.host).join("release");
         let support_lib_path = support_host_path.join("librun_make_support.rlib");
 
-        let support_lib_deps = support_host_path.join("deps");
-        let support_lib_deps_deps = tools_bin.join("release").join("deps");
+        let support_lib_deps = discover_out_dirs(support_host_path.join("build"));
+        let support_lib_deps_deps = discover_out_dirs(tools_bin.join("release").join("build"));
 
         // To compile the recipe with rustc, we need to provide suitable dynamic library search
         // paths to rustc. This includes both:
@@ -100,6 +101,10 @@ impl TestCx<'_> {
             p
         };
 
+        let out_dirs_to_args = |paths: Vec<PathBuf>| {
+            paths.into_iter().map(|p| format!("-Ldependency={}", p.display())).collect::<Vec<_>>()
+        };
+
         // run-make-support and run-make tests are compiled using the stage0 compiler
         // If the stage is 0, then the compiler that we test (either bootstrap or an explicitly
         // set compiler) is the one that actually compiled run-make-support.
@@ -119,8 +124,8 @@ impl TestCx<'_> {
             .arg(&recipe_bin)
             // Specify library search paths for `run_make_support`.
             .arg(format!("-Ldependency={}", &support_lib_path.parent().unwrap()))
-            .arg(format!("-Ldependency={}", &support_lib_deps))
-            .arg(format!("-Ldependency={}", &support_lib_deps_deps))
+            .args(out_dirs_to_args(support_lib_deps))
+            .args(out_dirs_to_args(support_lib_deps_deps))
             // Provide `run_make_support` as extern prelude, so test writers don't need to write
             // `extern run_make_support;`.
             .arg("--extern")
@@ -336,4 +341,20 @@ impl TestCx<'_> {
             self.fatal_proc_rec("rmake recipe failed to complete", &res);
         }
     }
+}
+
+/// Gets all of the `out` dirs in a given Cargo `build-dir/<profile>/build` dir.
+fn discover_out_dirs(dir: Utf8PathBuf) -> Vec<PathBuf> {
+    let read_dir = |path: &Path| path.read_dir().ok().into_iter().flatten().filter_map(Result::ok);
+    let contents = dir
+        .read_dir()
+        .unwrap_or_else(|e| panic!("Couldn't read {}: {}", dir, e))
+        .map(|e| e.unwrap())
+        .flat_map(|e| read_dir(&e.path()))
+        .flat_map(|e| read_dir(&e.path()))
+        .map(|e| e.path())
+        .filter(|path| path.ends_with("out"))
+        .collect::<Vec<_>>();
+
+    return contents;
 }

--- a/src/tools/compiletest/src/runtest/run_make.rs
+++ b/src/tools/compiletest/src/runtest/run_make.rs
@@ -7,7 +7,7 @@ use camino::{Utf8Path, Utf8PathBuf};
 
 use super::{ProcRes, TestCx, disable_error_reporting};
 use crate::common::TestSuite;
-use crate::util::{copy_dir_all, dylib_env_var};
+use crate::util::{ArgFileCommand, copy_dir_all, dylib_env_var};
 
 impl TestCx<'_> {
     pub(super) fn run_rmake_test(&self) {
@@ -113,7 +113,7 @@ impl TestCx<'_> {
             .stage0_rustc_path
             .as_ref()
             .expect("stage0 rustc is required to run run-make tests");
-        let mut rustc = Command::new(&stage0_rustc);
+        let mut rustc = ArgFileCommand::new(&stage0_rustc);
         rustc
             // `rmake.rs` **must** be buildable by a stable compiler, it may not use *any* unstable
             // library or compiler features. Here, we force the stage 0 rustc to consider itself as
@@ -139,7 +139,7 @@ impl TestCx<'_> {
         rustc.arg("-Dunused_must_use");
 
         // Now run rustc to build the recipe.
-        let res = self.run_command_to_procres(&mut rustc);
+        let res = self.run_command_to_procres(rustc);
         if !res.status.success() {
             self.fatal_proc_rec("run-make test failed: could not build `rmake.rs` recipe", &res);
         }

--- a/src/tools/compiletest/src/runtest/rustdoc.rs
+++ b/src/tools/compiletest/src/runtest/rustdoc.rs
@@ -1,6 +1,5 @@
-use std::process::Command;
-
 use super::{DocKind, TestCx, remove_and_create_dir_all};
+use crate::util::ArgFileCommand;
 
 impl TestCx<'_> {
     pub(super) fn run_rustdoc_html_test(&self) {
@@ -19,14 +18,14 @@ impl TestCx<'_> {
         if self.props.check_test_line_numbers_match {
             self.check_rustdoc_test_option(proc_res);
         } else {
-            let mut cmd = Command::new(&self.config.python);
+            let mut cmd = ArgFileCommand::new(&self.config.python);
             cmd.arg(self.config.src_root.join("src/etc/htmldocck.py"))
                 .arg(&out_dir)
                 .arg(&self.testpaths.file);
             if self.config.bless {
                 cmd.arg("--bless");
             }
-            let res = self.run_command_to_procres(&mut cmd);
+            let res = self.run_command_to_procres(cmd);
             if !res.status.success() {
                 self.fatal_proc_rec("htmldocck failed!", &res);
             }

--- a/src/tools/compiletest/src/runtest/rustdoc_json.rs
+++ b/src/tools/compiletest/src/runtest/rustdoc_json.rs
@@ -1,6 +1,5 @@
-use std::process::Command;
-
 use super::{DocKind, TestCx, remove_and_create_dir_all};
+use crate::util::ArgFileCommand;
 
 impl TestCx<'_> {
     pub(super) fn run_rustdoc_json_test(&self) {
@@ -23,13 +22,9 @@ impl TestCx<'_> {
             self.fatal_proc_rec("rustdoc failed!", &proc_res);
         }
 
-        let res = self.run_command_to_procres(
-            Command::new(self.config.jsondocck_path.as_ref().unwrap())
-                .arg("--doc-dir")
-                .arg(&out_dir)
-                .arg("--template")
-                .arg(&self.testpaths.file),
-        );
+        let mut cmd = ArgFileCommand::new(self.config.jsondocck_path.as_ref().unwrap());
+        cmd.arg("--doc-dir").arg(&out_dir).arg("--template").arg(&self.testpaths.file);
+        let res = self.run_command_to_procres(cmd);
 
         if !res.status.success() {
             self.fatal_proc_rec_general("jsondocck failed!", None, &res, || {
@@ -41,9 +36,9 @@ impl TestCx<'_> {
         let mut json_out = out_dir.join(self.testpaths.file.file_stem().unwrap());
         json_out.set_extension("json");
 
-        let res = self.run_command_to_procres(
-            Command::new(self.config.jsondoclint_path.as_ref().unwrap()).arg(&json_out),
-        );
+        let mut cmd = ArgFileCommand::new(self.config.jsondoclint_path.as_ref().unwrap());
+        cmd.arg(&json_out);
+        let res = self.run_command_to_procres(cmd);
 
         if !res.status.success() {
             self.fatal_proc_rec("jsondoclint failed!", &res);

--- a/src/tools/compiletest/src/util.rs
+++ b/src/tools/compiletest/src/util.rs
@@ -6,6 +6,11 @@ use camino::{Utf8Path, Utf8PathBuf};
 #[cfg(test)]
 mod tests;
 
+#[path = "../../../build_helper/src/arg_file_command.rs"]
+mod arg_file_command;
+
+pub(crate) use arg_file_command::ArgFileCommand;
+
 pub(crate) fn make_new_path(path: &str) -> String {
     assert!(cfg!(windows));
     // Windows just uses PATH as the library search path, so we have to

--- a/src/tools/miri/test-cargo-miri/run-test.py
+++ b/src/tools/miri/test-cargo-miri/run-test.py
@@ -215,7 +215,7 @@ for target_dir in ["target", "custom-run", "custom-test", "config-cli"]:
     if os.listdir(target_dir) != ["miri"]:
         fail(f"`{target_dir}` contains unexpected files")
     # Ensure something exists inside that target dir.
-    os.access(os.path.join(target_dir, "miri", "debug", "deps"), os.F_OK)
+    os.access(os.path.join(target_dir, "miri", "debug"), os.F_OK)
 
 print("\nTEST SUCCESSFUL!")
 sys.exit(0)

--- a/src/tools/rustfmt/.github/workflows/linux.yml
+++ b/src/tools/rustfmt/.github/workflows/linux.yml
@@ -36,4 +36,7 @@ jobs:
         rustup target add ${{ matrix.target }}
 
     - name: Build and Test
+      env:
+        RUSTFLAGS: -D warnings
+        CARGO_UNSTABLE_BUILD_DIR_NEW_LAYOUT: true
       run: ./ci/build_and_test.sh

--- a/src/tools/rustfmt/.github/workflows/mac.yml
+++ b/src/tools/rustfmt/.github/workflows/mac.yml
@@ -32,4 +32,7 @@ jobs:
         rustup target add ${{ matrix.target }}
 
     - name: Build and Test
+      env:
+        RUSTFLAGS: -D warnings
+        CARGO_UNSTABLE_BUILD_DIR_NEW_LAYOUT: true
       run: ./ci/build_and_test.sh

--- a/src/tools/rustfmt/.github/workflows/windows.yml
+++ b/src/tools/rustfmt/.github/workflows/windows.yml
@@ -59,4 +59,7 @@ jobs:
 
     - name: Build and Test
       shell: cmd
+      env:
+        RUSTFLAGS: -D warnings
+        CARGO_UNSTABLE_BUILD_DIR_NEW_LAYOUT: true
       run: ci\build_and_test.bat

--- a/src/tools/rustfmt/src/test/mod.rs
+++ b/src/tools/rustfmt/src/test/mod.rs
@@ -1077,8 +1077,23 @@ fn rustfmt() -> PathBuf {
     let mut me = env::current_exe().expect("failed to get current executable");
     // Chop of the test name.
     me.pop();
-    // Chop off `deps`.
-    me.pop();
+
+    // Handle Cargo's old and new filesystem layouts
+    // * v1: `target/<profile>/deps/test-bin-[HASH][EXE]`
+    // * v2: `target/<profile>/build/<pkgname>/[HASH]/out/test-bin-[HASH][EXE]`
+    if me.ends_with("deps") {
+        // Chop off `deps`.
+        me.pop();
+    } else if me.ends_with("out") {
+        // Chop off `out`.
+        me.pop();
+        // Chop off `<hash>`.
+        me.pop();
+        // Chop off `<pkgname>`.
+        me.pop();
+        // Chop off `build`.
+        me.pop();
+    }
 
     me.push("rustfmt");
     assert!(

--- a/src/tools/rustfmt/tests/cargo-fmt/main.rs
+++ b/src/tools/rustfmt/tests/cargo-fmt/main.rs
@@ -10,8 +10,17 @@ use rustfmt_config_proc_macro::rustfmt_only_ci_test;
 fn cargo_fmt(args: &[&str]) -> (String, String) {
     let mut bin_dir = env::current_exe().unwrap();
     bin_dir.pop(); // chop off test exe name
+
+    // Handle Cargo's old and new filesystem layouts
+    // * v1: `target/<profile>/deps/test-bin-[HASH][EXE]`
+    // * v2: `target/<profile>/build/<pkgname>/[HASH]/out/test-bin-[HASH][EXE]`
     if bin_dir.ends_with("deps") {
         bin_dir.pop();
+    } else if bin_dir.ends_with("out") {
+        bin_dir.pop(); // chop off `out`
+        bin_dir.pop(); // chop off `<hash>`
+        bin_dir.pop(); // chop off `<pkgname>`
+        bin_dir.pop(); // chop off `build`
     }
     let cmd = bin_dir.join(format!("cargo-fmt{}", env::consts::EXE_SUFFIX));
 

--- a/tests/incremental/hashes/function_interfaces.rs
+++ b/tests/incremental/hashes/function_interfaces.rs
@@ -275,9 +275,9 @@ pub fn inline_never() {}
 pub fn no_mangle() {}
 
 #[cfg(not(any(bpass1,bpass4)))]
-#[rustc_clean(cfg = "bpass2", except="hir_owner")] // dirty because of stashed UNSAFE_CODE lint
+#[rustc_clean(cfg = "bpass2")]
 #[rustc_clean(cfg = "bpass3")]
-#[rustc_clean(cfg = "bpass5", except="hir_owner")] // dirty because of stashed UNSAFE_CODE lint
+#[rustc_clean(cfg = "bpass5")]
 #[rustc_clean(cfg = "bpass6")]
 #[unsafe(no_mangle)]
 pub fn no_mangle() {}

--- a/tests/incremental/hashes/inherent_impls.rs
+++ b/tests/incremental/hashes/inherent_impls.rs
@@ -645,9 +645,9 @@ impl Foo {
 // Add #[no_mangle] to Method --------------------------------------------------
 #[cfg(any(bpass1,bpass4))]
 impl Foo {
-    //-------------------------------------------------------------------------------------------
     //--------------------------
-    //-------------------------------------------------------------------------------------------
+    //--------------------------
+    //--------------------------
     //--------------------------
     //------------------
     pub fn add_no_mangle_to_method(&self) { }
@@ -659,9 +659,9 @@ impl Foo {
 #[rustc_clean(cfg="bpass5")]
 #[rustc_clean(cfg="bpass6")]
 impl Foo {
-    #[rustc_clean(cfg="bpass2", except="hir_owner")] // dirty because of stashed UNSAFE_CODE lint
+    #[rustc_clean(cfg="bpass2")]
     #[rustc_clean(cfg="bpass3")]
-    #[rustc_clean(cfg="bpass5", except="hir_owner")] // dirty because of stashed UNSAFE_CODE lint
+    #[rustc_clean(cfg="bpass5")]
     #[rustc_clean(cfg="bpass6")]
     #[unsafe(no_mangle)]
     pub fn add_no_mangle_to_method(&self) { }

--- a/tests/incremental/hashes/statics.rs
+++ b/tests/incremental/hashes/statics.rs
@@ -62,9 +62,9 @@ static STATIC_LINKAGE: u8 = 0;
 static STATIC_NO_MANGLE: u8 = 0;
 
 #[cfg(not(any(bpass1,bpass4)))]
-#[rustc_clean(cfg="bpass2", except="hir_owner")] // dirty because of stashed UNSAFE_CODE lint
+#[rustc_clean(cfg="bpass2")]
 #[rustc_clean(cfg="bpass3")]
-#[rustc_clean(cfg="bpass5", except="hir_owner")] // dirty because of stashed UNSAFE_CODE lint
+#[rustc_clean(cfg="bpass5")]
 #[rustc_clean(cfg="bpass6")]
 #[unsafe(no_mangle)]
 static STATIC_NO_MANGLE: u8 = 0;

--- a/tests/incremental/hashes/trait_impls.rs
+++ b/tests/incremental/hashes/trait_impls.rs
@@ -565,9 +565,9 @@ trait AddNoMangleToMethod {
 
 #[cfg(any(bpass1,bpass4))]
 impl AddNoMangleToMethod for Foo {
-    //-------------------------------------------------------------------------------------------
     //--------------------------
-    //-------------------------------------------------------------------------------------------
+    //--------------------------
+    //--------------------------
     //--------------------------
     //------------------
     fn add_no_mangle_to_method(&self) { }
@@ -579,9 +579,9 @@ impl AddNoMangleToMethod for Foo {
 #[rustc_clean(cfg="bpass5")]
 #[rustc_clean(cfg="bpass6")]
 impl AddNoMangleToMethod for Foo {
-    #[rustc_clean(cfg="bpass2", except="hir_owner")] // dirty because of stashed UNSAFE_CODE lint
+    #[rustc_clean(cfg="bpass2")]
     #[rustc_clean(cfg="bpass3")]
-    #[rustc_clean(cfg="bpass5", except="hir_owner")] // dirty because of stashed UNSAFE_CODE lint
+    #[rustc_clean(cfg="bpass5")]
     #[rustc_clean(cfg="bpass6")]
     #[unsafe(no_mangle)]
     fn add_no_mangle_to_method(&self) { }

--- a/tests/rustdoc-ui/doc-cfg-check-cfg.cfg_empty.stderr
+++ b/tests/rustdoc-ui/doc-cfg-check-cfg.cfg_empty.stderr
@@ -1,4 +1,14 @@
 warning: unexpected `cfg` condition name: `foo`
+  --> $DIR/doc-cfg-check-cfg.rs:12:12
+   |
+LL | #![doc(cfg(foo))]
+   |            ^^^
+   |
+   = help: to expect this configuration use `--check-cfg=cfg(foo)`
+   = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
+   = note: `#[warn(unexpected_cfgs)]` on by default
+
+warning: unexpected `cfg` condition name: `foo`
   --> $DIR/doc-cfg-check-cfg.rs:15:11
    |
 LL | #[doc(cfg(foo))]
@@ -6,22 +16,12 @@ LL | #[doc(cfg(foo))]
    |
    = help: to expect this configuration use `--check-cfg=cfg(foo)`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
-   = note: `#[warn(unexpected_cfgs)]` on by default
 
 warning: unexpected `cfg` condition name: `foo`
   --> $DIR/doc-cfg-check-cfg.rs:19:11
    |
 LL | #[doc(cfg(foo))]
    |           ^^^
-   |
-   = help: to expect this configuration use `--check-cfg=cfg(foo)`
-   = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
-
-warning: unexpected `cfg` condition name: `foo`
-  --> $DIR/doc-cfg-check-cfg.rs:12:12
-   |
-LL | #![doc(cfg(foo))]
-   |            ^^^
    |
    = help: to expect this configuration use `--check-cfg=cfg(foo)`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration

--- a/tests/rustdoc-ui/lints/doc-attr-2.stderr
+++ b/tests/rustdoc-ui/lints/doc-attr-2.stderr
@@ -1,14 +1,20 @@
 error: unknown `doc` attribute `as_ptr`
-  --> $DIR/doc-attr-2.rs:5:7
+  --> $DIR/doc-attr-2.rs:2:8
    |
-LL | #[doc(as_ptr)]
-   |       ^^^^^^
+LL | #![doc(as_ptr)]
+   |        ^^^^^^
    |
 note: the lint level is defined here
   --> $DIR/doc-attr-2.rs:1:9
    |
 LL | #![deny(invalid_doc_attributes)]
    |         ^^^^^^^^^^^^^^^^^^^^^^
+
+error: unknown `doc` attribute `as_ptr`
+  --> $DIR/doc-attr-2.rs:5:7
+   |
+LL | #[doc(as_ptr)]
+   |       ^^^^^^
 
 error: unknown `doc` attribute `foo::bar`
   --> $DIR/doc-attr-2.rs:9:7
@@ -21,12 +27,6 @@ error: unknown `doc` attribute `crate::bar::baz`
    |
 LL | #[doc(foo::bar, crate::bar::baz = "bye")]
    |                 ^^^^^^^^^^^^^^^
-
-error: unknown `doc` attribute `as_ptr`
-  --> $DIR/doc-attr-2.rs:2:8
-   |
-LL | #![doc(as_ptr)]
-   |        ^^^^^^
 
 error: aborting due to 4 previous errors
 

--- a/tests/rustdoc-ui/lints/invalid-doc-attr-3.stderr
+++ b/tests/rustdoc-ui/lints/invalid-doc-attr-3.stderr
@@ -1,8 +1,8 @@
 error: didn't expect any arguments here
-  --> $DIR/invalid-doc-attr-3.rs:10:14
+  --> $DIR/invalid-doc-attr-3.rs:3:29
    |
-LL | #[doc(hidden = true)]
-   |              ^^^^^^
+LL | #![doc(test(no_crate_inject = 1))]
+   |                             ^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 note: the lint level is defined here
@@ -10,6 +10,22 @@ note: the lint level is defined here
    |
 LL | #![deny(invalid_doc_attributes)]
    |         ^^^^^^^^^^^^^^^^^^^^^^
+
+error: malformed `doc` attribute input
+  --> $DIR/invalid-doc-attr-3.rs:6:1
+   |
+LL | #![doc(test(attr = 1))]
+   | ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+
+error: didn't expect any arguments here
+  --> $DIR/invalid-doc-attr-3.rs:10:14
+   |
+LL | #[doc(hidden = true)]
+   |              ^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 error: didn't expect any arguments here
   --> $DIR/invalid-doc-attr-3.rs:13:13
@@ -32,22 +48,6 @@ error: malformed `doc` attribute input
    |
 LL | #[doc = 1]
    |         ^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-
-error: didn't expect any arguments here
-  --> $DIR/invalid-doc-attr-3.rs:3:29
-   |
-LL | #![doc(test(no_crate_inject = 1))]
-   |                             ^^^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-
-error: malformed `doc` attribute input
-  --> $DIR/invalid-doc-attr-3.rs:6:1
-   |
-LL | #![doc(test(attr = 1))]
-   | ^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 

--- a/tests/ui/attributes/doc-attr.stderr
+++ b/tests/ui/attributes/doc-attr.stderr
@@ -1,14 +1,20 @@
 error: unknown `doc` attribute `as_ptr`
-  --> $DIR/doc-attr.rs:6:7
+  --> $DIR/doc-attr.rs:3:8
    |
-LL | #[doc(as_ptr)]
-   |       ^^^^^^
+LL | #![doc(as_ptr)]
+   |        ^^^^^^
    |
 note: the lint level is defined here
   --> $DIR/doc-attr.rs:1:9
    |
 LL | #![deny(invalid_doc_attributes)]
    |         ^^^^^^^^^^^^^^^^^^^^^^
+
+error: unknown `doc` attribute `as_ptr`
+  --> $DIR/doc-attr.rs:6:7
+   |
+LL | #[doc(as_ptr)]
+   |       ^^^^^^
 
 error: expected this to be of the form `... = "..."`
   --> $DIR/doc-attr.rs:10:7
@@ -45,12 +51,6 @@ error: unknown `doc` attribute `crate::bar::baz`
    |
 LL | #[doc(foo::bar, crate::bar::baz = "bye")]
    |                 ^^^^^^^^^^^^^^^
-
-error: unknown `doc` attribute `as_ptr`
-  --> $DIR/doc-attr.rs:3:8
-   |
-LL | #![doc(as_ptr)]
-   |        ^^^^^^
 
 error: aborting due to 7 previous errors
 

--- a/tests/ui/attributes/malformed-no-std.stderr
+++ b/tests/ui/attributes/malformed-no-std.stderr
@@ -118,23 +118,6 @@ note: this attribute does not have an `!`, which means it is applied to this ext
 LL | extern crate core;
    | ^^^^^^^^^^^^^^^^^^
 
-error: crate-level attribute should be an inner attribute: add an exclamation mark: `#![no_std]`
-  --> $DIR/malformed-no-std.rs:21:1
-   |
-LL | #[no_std]
-   | ^^^^^^^^^
-   |
-note: this attribute does not have an `!`, which means it is applied to this extern crate
-  --> $DIR/malformed-no-std.rs:26:1
-   |
-LL | extern crate core;
-   | ^^^^^^^^^^^^^^^^^^
-note: the lint level is defined here
-  --> $DIR/malformed-no-std.rs:20:8
-   |
-LL | #[deny(unused_attributes)]
-   |        ^^^^^^^^^^^^^^^^^
-
 warning: unused attribute
   --> $DIR/malformed-no-std.rs:5:1
    |
@@ -159,6 +142,23 @@ note: attribute also specified here
    |
 LL | #![no_std = "foo"]
    | ^^^^^^^^^^^^^^^^^^
+
+error: crate-level attribute should be an inner attribute: add an exclamation mark: `#![no_std]`
+  --> $DIR/malformed-no-std.rs:21:1
+   |
+LL | #[no_std]
+   | ^^^^^^^^^
+   |
+note: this attribute does not have an `!`, which means it is applied to this extern crate
+  --> $DIR/malformed-no-std.rs:26:1
+   |
+LL | extern crate core;
+   | ^^^^^^^^^^^^^^^^^^
+note: the lint level is defined here
+  --> $DIR/malformed-no-std.rs:20:8
+   |
+LL | #[deny(unused_attributes)]
+   |        ^^^^^^^^^^^^^^^^^
 
 error: aborting due to 10 previous errors; 2 warnings emitted
 

--- a/tests/ui/consts/const-fn-variant-ctor.rs
+++ b/tests/ui/consts/const-fn-variant-ctor.rs
@@ -1,0 +1,20 @@
+//@ check-pass
+// @ needs-rustc-debug-assertions
+//@ revisions: current next
+//@[next] compile-flags: -Znext-solver
+
+#![feature(const_destruct, const_trait_impl)]
+
+use std::marker::Destruct;
+
+const fn impls_fn_once<F: [const] FnOnce(u32) -> Enum + [const] Destruct>(_: F) {}
+
+enum Enum {
+    Variant(u32),
+}
+
+const fn test() {
+    impls_fn_once(Enum::Variant);
+}
+
+fn main() {}

--- a/tests/ui/extern/extern-no-mangle.stderr
+++ b/tests/ui/extern/extern-no-mangle.stderr
@@ -1,5 +1,5 @@
-warning: `#[no_mangle]` attribute cannot be used on foreign statics
-  --> $DIR/extern-no-mangle.rs:11:5
+warning: `#[no_mangle]` attribute cannot be used on statements
+  --> $DIR/extern-no-mangle.rs:24:5
    |
 LL |     #[no_mangle]
    |     ^^^^^^^^^^^^
@@ -12,6 +12,15 @@ note: the lint level is defined here
 LL | #![warn(unused_attributes)]
    |         ^^^^^^^^^^^^^^^^^
 
+warning: `#[no_mangle]` attribute cannot be used on foreign statics
+  --> $DIR/extern-no-mangle.rs:11:5
+   |
+LL |     #[no_mangle]
+   |     ^^^^^^^^^^^^
+   |
+   = help: `#[no_mangle]` can be applied to functions and statics
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+
 warning: `#[no_mangle]` attribute cannot be used on foreign functions
   --> $DIR/extern-no-mangle.rs:16:5
    |
@@ -19,15 +28,6 @@ LL |     #[no_mangle]
    |     ^^^^^^^^^^^^
    |
    = help: `#[no_mangle]` can be applied to functions with a body and statics
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-
-warning: `#[no_mangle]` attribute cannot be used on statements
-  --> $DIR/extern-no-mangle.rs:24:5
-   |
-LL |     #[no_mangle]
-   |     ^^^^^^^^^^^^
-   |
-   = help: `#[no_mangle]` can be applied to functions and statics
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: 3 warnings emitted

--- a/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs-error.stderr
+++ b/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs-error.stderr
@@ -305,6 +305,23 @@ help: remove the `#[no_mangle]` attribute
 LL - #![no_mangle]
    |
 
+warning: unused attribute
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:16:1
+   |
+LL | #![repr()]
+   | ^^^^^^^^^^ help: remove this attribute
+   |
+   = note: using `repr` with an empty list has no effect
+
+warning: `#[no_mangle]` attribute cannot be used on crates
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:24:1
+   |
+LL | #![no_mangle]
+   | ^^^^^^^^^^^^^
+   |
+   = help: `#[no_mangle]` can be applied to functions and statics
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+
 error: valid forms for the attribute are `#[inline(always)]`, `#[inline(never)]`, and `#[inline]`
   --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:43:5
    |
@@ -340,23 +357,6 @@ LL |     #[no_link]
    |     ^^^^^^^^^^
    |
    = help: `#[no_link]` can only be applied to extern crates
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-
-warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:16:1
-   |
-LL | #![repr()]
-   | ^^^^^^^^^^ help: remove this attribute
-   |
-   = note: using `repr` with an empty list has no effect
-
-warning: `#[no_mangle]` attribute cannot be used on crates
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:24:1
-   |
-LL | #![no_mangle]
-   | ^^^^^^^^^^^^^
-   |
-   = help: `#[no_mangle]` can be applied to functions and statics
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 error: aborting due to 37 previous errors; 6 warnings emitted

--- a/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs.stderr
+++ b/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs.stderr
@@ -207,6 +207,87 @@ note: the lint level is defined here
 LL | #![warn(unused_attributes, unknown_lints)]
    |         ^^^^^^^^^^^^^^^^^
 
+warning: `#[macro_use]` attribute cannot be used on crates
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:45:1
+   |
+LL | #![macro_use]
+   | ^^^^^^^^^^^^^
+   |
+   = help: `#[macro_use]` can be applied to extern crates and modules
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+
+warning: `#[should_panic]` attribute cannot be used on crates
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:51:1
+   |
+LL | #![should_panic]
+   | ^^^^^^^^^^^^^^^^
+   |
+   = help: `#[should_panic]` can only be applied to functions
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+
+warning: `#[ignore]` attribute cannot be used on crates
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:55:1
+   |
+LL | #![ignore]
+   | ^^^^^^^^^^
+   |
+   = help: `#[ignore]` can only be applied to functions
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+
+warning: `#[proc_macro_derive]` attribute cannot be used on crates
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:63:1
+   |
+LL | #![proc_macro_derive(Test)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[proc_macro_derive]` can only be applied to functions
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+
+warning: `#[cold]` attribute cannot be used on crates
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:68:1
+   |
+LL | #![cold]
+   | ^^^^^^^^
+   |
+   = help: `#[cold]` can only be applied to functions
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+
+warning: `#[link]` attribute cannot be used on crates
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:72:1
+   |
+LL | #![link(name = "x")]
+   | ^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[link]` can only be applied to foreign modules
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+
+warning: `#[link_name]` attribute cannot be used on crates
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:76:1
+   |
+LL | #![link_name = "1900"]
+   | ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[link_name]` can be applied to foreign functions and foreign statics
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+
+warning: `#[link_section]` attribute cannot be used on crates
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:81:1
+   |
+LL | #![link_section = ",1800"]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[link_section]` can be applied to functions and statics
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+
+warning: `#[must_use]` attribute cannot be used on crates
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:86:1
+   |
+LL | #![must_use]
+   | ^^^^^^^^^^^^
+   |
+   = help: `#[must_use]` can be applied to data types, functions, and traits
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+
 warning: `#[macro_use]` attribute cannot be used on functions
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:193:5
    |
@@ -439,24 +520,6 @@ LL |     #[no_mangle] impl S { }
    |     ^^^^^^^^^^^^
    |
    = help: `#[no_mangle]` can be applied to functions and statics
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-
-warning: `#[no_mangle]` attribute cannot be used on required trait methods
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:362:9
-   |
-LL |         #[no_mangle] fn foo();
-   |         ^^^^^^^^^^^^
-   |
-   = help: `#[no_mangle]` can be applied to functions with a body and statics
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-
-warning: `#[no_mangle]` attribute cannot be used on provided trait methods
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:368:9
-   |
-LL |         #[no_mangle] fn bar() {}
-   |         ^^^^^^^^^^^^
-   |
-   = help: `#[no_mangle]` can be applied to functions, inherent methods, statics, and trait methods in impl blocks
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[should_panic]` attribute cannot be used on modules
@@ -851,15 +914,6 @@ LL |     #[link_section = ",1800"]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: `#[link_section]` can be applied to functions and statics
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-
-warning: `#[link_section]` attribute cannot be used on required trait methods
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:661:9
-   |
-LL |         #[link_section = ",1800"]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = help: `#[link_section]` can be applied to functions with a body and statics
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[link]` attribute cannot be used on modules
@@ -1512,85 +1566,31 @@ note: this attribute does not have an `!`, which means it is applied to this imp
 LL |     #[type_length_limit="0100"] impl S { }
    |                                 ^^^^^^^^^^
 
-warning: `#[macro_use]` attribute cannot be used on crates
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:45:1
+warning: `#[no_mangle]` attribute cannot be used on required trait methods
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:362:9
    |
-LL | #![macro_use]
-   | ^^^^^^^^^^^^^
+LL |         #[no_mangle] fn foo();
+   |         ^^^^^^^^^^^^
    |
-   = help: `#[macro_use]` can be applied to extern crates and modules
+   = help: `#[no_mangle]` can be applied to functions with a body and statics
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[should_panic]` attribute cannot be used on crates
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:51:1
+warning: `#[no_mangle]` attribute cannot be used on provided trait methods
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:368:9
    |
-LL | #![should_panic]
-   | ^^^^^^^^^^^^^^^^
+LL |         #[no_mangle] fn bar() {}
+   |         ^^^^^^^^^^^^
    |
-   = help: `#[should_panic]` can only be applied to functions
+   = help: `#[no_mangle]` can be applied to functions, inherent methods, statics, and trait methods in impl blocks
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[ignore]` attribute cannot be used on crates
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:55:1
+warning: `#[link_section]` attribute cannot be used on required trait methods
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:661:9
    |
-LL | #![ignore]
-   | ^^^^^^^^^^
+LL |         #[link_section = ",1800"]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[ignore]` can only be applied to functions
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-
-warning: `#[proc_macro_derive]` attribute cannot be used on crates
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:63:1
-   |
-LL | #![proc_macro_derive(Test)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = help: `#[proc_macro_derive]` can only be applied to functions
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-
-warning: `#[cold]` attribute cannot be used on crates
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:68:1
-   |
-LL | #![cold]
-   | ^^^^^^^^
-   |
-   = help: `#[cold]` can only be applied to functions
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-
-warning: `#[link]` attribute cannot be used on crates
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:72:1
-   |
-LL | #![link(name = "x")]
-   | ^^^^^^^^^^^^^^^^^^^^
-   |
-   = help: `#[link]` can only be applied to foreign modules
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-
-warning: `#[link_name]` attribute cannot be used on crates
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:76:1
-   |
-LL | #![link_name = "1900"]
-   | ^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = help: `#[link_name]` can be applied to foreign functions and foreign statics
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-
-warning: `#[link_section]` attribute cannot be used on crates
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:81:1
-   |
-LL | #![link_section = ",1800"]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = help: `#[link_section]` can be applied to functions and statics
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-
-warning: `#[must_use]` attribute cannot be used on crates
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:86:1
-   |
-LL | #![must_use]
-   | ^^^^^^^^^^^^
-   |
-   = help: `#[must_use]` can be applied to data types, functions, and traits
+   = help: `#[link_section]` can be applied to functions with a body and statics
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: 170 warnings emitted

--- a/tests/ui/feature-gates/issue-43106-gating-of-macro_use.stderr
+++ b/tests/ui/feature-gates/issue-43106-gating-of-macro_use.stderr
@@ -34,6 +34,16 @@ LL -     #[macro_use = "2700"] struct S;
 LL +     #[macro_use] struct S;
    |
 
+warning: `#[macro_use]` attribute cannot be used on crates
+  --> $DIR/issue-43106-gating-of-macro_use.rs:6:1
+   |
+LL | #![macro_use(my_macro)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[macro_use]` can be applied to extern crates and modules
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: requested on the command line with `-W unused-attributes`
+
 warning: `#[macro_use]` attribute cannot be used on structs
   --> $DIR/issue-43106-gating-of-macro_use.rs:17:5
    |
@@ -42,7 +52,6 @@ LL |     #[macro_use = "2700"] struct S;
    |
    = help: `#[macro_use]` can be applied to extern crates and modules
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: requested on the command line with `-W unused-attributes`
 
 warning: `#[macro_use]` attribute cannot be used on functions
   --> $DIR/issue-43106-gating-of-macro_use.rs:22:5
@@ -67,15 +76,6 @@ warning: `#[macro_use]` attribute cannot be used on inherent impl blocks
    |
 LL |     #[macro_use] impl S { }
    |     ^^^^^^^^^^^^
-   |
-   = help: `#[macro_use]` can be applied to extern crates and modules
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-
-warning: `#[macro_use]` attribute cannot be used on crates
-  --> $DIR/issue-43106-gating-of-macro_use.rs:6:1
-   |
-LL | #![macro_use(my_macro)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: `#[macro_use]` can be applied to extern crates and modules
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!

--- a/tests/ui/lint/lint-unsafe-code.stderr
+++ b/tests/ui/lint/lint-unsafe-code.stderr
@@ -109,22 +109,6 @@ LL | #[no_mangle] static FOO: u32 = 5;
    |
    = note: the linker's behavior with multiple libraries exporting duplicate symbol names is undefined and Rust cannot provide guarantees when you manually override them
 
-error: usage of the unsafe `#[no_mangle]` attribute
-  --> $DIR/lint-unsafe-code.rs:48:7
-   |
-LL |     #[no_mangle] fn foo() {}
-   |       ^^^^^^^^^
-   |
-   = note: the linker's behavior with multiple libraries exporting duplicate symbol names is undefined and Rust cannot provide guarantees when you manually override them
-
-error: usage of the unsafe `#[no_mangle]` attribute
-  --> $DIR/lint-unsafe-code.rs:52:7
-   |
-LL |     #[no_mangle] fn foo() {}
-   |       ^^^^^^^^^
-   |
-   = note: the linker's behavior with multiple libraries exporting duplicate symbol names is undefined and Rust cannot provide guarantees when you manually override them
-
 error: usage of the unsafe `#[export_name]` attribute
   --> $DIR/lint-unsafe-code.rs:55:3
    |
@@ -156,22 +140,6 @@ LL | #[link_section = "__TEXT,__text"] static UWU: u32 = 5;
    |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: the program's behavior with overridden link sections on items is unpredictable and Rust cannot provide guarantees when you manually override them
-
-error: usage of the unsafe `#[export_name]` attribute
-  --> $DIR/lint-unsafe-code.rs:64:7
-   |
-LL |     #[export_name = "bar"] fn bar() {}
-   |       ^^^^^^^^^^^^^^^^^^^
-   |
-   = note: the linker's behavior with multiple libraries exporting duplicate symbol names is undefined and Rust cannot provide guarantees when you manually override them
-
-error: usage of the unsafe `#[export_name]` attribute
-  --> $DIR/lint-unsafe-code.rs:68:7
-   |
-LL |     #[export_name = "bar"] fn foo() {}
-   |       ^^^^^^^^^^^^^^^^^^^
-   |
-   = note: the linker's behavior with multiple libraries exporting duplicate symbol names is undefined and Rust cannot provide guarantees when you manually override them
 
 error: usage of the unsafe `#[no_mangle]` attribute
   --> $DIR/lint-unsafe-code.rs:28:11
@@ -229,18 +197,66 @@ LL | #[unsafe(naked)] fn naked1() { naked_asm!("halt") }
    |
    = note: the `#[naked]` attribute adds the safety obligation that the function's body must respect the function’s calling convention, uphold its signature, and either return or diverge (i.e., not fall through past the end of the assembly code).
 
-error: usage of the unsafe `#[naked]` attribute
-  --> $DIR/lint-unsafe-code.rs:144:14
+error: usage of the unsafe `#[force_target_feature]` attribute
+  --> $DIR/lint-unsafe-code.rs:168:10
    |
-LL |     #[unsafe(naked)] fn naked2() { naked_asm!("halt") }
-   |              ^^^^^
+LL | #[unsafe(force_target_feature(enable = "avx2"))] fn force_target_feature() { }
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: the `#[naked]` attribute adds the safety obligation that the function's body must respect the function’s calling convention, uphold its signature, and either return or diverge (i.e., not fall through past the end of the assembly code).
+   = note: a function with the signature of the function the attribute is applied to must only be callable if the force-enabled features are guaranteed to be present
 
 error: usage of the unsafe `#[naked]` attribute
   --> $DIR/lint-unsafe-code.rs:149:14
    |
 LL |     #[unsafe(naked)] fn naked3() { naked_asm!("halt") }
+   |              ^^^^^
+   |
+   = note: the `#[naked]` attribute adds the safety obligation that the function's body must respect the function’s calling convention, uphold its signature, and either return or diverge (i.e., not fall through past the end of the assembly code).
+
+error: usage of the unsafe `#[force_target_feature]` attribute
+  --> $DIR/lint-unsafe-code.rs:178:14
+   |
+LL |     #[unsafe(force_target_feature(enable = "avx2"))] fn force_target_feature() { }
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: a function with the signature of the function the attribute is applied to must only be callable if the force-enabled features are guaranteed to be present
+
+error: usage of the unsafe `#[no_mangle]` attribute
+  --> $DIR/lint-unsafe-code.rs:48:7
+   |
+LL |     #[no_mangle] fn foo() {}
+   |       ^^^^^^^^^
+   |
+   = note: the linker's behavior with multiple libraries exporting duplicate symbol names is undefined and Rust cannot provide guarantees when you manually override them
+
+error: usage of the unsafe `#[no_mangle]` attribute
+  --> $DIR/lint-unsafe-code.rs:52:7
+   |
+LL |     #[no_mangle] fn foo() {}
+   |       ^^^^^^^^^
+   |
+   = note: the linker's behavior with multiple libraries exporting duplicate symbol names is undefined and Rust cannot provide guarantees when you manually override them
+
+error: usage of the unsafe `#[export_name]` attribute
+  --> $DIR/lint-unsafe-code.rs:64:7
+   |
+LL |     #[export_name = "bar"] fn bar() {}
+   |       ^^^^^^^^^^^^^^^^^^^
+   |
+   = note: the linker's behavior with multiple libraries exporting duplicate symbol names is undefined and Rust cannot provide guarantees when you manually override them
+
+error: usage of the unsafe `#[export_name]` attribute
+  --> $DIR/lint-unsafe-code.rs:68:7
+   |
+LL |     #[export_name = "bar"] fn foo() {}
+   |       ^^^^^^^^^^^^^^^^^^^
+   |
+   = note: the linker's behavior with multiple libraries exporting duplicate symbol names is undefined and Rust cannot provide guarantees when you manually override them
+
+error: usage of the unsafe `#[naked]` attribute
+  --> $DIR/lint-unsafe-code.rs:144:14
+   |
+LL |     #[unsafe(naked)] fn naked2() { naked_asm!("halt") }
    |              ^^^^^
    |
    = note: the `#[naked]` attribute adds the safety obligation that the function's body must respect the function’s calling convention, uphold its signature, and either return or diverge (i.e., not fall through past the end of the assembly code).
@@ -252,6 +268,22 @@ LL |     #[unsafe(naked)] fn naked4() { naked_asm!("halt") }
    |              ^^^^^
    |
    = note: the `#[naked]` attribute adds the safety obligation that the function's body must respect the function’s calling convention, uphold its signature, and either return or diverge (i.e., not fall through past the end of the assembly code).
+
+error: usage of the unsafe `#[force_target_feature]` attribute
+  --> $DIR/lint-unsafe-code.rs:173:14
+   |
+LL |     #[unsafe(force_target_feature(enable = "avx2"))] fn force_target_feature() { }
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: a function with the signature of the function the attribute is applied to must only be callable if the force-enabled features are guaranteed to be present
+
+error: usage of the unsafe `#[force_target_feature]` attribute
+  --> $DIR/lint-unsafe-code.rs:182:14
+   |
+LL |     #[unsafe(force_target_feature(enable = "avx2"))] fn force_target_feature() { }
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: a function with the signature of the function the attribute is applied to must only be callable if the force-enabled features are guaranteed to be present
 
 error: usage of the unsafe `#[ffi_pure]` attribute
   --> $DIR/lint-unsafe-code.rs:159:14
@@ -268,38 +300,6 @@ LL |     #[unsafe(ffi_const)]
    |              ^^^^^^^^^
    |
    = note: `#[ffi_const]` functions shall have no effects except for its return value, which can only depend on the values of the function parameters, and is not affected by changes to the observable state of the program.
-
-error: usage of the unsafe `#[force_target_feature]` attribute
-  --> $DIR/lint-unsafe-code.rs:168:10
-   |
-LL | #[unsafe(force_target_feature(enable = "avx2"))] fn force_target_feature() { }
-   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: a function with the signature of the function the attribute is applied to must only be callable if the force-enabled features are guaranteed to be present
-
-error: usage of the unsafe `#[force_target_feature]` attribute
-  --> $DIR/lint-unsafe-code.rs:173:14
-   |
-LL |     #[unsafe(force_target_feature(enable = "avx2"))] fn force_target_feature() { }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: a function with the signature of the function the attribute is applied to must only be callable if the force-enabled features are guaranteed to be present
-
-error: usage of the unsafe `#[force_target_feature]` attribute
-  --> $DIR/lint-unsafe-code.rs:178:14
-   |
-LL |     #[unsafe(force_target_feature(enable = "avx2"))] fn force_target_feature() { }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: a function with the signature of the function the attribute is applied to must only be callable if the force-enabled features are guaranteed to be present
-
-error: usage of the unsafe `#[force_target_feature]` attribute
-  --> $DIR/lint-unsafe-code.rs:182:14
-   |
-LL |     #[unsafe(force_target_feature(enable = "avx2"))] fn force_target_feature() { }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: a function with the signature of the function the attribute is applied to must only be callable if the force-enabled features are guaranteed to be present
 
 error: aborting due to 38 previous errors
 

--- a/tests/ui/lint/unused/empty-attributes.stderr
+++ b/tests/ui/lint/unused/empty-attributes.stderr
@@ -44,6 +44,14 @@ LL | #![forbid()]
    = note: attribute `forbid` with an empty list has no effect
 
 error: unused attribute
+  --> $DIR/empty-attributes.rs:7:1
+   |
+LL | #![feature()]
+   | ^^^^^^^^^^^^^ help: remove this attribute
+   |
+   = note: using `feature` with an empty list has no effect
+
+error: unused attribute
   --> $DIR/empty-attributes.rs:9:1
    |
 LL | #[repr()]
@@ -58,14 +66,6 @@ LL | #[target_feature()]
    | ^^^^^^^^^^^^^^^^^^^ help: remove this attribute
    |
    = note: using `target_feature` with an empty list has no effect
-
-error: unused attribute
-  --> $DIR/empty-attributes.rs:7:1
-   |
-LL | #![feature()]
-   | ^^^^^^^^^^^^^ help: remove this attribute
-   |
-   = note: using `feature` with an empty list has no effect
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/lint/unused/unused-attr-duplicate.stderr
+++ b/tests/ui/lint/unused/unused-attr-duplicate.stderr
@@ -17,6 +17,95 @@ LL | #![deny(unused_attributes)]
    |         ^^^^^^^^^^^^^^^^^
 
 error: unused attribute
+  --> $DIR/unused-attr-duplicate.rs:14:1
+   |
+LL | #![crate_name = "unused_attr_duplicate2"]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
+   |
+note: attribute also specified here
+  --> $DIR/unused-attr-duplicate.rs:13:1
+   |
+LL | #![crate_name = "unused_attr_duplicate"]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: unused attribute
+  --> $DIR/unused-attr-duplicate.rs:21:1
+   |
+LL | #![recursion_limit = "256"]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
+   |
+note: attribute also specified here
+  --> $DIR/unused-attr-duplicate.rs:20:1
+   |
+LL | #![recursion_limit = "128"]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+
+error: unused attribute
+  --> $DIR/unused-attr-duplicate.rs:24:1
+   |
+LL | #![type_length_limit = "1"]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
+   |
+note: attribute also specified here
+  --> $DIR/unused-attr-duplicate.rs:23:1
+   |
+LL | #![type_length_limit = "1048576"]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+
+error: unused attribute
+  --> $DIR/unused-attr-duplicate.rs:27:1
+   |
+LL | #![no_std]
+   | ^^^^^^^^^^ help: remove this attribute
+   |
+note: attribute also specified here
+  --> $DIR/unused-attr-duplicate.rs:26:1
+   |
+LL | #![no_std]
+   | ^^^^^^^^^^
+
+error: unused attribute
+  --> $DIR/unused-attr-duplicate.rs:29:1
+   |
+LL | #![no_implicit_prelude]
+   | ^^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
+   |
+note: attribute also specified here
+  --> $DIR/unused-attr-duplicate.rs:28:1
+   |
+LL | #![no_implicit_prelude]
+   | ^^^^^^^^^^^^^^^^^^^^^^^
+
+error: unused attribute
+  --> $DIR/unused-attr-duplicate.rs:31:1
+   |
+LL | #![windows_subsystem = "windows"]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
+   |
+note: attribute also specified here
+  --> $DIR/unused-attr-duplicate.rs:30:1
+   |
+LL | #![windows_subsystem = "console"]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+
+error: unused attribute
+  --> $DIR/unused-attr-duplicate.rs:34:1
+   |
+LL | #![no_builtins]
+   | ^^^^^^^^^^^^^^^ help: remove this attribute
+   |
+note: attribute also specified here
+  --> $DIR/unused-attr-duplicate.rs:33:1
+   |
+LL | #![no_builtins]
+   | ^^^^^^^^^^^^^^^
+
+error: unused attribute
   --> $DIR/unused-attr-duplicate.rs:37:1
    |
 LL | #[no_link]
@@ -165,19 +254,6 @@ LL | #[track_caller]
    | ^^^^^^^^^^^^^^^
 
 error: unused attribute
-  --> $DIR/unused-attr-duplicate.rs:94:5
-   |
-LL |     #[link_name = "rust_dbg_extern_identity_u32"]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
-   |
-note: attribute also specified here
-  --> $DIR/unused-attr-duplicate.rs:93:5
-   |
-LL |     #[link_name = "this_does_not_exist"]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-
-error: unused attribute
   --> $DIR/unused-attr-duplicate.rs:100:1
    |
 LL | #[export_name = "exported_symbol_name2"]
@@ -228,93 +304,17 @@ LL | #[link_section = "__TEXT,__text"]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 error: unused attribute
-  --> $DIR/unused-attr-duplicate.rs:14:1
+  --> $DIR/unused-attr-duplicate.rs:94:5
    |
-LL | #![crate_name = "unused_attr_duplicate2"]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
+LL |     #[link_name = "rust_dbg_extern_identity_u32"]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
    |
 note: attribute also specified here
-  --> $DIR/unused-attr-duplicate.rs:13:1
+  --> $DIR/unused-attr-duplicate.rs:93:5
    |
-LL | #![crate_name = "unused_attr_duplicate"]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     #[link_name = "this_does_not_exist"]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-error: unused attribute
-  --> $DIR/unused-attr-duplicate.rs:21:1
-   |
-LL | #![recursion_limit = "256"]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
-   |
-note: attribute also specified here
-  --> $DIR/unused-attr-duplicate.rs:20:1
-   |
-LL | #![recursion_limit = "128"]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-
-error: unused attribute
-  --> $DIR/unused-attr-duplicate.rs:24:1
-   |
-LL | #![type_length_limit = "1"]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
-   |
-note: attribute also specified here
-  --> $DIR/unused-attr-duplicate.rs:23:1
-   |
-LL | #![type_length_limit = "1048576"]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-
-error: unused attribute
-  --> $DIR/unused-attr-duplicate.rs:27:1
-   |
-LL | #![no_std]
-   | ^^^^^^^^^^ help: remove this attribute
-   |
-note: attribute also specified here
-  --> $DIR/unused-attr-duplicate.rs:26:1
-   |
-LL | #![no_std]
-   | ^^^^^^^^^^
-
-error: unused attribute
-  --> $DIR/unused-attr-duplicate.rs:29:1
-   |
-LL | #![no_implicit_prelude]
-   | ^^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
-   |
-note: attribute also specified here
-  --> $DIR/unused-attr-duplicate.rs:28:1
-   |
-LL | #![no_implicit_prelude]
-   | ^^^^^^^^^^^^^^^^^^^^^^^
-
-error: unused attribute
-  --> $DIR/unused-attr-duplicate.rs:31:1
-   |
-LL | #![windows_subsystem = "windows"]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
-   |
-note: attribute also specified here
-  --> $DIR/unused-attr-duplicate.rs:30:1
-   |
-LL | #![windows_subsystem = "console"]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-
-error: unused attribute
-  --> $DIR/unused-attr-duplicate.rs:34:1
-   |
-LL | #![no_builtins]
-   | ^^^^^^^^^^^^^^^ help: remove this attribute
-   |
-note: attribute also specified here
-  --> $DIR/unused-attr-duplicate.rs:33:1
-   |
-LL | #![no_builtins]
-   | ^^^^^^^^^^^^^^^
 
 error: aborting due to 25 previous errors
 

--- a/tests/ui/lint/unused/unused_attributes-must_use.stderr
+++ b/tests/ui/lint/unused/unused_attributes-must_use.stderr
@@ -76,15 +76,6 @@ LL | #[must_use]
    = help: `#[must_use]` can be applied to data types, functions, and traits
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-error: `#[must_use]` attribute cannot be used on foreign statics
-  --> $DIR/unused_attributes-must_use.rs:59:5
-   |
-LL |     #[must_use]
-   |     ^^^^^^^^^^^
-   |
-   = help: `#[must_use]` can be applied to data types, functions, and traits
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-
 error: `#[must_use]` attribute cannot be used on type aliases
   --> $DIR/unused_attributes-must_use.rs:73:1
    |
@@ -103,24 +94,6 @@ LL | fn qux<#[must_use] T>(_: T) {}
    = help: `#[must_use]` can be applied to data types, functions, and traits
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-error: `#[must_use]` attribute cannot be used on associated consts
-  --> $DIR/unused_attributes-must_use.rs:82:5
-   |
-LL |     #[must_use]
-   |     ^^^^^^^^^^^
-   |
-   = help: `#[must_use]` can be applied to data types, functions, and traits
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-
-error: `#[must_use]` attribute cannot be used on associated types
-  --> $DIR/unused_attributes-must_use.rs:85:5
-   |
-LL |     #[must_use]
-   |     ^^^^^^^^^^^
-   |
-   = help: `#[must_use]` can be applied to data types, functions, and traits
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-
 error: `#[must_use]` attribute cannot be used on trait impl blocks
   --> $DIR/unused_attributes-must_use.rs:95:1
    |
@@ -128,15 +101,6 @@ LL | #[must_use]
    | ^^^^^^^^^^^
    |
    = help: `#[must_use]` can be applied to data types, functions, and traits
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-
-error: `#[must_use]` attribute cannot be used on trait methods in impl blocks
-  --> $DIR/unused_attributes-must_use.rs:100:5
-   |
-LL |     #[must_use]
-   |     ^^^^^^^^^^^
-   |
-   = help: `#[must_use]` can be applied to data types, foreign functions, functions, inherent methods, provided trait methods, required trait methods, and traits
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 error: `#[must_use]` attribute cannot be used on trait aliases
@@ -198,6 +162,42 @@ error: `#[must_use]` attribute cannot be used on pattern fields
    |
 LL |     let PatternField { #[must_use] foo } = s;
    |                        ^^^^^^^^^^^
+   |
+   = help: `#[must_use]` can be applied to data types, functions, and traits
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+
+error: `#[must_use]` attribute cannot be used on associated consts
+  --> $DIR/unused_attributes-must_use.rs:82:5
+   |
+LL |     #[must_use]
+   |     ^^^^^^^^^^^
+   |
+   = help: `#[must_use]` can be applied to data types, functions, and traits
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+
+error: `#[must_use]` attribute cannot be used on associated types
+  --> $DIR/unused_attributes-must_use.rs:85:5
+   |
+LL |     #[must_use]
+   |     ^^^^^^^^^^^
+   |
+   = help: `#[must_use]` can be applied to data types, functions, and traits
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+
+error: `#[must_use]` attribute cannot be used on trait methods in impl blocks
+  --> $DIR/unused_attributes-must_use.rs:100:5
+   |
+LL |     #[must_use]
+   |     ^^^^^^^^^^^
+   |
+   = help: `#[must_use]` can be applied to data types, foreign functions, functions, inherent methods, provided trait methods, required trait methods, and traits
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+
+error: `#[must_use]` attribute cannot be used on foreign statics
+  --> $DIR/unused_attributes-must_use.rs:59:5
+   |
+LL |     #[must_use]
+   |     ^^^^^^^^^^^
    |
    = help: `#[must_use]` can be applied to data types, functions, and traits
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!

--- a/tests/ui/rfcs/rfc-2565-param-attrs/param-attrs-builtin-attrs.stderr
+++ b/tests/ui/rfcs/rfc-2565-param-attrs/param-attrs-builtin-attrs.stderr
@@ -402,6 +402,60 @@ LL |     #[no_mangle] b: i32,
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[must_use]` attribute cannot be used on function params
+  --> $DIR/param-attrs-builtin-attrs.rs:195:9
+   |
+LL |         #[must_use]
+   |         ^^^^^^^^^^^
+   |
+   = help: `#[must_use]` can be applied to data types, functions, and traits
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+
+warning: `#[no_mangle]` attribute cannot be used on function params
+  --> $DIR/param-attrs-builtin-attrs.rs:201:9
+   |
+LL |         #[no_mangle] b: i32
+   |         ^^^^^^^^^^^^
+   |
+   = help: `#[no_mangle]` can be applied to functions and statics
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+
+warning: `#[must_use]` attribute cannot be used on function params
+  --> $DIR/param-attrs-builtin-attrs.rs:131:9
+   |
+LL |         #[must_use]
+   |         ^^^^^^^^^^^
+   |
+   = help: `#[must_use]` can be applied to data types, functions, and traits
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+
+warning: `#[no_mangle]` attribute cannot be used on function params
+  --> $DIR/param-attrs-builtin-attrs.rs:137:9
+   |
+LL |         #[no_mangle] b: i32,
+   |         ^^^^^^^^^^^^
+   |
+   = help: `#[no_mangle]` can be applied to functions and statics
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+
+warning: `#[must_use]` attribute cannot be used on function params
+  --> $DIR/param-attrs-builtin-attrs.rs:150:9
+   |
+LL |         #[must_use]
+   |         ^^^^^^^^^^^
+   |
+   = help: `#[must_use]` can be applied to data types, functions, and traits
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+
+warning: `#[no_mangle]` attribute cannot be used on function params
+  --> $DIR/param-attrs-builtin-attrs.rs:156:9
+   |
+LL |         #[no_mangle] b: i32,
+   |         ^^^^^^^^^^^^
+   |
+   = help: `#[no_mangle]` can be applied to functions and statics
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+
+warning: `#[must_use]` attribute cannot be used on function params
   --> $DIR/param-attrs-builtin-attrs.rs:64:9
    |
 LL |         #[must_use]
@@ -456,42 +510,6 @@ LL |         #[no_mangle] b: i32,
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[must_use]` attribute cannot be used on function params
-  --> $DIR/param-attrs-builtin-attrs.rs:131:9
-   |
-LL |         #[must_use]
-   |         ^^^^^^^^^^^
-   |
-   = help: `#[must_use]` can be applied to data types, functions, and traits
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-
-warning: `#[no_mangle]` attribute cannot be used on function params
-  --> $DIR/param-attrs-builtin-attrs.rs:137:9
-   |
-LL |         #[no_mangle] b: i32,
-   |         ^^^^^^^^^^^^
-   |
-   = help: `#[no_mangle]` can be applied to functions and statics
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-
-warning: `#[must_use]` attribute cannot be used on function params
-  --> $DIR/param-attrs-builtin-attrs.rs:150:9
-   |
-LL |         #[must_use]
-   |         ^^^^^^^^^^^
-   |
-   = help: `#[must_use]` can be applied to data types, functions, and traits
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-
-warning: `#[no_mangle]` attribute cannot be used on function params
-  --> $DIR/param-attrs-builtin-attrs.rs:156:9
-   |
-LL |         #[no_mangle] b: i32,
-   |         ^^^^^^^^^^^^
-   |
-   = help: `#[no_mangle]` can be applied to functions and statics
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-
-warning: `#[must_use]` attribute cannot be used on function params
   --> $DIR/param-attrs-builtin-attrs.rs:174:9
    |
 LL |         #[must_use]
@@ -504,24 +522,6 @@ warning: `#[no_mangle]` attribute cannot be used on function params
   --> $DIR/param-attrs-builtin-attrs.rs:180:9
    |
 LL |         #[no_mangle] b: i32,
-   |         ^^^^^^^^^^^^
-   |
-   = help: `#[no_mangle]` can be applied to functions and statics
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-
-warning: `#[must_use]` attribute cannot be used on function params
-  --> $DIR/param-attrs-builtin-attrs.rs:195:9
-   |
-LL |         #[must_use]
-   |         ^^^^^^^^^^^
-   |
-   = help: `#[must_use]` can be applied to data types, functions, and traits
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-
-warning: `#[no_mangle]` attribute cannot be used on function params
-  --> $DIR/param-attrs-builtin-attrs.rs:201:9
-   |
-LL |         #[no_mangle] b: i32
    |         ^^^^^^^^^^^^
    |
    = help: `#[no_mangle]` can be applied to functions and statics


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#155439 (Enable Cargo's new build-dir layout)
 - rust-lang/rust#158193 (Remove `has_delayed_lints` optimization)
 - rust-lang/rust#158204 (More general assert in Interner const fn check)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=155439,158193,158204)
<!-- homu-ignore:end -->

