### PR TITLE
Use correct typing mode in mir building for the next solver

### DIFF
--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -1127,6 +1127,23 @@ impl<'tcx> TypingEnv<'tcx> {
         Self::new(tcx.param_env(def_id), TypingMode::non_body_analysis())
     }
 
+    /// Ideally we just use `TypingMode::PostTypeckUntilBorrowck`.
+    /// But that's not compatible with the old solver yet.
+    ///
+    /// FIXME: this should not be needed in the long term.
+    pub fn post_typeck_until_borrowck_for_mir_build(
+        tcx: TyCtxt<'tcx>,
+        def_id: LocalDefId,
+    ) -> TypingEnv<'tcx> {
+        if tcx.use_typing_mode_post_typeck_until_borrowck() {
+            TypingEnv::new(tcx.param_env(def_id.to_def_id()), ty::TypingMode::borrowck(tcx, def_id))
+        } else {
+            // FIXME(#132279): We're in a body, we should use a typing
+            // mode which reveals the opaque types defined by that body.
+            TypingEnv::non_body_analysis(tcx, def_id)
+        }
+    }
+
     pub fn post_analysis(tcx: TyCtxt<'tcx>, def_id: impl IntoQueryKey<DefId>) -> TypingEnv<'tcx> {
         TypingEnv::new(tcx.param_env_normalized_for_post_analysis(def_id), TypingMode::PostAnalysis)
     }

--- a/compiler/rustc_mir_build/src/builder/mod.rs
+++ b/compiler/rustc_mir_build/src/builder/mod.rs
@@ -505,9 +505,15 @@ fn construct_fn<'tcx>(
         );
     }
 
-    // FIXME(#132279): This should be able to reveal opaque
-    // types defined during HIR typeck.
-    let infcx = tcx.infer_ctxt().build(TypingMode::non_body_analysis());
+    let typing_mode = if tcx.use_typing_mode_post_typeck_until_borrowck() {
+        TypingMode::borrowck(tcx, fn_def)
+    } else {
+        // FIXME(#132279): This should be able to reveal opaque
+        // types defined during HIR typeck.
+        TypingMode::non_body_analysis()
+    };
+
+    let infcx = tcx.infer_ctxt().build(typing_mode);
     let mut builder = Builder::new(
         thir,
         infcx,
@@ -586,9 +592,15 @@ fn construct_const<'a, 'tcx>(
         _ => span_bug!(tcx.def_span(def), "can't build MIR for {:?}", def),
     };
 
-    // FIXME(#132279): We likely want to be able to use the hidden types of
-    // opaques used by this function here.
-    let infcx = tcx.infer_ctxt().build(TypingMode::non_body_analysis());
+    let typing_mode = if tcx.use_typing_mode_post_typeck_until_borrowck() {
+        TypingMode::borrowck(tcx, def)
+    } else {
+        // FIXME(#132279): This should be able to reveal opaque
+        // types defined during HIR typeck.
+        TypingMode::non_body_analysis()
+    };
+
+    let infcx = tcx.infer_ctxt().build(typing_mode);
     let mut builder =
         Builder::new(thir, infcx, def, hir_id, span, 0, const_ty, const_ty_span, None);
 

--- a/compiler/rustc_mir_build/src/builder/scope.rs
+++ b/compiler/rustc_mir_build/src/builder/scope.rs
@@ -969,8 +969,10 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             tcx: self.tcx,
             typeck_results,
             module: self.tcx.parent_module(self.hir_id).to_def_id(),
-            // FIXME(#132279): We're in a body, should handle opaques.
-            typing_env: rustc_middle::ty::TypingEnv::non_body_analysis(self.tcx, self.def_id),
+            typing_env: ty::TypingEnv::post_typeck_until_borrowck_for_mir_build(
+                self.tcx,
+                self.def_id,
+            ),
             dropless_arena: &dropless_arena,
             match_lint_level: self.hir_id,
             whole_match_span: Some(rustc_span::Span::default()),

--- a/compiler/rustc_mir_build/src/check_tail_calls.rs
+++ b/compiler/rustc_mir_build/src/check_tail_calls.rs
@@ -27,8 +27,7 @@ pub(crate) fn check_tail_calls(tcx: TyCtxt<'_>, def: LocalDefId) -> Result<(), E
         tcx,
         thir,
         found_errors: Ok(()),
-        // FIXME(#132279): we're clearly in a body here.
-        typing_env: ty::TypingEnv::non_body_analysis(tcx, def),
+        typing_env: ty::TypingEnv::post_typeck_until_borrowck_for_mir_build(tcx, def),
         is_closure,
         caller_def_id: def,
     };

--- a/compiler/rustc_mir_build/src/check_unsafety.rs
+++ b/compiler/rustc_mir_build/src/check_unsafety.rs
@@ -1093,8 +1093,7 @@ pub(crate) fn check_unsafety(tcx: TyCtxt<'_>, def: LocalDefId) {
         body_target_features,
         assignment_info: None,
         in_union_destructure: false,
-        // FIXME(#132279): we're clearly in a body here.
-        typing_env: ty::TypingEnv::non_body_analysis(tcx, def),
+        typing_env: ty::TypingEnv::post_typeck_until_borrowck_for_mir_build(tcx, def),
         inside_adt: false,
         warnings: &mut warnings,
         suggest_unsafe_block: true,

--- a/compiler/rustc_mir_build/src/thir/cx/mod.rs
+++ b/compiler/rustc_mir_build/src/thir/cx/mod.rs
@@ -99,9 +99,7 @@ impl<'tcx> ThirBuildCx<'tcx> {
         Self {
             tcx,
             thir: Thir::new(body_type),
-            // FIXME(#132279): We're in a body, we should use a typing
-            // mode which reveals the opaque types defined by that body.
-            typing_env: ty::TypingEnv::non_body_analysis(tcx, def),
+            typing_env: ty::TypingEnv::post_typeck_until_borrowck_for_mir_build(tcx, def),
             typeck_results,
             body_owner: def.to_def_id(),
             apply_adjustments: !find_attr!(tcx, hir_id, CustomMir(..)),

--- a/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
@@ -39,8 +39,7 @@ pub(crate) fn check_match(tcx: TyCtxt<'_>, def_id: LocalDefId) -> Result<(), Err
         tcx,
         thir: &*thir,
         typeck_results,
-        // FIXME(#132279): We're in a body, should handle opaques.
-        typing_env: ty::TypingEnv::non_body_analysis(tcx, def_id),
+        typing_env: ty::TypingEnv::post_typeck_until_borrowck_for_mir_build(tcx, def_id),
         hir_source: tcx.local_def_id_to_hir_id(def_id),
         let_source: LetSource::None,
         pattern_arena: &pattern_arena,

--- a/tests/ui/traits/next-solver/opaques/wrong-typing-mode-ice-1.rs
+++ b/tests/ui/traits/next-solver/opaques/wrong-typing-mode-ice-1.rs
@@ -1,0 +1,27 @@
+//@ compile-flags: -Znext-solver
+//@ edition: 2024
+
+// Previously, when building MIR body, we were using typing env
+// `non_body_analysis` which is wrong since we're indeed in a body.
+// It caused opaque types in defining body to be not revealed.
+// This caused opaque types in the defining body not to be revealed.
+
+#![feature(type_alias_impl_trait)]
+
+struct Task<F>(F);
+
+impl Task<Foo> {
+    fn spawn(&self, _: impl FnOnce() -> Foo) {}
+}
+type Foo = impl Sized;
+
+#[define_opaque(Foo)]
+fn foo() {
+    async fn cb() {}
+    Task::spawn(&POOL, cb)
+}
+
+static POOL: Task<Foo> = todo!();
+//~^ ERROR: evaluation panicked
+
+fn main() {}

--- a/tests/ui/traits/next-solver/opaques/wrong-typing-mode-ice-1.stderr
+++ b/tests/ui/traits/next-solver/opaques/wrong-typing-mode-ice-1.stderr
@@ -1,0 +1,9 @@
+error[E0080]: evaluation panicked: not yet implemented
+  --> $DIR/wrong-typing-mode-ice-1.rs:24:26
+   |
+LL | static POOL: Task<Foo> = todo!();
+   |                          ^^^^^^^ evaluation of `POOL` failed here
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0080`.

--- a/tests/ui/traits/next-solver/opaques/wrong-typing-mode-ice-2.rs
+++ b/tests/ui/traits/next-solver/opaques/wrong-typing-mode-ice-2.rs
@@ -1,0 +1,15 @@
+//@ compile-flags: -Znext-solver
+//@ check-pass
+
+// Previously, when building MIR body, we were using typing env
+// `non_body_analysis` which is wrong since we're indeed in a body.
+// It caused opaque types in defining body to be not revealed.
+// This caused opaque types in the defining body not to be revealed.
+
+#![feature(type_alias_impl_trait)]
+fn main() {
+    struct Foo(U);
+    type U = impl Copy;
+    let foo: _ = Foo(());
+    let Foo(()) = foo;
+}


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
Previously, we used typing env `non_body_analysis`  when building MIR body.
This is wrong because we're in a body and should reveal opaque types defined in this scope.

Fixes rust-lang/rust#158439
Fixes rust-lang/rust#158429

r? lcnr or anyone familiar with typing modes.