### PR TITLE
delegation: support simplest output `Self` mapping

### DIFF
--- a/compiler/rustc_ast_lowering/src/delegation.rs
+++ b/compiler/rustc_ast_lowering/src/delegation.rs
@@ -53,7 +53,7 @@ use rustc_middle::span_bug;
 use rustc_middle::ty::{Asyncness, PerOwnerResolverData};
 use rustc_span::def_id::{DefId, LocalDefId};
 use rustc_span::symbol::kw;
-use rustc_span::{ErrorGuaranteed, Ident, Span, Symbol};
+use rustc_span::{ErrorGuaranteed, Ident, Span, Symbol, sym};
 
 use crate::delegation::generics::{GenericsGenerationResult, GenericsGenerationResults};
 use crate::diagnostics::{
@@ -661,11 +661,34 @@ impl<'hir> LoweringContext<'_, 'hir> {
 
         let callee_path = self.arena.alloc(self.mk_expr(hir::ExprKind::Path(new_path), span));
         let args = self.arena.alloc_from_iter(args);
-        let call = self.arena.alloc(self.mk_expr(hir::ExprKind::Call(callee_path, args), span));
+        let call = self.mk_expr(hir::ExprKind::Call(callee_path, args), span);
+
+        let expr = if let Some((parent, of_trait)) = self.should_wrap_return_value(delegation) {
+            let res = Res::SelfTyAlias { alias_to: parent.to_def_id(), is_trait_impl: of_trait };
+            let ident = Ident::new(kw::SelfUpper, span);
+            let path = self.create_resolved_path(res, ident, span);
+
+            // FIXME(fn_delegation): add default `..` for all other fields.
+            let initializer = hir::ExprKind::Struct(
+                self.arena.alloc(path),
+                self.arena.alloc_slice(&[hir::ExprField {
+                    hir_id: self.next_id(),
+                    is_shorthand: false,
+                    ident: Ident::new(sym::integer(0), span),
+                    expr: self.arena.alloc(call),
+                    span,
+                }]),
+                hir::StructTailExpr::None,
+            );
+
+            self.arena.alloc(self.mk_expr(initializer, span))
+        } else {
+            self.arena.alloc(call)
+        };
 
         let block = self.arena.alloc(hir::Block {
             stmts,
-            expr: Some(call),
+            expr: Some(expr),
             hir_id: self.next_id(),
             rules: hir::BlockCheckMode::DefaultBlock,
             span,
@@ -673,6 +696,45 @@ impl<'hir> LoweringContext<'_, 'hir> {
         });
 
         (self.mk_expr(hir::ExprKind::Block(block, None), span), call.hir_id)
+    }
+
+    fn should_wrap_return_value(&self, delegation: &Delegation) -> Option<(LocalDefId, bool)> {
+        // Heuristic: don't do wrapping if there is no target expression.
+        if delegation.body.is_none() {
+            return None;
+        }
+
+        let tcx = self.tcx;
+        let parent = tcx.local_parent(self.owner.def_id);
+        let parent_kind = tcx.def_kind(parent);
+
+        // Apply wrapping for delegations inside
+        // 1) Trait impls, as the return type of both signature function
+        //    and generated delegation has `Self` generic param returned
+        //    (checked below).
+        //    FIXME(fn_delegation): think of enabling wrapping in more scenarios:
+        //      trait-(impl)-to-free
+        //      trait-(impl)-to-inherent
+        //      inherent-to-free
+        // 2) Inherent methods when delegating to trait, as we change the type of
+        //    `Self` to type of struct or enum we delegate from.
+        if !matches!(tcx.def_kind(parent), DefKind::Impl { .. }) {
+            return None;
+        }
+
+        let is_trait_impl = parent_kind == DefKind::Impl { of_trait: true };
+
+        // Check that delegation path resolves to a trait AssocFn, not to a free method.
+        Some((parent, is_trait_impl)).filter(|_| {
+            self.get_resolution_id(delegation.id).is_some_and(|id| {
+                tcx.def_kind(id) == DefKind::AssocFn
+                    // Check that the return type of the callee is `Self` param.
+                    // After previous check we are sure that `sig_id` and `delegation.id`
+                    // point to the same function.
+                    && tcx.def_kind(tcx.parent(id)) == DefKind::Trait
+                    && tcx.fn_sig(id).skip_binder().output().skip_binder().is_param(0)
+            })
+        })
     }
 
     fn process_segment(

--- a/compiler/rustc_ast_lowering/src/delegation/generics.rs
+++ b/compiler/rustc_ast_lowering/src/delegation/generics.rs
@@ -581,18 +581,27 @@ impl<'hir> LoweringContext<'_, 'hir> {
             p.def_id.to_def_id(),
         );
 
+        self.create_resolved_path(res, p.name.ident(), p.span)
+    }
+
+    pub(super) fn create_resolved_path(
+        &mut self,
+        res: Res,
+        ident: Ident,
+        span: Span,
+    ) -> hir::QPath<'hir> {
         hir::QPath::Resolved(
             None,
             self.arena.alloc(hir::Path {
                 segments: self.arena.alloc_slice(&[hir::PathSegment {
                     args: None,
                     hir_id: self.next_id(),
-                    ident: p.name.ident(),
+                    ident,
                     infer_args: false,
                     res,
                 }]),
                 res,
-                span: p.span,
+                span,
             }),
         )
     }

--- a/tests/pretty/delegation/self-mapping-output.pp
+++ b/tests/pretty/delegation/self-mapping-output.pp
@@ -1,0 +1,44 @@
+#![attr = Feature([fn_delegation#0])]
+extern crate std;
+#[attr = PreludeImport]
+use ::std::prelude::rust_2015::*;
+//@ pretty-compare-only
+//@ pretty-mode:hir
+//@ pp-exact:self-mapping-output.pp
+
+
+trait Trait {
+    fn method(&self)
+    -> Self;
+    fn r#static()
+    -> Self;
+    fn raw_S(&self) -> S { S }
+}
+
+struct S;
+impl Trait for S {
+    fn method(&self) -> S { S }
+    fn r#static() -> S { S }
+}
+
+struct W(S);
+impl Trait for W {
+    #[attr = Inline(Hint)]
+    fn method(self: _) -> _ { Self { 0: Trait::method(self.0) } }
+    #[attr = Inline(Hint)]
+    fn r#static() -> _ { Trait::r#static() }
+    //~^ WARN: function cannot return without recursing [unconditional_recursion]
+    #[attr = Inline(Hint)]
+    fn raw_S(self: _) -> _ { Trait::raw_S(self.0) }
+}
+
+impl W {
+    #[attr = Inline(Hint)]
+    fn method(self: _) -> _ { Self { 0: Trait::method(self.0) } }
+    #[attr = Inline(Hint)]
+    fn r#static() -> _ { Trait::r#static() }
+    #[attr = Inline(Hint)]
+    fn raw_S(self: _) -> _ { Trait::raw_S(self.0) }
+}
+
+fn main() { }

--- a/tests/pretty/delegation/self-mapping-output.rs
+++ b/tests/pretty/delegation/self-mapping-output.rs
@@ -1,0 +1,33 @@
+//@ pretty-compare-only
+//@ pretty-mode:hir
+//@ pp-exact:self-mapping-output.pp
+
+#![feature(fn_delegation)]
+
+trait Trait {
+    fn method(&self) -> Self;
+    fn r#static() -> Self;
+    fn raw_S(&self) -> S { S }
+}
+
+struct S;
+impl Trait for S {
+    fn method(&self) -> S { S }
+    fn r#static() -> S { S }
+}
+
+struct W(S);
+impl Trait for W {
+    reuse Trait::method { self.0 }
+    reuse Trait::r#static;
+    //~^ WARN: function cannot return without recursing [unconditional_recursion]
+    reuse Trait::raw_S { self.0 }
+}
+
+impl W {
+    reuse Trait::method { self.0 }
+    reuse Trait::r#static;
+    reuse Trait::raw_S { self.0 }
+}
+
+fn main() {}

--- a/tests/ui/delegation/self-mapping-output-privacy.rs
+++ b/tests/ui/delegation/self-mapping-output-privacy.rs
@@ -1,0 +1,28 @@
+#![feature(fn_delegation)]
+
+trait Trait {
+    fn method(&self) -> Self;
+}
+
+pub struct S;
+impl Trait for S {
+    fn method(&self) -> S {
+        S
+    }
+}
+
+mod private {
+    pub struct W(super::S);
+}
+
+impl Trait for private::W {
+    reuse Trait::method { S }
+    //~^ ERROR: field `0` of struct `W` is private
+}
+
+impl private::W {
+    reuse Trait::method { S }
+    //~^ ERROR: field `0` of struct `W` is private
+}
+
+fn main() {}

--- a/tests/ui/delegation/self-mapping-output-privacy.stderr
+++ b/tests/ui/delegation/self-mapping-output-privacy.stderr
@@ -1,0 +1,15 @@
+error[E0451]: field `0` of struct `W` is private
+  --> $DIR/self-mapping-output-privacy.rs:19:18
+   |
+LL |     reuse Trait::method { S }
+   |                  ^^^^^^ private field
+
+error[E0451]: field `0` of struct `W` is private
+  --> $DIR/self-mapping-output-privacy.rs:24:18
+   |
+LL |     reuse Trait::method { S }
+   |                  ^^^^^^ private field
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0451`.

--- a/tests/ui/delegation/self-mapping-output.rs
+++ b/tests/ui/delegation/self-mapping-output.rs
@@ -1,0 +1,357 @@
+#![feature(fn_delegation)]
+
+mod success {
+    trait Trait {
+        fn method(&self) -> Self;
+        fn r#static() -> Self;
+        fn raw_S(&self) -> S { S }
+    }
+
+    struct S;
+    impl Trait for S {
+        fn method(&self) -> S { S }
+        fn r#static() -> S { S }
+    }
+
+    struct W(S);
+    impl Trait for W {
+        reuse Trait::method { self.0 }
+        reuse Trait::r#static;
+        //~^ WARN: function cannot return without recursing [unconditional_recursion]
+        reuse Trait::raw_S { self.0 }
+    }
+
+    impl W {
+        reuse Trait::method { self.0 }
+        reuse Trait::r#static;
+        reuse Trait::raw_S { self.0 }
+    }
+}
+
+mod success_non_field {
+    trait Trait {
+        fn method(&self) -> Self;
+        fn r#static() -> Self;
+        fn raw_S(&self) -> S { S }
+    }
+
+    struct S;
+    impl Trait for S {
+        fn method(&self) -> S { S }
+        fn r#static() -> S { S }
+    }
+
+    struct W(S);
+    impl Trait for W {
+        reuse Trait::method { S }
+        reuse Trait::r#static;
+        //~^ WARN: function cannot return without recursing [unconditional_recursion]
+        reuse Trait::raw_S { S }
+    }
+
+    impl W {
+        reuse Trait::method { S }
+        reuse Trait::r#static;
+        reuse Trait::raw_S { S }
+    }
+}
+
+mod success_generics {
+    trait Trait<'a, T, const N: usize> {
+        fn method(&self) -> Self;
+        fn r#static() -> Self;
+        fn raw_S(&self) -> S<'a, 'static, T, (), N, 123> {
+            S::<'a, 'static, T, (), N, 123>(std::marker::PhantomData)
+        }
+    }
+
+    struct S<'a, 'b, A, B, const N: usize, const M: usize>(
+        std::marker::PhantomData<&'a &'b (A, B, &'a [(); N], &'b [(); M])>
+    );
+
+    impl<'a, T, const N: usize> Trait<'a, T, N> for S<'a, 'static, T, (), N, 123> {
+        fn method(&self) -> S<'a, 'static, T, (), N, 123> {
+            S(std::marker::PhantomData)
+        }
+
+        fn r#static() -> S<'a, 'static, T, (), N, 123> { S(std::marker::PhantomData) }
+    }
+
+    struct W<'a, 'b, A, B, const N: usize, const M: usize>(S<'a, 'b, A, B, N, M>);
+    impl<'a, T, const N: usize> Trait<'a, T, N> for W<'a, 'static, T, (), N, 123> {
+        reuse Trait::<'a, T, N>::method { self.0 }
+        reuse Trait::<'a, T, N>::r#static;
+        //~^ WARN: function cannot return without recursing [unconditional_recursion]
+        reuse Trait::<'a, T, N>::raw_S { self.0 }
+    }
+
+    impl<'a, T, const N: usize> W<'a, 'static, T, (), N, 123> {
+        reuse Trait::<'a, T, N>::method { self.0 }
+        reuse Trait::<'a, T, N>::r#static;
+        reuse Trait::<'a, T, N>::raw_S { self.0 }
+    }
+}
+
+mod no_constructor {
+    trait Trait {
+        fn method(&self) -> Self;
+        fn r#static() -> Self;
+        fn raw_S(&self) -> S { S }
+    }
+
+    struct S;
+    impl Trait for S {
+        fn method(&self) -> S { S }
+        fn r#static() -> S { S }
+    }
+
+    struct W { s: S }
+    impl Trait for W {
+        reuse Trait::method { self.0 }
+        //~^ ERROR: no field `0` on type `&no_constructor::W`
+        //~| ERROR: struct `no_constructor::W` has no field named `0`
+        reuse Trait::r#static;
+        //~^ WARN: function cannot return without recursing [unconditional_recursion]
+        reuse Trait::raw_S { self.0 }
+        //~^ ERROR: no field `0` on type `&no_constructor::W`
+    }
+
+    impl W {
+        reuse Trait::method { self.0 }
+        //~^ ERROR: no field `0` on type `&no_constructor::W`
+        //~| ERROR: struct `no_constructor::W` has no field named `0`
+        reuse Trait::r#static;
+        reuse Trait::raw_S { self.0 }
+        //~^ ERROR: no field `0` on type `&no_constructor::W`
+    }
+}
+
+mod more_than_one_field {
+    trait Trait {
+        fn method(&self) -> Self;
+        fn r#static() -> Self;
+        fn raw_S(&self) -> S { S }
+    }
+
+    struct S;
+    impl Trait for S {
+        fn method(&self) -> S { S }
+        fn r#static() -> S { S }
+    }
+
+    struct W(S, S, S);
+    impl Trait for W {
+        reuse Trait::method { self.0 }
+        //~^ ERROR: missing fields `1` and `2` in initializer of `more_than_one_field::W`
+        reuse Trait::r#static;
+        //~^ WARN: function cannot return without recursing [unconditional_recursion]
+        reuse Trait::raw_S { self.0 }
+    }
+
+    impl W {
+        reuse Trait::method { self.0 }
+        //~^ ERROR: missing fields `1` and `2` in initializer of `more_than_one_field::W`
+        reuse Trait::r#static;
+        reuse Trait::raw_S { self.0 }
+    }
+}
+
+mod non_trait_path_reuse {
+    trait Trait {
+        fn method(&self) -> Self;
+        fn r#static() -> Self;
+        fn raw_S(&self) -> S { S }
+    }
+
+    mod to_reuse {
+        pub fn method(_: impl super::Trait) -> impl super::Trait {
+            super::S
+        }
+
+        pub fn r#static() -> impl super::Trait {
+            super::S
+        }
+    }
+
+    pub struct S;
+    impl Trait for S {
+        fn method(&self) -> S { S }
+        fn r#static() -> S { S }
+    }
+
+    struct W(S);
+    impl Trait for W {
+        reuse to_reuse::method { self.0 }
+        //~^ ERROR: mismatched types
+        reuse to_reuse::r#static;
+        //~^ ERROR: mismatched types
+    }
+
+    impl W {
+        reuse to_reuse::method { self.0 }
+        //~^ ERROR: no field `0` on type `impl super::Trait`
+        reuse to_reuse::r#static;
+    }
+}
+
+mod non_Self_return_type {
+    trait Trait {
+        fn method(&self) -> ();
+        fn r#static() -> ();
+        fn raw_S(&self) -> S { S }
+    }
+
+    struct S;
+    impl Trait for S {
+        fn method(&self) -> () { () }
+        fn r#static() -> () { () }
+        fn raw_S(&self) -> S { S }
+    }
+
+    struct W(());
+    impl Trait for W {
+        reuse Trait::method { self.0 }
+        //~^ ERROR: mismatched types
+
+        reuse Trait::r#static;
+        //~^ ERROR: type annotations needed
+
+        reuse Trait::raw_S { self.0 }
+        //~^ ERROR: mismatched types
+    }
+
+    impl W {
+        reuse Trait::method { self.0 }
+        //~^ ERROR: mismatched types
+
+        reuse Trait::r#static;
+        //~^ ERROR: type annotations needed
+
+        reuse Trait::raw_S { self.0 }
+        //~^ ERROR: mismatched types
+    }
+}
+
+mod wrong_return_type {
+    trait Trait {
+        fn method(&self) -> Self;
+        fn r#static() -> Self;
+        fn raw_S(&self) -> S { S }
+    }
+
+    struct F;
+    impl Trait for F {
+        fn method(&self) -> F { F }
+        fn r#static() -> F { F }
+    }
+
+    struct S;
+    impl Trait for S {
+        fn method(&self) -> S { S }
+        fn r#static() -> S { S }
+    }
+
+    struct W(S);
+    impl Trait for W {
+        reuse <F as Trait>::method { self.0 }
+        //~^ ERROR: mismatched types
+        //~| ERROR: mismatched types
+
+        reuse <F as Trait>::r#static;
+        //~^ ERROR: mismatched types
+
+        reuse <F as Trait>::raw_S { self.0 }
+        //~^ ERROR: mismatched types
+    }
+
+    impl W {
+        reuse <F as Trait>::method { self.0 }
+        //~^ ERROR: mismatched types
+        //~| ERROR: mismatched types
+
+        reuse <F as Trait>::r#static;
+        //~^ ERROR: mismatched types
+
+        reuse <F as Trait>::raw_S { self.0 }
+        //~^ ERROR: mismatched types
+    }
+}
+
+mod wrong_target_expression {
+    trait Trait {
+        fn method(&self) -> Self;
+        fn r#static() -> Self;
+        fn raw_S(&self) -> S { S }
+    }
+
+    struct S;
+    impl Trait for S {
+        fn method(&self) -> S { S }
+        fn r#static() -> S { S }
+    }
+
+    struct F;
+    impl Trait for F {
+        fn method(&self) -> F { F }
+        fn r#static() -> F { F }
+    }
+
+    struct W(S);
+    impl Trait for W {
+        reuse Trait::method { F }
+        //~^ ERROR: mismatched types
+
+        reuse Trait::r#static;
+        //~^ WARN: function cannot return without recursing [unconditional_recursion]
+        reuse Trait::raw_S { F }
+    }
+
+    impl W {
+        reuse Trait::method { F }
+        //~^ ERROR: mismatched types
+
+        reuse Trait::r#static;
+        reuse Trait::raw_S { F }
+    }
+}
+
+mod privacy {
+    trait Trait {
+        fn method(&self) -> Self;
+        fn r#static() -> Self;
+        fn raw_S(&self) -> S { S }
+    }
+
+    pub struct S;
+    impl Trait for S {
+        fn method(&self) -> S { S }
+        fn r#static() -> S { S }
+    }
+
+    mod private {
+        pub struct W(super::S);
+    }
+
+    impl Trait for private::W {
+        reuse Trait::method { self.0 }
+        //~^ ERROR: field `0` of struct `private::W` is private
+
+        reuse Trait::r#static;
+        //~^ WARN: function cannot return without recursing [unconditional_recursion]
+
+        reuse Trait::raw_S { self.0 }
+        //~^ ERROR: field `0` of struct `private::W` is private
+    }
+
+    impl private::W {
+        reuse Trait::method { self.0 }
+        //~^ ERROR: field `0` of struct `private::W` is private
+
+        reuse Trait::r#static;
+
+        reuse Trait::raw_S { self.0 }
+        //~^ ERROR: field `0` of struct `private::W` is private
+    }
+}
+
+fn main() {}

--- a/tests/ui/delegation/self-mapping-output.stderr
+++ b/tests/ui/delegation/self-mapping-output.stderr
@@ -1,0 +1,468 @@
+error[E0560]: struct `no_constructor::W` has no field named `0`
+  --> $DIR/self-mapping-output.rs:110:22
+   |
+LL |         reuse Trait::method { self.0 }
+   |                      ^^^^^^ unknown field
+   |
+help: a field with a similar name exists
+   |
+LL -         reuse Trait::method { self.0 }
+LL +         reuse Trait::s { self.0 }
+   |
+
+error[E0609]: no field `0` on type `&no_constructor::W`
+  --> $DIR/self-mapping-output.rs:110:36
+   |
+LL |         reuse Trait::method { self.0 }
+   |                                    ^ unknown field
+   |
+help: a field with a similar name exists
+   |
+LL -         reuse Trait::method { self.0 }
+LL +         reuse Trait::method { self.s }
+   |
+
+error[E0609]: no field `0` on type `&no_constructor::W`
+  --> $DIR/self-mapping-output.rs:115:35
+   |
+LL |         reuse Trait::raw_S { self.0 }
+   |                                   ^ unknown field
+   |
+help: a field with a similar name exists
+   |
+LL -         reuse Trait::raw_S { self.0 }
+LL +         reuse Trait::raw_S { self.s }
+   |
+
+error[E0560]: struct `no_constructor::W` has no field named `0`
+  --> $DIR/self-mapping-output.rs:120:22
+   |
+LL |         reuse Trait::method { self.0 }
+   |                      ^^^^^^ unknown field
+   |
+help: a field with a similar name exists
+   |
+LL -         reuse Trait::method { self.0 }
+LL +         reuse Trait::s { self.0 }
+   |
+
+error[E0609]: no field `0` on type `&no_constructor::W`
+  --> $DIR/self-mapping-output.rs:120:36
+   |
+LL |         reuse Trait::method { self.0 }
+   |                                    ^ unknown field
+   |
+help: a field with a similar name exists
+   |
+LL -         reuse Trait::method { self.0 }
+LL +         reuse Trait::method { self.s }
+   |
+
+error[E0609]: no field `0` on type `&no_constructor::W`
+  --> $DIR/self-mapping-output.rs:124:35
+   |
+LL |         reuse Trait::raw_S { self.0 }
+   |                                   ^ unknown field
+   |
+help: a field with a similar name exists
+   |
+LL -         reuse Trait::raw_S { self.0 }
+LL +         reuse Trait::raw_S { self.s }
+   |
+
+error[E0063]: missing fields `1` and `2` in initializer of `more_than_one_field::W`
+  --> $DIR/self-mapping-output.rs:144:22
+   |
+LL |         reuse Trait::method { self.0 }
+   |                      ^^^^^^ missing `1` and `2`
+
+error[E0063]: missing fields `1` and `2` in initializer of `more_than_one_field::W`
+  --> $DIR/self-mapping-output.rs:152:22
+   |
+LL |         reuse Trait::method { self.0 }
+   |                      ^^^^^^ missing `1` and `2`
+
+error[E0308]: mismatched types
+  --> $DIR/self-mapping-output.rs:184:25
+   |
+LL |         pub fn method(_: impl super::Trait) -> impl super::Trait {
+   |                                                ----------------- the found opaque type
+...
+LL |         reuse to_reuse::method { self.0 }
+   |                         ^^^^^^
+   |                         |
+   |                         expected `W`, found opaque type
+   |                         expected `non_trait_path_reuse::W` because of return type
+   |
+   = note:   expected struct `non_trait_path_reuse::W`
+           found opaque type `impl non_trait_path_reuse::Trait`
+
+error[E0308]: mismatched types
+  --> $DIR/self-mapping-output.rs:186:25
+   |
+LL |         pub fn r#static() -> impl super::Trait {
+   |                              ----------------- the found opaque type
+...
+LL |         reuse to_reuse::r#static;
+   |                         ^^^^^^^^
+   |                         |
+   |                         expected `W`, found opaque type
+   |                         expected `non_trait_path_reuse::W` because of return type
+   |
+   = note:   expected struct `non_trait_path_reuse::W`
+           found opaque type `impl non_trait_path_reuse::Trait`
+
+error[E0609]: no field `0` on type `impl super::Trait`
+  --> $DIR/self-mapping-output.rs:191:39
+   |
+LL |         reuse to_reuse::method { self.0 }
+   |                                       ^ unknown field
+
+error[E0308]: mismatched types
+  --> $DIR/self-mapping-output.rs:213:31
+   |
+LL |         reuse Trait::method { self.0 }
+   |                      ------   ^^^^^^ expected `&_`, found `()`
+   |                      |
+   |                      arguments to this function are incorrect
+   |
+   = note: expected reference `&_`
+              found unit type `()`
+note: method defined here
+  --> $DIR/self-mapping-output.rs:199:12
+   |
+LL |         fn method(&self) -> ();
+   |            ^^^^^^  ----
+help: consider borrowing here
+   |
+LL |         reuse Trait::method { &self.0 }
+   |                               +
+
+error[E0283]: type annotations needed
+  --> $DIR/self-mapping-output.rs:216:22
+   |
+LL |         reuse Trait::r#static;
+   |                      ^^^^^^^^ cannot infer type
+   |
+   = note: the type must implement `non_Self_return_type::Trait`
+help: the following types implement trait `non_Self_return_type::Trait`
+  --> $DIR/self-mapping-output.rs:205:5
+   |
+LL |     impl Trait for S {
+   |     ^^^^^^^^^^^^^^^^ `non_Self_return_type::S`
+...
+LL |     impl Trait for W {
+   |     ^^^^^^^^^^^^^^^^ `non_Self_return_type::W`
+
+error[E0308]: mismatched types
+  --> $DIR/self-mapping-output.rs:219:30
+   |
+LL |         reuse Trait::raw_S { self.0 }
+   |                      -----   ^^^^^^ expected `&_`, found `()`
+   |                      |
+   |                      arguments to this function are incorrect
+   |
+   = note: expected reference `&_`
+              found unit type `()`
+note: method defined here
+  --> $DIR/self-mapping-output.rs:201:12
+   |
+LL |         fn raw_S(&self) -> S { S }
+   |            ^^^^^ -----
+help: consider borrowing here
+   |
+LL |         reuse Trait::raw_S { &self.0 }
+   |                              +
+
+error[E0308]: mismatched types
+  --> $DIR/self-mapping-output.rs:224:31
+   |
+LL |         reuse Trait::method { self.0 }
+   |                      ------   ^^^^^^ expected `&_`, found `()`
+   |                      |
+   |                      arguments to this function are incorrect
+   |
+   = note: expected reference `&_`
+              found unit type `()`
+note: method defined here
+  --> $DIR/self-mapping-output.rs:199:12
+   |
+LL |         fn method(&self) -> ();
+   |            ^^^^^^  ----
+help: consider borrowing here
+   |
+LL |         reuse Trait::method { &self.0 }
+   |                               +
+
+error[E0283]: type annotations needed
+  --> $DIR/self-mapping-output.rs:227:22
+   |
+LL |         reuse Trait::r#static;
+   |                      ^^^^^^^^ cannot infer type
+   |
+   = note: the type must implement `non_Self_return_type::Trait`
+help: the following types implement trait `non_Self_return_type::Trait`
+  --> $DIR/self-mapping-output.rs:205:5
+   |
+LL |     impl Trait for S {
+   |     ^^^^^^^^^^^^^^^^ `non_Self_return_type::S`
+...
+LL |     impl Trait for W {
+   |     ^^^^^^^^^^^^^^^^ `non_Self_return_type::W`
+
+error[E0308]: mismatched types
+  --> $DIR/self-mapping-output.rs:230:30
+   |
+LL |         reuse Trait::raw_S { self.0 }
+   |                      -----   ^^^^^^ expected `&_`, found `()`
+   |                      |
+   |                      arguments to this function are incorrect
+   |
+   = note: expected reference `&_`
+              found unit type `()`
+note: method defined here
+  --> $DIR/self-mapping-output.rs:201:12
+   |
+LL |         fn raw_S(&self) -> S { S }
+   |            ^^^^^ -----
+help: consider borrowing here
+   |
+LL |         reuse Trait::raw_S { &self.0 }
+   |                              +
+
+error[E0308]: mismatched types
+  --> $DIR/self-mapping-output.rs:256:38
+   |
+LL |         reuse <F as Trait>::method { self.0 }
+   |                             ------   ^^^^^^ expected `&F`, found `&S`
+   |                             |
+   |                             arguments to this function are incorrect
+   |                             this return type influences the call expression's return type
+   |
+   = note: expected reference `&wrong_return_type::F`
+              found reference `&wrong_return_type::S`
+note: method defined here
+  --> $DIR/self-mapping-output.rs:237:12
+   |
+LL |         fn method(&self) -> Self;
+   |            ^^^^^^  ----
+
+error[E0308]: mismatched types
+  --> $DIR/self-mapping-output.rs:256:29
+   |
+LL |         reuse <F as Trait>::method { self.0 }
+   |                             ^^^^^^ expected `S`, found `F`
+
+error[E0308]: mismatched types
+  --> $DIR/self-mapping-output.rs:260:29
+   |
+LL |         reuse <F as Trait>::r#static;
+   |                             ^^^^^^^^
+   |                             |
+   |                             expected `W`, found `F`
+   |                             expected `wrong_return_type::W` because of return type
+
+error[E0308]: mismatched types
+  --> $DIR/self-mapping-output.rs:263:37
+   |
+LL |         reuse <F as Trait>::raw_S { self.0 }
+   |                             -----   ^^^^^^ expected `&F`, found `&S`
+   |                             |
+   |                             arguments to this function are incorrect
+   |
+   = note: expected reference `&wrong_return_type::F`
+              found reference `&wrong_return_type::S`
+note: method defined here
+  --> $DIR/self-mapping-output.rs:239:12
+   |
+LL |         fn raw_S(&self) -> S { S }
+   |            ^^^^^ -----
+
+error[E0308]: mismatched types
+  --> $DIR/self-mapping-output.rs:268:38
+   |
+LL |         reuse <F as Trait>::method { self.0 }
+   |                             ------   ^^^^^^ expected `&F`, found `&S`
+   |                             |
+   |                             arguments to this function are incorrect
+   |                             this return type influences the call expression's return type
+   |
+   = note: expected reference `&wrong_return_type::F`
+              found reference `&wrong_return_type::S`
+note: method defined here
+  --> $DIR/self-mapping-output.rs:237:12
+   |
+LL |         fn method(&self) -> Self;
+   |            ^^^^^^  ----
+
+error[E0308]: mismatched types
+  --> $DIR/self-mapping-output.rs:268:29
+   |
+LL |         reuse <F as Trait>::method { self.0 }
+   |                             ^^^^^^ expected `S`, found `F`
+
+error[E0308]: mismatched types
+  --> $DIR/self-mapping-output.rs:272:29
+   |
+LL |         reuse <F as Trait>::r#static;
+   |                             ^^^^^^^^
+   |                             |
+   |                             expected `W`, found `F`
+   |                             expected `wrong_return_type::W` because of return type
+
+error[E0308]: mismatched types
+  --> $DIR/self-mapping-output.rs:275:37
+   |
+LL |         reuse <F as Trait>::raw_S { self.0 }
+   |                             -----   ^^^^^^ expected `&F`, found `&S`
+   |                             |
+   |                             arguments to this function are incorrect
+   |
+   = note: expected reference `&wrong_return_type::F`
+              found reference `&wrong_return_type::S`
+note: method defined here
+  --> $DIR/self-mapping-output.rs:239:12
+   |
+LL |         fn raw_S(&self) -> S { S }
+   |            ^^^^^ -----
+
+error[E0308]: mismatched types
+  --> $DIR/self-mapping-output.rs:301:31
+   |
+LL |         reuse Trait::method { F }
+   |                      ------   ^ expected `&S`, found `&F`
+   |                      |
+   |                      arguments to this function are incorrect
+   |                      this return type influences the call expression's return type
+   |
+   = note: expected reference `&wrong_target_expression::S`
+              found reference `&wrong_target_expression::F`
+note: method defined here
+  --> $DIR/self-mapping-output.rs:282:12
+   |
+LL |         fn method(&self) -> Self;
+   |            ^^^^^^  ----
+
+error[E0308]: mismatched types
+  --> $DIR/self-mapping-output.rs:310:31
+   |
+LL |         reuse Trait::method { F }
+   |                      ------   ^ expected `&S`, found `&F`
+   |                      |
+   |                      arguments to this function are incorrect
+   |                      this return type influences the call expression's return type
+   |
+   = note: expected reference `&wrong_target_expression::S`
+              found reference `&wrong_target_expression::F`
+note: method defined here
+  --> $DIR/self-mapping-output.rs:282:12
+   |
+LL |         fn method(&self) -> Self;
+   |            ^^^^^^  ----
+
+error[E0616]: field `0` of struct `private::W` is private
+  --> $DIR/self-mapping-output.rs:336:36
+   |
+LL |         reuse Trait::method { self.0 }
+   |                                    ^ private field
+
+error[E0616]: field `0` of struct `private::W` is private
+  --> $DIR/self-mapping-output.rs:342:35
+   |
+LL |         reuse Trait::raw_S { self.0 }
+   |                                   ^ private field
+
+error[E0616]: field `0` of struct `private::W` is private
+  --> $DIR/self-mapping-output.rs:347:36
+   |
+LL |         reuse Trait::method { self.0 }
+   |                                    ^ private field
+
+error[E0616]: field `0` of struct `private::W` is private
+  --> $DIR/self-mapping-output.rs:352:35
+   |
+LL |         reuse Trait::raw_S { self.0 }
+   |                                   ^ private field
+
+warning: function cannot return without recursing
+  --> $DIR/self-mapping-output.rs:19:22
+   |
+LL |         reuse Trait::r#static;
+   |                      ^^^^^^^^
+   |                      |
+   |                      cannot return without recursing
+   |                      recursive call site
+   |
+   = help: a `loop` may express intention better if this is on purpose
+   = note: `#[warn(unconditional_recursion)]` on by default
+
+warning: function cannot return without recursing
+  --> $DIR/self-mapping-output.rs:47:22
+   |
+LL |         reuse Trait::r#static;
+   |                      ^^^^^^^^
+   |                      |
+   |                      cannot return without recursing
+   |                      recursive call site
+   |
+   = help: a `loop` may express intention better if this is on purpose
+
+warning: function cannot return without recursing
+  --> $DIR/self-mapping-output.rs:83:34
+   |
+LL |         reuse Trait::<'a, T, N>::r#static;
+   |                                  ^^^^^^^^
+   |                                  |
+   |                                  cannot return without recursing
+   |                                  recursive call site
+   |
+   = help: a `loop` may express intention better if this is on purpose
+
+warning: function cannot return without recursing
+  --> $DIR/self-mapping-output.rs:113:22
+   |
+LL |         reuse Trait::r#static;
+   |                      ^^^^^^^^
+   |                      |
+   |                      cannot return without recursing
+   |                      recursive call site
+   |
+   = help: a `loop` may express intention better if this is on purpose
+
+warning: function cannot return without recursing
+  --> $DIR/self-mapping-output.rs:146:22
+   |
+LL |         reuse Trait::r#static;
+   |                      ^^^^^^^^
+   |                      |
+   |                      cannot return without recursing
+   |                      recursive call site
+   |
+   = help: a `loop` may express intention better if this is on purpose
+
+warning: function cannot return without recursing
+  --> $DIR/self-mapping-output.rs:304:22
+   |
+LL |         reuse Trait::r#static;
+   |                      ^^^^^^^^
+   |                      |
+   |                      cannot return without recursing
+   |                      recursive call site
+   |
+   = help: a `loop` may express intention better if this is on purpose
+
+warning: function cannot return without recursing
+  --> $DIR/self-mapping-output.rs:339:22
+   |
+LL |         reuse Trait::r#static;
+   |                      ^^^^^^^^
+   |                      |
+   |                      cannot return without recursing
+   |                      recursive call site
+   |
+   = help: a `loop` may express intention better if this is on purpose
+
+error: aborting due to 31 previous errors; 7 warnings emitted
+
+Some errors have detailed explanations: E0063, E0283, E0308, E0560, E0609, E0616.
+For more information about an error, try `rustc --explain E0063`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/158397)*
<!-- homu-ignore:end -->

This PR supports simplest output `Self` mapping for callee path if the following conditions are met (see `should_wrap_return_value`).

Example:
```rust
trait Trait {
    fn method(&self) -> Self;
    fn r#static() -> Self;
    fn raw_S(&self) -> S { S }
}

struct S;
impl Trait for S {
    fn method(&self) -> S { S }
    fn r#static() -> S { S }
}

struct W(S);
impl Trait for W {
    #[attr = Inline(Hint)]
    fn method(self: _) -> _ { Self { 0: Trait::method(self.0) } }
    #[attr = Inline(Hint)]
    fn r#static() -> _ { Trait::r#static() }
    //~^ WARN: function cannot return without recursing [unconditional_recursion]
    #[attr = Inline(Hint)]
    fn raw_S(self: _) -> _ { Trait::raw_S(self.0) }
}

impl W {
    #[attr = Inline(Hint)]
    fn method(self: _) -> _ { Self { 0: Trait::method(self.0) } }
    #[attr = Inline(Hint)]
    fn r#static() -> _ { Trait::r#static() }
    #[attr = Inline(Hint)]
    fn raw_S(self: _) -> _ { Trait::raw_S(self.0) }
}

```

~If the above conditions are met, there is no need to propagate generics of a newtype, as unused generics is an error, thus they should be used in a single field and it can be inferred from the return type of callee path.~

~Accessing signatures through queries produced query cycles in one test, so `with_no_trimmed_paths` was used to prevent it, though it can cause other cycles in other situations maybe.~

Part of rust-lang/rust#118212.
r? @petrochenkov