### PR TITLE
Add `io::ErrorKind::TooManyOpenFiles`

### DIFF
--- a/library/core/src/io/error.rs
+++ b/library/core/src/io/error.rs
@@ -238,6 +238,11 @@ pub enum ErrorKind {
     #[unstable(feature = "io_error_inprogress", issue = "130840")]
     InProgress,
 
+    /// The process or the whole system has reached its limit on the number of
+    /// open files or sockets.
+    #[unstable(feature = "io_error_too_many_open_files", issue = "158319")]
+    TooManyOpenFiles,
+
     // "Unusual" error kinds which do not correspond simply to (sets
     // of) OS error codes, should be added just above this comment.
     // `Other` and `Uncategorized` should remain at the end:
@@ -309,6 +314,7 @@ impl ErrorKind {
             StorageFull => "no storage space",
             TimedOut => "timed out",
             TooManyLinks => "too many links",
+            TooManyOpenFiles => "too many open files",
             Uncategorized => "uncategorized error",
             UnexpectedEof => "unexpected end of file",
             Unsupported => "unsupported",
@@ -379,6 +385,7 @@ impl ErrorKind {
             Unsupported,
             OutOfMemory,
             InProgress,
+            TooManyOpenFiles,
             Uncategorized,
         })
     }

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -355,6 +355,7 @@
 #![feature(int_from_ascii)]
 #![feature(io_error_inprogress)]
 #![feature(io_error_more)]
+#![feature(io_error_too_many_open_files)]
 #![feature(io_error_uncategorized)]
 #![feature(io_slice_as_bytes)]
 #![feature(ip)]

--- a/library/std/src/sys/fs/vexos.rs
+++ b/library/std/src/sys/fs/vexos.rs
@@ -612,7 +612,7 @@ fn map_fresult(fresult: vex_sdk::FRESULT) -> io::Result<()> {
             Err(io::const_error!(io::ErrorKind::OutOfMemory, "not enough memory for the operation"))
         }
         vex_sdk::FRESULT::FR_TOO_MANY_OPEN_FILES => Err(io::const_error!(
-            io::ErrorKind::Uncategorized,
+            io::ErrorKind::TooManyOpenFiles,
             "maximum number of open files has been reached",
         )),
         vex_sdk::FRESULT::FR_INVALID_PARAMETER => {

--- a/library/std/src/sys/io/error/unix.rs
+++ b/library/std/src/sys/io/error/unix.rs
@@ -137,6 +137,7 @@ pub fn decode_error_kind(errno: i32) -> io::ErrorKind {
         libc::ETXTBSY => ExecutableFileBusy,
         libc::EXDEV => CrossesDevices,
         libc::EINPROGRESS => InProgress,
+        libc::EMFILE | libc::ENFILE => TooManyOpenFiles,
         libc::EOPNOTSUPP => Unsupported,
 
         libc::EACCES | libc::EPERM => PermissionDenied,

--- a/library/std/src/sys/io/error/wasi.rs
+++ b/library/std/src/sys/io/error/wasi.rs
@@ -59,6 +59,7 @@ pub fn decode_error_kind(errno: i32) -> std_io::ErrorKind {
         libc::ETXTBSY => ExecutableFileBusy,
         libc::EXDEV => CrossesDevices,
         libc::EINPROGRESS => InProgress,
+        libc::EMFILE | libc::ENFILE => TooManyOpenFiles,
         libc::EOPNOTSUPP => Unsupported,
         libc::EACCES | libc::EPERM => PermissionDenied,
         libc::EWOULDBLOCK => WouldBlock,

--- a/library/std/src/sys/io/error/windows.rs
+++ b/library/std/src/sys/io/error/windows.rs
@@ -61,6 +61,7 @@ pub fn decode_error_kind(errno: i32) -> io::ErrorKind {
         c::ERROR_POSSIBLE_DEADLOCK => return Deadlock,
         c::ERROR_NOT_SAME_DEVICE => return CrossesDevices,
         c::ERROR_TOO_MANY_LINKS => return TooManyLinks,
+        c::ERROR_TOO_MANY_OPEN_FILES => return TooManyOpenFiles,
         c::ERROR_FILENAME_EXCED_RANGE => return InvalidFilename,
         c::ERROR_CANT_RESOLVE_FILENAME => return FilesystemLoop,
         _ => {}
@@ -81,6 +82,7 @@ pub fn decode_error_kind(errno: i32) -> io::ErrorKind {
         c::WSAENETDOWN => NetworkDown,
         c::WSAENETUNREACH => NetworkUnreachable,
         c::WSAEDQUOT => QuotaExceeded,
+        c::WSAEMFILE => TooManyOpenFiles,
         // Not a perfect mapping but this error is only returned when writing to
         // a socket after shutting down the write-end. On Unix targets, EPIPE is
         // returned in those cases.


### PR DESCRIPTION
Adds an unstable `io::ErrorKind::TooManyOpenFiles` for the open-file-limit condition.

`EMFILE` and `ENFILE` currently decode to `ErrorKind::Uncategorized`, so stable code cannot tell that an operation failed because the process or the system ran out of file descriptors without inspecting `raw_os_error()` and a platform-specific `libc`/`windows-sys` constant.

Implements the accepted ACP rust-lang/libs-team#818, including its decision to collapse `EMFILE` and `ENFILE` into a single variant. Finer-grained handling stays available through `raw_os_error()`.

The variant maps:
- `EMFILE` / `ENFILE` on Unix and WASI
- `ERROR_TOO_MANY_OPEN_FILES` / `WSAEMFILE` on Windows
- `FR_TOO_MANY_OPEN_FILES` on VEXos

Tracking issue: rust-lang/rust#158319

r? libs

