### PR TITLE
signed strict division: just use normal division

### DIFF
--- a/library/core/src/num/imp/overflow_panic.rs
+++ b/library/core/src/num/imp/overflow_panic.rs
@@ -22,12 +22,6 @@ pub(in crate::num) const fn mul() -> ! {
 
 #[cold]
 #[track_caller]
-pub(in crate::num) const fn div() -> ! {
-    panic!("attempt to divide with overflow")
-}
-
-#[cold]
-#[track_caller]
 pub(in crate::num) const fn rem() -> ! {
     panic!("attempt to calculate the remainder with overflow")
 }

--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -983,8 +983,11 @@ macro_rules! int_impl {
         /// This function will always panic on overflow, regardless of whether overflow checks are enabled.
         ///
         /// The only case where such an overflow can occur is when one divides `MIN / -1` on a signed type (where
-        /// [`MIN`](Self::MIN) is the negative minimal value for the type); this is equivalent to `-MIN`, a positive value
+        /// [`MIN`](Self::MIN) is the negative minimal value for the type); the result of this is `-MIN`, a positive value
         /// that is too large to represent in the type.
+        ///
+        /// Note that this is equivalent to normal division: `MIN / -1` will also panic both in
+        /// debug and release builds.
         ///
         /// # Examples
         ///
@@ -1010,8 +1013,8 @@ macro_rules! int_impl {
         #[inline]
         #[track_caller]
         pub const fn strict_div(self, rhs: Self) -> Self {
-            let (a, b) = self.overflowing_div(rhs);
-            if b { imp::overflow_panic::div() } else { a }
+            // Normal division already checks for "div-by-minus-1".
+            self / rhs
         }
 
         /// Checked Euclidean division. Computes `self.div_euclid(rhs)`,
@@ -1050,8 +1053,11 @@ macro_rules! int_impl {
         /// This function will always panic on overflow, regardless of whether overflow checks are enabled.
         ///
         /// The only case where such an overflow can occur is when one divides `MIN / -1` on a signed type (where
-        /// [`MIN`](Self::MIN) is the negative minimal value for the type); this is equivalent to `-MIN`, a positive value
+        /// [`MIN`](Self::MIN) is the negative minimal value for the type); the result of this is `-MIN`, a positive value
         /// that is too large to represent in the type.
+        ///
+        /// Note that this is equivalent to `div_euclid`: `MIN.div_euclid(-1)` will also panic both
+        /// in debug and release builds.
         ///
         /// # Examples
         ///
@@ -1077,8 +1083,8 @@ macro_rules! int_impl {
         #[inline]
         #[track_caller]
         pub const fn strict_div_euclid(self, rhs: Self) -> Self {
-            let (a, b) = self.overflowing_div_euclid(rhs);
-            if b { imp::overflow_panic::div() } else { a }
+            // Normal `div_euclid` already checks for "div-by-minus-1".
+            self.div_euclid(rhs)
         }
 
         /// Checked integer division without remainder. Computes `self / rhs`,


### PR DESCRIPTION
For some reason, https://github.com/rust-lang/rust/pull/116090 picked an unnecessarily complicated implementation for this. I don't know if there was any specific reason for this;. Cc @rmehri01 @m-ou-se in case someone remembers.

This was pointed out on IRLO: https://internals.rust-lang.org/t/why-is-strict-div-implemented-in-terms-of-overflowing-div-for-signed-integers/24387

Let's just use regular division here, which is consistent with what we do for unsigned types.