### PR TITLE
Improve unknown crate_type diagnostic suggestions

### DIFF
--- a/compiler/rustc_attr_parsing/src/attributes/crate_level.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/crate_level.rs
@@ -2,7 +2,7 @@ use rustc_feature::AttributeStability;
 use rustc_hir::attrs::{CrateType, WindowsSubsystemKind};
 use rustc_session::lint::builtin::UNKNOWN_CRATE_TYPES;
 use rustc_span::Symbol;
-use rustc_span::edit_distance::find_best_match_for_name;
+use rustc_span::edit_distance::find_best_match_for_name_with_substrings;
 
 use super::prelude::*;
 use crate::diagnostics::{UnknownCrateTypes, UnknownCrateTypesSuggestion};
@@ -49,10 +49,10 @@ impl CombineAttributeParser for CrateTypeParser {
         let Ok(crate_type) = crate_type.try_into() else {
             // We don't error on invalid `#![crate_type]` when not applied to a crate
             if cx.shared.target == Target::Crate {
-                let candidate = find_best_match_for_name(
+                let candidate = find_best_match_for_name_with_substrings(
                     &CrateType::all_stable().iter().map(|(name, _)| *name).collect::<Vec<_>>(),
                     crate_type,
-                    None,
+                    Some(5),
                 );
                 let span = n.value_span;
                 cx.emit_lint(

--- a/tests/ui/attributes/invalid-crate-type.rs
+++ b/tests/ui/attributes/invalid-crate-type.rs
@@ -1,5 +1,8 @@
 // regression test for issue 11256
 #![crate_type="foo"]    //~ ERROR invalid `crate_type` value
+//~| NOTE `#[deny(unknown_crate_types)]` on by default
+//~| HELP did you mean
+//~| SUGGESTION lib
 
 // Tests for suggestions (#53958)
 
@@ -42,6 +45,52 @@
 //~^ ERROR invalid `crate_type` value
 //~| HELP did you mean
 //~| SUGGESTION cdylib
+
+// substring matching tests
+#![crate_type="binary"]
+//~^ ERROR invalid `crate_type` value
+//~| HELP did you mean
+//~| SUGGESTION bin
+
+#![crate_type="library"]
+//~^ ERROR invalid `crate_type` value
+//~| HELP did you mean
+//~| SUGGESTION lib
+
+#![crate_type="rustlib"]
+//~^ ERROR invalid `crate_type` value
+//~| HELP did you mean
+//~| SUGGESTION rlib
+
+#![crate_type="dynamiclib"]
+//~^ ERROR invalid `crate_type` value
+//~| HELP did you mean
+//~| SUGGESTION dylib
+
+#![crate_type="dylibrary"]
+//~^ ERROR invalid `crate_type` value
+//~| HELP did you mean
+//~| SUGGESTION dylib
+
+#![crate_type="cdynamiclib"]
+//~^ ERROR invalid `crate_type` value
+//~| HELP did you mean
+//~| SUGGESTION cdylib
+
+#![crate_type="cdylibrary"]
+//~^ ERROR invalid `crate_type` value
+//~| HELP did you mean
+//~| SUGGESTION cdylib
+
+#![crate_type="staticlibrary"]
+//~^ ERROR invalid `crate_type` value
+//~| HELP did you mean
+//~| SUGGESTION staticlib
+
+#![crate_type="procedural-macro"]
+//~^ ERROR invalid `crate_type` value
+//~| HELP did you mean
+//~| SUGGESTION proc-macro
 
 fn main() {
     return

--- a/tests/ui/attributes/invalid-crate-type.stderr
+++ b/tests/ui/attributes/invalid-crate-type.stderr
@@ -2,57 +2,111 @@ error: invalid `crate_type` value
   --> $DIR/invalid-crate-type.rs:2:15
    |
 LL | #![crate_type="foo"]
-   |               ^^^^^
+   |               ^^^^^ help: did you mean: `"lib"`
    |
    = note: `#[deny(unknown_crate_types)]` on by default
 
 error: invalid `crate_type` value
-  --> $DIR/invalid-crate-type.rs:6:15
+  --> $DIR/invalid-crate-type.rs:9:15
    |
 LL | #![crate_type="statoclib"]
    |               ^^^^^^^^^^^ help: did you mean: `"staticlib"`
 
 error: invalid `crate_type` value
-  --> $DIR/invalid-crate-type.rs:11:15
+  --> $DIR/invalid-crate-type.rs:14:15
    |
 LL | #![crate_type="procmacro"]
    |               ^^^^^^^^^^^ help: did you mean: `"proc-macro"`
 
 error: invalid `crate_type` value
-  --> $DIR/invalid-crate-type.rs:16:15
+  --> $DIR/invalid-crate-type.rs:19:15
    |
 LL | #![crate_type="static-lib"]
    |               ^^^^^^^^^^^^ help: did you mean: `"staticlib"`
 
 error: invalid `crate_type` value
-  --> $DIR/invalid-crate-type.rs:21:15
+  --> $DIR/invalid-crate-type.rs:24:15
    |
 LL | #![crate_type="drylib"]
    |               ^^^^^^^^ help: did you mean: `"dylib"`
 
 error: invalid `crate_type` value
-  --> $DIR/invalid-crate-type.rs:26:15
+  --> $DIR/invalid-crate-type.rs:29:15
    |
 LL | #![crate_type="dlib"]
    |               ^^^^^^ help: did you mean: `"lib"`
 
 error: invalid `crate_type` value
-  --> $DIR/invalid-crate-type.rs:31:15
+  --> $DIR/invalid-crate-type.rs:34:15
    |
 LL | #![crate_type="lob"]
    |               ^^^^^ help: did you mean: `"lib"`
 
 error: invalid `crate_type` value
-  --> $DIR/invalid-crate-type.rs:36:15
+  --> $DIR/invalid-crate-type.rs:39:15
    |
 LL | #![crate_type="bon"]
    |               ^^^^^ help: did you mean: `"bin"`
 
 error: invalid `crate_type` value
-  --> $DIR/invalid-crate-type.rs:41:15
+  --> $DIR/invalid-crate-type.rs:44:15
    |
 LL | #![crate_type="cdalib"]
    |               ^^^^^^^^ help: did you mean: `"cdylib"`
 
-error: aborting due to 9 previous errors
+error: invalid `crate_type` value
+  --> $DIR/invalid-crate-type.rs:50:15
+   |
+LL | #![crate_type="binary"]
+   |               ^^^^^^^^ help: did you mean: `"bin"`
+
+error: invalid `crate_type` value
+  --> $DIR/invalid-crate-type.rs:55:15
+   |
+LL | #![crate_type="library"]
+   |               ^^^^^^^^^ help: did you mean: `"lib"`
+
+error: invalid `crate_type` value
+  --> $DIR/invalid-crate-type.rs:60:15
+   |
+LL | #![crate_type="rustlib"]
+   |               ^^^^^^^^^ help: did you mean: `"rlib"`
+
+error: invalid `crate_type` value
+  --> $DIR/invalid-crate-type.rs:65:15
+   |
+LL | #![crate_type="dynamiclib"]
+   |               ^^^^^^^^^^^^ help: did you mean: `"dylib"`
+
+error: invalid `crate_type` value
+  --> $DIR/invalid-crate-type.rs:70:15
+   |
+LL | #![crate_type="dylibrary"]
+   |               ^^^^^^^^^^^ help: did you mean: `"dylib"`
+
+error: invalid `crate_type` value
+  --> $DIR/invalid-crate-type.rs:75:15
+   |
+LL | #![crate_type="cdynamiclib"]
+   |               ^^^^^^^^^^^^^ help: did you mean: `"cdylib"`
+
+error: invalid `crate_type` value
+  --> $DIR/invalid-crate-type.rs:80:15
+   |
+LL | #![crate_type="cdylibrary"]
+   |               ^^^^^^^^^^^^ help: did you mean: `"cdylib"`
+
+error: invalid `crate_type` value
+  --> $DIR/invalid-crate-type.rs:85:15
+   |
+LL | #![crate_type="staticlibrary"]
+   |               ^^^^^^^^^^^^^^^ help: did you mean: `"staticlib"`
+
+error: invalid `crate_type` value
+  --> $DIR/invalid-crate-type.rs:90:15
+   |
+LL | #![crate_type="procedural-macro"]
+   |               ^^^^^^^^^^^^^^^^^^ help: did you mean: `"proc-macro"`
+
+error: aborting due to 18 previous errors
 


### PR DESCRIPTION
I have improved the suggestions given in the unknown crate_type diagnostic.

Before (no suggestion):
```
error: invalid `crate_type` value
 --> bad_error.rs:1:17
  |
1 | #![crate_type = "binary"]
  |                 ^^^^^^^^
  |
  = note: `#[deny(unknown_crate_types)]` on by default
```

After:
```
error: invalid `crate_type` value
 --> bad_error.rs:1:17
  |
1 | #![crate_type = "binary"]
  |                 ^^^^^^^^ help: did you mean: `"bin"`
  |
  = note: `#[deny(unknown_crate_types)]` on by default
```

By increasing the allowed edit distance for the matching, as well as allowing substring matches, this now also works for mistakes like `dynamiclib`, where it will suggest `dylib`, and `cdylibrary` where it suggests `cdylib`.

r? @JonathanBrouwer