### PR TITLE
Use rigidness marker in fast_reject

### DIFF
--- a/compiler/rustc_type_ir/src/fast_reject.rs
+++ b/compiler/rustc_type_ir/src/fast_reject.rs
@@ -256,13 +256,12 @@ impl<I: Interner, const INSTANTIATE_LHS_WITH_INFER: bool, const INSTANTIATE_RHS_
         match rhs.kind() {
             // Start by checking whether the `rhs` type may unify with
             // pretty much everything. Just return `true` in that case.
-            ty::Param(_) => {
+            ty::Param(_) | ty::Alias(ty::IsRigid::Yes, _) => {
                 if INSTANTIATE_RHS_WITH_INFER {
                     return true;
                 }
             }
-            // FIXME(#155345): we should fast-path for rigid aliases here.
-            ty::Error(_) | ty::Alias(..) | ty::Bound(..) => return true,
+            ty::Error(_) | ty::Alias(ty::IsRigid::No, _) | ty::Bound(..) => return true,
             ty::Infer(var) => return self.var_and_ty_may_unify(var, lhs),
 
             // These types only unify with inference variables or their own
@@ -339,12 +338,22 @@ impl<I: Interner, const INSTANTIATE_LHS_WITH_INFER: bool, const INSTANTIATE_RHS_
 
             ty::Infer(var) => self.var_and_ty_may_unify(var, rhs),
 
+            // Since we ensure that the rhs is not non-rigid alias,
+            // lhs rigid alias can only unify with it if it's a rigid alias of the same kind.
+            ty::Alias(ty::IsRigid::Yes, lhs_alias) => {
+                INSTANTIATE_LHS_WITH_INFER
+                    || match rhs.kind() {
+                        ty::Alias(ty::IsRigid::Yes, rhs_alias) => {
+                            lhs_alias.kind == rhs_alias.kind
+                                && self.args_may_unify_inner(lhs_alias.args, rhs_alias.args, depth)
+                        }
+                        _ => false,
+                    }
+            }
             // As we're walking the whole type, it may encounter projections
             // inside of binders and what not, so we're just going to assume that
-            // projections can unify with other stuff.
-            //
-            // Looking forward to lazy normalization this is the safer strategy anyways.
-            ty::Alias(..) => true,
+            // non-rigid alias can unify with anything.
+            ty::Alias(ty::IsRigid::No, _) => true,
 
             ty::Int(_)
             | ty::Uint(_)


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
Make use of rigidness marker to reject rigid-alias-non-alias or incompatible rigid-alias-rigid-alias relating, tracked in rust-lang/rust#155345

r? lcnr