### PR TITLE
Improve E0277 diagnostics for conditionally implemented traits

### DIFF
--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -2326,18 +2326,80 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 {
                     return false;
                 }
+                let mut multi_span = MultiSpan::from_span(self.tcx.def_span(def_id));
                 let (desc, mention_castable) =
                     match (cand.self_ty().kind(), trait_pred.self_ty().skip_binder().kind()) {
                         (ty::FnPtr(..), ty::FnDef(..)) => {
                             (" implemented for fn pointer `", ", cast using `as`")
                         }
                         (ty::FnPtr(..), _) => (" implemented for fn pointer `", ""),
-                        _ => (" implemented for `", ""),
+                        _ => {
+                            let evaluate_obligations = || {
+                                let ocx = ObligationCtxt::new_with_diagnostics(self);
+                                self.enter_forall(trait_pred, |obligation_trait_ref| {
+                                    let impl_args = self.fresh_args_for_item(DUMMY_SP, def_id);
+                                    let impl_trait_ref = ocx.normalize(
+                                        &ObligationCause::dummy(),
+                                        param_env,
+                                        ty::EarlyBinder::bind(self.tcx, cand)
+                                            .instantiate(self.tcx, impl_args),
+                                    );
+                                    if ocx
+                                        .eq(
+                                            &ObligationCause::dummy(),
+                                            param_env,
+                                            obligation_trait_ref.trait_ref,
+                                            impl_trait_ref,
+                                        )
+                                        .is_err()
+                                    {
+                                        return Vec::new();
+                                    }
+                                    ocx.register_obligations(
+                                        self.tcx
+                                            .predicates_of(def_id)
+                                            .instantiate(self.tcx, impl_args)
+                                            .into_iter()
+                                            .map(|(clause, span)| {
+                                                Obligation::new(
+                                                    self.tcx,
+                                                    ObligationCause::dummy_with_span(span),
+                                                    param_env,
+                                                    clause.skip_normalization(),
+                                                )
+                                            }),
+                                    );
+                                    ocx.try_evaluate_obligations()
+                                })
+                            };
+                            let failing_obligations =
+                                if !self.tcx.predicates_of(def_id).predicates.is_empty() {
+                                    self.probe(|_| evaluate_obligations())
+                                } else {
+                                    Vec::new()
+                                };
+
+                            if failing_obligations.is_empty() {
+                                (" implemented for `", "")
+                            } else {
+                                for error in failing_obligations {
+                                    multi_span.push_span_label(
+                                        error.root_obligation.cause.span,
+                                        format!(
+                                            "unsatisfied requirement introduced here: `{}`",
+                                            error.root_obligation.predicate,
+                                        ),
+                                    );
+                                }
+
+                                (" conditionally implemented for `", "")
+                            }
+                        }
                     };
                 let trait_ = self.tcx.short_string(cand.print_trait_sugared(), err.long_ty_path());
                 let self_ty = self.tcx.short_string(cand.self_ty(), err.long_ty_path());
                 err.highlighted_span_help(
-                    self.tcx.def_span(def_id),
+                    multi_span,
                     vec![
                         StringPart::normal(format!("the trait `{trait_}` ")),
                         StringPart::highlighted("is"),

--- a/tests/ui/derives/redundant-derive-note-on-unimplemented.stderr
+++ b/tests/ui/derives/redundant-derive-note-on-unimplemented.stderr
@@ -7,11 +7,13 @@ LL |     println!("{:?}", S(X));
    |               required by this formatting parameter
    |
    = help: the trait `Debug` is not implemented for `X`
-help: the trait `Debug` is implemented for `S<T>`
+help: the trait `Debug` is conditionally implemented for `S<T>`
   --> $DIR/redundant-derive-note-on-unimplemented.rs:8:10
    |
 LL | #[derive(Debug)]
    |          ^^^^^
+LL | struct S<T>(T);
+   |          - unsatisfied requirement introduced here: `X: Debug`
 note: required for `S<X>` to implement `Debug`
   --> $DIR/redundant-derive-note-on-unimplemented.rs:9:8
    |

--- a/tests/ui/errors/trait-bound-error-spans/blame-trait-error.stderr
+++ b/tests/ui/errors/trait-bound-error-spans/blame-trait-error.stderr
@@ -39,11 +39,13 @@ LL |     want(Some(()));
    |     required by a bound introduced by this call
    |
    = help: the trait `Iterator` is not implemented for `()`
-help: the trait `T1` is implemented for `Option<It>`
+help: the trait `T1` is conditionally implemented for `Option<It>`
   --> $DIR/blame-trait-error.rs:21:1
    |
 LL | impl<It: Iterator> T1 for Option<It> {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^--------^^^^^^^^^^^^^^^^^^^
+   |          |
+   |          unsatisfied requirement introduced here: `(): Iterator`
 note: required for `Option<()>` to implement `T1`
   --> $DIR/blame-trait-error.rs:21:20
    |

--- a/tests/ui/impl-trait/nested_impl_trait.stderr
+++ b/tests/ui/impl-trait/nested_impl_trait.stderr
@@ -50,8 +50,11 @@ LL | fn bad_in_ret_position(x: impl Into<u32>) -> impl Into<impl Debug> { x }
    |                                              |
    |                                              the trait `From<impl Into<u32>>` is not implemented for `impl Debug`
    |
-help: the trait `Into<U>` is implemented for `T`
+help: the trait `Into<U>` is conditionally implemented for `T`
   --> $SRC_DIR/core/src/convert/mod.rs:LL:COL
+  ::: $SRC_DIR/core/src/convert/mod.rs:LL:COL
+   |
+   = note: unsatisfied requirement introduced here: `impl Debug: From<impl Into<u32>>`
    = note: required for `impl Into<u32>` to implement `Into<impl Debug>`
 
 error[E0277]: the trait bound `impl Debug: From<impl Into<u32>>` is not satisfied
@@ -62,8 +65,11 @@ LL |     fn bad(x: impl Into<u32>) -> impl Into<impl Debug> { x }
    |                                  |
    |                                  the trait `From<impl Into<u32>>` is not implemented for `impl Debug`
    |
-help: the trait `Into<U>` is implemented for `T`
+help: the trait `Into<U>` is conditionally implemented for `T`
   --> $SRC_DIR/core/src/convert/mod.rs:LL:COL
+  ::: $SRC_DIR/core/src/convert/mod.rs:LL:COL
+   |
+   = note: unsatisfied requirement introduced here: `impl Debug: From<impl Into<u32>>`
    = note: required for `impl Into<u32>` to implement `Into<impl Debug>`
 
 error: aborting due to 7 previous errors

--- a/tests/ui/traits/copy-bounds-impl-type-params.stderr
+++ b/tests/ui/traits/copy-bounds-impl-type-params.stderr
@@ -80,11 +80,13 @@ error[E0277]: the trait bound `String: Copy` is not satisfied
 LL |     let a = t as Box<dyn Gettable<String>>;
    |             ^ the trait `Copy` is not implemented for `String`
    |
-help: the trait `Gettable<T>` is implemented for `S<T>`
+help: the trait `Gettable<T>` is conditionally implemented for `S<T>`
   --> $DIR/copy-bounds-impl-type-params.rs:14:1
    |
 LL | impl<T: Send + Copy + 'static> Gettable<T> for S<T> {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                |
+   |                unsatisfied requirement introduced here: `String: Copy`
 note: required for `S<String>` to implement `Gettable<String>`
   --> $DIR/copy-bounds-impl-type-params.rs:14:32
    |
@@ -100,11 +102,13 @@ error[E0277]: the trait bound `Foo: Copy` is not satisfied
 LL |     let a: Box<dyn Gettable<Foo>> = t;
    |                                     ^ the trait `Copy` is not implemented for `Foo`
    |
-help: the trait `Gettable<T>` is implemented for `S<T>`
+help: the trait `Gettable<T>` is conditionally implemented for `S<T>`
   --> $DIR/copy-bounds-impl-type-params.rs:14:1
    |
 LL | impl<T: Send + Copy + 'static> Gettable<T> for S<T> {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                |
+   |                unsatisfied requirement introduced here: `Foo: Copy`
 note: required for `S<Foo>` to implement `Gettable<Foo>`
   --> $DIR/copy-bounds-impl-type-params.rs:14:32
    |

--- a/tests/ui/traits/error_reporting/conditionally-implemented-trait-158423.rs
+++ b/tests/ui/traits/error_reporting/conditionally-implemented-trait-158423.rs
@@ -1,0 +1,28 @@
+struct Test(i32, i64);
+trait Foo<'a> {
+    type Assoc;
+}
+
+trait SimpleFoo {
+    type SimpleAssoc;
+}
+impl<'a, T> Foo<'a> for T where T: SimpleFoo {
+    type Assoc = T::SimpleAssoc;
+}
+
+impl SimpleFoo for i32 {
+    type SimpleAssoc = i32;
+}
+impl SimpleFoo for i64 {
+    type SimpleAssoc = i32;
+}
+
+impl<'a> Foo<'a> for Test where i32: Foo<'a, Assoc = i32>, i64: Foo<'a, Assoc = i64> {
+    type Assoc = Test;
+}
+
+fn process<'a, T: Foo<'a>>(_input: T) {}
+fn test() { process(Test(0, 1)) }
+//~^ ERROR the trait bound `Test: Foo<'_>` is not satisfied
+
+fn main() {}

--- a/tests/ui/traits/error_reporting/conditionally-implemented-trait-158423.stderr
+++ b/tests/ui/traits/error_reporting/conditionally-implemented-trait-158423.stderr
@@ -1,0 +1,27 @@
+error[E0277]: the trait bound `Test: Foo<'_>` is not satisfied
+  --> $DIR/conditionally-implemented-trait-158423.rs:25:21
+   |
+LL | fn test() { process(Test(0, 1)) }
+   |             ------- ^^^^^^^^^^ unsatisfied trait bound
+   |             |
+   |             required by a bound introduced by this call
+   |
+help: the trait `Foo<'_>` is not implemented for `Test`
+  --> $DIR/conditionally-implemented-trait-158423.rs:1:1
+   |
+LL | struct Test(i32, i64);
+   | ^^^^^^^^^^^
+help: the trait `Foo<'_>` is implemented for `Test`
+  --> $DIR/conditionally-implemented-trait-158423.rs:20:1
+   |
+LL | impl<'a> Foo<'a> for Test where i32: Foo<'a, Assoc = i32>, i64: Foo<'a, Assoc = i64> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: required by a bound in `process`
+  --> $DIR/conditionally-implemented-trait-158423.rs:24:19
+   |
+LL | fn process<'a, T: Foo<'a>>(_input: T) {}
+   |                   ^^^^^^^ required by this bound in `process`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/traits/error_reporting/conditionally-implemented-trait-158423.stderr
+++ b/tests/ui/traits/error_reporting/conditionally-implemented-trait-158423.stderr
@@ -11,11 +11,13 @@ help: the trait `Foo<'_>` is not implemented for `Test`
    |
 LL | struct Test(i32, i64);
    | ^^^^^^^^^^^
-help: the trait `Foo<'_>` is implemented for `Test`
+help: the trait `Foo<'_>` is conditionally implemented for `Test`
   --> $DIR/conditionally-implemented-trait-158423.rs:20:1
    |
 LL | impl<'a> Foo<'a> for Test where i32: Foo<'a, Assoc = i32>, i64: Foo<'a, Assoc = i64> {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-----------^
+   |                                                                         |
+   |                                                                         unsatisfied requirement introduced here: `<i64 as Foo<'_>>::Assoc == i64`
 note: required by a bound in `process`
   --> $DIR/conditionally-implemented-trait-158423.rs:24:19
    |

--- a/tests/ui/traits/next-solver/cycles/coinduction/incompleteness-unstable-result.with.stderr
+++ b/tests/ui/traits/next-solver/cycles/coinduction/incompleteness-unstable-result.with.stderr
@@ -9,13 +9,14 @@ help: the trait `Trait<_, _, _>` is not implemented for `A<X>`
    |
 LL | struct A<T>(*const T);
    | ^^^^^^^^^^^
-help: the trait `Trait<U, V, D>` is implemented for `A<T>`
+help: the trait `Trait<U, V, D>` is conditionally implemented for `A<T>`
   --> $DIR/incompleteness-unstable-result.rs:34:1
    |
 LL | / impl<T, U, V, D> Trait<U, V, D> for A<T>
 LL | | where
 LL | |     T: IncompleteGuidance<U, V>,
 LL | |     A<T>: Trait<U, D, V>,
+   | |           -------------- unsatisfied requirement introduced here: `A<_>: Trait<_, _, _>`
 LL | |     B<T>: Trait<U, V, D>,
 LL | |     (): ToU8<D>,
    | |________________^

--- a/tests/ui/traits/next-solver/cycles/coinduction/incompleteness-unstable-result.without.stderr
+++ b/tests/ui/traits/next-solver/cycles/coinduction/incompleteness-unstable-result.without.stderr
@@ -9,13 +9,14 @@ help: the trait `Trait<_, _, _>` is not implemented for `A<X>`
    |
 LL | struct A<T>(*const T);
    | ^^^^^^^^^^^
-help: the trait `Trait<U, V, D>` is implemented for `A<T>`
+help: the trait `Trait<U, V, D>` is conditionally implemented for `A<T>`
   --> $DIR/incompleteness-unstable-result.rs:34:1
    |
 LL | / impl<T, U, V, D> Trait<U, V, D> for A<T>
 LL | | where
 LL | |     T: IncompleteGuidance<U, V>,
 LL | |     A<T>: Trait<U, D, V>,
+   | |           -------------- unsatisfied requirement introduced here: `A<_>: Trait<_, _, _>`
 LL | |     B<T>: Trait<U, V, D>,
 LL | |     (): ToU8<D>,
    | |________________^


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/158494)*
<!-- homu-ignore:end -->

Fixes rust-lang/rust#158423.

The diagnostic previously reported that a trait was "implemented" even when the matching impl could not apply because its where-clause requirements were not satisfied, which was misleading.

This change:

- reports that the trait is "conditionally implemented" when a matching impl is rejected due to unsatisfied where-clause requirements;
- highlights the unsatisfied requirement in the impl and includes the corresponding predicate in the diagnostic;
- preserves the existing diagnostic flow while making it clearer why the candidate impl was rejected.