### PR TITLE
Use the call site for the assign suggestion on macro-expanded types

### DIFF
--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
@@ -3229,7 +3229,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                             "expected type, found associated function call",
                         )
                         .with_span_suggestion_verbose(
-                            stmt.pat.span.between(hir_ty.span),
+                            stmt.pat.span.between(hir_ty.span.source_callsite()),
                             "use `=` if you meant to assign",
                             " = ".to_string(),
                             Applicability::MaybeIncorrect,
@@ -3255,7 +3255,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                             "expected type, found associated function call",
                         )
                         .with_span_suggestion_verbose(
-                            stmt.pat.span.between(hir_ty.span),
+                            stmt.pat.span.between(hir_ty.span.source_callsite()),
                             "use `=` if you meant to assign",
                             " = ".to_string(),
                             Applicability::MaybeIncorrect,

--- a/tests/ui/suggestions/let-binding-init-expr-as-ty.rs
+++ b/tests/ui/suggestions/let-binding-init-expr-as-ty.rs
@@ -27,6 +27,7 @@ fn main() {
     let x: S::new(..); //~ ERROR expected type, found associated function call
     //~^ ERROR return type notation is experimental
     let x: S::new(()); //~ ERROR expected type, found associated function call
+    let x: vec![]; //~ ERROR expected type, found associated function call
 
     // Literals
     let x: 42; //~ ERROR expected type, found `42`

--- a/tests/ui/suggestions/let-binding-init-expr-as-ty.stderr
+++ b/tests/ui/suggestions/let-binding-init-expr-as-ty.stderr
@@ -1,5 +1,5 @@
 error: expected type, found `42`
-  --> $DIR/let-binding-init-expr-as-ty.rs:32:12
+  --> $DIR/let-binding-init-expr-as-ty.rs:33:12
    |
 LL |     let x: 42;
    |          - ^^ expected type
@@ -13,7 +13,7 @@ LL +     let x = 42;
    |
 
 error: expected type, found `""`
-  --> $DIR/let-binding-init-expr-as-ty.rs:33:12
+  --> $DIR/let-binding-init-expr-as-ty.rs:34:12
    |
 LL |     let x: "";
    |          - ^^ expected type
@@ -39,7 +39,7 @@ LL +     let foo = i32::from_be(num);
    |
 
 error[E0573]: expected type, found function `bar`
-  --> $DIR/let-binding-init-expr-as-ty.rs:36:12
+  --> $DIR/let-binding-init-expr-as-ty.rs:37:12
    |
 LL |     let x: bar();
    |            ^^^^^ not a type
@@ -51,13 +51,13 @@ LL +     let x = bar();
    |
 
 error[E0573]: expected type, found function `bar`
-  --> $DIR/let-binding-init-expr-as-ty.rs:37:12
+  --> $DIR/let-binding-init-expr-as-ty.rs:38:12
    |
 LL |     let x: bar;
    |            ^^^ not a type
 
 error[E0573]: expected type, found local variable `x`
-  --> $DIR/let-binding-init-expr-as-ty.rs:40:12
+  --> $DIR/let-binding-init-expr-as-ty.rs:41:12
    |
 LL | struct K(S::new(()));
    | --------------------- similarly named struct `K` defined here
@@ -153,7 +153,19 @@ LL -     let x: S::new(());
 LL +     let x = S::new(());
    |
 
-error: aborting due to 13 previous errors
+error: expected type, found associated function call
+  --> $DIR/let-binding-init-expr-as-ty.rs:30:12
+   |
+LL |     let x: vec![];
+   |            ^^^^^^
+   |
+help: use `=` if you meant to assign
+   |
+LL -     let x: vec![];
+LL +     let x = vec![];
+   |
+
+error: aborting due to 14 previous errors
 
 Some errors have detailed explanations: E0573, E0658.
 For more information about an error, try `rustc --explain E0573`.


### PR DESCRIPTION
Fixes rust-lang/rust#158492.

When a `let` binding's type is a macro invocation, for example:

    fn main() {
        let x: vec![];
    }

the compiler emits "expected type, found associated function call" and
suggests using `=` to assign. The suggestion span was derived from the
expanded type span, which points inside the macro definition, so the
help pointed at the standard library and proposed editing the
expansion of `vec!`:

    help: use `=` if you meant to assign
      --> library/alloc/src/macros.rs:44:9
       |
    44 -         $crate::vec::Vec::new()
    44 +          =

This maps the suggestion span back to the call site with
`source_callsite()`, so it now points at the user's code:

    help: use `=` if you meant to assign
       |
    LL -     let x: vec![];
    LL +     let x = vec![];

For non-macro types `source_callsite()` returns the same span, so the
existing cases (`Vec::new()`, `S::new(())`, `i32::from_be(num)`, and so
on) are unchanged. The same fix is applied to the sibling
primitive-type branch.

A regression case is added to
tests/ui/suggestions/let-binding-init-expr-as-ty.rs.
