### PR TITLE
Instatiate binder instead of skipping when suggesting function arg error

### DIFF
--- a/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
@@ -4872,12 +4872,22 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     })
                 } else if let Some(where_pred) = where_pred.as_projection_clause()
                     && let Some(failed_pred) = failed_pred.as_projection_clause()
-                    && let Some(found) = failed_pred.skip_binder().term.as_type()
+                    && let Some(found) =
+                        failed_pred.map_bound(|pred| pred.term.as_type()).transpose().map(|term| {
+                            self.instantiate_binder_with_fresh_vars(
+                                expr.span,
+                                BoundRegionConversionTime::FnCall,
+                                term,
+                            )
+                        })
                 {
                     type_diffs = vec![TypeError::Sorts(ty::error::ExpectedFound {
-                        expected: where_pred
-                            .skip_binder()
-                            .projection_term
+                        expected: self
+                            .instantiate_binder_with_fresh_vars(
+                                expr.span,
+                                BoundRegionConversionTime::FnCall,
+                                where_pred.map_bound(|pred| pred.projection_term),
+                            )
                             .expect_ty()
                             .to_ty(self.tcx, ty::IsRigid::No),
                         found,

--- a/tests/ui/traits/next-solver/diagnostics/iterator-item-suggest-no-ice.rs
+++ b/tests/ui/traits/next-solver/diagnostics/iterator-item-suggest-no-ice.rs
@@ -1,0 +1,22 @@
+//! Regression test for <https://github.com/rust-lang/rust/issues/158317>
+//@ compile-flags: -Znext-solver
+
+trait FooMut {
+    fn bar<I>(&self, _: I)
+    where
+        for<'b> &'b I: Iterator<Item = &'b ()>;
+
+    fn bar<I>(&self, _: I)
+    //~^ ERROR: the name `bar` is defined multiple times
+    where
+        I: Iterator,
+    {
+        let collection = vec![_I].iter().map(|x| ());
+        //~^ ERROR: cannot find value `_I` in this scope
+        self.bar(collection);
+        //~^ ERROR: `&'b _` is not an iterator
+        //~| ERROR: type mismatch resolving `<&_ as Iterator>::Item == &()`
+    }
+}
+
+fn main() {}

--- a/tests/ui/traits/next-solver/diagnostics/iterator-item-suggest-no-ice.stderr
+++ b/tests/ui/traits/next-solver/diagnostics/iterator-item-suggest-no-ice.stderr
@@ -1,0 +1,71 @@
+error[E0428]: the name `bar` is defined multiple times
+  --> $DIR/iterator-item-suggest-no-ice.rs:9:5
+   |
+LL | /     fn bar<I>(&self, _: I)
+LL | |     where
+LL | |         for<'b> &'b I: Iterator<Item = &'b ()>;
+   | |_______________________________________________- previous definition of the value `bar` here
+LL |
+LL | /     fn bar<I>(&self, _: I)
+LL | |
+LL | |     where
+LL | |         I: Iterator,
+...  |
+LL | |     }
+   | |_____^ `bar` redefined here
+   |
+   = note: `bar` must be defined only once in the value namespace of this trait
+
+error[E0425]: cannot find value `_I` in this scope
+  --> $DIR/iterator-item-suggest-no-ice.rs:14:31
+   |
+LL |         let collection = vec![_I].iter().map(|x| ());
+   |                               ^^ not found in this scope
+
+error[E0277]: `&'b _` is not an iterator
+  --> $DIR/iterator-item-suggest-no-ice.rs:16:18
+   |
+LL |         self.bar(collection);
+   |              --- ^^^^^^^^^^ `&'b _` is not an iterator
+   |              |
+   |              required by a bound introduced by this call
+   |
+   = help: the trait `for<'b> Iterator` is not implemented for `&'b _`
+note: required by a bound in `FooMut::bar`
+  --> $DIR/iterator-item-suggest-no-ice.rs:7:24
+   |
+LL |     fn bar<I>(&self, _: I)
+   |        --- required by a bound in this associated function
+LL |     where
+LL |         for<'b> &'b I: Iterator<Item = &'b ()>;
+   |                        ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `FooMut::bar`
+
+error[E0271]: type mismatch resolving `<&_ as Iterator>::Item == &()`
+  --> $DIR/iterator-item-suggest-no-ice.rs:16:18
+   |
+LL |         self.bar(collection);
+   |              --- ^^^^^^^^^^ types differ
+   |              |
+   |              required by a bound introduced by this call
+   |
+note: the method call chain might not have had the expected associated types
+  --> $DIR/iterator-item-suggest-no-ice.rs:14:35
+   |
+LL |         let collection = vec![_I].iter().map(|x| ());
+   |                          -------- ^^^^^^ ----------- `Iterator::Item` remains `<{type error} as Iterator>::Item` here
+   |                          |        |
+   |                          |        `Iterator::Item` is `<{type error} as Iterator>::Item` here
+   |                          this expression has type `Vec<{type error}>`
+note: required by a bound in `FooMut::bar`
+  --> $DIR/iterator-item-suggest-no-ice.rs:7:33
+   |
+LL |     fn bar<I>(&self, _: I)
+   |        --- required by a bound in this associated function
+LL |     where
+LL |         for<'b> &'b I: Iterator<Item = &'b ()>;
+   |                                 ^^^^^^^^^^^^^ required by this bound in `FooMut::bar`
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0271, E0277, E0425, E0428.
+For more information about an error, try `rustc --explain E0271`.


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/158317

r? lcnr