### PR TITLE
std: make `Instant` a signed `Duration` on all platforms

### DIFF
--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -386,6 +386,7 @@
 #![feature(ub_checks)]
 #![feature(uint_carryless_mul)]
 #![feature(used_with_arg)]
+#![feature(widening_mul)]
 // tidy-alphabetical-end
 //
 // Library features (alloc):

--- a/library/std/src/sys/helpers/mod.rs
+++ b/library/std/src/sys/helpers/mod.rs
@@ -16,19 +16,6 @@ pub use small_c_string::{run_path_with_cstr, run_with_cstr};
 #[cfg_attr(not(target_os = "windows"), allow(unused))] // Not used on all platforms.
 pub use wstr::WStrUnits;
 
-/// Computes `(value*numerator)/denom` without overflow, as long as both
-/// `numerator*denom` and the overall result fit into `u64` (which is the case
-/// for our time conversions).
-#[cfg_attr(not(target_os = "windows"), allow(unused))] // Not used on all platforms.
-pub fn mul_div_u64(value: u64, numerator: u64, denom: u64) -> u64 {
-    let q = value / denom;
-    let r = value % denom;
-    // Decompose value as (value/denom*denom + value%denom),
-    // substitute into (value*numerator)/denom and simplify.
-    // r < denom, so (denom*numerator) is the upper bound of (r*numerator)
-    q * numerator + r * numerator / denom
-}
-
 #[cfg_attr(not(target_os = "linux"), allow(unused))] // Not used on all platforms.
 pub fn ignore_notfound<T>(result: crate::io::Result<T>) -> crate::io::Result<()> {
     match result {

--- a/library/std/src/sys/helpers/tests.rs
+++ b/library/std/src/sys/helpers/tests.rs
@@ -1,6 +1,5 @@
 use core::iter::repeat;
 
-use super::mul_div_u64;
 use super::small_c_string::run_path_with_cstr;
 use crate::ffi::CString;
 use crate::hint::black_box;
@@ -65,9 +64,4 @@ fn bench_heap_path_alloc(b: &mut test::Bencher) {
         })
         .unwrap();
     });
-}
-
-#[test]
-fn test_muldiv() {
-    assert_eq!(mul_div_u64(1_000_000_000_001, 1_000_000_000, 1_000_000), 1_000_000_000_001_000);
 }

--- a/library/std/src/sys/pal/sgx/abi/usercalls/mod.rs
+++ b/library/std/src/sys/pal/sgx/abi/usercalls/mod.rs
@@ -266,9 +266,8 @@ pub fn send(event_set: u64, tcs: Option<Tcs>) -> io::Result<()> {
 
 /// Usercall `insecure_time`. See the ABI documentation for more information.
 #[unstable(feature = "sgx_platform", issue = "56975")]
-pub fn insecure_time() -> Duration {
-    let t = unsafe { raw::insecure_time().0 };
-    Duration::new(t / 1_000_000_000, (t % 1_000_000_000) as _)
+pub fn insecure_time() -> u64 {
+    unsafe { raw::insecure_time().0 }
 }
 
 /// Usercall `alloc`. See the ABI documentation for more information.

--- a/library/std/src/sys/thread/unix.rs
+++ b/library/std/src/sys/thread/unix.rs
@@ -552,7 +552,7 @@ pub fn sleep(dur: Duration) {
             // of `nanosleep` which used `CLOCK_REALTIME` even though it is unsupported
             // on WASIp2. Using `clock_nanosleep` directly bypasses the issue.
             unsafe fn nanosleep(rqtp: *const libc::timespec, rmtp: *mut libc::timespec) -> libc::c_int {
-                unsafe { libc::clock_nanosleep(crate::sys::time::Instant::CLOCK_ID, 0, rqtp, rmtp) }
+                unsafe { libc::clock_nanosleep(crate::sys::time::CLOCK_ID, 0, rqtp, rmtp) }
             }
         }
         _ => {
@@ -636,7 +636,10 @@ pub fn sleep(dur: Duration) {
     target_os = "wasi",
 ))]
 pub fn sleep_until(deadline: crate::time::Instant) {
+    use crate::sys::pal::time::Timespec;
     use crate::time::Instant;
+
+    let ts = Timespec { tv_sec: deadline.secs, tv_nsec: deadline.nanos };
 
     #[cfg(all(
         target_os = "linux",
@@ -660,11 +663,11 @@ pub fn sleep_until(deadline: crate::time::Instant) {
         }
 
         if let Some(clock_nanosleep) = __clock_nanosleep_time64.get() {
-            let ts = deadline.into_inner().into_timespec().to_timespec64();
+            let ts = ts.to_timespec64();
             loop {
                 let r = unsafe {
                     clock_nanosleep(
-                        crate::sys::time::Instant::CLOCK_ID,
+                        crate::sys::time::CLOCK_ID,
                         libc::TIMER_ABSTIME,
                         &ts,
                         core::ptr::null_mut(),
@@ -688,7 +691,7 @@ pub fn sleep_until(deadline: crate::time::Instant) {
         }
     }
 
-    let Some(ts) = deadline.into_inner().into_timespec().to_timespec() else {
+    let Some(ts) = ts.to_timespec() else {
         // The deadline is further in the future then can be passed to
         // clock_nanosleep. We have to use Self::sleep instead. This might
         // happen on 32 bit platforms, especially closer to 2038.
@@ -703,7 +706,7 @@ pub fn sleep_until(deadline: crate::time::Instant) {
         // When we get interrupted (res = EINTR) call clock_nanosleep again
         loop {
             let res = libc::clock_nanosleep(
-                crate::sys::time::Instant::CLOCK_ID,
+                crate::sys::time::CLOCK_ID,
                 libc::TIMER_ABSTIME,
                 &ts,
                 core::ptr::null_mut(), // not required with TIMER_ABSTIME
@@ -725,6 +728,12 @@ pub fn sleep_until(deadline: crate::time::Instant) {
 
 #[cfg(target_vendor = "apple")]
 pub fn sleep_until(deadline: crate::time::Instant) {
+    #[repr(C)]
+    struct mach_timebase_info {
+        numer: u32,
+        denom: u32,
+    }
+
     unsafe extern "C" {
         // This is defined in the public header mach/mach_time.h alongside
         // `mach_absolute_time`, and like it has been available since the very
@@ -734,15 +743,28 @@ pub fn sleep_until(deadline: crate::time::Instant) {
         // short reference in technical note 2169:
         // https://developer.apple.com/library/archive/technotes/tn2169/_index.html
         safe fn mach_wait_until(deadline: u64) -> libc::kern_return_t;
+        unsafe fn mach_timebase_info(info: *mut mach_timebase_info) -> libc::kern_return_t;
     }
 
-    // Make sure to round up to ensure that we definitely sleep until after
-    // the deadline has elapsed.
-    let Some(deadline) = deadline.into_inner().into_mach_absolute_time_ceil() else {
-        // Since the deadline is before the system boot time, it has already
-        // passed, so we can return immediately.
+    // `mach_wait_until` assumes that the `deadline` is in units of `mach_absolute_time`,
+    // so we need to convert the second/nanosecond-based `Instant` to those.
+    let Ok(secs) = u64::try_from(deadline.secs) else {
+        // The epoch of `Instant` is the system boot time. Since the deadline
+        // is that, it has already passed, so we can return immediately.
         return;
     };
+
+    let mut timebase = mach_timebase_info { numer: 0, denom: 0 };
+    assert_eq!(unsafe { mach_timebase_info(&mut timebase) }, libc::KERN_SUCCESS);
+
+    // Since `secs` is 64-bit and `nanos` is smaller than 1 billion,
+    // this cannot overflow. The resulting number needs at most 94 bits.
+    let nanos = 1_000_000_000 * u128::from(secs) + u128::from(deadline.nanos.as_inner());
+    // This multiplication cannot overflow since multiplying a 94-bit
+    // number by a 32-bit number yields a number that needs at most
+    // 126 bits. Make sure to round up to ensure that we definitely
+    // sleep until after the deadline has elapsed.
+    let deadline = (nanos * u128::from(timebase.denom)).div_ceil(u128::from(timebase.numer));
 
     // If the deadline is not representable, then sleep for the maximum duration
     // possible and worry about the potential clock issues later (in ca. 600 years).

--- a/library/std/src/sys/time/hermit.rs
+++ b/library/std/src/sys/time/hermit.rs
@@ -3,7 +3,7 @@ use hermit_abi::{self, CLOCK_MONOTONIC, CLOCK_REALTIME};
 use crate::io;
 use crate::sys::cvt;
 use crate::sys::pal::time::Timespec;
-use crate::time::Duration;
+use crate::time::{Duration, Instant};
 
 fn clock_gettime(clock: hermit_abi::clockid_t) -> Timespec {
     let mut t = hermit_abi::timespec { tv_sec: 0, tv_nsec: 0 };
@@ -11,25 +11,9 @@ fn clock_gettime(clock: hermit_abi::clockid_t) -> Timespec {
     Timespec::new(t.tv_sec, t.tv_nsec.into()).unwrap()
 }
 
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
-pub struct Instant(Timespec);
-
-impl Instant {
-    pub fn now() -> Instant {
-        Instant(clock_gettime(CLOCK_MONOTONIC))
-    }
-
-    pub fn checked_sub_instant(&self, other: &Instant) -> Option<Duration> {
-        self.0.sub_timespec(&other.0).ok()
-    }
-
-    pub fn checked_add_duration(&self, other: &Duration) -> Option<Instant> {
-        Some(Instant(self.0.checked_add_duration(other)?))
-    }
-
-    pub fn checked_sub_duration(&self, other: &Duration) -> Option<Instant> {
-        Some(Instant(self.0.checked_sub_duration(other)?))
-    }
+pub fn now() -> Instant {
+    let time = clock_gettime(CLOCK_MONOTONIC);
+    Instant { secs: time.tv_sec, nanos: time.tv_nsec }
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]

--- a/library/std/src/sys/time/mod.rs
+++ b/library/std/src/sys/time/mod.rs
@@ -32,7 +32,7 @@ cfg_select! {
         mod unsupported;
 
         mod imp {
-            pub use super::vexos::Instant;
+            pub use super::vexos::now;
             pub use super::unsupported::{SystemTime, UNIX_EPOCH};
         }
     }
@@ -50,4 +50,18 @@ cfg_select! {
     }
 }
 
-pub use imp::{Instant, SystemTime, UNIX_EPOCH};
+#[cfg(any(target_family = "unix", target_os = "wasi"))]
+#[cfg_attr(not(target_os = "linux"), allow(unused_imports))]
+pub(crate) use imp::CLOCK_ID;
+pub use imp::{SystemTime, UNIX_EPOCH, now};
+
+cfg_select! {
+    target_os = "windows" => {
+        pub use imp::epsilon;
+    },
+    _ => {
+        pub fn epsilon() -> crate::time::Duration {
+            crate::time::Duration::ZERO
+        }
+    }
+}

--- a/library/std/src/sys/time/sgx.rs
+++ b/library/std/src/sys/time/sgx.rs
@@ -1,31 +1,19 @@
-use crate::sys::pal::abi::usercalls;
-use crate::time::Duration;
+use core::num::niche_types::Nanoseconds;
 
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
-pub struct Instant(Duration);
+use crate::sys::pal::abi::usercalls;
+use crate::time::{Duration, Instant};
+
+pub fn now() -> Instant {
+    let time = usercalls::insecure_time();
+    let secs = (time / 1_000_000_000) as i64;
+    let nanos = Nanoseconds::new((time % 1_000_000_000) as u32).unwrap();
+    Instant { secs, nanos }
+}
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
 pub struct SystemTime(Duration);
 
 pub const UNIX_EPOCH: SystemTime = SystemTime(Duration::from_secs(0));
-
-impl Instant {
-    pub fn now() -> Instant {
-        Instant(usercalls::insecure_time())
-    }
-
-    pub fn checked_sub_instant(&self, other: &Instant) -> Option<Duration> {
-        self.0.checked_sub(other.0)
-    }
-
-    pub fn checked_add_duration(&self, other: &Duration) -> Option<Instant> {
-        Some(Instant(self.0.checked_add(*other)?))
-    }
-
-    pub fn checked_sub_duration(&self, other: &Duration) -> Option<Instant> {
-        Some(Instant(self.0.checked_sub(*other)?))
-    }
-}
 
 impl SystemTime {
     pub const MAX: SystemTime = SystemTime(Duration::MAX);
@@ -33,7 +21,8 @@ impl SystemTime {
     pub const MIN: SystemTime = SystemTime(Duration::ZERO);
 
     pub fn now() -> SystemTime {
-        SystemTime(usercalls::insecure_time())
+        let t = usercalls::insecure_time();
+        SystemTime(Duration::new(t / 1_000_000_000, (t % 1_000_000_000) as _))
     }
 
     pub fn sub_time(&self, other: &SystemTime) -> Result<Duration, Duration> {

--- a/library/std/src/sys/time/solid.rs
+++ b/library/std/src/sys/time/solid.rs
@@ -1,36 +1,16 @@
+use core::num::niche_types::Nanoseconds;
+
 use crate::mem::MaybeUninit;
 use crate::sys::pal::error::expect_success;
 use crate::sys::pal::{abi, itron};
-use crate::time::Duration;
+use crate::time::{Duration, Instant};
 
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
-pub struct Instant(itron::abi::SYSTIM);
-
-impl Instant {
-    pub fn now() -> Instant {
-        Instant(itron::time::get_tim())
-    }
-
-    pub fn checked_sub_instant(&self, other: &Instant) -> Option<Duration> {
-        self.0.checked_sub(other.0).map(|ticks| {
-            // `SYSTIM` is measured in microseconds
-            Duration::from_micros(ticks)
-        })
-    }
-
-    pub fn checked_add_duration(&self, other: &Duration) -> Option<Instant> {
-        // `SYSTIM` is measured in microseconds
-        let ticks = other.as_micros();
-
-        Some(Instant(self.0.checked_add(ticks.try_into().ok()?)?))
-    }
-
-    pub fn checked_sub_duration(&self, other: &Duration) -> Option<Instant> {
-        // `SYSTIM` is measured in microseconds
-        let ticks = other.as_micros();
-
-        Some(Instant(self.0.checked_sub(ticks.try_into().ok()?)?))
-    }
+pub fn now() -> Instant {
+    let time = itron::time::get_tim();
+    // `SYSTIM` is measured in microseconds
+    let secs = (time / 1_000_000) as i64;
+    let nanos = Nanoseconds::new(1000 * (time % 1_000_000) as u32).unwrap();
+    Instant { secs, nanos }
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]

--- a/library/std/src/sys/time/uefi.rs
+++ b/library/std/src/sys/time/uefi.rs
@@ -1,8 +1,18 @@
 use crate::sys::pal::system_time;
-use crate::time::Duration;
+use crate::time::{Duration, Instant};
 
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
-pub struct Instant(Duration);
+pub fn now() -> Instant {
+    // If we have a timestamp protocol, use it.
+    if let Some(x) = instant_internal::timestamp_protocol() {
+        return x;
+    }
+
+    if let Some(x) = instant_internal::platform_specific() {
+        return x;
+    }
+
+    panic!("time not implemented on this platform")
+}
 
 /// When a Timezone is specified, the stored Duration is in UTC. If timezone is unspecified, then
 /// the timezone is assumed to be in UTC.
@@ -40,33 +50,6 @@ const MAX_UEFI_TIME: SystemTime = SystemTime::from_uefi(r_efi::efi::Time {
     pad2: 0,
 })
 .unwrap();
-
-impl Instant {
-    pub fn now() -> Instant {
-        // If we have a timestamp protocol, use it.
-        if let Some(x) = instant_internal::timestamp_protocol() {
-            return x;
-        }
-
-        if let Some(x) = instant_internal::platform_specific() {
-            return x;
-        }
-
-        panic!("time not implemented on this platform")
-    }
-
-    pub fn checked_sub_instant(&self, other: &Instant) -> Option<Duration> {
-        self.0.checked_sub(other.0)
-    }
-
-    pub fn checked_add_duration(&self, other: &Duration) -> Option<Instant> {
-        Some(Instant(self.0.checked_add(*other)?))
-    }
-
-    pub fn checked_sub_duration(&self, other: &Duration) -> Option<Instant> {
-        Some(Instant(self.0.checked_sub(*other)?))
-    }
-}
 
 impl SystemTime {
     pub const MAX: SystemTime = MAX_UEFI_TIME;
@@ -137,19 +120,20 @@ impl SystemTime {
 }
 
 mod instant_internal {
+    use core::num::niche_types::Nanoseconds;
+
     use r_efi::protocols::timestamp;
 
     use super::*;
     use crate::mem::MaybeUninit;
     use crate::ptr::NonNull;
     use crate::sync::atomic::{Atomic, AtomicPtr, Ordering};
-    use crate::sys::helpers::mul_div_u64;
     use crate::sys::pal::helpers;
 
     const NS_PER_SEC: u64 = 1_000_000_000;
 
     pub fn timestamp_protocol() -> Option<Instant> {
-        fn try_handle(handle: NonNull<crate::ffi::c_void>) -> Option<u64> {
+        fn try_handle(handle: NonNull<crate::ffi::c_void>) -> Option<Instant> {
             let protocol: NonNull<timestamp::Protocol> =
                 helpers::open_protocol(handle, timestamp::PROTOCOL_GUID).ok()?;
             let mut properties: MaybeUninit<timestamp::Properties> = MaybeUninit::uninit();
@@ -161,23 +145,30 @@ mod instant_internal {
 
             let freq = unsafe { properties.assume_init().frequency };
             let ts = unsafe { ((*protocol.as_ptr()).get_timestamp)() };
-            Some(mul_div_u64(ts, NS_PER_SEC, freq))
+
+            let secs = (ts / freq) as i64;
+            let subsec_ts = ts % freq;
+
+            let nanos =
+                Nanoseconds::new((subsec_ts.widening_mul(NS_PER_SEC) / u128::from(freq)) as u32)
+                    .unwrap();
+            Some(Instant { secs, nanos })
         }
 
         static LAST_VALID_HANDLE: Atomic<*mut crate::ffi::c_void> =
             AtomicPtr::new(crate::ptr::null_mut());
 
         if let Some(handle) = NonNull::new(LAST_VALID_HANDLE.load(Ordering::Acquire)) {
-            if let Some(ns) = try_handle(handle) {
-                return Some(Instant(Duration::from_nanos(ns)));
+            if let Some(time) = try_handle(handle) {
+                return Some(time);
             }
         }
 
         if let Ok(handles) = helpers::locate_handles(timestamp::PROTOCOL_GUID) {
             for handle in handles {
-                if let Some(ns) = try_handle(handle) {
+                if let Some(time) = try_handle(handle) {
                     LAST_VALID_HANDLE.store(handle.as_ptr(), Ordering::Release);
-                    return Some(Instant(Duration::from_nanos(ns)));
+                    return Some(time);
                 }
             }
         }
@@ -187,48 +178,59 @@ mod instant_internal {
 
     pub fn platform_specific() -> Option<Instant> {
         cfg_select! {
-            any(target_arch = "x86_64", target_arch = "x86") => timestamp_rdtsc().map(Instant),
+            any(target_arch = "x86", target_arch = "x86_64") => timestamp_rdtsc(),
             _ => None,
         }
     }
 
-    #[cfg(target_arch = "x86_64")]
-    fn timestamp_rdtsc() -> Option<Duration> {
-        static FREQUENCY: crate::sync::OnceLock<u64> = crate::sync::OnceLock::new();
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    fn timestamp_rdtsc() -> Option<Instant> {
+        #[cfg(target_arch = "x86")]
+        use crate::arch::x86::{__cpuid, _rdtsc};
+        #[cfg(target_arch = "x86_64")]
+        use crate::arch::x86_64::{__cpuid, _rdtsc};
 
-        // Get Frequency in Mhz
-        // Inspired by [`edk2/UefiCpuPkg/Library/CpuTimerLib/CpuTimerLib.c`](https://github.com/tianocore/edk2/blob/master/UefiCpuPkg/Library/CpuTimerLib/CpuTimerLib.c)
-        let freq = FREQUENCY
+        struct Slope {
+            multiplier: u32,
+            divisor: u64,
+        }
+
+        static SLOPE: crate::sync::OnceLock<Slope> = crate::sync::OnceLock::new();
+
+        // Inspired by https://github.com/tianocore/edk2/blob/6d127c21406c89b50f6c7345f02c2b958660e231/UefiCpuPkg/Library/CpuTimerLib/CpuTimerLib.c
+        let slope = SLOPE
             .get_or_try_init(|| {
-                let cpuid = crate::arch::x86_64::__cpuid(0x15);
+                let cpuid = __cpuid(0x15);
                 if cpuid.eax == 0 || cpuid.ebx == 0 || cpuid.ecx == 0 {
                     return Err(());
                 }
-                Ok(mul_div_u64(cpuid.ecx as u64, cpuid.ebx as u64, cpuid.eax as u64))
+
+                let core_freq_mhz = cpuid.ecx;
+                let core_freq_tsc_mul = cpuid.ebx;
+                let core_freq_tsc_div = cpuid.eax;
+
+                // TSC_freq_hz = (core_freq_hz * core_freq_tsc_mul) / core_freq_tsc_div
+                // time = TSC / TSC_freq_hz
+                //      = TSC / ((core_freq_hz * core_freq_tsc_mul) / core_freq_tsc_div)
+                //      = (TSC * core_freq_tsc_div) / (core_freq_hz * core_freq_tsc_mul)
+
+                Ok(Slope {
+                    multiplier: core_freq_tsc_div,
+                    divisor: core_freq_mhz.widening_mul(core_freq_tsc_mul),
+                })
             })
             .ok()?;
 
-        let ts = unsafe { crate::arch::x86_64::_rdtsc() };
-        let ns = mul_div_u64(ts, 1000, *freq);
-        Some(Duration::from_nanos(ns))
-    }
+        let ts = unsafe { _rdtsc() };
 
-    #[cfg(target_arch = "x86")]
-    fn timestamp_rdtsc() -> Option<Duration> {
-        static FREQUENCY: crate::sync::OnceLock<u64> = crate::sync::OnceLock::new();
+        let divisor = u128::from(slope.divisor);
+        let numerator = ts.widening_mul(u64::from(slope.multiplier));
+        // The TSC definitely runs faster than 2 Hz, hence this cannot overflow.
+        let secs = (numerator / divisor) as i64;
+        let remainder = (numerator % divisor) as u64;
+        let nanos =
+            Nanoseconds::new((remainder.widening_mul(NS_PER_SEC) / divisor) as u32).unwrap();
 
-        let freq = FREQUENCY
-            .get_or_try_init(|| {
-                let cpuid = crate::arch::x86::__cpuid(0x15);
-                if cpuid.eax == 0 || cpuid.ebx == 0 || cpuid.ecx == 0 {
-                    return Err(());
-                }
-                Ok(mul_div_u64(cpuid.ecx as u64, cpuid.ebx as u64, cpuid.eax as u64))
-            })
-            .ok()?;
-
-        let ts = unsafe { crate::arch::x86::_rdtsc() };
-        let ns = mul_div_u64(ts, 1000, *freq);
-        Some(Duration::from_nanos(ns))
+        Some(Instant { secs, nanos })
     }
 }

--- a/library/std/src/sys/time/unix.rs
+++ b/library/std/src/sys/time/unix.rs
@@ -1,6 +1,5 @@
-use crate::sys::AsInner;
 use crate::sys::pal::time::Timespec;
-use crate::time::Duration;
+use crate::time::{Duration, Instant};
 use crate::{fmt, io};
 
 pub const UNIX_EPOCH: SystemTime = SystemTime { t: Timespec::zero() };
@@ -46,96 +45,24 @@ impl fmt::Debug for SystemTime {
     }
 }
 
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct Instant {
-    t: Timespec,
-}
+// CLOCK_UPTIME_RAW   clock that increments monotonically, in the same man-
+//                    ner as CLOCK_MONOTONIC_RAW, but that does not incre-
+//                    ment while the system is asleep.  The returned value
+//                    is identical to the result of mach_absolute_time()
+//                    after the appropriate mach_timebase conversion is
+//                    applied.
+//
+// We use `CLOCK_UPTIME_RAW` instead of `CLOCK_MONOTONIC` since
+// `CLOCK_UPTIME_RAW` is based on `mach_absolute_time`, which is the
+// clock that all timeouts and deadlines are measured against inside
+// the kernel.
+#[cfg(target_vendor = "apple")]
+pub(crate) const CLOCK_ID: libc::clockid_t = libc::CLOCK_UPTIME_RAW;
+#[cfg(not(target_vendor = "apple"))]
+pub(crate) const CLOCK_ID: libc::clockid_t = libc::CLOCK_MONOTONIC;
 
-impl Instant {
-    // CLOCK_UPTIME_RAW   clock that increments monotonically, in the same man-
-    //                    ner as CLOCK_MONOTONIC_RAW, but that does not incre-
-    //                    ment while the system is asleep.  The returned value
-    //                    is identical to the result of mach_absolute_time()
-    //                    after the appropriate mach_timebase conversion is
-    //                    applied.
-    //
-    // We use `CLOCK_UPTIME_RAW` instead of `CLOCK_MONOTONIC` since
-    // `CLOCK_UPTIME_RAW` is based on `mach_absolute_time`, which is the
-    // clock that all timeouts and deadlines are measured against inside
-    // the kernel.
-    #[cfg(target_vendor = "apple")]
-    pub(crate) const CLOCK_ID: libc::clockid_t = libc::CLOCK_UPTIME_RAW;
-
-    #[cfg(not(target_vendor = "apple"))]
-    pub(crate) const CLOCK_ID: libc::clockid_t = libc::CLOCK_MONOTONIC;
-
-    pub fn now() -> Instant {
-        // https://pubs.opengroup.org/onlinepubs/9799919799/functions/clock_getres.html
-        Instant { t: Timespec::now(Self::CLOCK_ID) }
-    }
-
-    pub fn checked_sub_instant(&self, other: &Instant) -> Option<Duration> {
-        self.t.sub_timespec(&other.t).ok()
-    }
-
-    pub fn checked_add_duration(&self, other: &Duration) -> Option<Instant> {
-        Some(Instant { t: self.t.checked_add_duration(other)? })
-    }
-
-    pub fn checked_sub_duration(&self, other: &Duration) -> Option<Instant> {
-        Some(Instant { t: self.t.checked_sub_duration(other)? })
-    }
-
-    #[cfg_attr(
-        not(target_os = "linux"),
-        allow(unused, reason = "needed by the `sleep_until` on some unix platforms")
-    )]
-    pub(crate) fn into_timespec(self) -> Timespec {
-        self.t
-    }
-
-    /// Returns `self` converted into units of `mach_absolute_time`, or `None`
-    /// if `self` is before the system boot time. If the conversion cannot be
-    /// performed precisely, this ceils the result up to the nearest
-    /// representable value.
-    #[cfg(target_vendor = "apple")]
-    pub fn into_mach_absolute_time_ceil(self) -> Option<u128> {
-        #[repr(C)]
-        struct mach_timebase_info {
-            numer: u32,
-            denom: u32,
-        }
-
-        unsafe extern "C" {
-            unsafe fn mach_timebase_info(info: *mut mach_timebase_info) -> libc::kern_return_t;
-        }
-
-        let secs = u64::try_from(self.t.tv_sec).ok()?;
-
-        let mut timebase = mach_timebase_info { numer: 0, denom: 0 };
-        assert_eq!(unsafe { mach_timebase_info(&mut timebase) }, libc::KERN_SUCCESS);
-
-        // Since `tv_sec` is 64-bit and `tv_nsec` is smaller than 1 billion,
-        // this cannot overflow. The resulting number needs at most 94 bits.
-        let nanos = 1_000_000_000 * u128::from(secs) + u128::from(self.t.tv_nsec.as_inner());
-        // This multiplication cannot overflow since multiplying a 94-bit
-        // number by a 32-bit number yields a number that needs at most
-        // 126 bits.
-        Some((nanos * u128::from(timebase.denom)).div_ceil(u128::from(timebase.numer)))
-    }
-}
-
-impl AsInner<Timespec> for Instant {
-    fn as_inner(&self) -> &Timespec {
-        &self.t
-    }
-}
-
-impl fmt::Debug for Instant {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Instant")
-            .field("tv_sec", &self.t.tv_sec)
-            .field("tv_nsec", &self.t.tv_nsec)
-            .finish()
-    }
+pub fn now() -> Instant {
+    // https://pubs.opengroup.org/onlinepubs/9799919799/functions/clock_getres.html
+    let time = Timespec::now(CLOCK_ID);
+    Instant { secs: time.tv_sec, nanos: time.tv_nsec }
 }

--- a/library/std/src/sys/time/unsupported.rs
+++ b/library/std/src/sys/time/unsupported.rs
@@ -1,30 +1,13 @@
-use crate::time::Duration;
+use crate::time::{Duration, Instant};
 
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
-pub struct Instant(Duration);
+pub fn now() -> Instant {
+    panic!("time not implemented on this platform")
+}
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
 pub struct SystemTime(Duration);
 
 pub const UNIX_EPOCH: SystemTime = SystemTime(Duration::from_secs(0));
-
-impl Instant {
-    pub fn now() -> Instant {
-        panic!("time not implemented on this platform")
-    }
-
-    pub fn checked_sub_instant(&self, other: &Instant) -> Option<Duration> {
-        self.0.checked_sub(other.0)
-    }
-
-    pub fn checked_add_duration(&self, other: &Duration) -> Option<Instant> {
-        Some(Instant(self.0.checked_add(*other)?))
-    }
-
-    pub fn checked_sub_duration(&self, other: &Duration) -> Option<Instant> {
-        Some(Instant(self.0.checked_sub(*other)?))
-    }
-}
 
 impl SystemTime {
     pub const MAX: SystemTime = SystemTime(Duration::MAX);

--- a/library/std/src/sys/time/vexos.rs
+++ b/library/std/src/sys/time/vexos.rs
@@ -1,23 +1,10 @@
-use crate::time::Duration;
+use core::num::niche_types::Nanoseconds;
 
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
-pub struct Instant(Duration);
+use crate::time::Instant;
 
-impl Instant {
-    pub fn now() -> Instant {
-        let micros = unsafe { vex_sdk::vexSystemHighResTimeGet() };
-        Self(Duration::from_micros(micros))
-    }
-
-    pub fn checked_sub_instant(&self, other: &Instant) -> Option<Duration> {
-        self.0.checked_sub(other.0)
-    }
-
-    pub fn checked_add_duration(&self, other: &Duration) -> Option<Instant> {
-        Some(Instant(self.0.checked_add(*other)?))
-    }
-
-    pub fn checked_sub_duration(&self, other: &Duration) -> Option<Instant> {
-        Some(Instant(self.0.checked_sub(*other)?))
-    }
+pub fn now() -> Instant {
+    let micros = unsafe { vex_sdk::vexSystemHighResTimeGet() };
+    let secs = (micros / 1_000_000) as i64;
+    let nanos = Nanoseconds::new(1000 * (micros % 1_000_000) as u32).unwrap();
+    Instant { secs, nanos }
 }

--- a/library/std/src/sys/time/windows.rs
+++ b/library/std/src/sys/time/windows.rs
@@ -1,21 +1,35 @@
+use core::num::niche_types::Nanoseconds;
+
 use crate::cmp::Ordering;
 use crate::hash::{Hash, Hasher};
-use crate::sys::helpers::mul_div_u64;
 use crate::sys::pal::time::{
     INTERVALS_PER_SEC, checked_dur2intervals, intervals2dur, perf_counter,
 };
 use crate::sys::{IntoInner, c};
-use crate::time::Duration;
+use crate::time::{Duration, Instant};
 use crate::{fmt, mem};
 
 const NANOS_PER_SEC: u64 = 1_000_000_000;
 
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Hash)]
-pub struct Instant {
-    // This duration is relative to an arbitrary microsecond epoch
-    // from the winapi QueryPerformanceCounter function.
-    t: Duration,
+pub fn now() -> Instant {
+    // High precision timing on windows operates in "Performance Counter"
+    // units, as returned by the WINAPI QueryPerformanceCounter function.
+    // These relate to seconds by a factor of QueryPerformanceFrequency.
+
+    let freq = perf_counter::frequency();
+    let counts = perf_counter::now();
+
+    let secs = counts.div_euclid(freq);
+    let subsec_counts = counts.rem_euclid(freq) as u64;
+
+    // "QPC does not go backward.", so the frequency cannot be negative.
+    let freq = freq as u64;
+    let nanos = Nanoseconds::new((NANOS_PER_SEC.strict_mul(subsec_counts) / freq) as u32).unwrap();
+
+    Instant { secs, nanos }
 }
+
+pub use perf_counter::epsilon;
 
 #[derive(Copy, Clone)]
 pub struct SystemTime {
@@ -24,48 +38,6 @@ pub struct SystemTime {
 
 pub const UNIX_EPOCH: SystemTime =
     SystemTime::from_intervals(11_644_473_600 * INTERVALS_PER_SEC as i64);
-
-impl Instant {
-    pub fn now() -> Instant {
-        // High precision timing on windows operates in "Performance Counter"
-        // units, as returned by the WINAPI QueryPerformanceCounter function.
-        // These relate to seconds by a factor of QueryPerformanceFrequency.
-        // In order to keep unit conversions out of normal interval math, we
-        // measure in QPC units and immediately convert to nanoseconds.
-
-        let freq = perf_counter::frequency() as u64;
-        let now = perf_counter::now();
-
-        // We convert now to `u64` to be able to use `Duration`.
-        let instant_nsec = mul_div_u64(now as u64, NANOS_PER_SEC, freq);
-        // We can add an arbitrary offset to shift the epoch of this clock. We do that to avoid
-        // being too close to 0 which would lead to underflow when computing times in the past. Also
-        // see <https://github.com/rust-lang/rust/issues/156142>.
-        let instant_nsec = instant_nsec + (u64::MAX / 4);
-
-        Self { t: Duration::from_nanos(instant_nsec) }
-    }
-
-    pub fn checked_sub_instant(&self, other: &Instant) -> Option<Duration> {
-        // On windows there's a threshold below which we consider two timestamps
-        // equivalent due to measurement error. For more details + doc link,
-        // check the docs on epsilon.
-        let epsilon = perf_counter::epsilon();
-        if other.t > self.t && other.t - self.t <= epsilon {
-            Some(Duration::new(0, 0))
-        } else {
-            self.t.checked_sub(other.t)
-        }
-    }
-
-    pub fn checked_add_duration(&self, other: &Duration) -> Option<Instant> {
-        Some(Instant { t: self.t.checked_add(*other)? })
-    }
-
-    pub fn checked_sub_duration(&self, other: &Duration) -> Option<Instant> {
-        Some(Instant { t: self.t.checked_sub(*other)? })
-    }
-}
 
 impl SystemTime {
     pub const MAX: SystemTime = SystemTime::from_intervals(i64::MAX);

--- a/library/std/src/sys/time/xous.rs
+++ b/library/std/src/sys/time/xous.rs
@@ -1,38 +1,27 @@
+use core::num::niche_types::Nanoseconds;
+
 use crate::os::xous::ffi::blocking_scalar;
 use crate::os::xous::services::SystimeScalar::GetUtcTimeMs;
 use crate::os::xous::services::TicktimerScalar::ElapsedMs;
 use crate::os::xous::services::{systime_server, ticktimer_server};
-use crate::time::Duration;
+use crate::time::{Duration, Instant};
 
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
-pub struct Instant(Duration);
+pub fn now() -> Instant {
+    let result = blocking_scalar(ticktimer_server(), ElapsedMs.into())
+        .expect("failed to request elapsed_ms");
+    let lower = result[0];
+    let upper = result[1];
+    let millis = lower as u64 | (upper as u64) << 32;
+
+    let secs = (millis / 1_000) as i64;
+    let nanos = Nanoseconds::new(1_000_000 * (millis % 1000) as u32).unwrap();
+    Instant { secs, nanos }
+}
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
 pub struct SystemTime(Duration);
 
 pub const UNIX_EPOCH: SystemTime = SystemTime(Duration::from_secs(0));
-
-impl Instant {
-    pub fn now() -> Instant {
-        let result = blocking_scalar(ticktimer_server(), ElapsedMs.into())
-            .expect("failed to request elapsed_ms");
-        let lower = result[0];
-        let upper = result[1];
-        Instant { 0: Duration::from_millis(lower as u64 | (upper as u64) << 32) }
-    }
-
-    pub fn checked_sub_instant(&self, other: &Instant) -> Option<Duration> {
-        self.0.checked_sub(other.0)
-    }
-
-    pub fn checked_add_duration(&self, other: &Duration) -> Option<Instant> {
-        self.0.checked_add(*other).map(Instant)
-    }
-
-    pub fn checked_sub_duration(&self, other: &Duration) -> Option<Instant> {
-        self.0.checked_sub(*other).map(Instant)
-    }
-}
 
 impl SystemTime {
     pub const MAX: SystemTime = SystemTime(Duration::MAX);

--- a/library/std/src/time.rs
+++ b/library/std/src/time.rs
@@ -64,9 +64,6 @@ const NANOS_PER_SEC: u32 = 1_000_000_000;
 /// allows measuring the duration between two instants (or comparing two
 /// instants).
 ///
-/// The size of an `Instant` struct may vary depending on the target operating
-/// system.
-///
 /// Example:
 ///
 /// ```no_run
@@ -84,27 +81,6 @@ const NANOS_PER_SEC: u32 = 1_000_000_000;
 /// ```
 ///
 /// [platform bugs]: Instant#monotonicity
-///
-/// # OS-specific behaviors
-///
-/// An `Instant` is a wrapper around system-specific types and it may behave
-/// differently depending on the underlying operating system. For example,
-/// the following snippet is fine on Linux but panics on macOS:
-///
-/// ```no_run
-/// use std::time::{Instant, Duration};
-///
-/// let now = Instant::now();
-/// let days_per_10_millennia = 365_2425;
-/// let solar_seconds_per_day = 60 * 60 * 24;
-/// let millennium_in_solar_seconds = 31_556_952_000;
-/// assert_eq!(millennium_in_solar_seconds, days_per_10_millennia * solar_seconds_per_day / 10);
-///
-/// let duration = Duration::new(millennium_in_solar_seconds, 0);
-/// println!("{:?}", now + duration);
-/// ```
-///
-/// For cross-platform code, you can comfortably use durations of up to around one hundred years.
 ///
 /// # Underlying System calls
 ///
@@ -129,8 +105,8 @@ const NANOS_PER_SEC: u32 = 1_000_000_000;
 ///
 /// **Disclaimer:** These system calls might change over time.
 ///
-/// > Note: mathematical operations like [`add`] may panic if the underlying
-/// > structure cannot represent the new point in time.
+/// > Note: mathematical operations like [`add`] may panic if the new point in
+/// > time cannot be represented.
 ///
 /// [`add`]: Instant::add
 ///
@@ -416,8 +392,7 @@ impl Instant {
     }
 
     /// Returns `Some(t)` where `t` is the time `self + duration` if `t` can be represented as
-    /// `Instant` (which means it's inside the bounds of the underlying data structure), `None`
-    /// otherwise.
+    /// `Instant`, `None` otherwise.
     #[stable(feature = "time_checked_add", since = "1.34.0")]
     pub fn checked_add(&self, duration: Duration) -> Option<Instant> {
         let secs = self.secs.checked_add_unsigned(duration.as_secs())?;
@@ -433,8 +408,7 @@ impl Instant {
     }
 
     /// Returns `Some(t)` where `t` is the time `self - duration` if `t` can be represented as
-    /// `Instant` (which means it's inside the bounds of the underlying data structure), `None`
-    /// otherwise.
+    /// `Instant`, `None` otherwise.
     #[stable(feature = "time_checked_add", since = "1.34.0")]
     pub fn checked_sub(&self, duration: Duration) -> Option<Instant> {
         let secs = self.secs.checked_sub_unsigned(duration.as_secs())?;
@@ -456,8 +430,8 @@ impl Add<Duration> for Instant {
 
     /// # Panics
     ///
-    /// This function may panic if the resulting point in time cannot be represented by the
-    /// underlying data structure. See [`Instant::checked_add`] for a version without panic.
+    /// This function may panic if the resulting point in time cannot be represented.
+    /// See [`Instant::checked_add`] for a version without panic.
     #[track_caller]
     fn add(self, other: Duration) -> Instant {
         self.checked_add(other).expect("overflow when adding duration to instant")

--- a/library/std/src/time.rs
+++ b/library/std/src/time.rs
@@ -31,6 +31,7 @@
 
 #![stable(feature = "time", since = "1.3.0")]
 
+use core::num::niche_types::Nanoseconds;
 #[stable(feature = "time", since = "1.3.0")]
 pub use core::time::Duration;
 #[stable(feature = "duration_checked_float", since = "1.66.0")]
@@ -40,6 +41,8 @@ use crate::error::Error;
 use crate::fmt;
 use crate::ops::{Add, AddAssign, Sub, SubAssign};
 use crate::sys::{FromInner, IntoInner, time};
+
+const NANOS_PER_SEC: u32 = 1_000_000_000;
 
 /// A measurement of a monotonically nondecreasing clock.
 /// Opaque and useful only with [`Duration`].
@@ -150,10 +153,13 @@ use crate::sys::{FromInner, IntoInner, time};
 /// [`sub`]: Instant::sub
 /// [`checked_duration_since`]: Instant::checked_duration_since
 ///
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[stable(feature = "time2", since = "1.8.0")]
 #[cfg_attr(not(test), rustc_diagnostic_item = "Instant")]
-pub struct Instant(time::Instant);
+pub struct Instant {
+    pub(crate) secs: i64,
+    pub(crate) nanos: Nanoseconds,
+}
 
 /// A measurement of the system clock, useful for talking to
 /// external entities like the file system or other processes.
@@ -283,7 +289,7 @@ impl Instant {
     #[stable(feature = "time2", since = "1.8.0")]
     #[cfg_attr(not(test), rustc_diagnostic_item = "instant_now")]
     pub fn now() -> Instant {
-        Instant(time::Instant::now())
+        time::now()
     }
 
     /// Returns the amount of time elapsed from another instant to this one,
@@ -338,7 +344,27 @@ impl Instant {
     #[must_use]
     #[stable(feature = "checked_duration_since", since = "1.39.0")]
     pub fn checked_duration_since(&self, earlier: Instant) -> Option<Duration> {
-        self.0.checked_sub_instant(&earlier.0)
+        if earlier.secs <= self.secs {
+            let secs = self.secs.wrapping_sub(earlier.secs) as u64;
+            let (nanos, borrow) = self.nanos.as_inner().overflowing_sub(earlier.nanos.as_inner());
+            if !borrow {
+                return Some(Duration::new(secs, nanos));
+            } else if let Some(sub_secs) = secs.checked_sub(1) {
+                let nanos = nanos.wrapping_add(NANOS_PER_SEC);
+                return Some(Duration::new(sub_secs, nanos));
+            }
+        }
+
+        let epsilon = time::epsilon();
+        if epsilon != Duration::ZERO {
+            // On windows there's a threshold below which we consider two timestamps
+            // equivalent due to measurement error. For more details + doc link,
+            // check the docs on epsilon.
+            let duration = earlier.checked_duration_since(*self).unwrap();
+            if duration <= epsilon { Some(Duration::ZERO) } else { None }
+        } else {
+            None
+        }
     }
 
     /// Returns the amount of time elapsed from another instant to this one,
@@ -394,7 +420,16 @@ impl Instant {
     /// otherwise.
     #[stable(feature = "time_checked_add", since = "1.34.0")]
     pub fn checked_add(&self, duration: Duration) -> Option<Instant> {
-        self.0.checked_add_duration(&duration).map(Instant)
+        let secs = self.secs.checked_add_unsigned(duration.as_secs())?;
+        let nanos = self.nanos.as_inner() + duration.subsec_nanos();
+        if let Some(nanos) = Nanoseconds::new(nanos) {
+            Some(Instant { secs, nanos })
+        } else if let Some(secs) = secs.checked_add(1) {
+            let nanos = Nanoseconds::new(nanos - NANOS_PER_SEC).unwrap();
+            Some(Instant { secs, nanos })
+        } else {
+            None
+        }
     }
 
     /// Returns `Some(t)` where `t` is the time `self - duration` if `t` can be represented as
@@ -402,16 +437,16 @@ impl Instant {
     /// otherwise.
     #[stable(feature = "time_checked_add", since = "1.34.0")]
     pub fn checked_sub(&self, duration: Duration) -> Option<Instant> {
-        self.0.checked_sub_duration(&duration).map(Instant)
-    }
-
-    // Used by platform specific `sleep_until` implementations such as the one used on Linux.
-    #[cfg_attr(
-        not(target_os = "linux"),
-        allow(unused, reason = "not every platform has a specific `sleep_until`")
-    )]
-    pub(crate) fn into_inner(self) -> time::Instant {
-        self.0
+        let secs = self.secs.checked_sub_unsigned(duration.as_secs())?;
+        let nanos = self.nanos.as_inner().wrapping_sub(duration.subsec_nanos());
+        if let Some(nanos) = Nanoseconds::new(nanos) {
+            Some(Instant { secs, nanos })
+        } else if let Some(secs) = secs.checked_sub(1) {
+            let nanos = Nanoseconds::new(nanos.wrapping_add(NANOS_PER_SEC)).unwrap();
+            Some(Instant { secs, nanos })
+        } else {
+            None
+        }
     }
 }
 
@@ -469,13 +504,6 @@ impl Sub<Instant> for Instant {
     /// [Monotonicity]: Instant#monotonicity
     fn sub(self, other: Instant) -> Duration {
         self.duration_since(other)
-    }
-}
-
-#[stable(feature = "time2", since = "1.8.0")]
-impl fmt::Debug for Instant {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.0.fmt(f)
     }
 }
 


### PR DESCRIPTION
This fixes https://github.com/rust-lang/rust/issues/156142 for all targets using a very principled solution: representing `Instant` the same way on all platforms.

Currently, not all platforms have the same range and precision of `Instant`: while all UNIX platforms (and Hermit) represent `Instant` using a pair consisting of an 64-bit signed second field and a non-negative nanosecond offset and thus are able to represent timepoints well before the system epoch, most other platforms use a `Duration` with the result that operations like `Instant::now() - Duration::from(/* 100 years */)` do not succeed. SOLID even represents `Instant` using a microsecond counter, which means that nanosecond arithmetic is lossy.

To improve the portability of time arithmetic, I propose using the same representation for `Instant` on all platforms: a 64-bit signed second field and a non-negative nanosecond offset (i.e. a signed `Duration`). This means that:
* Since all platform timestamp types can either represent the same time range or a smaller one, `Instant::now` can never fail due to an out-of-bounds timestamp from the platform.
* Time arithmetic works identically on all platforms, operations like adding or subtracting large but not unreasonable durations do not fail (as long as the platform chooses a reasonable epoch).

Note that this does not add any significant conversion cost since all platforms currently convert to some seconds-based unit anyway.

I've split this PR into two parts: the first makes the actual changes to the implementation, the second adjusts the documentation to remove any mentions of platform-specific representations.