### PR TITLE
Fix getrandom fallback test on platforms with `panic=abort`

### DIFF
--- a/library/std/src/sys/random/linux.rs
+++ b/library/std/src/sys/random/linux.rs
@@ -123,7 +123,9 @@ fn getrandom(mut bytes: &mut [u8], insecure: bool) {
                         GETRANDOM_AVAILABLE.store(false, Relaxed);
                         break;
                     }
-                    _ => panic!("failed to generate random data"),
+                    other => {
+                        panic!("failed to generate random data: errno={other:?}, flags={flags:?}")
+                    }
                 }
             }
         }

--- a/tests/ui/std/linux-getrandom-fallback.rs
+++ b/tests/ui/std/linux-getrandom-fallback.rs
@@ -1,5 +1,6 @@
 //@ only-linux
 //@ run-pass
+//@ needs-unwind
 
 #![feature(random)]
 #![feature(rustc_private)]


### PR DESCRIPTION
The recently-added linux-getrandom-fallback test fails on targets matching {aarch64*-none, armv7r-eabihf, thumbv7em-eabi*}. This is because those platforms set `panic=abort` by default, and the test relies on being able to catch a panic.

Mark the test as `needs-unwind` so that it won't be run in `panic=abort` configurations.

Also add extra debug information to the panic when getrandom() fails with an unexpected error code on Linux