### PR TITLE
Auto-assign, label, and CC lang-docs (+FLS) and edition

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -669,6 +669,27 @@ trigger_files = [
     "src/tools/rustfmt",
 ]
 
+# Language documentation labels
+
+[autolabel."T-lang-docs"]
+trigger_files = [
+    "library/core/src/primitive_docs.rs",
+    "library/std/src/attribute_docs.rs",
+    "library/std/src/keyword_docs.rs",
+    "src/doc/nomicon",
+    "src/doc/reference.md",
+    "src/doc/reference",
+]
+
+# Edition labels
+
+[autolabel."T-edition"]
+trigger_files = [
+    "compiler/rustc_span/src/edition.rs",
+    "src/doc/edition-guide",
+    "tests/ui/editions",
+]
+
 # ------------------------------------------------------------------------------
 # Prioritization and team nominations
 # ------------------------------------------------------------------------------
@@ -1464,6 +1485,46 @@ message = """
 """
 cc = ["@jieyouxu"]
 
+# Language documentation mentions
+
+[mentions."library/core/src/primitive_docs.rs"]
+message = "Some changes occurred in language documentation."
+cc = ["@rust-lang/lang-docs", "@rust-lang/fls"]
+
+[mentions."library/std/src/attribute_docs.rs"]
+message = "Some changes occurred in language documentation."
+cc = ["@rust-lang/lang-docs", "@rust-lang/fls"]
+
+[mentions."library/std/src/keyword_docs.rs"]
+message = "Some changes occurred in language documentation."
+cc = ["@rust-lang/lang-docs", "@rust-lang/fls"]
+
+[mentions."src/doc/nomicon"]
+message = "A language documentation submodule was updated."
+cc = ["@rust-lang/lang-docs"]
+
+[mentions."src/doc/reference.md"]
+message = "Some changes occurred in language documentation."
+cc = ["@rust-lang/lang-docs"]
+
+[mentions."src/doc/reference"]
+message = "A language documentation submodule was updated."
+cc = ["@rust-lang/lang-docs"]
+
+# Edition mentions
+
+[mentions."compiler/rustc_span/src/edition.rs"]
+message = "Edition-relevant code was updated."
+cc = ["@rust-lang/edition"]
+
+[mentions."src/doc/edition-guide"]
+message = "The Edition Guide submodule was updated."
+cc = ["@rust-lang/edition"]
+
+[mentions."tests/ui/editions"]
+message = "Edition-relevant tests were updated."
+cc = ["@rust-lang/edition"]
+
 # Content-based mentions
 
 [mentions."#[miri::intrinsic_fallback_is_spec]"]
@@ -1651,11 +1712,14 @@ dep-bumps = [
 "/library/alloc" =                                       ["libs"]
 "/library/alloctests" =                                  ["libs"]
 "/library/core" =                                        ["libs"]
+"/library/core/src/primitive_docs.rs" =                  ["lang-docs"]
 "/library/coretests" =                                   ["libs"]
 "/library/panic_abort" =                                 ["libs"]
 "/library/panic_unwind" =                                ["libs"]
 "/library/proc_macro" =                                  ["@petrochenkov"]
 "/library/std" =                                         ["libs", "@ChrisDenton"]
+"/library/std/src/attribute_docs.rs" =                   ["lang-docs", "@GuillaumeGomez"]
+"/library/std/src/keyword_docs.rs" =                     ["lang-docs"]
 "/library/std/src/sys/pal/windows" =                     ["@ChrisDenton"]
 "/library/stdarch" =                                     ["libs"]
 "/library/std_detect" =                                  ["libs"]


### PR DESCRIPTION
The documentation on primitives, attributes, and keywords is language documentation and should be kept synchronized with the Reference. When these files are touched, let's add the `T-lang-docs` label, CC the team (and the FLS team), and assign the issue to a team member. (For attribute documentation, we'll also include Guillaume in the rotation as he's been working on this.)

For bandwidth reasons, we may still reroll assignment to libs or compiler for ordinary matters.  We'll see.  The `primitive_docs.rs` file churns the most and is the one we'd be most likely to hand back.

When the submodule pointer for a book owned by lang-docs or edition is updated, let's CC the team and add the correct label.

For edition, we want changes to `compiler/rustc_span/src/edition.rs` and the tests in `tests/ui/editions` to cause the `T-edition` label to be applied and the team to be pinged; this arranges for that as well.

r? ehuss

cc @rust-lang/lang-docs @rust-lang/fls @rust-lang/edition
