### PR TITLE
Fix linking for wasm with crate metadata included

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/linker.rs
+++ b/compiler/rustc_codegen_ssa/src/back/linker.rs
@@ -1817,7 +1817,13 @@ pub(crate) fn exported_symbols(
         exported_symbols_for_non_proc_macro(tcx, crate_type)
     };
 
-    if crate_type == CrateType::Dylib || crate_type == CrateType::ProcMacro {
+    // Preserve the metadata symbol to ensure the metadata section doesn't get removed by the
+    // linker. On wasm however the metadata is put in a custom section, to which symbols can't
+    // refer, so there is no metadata symbol there. Luckily custom sections are always preserved by
+    // the linker.
+    if (crate_type == CrateType::Dylib || crate_type == CrateType::ProcMacro)
+        && !tcx.sess.target.is_like_wasm
+    {
         let metadata_symbol_name = exported_symbols::metadata_symbol_name(tcx);
         symbols.push((metadata_symbol_name, SymbolExportKind::Data));
     }


### PR DESCRIPTION
On wasm the crate metadata ends up in a custom section. It is not possible to refer to create symbols inside a custom section, so attempting to export it during linking will result in a linker error. This keeps the target spec flag to deny compiling rust dylibs for wasm, but may theoretically allow compiling wasm rust dylibs with a custom target spec. It will help with wasm proc-macros. And in the future we can try to flip the only-cdylib option to false on wasm.

Extracted out of https://github.com/rust-lang/rust/pull/157709, but also helps with https://github.com/rust-lang/rust/pull/157590.

r? @Mark-Simulacrum