### PR TITLE
Test(lib/net): Fix `hostname_smoketest` for Win7

### DIFF
--- a/library/std/src/net/tests.rs
+++ b/library/std/src/net/tests.rs
@@ -41,8 +41,9 @@ pub fn compare_ignore_zoneid(a: &SocketAddr, b: &SocketAddr) -> bool {
 fn hostname_smoketest() {
     // Just a smoke test to ensure it can be called.
     let name = crate::net::hostname();
-    if cfg!(windows) || cfg!(unix) {
+    if cfg!(any(all(windows, not(target_vendor = "win7")), unix)) {
         // At least on Windows and Unix, this should succeed.
+        // The `win7` Windows targets do not support it yet though.
         name.unwrap();
     }
 }


### PR DESCRIPTION
This test currently fails under both x86 and x86_64 Win7 on:

```
thread 'net::tests::hostname_smoketest' (2304) panicked at library/std/src/net/tests.rs:46:14:
called `Result::unwrap()` on an `Err` value: Error { kind: Unsupported, message: "operation not supported on this platform" }
```

This is simply because the feature was made to be effectively disabled under these targets in rust-lang/rust#150905. The test is therefore fixed in order to reflect that appropriately.

cc rust-lang/rust#135142 @roblabla

@rustbot label O-windows-7 O-x86_32 O-x86_64 A-io T-libs