### PR TITLE
Move `std::io::Seek` to `core::io`

### DIFF
--- a/library/alloc/src/io/impls.rs
+++ b/library/alloc/src/io/impls.rs
@@ -1,5 +1,7 @@
 use crate::boxed::Box;
-use crate::io::SizeHint;
+use crate::io::{self, Seek, SeekFrom, SizeHint};
+#[cfg(all(not(no_rc), not(no_sync), target_has_atomic = "ptr"))]
+use crate::sync::Arc;
 
 // =============================================================================
 // Forwarding implementations
@@ -18,5 +20,66 @@ impl<T> SizeHint for Box<T> {
     }
 }
 
+#[stable(feature = "rust1", since = "1.0.0")]
+impl<S: Seek + ?Sized> Seek for Box<S> {
+    #[inline]
+    fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
+        (**self).seek(pos)
+    }
+
+    #[inline]
+    fn rewind(&mut self) -> io::Result<()> {
+        (**self).rewind()
+    }
+
+    #[inline]
+    fn stream_len(&mut self) -> io::Result<u64> {
+        (**self).stream_len()
+    }
+
+    #[inline]
+    fn stream_position(&mut self) -> io::Result<u64> {
+        (**self).stream_position()
+    }
+
+    #[inline]
+    fn seek_relative(&mut self, offset: i64) -> io::Result<()> {
+        (**self).seek_relative(offset)
+    }
+}
+
 // =============================================================================
 // In-memory buffer implementations
+
+#[cfg(all(not(no_rc), not(no_sync), target_has_atomic = "ptr"))]
+#[stable(feature = "io_traits_arc", since = "1.73.0")]
+impl<S: Seek + ?Sized> Seek for Arc<S>
+where
+    for<'a> &'a S: Seek,
+    S: crate::io::IoHandle,
+{
+    #[inline]
+    fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
+        (&**self).seek(pos)
+    }
+
+    #[inline]
+    fn rewind(&mut self) -> io::Result<()> {
+        (&**self).rewind()
+    }
+
+    #[inline]
+    fn stream_len(&mut self) -> io::Result<u64> {
+        (&**self).stream_len()
+    }
+
+    #[inline]
+    fn stream_position(&mut self) -> io::Result<u64> {
+        (&**self).stream_position()
+    }
+
+    #[inline]
+    fn seek_relative(&mut self, offset: i64) -> io::Result<()> {
+        (&**self).seek_relative(offset)
+    }
+}

--- a/library/alloc/src/io/mod.rs
+++ b/library/alloc/src/io/mod.rs
@@ -13,9 +13,9 @@ pub use core::io::const_error;
 pub use core::io::{BorrowedBuf, BorrowedCursor};
 #[unstable(feature = "alloc_io", issue = "154046")]
 pub use core::io::{
-    Chain, Cursor, Empty, Error, ErrorKind, IoSlice, IoSliceMut, Repeat, Result, SeekFrom, Sink,
-    Take, empty, repeat, sink,
+    Chain, Cursor, Empty, Error, ErrorKind, IoSlice, IoSliceMut, Repeat, Result, Seek, SeekFrom,
+    Sink, Take, empty, repeat, sink,
 };
 #[doc(hidden)]
 #[unstable(feature = "core_io_internals", reason = "exposed only for libstd", issue = "none")]
-pub use core::io::{IoHandle, OsFunctions, SizeHint, chain, take};
+pub use core::io::{IoHandle, OsFunctions, SizeHint, chain, stream_len_default, take};

--- a/library/alloc/src/io/mod.rs
+++ b/library/alloc/src/io/mod.rs
@@ -13,8 +13,8 @@ pub use core::io::const_error;
 pub use core::io::{BorrowedBuf, BorrowedCursor};
 #[unstable(feature = "alloc_io", issue = "154046")]
 pub use core::io::{
-    Chain, Cursor, Empty, Error, ErrorKind, IoSlice, IoSliceMut, Repeat, Result, Sink, Take, empty,
-    repeat, sink,
+    Chain, Cursor, Empty, Error, ErrorKind, IoSlice, IoSliceMut, Repeat, Result, SeekFrom, Sink,
+    Take, empty, repeat, sink,
 };
 #[doc(hidden)]
 #[unstable(feature = "core_io_internals", reason = "exposed only for libstd", issue = "none")]

--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -155,6 +155,7 @@
 #![feature(ptr_metadata)]
 #![feature(raw_os_error_ty)]
 #![feature(rev_into_inner)]
+#![feature(seek_stream_len)]
 #![feature(set_ptr_value)]
 #![feature(share_trait)]
 #![feature(sized_type_properties)]

--- a/library/core/src/io/cursor.rs
+++ b/library/core/src/io/cursor.rs
@@ -1,3 +1,5 @@
+use crate::io::{self, ErrorKind, SeekFrom};
+
 /// A `Cursor` wraps an in-memory buffer and provides it with a
 /// [`Seek`] implementation.
 ///
@@ -289,5 +291,40 @@ where
     fn clone_from(&mut self, other: &Self) {
         self.inner.clone_from(&other.inner);
         self.pos = other.pos;
+    }
+}
+
+#[stable(feature = "rust1", since = "1.0.0")]
+impl<T> io::Seek for Cursor<T>
+where
+    T: AsRef<[u8]>,
+{
+    fn seek(&mut self, style: SeekFrom) -> io::Result<u64> {
+        let (base_pos, offset) = match style {
+            SeekFrom::Start(n) => {
+                self.set_position(n);
+                return Ok(n);
+            }
+            SeekFrom::End(n) => (self.get_ref().as_ref().len() as u64, n),
+            SeekFrom::Current(n) => (self.position(), n),
+        };
+        match base_pos.checked_add_signed(offset) {
+            Some(n) => {
+                self.set_position(n);
+                Ok(n)
+            }
+            None => Err(io::const_error!(
+                ErrorKind::InvalidInput,
+                "invalid seek to a negative or overflowing position",
+            )),
+        }
+    }
+
+    fn stream_len(&mut self) -> io::Result<u64> {
+        Ok(self.get_ref().as_ref().len() as u64)
+    }
+
+    fn stream_position(&mut self) -> io::Result<u64> {
+        Ok(self.position())
     }
 }

--- a/library/core/src/io/cursor.rs
+++ b/library/core/src/io/cursor.rs
@@ -23,7 +23,7 @@ use crate::io::{self, ErrorKind, SeekFrom};
 /// [`File`]: ../../std/fs/struct.File.html
 /// [`Read`]: ../../std/io/trait.Read.html
 /// [`Write`]: ../../std/io/trait.Write.html
-/// [`Seek`]: ../../std/io/trait.Seek.html
+/// [`Seek`]: crate::io::Seek
 /// [Vec]: ../../alloc/vec/struct.Vec.html
 ///
 /// ```no_run

--- a/library/core/src/io/error.rs
+++ b/library/core/src/io/error.rs
@@ -80,7 +80,7 @@ pub type Result<T> = result::Result<T, Error>;
 // FIXME(#74481): Hard-links required to link from `core` to `std`
 /// [Read]: ../../std/io/trait.Read.html
 /// [Write]: ../../std/io/trait.Write.html
-/// [Seek]: ../../std/io/trait.Seek.html
+/// [Seek]: crate::io::Seek
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_has_incoherent_inherent_impls]
 pub struct Error {

--- a/library/core/src/io/impls.rs
+++ b/library/core/src/io/impls.rs
@@ -1,4 +1,4 @@
-use crate::io::SizeHint;
+use crate::io::{self, Seek, SeekFrom, SizeHint};
 
 // =============================================================================
 // Forwarding implementations
@@ -14,6 +14,34 @@ impl<T> SizeHint for &mut T {
     #[inline]
     fn upper_bound(&self) -> Option<usize> {
         SizeHint::upper_bound(*self)
+    }
+}
+
+#[stable(feature = "rust1", since = "1.0.0")]
+impl<S: Seek + ?Sized> Seek for &mut S {
+    #[inline]
+    fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
+        (**self).seek(pos)
+    }
+
+    #[inline]
+    fn rewind(&mut self) -> io::Result<()> {
+        (**self).rewind()
+    }
+
+    #[inline]
+    fn stream_len(&mut self) -> io::Result<u64> {
+        (**self).stream_len()
+    }
+
+    #[inline]
+    fn stream_position(&mut self) -> io::Result<u64> {
+        (**self).stream_position()
+    }
+
+    #[inline]
+    fn seek_relative(&mut self, offset: i64) -> io::Result<()> {
+        (**self).seek_relative(offset)
     }
 }
 

--- a/library/core/src/io/mod.rs
+++ b/library/core/src/io/mod.rs
@@ -5,6 +5,7 @@ mod cursor;
 mod error;
 mod impls;
 mod io_slice;
+mod seek;
 mod size_hint;
 mod util;
 
@@ -21,6 +22,7 @@ pub use self::{
     cursor::Cursor,
     error::{Error, ErrorKind, Result},
     io_slice::{IoSlice, IoSliceMut},
+    seek::SeekFrom,
     util::{Chain, Empty, Repeat, Sink, Take, empty, repeat, sink},
 };
 #[doc(hidden)]

--- a/library/core/src/io/mod.rs
+++ b/library/core/src/io/mod.rs
@@ -22,13 +22,14 @@ pub use self::{
     cursor::Cursor,
     error::{Error, ErrorKind, Result},
     io_slice::{IoSlice, IoSliceMut},
-    seek::SeekFrom,
+    seek::{Seek, SeekFrom},
     util::{Chain, Empty, Repeat, Sink, Take, empty, repeat, sink},
 };
 #[doc(hidden)]
 #[unstable(feature = "core_io_internals", reason = "exposed only for libstd", issue = "none")]
 pub use self::{
     error::{Custom, CustomOwner, OsFunctions},
+    seek::stream_len_default,
     size_hint::SizeHint,
     util::{chain, take},
 };

--- a/library/core/src/io/mod.rs
+++ b/library/core/src/io/mod.rs
@@ -49,7 +49,7 @@ pub use self::{
 /// [file]: ../../std/fs/struct.File.html
 /// [arc]: ../../alloc/sync/struct.Arc.html
 /// [`Write`]: ../../std/io/trait.Write.html
-/// [`Seek`]: ../../std/io/trait.Seek.html
+/// [`Seek`]: crate::io::Seek
 #[doc(hidden)]
 #[unstable(feature = "core_io_internals", reason = "exposed only for libstd", issue = "none")]
 pub trait IoHandle {}

--- a/library/core/src/io/seek.rs
+++ b/library/core/src/io/seek.rs
@@ -1,8 +1,197 @@
+use crate::io::Result;
+
+/// The `Seek` trait provides a cursor which can be moved within a stream of
+/// bytes.
+///
+/// The stream typically has a fixed size, allowing seeking relative to either
+/// end or the current offset.
+///
+/// # Examples
+///
+/// `File`s implement `Seek`:
+///
+/// ```no_run
+/// use std::io;
+/// use std::io::prelude::*;
+/// use std::fs::File;
+/// use std::io::SeekFrom;
+///
+/// fn main() -> io::Result<()> {
+///     let mut f = File::open("foo.txt")?;
+///
+///     // move the cursor 42 bytes from the start of the file
+///     f.seek(SeekFrom::Start(42))?;
+///     Ok(())
+/// }
+/// ```
+#[stable(feature = "rust1", since = "1.0.0")]
+#[cfg_attr(not(test), rustc_diagnostic_item = "IoSeek")]
+pub trait Seek {
+    /// Seek to an offset, in bytes, in a stream.
+    ///
+    /// A seek beyond the end of a stream is allowed, but behavior is defined
+    /// by the implementation.
+    ///
+    /// If the seek operation completed successfully,
+    /// this method returns the new position from the start of the stream.
+    /// That position can be used later with [`SeekFrom::Start`].
+    ///
+    /// # Errors
+    ///
+    /// Seeking can fail, for example because it might involve flushing a buffer.
+    ///
+    /// Seeking to a negative offset is considered an error.
+    #[stable(feature = "rust1", since = "1.0.0")]
+    fn seek(&mut self, pos: SeekFrom) -> Result<u64>;
+
+    /// Rewind to the beginning of a stream.
+    ///
+    /// This is a convenience method, equivalent to `seek(SeekFrom::Start(0))`.
+    ///
+    /// # Errors
+    ///
+    /// Rewinding can fail, for example because it might involve flushing a buffer.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use std::io::{Read, Seek, Write};
+    /// use std::fs::OpenOptions;
+    ///
+    /// let mut f = OpenOptions::new()
+    ///     .write(true)
+    ///     .read(true)
+    ///     .create(true)
+    ///     .open("foo.txt")?;
+    ///
+    /// let hello = "Hello!\n";
+    /// write!(f, "{hello}")?;
+    /// f.rewind()?;
+    ///
+    /// let mut buf = String::new();
+    /// f.read_to_string(&mut buf)?;
+    /// assert_eq!(&buf, hello);
+    /// # std::io::Result::Ok(())
+    /// ```
+    #[stable(feature = "seek_rewind", since = "1.55.0")]
+    fn rewind(&mut self) -> Result<()> {
+        self.seek(SeekFrom::Start(0))?;
+        Ok(())
+    }
+
+    /// Returns the length of this stream (in bytes).
+    ///
+    /// The default implementation uses up to three seek operations. If this
+    /// method returns successfully, the seek position is unchanged (i.e. the
+    /// position before calling this method is the same as afterwards).
+    /// However, if this method returns an error, the seek position is
+    /// unspecified.
+    ///
+    /// If you need to obtain the length of *many* streams and you don't care
+    /// about the seek position afterwards, you can reduce the number of seek
+    /// operations by simply calling `seek(SeekFrom::End(0))` and using its
+    /// return value (it is also the stream length).
+    ///
+    /// Note that length of a stream can change over time (for example, when
+    /// data is appended to a file). So calling this method multiple times does
+    /// not necessarily return the same length each time.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// #![feature(seek_stream_len)]
+    /// use std::{
+    ///     io::{self, Seek},
+    ///     fs::File,
+    /// };
+    ///
+    /// fn main() -> io::Result<()> {
+    ///     let mut f = File::open("foo.txt")?;
+    ///
+    ///     let len = f.stream_len()?;
+    ///     println!("The file is currently {len} bytes long");
+    ///     Ok(())
+    /// }
+    /// ```
+    #[unstable(feature = "seek_stream_len", issue = "59359")]
+    fn stream_len(&mut self) -> Result<u64> {
+        stream_len_default(self)
+    }
+
+    /// Returns the current seek position from the start of the stream.
+    ///
+    /// This is equivalent to `self.seek(SeekFrom::Current(0))`.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use std::{
+    ///     io::{self, BufRead, BufReader, Seek},
+    ///     fs::File,
+    /// };
+    ///
+    /// fn main() -> io::Result<()> {
+    ///     let mut f = BufReader::new(File::open("foo.txt")?);
+    ///
+    ///     let before = f.stream_position()?;
+    ///     f.read_line(&mut String::new())?;
+    ///     let after = f.stream_position()?;
+    ///
+    ///     println!("The first line was {} bytes long", after - before);
+    ///     Ok(())
+    /// }
+    /// ```
+    #[stable(feature = "seek_convenience", since = "1.51.0")]
+    fn stream_position(&mut self) -> Result<u64> {
+        self.seek(SeekFrom::Current(0))
+    }
+
+    /// Seeks relative to the current position.
+    ///
+    /// This is equivalent to `self.seek(SeekFrom::Current(offset))` but
+    /// doesn't return the new position which can allow some implementations
+    /// such as `BufReader` to perform more efficient seeks.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use std::{
+    ///     io::{self, Seek},
+    ///     fs::File,
+    /// };
+    ///
+    /// fn main() -> io::Result<()> {
+    ///     let mut f = File::open("foo.txt")?;
+    ///     f.seek_relative(10)?;
+    ///     assert_eq!(f.stream_position()?, 10);
+    ///     Ok(())
+    /// }
+    /// ```
+    #[stable(feature = "seek_seek_relative", since = "1.80.0")]
+    fn seek_relative(&mut self, offset: i64) -> Result<()> {
+        self.seek(SeekFrom::Current(offset))?;
+        Ok(())
+    }
+}
+
+#[doc(hidden)]
+#[unstable(feature = "core_io_internals", reason = "exposed only for libstd", issue = "none")]
+pub fn stream_len_default<T: Seek + ?Sized>(self_: &mut T) -> Result<u64> {
+    let old_pos = self_.stream_position()?;
+    let len = self_.seek(SeekFrom::End(0))?;
+
+    // Avoid seeking a third time when we were already at the end of the
+    // stream. The branch is usually way cheaper than a seek operation.
+    if old_pos != len {
+        self_.seek(SeekFrom::Start(old_pos))?;
+    }
+
+    Ok(len)
+}
+
 /// Enumeration of possible methods to seek within an I/O object.
 ///
 /// It is used by the [`Seek`] trait.
-///
-/// [`Seek`]: ../../std/io/trait.Seek.html
 #[derive(Copy, PartialEq, Eq, Clone, Debug)]
 #[stable(feature = "rust1", since = "1.0.0")]
 #[cfg_attr(not(test), rustc_diagnostic_item = "SeekFrom")]

--- a/library/core/src/io/seek.rs
+++ b/library/core/src/io/seek.rs
@@ -1,0 +1,29 @@
+/// Enumeration of possible methods to seek within an I/O object.
+///
+/// It is used by the [`Seek`] trait.
+///
+/// [`Seek`]: ../../std/io/trait.Seek.html
+#[derive(Copy, PartialEq, Eq, Clone, Debug)]
+#[stable(feature = "rust1", since = "1.0.0")]
+#[cfg_attr(not(test), rustc_diagnostic_item = "SeekFrom")]
+pub enum SeekFrom {
+    /// Sets the offset to the provided number of bytes.
+    #[stable(feature = "rust1", since = "1.0.0")]
+    Start(#[stable(feature = "rust1", since = "1.0.0")] u64),
+
+    /// Sets the offset to the size of this object plus the specified number of
+    /// bytes.
+    ///
+    /// It is possible to seek beyond the end of an object, but it's an error to
+    /// seek before byte 0.
+    #[stable(feature = "rust1", since = "1.0.0")]
+    End(#[stable(feature = "rust1", since = "1.0.0")] i64),
+
+    /// Sets the offset to the current position plus the specified number of
+    /// bytes.
+    ///
+    /// It is possible to seek beyond the end of an object, but it's an error to
+    /// seek before byte 0.
+    #[stable(feature = "rust1", since = "1.0.0")]
+    Current(#[stable(feature = "rust1", since = "1.0.0")] i64),
+}

--- a/library/core/src/io/seek.rs
+++ b/library/core/src/io/seek.rs
@@ -174,6 +174,9 @@ pub trait Seek {
     }
 }
 
+/// The default implementation of [`Seek::stream_len`].
+/// This may be desirable in `libstd` where the default implementation is desirable,
+/// but additional work needs to be done before or after.
 #[doc(hidden)]
 #[unstable(feature = "core_io_internals", reason = "exposed only for libstd", issue = "none")]
 pub fn stream_len_default<T: Seek + ?Sized>(self_: &mut T) -> Result<u64> {

--- a/library/core/src/io/util.rs
+++ b/library/core/src/io/util.rs
@@ -1,4 +1,4 @@
-use crate::io::SizeHint;
+use crate::io::{ErrorKind, Result, Seek, SeekFrom, SizeHint};
 use crate::{cmp, fmt};
 
 /// `Empty` ignores any data written via [`Write`], and will always be empty
@@ -20,6 +20,24 @@ impl SizeHint for Empty {
     #[inline]
     fn upper_bound(&self) -> Option<usize> {
         Some(0)
+    }
+}
+
+#[stable(feature = "empty_seek", since = "1.51.0")]
+impl Seek for Empty {
+    #[inline]
+    fn seek(&mut self, _pos: SeekFrom) -> Result<u64> {
+        Ok(0)
+    }
+
+    #[inline]
+    fn stream_len(&mut self) -> Result<u64> {
+        Ok(0)
+    }
+
+    #[inline]
+    fn stream_position(&mut self) -> Result<u64> {
+        Ok(0)
     }
 }
 
@@ -461,6 +479,49 @@ impl<T> Take<T> {
     #[stable(feature = "more_io_inner_methods", since = "1.20.0")]
     pub fn get_mut(&mut self) -> &mut T {
         &mut self.inner
+    }
+}
+
+#[stable(feature = "seek_io_take", since = "1.89.0")]
+impl<T: Seek> Seek for Take<T> {
+    fn seek(&mut self, pos: SeekFrom) -> Result<u64> {
+        let new_position = match pos {
+            SeekFrom::Start(v) => Some(v),
+            SeekFrom::Current(v) => self.position().checked_add_signed(v),
+            SeekFrom::End(v) => self.len.checked_add_signed(v),
+        };
+        let new_position = match new_position {
+            Some(v) if v <= self.len => v,
+            _ => return Err(ErrorKind::InvalidInput.into()),
+        };
+        while new_position != self.position() {
+            if let Some(offset) = new_position.checked_signed_diff(self.position()) {
+                self.inner.seek_relative(offset)?;
+                self.limit = self.limit.wrapping_sub(offset as u64);
+                break;
+            }
+            let offset = if new_position > self.position() { i64::MAX } else { i64::MIN };
+            self.inner.seek_relative(offset)?;
+            self.limit = self.limit.wrapping_sub(offset as u64);
+        }
+        Ok(new_position)
+    }
+
+    fn stream_len(&mut self) -> Result<u64> {
+        Ok(self.len)
+    }
+
+    fn stream_position(&mut self) -> Result<u64> {
+        Ok(self.position())
+    }
+
+    fn seek_relative(&mut self, offset: i64) -> Result<()> {
+        if !self.position().checked_add_signed(offset).is_some_and(|p| p <= self.len) {
+            return Err(ErrorKind::InvalidInput.into());
+        }
+        self.inner.seek_relative(offset)?;
+        self.limit = self.limit.wrapping_sub(offset as u64);
+        Ok(())
     }
 }
 

--- a/library/std/src/io/cursor.rs
+++ b/library/std/src/io/cursor.rs
@@ -7,42 +7,7 @@ pub use core::io::Cursor;
 use crate::alloc::Allocator;
 use crate::cmp;
 use crate::io::prelude::*;
-use crate::io::{self, BorrowedCursor, ErrorKind, IoSlice, IoSliceMut, SeekFrom};
-
-#[stable(feature = "rust1", since = "1.0.0")]
-impl<T> io::Seek for Cursor<T>
-where
-    T: AsRef<[u8]>,
-{
-    fn seek(&mut self, style: SeekFrom) -> io::Result<u64> {
-        let (base_pos, offset) = match style {
-            SeekFrom::Start(n) => {
-                self.set_position(n);
-                return Ok(n);
-            }
-            SeekFrom::End(n) => (self.get_ref().as_ref().len() as u64, n),
-            SeekFrom::Current(n) => (self.position(), n),
-        };
-        match base_pos.checked_add_signed(offset) {
-            Some(n) => {
-                self.set_position(n);
-                Ok(n)
-            }
-            None => Err(io::const_error!(
-                ErrorKind::InvalidInput,
-                "invalid seek to a negative or overflowing position",
-            )),
-        }
-    }
-
-    fn stream_len(&mut self) -> io::Result<u64> {
-        Ok(self.get_ref().as_ref().len() as u64)
-    }
-
-    fn stream_position(&mut self) -> io::Result<u64> {
-        Ok(self.position())
-    }
-}
+use crate::io::{self, BorrowedCursor, ErrorKind, IoSlice, IoSliceMut};
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T> Read for Cursor<T>

--- a/library/std/src/io/impls.rs
+++ b/library/std/src/io/impls.rs
@@ -3,7 +3,7 @@ mod tests;
 
 use crate::alloc::Allocator;
 use crate::collections::VecDeque;
-use crate::io::{self, BorrowedCursor, BufRead, IoSlice, IoSliceMut, Read, Seek, SeekFrom, Write};
+use crate::io::{self, BorrowedCursor, BufRead, IoSlice, IoSliceMut, Read, Write};
 use crate::sync::Arc;
 use crate::{cmp, fmt, mem, str};
 
@@ -87,33 +87,6 @@ impl<W: Write + ?Sized> Write for &mut W {
     #[inline]
     fn write_fmt(&mut self, fmt: fmt::Arguments<'_>) -> io::Result<()> {
         (**self).write_fmt(fmt)
-    }
-}
-#[stable(feature = "rust1", since = "1.0.0")]
-impl<S: Seek + ?Sized> Seek for &mut S {
-    #[inline]
-    fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
-        (**self).seek(pos)
-    }
-
-    #[inline]
-    fn rewind(&mut self) -> io::Result<()> {
-        (**self).rewind()
-    }
-
-    #[inline]
-    fn stream_len(&mut self) -> io::Result<u64> {
-        (**self).stream_len()
-    }
-
-    #[inline]
-    fn stream_position(&mut self) -> io::Result<u64> {
-        (**self).stream_position()
-    }
-
-    #[inline]
-    fn seek_relative(&mut self, offset: i64) -> io::Result<()> {
-        (**self).seek_relative(offset)
     }
 }
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -226,33 +199,6 @@ impl<W: Write + ?Sized> Write for Box<W> {
     #[inline]
     fn write_fmt(&mut self, fmt: fmt::Arguments<'_>) -> io::Result<()> {
         (**self).write_fmt(fmt)
-    }
-}
-#[stable(feature = "rust1", since = "1.0.0")]
-impl<S: Seek + ?Sized> Seek for Box<S> {
-    #[inline]
-    fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
-        (**self).seek(pos)
-    }
-
-    #[inline]
-    fn rewind(&mut self) -> io::Result<()> {
-        (**self).rewind()
-    }
-
-    #[inline]
-    fn stream_len(&mut self) -> io::Result<u64> {
-        (**self).stream_len()
-    }
-
-    #[inline]
-    fn stream_position(&mut self) -> io::Result<u64> {
-        (**self).stream_position()
-    }
-
-    #[inline]
-    fn seek_relative(&mut self, offset: i64) -> io::Result<()> {
-        (**self).seek_relative(offset)
     }
 }
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -802,36 +748,5 @@ where
     #[inline]
     fn write_fmt(&mut self, fmt: fmt::Arguments<'_>) -> io::Result<()> {
         (&**self).write_fmt(fmt)
-    }
-}
-#[stable(feature = "io_traits_arc", since = "1.73.0")]
-impl<S: Seek + ?Sized> Seek for Arc<S>
-where
-    for<'a> &'a S: Seek,
-    S: crate::io::IoHandle,
-{
-    #[inline]
-    fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
-        (&**self).seek(pos)
-    }
-
-    #[inline]
-    fn rewind(&mut self) -> io::Result<()> {
-        (&**self).rewind()
-    }
-
-    #[inline]
-    fn stream_len(&mut self) -> io::Result<u64> {
-        (&**self).stream_len()
-    }
-
-    #[inline]
-    fn stream_position(&mut self) -> io::Result<u64> {
-        (&**self).stream_position()
-    }
-
-    #[inline]
-    fn seek_relative(&mut self, offset: i64) -> io::Result<()> {
-        (&**self).seek_relative(offset)
     }
 }

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -311,7 +311,7 @@ pub use alloc_crate::io::const_error;
 pub use alloc_crate::io::{BorrowedBuf, BorrowedCursor};
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use alloc_crate::io::{
-    Chain, Empty, Error, ErrorKind, Repeat, Result, Sink, Take, empty, repeat, sink,
+    Chain, Empty, Error, ErrorKind, Repeat, Result, SeekFrom, Sink, Take, empty, repeat, sink,
 };
 #[stable(feature = "iovec", since = "1.36.0")]
 pub use alloc_crate::io::{IoSlice, IoSliceMut};
@@ -1951,34 +1951,6 @@ pub(crate) fn stream_len_default<T: Seek + ?Sized>(self_: &mut T) -> Result<u64>
     }
 
     Ok(len)
-}
-
-/// Enumeration of possible methods to seek within an I/O object.
-///
-/// It is used by the [`Seek`] trait.
-#[derive(Copy, PartialEq, Eq, Clone, Debug)]
-#[stable(feature = "rust1", since = "1.0.0")]
-#[cfg_attr(not(test), rustc_diagnostic_item = "SeekFrom")]
-pub enum SeekFrom {
-    /// Sets the offset to the provided number of bytes.
-    #[stable(feature = "rust1", since = "1.0.0")]
-    Start(#[stable(feature = "rust1", since = "1.0.0")] u64),
-
-    /// Sets the offset to the size of this object plus the specified number of
-    /// bytes.
-    ///
-    /// It is possible to seek beyond the end of an object, but it's an error to
-    /// seek before byte 0.
-    #[stable(feature = "rust1", since = "1.0.0")]
-    End(#[stable(feature = "rust1", since = "1.0.0")] i64),
-
-    /// Sets the offset to the current position plus the specified number of
-    /// bytes.
-    ///
-    /// It is possible to seek beyond the end of an object, but it's an error to
-    /// seek before byte 0.
-    #[stable(feature = "rust1", since = "1.0.0")]
-    Current(#[stable(feature = "rust1", since = "1.0.0")] i64),
 }
 
 fn read_until<R: BufRead + ?Sized>(r: &mut R, delim: u8, buf: &mut Vec<u8>) -> Result<usize> {

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -299,7 +299,6 @@ mod tests;
 
 use core::slice::memchr;
 
-pub(crate) use alloc_crate::io::IoHandle;
 #[unstable(feature = "raw_os_error_ty", issue = "107792")]
 pub use alloc_crate::io::RawOsError;
 #[doc(hidden)]
@@ -311,8 +310,9 @@ pub use alloc_crate::io::const_error;
 pub use alloc_crate::io::{BorrowedBuf, BorrowedCursor};
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use alloc_crate::io::{
-    Chain, Empty, Error, ErrorKind, Repeat, Result, SeekFrom, Sink, Take, empty, repeat, sink,
+    Chain, Empty, Error, ErrorKind, Repeat, Result, Seek, SeekFrom, Sink, Take, empty, repeat, sink,
 };
+pub(crate) use alloc_crate::io::{IoHandle, stream_len_default};
 #[stable(feature = "iovec", since = "1.36.0")]
 pub use alloc_crate::io::{IoSlice, IoSliceMut};
 use alloc_crate::io::{OsFunctions, SizeHint};
@@ -1762,197 +1762,6 @@ pub trait Write {
     }
 }
 
-/// The `Seek` trait provides a cursor which can be moved within a stream of
-/// bytes.
-///
-/// The stream typically has a fixed size, allowing seeking relative to either
-/// end or the current offset.
-///
-/// # Examples
-///
-/// [`File`]s implement `Seek`:
-///
-/// [`File`]: crate::fs::File
-///
-/// ```no_run
-/// use std::io;
-/// use std::io::prelude::*;
-/// use std::fs::File;
-/// use std::io::SeekFrom;
-///
-/// fn main() -> io::Result<()> {
-///     let mut f = File::open("foo.txt")?;
-///
-///     // move the cursor 42 bytes from the start of the file
-///     f.seek(SeekFrom::Start(42))?;
-///     Ok(())
-/// }
-/// ```
-#[stable(feature = "rust1", since = "1.0.0")]
-#[cfg_attr(not(test), rustc_diagnostic_item = "IoSeek")]
-pub trait Seek {
-    /// Seek to an offset, in bytes, in a stream.
-    ///
-    /// A seek beyond the end of a stream is allowed, but behavior is defined
-    /// by the implementation.
-    ///
-    /// If the seek operation completed successfully,
-    /// this method returns the new position from the start of the stream.
-    /// That position can be used later with [`SeekFrom::Start`].
-    ///
-    /// # Errors
-    ///
-    /// Seeking can fail, for example because it might involve flushing a buffer.
-    ///
-    /// Seeking to a negative offset is considered an error.
-    #[stable(feature = "rust1", since = "1.0.0")]
-    fn seek(&mut self, pos: SeekFrom) -> Result<u64>;
-
-    /// Rewind to the beginning of a stream.
-    ///
-    /// This is a convenience method, equivalent to `seek(SeekFrom::Start(0))`.
-    ///
-    /// # Errors
-    ///
-    /// Rewinding can fail, for example because it might involve flushing a buffer.
-    ///
-    /// # Example
-    ///
-    /// ```no_run
-    /// use std::io::{Read, Seek, Write};
-    /// use std::fs::OpenOptions;
-    ///
-    /// let mut f = OpenOptions::new()
-    ///     .write(true)
-    ///     .read(true)
-    ///     .create(true)
-    ///     .open("foo.txt")?;
-    ///
-    /// let hello = "Hello!\n";
-    /// write!(f, "{hello}")?;
-    /// f.rewind()?;
-    ///
-    /// let mut buf = String::new();
-    /// f.read_to_string(&mut buf)?;
-    /// assert_eq!(&buf, hello);
-    /// # std::io::Result::Ok(())
-    /// ```
-    #[stable(feature = "seek_rewind", since = "1.55.0")]
-    fn rewind(&mut self) -> Result<()> {
-        self.seek(SeekFrom::Start(0))?;
-        Ok(())
-    }
-
-    /// Returns the length of this stream (in bytes).
-    ///
-    /// The default implementation uses up to three seek operations. If this
-    /// method returns successfully, the seek position is unchanged (i.e. the
-    /// position before calling this method is the same as afterwards).
-    /// However, if this method returns an error, the seek position is
-    /// unspecified.
-    ///
-    /// If you need to obtain the length of *many* streams and you don't care
-    /// about the seek position afterwards, you can reduce the number of seek
-    /// operations by simply calling `seek(SeekFrom::End(0))` and using its
-    /// return value (it is also the stream length).
-    ///
-    /// Note that length of a stream can change over time (for example, when
-    /// data is appended to a file). So calling this method multiple times does
-    /// not necessarily return the same length each time.
-    ///
-    /// # Example
-    ///
-    /// ```no_run
-    /// #![feature(seek_stream_len)]
-    /// use std::{
-    ///     io::{self, Seek},
-    ///     fs::File,
-    /// };
-    ///
-    /// fn main() -> io::Result<()> {
-    ///     let mut f = File::open("foo.txt")?;
-    ///
-    ///     let len = f.stream_len()?;
-    ///     println!("The file is currently {len} bytes long");
-    ///     Ok(())
-    /// }
-    /// ```
-    #[unstable(feature = "seek_stream_len", issue = "59359")]
-    fn stream_len(&mut self) -> Result<u64> {
-        stream_len_default(self)
-    }
-
-    /// Returns the current seek position from the start of the stream.
-    ///
-    /// This is equivalent to `self.seek(SeekFrom::Current(0))`.
-    ///
-    /// # Example
-    ///
-    /// ```no_run
-    /// use std::{
-    ///     io::{self, BufRead, BufReader, Seek},
-    ///     fs::File,
-    /// };
-    ///
-    /// fn main() -> io::Result<()> {
-    ///     let mut f = BufReader::new(File::open("foo.txt")?);
-    ///
-    ///     let before = f.stream_position()?;
-    ///     f.read_line(&mut String::new())?;
-    ///     let after = f.stream_position()?;
-    ///
-    ///     println!("The first line was {} bytes long", after - before);
-    ///     Ok(())
-    /// }
-    /// ```
-    #[stable(feature = "seek_convenience", since = "1.51.0")]
-    fn stream_position(&mut self) -> Result<u64> {
-        self.seek(SeekFrom::Current(0))
-    }
-
-    /// Seeks relative to the current position.
-    ///
-    /// This is equivalent to `self.seek(SeekFrom::Current(offset))` but
-    /// doesn't return the new position which can allow some implementations
-    /// such as [`BufReader`] to perform more efficient seeks.
-    ///
-    /// # Example
-    ///
-    /// ```no_run
-    /// use std::{
-    ///     io::{self, Seek},
-    ///     fs::File,
-    /// };
-    ///
-    /// fn main() -> io::Result<()> {
-    ///     let mut f = File::open("foo.txt")?;
-    ///     f.seek_relative(10)?;
-    ///     assert_eq!(f.stream_position()?, 10);
-    ///     Ok(())
-    /// }
-    /// ```
-    ///
-    /// [`BufReader`]: crate::io::BufReader
-    #[stable(feature = "seek_seek_relative", since = "1.80.0")]
-    fn seek_relative(&mut self, offset: i64) -> Result<()> {
-        self.seek(SeekFrom::Current(offset))?;
-        Ok(())
-    }
-}
-
-pub(crate) fn stream_len_default<T: Seek + ?Sized>(self_: &mut T) -> Result<u64> {
-    let old_pos = self_.stream_position()?;
-    let len = self_.seek(SeekFrom::End(0))?;
-
-    // Avoid seeking a third time when we were already at the end of the
-    // stream. The branch is usually way cheaper than a seek operation.
-    if old_pos != len {
-        self_.seek(SeekFrom::Start(old_pos))?;
-    }
-
-    Ok(len)
-}
-
 fn read_until<R: BufRead + ?Sized>(r: &mut R, delim: u8, buf: &mut Vec<u8>) -> Result<usize> {
     let mut read = 0;
     loop {
@@ -2601,49 +2410,6 @@ impl<T: BufRead> BufRead for Take<T> {
         let amt = cmp::min(amt as u64, self.limit) as usize;
         self.limit -= amt as u64;
         self.inner.consume(amt);
-    }
-}
-
-#[stable(feature = "seek_io_take", since = "1.89.0")]
-impl<T: Seek> Seek for Take<T> {
-    fn seek(&mut self, pos: SeekFrom) -> Result<u64> {
-        let new_position = match pos {
-            SeekFrom::Start(v) => Some(v),
-            SeekFrom::Current(v) => self.position().checked_add_signed(v),
-            SeekFrom::End(v) => self.len.checked_add_signed(v),
-        };
-        let new_position = match new_position {
-            Some(v) if v <= self.len => v,
-            _ => return Err(ErrorKind::InvalidInput.into()),
-        };
-        while new_position != self.position() {
-            if let Some(offset) = new_position.checked_signed_diff(self.position()) {
-                self.inner.seek_relative(offset)?;
-                self.limit = self.limit.wrapping_sub(offset as u64);
-                break;
-            }
-            let offset = if new_position > self.position() { i64::MAX } else { i64::MIN };
-            self.inner.seek_relative(offset)?;
-            self.limit = self.limit.wrapping_sub(offset as u64);
-        }
-        Ok(new_position)
-    }
-
-    fn stream_len(&mut self) -> Result<u64> {
-        Ok(self.len)
-    }
-
-    fn stream_position(&mut self) -> Result<u64> {
-        Ok(self.position())
-    }
-
-    fn seek_relative(&mut self, offset: i64) -> Result<()> {
-        if !self.position().checked_add_signed(offset).is_some_and(|p| p <= self.len) {
-            return Err(ErrorKind::InvalidInput.into());
-        }
-        self.inner.seek_relative(offset)?;
-        self.limit = self.limit.wrapping_sub(offset as u64);
-        Ok(())
     }
 }
 

--- a/library/std/src/io/util.rs
+++ b/library/std/src/io/util.rs
@@ -5,8 +5,7 @@ mod tests;
 
 use crate::fmt;
 use crate::io::{
-    self, BorrowedCursor, BufRead, Empty, IoSlice, IoSliceMut, Read, Repeat, Seek, SeekFrom, Sink,
-    Write,
+    self, BorrowedCursor, BufRead, Empty, IoSlice, IoSliceMut, Read, Repeat, Sink, Write,
 };
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -80,24 +79,6 @@ impl BufRead for Empty {
 
     #[inline]
     fn read_line(&mut self, _buf: &mut String) -> io::Result<usize> {
-        Ok(0)
-    }
-}
-
-#[stable(feature = "empty_seek", since = "1.51.0")]
-impl Seek for Empty {
-    #[inline]
-    fn seek(&mut self, _pos: SeekFrom) -> io::Result<u64> {
-        Ok(0)
-    }
-
-    #[inline]
-    fn stream_len(&mut self) -> io::Result<u64> {
-        Ok(0)
-    }
-
-    #[inline]
-    fn stream_position(&mut self) -> io::Result<u64> {
         Ok(0)
     }
 }

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -374,6 +374,7 @@
 #![feature(random)]
 #![feature(raw_os_error_ty)]
 #![feature(seek_io_take_position)]
+#![feature(seek_stream_len)]
 #![feature(share_trait)]
 #![feature(slice_internals)]
 #![feature(slice_ptr_get)]


### PR DESCRIPTION
ACP: https://github.com/rust-lang/libs-team/issues/755
Tracking issue: https://github.com/rust-lang/rust/issues/154046
Split From: https://github.com/rust-lang/rust/pull/156527
Blocked On: https://github.com/rust-lang/rust/pull/158539

## Description

Moves `std::io::Seek` and `SeekFrom` to `core::io`. This is a pretty simple migration, but it is blocked by rust-lang/rust#158539.

---

## Notes

* No AI tooling of any kind was used during the creation of this PR.
* Please see https://github.com/rust-lang/rust/issues/154046#issuecomment-4416678427 for a review order and broader context for this PR.