### PR TITLE
format: ignore println newline in foreign format hints

### DIFF
--- a/compiler/rustc_builtin_macros/src/format.rs
+++ b/compiler/rustc_builtin_macros/src/format.rs
@@ -607,6 +607,8 @@ fn make_format_args(
         // If there's a lot of unused arguments,
         // let's check if this format arguments looks like another syntax (printf / shell).
         let detect_foreign_fmt = unused.len() > args.explicit_args().len() / 2;
+        let foreign_fmt_str =
+            if append_newline { fmt_str.strip_suffix('\n').unwrap_or(fmt_str) } else { fmt_str };
         report_missing_placeholders(
             ecx,
             unused,
@@ -616,7 +618,7 @@ fn make_format_args(
             &invalid_refs,
             detect_foreign_fmt,
             str_style,
-            fmt_str,
+            foreign_fmt_str,
             uncooked_fmt_str.1.as_str(),
             fmt_span,
         );

--- a/tests/ui/macros/format-foreign-dollar-without-spec.stderr
+++ b/tests/ui/macros/format-foreign-dollar-without-spec.stderr
@@ -2,15 +2,13 @@ error: argument never used
   --> $DIR/format-foreign-dollar-without-spec.rs:3:25
    |
 LL |     println!("%65536$", 1);
-   |                         ^ argument never used
+   |              ---------  ^ argument never used
+   |              |
+   |              formatting specifier missing
    |
-note: format specifiers use curly braces, and the conversion specifier `
-      ` is unknown or unsupported
-  --> $DIR/format-foreign-dollar-without-spec.rs:3:15
+help: format specifiers use curly braces, consider adding a format specifier
    |
-LL |     println!("%65536$", 1);
-   |               ^^^^^^^^
-   = note: printf formatting is not supported; see the documentation for `std::fmt`
+LL |     println!("%65536${}", 1);
+   |                      ++
 
 error: aborting due to 1 previous error
-

--- a/tests/ui/macros/format-foreign-dollar-without-spec.stderr
+++ b/tests/ui/macros/format-foreign-dollar-without-spec.stderr
@@ -12,3 +12,4 @@ LL |     println!("%65536${}", 1);
    |                      ++
 
 error: aborting due to 1 previous error
+

--- a/tests/ui/macros/issue-92267.stderr
+++ b/tests/ui/macros/issue-92267.stderr
@@ -1,14 +1,15 @@
 error: argument never used
   --> $DIR/issue-92267.rs:3:34
    |
-LL | pub fn main() { println!("🦀%%%", 0) }
+LL | pub fn main() { println!("🦀%%%", 0) } //~ ERROR argument never used
    |                          -------  ^ argument never used
    |                          |
    |                          formatting specifier missing
    |
 help: format specifiers use curly braces, consider adding a format specifier
    |
-LL | pub fn main() { println!("🦀%%%{}", 0) }
+LL | pub fn main() { println!("🦀%%%{}", 0) } //~ ERROR argument never used
    |                                ++
 
 error: aborting due to 1 previous error
+

--- a/tests/ui/macros/issue-92267.stderr
+++ b/tests/ui/macros/issue-92267.stderr
@@ -1,15 +1,14 @@
 error: argument never used
   --> $DIR/issue-92267.rs:3:34
    |
-LL | pub fn main() { println!("🦀%%%", 0) } //~ ERROR argument never used
+LL | pub fn main() { println!("🦀%%%", 0) }
    |                          -------  ^ argument never used
    |                          |
    |                          formatting specifier missing
    |
 help: format specifiers use curly braces, consider adding a format specifier
    |
-LL | pub fn main() { println!("🦀%%%{}", 0) } //~ ERROR argument never used
+LL | pub fn main() { println!("🦀%%%{}", 0) }
    |                                ++
 
 error: aborting due to 1 previous error
-

--- a/tests/ui/macros/issue-92267.stderr
+++ b/tests/ui/macros/issue-92267.stderr
@@ -2,15 +2,13 @@ error: argument never used
   --> $DIR/issue-92267.rs:3:34
    |
 LL | pub fn main() { println!("🦀%%%", 0) }
-   |                                   ^ argument never used
+   |                          -------  ^ argument never used
+   |                          |
+   |                          formatting specifier missing
    |
-note: format specifiers use curly braces, and the conversion specifier `
-      ` is unknown or unsupported
-  --> $DIR/issue-92267.rs:3:30
+help: format specifiers use curly braces, consider adding a format specifier
    |
-LL | pub fn main() { println!("🦀%%%", 0) }
-   |                               ^^
-   = note: printf formatting is not supported; see the documentation for `std::fmt`
+LL | pub fn main() { println!("🦀%%%{}", 0) }
+   |                                ++
 
 error: aborting due to 1 previous error
-

--- a/tests/ui/macros/issue-92267.stderr
+++ b/tests/ui/macros/issue-92267.stderr
@@ -12,3 +12,4 @@ LL | pub fn main() { println!("🦀%%%{}", 0) }
    |                                ++
 
 error: aborting due to 1 previous error
+

--- a/tests/ui/macros/trailing-percent-format-hint-issue-158216.rs
+++ b/tests/ui/macros/trailing-percent-format-hint-issue-158216.rs
@@ -1,0 +1,7 @@
+//@ check-fail
+//@ compile-flags: --crate-type=lib
+
+pub fn f(x: f64) {
+    println!("{x:>8.2}%", "foo");
+    //~^ ERROR argument never used
+}

--- a/tests/ui/macros/trailing-percent-format-hint-issue-158216.stderr
+++ b/tests/ui/macros/trailing-percent-format-hint-issue-158216.stderr
@@ -12,3 +12,4 @@ LL |     println!("{x:>8.2}%{}", "foo");
    |                        ++
 
 error: aborting due to 1 previous error
+

--- a/tests/ui/macros/trailing-percent-format-hint-issue-158216.stderr
+++ b/tests/ui/macros/trailing-percent-format-hint-issue-158216.stderr
@@ -1,0 +1,14 @@
+error: argument never used
+  --> $DIR/trailing-percent-format-hint-issue-158216.rs:5:27
+   |
+LL |     println!("{x:>8.2}%", "foo");
+   |              -----------  ^^^^^ argument never used
+   |              |
+   |              formatting specifier missing
+   |
+help: format specifiers use curly braces, consider adding a format specifier
+   |
+LL |     println!("{x:>8.2}%{}", "foo");
+   |                        ++
+
+error: aborting due to 1 previous error


### PR DESCRIPTION
fixes rust-lang/rust#158216

`println!` adds a newline before the unused-arg diagnostic checks for printf-style formats. that made a trailing `%` look like `%` plus `
`, so rustc printed a weird unsupported conversion specifier note.

imo the least risky fix is to leave normal format parsing alone and only strip that synthetic newline for the foreign-format hint scan. idk if there is much more to do here, the ui tests cover the reported case plus the older trailing-percent baselines. lgtm to me, ltm this keeps the behavior narrow.