### PR TITLE
Add missing `needs_drop` check to `DroplessArena`.

### DIFF
--- a/compiler/rustc_arena/src/lib.rs
+++ b/compiler/rustc_arena/src/lib.rs
@@ -542,11 +542,12 @@ impl DroplessArena {
 
     #[inline]
     pub fn alloc_from_iter<T, I: IntoIterator<Item = T>>(&self, iter: I) -> &mut [T] {
+        assert!(!mem::needs_drop::<T>());
+        assert!(size_of::<T>() != 0);
+
         // Warning: this function is reentrant: `iter` could hold a reference to `&self` and
         // allocate additional elements while we're iterating.
         let iter = iter.into_iter();
-        assert!(size_of::<T>() != 0);
-        assert!(!mem::needs_drop::<T>());
 
         let size_hint = iter.size_hint();
 
@@ -577,6 +578,7 @@ impl DroplessArena {
     ) -> Result<&mut [T], E> {
         // Despite the similarity with `alloc_from_iter`, we cannot reuse their fast case, as we
         // cannot know the minimum length of the iterator in this case.
+        assert!(!mem::needs_drop::<T>());
         assert!(size_of::<T>() != 0);
 
         // Takes care of reentrancy.


### PR DESCRIPTION
Three of the four public allocation functions in `DroplessArena` check that the allocated type doesn't implement `Drop`: `alloc`, `alloc_slice`, `alloc_from_iter`. This commit adds the missing check to `try_alloc_from_iter`.

It also moves and reorders some lines in `alloc_from_iter` for consistency with the other methods.

r? @Nadrieril 