### PR TITLE
Split `DropGlueNoop` out from `DropGlue` shim

### DIFF
--- a/compiler/rustc_codegen_cranelift/src/abi/mod.rs
+++ b/compiler/rustc_codegen_cranelift/src/abi/mod.rs
@@ -467,7 +467,7 @@ pub(crate) fn codegen_terminator_call<'tcx>(
             }
             // We don't need AsyncDropGlueCtorShim here because it is not `noop func`,
             // it is `func returning noop future`
-            InstanceKind::Shim(ShimKind::DropGlue(_, None)) => {
+            InstanceKind::Shim(ShimKind::DropGlueNoop(_)) => {
                 // empty drop glue - a nop.
                 let dest = target.expect("Non terminating drop_in_place_real???");
                 let ret_block = fx.get_block(dest);
@@ -725,7 +725,7 @@ pub(crate) fn codegen_drop<'tcx>(
     let ret_block = fx.get_block(target);
 
     // AsyncDropGlueCtorShim can't be here
-    if let ty::InstanceKind::Shim(ty::ShimKind::DropGlue(_, None)) = drop_instance.def {
+    if let ty::InstanceKind::Shim(ty::ShimKind::DropGlueNoop(_)) = drop_instance.def {
         // we don't actually need to drop anything
         fx.bcx.ins().jump(ret_block, &[]);
     } else {

--- a/compiler/rustc_codegen_ssa/src/back/symbol_export.rs
+++ b/compiler/rustc_codegen_ssa/src/back/symbol_export.rs
@@ -335,7 +335,7 @@ fn exported_generic_symbols_provider_local<'tcx>(
                     }
                 }
                 MonoItem::Fn(Instance {
-                    def: InstanceKind::Shim(ShimKind::DropGlue(_, Some(ty))),
+                    def: InstanceKind::Shim(ShimKind::DropGlue(_, ty)),
                     args,
                 }) => {
                     // A little sanity-check

--- a/compiler/rustc_codegen_ssa/src/mir/block.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/block.rs
@@ -618,7 +618,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
         let ty = self.monomorphize(ty);
         let drop_fn = Instance::resolve_drop_glue(bx.tcx(), ty);
 
-        if let ty::InstanceKind::Shim(ty::ShimKind::DropGlue(_, None)) = drop_fn.def {
+        if let ty::InstanceKind::Shim(ty::ShimKind::DropGlueNoop(_)) = drop_fn.def {
             // we don't actually need to drop anything.
             return helper.funclet_br(self, bx, target, mergeable_succ, &[]);
         }
@@ -934,7 +934,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                 match instance.def {
                     // We don't need AsyncDropGlueCtorShim here because it is not `noop func`,
                     // it is `func returning noop future`
-                    ty::InstanceKind::Shim(ty::ShimKind::DropGlue(_, None)) => {
+                    ty::InstanceKind::Shim(ty::ShimKind::DropGlueNoop(_)) => {
                         // Empty drop glue; a no-op.
                         let target = target.unwrap();
                         return helper.funclet_br(self, bx, target, mergeable_succ, &[]);

--- a/compiler/rustc_const_eval/src/interpret/call.rs
+++ b/compiler/rustc_const_eval/src/interpret/call.rs
@@ -658,6 +658,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
             | ty::InstanceKind::Shim(ty::ShimKind::ConstructCoroutineInClosure { .. })
             | ty::InstanceKind::Shim(ty::ShimKind::FnPtr(..))
             | ty::InstanceKind::Shim(ty::ShimKind::DropGlue(..))
+            | ty::InstanceKind::Shim(ty::ShimKind::DropGlueNoop(..))
             | ty::InstanceKind::Shim(ty::ShimKind::Clone(..))
             | ty::InstanceKind::Shim(ty::ShimKind::FnPtrAddr(..))
             | ty::InstanceKind::Shim(ty::ShimKind::ThreadLocal(..))

--- a/compiler/rustc_const_eval/src/interpret/step.rs
+++ b/compiler/rustc_const_eval/src/interpret/step.rs
@@ -607,7 +607,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                         enter_trace_span!(M, resolve::resolve_drop_glue, ty = ?place.layout.ty);
                     Instance::resolve_drop_glue(*self.tcx, place.layout.ty)
                 };
-                if let ty::InstanceKind::Shim(ty::ShimKind::DropGlue(_, None)) = instance.def {
+                if let ty::InstanceKind::Shim(ty::ShimKind::DropGlueNoop(_)) = instance.def {
                     // This is the branch we enter if and only if the dropped type has no drop glue
                     // whatsoever. This can happen as a result of monomorphizing a drop of a
                     // generic. In order to make sure that generic and non-generic code behaves

--- a/compiler/rustc_middle/src/mir/pretty.rs
+++ b/compiler/rustc_middle/src/mir/pretty.rs
@@ -218,7 +218,7 @@ impl<'a, 'tcx> MirDumper<'a, 'tcx> {
         // All drop shims have the same DefId, so we have to add the type
         // to get unique file names.
         let shim_disambiguator = match source.instance {
-            ty::InstanceKind::Shim(ty::ShimKind::DropGlue(_, Some(ty))) => {
+            ty::InstanceKind::Shim(ty::ShimKind::DropGlue(_, ty)) => {
                 // Unfortunately, pretty-printed types are not very filename-friendly.
                 // We do some filtering.
                 let mut s = ".".to_owned();

--- a/compiler/rustc_middle/src/mir/visit.rs
+++ b/compiler/rustc_middle/src/mir/visit.rs
@@ -356,10 +356,10 @@ macro_rules! make_mir_visitor {
                             coroutine_closure_def_id: _def_id,
                             receiver_by_ref: _,
                         })
-                        | ty::InstanceKind::Shim(ty::ShimKind::DropGlue(_def_id, None)) => {}
+                        | ty::InstanceKind::Shim(ty::ShimKind::DropGlueNoop(_def_id)) => {}
 
                         ty::InstanceKind::Shim(ty::ShimKind::FnPtr(_def_id, ty))
-                        | ty::InstanceKind::Shim(ty::ShimKind::DropGlue(_def_id, Some(ty)))
+                        | ty::InstanceKind::Shim(ty::ShimKind::DropGlue(_def_id, ty))
                         | ty::InstanceKind::Shim(ty::ShimKind::Clone(_def_id, ty))
                         | ty::InstanceKind::Shim(ty::ShimKind::FnPtrAddr(_def_id, ty))
                         | ty::InstanceKind::Shim(ty::ShimKind::AsyncDropGlue(_def_id, ty))

--- a/compiler/rustc_middle/src/mono.rs
+++ b/compiler/rustc_middle/src/mono.rs
@@ -173,7 +173,7 @@ impl<'tcx> MonoItem<'tcx> {
         // incrementality (which wants small CGUs with as many things GloballyShared as possible).
         // The heuristics implemented here do better than a completely naive approach in the
         // compiler benchmark suite, but there is no reason to believe they are optimal.
-        if let InstanceKind::Shim(ShimKind::DropGlue(_, Some(ty))) = instance.def {
+        if let InstanceKind::Shim(ShimKind::DropGlue(_, ty)) = instance.def {
             if tcx.sess.opts.optimize == OptLevel::No {
                 return InstantiationMode::GloballyShared { may_conflict: false };
             }
@@ -531,6 +531,7 @@ impl<'tcx> CodegenUnit<'tcx> {
                     | InstanceKind::Shim(ShimKind::ClosureOnce { .. })
                     | InstanceKind::Shim(ShimKind::ConstructCoroutineInClosure { .. })
                     | InstanceKind::Shim(ShimKind::DropGlue(..))
+                    | InstanceKind::Shim(ShimKind::DropGlueNoop(..))
                     | InstanceKind::Shim(ShimKind::Clone(..))
                     | InstanceKind::Shim(ShimKind::ThreadLocal(..))
                     | InstanceKind::Shim(ShimKind::FnPtrAddr(..))

--- a/compiler/rustc_middle/src/ty/instance.rs
+++ b/compiler/rustc_middle/src/ty/instance.rs
@@ -156,11 +156,17 @@ pub enum ShimKind<'tcx> {
     /// `core::ptr::drop_glue::<T>`.
     ///
     /// The `DefId` is for `core::ptr::drop_glue`.
-    /// The `Option<Ty<'tcx>>` is either `Some(T)`, or `None` for empty drop glue.
+    /// The `Ty<'tcx>` is for `T`.
+    /// See [`ShimKind::DropGlueNoop`] for no-op drop glue.
     ///
     /// The type must be monomorphic; for polymorphic drop glue use
     /// `rustc_mir_transform::build_drop_shim`.
-    DropGlue(DefId, Option<Ty<'tcx>>),
+    DropGlue(DefId, Ty<'tcx>),
+
+    /// `core::ptr::drop_glue::<T>`.
+    ///
+    /// The `DefId` is for `core::ptr::drop_glue`.
+    DropGlueNoop(DefId),
 
     /// Compiler-generated `<T as Clone>::clone` implementation.
     ///
@@ -234,9 +240,7 @@ impl<'tcx> Instance<'tcx> {
             InstanceKind::Item(def) => tcx
                 .upstream_monomorphizations_for(def)
                 .and_then(|monos| monos.get(&self.args).cloned()),
-            InstanceKind::Shim(ShimKind::DropGlue(_, Some(_))) => {
-                tcx.upstream_drop_glue_for(self.args)
-            }
+            InstanceKind::Shim(ShimKind::DropGlue(_, _)) => tcx.upstream_drop_glue_for(self.args),
             InstanceKind::Shim(ShimKind::AsyncDropGlue(_, _)) => None,
             InstanceKind::Shim(ShimKind::FutureDropPoll(_, _, _)) => None,
             InstanceKind::Shim(ShimKind::AsyncDropGlueCtor(_, _)) => {
@@ -328,6 +332,7 @@ impl<'tcx> ShimKind<'tcx> {
                 receiver_by_ref: _,
             }
             | ShimKind::DropGlue(def_id, _)
+            | ShimKind::DropGlueNoop(def_id)
             | ShimKind::Clone(def_id, _)
             | ShimKind::FnPtrAddr(def_id, _)
             | ShimKind::FutureDropPoll(def_id, _, _)
@@ -339,7 +344,7 @@ impl<'tcx> ShimKind<'tcx> {
     /// Returns the `DefId` of instances which might not require codegen locally.
     pub fn def_id_if_not_guaranteed_local_codegen(self) -> Option<DefId> {
         match self {
-            ShimKind::DropGlue(def_id, Some(_))
+            ShimKind::DropGlue(def_id, _)
             | ShimKind::AsyncDropGlueCtor(def_id, _)
             | ShimKind::AsyncDropGlue(def_id, _)
             | ShimKind::FutureDropPoll(def_id, ..)
@@ -349,7 +354,7 @@ impl<'tcx> ShimKind<'tcx> {
             | ShimKind::FnPtr(..)
             | ShimKind::ClosureOnce { .. }
             | ShimKind::ConstructCoroutineInClosure { .. }
-            | ShimKind::DropGlue(..)
+            | ShimKind::DropGlueNoop(..)
             | ShimKind::Clone(..)
             | ShimKind::FnPtrAddr(..) => None,
         }
@@ -357,7 +362,7 @@ impl<'tcx> ShimKind<'tcx> {
 
     pub fn requires_inline(&self) -> bool {
         match self {
-            ShimKind::DropGlue(_, Some(ty)) => ty.is_array(),
+            ShimKind::DropGlue(_, ty) => ty.is_array(),
             ShimKind::AsyncDropGlueCtor(_, ty) => ty.is_coroutine(),
             ShimKind::FutureDropPoll(_, _, _) => false,
             ShimKind::AsyncDropGlue(_, _) => false,
@@ -372,13 +377,13 @@ impl<'tcx> ShimKind<'tcx> {
             | ShimKind::ThreadLocal(..)
             | ShimKind::FnPtrAddr(..)
             | ShimKind::FnPtr(..)
-            | ShimKind::DropGlue(_, Some(_))
+            | ShimKind::DropGlue(..)
             | ShimKind::FutureDropPoll(..)
             | ShimKind::AsyncDropGlue(_, _) => false,
             ShimKind::AsyncDropGlueCtor(_, _) => false,
             ShimKind::ClosureOnce { .. }
             | ShimKind::ConstructCoroutineInClosure { .. }
-            | ShimKind::DropGlue(..)
+            | ShimKind::DropGlueNoop(..)
             | ShimKind::Reify(..)
             | ShimKind::VTable(..) => true,
         }

--- a/compiler/rustc_middle/src/ty/print/mod.rs
+++ b/compiler/rustc_middle/src/ty/print/mod.rs
@@ -393,8 +393,8 @@ impl<'tcx, P: Printer<'tcx> + std::fmt::Write> Print<P> for ty::ShimKind<'tcx> {
             ty::ShimKind::FnPtr(_, ty) => cx.write_str(&format!("shim({ty})")),
             ty::ShimKind::ClosureOnce { .. } => cx.write_str("shim"),
             ty::ShimKind::ConstructCoroutineInClosure { .. } => cx.write_str("shim"),
-            ty::ShimKind::DropGlue(_, None) => cx.write_str("shim(None)"),
-            ty::ShimKind::DropGlue(_, Some(ty)) => cx.write_str(&format!("shim(Some({ty}))")),
+            ty::ShimKind::DropGlueNoop(_) => cx.write_str("shim(noop)"),
+            ty::ShimKind::DropGlue(_, ty) => cx.write_str(&format!("shim({ty})")),
             ty::ShimKind::Clone(_, ty) => cx.write_str(&format!("shim({ty})")),
             ty::ShimKind::FnPtrAddr(_, ty) => cx.write_str(&format!("shim({ty})")),
             ty::ShimKind::FutureDropPoll(_, proxy_ty, impl_ty) => {

--- a/compiler/rustc_mir_transform/src/coroutine/drop.rs
+++ b/compiler/rustc_mir_transform/src/coroutine/drop.rs
@@ -206,7 +206,7 @@ pub(super) fn create_coroutine_drop_shim<'tcx>(
     // Update the body's def to become the drop glue.
     let coroutine_instance = body.source.instance;
     let drop_glue = tcx.require_lang_item(LangItem::DropGlue, body.span);
-    let drop_instance = InstanceKind::Shim(ShimKind::DropGlue(drop_glue, Some(coroutine_ty)));
+    let drop_instance = InstanceKind::Shim(ShimKind::DropGlue(drop_glue, coroutine_ty));
 
     // Temporary change MirSource to coroutine's instance so that dump_mir produces more sensible
     // filename.

--- a/compiler/rustc_mir_transform/src/inline.rs
+++ b/compiler/rustc_mir_transform/src/inline.rs
@@ -739,7 +739,7 @@ fn check_mir_is_available<'tcx, I: Inliner<'tcx>>(
         // the correct param-env for types being dropped. Stall resolving
         // the MIR for this instance until all of its const params are
         // substituted.
-        InstanceKind::Shim(ShimKind::DropGlue(_, Some(ty)))
+        InstanceKind::Shim(ShimKind::DropGlue(_, ty))
             if ty.has_type_flags(TypeFlags::HAS_CT_PARAM) =>
         {
             debug!("still needs substitution");
@@ -771,6 +771,7 @@ fn check_mir_is_available<'tcx, I: Inliner<'tcx>>(
         | InstanceKind::Shim(ShimKind::ClosureOnce { .. })
         | InstanceKind::Shim(ShimKind::ConstructCoroutineInClosure { .. })
         | InstanceKind::Shim(ShimKind::DropGlue(..))
+        | InstanceKind::Shim(ShimKind::DropGlueNoop(..))
         | InstanceKind::Shim(ShimKind::Clone(..))
         | InstanceKind::Shim(ShimKind::ThreadLocal(..))
         | InstanceKind::Shim(ShimKind::FnPtrAddr(..)) => return Ok(()),
@@ -1373,7 +1374,7 @@ fn try_instance_mir<'tcx>(
     tcx: TyCtxt<'tcx>,
     instance: InstanceKind<'tcx>,
 ) -> Result<&'tcx Body<'tcx>, &'static str> {
-    if let ty::InstanceKind::Shim(ty::ShimKind::DropGlue(_, Some(ty)))
+    if let ty::InstanceKind::Shim(ty::ShimKind::DropGlue(_, ty))
     | ty::InstanceKind::Shim(ty::ShimKind::AsyncDropGlueCtor(_, ty)) = instance
         && let ty::Adt(def, args) = ty.kind()
     {

--- a/compiler/rustc_mir_transform/src/inline/cycle.rs
+++ b/compiler/rustc_mir_transform/src/inline/cycle.rs
@@ -41,6 +41,7 @@ fn should_recurse<'tcx>(tcx: TyCtxt<'tcx>, callee: ty::Instance<'tcx>) -> bool {
         // have its MIR built. Likely oli-obk just screwed up the `ParamEnv`s, so this
         // needs some more analysis.
         InstanceKind::Shim(ShimKind::DropGlue(..))
+        | InstanceKind::Shim(ShimKind::DropGlueNoop(..))
         | InstanceKind::Shim(ShimKind::FutureDropPoll(..))
         | InstanceKind::Shim(ShimKind::AsyncDropGlue(..))
         | InstanceKind::Shim(ShimKind::AsyncDropGlueCtor(..)) => {

--- a/compiler/rustc_mir_transform/src/shim.rs
+++ b/compiler/rustc_mir_transform/src/shim.rs
@@ -81,7 +81,7 @@ fn make_shim<'tcx>(tcx: TyCtxt<'tcx>, shim: ty::ShimKind<'tcx>) -> Body<'tcx> {
         ty::ShimKind::DropGlue(def_id, ty) => {
             // FIXME(#91576): Drop shims for coroutines aren't subject to the MIR passes at the end
             // of this function. Is this intentional?
-            if let Some(&ty::Coroutine(coroutine_def_id, args)) = ty.map(Ty::kind) {
+            if let &ty::Coroutine(coroutine_def_id, args) = ty.kind() {
                 let coroutine_body = tcx.optimized_mir(coroutine_def_id);
 
                 let ty::Coroutine(_, id_args) = *tcx.type_of(coroutine_def_id).skip_binder().kind()
@@ -125,7 +125,10 @@ fn make_shim<'tcx>(tcx: TyCtxt<'tcx>, shim: ty::ShimKind<'tcx>) -> Body<'tcx> {
                 return body;
             }
 
-            build_drop_shim(tcx, def_id, ty, ty::TypingEnv::post_analysis(tcx, def_id))
+            build_drop_shim(tcx, def_id, Some(ty), ty::TypingEnv::post_analysis(tcx, def_id))
+        }
+        ty::ShimKind::DropGlueNoop(def_id) => {
+            build_drop_shim(tcx, def_id, None, ty::TypingEnv::post_analysis(tcx, def_id))
         }
         ty::ShimKind::ThreadLocal(..) => build_thread_local_shim(tcx, shim),
         ty::ShimKind::Clone(def_id, ty) => build_clone_shim(tcx, def_id, ty),
@@ -292,7 +295,9 @@ pub fn build_drop_shim<'tcx>(
     }
     block(&mut blocks, TerminatorKind::Return);
 
-    let source = MirSource::from_shim(ty::ShimKind::DropGlue(def_id, ty));
+    let source = MirSource::from_shim(
+        ty.map_or(ty::ShimKind::DropGlueNoop(def_id), |t| ty::ShimKind::DropGlue(def_id, t)),
+    );
     let mut body =
         new_body(source, blocks, local_decls_for_sig(&sig, span), sig.inputs().len(), span);
 

--- a/compiler/rustc_monomorphize/src/collector.rs
+++ b/compiler/rustc_monomorphize/src/collector.rs
@@ -1016,7 +1016,7 @@ fn visit_instance_use<'tcx>(
         ty::InstanceKind::Shim(ty::ShimKind::ThreadLocal(..)) => {
             bug!("{:?} being reified", instance);
         }
-        ty::InstanceKind::Shim(ty::ShimKind::DropGlue(_, None)) => {
+        ty::InstanceKind::Shim(ty::ShimKind::DropGlueNoop(_)) => {
             // Don't need to emit noop drop glue if we are calling directly.
             //
             // Note that we also optimize away the call to visit_instance_use in vtable construction
@@ -1026,7 +1026,7 @@ fn visit_instance_use<'tcx>(
             }
         }
         ty::InstanceKind::Item(..)
-        | ty::InstanceKind::Shim(ty::ShimKind::DropGlue(_, Some(_)))
+        | ty::InstanceKind::Shim(ty::ShimKind::DropGlue(..))
         | ty::InstanceKind::Shim(ty::ShimKind::FutureDropPoll(..))
         | ty::InstanceKind::Shim(ty::ShimKind::AsyncDropGlue(_, _))
         | ty::InstanceKind::Shim(ty::ShimKind::AsyncDropGlueCtor(_, _))

--- a/compiler/rustc_monomorphize/src/partitioning.rs
+++ b/compiler/rustc_monomorphize/src/partitioning.rs
@@ -638,6 +638,7 @@ fn characteristic_def_id_of_mono_item<'tcx>(
                 | ty::InstanceKind::Shim(ty::ShimKind::ClosureOnce { .. })
                 | ty::InstanceKind::Shim(ty::ShimKind::ConstructCoroutineInClosure { .. })
                 | ty::InstanceKind::Shim(ty::ShimKind::DropGlue(..))
+                | ty::InstanceKind::Shim(ty::ShimKind::DropGlueNoop(..))
                 | ty::InstanceKind::Shim(ty::ShimKind::Clone(..))
                 | ty::InstanceKind::Shim(ty::ShimKind::ThreadLocal(..))
                 | ty::InstanceKind::Shim(ty::ShimKind::FnPtrAddr(..))
@@ -794,7 +795,7 @@ fn mono_item_visibility<'tcx>(
 
     let def_id = match instance.def {
         InstanceKind::Item(def_id)
-        | InstanceKind::Shim(ShimKind::DropGlue(def_id, Some(_)))
+        | InstanceKind::Shim(ShimKind::DropGlue(def_id, _))
         | InstanceKind::Shim(ShimKind::FutureDropPoll(def_id, _, _))
         | InstanceKind::Shim(ShimKind::AsyncDropGlue(def_id, _))
         | InstanceKind::Shim(ShimKind::AsyncDropGlueCtor(def_id, _)) => def_id,
@@ -812,7 +813,7 @@ fn mono_item_visibility<'tcx>(
         | InstanceKind::Intrinsic(..)
         | InstanceKind::Shim(ShimKind::ClosureOnce { .. })
         | InstanceKind::Shim(ShimKind::ConstructCoroutineInClosure { .. })
-        | InstanceKind::Shim(ShimKind::DropGlue(..))
+        | InstanceKind::Shim(ShimKind::DropGlueNoop(..))
         | InstanceKind::Shim(ShimKind::Clone(..))
         | InstanceKind::Shim(ShimKind::FnPtrAddr(..)) => return Visibility::Hidden,
     };
@@ -1332,6 +1333,7 @@ pub(crate) fn provide(providers: &mut Providers) {
             // statements, plus one for the terminator.
             InstanceKind::Item(..)
             | InstanceKind::Shim(ShimKind::DropGlue(..))
+            | InstanceKind::Shim(ShimKind::DropGlueNoop(..))
             | InstanceKind::Shim(ShimKind::AsyncDropGlueCtor(..)) => {
                 let mir = tcx.instance_mir(instance.def);
                 mir.basic_blocks

--- a/compiler/rustc_public_bridge/src/context/impls.rs
+++ b/compiler/rustc_public_bridge/src/context/impls.rs
@@ -645,7 +645,7 @@ impl<'tcx, B: Bridge> CompilerCtxt<'tcx, B> {
 
     /// Check if this is an empty DropGlue shim.
     pub fn is_empty_drop_shim(&self, instance: ty::Instance<'tcx>) -> bool {
-        matches!(instance.def, ty::InstanceKind::Shim(ty::ShimKind::DropGlue(_, None)))
+        matches!(instance.def, ty::InstanceKind::Shim(ty::ShimKind::DropGlueNoop(..)))
     }
 
     /// Convert a non-generic crate item into an instance.

--- a/compiler/rustc_sanitizers/src/cfi/typeid/itanium_cxx_abi/transform.rs
+++ b/compiler/rustc_sanitizers/src/cfi/typeid/itanium_cxx_abi/transform.rs
@@ -310,7 +310,10 @@ pub(crate) fn transform_instance<'tcx>(
     // FIXME: account for async-drop-glue
     if (matches!(instance.def, ty::InstanceKind::Virtual(..))
         && tcx.is_lang_item(instance.def_id(), LangItem::DropGlue))
-        || matches!(instance.def, ty::InstanceKind::Shim(ty::ShimKind::DropGlue(..)))
+        || matches!(
+            instance.def,
+            ty::InstanceKind::Shim(ty::ShimKind::DropGlue(..) | ty::ShimKind::DropGlueNoop(..))
+        )
     {
         // Adjust the type ids of DropGlues
         //

--- a/compiler/rustc_symbol_mangling/src/legacy.rs
+++ b/compiler/rustc_symbol_mangling/src/legacy.rs
@@ -62,7 +62,9 @@ pub(super) fn mangle<'tcx>(
     let mut p = LegacySymbolMangler { tcx, path: SymbolPath::new(), keep_within_component: false };
     p.print_def_path(
         def_id,
-        if let ty::InstanceKind::Shim(ty::ShimKind::DropGlue(_, _))
+        if let ty::InstanceKind::Shim(
+            ty::ShimKind::DropGlue(_, _) | ty::ShimKind::DropGlueNoop(_),
+        )
         | ty::InstanceKind::Shim(ty::ShimKind::AsyncDropGlueCtor(_, _))
         | ty::InstanceKind::Shim(ty::ShimKind::FutureDropPoll(_, _, _)) = instance.def
         {

--- a/compiler/rustc_ty_utils/src/instance.rs
+++ b/compiler/rustc_ty_utils/src/instance.rs
@@ -45,9 +45,9 @@ fn resolve_instance_raw<'tcx>(
                         // FIXME: sync drop of coroutine with async drop (generate both versions?)
                         // Currently just ignored
                         if tcx.optimized_mir(coroutine_def_id).coroutine_drop_async().is_some() {
-                            ty::ShimKind::DropGlue(def_id, None)
+                            ty::ShimKind::DropGlueNoop(def_id)
                         } else {
-                            ty::ShimKind::DropGlue(def_id, Some(ty))
+                            ty::ShimKind::DropGlue(def_id, ty)
                         }
                     }
                     ty::Closure(..)
@@ -57,13 +57,13 @@ fn resolve_instance_raw<'tcx>(
                     | ty::Dynamic(..)
                     | ty::Array(..)
                     | ty::Slice(..)
-                    | ty::UnsafeBinder(..) => ty::ShimKind::DropGlue(def_id, Some(ty)),
+                    | ty::UnsafeBinder(..) => ty::ShimKind::DropGlue(def_id, ty),
                     // Drop shims can only be built from ADTs.
                     _ => return Ok(None),
                 }
             } else {
                 debug!(" => trivial drop glue");
-                ty::ShimKind::DropGlue(def_id, None)
+                ty::ShimKind::DropGlueNoop(def_id)
             };
             ty::InstanceKind::Shim(shim)
         } else if tcx.is_lang_item(def_id, LangItem::AsyncDropInPlace) {

--- a/tests/ui/consts/const-eval/c-variadic-fail.stderr
+++ b/tests/ui/consts/const-eval/c-variadic-fail.stderr
@@ -464,7 +464,7 @@ LL |         drop(ap);
    |         ^^^^^^^^
 note: inside `std::mem::drop::<VaList<'_>>`
   --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
-note: inside `std::ptr::drop_glue::<VaList<'_>> - shim(Some(VaList<'_>))`
+note: inside `std::ptr::drop_glue::<VaList<'_>> - shim(VaList<'_>)`
   --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
 note: inside `<VaList<'_> as Drop>::drop`
   --> $SRC_DIR/core/src/ffi/va_list.rs:LL:COL
@@ -496,7 +496,7 @@ LL |         drop(ap);
    |         ^^^^^^^^
 note: inside `std::mem::drop::<VaList<'_>>`
   --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
-note: inside `std::ptr::drop_glue::<VaList<'_>> - shim(Some(VaList<'_>))`
+note: inside `std::ptr::drop_glue::<VaList<'_>> - shim(VaList<'_>)`
   --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
 note: inside `<VaList<'_> as Drop>::drop`
   --> $SRC_DIR/core/src/ffi/va_list.rs:LL:COL
@@ -549,7 +549,7 @@ error[E0080]: pointer not dereferenceable: pointer must point to some allocation
 LL |     }
    |     ^ evaluation of `drop_of_invalid::{constant#0}` failed inside this call
    |
-note: inside `std::ptr::drop_glue::<VaList<'_>> - shim(Some(VaList<'_>))`
+note: inside `std::ptr::drop_glue::<VaList<'_>> - shim(VaList<'_>)`
   --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
 note: inside `<VaList<'_> as Drop>::drop`
   --> $SRC_DIR/core/src/ffi/va_list.rs:LL:COL

--- a/tests/ui/consts/miri_unleashed/assoc_const.stderr
+++ b/tests/ui/consts/miri_unleashed/assoc_const.stderr
@@ -4,9 +4,9 @@ error[E0080]: calling non-const function `<NotConstDestruct as Drop>::drop`
 LL |     const F: u32 = (U::X, 42).1;
    |                               ^ evaluation of `<NotConstDestruct as Bar<NotConstDestruct, NotConstDestruct>>::F` failed inside this call
    |
-note: inside `std::ptr::drop_glue::<(NotConstDestruct, u32)> - shim(Some((NotConstDestruct, u32)))`
+note: inside `std::ptr::drop_glue::<(NotConstDestruct, u32)> - shim((NotConstDestruct, u32))`
   --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-note: inside `std::ptr::drop_glue::<NotConstDestruct> - shim(Some(NotConstDestruct))`
+note: inside `std::ptr::drop_glue::<NotConstDestruct> - shim(NotConstDestruct)`
   --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
 
 note: erroneous constant encountered

--- a/tests/ui/consts/miri_unleashed/drop.rs
+++ b/tests/ui/consts/miri_unleashed/drop.rs
@@ -22,6 +22,6 @@ static TEST_BAD: () = {
     let _v: NotConstDestruct = NotConstDestruct;
 }; //~ NOTE failed inside this call
    //~| ERROR calling non-const function `<NotConstDestruct as Drop>::drop`
-   //~| NOTE inside `std::ptr::drop_glue::<NotConstDestruct> - shim(Some(NotConstDestruct))`
+   //~| NOTE inside `std::ptr::drop_glue::<NotConstDestruct> - shim(NotConstDestruct)`
 
 //~? WARN skipping const checks

--- a/tests/ui/consts/miri_unleashed/drop.stderr
+++ b/tests/ui/consts/miri_unleashed/drop.stderr
@@ -4,7 +4,7 @@ error[E0080]: calling non-const function `<NotConstDestruct as Drop>::drop`
 LL | };
    | ^ evaluation of `TEST_BAD` failed inside this call
    |
-note: inside `std::ptr::drop_glue::<NotConstDestruct> - shim(Some(NotConstDestruct))`
+note: inside `std::ptr::drop_glue::<NotConstDestruct> - shim(NotConstDestruct)`
   --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
 
 warning: skipping const checks

--- a/tests/ui/consts/qualif-indirect-mutation-fail.stderr
+++ b/tests/ui/consts/qualif-indirect-mutation-fail.stderr
@@ -13,9 +13,9 @@ error[E0080]: calling non-const function `<NotConstDestruct as Drop>::drop`
 LL | };
    | ^ evaluation of `A1` failed inside this call
    |
-note: inside `std::ptr::drop_glue::<Option<NotConstDestruct>> - shim(Some(Option<NotConstDestruct>))`
+note: inside `std::ptr::drop_glue::<Option<NotConstDestruct>> - shim(Option<NotConstDestruct>)`
   --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-note: inside `std::ptr::drop_glue::<NotConstDestruct> - shim(Some(NotConstDestruct))`
+note: inside `std::ptr::drop_glue::<NotConstDestruct> - shim(NotConstDestruct)`
   --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
 
 error[E0493]: destructor of `Option<NotConstDestruct>` cannot be evaluated at compile-time
@@ -32,9 +32,9 @@ error[E0080]: calling non-const function `<NotConstDestruct as Drop>::drop`
 LL | };
    | ^ evaluation of `A2` failed inside this call
    |
-note: inside `std::ptr::drop_glue::<Option<NotConstDestruct>> - shim(Some(Option<NotConstDestruct>))`
+note: inside `std::ptr::drop_glue::<Option<NotConstDestruct>> - shim(Option<NotConstDestruct>)`
   --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-note: inside `std::ptr::drop_glue::<NotConstDestruct> - shim(Some(NotConstDestruct))`
+note: inside `std::ptr::drop_glue::<NotConstDestruct> - shim(NotConstDestruct)`
   --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
 
 error[E0493]: destructor of `(u32, Option<NotConstDestruct>)` cannot be evaluated at compile-time


### PR DESCRIPTION
No-op drop glue is fundamentally very different from regular drop glue. Most importantly, no-op drop glue is polymorphic and the same for all `T`, whereas regular drop glue specifies a concrete type.

r? @oli-obk 