### PR TITLE
std: abort when `resume_unwind` is called inside the panic hook

### DIFF
--- a/library/std/src/panicking.rs
+++ b/library/std/src/panicking.rs
@@ -415,6 +415,7 @@ pub mod panic_count {
     //
     // This also updates thread-local state to keep track of whether a panic
     // hook is currently executing.
+    #[must_use = "MustAbort may not be ignored"]
     pub fn increase(run_panic_hook: bool) -> Option<MustAbort> {
         let global_count = GLOBAL_PANIC_COUNT.fetch_add(1, Ordering::Relaxed);
         if global_count & ALWAYS_ABORT_FLAG != 0 {
@@ -843,7 +844,18 @@ fn panic_with_hook(
 /// It just forwards the payload to the panic runtime.
 #[cfg_attr(panic = "immediate-abort", inline)]
 pub fn resume_unwind(payload: Box<dyn Any + Send>) -> ! {
-    panic_count::increase(false);
+    if let Some(must_abort) = panic_count::increase(false) {
+        match must_abort {
+            panic_count::MustAbort::PanicInHook => {
+                rtprintpanic!("thread panicked while processing panic. aborting.\n");
+            }
+            panic_count::MustAbort::AlwaysAbort => {
+                rtprintpanic!("aborting due to panic\n");
+            }
+        }
+
+        crate::process::abort();
+    }
 
     struct RewrapBox(Box<dyn Any + Send>);
 

--- a/tests/ui/panics/abort-on-panic.rs
+++ b/tests/ui/panics/abort-on-panic.rs
@@ -61,11 +61,20 @@ fn test_always_abort_thread() {
     bomb_out_but_not_abort("joined - but we were supposed to panic!");
 }
 
+fn test_always_abort_resume_unwind() {
+    panic::always_abort();
+    let _ = panic::catch_unwind(|| {
+        panic::resume_unwind(Box::new(()));
+    });
+    should_have_aborted();
+}
+
 fn main() {
     let tests: &[(_, fn())] = &[
         ("test", test),
         ("test_always_abort", test_always_abort),
         ("test_always_abort_thread", test_always_abort_thread),
+        ("test_always_abort_resume_unwind", test_always_abort_resume_unwind),
     ];
 
     let args: Vec<String> = env::args().collect();

--- a/tests/ui/panics/panic-in-hook.rs
+++ b/tests/ui/panics/panic-in-hook.rs
@@ -1,0 +1,14 @@
+// Checks what happens when panicking inside the panic hook.
+
+//@ run-crash
+//@ exec-env:RUST_BACKTRACE=0
+//@ check-run-results
+//@ error-pattern: panicked while processing panic
+//@ ignore-emscripten "RuntimeError" junk in output
+
+use std::panic;
+
+fn main() {
+    panic::set_hook(Box::new(|_| panic!("panic in hook")));
+    panic!();
+}

--- a/tests/ui/panics/panic-in-hook.run.stderr
+++ b/tests/ui/panics/panic-in-hook.run.stderr
@@ -1,0 +1,3 @@
+panicked at $DIR/panic-in-hook.rs:12:34:
+
+thread panicked while processing panic. aborting.

--- a/tests/ui/panics/panic-resume_unwind-in-hook.rs
+++ b/tests/ui/panics/panic-resume_unwind-in-hook.rs
@@ -1,0 +1,14 @@
+// Checks what happens when panicking inside the panic hook.
+
+//@ run-crash
+//@ exec-env:RUST_BACKTRACE=0
+//@ check-run-results
+//@ error-pattern: panicked while processing panic
+//@ ignore-emscripten "RuntimeError" junk in output
+
+use std::panic;
+
+fn main() {
+    panic::set_hook(Box::new(|_| panic::resume_unwind(Box::new(()))));
+    panic!();
+}

--- a/tests/ui/panics/panic-resume_unwind-in-hook.run.stderr
+++ b/tests/ui/panics/panic-resume_unwind-in-hook.run.stderr
@@ -1,0 +1,1 @@
+thread panicked while processing panic. aborting.


### PR DESCRIPTION
`resume_unwind` neglected to check the result from the `panic_count::increase`. This led to both `resume_unwind` unwinding after a `always_abort` and to an irreversible increase of the panic count if it is called inside a panic hook (since both the original panic and `resume_unwind` increase the panic count, but only one unwind occurs and so `catch_unwind` is only able to undo one of the count increases).