### PR TITLE
hermit/fs: Return `unsupported()` instead of `from_raw_os_error(22)`

### DIFF
--- a/library/std/src/sys/fs/hermit.rs
+++ b/library/std/src/sys/fs/hermit.rs
@@ -352,7 +352,7 @@ impl File {
     }
 
     pub fn fsync(&self) -> io::Result<()> {
-        Err(Error::from_raw_os_error(22))
+        unsupported()
     }
 
     pub fn datasync(&self) -> io::Result<()> {
@@ -380,7 +380,7 @@ impl File {
     }
 
     pub fn truncate(&self, _size: u64) -> io::Result<()> {
-        Err(Error::from_raw_os_error(22))
+        unsupported()
     }
 
     pub fn read(&self, buf: &mut [u8]) -> io::Result<usize> {
@@ -431,15 +431,15 @@ impl File {
     }
 
     pub fn duplicate(&self) -> io::Result<File> {
-        Err(Error::from_raw_os_error(22))
+        unsupported()
     }
 
     pub fn set_permissions(&self, _perm: FilePermissions) -> io::Result<()> {
-        Err(Error::from_raw_os_error(22))
+        unsupported()
     }
 
     pub fn set_times(&self, _times: FileTimes) -> io::Result<()> {
-        Err(Error::from_raw_os_error(22))
+        unsupported()
     }
 }
 
@@ -563,7 +563,7 @@ pub fn rename(_old: &Path, _new: &Path) -> io::Result<()> {
 }
 
 pub fn set_perm(_p: &Path, _perm: FilePermissions) -> io::Result<()> {
-    Err(Error::from_raw_os_error(22))
+    unsupported()
 }
 
 pub fn set_perm_nofollow(_p: &Path, _perm: FilePermissions) -> io::Result<()> {
@@ -571,11 +571,11 @@ pub fn set_perm_nofollow(_p: &Path, _perm: FilePermissions) -> io::Result<()> {
 }
 
 pub fn set_times(_p: &Path, _times: FileTimes) -> io::Result<()> {
-    Err(Error::from_raw_os_error(22))
+    unsupported()
 }
 
 pub fn set_times_nofollow(_p: &Path, _times: FileTimes) -> io::Result<()> {
-    Err(Error::from_raw_os_error(22))
+    unsupported()
 }
 
 pub fn rmdir(path: &Path) -> io::Result<()> {


### PR DESCRIPTION
Currently, Hermit uses a mix of `Err(Error::from_raw_os_error(22))` (`EINVAL`) and `unsupported()` for unsupported operations.

This PR makes Hermit consistently use `unsupported()` everywhere. This should address https://github.com/rust-lang/rust/pull/158168#discussion_r3446228044 and https://github.com/rust-lang/rust/pull/158168#discussion_r3446241552.

r? clarfonthey

CC: @stlankes