### PR TITLE
Follow goto and drop when linting unreachable code

### DIFF
--- a/compiler/rustc_mir_transform/src/lint_and_remove_uninhabited.rs
+++ b/compiler/rustc_mir_transform/src/lint_and_remove_uninhabited.rs
@@ -93,8 +93,8 @@ fn find_unreachable_code_from<'tcx>(
     bb: BasicBlock,
     body: &Body<'tcx>,
 ) -> Option<(SourceInfo, &'static str)> {
-    let bb = &body.basic_blocks[bb];
-    for stmt in &bb.statements {
+    let bbdata = &body.basic_blocks[bb];
+    for stmt in &bbdata.statements {
         match &stmt.kind {
             // Ignore the implicit `()` return place assignment for unit functions/blocks
             StatementKind::Assign((_, Rvalue::Use(Operand::Constant(const_), _)))
@@ -108,7 +108,10 @@ fn find_unreachable_code_from<'tcx>(
             StatementKind::Assign((place, _)) if place.as_local() == Some(RETURN_PLACE) => {
                 continue;
             }
-            StatementKind::StorageLive(_) | StatementKind::StorageDead(_) => {
+            // Ignore statements inserted by MIR building that do not correspond to user code.
+            StatementKind::StorageLive(_)
+            | StatementKind::StorageDead(_)
+            | StatementKind::BackwardIncompatibleDropHint { .. } => {
                 continue;
             }
             StatementKind::FakeRead(..) => return Some((stmt.source_info, "definition")),
@@ -116,10 +119,18 @@ fn find_unreachable_code_from<'tcx>(
         }
     }
 
-    let term = bb.terminator();
+    let term = bbdata.terminator();
     match term.kind {
-        // No user code in this bb, and our goto target may be reachable via other paths
-        TerminatorKind::Goto { .. } | TerminatorKind::Return => None,
+        // The user does not care for `goto` and compiler-generated drops. If the target block is
+        // only reachable through those terminators, continue searching there.
+        TerminatorKind::Goto { target } | TerminatorKind::Drop { target, .. } => {
+            if &body.basic_blocks.predecessors()[target][..] == &[bb] {
+                find_unreachable_code_from(target, body)
+            } else {
+                None
+            }
+        }
+        TerminatorKind::Return => None,
         _ => Some((term.source_info, "expression")),
     }
 }

--- a/library/std/src/sync/poison.rs
+++ b/library/std/src/sync/poison.rs
@@ -57,9 +57,6 @@
 //!
 //! [`Once`]: crate::sync::Once
 
-// If we are not unwinding, `PoisonError` is uninhabited.
-#![cfg_attr(not(panic = "unwind"), expect(unreachable_code))]
-
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::condvar::Condvar;
 #[unstable(feature = "mapped_lock_guards", issue = "117108")]

--- a/tests/ui/uninhabited/void-branch.rs
+++ b/tests/ui/uninhabited/void-branch.rs
@@ -36,7 +36,6 @@ fn infallible_with_arg<T>(x: T) -> (T, std::convert::Infallible) {
 
 fn in_if_else(x: String) -> Result<String, (String, std::convert::Infallible)> {
     if x.len() > 0 { Err(infallible_with_arg(x)) } else { Ok(x) }
-    //~^ ERROR unreachable expression
 }
 
 fn main() {}

--- a/tests/ui/uninhabited/void-branch.rs
+++ b/tests/ui/uninhabited/void-branch.rs
@@ -29,4 +29,14 @@ fn with_infallible() {
     println!()
 }
 
+fn infallible_with_arg<T>(x: T) -> (T, std::convert::Infallible) {
+    (x, loop {})
+    //~^ ERROR unreachable expression
+}
+
+fn in_if_else(x: String) -> Result<String, (String, std::convert::Infallible)> {
+    if x.len() > 0 { Err(infallible_with_arg(x)) } else { Ok(x) }
+    //~^ ERROR unreachable expression
+}
+
 fn main() {}

--- a/tests/ui/uninhabited/void-branch.stderr
+++ b/tests/ui/uninhabited/void-branch.stderr
@@ -1,4 +1,19 @@
 error: unreachable expression
+  --> $DIR/void-branch.rs:33:5
+   |
+LL |     (x, loop {})
+   |     ^^^^-------^
+   |     |   |
+   |     |   any code following this expression is unreachable
+   |     unreachable expression
+   |
+note: the lint level is defined here
+  --> $DIR/void-branch.rs:1:9
+   |
+LL | #![deny(unreachable_code)]
+   |         ^^^^^^^^^^^^^^^^
+
+error: unreachable expression
   --> $DIR/void-branch.rs:10:13
    |
 LL |             std::mem::uninitialized::<Void>();
@@ -11,11 +26,6 @@ note: this expression has type `Void`, which is uninhabited
    |
 LL |             std::mem::uninitialized::<Void>();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: the lint level is defined here
-  --> $DIR/void-branch.rs:1:9
-   |
-LL | #![deny(unreachable_code)]
-   |         ^^^^^^^^^^^^^^^^
 
 error: unreachable expression
   --> $DIR/void-branch.rs:25:9
@@ -31,5 +41,19 @@ note: this expression has type `Infallible`, which is uninhabited
 LL |         infallible();
    |         ^^^^^^^^^^^^
 
-error: aborting due to 2 previous errors
+error: unreachable expression
+  --> $DIR/void-branch.rs:38:48
+   |
+LL |     if x.len() > 0 { Err(infallible_with_arg(x)) } else { Ok(x) }
+   |                          ----------------------^ unreachable expression
+   |                          |
+   |                          any code following this expression is unreachable
+   |
+note: this expression has type `(String, Infallible)`, which is uninhabited
+  --> $DIR/void-branch.rs:38:26
+   |
+LL |     if x.len() > 0 { Err(infallible_with_arg(x)) } else { Ok(x) }
+   |                          ^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 4 previous errors
 

--- a/tests/ui/uninhabited/void-branch.stderr
+++ b/tests/ui/uninhabited/void-branch.stderr
@@ -41,19 +41,5 @@ note: this expression has type `Infallible`, which is uninhabited
 LL |         infallible();
    |         ^^^^^^^^^^^^
 
-error: unreachable expression
-  --> $DIR/void-branch.rs:38:48
-   |
-LL |     if x.len() > 0 { Err(infallible_with_arg(x)) } else { Ok(x) }
-   |                          ----------------------^ unreachable expression
-   |                          |
-   |                          any code following this expression is unreachable
-   |
-note: this expression has type `(String, Infallible)`, which is uninhabited
-  --> $DIR/void-branch.rs:38:26
-   |
-LL |     if x.len() > 0 { Err(infallible_with_arg(x)) } else { Ok(x) }
-   |                          ^^^^^^^^^^^^^^^^^^^^^^
-
-error: aborting due to 4 previous errors
+error: aborting due to 3 previous errors
 


### PR DESCRIPTION
Those drops and gotos are compiler-generated and do not correspond to user code. Skip them when looking for unreachable code to lint.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
