### PR TITLE
add smoketest for std::net::hostname

### DIFF
--- a/library/std/src/net/ip_addr/tests.rs
+++ b/library/std/src/net/ip_addr/tests.rs
@@ -1,5 +1,5 @@
 use crate::net::Ipv4Addr;
-use crate::net::test::{sa4, tsa};
+use crate::net::tests::{sa4, tsa};
 
 #[test]
 fn to_socket_addr_socketaddr() {

--- a/library/std/src/net/mod.rs
+++ b/library/std/src/net/mod.rs
@@ -43,7 +43,7 @@ mod ip_addr;
 mod socket_addr;
 mod tcp;
 #[cfg(test)]
-pub(crate) mod test;
+pub(crate) mod tests;
 mod udp;
 
 /// Possible values which can be passed to the [`TcpStream::shutdown`] method.

--- a/library/std/src/net/socket_addr/tests.rs
+++ b/library/std/src/net/socket_addr/tests.rs
@@ -1,4 +1,4 @@
-use crate::net::test::{sa4, sa6, tsa};
+use crate::net::tests::{sa4, sa6, tsa};
 use crate::net::*;
 
 #[test]

--- a/library/std/src/net/tcp/tests.rs
+++ b/library/std/src/net/tcp/tests.rs
@@ -3,7 +3,7 @@ use rand::Rng;
 use crate::io::prelude::*;
 use crate::io::{BorrowedBuf, ErrorKind, IoSlice, IoSliceMut};
 use crate::mem::MaybeUninit;
-use crate::net::test::{LOCALHOST_IP4, LOCALHOST_IP6};
+use crate::net::tests::{LOCALHOST_IP4, LOCALHOST_IP6};
 use crate::net::*;
 use crate::sync::mpsc::channel;
 use crate::time::{Duration, Instant};

--- a/library/std/src/net/tests.rs
+++ b/library/std/src/net/tests.rs
@@ -36,3 +36,13 @@ pub fn compare_ignore_zoneid(a: &SocketAddr, b: &SocketAddr) -> bool {
         _ => a == b,
     }
 }
+
+#[test]
+fn hostname_smoketest() {
+    // Just a smoke test to ensure it can be called.
+    let name = crate::net::hostname();
+    if cfg!(windows) || cfg!(unix) {
+        // At least on Windows and Unix, this should succeed.
+        name.unwrap();
+    }
+}

--- a/library/std/src/net/udp/tests.rs
+++ b/library/std/src/net/udp/tests.rs
@@ -1,5 +1,5 @@
 use crate::io::ErrorKind;
-use crate::net::test::{LOCALHOST_IP4, LOCALHOST_IP6, compare_ignore_zoneid};
+use crate::net::tests::{LOCALHOST_IP4, LOCALHOST_IP6, compare_ignore_zoneid};
 use crate::net::*;
 use crate::sync::mpsc::channel;
 use crate::thread;

--- a/library/std/src/os/net/linux_ext/tests.rs
+++ b/library/std/src/os/net/linux_ext/tests.rs
@@ -1,6 +1,6 @@
 #[test]
 fn quickack() {
-    use crate::net::test::LOCALHOST_IP4;
+    use crate::net::tests::LOCALHOST_IP4;
     use crate::net::{TcpListener, TcpStream};
     use crate::os::net::linux_ext::tcp::TcpStreamExt;
 
@@ -29,7 +29,7 @@ fn quickack() {
 #[test]
 #[cfg(target_os = "linux")]
 fn deferaccept() {
-    use crate::net::test::LOCALHOST_IP4;
+    use crate::net::tests::LOCALHOST_IP4;
     use crate::net::{TcpListener, TcpStream};
     use crate::os::net::linux_ext::tcp::TcpStreamExt;
     use crate::time::Duration;


### PR DESCRIPTION
This function is currently not invoked by any test, which is why I didn't even realize that Miri does not support it.

Tracking issue: https://github.com/rust-lang/rust/issues/135142