### PR TITLE
std: map ENOTSUP to ErrorKind::Unsupported

### DIFF
--- a/library/std/src/sys/io/error/unix.rs
+++ b/library/std/src/sys/io/error/unix.rs
@@ -158,7 +158,6 @@ pub fn decode_error_kind(errno: i32) -> io::ErrorKind {
         libc::ENOENT => NotFound,
         libc::ENOMEM => OutOfMemory,
         libc::ENOSPC => StorageFull,
-        libc::ENOSYS => Unsupported,
         libc::EMLINK => TooManyLinks,
         libc::ENAMETOOLONG => InvalidFilename,
         libc::ENETDOWN => NetworkDown,
@@ -180,6 +179,7 @@ pub fn decode_error_kind(errno: i32) -> io::ErrorKind {
 
         libc::EACCES | libc::EPERM => PermissionDenied,
 
+        libc::ENOSYS => Unsupported,
         // EOPNOTSUPP and ENOTSUP can have the same value on some systems,
         // but different values on others (e.g. Apple), so we can't use a
         // match clause

--- a/library/std/src/sys/io/error/unix.rs
+++ b/library/std/src/sys/io/error/unix.rs
@@ -176,10 +176,14 @@ pub fn decode_error_kind(errno: i32) -> io::ErrorKind {
         libc::EXDEV => CrossesDevices,
         libc::EINPROGRESS => InProgress,
         libc::EMFILE | libc::ENFILE => TooManyOpenFiles,
-        libc::EOPNOTSUPP => Unsupported,
         libc::EIO => InputOutputError,
 
         libc::EACCES | libc::EPERM => PermissionDenied,
+
+        // EOPNOTSUPP and ENOTSUP can have the same value on some systems,
+        // but different values on others (e.g. Apple), so we can't use a
+        // match clause
+        x if x == libc::EOPNOTSUPP || x == libc::ENOTSUP => Unsupported,
 
         // These two constants can have the same value on some systems,
         // but different values on others, so we can't use a match


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/158580)*
<!-- homu-ignore:end -->

`ENOTSUP` and `EOPNOTSUPP` both mean the operation isn't supported. They're the same value on some targets (Linux, FreeBSD), where the existing `EOPNOTSUPP => Unsupported` arm (rust-lang/rust#139822) already covers both, and different on others (Apple, OpenBSD), where `ENOTSUP` decodes to `Uncategorized` instead. I don't see a reason to treat it differently, so this maps `ENOTSUP` to `Unsupported` as well.

It uses a match guard rather than an or-pattern, since the two are equal on the targets where they alias and an or-pattern would be unreachable there. Same shape as the `EAGAIN`/`EWOULDBLOCK` arm just below:

```rust
x if x == libc::EOPNOTSUPP || x == libc::ENOTSUP => Unsupported,
```

This was raised once before (rust-lang/rust#125228) and closed, since both errnos were left out of the original `Unsupported` PR (rust-lang/rust#78880). rust-lang/rust#139822 has since added `EOPNOTSUPP`, so the same reasoning now covers `ENOTSUP`.

I didn't add a test, since the decode arms aren't tested today.

r? libs

