### PR TITLE
CI job for parallel frontend ui tests

### DIFF
--- a/src/ci/docker/host-x86_64/optional-x86_64-gnu-parallel-frontend/Dockerfile
+++ b/src/ci/docker/host-x86_64/optional-x86_64-gnu-parallel-frontend/Dockerfile
@@ -24,13 +24,20 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
+ENV PARALLEL_FRONTEND_THREADS=4
+ENV ITERATION_COUNT=2
+
 ENV RUST_CONFIGURE_ARGS \
  --build=x86_64-unknown-linux-gnu \
  --enable-sanitizers \
  --enable-profiler \
  --enable-compiler-docs \
- --set llvm.libzstd=true
+ --set llvm.libzstd=true \
+ --set rust.parallel-frontend-threads=${PARALLEL_FRONTEND_THREADS}
 
 # Build the toolchain with multiple parallel frontend threads and then run tests
 # Tests are still compiled serially at the moment (intended to be changed in follow-ups).
-ENV SCRIPT python3 ../x.py --stage 2 test --set rust.parallel-frontend-threads=4
+# Running compiletest only tests for parallel frontend, then the rest without compiletest-only
+# options (i.e. `--parallel-frontend-threads=4 --iteration-count=2`)
+COPY ./scripts/optional-x86_64-gnu-parallel-frontend.sh /scripts/
+ENV SCRIPT="Must specify DOCKER_SCRIPT for this image"

--- a/src/ci/docker/scripts/optional-x86_64-gnu-parallel-frontend.sh
+++ b/src/ci/docker/scripts/optional-x86_64-gnu-parallel-frontend.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -eux -o pipefail
+
+if [ ! -v RUST_TEST_THREADS ]; then
+    RUST_TEST_THREADS_=$(python3 -c "print(max(1, $(nproc) // ${PARALLEL_FRONTEND_THREADS}))")
+else
+    RUST_TEST_THREADS_=${RUST_TEST_THREADS}
+fi
+
+RUST_TEST_THREADS=${RUST_TEST_THREADS_} \
+    python3 ../x.py --stage 2 test \
+    tests/ui \
+    -- \
+    --parallel-frontend-threads="${PARALLEL_FRONTEND_THREADS}" \
+    --iteration-count="${ITERATION_COUNT}"

--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -363,6 +363,8 @@ auto:
   - name: optional-x86_64-gnu-parallel-frontend
     # This test can be flaky, so do not cancel CI if it fails, for now.
     continue_on_error: true
+    env:
+      DOCKER_SCRIPT: optional-x86_64-gnu-parallel-frontend.sh
     <<: *job-linux-4c
 
   # This job ensures commits landing on nightly still pass the full


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/158307)*
<!-- homu-ignore:end -->

## Summary

Part of https://github.com/rust-lang/compiler-team/issues/1005.

Supersedes https://github.com/rust-lang/rust/pull/157705.

### Initial setup in this PR

For the initial setup in this PR, we'll go ahead with the following combination:

- `RUST_TEST_THREADS`: `max(1, $(nproc) // ${PARALLEL_FRONTEND_THREADS})`
- `--parallel-frontend-threads`: **4**
- `--iteration-count`: **2**

Against `./x test tests/ui --stage=2` only. We can tune these knobs in follow-ups. In try jobs we ran, this should not exceed the current longest auto job duration (at around 3h 15m).

## Additional context

### Issues with the previous attempt

The issue with the original change was arguments `--parallel-frontend-threads=4 --iteration-count=2` being compiletest-only. They were being passed to other parts of the test harness (e.g. libtest) as is. These parts, however, have no clue of the arguments, hence the errors.

I've spent a lot of time on this and haven't found any reasonable way to fix this behavior. We could make bootstrap aware of these specific two arguments and have an additional internal logic for handling this. It's big of a hack, i reckon. The best decision i arrived at is to split testing into two parts: one for compiletest only and another for everything else. The issue is (AFAIK) we can't tell bootstrap (or x.py, at least) to "test the default stuff, but only for compiletest". When used like `x test tests/` it runs _all_ the tests in this directory, including non-default ones, and crashes as it can't find nodejs for doctests. `--skip compiler/ --skip library/ --skip src/tools/ --skip tests/incremental ...` is still not exhaustive list  of exclusions.

I went on with a whitelist instead of a blacklist. But we, again, can't tell what tests are "default". There's a mechanism in [bootstrap::core::builder::Builder](https://doc.rust-lang.org/nightly/nightly-rustc/bootstrap/core/builder/struct.Builder.html#structfield.log_cli_step_for_tests) for showing "dry-run" test suites, but it's not available from the cli. For now, my whitelist is quite small and i have no idea what should it be like. 



r? @petrochenkov 

---

try-job: optional-x86_64-gnu-parallel-frontend
