### PR TITLE
Fix `rustc --unpretty=expanded` emit of `[const] [unsafe] impl Trait for`

### DIFF
--- a/compiler/rustc_ast_pretty/src/pprust/state/item.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state/item.rs
@@ -344,9 +344,9 @@ impl<'a> State<'a> {
                     let ast::TraitImplHeader { defaultness, safety, polarity, ref trait_ref } =
                         *of_trait;
                     self.print_defaultness(defaultness);
+                    self.print_constness(*constness);
                     self.print_safety(safety);
                     impl_generics(self);
-                    self.print_constness(*constness);
                     if let ast::ImplPolarity::Negative(_) = polarity {
                         self.word("!");
                     }

--- a/tests/ui/unpretty/exhaustive.expanded.stdout
+++ b/tests/ui/unpretty/exhaustive.expanded.stdout
@@ -449,7 +449,7 @@ mod items {
         impl () {}
         impl<T> () {}
         impl Default for () {}
-        impl<T> const Default for () {}
+        const impl<T> Default for () {}
     }
     /// ItemKind::MacCall
     mod item_mac_call { }


### PR DESCRIPTION
Fixes rust-lang/rust#158599

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
