### PR TITLE
tests: modify s390x vector test to be robust to instruction scheduling

### DIFF
--- a/tests/assembly-llvm/s390x-vector-abi.rs
+++ b/tests/assembly-llvm/s390x-vector-abi.rs
@@ -62,16 +62,11 @@ unsafe extern "C" fn vector_ret(x: &i8x16) -> i8x16 {
     *x
 }
 // CHECK-LABEL: vector_ret_large:
-// z10: vl %v0, 16(%r3), 4
-// z10-NEXT: vl %v1, 0(%r3), 4
-// z10-NEXT: vst %v0, 16(%r2), 4
-// z10-NEXT: vst %v1, 0(%r2), 4
-// z10-NEXT: br %r14
-// z13: vl %v0, 0(%r3), 4
-// z13-NEXT: vl %v1, 16(%r3), 4
-// z13-NEXT: vst %v1, 16(%r2), 4
-// z13-NEXT: vst %v0, 0(%r2), 4
-// z13-NEXT: br %r14
+// CHECK-DAG: vl [[REG1:%v[0-9]+]], 16(%r3), 4
+// CHECK-DAG: vl [[REG2:%v[0-9]+]], 0(%r3), 4
+// CHECK-DAG: vst [[REG1]], 16(%r2), 4
+// CHECK-DAG: vst [[REG2]], 0(%r2), 4
+// CHECK: br %r14
 #[cfg_attr(no_vector, target_feature(enable = "vector"))]
 #[no_mangle]
 unsafe extern "C" fn vector_ret_large(x: &i8x32) -> i8x32 {
@@ -95,16 +90,11 @@ unsafe extern "C" fn vector_wrapper_ret(x: &Wrapper<i8x16>) -> Wrapper<i8x16> {
     *x
 }
 // CHECK-LABEL: vector_wrapper_ret_large:
-// z10: vl %v0, 16(%r3), 4
-// z10-NEXT: vl %v1, 0(%r3), 4
-// z10-NEXT: vst %v0, 16(%r2), 4
-// z10-NEXT: vst %v1, 0(%r2), 4
-// z10-NEXT: br %r14
-// z13: vl %v0, 16(%r3), 4
-// z13-NEXT: vst %v0, 16(%r2), 4
-// z13-NEXT: vl %v0, 0(%r3), 4
-// z13-NEXT: vst %v0, 0(%r2), 4
-// z13-NEXT: br %r14
+// CHECK-DAG: vl [[REG1:%v[0-9]+]], 16(%r3), 4
+// CHECK-DAG: vl [[REG2:%v[0-9]+]], 0(%r3), 4
+// CHECK-DAG: vst [[REG1]], 16(%r2), 4
+// CHECK-DAG: vst [[REG2]], 0(%r2), 4
+// CHECK: br %r14
 #[cfg_attr(no_vector, target_feature(enable = "vector"))]
 #[no_mangle]
 unsafe extern "C" fn vector_wrapper_ret_large(x: &Wrapper<i8x32>) -> Wrapper<i8x32> {
@@ -141,16 +131,11 @@ unsafe extern "C" fn vector_wrapper_with_zst_ret(
     *x
 }
 // CHECK-LABEL: vector_wrapper_with_zst_ret_large:
-// z10: vl %v0, 16(%r3), 4
-// z10-NEXT: vl %v1, 0(%r3), 4
-// z10-NEXT: vst %v0, 16(%r2), 4
-// z10-NEXT: vst %v1, 0(%r2), 4
-// z10-NEXT: br %r14
-// z13: vl %v0, 16(%r3), 4
-// z13-NEXT: vst %v0, 16(%r2), 4
-// z13-NEXT: vl %v0, 0(%r3), 4
-// z13-NEXT: vst %v0, 0(%r2), 4
-// z13-NEXT: br %r14
+// CHECK-DAG: vl [[REG1:%v[0-9]+]], 16(%r3), 4
+// CHECK-DAG: vl [[REG2:%v[0-9]+]], 0(%r3), 4
+// CHECK-DAG: vst [[REG1]], 16(%r2), 4
+// CHECK-DAG: vst [[REG2]], 0(%r2), 4
+// CHECK: br %r14
 #[cfg_attr(no_vector, target_feature(enable = "vector"))]
 #[no_mangle]
 unsafe extern "C" fn vector_wrapper_with_zst_ret_large(
@@ -180,16 +165,11 @@ unsafe extern "C" fn vector_transparent_wrapper_ret(
     *x
 }
 // CHECK-LABEL: vector_transparent_wrapper_ret_large:
-// z10: vl %v0, 16(%r3), 4
-// z10-NEXT: vl %v1, 0(%r3), 4
-// z10-NEXT: vst %v0, 16(%r2), 4
-// z10-NEXT: vst %v1, 0(%r2), 4
-// z10-NEXT: br %r14
-// z13: vl %v0, 0(%r3), 4
-// z13-NEXT: vl %v1, 16(%r3), 4
-// z13-NEXT: vst %v1, 16(%r2), 4
-// z13-NEXT: vst %v0, 0(%r2), 4
-// z13-NEXT: br %r14
+// CHECK-DAG: vl [[REG1:%v[0-9]+]], 16(%r3), 4
+// CHECK-DAG: vl [[REG2:%v[0-9]+]], 0(%r3), 4
+// CHECK-DAG: vst [[REG1]], 16(%r2), 4
+// CHECK-DAG: vst [[REG2]], 0(%r2), 4
+// CHECK: br %r14
 #[cfg_attr(no_vector, target_feature(enable = "vector"))]
 #[no_mangle]
 unsafe extern "C" fn vector_transparent_wrapper_ret_large(


### PR DESCRIPTION
A recent LLVM change causes some changes here, if I'm understanding correctly it allows some better latency reduction. From what I can tell, this test doesn't care that only a single register is used, so we use -DAG instead of -NEXT to allow some instruction reordering.

By happy coincidence, the z10 and z13 code matches now, which collapsed some of the test lines. I'm happy to split them back out if that's bad for some reason though!

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
