### PR TITLE
Use `transmute_neo` in `assume_init`

### DIFF
--- a/library/core/src/mem/maybe_uninit.rs
+++ b/library/core/src/mem/maybe_uninit.rs
@@ -1,7 +1,7 @@
 use crate::any::type_name;
 use crate::clone::TrivialClone;
 use crate::marker::Destruct;
-use crate::mem::ManuallyDrop;
+use crate::mem::{ManuallyDrop, transmute_neo};
 use crate::{fmt, intrinsics, ptr, slice};
 
 /// A wrapper type to construct uninitialized instances of `T`.
@@ -724,9 +724,9 @@ impl<T> MaybeUninit<T> {
         // This also means that `self` must be a `value` variant.
         unsafe {
             intrinsics::assert_inhabited::<T>();
-            // We do this via a raw ptr read instead of `ManuallyDrop::into_inner` so that there's
+            // We do this via a transmute instead of `ManuallyDrop::into_inner` so that there's
             // no trace of `ManuallyDrop` in Miri's error messages here.
-            (&raw const self.value).cast::<T>().read()
+            transmute_neo(self)
         }
     }
 

--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -1196,6 +1196,9 @@ pub const unsafe fn transmute_prefix<Src, Dst>(src: Src) -> Dst {
 /// New version of `transmute`, exposed under this name so it can be iterated upon
 /// without risking breakage to uses of "real" transmute.
 ///
+/// Uses a `const`-`assert` to check the sizes instead of typeck hacks,
+/// but is semantially identical to `transmute` otherwise.
+///
 /// It will not be stabilized under this name.
 ///
 /// # Examples
@@ -1214,6 +1217,8 @@ pub const unsafe fn transmute_prefix<Src, Dst>(src: Src) -> Dst {
 /// unsafe { transmute_neo::<u32, u16>(123) };
 /// ```
 #[unstable(feature = "transmute_neo", issue = "155079")]
+#[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
+#[inline]
 pub const unsafe fn transmute_neo<Src, Dst>(src: Src) -> Dst {
     const { assert!(Src::SIZE == Dst::SIZE) };
 


### PR DESCRIPTION
I noticed this basically open-coding a transmute via `read`, but now that we have a transmute that doesn't fail there on the typeck size check I figured that we might as well use it here.  The Miri errors are preserved (at least locally, but CI will double-check) so hopefully this is ok.

r? @RalfJung as the author of https://github.com/rust-lang/rust/pull/143327

Context is that I saw the raw-ref-cast-and-read in https://github.com/rust-lang/rust/pull/158341/changes#diff-ee00b0dbbebae9c10bf879a79377c87a7a68208a7e213d6ca792a6ef5f216855R87-R90 and thought it could be simpler 🙂 