### PR TITLE
trait_selection: fix assumptions-on-binders diagnostics

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/region_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/region_errors.rs
@@ -478,14 +478,9 @@ impl<'diag, 'tcx> MirBorrowckCtxt<'_, 'diag, 'tcx> {
         let errci = ErrorConstraintInfo { fr, outlived_fr, category, span };
 
         let mut diag = match (category, fr_is_local, outlived_fr_is_local) {
-            (ConstraintCategory::SolverRegionConstraint(span), _, _) => {
-                let mut d = self.dcx().struct_span_err(
-                    span,
-                    "unsatisfied lifetime constraint from -Zassumptions-on-binders :3",
-                );
-                d.note("meoow :c");
-                d
-            }
+            (ConstraintCategory::SolverRegionConstraint(span), _, _) => self
+                .dcx()
+                .struct_span_err(span, "higher-ranked lifetime bound could not be satisfied"),
             (ConstraintCategory::Return(kind), true, false)
                 if self.regioncx.is_closure_fn_mut(fr) =>
             {

--- a/compiler/rustc_borrowck/src/type_check/constraint_conversion.rs
+++ b/compiler/rustc_borrowck/src/type_check/constraint_conversion.rs
@@ -153,7 +153,7 @@ impl<'a, 'tcx> ConstraintConversion<'a, 'tcx> {
             GenericArgKind::Lifetime(r1) => {
                 let r1_vid = self.to_region_vid(r1);
                 let r2_vid = self.to_region_vid(r2);
-                self.add_outlives(r1_vid, r2_vid, constraint_category);
+                self.add_outlives(r1_vid, r2_vid, constraint_category, self.span);
             }
 
             GenericArgKind::Type(mut t1) => {
@@ -221,6 +221,7 @@ impl<'a, 'tcx> ConstraintConversion<'a, 'tcx> {
         sup: ty::RegionVid,
         sub: ty::RegionVid,
         category: ConstraintCategory<'tcx>,
+        span: Span,
     ) {
         let category = match self.category {
             ConstraintCategory::Boring | ConstraintCategory::BoringNoLocation => category,
@@ -229,7 +230,7 @@ impl<'a, 'tcx> ConstraintConversion<'a, 'tcx> {
         self.constraints.outlives_constraints.push(OutlivesConstraint {
             locations: self.locations,
             category,
-            span: self.span,
+            span,
             sub,
             sup,
             variance_info: ty::VarianceDiagInfo::default(),
@@ -246,14 +247,14 @@ impl<'a, 'tcx> ConstraintConversion<'a, 'tcx> {
 impl<'a, 'b, 'tcx> TypeOutlivesDelegate<'tcx> for &'a mut ConstraintConversion<'b, 'tcx> {
     fn push_sub_region_constraint(
         &mut self,
-        _origin: SubregionOrigin<'tcx>,
+        origin: SubregionOrigin<'tcx>,
         a: ty::Region<'tcx>,
         b: ty::Region<'tcx>,
         constraint_category: ConstraintCategory<'tcx>,
     ) {
         let b = self.to_region_vid(b);
         let a = self.to_region_vid(a);
-        self.add_outlives(b, a, constraint_category);
+        self.add_outlives(b, a, constraint_category, origin.span());
     }
 
     fn push_verify(

--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -188,7 +188,6 @@ pub(crate) fn type_check<'tcx>(
             &mut converter,
             typeck.known_type_outlives_obligations,
             universal_region_relations.outlives.clone(),
-            infcx.tcx.def_span(infcx.root_def_id),
         );
     }
 

--- a/compiler/rustc_infer/src/infer/context.rs
+++ b/compiler/rustc_infer/src/infer/context.rs
@@ -64,12 +64,13 @@ impl<'tcx> rustc_type_ir::InferCtxtLike for InferCtxt<'tcx> {
     fn get_solver_region_constraint(
         &self,
     ) -> rustc_type_ir::region_constraint::RegionConstraint<TyCtxt<'tcx>> {
-        self.inner.borrow().solver_region_constraint_storage.get_constraint()
+        self.inner.borrow().solver_region_constraint_storage.get_unspanned_constraint()
     }
 
     fn overwrite_solver_region_constraint(
         &self,
         constraint: rustc_type_ir::region_constraint::RegionConstraint<TyCtxt<'tcx>>,
+        span: Span,
     ) {
         let mut inner = self.inner.borrow_mut();
         use rustc_data_structures::undo_log::UndoLogs;
@@ -77,7 +78,7 @@ impl<'tcx> rustc_type_ir::InferCtxtLike for InferCtxt<'tcx> {
         use crate::infer::UndoLog;
         let old_constraint = inner.solver_region_constraint_storage.get_constraint();
         inner.undo_log.push(UndoLog::OverwriteSolverRegionConstraint { old_constraint });
-        inner.solver_region_constraint_storage.overwrite_solver_region_constraint(constraint);
+        inner.solver_region_constraint_storage.overwrite(constraint, span);
     }
 
     fn universe_of_ty(&self, vid: ty::TyVid) -> Option<ty::UniverseIndex> {
@@ -331,6 +332,7 @@ impl<'tcx> rustc_type_ir::InferCtxtLike for InferCtxt<'tcx> {
     fn register_solver_region_constraint(
         &self,
         c: rustc_type_ir::region_constraint::RegionConstraint<TyCtxt<'tcx>>,
+        span: Span,
     ) {
         let mut inner = self.inner.borrow_mut();
         use rustc_data_structures::undo_log::UndoLogs;
@@ -338,7 +340,7 @@ impl<'tcx> rustc_type_ir::InferCtxtLike for InferCtxt<'tcx> {
         use crate::infer::UndoLog;
         let previous_was_and = inner.solver_region_constraint_storage.is_and();
         inner.undo_log.push(UndoLog::PushSolverRegionConstraint { previous_was_and });
-        inner.solver_region_constraint_storage.push(c);
+        inner.solver_region_constraint_storage.push(c, span);
     }
 
     fn register_ty_outlives(&self, ty: Ty<'tcx>, r: ty::Region<'tcx>, span: Span) {

--- a/compiler/rustc_infer/src/infer/context.rs
+++ b/compiler/rustc_infer/src/infer/context.rs
@@ -63,12 +63,13 @@ impl<'tcx> rustc_type_ir::InferCtxtLike for InferCtxt<'tcx> {
     fn get_solver_region_constraint(
         &self,
     ) -> rustc_type_ir::region_constraint::RegionConstraint<TyCtxt<'tcx>> {
-        self.inner.borrow().solver_region_constraint_storage.get_constraint()
+        self.inner.borrow().solver_region_constraint_storage.get_unspanned_constraint()
     }
 
     fn overwrite_solver_region_constraint(
         &self,
         constraint: rustc_type_ir::region_constraint::RegionConstraint<TyCtxt<'tcx>>,
+        span: Span,
     ) {
         let mut inner = self.inner.borrow_mut();
         use rustc_data_structures::undo_log::UndoLogs;
@@ -76,7 +77,7 @@ impl<'tcx> rustc_type_ir::InferCtxtLike for InferCtxt<'tcx> {
         use crate::infer::UndoLog;
         let old_constraint = inner.solver_region_constraint_storage.get_constraint();
         inner.undo_log.push(UndoLog::OverwriteSolverRegionConstraint { old_constraint });
-        inner.solver_region_constraint_storage.overwrite_solver_region_constraint(constraint);
+        inner.solver_region_constraint_storage.overwrite(constraint, span);
     }
 
     fn universe_of_ty(&self, vid: ty::TyVid) -> Option<ty::UniverseIndex> {
@@ -367,13 +368,14 @@ impl<'tcx> rustc_type_ir::InferCtxtLike for InferCtxt<'tcx> {
     fn register_solver_region_constraint(
         &self,
         c: rustc_type_ir::region_constraint::RegionConstraint<TyCtxt<'tcx>>,
+        span: Span,
     ) {
         let mut inner = self.inner.borrow_mut();
         use rustc_data_structures::undo_log::UndoLogs;
 
         use crate::infer::UndoLog;
         inner.undo_log.push(UndoLog::PushSolverRegionConstraint);
-        inner.solver_region_constraint_storage.push(c);
+        inner.solver_region_constraint_storage.push(c, span);
     }
 
     fn register_ty_outlives(&self, ty: Ty<'tcx>, r: ty::Region<'tcx>, span: Span) {

--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -61,8 +61,12 @@ pub mod region_constraints;
 pub mod relate;
 pub mod resolve;
 pub(crate) mod snapshot;
+mod solver_region_constraints;
 mod type_variable;
 mod unify_key;
+
+pub(crate) use solver_region_constraints::SolverRegionConstraint;
+use solver_region_constraints::SolverRegionConstraintStorage;
 
 /// `InferOk<'tcx, ()>` is used a lot. It may seem like a useless wrapper
 /// around `PredicateObligations<'tcx>`, but it has one important property:
@@ -1806,62 +1810,6 @@ impl<'tcx> InferCtxt<'tcx> {
             hir::Node::Expr(e) => e.span,
             _ => DUMMY_SP,
         }
-    }
-}
-
-type SolverRegionConstraint<'tcx> =
-    rustc_type_ir::region_constraint::RegionConstraint<TyCtxt<'tcx>>;
-
-#[derive(Clone, Debug)]
-struct SolverRegionConstraintStorage<'tcx>(SolverRegionConstraint<'tcx>);
-
-impl<'tcx> SolverRegionConstraintStorage<'tcx> {
-    fn new() -> Self {
-        SolverRegionConstraintStorage(SolverRegionConstraint::And(Box::new([])))
-    }
-
-    fn get_constraint(&self) -> SolverRegionConstraint<'tcx> {
-        self.0.clone()
-    }
-
-    fn is_and(&self) -> bool {
-        self.0.is_and()
-    }
-
-    fn pop(&mut self, previous_was_and: bool) -> Option<SolverRegionConstraint<'tcx>> {
-        match &mut self.0 {
-            SolverRegionConstraint::And(and) => {
-                let mut and = core::mem::take(and).into_iter().collect::<Vec<_>>();
-                let popped = and.pop()?;
-                if previous_was_and {
-                    self.0 = SolverRegionConstraint::And(and.into_boxed_slice());
-                } else {
-                    assert_eq!(and.len(), 1);
-                    self.0 = and.pop().unwrap();
-                }
-                Some(popped)
-            }
-            _ => unreachable!(),
-        }
-    }
-
-    #[instrument(level = "debug")]
-    fn push(&mut self, constraint: SolverRegionConstraint<'tcx>) {
-        match core::mem::replace(&mut self.0, SolverRegionConstraint::new_true()) {
-            SolverRegionConstraint::And(and) => {
-                let and =
-                    and.into_iter().chain([constraint]).collect::<Vec<_>>().into_boxed_slice();
-                self.0 = SolverRegionConstraint::And(and);
-            }
-            previous => {
-                self.0 = SolverRegionConstraint::And(Box::new([previous, constraint]));
-            }
-        }
-    }
-
-    #[instrument(level = "debug", skip(self))]
-    fn overwrite_solver_region_constraint(&mut self, constraint: SolverRegionConstraint<'tcx>) {
-        self.0 = constraint;
     }
 }
 

--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -60,8 +60,12 @@ pub mod region_constraints;
 pub mod relate;
 pub mod resolve;
 pub(crate) mod snapshot;
+mod solver_region_constraints;
 mod type_variable;
 mod unify_key;
+
+pub(crate) use solver_region_constraints::SolverRegionConstraint;
+use solver_region_constraints::SolverRegionConstraintStorage;
 
 /// `InferOk<'tcx, ()>` is used a lot. It may seem like a useless wrapper
 /// around `PredicateObligations<'tcx>`, but it has one important property:
@@ -1843,58 +1847,6 @@ impl<'tcx> InferCtxt<'tcx> {
             }
             hir::Node::Expr(e) => e.span,
             _ => DUMMY_SP,
-        }
-    }
-}
-
-type SolverRegionConstraint<'tcx> =
-    rustc_type_ir::region_constraint::RegionConstraint<TyCtxt<'tcx>>;
-
-#[derive(Clone, Debug)]
-struct SolverRegionConstraintStorage<'tcx>(SolverRegionConstraint<'tcx>);
-
-impl<'tcx> SolverRegionConstraintStorage<'tcx> {
-    fn new() -> Self {
-        SolverRegionConstraintStorage(SolverRegionConstraint::And(Box::new([])))
-    }
-
-    fn get_constraint(&self) -> SolverRegionConstraint<'tcx> {
-        self.0.clone()
-    }
-
-    fn pop(&mut self) -> Option<SolverRegionConstraint<'tcx>> {
-        match &mut self.0 {
-            SolverRegionConstraint::And(and) => {
-                let mut and = core::mem::take(and).into_iter().collect::<Vec<_>>();
-                let popped = and.pop()?;
-                self.0 = SolverRegionConstraint::And(and.into_boxed_slice());
-                Some(popped)
-            }
-            _ => unreachable!(),
-        }
-    }
-
-    #[instrument(level = "debug")]
-    fn push(&mut self, constraint: SolverRegionConstraint<'tcx>) {
-        match &mut self.0 {
-            SolverRegionConstraint::And(and) => {
-                let and = core::mem::take(and)
-                    .into_iter()
-                    .chain([constraint])
-                    .collect::<Vec<_>>()
-                    .into_boxed_slice();
-                self.0 = SolverRegionConstraint::And(and);
-            }
-            _ => unreachable!(),
-        }
-    }
-
-    #[instrument(level = "debug", skip(self))]
-    fn overwrite_solver_region_constraint(&mut self, constraint: SolverRegionConstraint<'tcx>) {
-        if !constraint.is_and() {
-            self.0 = SolverRegionConstraint::And(vec![constraint].into_boxed_slice())
-        } else {
-            self.0 = constraint;
         }
     }
 }

--- a/compiler/rustc_infer/src/infer/outlives/obligations.rs
+++ b/compiler/rustc_infer/src/infer/outlives/obligations.rs
@@ -248,20 +248,19 @@ impl<'tcx> InferCtxt<'tcx> {
 
         let constraint = self.inner.borrow().solver_region_constraint_storage.get_constraint();
         debug!(?constraint);
-        let constraint = constraint.map_atomic_constraints(&mut |constraint| {
+        let constraint =
             rustc_type_ir::region_constraint::destructure_type_outlives_constraints_in_root(
                 self,
                 constraint,
                 &assumptions,
-            )
-        });
+            );
         debug!(?constraint);
-        let constraint = constraint.evaluate();
+        let constraint = rustc_type_ir::region_constraint::evaluate_solver_constraint(&constraint);
         debug!(?constraint);
 
         let mut constraints = vec![constraint];
         while let Some(c) = constraints.pop() {
-            use crate::infer::SolverRegionConstraint::*;
+            use rustc_type_ir::region_constraint::RegionConstraint::*;
 
             match c {
                 Ambiguity(span) => {

--- a/compiler/rustc_infer/src/infer/outlives/obligations.rs
+++ b/compiler/rustc_infer/src/infer/outlives/obligations.rs
@@ -215,13 +215,12 @@ impl<'tcx> InferCtxt<'tcx> {
     pub fn destructure_solver_region_constraints_for_regionck(
         &self,
         outlives_env: &OutlivesEnvironment<'tcx>,
-        span: Span,
     ) {
         let assumptions = rustc_type_ir::region_constraint::Assumptions::new(
             outlives_env.known_type_outlives().into_iter().cloned().collect(),
             outlives_env.free_region_map().relation.clone(),
         );
-        self.destructure_solver_region_constraints(assumptions, self, span);
+        self.destructure_solver_region_constraints(assumptions, self);
     }
 
     pub fn destructure_solver_region_constraints_for_borrowck(
@@ -230,13 +229,12 @@ impl<'tcx> InferCtxt<'tcx> {
         conversion: impl TypeOutlivesDelegate<'tcx>,
         known_type_outlives: &[PolyTypeOutlivesClause<'tcx>],
         region_outlives: TransitiveRelation<RegionVid>,
-        span: Span,
     ) {
         let assumptions = rustc_type_ir::region_constraint::Assumptions::new(
             known_type_outlives.into_iter().cloned().collect(),
             region_outlives.maybe_map(|r| Some(Region::new_var(self.tcx, r))).unwrap(),
         );
-        self.destructure_solver_region_constraints(assumptions, conversion, span);
+        self.destructure_solver_region_constraints(assumptions, conversion);
     }
 
     #[instrument(level = "debug", skip(self, conversion))]
@@ -244,41 +242,42 @@ impl<'tcx> InferCtxt<'tcx> {
         &self,
         assumptions: rustc_type_ir::region_constraint::Assumptions<TyCtxt<'tcx>>,
         mut conversion: impl TypeOutlivesDelegate<'tcx>,
-        span: Span,
     ) {
         assert!(self.tcx.assumptions_on_binders());
         assert!(self.next_trait_solver());
 
-        let origin = SubregionOrigin::SolverRegionConstraint(span);
-        let category = origin.to_constraint_category();
-
         let constraint = self.inner.borrow().solver_region_constraint_storage.get_constraint();
         debug!(?constraint);
-        let constraint =
+        let constraint = constraint.map_atomic_constraints(&mut |constraint| {
             rustc_type_ir::region_constraint::destructure_type_outlives_constraints_in_root(
                 self,
                 constraint,
                 &assumptions,
-            );
+            )
+        });
         debug!(?constraint);
-        let constraint = rustc_type_ir::region_constraint::evaluate_solver_constraint(&constraint);
+        let constraint = constraint.evaluate();
         debug!(?constraint);
 
         let mut constraints = vec![constraint];
         while let Some(c) = constraints.pop() {
-            use rustc_type_ir::region_constraint::RegionConstraint::*;
+            use crate::infer::SolverRegionConstraint::*;
 
             match c {
-                Ambiguity => {
-                    self.dcx().err("unable to satisfy constraints involving placeholders due to unknown implied bounds");
+                Ambiguity(span) => {
+                    self.dcx()
+                        .struct_span_err(
+                            span,
+                            "unable to satisfy constraints involving placeholders due to unknown implied bounds",
+                        )
+                        .emit();
                 }
-                RegionOutlives(a, b) => {
+                RegionOutlives(a, b, span) => {
+                    let origin = SubregionOrigin::SolverRegionConstraint(span);
+                    let category = origin.to_constraint_category();
                     conversion.push_sub_region_constraint(
-                        origin.clone(),
-                        // we flip these because regionck is silly :>
-                        b,
-                        a,
-                        category,
+                        origin, // we flip these because regionck is silly :>
+                        b, a, category,
                     );
                 }
                 // FIXME(-Zassumptions-on-binders): actually implement OR as an  OR
@@ -306,7 +305,7 @@ impl<'tcx> InferCtxt<'tcx> {
         assert!(!self.in_snapshot(), "cannot process registered region obligations in a snapshot");
 
         if self.tcx.assumptions_on_binders() {
-            self.destructure_solver_region_constraints_for_regionck(outlives_env, span);
+            self.destructure_solver_region_constraints_for_regionck(outlives_env);
         }
 
         // Must loop since the process of normalizing may itself register region obligations.

--- a/compiler/rustc_infer/src/infer/outlives/obligations.rs
+++ b/compiler/rustc_infer/src/infer/outlives/obligations.rs
@@ -237,20 +237,19 @@ impl<'tcx> InferCtxt<'tcx> {
 
         let constraint = self.inner.borrow().solver_region_constraint_storage.get_constraint();
         debug!(?constraint);
-        let constraint = constraint.map_atomic_constraints(&mut |constraint| {
+        let constraint =
             rustc_type_ir::region_constraint::destructure_type_outlives_constraints_in_root(
                 self,
                 constraint,
                 &assumptions,
-            )
-        });
+            );
         debug!(?constraint);
-        let constraint = constraint.evaluate();
+        let constraint = rustc_type_ir::region_constraint::evaluate_solver_constraint(&constraint);
         debug!(?constraint);
 
         let mut constraints = vec![constraint];
         while let Some(c) = constraints.pop() {
-            use crate::infer::SolverRegionConstraint::*;
+            use rustc_type_ir::region_constraint::RegionConstraint::*;
 
             match c {
                 Ambiguity(span) => {

--- a/compiler/rustc_infer/src/infer/outlives/obligations.rs
+++ b/compiler/rustc_infer/src/infer/outlives/obligations.rs
@@ -204,13 +204,12 @@ impl<'tcx> InferCtxt<'tcx> {
     pub fn destructure_solver_region_constraints_for_regionck(
         &self,
         outlives_env: &OutlivesEnvironment<'tcx>,
-        span: Span,
     ) {
         let assumptions = rustc_type_ir::region_constraint::Assumptions::new(
             outlives_env.known_type_outlives().into_iter().cloned().collect(),
             outlives_env.free_region_map().relation.clone(),
         );
-        self.destructure_solver_region_constraints(assumptions, self, span);
+        self.destructure_solver_region_constraints(assumptions, self);
     }
 
     pub fn destructure_solver_region_constraints_for_borrowck(
@@ -219,13 +218,12 @@ impl<'tcx> InferCtxt<'tcx> {
         conversion: impl TypeOutlivesDelegate<'tcx>,
         known_type_outlives: &[PolyTypeOutlivesPredicate<'tcx>],
         region_outlives: TransitiveRelation<RegionVid>,
-        span: Span,
     ) {
         let assumptions = rustc_type_ir::region_constraint::Assumptions::new(
             known_type_outlives.into_iter().cloned().collect(),
             region_outlives.maybe_map(|r| Some(Region::new_var(self.tcx, r))).unwrap(),
         );
-        self.destructure_solver_region_constraints(assumptions, conversion, span);
+        self.destructure_solver_region_constraints(assumptions, conversion);
     }
 
     #[instrument(level = "debug", skip(self, conversion))]
@@ -233,41 +231,42 @@ impl<'tcx> InferCtxt<'tcx> {
         &self,
         assumptions: rustc_type_ir::region_constraint::Assumptions<TyCtxt<'tcx>>,
         mut conversion: impl TypeOutlivesDelegate<'tcx>,
-        span: Span,
     ) {
         assert!(self.tcx.assumptions_on_binders());
         assert!(self.next_trait_solver());
 
-        let origin = SubregionOrigin::SolverRegionConstraint(span);
-        let category = origin.to_constraint_category();
-
         let constraint = self.inner.borrow().solver_region_constraint_storage.get_constraint();
         debug!(?constraint);
-        let constraint =
+        let constraint = constraint.map_atomic_constraints(&mut |constraint| {
             rustc_type_ir::region_constraint::destructure_type_outlives_constraints_in_root(
                 self,
                 constraint,
                 &assumptions,
-            );
+            )
+        });
         debug!(?constraint);
-        let constraint = rustc_type_ir::region_constraint::evaluate_solver_constraint(&constraint);
+        let constraint = constraint.evaluate();
         debug!(?constraint);
 
         let mut constraints = vec![constraint];
         while let Some(c) = constraints.pop() {
-            use rustc_type_ir::region_constraint::RegionConstraint::*;
+            use crate::infer::SolverRegionConstraint::*;
 
             match c {
-                Ambiguity => {
-                    self.dcx().err("unable to satisfy constraints involving placeholders due to unknown implied bounds");
+                Ambiguity(span) => {
+                    self.dcx()
+                        .struct_span_err(
+                            span,
+                            "unable to satisfy constraints involving placeholders due to unknown implied bounds",
+                        )
+                        .emit();
                 }
-                RegionOutlives(a, b) => {
+                RegionOutlives(a, b, span) => {
+                    let origin = SubregionOrigin::SolverRegionConstraint(span);
+                    let category = origin.to_constraint_category();
                     conversion.push_sub_region_constraint(
-                        origin.clone(),
-                        // we flip these because regionck is silly :>
-                        b,
-                        a,
-                        category,
+                        origin, // we flip these because regionck is silly :>
+                        b, a, category,
                     );
                 }
                 // FIXME(-Zassumptions-on-binders): actually implement OR as an  OR
@@ -295,7 +294,7 @@ impl<'tcx> InferCtxt<'tcx> {
         assert!(!self.in_snapshot(), "cannot process registered region obligations in a snapshot");
 
         if self.tcx.assumptions_on_binders() {
-            self.destructure_solver_region_constraints_for_regionck(outlives_env, span);
+            self.destructure_solver_region_constraints_for_regionck(outlives_env);
         }
 
         // Must loop since the process of normalizing may itself register region obligations.

--- a/compiler/rustc_infer/src/infer/snapshot/undo_log.rs
+++ b/compiler/rustc_infer/src/infer/snapshot/undo_log.rs
@@ -88,8 +88,7 @@ impl<'tcx> Rollback<UndoLog<'tcx>> for InferCtxtInner<'tcx> {
                 );
             }
             UndoLog::OverwriteSolverRegionConstraint { old_constraint } => {
-                self.solver_region_constraint_storage
-                    .overwrite_solver_region_constraint(old_constraint);
+                self.solver_region_constraint_storage.overwrite_spanned(old_constraint);
             }
             UndoLog::PushTypeOutlivesConstraint => {
                 let popped = self.region_obligations.pop();

--- a/compiler/rustc_infer/src/infer/solver_region_constraints.rs
+++ b/compiler/rustc_infer/src/infer/solver_region_constraints.rs
@@ -1,135 +1,11 @@
-use rustc_middle::ty::{self, Ty, TyCtxt};
+use rustc_middle::ty::TyCtxt;
 use rustc_span::Span;
-use rustc_type_ir::region_constraint::RegionConstraint as UnspannedRegionConstraint;
+use rustc_type_ir::region_constraint::{
+    RegionConstraint as UnspannedRegionConstraint, SpannedRegionConstraint,
+};
 use tracing::instrument;
 
-/// A solver region constraint together with the span that caused each atomic constraint.
-///
-/// Solver query responses use [`UnspannedRegionConstraint`] so that source locations do not
-/// participate in candidate equality or caching. Spans are attached when those responses are
-/// applied to an inference context.
-#[derive(Clone, Debug)]
-pub(crate) enum SolverRegionConstraint<'tcx> {
-    Ambiguity(Span),
-    RegionOutlives(ty::Region<'tcx>, ty::Region<'tcx>, Span),
-    AliasTyOutlivesViaEnv(ty::Binder<'tcx, (ty::AliasTy<'tcx>, ty::Region<'tcx>)>, Span),
-    PlaceholderTyOutlives(Ty<'tcx>, ty::Region<'tcx>, Span),
-    And(Box<[SolverRegionConstraint<'tcx>]>),
-    Or(Box<[SolverRegionConstraint<'tcx>]>),
-}
-
-impl<'tcx> SolverRegionConstraint<'tcx> {
-    fn with_span(
-        constraint: UnspannedRegionConstraint<TyCtxt<'tcx>>,
-        span: Span,
-    ) -> SolverRegionConstraint<'tcx> {
-        use rustc_type_ir::region_constraint::RegionConstraint::*;
-
-        match constraint {
-            Ambiguity => Self::Ambiguity(span),
-            RegionOutlives(a, b) => Self::RegionOutlives(a, b, span),
-            AliasTyOutlivesViaEnv(outlives) => Self::AliasTyOutlivesViaEnv(outlives, span),
-            PlaceholderTyOutlives(ty, region) => Self::PlaceholderTyOutlives(ty, region, span),
-            And(constraints) => {
-                Self::And(constraints.into_iter().map(|c| Self::with_span(c, span)).collect())
-            }
-            Or(constraints) => {
-                Self::Or(constraints.into_iter().map(|c| Self::with_span(c, span)).collect())
-            }
-        }
-    }
-
-    fn without_spans(&self) -> UnspannedRegionConstraint<TyCtxt<'tcx>> {
-        use rustc_type_ir::region_constraint::RegionConstraint::*;
-
-        match self {
-            Self::Ambiguity(_) => Ambiguity,
-            Self::RegionOutlives(a, b, _) => RegionOutlives(*a, *b),
-            Self::AliasTyOutlivesViaEnv(outlives, _) => AliasTyOutlivesViaEnv(*outlives),
-            Self::PlaceholderTyOutlives(ty, region, _) => PlaceholderTyOutlives(*ty, *region),
-            Self::And(constraints) => And(constraints.iter().map(Self::without_spans).collect()),
-            Self::Or(constraints) => Or(constraints.iter().map(Self::without_spans).collect()),
-        }
-    }
-
-    pub(crate) fn map_atomic_constraints(
-        self,
-        f: &mut impl FnMut(
-            UnspannedRegionConstraint<TyCtxt<'tcx>>,
-        ) -> UnspannedRegionConstraint<TyCtxt<'tcx>>,
-    ) -> SolverRegionConstraint<'tcx> {
-        let (constraint, span) = match self {
-            Self::Ambiguity(span) => (UnspannedRegionConstraint::Ambiguity, span),
-            Self::RegionOutlives(a, b, span) => {
-                (UnspannedRegionConstraint::RegionOutlives(a, b), span)
-            }
-            Self::AliasTyOutlivesViaEnv(outlives, span) => {
-                (UnspannedRegionConstraint::AliasTyOutlivesViaEnv(outlives), span)
-            }
-            Self::PlaceholderTyOutlives(ty, region, span) => {
-                (UnspannedRegionConstraint::PlaceholderTyOutlives(ty, region), span)
-            }
-            Self::And(constraints) => {
-                return Self::And(
-                    constraints.into_iter().map(|c| c.map_atomic_constraints(f)).collect(),
-                );
-            }
-            Self::Or(constraints) => {
-                return Self::Or(
-                    constraints.into_iter().map(|c| c.map_atomic_constraints(f)).collect(),
-                );
-            }
-        };
-
-        Self::with_span(f(constraint), span)
-    }
-
-    pub(crate) fn evaluate(self) -> SolverRegionConstraint<'tcx> {
-        match self {
-            Self::And(constraints) => {
-                let mut evaluated = Vec::new();
-                let mut ambiguity = None;
-                for constraint in constraints {
-                    let constraint = constraint.evaluate();
-                    if constraint.is_false() {
-                        return Self::Or(Box::new([]));
-                    } else if let Self::Ambiguity(span) = constraint {
-                        ambiguity.get_or_insert(span);
-                    } else if !constraint.is_true() {
-                        evaluated.push(constraint);
-                    }
-                }
-
-                ambiguity.map_or_else(|| Self::And(evaluated.into_boxed_slice()), Self::Ambiguity)
-            }
-            Self::Or(constraints) => {
-                let mut evaluated = Vec::new();
-                let mut ambiguity = None;
-                for constraint in constraints {
-                    let constraint = constraint.evaluate();
-                    if constraint.is_true() {
-                        return Self::And(Box::new([]));
-                    } else if let Self::Ambiguity(span) = constraint {
-                        ambiguity.get_or_insert(span);
-                    } else if !constraint.is_false() {
-                        evaluated.push(constraint);
-                    }
-                }
-
-                ambiguity.map_or_else(|| Self::Or(evaluated.into_boxed_slice()), Self::Ambiguity)
-            }
-            constraint => constraint,
-        }
-    }
-
-    fn is_true(&self) -> bool {
-        matches!(self, Self::And(constraints) if constraints.is_empty())
-    }
-
-    fn is_false(&self) -> bool {
-        matches!(self, Self::Or(constraints) if constraints.is_empty())
-    }
-}
+pub(crate) type SolverRegionConstraint<'tcx> = SpannedRegionConstraint<TyCtxt<'tcx>>;
 
 #[derive(Clone, Debug)]
 pub(crate) struct SolverRegionConstraintStorage<'tcx>(SolverRegionConstraint<'tcx>);
@@ -144,7 +20,7 @@ impl<'tcx> SolverRegionConstraintStorage<'tcx> {
     }
 
     pub(crate) fn get_unspanned_constraint(&self) -> UnspannedRegionConstraint<TyCtxt<'tcx>> {
-        self.0.without_spans()
+        self.0.clone().without_spans()
     }
 
     pub(crate) fn pop(&mut self) -> Option<SolverRegionConstraint<'tcx>> {
@@ -161,7 +37,7 @@ impl<'tcx> SolverRegionConstraintStorage<'tcx> {
 
     #[instrument(level = "debug")]
     pub(crate) fn push(&mut self, constraint: UnspannedRegionConstraint<TyCtxt<'tcx>>, span: Span) {
-        let constraint = SolverRegionConstraint::with_span(constraint, span);
+        let constraint = constraint.with_span(span);
         match &mut self.0 {
             SolverRegionConstraint::And(and) => {
                 let and = core::mem::take(and)
@@ -181,7 +57,7 @@ impl<'tcx> SolverRegionConstraintStorage<'tcx> {
         constraint: UnspannedRegionConstraint<TyCtxt<'tcx>>,
         span: Span,
     ) {
-        self.overwrite_spanned(SolverRegionConstraint::with_span(constraint, span));
+        self.overwrite_spanned(constraint.with_span(span));
     }
 
     pub(crate) fn overwrite_spanned(&mut self, constraint: SolverRegionConstraint<'tcx>) {

--- a/compiler/rustc_infer/src/infer/solver_region_constraints.rs
+++ b/compiler/rustc_infer/src/infer/solver_region_constraints.rs
@@ -1,0 +1,197 @@
+use rustc_middle::ty::{self, Ty, TyCtxt};
+use rustc_span::Span;
+use rustc_type_ir::region_constraint::RegionConstraint as UnspannedRegionConstraint;
+use tracing::instrument;
+
+/// A solver region constraint together with the span that caused each atomic constraint.
+///
+/// Solver query responses use [`UnspannedRegionConstraint`] so that source locations do not
+/// participate in candidate equality or caching. Spans are attached when those responses are
+/// applied to an inference context.
+#[derive(Clone, Debug)]
+pub(crate) enum SolverRegionConstraint<'tcx> {
+    Ambiguity(Span),
+    RegionOutlives(ty::Region<'tcx>, ty::Region<'tcx>, Span),
+    AliasTyOutlivesViaEnv(ty::Binder<'tcx, (ty::AliasTy<'tcx>, ty::Region<'tcx>)>, Span),
+    PlaceholderTyOutlives(Ty<'tcx>, ty::Region<'tcx>, Span),
+    And(Box<[SolverRegionConstraint<'tcx>]>),
+    Or(Box<[SolverRegionConstraint<'tcx>]>),
+}
+
+impl<'tcx> SolverRegionConstraint<'tcx> {
+    fn with_span(
+        constraint: UnspannedRegionConstraint<TyCtxt<'tcx>>,
+        span: Span,
+    ) -> SolverRegionConstraint<'tcx> {
+        use rustc_type_ir::region_constraint::RegionConstraint::*;
+
+        match constraint {
+            Ambiguity => Self::Ambiguity(span),
+            RegionOutlives(a, b) => Self::RegionOutlives(a, b, span),
+            AliasTyOutlivesViaEnv(outlives) => Self::AliasTyOutlivesViaEnv(outlives, span),
+            PlaceholderTyOutlives(ty, region) => Self::PlaceholderTyOutlives(ty, region, span),
+            And(constraints) => {
+                Self::And(constraints.into_iter().map(|c| Self::with_span(c, span)).collect())
+            }
+            Or(constraints) => {
+                Self::Or(constraints.into_iter().map(|c| Self::with_span(c, span)).collect())
+            }
+        }
+    }
+
+    fn without_spans(&self) -> UnspannedRegionConstraint<TyCtxt<'tcx>> {
+        use rustc_type_ir::region_constraint::RegionConstraint::*;
+
+        match self {
+            Self::Ambiguity(_) => Ambiguity,
+            Self::RegionOutlives(a, b, _) => RegionOutlives(*a, *b),
+            Self::AliasTyOutlivesViaEnv(outlives, _) => AliasTyOutlivesViaEnv(*outlives),
+            Self::PlaceholderTyOutlives(ty, region, _) => PlaceholderTyOutlives(*ty, *region),
+            Self::And(constraints) => And(constraints.iter().map(Self::without_spans).collect()),
+            Self::Or(constraints) => Or(constraints.iter().map(Self::without_spans).collect()),
+        }
+    }
+
+    pub(crate) fn map_atomic_constraints(
+        self,
+        f: &mut impl FnMut(
+            UnspannedRegionConstraint<TyCtxt<'tcx>>,
+        ) -> UnspannedRegionConstraint<TyCtxt<'tcx>>,
+    ) -> SolverRegionConstraint<'tcx> {
+        let (constraint, span) = match self {
+            Self::Ambiguity(span) => (UnspannedRegionConstraint::Ambiguity, span),
+            Self::RegionOutlives(a, b, span) => {
+                (UnspannedRegionConstraint::RegionOutlives(a, b), span)
+            }
+            Self::AliasTyOutlivesViaEnv(outlives, span) => {
+                (UnspannedRegionConstraint::AliasTyOutlivesViaEnv(outlives), span)
+            }
+            Self::PlaceholderTyOutlives(ty, region, span) => {
+                (UnspannedRegionConstraint::PlaceholderTyOutlives(ty, region), span)
+            }
+            Self::And(constraints) => {
+                return Self::And(
+                    constraints.into_iter().map(|c| c.map_atomic_constraints(f)).collect(),
+                );
+            }
+            Self::Or(constraints) => {
+                return Self::Or(
+                    constraints.into_iter().map(|c| c.map_atomic_constraints(f)).collect(),
+                );
+            }
+        };
+
+        Self::with_span(f(constraint), span)
+    }
+
+    pub(crate) fn evaluate(self) -> SolverRegionConstraint<'tcx> {
+        match self {
+            Self::And(constraints) => {
+                let mut evaluated = Vec::new();
+                let mut ambiguity = None;
+                for constraint in constraints {
+                    let constraint = constraint.evaluate();
+                    if constraint.is_false() {
+                        return Self::Or(Box::new([]));
+                    } else if let Self::Ambiguity(span) = constraint {
+                        ambiguity.get_or_insert(span);
+                    } else if !constraint.is_true() {
+                        evaluated.push(constraint);
+                    }
+                }
+
+                ambiguity.map_or_else(|| Self::And(evaluated.into_boxed_slice()), Self::Ambiguity)
+            }
+            Self::Or(constraints) => {
+                let mut evaluated = Vec::new();
+                let mut ambiguity = None;
+                for constraint in constraints {
+                    let constraint = constraint.evaluate();
+                    if constraint.is_true() {
+                        return Self::And(Box::new([]));
+                    } else if let Self::Ambiguity(span) = constraint {
+                        ambiguity.get_or_insert(span);
+                    } else if !constraint.is_false() {
+                        evaluated.push(constraint);
+                    }
+                }
+
+                ambiguity.map_or_else(|| Self::Or(evaluated.into_boxed_slice()), Self::Ambiguity)
+            }
+            constraint => constraint,
+        }
+    }
+
+    fn is_true(&self) -> bool {
+        matches!(self, Self::And(constraints) if constraints.is_empty())
+    }
+
+    fn is_false(&self) -> bool {
+        matches!(self, Self::Or(constraints) if constraints.is_empty())
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct SolverRegionConstraintStorage<'tcx>(SolverRegionConstraint<'tcx>);
+
+impl<'tcx> SolverRegionConstraintStorage<'tcx> {
+    pub(crate) fn new() -> Self {
+        Self(SolverRegionConstraint::And(Box::new([])))
+    }
+
+    pub(crate) fn get_constraint(&self) -> SolverRegionConstraint<'tcx> {
+        self.0.clone()
+    }
+
+    pub(crate) fn get_unspanned_constraint(&self) -> UnspannedRegionConstraint<TyCtxt<'tcx>> {
+        self.0.without_spans()
+    }
+
+    pub(crate) fn pop(&mut self) -> Option<SolverRegionConstraint<'tcx>> {
+        match &mut self.0 {
+            SolverRegionConstraint::And(and) => {
+                let mut and = core::mem::take(and).into_vec();
+                let popped = and.pop()?;
+                self.0 = SolverRegionConstraint::And(and.into_boxed_slice());
+                Some(popped)
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    #[instrument(level = "debug")]
+    pub(crate) fn push(&mut self, constraint: UnspannedRegionConstraint<TyCtxt<'tcx>>, span: Span) {
+        let constraint = SolverRegionConstraint::with_span(constraint, span);
+        match &mut self.0 {
+            SolverRegionConstraint::And(and) => {
+                let and = core::mem::take(and)
+                    .into_iter()
+                    .chain([constraint])
+                    .collect::<Vec<_>>()
+                    .into_boxed_slice();
+                self.0 = SolverRegionConstraint::And(and);
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    #[instrument(level = "debug", skip(self))]
+    pub(crate) fn overwrite(
+        &mut self,
+        constraint: UnspannedRegionConstraint<TyCtxt<'tcx>>,
+        span: Span,
+    ) {
+        self.overwrite_spanned(SolverRegionConstraint::with_span(constraint, span));
+    }
+
+    pub(crate) fn overwrite_spanned(&mut self, constraint: SolverRegionConstraint<'tcx>) {
+        if matches!(constraint, SolverRegionConstraint::And(_)) {
+            self.0 = constraint;
+        } else {
+            self.0 = SolverRegionConstraint::And(vec![constraint].into_boxed_slice());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/compiler/rustc_infer/src/infer/solver_region_constraints.rs
+++ b/compiler/rustc_infer/src/infer/solver_region_constraints.rs
@@ -1,135 +1,11 @@
-use rustc_middle::ty::{self, Ty, TyCtxt};
+use rustc_middle::ty::TyCtxt;
 use rustc_span::Span;
-use rustc_type_ir::region_constraint::RegionConstraint as UnspannedRegionConstraint;
+use rustc_type_ir::region_constraint::{
+    RegionConstraint as UnspannedRegionConstraint, SpannedRegionConstraint,
+};
 use tracing::instrument;
 
-/// A solver region constraint together with the span that caused each atomic constraint.
-///
-/// Solver query responses use [`UnspannedRegionConstraint`] so that source locations do not
-/// participate in candidate equality or caching. Spans are attached when those responses are
-/// applied to an inference context.
-#[derive(Clone, Debug)]
-pub(crate) enum SolverRegionConstraint<'tcx> {
-    Ambiguity(Span),
-    RegionOutlives(ty::Region<'tcx>, ty::Region<'tcx>, Span),
-    AliasTyOutlivesViaEnv(ty::Binder<'tcx, (ty::AliasTy<'tcx>, ty::Region<'tcx>)>, Span),
-    PlaceholderTyOutlives(Ty<'tcx>, ty::Region<'tcx>, Span),
-    And(Box<[SolverRegionConstraint<'tcx>]>),
-    Or(Box<[SolverRegionConstraint<'tcx>]>),
-}
-
-impl<'tcx> SolverRegionConstraint<'tcx> {
-    fn with_span(
-        constraint: UnspannedRegionConstraint<TyCtxt<'tcx>>,
-        span: Span,
-    ) -> SolverRegionConstraint<'tcx> {
-        use rustc_type_ir::region_constraint::RegionConstraint::*;
-
-        match constraint {
-            Ambiguity => Self::Ambiguity(span),
-            RegionOutlives(a, b) => Self::RegionOutlives(a, b, span),
-            AliasTyOutlivesViaEnv(outlives) => Self::AliasTyOutlivesViaEnv(outlives, span),
-            PlaceholderTyOutlives(ty, region) => Self::PlaceholderTyOutlives(ty, region, span),
-            And(constraints) => {
-                Self::And(constraints.into_iter().map(|c| Self::with_span(c, span)).collect())
-            }
-            Or(constraints) => {
-                Self::Or(constraints.into_iter().map(|c| Self::with_span(c, span)).collect())
-            }
-        }
-    }
-
-    fn without_spans(&self) -> UnspannedRegionConstraint<TyCtxt<'tcx>> {
-        use rustc_type_ir::region_constraint::RegionConstraint::*;
-
-        match self {
-            Self::Ambiguity(_) => Ambiguity,
-            Self::RegionOutlives(a, b, _) => RegionOutlives(*a, *b),
-            Self::AliasTyOutlivesViaEnv(outlives, _) => AliasTyOutlivesViaEnv(*outlives),
-            Self::PlaceholderTyOutlives(ty, region, _) => PlaceholderTyOutlives(*ty, *region),
-            Self::And(constraints) => And(constraints.iter().map(Self::without_spans).collect()),
-            Self::Or(constraints) => Or(constraints.iter().map(Self::without_spans).collect()),
-        }
-    }
-
-    pub(crate) fn map_atomic_constraints(
-        self,
-        f: &mut impl FnMut(
-            UnspannedRegionConstraint<TyCtxt<'tcx>>,
-        ) -> UnspannedRegionConstraint<TyCtxt<'tcx>>,
-    ) -> SolverRegionConstraint<'tcx> {
-        let (constraint, span) = match self {
-            Self::Ambiguity(span) => (UnspannedRegionConstraint::Ambiguity, span),
-            Self::RegionOutlives(a, b, span) => {
-                (UnspannedRegionConstraint::RegionOutlives(a, b), span)
-            }
-            Self::AliasTyOutlivesViaEnv(outlives, span) => {
-                (UnspannedRegionConstraint::AliasTyOutlivesViaEnv(outlives), span)
-            }
-            Self::PlaceholderTyOutlives(ty, region, span) => {
-                (UnspannedRegionConstraint::PlaceholderTyOutlives(ty, region), span)
-            }
-            Self::And(constraints) => {
-                return Self::And(
-                    constraints.into_iter().map(|c| c.map_atomic_constraints(f)).collect(),
-                );
-            }
-            Self::Or(constraints) => {
-                return Self::Or(
-                    constraints.into_iter().map(|c| c.map_atomic_constraints(f)).collect(),
-                );
-            }
-        };
-
-        Self::with_span(f(constraint), span)
-    }
-
-    pub(crate) fn evaluate(self) -> SolverRegionConstraint<'tcx> {
-        match self {
-            Self::And(constraints) => {
-                let mut evaluated = Vec::new();
-                let mut ambiguity = None;
-                for constraint in constraints {
-                    let constraint = constraint.evaluate();
-                    if constraint.is_false() {
-                        return Self::Or(Box::new([]));
-                    } else if let Self::Ambiguity(span) = constraint {
-                        ambiguity.get_or_insert(span);
-                    } else if !constraint.is_true() {
-                        evaluated.push(constraint);
-                    }
-                }
-
-                ambiguity.map_or_else(|| Self::And(evaluated.into_boxed_slice()), Self::Ambiguity)
-            }
-            Self::Or(constraints) => {
-                let mut evaluated = Vec::new();
-                let mut ambiguity = None;
-                for constraint in constraints {
-                    let constraint = constraint.evaluate();
-                    if constraint.is_true() {
-                        return Self::And(Box::new([]));
-                    } else if let Self::Ambiguity(span) = constraint {
-                        ambiguity.get_or_insert(span);
-                    } else if !constraint.is_false() {
-                        evaluated.push(constraint);
-                    }
-                }
-
-                ambiguity.map_or_else(|| Self::Or(evaluated.into_boxed_slice()), Self::Ambiguity)
-            }
-            constraint => constraint,
-        }
-    }
-
-    fn is_true(&self) -> bool {
-        matches!(self, Self::And(constraints) if constraints.is_empty())
-    }
-
-    fn is_false(&self) -> bool {
-        matches!(self, Self::Or(constraints) if constraints.is_empty())
-    }
-}
+pub(crate) type SolverRegionConstraint<'tcx> = SpannedRegionConstraint<TyCtxt<'tcx>>;
 
 #[derive(Clone, Debug)]
 pub(crate) struct SolverRegionConstraintStorage<'tcx>(SolverRegionConstraint<'tcx>);
@@ -144,11 +20,11 @@ impl<'tcx> SolverRegionConstraintStorage<'tcx> {
     }
 
     pub(crate) fn get_unspanned_constraint(&self) -> UnspannedRegionConstraint<TyCtxt<'tcx>> {
-        self.0.without_spans()
+        self.0.clone().without_spans()
     }
 
     pub(crate) fn is_and(&self) -> bool {
-        matches!(self.0, SolverRegionConstraint::And(_))
+        self.0.is_and()
     }
 
     pub(crate) fn pop(&mut self, previous_was_and: bool) -> Option<SolverRegionConstraint<'tcx>> {
@@ -170,8 +46,8 @@ impl<'tcx> SolverRegionConstraintStorage<'tcx> {
 
     #[instrument(level = "debug")]
     pub(crate) fn push(&mut self, constraint: UnspannedRegionConstraint<TyCtxt<'tcx>>, span: Span) {
-        let constraint = SolverRegionConstraint::with_span(constraint, span);
-        match core::mem::replace(&mut self.0, SolverRegionConstraint::And(Box::new([]))) {
+        let constraint = constraint.with_span(span);
+        match core::mem::replace(&mut self.0, SolverRegionConstraint::new_true()) {
             SolverRegionConstraint::And(and) => {
                 let and =
                     and.into_iter().chain([constraint]).collect::<Vec<_>>().into_boxed_slice();
@@ -189,7 +65,7 @@ impl<'tcx> SolverRegionConstraintStorage<'tcx> {
         constraint: UnspannedRegionConstraint<TyCtxt<'tcx>>,
         span: Span,
     ) {
-        self.overwrite_spanned(SolverRegionConstraint::with_span(constraint, span));
+        self.overwrite_spanned(constraint.with_span(span));
     }
 
     pub(crate) fn overwrite_spanned(&mut self, constraint: SolverRegionConstraint<'tcx>) {

--- a/compiler/rustc_infer/src/infer/solver_region_constraints.rs
+++ b/compiler/rustc_infer/src/infer/solver_region_constraints.rs
@@ -1,0 +1,201 @@
+use rustc_middle::ty::{self, Ty, TyCtxt};
+use rustc_span::Span;
+use rustc_type_ir::region_constraint::RegionConstraint as UnspannedRegionConstraint;
+use tracing::instrument;
+
+/// A solver region constraint together with the span that caused each atomic constraint.
+///
+/// Solver query responses use [`UnspannedRegionConstraint`] so that source locations do not
+/// participate in candidate equality or caching. Spans are attached when those responses are
+/// applied to an inference context.
+#[derive(Clone, Debug)]
+pub(crate) enum SolverRegionConstraint<'tcx> {
+    Ambiguity(Span),
+    RegionOutlives(ty::Region<'tcx>, ty::Region<'tcx>, Span),
+    AliasTyOutlivesViaEnv(ty::Binder<'tcx, (ty::AliasTy<'tcx>, ty::Region<'tcx>)>, Span),
+    PlaceholderTyOutlives(Ty<'tcx>, ty::Region<'tcx>, Span),
+    And(Box<[SolverRegionConstraint<'tcx>]>),
+    Or(Box<[SolverRegionConstraint<'tcx>]>),
+}
+
+impl<'tcx> SolverRegionConstraint<'tcx> {
+    fn with_span(
+        constraint: UnspannedRegionConstraint<TyCtxt<'tcx>>,
+        span: Span,
+    ) -> SolverRegionConstraint<'tcx> {
+        use rustc_type_ir::region_constraint::RegionConstraint::*;
+
+        match constraint {
+            Ambiguity => Self::Ambiguity(span),
+            RegionOutlives(a, b) => Self::RegionOutlives(a, b, span),
+            AliasTyOutlivesViaEnv(outlives) => Self::AliasTyOutlivesViaEnv(outlives, span),
+            PlaceholderTyOutlives(ty, region) => Self::PlaceholderTyOutlives(ty, region, span),
+            And(constraints) => {
+                Self::And(constraints.into_iter().map(|c| Self::with_span(c, span)).collect())
+            }
+            Or(constraints) => {
+                Self::Or(constraints.into_iter().map(|c| Self::with_span(c, span)).collect())
+            }
+        }
+    }
+
+    fn without_spans(&self) -> UnspannedRegionConstraint<TyCtxt<'tcx>> {
+        use rustc_type_ir::region_constraint::RegionConstraint::*;
+
+        match self {
+            Self::Ambiguity(_) => Ambiguity,
+            Self::RegionOutlives(a, b, _) => RegionOutlives(*a, *b),
+            Self::AliasTyOutlivesViaEnv(outlives, _) => AliasTyOutlivesViaEnv(*outlives),
+            Self::PlaceholderTyOutlives(ty, region, _) => PlaceholderTyOutlives(*ty, *region),
+            Self::And(constraints) => And(constraints.iter().map(Self::without_spans).collect()),
+            Self::Or(constraints) => Or(constraints.iter().map(Self::without_spans).collect()),
+        }
+    }
+
+    pub(crate) fn map_atomic_constraints(
+        self,
+        f: &mut impl FnMut(
+            UnspannedRegionConstraint<TyCtxt<'tcx>>,
+        ) -> UnspannedRegionConstraint<TyCtxt<'tcx>>,
+    ) -> SolverRegionConstraint<'tcx> {
+        let (constraint, span) = match self {
+            Self::Ambiguity(span) => (UnspannedRegionConstraint::Ambiguity, span),
+            Self::RegionOutlives(a, b, span) => {
+                (UnspannedRegionConstraint::RegionOutlives(a, b), span)
+            }
+            Self::AliasTyOutlivesViaEnv(outlives, span) => {
+                (UnspannedRegionConstraint::AliasTyOutlivesViaEnv(outlives), span)
+            }
+            Self::PlaceholderTyOutlives(ty, region, span) => {
+                (UnspannedRegionConstraint::PlaceholderTyOutlives(ty, region), span)
+            }
+            Self::And(constraints) => {
+                return Self::And(
+                    constraints.into_iter().map(|c| c.map_atomic_constraints(f)).collect(),
+                );
+            }
+            Self::Or(constraints) => {
+                return Self::Or(
+                    constraints.into_iter().map(|c| c.map_atomic_constraints(f)).collect(),
+                );
+            }
+        };
+
+        Self::with_span(f(constraint), span)
+    }
+
+    pub(crate) fn evaluate(self) -> SolverRegionConstraint<'tcx> {
+        match self {
+            Self::And(constraints) => {
+                let mut evaluated = Vec::new();
+                let mut ambiguity = None;
+                for constraint in constraints {
+                    let constraint = constraint.evaluate();
+                    if constraint.is_false() {
+                        return Self::Or(Box::new([]));
+                    } else if let Self::Ambiguity(span) = constraint {
+                        ambiguity.get_or_insert(span);
+                    } else if !constraint.is_true() {
+                        evaluated.push(constraint);
+                    }
+                }
+
+                ambiguity.map_or_else(|| Self::And(evaluated.into_boxed_slice()), Self::Ambiguity)
+            }
+            Self::Or(constraints) => {
+                let mut evaluated = Vec::new();
+                let mut ambiguity = None;
+                for constraint in constraints {
+                    let constraint = constraint.evaluate();
+                    if constraint.is_true() {
+                        return Self::And(Box::new([]));
+                    } else if let Self::Ambiguity(span) = constraint {
+                        ambiguity.get_or_insert(span);
+                    } else if !constraint.is_false() {
+                        evaluated.push(constraint);
+                    }
+                }
+
+                ambiguity.map_or_else(|| Self::Or(evaluated.into_boxed_slice()), Self::Ambiguity)
+            }
+            constraint => constraint,
+        }
+    }
+
+    fn is_true(&self) -> bool {
+        matches!(self, Self::And(constraints) if constraints.is_empty())
+    }
+
+    fn is_false(&self) -> bool {
+        matches!(self, Self::Or(constraints) if constraints.is_empty())
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct SolverRegionConstraintStorage<'tcx>(SolverRegionConstraint<'tcx>);
+
+impl<'tcx> SolverRegionConstraintStorage<'tcx> {
+    pub(crate) fn new() -> Self {
+        Self(SolverRegionConstraint::And(Box::new([])))
+    }
+
+    pub(crate) fn get_constraint(&self) -> SolverRegionConstraint<'tcx> {
+        self.0.clone()
+    }
+
+    pub(crate) fn get_unspanned_constraint(&self) -> UnspannedRegionConstraint<TyCtxt<'tcx>> {
+        self.0.without_spans()
+    }
+
+    pub(crate) fn is_and(&self) -> bool {
+        matches!(self.0, SolverRegionConstraint::And(_))
+    }
+
+    pub(crate) fn pop(&mut self, previous_was_and: bool) -> Option<SolverRegionConstraint<'tcx>> {
+        match &mut self.0 {
+            SolverRegionConstraint::And(and) => {
+                let mut and = core::mem::take(and).into_vec();
+                let popped = and.pop()?;
+                if previous_was_and {
+                    self.0 = SolverRegionConstraint::And(and.into_boxed_slice());
+                } else {
+                    assert_eq!(and.len(), 1);
+                    self.0 = and.pop().unwrap();
+                }
+                Some(popped)
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    #[instrument(level = "debug")]
+    pub(crate) fn push(&mut self, constraint: UnspannedRegionConstraint<TyCtxt<'tcx>>, span: Span) {
+        let constraint = SolverRegionConstraint::with_span(constraint, span);
+        match core::mem::replace(&mut self.0, SolverRegionConstraint::And(Box::new([]))) {
+            SolverRegionConstraint::And(and) => {
+                let and =
+                    and.into_iter().chain([constraint]).collect::<Vec<_>>().into_boxed_slice();
+                self.0 = SolverRegionConstraint::And(and);
+            }
+            previous => {
+                self.0 = SolverRegionConstraint::And(Box::new([previous, constraint]));
+            }
+        }
+    }
+
+    #[instrument(level = "debug", skip(self))]
+    pub(crate) fn overwrite(
+        &mut self,
+        constraint: UnspannedRegionConstraint<TyCtxt<'tcx>>,
+        span: Span,
+    ) {
+        self.overwrite_spanned(SolverRegionConstraint::with_span(constraint, span));
+    }
+
+    pub(crate) fn overwrite_spanned(&mut self, constraint: SolverRegionConstraint<'tcx>) {
+        self.0 = constraint;
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/compiler/rustc_infer/src/infer/solver_region_constraints/tests.rs
+++ b/compiler/rustc_infer/src/infer/solver_region_constraints/tests.rs
@@ -1,0 +1,57 @@
+use rustc_span::{BytePos, DUMMY_SP, Span};
+use rustc_type_ir::region_constraint::evaluate_solver_constraint;
+
+use super::SolverRegionConstraint;
+
+fn and(constraints: Vec<SolverRegionConstraint<'static>>) -> SolverRegionConstraint<'static> {
+    SolverRegionConstraint::And(constraints.into_boxed_slice())
+}
+
+fn or(constraints: Vec<SolverRegionConstraint<'static>>) -> SolverRegionConstraint<'static> {
+    SolverRegionConstraint::Or(constraints.into_boxed_slice())
+}
+
+fn ambiguity() -> SolverRegionConstraint<'static> {
+    SolverRegionConstraint::Ambiguity(DUMMY_SP)
+}
+
+#[test]
+fn evaluation_matches_type_ir() {
+    let constraints = [
+        ambiguity(),
+        and(vec![]),
+        or(vec![]),
+        and(vec![and(vec![]), ambiguity()]),
+        and(vec![ambiguity(), or(vec![])]),
+        or(vec![or(vec![]), ambiguity()]),
+        or(vec![ambiguity(), and(vec![])]),
+        and(vec![or(vec![or(vec![]), ambiguity()]), or(vec![ambiguity(), and(vec![])])]),
+    ];
+
+    for constraint in constraints {
+        let expected = evaluate_solver_constraint(&constraint.without_spans());
+        let actual = constraint.evaluate().without_spans();
+        assert_eq!(actual, expected);
+    }
+}
+
+#[test]
+fn evaluation_preserves_first_ambiguity_span() {
+    let first = Span::with_root_ctxt(BytePos(1), BytePos(2));
+    let second = Span::with_root_ctxt(BytePos(3), BytePos(4));
+
+    for constraint in [
+        and(vec![
+            SolverRegionConstraint::Ambiguity(first),
+            SolverRegionConstraint::Ambiguity(second),
+        ]),
+        or(vec![
+            SolverRegionConstraint::Ambiguity(first),
+            SolverRegionConstraint::Ambiguity(second),
+        ]),
+    ] {
+        assert!(
+            matches!(constraint.evaluate(), SolverRegionConstraint::Ambiguity(span) if span == first)
+        );
+    }
+}

--- a/compiler/rustc_infer/src/infer/solver_region_constraints/tests.rs
+++ b/compiler/rustc_infer/src/infer/solver_region_constraints/tests.rs
@@ -16,7 +16,7 @@ fn ambiguity() -> SolverRegionConstraint<'static> {
 }
 
 #[test]
-fn evaluation_matches_type_ir() {
+fn evaluation_is_span_agnostic() {
     let constraints = [
         ambiguity(),
         and(vec![]),
@@ -29,8 +29,8 @@ fn evaluation_matches_type_ir() {
     ];
 
     for constraint in constraints {
-        let expected = evaluate_solver_constraint(&constraint.without_spans());
-        let actual = constraint.evaluate().without_spans();
+        let expected = evaluate_solver_constraint(&constraint.clone().without_spans());
+        let actual = evaluate_solver_constraint(&constraint).without_spans();
         assert_eq!(actual, expected);
     }
 }
@@ -50,8 +50,9 @@ fn evaluation_preserves_first_ambiguity_span() {
             SolverRegionConstraint::Ambiguity(second),
         ]),
     ] {
-        assert!(
-            matches!(constraint.evaluate(), SolverRegionConstraint::Ambiguity(span) if span == first)
-        );
+        assert!(matches!(
+            evaluate_solver_constraint(&constraint),
+            SolverRegionConstraint::Ambiguity(span) if span == first
+        ));
     }
 }

--- a/compiler/rustc_next_trait_solver/src/canonical/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/canonical/mod.rs
@@ -134,7 +134,7 @@ where
             span,
         ),
         ExternalRegionConstraints::NextGen(r) => {
-            delegate.register_solver_region_constraint(r.clone())
+            delegate.register_solver_region_constraint(r.clone(), span)
         }
     };
     register_new_opaque_types(delegate, opaque_types, span);

--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
@@ -1329,7 +1329,7 @@ where
     }
 
     pub(super) fn register_solver_region_constraint(&self, c: RegionConstraint<I>) {
-        self.delegate.register_solver_region_constraint(c);
+        self.delegate.register_solver_region_constraint(c, self.origin_span);
     }
 
     pub(super) fn register_ty_outlives(&self, ty: I::Ty, lt: Region<I>) {

--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
@@ -1309,7 +1309,7 @@ where
     }
 
     pub(super) fn register_solver_region_constraint(&self, c: RegionConstraint<I>) {
-        self.delegate.register_solver_region_constraint(c);
+        self.delegate.register_solver_region_constraint(c, self.origin_span);
     }
 
     pub(super) fn register_ty_outlives(&self, ty: I::Ty, lt: Region<I>) {

--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/solver_region_constraints.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/solver_region_constraints.rs
@@ -137,7 +137,7 @@ where
                 eagerly_handle_placeholders_in_universe(&**self.delegate, constraint, u)
             });
 
-        self.delegate.overwrite_solver_region_constraint(constraint.clone());
+        self.delegate.overwrite_solver_region_constraint(constraint.clone(), self.origin_span);
 
         if constraint.is_false() {
             Err(NoSolution)

--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/solver_region_constraints.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/solver_region_constraints.rs
@@ -177,13 +177,13 @@ where
     fn destructure_component(&mut self, c: &Component<I>, r: Region<I>) -> RegionConstraint<I> {
         use Component::*;
         match c {
-            Region(c_r) => RegionConstraint::RegionOutlives(*c_r, r),
+            Region(c_r) => RegionConstraint::RegionOutlives(*c_r, r, ()),
             Placeholder(p) => {
-                RegionConstraint::PlaceholderTyOutlives(Ty::new_placeholder(self.cx(), *p), r)
+                RegionConstraint::PlaceholderTyOutlives(Ty::new_placeholder(self.cx(), *p), r, ())
             }
             // The alias is either rigid or ambiguous in which case we'll return with ambiguity.
             Alias(_, alias) => self.destructure_alias_outlives(*alias, r),
-            UnresolvedInferenceVariable(_) => RegionConstraint::Ambiguity,
+            UnresolvedInferenceVariable(_) => RegionConstraint::Ambiguity(()),
             Param(_) => panic!("Params should have been canonicalized to placeholders"),
             EscapingAlias(components) => self.destructure_components(components, r),
         }
@@ -204,11 +204,11 @@ where
     ) -> RegionConstraint<I> {
         let item_bounds =
             rustc_type_ir::outlives::declared_bounds_from_definition(self.cx(), alias)
-                .map(|bound| RegionConstraint::RegionOutlives(bound, r));
+                .map(|bound| RegionConstraint::RegionOutlives(bound, r, ()));
         let item_bound_outlives = RegionConstraint::Or(item_bounds.collect());
 
         let where_clause_outlives =
-            RegionConstraint::AliasTyOutlivesViaEnv(Binder::dummy((alias, r)));
+            RegionConstraint::AliasTyOutlivesViaEnv(Binder::dummy((alias, r)), ());
 
         let mut components = Default::default();
         rustc_type_ir::outlives::compute_alias_components_recursive(

--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/solver_region_constraints.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/solver_region_constraints.rs
@@ -139,7 +139,7 @@ where
             });
         let constraint = evaluate_solver_constraint(&constraint.canonical_form());
 
-        self.delegate.overwrite_solver_region_constraint(constraint.clone());
+        self.delegate.overwrite_solver_region_constraint(constraint.clone(), self.origin_span);
 
         if constraint.is_false() {
             Err(NoSolution)

--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/solver_region_constraints.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/solver_region_constraints.rs
@@ -175,13 +175,13 @@ where
     fn destructure_component(&mut self, c: &Component<I>, r: Region<I>) -> RegionConstraint<I> {
         use Component::*;
         match c {
-            Region(c_r) => RegionConstraint::RegionOutlives(*c_r, r),
+            Region(c_r) => RegionConstraint::RegionOutlives(*c_r, r, ()),
             Placeholder(p) => {
-                RegionConstraint::PlaceholderTyOutlives(Ty::new_placeholder(self.cx(), *p), r)
+                RegionConstraint::PlaceholderTyOutlives(Ty::new_placeholder(self.cx(), *p), r, ())
             }
             // The alias is either rigid or ambiguous in which case we'll return with ambiguity.
             Alias(_, alias) => self.destructure_alias_outlives(*alias, r),
-            UnresolvedInferenceVariable(_) => RegionConstraint::Ambiguity,
+            UnresolvedInferenceVariable(_) => RegionConstraint::Ambiguity(()),
             Param(_) => panic!("Params should have been canonicalized to placeholders"),
             EscapingAlias(components) => self.destructure_components(components, r),
         }
@@ -202,11 +202,11 @@ where
     ) -> RegionConstraint<I> {
         let item_bounds =
             rustc_type_ir::outlives::declared_bounds_from_definition(self.cx(), alias)
-                .map(|bound| RegionConstraint::RegionOutlives(bound, r));
+                .map(|bound| RegionConstraint::RegionOutlives(bound, r, ()));
         let item_bound_outlives = RegionConstraint::Or(item_bounds.collect());
 
         let where_clause_outlives =
-            RegionConstraint::AliasTyOutlivesViaEnv(Binder::dummy((alias, r)));
+            RegionConstraint::AliasTyOutlivesViaEnv(Binder::dummy((alias, r)), ());
 
         let mut components = Default::default();
         rustc_type_ir::outlives::compute_alias_components_recursive(

--- a/compiler/rustc_next_trait_solver/src/solve/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/mod.rs
@@ -120,7 +120,7 @@ where
 
         if self.cx().assumptions_on_binders() {
             let constraint =
-                rustc_type_ir::region_constraint::RegionConstraint::RegionOutlives(a, b);
+                rustc_type_ir::region_constraint::RegionConstraint::RegionOutlives(a, b, ());
             self.register_solver_region_constraint(constraint);
         } else {
             self.register_region_outlives(a, b, VisibleForLeakCheck::Yes);

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/region.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/region.rs
@@ -297,7 +297,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             SubregionOrigin::SolverRegionConstraint(span) => {
                 RegionOriginNote::Plain {
                     span,
-                    msg: msg!("this diagnostic is currently WIP while -Zassumptions-on-binders is incomplete"),
+                    msg: msg!("...so that a higher-ranked lifetime bound can be satisfied"),
                 }
                 .add_to_diag(err);
             }
@@ -569,14 +569,9 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     notes: instantiated.into_iter().chain(must_outlive).collect(),
                 })
             }
-            SubregionOrigin::SolverRegionConstraint(span) => {
-                let mut d = self.dcx().struct_span_err(
-                    span,
-                    "unsatisfied lifetime constraint from -Zassumptions-on-binders :3",
-                );
-                d.note("meoow :c");
-                d
-            }
+            SubregionOrigin::SolverRegionConstraint(span) => self
+                .dcx()
+                .struct_span_err(span, "higher-ranked lifetime bound could not be satisfied"),
         };
         if sub.is_error() || sup.is_error() {
             err.downgrade_to_delayed_bug();

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/mod.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/mod.rs
@@ -312,6 +312,13 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             FulfillmentErrorCode::Project(ref e) => {
                 self.report_projection_error(&error.obligation, e)
             }
+            FulfillmentErrorCode::Outlives => self
+                .dcx()
+                .struct_span_err(
+                    error.obligation.cause.span,
+                    "higher-ranked lifetime bound could not be satisfied",
+                )
+                .emit(),
             FulfillmentErrorCode::Ambiguity { overflow: None } => {
                 self.maybe_report_ambiguity(&error.obligation)
             }

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/mod.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/mod.rs
@@ -419,6 +419,13 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             FulfillmentErrorCode::Project(ref e) => {
                 self.report_projection_error(&error.obligation, e)
             }
+            FulfillmentErrorCode::Outlives => self
+                .dcx()
+                .struct_span_err(
+                    error.obligation.cause.span,
+                    "higher-ranked lifetime bound could not be satisfied",
+                )
+                .emit(),
             FulfillmentErrorCode::Ambiguity { overflow: None } => {
                 self.maybe_report_ambiguity(&error.obligation, related)
             }

--- a/compiler/rustc_trait_selection/src/solve/fulfill/derive_errors.rs
+++ b/compiler/rustc_trait_selection/src/solve/fulfill/derive_errors.rs
@@ -66,6 +66,9 @@ pub(super) fn fulfillment_error_for_no_solution<'tcx>(
             let expected_found = ExpectedFound::new(b, a);
             FulfillmentErrorCode::Subtype(expected_found, TypeError::Sorts(expected_found))
         }
+        ty::PredicateKind::Clause(
+            ty::ClauseKind::RegionOutlives(_) | ty::ClauseKind::TypeOutlives(_),
+        ) if infcx.tcx.assumptions_on_binders() => FulfillmentErrorCode::Outlives,
         ty::PredicateKind::Clause(_)
         | ty::PredicateKind::DynCompatible(_)
         | ty::PredicateKind::Ambiguous => {

--- a/compiler/rustc_trait_selection/src/traits/fulfill.rs
+++ b/compiler/rustc_trait_selection/src/traits/fulfill.rs
@@ -1066,6 +1066,7 @@ impl<'tcx> FromSolverError<'tcx, OldSolverError<'tcx>> for ScrubbedTraitError<'t
         match error.0.error {
             FulfillmentErrorCode::Select(_)
             | FulfillmentErrorCode::Project(_)
+            | FulfillmentErrorCode::Outlives
             | FulfillmentErrorCode::Subtype(_, _)
             | FulfillmentErrorCode::ConstEquate(_, _) => ScrubbedTraitError::TrueError,
             FulfillmentErrorCode::Ambiguity { overflow: _ } => ScrubbedTraitError::Ambiguity,

--- a/compiler/rustc_trait_selection/src/traits/fulfill.rs
+++ b/compiler/rustc_trait_selection/src/traits/fulfill.rs
@@ -1069,6 +1069,7 @@ impl<'tcx> FromSolverError<'tcx, OldSolverError<'tcx>> for ScrubbedTraitError<'t
         match error.0.error {
             FulfillmentErrorCode::Select(_)
             | FulfillmentErrorCode::Project(_)
+            | FulfillmentErrorCode::Outlives
             | FulfillmentErrorCode::Subtype(_, _)
             | FulfillmentErrorCode::ConstEquate(_, _) => ScrubbedTraitError::TrueError,
             FulfillmentErrorCode::Ambiguity { overflow: _ } => ScrubbedTraitError::Ambiguity,

--- a/compiler/rustc_trait_selection/src/traits/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/mod.rs
@@ -98,6 +98,7 @@ impl<'tcx> FulfillmentError<'tcx> {
         match self.code {
             FulfillmentErrorCode::Select(_)
             | FulfillmentErrorCode::Project(_)
+            | FulfillmentErrorCode::Outlives
             | FulfillmentErrorCode::Subtype(_, _)
             | FulfillmentErrorCode::ConstEquate(_, _) => true,
             FulfillmentErrorCode::Cycle(_) | FulfillmentErrorCode::Ambiguity { overflow: _ } => {
@@ -114,6 +115,8 @@ pub enum FulfillmentErrorCode<'tcx> {
     Cycle(PredicateObligations<'tcx>),
     Select(SelectionError<'tcx>),
     Project(MismatchedProjectionTypes<'tcx>),
+    /// An outlives constraint emitted for `-Zassumptions-on-binders` was unsatisfiable.
+    Outlives,
     Subtype(ExpectedFound<Ty<'tcx>>, TypeError<'tcx>), // always comes from a SubtypePredicate
     ConstEquate(ExpectedFound<ty::Const<'tcx>>, TypeError<'tcx>),
     Ambiguity {
@@ -129,6 +132,7 @@ impl<'tcx> Debug for FulfillmentErrorCode<'tcx> {
         match *self {
             FulfillmentErrorCode::Select(ref e) => write!(f, "{e:?}"),
             FulfillmentErrorCode::Project(ref e) => write!(f, "{e:?}"),
+            FulfillmentErrorCode::Outlives => write!(f, "CodeOutlivesError"),
             FulfillmentErrorCode::Subtype(ref a, ref b) => {
                 write!(f, "CodeSubtypeError({a:?}, {b:?})")
             }

--- a/compiler/rustc_trait_selection/src/traits/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/mod.rs
@@ -97,6 +97,7 @@ impl<'tcx> FulfillmentError<'tcx> {
         match self.code {
             FulfillmentErrorCode::Select(_)
             | FulfillmentErrorCode::Project(_)
+            | FulfillmentErrorCode::Outlives
             | FulfillmentErrorCode::Subtype(_, _)
             | FulfillmentErrorCode::ConstEquate(_, _) => true,
             FulfillmentErrorCode::Cycle(_) | FulfillmentErrorCode::Ambiguity { overflow: _ } => {
@@ -113,6 +114,8 @@ pub enum FulfillmentErrorCode<'tcx> {
     Cycle(PredicateObligations<'tcx>),
     Select(SelectionError<'tcx>),
     Project(MismatchedProjectionTypes<'tcx>),
+    /// An outlives constraint emitted for `-Zassumptions-on-binders` was unsatisfiable.
+    Outlives,
     Subtype(ExpectedFound<Ty<'tcx>>, TypeError<'tcx>), // always comes from a SubtypePredicate
     ConstEquate(ExpectedFound<ty::Const<'tcx>>, TypeError<'tcx>),
     Ambiguity {
@@ -128,6 +131,7 @@ impl<'tcx> Debug for FulfillmentErrorCode<'tcx> {
         match *self {
             FulfillmentErrorCode::Select(ref e) => write!(f, "{e:?}"),
             FulfillmentErrorCode::Project(ref e) => write!(f, "{e:?}"),
+            FulfillmentErrorCode::Outlives => write!(f, "CodeOutlivesError"),
             FulfillmentErrorCode::Subtype(ref a, ref b) => {
                 write!(f, "CodeSubtypeError({a:?}, {b:?})")
             }

--- a/compiler/rustc_trait_selection/src/traits/query/type_op/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/query/type_op/mod.rs
@@ -146,6 +146,24 @@ where
         root_def_id: LocalDefId,
         span: Span,
     ) -> Result<TypeOpOutput<'tcx, Self>, ErrorGuaranteed> {
+        // Canonical type-op queries drop NextGen solver region constraints when
+        // building `QueryResponse`. Evaluate locally so `-Zassumptions-on-binders`
+        // can attach those constraints to this `InferCtxt` and report them from
+        // borrowck instead of silently succeeding.
+        if infcx.tcx.assumptions_on_binders() {
+            if !infcx.disable_trait_solver_fast_paths()
+                && let Some(output) = Q::try_fast_path(infcx.tcx, &self)
+            {
+                return Ok(TypeOpOutput { output, constraints: None, error_info: None });
+            }
+
+            let (output, _) =
+                scrape_region_constraints(infcx, root_def_id, "fully_perform", span, |ocx| {
+                    Q::perform_locally_with_next_solver(ocx, self, span)
+                })?;
+            return Ok(output);
+        }
+
         let mut error_info = None;
         let mut region_constraints = QueryRegionConstraints::default();
 

--- a/compiler/rustc_trait_selection/src/traits/query/type_op/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/query/type_op/mod.rs
@@ -146,24 +146,6 @@ where
         root_def_id: LocalDefId,
         span: Span,
     ) -> Result<TypeOpOutput<'tcx, Self>, ErrorGuaranteed> {
-        // Canonical type-op queries drop NextGen solver region constraints when
-        // building `QueryResponse`. Evaluate locally so `-Zassumptions-on-binders`
-        // can attach those constraints to this `InferCtxt` and report them from
-        // borrowck instead of silently succeeding.
-        if infcx.tcx.assumptions_on_binders() {
-            if !infcx.disable_trait_solver_fast_paths()
-                && let Some(output) = Q::try_fast_path(infcx.tcx, &self)
-            {
-                return Ok(TypeOpOutput { output, constraints: None, error_info: None });
-            }
-
-            let (output, _) =
-                scrape_region_constraints(infcx, root_def_id, "fully_perform", span, |ocx| {
-                    Q::perform_locally_with_next_solver(ocx, self, span)
-                })?;
-            return Ok(output);
-        }
-
         let mut error_info = None;
         let mut region_constraints = QueryRegionConstraints::default();
 

--- a/compiler/rustc_type_ir/src/infer_ctxt.rs
+++ b/compiler/rustc_type_ir/src/infer_ctxt.rs
@@ -399,6 +399,7 @@ pub trait InferCtxtLike: Sized {
     fn overwrite_solver_region_constraint(
         &self,
         constraint: crate::region_constraint::RegionConstraint<Self::Interner>,
+        span: <Self::Interner as Interner>::Span,
     );
 
     fn universe_of_ty(&self, ty: ty::TyVid) -> Option<ty::UniverseIndex>;
@@ -520,6 +521,7 @@ pub trait InferCtxtLike: Sized {
     fn register_solver_region_constraint(
         &self,
         c: crate::region_constraint::RegionConstraint<Self::Interner>,
+        span: <Self::Interner as Interner>::Span,
     );
 
     fn register_ty_outlives(

--- a/compiler/rustc_type_ir/src/infer_ctxt.rs
+++ b/compiler/rustc_type_ir/src/infer_ctxt.rs
@@ -399,6 +399,7 @@ pub trait InferCtxtLike: Sized {
     fn overwrite_solver_region_constraint(
         &self,
         constraint: crate::region_constraint::RegionConstraint<Self::Interner>,
+        span: <Self::Interner as Interner>::Span,
     );
 
     fn universe_of_ty(&self, ty: ty::TyVid) -> Option<ty::UniverseIndex>;
@@ -519,6 +520,7 @@ pub trait InferCtxtLike: Sized {
     fn register_solver_region_constraint(
         &self,
         c: crate::region_constraint::RegionConstraint<Self::Interner>,
+        span: <Self::Interner as Interner>::Span,
     );
 
     fn register_ty_outlives(

--- a/compiler/rustc_type_ir/src/region_constraint.rs
+++ b/compiler/rustc_type_ir/src/region_constraint.rs
@@ -91,11 +91,11 @@ impl<I: Interner> Assumptions<I> {
     }
 }
 
-#[derive_where(Clone, Hash, PartialEq, Debug; I: Interner)]
+#[derive_where(Clone, Hash, PartialEq, Debug; I: Interner, S)]
 #[derive(GenericTypeVisitable)]
-pub enum RegionConstraint<I: Interner> {
-    Ambiguity,
-    RegionOutlives(Region<I>, Region<I>),
+pub enum RegionConstraint<I: Interner, S = ()> {
+    Ambiguity(S),
+    RegionOutlives(Region<I>, Region<I>, S),
     /// Requirement that a (potentially higher ranked) alias outlives some (potentially higher ranked)
     /// region due to an assumption in the environment. This cannot be satisfied via component outlives
     /// or item bounds.
@@ -105,7 +105,7 @@ pub enum RegionConstraint<I: Interner> {
     ///
     /// We eagerly destructure alias outlives requirements into region outlives requirements corresponding to
     /// component outlives & item bound outlives rules, leaving only param env candidates.
-    AliasTyOutlivesViaEnv(Binder<I, (AliasTy<I>, Region<I>)>),
+    AliasTyOutlivesViaEnv(Binder<I, (AliasTy<I>, Region<I>)>, S),
     /// This is an `I::Ty` for two reasons:
     /// 1. We need the type visitable impl to be able to `visit_ty` on this so canonicalization
     ///    knows about the placeholder
@@ -115,11 +115,18 @@ pub enum RegionConstraint<I: Interner> {
     ///
     /// We cannot eagerly look at assumptions as we are usually working with an incomplete set of assumptions
     /// and there may wind up being assumptions we can use to prove this when we're in a smaller universe.
-    PlaceholderTyOutlives(I::Ty, Region<I>),
+    PlaceholderTyOutlives(I::Ty, Region<I>, S),
 
-    And(Box<[RegionConstraint<I>]>),
-    Or(Box<[RegionConstraint<I>]>),
+    And(Box<[RegionConstraint<I, S>]>),
+    Or(Box<[RegionConstraint<I, S>]>),
 }
+
+/// A solver region constraint together with the span that caused each atomic constraint.
+///
+/// Solver query responses use [`RegionConstraint`] so source locations do not participate in
+/// candidate equality or caching. Spans are attached when responses are applied to an inference
+/// context.
+pub type SpannedRegionConstraint<I> = RegionConstraint<I, <I as Interner>::Span>;
 
 // This is not a derived impl because a perfect derive leads to inductive
 // cycle causing the trait to never actually be implemented.
@@ -141,15 +148,15 @@ where
 
         std::mem::discriminant(self).stable_hash(hcx, hasher);
         match self {
-            Ambiguity => (),
-            RegionOutlives(a, b) => {
+            Ambiguity(_) => (),
+            RegionOutlives(a, b, _) => {
                 a.stable_hash(hcx, hasher);
                 b.stable_hash(hcx, hasher);
             }
-            AliasTyOutlivesViaEnv(outlives) => {
+            AliasTyOutlivesViaEnv(outlives, _) => {
                 outlives.stable_hash(hcx, hasher);
             }
-            PlaceholderTyOutlives(a, b) => {
+            PlaceholderTyOutlives(a, b, _) => {
                 a.stable_hash(hcx, hasher);
                 b.stable_hash(hcx, hasher);
             }
@@ -167,15 +174,19 @@ where
     }
 }
 
-impl<I: Interner> TypeFoldable<I> for RegionConstraint<I> {
+impl<I: Interner, S: Clone + std::fmt::Debug> TypeFoldable<I> for RegionConstraint<I, S> {
     fn try_fold_with<F: FallibleTypeFolder<I>>(self, f: &mut F) -> Result<Self, F::Error> {
         use RegionConstraint::*;
         Ok(match self {
-            Ambiguity => self,
-            RegionOutlives(a, b) => RegionOutlives(a.try_fold_with(f)?, b.try_fold_with(f)?),
-            AliasTyOutlivesViaEnv(outlives) => AliasTyOutlivesViaEnv(outlives.try_fold_with(f)?),
-            PlaceholderTyOutlives(a, b) => {
-                PlaceholderTyOutlives(a.try_fold_with(f)?, b.try_fold_with(f)?)
+            Ambiguity(_) => self,
+            RegionOutlives(a, b, span) => {
+                RegionOutlives(a.try_fold_with(f)?, b.try_fold_with(f)?, span)
+            }
+            AliasTyOutlivesViaEnv(outlives, span) => {
+                AliasTyOutlivesViaEnv(outlives.try_fold_with(f)?, span)
+            }
+            PlaceholderTyOutlives(a, b, span) => {
+                PlaceholderTyOutlives(a.try_fold_with(f)?, b.try_fold_with(f)?, span)
             }
             And(and) => {
                 let mut new_and = Vec::new();
@@ -197,10 +208,14 @@ impl<I: Interner> TypeFoldable<I> for RegionConstraint<I> {
     fn fold_with<F: TypeFolder<I>>(self, f: &mut F) -> Self {
         use RegionConstraint::*;
         match self {
-            Ambiguity => self,
-            RegionOutlives(a, b) => RegionOutlives(a.fold_with(f), b.fold_with(f)),
-            AliasTyOutlivesViaEnv(outlives) => AliasTyOutlivesViaEnv(outlives.fold_with(f)),
-            PlaceholderTyOutlives(a, b) => PlaceholderTyOutlives(a.fold_with(f), b.fold_with(f)),
+            Ambiguity(_) => self,
+            RegionOutlives(a, b, span) => RegionOutlives(a.fold_with(f), b.fold_with(f), span),
+            AliasTyOutlivesViaEnv(outlives, span) => {
+                AliasTyOutlivesViaEnv(outlives.fold_with(f), span)
+            }
+            PlaceholderTyOutlives(a, b, span) => {
+                PlaceholderTyOutlives(a.fold_with(f), b.fold_with(f), span)
+            }
             And(and) => {
                 let mut new_and = Vec::new();
                 for a in and {
@@ -219,20 +234,20 @@ impl<I: Interner> TypeFoldable<I> for RegionConstraint<I> {
     }
 }
 
-impl<I: Interner> TypeVisitable<I> for RegionConstraint<I> {
+impl<I: Interner, S: std::fmt::Debug> TypeVisitable<I> for RegionConstraint<I, S> {
     fn visit_with<F: TypeVisitor<I>>(&self, f: &mut F) -> F::Result {
         use RegionConstraint::*;
 
         match self {
-            Ambiguity => (),
-            RegionOutlives(a, b) => {
+            Ambiguity(_) => (),
+            RegionOutlives(a, b, _) => {
                 try_visit!(a.visit_with(f));
                 try_visit!(b.visit_with(f));
             }
-            AliasTyOutlivesViaEnv(outlives) => {
+            AliasTyOutlivesViaEnv(outlives, _) => {
                 try_visit!(outlives.visit_with(f));
             }
-            PlaceholderTyOutlives(a, b) => {
+            PlaceholderTyOutlives(a, b, _) => {
                 try_visit!(a.visit_with(f));
                 try_visit!(b.visit_with(f));
             }
@@ -248,13 +263,38 @@ impl<I: Interner> TypeVisitable<I> for RegionConstraint<I> {
     }
 }
 
-impl<I: Interner> Default for RegionConstraint<I> {
+impl<I: Interner, S> RegionConstraint<I, S> {
+    fn map_spans<T>(self, f: &mut impl FnMut(S) -> T) -> RegionConstraint<I, T> {
+        use RegionConstraint::*;
+
+        match self {
+            Ambiguity(span) => Ambiguity(f(span)),
+            RegionOutlives(a, b, span) => RegionOutlives(a, b, f(span)),
+            AliasTyOutlivesViaEnv(outlives, span) => AliasTyOutlivesViaEnv(outlives, f(span)),
+            PlaceholderTyOutlives(ty, region, span) => PlaceholderTyOutlives(ty, region, f(span)),
+            And(constraints) => And(constraints.into_iter().map(|c| c.map_spans(f)).collect()),
+            Or(constraints) => Or(constraints.into_iter().map(|c| c.map_spans(f)).collect()),
+        }
+    }
+
+    pub fn without_spans(self) -> RegionConstraint<I> {
+        self.map_spans(&mut |_| ())
+    }
+}
+
+impl<I: Interner> RegionConstraint<I> {
+    pub fn with_span<S: Clone>(self, span: S) -> RegionConstraint<I, S> {
+        self.map_spans(&mut |_| span.clone())
+    }
+}
+
+impl<I: Interner, S: Clone + std::fmt::Debug> Default for RegionConstraint<I, S> {
     fn default() -> Self {
         Self::new_true()
     }
 }
 
-impl<I: Interner> RegionConstraint<I> {
+impl<I: Interner, S: Clone + std::fmt::Debug> RegionConstraint<I, S> {
     pub fn new_true() -> Self {
         RegionConstraint::And(Box::new([]))
     }
@@ -281,14 +321,14 @@ impl<I: Interner> RegionConstraint<I> {
         matches!(self, Self::Or(_))
     }
 
-    pub fn unwrap_or(self) -> Box<[RegionConstraint<I>]> {
+    pub fn unwrap_or(self) -> Box<[RegionConstraint<I, S>]> {
         match self {
             Self::Or(ors) => ors,
             _ => panic!("`unwrap_or` on non-Or: {self:?}"),
         }
     }
 
-    pub fn unwrap_and(self) -> Box<[RegionConstraint<I>]> {
+    pub fn unwrap_and(self) -> Box<[RegionConstraint<I, S>]> {
         match self {
             Self::And(ands) => ands,
             _ => panic!("`unwrap_and` on non-And: {self:?}"),
@@ -300,10 +340,10 @@ impl<I: Interner> RegionConstraint<I> {
     }
 
     pub fn is_ambig(&self) -> bool {
-        matches!(self, Self::Ambiguity)
+        matches!(self, Self::Ambiguity(_))
     }
 
-    pub fn and(self, other: RegionConstraint<I>) -> RegionConstraint<I> {
+    pub fn and(self, other: RegionConstraint<I, S>) -> RegionConstraint<I, S> {
         use RegionConstraint::*;
 
         match (self, other) {
@@ -325,9 +365,9 @@ impl<I: Interner> RegionConstraint<I> {
     pub fn canonical_form(self) -> Self {
         use RegionConstraint::*;
 
-        fn permutations<I: Interner>(
-            ors: &[Vec<RegionConstraint<I>>],
-        ) -> Vec<Vec<RegionConstraint<I>>> {
+        fn permutations<I: Interner, S: Clone>(
+            ors: &[Vec<RegionConstraint<I, S>>],
+        ) -> Vec<Vec<RegionConstraint<I, S>>> {
             match ors {
                 [] => vec![vec![]],
                 [or1] => {
@@ -405,7 +445,7 @@ impl<I: Interner> RegionConstraint<I> {
     fn is_leaf_constraint(&self) -> bool {
         use RegionConstraint::*;
         match self {
-            Ambiguity
+            Ambiguity(_)
             | RegionOutlives(..)
             | AliasTyOutlivesViaEnv(..)
             | PlaceholderTyOutlives(..) => true,
@@ -504,10 +544,10 @@ fn compute_new_region_constraints<Infcx: InferCtxtLike<Interner = I>, I: Interne
     for c in constraints {
         match c {
             And(..) | Or(..) => unreachable!(),
-            Ambiguity | PlaceholderTyOutlives(..) | AliasTyOutlivesViaEnv(..) => {
+            Ambiguity(_) | PlaceholderTyOutlives(..) | AliasTyOutlivesViaEnv(..) => {
                 new_constraints.push(c.clone())
             }
-            RegionOutlives(r1, r2) => {
+            RegionOutlives(r1, r2, _) => {
                 regions.insert(r1);
                 regions.insert(r2);
                 region_flows_builder.add(r2, r1);
@@ -531,7 +571,7 @@ fn compute_new_region_constraints<Infcx: InferCtxtLike<Interner = I>, I: Interne
             };
 
             if is_placeholder_like(*r) && is_placeholder_like(*ub) {
-                new_constraints.push(RegionOutlives(*ub, *r));
+                new_constraints.push(RegionOutlives(*ub, *r, ()));
             }
         }
     }
@@ -541,57 +581,56 @@ fn compute_new_region_constraints<Infcx: InferCtxtLike<Interner = I>, I: Interne
 
 /// Evaluate ANDs and ORs to true/false/ambiguous based on whether their arguments are true/false/ambiguous
 #[instrument(level = "debug", ret)]
-pub fn evaluate_solver_constraint<I: Interner>(
-    constraint: &RegionConstraint<I>,
-) -> RegionConstraint<I> {
+pub fn evaluate_solver_constraint<I: Interner, S: Clone + std::fmt::Debug>(
+    constraint: &RegionConstraint<I, S>,
+) -> RegionConstraint<I, S> {
     use RegionConstraint::*;
     match constraint {
-        Ambiguity | RegionOutlives(..) | AliasTyOutlivesViaEnv(..) | PlaceholderTyOutlives(..) => {
-            constraint.clone()
-        }
+        Ambiguity(_)
+        | RegionOutlives(..)
+        | AliasTyOutlivesViaEnv(..)
+        | PlaceholderTyOutlives(..) => constraint.clone(),
         And(and) => {
             let mut and_constraints = Vec::new();
-            let mut is_ambiguous_constraint = false;
+            let mut ambiguity = None;
             for c in and.iter() {
                 let evaluated_constraint = evaluate_solver_constraint(c);
                 if evaluated_constraint.is_true() {
                     // - do nothing
                 } else if evaluated_constraint.is_false() {
                     return RegionConstraint::new_false();
-                } else if evaluated_constraint.is_ambig() {
-                    is_ambiguous_constraint = true;
+                } else if let Ambiguity(span) = evaluated_constraint {
+                    ambiguity.get_or_insert(span);
                 } else {
                     and_constraints.push(evaluated_constraint);
                 }
             }
 
-            if is_ambiguous_constraint {
-                RegionConstraint::Ambiguity
-            } else {
-                RegionConstraint::And(and_constraints.into_boxed_slice())
-            }
+            ambiguity.map_or_else(
+                || RegionConstraint::And(and_constraints.into_boxed_slice()),
+                RegionConstraint::Ambiguity,
+            )
         }
         Or(or) => {
             let mut or_constraints = Vec::new();
-            let mut is_ambiguous_constraint = false;
+            let mut ambiguity = None;
             for c in or.iter() {
                 let evaluated_constraint = evaluate_solver_constraint(c);
                 if evaluated_constraint.is_false() {
                     // do nothing
                 } else if evaluated_constraint.is_true() {
                     return RegionConstraint::new_true();
-                } else if evaluated_constraint.is_ambig() {
-                    is_ambiguous_constraint = true;
+                } else if let Ambiguity(span) = evaluated_constraint {
+                    ambiguity.get_or_insert(span);
                 } else {
                     or_constraints.push(evaluated_constraint);
                 }
             }
 
-            if is_ambiguous_constraint {
-                RegionConstraint::Ambiguity
-            } else {
-                RegionConstraint::Or(or_constraints.into_boxed_slice())
-            }
+            ambiguity.map_or_else(
+                || RegionConstraint::Or(or_constraints.into_boxed_slice()),
+                RegionConstraint::Ambiguity,
+            )
         }
     }
 }
@@ -637,11 +676,11 @@ fn pull_region_outlives_constraints_out_of_universe<
 
     use RegionConstraint::*;
     match constraint {
-        Ambiguity | PlaceholderTyOutlives(..) | AliasTyOutlivesViaEnv(..) => {
+        Ambiguity(_) | PlaceholderTyOutlives(..) | AliasTyOutlivesViaEnv(..) => {
             assert!(max_universe(infcx, constraint.clone()) < u);
             constraint
         }
-        RegionOutlives(region_1, region_2) => {
+        RegionOutlives(region_1, region_2, ()) => {
             let region_1_u = max_universe(infcx, region_1);
             let region_2_u = max_universe(infcx, region_2);
 
@@ -651,7 +690,7 @@ fn pull_region_outlives_constraints_out_of_universe<
 
             let assumptions = match assumptions {
                 Some(assumptions) => assumptions,
-                None => return RegionConstraint::Ambiguity,
+                None => return RegionConstraint::Ambiguity(()),
             };
 
             let mut candidates = vec![];
@@ -667,7 +706,7 @@ fn pull_region_outlives_constraints_out_of_universe<
                     // As long as any region outlived by `region_1` outlives any region region which
                     // `region_2` outlives, we know that `region_1: region_2` holds. In other words,
                     // there exists some set of 4 regions for which `'r1: 'i1` `'i1: 'i2` `'i2: 'r2`
-                    candidates.push(RegionOutlives(ub, lb));
+                    candidates.push(RegionOutlives(ub, lb, ()));
                 }
             }
 
@@ -690,23 +729,25 @@ fn pull_region_outlives_constraints_out_of_universe<
 pub fn destructure_type_outlives_constraints_in_root<
     Infcx: InferCtxtLike<Interner = I>,
     I: Interner,
+    S: Clone + std::fmt::Debug,
 >(
     infcx: &Infcx,
-    constraint: RegionConstraint<I>,
+    constraint: RegionConstraint<I, S>,
     assumptions: &Assumptions<I>,
-) -> RegionConstraint<I> {
+) -> RegionConstraint<I, S> {
     use RegionConstraint::*;
 
     match constraint {
-        Ambiguity | RegionOutlives(..) => constraint,
-        PlaceholderTyOutlives(ty, r) => {
+        Ambiguity(_) | RegionOutlives(..) => constraint,
+        PlaceholderTyOutlives(ty, r, span) => {
             Or(regions_outlived_by_placeholder(ty, assumptions, infcx.cx())
-                .map(move |assumption_r| RegionOutlives(assumption_r, r))
+                .map(move |assumption_r| RegionOutlives(assumption_r, r, span.clone()))
                 .collect::<Vec<_>>()
                 .into_boxed_slice())
         }
-        AliasTyOutlivesViaEnv(bound_outlives) => {
+        AliasTyOutlivesViaEnv(bound_outlives, span) => {
             alias_outlives_candidates_from_assumptions(infcx, bound_outlives, assumptions)
+                .with_span(span)
         }
         And(constraints) => And(constraints
             .into_iter()
@@ -752,8 +793,8 @@ fn rewrite_type_outlives_constraints_in_universe_for_eager_placeholder_handling<
 
     use RegionConstraint::*;
     match constraint {
-        Ambiguity | RegionOutlives(..) => constraint,
-        PlaceholderTyOutlives(ty, region) => {
+        Ambiguity(_) | RegionOutlives(..) => constraint,
+        PlaceholderTyOutlives(ty, region, ()) => {
             let ty_u = max_universe(infcx, ty);
             let region_u = max_universe(infcx, region);
 
@@ -763,7 +804,7 @@ fn rewrite_type_outlives_constraints_in_universe_for_eager_placeholder_handling<
 
             let assumptions = match assumptions {
                 Some(assumptions) => assumptions,
-                None => return Ambiguity,
+                None => return Ambiguity(()),
             };
 
             let mut candidates = vec![];
@@ -772,7 +813,7 @@ fn rewrite_type_outlives_constraints_in_universe_for_eager_placeholder_handling<
             // smaller universe
             candidates.extend(
                 regions_outlived_by_placeholder(ty, assumptions, infcx.cx())
-                    .map(move |assumption_r| RegionOutlives(assumption_r, region)),
+                    .map(move |assumption_r| RegionOutlives(assumption_r, region, ())),
             );
 
             // We can express `!T: 'region` as `!T: 'r` where `'r: 'region`. This is only necessary
@@ -782,13 +823,13 @@ fn rewrite_type_outlives_constraints_in_universe_for_eager_placeholder_handling<
                 candidates.extend(
                     regions_outliving::<I>(region, assumptions, infcx.cx())
                         .filter(|r| max_universe(infcx, *r) < u)
-                        .map(|r| PlaceholderTyOutlives(ty, r)),
+                        .map(|r| PlaceholderTyOutlives(ty, r, ())),
                 );
             }
 
             Or(candidates.into_boxed_slice())
         }
-        AliasTyOutlivesViaEnv(bound_outlives) => {
+        AliasTyOutlivesViaEnv(bound_outlives, ()) => {
             let mut candidates = Vec::new();
 
             // given there can be higher ranked assumptions, e.g. `for<'a> <T as Trait<'a>>::Assoc: 'c`, that
@@ -824,21 +865,21 @@ fn rewrite_type_outlives_constraints_in_universe_for_eager_placeholder_handling<
                     escaping_outlives,
                     I::BoundVarKinds::from_vars(infcx.cx(), bound_vars),
                 );
-                let candidate = RegionConstraint::AliasTyOutlivesViaEnv(bound_outlives);
+                let candidate = RegionConstraint::AliasTyOutlivesViaEnv(bound_outlives, ());
                 if max_universe(infcx, candidate.clone()) < u {
                     candidates.push(candidate);
                 } else {
                     // `PlaceholderReplacer` only folds regions. A non-lifetime binder can leave
                     // a placeholder type in `u`, so this type-outlives constraint cannot be
                     // handled by the region-outlives-only eager placeholder machinery.
-                    candidates.push(Ambiguity);
+                    candidates.push(Ambiguity(()));
                 }
             }
 
             let assumptions = match assumptions {
                 Some(assumptions) => assumptions,
                 None => {
-                    candidates.push(Ambiguity);
+                    candidates.push(Ambiguity(()));
                     return Or(candidates.into_boxed_slice());
                 }
             };
@@ -881,11 +922,11 @@ fn rewrite_type_outlives_constraints_in_universe_for_eager_placeholder_handling<
                     .filter(|r2| max_universe(infcx, *r2) < u)
                 {
                     let candidate =
-                        AliasTyOutlivesViaEnv(bound_alias.map_bound(|alias| (alias, r2)));
+                        AliasTyOutlivesViaEnv(bound_alias.map_bound(|alias| (alias, r2)), ());
                     if max_universe(infcx, candidate.clone()) < u {
                         candidates.push(candidate);
                     } else {
-                        candidates.push(Ambiguity);
+                        candidates.push(Ambiguity(()));
                     }
                 }
             }
@@ -894,7 +935,7 @@ fn rewrite_type_outlives_constraints_in_universe_for_eager_placeholder_handling<
             // let's be conservative and not let alias outlives' cause NoSolution
             // in coherence
             match infcx.typing_mode_raw() {
-                TypingMode::Coherence => candidates.push(RegionConstraint::Ambiguity),
+                TypingMode::Coherence => candidates.push(RegionConstraint::Ambiguity(())),
                 TypingMode::Typeck { .. }
                 | TypingMode::ErasedNotCoherence { .. }
                 | TypingMode::PostTypeckUntilBorrowck { .. }
@@ -1032,7 +1073,7 @@ fn alias_outlives_candidates_from_assumptions<Infcx: InferCtxtLike<Interner = I>
 
             let mut relation = HigherRankedAliasMatcher {
                 infcx,
-                region_constraints: vec![RegionConstraint::RegionOutlives(r2, r)],
+                region_constraints: vec![RegionConstraint::RegionOutlives(r2, r, ())],
             };
 
             // FIXME(#155345): Both sides should be rigid in the future.
@@ -1103,8 +1144,8 @@ impl<'a, Infcx: InferCtxtLike<Interner = I>, I: Interner> TypeRelation<I>
 
     fn regions(&mut self, a: Region<I>, b: Region<I>) -> RelateResult<I, Region<I>> {
         if a != b {
-            self.region_constraints.push(RegionConstraint::RegionOutlives(a, b));
-            self.region_constraints.push(RegionConstraint::RegionOutlives(b, a));
+            self.region_constraints.push(RegionConstraint::RegionOutlives(a, b, ()));
+            self.region_constraints.push(RegionConstraint::RegionOutlives(b, a, ()));
         }
         Ok(a)
     }

--- a/compiler/rustc_type_ir/src/region_constraint.rs
+++ b/compiler/rustc_type_ir/src/region_constraint.rs
@@ -121,7 +121,7 @@ pub enum RegionConstraint<I: Interner, S = ()> {
     Or(Box<[RegionConstraint<I, S>]>),
 }
 
-/// A solver region constraint together with the span that caused each atomic constraint.
+/// A solver region constraint together with the span that caused each leaf constraint.
 ///
 /// Solver query responses use [`RegionConstraint`] so source locations do not participate in
 /// candidate equality or caching. Spans are attached when responses are applied to an inference

--- a/compiler/rustc_type_ir/src/region_constraint.rs
+++ b/compiler/rustc_type_ir/src/region_constraint.rs
@@ -91,11 +91,11 @@ impl<I: Interner> Assumptions<I> {
     }
 }
 
-#[derive_where(Clone, Hash, PartialEq, Debug; I: Interner)]
+#[derive_where(Clone, Hash, PartialEq, Debug; I: Interner, S)]
 #[derive(GenericTypeVisitable)]
-pub enum RegionConstraint<I: Interner> {
-    Ambiguity,
-    RegionOutlives(Region<I>, Region<I>),
+pub enum RegionConstraint<I: Interner, S = ()> {
+    Ambiguity(S),
+    RegionOutlives(Region<I>, Region<I>, S),
     /// Requirement that a (potentially higher ranked) alias outlives some (potentially higher ranked)
     /// region due to an assumption in the environment. This cannot be satisfied via component outlives
     /// or item bounds.
@@ -105,7 +105,7 @@ pub enum RegionConstraint<I: Interner> {
     ///
     /// We eagerly destructure alias outlives requirements into region outlives requirements corresponding to
     /// component outlives & item bound outlives rules, leaving only param env candidates.
-    AliasTyOutlivesViaEnv(Binder<I, (AliasTy<I>, Region<I>)>),
+    AliasTyOutlivesViaEnv(Binder<I, (AliasTy<I>, Region<I>)>, S),
     /// This is an `I::Ty` for two reasons:
     /// 1. We need the type visitable impl to be able to `visit_ty` on this so canonicalization
     ///    knows about the placeholder
@@ -115,11 +115,18 @@ pub enum RegionConstraint<I: Interner> {
     ///
     /// We cannot eagerly look at assumptions as we are usually working with an incomplete set of assumptions
     /// and there may wind up being assumptions we can use to prove this when we're in a smaller universe.
-    PlaceholderTyOutlives(I::Ty, Region<I>),
+    PlaceholderTyOutlives(I::Ty, Region<I>, S),
 
-    And(Box<[RegionConstraint<I>]>),
-    Or(Box<[RegionConstraint<I>]>),
+    And(Box<[RegionConstraint<I, S>]>),
+    Or(Box<[RegionConstraint<I, S>]>),
 }
+
+/// A solver region constraint together with the span that caused each atomic constraint.
+///
+/// Solver query responses use [`RegionConstraint`] so source locations do not participate in
+/// candidate equality or caching. Spans are attached when responses are applied to an inference
+/// context.
+pub type SpannedRegionConstraint<I> = RegionConstraint<I, <I as Interner>::Span>;
 
 // This is not a derived impl because a perfect derive leads to inductive
 // cycle causing the trait to never actually be implemented.
@@ -141,15 +148,15 @@ where
 
         std::mem::discriminant(self).stable_hash(hcx, hasher);
         match self {
-            Ambiguity => (),
-            RegionOutlives(a, b) => {
+            Ambiguity(_) => (),
+            RegionOutlives(a, b, _) => {
                 a.stable_hash(hcx, hasher);
                 b.stable_hash(hcx, hasher);
             }
-            AliasTyOutlivesViaEnv(outlives) => {
+            AliasTyOutlivesViaEnv(outlives, _) => {
                 outlives.stable_hash(hcx, hasher);
             }
-            PlaceholderTyOutlives(a, b) => {
+            PlaceholderTyOutlives(a, b, _) => {
                 a.stable_hash(hcx, hasher);
                 b.stable_hash(hcx, hasher);
             }
@@ -167,15 +174,19 @@ where
     }
 }
 
-impl<I: Interner> TypeFoldable<I> for RegionConstraint<I> {
+impl<I: Interner, S: Clone + std::fmt::Debug> TypeFoldable<I> for RegionConstraint<I, S> {
     fn try_fold_with<F: FallibleTypeFolder<I>>(self, f: &mut F) -> Result<Self, F::Error> {
         use RegionConstraint::*;
         Ok(match self {
-            Ambiguity => self,
-            RegionOutlives(a, b) => RegionOutlives(a.try_fold_with(f)?, b.try_fold_with(f)?),
-            AliasTyOutlivesViaEnv(outlives) => AliasTyOutlivesViaEnv(outlives.try_fold_with(f)?),
-            PlaceholderTyOutlives(a, b) => {
-                PlaceholderTyOutlives(a.try_fold_with(f)?, b.try_fold_with(f)?)
+            Ambiguity(_) => self,
+            RegionOutlives(a, b, span) => {
+                RegionOutlives(a.try_fold_with(f)?, b.try_fold_with(f)?, span)
+            }
+            AliasTyOutlivesViaEnv(outlives, span) => {
+                AliasTyOutlivesViaEnv(outlives.try_fold_with(f)?, span)
+            }
+            PlaceholderTyOutlives(a, b, span) => {
+                PlaceholderTyOutlives(a.try_fold_with(f)?, b.try_fold_with(f)?, span)
             }
             And(and) => {
                 let mut new_and = Vec::new();
@@ -197,10 +208,14 @@ impl<I: Interner> TypeFoldable<I> for RegionConstraint<I> {
     fn fold_with<F: TypeFolder<I>>(self, f: &mut F) -> Self {
         use RegionConstraint::*;
         match self {
-            Ambiguity => self,
-            RegionOutlives(a, b) => RegionOutlives(a.fold_with(f), b.fold_with(f)),
-            AliasTyOutlivesViaEnv(outlives) => AliasTyOutlivesViaEnv(outlives.fold_with(f)),
-            PlaceholderTyOutlives(a, b) => PlaceholderTyOutlives(a.fold_with(f), b.fold_with(f)),
+            Ambiguity(_) => self,
+            RegionOutlives(a, b, span) => RegionOutlives(a.fold_with(f), b.fold_with(f), span),
+            AliasTyOutlivesViaEnv(outlives, span) => {
+                AliasTyOutlivesViaEnv(outlives.fold_with(f), span)
+            }
+            PlaceholderTyOutlives(a, b, span) => {
+                PlaceholderTyOutlives(a.fold_with(f), b.fold_with(f), span)
+            }
             And(and) => {
                 let mut new_and = Vec::new();
                 for a in and {
@@ -219,20 +234,20 @@ impl<I: Interner> TypeFoldable<I> for RegionConstraint<I> {
     }
 }
 
-impl<I: Interner> TypeVisitable<I> for RegionConstraint<I> {
+impl<I: Interner, S: std::fmt::Debug> TypeVisitable<I> for RegionConstraint<I, S> {
     fn visit_with<F: TypeVisitor<I>>(&self, f: &mut F) -> F::Result {
         use RegionConstraint::*;
 
         match self {
-            Ambiguity => (),
-            RegionOutlives(a, b) => {
+            Ambiguity(_) => (),
+            RegionOutlives(a, b, _) => {
                 try_visit!(a.visit_with(f));
                 try_visit!(b.visit_with(f));
             }
-            AliasTyOutlivesViaEnv(outlives) => {
+            AliasTyOutlivesViaEnv(outlives, _) => {
                 try_visit!(outlives.visit_with(f));
             }
-            PlaceholderTyOutlives(a, b) => {
+            PlaceholderTyOutlives(a, b, _) => {
                 try_visit!(a.visit_with(f));
                 try_visit!(b.visit_with(f));
             }
@@ -248,13 +263,38 @@ impl<I: Interner> TypeVisitable<I> for RegionConstraint<I> {
     }
 }
 
-impl<I: Interner> Default for RegionConstraint<I> {
+impl<I: Interner, S> RegionConstraint<I, S> {
+    fn map_spans<T>(self, f: &mut impl FnMut(S) -> T) -> RegionConstraint<I, T> {
+        use RegionConstraint::*;
+
+        match self {
+            Ambiguity(span) => Ambiguity(f(span)),
+            RegionOutlives(a, b, span) => RegionOutlives(a, b, f(span)),
+            AliasTyOutlivesViaEnv(outlives, span) => AliasTyOutlivesViaEnv(outlives, f(span)),
+            PlaceholderTyOutlives(ty, region, span) => PlaceholderTyOutlives(ty, region, f(span)),
+            And(constraints) => And(constraints.into_iter().map(|c| c.map_spans(f)).collect()),
+            Or(constraints) => Or(constraints.into_iter().map(|c| c.map_spans(f)).collect()),
+        }
+    }
+
+    pub fn without_spans(self) -> RegionConstraint<I> {
+        self.map_spans(&mut |_| ())
+    }
+}
+
+impl<I: Interner> RegionConstraint<I> {
+    pub fn with_span<S: Clone>(self, span: S) -> RegionConstraint<I, S> {
+        self.map_spans(&mut |_| span.clone())
+    }
+}
+
+impl<I: Interner, S: Clone + std::fmt::Debug> Default for RegionConstraint<I, S> {
     fn default() -> Self {
         Self::new_true()
     }
 }
 
-impl<I: Interner> RegionConstraint<I> {
+impl<I: Interner, S: Clone + std::fmt::Debug> RegionConstraint<I, S> {
     pub fn new_true() -> Self {
         RegionConstraint::And(Box::new([]))
     }
@@ -281,14 +321,14 @@ impl<I: Interner> RegionConstraint<I> {
         matches!(self, Self::Or(_))
     }
 
-    pub fn unwrap_or(self) -> Box<[RegionConstraint<I>]> {
+    pub fn unwrap_or(self) -> Box<[RegionConstraint<I, S>]> {
         match self {
             Self::Or(ors) => ors,
             _ => panic!("`unwrap_or` on non-Or: {self:?}"),
         }
     }
 
-    pub fn unwrap_and(self) -> Box<[RegionConstraint<I>]> {
+    pub fn unwrap_and(self) -> Box<[RegionConstraint<I, S>]> {
         match self {
             Self::And(ands) => ands,
             _ => panic!("`unwrap_and` on non-And: {self:?}"),
@@ -300,10 +340,10 @@ impl<I: Interner> RegionConstraint<I> {
     }
 
     pub fn is_ambig(&self) -> bool {
-        matches!(self, Self::Ambiguity)
+        matches!(self, Self::Ambiguity(_))
     }
 
-    pub fn and(self, other: RegionConstraint<I>) -> RegionConstraint<I> {
+    pub fn and(self, other: RegionConstraint<I, S>) -> RegionConstraint<I, S> {
         use RegionConstraint::*;
 
         match (self, other) {
@@ -325,9 +365,9 @@ impl<I: Interner> RegionConstraint<I> {
     pub fn canonical_form(self) -> Self {
         use RegionConstraint::*;
 
-        fn permutations<I: Interner>(
-            ors: &[Vec<RegionConstraint<I>>],
-        ) -> Vec<Vec<RegionConstraint<I>>> {
+        fn permutations<I: Interner, S: Clone>(
+            ors: &[Vec<RegionConstraint<I, S>>],
+        ) -> Vec<Vec<RegionConstraint<I, S>>> {
             match ors {
                 [] => vec![vec![]],
                 [or1] => {
@@ -404,7 +444,7 @@ impl<I: Interner> RegionConstraint<I> {
     fn is_leaf_constraint(&self) -> bool {
         use RegionConstraint::*;
         match self {
-            Ambiguity
+            Ambiguity(_)
             | RegionOutlives(..)
             | AliasTyOutlivesViaEnv(..)
             | PlaceholderTyOutlives(..) => true,
@@ -503,10 +543,10 @@ fn compute_new_region_constraints<Infcx: InferCtxtLike<Interner = I>, I: Interne
     for c in constraints {
         match c {
             And(..) | Or(..) => unreachable!(),
-            Ambiguity | PlaceholderTyOutlives(..) | AliasTyOutlivesViaEnv(..) => {
+            Ambiguity(_) | PlaceholderTyOutlives(..) | AliasTyOutlivesViaEnv(..) => {
                 new_constraints.push(c.clone())
             }
-            RegionOutlives(r1, r2) => {
+            RegionOutlives(r1, r2, _) => {
                 regions.insert(r1);
                 regions.insert(r2);
                 region_flows_builder.add(r2, r1);
@@ -530,7 +570,7 @@ fn compute_new_region_constraints<Infcx: InferCtxtLike<Interner = I>, I: Interne
             };
 
             if is_placeholder_like(*r) && is_placeholder_like(*ub) {
-                new_constraints.push(RegionOutlives(*ub, *r));
+                new_constraints.push(RegionOutlives(*ub, *r, ()));
             }
         }
     }
@@ -540,57 +580,56 @@ fn compute_new_region_constraints<Infcx: InferCtxtLike<Interner = I>, I: Interne
 
 /// Evaluate ANDs and ORs to true/false/ambiguous based on whether their arguments are true/false/ambiguous
 #[instrument(level = "debug", ret)]
-pub fn evaluate_solver_constraint<I: Interner>(
-    constraint: &RegionConstraint<I>,
-) -> RegionConstraint<I> {
+pub fn evaluate_solver_constraint<I: Interner, S: Clone + std::fmt::Debug>(
+    constraint: &RegionConstraint<I, S>,
+) -> RegionConstraint<I, S> {
     use RegionConstraint::*;
     match constraint {
-        Ambiguity | RegionOutlives(..) | AliasTyOutlivesViaEnv(..) | PlaceholderTyOutlives(..) => {
-            constraint.clone()
-        }
+        Ambiguity(_)
+        | RegionOutlives(..)
+        | AliasTyOutlivesViaEnv(..)
+        | PlaceholderTyOutlives(..) => constraint.clone(),
         And(and) => {
             let mut and_constraints = Vec::new();
-            let mut is_ambiguous_constraint = false;
+            let mut ambiguity = None;
             for c in and.iter() {
                 let evaluated_constraint = evaluate_solver_constraint(c);
                 if evaluated_constraint.is_true() {
                     // - do nothing
                 } else if evaluated_constraint.is_false() {
                     return RegionConstraint::new_false();
-                } else if evaluated_constraint.is_ambig() {
-                    is_ambiguous_constraint = true;
+                } else if let Ambiguity(span) = evaluated_constraint {
+                    ambiguity.get_or_insert(span);
                 } else {
                     and_constraints.push(evaluated_constraint);
                 }
             }
 
-            if is_ambiguous_constraint {
-                RegionConstraint::Ambiguity
-            } else {
-                RegionConstraint::And(and_constraints.into_boxed_slice())
-            }
+            ambiguity.map_or_else(
+                || RegionConstraint::And(and_constraints.into_boxed_slice()),
+                RegionConstraint::Ambiguity,
+            )
         }
         Or(or) => {
             let mut or_constraints = Vec::new();
-            let mut is_ambiguous_constraint = false;
+            let mut ambiguity = None;
             for c in or.iter() {
                 let evaluated_constraint = evaluate_solver_constraint(c);
                 if evaluated_constraint.is_false() {
                     // do nothing
                 } else if evaluated_constraint.is_true() {
                     return RegionConstraint::new_true();
-                } else if evaluated_constraint.is_ambig() {
-                    is_ambiguous_constraint = true;
+                } else if let Ambiguity(span) = evaluated_constraint {
+                    ambiguity.get_or_insert(span);
                 } else {
                     or_constraints.push(evaluated_constraint);
                 }
             }
 
-            if is_ambiguous_constraint {
-                RegionConstraint::Ambiguity
-            } else {
-                RegionConstraint::Or(or_constraints.into_boxed_slice())
-            }
+            ambiguity.map_or_else(
+                || RegionConstraint::Or(or_constraints.into_boxed_slice()),
+                RegionConstraint::Ambiguity,
+            )
         }
     }
 }
@@ -636,11 +675,11 @@ fn pull_region_outlives_constraints_out_of_universe<
 
     use RegionConstraint::*;
     match constraint {
-        Ambiguity | PlaceholderTyOutlives(..) | AliasTyOutlivesViaEnv(..) => {
+        Ambiguity(_) | PlaceholderTyOutlives(..) | AliasTyOutlivesViaEnv(..) => {
             assert!(max_universe(infcx, constraint.clone()) < u);
             constraint
         }
-        RegionOutlives(region_1, region_2) => {
+        RegionOutlives(region_1, region_2, ()) => {
             let region_1_u = max_universe(infcx, region_1);
             let region_2_u = max_universe(infcx, region_2);
 
@@ -650,7 +689,7 @@ fn pull_region_outlives_constraints_out_of_universe<
 
             let assumptions = match assumptions {
                 Some(assumptions) => assumptions,
-                None => return RegionConstraint::Ambiguity,
+                None => return RegionConstraint::Ambiguity(()),
             };
 
             let mut candidates = vec![];
@@ -666,7 +705,7 @@ fn pull_region_outlives_constraints_out_of_universe<
                     // As long as any region outlived by `region_1` outlives any region region which
                     // `region_2` outlives, we know that `region_1: region_2` holds. In other words,
                     // there exists some set of 4 regions for which `'r1: 'i1` `'i1: 'i2` `'i2: 'r2`
-                    candidates.push(RegionOutlives(ub, lb));
+                    candidates.push(RegionOutlives(ub, lb, ()));
                 }
             }
 
@@ -689,23 +728,25 @@ fn pull_region_outlives_constraints_out_of_universe<
 pub fn destructure_type_outlives_constraints_in_root<
     Infcx: InferCtxtLike<Interner = I>,
     I: Interner,
+    S: Clone + std::fmt::Debug,
 >(
     infcx: &Infcx,
-    constraint: RegionConstraint<I>,
+    constraint: RegionConstraint<I, S>,
     assumptions: &Assumptions<I>,
-) -> RegionConstraint<I> {
+) -> RegionConstraint<I, S> {
     use RegionConstraint::*;
 
     match constraint {
-        Ambiguity | RegionOutlives(..) => constraint,
-        PlaceholderTyOutlives(ty, r) => {
+        Ambiguity(_) | RegionOutlives(..) => constraint,
+        PlaceholderTyOutlives(ty, r, span) => {
             Or(regions_outlived_by_placeholder(ty, assumptions, infcx.cx())
-                .map(move |assumption_r| RegionOutlives(assumption_r, r))
+                .map(move |assumption_r| RegionOutlives(assumption_r, r, span.clone()))
                 .collect::<Vec<_>>()
                 .into_boxed_slice())
         }
-        AliasTyOutlivesViaEnv(bound_outlives) => {
+        AliasTyOutlivesViaEnv(bound_outlives, span) => {
             alias_outlives_candidates_from_assumptions(infcx, bound_outlives, assumptions)
+                .with_span(span)
         }
         And(constraints) => And(constraints
             .into_iter()
@@ -751,8 +792,8 @@ fn rewrite_type_outlives_constraints_in_universe_for_eager_placeholder_handling<
 
     use RegionConstraint::*;
     match constraint {
-        Ambiguity | RegionOutlives(..) => constraint,
-        PlaceholderTyOutlives(ty, region) => {
+        Ambiguity(_) | RegionOutlives(..) => constraint,
+        PlaceholderTyOutlives(ty, region, ()) => {
             let ty_u = max_universe(infcx, ty);
             let region_u = max_universe(infcx, region);
 
@@ -762,7 +803,7 @@ fn rewrite_type_outlives_constraints_in_universe_for_eager_placeholder_handling<
 
             let assumptions = match assumptions {
                 Some(assumptions) => assumptions,
-                None => return Ambiguity,
+                None => return Ambiguity(()),
             };
 
             let mut candidates = vec![];
@@ -771,7 +812,7 @@ fn rewrite_type_outlives_constraints_in_universe_for_eager_placeholder_handling<
             // smaller universe
             candidates.extend(
                 regions_outlived_by_placeholder(ty, assumptions, infcx.cx())
-                    .map(move |assumption_r| RegionOutlives(assumption_r, region)),
+                    .map(move |assumption_r| RegionOutlives(assumption_r, region, ())),
             );
 
             // We can express `!T: 'region` as `!T: 'r` where `'r: 'region`. This is only necessary
@@ -781,13 +822,13 @@ fn rewrite_type_outlives_constraints_in_universe_for_eager_placeholder_handling<
                 candidates.extend(
                     regions_outliving::<I>(region, assumptions, infcx.cx())
                         .filter(|r| max_universe(infcx, *r) < u)
-                        .map(|r| PlaceholderTyOutlives(ty, r)),
+                        .map(|r| PlaceholderTyOutlives(ty, r, ())),
                 );
             }
 
             Or(candidates.into_boxed_slice())
         }
-        AliasTyOutlivesViaEnv(bound_outlives) => {
+        AliasTyOutlivesViaEnv(bound_outlives, ()) => {
             let mut candidates = Vec::new();
 
             // given there can be higher ranked assumptions, e.g. `for<'a> <T as Trait<'a>>::Assoc: 'c`, that
@@ -823,21 +864,21 @@ fn rewrite_type_outlives_constraints_in_universe_for_eager_placeholder_handling<
                     escaping_outlives,
                     I::BoundVarKinds::from_vars(infcx.cx(), bound_vars),
                 );
-                let candidate = RegionConstraint::AliasTyOutlivesViaEnv(bound_outlives);
+                let candidate = RegionConstraint::AliasTyOutlivesViaEnv(bound_outlives, ());
                 if max_universe(infcx, candidate.clone()) < u {
                     candidates.push(candidate);
                 } else {
                     // `PlaceholderReplacer` only folds regions. A non-lifetime binder can leave
                     // a placeholder type in `u`, so this type-outlives constraint cannot be
                     // handled by the region-outlives-only eager placeholder machinery.
-                    candidates.push(Ambiguity);
+                    candidates.push(Ambiguity(()));
                 }
             }
 
             let assumptions = match assumptions {
                 Some(assumptions) => assumptions,
                 None => {
-                    candidates.push(Ambiguity);
+                    candidates.push(Ambiguity(()));
                     return Or(candidates.into_boxed_slice());
                 }
             };
@@ -880,11 +921,11 @@ fn rewrite_type_outlives_constraints_in_universe_for_eager_placeholder_handling<
                     .filter(|r2| max_universe(infcx, *r2) < u)
                 {
                     let candidate =
-                        AliasTyOutlivesViaEnv(bound_alias.map_bound(|alias| (alias, r2)));
+                        AliasTyOutlivesViaEnv(bound_alias.map_bound(|alias| (alias, r2)), ());
                     if max_universe(infcx, candidate.clone()) < u {
                         candidates.push(candidate);
                     } else {
-                        candidates.push(Ambiguity);
+                        candidates.push(Ambiguity(()));
                     }
                 }
             }
@@ -893,7 +934,7 @@ fn rewrite_type_outlives_constraints_in_universe_for_eager_placeholder_handling<
             // let's be conservative and not let alias outlives' cause NoSolution
             // in coherence
             match infcx.typing_mode_raw() {
-                TypingMode::Coherence => candidates.push(RegionConstraint::Ambiguity),
+                TypingMode::Coherence => candidates.push(RegionConstraint::Ambiguity(())),
                 TypingMode::Typeck { .. }
                 | TypingMode::ErasedNotCoherence { .. }
                 | TypingMode::PostTypeckUntilBorrowck { .. }
@@ -1031,7 +1072,7 @@ fn alias_outlives_candidates_from_assumptions<Infcx: InferCtxtLike<Interner = I>
 
             let mut relation = HigherRankedAliasMatcher {
                 infcx,
-                region_constraints: vec![RegionConstraint::RegionOutlives(r2, r)],
+                region_constraints: vec![RegionConstraint::RegionOutlives(r2, r, ())],
             };
 
             // FIXME(#155345): Both sides should be rigid in the future.
@@ -1102,8 +1143,8 @@ impl<'a, Infcx: InferCtxtLike<Interner = I>, I: Interner> TypeRelation<I>
 
     fn regions(&mut self, a: Region<I>, b: Region<I>) -> RelateResult<I, Region<I>> {
         if a != b {
-            self.region_constraints.push(RegionConstraint::RegionOutlives(a, b));
-            self.region_constraints.push(RegionConstraint::RegionOutlives(b, a));
+            self.region_constraints.push(RegionConstraint::RegionOutlives(a, b, ()));
+            self.region_constraints.push(RegionConstraint::RegionOutlives(b, a, ()));
         }
         Ok(a)
     }

--- a/tests/ui/assumptions_on_binders/alias_outlives.rs
+++ b/tests/ui/assumptions_on_binders/alias_outlives.rs
@@ -23,11 +23,22 @@ where
 }
 
 fn borrowck_env_fail<'a, T: AliasHaver>()
-//~^ ERROR: unsatisfied lifetime constraint from -Zassumptions-on-binders
 where
     <T as AliasHaver>::Assoc: 'a,
 {
     let _: ReqTrait<T::Assoc>;
+    //~^ ERROR: higher-ranked lifetime bound could not be satisfied
+}
+
+fn borrowck_multiple_origins_fail<'a, 'b, T: AliasHaver, U: AliasHaver>()
+where
+    <T as AliasHaver>::Assoc: 'a,
+    <U as AliasHaver>::Assoc: 'b,
+{
+    let _: ReqTrait<T::Assoc>;
+    //~^ ERROR: higher-ranked lifetime bound could not be satisfied
+    let _: ReqTrait<U::Assoc>;
+    //~^ ERROR: higher-ranked lifetime bound could not be satisfied
 }
 
 const REGIONCK_ENV_PASS<'a, T: AliasHaver>: ReqTrait<T::Assoc> = todo!()
@@ -35,7 +46,7 @@ where
     <T as AliasHaver>::Assoc: 'static;
 
 const REGIONCK_ENV_FAIL<'a, T: AliasHaver>: ReqTrait<T::Assoc> = todo!()
-//~^ ERROR: unsatisfied lifetime constraint from -Zassumptions-on-binders
+//~^ ERROR: higher-ranked lifetime bound could not be satisfied
 where
     <T as AliasHaver>::Assoc: 'a;
 

--- a/tests/ui/assumptions_on_binders/alias_outlives.rs
+++ b/tests/ui/assumptions_on_binders/alias_outlives.rs
@@ -23,11 +23,22 @@ where
 }
 
 fn borrowck_env_fail<'a, T: AliasHaver>()
-// FIXME: ^ this should raise an ERROR: unsatisfied lifetime constraint from -Zassumptions-on-binders
 where
     <T as AliasHaver>::Assoc: 'a,
 {
     let _: ReqTrait<T::Assoc>;
+    //~^ ERROR: higher-ranked lifetime bound could not be satisfied
+}
+
+fn borrowck_multiple_origins_fail<'a, 'b, T: AliasHaver, U: AliasHaver>()
+where
+    <T as AliasHaver>::Assoc: 'a,
+    <U as AliasHaver>::Assoc: 'b,
+{
+    let _: ReqTrait<T::Assoc>;
+    //~^ ERROR: higher-ranked lifetime bound could not be satisfied
+    let _: ReqTrait<U::Assoc>;
+    //~^ ERROR: higher-ranked lifetime bound could not be satisfied
 }
 
 const REGIONCK_ENV_PASS<'a, T: AliasHaver>: ReqTrait<T::Assoc> = todo!()
@@ -35,7 +46,7 @@ where
     <T as AliasHaver>::Assoc: 'static;
 
 const REGIONCK_ENV_FAIL<'a, T: AliasHaver>: ReqTrait<T::Assoc> = todo!()
-//~^ ERROR: unsatisfied lifetime constraint from -Zassumptions-on-binders
+//~^ ERROR: higher-ranked lifetime bound could not be satisfied
 where
     <T as AliasHaver>::Assoc: 'a;
 

--- a/tests/ui/assumptions_on_binders/alias_outlives.rs
+++ b/tests/ui/assumptions_on_binders/alias_outlives.rs
@@ -23,22 +23,11 @@ where
 }
 
 fn borrowck_env_fail<'a, T: AliasHaver>()
+// FIXME: ^ this should raise an ERROR: unsatisfied lifetime constraint from -Zassumptions-on-binders
 where
     <T as AliasHaver>::Assoc: 'a,
 {
     let _: ReqTrait<T::Assoc>;
-    //~^ ERROR: higher-ranked lifetime bound could not be satisfied
-}
-
-fn borrowck_multiple_origins_fail<'a, 'b, T: AliasHaver, U: AliasHaver>()
-where
-    <T as AliasHaver>::Assoc: 'a,
-    <U as AliasHaver>::Assoc: 'b,
-{
-    let _: ReqTrait<T::Assoc>;
-    //~^ ERROR: higher-ranked lifetime bound could not be satisfied
-    let _: ReqTrait<U::Assoc>;
-    //~^ ERROR: higher-ranked lifetime bound could not be satisfied
 }
 
 const REGIONCK_ENV_PASS<'a, T: AliasHaver>: ReqTrait<T::Assoc> = todo!()

--- a/tests/ui/assumptions_on_binders/alias_outlives.stderr
+++ b/tests/ui/assumptions_on_binders/alias_outlives.stderr
@@ -1,21 +1,26 @@
-error: unsatisfied lifetime constraint from -Zassumptions-on-binders :3
-  --> $DIR/alias_outlives.rs:37:1
+error: higher-ranked lifetime bound could not be satisfied
+  --> $DIR/alias_outlives.rs:48:45
    |
 LL | const REGIONCK_ENV_FAIL<'a, T: AliasHaver>: ReqTrait<T::Assoc> = todo!()
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: meoow :c
+   |                                             ^^^^^^^^^^^^^^^^^^
 
-error: unsatisfied lifetime constraint from -Zassumptions-on-binders :3
-  --> $DIR/alias_outlives.rs:25:1
+error: higher-ranked lifetime bound could not be satisfied
+  --> $DIR/alias_outlives.rs:29:12
    |
-LL | / fn borrowck_env_fail<'a, T: AliasHaver>()
-LL | |
-LL | | where
-LL | |     <T as AliasHaver>::Assoc: 'a,
-   | |_________________________________^
-   |
-   = note: meoow :c
+LL |     let _: ReqTrait<T::Assoc>;
+   |            ^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 2 previous errors
+error: higher-ranked lifetime bound could not be satisfied
+  --> $DIR/alias_outlives.rs:38:12
+   |
+LL |     let _: ReqTrait<T::Assoc>;
+   |            ^^^^^^^^^^^^^^^^^^
+
+error: higher-ranked lifetime bound could not be satisfied
+  --> $DIR/alias_outlives.rs:40:12
+   |
+LL |     let _: ReqTrait<U::Assoc>;
+   |            ^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 4 previous errors
 

--- a/tests/ui/assumptions_on_binders/alias_outlives.stderr
+++ b/tests/ui/assumptions_on_binders/alias_outlives.stderr
@@ -1,26 +1,8 @@
 error: higher-ranked lifetime bound could not be satisfied
-  --> $DIR/alias_outlives.rs:48:45
+  --> $DIR/alias_outlives.rs:37:45
    |
 LL | const REGIONCK_ENV_FAIL<'a, T: AliasHaver>: ReqTrait<T::Assoc> = todo!()
    |                                             ^^^^^^^^^^^^^^^^^^
 
-error: higher-ranked lifetime bound could not be satisfied
-  --> $DIR/alias_outlives.rs:29:12
-   |
-LL |     let _: ReqTrait<T::Assoc>;
-   |            ^^^^^^^^^^^^^^^^^^
-
-error: higher-ranked lifetime bound could not be satisfied
-  --> $DIR/alias_outlives.rs:38:12
-   |
-LL |     let _: ReqTrait<T::Assoc>;
-   |            ^^^^^^^^^^^^^^^^^^
-
-error: higher-ranked lifetime bound could not be satisfied
-  --> $DIR/alias_outlives.rs:40:12
-   |
-LL |     let _: ReqTrait<U::Assoc>;
-   |            ^^^^^^^^^^^^^^^^^^
-
-error: aborting due to 4 previous errors
+error: aborting due to 1 previous error
 

--- a/tests/ui/assumptions_on_binders/alias_outlives.stderr
+++ b/tests/ui/assumptions_on_binders/alias_outlives.stderr
@@ -1,10 +1,25 @@
-error: unsatisfied lifetime constraint from -Zassumptions-on-binders :3
-  --> $DIR/alias_outlives.rs:37:1
+error: higher-ranked lifetime bound could not be satisfied
+  --> $DIR/alias_outlives.rs:48:45
    |
 LL | const REGIONCK_ENV_FAIL<'a, T: AliasHaver>: ReqTrait<T::Assoc> = todo!()
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                             ^^^^^^^^^^^^^^^^^^
+
+error: higher-ranked lifetime bound could not be satisfied
+  --> $DIR/alias_outlives.rs:29:12
    |
-   = note: meoow :c
+LL |     let _: ReqTrait<T::Assoc>;
+   |            ^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 1 previous error
+error: higher-ranked lifetime bound could not be satisfied
+  --> $DIR/alias_outlives.rs:38:12
+   |
+LL |     let _: ReqTrait<T::Assoc>;
+   |            ^^^^^^^^^^^^^^^^^^
 
+error: higher-ranked lifetime bound could not be satisfied
+  --> $DIR/alias_outlives.rs:40:12
+   |
+LL |     let _: ReqTrait<U::Assoc>;
+   |            ^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 4 previous errors

--- a/tests/ui/assumptions_on_binders/alias_outlives.stderr
+++ b/tests/ui/assumptions_on_binders/alias_outlives.stderr
@@ -23,3 +23,4 @@ LL |     let _: ReqTrait<U::Assoc>;
    |            ^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 4 previous errors
+

--- a/tests/ui/assumptions_on_binders/higher-ranked-outlives-issue-157732.rs
+++ b/tests/ui/assumptions_on_binders/higher-ranked-outlives-issue-157732.rs
@@ -1,0 +1,12 @@
+//@ compile-flags: -Zassumptions-on-binders -Znext-solver=globally
+
+fn foo<'a>(_a: &'a u32)
+where
+    for<'b> &'b (): 'a,
+{
+}
+
+fn main() {
+    foo(&10);
+    //~^ ERROR: higher-ranked lifetime bound could not be satisfied
+}

--- a/tests/ui/assumptions_on_binders/higher-ranked-outlives-issue-157732.stderr
+++ b/tests/ui/assumptions_on_binders/higher-ranked-outlives-issue-157732.stderr
@@ -1,0 +1,8 @@
+error: higher-ranked lifetime bound could not be satisfied
+  --> $DIR/higher-ranked-outlives-issue-157732.rs:10:5
+   |
+LL |     foo(&10);
+   |     ^^^^^^^^
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/158588)*
<!-- homu-ignore:end -->

fixes rust-lang/rust#157732

`-Zassumptions-on-binders` was losing the origin of solver region constraints. By the time regionck or borrowck reported them, every constraint received the containing item span, so diagnostics pointed at an entire function or const. Some paths were also still emitting placeholder text (`:3` and `meoow :c`).

This keeps canonical solver responses and `ExternalConstraintsData` span-free, so source locations do not participate in candidate equality or caching. When a response is applied, `EvalCtxt::origin_span` is attached to each atomic solver `RegionConstraint` stored in `InferCtxt`. Late region conversion then uses the span attached to each constraint, including for ambiguity diagnostics.

The affected paths now report `higher-ranked lifetime bound could not be satisfied` at the type use that introduced the failing constraint. UI coverage checks the rust-lang/rust#157732 call-site diagnostic and the existing regionck alias-outlives case. Unit coverage checks that the spanned evaluator stays in semantic parity with the type-ir evaluator and preserves the first ambiguity origin span.

The type-op behavior I ran into while working on this is split into rust-lang/rust#161423.

Future work: carry the failed outlives predicate or originating binder far enough through this path to name the exact bound that failed, rather than only pointing at its origin.
