### PR TITLE
Enable `static_position_independent_executables` on all gnu targets

### DIFF
--- a/compiler/rustc_target/src/spec/base/linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/base/linux_gnu.rs
@@ -1,7 +1,11 @@
 use crate::spec::{Cc, Env, LinkerFlavor, Lld, TargetOptions, base};
 
 pub(crate) fn opts() -> TargetOptions {
-    let mut base = TargetOptions { env: Env::Gnu, ..base::linux::opts() };
+    let mut base = TargetOptions {
+        env: Env::Gnu,
+        static_position_independent_executables: true,
+        ..base::linux::opts()
+    };
 
     // When we're asked to use the `rust-lld` linker by default, set the appropriate lld-using
     // linker flavor, and self-contained linker component.

--- a/compiler/rustc_target/src/spec/targets/x86_64_unknown_linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/targets/x86_64_unknown_linux_gnu.rs
@@ -9,7 +9,6 @@ pub(crate) fn target() -> Target {
     base.max_atomic_width = Some(64);
     base.add_pre_link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-m64"]);
     base.stack_probes = StackProbeType::Inline;
-    base.static_position_independent_executables = true;
     base.supported_sanitizers = SanitizerSet::ADDRESS
         | SanitizerSet::CFI
         | SanitizerSet::KCFI


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/158510)*
<!-- homu-ignore:end -->

Glibc has supported static PIE for a while, so there's no reason to ever build a non-PIE executable with a modern toolchain.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
