### PR TITLE
Quote version script symbols

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/linker.rs
+++ b/compiler/rustc_codegen_ssa/src/back/linker.rs
@@ -872,8 +872,8 @@ impl<'a> Linker for GccLinker<'a> {
                 if !symbols.is_empty() {
                     writeln!(f, "  global:")?;
                     for sym in symbols {
-                        debug!("    {};", sym.name);
-                        writeln!(f, "    {};", sym.name)?;
+                        debug!("    \"{}\";", sym.name);
+                        writeln!(f, "    \"{}\";", sym.name)?;
                     }
                 }
                 writeln!(f, "\n  local:\n    *;\n}};")?;

--- a/tests/run-make/export-quoted-symbols-version-script/lib.rs
+++ b/tests/run-make/export-quoted-symbols-version-script/lib.rs
@@ -1,0 +1,4 @@
+#![crate_type = "cdylib"]
+
+#[unsafe(export_name = "some$foo::bar$thing/path.rs:42")]
+pub extern "C" fn exported_symbol_with_version_script_special_characters() {}

--- a/tests/run-make/export-quoted-symbols-version-script/rmake.rs
+++ b/tests/run-make/export-quoted-symbols-version-script/rmake.rs
@@ -1,10 +1,19 @@
 //@ only-linux
-//@ needs-dynamic-linking
+//@ needs-crate-type: cdylib
 
 extern crate run_make_support;
 
-use run_make_support::rustc;
+use run_make_support::object::Object;
+use run_make_support::{dynamic_lib_name, object, rfs, rustc};
+
+const EXPORTED_SYMBOL: &[u8] = b"some$foo::bar$thing/path.rs:42";
 
 fn main() {
     rustc().input("lib.rs").run();
+
+    let contents = rfs::read(dynamic_lib_name("lib"));
+    let object = object::File::parse(contents.as_slice()).unwrap();
+    let matching_exports =
+        object.exports().unwrap().iter().filter(|x| x.name() == EXPORTED_SYMBOL).count();
+    assert_eq!(matching_exports, 1);
 }

--- a/tests/run-make/export-quoted-symbols-version-script/rmake.rs
+++ b/tests/run-make/export-quoted-symbols-version-script/rmake.rs
@@ -1,0 +1,10 @@
+//@ only-linux
+//@ needs-dynamic-linking
+
+extern crate run_make_support;
+
+use run_make_support::rustc;
+
+fn main() {
+    rustc().input("lib.rs").run();
+}


### PR DESCRIPTION
Hi

`rustc` generates an LD version script in the following format:
```
{
  global:
    exported_symbol;
    some$foo::bar$thing/path.rs:42;

  local:
    *;
};
```
However, the symbols are not quoted, which means that the following code will cause a linker failure because the gnerated LD version script has an invalid syntax.

```rust
#[unsafe(export_name = "some$foo::bar$thing/path.rs:42")]
pub extern "C" fn exported_symbol_with_version_script_special_characters() {}
```

```
error: linking with `cc` failed: exit status: 1
  |
  = note:  "cc" "-Wl,--version-script=/project/target/release/deps/rustcYQww7z/list" "-Wl,--no-undefined-version" "/project/target/release/deps/rustcYQww7z/symbols.o" ...
  = note: /project/target/release/deps/rustcYQww7z/list:349: ignoring invalid character `/' in script
          /usr/bin/ld:/project/target/release/deps/rustcYQww7z/list:349: syntax error in VERSION script
          clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

Special characters such as `$`, `/`, `.`, and `:` are valid for a symbol name in an ELF binary. [LD Script Format documentation](https://sourceware.org/binutils/docs/ld/Script-Format.html) specifies (same rules apply for symbols and file names):

> If the file name contains a character such as a comma which would otherwise serve to separate file names, you may put the file name in double quotes.

This PR quotes each symbol name before adding it to the `global:` section. This allows exported symbols containing linker-special characters, such as `$`, `::`, `/`, `.`, and `:`, to be handled correctly by the linker:

```
{
  global:
    "exported_symbol";
    "some$foo::bar$thing/path.rs:42";

  local:
    *;
};
```

The new run-make test builds a `cdylib` with an `export_name` containing those characters and verifies that the exact symbol is exported from the produced shared object.

Cheers
Alex

Fixes https://github.com/rust-lang/rust/issues/38238