### PR TITLE
FromUtf8Error::into_utf8_lossy better example and suggest use

### DIFF
--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -2239,15 +2239,33 @@ impl FromUtf8Error {
     /// invalid sequences, and [`String::from_utf8_lossy_owned`] for the
     /// `String` function which corresponds to this function.
     ///
+    /// This is useful in conjunction with [`String::from_utf8`] when you need
+    /// to branch on whether the bytes are valid UTF-8, but still want to
+    /// recover a lossily converted `String` in the error case. Use
+    /// [`String::from_utf8_lossy_owned`] if you always need a lossily converted
+    /// `String`.
+    ///
+    /// Since the original [`String::from_utf8`] error records where validation
+    /// stopped, this method does not need to re-check the already valid prefix
+    /// of the byte sequence.
+    ///
     /// # Examples
     ///
     /// ```
     /// #![feature(string_from_utf8_lossy_owned)]
     /// // some invalid bytes
     /// let input: Vec<u8> = b"Hello \xF0\x90\x80World".into();
-    /// let output = String::from_utf8(input).unwrap_or_else(|e| e.into_utf8_lossy());
+    ///
+    /// let (output, had_invalid_utf8) = match String::from_utf8(input) {
+    ///     Ok(output) => (output, false),
+    ///     Err(error) => {
+    ///         // The bytes were not valid UTF-8, but we can still recover a string.
+    ///         (error.into_utf8_lossy(), true)
+    ///     }
+    /// };
     ///
     /// assert_eq!(String::from("Hello �World"), output);
+    /// assert!(had_invalid_utf8);
     /// ```
     #[must_use]
     #[cfg(not(no_global_oom_handling))]


### PR DESCRIPTION
This handles https://github.com/rust-lang/rust/issues/129436#issuecomment-4766575974 and refers to https://github.com/rust-lang/rust/pull/129439/changes#r1763510354

r? @tgross35