### PR TITLE
rustc_target: Add ARMv8-M related target features

### DIFF
--- a/compiler/rustc_target/src/target_features.rs
+++ b/compiler/rustc_target/src/target_features.rs
@@ -153,6 +153,7 @@ type ImpliedFeatures = &'static [&'static str];
 static ARM_FEATURES: &[(&str, Stability, ImpliedFeatures)] = &[
     // tidy-alphabetical-start
     ("aclass", Unstable(sym::arm_target_feature), &[]),
+    ("acquire-release", Unstable(sym::arm_target_feature), &[]),
     ("aes", Unstable(sym::arm_target_feature), &["neon"]),
     (
         "atomics-32",
@@ -171,6 +172,8 @@ static ARM_FEATURES: &[(&str, Stability, ImpliedFeatures)] = &[
     ("fpregs", Unstable(sym::arm_target_feature), &[]),
     ("i8mm", Unstable(sym::arm_target_feature), &["neon"]),
     ("mclass", Unstable(sym::arm_target_feature), &[]),
+    ("mve", Unstable(sym::arm_target_feature), &["v8.1m.main", "dsp", "fpregs"]),
+    ("mve.fp", Unstable(sym::arm_target_feature), &["mve"]),
     ("neon", Unstable(sym::arm_target_feature), &["vfp3"]),
     ("rclass", Unstable(sym::arm_target_feature), &[]),
     ("sha2", Unstable(sym::arm_target_feature), &["neon"]),
@@ -188,9 +191,13 @@ static ARM_FEATURES: &[(&str, Stability, ImpliedFeatures)] = &[
     ("v5te", Unstable(sym::arm_target_feature), &[]),
     ("v6", Unstable(sym::arm_target_feature), &["v5te"]),
     ("v6k", Unstable(sym::arm_target_feature), &["v6"]),
-    ("v6t2", Unstable(sym::arm_target_feature), &["v6k", "thumb2"]),
+    ("v6m", Unstable(sym::arm_target_feature), &["v6"]),
+    ("v6t2", Unstable(sym::arm_target_feature), &["v6k", "v8m", "thumb2"]),
     ("v7", Unstable(sym::arm_target_feature), &["v6t2"]),
     ("v8", Unstable(sym::arm_target_feature), &["v7"]),
+    ("v8.1m.main", Unstable(sym::arm_target_feature), &["v8m.main"]),
+    ("v8m", Unstable(sym::arm_target_feature), &["v6m"]),
+    ("v8m.main", Unstable(sym::arm_target_feature), &["v7"]),
     ("vfp2", Unstable(sym::arm_target_feature), &[]),
     ("vfp3", Unstable(sym::arm_target_feature), &["vfp2", "d32"]),
     ("vfp4", Unstable(sym::arm_target_feature), &["vfp3"]),
@@ -1073,9 +1080,8 @@ const X86_FEATURES_FOR_CORRECT_FIXED_LENGTH_VECTOR_ABI: &'static [(u64, &'static
 const AARCH64_FEATURES_FOR_CORRECT_FIXED_LENGTH_VECTOR_ABI: &'static [(u64, &'static str)] =
     &[(128, "neon")];
 
-// We might want to add "helium" too.
 const ARM_FEATURES_FOR_CORRECT_FIXED_LENGTH_VECTOR_ABI: &'static [(u64, &'static str)] =
-    &[(128, "neon")];
+    &[(128, "neon"), (128, "mve")];
 
 const AMDGPU_FEATURES_FOR_CORRECT_FIXED_LENGTH_VECTOR_ABI: &'static [(u64, &'static str)] =
     &[(1024, "")];

--- a/tests/ui/check-cfg/target_feature.stderr
+++ b/tests/ui/check-cfg/target_feature.stderr
@@ -14,6 +14,7 @@ LL |     cfg!(target_feature = "_UNEXPECTED_VALUE");
 `7e10`
 `a`
 `aclass`
+`acquire-release`
 `addsubiw`
 `adx`
 `aes`
@@ -223,6 +224,8 @@ LL |     cfg!(target_feature = "_UNEXPECTED_VALUE");
 `mul32high`
 `multivalue`
 `mutable-globals`
+`mve`
+`mve.fp`
 `neon`
 `nnp-assist`
 `nontrapping-fptoint`
@@ -366,6 +369,7 @@ LL |     cfg!(target_feature = "_UNEXPECTED_VALUE");
 `v68`
 `v69`
 `v6k`
+`v6m`
 `v6t2`
 `v7`
 `v71`
@@ -374,6 +378,7 @@ LL |     cfg!(target_feature = "_UNEXPECTED_VALUE");
 `v79`
 `v8`
 `v8.1a`
+`v8.1m.main`
 `v8.2a`
 `v8.3a`
 `v8.4a`
@@ -382,6 +387,8 @@ LL |     cfg!(target_feature = "_UNEXPECTED_VALUE");
 `v8.7a`
 `v8.8a`
 `v8.9a`
+`v8m`
+`v8m.main`
 `v8plus`
 `v9`
 `v9.1a`


### PR DESCRIPTION

This adds the following unstable target features to `feature(arm_target_feature)` (tracking issue: https://github.com/rust-lang/rust/issues/150246):

- `acquire-release`: Armv8 atomic instructions
- `v6m`: Armv6-M instructions (implies `v6`)
- `v8m`: Armv8-M baseline instructions (implies `v6m`) 
- `v8m.main`: Armv8-M mainline instructions (implies `v7`)
- `v8.1m.main`: Armv8.1-M mainline instructions (implies `v8m.main`)
- `mve`: M-Profile Vector Extension (Helium) for integer ops (implies `v8.1m.main`, `dsp`, and `fpregs`)
- `mve.fp`: MVE for integer & float ops (implies `mve`)

The target feature names match with [definitions in LLVM](https://github.com/llvm/llvm-project/blob/llvmorg-22.1.8/llvm/lib/Target/ARM/ARMFeatures.td#L597-L741). The dependencies should also match those in LLVM, unless there is no corresponding feature in Rust.

This also adds `mve` to vector ABI check and resolve this comment.
https://github.com/rust-lang/rust/blob/973ad0d0ab149bde2e96422833c1265c7a5be217/compiler/rustc_target/src/target_features.rs#L1076-L1078

One of the motivations for adding this: In LLVM, the `v8` target feature is not enabled for ARMv8-M targets, and `v8m`/`v8m.main` is enabled instead, so currently there is no way to detect ARMv8-M from target features.

```console
$ rustc +nightly --print cfg --target thumbv8m.main-none-eabihf | grep target_feature
target_feature="fpregs"
target_feature="mclass"
target_feature="thumb-mode"
target_feature="thumb2"
target_feature="v5te"
target_feature="v6"
target_feature="v6k"
target_feature="v6t2"
target_feature="v7"
```

r? @davidtwco 
cc @jonathanpallant

@rustbot label +O-arm +A-target-feature