### PR TITLE
Add safety section for SliceIndex::get_unchecked(mut)

### DIFF
--- a/library/core/src/slice/index.rs
+++ b/library/core/src/slice/index.rs
@@ -139,6 +139,8 @@ pub impl(crate) const unsafe trait SliceIndex<T: ?Sized> {
     /// Returns a pointer to the output at this location, without
     /// performing any bounds checking.
     ///
+    /// # Safety
+    ///
     /// Calling this method with an out-of-bounds index or a dangling `slice` pointer
     /// is *[undefined behavior]* even if the resulting pointer is not used.
     ///
@@ -148,6 +150,8 @@ pub impl(crate) const unsafe trait SliceIndex<T: ?Sized> {
 
     /// Returns a mutable pointer to the output at this location, without
     /// performing any bounds checking.
+    ///
+    /// # Safety
     ///
     /// Calling this method with an out-of-bounds index or a dangling `slice` pointer
     /// is *[undefined behavior]* even if the resulting pointer is not used.


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

This PR adds `# Safety` sections to the documentation for the unsafe `SliceIndex::get_unchecked` and `SliceIndex::get_unchecked_mut` trait methods.

The existing documentation already described the undefined behavior conditions for out-of-bounds indices and dangling slice pointers. This change keeps that content unchanged, but moves it under the standard rustdoc `# Safety` heading expected for unsafe functions.

No behavior changes.
