### PR TITLE
disallow tail calling extern "rust-call" functions

### DIFF
--- a/compiler/rustc_abi/src/extern_abi.rs
+++ b/compiler/rustc_abi/src/extern_abi.rs
@@ -343,10 +343,16 @@ impl ExternAbi {
                 // This ABI does not support calls at all (except via assembly).
                 false
             }
+            Self::RustCall => {
+                // Argument untupling requires additional support for tail calls to be possible,
+                // see <https://github.com/rust-lang/rust/pull/158248>. There is no real uses of
+                // tail calling `extern "rust-call"` functions
+                false
+            }
+
             Self::C { .. }
             | Self::System { .. }
             | Self::Rust
-            | Self::RustCall
             | Self::RustCold
             | Self::RustInvalid
             | Self::Unadjusted

--- a/tests/ui/explicit-tail-calls/unsupported-abi/rust-call.rs
+++ b/tests/ui/explicit-tail-calls/unsupported-abi/rust-call.rs
@@ -1,0 +1,16 @@
+// extern "rust-call" untuples the first (and only, except self) argument, this requires additional
+// support for tail calls to work correctly. Since there doesn't seem to be a usecase for tail
+// calling extern "rust-call" functions (extern "rust-call" only shows up in closures, which we
+// disallow tail-calling anyway), we just disallow that.
+//
+// @ ignore-backends: gcc
+#![expect(incomplete_features)]
+#![feature(explicit_tail_calls)]
+#![feature(unboxed_closures)]
+
+extern "rust-call" fn a(_: ()) {
+    become a(());
+    //~^ error: ABI does not support guaranteed tail calls
+}
+
+fn main() {}

--- a/tests/ui/explicit-tail-calls/unsupported-abi/rust-call.stderr
+++ b/tests/ui/explicit-tail-calls/unsupported-abi/rust-call.stderr
@@ -1,0 +1,10 @@
+error: ABI does not support guaranteed tail calls
+  --> $DIR/rust-call.rs:12:5
+   |
+LL |     become a(());
+   |     ^^^^^^^^^^^^
+   |
+   = note: `become` is not supported for `extern "rust-call"` functions
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

r? folkertdev

Following discussion from https://github.com/rust-lang/rust/pull/158248.

Fixes https://github.com/rust-lang/rust/issues/158017
Closes rust-lang/rust#158248