### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/compiler/rustc_attr_parsing/src/attributes/stability.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/stability.rs
@@ -40,6 +40,7 @@ const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
     Allow(Target::Static),
     Allow(Target::ForeignFn),
     Allow(Target::ForeignStatic),
+    Allow(Target::ForeignTy),
     Allow(Target::ExternCrate),
 ]);
 

--- a/src/librustdoc/lint.rs
+++ b/src/librustdoc/lint.rs
@@ -196,6 +196,13 @@ declare_rustdoc_lint! {
     "detects redundant explicit links in doc comments"
 }
 
+declare_rustdoc_lint! {
+    /// This lint checks for uses of footnote references without definition.
+    BROKEN_FOOTNOTE,
+    Warn,
+    "footnote reference with no associated definition"
+}
+
 pub(crate) static RUSTDOC_LINTS: Lazy<Vec<&'static Lint>> = Lazy::new(|| {
     vec![
         BROKEN_INTRA_DOC_LINKS,
@@ -209,6 +216,7 @@ pub(crate) static RUSTDOC_LINTS: Lazy<Vec<&'static Lint>> = Lazy::new(|| {
         MISSING_CRATE_LEVEL_DOCS,
         UNESCAPED_BACKTICKS,
         REDUNDANT_EXPLICIT_LINKS,
+        BROKEN_FOOTNOTE,
     ]
 });
 

--- a/src/librustdoc/lint.rs
+++ b/src/librustdoc/lint.rs
@@ -203,6 +203,13 @@ declare_rustdoc_lint! {
     "footnote reference with no associated definition"
 }
 
+declare_rustdoc_lint! {
+    /// This lint checks if all footnote definitions are used.
+    UNUSED_FOOTNOTE_DEFINITION,
+    Warn,
+    "unused footnote definition"
+}
+
 pub(crate) static RUSTDOC_LINTS: Lazy<Vec<&'static Lint>> = Lazy::new(|| {
     vec![
         BROKEN_INTRA_DOC_LINKS,
@@ -217,6 +224,7 @@ pub(crate) static RUSTDOC_LINTS: Lazy<Vec<&'static Lint>> = Lazy::new(|| {
         UNESCAPED_BACKTICKS,
         REDUNDANT_EXPLICIT_LINKS,
         BROKEN_FOOTNOTE,
+        UNUSED_FOOTNOTE_DEFINITION,
     ]
 });
 

--- a/src/librustdoc/lint.rs
+++ b/src/librustdoc/lint.rs
@@ -200,14 +200,14 @@ declare_rustdoc_lint! {
     /// This lint checks for uses of footnote references without definition.
     BROKEN_FOOTNOTE,
     Warn,
-    "footnote reference with no associated definition"
+    "detects footnote references with no associated definition"
 }
 
 declare_rustdoc_lint! {
     /// This lint checks if all footnote definitions are used.
     UNUSED_FOOTNOTE_DEFINITION,
     Warn,
-    "unused footnote definition"
+    "detects unused footnote definitions"
 }
 
 pub(crate) static RUSTDOC_LINTS: Lazy<Vec<&'static Lint>> = Lazy::new(|| {

--- a/src/librustdoc/passes/lint.rs
+++ b/src/librustdoc/passes/lint.rs
@@ -3,6 +3,7 @@
 
 mod bare_urls;
 mod check_code_block_syntax;
+mod footnotes;
 mod html_tags;
 mod redundant_explicit_links;
 mod unescaped_backticks;
@@ -41,6 +42,7 @@ impl DocVisitor<'_> for Linter<'_, '_> {
             if may_have_link {
                 bare_urls::visit_item(self.cx, item, hir_id, &dox);
                 redundant_explicit_links::visit_item(self.cx, item, hir_id);
+                footnotes::visit_item(self.cx, item, hir_id, &dox);
             }
             if may_have_code {
                 check_code_block_syntax::visit_item(self.cx, item, &dox);

--- a/src/librustdoc/passes/lint/footnotes.rs
+++ b/src/librustdoc/passes/lint/footnotes.rs
@@ -77,26 +77,23 @@ pub(crate) fn visit_item(cx: &DocContext<'_>, item: &Item, hir_id: HirId, dox: &
 
     #[allow(rustc::potential_query_instability)]
     for span in missing_footnote_references {
-        let (ref_span, precise) =
-            source_span_for_markdown_range(tcx, dox, &span, &item.attrs.doc_strings)
-                .map(|(span, _)| (span, true))
-                .unwrap_or_else(|| (item.attr_span(tcx), false));
+        let ref_span = source_span_for_markdown_range(tcx, dox, &span, &item.attrs.doc_strings)
+            .map(|(span, _)| span)
+            .unwrap_or_else(|| item.attr_span(tcx));
 
-        if precise {
-            tcx.emit_node_span_lint(
-                crate::lint::BROKEN_FOOTNOTE,
-                hir_id,
-                ref_span,
-                DiagDecorator(|lint| {
-                    lint.primary_message("no footnote definition matching this footnote");
-                    lint.span_suggestion(
-                        ref_span.shrink_to_lo(),
-                        "if it should not be a footnote, escape it",
-                        "\\",
-                        Applicability::MaybeIncorrect,
-                    );
-                }),
-            );
-        }
+        tcx.emit_node_span_lint(
+            crate::lint::BROKEN_FOOTNOTE,
+            hir_id,
+            ref_span,
+            DiagDecorator(|lint| {
+                lint.primary_message("no footnote definition matching this footnote");
+                lint.span_suggestion(
+                    ref_span.shrink_to_lo(),
+                    "if it should not be a footnote, escape it",
+                    "\\",
+                    Applicability::MaybeIncorrect,
+                );
+            }),
+        );
     }
 }

--- a/src/librustdoc/passes/lint/footnotes.rs
+++ b/src/librustdoc/passes/lint/footnotes.rs
@@ -1,15 +1,3 @@
-//! Detects specific markdown syntax that's different between pulldown-cmark
-//! 0.9 and 0.11.
-//!
-//! This is a mitigation for old parser bugs that affected some
-//! real crates' docs. The old parser claimed to comply with CommonMark,
-//! but it did not. These warnings will eventually be removed,
-//! though some of them may become Clippy lints.
-//!
-//! <https://github.com/rust-lang/rust/pull/121659#issuecomment-1992752820>
-//!
-//! <https://rustc-dev-guide.rust-lang.org/bug-fix-procedure.html#add-the-lint-to-the-list-of-removed-lists>
-
 use std::ops::Range;
 
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};

--- a/src/librustdoc/passes/lint/footnotes.rs
+++ b/src/librustdoc/passes/lint/footnotes.rs
@@ -12,10 +12,11 @@
 
 use std::ops::Range;
 
-use rustc_data_structures::fx::FxHashSet;
+use rustc_data_structures::fx::{FxHashMap, FxHashSet};
+use rustc_errors::DiagDecorator;
 use rustc_hir::HirId;
 use rustc_lint_defs::Applicability;
-use rustc_resolve::rustdoc::pulldown_cmark::{Event, Options, Parser};
+use rustc_resolve::rustdoc::pulldown_cmark::{Event, Options, Parser, Tag};
 use rustc_resolve::rustdoc::source_span_for_markdown_range;
 
 use crate::clean::Item;
@@ -25,6 +26,8 @@ pub(crate) fn visit_item(cx: &DocContext<'_>, item: &Item, hir_id: HirId, dox: &
     let tcx = cx.tcx;
 
     let mut missing_footnote_references = FxHashSet::default();
+    let mut footnote_references = FxHashSet::default();
+    let mut footnote_definitions = FxHashMap::default();
 
     let options = Options::ENABLE_FOOTNOTES;
     let mut parser = Parser::new_ext(dox, options).into_offset_iter().peekable();
@@ -40,7 +43,35 @@ pub(crate) fn visit_item(cx: &DocContext<'_>, item: &Item, hir_id: HirId, dox: &
             {
                 missing_footnote_references.insert(Range { start: span.start, end: end_span.end });
             }
+            Event::FootnoteReference(label) => {
+                footnote_references.insert(label);
+            }
+            Event::Start(Tag::FootnoteDefinition(label)) => {
+                footnote_definitions.insert(label, span.start + 1);
+            }
             _ => {}
+        }
+    }
+
+    #[allow(rustc::potential_query_instability)]
+    for (footnote, span) in footnote_definitions {
+        if !footnote_references.contains(&footnote) {
+            let (span, _) = source_span_for_markdown_range(
+                tcx,
+                dox,
+                &(span..span + 1),
+                &item.attrs.doc_strings,
+            )
+            .unwrap_or_else(|| (item.attr_span(tcx), false));
+
+            tcx.emit_node_span_lint(
+                crate::lint::UNUSED_FOOTNOTE_DEFINITION,
+                hir_id,
+                span,
+                DiagDecorator(|lint| {
+                    lint.primary_message("unused footnote definition");
+                }),
+            );
         }
     }
 
@@ -56,7 +87,7 @@ pub(crate) fn visit_item(cx: &DocContext<'_>, item: &Item, hir_id: HirId, dox: &
                 crate::lint::BROKEN_FOOTNOTE,
                 hir_id,
                 ref_span,
-                rustc_errors::DiagDecorator(|lint| {
+                DiagDecorator(|lint| {
                     lint.primary_message("no footnote definition matching this footnote");
                     lint.span_suggestion(
                         ref_span.shrink_to_lo(),

--- a/src/librustdoc/passes/lint/footnotes.rs
+++ b/src/librustdoc/passes/lint/footnotes.rs
@@ -1,0 +1,71 @@
+//! Detects specific markdown syntax that's different between pulldown-cmark
+//! 0.9 and 0.11.
+//!
+//! This is a mitigation for old parser bugs that affected some
+//! real crates' docs. The old parser claimed to comply with CommonMark,
+//! but it did not. These warnings will eventually be removed,
+//! though some of them may become Clippy lints.
+//!
+//! <https://github.com/rust-lang/rust/pull/121659#issuecomment-1992752820>
+//!
+//! <https://rustc-dev-guide.rust-lang.org/bug-fix-procedure.html#add-the-lint-to-the-list-of-removed-lists>
+
+use std::ops::Range;
+
+use rustc_data_structures::fx::FxHashSet;
+use rustc_hir::HirId;
+use rustc_lint_defs::Applicability;
+use rustc_resolve::rustdoc::pulldown_cmark::{Event, Options, Parser};
+use rustc_resolve::rustdoc::source_span_for_markdown_range;
+
+use crate::clean::Item;
+use crate::core::DocContext;
+
+pub(crate) fn visit_item(cx: &DocContext<'_>, item: &Item, hir_id: HirId, dox: &str) {
+    let tcx = cx.tcx;
+
+    let mut missing_footnote_references = FxHashSet::default();
+
+    let options = Options::ENABLE_FOOTNOTES;
+    let mut parser = Parser::new_ext(dox, options).into_offset_iter().peekable();
+    while let Some((event, span)) = parser.next() {
+        match event {
+            Event::Text(text)
+                if &*text == "["
+                    && let Some((Event::Text(text), _)) = parser.peek()
+                    && text.trim_start().starts_with('^')
+                    && parser.next().is_some()
+                    && let Some((Event::Text(text), end_span)) = parser.peek()
+                    && &**text == "]" =>
+            {
+                missing_footnote_references.insert(Range { start: span.start, end: end_span.end });
+            }
+            _ => {}
+        }
+    }
+
+    #[allow(rustc::potential_query_instability)]
+    for span in missing_footnote_references {
+        let (ref_span, precise) =
+            source_span_for_markdown_range(tcx, dox, &span, &item.attrs.doc_strings)
+                .map(|(span, _)| (span, true))
+                .unwrap_or_else(|| (item.attr_span(tcx), false));
+
+        if precise {
+            tcx.emit_node_span_lint(
+                crate::lint::BROKEN_FOOTNOTE,
+                hir_id,
+                ref_span,
+                rustc_errors::DiagDecorator(|lint| {
+                    lint.primary_message("no footnote definition matching this footnote");
+                    lint.span_suggestion(
+                        ref_span.shrink_to_lo(),
+                        "if it should not be a footnote, escape it",
+                        "\\",
+                        Applicability::MaybeIncorrect,
+                    );
+                }),
+            );
+        }
+    }
+}

--- a/src/librustdoc/passes/lint/footnotes.rs
+++ b/src/librustdoc/passes/lint/footnotes.rs
@@ -23,13 +23,11 @@ pub(crate) fn visit_item(cx: &DocContext<'_>, item: &Item, hir_id: HirId, dox: &
         match event {
             Event::Text(text)
                 if &*text == "["
-                    && let Some((Event::Text(text), _)) = parser.peek()
-                    && text.trim_start().starts_with('^')
-                    && parser.next().is_some()
-                    && let Some((Event::Text(text), end_span)) = parser.peek()
-                    && &**text == "]" =>
+                    && (span.start == 0 || dox.as_bytes().get(span.start - 1) != Some(&b'\\'))
+                    && let Some(len) = scan_footnote_ref(&dox[span.start..]) =>
             {
-                missing_footnote_references.insert(Range { start: span.start, end: end_span.end });
+                missing_footnote_references
+                    .insert(Range { start: span.start, end: span.start + len });
             }
             Event::FootnoteReference(label) => {
                 footnote_references.insert(label);
@@ -84,4 +82,36 @@ pub(crate) fn visit_item(cx: &DocContext<'_>, item: &Item, hir_id: HirId, dox: &
             }),
         );
     }
+}
+
+fn scan_footnote_ref(dox: &str) -> Option<usize> {
+    let dox = dox.as_bytes();
+    let mut i = 0;
+    if dox.get(i) != Some(&b'[') {
+        return None;
+    }
+    i += 1;
+    if dox.get(i) != Some(&b'^') {
+        return None;
+    }
+    i += 1;
+    while let Some(&c) = dox.get(i) {
+        if c == b']' {
+            i += 1;
+            return Some(i);
+        }
+        if c == b'\r' || c == b'\n' || c == b'[' {
+            // Can't nest things like this.
+            break;
+        }
+        if c == b'\\' {
+            i += 1;
+        }
+        if dox.get(i) == Some(&b'\r') || dox.get(i) == Some(&b'\n') {
+            // Can't have line breaks in footnote refs
+            break;
+        }
+        i += 1;
+    }
+    None
 }

--- a/src/rustdoc-json-types/Cargo.toml
+++ b/src/rustdoc-json-types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustdoc-json-types"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [lib]
 path = "lib.rs"

--- a/src/tools/jsondocck/Cargo.toml
+++ b/src/tools/jsondocck/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "jsondocck"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 jsonpath-rust = "1.0.0"

--- a/src/tools/jsondoclint/Cargo.toml
+++ b/src/tools/jsondoclint/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "jsondoclint"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/tests/rustdoc-ui/lints/broken-footnote.rs
+++ b/tests/rustdoc-ui/lints/broken-footnote.rs
@@ -1,0 +1,7 @@
+#![deny(rustdoc::broken_footnote)]
+
+//! Footnote referenced [^1]. And [^2]. And [^bla].
+//!
+//! [^1]: footnote defined
+//~^^^ ERROR: no footnote definition matching this footnote
+//~| ERROR: no footnote definition matching this footnote

--- a/tests/rustdoc-ui/lints/broken-footnote.rs
+++ b/tests/rustdoc-ui/lints/broken-footnote.rs
@@ -5,3 +5,12 @@
 //! [^1]: footnote defined
 //~^^^ ERROR: no footnote definition matching this footnote
 //~| ERROR: no footnote definition matching this footnote
+
+// Should not lint.
+//! foo[^1]
+//!
+//! ```
+//!
+//! [^1]: bar
+//!
+//! ```

--- a/tests/rustdoc-ui/lints/broken-footnote.rs
+++ b/tests/rustdoc-ui/lints/broken-footnote.rs
@@ -14,3 +14,31 @@
 //! [^1]: bar
 //!
 //! ```
+
+// Edge cases from https://pulldown-cmark.github.io/pulldown-cmark/specs/footnotes.html
+/// The following are not footnote references:
+///
+/// \[^a]
+///
+/// [\^b]
+///
+/// [^c\]
+///
+/// [^d
+/// e]
+///
+/// [^f\
+/// g]
+pub struct NotReferences;
+
+/// The following are not footnote references:
+///
+/// [^a b]
+//~^ ERROR: no footnote definition matching this footnote
+///
+/// [^1\.2]
+//~^ ERROR: no footnote definition matching this footnote
+///
+/// [^*]
+//~^ ERROR: no footnote definition matching this footnote
+pub struct EdgeCases;

--- a/tests/rustdoc-ui/lints/broken-footnote.stderr
+++ b/tests/rustdoc-ui/lints/broken-footnote.stderr
@@ -1,0 +1,24 @@
+error: no footnote definition matching this footnote
+  --> $DIR/broken-footnote.rs:3:45
+   |
+LL | //! Footnote referenced [^1]. And [^2]. And [^bla].
+   |                                             -^^^^^
+   |                                             |
+   |                                             help: if it should not be a footnote, escape it: `\`
+   |
+note: the lint level is defined here
+  --> $DIR/broken-footnote.rs:1:9
+   |
+LL | #![deny(rustdoc::broken_footnote)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: no footnote definition matching this footnote
+  --> $DIR/broken-footnote.rs:3:35
+   |
+LL | //! Footnote referenced [^1]. And [^2]. And [^bla].
+   |                                   -^^^
+   |                                   |
+   |                                   help: if it should not be a footnote, escape it: `\`
+
+error: aborting due to 2 previous errors
+

--- a/tests/rustdoc-ui/lints/broken-footnote.stderr
+++ b/tests/rustdoc-ui/lints/broken-footnote.stderr
@@ -20,5 +20,29 @@ LL | //! Footnote referenced [^1]. And [^2]. And [^bla].
    |                                   |
    |                                   help: if it should not be a footnote, escape it: `\`
 
-error: aborting due to 2 previous errors
+error: no footnote definition matching this footnote
+  --> $DIR/broken-footnote.rs:39:5
+   |
+LL | /// [^1\.2]
+   |     -^^^^^^
+   |     |
+   |     help: if it should not be a footnote, escape it: `\`
+
+error: no footnote definition matching this footnote
+  --> $DIR/broken-footnote.rs:42:5
+   |
+LL | /// [^*]
+   |     -^^^
+   |     |
+   |     help: if it should not be a footnote, escape it: `\`
+
+error: no footnote definition matching this footnote
+  --> $DIR/broken-footnote.rs:36:5
+   |
+LL | /// [^a b]
+   |     -^^^^^
+   |     |
+   |     help: if it should not be a footnote, escape it: `\`
+
+error: aborting due to 5 previous errors
 

--- a/tests/rustdoc-ui/lints/unused-footnote.rs
+++ b/tests/rustdoc-ui/lints/unused-footnote.rs
@@ -1,4 +1,4 @@
-// This test ensures that the rustdoc `unused_footnote` is working as expected.
+// This test ensures that the `rustdoc::unused_footnote` lint is working as expected.
 
 #![deny(rustdoc::unused_footnote_definition)]
 

--- a/tests/rustdoc-ui/lints/unused-footnote.rs
+++ b/tests/rustdoc-ui/lints/unused-footnote.rs
@@ -1,0 +1,9 @@
+// This test ensures that the rustdoc `unused_footnote` is working as expected.
+
+#![deny(rustdoc::unused_footnote_definition)]
+
+//! Footnote referenced. [^2]
+//!
+//! [^1]: footnote defined
+//! [^2]: footnote defined
+//~^^ ERROR: unused_footnote_definition

--- a/tests/rustdoc-ui/lints/unused-footnote.stderr
+++ b/tests/rustdoc-ui/lints/unused-footnote.stderr
@@ -1,0 +1,14 @@
+error: unused footnote definition
+  --> $DIR/unused-footnote.rs:7:6
+   |
+LL | //! [^1]: footnote defined
+   |      ^
+   |
+note: the lint level is defined here
+  --> $DIR/unused-footnote.rs:3:9
+   |
+LL | #![deny(rustdoc::unused_footnote_definition)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/lint/auxiliary/lint_stability.rs
+++ b/tests/ui/lint/auxiliary/lint_stability.rs
@@ -1,5 +1,6 @@
 #![crate_name="lint_stability"]
 #![crate_type = "lib"]
+#![feature(extern_types)]
 #![feature(staged_api)]
 #![feature(associated_type_defaults)]
 #![stable(feature = "lint_stability", since = "1.0.0")]
@@ -185,4 +186,9 @@ macro_rules! macro_test_arg {
 #[macro_export]
 macro_rules! macro_test_arg_nested {
     ($func:ident) => (macro_test_arg!($func()));
+}
+
+extern "C" {
+    #[unstable(feature = "unstable_test_feature", issue = "none")]
+    pub type UnstableForeignType;
 }

--- a/tests/ui/lint/lint-stability.rs
+++ b/tests/ui/lint/lint-stability.rs
@@ -6,9 +6,13 @@
 #![allow(deprecated)]
 #![allow(dead_code)]
 #![feature(staged_api)]
-
+#![feature(extern_types)]
 #![stable(feature = "rust1", since = "1.0.0")]
 
+extern "C" {
+    #[unstable(feature = "fn_static", issue = "none")]
+    type Ty;
+}
 #[macro_use]
 extern crate lint_stability;
 

--- a/tests/ui/lint/lint-stability.rs
+++ b/tests/ui/lint/lint-stability.rs
@@ -9,10 +9,6 @@
 #![feature(extern_types)]
 #![stable(feature = "rust1", since = "1.0.0")]
 
-extern "C" {
-    #[unstable(feature = "fn_static", issue = "none")]
-    type Ty;
-}
 #[macro_use]
 extern crate lint_stability;
 
@@ -21,6 +17,9 @@ mod cross_crate {
     extern crate stability_cfg2; //~ ERROR use of unstable library feature
 
     use lint_stability::*;
+
+    fn test_foreign_type(_: &mut UnstableForeignType) { //~ ERROR use of unstable library feature
+    }
 
     fn test() {
         type Foo = MethodTester;

--- a/tests/ui/lint/lint-stability.stderr
+++ b/tests/ui/lint/lint-stability.stderr
@@ -8,7 +8,16 @@ LL |     extern crate stability_cfg2;
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature `unstable_test_feature`
-  --> $DIR/lint-stability.rs:45:9
+  --> $DIR/lint-stability.rs:21:34
+   |
+LL |     fn test_foreign_type(_: &mut UnstableForeignType) {
+   |                                  ^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: use of unstable library feature `unstable_test_feature`
+  --> $DIR/lint-stability.rs:48:9
    |
 LL |         deprecated_unstable();
    |         ^^^^^^^^^^^^^^^^^^^
@@ -17,7 +26,7 @@ LL |         deprecated_unstable();
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature `unstable_test_feature`
-  --> $DIR/lint-stability.rs:47:9
+  --> $DIR/lint-stability.rs:50:9
    |
 LL |         Trait::trait_deprecated_unstable(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -26,7 +35,7 @@ LL |         Trait::trait_deprecated_unstable(&foo);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature `unstable_test_feature`
-  --> $DIR/lint-stability.rs:49:9
+  --> $DIR/lint-stability.rs:52:9
    |
 LL |         <Foo as Trait>::trait_deprecated_unstable(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -35,7 +44,7 @@ LL |         <Foo as Trait>::trait_deprecated_unstable(&foo);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature `unstable_test_feature`
-  --> $DIR/lint-stability.rs:52:9
+  --> $DIR/lint-stability.rs:55:9
    |
 LL |         deprecated_unstable_text();
    |         ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -44,7 +53,7 @@ LL |         deprecated_unstable_text();
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature `unstable_test_feature`
-  --> $DIR/lint-stability.rs:54:9
+  --> $DIR/lint-stability.rs:57:9
    |
 LL |         Trait::trait_deprecated_unstable_text(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -53,7 +62,7 @@ LL |         Trait::trait_deprecated_unstable_text(&foo);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature `unstable_test_feature`
-  --> $DIR/lint-stability.rs:56:9
+  --> $DIR/lint-stability.rs:59:9
    |
 LL |         <Foo as Trait>::trait_deprecated_unstable_text(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -62,7 +71,7 @@ LL |         <Foo as Trait>::trait_deprecated_unstable_text(&foo);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature `unstable_test_feature`
-  --> $DIR/lint-stability.rs:59:9
+  --> $DIR/lint-stability.rs:62:9
    |
 LL |         unstable();
    |         ^^^^^^^^
@@ -71,7 +80,7 @@ LL |         unstable();
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature `unstable_test_feature`
-  --> $DIR/lint-stability.rs:60:9
+  --> $DIR/lint-stability.rs:63:9
    |
 LL |         Trait::trait_unstable(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^
@@ -80,7 +89,7 @@ LL |         Trait::trait_unstable(&foo);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature `unstable_test_feature`
-  --> $DIR/lint-stability.rs:61:9
+  --> $DIR/lint-stability.rs:64:9
    |
 LL |         <Foo as Trait>::trait_unstable(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -89,7 +98,7 @@ LL |         <Foo as Trait>::trait_unstable(&foo);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature `unstable_test_feature`: text
-  --> $DIR/lint-stability.rs:63:9
+  --> $DIR/lint-stability.rs:66:9
    |
 LL |         unstable_text();
    |         ^^^^^^^^^^^^^
@@ -98,7 +107,7 @@ LL |         unstable_text();
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature `unstable_test_feature`: text
-  --> $DIR/lint-stability.rs:65:9
+  --> $DIR/lint-stability.rs:68:9
    |
 LL |         Trait::trait_unstable_text(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -107,7 +116,7 @@ LL |         Trait::trait_unstable_text(&foo);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature `unstable_test_feature`: text
-  --> $DIR/lint-stability.rs:67:9
+  --> $DIR/lint-stability.rs:70:9
    |
 LL |         <Foo as Trait>::trait_unstable_text(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -116,7 +125,7 @@ LL |         <Foo as Trait>::trait_unstable_text(&foo);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature `unstable_test_feature`
-  --> $DIR/lint-stability.rs:99:17
+  --> $DIR/lint-stability.rs:102:17
    |
 LL |         let _ = DeprecatedUnstableStruct {
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -125,7 +134,7 @@ LL |         let _ = DeprecatedUnstableStruct {
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature `unstable_test_feature`
-  --> $DIR/lint-stability.rs:103:17
+  --> $DIR/lint-stability.rs:106:17
    |
 LL |         let _ = UnstableStruct { i: 0 };
    |                 ^^^^^^^^^^^^^^
@@ -134,7 +143,7 @@ LL |         let _ = UnstableStruct { i: 0 };
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature `unstable_test_feature`
-  --> $DIR/lint-stability.rs:107:17
+  --> $DIR/lint-stability.rs:110:17
    |
 LL |         let _ = DeprecatedUnstableUnitStruct;
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -143,7 +152,7 @@ LL |         let _ = DeprecatedUnstableUnitStruct;
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature `unstable_test_feature`
-  --> $DIR/lint-stability.rs:109:17
+  --> $DIR/lint-stability.rs:112:17
    |
 LL |         let _ = UnstableUnitStruct;
    |                 ^^^^^^^^^^^^^^^^^^
@@ -152,7 +161,7 @@ LL |         let _ = UnstableUnitStruct;
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature `unstable_test_feature`
-  --> $DIR/lint-stability.rs:113:17
+  --> $DIR/lint-stability.rs:116:17
    |
 LL |         let _ = Enum::DeprecatedUnstableVariant;
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -161,7 +170,7 @@ LL |         let _ = Enum::DeprecatedUnstableVariant;
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature `unstable_test_feature`
-  --> $DIR/lint-stability.rs:115:17
+  --> $DIR/lint-stability.rs:118:17
    |
 LL |         let _ = Enum::UnstableVariant;
    |                 ^^^^^^^^^^^^^^^^^^^^^
@@ -170,7 +179,7 @@ LL |         let _ = Enum::UnstableVariant;
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature `unstable_test_feature`
-  --> $DIR/lint-stability.rs:119:17
+  --> $DIR/lint-stability.rs:122:17
    |
 LL |         let _ = DeprecatedUnstableTupleStruct (1);
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -179,7 +188,7 @@ LL |         let _ = DeprecatedUnstableTupleStruct (1);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature `unstable_test_feature`
-  --> $DIR/lint-stability.rs:121:17
+  --> $DIR/lint-stability.rs:124:17
    |
 LL |         let _ = UnstableTupleStruct (1);
    |                 ^^^^^^^^^^^^^^^^^^^
@@ -188,7 +197,7 @@ LL |         let _ = UnstableTupleStruct (1);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature `unstable_test_feature`
-  --> $DIR/lint-stability.rs:130:25
+  --> $DIR/lint-stability.rs:133:25
    |
 LL |         macro_test_arg!(deprecated_unstable_text());
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -197,7 +206,7 @@ LL |         macro_test_arg!(deprecated_unstable_text());
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature `unstable_test_feature`
-  --> $DIR/lint-stability.rs:144:9
+  --> $DIR/lint-stability.rs:147:9
    |
 LL |         Trait::trait_deprecated_unstable(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -206,7 +215,7 @@ LL |         Trait::trait_deprecated_unstable(&foo);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature `unstable_test_feature`
-  --> $DIR/lint-stability.rs:146:9
+  --> $DIR/lint-stability.rs:149:9
    |
 LL |         <Foo as Trait>::trait_deprecated_unstable(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -215,7 +224,7 @@ LL |         <Foo as Trait>::trait_deprecated_unstable(&foo);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature `unstable_test_feature`
-  --> $DIR/lint-stability.rs:148:9
+  --> $DIR/lint-stability.rs:151:9
    |
 LL |         Trait::trait_deprecated_unstable_text(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -224,7 +233,7 @@ LL |         Trait::trait_deprecated_unstable_text(&foo);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature `unstable_test_feature`
-  --> $DIR/lint-stability.rs:150:9
+  --> $DIR/lint-stability.rs:153:9
    |
 LL |         <Foo as Trait>::trait_deprecated_unstable_text(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -233,7 +242,7 @@ LL |         <Foo as Trait>::trait_deprecated_unstable_text(&foo);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature `unstable_test_feature`
-  --> $DIR/lint-stability.rs:152:9
+  --> $DIR/lint-stability.rs:155:9
    |
 LL |         Trait::trait_unstable(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^
@@ -242,7 +251,7 @@ LL |         Trait::trait_unstable(&foo);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature `unstable_test_feature`
-  --> $DIR/lint-stability.rs:153:9
+  --> $DIR/lint-stability.rs:156:9
    |
 LL |         <Foo as Trait>::trait_unstable(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -251,7 +260,7 @@ LL |         <Foo as Trait>::trait_unstable(&foo);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature `unstable_test_feature`: text
-  --> $DIR/lint-stability.rs:154:9
+  --> $DIR/lint-stability.rs:157:9
    |
 LL |         Trait::trait_unstable_text(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -260,7 +269,7 @@ LL |         Trait::trait_unstable_text(&foo);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature `unstable_test_feature`: text
-  --> $DIR/lint-stability.rs:156:9
+  --> $DIR/lint-stability.rs:159:9
    |
 LL |         <Foo as Trait>::trait_unstable_text(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -269,7 +278,7 @@ LL |         <Foo as Trait>::trait_unstable_text(&foo);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature `unstable_test_feature`
-  --> $DIR/lint-stability.rs:172:10
+  --> $DIR/lint-stability.rs:175:10
    |
 LL |     impl UnstableTrait for S { }
    |          ^^^^^^^^^^^^^
@@ -278,7 +287,7 @@ LL |     impl UnstableTrait for S { }
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature `unstable_test_feature`
-  --> $DIR/lint-stability.rs:174:24
+  --> $DIR/lint-stability.rs:177:24
    |
 LL |     trait LocalTrait : UnstableTrait { }
    |                        ^^^^^^^^^^^^^
@@ -287,7 +296,7 @@ LL |     trait LocalTrait : UnstableTrait { }
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature `unstable_test_feature`
-  --> $DIR/lint-stability.rs:179:9
+  --> $DIR/lint-stability.rs:182:9
    |
 LL |         fn trait_unstable(&self) {}
    |         ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -296,7 +305,7 @@ LL |         fn trait_unstable(&self) {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature `unstable_test_feature`
-  --> $DIR/lint-stability.rs:184:5
+  --> $DIR/lint-stability.rs:187:5
    |
 LL |     extern crate inherited_stability;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -305,7 +314,7 @@ LL |     extern crate inherited_stability;
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature `unstable_test_feature`
-  --> $DIR/lint-stability.rs:185:9
+  --> $DIR/lint-stability.rs:188:9
    |
 LL |     use self::inherited_stability::*;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -314,7 +323,7 @@ LL |     use self::inherited_stability::*;
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature `unstable_test_feature`
-  --> $DIR/lint-stability.rs:188:9
+  --> $DIR/lint-stability.rs:191:9
    |
 LL |         unstable();
    |         ^^^^^^^^
@@ -323,7 +332,7 @@ LL |         unstable();
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature `unstable_test_feature`
-  --> $DIR/lint-stability.rs:191:9
+  --> $DIR/lint-stability.rs:194:9
    |
 LL |         stable_mod::unstable();
    |         ^^^^^^^^^^^^^^^^^^^^
@@ -332,7 +341,7 @@ LL |         stable_mod::unstable();
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature `unstable_test_feature`
-  --> $DIR/lint-stability.rs:194:9
+  --> $DIR/lint-stability.rs:197:9
    |
 LL |         unstable_mod::deprecated();
    |         ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -341,7 +350,7 @@ LL |         unstable_mod::deprecated();
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature `unstable_test_feature`
-  --> $DIR/lint-stability.rs:195:9
+  --> $DIR/lint-stability.rs:198:9
    |
 LL |         unstable_mod::unstable();
    |         ^^^^^^^^^^^^^^^^^^^^^^
@@ -350,7 +359,7 @@ LL |         unstable_mod::unstable();
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature `unstable_test_feature`
-  --> $DIR/lint-stability.rs:197:17
+  --> $DIR/lint-stability.rs:200:17
    |
 LL |         let _ = Unstable::UnstableVariant;
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -359,7 +368,7 @@ LL |         let _ = Unstable::UnstableVariant;
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature `unstable_test_feature`
-  --> $DIR/lint-stability.rs:198:17
+  --> $DIR/lint-stability.rs:201:17
    |
 LL |         let _ = Unstable::StableVariant;
    |                 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -368,7 +377,7 @@ LL |         let _ = Unstable::StableVariant;
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature `unstable_test_feature`
-  --> $DIR/lint-stability.rs:88:48
+  --> $DIR/lint-stability.rs:91:48
    |
 LL |         struct S1<T: TraitWithAssociatedTypes>(T::TypeUnstable);
    |                                                ^^^^^^^^^^^^^^^
@@ -377,7 +386,7 @@ LL |         struct S1<T: TraitWithAssociatedTypes>(T::TypeUnstable);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature `unstable_test_feature`
-  --> $DIR/lint-stability.rs:92:13
+  --> $DIR/lint-stability.rs:95:13
    |
 LL |             TypeUnstable = u8,
    |             ^^^^^^^^^^^^^^^^^
@@ -385,6 +394,6 @@ LL |             TypeUnstable = u8,
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error: aborting due to 43 previous errors
+error: aborting due to 44 previous errors
 
 For more information about this error, try `rustc --explain E0658`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/158493)*
<!-- homu-ignore:end -->

Successful merges:

 - rust-lang/rust#137858 (Add new `unused_footnote_definition` rustdoc lint)
 - rust-lang/rust#158233 (Allow the unstable attribute on foreign type)
 - rust-lang/rust#158470 (Upgrade `jsonsocck` and `jsondoclint` to edition 2024.)
 - rust-lang/rust#158488 (Upgrade `rustdoc-json-types` to 2024 edition.)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=137858,158233,158470,158488)
<!-- homu-ignore:end -->

