### PR TITLE
Fix feature gate for `repr(simd)`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3699,7 +3699,6 @@ dependencies = [
  "rustc_session",
  "rustc_span",
  "rustc_target",
- "thin-vec",
 ]
 
 [[package]]

--- a/compiler/rustc_ast_passes/Cargo.toml
+++ b/compiler/rustc_ast_passes/Cargo.toml
@@ -18,5 +18,4 @@ rustc_macros = { path = "../rustc_macros" }
 rustc_session = { path = "../rustc_session" }
 rustc_span = { path = "../rustc_span" }
 rustc_target = { path = "../rustc_target" }
-thin-vec = "0.2.18"
 # tidy-alphabetical-end

--- a/compiler/rustc_ast_passes/src/feature_gate.rs
+++ b/compiler/rustc_ast_passes/src/feature_gate.rs
@@ -8,7 +8,6 @@ use rustc_hir::attrs::AttributeKind;
 use rustc_session::Session;
 use rustc_session::errors::{feature_err, feature_warn};
 use rustc_span::{Span, Spanned, Symbol, sym};
-use thin_vec::ThinVec;
 
 use crate::diagnostics;
 
@@ -188,21 +187,6 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
             ast::ItemKind::ForeignMod(_foreign_module) => {
                 // handled during lowering
             }
-            ast::ItemKind::Struct(..) | ast::ItemKind::Enum(..) | ast::ItemKind::Union(..) => {
-                for attr in attr::filter_by_name(&i.attrs, sym::repr) {
-                    for item in attr.meta_item_list().unwrap_or_else(ThinVec::new) {
-                        if item.has_name(sym::simd) {
-                            gate!(
-                                self,
-                                repr_simd,
-                                attr.span,
-                                "SIMD types are experimental and possibly buggy"
-                            );
-                        }
-                    }
-                }
-            }
-
             ast::ItemKind::Impl(ast::Impl { of_trait: Some(of_trait), .. }) => {
                 if let ast::ImplPolarity::Negative(span) = of_trait.polarity {
                     gate!(

--- a/compiler/rustc_attr_parsing/src/attributes/repr.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/repr.rs
@@ -3,6 +3,7 @@ use rustc_ast::{IntTy, LitIntType, LitKind, UintTy};
 use rustc_feature::AttributeStability;
 use rustc_hir::attrs::IntType::{SignedInt, UnsignedInt};
 use rustc_hir::attrs::ReprAttr;
+use rustc_session::errors::feature_err;
 
 use super::prelude::*;
 use crate::session_diagnostics;
@@ -141,13 +142,16 @@ fn parse_repr(cx: &mut AcceptContext<'_, '_>, param: &MetaItemParser) -> Option<
             Some(ReprC)
         }
         Some(sym::simd) => {
-            cx.check_target(
-                "(simd)",
-                &AllowedTargets::AllowList(&[
-                    Allow(Target::Struct),   // Feature gated in `rustc_ast_passes`
-                    Warn(Target::MacroCall), // FIXME: This is not feature gated (!!)
-                ]),
-            );
+            if cx.features.is_some_and(|feats| !feats.repr_simd()) {
+                feature_err(
+                    &cx.sess(),
+                    sym::repr_simd,
+                    param.span(),
+                    "SIMD types are experimental and possibly buggy",
+                )
+                .emit();
+            }
+            cx.check_target("(simd)", &AllowedTargets::AllowList(&[Allow(Target::Struct)]));
             cx.expect_no_args(param.args())?;
             Some(ReprSimd)
         }

--- a/tests/ui/attributes/attr-on-mac-call.rs
+++ b/tests/ui/attributes/attr-on-mac-call.rs
@@ -104,8 +104,8 @@ fn main() {
     //~| WARN previously accepted
     unreachable!();
     #[repr(simd)]
-    //~^ WARN attribute cannot be used on macro calls
-    //~| WARN previously accepted
+    //~^ ERROR attribute cannot be used on macro calls
+    //~| ERROR SIMD types are experimental and possibly buggy
     unreachable!();
     #[register_tool(xyz)]
     //~^ ERROR crate-level attribute should be an inner attribute

--- a/tests/ui/attributes/attr-on-mac-call.stderr
+++ b/tests/ui/attributes/attr-on-mac-call.stderr
@@ -7,6 +7,25 @@ LL |     #[sanitize(address = "off")]
    = help: `#[sanitize]` can be applied to crates, functions, impl blocks, modules, and statics
    = note: placing this attribute on a macro invocation does nothing even if the macro expands to what would be a valid target for the attribute
 
+error[E0658]: SIMD types are experimental and possibly buggy
+  --> $DIR/attr-on-mac-call.rs:106:12
+   |
+LL |     #[repr(simd)]
+   |            ^^^^
+   |
+   = note: see issue #27731 <https://github.com/rust-lang/rust/issues/27731> for more information
+   = help: add `#![feature(repr_simd)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: `#[repr(simd)]` attribute cannot be used on macro calls
+  --> $DIR/attr-on-mac-call.rs:106:5
+   |
+LL |     #[repr(simd)]
+   |     ^^^^^^^^^^^^^
+   |
+   = help: `#[repr(simd)]` can only be applied to structs
+   = note: placing this attribute on a macro invocation does nothing even if the macro expands to what would be a valid target for the attribute
+
 error: crate-level attribute should be an inner attribute: add an exclamation mark: `#![register_tool]`
   --> $DIR/attr-on-mac-call.rs:110:5
    |
@@ -322,15 +341,6 @@ LL |     #[repr(Rust)]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: placing this attribute on a macro invocation does nothing even if the macro expands to what would be a valid target for the attribute
 
-warning: `#[repr(simd)]` attribute cannot be used on macro calls
-  --> $DIR/attr-on-mac-call.rs:106:5
-   |
-LL |     #[repr(simd)]
-   |     ^^^^^^^^^^^^^
-   |
-   = help: `#[repr(simd)]` can only be applied to structs
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: placing this attribute on a macro invocation does nothing even if the macro expands to what would be a valid target for the attribute
+error: aborting due to 4 previous errors; 30 warnings emitted
 
-error: aborting due to 2 previous errors; 31 warnings emitted
-
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/feature-gates/feature-gate-repr-simd.stderr
+++ b/tests/ui/feature-gates/feature-gate-repr-simd.stderr
@@ -1,38 +1,28 @@
 error[E0658]: SIMD types are experimental and possibly buggy
-  --> $DIR/feature-gate-repr-simd.rs:1:1
+  --> $DIR/feature-gate-repr-simd.rs:1:8
    |
 LL | #[repr(simd)]
-   | ^^^^^^^^^^^^^
+   |        ^^^^
    |
    = note: see issue #27731 <https://github.com/rust-lang/rust/issues/27731> for more information
    = help: add `#![feature(repr_simd)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: SIMD types are experimental and possibly buggy
-  --> $DIR/feature-gate-repr-simd.rs:6:1
+  --> $DIR/feature-gate-repr-simd.rs:6:8
    |
 LL | #[repr(simd)]
-   | ^^^^^^^^^^^^^
+   |        ^^^^
    |
    = note: see issue #27731 <https://github.com/rust-lang/rust/issues/27731> for more information
    = help: add `#![feature(repr_simd)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: SIMD types are experimental and possibly buggy
-  --> $DIR/feature-gate-repr-simd.rs:9:1
+  --> $DIR/feature-gate-repr-simd.rs:9:8
    |
 LL | #[repr(simd)]
-   | ^^^^^^^^^^^^^
-   |
-   = note: see issue #27731 <https://github.com/rust-lang/rust/issues/27731> for more information
-   = help: add `#![feature(repr_simd)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
-error[E0658]: SIMD types are experimental and possibly buggy
-  --> $DIR/feature-gate-repr-simd.rs:13:1
-   |
-LL | #[repr(simd)]
-   | ^^^^^^^^^^^^^
+   |        ^^^^
    |
    = note: see issue #27731 <https://github.com/rust-lang/rust/issues/27731> for more information
    = help: add `#![feature(repr_simd)]` to the crate attributes to enable
@@ -45,6 +35,16 @@ LL | #[repr(simd)]
    | ^^^^^^^^^^^^^
    |
    = help: `#[repr(simd)]` can only be applied to structs
+
+error[E0658]: SIMD types are experimental and possibly buggy
+  --> $DIR/feature-gate-repr-simd.rs:13:8
+   |
+LL | #[repr(simd)]
+   |        ^^^^
+   |
+   = note: see issue #27731 <https://github.com/rust-lang/rust/issues/27731> for more information
+   = help: add `#![feature(repr_simd)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: `#[repr(simd)]` attribute cannot be used on enums
   --> $DIR/feature-gate-repr-simd.rs:13:1

--- a/tests/ui/feature-gates/feature-gate-simd.stderr
+++ b/tests/ui/feature-gates/feature-gate-simd.stderr
@@ -1,8 +1,8 @@
 error[E0658]: SIMD types are experimental and possibly buggy
-  --> $DIR/feature-gate-simd.rs:1:1
+  --> $DIR/feature-gate-simd.rs:1:8
    |
 LL | #[repr(simd)]
-   | ^^^^^^^^^^^^^
+   |        ^^^^
    |
    = note: see issue #27731 <https://github.com/rust-lang/rust/issues/27731> for more information
    = help: add `#![feature(repr_simd)]` to the crate attributes to enable

--- a/tests/ui/repr/explicit-rust-repr-conflicts.stderr
+++ b/tests/ui/repr/explicit-rust-repr-conflicts.stderr
@@ -1,8 +1,8 @@
 error[E0658]: SIMD types are experimental and possibly buggy
-  --> $DIR/explicit-rust-repr-conflicts.rs:18:1
+  --> $DIR/explicit-rust-repr-conflicts.rs:18:14
    |
 LL | #[repr(Rust, simd)]
-   | ^^^^^^^^^^^^^^^^^^^
+   |              ^^^^
    |
    = note: see issue #27731 <https://github.com/rust-lang/rust/issues/27731> for more information
    = help: add `#![feature(repr_simd)]` to the crate attributes to enable

--- a/tests/ui/repr/issue-83505-repr-simd.stderr
+++ b/tests/ui/repr/issue-83505-repr-simd.stderr
@@ -7,10 +7,10 @@ LL | static CLs: Es;
    |               help: provide a definition for the static: `= <expr>;`
 
 error[E0658]: SIMD types are experimental and possibly buggy
-  --> $DIR/issue-83505-repr-simd.rs:5:1
+  --> $DIR/issue-83505-repr-simd.rs:5:8
    |
 LL | #[repr(simd)]
-   | ^^^^^^^^^^^^^
+   |        ^^^^
    |
    = note: see issue #27731 <https://github.com/rust-lang/rust/issues/27731> for more information
    = help: add `#![feature(repr_simd)]` to the crate attributes to enable

--- a/tests/ui/span/gated-features-attr-spans.stderr
+++ b/tests/ui/span/gated-features-attr-spans.stderr
@@ -1,8 +1,8 @@
 error[E0658]: SIMD types are experimental and possibly buggy
-  --> $DIR/gated-features-attr-spans.rs:1:1
+  --> $DIR/gated-features-attr-spans.rs:1:8
    |
 LL | #[repr(simd)]
-   | ^^^^^^^^^^^^^
+   |        ^^^^
    |
    = note: see issue #27731 <https://github.com/rust-lang/rust/issues/27731> for more information
    = help: add `#![feature(repr_simd)]` to the crate attributes to enable


### PR DESCRIPTION
The following code currently compiles on stable rust:
```rust
#[repr(simd)]
println!()
```

This has the following behavior:
- 1.90 and earlier give an "unused attribute warning"
- 1.91 ..= beta give no diagnostic output
- nightly gives the following:
```
warning: `#[repr(simd)]` attribute cannot be used on macro calls
 --> src/main.rs:4:5
  |
4 |     #[repr(simd)]
  |     ^^^^^^^^^^^^^
  |
  = help: `#[repr(simd)]` can only be applied to structs
  = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
  = note: `#[warn(unused_attributes)]` (part of `#[warn(unused)]`) on by default
```

This PR changes this to a feature gate **error**.
r? @mejrs