### PR TITLE
Workaround: Skip rustc book on i686

### DIFF
--- a/src/bootstrap/mk/Makefile.in
+++ b/src/bootstrap/mk/Makefile.in
@@ -112,9 +112,9 @@ TEST_SET2 := --skip=tests --skip=coverage-map --skip=coverage-run --skip=library
 
 # this intentionally doesn't use `$(BOOTSTRAP)` so we can test the shebang on Windows
 ci-msvc-py:
-	$(Q)$(CFG_SRC_DIR)/x.py test --stage 2 $(TEST_SET1)
+	$(Q)$(CFG_SRC_DIR)/x.py test --stage 2 $(TEST_SET1) --skip=src/tools/linkchecker
 ci-msvc-ps1:
-	$(Q)$(CFG_SRC_DIR)/x.ps1 test --stage 2 $(TEST_SET2)
+	$(Q)$(CFG_SRC_DIR)/x.ps1 test --stage 2 $(TEST_SET2) --skip=src/tools/linkchecker
 ci-msvc: ci-msvc-py ci-msvc-ps1
 
 ## MingW native builders

--- a/src/bootstrap/src/core/build_steps/doc.rs
+++ b/src/bootstrap/src/core/build_steps/doc.rs
@@ -1393,6 +1393,7 @@ impl Step for RustcBook {
     /// "rustbook" is used to convert it to HTML.
     fn run(self, builder: &Builder<'_>) {
         // FIXME: Temporary workaround for https://github.com/rust-lang/rust/issues/158378
+        #[cfg(not(test))] // So this check doesn't affect the bootstrap tests
         if self.target == "i686-pc-windows-msvc" {
             eprintln!("WARNING: Skipping rustc book build to work around #158378");
             return;

--- a/src/bootstrap/src/core/build_steps/doc.rs
+++ b/src/bootstrap/src/core/build_steps/doc.rs
@@ -1392,6 +1392,12 @@ impl Step for RustcBook {
     /// in the "md-doc" directory in the build output directory. Then
     /// "rustbook" is used to convert it to HTML.
     fn run(self, builder: &Builder<'_>) {
+        // FIXME: Temporary workaround for https://github.com/rust-lang/rust/issues/158378
+        if self.target == "i686-pc-windows-msvc" {
+            eprintln!("WARNING: Skipping rustc book build to work around #158378");
+            return;
+        }
+
         let out_base = builder.md_doc_out(self.target).join("rustc");
         t!(fs::create_dir_all(&out_base));
         let out_listing = out_base.join("src/lints");

--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -161,7 +161,7 @@ pr:
     env:
       CODEGEN_BACKENDS: gcc
     <<: *job-linux-4c
-  
+
   # This job tests features we want to stabilize soon, to ensure they don't
   # regress.
   - name: x86_64-gnu-next-trait-solver-polonius
@@ -720,6 +720,7 @@ auto:
         --target=i686-pc-windows-msvc
         --enable-full-tools
         --enable-profiler
+        --disable-docs
       SCRIPT: python x.py dist bootstrap --include-default-paths
       DIST_REQUIRE_ALL_TOOLS: 1
       CODEGEN_BACKENDS: llvm,cranelift

--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -26,6 +26,7 @@ static DOCS_FALLBACK: &[(&str, &str)] = &[
     ("-apple-", "aarch64-apple-darwin"),
     ("aarch64", "aarch64-unknown-linux-gnu"),
     ("arm-", "aarch64-unknown-linux-gnu"),
+    ("i686-pc-windows", "x86_64-pc-windows-msvc"),
     ("", "x86_64-unknown-linux-gnu"),
 ];
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/158379)*
<!-- homu-ignore:end -->

Workaround for https://github.com/rust-lang/rust/issues/158378 so we can get CI going again

r? @ghost

