### PR TITLE
Upgrade `jsonsocck` and `jsondoclint` to edition 2024.

### DIFF
--- a/src/tools/jsondocck/Cargo.toml
+++ b/src/tools/jsondocck/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "jsondocck"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 jsonpath-rust = "1.0.0"

--- a/src/tools/jsondoclint/Cargo.toml
+++ b/src/tools/jsondoclint/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "jsondoclint"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
No code changes were necessary to perform the upgrade. I used `cargo fix --edition`, and additionally had an AI tool review the source code against the [Rust 2024 edition guide](https://github.com/rust-lang/edition-guide/tree/master/src/rust-2024) and the [edition upgrade guide](https://doc.rust-lang.org/edition-guide/editions/transitioning-an-existing-project-to-a-new-edition.html) to ensure the change works properly.

r? @GuillaumeGomez 

**AI disclosure:** This PR is the product of a combination of manual work and AI tools. I secured approval in advance from the designated reviewer. I stand behind the quality of the code I'm submitting, and I vouch it's as good or better compared to if I had written every line by my own hand.