### PR TITLE
Fix incorrect unsafe debug assertion in unchecked_div_exact

### DIFF
--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -1181,7 +1181,7 @@ macro_rules! int_impl {
                 (
                     lhs: $SelfT = self,
                     rhs: $SelfT = rhs,
-                ) => rhs > 0 && lhs % rhs == 0 && (lhs != <$SelfT>::MIN || rhs != -1),
+                ) => rhs != 0 && lhs % rhs == 0 && (lhs != <$SelfT>::MIN || rhs != -1),
             );
             // SAFETY: Same precondition
             unsafe { intrinsics::exact_div(self, rhs) }


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

This PR fixes a bug in the `assert_unsafe_precondition!` check for the unstable `unchecked_div_exact` method in signed integers (`int_macros.rs`).

### What is the problem?
Currently, the precondition check for signed integers asserts that `rhs > 0`. This causes a panic in debug builds when performing a perfectly valid exact division with a negative divisor (e.g., `-10i32 / -2i32`). 

The following code snippet will panic in debug mode, but successfully build within release mode:

```rust
#![feature(exact_div)]

fn main() {
    let lhs: i32 = -10;
    let rhs: i32 = -2;
    unsafe {
        let result = lhs.unchecked_div_exact(rhs);
    }
}
```

Furthermore, this erroneous `rhs > 0` check renders the overflow prevention logic `(lhs != <$SelfT>::MIN || rhs != -1)` completely unreachable (dead code), since `rhs` could never be `-1` if it is strictly greater than `0`.

It appears that it should be `rhs != 0`.

### What does this PR do?
- Changes `rhs > 0` to `rhs != 0` in `library/core/src/num/int_macros.rs` to allow valid negative divisors.

Tracking issue: rust-lang/rust#139911