### PR TITLE
make some tidy errors around python easier to understand

### DIFF
--- a/src/ci/docker/host-x86_64/tidy/Dockerfile
+++ b/src/ci/docker/host-x86_64/tidy/Dockerfile
@@ -39,5 +39,4 @@ COPY host-x86_64/pr-check-1/validate-toolstate.sh /scripts/
 
 # NOTE: intentionally uses python2 for x.py so we can test it still works.
 # validate-toolstate only runs in our CI, so it's ok for it to only support python3.
-ENV SCRIPT="TIDY_PRINT_DIFF=1 python2.7 ../x.py test \
-  src/tools/tidy tidyselftest --extra-checks=py,cpp,js,spellcheck"
+ENV SCRIPT="python2.7 ../x.py test src/tools/tidy tidyselftest --extra-checks=py,cpp,js,spellcheck"

--- a/src/etc/pre-push.sh
+++ b/src/etc/pre-push.sh
@@ -33,8 +33,7 @@ ROOT_DIR="$(git rev-parse --show-toplevel)"
 echo "Running pre-push script $ROOT_DIR/x test tidy"
 
 cd "$ROOT_DIR"
-# The env var is necessary for printing diffs in py (fmt/lint) and cpp.
-TIDY_PRINT_DIFF=1 ./x test tidy \
+./x test tidy \
     --set build.locked-deps=true \
     --extra-checks auto:py,auto:cpp,auto:js
 if [ $? -ne 0 ]; then

--- a/src/tools/tidy/src/deps.rs
+++ b/src/tools/tidy/src/deps.rs
@@ -683,6 +683,9 @@ pub fn check(root: &Path, cargo: &Path, tidy_ctx: TidyCtx) {
 
 /// Ensure the list of proc-macro crate transitive dependencies is up to date
 fn check_proc_macro_dep_list(root: &Path, cargo: &Path, bless: bool, check: &mut RunningCheck) {
+    if std::env::var("RUSTC").is_err() {
+        panic!("tidy must be run under bootstrap (./x test tidy), not as a standalone command");
+    }
     let mut cmd = cargo_metadata::MetadataCommand::new();
     cmd.cargo_path(cargo)
         .manifest_path(root.join("Cargo.toml"))

--- a/src/tools/tidy/src/extra_checks/mod.rs
+++ b/src/tools/tidy/src/extra_checks/mod.rs
@@ -10,12 +10,11 @@
 //!    configuration after a double dash (`--extra-checks=py -- foo.py`)
 //! 2. Build configuration based on args/environment:
 //!    - Formatters by default are in check only mode
-//!    - If in CI (TIDY_PRINT_DIFF=1 is set), check and print the diff
 //!    - If `--bless` is provided, formatters may run
 //!    - Pass any additional config after the `--`. If no files are specified,
 //!      use a default.
-//! 3. Print the output of the given command. If it fails and `TIDY_PRINT_DIFF`
-//!    is set, rerun the tool to print a suggestion diff (for e.g. CI)
+//! 3. Print the output of the given command. If it fails, rerun the tool to print a suggestion
+//!    diff.
 
 use std::ffi::{OsStr, OsString};
 use std::path::{Path, PathBuf};
@@ -206,12 +205,6 @@ fn show_bless_help(mode: &str, action: &str, bless: bool) {
     }
 }
 
-fn show_diff() -> bool {
-    let disable_diff =
-        std::env::var("TIDY_PRINT_DIFF").is_ok_and(|v| v.eq_ignore_ascii_case("false") || v == "0");
-    !disable_diff
-}
-
 fn check_spellcheck(root_path: &Path, outdir: &Path, cargo: &Path, tidy_ctx: &TidyCtx) {
     let mut check = tidy_ctx.start_check("extra_checks:spellcheck");
 
@@ -318,7 +311,7 @@ fn check_python_lint(
 
     let res = run_ruff(root_path, outdir, py_path, &cfg_args, &file_args, args);
 
-    if res.is_err() && !bless && show_diff() {
+    if res.is_err() && !bless {
         eprintln!("\npython linting failed! Printing diff suggestions:");
 
         let diff_res = run_ruff(
@@ -362,18 +355,16 @@ fn check_python_fmt(
     let res = run_ruff(root_path, outdir, py_path, &cfg_args, &file_args, &args);
 
     if res.is_err() && !bless {
-        if show_diff() {
-            eprintln!("\npython formatting does not match! Printing diff:");
+        eprintln!("\npython formatting does not match! Printing diff:");
 
-            let _ = run_ruff(
-                root_path,
-                outdir,
-                py_path,
-                &cfg_args,
-                &file_args,
-                &["format".as_ref(), "--diff".as_ref()],
-            );
-        }
+        let _ = run_ruff(
+            root_path,
+            outdir,
+            py_path,
+            &cfg_args,
+            &file_args,
+            &["format".as_ref(), "--diff".as_ref()],
+        );
         show_bless_help("py:fmt", "reformat Python code", bless);
     }
 
@@ -425,7 +416,7 @@ fn check_cpp_fmt(
     let args = merge_args(&cfg_args_clang_format, &file_args_clang_format);
     let res = py_runner(py_path, false, None, "clang-format", &args);
 
-    if res.is_err() && !bless && show_diff() {
+    if res.is_err() && !bless {
         eprintln!("\nclang-format linting failed! Printing diff suggestions:");
 
         let mut cfg_args_diff = cfg_args.clone();

--- a/src/tools/tidy/src/extra_checks/mod.rs
+++ b/src/tools/tidy/src/extra_checks/mod.rs
@@ -207,7 +207,9 @@ fn show_bless_help(mode: &str, action: &str, bless: bool) {
 }
 
 fn show_diff() -> bool {
-    std::env::var("TIDY_PRINT_DIFF").is_ok_and(|v| v.eq_ignore_ascii_case("true") || v == "1")
+    let disable_diff =
+        std::env::var("TIDY_PRINT_DIFF").is_ok_and(|v| v.eq_ignore_ascii_case("false") || v == "0");
+    !disable_diff
 }
 
 fn check_spellcheck(root_path: &Path, outdir: &Path, cargo: &Path, tidy_ctx: &TidyCtx) {

--- a/src/tools/tidy/src/extra_checks/mod.rs
+++ b/src/tools/tidy/src/extra_checks/mod.rs
@@ -200,7 +200,9 @@ fn js_prepare(root_path: &Path, outdir: &Path, npm: &Path, tidy_ctx: &TidyCtx) -
 
 fn show_bless_help(mode: &str, action: &str, bless: bool) {
     if !bless {
-        eprintln!("rerun tidy with `--extra-checks={mode} --bless` to {action}");
+        eprintln!(
+            "rerun with `--bless` to {action}: `./x.py test tidy --extra-checks={mode} --bless`"
+        );
     }
 }
 


### PR DESCRIPTION
someone i was helping hit a tidy python formatting error in CI, tried to run the exact `tidy` command that bootstrap printed as an error, got *another* error because rustc isn't installed globally, only locally, and then gave up in frustration because they couldn't tell what tidy even wanted them to fix.

make some targeted improvements.

i'm not sure why diffs were disabled by default before. it's been like that ever since python formatting was originally added in https://github.com/rust-lang/rust/pull/112482, with no explanation. i think showing the diff is a better default.

before:
```
$ ./x t tidy --extra-checks=py:fmt
checking python file formatting
Would reformat: ferrocene/ci/scripts/calculate_parameters.py
1 file would be reformatted, 118 files already formatted
rerun tidy with `--extra-checks=py:fmt --bless` to reformat Python code
tidy [extra_checks:python_fmt]: checks with external tool 'ruff' failed
tidy [extra_checks:python_fmt]: FAIL
tidy: The following check failed: extra_checks:python_fmt
Command `/home/ci/project/build/x86_64-unknown-linux-gnu/stage1-tools-bin/rust-tidy --root-path=/home/ci/project --cargo-path=/home/ci/project/build/x86_64-unknown-linux-gnu/stage0/bin/cargo --output-dir=/home/ci/project/build --concurrency=4 --npm-path=yarn --extra-checks=py:fmt` failed with exit code 1
Created at: src/bootstrap/src/core/build_steps/tool.rs:1630:23
Executed at: src/bootstrap/src/core/build_steps/test.rs:1533:29

Command has failed. Rerun with -v to see more details.
Build completed unsuccessfully in 0:00:55
$ /home/ci/project/build/x86_64-unknown-linux-gnu/stage1-tools-bin/rust-tidy --root-path=/home/ci/project --cargo-path=/home/ci/project/build/x86_64-unknown-linux-gnu/stage0/bin/cargo --output-dir=/home/ci/project/build --concurrency=4 --npm-path=yarn --extra-checks=py:fmt --bless
tidy [CI history]: no base commit found. Some checks will be skipped.

thread 'deps (.)' (25771) panicked at src/tools/tidy/src/deps.rs:700:20:
cmd.exec() failed with `cargo metadata` exited with an error: error: could not execute process `rustc -vV` (never executed)

Caused by:
  No such file or directory (os error 2)

note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

thread 'main' (25768) panicked at src/tools/tidy/src/main.rs:53:61:
called `Result::unwrap()` on an `Err` value: Any { .. }
```

after:

```
checking python file formatting
Would reformat: ferrocene/doc/specification/make.py
1 file would be reformatted, 118 files already formatted

python formatting does not match! Printing diff:
--- ferrocene/doc/specification/make.py
+++ ferrocene/doc/specification/make.py
@@ -64,6 +64,7 @@

     return dest / builder

+
 def build_linkchecker(root):
     repo = root / ".linkchecker"
     src = repo / "src" / "tools" / "linkchecker"

1 file would be reformatted, 118 files already formatted
rerun with `--bless` to reformat Python code: `./x.py test tidy --extra-checks=py:fmt --bless`
```
```
thread 'deps (.)' (249572429) panicked at src/tools/tidy/src/deps.rs:696:9:
tidy must be run under bootstrap (./x test tidy), not as a standalone command
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
