### PR TITLE
Initial implementation of named `Fn` trait parameters

### DIFF
--- a/compiler/rustc_ast_passes/src/feature_gate.rs
+++ b/compiler/rustc_ast_passes/src/feature_gate.rs
@@ -512,6 +512,10 @@ pub fn check_crate(krate: &ast::Crate, sess: &Session, features: &Features) {
         half_open_range_patterns_in_slices,
         "half-open range patterns in slices are unstable"
     );
+    gate_all!(
+        named_fn_trait_parameters,
+        "named parameters in parenthesized generic argument lists are experimental"
+    );
 
     // `associated_const_equality` will be stabilized as part of `min_generic_const_args`.
     for &span in spans.get(&sym::associated_const_equality).into_flat_iter() {

--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -669,7 +669,7 @@ declare_features! (
     /// Allows using `#[target_feature(enable = "...")]` on `#[naked]` on functions.
     (unstable, naked_functions_target_feature, "1.86.0", Some(138568)),
     /// Allows providing names to parameters of `impl Fn` etc
-    (unstable, named_fn_trait_parameters, "CURRENT_RUSTC_VERSION", Some(158499)),
+    (incomplete, named_fn_trait_parameters, "CURRENT_RUSTC_VERSION", Some(158499)),
     /// Allows specifying the as-needed link modifier
     (unstable, native_link_modifiers_as_needed, "1.53.0", Some(81490)),
     /// Allow negative trait implementations.

--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -668,6 +668,8 @@ declare_features! (
     (unstable, naked_functions_rustic_abi, "1.88.0", Some(138997)),
     /// Allows using `#[target_feature(enable = "...")]` on `#[naked]` on functions.
     (unstable, naked_functions_target_feature, "1.86.0", Some(138568)),
+    /// Allows providing names to parameters of `impl Fn` etc
+    (unstable, named_fn_trait_parameters, "CURRENT_RUSTC_VERSION", Some(158499)),
     /// Allows specifying the as-needed link modifier
     (unstable, native_link_modifiers_as_needed, "1.53.0", Some(81490)),
     /// Allow negative trait implementations.

--- a/compiler/rustc_parse/src/diagnostics.rs
+++ b/compiler/rustc_parse/src/diagnostics.rs
@@ -2076,14 +2076,6 @@ pub(crate) struct ExpectedFnPathFoundFnKeyword {
 }
 
 #[derive(Diagnostic)]
-#[diag("`Trait(...)` syntax does not support named parameters")]
-pub(crate) struct FnPathFoundNamedParams {
-    #[primary_span]
-    #[suggestion("remove the parameter name", applicability = "machine-applicable", code = "")]
-    pub named_param_span: Span,
-}
-
-#[derive(Diagnostic)]
 #[diag("`Trait(...)` syntax does not support c_variadic parameters")]
 pub(crate) struct PathFoundCVariadicParams {
     #[primary_span]

--- a/compiler/rustc_parse/src/parser/path.rs
+++ b/compiler/rustc_parse/src/parser/path.rs
@@ -17,8 +17,8 @@ use super::{Parser, Restrictions, TokenType};
 use crate::ast::{PatKind, TyKind};
 use crate::diagnostics::{
     self, AttributeOnEmptyType, AttributeOnGenericArg, ConstGenericWithoutBraces,
-    ConstGenericWithoutBracesSugg, FnPathFoundNamedParams, PathFoundAttributeInParams,
-    PathFoundCVariadicParams, PathSingleColon, PathTripleColon,
+    ConstGenericWithoutBracesSugg, PathFoundAttributeInParams, PathFoundCVariadicParams,
+    PathSingleColon, PathTripleColon,
 };
 use crate::exp;
 use crate::parser::{
@@ -408,11 +408,11 @@ impl<'a> Parser<'a> {
                             req_body: false,
                         };
                         let param = p.parse_param_general(&mode, false, false);
-                        param.map(move |param| {
+                        param.map(|param| {
                             if !matches!(param.pat.kind, PatKind::Missing) {
-                                dcx.emit_err(FnPathFoundNamedParams {
-                                    named_param_span: param.pat.span,
-                                });
+                                self.psess
+                                    .gated_spans
+                                    .gate(sym::named_fn_trait_parameters, param.pat.span);
                             }
                             if matches!(param.ty.kind, TyKind::CVarArgs) {
                                 dcx.emit_err(PathFoundCVariadicParams { span: param.pat.span });

--- a/compiler/rustc_session/src/parse.rs
+++ b/compiler/rustc_session/src/parse.rs
@@ -22,7 +22,7 @@ use crate::Session;
 use crate::lint::{Lint, LintId};
 
 /// Collected spans during parsing for places where a certain feature was
-/// used and should be feature gated accordingly in `check_crate`.
+/// used and should be feature gated accordingly in `check_crate` in `rustc_ast_passes`.
 #[derive(Default)]
 pub struct GatedSpans {
     pub spans: Lock<FxHashMap<Symbol, Vec<Span>>>,

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1384,6 +1384,7 @@ symbols! {
         naked_functions_rustic_abi,
         naked_functions_target_feature,
         name,
+        named_fn_trait_parameters,
         names,
         native_link_modifiers,
         native_link_modifiers_as_needed,

--- a/tests/ui/feature-gates/feature-gate-named-fn-trait-parameters.rs
+++ b/tests/ui/feature-gates/feature-gate-named-fn-trait-parameters.rs
@@ -1,7 +1,7 @@
 fn parse_my_data(
     data: &str,
     log: impl Fn(msg: String),
-    //~^ ERROR `Trait(...)` syntax does not support named parameters
+    //~^ ERROR named parameters in parenthesized generic argument lists are experimental [E0658]
 ) { }
 
 fn main() {}

--- a/tests/ui/feature-gates/feature-gate-named-fn-trait-parameters.rs
+++ b/tests/ui/feature-gates/feature-gate-named-fn-trait-parameters.rs
@@ -1,0 +1,7 @@
+fn parse_my_data(
+    data: &str,
+    log: impl Fn(msg: String),
+    //~^ ERROR `Trait(...)` syntax does not support named parameters
+) { }
+
+fn main() {}

--- a/tests/ui/feature-gates/feature-gate-named-fn-trait-parameters.stderr
+++ b/tests/ui/feature-gates/feature-gate-named-fn-trait-parameters.stderr
@@ -1,0 +1,8 @@
+error: `Trait(...)` syntax does not support named parameters
+  --> $DIR/feature-gate-named-fn-trait-parameters.rs:3:18
+   |
+LL |     log: impl Fn(msg: String),
+   |                  ^^^ help: remove the parameter name
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/feature-gates/feature-gate-named-fn-trait-parameters.stderr
+++ b/tests/ui/feature-gates/feature-gate-named-fn-trait-parameters.stderr
@@ -1,8 +1,13 @@
-error: `Trait(...)` syntax does not support named parameters
+error[E0658]: named parameters in parenthesized generic argument lists are experimental
   --> $DIR/feature-gate-named-fn-trait-parameters.rs:3:18
    |
 LL |     log: impl Fn(msg: String),
-   |                  ^^^ help: remove the parameter name
+   |                  ^^^
+   |
+   = note: see issue #158499 <https://github.com/rust-lang/rust/issues/158499> for more information
+   = help: add `#![feature(named_fn_trait_parameters)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/fn/fn-trait-use-named-params-issue-140169.rs
+++ b/tests/ui/fn/fn-trait-use-named-params-issue-140169.rs
@@ -1,9 +1,9 @@
 fn f1(_: fn(a: u8)) {}
-fn f2(_: impl Fn(u8, vvvv: u8)) {} //~ ERROR `Trait(...)` syntax does not support named parameters
-fn f3(_: impl Fn(aaaa: u8, u8)) {} //~ ERROR `Trait(...)` syntax does not support named parameters
+fn f2(_: impl Fn(u8, vvvv: u8)) {} //~ ERROR named parameters in parenthesized generic argument lists are experimental
+fn f3(_: impl Fn(aaaa: u8, u8)) {} //~ ERROR named parameters in parenthesized generic argument lists are experimental
 fn f4(_: impl Fn(aaaa: u8, vvvv: u8)) {}
-//~^ ERROR `Trait(...)` syntax does not support named parameters
-//~| ERROR `Trait(...)` syntax does not support named parameters
+//~^ ERROR named parameters in parenthesized generic argument lists are experimental
+//~| ERROR named parameters in parenthesized generic argument lists are experimental
 fn f5(_: impl Fn(u8, ...)) {}
 //~^ ERROR `Trait(...)` syntax does not support c_variadic parameters
 fn f6(_: impl Fn(u8, #[allow(unused_attributes)] u8)) {}

--- a/tests/ui/fn/fn-trait-use-named-params-issue-140169.stderr
+++ b/tests/ui/fn/fn-trait-use-named-params-issue-140169.stderr
@@ -1,27 +1,3 @@
-error: `Trait(...)` syntax does not support named parameters
-  --> $DIR/fn-trait-use-named-params-issue-140169.rs:2:22
-   |
-LL | fn f2(_: impl Fn(u8, vvvv: u8)) {}
-   |                      ^^^^ help: remove the parameter name
-
-error: `Trait(...)` syntax does not support named parameters
-  --> $DIR/fn-trait-use-named-params-issue-140169.rs:3:18
-   |
-LL | fn f3(_: impl Fn(aaaa: u8, u8)) {}
-   |                  ^^^^ help: remove the parameter name
-
-error: `Trait(...)` syntax does not support named parameters
-  --> $DIR/fn-trait-use-named-params-issue-140169.rs:4:18
-   |
-LL | fn f4(_: impl Fn(aaaa: u8, vvvv: u8)) {}
-   |                  ^^^^ help: remove the parameter name
-
-error: `Trait(...)` syntax does not support named parameters
-  --> $DIR/fn-trait-use-named-params-issue-140169.rs:4:28
-   |
-LL | fn f4(_: impl Fn(aaaa: u8, vvvv: u8)) {}
-   |                            ^^^^ help: remove the parameter name
-
 error: `Trait(...)` syntax does not support c_variadic parameters
   --> $DIR/fn-trait-use-named-params-issue-140169.rs:7:22
    |
@@ -34,5 +10,46 @@ error: `Trait(...)` syntax does not support attributes in parameters
 LL | fn f6(_: impl Fn(u8, #[allow(unused_attributes)] u8)) {}
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove the attributes
 
+error[E0658]: named parameters in parenthesized generic argument lists are experimental
+  --> $DIR/fn-trait-use-named-params-issue-140169.rs:2:22
+   |
+LL | fn f2(_: impl Fn(u8, vvvv: u8)) {}
+   |                      ^^^^
+   |
+   = note: see issue #158499 <https://github.com/rust-lang/rust/issues/158499> for more information
+   = help: add `#![feature(named_fn_trait_parameters)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: named parameters in parenthesized generic argument lists are experimental
+  --> $DIR/fn-trait-use-named-params-issue-140169.rs:3:18
+   |
+LL | fn f3(_: impl Fn(aaaa: u8, u8)) {}
+   |                  ^^^^
+   |
+   = note: see issue #158499 <https://github.com/rust-lang/rust/issues/158499> for more information
+   = help: add `#![feature(named_fn_trait_parameters)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: named parameters in parenthesized generic argument lists are experimental
+  --> $DIR/fn-trait-use-named-params-issue-140169.rs:4:18
+   |
+LL | fn f4(_: impl Fn(aaaa: u8, vvvv: u8)) {}
+   |                  ^^^^
+   |
+   = note: see issue #158499 <https://github.com/rust-lang/rust/issues/158499> for more information
+   = help: add `#![feature(named_fn_trait_parameters)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: named parameters in parenthesized generic argument lists are experimental
+  --> $DIR/fn-trait-use-named-params-issue-140169.rs:4:28
+   |
+LL | fn f4(_: impl Fn(aaaa: u8, vvvv: u8)) {}
+   |                            ^^^^
+   |
+   = note: see issue #158499 <https://github.com/rust-lang/rust/issues/158499> for more information
+   = help: add `#![feature(named_fn_trait_parameters)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
 error: aborting due to 6 previous errors
 
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/fn/named-fn-trait-parameters.rs
+++ b/tests/ui/fn/named-fn-trait-parameters.rs
@@ -1,0 +1,80 @@
+#![feature(named_fn_trait_parameters)]
+
+fn allowed<F>(
+    data: &str,
+    f1: impl Fn(msg: String),
+    f2: impl Fn(_: String),
+    f3: impl Fn(String, msg: String),
+    f4: impl Fn(msg: String, String),
+    f5: impl Fn(duplicate_name: bool, duplicate_name: bool),
+    fg: F
+) where F: Fn(msg: String)
+{ }
+
+
+// Patterns are semantically rejected
+fn semantics<F>(
+    pat1: impl Fn(1..3: bool),
+    //~^ ERROR expected type, found `1`
+    pat2: impl Fn((x, y): (bool, bool)),
+    //~^ ERROR unexpected token: `:`
+    pat3: impl Fn(Thing { a, b }: Thing),
+    //~^ ERROR expected one of `!`, `(`, `+`, `::`, or `<`, found `{`
+    pat4: impl Fn(NoThing { a, b }: NoThing),
+    //~^ ERROR expected one of `!`, `(`, `+`, `::`, or `<`, found `{`
+    pat5: impl Fn((((((x))))): bool),
+    //~^ ERROR unexpected token: `:`
+
+    self1: impl Fn(self),
+    //~^ ERROR unexpected `self` parameter in function
+    self2: impl Fn(self, self),
+    //~^ ERROR unexpected `self` parameter in function
+    //~| ERROR unexpected `self` parameter in function
+    self3: impl Fn(bool, self),
+    //~^ ERROR unexpected `self` parameter in function
+
+    // FIXME should be rejected
+    restricted_pat1: impl Fn(mut x: ()),
+    restricted_pat2: impl Fn(&x: ()),
+    restricted_pat3: impl Fn(&&x: ()),
+    restricted_pat4: impl Fn(false: ()),
+    restricted_pat5: impl Fn(&_: ()),
+    restricted_pat6: impl Fn(&true: ()),
+) { }
+
+// Patterns are also syntactically rejected, but restricted patterns are not
+#[cfg(false)]
+fn syntax<F>(
+    pat1: impl Fn(1..3: bool),
+    //~^ ERROR expected type, found `1`
+    pat2: impl Fn((x, y): (bool, bool)),
+    //~^ ERROR unexpected token: `:`
+    pat3: impl Fn(Thing { a, b }: Thing),
+    //~^ ERROR expected one of `!`, `(`, `+`, `::`, or `<`, found `{`
+    pat4: impl Fn(NoThing { a, b }: NoThing),
+    //~^ ERROR expected one of `!`, `(`, `+`, `::`, or `<`, found `{`
+    pat5: impl Fn((((((x))))): bool),
+    //~^ ERROR unexpected token: `:`
+
+    self1: impl Fn(self), // FIXME should be accepted
+    //~^ ERROR unexpected `self` parameter in function
+    self2: impl Fn(self, self),
+    //~^ ERROR unexpected `self` parameter in function
+    //~| ERROR unexpected `self` parameter in function
+    self3: impl Fn(bool, self),
+    //~^ ERROR unexpected `self` parameter in function
+
+    // These are correctly accepted, as to match the behaviour `fn` ptrs
+    restricted_pat1: impl Fn(mut x: ()),
+    restricted_pat2: impl Fn(&x: ()),
+    restricted_pat3: impl Fn(&&x: ()),
+    restricted_pat4: impl Fn(false: ()),
+    restricted_pat5: impl Fn(&_: ()),
+    restricted_pat6: impl Fn(&true: ()),
+) { }
+
+struct Thing { a: bool, b: bool }
+
+fn main() {
+
+}

--- a/tests/ui/fn/named-fn-trait-parameters.stderr
+++ b/tests/ui/fn/named-fn-trait-parameters.stderr
@@ -1,0 +1,110 @@
+error: expected type, found `1`
+  --> $DIR/named-fn-trait-parameters.rs:17:19
+   |
+LL |     pat1: impl Fn(1..3: bool),
+   |                   ^ expected type
+
+error: unexpected token: `:`
+  --> $DIR/named-fn-trait-parameters.rs:19:25
+   |
+LL |     pat2: impl Fn((x, y): (bool, bool)),
+   |                         ^ unexpected token after this
+
+error: expected one of `!`, `(`, `+`, `::`, or `<`, found `{`
+  --> $DIR/named-fn-trait-parameters.rs:21:25
+   |
+LL |     pat3: impl Fn(Thing { a, b }: Thing),
+   |                         ^ expected one of `!`, `(`, `+`, `::`, or `<`
+
+error: expected one of `!`, `(`, `+`, `::`, or `<`, found `{`
+  --> $DIR/named-fn-trait-parameters.rs:23:27
+   |
+LL |     pat4: impl Fn(NoThing { a, b }: NoThing),
+   |                           ^ expected one of `!`, `(`, `+`, `::`, or `<`
+
+error: unexpected token: `:`
+  --> $DIR/named-fn-trait-parameters.rs:25:30
+   |
+LL |     pat5: impl Fn((((((x))))): bool),
+   |                              ^ unexpected token after this
+
+error: unexpected `self` parameter in function
+  --> $DIR/named-fn-trait-parameters.rs:28:20
+   |
+LL |     self1: impl Fn(self),
+   |                    ^^^^ must be the first parameter of an associated function
+
+error: unexpected `self` parameter in function
+  --> $DIR/named-fn-trait-parameters.rs:30:20
+   |
+LL |     self2: impl Fn(self, self),
+   |                    ^^^^ must be the first parameter of an associated function
+
+error: unexpected `self` parameter in function
+  --> $DIR/named-fn-trait-parameters.rs:30:26
+   |
+LL |     self2: impl Fn(self, self),
+   |                          ^^^^ must be the first parameter of an associated function
+
+error: unexpected `self` parameter in function
+  --> $DIR/named-fn-trait-parameters.rs:33:26
+   |
+LL |     self3: impl Fn(bool, self),
+   |                          ^^^^ must be the first parameter of an associated function
+
+error: expected type, found `1`
+  --> $DIR/named-fn-trait-parameters.rs:48:19
+   |
+LL |     pat1: impl Fn(1..3: bool),
+   |                   ^ expected type
+
+error: unexpected token: `:`
+  --> $DIR/named-fn-trait-parameters.rs:50:25
+   |
+LL |     pat2: impl Fn((x, y): (bool, bool)),
+   |                         ^ unexpected token after this
+
+error: expected one of `!`, `(`, `+`, `::`, or `<`, found `{`
+  --> $DIR/named-fn-trait-parameters.rs:52:25
+   |
+LL |     pat3: impl Fn(Thing { a, b }: Thing),
+   |                         ^ expected one of `!`, `(`, `+`, `::`, or `<`
+
+error: expected one of `!`, `(`, `+`, `::`, or `<`, found `{`
+  --> $DIR/named-fn-trait-parameters.rs:54:27
+   |
+LL |     pat4: impl Fn(NoThing { a, b }: NoThing),
+   |                           ^ expected one of `!`, `(`, `+`, `::`, or `<`
+
+error: unexpected token: `:`
+  --> $DIR/named-fn-trait-parameters.rs:56:30
+   |
+LL |     pat5: impl Fn((((((x))))): bool),
+   |                              ^ unexpected token after this
+
+error: unexpected `self` parameter in function
+  --> $DIR/named-fn-trait-parameters.rs:59:20
+   |
+LL |     self1: impl Fn(self), // FIXME should be accepted
+   |                    ^^^^ must be the first parameter of an associated function
+
+error: unexpected `self` parameter in function
+  --> $DIR/named-fn-trait-parameters.rs:61:20
+   |
+LL |     self2: impl Fn(self, self),
+   |                    ^^^^ must be the first parameter of an associated function
+
+error: unexpected `self` parameter in function
+  --> $DIR/named-fn-trait-parameters.rs:61:26
+   |
+LL |     self2: impl Fn(self, self),
+   |                          ^^^^ must be the first parameter of an associated function
+
+error: unexpected `self` parameter in function
+  --> $DIR/named-fn-trait-parameters.rs:64:26
+   |
+LL |     self3: impl Fn(bool, self),
+   |                          ^^^^ must be the first parameter of an associated function
+
+error: aborting due to 18 previous errors
+

--- a/tests/ui/parser/diagnostics-parenthesized-type-arguments-ice-issue-122345.rs
+++ b/tests/ui/parser/diagnostics-parenthesized-type-arguments-ice-issue-122345.rs
@@ -2,7 +2,7 @@
 
 fn main() {
     unsafe {
-        dealloc(ptr2, Layout::(x: !)(1, 1)); //~ ERROR `Trait(...)` syntax does not support named parameters
+        dealloc(ptr2, Layout::(x: !)(1, 1)); //~ ERROR named parameters in parenthesized generic argument lists are experimental
         //~^ ERROR cannot find function `dealloc` in this scope [E0425]
         //~| ERROR cannot find value `ptr2` in this scope [E0425]
         //~| ERROR the `!` type is experimental [E0658]

--- a/tests/ui/parser/diagnostics-parenthesized-type-arguments-ice-issue-122345.stderr
+++ b/tests/ui/parser/diagnostics-parenthesized-type-arguments-ice-issue-122345.stderr
@@ -1,9 +1,3 @@
-error: `Trait(...)` syntax does not support named parameters
-  --> $DIR/diagnostics-parenthesized-type-arguments-ice-issue-122345.rs:5:32
-   |
-LL |         dealloc(ptr2, Layout::(x: !)(1, 1));
-   |                                ^ help: remove the parameter name
-
 error[E0425]: cannot find function `dealloc` in this scope
   --> $DIR/diagnostics-parenthesized-type-arguments-ice-issue-122345.rs:5:9
    |
@@ -20,6 +14,16 @@ error[E0425]: cannot find value `ptr2` in this scope
    |
 LL |         dealloc(ptr2, Layout::(x: !)(1, 1));
    |                 ^^^^ not found in this scope
+
+error[E0658]: named parameters in parenthesized generic argument lists are experimental
+  --> $DIR/diagnostics-parenthesized-type-arguments-ice-issue-122345.rs:5:32
+   |
+LL |         dealloc(ptr2, Layout::(x: !)(1, 1));
+   |                                ^
+   |
+   = note: see issue #158499 <https://github.com/rust-lang/rust/issues/158499> for more information
+   = help: add `#![feature(named_fn_trait_parameters)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the `!` type is experimental
   --> $DIR/diagnostics-parenthesized-type-arguments-ice-issue-122345.rs:5:35


### PR DESCRIPTION
This is an initial implementation of the feature `named_fn_trait_parameters`.
This implementation is incomplete (and also marked as such) , and needs significant further changes to be implemented correctly. To keep the size of this PR managable, I propose we do this in follow-up PRs.
I've added a test that shows the current behaviour, with `FIXME` comments where the test output is currently incorrect.

Tracking issue: https://github.com/rust-lang/rust/issues/158499
Accepted RFC: https://github.com/rust-lang/rfcs/pull/3955