### PR TITLE
Make normalization in a test case resilient to dist compilation

### DIFF
--- a/tests/rustdoc-ui/ice-bug-report-url.rs
+++ b/tests/rustdoc-ui/ice-bug-report-url.rs
@@ -4,7 +4,7 @@
 
 //@ normalize-stderr: "note: compiler flags.*\n\n" -> ""
 //@ normalize-stderr: "note: rustc.*running on.*" -> "note: rustc {version} running on {platform}"
-//@ normalize-stderr: "thread.*panicked at compiler.*" -> ""
+//@ normalize-stderr: "thread 'rustc'.*panicked.*:\n.*\n" -> ""
 //@ normalize-stderr: " +\d{1,}: .*\n" -> ""
 //@ normalize-stderr: " + at .*\n" -> ""
 //@ normalize-stderr: ".*note: Some details are omitted.*\n" -> ""

--- a/tests/rustdoc-ui/ice-bug-report-url.stderr
+++ b/tests/rustdoc-ui/ice-bug-report-url.stderr
@@ -5,8 +5,6 @@ LL | fn wrong()
    |          ^ expected one of `->`, `where`, or `{`
 
 
-
-aborting due to `-Z treat-err-as-bug=1`
 stack backtrace:
 
 error: the compiler unexpectedly panicked. This is a bug


### PR DESCRIPTION
This fixes rust-lang/rust#158219 by adapting the `tests/rustdoc-ui/ice-bug-report-url` test case such that it will no longer fail with the remapping prefixes from rust-lang/rust#150110

This was previously sometimes the first test failure if someone tried `x.py test` on a compiler checkout configured with `dist` setup, prominently featuring the new (mismatching) test `stdout` containing the scary ICE error message.

---

The new normalization regex is taken from many existing test cases,
see: [↝ this code search ⮺](https://github.com/search?q=repo%3Arust-lang%2Frust+%2Fthread+%27rustc%27%5C.%5C*panicked%2F&type=code)

which includes files such as [`tests/ui/treat-err-as-bug/span_delayed_bug.rs`](https://github.com/rust-lang/rust/blob/4429659e4745016bd3f26a4a421843edc7fbc422/tests/ui/treat-err-as-bug/span_delayed_bug.rs#L4) or [`tests/ui/treat-err-as-bug/err.rs`](https://github.com/rust-lang/rust/blob/4429659e4745016bd3f26a4a421843edc7fbc422/tests/ui/treat-err-as-bug/err.rs#L4).

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
