### PR TITLE
disallow `extern "custom"` on wasm and spirv targets

### DIFF
--- a/compiler/rustc_target/src/spec/abi_map.rs
+++ b/compiler/rustc_target/src/spec/abi_map.rs
@@ -62,6 +62,7 @@ impl AbiMap {
             Arch::RiscV32 | Arch::RiscV64 => ArchKind::Riscv,
             Arch::X86 => ArchKind::X86,
             Arch::X86_64 => ArchKind::X86_64,
+            Arch::Wasm32 | Arch::Wasm64 => ArchKind::Wasm,
             _ => ArchKind::Other,
         };
 
@@ -102,8 +103,6 @@ impl AbiMap {
             (ExternAbi::RustPreserveNone, _) => CanonAbi::RustPreserveNone,
             (ExternAbi::RustTail, _) => CanonAbi::RustTail,
 
-            (ExternAbi::Custom, _) => CanonAbi::Custom,
-
             (ExternAbi::Swift, _) => CanonAbi::Swift,
 
             (ExternAbi::System { .. }, ArchKind::X86)
@@ -121,6 +120,9 @@ impl AbiMap {
             /* multi-platform */
             // always and forever
             (ExternAbi::RustInvalid, _) => return AbiMapping::Invalid,
+
+            (ExternAbi::Custom, ArchKind::Wasm) => return AbiMapping::Invalid,
+            (ExternAbi::Custom, _) => CanonAbi::Custom,
 
             (ExternAbi::EfiApi, ArchKind::Arm(..)) => CanonAbi::Arm(ArmCall::Aapcs),
             (ExternAbi::EfiApi, ArchKind::X86_64) => CanonAbi::X86(X86Call::Win64),
@@ -221,6 +223,7 @@ enum ArchKind {
     Riscv,
     X86,
     X86_64,
+    Wasm,
     /// Architectures which don't need other considerations for ABI lowering
     Other,
 }

--- a/compiler/rustc_target/src/spec/abi_map.rs
+++ b/compiler/rustc_target/src/spec/abi_map.rs
@@ -60,9 +60,10 @@ impl AbiMap {
             Arch::Msp430 => ArchKind::Msp430,
             Arch::Nvptx64 => ArchKind::Nvptx,
             Arch::RiscV32 | Arch::RiscV64 => ArchKind::Riscv,
+            Arch::SpirV => ArchKind::Spirv,
+            Arch::Wasm32 | Arch::Wasm64 => ArchKind::Wasm,
             Arch::X86 => ArchKind::X86,
             Arch::X86_64 => ArchKind::X86_64,
-            Arch::Wasm32 | Arch::Wasm64 => ArchKind::Wasm,
             _ => ArchKind::Other,
         };
 
@@ -121,7 +122,7 @@ impl AbiMap {
             // always and forever
             (ExternAbi::RustInvalid, _) => return AbiMapping::Invalid,
 
-            (ExternAbi::Custom, ArchKind::Wasm) => return AbiMapping::Invalid,
+            (ExternAbi::Custom, ArchKind::Wasm | ArchKind::Spirv) => return AbiMapping::Invalid,
             (ExternAbi::Custom, _) => CanonAbi::Custom,
 
             (ExternAbi::EfiApi, ArchKind::Arm(..)) => CanonAbi::Arm(ArmCall::Aapcs),
@@ -224,6 +225,7 @@ enum ArchKind {
     X86,
     X86_64,
     Wasm,
+    Spirv,
     /// Architectures which don't need other considerations for ABI lowering
     Other,
 }

--- a/tests/ui/abi/unsupported.aarch64.stderr
+++ b/tests/ui/abi/unsupported.aarch64.stderr
@@ -1,89 +1,89 @@
 error[E0570]: "ptx-kernel" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:37:8
+  --> $DIR/unsupported.rs:41:8
    |
 LL | extern "ptx-kernel" fn ptx() {}
    |        ^^^^^^^^^^^^
 
 error[E0570]: "ptx-kernel" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:39:22
+  --> $DIR/unsupported.rs:43:22
    |
 LL | fn ptx_ptr(f: extern "ptx-kernel" fn()) {
    |                      ^^^^^^^^^^^^
 
 error[E0570]: "ptx-kernel" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:43:8
+  --> $DIR/unsupported.rs:47:8
    |
 LL | extern "ptx-kernel" {}
    |        ^^^^^^^^^^^^
 
 error[E0570]: "gpu-kernel" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:45:8
+  --> $DIR/unsupported.rs:49:8
    |
 LL | extern "gpu-kernel" fn gpu() {}
    |        ^^^^^^^^^^^^
 
 error[E0570]: "aapcs" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:48:8
+  --> $DIR/unsupported.rs:52:8
    |
 LL | extern "aapcs" fn aapcs() {}
    |        ^^^^^^^
 
 error[E0570]: "aapcs" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:50:24
+  --> $DIR/unsupported.rs:54:24
    |
 LL | fn aapcs_ptr(f: extern "aapcs" fn()) {
    |                        ^^^^^^^
 
 error[E0570]: "aapcs" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:54:8
+  --> $DIR/unsupported.rs:58:8
    |
 LL | extern "aapcs" {}
    |        ^^^^^^^
 
 error[E0570]: "msp430-interrupt" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:57:8
+  --> $DIR/unsupported.rs:61:8
    |
 LL | extern "msp430-interrupt" {}
    |        ^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "avr-interrupt" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:60:8
+  --> $DIR/unsupported.rs:64:8
    |
 LL | extern "avr-interrupt" {}
    |        ^^^^^^^^^^^^^^^
 
 error[E0570]: "riscv-interrupt-m" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:63:8
+  --> $DIR/unsupported.rs:67:8
    |
 LL | extern "riscv-interrupt-m" {}
    |        ^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "x86-interrupt" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:66:8
+  --> $DIR/unsupported.rs:70:8
    |
 LL | extern "x86-interrupt" {}
    |        ^^^^^^^^^^^^^^^
 
 error[E0570]: "thiscall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:69:8
+  --> $DIR/unsupported.rs:73:8
    |
 LL | extern "thiscall" fn thiscall() {}
    |        ^^^^^^^^^^
 
 error[E0570]: "thiscall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:71:27
+  --> $DIR/unsupported.rs:75:27
    |
 LL | fn thiscall_ptr(f: extern "thiscall" fn()) {
    |                           ^^^^^^^^^^
 
 error[E0570]: "thiscall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:75:8
+  --> $DIR/unsupported.rs:79:8
    |
 LL | extern "thiscall" {}
    |        ^^^^^^^^^^
 
 error[E0570]: "stdcall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:78:8
+  --> $DIR/unsupported.rs:82:8
    |
 LL | extern "stdcall" fn stdcall() {}
    |        ^^^^^^^^^
@@ -91,7 +91,7 @@ LL | extern "stdcall" fn stdcall() {}
    = help: if you need `extern "stdcall"` on win32 and `extern "C"` everywhere else, use `extern "system"`
 
 error[E0570]: "stdcall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:82:26
+  --> $DIR/unsupported.rs:86:26
    |
 LL | fn stdcall_ptr(f: extern "stdcall" fn()) {
    |                          ^^^^^^^^^
@@ -99,7 +99,7 @@ LL | fn stdcall_ptr(f: extern "stdcall" fn()) {
    = help: if you need `extern "stdcall"` on win32 and `extern "C"` everywhere else, use `extern "system"`
 
 error[E0570]: "stdcall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:88:8
+  --> $DIR/unsupported.rs:92:8
    |
 LL | extern "stdcall" {}
    |        ^^^^^^^^^
@@ -107,7 +107,7 @@ LL | extern "stdcall" {}
    = help: if you need `extern "stdcall"` on win32 and `extern "C"` everywhere else, use `extern "system"`
 
 error[E0570]: "stdcall-unwind" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:92:8
+  --> $DIR/unsupported.rs:96:8
    |
 LL | extern "stdcall-unwind" {}
    |        ^^^^^^^^^^^^^^^^
@@ -115,49 +115,49 @@ LL | extern "stdcall-unwind" {}
    = help: if you need `extern "stdcall-unwind"` on win32 and `extern "C-unwind"` everywhere else, use `extern "system-unwind"`
 
 error[E0570]: "vectorcall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:112:8
+  --> $DIR/unsupported.rs:116:8
    |
 LL | extern "vectorcall" fn vectorcall() {}
    |        ^^^^^^^^^^^^
 
 error[E0570]: "vectorcall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:114:29
+  --> $DIR/unsupported.rs:118:29
    |
 LL | fn vectorcall_ptr(f: extern "vectorcall" fn()) {
    |                             ^^^^^^^^^^^^
 
 error[E0570]: "vectorcall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:118:8
+  --> $DIR/unsupported.rs:122:8
    |
 LL | extern "vectorcall" {}
    |        ^^^^^^^^^^^^
 
 error[E0570]: "cmse-nonsecure-call" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:121:28
+  --> $DIR/unsupported.rs:125:28
    |
 LL | fn cmse_call_ptr(f: extern "cmse-nonsecure-call" fn()) {
    |                            ^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "cmse-nonsecure-entry" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:126:8
+  --> $DIR/unsupported.rs:130:8
    |
 LL | extern "cmse-nonsecure-entry" fn cmse_entry() {}
    |        ^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "cmse-nonsecure-entry" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:128:29
+  --> $DIR/unsupported.rs:132:29
    |
 LL | fn cmse_entry_ptr(f: extern "cmse-nonsecure-entry" fn()) {
    |                             ^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "cmse-nonsecure-entry" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:132:8
+  --> $DIR/unsupported.rs:136:8
    |
 LL | extern "cmse-nonsecure-entry" {}
    |        ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: "cdecl" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:100:17
+  --> $DIR/unsupported.rs:104:17
    |
 LL | fn cdecl_ptr(f: extern "cdecl" fn()) {
    |                 ^^^^^^^^^^^^^^^^^^^
@@ -168,7 +168,7 @@ LL | fn cdecl_ptr(f: extern "cdecl" fn()) {
    = note: `#[warn(unsupported_calling_conventions)]` (part of `#[warn(future_incompatible)]`) on by default
 
 warning: "cdecl" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:105:1
+  --> $DIR/unsupported.rs:109:1
    |
 LL | extern "cdecl" {}
    | ^^^^^^^^^^^^^^^^^
@@ -178,7 +178,7 @@ LL | extern "cdecl" {}
    = note: for more information, see issue #137018 <https://github.com/rust-lang/rust/issues/137018>
 
 warning: "cdecl-unwind" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:108:1
+  --> $DIR/unsupported.rs:112:1
    |
 LL | extern "cdecl-unwind" {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -188,7 +188,7 @@ LL | extern "cdecl-unwind" {}
    = note: for more information, see issue #137018 <https://github.com/rust-lang/rust/issues/137018>
 
 warning: "cdecl" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:97:1
+  --> $DIR/unsupported.rs:101:1
    |
 LL | extern "cdecl" fn cdecl() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/abi/unsupported.aarch64.stderr
+++ b/tests/ui/abi/unsupported.aarch64.stderr
@@ -1,89 +1,89 @@
 error[E0570]: "ptx-kernel" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:41:8
+  --> $DIR/unsupported.rs:42:8
    |
 LL | extern "ptx-kernel" fn ptx() {}
    |        ^^^^^^^^^^^^
 
 error[E0570]: "ptx-kernel" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:43:22
+  --> $DIR/unsupported.rs:44:22
    |
 LL | fn ptx_ptr(f: extern "ptx-kernel" fn()) {
    |                      ^^^^^^^^^^^^
 
 error[E0570]: "ptx-kernel" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:47:8
+  --> $DIR/unsupported.rs:48:8
    |
 LL | extern "ptx-kernel" {}
    |        ^^^^^^^^^^^^
 
 error[E0570]: "gpu-kernel" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:49:8
+  --> $DIR/unsupported.rs:50:8
    |
 LL | extern "gpu-kernel" fn gpu() {}
    |        ^^^^^^^^^^^^
 
 error[E0570]: "aapcs" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:52:8
+  --> $DIR/unsupported.rs:53:8
    |
 LL | extern "aapcs" fn aapcs() {}
    |        ^^^^^^^
 
 error[E0570]: "aapcs" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:54:24
+  --> $DIR/unsupported.rs:55:24
    |
 LL | fn aapcs_ptr(f: extern "aapcs" fn()) {
    |                        ^^^^^^^
 
 error[E0570]: "aapcs" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:58:8
+  --> $DIR/unsupported.rs:59:8
    |
 LL | extern "aapcs" {}
    |        ^^^^^^^
 
 error[E0570]: "msp430-interrupt" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:61:8
+  --> $DIR/unsupported.rs:62:8
    |
 LL | extern "msp430-interrupt" {}
    |        ^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "avr-interrupt" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:64:8
+  --> $DIR/unsupported.rs:65:8
    |
 LL | extern "avr-interrupt" {}
    |        ^^^^^^^^^^^^^^^
 
 error[E0570]: "riscv-interrupt-m" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:67:8
+  --> $DIR/unsupported.rs:68:8
    |
 LL | extern "riscv-interrupt-m" {}
    |        ^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "x86-interrupt" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:70:8
+  --> $DIR/unsupported.rs:71:8
    |
 LL | extern "x86-interrupt" {}
    |        ^^^^^^^^^^^^^^^
 
 error[E0570]: "thiscall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:73:8
+  --> $DIR/unsupported.rs:74:8
    |
 LL | extern "thiscall" fn thiscall() {}
    |        ^^^^^^^^^^
 
 error[E0570]: "thiscall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:75:27
+  --> $DIR/unsupported.rs:76:27
    |
 LL | fn thiscall_ptr(f: extern "thiscall" fn()) {
    |                           ^^^^^^^^^^
 
 error[E0570]: "thiscall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:79:8
+  --> $DIR/unsupported.rs:80:8
    |
 LL | extern "thiscall" {}
    |        ^^^^^^^^^^
 
 error[E0570]: "stdcall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:82:8
+  --> $DIR/unsupported.rs:83:8
    |
 LL | extern "stdcall" fn stdcall() {}
    |        ^^^^^^^^^
@@ -91,7 +91,7 @@ LL | extern "stdcall" fn stdcall() {}
    = help: if you need `extern "stdcall"` on win32 and `extern "C"` everywhere else, use `extern "system"`
 
 error[E0570]: "stdcall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:86:26
+  --> $DIR/unsupported.rs:87:26
    |
 LL | fn stdcall_ptr(f: extern "stdcall" fn()) {
    |                          ^^^^^^^^^
@@ -99,7 +99,7 @@ LL | fn stdcall_ptr(f: extern "stdcall" fn()) {
    = help: if you need `extern "stdcall"` on win32 and `extern "C"` everywhere else, use `extern "system"`
 
 error[E0570]: "stdcall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:92:8
+  --> $DIR/unsupported.rs:93:8
    |
 LL | extern "stdcall" {}
    |        ^^^^^^^^^
@@ -107,7 +107,7 @@ LL | extern "stdcall" {}
    = help: if you need `extern "stdcall"` on win32 and `extern "C"` everywhere else, use `extern "system"`
 
 error[E0570]: "stdcall-unwind" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:96:8
+  --> $DIR/unsupported.rs:97:8
    |
 LL | extern "stdcall-unwind" {}
    |        ^^^^^^^^^^^^^^^^
@@ -115,49 +115,49 @@ LL | extern "stdcall-unwind" {}
    = help: if you need `extern "stdcall-unwind"` on win32 and `extern "C-unwind"` everywhere else, use `extern "system-unwind"`
 
 error[E0570]: "vectorcall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:116:8
+  --> $DIR/unsupported.rs:117:8
    |
 LL | extern "vectorcall" fn vectorcall() {}
    |        ^^^^^^^^^^^^
 
 error[E0570]: "vectorcall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:118:29
+  --> $DIR/unsupported.rs:119:29
    |
 LL | fn vectorcall_ptr(f: extern "vectorcall" fn()) {
    |                             ^^^^^^^^^^^^
 
 error[E0570]: "vectorcall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:122:8
+  --> $DIR/unsupported.rs:123:8
    |
 LL | extern "vectorcall" {}
    |        ^^^^^^^^^^^^
 
 error[E0570]: "cmse-nonsecure-call" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:125:28
+  --> $DIR/unsupported.rs:126:28
    |
 LL | fn cmse_call_ptr(f: extern "cmse-nonsecure-call" fn()) {
    |                            ^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "cmse-nonsecure-entry" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:130:8
+  --> $DIR/unsupported.rs:131:8
    |
 LL | extern "cmse-nonsecure-entry" fn cmse_entry() {}
    |        ^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "cmse-nonsecure-entry" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:132:29
+  --> $DIR/unsupported.rs:133:29
    |
 LL | fn cmse_entry_ptr(f: extern "cmse-nonsecure-entry" fn()) {
    |                             ^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "cmse-nonsecure-entry" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:136:8
+  --> $DIR/unsupported.rs:137:8
    |
 LL | extern "cmse-nonsecure-entry" {}
    |        ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: "cdecl" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:104:17
+  --> $DIR/unsupported.rs:105:17
    |
 LL | fn cdecl_ptr(f: extern "cdecl" fn()) {
    |                 ^^^^^^^^^^^^^^^^^^^
@@ -168,7 +168,7 @@ LL | fn cdecl_ptr(f: extern "cdecl" fn()) {
    = note: `#[warn(unsupported_calling_conventions)]` (part of `#[warn(future_incompatible)]`) on by default
 
 warning: "cdecl" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:109:1
+  --> $DIR/unsupported.rs:110:1
    |
 LL | extern "cdecl" {}
    | ^^^^^^^^^^^^^^^^^
@@ -178,7 +178,7 @@ LL | extern "cdecl" {}
    = note: for more information, see issue #137018 <https://github.com/rust-lang/rust/issues/137018>
 
 warning: "cdecl-unwind" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:112:1
+  --> $DIR/unsupported.rs:113:1
    |
 LL | extern "cdecl-unwind" {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -188,7 +188,7 @@ LL | extern "cdecl-unwind" {}
    = note: for more information, see issue #137018 <https://github.com/rust-lang/rust/issues/137018>
 
 warning: "cdecl" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:101:1
+  --> $DIR/unsupported.rs:102:1
    |
 LL | extern "cdecl" fn cdecl() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/abi/unsupported.arm.stderr
+++ b/tests/ui/abi/unsupported.arm.stderr
@@ -1,71 +1,71 @@
 error[E0570]: "ptx-kernel" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:37:8
+  --> $DIR/unsupported.rs:41:8
    |
 LL | extern "ptx-kernel" fn ptx() {}
    |        ^^^^^^^^^^^^
 
 error[E0570]: "ptx-kernel" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:39:22
+  --> $DIR/unsupported.rs:43:22
    |
 LL | fn ptx_ptr(f: extern "ptx-kernel" fn()) {
    |                      ^^^^^^^^^^^^
 
 error[E0570]: "ptx-kernel" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:43:8
+  --> $DIR/unsupported.rs:47:8
    |
 LL | extern "ptx-kernel" {}
    |        ^^^^^^^^^^^^
 
 error[E0570]: "gpu-kernel" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:45:8
+  --> $DIR/unsupported.rs:49:8
    |
 LL | extern "gpu-kernel" fn gpu() {}
    |        ^^^^^^^^^^^^
 
 error[E0570]: "msp430-interrupt" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:57:8
+  --> $DIR/unsupported.rs:61:8
    |
 LL | extern "msp430-interrupt" {}
    |        ^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "avr-interrupt" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:60:8
+  --> $DIR/unsupported.rs:64:8
    |
 LL | extern "avr-interrupt" {}
    |        ^^^^^^^^^^^^^^^
 
 error[E0570]: "riscv-interrupt-m" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:63:8
+  --> $DIR/unsupported.rs:67:8
    |
 LL | extern "riscv-interrupt-m" {}
    |        ^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "x86-interrupt" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:66:8
+  --> $DIR/unsupported.rs:70:8
    |
 LL | extern "x86-interrupt" {}
    |        ^^^^^^^^^^^^^^^
 
 error[E0570]: "thiscall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:69:8
+  --> $DIR/unsupported.rs:73:8
    |
 LL | extern "thiscall" fn thiscall() {}
    |        ^^^^^^^^^^
 
 error[E0570]: "thiscall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:71:27
+  --> $DIR/unsupported.rs:75:27
    |
 LL | fn thiscall_ptr(f: extern "thiscall" fn()) {
    |                           ^^^^^^^^^^
 
 error[E0570]: "thiscall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:75:8
+  --> $DIR/unsupported.rs:79:8
    |
 LL | extern "thiscall" {}
    |        ^^^^^^^^^^
 
 error[E0570]: "stdcall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:78:8
+  --> $DIR/unsupported.rs:82:8
    |
 LL | extern "stdcall" fn stdcall() {}
    |        ^^^^^^^^^
@@ -73,7 +73,7 @@ LL | extern "stdcall" fn stdcall() {}
    = help: if you need `extern "stdcall"` on win32 and `extern "C"` everywhere else, use `extern "system"`
 
 error[E0570]: "stdcall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:82:26
+  --> $DIR/unsupported.rs:86:26
    |
 LL | fn stdcall_ptr(f: extern "stdcall" fn()) {
    |                          ^^^^^^^^^
@@ -81,7 +81,7 @@ LL | fn stdcall_ptr(f: extern "stdcall" fn()) {
    = help: if you need `extern "stdcall"` on win32 and `extern "C"` everywhere else, use `extern "system"`
 
 error[E0570]: "stdcall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:88:8
+  --> $DIR/unsupported.rs:92:8
    |
 LL | extern "stdcall" {}
    |        ^^^^^^^^^
@@ -89,7 +89,7 @@ LL | extern "stdcall" {}
    = help: if you need `extern "stdcall"` on win32 and `extern "C"` everywhere else, use `extern "system"`
 
 error[E0570]: "stdcall-unwind" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:92:8
+  --> $DIR/unsupported.rs:96:8
    |
 LL | extern "stdcall-unwind" {}
    |        ^^^^^^^^^^^^^^^^
@@ -97,49 +97,49 @@ LL | extern "stdcall-unwind" {}
    = help: if you need `extern "stdcall-unwind"` on win32 and `extern "C-unwind"` everywhere else, use `extern "system-unwind"`
 
 error[E0570]: "vectorcall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:112:8
+  --> $DIR/unsupported.rs:116:8
    |
 LL | extern "vectorcall" fn vectorcall() {}
    |        ^^^^^^^^^^^^
 
 error[E0570]: "vectorcall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:114:29
+  --> $DIR/unsupported.rs:118:29
    |
 LL | fn vectorcall_ptr(f: extern "vectorcall" fn()) {
    |                             ^^^^^^^^^^^^
 
 error[E0570]: "vectorcall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:118:8
+  --> $DIR/unsupported.rs:122:8
    |
 LL | extern "vectorcall" {}
    |        ^^^^^^^^^^^^
 
 error[E0570]: "cmse-nonsecure-call" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:121:28
+  --> $DIR/unsupported.rs:125:28
    |
 LL | fn cmse_call_ptr(f: extern "cmse-nonsecure-call" fn()) {
    |                            ^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "cmse-nonsecure-entry" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:126:8
+  --> $DIR/unsupported.rs:130:8
    |
 LL | extern "cmse-nonsecure-entry" fn cmse_entry() {}
    |        ^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "cmse-nonsecure-entry" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:128:29
+  --> $DIR/unsupported.rs:132:29
    |
 LL | fn cmse_entry_ptr(f: extern "cmse-nonsecure-entry" fn()) {
    |                             ^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "cmse-nonsecure-entry" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:132:8
+  --> $DIR/unsupported.rs:136:8
    |
 LL | extern "cmse-nonsecure-entry" {}
    |        ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: "cdecl" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:100:17
+  --> $DIR/unsupported.rs:104:17
    |
 LL | fn cdecl_ptr(f: extern "cdecl" fn()) {
    |                 ^^^^^^^^^^^^^^^^^^^
@@ -150,7 +150,7 @@ LL | fn cdecl_ptr(f: extern "cdecl" fn()) {
    = note: `#[warn(unsupported_calling_conventions)]` (part of `#[warn(future_incompatible)]`) on by default
 
 warning: "cdecl" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:105:1
+  --> $DIR/unsupported.rs:109:1
    |
 LL | extern "cdecl" {}
    | ^^^^^^^^^^^^^^^^^
@@ -160,7 +160,7 @@ LL | extern "cdecl" {}
    = note: for more information, see issue #137018 <https://github.com/rust-lang/rust/issues/137018>
 
 warning: "cdecl-unwind" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:108:1
+  --> $DIR/unsupported.rs:112:1
    |
 LL | extern "cdecl-unwind" {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -170,7 +170,7 @@ LL | extern "cdecl-unwind" {}
    = note: for more information, see issue #137018 <https://github.com/rust-lang/rust/issues/137018>
 
 warning: "cdecl" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:97:1
+  --> $DIR/unsupported.rs:101:1
    |
 LL | extern "cdecl" fn cdecl() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/abi/unsupported.arm.stderr
+++ b/tests/ui/abi/unsupported.arm.stderr
@@ -1,71 +1,71 @@
 error[E0570]: "ptx-kernel" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:41:8
+  --> $DIR/unsupported.rs:42:8
    |
 LL | extern "ptx-kernel" fn ptx() {}
    |        ^^^^^^^^^^^^
 
 error[E0570]: "ptx-kernel" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:43:22
+  --> $DIR/unsupported.rs:44:22
    |
 LL | fn ptx_ptr(f: extern "ptx-kernel" fn()) {
    |                      ^^^^^^^^^^^^
 
 error[E0570]: "ptx-kernel" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:47:8
+  --> $DIR/unsupported.rs:48:8
    |
 LL | extern "ptx-kernel" {}
    |        ^^^^^^^^^^^^
 
 error[E0570]: "gpu-kernel" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:49:8
+  --> $DIR/unsupported.rs:50:8
    |
 LL | extern "gpu-kernel" fn gpu() {}
    |        ^^^^^^^^^^^^
 
 error[E0570]: "msp430-interrupt" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:61:8
+  --> $DIR/unsupported.rs:62:8
    |
 LL | extern "msp430-interrupt" {}
    |        ^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "avr-interrupt" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:64:8
+  --> $DIR/unsupported.rs:65:8
    |
 LL | extern "avr-interrupt" {}
    |        ^^^^^^^^^^^^^^^
 
 error[E0570]: "riscv-interrupt-m" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:67:8
+  --> $DIR/unsupported.rs:68:8
    |
 LL | extern "riscv-interrupt-m" {}
    |        ^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "x86-interrupt" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:70:8
+  --> $DIR/unsupported.rs:71:8
    |
 LL | extern "x86-interrupt" {}
    |        ^^^^^^^^^^^^^^^
 
 error[E0570]: "thiscall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:73:8
+  --> $DIR/unsupported.rs:74:8
    |
 LL | extern "thiscall" fn thiscall() {}
    |        ^^^^^^^^^^
 
 error[E0570]: "thiscall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:75:27
+  --> $DIR/unsupported.rs:76:27
    |
 LL | fn thiscall_ptr(f: extern "thiscall" fn()) {
    |                           ^^^^^^^^^^
 
 error[E0570]: "thiscall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:79:8
+  --> $DIR/unsupported.rs:80:8
    |
 LL | extern "thiscall" {}
    |        ^^^^^^^^^^
 
 error[E0570]: "stdcall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:82:8
+  --> $DIR/unsupported.rs:83:8
    |
 LL | extern "stdcall" fn stdcall() {}
    |        ^^^^^^^^^
@@ -73,7 +73,7 @@ LL | extern "stdcall" fn stdcall() {}
    = help: if you need `extern "stdcall"` on win32 and `extern "C"` everywhere else, use `extern "system"`
 
 error[E0570]: "stdcall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:86:26
+  --> $DIR/unsupported.rs:87:26
    |
 LL | fn stdcall_ptr(f: extern "stdcall" fn()) {
    |                          ^^^^^^^^^
@@ -81,7 +81,7 @@ LL | fn stdcall_ptr(f: extern "stdcall" fn()) {
    = help: if you need `extern "stdcall"` on win32 and `extern "C"` everywhere else, use `extern "system"`
 
 error[E0570]: "stdcall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:92:8
+  --> $DIR/unsupported.rs:93:8
    |
 LL | extern "stdcall" {}
    |        ^^^^^^^^^
@@ -89,7 +89,7 @@ LL | extern "stdcall" {}
    = help: if you need `extern "stdcall"` on win32 and `extern "C"` everywhere else, use `extern "system"`
 
 error[E0570]: "stdcall-unwind" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:96:8
+  --> $DIR/unsupported.rs:97:8
    |
 LL | extern "stdcall-unwind" {}
    |        ^^^^^^^^^^^^^^^^
@@ -97,49 +97,49 @@ LL | extern "stdcall-unwind" {}
    = help: if you need `extern "stdcall-unwind"` on win32 and `extern "C-unwind"` everywhere else, use `extern "system-unwind"`
 
 error[E0570]: "vectorcall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:116:8
+  --> $DIR/unsupported.rs:117:8
    |
 LL | extern "vectorcall" fn vectorcall() {}
    |        ^^^^^^^^^^^^
 
 error[E0570]: "vectorcall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:118:29
+  --> $DIR/unsupported.rs:119:29
    |
 LL | fn vectorcall_ptr(f: extern "vectorcall" fn()) {
    |                             ^^^^^^^^^^^^
 
 error[E0570]: "vectorcall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:122:8
+  --> $DIR/unsupported.rs:123:8
    |
 LL | extern "vectorcall" {}
    |        ^^^^^^^^^^^^
 
 error[E0570]: "cmse-nonsecure-call" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:125:28
+  --> $DIR/unsupported.rs:126:28
    |
 LL | fn cmse_call_ptr(f: extern "cmse-nonsecure-call" fn()) {
    |                            ^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "cmse-nonsecure-entry" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:130:8
+  --> $DIR/unsupported.rs:131:8
    |
 LL | extern "cmse-nonsecure-entry" fn cmse_entry() {}
    |        ^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "cmse-nonsecure-entry" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:132:29
+  --> $DIR/unsupported.rs:133:29
    |
 LL | fn cmse_entry_ptr(f: extern "cmse-nonsecure-entry" fn()) {
    |                             ^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "cmse-nonsecure-entry" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:136:8
+  --> $DIR/unsupported.rs:137:8
    |
 LL | extern "cmse-nonsecure-entry" {}
    |        ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: "cdecl" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:104:17
+  --> $DIR/unsupported.rs:105:17
    |
 LL | fn cdecl_ptr(f: extern "cdecl" fn()) {
    |                 ^^^^^^^^^^^^^^^^^^^
@@ -150,7 +150,7 @@ LL | fn cdecl_ptr(f: extern "cdecl" fn()) {
    = note: `#[warn(unsupported_calling_conventions)]` (part of `#[warn(future_incompatible)]`) on by default
 
 warning: "cdecl" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:109:1
+  --> $DIR/unsupported.rs:110:1
    |
 LL | extern "cdecl" {}
    | ^^^^^^^^^^^^^^^^^
@@ -160,7 +160,7 @@ LL | extern "cdecl" {}
    = note: for more information, see issue #137018 <https://github.com/rust-lang/rust/issues/137018>
 
 warning: "cdecl-unwind" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:112:1
+  --> $DIR/unsupported.rs:113:1
    |
 LL | extern "cdecl-unwind" {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -170,7 +170,7 @@ LL | extern "cdecl-unwind" {}
    = note: for more information, see issue #137018 <https://github.com/rust-lang/rust/issues/137018>
 
 warning: "cdecl" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:101:1
+  --> $DIR/unsupported.rs:102:1
    |
 LL | extern "cdecl" fn cdecl() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/abi/unsupported.i686.stderr
+++ b/tests/ui/abi/unsupported.i686.stderr
@@ -1,83 +1,83 @@
 error[E0570]: "ptx-kernel" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:37:8
+  --> $DIR/unsupported.rs:41:8
    |
 LL | extern "ptx-kernel" fn ptx() {}
    |        ^^^^^^^^^^^^
 
 error[E0570]: "ptx-kernel" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:39:22
+  --> $DIR/unsupported.rs:43:22
    |
 LL | fn ptx_ptr(f: extern "ptx-kernel" fn()) {
    |                      ^^^^^^^^^^^^
 
 error[E0570]: "ptx-kernel" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:43:8
+  --> $DIR/unsupported.rs:47:8
    |
 LL | extern "ptx-kernel" {}
    |        ^^^^^^^^^^^^
 
 error[E0570]: "gpu-kernel" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:45:8
+  --> $DIR/unsupported.rs:49:8
    |
 LL | extern "gpu-kernel" fn gpu() {}
    |        ^^^^^^^^^^^^
 
 error[E0570]: "aapcs" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:48:8
+  --> $DIR/unsupported.rs:52:8
    |
 LL | extern "aapcs" fn aapcs() {}
    |        ^^^^^^^
 
 error[E0570]: "aapcs" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:50:24
+  --> $DIR/unsupported.rs:54:24
    |
 LL | fn aapcs_ptr(f: extern "aapcs" fn()) {
    |                        ^^^^^^^
 
 error[E0570]: "aapcs" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:54:8
+  --> $DIR/unsupported.rs:58:8
    |
 LL | extern "aapcs" {}
    |        ^^^^^^^
 
 error[E0570]: "msp430-interrupt" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:57:8
+  --> $DIR/unsupported.rs:61:8
    |
 LL | extern "msp430-interrupt" {}
    |        ^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "avr-interrupt" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:60:8
+  --> $DIR/unsupported.rs:64:8
    |
 LL | extern "avr-interrupt" {}
    |        ^^^^^^^^^^^^^^^
 
 error[E0570]: "riscv-interrupt-m" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:63:8
+  --> $DIR/unsupported.rs:67:8
    |
 LL | extern "riscv-interrupt-m" {}
    |        ^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "cmse-nonsecure-call" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:121:28
+  --> $DIR/unsupported.rs:125:28
    |
 LL | fn cmse_call_ptr(f: extern "cmse-nonsecure-call" fn()) {
    |                            ^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "cmse-nonsecure-entry" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:126:8
+  --> $DIR/unsupported.rs:130:8
    |
 LL | extern "cmse-nonsecure-entry" fn cmse_entry() {}
    |        ^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "cmse-nonsecure-entry" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:128:29
+  --> $DIR/unsupported.rs:132:29
    |
 LL | fn cmse_entry_ptr(f: extern "cmse-nonsecure-entry" fn()) {
    |                             ^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "cmse-nonsecure-entry" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:132:8
+  --> $DIR/unsupported.rs:136:8
    |
 LL | extern "cmse-nonsecure-entry" {}
    |        ^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/abi/unsupported.i686.stderr
+++ b/tests/ui/abi/unsupported.i686.stderr
@@ -1,83 +1,83 @@
 error[E0570]: "ptx-kernel" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:41:8
+  --> $DIR/unsupported.rs:42:8
    |
 LL | extern "ptx-kernel" fn ptx() {}
    |        ^^^^^^^^^^^^
 
 error[E0570]: "ptx-kernel" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:43:22
+  --> $DIR/unsupported.rs:44:22
    |
 LL | fn ptx_ptr(f: extern "ptx-kernel" fn()) {
    |                      ^^^^^^^^^^^^
 
 error[E0570]: "ptx-kernel" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:47:8
+  --> $DIR/unsupported.rs:48:8
    |
 LL | extern "ptx-kernel" {}
    |        ^^^^^^^^^^^^
 
 error[E0570]: "gpu-kernel" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:49:8
+  --> $DIR/unsupported.rs:50:8
    |
 LL | extern "gpu-kernel" fn gpu() {}
    |        ^^^^^^^^^^^^
 
 error[E0570]: "aapcs" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:52:8
+  --> $DIR/unsupported.rs:53:8
    |
 LL | extern "aapcs" fn aapcs() {}
    |        ^^^^^^^
 
 error[E0570]: "aapcs" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:54:24
+  --> $DIR/unsupported.rs:55:24
    |
 LL | fn aapcs_ptr(f: extern "aapcs" fn()) {
    |                        ^^^^^^^
 
 error[E0570]: "aapcs" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:58:8
+  --> $DIR/unsupported.rs:59:8
    |
 LL | extern "aapcs" {}
    |        ^^^^^^^
 
 error[E0570]: "msp430-interrupt" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:61:8
+  --> $DIR/unsupported.rs:62:8
    |
 LL | extern "msp430-interrupt" {}
    |        ^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "avr-interrupt" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:64:8
+  --> $DIR/unsupported.rs:65:8
    |
 LL | extern "avr-interrupt" {}
    |        ^^^^^^^^^^^^^^^
 
 error[E0570]: "riscv-interrupt-m" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:67:8
+  --> $DIR/unsupported.rs:68:8
    |
 LL | extern "riscv-interrupt-m" {}
    |        ^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "cmse-nonsecure-call" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:125:28
+  --> $DIR/unsupported.rs:126:28
    |
 LL | fn cmse_call_ptr(f: extern "cmse-nonsecure-call" fn()) {
    |                            ^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "cmse-nonsecure-entry" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:130:8
+  --> $DIR/unsupported.rs:131:8
    |
 LL | extern "cmse-nonsecure-entry" fn cmse_entry() {}
    |        ^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "cmse-nonsecure-entry" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:132:29
+  --> $DIR/unsupported.rs:133:29
    |
 LL | fn cmse_entry_ptr(f: extern "cmse-nonsecure-entry" fn()) {
    |                             ^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "cmse-nonsecure-entry" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:136:8
+  --> $DIR/unsupported.rs:137:8
    |
 LL | extern "cmse-nonsecure-entry" {}
    |        ^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/abi/unsupported.riscv32.stderr
+++ b/tests/ui/abi/unsupported.riscv32.stderr
@@ -1,83 +1,83 @@
 error[E0570]: "ptx-kernel" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:37:8
+  --> $DIR/unsupported.rs:41:8
    |
 LL | extern "ptx-kernel" fn ptx() {}
    |        ^^^^^^^^^^^^
 
 error[E0570]: "ptx-kernel" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:39:22
+  --> $DIR/unsupported.rs:43:22
    |
 LL | fn ptx_ptr(f: extern "ptx-kernel" fn()) {
    |                      ^^^^^^^^^^^^
 
 error[E0570]: "ptx-kernel" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:43:8
+  --> $DIR/unsupported.rs:47:8
    |
 LL | extern "ptx-kernel" {}
    |        ^^^^^^^^^^^^
 
 error[E0570]: "gpu-kernel" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:45:8
+  --> $DIR/unsupported.rs:49:8
    |
 LL | extern "gpu-kernel" fn gpu() {}
    |        ^^^^^^^^^^^^
 
 error[E0570]: "aapcs" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:48:8
+  --> $DIR/unsupported.rs:52:8
    |
 LL | extern "aapcs" fn aapcs() {}
    |        ^^^^^^^
 
 error[E0570]: "aapcs" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:50:24
+  --> $DIR/unsupported.rs:54:24
    |
 LL | fn aapcs_ptr(f: extern "aapcs" fn()) {
    |                        ^^^^^^^
 
 error[E0570]: "aapcs" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:54:8
+  --> $DIR/unsupported.rs:58:8
    |
 LL | extern "aapcs" {}
    |        ^^^^^^^
 
 error[E0570]: "msp430-interrupt" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:57:8
+  --> $DIR/unsupported.rs:61:8
    |
 LL | extern "msp430-interrupt" {}
    |        ^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "avr-interrupt" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:60:8
+  --> $DIR/unsupported.rs:64:8
    |
 LL | extern "avr-interrupt" {}
    |        ^^^^^^^^^^^^^^^
 
 error[E0570]: "x86-interrupt" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:66:8
+  --> $DIR/unsupported.rs:70:8
    |
 LL | extern "x86-interrupt" {}
    |        ^^^^^^^^^^^^^^^
 
 error[E0570]: "thiscall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:69:8
+  --> $DIR/unsupported.rs:73:8
    |
 LL | extern "thiscall" fn thiscall() {}
    |        ^^^^^^^^^^
 
 error[E0570]: "thiscall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:71:27
+  --> $DIR/unsupported.rs:75:27
    |
 LL | fn thiscall_ptr(f: extern "thiscall" fn()) {
    |                           ^^^^^^^^^^
 
 error[E0570]: "thiscall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:75:8
+  --> $DIR/unsupported.rs:79:8
    |
 LL | extern "thiscall" {}
    |        ^^^^^^^^^^
 
 error[E0570]: "stdcall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:78:8
+  --> $DIR/unsupported.rs:82:8
    |
 LL | extern "stdcall" fn stdcall() {}
    |        ^^^^^^^^^
@@ -85,7 +85,7 @@ LL | extern "stdcall" fn stdcall() {}
    = help: if you need `extern "stdcall"` on win32 and `extern "C"` everywhere else, use `extern "system"`
 
 error[E0570]: "stdcall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:82:26
+  --> $DIR/unsupported.rs:86:26
    |
 LL | fn stdcall_ptr(f: extern "stdcall" fn()) {
    |                          ^^^^^^^^^
@@ -93,7 +93,7 @@ LL | fn stdcall_ptr(f: extern "stdcall" fn()) {
    = help: if you need `extern "stdcall"` on win32 and `extern "C"` everywhere else, use `extern "system"`
 
 error[E0570]: "stdcall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:88:8
+  --> $DIR/unsupported.rs:92:8
    |
 LL | extern "stdcall" {}
    |        ^^^^^^^^^
@@ -101,7 +101,7 @@ LL | extern "stdcall" {}
    = help: if you need `extern "stdcall"` on win32 and `extern "C"` everywhere else, use `extern "system"`
 
 error[E0570]: "stdcall-unwind" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:92:8
+  --> $DIR/unsupported.rs:96:8
    |
 LL | extern "stdcall-unwind" {}
    |        ^^^^^^^^^^^^^^^^
@@ -109,49 +109,49 @@ LL | extern "stdcall-unwind" {}
    = help: if you need `extern "stdcall-unwind"` on win32 and `extern "C-unwind"` everywhere else, use `extern "system-unwind"`
 
 error[E0570]: "vectorcall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:112:8
+  --> $DIR/unsupported.rs:116:8
    |
 LL | extern "vectorcall" fn vectorcall() {}
    |        ^^^^^^^^^^^^
 
 error[E0570]: "vectorcall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:114:29
+  --> $DIR/unsupported.rs:118:29
    |
 LL | fn vectorcall_ptr(f: extern "vectorcall" fn()) {
    |                             ^^^^^^^^^^^^
 
 error[E0570]: "vectorcall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:118:8
+  --> $DIR/unsupported.rs:122:8
    |
 LL | extern "vectorcall" {}
    |        ^^^^^^^^^^^^
 
 error[E0570]: "cmse-nonsecure-call" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:121:28
+  --> $DIR/unsupported.rs:125:28
    |
 LL | fn cmse_call_ptr(f: extern "cmse-nonsecure-call" fn()) {
    |                            ^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "cmse-nonsecure-entry" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:126:8
+  --> $DIR/unsupported.rs:130:8
    |
 LL | extern "cmse-nonsecure-entry" fn cmse_entry() {}
    |        ^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "cmse-nonsecure-entry" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:128:29
+  --> $DIR/unsupported.rs:132:29
    |
 LL | fn cmse_entry_ptr(f: extern "cmse-nonsecure-entry" fn()) {
    |                             ^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "cmse-nonsecure-entry" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:132:8
+  --> $DIR/unsupported.rs:136:8
    |
 LL | extern "cmse-nonsecure-entry" {}
    |        ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: "cdecl" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:100:17
+  --> $DIR/unsupported.rs:104:17
    |
 LL | fn cdecl_ptr(f: extern "cdecl" fn()) {
    |                 ^^^^^^^^^^^^^^^^^^^
@@ -162,7 +162,7 @@ LL | fn cdecl_ptr(f: extern "cdecl" fn()) {
    = note: `#[warn(unsupported_calling_conventions)]` (part of `#[warn(future_incompatible)]`) on by default
 
 warning: "cdecl" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:105:1
+  --> $DIR/unsupported.rs:109:1
    |
 LL | extern "cdecl" {}
    | ^^^^^^^^^^^^^^^^^
@@ -172,7 +172,7 @@ LL | extern "cdecl" {}
    = note: for more information, see issue #137018 <https://github.com/rust-lang/rust/issues/137018>
 
 warning: "cdecl-unwind" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:108:1
+  --> $DIR/unsupported.rs:112:1
    |
 LL | extern "cdecl-unwind" {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -182,7 +182,7 @@ LL | extern "cdecl-unwind" {}
    = note: for more information, see issue #137018 <https://github.com/rust-lang/rust/issues/137018>
 
 warning: "cdecl" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:97:1
+  --> $DIR/unsupported.rs:101:1
    |
 LL | extern "cdecl" fn cdecl() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/abi/unsupported.riscv32.stderr
+++ b/tests/ui/abi/unsupported.riscv32.stderr
@@ -1,83 +1,83 @@
 error[E0570]: "ptx-kernel" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:41:8
+  --> $DIR/unsupported.rs:42:8
    |
 LL | extern "ptx-kernel" fn ptx() {}
    |        ^^^^^^^^^^^^
 
 error[E0570]: "ptx-kernel" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:43:22
+  --> $DIR/unsupported.rs:44:22
    |
 LL | fn ptx_ptr(f: extern "ptx-kernel" fn()) {
    |                      ^^^^^^^^^^^^
 
 error[E0570]: "ptx-kernel" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:47:8
+  --> $DIR/unsupported.rs:48:8
    |
 LL | extern "ptx-kernel" {}
    |        ^^^^^^^^^^^^
 
 error[E0570]: "gpu-kernel" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:49:8
+  --> $DIR/unsupported.rs:50:8
    |
 LL | extern "gpu-kernel" fn gpu() {}
    |        ^^^^^^^^^^^^
 
 error[E0570]: "aapcs" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:52:8
+  --> $DIR/unsupported.rs:53:8
    |
 LL | extern "aapcs" fn aapcs() {}
    |        ^^^^^^^
 
 error[E0570]: "aapcs" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:54:24
+  --> $DIR/unsupported.rs:55:24
    |
 LL | fn aapcs_ptr(f: extern "aapcs" fn()) {
    |                        ^^^^^^^
 
 error[E0570]: "aapcs" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:58:8
+  --> $DIR/unsupported.rs:59:8
    |
 LL | extern "aapcs" {}
    |        ^^^^^^^
 
 error[E0570]: "msp430-interrupt" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:61:8
+  --> $DIR/unsupported.rs:62:8
    |
 LL | extern "msp430-interrupt" {}
    |        ^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "avr-interrupt" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:64:8
+  --> $DIR/unsupported.rs:65:8
    |
 LL | extern "avr-interrupt" {}
    |        ^^^^^^^^^^^^^^^
 
 error[E0570]: "x86-interrupt" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:70:8
+  --> $DIR/unsupported.rs:71:8
    |
 LL | extern "x86-interrupt" {}
    |        ^^^^^^^^^^^^^^^
 
 error[E0570]: "thiscall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:73:8
+  --> $DIR/unsupported.rs:74:8
    |
 LL | extern "thiscall" fn thiscall() {}
    |        ^^^^^^^^^^
 
 error[E0570]: "thiscall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:75:27
+  --> $DIR/unsupported.rs:76:27
    |
 LL | fn thiscall_ptr(f: extern "thiscall" fn()) {
    |                           ^^^^^^^^^^
 
 error[E0570]: "thiscall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:79:8
+  --> $DIR/unsupported.rs:80:8
    |
 LL | extern "thiscall" {}
    |        ^^^^^^^^^^
 
 error[E0570]: "stdcall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:82:8
+  --> $DIR/unsupported.rs:83:8
    |
 LL | extern "stdcall" fn stdcall() {}
    |        ^^^^^^^^^
@@ -85,7 +85,7 @@ LL | extern "stdcall" fn stdcall() {}
    = help: if you need `extern "stdcall"` on win32 and `extern "C"` everywhere else, use `extern "system"`
 
 error[E0570]: "stdcall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:86:26
+  --> $DIR/unsupported.rs:87:26
    |
 LL | fn stdcall_ptr(f: extern "stdcall" fn()) {
    |                          ^^^^^^^^^
@@ -93,7 +93,7 @@ LL | fn stdcall_ptr(f: extern "stdcall" fn()) {
    = help: if you need `extern "stdcall"` on win32 and `extern "C"` everywhere else, use `extern "system"`
 
 error[E0570]: "stdcall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:92:8
+  --> $DIR/unsupported.rs:93:8
    |
 LL | extern "stdcall" {}
    |        ^^^^^^^^^
@@ -101,7 +101,7 @@ LL | extern "stdcall" {}
    = help: if you need `extern "stdcall"` on win32 and `extern "C"` everywhere else, use `extern "system"`
 
 error[E0570]: "stdcall-unwind" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:96:8
+  --> $DIR/unsupported.rs:97:8
    |
 LL | extern "stdcall-unwind" {}
    |        ^^^^^^^^^^^^^^^^
@@ -109,49 +109,49 @@ LL | extern "stdcall-unwind" {}
    = help: if you need `extern "stdcall-unwind"` on win32 and `extern "C-unwind"` everywhere else, use `extern "system-unwind"`
 
 error[E0570]: "vectorcall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:116:8
+  --> $DIR/unsupported.rs:117:8
    |
 LL | extern "vectorcall" fn vectorcall() {}
    |        ^^^^^^^^^^^^
 
 error[E0570]: "vectorcall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:118:29
+  --> $DIR/unsupported.rs:119:29
    |
 LL | fn vectorcall_ptr(f: extern "vectorcall" fn()) {
    |                             ^^^^^^^^^^^^
 
 error[E0570]: "vectorcall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:122:8
+  --> $DIR/unsupported.rs:123:8
    |
 LL | extern "vectorcall" {}
    |        ^^^^^^^^^^^^
 
 error[E0570]: "cmse-nonsecure-call" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:125:28
+  --> $DIR/unsupported.rs:126:28
    |
 LL | fn cmse_call_ptr(f: extern "cmse-nonsecure-call" fn()) {
    |                            ^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "cmse-nonsecure-entry" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:130:8
+  --> $DIR/unsupported.rs:131:8
    |
 LL | extern "cmse-nonsecure-entry" fn cmse_entry() {}
    |        ^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "cmse-nonsecure-entry" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:132:29
+  --> $DIR/unsupported.rs:133:29
    |
 LL | fn cmse_entry_ptr(f: extern "cmse-nonsecure-entry" fn()) {
    |                             ^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "cmse-nonsecure-entry" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:136:8
+  --> $DIR/unsupported.rs:137:8
    |
 LL | extern "cmse-nonsecure-entry" {}
    |        ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: "cdecl" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:104:17
+  --> $DIR/unsupported.rs:105:17
    |
 LL | fn cdecl_ptr(f: extern "cdecl" fn()) {
    |                 ^^^^^^^^^^^^^^^^^^^
@@ -162,7 +162,7 @@ LL | fn cdecl_ptr(f: extern "cdecl" fn()) {
    = note: `#[warn(unsupported_calling_conventions)]` (part of `#[warn(future_incompatible)]`) on by default
 
 warning: "cdecl" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:109:1
+  --> $DIR/unsupported.rs:110:1
    |
 LL | extern "cdecl" {}
    | ^^^^^^^^^^^^^^^^^
@@ -172,7 +172,7 @@ LL | extern "cdecl" {}
    = note: for more information, see issue #137018 <https://github.com/rust-lang/rust/issues/137018>
 
 warning: "cdecl-unwind" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:112:1
+  --> $DIR/unsupported.rs:113:1
    |
 LL | extern "cdecl-unwind" {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -182,7 +182,7 @@ LL | extern "cdecl-unwind" {}
    = note: for more information, see issue #137018 <https://github.com/rust-lang/rust/issues/137018>
 
 warning: "cdecl" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:101:1
+  --> $DIR/unsupported.rs:102:1
    |
 LL | extern "cdecl" fn cdecl() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/abi/unsupported.riscv64.stderr
+++ b/tests/ui/abi/unsupported.riscv64.stderr
@@ -1,83 +1,83 @@
 error[E0570]: "ptx-kernel" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:37:8
+  --> $DIR/unsupported.rs:41:8
    |
 LL | extern "ptx-kernel" fn ptx() {}
    |        ^^^^^^^^^^^^
 
 error[E0570]: "ptx-kernel" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:39:22
+  --> $DIR/unsupported.rs:43:22
    |
 LL | fn ptx_ptr(f: extern "ptx-kernel" fn()) {
    |                      ^^^^^^^^^^^^
 
 error[E0570]: "ptx-kernel" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:43:8
+  --> $DIR/unsupported.rs:47:8
    |
 LL | extern "ptx-kernel" {}
    |        ^^^^^^^^^^^^
 
 error[E0570]: "gpu-kernel" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:45:8
+  --> $DIR/unsupported.rs:49:8
    |
 LL | extern "gpu-kernel" fn gpu() {}
    |        ^^^^^^^^^^^^
 
 error[E0570]: "aapcs" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:48:8
+  --> $DIR/unsupported.rs:52:8
    |
 LL | extern "aapcs" fn aapcs() {}
    |        ^^^^^^^
 
 error[E0570]: "aapcs" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:50:24
+  --> $DIR/unsupported.rs:54:24
    |
 LL | fn aapcs_ptr(f: extern "aapcs" fn()) {
    |                        ^^^^^^^
 
 error[E0570]: "aapcs" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:54:8
+  --> $DIR/unsupported.rs:58:8
    |
 LL | extern "aapcs" {}
    |        ^^^^^^^
 
 error[E0570]: "msp430-interrupt" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:57:8
+  --> $DIR/unsupported.rs:61:8
    |
 LL | extern "msp430-interrupt" {}
    |        ^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "avr-interrupt" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:60:8
+  --> $DIR/unsupported.rs:64:8
    |
 LL | extern "avr-interrupt" {}
    |        ^^^^^^^^^^^^^^^
 
 error[E0570]: "x86-interrupt" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:66:8
+  --> $DIR/unsupported.rs:70:8
    |
 LL | extern "x86-interrupt" {}
    |        ^^^^^^^^^^^^^^^
 
 error[E0570]: "thiscall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:69:8
+  --> $DIR/unsupported.rs:73:8
    |
 LL | extern "thiscall" fn thiscall() {}
    |        ^^^^^^^^^^
 
 error[E0570]: "thiscall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:71:27
+  --> $DIR/unsupported.rs:75:27
    |
 LL | fn thiscall_ptr(f: extern "thiscall" fn()) {
    |                           ^^^^^^^^^^
 
 error[E0570]: "thiscall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:75:8
+  --> $DIR/unsupported.rs:79:8
    |
 LL | extern "thiscall" {}
    |        ^^^^^^^^^^
 
 error[E0570]: "stdcall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:78:8
+  --> $DIR/unsupported.rs:82:8
    |
 LL | extern "stdcall" fn stdcall() {}
    |        ^^^^^^^^^
@@ -85,7 +85,7 @@ LL | extern "stdcall" fn stdcall() {}
    = help: if you need `extern "stdcall"` on win32 and `extern "C"` everywhere else, use `extern "system"`
 
 error[E0570]: "stdcall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:82:26
+  --> $DIR/unsupported.rs:86:26
    |
 LL | fn stdcall_ptr(f: extern "stdcall" fn()) {
    |                          ^^^^^^^^^
@@ -93,7 +93,7 @@ LL | fn stdcall_ptr(f: extern "stdcall" fn()) {
    = help: if you need `extern "stdcall"` on win32 and `extern "C"` everywhere else, use `extern "system"`
 
 error[E0570]: "stdcall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:88:8
+  --> $DIR/unsupported.rs:92:8
    |
 LL | extern "stdcall" {}
    |        ^^^^^^^^^
@@ -101,7 +101,7 @@ LL | extern "stdcall" {}
    = help: if you need `extern "stdcall"` on win32 and `extern "C"` everywhere else, use `extern "system"`
 
 error[E0570]: "stdcall-unwind" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:92:8
+  --> $DIR/unsupported.rs:96:8
    |
 LL | extern "stdcall-unwind" {}
    |        ^^^^^^^^^^^^^^^^
@@ -109,49 +109,49 @@ LL | extern "stdcall-unwind" {}
    = help: if you need `extern "stdcall-unwind"` on win32 and `extern "C-unwind"` everywhere else, use `extern "system-unwind"`
 
 error[E0570]: "vectorcall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:112:8
+  --> $DIR/unsupported.rs:116:8
    |
 LL | extern "vectorcall" fn vectorcall() {}
    |        ^^^^^^^^^^^^
 
 error[E0570]: "vectorcall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:114:29
+  --> $DIR/unsupported.rs:118:29
    |
 LL | fn vectorcall_ptr(f: extern "vectorcall" fn()) {
    |                             ^^^^^^^^^^^^
 
 error[E0570]: "vectorcall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:118:8
+  --> $DIR/unsupported.rs:122:8
    |
 LL | extern "vectorcall" {}
    |        ^^^^^^^^^^^^
 
 error[E0570]: "cmse-nonsecure-call" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:121:28
+  --> $DIR/unsupported.rs:125:28
    |
 LL | fn cmse_call_ptr(f: extern "cmse-nonsecure-call" fn()) {
    |                            ^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "cmse-nonsecure-entry" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:126:8
+  --> $DIR/unsupported.rs:130:8
    |
 LL | extern "cmse-nonsecure-entry" fn cmse_entry() {}
    |        ^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "cmse-nonsecure-entry" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:128:29
+  --> $DIR/unsupported.rs:132:29
    |
 LL | fn cmse_entry_ptr(f: extern "cmse-nonsecure-entry" fn()) {
    |                             ^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "cmse-nonsecure-entry" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:132:8
+  --> $DIR/unsupported.rs:136:8
    |
 LL | extern "cmse-nonsecure-entry" {}
    |        ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: "cdecl" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:100:17
+  --> $DIR/unsupported.rs:104:17
    |
 LL | fn cdecl_ptr(f: extern "cdecl" fn()) {
    |                 ^^^^^^^^^^^^^^^^^^^
@@ -162,7 +162,7 @@ LL | fn cdecl_ptr(f: extern "cdecl" fn()) {
    = note: `#[warn(unsupported_calling_conventions)]` (part of `#[warn(future_incompatible)]`) on by default
 
 warning: "cdecl" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:105:1
+  --> $DIR/unsupported.rs:109:1
    |
 LL | extern "cdecl" {}
    | ^^^^^^^^^^^^^^^^^
@@ -172,7 +172,7 @@ LL | extern "cdecl" {}
    = note: for more information, see issue #137018 <https://github.com/rust-lang/rust/issues/137018>
 
 warning: "cdecl-unwind" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:108:1
+  --> $DIR/unsupported.rs:112:1
    |
 LL | extern "cdecl-unwind" {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -182,7 +182,7 @@ LL | extern "cdecl-unwind" {}
    = note: for more information, see issue #137018 <https://github.com/rust-lang/rust/issues/137018>
 
 warning: "cdecl" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:97:1
+  --> $DIR/unsupported.rs:101:1
    |
 LL | extern "cdecl" fn cdecl() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/abi/unsupported.riscv64.stderr
+++ b/tests/ui/abi/unsupported.riscv64.stderr
@@ -1,83 +1,83 @@
 error[E0570]: "ptx-kernel" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:41:8
+  --> $DIR/unsupported.rs:42:8
    |
 LL | extern "ptx-kernel" fn ptx() {}
    |        ^^^^^^^^^^^^
 
 error[E0570]: "ptx-kernel" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:43:22
+  --> $DIR/unsupported.rs:44:22
    |
 LL | fn ptx_ptr(f: extern "ptx-kernel" fn()) {
    |                      ^^^^^^^^^^^^
 
 error[E0570]: "ptx-kernel" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:47:8
+  --> $DIR/unsupported.rs:48:8
    |
 LL | extern "ptx-kernel" {}
    |        ^^^^^^^^^^^^
 
 error[E0570]: "gpu-kernel" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:49:8
+  --> $DIR/unsupported.rs:50:8
    |
 LL | extern "gpu-kernel" fn gpu() {}
    |        ^^^^^^^^^^^^
 
 error[E0570]: "aapcs" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:52:8
+  --> $DIR/unsupported.rs:53:8
    |
 LL | extern "aapcs" fn aapcs() {}
    |        ^^^^^^^
 
 error[E0570]: "aapcs" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:54:24
+  --> $DIR/unsupported.rs:55:24
    |
 LL | fn aapcs_ptr(f: extern "aapcs" fn()) {
    |                        ^^^^^^^
 
 error[E0570]: "aapcs" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:58:8
+  --> $DIR/unsupported.rs:59:8
    |
 LL | extern "aapcs" {}
    |        ^^^^^^^
 
 error[E0570]: "msp430-interrupt" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:61:8
+  --> $DIR/unsupported.rs:62:8
    |
 LL | extern "msp430-interrupt" {}
    |        ^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "avr-interrupt" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:64:8
+  --> $DIR/unsupported.rs:65:8
    |
 LL | extern "avr-interrupt" {}
    |        ^^^^^^^^^^^^^^^
 
 error[E0570]: "x86-interrupt" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:70:8
+  --> $DIR/unsupported.rs:71:8
    |
 LL | extern "x86-interrupt" {}
    |        ^^^^^^^^^^^^^^^
 
 error[E0570]: "thiscall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:73:8
+  --> $DIR/unsupported.rs:74:8
    |
 LL | extern "thiscall" fn thiscall() {}
    |        ^^^^^^^^^^
 
 error[E0570]: "thiscall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:75:27
+  --> $DIR/unsupported.rs:76:27
    |
 LL | fn thiscall_ptr(f: extern "thiscall" fn()) {
    |                           ^^^^^^^^^^
 
 error[E0570]: "thiscall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:79:8
+  --> $DIR/unsupported.rs:80:8
    |
 LL | extern "thiscall" {}
    |        ^^^^^^^^^^
 
 error[E0570]: "stdcall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:82:8
+  --> $DIR/unsupported.rs:83:8
    |
 LL | extern "stdcall" fn stdcall() {}
    |        ^^^^^^^^^
@@ -85,7 +85,7 @@ LL | extern "stdcall" fn stdcall() {}
    = help: if you need `extern "stdcall"` on win32 and `extern "C"` everywhere else, use `extern "system"`
 
 error[E0570]: "stdcall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:86:26
+  --> $DIR/unsupported.rs:87:26
    |
 LL | fn stdcall_ptr(f: extern "stdcall" fn()) {
    |                          ^^^^^^^^^
@@ -93,7 +93,7 @@ LL | fn stdcall_ptr(f: extern "stdcall" fn()) {
    = help: if you need `extern "stdcall"` on win32 and `extern "C"` everywhere else, use `extern "system"`
 
 error[E0570]: "stdcall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:92:8
+  --> $DIR/unsupported.rs:93:8
    |
 LL | extern "stdcall" {}
    |        ^^^^^^^^^
@@ -101,7 +101,7 @@ LL | extern "stdcall" {}
    = help: if you need `extern "stdcall"` on win32 and `extern "C"` everywhere else, use `extern "system"`
 
 error[E0570]: "stdcall-unwind" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:96:8
+  --> $DIR/unsupported.rs:97:8
    |
 LL | extern "stdcall-unwind" {}
    |        ^^^^^^^^^^^^^^^^
@@ -109,49 +109,49 @@ LL | extern "stdcall-unwind" {}
    = help: if you need `extern "stdcall-unwind"` on win32 and `extern "C-unwind"` everywhere else, use `extern "system-unwind"`
 
 error[E0570]: "vectorcall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:116:8
+  --> $DIR/unsupported.rs:117:8
    |
 LL | extern "vectorcall" fn vectorcall() {}
    |        ^^^^^^^^^^^^
 
 error[E0570]: "vectorcall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:118:29
+  --> $DIR/unsupported.rs:119:29
    |
 LL | fn vectorcall_ptr(f: extern "vectorcall" fn()) {
    |                             ^^^^^^^^^^^^
 
 error[E0570]: "vectorcall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:122:8
+  --> $DIR/unsupported.rs:123:8
    |
 LL | extern "vectorcall" {}
    |        ^^^^^^^^^^^^
 
 error[E0570]: "cmse-nonsecure-call" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:125:28
+  --> $DIR/unsupported.rs:126:28
    |
 LL | fn cmse_call_ptr(f: extern "cmse-nonsecure-call" fn()) {
    |                            ^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "cmse-nonsecure-entry" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:130:8
+  --> $DIR/unsupported.rs:131:8
    |
 LL | extern "cmse-nonsecure-entry" fn cmse_entry() {}
    |        ^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "cmse-nonsecure-entry" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:132:29
+  --> $DIR/unsupported.rs:133:29
    |
 LL | fn cmse_entry_ptr(f: extern "cmse-nonsecure-entry" fn()) {
    |                             ^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "cmse-nonsecure-entry" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:136:8
+  --> $DIR/unsupported.rs:137:8
    |
 LL | extern "cmse-nonsecure-entry" {}
    |        ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: "cdecl" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:104:17
+  --> $DIR/unsupported.rs:105:17
    |
 LL | fn cdecl_ptr(f: extern "cdecl" fn()) {
    |                 ^^^^^^^^^^^^^^^^^^^
@@ -162,7 +162,7 @@ LL | fn cdecl_ptr(f: extern "cdecl" fn()) {
    = note: `#[warn(unsupported_calling_conventions)]` (part of `#[warn(future_incompatible)]`) on by default
 
 warning: "cdecl" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:109:1
+  --> $DIR/unsupported.rs:110:1
    |
 LL | extern "cdecl" {}
    | ^^^^^^^^^^^^^^^^^
@@ -172,7 +172,7 @@ LL | extern "cdecl" {}
    = note: for more information, see issue #137018 <https://github.com/rust-lang/rust/issues/137018>
 
 warning: "cdecl-unwind" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:112:1
+  --> $DIR/unsupported.rs:113:1
    |
 LL | extern "cdecl-unwind" {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -182,7 +182,7 @@ LL | extern "cdecl-unwind" {}
    = note: for more information, see issue #137018 <https://github.com/rust-lang/rust/issues/137018>
 
 warning: "cdecl" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:101:1
+  --> $DIR/unsupported.rs:102:1
    |
 LL | extern "cdecl" fn cdecl() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/abi/unsupported.rs
+++ b/tests/ui/abi/unsupported.rs
@@ -1,5 +1,5 @@
 //@ add-minicore
-//@ revisions: x64 x64_win i686 aarch64 arm riscv32 riscv64
+//@ revisions: x64 x64_win i686 aarch64 arm riscv32 riscv64 wasm32 wasm64
 //
 //@ [x64] needs-llvm-components: x86
 //@ [x64] compile-flags: --target=x86_64-unknown-linux-gnu --crate-type=rlib
@@ -15,6 +15,10 @@
 //@ [riscv32] compile-flags: --target=riscv32i-unknown-none-elf --crate-type=rlib
 //@ [riscv64] needs-llvm-components: riscv
 //@ [riscv64] compile-flags: --target=riscv64gc-unknown-none-elf --crate-type=rlib
+//@ [wasm32] needs-llvm-components: webassembly
+//@ [wasm32] compile-flags: --target wasm32-unknown-unknown --crate-type=rlib
+//@ [wasm64] needs-llvm-components: webassembly
+//@ [wasm64] compile-flags: --target wasm64-unknown-unknown --crate-type=rlib
 //@ ignore-backends: gcc
 #![no_core]
 #![feature(
@@ -37,7 +41,7 @@ use minicore::*;
 extern "ptx-kernel" fn ptx() {}
 //~^ ERROR is not a supported ABI
 fn ptx_ptr(f: extern "ptx-kernel" fn()) {
-//~^ ERROR is not a supported ABI
+    //~^ ERROR is not a supported ABI
     f()
 }
 extern "ptx-kernel" {}
@@ -46,13 +50,13 @@ extern "gpu-kernel" fn gpu() {}
 //~^ ERROR is not a supported ABI
 
 extern "aapcs" fn aapcs() {}
-//[x64,x64_win,i686,aarch64,riscv32,riscv64]~^ ERROR is not a supported ABI
+//[x64,x64_win,i686,aarch64,riscv32,riscv64,wasm32,wasm64]~^ ERROR is not a supported ABI
 fn aapcs_ptr(f: extern "aapcs" fn()) {
-    //[x64,x64_win,i686,aarch64,riscv32,riscv64]~^ ERROR is not a supported ABI
+    //[x64,x64_win,i686,aarch64,riscv32,riscv64,wasm32,wasm64]~^ ERROR is not a supported ABI
     f()
 }
 extern "aapcs" {}
-//[x64,x64_win,i686,aarch64,riscv32,riscv64]~^ ERROR is not a supported ABI
+//[x64,x64_win,i686,aarch64,riscv32,riscv64,wasm32,wasm64]~^ ERROR is not a supported ABI
 
 extern "msp430-interrupt" {}
 //~^ ERROR is not a supported ABI
@@ -61,72 +65,72 @@ extern "avr-interrupt" {}
 //~^ ERROR is not a supported ABI
 
 extern "riscv-interrupt-m" {}
-//[x64,x64_win,i686,arm,aarch64]~^ ERROR is not a supported ABI
+//[x64,x64_win,i686,arm,aarch64,wasm32,wasm64]~^ ERROR is not a supported ABI
 
 extern "x86-interrupt" {}
-//[aarch64,arm,riscv32,riscv64]~^ ERROR is not a supported ABI
+//[aarch64,arm,riscv32,riscv64,wasm32,wasm64]~^ ERROR is not a supported ABI
 
 extern "thiscall" fn thiscall() {}
-//[x64,x64_win,arm,aarch64,riscv32,riscv64]~^ ERROR is not a supported ABI
+//[x64,x64_win,arm,aarch64,riscv32,riscv64,wasm32,wasm64]~^ ERROR is not a supported ABI
 fn thiscall_ptr(f: extern "thiscall" fn()) {
-    //[x64,x64_win,arm,aarch64,riscv32,riscv64]~^ ERROR is not a supported ABI
+    //[x64,x64_win,arm,aarch64,riscv32,riscv64,wasm32,wasm64]~^ ERROR is not a supported ABI
     f()
 }
 extern "thiscall" {}
-//[x64,x64_win,arm,aarch64,riscv32,riscv64]~^ ERROR is not a supported ABI
+//[x64,x64_win,arm,aarch64,riscv32,riscv64,wasm32,wasm64]~^ ERROR is not a supported ABI
 
 extern "stdcall" fn stdcall() {}
-//[x64,arm,aarch64,riscv32,riscv64]~^ ERROR is not a supported ABI
+//[x64,arm,aarch64,riscv32,riscv64,wasm32,wasm64]~^ ERROR is not a supported ABI
 //[x64_win]~^^ WARN unsupported_calling_conventions
 //[x64_win]~^^^ WARN this was previously accepted
 fn stdcall_ptr(f: extern "stdcall" fn()) {
-    //[x64,arm,aarch64,riscv32,riscv64]~^ ERROR is not a supported ABI
+    //[x64,arm,aarch64,riscv32,riscv64,wasm32,wasm64]~^ ERROR is not a supported ABI
     //[x64_win]~^^ WARN unsupported_calling_conventions
     //[x64_win]~|  WARN this was previously accepted
     f()
 }
 extern "stdcall" {}
-//[x64,arm,aarch64,riscv32,riscv64]~^ ERROR is not a supported ABI
+//[x64,arm,aarch64,riscv32,riscv64,wasm32,wasm64]~^ ERROR is not a supported ABI
 //[x64_win]~^^ WARN unsupported_calling_conventions
 //[x64_win]~^^^ WARN this was previously accepted
 extern "stdcall-unwind" {}
-//[x64,arm,aarch64,riscv32,riscv64]~^ ERROR is not a supported ABI
+//[x64,arm,aarch64,riscv32,riscv64,wasm32,wasm64]~^ ERROR is not a supported ABI
 //[x64_win]~^^ WARN unsupported_calling_conventions
 //[x64_win]~^^^ WARN this was previously accepted
 
 extern "cdecl" fn cdecl() {}
-//[x64,x64_win,arm,aarch64,riscv32,riscv64]~^ WARN unsupported_calling_conventions
-//[x64,x64_win,arm,aarch64,riscv32,riscv64]~^^ WARN this was previously accepted
+//[x64,x64_win,arm,aarch64,riscv32,riscv64,wasm32,wasm64]~^ WARN unsupported_calling_conventions
+//[x64,x64_win,arm,aarch64,riscv32,riscv64,wasm32,wasm64]~^^ WARN this was previously accepted
 fn cdecl_ptr(f: extern "cdecl" fn()) {
-    //[x64,x64_win,arm,aarch64,riscv32,riscv64]~^ WARN unsupported_calling_conventions
-    //[x64,x64_win,arm,aarch64,riscv32,riscv64]~| WARN this was previously accepted
+    //[x64,x64_win,arm,aarch64,riscv32,riscv64,wasm32,wasm64]~^ WARN unsupported_calling_conventions
+    //[x64,x64_win,arm,aarch64,riscv32,riscv64,wasm32,wasm64]~| WARN this was previously accepted
     f()
 }
 extern "cdecl" {}
-//[x64,x64_win,arm,aarch64,riscv32,riscv64]~^ WARN unsupported_calling_conventions
-//[x64,x64_win,arm,aarch64,riscv32,riscv64]~^^ WARN this was previously accepted
+//[x64,x64_win,arm,aarch64,riscv32,riscv64,wasm32,wasm64]~^ WARN unsupported_calling_conventions
+//[x64,x64_win,arm,aarch64,riscv32,riscv64,wasm32,wasm64]~^^ WARN this was previously accepted
 extern "cdecl-unwind" {}
-//[x64,x64_win,arm,aarch64,riscv32,riscv64]~^ WARN unsupported_calling_conventions
-//[x64,x64_win,arm,aarch64,riscv32,riscv64]~^^ WARN this was previously accepted
+//[x64,x64_win,arm,aarch64,riscv32,riscv64,wasm32,wasm64]~^ WARN unsupported_calling_conventions
+//[x64,x64_win,arm,aarch64,riscv32,riscv64,wasm32,wasm64]~^^ WARN this was previously accepted
 
 extern "vectorcall" fn vectorcall() {}
-//[arm,aarch64,riscv32,riscv64]~^ ERROR is not a supported ABI
+//[arm,aarch64,riscv32,riscv64,wasm32,wasm64]~^ ERROR is not a supported ABI
 fn vectorcall_ptr(f: extern "vectorcall" fn()) {
-    //[arm,aarch64,riscv32,riscv64]~^ ERROR is not a supported ABI
+    //[arm,aarch64,riscv32,riscv64,wasm32,wasm64]~^ ERROR is not a supported ABI
     f()
 }
 extern "vectorcall" {}
-//[arm,aarch64,riscv32,riscv64]~^ ERROR is not a supported ABI
+//[arm,aarch64,riscv32,riscv64,wasm32,wasm64]~^ ERROR is not a supported ABI
 
 fn cmse_call_ptr(f: extern "cmse-nonsecure-call" fn()) {
-//~^ ERROR is not a supported ABI
+    //~^ ERROR is not a supported ABI
     f()
 }
 
 extern "cmse-nonsecure-entry" fn cmse_entry() {}
 //~^ ERROR is not a supported ABI
 fn cmse_entry_ptr(f: extern "cmse-nonsecure-entry" fn()) {
-//~^ ERROR is not a supported ABI
+    //~^ ERROR is not a supported ABI
     f()
 }
 extern "cmse-nonsecure-entry" {}

--- a/tests/ui/abi/unsupported.rs
+++ b/tests/ui/abi/unsupported.rs
@@ -32,7 +32,8 @@
     abi_riscv_interrupt,
     abi_cmse_nonsecure_call,
     abi_vectorcall,
-    cmse_nonsecure_entry
+    cmse_nonsecure_entry,
+    abi_custom
 )]
 
 extern crate minicore;
@@ -141,3 +142,10 @@ extern "cmse-nonsecure-entry" {}
 extern "cdecl" {}
 //[x64_win]~^ WARN unsupported_calling_conventions
 //[x64_win]~^^ WARN this was previously accepted
+
+fn custom_ptr(f: extern "custom" fn()) {
+    //[wasm32,wasm64]~^ ERROR is not a supported ABI
+    let _ = f;
+}
+extern "custom" {}
+//[wasm32,wasm64]~^ ERROR is not a supported ABI

--- a/tests/ui/abi/unsupported.wasm32.stderr
+++ b/tests/ui/abi/unsupported.wasm32.stderr
@@ -58,6 +58,12 @@ error[E0570]: "riscv-interrupt-m" is not a supported ABI for the current target
 LL | extern "riscv-interrupt-m" {}
    |        ^^^^^^^^^^^^^^^^^^^
 
+error[E0570]: "x86-interrupt" is not a supported ABI for the current target
+  --> $DIR/unsupported.rs:71:8
+   |
+LL | extern "x86-interrupt" {}
+   |        ^^^^^^^^^^^^^^^
+
 error[E0570]: "thiscall" is not a supported ABI for the current target
   --> $DIR/unsupported.rs:74:8
    |
@@ -75,6 +81,56 @@ error[E0570]: "thiscall" is not a supported ABI for the current target
    |
 LL | extern "thiscall" {}
    |        ^^^^^^^^^^
+
+error[E0570]: "stdcall" is not a supported ABI for the current target
+  --> $DIR/unsupported.rs:83:8
+   |
+LL | extern "stdcall" fn stdcall() {}
+   |        ^^^^^^^^^
+   |
+   = help: if you need `extern "stdcall"` on win32 and `extern "C"` everywhere else, use `extern "system"`
+
+error[E0570]: "stdcall" is not a supported ABI for the current target
+  --> $DIR/unsupported.rs:87:26
+   |
+LL | fn stdcall_ptr(f: extern "stdcall" fn()) {
+   |                          ^^^^^^^^^
+   |
+   = help: if you need `extern "stdcall"` on win32 and `extern "C"` everywhere else, use `extern "system"`
+
+error[E0570]: "stdcall" is not a supported ABI for the current target
+  --> $DIR/unsupported.rs:93:8
+   |
+LL | extern "stdcall" {}
+   |        ^^^^^^^^^
+   |
+   = help: if you need `extern "stdcall"` on win32 and `extern "C"` everywhere else, use `extern "system"`
+
+error[E0570]: "stdcall-unwind" is not a supported ABI for the current target
+  --> $DIR/unsupported.rs:97:8
+   |
+LL | extern "stdcall-unwind" {}
+   |        ^^^^^^^^^^^^^^^^
+   |
+   = help: if you need `extern "stdcall-unwind"` on win32 and `extern "C-unwind"` everywhere else, use `extern "system-unwind"`
+
+error[E0570]: "vectorcall" is not a supported ABI for the current target
+  --> $DIR/unsupported.rs:117:8
+   |
+LL | extern "vectorcall" fn vectorcall() {}
+   |        ^^^^^^^^^^^^
+
+error[E0570]: "vectorcall" is not a supported ABI for the current target
+  --> $DIR/unsupported.rs:119:29
+   |
+LL | fn vectorcall_ptr(f: extern "vectorcall" fn()) {
+   |                             ^^^^^^^^^^^^
+
+error[E0570]: "vectorcall" is not a supported ABI for the current target
+  --> $DIR/unsupported.rs:123:8
+   |
+LL | extern "vectorcall" {}
+   |        ^^^^^^^^^^^^
 
 error[E0570]: "cmse-nonsecure-call" is not a supported ABI for the current target
   --> $DIR/unsupported.rs:126:28
@@ -100,36 +156,17 @@ error[E0570]: "cmse-nonsecure-entry" is not a supported ABI for the current targ
 LL | extern "cmse-nonsecure-entry" {}
    |        ^^^^^^^^^^^^^^^^^^^^^^
 
-warning: "stdcall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:87:19
+error[E0570]: "custom" is not a supported ABI for the current target
+  --> $DIR/unsupported.rs:146:25
    |
-LL | fn stdcall_ptr(f: extern "stdcall" fn()) {
-   |                   ^^^^^^^^^^^^^^^^^^^^^
-   |
-   = help: if you need `extern "stdcall"` on win32 and `extern "C"` everywhere else, use `extern "system"`
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #137018 <https://github.com/rust-lang/rust/issues/137018>
-   = note: `#[warn(unsupported_calling_conventions)]` (part of `#[warn(future_incompatible)]`) on by default
+LL | fn custom_ptr(f: extern "custom" fn()) {
+   |                         ^^^^^^^^
 
-warning: "stdcall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:93:1
+error[E0570]: "custom" is not a supported ABI for the current target
+  --> $DIR/unsupported.rs:150:8
    |
-LL | extern "stdcall" {}
-   | ^^^^^^^^^^^^^^^^^^^
-   |
-   = help: if you need `extern "stdcall"` on win32 and `extern "C"` everywhere else, use `extern "system"`
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #137018 <https://github.com/rust-lang/rust/issues/137018>
-
-warning: "stdcall-unwind" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:97:1
-   |
-LL | extern "stdcall-unwind" {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = help: if you need `extern "stdcall-unwind"` on win32 and `extern "C-unwind"` everywhere else, use `extern "system-unwind"`
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #137018 <https://github.com/rust-lang/rust/issues/137018>
+LL | extern "custom" {}
+   |        ^^^^^^^^
 
 warning: "cdecl" is not a supported ABI for the current target
   --> $DIR/unsupported.rs:105:17
@@ -140,6 +177,7 @@ LL | fn cdecl_ptr(f: extern "cdecl" fn()) {
    = help: use `extern "C"` instead
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #137018 <https://github.com/rust-lang/rust/issues/137018>
+   = note: `#[warn(unsupported_calling_conventions)]` (part of `#[warn(future_incompatible)]`) on by default
 
 warning: "cdecl" is not a supported ABI for the current target
   --> $DIR/unsupported.rs:110:1
@@ -162,26 +200,6 @@ LL | extern "cdecl-unwind" {}
    = note: for more information, see issue #137018 <https://github.com/rust-lang/rust/issues/137018>
 
 warning: "cdecl" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:142:1
-   |
-LL | extern "cdecl" {}
-   | ^^^^^^^^^^^^^^^^^
-   |
-   = help: use `extern "C"` instead
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #137018 <https://github.com/rust-lang/rust/issues/137018>
-
-warning: "stdcall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:83:1
-   |
-LL | extern "stdcall" fn stdcall() {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = help: if you need `extern "stdcall"` on win32 and `extern "C"` everywhere else, use `extern "system"`
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #137018 <https://github.com/rust-lang/rust/issues/137018>
-
-warning: "cdecl" is not a supported ABI for the current target
   --> $DIR/unsupported.rs:102:1
    |
 LL | extern "cdecl" fn cdecl() {}
@@ -191,6 +209,6 @@ LL | extern "cdecl" fn cdecl() {}
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #137018 <https://github.com/rust-lang/rust/issues/137018>
 
-error: aborting due to 17 previous errors; 9 warnings emitted
+error: aborting due to 27 previous errors; 4 warnings emitted
 
 For more information about this error, try `rustc --explain E0570`.

--- a/tests/ui/abi/unsupported.wasm64.stderr
+++ b/tests/ui/abi/unsupported.wasm64.stderr
@@ -58,6 +58,12 @@ error[E0570]: "riscv-interrupt-m" is not a supported ABI for the current target
 LL | extern "riscv-interrupt-m" {}
    |        ^^^^^^^^^^^^^^^^^^^
 
+error[E0570]: "x86-interrupt" is not a supported ABI for the current target
+  --> $DIR/unsupported.rs:71:8
+   |
+LL | extern "x86-interrupt" {}
+   |        ^^^^^^^^^^^^^^^
+
 error[E0570]: "thiscall" is not a supported ABI for the current target
   --> $DIR/unsupported.rs:74:8
    |
@@ -75,6 +81,56 @@ error[E0570]: "thiscall" is not a supported ABI for the current target
    |
 LL | extern "thiscall" {}
    |        ^^^^^^^^^^
+
+error[E0570]: "stdcall" is not a supported ABI for the current target
+  --> $DIR/unsupported.rs:83:8
+   |
+LL | extern "stdcall" fn stdcall() {}
+   |        ^^^^^^^^^
+   |
+   = help: if you need `extern "stdcall"` on win32 and `extern "C"` everywhere else, use `extern "system"`
+
+error[E0570]: "stdcall" is not a supported ABI for the current target
+  --> $DIR/unsupported.rs:87:26
+   |
+LL | fn stdcall_ptr(f: extern "stdcall" fn()) {
+   |                          ^^^^^^^^^
+   |
+   = help: if you need `extern "stdcall"` on win32 and `extern "C"` everywhere else, use `extern "system"`
+
+error[E0570]: "stdcall" is not a supported ABI for the current target
+  --> $DIR/unsupported.rs:93:8
+   |
+LL | extern "stdcall" {}
+   |        ^^^^^^^^^
+   |
+   = help: if you need `extern "stdcall"` on win32 and `extern "C"` everywhere else, use `extern "system"`
+
+error[E0570]: "stdcall-unwind" is not a supported ABI for the current target
+  --> $DIR/unsupported.rs:97:8
+   |
+LL | extern "stdcall-unwind" {}
+   |        ^^^^^^^^^^^^^^^^
+   |
+   = help: if you need `extern "stdcall-unwind"` on win32 and `extern "C-unwind"` everywhere else, use `extern "system-unwind"`
+
+error[E0570]: "vectorcall" is not a supported ABI for the current target
+  --> $DIR/unsupported.rs:117:8
+   |
+LL | extern "vectorcall" fn vectorcall() {}
+   |        ^^^^^^^^^^^^
+
+error[E0570]: "vectorcall" is not a supported ABI for the current target
+  --> $DIR/unsupported.rs:119:29
+   |
+LL | fn vectorcall_ptr(f: extern "vectorcall" fn()) {
+   |                             ^^^^^^^^^^^^
+
+error[E0570]: "vectorcall" is not a supported ABI for the current target
+  --> $DIR/unsupported.rs:123:8
+   |
+LL | extern "vectorcall" {}
+   |        ^^^^^^^^^^^^
 
 error[E0570]: "cmse-nonsecure-call" is not a supported ABI for the current target
   --> $DIR/unsupported.rs:126:28
@@ -100,36 +156,17 @@ error[E0570]: "cmse-nonsecure-entry" is not a supported ABI for the current targ
 LL | extern "cmse-nonsecure-entry" {}
    |        ^^^^^^^^^^^^^^^^^^^^^^
 
-warning: "stdcall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:87:19
+error[E0570]: "custom" is not a supported ABI for the current target
+  --> $DIR/unsupported.rs:146:25
    |
-LL | fn stdcall_ptr(f: extern "stdcall" fn()) {
-   |                   ^^^^^^^^^^^^^^^^^^^^^
-   |
-   = help: if you need `extern "stdcall"` on win32 and `extern "C"` everywhere else, use `extern "system"`
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #137018 <https://github.com/rust-lang/rust/issues/137018>
-   = note: `#[warn(unsupported_calling_conventions)]` (part of `#[warn(future_incompatible)]`) on by default
+LL | fn custom_ptr(f: extern "custom" fn()) {
+   |                         ^^^^^^^^
 
-warning: "stdcall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:93:1
+error[E0570]: "custom" is not a supported ABI for the current target
+  --> $DIR/unsupported.rs:150:8
    |
-LL | extern "stdcall" {}
-   | ^^^^^^^^^^^^^^^^^^^
-   |
-   = help: if you need `extern "stdcall"` on win32 and `extern "C"` everywhere else, use `extern "system"`
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #137018 <https://github.com/rust-lang/rust/issues/137018>
-
-warning: "stdcall-unwind" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:97:1
-   |
-LL | extern "stdcall-unwind" {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = help: if you need `extern "stdcall-unwind"` on win32 and `extern "C-unwind"` everywhere else, use `extern "system-unwind"`
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #137018 <https://github.com/rust-lang/rust/issues/137018>
+LL | extern "custom" {}
+   |        ^^^^^^^^
 
 warning: "cdecl" is not a supported ABI for the current target
   --> $DIR/unsupported.rs:105:17
@@ -140,6 +177,7 @@ LL | fn cdecl_ptr(f: extern "cdecl" fn()) {
    = help: use `extern "C"` instead
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #137018 <https://github.com/rust-lang/rust/issues/137018>
+   = note: `#[warn(unsupported_calling_conventions)]` (part of `#[warn(future_incompatible)]`) on by default
 
 warning: "cdecl" is not a supported ABI for the current target
   --> $DIR/unsupported.rs:110:1
@@ -162,26 +200,6 @@ LL | extern "cdecl-unwind" {}
    = note: for more information, see issue #137018 <https://github.com/rust-lang/rust/issues/137018>
 
 warning: "cdecl" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:142:1
-   |
-LL | extern "cdecl" {}
-   | ^^^^^^^^^^^^^^^^^
-   |
-   = help: use `extern "C"` instead
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #137018 <https://github.com/rust-lang/rust/issues/137018>
-
-warning: "stdcall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:83:1
-   |
-LL | extern "stdcall" fn stdcall() {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = help: if you need `extern "stdcall"` on win32 and `extern "C"` everywhere else, use `extern "system"`
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #137018 <https://github.com/rust-lang/rust/issues/137018>
-
-warning: "cdecl" is not a supported ABI for the current target
   --> $DIR/unsupported.rs:102:1
    |
 LL | extern "cdecl" fn cdecl() {}
@@ -191,6 +209,6 @@ LL | extern "cdecl" fn cdecl() {}
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #137018 <https://github.com/rust-lang/rust/issues/137018>
 
-error: aborting due to 17 previous errors; 9 warnings emitted
+error: aborting due to 27 previous errors; 4 warnings emitted
 
 For more information about this error, try `rustc --explain E0570`.

--- a/tests/ui/abi/unsupported.x64.stderr
+++ b/tests/ui/abi/unsupported.x64.stderr
@@ -1,83 +1,83 @@
 error[E0570]: "ptx-kernel" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:37:8
+  --> $DIR/unsupported.rs:41:8
    |
 LL | extern "ptx-kernel" fn ptx() {}
    |        ^^^^^^^^^^^^
 
 error[E0570]: "ptx-kernel" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:39:22
+  --> $DIR/unsupported.rs:43:22
    |
 LL | fn ptx_ptr(f: extern "ptx-kernel" fn()) {
    |                      ^^^^^^^^^^^^
 
 error[E0570]: "ptx-kernel" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:43:8
+  --> $DIR/unsupported.rs:47:8
    |
 LL | extern "ptx-kernel" {}
    |        ^^^^^^^^^^^^
 
 error[E0570]: "gpu-kernel" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:45:8
+  --> $DIR/unsupported.rs:49:8
    |
 LL | extern "gpu-kernel" fn gpu() {}
    |        ^^^^^^^^^^^^
 
 error[E0570]: "aapcs" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:48:8
+  --> $DIR/unsupported.rs:52:8
    |
 LL | extern "aapcs" fn aapcs() {}
    |        ^^^^^^^
 
 error[E0570]: "aapcs" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:50:24
+  --> $DIR/unsupported.rs:54:24
    |
 LL | fn aapcs_ptr(f: extern "aapcs" fn()) {
    |                        ^^^^^^^
 
 error[E0570]: "aapcs" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:54:8
+  --> $DIR/unsupported.rs:58:8
    |
 LL | extern "aapcs" {}
    |        ^^^^^^^
 
 error[E0570]: "msp430-interrupt" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:57:8
+  --> $DIR/unsupported.rs:61:8
    |
 LL | extern "msp430-interrupt" {}
    |        ^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "avr-interrupt" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:60:8
+  --> $DIR/unsupported.rs:64:8
    |
 LL | extern "avr-interrupt" {}
    |        ^^^^^^^^^^^^^^^
 
 error[E0570]: "riscv-interrupt-m" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:63:8
+  --> $DIR/unsupported.rs:67:8
    |
 LL | extern "riscv-interrupt-m" {}
    |        ^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "thiscall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:69:8
+  --> $DIR/unsupported.rs:73:8
    |
 LL | extern "thiscall" fn thiscall() {}
    |        ^^^^^^^^^^
 
 error[E0570]: "thiscall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:71:27
+  --> $DIR/unsupported.rs:75:27
    |
 LL | fn thiscall_ptr(f: extern "thiscall" fn()) {
    |                           ^^^^^^^^^^
 
 error[E0570]: "thiscall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:75:8
+  --> $DIR/unsupported.rs:79:8
    |
 LL | extern "thiscall" {}
    |        ^^^^^^^^^^
 
 error[E0570]: "stdcall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:78:8
+  --> $DIR/unsupported.rs:82:8
    |
 LL | extern "stdcall" fn stdcall() {}
    |        ^^^^^^^^^
@@ -85,7 +85,7 @@ LL | extern "stdcall" fn stdcall() {}
    = help: if you need `extern "stdcall"` on win32 and `extern "C"` everywhere else, use `extern "system"`
 
 error[E0570]: "stdcall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:82:26
+  --> $DIR/unsupported.rs:86:26
    |
 LL | fn stdcall_ptr(f: extern "stdcall" fn()) {
    |                          ^^^^^^^^^
@@ -93,7 +93,7 @@ LL | fn stdcall_ptr(f: extern "stdcall" fn()) {
    = help: if you need `extern "stdcall"` on win32 and `extern "C"` everywhere else, use `extern "system"`
 
 error[E0570]: "stdcall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:88:8
+  --> $DIR/unsupported.rs:92:8
    |
 LL | extern "stdcall" {}
    |        ^^^^^^^^^
@@ -101,7 +101,7 @@ LL | extern "stdcall" {}
    = help: if you need `extern "stdcall"` on win32 and `extern "C"` everywhere else, use `extern "system"`
 
 error[E0570]: "stdcall-unwind" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:92:8
+  --> $DIR/unsupported.rs:96:8
    |
 LL | extern "stdcall-unwind" {}
    |        ^^^^^^^^^^^^^^^^
@@ -109,31 +109,31 @@ LL | extern "stdcall-unwind" {}
    = help: if you need `extern "stdcall-unwind"` on win32 and `extern "C-unwind"` everywhere else, use `extern "system-unwind"`
 
 error[E0570]: "cmse-nonsecure-call" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:121:28
+  --> $DIR/unsupported.rs:125:28
    |
 LL | fn cmse_call_ptr(f: extern "cmse-nonsecure-call" fn()) {
    |                            ^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "cmse-nonsecure-entry" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:126:8
+  --> $DIR/unsupported.rs:130:8
    |
 LL | extern "cmse-nonsecure-entry" fn cmse_entry() {}
    |        ^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "cmse-nonsecure-entry" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:128:29
+  --> $DIR/unsupported.rs:132:29
    |
 LL | fn cmse_entry_ptr(f: extern "cmse-nonsecure-entry" fn()) {
    |                             ^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "cmse-nonsecure-entry" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:132:8
+  --> $DIR/unsupported.rs:136:8
    |
 LL | extern "cmse-nonsecure-entry" {}
    |        ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: "cdecl" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:100:17
+  --> $DIR/unsupported.rs:104:17
    |
 LL | fn cdecl_ptr(f: extern "cdecl" fn()) {
    |                 ^^^^^^^^^^^^^^^^^^^
@@ -144,7 +144,7 @@ LL | fn cdecl_ptr(f: extern "cdecl" fn()) {
    = note: `#[warn(unsupported_calling_conventions)]` (part of `#[warn(future_incompatible)]`) on by default
 
 warning: "cdecl" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:105:1
+  --> $DIR/unsupported.rs:109:1
    |
 LL | extern "cdecl" {}
    | ^^^^^^^^^^^^^^^^^
@@ -154,7 +154,7 @@ LL | extern "cdecl" {}
    = note: for more information, see issue #137018 <https://github.com/rust-lang/rust/issues/137018>
 
 warning: "cdecl-unwind" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:108:1
+  --> $DIR/unsupported.rs:112:1
    |
 LL | extern "cdecl-unwind" {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -164,7 +164,7 @@ LL | extern "cdecl-unwind" {}
    = note: for more information, see issue #137018 <https://github.com/rust-lang/rust/issues/137018>
 
 warning: "cdecl" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:97:1
+  --> $DIR/unsupported.rs:101:1
    |
 LL | extern "cdecl" fn cdecl() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/abi/unsupported.x64.stderr
+++ b/tests/ui/abi/unsupported.x64.stderr
@@ -1,83 +1,83 @@
 error[E0570]: "ptx-kernel" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:41:8
+  --> $DIR/unsupported.rs:42:8
    |
 LL | extern "ptx-kernel" fn ptx() {}
    |        ^^^^^^^^^^^^
 
 error[E0570]: "ptx-kernel" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:43:22
+  --> $DIR/unsupported.rs:44:22
    |
 LL | fn ptx_ptr(f: extern "ptx-kernel" fn()) {
    |                      ^^^^^^^^^^^^
 
 error[E0570]: "ptx-kernel" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:47:8
+  --> $DIR/unsupported.rs:48:8
    |
 LL | extern "ptx-kernel" {}
    |        ^^^^^^^^^^^^
 
 error[E0570]: "gpu-kernel" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:49:8
+  --> $DIR/unsupported.rs:50:8
    |
 LL | extern "gpu-kernel" fn gpu() {}
    |        ^^^^^^^^^^^^
 
 error[E0570]: "aapcs" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:52:8
+  --> $DIR/unsupported.rs:53:8
    |
 LL | extern "aapcs" fn aapcs() {}
    |        ^^^^^^^
 
 error[E0570]: "aapcs" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:54:24
+  --> $DIR/unsupported.rs:55:24
    |
 LL | fn aapcs_ptr(f: extern "aapcs" fn()) {
    |                        ^^^^^^^
 
 error[E0570]: "aapcs" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:58:8
+  --> $DIR/unsupported.rs:59:8
    |
 LL | extern "aapcs" {}
    |        ^^^^^^^
 
 error[E0570]: "msp430-interrupt" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:61:8
+  --> $DIR/unsupported.rs:62:8
    |
 LL | extern "msp430-interrupt" {}
    |        ^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "avr-interrupt" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:64:8
+  --> $DIR/unsupported.rs:65:8
    |
 LL | extern "avr-interrupt" {}
    |        ^^^^^^^^^^^^^^^
 
 error[E0570]: "riscv-interrupt-m" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:67:8
+  --> $DIR/unsupported.rs:68:8
    |
 LL | extern "riscv-interrupt-m" {}
    |        ^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "thiscall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:73:8
+  --> $DIR/unsupported.rs:74:8
    |
 LL | extern "thiscall" fn thiscall() {}
    |        ^^^^^^^^^^
 
 error[E0570]: "thiscall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:75:27
+  --> $DIR/unsupported.rs:76:27
    |
 LL | fn thiscall_ptr(f: extern "thiscall" fn()) {
    |                           ^^^^^^^^^^
 
 error[E0570]: "thiscall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:79:8
+  --> $DIR/unsupported.rs:80:8
    |
 LL | extern "thiscall" {}
    |        ^^^^^^^^^^
 
 error[E0570]: "stdcall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:82:8
+  --> $DIR/unsupported.rs:83:8
    |
 LL | extern "stdcall" fn stdcall() {}
    |        ^^^^^^^^^
@@ -85,7 +85,7 @@ LL | extern "stdcall" fn stdcall() {}
    = help: if you need `extern "stdcall"` on win32 and `extern "C"` everywhere else, use `extern "system"`
 
 error[E0570]: "stdcall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:86:26
+  --> $DIR/unsupported.rs:87:26
    |
 LL | fn stdcall_ptr(f: extern "stdcall" fn()) {
    |                          ^^^^^^^^^
@@ -93,7 +93,7 @@ LL | fn stdcall_ptr(f: extern "stdcall" fn()) {
    = help: if you need `extern "stdcall"` on win32 and `extern "C"` everywhere else, use `extern "system"`
 
 error[E0570]: "stdcall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:92:8
+  --> $DIR/unsupported.rs:93:8
    |
 LL | extern "stdcall" {}
    |        ^^^^^^^^^
@@ -101,7 +101,7 @@ LL | extern "stdcall" {}
    = help: if you need `extern "stdcall"` on win32 and `extern "C"` everywhere else, use `extern "system"`
 
 error[E0570]: "stdcall-unwind" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:96:8
+  --> $DIR/unsupported.rs:97:8
    |
 LL | extern "stdcall-unwind" {}
    |        ^^^^^^^^^^^^^^^^
@@ -109,31 +109,31 @@ LL | extern "stdcall-unwind" {}
    = help: if you need `extern "stdcall-unwind"` on win32 and `extern "C-unwind"` everywhere else, use `extern "system-unwind"`
 
 error[E0570]: "cmse-nonsecure-call" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:125:28
+  --> $DIR/unsupported.rs:126:28
    |
 LL | fn cmse_call_ptr(f: extern "cmse-nonsecure-call" fn()) {
    |                            ^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "cmse-nonsecure-entry" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:130:8
+  --> $DIR/unsupported.rs:131:8
    |
 LL | extern "cmse-nonsecure-entry" fn cmse_entry() {}
    |        ^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "cmse-nonsecure-entry" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:132:29
+  --> $DIR/unsupported.rs:133:29
    |
 LL | fn cmse_entry_ptr(f: extern "cmse-nonsecure-entry" fn()) {
    |                             ^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "cmse-nonsecure-entry" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:136:8
+  --> $DIR/unsupported.rs:137:8
    |
 LL | extern "cmse-nonsecure-entry" {}
    |        ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: "cdecl" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:104:17
+  --> $DIR/unsupported.rs:105:17
    |
 LL | fn cdecl_ptr(f: extern "cdecl" fn()) {
    |                 ^^^^^^^^^^^^^^^^^^^
@@ -144,7 +144,7 @@ LL | fn cdecl_ptr(f: extern "cdecl" fn()) {
    = note: `#[warn(unsupported_calling_conventions)]` (part of `#[warn(future_incompatible)]`) on by default
 
 warning: "cdecl" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:109:1
+  --> $DIR/unsupported.rs:110:1
    |
 LL | extern "cdecl" {}
    | ^^^^^^^^^^^^^^^^^
@@ -154,7 +154,7 @@ LL | extern "cdecl" {}
    = note: for more information, see issue #137018 <https://github.com/rust-lang/rust/issues/137018>
 
 warning: "cdecl-unwind" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:112:1
+  --> $DIR/unsupported.rs:113:1
    |
 LL | extern "cdecl-unwind" {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -164,7 +164,7 @@ LL | extern "cdecl-unwind" {}
    = note: for more information, see issue #137018 <https://github.com/rust-lang/rust/issues/137018>
 
 warning: "cdecl" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:101:1
+  --> $DIR/unsupported.rs:102:1
    |
 LL | extern "cdecl" fn cdecl() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/abi/unsupported.x64_win.stderr
+++ b/tests/ui/abi/unsupported.x64_win.stderr
@@ -1,107 +1,107 @@
 error[E0570]: "ptx-kernel" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:37:8
+  --> $DIR/unsupported.rs:41:8
    |
 LL | extern "ptx-kernel" fn ptx() {}
    |        ^^^^^^^^^^^^
 
 error[E0570]: "ptx-kernel" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:39:22
+  --> $DIR/unsupported.rs:43:22
    |
 LL | fn ptx_ptr(f: extern "ptx-kernel" fn()) {
    |                      ^^^^^^^^^^^^
 
 error[E0570]: "ptx-kernel" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:43:8
+  --> $DIR/unsupported.rs:47:8
    |
 LL | extern "ptx-kernel" {}
    |        ^^^^^^^^^^^^
 
 error[E0570]: "gpu-kernel" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:45:8
+  --> $DIR/unsupported.rs:49:8
    |
 LL | extern "gpu-kernel" fn gpu() {}
    |        ^^^^^^^^^^^^
 
 error[E0570]: "aapcs" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:48:8
+  --> $DIR/unsupported.rs:52:8
    |
 LL | extern "aapcs" fn aapcs() {}
    |        ^^^^^^^
 
 error[E0570]: "aapcs" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:50:24
+  --> $DIR/unsupported.rs:54:24
    |
 LL | fn aapcs_ptr(f: extern "aapcs" fn()) {
    |                        ^^^^^^^
 
 error[E0570]: "aapcs" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:54:8
+  --> $DIR/unsupported.rs:58:8
    |
 LL | extern "aapcs" {}
    |        ^^^^^^^
 
 error[E0570]: "msp430-interrupt" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:57:8
+  --> $DIR/unsupported.rs:61:8
    |
 LL | extern "msp430-interrupt" {}
    |        ^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "avr-interrupt" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:60:8
+  --> $DIR/unsupported.rs:64:8
    |
 LL | extern "avr-interrupt" {}
    |        ^^^^^^^^^^^^^^^
 
 error[E0570]: "riscv-interrupt-m" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:63:8
+  --> $DIR/unsupported.rs:67:8
    |
 LL | extern "riscv-interrupt-m" {}
    |        ^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "thiscall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:69:8
+  --> $DIR/unsupported.rs:73:8
    |
 LL | extern "thiscall" fn thiscall() {}
    |        ^^^^^^^^^^
 
 error[E0570]: "thiscall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:71:27
+  --> $DIR/unsupported.rs:75:27
    |
 LL | fn thiscall_ptr(f: extern "thiscall" fn()) {
    |                           ^^^^^^^^^^
 
 error[E0570]: "thiscall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:75:8
+  --> $DIR/unsupported.rs:79:8
    |
 LL | extern "thiscall" {}
    |        ^^^^^^^^^^
 
 error[E0570]: "cmse-nonsecure-call" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:121:28
+  --> $DIR/unsupported.rs:125:28
    |
 LL | fn cmse_call_ptr(f: extern "cmse-nonsecure-call" fn()) {
    |                            ^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "cmse-nonsecure-entry" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:126:8
+  --> $DIR/unsupported.rs:130:8
    |
 LL | extern "cmse-nonsecure-entry" fn cmse_entry() {}
    |        ^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "cmse-nonsecure-entry" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:128:29
+  --> $DIR/unsupported.rs:132:29
    |
 LL | fn cmse_entry_ptr(f: extern "cmse-nonsecure-entry" fn()) {
    |                             ^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "cmse-nonsecure-entry" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:132:8
+  --> $DIR/unsupported.rs:136:8
    |
 LL | extern "cmse-nonsecure-entry" {}
    |        ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: "stdcall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:82:19
+  --> $DIR/unsupported.rs:86:19
    |
 LL | fn stdcall_ptr(f: extern "stdcall" fn()) {
    |                   ^^^^^^^^^^^^^^^^^^^^^
@@ -112,7 +112,7 @@ LL | fn stdcall_ptr(f: extern "stdcall" fn()) {
    = note: `#[warn(unsupported_calling_conventions)]` (part of `#[warn(future_incompatible)]`) on by default
 
 warning: "stdcall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:88:1
+  --> $DIR/unsupported.rs:92:1
    |
 LL | extern "stdcall" {}
    | ^^^^^^^^^^^^^^^^^^^
@@ -122,7 +122,7 @@ LL | extern "stdcall" {}
    = note: for more information, see issue #137018 <https://github.com/rust-lang/rust/issues/137018>
 
 warning: "stdcall-unwind" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:92:1
+  --> $DIR/unsupported.rs:96:1
    |
 LL | extern "stdcall-unwind" {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -132,7 +132,7 @@ LL | extern "stdcall-unwind" {}
    = note: for more information, see issue #137018 <https://github.com/rust-lang/rust/issues/137018>
 
 warning: "cdecl" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:100:17
+  --> $DIR/unsupported.rs:104:17
    |
 LL | fn cdecl_ptr(f: extern "cdecl" fn()) {
    |                 ^^^^^^^^^^^^^^^^^^^
@@ -142,7 +142,7 @@ LL | fn cdecl_ptr(f: extern "cdecl" fn()) {
    = note: for more information, see issue #137018 <https://github.com/rust-lang/rust/issues/137018>
 
 warning: "cdecl" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:105:1
+  --> $DIR/unsupported.rs:109:1
    |
 LL | extern "cdecl" {}
    | ^^^^^^^^^^^^^^^^^
@@ -152,7 +152,7 @@ LL | extern "cdecl" {}
    = note: for more information, see issue #137018 <https://github.com/rust-lang/rust/issues/137018>
 
 warning: "cdecl-unwind" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:108:1
+  --> $DIR/unsupported.rs:112:1
    |
 LL | extern "cdecl-unwind" {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -162,7 +162,7 @@ LL | extern "cdecl-unwind" {}
    = note: for more information, see issue #137018 <https://github.com/rust-lang/rust/issues/137018>
 
 warning: "cdecl" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:137:1
+  --> $DIR/unsupported.rs:141:1
    |
 LL | extern "cdecl" {}
    | ^^^^^^^^^^^^^^^^^
@@ -172,7 +172,7 @@ LL | extern "cdecl" {}
    = note: for more information, see issue #137018 <https://github.com/rust-lang/rust/issues/137018>
 
 warning: "stdcall" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:78:1
+  --> $DIR/unsupported.rs:82:1
    |
 LL | extern "stdcall" fn stdcall() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -182,7 +182,7 @@ LL | extern "stdcall" fn stdcall() {}
    = note: for more information, see issue #137018 <https://github.com/rust-lang/rust/issues/137018>
 
 warning: "cdecl" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:97:1
+  --> $DIR/unsupported.rs:101:1
    |
 LL | extern "cdecl" fn cdecl() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/asm/naked-functions.rs
+++ b/tests/ui/asm/naked-functions.rs
@@ -3,7 +3,7 @@
 //@ ignore-spirv
 //@ reference: attributes.codegen.naked.body
 
-#![feature(asm_unwind, linkage, rustc_attrs, cfg_target_object_format)]
+#![feature(asm_unwind, linkage, rustc_attrs, cfg_target_object_format, abi_custom)]
 #![crate_type = "lib"]
 
 use std::arch::{asm, naked_asm};
@@ -240,4 +240,11 @@ pub extern "C" fn rustc_std_internal_symbol() {
 #[unsafe(naked)]
 pub extern "C" fn rustfmt_skip() {
     naked_asm!("", options(raw));
+}
+
+/// This is here to ensure that for any new target that adds assembly support, we
+/// check whether it can/does support `extern "custom"`.
+#[unsafe(naked)]
+unsafe extern "custom" fn abi_custom() {
+    naked_asm!("")
 }


### PR DESCRIPTION
tracking issue: https://github.com/rust-lang/rust/issues/140829

I'm not sure if we should exclude any other architectures? The GPU ones are a bit suspect maybe?