### PR TITLE
Cross-referencing tuple_trait tracking issue, source and the Unstable Book

### DIFF
--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -1066,7 +1066,7 @@ pub const trait Destruct: PointeeSized {}
 ///
 /// The implementation of this trait is built-in and cannot be implemented
 /// for any user type.
-#[unstable(feature = "tuple_trait", issue = "none")]
+#[unstable(feature = "tuple_trait", issue = "157987")]
 #[lang = "tuple_trait"]
 #[diagnostic::on_unimplemented(message = "`{Self}` is not a tuple")]
 #[rustc_deny_explicit_impl]

--- a/src/doc/unstable-book/src/library-features/tuple-trait.md
+++ b/src/doc/unstable-book/src/library-features/tuple-trait.md
@@ -1,0 +1,5 @@
+# `tuple_trait`
+
+The tracking issue for this feature is [#157987].
+
+[#157987]: https://github.com/rust-lang/rust/issues/157987


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
- https://github.com/rust-lang/rust/issues/157987
- https://doc.rust-lang.org/core/marker/trait.Tuple.html
- https://dev-doc.rust-lang.org/beta/unstable-book/library-features/tuple-trait.html
<!-- homu-ignore:end -->
