### PR TITLE
trait solver: account for universes from replace_bound_vars

### DIFF
--- a/compiler/rustc_next_trait_solver/src/canonical/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/canonical/mod.rs
@@ -160,13 +160,7 @@ where
     let prev_universe = delegate.universe();
     let universes_created_in_query = response.max_universe.index();
     for _ in 0..universes_created_in_query {
-        let new_universe = delegate.create_next_universe();
-        if delegate.cx().assumptions_on_binders() {
-            delegate.insert_placeholder_assumptions(
-                new_universe,
-                Some(rustc_type_ir::region_constraint::Assumptions::empty()),
-            );
-        }
+        delegate.create_next_universe();
     }
 
     let var_values = response.value.var_values();

--- a/compiler/rustc_next_trait_solver/src/canonical/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/canonical/mod.rs
@@ -160,7 +160,13 @@ where
     let prev_universe = delegate.universe();
     let universes_created_in_query = response.max_universe.index();
     for _ in 0..universes_created_in_query {
-        delegate.create_next_universe();
+        let new_universe = delegate.create_next_universe();
+        if delegate.cx().assumptions_on_binders() {
+            delegate.insert_placeholder_assumptions(
+                new_universe,
+                Some(rustc_type_ir::region_constraint::Assumptions::empty()),
+            );
+        }
     }
 
     let var_values = response.value.var_values();

--- a/compiler/rustc_next_trait_solver/src/placeholder.rs
+++ b/compiler/rustc_next_trait_solver/src/placeholder.rs
@@ -47,6 +47,7 @@ where
         IndexMap<ty::PlaceholderType<I>, ty::BoundTy<I>>,
         IndexMap<ty::PlaceholderConst<I>, ty::BoundConst<I>>,
     ) {
+        let old_universes = universe_indices.clone();
         let mut replacer = BoundVarReplacer {
             infcx,
             mapped_regions: Default::default(),
@@ -57,8 +58,29 @@ where
         };
 
         let value = value.fold_with(&mut replacer);
+        let BoundVarReplacer {
+            mapped_regions,
+            mapped_types,
+            mapped_consts,
+            universe_indices,
+            infcx: _,
+            current_index: _,
+        } = replacer;
 
-        (value, replacer.mapped_regions, replacer.mapped_types, replacer.mapped_consts)
+        if infcx.cx().assumptions_on_binders() {
+            for (old, new) in old_universes.into_iter().zip(universe_indices.iter()) {
+                if let (None, Some(new)) = (old, new) {
+                    // FIXME(-Zassumptions-on-binders): `replace_bound_vars` does not have enough
+                    // context to compute placeholder assumptions for the binders it enters.
+                    infcx.insert_placeholder_assumptions(
+                        *new,
+                        Some(rustc_type_ir::region_constraint::Assumptions::empty()),
+                    );
+                }
+            }
+        }
+
+        (value, mapped_regions, mapped_types, mapped_consts)
     }
 
     fn universe_for(&mut self, debruijn: ty::DebruijnIndex) -> ty::UniverseIndex {

--- a/tests/ui/assumptions_on_binders/placeholder-assumptions-issue-157840.rs
+++ b/tests/ui/assumptions_on_binders/placeholder-assumptions-issue-157840.rs
@@ -1,0 +1,17 @@
+//@ compile-flags: -Znext-solver=globally -Zassumptions-on-binders
+
+trait Trait<T> {}
+
+trait Proj<'a> {
+    type Assoc;
+}
+
+fn foo<'a, T>()
+where
+    T: Proj<'a, Assoc = fn(<T as Proj>::Assoc)>,
+    (): Trait<<T as Proj<'a>>::Assoc>,
+    //~^ ERROR the trait bound `(): Trait<fn(for<'a> fn(<T as Proj<'a>>::Assoc))>` is not satisfied
+{
+}
+
+fn main() {}

--- a/tests/ui/assumptions_on_binders/placeholder-assumptions-issue-157840.stderr
+++ b/tests/ui/assumptions_on_binders/placeholder-assumptions-issue-157840.stderr
@@ -1,0 +1,14 @@
+error[E0277]: the trait bound `(): Trait<fn(for<'a> fn(<T as Proj<'a>>::Assoc))>` is not satisfied
+  --> $DIR/placeholder-assumptions-issue-157840.rs:12:9
+   |
+LL |     (): Trait<<T as Proj<'a>>::Assoc>,
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Trait<fn(for<'a> fn(<T as Proj<'a>>::Assoc))>` is not implemented for `()`
+   |
+help: consider extending the `where` clause, but there might be an alternative better way to express this requirement
+   |
+LL |     (): Trait<<T as Proj<'a>>::Assoc>, (): Trait<fn(for<'a> fn(<T as Proj<'a>>::Assoc))>
+   |                                        +++++++++++++++++++++++++++++++++++++++++++++++++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/158362)*
<!-- homu-ignore:end -->

Fixes rust-lang/rust#157840.

The ICE was not really because eager placeholder handling looked at too many universes. Boxy was right: with `-Zassumptions-on-binders`, if the new solver creates a placeholder universe, that universe needs an assumptions entry.

The bad path is `FindParamInClause` entering a binder through `replace_bound_vars`. `BoundVarReplacer` materializes a placeholder universe for the escaping bound vars, but nothing records placeholder assumptions for it. Later eager placeholder handling walks all non-input universes, which imo is the right behavior, and `get_placeholder_assumptions` hits the missing entry.

This moves the empty-assumptions bookkeeping into `EvalCtxt::replace_bound_vars` instead of keeping it local to `FindParamInClause`. The helper snapshots the universe slots before replacement and inserts `Assumptions::empty()` for any slot that got filled.

There is still a FIXME there because idk that empty assumptions is the final shape irl. `replace_bound_vars` does not have the param-env context to compute proper assumptions. But for this PR, imo this is the least weird local fix: it keeps the eager pass looking at all non-input universes and fixes the missing bookkeeping where the universe is created.

The repro is covered by a UI test. It reports the overflow diagnostic instead of ICEing.
