### PR TITLE
 Deduplicate codegen backends in bootstrap config

### DIFF
--- a/src/bootstrap/src/core/config/tests.rs
+++ b/src/bootstrap/src/core/config/tests.rs
@@ -11,8 +11,9 @@ use serde::Deserialize;
 
 use super::flags::Flags;
 use super::toml::change_id::ChangeIdWrapper;
+use super::toml::rust::parse_codegen_backends;
 use super::{Config, RUSTC_IF_UNCHANGED_ALLOWED_PATHS};
-use crate::ChangeId;
+use crate::{ChangeId, CodegenBackendKind};
 use crate::core::build_steps::clippy::{LintConfig, get_clippy_rules_in_order};
 use crate::core::build_steps::llvm::LLVM_INVALIDATION_PATHS;
 use crate::core::build_steps::{llvm, test};
@@ -204,6 +205,25 @@ fn rust_optimize() {
     assert!(parse("rust.optimize = \"s\"").rust_optimize.is_release());
     assert_eq!(parse("rust.optimize = 1").rust_optimize.get_opt_level(), Some("1".to_string()));
     assert_eq!(parse("rust.optimize = \"s\"").rust_optimize.get_opt_level(), Some("s".to_string()));
+}
+
+#[test]
+fn deduplicates_codegen_backends() {
+    assert_eq!(
+        parse_codegen_backends(
+            vec!["llvm", "llvm", "cranelift", "llvm"].into_iter().map(str::to_owned).collect(),
+            "rust",
+        ),
+        [CodegenBackendKind::Llvm, CodegenBackendKind::Cranelift]
+    );
+
+    assert_eq!(
+        parse_codegen_backends(
+            vec!["cranelift", "llvm", "cranelift"].into_iter().map(str::to_owned).collect(),
+            "target.x86_64-unknown-linux-gnu",
+        ),
+        [CodegenBackendKind::Cranelift, CodegenBackendKind::Llvm]
+    );
 }
 
 #[test]

--- a/src/bootstrap/src/core/config/tests.rs
+++ b/src/bootstrap/src/core/config/tests.rs
@@ -13,6 +13,7 @@ use super::flags::Flags;
 use super::toml::change_id::ChangeIdWrapper;
 use super::toml::rust::parse_codegen_backends;
 use super::{Config, RUSTC_IF_UNCHANGED_ALLOWED_PATHS};
+use crate::ChangeId;
 use crate::core::build_steps::clippy::{LintConfig, get_clippy_rules_in_order};
 use crate::core::build_steps::llvm::LLVM_INVALIDATION_PATHS;
 use crate::core::build_steps::{llvm, test};
@@ -22,7 +23,6 @@ use crate::core::config::{
 };
 use crate::utils::tests::TestCtx;
 use crate::utils::tests::git::git_test;
-use crate::ChangeId;
 
 pub(crate) fn parse(config: &str) -> Config {
     TestCtx::new().config("check").with_default_toml_config(config).create_config()

--- a/src/bootstrap/src/core/config/tests.rs
+++ b/src/bootstrap/src/core/config/tests.rs
@@ -22,7 +22,7 @@ use crate::core::config::{
 };
 use crate::utils::tests::TestCtx;
 use crate::utils::tests::git::git_test;
-use crate::{ChangeId, CodegenBackendKind};
+use crate::ChangeId;
 
 pub(crate) fn parse(config: &str) -> Config {
     TestCtx::new().config("check").with_default_toml_config(config).create_config()
@@ -208,21 +208,11 @@ fn rust_optimize() {
 }
 
 #[test]
-fn deduplicates_codegen_backends() {
-    assert_eq!(
-        parse_codegen_backends(
-            vec!["llvm", "llvm", "cranelift", "llvm"].into_iter().map(str::to_owned).collect(),
-            "rust",
-        ),
-        [CodegenBackendKind::Llvm, CodegenBackendKind::Cranelift]
-    );
-
-    assert_eq!(
-        parse_codegen_backends(
-            vec!["cranelift", "llvm", "cranelift"].into_iter().map(str::to_owned).collect(),
-            "target.x86_64-unknown-linux-gnu",
-        ),
-        [CodegenBackendKind::Cranelift, CodegenBackendKind::Llvm]
+#[should_panic(expected = "Duplicate value 'llvm' for 'rust.codegen-backends'")]
+fn rejects_duplicate_codegen_backends() {
+    parse_codegen_backends(
+        vec!["llvm", "llvm", "cranelift"].into_iter().map(str::to_owned).collect(),
+        "rust",
     );
 }
 

--- a/src/bootstrap/src/core/config/tests.rs
+++ b/src/bootstrap/src/core/config/tests.rs
@@ -13,7 +13,6 @@ use super::flags::Flags;
 use super::toml::change_id::ChangeIdWrapper;
 use super::toml::rust::parse_codegen_backends;
 use super::{Config, RUSTC_IF_UNCHANGED_ALLOWED_PATHS};
-use crate::{ChangeId, CodegenBackendKind};
 use crate::core::build_steps::clippy::{LintConfig, get_clippy_rules_in_order};
 use crate::core::build_steps::llvm::LLVM_INVALIDATION_PATHS;
 use crate::core::build_steps::{llvm, test};
@@ -23,6 +22,7 @@ use crate::core::config::{
 };
 use crate::utils::tests::TestCtx;
 use crate::utils::tests::git::git_test;
+use crate::{ChangeId, CodegenBackendKind};
 
 pub(crate) fn parse(config: &str) -> Config {
     TestCtx::new().config("check").with_default_toml_config(config).create_config()

--- a/src/bootstrap/src/core/config/toml/rust.rs
+++ b/src/bootstrap/src/core/config/toml/rust.rs
@@ -422,23 +422,29 @@ pub(crate) fn parse_codegen_backends(
                 Please, use '{stripped}' instead."
             )
         }
-        if !BUILTIN_CODEGEN_BACKENDS.contains(&backend.as_str()) {
-            if CiEnv::is_rust_lang_managed_ci_job() {
-                eprintln!("Unknown codegen backend {backend}");
-                exit!(1);
-            }
-
-            println!(
-                "HELP: '{backend}' for '{section}.codegen-backends' might fail. \
-                List of known codegen backends: {BUILTIN_CODEGEN_BACKENDS:?}"
-            );
-        }
         let backend = match backend.as_str() {
             "llvm" => CodegenBackendKind::Llvm,
             "cranelift" => CodegenBackendKind::Cranelift,
             "gcc" => CodegenBackendKind::Gcc,
             backend => CodegenBackendKind::Custom(backend.to_string()),
         };
+
+        if found_backends.contains(&backend) {
+            continue;
+        }
+
+        if !BUILTIN_CODEGEN_BACKENDS.contains(&backend.name()) {
+            if CiEnv::is_rust_lang_managed_ci_job() {
+                eprintln!("Unknown codegen backend {}", backend.name());
+                exit!(1);
+            }
+
+            println!(
+                "HELP: '{}' for '{section}.codegen-backends' might fail. \
+                List of known codegen backends: {BUILTIN_CODEGEN_BACKENDS:?}",
+                backend.name()
+            );
+        }
         found_backends.push(backend);
     }
     if found_backends.is_empty() {

--- a/src/bootstrap/src/core/config/toml/rust.rs
+++ b/src/bootstrap/src/core/config/toml/rust.rs
@@ -430,7 +430,11 @@ pub(crate) fn parse_codegen_backends(
         };
 
         if found_backends.contains(&backend) {
-            continue;
+            panic!(
+                "Duplicate value '{}' for '{section}.codegen-backends'. \
+                Each codegen backend should only be specified once.",
+                backend.name()
+            );
         }
 
         if !BUILTIN_CODEGEN_BACKENDS.contains(&backend.name()) {


### PR DESCRIPTION
Deduplicate `rust.codegen-backends` and `target.<triple>.codegen-backends` during bootstrap config parsing while preserving first occurrence order.

This avoids carrying redundant backend entries into later bootstrap planning.

test:
```powershell
$env:CARGO_NET_OFFLINE='false'; $env:CARGO_TARGET_DIR='target-codex-test'; $cargo = Join-Path $env:USERPROFILE '.cargo\bin\cargo.exe'; & $cargo test --manifest-path src/bootstrap/Cargo.toml deduplicates_codegen_backends
```

result:
```text
running 1 test
test core::config::tests::deduplicates_codegen_backends ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 255 filtered out; finished in 0.00s
```