### PR TITLE
Add rem_floor and rem_ceil

### DIFF
--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -3300,6 +3300,47 @@ macro_rules! int_impl {
             }
         }
 
+        /// Calculates the remainder of `self` and `rhs`, where the sign of the
+        /// remainder is always equal to the sign of `rhs`.
+        ///
+        /// # Panics
+        ///
+        /// This function will panic if `rhs` is zero or if `self` is `Self::MIN`
+        /// and `rhs` is -1. This behavior is not affected by the `overflow-checks` flag.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// #![feature(int_roundings)]
+        #[doc = concat!("let a: ", stringify!($SelfT)," = 8;")]
+        /// let b = 3;
+        ///
+        /// assert_eq!(a.rem_floor(b), 2);
+        /// assert_eq!(a.rem_floor(-b), -1);
+        /// assert_eq!((-a).rem_floor(b), 1);
+        /// assert_eq!((-a).rem_floor(-b), -2);
+        /// ```
+        #[unstable(feature = "int_roundings", issue = "88581")]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[inline]
+        #[track_caller]
+        pub const fn rem_floor(self, rhs: Self) -> Self {
+            let r = self % rhs;
+
+            // r currently always has the sign of self.
+            // If the remainder is non-zero and the signs of self and rhs are
+            // different, we must rectify this by adding rhs. We check that the
+            // signs are different not by comparing self < 0, but r < 0. This is
+            // done so the compiler can optimize this function better for
+            // constant divisors (e.g. x.rem_floor(8) simply becomes x & 7).
+            if r != 0 && (r < 0) != (rhs < 0) {
+                r + rhs
+            } else {
+                r
+            }
+        }
+
         /// Calculates the quotient of `self` and `rhs`, rounding the result towards positive infinity.
         ///
         /// # Panics
@@ -3335,6 +3376,47 @@ macro_rules! int_impl {
                 d + correction
             } else {
                 d
+            }
+        }
+
+        /// Calculates the remainder of `self` and `rhs`, where the sign of the
+        /// remainder is always the opposite of the sign of `rhs`.
+        ///
+        /// # Panics
+        ///
+        /// This function will panic if `rhs` is zero or if `self` is `Self::MIN`
+        /// and `rhs` is -1. This behavior is not affected by the `overflow-checks` flag.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// #![feature(int_roundings)]
+        #[doc = concat!("let a: ", stringify!($SelfT)," = 8;")]
+        /// let b = 3;
+        ///
+        /// assert_eq!(a.rem_ceil(b), -1);
+        /// assert_eq!(a.rem_ceil(-b), 2);
+        /// assert_eq!((-a).rem_ceil(b), -2);
+        /// assert_eq!((-a).rem_ceil(-b), 1);
+        /// ```
+        #[unstable(feature = "int_roundings", issue = "88581")]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[inline]
+        #[track_caller]
+        pub const fn rem_ceil(self, rhs: Self) -> Self {
+            let r = self % rhs;
+
+            // r currently always has the sign of self.
+            // If the remainder is non-zero and the signs of self and rhs are
+            // the same, we must rectify this by subtracting rhs. We check that
+            // the signs are different not by comparing self < 0, but r < 0.
+            // This is done so the compiler can optimize this function better
+            // for constant divisors.
+            if r != 0 && (r < 0) == (rhs < 0) {
+                r - rhs
+            } else {
+                r
             }
         }
 

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -1444,7 +1444,7 @@ macro_rules! uint_impl {
         /// Strict division on unsigned types is just normal division. There's no
         /// way overflow could ever happen. This function exists so that all
         /// operations are accounted for in the strict operations. Since, for the
-        /// positive integers, all common definitions of division are equal, this
+        /// non-negative integers, Euclidean division matches normal division, this
         /// is exactly equal to `self.strict_div(rhs)`.
         ///
         /// # Panics
@@ -1644,8 +1644,8 @@ macro_rules! uint_impl {
         /// Strict modulo calculation on unsigned types is just the regular
         /// remainder calculation. There's no way overflow could ever happen.
         /// This function exists so that all operations are accounted for in the
-        /// strict operations. Since, for the positive integers, all common
-        /// definitions of division are equal, this is exactly equal to
+        /// strict operations. Since, for the non-negative integers, Euclidean
+        /// division matches normal division, this is exactly equal to
         /// `self.strict_rem(rhs)`.
         ///
         /// # Panics
@@ -2715,11 +2715,10 @@ macro_rules! uint_impl {
 
         /// Wrapping Euclidean division. Computes `self.div_euclid(rhs)`.
         ///
-        /// Wrapped division on unsigned types is just normal division. There's
-        /// no way wrapping could ever happen. This function exists so that all
-        /// operations are accounted for in the wrapping operations. Since, for
-        /// the positive integers, all common definitions of division are equal,
-        /// this is exactly equal to `self.wrapping_div(rhs)`.
+        /// Wrapped Euclidean division on unsigned types is just normal
+        /// division. There's no way wrapping could ever happen. This function
+        /// exists so that all operations are accounted for in the wrapping
+        /// operations.
         ///
         /// # Panics
         ///
@@ -2766,14 +2765,12 @@ macro_rules! uint_impl {
             self % rhs
         }
 
-        /// Wrapping Euclidean modulo. Computes `self.rem_euclid(rhs)`.
+        /// Wrapping Euclidean remainder. Computes `self.rem_euclid(rhs)`.
         ///
-        /// Wrapped modulo calculation on unsigned types is just the regular
-        /// remainder calculation. There's no way wrapping could ever happen.
-        /// This function exists so that all operations are accounted for in the
-        /// wrapping operations. Since, for the positive integers, all common
-        /// definitions of division are equal, this is exactly equal to
-        /// `self.wrapping_rem(rhs)`.
+        /// The wrapped Euclidean remainder on unsigned types is just the
+        /// regular remainder calculation. There's no way wrapping could ever
+        /// happen. This function exists so that all operations are accounted
+        /// for in the wrapping operations.
         ///
         /// # Panics
         ///
@@ -3355,9 +3352,8 @@ macro_rules! uint_impl {
         /// whether an arithmetic overflow would occur. Note that for unsigned
         /// integers overflow never occurs, so the second value is always
         /// `false`.
-        /// Since, for the positive integers, all common
-        /// definitions of division are equal, this
-        /// is exactly equal to `self.overflowing_div(rhs)`.
+        /// Since, for the non-negative integers, Euclidean division matches
+        /// normal division, this is exactly equal to `self.overflowing_div(rhs)`.
         ///
         /// # Panics
         ///
@@ -3410,9 +3406,8 @@ macro_rules! uint_impl {
         /// indicating whether an arithmetic overflow would occur. Note that for
         /// unsigned integers overflow never occurs, so the second value is
         /// always `false`.
-        /// Since, for the positive integers, all common
-        /// definitions of division are equal, this operation
-        /// is exactly equal to `self.overflowing_rem(rhs)`.
+        /// Since, for the non-negative integers, Euclidean division matches
+        /// normal division, this is exactly equal to `self.overflowing_rem(rhs)`.
         ///
         /// # Panics
         ///
@@ -3653,9 +3648,8 @@ macro_rules! uint_impl {
 
         /// Performs Euclidean division.
         ///
-        /// Since, for the positive integers, all common
-        /// definitions of division are equal, this
-        /// is exactly equal to `self / rhs`.
+        /// Since, for the non-negative integers, Euclidean division matches
+        /// normal division, this is exactly equal to `self / rhs`.
         ///
         /// # Panics
         ///
@@ -3680,9 +3674,8 @@ macro_rules! uint_impl {
         /// Calculates the least remainder of `self` when divided by
         /// `rhs`.
         ///
-        /// Since, for the positive integers, all common
-        /// definitions of division are equal, this
-        /// is exactly equal to `self % rhs`.
+        /// Since, for the non-negative integers, Euclidean division matches
+        /// normal division, this is exactly equal to `self % rhs`.
         ///
         /// # Panics
         ///
@@ -3727,7 +3720,36 @@ macro_rules! uint_impl {
             self / rhs
         }
 
+        /// Calculates the least remainder of `self` when divided by
+        /// `rhs`.
+        ///
+        /// Since, for the non-negative integers, flooring division matches
+        /// normal division, this is exactly equal to `self % rhs`.
+        ///
+        /// # Panics
+        ///
+        /// This function will panic if `rhs` is zero.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// #![feature(int_roundings)]
+        #[doc = concat!("assert_eq!(7", stringify!($SelfT), ".rem_floor(4), 3);")]
+        /// ```
+        #[unstable(feature = "int_roundings", issue = "88581")]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[inline(always)]
+        #[track_caller]
+        pub const fn rem_floor(self, rhs: Self) -> Self {
+            self % rhs
+        }
+
         /// Calculates the quotient of `self` and `rhs`, rounding the result towards positive infinity.
+        ///
+        /// Note that since the corresponding remainder `rem_ceil` would always
+        /// return negative remainders for positive inputs, it is not implemented for unsigned
+        /// integers.
         ///
         /// # Panics
         ///

--- a/library/coretests/tests/num/i8.rs
+++ b/library/coretests/tests/num/i8.rs
@@ -15,23 +15,24 @@ fn test_signed_div_rem_exhaustive() {
                 assert!(std::panic::catch_unwind(|| a.div_ceil(b)).is_err());
                 assert!(std::panic::catch_unwind(|| a.rem_ceil(b)).is_err());
             } else {
+                let valid_q_r = |a, b, q, r| q as i32 * b as i32 + r as i32 == a as i32;
                 let r_euclid = a.rem_euclid(b);
                 assert!(r_euclid.unsigned_abs() < b.unsigned_abs() && r_euclid >= 0);
-                assert_eq!(a.div_euclid(b) * b + r_euclid, a);
+                assert!(valid_q_r(a, b, a.div_euclid(b), r_euclid));
 
                 let r_floor = a.rem_floor(b);
                 assert!(
                     r_floor.unsigned_abs() < b.unsigned_abs()
                         && (r_floor == 0 || (r_floor < 0) == (b < 0))
                 );
-                assert_eq!(a.div_floor(b) * b + r_floor, a);
+                assert!(valid_q_r(a, b, a.div_floor(b), r_floor));
 
                 let r_ceil = a.rem_ceil(b);
                 assert!(
                     r_ceil.unsigned_abs() < b.unsigned_abs()
-                        && (r_floor == 0 || (r_ceil < 0) != (b < 0))
+                        && (r_ceil == 0 || (r_ceil < 0) != (b < 0))
                 );
-                assert_eq!(a.div_ceil(b) * b + r_ceil, a);
+                assert!(valid_q_r(a, b, a.div_ceil(b), r_ceil));
             }
         }
     }

--- a/library/coretests/tests/num/i8.rs
+++ b/library/coretests/tests/num/i8.rs
@@ -1,1 +1,38 @@
 int_module!(i8, u8);
+
+#[test]
+fn test_signed_div_rem_exhaustive() {
+    // For i8 an exhaustive test only involves ~65k operations, and since the
+    // implementations are generic, any bugs are likely to exist in all
+    // variants. So an exhaustive check here is useful for all types.
+    for a in i8::MIN..=i8::MAX {
+        for b in i8::MIN..=i8::MAX {
+            if b == 0 || a == i8::MIN && b == -1 {
+                assert!(std::panic::catch_unwind(|| a.div_euclid(b)).is_err());
+                assert!(std::panic::catch_unwind(|| a.rem_euclid(b)).is_err());
+                assert!(std::panic::catch_unwind(|| a.div_floor(b)).is_err());
+                assert!(std::panic::catch_unwind(|| a.rem_floor(b)).is_err());
+                assert!(std::panic::catch_unwind(|| a.div_ceil(b)).is_err());
+                assert!(std::panic::catch_unwind(|| a.rem_ceil(b)).is_err());
+            } else {
+                let r_euclid = a.rem_euclid(b);
+                assert!(r_euclid.unsigned_abs() < b.unsigned_abs() && r_euclid >= 0);
+                assert_eq!(a.div_euclid(b) * b + r_euclid, a);
+
+                let r_floor = a.rem_floor(b);
+                assert!(
+                    r_floor.unsigned_abs() < b.unsigned_abs()
+                        && (r_floor == 0 || (r_floor < 0) == (b < 0))
+                );
+                assert_eq!(a.div_floor(b) * b + r_floor, a);
+
+                let r_ceil = a.rem_ceil(b);
+                assert!(
+                    r_ceil.unsigned_abs() < b.unsigned_abs()
+                        && (r_floor == 0 || (r_ceil < 0) != (b < 0))
+                );
+                assert_eq!(a.div_ceil(b) * b + r_ceil, a);
+            }
+        }
+    }
+}

--- a/library/coretests/tests/num/i8.rs
+++ b/library/coretests/tests/num/i8.rs
@@ -8,12 +8,7 @@ fn test_signed_div_rem_exhaustive() {
     for a in i8::MIN..=i8::MAX {
         for b in i8::MIN..=i8::MAX {
             if b == 0 || a == i8::MIN && b == -1 {
-                assert!(std::panic::catch_unwind(|| a.div_euclid(b)).is_err());
-                assert!(std::panic::catch_unwind(|| a.rem_euclid(b)).is_err());
-                assert!(std::panic::catch_unwind(|| a.div_floor(b)).is_err());
-                assert!(std::panic::catch_unwind(|| a.rem_floor(b)).is_err());
-                assert!(std::panic::catch_unwind(|| a.div_ceil(b)).is_err());
-                assert!(std::panic::catch_unwind(|| a.rem_ceil(b)).is_err());
+                continue; // Tested in int_macros.rs.
             } else {
                 let valid_q_r = |a, b, q, r| q as i32 * b as i32 + r as i32 == a as i32;
                 let r_euclid = a.rem_euclid(b);

--- a/library/coretests/tests/num/int_macros.rs
+++ b/library/coretests/tests/num/int_macros.rs
@@ -1030,12 +1030,12 @@ macro_rules! int_module {
         }
 
         test_panic! {
-            test_div_euclid_zero: ($T::MIN).div_euclid(0),
-            test_rem_euclid_zero: ($T::MIN).rem_euclid(0),
-            test_div_floor_zero: ($T::MIN).div_floor(0),
-            test_rem_floor_zero: ($T::MIN).rem_floor(0),
-            test_div_ceil_zero: ($T::MIN).div_ceil(0),
-            test_rem_ceil_zero: ($T::MIN).rem_ceil(0),
+            test_div_euclid_panic_zero: ($T::MIN).div_euclid(0),
+            test_rem_euclid_panic_zero: ($T::MIN).rem_euclid(0),
+            test_div_floor_panic_zero: ($T::MIN).div_floor(0),
+            test_rem_floor_panic_zero: ($T::MIN).rem_floor(0),
+            test_div_ceil_panic_zero: ($T::MIN).div_ceil(0),
+            test_rem_ceil_panic_zero: ($T::MIN).rem_ceil(0),
 
             test_div_euclid_panic_overflow: ($T::MIN).div_euclid(-1),
             test_rem_euclid_panic_overflow: ($T::MIN).rem_euclid(-1),

--- a/library/coretests/tests/num/int_macros.rs
+++ b/library/coretests/tests/num/int_macros.rs
@@ -1,3 +1,15 @@
+macro_rules! test_panic {
+    ($($test_name:ident: $expr:expr),* $(,)?) => {
+        $(
+            #[test]
+            #[should_panic]
+            fn $test_name() {
+                let _unused = $expr;
+            }
+        )*
+    }
+}
+
 macro_rules! int_module {
     ($T:ident, $U:ident) => {
         use core::num::ParseIntError;
@@ -1015,6 +1027,22 @@ macro_rules! int_module {
                 assert_eq_const_safe!(Option<$T>: <$T>::checked_div_exact(<$T>::MIN, -1), None);
                 assert_eq_const_safe!(Option<$T>: <$T>::checked_div_exact(0, 0), None);
             }
+        }
+
+        test_panic! {
+            test_div_euclid_zero: ($T::MIN).div_euclid(0),
+            test_rem_euclid_zero: ($T::MIN).rem_euclid(0),
+            test_div_floor_zero: ($T::MIN).div_floor(0),
+            test_rem_floor_zero: ($T::MIN).rem_floor(0),
+            test_div_ceil_zero: ($T::MIN).div_ceil(0),
+            test_rem_ceil_zero: ($T::MIN).rem_ceil(0),
+
+            test_div_euclid_panic_overflow: ($T::MIN).div_euclid(-1),
+            test_rem_euclid_panic_overflow: ($T::MIN).rem_euclid(-1),
+            test_div_floor_panic_overflow: ($T::MIN).div_floor(-1),
+            test_rem_floor_panic_overflow: ($T::MIN).rem_floor(-1),
+            test_div_ceil_panic_overflow: ($T::MIN).div_ceil(-1),
+            test_rem_ceil_panic_overflow: ($T::MIN).rem_ceil(-1),
         }
     };
 }

--- a/library/coretests/tests/num/int_macros.rs
+++ b/library/coretests/tests/num/int_macros.rs
@@ -614,6 +614,15 @@ macro_rules! int_module {
                 assert_eq_const_safe!($T: (-A).div_floor(-B), 2);
             }
 
+            fn test_rem_floor() {
+                const A: $T = 8;
+                const B: $T = 3;
+                assert_eq_const_safe!($T: A.rem_floor(B), 2);
+                assert_eq_const_safe!($T: A.rem_floor(-B), -1);
+                assert_eq_const_safe!($T: (-A).rem_floor(B), 1);
+                assert_eq_const_safe!($T: (-A).rem_floor(-B), -2);
+            }
+
             fn test_div_ceil() {
                 const A: $T = 8;
                 const B: $T = 3;
@@ -621,6 +630,15 @@ macro_rules! int_module {
                 assert_eq_const_safe!($T: A.div_ceil(-B), -2);
                 assert_eq_const_safe!($T: (-A).div_ceil(B), -2);
                 assert_eq_const_safe!($T: (-A).div_ceil(-B), 3);
+            }
+
+            fn test_rem_ceil() {
+                const A: $T = 8;
+                const B: $T = 3;
+                assert_eq_const_safe!($T: A.rem_ceil(B), -1);
+                assert_eq_const_safe!($T: A.rem_ceil(-B), 2);
+                assert_eq_const_safe!($T: (-A).rem_ceil(B), -2);
+                assert_eq_const_safe!($T: (-A).rem_ceil(-B), 1);
             }
 
             fn test_next_multiple_of() {

--- a/library/coretests/tests/num/uint_macros.rs
+++ b/library/coretests/tests/num/uint_macros.rs
@@ -555,6 +555,10 @@ macro_rules! uint_module {
                 assert_eq_const_safe!($T: (8 as $T).div_floor(3), 2);
             }
 
+            fn test_rem_floor() {
+                assert_eq_const_safe!($T: (8 as $T).rem_floor(3), 2);
+            }
+
             fn test_div_ceil() {
                 assert_eq_const_safe!($T: (8 as $T).div_ceil(3), 3);
             }


### PR DESCRIPTION
This adds the `rem_floor` (for all signed and unsigned integers) and `rem_ceil` (for all signed integers) methods. I found these to be missing from the [`int_roundings` feature](https://github.com/rust-lang/rust/issues/88581). I don't think we should ship `div` functions without a corresponding `rem`.

The exception is that there is no `rem_ceil` for unsigned integers, as it would always return a negative result when non-zero.

r? @jhpratt