### PR TITLE
diagnostics: emit unused_doc_comments on fn nest

### DIFF
--- a/compiler/rustc_expand/src/mbe/transcribe.rs
+++ b/compiler/rustc_expand/src/mbe/transcribe.rs
@@ -916,7 +916,7 @@ fn count_repetitions<'dx>(
         }
     }
 
-    /// Maximum depth
+    // Maximum depth
     fn depth(counter: usize, matched: &NamedMatch) -> usize {
         match matched {
             MatchedSingle(_) => counter,

--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -838,6 +838,32 @@ impl EarlyLintPass for UnusedDocComment {
     fn check_item(&mut self, cx: &EarlyContext<'_>, item: &ast::Item) {
         if let ast::ItemKind::ForeignMod(_) = item.kind {
             warn_if_doc(cx, item.span, "extern blocks", &item.attrs);
+        } else if self.in_fn != 0 {
+            warn_if_doc(cx, item.span, "items defined in functions", &item.attrs);
+            fn warn_on_fields(cx: &EarlyContext<'_>, var_data: &VariantData) {
+                for field in var_data.fields() {
+                    warn_if_doc(cx, field.span, "fields defined nested in functions", &field.attrs);
+                }
+            }
+            if let ast::ItemKind::Struct(_, _, var_data) = &item.kind {
+                warn_on_fields(cx, var_data);
+            } else if let ast::ItemKind::Union(_, _, var_data) = &item.kind {
+                warn_on_fields(cx, var_data);
+            } else if let ast::ItemKind::Enum(_, _, def) = &item.kind {
+                for var in &def.variants {
+                    warn_if_doc(cx, var.span, "variants defined nested in functions", &var.attrs);
+                    warn_on_fields(cx, &var.data);
+                }
+            }
+        }
+        if let ast::ItemKind::Fn(_) = item.kind {
+            self.in_fn += 1;
+        }
+    }
+
+    fn check_item_post(&mut self, _: &EarlyContext<'_>, item: &ast::Item) {
+        if let ast::ItemKind::Fn(_) = item.kind {
+            self.in_fn -= 1;
         }
     }
 }

--- a/compiler/rustc_lint/src/lib.rs
+++ b/compiler/rustc_lint/src/lib.rs
@@ -184,7 +184,7 @@ early_lint_methods!(
             NonAsciiIdents: NonAsciiIdents,
             IncompleteInternalFeatures: IncompleteInternalFeatures,
             RedundantSemicolons: RedundantSemicolons,
-            UnusedDocComment: UnusedDocComment,
+            UnusedDocComment: UnusedDocComment::default(),
             Expr2024: Expr2024,
             Precedence: Precedence,
             DoubleNegations: DoubleNegations,

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -7,7 +7,7 @@
 //! When removing a lint, make sure to also add a call to `register_removed` in
 //! compiler/rustc_lint/src/lib.rs.
 
-use crate::{declare_lint, declare_lint_pass, fcw};
+use crate::{declare_lint, fcw, impl_lint_pass};
 
 pub mod hardwired {
     use super::*;
@@ -3341,7 +3341,11 @@ declare_lint! {
     };
 }
 
-declare_lint_pass!(UnusedDocComment => [UNUSED_DOC_COMMENTS]);
+#[derive(Clone, Copy, Default)]
+pub struct UnusedDocComment {
+    pub in_fn: usize,
+}
+impl_lint_pass!(UnusedDocComment => [UNUSED_DOC_COMMENTS]);
 
 declare_lint! {
     /// The `missing_abi` lint detects cases where the ABI is omitted from

--- a/compiler/rustc_middle/src/mir/interpret/allocation/init_mask.rs
+++ b/compiler/rustc_middle/src/mir/interpret/allocation/init_mask.rs
@@ -381,7 +381,7 @@ impl InitMaskMaterialized {
             end: Size,
             is_init: bool,
         ) -> Option<Size> {
-            /// Search one block, returning the index of the first bit equal to `is_init`.
+            // Search one block, returning the index of the first bit equal to `is_init`.
             fn search_block(
                 bits: Block,
                 block: usize,

--- a/library/compiler-builtins/compiler-builtins/src/mem/impls.rs
+++ b/library/compiler-builtins/compiler-builtins/src/mem/impls.rs
@@ -183,8 +183,8 @@ pub unsafe fn copy_forward(mut dest: *mut u8, mut src: *const u8, mut n: usize) 
         // dest_usize does not matter any more
     }
 
-    /// `n` is in units of bytes, but must be a multiple of the word size and must not be 0.
-    /// `src` *must not* be `usize`-aligned.
+    // `n` is in units of bytes, but must be a multiple of the word size and must not be 0.
+    // `src` *must not* be `usize`-aligned.
     #[cfg(mem_unaligned)]
     #[inline(always)]
     unsafe fn copy_forward_misaligned_words(dest: *mut u8, src: *const u8, n: usize) {
@@ -299,8 +299,8 @@ pub unsafe fn copy_backward(dest: *mut u8, src: *const u8, mut n: usize) {
         *dest_usize = reassembled;
     }
 
-    /// `n` is in units of bytes, but must be a multiple of the word size and must not be 0.
-    /// `src` *must not* be `usize`-aligned.
+    // `n` is in units of bytes, but must be a multiple of the word size and must not be 0.
+    // `src` *must not* be `usize`-aligned.
     #[cfg(mem_unaligned)]
     #[inline(always)]
     unsafe fn copy_backward_misaligned_words(dest: *mut u8, src: *const u8, n: usize) {

--- a/library/compiler-builtins/libm/src/math/support/feature_detect.rs
+++ b/library/compiler-builtins/libm/src/math/support/feature_detect.rs
@@ -52,11 +52,11 @@ macro_rules! select_once {
 
         type Func = unsafe fn($($arg: $ArgTy),*) -> $RetTy;
 
-        /// Stores a pointer that is immediately jumped to. By default it is an init function
-        /// that sets FUNC to something else.
+        // Stores a pointer that is immediately jumped to. By default it is an init function
+        // that sets FUNC to something else.
         static FUNC: AtomicPtr<()> = AtomicPtr::new((initializer as Func) as *mut ());
 
-        /// Run once to set the function that will be used for all subsequent calls.
+        // Run once to set the function that will be used for all subsequent calls.
         fn initializer($($arg: $ArgTy),*) -> $RetTy {
             // Select an implementation, ensuring a 'static lifetime.
             let fn_ptr: Func = $init();

--- a/library/core/src/escape.rs
+++ b/library/core/src/escape.rs
@@ -80,13 +80,13 @@ const fn escape_ascii<const N: usize>(byte: u8) -> ([ascii::Char; N], Range<u8>)
 
     #[cfg(not(feature = "optimize_for_size"))]
     {
-        /// Lookup table helps us determine how to display character.
-        ///
-        /// Since ASCII characters will always be 7 bits, we can exploit this to store the 8th bit to
-        /// indicate whether the result is escaped or unescaped.
-        ///
-        /// We additionally use 0x80 (escaped NUL character) to indicate hex-escaped bytes, since
-        /// escaped NUL will not occur.
+        // Lookup table helps us determine how to display character.
+        //
+        // Since ASCII characters will always be 7 bits, we can exploit this to store the 8th bit to
+        // indicate whether the result is escaped or unescaped.
+        //
+        // We additionally use 0x80 (escaped NUL character) to indicate hex-escaped bytes, since
+        // escaped NUL will not occur.
         const LOOKUP: [u8; 256] = {
             let mut arr = [0; 256];
             let mut idx = 0;

--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -2251,22 +2251,22 @@ pub(crate) unsafe fn align_offset<T: Sized>(p: *const T, a: usize) -> usize {
         unchecked_shr, unchecked_sub, wrapping_add, wrapping_mul, wrapping_sub,
     };
 
-    /// Calculate multiplicative modular inverse of `x` modulo `m`.
-    ///
-    /// This implementation is tailored for `align_offset` and has following preconditions:
-    ///
-    /// * `m` is a power-of-two;
-    /// * `x < m`; (if `x ≥ m`, pass in `x % m` instead)
-    ///
-    /// Implementation of this function shall not panic. Ever.
+    // Calculate multiplicative modular inverse of `x` modulo `m`.
+    //
+    // This implementation is tailored for `align_offset` and has following preconditions:
+    //
+    // * `m` is a power-of-two;
+    // * `x < m`; (if `x ≥ m`, pass in `x % m` instead)
+    //
+    // Implementation of this function shall not panic. Ever.
     #[inline]
     const unsafe fn mod_inv(x: usize, m: usize) -> usize {
-        /// Multiplicative modular inverse table modulo 2⁴ = 16.
-        ///
-        /// Note, that this table does not contain values where inverse does not exist (i.e., for
-        /// `0⁻¹ mod 16`, `2⁻¹ mod 16`, etc.)
+        // Multiplicative modular inverse table modulo 2⁴ = 16.
+        //
+        // Note, that this table does not contain values where inverse does not exist (i.e., for
+        // `0⁻¹ mod 16`, `2⁻¹ mod 16`, etc.)
         const INV_TABLE_MOD_16: [u8; 8] = [1, 11, 13, 7, 9, 3, 5, 15];
-        /// Modulo for which the `INV_TABLE_MOD_16` is intended.
+        // Modulo for which the `INV_TABLE_MOD_16` is intended.
         const INV_TABLE_MOD: usize = 16;
 
         // SAFETY: `m` is required to be a power-of-two, hence non-zero.

--- a/library/core/src/slice/ascii.rs
+++ b/library/core/src/slice/ascii.rs
@@ -463,8 +463,8 @@ const fn is_ascii(s: &[u8]) -> bool {
         if const {
             is_ascii_simple(s)
         } else {
-            /// Returns `true` if any byte in the word `v` is nonascii (>= 128). Snarfed
-            /// from `../str/mod.rs`, which does something similar for utf8 validation.
+            // Returns `true` if any byte in the word `v` is nonascii (>= 128). Snarfed
+            // from `../str/mod.rs`, which does something similar for utf8 validation.
             const fn contains_nonascii(v: usize) -> bool {
                 const NONASCII_MASK: usize = usize::repeat_u8(0x80);
                 (NONASCII_MASK & v) != 0

--- a/library/coretests/tests/fmt/mod.rs
+++ b/library/coretests/tests/fmt/mod.rs
@@ -31,7 +31,7 @@ fn test_format_flags() {
 
     assert_eq!(format!("{: >3}", 'a'), "  a");
 
-    /// Regression test for <https://github.com/rust-lang/rust/issues/50280#issuecomment-626035934>.
+    // Regression test for <https://github.com/rust-lang/rust/issues/50280#issuecomment-626035934>.
     fn show(a: fn() -> f32, b: fn(&Vec<i8>) -> f32) {
         println!("the two pointers: {:p} {:p}", a, b);
     }

--- a/library/coretests/tests/iter/adapters/intersperse.rs
+++ b/library/coretests/tests/iter/adapters/intersperse.rs
@@ -160,9 +160,9 @@ fn test_non_fused_iterator_intersperse() {
         counter: usize,
     }
 
-    /// Given a counter of 0, this produces:
-    /// `None` -> `Some(2)` -> `None` -> `Some(4)` -> `None` -> `Some(6)`
-    /// -> and then `None` endlessly
+    // Given a counter of 0, this produces:
+    // `None` -> `Some(2)` -> `None` -> `Some(4)` -> `None` -> `Some(6)`
+    // -> and then `None` endlessly
     impl Iterator for TestCounter {
         type Item = usize;
         fn next(&mut self) -> Option<Self::Item> {

--- a/library/coretests/tests/ptr.rs
+++ b/library/coretests/tests/ptr.rs
@@ -775,7 +775,7 @@ fn nonnull_tagged_pointer_with_provenance() {
 
     unsafe { drop(Box::from_raw(p.pointer().as_ptr())) };
 
-    /// A non-null pointer type which carries several bits of metadata and maintains provenance.
+    // A non-null pointer type which carries several bits of metadata and maintains provenance.
     #[repr(transparent)]
     pub struct TaggedPointer<T>(NonNull<T>);
 

--- a/tests/rustdoc-ui/crate-reference-in-block-module.rs
+++ b/tests/rustdoc-ui/crate-reference-in-block-module.rs
@@ -1,4 +1,5 @@
 //@ check-pass
+#![allow(unused_doc_comments)]
 fn main() {
     /// [](crate)
     struct X;

--- a/tests/rustdoc-ui/impl-fn-nesting.rs
+++ b/tests/rustdoc-ui/impl-fn-nesting.rs
@@ -1,5 +1,6 @@
 // Ensure that rustdoc gives errors for trait impls inside function bodies that don't resolve.
 // See https://github.com/rust-lang/rust/pull/73566
+#![allow(unused_doc_comments)]
 pub struct ValidType;
 pub trait ValidTrait {}
 pub trait NeedsBody {

--- a/tests/rustdoc-ui/impl-fn-nesting.stderr
+++ b/tests/rustdoc-ui/impl-fn-nesting.stderr
@@ -1,59 +1,59 @@
 error: cannot find macro `unknown_macro` in this scope
-  --> $DIR/impl-fn-nesting.rs:32:13
+  --> $DIR/impl-fn-nesting.rs:33:13
    |
 LL |             unknown_macro!();
    |             ^^^^^^^^^^^^^
 
 error[E0405]: cannot find trait `UnknownBound` in this scope
-  --> $DIR/impl-fn-nesting.rs:11:13
+  --> $DIR/impl-fn-nesting.rs:12:13
    |
 LL | pub fn f<B: UnknownBound>(a: UnknownType, b: B) {
    |             ^^^^^^^^^^^^ not found in this scope
 
 error[E0425]: cannot find type `UnknownType` in this scope
-  --> $DIR/impl-fn-nesting.rs:11:30
+  --> $DIR/impl-fn-nesting.rs:12:30
    |
 LL | pub fn f<B: UnknownBound>(a: UnknownType, b: B) {
    |                              ^^^^^^^^^^^ not found in this scope
 
 error[E0405]: cannot find trait `UnknownTrait` in this scope
-  --> $DIR/impl-fn-nesting.rs:14:10
+  --> $DIR/impl-fn-nesting.rs:15:10
    |
 LL |     impl UnknownTrait for ValidType {}
    |          ^^^^^^^^^^^^ not found in this scope
 
 error[E0405]: cannot find trait `UnknownTrait` in this scope
-  --> $DIR/impl-fn-nesting.rs:15:27
+  --> $DIR/impl-fn-nesting.rs:16:27
    |
 LL |     impl<T: UnknownBound> UnknownTrait for T {}
    |                           ^^^^^^^^^^^^ not found in this scope
 
 error[E0405]: cannot find trait `UnknownBound` in this scope
-  --> $DIR/impl-fn-nesting.rs:15:13
+  --> $DIR/impl-fn-nesting.rs:16:13
    |
 LL |     impl<T: UnknownBound> UnknownTrait for T {}
    |             ^^^^^^^^^^^^ not found in this scope
 
 error[E0425]: cannot find type `UnknownType` in this scope
-  --> $DIR/impl-fn-nesting.rs:18:25
+  --> $DIR/impl-fn-nesting.rs:19:25
    |
 LL |     impl ValidTrait for UnknownType {}
    |                         ^^^^^^^^^^^ not found in this scope
 
 error[E0405]: cannot find trait `UnknownBound` in this scope
-  --> $DIR/impl-fn-nesting.rs:20:53
+  --> $DIR/impl-fn-nesting.rs:21:53
    |
 LL |     impl ValidTrait for ValidType where ValidTrait: UnknownBound {}
    |                                                     ^^^^^^^^^^^^ not found in this scope
 
 error[E0425]: cannot find type `UnknownType` in this scope
-  --> $DIR/impl-fn-nesting.rs:25:21
+  --> $DIR/impl-fn-nesting.rs:26:21
    |
 LL |         type Item = UnknownType;
    |                     ^^^^^^^^^^^ not found in this scope
 
 error[E0425]: cannot find type `UnknownType` in this scope
-  --> $DIR/impl-fn-nesting.rs:44:37
+  --> $DIR/impl-fn-nesting.rs:45:37
    |
 LL |             pub fn doubly_nested(c: UnknownType) {
    |                                     ^^^^^^^^^^^ not found in this scope

--- a/tests/ui/lint/unused/unused-doc-comments-edge-cases.rs
+++ b/tests/ui/lint/unused/unused-doc-comments-edge-cases.rs
@@ -1,3 +1,4 @@
+#![allow(unused)]
 #![deny(unused_doc_comments)]
 
 fn doc_comment_on_match_arms(num: u8) -> bool {
@@ -69,4 +70,31 @@ extern "C" {
     fn foo();
 }
 
-fn main() {}
+fn main() {
+    /// Check //~ ERROR: unused doc comment
+    struct Foo {
+        /// Check //~ ERROR: unused doc comment
+        f: i32,
+    }
+
+    /// Check //~ ERROR: unused doc comment
+    enum Bar {
+        /// Check //~ ERROR: unused doc comment
+        F {
+            /// Check //~ ERROR: unused doc comment
+            f: i32,
+        }
+    }
+
+    /// Check //~ ERROR: unused doc comment
+    union Baz {
+        /// Check //~ ERROR: unused doc comment
+        f: i32,
+    }
+
+    /// Check //~ ERROR: unused doc comment
+    fn fn_1() {
+        /// Check //~ ERROR: unused doc comment
+        fn fn_2() {}
+    }
+}

--- a/tests/ui/lint/unused/unused-doc-comments-edge-cases.stderr
+++ b/tests/ui/lint/unused/unused-doc-comments-edge-cases.stderr
@@ -1,11 +1,11 @@
 error: expected expression, found keyword `else`
-  --> $DIR/unused-doc-comments-edge-cases.rs:17:5
+  --> $DIR/unused-doc-comments-edge-cases.rs:18:5
    |
 LL |     else {
    |     ^^^^ expected expression
 
 error[E0658]: attributes on expressions are experimental
-  --> $DIR/unused-doc-comments-edge-cases.rs:23:5
+  --> $DIR/unused-doc-comments-edge-cases.rs:24:5
    |
 LL |     /// useless doc comment
    |     ^^^^^^^^^^^^^^^^^^^^^^^
@@ -16,7 +16,7 @@ LL |     /// useless doc comment
    = help: `///` is used for outer documentation comments; for a plain comment, use `//`
 
 error: unused doc comment
-  --> $DIR/unused-doc-comments-edge-cases.rs:6:9
+  --> $DIR/unused-doc-comments-edge-cases.rs:7:9
    |
 LL |         /// useless doc comment
    |         ^^^^^^^^^^^^^^^^^^^^^^^
@@ -26,13 +26,13 @@ LL |         _ => false,
    |
    = help: use `//` for a plain comment
 note: the lint level is defined here
-  --> $DIR/unused-doc-comments-edge-cases.rs:1:9
+  --> $DIR/unused-doc-comments-edge-cases.rs:2:9
    |
 LL | #![deny(unused_doc_comments)]
    |         ^^^^^^^^^^^^^^^^^^^
 
 error: unused doc comment
-  --> $DIR/unused-doc-comments-edge-cases.rs:23:5
+  --> $DIR/unused-doc-comments-edge-cases.rs:24:5
    |
 LL |     /// useless doc comment
    |     ^^^^^^^^^^^^^^^^^^^^^^^
@@ -43,7 +43,7 @@ LL |     num == 3
    = help: use `//` for a plain comment
 
 error: unused doc comment
-  --> $DIR/unused-doc-comments-edge-cases.rs:33:9
+  --> $DIR/unused-doc-comments-edge-cases.rs:34:9
    |
 LL |         /// useless doc comment
    |         ^^^^^^^^^^^^^^^^^^^^^^^
@@ -54,7 +54,7 @@ LL |         foo: 3
    = help: use `//` for a plain comment
 
 error: unused doc comment
-  --> $DIR/unused-doc-comments-edge-cases.rs:45:9
+  --> $DIR/unused-doc-comments-edge-cases.rs:46:9
    |
 LL |         /// useless doc comment
    |         ^^^^^^^^^^^^^^^^^^^^^^^
@@ -65,7 +65,7 @@ LL |         foo
    = help: use `//` for a plain comment
 
 error: unused doc comment
-  --> $DIR/unused-doc-comments-edge-cases.rs:55:27
+  --> $DIR/unused-doc-comments-edge-cases.rs:56:27
    |
 LL | fn doc_comment_on_generic<#[doc = "x"] T>(val: T) {}
    |                           ^^^^^^^^^^^^ - rustdoc does not generate documentation for generic parameters
@@ -73,7 +73,7 @@ LL | fn doc_comment_on_generic<#[doc = "x"] T>(val: T) {}
    = help: use `//` for a plain comment
 
 error: unused doc comment
-  --> $DIR/unused-doc-comments-edge-cases.rs:59:5
+  --> $DIR/unused-doc-comments-edge-cases.rs:60:5
    |
 LL |       /// unused doc comment
    |       ^^^^^^^^^^^^^^^^^^^^^^
@@ -86,7 +86,7 @@ LL | |     }
    = help: use `//` for a plain comment
 
 error: unused doc comment
-  --> $DIR/unused-doc-comments-edge-cases.rs:66:1
+  --> $DIR/unused-doc-comments-edge-cases.rs:67:1
    |
 LL |   /// unused doc comment
    |   ^^^^^^^^^^^^^^^^^^^^^^
@@ -98,8 +98,115 @@ LL | | }
    |
    = help: use `//` for a plain comment
 
+error: unused doc comment
+  --> $DIR/unused-doc-comments-edge-cases.rs:74:5
+   |
+LL |       /// Check
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | /     struct Foo {
+LL | |         /// Check
+LL | |         f: i32,
+LL | |     }
+   | |_____- rustdoc does not generate documentation for items defined in functions
+   |
+   = help: use `//` for a plain comment
+
+error: unused doc comment
+  --> $DIR/unused-doc-comments-edge-cases.rs:76:9
+   |
+LL |         /// Check
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         f: i32,
+   |         ------ rustdoc does not generate documentation for fields defined nested in functions
+   |
+   = help: use `//` for a plain comment
+
+error: unused doc comment
+  --> $DIR/unused-doc-comments-edge-cases.rs:80:5
+   |
+LL |       /// Check
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | /     enum Bar {
+LL | |         /// Check
+LL | |         F {
+LL | |             /// Check
+...  |
+LL | |     }
+   | |_____- rustdoc does not generate documentation for items defined in functions
+   |
+   = help: use `//` for a plain comment
+
+error: unused doc comment
+  --> $DIR/unused-doc-comments-edge-cases.rs:82:9
+   |
+LL |           /// Check
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | /         F {
+LL | |             /// Check
+LL | |             f: i32,
+LL | |         }
+   | |_________- rustdoc does not generate documentation for variants defined nested in functions
+   |
+   = help: use `//` for a plain comment
+
+error: unused doc comment
+  --> $DIR/unused-doc-comments-edge-cases.rs:84:13
+   |
+LL |             /// Check
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |             f: i32,
+   |             ------ rustdoc does not generate documentation for fields defined nested in functions
+   |
+   = help: use `//` for a plain comment
+
+error: unused doc comment
+  --> $DIR/unused-doc-comments-edge-cases.rs:89:5
+   |
+LL |       /// Check
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | /     union Baz {
+LL | |         /// Check
+LL | |         f: i32,
+LL | |     }
+   | |_____- rustdoc does not generate documentation for items defined in functions
+   |
+   = help: use `//` for a plain comment
+
+error: unused doc comment
+  --> $DIR/unused-doc-comments-edge-cases.rs:91:9
+   |
+LL |         /// Check
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         f: i32,
+   |         ------ rustdoc does not generate documentation for fields defined nested in functions
+   |
+   = help: use `//` for a plain comment
+
+error: unused doc comment
+  --> $DIR/unused-doc-comments-edge-cases.rs:95:5
+   |
+LL |       /// Check
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | /     fn fn_1() {
+LL | |         /// Check
+LL | |         fn fn_2() {}
+LL | |     }
+   | |_____- rustdoc does not generate documentation for items defined in functions
+   |
+   = help: use `//` for a plain comment
+
+error: unused doc comment
+  --> $DIR/unused-doc-comments-edge-cases.rs:97:9
+   |
+LL |         /// Check
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         fn fn_2() {}
+   |         ------------ rustdoc does not generate documentation for items defined in functions
+   |
+   = help: use `//` for a plain comment
+
 error[E0308]: mismatched types
-  --> $DIR/unused-doc-comments-edge-cases.rs:14:9
+  --> $DIR/unused-doc-comments-edge-cases.rs:15:9
    |
 LL | /     if num == 3 {
 LL | |         true
@@ -112,7 +219,7 @@ help: you might have meant to return this value
 LL |         return true;
    |         ++++++     +
 
-error: aborting due to 10 previous errors
+error: aborting due to 19 previous errors
 
 Some errors have detailed explanations: E0308, E0658.
 For more information about an error, try `rustc --explain E0308`.

--- a/tests/ui/macros/macro-literal.rs
+++ b/tests/ui/macros/macro-literal.rs
@@ -1,4 +1,5 @@
 //@ run-pass
+#![allow(unused_doc_comments)]
 
 macro_rules! mtester {
     ($l:literal) => {

--- a/tests/ui/macros/macro-nested_expr.rs
+++ b/tests/ui/macros/macro-nested_expr.rs
@@ -3,6 +3,7 @@
 
 #![feature(decl_macro)]
 #![allow(dead_code)]
+#![allow(unused_doc_comments)]
 
 pub macro m($inner_str:expr) {
     #[doc = $inner_str]


### PR DESCRIPTION
When a doc comment is nested within an item:

    fn foo() {
        /// doc comment
        fn bar() {}
    }

When that happens, emit a warning, because they aren't rendered, even with `--document-private-items`

    warning: unused doc comment
     --> src/lib.rs:3:3
      |
    3 |     /// doc comment
      |     ^^^^^^^^^^^^^^^
    4 |     fn bar() {}
      |     ----------- rustdoc does not generate documentation for items defined in functions
      |
      = help: use `//` for a plain comment
      = note: `#[warn(unused_doc_comments)]` (part of `#[warn(unused)]`) on by default

Fixes https://github.com/rust-lang/rust/issues/158513