### PR TITLE
Expose debug scope of statement and terminator in rustc_public

### DIFF
--- a/compiler/rustc_public/src/mir/body.rs
+++ b/compiler/rustc_public/src/mir/body.rs
@@ -139,7 +139,7 @@ pub struct BasicBlock {
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct Terminator {
     pub kind: TerminatorKind,
-    pub span: Span,
+    pub source_info: SourceInfo,
 }
 
 impl Terminator {
@@ -468,7 +468,7 @@ pub enum NonDivergingIntrinsic {
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct Statement {
     pub kind: StatementKind,
-    pub span: Span,
+    pub source_info: SourceInfo,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]

--- a/compiler/rustc_public/src/mir/visit.rs
+++ b/compiler/rustc_public/src/mir/visit.rs
@@ -139,9 +139,9 @@ macro_rules! make_mir_visitor {
             fn super_basic_block(&mut self, bb: &$($mutability)? BasicBlock) {
                 let BasicBlock { statements, terminator } = bb;
                 for stmt in statements {
-                    self.visit_statement(stmt, Location(stmt.span));
+                    self.visit_statement(stmt, Location(stmt.source_info.span));
                 }
-                self.visit_terminator(terminator, Location(terminator.span));
+                self.visit_terminator(terminator, Location(terminator.source_info.span));
             }
 
             fn super_local_decl(&mut self, local: Local, decl: &$($mutability)? LocalDecl) {
@@ -159,8 +159,8 @@ macro_rules! make_mir_visitor {
             }
 
             fn super_statement(&mut self, stmt: &$($mutability)? Statement, location: Location) {
-                let Statement { kind, span } = stmt;
-                self.visit_span(span);
+                let Statement { kind, source_info } = stmt;
+                self.visit_span(&$($mutability)? source_info.span);
                 match kind {
                     StatementKind::Assign(place, rvalue) => {
                         self.visit_place(place, PlaceContext::MUTATING, location);
@@ -199,8 +199,8 @@ macro_rules! make_mir_visitor {
             }
 
             fn super_terminator(&mut self, term: &$($mutability)? Terminator, location: Location) {
-                let Terminator { kind, span } = term;
-                self.visit_span(span);
+                let Terminator { kind, source_info } = term;
+                self.visit_span(&$($mutability)? source_info.span);
                 match kind {
                     TerminatorKind::Goto { .. }
                     | TerminatorKind::Resume
@@ -540,7 +540,7 @@ impl Location {
 pub fn statement_location(body: &Body, bb_idx: &BasicBlockIdx, stmt_idx: usize) -> Location {
     let bb = &body.blocks[*bb_idx];
     let stmt = &bb.statements[stmt_idx];
-    Location(stmt.span)
+    Location(stmt.source_info.span)
 }
 
 /// Location of the terminator for a given basic block. Assumes that `bb_idx` is valid for a given
@@ -548,7 +548,7 @@ pub fn statement_location(body: &Body, bb_idx: &BasicBlockIdx, stmt_idx: usize) 
 pub fn terminator_location(body: &Body, bb_idx: &BasicBlockIdx) -> Location {
     let bb = &body.blocks[*bb_idx];
     let terminator = &bb.terminator;
-    Location(terminator.span)
+    Location(terminator.source_info.span)
 }
 
 /// Reference to a place used to represent a partial projection.

--- a/compiler/rustc_public/src/unstable/convert/stable/mir.rs
+++ b/compiler/rustc_public/src/unstable/convert/stable/mir.rs
@@ -74,7 +74,7 @@ impl<'tcx> Stable<'tcx> for mir::Statement<'tcx> {
     ) -> Self::T {
         Statement {
             kind: self.kind.stable(tables, cx),
-            span: self.source_info.span.stable(tables, cx),
+            source_info: self.source_info.stable(tables, cx),
         }
     }
 }
@@ -695,7 +695,7 @@ impl<'tcx> Stable<'tcx> for mir::Terminator<'tcx> {
         use crate::mir::Terminator;
         Terminator {
             kind: self.kind.stable(tables, cx),
-            span: self.source_info.span.stable(tables, cx),
+            source_info: self.source_info.stable(tables, cx),
         }
     }
 }

--- a/tests/ui-fulldeps/rustc_public/check_transform.rs
+++ b/tests/ui-fulldeps/rustc_public/check_transform.rs
@@ -95,7 +95,7 @@ fn change_panic_msg(mut body: Body, new_msg: &str) -> Body {
                 let new_const = MirConst::from_str(new_msg);
                 args[0] = Operand::Constant(ConstOperand {
                     const_: new_const,
-                    span: bb.terminator.span,
+                    span: bb.terminator.source_info.span,
                     user_ty: None,
                 });
             }


### PR DESCRIPTION
Currently, `scope` is exposed for variables, but it is a meaningless number since the boundary of each scope is not available. This PR changes `span` fields of statement and terminator to `source_info` which includes scope as well.

Disclaimer: Written by LLM