### PR TITLE
powerpc64le_unknown_freebsd.rs: link with -lgcc

### DIFF
--- a/compiler/rustc_target/src/spec/targets/powerpc64le_unknown_freebsd.rs
+++ b/compiler/rustc_target/src/spec/targets/powerpc64le_unknown_freebsd.rs
@@ -1,12 +1,15 @@
 use crate::spec::{
     Arch, Cc, CfgAbi, LinkerFlavor, Lld, LlvmAbi, StackProbeType, Target, TargetMetadata,
-    TargetOptions, base,
+    TargetOptions, add_link_args, base,
 };
 
 pub(crate) fn target() -> Target {
     let mut base = base::freebsd::opts();
     base.cpu = "ppc64le".into();
     base.add_pre_link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-m64"]);
+    // long double is IEEE-128; f128 soft-float ops emit the PPC __*kf* helpers,
+    // which compiler_builtins lacks. Resolve them from base libgcc.
+    add_link_args(&mut base.late_link_args, LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-lgcc"]);
     base.max_atomic_width = Some(64);
     base.stack_probes = StackProbeType::Inline;
     base.cfg_abi = CfgAbi::ElfV2;


### PR DESCRIPTION
Starting with FreeBSD 16.0, powerpc64le switches to IEEE long double. 128 bit arithmetics are implemented in LLVM's compiler_rt, which is FreeBSD's libgcc. Link with it so that building on FreeBSD 16.0 succeeds - noop for earlier releases.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
