### PR TITLE
fix(std): recover thread handle when current() runs before spawn init on Windows

### DIFF
--- a/library/std/src/thread/current.rs
+++ b/library/std/src/thread/current.rs
@@ -116,6 +116,27 @@ pub(super) mod id {
     }
 }
 
+/// If `thread::current()` ran before [`super::lifecycle::ThreadInit::init`] on a
+/// newly spawned thread (e.g. during `DLL_THREAD_ATTACH` on Windows), replace
+/// the temporary handle created by [`init_current`] with the one from `thread::spawn`.
+pub(super) fn recover_preinitialized_for_spawn(thread: Thread) -> bool {
+    let current = CURRENT.get();
+    if current <= DESTROYED || current == NONE || current == BUSY {
+        return false;
+    }
+
+    // SAFETY: `current` points to a valid `Thread` created by `init_current`.
+    let old = unsafe { Thread::from_raw(current) };
+    if old.name().is_some() {
+        return false;
+    }
+
+    drop(old);
+    CURRENT.set(NONE);
+    id::set(thread.id());
+    set_current(thread).is_ok()
+}
+
 /// Tries to set the thread handle for the current thread. Fails if a handle was
 /// already set or if the thread ID of `thread` would change an already-set ID.
 pub(super) fn set_current(thread: Thread) -> Result<(), Thread> {

--- a/library/std/src/thread/current.rs
+++ b/library/std/src/thread/current.rs
@@ -116,45 +116,30 @@ pub(super) mod id {
     }
 }
 
-/// If `thread::current()` ran before [`super::lifecycle::ThreadInit::init`] on a
-/// newly spawned thread (e.g. during `DLL_THREAD_ATTACH` on Windows), replace
-/// the temporary handle created by [`init_current`] with the one from `thread::spawn`.
-pub(super) fn recover_preinitialized_for_spawn(thread: Thread) -> bool {
+/// Sets the thread handle for the current thread.
+///
+/// This is only called from [`super::lifecycle::ThreadInit::init`]. If
+/// `thread::current()` ran earlier on this thread (e.g. during `DLL_THREAD_ATTACH`
+/// on Windows), replace the temporary handle from [`init_current`] with the one from
+/// `thread::spawn`.
+pub(super) fn set_current(thread: Thread) {
     let current = CURRENT.get();
-    if current <= DESTROYED || current == NONE || current == BUSY {
-        return false;
+    if current > DESTROYED {
+        // SAFETY: `current` points to a valid `Thread` created by `init_current`.
+        unsafe {
+            CURRENT.set(DESTROYED);
+            drop(Thread::from_raw(current));
+        }
+    } else if current == BUSY {
+        rtabort!(
+            "set_current() was called while init_current() is in progress, \
+            which indicates a bug in the Rust threading implementation"
+        );
     }
 
-    // SAFETY: `current` points to a valid `Thread` created by `init_current`.
-    let old = unsafe { Thread::from_raw(current) };
-    if old.name().is_some() {
-        return false;
-    }
-
-    drop(old);
-    CURRENT.set(NONE);
     id::set(thread.id());
-    set_current(thread).is_ok()
-}
-
-/// Tries to set the thread handle for the current thread. Fails if a handle was
-/// already set or if the thread ID of `thread` would change an already-set ID.
-pub(super) fn set_current(thread: Thread) -> Result<(), Thread> {
-    if CURRENT.get() != NONE {
-        return Err(thread);
-    }
-
-    match id::get() {
-        Some(id) if id == thread.id() => {}
-        None => id::set(thread.id()),
-        _ => return Err(thread),
-    }
-
-    // Make sure that `crate::rt::thread_cleanup` will be run, which will
-    // call `drop_current`.
     crate::sys::thread_local::guard::enable();
     CURRENT.set(thread.into_raw().cast_mut());
-    Ok(())
 }
 
 /// Gets the unique identifier of the thread which invokes it.

--- a/library/std/src/thread/lifecycle.rs
+++ b/library/std/src/thread/lifecycle.rs
@@ -136,10 +136,6 @@ impl ThreadInit {
         // so that it may call std::thread::current() in its implementation. This is also
         // why we take Box<Self>, to ensure the Box is not destroyed until after this point.
         // Cloning the handle does not invoke the global allocator, it is an Arc.
-        #[cfg(test)]
-        if crate::env::var_os("__RUST_STD_TEST_PREINIT_CURRENT").is_some() {
-            let _ = crate::thread::current();
-        }
         if let Err(thread) = set_current(self.handle.clone()) {
             if !recover_preinitialized_for_spawn(thread) {
                 // The current thread should not have set yet. Use an abort to save binary size (see #123356).

--- a/library/std/src/thread/lifecycle.rs
+++ b/library/std/src/thread/lifecycle.rs
@@ -1,6 +1,6 @@
 //! The inner logic for thread spawning and joining.
 
-use super::current::set_current;
+use super::current::{recover_preinitialized_for_spawn, set_current};
 use super::id::ThreadId;
 use super::scoped::ScopeData;
 use super::thread::Thread;
@@ -136,9 +136,15 @@ impl ThreadInit {
         // so that it may call std::thread::current() in its implementation. This is also
         // why we take Box<Self>, to ensure the Box is not destroyed until after this point.
         // Cloning the handle does not invoke the global allocator, it is an Arc.
-        if let Err(_thread) = set_current(self.handle.clone()) {
-            // The current thread should not have set yet. Use an abort to save binary size (see #123356).
-            rtabort!("current thread handle already set during thread spawn");
+        #[cfg(test)]
+        if crate::env::var_os("__RUST_STD_TEST_PREINIT_CURRENT").is_some() {
+            let _ = crate::thread::current();
+        }
+        if let Err(thread) = set_current(self.handle.clone()) {
+            if !recover_preinitialized_for_spawn(thread) {
+                // The current thread should not have set yet. Use an abort to save binary size (see #123356).
+                rtabort!("current thread handle already set during thread spawn");
+            }
         }
 
         if let Some(name) = self.handle.cname() {

--- a/library/std/src/thread/lifecycle.rs
+++ b/library/std/src/thread/lifecycle.rs
@@ -1,6 +1,6 @@
 //! The inner logic for thread spawning and joining.
 
-use super::current::{recover_preinitialized_for_spawn, set_current};
+use super::current::set_current;
 use super::id::ThreadId;
 use super::scoped::ScopeData;
 use super::thread::Thread;
@@ -136,12 +136,7 @@ impl ThreadInit {
         // so that it may call std::thread::current() in its implementation. This is also
         // why we take Box<Self>, to ensure the Box is not destroyed until after this point.
         // Cloning the handle does not invoke the global allocator, it is an Arc.
-        if let Err(thread) = set_current(self.handle.clone()) {
-            if !recover_preinitialized_for_spawn(thread) {
-                // The current thread should not have set yet. Use an abort to save binary size (see #123356).
-                rtabort!("current thread handle already set during thread spawn");
-            }
-        }
+        set_current(self.handle.clone());
 
         if let Some(name) = self.handle.cname() {
             imp::set_name(name);

--- a/library/std/src/thread/tests.rs
+++ b/library/std/src/thread/tests.rs
@@ -21,60 +21,6 @@ fn test_unnamed_thread() {
 }
 
 #[test]
-fn test_spawn_recovers_from_preinit_current() {
-    // SAFETY: only this test reads the variable, and it is cleared before returning.
-    unsafe { crate::env::set_var("__RUST_STD_TEST_PREINIT_CURRENT", "1") };
-    let result = Builder::new()
-        .name("worker".into())
-        .spawn(|| {
-            assert_eq!(thread::current().name(), Some("worker"));
-        });
-    unsafe { crate::env::remove_var("__RUST_STD_TEST_PREINIT_CURRENT") };
-    result.unwrap().join().unwrap();
-}
-
-#[test]
-fn test_spawn_recovers_from_preinit_current_nested_spawn() {
-    unsafe { crate::env::set_var("__RUST_STD_TEST_PREINIT_CURRENT", "1") };
-    let outer = Builder::new()
-        .name("outer".into())
-        .spawn(|| {
-            assert_eq!(thread::current().name(), Some("outer"));
-            let inner = Builder::new()
-                .name("inner".into())
-                .spawn(|| {
-                    assert_eq!(thread::current().name(), Some("inner"));
-                    thread::current().id()
-                })
-                .unwrap()
-                .join()
-                .unwrap();
-            assert_ne!(thread::current().id(), inner);
-        });
-    unsafe { crate::env::remove_var("__RUST_STD_TEST_PREINIT_CURRENT") };
-    outer.unwrap().join().unwrap();
-}
-
-#[test]
-fn test_spawn_recovers_from_preinit_current_preserves_thread_id() {
-    unsafe { crate::env::set_var("__RUST_STD_TEST_PREINIT_CURRENT", "1") };
-    let preinit_id = thread::current().id();
-    let child = Builder::new()
-        .name("preinit-worker".into())
-        .spawn(move || {
-            let current = thread::current();
-            assert_eq!(current.name(), Some("preinit-worker"));
-            assert_ne!(current.id(), preinit_id);
-            current.id()
-        })
-        .unwrap()
-        .join()
-        .unwrap();
-    unsafe { crate::env::remove_var("__RUST_STD_TEST_PREINIT_CURRENT") };
-    assert_ne!(child, preinit_id);
-}
-
-#[test]
 fn test_named_thread() {
     Builder::new()
         .name("ada lovelace".to_string())

--- a/library/std/src/thread/tests.rs
+++ b/library/std/src/thread/tests.rs
@@ -21,6 +21,60 @@ fn test_unnamed_thread() {
 }
 
 #[test]
+fn test_spawn_recovers_from_preinit_current() {
+    // SAFETY: only this test reads the variable, and it is cleared before returning.
+    unsafe { crate::env::set_var("__RUST_STD_TEST_PREINIT_CURRENT", "1") };
+    let result = Builder::new()
+        .name("worker".into())
+        .spawn(|| {
+            assert_eq!(thread::current().name(), Some("worker"));
+        });
+    unsafe { crate::env::remove_var("__RUST_STD_TEST_PREINIT_CURRENT") };
+    result.unwrap().join().unwrap();
+}
+
+#[test]
+fn test_spawn_recovers_from_preinit_current_nested_spawn() {
+    unsafe { crate::env::set_var("__RUST_STD_TEST_PREINIT_CURRENT", "1") };
+    let outer = Builder::new()
+        .name("outer".into())
+        .spawn(|| {
+            assert_eq!(thread::current().name(), Some("outer"));
+            let inner = Builder::new()
+                .name("inner".into())
+                .spawn(|| {
+                    assert_eq!(thread::current().name(), Some("inner"));
+                    thread::current().id()
+                })
+                .unwrap()
+                .join()
+                .unwrap();
+            assert_ne!(thread::current().id(), inner);
+        });
+    unsafe { crate::env::remove_var("__RUST_STD_TEST_PREINIT_CURRENT") };
+    outer.unwrap().join().unwrap();
+}
+
+#[test]
+fn test_spawn_recovers_from_preinit_current_preserves_thread_id() {
+    unsafe { crate::env::set_var("__RUST_STD_TEST_PREINIT_CURRENT", "1") };
+    let preinit_id = thread::current().id();
+    let child = Builder::new()
+        .name("preinit-worker".into())
+        .spawn(move || {
+            let current = thread::current();
+            assert_eq!(current.name(), Some("preinit-worker"));
+            assert_ne!(current.id(), preinit_id);
+            current.id()
+        })
+        .unwrap()
+        .join()
+        .unwrap();
+    unsafe { crate::env::remove_var("__RUST_STD_TEST_PREINIT_CURRENT") };
+    assert_ne!(child, preinit_id);
+}
+
+#[test]
 fn test_named_thread() {
     Builder::new()
         .name("ada lovelace".to_string())


### PR DESCRIPTION
Fixes rust-lang/rust#156277

On Windows, `thread::spawn` can abort if `current()` is called from a
`DLL_THREAD_ATTACH` handler before the new thread's TLS is initialized.
Recover the pre-initialized handle instead of aborting.