### PR TITLE
add `-Zforce-intrinsic-fallback` flag

### DIFF
--- a/compiler/rustc_codegen_ssa/src/mir/intrinsic.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/intrinsic.rs
@@ -63,6 +63,17 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
         result_place: Option<PlaceValue<Bx::Value>>,
         source_info: SourceInfo,
     ) -> IntrinsicResult<'tcx, Bx::Value> {
+        // When `-Zforce-intrinsic-fallback` is enabled, always use the fallback body if it exists,
+        if bx.tcx().sess.opts.unstable_opts.force_intrinsic_fallback
+            && let Some(def) = bx.tcx().intrinsic(instance.def_id())
+            && !def.must_be_overridden
+        {
+            return IntrinsicResult::Fallback(ty::Instance::new_raw(
+                instance.def_id(),
+                instance.args,
+            ));
+        }
+
         let span = source_info.span;
 
         let name = bx.tcx().item_name(instance.def_id());

--- a/compiler/rustc_monomorphize/src/collector.rs
+++ b/compiler/rustc_monomorphize/src/collector.rs
@@ -995,11 +995,18 @@ fn visit_instance_use<'tcx>(
                 output.push(create_fn_mono_item(tcx, panic_instance, source));
             }
         } else if !intrinsic.must_be_overridden
-            && !tcx.sess.replaced_intrinsics.contains(&intrinsic.name)
+            && (tcx.sess.opts.unstable_opts.force_intrinsic_fallback
+                || !tcx.sess.replaced_intrinsics.contains(&intrinsic.name))
         {
             // Codegen the fallback body of intrinsics with fallback bodies.
             // We have to skip this otherwise as there's no body to codegen.
-            // We also skip intrinsics the backend handles, to reduce monomorphizations.
+            //
+            // We also skip `replaced_intrinsics` which are always replaced by the backend and hence
+            // monomorphizing the fallback body would be pointless.
+            //
+            // However, when -Zforce-intrinsic-fallback is set (e.g. to test the fallback
+            // implementations) we ignore the optimization hint and do monomorphize
+            // the fallback body.
             let instance = ty::Instance::new_raw(instance.def_id(), instance.args);
             if tcx.should_codegen_locally(instance) {
                 output.push(create_fn_mono_item(tcx, instance, source));

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -2417,6 +2417,9 @@ options! {
     fmt_debug: FmtDebug = (FmtDebug::Full, parse_fmt_debug, [TRACKED],
         "how detailed `#[derive(Debug)]` should be. `full` prints types recursively, \
         `shallow` prints only type names, `none` prints nothing and disables `{:?}`. (default: `full`)"),
+    force_intrinsic_fallback: bool = (false, parse_bool, [TRACKED],
+        "always use the fallback body of an intrinsic, if it has one, instead of lowering \
+        the intrinsic in the codegen backend (default: no)."),
     force_unstable_if_unmarked: bool = (false, parse_bool, [TRACKED],
         "force all crates to be `rustc_private` unstable (default: no)"),
     function_return: FunctionReturn = (FunctionReturn::default(), parse_function_return, [TRACKED],

--- a/src/doc/unstable-book/src/compiler-flags/force-intrinsic-fallback.md
+++ b/src/doc/unstable-book/src/compiler-flags/force-intrinsic-fallback.md
@@ -1,0 +1,6 @@
+## `force-intrinsic-fallback`
+
+Configures codegen to always use the fallback body of an intrinsic, if it has one,
+instead of lowering the intrinsic in the codegen backend.
+
+This is useful for testing the fallback implementation.

--- a/tests/codegen-llvm/force-intrinsic-fallback.rs
+++ b/tests/codegen-llvm/force-intrinsic-fallback.rs
@@ -1,0 +1,38 @@
+//@ compile-flags: --crate-type=lib -C no-prepopulate-passes -Copt-level=3
+//
+//@ revisions: NORMAL FALLBACK
+//@ [FALLBACK] compile-flags: -Zforce-intrinsic-fallback
+#![feature(core_intrinsics, funnel_shifts)]
+
+// Check the effect of `-Zforce-intrinsic-fallback`.
+//
+// Without the flag, the dedicated backend lowering of the intrinsic is used.
+// With the flag, the fallback body is called instead.
+
+#[no_mangle]
+pub fn call_minimumf32(x: f32, y: f32) -> f32 {
+    // CHECK-LABEL: @call_minimumf32
+
+    // NORMAL: call float @llvm.minimum.f32
+    // NORMAL-NOT: minimumf32
+
+    // FALLBACK-NOT: @llvm.minimum
+    // FALLBACK: call {{.*}}minimumf32
+    core::intrinsics::minimumf32(x, y)
+}
+
+// Codegen backends can return a list of `replaced_intrinsics`, for which codegen of the fallback is
+// normally skipped. `unchecked_funnel_shl` is in that list for the LLVM backend, so we test it here
+// to ensure that with the flag enabled the fallback body is actually code generated and called.
+
+#[no_mangle]
+pub fn call_funnel_shl(a: u32, b: u32, shift: u32) -> u32 {
+    // CHECK-LABEL: @call_funnel_shl
+
+    // NORMAL: call i32 @llvm.fshl.i32
+    // NORMAL-NOT: funnel_shl
+
+    // FALLBACK-NOT: @llvm.fshl
+    // FALLBACK: call {{.*}}funnel_shl
+    unsafe { core::intrinsics::unchecked_funnel_shl(a, b, shift) }
+}


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/158377)*
<!-- homu-ignore:end -->

Add a flag that forces the use of the fallback body (if one exists), so that we can test that these fallback implementations actually work.

cc https://github.com/rust-lang/rust/pull/150946 
cc [#t-compiler > testing intrinsic fallback bodies](https://rust-lang.zulipchat.com/#narrow/channel/131828-t-compiler/topic/testing.20intrinsic.20fallback.20bodies/with/606299558)
cc [#t-infra > CI for -Zforce-intrinsic-fallback](https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/CI.20for.20-Zforce-intrinsic-fallback/with/608129693)