### PR TITLE
Only load the feature list once in the entire resolver

### DIFF
--- a/compiler/rustc_resolve/src/build_reduced_graph.rs
+++ b/compiler/rustc_resolve/src/build_reduced_graph.rs
@@ -548,7 +548,7 @@ impl<'a, 'ra, 'tcx> DefCollector<'a, 'ra, 'tcx> {
             root_id,
             vis,
             vis_span: item.vis.span,
-            on_unknown_attr: OnUnknownData::from_attrs(self.r.tcx, &item.attrs),
+            on_unknown_attr: OnUnknownData::from_attrs(self.r, &item.attrs),
         });
 
         self.r.indeterminate_imports.push(import);
@@ -863,7 +863,7 @@ impl<'a, 'ra, 'tcx> DefCollector<'a, 'ra, 'tcx> {
                         || ast::attr::contains_name(&item.attrs, sym::no_implicit_prelude),
                 );
                 self.parent_scope.module = module.to_module();
-                if let Some(directive) = OnUnknownData::from_attrs(self.r.tcx, &item.attrs) {
+                if let Some(directive) = OnUnknownData::from_attrs(self.r, &item.attrs) {
                     self.r.on_unknown_data.insert(local_def_id, directive);
                 }
             }
@@ -1040,7 +1040,7 @@ impl<'a, 'ra, 'tcx> DefCollector<'a, 'ra, 'tcx> {
             module_path: Vec::new(),
             vis,
             vis_span: item.vis.span,
-            on_unknown_attr: OnUnknownData::from_attrs(self.r.tcx, &item.attrs),
+            on_unknown_attr: OnUnknownData::from_attrs(self.r, &item.attrs),
         });
         if used {
             self.r.import_use_map.insert(import, Used::Other);
@@ -1172,7 +1172,7 @@ impl<'a, 'ra, 'tcx> DefCollector<'a, 'ra, 'tcx> {
                 module_path: Vec::new(),
                 vis: Visibility::Restricted(CRATE_DEF_ID),
                 vis_span: item.vis.span,
-                on_unknown_attr: OnUnknownData::from_attrs(this.r.tcx, &item.attrs),
+                on_unknown_attr: OnUnknownData::from_attrs(this.r, &item.attrs),
             })
         };
 
@@ -1353,7 +1353,7 @@ impl<'a, 'ra, 'tcx> DefCollector<'a, 'ra, 'tcx> {
                     module_path: Vec::new(),
                     vis,
                     vis_span: item.vis.span,
-                    on_unknown_attr: OnUnknownData::from_attrs(self.r.tcx, &item.attrs),
+                    on_unknown_attr: OnUnknownData::from_attrs(self.r, &item.attrs),
                 });
                 self.r.import_use_map.insert(import, Used::Other);
                 let import_decl = self.r.new_import_decl(decl, import);

--- a/compiler/rustc_resolve/src/def_collector.rs
+++ b/compiler/rustc_resolve/src/def_collector.rs
@@ -186,7 +186,7 @@ impl<'a, 'ra, 'tcx> visit::Visitor<'a> for DefCollector<'a, 'ra, 'tcx> {
                 // Does that prevents errors from happening? maybe
                 let mut parser = AttributeParser::new(
                     &self.r.tcx.sess,
-                    self.r.tcx.features(),
+                    self.r.features,
                     self.r.tcx().registered_tools(()),
                     ShouldEmit::Nothing,
                 );
@@ -433,7 +433,7 @@ impl<'a, 'ra, 'tcx> visit::Visitor<'a> for DefCollector<'a, 'ra, 'tcx> {
         // `MgcaDisambiguation::Direct` is set even when MGCA is disabled, so
         // to avoid affecting stable we have to feature gate the not creating
         // anon consts
-        if !self.r.tcx.features().min_generic_const_args() {
+        if !self.r.features.min_generic_const_args() {
             let parent = self
                 .create_def(constant.id, None, DefKind::AnonConst, constant.value.span)
                 .def_id();

--- a/compiler/rustc_resolve/src/error_helper.rs
+++ b/compiler/rustc_resolve/src/error_helper.rs
@@ -1628,7 +1628,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             in_module.for_each_child(self, |this, ident, orig_ident_span, ns, name_binding| {
                 // Avoid non-importable candidates.
                 if name_binding.is_assoc_item()
-                    && !this.tcx.features().import_trait_associated_functions()
+                    && !this.features.import_trait_associated_functions()
                 {
                     return;
                 }
@@ -1809,10 +1809,10 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             }) => {
                 if span.allows_unstable(feature) {
                     true
-                } else if self.tcx.features().enabled(feature) {
+                } else if self.features.enabled(feature) {
                     true
                 } else if let Some(implied_by) = implied_by
-                    && self.tcx.features().enabled(implied_by)
+                    && self.features.enabled(implied_by)
                 {
                     true
                 } else {
@@ -4144,13 +4144,17 @@ pub(crate) struct OnUnknownData {
 }
 
 impl OnUnknownData {
-    pub(crate) fn from_attrs<'tcx>(
-        tcx: TyCtxt<'tcx>,
+    pub(crate) fn from_attrs(
+        r: &Resolver<'_, '_>,
         attrs: &[ast::Attribute],
     ) -> Option<OnUnknownData> {
-        if tcx.features().diagnostic_on_unknown()
+        if r.features.diagnostic_on_unknown()
             && let Some(Attribute::Parsed(AttributeKind::OnUnknown { directive, .. })) =
-                AttributeParser::parse_limited(tcx.sess, attrs, &[sym::diagnostic, sym::on_unknown])
+                AttributeParser::parse_limited(
+                    r.tcx.sess,
+                    attrs,
+                    &[sym::diagnostic, sym::on_unknown],
+                )
         {
             Some(Self { directive: directive? })
         } else {

--- a/compiler/rustc_resolve/src/ident.rs
+++ b/compiler/rustc_resolve/src/ident.rs
@@ -746,7 +746,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             Scope::BuiltinTypes => match self.builtin_type_decls.get(&ident.name) {
                 Some(decl) => {
                     if matches!(ident.name, sym::f16)
-                        && !self.tcx.features().f16()
+                        && !self.features.f16()
                         && !orig_ident_span.allows_unstable(sym::f16)
                         && finalize.is_some()
                     {
@@ -759,7 +759,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                         .emit();
                     }
                     if matches!(ident.name, sym::f128)
-                        && !self.tcx.features().f128()
+                        && !self.features.f128()
                         && !orig_ident_span.allows_unstable(sym::f128)
                         && finalize.is_some()
                     {
@@ -1535,7 +1535,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                         }
 
                         RibKind::ConstParamTy => {
-                            if !self.tcx.features().generic_const_parameter_types() {
+                            if !self.features.generic_const_parameter_types() {
                                 if let Some(span) = finalize {
                                     self.report_error(
                                         span,
@@ -1564,7 +1564,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                                         }
                                         NoConstantGenericsReason::NonTrivialConstArg => {
                                             ResolutionError::ParamInNonTrivialAnonConst {
-                                                is_gca: self.tcx.features().generic_const_args(),
+                                                is_gca: self.features.generic_const_args(),
                                                 name: rib_ident.name,
                                                 param_kind: ParamKindInNonTrivialAnonConst::Type,
                                             }
@@ -1629,7 +1629,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                         | RibKind::ForwardGenericParamBan(_) => continue,
 
                         RibKind::ConstParamTy => {
-                            if !self.tcx.features().generic_const_parameter_types() {
+                            if !self.features.generic_const_parameter_types() {
                                 if let Some(span) = finalize {
                                     self.report_error(
                                         span,
@@ -1656,7 +1656,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                                         }
                                         NoConstantGenericsReason::NonTrivialConstArg => {
                                             ResolutionError::ParamInNonTrivialAnonConst {
-                                                is_gca: self.tcx.features().generic_const_args(),
+                                                is_gca: self.features.generic_const_args(),
                                                 name: rib_ident.name,
                                                 param_kind: ParamKindInNonTrivialAnonConst::Const {
                                                     name: rib_ident.name,
@@ -2019,7 +2019,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                             module,
                             || {
                                 let import_inherent_item_error_flag =
-                                    self.tcx.features().import_trait_associated_functions()
+                                    self.features.import_trait_associated_functions()
                                         && matches!(
                                             res,
                                             Res::Def(

--- a/compiler/rustc_resolve/src/imports.rs
+++ b/compiler/rustc_resolve/src/imports.rs
@@ -779,7 +779,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                         match import_decls[ns] {
                             PendingDecl::Ready(Some(import_decl)) => {
                                 if import_decl.is_assoc_item()
-                                    && !this.tcx.features().import_trait_associated_functions()
+                                    && !this.features.import_trait_associated_functions()
                                 {
                                     feature_err(
                                         this.tcx.sess,
@@ -822,8 +822,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                         continue;
                     };
 
-                    if module.is_trait() && !self.tcx.features().import_trait_associated_functions()
-                    {
+                    if module.is_trait() && !self.features.import_trait_associated_functions() {
                         feature_err(
                             self.tcx.sess,
                             sym::import_trait_associated_functions,
@@ -1487,7 +1486,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
 
                 // If importing of trait asscoiated items is enabled, an also find an
                 // `Enum`, then note that inherent associated items cannot be imported.
-                let note = if self.tcx.features().import_trait_associated_functions()
+                let note = if self.features.import_trait_associated_functions()
                     && let PathResult::Module(ModuleOrUniformRoot::Module(m)) = path_res
                     && let Some(Res::Def(DefKind::Enum, _)) = m.res()
                 {

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -1664,7 +1664,7 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
         };
         // We'll ban these with a `ConstParamTy` rib, so just clear these ribs for better
         // diagnostics, so we don't mention anything about const param tys having generics at all.
-        if !self.r.tcx.features().generic_const_parameter_types() {
+        if !self.r.features.generic_const_parameter_types() {
             forward_ty_ban_rib_const_param_ty.bindings.clear();
             forward_const_ban_rib_const_param_ty.bindings.clear();
         }
@@ -1701,7 +1701,7 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
 
                         this.ribs[TypeNS].push(forward_ty_ban_rib_const_param_ty);
                         this.ribs[ValueNS].push(forward_const_ban_rib_const_param_ty);
-                        if this.r.tcx.features().generic_const_parameter_types() {
+                        if this.r.features.generic_const_parameter_types() {
                             this.visit_ty(ty)
                         } else {
                             this.ribs[TypeNS].push(Rib::new(RibKind::ConstParamTy));
@@ -1812,8 +1812,7 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
                                     }
 
                                     LifetimeRibKind::ImplTrait => {
-                                        if self.r.tcx.features().anonymous_lifetime_in_impl_trait()
-                                        {
+                                        if self.r.features.anonymous_lifetime_in_impl_trait() {
                                             None
                                         } else {
                                             Some(LifetimeUseSet::Many)
@@ -2991,7 +2990,7 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
                 self.with_generic_param_rib(
                     &generics.params,
                     RibKind::Item(
-                        if self.r.tcx.features().generic_const_items() {
+                        if self.r.features.generic_const_items() {
                             HasGenericParams::Yes(generics.span)
                         } else {
                             HasGenericParams::No
@@ -3008,7 +3007,7 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
                             LifetimeRibKind::Elided(LifetimeRes::Static),
                             |this| {
                                 if rhs_kind.is_type_const()
-                                    && !this.r.tcx.features().generic_const_parameter_types()
+                                    && !this.r.features.generic_const_parameter_types()
                                 {
                                     this.with_rib(TypeNS, RibKind::ConstParamTy, |this| {
                                         this.with_rib(ValueNS, RibKind::ConstParamTy, |this| {
@@ -3255,7 +3254,7 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
                     RibKind::Normal => {
                         // FIXME(non_lifetime_binders): Stop special-casing
                         // const params to error out here.
-                        if self.r.tcx.features().non_lifetime_binders()
+                        if self.r.features.non_lifetime_binders()
                             && matches!(param.kind, GenericParamKind::Type { .. })
                         {
                             Res::Def(def_kind, def_id.to_def_id())
@@ -3409,7 +3408,7 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
                             |this| {
                                 this.visit_generics(generics);
                                 if rhs_kind.is_type_const()
-                                    && !this.r.tcx.features().generic_const_parameter_types()
+                                    && !this.r.features.generic_const_parameter_types()
                                 {
                                     this.with_rib(TypeNS, RibKind::ConstParamTy, |this| {
                                         this.with_rib(ValueNS, RibKind::ConstParamTy, |this| {
@@ -5038,10 +5037,10 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
                 let tcx = self.r.tcx();
 
                 let gate_err_sym_msg = match prim {
-                    PrimTy::Float(FloatTy::F16) if !tcx.features().f16() => {
+                    PrimTy::Float(FloatTy::F16) if !self.r.features.f16() => {
                         Some((sym::f16, "the type `f16` is unstable"))
                     }
-                    PrimTy::Float(FloatTy::F128) if !tcx.features().f128() => {
+                    PrimTy::Float(FloatTy::F128) if !self.r.features.f128() => {
                         Some((sym::f128, "the type `f128` is unstable"))
                     }
                     _ => None,
@@ -5196,8 +5195,8 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
             AnonConstKind::FieldDefaultValue => ConstantHasGenerics::Yes,
             AnonConstKind::InlineConst => ConstantHasGenerics::Yes,
             AnonConstKind::ConstArg(_) => {
-                if self.r.tcx.features().generic_const_exprs()
-                    || self.r.tcx.features().min_generic_const_args()
+                if self.r.features.generic_const_exprs()
+                    || self.r.features.min_generic_const_args()
                     || is_trivial_const_arg
                 {
                     ConstantHasGenerics::Yes

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -1775,8 +1775,7 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
             // const generics. Of course, `Struct` and `Enum` may contain ty params, too, but the
             // benefits of including them here outweighs the small number of false positives.
             Some(Res::Def(DefKind::Struct | DefKind::Enum, _))
-                if self.r.tcx.features().adt_const_params()
-                    || self.r.tcx.features().min_adt_const_params() =>
+                if self.r.features.adt_const_params() || self.r.features.min_adt_const_params() =>
             {
                 Applicability::MaybeIncorrect
             }
@@ -3977,7 +3976,7 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
                 })
                 .emit(),
             NoConstantGenericsReason::NonTrivialConstArg => {
-                assert!(!self.r.tcx.features().generic_const_exprs());
+                assert!(!self.r.features.generic_const_exprs());
                 self.r
                     .dcx()
                     .create_err(diagnostics::ParamInNonTrivialAnonConst {
@@ -3985,8 +3984,8 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
                         name: lifetime_ref.ident.name,
                         param_kind: diagnostics::ParamKindInNonTrivialAnonConst::Lifetime,
                         help: self.r.tcx.sess.is_nightly_build(),
-                        is_gca: self.r.tcx.features().generic_const_args(),
-                        help_gca: self.r.tcx.features().generic_const_args(),
+                        is_gca: self.r.features.generic_const_args(),
+                        help_gca: self.r.features.generic_const_args(),
                     })
                     .emit()
             }

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -50,7 +50,7 @@ use rustc_data_structures::sync::{FreezeReadGuard, FreezeWriteGuard};
 use rustc_data_structures::unord::{UnordItems, UnordMap, UnordSet};
 use rustc_errors::{Applicability, Diag, ErrCode, ErrorGuaranteed, LintBuffer};
 use rustc_expand::base::{DeriveResolution, SyntaxExtension, SyntaxExtensionKind};
-use rustc_feature::BUILTIN_ATTRIBUTES;
+use rustc_feature::{BUILTIN_ATTRIBUTES, Features};
 use rustc_hir::attrs::StrippedCfgItem;
 use rustc_hir::def::Namespace::{self, *};
 use rustc_hir::def::{
@@ -1550,7 +1550,8 @@ pub struct Resolver<'ra, 'tcx> {
     impl_trait_names: FxHashMap<NodeId, Symbol> = default::fx_hash_map(),
 
     /// Stores `#[diagnostic::on_unknown]` attributes placed on module declarations.
-    on_unknown_data: FxHashMap<LocalDefId, OnUnknownData>,
+    on_unknown_data: FxHashMap<LocalDefId, OnUnknownData> = default::fx_hash_map(),
+    features: &'tcx Features,
 }
 
 /// This provides memory for the rest of the crate. The `'ra` lifetime that is
@@ -1808,11 +1809,6 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         let registered_tools = tcx.registered_tools(());
         let edition = tcx.sess.edition();
 
-        let mut on_unknown_data = default::fx_hash_map();
-        if let Some(directive) = OnUnknownData::from_attrs(tcx, attrs) {
-            on_unknown_data.insert(CRATE_DEF_ID, directive);
-        }
-
         let mut resolver = Resolver {
             tcx,
 
@@ -1880,9 +1876,13 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             current_crate_outer_attr_insert_span,
             disambiguators: Default::default(),
             delegation_infos: Default::default(),
-            on_unknown_data,
+            features: tcx.features(),
             ..
         };
+
+        if let Some(directive) = OnUnknownData::from_attrs(&resolver, attrs) {
+            resolver.on_unknown_data.insert(CRATE_DEF_ID, directive);
+        }
 
         let root_parent_scope = ParentScope::module(graph_root, resolver.arenas);
         resolver.invocation_parent_scopes.insert(LocalExpnId::ROOT, root_parent_scope);

--- a/compiler/rustc_resolve/src/macros.rs
+++ b/compiler/rustc_resolve/src/macros.rs
@@ -699,7 +699,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         }
 
         // We are trying to avoid reporting this error if other related errors were reported.
-        if res != Res::Err && inner_attr && !self.tcx.features().custom_inner_attributes() {
+        if res != Res::Err && inner_attr && !self.features.custom_inner_attributes() {
             let is_macro = match res {
                 Res::Def(..) => true,
                 Res::NonMacroAttr(..) => false,
@@ -727,8 +727,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             && let [namespace, attribute, ..] = &*path.segments
             && namespace.ident.name == sym::diagnostic
             && !DIAGNOSTIC_ATTRIBUTES.iter().any(|(attr, feature)| {
-                attribute.ident.name == *attr
-                    && feature.is_none_or(|f| self.tcx.features().enabled(f))
+                attribute.ident.name == *attr && feature.is_none_or(|f| self.features.enabled(f))
             })
         {
             let name = attribute.ident.name;
@@ -750,7 +749,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 let candidates = DIAGNOSTIC_ATTRIBUTES
                     .iter()
                     .filter_map(|(attr, feature)| {
-                        feature.is_none_or(|f| self.tcx.features().enabled(f)).then_some(*attr)
+                        feature.is_none_or(|f| self.features.enabled(f)).then_some(*attr)
                     })
                     .collect::<Vec<_>>();
 
@@ -1112,7 +1111,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             let feature = stability.feature;
 
             let is_allowed =
-                |feature| self.tcx.features().enabled(feature) || span.allows_unstable(feature);
+                |feature| self.features.enabled(feature) || span.allows_unstable(feature);
             let allowed_by_implication = implied_by.is_some_and(|feature| is_allowed(feature));
             if !is_allowed(feature) && !allowed_by_implication {
                 stability::report_unstable(
@@ -1242,7 +1241,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
     ) -> SyntaxExtension {
         let mut ext = compile_declarative_macro(
             self.tcx.sess,
-            self.tcx.features(),
+            self.features,
             macro_def,
             ident,
             attrs,


### PR DESCRIPTION
I saw that a bunch of code in ast validation and other early logic just had the features query called once and stored the result. Let's see what the resolver does with that.