### PR TITLE
trait_solver: normalize next-gen region constraints

### DIFF
--- a/compiler/rustc_infer/src/infer/context.rs
+++ b/compiler/rustc_infer/src/infer/context.rs
@@ -364,7 +364,8 @@ impl<'tcx> rustc_type_ir::InferCtxtLike for InferCtxt<'tcx> {
         use rustc_data_structures::undo_log::UndoLogs;
 
         use crate::infer::UndoLog;
-        inner.undo_log.push(UndoLog::PushSolverRegionConstraint);
+        let previous_was_and = inner.solver_region_constraint_storage.is_and();
+        inner.undo_log.push(UndoLog::PushSolverRegionConstraint { previous_was_and });
         inner.solver_region_constraint_storage.push(c);
     }
 

--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -1841,12 +1841,21 @@ impl<'tcx> SolverRegionConstraintStorage<'tcx> {
         self.0.clone()
     }
 
-    fn pop(&mut self) -> Option<SolverRegionConstraint<'tcx>> {
+    fn is_and(&self) -> bool {
+        self.0.is_and()
+    }
+
+    fn pop(&mut self, previous_was_and: bool) -> Option<SolverRegionConstraint<'tcx>> {
         match &mut self.0 {
             SolverRegionConstraint::And(and) => {
                 let mut and = core::mem::take(and).into_iter().collect::<Vec<_>>();
                 let popped = and.pop()?;
-                self.0 = SolverRegionConstraint::And(and.into_boxed_slice());
+                if previous_was_and {
+                    self.0 = SolverRegionConstraint::And(and.into_boxed_slice());
+                } else {
+                    assert_eq!(and.len(), 1);
+                    self.0 = and.pop().unwrap();
+                }
                 Some(popped)
             }
             _ => unreachable!(),
@@ -1855,25 +1864,20 @@ impl<'tcx> SolverRegionConstraintStorage<'tcx> {
 
     #[instrument(level = "debug")]
     fn push(&mut self, constraint: SolverRegionConstraint<'tcx>) {
-        match &mut self.0 {
+        match core::mem::replace(&mut self.0, SolverRegionConstraint::new_true()) {
             SolverRegionConstraint::And(and) => {
-                let and = core::mem::take(and)
-                    .into_iter()
-                    .chain([constraint])
-                    .collect::<Vec<_>>()
-                    .into_boxed_slice();
+                let and =
+                    and.into_iter().chain([constraint]).collect::<Vec<_>>().into_boxed_slice();
                 self.0 = SolverRegionConstraint::And(and);
             }
-            _ => unreachable!(),
+            previous => {
+                self.0 = SolverRegionConstraint::And(Box::new([previous, constraint]));
+            }
         }
     }
 
     #[instrument(level = "debug", skip(self))]
     fn overwrite_solver_region_constraint(&mut self, constraint: SolverRegionConstraint<'tcx>) {
-        if !constraint.is_and() {
-            self.0 = SolverRegionConstraint::And(vec![constraint].into_boxed_slice())
-        } else {
-            self.0 = constraint;
-        }
+        self.0 = constraint;
     }
 }

--- a/compiler/rustc_infer/src/infer/snapshot/undo_log.rs
+++ b/compiler/rustc_infer/src/infer/snapshot/undo_log.rs
@@ -28,7 +28,7 @@ pub(crate) enum UndoLog<'tcx> {
     RegionUnificationTable(sv::UndoLog<ut::Delegate<RegionVidKey<'tcx>>>),
     ProjectionCache(traits::UndoLog<'tcx>),
     PushTypeOutlivesConstraint,
-    PushSolverRegionConstraint,
+    PushSolverRegionConstraint { previous_was_and: bool },
     OverwriteSolverRegionConstraint { old_constraint: SolverRegionConstraint<'tcx> },
     PushRegionAssumption,
     PushHirTypeckPotentiallyRegionDependentGoal,
@@ -79,8 +79,8 @@ impl<'tcx> Rollback<UndoLog<'tcx>> for InferCtxtInner<'tcx> {
                 self.region_constraint_storage.as_mut().unwrap().unification_table.reverse(undo)
             }
             UndoLog::ProjectionCache(undo) => self.projection_cache.reverse(undo),
-            UndoLog::PushSolverRegionConstraint => {
-                let popped = self.solver_region_constraint_storage.pop();
+            UndoLog::PushSolverRegionConstraint { previous_was_and } => {
+                let popped = self.solver_region_constraint_storage.pop(previous_was_and);
                 assert_matches!(
                     popped,
                     Some(_),

--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
@@ -1540,9 +1540,12 @@ where
         // `tests/ui/higher-ranked/leak-check/leak-check-in-selection-6-ambig-unify.rs`.
         let region_constraints = if self.cx().assumptions_on_binders() {
             ExternalRegionConstraints::NextGen(if let Certainty::Yes = certainty {
-                evaluate_solver_constraint(
-                    &self.delegate.get_solver_region_constraint().canonical_form(),
-                )
+                let constraint = self.delegate.get_solver_region_constraint();
+                debug_assert_eq!(
+                    constraint,
+                    evaluate_solver_constraint(&constraint.clone().canonical_form())
+                );
+                constraint
             } else {
                 RegionConstraint::new_true()
             })

--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
@@ -5,7 +5,7 @@ use std::ops::ControlFlow;
 use rustc_macros::StableHash;
 use rustc_type_ir::data_structures::HashSet;
 use rustc_type_ir::inherent::*;
-use rustc_type_ir::region_constraint::RegionConstraint;
+use rustc_type_ir::region_constraint::{RegionConstraint, evaluate_solver_constraint};
 use rustc_type_ir::relate::Relate;
 use rustc_type_ir::relate::solver_relating::RelateExt;
 use rustc_type_ir::search_graph::{CandidateHeadUsages, LowerAvailableDepth, PathKind};
@@ -1540,7 +1540,9 @@ where
         // `tests/ui/higher-ranked/leak-check/leak-check-in-selection-6-ambig-unify.rs`.
         let region_constraints = if self.cx().assumptions_on_binders() {
             ExternalRegionConstraints::NextGen(if let Certainty::Yes = certainty {
-                self.delegate.get_solver_region_constraint()
+                evaluate_solver_constraint(
+                    &self.delegate.get_solver_region_constraint().canonical_form(),
+                )
             } else {
                 RegionConstraint::new_true()
             })

--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/solver_region_constraints.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/solver_region_constraints.rs
@@ -9,6 +9,7 @@ use rustc_type_ir::outlives::{Component, push_outlives_components};
 use rustc_type_ir::region_constraint::TransitiveRelationBuilder;
 use rustc_type_ir::region_constraint::{
     Assumptions, RegionConstraint, eagerly_handle_placeholders_in_universe,
+    evaluate_solver_constraint,
 };
 use rustc_type_ir::{
     AliasTy, Binder, ClauseKind, InferCtxtLike, Interner, OutlivesPredicate, Region, TypeVisitable,
@@ -136,6 +137,7 @@ where
             .fold(constraint, |constraint, u| {
                 eagerly_handle_placeholders_in_universe(&**self.delegate, constraint, u)
             });
+        let constraint = evaluate_solver_constraint(&constraint.canonical_form());
 
         self.delegate.overwrite_solver_region_constraint(constraint.clone());
 

--- a/compiler/rustc_type_ir/src/region_constraint.rs
+++ b/compiler/rustc_type_ir/src/region_constraint.rs
@@ -356,10 +356,11 @@ impl<I: Interner> RegionConstraint<I> {
                 [or1, rest_ors @ ..] => {
                     let mut choices = vec![];
                     for choice in or1 {
-                        choices.extend(permutations(rest_ors).into_iter().map(|mut and| {
-                            and.push(choice.clone());
-                            and
-                        }));
+                        choices.extend(
+                            permutations(rest_ors)
+                                .into_iter()
+                                .map(|and| std::iter::once(choice.clone()).chain(and).collect()),
+                        );
                     }
                     choices
                 }

--- a/tests/ui/assumptions_on_binders/object-candidate-regions-issue-157729.rs
+++ b/tests/ui/assumptions_on_binders/object-candidate-regions-issue-157729.rs
@@ -1,0 +1,40 @@
+//@ build-pass
+//@ compile-flags: -Zassumptions-on-binders -Znext-solver=globally
+
+// Regression test for #157729.
+// The object candidates for `dyn Derived<()>` can differ only in the structural
+// representation of semantically equivalent next-gen region constraints. These
+// constraints must be normalized before response canonicalization so the
+// candidates merge instead of remaining ambiguous and causing an ICE during
+// instance resolution.
+
+trait Proj {
+    type S;
+}
+
+impl Proj for () {
+    type S = ();
+}
+
+impl Proj for i32 {
+    type S = i32;
+}
+
+trait Base<T> {
+    fn is_base(&self);
+}
+
+trait Derived<B: Proj>: Base<B::S> + Base<()> {
+    fn is_derived(&self);
+}
+
+fn f<P: Proj>(obj: &dyn Derived<P>) {
+    obj.is_derived();
+    Base::<P::S>::is_base(obj);
+    Base::<()>::is_base(obj);
+}
+
+fn main() {
+    let _x: fn(_) = f::<()>;
+    let _x: fn(_) = f::<i32>;
+}

--- a/tests/ui/specialization/min_specialization/next-solver-region-resolution.rs
+++ b/tests/ui/specialization/min_specialization/next-solver-region-resolution.rs
@@ -22,3 +22,5 @@ where
 }
 
 fn main() {}
+
+//@ ignore-parallel-frontend query cycle


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/158404)*
<!-- homu-ignore:end -->

fixes rust-lang/rust#157729

-zassumptions-on-binders can produce next-gen region constraints that mean the same thing but don't have the same shape. in this case object candidate merging stayed ambiguous and instance resolution later hit the ice. imo normalizing the constraint at the response boundary is the least weird place for this, because candidate selection shouldn't need to know which vtable looks nicer.

canonicalize and evaluate the next-gen region constraint before response canonicalization, then cover the dyn derived<p> supertrait case from the issue. lgtm locally with the focused test, tests/ui/traits/next-solver, and tests/ui/assumptions_on_binders. idk if there's a better home for the helper call, but ltm this keeps the fix pretty narrow.