### PR TITLE
Move target checking for #[lang] to the attribute parser

### DIFF
--- a/compiler/rustc_attr_parsing/src/attributes/allow_unstable.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/allow_unstable.rs
@@ -11,7 +11,7 @@ impl CombineAttributeParser for AllowInternalUnstableParser {
     type Item = (Symbol, Span);
     const CONVERT: ConvertFn<Self::Item> =
         |items, span| AttributeKind::AllowInternalUnstable(items, span);
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[
         Allow(Target::MacroDef),
         Allow(Target::Fn),
         Warn(Target::Field),
@@ -36,7 +36,7 @@ impl CombineAttributeParser for UnstableFeatureBoundParser {
     type Item = (Symbol, Span);
     const CONVERT: ConvertFn<Self::Item> = |items, _| AttributeKind::UnstableFeatureBound(items);
     const STABILITY: AttributeStability = unstable!(staged_api);
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[
         Allow(Target::Fn),
         Allow(Target::Impl { of_trait: true }),
         Allow(Target::Trait),
@@ -59,7 +59,7 @@ impl CombineAttributeParser for RustcAllowConstFnUnstableParser {
     type Item = Symbol;
     const CONVERT: ConvertFn<Self::Item> =
         |items, first_span| AttributeKind::RustcAllowConstFnUnstable(items, first_span);
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[
         Allow(Target::Fn),
         Allow(Target::Method(MethodKind::Inherent)),
         Allow(Target::Method(MethodKind::Trait { body: true })),

--- a/compiler/rustc_attr_parsing/src/attributes/autodiff.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/autodiff.rs
@@ -19,7 +19,7 @@ pub(crate) struct RustcAutodiffParser;
 
 impl SingleAttributeParser for RustcAutodiffParser {
     const PATH: &[Symbol] = &[sym::rustc_autodiff];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[
         Allow(Target::Fn),
         Allow(Target::Method(MethodKind::Inherent)),
         Allow(Target::Method(MethodKind::Trait { body: true })),

--- a/compiler/rustc_attr_parsing/src/attributes/body.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/body.rs
@@ -8,7 +8,8 @@ pub(crate) struct CoroutineParser;
 
 impl NoArgsAttributeParser for CoroutineParser {
     const PATH: &[Symbol] = &[sym::coroutine];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Closure)]);
+    const ALLOWED_TARGETS: AllowedTargets<'_> =
+        AllowedTargets::AllowList(&[Allow(Target::Closure)]);
     const STABILITY: AttributeStability = unstable!(coroutines);
     const CREATE: fn(rustc_span::Span) -> AttributeKind = |_| AttributeKind::Coroutine;
 }

--- a/compiler/rustc_attr_parsing/src/attributes/cfi_encoding.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/cfi_encoding.rs
@@ -4,7 +4,7 @@ use super::prelude::*;
 pub(crate) struct CfiEncodingParser;
 impl SingleAttributeParser for CfiEncodingParser {
     const PATH: &[Symbol] = &[sym::cfi_encoding];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowListWarnRest(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowListWarnRest(&[
         Allow(Target::Struct),
         Allow(Target::ForeignTy),
         Allow(Target::Enum),

--- a/compiler/rustc_attr_parsing/src/attributes/codegen_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/codegen_attrs.rs
@@ -18,7 +18,7 @@ pub(crate) struct OptimizeParser;
 
 impl SingleAttributeParser for OptimizeParser {
     const PATH: &[Symbol] = &[sym::optimize];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[
         Allow(Target::Fn),
         Allow(Target::Closure),
         Allow(Target::Method(MethodKind::Trait { body: true })),
@@ -51,7 +51,7 @@ pub(crate) struct ColdParser;
 impl NoArgsAttributeParser for ColdParser {
     const PATH: &[Symbol] = &[sym::cold];
     const ON_DUPLICATE: OnDuplicate = OnDuplicate::Warn;
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowListWarnRest(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowListWarnRest(&[
         Allow(Target::Fn),
         Allow(Target::Method(MethodKind::Trait { body: true })),
         Allow(Target::Method(MethodKind::TraitImpl)),
@@ -67,7 +67,7 @@ pub(crate) struct CoverageParser;
 
 impl SingleAttributeParser for CoverageParser {
     const PATH: &[Symbol] = &[sym::coverage];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[
         Allow(Target::Fn),
         Allow(Target::Closure),
         Allow(Target::Method(MethodKind::Trait { body: true })),
@@ -114,7 +114,7 @@ impl SingleAttributeParser for ExportNameParser {
         note: "the linker's behavior with multiple libraries exporting duplicate symbol names is undefined and Rust cannot provide guarantees when you manually override them",
         unsafe_since: Some(Edition2024),
     };
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[
         Allow(Target::Static),
         Allow(Target::Fn),
         Allow(Target::Method(MethodKind::Inherent)),
@@ -151,7 +151,7 @@ pub(crate) struct RustcObjcClassParser;
 
 impl SingleAttributeParser for RustcObjcClassParser {
     const PATH: &[rustc_span::Symbol] = &[sym::rustc_objc_class];
-    const ALLOWED_TARGETS: AllowedTargets =
+    const ALLOWED_TARGETS: AllowedTargets<'_> =
         AllowedTargets::AllowList(&[Allow(Target::ForeignStatic)]);
     const TEMPLATE: AttributeTemplate = template!(NameValueStr: "ClassName");
     const STABILITY: AttributeStability = unstable!(rustc_attrs);
@@ -179,7 +179,7 @@ pub(crate) struct RustcObjcSelectorParser;
 
 impl SingleAttributeParser for RustcObjcSelectorParser {
     const PATH: &[rustc_span::Symbol] = &[sym::rustc_objc_selector];
-    const ALLOWED_TARGETS: AllowedTargets =
+    const ALLOWED_TARGETS: AllowedTargets<'_> =
         AllowedTargets::AllowList(&[Allow(Target::ForeignStatic)]);
     const TEMPLATE: AttributeTemplate = template!(NameValueStr: "methodName");
     const STABILITY: AttributeStability = unstable!(rustc_attrs);
@@ -226,7 +226,7 @@ impl AttributeParser for NakedParser {
         note: "the `#[naked]` attribute adds the safety obligation that the function's body must respect the function’s calling convention, uphold its signature, and either return or diverge (i.e., not fall through past the end of the assembly code).",
         unsafe_since: None,
     };
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[
         Allow(Target::Fn),
         Allow(Target::Method(MethodKind::Inherent)),
         Allow(Target::Method(MethodKind::Trait { body: true })),
@@ -334,7 +334,7 @@ pub(crate) struct TrackCallerParser;
 impl NoArgsAttributeParser for TrackCallerParser {
     const PATH: &[Symbol] = &[sym::track_caller];
     const ON_DUPLICATE: OnDuplicate = OnDuplicate::Warn;
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[
         Allow(Target::Fn),
         Allow(Target::Method(MethodKind::Inherent)),
         Allow(Target::Method(MethodKind::Trait { body: true })),
@@ -359,7 +359,7 @@ impl NoArgsAttributeParser for NoMangleParser {
         note: "the linker's behavior with multiple libraries exporting duplicate symbol names is undefined and Rust cannot provide guarantees when you manually override them",
         unsafe_since: Some(Edition2024),
     };
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowListWarnRest(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowListWarnRest(&[
         Allow(Target::Fn),
         Allow(Target::Static),
         Allow(Target::Method(MethodKind::Inherent)),
@@ -462,7 +462,7 @@ impl AttributeParser for UsedParser {
             }
         },
     )];
-    const ALLOWED_TARGETS: AllowedTargets =
+    const ALLOWED_TARGETS: AllowedTargets<'_> =
         AllowedTargets::AllowList(&[Allow(Target::Static), Warn(Target::MacroCall)]);
 
     fn finalize(self, _cx: &FinalizeContext<'_, '_>) -> Option<AttributeKind> {
@@ -533,7 +533,7 @@ impl CombineAttributeParser for TargetFeatureParser {
         parse_tf_attribute(cx, args)
     }
 
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[
         Allow(Target::Fn),
         Allow(Target::Method(MethodKind::Inherent)),
         Allow(Target::Method(MethodKind::Trait { body: true })),
@@ -561,7 +561,7 @@ impl CombineAttributeParser for ForceTargetFeatureParser {
         was_forced: true,
     };
     const TEMPLATE: AttributeTemplate = template!(List: &["enable = \"feat1, feat2\""]);
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[
         Allow(Target::Fn),
         Allow(Target::Method(MethodKind::Inherent)),
         Allow(Target::Method(MethodKind::Trait { body: true })),
@@ -581,7 +581,7 @@ pub(crate) struct InstrumentFnParser;
 
 impl SingleAttributeParser for InstrumentFnParser {
     const PATH: &[Symbol] = &[sym::instrument_fn];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[
         Allow(Target::Fn),
         Allow(Target::Method(MethodKind::Inherent)),
         Allow(Target::Method(MethodKind::Trait { body: true })),
@@ -619,7 +619,7 @@ pub(crate) struct SanitizeParser;
 
 impl SingleAttributeParser for SanitizeParser {
     const PATH: &[Symbol] = &[sym::sanitize];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[
         Allow(Target::Fn),
         Allow(Target::Closure),
         Allow(Target::Method(MethodKind::Inherent)),
@@ -751,7 +751,7 @@ pub(crate) struct ThreadLocalParser;
 
 impl NoArgsAttributeParser for ThreadLocalParser {
     const PATH: &[Symbol] = &[sym::thread_local];
-    const ALLOWED_TARGETS: AllowedTargets =
+    const ALLOWED_TARGETS: AllowedTargets<'_> =
         AllowedTargets::AllowList(&[Allow(Target::Static), Allow(Target::ForeignStatic)]);
     const STABILITY: AttributeStability = unstable!(thread_local);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::ThreadLocal;
@@ -761,7 +761,7 @@ pub(crate) struct RustcPassIndirectlyInNonRusticAbisParser;
 
 impl NoArgsAttributeParser for RustcPassIndirectlyInNonRusticAbisParser {
     const PATH: &[Symbol] = &[sym::rustc_pass_indirectly_in_non_rustic_abis];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Struct)]);
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[Allow(Target::Struct)]);
     const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const CREATE: fn(Span) -> AttributeKind = AttributeKind::RustcPassIndirectlyInNonRusticAbis;
 }
@@ -770,7 +770,7 @@ pub(crate) struct RustcEiiForeignItemParser;
 
 impl NoArgsAttributeParser for RustcEiiForeignItemParser {
     const PATH: &[Symbol] = &[sym::rustc_eii_foreign_item];
-    const ALLOWED_TARGETS: AllowedTargets =
+    const ALLOWED_TARGETS: AllowedTargets<'_> =
         AllowedTargets::AllowList(&[Allow(Target::ForeignFn), Allow(Target::ForeignStatic)]);
     const STABILITY: AttributeStability = unstable!(eii_internals);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcEiiForeignItem;
@@ -780,7 +780,7 @@ pub(crate) struct PatchableFunctionEntryParser;
 
 impl SingleAttributeParser for PatchableFunctionEntryParser {
     const PATH: &[Symbol] = &[sym::patchable_function_entry];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Fn)]);
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[Allow(Target::Fn)]);
     const TEMPLATE: AttributeTemplate = template!(List: &["prefix_nops = m, entry_nops = n"]);
     const STABILITY: AttributeStability = unstable!(patchable_function_entry);
 

--- a/compiler/rustc_attr_parsing/src/attributes/confusables.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/confusables.rs
@@ -32,7 +32,7 @@ impl AttributeParser for ConfusablesParser {
             this.first_span.get_or_insert(cx.attr_span);
         },
     )];
-    const ALLOWED_TARGETS: AllowedTargets =
+    const ALLOWED_TARGETS: AllowedTargets<'_> =
         AllowedTargets::AllowList(&[Allow(Target::Method(MethodKind::Inherent))]);
 
     fn finalize(self, _cx: &FinalizeContext<'_, '_>) -> Option<AttributeKind> {

--- a/compiler/rustc_attr_parsing/src/attributes/crate_level.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/crate_level.rs
@@ -13,7 +13,7 @@ impl SingleAttributeParser for CrateNameParser {
     const PATH: &[Symbol] = &[sym::crate_name];
     const ON_DUPLICATE: OnDuplicate = OnDuplicate::WarnButFutureError;
     const TEMPLATE: AttributeTemplate = template!(NameValueStr: "name");
-    const ALLOWED_TARGETS: AllowedTargets =
+    const ALLOWED_TARGETS: AllowedTargets<'_> =
         AllowedTargets::AllowListWarnRest(&[Allow(Target::Crate)]);
     const STABILITY: AttributeStability = AttributeStability::Stable;
 
@@ -32,7 +32,7 @@ impl CombineAttributeParser for CrateTypeParser {
     const PATH: &[Symbol] = &[sym::crate_type];
     type Item = CrateType;
     const CONVERT: ConvertFn<Self::Item> = |items, _| AttributeKind::CrateType(items);
-    const ALLOWED_TARGETS: AllowedTargets =
+    const ALLOWED_TARGETS: AllowedTargets<'_> =
         AllowedTargets::AllowListWarnRest(&[Allow(Target::Crate)]);
     const TEMPLATE: AttributeTemplate =
         template!(NameValueStr: "crate type", "https://doc.rust-lang.org/reference/linkage.html");
@@ -76,7 +76,7 @@ impl SingleAttributeParser for RecursionLimitParser {
     const PATH: &[Symbol] = &[sym::recursion_limit];
     const ON_DUPLICATE: OnDuplicate = OnDuplicate::WarnButFutureError;
     const TEMPLATE: AttributeTemplate = template!(NameValueStr: "N", "https://doc.rust-lang.org/reference/attributes/limits.html#the-recursion_limit-attribute");
-    const ALLOWED_TARGETS: AllowedTargets =
+    const ALLOWED_TARGETS: AllowedTargets<'_> =
         AllowedTargets::AllowListWarnRest(&[Allow(Target::Crate)]);
     const STABILITY: AttributeStability = AttributeStability::Stable;
 
@@ -92,7 +92,7 @@ pub(crate) struct MoveSizeLimitParser;
 impl SingleAttributeParser for MoveSizeLimitParser {
     const PATH: &[Symbol] = &[sym::move_size_limit];
     const TEMPLATE: AttributeTemplate = template!(NameValueStr: "N");
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
     const STABILITY: AttributeStability = unstable!(large_assignments);
 
     fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
@@ -108,7 +108,7 @@ impl SingleAttributeParser for TypeLengthLimitParser {
     const PATH: &[Symbol] = &[sym::type_length_limit];
     const ON_DUPLICATE: OnDuplicate = OnDuplicate::WarnButFutureError;
     const TEMPLATE: AttributeTemplate = template!(NameValueStr: "N");
-    const ALLOWED_TARGETS: AllowedTargets =
+    const ALLOWED_TARGETS: AllowedTargets<'_> =
         AllowedTargets::AllowListWarnRest(&[Allow(Target::Crate)]);
     const STABILITY: AttributeStability = AttributeStability::Stable;
 
@@ -124,7 +124,7 @@ pub(crate) struct PatternComplexityLimitParser;
 impl SingleAttributeParser for PatternComplexityLimitParser {
     const PATH: &[Symbol] = &[sym::pattern_complexity_limit];
     const TEMPLATE: AttributeTemplate = template!(NameValueStr: "N");
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
     const STABILITY: AttributeStability = unstable!(
         rustc_attrs,
         "the `#[pattern_complexity_limit]` attribute is used for rustc unit tests"
@@ -141,7 +141,7 @@ pub(crate) struct NoCoreParser;
 
 impl NoArgsAttributeParser for NoCoreParser {
     const PATH: &[Symbol] = &[sym::no_core];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
     const STABILITY: AttributeStability = unstable!(no_core);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::NoCore;
 }
@@ -151,7 +151,7 @@ pub(crate) struct NoStdParser;
 impl NoArgsAttributeParser for NoStdParser {
     const PATH: &[Symbol] = &[sym::no_std];
     const ON_DUPLICATE: OnDuplicate = OnDuplicate::Warn;
-    const ALLOWED_TARGETS: AllowedTargets =
+    const ALLOWED_TARGETS: AllowedTargets<'_> =
         AllowedTargets::AllowListWarnRest(&[Allow(Target::Crate)]);
     const STABILITY: AttributeStability = AttributeStability::Stable;
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::NoStd;
@@ -162,7 +162,7 @@ pub(crate) struct NoMainParser;
 impl NoArgsAttributeParser for NoMainParser {
     const PATH: &[Symbol] = &[sym::no_main];
     const ON_DUPLICATE: OnDuplicate = OnDuplicate::Warn;
-    const ALLOWED_TARGETS: AllowedTargets =
+    const ALLOWED_TARGETS: AllowedTargets<'_> =
         AllowedTargets::AllowListWarnRest(&[Allow(Target::Crate)]);
     const STABILITY: AttributeStability = AttributeStability::Stable;
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::NoMain;
@@ -172,7 +172,7 @@ pub(crate) struct RustcCoherenceIsCoreParser;
 
 impl NoArgsAttributeParser for RustcCoherenceIsCoreParser {
     const PATH: &[Symbol] = &[sym::rustc_coherence_is_core];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
     const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcCoherenceIsCore;
 }
@@ -182,7 +182,7 @@ pub(crate) struct WindowsSubsystemParser;
 impl SingleAttributeParser for WindowsSubsystemParser {
     const PATH: &[Symbol] = &[sym::windows_subsystem];
     const ON_DUPLICATE: OnDuplicate = OnDuplicate::WarnButFutureError;
-    const ALLOWED_TARGETS: AllowedTargets =
+    const ALLOWED_TARGETS: AllowedTargets<'_> =
         AllowedTargets::AllowListWarnRest(&[Allow(Target::Crate)]);
     const TEMPLATE: AttributeTemplate = template!(NameValueStr: ["windows", "console"], "https://doc.rust-lang.org/reference/runtime.html#the-windows_subsystem-attribute");
     const STABILITY: AttributeStability = AttributeStability::Stable;
@@ -210,7 +210,7 @@ pub(crate) struct PanicRuntimeParser;
 
 impl NoArgsAttributeParser for PanicRuntimeParser {
     const PATH: &[Symbol] = &[sym::panic_runtime];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
     const STABILITY: AttributeStability = unstable!(panic_runtime);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::PanicRuntime;
 }
@@ -219,7 +219,7 @@ pub(crate) struct NeedsPanicRuntimeParser;
 
 impl NoArgsAttributeParser for NeedsPanicRuntimeParser {
     const PATH: &[Symbol] = &[sym::needs_panic_runtime];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
     const STABILITY: AttributeStability = unstable!(needs_panic_runtime);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::NeedsPanicRuntime;
 }
@@ -228,7 +228,7 @@ pub(crate) struct ProfilerRuntimeParser;
 
 impl NoArgsAttributeParser for ProfilerRuntimeParser {
     const PATH: &[Symbol] = &[sym::profiler_runtime];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
     const STABILITY: AttributeStability = unstable!(profiler_runtime);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::ProfilerRuntime;
 }
@@ -238,7 +238,7 @@ pub(crate) struct NoBuiltinsParser;
 impl NoArgsAttributeParser for NoBuiltinsParser {
     const PATH: &[Symbol] = &[sym::no_builtins];
     const ON_DUPLICATE: OnDuplicate = OnDuplicate::Warn;
-    const ALLOWED_TARGETS: AllowedTargets =
+    const ALLOWED_TARGETS: AllowedTargets<'_> =
         AllowedTargets::AllowListWarnRest(&[Allow(Target::Crate)]);
     const STABILITY: AttributeStability = AttributeStability::Stable;
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::NoBuiltins;
@@ -248,7 +248,7 @@ pub(crate) struct RustcPreserveUbChecksParser;
 
 impl NoArgsAttributeParser for RustcPreserveUbChecksParser {
     const PATH: &[Symbol] = &[sym::rustc_preserve_ub_checks];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
     const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcPreserveUbChecks;
 }
@@ -257,7 +257,7 @@ pub(crate) struct RustcNoImplicitBoundsParser;
 
 impl NoArgsAttributeParser for RustcNoImplicitBoundsParser {
     const PATH: &[Symbol] = &[sym::rustc_no_implicit_bounds];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
     const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcNoImplicitBounds;
 }
@@ -266,7 +266,7 @@ pub(crate) struct DefaultLibAllocatorParser;
 
 impl NoArgsAttributeParser for DefaultLibAllocatorParser {
     const PATH: &[Symbol] = &[sym::default_lib_allocator];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
     const STABILITY: AttributeStability = unstable!(allocator_internals);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::DefaultLibAllocator;
 }
@@ -277,7 +277,7 @@ impl CombineAttributeParser for FeatureParser {
     const PATH: &[Symbol] = &[sym::feature];
     type Item = Ident;
     const CONVERT: ConvertFn<Self::Item> = AttributeKind::Feature;
-    const ALLOWED_TARGETS: AllowedTargets =
+    const ALLOWED_TARGETS: AllowedTargets<'_> =
         AllowedTargets::AllowListWarnRest(&[Allow(Target::Crate)]);
     const TEMPLATE: AttributeTemplate = template!(List: &["feature1, feature2, ..."]);
     const STABILITY: AttributeStability = AttributeStability::Stable;
@@ -323,7 +323,7 @@ impl CombineAttributeParser for RegisterToolParser {
     const PATH: &[Symbol] = &[sym::register_tool];
     type Item = Ident;
     const CONVERT: ConvertFn<Self::Item> = |tools, _span| AttributeKind::RegisterTool(tools);
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
     const TEMPLATE: AttributeTemplate = template!(List: &["tool1, tool2, ..."]);
     const STABILITY: AttributeStability = unstable!(register_tool);
 

--- a/compiler/rustc_attr_parsing/src/attributes/debugger.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/debugger.rs
@@ -7,7 +7,7 @@ pub(crate) struct DebuggerVisualizerParser;
 
 impl CombineAttributeParser for DebuggerVisualizerParser {
     const PATH: &[Symbol] = &[sym::debugger_visualizer];
-    const ALLOWED_TARGETS: AllowedTargets =
+    const ALLOWED_TARGETS: AllowedTargets<'_> =
         AllowedTargets::AllowList(&[Allow(Target::Mod), Allow(Target::Crate)]);
     const TEMPLATE: AttributeTemplate = template!(
         List: &[r#"natvis_file = "...", gdb_script_file = "...""#],

--- a/compiler/rustc_attr_parsing/src/attributes/deprecation.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/deprecation.rs
@@ -32,7 +32,7 @@ fn get(
 pub(crate) struct DeprecatedParser;
 impl SingleAttributeParser for DeprecatedParser {
     const PATH: &[Symbol] = &[sym::deprecated];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowListWarnRest(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowListWarnRest(&[
         Allow(Target::Fn),
         Allow(Target::Mod),
         Allow(Target::Struct),

--- a/compiler/rustc_attr_parsing/src/attributes/diagnostic/do_not_recommend.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/diagnostic/do_not_recommend.rs
@@ -16,7 +16,7 @@ impl SingleAttributeParser for DoNotRecommendParser {
     const PATH: &[Symbol] = &[sym::diagnostic, sym::do_not_recommend];
     const ON_DUPLICATE: OnDuplicate = OnDuplicate::Warn;
     // "Allowed" on any target, noop on all but trait impls
-    const ALLOWED_TARGETS: AllowedTargets =
+    const ALLOWED_TARGETS: AllowedTargets<'_> =
         AllowedTargets::AllowListWarnRest(&[Allow(Target::Impl { of_trait: true })]);
     const TEMPLATE: AttributeTemplate = template!(Word /*doesn't matter */);
     const STABILITY: AttributeStability = AttributeStability::Stable;

--- a/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_const.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_const.rs
@@ -37,7 +37,7 @@ impl AttributeParser for OnConstParser {
 
     // "Allowed" on all targets; noop on anything but non-const trait impls;
     // this linted on in parser.
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowListWarnRest(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowListWarnRest(&[
         // FIXME(mejrs) no constness field on `Target`,
         // so non-constness is still checked in check_attr.rs
         Allow(Target::Impl { of_trait: true }),

--- a/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_move.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_move.rs
@@ -43,7 +43,7 @@ impl AttributeParser for OnMoveParser {
         },
     )];
 
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowListWarnRest(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowListWarnRest(&[
         Allow(Target::Enum),
         Allow(Target::Struct),
         Allow(Target::Union),

--- a/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_type_error.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_type_error.rs
@@ -42,7 +42,7 @@ impl AttributeParser for OnTypeErrorParser {
         },
     )];
 
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowListWarnRest(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowListWarnRest(&[
         Allow(Target::Enum),
         Allow(Target::Struct),
         Allow(Target::Union),

--- a/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_unimplemented.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_unimplemented.rs
@@ -45,7 +45,7 @@ impl AttributeParser for OnUnimplementedParser {
             },
         ),
     ];
-    const ALLOWED_TARGETS: AllowedTargets =
+    const ALLOWED_TARGETS: AllowedTargets<'_> =
         AllowedTargets::AllowListWarnRest(&[Allow(Target::Trait)]);
 
     fn finalize(self, _cx: &FinalizeContext<'_, '_>) -> Option<AttributeKind> {

--- a/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_unknown.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_unknown.rs
@@ -40,7 +40,7 @@ impl AttributeParser for OnUnknownParser {
         },
     )];
     // "Allowed" for all targets, but noop for all but use statements.
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowListWarnRest(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowListWarnRest(&[
         Allow(Target::Use),
         Allow(Target::Mod),
         Allow(Target::Crate),

--- a/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_unmatched_args.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_unmatched_args.rs
@@ -33,7 +33,7 @@ impl AttributeParser for OnUnmatchedArgsParser {
         },
     )];
 
-    const ALLOWED_TARGETS: AllowedTargets =
+    const ALLOWED_TARGETS: AllowedTargets<'_> =
         AllowedTargets::AllowListWarnRest(&[Allow(Target::MacroDef)]);
 
     fn finalize(self, _cx: &FinalizeContext<'_, '_>) -> Option<AttributeKind> {

--- a/compiler/rustc_attr_parsing/src/attributes/doc.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/doc.rs
@@ -706,8 +706,8 @@ impl AttributeParser for DocParser {
         },
     )];
     // FIXME: Currently emitted from 2 different places, generating duplicated warnings.
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(ALL_TARGETS);
-    // const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowListWarnRest(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(ALL_TARGETS);
+    // const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowListWarnRest(&[
     //     Allow(Target::ExternCrate),
     //     Allow(Target::Use),
     //     Allow(Target::Static),

--- a/compiler/rustc_attr_parsing/src/attributes/dummy.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/dummy.rs
@@ -12,7 +12,7 @@ pub(crate) struct RustcDummyParser;
 impl SingleAttributeParser for RustcDummyParser {
     const PATH: &[Symbol] = &[sym::rustc_dummy];
     const ON_DUPLICATE: OnDuplicate = OnDuplicate::Ignore;
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::ManuallyChecked;
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::ManuallyChecked;
     const TEMPLATE: AttributeTemplate = template!(Word); // Anything, really
     const STABILITY: AttributeStability =
         unstable!(rustc_attrs, "the `#[rustc_dummy]` attribute is used for rustc unit tests");

--- a/compiler/rustc_attr_parsing/src/attributes/inline.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/inline.rs
@@ -13,7 +13,7 @@ pub(crate) struct InlineParser;
 impl SingleAttributeParser for InlineParser {
     const PATH: &[Symbol] = &[sym::inline];
     const ON_DUPLICATE: OnDuplicate = OnDuplicate::WarnButFutureError;
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[
         Allow(Target::Fn),
         Allow(Target::Method(MethodKind::Inherent)),
         Allow(Target::Method(MethodKind::Trait { body: true })),
@@ -66,7 +66,7 @@ pub(crate) struct RustcForceInlineParser;
 
 impl SingleAttributeParser for RustcForceInlineParser {
     const PATH: &[Symbol] = &[sym::rustc_force_inline];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[
         Allow(Target::Fn),
         Allow(Target::Method(MethodKind::Inherent)),
     ]);

--- a/compiler/rustc_attr_parsing/src/attributes/instruction_set.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/instruction_set.rs
@@ -8,7 +8,7 @@ pub(crate) struct InstructionSetParser;
 
 impl SingleAttributeParser for InstructionSetParser {
     const PATH: &[Symbol] = &[sym::instruction_set];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowListWarnRest(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowListWarnRest(&[
         Allow(Target::Fn),
         Allow(Target::Closure),
         Allow(Target::Method(MethodKind::Inherent)),

--- a/compiler/rustc_attr_parsing/src/attributes/link_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/link_attrs.rs
@@ -26,7 +26,7 @@ pub(crate) struct LinkNameParser;
 impl SingleAttributeParser for LinkNameParser {
     const PATH: &[Symbol] = &[sym::link_name];
     const ON_DUPLICATE: OnDuplicate = OnDuplicate::WarnButFutureError;
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowListWarnRest(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowListWarnRest(&[
         Allow(Target::ForeignFn),
         Allow(Target::ForeignStatic),
     ]);
@@ -70,7 +70,7 @@ impl CombineAttributeParser for LinkParser {
             r#"name = "...", import_name_type = "decorated|noprefix|undecorated""#,
             r#"name = "...", kind = "dylib|static|...", wasm_import_module = "...", import_name_type = "decorated|noprefix|undecorated""#,
         ], "https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute");
-    const ALLOWED_TARGETS: AllowedTargets =
+    const ALLOWED_TARGETS: AllowedTargets<'_> =
         AllowedTargets::AllowListWarnRest(&[Allow(Target::ForeignMod)]);
     const STABILITY: AttributeStability = AttributeStability::Stable;
 
@@ -494,7 +494,7 @@ impl SingleAttributeParser for LinkSectionParser {
         unsafe_since: Some(Edition2024),
     };
     const STABILITY: AttributeStability = AttributeStability::Stable;
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowListWarnRest(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowListWarnRest(&[
         Allow(Target::Static),
         Allow(Target::Fn),
         Allow(Target::Method(MethodKind::Inherent)),
@@ -535,7 +535,7 @@ impl SingleAttributeParser for LinkSectionParser {
 pub(crate) struct ExportStableParser;
 impl NoArgsAttributeParser for ExportStableParser {
     const PATH: &[Symbol] = &[sym::export_stable];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[
         Allow(Target::Fn),
         Allow(Target::Method(MethodKind::Inherent)),
         Allow(Target::Struct),
@@ -558,7 +558,8 @@ impl NoArgsAttributeParser for FfiConstParser {
         note: "`#[ffi_const]` functions shall have no effects except for its return value, which can only depend on the values of the function parameters, and is not affected by changes to the observable state of the program.",
         unsafe_since: None,
     };
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::ForeignFn)]);
+    const ALLOWED_TARGETS: AllowedTargets<'_> =
+        AllowedTargets::AllowList(&[Allow(Target::ForeignFn)]);
     const STABILITY: AttributeStability = unstable!(ffi_const);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::FfiConst;
 }
@@ -570,7 +571,8 @@ impl NoArgsAttributeParser for FfiPureParser {
         note: "`#[ffi_pure]` functions shall have no effects except for its return value, which shall not change across two consecutive function calls with the same parameters.",
         unsafe_since: None,
     };
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::ForeignFn)]);
+    const ALLOWED_TARGETS: AllowedTargets<'_> =
+        AllowedTargets::AllowList(&[Allow(Target::ForeignFn)]);
     const STABILITY: AttributeStability = unstable!(ffi_pure);
     const CREATE: fn(Span) -> AttributeKind = AttributeKind::FfiPure;
 }
@@ -578,7 +580,7 @@ impl NoArgsAttributeParser for FfiPureParser {
 pub(crate) struct RustcStdInternalSymbolParser;
 impl NoArgsAttributeParser for RustcStdInternalSymbolParser {
     const PATH: &[Symbol] = &[sym::rustc_std_internal_symbol];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[
         Allow(Target::Fn),
         Allow(Target::ForeignFn),
         Allow(Target::Static),
@@ -592,7 +594,7 @@ pub(crate) struct LinkOrdinalParser;
 
 impl SingleAttributeParser for LinkOrdinalParser {
     const PATH: &[Symbol] = &[sym::link_ordinal];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[
         Allow(Target::ForeignFn),
         Allow(Target::ForeignStatic),
         Warn(Target::MacroCall),
@@ -632,7 +634,7 @@ pub(crate) struct LinkageParser;
 
 impl SingleAttributeParser for LinkageParser {
     const PATH: &[Symbol] = &[sym::linkage];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[
         Allow(Target::Fn),
         Allow(Target::Method(MethodKind::Inherent)),
         Allow(Target::Method(MethodKind::Trait { body: true })),
@@ -708,7 +710,7 @@ pub(crate) struct NeedsAllocatorParser;
 
 impl NoArgsAttributeParser for NeedsAllocatorParser {
     const PATH: &[Symbol] = &[sym::needs_allocator];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
     const STABILITY: AttributeStability = unstable!(allocator_internals);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::NeedsAllocator;
 }
@@ -717,7 +719,7 @@ pub(crate) struct CompilerBuiltinsParser;
 
 impl NoArgsAttributeParser for CompilerBuiltinsParser {
     const PATH: &[Symbol] = &[sym::compiler_builtins];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
     const STABILITY: AttributeStability = unstable!(compiler_builtins);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::CompilerBuiltins;
 }

--- a/compiler/rustc_attr_parsing/src/attributes/lint_helpers.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/lint_helpers.rs
@@ -5,7 +5,7 @@ use super::prelude::*;
 pub(crate) struct RustcAsPtrParser;
 impl NoArgsAttributeParser for RustcAsPtrParser {
     const PATH: &[Symbol] = &[sym::rustc_as_ptr];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[
         Allow(Target::Fn),
         Allow(Target::Method(MethodKind::Inherent)),
         Allow(Target::Method(MethodKind::Trait { body: false })),
@@ -19,7 +19,7 @@ impl NoArgsAttributeParser for RustcAsPtrParser {
 pub(crate) struct RustcPubTransparentParser;
 impl NoArgsAttributeParser for RustcPubTransparentParser {
     const PATH: &[Symbol] = &[sym::rustc_pub_transparent];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[
         Allow(Target::Struct),
         Allow(Target::Enum),
         Allow(Target::Union),
@@ -31,7 +31,7 @@ impl NoArgsAttributeParser for RustcPubTransparentParser {
 pub(crate) struct RustcPassByValueParser;
 impl NoArgsAttributeParser for RustcPassByValueParser {
     const PATH: &[Symbol] = &[sym::rustc_pass_by_value];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[
         Allow(Target::Struct),
         Allow(Target::Enum),
         Allow(Target::TyAlias),
@@ -43,7 +43,7 @@ impl NoArgsAttributeParser for RustcPassByValueParser {
 pub(crate) struct RustcShouldNotBeCalledOnConstItemsParser;
 impl NoArgsAttributeParser for RustcShouldNotBeCalledOnConstItemsParser {
     const PATH: &[Symbol] = &[sym::rustc_should_not_be_called_on_const_items];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[
         Allow(Target::Method(MethodKind::Inherent)),
         Allow(Target::Method(MethodKind::TraitImpl)),
     ]);
@@ -55,7 +55,7 @@ pub(crate) struct AutomaticallyDerivedParser;
 impl NoArgsAttributeParser for AutomaticallyDerivedParser {
     const PATH: &[Symbol] = &[sym::automatically_derived];
     const ON_DUPLICATE: OnDuplicate = OnDuplicate::Warn;
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowListWarnRest(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowListWarnRest(&[
         Allow(Target::Impl { of_trait: true }),
         Error(Target::Crate),
         Error(Target::WherePredicate),

--- a/compiler/rustc_attr_parsing/src/attributes/loop_match.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/loop_match.rs
@@ -5,7 +5,7 @@ use super::prelude::*;
 pub(crate) struct LoopMatchParser;
 impl NoArgsAttributeParser for LoopMatchParser {
     const PATH: &[Symbol] = &[sym::loop_match];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Loop)]);
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[Allow(Target::Loop)]);
     const STABILITY: AttributeStability = unstable!(loop_match);
     const CREATE: fn(Span) -> AttributeKind = AttributeKind::LoopMatch;
 }
@@ -13,7 +13,7 @@ impl NoArgsAttributeParser for LoopMatchParser {
 pub(crate) struct ConstContinueParser;
 impl NoArgsAttributeParser for ConstContinueParser {
     const PATH: &[Symbol] = &[sym::const_continue];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Break)]);
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[Allow(Target::Break)]);
     const STABILITY: AttributeStability = unstable!(loop_match);
     const CREATE: fn(Span) -> AttributeKind = AttributeKind::ConstContinue;
 }

--- a/compiler/rustc_attr_parsing/src/attributes/macro_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/macro_attrs.rs
@@ -8,7 +8,7 @@ pub(crate) struct MacroEscapeParser;
 impl NoArgsAttributeParser for MacroEscapeParser {
     const PATH: &[Symbol] = &[sym::macro_escape];
     const ON_DUPLICATE: OnDuplicate = OnDuplicate::Warn;
-    const ALLOWED_TARGETS: AllowedTargets = MACRO_USE_ALLOWED_TARGETS;
+    const ALLOWED_TARGETS: AllowedTargets<'_> = MACRO_USE_ALLOWED_TARGETS;
     const STABILITY: AttributeStability = AttributeStability::Stable;
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::MacroEscape;
 }
@@ -32,7 +32,7 @@ const MACRO_USE_TEMPLATE: AttributeTemplate = template!(
     Word, List: &["name1, name2, ..."],
     "https://doc.rust-lang.org/reference/macros-by-example.html#the-macro_use-attribute"
 );
-const MACRO_USE_ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowListWarnRest(&[
+const MACRO_USE_ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowListWarnRest(&[
     Allow(Target::Mod),
     Allow(Target::ExternCrate),
     Error(Target::WherePredicate),
@@ -106,7 +106,7 @@ impl AttributeParser for MacroUseParser {
             }
         },
     )];
-    const ALLOWED_TARGETS: AllowedTargets = MACRO_USE_ALLOWED_TARGETS;
+    const ALLOWED_TARGETS: AllowedTargets<'_> = MACRO_USE_ALLOWED_TARGETS;
 
     fn finalize(self, _cx: &FinalizeContext<'_, '_>) -> Option<AttributeKind> {
         Some(AttributeKind::MacroUse { span: self.first_span?, arguments: self.state })
@@ -118,7 +118,7 @@ pub(crate) struct AllowInternalUnsafeParser;
 impl NoArgsAttributeParser for AllowInternalUnsafeParser {
     const PATH: &[Symbol] = &[sym::allow_internal_unsafe];
     const ON_DUPLICATE: OnDuplicate = OnDuplicate::Ignore;
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[
         Allow(Target::Fn),
         Allow(Target::MacroDef),
         Warn(Target::Field),
@@ -134,7 +134,7 @@ impl SingleAttributeParser for MacroExportParser {
     const PATH: &[Symbol] = &[sym::macro_export];
     const ON_DUPLICATE: OnDuplicate = OnDuplicate::Warn;
     const TEMPLATE: AttributeTemplate = template!(Word, List: &["local_inner_macros"]);
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowListWarnRest(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowListWarnRest(&[
         Allow(Target::MacroDef),
         Error(Target::WherePredicate),
         Error(Target::Crate),
@@ -174,7 +174,8 @@ impl SingleAttributeParser for CollapseDebugInfoParser {
         List: &["no", "external", "yes"],
         "https://doc.rust-lang.org/reference/attributes/debugger.html#the-collapse_debuginfo-attribute"
     );
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::MacroDef)]);
+    const ALLOWED_TARGETS: AllowedTargets<'_> =
+        AllowedTargets::AllowList(&[Allow(Target::MacroDef)]);
     const STABILITY: AttributeStability = AttributeStability::Stable;
 
     fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
@@ -204,7 +205,7 @@ pub(crate) struct RustcProcMacroDeclsParser;
 
 impl NoArgsAttributeParser for RustcProcMacroDeclsParser {
     const PATH: &[Symbol] = &[sym::rustc_proc_macro_decls];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Static)]);
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[Allow(Target::Static)]);
     const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcProcMacroDecls;
 }

--- a/compiler/rustc_attr_parsing/src/attributes/mod.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/mod.rs
@@ -105,7 +105,7 @@ pub(crate) trait AttributeParser: Default + 'static {
     ///
     /// If an attribute has this symbol, the `accept` function will be called on it.
     const ATTRIBUTES: AcceptMapping<Self>;
-    const ALLOWED_TARGETS: AllowedTargets;
+    const ALLOWED_TARGETS: AllowedTargets<'_>;
     const SAFETY: AttributeSafety = AttributeSafety::Normal;
 
     /// The parser has gotten a chance to accept the attributes on an item,
@@ -140,7 +140,7 @@ pub(crate) trait SingleAttributeParser: 'static {
     const SAFETY: AttributeSafety = AttributeSafety::Normal;
     const STABILITY: AttributeStability;
 
-    const ALLOWED_TARGETS: AllowedTargets;
+    const ALLOWED_TARGETS: AllowedTargets<'_>;
 
     /// The template this attribute parser should implement. Used for diagnostics.
     const TEMPLATE: AttributeTemplate;
@@ -174,7 +174,7 @@ impl<T: SingleAttributeParser> AttributeParser for Single<T> {
             }
         },
     )];
-    const ALLOWED_TARGETS: AllowedTargets = T::ALLOWED_TARGETS;
+    const ALLOWED_TARGETS: AllowedTargets<'_> = T::ALLOWED_TARGETS;
     const SAFETY: AttributeSafety = T::SAFETY;
 
     fn finalize(self, _cx: &FinalizeContext<'_, '_>) -> Option<AttributeKind> {
@@ -252,7 +252,7 @@ pub enum AttributeSafety {
 pub(crate) trait NoArgsAttributeParser: 'static {
     const PATH: &[Symbol];
     const ON_DUPLICATE: OnDuplicate = OnDuplicate::Error;
-    const ALLOWED_TARGETS: AllowedTargets;
+    const ALLOWED_TARGETS: AllowedTargets<'_>;
     const SAFETY: AttributeSafety = AttributeSafety::Normal;
     const STABILITY: AttributeStability;
 
@@ -273,7 +273,7 @@ impl<T: NoArgsAttributeParser> SingleAttributeParser for WithoutArgs<T> {
     const ON_DUPLICATE: OnDuplicate = T::ON_DUPLICATE;
     const SAFETY: AttributeSafety = T::SAFETY;
     const STABILITY: AttributeStability = T::STABILITY;
-    const ALLOWED_TARGETS: AllowedTargets = T::ALLOWED_TARGETS;
+    const ALLOWED_TARGETS: AllowedTargets<'_> = T::ALLOWED_TARGETS;
     const TEMPLATE: AttributeTemplate = template!(Word);
 
     fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
@@ -303,7 +303,7 @@ pub(crate) trait CombineAttributeParser: 'static {
     const SAFETY: AttributeSafety = AttributeSafety::Normal;
     const STABILITY: AttributeStability;
 
-    const ALLOWED_TARGETS: AllowedTargets;
+    const ALLOWED_TARGETS: AllowedTargets<'_>;
 
     /// The template this attribute parser should implement. Used for diagnostics.
     const TEMPLATE: AttributeTemplate;
@@ -342,7 +342,7 @@ impl<T: CombineAttributeParser> AttributeParser for Combine<T> {
             group.first_span.get_or_insert(cx.attr_span);
             group.items.extend(T::extend(cx, args))
         })];
-    const ALLOWED_TARGETS: AllowedTargets = T::ALLOWED_TARGETS;
+    const ALLOWED_TARGETS: AllowedTargets<'_> = T::ALLOWED_TARGETS;
     const SAFETY: AttributeSafety = T::SAFETY;
 
     fn finalize(self, _cx: &FinalizeContext<'_, '_>) -> Option<AttributeKind> {

--- a/compiler/rustc_attr_parsing/src/attributes/must_not_suspend.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/must_not_suspend.rs
@@ -6,7 +6,7 @@ pub(crate) struct MustNotSuspendParser;
 
 impl SingleAttributeParser for MustNotSuspendParser {
     const PATH: &[rustc_span::Symbol] = &[sym::must_not_suspend];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[
         Allow(Target::Struct),
         Allow(Target::Enum),
         Allow(Target::Union),

--- a/compiler/rustc_attr_parsing/src/attributes/must_use.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/must_use.rs
@@ -7,7 +7,7 @@ pub(crate) struct MustUseParser;
 impl SingleAttributeParser for MustUseParser {
     const PATH: &[Symbol] = &[sym::must_use];
     const ON_DUPLICATE: OnDuplicate = OnDuplicate::WarnButFutureError;
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowListWarnRest(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowListWarnRest(&[
         Allow(Target::Fn),
         Allow(Target::Enum),
         Allow(Target::Struct),

--- a/compiler/rustc_attr_parsing/src/attributes/no_implicit_prelude.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/no_implicit_prelude.rs
@@ -7,7 +7,7 @@ pub(crate) struct NoImplicitPreludeParser;
 impl NoArgsAttributeParser for NoImplicitPreludeParser {
     const PATH: &[rustc_span::Symbol] = &[sym::no_implicit_prelude];
     const ON_DUPLICATE: OnDuplicate = OnDuplicate::Warn;
-    const ALLOWED_TARGETS: AllowedTargets =
+    const ALLOWED_TARGETS: AllowedTargets<'_> =
         AllowedTargets::AllowListWarnRest(&[Allow(Target::Mod), Allow(Target::Crate)]);
     const STABILITY: AttributeStability = AttributeStability::Stable;
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::NoImplicitPrelude;

--- a/compiler/rustc_attr_parsing/src/attributes/no_link.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/no_link.rs
@@ -6,7 +6,7 @@ pub(crate) struct NoLinkParser;
 impl NoArgsAttributeParser for NoLinkParser {
     const PATH: &[Symbol] = &[sym::no_link];
     const ON_DUPLICATE: OnDuplicate = OnDuplicate::Warn;
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[
         Allow(Target::ExternCrate),
         Warn(Target::Field),
         Warn(Target::Arm),

--- a/compiler/rustc_attr_parsing/src/attributes/non_exhaustive.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/non_exhaustive.rs
@@ -12,7 +12,7 @@ pub(crate) struct NonExhaustiveParser;
 impl NoArgsAttributeParser for NonExhaustiveParser {
     const PATH: &[Symbol] = &[sym::non_exhaustive];
     const ON_DUPLICATE: OnDuplicate = OnDuplicate::Warn;
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[
         Allow(Target::Enum),
         Allow(Target::Struct),
         Allow(Target::Variant),

--- a/compiler/rustc_attr_parsing/src/attributes/path.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/path.rs
@@ -7,7 +7,7 @@ pub(crate) struct PathParser;
 impl SingleAttributeParser for PathParser {
     const PATH: &[Symbol] = &[sym::path];
     const ON_DUPLICATE: OnDuplicate = OnDuplicate::WarnButFutureError;
-    const ALLOWED_TARGETS: AllowedTargets =
+    const ALLOWED_TARGETS: AllowedTargets<'_> =
         AllowedTargets::AllowListWarnRest(&[Allow(Target::Mod), Error(Target::Crate)]);
     const TEMPLATE: AttributeTemplate = template!(
         NameValueStr: "file",

--- a/compiler/rustc_attr_parsing/src/attributes/pin_v2.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/pin_v2.rs
@@ -12,7 +12,7 @@ pub(crate) struct PinV2Parser;
 
 impl NoArgsAttributeParser for PinV2Parser {
     const PATH: &[Symbol] = &[sym::pin_v2];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[
         Allow(Target::Enum),
         Allow(Target::Struct),
         Allow(Target::Union),

--- a/compiler/rustc_attr_parsing/src/attributes/proc_macro_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/proc_macro_attrs.rs
@@ -3,13 +3,13 @@ use rustc_session::lint::builtin::AMBIGUOUS_DERIVE_HELPERS;
 
 use super::prelude::*;
 
-const PROC_MACRO_ALLOWED_TARGETS: AllowedTargets =
+const PROC_MACRO_ALLOWED_TARGETS: AllowedTargets<'_> =
     AllowedTargets::AllowList(&[Allow(Target::Fn), Warn(Target::Crate), Warn(Target::MacroCall)]);
 
 pub(crate) struct ProcMacroParser;
 impl NoArgsAttributeParser for ProcMacroParser {
     const PATH: &[Symbol] = &[sym::proc_macro];
-    const ALLOWED_TARGETS: AllowedTargets = PROC_MACRO_ALLOWED_TARGETS;
+    const ALLOWED_TARGETS: AllowedTargets<'_> = PROC_MACRO_ALLOWED_TARGETS;
     const STABILITY: AttributeStability = AttributeStability::Stable;
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::ProcMacro;
 }
@@ -17,7 +17,7 @@ impl NoArgsAttributeParser for ProcMacroParser {
 pub(crate) struct ProcMacroAttributeParser;
 impl NoArgsAttributeParser for ProcMacroAttributeParser {
     const PATH: &[Symbol] = &[sym::proc_macro_attribute];
-    const ALLOWED_TARGETS: AllowedTargets = PROC_MACRO_ALLOWED_TARGETS;
+    const ALLOWED_TARGETS: AllowedTargets<'_> = PROC_MACRO_ALLOWED_TARGETS;
     const STABILITY: AttributeStability = AttributeStability::Stable;
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::ProcMacroAttribute;
 }
@@ -25,7 +25,7 @@ impl NoArgsAttributeParser for ProcMacroAttributeParser {
 pub(crate) struct ProcMacroDeriveParser;
 impl SingleAttributeParser for ProcMacroDeriveParser {
     const PATH: &[Symbol] = &[sym::proc_macro_derive];
-    const ALLOWED_TARGETS: AllowedTargets = PROC_MACRO_ALLOWED_TARGETS;
+    const ALLOWED_TARGETS: AllowedTargets<'_> = PROC_MACRO_ALLOWED_TARGETS;
     const TEMPLATE: AttributeTemplate = template!(
         List: &["TraitName", "TraitName, attributes(name1, name2, ...)"],
         "https://doc.rust-lang.org/reference/procedural-macros.html#derive-macros"
@@ -44,7 +44,8 @@ impl SingleAttributeParser for ProcMacroDeriveParser {
 pub(crate) struct RustcBuiltinMacroParser;
 impl SingleAttributeParser for RustcBuiltinMacroParser {
     const PATH: &[Symbol] = &[sym::rustc_builtin_macro];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::MacroDef)]);
+    const ALLOWED_TARGETS: AllowedTargets<'_> =
+        AllowedTargets::AllowList(&[Allow(Target::MacroDef)]);
     const TEMPLATE: AttributeTemplate =
         template!(List: &["TraitName", "TraitName, attributes(name1, name2, ...)"]);
     const STABILITY: AttributeStability = unstable!(rustc_attrs);

--- a/compiler/rustc_attr_parsing/src/attributes/prototype.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/prototype.rs
@@ -18,7 +18,7 @@ impl SingleAttributeParser for CustomMirParser {
     const PATH: &[rustc_span::Symbol] = &[sym::custom_mir];
     const STABILITY: AttributeStability = unstable!(custom_mir);
 
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Fn)]);
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[Allow(Target::Fn)]);
 
     const TEMPLATE: AttributeTemplate = template!(List: &[r#"dialect = "...", phase = "...""#]);
 

--- a/compiler/rustc_attr_parsing/src/attributes/repr.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/repr.rs
@@ -63,7 +63,7 @@ impl CombineAttributeParser for ReprParser {
         reprs
     }
 
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::ManuallyChecked;
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::ManuallyChecked;
     const STABILITY: AttributeStability = AttributeStability::Stable;
 }
 
@@ -306,7 +306,7 @@ impl RustcAlignParser {
 impl AttributeParser for RustcAlignParser {
     const ATTRIBUTES: AcceptMapping<Self> =
         &[(Self::PATH, Self::TEMPLATE, unstable!(fn_align), Self::parse)];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[
         Allow(Target::Fn),
         Allow(Target::Method(MethodKind::Inherent)),
         Allow(Target::Method(MethodKind::Trait { body: true })),
@@ -336,7 +336,7 @@ impl RustcAlignStaticParser {
 impl AttributeParser for RustcAlignStaticParser {
     const ATTRIBUTES: AcceptMapping<Self> =
         &[(Self::PATH, Self::TEMPLATE, unstable!(static_align), Self::parse)];
-    const ALLOWED_TARGETS: AllowedTargets =
+    const ALLOWED_TARGETS: AllowedTargets<'_> =
         AllowedTargets::AllowList(&[Allow(Target::Static), Allow(Target::ForeignStatic)]);
 
     fn finalize(self, _cx: &FinalizeContext<'_, '_>) -> Option<AttributeKind> {

--- a/compiler/rustc_attr_parsing/src/attributes/rustc_allocator.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/rustc_allocator.rs
@@ -6,7 +6,7 @@ pub(crate) struct RustcAllocatorParser;
 
 impl NoArgsAttributeParser for RustcAllocatorParser {
     const PATH: &[Symbol] = &[sym::rustc_allocator];
-    const ALLOWED_TARGETS: AllowedTargets =
+    const ALLOWED_TARGETS: AllowedTargets<'_> =
         AllowedTargets::AllowList(&[Allow(Target::Fn), Allow(Target::ForeignFn)]);
     const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcAllocator;
@@ -16,7 +16,7 @@ pub(crate) struct RustcAllocatorZeroedParser;
 
 impl NoArgsAttributeParser for RustcAllocatorZeroedParser {
     const PATH: &[Symbol] = &[sym::rustc_allocator_zeroed];
-    const ALLOWED_TARGETS: AllowedTargets =
+    const ALLOWED_TARGETS: AllowedTargets<'_> =
         AllowedTargets::AllowList(&[Allow(Target::Fn), Allow(Target::ForeignFn)]);
     const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcAllocatorZeroed;
@@ -26,7 +26,7 @@ pub(crate) struct RustcAllocatorZeroedVariantParser;
 
 impl SingleAttributeParser for RustcAllocatorZeroedVariantParser {
     const PATH: &[Symbol] = &[sym::rustc_allocator_zeroed_variant];
-    const ALLOWED_TARGETS: AllowedTargets =
+    const ALLOWED_TARGETS: AllowedTargets<'_> =
         AllowedTargets::AllowList(&[Allow(Target::Fn), Allow(Target::ForeignFn)]);
     const TEMPLATE: AttributeTemplate = template!(NameValueStr: "function");
     const STABILITY: AttributeStability = unstable!(rustc_attrs);
@@ -42,7 +42,7 @@ pub(crate) struct RustcDeallocatorParser;
 
 impl NoArgsAttributeParser for RustcDeallocatorParser {
     const PATH: &[Symbol] = &[sym::rustc_deallocator];
-    const ALLOWED_TARGETS: AllowedTargets =
+    const ALLOWED_TARGETS: AllowedTargets<'_> =
         AllowedTargets::AllowList(&[Allow(Target::Fn), Allow(Target::ForeignFn)]);
     const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcDeallocator;
@@ -52,7 +52,7 @@ pub(crate) struct RustcReallocatorParser;
 
 impl NoArgsAttributeParser for RustcReallocatorParser {
     const PATH: &[Symbol] = &[sym::rustc_reallocator];
-    const ALLOWED_TARGETS: AllowedTargets =
+    const ALLOWED_TARGETS: AllowedTargets<'_> =
         AllowedTargets::AllowList(&[Allow(Target::Fn), Allow(Target::ForeignFn)]);
     const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcReallocator;

--- a/compiler/rustc_attr_parsing/src/attributes/rustc_dump.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/rustc_dump.rs
@@ -10,7 +10,7 @@ pub(crate) struct RustcDumpUserArgsParser;
 
 impl NoArgsAttributeParser for RustcDumpUserArgsParser {
     const PATH: &[Symbol] = &[sym::rustc_dump_user_args];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Fn)]);
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[Allow(Target::Fn)]);
     const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcDumpUserArgs;
 }
@@ -19,7 +19,7 @@ pub(crate) struct RustcDumpDefParentsParser;
 
 impl NoArgsAttributeParser for RustcDumpDefParentsParser {
     const PATH: &[Symbol] = &[sym::rustc_dump_def_parents];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Fn)]);
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[Allow(Target::Fn)]);
     const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcDumpDefParents;
 }
@@ -28,7 +28,7 @@ pub(crate) struct RustcDumpDefPathParser;
 
 impl SingleAttributeParser for RustcDumpDefPathParser {
     const PATH: &[Symbol] = &[sym::rustc_dump_def_path];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[
         Allow(Target::Fn),
         Allow(Target::Method(MethodKind::TraitImpl)),
         Allow(Target::Method(MethodKind::Inherent)),
@@ -49,7 +49,7 @@ pub(crate) struct RustcDumpGenericsParser;
 
 impl NoArgsAttributeParser for RustcDumpGenericsParser {
     const PATH: &[Symbol] = &[sym::rustc_dump_generics];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[
         Allow(Target::Struct),
         Allow(Target::Enum),
         Allow(Target::Union),
@@ -78,7 +78,7 @@ pub(crate) struct RustcDumpHiddenTypeOfOpaquesParser;
 
 impl NoArgsAttributeParser for RustcDumpHiddenTypeOfOpaquesParser {
     const PATH: &[Symbol] = &[sym::rustc_dump_hidden_type_of_opaques];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
     const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcDumpHiddenTypeOfOpaques;
 }
@@ -87,7 +87,7 @@ pub(crate) struct RustcDumpInferredOutlivesParser;
 
 impl NoArgsAttributeParser for RustcDumpInferredOutlivesParser {
     const PATH: &[Symbol] = &[sym::rustc_dump_inferred_outlives];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[
         Allow(Target::Struct),
         Allow(Target::Enum),
         Allow(Target::Union),
@@ -101,7 +101,8 @@ pub(crate) struct RustcDumpItemBoundsParser;
 
 impl NoArgsAttributeParser for RustcDumpItemBoundsParser {
     const PATH: &[Symbol] = &[sym::rustc_dump_item_bounds];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::AssocTy)]);
+    const ALLOWED_TARGETS: AllowedTargets<'_> =
+        AllowedTargets::AllowList(&[Allow(Target::AssocTy)]);
     const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcDumpItemBounds;
 }
@@ -115,7 +116,7 @@ impl CombineAttributeParser for RustcDumpLayoutParser {
 
     const CONVERT: ConvertFn<Self::Item> = |items, _| AttributeKind::RustcDumpLayout(items);
 
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[
         Allow(Target::Struct),
         Allow(Target::Enum),
         Allow(Target::Union),
@@ -174,7 +175,7 @@ pub(crate) struct RustcDumpObjectLifetimeDefaultsParser;
 
 impl NoArgsAttributeParser for RustcDumpObjectLifetimeDefaultsParser {
     const PATH: &[Symbol] = &[sym::rustc_dump_object_lifetime_defaults];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[
         Allow(Target::AssocConst),
         Allow(Target::AssocTy),
         Allow(Target::Const),
@@ -201,7 +202,7 @@ pub(crate) struct RustcDumpPredicatesParser;
 
 impl NoArgsAttributeParser for RustcDumpPredicatesParser {
     const PATH: &[Symbol] = &[sym::rustc_dump_predicates];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[
         Allow(Target::AssocConst),
         Allow(Target::AssocTy),
         Allow(Target::Const),
@@ -229,7 +230,7 @@ pub(crate) struct RustcDumpSymbolNameParser;
 
 impl SingleAttributeParser for RustcDumpSymbolNameParser {
     const PATH: &[Symbol] = &[sym::rustc_dump_symbol_name];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[
         Allow(Target::Fn),
         Allow(Target::Method(MethodKind::TraitImpl)),
         Allow(Target::Method(MethodKind::Inherent)),
@@ -250,7 +251,7 @@ pub(crate) struct RustcDumpVariancesParser;
 
 impl NoArgsAttributeParser for RustcDumpVariancesParser {
     const PATH: &[Symbol] = &[sym::rustc_dump_variances];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[
         Allow(Target::Enum),
         Allow(Target::Fn),
         Allow(Target::Method(MethodKind::Inherent)),
@@ -271,7 +272,7 @@ pub(crate) struct RustcDumpVariancesOfOpaquesParser;
 
 impl NoArgsAttributeParser for RustcDumpVariancesOfOpaquesParser {
     const PATH: &[Symbol] = &[sym::rustc_dump_variances_of_opaques];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
     const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcDumpVariancesOfOpaques;
 }
@@ -280,7 +281,7 @@ pub(crate) struct RustcDumpVtableParser;
 
 impl NoArgsAttributeParser for RustcDumpVtableParser {
     const PATH: &[Symbol] = &[sym::rustc_dump_vtable];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[
         Allow(Target::Impl { of_trait: true }),
         Allow(Target::TyAlias),
     ]);

--- a/compiler/rustc_attr_parsing/src/attributes/rustc_internal.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/rustc_internal.rs
@@ -12,6 +12,7 @@ use rustc_span::Symbol;
 use super::prelude::*;
 use super::util::parse_single_integer;
 use crate::diagnostics;
+use crate::diagnostics::{LangItemOnIncorrectTarget, UnknownExternLangItem};
 use crate::session_diagnostics::{
     AttributeRequiresOpt, CguFieldsMissing, RustcScalableVectorCountOutOfRange, UnknownLangItem,
 };
@@ -576,6 +577,28 @@ impl SingleAttributeParser for LangParser {
             cx.emit_err(UnknownLangItem { span: cx.attr_span, name });
             return None;
         };
+
+        // Only weak lang items may be applied to foreign items
+        if [Target::ForeignFn, Target::ForeignStatic, Target::ForeignTy, Target::ForeignMod]
+            .contains(&cx.target)
+            && !lang_item.is_weak()
+        {
+            cx.emit_err(UnknownExternLangItem { span: cx.attr_span, lang_item: lang_item.name() });
+            return None;
+        }
+
+        // Check the target
+        if cx.target != lang_item.target()
+            && !(cx.target == Target::ForeignFn && lang_item == LangItem::PanicImpl)
+        {
+            cx.emit_err(LangItemOnIncorrectTarget {
+                span: cx.attr_span,
+                name,
+                expected_target: lang_item.target(),
+                actual_target: cx.target,
+            });
+            return None;
+        }
         Some(AttributeKind::Lang(lang_item))
     }
 }
@@ -599,7 +622,7 @@ pub(crate) struct PanicHandlerParser;
 
 impl NoArgsAttributeParser for PanicHandlerParser {
     const PATH: &[Symbol] = &[sym::panic_handler];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(ALL_TARGETS); // Targets are checked per lang item in `rustc_passes`
+    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Fn)]);
     const STABILITY: AttributeStability = AttributeStability::Stable;
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::Lang(LangItem::PanicImpl);
 }

--- a/compiler/rustc_attr_parsing/src/attributes/rustc_internal.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/rustc_internal.rs
@@ -21,7 +21,7 @@ pub(crate) struct RustcMainParser;
 
 impl NoArgsAttributeParser for RustcMainParser {
     const PATH: &[Symbol] = &[sym::rustc_main];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Fn)]);
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[Allow(Target::Fn)]);
     const STABILITY: AttributeStability = unstable!(
         rustc_attrs,
         "the `#[rustc_main]` attribute is used internally to specify test entry point function"
@@ -33,7 +33,7 @@ pub(crate) struct RustcMustImplementOneOfParser;
 
 impl SingleAttributeParser for RustcMustImplementOneOfParser {
     const PATH: &[Symbol] = &[sym::rustc_must_implement_one_of];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Trait)]);
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[Allow(Target::Trait)]);
     const STABILITY: AttributeStability = unstable!(
         rustc_attrs,
         "the `#[rustc_must_implement_one_of]` attribute is used to change minimal complete definition of a trait. Its syntax and semantics are highly experimental and will be subject to change before stabilization"
@@ -79,7 +79,7 @@ pub(crate) struct RustcNeverReturnsNullPtrParser;
 
 impl NoArgsAttributeParser for RustcNeverReturnsNullPtrParser {
     const PATH: &[Symbol] = &[sym::rustc_never_returns_null_ptr];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[
         Allow(Target::Fn),
         Allow(Target::Method(MethodKind::Inherent)),
         Allow(Target::Method(MethodKind::Trait { body: false })),
@@ -94,7 +94,7 @@ pub(crate) struct RustcNoImplicitAutorefsParser;
 
 impl NoArgsAttributeParser for RustcNoImplicitAutorefsParser {
     const PATH: &[Symbol] = &[sym::rustc_no_implicit_autorefs];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[
         Allow(Target::Fn),
         Allow(Target::Method(MethodKind::Inherent)),
         Allow(Target::Method(MethodKind::Trait { body: false })),
@@ -110,7 +110,7 @@ pub(crate) struct RustcLegacyConstGenericsParser;
 
 impl SingleAttributeParser for RustcLegacyConstGenericsParser {
     const PATH: &[Symbol] = &[sym::rustc_legacy_const_generics];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Fn)]);
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[Allow(Target::Fn)]);
     const TEMPLATE: AttributeTemplate = template!(List: &["N"]);
     const STABILITY: AttributeStability = unstable!(rustc_attrs);
 
@@ -150,7 +150,7 @@ pub(crate) struct RustcInheritOverflowChecksParser;
 
 impl NoArgsAttributeParser for RustcInheritOverflowChecksParser {
     const PATH: &[Symbol] = &[sym::rustc_inherit_overflow_checks];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[
         Allow(Target::Fn),
         Allow(Target::Method(MethodKind::Inherent)),
         Allow(Target::Method(MethodKind::TraitImpl)),
@@ -164,7 +164,7 @@ pub(crate) struct RustcLintOptDenyFieldAccessParser;
 
 impl SingleAttributeParser for RustcLintOptDenyFieldAccessParser {
     const PATH: &[Symbol] = &[sym::rustc_lint_opt_deny_field_access];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Field)]);
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[Allow(Target::Field)]);
     const TEMPLATE: AttributeTemplate = template!(Word);
     const STABILITY: AttributeStability = unstable!(rustc_attrs);
     fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
@@ -179,7 +179,7 @@ pub(crate) struct RustcLintOptTyParser;
 
 impl NoArgsAttributeParser for RustcLintOptTyParser {
     const PATH: &[Symbol] = &[sym::rustc_lint_opt_ty];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Struct)]);
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[Allow(Target::Struct)]);
     const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcLintOptTy;
 }
@@ -306,7 +306,7 @@ impl AttributeParser for RustcCguTestAttributeParser {
         ),
     ];
 
-    const ALLOWED_TARGETS: AllowedTargets =
+    const ALLOWED_TARGETS: AllowedTargets<'_> =
         AllowedTargets::AllowList(&[Allow(Target::Mod), Allow(Target::Crate)]);
 
     fn finalize(self, _cx: &FinalizeContext<'_, '_>) -> Option<AttributeKind> {
@@ -318,7 +318,7 @@ pub(crate) struct RustcDeprecatedSafe2024Parser;
 
 impl SingleAttributeParser for RustcDeprecatedSafe2024Parser {
     const PATH: &[Symbol] = &[sym::rustc_deprecated_safe_2024];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[
         Allow(Target::Fn),
         Allow(Target::Method(MethodKind::Inherent)),
         Allow(Target::Method(MethodKind::Trait { body: false })),
@@ -348,7 +348,7 @@ pub(crate) struct RustcConversionSuggestionParser;
 
 impl NoArgsAttributeParser for RustcConversionSuggestionParser {
     const PATH: &[Symbol] = &[sym::rustc_conversion_suggestion];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[
         Allow(Target::Fn),
         Allow(Target::Method(MethodKind::Inherent)),
         Allow(Target::Method(MethodKind::Trait { body: false })),
@@ -363,7 +363,8 @@ pub(crate) struct RustcCaptureAnalysisParser;
 
 impl NoArgsAttributeParser for RustcCaptureAnalysisParser {
     const PATH: &[Symbol] = &[sym::rustc_capture_analysis];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Closure)]);
+    const ALLOWED_TARGETS: AllowedTargets<'_> =
+        AllowedTargets::AllowList(&[Allow(Target::Closure)]);
     const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcCaptureAnalysis;
 }
@@ -372,7 +373,7 @@ pub(crate) struct RustcNeverTypeOptionsParser;
 
 impl SingleAttributeParser for RustcNeverTypeOptionsParser {
     const PATH: &[Symbol] = &[sym::rustc_never_type_options];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
     const TEMPLATE: AttributeTemplate = template!(List: &[
         r#"fallback = "unit", "never", "no""#,
         r#"diverging_block_default = "unit", "never""#,
@@ -445,7 +446,7 @@ pub(crate) struct RustcTrivialFieldReadsParser;
 
 impl NoArgsAttributeParser for RustcTrivialFieldReadsParser {
     const PATH: &[Symbol] = &[sym::rustc_trivial_field_reads];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Trait)]);
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[Allow(Target::Trait)]);
     const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcTrivialFieldReads;
 }
@@ -454,7 +455,7 @@ pub(crate) struct RustcNoMirInlineParser;
 
 impl NoArgsAttributeParser for RustcNoMirInlineParser {
     const PATH: &[Symbol] = &[sym::rustc_no_mir_inline];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[
         Allow(Target::Fn),
         Allow(Target::Method(MethodKind::Inherent)),
         Allow(Target::Method(MethodKind::Trait { body: false })),
@@ -470,7 +471,7 @@ pub(crate) struct RustcNoWritableParser;
 impl NoArgsAttributeParser for RustcNoWritableParser {
     const PATH: &[Symbol] = &[sym::rustc_no_writable];
     const ON_DUPLICATE: OnDuplicate = OnDuplicate::Error;
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[
         Allow(Target::Fn),
         Allow(Target::Closure),
         Allow(Target::Method(MethodKind::Inherent)),
@@ -485,7 +486,7 @@ pub(crate) struct RustcLintQueryInstabilityParser;
 
 impl NoArgsAttributeParser for RustcLintQueryInstabilityParser {
     const PATH: &[Symbol] = &[sym::rustc_lint_query_instability];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[
         Allow(Target::Fn),
         Allow(Target::Method(MethodKind::Inherent)),
         Allow(Target::Method(MethodKind::Trait { body: false })),
@@ -500,7 +501,7 @@ pub(crate) struct RustcRegionsParser;
 
 impl NoArgsAttributeParser for RustcRegionsParser {
     const PATH: &[Symbol] = &[sym::rustc_regions];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[
         Allow(Target::Fn),
         Allow(Target::Method(MethodKind::Inherent)),
         Allow(Target::Method(MethodKind::Trait { body: false })),
@@ -515,7 +516,7 @@ pub(crate) struct RustcLintUntrackedQueryInformationParser;
 
 impl NoArgsAttributeParser for RustcLintUntrackedQueryInformationParser {
     const PATH: &[Symbol] = &[sym::rustc_lint_untracked_query_information];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[
         Allow(Target::Fn),
         Allow(Target::Method(MethodKind::Inherent)),
         Allow(Target::Method(MethodKind::Trait { body: false })),
@@ -530,7 +531,7 @@ pub(crate) struct RustcSimdMonomorphizeLaneLimitParser;
 
 impl SingleAttributeParser for RustcSimdMonomorphizeLaneLimitParser {
     const PATH: &[Symbol] = &[sym::rustc_simd_monomorphize_lane_limit];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Struct)]);
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[Allow(Target::Struct)]);
     const TEMPLATE: AttributeTemplate = template!(NameValueStr: "N");
     const STABILITY: AttributeStability = unstable!(rustc_attrs);
 
@@ -544,7 +545,7 @@ pub(crate) struct RustcScalableVectorParser;
 
 impl SingleAttributeParser for RustcScalableVectorParser {
     const PATH: &[Symbol] = &[sym::rustc_scalable_vector];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Struct)]);
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[Allow(Target::Struct)]);
     const TEMPLATE: AttributeTemplate = template!(Word, List: &["count"]);
     const STABILITY: AttributeStability = unstable!(rustc_attrs);
 
@@ -566,7 +567,7 @@ pub(crate) struct LangParser;
 
 impl SingleAttributeParser for LangParser {
     const PATH: &[Symbol] = &[sym::lang];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(ALL_TARGETS); // Targets are checked per lang item in `rustc_passes`
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::ManuallyChecked;
     const TEMPLATE: AttributeTemplate = template!(NameValueStr: "name");
     const STABILITY: AttributeStability = unstable!(lang_items);
 
@@ -607,7 +608,7 @@ pub(crate) struct RustcHasIncoherentInherentImplsParser;
 
 impl NoArgsAttributeParser for RustcHasIncoherentInherentImplsParser {
     const PATH: &[Symbol] = &[sym::rustc_has_incoherent_inherent_impls];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[
         Allow(Target::Trait),
         Allow(Target::Struct),
         Allow(Target::Enum),
@@ -622,7 +623,7 @@ pub(crate) struct PanicHandlerParser;
 
 impl NoArgsAttributeParser for PanicHandlerParser {
     const PATH: &[Symbol] = &[sym::panic_handler];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Fn)]);
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[Allow(Target::Fn)]);
     const STABILITY: AttributeStability = AttributeStability::Stable;
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::Lang(LangItem::PanicImpl);
 }
@@ -631,7 +632,7 @@ pub(crate) struct RustcNounwindParser;
 
 impl NoArgsAttributeParser for RustcNounwindParser {
     const PATH: &[Symbol] = &[sym::rustc_nounwind];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[
         Allow(Target::Fn),
         Allow(Target::ForeignFn),
         Allow(Target::Method(MethodKind::Inherent)),
@@ -646,7 +647,7 @@ pub(crate) struct RustcOffloadKernelParser;
 
 impl NoArgsAttributeParser for RustcOffloadKernelParser {
     const PATH: &[Symbol] = &[sym::rustc_offload_kernel];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Fn)]);
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[Allow(Target::Fn)]);
     const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcOffloadKernel;
 }
@@ -659,7 +660,7 @@ impl CombineAttributeParser for RustcMirParser {
     type Item = RustcMirKind;
 
     const CONVERT: ConvertFn<Self::Item> = |items, _| AttributeKind::RustcMir(items);
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[
         Allow(Target::Fn),
         Allow(Target::Method(MethodKind::Inherent)),
         Allow(Target::Method(MethodKind::TraitImpl)),
@@ -735,7 +736,7 @@ pub(crate) struct RustcNonConstTraitMethodParser;
 
 impl NoArgsAttributeParser for RustcNonConstTraitMethodParser {
     const PATH: &[Symbol] = &[sym::rustc_non_const_trait_method];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[
         Allow(Target::Method(MethodKind::Trait { body: true })),
         Allow(Target::Method(MethodKind::Trait { body: false })),
     ]);
@@ -754,7 +755,7 @@ impl CombineAttributeParser for RustcCleanParser {
     type Item = RustcCleanAttribute;
 
     const CONVERT: ConvertFn<Self::Item> = |items, _| AttributeKind::RustcClean(items);
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[
         // tidy-alphabetical-start
         Allow(Target::AssocConst),
         Allow(Target::AssocTy),
@@ -847,7 +848,7 @@ pub(crate) struct RustcIfThisChangedParser;
 
 impl SingleAttributeParser for RustcIfThisChangedParser {
     const PATH: &[Symbol] = &[sym::rustc_if_this_changed];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[
         // tidy-alphabetical-start
         Allow(Target::AssocConst),
         Allow(Target::AssocTy),
@@ -905,7 +906,7 @@ impl CombineAttributeParser for RustcThenThisWouldNeedParser {
 
     const CONVERT: ConvertFn<Self::Item> =
         |items, _span| AttributeKind::RustcThenThisWouldNeed(items);
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[
         // tidy-alphabetical-start
         Allow(Target::AssocConst),
         Allow(Target::AssocTy),
@@ -952,7 +953,7 @@ pub(crate) struct RustcInsignificantDtorParser;
 
 impl NoArgsAttributeParser for RustcInsignificantDtorParser {
     const PATH: &[Symbol] = &[sym::rustc_insignificant_dtor];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[
         Allow(Target::Enum),
         Allow(Target::Struct),
         Allow(Target::ForeignTy),
@@ -965,7 +966,7 @@ pub(crate) struct RustcEffectiveVisibilityParser;
 
 impl NoArgsAttributeParser for RustcEffectiveVisibilityParser {
     const PATH: &[Symbol] = &[sym::rustc_effective_visibility];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[
         Allow(Target::Use),
         Allow(Target::Static),
         Allow(Target::Const),
@@ -1004,7 +1005,7 @@ pub(crate) struct RustcDiagnosticItemParser;
 
 impl SingleAttributeParser for RustcDiagnosticItemParser {
     const PATH: &[Symbol] = &[sym::rustc_diagnostic_item];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[
         Allow(Target::Trait),
         Allow(Target::Struct),
         Allow(Target::Enum),
@@ -1039,7 +1040,7 @@ pub(crate) struct RustcDoNotConstCheckParser;
 
 impl NoArgsAttributeParser for RustcDoNotConstCheckParser {
     const PATH: &[Symbol] = &[sym::rustc_do_not_const_check];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[
         Allow(Target::Fn),
         Allow(Target::Method(MethodKind::Inherent)),
         Allow(Target::Method(MethodKind::TraitImpl)),
@@ -1057,7 +1058,7 @@ pub(crate) struct RustcNonnullOptimizationGuaranteedParser;
 
 impl NoArgsAttributeParser for RustcNonnullOptimizationGuaranteedParser {
     const PATH: &[Symbol] = &[sym::rustc_nonnull_optimization_guaranteed];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Struct)]);
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[Allow(Target::Struct)]);
     const STABILITY: AttributeStability = unstable!(
         rustc_attrs,
         "the `#[rustc_nonnull_optimization_guaranteed]` attribute is just used to document guaranteed niche optimizations in the standard library",
@@ -1070,7 +1071,7 @@ pub(crate) struct RustcStrictCoherenceParser;
 
 impl NoArgsAttributeParser for RustcStrictCoherenceParser {
     const PATH: &[Symbol] = &[sym::rustc_strict_coherence];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[
         Allow(Target::Trait),
         Allow(Target::Struct),
         Allow(Target::Enum),
@@ -1085,7 +1086,7 @@ pub(crate) struct RustcReservationImplParser;
 
 impl SingleAttributeParser for RustcReservationImplParser {
     const PATH: &[Symbol] = &[sym::rustc_reservation_impl];
-    const ALLOWED_TARGETS: AllowedTargets =
+    const ALLOWED_TARGETS: AllowedTargets<'_> =
         AllowedTargets::AllowList(&[Allow(Target::Impl { of_trait: true })]);
     const TEMPLATE: AttributeTemplate = template!(NameValueStr: "reservation message");
     const STABILITY: AttributeStability = unstable!(rustc_attrs);
@@ -1102,7 +1103,7 @@ pub(crate) struct PreludeImportParser;
 
 impl NoArgsAttributeParser for PreludeImportParser {
     const PATH: &[Symbol] = &[sym::prelude_import];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Use)]);
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[Allow(Target::Use)]);
     const STABILITY: AttributeStability = unstable!(prelude_import);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::PreludeImport;
 }
@@ -1111,7 +1112,7 @@ pub(crate) struct RustcDocPrimitiveParser;
 
 impl SingleAttributeParser for RustcDocPrimitiveParser {
     const PATH: &[Symbol] = &[sym::rustc_doc_primitive];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Mod)]);
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[Allow(Target::Mod)]);
     const TEMPLATE: AttributeTemplate = template!(NameValueStr: "primitive name");
     const STABILITY: AttributeStability = unstable!(
         rustc_attrs,
@@ -1130,7 +1131,7 @@ pub(crate) struct RustcIntrinsicParser;
 
 impl NoArgsAttributeParser for RustcIntrinsicParser {
     const PATH: &[Symbol] = &[sym::rustc_intrinsic];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Fn)]);
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[Allow(Target::Fn)]);
     const STABILITY: AttributeStability = unstable!(intrinsics);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcIntrinsic;
 }
@@ -1139,7 +1140,7 @@ pub(crate) struct RustcIntrinsicConstStableIndirectParser;
 
 impl NoArgsAttributeParser for RustcIntrinsicConstStableIndirectParser {
     const PATH: &'static [Symbol] = &[sym::rustc_intrinsic_const_stable_indirect];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Fn)]);
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[Allow(Target::Fn)]);
     const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcIntrinsicConstStableIndirect;
 }
@@ -1148,7 +1149,7 @@ pub(crate) struct RustcExhaustiveParser;
 
 impl NoArgsAttributeParser for RustcExhaustiveParser {
     const PATH: &'static [Symbol] = &[sym::rustc_must_match_exhaustively];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Enum)]);
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[Allow(Target::Enum)]);
     const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const CREATE: fn(Span) -> AttributeKind = AttributeKind::RustcMustMatchExhaustively;
 }

--- a/compiler/rustc_attr_parsing/src/attributes/rustc_internal.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/rustc_internal.rs
@@ -12,7 +12,7 @@ use rustc_span::Symbol;
 use super::prelude::*;
 use super::util::parse_single_integer;
 use crate::diagnostics;
-use crate::diagnostics::{LangItemOnIncorrectTarget, UnknownExternLangItem};
+use crate::diagnostics::UnknownExternLangItem;
 use crate::session_diagnostics::{
     AttributeRequiresOpt, CguFieldsMissing, RustcScalableVectorCountOutOfRange, UnknownLangItem,
 };
@@ -589,17 +589,13 @@ impl SingleAttributeParser for LangParser {
         }
 
         // Check the target
-        if cx.target != lang_item.target()
-            && !(cx.target == Target::ForeignFn && lang_item == LangItem::PanicImpl)
-        {
-            cx.emit_err(LangItemOnIncorrectTarget {
-                span: cx.attr_span,
-                name,
-                expected_target: lang_item.target(),
-                actual_target: cx.target,
-            });
-            return None;
-        }
+        let allowed_targets: &[_] = if lang_item == LangItem::PanicImpl {
+            &[Allow(Target::Fn), Allow(Target::ForeignFn)]
+        } else {
+            &[Allow(lang_item.target())]
+        };
+        cx.check_target(&format!(" = \"{name}\""), &AllowedTargets::AllowList(allowed_targets));
+
         Some(AttributeKind::Lang(lang_item))
     }
 }

--- a/compiler/rustc_attr_parsing/src/attributes/semantics.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/semantics.rs
@@ -5,7 +5,7 @@ use super::prelude::*;
 pub(crate) struct MayDangleParser;
 impl NoArgsAttributeParser for MayDangleParser {
     const PATH: &[Symbol] = &[sym::may_dangle];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(ALL_TARGETS); //FIXME Still checked fully in `check_attr.rs`
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(ALL_TARGETS); //FIXME Still checked fully in `check_attr.rs`
     const STABILITY: AttributeStability = unstable!(dropck_eyepatch);
     const CREATE: fn(span: Span) -> AttributeKind = AttributeKind::MayDangle;
 }
@@ -14,7 +14,7 @@ pub(crate) struct ComptimeParser;
 impl NoArgsAttributeParser for ComptimeParser {
     const PATH: &[Symbol] = &[sym::rustc_comptime];
     const ON_DUPLICATE: OnDuplicate = OnDuplicate::Error;
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[
         Allow(Target::Method(MethodKind::Inherent)),
         Allow(Target::Fn),
     ]);

--- a/compiler/rustc_attr_parsing/src/attributes/splat.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/splat.rs
@@ -9,7 +9,7 @@ pub(crate) struct SplatParser;
 
 impl NoArgsAttributeParser for SplatParser {
     const PATH: &[Symbol] = &[sym::splat];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Param)]);
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[Allow(Target::Param)]);
     const STABILITY: AttributeStability =
         unstable!(splat, "the `#[splat]` attribute is experimental");
     const CREATE: fn(Span) -> AttributeKind = AttributeKind::Splat;

--- a/compiler/rustc_attr_parsing/src/attributes/stability.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/stability.rs
@@ -13,7 +13,7 @@ use super::prelude::*;
 use super::util::parse_version;
 use crate::session_diagnostics;
 
-const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
+const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[
     Allow(Target::Fn),
     Allow(Target::Struct),
     Allow(Target::Enum),
@@ -102,7 +102,7 @@ impl AttributeParser for StabilityParser {
             },
         ),
     ];
-    const ALLOWED_TARGETS: AllowedTargets = ALLOWED_TARGETS;
+    const ALLOWED_TARGETS: AllowedTargets<'_> = ALLOWED_TARGETS;
 
     fn finalize(mut self, cx: &FinalizeContext<'_, '_>) -> Option<AttributeKind> {
         if let Some(atum) = self.allowed_through_unstable_modules {
@@ -158,7 +158,7 @@ impl AttributeParser for BodyStabilityParser {
             }
         },
     )];
-    const ALLOWED_TARGETS: AllowedTargets = ALLOWED_TARGETS;
+    const ALLOWED_TARGETS: AllowedTargets<'_> = ALLOWED_TARGETS;
 
     fn finalize(self, _cx: &FinalizeContext<'_, '_>) -> Option<AttributeKind> {
         let (stability, span) = self.stability?;
@@ -171,7 +171,7 @@ pub(crate) struct RustcConstStableIndirectParser;
 impl NoArgsAttributeParser for RustcConstStableIndirectParser {
     const PATH: &[Symbol] = &[sym::rustc_const_stable_indirect];
     const ON_DUPLICATE: OnDuplicate = OnDuplicate::Ignore;
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[
         Allow(Target::Fn),
         Allow(Target::Method(MethodKind::Inherent)),
     ]);
@@ -233,7 +233,7 @@ impl AttributeParser for ConstStabilityParser {
             this.promotable = true;
         }),
     ];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[
         Allow(Target::Fn),
         Allow(Target::Method(MethodKind::Inherent)),
         Allow(Target::Method(MethodKind::TraitImpl)),
@@ -460,7 +460,7 @@ pub(crate) struct UnstableRemovedParser;
 impl CombineAttributeParser for UnstableRemovedParser {
     type Item = UnstableRemovedFeature;
     const PATH: &[Symbol] = &[sym::unstable_removed];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
     const TEMPLATE: AttributeTemplate =
         template!(List: &[r#"feature = "name", reason = "...", link = "...", since = "version""#]);
     const STABILITY: AttributeStability = unstable!(staged_api);

--- a/compiler/rustc_attr_parsing/src/attributes/test_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/test_attrs.rs
@@ -9,7 +9,7 @@ pub(crate) struct IgnoreParser;
 impl SingleAttributeParser for IgnoreParser {
     const PATH: &[Symbol] = &[sym::ignore];
     const ON_DUPLICATE: OnDuplicate = OnDuplicate::Warn;
-    const ALLOWED_TARGETS: AllowedTargets =
+    const ALLOWED_TARGETS: AllowedTargets<'_> =
         AllowedTargets::AllowListWarnRest(&[Allow(Target::Fn), Error(Target::WherePredicate)]);
     const TEMPLATE: AttributeTemplate = template!(
         Word, NameValueStr: "reason",
@@ -51,7 +51,7 @@ pub(crate) struct ShouldPanicParser;
 impl SingleAttributeParser for ShouldPanicParser {
     const PATH: &[Symbol] = &[sym::should_panic];
     const ON_DUPLICATE: OnDuplicate = OnDuplicate::WarnButFutureError;
-    const ALLOWED_TARGETS: AllowedTargets =
+    const ALLOWED_TARGETS: AllowedTargets<'_> =
         AllowedTargets::AllowListWarnRest(&[Allow(Target::Fn), Error(Target::WherePredicate)]);
     const TEMPLATE: AttributeTemplate = template!(
         Word, List: &[r#"expected = "reason""#], NameValueStr: "reason",
@@ -83,7 +83,7 @@ pub(crate) struct ReexportTestHarnessMainParser;
 
 impl SingleAttributeParser for ReexportTestHarnessMainParser {
     const PATH: &[Symbol] = &[sym::reexport_test_harness_main];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
     const TEMPLATE: AttributeTemplate = template!(NameValueStr: "name");
     const STABILITY: AttributeStability = unstable!(custom_test_frameworks);
 
@@ -105,7 +105,7 @@ pub(crate) struct RustcAbiParser;
 impl SingleAttributeParser for RustcAbiParser {
     const PATH: &[Symbol] = &[sym::rustc_abi];
     const TEMPLATE: AttributeTemplate = template!(OneOf: &[sym::debug, sym::assert_eq]);
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[
         Allow(Target::TyAlias),
         Allow(Target::Fn),
         Allow(Target::ForeignFn),
@@ -150,7 +150,7 @@ pub(crate) struct RustcDelayedBugFromInsideQueryParser;
 
 impl NoArgsAttributeParser for RustcDelayedBugFromInsideQueryParser {
     const PATH: &[Symbol] = &[sym::rustc_delayed_bug_from_inside_query];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Fn)]);
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[Allow(Target::Fn)]);
     const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcDelayedBugFromInsideQuery;
 }
@@ -159,7 +159,7 @@ pub(crate) struct RustcEvaluateWhereClausesParser;
 
 impl NoArgsAttributeParser for RustcEvaluateWhereClausesParser {
     const PATH: &[Symbol] = &[sym::rustc_evaluate_where_clauses];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[
         Allow(Target::Fn),
         Allow(Target::Method(MethodKind::Inherent)),
         Allow(Target::Method(MethodKind::Trait { body: true })),
@@ -174,7 +174,7 @@ pub(crate) struct TestRunnerParser;
 
 impl SingleAttributeParser for TestRunnerParser {
     const PATH: &[Symbol] = &[sym::test_runner];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
     const TEMPLATE: AttributeTemplate = template!(List: &["path"]);
     const STABILITY: AttributeStability = unstable!(custom_test_frameworks);
 
@@ -194,7 +194,7 @@ pub(crate) struct RustcTestMarkerParser;
 
 impl SingleAttributeParser for RustcTestMarkerParser {
     const PATH: &[Symbol] = &[sym::rustc_test_marker];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[
         Allow(Target::Const),
         Allow(Target::Fn),
         Allow(Target::Static),

--- a/compiler/rustc_attr_parsing/src/attributes/traits.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/traits.rs
@@ -12,7 +12,7 @@ use crate::target_checking::Policy::{Allow, Warn};
 pub(crate) struct RustcSkipDuringMethodDispatchParser;
 impl SingleAttributeParser for RustcSkipDuringMethodDispatchParser {
     const PATH: &[Symbol] = &[sym::rustc_skip_during_method_dispatch];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Trait)]);
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[Allow(Target::Trait)]);
 
     const TEMPLATE: AttributeTemplate = template!(List: &["array, boxed_slice"]);
     const STABILITY: AttributeStability = unstable!(rustc_attrs);
@@ -52,7 +52,7 @@ impl SingleAttributeParser for RustcSkipDuringMethodDispatchParser {
 pub(crate) struct RustcParenSugarParser;
 impl NoArgsAttributeParser for RustcParenSugarParser {
     const PATH: &[Symbol] = &[sym::rustc_paren_sugar];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Trait)]);
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[Allow(Target::Trait)]);
     const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcParenSugar;
 }
@@ -62,7 +62,7 @@ impl NoArgsAttributeParser for RustcParenSugarParser {
 pub(crate) struct MarkerParser;
 impl NoArgsAttributeParser for MarkerParser {
     const PATH: &[Symbol] = &[sym::marker];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[
         Allow(Target::Trait),
         Warn(Target::Field),
         Warn(Target::Arm),
@@ -75,7 +75,7 @@ impl NoArgsAttributeParser for MarkerParser {
 pub(crate) struct RustcDenyExplicitImplParser;
 impl NoArgsAttributeParser for RustcDenyExplicitImplParser {
     const PATH: &[Symbol] = &[sym::rustc_deny_explicit_impl];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Trait)]);
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[Allow(Target::Trait)]);
     const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcDenyExplicitImpl;
 }
@@ -83,7 +83,7 @@ impl NoArgsAttributeParser for RustcDenyExplicitImplParser {
 pub(crate) struct RustcDynIncompatibleTraitParser;
 impl NoArgsAttributeParser for RustcDynIncompatibleTraitParser {
     const PATH: &[Symbol] = &[sym::rustc_dyn_incompatible_trait];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Trait)]);
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[Allow(Target::Trait)]);
     const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const CREATE: fn(Span) -> AttributeKind = AttributeKind::RustcDynIncompatibleTrait;
 }
@@ -93,7 +93,7 @@ impl NoArgsAttributeParser for RustcDynIncompatibleTraitParser {
 pub(crate) struct RustcSpecializationTraitParser;
 impl NoArgsAttributeParser for RustcSpecializationTraitParser {
     const PATH: &[Symbol] = &[sym::rustc_specialization_trait];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Trait)]);
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[Allow(Target::Trait)]);
     const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcSpecializationTrait;
 }
@@ -101,7 +101,7 @@ impl NoArgsAttributeParser for RustcSpecializationTraitParser {
 pub(crate) struct RustcUnsafeSpecializationMarkerParser;
 impl NoArgsAttributeParser for RustcUnsafeSpecializationMarkerParser {
     const PATH: &[Symbol] = &[sym::rustc_unsafe_specialization_marker];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Trait)]);
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[Allow(Target::Trait)]);
     const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcUnsafeSpecializationMarker;
 }
@@ -111,7 +111,7 @@ impl NoArgsAttributeParser for RustcUnsafeSpecializationMarkerParser {
 pub(crate) struct RustcCoinductiveParser;
 impl NoArgsAttributeParser for RustcCoinductiveParser {
     const PATH: &[Symbol] = &[sym::rustc_coinductive];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Trait)]);
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[Allow(Target::Trait)]);
     const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcCoinductive;
 }
@@ -119,7 +119,7 @@ impl NoArgsAttributeParser for RustcCoinductiveParser {
 pub(crate) struct RustcAllowIncoherentImplParser;
 impl NoArgsAttributeParser for RustcAllowIncoherentImplParser {
     const PATH: &[Symbol] = &[sym::rustc_allow_incoherent_impl];
-    const ALLOWED_TARGETS: AllowedTargets =
+    const ALLOWED_TARGETS: AllowedTargets<'_> =
         AllowedTargets::AllowList(&[Allow(Target::Method(MethodKind::Inherent))]);
     const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const CREATE: fn(Span) -> AttributeKind = AttributeKind::RustcAllowIncoherentImpl;
@@ -128,7 +128,7 @@ impl NoArgsAttributeParser for RustcAllowIncoherentImplParser {
 pub(crate) struct FundamentalParser;
 impl NoArgsAttributeParser for FundamentalParser {
     const PATH: &[Symbol] = &[sym::fundamental];
-    const ALLOWED_TARGETS: AllowedTargets =
+    const ALLOWED_TARGETS: AllowedTargets<'_> =
         AllowedTargets::AllowList(&[Allow(Target::Struct), Allow(Target::Trait)]);
     const STABILITY: AttributeStability = unstable!(fundamental);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::Fundamental;

--- a/compiler/rustc_attr_parsing/src/attributes/transparency.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/transparency.rs
@@ -11,7 +11,8 @@ impl SingleAttributeParser for RustcMacroTransparencyParser {
         cx.dcx().span_err(vec![used, unused], "multiple macro transparency attributes");
     });
     const STABILITY: AttributeStability = unstable!(rustc_attrs);
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::MacroDef)]);
+    const ALLOWED_TARGETS: AllowedTargets<'_> =
+        AllowedTargets::AllowList(&[Allow(Target::MacroDef)]);
     const TEMPLATE: AttributeTemplate =
         template!(NameValueStr: ["transparent", "semiopaque", "opaque"]);
 

--- a/compiler/rustc_attr_parsing/src/attributes/unroll.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/unroll.rs
@@ -7,7 +7,7 @@ use super::prelude::*;
 pub(crate) struct UnrollParser;
 impl SingleAttributeParser for UnrollParser {
     const PATH: &[Symbol] = &[sym::unroll];
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[
         Allow(Target::Loop),
         Allow(Target::ForLoop),
         Allow(Target::While),

--- a/compiler/rustc_attr_parsing/src/context.rs
+++ b/compiler/rustc_attr_parsing/src/context.rs
@@ -85,7 +85,7 @@ pub(super) struct GroupTypeInner {
 pub(super) struct GroupTypeInnerAccept {
     pub(super) template: AttributeTemplate,
     pub(super) accept_fn: AcceptFn,
-    pub(super) allowed_targets: AllowedTargets,
+    pub(super) allowed_targets: AllowedTargets<'static>,
     pub(super) safety: AttributeSafety,
     pub(super) stability: AttributeStability,
     pub(super) finalizer: FinalizeFn,

--- a/compiler/rustc_attr_parsing/src/diagnostics.rs
+++ b/compiler/rustc_attr_parsing/src/diagnostics.rs
@@ -1,5 +1,4 @@
-use rustc_errors::E0264;
-use rustc_errors::{Applicability, DiagArgValue, E0232, E0718, MultiSpan};
+use rustc_errors::{Applicability, DiagArgValue, E0232, E0264, E0718, MultiSpan};
 use rustc_hir::{AttrPath, Target};
 use rustc_macros::{Diagnostic, Subdiagnostic};
 use rustc_span::{Span, Symbol};

--- a/compiler/rustc_attr_parsing/src/diagnostics.rs
+++ b/compiler/rustc_attr_parsing/src/diagnostics.rs
@@ -1,5 +1,6 @@
-use rustc_errors::{Applicability, DiagArgValue, E0232, MultiSpan};
-use rustc_hir::AttrPath;
+use rustc_errors::E0264;
+use rustc_errors::{Applicability, DiagArgValue, E0232, E0718, MultiSpan};
+use rustc_hir::{AttrPath, Target};
 use rustc_macros::{Diagnostic, Subdiagnostic};
 use rustc_span::{Span, Symbol};
 
@@ -800,4 +801,23 @@ pub(crate) struct DupesNotAllowed;
 pub(crate) struct UnsafeAttribute {
     pub attr_path: AttrPath,
     pub note: &'static str,
+}
+
+#[derive(Diagnostic)]
+#[diag("`{$name}` lang item must be applied to a {$expected_target}", code = E0718)]
+pub(crate) struct LangItemOnIncorrectTarget {
+    #[primary_span]
+    #[label("attribute should be applied to a {$expected_target}, not a {$actual_target}")]
+    pub span: Span,
+    pub name: Symbol,
+    pub expected_target: Target,
+    pub actual_target: Target,
+}
+
+#[derive(Diagnostic)]
+#[diag("unknown external lang item: `{$lang_item}`", code = E0264)]
+pub(crate) struct UnknownExternLangItem {
+    #[primary_span]
+    pub span: Span,
+    pub lang_item: Symbol,
 }

--- a/compiler/rustc_attr_parsing/src/diagnostics.rs
+++ b/compiler/rustc_attr_parsing/src/diagnostics.rs
@@ -1,5 +1,5 @@
-use rustc_errors::{Applicability, DiagArgValue, E0232, E0264, E0718, MultiSpan};
-use rustc_hir::{AttrPath, Target};
+use rustc_errors::{Applicability, DiagArgValue, E0232, E0264, MultiSpan};
+use rustc_hir::AttrPath;
 use rustc_macros::{Diagnostic, Subdiagnostic};
 use rustc_span::{Span, Symbol};
 
@@ -800,17 +800,6 @@ pub(crate) struct DupesNotAllowed;
 pub(crate) struct UnsafeAttribute {
     pub attr_path: AttrPath,
     pub note: &'static str,
-}
-
-#[derive(Diagnostic)]
-#[diag("`{$name}` lang item must be applied to a {$expected_target}", code = E0718)]
-pub(crate) struct LangItemOnIncorrectTarget {
-    #[primary_span]
-    #[label("attribute should be applied to a {$expected_target}, not a {$actual_target}")]
-    pub span: Span,
-    pub name: Symbol,
-    pub expected_target: Target,
-    pub actual_target: Target,
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_attr_parsing/src/session_diagnostics.rs
+++ b/compiler/rustc_attr_parsing/src/session_diagnostics.rs
@@ -337,7 +337,7 @@ pub(crate) struct InvalidTarget {
     pub target: &'static str,
     pub applied: DiagArgValue,
     pub only: &'static str,
-    pub attribute_args: &'static str,
+    pub attribute_args: String,
     #[subdiagnostic]
     pub help: Option<InvalidTargetHelp>,
     #[warning(

--- a/compiler/rustc_attr_parsing/src/target_checking.rs
+++ b/compiler/rustc_attr_parsing/src/target_checking.rs
@@ -95,7 +95,7 @@ pub(crate) enum Policy {
 impl<'sess> AttributeParser<'sess> {
     pub(crate) fn check_target(
         allowed_targets: &AllowedTargets<'_>,
-        attribute_args: &'static str,
+        attribute_args: &str,
         cx: &mut AcceptContext<'_, 'sess>,
     ) {
         if matches!(cx.should_emit, ShouldEmit::Nothing) {
@@ -137,7 +137,7 @@ impl<'sess> AttributeParser<'sess> {
             target: cx.target.plural_name(),
             only: if only { "only " } else { "" },
             applied: DiagArgValue::StrListSepByAnd(applied.into_iter().map(Cow::Owned).collect()),
-            attribute_args,
+            attribute_args: attribute_args.to_string(),
             help: Self::target_checking_help(attribute_args, cx),
             previously_accepted: matches!(result, AllowedResult::Warn) && !is_diagnostic_attr,
             on_macro_call: matches!(cx.target, Target::MacroCall),
@@ -173,7 +173,7 @@ impl<'sess> AttributeParser<'sess> {
     }
 
     fn target_checking_help(
-        attribute_args: &'static str,
+        attribute_args: &str,
         cx: &AcceptContext<'_, '_>,
     ) -> Option<InvalidTargetHelp> {
         match &*cx.attr_path.segments {
@@ -443,7 +443,7 @@ fn filter_targets(
 impl<'f, 'sess> AcceptContext<'f, 'sess> {
     pub(crate) fn check_target(
         &mut self,
-        attribute_args: &'static str,
+        attribute_args: &str,
         allowed_targets: &AllowedTargets<'_>,
     ) {
         self.ignore_target_checks();

--- a/compiler/rustc_attr_parsing/src/target_checking.rs
+++ b/compiler/rustc_attr_parsing/src/target_checking.rs
@@ -16,9 +16,9 @@ use crate::target_checking::Policy::Allow;
 use crate::{AttributeParser, ShouldEmit};
 
 #[derive(Debug)]
-pub(crate) enum AllowedTargets {
-    AllowList(&'static [Policy]),
-    AllowListWarnRest(&'static [Policy]),
+pub(crate) enum AllowedTargets<'a> {
+    AllowList(&'a [Policy]),
+    AllowListWarnRest(&'a [Policy]),
     /// This is useful for argument-dependent target checking.
     /// If debug assertions are enabled,
     /// this emits a delayed bug if the `cx.check_target(...)` method is not called during attribute parsing.
@@ -31,7 +31,7 @@ pub(crate) enum AllowedResult {
     Error,
 }
 
-impl AllowedTargets {
+impl AllowedTargets<'_> {
     pub(crate) fn is_allowed(&self, target: Target) -> AllowedResult {
         match self {
             AllowedTargets::AllowList(list) => {
@@ -94,7 +94,7 @@ pub(crate) enum Policy {
 
 impl<'sess> AttributeParser<'sess> {
     pub(crate) fn check_target(
-        allowed_targets: &AllowedTargets,
+        allowed_targets: &AllowedTargets<'_>,
         attribute_args: &'static str,
         cx: &mut AcceptContext<'_, 'sess>,
     ) {
@@ -444,7 +444,7 @@ impl<'f, 'sess> AcceptContext<'f, 'sess> {
     pub(crate) fn check_target(
         &mut self,
         attribute_args: &'static str,
-        allowed_targets: &AllowedTargets,
+        allowed_targets: &AllowedTargets<'_>,
     ) {
         self.ignore_target_checks();
         AttributeParser::check_target(allowed_targets, attribute_args, self);

--- a/compiler/rustc_error_codes/src/error_codes/E0718.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0718.md
@@ -1,8 +1,10 @@
+#### Note: this error code is no longer emitted by the compiler.
+
 A `#[lang = ".."]` attribute was placed on the wrong item type.
 
 Erroneous code example:
 
-```compile_fail,E0718
+```compile_fail
 #![feature(lang_items)]
 
 #[lang = "owned_box"]

--- a/compiler/rustc_passes/src/diagnostics.rs
+++ b/compiler/rustc_passes/src/diagnostics.rs
@@ -5,7 +5,6 @@ use rustc_errors::codes::*;
 use rustc_errors::{
     Diag, DiagCtxtHandle, DiagSymbolList, Diagnostic, EmissionGuarantee, Level, MultiSpan, msg,
 };
-use rustc_hir::Target;
 use rustc_macros::{Diagnostic, Subdiagnostic};
 use rustc_middle::ty::{MainDefinition, Ty};
 use rustc_span::{DUMMY_SP, Ident, Span, Symbol};
@@ -327,14 +326,6 @@ pub(crate) struct DeprecatedAnnotationHasNoEffect {
 }
 
 #[derive(Diagnostic)]
-#[diag("unknown external lang item: `{$lang_item}`", code = E0264)]
-pub(crate) struct UnknownExternLangItem {
-    #[primary_span]
-    pub span: Span,
-    pub lang_item: Symbol,
-}
-
-#[derive(Diagnostic)]
 #[diag("`#[panic_handler]` function required, but not found")]
 pub(crate) struct MissingPanicHandler;
 
@@ -396,17 +387,6 @@ pub(crate) struct LangItemWithTargetFeature {
         } function is not allowed to have `#[target_feature]`"
     )]
     pub sig_span: Span,
-}
-
-#[derive(Diagnostic)]
-#[diag("`{$name}` lang item must be applied to a {$expected_target}", code = E0718)]
-pub(crate) struct LangItemOnIncorrectTarget {
-    #[primary_span]
-    #[label("attribute should be applied to a {$expected_target}, not a {$actual_target}")]
-    pub span: Span,
-    pub name: Symbol,
-    pub expected_target: Target,
-    pub actual_target: Target,
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_passes/src/lang_items.rs
+++ b/compiler/rustc_passes/src/lang_items.rs
@@ -18,9 +18,7 @@ use rustc_middle::ty::{ResolverAstLowering, TyCtxt};
 use rustc_session::cstore::ExternCrate;
 use rustc_span::{Span, Symbol, sym};
 
-use crate::diagnostics::{
-    DuplicateLangItem, IncorrectCrateType, IncorrectTarget, LangItemOnIncorrectTarget,
-};
+use crate::diagnostics::{DuplicateLangItem, IncorrectCrateType, IncorrectTarget};
 use crate::weak_lang_items;
 
 pub(crate) enum Duplicate {
@@ -63,8 +61,14 @@ impl<'ast, 'tcx> LanguageItemCollector<'ast, 'tcx> {
     ) {
         if let Some((name, attr_span)) = extract_ast(attrs) {
             match LangItem::from_name(name) {
-                // Known lang item with attribute on correct target.
-                Some(lang_item) if actual_target == lang_item.target() => {
+                // Known lang item
+                Some(lang_item) => {
+                    if actual_target != lang_item.target() {
+                        self.tcx
+                            .dcx()
+                            .delayed_bug("lang item target is checked in attribute parser");
+                        return;
+                    }
                     self.collect_item_extended(
                         lang_item,
                         def_id,
@@ -73,15 +77,6 @@ impl<'ast, 'tcx> LanguageItemCollector<'ast, 'tcx> {
                         generics,
                         actual_target,
                     );
-                }
-                // Known lang item with attribute on incorrect target.
-                Some(lang_item) => {
-                    self.tcx.dcx().emit_err(LangItemOnIncorrectTarget {
-                        span: attr_span,
-                        name,
-                        expected_target: lang_item.target(),
-                        actual_target,
-                    });
                 }
                 // Unknown lang item.
                 _ => {

--- a/compiler/rustc_passes/src/weak_lang_items.rs
+++ b/compiler/rustc_passes/src/weak_lang_items.rs
@@ -10,7 +10,7 @@ use rustc_middle::ty::TyCtxt;
 use rustc_session::config::CrateType;
 
 use crate::diagnostics::{
-    MissingLangItem, MissingPanicHandler, PanicUnwindWithoutStd, UnknownExternLangItem,
+    MissingLangItem, MissingPanicHandler, PanicUnwindWithoutStd,
 };
 use crate::lang_items::extract_ast;
 
@@ -28,27 +28,23 @@ pub(crate) fn check_crate(
         items.missing.push(LangItem::EhPersonality);
     }
 
-    visit::Visitor::visit_crate(&mut WeakLangItemVisitor { tcx, items }, krate);
+    visit::Visitor::visit_crate(&mut WeakLangItemVisitor { items }, krate);
 
     verify(tcx, items);
 }
 
-struct WeakLangItemVisitor<'a, 'tcx> {
-    tcx: TyCtxt<'tcx>,
+struct WeakLangItemVisitor<'a> {
     items: &'a mut lang_items::LanguageItems,
 }
 
-impl<'ast> visit::Visitor<'ast> for WeakLangItemVisitor<'_, '_> {
+impl<'ast> visit::Visitor<'ast> for WeakLangItemVisitor<'_> {
     fn visit_foreign_item(&mut self, i: &'ast ast::ForeignItem) {
-        if let Some((lang_item, _)) = extract_ast(&i.attrs) {
-            if let Some(item) = LangItem::from_name(lang_item)
-                && item.is_weak()
-            {
-                if self.items.get(item).is_none() {
-                    self.items.missing.push(item);
-                }
-            } else {
-                self.tcx.dcx().emit_err(UnknownExternLangItem { span: i.span, lang_item });
+        if let Some((lang_item, _)) = extract_ast(&i.attrs)
+            && let Some(item) = LangItem::from_name(lang_item)
+            && item.is_weak()
+        {
+            if self.items.get(item).is_none() {
+                self.items.missing.push(item);
             }
         }
     }

--- a/compiler/rustc_passes/src/weak_lang_items.rs
+++ b/compiler/rustc_passes/src/weak_lang_items.rs
@@ -9,9 +9,7 @@ use rustc_middle::middle::lang_items::required;
 use rustc_middle::ty::TyCtxt;
 use rustc_session::config::CrateType;
 
-use crate::diagnostics::{
-    MissingLangItem, MissingPanicHandler, PanicUnwindWithoutStd,
-};
+use crate::diagnostics::{MissingLangItem, MissingPanicHandler, PanicUnwindWithoutStd};
 use crate::lang_items::extract_ast;
 
 /// Checks the crate for usage of weak lang items, returning a vector of all the

--- a/tests/ui/error-codes/E0264.rs
+++ b/tests/ui/error-codes/E0264.rs
@@ -1,8 +1,8 @@
 #![feature(lang_items)]
 
 extern "C" {
-    #[lang = "copy"]
-    fn copy(); //~ ERROR E0264
+    #[lang = "copy"] //~ ERROR E0264
+    fn copy();
 }
 
 fn main() {}

--- a/tests/ui/error-codes/E0264.stderr
+++ b/tests/ui/error-codes/E0264.stderr
@@ -1,8 +1,8 @@
 error[E0264]: unknown external lang item: `copy`
-  --> $DIR/E0264.rs:5:5
+  --> $DIR/E0264.rs:4:5
    |
-LL |     fn copy();
-   |     ^^^^^^^^^^
+LL |     #[lang = "copy"]
+   |     ^^^^^^^^^^^^^^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/error-codes/E0718.rs
+++ b/tests/ui/error-codes/E0718.rs
@@ -1,7 +1,7 @@
 #![feature(lang_items)]
 
 // Box is expected to be a struct, so this will error.
-#[lang = "owned_box"] //~ ERROR lang item must be applied to a struct
+#[lang = "owned_box"] //~ ERROR `#[lang = "owned_box"]` attribute cannot be used on statics
 static X: u32 = 42;
 
 fn main() {}

--- a/tests/ui/error-codes/E0718.stderr
+++ b/tests/ui/error-codes/E0718.stderr
@@ -1,9 +1,10 @@
-error[E0718]: `owned_box` lang item must be applied to a struct
+error: `#[lang = "owned_box"]` attribute cannot be used on statics
   --> $DIR/E0718.rs:4:1
    |
 LL | #[lang = "owned_box"]
-   | ^^^^^^^^^^^^^^^^^^^^^ attribute should be applied to a struct, not a static
+   | ^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[lang = "owned_box"]` can only be applied to structs
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0718`.

--- a/tests/ui/panic-handler/panic-handler-wrong-location.rs
+++ b/tests/ui/panic-handler/panic-handler-wrong-location.rs
@@ -3,7 +3,7 @@
 #![no_std]
 #![no_main]
 
-#[panic_handler] //~ ERROR `panic_impl` lang item must be applied to a function
+#[panic_handler] //~ ERROR attribute cannot be used on statics
 static X: u32 = 42;
 
 //~? ERROR `#[panic_handler]` function required, but not found

--- a/tests/ui/panic-handler/panic-handler-wrong-location.stderr
+++ b/tests/ui/panic-handler/panic-handler-wrong-location.stderr
@@ -1,11 +1,12 @@
-error[E0718]: `panic_impl` lang item must be applied to a function
+error: `#[panic_handler]` function required, but not found
+
+error: `#[panic_handler]` attribute cannot be used on statics
   --> $DIR/panic-handler-wrong-location.rs:6:1
    |
 LL | #[panic_handler]
-   | ^^^^^^^^^^^^^^^^ attribute should be applied to a function, not a static
-
-error: `#[panic_handler]` function required, but not found
+   | ^^^^^^^^^^^^^^^^
+   |
+   = help: `#[panic_handler]` can only be applied to functions
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0718`.


### PR DESCRIPTION
Work towards removing the `ALL_TARGETS` list.

r? @mejrs 