### PR TITLE
prevent unloading of all GNU/Linux objects by setting `DF_1_NODELETE`

### DIFF
--- a/compiler/rustc_target/src/spec/base/linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/base/linux_gnu.rs
@@ -10,5 +10,16 @@ pub(crate) fn opts() -> TargetOptions {
         base.link_self_contained = crate::spec::LinkSelfContainedDefault::with_linker();
     }
 
+    // glibc supports unloading dynamic libraries through dlclose. However,
+    // unloading dynamic libraries is fundamentally incompatible with assumptions
+    // made by `std` and much of the Rust ecosystem. Notably, the `'static`
+    // lifetime is commonly expected to last until the termination of the abstract
+    // machine, which is required for the soundness of e.g. thread-local destructors.
+    // Hence, we disable unloading for all Rust objects by having the linker set
+    // the DF_1_NODELETE flag. Note that this flag does not make `dlclose` fail,
+    // it will just not have any effect.
+    base.add_pre_link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-Wl,-z,nodelete"]);
+    base.add_pre_link_args(LinkerFlavor::Gnu(Cc::No, Lld::No), &["-z", "nodelete"]);
+
     base
 }


### PR DESCRIPTION
glibc supports unloading dynamic libraries through dlclose. However, unloading dynamic libraries is fundamentally incompatible with assumptions made by `std` and much of the Rust ecosystem. Notably, the `'static` lifetime is commonly expected to last until the termination of the abstract machine, which is required for the soundness of e.g. thread-local destructors. Hence, this PR disables unloading for all GNU/Linux Rust objects by having the linker set the DF_1_NODELETE flag ([LD docs](https://gcc.gnu.org/onlinedocs/gcc/Link-Options.html)/[LLD docs](https://man.archlinux.org/man/extra/lld/ld.lld.1.en#nodelete)). Note that this flag does not make `dlclose` fail, it will just not have any effect.

I suppose this requires a MCP? Not sure how this is handled...