### PR TITLE
Support `DefKind::InlineConst` in `ConstKind::Unevaluated`

### DIFF
--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -2791,7 +2791,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
             }
             ExprKind::ConstBlock(anon_const) => {
                 let def_id = self.local_def_id(anon_const.id);
-                assert_eq!(DefKind::AnonConst, self.tcx.def_kind(def_id));
+                assert_eq!(DefKind::InlineConst, self.tcx.def_kind(def_id));
                 self.lower_anon_const_to_const_arg(anon_const, span)
             }
             _ => overly_complex_const(self),

--- a/compiler/rustc_borrowck/src/universal_regions.rs
+++ b/compiler/rustc_borrowck/src/universal_regions.rs
@@ -615,7 +615,7 @@ impl<'cx, 'tcx> UniversalRegionsBuilder<'cx, 'tcx> {
 
             BodyOwnerKind::Const { .. } | BodyOwnerKind::Static(..) => {
                 match tcx.def_kind(self.mir_def) {
-                    DefKind::InlineConst => {
+                    DefKind::InlineConst if !tcx.is_type_system_inline_const(self.mir_def) => {
                         // This is required for `AscribeUserType` canonical query, which will call
                         // `type_of(inline_const_def_id)`. That `type_of` would inject erased lifetimes
                         // into borrowck, which is ICE #78174.

--- a/compiler/rustc_hir/src/def.rs
+++ b/compiler/rustc_hir/src/def.rs
@@ -448,43 +448,6 @@ impl DefKind {
             | DefKind::ExternCrate => false,
         }
     }
-
-    /// Returns `true` if `self` is a kind of definition that does not have its own
-    /// type-checking context, i.e. closure, coroutine or inline const.
-    #[inline]
-    pub fn is_typeck_child(self) -> bool {
-        match self {
-            DefKind::Closure | DefKind::InlineConst | DefKind::SyntheticCoroutineBody => true,
-            DefKind::Mod
-            | DefKind::Struct
-            | DefKind::Union
-            | DefKind::Enum
-            | DefKind::Variant
-            | DefKind::Trait
-            | DefKind::TyAlias
-            | DefKind::ForeignTy
-            | DefKind::TraitAlias
-            | DefKind::AssocTy
-            | DefKind::TyParam
-            | DefKind::Fn
-            | DefKind::Const { .. }
-            | DefKind::ConstParam
-            | DefKind::Static { .. }
-            | DefKind::Ctor(_, _)
-            | DefKind::AssocFn
-            | DefKind::AssocConst { .. }
-            | DefKind::Macro(_)
-            | DefKind::ExternCrate
-            | DefKind::Use
-            | DefKind::ForeignMod
-            | DefKind::AnonConst
-            | DefKind::OpaqueTy
-            | DefKind::Field
-            | DefKind::LifetimeParam
-            | DefKind::GlobalAsm
-            | DefKind::Impl { .. } => false,
-        }
-    }
 }
 
 /// The resolution of a path or export.

--- a/compiler/rustc_hir_analysis/src/collect.rs
+++ b/compiler/rustc_hir_analysis/src/collect.rs
@@ -15,7 +15,7 @@
 //! crate as a kind of pass. This should eventually be factored away.
 
 use std::cell::Cell;
-use std::{assert_matches, iter};
+use std::{assert_matches, debug_assert_matches, iter};
 
 use rustc_abi::{ExternAbi, Size};
 use rustc_ast::Recovered;
@@ -1635,10 +1635,12 @@ fn const_param_default<'tcx>(
 }
 
 fn anon_const_kind<'tcx>(tcx: TyCtxt<'tcx>, def: LocalDefId) -> ty::AnonConstKind {
+    debug_assert_matches!(tcx.def_kind(def), DefKind::AnonConst | DefKind::InlineConst);
     let hir_id = tcx.local_def_id_to_hir_id(def);
     let const_arg_id = tcx.parent_hir_id(hir_id);
     match tcx.hir_node(const_arg_id) {
-        hir::Node::ConstArg(_) => {
+        hir::Node::ConstArg(const_arg) => {
+            debug_assert_matches!(const_arg.kind, hir::ConstArgKind::Anon(hir::AnonConst { def_id, .. }) if *def_id == def);
             let parent_hir_node = tcx.hir_node(tcx.parent_hir_id(const_arg_id));
             if tcx.features().generic_const_exprs() {
                 ty::AnonConstKind::GCE

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
@@ -482,7 +482,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
         let tcx = self.tcx();
         let parent_def_id = self.item_def_id();
         if let Res::Def(DefKind::ConstParam, _) = res
-            && tcx.def_kind(parent_def_id) == DefKind::AnonConst
+            && matches!(tcx.def_kind(parent_def_id), DefKind::AnonConst | DefKind::InlineConst)
             && let ty::AnonConstKind::MCG = tcx.anon_const_kind(parent_def_id)
         {
             let folder = ForbidParamUsesFolder {
@@ -511,15 +511,11 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
         // Inline consts and closures can be nested inside anon consts that forbid generic
         // params (e.g. an enum discriminant). Walk up the def parent chain to find the
         // nearest enclosing AnonConst and use that to determine the context.
+        let parent_def_id = tcx.typeck_root_def_id(parent_def_id.into());
+
         let anon_const_def_id = match tcx.def_kind(parent_def_id) {
             DefKind::AnonConst => parent_def_id,
-            DefKind::InlineConst | DefKind::Closure => {
-                let root = tcx.typeck_root_def_id(parent_def_id.into());
-                match tcx.def_kind(root) {
-                    DefKind::AnonConst => root.expect_local(),
-                    _ => return None,
-                }
-            }
+            DefKind::InlineConst if tcx.is_type_system_inline_const(parent_def_id) => parent_def_id,
             _ => return None,
         };
 

--- a/compiler/rustc_hir_analysis/src/lib.rs
+++ b/compiler/rustc_hir_analysis/src/lib.rs
@@ -186,9 +186,13 @@ pub fn check_crate(tcx: TyCtxt<'_>) {
             }
             _ => (),
         }
-        // Skip `AnonConst`s because we feed their `type_of`.
+        // Skip `AnonConst`s and type system `InlineConst`s because we feed their `type_of` in
+        // `feed_anon_const_type`.
         // Also skip items for which typeck forwards to parent typeck.
-        if !(matches!(def_kind, DefKind::AnonConst) || def_kind.is_typeck_child()) {
+        if !(def_kind == DefKind::AnonConst
+            || def_kind == DefKind::InlineConst && tcx.is_type_system_inline_const(item_def_id)
+            || tcx.is_typeck_child(item_def_id.to_def_id()))
+        {
             tcx.ensure_ok().typeck(item_def_id);
         }
         // Ensure we generate the new `DefId` before finishing `check_crate`.

--- a/compiler/rustc_hir_typeck/src/loops.rs
+++ b/compiler/rustc_hir_typeck/src/loops.rs
@@ -84,6 +84,11 @@ pub(crate) fn check<'tcx>(tcx: TyCtxt<'tcx>, def_id: LocalDefId, body: &'tcx hir
         CheckLoopVisitor { tcx, cx_stack: vec![Normal], block_breaks: Default::default() };
     let cx = match tcx.def_kind(def_id) {
         DefKind::AnonConst => AnonConst,
+        DefKind::InlineConst => {
+            // only type system inline consts are typeck roots
+            debug_assert!(tcx.is_type_system_inline_const(def_id));
+            ConstBlock
+        }
         _ => Fn,
     };
     check.with_context(cx, |v| v.visit_body(body));

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -1624,7 +1624,7 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
                         <- tcx.explicit_implied_const_bounds(def_id).skip_binder());
                 }
             }
-            if let DefKind::AnonConst = def_kind {
+            if let DefKind::AnonConst | DefKind::InlineConst = def_kind {
                 record!(self.tables.anon_const_kind[def_id] <- self.tcx.anon_const_kind(def_id));
             }
             if should_encode_const_of_item(self.tcx, def_id, def_kind) {

--- a/compiler/rustc_middle/src/hir/map.rs
+++ b/compiler/rustc_middle/src/hir/map.rs
@@ -22,7 +22,7 @@ use rustc_span::{ErrorGuaranteed, Ident, Span, Symbol, kw, with_metavar_spans};
 use crate::hir::{ModuleItems, ProjectedMaybeOwner, nested_filter};
 use crate::middle::debugger_visualizer::DebuggerVisualizerFile;
 use crate::query::{IntoQueryKey, LocalCrate};
-use crate::ty::TyCtxt;
+use crate::ty::{self, TyCtxt};
 
 /// An iterator that walks up the ancestor tree of a given `HirId`.
 /// Constructed using `tcx.hir_parent_iter(hir_id)`.
@@ -1113,6 +1113,12 @@ impl<'tcx> TyCtxt<'tcx> {
             }) => Some(*param_id),
             _ => None,
         }
+    }
+
+    pub fn is_type_system_inline_const(self, def_id: impl IntoQueryKey<DefId>) -> bool {
+        let def_id = def_id.into_query_key();
+        debug_assert_eq!(self.def_kind(def_id), DefKind::InlineConst);
+        self.anon_const_kind(def_id) != ty::AnonConstKind::NonTypeSystem
     }
 
     pub fn hir_maybe_get_struct_pattern_shorthand_field(self, expr: &Expr<'_>) -> Option<Symbol> {

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -601,7 +601,14 @@ impl<'tcx> TyCtxt<'tcx> {
     /// effect. However, we do not want this as a general capability, so this interface restricts
     /// to the only allowed case.
     pub fn feed_anon_const_type(self, key: LocalDefId, value: ty::EarlyBinder<'tcx, Ty<'tcx>>) {
-        debug_assert_eq!(self.def_kind(key), DefKind::AnonConst);
+        if cfg!(debug_assertions) {
+            match self.def_kind(key) {
+                DefKind::AnonConst => (),
+                DefKind::InlineConst => assert!(self.is_type_system_inline_const(key)),
+                def_kind => bug!("unexpected DefKind in feed_anon_const_type: {def_kind:?}"),
+            }
+        }
+
         TyCtxtFeed { tcx: self, key }.type_of(value)
     }
 

--- a/compiler/rustc_middle/src/ty/context/impl_interner.rs
+++ b/compiler/rustc_middle/src/ty/context/impl_interner.rs
@@ -247,7 +247,7 @@ impl<'tcx> Interner for TyCtxt<'tcx> {
             DefKind::OpaqueTy => ty::AliasTermKind::OpaqueTy { def_id },
             DefKind::TyAlias => ty::AliasTermKind::FreeTy { def_id },
             DefKind::Const { .. } => ty::AliasTermKind::FreeConst { def_id },
-            DefKind::AnonConst | DefKind::Ctor(_, CtorKind::Const) => {
+            DefKind::AnonConst | DefKind::InlineConst | DefKind::Ctor(_, CtorKind::Const) => {
                 ty::AliasTermKind::AnonConst { def_id }
             }
             kind => bug!("unexpected DefKind in AliasTy: {kind:?}"),

--- a/compiler/rustc_middle/src/ty/util.rs
+++ b/compiler/rustc_middle/src/ty/util.rs
@@ -597,7 +597,38 @@ impl<'tcx> TyCtxt<'tcx> {
     /// Returns `true` if `def_id` refers to a definition that does not have its own
     /// type-checking context, i.e. closure, coroutine or inline const.
     pub fn is_typeck_child(self, def_id: DefId) -> bool {
-        self.def_kind(def_id).is_typeck_child()
+        match self.def_kind(def_id) {
+            DefKind::InlineConst => !self.is_type_system_inline_const(def_id),
+            DefKind::Closure | DefKind::SyntheticCoroutineBody => true,
+            DefKind::Mod
+            | DefKind::Struct
+            | DefKind::Union
+            | DefKind::Enum
+            | DefKind::Variant
+            | DefKind::Trait
+            | DefKind::TyAlias
+            | DefKind::ForeignTy
+            | DefKind::TraitAlias
+            | DefKind::AssocTy
+            | DefKind::TyParam
+            | DefKind::Fn
+            | DefKind::Const { .. }
+            | DefKind::ConstParam
+            | DefKind::Static { .. }
+            | DefKind::Ctor(_, _)
+            | DefKind::AssocFn
+            | DefKind::AssocConst { .. }
+            | DefKind::Macro(_)
+            | DefKind::ExternCrate
+            | DefKind::Use
+            | DefKind::ForeignMod
+            | DefKind::AnonConst
+            | DefKind::OpaqueTy
+            | DefKind::Field
+            | DefKind::LifetimeParam
+            | DefKind::GlobalAsm
+            | DefKind::Impl { .. } => false,
+        }
     }
 
     /// Returns `true` if `def_id` refers to a trait (i.e., `trait Foo { ... }`).

--- a/compiler/rustc_mir_transform/src/trivial_const.rs
+++ b/compiler/rustc_mir_transform/src/trivial_const.rs
@@ -52,11 +52,10 @@ where
     F: FnOnce() -> B,
     B: Deref<Target = Body<'tcx>>,
 {
-    if !matches!(
-        tcx.def_kind(def),
-        DefKind::AssocConst { .. } | DefKind::Const { .. } | DefKind::AnonConst
-    ) {
-        return None;
+    match tcx.def_kind(def) {
+        DefKind::AssocConst { .. } | DefKind::Const { .. } | DefKind::AnonConst => (),
+        DefKind::InlineConst if tcx.is_type_system_inline_const(def) => (),
+        _ => return None,
     }
 
     // If there are impossible predicates then MIR passes will replace the body with

--- a/compiler/rustc_resolve/src/def_collector.rs
+++ b/compiler/rustc_resolve/src/def_collector.rs
@@ -17,8 +17,7 @@ use tracing::{debug, instrument};
 
 use crate::macros::MacroRulesScopeRef;
 use crate::{
-    ConstArgContext, ImplTraitContext, InvocationParent, ParentScope, Resolver, with_owner,
-    with_owner_tables,
+    ImplTraitContext, InvocationParent, ParentScope, Resolver, with_owner, with_owner_tables,
 };
 
 pub(crate) fn collect_definitions<'ra>(
@@ -113,12 +112,6 @@ impl<'a, 'ra, 'tcx> DefCollector<'a, 'ra, 'tcx> {
             mem::replace(&mut self.invocation_parent.impl_trait_context, impl_trait_context);
         f(self);
         self.invocation_parent.impl_trait_context = orig_itc;
-    }
-
-    fn with_const_arg<F: FnOnce(&mut Self)>(&mut self, ctxt: ConstArgContext, f: F) {
-        let orig = mem::replace(&mut self.invocation_parent.const_arg_context, ctxt);
-        f(self);
-        self.invocation_parent.const_arg_context = orig;
     }
 
     fn collect_field(&mut self, field: &'a FieldDef, index: Option<usize>) {
@@ -430,6 +423,9 @@ impl<'a, 'ra, 'tcx> visit::Visitor<'a> for DefCollector<'a, 'ra, 'tcx> {
     }
 
     fn visit_anon_const(&mut self, constant: &'a AnonConst) {
+        // Note that `visit_anon_const` is skipped for AnonConst nodes wrapped in an
+        // ExprKind::ConstBlock - these are handled in visit_expr, and are DefKind::InlineConst.
+
         // `MgcaDisambiguation::Direct` is set even when MGCA is disabled, so
         // to avoid affecting stable we have to feature gate the not creating
         // anon consts
@@ -441,16 +437,12 @@ impl<'a, 'ra, 'tcx> visit::Visitor<'a> for DefCollector<'a, 'ra, 'tcx> {
         }
 
         match constant.mgca_disambiguation {
-            MgcaDisambiguation::Direct => self.with_const_arg(ConstArgContext::Direct, |this| {
-                visit::walk_anon_const(this, constant);
-            }),
+            MgcaDisambiguation::Direct => visit::walk_anon_const(self, constant),
             MgcaDisambiguation::AnonConst => {
-                self.with_const_arg(ConstArgContext::NonDirect, |this| {
-                    let parent = this
-                        .create_def(constant.id, None, DefKind::AnonConst, constant.value.span)
-                        .def_id();
-                    this.with_parent(parent, |this| visit::walk_anon_const(this, constant));
-                })
+                let parent = self
+                    .create_def(constant.id, None, DefKind::AnonConst, constant.value.span)
+                    .def_id();
+                self.with_parent(parent, |this| visit::walk_anon_const(this, constant));
             }
         };
     }
@@ -459,60 +451,28 @@ impl<'a, 'ra, 'tcx> visit::Visitor<'a> for DefCollector<'a, 'ra, 'tcx> {
     fn visit_expr(&mut self, expr: &'a Expr) {
         debug!(?self.invocation_parent);
 
-        let parent_def = match &expr.kind {
+        match &expr.kind {
             ExprKind::MacCall(..) => {
                 self.visit_macro_invoc(expr.id);
                 self.visit_invoc(expr.id);
-                return;
             }
             ExprKind::Closure(..) | ExprKind::Gen(..) => {
-                self.create_def(expr.id, None, DefKind::Closure, expr.span).def_id()
+                let def = self.create_def(expr.id, None, DefKind::Closure, expr.span).def_id();
+                self.with_parent(def, |this| visit::walk_expr(this, expr));
             }
             ExprKind::ConstBlock(constant) => {
-                // Under `min_generic_const_args` a `const { }` block sometimes
-                // corresponds to an anon const rather than an inline const.
-                let def_kind = match self.invocation_parent.const_arg_context {
-                    ConstArgContext::Direct => DefKind::AnonConst,
-                    ConstArgContext::NonDirect => DefKind::InlineConst,
-                };
-
-                return self.with_const_arg(ConstArgContext::NonDirect, |this| {
-                    for attr in &expr.attrs {
-                        visit::walk_attribute(this, attr);
-                    }
-
-                    let def =
-                        this.create_def(constant.id, None, def_kind, constant.value.span).def_id();
-                    this.with_parent(def, |this| visit::walk_anon_const(this, constant));
-                });
-            }
-
-            // Avoid overwriting `const_arg_context` as we may want to treat const blocks
-            // as being anon consts if we are inside a const argument.
-            ExprKind::Struct(_) | ExprKind::Call(..) | ExprKind::Tup(..) | ExprKind::Array(..) => {
-                return visit::walk_expr(self, expr);
-            }
-            // FIXME(mgca): we may want to handle block labels in some manner
-            ExprKind::Block(block, _) if let [stmt] = block.stmts.as_slice() => match stmt.kind {
-                // FIXME(mgca): this probably means that mac calls that expand
-                // to semi'd const blocks are handled differently to just writing
-                // out a semi'd const block.
-                StmtKind::Expr(..) | StmtKind::MacCall(..) => return visit::walk_expr(self, expr),
-
-                // Fallback to normal behaviour
-                StmtKind::Let(..) | StmtKind::Item(..) | StmtKind::Semi(..) | StmtKind::Empty => {
-                    self.invocation_parent.parent_def
+                for attr in &expr.attrs {
+                    visit::walk_attribute(self, attr);
                 }
-            },
 
-            _ => self.invocation_parent.parent_def,
-        };
-
-        self.with_const_arg(ConstArgContext::NonDirect, |this| {
-            // Note in some cases the `parent_def` here may be the existing parent
-            // and this is actually a no-op `with_parent` call.
-            this.with_parent(parent_def, |this| visit::walk_expr(this, expr))
-        })
+                let def = self
+                    .create_def(constant.id, None, DefKind::InlineConst, constant.value.span)
+                    .def_id();
+                // use specifically walk_anon_const, not walk_expr, to skip self.visit_anon_const
+                self.with_parent(def, |this| visit::walk_anon_const(this, constant));
+            }
+            _ => visit::walk_expr(self, expr),
+        }
     }
 
     fn visit_ty(&mut self, ty: &'a Ty) {

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -186,7 +186,6 @@ struct InvocationParent {
     parent_def: LocalDefId,
     impl_trait_context: ImplTraitContext,
     in_attr: bool,
-    const_arg_context: ConstArgContext,
     owner: NodeId,
 }
 
@@ -195,7 +194,6 @@ impl InvocationParent {
         parent_def: CRATE_DEF_ID,
         impl_trait_context: ImplTraitContext::Existential,
         in_attr: false,
-        const_arg_context: ConstArgContext::NonDirect,
         owner: CRATE_NODE_ID,
     };
 }
@@ -205,13 +203,6 @@ enum ImplTraitContext {
     Existential,
     Universal,
     InBinding,
-}
-
-#[derive(Copy, Clone, Debug)]
-enum ConstArgContext {
-    Direct,
-    /// Either inside of an `AnonConst` or not inside a const argument at all.
-    NonDirect,
 }
 
 /// Used for tracking import use types which will be used for redundant import checking.

--- a/compiler/rustc_ty_utils/src/opaque_types.rs
+++ b/compiler/rustc_ty_utils/src/opaque_types.rs
@@ -317,6 +317,10 @@ fn opaque_types_defined_by<'tcx>(
     tcx: TyCtxt<'tcx>,
     item: LocalDefId,
 ) -> &'tcx ty::List<LocalDefId> {
+    // Closures and coroutines are type checked with their parent
+    // Note that we also support `SyntheticCoroutineBody` since we create
+    // a MIR body for the def kind, and some MIR passes (like promotion)
+    // may require doing analysis using its typing env.
     if tcx.is_typeck_child(item.to_def_id()) {
         return tcx.opaque_types_defined_by(tcx.local_parent(item));
     }
@@ -332,7 +336,11 @@ fn opaque_types_defined_by<'tcx>(
         | DefKind::Static { .. }
         | DefKind::Const { .. }
         | DefKind::AssocConst { .. }
-        | DefKind::AnonConst => {
+        | DefKind::AnonConst
+        | DefKind::InlineConst => {
+            // Non-type-system inline consts should be caught by `if tcx.is_typeck_child` above
+            debug_assert!(kind != DefKind::InlineConst || tcx.is_type_system_inline_const(item));
+
             collector.collect_taits_declared_in_body();
         }
         DefKind::AssocTy | DefKind::TyAlias | DefKind::GlobalAsm => {}
@@ -345,15 +353,8 @@ fn opaque_types_defined_by<'tcx>(
         | DefKind::Trait
         | DefKind::ForeignTy
         | DefKind::TraitAlias
-
-        // Closures and coroutines are type checked with their parent
-        // Note that we also support `SyntheticCoroutineBody` since we create
-        // a MIR body for the def kind, and some MIR passes (like promotion)
-        // may require doing analysis using its typing env.
         | DefKind::Closure
-        | DefKind::InlineConst
         | DefKind::SyntheticCoroutineBody
-
         | DefKind::TyParam
         | DefKind::ConstParam
         | DefKind::Ctor(_, _)

--- a/compiler/rustc_ty_utils/src/sig_types.rs
+++ b/compiler/rustc_ty_utils/src/sig_types.rs
@@ -21,6 +21,24 @@ pub fn walk_types<'tcx, V: SpannedTypeVisitor<'tcx>>(
 ) -> V::Result {
     let kind = tcx.def_kind(item);
     trace!(?kind);
+    let mut visit_alias = || {
+        if let Some(ty) = tcx.hir_node_by_def_id(item).ty() {
+            // If the type of the item uses `_`, we're gonna error out anyway, but
+            // typeck (which type_of invokes below), will call back into opaque_types_defined_by
+            // causing a cycle. So we just bail out in this case.
+            if ty.is_suggestable_infer_ty() {
+                return V::Result::output();
+            }
+            // Associated types in traits don't necessarily have a type that we can visit
+            try_visit!(
+                visitor.visit(ty.span, tcx.type_of(item).instantiate_identity().skip_norm_wip())
+            );
+        }
+        for (pred, span) in tcx.explicit_predicates_of(item).instantiate_identity(tcx) {
+            try_visit!(visitor.visit(span, pred.skip_norm_wip()));
+        }
+        V::Result::output()
+    };
     match kind {
         // Walk over the signature of the function
         DefKind::AssocFn | DefKind::Fn => {
@@ -47,24 +65,8 @@ pub fn walk_types<'tcx, V: SpannedTypeVisitor<'tcx>>(
         | DefKind::Static { .. }
         | DefKind::Const { .. }
         | DefKind::AssocConst { .. }
-        | DefKind::AnonConst => {
-            if let Some(ty) = tcx.hir_node_by_def_id(item).ty() {
-                // If the type of the item uses `_`, we're gonna error out anyway, but
-                // typeck (which type_of invokes below), will call back into opaque_types_defined_by
-                // causing a cycle. So we just bail out in this case.
-                if ty.is_suggestable_infer_ty() {
-                    return V::Result::output();
-                }
-                // Associated types in traits don't necessarily have a type that we can visit
-                try_visit!(
-                    visitor
-                        .visit(ty.span, tcx.type_of(item).instantiate_identity().skip_norm_wip())
-                );
-            }
-            for (pred, span) in tcx.explicit_predicates_of(item).instantiate_identity(tcx) {
-                try_visit!(visitor.visit(span, pred.skip_norm_wip()));
-            }
-        }
+        | DefKind::AnonConst => return visit_alias(),
+        DefKind::InlineConst if tcx.is_type_system_inline_const(item) => return visit_alias(),
         DefKind::OpaqueTy => {
             for (pred, span) in tcx
                 .explicit_item_bounds(item)

--- a/tests/ui/const-generics/mgca/double-inline-const.rs
+++ b/tests/ui/const-generics/mgca/double-inline-const.rs
@@ -1,0 +1,11 @@
+#![feature(min_generic_const_args)]
+
+struct S<const N: usize>;
+
+impl<const N: usize> S<N> {
+    const Q: usize = 2;
+    fn foo(_: S<{ const { const { Self::Q } } }>) {}
+    //~^ ERROR generic `Self` types are currently not permitted in anonymous constants
+}
+
+fn main() {}

--- a/tests/ui/const-generics/mgca/double-inline-const.stderr
+++ b/tests/ui/const-generics/mgca/double-inline-const.stderr
@@ -1,0 +1,15 @@
+error: generic `Self` types are currently not permitted in anonymous constants
+  --> $DIR/double-inline-const.rs:7:35
+   |
+LL |     fn foo(_: S<{ const { const { Self::Q } } }>) {}
+   |                                   ^^^^
+   |
+note: not a concrete type
+  --> $DIR/double-inline-const.rs:5:22
+   |
+LL | impl<const N: usize> S<N> {
+   |                      ^^^^
+   = help: add `#![feature(generic_const_args)]` to allow generic expressions as the RHS of const items
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/158375)*
<!-- homu-ignore:end -->

fixes https://github.com/rust-lang/project-const-generics/issues/101

required for https://github.com/rust-lang/project-const-generics/issues/108

consider: `Struct<{ (some, stuff, const { hi }) }>`. The following is very pseudocode-y, the important parts are whether it says AnonConst or InlineConst, not the Tuple stuff

- On stable, we represent this with: `AnonConst(Tuple(some, stuff, InlineConst(hi)))`
- Under mGCA, with "direct" arguments, before this PR, it was `Tuple(some, stuff, AnonConst(hi))`. The inner InlineConst got intercepted in the def_collector with hacks (`ConstArgContext`) and converted into an AnonConst, even though it has inline const syntax.

It would be nice to keep it as an InlineConst under mGCA, i.e. `Tuple(some, stuff, InlineConst(hi))`, and have the type system support passing around InlineConsts in `ConstKind::Unevaluated` (soon to be renamed `ConstKind::Alias`). This would allow the def collector to not need to know if we are in a "direct" or "regular/anon" context, which it turns out is extremely useful for implementing https://github.com/rust-lang/project-const-generics/issues/108. Supporting InlineConsts in the type system are also useful for other things, for example, mentioned in https://github.com/rust-lang/project-const-generics/issues/101 is arg position const generics experiments.

This PR does two things:

- support InlineConsts in the type system (i.e. in `ConstKind::Unevaluated`)
- exercise that support, by no longer intercepting mGCA "direct" argument inline consts to be anon consts

r? @BoxyUwU