### PR TITLE
Upgrade `rustdoc-json-types` to 2024 edition.

### DIFF
--- a/src/rustdoc-json-types/Cargo.toml
+++ b/src/rustdoc-json-types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustdoc-json-types"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [lib]
 path = "lib.rs"


### PR DESCRIPTION
No code changes were necessary to perform the upgrade. I used `cargo fix --edition`, and additionally had an AI tool review the source code against the [Rust 2024 edition guide](https://github.com/rust-lang/edition-guide/tree/master/src/rust-2024) and the [edition upgrade guide](https://doc.rust-lang.org/edition-guide/editions/transitioning-an-existing-project-to-a-new-edition.html) to ensure the change works properly.

Same approach as in rust-lang/rust#158470.

I don't believe this will raise the MSRV of `rustdoc-types`, because [its MSRV is already 1.85](https://crates.io/crates/rustdoc-types) which [supports the 2024 edition](https://blog.rust-lang.org/2025/02/20/Rust-1.85.0/).

r? @GuillaumeGomez 

**AI disclosure:** This PR is the product of a combination of manual work and AI tools. I secured approval in advance from the designated reviewer. I stand behind the quality of the code I'm submitting, and I vouch it's as good or better compared to if I had written every line by my own hand.