### PR TITLE
Remove `std::fmt::Display` implementation for `std::bstr::ByteStr`/`ByteString`

### DIFF
--- a/library/alloc/src/bstr.rs
+++ b/library/alloc/src/bstr.rs
@@ -38,8 +38,8 @@ use crate::vec::Vec;
 /// available on `ByteString`. Similarly, `ByteString` implements `DerefMut` to `&mut Vec<u8>`,
 /// so you can modify a `ByteString` using any method available on `&mut Vec<u8>`.
 ///
-/// The `Debug` and `Display` implementations for `ByteString` are the same as those for `ByteStr`,
-/// showing invalid UTF-8 as hex escapes or the Unicode replacement character, respectively.
+/// The `Debug` implementation for `ByteString` is the same as the one for `ByteStr`,
+/// showing invalid UTF-8 as hex escapes.
 #[unstable(feature = "bstr", issue = "134915")]
 #[repr(transparent)]
 #[derive(Clone)]
@@ -89,14 +89,6 @@ impl fmt::Debug for ByteString {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Debug::fmt(self.as_bytestr(), f)
-    }
-}
-
-#[unstable(feature = "bstr", issue = "134915")]
-impl fmt::Display for ByteString {
-    #[inline]
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Display::fmt(self.as_bytestr(), f)
     }
 }
 

--- a/library/core/src/bstr/mod.rs
+++ b/library/core/src/bstr/mod.rs
@@ -6,7 +6,7 @@ mod traits;
 pub use traits::{impl_partial_eq, impl_partial_eq_n, impl_partial_eq_ord};
 
 use crate::borrow::{Borrow, BorrowMut};
-use crate::fmt::{self, Alignment};
+use crate::fmt;
 use crate::ops::{Deref, DerefMut, DerefPure};
 
 /// A wrapper for `&[u8]` representing a human-readable string that's conventionally, but not
@@ -34,9 +34,6 @@ use crate::ops::{Deref, DerefMut, DerefPure};
 ///
 /// The `Debug` implementation for `ByteStr` shows its bytes as a normal string, with invalid UTF-8
 /// presented as hex escape sequences.
-///
-/// The `Display` implementation behaves as if the `ByteStr` were first lossily converted to a
-/// `str`, with invalid UTF-8 presented as the Unicode replacement character (�).
 #[unstable(feature = "bstr", issue = "134915")]
 #[repr(transparent)]
 #[doc(alias = "BStr")]
@@ -168,91 +165,6 @@ impl fmt::Debug for ByteStr {
         }
         write!(f, "\"")?;
         Ok(())
-    }
-}
-
-#[unstable(feature = "bstr", issue = "134915")]
-impl fmt::Display for ByteStr {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fn emit(byte_str: &ByteStr, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            for chunk in byte_str.utf8_chunks() {
-                f.write_str(chunk.valid())?;
-                if !chunk.invalid().is_empty() {
-                    f.write_str("\u{FFFD}")?;
-                }
-            }
-
-            Ok(())
-        }
-
-        let requested_width = f.width().unwrap_or(0);
-        if requested_width == 0 && f.precision().is_none() {
-            // Avoid counting the characters if no truncation or padding was
-            // requested.
-            return emit(self, f);
-        }
-
-        let (truncated, actual_width) = match f.precision() {
-            // The entire string is truncated away. Weird, but ok.
-            Some(0) => (ByteStr::new(&[]), 0),
-            // Advance through string until we run out of space.
-            Some(precision) => {
-                let mut remaining_width = precision;
-                let mut chunks = self.utf8_chunks();
-                let mut current_width = 0;
-                let mut offset = 0;
-                loop {
-                    let Some(chunk) = chunks.next() else {
-                        // We reached the end of the string without running out
-                        // of space, so print the entire string.
-                        break (self, current_width);
-                    };
-
-                    let mut chars = chunk.valid().char_indices();
-                    let Err(remaining) = chars.advance_by(remaining_width) else {
-                        // We've counted off `precision` characters, so truncate
-                        // the string at the current offset.
-                        break (&self[..offset + chars.offset()], precision);
-                    };
-
-                    offset += chunk.valid().len();
-                    current_width += remaining_width - remaining.get();
-                    remaining_width = remaining.get();
-
-                    // `remaining_width` cannot be zero, there is still space
-                    // remaining. So next, count the � character emitted for
-                    // the invalid chunk (if it exists).
-                    if !chunk.invalid().is_empty() {
-                        offset += chunk.invalid().len();
-                        current_width += 1;
-                        remaining_width -= 1;
-
-                        if remaining_width == 0 {
-                            break (&self[..offset], precision);
-                        }
-                    }
-                }
-            }
-            // The string shouldn't be truncated at all, so just count the number
-            // of characters to calculate the padding.
-            None => {
-                let actual_width = self
-                    .utf8_chunks()
-                    .map(|chunk| {
-                        chunk.valid().chars().count()
-                            + if chunk.invalid().is_empty() { 0 } else { 1 }
-                    })
-                    .sum();
-                (self, actual_width)
-            }
-        };
-
-        // The width is originally stored as a 16-bit number, so this cannot fail.
-        let padding = u16::try_from(requested_width.saturating_sub(actual_width)).unwrap();
-
-        let post_padding = f.padding(padding, Alignment::Left)?;
-        emit(truncated, f)?;
-        post_padding.write(f)
     }
 }
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->

Part of rust-lang/rust#134915
r? @BurntSushi
<!-- homu-ignore:end -->
