### PR TITLE
Use an unexpanded span for actually written down opt out params

### DIFF
--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/bounds.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/bounds.rs
@@ -25,17 +25,17 @@ use crate::hir_ty_lowering::{
 #[derive(Debug, Default)]
 struct CollectedBound {
     /// `Trait`
-    positive: bool,
+    positive: Option<Span>,
     /// `?Trait`
-    maybe: bool,
+    maybe: Option<Span>,
     /// `!Trait`
-    negative: bool,
+    negative: Option<Span>,
 }
 
 impl CollectedBound {
     /// Returns `true` if any of `Trait`, `?Trait` or `!Trait` were encountered.
     fn any(&self) -> bool {
-        self.positive || self.maybe || self.negative
+        self.positive.is_some() || self.maybe.is_some() || self.negative.is_some()
     }
 }
 
@@ -96,9 +96,9 @@ fn collect_bounds<'a, 'tcx>(
         }
 
         match ptr.modifiers.polarity {
-            hir::BoundPolarity::Maybe(_) => collect_into.maybe = true,
-            hir::BoundPolarity::Negative(_) => collect_into.negative = true,
-            hir::BoundPolarity::Positive => collect_into.positive = true,
+            hir::BoundPolarity::Maybe(_) => collect_into.maybe = Some(ptr.span),
+            hir::BoundPolarity::Negative(_) => collect_into.negative = Some(ptr.span),
+            hir::BoundPolarity::Positive => collect_into.positive = Some(ptr.span),
         }
     });
     collect_into
@@ -180,10 +180,9 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             ImpliedBoundsContext::TyParam(..) | ImpliedBoundsContext::AssociatedTypeOrImplTrait => {
             }
         }
-
         let collected = collect_sizedness_bounds(tcx, hir_bounds, context, span);
-        if (collected.sized.maybe || collected.sized.negative)
-            && !collected.sized.positive
+        if let Some(span) = collected.sized.maybe.or(collected.sized.negative)
+            && collected.sized.positive.is_none()
             && !collected.meta_sized.any()
             && !collected.pointee_sized.any()
         {

--- a/tests/ui/const-generics/unused-type-param-suggestion.rs
+++ b/tests/ui/const-generics/unused-type-param-suggestion.rs
@@ -1,4 +1,4 @@
-#![crate_type="lib"]
+#![crate_type = "lib"]
 
 struct S<N>;
 //~^ ERROR type parameter `N` is never used
@@ -25,4 +25,3 @@ type C<N: Sized> = ();
 type D<N: ?Sized> = ();
 //~^ ERROR type parameter `N` is never used
 //~| HELP consider removing `N`
-//~| HELP if you intended `N` to be a const parameter

--- a/tests/ui/const-generics/unused-type-param-suggestion.stderr
+++ b/tests/ui/const-generics/unused-type-param-suggestion.stderr
@@ -47,7 +47,6 @@ LL | type D<N: ?Sized> = ();
    |        ^ unused type parameter
    |
    = help: consider removing `N` or referring to it in the body of the type alias
-   = help: if you intended `N` to be a const parameter, use `const N: /* Type */` instead
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/extern/extern-types-unsized.stderr
+++ b/tests/ui/extern/extern-types-unsized.stderr
@@ -67,10 +67,10 @@ LL |     assert_sized::<Bar<A>>();
    |
    = help: the nightly-only, unstable trait `MetaSized` is not implemented for `A`
 note: required by a bound in `Bar`
-  --> $DIR/extern-types-unsized.rs:14:12
+  --> $DIR/extern-types-unsized.rs:14:15
    |
 LL | struct Bar<T: ?Sized> {
-   |            ^ required by this bound in `Bar`
+   |               ^^^^^^ required by this bound in `Bar`
 
 error[E0277]: the size for values of type `A` cannot be known at compilation time
   --> $DIR/extern-types-unsized.rs:32:20
@@ -102,10 +102,10 @@ LL |     assert_sized::<Bar<Bar<A>>>();
    |
    = help: the nightly-only, unstable trait `MetaSized` is not implemented for `A`
 note: required by a bound in `Bar`
-  --> $DIR/extern-types-unsized.rs:14:12
+  --> $DIR/extern-types-unsized.rs:14:15
    |
 LL | struct Bar<T: ?Sized> {
-   |            ^ required by this bound in `Bar`
+   |               ^^^^^^ required by this bound in `Bar`
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/sized-hierarchy/overflow.current.stderr
+++ b/tests/ui/sized-hierarchy/overflow.current.stderr
@@ -8,9 +8,9 @@ note: required for `Box<Element>` to implement `ParseTokens`
   --> $DIR/overflow.rs:13:31
    |
 LL | impl<T: ParseTokens + ?Sized> ParseTokens for Box<T> {
-   |      -                        ^^^^^^^^^^^     ^^^^^^
-   |      |
-   |      unsatisfied trait bound introduced here
+   |                       ------  ^^^^^^^^^^^     ^^^^^^
+   |                       |
+   |                       unsatisfied trait bound introduced here
    = note: 1 redundant requirement hidden
    = note: required for `Box<Box<Element>>` to implement `ParseTokens`
 


### PR DESCRIPTION
I'm trying to land the components of rust-lang/rust#158122 individually now (and fixing the bugs in the process).

TLDR: we didn't use the span of `?Sized` for generating other default bounds of the sized hierarchy, causing in funky diagnostics, this PR fixes that