### PR TITLE
delegation: store child segment flag in `PathSegment`

### DIFF
--- a/compiler/rustc_ast_lowering/src/delegation.rs
+++ b/compiler/rustc_ast_lowering/src/delegation.rs
@@ -55,7 +55,9 @@ use rustc_span::def_id::{DefId, LocalDefId};
 use rustc_span::symbol::kw;
 use rustc_span::{ErrorGuaranteed, Ident, Span, Symbol};
 
-use crate::delegation::generics::{GenericsGenerationResult, GenericsGenerationResults};
+use crate::delegation::generics::{
+    GenericsGenerationResult, GenericsGenerationResults, GenericsPosition,
+};
 use crate::diagnostics::{
     CycleInDelegationSignatureResolution, DelegationAttemptedBlockWithDefsDeletion,
     DelegationBlockSpecifiedWhenNoParams, UnresolvedDelegationCallee,
@@ -505,6 +507,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
             res: Res::Local(param_id),
             args: None,
             infer_args: false,
+            delegation_child_segment: false,
         }));
 
         let path = self.arena.alloc(hir::Path { span, res: Res::Local(param_id), segments });
@@ -713,6 +716,8 @@ impl<'hir> LoweringContext<'_, 'hir> {
 
         result.args_segment_id = segment.hir_id;
         result.use_for_sig_inheritance = !result.generics.is_trait_impl();
+
+        segment.delegation_child_segment = result.generics.pos() == GenericsPosition::Child;
 
         segment
     }

--- a/compiler/rustc_ast_lowering/src/delegation/generics.rs
+++ b/compiler/rustc_ast_lowering/src/delegation/generics.rs
@@ -12,7 +12,7 @@ use rustc_span::{Ident, Span, sym};
 use crate::LoweringContext;
 use crate::diagnostics::DelegationInfersMismatch;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub(super) enum GenericsPosition {
     Parent,
     Child,
@@ -155,7 +155,7 @@ impl<'hir> DelegationGenericArgsIterator<'hir> {
 impl<'hir> HirOrTyGenerics<'hir> {
     pub(super) fn into_hir_generics(&mut self, ctx: &mut LoweringContext<'_, 'hir>, span: Span) {
         if let HirOrTyGenerics::Ty(ty) = self {
-            let rename_self = matches!(ty.pos, GenericsPosition::Child);
+            let rename_self = ty.pos == GenericsPosition::Child;
             let params = ctx.uplift_delegation_generic_params(span, &ty.data, rename_self);
 
             *self = HirOrTyGenerics::Hir(DelegationGenerics {
@@ -216,6 +216,13 @@ impl<'hir> HirOrTyGenerics<'hir> {
                 .iter()
                 .find(|p| p.name.ident().name == kw::SelfUpper)
                 .expect("`Self` generic param is not found while expected"),
+        }
+    }
+
+    pub(crate) fn pos(&self) -> GenericsPosition {
+        match self {
+            HirOrTyGenerics::Ty(ty) => ty.pos,
+            HirOrTyGenerics::Hir(hir) => hir.pos,
         }
     }
 }
@@ -590,6 +597,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                     ident: p.name.ident(),
                     infer_args: false,
                     res,
+                    delegation_child_segment: false,
                 }]),
                 res,
                 span: p.span,

--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -1014,6 +1014,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 res,
                 args,
                 infer_args: args.is_none(),
+                delegation_child_segment: false,
             }]),
         })
     }

--- a/compiler/rustc_ast_lowering/src/path.rs
+++ b/compiler/rustc_ast_lowering/src/path.rs
@@ -412,6 +412,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
             } else {
                 Some(generic_args.into_generic_args(self))
             },
+            delegation_child_segment: false,
         }
     }
 

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -387,12 +387,24 @@ pub struct PathSegment<'hir> {
     /// out of those only the segments with no type parameters
     /// to begin with, e.g., `Vec::new` is `<Vec<..>>::new::<..>`.
     pub infer_args: bool,
+
+    /// Whether this segment is a delegation's child segment:
+    /// `reuse Trait::foo`, in this case `foo` is a delegation's child segment.
+    /// Used for faster check during generic args lowering.
+    pub delegation_child_segment: bool,
 }
 
 impl<'hir> PathSegment<'hir> {
     /// Converts an identifier to the corresponding segment.
     pub fn new(ident: Ident, hir_id: HirId, res: Res) -> PathSegment<'hir> {
-        PathSegment { ident, hir_id, res, infer_args: true, args: None }
+        PathSegment {
+            ident,
+            hir_id,
+            res,
+            infer_args: true,
+            args: None,
+            delegation_child_segment: false,
+        }
     }
 
     pub fn invalid() -> Self {

--- a/compiler/rustc_hir/src/intravisit.rs
+++ b/compiler/rustc_hir/src/intravisit.rs
@@ -1468,7 +1468,8 @@ pub fn walk_path_segment<'v, V: Visitor<'v>>(
     visitor: &mut V,
     segment: &'v PathSegment<'v>,
 ) -> V::Result {
-    let PathSegment { ident, hir_id, res: _, args, infer_args: _ } = segment;
+    let PathSegment { ident, hir_id, res: _, args, infer_args: _, delegation_child_segment: _ } =
+        segment;
     try_visit!(visitor.visit_ident(*ident));
     try_visit!(visitor.visit_id(*hir_id));
     visit_opt!(visitor, visit_generic_args, *args);

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/bounds.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/bounds.rs
@@ -467,6 +467,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                     res: Res::Err,
                     args: Some(constraint.gen_args),
                     infer_args: false,
+                    delegation_child_segment: false,
                 };
 
                 let alias_args = self.lower_generic_args_of_assoc_item(

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/errors.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/errors.rs
@@ -471,6 +471,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                                             res: Res::Err,
                                             args: Some(constraint.gen_args),
                                             infer_args: false,
+                                            delegation_child_segment: false,
                                         };
 
                                         let alias_args = self.lower_generic_args_of_assoc_item(

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/generics.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/generics.rs
@@ -434,7 +434,7 @@ pub(crate) fn check_generic_arg_count(
 
     // Suppress this warning for delegations as it is compiler generated and lifetimes are
     // propagated while late-bound lifetimes may be present.
-    let explicit_late_bound = match tcx.hir_is_delegation_child_segment(seg) {
+    let explicit_late_bound = match seg.delegation_child_segment {
         true => ExplicitLateBound::No,
         false => prohibit_explicit_late_bound_lifetimes(cx, gen_params, gen_args, gen_pos),
     };

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
@@ -870,7 +870,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             span,
             generic_args: segment.args(),
             infer_args: segment.infer_args,
-            create_synth_args: tcx.hir_is_delegation_child_segment(segment),
+            create_synth_args: segment.delegation_child_segment,
             incorrect_args: &arg_count.correct,
         };
 

--- a/compiler/rustc_middle/src/hir/map.rs
+++ b/compiler/rustc_middle/src/hir/map.rs
@@ -879,13 +879,6 @@ impl<'tcx> TyCtxt<'tcx> {
         self.hir_opt_delegation_info(delegation_id).expect("processing delegation")
     }
 
-    pub fn hir_is_delegation_child_segment(self, segment: &PathSegment<'_>) -> bool {
-        let parent_def = self.hir_get_parent_item(segment.hir_id).def_id;
-
-        self.hir_opt_delegation_info(parent_def)
-            .is_some_and(|info| info.child_seg_id == segment.hir_id)
-    }
-
     #[inline]
     fn hir_opt_ident(self, id: HirId) -> Option<Ident> {
         match self.hir_node(id) {


### PR DESCRIPTION
This should reduce [perf overhead](https://github.com/rust-lang/rust/pull/157960#issuecomment-4801486183) of checking whether path segment is a delegation's child segment.

r? @petrochenkov
