### PR TITLE
Move fast paths around to gain a bit of new-solver perf

### DIFF
--- a/compiler/rustc_middle/src/traits/solve.rs
+++ b/compiler/rustc_middle/src/traits/solve.rs
@@ -18,7 +18,7 @@ pub type FetchEligibleAssocItemResponse<'tcx> =
     ir::solve::FetchEligibleAssocItemResponse<TyCtxt<'tcx>>;
 pub type ComputeGoalFastPathOutcome<'tcx> = ir::solve::ComputeGoalFastPathOutcome<TyCtxt<'tcx>>;
 pub type GoalStalledOn<'tcx> = ir::solve::GoalStalledOn<TyCtxt<'tcx>>;
-pub type GoalStalledOnReason<'tcx> = ir::solve::GoalStalledOnReason<TyCtxt<'tcx>>;
+pub type GoalStalledOnOpaques<'tcx> = ir::solve::GoalStalledOnOpaques<TyCtxt<'tcx>>;
 pub type SucceededInErased<'tcx> = ir::solve::SucceededInErased<TyCtxt<'tcx>>;
 
 pub type PredefinedOpaques<'tcx> = &'tcx ty::List<(ty::OpaqueTypeKey<'tcx>, Ty<'tcx>)>;

--- a/compiler/rustc_middle/src/traits/solve.rs
+++ b/compiler/rustc_middle/src/traits/solve.rs
@@ -16,6 +16,10 @@ pub type CanonicalInput<'tcx, P = ty::Predicate<'tcx>> = ir::solve::CanonicalInp
 pub type CanonicalResponse<'tcx> = ir::solve::CanonicalResponse<TyCtxt<'tcx>>;
 pub type FetchEligibleAssocItemResponse<'tcx> =
     ir::solve::FetchEligibleAssocItemResponse<TyCtxt<'tcx>>;
+pub type ComputeGoalFastPathOutcome<'tcx> = ir::solve::ComputeGoalFastPathOutcome<TyCtxt<'tcx>>;
+pub type GoalStalledOn<'tcx> = ir::solve::GoalStalledOn<TyCtxt<'tcx>>;
+pub type GoalStalledOnReason<'tcx> = ir::solve::GoalStalledOnReason<TyCtxt<'tcx>>;
+pub type SucceededInErased<'tcx> = ir::solve::SucceededInErased<TyCtxt<'tcx>>;
 
 pub type PredefinedOpaques<'tcx> = &'tcx ty::List<(ty::OpaqueTypeKey<'tcx>, Ty<'tcx>)>;
 

--- a/compiler/rustc_next_trait_solver/src/delegate.rs
+++ b/compiler/rustc_next_trait_solver/src/delegate.rs
@@ -1,7 +1,8 @@
 use std::ops::Deref;
 
 use rustc_type_ir::solve::{
-    Certainty, FetchEligibleAssocItemResponse, Goal, NoSolution, VisibleForLeakCheck,
+    Certainty, ComputeGoalFastPathOutcome, FetchEligibleAssocItemResponse, Goal, NoSolution,
+    VisibleForLeakCheck,
 };
 use rustc_type_ir::{self as ty, InferCtxtLike, Interner, TypeFoldable};
 
@@ -23,7 +24,7 @@ pub trait SolverDelegate: Deref<Target = Self::Infcx> + Sized {
         &self,
         goal: Goal<Self::Interner, <Self::Interner as Interner>::Predicate>,
         span: <Self::Interner as Interner>::Span,
-    ) -> Option<Certainty>;
+    ) -> ComputeGoalFastPathOutcome<Self::Interner>;
 
     fn fresh_var_for_kind_with_span(
         &self,

--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/fast_path.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/fast_path.rs
@@ -108,6 +108,13 @@ where
     WontMakeProgress(stalled_certainty)
 }
 
+/// `compute_goal_fast_path` is complicated enough that outling helps, so it gets optimized
+/// separately from the caller. `compute_goal_fast_path` is the inlined version,
+/// and most call sites (when adding goals) use it. However, when entering the root
+/// we also want to check the fast path, and there the outlining matters.
+///
+/// FIXME(perf) cold might not be worth it here, given that we shuffled some things around since it
+/// mattered.
 #[cold]
 #[inline(never)]
 pub(super) fn compute_goal_fast_path_cold<D, I>(

--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/fast_path.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/fast_path.rs
@@ -26,6 +26,7 @@ pub(super) enum RerunStalled {
 /// args have changed. This is a cheap way to determine that if we were to rerun this goal now,
 /// it will remain stalled since it'll canonicalize the same way and evaluation is pure.
 /// Therefore, we can skip this rerun
+#[inline]
 pub(super) fn rerunning_stalled_goal_may_make_progress<D, I>(
     delegate: &D,
     stalled_on: Option<&GoalStalledOn<I>>,
@@ -103,9 +104,23 @@ where
     WontMakeProgress(stalled_certainty)
 }
 
+#[cold]
+#[inline(never)]
+pub(super) fn compute_goal_fast_path_cold<D, I>(
+    delegate: &D,
+    goal: Goal<I, I::Predicate>,
+    origin_span: I::Span,
+) -> Option<GoalEvaluation<I>>
+where
+    D: SolverDelegate<Interner = I>,
+    I: Interner,
+{
+    compute_goal_fast_path(delegate, goal, origin_span)
+}
+
 /// This is a fast path optimization:
 /// See the docs on [`ComputeGoalFastPathOutcome`]
-pub(super) fn compute_goal_fast_path<D, I>(
+pub fn compute_goal_fast_path<D, I>(
     delegate: &D,
     goal: Goal<I, I::Predicate>,
     origin_span: I::Span,

--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/fast_path.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/fast_path.rs
@@ -1,0 +1,136 @@
+//! This file contains a number of standalone functions useful for taking _fast paths_ in the trait
+//! solver. The exact place where we check for these fast paths changes, and matters a lot for
+//! performance. Ideally we'd only check them in `evaluate_goal`, but when evaluating root goals
+//! we can check them earlier and save some time creating an `EvalCtxt` in the first place.
+//!
+//! For debugging, fast paths can be disabled using `-Zdisable-fast-paths`.
+
+use rustc_type_ir::inherent::*;
+use rustc_type_ir::solve::{
+    Certainty, ComputeGoalFastPathOutcome, Goal, GoalStalledOn, GoalStalledOnReason,
+    SucceededInErased,
+};
+use rustc_type_ir::{InferCtxtLike, Interner};
+
+use crate::delegate::SolverDelegate;
+use crate::solve::eval_ctxt::{RerunDecision, should_rerun_after_erased_canonicalization};
+use crate::solve::{GoalEvaluation, HasChanged};
+
+#[derive(Debug, Clone, Copy)]
+pub(super) enum RerunStalled {
+    WontMakeProgress(Certainty),
+    MayMakeProgress,
+}
+
+/// If we have run a goal before, and it was stalled, check that any of the goal's
+/// args have changed. This is a cheap way to determine that if we were to rerun this goal now,
+/// it will remain stalled since it'll canonicalize the same way and evaluation is pure.
+/// Therefore, we can skip this rerun
+pub(super) fn rerunning_stalled_goal_may_make_progress<D, I>(
+    delegate: &D,
+    stalled_on: Option<&GoalStalledOn<I>>,
+) -> RerunStalled
+where
+    D: SolverDelegate<Interner = I>,
+    I: Interner,
+{
+    use RerunStalled::*;
+
+    // If fast paths are turned off, then we assume all goals can always make progress
+    if delegate.disable_trait_solver_fast_paths() {
+        return MayMakeProgress;
+    }
+
+    // If the goal isn't stalled, we should definitely run it.
+    let Some(&GoalStalledOn { ref reason, ref stalled_vars, ref sub_roots, stalled_certainty }) =
+        stalled_on
+    else {
+        return MayMakeProgress;
+    };
+
+    // If any of the stalled goal's generic arguments changed,
+    // rerunning might make progress so we should rerun.
+    if stalled_vars.iter().any(|value| delegate.is_changed_arg(*value)) {
+        return MayMakeProgress;
+    }
+
+    // If some inference took place in any of the sub roots,
+    // rerunning might make progress so we should rerun.
+    if sub_roots.iter().any(|&vid| delegate.sub_unification_table_root_var(vid) != vid) {
+        return MayMakeProgress;
+    }
+
+    match reason {
+        GoalStalledOnReason::FastPath => {
+            // fastpath is never because of opaques, we can skip this check
+        }
+        &GoalStalledOnReason::Other { num_opaques, ref previously_succeeded_in_erased } => {
+            // If any opaques changed in the opaque type storage,
+            // rerunning might make progress so we should rerun.
+            if delegate.opaque_types_storage_num_entries().needs_reevaluation(num_opaques) {
+                // Unless this goal previously succeeded in erased mode.
+                // If the stalled goal successfully evaluated while erasing opaque types,
+                // and the current state of the opaque type storage is not different in a way that is
+                // relevant, this stalled goal cannot make any progress and we set this variable to true.
+                let mut previous_erased_run_is_still_valid = false;
+
+                if let &SucceededInErased::Yes { accessed_opaques } = previously_succeeded_in_erased
+                {
+                    match should_rerun_after_erased_canonicalization(
+                        accessed_opaques,
+                        delegate.typing_mode_raw(),
+                        &delegate.clone_opaque_types_lookup_table(),
+                    ) {
+                        RerunDecision::Yes => {}
+                        RerunDecision::EagerlyPropagateToParent => {
+                            unreachable!("we never retry stalled queries if the parent was erased")
+                        }
+                        RerunDecision::No => {
+                            previous_erased_run_is_still_valid = true;
+                        }
+                    }
+                }
+
+                if !previous_erased_run_is_still_valid {
+                    return MayMakeProgress;
+                }
+            }
+        }
+    }
+
+    // Otherwise, we can be sure that this stalled goal cannot make any progress
+    // and we can exit early.
+    WontMakeProgress(stalled_certainty)
+}
+
+/// This is a fast path optimization:
+/// See the docs on [`ComputeGoalFastPathOutcome`]
+pub(super) fn compute_goal_fast_path<D, I>(
+    delegate: &D,
+    goal: Goal<I, I::Predicate>,
+    origin_span: I::Span,
+) -> Option<GoalEvaluation<I>>
+where
+    D: SolverDelegate<Interner = I>,
+    I: Interner,
+{
+    if delegate.disable_trait_solver_fast_paths() {
+        return None;
+    }
+
+    match delegate.compute_goal_fast_path(goal, origin_span) {
+        ComputeGoalFastPathOutcome::NoFastPath => None,
+        ComputeGoalFastPathOutcome::TriviallyHolds => Some(GoalEvaluation {
+            goal,
+            certainty: Certainty::Yes,
+            has_changed: HasChanged::No,
+            stalled_on: None,
+        }),
+        ComputeGoalFastPathOutcome::TriviallyStalled { stalled_on } => Some(GoalEvaluation {
+            goal,
+            certainty: Certainty::AMBIGUOUS,
+            has_changed: HasChanged::No,
+            stalled_on: Some(stalled_on),
+        }),
+    }
+}

--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/fast_path.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/fast_path.rs
@@ -7,7 +7,7 @@
 
 use rustc_type_ir::inherent::*;
 use rustc_type_ir::solve::{
-    Certainty, ComputeGoalFastPathOutcome, Goal, GoalStalledOn, GoalStalledOnReason,
+    Certainty, ComputeGoalFastPathOutcome, Goal, GoalStalledOn, GoalStalledOnOpaques,
     SucceededInErased,
 };
 use rustc_type_ir::{InferCtxtLike, Interner};
@@ -43,7 +43,7 @@ where
     }
 
     // If the goal isn't stalled, we should definitely run it.
-    let Some(&GoalStalledOn { ref reason, ref stalled_vars, ref sub_roots, stalled_certainty }) =
+    let Some(&GoalStalledOn { ref opaques, ref stalled_vars, ref sub_roots, stalled_certainty }) =
         stalled_on
     else {
         return MayMakeProgress;
@@ -61,14 +61,18 @@ where
         return MayMakeProgress;
     }
 
-    match reason {
-        GoalStalledOnReason::FastPath => {
-            // fastpath is never because of opaques, we can skip this check
-        }
-        &GoalStalledOnReason::Other { num_opaques, ref previously_succeeded_in_erased } => {
+    match opaques {
+        GoalStalledOnOpaques::No => {}
+        &GoalStalledOnOpaques::Yes {
+            num_opaques_in_storage,
+            ref previously_succeeded_in_erased,
+        } => {
             // If any opaques changed in the opaque type storage,
             // rerunning might make progress so we should rerun.
-            if delegate.opaque_types_storage_num_entries().needs_reevaluation(num_opaques) {
+            if delegate
+                .opaque_types_storage_num_entries()
+                .needs_reevaluation(num_opaques_in_storage)
+            {
                 // Unless this goal previously succeeded in erased mode.
                 // If the stalled goal successfully evaluated while erasing opaque types,
                 // and the current state of the opaque type storage is not different in a way that is

--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
@@ -10,9 +10,10 @@ use rustc_type_ir::relate::Relate;
 use rustc_type_ir::relate::solver_relating::RelateExt;
 use rustc_type_ir::search_graph::{CandidateHeadUsages, LowerAvailableDepth, PathKind};
 use rustc_type_ir::solve::{
-    AccessedOpaques, ExternalRegionConstraints, FetchEligibleAssocItemResponse, MaybeInfo,
-    NoSolutionOrRerunNonErased, OpaqueTypesJank, QueryResultOrRerunNonErased, RerunCondition,
-    RerunNonErased, RerunReason, RerunResultExt, SmallCopyList,
+    AccessedOpaques, ComputeGoalFastPathOutcome, ExternalRegionConstraints,
+    FetchEligibleAssocItemResponse, MaybeInfo, NoSolutionOrRerunNonErased, OpaqueTypesJank,
+    QueryResultOrRerunNonErased, RerunCondition, RerunNonErased, RerunReason, RerunResultExt,
+    SmallCopyList,
 };
 use rustc_type_ir::{
     self as ty, CanonicalVarValues, ClauseKind, InferCtxtLike, Interner, MayBeErased,
@@ -35,7 +36,7 @@ use crate::solve::search_graph::SearchGraph;
 use crate::solve::ty::may_use_unstable_feature;
 use crate::solve::{
     CanonicalInput, CanonicalResponse, Certainty, ExternalConstraintsData, FIXPOINT_STEP_LIMIT,
-    Goal, GoalEvaluation, GoalSource, GoalStalledOn, HasChanged, MaybeCause,
+    Goal, GoalEvaluation, GoalSource, GoalStalledOn, GoalStalledOnReason, HasChanged, MaybeCause,
     NestedNormalizationGoals, NoSolution, QueryInput, QueryResult, Response, SucceededInErased,
     VisibleForLeakCheck, inspect,
 };
@@ -506,13 +507,8 @@ where
         }
 
         // If the goal isn't stalled, we should definitely run it.
-        let Some(&GoalStalledOn {
-            num_opaques,
-            ref stalled_vars,
-            ref sub_roots,
-            stalled_certainty,
-            ref previously_succeeded_in_erased,
-        }) = stalled_on
+        let Some(&GoalStalledOn { ref reason, ref stalled_vars, ref sub_roots, stalled_certainty }) =
+            stalled_on
         else {
             return MayMakeProgress;
         };
@@ -529,39 +525,84 @@ where
             return MayMakeProgress;
         }
 
-        // If any opaques changed in the opaque type storage,
-        // rerunning might make progress so we should rerun.
-        if self.delegate.opaque_types_storage_num_entries().needs_reevaluation(num_opaques) {
-            // Unless this goal previously succeeded in erased mode.
-            // If the stalled goal successfully evaluated while erasing opaque types,
-            // and the current state of the opaque type storage is not different in a way that is
-            // relevant, this stalled goal cannot make any progress and we set this variable to true.
-            let mut previous_erased_run_is_still_valid = false;
+        match reason {
+            GoalStalledOnReason::FastPath => {
+                // fastpath is never because of opaques, we can skip this check
+            }
+            &GoalStalledOnReason::Other { num_opaques, ref previously_succeeded_in_erased } => {
+                // If any opaques changed in the opaque type storage,
+                // rerunning might make progress so we should rerun.
+                if self.delegate.opaque_types_storage_num_entries().needs_reevaluation(num_opaques)
+                {
+                    // Unless this goal previously succeeded in erased mode.
+                    // If the stalled goal successfully evaluated while erasing opaque types,
+                    // and the current state of the opaque type storage is not different in a way that is
+                    // relevant, this stalled goal cannot make any progress and we set this variable to true.
+                    let mut previous_erased_run_is_still_valid = false;
 
-            if let &SucceededInErased::Yes { accessed_opaques } = previously_succeeded_in_erased {
-                match self.should_rerun_after_erased_canonicalization(
-                    accessed_opaques,
-                    self.typing_mode(),
-                    &self.delegate.clone_opaque_types_lookup_table(),
-                ) {
-                    RerunDecision::Yes => {}
-                    RerunDecision::EagerlyPropagateToParent => {
-                        unreachable!("we never retry stalled queries if the parent was erased")
+                    if let &SucceededInErased::Yes { accessed_opaques } =
+                        previously_succeeded_in_erased
+                    {
+                        match self.should_rerun_after_erased_canonicalization(
+                            accessed_opaques,
+                            self.typing_mode(),
+                            &self.delegate.clone_opaque_types_lookup_table(),
+                        ) {
+                            RerunDecision::Yes => {}
+                            RerunDecision::EagerlyPropagateToParent => {
+                                unreachable!(
+                                    "we never retry stalled queries if the parent was erased"
+                                )
+                            }
+                            RerunDecision::No => {
+                                previous_erased_run_is_still_valid = true;
+                            }
+                        }
                     }
-                    RerunDecision::No => {
-                        previous_erased_run_is_still_valid = true;
+
+                    if !previous_erased_run_is_still_valid {
+                        return MayMakeProgress;
                     }
                 }
-            }
-
-            if !previous_erased_run_is_still_valid {
-                return MayMakeProgress;
             }
         }
 
         // Otherwise, we can be sure that this stalled goal cannot make any progress
         // and we can exit early.
         WontMakeProgress(stalled_certainty)
+    }
+
+    /// This is a fast path optimization:
+    /// See the docs on [`ComputeGoalFastPathOutcome`]
+    pub fn compute_goal_fast_path(
+        &self,
+        goal: Goal<I, I::Predicate>,
+    ) -> Option<(NestedNormalizationGoals<I>, GoalEvaluation<I>)> {
+        if self.delegate.disable_trait_solver_fast_paths() {
+            return None;
+        }
+
+        match self.delegate.compute_goal_fast_path(goal, self.origin_span) {
+            ComputeGoalFastPathOutcome::NoFastPath => None,
+            ComputeGoalFastPathOutcome::TriviallyHolds => Some((
+                NestedNormalizationGoals::empty(),
+                GoalEvaluation {
+                    goal,
+                    certainty: Certainty::Yes,
+                    has_changed: HasChanged::No,
+                    stalled_on: None,
+                },
+            )),
+            ComputeGoalFastPathOutcome::TriviallyStalled { stalled_on } => Some((
+                NestedNormalizationGoals::empty(),
+                GoalEvaluation {
+                    goal,
+                    certainty: Certainty::AMBIGUOUS,
+                    has_changed: HasChanged::No,
+                    stalled_on: Some(stalled_on),
+                },
+            )),
+        }
     }
 
     /// Recursively evaluates `goal`, returning the nested goals in case
@@ -592,13 +633,8 @@ where
             ));
         }
 
-        if !self.delegate.disable_trait_solver_fast_paths()
-            && let Some(certainty) = self.delegate.compute_goal_fast_path(goal, self.origin_span)
-        {
-            return Ok((
-                NestedNormalizationGoals::empty(),
-                GoalEvaluation { goal, certainty, has_changed: HasChanged::No, stalled_on: None },
-            ));
+        if let Some(res) = self.compute_goal_fast_path(goal) {
+            return Ok(res);
         }
 
         self.evaluate_goal_cold(source, goal, increase_depth_for_nested)
@@ -768,41 +804,12 @@ where
                 // that is not resolved. Only when *these* have changed is it meaningful
                 // to recompute this goal.
                 HasChanged::Yes => None,
-                HasChanged::No => {
-                    // Remove the canonicalized universal vars, since we only care about stalled existentials.
-                    let mut sub_roots = Vec::new();
-                    let mut stalled_vars = orig_values;
-                    stalled_vars.retain(|arg| match arg.kind() {
-                        // Lifetimes can never stall goals.
-                        ty::GenericArgKind::Lifetime(_) => false,
-                        ty::GenericArgKind::Type(ty) => match ty.kind() {
-                            ty::Infer(ty::TyVar(vid)) => {
-                                sub_roots.push(self.delegate.sub_unification_table_root_var(vid));
-                                true
-                            }
-                            ty::Infer(_) => true,
-                            ty::Param(_) | ty::Placeholder(_) => false,
-                            _ => unreachable!("unexpected orig_value: {ty:?}"),
-                        },
-                        ty::GenericArgKind::Const(ct) => match ct.kind() {
-                            ty::ConstKind::Infer(_) => true,
-                            ty::ConstKind::Param(_) | ty::ConstKind::Placeholder(_) => false,
-                            _ => unreachable!("unexpected orig_value: {ct:?}"),
-                        },
-                    });
-
-                    Some(GoalStalledOn {
-                        num_opaques: canonical_goal
-                            .canonical
-                            .value
-                            .predefined_opaques_in_body
-                            .len(),
-                        stalled_vars,
-                        sub_roots,
-                        stalled_certainty: certainty,
-                        previously_succeeded_in_erased: succeeded_in_erased,
-                    })
-                }
+                HasChanged::No => Some(self.build_stalled_on(
+                    canonical_goal,
+                    certainty,
+                    orig_values,
+                    succeeded_in_erased,
+                )),
             },
         };
 
@@ -810,6 +817,45 @@ where
             normalization_nested_goals,
             GoalEvaluation { goal, certainty, has_changed, stalled_on },
         ))
+    }
+
+    fn build_stalled_on(
+        &self,
+        canonical_goal: CanonicalInput<I>,
+        certainty: Certainty,
+        mut stalled_vars: Vec<I::GenericArg>,
+        previously_succeeded_in_erased: SucceededInErased<I>,
+    ) -> GoalStalledOn<I> {
+        // Remove the canonicalized universal vars, since we only care about stalled existentials.
+        let mut sub_roots = Vec::new();
+        stalled_vars.retain(|arg| match arg.kind() {
+            // Lifetimes can never stall goals.
+            ty::GenericArgKind::Lifetime(_) => false,
+            ty::GenericArgKind::Type(ty) => match ty.kind() {
+                ty::Infer(ty::TyVar(vid)) => {
+                    sub_roots.push(self.delegate.sub_unification_table_root_var(vid));
+                    true
+                }
+                ty::Infer(_) => true,
+                ty::Param(_) | ty::Placeholder(_) => false,
+                _ => unreachable!("unexpected orig_value: {ty:?}"),
+            },
+            ty::GenericArgKind::Const(ct) => match ct.kind() {
+                ty::ConstKind::Infer(_) => true,
+                ty::ConstKind::Param(_) | ty::ConstKind::Placeholder(_) => false,
+                _ => unreachable!("unexpected orig_value: {ct:?}"),
+            },
+        });
+
+        GoalStalledOn {
+            stalled_vars,
+            sub_roots,
+            stalled_certainty: certainty,
+            reason: GoalStalledOnReason::Other {
+                num_opaques: canonical_goal.canonical.value.predefined_opaques_in_body.len(),
+                previously_succeeded_in_erased,
+            },
+        }
     }
 
     fn should_rerun_after_erased_canonicalization(

--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
@@ -592,6 +592,15 @@ where
             ));
         }
 
+        if !self.delegate.disable_trait_solver_fast_paths()
+            && let Some(certainty) = self.delegate.compute_goal_fast_path(goal, self.origin_span)
+        {
+            return Ok((
+                NestedNormalizationGoals::empty(),
+                GoalEvaluation { goal, certainty, has_changed: HasChanged::No, stalled_on: None },
+            ));
+        }
+
         self.evaluate_goal_cold(source, goal, increase_depth_for_nested)
     }
 
@@ -989,20 +998,6 @@ where
                 goal.predicate.kind().skip_binder(),
                 PredicateKind::NormalizesTo(_)
             ));
-
-            if !self.delegate.disable_trait_solver_fast_paths()
-                && let Some(certainty) =
-                    self.delegate.compute_goal_fast_path(goal, self.origin_span)
-            {
-                match certainty {
-                    Certainty::Yes => {}
-                    Certainty::Maybe { .. } => {
-                        self.nested_goals.push((source, goal, None));
-                        unchanged_certainty = unchanged_certainty.map(|c| c.and(certainty));
-                    }
-                }
-                continue;
-            }
 
             let GoalEvaluation { goal, certainty, has_changed, stalled_on } =
                 self.evaluate_goal(source, goal, stalled_on)?;

--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
@@ -237,11 +237,10 @@ where
             });
         }
 
-        if
         // No need to try the fast path if stalled_on is `None`, since we already try the fast path
         // immediately when adding new goals. If we didn't check `stalled_on` here we'd be trying
         // the fast path twice for some goals.
-        stalled_on.is_some()
+        if stalled_on.is_some()
             && let Some(res) = compute_goal_fast_path_cold(self, goal, span)
         {
             return Ok(res);
@@ -510,11 +509,10 @@ where
             });
         }
 
-        if
         // No need to try the fast path if stalled_on is `None`, since we already try the fast path
         // immediately when adding new goals. If we didn't check `stalled_on` here we'd be trying
         // the fast path twice for some goals.
-        stalled_on.is_some()
+        if stalled_on.is_some()
             && let Some(res) = compute_goal_fast_path_cold(self.delegate, goal, self.origin_span)
         {
             return Ok(res);
@@ -1611,19 +1609,20 @@ enum RerunDecision {
     EagerlyPropagateToParent,
 }
 
+#[tracing::instrument(ret)]
 fn should_rerun_after_erased_canonicalization<I: Interner>(
     AccessedOpaques { reason: _, rerun }: AccessedOpaques<I>,
     original_typing_mode: TypingMode<I>,
     parent_opaque_types: &[(OpaqueTypeKey<I>, I::Ty)],
 ) -> RerunDecision {
-    let parent_opaque_defids = parent_opaque_types.iter().map(|(key, _)| key.def_id.into());
-    let opaque_in_storage = |opaques: I::LocalDefIds, defids: SmallCopyList<_>| {
-        if defids.as_ref().is_empty() {
+    let parent_opaque_def_ids = parent_opaque_types.iter().map(|(key, _)| key.def_id.into());
+    let opaque_in_storage = |opaques: I::LocalDefIds, def_ids: SmallCopyList<_>| {
+        if def_ids.as_ref().is_empty() {
             RerunDecision::No
         } else if opaques
             .iter()
-            .chain(parent_opaque_defids)
-            .any(|opaque| defids.as_ref().contains(&opaque))
+            .chain(parent_opaque_def_ids)
+            .any(|opaque| def_ids.as_ref().contains(&opaque))
         {
             RerunDecision::Yes
         } else {
@@ -1638,7 +1637,7 @@ fn should_rerun_after_erased_canonicalization<I: Interner>(
         }
     };
 
-    let res = match (rerun, original_typing_mode) {
+    match (rerun, original_typing_mode) {
         // =============================
         (RerunCondition::Never, _) => RerunDecision::No,
         // =============================
@@ -1692,13 +1691,7 @@ fn should_rerun_after_erased_canonicalization<I: Interner>(
             TypingMode::PostBorrowck { defined_opaque_types: opaques }
             | TypingMode::PostTypeckUntilBorrowck { defining_opaque_types: opaques },
         ) => opaque_in_storage(opaques, defids),
-    };
-
-    debug!(
-        "checking whether to rerun {rerun:?} in outer typing mode {original_typing_mode:?} and opaques {parent_opaque_types:?}: {res:?}"
-    );
-
-    res
+    }
 }
 
 /// Do not call this directly, use the `tcx` query instead.

--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
@@ -992,6 +992,9 @@ where
     ) -> Result<Option<Certainty>, NoSolutionOrRerunNonErased> {
         // If this loop did not result in any progress, what's our final certainty.
         let mut unchanged_certainty = Some(Certainty::Yes);
+        // This mem::take seems super inefficient, given that we push to it again later.
+        // Despite that, replacing it has no effect on performance. We tried.
+        // (https://github.com/rust-lang/rust/pull/158126)
         for (source, goal, stalled_on) in mem::take(&mut self.nested_goals) {
             // We never handle `NormalizesTo` as a nested goal
             debug_assert!(!matches!(

--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
@@ -10,10 +10,9 @@ use rustc_type_ir::relate::Relate;
 use rustc_type_ir::relate::solver_relating::RelateExt;
 use rustc_type_ir::search_graph::{CandidateHeadUsages, LowerAvailableDepth, PathKind};
 use rustc_type_ir::solve::{
-    AccessedOpaques, ComputeGoalFastPathOutcome, ExternalRegionConstraints,
-    FetchEligibleAssocItemResponse, MaybeInfo, NoSolutionOrRerunNonErased, OpaqueTypesJank,
-    QueryResultOrRerunNonErased, RerunCondition, RerunNonErased, RerunReason, RerunResultExt,
-    SmallCopyList,
+    AccessedOpaques, ExternalRegionConstraints, FetchEligibleAssocItemResponse, MaybeInfo,
+    NoSolutionOrRerunNonErased, OpaqueTypesJank, QueryResultOrRerunNonErased, RerunCondition,
+    RerunNonErased, RerunReason, RerunResultExt, SmallCopyList,
 };
 use rustc_type_ir::{
     self as ty, CanonicalVarValues, ClauseKind, InferCtxtLike, Interner, MayBeErased,
@@ -32,6 +31,9 @@ use crate::delegate::SolverDelegate;
 use crate::normalize::{NormalizationFolder, NormalizationWasAmbiguous};
 use crate::placeholder::BoundVarReplacer;
 use crate::resolve::eager_resolve_vars;
+use crate::solve::eval_ctxt::fast_path::{
+    RerunStalled, compute_goal_fast_path, rerunning_stalled_goal_may_make_progress,
+};
 use crate::solve::search_graph::SearchGraph;
 use crate::solve::ty::may_use_unstable_feature;
 use crate::solve::{
@@ -41,6 +43,7 @@ use crate::solve::{
     VisibleForLeakCheck, inspect,
 };
 
+mod fast_path;
 mod probe;
 mod solver_region_constraints;
 
@@ -90,12 +93,6 @@ impl CurrentGoalKind {
     }
 }
 
-#[derive(Debug)]
-enum RerunDecision {
-    Yes,
-    No,
-    EagerlyPropagateToParent,
-}
 pub struct EvalCtxt<'a, D, I = <D as SolverDelegate>::Interner>
 where
     D: SolverDelegate<Interner = I>,
@@ -227,8 +224,25 @@ where
         span: I::Span,
         stalled_on: Option<GoalStalledOn<I>>,
     ) -> Result<GoalEvaluation<I>, NoSolution> {
+        // Run fast paths *before* building an `EvalCtxt`, saving a little bit of time.
+        if let RerunStalled::WontMakeProgress(stalled_certainty) =
+            rerunning_stalled_goal_may_make_progress(self, stalled_on.as_ref())
+        {
+            return Ok(GoalEvaluation {
+                goal,
+                certainty: stalled_certainty,
+                has_changed: HasChanged::No,
+                stalled_on,
+            });
+        }
+
+        if let Some(res) = compute_goal_fast_path(self, goal, span) {
+            return Ok(res);
+        }
+
         let result = EvalCtxt::enter_root(self, self.cx().recursion_limit(), span, |ecx| {
-            ecx.evaluate_goal(GoalSource::Misc, goal, stalled_on)
+            // Fast paths handled above
+            ecx.evaluate_goal_no_fast_paths(GoalSource::Misc, goal)
         });
 
         match result {
@@ -284,12 +298,6 @@ where
     ) -> (Result<NestedNormalizationGoals<I>, NoSolution>, inspect::GoalEvaluation<I>) {
         evaluate_root_goal_for_proof_tree(self, goal, span)
     }
-}
-
-#[derive(Debug, Clone, Copy)]
-enum RerunStalled {
-    WontMakeProgress(Certainty),
-    MayMakeProgress,
 }
 
 impl<'a, D, I> EvalCtxt<'a, D>
@@ -484,125 +492,35 @@ where
         goal: Goal<I, I::Predicate>,
         stalled_on: Option<GoalStalledOn<I>>,
     ) -> Result<GoalEvaluation<I>, NoSolutionOrRerunNonErased> {
-        let (normalization_nested_goals, goal_evaluation) =
-            self.evaluate_goal_raw(source, goal, stalled_on, LowerAvailableDepth::Yes)?;
-        assert!(normalization_nested_goals.is_empty());
-        Ok(goal_evaluation)
+        if let RerunStalled::WontMakeProgress(stalled_certainty) =
+            rerunning_stalled_goal_may_make_progress(self.delegate, stalled_on.as_ref())
+        {
+            return Ok(GoalEvaluation {
+                goal,
+                certainty: stalled_certainty,
+                has_changed: HasChanged::No,
+                stalled_on,
+            });
+        }
+
+        if let Some(res) = compute_goal_fast_path(self.delegate, goal, self.origin_span) {
+            return Ok(res);
+        }
+
+        self.evaluate_goal_no_fast_paths(source, goal)
     }
 
-    /// This is a fast path optimization:
-    /// If we have run this goal before, and it was stalled, check that any of the goal's
-    /// args have changed. This is a cheap way to determine that if we were to rerun this goal now,
-    /// it will remain stalled since it'll canonicalize the same way and evaluation is pure.
-    /// Therefore, we can skip this rerun
-    fn rerunning_stalled_goal_may_make_progress(
-        &self,
-        stalled_on: Option<&GoalStalledOn<I>>,
-    ) -> RerunStalled {
-        use RerunStalled::*;
-
-        // If fast paths are turned off, then we assume all goals can always make progress
-        if self.delegate.disable_trait_solver_fast_paths() {
-            return MayMakeProgress;
-        }
-
-        // If the goal isn't stalled, we should definitely run it.
-        let Some(&GoalStalledOn { ref reason, ref stalled_vars, ref sub_roots, stalled_certainty }) =
-            stalled_on
-        else {
-            return MayMakeProgress;
-        };
-
-        // If any of the stalled goal's generic arguments changed,
-        // rerunning might make progress so we should rerun.
-        if stalled_vars.iter().any(|value| self.delegate.is_changed_arg(*value)) {
-            return MayMakeProgress;
-        }
-
-        // If some inference took place in any of the sub roots,
-        // rerunning might make progress so we should rerun.
-        if sub_roots.iter().any(|&vid| self.delegate.sub_unification_table_root_var(vid) != vid) {
-            return MayMakeProgress;
-        }
-
-        match reason {
-            GoalStalledOnReason::FastPath => {
-                // fastpath is never because of opaques, we can skip this check
-            }
-            &GoalStalledOnReason::Other { num_opaques, ref previously_succeeded_in_erased } => {
-                // If any opaques changed in the opaque type storage,
-                // rerunning might make progress so we should rerun.
-                if self.delegate.opaque_types_storage_num_entries().needs_reevaluation(num_opaques)
-                {
-                    // Unless this goal previously succeeded in erased mode.
-                    // If the stalled goal successfully evaluated while erasing opaque types,
-                    // and the current state of the opaque type storage is not different in a way that is
-                    // relevant, this stalled goal cannot make any progress and we set this variable to true.
-                    let mut previous_erased_run_is_still_valid = false;
-
-                    if let &SucceededInErased::Yes { accessed_opaques } =
-                        previously_succeeded_in_erased
-                    {
-                        match self.should_rerun_after_erased_canonicalization(
-                            accessed_opaques,
-                            self.typing_mode(),
-                            &self.delegate.clone_opaque_types_lookup_table(),
-                        ) {
-                            RerunDecision::Yes => {}
-                            RerunDecision::EagerlyPropagateToParent => {
-                                unreachable!(
-                                    "we never retry stalled queries if the parent was erased"
-                                )
-                            }
-                            RerunDecision::No => {
-                                previous_erased_run_is_still_valid = true;
-                            }
-                        }
-                    }
-
-                    if !previous_erased_run_is_still_valid {
-                        return MayMakeProgress;
-                    }
-                }
-            }
-        }
-
-        // Otherwise, we can be sure that this stalled goal cannot make any progress
-        // and we can exit early.
-        WontMakeProgress(stalled_certainty)
-    }
-
-    /// This is a fast path optimization:
-    /// See the docs on [`ComputeGoalFastPathOutcome`]
-    pub fn compute_goal_fast_path(
-        &self,
+    // Outlining and `#[cold]` matter here because fast paths make it less likely to get here.
+    #[cold]
+    #[inline(never)]
+    fn evaluate_goal_no_fast_paths(
+        &mut self,
+        source: GoalSource,
         goal: Goal<I, I::Predicate>,
-    ) -> Option<(NestedNormalizationGoals<I>, GoalEvaluation<I>)> {
-        if self.delegate.disable_trait_solver_fast_paths() {
-            return None;
-        }
-
-        match self.delegate.compute_goal_fast_path(goal, self.origin_span) {
-            ComputeGoalFastPathOutcome::NoFastPath => None,
-            ComputeGoalFastPathOutcome::TriviallyHolds => Some((
-                NestedNormalizationGoals::empty(),
-                GoalEvaluation {
-                    goal,
-                    certainty: Certainty::Yes,
-                    has_changed: HasChanged::No,
-                    stalled_on: None,
-                },
-            )),
-            ComputeGoalFastPathOutcome::TriviallyStalled { stalled_on } => Some((
-                NestedNormalizationGoals::empty(),
-                GoalEvaluation {
-                    goal,
-                    certainty: Certainty::AMBIGUOUS,
-                    has_changed: HasChanged::No,
-                    stalled_on: Some(stalled_on),
-                },
-            )),
-        }
+    ) -> Result<GoalEvaluation<I>, NoSolutionOrRerunNonErased> {
+        let (normalization_nested_goals, goal_evaluation) =
+            self.evaluate_goal_raw(source, goal, LowerAvailableDepth::Yes)?;
+        Ok(goal_evaluation)
     }
 
     /// Recursively evaluates `goal`, returning the nested goals in case
@@ -616,38 +534,8 @@ where
         &mut self,
         source: GoalSource,
         goal: Goal<I, I::Predicate>,
-        stalled_on: Option<GoalStalledOn<I>>,
         increase_depth_for_nested: LowerAvailableDepth,
     ) -> Result<(NestedNormalizationGoals<I>, GoalEvaluation<I>), NoSolutionOrRerunNonErased> {
-        if let RerunStalled::WontMakeProgress(stalled_certainty) =
-            self.rerunning_stalled_goal_may_make_progress(stalled_on.as_ref())
-        {
-            return Ok((
-                NestedNormalizationGoals::empty(),
-                GoalEvaluation {
-                    goal,
-                    certainty: stalled_certainty,
-                    has_changed: HasChanged::No,
-                    stalled_on,
-                },
-            ));
-        }
-
-        self.evaluate_goal_cold(source, goal, increase_depth_for_nested)
-    }
-
-    #[cold]
-    #[inline(never)]
-    pub(super) fn evaluate_goal_cold(
-        &mut self,
-        source: GoalSource,
-        goal: Goal<I, I::Predicate>,
-        increase_depth_for_nested: LowerAvailableDepth,
-    ) -> Result<(NestedNormalizationGoals<I>, GoalEvaluation<I>), NoSolutionOrRerunNonErased> {
-        if let Some(res) = self.compute_goal_fast_path(goal) {
-            return Ok(res);
-        }
-
         // We only care about one entry per `OpaqueTypeKey` here,
         // so we only canonicalize the lookup table and ignore
         // duplicate entries.
@@ -714,7 +602,7 @@ where
                     &mut inspect::ProofTreeBuilder::new_noop(),
                 );
 
-                let should_rerun = self.should_rerun_after_erased_canonicalization(
+                let should_rerun = should_rerun_after_erased_canonicalization(
                     accessed_opaques,
                     self.typing_mode(),
                     &opaque_types,
@@ -856,100 +744,6 @@ where
                 previously_succeeded_in_erased,
             },
         }
-    }
-
-    fn should_rerun_after_erased_canonicalization(
-        &self,
-        AccessedOpaques { reason: _, rerun }: AccessedOpaques<I>,
-        original_typing_mode: TypingMode<I>,
-        parent_opaque_types: &[(OpaqueTypeKey<I>, I::Ty)],
-    ) -> RerunDecision {
-        let parent_opaque_defids = parent_opaque_types.iter().map(|(key, _)| key.def_id.into());
-        let opaque_in_storage = |opaques: I::LocalDefIds, defids: SmallCopyList<_>| {
-            if defids.as_ref().is_empty() {
-                RerunDecision::No
-            } else if opaques
-                .iter()
-                .chain(parent_opaque_defids)
-                .any(|opaque| defids.as_ref().contains(&opaque))
-            {
-                RerunDecision::Yes
-            } else {
-                RerunDecision::No
-            }
-        };
-        let any_opaque_has_infer_as_hidden = || {
-            if parent_opaque_types.iter().any(|(_, ty)| ty.is_ty_var()) {
-                RerunDecision::Yes
-            } else {
-                RerunDecision::No
-            }
-        };
-
-        let res = match (rerun, original_typing_mode) {
-            // =============================
-            (RerunCondition::Never, _) => RerunDecision::No,
-            // =============================
-            (_, TypingMode::ErasedNotCoherence(MayBeErased)) => {
-                RerunDecision::EagerlyPropagateToParent
-            }
-            // =============================
-            // In coherence, we never switch to erased mode, so we will never register anything
-            // in the rerun state, so we should've taken the first branch of this match
-            (_, TypingMode::Coherence) => unreachable!(),
-            // =============================
-            (RerunCondition::Always, _) => RerunDecision::Yes,
-            // =============================
-            (
-                RerunCondition::OpaqueInStorage(..),
-                TypingMode::PostAnalysis | TypingMode::Codegen,
-            ) => RerunDecision::Yes,
-            (
-                RerunCondition::OpaqueInStorage(defids),
-                TypingMode::PostBorrowck { defined_opaque_types: opaques }
-                | TypingMode::Typeck { defining_opaque_types_and_generators: opaques }
-                | TypingMode::PostTypeckUntilBorrowck { defining_opaque_types: opaques },
-            ) => opaque_in_storage(opaques, defids),
-            // =============================
-            (RerunCondition::AnyOpaqueHasInferAsHidden, TypingMode::Typeck { .. }) => {
-                any_opaque_has_infer_as_hidden()
-            }
-            (
-                RerunCondition::AnyOpaqueHasInferAsHidden,
-                TypingMode::PostBorrowck { .. }
-                | TypingMode::PostAnalysis
-                | TypingMode::Codegen
-                | TypingMode::PostTypeckUntilBorrowck { .. },
-            ) => RerunDecision::No,
-            // =============================
-            (
-                RerunCondition::OpaqueInStorageOrAnyOpaqueHasInferAsHidden(_),
-                TypingMode::PostAnalysis | TypingMode::Codegen,
-            ) => RerunDecision::Yes,
-            (
-                RerunCondition::OpaqueInStorageOrAnyOpaqueHasInferAsHidden(defids),
-                TypingMode::Typeck { defining_opaque_types_and_generators: opaques },
-            ) => {
-                if let RerunDecision::Yes = any_opaque_has_infer_as_hidden() {
-                    RerunDecision::Yes
-                } else if let RerunDecision::Yes = opaque_in_storage(opaques, defids) {
-                    RerunDecision::Yes
-                } else {
-                    RerunDecision::No
-                }
-            }
-            (
-                RerunCondition::OpaqueInStorageOrAnyOpaqueHasInferAsHidden(defids),
-                TypingMode::PostBorrowck { defined_opaque_types: opaques }
-                | TypingMode::PostTypeckUntilBorrowck { defining_opaque_types: opaques },
-            ) => opaque_in_storage(opaques, defids),
-        };
-
-        debug!(
-            "checking whether to rerun {rerun:?} in outer typing mode {original_typing_mode:?} and opaques {parent_opaque_types:?}: {res:?}"
-        );
-
-        res
     }
 
     pub(super) fn compute_goal(
@@ -1777,6 +1571,103 @@ where
         });
         value.try_fold_with(&mut folder)
     }
+}
+
+#[derive(Debug)]
+enum RerunDecision {
+    Yes,
+    No,
+    EagerlyPropagateToParent,
+}
+
+fn should_rerun_after_erased_canonicalization<I: Interner>(
+    AccessedOpaques { reason: _, rerun }: AccessedOpaques<I>,
+    original_typing_mode: TypingMode<I>,
+    parent_opaque_types: &[(OpaqueTypeKey<I>, I::Ty)],
+) -> RerunDecision {
+    let parent_opaque_defids = parent_opaque_types.iter().map(|(key, _)| key.def_id.into());
+    let opaque_in_storage = |opaques: I::LocalDefIds, defids: SmallCopyList<_>| {
+        if defids.as_ref().is_empty() {
+            RerunDecision::No
+        } else if opaques
+            .iter()
+            .chain(parent_opaque_defids)
+            .any(|opaque| defids.as_ref().contains(&opaque))
+        {
+            RerunDecision::Yes
+        } else {
+            RerunDecision::No
+        }
+    };
+    let any_opaque_has_infer_as_hidden = || {
+        if parent_opaque_types.iter().any(|(_, ty)| ty.is_ty_var()) {
+            RerunDecision::Yes
+        } else {
+            RerunDecision::No
+        }
+    };
+
+    let res = match (rerun, original_typing_mode) {
+        // =============================
+        (RerunCondition::Never, _) => RerunDecision::No,
+        // =============================
+        (_, TypingMode::ErasedNotCoherence(MayBeErased)) => RerunDecision::EagerlyPropagateToParent,
+        // =============================
+        // In coherence, we never switch to erased mode, so we will never register anything
+        // in the rerun state, so we should've taken the first branch of this match
+        (_, TypingMode::Coherence) => unreachable!(),
+        // =============================
+        (RerunCondition::Always, _) => RerunDecision::Yes,
+        // =============================
+        (RerunCondition::OpaqueInStorage(..), TypingMode::PostAnalysis | TypingMode::Codegen) => {
+            RerunDecision::Yes
+        }
+        (
+            RerunCondition::OpaqueInStorage(defids),
+            TypingMode::PostBorrowck { defined_opaque_types: opaques }
+            | TypingMode::Typeck { defining_opaque_types_and_generators: opaques }
+            | TypingMode::PostTypeckUntilBorrowck { defining_opaque_types: opaques },
+        ) => opaque_in_storage(opaques, defids),
+        // =============================
+        (RerunCondition::AnyOpaqueHasInferAsHidden, TypingMode::Typeck { .. }) => {
+            any_opaque_has_infer_as_hidden()
+        }
+        (
+            RerunCondition::AnyOpaqueHasInferAsHidden,
+            TypingMode::PostBorrowck { .. }
+            | TypingMode::PostAnalysis
+            | TypingMode::Codegen
+            | TypingMode::PostTypeckUntilBorrowck { .. },
+        ) => RerunDecision::No,
+        // =============================
+        (
+            RerunCondition::OpaqueInStorageOrAnyOpaqueHasInferAsHidden(_),
+            TypingMode::PostAnalysis | TypingMode::Codegen,
+        ) => RerunDecision::Yes,
+        (
+            RerunCondition::OpaqueInStorageOrAnyOpaqueHasInferAsHidden(defids),
+            TypingMode::Typeck { defining_opaque_types_and_generators: opaques },
+        ) => {
+            if let RerunDecision::Yes = any_opaque_has_infer_as_hidden() {
+                RerunDecision::Yes
+            } else if let RerunDecision::Yes = opaque_in_storage(opaques, defids) {
+                RerunDecision::Yes
+            } else {
+                RerunDecision::No
+            }
+        }
+        (
+            RerunCondition::OpaqueInStorageOrAnyOpaqueHasInferAsHidden(defids),
+            TypingMode::PostBorrowck { defined_opaque_types: opaques }
+            | TypingMode::PostTypeckUntilBorrowck { defining_opaque_types: opaques },
+        ) => opaque_in_storage(opaques, defids),
+    };
+
+    debug!(
+        "checking whether to rerun {rerun:?} in outer typing mode {original_typing_mode:?} and opaques {parent_opaque_types:?}: {res:?}"
+    );
+
+    res
 }
 
 /// Do not call this directly, use the `tcx` query instead.

--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
@@ -633,10 +633,6 @@ where
             ));
         }
 
-        if let Some(res) = self.compute_goal_fast_path(goal) {
-            return Ok(res);
-        }
-
         self.evaluate_goal_cold(source, goal, increase_depth_for_nested)
     }
 
@@ -648,6 +644,10 @@ where
         goal: Goal<I, I::Predicate>,
         increase_depth_for_nested: LowerAvailableDepth,
     ) -> Result<(NestedNormalizationGoals<I>, GoalEvaluation<I>), NoSolutionOrRerunNonErased> {
+        if let Some(res) = self.compute_goal_fast_path(goal) {
+            return Ok(res);
+        }
+
         // We only care about one entry per `OpaqueTypeKey` here,
         // so we only canonicalize the lookup table and ignore
         // duplicate entries.

--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
@@ -34,6 +34,7 @@ use crate::resolve::eager_resolve_vars;
 use crate::solve::eval_ctxt::fast_path::{
     RerunStalled, compute_goal_fast_path, rerunning_stalled_goal_may_make_progress,
 };
+use crate::solve::fast_path::compute_goal_fast_path_cold;
 use crate::solve::search_graph::SearchGraph;
 use crate::solve::ty::may_use_unstable_feature;
 use crate::solve::{
@@ -43,7 +44,7 @@ use crate::solve::{
     VisibleForLeakCheck, inspect,
 };
 
-mod fast_path;
+pub mod fast_path;
 mod probe;
 mod solver_region_constraints;
 
@@ -236,7 +237,13 @@ where
             });
         }
 
-        if let Some(res) = compute_goal_fast_path(self, goal, span) {
+        if
+        // No need to try the fast path if stalled_on is `None`, since we already try the fast path
+        // immediately when adding new goals. If we didn't check `stalled_on` here we'd be trying
+        // the fast path twice for some goals.
+        stalled_on.is_some()
+            && let Some(res) = compute_goal_fast_path_cold(self, goal, span)
+        {
             return Ok(res);
         }
 
@@ -503,7 +510,13 @@ where
             });
         }
 
-        if let Some(res) = compute_goal_fast_path(self.delegate, goal, self.origin_span) {
+        if
+        // No need to try the fast path if stalled_on is `None`, since we already try the fast path
+        // immediately when adding new goals. If we didn't check `stalled_on` here we'd be trying
+        // the fast path twice for some goals.
+        stalled_on.is_some()
+            && let Some(res) = compute_goal_fast_path_cold(self.delegate, goal, self.origin_span)
+        {
             return Ok(res);
         }
 
@@ -520,6 +533,7 @@ where
     ) -> Result<GoalEvaluation<I>, NoSolutionOrRerunNonErased> {
         let (normalization_nested_goals, goal_evaluation) =
             self.evaluate_goal_raw(source, goal, LowerAvailableDepth::Yes)?;
+        assert!(normalization_nested_goals.is_empty());
         Ok(goal_evaluation)
     }
 
@@ -881,7 +895,20 @@ where
             ty::Unnormalized::new_wip(goal.predicate),
         )?;
         self.inspect.add_goal(self.delegate, self.max_input_universe, source, goal);
-        self.nested_goals.push((source, goal, None));
+
+        if let Some(GoalEvaluation { goal, certainty, has_changed: _, stalled_on }) =
+            compute_goal_fast_path(self.delegate, goal, self.origin_span)
+        {
+            match certainty {
+                // We're done here
+                Certainty::Yes => {}
+                Certainty::Maybe(_) => {
+                    self.nested_goals.push((source, goal, stalled_on));
+                }
+            }
+        } else {
+            self.nested_goals.push((source, goal, None));
+        }
         Ok(())
     }
 

--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
@@ -39,7 +39,7 @@ use crate::solve::search_graph::SearchGraph;
 use crate::solve::ty::may_use_unstable_feature;
 use crate::solve::{
     CanonicalInput, CanonicalResponse, Certainty, ExternalConstraintsData, FIXPOINT_STEP_LIMIT,
-    Goal, GoalEvaluation, GoalSource, GoalStalledOn, GoalStalledOnReason, HasChanged, MaybeCause,
+    Goal, GoalEvaluation, GoalSource, GoalStalledOn, GoalStalledOnOpaques, HasChanged, MaybeCause,
     NestedNormalizationGoals, NoSolution, QueryInput, QueryResult, Response, SucceededInErased,
     VisibleForLeakCheck, inspect,
 };
@@ -753,8 +753,12 @@ where
             stalled_vars,
             sub_roots,
             stalled_certainty: certainty,
-            reason: GoalStalledOnReason::Other {
-                num_opaques: canonical_goal.canonical.value.predefined_opaques_in_body.len(),
+            opaques: GoalStalledOnOpaques::Yes {
+                num_opaques_in_storage: canonical_goal
+                    .canonical
+                    .value
+                    .predefined_opaques_in_body
+                    .len(),
                 previously_succeeded_in_erased,
             },
         }

--- a/compiler/rustc_next_trait_solver/src/solve/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/mod.rs
@@ -28,7 +28,7 @@ use tracing::instrument;
 
 pub use self::eval_ctxt::{
     EvalCtxt, GenerateProofTree, SolverDelegateEvalExt,
-    evaluate_root_goal_for_proof_tree_raw_provider,
+    evaluate_root_goal_for_proof_tree_raw_provider, fast_path,
 };
 use crate::delegate::SolverDelegate;
 use crate::solve::assembly::Candidate;

--- a/compiler/rustc_next_trait_solver/src/solve/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/mod.rs
@@ -23,7 +23,7 @@ mod trait_goals;
 use derive_where::derive_where;
 use rustc_type_ir::inherent::*;
 pub use rustc_type_ir::solve::*;
-use rustc_type_ir::{self as ty, Interner, TyVid};
+use rustc_type_ir::{self as ty, Interner};
 use tracing::instrument;
 
 pub use self::eval_ctxt::{
@@ -423,22 +423,4 @@ pub struct GoalEvaluation<I: Interner> {
     /// If the [`Certainty`] was `Maybe`, then keep track of whether the goal has changed
     /// before rerunning it.
     pub stalled_on: Option<GoalStalledOn<I>>,
-}
-
-/// The conditions that must change for a goal to warrant
-#[derive_where(Clone, Debug; I: Interner)]
-pub struct GoalStalledOn<I: Interner> {
-    pub num_opaques: usize,
-    pub stalled_vars: Vec<I::GenericArg>,
-    pub sub_roots: Vec<TyVid>,
-    /// The certainty that will be returned on subsequent evaluations if this
-    /// goal remains stalled.
-    pub stalled_certainty: Certainty,
-    pub previously_succeeded_in_erased: SucceededInErased<I>,
-}
-
-#[derive_where(Clone, Debug; I: Interner)]
-pub enum SucceededInErased<I: Interner> {
-    Yes { accessed_opaques: AccessedOpaques<I> },
-    No,
 }

--- a/compiler/rustc_next_trait_solver/src/solve/project_goals/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/project_goals/mod.rs
@@ -71,7 +71,6 @@ where
         ) = self.evaluate_goal_raw(
             GoalSource::TypeRelating,
             normalizes_to,
-            None,
             // We don't lower thr available depth for this `NormalizesTo` goal, as evaluating
             // it is an extra step only exists in the new solver that behaves like a function
             // call rather than an independent nested goal evaluation. So, decreasing the

--- a/compiler/rustc_trait_selection/src/solve/delegate.rs
+++ b/compiler/rustc_trait_selection/src/solve/delegate.rs
@@ -10,12 +10,15 @@ use rustc_infer::infer::canonical::{
     QueryRegionConstraint,
 };
 use rustc_infer::infer::{InferCtxt, RegionVariableOrigin, SubregionOrigin, TyCtxtInferExt};
-use rustc_infer::traits::solve::{FetchEligibleAssocItemResponse, Goal};
+use rustc_infer::traits::solve::{
+    ComputeGoalFastPathOutcome, FetchEligibleAssocItemResponse, Goal,
+};
 use rustc_middle::traits::query::NoSolution;
 use rustc_middle::traits::solve::Certainty;
 use rustc_middle::ty::{
     self, MayBeErased, Ty, TyCtxt, TypeFlags, TypeFoldable, TypeVisitableExt, TypingMode,
 };
+use rustc_next_trait_solver::solve::{GoalStalledOn, GoalStalledOnReason};
 use rustc_span::{DUMMY_SP, Span};
 
 use crate::traits::{EvaluateConstErr, ObligationCause, sizedness_fast_path, specialization_graph};
@@ -73,10 +76,25 @@ impl<'tcx> rustc_next_trait_solver::delegate::SolverDelegate for SolverDelegate<
         &self,
         goal: Goal<'tcx, ty::Predicate<'tcx>>,
         span: Span,
-    ) -> Option<Certainty> {
+    ) -> ComputeGoalFastPathOutcome<'tcx> {
+        use ComputeGoalFastPathOutcome as Outcome;
+
+        fn stalled_with_args<'tcx>(
+            stalled_vars: Vec<ty::GenericArg<'tcx>>,
+        ) -> ComputeGoalFastPathOutcome<'tcx> {
+            Outcome::TriviallyStalled {
+                stalled_on: GoalStalledOn {
+                    stalled_vars,
+                    sub_roots: Vec::new(),
+                    stalled_certainty: Certainty::AMBIGUOUS,
+                    reason: GoalStalledOnReason::FastPath,
+                },
+            }
+        }
+
         // FIXME(-Zassumptions-on-binders): actually handle fast path
         if self.tcx.assumptions_on_binders() {
-            return None;
+            return Outcome::NoFastPath;
         }
 
         let pred = goal.predicate.kind();
@@ -84,22 +102,23 @@ impl<'tcx> rustc_next_trait_solver::delegate::SolverDelegate for SolverDelegate<
             ty::PredicateKind::Clause(ty::ClauseKind::Trait(trait_pred)) => {
                 let trait_pred = pred.rebind(trait_pred);
 
-                if self.shallow_resolve(trait_pred.self_ty().skip_binder()).is_ty_var()
+                let self_ty = self.shallow_resolve(trait_pred.self_ty().skip_binder());
+                if self_ty.is_ty_var()
                 // We don't do this fast path when opaques are defined since we may
                 // eventually use opaques to incompletely guide inference via ty var
                 // self types.
                 // FIXME: Properly consider opaques here.
                 && self.known_no_opaque_types_in_storage()
                 {
-                    Some(Certainty::AMBIGUOUS)
+                    stalled_with_args(vec![self_ty.into()])
                 } else if trait_pred.polarity() == ty::PredicatePolarity::Positive {
                     match self.0.tcx.as_lang_item(trait_pred.def_id()) {
                         Some(LangItem::Sized) | Some(LangItem::MetaSized) => {
                             let predicate = self.resolve_vars_if_possible(goal.predicate);
                             if sizedness_fast_path(self.tcx, predicate, goal.param_env) {
-                                return Some(Certainty::Yes);
+                                return Outcome::TriviallyHolds;
                             } else {
-                                None
+                                Outcome::NoFastPath
                             }
                         }
                         Some(LangItem::Copy | LangItem::Clone) => {
@@ -114,23 +133,23 @@ impl<'tcx> rustc_next_trait_solver::delegate::SolverDelegate for SolverDelegate<
                                 .has_type_flags(TypeFlags::HAS_FREE_REGIONS | TypeFlags::HAS_INFER)
                                 && self_ty.is_trivially_pure_clone_copy()
                             {
-                                return Some(Certainty::Yes);
+                                return Outcome::TriviallyHolds;
                             } else {
-                                None
+                                Outcome::NoFastPath
                             }
                         }
-                        _ => None,
+                        _ => Outcome::NoFastPath,
                     }
                 } else {
-                    None
+                    Outcome::NoFastPath
                 }
             }
             ty::PredicateKind::DynCompatible(def_id) if self.0.tcx.is_dyn_compatible(def_id) => {
-                Some(Certainty::Yes)
+                Outcome::TriviallyHolds
             }
             ty::PredicateKind::Clause(ty::ClauseKind::RegionOutlives(outlives)) => {
                 if outlives.has_escaping_bound_vars() {
-                    return None;
+                    return Outcome::NoFastPath;
                 }
 
                 self.0.sub_regions(
@@ -139,11 +158,11 @@ impl<'tcx> rustc_next_trait_solver::delegate::SolverDelegate for SolverDelegate<
                     outlives.0,
                     ty::VisibleForLeakCheck::Yes,
                 );
-                Some(Certainty::Yes)
+                Outcome::TriviallyHolds
             }
             ty::PredicateKind::Clause(ty::ClauseKind::TypeOutlives(outlives)) => {
                 if outlives.has_escaping_bound_vars() {
-                    return None;
+                    return Outcome::NoFastPath;
                 }
 
                 self.0.register_type_outlives_constraint(
@@ -152,48 +171,49 @@ impl<'tcx> rustc_next_trait_solver::delegate::SolverDelegate for SolverDelegate<
                     &ObligationCause::dummy_with_span(span),
                 );
 
-                Some(Certainty::Yes)
+                Outcome::TriviallyHolds
             }
             ty::PredicateKind::Subtype(ty::SubtypePredicate { a, b, .. })
             | ty::PredicateKind::Coerce(ty::CoercePredicate { a, b }) => {
                 if a.has_escaping_bound_vars() || b.has_escaping_bound_vars() {
-                    return None;
+                    return Outcome::NoFastPath;
                 }
 
                 match (self.shallow_resolve(a).kind(), self.shallow_resolve(b).kind()) {
                     (&ty::Infer(ty::TyVar(a_vid)), &ty::Infer(ty::TyVar(b_vid))) => {
                         self.sub_unify_ty_vids_raw(a_vid, b_vid);
-                        Some(Certainty::AMBIGUOUS)
+                        stalled_with_args(vec![a.into(), b.into()])
                     }
-                    _ => None,
+                    _ => Outcome::NoFastPath,
                 }
             }
             ty::PredicateKind::Clause(ty::ClauseKind::ConstArgHasType(ct, _)) => {
                 if ct.has_escaping_bound_vars() {
-                    return None;
+                    return Outcome::NoFastPath;
                 }
 
-                if self.shallow_resolve_const(ct).is_ct_infer() {
-                    Some(Certainty::AMBIGUOUS)
+                let arg = self.shallow_resolve_const(ct);
+                if arg.is_ct_infer() {
+                    stalled_with_args(vec![arg.into()])
                 } else {
-                    None
+                    Outcome::NoFastPath
                 }
             }
             ty::PredicateKind::Clause(ty::ClauseKind::WellFormed(arg)) => {
                 if arg.has_escaping_bound_vars() {
-                    return None;
+                    return Outcome::NoFastPath;
                 }
 
                 let arg = self.shallow_resolve_term(arg);
                 if arg.is_trivially_wf(self.tcx) {
-                    Some(Certainty::Yes)
+                    Outcome::TriviallyHolds
                 } else if arg.is_infer() {
-                    Some(Certainty::AMBIGUOUS)
+                    stalled_with_args(vec![arg.into_arg()])
                 } else {
-                    None
+                    Outcome::NoFastPath
                 }
             }
-            _ => None,
+            _ => Outcome::NoFastPath,
         }
     }
 

--- a/compiler/rustc_trait_selection/src/solve/delegate.rs
+++ b/compiler/rustc_trait_selection/src/solve/delegate.rs
@@ -11,14 +11,14 @@ use rustc_infer::infer::canonical::{
 };
 use rustc_infer::infer::{InferCtxt, RegionVariableOrigin, SubregionOrigin, TyCtxtInferExt};
 use rustc_infer::traits::solve::{
-    ComputeGoalFastPathOutcome, FetchEligibleAssocItemResponse, Goal,
+    ComputeGoalFastPathOutcome, FetchEligibleAssocItemResponse, Goal, SucceededInErased,
 };
 use rustc_middle::traits::query::NoSolution;
 use rustc_middle::traits::solve::Certainty;
 use rustc_middle::ty::{
     self, MayBeErased, Ty, TyCtxt, TypeFlags, TypeFoldable, TypeVisitableExt, TypingMode,
 };
-use rustc_next_trait_solver::solve::{GoalStalledOn, GoalStalledOnReason};
+use rustc_next_trait_solver::solve::{GoalStalledOn, GoalStalledOnOpaques};
 use rustc_span::{DUMMY_SP, Span};
 
 use crate::traits::{EvaluateConstErr, ObligationCause, sizedness_fast_path, specialization_graph};
@@ -47,6 +47,43 @@ impl<'tcx> SolverDelegate<'tcx> {
             // in erased mode, observing that opaques are empty aren't enough to give a result
             // here, so let's try the slow path instead.
             && !self.typing_mode_raw().is_erased_not_coherence()
+    }
+}
+
+/// Create a [`ComputeGoalFastPathOutcome`] signalling the  goal is stalled
+/// on a list of [`ty::GenericArg`]
+fn goal_stalled_on_args<'tcx>(
+    stalled_vars: Vec<ty::GenericArg<'tcx>>,
+) -> ComputeGoalFastPathOutcome<'tcx> {
+    ComputeGoalFastPathOutcome::TriviallyStalled {
+        stalled_on: GoalStalledOn {
+            stalled_vars,
+            sub_roots: Vec::new(),
+            stalled_certainty: Certainty::AMBIGUOUS,
+            opaques: GoalStalledOnOpaques::No,
+        },
+    }
+}
+
+/// Create a [`ComputeGoalFastPathOutcome`] signalling the  goal is stalled
+/// on a list of [`ty::GenericArg`] *or* the opaque type storage being nonempty.
+///
+fn goal_stalled_on_args_or_nonempty_opaques<'tcx>(
+    stalled_vars: Vec<ty::GenericArg<'tcx>>,
+) -> ComputeGoalFastPathOutcome<'tcx> {
+    ComputeGoalFastPathOutcome::TriviallyStalled {
+        stalled_on: GoalStalledOn {
+            stalled_vars,
+            sub_roots: Vec::new(),
+            stalled_certainty: Certainty::AMBIGUOUS,
+            opaques: GoalStalledOnOpaques::Yes {
+                num_opaques_in_storage: 0,
+                // This function should only be called when not in erased mode,
+                // otherwise this is wrong. The `compute_goal_fast_path` does this
+                // through `known_no_opaque_types_in_storage`
+                previously_succeeded_in_erased: SucceededInErased::No,
+            },
+        },
     }
 }
 
@@ -79,19 +116,6 @@ impl<'tcx> rustc_next_trait_solver::delegate::SolverDelegate for SolverDelegate<
     ) -> ComputeGoalFastPathOutcome<'tcx> {
         use ComputeGoalFastPathOutcome as Outcome;
 
-        fn stalled_with_args<'tcx>(
-            stalled_vars: Vec<ty::GenericArg<'tcx>>,
-        ) -> ComputeGoalFastPathOutcome<'tcx> {
-            Outcome::TriviallyStalled {
-                stalled_on: GoalStalledOn {
-                    stalled_vars,
-                    sub_roots: Vec::new(),
-                    stalled_certainty: Certainty::AMBIGUOUS,
-                    reason: GoalStalledOnReason::FastPath,
-                },
-            }
-        }
-
         // FIXME(-Zassumptions-on-binders): actually handle fast path
         if self.tcx.assumptions_on_binders() {
             return Outcome::NoFastPath;
@@ -110,13 +134,13 @@ impl<'tcx> rustc_next_trait_solver::delegate::SolverDelegate for SolverDelegate<
                 // FIXME: Properly consider opaques here.
                 && self.known_no_opaque_types_in_storage()
                 {
-                    stalled_with_args(vec![self_ty.into()])
+                    goal_stalled_on_args_or_nonempty_opaques(vec![self_ty.into()])
                 } else if trait_pred.polarity() == ty::PredicatePolarity::Positive {
                     match self.0.tcx.as_lang_item(trait_pred.def_id()) {
                         Some(LangItem::Sized) | Some(LangItem::MetaSized) => {
                             let predicate = self.resolve_vars_if_possible(goal.predicate);
                             if sizedness_fast_path(self.tcx, predicate, goal.param_env) {
-                                return Outcome::TriviallyHolds;
+                                Outcome::TriviallyHolds
                             } else {
                                 Outcome::NoFastPath
                             }
@@ -133,7 +157,7 @@ impl<'tcx> rustc_next_trait_solver::delegate::SolverDelegate for SolverDelegate<
                                 .has_type_flags(TypeFlags::HAS_FREE_REGIONS | TypeFlags::HAS_INFER)
                                 && self_ty.is_trivially_pure_clone_copy()
                             {
-                                return Outcome::TriviallyHolds;
+                                Outcome::TriviallyHolds
                             } else {
                                 Outcome::NoFastPath
                             }
@@ -182,7 +206,7 @@ impl<'tcx> rustc_next_trait_solver::delegate::SolverDelegate for SolverDelegate<
                 match (self.shallow_resolve(a).kind(), self.shallow_resolve(b).kind()) {
                     (&ty::Infer(ty::TyVar(a_vid)), &ty::Infer(ty::TyVar(b_vid))) => {
                         self.sub_unify_ty_vids_raw(a_vid, b_vid);
-                        stalled_with_args(vec![a.into(), b.into()])
+                        goal_stalled_on_args(vec![a.into(), b.into()])
                     }
                     _ => Outcome::NoFastPath,
                 }
@@ -194,7 +218,7 @@ impl<'tcx> rustc_next_trait_solver::delegate::SolverDelegate for SolverDelegate<
 
                 let arg = self.shallow_resolve_const(ct);
                 if arg.is_ct_infer() {
-                    stalled_with_args(vec![arg.into()])
+                    goal_stalled_on_args(vec![arg.into()])
                 } else {
                     Outcome::NoFastPath
                 }
@@ -208,7 +232,7 @@ impl<'tcx> rustc_next_trait_solver::delegate::SolverDelegate for SolverDelegate<
                 if arg.is_trivially_wf(self.tcx) {
                     Outcome::TriviallyHolds
                 } else if arg.is_infer() {
-                    stalled_with_args(vec![arg.into_arg()])
+                    goal_stalled_on_args(vec![arg.into_arg()])
                 } else {
                     Outcome::NoFastPath
                 }

--- a/compiler/rustc_trait_selection/src/solve/delegate.rs
+++ b/compiler/rustc_trait_selection/src/solve/delegate.rs
@@ -50,7 +50,7 @@ impl<'tcx> SolverDelegate<'tcx> {
     }
 }
 
-/// Create a [`ComputeGoalFastPathOutcome`] signalling the  goal is stalled
+/// Create a [`ComputeGoalFastPathOutcome`] signalling the goal is stalled
 /// on a list of [`ty::GenericArg`]
 fn goal_stalled_on_args<'tcx>(
     stalled_vars: Vec<ty::GenericArg<'tcx>>,

--- a/compiler/rustc_trait_selection/src/solve/fulfill.rs
+++ b/compiler/rustc_trait_selection/src/solve/fulfill.rs
@@ -7,6 +7,7 @@ use rustc_infer::traits::{
     FromSolverError, PredicateObligation, PredicateObligations, TraitEngine,
 };
 use rustc_middle::ty::{self, TyCtxt, TyVid, TypeVisitableExt, TypingMode};
+use rustc_next_trait_solver::solve::fast_path::compute_goal_fast_path;
 use rustc_next_trait_solver::solve::{
     GoalEvaluation, GoalStalledOn, HasChanged, MaybeInfo, SolverDelegateEvalExt as _,
     StalledOnCoroutines,
@@ -184,7 +185,22 @@ where
         obligation: PredicateObligation<'tcx>,
     ) {
         assert_eq!(self.usable_in_snapshot, infcx.num_open_snapshots());
-        self.obligations.register(obligation, None);
+
+        let delegate = <&SolverDelegate<'tcx>>::from(infcx);
+        if let Some(GoalEvaluation { goal: _, certainty, has_changed: _, stalled_on }) =
+            compute_goal_fast_path(delegate, obligation.as_goal(), obligation.cause.span)
+        {
+            // If we can take the fast path, don't even bother adding the goal to obligations,
+            // or if `Certainty::Maybe`, add it with precise stalled_on information.
+            match certainty {
+                Certainty::Yes => {}
+                Certainty::Maybe(_) => {
+                    self.obligations.register(obligation, stalled_on);
+                }
+            }
+        } else {
+            self.obligations.register(obligation, None);
+        }
     }
 
     fn collect_remaining_errors(&mut self, infcx: &InferCtxt<'tcx>) -> Vec<E> {

--- a/compiler/rustc_trait_selection/src/solve/fulfill.rs
+++ b/compiler/rustc_trait_selection/src/solve/fulfill.rs
@@ -209,12 +209,6 @@ where
         loop {
             let mut any_changed = false;
             for (mut obligation, stalled_on) in self.obligations.drain_pending(|_, _| true) {
-                if !infcx.tcx.recursion_limit().value_within_limit(obligation.recursion_depth) {
-                    self.obligations.on_fulfillment_overflow(infcx);
-                    // Only return true errors that we have accumulated while processing.
-                    return errors;
-                }
-
                 let goal = obligation.as_goal();
                 let delegate = <&SolverDelegate<'tcx>>::from(infcx);
                 if !delegate.disable_trait_solver_fast_paths()
@@ -261,7 +255,14 @@ where
                     // approximation and should only result in fulfillment overflow in
                     // pathological cases.
                     obligation.recursion_depth += 1;
-                    any_changed = true;
+
+                    if !infcx.tcx.recursion_limit().value_within_limit(obligation.recursion_depth) {
+                        self.obligations.on_fulfillment_overflow(infcx);
+                        // Only return true errors that we have accumulated while processing.
+                        return errors;
+                    } else {
+                        any_changed = true;
+                    }
                 }
 
                 match certainty {

--- a/compiler/rustc_trait_selection/src/solve/fulfill.rs
+++ b/compiler/rustc_trait_selection/src/solve/fulfill.rs
@@ -7,7 +7,6 @@ use rustc_infer::traits::{
     FromSolverError, PredicateObligation, PredicateObligations, TraitEngine,
 };
 use rustc_middle::ty::{self, TyCtxt, TyVid, TypeVisitableExt, TypingMode};
-use rustc_next_trait_solver::delegate::SolverDelegate as _;
 use rustc_next_trait_solver::solve::{
     GoalEvaluation, GoalStalledOn, HasChanged, MaybeInfo, SolverDelegateEvalExt as _,
     StalledOnCoroutines,
@@ -211,24 +210,6 @@ where
             for (mut obligation, stalled_on) in self.obligations.drain_pending(|_, _| true) {
                 let goal = obligation.as_goal();
                 let delegate = <&SolverDelegate<'tcx>>::from(infcx);
-                if !delegate.disable_trait_solver_fast_paths()
-                    && let Some(certainty) =
-                        delegate.compute_goal_fast_path(goal, obligation.cause.span)
-                {
-                    match certainty {
-                        // This fast path doesn't depend on region identity so it doesn't
-                        // matter if the goal contains inference variables or not, so we
-                        // don't need to call `push_hir_typeck_potentially_region_dependent_goal`
-                        // here.
-                        //
-                        // Only goals proven via the trait solver should be region dependent.
-                        Certainty::Yes => {}
-                        Certainty::Maybe(_) => {
-                            self.obligations.register(obligation, None);
-                        }
-                    }
-                    continue;
-                }
 
                 let result = delegate.evaluate_root_goal(goal, obligation.cause.span, stalled_on);
                 self.inspect_evaluated_obligation(infcx, &obligation, &result);

--- a/compiler/rustc_type_ir/src/solve/mod.rs
+++ b/compiler/rustc_type_ir/src/solve/mod.rs
@@ -954,13 +954,13 @@ pub enum SucceededInErased<I: Interner> {
 }
 
 #[derive_where(Clone, Debug; I: Interner)]
-pub enum GoalStalledOnReason<I: Interner> {
+pub enum GoalStalledOnOpaques<I: Interner> {
     /// This goal got stalled in `compute_goal_fast_path`. Usually this means
     /// the goal is stalled on not that much, only one or two variables, and
     /// definitely nothing to do with opaque types. So we don't store that information.
-    FastPath,
-    Other {
-        num_opaques: usize,
+    No,
+    Yes {
+        num_opaques_in_storage: usize,
         previously_succeeded_in_erased: SucceededInErased<I>,
     },
 }
@@ -973,7 +973,7 @@ pub struct GoalStalledOn<I: Interner> {
     /// The certainty that will be returned on subsequent evaluations if this
     /// goal remains stalled.
     pub stalled_certainty: Certainty,
-    pub reason: GoalStalledOnReason<I>,
+    pub opaques: GoalStalledOnOpaques<I>,
 }
 
 /// For some goals we can trivially answer some questions without going through

--- a/compiler/rustc_type_ir/src/solve/mod.rs
+++ b/compiler/rustc_type_ir/src/solve/mod.rs
@@ -16,7 +16,7 @@ use crate::lang_items::SolverTraitLangItem;
 use crate::region_constraint::RegionConstraint;
 use crate::search_graph::PathKind;
 use crate::{
-    self as ty, Canonical, CanonicalVarValues, CantBeErased, Interner, TypingMode, Upcast,
+    self as ty, Canonical, CanonicalVarValues, CantBeErased, Interner, TyVid, TypingMode, Upcast,
 };
 
 pub type CanonicalInput<I, T = <I as Interner>::Predicate> =
@@ -941,4 +941,51 @@ impl SizedTraitKind {
             SizedTraitKind::MetaSized => SolverTraitLangItem::MetaSized,
         })
     }
+}
+
+#[derive_where(Clone, Debug; I: Interner)]
+pub enum SucceededInErased<I: Interner> {
+    /// This goal previously succeeded in erased mode, which based on `accessed_opaques`
+    /// might make us take a fast path slightly more often.
+    Yes {
+        accessed_opaques: AccessedOpaques<I>,
+    },
+    No,
+}
+
+#[derive_where(Clone, Debug; I: Interner)]
+pub enum GoalStalledOnReason<I: Interner> {
+    /// This goal got stalled in `compute_goal_fast_path`. Usually this means
+    /// the goal is stalled on not that much, only one or two variables, and
+    /// definitely nothing to do with opaque types. So we don't store that information.
+    FastPath,
+    Other {
+        num_opaques: usize,
+        previously_succeeded_in_erased: SucceededInErased<I>,
+    },
+}
+
+/// The conditions that must change for a goal to warrant
+#[derive_where(Clone, Debug; I: Interner)]
+pub struct GoalStalledOn<I: Interner> {
+    pub stalled_vars: Vec<I::GenericArg>,
+    pub sub_roots: Vec<TyVid>,
+    /// The certainty that will be returned on subsequent evaluations if this
+    /// goal remains stalled.
+    pub stalled_certainty: Certainty,
+    pub reason: GoalStalledOnReason<I>,
+}
+
+/// For some goals we can trivially answer some questions without going through
+/// canonicalization. There are three options:
+
+#[derive(Clone, Debug)]
+pub enum ComputeGoalFastPathOutcome<I: Interner> {
+    /// Do not attempt the fast path. Compute as normal.
+    NoFastPath,
+    /// The goal trivially holds, immediately produce a result with [`Certainty::Yes`]
+    TriviallyHolds,
+    /// The goal is trivially stalled: we know for sure that it makes no sense to compute it right
+    /// now, but can return information about what its stalled on and when it can be computed for real.
+    TriviallyStalled { stalled_on: GoalStalledOn<I> },
 }


### PR DESCRIPTION

Change in % compared to previous commit on 4 benchmarks. All measured locally on ragdoll (AMD RYZEN 3990X, x86_64). These benchmarks have been quite repeatable in the past, but don't exactly match perf runs. All benchmarks show change in instruction count
First change is compared to baseline
Commit ids may change on rebases, so these links may become outdated.

|                                                                                                                                                           | nalgebra [check,debug,opt]                                                      | serde [check,debug, opt]                                                        | syn [check, debug, opt]                                                         | wg-grammar [check, debug, opt]                                                     |
| --------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
| [move overflow check](https://github.com/rust-lang/rust/pull/158249/changes/039cc59ac1e2a32da460a046f2b2e479c870d0fb)                                     | $${\color{green}-0.04\\%}$$<br> $${\color{green}-0.03\\%}$$<br> $${\color{green}-0.02\\%}$$ | $${\color{green}-0.15\\%}$$<br> $${\color{green}-0.12\\%}$$<br> $${\color{green}-0.11\\%}$$ | $${\color{green}-0.08\\%}$$<br> $${\color{green}-0.04\\%}$$<br> $${\color{green}-0.01\\%}$$ | $${\color{green}-0.32\\%}$$<br> $${\color{green}-0.31\\%}$$<br> $${\color{green}-0.29\\%}$$    |
| [move fast path into evaluate_goal](https://github.com/rust-lang/rust/pull/158249/changes/8cc6291e8691df7d69e61fa322be376d0da05631)                       | $${\color{red}+0.61\\%}$$<br> $${\color{red}+0.60\\%}$$<br> $${\color{red}+0.43\\%}$$       | $${\color{red}+0.75\\%}$$<br> $${\color{red}+0.69\\%}$$<br> $${\color{red}+0.65\\%}$$       | $${\color{red}+0.55\\%}$$<br> $${\color{red}+0.36\\%}$$<br> $${\color{red}+0.14\\%}$$       | $${\color{red}+0.13\\%}$$<br> $${\color{red}+0.21\\%}$$<br> $${\color{red}+0.15\\%}$$          |
| [remove fastpath from fullfilment loop](https://github.com/rust-lang/rust/pull/158249/changes/3536b417b53392757228279a335f89f8f7056358)                   | $${\color{red}+0.56\\%}$$<br> $${\color{red}+0.50\\%}$$<br> $${\color{red}+0.35\\%}$$       | $${\color{red}+3.33\\%}$$<br> $${\color{red}+2.76\\%}$$<br> $${\color{red}+2.55\\%}$$       | $${\color{red}+1.65\\%}$$<br> $${\color{red}+0.93\\%}$$<br> $${\color{red}+0.33\\%}$$       | $${\color{green}-5.06\\%}$$<br> $${\color{green}-5.00\\%}$$<br> $${\color{green}-4.65\\%}$$    |
| [return stalled info from fast path](https://github.com/rust-lang/rust/pull/158249/changes/187954fb08d2d275043ff8d7a013b9534120c460)                      | $${\color{red}+0.16\\%}$$<br> $${\color{red}+0.16\\%}$$<br> $${\color{red}+0.12\\%}$$       | $${\color{red}+0.01\\%}$$<br> $${\color{red}+0.01\\%}$$<br> $${\color{red}+0.01\\%}$$       | $${\color{red}+0.24\\%}$$<br> $${\color{red}+0.15\\%}$$<br> $${\color{red}+0.05\\%}$$       | $${\color{green}-0.24\\%}$$<br> $${\color{green}-0.24\\%}$$<br> $${\color{green}-0.25\\%}$$    |
| [move goal fast path into evaluate_goal_cold](https://github.com/rust-lang/rust/pull/158249/changes/4946875445c309d674e2500c85b1c72809f05e8c)             | $${\color{red}+0.01\\%}$$<br> $${\color{red}+0.01\\%}$$<br> $${\color{red}+0.01\\%}$$       | $${\color{red}+0.02\\%}$$<br> $${\color{red}+0.02\\%}$$<br> $${\color{red}+0.02\\%}$$       | $${\color{red}+0.02\\%}$$<br> $${\color{red}+0.02\\%}$$<br> $${\color{red}+0.01\\%}$$       | $${\color{green}-0.01\\%}$$<br> $${\color{green}-0.01\\%}$$<br> $${\color{green}-0.01\\%}$$    |
| [shuffle fastpaths around to before creating an evalctxt](https://github.com/rust-lang/rust/pull/158249/changes/58f22e89416534c46fde0248cb997ace6c0f662a) | $${\color{green}-0.44\\%}$$<br> $${\color{green}-0.41\\%}$$<br> $${\color{green}-0.30\\%}$$ | $${\color{green}-2.31\\%}$$<br> $${\color{green}-1.93\\%}$$<br> $${\color{green}-1.80\\%}$$ | $${\color{green}-1.29\\%}$$<br> $${\color{green}-0.77\\%}$$<br> $${\color{green}-0.29\\%}$$ | $${\color{green}-6.06\\%}$$<br> $${\color{green}-5.90\\%}$$<br> $${\color{green}-5.48\\%}$$    |
| [fast path when adding goals](https://github.com/rust-lang/rust/pull/158249/changes/adbd01966efaabdab8f3b4ef7de3d504ccfb2e71)                             | $${\color{green}-0.62\\%}$$<br> $${\color{green}-0.58\\%}$$<br> $${\color{green}-0.41\\%}$$ | $${\color{green}-0.78\\%}$$<br> $${\color{green}-0.66\\%}$$<br> $${\color{green}-0.61\\%}$$ | $${\color{green}-0.36\\%}$$<br> $${\color{green}-0.28\\%}$$<br> $${\color{green}-0.10\\%}$$ | $${\color{green}-0.12\\%}$$<br> $${\color{green}-0.09\\%}$$<br> $${\color{green}-0.04\\%}$$    |
| overall from baseline                                                                                                                                     | $${\color{red}+0.24\\%}$$<br> $${\color{red}+0.23\\%}$$<br> $${\color{red}+0.16\\%}$$       | $${\color{red}+0.79\\%}$$<br> $${\color{red}+0.70\\%}$$<br> $${\color{red}+0.66\\%}$$       | $${\color{red}+0.60\\%}$$<br> $${\color{red}+0.36\\%}$$<br> $${\color{red}+0.13\\%}$$       | $${\color{green}-11.31\\%}$$<br> $${\color{green}-11.00\\%}$$<br> $${\color{green}-10.27\\%}$$ |





<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/158249)*
<!-- homu-ignore:end -->

