### PR TITLE
Revert "LLVM 23: Adapt codegen test to moved assume"

### DIFF
--- a/tests/codegen-llvm/issues/issue-107681-unwrap_unchecked.rs
+++ b/tests/codegen-llvm/issues/issue-107681-unwrap_unchecked.rs
@@ -1,6 +1,4 @@
 //@ compile-flags: -Copt-level=3
-//@ filecheck-flags: --implicit-check-not 'br {{.*}}' --implicit-check-not 'select'
-//@ min-llvm-version: 22
 
 // Test for #107681.
 // Make sure we don't create `br` or `select` instructions.
@@ -13,8 +11,10 @@ use std::slice::Iter;
 #[no_mangle]
 pub unsafe fn foo(x: &mut Copied<Iter<'_, u32>>) -> u32 {
     // CHECK-LABEL: @foo(
-    // CHECK: [[INNER:%.*]] = load ptr, ptr %x
-    // CHECK: [[RET:%.*]] = load i32, ptr [[INNER]]
-    // CHECK: ret i32 [[RET]]
+    // CHECK-NOT: br {{.*}}
+    // CHECK-NOT: select
+    // CHECK: [[RET:%.*]] = load i32, ptr
+    // CHECK-NEXT: assume
+    // CHECK-NEXT: ret i32 [[RET]]
     x.next().unwrap_unchecked()
 }


### PR DESCRIPTION
This reverts https://github.com/rust-lang/rust/pull/158067.
Fixes https://github.com/rust-lang/rust/issues/158500

The fix that was applied here is not robust against layout randomization, specifically the IR to load through the slice head pointer needs to come after a gepi, and not just a `load ptr, ptr %x`.

Based on the PR discussion, I think it's possible that the `min-llvm-version: 22` was mistakenly added when CI happened to choose the bad layout during the initial merge.

I'm not yet sure what the right fix is, but this is causing about half of all merges to fail right now so a revert seems prudent.

I don't think we have a way to skip tests when randomize-layout is set. The problem here is that we run codegen tests against the globally-configured sysroot, so setting `-Zrandomize-layout` in the test doesn't do anything.