### PR TITLE
Allow BackwardIncompatibleDropHint in polonius legacy

### DIFF
--- a/compiler/rustc_borrowck/src/polonius/legacy/loan_invalidations.rs
+++ b/compiler/rustc_borrowck/src/polonius/legacy/loan_invalidations.rs
@@ -70,7 +70,9 @@ impl<'a, 'tcx> Visitor<'tcx> for LoanInvalidationsGenerator<'a, 'tcx> {
             // Doesn't have any language semantics
             | StatementKind::Coverage(..)
             // Does not actually affect borrowck
-            | StatementKind::StorageLive(..) => {}
+            | StatementKind::StorageLive(..)
+            // Does not affect borrowck
+            | StatementKind::BackwardIncompatibleDropHint { .. } => {}
             StatementKind::StorageDead(local) => {
                 self.access_place(
                     location,
@@ -81,7 +83,6 @@ impl<'a, 'tcx> Visitor<'tcx> for LoanInvalidationsGenerator<'a, 'tcx> {
             }
             StatementKind::ConstEvalCounter
             | StatementKind::Nop
-            | StatementKind::BackwardIncompatibleDropHint { .. }
             | StatementKind::SetDiscriminant { .. } => {
                 bug!("Statement not allowed in this MIR phase")
             }

--- a/tests/ui/nll/polonius/allow-backward-incompatible-drop-hint.rs
+++ b/tests/ui/nll/polonius/allow-backward-incompatible-drop-hint.rs
@@ -1,5 +1,7 @@
-//@ known-bug: #157568
+// Test for issue #157568
 //@ compile-flags: -Zpolonius
+//@ check-pass
+
 #![warn(rust_2024_compatibility)]
 pub struct F;
 impl std::fmt::Debug for F {
@@ -7,4 +9,5 @@ impl std::fmt::Debug for F {
         f.debug_struct("F").finish_non_exhaustive()
     }
 }
+
 fn main() {}


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/158384)*
<!-- homu-ignore:end -->

Fixes rust-lang/rust#157568.

Very simple fix to make `StatementKind::BackwardIncompatibleDropHint` a noop and prevent it from panicking when collecting loan invalidations while running `-Zpolonius=legacy`.