### PR TITLE
llvm-wrapper: use accessors for private fields in LLVM 23+

### DIFF
--- a/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
@@ -288,7 +288,11 @@ extern "C" void LLVMRustPrintTargetCPUs(LLVMTargetMachineRef TM,
   // Just print a bare list of target CPU names, and let Rust-side code handle
   // the full formatting of `--print=target-cpus`.
   for (auto &CPU : CPUTable) {
+#if LLVM_VERSION_GE(23, 0)
+    OS << CPU.key() << "\n";
+#else
     OS << CPU.Key << "\n";
+#endif
   }
 }
 
@@ -315,9 +319,15 @@ extern "C" void LLVMRustGetTargetFeature(LLVMTargetMachineRef TM, size_t Index,
 #endif
   const ArrayRef<SubtargetFeatureKV> FeatTable =
       MCInfo.getAllProcessorFeatures();
+#if LLVM_VERSION_GE(23, 0)
+  const SubtargetFeatureKV &Feat = FeatTable[Index];
+  *Feature = Feat.key();
+  *Desc = Feat.desc();
+#else
   const SubtargetFeatureKV Feat = FeatTable[Index];
   *Feature = Feat.Key;
   *Desc = Feat.Desc;
+#endif
 }
 
 extern "C" const char *LLVMRustGetHostCPUName(size_t *OutLen) {


### PR DESCRIPTION
In LLVM, FeatureKV/SubtargetKV pointers are now private:
https://github.com/llvm/llvm-project/pull/206237
This change fixes compiler errors when building rustc with ToT LLVM
by using the key() and desc() accessors.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
