### PR TITLE
check if len of array const arg matches the expected len of the type when lowering to valtree

### DIFF
--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
@@ -2478,13 +2478,13 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
     ) -> Const<'tcx> {
         let tcx = self.tcx();
 
-        let elem_ty = match ty.kind() {
-            ty::Array(elem_ty, _) => elem_ty,
+        let (elem_ty, len) = match ty.kind() {
+            ty::Array(elem_ty, len) => (elem_ty, len),
             ty::Error(e) => return Const::new_error(tcx, *e),
             _ => {
                 let e = tcx
                     .dcx()
-                    .span_err(array_expr.span, format!("expected `{}`, found const array", ty));
+                    .span_err(array_expr.span, format!("expected `{ty}`, found const array"));
                 return Const::new_error(tcx, e);
             }
         };
@@ -2494,6 +2494,25 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             .iter()
             .map(|elem| self.lower_const_arg(elem, *elem_ty))
             .collect::<Vec<_>>();
+
+        let len = tcx
+            .try_normalize_erasing_regions(
+                ty::TypingEnv::new(ty::ParamEnv::empty(), TypingMode::non_body_analysis()),
+                Unnormalized::new_wip(*len),
+            )
+            .unwrap_or(*len);
+        if let Some(expected_len) = len.try_to_target_usize(tcx)
+            && expected_len != elems.len() as u64
+        {
+            let e = tcx.dcx().span_err(
+                array_expr.span,
+                format!(
+                    "expected array with {expected_len} elements, found {} elements",
+                    array_expr.elems.len()
+                ),
+            );
+            return Const::new_error(tcx, e);
+        }
 
         let valtree = ty::ValTree::from_branches(tcx, elems);
 

--- a/tests/crashes/160553.rs
+++ b/tests/crashes/160553.rs
@@ -1,0 +1,26 @@
+//@ known-bug: #160553
+//@ compile-flags: -Copt-level=0
+#![allow(incomplete_features)]
+#![feature(adt_const_params, min_generic_const_args, macroless_generic_const_args)]
+#![feature(generic_const_parameter_types)]
+
+trait Trait {
+    type const LEN: usize;
+}
+
+struct S;
+impl Trait for S {
+    type const LEN: usize = 2;
+}
+
+fn foo<T: Trait, const A: [u8; <T as Trait>::LEN]>() -> [u8; <T as Trait>::LEN] {
+    A
+}
+
+fn bar<T: Trait>() -> [u8; <T as Trait>::LEN] {
+    foo::<T, { [1, 2, 3] }>()
+}
+
+fn main() {
+    bar::<S>();
+}

--- a/tests/ui/const-generics/mgca/array-const-arg-len-mismatch.rs
+++ b/tests/ui/const-generics/mgca/array-const-arg-len-mismatch.rs
@@ -1,0 +1,39 @@
+//! Regression test for #155168
+//!
+//! Ensure that providing an array const arg with the wrong number of elements
+//! doesn't ICE or silently cause UB.
+#![expect(incomplete_features)]
+#![feature(adt_const_params, min_generic_const_args, macroless_generic_const_args)]
+#![feature(unsized_const_params, generic_const_parameter_types)]
+
+use std::marker::ConstParamTy_;
+
+fn foo<T: ConstParamTy_, const N: usize, const M: [T; N]>() -> [T; N] {
+    M
+}
+
+fn bar<const A: [u8; 2]>() {}
+
+trait Trait {
+    type const LEN: usize;
+}
+
+struct S;
+impl Trait for S {
+    type const LEN: usize = 3;
+}
+
+fn baz<const A: [u8; <S as Trait>::LEN]>() {}
+
+fn main() {
+    foo::<u8, 2, { [] }>();
+    //~^ ERROR: expected array with 2 elements, found 0 elements
+    foo::<u8, 2, { [0, 0, 0] }>();
+    //~^ ERROR: expected array with 2 elements, found 3 elements
+    bar::<{ [] }>();
+    //~^ ERROR: expected array with 2 elements, found 0 elements
+    bar::<{ [1, 2, 3] }>();
+    //~^ ERROR: expected array with 2 elements, found 3 elements
+    baz::<{ [42] }>();
+    //~^ ERROR: expected array with 3 elements, found 1 elements
+}

--- a/tests/ui/const-generics/mgca/array-const-arg-len-mismatch.stderr
+++ b/tests/ui/const-generics/mgca/array-const-arg-len-mismatch.stderr
@@ -1,0 +1,32 @@
+error: expected array with 2 elements, found 0 elements
+  --> $DIR/array-const-arg-len-mismatch.rs:29:20
+   |
+LL |     foo::<u8, 2, { [] }>();
+   |                    ^^
+
+error: expected array with 2 elements, found 3 elements
+  --> $DIR/array-const-arg-len-mismatch.rs:31:20
+   |
+LL |     foo::<u8, 2, { [0, 0, 0] }>();
+   |                    ^^^^^^^^^
+
+error: expected array with 2 elements, found 0 elements
+  --> $DIR/array-const-arg-len-mismatch.rs:33:13
+   |
+LL |     bar::<{ [] }>();
+   |             ^^
+
+error: expected array with 2 elements, found 3 elements
+  --> $DIR/array-const-arg-len-mismatch.rs:35:13
+   |
+LL |     bar::<{ [1, 2, 3] }>();
+   |             ^^^^^^^^^
+
+error: expected array with 3 elements, found 1 elements
+  --> $DIR/array-const-arg-len-mismatch.rs:37:13
+   |
+LL |     baz::<{ [42] }>();
+   |             ^^^^
+
+error: aborting due to 5 previous errors
+


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

When creating valtrees for arrays passed as const args in `lower_const_arg_array`, we assume the array has the correct length without actually checking the length of the arg, leading to UB at runtime (rust-lang/rust#155168) or an ICE during CTFE (rust-lang/rust#151079). This PR adds a check comparing the expected length of the type with the actual number of elements, similar to `lower_const_arg_tup`.

fixes rust-lang/rust#155168