### PR TITLE
regression test for `Trait<A><B>` in "consider further restricting this bound" suggestion

### DIFF
--- a/compiler/rustc_middle/src/ty/diagnostics.rs
+++ b/compiler/rustc_middle/src/ty/diagnostics.rs
@@ -398,15 +398,28 @@ pub fn suggest_constraining_type_params<'a>(
             }
         };
         let constraint = constraint.join(" + ");
-        let mut suggest_restrict = |span, bound_list_non_empty, open_paren_sp| {
-            let suggestion = if span_to_replace.is_some() {
-                constraint.clone()
-            } else if constraint.starts_with('<') {
-                constraint.clone()
+        let mut suggest_restrict = |span: Span, bound_list_non_empty, open_paren_sp| {
+            let (span, suggestion) = if span_to_replace.is_some() {
+                (span, constraint.clone())
+            } else if let Some(rest) = constraint.strip_prefix('<') {
+                // `constraint` adds generic args; check whether the bound already has some.
+                // Naively inserting `<B>` after `Foo<A>` yields invalid `Foo<A><B>`.
+                if span.lo() > BytePos(0)
+                    && tcx
+                        .sess
+                        .source_map()
+                        .span_to_snippet(span.with_lo(span.lo() - BytePos(1)))
+                        .as_deref()
+                        == Ok(">")
+                {
+                    (span.with_lo(span.lo() - BytePos(1)), format!(", {rest}"))
+                } else {
+                    (span, constraint.clone())
+                }
             } else if bound_list_non_empty {
-                format!(" + {constraint}")
+                (span, format!(" + {constraint}"))
             } else {
-                format!(" {constraint}")
+                (span, format!(" {constraint}"))
             };
 
             if let Some(open_paren_sp) = open_paren_sp {

--- a/compiler/rustc_middle/src/ty/diagnostics.rs
+++ b/compiler/rustc_middle/src/ty/diagnostics.rs
@@ -398,28 +398,15 @@ pub fn suggest_constraining_type_params<'a>(
             }
         };
         let constraint = constraint.join(" + ");
-        let mut suggest_restrict = |span: Span, bound_list_non_empty, open_paren_sp| {
-            let (span, suggestion) = if span_to_replace.is_some() {
-                (span, constraint.clone())
-            } else if let Some(rest) = constraint.strip_prefix('<') {
-                // `constraint` adds generic args; check whether the bound already has some.
-                // Naively inserting `<B>` after `Foo<A>` yields invalid `Foo<A><B>`.
-                if span.lo() > BytePos(0)
-                    && tcx
-                        .sess
-                        .source_map()
-                        .span_to_snippet(span.with_lo(span.lo() - BytePos(1)))
-                        .as_deref()
-                        == Ok(">")
-                {
-                    (span.with_lo(span.lo() - BytePos(1)), format!(", {rest}"))
-                } else {
-                    (span, constraint.clone())
-                }
+        let mut suggest_restrict = |span, bound_list_non_empty, open_paren_sp| {
+            let suggestion = if span_to_replace.is_some() {
+                constraint.clone()
+            } else if constraint.starts_with('<') {
+                constraint.clone()
             } else if bound_list_non_empty {
-                (span, format!(" + {constraint}"))
+                format!(" + {constraint}")
             } else {
-                (span, format!(" {constraint}"))
+                format!(" {constraint}")
             };
 
             if let Some(open_paren_sp) = open_paren_sp {

--- a/tests/ui/suggestions/restrict-bound-already-has-generic-args.rs
+++ b/tests/ui/suggestions/restrict-bound-already-has-generic-args.rs
@@ -18,6 +18,8 @@ impl<A, B> Pair for (A, B) {
 
 fn frob<A, B>(pair: impl Pair<Left = A>) -> impl Pair<Left = A, Right = B> {
     //~^ ERROR type mismatch
+    //~| HELP consider further restricting this bound
+    //~| SUGGESTION , Right = B
     let (left, right) = pair.split();
     (left, right)
 }

--- a/tests/ui/suggestions/restrict-bound-already-has-generic-args.rs
+++ b/tests/ui/suggestions/restrict-bound-already-has-generic-args.rs
@@ -1,0 +1,25 @@
+// Regression test for https://github.com/rust-lang/rust/issues/142803.
+
+trait Pair {
+    type Left;
+    type Right;
+
+    fn split(self) -> (Self::Left, Self::Right);
+}
+
+impl<A, B> Pair for (A, B) {
+    type Left = A;
+    type Right = B;
+
+    fn split(self) -> (Self::Left, Self::Right) {
+        self
+    }
+}
+
+fn frob<A, B>(pair: impl Pair<Left = A>) -> impl Pair<Left = A, Right = B> {
+    //~^ ERROR type mismatch
+    let (left, right) = pair.split();
+    (left, right)
+}
+
+fn main() {}

--- a/tests/ui/suggestions/restrict-bound-already-has-generic-args.stderr
+++ b/tests/ui/suggestions/restrict-bound-already-has-generic-args.stderr
@@ -1,0 +1,24 @@
+error[E0271]: type mismatch resolving `<(A, <impl Pair<Left = A> as Pair>::Right) as Pair>::Right == B`
+  --> $DIR/restrict-bound-already-has-generic-args.rs:19:45
+   |
+LL | fn frob<A, B>(pair: impl Pair<Left = A>) -> impl Pair<Left = A, Right = B> {
+   |            - expected this type parameter   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type mismatch resolving `<(A, <impl Pair<Left = A> as Pair>::Right) as Pair>::Right == B`
+...
+LL |     (left, right)
+   |     ------------- return type was inferred to be `(A, <impl Pair<Left = A> as Pair>::Right)` here
+   |
+note: expected this to be `B`
+  --> $DIR/restrict-bound-already-has-generic-args.rs:12:18
+   |
+LL |     type Right = B;
+   |                  ^
+   = note: expected type parameter `B`
+             found associated type `<impl Pair<Left = A> as Pair>::Right`
+help: consider further restricting this bound
+   |
+LL | fn frob<A, B>(pair: impl Pair<Left = A, Right = B>) -> impl Pair<Left = A, Right = B> {
+   |                                       +++++++++++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0271`.


### PR DESCRIPTION
when a bound already has generic args (e.g. `impl Pair<Left = A>`) the "consider further restricting this bound" suggestion would generate invalid syntax by appending a new `<Right = B>` producing `Pair<Left = A><Right = B>`.

the fix detects when the insertion point immediately follows a `>` and merges into the existing arg list instead producing the valid `Pair<Left = A, Right = B>`.

fixes https://github.com/rust-lang/rust/issues/142803

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
