### PR TITLE
Implement ExactSizeIterator for Chain when underlying iterators are ExactSize

### DIFF
--- a/library/core/src/iter/adapters/chain.rs
+++ b/library/core/src/iter/adapters/chain.rs
@@ -304,6 +304,18 @@ where
 {
 }
 
+#[stable(feature = "chain_exact_size", since = "CURRENT_RUSTC_VERSION")]
+impl<A, B> ExactSizeIterator for Chain<A, B>
+where
+    A: ExactSizeIterator,
+    B: ExactSizeIterator<Item = A::Item>,
+{
+    fn len(&self) -> usize {
+        self.a.as_ref().map_or(0, ExactSizeIterator::len)
+            + self.b.as_ref().map_or(0, ExactSizeIterator::len)
+    }
+}
+
 #[stable(feature = "default_iters", since = "1.70.0")]
 impl<A: Default, B: Default> Default for Chain<A, B> {
     /// Creates a `Chain` from the default values for `A` and `B`.

--- a/library/coretests/tests/iter/adapters/chain.rs
+++ b/library/coretests/tests/iter/adapters/chain.rs
@@ -291,3 +291,13 @@ fn test_double_ended_chain() {
     assert_eq!(CrazyIterator::new().chain(0..10).rev().last(), Some(0));
     assert!((0..10).chain(CrazyIterator::new()).rev().any(|i| i == 0));
 }
+
+#[test]
+fn chain_implements_exact_size() {
+    fn requires_exact_size<I: ExactSizeIterator>(_i: &I) {}
+
+    let chain = [1, 2, 3].into_iter().chain([4, 5, 6]);
+    requires_exact_size(&chain);
+
+    assert_eq!(chain.len(), 6);
+}


### PR DESCRIPTION
I couldn't find any reason why `Chain` couldn't be `ExactSizeIterator` when the underlying iterators are both `ExactSizeIterator`, so I've implemented it here.

I'm not 100% certain how this sort of addition to the language is supposed to be feature-gated, so I just modeled the `#[stable]` attribute after other PRs I was able to find that did similar additions.