### PR TITLE
Fix: auto trait, const trait bound

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/auto_trait.rs
+++ b/compiler/rustc_trait_selection/src/traits/auto_trait.rs
@@ -607,6 +607,12 @@ impl<'tcx> AutoTraitFinder<'tcx> {
                     // if possible.
                     predicates.push_back(bound_predicate.rebind(p));
                 }
+                ty::PredicateKind::Clause(ty::ClauseKind::HostEffect(p)) => {
+                    let p = bound_predicate.rebind(p);
+                    if self.is_param_no_infer(p.skip_binder().trait_ref.args) && is_new_pred {
+                        self.add_user_pred(computed_preds, predicate);
+                    }
+                }
                 ty::PredicateKind::Clause(ty::ClauseKind::Projection(p)) => {
                     let p = bound_predicate.rebind(p);
                     debug!(
@@ -811,8 +817,7 @@ impl<'tcx> AutoTraitFinder<'tcx> {
                 | ty::PredicateKind::DynCompatible(..)
                 | ty::PredicateKind::Subtype(..)
                 | ty::PredicateKind::Coerce(..)
-                | ty::PredicateKind::Clause(ty::ClauseKind::UnstableFeature(_))
-                | ty::PredicateKind::Clause(ty::ClauseKind::HostEffect(..)) => {}
+                | ty::PredicateKind::Clause(ty::ClauseKind::UnstableFeature(_)) => {}
                 ty::PredicateKind::Ambiguous => return false,
 
                 // FIXME(generic_const_exprs): you can absolutely add this as a where clauses

--- a/tests/rustdoc-ui/synthetic-auto-trait-impls/const-trait-bound.rs
+++ b/tests/rustdoc-ui/synthetic-auto-trait-impls/const-trait-bound.rs
@@ -1,0 +1,14 @@
+// We used to ICE here while trying to synthesize auto trait impls.
+//@ check-pass
+
+#![feature(const_default)]
+#![feature(const_trait_impl)]
+
+pub struct Inner<T>(T);
+
+pub struct Outer<T>(Inner<T>);
+
+impl<T> Unpin for Inner<T>
+where
+    T: const std::default::Default,
+{}


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Split from https://github.com/rust-lang/rust/pull/158346. I was fiddling about with the code to understand the behaviour of the snippet below, got confused, and somehow fixed something 🤷

```rust
#![feature(const_trait_impl)]

pub struct Outer<T>(Inner<T>);
struct Inner<T>(T);

impl<T> Unpin for Inner<T>
where
    T: const std::default::Default,
{}
```

Fixes https://github.com/rust-lang/rust/issues/149281