### PR TITLE
Suggest `>=` for `=>` typo in closure and call argument positions

### DIFF
--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -602,7 +602,9 @@ impl<'a> Parser<'a> {
         // Look for usages of '=>' where '>=' was probably intended
         if self.token == token::FatArrow
             && expected.iter().any(|tok| matches!(tok, TokenType::Operator | TokenType::Le))
-            && !expected.iter().any(|tok| matches!(tok, TokenType::FatArrow | TokenType::Comma))
+            && !expected
+                .iter()
+                .any(|tok| matches!(tok, TokenType::FatArrow | TokenType::CloseBrace))
         {
             err.span_suggestion(
                 self.token.span,

--- a/tests/ui/asm/parse-error.stderr
+++ b/tests/ui/asm/parse-error.stderr
@@ -57,6 +57,12 @@ error: expected one of `!`, `,`, `.`, `::`, `?`, `{`, or an operator, found `=>`
    |
 LL |         asm!("{}", in(reg) foo => bar);
    |                                ^^ expected one of 7 possible tokens
+   |
+help: you might have meant to write a "greater than or equal to" comparison
+   |
+LL -         asm!("{}", in(reg) foo => bar);
+LL +         asm!("{}", in(reg) foo >= bar);
+   |
 
 error: expected a path for argument to `sym`
   --> $DIR/parse-error.rs:32:24

--- a/tests/ui/parser/eq-gt-to-gt-eq.fixed
+++ b/tests/ui/parser/eq-gt-to-gt-eq.fixed
@@ -43,3 +43,9 @@ fn b() {
         _ => todo!(),
     }
 }
+
+fn closure() {
+    let a = 0;
+    let b = 1;
+    let _ = [a].iter().any(|x| x >= &b); //~ERROR
+}

--- a/tests/ui/parser/eq-gt-to-gt-eq.rs
+++ b/tests/ui/parser/eq-gt-to-gt-eq.rs
@@ -43,3 +43,9 @@ fn b() {
         _ => todo!(),
     }
 }
+
+fn closure() {
+    let a = 0;
+    let b = 1;
+    let _ = [a].iter().any(|x| x => &b); //~ERROR
+}

--- a/tests/ui/parser/eq-gt-to-gt-eq.stderr
+++ b/tests/ui/parser/eq-gt-to-gt-eq.stderr
@@ -109,5 +109,17 @@ LL -     match a => b {
 LL +     match a >= b {
    |
 
-error: aborting due to 7 previous errors
+error: expected one of `!`, `)`, `,`, `.`, `::`, `?`, `{`, or an operator, found `=>`
+  --> $DIR/eq-gt-to-gt-eq.rs:50:34
+   |
+LL |     let _ = [a].iter().any(|x| x => &b);
+   |                                  ^^ expected one of 8 possible tokens
+   |
+help: you might have meant to write a "greater than or equal to" comparison
+   |
+LL -     let _ = [a].iter().any(|x| x => &b);
+LL +     let _ = [a].iter().any(|x| x >= &b);
+   |
+
+error: aborting due to 8 previous errors
 


### PR DESCRIPTION
The parser suggests replacing `=>` with `>=` when it looks like a typo in a comparison, but it skipped the suggestion whenever a comma was an expected token. That excluded closure bodies used as call arguments, such as `iter.position(|x| x => &y)`, which is the case reported in rust-lang/rust#149805.

The comma exclusion was there to avoid suggesting `>=` for a missing comma between match arms, where `=>` is a real arm arrow. Those cases have a close brace in the expected token set, while the comparison cases do not, so this gates on the close brace instead of the comma. The existing `if`/`let`/`match` cases keep working, and the missing-comma-in-match suggestion is unaffected.

Fixes rust-lang/rust#149805