### PR TITLE
Fix inconsistent safety requirement in VecDeque::nonoverlapping_ranges

### DIFF
--- a/library/alloc/src/collections/vec_deque/mod.rs
+++ b/library/alloc/src/collections/vec_deque/mod.rs
@@ -267,7 +267,7 @@ impl<T, A: Allocator> VecDeque<T, A> {
     ///
     /// - Ranges must not overlap: `src.abs_diff(dst) >= count`.
     /// - Ranges must be in bounds of the logical buffer: `src + count <= self.capacity()` and `dst + count <= self.capacity()`.
-    /// - `head` must be in bounds: `head < self.capacity()`.
+    /// - `head` must be in bounds: `head < self.capacity()`, unless `self.capacity() == 0`, in which case `head == 0`.
     #[cfg(not(no_global_oom_handling))]
     unsafe fn nonoverlapping_ranges(
         &mut self,


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

The safety documentation of `nonoverlapping_ranges` says that its `head` argument must be in bounds:

```rust
    /// Get source, destination and count (like the arguments to [`ptr::copy_nonoverlapping`])
    /// for copying `count` values from index `src` to index `dst`.
    /// One of the ranges can wrap around the physical buffer, for this reason 2 triples are returned.
    ///
    /// Use of the word "ranges" specifically refers to `src..src + count` and `dst..dst + count`.
    ///
    /// # Safety
    ///
    /// - Ranges must not overlap: `src.abs_diff(dst) >= count`.
    /// - Ranges must be in bounds of the logical buffer: `src + count <= self.capacity()` and `dst + count <= self.capacity()`.
    /// - `head` must be in bounds: `head < self.capacity()`.
    #[cfg(not(no_global_oom_handling))]
    unsafe fn nonoverlapping_ranges(
        &mut self,
        src: usize,
        dst: usize,
        count: usize,
        head: usize,
    ) -> [(*const T, *mut T, usize); 2] {
```

However, this is slightly stricter than the `VecDeque` internal invariant for `head`. The struct-level invariant allows `head == 0` when the buffer capacity is zero:

```rust
pub struct VecDeque<
    T,
    #[unstable(feature = "allocator_api", issue = "32838")] A: Allocator = Global,
> {
    // `self[0]`, if it exists, is `buf[head]`.
    // `head < buf.capacity()`, unless `buf.capacity() == 0` when `head == 0`.
    head: WrappedIndex,
    // the number of initialized elements, starting from the one at `head` and potentially wrapping around.
    // if `len == 0`, the exact value of `head` is unimportant.
    // if `T` is zero-Sized, then `self.len <= usize::MAX`, otherwise `self.len <= isize::MAX as usize`.
    len: usize,
    buf: RawVec<T, A>,
}
```
This zero-capacity case is reachable through the public API. I create the corresponding case in [Rustplayground](https://play.rust-lang.org/?version=nightly&mode=debug&edition=2024&gist=c1632f2a9170264c3ae50f6c229027db). This case can run without UB, also Miri runs successfully.

So it seems that the safety documentation of `VecDeque::nonoverlapping_ranges` is incorrect, or this API should add additional processing to approach this condition. This PR provides the minimal fix: updates the safety documentation for `nonoverlapping_ranges` to match the existing VecDeque invariant.

If needed, I can add a debug_assert! to check whether the input satisfies the requirement.

No behavior is changed.