### PR TITLE
Fix mixed use of "a" / "an" article in E0277

### DIFF
--- a/library/core/src/ops/function.rs
+++ b/library/core/src/ops/function.rs
@@ -67,7 +67,7 @@ use crate::marker::Tuple;
         // SAFETY: tidy is not smart enough to tell that the below unsafe block is a string
         label = "call the function in a closure: `|| unsafe {{ /* code */ }}`"
     ),
-    message = "expected a `{This:resolved}` closure, found `{Self}`",
+    message = "expected an `{This:resolved}` closure, found `{Self}`",
     label = "expected an `{This:resolved}` closure, found `{Self}`"
 )]
 #[fundamental] // so that regex can rely that `&str: !FnMut`
@@ -154,7 +154,7 @@ pub const trait Fn<Args: Tuple>: [const] FnMut<Args> {
         // SAFETY: tidy is not smart enough to tell that the below unsafe block is a string
         label = "call the function in a closure: `|| unsafe {{ /* code */ }}`"
     ),
-    message = "expected a `{This:resolved}` closure, found `{Self}`",
+    message = "expected an `{This:resolved}` closure, found `{Self}`",
     label = "expected an `{This:resolved}` closure, found `{Self}`"
 )]
 #[fundamental] // so that regex can rely that `&str: !FnMut`
@@ -233,7 +233,7 @@ pub const trait FnMut<Args: Tuple>: FnOnce<Args> {
         // SAFETY: tidy is not smart enough to tell that the below unsafe block is a string
         label = "call the function in a closure: `|| unsafe {{ /* code */ }}`"
     ),
-    message = "expected a `{This:resolved}` closure, found `{Self}`",
+    message = "expected an `{This:resolved}` closure, found `{Self}`",
     label = "expected an `{This:resolved}` closure, found `{Self}`"
 )]
 #[fundamental] // so that regex can rely that `&str: !FnMut`

--- a/tests/ui/abi/bad-custom.rs
+++ b/tests/ui/abi/bad-custom.rs
@@ -100,7 +100,7 @@ async unsafe extern "custom" fn no_async_fn() {
 }
 
 fn no_promotion_to_fn_trait(f: unsafe extern "custom" fn()) -> impl Fn()  {
-    //~^ ERROR expected a `Fn()` closure, found `unsafe extern "custom" fn()`
+    //~^ ERROR expected an `Fn()` closure, found `unsafe extern "custom" fn()`
     f
 }
 

--- a/tests/ui/abi/bad-custom.stderr
+++ b/tests/ui/abi/bad-custom.stderr
@@ -184,7 +184,7 @@ LL + #[unsafe(naked)]
 LL | async unsafe extern "custom" fn no_async_fn() {
    |
 
-error[E0277]: expected a `Fn()` closure, found `unsafe extern "custom" fn()`
+error[E0277]: expected an `Fn()` closure, found `unsafe extern "custom" fn()`
   --> $DIR/bad-custom.rs:102:64
    |
 LL | fn no_promotion_to_fn_trait(f: unsafe extern "custom" fn()) -> impl Fn()  {

--- a/tests/ui/associated-types/normalization-ice-issue-149746.rs
+++ b/tests/ui/associated-types/normalization-ice-issue-149746.rs
@@ -4,14 +4,14 @@ trait Owner { type Ty<T: FnMut()>; }
 impl Owner for () { type Ty<T: FnMut()> = T; }
 pub struct Warns<T> {
     _significant_drop: <() as Owner>::Ty<T>,
-    //~^ ERROR expected a `FnMut()` closure, found `T`
+    //~^ ERROR expected an `FnMut()` closure, found `T`
     field: String,
 }
 pub fn test<T>(w: Warns<T>) {
-    //~^ ERROR expected a `FnMut()` closure, found `T`
+    //~^ ERROR expected an `FnMut()` closure, found `T`
     _ = || w.field
-    //~^ ERROR expected a `FnMut()` closure, found `T`
-    //~| ERROR expected a `FnMut()` closure, found `T`
+    //~^ ERROR expected an `FnMut()` closure, found `T`
+    //~| ERROR expected an `FnMut()` closure, found `T`
     //~| WARN: changes to closure capture in Rust 2021 will affect drop order
 }
 fn main() {}

--- a/tests/ui/associated-types/normalization-ice-issue-149746.stderr
+++ b/tests/ui/associated-types/normalization-ice-issue-149746.stderr
@@ -1,4 +1,4 @@
-error[E0277]: expected a `FnMut()` closure, found `T`
+error[E0277]: expected an `FnMut()` closure, found `T`
   --> $DIR/normalization-ice-issue-149746.rs:6:24
    |
 LL |     _significant_drop: <() as Owner>::Ty<T>,
@@ -35,7 +35,7 @@ help: add a dummy let to cause `w` to be fully captured
 LL |     _ = || { let _ = &w; w.field }
    |            +++++++++++++         +
 
-error[E0277]: expected a `FnMut()` closure, found `T`
+error[E0277]: expected an `FnMut()` closure, found `T`
   --> $DIR/normalization-ice-issue-149746.rs:12:9
    |
 LL |     _ = || w.field
@@ -48,7 +48,7 @@ note: required by a bound in `Owner::Ty`
 LL | trait Owner { type Ty<T: FnMut()>; }
    |                          ^^^^^^^ required by this bound in `Owner::Ty`
 
-error[E0277]: expected a `FnMut()` closure, found `T`
+error[E0277]: expected an `FnMut()` closure, found `T`
   --> $DIR/normalization-ice-issue-149746.rs:10:16
    |
 LL | pub fn test<T>(w: Warns<T>) {
@@ -61,7 +61,7 @@ note: required by a bound in `Owner::Ty`
 LL | trait Owner { type Ty<T: FnMut()>; }
    |                          ^^^^^^^ required by this bound in `Owner::Ty`
 
-error[E0277]: expected a `FnMut()` closure, found `T`
+error[E0277]: expected an `FnMut()` closure, found `T`
   --> $DIR/normalization-ice-issue-149746.rs:12:9
    |
 LL |     _ = || w.field

--- a/tests/ui/async-await/async-fn/impl-header.rs
+++ b/tests/ui/async-await/async-fn/impl-header.rs
@@ -6,7 +6,7 @@ impl async Fn<()> for F {}
 //~^ ERROR `async` trait implementations are unsupported
 //~| ERROR the precise format of `Fn`-family traits' type parameters is subject to change
 //~| ERROR manual implementations of `Fn` are experimental
-//~| ERROR expected a `FnMut()` closure, found `F`
+//~| ERROR expected an `FnMut()` closure, found `F`
 //~| ERROR not all trait items implemented, missing: `call`
 
 fn main() {}

--- a/tests/ui/async-await/async-fn/impl-header.stderr
+++ b/tests/ui/async-await/async-fn/impl-header.stderr
@@ -30,7 +30,7 @@ LL | impl async Fn<()> for F {}
    |
    = help: implement the missing item: `fn call(&self, _: ()) -> <Self as FnOnce<()>>::Output { todo!() }`
 
-error[E0277]: expected a `FnMut()` closure, found `F`
+error[E0277]: expected an `FnMut()` closure, found `F`
   --> $DIR/impl-header.rs:5:23
    |
 LL | impl async Fn<()> for F {}

--- a/tests/ui/cast/raw-ptr-to-dyn-fn-raw-ptr.rs
+++ b/tests/ui/cast/raw-ptr-to-dyn-fn-raw-ptr.rs
@@ -4,6 +4,6 @@ fn main() {
     let ptr: *mut () = core::ptr::null_mut();
     let _: &mut dyn Fn() = unsafe {
         &mut *(ptr as *mut dyn Fn())
-        //~^ ERROR expected a `Fn()` closure, found `()`
+        //~^ ERROR expected an `Fn()` closure, found `()`
     };
 }

--- a/tests/ui/cast/raw-ptr-to-dyn-fn-raw-ptr.stderr
+++ b/tests/ui/cast/raw-ptr-to-dyn-fn-raw-ptr.stderr
@@ -1,4 +1,4 @@
-error[E0277]: expected a `Fn()` closure, found `()`
+error[E0277]: expected an `Fn()` closure, found `()`
   --> $DIR/raw-ptr-to-dyn-fn-raw-ptr.rs:6:16
    |
 LL |         &mut *(ptr as *mut dyn Fn())

--- a/tests/ui/closures/closure-expected.rs
+++ b/tests/ui/closures/closure-expected.rs
@@ -1,5 +1,5 @@
 fn main() {
     let x = Some(1);
     let y = x.or_else(4);
-    //~^ ERROR expected a `FnOnce()` closure, found `{integer}`
+    //~^ ERROR expected an `FnOnce()` closure, found `{integer}`
 }

--- a/tests/ui/closures/closure-expected.stderr
+++ b/tests/ui/closures/closure-expected.stderr
@@ -1,4 +1,4 @@
-error[E0277]: expected a `FnOnce()` closure, found `{integer}`
+error[E0277]: expected an `FnOnce()` closure, found `{integer}`
   --> $DIR/closure-expected.rs:3:23
    |
 LL |     let y = x.or_else(4);

--- a/tests/ui/closures/coerce-unsafe-to-closure.stderr
+++ b/tests/ui/closures/coerce-unsafe-to-closure.stderr
@@ -1,4 +1,4 @@
-error[E0277]: expected a `FnOnce(&str)` closure, found `unsafe fn(_) -> _ {std::intrinsics::transmute::<_, _>}`
+error[E0277]: expected an `FnOnce(&str)` closure, found `unsafe fn(_) -> _ {std::intrinsics::transmute::<_, _>}`
   --> $DIR/coerce-unsafe-to-closure.rs:2:44
    |
 LL |     let x: Option<&[u8]> = Some("foo").map(std::mem::transmute);

--- a/tests/ui/contracts/empty-ensures.rs
+++ b/tests/ui/contracts/empty-ensures.rs
@@ -6,7 +6,7 @@ extern crate core;
 use core::contracts::ensures;
 
 #[ensures()]
-//~^ ERROR expected a `Fn(&_)` closure, found `()` [E0277]
+//~^ ERROR expected an `Fn(&_)` closure, found `()` [E0277]
 fn foo(x: u32) -> u32 {
     x * 2
 }

--- a/tests/ui/contracts/empty-ensures.stderr
+++ b/tests/ui/contracts/empty-ensures.stderr
@@ -1,4 +1,4 @@
-error[E0277]: expected a `Fn(&_)` closure, found `()`
+error[E0277]: expected an `Fn(&_)` closure, found `()`
   --> $DIR/empty-ensures.rs:8:1
    |
 LL | #[ensures()]

--- a/tests/ui/expr/malformed_closure/block_instead_of_closure_in_arg.rs
+++ b/tests/ui/expr/malformed_closure/block_instead_of_closure_in_arg.rs
@@ -1,6 +1,6 @@
 fn main() {
     let number = 2;
-    Some(true).filter({ //~ ERROR expected a `FnOnce(&bool)` closure, found `bool`
+    Some(true).filter({ //~ ERROR expected an `FnOnce(&bool)` closure, found `bool`
         if number % 2 == 0 {
             number == 0
         } else {

--- a/tests/ui/expr/malformed_closure/block_instead_of_closure_in_arg.stderr
+++ b/tests/ui/expr/malformed_closure/block_instead_of_closure_in_arg.stderr
@@ -1,4 +1,4 @@
-error[E0277]: expected a `FnOnce(&bool)` closure, found `bool`
+error[E0277]: expected an `FnOnce(&bool)` closure, found `bool`
   --> $DIR/block_instead_of_closure_in_arg.rs:3:23
    |
 LL |        Some(true).filter({

--- a/tests/ui/expr/malformed_closure/ruby_style_closure_successful_parse.rs
+++ b/tests/ui/expr/malformed_closure/ruby_style_closure_successful_parse.rs
@@ -1,6 +1,6 @@
 const x: usize =42;
 fn main() {
-    let p = Some(45).and_then({|x| //~ ERROR expected a `FnOnce({integer})` closure, found `Option<usize>`
+    let p = Some(45).and_then({|x| //~ ERROR expected an `FnOnce({integer})` closure, found `Option<usize>`
         1 + 1;
         Some(x * 2)
     });

--- a/tests/ui/expr/malformed_closure/ruby_style_closure_successful_parse.stderr
+++ b/tests/ui/expr/malformed_closure/ruby_style_closure_successful_parse.stderr
@@ -1,4 +1,4 @@
-error[E0277]: expected a `FnOnce({integer})` closure, found `Option<usize>`
+error[E0277]: expected an `FnOnce({integer})` closure, found `Option<usize>`
   --> $DIR/ruby_style_closure_successful_parse.rs:3:31
    |
 LL |       let p = Some(45).and_then({|x|

--- a/tests/ui/extern/extern-wrong-value-type.rs
+++ b/tests/ui/extern/extern-wrong-value-type.rs
@@ -7,5 +7,5 @@ fn main() {
     // extern functions are extern "C" fn
     let _x: extern "C" fn() = f; // OK
     is_fn(f);
-    //~^ ERROR expected a `Fn()` closure, found `extern "C" fn() {f}`
+    //~^ ERROR expected an `Fn()` closure, found `extern "C" fn() {f}`
 }

--- a/tests/ui/extern/extern-wrong-value-type.stderr
+++ b/tests/ui/extern/extern-wrong-value-type.stderr
@@ -1,4 +1,4 @@
-error[E0277]: expected a `Fn()` closure, found `extern "C" fn() {f}`
+error[E0277]: expected an `Fn()` closure, found `extern "C" fn() {f}`
   --> $DIR/extern-wrong-value-type.rs:9:11
    |
 LL |     is_fn(f);

--- a/tests/ui/feature-gates/feature-gate-unboxed-closures-manual-impls.rs
+++ b/tests/ui/feature-gates/feature-gate-unboxed-closures-manual-impls.rs
@@ -9,7 +9,7 @@ struct Foo;
 impl Fn<()> for Foo {
     //~^ ERROR the precise format of `Fn`-family traits' type parameters is subject to change
     //~| ERROR manual implementations of `Fn` are experimental
-    //~| ERROR expected a `FnMut()` closure, found `Foo`
+    //~| ERROR expected an `FnMut()` closure, found `Foo`
     extern "rust-call" fn call(self, args: ()) -> () {}
     //~^ ERROR "rust-call" ABI is experimental and subject to change
     //~| ERROR `call` has an incompatible type for trait
@@ -26,7 +26,7 @@ struct Bar;
 impl FnMut<()> for Bar {
     //~^ ERROR the precise format of `Fn`-family traits' type parameters is subject to change
     //~| ERROR manual implementations of `FnMut` are experimental
-    //~| ERROR expected a `FnOnce()` closure, found `Bar`
+    //~| ERROR expected an `FnOnce()` closure, found `Bar`
     extern "rust-call" fn call_mut(&self, args: ()) -> () {}
     //~^ ERROR "rust-call" ABI is experimental and subject to change
     //~| ERROR incompatible type for trait

--- a/tests/ui/feature-gates/feature-gate-unboxed-closures-manual-impls.stderr
+++ b/tests/ui/feature-gates/feature-gate-unboxed-closures-manual-impls.stderr
@@ -87,7 +87,7 @@ LL | impl FnMut<()> for Bar {
    |
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
-error[E0277]: expected a `FnMut()` closure, found `Foo`
+error[E0277]: expected an `FnMut()` closure, found `Foo`
   --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:9:17
    |
 LL | impl Fn<()> for Foo {
@@ -161,7 +161,7 @@ help: change the self-receiver type to match the trait
 LL |     extern "rust-call" fn call_mut(&mut self, args: ()) -> () {}
    |                                     +++
 
-error[E0277]: expected a `FnOnce()` closure, found `Bar`
+error[E0277]: expected an `FnOnce()` closure, found `Bar`
   --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:26:20
    |
 LL | impl FnMut<()> for Bar {

--- a/tests/ui/fn/fn-trait-formatting.rs
+++ b/tests/ui/fn/fn-trait-formatting.rs
@@ -17,5 +17,5 @@ fn main() {
     //~| NOTE found struct `Box<dyn FnMut() -> isize>`
 
     needs_fn(1);
-    //~^ ERROR expected a `Fn(isize)` closure, found `{integer}`
+    //~^ ERROR expected an `Fn(isize)` closure, found `{integer}`
 }

--- a/tests/ui/fn/fn-trait-formatting.stderr
+++ b/tests/ui/fn/fn-trait-formatting.stderr
@@ -39,7 +39,7 @@ LL |     let _: () = Box::new(|| -> isize { unimplemented!() }) as Box<dyn FnMut
    = note: expected unit type `()`
                  found struct `Box<dyn FnMut() -> isize>`
 
-error[E0277]: expected a `Fn(isize)` closure, found `{integer}`
+error[E0277]: expected an `Fn(isize)` closure, found `{integer}`
   --> $DIR/fn-trait-formatting.rs:19:14
    |
 LL |     needs_fn(1);

--- a/tests/ui/fn/issue-39259.rs
+++ b/tests/ui/fn/issue-39259.rs
@@ -5,7 +5,7 @@ struct S;
 
 impl Fn(u32) -> u32 for S {
     //~^ ERROR associated item constraints are not allowed here [E0229]
-    //~| ERROR expected a `FnMut(u32)` closure, found `S`
+    //~| ERROR expected an `FnMut(u32)` closure, found `S`
     fn call(&self) -> u32 {
         //~^ ERROR method `call` has 1 parameter but the declaration in trait `call` has 2
         5

--- a/tests/ui/fn/issue-39259.stderr
+++ b/tests/ui/fn/issue-39259.stderr
@@ -22,7 +22,7 @@ help: add the missing parameter from the trait
 LL |     fn call(&self, args: Args) -> u32 {
    |                  ++++++++++++
 
-error[E0277]: expected a `FnMut(u32)` closure, found `S`
+error[E0277]: expected an `FnMut(u32)` closure, found `S`
   --> $DIR/issue-39259.rs:6:25
    |
 LL | impl Fn(u32) -> u32 for S {

--- a/tests/ui/generic-associated-types/issue-68642-broken-llvm-ir.rs
+++ b/tests/ui/generic-associated-types/issue-68642-broken-llvm-ir.rs
@@ -10,7 +10,7 @@ trait Fun {
 
 impl<T> Fun for T {
     type F<'a> = Self;
-    //~^ ERROR expected a `Fn()` closure, found `T`
+    //~^ ERROR expected an `Fn()` closure, found `T`
 }
 
 fn main() {

--- a/tests/ui/generic-associated-types/issue-68642-broken-llvm-ir.stderr
+++ b/tests/ui/generic-associated-types/issue-68642-broken-llvm-ir.stderr
@@ -1,4 +1,4 @@
-error[E0277]: expected a `Fn()` closure, found `T`
+error[E0277]: expected an `Fn()` closure, found `T`
   --> $DIR/issue-68642-broken-llvm-ir.rs:12:18
    |
 LL |     type F<'a> = Self;

--- a/tests/ui/generic-associated-types/issue-68643-broken-mir.rs
+++ b/tests/ui/generic-associated-types/issue-68643-broken-mir.rs
@@ -10,7 +10,7 @@ trait Fun {
 
 impl<T> Fun for T {
     type F<'a> = Self;
-    //~^ ERROR expected a `Fn()` closure, found `T`
+    //~^ ERROR expected an `Fn()` closure, found `T`
 }
 
 pub fn main() {

--- a/tests/ui/generic-associated-types/issue-68643-broken-mir.stderr
+++ b/tests/ui/generic-associated-types/issue-68643-broken-mir.stderr
@@ -1,4 +1,4 @@
-error[E0277]: expected a `Fn()` closure, found `T`
+error[E0277]: expected an `Fn()` closure, found `T`
   --> $DIR/issue-68643-broken-mir.rs:12:18
    |
 LL |     type F<'a> = Self;

--- a/tests/ui/generic-associated-types/issue-68644-codegen-selection.rs
+++ b/tests/ui/generic-associated-types/issue-68644-codegen-selection.rs
@@ -10,7 +10,7 @@ trait Fun {
 
 impl<T> Fun for T {
     type F<'a> = Self;
-    //~^ ERROR expected a `Fn()` closure, found `T`
+    //~^ ERROR expected an `Fn()` closure, found `T`
 }
 
 fn main() {

--- a/tests/ui/generic-associated-types/issue-68644-codegen-selection.stderr
+++ b/tests/ui/generic-associated-types/issue-68644-codegen-selection.stderr
@@ -1,4 +1,4 @@
-error[E0277]: expected a `Fn()` closure, found `T`
+error[E0277]: expected an `Fn()` closure, found `T`
   --> $DIR/issue-68644-codegen-selection.rs:12:18
    |
 LL |     type F<'a> = Self;

--- a/tests/ui/generic-associated-types/issue-68645-codegen-fulfillment.rs
+++ b/tests/ui/generic-associated-types/issue-68645-codegen-fulfillment.rs
@@ -10,7 +10,7 @@ trait Fun {
 
 impl<T> Fun for T {
     type F<'a> = Self;
-    //~^ ERROR expected a `Fn()` closure, found `T`
+    //~^ ERROR expected an `Fn()` closure, found `T`
 }
 
 fn main() {

--- a/tests/ui/generic-associated-types/issue-68645-codegen-fulfillment.stderr
+++ b/tests/ui/generic-associated-types/issue-68645-codegen-fulfillment.stderr
@@ -1,4 +1,4 @@
-error[E0277]: expected a `Fn()` closure, found `T`
+error[E0277]: expected an `Fn()` closure, found `T`
   --> $DIR/issue-68645-codegen-fulfillment.rs:12:18
    |
 LL |     type F<'a> = Self;

--- a/tests/ui/higher-ranked/trait-bounds/normalize-under-binder/issue-62529-3.stderr
+++ b/tests/ui/higher-ranked/trait-bounds/normalize-under-binder/issue-62529-3.stderr
@@ -1,4 +1,4 @@
-error[E0277]: expected a `Fn(<_ as ATC<'a>>::Type)` closure, found `F`
+error[E0277]: expected an `Fn(<_ as ATC<'a>>::Type)` closure, found `F`
   --> $DIR/issue-62529-3.rs:25:14
    |
 LL |         call(f, ());

--- a/tests/ui/implied-bounds/issue-100690.rs
+++ b/tests/ui/implied-bounds/issue-100690.rs
@@ -32,7 +32,7 @@ impl<'a, T: 'a> Handle<'a, T, UIView<'a, T>, Result<(), io::Error>> for TUIHandl
         F: FnOnce(&mut UIView<'a, T>) -> Result<(), io::Error> + Send + 'static,
     {
         real_dispatch(f)
-        //~^ ERROR expected a `FnOnce(&mut UIView<'_, T>)` closure, found `F`
+        //~^ ERROR expected an `FnOnce(&mut UIView<'_, T>)` closure, found `F`
     }
 }
 

--- a/tests/ui/implied-bounds/issue-100690.stderr
+++ b/tests/ui/implied-bounds/issue-100690.stderr
@@ -1,4 +1,4 @@
-error[E0277]: expected a `FnOnce(&mut UIView<'_, T>)` closure, found `F`
+error[E0277]: expected an `FnOnce(&mut UIView<'_, T>)` closure, found `F`
   --> $DIR/issue-100690.rs:34:23
    |
 LL |         real_dispatch(f)

--- a/tests/ui/intrinsics/const-eval-select-bad.rs
+++ b/tests/ui/intrinsics/const-eval-select-bad.rs
@@ -7,8 +7,8 @@ const fn not_fn_items() {
     const_eval_select((), || {}, || {});
     //~^ ERROR const FnOnce()` is not satisfied
     const_eval_select((), 42, 0xDEADBEEF);
-    //~^ ERROR expected a `FnOnce()` closure
-    //~| ERROR expected a `FnOnce()` closure
+    //~^ ERROR expected an `FnOnce()` closure
+    //~| ERROR expected an `FnOnce()` closure
 }
 
 const fn foo(n: i32) -> i32 {

--- a/tests/ui/intrinsics/const-eval-select-bad.stderr
+++ b/tests/ui/intrinsics/const-eval-select-bad.stderr
@@ -9,7 +9,7 @@ LL |     const_eval_select((), || {}, || {});
 note: required by a bound in `const_eval_select`
   --> $SRC_DIR/core/src/intrinsics/mod.rs:LL:COL
 
-error[E0277]: expected a `FnOnce()` closure, found `{integer}`
+error[E0277]: expected an `FnOnce()` closure, found `{integer}`
   --> $DIR/const-eval-select-bad.rs:9:27
    |
 LL |     const_eval_select((), 42, 0xDEADBEEF);
@@ -22,7 +22,7 @@ LL |     const_eval_select((), 42, 0xDEADBEEF);
 note: required by a bound in `const_eval_select`
   --> $SRC_DIR/core/src/intrinsics/mod.rs:LL:COL
 
-error[E0277]: expected a `FnOnce()` closure, found `{integer}`
+error[E0277]: expected an `FnOnce()` closure, found `{integer}`
   --> $DIR/const-eval-select-bad.rs:9:31
    |
 LL |     const_eval_select((), 42, 0xDEADBEEF);

--- a/tests/ui/iterators/fold-iterator-error-23966.stderr
+++ b/tests/ui/iterators/fold-iterator-error-23966.stderr
@@ -1,4 +1,4 @@
-error[E0277]: expected a `FnMut(_, char)` closure, found `()`
+error[E0277]: expected an `FnMut(_, char)` closure, found `()`
   --> $DIR/fold-iterator-error-23966.rs:3:32
    |
 LL |     "".chars().fold(|_, _| (), ());

--- a/tests/ui/lifetimes/issue-76168-hr-outlives-3.rs
+++ b/tests/ui/lifetimes/issue-76168-hr-outlives-3.rs
@@ -4,9 +4,9 @@
 use std::future::Future;
 
 async fn wrapper<F>(f: F)
-//~^ ERROR: expected a `FnOnce(&'a mut i32)` closure, found `i32`
-//~| ERROR: expected a `FnOnce(&'a mut i32)` closure, found `i32`
-//~| ERROR: expected a `FnOnce(&'a mut i32)` closure, found `i32`
+//~^ ERROR: expected an `FnOnce(&'a mut i32)` closure, found `i32`
+//~| ERROR: expected an `FnOnce(&'a mut i32)` closure, found `i32`
+//~| ERROR: expected an `FnOnce(&'a mut i32)` closure, found `i32`
 where
     F:,
     for<'a> <i32 as FnOnce<(&'a mut i32,)>>::Output: Future<Output = ()> + 'a,

--- a/tests/ui/lifetimes/issue-76168-hr-outlives-3.stderr
+++ b/tests/ui/lifetimes/issue-76168-hr-outlives-3.stderr
@@ -1,4 +1,4 @@
-error[E0277]: expected a `FnOnce(&'a mut i32)` closure, found `i32`
+error[E0277]: expected an `FnOnce(&'a mut i32)` closure, found `i32`
   --> $DIR/issue-76168-hr-outlives-3.rs:6:1
    |
 LL | / async fn wrapper<F>(f: F)
@@ -9,7 +9,7 @@ LL | |     for<'a> <i32 as FnOnce<(&'a mut i32,)>>::Output: Future<Output = ()> 
    |
    = help: the trait `for<'a> FnOnce(&'a mut i32)` is not implemented for `i32`
 
-error[E0277]: expected a `FnOnce(&'a mut i32)` closure, found `i32`
+error[E0277]: expected an `FnOnce(&'a mut i32)` closure, found `i32`
   --> $DIR/issue-76168-hr-outlives-3.rs:6:26
    |
 LL | async fn wrapper<F>(f: F)
@@ -17,7 +17,7 @@ LL | async fn wrapper<F>(f: F)
    |
    = help: the trait `for<'a> FnOnce(&'a mut i32)` is not implemented for `i32`
 
-error[E0277]: expected a `FnOnce(&'a mut i32)` closure, found `i32`
+error[E0277]: expected an `FnOnce(&'a mut i32)` closure, found `i32`
   --> $DIR/issue-76168-hr-outlives-3.rs:6:26
    |
 LL | async fn wrapper<F>(f: F)

--- a/tests/ui/lifetimes/issue-95023.rs
+++ b/tests/ui/lifetimes/issue-95023.rs
@@ -4,7 +4,7 @@ impl Fn(&isize) for Error {
     //~^ ERROR manual implementations of `Fn` are experimental [E0183]
     //~| ERROR associated item constraints are not allowed here [E0229]
     //~| ERROR not all trait items implemented
-    //~| ERROR expected a `FnMut(&isize)` closure, found `Error`
+    //~| ERROR expected an `FnMut(&isize)` closure, found `Error`
     fn foo<const N: usize>(&self) -> Self::B<{ N }>;
     //~^ ERROR associated function in `impl` without body
     //~| ERROR method `foo` is not a member of trait `Fn` [E0407]

--- a/tests/ui/lifetimes/issue-95023.stderr
+++ b/tests/ui/lifetimes/issue-95023.stderr
@@ -40,7 +40,7 @@ LL | impl Fn(&isize) for Error {
    |
    = help: implement the missing item: `fn call(&self, _: (&isize,)) -> <Self as FnOnce<(&isize,)>>::Output { todo!() }`
 
-error[E0277]: expected a `FnMut(&isize)` closure, found `Error`
+error[E0277]: expected an `FnMut(&isize)` closure, found `Error`
   --> $DIR/issue-95023.rs:3:21
    |
 LL | impl Fn(&isize) for Error {

--- a/tests/ui/macros/ice-in-tokenstream-for-contracts-issue-140683.rs
+++ b/tests/ui/macros/ice-in-tokenstream-for-contracts-issue-140683.rs
@@ -4,7 +4,7 @@
 struct T;
 
 impl T {
-    #[core::contracts::ensures] //~ ERROR expected a `Fn(&_)` closure, found `()`
+    #[core::contracts::ensures] //~ ERROR expected an `Fn(&_)` closure, found `()`
     fn b() {(loop)}
     //~^ ERROR expected `{`, found `)`
     //~| ERROR expected `{`, found `)`

--- a/tests/ui/macros/ice-in-tokenstream-for-contracts-issue-140683.stderr
+++ b/tests/ui/macros/ice-in-tokenstream-for-contracts-issue-140683.stderr
@@ -16,7 +16,7 @@ LL |     fn b() {(loop)}
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error[E0277]: expected a `Fn(&_)` closure, found `()`
+error[E0277]: expected an `Fn(&_)` closure, found `()`
   --> $DIR/ice-in-tokenstream-for-contracts-issue-140683.rs:7:5
    |
 LL |     #[core::contracts::ensures]

--- a/tests/ui/methods/filter-relevant-fn-bounds.rs
+++ b/tests/ui/methods/filter-relevant-fn-bounds.rs
@@ -16,5 +16,5 @@ impl Wrapper {
 fn main() {
     let mut wrapper = Wrapper;
     wrapper.do_something_wrapper(|value| ());
-    //~^ ERROR expected a `FnOnce
+    //~^ ERROR expected an `FnOnce
 }

--- a/tests/ui/methods/filter-relevant-fn-bounds.stderr
+++ b/tests/ui/methods/filter-relevant-fn-bounds.stderr
@@ -12,7 +12,7 @@ help: consider further restricting type parameter `F` with trait `Output`
 LL |         F: for<'a> FnOnce(<F as Output<'a>>::Type) + for<'a> Output<'a>,
    |                                                    ++++++++++++++++++++
 
-error[E0277]: expected a `FnOnce(<{closure@$DIR/filter-relevant-fn-bounds.rs:18:34: 18:41} as Output<'a>>::Type)` closure, found `{closure@$DIR/filter-relevant-fn-bounds.rs:18:34: 18:41}`
+error[E0277]: expected an `FnOnce(<{closure@$DIR/filter-relevant-fn-bounds.rs:18:34: 18:41} as Output<'a>>::Type)` closure, found `{closure@$DIR/filter-relevant-fn-bounds.rs:18:34: 18:41}`
   --> $DIR/filter-relevant-fn-bounds.rs:18:34
    |
 LL |     wrapper.do_something_wrapper(|value| ());

--- a/tests/ui/methods/method-suggestion-trait-with-extra-generics-no-ice.rs
+++ b/tests/ui/methods/method-suggestion-trait-with-extra-generics-no-ice.rs
@@ -16,7 +16,7 @@ struct Bar;
 
 fn main() {
     let foo: Box<dyn Fn(bool) -> usize> = Box::new(Bar);
-    //~^ ERROR expected a `Fn(bool)` closure, found `Bar`
+    //~^ ERROR expected an `Fn(bool)` closure, found `Bar`
     foo.borrow();
     //~^ ERROR no method named `borrow` found
     foo.take()

--- a/tests/ui/methods/method-suggestion-trait-with-extra-generics-no-ice.stderr
+++ b/tests/ui/methods/method-suggestion-trait-with-extra-generics-no-ice.stderr
@@ -22,7 +22,7 @@ help: there is a method `borrow_mut` with a similar name
 LL |     foo.borrow_mut();
    |               ++++
 
-error[E0277]: expected a `Fn(bool)` closure, found `Bar`
+error[E0277]: expected an `Fn(bool)` closure, found `Bar`
   --> $DIR/method-suggestion-trait-with-extra-generics-no-ice.rs:18:43
    |
 LL |     let foo: Box<dyn Fn(bool) -> usize> = Box::new(Bar);

--- a/tests/ui/mismatched_types/closure-arg-type-mismatch-issue-45727.current.fixed
+++ b/tests/ui/mismatched_types/closure-arg-type-mismatch-issue-45727.current.fixed
@@ -5,10 +5,10 @@
 fn main() {
     let _ = (-10..=10).find(|x: &i32| x.signum() == 0);
     //[current]~^ ERROR type mismatch in closure arguments
-    //[next]~^^ ERROR: expected a `FnMut(&{integer})` closure, found
+    //[next]~^^ ERROR: expected an `FnMut(&{integer})` closure, found
     //[next]~| ERROR: type mismatch resolving `<{closure@closure-arg-type-mismatch-issue-45727.rs:6:29} as FnOnce<(&{integer},)>>::Output == bool`
     let _ = (-10..=10).find(|x: &i32| x.signum() == 0);
     //[current]~^ ERROR type mismatch in closure arguments
-    //[next]~^^ ERROR: expected a `FnMut(&{integer})` closure, found
+    //[next]~^^ ERROR: expected an `FnMut(&{integer})` closure, found
     //[next]~| ERROR: type mismatch resolving `<{closure@closure-arg-type-mismatch-issue-45727.rs:10:29} as FnOnce<(&{integer},)>>::Output == bool`
 }

--- a/tests/ui/mismatched_types/closure-arg-type-mismatch-issue-45727.next.stderr
+++ b/tests/ui/mismatched_types/closure-arg-type-mismatch-issue-45727.next.stderr
@@ -1,4 +1,4 @@
-error[E0277]: expected a `FnMut(&{integer})` closure, found `{closure@$DIR/closure-arg-type-mismatch-issue-45727.rs:6:29: 6:37}`
+error[E0277]: expected an `FnMut(&{integer})` closure, found `{closure@$DIR/closure-arg-type-mismatch-issue-45727.rs:6:29: 6:37}`
   --> $DIR/closure-arg-type-mismatch-issue-45727.rs:6:29
    |
 LL |     let _ = (-10..=10).find(|x: i32| x.signum() == 0);
@@ -23,7 +23,7 @@ LL |     let _ = (-10..=10).find(|x: i32| x.signum() == 0);
 note: required by a bound in `find`
   --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
 
-error[E0277]: expected a `FnMut(&{integer})` closure, found `{closure@$DIR/closure-arg-type-mismatch-issue-45727.rs:10:29: 10:40}`
+error[E0277]: expected an `FnMut(&{integer})` closure, found `{closure@$DIR/closure-arg-type-mismatch-issue-45727.rs:10:29: 10:40}`
   --> $DIR/closure-arg-type-mismatch-issue-45727.rs:10:29
    |
 LL |     let _ = (-10..=10).find(|x: &&&i32| x.signum() == 0);

--- a/tests/ui/mismatched_types/closure-arg-type-mismatch-issue-45727.rs
+++ b/tests/ui/mismatched_types/closure-arg-type-mismatch-issue-45727.rs
@@ -5,10 +5,10 @@
 fn main() {
     let _ = (-10..=10).find(|x: i32| x.signum() == 0);
     //[current]~^ ERROR type mismatch in closure arguments
-    //[next]~^^ ERROR: expected a `FnMut(&{integer})` closure, found
+    //[next]~^^ ERROR: expected an `FnMut(&{integer})` closure, found
     //[next]~| ERROR: type mismatch resolving `<{closure@closure-arg-type-mismatch-issue-45727.rs:6:29} as FnOnce<(&{integer},)>>::Output == bool`
     let _ = (-10..=10).find(|x: &&&i32| x.signum() == 0);
     //[current]~^ ERROR type mismatch in closure arguments
-    //[next]~^^ ERROR: expected a `FnMut(&{integer})` closure, found
+    //[next]~^^ ERROR: expected an `FnMut(&{integer})` closure, found
     //[next]~| ERROR: type mismatch resolving `<{closure@closure-arg-type-mismatch-issue-45727.rs:10:29} as FnOnce<(&{integer},)>>::Output == bool`
 }

--- a/tests/ui/mismatched_types/suggest-option-asderef-unfixable.rs
+++ b/tests/ui/mismatched_types/suggest-option-asderef-unfixable.rs
@@ -24,9 +24,9 @@ fn main() {
     let _ = produces_string().and_then(takes_str_but_too_many_refs);
     //~^ ERROR type mismatch in function arguments
     let _ = produces_string().and_then(takes_str_but_wrong_abi);
-    //~^ ERROR expected a `FnOnce(String)` closure, found `for<'a> extern "C" fn(&'a str) -> Option<()> {takes_str_but_wrong_abi}`
+    //~^ ERROR expected an `FnOnce(String)` closure, found `for<'a> extern "C" fn(&'a str) -> Option<()> {takes_str_but_wrong_abi}`
     let _ = produces_string().and_then(takes_str_but_unsafe);
-    //~^ ERROR expected a `FnOnce(String)` closure, found `for<'a> unsafe fn(&'a str) -> Option<()> {takes_str_but_unsafe}`
+    //~^ ERROR expected an `FnOnce(String)` closure, found `for<'a> unsafe fn(&'a str) -> Option<()> {takes_str_but_unsafe}`
     let _ = produces_string().and_then(no_args);
     //~^ ERROR function is expected to take 1 argument, but it takes 0 arguments
     let _ = Some(TypeWithoutDeref).and_then(takes_str_but_too_many_refs);

--- a/tests/ui/mismatched_types/suggest-option-asderef-unfixable.stderr
+++ b/tests/ui/mismatched_types/suggest-option-asderef-unfixable.stderr
@@ -18,7 +18,7 @@ help: consider wrapping the function in a closure
 LL |     let _ = produces_string().and_then(|arg0: String| takes_str_but_too_many_refs(/* &&str */));
    |                                        ++++++++++++++                            +++++++++++++
 
-error[E0277]: expected a `FnOnce(String)` closure, found `for<'a> extern "C" fn(&'a str) -> Option<()> {takes_str_but_wrong_abi}`
+error[E0277]: expected an `FnOnce(String)` closure, found `for<'a> extern "C" fn(&'a str) -> Option<()> {takes_str_but_wrong_abi}`
   --> $DIR/suggest-option-asderef-unfixable.rs:26:40
    |
 LL |     let _ = produces_string().and_then(takes_str_but_wrong_abi);
@@ -30,7 +30,7 @@ LL |     let _ = produces_string().and_then(takes_str_but_wrong_abi);
 note: required by a bound in `Option::<T>::and_then`
   --> $SRC_DIR/core/src/option.rs:LL:COL
 
-error[E0277]: expected a `FnOnce(String)` closure, found `for<'a> unsafe fn(&'a str) -> Option<()> {takes_str_but_unsafe}`
+error[E0277]: expected an `FnOnce(String)` closure, found `for<'a> unsafe fn(&'a str) -> Option<()> {takes_str_but_unsafe}`
   --> $DIR/suggest-option-asderef-unfixable.rs:28:40
    |
 LL |     let _ = produces_string().and_then(takes_str_but_unsafe);

--- a/tests/ui/rfcs/rfc-2396-target_feature-11/fn-traits.rs
+++ b/tests/ui/rfcs/rfc-2396-target_feature-11/fn-traits.rs
@@ -26,15 +26,15 @@ fn call_once_i32(f: impl FnOnce(i32)) {
 }
 
 fn main() {
-    call(foo); //~ ERROR expected a `Fn()` closure, found `#[target_features] fn() {foo}`
-    call_mut(foo); //~ ERROR expected a `FnMut()` closure, found `#[target_features] fn() {foo}`
-    call_once(foo); //~ ERROR expected a `FnOnce()` closure, found `#[target_features] fn() {foo}`
-    call_once_i32(bar); //~ ERROR expected a `FnOnce(i32)` closure, found `#[target_features] fn(i32) {bar}`
+    call(foo); //~ ERROR expected an `Fn()` closure, found `#[target_features] fn() {foo}`
+    call_mut(foo); //~ ERROR expected an `FnMut()` closure, found `#[target_features] fn() {foo}`
+    call_once(foo); //~ ERROR expected an `FnOnce()` closure, found `#[target_features] fn() {foo}`
+    call_once_i32(bar); //~ ERROR expected an `FnOnce(i32)` closure, found `#[target_features] fn(i32) {bar}`
 
     call(foo_unsafe);
-    //~^ ERROR expected a `Fn()` closure, found `unsafe fn() {foo_unsafe}`
+    //~^ ERROR expected an `Fn()` closure, found `unsafe fn() {foo_unsafe}`
     call_mut(foo_unsafe);
-    //~^ ERROR expected a `FnMut()` closure, found `unsafe fn() {foo_unsafe}`
+    //~^ ERROR expected an `FnMut()` closure, found `unsafe fn() {foo_unsafe}`
     call_once(foo_unsafe);
-    //~^ ERROR expected a `FnOnce()` closure, found `unsafe fn() {foo_unsafe}`
+    //~^ ERROR expected an `FnOnce()` closure, found `unsafe fn() {foo_unsafe}`
 }

--- a/tests/ui/rfcs/rfc-2396-target_feature-11/fn-traits.stderr
+++ b/tests/ui/rfcs/rfc-2396-target_feature-11/fn-traits.stderr
@@ -1,4 +1,4 @@
-error[E0277]: expected a `Fn()` closure, found `#[target_features] fn() {foo}`
+error[E0277]: expected an `Fn()` closure, found `#[target_features] fn() {foo}`
   --> $DIR/fn-traits.rs:29:10
    |
 LL |     call(foo);
@@ -16,7 +16,7 @@ note: required by a bound in `call`
 LL | fn call(f: impl Fn()) {
    |                 ^^^^ required by this bound in `call`
 
-error[E0277]: expected a `FnMut()` closure, found `#[target_features] fn() {foo}`
+error[E0277]: expected an `FnMut()` closure, found `#[target_features] fn() {foo}`
   --> $DIR/fn-traits.rs:30:14
    |
 LL |     call_mut(foo);
@@ -34,7 +34,7 @@ note: required by a bound in `call_mut`
 LL | fn call_mut(mut f: impl FnMut()) {
    |                         ^^^^^^^ required by this bound in `call_mut`
 
-error[E0277]: expected a `FnOnce()` closure, found `#[target_features] fn() {foo}`
+error[E0277]: expected an `FnOnce()` closure, found `#[target_features] fn() {foo}`
   --> $DIR/fn-traits.rs:31:15
    |
 LL |     call_once(foo);
@@ -52,7 +52,7 @@ note: required by a bound in `call_once`
 LL | fn call_once(f: impl FnOnce()) {
    |                      ^^^^^^^^ required by this bound in `call_once`
 
-error[E0277]: expected a `FnOnce(i32)` closure, found `#[target_features] fn(i32) {bar}`
+error[E0277]: expected an `FnOnce(i32)` closure, found `#[target_features] fn(i32) {bar}`
   --> $DIR/fn-traits.rs:32:19
    |
 LL |     call_once_i32(bar);
@@ -69,7 +69,7 @@ note: required by a bound in `call_once_i32`
 LL | fn call_once_i32(f: impl FnOnce(i32)) {
    |                          ^^^^^^^^^^^ required by this bound in `call_once_i32`
 
-error[E0277]: expected a `Fn()` closure, found `unsafe fn() {foo_unsafe}`
+error[E0277]: expected an `Fn()` closure, found `unsafe fn() {foo_unsafe}`
   --> $DIR/fn-traits.rs:34:10
    |
 LL |     call(foo_unsafe);
@@ -88,7 +88,7 @@ note: required by a bound in `call`
 LL | fn call(f: impl Fn()) {
    |                 ^^^^ required by this bound in `call`
 
-error[E0277]: expected a `FnMut()` closure, found `unsafe fn() {foo_unsafe}`
+error[E0277]: expected an `FnMut()` closure, found `unsafe fn() {foo_unsafe}`
   --> $DIR/fn-traits.rs:36:14
    |
 LL |     call_mut(foo_unsafe);
@@ -107,7 +107,7 @@ note: required by a bound in `call_mut`
 LL | fn call_mut(mut f: impl FnMut()) {
    |                         ^^^^^^^ required by this bound in `call_mut`
 
-error[E0277]: expected a `FnOnce()` closure, found `unsafe fn() {foo_unsafe}`
+error[E0277]: expected an `FnOnce()` closure, found `unsafe fn() {foo_unsafe}`
   --> $DIR/fn-traits.rs:38:15
    |
 LL |     call_once(foo_unsafe);

--- a/tests/ui/trait-bounds/mismatch-fn-trait.stderr
+++ b/tests/ui/trait-bounds/mismatch-fn-trait.stderr
@@ -1,4 +1,4 @@
-error[E0277]: expected a `FnMut(i32)` closure, found `impl FnMut(u32)`
+error[E0277]: expected an `FnMut(i32)` closure, found `impl FnMut(u32)`
   --> $DIR/mismatch-fn-trait.rs:4:10
    |
 LL |     take(f)
@@ -14,7 +14,7 @@ note: required by a bound in `take`
 LL | fn take(_f: impl FnMut(i32)) {}
    |                  ^^^^^^^^^^ required by this bound in `take`
 
-error[E0277]: expected a `FnMut(i32)` closure, found `impl FnMut(i32, i32)`
+error[E0277]: expected an `FnMut(i32)` closure, found `impl FnMut(i32, i32)`
   --> $DIR/mismatch-fn-trait.rs:9:10
    |
 LL |     take(f)
@@ -29,7 +29,7 @@ note: required by a bound in `take`
 LL | fn take(_f: impl FnMut(i32)) {}
    |                  ^^^^^^^^^^ required by this bound in `take`
 
-error[E0277]: expected a `FnMut(i32)` closure, found `impl FnMut()`
+error[E0277]: expected an `FnMut(i32)` closure, found `impl FnMut()`
   --> $DIR/mismatch-fn-trait.rs:14:10
    |
 LL |     take(f)
@@ -44,7 +44,7 @@ note: required by a bound in `take`
 LL | fn take(_f: impl FnMut(i32)) {}
    |                  ^^^^^^^^^^ required by this bound in `take`
 
-error[E0277]: expected a `FnMut(i32)` closure, found `impl FnOnce(i32)`
+error[E0277]: expected an `FnMut(i32)` closure, found `impl FnOnce(i32)`
   --> $DIR/mismatch-fn-trait.rs:19:10
    |
 LL |     take(f)
@@ -59,7 +59,7 @@ note: required by a bound in `take`
 LL | fn take(_f: impl FnMut(i32)) {}
    |                  ^^^^^^^^^^ required by this bound in `take`
 
-error[E0277]: expected a `FnMut(i32)` closure, found `impl FnOnce(u32)`
+error[E0277]: expected an `FnMut(i32)` closure, found `impl FnOnce(u32)`
   --> $DIR/mismatch-fn-trait.rs:24:10
    |
 LL |     take(f)

--- a/tests/ui/traits/associated_type_bound/check-trait-object-bounds-2.rs
+++ b/tests/ui/traits/associated_type_bound/check-trait-object-bounds-2.rs
@@ -11,5 +11,5 @@ fn f<T: for<'r> X<'r> + ?Sized>() {
 
 fn main() {
     f::<dyn for<'x> X<'x, F = i32>>();
-    //~^ ERROR expected a `FnOnce(&i32)` closure, found `i32`
+    //~^ ERROR expected an `FnOnce(&i32)` closure, found `i32`
 }

--- a/tests/ui/traits/associated_type_bound/check-trait-object-bounds-2.stderr
+++ b/tests/ui/traits/associated_type_bound/check-trait-object-bounds-2.stderr
@@ -1,4 +1,4 @@
-error[E0277]: expected a `FnOnce(&i32)` closure, found `i32`
+error[E0277]: expected an `FnOnce(&i32)` closure, found `i32`
   --> $DIR/check-trait-object-bounds-2.rs:13:9
    |
 LL |     f::<dyn for<'x> X<'x, F = i32>>();

--- a/tests/ui/traits/issue-87558.stderr
+++ b/tests/ui/traits/issue-87558.stderr
@@ -32,7 +32,7 @@ LL | impl Fn(&isize) for Error {
    |
    = help: implement the missing item: `fn call(&self, _: (&isize,)) -> <Self as FnOnce<(&isize,)>>::Output { todo!() }`
 
-error[E0277]: expected a `FnMut(&isize)` closure, found `Error`
+error[E0277]: expected an `FnMut(&isize)` closure, found `Error`
   --> $DIR/issue-87558.rs:3:21
    |
 LL | impl Fn(&isize) for Error {

--- a/tests/ui/traits/next-solver/diagnostics/const-host-effect-hrtb-no-ice.rs
+++ b/tests/ui/traits/next-solver/diagnostics/const-host-effect-hrtb-no-ice.rs
@@ -7,7 +7,7 @@ const fn with_positive<F: for<'a> [const] Fn(&'a ())>() {}
 
 const _: () = {
     with_positive::<()>();
-    //~^ ERROR expected a `Fn(&'a ())` closure, found `()`
+    //~^ ERROR expected an `Fn(&'a ())` closure, found `()`
     //~| ERROR type mismatch resolving `<() as FnOnce<(&(),)>>::Output == ()`
 };
 

--- a/tests/ui/traits/next-solver/diagnostics/const-host-effect-hrtb-no-ice.stderr
+++ b/tests/ui/traits/next-solver/diagnostics/const-host-effect-hrtb-no-ice.stderr
@@ -1,4 +1,4 @@
-error[E0277]: expected a `Fn(&'a ())` closure, found `()`
+error[E0277]: expected an `Fn(&'a ())` closure, found `()`
   --> $DIR/const-host-effect-hrtb-no-ice.rs:9:21
    |
 LL |     with_positive::<()>();

--- a/tests/ui/traits/next-solver/fn-trait.rs
+++ b/tests/ui/traits/next-solver/fn-trait.rs
@@ -18,11 +18,11 @@ fn main() {
     require_fn(f);
     require_fn(f as fn() -> i32);
     require_fn(f as unsafe fn() -> i32);
-    //~^ ERROR: expected a `Fn()` closure, found `unsafe fn() -> i32`
+    //~^ ERROR: expected an `Fn()` closure, found `unsafe fn() -> i32`
     require_fn(g);
-    //~^ ERROR: expected a `Fn()` closure, found `extern "C" fn() -> i32 {g}`
+    //~^ ERROR: expected an `Fn()` closure, found `extern "C" fn() -> i32 {g}`
     require_fn(g as extern "C" fn() -> i32);
-    //~^ ERROR: expected a `Fn()` closure, found `extern "C" fn() -> i32`
+    //~^ ERROR: expected an `Fn()` closure, found `extern "C" fn() -> i32`
     require_fn(h);
-    //~^ ERROR: expected a `Fn()` closure, found `unsafe fn() -> i32 {h}`
+    //~^ ERROR: expected an `Fn()` closure, found `unsafe fn() -> i32 {h}`
 }

--- a/tests/ui/traits/next-solver/fn-trait.stderr
+++ b/tests/ui/traits/next-solver/fn-trait.stderr
@@ -1,4 +1,4 @@
-error[E0277]: expected a `Fn()` closure, found `unsafe fn() -> i32`
+error[E0277]: expected an `Fn()` closure, found `unsafe fn() -> i32`
   --> $DIR/fn-trait.rs:20:16
    |
 LL |     require_fn(f as unsafe fn() -> i32);
@@ -15,7 +15,7 @@ note: required by a bound in `require_fn`
 LL | fn require_fn(_: impl Fn() -> i32) {}
    |                       ^^^^^^^^^^^ required by this bound in `require_fn`
 
-error[E0277]: expected a `Fn()` closure, found `extern "C" fn() -> i32 {g}`
+error[E0277]: expected an `Fn()` closure, found `extern "C" fn() -> i32 {g}`
   --> $DIR/fn-trait.rs:22:16
    |
 LL |     require_fn(g);
@@ -31,7 +31,7 @@ note: required by a bound in `require_fn`
 LL | fn require_fn(_: impl Fn() -> i32) {}
    |                       ^^^^^^^^^^^ required by this bound in `require_fn`
 
-error[E0277]: expected a `Fn()` closure, found `extern "C" fn() -> i32`
+error[E0277]: expected an `Fn()` closure, found `extern "C" fn() -> i32`
   --> $DIR/fn-trait.rs:24:16
    |
 LL |     require_fn(g as extern "C" fn() -> i32);
@@ -47,7 +47,7 @@ note: required by a bound in `require_fn`
 LL | fn require_fn(_: impl Fn() -> i32) {}
    |                       ^^^^^^^^^^^ required by this bound in `require_fn`
 
-error[E0277]: expected a `Fn()` closure, found `unsafe fn() -> i32 {h}`
+error[E0277]: expected an `Fn()` closure, found `unsafe fn() -> i32 {h}`
   --> $DIR/fn-trait.rs:26:16
    |
 LL |     require_fn(h);

--- a/tests/ui/type-alias-impl-trait/issue-63279.rs
+++ b/tests/ui/type-alias-impl-trait/issue-63279.rs
@@ -4,11 +4,11 @@ type Closure = impl FnOnce();
 
 #[define_opaque(Closure)]
 fn c() -> Closure {
-    //~^ ERROR: expected a `FnOnce()` closure, found `()`
+    //~^ ERROR: expected an `FnOnce()` closure, found `()`
     || -> Closure { || () }
     //~^ ERROR: mismatched types
     //~| ERROR: mismatched types
-    //~| ERROR: expected a `FnOnce()` closure, found `()`
+    //~| ERROR: expected an `FnOnce()` closure, found `()`
 }
 
 fn main() {}

--- a/tests/ui/type-alias-impl-trait/issue-63279.stderr
+++ b/tests/ui/type-alias-impl-trait/issue-63279.stderr
@@ -1,4 +1,4 @@
-error[E0277]: expected a `FnOnce()` closure, found `()`
+error[E0277]: expected an `FnOnce()` closure, found `()`
   --> $DIR/issue-63279.rs:6:11
    |
 LL | fn c() -> Closure {
@@ -7,7 +7,7 @@ LL | fn c() -> Closure {
    = help: the trait `FnOnce()` is not implemented for `()`
    = note: wrap the `()` in a closure with no arguments: `|| { /* code */ }`
 
-error[E0277]: expected a `FnOnce()` closure, found `()`
+error[E0277]: expected an `FnOnce()` closure, found `()`
   --> $DIR/issue-63279.rs:8:11
    |
 LL |     || -> Closure { || () }

--- a/tests/ui/type-alias-impl-trait/lazy_subtyping_of_opaques.rs
+++ b/tests/ui/type-alias-impl-trait/lazy_subtyping_of_opaques.rs
@@ -8,10 +8,10 @@ type Tait = impl FnOnce() -> ();
 
 #[define_opaque(Tait)]
 fn reify_as_tait() -> Thunk<Tait> {
-    //~^ ERROR: expected a `FnOnce()` closure, found `()`
+    //~^ ERROR: expected an `FnOnce()` closure, found `()`
     Thunk::new(|cont| cont)
     //~^ ERROR: mismatched types
-    //~| ERROR: expected a `FnOnce()` closure, found `()`
+    //~| ERROR: expected an `FnOnce()` closure, found `()`
 }
 
 struct Thunk<F>(F);

--- a/tests/ui/type-alias-impl-trait/lazy_subtyping_of_opaques.stderr
+++ b/tests/ui/type-alias-impl-trait/lazy_subtyping_of_opaques.stderr
@@ -10,7 +10,7 @@ LL |     Thunk::new(|cont| cont)
    = note: expected struct `Thunk<_>`
            found unit type `()`
 
-error[E0277]: expected a `FnOnce()` closure, found `()`
+error[E0277]: expected an `FnOnce()` closure, found `()`
   --> $DIR/lazy_subtyping_of_opaques.rs:12:23
    |
 LL |     Thunk::new(|cont| cont)
@@ -19,7 +19,7 @@ LL |     Thunk::new(|cont| cont)
    = help: the trait `FnOnce()` is not implemented for `()`
    = note: wrap the `()` in a closure with no arguments: `|| { /* code */ }`
 
-error[E0277]: expected a `FnOnce()` closure, found `()`
+error[E0277]: expected an `FnOnce()` closure, found `()`
   --> $DIR/lazy_subtyping_of_opaques.rs:10:23
    |
 LL | fn reify_as_tait() -> Thunk<Tait> {

--- a/tests/ui/unboxed-closures/unboxed-closures-fnmut-as-fn.stderr
+++ b/tests/ui/unboxed-closures/unboxed-closures-fnmut-as-fn.stderr
@@ -1,4 +1,4 @@
-error[E0277]: expected a `Fn(isize)` closure, found `S`
+error[E0277]: expected an `Fn(isize)` closure, found `S`
   --> $DIR/unboxed-closures-fnmut-as-fn.rs:27:21
    |
 LL |     let x = call_it(&S, 22);

--- a/tests/ui/unboxed-closures/unboxed-closures-unsafe-extern-fn.stderr
+++ b/tests/ui/unboxed-closures/unboxed-closures-unsafe-extern-fn.stderr
@@ -1,4 +1,4 @@
-error[E0277]: expected a `Fn(&isize)` closure, found `for<'a> unsafe fn(&'a isize) -> isize {square}`
+error[E0277]: expected an `Fn(&isize)` closure, found `for<'a> unsafe fn(&'a isize) -> isize {square}`
   --> $DIR/unboxed-closures-unsafe-extern-fn.rs:20:21
    |
 LL |     let x = call_it(&square, 22);
@@ -14,7 +14,7 @@ note: required by a bound in `call_it`
 LL | fn call_it<F: Fn(&isize) -> isize>(_: &F, _: isize) -> isize {
    |               ^^^^^^^^^^^^^^^^^^^ required by this bound in `call_it`
 
-error[E0277]: expected a `FnMut(&isize)` closure, found `for<'a> unsafe fn(&'a isize) -> isize {square}`
+error[E0277]: expected an `FnMut(&isize)` closure, found `for<'a> unsafe fn(&'a isize) -> isize {square}`
   --> $DIR/unboxed-closures-unsafe-extern-fn.rs:25:25
    |
 LL |     let y = call_it_mut(&mut square, 22);
@@ -30,7 +30,7 @@ note: required by a bound in `call_it_mut`
 LL | fn call_it_mut<F: FnMut(&isize) -> isize>(_: &mut F, _: isize) -> isize {
    |                   ^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `call_it_mut`
 
-error[E0277]: expected a `FnOnce(&isize)` closure, found `for<'a> unsafe fn(&'a isize) -> isize {square}`
+error[E0277]: expected an `FnOnce(&isize)` closure, found `for<'a> unsafe fn(&'a isize) -> isize {square}`
   --> $DIR/unboxed-closures-unsafe-extern-fn.rs:30:26
    |
 LL |     let z = call_it_once(square, 22);

--- a/tests/ui/unboxed-closures/unboxed-closures-wrong-abi.stderr
+++ b/tests/ui/unboxed-closures/unboxed-closures-wrong-abi.stderr
@@ -1,4 +1,4 @@
-error[E0277]: expected a `Fn(&isize)` closure, found `for<'a> extern "C" fn(&'a isize) -> isize {square}`
+error[E0277]: expected an `Fn(&isize)` closure, found `for<'a> extern "C" fn(&'a isize) -> isize {square}`
   --> $DIR/unboxed-closures-wrong-abi.rs:20:21
    |
 LL |     let x = call_it(&square, 22);
@@ -13,7 +13,7 @@ note: required by a bound in `call_it`
 LL | fn call_it<F: Fn(&isize) -> isize>(_: &F, _: isize) -> isize {
    |               ^^^^^^^^^^^^^^^^^^^ required by this bound in `call_it`
 
-error[E0277]: expected a `FnMut(&isize)` closure, found `for<'a> extern "C" fn(&'a isize) -> isize {square}`
+error[E0277]: expected an `FnMut(&isize)` closure, found `for<'a> extern "C" fn(&'a isize) -> isize {square}`
   --> $DIR/unboxed-closures-wrong-abi.rs:25:25
    |
 LL |     let y = call_it_mut(&mut square, 22);
@@ -28,7 +28,7 @@ note: required by a bound in `call_it_mut`
 LL | fn call_it_mut<F: FnMut(&isize) -> isize>(_: &mut F, _: isize) -> isize {
    |                   ^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `call_it_mut`
 
-error[E0277]: expected a `FnOnce(&isize)` closure, found `for<'a> extern "C" fn(&'a isize) -> isize {square}`
+error[E0277]: expected an `FnOnce(&isize)` closure, found `for<'a> extern "C" fn(&'a isize) -> isize {square}`
   --> $DIR/unboxed-closures-wrong-abi.rs:30:26
    |
 LL |     let z = call_it_once(square, 22);

--- a/tests/ui/unboxed-closures/unboxed-closures-wrong-arg-type-extern-fn.stderr
+++ b/tests/ui/unboxed-closures/unboxed-closures-wrong-arg-type-extern-fn.stderr
@@ -1,4 +1,4 @@
-error[E0277]: expected a `Fn(&isize)` closure, found `unsafe fn(isize) -> isize {square}`
+error[E0277]: expected an `Fn(&isize)` closure, found `unsafe fn(isize) -> isize {square}`
   --> $DIR/unboxed-closures-wrong-arg-type-extern-fn.rs:21:21
    |
 LL |     let x = call_it(&square, 22);
@@ -14,7 +14,7 @@ note: required by a bound in `call_it`
 LL | fn call_it<F: Fn(&isize) -> isize>(_: &F, _: isize) -> isize {
    |               ^^^^^^^^^^^^^^^^^^^ required by this bound in `call_it`
 
-error[E0277]: expected a `FnMut(&isize)` closure, found `unsafe fn(isize) -> isize {square}`
+error[E0277]: expected an `FnMut(&isize)` closure, found `unsafe fn(isize) -> isize {square}`
   --> $DIR/unboxed-closures-wrong-arg-type-extern-fn.rs:26:25
    |
 LL |     let y = call_it_mut(&mut square, 22);
@@ -30,7 +30,7 @@ note: required by a bound in `call_it_mut`
 LL | fn call_it_mut<F: FnMut(&isize) -> isize>(_: &mut F, _: isize) -> isize {
    |                   ^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `call_it_mut`
 
-error[E0277]: expected a `FnOnce(&isize)` closure, found `unsafe fn(isize) -> isize {square}`
+error[E0277]: expected an `FnOnce(&isize)` closure, found `unsafe fn(isize) -> isize {square}`
   --> $DIR/unboxed-closures-wrong-arg-type-extern-fn.rs:31:26
    |
 LL |     let z = call_it_once(square, 22);


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

This PR fixes a tiny little annoyance typo in error E0277. Currently, this code fails to compile (correctly) with the following error:

```rs
struct A<F: Fn()>(F);

impl<F> A<F> {}

fn main() {}
```

```rs
error[E0277]: expected a `Fn()` closure, found `F`
 --> src/main.rs:3:9
  |
3 | impl<F> A<F> {}
  |         ^^^^ expected an `Fn()` closure, found `F`
  |
  = note: wrap the `F` in a closure with no arguments: `|| { /* code */ }`
... truncated
```


Unfortunately, the first line of the error message uses the article "a", when it should be "an" for the `Fn` trait and friends. The help label does use the correct article, "an".

Unless if I have been pronouncing `Fn` incorrectly...
