### PR TITLE
hir_ty_lowering: avoid self type lookup for inherent aliases

### DIFF
--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/errors.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/errors.rs
@@ -984,15 +984,17 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                 ty::PredicateKind::Clause(ty::ClauseKind::Projection(pred)) => {
                     // `<Foo as Iterator>::Item = String`.
                     let projection_term = pred.projection_term;
+                    let term = pred.term;
+                    let self_ty = projection_term.args.get(0).and_then(|arg| arg.as_type())?;
+
+                    let obligation = format!("{projection_term} = {term}");
                     let quiet_projection_term = projection_term
                         .with_replaced_self_ty(tcx, Ty::new_var(tcx, ty::TyVid::ZERO));
-
-                    let term = pred.term;
-                    let obligation = format!("{projection_term} = {term}");
                     let quiet = format!("{quiet_projection_term} = {term}");
 
-                    bound_span_label(projection_term.self_ty(), &obligation, &quiet);
-                    Some((obligation, projection_term.self_ty()))
+                    bound_span_label(self_ty, &obligation, &quiet);
+
+                    Some(obligation)
                 }
                 ty::PredicateKind::Clause(ty::ClauseKind::Trait(poly_trait_ref)) => {
                     let p = poly_trait_ref.trait_ref;
@@ -1001,7 +1003,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                     let obligation = format!("{self_ty}: {path}");
                     let quiet = format!("_: {path}");
                     bound_span_label(self_ty, &obligation, &quiet);
-                    Some((obligation, self_ty))
+                    Some(obligation)
                 }
                 _ => None,
             }
@@ -1013,7 +1015,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             .into_iter()
             .map(|error| error.root_obligation.predicate)
             .filter_map(format_pred)
-            .map(|(p, _)| format!("`{p}`"))
+            .map(|p| format!("`{p}`"))
             .collect();
         bounds.sort();
         bounds.dedup();

--- a/tests/ui/associated-inherent-types/next-solver-unsatisfied-bounds-inherent-tait.rs
+++ b/tests/ui/associated-inherent-types/next-solver-unsatisfied-bounds-inherent-tait.rs
@@ -1,0 +1,22 @@
+//@ compile-flags: -Znext-solver=globally
+
+#![feature(inherent_associated_types)]
+#![feature(type_alias_impl_trait)]
+#![allow(incomplete_features)]
+
+struct Foo<T>(T);
+
+impl Foo<Vec<[u32]>> {
+    //~^ ERROR the size for values of type `[u32]` cannot be known at compilation time
+    type Assoc = u32;
+}
+
+type Tait = impl Sized;
+
+#[define_opaque(Tait)]
+fn bar() {
+    let _: Foo<Tait>::Assoc = 42;
+    //~^ ERROR the associated type `Assoc` exists for `Foo<Tait>`, but its trait bounds were not satisfied
+}
+
+fn main() {}

--- a/tests/ui/associated-inherent-types/next-solver-unsatisfied-bounds-inherent-tait.stderr
+++ b/tests/ui/associated-inherent-types/next-solver-unsatisfied-bounds-inherent-tait.stderr
@@ -1,0 +1,22 @@
+error[E0277]: the size for values of type `[u32]` cannot be known at compilation time
+  --> $DIR/next-solver-unsatisfied-bounds-inherent-tait.rs:9:10
+   |
+LL | impl Foo<Vec<[u32]>> {
+   |          ^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u32]`
+note: required by an implicit `Sized` bound in `Vec`
+  --> $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
+
+error: the associated type `Assoc` exists for `Foo<Tait>`, but its trait bounds were not satisfied
+  --> $DIR/next-solver-unsatisfied-bounds-inherent-tait.rs:18:23
+   |
+LL | struct Foo<T>(T);
+   | ------------- associated type `Assoc` not found for this struct
+...
+LL |     let _: Foo<Tait>::Assoc = 42;
+   |                       ^^^^^ associated type cannot be referenced on `Foo<Tait>` due to unsatisfied trait bounds
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
fixes rust-lang/rust#158512

the crash happens while building the unsatisfied-bounds diagnostic for an inherent associated alias. that path was calling `self_ty()` directly, so an empty args list could panic under the global next solver.

imo the guard belongs in the diagnostic code. it keeps the existing span label when the inherent alias still has a self arg, and only skips that label when the args are already malformed.