### PR TITLE
Update POSIX edition links

### DIFF
--- a/library/core/src/ascii/ascii_char.rs
+++ b/library/core/src/ascii/ascii_char.rs
@@ -1049,8 +1049,8 @@ impl AsciiChar {
     /// before using this function.
     ///
     /// [infra-aw]: https://infra.spec.whatwg.org/#ascii-whitespace
-    /// [pct]: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap07.html#tag_07_03_01
-    /// [bfs]: https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_06_05
+    /// [pct]: https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/V1_chap07.html#tag_07_03_01
+    /// [bfs]: https://pubs.opengroup.org/onlinepubs/9799919799/utilities/V3_chap02.html#tag_19_06_05
     ///
     /// # Examples
     ///

--- a/library/core/src/char/methods.rs
+++ b/library/core/src/char/methods.rs
@@ -2354,8 +2354,8 @@ impl char {
     /// before using this function.
     ///
     /// [infra-aw]: https://infra.spec.whatwg.org/#ascii-whitespace
-    /// [pct]: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap07.html#tag_07_03_01
-    /// [bfs]: https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_06_05
+    /// [pct]: https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/V1_chap07.html#tag_07_03_01
+    /// [bfs]: https://pubs.opengroup.org/onlinepubs/9799919799/utilities/V3_chap02.html#tag_19_06_05
     ///
     /// # Examples
     ///

--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -1125,8 +1125,8 @@ impl u8 {
     /// before using this function.
     ///
     /// [infra-aw]: https://infra.spec.whatwg.org/#ascii-whitespace
-    /// [pct]: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap07.html#tag_07_03_01
-    /// [bfs]: https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_06_05
+    /// [pct]: https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/V1_chap07.html#tag_07_03_01
+    /// [bfs]: https://pubs.opengroup.org/onlinepubs/9799919799/utilities/V3_chap02.html#tag_19_06_05
     ///
     /// # Examples
     ///

--- a/library/std/src/os/fd/owned.rs
+++ b/library/std/src/os/fd/owned.rs
@@ -199,7 +199,7 @@ impl Drop for OwnedFd {
         unsafe {
             // Note that errors are ignored when closing a file descriptor. According to POSIX 2024,
             // we can and indeed should retry `close` on `EINTR`
-            // (https://pubs.opengroup.org/onlinepubs/9799919799.2024edition/functions/close.html),
+            // (https://pubs.opengroup.org/onlinepubs/9799919799/functions/close.html),
             // but it is not clear yet how well widely-used implementations are conforming with this
             // mandate since older versions of POSIX left the state of the FD after an `EINTR`
             // unspecified. Ignoring errors is "fine" because some of the major Unices (in

--- a/library/std/src/os/unix/process.rs
+++ b/library/std/src/os/unix/process.rs
@@ -100,7 +100,7 @@ pub impl(self) trait CommandExt {
     /// locations might not appear where intended.
     ///
     /// [POSIX fork() specification]:
-    ///     https://pubs.opengroup.org/onlinepubs/9699919799/functions/fork.html
+    ///     https://pubs.opengroup.org/onlinepubs/9799919799/functions/fork.html
     /// [`std::env`]: mod@crate::env
     /// [`Error::new`]: ../../../io/struct.Error.html#method.new
     /// [`Error::other`]: ../../../io/struct.Error.html#method.other

--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -4137,7 +4137,7 @@ impl Error for NormalizeError {}
 /// Note that this [may change in the future][changes].
 ///
 /// [changes]: io#platform-specific-behavior
-/// [posix-semantics]: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap04.html#tag_04_13
+/// [posix-semantics]: https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/V1_chap04.html#tag_04_16
 /// [windows-path]: https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getfullpathnamew
 /// [cygwin-path]: https://cygwin.com/cygwin-api/func-cygwin-conv-path.html
 #[stable(feature = "absolute_path", since = "1.79.0")]

--- a/library/std/src/sys/fs/unix.rs
+++ b/library/std/src/sys/fs/unix.rs
@@ -1926,7 +1926,7 @@ impl fmt::Debug for File {
 // Format in octal, followed by the mode format used in `ls -l`.
 //
 // References:
-//   https://pubs.opengroup.org/onlinepubs/009696899/utilities/ls.html
+//   https://pubs.opengroup.org/onlinepubs/9799919799/utilities/ls.html
 //   https://www.gnu.org/software/libc/manual/html_node/Testing-File-Type.html
 //   https://www.gnu.org/software/libc/manual/html_node/Permission-Bits.html
 //

--- a/library/std/src/sys/pal/unix/conf.rs
+++ b/library/std/src/sys/pal/unix/conf.rs
@@ -11,7 +11,7 @@ pub fn page_size() -> usize {
 /// `_CS_PATH` or `_CS_V[67]_ENV` in the future).
 ///
 /// [posix_confstr]:
-///     https://pubs.opengroup.org/onlinepubs/9699919799/functions/confstr.html
+///     https://pubs.opengroup.org/onlinepubs/9799919799/functions/confstr.html
 #[cfg(target_vendor = "apple")]
 pub fn confstr(
     key: crate::ffi::c_int,

--- a/library/std/src/sys/pal/unix/sync/mutex.rs
+++ b/library/std/src/sys/pal/unix/sync/mutex.rs
@@ -25,7 +25,7 @@ impl Mutex {
         // A pthread mutex initialized with PTHREAD_MUTEX_INITIALIZER will have
         // a type of PTHREAD_MUTEX_DEFAULT, which has undefined behavior if you
         // try to re-lock it from the same thread when you already hold a lock
-        // (https://pubs.opengroup.org/onlinepubs/9699919799/functions/pthread_mutex_init.html).
+        // (https://pubs.opengroup.org/onlinepubs/9799919799/functions/pthread_mutex_init.html).
         // This is the case even if PTHREAD_MUTEX_DEFAULT == PTHREAD_MUTEX_NORMAL
         // (https://github.com/rust-lang/rust/issues/33770#issuecomment-220847521) -- in that
         // case, `pthread_mutexattr_settype(PTHREAD_MUTEX_DEFAULT)` will of course be the same

--- a/library/std/src/sys/path/unix.rs
+++ b/library/std/src/sys/path/unix.rs
@@ -20,8 +20,8 @@ pub const HAS_PREFIXES: bool = false;
 pub(crate) fn absolute(path: &Path) -> io::Result<PathBuf> {
     // This is mostly a wrapper around collecting `Path::components`, with
     // exceptions made where this conflicts with the POSIX specification.
-    // See 4.13 Pathname Resolution, IEEE Std 1003.1-2017
-    // https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap04.html#tag_04_13
+    // See 4.16 Pathname Resolution, IEEE Std 1003.1-2024
+    // https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/V1_chap04.html#tag_04_16
 
     // Get the components, skipping the redundant leading "." component if it exists.
     let mut components = path.strip_prefix(".").unwrap_or(path).components();

--- a/library/std/src/sys/process/unix/unix.rs
+++ b/library/std/src/sys/process/unix/unix.rs
@@ -1101,7 +1101,7 @@ impl ExitStatus {
     pub fn exit_ok(&self) -> Result<(), ExitStatusError> {
         // This assumes that WIFEXITED(status) && WEXITSTATUS==0 corresponds to status==0. This is
         // true on all actual versions of Unix, is widely assumed, and is specified in SuS
-        // https://pubs.opengroup.org/onlinepubs/9699919799/functions/wait.html. If it is not
+        // https://pubs.opengroup.org/onlinepubs/9799919799/functions/wait.html. If it is not
         // true for a platform pretending to be Unix, the tests (our doctests, and also
         // unix/tests.rs) will spot it. `ExitStatusError::code` assumes this too.
         match NonZero::try_from(self.0) {

--- a/library/std/src/sys/process/unix/unsupported/wait_status.rs
+++ b/library/std/src/sys/process/unix/unsupported/wait_status.rs
@@ -46,7 +46,7 @@ impl ExitStatus {
     pub fn exit_ok(&self) -> Result<(), ExitStatusError> {
         // This assumes that WIFEXITED(status) && WEXITSTATUS==0 corresponds to status==0. This is
         // true on all actual versions of Unix, is widely assumed, and is specified in SuS
-        // https://pubs.opengroup.org/onlinepubs/9699919799/functions/wait.html. If it is not
+        // https://pubs.opengroup.org/onlinepubs/9799919799/functions/wait.html. If it is not
         // true for a platform pretending to be Unix, the tests (our doctests, and also
         // unix/tests.rs) will spot it. `ExitStatusError::code` assumes this too.
         match NonZero::try_from(self.wait_status) {

--- a/library/std/src/sys/process/unix/vxworks.rs
+++ b/library/std/src/sys/process/unix/vxworks.rs
@@ -211,7 +211,7 @@ impl ExitStatus {
     pub fn exit_ok(&self) -> Result<(), ExitStatusError> {
         // This assumes that WIFEXITED(status) && WEXITSTATUS==0 corresponds to status==0. This is
         // true on all actual versions of Unix, is widely assumed, and is specified in SuS
-        // https://pubs.opengroup.org/onlinepubs/9699919799/functions/wait.html. If it is not
+        // https://pubs.opengroup.org/onlinepubs/9799919799/functions/wait.html. If it is not
         // true for a platform pretending to be Unix, the tests (our doctests, and also
         // unix/tests.rs) will spot it. `ExitStatusError::code` assumes this too.
         match NonZero::try_from(self.0) {

--- a/tests/ui/process/process-spawn-failure.rs
+++ b/tests/ui/process/process-spawn-failure.rs
@@ -38,7 +38,7 @@ fn find_zombies() {
     extern crate libc;
     let my_pid = unsafe { libc::getpid() };
 
-    // https://pubs.opengroup.org/onlinepubs/9699919799/utilities/ps.html
+    // https://pubs.opengroup.org/onlinepubs/9799919799/utilities/ps.html
     let ps_cmd_output = Command::new("ps").args(&["-A", "-o", "pid,ppid,args"]).output().unwrap();
     let ps_output = String::from_utf8_lossy(&ps_cmd_output.stdout);
     // On AIX, the PPID is not always present, such as when a process is blocked


### PR DESCRIPTION
Comments that reference https://pubs.opengroup.org point to issue 7 (the 2018 edition of IEEE Std 1003.1-2017), with one link still on the older issue 6. The latest issue is 8 (the 2024 edition, IEEE Std 1003.1-2024). From https://www.opengroup.org/austin/papers/posix_faq.html:

> Q3. What is the latest version of POSIX.1?
>
> The 1003.1-2024 standard was published in June 2024. The standard is
> formally known as: IEEE Std 1003.1-2024 The Open Group Technical
> Standard Base Specifications, Issue 8

Issue 8 lives at https://pubs.opengroup.org/onlinepubs/9799919799/.

This PR points all older-edition links to issue 8.

Most links are a straight edition bump, but links with a section anchor needed their anchor rechecked, because section numbering shifts between editions. Verified against the 2024 edition:

- Pathname Resolution moved from 4.13 (`tag_04_13`) to 4.16 (`tag_04_16`)
- Field Splitting moved from `tag_18_06_05` to `tag_19_06_05`
- LC_CTYPE (`tag_07_03_01`) was unchanged

The Miri changes (`src/tools/miri/`) are kept in a separate commit since that's a synced subtree. I'm happy to move them to a `rust-lang/miri` PR if preferred.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
