### PR TITLE
Cleanup `NumBuffer` comment and replace `ilog(10)` with `ilog10()`

### DIFF
--- a/library/core/src/fmt/num.rs
+++ b/library/core/src/fmt/num.rs
@@ -361,7 +361,7 @@ macro_rules! impl_Display {
 
         #[cfg(feature = "optimize_for_size")]
         fn ${concat($fmt_fn, _small)}(n: $T, is_nonnegative: bool, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            const MAX_DEC_N: usize = $T::MAX.ilog(10) as usize + 1;
+            const MAX_DEC_N: usize = $T::MAX.ilog10() as usize + 1;
             let mut buf = [MaybeUninit::<u8>::uninit(); MAX_DEC_N];
 
             let offset = ${concat($fmt_fn, _in_buf_small)}(n, &mut buf);

--- a/library/core/src/fmt/num_buffer.rs
+++ b/library/core/src/fmt/num_buffer.rs
@@ -74,7 +74,6 @@ impl<T: NumBufferTrait> NumBuffer<T> {
     #[stable(feature = "int_format_into", since = "CURRENT_RUSTC_VERSION")]
     #[rustc_const_stable(feature = "int_format_into", since = "CURRENT_RUSTC_VERSION")]
     pub const fn new() -> Self {
-        // FIXME: Once const generics feature is working, use `T::BUF_SIZE` instead of 40.
         NumBuffer { buf: T::DEFAULT, phantom: core::marker::PhantomData }
     }
 }

--- a/library/core/src/fmt/num_buffer.rs
+++ b/library/core/src/fmt/num_buffer.rs
@@ -17,13 +17,13 @@ macro_rules! impl_NumBufferTrait {
             #[stable(feature = "int_format_into", since = "CURRENT_RUSTC_VERSION")]
             impl NumBufferTrait for $signed {
                 // `+ 2` and not `+ 1` to include the `-` character.
-                const DEFAULT: Self::Buf = [MaybeUninit::<u8>::uninit(); $signed::MAX.ilog(10) as usize + 2];
-                type Buf = [MaybeUninit<u8>; $signed::MAX.ilog(10) as usize + 2];
+                const DEFAULT: Self::Buf = [MaybeUninit::<u8>::uninit(); $signed::MAX.ilog10() as usize + 2];
+                type Buf = [MaybeUninit<u8>; $signed::MAX.ilog10() as usize + 2];
             }
             #[stable(feature = "int_format_into", since = "CURRENT_RUSTC_VERSION")]
             impl NumBufferTrait for $unsigned {
-                const DEFAULT: Self::Buf = [MaybeUninit::<u8>::uninit(); $unsigned::MAX.ilog(10) as usize + 1];
-                type Buf = [MaybeUninit<u8>; $unsigned::MAX.ilog(10) as usize + 1];
+                const DEFAULT: Self::Buf = [MaybeUninit::<u8>::uninit(); $unsigned::MAX.ilog10() as usize + 1];
+                type Buf = [MaybeUninit<u8>; $unsigned::MAX.ilog10() as usize + 1];
             }
         )*
     }


### PR DESCRIPTION
A [nice person from mastodon](https://toot.cat/@jamey/116815991086205506) pointed out that a `FIXME` comment should have been removed alongside the others in https://github.com/rust-lang/rust/pull/157976, and also pointed out that the documentation mentions that `ilog10` is more optimized than `ilog(10)`. Shouldn't matter much here but since I already made a PR to remove the FIXME comment...

r? @Amanieu 