### PR TITLE
allow mGCA const arguments to fall back to anon consts

### DIFF
--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -1378,15 +1378,6 @@ pub enum UnsafeSource {
     UserProvided,
 }
 
-/// Track whether under `feature(min_generic_const_args)` this anon const
-/// was explicitly disambiguated as an anon const or not through the use of
-/// `const { ... }` syntax.
-#[derive(Clone, PartialEq, Encodable, Decodable, Debug, Copy, Walkable)]
-pub enum MgcaDisambiguation {
-    AnonConst,
-    Direct,
-}
-
 /// A constant (expression) that's not an item or associated item,
 /// but needs its own `DefId` for type-checking, const-eval, etc.
 /// These are usually found nested inside types (e.g., array lengths)
@@ -1396,7 +1387,6 @@ pub enum MgcaDisambiguation {
 pub struct AnonConst {
     pub id: NodeId,
     pub value: Box<Expr>,
-    pub mgca_disambiguation: MgcaDisambiguation,
 }
 
 /// An expression.
@@ -1627,6 +1617,7 @@ impl Expr {
             | ExprKind::UnsafeBinderCast(..)
             | ExprKind::While(..)
             | ExprKind::Yield(YieldKind::Postfix(..))
+            | ExprKind::DirectConstArg(..)
             | ExprKind::Err(_)
             | ExprKind::Dummy => prefix_attrs_precedence(&self.attrs),
         }
@@ -1919,6 +1910,9 @@ pub enum ExprKind {
     FormatArgs(Box<FormatArgs>),
 
     UnsafeBinderCast(UnsafeBinderCastKind, Box<Expr>, Option<Box<Ty>>),
+
+    /// An mGCA `direct_const_arg!()` expression.
+    DirectConstArg(Box<Expr>),
 
     /// Placeholder for an expression that wasn't syntactically well formed in some way.
     Err(ErrorGuaranteed),
@@ -2566,6 +2560,8 @@ pub enum TyKind {
     FieldOf(Box<Ty>, Option<Ident>, Ident),
     /// A view of a type. `T.{ field_1, field_2 }`.
     View(Box<Ty>, #[visitable(ignore)] ThinVec<Ident>),
+    /// An mGCA `direct_const_arg!()` expression.
+    DirectConstArg(Box<Expr>),
     /// Sometimes we need a dummy value when no error has occurred.
     Dummy,
     /// Placeholder for a kind that has failed to be defined.

--- a/compiler/rustc_ast/src/util/classify.rs
+++ b/compiler/rustc_ast/src/util/classify.rs
@@ -155,6 +155,7 @@ pub fn leading_labeled_expr(mut expr: &ast::Expr) -> bool {
             | Yeet(..)
             | Yield(..)
             | UnsafeBinderCast(..)
+            | DirectConstArg(..)
             | Err(..)
             | Dummy => return false,
         }
@@ -240,6 +241,7 @@ pub fn expr_trailing_brace(mut expr: &ast::Expr) -> Option<TrailingBrace<'_>> {
             | Try(_)
             | Yeet(None)
             | UnsafeBinderCast(..)
+            | DirectConstArg(..)
             | Err(_)
             | Dummy => {
                 break None;
@@ -301,9 +303,10 @@ fn type_trailing_braced_mac_call(mut ty: &ast::Ty) -> Option<&ast::MacCall> {
             | ast::TyKind::CVarArgs
             | ast::TyKind::Pat(..)
             | ast::TyKind::FieldOf(..)
+            | ast::TyKind::View(..)
+            | ast::TyKind::DirectConstArg(..)
             | ast::TyKind::Dummy
-            | ast::TyKind::Err(..)
-            | ast::TyKind::View(..) => break None,
+            | ast::TyKind::Err(..) => break None,
         }
     }
 }

--- a/compiler/rustc_ast/src/visit.rs
+++ b/compiler/rustc_ast/src/visit.rs
@@ -418,7 +418,6 @@ macro_rules! common_visitor_and_walkers {
             UnsafeBinderCastKind,
             BinOpKind,
             BlockCheckMode,
-            MgcaDisambiguation,
             BorrowKind,
             BoundAsyncness,
             BoundConstness,
@@ -1074,6 +1073,8 @@ macro_rules! common_visitor_and_walkers {
                     visit_visitable!($($mut)? vis, bytes),
                 ExprKind::UnsafeBinderCast(kind, expr, ty) =>
                     visit_visitable!($($mut)? vis, kind, expr, ty),
+                ExprKind::DirectConstArg(expr) =>
+                    visit_visitable!($($mut)? vis, expr),
                 ExprKind::Err(_guar) => {}
                 ExprKind::Dummy => {}
             }

--- a/compiler/rustc_ast_lowering/src/expr.rs
+++ b/compiler/rustc_ast_lowering/src/expr.rs
@@ -498,6 +498,18 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 }
 
                 ExprKind::MacCall(_) => panic!("{:?} shouldn't exist here", e.span),
+
+                ExprKind::DirectConstArg(_) => {
+                    let e = self
+                        .tcx
+                        .dcx()
+                        .struct_span_err(
+                            e.span,
+                            "expected expression, found `direct_const_arg!()` constant",
+                        )
+                        .emit();
+                    hir::ExprKind::Err(e)
+                }
             };
 
             hir::Expr { hir_id: expr_hir_id, kind, span }
@@ -599,11 +611,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                         arg
                     };
 
-                let anon_const = AnonConst {
-                    id: node_id,
-                    value: const_value,
-                    mgca_disambiguation: MgcaDisambiguation::AnonConst,
-                };
+                let anon_const = AnonConst { id: node_id, value: const_value };
                 generic_args.push(AngleBracketedArg::Arg(GenericArg::Const(anon_const)));
             } else {
                 real_args.push(arg);

--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -1478,6 +1478,16 @@ impl<'hir> LoweringContext<'_, 'hir> {
                             }
                         }
                     }
+                    TyKind::DirectConstArg(expr)
+                        if self.tcx.features().min_generic_const_args() =>
+                    {
+                        let ct = match self.can_lower_expr_to_const_arg_direct(expr) {
+                            Ok(()) => self.lower_expr_to_const_arg_direct(expr, None),
+                            Err(e) => e.emit(self),
+                        };
+                        let ct = self.arena.alloc(ct);
+                        return GenericArg::Const(ct.try_as_ambig_ct().unwrap());
+                    }
                     _ => {}
                 }
                 GenericArg::Type(self.lower_ty_alloc(ty, itctx).try_as_ambig_ty().unwrap())
@@ -1753,6 +1763,14 @@ impl<'hir> LoweringContext<'_, 'hir> {
             TyKind::View(ty, _) => {
                 // FIXME(scrabsha): lower view types to HIR.
                 return self.lower_ty(ty, itctx);
+            }
+            TyKind::DirectConstArg(_) => {
+                let e = self
+                    .tcx
+                    .dcx()
+                    .struct_span_err(t.span, "expected type, found `direct_const_arg!()` constant")
+                    .emit();
+                hir::TyKind::Err(e)
             }
             TyKind::Dummy => panic!("`TyKind::Dummy` should never be lowered"),
         };
@@ -2672,23 +2690,86 @@ impl<'hir> LoweringContext<'_, 'hir> {
     }
 
     #[instrument(level = "debug", skip(self), ret)]
-    fn lower_expr_to_const_arg_direct(&mut self, expr: &Expr) -> hir::ConstArg<'hir> {
+    fn can_lower_expr_to_const_arg_direct(
+        &mut self,
+        expr: &Expr,
+    ) -> Result<(), UnrepresentableConstArgError> {
+        let is_mgca = self.tcx.features().min_generic_const_args();
+        // Note the only stable case is currently ExprKind::Path. All others have an is_mgca guard.
+        match &expr.kind {
+            ExprKind::Call(func, args)
+                if is_mgca && let ExprKind::Path(_qself, _path) = &func.kind =>
+            {
+                for arg in args {
+                    self.can_lower_expr_to_const_arg_direct(arg)?;
+                }
+                Ok(())
+            }
+            ExprKind::Tup(exprs) if is_mgca => {
+                for expr in exprs {
+                    self.can_lower_expr_to_const_arg_direct(expr)?;
+                }
+                Ok(())
+            }
+            ExprKind::Path(qself, path)
+                if is_mgca
+                    || path.is_potential_trivial_const_arg()
+                        && matches!(
+                            self.get_partial_res(expr.id)
+                                .and_then(|partial_res| partial_res.full_res()),
+                            Some(Res::Def(DefKind::ConstParam, _))
+                        ) =>
+            {
+                Ok(())
+            }
+            ExprKind::Struct(se) if is_mgca => {
+                for f in &se.fields {
+                    self.can_lower_expr_to_const_arg_direct(&f.expr)?;
+                }
+                Ok(())
+            }
+            ExprKind::Array(elements) if is_mgca => {
+                for element in elements {
+                    self.can_lower_expr_to_const_arg_direct(element)?;
+                }
+                Ok(())
+            }
+            ExprKind::Underscore if is_mgca => Ok(()),
+            ExprKind::Block(block, _)
+                if is_mgca
+                    && let [stmt] = block.stmts.as_slice()
+                    && let StmtKind::Expr(expr) = &stmt.kind =>
+            {
+                self.can_lower_expr_to_const_arg_direct(expr)
+            }
+            ExprKind::Lit(literal) if is_mgca => Ok(()),
+            ExprKind::Unary(UnOp::Neg, inner_expr)
+                if is_mgca && let ExprKind::Lit(_) = &inner_expr.kind =>
+            {
+                Ok(())
+            }
+            ExprKind::ConstBlock(anon) if is_mgca => Ok(()),
+            ExprKind::DirectConstArg(expr) if is_mgca => {
+                // Always report this as able to be represented directly. If it turns out not to be,
+                // `lower_expr_to_const_arg_direct` will report an error.
+                Ok(())
+            }
+            _ => Err(UnrepresentableConstArgError::new(expr)),
+        }
+    }
+
+    /// It is not allowed to call this function without checking can_lower_expr_to_const_arg_direct
+    /// first, as we assume all feature gates/etc. have been checked already.
+    #[instrument(level = "debug", skip(self), ret)]
+    fn lower_expr_to_const_arg_direct(
+        &mut self,
+        expr: &Expr,
+        id_override: Option<NodeId>,
+    ) -> hir::ConstArg<'hir> {
+        debug_assert!(self.can_lower_expr_to_const_arg_direct(expr).is_ok());
+
         let span = self.lower_span(expr.span);
-
-        let overly_complex_const = |this: &mut Self| {
-            let msg = "complex const arguments must be placed inside of a `const` block";
-            let e = if expr::WillCreateDefIdsVisitor.visit_expr(expr).is_break() {
-                // FIXME(mgca): make this non-fatal once we have a better way to handle
-                // nested items in const args
-                // Issue: https://github.com/rust-lang/rust/issues/154539
-                this.dcx().struct_span_fatal(expr.span, msg).emit()
-            } else {
-                this.dcx().struct_span_err(expr.span, msg).emit()
-            };
-
-            ConstArg { hir_id: this.next_id(), kind: hir::ConstArgKind::Error(e), span }
-        };
-
+        let node_id = id_override.unwrap_or(expr.id);
         match &expr.kind {
             ExprKind::Call(func, args) if let ExprKind::Path(qself, path) = &func.kind => {
                 let qpath = self.lower_qpath(
@@ -2702,23 +2783,27 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 );
 
                 let lowered_args = self.arena.alloc_from_iter(args.iter().map(|arg| {
-                    let const_arg = self.lower_expr_to_const_arg_direct(arg);
+                    let const_arg = self.lower_expr_to_const_arg_direct(arg, None);
                     &*self.arena.alloc(const_arg)
                 }));
 
                 ConstArg {
-                    hir_id: self.next_id(),
+                    hir_id: self.lower_node_id(node_id),
                     kind: hir::ConstArgKind::TupleCall(qpath, lowered_args),
                     span,
                 }
             }
             ExprKind::Tup(exprs) => {
                 let exprs = self.arena.alloc_from_iter(exprs.iter().map(|expr| {
-                    let expr = self.lower_expr_to_const_arg_direct(&expr);
+                    let expr = self.lower_expr_to_const_arg_direct(expr, None);
                     &*self.arena.alloc(expr)
                 }));
 
-                ConstArg { hir_id: self.next_id(), kind: hir::ConstArgKind::Tup(exprs), span }
+                ConstArg {
+                    hir_id: self.lower_node_id(node_id),
+                    kind: hir::ConstArgKind::Tup(exprs),
+                    span,
+                }
             }
             ExprKind::Path(qself, path) => {
                 let qpath = self.lower_qpath(
@@ -2732,7 +2817,11 @@ impl<'hir> LoweringContext<'_, 'hir> {
                     None,
                 );
 
-                ConstArg { hir_id: self.next_id(), kind: hir::ConstArgKind::Path(qpath), span }
+                ConstArg {
+                    hir_id: self.lower_node_id(node_id),
+                    kind: hir::ConstArgKind::Path(qpath),
+                    span,
+                }
             }
             ExprKind::Struct(se) => {
                 let path = self.lower_qpath(
@@ -2754,7 +2843,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                     // then go unused as the `Target::ExprField` is not actually
                     // corresponding to `Node::ExprField`.
                     self.lower_attrs(hir_id, &f.attrs, f.span, Target::ExprField);
-                    let expr = self.lower_expr_to_const_arg_direct(&f.expr);
+                    let expr = self.lower_expr_to_const_arg_direct(&f.expr, None);
 
                     &*self.arena.alloc(hir::ConstArgExprField {
                         hir_id,
@@ -2765,14 +2854,14 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 }));
 
                 ConstArg {
-                    hir_id: self.next_id(),
+                    hir_id: self.lower_node_id(node_id),
                     kind: hir::ConstArgKind::Struct(path, fields),
                     span,
                 }
             }
             ExprKind::Array(elements) => {
                 let lowered_elems = self.arena.alloc_from_iter(elements.iter().map(|element| {
-                    let const_arg = self.lower_expr_to_const_arg_direct(element);
+                    let const_arg = self.lower_expr_to_const_arg_direct(element, None);
                     &*self.arena.alloc(const_arg)
                 }));
                 let array_expr = self.arena.alloc(hir::ConstArgArrayExpr {
@@ -2781,31 +2870,28 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 });
 
                 ConstArg {
-                    hir_id: self.next_id(),
+                    hir_id: self.lower_node_id(node_id),
                     kind: hir::ConstArgKind::Array(array_expr),
                     span,
                 }
             }
             ExprKind::Underscore => ConstArg {
-                hir_id: self.lower_node_id(expr.id),
+                hir_id: self.lower_node_id(node_id),
                 kind: hir::ConstArgKind::Infer(()),
                 span,
             },
-            ExprKind::Block(block, _) => {
+            ExprKind::Block(block, _)
                 if let [stmt] = block.stmts.as_slice()
-                    && let StmtKind::Expr(expr) = &stmt.kind
-                {
-                    return self.lower_expr_to_const_arg_direct(expr);
-                }
-
-                overly_complex_const(self)
+                    && let StmtKind::Expr(expr) = &stmt.kind =>
+            {
+                return self.lower_expr_to_const_arg_direct(expr, id_override);
             }
             ExprKind::Lit(literal) => {
                 let span = self.lower_span(expr.span);
                 let literal = self.lower_lit(literal, span);
 
                 ConstArg {
-                    hir_id: self.lower_node_id(expr.id),
+                    hir_id: self.lower_node_id(node_id),
                     kind: hir::ConstArgKind::Literal { lit: literal.node, negated: false },
                     span,
                 }
@@ -2816,29 +2902,45 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 let span = self.lower_span(expr.span);
                 let literal = self.lower_lit(literal, span);
 
-                if !matches!(literal.node, LitKind::Int(..)) {
+                let kind = if !matches!(literal.node, LitKind::Int(..)) {
                     let err =
                         self.dcx().struct_span_err(expr.span, "negated literal must be an integer");
-
-                    return ConstArg {
-                        hir_id: self.next_id(),
-                        kind: hir::ConstArgKind::Error(err.emit()),
-                        span,
-                    };
-                }
-
+                    hir::ConstArgKind::Error(err.emit())
+                } else {
+                    hir::ConstArgKind::Literal { lit: literal.node, negated: true }
+                };
+                ConstArg { hir_id: self.lower_node_id(node_id), kind, span }
+            }
+            ExprKind::ConstBlock(anon_const) => {
+                // Do not use lower_anon_const_to_const_arg, as that attempts to represent the body
+                // directly. Instead, force an anon const.
+                let def_id = self.local_def_id(anon_const.id);
+                assert_eq!(DefKind::InlineConst, self.tcx.def_kind(def_id));
+                let lowered_anon = self.lower_anon_const_to_anon_const(anon_const, span);
                 ConstArg {
-                    hir_id: self.lower_node_id(expr.id),
-                    kind: hir::ConstArgKind::Literal { lit: literal.node, negated: true },
+                    hir_id: self.lower_node_id(node_id),
+                    kind: hir::ConstArgKind::Anon(lowered_anon),
                     span,
                 }
             }
-            ExprKind::ConstBlock(anon_const) => {
-                let def_id = self.local_def_id(anon_const.id);
-                assert_eq!(DefKind::InlineConst, self.tcx.def_kind(def_id));
-                self.lower_anon_const_to_const_arg(anon_const, span)
+            ExprKind::DirectConstArg(expr) => {
+                // `can_lower_expr_to_const_arg_direct` always returns success upon encountering a
+                // ExprKind::DirectConstArg, which effectively forces the expression to be lowered
+                // as a direct arg. If it actually turns out to not be possible, emit an error
+                // instead.
+                match self.can_lower_expr_to_const_arg_direct(expr) {
+                    Ok(()) => self.lower_expr_to_const_arg_direct(expr, id_override),
+                    Err(err) => err.emit(self),
+                }
             }
-            _ => overly_complex_const(self),
+            _ => {
+                span_bug!(
+                    expr.span,
+                    "lower_expr_to_const_arg_direct encountered an unlowerable expression, either \
+                    can_lower_expr_to_const_arg_direct returned Ok() on something it shouldn't \
+                    have, or you forgot to check can_lower_expr_to_const_arg_direct first"
+                );
+            }
         }
     }
 
@@ -2857,67 +2959,23 @@ impl<'hir> LoweringContext<'_, 'hir> {
         anon: &AnonConst,
         span: Span,
     ) -> hir::ConstArg<'hir> {
-        let tcx = self.tcx;
-
-        // We cannot change parsing depending on feature gates available,
-        // we can only require feature gates to be active as a delayed check.
-        // Thus we just parse anon consts generally and make the real decision
-        // making in ast lowering.
-        // FIXME(min_generic_const_args): revisit once stable
-        if tcx.features().min_generic_const_args() {
-            return match anon.mgca_disambiguation {
-                MgcaDisambiguation::AnonConst => {
-                    let lowered_anon = self.lower_anon_const_to_anon_const(anon, span);
-                    ConstArg {
-                        hir_id: self.next_id(),
-                        kind: hir::ConstArgKind::Anon(lowered_anon),
-                        span: lowered_anon.span,
-                    }
-                }
-                MgcaDisambiguation::Direct => self.lower_expr_to_const_arg_direct(&anon.value),
-            };
-        }
-
-        // Unwrap a block, so that e.g. `{ P }` is recognised as a parameter. Const arguments
-        // currently have to be wrapped in curly brackets, so it's necessary to special-case.
-        let expr = if let ExprKind::Block(block, _) = &anon.value.kind
-            && let [stmt] = block.stmts.as_slice()
-            && let StmtKind::Expr(expr) = &stmt.kind
-            && let ExprKind::Path(..) = &expr.kind
-        {
-            expr
-        } else {
+        // Stable only allows one nesting of blocks for directly represented paths. mGCA allows
+        // arbitrarily many, and are handled inside lower_expr_to_const_arg_direct for consistency.
+        let expr = if self.tcx.features().min_generic_const_args() {
             &anon.value
+        } else {
+            anon.value.maybe_unwrap_block()
         };
 
-        let maybe_res =
-            self.get_partial_res(expr.id).and_then(|partial_res| partial_res.full_res());
-        if let ExprKind::Path(qself, path) = &expr.kind
-            && path.is_potential_trivial_const_arg()
-            && matches!(maybe_res, Some(Res::Def(DefKind::ConstParam, _)))
-        {
-            let qpath = self.lower_qpath(
-                expr.id,
-                qself,
-                path,
-                ParamMode::Explicit,
-                AllowReturnTypeNotation::No,
-                ImplTraitContext::Disallowed(ImplTraitPosition::Path),
-                None,
-            );
-
-            return ConstArg {
-                hir_id: self.lower_node_id(anon.id),
-                kind: hir::ConstArgKind::Path(qpath),
-                span: self.lower_span(expr.span),
-            };
+        if self.can_lower_expr_to_const_arg_direct(expr).is_ok() {
+            return self.lower_expr_to_const_arg_direct(expr, Some(anon.id));
         }
 
         let lowered_anon = self.lower_anon_const_to_anon_const(anon, anon.value.span);
         ConstArg {
             hir_id: self.next_id(),
             kind: hir::ConstArgKind::Anon(lowered_anon),
-            span: self.lower_span(expr.span),
+            span: self.lower_span(anon.value.span),
         }
     }
 
@@ -3211,5 +3269,38 @@ impl<'hir> GenericArgsCtor<'hir> {
             span_ext: this.lower_span(self.span),
         };
         this.arena.alloc(ga)
+    }
+}
+
+#[derive(Debug)]
+struct UnrepresentableConstArgError {
+    span: Span,
+    will_create_def_ids: bool,
+}
+
+impl UnrepresentableConstArgError {
+    fn new(expr: &Expr) -> Self {
+        Self {
+            span: expr.span,
+            will_create_def_ids: expr::WillCreateDefIdsVisitor.visit_expr(expr).is_break(),
+        }
+    }
+
+    fn emit<'hir>(self, lowering_context: &mut LoweringContext<'_, 'hir>) -> ConstArg<'hir> {
+        let msg = "complex const arguments must be placed inside of a `const` block";
+        let e = if self.will_create_def_ids {
+            // FIXME(mgca): make this non-fatal once we have a better way to handle
+            // nested items in const args
+            // Issue: https://github.com/rust-lang/rust/issues/154539
+            lowering_context.dcx().struct_span_fatal(self.span, msg).emit()
+        } else {
+            lowering_context.dcx().struct_span_err(self.span, msg).emit()
+        };
+
+        ConstArg {
+            hir_id: lowering_context.next_id(),
+            kind: hir::ConstArgKind::Error(e),
+            span: self.span,
+        }
     }
 }

--- a/compiler/rustc_ast_pretty/src/pprust/state.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state.rs
@@ -1459,6 +1459,12 @@ impl<'a> State<'a> {
                 self.print_type(ty);
                 self.print_view(fields);
             }
+            ast::TyKind::DirectConstArg(expr) => {
+                self.word_nbsp("core::direct_const_arg!");
+                self.popen();
+                self.print_expr(expr, FixupContext::default());
+                self.pclose();
+            }
         }
         self.end(ib);
     }

--- a/compiler/rustc_ast_pretty/src/pprust/state/expr.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state/expr.rs
@@ -883,6 +883,12 @@ impl<'a> State<'a> {
                 self.word("/*DUMMY*/");
                 self.pclose();
             }
+            ast::ExprKind::DirectConstArg(expr) => {
+                self.word_nbsp("core::direct_const_arg!");
+                self.popen();
+                self.print_expr(expr, FixupContext::default());
+                self.pclose()
+            }
         }
 
         self.ann.post(self, AnnNode::Expr(expr));

--- a/compiler/rustc_builtin_macros/src/assert/context.rs
+++ b/compiler/rustc_builtin_macros/src/assert/context.rs
@@ -323,6 +323,7 @@ impl<'cx, 'a> Context<'cx, 'a> {
             | ExprKind::Yeet(_)
             | ExprKind::Become(_)
             | ExprKind::Yield(_)
+            | ExprKind::DirectConstArg(_)
             | ExprKind::UnsafeBinderCast(..) => {}
         }
     }

--- a/compiler/rustc_builtin_macros/src/autodiff.rs
+++ b/compiler/rustc_builtin_macros/src/autodiff.rs
@@ -16,7 +16,7 @@ mod llvm_enzyme {
     use rustc_ast::{
         self as ast, AngleBracketedArg, AngleBracketedArgs, AnonConst, AssocItemKind, BindingMode,
         FnRetTy, FnSig, GenericArg, GenericArgs, GenericParamKind, Generics, ItemKind,
-        MetaItemInner, MgcaDisambiguation, PatKind, Path, PathSegment, TyKind, Visibility,
+        MetaItemInner, PatKind, Path, PathSegment, TyKind, Visibility,
     };
     use rustc_expand::base::{Annotatable, ExtCtxt};
     use rustc_hir::attrs::RustcAutodiff;
@@ -602,11 +602,7 @@ mod llvm_enzyme {
                 }
                 GenericParamKind::Const { .. } => {
                     let expr = ecx.expr_path(ast::Path::from_ident(p.ident));
-                    let anon_const = AnonConst {
-                        id: ast::DUMMY_NODE_ID,
-                        value: expr,
-                        mgca_disambiguation: MgcaDisambiguation::Direct,
-                    };
+                    let anon_const = AnonConst { id: ast::DUMMY_NODE_ID, value: expr };
                     Some(AngleBracketedArg::Arg(GenericArg::Const(anon_const)))
                 }
                 GenericParamKind::Lifetime { .. } => None,
@@ -861,7 +857,6 @@ mod llvm_enzyme {
                     let anon_const = rustc_ast::AnonConst {
                         id: ast::DUMMY_NODE_ID,
                         value: ecx.expr_usize(span, 1 + x.width as usize),
-                        mgca_disambiguation: MgcaDisambiguation::Direct,
                     };
                     TyKind::Array(ty.clone(), anon_const)
                 };
@@ -876,7 +871,6 @@ mod llvm_enzyme {
                     let anon_const = rustc_ast::AnonConst {
                         id: ast::DUMMY_NODE_ID,
                         value: ecx.expr_usize(span, x.width as usize),
-                        mgca_disambiguation: MgcaDisambiguation::Direct,
                     };
                     let kind = TyKind::Array(ty.clone(), anon_const);
                     let ty =

--- a/compiler/rustc_builtin_macros/src/direct_const_arg.rs
+++ b/compiler/rustc_builtin_macros/src/direct_const_arg.rs
@@ -1,0 +1,39 @@
+use rustc_ast::ast;
+use rustc_ast::tokenstream::TokenStream;
+use rustc_expand::base::{self, DummyResult, ExpandResult, ExtCtxt, MacroExpanderResult};
+use rustc_span::Span;
+
+use crate::util::get_single_expr_from_tts;
+
+pub(crate) fn expand<'cx>(
+    cx: &'cx mut ExtCtxt<'_>,
+    span: Span,
+    tts: TokenStream,
+) -> MacroExpanderResult<'cx> {
+    let ExpandResult::Ready(expr) = get_single_expr_from_tts(cx, span, tts, "direct_const_arg!")
+    else {
+        return ExpandResult::Retry(());
+    };
+    let expr = match expr {
+        Ok(expr) => expr,
+        Err(err) => return ExpandResult::Ready(DummyResult::any(span, err)),
+    };
+
+    let id = ast::DUMMY_NODE_ID;
+    ExpandResult::Ready(Box::new(base::MacEager {
+        expr: Some(Box::new(ast::Expr {
+            id,
+            kind: ast::ExprKind::DirectConstArg(expr.clone()),
+            span,
+            attrs: Default::default(),
+            tokens: None,
+        })),
+        ty: Some(Box::new(ast::Ty {
+            id,
+            kind: ast::TyKind::DirectConstArg(expr),
+            span,
+            tokens: None,
+        })),
+        ..Default::default()
+    }))
+}

--- a/compiler/rustc_builtin_macros/src/lib.rs
+++ b/compiler/rustc_builtin_macros/src/lib.rs
@@ -34,6 +34,7 @@ mod define_opaque;
 mod derive;
 mod deriving;
 mod diagnostics;
+mod direct_const_arg;
 mod edition_panic;
 mod eii;
 mod env;
@@ -81,6 +82,7 @@ pub fn register_builtin_macros(resolver: &mut dyn ResolverExpand) {
         concat_bytes: concat_bytes::expand_concat_bytes,
         const_format_args: format::expand_format_args,
         core_panic: edition_panic::expand_panic,
+        direct_const_arg: direct_const_arg::expand,
         env: env::expand_env,
         file: source_util::expand_file,
         format_args: format::expand_format_args,

--- a/compiler/rustc_builtin_macros/src/pattern_type.rs
+++ b/compiler/rustc_builtin_macros/src/pattern_type.rs
@@ -1,5 +1,5 @@
 use rustc_ast::tokenstream::TokenStream;
-use rustc_ast::{AnonConst, DUMMY_NODE_ID, MgcaDisambiguation, Ty, TyPat, TyPatKind, ast, token};
+use rustc_ast::{AnonConst, DUMMY_NODE_ID, Ty, TyPat, TyPatKind, ast, token};
 use rustc_errors::PResult;
 use rustc_expand::base::{self, DummyResult, ExpandResult, ExtCtxt, MacroExpanderResult};
 use rustc_parse::exp;
@@ -60,20 +60,8 @@ fn ty_pat(kind: TyPatKind, span: Span) -> TyPat {
 fn pat_to_ty_pat(cx: &mut ExtCtxt<'_>, pat: ast::Pat) -> TyPat {
     let kind = match pat.kind {
         ast::PatKind::Range(start, end, include_end) => TyPatKind::Range(
-            start.map(|value| {
-                Box::new(AnonConst {
-                    id: DUMMY_NODE_ID,
-                    value,
-                    mgca_disambiguation: MgcaDisambiguation::Direct,
-                })
-            }),
-            end.map(|value| {
-                Box::new(AnonConst {
-                    id: DUMMY_NODE_ID,
-                    value,
-                    mgca_disambiguation: MgcaDisambiguation::Direct,
-                })
-            }),
+            start.map(|value| Box::new(AnonConst { id: DUMMY_NODE_ID, value })),
+            end.map(|value| Box::new(AnonConst { id: DUMMY_NODE_ID, value })),
             include_end,
         ),
         ast::PatKind::Or(variants) => {

--- a/compiler/rustc_expand/src/build.rs
+++ b/compiler/rustc_expand/src/build.rs
@@ -2,8 +2,8 @@ use rustc_ast::token::Delimiter;
 use rustc_ast::tokenstream::TokenStream;
 use rustc_ast::util::literal;
 use rustc_ast::{
-    self as ast, AnonConst, AttrItem, AttrVec, BlockCheckMode, Expr, LocalKind, MatchKind,
-    MgcaDisambiguation, PatKind, UnOp, attr, token, tokenstream,
+    self as ast, AnonConst, AttrItem, AttrVec, BlockCheckMode, Expr, LocalKind, MatchKind, PatKind,
+    UnOp, attr, token, tokenstream,
 };
 use rustc_span::{DUMMY_SP, Ident, Span, Spanned, Symbol, kw, sym};
 use thin_vec::{ThinVec, thin_vec};
@@ -100,7 +100,6 @@ impl<'a> ExtCtxt<'a> {
                 attrs: AttrVec::new(),
                 tokens: None,
             }),
-            mgca_disambiguation: MgcaDisambiguation::Direct,
         }
     }
 

--- a/compiler/rustc_hir_analysis/src/collect/generics_of.rs
+++ b/compiler/rustc_hir_analysis/src/collect/generics_of.rs
@@ -214,6 +214,17 @@ pub(super) fn generics_of(tcx: TyCtxt<'_>, def_id: LocalDefId) -> ty::Generics {
             "synthetic HIR should have its `generics_of` explicitly fed"
         ),
 
+        Node::ConstArg(..) => {
+            // These can show up in mGCA when representing "direct" const arguments. The
+            // DefCollector cannot know whether an anon const will be represented by an actual HIR
+            // Node::AnonConst, or whether it will be represented directly, so it must generate a
+            // DefId. If it ends up being direct, this DefId is then attached to the top-level
+            // ConstArg, which is what we are seeing here.
+            debug_assert!(tcx.features().min_generic_const_args());
+            // Forward to the real parent.
+            Some(tcx.local_parent(def_id))
+        }
+
         _ => span_bug!(tcx.def_span(def_id), "generics_of: unexpected node kind {node:?}"),
     };
 

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -1108,7 +1108,7 @@ fn should_encode_mir(
         // instance_mir uses mir_for_ctfe rather than optimized_mir for constructors
         DefKind::Ctor(_, _) => (true, false),
         // Constants
-        DefKind::AnonConst { .. }
+        DefKind::AnonConst
         | DefKind::InlineConst
         | DefKind::AssocConst { .. }
         | DefKind::Const { .. } => (true, false),
@@ -1438,27 +1438,11 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
             // for trivial const arguments which are directly lowered to
             // `ConstArgKind::Path`. We never actually access this `DefId`
             // anywhere so we don't need to encode it for other crates.
+            // FIXME(mgca): This probably isn't true, they probably are accessed, but, test case?
             if def_kind == DefKind::AnonConst
-                && match tcx.hir_node_by_def_id(local_id) {
-                    hir::Node::ConstArg(hir::ConstArg { kind, .. }) => match kind {
-                        // Skip encoding defs for these as they should not have had a `DefId` created
-                        hir::ConstArgKind::Error(..)
-                        | hir::ConstArgKind::Struct(..)
-                        | hir::ConstArgKind::Array(..)
-                        | hir::ConstArgKind::TupleCall(..)
-                        | hir::ConstArgKind::Tup(..)
-                        | hir::ConstArgKind::Path(..)
-                        | hir::ConstArgKind::Literal { .. }
-                        | hir::ConstArgKind::Infer(..) => true,
-                        hir::ConstArgKind::Anon(..) => false,
-                    },
-                    _ => false,
-                }
+                && matches!(tcx.hir_node_by_def_id(local_id), hir::Node::ConstArg(_))
             {
-                // MGCA doesn't have unnecessary DefIds
-                if !tcx.features().min_generic_const_args() {
-                    continue;
-                }
+                continue;
             }
 
             if def_kind == DefKind::Field

--- a/compiler/rustc_parse/src/parser/asm.rs
+++ b/compiler/rustc_parse/src/parser/asm.rs
@@ -1,4 +1,4 @@
-use rustc_ast::{self as ast, AsmMacro, MgcaDisambiguation};
+use rustc_ast::{self as ast, AsmMacro};
 use rustc_span::{Span, Symbol, kw};
 
 use super::{ExpKeywordPair, ForceCollect, IdentIsRaw, Trailing, UsePreAttrPos};
@@ -149,7 +149,7 @@ fn parse_asm_operand<'a>(
         let block = p.parse_block()?;
         ast::InlineAsmOperand::Label { block }
     } else if p.eat_keyword(exp!(Const)) {
-        let anon_const = p.parse_expr_anon_const(|_, _| MgcaDisambiguation::AnonConst)?;
+        let anon_const = p.parse_expr_anon_const()?;
         ast::InlineAsmOperand::Const { anon_const }
     } else if p.eat_keyword(exp!(Sym)) {
         let expr = p.parse_expr()?;

--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -7,7 +7,7 @@ use rustc_ast::util::parser::AssocOp;
 use rustc_ast::{
     self as ast, AngleBracketedArg, AngleBracketedArgs, AnonConst, AttrVec, BinOpKind, BindingMode,
     Block, BlockCheckMode, Expr, ExprKind, GenericArg, GenericArgs, Generics, Item, ItemKind,
-    MgcaDisambiguation, Param, Pat, PatKind, Path, PathSegment, QSelf, Recovered, Ty, TyKind,
+    Param, Pat, PatKind, Path, PathSegment, QSelf, Recovered, Ty, TyKind,
 };
 use rustc_ast_pretty::pprust;
 use rustc_data_structures::fx::FxHashSet;
@@ -2585,11 +2585,7 @@ impl<'a> Parser<'a> {
             self.dcx().emit_err(UnexpectedConstParamDeclaration { span: param.span(), sugg });
 
         let value = self.mk_expr_err(param.span(), guar);
-        Some(GenericArg::Const(AnonConst {
-            id: ast::DUMMY_NODE_ID,
-            value,
-            mgca_disambiguation: MgcaDisambiguation::Direct,
-        }))
+        Some(GenericArg::Const(AnonConst { id: ast::DUMMY_NODE_ID, value }))
     }
 
     pub(super) fn recover_const_param_declaration(
@@ -2673,11 +2669,7 @@ impl<'a> Parser<'a> {
                     );
                     let guar = err.emit();
                     let value = self.mk_expr_err(start.to(expr.span), guar);
-                    return Ok(GenericArg::Const(AnonConst {
-                        id: ast::DUMMY_NODE_ID,
-                        value,
-                        mgca_disambiguation: MgcaDisambiguation::Direct,
-                    }));
+                    return Ok(GenericArg::Const(AnonConst { id: ast::DUMMY_NODE_ID, value }));
                 } else if snapshot.token == token::Colon
                     && expr.span.lo() == snapshot.token.span.hi()
                     && matches!(expr.kind, ExprKind::Path(..))
@@ -2746,11 +2738,7 @@ impl<'a> Parser<'a> {
         );
         let guar = err.emit();
         let value = self.mk_expr_err(span, guar);
-        GenericArg::Const(AnonConst {
-            id: ast::DUMMY_NODE_ID,
-            value,
-            mgca_disambiguation: MgcaDisambiguation::Direct,
-        })
+        GenericArg::Const(AnonConst { id: ast::DUMMY_NODE_ID, value })
     }
 
     /// Some special error handling for the "top-level" patterns in a match arm,

--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -15,8 +15,8 @@ use rustc_ast::visit::{Visitor, walk_expr};
 use rustc_ast::{
     self as ast, AnonConst, Arm, AssignOp, AssignOpKind, AttrStyle, AttrVec, BinOp, BinOpKind,
     BlockCheckMode, CaptureBy, ClosureBinder, DUMMY_NODE_ID, Expr, ExprField, ExprKind, FnDecl,
-    FnRetTy, Guard, Label, MacCall, MetaItemLit, MgcaDisambiguation, Movability, Param,
-    RangeLimits, StmtKind, Ty, TyKind, UnOp, UnsafeBinderCastKind, YieldKind,
+    FnRetTy, Guard, Label, MacCall, MetaItemLit, Movability, Param, RangeLimits, StmtKind, Ty,
+    TyKind, UnOp, UnsafeBinderCastKind, YieldKind,
 };
 use rustc_ast_pretty::pprust;
 use rustc_data_structures::stack::ensure_sufficient_stack;
@@ -83,15 +83,8 @@ impl<'a> Parser<'a> {
         )
     }
 
-    pub fn parse_expr_anon_const(
-        &mut self,
-        mgca_disambiguation: impl FnOnce(&Self, &Expr) -> MgcaDisambiguation,
-    ) -> PResult<'a, AnonConst> {
-        self.parse_expr().map(|value| AnonConst {
-            id: DUMMY_NODE_ID,
-            mgca_disambiguation: mgca_disambiguation(self, &value),
-            value,
-        })
+    pub fn parse_expr_anon_const(&mut self) -> PResult<'a, AnonConst> {
+        self.parse_expr().map(|value| AnonConst { id: DUMMY_NODE_ID, value })
     }
 
     fn parse_expr_catch_underscore(
@@ -1672,7 +1665,7 @@ impl<'a> Parser<'a> {
             let first_expr = self.parse_expr()?;
             if self.eat(exp!(Semi)) {
                 // Repeating array syntax: `[ 0; 512 ]`
-                let count = self.parse_expr_anon_const(|_, _| MgcaDisambiguation::Direct)?;
+                let count = self.parse_expr_anon_const()?;
                 self.expect(close)?;
                 ExprKind::Repeat(first_expr, count)
             } else if self.eat(exp!(Comma)) {
@@ -4508,6 +4501,7 @@ impl MutVisitor for CondChecker<'_> {
             | ExprKind::IncludedBytes(_)
             | ExprKind::FormatArgs(_)
             | ExprKind::Err(_)
+            | ExprKind::DirectConstArg(_)
             | ExprKind::Dummy => {
                 // These would forbid any let expressions they contain already.
             }

--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -1696,9 +1696,9 @@ impl<'a> Parser<'a> {
             if self.may_recover() { self.parse_where_clause()? } else { WhereClause::default() };
 
         let rhs = match (self.eat(exp!(Eq)), const_arg) {
-            (true, true) => ConstItemRhsKind::TypeConst {
-                rhs: Some(self.parse_expr_anon_const(|_, _| MgcaDisambiguation::Direct)?),
-            },
+            (true, true) => {
+                ConstItemRhsKind::TypeConst { rhs: Some(self.parse_expr_anon_const()?) }
+            }
             (true, false) => ConstItemRhsKind::Body { rhs: Some(self.parse_expr()?) },
             (false, true) => ConstItemRhsKind::TypeConst { rhs: None },
             (false, false) => ConstItemRhsKind::Body { rhs: None },
@@ -1918,11 +1918,8 @@ impl<'a> Parser<'a> {
                 VariantData::Unit(DUMMY_NODE_ID)
             };
 
-            let disr_expr = if this.eat(exp!(Eq)) {
-                Some(this.parse_expr_anon_const(|_, _| MgcaDisambiguation::AnonConst)?)
-            } else {
-                None
-            };
+            let disr_expr =
+                if this.eat(exp!(Eq)) { Some(this.parse_expr_anon_const()?) } else { None };
 
             let span = vlo.to(this.prev_token.span);
             if ident.name == kw::Underscore {
@@ -2143,7 +2140,7 @@ impl<'a> Parser<'a> {
                 if p.token == token::Eq {
                     let mut snapshot = p.create_snapshot_for_diagnostic();
                     snapshot.bump();
-                    match snapshot.parse_expr_anon_const(|_, _| MgcaDisambiguation::AnonConst) {
+                    match snapshot.parse_expr_anon_const() {
                         Ok(const_expr) => {
                             let sp = ty.span.shrink_to_hi().to(const_expr.value.span);
                             p.psess.gated_spans.gate(sym::default_field_values, sp);
@@ -2372,7 +2369,7 @@ impl<'a> Parser<'a> {
         }
         let default = if self.token == token::Eq {
             self.bump();
-            let const_expr = self.parse_expr_anon_const(|_, _| MgcaDisambiguation::AnonConst)?;
+            let const_expr = self.parse_expr_anon_const()?;
             let sp = ty.span.shrink_to_hi().to(const_expr.value.span);
             self.psess.gated_spans.gate(sym::default_field_values, sp);
             Some(const_expr)

--- a/compiler/rustc_parse/src/parser/mod.rs
+++ b/compiler/rustc_parse/src/parser/mod.rs
@@ -36,8 +36,8 @@ use rustc_ast::util::classify;
 use rustc_ast::{
     self as ast, AnonConst, AttrArgs, AttrId, BinOpKind, ByRef, Const, CoroutineKind,
     DUMMY_NODE_ID, DelimArgs, Expr, ExprKind, Extern, HasAttrs, HasTokens, ImplRestriction,
-    MgcaDisambiguation, MutRestriction, Mutability, Recovered, RestrictionKind, Safety, StrLit,
-    Visibility, VisibilityKind,
+    MutRestriction, Mutability, Recovered, RestrictionKind, Safety, StrLit, Visibility,
+    VisibilityKind,
 };
 use rustc_ast_pretty::pprust;
 use rustc_data_structures::fx::FxHashMap;
@@ -1298,7 +1298,6 @@ impl<'a> Parser<'a> {
         let anon_const = AnonConst {
             id: DUMMY_NODE_ID,
             value: self.mk_expr(blk.span, ExprKind::Block(blk, None)),
-            mgca_disambiguation: MgcaDisambiguation::AnonConst,
         };
         let blk_span = anon_const.value.span;
         let kind = if pat {

--- a/compiler/rustc_parse/src/parser/path.rs
+++ b/compiler/rustc_parse/src/parser/path.rs
@@ -4,8 +4,8 @@ use ast::token::IdentIsRaw;
 use rustc_ast::token::{self, MetaVarKind, Token, TokenKind};
 use rustc_ast::{
     self as ast, AngleBracketedArg, AngleBracketedArgs, AnonConst, AssocItemConstraint,
-    AssocItemConstraintKind, BlockCheckMode, GenericArg, GenericArgs, Generics, MgcaDisambiguation,
-    ParenthesizedArgs, Path, PathSegment, QSelf,
+    AssocItemConstraintKind, BlockCheckMode, GenericArg, GenericArgs, Generics, ParenthesizedArgs,
+    Path, PathSegment, QSelf,
 };
 use rustc_errors::{Applicability, Diag, PResult};
 use rustc_span::{BytePos, Ident, Span, kw, sym};
@@ -876,13 +876,12 @@ impl<'a> Parser<'a> {
     /// the caller.
     pub(super) fn parse_const_arg(&mut self) -> PResult<'a, AnonConst> {
         // Parse const argument.
-        let (value, mgca_disambiguation) = if self.token.kind == token::OpenBrace {
-            let value = self.parse_expr_block(None, self.token.span, BlockCheckMode::Default)?;
-            (value, MgcaDisambiguation::Direct)
+        let value = if self.token.kind == token::OpenBrace {
+            self.parse_expr_block(None, self.token.span, BlockCheckMode::Default)?
         } else {
             self.parse_unambiguous_unbraced_const_arg()?
         };
-        Ok(AnonConst { id: ast::DUMMY_NODE_ID, value, mgca_disambiguation })
+        Ok(AnonConst { id: ast::DUMMY_NODE_ID, value })
     }
 
     /// Attempt to parse a const argument that has not been enclosed in braces.
@@ -892,9 +891,7 @@ impl<'a> Parser<'a> {
     /// - Single-segment paths (i.e. standalone generic const parameters).
     /// All other expressions that can be parsed will emit an error suggesting the expression be
     /// wrapped in braces.
-    pub(super) fn parse_unambiguous_unbraced_const_arg(
-        &mut self,
-    ) -> PResult<'a, (Box<Expr>, MgcaDisambiguation)> {
+    pub(super) fn parse_unambiguous_unbraced_const_arg(&mut self) -> PResult<'a, Box<Expr>> {
         let start = self.token.span;
         let attrs = self.parse_outer_attributes()?;
         let (expr, _) =
@@ -915,7 +912,7 @@ impl<'a> Parser<'a> {
             });
         }
 
-        Ok((expr, MgcaDisambiguation::Direct))
+        Ok(expr)
     }
 
     /// Parse a generic argument in a path segment.
@@ -1019,11 +1016,7 @@ impl<'a> Parser<'a> {
                 GenericArg::Type(_) => GenericArg::Type(self.mk_ty(attr_span, TyKind::Err(guar))),
                 GenericArg::Const(_) => {
                     let error_expr = self.mk_expr(attr_span, ExprKind::Err(guar));
-                    GenericArg::Const(AnonConst {
-                        id: ast::DUMMY_NODE_ID,
-                        value: error_expr,
-                        mgca_disambiguation: MgcaDisambiguation::Direct,
-                    })
+                    GenericArg::Const(AnonConst { id: ast::DUMMY_NODE_ID, value: error_expr })
                 }
                 GenericArg::Lifetime(lt) => GenericArg::Lifetime(lt),
             }));

--- a/compiler/rustc_parse/src/parser/ty.rs
+++ b/compiler/rustc_parse/src/parser/ty.rs
@@ -2,9 +2,9 @@ use rustc_ast::token::{self, IdentIsRaw, MetaVarKind, Token, TokenKind};
 use rustc_ast::util::case::Case;
 use rustc_ast::{
     self as ast, BoundAsyncness, BoundConstness, BoundPolarity, DUMMY_NODE_ID, FnPtrTy, FnRetTy,
-    GenericBound, GenericBounds, GenericParam, Generics, Lifetime, MacCall, MgcaDisambiguation,
-    MutTy, Mutability, Pinnedness, PolyTraitRef, PreciseCapturingArg, TraitBoundModifiers,
-    TraitObjectSyntax, Ty, TyKind, UnsafeBinderTy,
+    GenericBound, GenericBounds, GenericParam, Generics, Lifetime, MacCall, MutTy, Mutability,
+    Pinnedness, PolyTraitRef, PreciseCapturingArg, TraitBoundModifiers, TraitObjectSyntax, Ty,
+    TyKind, UnsafeBinderTy,
 };
 use rustc_data_structures::stack::ensure_sufficient_stack;
 use rustc_errors::{Applicability, Diag, E0516, PResult};
@@ -660,7 +660,7 @@ impl<'a> Parser<'a> {
         };
 
         let ty = if self.eat(exp!(Semi)) {
-            let mut length = self.parse_expr_anon_const(|_, _| MgcaDisambiguation::Direct)?;
+            let mut length = self.parse_expr_anon_const()?;
 
             if let Err(e) = self.expect(exp!(CloseBracket)) {
                 // Try to recover from `X<Y, ...>` when `X::<Y, ...>` works
@@ -704,7 +704,7 @@ impl<'a> Parser<'a> {
 
         // FIXME(mgca): recovery is broken for `const {` args
         // we first try to parse pattern like `[u8 5]`
-        let length = match self.parse_expr_anon_const(|_, _| MgcaDisambiguation::Direct) {
+        let length = match self.parse_expr_anon_const() {
             Ok(length) => length,
             Err(e) => {
                 e.cancel();
@@ -794,7 +794,7 @@ impl<'a> Parser<'a> {
     /// an error type.
     fn parse_typeof_ty(&mut self, lo: Span) -> PResult<'a, TyKind> {
         self.expect(exp!(OpenParen))?;
-        let _expr = self.parse_expr_anon_const(|_, _| MgcaDisambiguation::AnonConst)?;
+        let _expr = self.parse_expr_anon_const()?;
         self.expect(exp!(CloseParen))?;
         let span = lo.to(self.prev_token.span);
         let guar = self

--- a/compiler/rustc_passes/src/input_stats.rs
+++ b/compiler/rustc_passes/src/input_stats.rs
@@ -660,7 +660,7 @@ impl<'v> ast_visit::Visitor<'v> for StatCollector<'v> {
                 If, While, ForLoop, Loop, Match, Closure, Block, Await, Move, Use, TryBlock, Assign,
                 AssignOp, Field, Index, Range, Underscore, Path, AddrOf, Break, Continue, Ret,
                 InlineAsm, FormatArgs, OffsetOf, MacCall, Struct, Repeat, Paren, Try, Yield, Yeet,
-                Become, IncludedBytes, Gen, UnsafeBinderCast, Err, Dummy
+                Become, IncludedBytes, Gen, UnsafeBinderCast, Err, Dummy, DirectConstArg
             ]
         );
         ast_visit::walk_expr(self, e)
@@ -688,9 +688,10 @@ impl<'v> ast_visit::Visitor<'v> for StatCollector<'v> {
                 ImplicitSelf,
                 MacCall,
                 CVarArgs,
-                Dummy,
                 FieldOf,
                 View,
+                DirectConstArg,
+                Dummy,
                 Err
             ]
         );

--- a/compiler/rustc_resolve/src/def_collector.rs
+++ b/compiler/rustc_resolve/src/def_collector.rs
@@ -425,26 +425,9 @@ impl<'a, 'ra, 'tcx> visit::Visitor<'a> for DefCollector<'a, 'ra, 'tcx> {
     fn visit_anon_const(&mut self, constant: &'a AnonConst) {
         // Note that `visit_anon_const` is skipped for AnonConst nodes wrapped in an
         // ExprKind::ConstBlock - these are handled in visit_expr, and are DefKind::InlineConst.
-
-        // `MgcaDisambiguation::Direct` is set even when MGCA is disabled, so
-        // to avoid affecting stable we have to feature gate the not creating
-        // anon consts
-        if !self.r.features.min_generic_const_args() {
-            let parent = self
-                .create_def(constant.id, None, DefKind::AnonConst, constant.value.span)
-                .def_id();
-            return self.with_parent(parent, |this| visit::walk_anon_const(this, constant));
-        }
-
-        match constant.mgca_disambiguation {
-            MgcaDisambiguation::Direct => visit::walk_anon_const(self, constant),
-            MgcaDisambiguation::AnonConst => {
-                let parent = self
-                    .create_def(constant.id, None, DefKind::AnonConst, constant.value.span)
-                    .def_id();
-                self.with_parent(parent, |this| visit::walk_anon_const(this, constant));
-            }
-        };
+        let parent =
+            self.create_def(constant.id, None, DefKind::AnonConst, constant.value.span).def_id();
+        self.with_parent(parent, |this| visit::walk_anon_const(this, constant));
     }
 
     #[instrument(level = "debug", skip(self))]

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -822,6 +822,7 @@ symbols! {
         diagnostic_on_unmatched_args,
         dialect,
         direct,
+        direct_const_arg,
         discriminant_kind,
         discriminant_type,
         discriminant_value,

--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -1073,6 +1073,20 @@ pub const trait Destruct: PointeeSized {}
 #[rustc_dyn_incompatible_trait]
 pub trait Tuple {}
 
+/// Creates a new style directly represented const argument.
+/// ```ignore (cannot test this from within core yet)
+/// type const BAR<const N: usize>: usize = N;
+/// type const FOO<const N: usize>: usize = direct!(BAR::<N>);
+/// ```
+#[rustc_builtin_macro(direct_const_arg)]
+#[unstable(feature = "min_generic_const_args", issue = "132980")]
+#[macro_export]
+macro_rules! direct_const_arg {
+    ($($arg:tt)*) => {
+        /* compiler built-in */
+    };
+}
+
 /// A marker for types which can be used as types of `const` generic parameters.
 ///
 /// These types must have a proper equivalence relation (`Eq`) and it must be automatically

--- a/src/tools/clippy/clippy_utils/src/check_proc_macro.rs
+++ b/src/tools/clippy/clippy_utils/src/check_proc_macro.rs
@@ -537,6 +537,7 @@ fn ast_ty_search_pat(ty: &ast::Ty) -> (Pat, Pat) {
         | TyKind::Pat(..)
         | TyKind::FieldOf(..)
         | TyKind::View(..)
+        | TyKind::DirectConstArg(..)
 
         // unused
         | TyKind::CVarArgs

--- a/src/tools/clippy/clippy_utils/src/sugg.rs
+++ b/src/tools/clippy/clippy_utils/src/sugg.rs
@@ -248,6 +248,7 @@ impl<'a> Sugg<'a> {
             | ast::ExprKind::Array(..)
             | ast::ExprKind::While(..)
             | ast::ExprKind::Await(..)
+            | ast::ExprKind::DirectConstArg(..)
             | ast::ExprKind::Err(_)
             | ast::ExprKind::Dummy
             | ast::ExprKind::UnsafeBinderCast(..) => Sugg::NonParen(snippet(expr.span)),

--- a/src/tools/rustfmt/src/expr.rs
+++ b/src/tools/rustfmt/src/expr.rs
@@ -486,7 +486,8 @@ pub(crate) fn format_expr(
         | ast::ExprKind::Type(..)
         | ast::ExprKind::IncludedBytes(..)
         | ast::ExprKind::OffsetOf(..)
-        | ast::ExprKind::UnsafeBinderCast(..) => {
+        | ast::ExprKind::UnsafeBinderCast(..)
+        | ast::ExprKind::DirectConstArg(..) => {
             // These don't normally occur in the AST because macros aren't expanded. However,
             // rustfmt tries to parse macro arguments when formatting macros, so it's not totally
             // impossible for rustfmt to come across one of these nodes when formatting a file.

--- a/src/tools/rustfmt/src/types.rs
+++ b/src/tools/rustfmt/src/types.rs
@@ -1014,7 +1014,6 @@ impl Rewrite for ast::Ty {
                 })
             }
             ast::TyKind::CVarArgs => Ok("...".to_owned()),
-            ast::TyKind::Dummy | ast::TyKind::Err(_) => Ok(context.snippet(self.span).to_owned()),
             ast::TyKind::FieldOf(ref ty, ref variant, ref field) => {
                 let ty = ty.rewrite_result(context, shape)?;
                 if let Some(variant) = variant {
@@ -1049,14 +1048,14 @@ impl Rewrite for ast::Ty {
                 result.push_str(&rewrite);
                 Ok(result)
             }
-
-            ast::TyKind::Pat(..) | ast::TyKind::View(..) => {
+            ast::TyKind::Pat(..) | ast::TyKind::View(..) | ast::TyKind::DirectConstArg(..) => {
                 // These don't normally occur in the AST because macros aren't expanded. However,
                 // rustfmt tries to parse macro arguments when formatting macros, so it's not
                 // totally impossible for rustfmt to come across these nodes when formatting a file.
                 // Also, rustfmt might get passed the output from `-Zunpretty=expanded`.
                 Err(RewriteError::Unknown)
             }
+            ast::TyKind::Dummy | ast::TyKind::Err(_) => Ok(context.snippet(self.span).to_owned()),
         }
     }
 }

--- a/src/tools/rustfmt/src/utils.rs
+++ b/src/tools/rustfmt/src/utils.rs
@@ -532,9 +532,8 @@ pub(crate) fn is_block_expr(context: &RewriteContext<'_>, expr: &ast::Expr, repr
         | ast::ExprKind::Index(_, ref expr, _)
         | ast::ExprKind::Unary(_, ref expr)
         | ast::ExprKind::Try(ref expr)
-        | ast::ExprKind::Yield(YieldKind::Prefix(Some(ref expr))) => {
-            is_block_expr(context, expr, repr)
-        }
+        | ast::ExprKind::Yield(YieldKind::Prefix(Some(ref expr)))
+        | ast::ExprKind::DirectConstArg(ref expr) => is_block_expr(context, expr, repr),
         ast::ExprKind::Closure(ref closure) => is_block_expr(context, &closure.body, repr),
         // This can only be a string lit
         ast::ExprKind::Lit(_) => {

--- a/src/tools/rustfmt/tests/source/direct_const_arg.rs
+++ b/src/tools/rustfmt/tests/source/direct_const_arg.rs
@@ -1,0 +1,14 @@
+// direct_const_arg! is a built-in macro relevant to min_generic_const_args; its contents should be
+// formatted as if its contents were passed through unchanged (the macro changes the semantics of
+// the contained expression, the syntax is unchanged)
+
+#![feature(min_generic_const_args)]
+
+trait Trait {
+    type const TYPE_CONST: usize;
+}
+
+struct S<const N: usize>;
+
+fn parsed_as_expr_kind<T: Trait>(_: S<{ core::direct_const_arg!( T  ::  TYPE_CONST ) }>) {}
+fn parsed_as_ty_kind<T: Trait>(_: S< core::direct_const_arg!( T  ::  TYPE_CONST ) >) {}

--- a/src/tools/rustfmt/tests/target/direct_const_arg.rs
+++ b/src/tools/rustfmt/tests/target/direct_const_arg.rs
@@ -1,0 +1,14 @@
+// direct_const_arg! is a built-in macro relevant to min_generic_const_args; its contents should be
+// formatted as if its contents were passed through unchanged (the macro changes the semantics of
+// the contained expression, the syntax is unchanged)
+
+#![feature(min_generic_const_args)]
+
+trait Trait {
+    type const TYPE_CONST: usize;
+}
+
+struct S<const N: usize>;
+
+fn parsed_as_expr_kind<T: Trait>(_: S<{ core::direct_const_arg!(T::TYPE_CONST) }>) {}
+fn parsed_as_ty_kind<T: Trait>(_: S<core::direct_const_arg!(T::TYPE_CONST)>) {}

--- a/tests/pretty/direct-const-arg.pp
+++ b/tests/pretty/direct-const-arg.pp
@@ -1,0 +1,15 @@
+#![feature(prelude_import)]
+#![no_std]
+//@ pretty-mode:expanded
+//@ pp-exact:direct-const-arg.pp
+#![feature(min_generic_const_args)]
+extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
+
+fn f<const N : usize>() {}
+
+fn main() {
+    f::<core::direct_const_arg! (2)>();
+    f::<{ core::direct_const_arg! (2) }>();
+}

--- a/tests/pretty/direct-const-arg.rs
+++ b/tests/pretty/direct-const-arg.rs
@@ -1,0 +1,10 @@
+//@ pretty-mode:expanded
+//@ pp-exact:direct-const-arg.pp
+#![feature(min_generic_const_args)]
+
+fn f<const N: usize>() {}
+
+fn main() {
+    f::<core::direct_const_arg!(2)>();
+    f::<{ core::direct_const_arg!(2) }>();
+}

--- a/tests/ui/const-generics/generic_const_exprs/assoc_const_unification/doesnt_unify_evaluatable.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/assoc_const_unification/doesnt_unify_evaluatable.stderr
@@ -1,8 +1,8 @@
 error: unconstrained generic constant
-  --> $DIR/doesnt_unify_evaluatable.rs:9:13
+  --> $DIR/doesnt_unify_evaluatable.rs:9:11
    |
 LL |     bar::<{ T::ASSOC }>();
-   |             ^^^^^^^^
+   |           ^^^^^^^^^^^^
    |
 help: try adding a `where` bound
    |

--- a/tests/ui/const-generics/mgca/adt_expr_arg_simple.rs
+++ b/tests/ui/const-generics/mgca/adt_expr_arg_simple.rs
@@ -10,7 +10,6 @@ use Option::Some;
 
 fn foo<const N: Option<u32>>() {}
 
-
 trait Trait {
     type const ASSOC: u32;
 }
@@ -26,7 +25,7 @@ fn bar<T: Trait, const N: u32>() {
 
     // this on the other hand is not allowed as `N + 1` is not a legal
     // const argument
-    foo::<{ Some::<u32> { 0: N + 1 } }>();
+    foo::<{ core::direct_const_arg!(Some::<u32> { 0: N + 1 }) }>();
     //~^ ERROR: complex const arguments must be placed inside of a `const` block
 
     // this also is not allowed as generic parameters cannot be used

--- a/tests/ui/const-generics/mgca/adt_expr_arg_simple.stderr
+++ b/tests/ui/const-generics/mgca/adt_expr_arg_simple.stderr
@@ -1,11 +1,11 @@
 error: complex const arguments must be placed inside of a `const` block
-  --> $DIR/adt_expr_arg_simple.rs:29:30
+  --> $DIR/adt_expr_arg_simple.rs:28:54
    |
-LL |     foo::<{ Some::<u32> { 0: N + 1 } }>();
-   |                              ^^^^^
+LL |     foo::<{ core::direct_const_arg!(Some::<u32> { 0: N + 1 }) }>();
+   |                                                      ^^^^^
 
 error: generic parameters may not be used in const operations
-  --> $DIR/adt_expr_arg_simple.rs:34:38
+  --> $DIR/adt_expr_arg_simple.rs:33:38
    |
 LL |     foo::<{ Some::<u32> { 0: const { N + 1 } } }>();
    |                                      ^

--- a/tests/ui/const-generics/mgca/array-expr-complex.r1.stderr
+++ b/tests/ui/const-generics/mgca/array-expr-complex.r1.stderr
@@ -1,8 +1,8 @@
 error: complex const arguments must be placed inside of a `const` block
-  --> $DIR/array-expr-complex.rs:11:28
+  --> $DIR/array-expr-complex.rs:11:52
    |
-LL |     takes_array::<{ [1, 2, 1 + 2] }>();
-   |                            ^^^^^
+LL |     takes_array::<{ core::direct_const_arg!([1, 2, 1 + 2]) }>();
+   |                                                    ^^^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/mgca/array-expr-complex.r2.stderr
+++ b/tests/ui/const-generics/mgca/array-expr-complex.r2.stderr
@@ -1,8 +1,8 @@
 error: complex const arguments must be placed inside of a `const` block
-  --> $DIR/array-expr-complex.rs:14:21
+  --> $DIR/array-expr-complex.rs:14:45
    |
-LL |     takes_array::<{ [X; 3] }>();
-   |                     ^^^^^^
+LL |     takes_array::<{ core::direct_const_arg!([X; 3]) }>();
+   |                                             ^^^^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/mgca/array-expr-complex.r3.stderr
+++ b/tests/ui/const-generics/mgca/array-expr-complex.r3.stderr
@@ -1,8 +1,8 @@
 error: complex const arguments must be placed inside of a `const` block
-  --> $DIR/array-expr-complex.rs:17:21
+  --> $DIR/array-expr-complex.rs:17:45
    |
-LL |     takes_array::<{ [0; Y] }>();
-   |                     ^^^^^^
+LL |     takes_array::<{ core::direct_const_arg!([0; Y]) }>();
+   |                                             ^^^^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/mgca/array-expr-complex.rs
+++ b/tests/ui/const-generics/mgca/array-expr-complex.rs
@@ -8,13 +8,13 @@ fn takes_array<const A: [u32; 3]>() {}
 fn generic_caller<const X: u32, const Y: usize>() {
     // not supported yet
     #[cfg(r1)]
-    takes_array::<{ [1, 2, 1 + 2] }>();
+    takes_array::<{ core::direct_const_arg!([1, 2, 1 + 2]) }>();
     //[r1]~^ ERROR: complex const arguments must be placed inside of a `const` block
     #[cfg(r2)]
-    takes_array::<{ [X; 3] }>();
+    takes_array::<{ core::direct_const_arg!([X; 3]) }>();
     //[r2]~^ ERROR: complex const arguments must be placed inside of a `const` block
     #[cfg(r3)]
-    takes_array::<{ [0; Y] }>();
+    takes_array::<{ core::direct_const_arg!([0; Y]) }>();
     //[r3]~^ ERROR: complex const arguments must be placed inside of a `const` block
 }
 

--- a/tests/ui/const-generics/mgca/array_expr_arg_complex.rs
+++ b/tests/ui/const-generics/mgca/array_expr_arg_complex.rs
@@ -9,8 +9,8 @@ fn takes_array<const A: [u32; 2]>() {}
 fn takes_tuple_with_array<const A: ([u32; 2], u32)>() {}
 
 fn generic_caller<T: Trait, const N: u32, const N2: u32>() {
-    takes_array::<{ [N, N + 1] }>(); //~ ERROR complex const arguments must be placed inside of a `const` block
-    takes_tuple_with_array::<{ ([N, N + 1], N) }>(); //~ ERROR complex const arguments must be placed inside of a `const` block
+    takes_array::<{ core::direct_const_arg!([N, N + 1]) }>(); //~ ERROR complex const arguments must be placed inside of a `const` block
+    takes_tuple_with_array::<{ core::direct_const_arg!(([N, N + 1], N)) }>(); //~ ERROR complex const arguments must be placed inside of a `const` block
 }
 
 fn main() {}

--- a/tests/ui/const-generics/mgca/array_expr_arg_complex.stderr
+++ b/tests/ui/const-generics/mgca/array_expr_arg_complex.stderr
@@ -1,14 +1,14 @@
 error: complex const arguments must be placed inside of a `const` block
-  --> $DIR/array_expr_arg_complex.rs:12:25
+  --> $DIR/array_expr_arg_complex.rs:12:49
    |
-LL |     takes_array::<{ [N, N + 1] }>();
-   |                         ^^^^^
+LL |     takes_array::<{ core::direct_const_arg!([N, N + 1]) }>();
+   |                                                 ^^^^^
 
 error: complex const arguments must be placed inside of a `const` block
-  --> $DIR/array_expr_arg_complex.rs:13:37
+  --> $DIR/array_expr_arg_complex.rs:13:61
    |
-LL |     takes_tuple_with_array::<{ ([N, N + 1], N) }>();
-   |                                     ^^^^^
+LL |     takes_tuple_with_array::<{ core::direct_const_arg!(([N, N + 1], N)) }>();
+   |                                                             ^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/mgca/auxiliary/anon-const-def-id-on-const-arg-with-anon.rs
+++ b/tests/ui/const-generics/mgca/auxiliary/anon-const-def-id-on-const-arg-with-anon.rs
@@ -1,0 +1,11 @@
+#![feature(min_generic_const_args)]
+#![allow(incomplete_features)]
+pub struct S<const N: usize>;
+// this is a directly represented anon const... it's a bit weird.
+// imagine `S<{ (2, const { 1 + 1 }) }>`. a directly represented tuple, containing an anon const.
+// now, replace `(2, _)` with `_`. it's a directly represented anon const.
+// this is different from const argument lowering failing to represent an argument directly and
+// falling back to representing it as an anon const instead.
+pub fn f() -> S<{ const { 1 + 1 } }> {
+    S
+}

--- a/tests/ui/const-generics/mgca/bad-const-arg-fn-154539.rs
+++ b/tests/ui/const-generics/mgca/bad-const-arg-fn-154539.rs
@@ -2,10 +2,11 @@
 
 trait Iter<
     const FN: fn() = {
-        || { //~ ERROR complex const arguments must be placed inside of a `const` block
+        core::direct_const_arg!(|| {
+            //~^ ERROR complex const arguments must be placed inside of a `const` block
             use std::io::*;
             write!(_, "")
-        }
+        })
     },
 >
 {

--- a/tests/ui/const-generics/mgca/bad-const-arg-fn-154539.stderr
+++ b/tests/ui/const-generics/mgca/bad-const-arg-fn-154539.stderr
@@ -1,10 +1,12 @@
 error: complex const arguments must be placed inside of a `const` block
-  --> $DIR/bad-const-arg-fn-154539.rs:5:9
+  --> $DIR/bad-const-arg-fn-154539.rs:5:33
    |
-LL | /         || {
+LL |           core::direct_const_arg!(|| {
+   |  _________________________________^
+LL | |
 LL | |             use std::io::*;
 LL | |             write!(_, "")
-LL | |         }
+LL | |         })
    | |_________^
 
 error: aborting due to 1 previous error

--- a/tests/ui/const-generics/mgca/bad-direct-const-arg.rs
+++ b/tests/ui/const-generics/mgca/bad-direct-const-arg.rs
@@ -1,0 +1,8 @@
+//! Simple error message test, nothing special here
+#![feature(min_generic_const_args)]
+
+fn main(x: core::direct_const_arg!(2)) {
+    //~^ ERROR expected type, found `direct_const_arg!()` constant
+    let _ = core::direct_const_arg!(2);
+    //~^ ERROR expected expression, found `direct_const_arg!()` constant
+}

--- a/tests/ui/const-generics/mgca/bad-direct-const-arg.stderr
+++ b/tests/ui/const-generics/mgca/bad-direct-const-arg.stderr
@@ -1,0 +1,14 @@
+error: expected expression, found `direct_const_arg!()` constant
+  --> $DIR/bad-direct-const-arg.rs:6:13
+   |
+LL |     let _ = core::direct_const_arg!(2);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: expected type, found `direct_const_arg!()` constant
+  --> $DIR/bad-direct-const-arg.rs:4:12
+   |
+LL | fn main(x: core::direct_const_arg!(2)) {
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/const-generics/mgca/direct-const-arg-feature-gate.rs
+++ b/tests/ui/const-generics/mgca/direct-const-arg-feature-gate.rs
@@ -1,0 +1,5 @@
+fn foo<const N: usize>(_: [(); core::direct_const_arg!(N)]) {}
+//~^ ERROR use of unstable library feature `min_generic_const_args`
+//~| ERROR expected expression, found `direct_const_arg!()` constant
+//~| ERROR generic parameters may not be used in const operations
+fn main() {}

--- a/tests/ui/const-generics/mgca/direct-const-arg-feature-gate.stderr
+++ b/tests/ui/const-generics/mgca/direct-const-arg-feature-gate.stderr
@@ -1,0 +1,28 @@
+error[E0658]: use of unstable library feature `min_generic_const_args`
+  --> $DIR/direct-const-arg-feature-gate.rs:1:32
+   |
+LL | fn foo<const N: usize>(_: [(); core::direct_const_arg!(N)]) {}
+   |                                ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #132980 <https://github.com/rust-lang/rust/issues/132980> for more information
+   = help: add `#![feature(min_generic_const_args)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: generic parameters may not be used in const operations
+  --> $DIR/direct-const-arg-feature-gate.rs:1:56
+   |
+LL | fn foo<const N: usize>(_: [(); core::direct_const_arg!(N)]) {}
+   |                                                        ^ cannot perform const operation using `N`
+   |
+   = help: const parameters may only be used as standalone arguments here, i.e. `N`
+   = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+
+error: expected expression, found `direct_const_arg!()` constant
+  --> $DIR/direct-const-arg-feature-gate.rs:1:32
+   |
+LL | fn foo<const N: usize>(_: [(); core::direct_const_arg!(N)]) {}
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/const-generics/mgca/direct-const-arg-multiple-exprs.rs
+++ b/tests/ui/const-generics/mgca/direct-const-arg-multiple-exprs.rs
@@ -1,0 +1,5 @@
+#![feature(min_generic_const_args)]
+struct S<const N: usize>;
+fn foo<const N: usize, const M: usize>(_: S<core::direct_const_arg!(N, M)>) {}
+//~^ ERROR direct_const_arg! takes 1 argument
+fn main() {}

--- a/tests/ui/const-generics/mgca/direct-const-arg-multiple-exprs.stderr
+++ b/tests/ui/const-generics/mgca/direct-const-arg-multiple-exprs.stderr
@@ -1,0 +1,8 @@
+error: direct_const_arg! takes 1 argument
+  --> $DIR/direct-const-arg-multiple-exprs.rs:3:45
+   |
+LL | fn foo<const N: usize, const M: usize>(_: S<core::direct_const_arg!(N, M)>) {}
+   |                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/const-generics/mgca/double-wrapped-path-not-accidentally-stabilized.rs
+++ b/tests/ui/const-generics/mgca/double-wrapped-path-not-accidentally-stabilized.rs
@@ -1,0 +1,15 @@
+//! When doing some refactorings in mGCA, it was easy to accidentally stabilize doubly-brace-wrapped
+//! paths. Check to make sure we don't accidentally do so.
+//!
+//! Feel free to delete this test if/when mGCA is stabilized and we support this syntax on stable,
+//! it's testing nothing useful beyond that point.
+
+fn f<const N: usize>() {}
+
+fn g<const N: usize>() {
+    f::<{ N }>(); // ok
+    f::<{ { N } }>();
+    //~^ ERROR: generic parameters may not be used in const operations
+}
+
+fn main() {}

--- a/tests/ui/const-generics/mgca/double-wrapped-path-not-accidentally-stabilized.stderr
+++ b/tests/ui/const-generics/mgca/double-wrapped-path-not-accidentally-stabilized.stderr
@@ -1,0 +1,11 @@
+error: generic parameters may not be used in const operations
+  --> $DIR/double-wrapped-path-not-accidentally-stabilized.rs:11:13
+   |
+LL |     f::<{ { N } }>();
+   |             ^ cannot perform const operation using `N`
+   |
+   = help: const parameters may only be used as standalone arguments here, i.e. `N`
+   = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/const-generics/mgca/explicit_anon_consts.rs
+++ b/tests/ui/const-generics/mgca/explicit_anon_consts.rs
@@ -10,7 +10,7 @@ type Adt1<const N: usize> = Foo<N>;
 type Adt2<const N: usize> = Foo<{ N }>;
 type Adt3<const N: usize> = Foo<const { N }>;
 //~^ ERROR: generic parameters may not be used in const operations
-type Adt4<const N: usize> = Foo<{ 1 + 1 }>;
+type Adt4<const N: usize> = Foo<core::direct_const_arg!(1 + 1)>;
 //~^ ERROR: complex const arguments must be placed inside of a `const` block
 type Adt5<const N: usize> = Foo<const { 1 + 1 }>;
 
@@ -18,7 +18,7 @@ type Arr<const N: usize> = [(); N];
 type Arr2<const N: usize> = [(); { N }];
 type Arr3<const N: usize> = [(); const { N }];
 //~^ ERROR: generic parameters may not be used in const operations
-type Arr4<const N: usize> = [(); 1 + 1];
+type Arr4<const N: usize> = [(); core::direct_const_arg!(1 + 1)];
 //~^ ERROR: complex const arguments must be placed inside of a `const` block
 type Arr5<const N: usize> = [(); const { 1 + 1 }];
 
@@ -27,7 +27,7 @@ fn repeats<const N: usize>() -> [(); N] {
     let _2 = [(); { N }];
     let _3 = [(); const { N }];
     //~^ ERROR: generic parameters may not be used in const operations
-    let _4 = [(); 1 + 1];
+    let _4 = [(); core::direct_const_arg!(1 + 1)];
     //~^ ERROR: complex const arguments must be placed inside of a `const` block
     let _5 = [(); const { 1 + 1 }];
     let _6: [(); const { N }] = todo!();
@@ -42,10 +42,10 @@ type const ITEM2<const N: usize>: usize = { N };
 type const ITEM3<const N: usize>: usize = const { N };
 //~^ ERROR: generic parameters may not be used in const operations
 
-type const ITEM4<const N: usize>: usize = { 1 + 1 };
+type const ITEM4<const N: usize>: usize = core::direct_const_arg!(1 + 1);
 //~^ ERROR: complex const arguments must be placed inside of a `const` block
 
-type const ITEM5<const N: usize>: usize = const { 1 + 1};
+type const ITEM5<const N: usize>: usize = const { 1 + 1 };
 
 trait Trait {
 
@@ -59,7 +59,7 @@ fn ace_bounds<
     T2: Trait<ASSOC = { N }>,
     T3: Trait<ASSOC = const { N }>,
     //~^ ERROR: generic parameters may not be used in const operations
-    T4: Trait<ASSOC = { 1 + 1 }>,
+    T4: Trait<ASSOC = { core::direct_const_arg!(1 + 1) }>,
     //~^ ERROR: complex const arguments must be placed inside of a `const` block
     T5: Trait<ASSOC = const { 1 + 1 }>,
 >() {}
@@ -68,6 +68,6 @@ struct Default1<const N: usize, const M: usize = N>;
 struct Default2<const N: usize, const M: usize = { N }>;
 struct Default3<const N: usize, const M: usize = const { N }>;
 //~^ ERROR: generic parameters may not be used in const operations
-struct Default4<const N: usize, const M: usize = { 1 + 1 }>;
+struct Default4<const N: usize, const M: usize = { core::direct_const_arg!(1 + 1) }>;
 //~^ ERROR: complex const arguments must be placed inside of a `const` block
-struct Default5<const N: usize, const M: usize = const { 1 + 1}>;
+struct Default5<const N: usize, const M: usize = const { 1 + 1 }>;

--- a/tests/ui/const-generics/mgca/explicit_anon_consts.stderr
+++ b/tests/ui/const-generics/mgca/explicit_anon_consts.stderr
@@ -1,38 +1,38 @@
 error: complex const arguments must be placed inside of a `const` block
-  --> $DIR/explicit_anon_consts.rs:13:35
+  --> $DIR/explicit_anon_consts.rs:13:57
    |
-LL | type Adt4<const N: usize> = Foo<{ 1 + 1 }>;
-   |                                   ^^^^^
+LL | type Adt4<const N: usize> = Foo<core::direct_const_arg!(1 + 1)>;
+   |                                                         ^^^^^
 
 error: complex const arguments must be placed inside of a `const` block
-  --> $DIR/explicit_anon_consts.rs:21:34
+  --> $DIR/explicit_anon_consts.rs:21:58
    |
-LL | type Arr4<const N: usize> = [(); 1 + 1];
-   |                                  ^^^^^
+LL | type Arr4<const N: usize> = [(); core::direct_const_arg!(1 + 1)];
+   |                                                          ^^^^^
 
 error: complex const arguments must be placed inside of a `const` block
-  --> $DIR/explicit_anon_consts.rs:30:19
+  --> $DIR/explicit_anon_consts.rs:30:43
    |
-LL |     let _4 = [(); 1 + 1];
-   |                   ^^^^^
+LL |     let _4 = [(); core::direct_const_arg!(1 + 1)];
+   |                                           ^^^^^
 
 error: complex const arguments must be placed inside of a `const` block
-  --> $DIR/explicit_anon_consts.rs:45:45
+  --> $DIR/explicit_anon_consts.rs:45:67
    |
-LL | type const ITEM4<const N: usize>: usize = { 1 + 1 };
-   |                                             ^^^^^
+LL | type const ITEM4<const N: usize>: usize = core::direct_const_arg!(1 + 1);
+   |                                                                   ^^^^^
 
 error: complex const arguments must be placed inside of a `const` block
-  --> $DIR/explicit_anon_consts.rs:62:25
+  --> $DIR/explicit_anon_consts.rs:62:49
    |
-LL |     T4: Trait<ASSOC = { 1 + 1 }>,
-   |                         ^^^^^
+LL |     T4: Trait<ASSOC = { core::direct_const_arg!(1 + 1) }>,
+   |                                                 ^^^^^
 
 error: complex const arguments must be placed inside of a `const` block
-  --> $DIR/explicit_anon_consts.rs:71:52
+  --> $DIR/explicit_anon_consts.rs:71:76
    |
-LL | struct Default4<const N: usize, const M: usize = { 1 + 1 }>;
-   |                                                    ^^^^^
+LL | struct Default4<const N: usize, const M: usize = { core::direct_const_arg!(1 + 1) }>;
+   |                                                                            ^^^^^
 
 error: generic parameters may not be used in const operations
   --> $DIR/explicit_anon_consts.rs:42:51

--- a/tests/ui/const-generics/mgca/mixed-direct-anon-expression-diagnostics.rs
+++ b/tests/ui/const-generics/mgca/mixed-direct-anon-expression-diagnostics.rs
@@ -1,0 +1,17 @@
+//! Diagnostics for expressions that contain things that must be a mGCA direct expression, *and*
+//! things that must be an anon const, are currently less than ideal. This test merely asserts the
+//! current (bad) state of diagnostics, so we can track improvements over time.
+
+#![feature(min_generic_const_args, min_adt_const_params)]
+#![allow(incomplete_features)]
+
+fn f<const N: (u32, u32)>() {}
+
+fn g<const N: u32>() {
+    f::<{ (N, 1 + 1) }>();
+    //~^ ERROR: generic parameters may not be used in const operations
+    f::<{ core::direct_const_arg!((N, 1 + 1)) }>();
+    //~^ ERROR: complex const arguments must be placed inside of a `const` block
+}
+
+fn main() {}

--- a/tests/ui/const-generics/mgca/mixed-direct-anon-expression-diagnostics.stderr
+++ b/tests/ui/const-generics/mgca/mixed-direct-anon-expression-diagnostics.stderr
@@ -1,0 +1,16 @@
+error: complex const arguments must be placed inside of a `const` block
+  --> $DIR/mixed-direct-anon-expression-diagnostics.rs:13:39
+   |
+LL |     f::<{ core::direct_const_arg!((N, 1 + 1)) }>();
+   |                                       ^^^^^
+
+error: generic parameters may not be used in const operations
+  --> $DIR/mixed-direct-anon-expression-diagnostics.rs:11:12
+   |
+LL |     f::<{ (N, 1 + 1) }>();
+   |            ^
+   |
+   = help: add `#![feature(generic_const_args)]` to allow generic expressions as the RHS of const items
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/const-generics/mgca/serialized-direct-const-with-anon-const-body.rs
+++ b/tests/ui/const-generics/mgca/serialized-direct-const-with-anon-const-body.rs
@@ -1,0 +1,16 @@
+//@ check-pass
+//@ aux-build:anon-const-def-id-on-const-arg-with-anon.rs
+//! The DefCollector sometimes generates "fake" DefKind::AnonConst DefIds for AST AnonConsts that
+//! are not actually lowered to HIR AnonConsts, and so the DefId is placed on a hir::Node::ConstArg
+//! (just to place it *somewhere*). These "fake" DefIds should not be serialized. Previously, the
+//! logic to skip serializing them was incorrect (we were still serializing fake DefIds for
+//! `ConstArg(ConstArgKind::Anon)` if the directly represented expression contained within it
+//! *another*, unrelated, anon const). This test checks that case, a directly-represented
+//! fake-anon-const directly containing another anon const.
+
+#![feature(min_generic_const_args)]
+#![allow(incomplete_features)]
+extern crate anon_const_def_id_on_const_arg_with_anon;
+fn main() {
+    anon_const_def_id_on_const_arg_with_anon::f();
+}

--- a/tests/ui/const-generics/mgca/tuple_ctor_complex_args.rs
+++ b/tests/ui/const-generics/mgca/tuple_ctor_complex_args.rs
@@ -9,7 +9,7 @@ struct Point(u32, u32);
 fn with_point<const P: Point>() {}
 
 fn test<const N: u32>() {
-    with_point::<{ Point(N + 1, N) }>();
+    with_point::<{ core::direct_const_arg!(Point(N + 1, N)) }>();
     //~^ ERROR complex const arguments must be placed inside of a `const` block
 
     with_point::<{ Point(const { N + 1 }, N) }>();

--- a/tests/ui/const-generics/mgca/tuple_ctor_complex_args.stderr
+++ b/tests/ui/const-generics/mgca/tuple_ctor_complex_args.stderr
@@ -1,8 +1,8 @@
 error: complex const arguments must be placed inside of a `const` block
-  --> $DIR/tuple_ctor_complex_args.rs:12:26
+  --> $DIR/tuple_ctor_complex_args.rs:12:50
    |
-LL |     with_point::<{ Point(N + 1, N) }>();
-   |                          ^^^^^
+LL |     with_point::<{ core::direct_const_arg!(Point(N + 1, N)) }>();
+   |                                                  ^^^^^
 
 error: generic parameters may not be used in const operations
   --> $DIR/tuple_ctor_complex_args.rs:15:34

--- a/tests/ui/const-generics/mgca/tuple_expr_arg_complex.rs
+++ b/tests/ui/const-generics/mgca/tuple_expr_arg_complex.rs
@@ -9,11 +9,11 @@ fn takes_tuple<const A: (u32, u32)>() {}
 fn takes_nested_tuple<const A: (u32, (u32, u32))>() {}
 
 fn generic_caller<T: Trait, const N: u32, const N2: u32>() {
-    takes_tuple::<{ (N, N + 1) }>(); //~ ERROR complex const arguments must be placed inside of a `const` block
-    takes_tuple::<{ (N, T::ASSOC + 1) }>(); //~ ERROR complex const arguments must be placed inside of a `const` block
+    takes_tuple::<{ core::direct_const_arg!((N, N + 1)) }>(); //~ ERROR complex const arguments must be placed inside of a `const` block
+    takes_tuple::<{ core::direct_const_arg!((N, T::ASSOC + 1)) }>(); //~ ERROR complex const arguments must be placed inside of a `const` block
 
-    takes_nested_tuple::<{ (N, (N, N + 1)) }>(); //~ ERROR complex const arguments must be placed inside of a `const` block
-    takes_nested_tuple::<{ (N, (N, const { N + 1 })) }>(); //~ ERROR generic parameters may not be used in const operations
+    takes_nested_tuple::<{ core::direct_const_arg!((N, (N, N + 1))) }>(); //~ ERROR complex const arguments must be placed inside of a `const` block
+    takes_nested_tuple::<{ core::direct_const_arg!((N, (N, const { N + 1 }))) }>(); //~ ERROR generic parameters may not be used in const operations
 }
 
 fn main() {}

--- a/tests/ui/const-generics/mgca/tuple_expr_arg_complex.stderr
+++ b/tests/ui/const-generics/mgca/tuple_expr_arg_complex.stderr
@@ -1,26 +1,26 @@
 error: complex const arguments must be placed inside of a `const` block
-  --> $DIR/tuple_expr_arg_complex.rs:12:25
+  --> $DIR/tuple_expr_arg_complex.rs:12:49
    |
-LL |     takes_tuple::<{ (N, N + 1) }>();
-   |                         ^^^^^
+LL |     takes_tuple::<{ core::direct_const_arg!((N, N + 1)) }>();
+   |                                                 ^^^^^
 
 error: complex const arguments must be placed inside of a `const` block
-  --> $DIR/tuple_expr_arg_complex.rs:13:25
+  --> $DIR/tuple_expr_arg_complex.rs:13:49
    |
-LL |     takes_tuple::<{ (N, T::ASSOC + 1) }>();
-   |                         ^^^^^^^^^^^^
+LL |     takes_tuple::<{ core::direct_const_arg!((N, T::ASSOC + 1)) }>();
+   |                                                 ^^^^^^^^^^^^
 
 error: complex const arguments must be placed inside of a `const` block
-  --> $DIR/tuple_expr_arg_complex.rs:15:36
+  --> $DIR/tuple_expr_arg_complex.rs:15:60
    |
-LL |     takes_nested_tuple::<{ (N, (N, N + 1)) }>();
-   |                                    ^^^^^
+LL |     takes_nested_tuple::<{ core::direct_const_arg!((N, (N, N + 1))) }>();
+   |                                                            ^^^^^
 
 error: generic parameters may not be used in const operations
-  --> $DIR/tuple_expr_arg_complex.rs:16:44
+  --> $DIR/tuple_expr_arg_complex.rs:16:68
    |
-LL |     takes_nested_tuple::<{ (N, (N, const { N + 1 })) }>();
-   |                                            ^
+LL |     takes_nested_tuple::<{ core::direct_const_arg!((N, (N, const { N + 1 }))) }>();
+   |                                                                    ^
    |
    = help: add `#![feature(generic_const_args)]` to allow generic expressions as the RHS of const items
 

--- a/tests/ui/const-generics/mgca/type-const-free-anon-const-mismatch.stderr
+++ b/tests/ui/const-generics/mgca/type-const-free-anon-const-mismatch.stderr
@@ -4,7 +4,7 @@ error[E0284]: type annotations needed
 LL | type const X: usize = const { N };
    | ^^^^^^^^^^^^^^^^^^^ cannot infer the value of the constant `_`
    |
-   = note: cannot satisfy `X::{constant#0} == _`
+   = note: cannot satisfy `X::{constant#0}::{constant#0} == _`
 
 error: the constant `"this isn't a usize"` is not of type `usize`
   --> $DIR/type-const-free-anon-const-mismatch.rs:8:1

--- a/tests/ui/const-generics/mgca/type-const-free-value-type-mismatch.next.stderr
+++ b/tests/ui/const-generics/mgca/type-const-free-value-type-mismatch.next.stderr
@@ -10,7 +10,7 @@ error[E0284]: type annotations needed
 LL | fn f() -> [u8; const { N }] {}
    |           ^^^^^^^^^^^^^^^^^ cannot infer the value of the constant `_`
    |
-   = note: cannot satisfy `f::{constant#0} == _`
+   = note: cannot satisfy `f::{constant#0}::{constant#0} == _`
 
 error[E0308]: mismatched types
   --> $DIR/type-const-free-value-type-mismatch.rs:11:11

--- a/tests/ui/const-generics/mgca/type-const-inherent-value-type-mismatch.next.stderr
+++ b/tests/ui/const-generics/mgca/type-const-inherent-value-type-mismatch.next.stderr
@@ -4,7 +4,7 @@ error[E0284]: type annotations needed
 LL | fn f() -> [u8; const { Struct::N }] {}
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer the value of the constant `_`
    |
-   = note: cannot satisfy `f::{constant#0} == _`
+   = note: cannot satisfy `f::{constant#0}::{constant#0} == _`
 
 error: the constant `"this isn't a usize"` is not of type `usize`
   --> $DIR/type-const-inherent-value-type-mismatch.rs:13:5

--- a/tests/ui/const-generics/mgca/type-const-value-type-mismatch.next.stderr
+++ b/tests/ui/const-generics/mgca/type-const-value-type-mismatch.next.stderr
@@ -16,7 +16,7 @@ error[E0284]: type annotations needed
 LL |     fn arr() -> [u8; const { Self::LEN }] {}
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer the value of the constant `_`
    |
-   = note: cannot satisfy `<A as Array>::arr::{constant#0} == _`
+   = note: cannot satisfy `<A as Array>::arr::{constant#0}::{constant#0} == _`
 
 error[E0308]: mismatched types
   --> $DIR/type-const-value-type-mismatch.rs:21:17

--- a/tests/ui/delegation/hir-crate-items-before-lowering-ices.ice_155125.stderr
+++ b/tests/ui/delegation/hir-crate-items-before-lowering-ices.ice_155125.stderr
@@ -9,13 +9,14 @@ LL |                 reuse foo;
    = note: `foo` must be defined only once in the value namespace of this block
 
 error: complex const arguments must be placed inside of a `const` block
-  --> $DIR/hir-crate-items-before-lowering-ices.rs:10:13
+  --> $DIR/hir-crate-items-before-lowering-ices.rs:10:37
    |
-LL | /             {
+LL |               core::direct_const_arg!({
+   |  _____________________________________^
 LL | |                 fn foo() {}
 LL | |                 reuse foo;
 LL | |                 2
-LL | |             },
+LL | |             }),
    | |_____________^
 
 error: aborting due to 2 previous errors

--- a/tests/ui/delegation/hir-crate-items-before-lowering-ices.ice_155164.stderr
+++ b/tests/ui/delegation/hir-crate-items-before-lowering-ices.ice_155164.stderr
@@ -1,12 +1,13 @@
 error: complex const arguments must be placed inside of a `const` block
-  --> $DIR/hir-crate-items-before-lowering-ices.rs:47:13
+  --> $DIR/hir-crate-items-before-lowering-ices.rs:47:37
    |
-LL | /             {
+LL |               core::direct_const_arg!({
+   |  _____________________________________^
 LL | |
 LL | |                 struct W<I>;
 LL | |                 impl<I> W<I> {
 ...  |
-LL | |             },
+LL | |             }),
    | |_____________^
 
 error: aborting due to 1 previous error

--- a/tests/ui/delegation/hir-crate-items-before-lowering-ices.rs
+++ b/tests/ui/delegation/hir-crate-items-before-lowering-ices.rs
@@ -7,11 +7,11 @@ mod ice_155125 {
     struct S<const N: usize>;
     impl
         S<
-            { //[ice_155125]~ ERROR: complex const arguments must be placed inside of a `const` block
+            core::direct_const_arg!({ //[ice_155125]~ ERROR: complex const arguments must be placed inside of a `const` block
                 fn foo() {}
                 reuse foo; //[ice_155125]~ ERROR: the name `foo` is defined multiple times
                 2
-            },
+            }),
         >
     {
     }
@@ -44,13 +44,13 @@ mod ice_155128 {
 mod ice_155164 {
     struct X<const N: usize, F> {
         inner: std::iter::Map<
-            {
+            core::direct_const_arg!({
             //[ice_155164]~^ ERROR: complex const arguments must be placed inside of a `const` block
                 struct W<I>;
                 impl<I> W<I> {
                     reuse Iterator::fold;
                 }
-            },
+            }),
             F,
         >,
     }

--- a/tests/ui/delegation/inside-const-body-ice-155300.rs
+++ b/tests/ui/delegation/inside-const-body-ice-155300.rs
@@ -5,12 +5,13 @@ pub struct S<const N: usize>;
 
 impl
     S<
-        { //~ ERROR: complex const arguments must be placed inside of a `const` block
+        core::direct_const_arg!({
+            //~^ ERROR: complex const arguments must be placed inside of a `const` block
             fn foo() {}
             reuse foo::<> as bar;
             reuse bar;
             //~^ ERROR: the name `bar` is defined multiple times
-        },
+        }),
     >
 {
 }

--- a/tests/ui/delegation/inside-const-body-ice-155300.stderr
+++ b/tests/ui/delegation/inside-const-body-ice-155300.stderr
@@ -1,5 +1,5 @@
 error[E0428]: the name `bar` is defined multiple times
-  --> $DIR/inside-const-body-ice-155300.rs:11:13
+  --> $DIR/inside-const-body-ice-155300.rs:12:13
    |
 LL |             reuse foo::<> as bar;
    |             --------------------- previous definition of the value `bar` here
@@ -9,14 +9,15 @@ LL |             reuse bar;
    = note: `bar` must be defined only once in the value namespace of this block
 
 error: complex const arguments must be placed inside of a `const` block
-  --> $DIR/inside-const-body-ice-155300.rs:8:9
+  --> $DIR/inside-const-body-ice-155300.rs:8:33
    |
-LL | /         {
+LL |           core::direct_const_arg!({
+   |  _________________________________^
+LL | |
 LL | |             fn foo() {}
 LL | |             reuse foo::<> as bar;
-LL | |             reuse bar;
-LL | |
-LL | |         },
+...  |
+LL | |         }),
    | |_________^
 
 error: aborting due to 2 previous errors


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/158617)*
<!-- homu-ignore:end -->

makes good progress on https://github.com/rust-lang/project-const-generics/issues/108

`min_generic_const_args` (mGCA) is all about "is this const lowered to a const item with a body, or, is it "directly" represented and visible in the type system?"

Here's various answers to the question of "can we represent this const arg directly?" - if we answer "no", then we fall back to an anon const (or error, sometimes, depending on context)

on **stable**, the full list of things can be directly represented is (... it's just the one thing)

- paths to generic const parameters

on `main`, under mGCA, **before** this PR:

- absolutely everything, if something cannot be represented directly, compiler error
- `const { }` gives you an escape hatch to go back to being an anon const

on macro**ful** gca, the directly represented things will be:

- paths to const parameters
- `direct_const_arg!` macro

on macro**less** gca, the directly represented things will be:

- paths to const parameters
- `direct_const_arg!` macro (not *particularly* useful under macro**less** gca)
- struct expressions, arrays, blah blah
- currently, paths to *anything*, even if that produces a compiler error later down the line (potential followup work here...)

this PR implements macro**less** gca, with the intent of a quick follow-up introducing a "macroless gca" feature and transitioning `#[feature(min_generic_const_args)]` to be macro**ful** gca

Also of note is that this PR removes the logic to skip generating "fake" DefIds for directly represented AnonConsts under mGCA, we now always generate a DefId when encountering an AnonConst. This lines up with stable, which has a fake AnonConst DefId for a directly represented plain path generic parameter (i.e. the bullet point under the "stable" entry above).

r? @BoxyUwU 