### PR TITLE
Generate synthetic generic args only for delegation's child segment

### DIFF
--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/generics.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/generics.rs
@@ -6,7 +6,7 @@ use rustc_errors::{
 };
 use rustc_hir::def::{DefKind, Res};
 use rustc_hir::def_id::DefId;
-use rustc_hir::{self as hir, DelegationInfo, GenericArg};
+use rustc_hir::{self as hir, GenericArg};
 use rustc_middle::ty::{
     self, GenericArgsRef, GenericParamDef, GenericParamDefKind, IsSuggestable, Ty,
 };
@@ -431,15 +431,12 @@ pub(crate) fn check_generic_arg_count(
     }
 
     let tcx = cx.tcx();
-    let parent_def = tcx.hir_get_parent_item(seg.hir_id).def_id;
 
     // Suppress this warning for delegations as it is compiler generated and lifetimes are
     // propagated while late-bound lifetimes may be present.
-    let explicit_late_bound = match tcx.hir_opt_delegation_info(parent_def) {
-        Some(DelegationInfo { child_seg_id, .. }) if seg.hir_id == *child_seg_id => {
-            ExplicitLateBound::No
-        }
-        _ => prohibit_explicit_late_bound_lifetimes(cx, gen_params, gen_args, gen_pos),
+    let explicit_late_bound = match tcx.hir_is_delegation_child_segment(seg) {
+        true => ExplicitLateBound::No,
+        false => prohibit_explicit_late_bound_lifetimes(cx, gen_params, gen_args, gen_pos),
     };
 
     let mut invalid_args = vec![];

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
@@ -716,6 +716,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             generic_args: &'a GenericArgs<'tcx>,
             span: Span,
             infer_args: bool,
+            create_synth_args: bool,
             incorrect_args: &'a Result<(), GenericArgCountMismatch>,
         }
 
@@ -828,7 +829,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                                 .instantiate(tcx, preceding_args)
                                 .skip_norm_wip()
                                 .into()
-                        } else if synthetic {
+                        } else if self.create_synth_args && synthetic {
                             Ty::new_param(tcx, param.index, param.name).into()
                         } else if infer_args {
                             self.lowerer.ty_infer(Some(param), self.span).into()
@@ -868,6 +869,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             span,
             generic_args: segment.args(),
             infer_args: segment.infer_args,
+            create_synth_args: tcx.hir_is_delegation_child_segment(segment),
             incorrect_args: &arg_count.correct,
         };
 

--- a/compiler/rustc_middle/src/hir/map.rs
+++ b/compiler/rustc_middle/src/hir/map.rs
@@ -879,6 +879,13 @@ impl<'tcx> TyCtxt<'tcx> {
         self.hir_opt_delegation_info(delegation_id).expect("processing delegation")
     }
 
+    pub fn hir_is_delegation_child_segment(self, segment: &PathSegment<'_>) -> bool {
+        let parent_def = self.hir_get_parent_item(segment.hir_id).def_id;
+
+        self.hir_opt_delegation_info(parent_def)
+            .is_some_and(|info| info.child_seg_id == segment.hir_id)
+    }
+
     #[inline]
     fn hir_opt_ident(self, id: HirId) -> Option<Ident> {
         match self.hir_node(id) {

--- a/tests/ui/const-generics/mgca/synth-gen-arg-ice-158152.rs
+++ b/tests/ui/const-generics/mgca/synth-gen-arg-ice-158152.rs
@@ -1,0 +1,11 @@
+#![feature(min_generic_const_args)]
+
+trait A<T> {}
+trait Trait<const N: usize> {}
+
+impl A<[usize; fn_item]> for () {}
+
+fn fn_item(_: impl Trait<usize>) {}
+//~^ ERROR: type provided when a constant was expected
+
+fn main() {}

--- a/tests/ui/const-generics/mgca/synth-gen-arg-ice-158152.stderr
+++ b/tests/ui/const-generics/mgca/synth-gen-arg-ice-158152.stderr
@@ -1,0 +1,14 @@
+error[E0747]: type provided when a constant was expected
+  --> $DIR/synth-gen-arg-ice-158152.rs:8:26
+   |
+LL | fn fn_item(_: impl Trait<usize>) {}
+   |                          ^^^^^
+   |
+help: if this generic argument was intended as a const parameter, surround it with braces
+   |
+LL | fn fn_item(_: impl Trait<{ usize }>) {}
+   |                          +       +
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0747`.


### PR DESCRIPTION
Fixes rust-lang/rust#158152 by generating synthetic generic args only for delegation's child segment.

r? @petrochenkov
cc @fmease