### PR TITLE
Include `Item::stability` info in rustdoc JSON.

### DIFF
--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -75,6 +75,7 @@ impl JsonRenderer<'_> {
             name: name.map(|sym| sym.to_string()),
             span: span.and_then(|span| span.into_json(self)),
             visibility: visibility.into_json(self),
+            stability: item.stability(self.tcx).into_json(self),
             docs,
             attrs,
             deprecation: deprecation.into_json(self),
@@ -200,6 +201,18 @@ impl FromClean<attrs::Deprecation> for Deprecation {
             DeprecatedSince::Unspecified | DeprecatedSince::Err => None,
         };
         Deprecation { since, note: note.map(|sym| sym.to_string()) }
+    }
+}
+
+impl FromClean<hir::Stability> for Stability {
+    fn from_clean(stab: &hir::Stability, _renderer: &JsonRenderer<'_>) -> Self {
+        Stability {
+            feature: stab.feature.to_string(),
+            level: match stab.level {
+                hir::StabilityLevel::Unstable { .. } => StabilityLevel::Unstable,
+                hir::StabilityLevel::Stable { .. } => StabilityLevel::Stable,
+            },
+        }
     }
 }
 
@@ -922,6 +935,8 @@ fn maybe_from_hir_attr(attr: &hir::Attribute, item_id: ItemId, tcx: TyCtxt<'_>) 
 
     vec![match kind {
         AK::Deprecated { .. } => return Vec::new(), // Handled separately into Item::deprecation.
+        AK::Stability { .. } => return Vec::new(),  // Handled separately into Item::stability
+
         AK::DocComment { .. } => unreachable!("doc comments stripped out earlier"),
 
         AK::MacroExport { .. } => Attribute::MacroExport,

--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -69,13 +69,37 @@ impl JsonRenderer<'_> {
             }
             _ => from_clean_item(item, self),
         };
+
+        // Rustdoc JSON keeps re-exports as `Use` items, so their stability describes
+        // the local `pub use` declaration. The imported target item's stability
+        // remains available through `inner.use.id`.
+        //
+        // We use raw stability attributes here instead of `clean::Item::stability()`,
+        // which is the effective stability rustdoc uses for rendering paths.
+        // For example, a stable `pub use` inside an unstable module is effectively unstable
+        // through that module path, but the `Use` declaration itself is still stable.
+        // In that example, `clean::Item::stability()` would return "unstable" as
+        // the effective stability, which is appropriate for HTML but makes JSON uses harder.
+        //
+        // JSON consumers already have to do path-based reasoning to reconstruct item reachability,
+        // names, and stability. Keeping component-wise stability allows them to easily reconstruct
+        // stability from the module, use item, and target item records.
+        let stability_def_id = if matches!(&item.kind, clean::ImportItem(_)) {
+            item.inline_stmt_id
+                .map(|def_id| def_id.to_def_id())
+                .or_else(|| item.item_id.as_def_id())
+        } else {
+            item.item_id.as_def_id()
+        };
+        let stability = stability_def_id.and_then(|def_id| self.tcx.lookup_stability(def_id));
+
         Some(Item {
             id,
             crate_id: item_id.krate().as_u32(),
             name: name.map(|sym| sym.to_string()),
             span: span.and_then(|span| span.into_json(self)),
             visibility: visibility.into_json(self),
-            stability: item.stability(self.tcx).into_json(self),
+            stability: stability.map(|s| Box::new(s.into_json(self))),
             docs,
             attrs,
             deprecation: deprecation.into_json(self),
@@ -206,13 +230,19 @@ impl FromClean<attrs::Deprecation> for Deprecation {
 
 impl FromClean<hir::Stability> for Stability {
     fn from_clean(stab: &hir::Stability, _renderer: &JsonRenderer<'_>) -> Self {
-        Stability {
-            feature: stab.feature.to_string(),
-            level: match stab.level {
-                hir::StabilityLevel::Unstable { .. } => StabilityLevel::Unstable,
-                hir::StabilityLevel::Stable { .. } => StabilityLevel::Stable,
+        let feature = stab.feature.to_string();
+        let level = match stab.level {
+            hir::StabilityLevel::Stable { since, .. } => StabilityLevel::Stable {
+                since: match since {
+                    hir::StableSince::Version(since) => Some(since.to_string()),
+                    hir::StableSince::Current => Some(hir::RustcVersion::CURRENT.to_string()),
+                    // Match rustdoc HTML: malformed stable-since values are omitted.
+                    hir::StableSince::Err(_) => None,
+                },
             },
-        }
+            hir::StabilityLevel::Unstable { .. } => StabilityLevel::Unstable,
+        };
+        Stability { feature, level }
     }
 }
 

--- a/src/librustdoc/json/mod.rs
+++ b/src/librustdoc/json/mod.rs
@@ -361,6 +361,6 @@ mod size_asserts {
     // tidy-alphabetical-end
 
     // These contains a `PathBuf`, which is different sizes on different OSes.
-    static_assert_size!(Item, 560 + size_of::<std::path::PathBuf>());
+    static_assert_size!(Item, 536 + size_of::<std::path::PathBuf>());
     static_assert_size!(ExternalCrate, 48 + size_of::<std::path::PathBuf>());
 }

--- a/src/librustdoc/json/mod.rs
+++ b/src/librustdoc/json/mod.rs
@@ -361,6 +361,6 @@ mod size_asserts {
     // tidy-alphabetical-end
 
     // These contains a `PathBuf`, which is different sizes on different OSes.
-    static_assert_size!(Item, 528 + size_of::<std::path::PathBuf>());
+    static_assert_size!(Item, 560 + size_of::<std::path::PathBuf>());
     static_assert_size!(ExternalCrate, 48 + size_of::<std::path::PathBuf>());
 }

--- a/src/rustdoc-json-types/lib.rs
+++ b/src/rustdoc-json-types/lib.rs
@@ -114,8 +114,8 @@ pub type FxHashMap<K, V> = HashMap<K, V>; // re-export for use in src/librustdoc
 // will instead cause conflicts. See #94591 for more. (This paragraph and the "Latest feature" line
 // are deliberately not in a doc comment, because they need not be in public docs.)
 //
-// Latest feature: Add `ExternCrate::path`.
-pub const FORMAT_VERSION: u32 = 57;
+// Latest feature: Add `Item::stability`.
+pub const FORMAT_VERSION: u32 = 58;
 
 /// The root of the emitted JSON blob.
 ///
@@ -294,8 +294,28 @@ pub struct Item {
     pub attrs: Vec<Attribute>,
     /// Information about the item’s deprecation, if present.
     pub deprecation: Option<Deprecation>,
+
+    pub stability: Option<Stability>,
+
     /// The type-specific fields describing this item.
     pub inner: ItemEnum,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "rkyv_0_8", derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize))]
+#[cfg_attr(feature = "rkyv_0_8", rkyv(derive(Debug)))]
+pub struct Stability {
+    pub feature: String,
+    pub level: StabilityLevel,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "rkyv_0_8", derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize))]
+#[cfg_attr(feature = "rkyv_0_8", rkyv(derive(Debug)))]
+#[serde(rename_all = "snake_case")]
+pub enum StabilityLevel {
+    Stable,
+    Unstable,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/rustdoc-json-types/lib.rs
+++ b/src/rustdoc-json-types/lib.rs
@@ -282,7 +282,10 @@ pub struct Item {
     pub links: HashMap<String, Id>,
     /// Attributes on this item.
     ///
-    /// Does not include `#[deprecated]` attributes: see the [`Self::deprecation`] field instead.
+    /// Does not include:
+    /// - `#[doc = "Doc Comment"]` or `/// Doc comment`: see [`Self::docs`] instead.
+    /// - `#[deprecated]` attributes: see the [`Self::deprecation`] field instead.
+    /// - `#[stable]` and `#[unstable]` attributes: see the [`Self::stability`] field instead.
     ///
     /// Attributes appear in pretty-printed Rust form, regardless of their formatting
     /// in the original source code. For example:
@@ -295,26 +298,60 @@ pub struct Item {
     /// Information about the item’s deprecation, if present.
     pub deprecation: Option<Deprecation>,
 
-    pub stability: Option<Stability>,
+    /// Stability information for this item, if any.
+    ///
+    /// This describes whether the item itself is stable or unstable, as noted by a `#[stable]` or
+    /// `#[unstable]` attribute. It does not capture const stability, default-body stability, etc.
+    ///
+    /// Whether a path to an item is stable depends on the stability of containing modules
+    /// or re-exports along that path. For example, a stable item can be reachable through both an
+    /// unstable module and a stable re-export.
+    ///
+    /// For items whose inner kind is [`ItemEnum::Use`], this is the stability of the import itself,
+    /// not the item being imported. This allows users to determine the stability of paths
+    /// that involve re-exports.
+    ///
+    /// Associated items can inherit instability from their enclosing unstable trait or impl.
+    /// Unannotated associated items in stable traits or impls may have no separate stability value.
+    ///
+    /// Currently, Rust's `#[stable]` and `#[unstable]` attributes are themselves not stable.
+    /// As a result, this field is primarily populated for standard-library items;
+    /// most ordinary third-party crates usually have no data here.
+    pub stability: Option<Box<Stability>>,
 
     /// The type-specific fields describing this item.
     pub inner: ItemEnum,
 }
 
+/// Stability information for an item.
+///
+/// This only refers to regular item stability: whether the item is stable or unstable
+/// as represented by the `#[stable]` or `#[unstable]` attributes.
+/// Const stability and default-body stability are different things and not captured here.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "rkyv_0_8", derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize))]
 #[cfg_attr(feature = "rkyv_0_8", rkyv(derive(Debug)))]
 pub struct Stability {
+    /// The stability feature associated with this item.
+    ///
+    /// For unstable items, this is the feature gate associated with the item.
+    /// For stable items, this is the historical label recorded when the item was stabilized.
     pub feature: String,
+
+    #[serde(flatten)]
     pub level: StabilityLevel,
 }
 
+/// Whether an item is stable or unstable as regular public API.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "rkyv_0_8", derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize))]
 #[cfg_attr(feature = "rkyv_0_8", rkyv(derive(Debug)))]
-#[serde(rename_all = "snake_case")]
+#[serde(tag = "level", rename_all = "snake_case")]
 pub enum StabilityLevel {
-    Stable,
+    Stable {
+        /// The Rust version in which this item became stable, if available.
+        since: Option<String>,
+    },
     Unstable,
 }
 
@@ -327,6 +364,7 @@ pub enum StabilityLevel {
 /// This doesn't include:
 /// - `#[doc = "Doc Comment"]` or `/// Doc comment`. These are in [`Item::docs`] instead.
 /// - `#[deprecated]`. These are in [`Item::deprecation`] instead.
+/// - `#[stable]` and `#[unstable]`. These are in [`Item::stability`] instead.
 pub enum Attribute {
     /// `#[non_exhaustive]`
     NonExhaustive,

--- a/src/tools/jsondoclint/src/validator/tests.rs
+++ b/src/tools/jsondoclint/src/validator/tests.rs
@@ -33,6 +33,7 @@ fn errors_on_missing_links() {
                 links: FxHashMap::from_iter([("Not Found".to_owned(), Id(1))]),
                 attrs: vec![],
                 deprecation: None,
+                stability: None,
                 inner: ItemEnum::Module(Module {
                     is_crate: true,
                     items: vec![],
@@ -81,6 +82,7 @@ fn errors_on_local_in_paths_and_not_index() {
                     links: FxHashMap::from_iter([("prim@i32".to_owned(), Id(2))]),
                     attrs: Vec::new(),
                     deprecation: None,
+                    stability: None,
                     inner: ItemEnum::Module(Module {
                         is_crate: true,
                         items: vec![Id(1)],
@@ -100,6 +102,7 @@ fn errors_on_local_in_paths_and_not_index() {
                     links: FxHashMap::default(),
                     attrs: Vec::new(),
                     deprecation: None,
+                    stability: None,
                     inner: ItemEnum::Primitive(Primitive { name: "i32".to_owned(), impls: vec![] }),
                 },
             ),
@@ -153,6 +156,7 @@ fn errors_on_missing_path() {
                     links: FxHashMap::default(),
                     attrs: Vec::new(),
                     deprecation: None,
+                    stability: None,
                     inner: ItemEnum::Module(Module {
                         is_crate: true,
                         items: vec![Id(1), Id(2)],
@@ -172,6 +176,7 @@ fn errors_on_missing_path() {
                     links: FxHashMap::default(),
                     attrs: Vec::new(),
                     deprecation: None,
+                    stability: None,
                     inner: ItemEnum::Struct(Struct {
                         kind: StructKind::Unit,
                         generics: generics.clone(),
@@ -191,6 +196,7 @@ fn errors_on_missing_path() {
                     links: FxHashMap::default(),
                     attrs: Vec::new(),
                     deprecation: None,
+                    stability: None,
                     inner: ItemEnum::Function(Function {
                         sig: FunctionSignature {
                             inputs: vec![],
@@ -253,6 +259,7 @@ fn checks_local_crate_id_is_correct() {
                 links: FxHashMap::default(),
                 attrs: Vec::new(),
                 deprecation: None,
+                stability: None,
                 inner: ItemEnum::Module(Module {
                     is_crate: true,
                     items: vec![],

--- a/tests/rustdoc-json/attrs/stability/associated_items.rs
+++ b/tests/rustdoc-json/attrs/stability/associated_items.rs
@@ -1,0 +1,66 @@
+#![feature(staged_api)]
+
+// Trait-associated item declarations only. Items defined inside impl blocks are tested in
+// `impls.rs` because they have different parent-item behavior.
+
+//@ is "$.index[?(@.name=='StableTraitWithAssociatedItems')].stability.level" '"stable"'
+//@ is "$.index[?(@.name=='StableTraitWithAssociatedItems')].stability.feature" '"stable_trait_with_associated_items"'
+//@ is "$.index[?(@.name=='StableTraitWithAssociatedItems')].stability.since" '"1.0.0"'
+#[stable(feature = "stable_trait_with_associated_items", since = "1.0.0")]
+pub trait StableTraitWithAssociatedItems {
+    // Stable trait-associated items need their own stability attributes in staged API crates.
+    //@ is "$.index[?(@.name=='StableAssocType')].stability.level" '"stable"'
+    //@ is "$.index[?(@.name=='StableAssocType')].stability.feature" '"stable_assoc_type_feature"'
+    //@ is "$.index[?(@.name=='StableAssocType')].stability.since" '"1.1.0"'
+    //@ is "$.index[?(@.name=='StableAssocType')].attrs" []
+    #[stable(feature = "stable_assoc_type_feature", since = "1.1.0")]
+    type StableAssocType;
+
+    //@ is "$.index[?(@.name=='UNSTABLE_ASSOC_CONST_IN_STABLE_TRAIT')].stability.level" '"unstable"'
+    //@ is "$.index[?(@.name=='UNSTABLE_ASSOC_CONST_IN_STABLE_TRAIT')].stability.feature" '"unstable_assoc_const_in_stable_trait"'
+    //@ !has "$.index[?(@.name=='UNSTABLE_ASSOC_CONST_IN_STABLE_TRAIT')].stability.since"
+    #[unstable(feature = "unstable_assoc_const_in_stable_trait", issue = "none")]
+    const UNSTABLE_ASSOC_CONST_IN_STABLE_TRAIT: usize = 0;
+
+    //@ is "$.index[?(@.name=='unstable_provided_method')].stability.level" '"unstable"'
+    //@ is "$.index[?(@.name=='unstable_provided_method')].stability.feature" '"unstable_provided_method_feature"'
+    //@ !has "$.index[?(@.name=='unstable_provided_method')].stability.since"
+    #[unstable(feature = "unstable_provided_method_feature", issue = "none")]
+    fn unstable_provided_method(&self) {}
+}
+
+//@ is "$.index[?(@.name=='UnstableTraitWithUnannotatedAssociatedItems')].stability.level" '"unstable"'
+//@ is "$.index[?(@.name=='UnstableTraitWithUnannotatedAssociatedItems')].stability.feature" '"unstable_trait_with_unannotated_associated_items"'
+//@ !has "$.index[?(@.name=='UnstableTraitWithUnannotatedAssociatedItems')].stability.since"
+#[unstable(feature = "unstable_trait_with_unannotated_associated_items", issue = "none")]
+pub trait UnstableTraitWithUnannotatedAssociatedItems {
+    // Unannotated associated items in unstable traits inherit the trait's unstable stability.
+    //@ is "$.index[?(@.name=='UnannotatedAssocTypeInUnstableTrait')].stability.level" '"unstable"'
+    //@ is "$.index[?(@.name=='UnannotatedAssocTypeInUnstableTrait')].stability.feature" '"unstable_trait_with_unannotated_associated_items"'
+    //@ !has "$.index[?(@.name=='UnannotatedAssocTypeInUnstableTrait')].stability.since"
+    type UnannotatedAssocTypeInUnstableTrait;
+
+    //@ is "$.index[?(@.name=='UNANNOTATED_ASSOC_CONST_IN_UNSTABLE_TRAIT')].stability.level" '"unstable"'
+    //@ is "$.index[?(@.name=='UNANNOTATED_ASSOC_CONST_IN_UNSTABLE_TRAIT')].stability.feature" '"unstable_trait_with_unannotated_associated_items"'
+    //@ !has "$.index[?(@.name=='UNANNOTATED_ASSOC_CONST_IN_UNSTABLE_TRAIT')].stability.since"
+    const UNANNOTATED_ASSOC_CONST_IN_UNSTABLE_TRAIT: usize;
+
+    //@ is "$.index[?(@.name=='unannotated_required_method_in_unstable_trait')].stability.level" '"unstable"'
+    //@ is "$.index[?(@.name=='unannotated_required_method_in_unstable_trait')].stability.feature" '"unstable_trait_with_unannotated_associated_items"'
+    //@ !has "$.index[?(@.name=='unannotated_required_method_in_unstable_trait')].stability.since"
+    fn unannotated_required_method_in_unstable_trait(&self);
+}
+
+//@ is "$.index[?(@.name=='UnstableTraitWithExplicitAssociatedItem')].stability.level" '"unstable"'
+//@ is "$.index[?(@.name=='UnstableTraitWithExplicitAssociatedItem')].stability.feature" '"unstable_trait_with_explicit_associated_item"'
+//@ !has "$.index[?(@.name=='UnstableTraitWithExplicitAssociatedItem')].stability.since"
+#[unstable(feature = "unstable_trait_with_explicit_associated_item", issue = "none")]
+pub trait UnstableTraitWithExplicitAssociatedItem {
+    // It's possble to override the parent's instability with another `#[unstable]` attribute,
+    // for example to specify a different feature gate for that item.
+    //@ is "$.index[?(@.name=='UnstableAssocTypeInUnstableTrait')].stability.level" '"unstable"'
+    //@ is "$.index[?(@.name=='UnstableAssocTypeInUnstableTrait')].stability.feature" '"unstable_assoc_type_in_unstable_trait"'
+    //@ !has "$.index[?(@.name=='UnstableAssocTypeInUnstableTrait')].stability.since"
+    #[unstable(feature = "unstable_assoc_type_in_unstable_trait", issue = "none")]
+    type UnstableAssocTypeInUnstableTrait;
+}

--- a/tests/rustdoc-json/attrs/stability/impls.rs
+++ b/tests/rustdoc-json/attrs/stability/impls.rs
@@ -1,0 +1,136 @@
+#![feature(staged_api)]
+
+// Impl blocks and items defined inside impl blocks only. Trait-associated item declarations are
+// tested in `associated_items.rs`; any trait items below are scaffolding for impl-item assertions.
+// Staged API still requires stability attributes on stable trait items even when the assertions
+// below focus on the corresponding impl items.
+
+#[stable(feature = "stable_impl_target", since = "1.0.0")]
+pub struct StableImplTarget;
+
+#[stable(feature = "stable_trait_for_impl", since = "1.0.0")]
+pub trait StableTraitForImpl {
+    #[stable(feature = "stable_trait_output", since = "1.0.0")]
+    type StableOutput;
+
+    #[stable(feature = "stable_trait_assoc_const", since = "1.0.0")]
+    const STABLE_ASSOC_CONST: usize;
+
+    #[stable(feature = "stable_trait_method", since = "1.0.0")]
+    fn stable_trait_method(&self);
+}
+
+#[stable(feature = "stable_trait_with_unstable_method_for_impl", since = "1.0.0")]
+pub trait StableTraitWithUnstableMethodForImpl {
+    #[unstable(feature = "unstable_trait_method_for_stable_impl", issue = "none")]
+    fn unstable_trait_method_for_stable_impl(&self);
+}
+
+#[unstable(feature = "unstable_trait_for_impl", issue = "none")]
+pub trait UnstableTraitForImpl {
+    type UnstableOutput;
+    const UNSTABLE_ASSOC_CONST: usize;
+    fn unstable_trait_method(&self);
+}
+
+//@ is "$.index[?(@.docs=='stable inherent impl')].stability.level" '"stable"'
+//@ is "$.index[?(@.docs=='stable inherent impl')].stability.feature" '"stable_inherent_impl"'
+//@ is "$.index[?(@.docs=='stable inherent impl')].stability.since" '"2.0.0"'
+/// stable inherent impl
+#[stable(feature = "stable_inherent_impl", since = "2.0.0")]
+impl StableImplTarget {
+    //@ is "$.index[?(@.name=='stable_inherent_method')].stability.level" '"stable"'
+    //@ is "$.index[?(@.name=='stable_inherent_method')].stability.feature" '"stable_inherent_method_feature"'
+    //@ is "$.index[?(@.name=='stable_inherent_method')].stability.since" '"2.1.0"'
+    //@ is "$.index[?(@.name=='stable_inherent_method')].attrs" []
+    #[stable(feature = "stable_inherent_method_feature", since = "2.1.0")]
+    pub fn stable_inherent_method(&self) {}
+
+    //@ is "$.index[?(@.name=='UNSTABLE_ASSOC_CONST_IN_IMPL')].stability.level" '"unstable"'
+    //@ is "$.index[?(@.name=='UNSTABLE_ASSOC_CONST_IN_IMPL')].stability.feature" '"unstable_assoc_const_in_impl_feature"'
+    //@ !has "$.index[?(@.name=='UNSTABLE_ASSOC_CONST_IN_IMPL')].stability.since"
+    #[unstable(feature = "unstable_assoc_const_in_impl_feature", issue = "none")]
+    pub const UNSTABLE_ASSOC_CONST_IN_IMPL: usize = 2;
+}
+
+//@ is "$.index[?(@.docs=='unstable inherent impl')].stability.level" '"unstable"'
+//@ is "$.index[?(@.docs=='unstable inherent impl')].stability.feature" '"unstable_inherent_impl"'
+//@ !has "$.index[?(@.docs=='unstable inherent impl')].stability.since"
+/// unstable inherent impl
+#[unstable(feature = "unstable_inherent_impl", issue = "none")]
+impl StableImplTarget {
+    // The instability of the inherent `impl` block is inherited by the item.
+    //@ is "$.index[?(@.name=='method_inside_unstable_inherent_impl')].stability.level" '"unstable"'
+    //@ is "$.index[?(@.name=='method_inside_unstable_inherent_impl')].stability.feature" '"unstable_inherent_impl"'
+    //@ !has "$.index[?(@.name=='method_inside_unstable_inherent_impl')].stability.since"
+    pub fn method_inside_unstable_inherent_impl(&self) {}
+}
+
+// For trait impl items, `stability: null` means the implementation item has no separate
+// stability attribute of its own. To decide whether the implemented method/type/const is usable,
+// consumers need to combine the trait item stability with the impl block stability.
+//
+// The stable impl below intentionally does not copy either stable or unstable trait-item
+// stability onto the implemented item. The unstable impl case is different: rustc records the
+// impl block's instability on contained impl items, so JSON exposes that inherited instability.
+
+//@ is "$.index[?(@.docs=='stable trait impl with unstable trait method')].stability.level" '"stable"'
+//@ is "$.index[?(@.docs=='stable trait impl with unstable trait method')].stability.feature" '"stable_trait_impl_with_unstable_trait_method"'
+//@ is "$.index[?(@.docs=='stable trait impl with unstable trait method')].stability.since" '"3.0.0"'
+/// stable trait impl with unstable trait method
+#[stable(feature = "stable_trait_impl_with_unstable_trait_method", since = "3.0.0")]
+impl StableTraitWithUnstableMethodForImpl for StableImplTarget {
+    // The impl item has no separate stability record; the trait method is unstable.
+    //@ is "$.index[?(@.docs=='method for unstable trait item inside stable trait impl')].stability" null
+    /// method for unstable trait item inside stable trait impl
+    fn unstable_trait_method_for_stable_impl(&self) {}
+}
+
+//@ is "$.index[?(@.docs=='stable trait impl')].stability.level" '"stable"'
+//@ is "$.index[?(@.docs=='stable trait impl')].stability.feature" '"stable_trait_impl"'
+//@ is "$.index[?(@.docs=='stable trait impl')].stability.since" '"3.0.0"'
+/// stable trait impl
+#[stable(feature = "stable_trait_impl", since = "3.0.0")]
+impl StableTraitForImpl for StableImplTarget {
+    // These impl items likewise have no separate stability records.
+    // Their trait item declarations and the impl block are all stable.
+
+    //@ is "$.index[?(@.docs=='assoc type inside stable trait impl')].stability" null
+    /// assoc type inside stable trait impl
+    type StableOutput = usize;
+
+    //@ is "$.index[?(@.docs=='assoc const inside stable trait impl')].stability" null
+    /// assoc const inside stable trait impl
+    const STABLE_ASSOC_CONST: usize = 0;
+
+    //@ is "$.index[?(@.docs=='method inside stable trait impl')].stability" null
+    /// method inside stable trait impl
+    fn stable_trait_method(&self) {}
+}
+
+//@ is "$.index[?(@.docs=='unstable trait impl')].stability.level" '"unstable"'
+//@ is "$.index[?(@.docs=='unstable trait impl')].stability.feature" '"unstable_trait_impl"'
+//@ !has "$.index[?(@.docs=='unstable trait impl')].stability.since"
+/// unstable trait impl
+#[unstable(feature = "unstable_trait_impl", issue = "none")]
+impl UnstableTraitForImpl for StableImplTarget {
+    // These associated items inherit the impl block's instability in rustdoc JSON.
+
+    //@ is "$.index[?(@.docs=='assoc type inside unstable trait impl')].stability.level" '"unstable"'
+    //@ is "$.index[?(@.docs=='assoc type inside unstable trait impl')].stability.feature" '"unstable_trait_impl"'
+    //@ !has "$.index[?(@.docs=='assoc type inside unstable trait impl')].stability.since"
+    /// assoc type inside unstable trait impl
+    type UnstableOutput = usize;
+
+    //@ is "$.index[?(@.docs=='assoc const inside unstable trait impl')].stability.level" '"unstable"'
+    //@ is "$.index[?(@.docs=='assoc const inside unstable trait impl')].stability.feature" '"unstable_trait_impl"'
+    //@ !has "$.index[?(@.docs=='assoc const inside unstable trait impl')].stability.since"
+    /// assoc const inside unstable trait impl
+    const UNSTABLE_ASSOC_CONST: usize = 0;
+
+    //@ is "$.index[?(@.docs=='method inside unstable trait impl')].stability.level" '"unstable"'
+    //@ is "$.index[?(@.docs=='method inside unstable trait impl')].stability.feature" '"unstable_trait_impl"'
+    //@ !has "$.index[?(@.docs=='method inside unstable trait impl')].stability.since"
+    /// method inside unstable trait impl
+    fn unstable_trait_method(&self) {}
+}

--- a/tests/rustdoc-json/attrs/stability/item_kinds.rs
+++ b/tests/rustdoc-json/attrs/stability/item_kinds.rs
@@ -1,0 +1,46 @@
+#![feature(staged_api)]
+
+// Mirrors standard-library stability on item kinds that are distinct from ordinary functions,
+// modules, structs, enums, traits, and impls.
+
+//@ is "$.index[?(@.name=='STABLE_CONST')].stability.level" '"stable"'
+//@ is "$.index[?(@.name=='STABLE_CONST')].stability.feature" '"stable_const_feature"'
+//@ is "$.index[?(@.name=='STABLE_CONST')].stability.since" '"1.0.0"'
+#[stable(feature = "stable_const_feature", since = "1.0.0")]
+pub const STABLE_CONST: usize = 0;
+
+//@ is "$.index[?(@.name=='UNSTABLE_STATIC')].stability.level" '"unstable"'
+//@ is "$.index[?(@.name=='UNSTABLE_STATIC')].stability.feature" '"unstable_static_feature"'
+//@ !has "$.index[?(@.name=='UNSTABLE_STATIC')].stability.since"
+#[unstable(feature = "unstable_static_feature", issue = "none")]
+pub static UNSTABLE_STATIC: usize = 0;
+
+//@ is "$.index[?(@.name=='StableTypeAlias')].stability.level" '"stable"'
+//@ is "$.index[?(@.name=='StableTypeAlias')].stability.feature" '"stable_type_alias_feature"'
+//@ is "$.index[?(@.name=='StableTypeAlias')].stability.since" '"1.1.0"'
+#[stable(feature = "stable_type_alias_feature", since = "1.1.0")]
+pub type StableTypeAlias = usize;
+
+//@ is "$.index[?(@.name=='StableUnion')].stability.level" '"stable"'
+//@ is "$.index[?(@.name=='StableUnion')].stability.feature" '"stable_union_feature"'
+//@ is "$.index[?(@.name=='StableUnion')].stability.since" '"1.3.0"'
+#[stable(feature = "stable_union_feature", since = "1.3.0")]
+pub union StableUnion {
+    storage: usize,
+}
+
+//@ is "$.index[?(@.inner.extern_crate.name=='stable_extern_crate_self')].stability.level" '"stable"'
+//@ is "$.index[?(@.inner.extern_crate.name=='stable_extern_crate_self')].stability.feature" '"stable_extern_crate_feature"'
+//@ is "$.index[?(@.inner.extern_crate.name=='stable_extern_crate_self')].stability.since" '"1.4.0"'
+#[stable(feature = "stable_extern_crate_feature", since = "1.4.0")]
+pub extern crate self as stable_extern_crate_self;
+
+//@ is "$.index[?(@.name=='unstable_macro_rules')].stability.level" '"unstable"'
+//@ is "$.index[?(@.name=='unstable_macro_rules')].stability.feature" '"unstable_macro_rules_feature"'
+//@ !has "$.index[?(@.name=='unstable_macro_rules')].stability.since"
+//@ is "$.index[?(@.name=='unstable_macro_rules')].attrs" '["macro_export"]'
+#[unstable(feature = "unstable_macro_rules_feature", issue = "none")]
+#[macro_export]
+macro_rules! unstable_macro_rules {
+    () => {};
+}

--- a/tests/rustdoc-json/attrs/stability/members.rs
+++ b/tests/rustdoc-json/attrs/stability/members.rs
@@ -1,0 +1,72 @@
+#![feature(staged_api)]
+
+// Mirrors standard-library cases where stable parent items have unstable variants or fields.
+
+#[stable(feature = "stable_enum_feature", since = "1.0.0")]
+pub enum StableEnumWithUnstableVariant {
+    StableVariant,
+
+    //@ is "$.index[?(@.name=='UnstableVariant')].stability.level" '"unstable"'
+    //@ is "$.index[?(@.name=='UnstableVariant')].stability.feature" '"unstable_variant_feature"'
+    //@ !has "$.index[?(@.name=='UnstableVariant')].stability.since"
+    #[unstable(feature = "unstable_variant_feature", issue = "none")]
+    UnstableVariant,
+}
+
+#[stable(feature = "stable_struct_feature", since = "2.0.0")]
+pub struct StableStructWithUnstableField {
+    pub stable_field: usize,
+
+    //@ is "$.index[?(@.name=='unstable_field')].stability.level" '"unstable"'
+    //@ is "$.index[?(@.name=='unstable_field')].stability.feature" '"unstable_field_feature"'
+    //@ !has "$.index[?(@.name=='unstable_field')].stability.since"
+    #[unstable(feature = "unstable_field_feature", issue = "none")]
+    pub unstable_field: usize,
+}
+
+#[stable(feature = "stable_union_with_unstable_field", since = "2.5.0")]
+pub union StableUnionWithUnstableField {
+    pub stable_union_field: usize,
+
+    //@ is "$.index[?(@.name=='unstable_union_field')].stability.level" '"unstable"'
+    //@ is "$.index[?(@.name=='unstable_union_field')].stability.feature" '"unstable_union_field_feature"'
+    //@ !has "$.index[?(@.name=='unstable_union_field')].stability.since"
+    #[unstable(feature = "unstable_union_field_feature", issue = "none")]
+    pub unstable_union_field: usize,
+}
+
+#[stable(feature = "stable_tuple_struct_feature", since = "3.0.0")]
+pub struct StableTupleStructWithUnstableField(
+    pub usize,
+    //@ is "$.index[?(@.docs=='unstable tuple struct field')].stability.level" '"unstable"'
+    //@ is "$.index[?(@.docs=='unstable tuple struct field')].stability.feature" '"unstable_tuple_struct_field_feature"'
+    //@ !has "$.index[?(@.docs=='unstable tuple struct field')].stability.since"
+    /// unstable tuple struct field
+    #[unstable(feature = "unstable_tuple_struct_field_feature", issue = "none")]
+    pub usize,
+);
+
+#[stable(feature = "stable_enum_field_variants_feature", since = "4.0.0")]
+pub enum StableEnumWithFieldVariants {
+    #[stable(feature = "stable_tuple_variant_feature", since = "4.1.0")]
+    TupleVariant(
+        usize,
+        //@ is "$.index[?(@.docs=='unstable tuple variant field')].stability.level" '"unstable"'
+        //@ is "$.index[?(@.docs=='unstable tuple variant field')].stability.feature" '"unstable_tuple_variant_field_feature"'
+        //@ !has "$.index[?(@.docs=='unstable tuple variant field')].stability.since"
+        /// unstable tuple variant field
+        #[unstable(feature = "unstable_tuple_variant_field_feature", issue = "none")]
+        usize,
+    ),
+
+    #[stable(feature = "stable_struct_variant_feature", since = "4.3.0")]
+    StructVariant {
+        stable_struct_variant_field: usize,
+
+        //@ is "$.index[?(@.name=='unstable_struct_variant_field')].stability.level" '"unstable"'
+        //@ is "$.index[?(@.name=='unstable_struct_variant_field')].stability.feature" '"unstable_struct_variant_field_feature"'
+        //@ !has "$.index[?(@.name=='unstable_struct_variant_field')].stability.since"
+        #[unstable(feature = "unstable_struct_variant_field_feature", issue = "none")]
+        unstable_struct_variant_field: usize,
+    },
+}

--- a/tests/rustdoc-json/attrs/stability/modules.rs
+++ b/tests/rustdoc-json/attrs/stability/modules.rs
@@ -1,0 +1,49 @@
+//! Module items, including the crate root and containing-module stability facts that consumers
+//! need when deciding whether a particular path is stable.
+
+#![feature(staged_api)]
+#![stable(feature = "stable_crate_feature", since = "1.0.0")]
+//@ is "$.index[?(@.name=='modules')].stability.level" '"stable"'
+//@ is "$.index[?(@.name=='modules')].stability.feature" '"stable_crate_feature"'
+//@ is "$.index[?(@.name=='modules')].stability.since" '"1.0.0"'
+
+pub mod inner_stable_module {
+    #![stable(feature = "inner_stable_module_feature", since = "1.1.0")]
+
+    //@ is "$.index[?(@.name=='inner_stable_module')].stability.level" '"stable"'
+    //@ is "$.index[?(@.name=='inner_stable_module')].stability.feature" '"inner_stable_module_feature"'
+    //@ is "$.index[?(@.name=='inner_stable_module')].stability.since" '"1.1.0"'
+}
+
+#[unstable(feature = "unstable_module_feature", issue = "none")]
+pub mod unstable_module {
+    //@ is "$.index[?(@.name=='unstable_module')].stability.level" '"unstable"'
+    //@ is "$.index[?(@.name=='unstable_module')].stability.feature" '"unstable_module_feature"'
+    //@ !has "$.index[?(@.name=='unstable_module')].stability.since"
+}
+
+#[stable(feature = "stable_parent_feature", since = "2.0.0")]
+pub mod stable_parent {
+    //@ is "$.index[?(@.name=='stable_parent')].stability.level" '"stable"'
+    //@ is "$.index[?(@.name=='stable_parent')].stability.feature" '"stable_parent_feature"'
+    //@ is "$.index[?(@.name=='stable_parent')].stability.since" '"2.0.0"'
+
+    //@ is "$.index[?(@.name=='UnstableChildInStable')].stability.level" '"unstable"'
+    //@ is "$.index[?(@.name=='UnstableChildInStable')].stability.feature" '"unstable_child_in_stable"'
+    //@ !has "$.index[?(@.name=='UnstableChildInStable')].stability.since"
+    #[unstable(feature = "unstable_child_in_stable", issue = "none")]
+    pub struct UnstableChildInStable;
+}
+
+#[unstable(feature = "unstable_parent_feature", issue = "27")]
+pub mod unstable_parent {
+    //@ is "$.index[?(@.name=='unstable_parent')].stability.level" '"unstable"'
+    //@ is "$.index[?(@.name=='unstable_parent')].stability.feature" '"unstable_parent_feature"'
+    //@ !has "$.index[?(@.name=='unstable_parent')].stability.since"
+
+    //@ is "$.index[?(@.name=='StableChildInUnstable')].stability.level" '"stable"'
+    //@ is "$.index[?(@.name=='StableChildInUnstable')].stability.feature" '"stable_child_in_unstable"'
+    //@ is "$.index[?(@.name=='StableChildInUnstable')].stability.since" '"3.0.0"'
+    #[stable(feature = "stable_child_in_unstable", since = "3.0.0")]
+    pub struct StableChildInUnstable;
+}

--- a/tests/rustdoc-json/attrs/stability/reexports.rs
+++ b/tests/rustdoc-json/attrs/stability/reexports.rs
@@ -1,0 +1,98 @@
+#![feature(staged_api)]
+
+// The stability of an item is a function of both the item and the path by which it is used.
+// It's possible for a stable item to be available under both a stable and an unstable path,
+// depending on re-exports and module stability. This file tests such edge cases.
+//
+// To determine if a path is stable, users of rustdoc JSON should walk all path components
+// (including `Use` items' `inner.use.id` value) and check for (in)stability.
+// The path is unstable if any traversed component (modules, re-exports, or the final item)
+// is marked unstable.
+
+#[unstable(feature = "unstable_source_mod", issue = "none")]
+pub mod unstable_source_mod {
+    //@ set stable_in_unstable = "$.index[?(@.name=='StableInUnstable')].id"
+    //@ is "$.index[?(@.name=='StableInUnstable')].stability.level" '"stable"'
+    //@ is "$.index[?(@.name=='StableInUnstable')].stability.feature" '"stable_in_unstable"'
+    //@ is "$.index[?(@.name=='StableInUnstable')].stability.since" '"1.0.0"'
+    #[stable(feature = "stable_in_unstable", since = "1.0.0")]
+    pub struct StableInUnstable;
+
+    //@ set second_stable_in_unstable = "$.index[?(@.name=='SecondStableInUnstable')].id"
+    #[stable(feature = "second_stable_in_unstable", since = "1.1.0")]
+    pub struct SecondStableInUnstable;
+
+    #[stable(feature = "glob_stable_in_unstable", since = "1.2.0")]
+    pub struct GlobStableInUnstable;
+}
+
+//@ is "$.index[?(@.inner.use.name=='ReexportedStableInUnstable')].inner.use.id" $stable_in_unstable
+//@ is "$.index[?(@.inner.use.name=='ReexportedStableInUnstable')].stability.level" '"stable"'
+//@ is "$.index[?(@.inner.use.name=='ReexportedStableInUnstable')].stability.feature" '"stable_reexport"'
+//@ is "$.index[?(@.inner.use.name=='ReexportedStableInUnstable')].stability.since" '"3.0.0"'
+//@ is "$.index[?(@.inner.use.name=='ReexportedStableInUnstable')].attrs" []
+#[stable(feature = "stable_reexport", since = "3.0.0")]
+pub use crate::unstable_source_mod::StableInUnstable as ReexportedStableInUnstable;
+//@ is "$.index[?(@.inner.use.source=='crate::unstable_source_mod')].inner.use.is_glob" true
+//@ is "$.index[?(@.inner.use.source=='crate::unstable_source_mod')].stability.level" '"stable"'
+//@ is "$.index[?(@.inner.use.source=='crate::unstable_source_mod')].stability.feature" '"stable_glob_reexport"'
+//@ is "$.index[?(@.inner.use.source=='crate::unstable_source_mod')].stability.since" '"4.0.0"'
+#[stable(feature = "stable_glob_reexport", since = "4.0.0")]
+pub use crate::unstable_source_mod::*;
+//@ is "$.index[?(@.inner.use.name=='GroupedStableReexport')].inner.use.id" $stable_in_unstable
+//@ is "$.index[?(@.inner.use.name=='GroupedStableReexport')].stability.level" '"stable"'
+//@ is "$.index[?(@.inner.use.name=='GroupedStableReexport')].stability.feature" '"stable_grouped_reexport"'
+//@ is "$.index[?(@.inner.use.name=='GroupedStableReexport')].stability.since" '"3.5.0"'
+//@ is "$.index[?(@.inner.use.name=='SecondGroupedStableReexport')].inner.use.id" $second_stable_in_unstable
+//@ is "$.index[?(@.inner.use.name=='SecondGroupedStableReexport')].stability.level" '"stable"'
+//@ is "$.index[?(@.inner.use.name=='SecondGroupedStableReexport')].stability.feature" '"stable_grouped_reexport"'
+//@ is "$.index[?(@.inner.use.name=='SecondGroupedStableReexport')].stability.since" '"3.5.0"'
+#[stable(feature = "stable_grouped_reexport", since = "3.5.0")]
+pub use crate::unstable_source_mod::{
+    SecondStableInUnstable as SecondGroupedStableReexport,
+    StableInUnstable as GroupedStableReexport,
+};
+
+#[unstable(feature = "unstable_reexport_source_mod", issue = "none")]
+pub mod unstable_reexport_source_mod {
+    //@ set stable_for_unstable_reexport = "$.index[?(@.name=='StableForUnstableReexport')].id"
+    #[stable(feature = "stable_for_unstable_reexport", since = "6.0.0")]
+    pub struct StableForUnstableReexport;
+
+    //@ set grouped_stable_for_unstable_reexport = "$.index[?(@.name=='GroupedStableForUnstableReexport')].id"
+    #[stable(feature = "grouped_stable_for_unstable_reexport", since = "6.1.0")]
+    pub struct GroupedStableForUnstableReexport;
+
+    //@ set second_grouped_stable_for_unstable_reexport = "$.index[?(@.name=='SecondGroupedStableForUnstableReexport')].id"
+    #[stable(feature = "second_grouped_stable_for_unstable_reexport", since = "6.2.0")]
+    pub struct SecondGroupedStableForUnstableReexport;
+
+    #[stable(feature = "glob_stable_for_unstable_reexport", since = "6.3.0")]
+    pub struct GlobStableForUnstableReexport;
+}
+
+//@ is "$.index[?(@.inner.use.name=='UnstableReexportedStable')].inner.use.id" $stable_for_unstable_reexport
+//@ is "$.index[?(@.inner.use.name=='UnstableReexportedStable')].stability.level" '"unstable"'
+//@ is "$.index[?(@.inner.use.name=='UnstableReexportedStable')].stability.feature" '"unstable_reexport"'
+//@ !has "$.index[?(@.inner.use.name=='UnstableReexportedStable')].stability.since"
+#[unstable(feature = "unstable_reexport", issue = "none")]
+pub use crate::unstable_reexport_source_mod::StableForUnstableReexport as UnstableReexportedStable;
+//@ is "$.index[?(@.inner.use.source=='crate::unstable_reexport_source_mod')].inner.use.is_glob" true
+//@ is "$.index[?(@.inner.use.source=='crate::unstable_reexport_source_mod')].stability.level" '"unstable"'
+//@ is "$.index[?(@.inner.use.source=='crate::unstable_reexport_source_mod')].stability.feature" '"unstable_glob_reexport"'
+//@ !has "$.index[?(@.inner.use.source=='crate::unstable_reexport_source_mod')].stability.since"
+#[unstable(feature = "unstable_glob_reexport", issue = "none")]
+pub use crate::unstable_reexport_source_mod::*;
+//@ is "$.index[?(@.inner.use.name=='GroupedUnstableReexport')].inner.use.id" $grouped_stable_for_unstable_reexport
+//@ is "$.index[?(@.inner.use.name=='GroupedUnstableReexport')].stability.level" '"unstable"'
+//@ is "$.index[?(@.inner.use.name=='GroupedUnstableReexport')].stability.feature" '"unstable_grouped_reexport"'
+//@ !has "$.index[?(@.inner.use.name=='GroupedUnstableReexport')].stability.since"
+//@ is "$.index[?(@.inner.use.name=='SecondGroupedUnstableReexport')].inner.use.id" $second_grouped_stable_for_unstable_reexport
+//@ is "$.index[?(@.inner.use.name=='SecondGroupedUnstableReexport')].stability.level" '"unstable"'
+//@ is "$.index[?(@.inner.use.name=='SecondGroupedUnstableReexport')].stability.feature" '"unstable_grouped_reexport"'
+//@ !has "$.index[?(@.inner.use.name=='SecondGroupedUnstableReexport')].stability.since"
+#[unstable(feature = "unstable_grouped_reexport", issue = "none")]
+pub use crate::unstable_reexport_source_mod::{
+    GroupedStableForUnstableReexport as GroupedUnstableReexport,
+    SecondGroupedStableForUnstableReexport as SecondGroupedUnstableReexport,
+};

--- a/tests/rustdoc-json/attrs/stability/stable.rs
+++ b/tests/rustdoc-json/attrs/stability/stable.rs
@@ -1,0 +1,7 @@
+#![feature(staged_api)]
+
+//@ is "$.index[?(@.name=='foo')].stability.level" '"stable"'
+//@ is "$.index[?(@.name=='foo')].stability.feature" '"eeeee"'
+//@ is "$.index[?(@.name=='foo')].attrs" []
+#[stable(since = "2.71.8", feature = "eeeee")]
+pub fn foo() {}

--- a/tests/rustdoc-json/attrs/stability/stable.rs
+++ b/tests/rustdoc-json/attrs/stability/stable.rs
@@ -2,6 +2,7 @@
 
 //@ is "$.index[?(@.name=='foo')].stability.level" '"stable"'
 //@ is "$.index[?(@.name=='foo')].stability.feature" '"eeeee"'
+//@ is "$.index[?(@.name=='foo')].stability.since" '"2.71.8"'
 //@ is "$.index[?(@.name=='foo')].attrs" []
 #[stable(since = "2.71.8", feature = "eeeee")]
 pub fn foo() {}

--- a/tests/rustdoc-json/attrs/stability/unmarked.rs
+++ b/tests/rustdoc-json/attrs/stability/unmarked.rs
@@ -1,0 +1,3 @@
+//@ is "$.index[?(@.name=='foo')].stability" null
+//@ is "$.index[?(@.name=='foo')].attrs" []
+pub fn foo() {}

--- a/tests/rustdoc-json/attrs/stability/unstable.rs
+++ b/tests/rustdoc-json/attrs/stability/unstable.rs
@@ -1,0 +1,7 @@
+#![feature(staged_api)]
+
+//@ is "$.index[?(@.name=='foo')].stability.level" '"unstable"'
+//@ is "$.index[?(@.name=='foo')].stability.feature" '"delights"'
+//@ is "$.index[?(@.name=='foo')].attrs" []
+#[unstable(feature = "delights", issue = "26")]
+pub fn foo() {}

--- a/tests/rustdoc-json/attrs/stability/unstable.rs
+++ b/tests/rustdoc-json/attrs/stability/unstable.rs
@@ -2,6 +2,7 @@
 
 //@ is "$.index[?(@.name=='foo')].stability.level" '"unstable"'
 //@ is "$.index[?(@.name=='foo')].stability.feature" '"delights"'
+//@ !has "$.index[?(@.name=='foo')].stability.since"
 //@ is "$.index[?(@.name=='foo')].attrs" []
 #[unstable(feature = "delights", issue = "26")]
 pub fn foo() {}

--- a/tests/rustdoc-json/attrs/stability/unstable_crate.rs
+++ b/tests/rustdoc-json/attrs/stability/unstable_crate.rs
@@ -1,0 +1,6 @@
+#![feature(staged_api)]
+#![unstable(feature = "unstable_crate_feature", issue = "none")]
+
+//@ is "$.index[?(@.name=='unstable_crate')].stability.level" '"unstable"'
+//@ is "$.index[?(@.name=='unstable_crate')].stability.feature" '"unstable_crate_feature"'
+//@ !has "$.index[?(@.name=='unstable_crate')].stability.since"


### PR DESCRIPTION
Include `Item::stability` info in rustdoc JSON, to enable tools like `cargo-semver-checks` to compute stability information and (eventually, soon™️) be used to catch accidental breaking changes in the Rust standard library (cc @Amanieu).

Successor to rust-lang/rust#154603 by @aDotInTheVoid, building directly on top of its commit.

Differences relative to that PR:
- Added `since` information for stable items.
- `Stability` is now boxed to ensure a smaller bump in `Item` size. Most non-built-in crates won't have stability information, so minimizing that memory use is material for them.
- We have well-defined stability semantics for items, optimizing for consistency with how existing JSON users already must perform reachability and `#[doc(hidden)]` analysis, instead of how rustdoc HTML presentation works. Note the detailed inline comment about this.
- Tests and docs, which the original PR noted needed to be added.

Other flavors of stability, such as const stability or default-body stability, are left as future work.

r? @GuillaumeGomez 

**AI disclosure:** This PR is the product of a combination of manual work and AI tools. I secured approval in advance from the designated reviewer. I stand behind the quality of the code I'm submitting, and I vouch it's as good or better compared to if I had written every line by my own hand.