### PR TITLE
std: fix xous dns ipv6 parsing off-by-one

### DIFF
--- a/library/std/src/sys/net/connection/xous/dns.rs
+++ b/library/std/src/sys/net/connection/xous/dns.rs
@@ -43,9 +43,8 @@ impl Iterator for LookupHost {
                     return None;
                 }
                 let mut new_addr = [0u8; 16];
-                for (src, octet) in self.data.0[(self.offset + 1)..(self.offset + 16 + 1)]
-                    .iter()
-                    .zip(new_addr.iter_mut())
+                for (src, octet) in
+                    self.data.0[self.offset..(self.offset + 16)].iter().zip(new_addr.iter_mut())
                 {
                     *octet = *src;
                 }


### PR DESCRIPTION
the ipv6 arm read the 16-byte address from offset+1 instead of offset, unlike the ipv4 arm. this mis-parsed every ipv6 result and let the slice reach offset+17 while the bounds check only guards offset+16, so a malformed dns response could index past the 4096-byte buffer and panic.