### PR TITLE
fix: don't fire `explicit_outlives_requirements` on `?Sized` type params

### DIFF
--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -2069,6 +2069,24 @@ impl<'tcx> LateLintPass<'tcx> for ExplicitOutlivesRequirements {
                                         continue;
                                     };
                                     let index = ty_generics.param_def_id_to_index[&def_id];
+                                    // Removing a `T: 'r` outlives bound can silently change
+                                    // the object lifetime default for `Struct<'r, dyn Trait>`
+                                    // (RFC 599): the explicit bound sets the default to `'r`,
+                                    // so removing it may change it to `'static` (or cause an
+                                    // ambiguity error if there is no unique default). Only
+                                    // suppress the lint for non-higher-ranked predicates when
+                                    // T is not `Sized` (i.e. can hold trait object types).
+                                    // Higher-ranked predicates (`for<'x> T: 'r`) are excluded
+                                    // from RFC 599 object lifetime defaulting and are always
+                                    // safe to remove.
+                                    if predicate.bound_generic_params.is_empty() {
+                                        let ty_param = &ty_generics.own_params[index as usize];
+                                        let param_ty =
+                                            Ty::new_param(cx.tcx, ty_param.index, ty_param.name);
+                                        if !param_ty.is_sized(cx.tcx, cx.typing_env()) {
+                                            continue;
+                                        }
+                                    }
                                     (
                                         Self::lifetimes_outliving_type(
                                             // don't warn if the inferred span actually came from the predicate we're looking at

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -2298,33 +2298,7 @@ declare_lint! {
     ///
     /// See [RFC 2093] for more details.
     ///
-    /// > [!WARNING]
-    /// > Implicit lifetime bounds are not semantically equivalent to explicit ones since the latter
-    /// > may affect the implicit lifetime bound of trait object types that are passed as arguments
-    /// > to the overarching struct, enum or union.
-    /// > Rephrased, they participate in [trait object lifetime defaulting][TOLD].
-    /// >
-    /// > Consider the following piece of code where removing bound `T: 'a` would lead to a lifetime
-    /// > error in function `scope`:
-    /// >
-    /// > ```rust,no_run
-    /// > struct Ref<'a, T: ?Sized + 'a>(&'a T);
-    /// >
-    /// > fn scope() {
-    /// >     let buf = String::new();
-    /// >     let str = buf.as_str();
-    /// >     render(Ref(&str));
-    /// > }
-    /// >
-    /// > fn render(_: Ref<dyn std::fmt::Display>) {}
-    /// > ```
-    /// >
-    /// > Consequently, removing explicit outlives-bounds on type parameters of publicly reachable types
-    /// > constitutes a **breaking change** if the lifetime refers to a lifetime parameter and
-    /// > the type parameter is not bounded by `Sized` (thereby admitting trait object types).
-    ///
     /// [RFC 2093]: https://github.com/rust-lang/rfcs/blob/master/text/2093-infer-outlives.md
-    /// [TOLD]: https://doc.rust-lang.org/reference/lifetime-elision.html#default-trait-object-lifetimes
     pub EXPLICIT_OUTLIVES_REQUIREMENTS,
     Allow,
     "outlives requirements can be inferred"

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -2298,7 +2298,43 @@ declare_lint! {
     ///
     /// See [RFC 2093] for more details.
     ///
+    /// > [!NOTE]
+    /// > This lint intentionally doesn't get emitted for explicit outlives-bounds on type
+    /// > parameters that aren't bounded by `Sized` (unless they're higher-ranked) since unlike
+    /// > implicit outlives-bounds these may affect the implicit lifetime bound of trait object
+    /// > types that are passed as arguments to the overarching struct, enum or union.
+    /// >
+    /// > Rephrased, they participate in [trait object lifetime defaulting][TOLD].
+    /// >
+    /// > Consider the following piece of code where removing bound `T: 'a` would lead to a lifetime
+    /// > error in function `scope`:
+    /// >
+    /// > ```rust,no_run
+    /// > struct Ref<'a, T: ?Sized + 'a>(&'a T);
+    /// >
+    /// > fn scope() {
+    /// >     let buf = String::new();
+    /// >     let str = buf.as_str();
+    /// >     render(Ref(&str));
+    /// > }
+    /// >
+    /// > fn render(_: Ref<dyn std::fmt::Display>) {}
+    /// > ```
+    /// >
+    /// > Due to the explicit outlives-bound the function `render` above is equivalent to:
+    /// >
+    /// > ```rust,ignore (incomplete)
+    /// > fn render<'r>(_: Ref<'r, dyn std::fmt::Display + 'r>) {}
+    /// > ```
+    /// >
+    /// > If it wasn't for that explicit bound then the function would mean the following instead:
+    /// >
+    /// > ```rust,ignore (incomplete)
+    /// > fn render<'r>(_: Ref<'r, dyn std::fmt::Display + 'static>) {}
+    /// > ```
+    ///
     /// [RFC 2093]: https://github.com/rust-lang/rfcs/blob/master/text/2093-infer-outlives.md
+    /// [TOLD]: https://doc.rust-lang.org/reference/lifetime-elision.html#default-trait-object-lifetimes
     pub EXPLICIT_OUTLIVES_REQUIREMENTS,
     Allow,
     "outlives requirements can be inferred"

--- a/tests/ui/lint/explicit-outlives-unsized-object-lifetime.rs
+++ b/tests/ui/lint/explicit-outlives-unsized-object-lifetime.rs
@@ -1,0 +1,55 @@
+//@ check-pass
+// Regression test for https://github.com/rust-lang/rust/issues/134902
+//
+// `explicit_outlives_requirements` must not suggest removing `T: 'r` when T is not
+// `Sized` (i.e. can hold trait object types). Such a bound can set the object lifetime
+// default for `Struct<'r, dyn Trait>` (RFC 599): removing it may silently change
+// `dyn Trait + 'r` to `dyn Trait + 'static`, breaking callers.
+//
+// Note: higher-ranked predicates (`for<'x> T: 'r`) are excluded from RFC 599 and are
+// always safe to remove; and when T is `Sized` (e.g. `T: ?Sized + Sized` or `T: Clone`),
+// it cannot hold trait object types so the bound is also safe to remove.
+
+#![deny(explicit_outlives_requirements)]
+#![allow(unused)]
+
+trait Test {}
+
+// Inline bound: `T: 'a + ?Sized`.
+struct Ref<'a, T: 'a + ?Sized> {
+    r: &'a T,
+}
+
+// Where clause for the outlives bound, inline `?Sized`.
+struct Ref2<'a, T: ?Sized>
+where
+    T: 'a,
+{
+    r: &'a T,
+}
+
+// Where clause for both.
+struct Ref3<'a, T>
+where
+    T: 'a + ?Sized,
+{
+    r: &'a T,
+}
+
+// Two lifetime params; neither bound should be removed.
+struct Ref4<'a, 'b, T: 'a + 'b + ?Sized> {
+    a: &'a T,
+    b: &'b T,
+}
+
+// Verify the semantics that motivated the fix: a struct field typed `Ref<dyn Test>`
+// (without an explicit lifetime) must resolve to `dyn Test + 'a`, not `dyn Test + 'static`.
+struct Container<'a> {
+    t: Ref<'a, dyn Test>,
+}
+
+fn check<'a>(t: Ref<'a, dyn Test + 'a>, mut c: Container<'a>) {
+    c.t = t;
+}
+
+fn main() {}

--- a/tests/ui/rust-2018/edition-lint-inter-outlives/edition-lint-infer-outlives.fixed
+++ b/tests/ui/rust-2018/edition-lint-inter-outlives/edition-lint-infer-outlives.fixed
@@ -801,8 +801,8 @@ where
     yoo: &'a U
 }
 
-// https://github.com/rust-lang/rust/issues/105150
-struct InferredWhereBoundWithInlineBound<'a, T: ?Sized>
+// `T: 'a` is implied by the field — the lint should fire here.
+struct InferredWhereBoundWithInlineBound<'a, T> //~^ ERROR outlives requirements can be inferred
 {
     data: &'a T,
 }

--- a/tests/ui/rust-2018/edition-lint-inter-outlives/edition-lint-infer-outlives.rs
+++ b/tests/ui/rust-2018/edition-lint-inter-outlives/edition-lint-infer-outlives.rs
@@ -801,10 +801,9 @@ where
     yoo: &'a U
 }
 
-// https://github.com/rust-lang/rust/issues/105150
-struct InferredWhereBoundWithInlineBound<'a, T: ?Sized>
-//~^ ERROR outlives requirements can be inferred
-    where T: 'a,
+// `T: 'a` is implied by the field — the lint should fire here.
+struct InferredWhereBoundWithInlineBound<'a, T>
+    where T: 'a, //~^ ERROR outlives requirements can be inferred
 {
     data: &'a T,
 }

--- a/tests/ui/rust-2018/edition-lint-inter-outlives/edition-lint-infer-outlives.stderr
+++ b/tests/ui/rust-2018/edition-lint-inter-outlives/edition-lint-infer-outlives.stderr
@@ -11,11 +11,10 @@ LL | #![deny(explicit_outlives_requirements)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: outlives requirements can be inferred
-  --> $DIR/edition-lint-infer-outlives.rs:805:56
+  --> $DIR/edition-lint-infer-outlives.rs:805:48
    |
-LL |   struct InferredWhereBoundWithInlineBound<'a, T: ?Sized>
-   |  ________________________________________________________^
-LL | |
+LL |   struct InferredWhereBoundWithInlineBound<'a, T>
+   |  ________________________________________________^
 LL | |     where T: 'a,
    | |________________^ help: remove this bound
 


### PR DESCRIPTION
`explicit_outlives_requirements` uses `tcx.inferred_outlives_of()` to check whether an explicit `T: 'a` bound is structurally implied by struct fields. for a field `r: &'a T`, it is — so the lint fired and suggested removing it.

but RFC 599 object lifetime defaults are computed from *explicit* HIR bounds not inferred ones. removing an explicit `T: 'a` from a `?Sized` type param silently changes every `Struct<dyn Trait>` use from `dyn Trait + 'a` to `dyn Trait + 'static`, breaking callers without any error.

added a guard: before emitting the lint for a type param outlives bound, check whether the param carries any `?Sized` bound (`BoundPolarity::Maybe` in HIR). if so, skip — the bound may be the sole anchor for the object lifetime default.

also suppresses the pre-existing false positive in `edition-lint-infer-outlives.rs` (noted in issue https://github.com/rust-lang/rust/issues/105150) which was an instance of the same bug.

closes https://github.com/rust-lang/rust/issues/134902
