### PR TITLE
tests: only run `lexical-scope-in-match.rs` for LLDB >= 21

### DIFF
--- a/tests/debuginfo/lexical-scope-in-match.rs
+++ b/tests/debuginfo/lexical-scope-in-match.rs
@@ -1,6 +1,7 @@
 //@ compile-flags:-g
 //@ disable-gdb-pretty-printers
 //@ ignore-backends: gcc
+//@ min-lldb-version: 2100
 
 // === GDB TESTS ===================================================================================
 


### PR DESCRIPTION
Dev Desktops currently run on an Ubuntu which has an older LLDB (e.g. LLDB 18), where this debuginfo test fails.

Run this test only on LLDB >= 21. This passes for me locally with Apple/Swift-variant LLDB 21.