### PR TITLE
Add safety section for DisjointBitor::disjoint_bitor

### DIFF
--- a/library/core/src/intrinsics/fallback.rs
+++ b/library/core/src/intrinsics/fallback.rs
@@ -114,6 +114,13 @@ const impl CarryingMulAdd for i128 {
 pub const trait DisjointBitOr: Copy + 'static {
     /// See [`super::disjoint_bitor`]; we just need the trait indirection to handle
     /// different types since calling intrinsics with generics doesn't work.
+    ///
+    /// # Safety
+    ///
+    /// Requires that `(self & other) == 0`, or equivalently that
+    /// `(self | other) == (self + other)`.
+    ///
+    /// Otherwise it's immediate UB.
     unsafe fn disjoint_bitor(self, other: Self) -> Self;
 }
 macro_rules! zero {


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

This PR adds a `# Safety` section to the documentation for the unsafe `fallback::DisjointBitOr::disjoint_bitor` method.

The method previously referred readers to `core::intrinsics::disjoint_bitor`, whose documentation already describes the required safety invariant. This change copies that invariant into the fallback trait method documentation directly, using `self` and `other` to match the method parameters.

No behavior changes.