### PR TITLE
Appropirate os family definitions for Apple-made operating systems

### DIFF
--- a/library/std/src/sys/env_consts.rs
+++ b/library/std/src/sys/env_consts.rs
@@ -160,7 +160,7 @@ pub mod os {
 
 #[cfg(target_os = "ios")]
 pub mod os {
-    pub const FAMILY: &str = "unix";
+    pub const FAMILY: &str = "xnu";
     pub const OS: &str = "ios";
     pub const DLL_PREFIX: &str = "lib";
     pub const DLL_SUFFIX: &str = ".dylib";
@@ -193,7 +193,7 @@ pub mod os {
 
 #[cfg(target_os = "macos")]
 pub mod os {
-    pub const FAMILY: &str = "unix";
+    pub const FAMILY: &str = "xnu";
     pub const OS: &str = "macos";
     pub const DLL_PREFIX: &str = "lib";
     pub const DLL_SUFFIX: &str = ".dylib";
@@ -303,7 +303,7 @@ pub mod os {
 
 #[cfg(target_os = "tvos")]
 pub mod os {
-    pub const FAMILY: &str = "unix";
+    pub const FAMILY: &str = "xnu";
     pub const OS: &str = "tvos";
     pub const DLL_PREFIX: &str = "lib";
     pub const DLL_SUFFIX: &str = ".dylib";
@@ -336,7 +336,7 @@ pub mod os {
 
 #[cfg(target_os = "visionos")]
 pub mod os {
-    pub const FAMILY: &str = "unix";
+    pub const FAMILY: &str = "xnu";
     pub const OS: &str = "visionos";
     pub const DLL_PREFIX: &str = "lib";
     pub const DLL_SUFFIX: &str = ".dylib";
@@ -380,7 +380,7 @@ pub mod os {
 
 #[cfg(target_os = "watchos")]
 pub mod os {
-    pub const FAMILY: &str = "unix";
+    pub const FAMILY: &str = "xnu";
     pub const OS: &str = "watchos";
     pub const DLL_PREFIX: &str = "lib";
     pub const DLL_SUFFIX: &str = ".dylib";


### PR DESCRIPTION
[NOTE]: This is my first pr actually contributing to a programming language, so there will likely be errors in code styling and what not.

## Changes and what not

Apple operating systems use apple's [XNU](https://github.com/apple-oss-distributions/xnu) kernel, which literally stands for X is not Unix. It would better differentiate Apple's operating systems from other Unix-like operating systems when doing conditional-compilation (e.g. a janky workaround for XNU systems could look much cleaner). The code writing difference would look like so:

```Rust
// Current:
#[cfg(any(target_os = "macos", target_os = "ios", ...))]

// Proposed:
#[cfg(target_family = "xnu")]
```

## Other things needed

- [ ] Compiler env update things
- [ ] Documentation updates
- [ ] Updating of some under-the-hood things in rustc that use and define related things.

Please feel free to help with this pr.

[EDIT]: Apparently the target_vendor variable exists, so is this pr not needed for the proposed case, is there any reason for this pr's existence even? I will leave this up just in case there is a case to be made for it's existence.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
