### PR TITLE
std: treat ENFILE as transient in the pidfd support probe

### DIFF
--- a/library/std/src/sys/process/unix/unix.rs
+++ b/library/std/src/sys/process/unix/unix.rs
@@ -510,7 +510,7 @@ impl Command {
                                     support = SPAWN;
                                 }
                             }
-                            Err(e) if e.raw_os_error() == Some(libc::EMFILE) => {
+                            Err(e) if matches!(e.raw_os_error(), Some(libc::EMFILE | libc::ENFILE)) => {
                                 // We're temporarily(?) out of file descriptors. In this case pidfd_spawnp would also fail
                                 // Don't update the support flag so we can probe again later.
                                 return Err(e)

--- a/library/std/src/sys/process/unix/unix.rs
+++ b/library/std/src/sys/process/unix/unix.rs
@@ -510,8 +510,8 @@ impl Command {
                                     support = SPAWN;
                                 }
                             }
-                            Err(e) if matches!(e.raw_os_error(), Some(libc::EMFILE | libc::ENFILE)) => {
-                                // We're temporarily(?) out of file descriptors. In this case pidfd_spawnp would also fail
+                            Err(e) if matches!(e.raw_os_error(), Some(libc::EMFILE | libc::ENFILE | libc::ENOMEM)) => {
+                                // We're temporarily(?) out of file descriptors or memory. In this case pidfd_spawnp would also fail
                                 // Don't update the support flag so we can probe again later.
                                 return Err(e)
                             }


### PR DESCRIPTION
The pidfd support probe special-cases `EMFILE` from `pidfd_open`: it returns the
error without caching anything, so the next spawn re-probes. `ENFILE` falls
through instead, into the fallback arm, so the probe caches pidfd as unsupported
for the rest of the process, even after descriptors free up.

Both errnos come from the same `pidfd_open` call and mean the same thing: the
process is out of file descriptors, just per-process (`EMFILE`) vs system-wide
(`ENFILE`). I don't see a reason to treat them differently here, so this handles
`ENFILE` the same way:

```rust
Err(e) if matches!(e.raw_os_error(), Some(libc::EMFILE | libc::ENFILE)) => {
```

I kept the raw `raw_os_error()` check rather than `ErrorKind::TooManyOpenFiles`
(rust-lang/rust#158326, which maps both) to match the rest of this probe, but can switch if
you'd prefer.

I didn't add a test, since triggering it needs real fd exhaustion during the
probe, which isn't practical to reproduce. The `EMFILE` arm isn't tested either.

r? libs
