### PR TITLE
Remove unexpected usage of Unambig in non-infer variants

### DIFF
--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -499,7 +499,7 @@ impl<'hir, Unambig> ConstArg<'hir, Unambig> {
 #[derive(Clone, Copy, Debug, StableHash)]
 #[repr(u8, C)]
 pub enum ConstArgKind<'hir, Unambig = ()> {
-    Tup(&'hir [&'hir ConstArg<'hir, Unambig>]),
+    Tup(&'hir [&'hir ConstArg<'hir>]),
     /// **Note:** Currently this is only used for bare const params
     /// (`N` where `fn foo<const N: usize>(...)`),
     /// not paths to any const (`N` where `const N: usize = ...`).

--- a/compiler/rustc_hir/src/intravisit.rs
+++ b/compiler/rustc_hir/src/intravisit.rs
@@ -1088,7 +1088,7 @@ pub fn walk_const_arg<'v, V: Visitor<'v>>(
     try_visit!(visitor.visit_id(*hir_id));
     match kind {
         ConstArgKind::Tup(exprs) => {
-            walk_list!(visitor, visit_const_arg, *exprs);
+            walk_list!(visitor, visit_const_arg_unambig, *exprs);
             V::Result::output()
         }
         ConstArgKind::Struct(qpath, field_exprs) => {

--- a/tests/ui/const-generics/min_adt_const_params/tuple_with_infer_arg.rs
+++ b/tests/ui/const-generics/min_adt_const_params/tuple_with_infer_arg.rs
@@ -1,0 +1,10 @@
+//@ check-pass
+
+#![feature(min_adt_const_params)]
+#![feature(min_generic_const_args)]
+
+struct S<const X: (u32, u32)>;
+
+fn main() {
+    let _: S<{ (1, _) }> = S::<{ (1, 2) }>;
+}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/158289

The previous implementation incorrectly used `Unambig` in the variant `Tup`.