### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
@@ -1461,15 +1461,19 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
             let cause = ObligationCause::misc(expr.span, self.mir_def_id());
             ocx.register_bound(cause, self.infcx.param_env, ty, clone_trait);
             let errors = ocx.evaluate_obligations_error_on_ambiguity();
-            if errors.iter().all(|error| {
-                match error.obligation.predicate.as_clause().and_then(|c| c.as_trait_clause()) {
-                    Some(clause) => match clause.self_ty().skip_binder().kind() {
-                        ty::Adt(def, _) => def.did().is_local() && clause.def_id() == clone_trait,
-                        _ => false,
-                    },
-                    None => false,
-                }
-            }) {
+            if !errors.is_empty()
+                && errors.iter().all(|error| {
+                    match error.obligation.predicate.as_clause().and_then(|c| c.as_trait_clause()) {
+                        Some(clause) => match clause.self_ty().skip_binder().kind() {
+                            ty::Adt(def, _) => {
+                                def.did().is_local() && clause.def_id() == clone_trait
+                            }
+                            _ => false,
+                        },
+                        None => false,
+                    }
+                })
+            {
                 let mut type_spans = vec![];
                 let mut types = FxIndexSet::default();
                 for clause in errors

--- a/compiler/rustc_borrowck/src/diagnostics/explain_borrow.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/explain_borrow.rs
@@ -706,7 +706,7 @@ impl<'tcx> MirBorrowckCtxt<'_, '_, 'tcx> {
             Some(Cause::LiveVar(..) | Cause::DropVar(..)) | None => {
                 // Here, under NLL: no cause was found. Under polonius: no cause was found, or a
                 // boring local was found, which we ignore like NLLs do to match its diagnostics.
-                if let Some(region) = self.to_error_region_vid(borrow_region_vid) {
+                if let Some(region) = self.regioncx.to_error_region_vid(borrow_region_vid) {
                     let (category, from_closure, span, region_name, path) =
                         self.free_region_constraint_info(borrow_region_vid, region);
                     if let Some(region_name) = region_name {

--- a/compiler/rustc_borrowck/src/diagnostics/mod.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/mod.rs
@@ -116,11 +116,42 @@ impl<'infcx, 'tcx> BorrowckDiagnosticsBuffer<'infcx, 'tcx> {
     pub(crate) fn buffer_non_error(&mut self, diag: Diag<'infcx, ()>) {
         self.buffered_diags.push(BufferedDiag::NonError(diag));
     }
+    pub(crate) fn buffer_error(&mut self, diag: Diag<'infcx>) {
+        self.buffered_diags.push(BufferedDiag::Error(diag));
+    }
+
+    pub(crate) fn emit_errors(&mut self) -> Option<ErrorGuaranteed> {
+        let mut res = None;
+
+        // Buffer any move errors that we collected and de-duplicated.
+        for (_, (_, diag)) in std::mem::take(&mut self.buffered_move_errors) {
+            // We have already set tainted for this error, so just buffer it.
+            self.buffer_error(diag);
+        }
+        for (_, (mut diag, count)) in std::mem::take(&mut self.buffered_mut_errors) {
+            if count > 10 {
+                diag.note(format!("...and {} other attempted mutable borrows", count - 10));
+            }
+            self.buffer_error(diag);
+        }
+
+        if !self.buffered_diags.is_empty() {
+            self.buffered_diags.sort_by_key(|buffered_diag| buffered_diag.sort_span());
+            for buffered_diag in self.buffered_diags.drain(..) {
+                match buffered_diag {
+                    BufferedDiag::Error(diag) => res = Some(diag.emit()),
+                    BufferedDiag::NonError(diag) => diag.emit(),
+                }
+            }
+        }
+
+        res
+    }
 }
 
 impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
     pub(crate) fn buffer_error(&mut self, diag: Diag<'infcx>) {
-        self.diags_buffer.buffered_diags.push(BufferedDiag::Error(diag));
+        self.diags_buffer.buffer_error(diag);
     }
 
     pub(crate) fn buffer_non_error(&mut self, diag: Diag<'infcx, ()>) {
@@ -150,34 +181,6 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
 
     pub(crate) fn buffer_mut_error(&mut self, span: Span, diag: Diag<'infcx>, count: usize) {
         self.diags_buffer.buffered_mut_errors.insert(span, (diag, count));
-    }
-
-    pub(crate) fn emit_errors(&mut self) -> Option<ErrorGuaranteed> {
-        let mut res = self.infcx.tainted_by_errors();
-
-        // Buffer any move errors that we collected and de-duplicated.
-        for (_, (_, diag)) in std::mem::take(&mut self.diags_buffer.buffered_move_errors) {
-            // We have already set tainted for this error, so just buffer it.
-            self.buffer_error(diag);
-        }
-        for (_, (mut diag, count)) in std::mem::take(&mut self.diags_buffer.buffered_mut_errors) {
-            if count > 10 {
-                diag.note(format!("...and {} other attempted mutable borrows", count - 10));
-            }
-            self.buffer_error(diag);
-        }
-
-        if !self.diags_buffer.buffered_diags.is_empty() {
-            self.diags_buffer.buffered_diags.sort_by_key(|buffered_diag| buffered_diag.sort_span());
-            for buffered_diag in self.diags_buffer.buffered_diags.drain(..) {
-                match buffered_diag {
-                    BufferedDiag::Error(diag) => res = Some(diag.emit()),
-                    BufferedDiag::NonError(diag) => diag.emit(),
-                }
-            }
-        }
-
-        res
     }
 
     pub(crate) fn has_buffered_diags(&self) -> bool {

--- a/compiler/rustc_borrowck/src/diagnostics/opaque_types.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/opaque_types.rs
@@ -28,11 +28,10 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
         }
 
         let infcx = self.infcx;
-        let mut guar = None;
         let mut last_unexpected_hidden_region: Option<(Span, Ty<'_>, ty::OpaqueTypeKey<'tcx>)> =
             None;
         for error in errors {
-            guar = Some(match error {
+            match error {
                 DeferredOpaqueTypeError::InvalidOpaqueTypeArgs(err) => err.report(infcx),
                 DeferredOpaqueTypeError::LifetimeMismatchOpaqueParam(err) => {
                     infcx.dcx().emit_err(err)
@@ -81,11 +80,8 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
                         )
                     ),
                 ),
-            });
+            };
         }
-        let guar = guar.unwrap();
-        self.root_cx.set_tainted_by_errors(guar);
-        self.infcx.set_tainted_by_errors(guar);
     }
 
     /// Try to note when an opaque is involved in a borrowck error and that

--- a/compiler/rustc_borrowck/src/diagnostics/region_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/region_errors.rs
@@ -28,6 +28,7 @@ use rustc_trait_selection::traits::{Obligation, ObligationCtxt};
 use tracing::{debug, instrument, trace};
 
 use super::{LIMITATION_NOTE, OutlivesSuggestionBuilder, RegionName, RegionNameSource};
+use crate::consumers::RegionInferenceContext;
 use crate::nll::ConstraintDescription;
 use crate::region_infer::{BlameConstraint, TypeTest};
 use crate::session_diagnostics::{
@@ -134,7 +135,7 @@ pub(crate) struct ErrorConstraintInfo<'tcx> {
     pub(super) span: Span,
 }
 
-impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
+impl<'tcx> RegionInferenceContext<'tcx> {
     /// Converts a region inference variable into a `ty::Region` that
     /// we can use for error reporting. If `r` is universally bound,
     /// then we use the name that we have on record for it. If `r` is
@@ -142,20 +143,20 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
     /// to find a good name from that. Returns `None` if we can't find
     /// one (e.g., this is just some random part of the CFG).
     pub(super) fn to_error_region(&self, r: RegionVid) -> Option<ty::Region<'tcx>> {
-        self.to_error_region_vid(r).and_then(|r| self.regioncx.region_definition(r).external_name)
+        self.to_error_region_vid(r).and_then(|r| self.region_definition(r).external_name)
     }
 
     /// Returns the `RegionVid` corresponding to the region returned by
     /// `to_error_region`.
     pub(super) fn to_error_region_vid(&self, r: RegionVid) -> Option<RegionVid> {
-        if self.regioncx.universal_regions().is_universal_region(r) {
+        if self.universal_regions().is_universal_region(r) {
             Some(r)
         } else {
             // We just want something nameable, even if it's not
             // actually an upper bound.
-            let upper_bound = self.regioncx.approx_universal_upper_bound(r);
+            let upper_bound = self.approx_universal_upper_bound(r);
 
-            if self.regioncx.upper_bound_in_region_scc(r, upper_bound) {
+            if self.upper_bound_in_region_scc(r, upper_bound) {
                 self.to_error_region_vid(upper_bound)
             } else {
                 None
@@ -179,14 +180,16 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
         if let Some(r) = self.to_error_region(fr)
             && let ty::ReLateParam(late_param) = r.kind()
             && let ty::LateParamRegionKind::ClosureEnv = late_param.kind
-            && let DefiningTy::Closure(_, args) = self.regioncx.universal_regions().defining_ty
+            && let DefiningTy::Closure(_, args) = self.universal_regions().defining_ty
         {
             return args.as_closure().kind() == ty::ClosureKind::FnMut;
         }
 
         false
     }
+}
 
+impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
     // For generic associated types (GATs) which implied 'static requirement
     // from higher-ranked trait bounds (HRTB). Try to locate span of the trait
     // and the span which bounded to the trait for adding 'static lifetime suggestion
@@ -309,12 +312,12 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
                 RegionErrorKind::TypeTestError { type_test } => {
                     // Try to convert the lower-bound region into something named we can print for
                     // the user.
-                    let lower_bound_region = self.to_error_region(type_test.lower_bound);
+                    let lower_bound_region = self.regioncx.to_error_region(type_test.lower_bound);
 
                     let type_test_span = type_test.span;
 
                     if let Some(lower_bound_region) = lower_bound_region {
-                        let generic_ty = self.name_regions(
+                        let generic_ty = self.regioncx.name_regions(
                             self.infcx.tcx,
                             type_test.generic_kind.to_ty(self.infcx.tcx),
                         );
@@ -324,7 +327,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
                             self.body.source.def_id().expect_local(),
                             type_test_span,
                             Some(origin),
-                            self.name_regions(self.infcx.tcx, type_test.generic_kind),
+                            self.regioncx.name_regions(self.infcx.tcx, type_test.generic_kind),
                             lower_bound_region,
                         ));
                     } else {
@@ -450,7 +453,9 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
         debug!("report_region_error: category={:?} {:?} {:?}", category, cause, variance_info);
 
         // Check if we can use one of the "nice region errors".
-        if let (Some(f), Some(o)) = (self.to_error_region(fr), self.to_error_region(outlived_fr)) {
+        if let (Some(f), Some(o)) =
+            (self.regioncx.to_error_region(fr), self.regioncx.to_error_region(outlived_fr))
+        {
             let infer_err = self.infcx.err_ctxt();
             let nice =
                 NiceRegionError::new_from_span(&infer_err, self.mir_def_id(), cause.span, o, f);
@@ -481,7 +486,9 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
                 d.note("meoow :c");
                 d
             }
-            (ConstraintCategory::Return(kind), true, false) if self.is_closure_fn_mut(fr) => {
+            (ConstraintCategory::Return(kind), true, false)
+                if self.regioncx.is_closure_fn_mut(fr) =>
+            {
                 self.report_fnmut_error(&errci, kind)
             }
             (ConstraintCategory::Assignment, true, false)
@@ -736,7 +743,10 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
         // Only show an extra note if we can find an 'error region' for both of the region
         // variables. This avoids showing a noisy note that just mentions 'synthetic' regions
         // that don't help the user understand the error.
-        match (self.to_error_region(errci.fr), self.to_error_region(errci.outlived_fr)) {
+        match (
+            self.regioncx.to_error_region(errci.fr),
+            self.regioncx.to_error_region(errci.outlived_fr),
+        ) {
             (Some(f), Some(o)) => {
                 self.maybe_suggest_constrain_dyn_trait_impl(&mut diag, f, o, category);
 
@@ -842,7 +852,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
         outlived_fr: RegionVid,
     ) {
         if let (Some(f), Some(outlived_f)) =
-            (self.to_error_region(fr), self.to_error_region(outlived_fr))
+            (self.regioncx.to_error_region(fr), self.regioncx.to_error_region(outlived_fr))
         {
             if outlived_f.kind() != ty::ReStatic {
                 return;
@@ -1013,7 +1023,9 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
     }
 
     fn suggest_adding_lifetime_params(&self, diag: &mut Diag<'_>, sub: RegionVid, sup: RegionVid) {
-        let (Some(sub), Some(sup)) = (self.to_error_region(sub), self.to_error_region(sup)) else {
+        let (Some(sub), Some(sup)) =
+            (self.regioncx.to_error_region(sub), self.regioncx.to_error_region(sup))
+        else {
             return;
         };
 

--- a/compiler/rustc_borrowck/src/diagnostics/region_name.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/region_name.rs
@@ -283,7 +283,7 @@ impl<'tcx> MirBorrowckCtxt<'_, '_, 'tcx> {
     /// named variants.
     #[instrument(level = "trace", skip(self))]
     fn give_name_from_error_region(&self, fr: RegionVid) -> Option<RegionName> {
-        let error_region = self.to_error_region(fr)?;
+        let error_region = self.regioncx.to_error_region(fr)?;
 
         let tcx = self.infcx.tcx;
 
@@ -1015,7 +1015,7 @@ impl<'tcx> MirBorrowckCtxt<'_, '_, 'tcx> {
         &self,
         fr: RegionVid,
     ) -> Option<RegionName> {
-        let ty::ReEarlyParam(region) = self.to_error_region(fr)?.kind() else {
+        let ty::ReEarlyParam(region) = self.regioncx.to_error_region(fr)?.kind() else {
             return None;
         };
         if region.is_named() {
@@ -1050,7 +1050,7 @@ impl<'tcx> MirBorrowckCtxt<'_, '_, 'tcx> {
         &self,
         fr: RegionVid,
     ) -> Option<RegionName> {
-        let ty::ReEarlyParam(region) = self.to_error_region(fr)?.kind() else {
+        let ty::ReEarlyParam(region) = self.regioncx.to_error_region(fr)?.kind() else {
             return None;
         };
         if region.is_named() {

--- a/compiler/rustc_borrowck/src/lib.rs
+++ b/compiler/rustc_borrowck/src/lib.rs
@@ -718,7 +718,7 @@ impl<'tcx> Deref for BorrowckInferCtxt<'tcx> {
 }
 
 pub(crate) struct MirBorrowckCtxt<'a, 'infcx, 'tcx> {
-    root_cx: &'a mut BorrowCheckRootCtxt<'tcx>,
+    root_cx: &'a BorrowCheckRootCtxt<'tcx>,
     infcx: &'infcx BorrowckInferCtxt<'tcx>,
     body: &'a Body<'tcx>,
     move_data: &'a MoveData<'tcx>,

--- a/compiler/rustc_borrowck/src/lib.rs
+++ b/compiler/rustc_borrowck/src/lib.rs
@@ -323,7 +323,6 @@ fn borrowck_collect_region_constraints<'tcx>(
     let input_promoted: &IndexSlice<_, _> = &promoted.borrow();
     if let Some(e) = input_body.tainted_by_errors {
         infcx.set_tainted_by_errors(e);
-        root_cx.set_tainted_by_errors(e);
     }
 
     // Replace all regions with fresh inference variables. This
@@ -571,14 +570,15 @@ fn borrowck_check_region_constraints<'tcx>(
 
     debug!("mbcx.used_mut: {:?}", mbcx.used_mut);
     mbcx.lint_unused_mut();
-    if let Some(guar) = mbcx.emit_errors() {
-        mbcx.root_cx.set_tainted_by_errors(guar);
-    }
 
     let result = PropagatedBorrowCheckResults {
         closure_requirements: opt_closure_req,
         used_mut_upvars: mbcx.used_mut_upvars,
     };
+
+    if let Some(guar) = mbcx.diags_buffer.emit_errors().or(infcx.tainted_by_errors()) {
+        root_cx.set_tainted_by_errors(guar);
+    }
 
     if let Some(consumer) = &mut root_cx.consumer {
         consumer.insert_body(

--- a/compiler/rustc_borrowck/src/lib.rs
+++ b/compiler/rustc_borrowck/src/lib.rs
@@ -48,6 +48,7 @@ use rustc_mir_dataflow::points::DenseLocationMap;
 use rustc_mir_dataflow::{Analysis, EntryStates, Results, ResultsVisitor, visit_results};
 use rustc_session::lint::builtin::{TAIL_EXPR_DROP_ORDER, UNUSED_MUT};
 use rustc_span::{ErrorGuaranteed, Span, Symbol};
+use rustc_trait_selection::traits::query::type_op::{QueryTypeOp, TypeOp, TypeOpOutput};
 use smallvec::SmallVec;
 use tracing::{debug, instrument};
 
@@ -706,6 +707,14 @@ impl<'tcx> BorrowckInferCtxt<'tcx> {
         }
 
         next_region
+    }
+
+    fn fully_perform<Q: QueryTypeOp<'tcx> + TypeVisitable<TyCtxt<'tcx>>>(
+        &self,
+        q: Q,
+        span: Span,
+    ) -> Result<TypeOpOutput<'tcx, ty::ParamEnvAnd<'tcx, Q>>, ErrorGuaranteed> {
+        self.param_env.and(q).fully_perform(&self.infcx, self.root_def_id, span)
     }
 }
 

--- a/compiler/rustc_borrowck/src/nll.rs
+++ b/compiler/rustc_borrowck/src/nll.rs
@@ -111,7 +111,7 @@ pub(crate) fn compute_closure_requirements_modulo_opaques<'tcx>(
 ///
 /// This may result in errors being reported.
 pub(crate) fn compute_regions<'tcx>(
-    root_cx: &mut BorrowCheckRootCtxt<'tcx>,
+    root_cx: &BorrowCheckRootCtxt<'tcx>,
     infcx: &BorrowckInferCtxt<'tcx>,
     body: &Body<'tcx>,
     location_table: &PoloniusLocationTable,

--- a/compiler/rustc_borrowck/src/root_cx.rs
+++ b/compiler/rustc_borrowck/src/root_cx.rs
@@ -72,7 +72,7 @@ impl<'tcx> BorrowCheckRootCtxt<'tcx> {
     }
 
     pub(super) fn used_mut_upvars(
-        &mut self,
+        &self,
         nested_body_def_id: LocalDefId,
     ) -> &SmallVec<[FieldIdx; 8]> {
         &self.propagated_borrowck_results[&nested_body_def_id].used_mut_upvars

--- a/compiler/rustc_borrowck/src/type_check/constraint_conversion.rs
+++ b/compiler/rustc_borrowck/src/type_check/constraint_conversion.rs
@@ -11,7 +11,7 @@ use rustc_middle::ty::{
     self, GenericArgKind, Ty, TyCtxt, TypeFoldable, TypeVisitableExt, elaborate, fold_regions,
 };
 use rustc_span::Span;
-use rustc_trait_selection::traits::query::type_op::{TypeOp, TypeOpOutput};
+use rustc_trait_selection::traits::query::type_op::TypeOpOutput;
 use tracing::{debug, instrument};
 
 use crate::constraints::OutlivesConstraint;
@@ -287,11 +287,7 @@ impl<'a, 'tcx> ConstraintConversion<'a, 'tcx> {
             ConstraintCategory<'tcx>,
         )>,
     ) -> Ty<'tcx> {
-        match self.infcx.param_env.and(DeeplyNormalize { value: ty }).fully_perform(
-            self.infcx,
-            self.infcx.root_def_id,
-            self.span,
-        ) {
+        match self.infcx.fully_perform(DeeplyNormalize { value: ty }, self.span) {
             Ok(TypeOpOutput { output: ty, constraints, .. }) => {
                 // FIXME(higher_ranked_auto): What should we do with the assumptions here?
                 if let Some(QueryRegionConstraints { constraints, assumptions: _ }) = constraints {

--- a/compiler/rustc_borrowck/src/type_check/free_region_relations.rs
+++ b/compiler/rustc_borrowck/src/type_check/free_region_relations.rs
@@ -10,7 +10,7 @@ use rustc_middle::mir::ConstraintCategory;
 use rustc_middle::traits::query::OutlivesBound;
 use rustc_middle::ty::{self, RegionVid, Ty, TypeVisitableExt};
 use rustc_span::{ErrorGuaranteed, Span};
-use rustc_trait_selection::traits::query::type_op::{self, TypeOp};
+use rustc_trait_selection::traits::query::type_op;
 use tracing::{debug, instrument};
 use type_op::TypeOpOutput;
 
@@ -242,15 +242,14 @@ impl<'tcx> UniversalRegionRelationsBuilder<'_, 'tcx> {
             if let Some(c) = constraints_unnorm {
                 constraints.push(c)
             }
-            let TypeOpOutput { output: norm_ty, constraints: constraints_normalize, .. } =
-                param_env
-                    .and(DeeplyNormalize { value: ty })
-                    .fully_perform(self.infcx, self.infcx.root_def_id, span)
-                    .unwrap_or_else(|guar| TypeOpOutput {
-                        output: Ty::new_error(self.infcx.tcx, guar),
-                        constraints: None,
-                        error_info: None,
-                    });
+            let TypeOpOutput { output: norm_ty, constraints: constraints_normalize, .. } = self
+                .infcx
+                .fully_perform(DeeplyNormalize { value: ty }, span)
+                .unwrap_or_else(|guar| TypeOpOutput {
+                    output: Ty::new_error(self.infcx.tcx, guar),
+                    constraints: None,
+                    error_info: None,
+                });
             if let Some(c) = constraints_normalize {
                 constraints.push(c)
             }
@@ -299,9 +298,8 @@ impl<'tcx> UniversalRegionRelationsBuilder<'_, 'tcx> {
         if matches!(tcx.def_kind(defining_ty_def_id), DefKind::AssocFn | DefKind::AssocConst { .. })
         {
             for &(ty, _) in tcx.assumed_wf_types(tcx.local_parent(defining_ty_def_id)) {
-                let result: Result<_, ErrorGuaranteed> = param_env
-                    .and(DeeplyNormalize { value: ty })
-                    .fully_perform(self.infcx, self.infcx.root_def_id, span);
+                let result: Result<_, ErrorGuaranteed> =
+                    self.infcx.fully_perform(DeeplyNormalize { value: ty }, span);
                 let Ok(TypeOpOutput { output: norm_ty, constraints: c, .. }) = result else {
                     continue;
                 };
@@ -354,11 +352,7 @@ impl<'tcx> UniversalRegionRelationsBuilder<'_, 'tcx> {
                 output: normalized_outlives,
                 constraints: constraints_normalize,
                 error_info: _,
-            }) = self.infcx.param_env.and(DeeplyNormalize { value: outlives }).fully_perform(
-                self.infcx,
-                self.infcx.root_def_id,
-                span,
-            )
+            }) = self.infcx.fully_perform(DeeplyNormalize { value: outlives }, span)
             else {
                 self.infcx.dcx().delayed_bug(format!("could not normalize {outlives:?}"));
                 return;
@@ -381,9 +375,7 @@ impl<'tcx> UniversalRegionRelationsBuilder<'_, 'tcx> {
     ) -> Option<&'tcx QueryRegionConstraints<'tcx>> {
         let TypeOpOutput { output: bounds, constraints, .. } = self
             .infcx
-            .param_env
-            .and(type_op::ImpliedOutlivesBounds { ty })
-            .fully_perform(self.infcx, self.infcx.root_def_id, span)
+            .fully_perform(type_op::ImpliedOutlivesBounds { ty }, span)
             .map_err(|_: ErrorGuaranteed| debug!("failed to compute implied bounds {:?}", ty))
             .ok()?;
         debug!(?bounds, ?constraints);

--- a/compiler/rustc_borrowck/src/type_check/liveness/trace.rs
+++ b/compiler/rustc_borrowck/src/type_check/liveness/trace.rs
@@ -15,7 +15,7 @@ use rustc_span::{DUMMY_SP, ErrorGuaranteed, Span};
 use rustc_trait_selection::error_reporting::InferCtxtErrorExt;
 use rustc_trait_selection::traits::ObligationCtxt;
 use rustc_trait_selection::traits::query::dropck_outlives;
-use rustc_trait_selection::traits::query::type_op::{DropckOutlives, TypeOp, TypeOpOutput};
+use rustc_trait_selection::traits::query::type_op::{DropckOutlives, TypeOpOutput};
 use tracing::debug;
 
 use crate::polonius;
@@ -638,9 +638,9 @@ impl<'tcx> LivenessContext<'_, '_, 'tcx> {
     ) -> DropData<'tcx> {
         debug!("compute_drop_data(dropped_ty={:?})", dropped_ty);
 
-        let op = typeck.infcx.param_env.and(DropckOutlives { dropped_ty });
+        let goal = DropckOutlives { dropped_ty };
 
-        match op.fully_perform(typeck.infcx, typeck.root_cx.root_def_id(), DUMMY_SP) {
+        match typeck.infcx.fully_perform(goal, DUMMY_SP) {
             Ok(TypeOpOutput { output, constraints, .. }) => {
                 DropData { dropck_result: output, region_constraint_data: constraints }
             }
@@ -655,7 +655,9 @@ impl<'tcx> LivenessContext<'_, '_, 'tcx> {
                 typeck.infcx.probe(|_| {
                     let ocx = ObligationCtxt::new_with_diagnostics(&typeck.infcx);
                     let errors = match dropck_outlives::compute_dropck_outlives_with_errors(
-                        &ocx, op, span,
+                        &ocx,
+                        typeck.infcx.param_env.and(goal),
+                        span,
                     ) {
                         Ok(_) => ocx.evaluate_obligations_error_on_ambiguity(),
                         Err(e) => e,

--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -95,7 +95,7 @@ mod relate_tys;
 /// - `move_data` -- move-data constructed when performing the maybe-init dataflow analysis
 /// - `location_map` -- map between MIR `Location` and `PointIndex`
 pub(crate) fn type_check<'tcx>(
-    root_cx: &mut BorrowCheckRootCtxt<'tcx>,
+    root_cx: &BorrowCheckRootCtxt<'tcx>,
     infcx: &BorrowckInferCtxt<'tcx>,
     body: &Body<'tcx>,
     promoted: &IndexSlice<Promoted, Body<'tcx>>,
@@ -228,7 +228,7 @@ enum FieldAccessError {
 /// way, it accrues region constraints -- these can later be used by
 /// NLL region checking.
 struct TypeChecker<'a, 'tcx> {
-    root_cx: &'a mut BorrowCheckRootCtxt<'tcx>,
+    root_cx: &'a BorrowCheckRootCtxt<'tcx>,
     infcx: &'a BorrowckInferCtxt<'tcx>,
     last_span: Span,
     body: &'a Body<'tcx>,

--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -198,7 +198,6 @@ pub(crate) fn type_check<'tcx>(
         debug!("encountered an error region; removing constraints!");
         constraints.outlives_constraints = Default::default();
         constraints.type_tests = Default::default();
-        root_cx.set_tainted_by_errors(guar);
         infcx.set_tainted_by_errors(guar);
     }
 

--- a/compiler/rustc_codegen_gcc/src/builder.rs
+++ b/compiler/rustc_codegen_gcc/src/builder.rs
@@ -993,7 +993,8 @@ impl<'a, 'gcc, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'gcc, 'tcx> {
         loaded_value.to_rvalue()
     }
 
-    fn volatile_load(&mut self, ty: Type<'gcc>, ptr: RValue<'gcc>) -> RValue<'gcc> {
+    fn volatile_load(&mut self, ty: Type<'gcc>, ptr: RValue<'gcc>, _: Align) -> RValue<'gcc> {
+        // FIXME(antoyo): set alignment.
         let ptr = self.context.new_cast(self.location, ptr, ty.make_volatile().make_pointer());
         // (FractalFir): We insert a local here, to ensure this volatile load can't move across
         // blocks.

--- a/compiler/rustc_codegen_gcc/src/intrinsic/mod.rs
+++ b/compiler/rustc_codegen_gcc/src/intrinsic/mod.rs
@@ -5,7 +5,7 @@ mod simd;
 use std::iter;
 
 use gccjit::{ComparisonOp, Function, FunctionType, RValue, ToRValue, Type, UnaryOp};
-use rustc_abi::{BackendRepr, HasDataLayout, WrappingRange};
+use rustc_abi::{Align, BackendRepr, HasDataLayout, WrappingRange};
 use rustc_codegen_ssa::base::wants_msvc_seh;
 use rustc_codegen_ssa::common::IntPredicate;
 use rustc_codegen_ssa::errors::InvalidMonomorphization;
@@ -368,8 +368,9 @@ impl<'a, 'gcc, 'tcx> IntrinsicCallBuilderMethods<'tcx> for Builder<'a, 'gcc, 'tc
 
             sym::volatile_load | sym::unaligned_volatile_load => {
                 let ptr = args[0].immediate();
-                let load = self.volatile_load(result.layout.gcc_type(self), ptr);
-                // FIXME(antoyo): set alignment.
+                let abi_align = result_layout.align.abi;
+                let ptr_align = if name == sym::volatile_load { abi_align } else { Align::ONE };
+                let load = self.volatile_load(result.layout.gcc_type(self), ptr, ptr_align);
                 if let BackendRepr::Scalar(scalar) = result.layout.backend_repr {
                     self.to_immediate_scalar(load, scalar)
                 } else {

--- a/compiler/rustc_codegen_llvm/src/builder.rs
+++ b/compiler/rustc_codegen_llvm/src/builder.rs
@@ -682,9 +682,9 @@ impl<'a, 'll, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
         }
     }
 
-    fn volatile_load(&mut self, ty: &'ll Type, ptr: &'ll Value) -> &'ll Value {
+    fn volatile_load(&mut self, ty: &'ll Type, ptr: &'ll Value, align: Align) -> &'ll Value {
         unsafe {
-            let load = llvm::LLVMBuildLoad2(self.llbuilder, ty, ptr, UNNAMED);
+            let load = self.load(ty, ptr, align);
             llvm::LLVMSetVolatile(load, llvm::TRUE);
             load
         }

--- a/compiler/rustc_codegen_llvm/src/context.rs
+++ b/compiler/rustc_codegen_llvm/src/context.rs
@@ -978,7 +978,7 @@ impl<'ll, 'tcx> MiscCodegenMethods<'tcx> for CodegenCx<'ll, 'tcx> {
     }
 
     fn intrinsic_call_expects_place_always(&self, name: Symbol) -> bool {
-        matches!(name, sym::volatile_load | sym::unaligned_volatile_load | sym::black_box)
+        matches!(name, sym::black_box)
     }
 }
 

--- a/compiler/rustc_codegen_llvm/src/debuginfo/gdb.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/gdb.rs
@@ -1,5 +1,6 @@
 // .debug_gdb_scripts binary section.
 
+use rustc_abi::Align;
 use rustc_codegen_ssa::base::collect_debugger_visualizers_transitive;
 use rustc_codegen_ssa::traits::*;
 use rustc_hir::attrs::DebuggerVisualizerType;
@@ -18,10 +19,7 @@ pub(crate) fn insert_reference_to_gdb_debug_scripts_section_global(bx: &mut Buil
         let gdb_debug_scripts_section = get_or_insert_gdb_debug_scripts_section_global(bx);
         // Load just the first byte as that's all that's necessary to force
         // LLVM to keep around the reference to the global.
-        let volatile_load_instruction = bx.volatile_load(bx.type_i8(), gdb_debug_scripts_section);
-        unsafe {
-            llvm::LLVMSetAlignment(volatile_load_instruction, 1);
-        }
+        bx.volatile_load(bx.type_i8(), gdb_debug_scripts_section, Align::ONE);
     }
 }
 

--- a/compiler/rustc_codegen_llvm/src/intrinsic.rs
+++ b/compiler/rustc_codegen_llvm/src/intrinsic.rs
@@ -354,25 +354,39 @@ impl<'ll, 'tcx> IntrinsicCallBuilderMethods<'tcx> for Builder<'_, 'll, 'tcx> {
             }
 
             sym::volatile_load | sym::unaligned_volatile_load => {
-                let result = PlaceRef {
-                    val: result_place.unwrap(),
-                    layout: result_layout,
-                };
-
+                // Note that we cannot just load the `llvm_type` because we should never load non-scalars.
+                // Trying to do so blows up horribly in some cases -- for example loading a
+                // `MaybeUninint<&dyn Trait>` would load as `{ [i64x2] }` which gives assertions later
+                // (if we're lucky) from things not being pointers that ought to be.
                 let ptr = args[0].immediate();
-                let load = self.volatile_load(result_layout.llvm_type(self), ptr);
-                let align = if name == sym::unaligned_volatile_load {
-                    1
+                let abi_align = result_layout.align.abi;
+                let ptr_align = if name == sym::volatile_load { abi_align } else { Align::ONE };
+                if result_layout.is_zst() {
+                    return IntrinsicResult::Operand(OperandValue::ZeroSized);
+                } else if let BackendRepr::Scalar(scalar) = result_layout.backend_repr {
+                    let load = self.volatile_load(self.type_from_scalar(scalar), ptr, ptr_align);
+                    self.to_immediate_scalar(load, scalar)
                 } else {
-                    result_layout.align.bytes() as u32
-                };
-                unsafe {
-                    llvm::LLVMSetAlignment(load, align);
+                    // One day Rust will probably want to define how we split up a volatile load
+                    // of something that's *not* just an ordinary scalar, but for now we can just
+                    // use an LLVM integer type of the correct width and let it split it however.
+                    let llty = self.type_ix(result_layout.size.bits());
+                    let temp = if let Some(result_place) = result_place {
+                        PlaceRef {
+                            val: result_place,
+                            layout: result_layout,
+                        }
+                    } else {
+                        PlaceRef::alloca(self, result_layout)
+                    };
+                    let llval = self.volatile_load(llty, ptr, ptr_align);
+                    self.store(llval, temp.val.llval, abi_align);
+                    return if result_place.is_none() {
+                        IntrinsicResult::Operand(self.load_operand(temp).val)
+                    } else {
+                        IntrinsicResult::WroteIntoPlace
+                    };
                 }
-                if !result_layout.is_zst() {
-                    self.store_to_place(load, result.val);
-                }
-                return IntrinsicResult::WroteIntoPlace;
             }
             sym::volatile_store => {
                 let dst = args[0].deref(self.cx());

--- a/compiler/rustc_codegen_ssa/src/traits/builder.rs
+++ b/compiler/rustc_codegen_ssa/src/traits/builder.rs
@@ -242,7 +242,7 @@ pub trait BuilderMethods<'a, 'tcx>:
     fn alloca_with_ty(&mut self, layout: TyAndLayout<'tcx>) -> Self::Value;
 
     fn load(&mut self, ty: Self::Type, ptr: Self::Value, align: Align) -> Self::Value;
-    fn volatile_load(&mut self, ty: Self::Type, ptr: Self::Value) -> Self::Value;
+    fn volatile_load(&mut self, ty: Self::Type, ptr: Self::Value, align: Align) -> Self::Value;
     fn atomic_load(
         &mut self,
         ty: Self::Type,

--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
@@ -462,7 +462,7 @@ where
                 Ok(i) => Ok(i),
                 Err(NoSolutionOrRerunNonErased::NoSolution(NoSolution)) => Err(NoSolution),
                 Err(NoSolutionOrRerunNonErased::RerunNonErased(_)) => {
-                    // check th t the opaque_accesses state mirrors the result we got.
+                    // Check that the opaque_accesses state mirrors the result we got.
                     assert!(opaque_accesses.should_bail().is_err());
                     Err(NoSolution)
                 }
@@ -1442,7 +1442,7 @@ where
         uv: ty::UnevaluatedConst<I>,
     ) -> Result<Option<I::Const>, RerunNonErased> {
         if self.typing_mode().is_erased_not_coherence() {
-            self.opaque_accesses.rerun_always(RerunReason::EvaluateConst)?;
+            match self.opaque_accesses.rerun_always(RerunReason::EvaluateConst)? {}
         }
 
         Ok(self.delegate.evaluate_const(param_env, uv))
@@ -1515,7 +1515,7 @@ where
         symbol: I::Symbol,
     ) -> Result<bool, RerunNonErased> {
         if self.typing_mode().is_erased_not_coherence() {
-            self.opaque_accesses.rerun_always(RerunReason::MayUseUnstableFeature)?;
+            match self.opaque_accesses.rerun_always(RerunReason::MayUseUnstableFeature)? {}
         }
 
         Ok(may_use_unstable_feature(&**self.delegate, param_env, symbol))

--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/probe.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/probe.rs
@@ -98,10 +98,8 @@ where
 
         outer.opaque_accesses.update(nested.opaque_accesses)?;
 
-        let r = match r.map_err_to_rerun()? {
-            Ok(i) => Ok(i),
-            Err(NoSolution) => Err(NoSolution),
-        };
+        // Unwrap is unreachable, we would have returned on the line above.
+        let r = r.map_err_to_rerun().unwrap();
 
         if !nested.inspect.is_noop() {
             let probe_kind = probe_kind(&r);

--- a/compiler/rustc_next_trait_solver/src/solve/normalizes_to.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/normalizes_to.rs
@@ -81,15 +81,10 @@ where
                 None
             },
             |ecx| {
-                ecx.probe(|&result| ProbeKind::RigidAlias { result })
-                    .enter(|this| {
-                        this.structurally_instantiate_normalizes_to_term(
-                            goal,
-                            goal.predicate.alias,
-                        );
-                        this.evaluate_added_goals_and_make_canonical_response(Certainty::Yes)
-                    })
-                    .map_err(Into::into)
+                ecx.probe(|&result| ProbeKind::RigidAlias { result }).enter(|this| {
+                    this.structurally_instantiate_normalizes_to_term(goal, goal.predicate.alias);
+                    this.evaluate_added_goals_and_make_canonical_response(Certainty::Yes)
+                })
             },
         )
     }
@@ -351,11 +346,9 @@ where
                                     GoalSource::Misc,
                                     goal.with(cx, PredicateKind::Ambiguous),
                                 )?;
-                                return ecx
-                                    .evaluate_added_goals_and_make_canonical_response(
-                                        Certainty::Yes,
-                                    )
-                                    .map_err(Into::into);
+                                return ecx.evaluate_added_goals_and_make_canonical_response(
+                                    Certainty::Yes,
+                                );
                             }
                             // Outside of coherence, we treat the associated item as rigid instead.
                             ty::TypingMode::Typeck { .. }
@@ -367,11 +360,9 @@ where
                                     goal,
                                     goal.predicate.alias,
                                 );
-                                return ecx
-                                    .evaluate_added_goals_and_make_canonical_response(
-                                        Certainty::Yes,
-                                    )
-                                    .map_err(Into::into);
+                                return ecx.evaluate_added_goals_and_make_canonical_response(
+                                    Certainty::Yes,
+                                );
                             }
                         };
                     }
@@ -401,10 +392,10 @@ where
                         // This is not the case here and we only prefer adding an ambiguous
                         // nested goal for consistency.
                         ecx.add_goal(GoalSource::Misc, goal.with(cx, PredicateKind::Ambiguous))?;
-                        return then(ecx, Certainty::Yes).map_err(Into::into);
+                        return then(ecx, Certainty::Yes);
                     } else {
                         ecx.structurally_instantiate_normalizes_to_term(goal, goal.predicate.alias);
-                        return then(ecx, Certainty::Yes).map_err(Into::into);
+                        return then(ecx, Certainty::Yes);
                     }
                 } else {
                     return error_response(ecx, cx.delay_bug("missing item"));
@@ -472,7 +463,7 @@ where
             };
 
             ecx.instantiate_normalizes_to_term(goal, term)?;
-            ecx.evaluate_added_goals_and_make_canonical_response(Certainty::Yes).map_err(Into::into)
+            ecx.evaluate_added_goals_and_make_canonical_response(Certainty::Yes)
         })
     }
 
@@ -572,7 +563,6 @@ where
             pred,
             [(GoalSource::ImplWhereBound, goal.with(cx, output_is_sized_pred))],
         )
-        .map_err(Into::into)
     }
 
     fn consider_builtin_async_fn_trait_candidates(
@@ -759,8 +749,9 @@ where
                 // and opaque types: If the `self_ty` is `Sized`, then the metadata is `()`.
                 // FIXME(ptr_metadata): This impl overlaps with the other impls and shouldn't
                 // exist. Instead, `Pointee<Metadata = ()>` should be a supertrait of `Sized`.
-                let alias_bound_result =
-                    ecx.probe_builtin_trait_candidate(BuiltinImplSource::Misc).enter(|ecx| {
+                let alias_bound_result = ecx
+                    .probe_builtin_trait_candidate(BuiltinImplSource::Misc)
+                    .enter(|ecx| {
                         let sized_predicate = ty::TraitRef::new(
                             cx,
                             cx.require_trait_lang_item(SolverTraitLangItem::Sized),
@@ -769,12 +760,8 @@ where
                         ecx.add_goal(GoalSource::Misc, goal.with(cx, sized_predicate))?;
                         ecx.instantiate_normalizes_to_term(goal, Ty::new_unit(cx).into())?;
                         ecx.evaluate_added_goals_and_make_canonical_response(Certainty::Yes)
-                    });
-
-                let alias_bound_result = match alias_bound_result.map_err_to_rerun()? {
-                    Ok(i) => Ok(i),
-                    Err(NoSolution) => Err(NoSolution),
-                };
+                    })
+                    .map_err_to_rerun()?;
 
                 // In case the dummy alias-bound candidate does not apply, we instead treat this projection
                 // as rigid.
@@ -900,7 +887,6 @@ where
             // but that's already proven by the generator being WF.
             [],
         )
-        .map_err(Into::into)
     }
 
     fn consider_builtin_fused_iterator_candidate(

--- a/compiler/rustc_next_trait_solver/src/solve/search_graph.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/search_graph.rs
@@ -4,7 +4,7 @@ use std::marker::PhantomData;
 use rustc_type_ir::data_structures::ensure_sufficient_stack;
 use rustc_type_ir::search_graph::{self, PathKind};
 use rustc_type_ir::solve::{
-    AccessedOpaques, CanonicalInput, Certainty, NoSolution, NoSolutionOrRerunNonErased, QueryResult,
+    AccessedOpaques, CanonicalInput, Certainty, NoSolution, QueryResult, RerunResultExt,
 };
 use rustc_type_ir::{Interner, MayBeErased, TypingMode};
 
@@ -141,17 +141,8 @@ where
     ) -> (QueryResult<I>, AccessedOpaques<I>) {
         ensure_sufficient_stack(|| {
             EvalCtxt::enter_canonical(cx, search_graph, input, inspect, |ecx, goal| {
-                let result = ecx.compute_goal(goal);
-
-                // if we're in `RerunNonErased`, don't even bother with inspect,
-                // and immediately return
-                let result = match result {
-                    Ok(i) => Ok(i),
-                    Err(NoSolutionOrRerunNonErased::NoSolution(NoSolution)) => Err(NoSolution),
-                    Err(NoSolutionOrRerunNonErased::RerunNonErased(e)) => {
-                        return Err(e.into());
-                    }
-                };
+                // if we're in `RerunNonErased`, don't even bother with inspect, and immediately return
+                let result = ecx.compute_goal(goal).map_err_to_rerun()?;
 
                 ecx.inspect.query_result(result);
                 result.map_err(Into::into)

--- a/compiler/rustc_next_trait_solver/src/solve/trait_goals.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/trait_goals.rs
@@ -119,7 +119,7 @@ where
                     .map(|pred| goal.with(cx, pred)),
             )?;
 
-            then(ecx, maximal_certainty).map_err(Into::into)
+            then(ecx, maximal_certainty)
         })
     }
 
@@ -399,7 +399,6 @@ where
             pred,
             [(GoalSource::ImplWhereBound, goal.with(cx, output_is_sized_pred))],
         )
-        .map_err(Into::into)
     }
 
     fn consider_builtin_async_fn_trait_candidates(
@@ -450,7 +449,6 @@ where
                 .chain(nested_preds.into_iter().map(|pred| goal.with(cx, pred)))
                 .map(|goal| (GoalSource::ImplWhereBound, goal)),
         )
-        .map_err(Into::into)
     }
 
     fn consider_builtin_async_fn_kind_helper_candidate(
@@ -696,7 +694,7 @@ where
                     goal.predicate.trait_ref.args.type_at(1),
                     assume,
                 )?;
-                ecx.evaluate_added_goals_and_make_canonical_response(certainty).map_err(Into::into)
+                ecx.evaluate_added_goals_and_make_canonical_response(certainty)
             },
         )
     }
@@ -1085,7 +1083,6 @@ where
                                     ecx.try_evaluate_added_goals()
                                 },
                             )
-                            .map_err(Into::into)
                         })
                         .is_ok()
             };
@@ -1124,11 +1121,9 @@ where
                             return Err(NoSolution.into());
                         };
                         if matching_projections.next().is_some() {
-                            return ecx
-                                .evaluate_added_goals_and_make_canonical_response(
-                                    Certainty::AMBIGUOUS,
-                                )
-                                .map_err(Into::into);
+                            return ecx.evaluate_added_goals_and_make_canonical_response(
+                                Certainty::AMBIGUOUS,
+                            );
                         }
                         ecx.enter_forall_with_assumptions(
                             target_projection,
@@ -1156,7 +1151,7 @@ where
                 Goal::new(ecx.cx(), param_env, ty::OutlivesPredicate(a_region, b_region)),
             )?;
 
-            ecx.evaluate_added_goals_and_make_canonical_response(Certainty::Yes).map_err(Into::into)
+            ecx.evaluate_added_goals_and_make_canonical_response(Certainty::Yes)
         })
     }
 

--- a/compiler/rustc_ty_utils/src/opaque_types.rs
+++ b/compiler/rustc_ty_utils/src/opaque_types.rs
@@ -316,6 +316,9 @@ fn opaque_types_defined_by<'tcx>(
     tcx: TyCtxt<'tcx>,
     item: LocalDefId,
 ) -> &'tcx ty::List<LocalDefId> {
+    if tcx.is_typeck_child(item.to_def_id()) {
+        return tcx.opaque_types_defined_by(tcx.local_parent(item));
+    }
     let kind = tcx.def_kind(item);
     trace!(?kind);
     let mut collector = OpaqueTypeCollector::new(tcx, item);
@@ -331,13 +334,6 @@ fn opaque_types_defined_by<'tcx>(
         | DefKind::AnonConst => {
             collector.collect_taits_declared_in_body();
         }
-        // Closures and coroutines are type checked with their parent
-        // Note that we also support `SyntheticCoroutineBody` since we create
-        // a MIR body for the def kind, and some MIR passes (like promotion)
-        // may require doing analysis using its typing env.
-        DefKind::Closure | DefKind::InlineConst | DefKind::SyntheticCoroutineBody => {
-            collector.opaques.extend(tcx.opaque_types_defined_by(tcx.local_parent(item)));
-        }
         DefKind::AssocTy | DefKind::TyAlias | DefKind::GlobalAsm => {}
         DefKind::OpaqueTy
         | DefKind::Mod
@@ -348,6 +344,15 @@ fn opaque_types_defined_by<'tcx>(
         | DefKind::Trait
         | DefKind::ForeignTy
         | DefKind::TraitAlias
+
+        // Closures and coroutines are type checked with their parent
+        // Note that we also support `SyntheticCoroutineBody` since we create
+        // a MIR body for the def kind, and some MIR passes (like promotion)
+        // may require doing analysis using its typing env.
+        | DefKind::Closure
+        | DefKind::InlineConst
+        | DefKind::SyntheticCoroutineBody
+
         | DefKind::TyParam
         | DefKind::ConstParam
         | DefKind::Ctor(_, _)

--- a/compiler/rustc_ty_utils/src/ty.rs
+++ b/compiler/rustc_ty_utils/src/ty.rs
@@ -149,6 +149,9 @@ fn adt_sizedness_constraint<'tcx>(
 
 /// See `ParamEnv` struct definition for details.
 fn param_env(tcx: TyCtxt<'_>, def_id: DefId) -> ty::ParamEnv<'_> {
+    if tcx.is_typeck_child(def_id) {
+        return tcx.param_env(tcx.typeck_root_def_id(def_id));
+    }
     // Compute the bounds on Self and the type parameters.
     let ty::InstantiatedPredicates { predicates, .. } =
         tcx.predicates_of(def_id).instantiate_identity(tcx);

--- a/library/std/src/attribute_docs.rs
+++ b/library/std/src/attribute_docs.rs
@@ -85,3 +85,253 @@
 /// [`unused_must_use`]: ../rustc/lints/listing/warn-by-default.html#unused-must-use
 /// [the `must_use` attribute]: ../reference/attributes/diagnostics.html#the-must_use-attribute
 mod must_use_attribute {}
+
+#[doc(attribute = "allow")]
+//
+/// The `allow` attribute suppresses lint diagnostics that would otherwise produce
+/// warnings or errors. It can be used on any lint or lint group (except those
+/// set to `forbid`).
+///
+/// ```rust
+/// #[allow(dead_code)]
+/// fn unused_function() {
+///     // ...
+/// }
+///
+/// fn main() {
+///   // `unused_function` does not generate a compiler warning.
+/// }
+/// ```
+///
+/// Without `#[allow(dead_code)]`, the example above would emit:
+///
+/// ```text
+/// warning: function `unused_function` is never used
+///  --> main.rs:1:4
+///   |
+/// 1 | fn unused_function() {
+///   |    ^^^^^^^^^^^^^^^
+///   |
+///   = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
+///
+///   warning: 1 warning emitted
+/// ```
+///
+/// Multiple lints can be set to `allow` at once with commas:
+///
+/// ```rust
+/// #[allow(unused_variables, unused_mut)]
+/// fn main() {
+///     let mut x: u32 = 42;
+/// }
+/// ```
+///
+/// This is mostly used to prevent lint warnings or errors while still under development.
+///
+/// It cannot override a lint that has been set to `forbid`.
+///
+/// It's also important to consider that overusing `allow` could make code harder to maintain
+/// and possibly hide issues. To mitigate this issue, using the `expect` attribute is preferred.
+///
+/// `allow` can be overridden by `warn`, `deny`, and `forbid`.
+///
+/// The lint checks supported by rustc can be found via `rustc -W help`,
+/// along with their default settings and are documented in [the `rustc` book].
+///
+/// [the `rustc` book]: ../rustc/lints/listing/index.html
+///
+/// For more information, see the Reference on [the `allow` attribute].
+///
+/// [the `allow` attribute]: ../reference/attributes/diagnostics.html#lint-check-attributes
+mod allow_attribute {}
+
+#[doc(attribute = "cfg")]
+//
+/// Used for conditional compilation.
+///
+/// The `cfg` attribute allows compiling an item under specific conditions, otherwise it
+/// will be ignored.
+///
+/// ```rust
+/// // Only compiles this function for Linux.
+/// #[cfg(target_os = "linux")]
+/// fn platform_specific() {
+///     println!("Running on Linux");
+/// }
+///
+/// // Only compiles this function if not for Linux.
+/// #[cfg(not(target_os = "linux"))]
+/// fn platform_specific() {
+///     println!("Running on something else");
+/// }
+/// ```
+///
+/// Depending on the platform you're targeting, only one of these two functions will be considered
+/// during the compilation.
+///
+/// Conditions can also be combined with `all(...)`, `any(...)`, and `not(...)`.
+///
+/// * `all`: True if all given predicates are true.
+/// * `any`: True if at least one of the given predicates is true.
+/// * `not`: True if the predicate is false and false if the predicate is true.
+///
+/// ```rust
+/// #[cfg(all(unix, target_pointer_width = "64"))]
+/// fn unix_64bit() {
+/// }
+/// ```
+///
+/// If you want to use this mechanism in an `if` condition in your code, you
+/// can use the [`cfg!`] macro. To conditionally apply an attribute,
+/// see [`cfg_attr`].
+///
+/// For more information, see the Reference on [the `cfg` attribute].
+///
+/// [`cfg_attr`]: ../reference/conditional-compilation.html#the-cfg_attr-attribute
+/// [the `cfg` attribute]: ../reference/conditional-compilation.html#the-cfg-attribute
+mod cfg_attribute {}
+
+#[doc(attribute = "deny")]
+//
+/// Emits an error, preventing the compilation from finishing, when a lint check has failed.
+/// This is useful for enforcing rules or preventing certain patterns:
+///
+/// ```rust,compile_fail
+/// #[deny(unused)]
+/// fn foo() {
+///     let x = 42; // Emits an error because x is unused.
+/// }
+/// ```
+///
+/// `deny` can be overridden by `allow`, `warn`, and `forbid`:
+///
+/// ```rust
+/// #![deny(unused)]
+///
+/// #[allow(unused)] // We override the `deny` for this function.
+/// fn foo() {
+///     let x = 42; // No lint emitted even though `x` is unused.
+/// }
+/// ```
+///
+/// Multiple lints can also be set to `deny` at once:
+///
+/// ```rust,compile_fail
+/// #![deny(unused_imports, unused_variables)]
+/// use std::collections::*;
+///
+/// fn main() {
+///     let mut x = 10;
+/// }
+/// ```
+///
+/// The lint checks supported by rustc can be found via `rustc -W help`,
+/// along with their default settings and are documented in [the `rustc` book].
+///
+/// [the `rustc` book]: ../rustc/lints/listing/index.html
+///
+/// For more information, see the Reference on [the `deny` attribute].
+///
+/// [the `deny` attribute]: ../reference/attributes/diagnostics.html#lint-check-attributes
+mod deny_attribute {}
+
+#[doc(attribute = "forbid")]
+//
+/// Emits an error, preventing the compilation from finishing, when a lint check has failed.
+///
+/// A lint set to `forbid` cannot be overridden by `allow` or `warn`.
+/// Attempting either will result in a compilation error. Writing `#[deny(...)]` on the same lint inside a
+/// `forbid` scope is permitted, but has no effect; the lint remains at the `forbid` level.
+///
+/// This is useful for enforcing strict policies that should not be relaxed
+/// anywhere in the codebase. Example:
+///
+/// ```rust
+/// #![forbid(unsafe_code)]
+///
+/// // This would cause a compilation error if uncommented:
+/// // #[allow(unsafe_code)] // error: cannot override `forbid`
+/// ```
+///
+/// Multiple lints can be set to `forbid` at once:
+///
+/// ```rust
+/// #![forbid(unsafe_code, unused)]
+/// ```
+///
+/// The lint checks supported by rustc can be found via `rustc -W help`,
+/// along with their default settings and are documented in [the `rustc` book].
+///
+/// [the `rustc` book]: ../rustc/lints/listing/index.html
+///
+/// For more information, see the Reference on [the `forbid` attribute].
+///
+/// [the `forbid` attribute]: ../reference/attributes/diagnostics.html#lint-check-attributes
+mod forbid_attribute {}
+
+#[doc(attribute = "deprecated")]
+//
+/// Emits a warning during compilation when an item with this attribute is used.
+/// `since` and `note` are optional fields giving more detail about why the item is deprecated.
+///
+/// * `since`: the version since when the item is deprecated.
+/// * `note`: the reason why an item is deprecated.
+///
+/// Example:
+///
+/// ```rust
+/// #[deprecated(since = "1.0.0", note = "Use bar instead")]
+/// struct Foo;
+/// struct Bar;
+/// ```
+///
+/// `deprecated` attribute helps developers transition away from old code by providing warnings when
+/// deprecated items are used. Note that during `Cargo` builds, warnings on dependencies get silenced
+/// by default, so you may not see a deprecation warning unless you build that dependency directly.
+///
+/// For more information, see the Reference on [the `deprecated` attribute].
+///
+/// [the `deprecated` attribute]: ../reference/attributes/diagnostics.html#the-deprecated-attribute
+mod deprecated_attribute {}
+
+#[doc(attribute = "warn")]
+//
+/// Emits a warning during compilation when a lint check failed.
+///
+/// Unlike `deny` or `forbid`, `warn` does not produce a hard error: the compilation continues, but
+/// the compiler emits a warning message. `warn` can be overridden by `allow`, `deny`, and `forbid`.
+///
+/// Example:
+///
+/// ```rust,compile_fail
+/// #![allow(unused)]
+///
+/// #[warn(unused)] // We override the allowed `unused` lint.
+/// fn foo() {
+///     // This lint warns by default even without #[warn(unused)] being explicitly set
+///     let x = 42; // warning: unused variable `x`
+/// }
+/// ```
+///
+///
+/// Many lints, including `unused`, are already set to `warn` by default so this attribute is
+/// mainly useful for lints that are normally `allow` by default.
+///
+/// Multiple lints can be set to `warn` at once:
+///
+/// ```rust,compile_fail
+/// #[warn(unused_mut, unused_variables)]
+/// fn main() {
+///     let mut x = 42;
+/// }
+/// ```
+///
+/// The lint checks supported by rustc can be found via `rustc -W help`,
+/// along with their default settings and are documented in [the `rustc` book].
+///
+/// [the `rustc` book]: ../rustc/lints/listing/index.html
+///
+/// For more information, see the Reference on [the `warn` attribute].
+///
+/// [the `warn` attribute]: ../reference/attributes/diagnostics.html#lint-check-attributes
+mod warn_attribute {}

--- a/library/std/src/sys/thread/unix.rs
+++ b/library/std/src/sys/thread/unix.rs
@@ -392,6 +392,7 @@ pub fn current_os_id() -> Option<u64> {
     target_os = "vxworks",
     target_os = "cygwin",
     target_vendor = "apple",
+    target_os = "netbsd",
 ))]
 fn truncate_cstr<const MAX_WITH_NUL: usize>(cstr: &CStr) -> [libc::c_char; MAX_WITH_NUL] {
     let mut result = [0; MAX_WITH_NUL];
@@ -463,7 +464,12 @@ pub fn set_name(name: &CStr) {
 
 #[cfg(target_os = "netbsd")]
 pub fn set_name(name: &CStr) {
+    // See https://github.com/NetBSD/src/blob/8d40872b4c550a802379f3b9c22a40212d5e149d/lib/libpthread/pthread.h#L281
+    // FIXME: move to libc.
+    const PTHREAD_MAX_NAMELEN_NP: usize = 32;
+
     unsafe {
+        let name = truncate_cstr::<{ PTHREAD_MAX_NAMELEN_NP }>(name);
         let res = libc::pthread_setname_np(
             libc::pthread_self(),
             c"%s".as_ptr(),

--- a/tests/codegen-llvm/i128-x86-align.rs
+++ b/tests/codegen-llvm/i128-x86-align.rs
@@ -5,8 +5,6 @@
 // while rustc wants it to have 16 byte alignment. This test checks that we handle this
 // correctly.
 
-// CHECK: %ScalarPair = type { i32, [3 x i32], i128 }
-
 #![feature(core_intrinsics)]
 
 #[repr(C)]
@@ -62,8 +60,8 @@ pub fn load_volatile(x: &ScalarPair) -> ScalarPair {
     // CHECK-SAME: dereferenceable(32) %_0,
     // CHECK-SAME: align 16
     // CHECK-SAME: dereferenceable(32) %x
-    // CHECK:      [[LOAD:%.*]] = load volatile %ScalarPair, ptr %x, align 16
-    // CHECK-NEXT: store %ScalarPair [[LOAD]], ptr %_0, align 16
+    // CHECK:      [[LOAD:%.*]] = load volatile i256, ptr %x, align 16
+    // CHECK-NEXT: store i256 [[LOAD]], ptr %_0, align 16
     // CHECK-NEXT: ret void
     unsafe { std::intrinsics::volatile_load(x) }
 }

--- a/tests/codegen-llvm/intrinsics/volatile.rs
+++ b/tests/codegen-llvm/intrinsics/volatile.rs
@@ -5,6 +5,11 @@
 
 use std::intrinsics;
 
+#[repr(align(32))]
+pub struct CustomZst;
+
+type UninitFatPointer = std::mem::MaybeUninit<&'static dyn std::fmt::Debug>;
+
 // CHECK-LABEL: @volatile_copy_memory
 #[no_mangle]
 pub unsafe fn volatile_copy_memory(a: *mut u8, b: *const u8) {
@@ -28,8 +33,62 @@ pub unsafe fn volatile_set_memory(a: *mut u8, b: u8) {
 
 // CHECK-LABEL: @volatile_load
 #[no_mangle]
-pub unsafe fn volatile_load(a: *const u8) -> u8 {
-    // CHECK: load volatile
+pub unsafe fn volatile_load(a: *const u16) -> u16 {
+    // CHECK: [[TEMP:%.+]] = load volatile i16, ptr %a
+    // CHECK-SAME: align 2{{,|$}}
+    // CHECK-NEXT: ret i16 [[TEMP]]
+    intrinsics::volatile_load(a)
+}
+
+// CHECK-LABEL: @volatile_load_bool
+#[no_mangle]
+pub unsafe fn volatile_load_bool(a: *const bool) -> bool {
+    // CHECK: [[TEMP:%.+]] = load volatile i8, ptr %a
+    // CHECK-SAME: align 1{{,|$}}
+    // CHECK: [[TRUNC:%.+]] = trunc nuw i8 [[TEMP]] to i1
+    // CHECK: ret i1 [[TRUNC]]
+    intrinsics::volatile_load(a)
+}
+
+// CHECK-LABEL: @volatile_load_zst
+#[no_mangle]
+pub unsafe fn volatile_load_zst(a: *const CustomZst) -> CustomZst {
+    // CHECK: start:
+    // CHECK-NEXT: ret void
+    intrinsics::volatile_load(a)
+}
+
+// CHECK-LABEL: @volatile_load_array
+// CHECK-SAME: ptr{{.+}}sret([16 x i8]){{.+}}%_0
+#[no_mangle]
+pub unsafe fn volatile_load_array(a: *const [u16; 8]) -> [u16; 8] {
+    // CHECK-NOT: alloca
+    // CHECK: [[TEMP:%.+]] = load volatile i128, ptr %a,
+    // CHECK-SAME: align 2{{,|$}}
+    // CHECK: store i128 [[TEMP]], ptr %_0,
+    // CHECK-SAME: align 2{{,|$}}
+    // CHECK-NEXT: ret void
+    intrinsics::volatile_load(a)
+}
+
+// CHECK-LABEL: @volatile_load_fat
+#[no_mangle]
+pub unsafe fn volatile_load_fat(a: *const UninitFatPointer) -> UninitFatPointer {
+    // CHECK: [[ALLOCA:%.+]] = alloca
+    // CHECK-SAME: [[SIZE:4|8|16]] x i8
+    // CHECK-SAME: align [[ALIGN:2|4|8]]
+
+    // CHECK: [[TEMP:%.+]] = load volatile [[INT:i32|i64|i128]], ptr %a,
+    // CHECK-SAME: align [[ALIGN]]{{,|$}}
+    // CHECK: store [[INT]] [[TEMP]], ptr [[ALLOCA]],
+    // CHECK-SAME: align [[ALIGN]]{{,|$}}
+
+    // CHECK: [[T0:%.+]] = load ptr, ptr [[ALLOCA]], align [[ALIGN]]
+    // CHECK: [[T1:%.+]] = getelementptr inbounds i8, ptr [[ALLOCA]]
+    // CHECK: [[T2:%.+]] = load ptr, ptr [[T1]], align [[ALIGN]]
+    // CHECK: [[P1:%.+]] = insertvalue { ptr, ptr } poison, ptr [[T0]], 0
+    // CHECK: [[P2:%.+]] = insertvalue { ptr, ptr } [[P1]], ptr [[T2]], 1
+    // CHECK: ret { ptr, ptr } [[P2]]
     intrinsics::volatile_load(a)
 }
 
@@ -42,8 +101,62 @@ pub unsafe fn volatile_store(a: *mut u8, b: u8) {
 
 // CHECK-LABEL: @unaligned_volatile_load
 #[no_mangle]
-pub unsafe fn unaligned_volatile_load(a: *const u8) -> u8 {
-    // CHECK: load volatile
+pub unsafe fn unaligned_volatile_load(a: *const u16) -> u16 {
+    // CHECK: [[TEMP:%.+]] = load volatile i16, ptr %a
+    // CHECK-SAME: align 1{{,|$}}
+    // CHECK-NEXT: ret i16 [[TEMP]]
+    intrinsics::unaligned_volatile_load(a)
+}
+
+// CHECK-LABEL: @unaligned_volatile_load_bool
+#[no_mangle]
+pub unsafe fn unaligned_volatile_load_bool(a: *const bool) -> bool {
+    // CHECK: [[TEMP:%.+]] = load volatile i8, ptr %a
+    // CHECK-SAME: align 1{{,|$}}
+    // CHECK: [[TRUNC:%.+]] = trunc nuw i8 [[TEMP]] to i1
+    // CHECK: ret i1 [[TRUNC]]
+    intrinsics::unaligned_volatile_load(a)
+}
+
+// CHECK-LABEL: @unaligned_volatile_load_zst
+#[no_mangle]
+pub unsafe fn unaligned_volatile_load_zst(a: *const CustomZst) -> CustomZst {
+    // CHECK: start:
+    // CHECK-NEXT: ret void
+    intrinsics::unaligned_volatile_load(a)
+}
+
+// CHECK-LABEL: @unaligned_volatile_load_array
+// CHECK-SAME: ptr{{.+}}sret([16 x i8]){{.+}}%_0,
+#[no_mangle]
+pub unsafe fn unaligned_volatile_load_array(a: *const [u16; 8]) -> [u16; 8] {
+    // CHECK-NOT: alloca
+    // CHECK: [[TEMP:%.+]] = load volatile i128, ptr %a,
+    // CHECK-SAME: align 1{{,|$}}
+    // CHECK: store i128 [[TEMP]], ptr %_0,
+    // CHECK-SAME: align 2{{,|$}}
+    // CHECK-NEXT: ret void
+    intrinsics::unaligned_volatile_load(a)
+}
+
+// CHECK-LABEL: @unaligned_volatile_load_fat
+#[no_mangle]
+pub unsafe fn unaligned_volatile_load_fat(a: *const UninitFatPointer) -> UninitFatPointer {
+    // CHECK: [[ALLOCA:%.+]] = alloca
+    // CHECK-SAME: [[SIZE]] x i8
+    // CHECK-SAME: align [[ALIGN]]
+
+    // CHECK: [[TEMP:%.+]] = load volatile [[INT]], ptr %a,
+    // CHECK-SAME: align 1{{,|$}}
+    // CHECK: store [[INT]] [[TEMP]], ptr [[ALLOCA]],
+    // CHECK-SAME: align [[ALIGN]]{{,|$}}
+
+    // CHECK: [[T0:%.+]] = load ptr, ptr [[ALLOCA]], align [[ALIGN]]
+    // CHECK: [[T1:%.+]] = getelementptr inbounds i8, ptr [[ALLOCA]]
+    // CHECK: [[T2:%.+]] = load ptr, ptr [[T1]], align [[ALIGN]]
+    // CHECK: [[P1:%.+]] = insertvalue { ptr, ptr } poison, ptr [[T0]], 0
+    // CHECK: [[P2:%.+]] = insertvalue { ptr, ptr } [[P1]], ptr [[T2]], 1
+    // CHECK: ret { ptr, ptr } [[P2]]
     intrinsics::unaligned_volatile_load(a)
 }
 

--- a/tests/ui/lifetimes/issue-76168-hr-outlives-3.rs
+++ b/tests/ui/lifetimes/issue-76168-hr-outlives-3.rs
@@ -8,10 +8,9 @@ async fn wrapper<F>(f: F)
 //~| ERROR: expected a `FnOnce(&'a mut i32)` closure, found `i32`
 //~| ERROR: expected a `FnOnce(&'a mut i32)` closure, found `i32`
 where
-F:,
-for<'a> <i32 as FnOnce<(&'a mut i32,)>>::Output: Future<Output = ()> + 'a,
+    F:,
+    for<'a> <i32 as FnOnce<(&'a mut i32,)>>::Output: Future<Output = ()> + 'a,
 {
-    //~^ ERROR: expected a `FnOnce(&'a mut i32)` closure, found `i32`
     let mut i = 41;
     &mut i;
 }

--- a/tests/ui/lifetimes/issue-76168-hr-outlives-3.stderr
+++ b/tests/ui/lifetimes/issue-76168-hr-outlives-3.stderr
@@ -3,9 +3,9 @@ error[E0277]: expected a `FnOnce(&'a mut i32)` closure, found `i32`
    |
 LL | / async fn wrapper<F>(f: F)
 ...  |
-LL | | F:,
-LL | | for<'a> <i32 as FnOnce<(&'a mut i32,)>>::Output: Future<Output = ()> + 'a,
-   | |__________________________________________________________________________^ expected an `FnOnce(&'a mut i32)` closure, found `i32`
+LL | |     F:,
+LL | |     for<'a> <i32 as FnOnce<(&'a mut i32,)>>::Output: Future<Output = ()> + 'a,
+   | |______________________________________________________________________________^ expected an `FnOnce(&'a mut i32)` closure, found `i32`
    |
    = help: the trait `for<'a> FnOnce(&'a mut i32)` is not implemented for `i32`
 
@@ -26,18 +26,6 @@ LL | async fn wrapper<F>(f: F)
    = help: the trait `for<'a> FnOnce(&'a mut i32)` is not implemented for `i32`
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error[E0277]: expected a `FnOnce(&'a mut i32)` closure, found `i32`
-  --> $DIR/issue-76168-hr-outlives-3.rs:13:1
-   |
-LL | / {
-LL | |
-LL | |     let mut i = 41;
-LL | |     &mut i;
-LL | | }
-   | |_^ expected an `FnOnce(&'a mut i32)` closure, found `i32`
-   |
-   = help: the trait `for<'a> FnOnce(&'a mut i32)` is not implemented for `i32`
-
-error: aborting due to 4 previous errors
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/moves/unconstrained-impl-param-clone-suggestion.rs
+++ b/tests/ui/moves/unconstrained-impl-param-clone-suggestion.rs
@@ -1,0 +1,20 @@
+// Regression test for https://github.com/rust-lang/rust/issues/148631
+
+struct C;
+
+struct S<T>(T);
+
+trait Tr {}
+
+impl<T> Clone for S<C>
+//~^ ERROR the type parameter `T` is not constrained
+where
+    S<T>: Tr,
+{
+    fn clone(&self) -> Self {
+        *self
+        //~^ ERROR cannot move out of `*self`
+    }
+}
+
+fn main() {}

--- a/tests/ui/moves/unconstrained-impl-param-clone-suggestion.stderr
+++ b/tests/ui/moves/unconstrained-impl-param-clone-suggestion.stderr
@@ -1,0 +1,19 @@
+error[E0207]: the type parameter `T` is not constrained by the impl trait, self type, or predicates
+  --> $DIR/unconstrained-impl-param-clone-suggestion.rs:9:6
+   |
+LL | impl<T> Clone for S<C>
+   |     -^-
+   |     ||
+   |     |unconstrained type parameter
+   |     help: remove the unused type parameter `T`
+
+error[E0507]: cannot move out of `*self` which is behind a shared reference
+  --> $DIR/unconstrained-impl-param-clone-suggestion.rs:15:9
+   |
+LL |         *self
+   |         ^^^^^ move occurs because `*self` has type `S<C>`, which does not implement the `Copy` trait
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0207, E0507.
+For more information about an error, try `rustc --explain E0207`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/158437)*
<!-- homu-ignore:end -->

Successful merges:

 - rust-lang/rust#158360 (Various borrowck cleanups and param_env/opaque_types_defined_by query simplifications for typeck children)
 - rust-lang/rust#157127 (cg_LLVM: Stop needing an alloca for volatile loads)
 - rust-lang/rust#158244 (Attribute docs `deprecated` , `warn`, `allow`, `cfg`, `deny`, and `forbid` )
 - rust-lang/rust#158355 (Fixup the refactoring errors in rust-lang/rust#156246)
 - rust-lang/rust#158399 (std: truncate thread names on NetBSD)
 - rust-lang/rust#158430 (Guard clone suggestion against empty obligation errors)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=158360,157127,158244,158355,158399,158430)
<!-- homu-ignore:end -->

