### PR TITLE
Comment on needed RAM in huge-stacks.rs

### DIFF
--- a/tests/ui/codegen/huge-stacks.rs
+++ b/tests/ui/codegen/huge-stacks.rs
@@ -5,6 +5,7 @@
 //@ min-llvm-version: 22
 
 // Regression test for https://github.com/rust-lang/rust/issues/83060
+// Verifies a program is not miscompiled if it includes a 4GB array on the stack
 
 fn func() {
     const CAP: usize = std::u32::MAX as usize;
@@ -17,7 +18,7 @@ fn main() {
     std::thread::Builder::new()
         .stack_size(5 * 1024 * 1024 * 1024)
         .spawn(func)
-        .unwrap()
+        .expect("huge-stacks.rs requires 5GB RAM to run")
         .join()
         .unwrap();
 }


### PR DESCRIPTION
We were asked to make this test error with a more useful message for external CIs with resource-constrained runners.

<!-- homu-ignore:start -->
Fixes rust-lang/rust#158557
<!-- homu-ignore:end -->