### PR TITLE
Stop excluding `stdarch` test crates from `rust-src`

### DIFF
--- a/src/bootstrap/src/core/build_steps/dist.rs
+++ b/src/bootstrap/src/core/build_steps/dist.rs
@@ -1201,11 +1201,6 @@ impl Step for Src {
                 // not needed and contains symlinks which rustup currently
                 // chokes on when unpacking.
                 "library/backtrace/crates",
-                // these are 30MB combined and aren't necessary for building
-                // the standard library.
-                "library/stdarch/Cargo.toml",
-                "library/stdarch/crates/stdarch-verify",
-                "library/stdarch/crates/intrinsic-test",
             ],
             &dst_src,
         );


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

In the past, this exclusion saved 30MB of heavy intrinsics data from ending up in `rust-src`. However, this filter has been outdated since https://github.com/rust-lang/stdarch/pull/1894, which moved the data to `library/stdarch/intrinsics_data`. These intrinsics have also shrunk since then, and now sit around 12MB (300KB when compressed).

So this specific change only adds a few KBs:

| `rust-src` | compressed | unpacked |
| ---------- | ---------- | -------- |
| before     | 8.01 MB    | 76.5 MB  |
| after      | 8.06 MB    | 76.9 MB  |

The motivation for this change would be simplifying integration of the `stdarch` test suite into `cg_clif`. 

For completeness, if we instead fixed the filter to point to the new data location, we'd shrink the dist to:

| `rust-src` | compressed | unpacked |
| ---------- | ---------- | -------- |
| filtered   | 7.64 MB    | 64.7 MB  |

cc @bjorn3
