### PR TITLE
Update `rustc-literal-escaper` version to `0.0.8`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3561,9 +3561,9 @@ checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc-literal-escaper"
-version = "0.0.7"
+version = "0.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be87abb9e40db7466e0681dc8ecd9dcfd40360cb10b4c8fe24a7c4c3669b198"
+checksum = "bfe6f213fb658c8fb95baabd5420393438cf5a98d707f5dd701d9197c705f71e"
 
 [[package]]
 name = "rustc-main"

--- a/compiler/rustc_ast/Cargo.toml
+++ b/compiler/rustc_ast/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2024"
 # tidy-alphabetical-start
 bitflags = "2.4.1"
 memchr = "2.7.6"
-rustc-literal-escaper = "0.0.7"
+rustc-literal-escaper = "0.0.8"
 rustc_ast_ir = { path = "../rustc_ast_ir" }
 rustc_data_structures = { path = "../rustc_data_structures" }
 rustc_index = { path = "../rustc_index" }

--- a/compiler/rustc_parse/Cargo.toml
+++ b/compiler/rustc_parse/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 [dependencies]
 # tidy-alphabetical-start
 bitflags = "2.4.1"
-rustc-literal-escaper = "0.0.7"
+rustc-literal-escaper = "0.0.8"
 rustc_ast = { path = "../rustc_ast" }
 rustc_ast_pretty = { path = "../rustc_ast_pretty" }
 rustc_data_structures = { path = "../rustc_data_structures" }

--- a/compiler/rustc_parse_format/Cargo.toml
+++ b/compiler/rustc_parse_format/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 
 [dependencies]
 # tidy-alphabetical-start
-rustc-literal-escaper = "0.0.7"
+rustc-literal-escaper = "0.0.8"
 rustc_lexer = { path = "../rustc_lexer" }
 # tidy-alphabetical-end
 

--- a/compiler/rustc_proc_macro/Cargo.toml
+++ b/compiler/rustc_proc_macro/Cargo.toml
@@ -16,7 +16,7 @@ doctest = false
 
 [dependencies]
 # tidy-alphabetical-start
-rustc-literal-escaper = "0.0.7"
+rustc-literal-escaper = "0.0.8"
 # tidy-alphabetical-end
 
 [features]

--- a/library/Cargo.lock
+++ b/library/Cargo.lock
@@ -283,9 +283,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-literal-escaper"
-version = "0.0.7"
+version = "0.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be87abb9e40db7466e0681dc8ecd9dcfd40360cb10b4c8fe24a7c4c3669b198"
+checksum = "bfe6f213fb658c8fb95baabd5420393438cf5a98d707f5dd701d9197c705f71e"
 dependencies = [
  "rustc-std-workspace-core",
 ]

--- a/library/proc_macro/Cargo.toml
+++ b/library/proc_macro/Cargo.toml
@@ -9,7 +9,7 @@ std = { path = "../std" }
 # `core` when resolving doc links. Without this line a different `core` will be
 # loaded from sysroot causing duplicate lang items and other similar errors.
 core = { path = "../core" }
-rustc-literal-escaper = { version = "0.0.7", features = ["rustc-dep-of-std"] }
+rustc-literal-escaper = { version = "0.0.8", features = ["rustc-dep-of-std"] }
 
 [features]
 default = ["rustc-dep-of-std"]

--- a/src/tools/clippy/clippy_dev/Cargo.toml
+++ b/src/tools/clippy/clippy_dev/Cargo.toml
@@ -10,7 +10,7 @@ clap = { version = "4.4", features = ["derive"] }
 indoc = "1.0"
 itertools = "0.12"
 opener = "0.8"
-rustc-literal-escaper = "0.0.7"
+rustc-literal-escaper = "0.0.8"
 walkdir = "2.3"
 
 [package.metadata.rust-analyzer]

--- a/src/tools/lint-docs/Cargo.toml
+++ b/src/tools/lint-docs/Cargo.toml
@@ -7,7 +7,7 @@ description = "A script to extract the lint documentation for the rustc book."
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rustc-literal-escaper = "0.0.7"
+rustc-literal-escaper = "0.0.8"
 serde_json = "1.0.57"
 tempfile = "3.1.0"
 walkdir = "2.3.1"


### PR DESCRIPTION
This new version contains a minor performance improvement. More detail in the PR: https://github.com/rust-lang/literal-escaper/pull/27

cc @hkBst
r? ghost