### PR TITLE
Fix invalid E0609 raw pointer deref suggestion inside macros

### DIFF
--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -3159,6 +3159,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
     fn suggest_first_deref_field(&self, err: &mut Diag<'_>, base: &hir::Expr<'_>, field: Ident) {
         err.span_label(field.span, "unknown field");
+        if base.span.from_expansion() || field.span.from_expansion() {
+            return;
+        }
         let val = if let Ok(base) = self.tcx.sess.source_map().span_to_snippet(base.span)
             && base.len() < 20
         {

--- a/tests/ui/macros/deref-raw-pointer-issue-158158.rs
+++ b/tests/ui/macros/deref-raw-pointer-issue-158158.rs
@@ -1,0 +1,21 @@
+struct Demo {
+    val: u32,
+}
+
+macro_rules! as_ptr {
+    ($d:expr) => {
+        &mut $d as *mut Demo
+    };
+}
+
+macro_rules! get_value {
+    ($d:expr) => {
+        as_ptr!($d).val
+        //~^ ERROR no field `val` on type `*mut Demo`
+    }
+}
+
+fn main() {
+    let mut d = Demo { val: 123 };
+    let _ = get_value!(d);
+}

--- a/tests/ui/macros/deref-raw-pointer-issue-158158.stderr
+++ b/tests/ui/macros/deref-raw-pointer-issue-158158.stderr
@@ -8,11 +8,6 @@ LL |     let _ = get_value!(d);
    |             ------------- in this macro invocation
    |
    = note: this error originates in the macro `get_value` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: `$d as *mut Demo` is a raw pointer; try dereferencing it
-   |
-LL -         &mut $d as *mut Demo
-LL +         &mut (*).
-   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/macros/deref-raw-pointer-issue-158158.stderr
+++ b/tests/ui/macros/deref-raw-pointer-issue-158158.stderr
@@ -1,0 +1,19 @@
+error[E0609]: no field `val` on type `*mut Demo`
+  --> $DIR/deref-raw-pointer-issue-158158.rs:13:21
+   |
+LL |         as_ptr!($d).val
+   |                     ^^^ unknown field
+...
+LL |     let _ = get_value!(d);
+   |             ------------- in this macro invocation
+   |
+   = note: this error originates in the macro `get_value` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: `$d as *mut Demo` is a raw pointer; try dereferencing it
+   |
+LL -         &mut $d as *mut Demo
+LL +         &mut (*).
+   |
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0609`.


### PR DESCRIPTION
Fixes rust-lang/rust#158158

`suggest_first_deref_field` blindly applied span math (`shrink_to_lo()`, `between()`) to generate a dereference suggestion for E0609. When the base expression and field access originate from different macro expansions, the `SyntaxContext` mismatch caused the span combinations to fail. This resulted in the compiler falling back to incorrect source locations and generating malformed replacement strings like `&mut (*).`.

* Added a `span.from_expansion()` guard at the top of `suggest_first_deref_field` to check both `base.span` and `field.span`.
* Suppressed the multipart suggestion entirely when inside macro expansions to prevent emitting broken syntax, bypassing complex and unreliable cross-macro span traversals.
* Added a new UI test to ensure the standard E0609 error is emitted cleanly without the garbled `help:` label.