### PR TITLE
Always escape grapheme extenders in `str::escape_debug`

### DIFF
--- a/library/alloctests/tests/str.rs
+++ b/library/alloctests/tests/str.rs
@@ -1141,7 +1141,7 @@ fn test_escape_debug() {
     assert_eq!("\u{10d4ea}\r".escape_debug().to_string(), "\\u{10d4ea}\\r");
     assert_eq!(
         "\u{301}a\u{301}bé\u{e000}".escape_debug().to_string(),
-        "\\u{301}a\u{301}bé\\u{e000}"
+        "\\u{301}a\\u{301}bé\\u{e000}"
     );
 }
 

--- a/library/alloctests/tests/str.rs
+++ b/library/alloctests/tests/str.rs
@@ -1156,7 +1156,7 @@ fn test_escape_debug() {
     assert_eq!("\u{10d4ea}\r".escape_debug().to_string(), "\\u{10d4ea}\\r");
     assert_eq!(
         "\u{301}a\u{301}bé\u{e000}".escape_debug().to_string(),
-        "\\u{301}a\u{301}bé\\u{e000}"
+        "\\u{301}a\\u{301}bé\\u{e000}"
     );
 }
 

--- a/library/core/src/char/methods.rs
+++ b/library/core/src/char/methods.rs
@@ -470,9 +470,7 @@ impl char {
     }
 
     /// An extended version of `escape_debug` that optionally permits escaping
-    /// Extended Grapheme codepoints, single quotes, and double quotes. This
-    /// allows us to format characters like nonspacing marks better when they're
-    /// at the start of a string, and allows escaping single quotes in
+    /// single quotes and double quotes. This allows escaping single quotes in
     /// characters, and double quotes in strings.
     #[inline]
     pub(crate) fn escape_debug_ext(self, args: EscapeDebugExtArgs) -> EscapeDebug {
@@ -492,7 +490,7 @@ impl char {
             _ if self.is_control()
                 || self.is_private_use()
                 || self.is_whitespace()
-                || args.escape_grapheme_extender && self.is_grapheme_extender()
+                || self.is_grapheme_extender()
                 || self.is_default_ignorable()
                 || self.is_format_control()
                 || self.is_unassigned() =>
@@ -2423,9 +2421,6 @@ impl char {
 }
 
 pub(crate) struct EscapeDebugExtArgs {
-    /// Escape Grapheme Extender codepoints?
-    pub(crate) escape_grapheme_extender: bool,
-
     /// Escape single quotes?
     pub(crate) escape_single_quote: bool,
 
@@ -2434,11 +2429,8 @@ pub(crate) struct EscapeDebugExtArgs {
 }
 
 impl EscapeDebugExtArgs {
-    pub(crate) const ESCAPE_ALL: Self = Self {
-        escape_grapheme_extender: true,
-        escape_single_quote: true,
-        escape_double_quote: true,
-    };
+    pub(crate) const ESCAPE_ALL: Self =
+        Self { escape_single_quote: true, escape_double_quote: true };
 }
 
 #[inline]

--- a/library/core/src/char/methods.rs
+++ b/library/core/src/char/methods.rs
@@ -470,9 +470,7 @@ impl char {
     }
 
     /// An extended version of `escape_debug` that optionally permits escaping
-    /// Extended Grapheme codepoints, single quotes, and double quotes. This
-    /// allows us to format characters like nonspacing marks better when they're
-    /// at the start of a string, and allows escaping single quotes in
+    /// single quotes and double quotes. This allows escaping single quotes in
     /// characters, and double quotes in strings.
     #[inline]
     pub(crate) fn escape_debug_ext(self, args: EscapeDebugExtArgs) -> EscapeDebug {
@@ -495,7 +493,7 @@ impl char {
             _ if self.is_control()
                 || self.is_private_use()
                 || self.is_whitespace()
-                || args.escape_grapheme_extender && self.is_grapheme_extender()
+                || self.is_grapheme_extender()
                 || self.is_default_ignorable()
                 || self.is_format_control()
                 || !self.is_assigned() =>
@@ -2454,16 +2452,6 @@ impl char {
 }
 
 pub(crate) struct EscapeDebugExtArgs {
-    /// Escape Grapheme Extender codepoints?
-    ///
-    /// Note that this excludes
-    /// U+FF9E HALFWIDTH KATAKANA VOICED SOUND MARK
-    /// and U+FF9F HALFWIDTH KATAKANA SEMI-VOICED SOUND MARK,
-    /// which are never escaped, as graphically
-    /// they are not combining. See <https://github.com/microsoft/terminal/issues/18087>
-    /// for background on these characters.
-    pub(crate) escape_grapheme_extender: bool,
-
     /// Escape single quotes?
     pub(crate) escape_single_quote: bool,
 
@@ -2472,11 +2460,8 @@ pub(crate) struct EscapeDebugExtArgs {
 }
 
 impl EscapeDebugExtArgs {
-    pub(crate) const ESCAPE_ALL: Self = Self {
-        escape_grapheme_extender: true,
-        escape_single_quote: true,
-        escape_double_quote: true,
-    };
+    pub(crate) const ESCAPE_ALL: Self =
+        Self { escape_single_quote: true, escape_double_quote: true };
 }
 
 #[inline]

--- a/library/core/src/fmt/mod.rs
+++ b/library/core/src/fmt/mod.rs
@@ -2943,7 +2943,6 @@ impl Debug for str {
             let mut chars = rest.chars();
             if let Some(c) = chars.next() {
                 let esc = c.escape_debug_ext(EscapeDebugExtArgs {
-                    escape_grapheme_extender: true,
                     escape_single_quote: false,
                     escape_double_quote: true,
                 });
@@ -2975,7 +2974,6 @@ impl Debug for char {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         f.write_char('\'')?;
         let esc = self.escape_debug_ext(EscapeDebugExtArgs {
-            escape_grapheme_extender: true,
             escape_single_quote: true,
             escape_double_quote: false,
         });

--- a/library/core/src/fmt/mod.rs
+++ b/library/core/src/fmt/mod.rs
@@ -2956,7 +2956,6 @@ impl Debug for str {
             let mut chars = rest.chars();
             if let Some(c) = chars.next() {
                 let esc = c.escape_debug_ext(EscapeDebugExtArgs {
-                    escape_grapheme_extender: true,
                     escape_single_quote: false,
                     escape_double_quote: true,
                 });
@@ -2988,7 +2987,6 @@ impl Debug for char {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         f.write_char('\'')?;
         let esc = self.escape_debug_ext(EscapeDebugExtArgs {
-            escape_grapheme_extender: true,
             escape_single_quote: true,
             escape_double_quote: false,
         });

--- a/library/core/src/str/iter.rs
+++ b/library/core/src/str/iter.rs
@@ -3,18 +3,18 @@
 use super::pattern::{DoubleEndedSearcher, Pattern, ReverseSearcher, Searcher};
 use super::validations::{next_code_point, next_code_point_reverse};
 use super::{
-    BytesIsNotEmpty, CharEscapeDebugContinue, CharEscapeDefault, CharEscapeUnicode,
-    IsAsciiWhitespace, IsNotEmpty, IsWhitespace, LinesMap, UnsafeBytesToStr, from_utf8_unchecked,
+    BytesIsNotEmpty, CharEscapeDebug, CharEscapeDefault, CharEscapeUnicode, IsAsciiWhitespace,
+    IsNotEmpty, IsWhitespace, LinesMap, UnsafeBytesToStr, from_utf8_unchecked,
 };
+use crate::char as char_mod;
 use crate::fmt::{self, Write};
 use crate::iter::{
-    Chain, Copied, Filter, FlatMap, Flatten, FusedIterator, Map, TrustedLen, TrustedRandomAccess,
+    Copied, Filter, FlatMap, FusedIterator, Map, TrustedLen, TrustedRandomAccess,
     TrustedRandomAccessNoCoerce,
 };
 use crate::num::NonZero;
 use crate::ops::Try;
 use crate::slice::{self, Split as SliceSplit};
-use crate::{char as char_mod, option};
 
 /// An iterator over the [`char`]s of a string slice.
 ///
@@ -1542,10 +1542,7 @@ impl FusedIterator for EncodeUtf16<'_> {}
 #[stable(feature = "str_escape", since = "1.34.0")]
 #[derive(Clone, Debug)]
 pub struct EscapeDebug<'a> {
-    pub(super) inner: Chain<
-        Flatten<option::IntoIter<char_mod::EscapeDebug>>,
-        FlatMap<Chars<'a>, char_mod::EscapeDebug, CharEscapeDebugContinue>,
-    >,
+    pub(super) inner: FlatMap<Chars<'a>, char_mod::EscapeDebug, CharEscapeDebug>,
 }
 
 /// The return type of [`str::escape_default`].

--- a/library/core/src/str/iter.rs
+++ b/library/core/src/str/iter.rs
@@ -3,18 +3,18 @@
 use super::pattern::{DoubleEndedSearcher, Pattern, ReverseSearcher, Searcher};
 use super::validations::{next_code_point, next_code_point_reverse};
 use super::{
-    BytesIsNotEmpty, CharEscapeDebugContinue, CharEscapeDefault, CharEscapeUnicode,
-    IsAsciiWhitespace, IsNotEmpty, IsWhitespace, LinesMap, UnsafeBytesToStr, from_utf8_unchecked,
+    BytesIsNotEmpty, CharEscapeDebug, CharEscapeDefault, CharEscapeUnicode, IsAsciiWhitespace,
+    IsNotEmpty, IsWhitespace, LinesMap, UnsafeBytesToStr, from_utf8_unchecked,
 };
+use crate::char as char_mod;
 use crate::fmt::{self, Write};
 use crate::iter::{
-    Chain, Copied, Filter, FlatMap, Flatten, FusedIterator, Map, TrustedLen, TrustedRandomAccess,
+    Copied, Filter, FlatMap, FusedIterator, Map, TrustedLen, TrustedRandomAccess,
     TrustedRandomAccessNoCoerce,
 };
 use crate::num::NonZero;
 use crate::ops::Try;
 use crate::slice::{self, Split as SliceSplit};
-use crate::{char as char_mod, option};
 
 /// An iterator over the [`char`]s of a string slice.
 ///
@@ -1579,10 +1579,7 @@ impl FusedIterator for EncodeUtf16<'_> {}
 #[stable(feature = "str_escape", since = "1.34.0")]
 #[derive(Clone, Debug)]
 pub struct EscapeDebug<'a> {
-    pub(super) inner: Chain<
-        Flatten<option::IntoIter<char_mod::EscapeDebug>>,
-        FlatMap<Chars<'a>, char_mod::EscapeDebug, CharEscapeDebugContinue>,
-    >,
+    pub(super) inner: FlatMap<Chars<'a>, char_mod::EscapeDebug, CharEscapeDebug>,
 }
 
 /// The return type of [`str::escape_default`].

--- a/library/core/src/str/lossy.rs
+++ b/library/core/src/str/lossy.rs
@@ -123,7 +123,6 @@ impl fmt::Debug for Debug<'_> {
                 let mut from = 0;
                 for (i, c) in valid.char_indices() {
                     let esc = c.escape_debug_ext(EscapeDebugExtArgs {
-                        escape_grapheme_extender: true,
                         escape_single_quote: false,
                         escape_double_quote: true,
                     });

--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -3053,9 +3053,6 @@ impl str {
 
     /// Returns an iterator that escapes each char in `self` with [`char::escape_debug`].
     ///
-    /// Note: only extended grapheme codepoints that begin the string will be
-    /// escaped.
-    ///
     /// # Examples
     ///
     /// As an iterator:
@@ -3089,15 +3086,7 @@ impl str {
                   without modifying the original"]
     #[stable(feature = "str_escape", since = "1.34.0")]
     pub fn escape_debug(&self) -> EscapeDebug<'_> {
-        let mut chars = self.chars();
-        EscapeDebug {
-            inner: chars
-                .next()
-                .map(|first| first.escape_debug_ext(EscapeDebugExtArgs::ESCAPE_ALL))
-                .into_iter()
-                .flatten()
-                .chain(chars.flat_map(CharEscapeDebugContinue)),
-        }
+        EscapeDebug { inner: self.chars().flat_map(CharEscapeDebug) }
     }
 
     /// Returns an iterator that escapes each char in `self` with [`char::escape_default`].
@@ -3261,12 +3250,8 @@ impl_fn_for_zst! {
     };
 
     #[derive(Clone)]
-    struct CharEscapeDebugContinue impl Fn = |c: char| -> char::EscapeDebug {
-        c.escape_debug_ext(EscapeDebugExtArgs {
-            escape_grapheme_extender: false,
-            escape_single_quote: true,
-            escape_double_quote: true
-        })
+    struct CharEscapeDebug impl Fn = |c: char| -> char::EscapeDebug {
+        c.escape_debug_ext(EscapeDebugExtArgs::ESCAPE_ALL)
     };
 
     #[derive(Clone)]

--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -3120,9 +3120,6 @@ impl str {
 
     /// Returns an iterator that escapes each char in `self` with [`char::escape_debug`].
     ///
-    /// Note: only extended grapheme codepoints that begin the string will be
-    /// escaped.
-    ///
     /// # Examples
     ///
     /// As an iterator:
@@ -3156,15 +3153,7 @@ impl str {
                   without modifying the original"]
     #[stable(feature = "str_escape", since = "1.34.0")]
     pub fn escape_debug(&self) -> EscapeDebug<'_> {
-        let mut chars = self.chars();
-        EscapeDebug {
-            inner: chars
-                .next()
-                .map(|first| first.escape_debug_ext(EscapeDebugExtArgs::ESCAPE_ALL))
-                .into_iter()
-                .flatten()
-                .chain(chars.flat_map(CharEscapeDebugContinue)),
-        }
+        EscapeDebug { inner: self.chars().flat_map(CharEscapeDebug) }
     }
 
     /// Returns an iterator that escapes each char in `self` with [`char::escape_default`].
@@ -3328,12 +3317,8 @@ impl_fn_for_zst! {
     };
 
     #[derive(Clone)]
-    struct CharEscapeDebugContinue impl Fn = |c: char| -> char::EscapeDebug {
-        c.escape_debug_ext(EscapeDebugExtArgs {
-            escape_grapheme_extender: false,
-            escape_single_quote: true,
-            escape_double_quote: true
-        })
+    struct CharEscapeDebug impl Fn = |c: char| -> char::EscapeDebug {
+        c.escape_debug_ext(EscapeDebugExtArgs::ESCAPE_ALL)
     };
 
     #[derive(Clone)]

--- a/library/core/src/wtf8.rs
+++ b/library/core/src/wtf8.rs
@@ -147,7 +147,6 @@ impl fmt::Debug for Wtf8 {
             use crate::fmt::Write as _;
             for c in s.chars().flat_map(|c| {
                 c.escape_debug_ext(EscapeDebugExtArgs {
-                    escape_grapheme_extender: true,
                     escape_single_quote: false,
                     escape_double_quote: true,
                 })


### PR DESCRIPTION
This matches the behavior of `impl Debug for str`.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

@rustbot label A-Unicode T-libs-api needs-fcp