### PR TITLE
Remove redundant dyn-compatibility check.

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -771,12 +771,10 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                     Ok(EvaluatedToOkModuloRegions)
                 }
 
-                ty::PredicateKind::DynCompatible(trait_def_id) => {
-                    if self.tcx().is_dyn_compatible(trait_def_id) {
-                        Ok(EvaluatedToOk)
-                    } else {
-                        Ok(EvaluatedToErr)
-                    }
+                ty::PredicateKind::DynCompatible(_) => {
+                    bug!(
+                        "Obligation {obligation:?} should have been handled by fulfillment already."
+                    )
                 }
 
                 ty::PredicateKind::Clause(ty::ClauseKind::Projection(data)) => {


### PR DESCRIPTION
This check is already handled in [`rustc_trait_selection::traits::fulfill::FulfillProcessor::process_obligation`](https://github.com/rust-lang/rust/blob/16761606d606b6ec4d0c88fc9251670742ad9fd2/compiler/rustc_trait_selection/src/traits/fulfill.rs#L524).

r? types