### PR TITLE
Move `std::io::read_to_string` to `alloc::io`

### DIFF
--- a/library/alloc/src/io/mod.rs
+++ b/library/alloc/src/io/mod.rs
@@ -27,8 +27,6 @@ pub use core::io::{
     stream_len_default, take,
 };
 
-#[unstable(feature = "alloc_io", issue = "154046")]
-pub use self::{read::Read, util::Bytes};
 #[doc(hidden)]
 #[unstable(feature = "core_io_internals", reason = "exposed only for libstd", issue = "none")]
 pub use self::{
@@ -37,4 +35,9 @@ pub use self::{
         default_read_exact, default_read_to_end, default_read_to_string, default_read_vectored,
     },
     util::{SpecReadByte, bytes, uninlined_slow_read_byte},
+};
+#[unstable(feature = "alloc_io", issue = "154046")]
+pub use self::{
+    read::{Read, read_to_string},
+    util::Bytes,
 };

--- a/library/alloc/src/io/read.rs
+++ b/library/alloc/src/io/read.rs
@@ -700,6 +700,71 @@ pub trait Read {
     }
 }
 
+/// Reads all bytes from a [reader][Read] into a new [`String`].
+///
+/// This is a convenience function for [`Read::read_to_string`]. Using this
+/// function avoids having to create a variable first and provides more type
+/// safety since you can only get the buffer out if there were no errors. (If you
+/// use [`Read::read_to_string`] you have to remember to check whether the read
+/// succeeded because otherwise your buffer will be empty or only partially full.)
+///
+/// # Performance
+///
+/// The downside of this function's increased ease of use and type safety is
+/// that it gives you less control over performance. For example, you can't
+/// pre-allocate memory like you can using [`String::with_capacity`] and
+/// [`Read::read_to_string`]. Also, you can't re-use the buffer if an error
+/// occurs while reading.
+///
+/// In many cases, this function's performance will be adequate and the ease of use
+/// and type safety tradeoffs will be worth it. However, there are cases where you
+/// need more control over performance, and in those cases you should definitely use
+/// [`Read::read_to_string`] directly.
+///
+/// Note that in some special cases, such as when reading files, this function will
+/// pre-allocate memory based on the size of the input it is reading. In those
+/// cases, the performance should be as good as if you had used
+/// [`Read::read_to_string`] with a manually pre-allocated buffer.
+///
+/// # Errors
+///
+/// This function forces you to handle errors because the output (the `String`)
+/// is wrapped in a [`Result`]. See [`Read::read_to_string`] for the errors
+/// that can occur. If any error occurs, you will get an [`Err`], so you
+/// don't have to worry about your buffer being empty or partially full.
+///
+/// # Examples
+///
+/// ```no_run
+/// # use std::io;
+/// fn main() -> io::Result<()> {
+///     let stdin = io::read_to_string(io::stdin())?;
+///     println!("Stdin was:");
+///     println!("{stdin}");
+///     Ok(())
+/// }
+/// ```
+///
+/// # Usage Notes
+///
+/// `read_to_string` attempts to read a source until EOF, but many sources are continuous streams
+/// that do not send EOF. In these cases, `read_to_string` will block indefinitely. Standard input
+/// is one such stream which may be finite if piped, but is typically continuous. For example,
+/// `cat file | my-rust-program` will correctly terminate with an `EOF` upon closure of cat.
+/// Reading user input or running programs that remain open indefinitely will never terminate
+/// the stream with `EOF` (e.g. `yes | my-rust-program`).
+///
+/// Using `.lines()` with a `BufReader` or using [`read`] can provide a better solution
+///
+/// [`read`]: Read::read
+///
+#[stable(feature = "io_read_to_string", since = "1.65.0")]
+pub fn read_to_string<R: Read>(mut reader: R) -> Result<String> {
+    let mut buf = String::new();
+    reader.read_to_string(&mut buf)?;
+    Ok(buf)
+}
+
 /// Bare metal platforms usually have very small amounts of RAM
 /// (in the order of hundreds of KB)
 #[doc(hidden)]

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -306,6 +306,8 @@ pub use alloc_crate::io::RawOsError;
 pub use alloc_crate::io::SimpleMessage;
 #[unstable(feature = "io_const_error", issue = "133448")]
 pub use alloc_crate::io::const_error;
+#[stable(feature = "io_read_to_string", since = "1.65.0")]
+pub use alloc_crate::io::read_to_string;
 #[unstable(feature = "read_buf", issue = "78485")]
 pub use alloc_crate::io::{BorrowedBuf, BorrowedCursor};
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -358,71 +360,6 @@ mod stdio;
 mod util;
 
 pub(crate) use stdio::cleanup;
-
-/// Reads all bytes from a [reader][Read] into a new [`String`].
-///
-/// This is a convenience function for [`Read::read_to_string`]. Using this
-/// function avoids having to create a variable first and provides more type
-/// safety since you can only get the buffer out if there were no errors. (If you
-/// use [`Read::read_to_string`] you have to remember to check whether the read
-/// succeeded because otherwise your buffer will be empty or only partially full.)
-///
-/// # Performance
-///
-/// The downside of this function's increased ease of use and type safety is
-/// that it gives you less control over performance. For example, you can't
-/// pre-allocate memory like you can using [`String::with_capacity`] and
-/// [`Read::read_to_string`]. Also, you can't re-use the buffer if an error
-/// occurs while reading.
-///
-/// In many cases, this function's performance will be adequate and the ease of use
-/// and type safety tradeoffs will be worth it. However, there are cases where you
-/// need more control over performance, and in those cases you should definitely use
-/// [`Read::read_to_string`] directly.
-///
-/// Note that in some special cases, such as when reading files, this function will
-/// pre-allocate memory based on the size of the input it is reading. In those
-/// cases, the performance should be as good as if you had used
-/// [`Read::read_to_string`] with a manually pre-allocated buffer.
-///
-/// # Errors
-///
-/// This function forces you to handle errors because the output (the `String`)
-/// is wrapped in a [`Result`]. See [`Read::read_to_string`] for the errors
-/// that can occur. If any error occurs, you will get an [`Err`], so you
-/// don't have to worry about your buffer being empty or partially full.
-///
-/// # Examples
-///
-/// ```no_run
-/// # use std::io;
-/// fn main() -> io::Result<()> {
-///     let stdin = io::read_to_string(io::stdin())?;
-///     println!("Stdin was:");
-///     println!("{stdin}");
-///     Ok(())
-/// }
-/// ```
-///
-/// # Usage Notes
-///
-/// `read_to_string` attempts to read a source until EOF, but many sources are continuous streams
-/// that do not send EOF. In these cases, `read_to_string` will block indefinitely. Standard input
-/// is one such stream which may be finite if piped, but is typically continuous. For example,
-/// `cat file | my-rust-program` will correctly terminate with an `EOF` upon closure of cat.
-/// Reading user input or running programs that remain open indefinitely will never terminate
-/// the stream with `EOF` (e.g. `yes | my-rust-program`).
-///
-/// Using `.lines()` with a [`BufReader`] or using [`read`] can provide a better solution
-///
-///[`read`]: Read::read
-///
-#[stable(feature = "io_read_to_string", since = "1.65.0")]
-pub fn read_to_string<R: Read>(mut reader: R) -> Result<String> {
-    let mut buf = String::new();
-    reader.read_to_string(&mut buf)?;
-    Ok(buf)
-}
 
 fn read_until<R: BufRead + ?Sized>(r: &mut R, delim: u8, buf: &mut Vec<u8>) -> Result<usize> {
     let mut read = 0;


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/158545)*
<!-- homu-ignore:end -->

ACP: https://github.com/rust-lang/libs-team/issues/755
Tracking issue: https://github.com/rust-lang/rust/issues/154046
Split From: https://github.com/rust-lang/rust/pull/156527
~~Blocked On: https://github.com/rust-lang/rust/pull/158544~~

## Description

Moves `std::io::read_to_string` to `alloc::io`. This is a trivial move. Blocked on rust-lang/rust#158544.

---

## Notes

* No AI tooling of any kind was used during the creation of this PR.
* Please see https://github.com/rust-lang/rust/issues/154046#issuecomment-4416678427 for a review order and broader context for this PR.