### PR TITLE
Add regression test for unexpected pointer dereference issue

### DIFF
--- a/tests/ui/traits/next-solver/unexpected-pointer-deref-issue-154568.rs
+++ b/tests/ui/traits/next-solver/unexpected-pointer-deref-issue-154568.rs
@@ -1,0 +1,22 @@
+// Regression test for #154568
+//@ compile-flags: -Znext-solver=globally
+
+trait Role {
+    type Inner;
+}
+
+struct HandshakeCallback<C>(C);
+struct Handshake<R: Role>(R::Inner);
+
+fn main() {
+    let callback = HandshakeCallback(());
+    let handshake = Handshake(callback.0.clone());
+    //~^ ERROR type annotations needed
+    match &handshake {
+        hs if (|| {
+            let borrowed_inner = &hs.0;
+            borrowed_inner == &callback.0
+        })() => println!(),
+        _ => {}
+    }
+}

--- a/tests/ui/traits/next-solver/unexpected-pointer-deref-issue-154568.stderr
+++ b/tests/ui/traits/next-solver/unexpected-pointer-deref-issue-154568.stderr
@@ -1,0 +1,20 @@
+error[E0283]: type annotations needed for `Handshake<_>`
+  --> $DIR/unexpected-pointer-deref-issue-154568.rs:13:9
+   |
+LL |     let handshake = Handshake(callback.0.clone());
+   |         ^^^^^^^^^   ----------------------------- type must be known at this point
+   |
+   = note: the type must implement `Role`
+note: required by a bound in `Handshake`
+  --> $DIR/unexpected-pointer-deref-issue-154568.rs:9:21
+   |
+LL | struct Handshake<R: Role>(R::Inner);
+   |                     ^^^^ required by this bound in `Handshake`
+help: consider giving `handshake` an explicit type, where the type for type parameter `R` is specified
+   |
+LL |     let handshake: Handshake<R> = Handshake(callback.0.clone());
+   |                  ++++++++++++++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0283`.


### PR DESCRIPTION
I try to pick up rust-lang/rust#154568 and found it's fixed by https://github.com/rust-lang/rust/commit/4767f23f58155cd17856d31e43917eaefee5e341.

Fixes rust-lang/rust#154568

cc @adwinwhite
