### PR TITLE
Fix error message when rejecting implicit stage != 2 in CI

### DIFF
--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -1206,7 +1206,9 @@ impl Config {
                 | Subcommand::Install => {
                     assert_eq!(
                         stage, 2,
-                        "x.py should be run with `--stage 2` on CI, but was run with `--stage {stage}`",
+                        "\
+x.py was run under CI with an implicit `--stage {stage}`. This is probably wrong and you want stage 2.
+NOTE: Please add `--stage 2` to your command line, or if you're sure you want to run stage {stage} then add `--stage {stage}` explicitly"
                     );
                 }
                 Subcommand::Clean { .. }


### PR DESCRIPTION
The previous error message made it sound like stage != 2 was entirely disallowed under CI. But actually it was only *implicit* stage != 2 which is disallowed - an explicit `--stage 1` is permitted and is sometimes correct.

Minimal command to trigger the error message: `GITHUB_ACTIONS=true ./x test ui`
