### PR TITLE
doc(unstable-book): fix typo "earier" -> "earlier" in default-visibility flag

### DIFF
--- a/src/doc/unstable-book/src/compiler-flags/default-visibility.md
+++ b/src/doc/unstable-book/src/compiler-flags/default-visibility.md
@@ -41,4 +41,4 @@ building for Linux. Other linkers such as LLD are not affected.
 Using `-Zdefault-visibility=interposable` will cause symbols to be emitted with "default"
 visibility. On platforms that support it, this makes it so that symbols can be interposed, which
 means that they can be overridden by symbols with the same name from the executable or by other
-shared objects earier in the load order.
+shared objects earlier in the load order.


### PR DESCRIPTION
## Summary

Fix a small typo (`earier` → `earlier`) in the unstable-book documentation for the `-Zdefault-visibility` flag.

This is detected by the project's typos configuration (`./x test tidy --extra-checks=spellcheck`) and would emit a CI warning on the next run.

## Diff

```diff
-using `-Zdefault-visibility=interposable` will cause symbols to be emitted with "default"
-visibility. On platforms that support it, this makes it so that symbols can be interposed, which
-means that they can be overridden by symbols with the same name from the executable or by other
-shared objects earier in the load order.
+using `-Zdefault-visibility=interposable` will cause symbols to be emitted with "default"
+visibility. On platforms that support it, this makes it so that symbols can be interposed, which
+means that they can be overridden by symbols with the same name from the executable or by other
+shared objects earlier in the load order.
```

## AI assistance

This patch was drafted with the help of an AI coding assistant, then reviewed line-by-line before submission. This is the only change in the diff.
