### PR TITLE
Clarify ExitStatusExt documentation

### DIFF
--- a/library/std/src/os/unix/process.rs
+++ b/library/std/src/os/unix/process.rs
@@ -7,6 +7,8 @@
 use crate::ffi::OsStr;
 use crate::os::unix::io::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, OwnedFd, RawFd};
 use crate::path::Path;
+#[cfg(doc)]
+use crate::process::{ExitStatus, ExitStatusError};
 use crate::sys::process::ChildPipe;
 use crate::sys::{AsInner, AsInnerMut, FromInner, IntoInner};
 use crate::{io, process, sys};
@@ -272,35 +274,105 @@ impl CommandExt for process::Command {
     }
 }
 
-/// Unix-specific extensions to [`process::ExitStatus`] and
-/// [`ExitStatusError`](process::ExitStatusError).
+/// Unix-specific extensions to [`ExitStatus`] and [`ExitStatusError`].
 ///
-/// On Unix, `ExitStatus` **does not necessarily represent an exit status**, as
+/// On Unix, [`ExitStatus`] **does not necessarily represent an exit status**, as
 /// passed to the `_exit` system call or returned by
-/// [`ExitStatus::code()`](crate::process::ExitStatus::code).  It represents **any wait status**
-/// as returned by one of the `wait` family of system
+/// [`ExitStatus::code()`](ExitStatus::code).  It represents **any wait status**
+/// as returned by one of the [`wait`] family of system
 /// calls.
 ///
-/// A Unix wait status (a Rust `ExitStatus`) can represent a Unix exit status, but can also
+/// A Unix wait status (a Rust [`ExitStatus`]) can represent a Unix exit status, but can also
 /// represent other kinds of process event.
+///
+/// [`wait`]: https://pubs.opengroup.org/onlinepubs/9799919799/functions/wait.html
 #[stable(feature = "rust1", since = "1.0.0")]
 pub impl(self) trait ExitStatusExt {
-    /// Creates a new `ExitStatus` or `ExitStatusError` from the raw underlying integer status
-    /// value from `wait`
+    /// Creates a new [`ExitStatus`] or [`ExitStatusError`] from the raw underlying integer status
+    /// value from [`wait`].
     ///
     /// The value should be a **wait status, not an exit status**.
     ///
+    /// # Example
+    ///
+    /// A signal-terminated [`wait`] status carries the signal number, which [`ExitStatus::signal`]
+    /// recovers using the platform's [`WTERMSIG`][`wait`] macro. Note that the bit layout of a
+    /// wait status is **not** specified by POSIX and is platform-specific. By convention on most
+    /// Unix platforms, the signal number occupies the low 7 bits with the exit-code byte left
+    /// zero, so a bare signal number between 1 and 126 is treated as a signal-terminated wait
+    /// status. The following example relies on that convention and is therefore not guaranteed to
+    /// hold on every target:
+    ///
+    /// ```
+    /// # if cfg!(target_os = "fuchsia") { return; }
+    /// use std::os::unix::process::ExitStatusExt;
+    /// use std::process::ExitStatus;
+    ///
+    /// let signal = 15; // SIGTERM
+    /// assert!(signal > 0 && signal < 0x7f, "not a valid Unix termination signal: {signal}");
+    ///
+    /// let status = ExitStatus::from_raw(signal);
+    /// assert!(!status.success());
+    /// assert_eq!(status.code(), None);
+    /// assert_eq!(status.signal(), Some(15));
+    /// ```
+    ///
+    /// Generating an [`ExitStatus`] with a given exit code (0-255) is system-dependent.
+    /// The value returned by [`ExitStatus::code`] is specified to come from applying the
+    /// [`WEXITSTATUS`][`wait`] macro, but there is no POSIX-specified constructor and the bit
+    /// layout is left unspecified. By near-universal convention every Unix libc stores the
+    /// 8-bit exit code in bits 8..16, so a status built with `(code & 0xff) << 8` will usually
+    /// round-trip back to the original exit code:
+    ///
+    /// ```
+    /// # if cfg!(target_os = "fuchsia") { return; }
+    /// use std::os::unix::process::ExitStatusExt;
+    /// use std::process::ExitStatus;
+    ///
+    /// let code = 41;
+    /// let status = ExitStatus::from_raw((code & 0xff) << 8);
+    /// assert_eq!(status.code(), Some(41));
+    /// assert!(!status.success());
+    /// ```
+    ///
     /// # Panics
     ///
-    /// Panics on an attempt to make an `ExitStatusError` from a wait status of `0`.
+    /// - `ExitStatusError::from_raw` panics on an attempt to make an [`ExitStatusError`] from a
+    ///    [`wait`] status of `0`.
+    /// - `ExitStatus::from_raw` always succeeds and never panics.
     ///
-    /// Making an `ExitStatus` always succeeds and never panics.
+    /// [`wait`]: https://pubs.opengroup.org/onlinepubs/9799919799/functions/wait.html
     #[stable(feature = "exit_status_from", since = "1.12.0")]
     fn from_raw(raw: i32) -> Self;
 
     /// If the process was terminated by a signal, returns that signal.
     ///
-    /// In other words, if `WIFSIGNALED`, this returns `WTERMSIG`.
+    /// In other words, if [`WIFSIGNALED`][`wait`], this returns [`WTERMSIG`][`wait`]. For such a status,
+    /// [`ExitStatus::code`] returns `None`:
+    ///
+    /// ```
+    /// # if cfg!(target_os = "fuchsia") { return; }
+    /// use std::os::unix::process::ExitStatusExt;
+    /// use std::process::ExitStatus;
+    ///
+    /// let sigterm = 15;
+    /// let status = ExitStatus::from_raw(sigterm);
+    /// assert_eq!(status.code(), None);
+    /// assert_eq!(status.signal(), Some(sigterm));
+    /// ```
+    ///
+    /// A process that receives a signal may catch and handle it, then exit normally with an
+    /// exit code. When that happens, `signal` returns `None`.
+    ///
+    /// Rust does not pass commands through a shell, such as `bash` and `sh`, but it
+    /// is possible to do so manually. When invoking a shell, the signal value indicates whether
+    /// the top-level shell itself received a terminating signal. If instead a command *within*
+    /// an invoked shell receives a terminating signal, many shells convert the signal number
+    /// into an exit code by adding 128. For example, a command run under `sh` that receives a
+    /// [`SIGTERM`] canonically causes the shell to report an exit code of `15 + 128`, i.e. `143`.
+    ///
+    /// [`SIGTERM`]: https://pubs.opengroup.org/onlinepubs/9799919799/utilities/kill.html
+    /// [`wait`]: https://pubs.opengroup.org/onlinepubs/9799919799/functions/wait.html
     #[stable(feature = "rust1", since = "1.0.0")]
     fn signal(&self) -> Option<i32>;
 
@@ -310,21 +382,27 @@ pub impl(self) trait ExitStatusExt {
 
     /// If the process was stopped by a signal, returns that signal.
     ///
-    /// In other words, if `WIFSTOPPED`, this returns `WSTOPSIG`.  This is only possible if the status came from
-    /// a `wait` system call which was passed `WUNTRACED`, and was then converted into an `ExitStatus`.
+    /// In other words, if [`WIFSTOPPED`][`wait`], this returns [`WSTOPSIG`][`wait`].  This is only possible if the status came from
+    /// a [`wait`] system call which was passed [`WUNTRACED`][`wait`], and was then converted into an [`ExitStatus`].
+    ///
+    /// [`wait`]: https://pubs.opengroup.org/onlinepubs/9799919799/functions/wait.html
     #[stable(feature = "unix_process_wait_more", since = "1.58.0")]
     fn stopped_signal(&self) -> Option<i32>;
 
     /// Whether the process was continued from a stopped status.
     ///
-    /// Ie, `WIFCONTINUED`.  This is only possible if the status came from a `wait` system call
-    /// which was passed `WCONTINUED`, and was then converted into an `ExitStatus`.
+    /// I.e. [`WIFCONTINUED`][`wait`].  This is only possible if the status came from a [`wait`] system call
+    /// which was passed [`WCONTINUED`][`wait`], and was then converted into an [`ExitStatus`].
+    ///
+    /// [`wait`]: https://pubs.opengroup.org/onlinepubs/9799919799/functions/wait.html
     #[stable(feature = "unix_process_wait_more", since = "1.58.0")]
     fn continued(&self) -> bool;
 
-    /// Returns the underlying raw `wait` status.
+    /// Returns the underlying raw [`wait`] status.
     ///
     /// The returned integer is a **wait status, not an exit status**.
+    ///
+    /// [`wait`]: https://pubs.opengroup.org/onlinepubs/9799919799/functions/wait.html
     #[stable(feature = "unix_process_wait_more", since = "1.58.0")]
     fn into_raw(self) -> i32;
 }


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/158574)*
<!-- homu-ignore:end -->

## Fix struct links

There are several structs (`ExitStatus` and `ExitStatusError`) that could be linked, but aren't. Fixed. All links show their struct now instead of previously some showed `process::ExitStatus` when rendered.

## Add `wait` links

The docs distinguish `wait` as code, but do not link to **what** wait they're referring to. As this is Unix extension documentation, adding a link to the POSIX standard for `wait`. Showing a construction of an `ExitStatus` for both a signal and an exit code helps to highlight and internalize what **wait status, not an exit status** means.

## Example for `from_raw`

Current documentation calls out "The value should be a **wait status, not an exit status**." but it's unclear what exactly that means without a reference or an example. I added a doctest that shows you need to shift by 8 to get the desired result and annotated it with information about how that's derived based on the linked `wait` documentation.

## Example to `ExitStatus::signal`

Called out that a signaled process does not also produce an exit code. Added an example. Called out that just because a process reports that it was not terminated via a signal doesn't mean it never got one (it could be handled). Also added a note correlating shell behavior to exit codes:

GNU Bash manual: https://web.archive.org/web/20260625050034/https://www.gnu.org/software/bash/manual/bash.html#Exit-Status-1

> [...] a fatal signal whose number is N, Bash uses the value 128+N as the exit status.

FreeBSD bash(1) man page: https://man.freebsd.org/bash/1

> The return value	[...]  128+n  if the command is terminated by signal n.

## Panic scope on `from_raw`

This change is based on preference/experience:

When I originally read this documentation, it was because I clicked through `Output` -> `ExitStatus`. While the text "Creates a new `ExitStatus` or `ExitStatusError`" is present at the top, I didn't internalize what that meant exactly. Therefore, when I got to the panic section, I was mildly confused.

This edit makes the behavior more explicitly attached to the type. While the original format had all of the same information available, it was left for the reader to bridge that "making an ExitStatusError" is referring to `ExitStatus::from_raw` as that's the only constructor (for now).

Making this bridge more explicit also future-proofs us for future constructors (if they're ever added) that may or may not panic. While the context of the panic documentation is directly attached to `from_raw`, it's slightly (pedantically) more correct to not imply that ANY way of creating an ExitStatusError` from a `wait` of `0` will panic (a different constructor could perhaps return an option instead).

Technically, the syntax isn't correct, as it should be `<ExitStatusError as ExitStatusExt>::from_raw`, but I think this conveys intent without being overly verbose.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
