### PR TITLE
Add documentation for the `cold` and `track_caller` attributes

### DIFF
--- a/library/core/src/attribute_docs.rs
+++ b/library/core/src/attribute_docs.rs
@@ -445,3 +445,64 @@ mod no_std_attribute {}
 ///
 /// [the `inline` attribute]: ../reference/attributes/codegen.html#the-inline-attribute
 mod inline_attribute {}
+
+#[doc(attribute = "cold")]
+//
+/// Hint to the compiler that a function is unlikely to be called.
+///
+/// Marking a function `#[cold]` tells the compiler that calls to it are rare, so it can
+/// optimize for the common case where the function is not called. It is only a hint: the
+/// compiler may ignore it, and it does not change the function's behavior.
+///
+/// It is typically used on functions that handle uncommon cases, such as error or panic paths:
+///
+/// ```rust
+/// # #![allow(dead_code)]
+/// fn check(value: i32) {
+///     if value < 0 {
+///         report_error("value must be non-negative");
+///     }
+///     // ... the common case continues here ...
+/// }
+///
+/// #[cold]
+/// fn report_error(message: &str) {
+///     eprintln!("error: {message}");
+/// }
+/// ```
+///
+/// For more information, see the Reference on [the `cold` attribute].
+///
+/// [the `cold` attribute]: ../reference/attributes/codegen.html#the-cold-attribute
+mod cold_attribute {}
+
+#[doc(attribute = "track_caller")]
+//
+/// Make a function report the location of its caller instead of its own.
+///
+/// When a function panics, the panic message normally points at the line inside that function
+/// where the panic happened. `#[track_caller]` changes that: it lets the function see the
+/// [`Location`] it was called from, so the panic (and any direct use of [`Location::caller`])
+/// points at the call site instead. The standard library uses this on methods like
+/// [`Option::unwrap`], so a failed `unwrap` blames the line that called it rather than a line
+/// inside the standard library.
+///
+/// ```rust,should_panic
+/// #[track_caller]
+/// fn assert_even(n: i32) {
+///     assert!(n % 2 == 0, "{n} is not even");
+/// }
+///
+/// // The panic blames this line, not the `assert!` inside `assert_even`.
+/// assert_even(3);
+/// ```
+///
+/// The attribute applies to functions with the default `"Rust"` ABI, other than `fn main`.
+///
+/// For more information, see the Reference on [the `track_caller` attribute].
+///
+/// [`Location`]: panic::Location
+/// [`Location::caller`]: panic::Location::caller
+/// [`Option::unwrap`]: Option::unwrap
+/// [the `track_caller` attribute]: ../reference/attributes/codegen.html#the-track_caller-attribute
+mod track_caller_attribute {}


### PR DESCRIPTION
Adds `cold` and `track_caller`, the two code generation attributes left from my claim on the tracking issue.

Both stay guide-level, with one runnable example each. For `track_caller` I used a small assert-style helper, since the attribute mainly affects which line a panic points at. `inline` is already up in rust-lang/rust#158348.

Part of rust-lang/rust#157604

r? @GuillaumeGomez

Tested with `./x test library/std --doc --test-args attribute_docs`.
