### PR TITLE
Reject static item as direct const generic arg

### DIFF
--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
@@ -2933,7 +2933,10 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                 .unwrap_or_else(|guar| Const::new_error(tcx, guar))
             }
             Res::Def(DefKind::Static { .. }, _) => {
-                span_bug!(span, "use of bare `static` ConstArgKind::Path's not yet supported")
+                let guar = self
+                    .dcx()
+                    .span_err(path.span, "static items cannot be used as const arguments");
+                return Const::new_error(tcx, guar);
             }
             // FIXME(const_generics): create real const to allow fn items as const paths
             Res::Def(DefKind::Fn | DefKind::AssocFn, did) => {

--- a/tests/ui/const-generics/mgca/static-const-arg.rs
+++ b/tests/ui/const-generics/mgca/static-const-arg.rs
@@ -2,7 +2,7 @@
 // FIXME(min_generic_const_args): using statics as direct const arguments should error instead of
 // ICEing until const eval can evaluate statics to valtrees for const generics.
 
-#![feature(min_generic_const_args)]
+#![feature(min_generic_const_args, macroless_generic_const_args)]
 #![allow(incomplete_features)]
 
 static A: u32 = 0;

--- a/tests/ui/const-generics/mgca/static-const-arg.rs
+++ b/tests/ui/const-generics/mgca/static-const-arg.rs
@@ -1,0 +1,18 @@
+// Regression test for #132986.
+// FIXME(min_generic_const_args): using statics as direct const arguments should error instead of
+// ICEing until const eval can evaluate statics to valtrees for const generics.
+
+#![feature(min_generic_const_args)]
+#![allow(incomplete_features)]
+
+static A: u32 = 0;
+
+struct Foo<const N: u32>;
+
+const _: Foo<{ A }> = Foo;
+//~^ ERROR static items cannot be used as const arguments
+
+const _: Foo<A> = Foo;
+//~^ ERROR static items cannot be used as const arguments
+
+fn main() {}

--- a/tests/ui/const-generics/mgca/static-const-arg.stderr
+++ b/tests/ui/const-generics/mgca/static-const-arg.stderr
@@ -1,0 +1,14 @@
+error: static items cannot be used as const arguments
+  --> $DIR/static-const-arg.rs:12:16
+   |
+LL | const _: Foo<{ A }> = Foo;
+   |                ^
+
+error: static items cannot be used as const arguments
+  --> $DIR/static-const-arg.rs:15:14
+   |
+LL | const _: Foo<A> = Foo;
+   |              ^
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
closes: rust-lang/rust#136139



This PR fixes the ICE and not add support for static in MGCA