### PR TITLE
Add `riscv32imfc-unknown-none-elf` bare-metal target

### DIFF
--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -1686,6 +1686,7 @@ supported_targets! {
     ("riscv32im-unknown-none-elf", riscv32im_unknown_none_elf),
     ("riscv32ima-unknown-none-elf", riscv32ima_unknown_none_elf),
     ("riscv32imc-unknown-none-elf", riscv32imc_unknown_none_elf),
+    ("riscv32imfc-unknown-none-elf", riscv32imfc_unknown_none_elf),
     ("riscv32imc-esp-espidf", riscv32imc_esp_espidf),
     ("riscv32imac-esp-espidf", riscv32imac_esp_espidf),
     ("riscv32imafc-esp-espidf", riscv32imafc_esp_espidf),

--- a/compiler/rustc_target/src/spec/targets/riscv32imfc_unknown_none_elf.rs
+++ b/compiler/rustc_target/src/spec/targets/riscv32imfc_unknown_none_elf.rs
@@ -1,0 +1,44 @@
+use crate::spec::{
+    Arch, Cc, LinkerFlavor, Lld, LlvmAbi, PanicStrategy, RelocModel, Target, TargetMetadata,
+    TargetOptions,
+};
+
+// Bare-metal RV32IMFC for cores that have hardware single-precision float (the `F`
+// extension, with the `ilp32f` ABI) but NO atomic ('a') extension.
+// This is `riscv32imafc-unknown-none-elf` MINUS the atomic extension, handled the
+// same way the in-tree `riscv32imc-unknown-none-elf` handles a no-`a` core:
+// `+forced-atomics` makes atomic load/store lower to plain ld/st (sound on a single
+// hart) while `atomic_cas = false` keeps RMW/CAS off — downstream crates use a
+// critical-section polyfill (e.g. portable-atomic) for those. No lr.w/sc.w/amo* are
+// ever emitted, so it does not trap on a core without the A extension.
+pub(crate) fn target() -> Target {
+    Target {
+        data_layout: "e-m:e-p:32:32-i64:64-n32-S128".into(),
+        llvm_target: "riscv32".into(),
+        metadata: TargetMetadata {
+            description: Some(
+                "Bare RISC-V (RV32IMFC ISA, hardware single-float, no atomics)".into(),
+            ),
+            tier: Some(3),
+            host_tools: Some(false),
+            std: Some(false),
+        },
+        pointer_width: 32,
+        arch: Arch::RiscV32,
+
+        options: TargetOptions {
+            linker_flavor: LinkerFlavor::Gnu(Cc::No, Lld::Yes),
+            linker: Some("rust-lld".into()),
+            cpu: "generic-rv32".into(),
+            max_atomic_width: Some(32),
+            atomic_cas: false,
+            features: "+m,+f,+c,+forced-atomics".into(),
+            llvm_abiname: LlvmAbi::Ilp32f,
+            panic_strategy: PanicStrategy::Abort,
+            relocation_model: RelocModel::Static,
+            emit_debug_gdb_scripts: false,
+            eh_frame_header: false,
+            ..Default::default()
+        },
+    }
+}

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -397,6 +397,7 @@ target | std | host | notes
 `riscv32gc-unknown-linux-musl` | ? |  | RISC-V Linux (kernel 5.4, musl 1.2.5)
 [`riscv32im-risc0-zkvm-elf`](platform-support/riscv32im-risc0-zkvm-elf.md) | ? |  | RISC Zero's zero-knowledge Virtual Machine (RV32IM ISA)
 [`riscv32ima-unknown-none-elf`](platform-support/riscv32-unknown-none-elf.md) | * |  | Bare RISC-V (RV32IMA ISA)
+[`riscv32imfc-unknown-none-elf`](platform-support/riscv32-unknown-none-elf.md) | * |  | Bare RISC-V (RV32IMFC ISA, hardware single-float, no atomics)
 [`riscv32imac-esp-espidf`](platform-support/esp-idf.md) | ✓ |  | RISC-V ESP-IDF
 [`riscv32imac-unknown-nuttx-elf`](platform-support/nuttx.md) | ✓ |  | RISC-V 32bit with NuttX
 [`riscv32imac-unknown-xous-elf`](platform-support/riscv32imac-unknown-xous-elf.md) | ? |  | RISC-V Xous (RV32IMAC ISA)

--- a/src/doc/rustc/src/platform-support/riscv32-unknown-none-elf.md
+++ b/src/doc/rustc/src/platform-support/riscv32-unknown-none-elf.md
@@ -1,4 +1,4 @@
-# `riscv32{i,im,ima,imc,imac,imafc}-unknown-none-elf`
+# `riscv32{i,im,ima,imc,imfc,imac,imafc}-unknown-none-elf`
 
 **Tier: 2**
 
@@ -6,11 +6,24 @@ Bare-metal target for RISC-V CPUs with the RV32I, RV32IM, RV32IMC, RV32IMAFC and
 
 **Tier: 3**
 
-Bare-metal target for RISC-V CPUs with the RV32IMA ISA.
+Bare-metal target for RISC-V CPUs with the RV32IMA and RV32IMFC ISAs.
+
+The `riscv32imfc-unknown-none-elf` target covers RV32IMFC cores that have
+hardware single-precision floating point (the `F` extension, using the `ilp32f`
+ABI) but *no* atomic (`A`) extension. Like `riscv32imc-unknown-none-elf`, it is
+built with `+forced-atomics`: atomic loads/stores lower to plain loads/stores
+(sound on a single hart) and `lr`/`sc`/`amo*` instructions are never emitted, so
+it does not trap on a core without the `A` extension. Compare-and-swap and other
+read-modify-write atomics are disabled (`atomic_cas = false`); downstream crates
+that need them use a critical-section polyfill (e.g. `portable-atomic`).
 
 ## Target maintainers
 
 * Rust Embedded Working Group, [RISC-V team](https://github.com/rust-embedded/wg#the-risc-v-team)
+
+The `riscv32imfc-unknown-none-elf` target is additionally maintained by:
+
+* [@sanchuanhehe](https://github.com/sanchuanhehe)
 
 ## Requirements
 

--- a/tests/assembly-llvm/targets/targets-elf.rs
+++ b/tests/assembly-llvm/targets/targets-elf.rs
@@ -496,6 +496,9 @@
 //@ revisions: riscv32imc_unknown_none_elf
 //@ [riscv32imc_unknown_none_elf] compile-flags: --target riscv32imc-unknown-none-elf
 //@ [riscv32imc_unknown_none_elf] needs-llvm-components: riscv
+//@ revisions: riscv32imfc_unknown_none_elf
+//@ [riscv32imfc_unknown_none_elf] compile-flags: --target riscv32imfc-unknown-none-elf
+//@ [riscv32imfc_unknown_none_elf] needs-llvm-components: riscv
 //@ revisions: riscv64_linux_android
 //@ [riscv64_linux_android] compile-flags: --target riscv64-linux-android
 //@ [riscv64_linux_android] needs-llvm-components: riscv


### PR DESCRIPTION
This adds a new tier 3 bare-metal target for RV32IMFC cores: RISC-V 32-bit with
the `M`, `F` (hardware single-precision float, `ilp32f` ABI) and `C` extensions,
but **no** atomic (`A`) extension.

## Why a new builtin target

No builtin target pairs **hardware single-float** with **no atomics** today:

- `riscv32imafc-unknown-none-elf` (tier 2) has hard-float but *requires* `A`.
- `riscv32imc-unknown-none-elf` has no atomics but is **soft-float** (`ilp32`).

Cores that have an `F` unit but no `A` extension (a common shape for the
application core of low-power Wi-Fi/BT SoCs, where vendor-supplied closed binary
blobs are compiled with the `ilp32f` ABI, so the soft-float ABI is incompatible)
currently have to ship a custom JSON target spec and build `core` with
`-Zbuild-std` on nightly. There is **no stable path today**: custom target specs
are nightly-only, and the spec drifts with each nightly. A builtin target lets
these users stay on stable with a precompiled `core`. The motivating hardware
includes the application core of SoCs such as the HiSilicon WS63/BS2X family, but
the target itself is vendor-neutral.

A working nightly + `-Zbuild-std` proof of concept (builds `core`/`alloc`,
confirms hard-float `fmul.s`/`fadd.s`, and that atomics lower to plain `lw`/`sw`
with zero `amo*`/`lr.w`/`sc.w`): https://github.com/hispark-rs/hisi-riscv-imfc-poc

## How it is defined

It is `riscv32imafc-unknown-none-elf` minus the `A` extension, handled exactly the
way the existing `riscv32imc-unknown-none-elf` handles a no-`a` core:

- `features = "+m,+f,+c,+forced-atomics"`, `llvm_abiname = ilp32f`
- `atomic_cas = false`: `lr.w`/`sc.w`/`amo*` are never emitted, so the target does
  not trap on a core without `A`. `+forced-atomics` lowers atomic load/store to
  plain load/store (sound on a single hart); compare-and-swap and other RMW
  atomics are off, so downstream crates use a critical-section polyfill (e.g.
  `portable-atomic`'s `critical-section` feature) for those.

## Changes

- New target spec `riscv32imfc_unknown_none_elf.rs` + registration in `spec/mod.rs`.
- Added to the `tests/assembly-llvm/targets/targets-elf.rs` sanity test (satisfies
  the `target_policy` and `target_specific_tests` tidy checks).
- Documented on the shared `riscv32-unknown-none-elf` platform-support page and
  listed in `platform-support.md`.

## Verification

- `./x test tidy` — passes.
- `./x test tests/assembly-llvm/targets/targets-elf.rs` — passes (262 passed,
  0 failed); satisfies the "must be able to produce assembly" requirement.

## Tier 3 target policy

Acknowledgement of each [tier 3 target policy](https://doc.rust-lang.org/rustc/target-tier-policy.html#tier-3-target-policy) requirement:

> A tier 3 target must have a designated developer or developers (the "target maintainers") on record to be CCed when issues arise regarding the target. (The mechanism to track and CC such developers may evolve over time.)

Ack. @sanchuanhehe will maintain the target; recorded on the
`riscv32-unknown-none-elf` platform-support page.

> Targets must use naming consistent with any existing targets; for instance, a target for the same CPU or OS as an existing Rust target should use the same name for that CPU or OS. Targets should normally use the same names and naming conventions as used elsewhere in the broader ecosystem beyond Rust (such as in other toolchains), unless they have a very good reason to diverge. Changing the name of a target can be highly disruptive, especially once the target reaches a higher tier, so getting the name right is important even for a tier 3 target.
>
> Target names should not introduce undue confusion or ambiguity unless absolutely necessary to maintain ecosystem compatibility. For example, if the name of the target makes people extremely likely to form incorrect beliefs about what it targets, the name should be changed or augmented to disambiguate it.
>
> If possible, use only letters, numbers, dashes and underscores for the name. Periods (.) are known to cause issues in Cargo.

Ack. The target is named `riscv32imfc-unknown-none-elf`, fitting the existing
`riscv32im{,a,c,fc,ac,afc}-unknown-none-elf` family: standard RISC-V ISA-extension
letters (`imfc`) and the `unknown-none-elf` triple shared by the other bare-metal
RISC-V targets. The name uses only letters, numbers and dashes.

> Tier 3 targets may have unusual requirements to build or use, but must not create legal issues or impose onerous legal terms for the Rust project or for Rust developers or users.
>
> The target must not introduce license incompatibilities.
>
> Anything added to the Rust repository must be under the standard Rust license (MIT OR Apache-2.0).
>
> The target must not cause the Rust tools or libraries built for any other host (even when supporting cross-compilation to the target) to depend on any new dependency less permissive than the Rust licensing policy.
>
> Compiling, linking, and emitting functional binaries, libraries, or other code for the target must not depend on proprietary (non-FOSS) libraries.

Ack. Everything added is under `MIT OR Apache-2.0`. The change is a purely
additive target spec plus docs and a test; it introduces no new dependency and no
proprietary component. Code generation uses the in-tree LLVM RISC-V backend only.

> Neither this policy nor any decisions made regarding targets shall create any binding agreement or estoppel by any party. If any member of an approving Rust team serves as one of the maintainers of a target, or has any legal or employment requirement (explicit or implicit) that might affect their decisions regarding a target, they must recuse themselves from any approval decisions regarding the target's tier status, though they may otherwise participate in discussions.

Ack.

> Tier 3 targets should attempt to implement as much of the standard libraries as possible and appropriate (core for most targets, alloc for targets that can support dynamic memory allocation, std for targets with an operating system or equivalent layer of system-provided functionality), but may leave some code unimplemented (either unavailable or stubbed out as appropriate), whether because the target makes it impossible to implement or challenging to implement. The authors of pull requests are not obligated to avoid calling any portions of the standard library on the basis of a tier 3 target not implementing those portions.

Ack. This is a bare-metal `no_std` target (`std: false`). `core` and `alloc`
build for it, the same as the sibling `riscv32imc` / `riscv32imafc` targets; `std`
is not applicable as there is no operating system layer.

> The target must provide documentation for the Rust community explaining how to build for the target, using cross-compilation if possible. If the target supports running binaries, or running tests (even if they do not pass), the documentation must explain how to run such binaries or tests for the target, using emulation if possible or dedicated hardware if necessary.

Ack. Documented on the shared `riscv32-unknown-none-elf` platform-support page
(cross-compiled, `rust-lld`, linker-script requirement). Like the other bare-metal
RISC-V targets, the Rust test suite cannot be run on it; it must be run in a
simulator or on hardware.

> Tier 3 targets must not impose burden on the authors of pull requests, or other developers in the community, to maintain the target. In particular, do not post comments (automated or manual) on a PR that derail or suggest a block on the PR based on a tier 3 target. Do not send automated messages or notifications (via any medium, including via @) to a PR author or others involved with a PR regarding a tier 3 target, unless they have opted into such messages.

Ack.

> Patches adding or updating tier 3 targets must not break any existing tier 2 or tier 1 target, and must not knowingly break another tier 3 target without approval of either the compiler team or the maintainers of the other tier 3 target. In particular, this may come up when working on closely related targets, such as variations of the same architecture with different features. Avoid introducing unconditional uses of features that another variation of the target may not have; use conditional compilation or runtime detection, as appropriate, to let each target run code supported by that target.

Ack. The change is additive only and touches no code shared with other targets;
`./x test tidy` and the `targets-elf` assembly test pass. No unconditional use of
any feature is introduced that would affect other RISC-V target variations.

> Tier 3 targets must be able to produce assembly using at least one of rustc's supported backends from any host target. (Having support in a fork of the backend is not sufficient, it must be upstream.)

Ack. Covered by the new `tests/assembly-llvm/targets/targets-elf.rs` revision,
which passes using the upstream LLVM backend.

> If a tier 3 target stops meeting these requirements [...] we may post a PR to remove it; any such PR will be CCed to the target maintainers [...] to check potential interest in improving the situation.

Ack.
