### PR TITLE
Move `SizeHint` and `IoHandle` to `core::io`

### DIFF
--- a/library/alloc/src/io/impls.rs
+++ b/library/alloc/src/io/impls.rs
@@ -1,0 +1,22 @@
+use crate::boxed::Box;
+use crate::io::SizeHint;
+
+// =============================================================================
+// Forwarding implementations
+
+#[doc(hidden)]
+#[unstable(feature = "core_io_internals", reason = "exposed only for libstd", issue = "none")]
+impl<T> SizeHint for Box<T> {
+    #[inline]
+    fn lower_bound(&self) -> usize {
+        SizeHint::lower_bound(&**self)
+    }
+
+    #[inline]
+    fn upper_bound(&self) -> Option<usize> {
+        SizeHint::upper_bound(&**self)
+    }
+}
+
+// =============================================================================
+// In-memory buffer implementations

--- a/library/alloc/src/io/mod.rs
+++ b/library/alloc/src/io/mod.rs
@@ -1,6 +1,7 @@
 //! Traits, helpers, and type definitions for core I/O functionality.
 
 mod error;
+mod impls;
 
 #[unstable(feature = "raw_os_error_ty", issue = "107792")]
 pub use core::io::RawOsError;
@@ -17,4 +18,4 @@ pub use core::io::{
 };
 #[doc(hidden)]
 #[unstable(feature = "core_io_internals", reason = "exposed only for libstd", issue = "none")]
-pub use core::io::{IoHandle, OsFunctions, chain, take};
+pub use core::io::{IoHandle, OsFunctions, SizeHint, chain, take};

--- a/library/alloc/src/io/mod.rs
+++ b/library/alloc/src/io/mod.rs
@@ -17,4 +17,4 @@ pub use core::io::{
 };
 #[doc(hidden)]
 #[unstable(feature = "core_io_internals", reason = "exposed only for libstd", issue = "none")]
-pub use core::io::{OsFunctions, chain, take};
+pub use core::io::{IoHandle, OsFunctions, chain, take};

--- a/library/core/src/io/impls.rs
+++ b/library/core/src/io/impls.rs
@@ -1,0 +1,35 @@
+use crate::io::SizeHint;
+
+// =============================================================================
+// Forwarding implementations
+
+#[doc(hidden)]
+#[unstable(feature = "core_io_internals", reason = "exposed only for libstd", issue = "none")]
+impl<T> SizeHint for &mut T {
+    #[inline]
+    fn lower_bound(&self) -> usize {
+        SizeHint::lower_bound(*self)
+    }
+
+    #[inline]
+    fn upper_bound(&self) -> Option<usize> {
+        SizeHint::upper_bound(*self)
+    }
+}
+
+// =============================================================================
+// In-memory buffer implementations
+
+#[doc(hidden)]
+#[unstable(feature = "core_io_internals", reason = "exposed only for libstd", issue = "none")]
+impl SizeHint for &[u8] {
+    #[inline]
+    fn lower_bound(&self) -> usize {
+        self.len()
+    }
+
+    #[inline]
+    fn upper_bound(&self) -> Option<usize> {
+        Some(self.len())
+    }
+}

--- a/library/core/src/io/mod.rs
+++ b/library/core/src/io/mod.rs
@@ -3,7 +3,9 @@
 mod borrowed_buf;
 mod cursor;
 mod error;
+mod impls;
 mod io_slice;
+mod size_hint;
 mod util;
 
 #[unstable(feature = "core_io_borrowed_buf", issue = "117693")]
@@ -25,6 +27,7 @@ pub use self::{
 #[unstable(feature = "core_io_internals", reason = "exposed only for libstd", issue = "none")]
 pub use self::{
     error::{Custom, CustomOwner, OsFunctions},
+    size_hint::SizeHint,
     util::{chain, take},
 };
 

--- a/library/core/src/io/mod.rs
+++ b/library/core/src/io/mod.rs
@@ -27,3 +27,23 @@ pub use self::{
     error::{Custom, CustomOwner, OsFunctions},
     util::{chain, take},
 };
+
+/// Marks that a type `T` can have IO traits such as [`Seek`], [`Write`], etc. automatically
+/// implemented for handle types like [`Arc`][arc] as well.
+///
+/// This trait should only be implemented for types where `<&T as Trait>::method(&mut &value, ..)`
+/// would be identical to `<T as Trait>::method(&mut value, ..)`.
+///
+/// [`File`][file] passes this test, as operations on `&File` and `File` both affect
+/// the same underlying file.
+/// `[u8]` fails, because any modification to `&mut &[u8]` would only affect a temporary
+/// and be lost after the method has been called.
+///
+// FIXME(#74481): Hard-links required to link from `core` to `std`
+/// [file]: ../../std/fs/struct.File.html
+/// [arc]: ../../alloc/sync/struct.Arc.html
+/// [`Write`]: ../../std/io/trait.Write.html
+/// [`Seek`]: ../../std/io/trait.Seek.html
+#[doc(hidden)]
+#[unstable(feature = "core_io_internals", reason = "exposed only for libstd", issue = "none")]
+pub trait IoHandle {}

--- a/library/core/src/io/size_hint.rs
+++ b/library/core/src/io/size_hint.rs
@@ -1,0 +1,25 @@
+#[doc(hidden)]
+#[unstable(feature = "core_io_internals", reason = "exposed only for libstd", issue = "none")]
+pub trait SizeHint {
+    fn lower_bound(&self) -> usize;
+
+    fn upper_bound(&self) -> Option<usize>;
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.lower_bound(), self.upper_bound())
+    }
+}
+
+#[doc(hidden)]
+#[unstable(feature = "core_io_internals", reason = "exposed only for libstd", issue = "none")]
+impl<T: ?Sized> SizeHint for T {
+    #[inline]
+    default fn lower_bound(&self) -> usize {
+        0
+    }
+
+    #[inline]
+    default fn upper_bound(&self) -> Option<usize> {
+        None
+    }
+}

--- a/library/core/src/io/size_hint.rs
+++ b/library/core/src/io/size_hint.rs
@@ -1,10 +1,45 @@
+/// Internal trait used to allow for specialization in `Read::size_hint` and
+/// `Iterator::size_hint`.
+///
+/// All types implement this through a blanket default implementation returning
+/// a hint of `(0, None)`.
+///
+/// Implementors should only provide [`lower_bound`](SizeHint::lower_bound) and
+/// [`upper_bound`](SizeHint::upper_bound).
+/// [`size_hint`](SizeHint::size_hint) is provided as a `final` method to enforce
+/// correctness.
 #[doc(hidden)]
 #[unstable(feature = "core_io_internals", reason = "exposed only for libstd", issue = "none")]
 pub trait SizeHint {
+    /// Returns a lower bound on the number of elements this container-like item
+    /// contains.
+    /// For example, an array `[u8; 12]` could return any value between `0` and
+    /// `12` inclusively as a correct implementation.
+    ///
+    /// Through specialization, all types implement this method returning a default
+    /// value of `0`.
+    ///
+    /// Implementations *must* ensure the returned value is less than or equal to
+    /// the true element count.
     fn lower_bound(&self) -> usize;
 
+    /// Returns an upper bound on the number of elements this container-like item
+    /// contains if it can be determined, otherwise `None`.
+    ///
+    /// Through specialization, all types implement this method returning a default
+    /// value of `None`.
+    ///
+    /// Implementations *must* ensure the returned value is greater than or equal
+    /// to the true element count.
     fn upper_bound(&self) -> Option<usize>;
 
+    /// Returns an estimate for the number of elements this container like type
+    /// contains.
+    ///
+    /// This is a `final` method, and is guaranteed to return
+    /// `(self.lower_bound(), self.upper_bound())`.
+    ///
+    /// Without specialization, types implementing this trait will return `(0, None)`.
     final fn size_hint(&self) -> (usize, Option<usize>) {
         (self.lower_bound(), self.upper_bound())
     }

--- a/library/core/src/io/size_hint.rs
+++ b/library/core/src/io/size_hint.rs
@@ -5,7 +5,7 @@ pub trait SizeHint {
 
     fn upper_bound(&self) -> Option<usize>;
 
-    fn size_hint(&self) -> (usize, Option<usize>) {
+    final fn size_hint(&self) -> (usize, Option<usize>) {
         (self.lower_bound(), self.upper_bound())
     }
 }

--- a/library/core/src/io/util.rs
+++ b/library/core/src/io/util.rs
@@ -1,4 +1,5 @@
-use crate::fmt;
+use crate::io::SizeHint;
+use crate::{cmp, fmt};
 
 /// `Empty` ignores any data written via [`Write`], and will always be empty
 /// (returning zero bytes) when read via [`Read`].
@@ -12,6 +13,15 @@ use crate::fmt;
 #[non_exhaustive]
 #[derive(Copy, Clone, Debug, Default)]
 pub struct Empty;
+
+#[doc(hidden)]
+#[unstable(feature = "core_io_internals", reason = "exposed only for libstd", issue = "none")]
+impl SizeHint for Empty {
+    #[inline]
+    fn upper_bound(&self) -> Option<usize> {
+        Some(0)
+    }
+}
 
 /// Creates a value that is always at EOF for reads, and ignores all data written.
 ///
@@ -61,6 +71,20 @@ pub struct Repeat {
     #[doc(hidden)]
     #[unstable(feature = "core_io_internals", reason = "exposed only for libstd", issue = "none")]
     pub byte: u8,
+}
+
+#[doc(hidden)]
+#[unstable(feature = "core_io_internals", reason = "exposed only for libstd", issue = "none")]
+impl SizeHint for Repeat {
+    #[inline]
+    fn lower_bound(&self) -> usize {
+        usize::MAX
+    }
+
+    #[inline]
+    fn upper_bound(&self) -> Option<usize> {
+        None
+    }
 }
 
 /// Creates an instance of a reader that infinitely repeats one byte.
@@ -143,6 +167,23 @@ pub struct Chain<T, U> {
     #[doc(hidden)]
     #[unstable(feature = "core_io_internals", reason = "exposed only for libstd", issue = "none")]
     pub done_first: bool,
+}
+
+#[doc(hidden)]
+#[unstable(feature = "core_io_internals", reason = "exposed only for libstd", issue = "none")]
+impl<T, U> SizeHint for Chain<T, U> {
+    #[inline]
+    fn lower_bound(&self) -> usize {
+        SizeHint::lower_bound(&self.first) + SizeHint::lower_bound(&self.second)
+    }
+
+    #[inline]
+    fn upper_bound(&self) -> Option<usize> {
+        match (SizeHint::upper_bound(&self.first), SizeHint::upper_bound(&self.second)) {
+            (Some(first), Some(second)) => first.checked_add(second),
+            _ => None,
+        }
+    }
 }
 
 impl<T, U> Chain<T, U> {
@@ -251,6 +292,23 @@ pub struct Take<T> {
     #[doc(hidden)]
     #[unstable(feature = "core_io_internals", reason = "exposed only for libstd", issue = "none")]
     pub limit: u64,
+}
+
+#[doc(hidden)]
+#[unstable(feature = "core_io_internals", reason = "exposed only for libstd", issue = "none")]
+impl<T> SizeHint for Take<T> {
+    #[inline]
+    fn lower_bound(&self) -> usize {
+        cmp::min(SizeHint::lower_bound(&self.inner) as u64, self.limit) as usize
+    }
+
+    #[inline]
+    fn upper_bound(&self) -> Option<usize> {
+        match SizeHint::upper_bound(&self.inner) {
+            Some(upper_bound) => Some(cmp::min(upper_bound as u64, self.limit) as usize),
+            None => self.limit.try_into().ok(),
+        }
+    }
 }
 
 impl<T> Take<T> {

--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -1540,6 +1540,8 @@ impl Seek for File {
         (&*self).stream_position()
     }
 }
+#[doc(hidden)]
+#[unstable(feature = "core_io_internals", reason = "exposed only for libstd", issue = "none")]
 impl crate::io::IoHandle for File {}
 
 impl Dir {

--- a/library/std/src/io/buffered/bufreader.rs
+++ b/library/std/src/io/buffered/bufreader.rs
@@ -580,6 +580,8 @@ impl<R: ?Sized + Seek> Seek for BufReader<R> {
     }
 }
 
+#[doc(hidden)]
+#[unstable(feature = "core_io_internals", reason = "exposed only for libstd", issue = "none")]
 impl<T: ?Sized> SizeHint for BufReader<T> {
     #[inline]
     fn lower_bound(&self) -> usize {

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -300,7 +300,6 @@ mod tests;
 use core::slice::memchr;
 
 pub(crate) use alloc_crate::io::IoHandle;
-use alloc_crate::io::OsFunctions;
 #[unstable(feature = "raw_os_error_ty", issue = "107792")]
 pub use alloc_crate::io::RawOsError;
 #[doc(hidden)]
@@ -316,6 +315,7 @@ pub use alloc_crate::io::{
 };
 #[stable(feature = "iovec", since = "1.36.0")]
 pub use alloc_crate::io::{IoSlice, IoSliceMut};
+use alloc_crate::io::{OsFunctions, SizeHint};
 
 #[stable(feature = "bufwriter_into_parts", since = "1.56.0")]
 pub use self::buffered::WriterPanicked;
@@ -2538,21 +2538,6 @@ impl<T: BufRead, U: BufRead> BufRead for Chain<T, U> {
     // split between the two parts of the chain
 }
 
-impl<T, U> SizeHint for Chain<T, U> {
-    #[inline]
-    fn lower_bound(&self) -> usize {
-        SizeHint::lower_bound(&self.first) + SizeHint::lower_bound(&self.second)
-    }
-
-    #[inline]
-    fn upper_bound(&self) -> Option<usize> {
-        match (SizeHint::upper_bound(&self.first), SizeHint::upper_bound(&self.second)) {
-            (Some(first), Some(second)) => first.checked_add(second),
-            _ => None,
-        }
-    }
-}
-
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: Read> Read for Take<T> {
     fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
@@ -2644,21 +2629,6 @@ impl<T: BufRead> BufRead for Take<T> {
         let amt = cmp::min(amt as u64, self.limit) as usize;
         self.limit -= amt as u64;
         self.inner.consume(amt);
-    }
-}
-
-impl<T> SizeHint for Take<T> {
-    #[inline]
-    fn lower_bound(&self) -> usize {
-        cmp::min(SizeHint::lower_bound(&self.inner) as u64, self.limit) as usize
-    }
-
-    #[inline]
-    fn upper_bound(&self) -> Option<usize> {
-        match SizeHint::upper_bound(&self.inner) {
-            Some(upper_bound) => Some(cmp::min(upper_bound as u64, self.limit) as usize),
-            None => self.limit.try_into().ok(),
-        }
     }
 }
 
@@ -2768,64 +2738,6 @@ fn inlined_slow_read_byte<R: Read>(reader: &mut R) -> Option<Result<u8>> {
 #[inline(never)]
 fn uninlined_slow_read_byte<R: Read>(reader: &mut R) -> Option<Result<u8>> {
     inlined_slow_read_byte(reader)
-}
-
-trait SizeHint {
-    fn lower_bound(&self) -> usize;
-
-    fn upper_bound(&self) -> Option<usize>;
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        (self.lower_bound(), self.upper_bound())
-    }
-}
-
-impl<T: ?Sized> SizeHint for T {
-    #[inline]
-    default fn lower_bound(&self) -> usize {
-        0
-    }
-
-    #[inline]
-    default fn upper_bound(&self) -> Option<usize> {
-        None
-    }
-}
-
-impl<T> SizeHint for &mut T {
-    #[inline]
-    fn lower_bound(&self) -> usize {
-        SizeHint::lower_bound(*self)
-    }
-
-    #[inline]
-    fn upper_bound(&self) -> Option<usize> {
-        SizeHint::upper_bound(*self)
-    }
-}
-
-impl<T> SizeHint for Box<T> {
-    #[inline]
-    fn lower_bound(&self) -> usize {
-        SizeHint::lower_bound(&**self)
-    }
-
-    #[inline]
-    fn upper_bound(&self) -> Option<usize> {
-        SizeHint::upper_bound(&**self)
-    }
-}
-
-impl SizeHint for &[u8] {
-    #[inline]
-    fn lower_bound(&self) -> usize {
-        self.len()
-    }
-
-    #[inline]
-    fn upper_bound(&self) -> Option<usize> {
-        Some(self.len())
-    }
 }
 
 /// An iterator over the contents of an instance of `BufRead` split on a

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -299,6 +299,7 @@ mod tests;
 
 use core::slice::memchr;
 
+pub(crate) use alloc_crate::io::IoHandle;
 use alloc_crate::io::OsFunctions;
 #[unstable(feature = "raw_os_error_ty", issue = "107792")]
 pub use alloc_crate::io::RawOsError;
@@ -1979,21 +1980,6 @@ pub enum SeekFrom {
     #[stable(feature = "rust1", since = "1.0.0")]
     Current(#[stable(feature = "rust1", since = "1.0.0")] i64),
 }
-
-/// Marks that a type `T` can have IO traits such as [`Seek`], [`Write`], etc. automatically
-/// implemented for handle types like [`Arc`][arc] as well.
-///
-/// This trait should only be implemented for types where `<&T as Trait>::method(&mut &value, ..)`
-/// would be identical to `<T as Trait>::method(&mut value, ..)`.
-///
-/// [`File`][file] passes this test, as operations on `&File` and `File` both affect
-/// the same underlying file.
-/// `[u8]` fails, because any modification to `&mut &[u8]` would only affect a temporary
-/// and be lost after the method has been called.
-///
-/// [file]: crate::fs::File
-/// [arc]: crate::sync::Arc
-pub(crate) trait IoHandle {}
 
 fn read_until<R: BufRead + ?Sized>(r: &mut R, delim: u8, buf: &mut Vec<u8>) -> Result<usize> {
     let mut read = 0;

--- a/library/std/src/io/util.rs
+++ b/library/std/src/io/util.rs
@@ -6,7 +6,7 @@ mod tests;
 use crate::fmt;
 use crate::io::{
     self, BorrowedCursor, BufRead, Empty, IoSlice, IoSliceMut, Read, Repeat, Seek, SeekFrom, Sink,
-    SizeHint, Write,
+    Write,
 };
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -99,13 +99,6 @@ impl Seek for Empty {
     #[inline]
     fn stream_position(&mut self) -> io::Result<u64> {
         Ok(0)
-    }
-}
-
-impl SizeHint for Empty {
-    #[inline]
-    fn upper_bound(&self) -> Option<usize> {
-        Some(0)
     }
 }
 
@@ -237,18 +230,6 @@ impl Read for Repeat {
     #[inline]
     fn is_read_vectored(&self) -> bool {
         true
-    }
-}
-
-impl SizeHint for Repeat {
-    #[inline]
-    fn lower_bound(&self) -> usize {
-        usize::MAX
-    }
-
-    #[inline]
-    fn upper_bound(&self) -> Option<usize> {
-        None
     }
 }
 


### PR DESCRIPTION
ACP: https://github.com/rust-lang/libs-team/issues/755
Tracking issue: https://github.com/rust-lang/rust/issues/154046
Split From: https://github.com/rust-lang/rust/pull/156527

## Description

Move both of these internal IO traits to `core::io`. Since these are already unstable this is just a simple move with no observable changes.

---

## Notes

* No AI tooling of any kind was used during the creation of this PR.
* Please see https://github.com/rust-lang/rust/issues/154046#issuecomment-4416678427 for a review order and broader context for this PR.
