### PR TITLE
Make let-else respect macro_rules expr metavariable grouping

### DIFF
--- a/compiler/rustc_parse/src/parser/stmt.rs
+++ b/compiler/rustc_parse/src/parser/stmt.rs
@@ -5,6 +5,7 @@ use std::ops::Bound;
 use ast::Label;
 use rustc_ast as ast;
 use rustc_ast::token::{self, Delimiter, InvisibleOrigin, MetaVarKind, TokenKind};
+use rustc_ast::tokenstream::TokenTree;
 use rustc_ast::util::classify::{self, TrailingBrace};
 use rustc_ast::visit::{Visitor, walk_expr};
 use rustc_ast::{
@@ -353,6 +354,14 @@ impl<'a> Parser<'a> {
         } else {
             (None, None, None)
         };
+
+        let init_wrapped = self
+            .tree_look_ahead(2, |tree| match tree {
+                TokenTree::Token(tok, _) => tok.is_keyword(kw::Else),
+                TokenTree::Delimited(..) => false,
+            })
+            .unwrap_or(false);
+
         let init = match (self.parse_initializer(err.is_some()), err) {
             (Ok(init), None) => {
                 // init parsed, ty parsed
@@ -390,6 +399,7 @@ impl<'a> Parser<'a> {
                 return Err(err);
             }
         };
+        let trailing_token = self.prev_token;
         let kind = match init {
             None => LocalKind::Decl,
             Some(init) => {
@@ -401,8 +411,14 @@ impl<'a> Parser<'a> {
                         return Err(self.error_block_no_opening_brace_msg(Cow::from(msg)));
                     }
                     let els = self.parse_block()?;
-                    self.check_let_else_init_bool_expr(&init);
-                    self.check_let_else_init_trailing_brace(&init);
+                    // These checks should also respect invisible delimiter
+                    if !init_wrapped {
+                        self.check_let_else_init_bool_expr(&init);
+                    }
+                    if matches!(trailing_token.kind, TokenKind::CloseBrace) {
+                        self.check_let_else_init_trailing_brace(&init);
+                    }
+
                     LocalKind::InitElse(init, els)
                 } else {
                     LocalKind::Init(init)

--- a/tests/ui/let-else/detect-invisible-delimiter.rs
+++ b/tests/ui/let-else/detect-invisible-delimiter.rs
@@ -1,0 +1,16 @@
+// The user shouldn't need to wrap the expression in parentheses(#147899)
+//@check-pass
+#![allow(irrefutable_let_patterns)]
+struct Thing {}
+macro_rules! foo {
+    ($e:expr) => {
+        let _ = $e else {
+            return;
+        };
+    };
+}
+
+fn main() {
+    foo!(true && true);
+    foo!(Thing {});
+}


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
Fixes rust-lang/rust#147899 