### PR TITLE
Improve diagnostic for too many super keywords

### DIFF
--- a/compiler/rustc_resolve/src/ident.rs
+++ b/compiler/rustc_resolve/src/ident.rs
@@ -26,6 +26,7 @@ use crate::{
     Determinacy, ExternModule, Finalize, IdentKey, ImportKind, ImportSummary, LateDecl,
     LocalModule, Module, ModuleKind, ModuleOrUniformRoot, ParentScope, PathResult, PrivacyError,
     Res, ResolutionError, Resolver, Scope, ScopeSet, Segment, Stage, Symbol, Used, diagnostics,
+    module_to_string,
 };
 
 #[derive(Copy, Clone)]
@@ -1865,6 +1866,10 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                         module = Some(ModuleOrUniformRoot::Module(parent));
                         continue;
                     }
+                    let mut ctxt = ident.span.ctxt().normalize_to_macros_2_0();
+                    let current_module = self.resolve_self(&mut ctxt, parent_scope.module);
+                    let current_module_path = module_to_string(current_module)
+                        .map_or_else(|| "crate".to_string(), |path| format!("crate::{path}"));
                     return PathResult::failed(
                         ident,
                         false,
@@ -1873,8 +1878,10 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                         module,
                         || {
                             (
-                                "too many leading `super` keywords".to_string(),
-                                "there are too many leading `super` keywords".to_string(),
+                                format!(
+                                    "too many leading `super` keywords within `{current_module_path}`"
+                                ),
+                                "this `super` would go above the crate root".to_string(),
                                 None,
                                 None,
                             )

--- a/tests/ui/impl-restriction/restriction_resolution_errors.rs
+++ b/tests/ui/impl-restriction/restriction_resolution_errors.rs
@@ -23,7 +23,7 @@ pub mod a {
 
         pub impl(in super::E) trait T6 {} //~ ERROR expected module, found enum `super::E` [E0577]
 
-        pub impl(in super::super::super) trait T7 {} //~ ERROR too many leading `super` keywords [E0433]
+        pub impl(in super::super::super) trait T7 {} //~ ERROR too many leading `super` keywords within `crate::a::b` [E0433]
 
         // OK paths
         pub impl(crate) trait T8 {}
@@ -53,7 +53,7 @@ pub impl(in crate::a::E) trait T14 {} //~ ERROR expected module, found enum `cra
 pub impl(crate) trait T15 {}
 pub impl(self) trait T16 {}
 
-pub impl(super) trait T17 {} //~ ERROR too many leading `super` keywords [E0433]
+pub impl(super) trait T17 {} //~ ERROR too many leading `super` keywords within `crate` [E0433]
 
 pub impl(in external) trait T18 {} //~ ERROR trait implementation can only be restricted to ancestor modules
 

--- a/tests/ui/impl-restriction/restriction_resolution_errors.stderr
+++ b/tests/ui/impl-restriction/restriction_resolution_errors.stderr
@@ -16,11 +16,11 @@ error: trait implementation can only be restricted to ancestor modules
 LL |         pub impl(in super::d) trait T4 {}
    |                     ^^^^^^^^
 
-error[E0433]: too many leading `super` keywords
+error[E0433]: too many leading `super` keywords within `crate::a::b`
   --> $DIR/restriction_resolution_errors.rs:26:35
    |
 LL |         pub impl(in super::super::super) trait T7 {}
-   |                                   ^^^^^ there are too many leading `super` keywords
+   |                                   ^^^^^ this `super` would go above the crate root
 
 error: trait implementation can only be restricted to ancestor modules
   --> $DIR/restriction_resolution_errors.rs:36:21
@@ -40,11 +40,11 @@ error: trait implementation can only be restricted to ancestor modules
 LL | pub impl(in crate::a) trait T13 {}
    |             ^^^^^^^^
 
-error[E0433]: too many leading `super` keywords
+error[E0433]: too many leading `super` keywords within `crate`
   --> $DIR/restriction_resolution_errors.rs:56:10
    |
 LL | pub impl(super) trait T17 {}
-   |          ^^^^^ there are too many leading `super` keywords
+   |          ^^^^^ this `super` would go above the crate root
 
 error: trait implementation can only be restricted to ancestor modules
   --> $DIR/restriction_resolution_errors.rs:58:13

--- a/tests/ui/keyword/keyword-super-as-identifier.rs
+++ b/tests/ui/keyword/keyword-super-as-identifier.rs
@@ -1,3 +1,3 @@
 fn main() {
-    let super = 22; //~ ERROR too many leading `super` keywords
+    let super = 22; //~ ERROR too many leading `super` keywords within `crate`
 }

--- a/tests/ui/keyword/keyword-super-as-identifier.stderr
+++ b/tests/ui/keyword/keyword-super-as-identifier.stderr
@@ -1,8 +1,8 @@
-error[E0433]: too many leading `super` keywords
+error[E0433]: too many leading `super` keywords within `crate`
   --> $DIR/keyword-super-as-identifier.rs:2:9
    |
 LL |     let super = 22;
-   |         ^^^^^ there are too many leading `super` keywords
+   |         ^^^^^ this `super` would go above the crate root
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/keyword/keyword-super.rs
+++ b/tests/ui/keyword/keyword-super.rs
@@ -1,3 +1,3 @@
 fn main() {
-    let super: isize; //~ ERROR: too many leading `super` keywords
+    let super: isize; //~ ERROR: too many leading `super` keywords within `crate`
 }

--- a/tests/ui/keyword/keyword-super.stderr
+++ b/tests/ui/keyword/keyword-super.stderr
@@ -1,8 +1,8 @@
-error[E0433]: too many leading `super` keywords
+error[E0433]: too many leading `super` keywords within `crate`
   --> $DIR/keyword-super.rs:2:9
    |
 LL |     let super: isize;
-   |         ^^^^^ there are too many leading `super` keywords
+   |         ^^^^^ this `super` would go above the crate root
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/modules/super-at-crate-root.rs
+++ b/tests/ui/modules/super-at-crate-root.rs
@@ -1,6 +1,6 @@
 //! Check that `super` keyword used at the crate root (top-level) results in a compilation error
 //! as there is no parent module to resolve.
 
-use super::f; //~ ERROR too many leading `super` keywords
+use super::f; //~ ERROR too many leading `super` keywords within `crate`
 
 fn main() {}

--- a/tests/ui/modules/super-at-crate-root.stderr
+++ b/tests/ui/modules/super-at-crate-root.stderr
@@ -1,8 +1,8 @@
-error[E0433]: too many leading `super` keywords
+error[E0433]: too many leading `super` keywords within `crate`
   --> $DIR/super-at-crate-root.rs:4:5
    |
 LL | use super::f;
-   |     ^^^^^ there are too many leading `super` keywords
+   |     ^^^^^ this `super` would go above the crate root
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/resolve/impl-items-vis-unresolved.rs
+++ b/tests/ui/resolve/impl-items-vis-unresolved.rs
@@ -19,7 +19,7 @@ pub struct RawFloatState;
 impl RawFloatState {
     perftools_inline! {
         pub(super) fn new() {}
-        //~^ ERROR: too many leading `super` keywords
+        //~^ ERROR: too many leading `super` keywords within `crate`
     }
 }
 

--- a/tests/ui/resolve/impl-items-vis-unresolved.stderr
+++ b/tests/ui/resolve/impl-items-vis-unresolved.stderr
@@ -1,8 +1,8 @@
-error[E0433]: too many leading `super` keywords
+error[E0433]: too many leading `super` keywords within `crate`
   --> $DIR/impl-items-vis-unresolved.rs:21:13
    |
 LL |         pub(super) fn new() {}
-   |             ^^^^^ there are too many leading `super` keywords
+   |             ^^^^^ this `super` would go above the crate root
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/resolve/issue-117920.rs
+++ b/tests/ui/resolve/issue-117920.rs
@@ -1,6 +1,6 @@
 #![crate_type = "lib"]
 
-use super::A; //~ ERROR too many leading `super` keywords
+use super::A; //~ ERROR too many leading `super` keywords within `crate`
 
 mod b {
     pub trait A {}

--- a/tests/ui/resolve/issue-117920.stderr
+++ b/tests/ui/resolve/issue-117920.stderr
@@ -1,8 +1,8 @@
-error[E0433]: too many leading `super` keywords
+error[E0433]: too many leading `super` keywords within `crate`
   --> $DIR/issue-117920.rs:3:5
    |
 LL | use super::A;
-   |     ^^^^^ there are too many leading `super` keywords
+   |     ^^^^^ this `super` would go above the crate root
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/resolve/issue-82156.rs
+++ b/tests/ui/resolve/issue-82156.rs
@@ -1,3 +1,3 @@
 fn main() {
-    super(); //~ ERROR: too many leading `super` keywords
+    super(); //~ ERROR: too many leading `super` keywords within `crate`
 }

--- a/tests/ui/resolve/issue-82156.stderr
+++ b/tests/ui/resolve/issue-82156.stderr
@@ -1,8 +1,8 @@
-error[E0433]: too many leading `super` keywords
+error[E0433]: too many leading `super` keywords within `crate`
   --> $DIR/issue-82156.rs:2:5
    |
 LL |     super();
-   |     ^^^^^ there are too many leading `super` keywords
+   |     ^^^^^ this `super` would go above the crate root
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/resolve/too-many-super-issue-158275.rs
+++ b/tests/ui/resolve/too-many-super-issue-158275.rs
@@ -1,0 +1,10 @@
+#![crate_type = "lib"]
+
+mod outer {
+    mod inner {
+        struct Example(super::super::super::Impl);
+        //~^ ERROR too many leading `super` keywords within `crate::outer::inner`
+    }
+}
+
+struct Impl;

--- a/tests/ui/resolve/too-many-super-issue-158275.stderr
+++ b/tests/ui/resolve/too-many-super-issue-158275.stderr
@@ -1,0 +1,9 @@
+error[E0433]: too many leading `super` keywords within `crate::outer::inner`
+  --> $DIR/too-many-super-issue-158275.rs:5:38
+   |
+LL |         struct Example(super::super::super::Impl);
+   |                                      ^^^^^ this `super` would go above the crate root
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0433`.


### PR DESCRIPTION
Fixes rust-lang/rust#158275

When resolving a path with too many leading `super` segments inside a nested module,
include the current module path in the diagnostic. This makes it easier to see where
the `super` chain started, especially for generated code or code included from
another location.

The overflowing `super` label now also explains that it would go above the crate root.

Example:

```text
error[E0433]: too many leading `super` keywords within `crate::outer::inner`
  --> tests/ui/resolve/too-many-super-issue-158275.rs:5:38
   |
LL |         struct Example(super::super::super::Impl);
   |                                      ^^^^^ this `super` would go above the crate root
```

Tests:

```text
x.py --build x86_64-pc-windows-gnu --host x86_64-pc-windows-gnu check compiler/rustc_resolve --stage 1
x.py --build x86_64-pc-windows-gnu --host x86_64-pc-windows-gnu test tidy
```

