### PR TITLE
Prevent rustdoc auto-trait ICEs with `-Znext-solver=globally`

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/auto_trait.rs
+++ b/compiler/rustc_trait_selection/src/traits/auto_trait.rs
@@ -33,6 +33,7 @@ pub struct RegionDeps<'tcx> {
 }
 
 pub enum AutoTraitResult<A> {
+    NoImpl,
     ExplicitImpl,
     PositiveImpl(A),
     NegativeImpl,
@@ -79,6 +80,15 @@ impl<'tcx> AutoTraitFinder<'tcx> {
         mut auto_trait_callback: impl FnMut(AutoTraitInfo<'tcx>) -> A,
     ) -> AutoTraitResult<A> {
         let tcx = self.tcx;
+
+        if tcx.next_trait_solver_globally() {
+            return self.find_auto_trait_generics_next_solver(
+                ty,
+                typing_env,
+                trait_did,
+                auto_trait_callback,
+            );
+        }
 
         let trait_ref = ty::TraitRef::new(tcx, trait_did, [ty]);
 
@@ -172,6 +182,79 @@ impl<'tcx> AutoTraitFinder<'tcx> {
 
         let info = AutoTraitInfo { full_user_env, region_data, vid_to_region };
 
+        AutoTraitResult::PositiveImpl(auto_trait_callback(info))
+    }
+
+    fn find_auto_trait_generics_next_solver<A>(
+        &self,
+        ty: Ty<'tcx>,
+        typing_env: ty::TypingEnv<'tcx>,
+        trait_did: DefId,
+        mut auto_trait_callback: impl FnMut(AutoTraitInfo<'tcx>) -> A,
+    ) -> AutoTraitResult<A> {
+        // When the new solver is enabled globally we keep things deliberately
+        // simple. The precise auto-trait synthesis depends on old-solver
+        // internals, so here we only synthesize a simple field-based auto-trait
+        // impl for ADTs.
+        //
+        // If the self type is not an ADT we return `NoImpl` instead of trying
+        // to do anything fancy. To decide whether to emit a negative impl, we
+        // replace the ADT's generic arguments with inference variables and
+        // check whether the auto trait can hold. A true error from that probe
+        // becomes a `NegativeImpl`, otherwise we continue on to emit the
+        // imprecise field-based impl.
+        //
+        // This keeps rustdoc from ICE-ing while `-Znext-solver=globally` is
+        // used for testing, even if the generated synthetic impls are less
+        // precise.
+        let tcx = self.tcx;
+        let ty::Adt(adt_def, args) = *ty.kind() else {
+            return AutoTraitResult::NoImpl;
+        };
+
+        let mut disqualifying_impl = None;
+        tcx.for_each_relevant_impl(trait_did, ty, |impl_def_id| {
+            disqualifying_impl = Some(impl_def_id);
+        });
+        if let Some(impl_def_id) = disqualifying_impl {
+            debug!(
+                "find_auto_trait_generics({:?}): possible manual impl {impl_def_id:?} found, bailing",
+                ty::TraitRef::new(tcx, trait_did, [ty]),
+            );
+            return AutoTraitResult::ExplicitImpl;
+        }
+
+        let (infcx, orig_env) = tcx.infer_ctxt().build_with_typing_env(typing_env);
+        let field_clauses = adt_def
+            .all_fields()
+            .map(|field| field.ty(tcx, args).skip_norm_wip())
+            .filter(|field_ty| field_ty.has_non_region_param())
+            .map(|field_ty| {
+                ty::TraitPredicate {
+                    trait_ref: ty::TraitRef::new(tcx, trait_did, [field_ty]),
+                    polarity: ty::PredicatePolarity::Positive,
+                }
+                .upcast(tcx)
+            })
+            .collect::<Vec<ty::Clause<'tcx>>>();
+        let full_user_env = ty::ParamEnv::new(
+            tcx.mk_clauses_from_iter(orig_env.caller_bounds().iter().chain(field_clauses)),
+        );
+
+        let fresh_args = infcx.fresh_args_for_item(DUMMY_SP, adt_def.did());
+        let fresh_ty = ty::EarlyBinder::bind(tcx, ty).instantiate(tcx, fresh_args).skip_norm_wip();
+        let ocx = ObligationCtxt::new(&infcx);
+        ocx.register_bound(ObligationCause::dummy(), orig_env, fresh_ty, trait_did);
+        let errors = ocx.try_evaluate_obligations();
+        if !errors.is_empty() {
+            return AutoTraitResult::NegativeImpl;
+        }
+
+        let info = AutoTraitInfo {
+            full_user_env,
+            region_data: RegionConstraintData::default(),
+            vid_to_region: FxIndexMap::default(),
+        };
         AutoTraitResult::PositiveImpl(auto_trait_callback(info))
     }
 

--- a/src/librustdoc/clean/auto_trait.rs
+++ b/src/librustdoc/clean/auto_trait.rs
@@ -110,6 +110,7 @@ fn synthesize_auto_trait_impl<'tcx>(
 
             (generics, ty::ImplPolarity::Negative)
         }
+        auto_trait::AutoTraitResult::NoImpl => return None,
         auto_trait::AutoTraitResult::ExplicitImpl => return None,
     };
 

--- a/tests/rustdoc-html/synthetic_auto/next-solver-ambiguity.rs
+++ b/tests/rustdoc-html/synthetic_auto/next-solver-ambiguity.rs
@@ -1,0 +1,7 @@
+//@ compile-flags: -Znext-solver=globally
+//@ edition: 2021
+#![crate_name = "foo"]
+
+//@ has 'foo/struct.Foo.html'
+//@ has - '//h3[@class="code-header"]' "impl<'a, 'b, T> Send for Foo<'a, 'b, T>where &'a T: Send, &'b T: Send"
+pub struct Foo<'a, 'b, T: 'a + 'b>(&'a T, &'b T);

--- a/tests/rustdoc-html/synthetic_auto/next-solver-possible-impl.rs
+++ b/tests/rustdoc-html/synthetic_auto/next-solver-possible-impl.rs
@@ -1,0 +1,12 @@
+//@ compile-flags: -Znext-solver=globally
+
+#![feature(auto_traits)]
+#![crate_name = "foo"]
+
+pub auto trait Marker {}
+
+//@ has 'foo/struct.MyType.html'
+//@ !has - '//*[@id="synthetic-implementations-list"]//*[@class="impl"]' 'Marker for MyType<T>'
+pub struct MyType<T>(T);
+
+impl Marker for MyType<u32> {}

--- a/tests/rustdoc-ui/synthetic-auto-trait-impls/next-solver-globally.rs
+++ b/tests/rustdoc-ui/synthetic-auto-trait-impls/next-solver-globally.rs
@@ -1,0 +1,16 @@
+// We used to ICE here while trying to synthesize auto trait impls
+// with the next trait solver enabled globally.
+//@ check-pass
+//@ compile-flags: -Znext-solver=globally
+
+#![feature(const_default)]
+#![feature(const_trait_impl)]
+
+pub struct Inner<T>(T);
+
+pub struct Outer<T>(Inner<T>);
+
+impl<T> Unpin for Inner<T>
+where
+    T: const std::default::Default,
+{}


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
- Ensure rustdoc with `-Znext-solver=globally` does not ICE.

r? @lcnr 