### PR TITLE
Fix tracing::instrument async block coverage

### DIFF
--- a/compiler/rustc_mir_transform/src/coverage/query.rs
+++ b/compiler/rustc_mir_transform/src/coverage/query.rs
@@ -28,8 +28,8 @@ fn is_eligible_for_coverage(tcx: TyCtxt<'_>, def_id: LocalDefId) -> bool {
     // expressions from coverage spans in enclosing MIR's, like we do for closures. (That might
     // be tricky if const expressions have no corresponding statements in the enclosing MIR.
     // Closures are carved out by their initial `Assign` statement.)
-    if !tcx.def_kind(def_id).is_fn_like() {
-        trace!("InstrumentCoverage skipped for {def_id:?} (not an fn-like)");
+    if tcx.is_const_fn(def_id) || tcx.is_const_trait_impl(def_id.to_def_id()) {
+        trace!("InstrumentCoverage skipped for {def_id:?} (const context eval)");
         return false;
     }
 

--- a/compiler/rustc_mir_transform/src/coverage/spans.rs
+++ b/compiler/rustc_mir_transform/src/coverage/spans.rs
@@ -28,7 +28,20 @@ pub(super) fn extract_refined_covspans<'tcx>(
 
     // If there somehow isn't an expansion tree node corresponding to the
     // body span, return now and don't create any mappings.
-    let Some(node) = expn_tree.get(hir_info.body_span.ctxt()) else { return };
+    let Some(mut node) = expn_tree.get(hir_info.body_span.ctxt()) else { return };
+
+    // An attribute proc macro can create a closure whose body has only empty spans in the
+    // expansion context, while interpolated user code retains root-context spans. Since this
+    // expansion tree contains spans from only one MIR body, use that root node as the body.
+    if matches!(
+        hir_info.body_span.ctxt().outer_expn_data().kind,
+        ExpnKind::Macro(MacroKind::Attr, _)
+    ) && node.child_contexts.is_empty()
+        && node.spans.iter().all(|span| span.span.is_dummy() || span.span.is_empty())
+        && let Some(root_node) = expn_tree.get(SyntaxContext::root())
+    {
+        node = root_node;
+    }
 
     let mut covspans = vec![];
 


### PR DESCRIPTION
Fixes rust-lang/rust#131119 (or tries to...)

Using tracing::instrument code such as:

```rust
  #[tracing::instrument]
  pub async fn fetch(id: u64) -> Result<String, Error> {
      let row = db_get(id).await?;
      Ok(row.name)
  }
```

Often results in functions with no coverage counters.

Using the following MRE:

```rust
use tracing::instrument;

pub async fn plain_async_branch(value: u8) -> &'static str {
    if value.is_multiple_of(2) {
        "plain even"
    } else {
        "plain odd"
    }
}

#[tracing::instrument]
pub fn instrumented_sync_branch(value: u8) -> &'static str {
    if value.is_multiple_of(2) {
        "sync even"
    } else {
        "sync odd"
    }
}

#[tracing::instrument]
pub async fn instrumented_async_branch(value: u8) -> &'static str {
    if value.is_multiple_of(2) {
        "async even"
    } else {
        "async odd"
    }
}

mod tests {
    use super::*;

    #[tokio::test]
    async fn plain_async_branch_reports_coverage() {
        assert_eq!(plain_async_branch(2).await, "plain even");
        assert_eq!(plain_async_branch(3).await, "plain odd");
    }

    #[test]
    fn instrumented_sync_branch_reports_coverage() {
        assert_eq!(instrumented_sync_branch(2), "sync even");
        assert_eq!(instrumented_sync_branch(3), "sync odd");
    }

    #[tokio::test]
    async fn instrumented_async_branch_reports_coverage() {
        assert_eq!(instrumented_async_branch(2).await, "async even");
        assert_eq!(instrumented_async_branch(3).await, "async odd");
    }
}
```

That was all wrong, a new approach has been done! It seems it was caused by looking at the wrong place in the macro expansion tree 

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
