### PR TITLE
doc(rustc/linker-plugin-lto): fix typo 'compability' -> 'compatibility'

### DIFF
--- a/src/doc/rustc/src/linker-plugin-lto.md
+++ b/src/doc/rustc/src/linker-plugin-lto.md
@@ -21,7 +21,7 @@ also be compiled in thin LTO mode. To use fat LTO with linker-plugin-based LTO,
 the `rustc` compiler requires the additional `-C lto=fat` flag, and the
 interoperable language must likewise be compiled in fat LTO mode. Note that
 interoperable language must be compiled using the LLVM infrastructure
-(see more details in [toolchain compability](#toolchain-compatibility)).
+(see more details in [toolchain compatibility](#toolchain-compatibility)).
 
 The following table summarizes how to enable thin LTO and fat LTO in
 different compilers:


### PR DESCRIPTION
Fixes a doc typo in `src/doc/rustc/src/linker-plugin-lto.md`: "compability" -> "compatibility" in the description of the `-C linker-plugin-lto` flag.

The misspelled word was introduced in commit cd50e622774c (Feb 2026) and was never caught by automated spellcheck. The phrase reads "(see more details in [toolchain compability](#toolchain-compatibility))."

This is a documentation-only change, one line.

## AI assistance

This patch was drafted with the help of an AI coding assistant. The diff was reviewed line-by-line before submission; the change is limited to a typo and has been verified with `typos` (typos-cli 1.47.2) which flags "compability" as the only remaining typo in the file.
