### PR TITLE
rustdoc: Show use-site paths for unevaluated const array lengths

### DIFF
--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -350,28 +350,21 @@ pub(crate) fn name_from_pat(p: &hir::Pat<'_>) -> Symbol {
 
 pub(crate) fn print_const(tcx: TyCtxt<'_>, n: ty::Const<'_>) -> String {
     match n.kind() {
-        ty::ConstKind::Alias(_, ty::AliasConst { kind, .. }) => match kind {
-            ty::AliasConstKind::Projection { def_id } => {
-                if let Some(local_def_id) = def_id.as_local()
-                    && let Some(body_id) = tcx.hir_maybe_body_owned_by(local_def_id)
-                {
-                    rendered_const(tcx, body_id, local_def_id)
-                } else {
-                    n.to_string()
-                }
+        ty::ConstKind::Alias(_, ty::AliasConst { kind, .. }) => {
+            let def_id: DefId = match kind {
+                ty::AliasConstKind::Projection { def_id } => def_id.into(),
+                ty::AliasConstKind::Inherent { def_id } => def_id.into(),
+                ty::AliasConstKind::Free { def_id } => def_id.into(),
+                ty::AliasConstKind::Anon { def_id } => def_id.into(),
+            };
+            if let Some(local_def_id) = def_id.as_local()
+                && let Some(body_id) = tcx.hir_maybe_body_owned_by(local_def_id)
+            {
+                rendered_const(tcx, body_id, local_def_id)
+            } else {
+                n.to_string()
             }
-            ty::AliasConstKind::Inherent { def_id }
-            | ty::AliasConstKind::Free { def_id }
-            | ty::AliasConstKind::Anon { def_id } => {
-                if let Some(local_def_id) = def_id.as_local()
-                    && let Some(body_id) = tcx.hir_maybe_body_owned_by(local_def_id)
-                {
-                    rendered_const(tcx, body_id, local_def_id)
-                } else {
-                    inline::print_inlined_const(tcx, def_id)
-                }
-            }
-        },
+        }
         // array lengths are obviously usize
         ty::ConstKind::Value(cv) if *cv.ty.kind() == ty::Uint(ty::UintTy::Usize) => {
             cv.to_leaf().to_string()

--- a/tests/rustdoc-html/type-const-free-in-array.rs
+++ b/tests/rustdoc-html/type-const-free-in-array.rs
@@ -1,0 +1,11 @@
+#![crate_name = "foo"]
+#![feature(min_generic_const_args)]
+#![expect(incomplete_features)]
+
+type const N: usize = 2;
+
+//@ has 'foo/trait.CollectArray.html'
+//@ has - '//pre[@class="rust item-decl"]/code' '[A; N]'
+pub trait CollectArray<A> {
+    fn inner_array(&mut self) -> [A; N];
+}

--- a/tests/rustdoc-html/type-const-inherent-with-body.rs
+++ b/tests/rustdoc-html/type-const-inherent-with-body.rs
@@ -1,0 +1,15 @@
+#![crate_name = "foo"]
+#![feature(min_generic_const_args, inherent_associated_types)]
+#![expect(incomplete_features)]
+
+pub struct Foo;
+
+impl Foo {
+    type const LEN: usize = 4;
+}
+
+//@ has 'foo/fn.mk_array.html'
+//@ has - '//pre[@class="rust item-decl"]/code' '[u8; Foo::LEN]'
+pub fn mk_array() -> [u8; Foo::LEN] {
+    [0u8; Foo::LEN]
+}


### PR DESCRIPTION
After rust-lang/rust#158171, I noticed a few additional issues with the rendering of consts in rustdoc. This PR fixes them. When rendering array lengths, avoid inlining the full definition of unevaluated constants via `print_inlined_const`. Instead, fall back to `Const::to_string()` for use-site rendering, matching the behavior already used for projections without bodies.

r? camelid