### PR TITLE
Fix spacing issue for unused parentheses lint

### DIFF
--- a/compiler/rustc_lint/src/unused.rs
+++ b/compiler/rustc_lint/src/unused.rs
@@ -338,7 +338,7 @@ trait UnusedDelimLint {
                 && !snip.starts_with(' ')
             {
                 " "
-            } else if let Ok(snip) = sm.span_to_prev_source(value_span)
+            } else if let Ok(snip) = sm.span_to_next_source(value_span)
                 && snip.starts_with(|c: char| c.is_alphanumeric())
             {
                 " "

--- a/tests/ui/lint/unused-parens-trailing-space-issue-158583.rs
+++ b/tests/ui/lint/unused-parens-trailing-space-issue-158583.rs
@@ -1,0 +1,5 @@
+fn main() {
+    #[deny(unused_parens)]
+    let _x = (3 + 6);
+    //~^ ERROR unnecessary parentheses around assigned value
+}

--- a/tests/ui/lint/unused-parens-trailing-space-issue-158583.stderr
+++ b/tests/ui/lint/unused-parens-trailing-space-issue-158583.stderr
@@ -1,0 +1,19 @@
+error: unnecessary parentheses around assigned value
+  --> $DIR/unused-parens-trailing-space-issue-158583.rs:3:14
+   |
+LL |     let _x = (3 + 6);
+   |              ^     ^
+   |
+note: the lint level is defined here
+  --> $DIR/unused-parens-trailing-space-issue-158583.rs:2:12
+   |
+LL |     #[deny(unused_parens)]
+   |            ^^^^^^^^^^^^^
+help: remove these parentheses
+   |
+LL -     let _x = (3 + 6);
+LL +     let _x = 3 + 6;
+   |
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
There is a typo.

Fixes rust-lang/rust#158583