### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/bootstrap.example.toml
+++ b/bootstrap.example.toml
@@ -697,6 +697,13 @@
 # FIXME(#61117): Some tests fail when this option is enabled.
 #rust.debuginfo-level-tests = 0
 
+# Compress debuginfo of Rust and C/C++ code.
+# Valid options:
+# - "off" or false: disable compression
+# - true: compress debuginfo with the default compression method (currently zlib)
+# - "zlib": compress debuginfo with zlib
+#rust.compress-debuginfo = "off"
+
 # Should rustc and the standard library be built with split debuginfo? Default
 # is platform dependent.
 #
@@ -1018,6 +1025,13 @@
 # producing a `.pdb` file. On Windows GNU rustc doesn't support splitting debuginfo,
 # and enabling it causes issues.
 #split-debuginfo = if linux || windows-gnu { off } else if windows-msvc { packed } else if apple { unpacked }
+
+# Compress debuginfo for Rust and C/C++ code of this target.
+# Valid options:
+# - "off" or false: disable compression
+# - true: compress debuginfo with the default compression method (currently zlib)
+# - "zlib": compress debuginfo with zlib
+#compress-debuginfo = "off"
 
 # Path to the `llvm-config` binary of the installation of a custom LLVM to link
 # against. Note that if this is specified we don't compile LLVM at all for this

--- a/compiler/rustc_arena/src/lib.rs
+++ b/compiler/rustc_arena/src/lib.rs
@@ -542,11 +542,12 @@ impl DroplessArena {
 
     #[inline]
     pub fn alloc_from_iter<T, I: IntoIterator<Item = T>>(&self, iter: I) -> &mut [T] {
+        assert!(!mem::needs_drop::<T>());
+        assert!(size_of::<T>() != 0);
+
         // Warning: this function is reentrant: `iter` could hold a reference to `&self` and
         // allocate additional elements while we're iterating.
         let iter = iter.into_iter();
-        assert!(size_of::<T>() != 0);
-        assert!(!mem::needs_drop::<T>());
 
         let size_hint = iter.size_hint();
 
@@ -577,6 +578,7 @@ impl DroplessArena {
     ) -> Result<&mut [T], E> {
         // Despite the similarity with `alloc_from_iter`, we cannot reuse their fast case, as we
         // cannot know the minimum length of the iterator in this case.
+        assert!(!mem::needs_drop::<T>());
         assert!(size_of::<T>() != 0);
 
         // Takes care of reentrancy.

--- a/compiler/rustc_expand/src/base.rs
+++ b/compiler/rustc_expand/src/base.rs
@@ -1199,7 +1199,7 @@ pub trait LintStoreExpand {
 
 type LintStoreExpandDyn<'a> = Option<&'a (dyn LintStoreExpand + 'a)>;
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Default)]
 pub struct ModuleData {
     /// Path to the module starting from the crate name, like `my_crate::foo::bar`.
     pub mod_path: Vec<Ident>,

--- a/compiler/rustc_hir_analysis/src/check/check.rs
+++ b/compiler/rustc_hir_analysis/src/check/check.rs
@@ -839,9 +839,8 @@ pub(crate) fn check_item_type(tcx: TyCtxt<'_>, def_id: LocalDefId) -> Result<(),
             tcx.ensure_ok().associated_items(def_id);
             if of_trait {
                 let impl_trait_header = tcx.impl_trait_header(def_id);
-                res = res.and(tcx.ensure_result().coherent_trait(
-                    impl_trait_header.trait_ref.instantiate_identity().skip_norm_wip().def_id,
-                ));
+                res = res
+                    .and(tcx.ensure_result().coherent_trait(impl_trait_header.trait_ref.def_id()));
 
                 if res.is_ok() {
                     // Checking this only makes sense if the all trait impls satisfy basic

--- a/compiler/rustc_mir_transform/src/check_call_recursion.rs
+++ b/compiler/rustc_mir_transform/src/check_call_recursion.rs
@@ -45,7 +45,7 @@ impl<'tcx> MirLint<'tcx> for CheckDropRecursion {
         if let DefKind::AssocFn = tcx.def_kind(def_id)
         && let Some(impl_id) = tcx.trait_impl_of_assoc(def_id.to_def_id())
         && let trait_ref = tcx.impl_trait_ref(impl_id)
-        && tcx.is_lang_item(trait_ref.instantiate_identity().skip_norm_wip().def_id, LangItem::Drop)
+        && tcx.is_lang_item(trait_ref.def_id(), LangItem::Drop)
         // avoid erroneous `Drop` impls from causing ICEs below
         && let sig = tcx.fn_sig(def_id).instantiate_identity().skip_norm_wip()
         && sig.inputs().skip_binder().len() == 1

--- a/compiler/rustc_resolve/src/error_helper.rs
+++ b/compiler/rustc_resolve/src/error_helper.rs
@@ -109,7 +109,7 @@ impl TypoSuggestion {
 }
 
 /// A free importable items suggested in case of resolution failure.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub(crate) struct ImportSuggestion {
     pub did: Option<DefId>,
     pub descr: &'static str,

--- a/compiler/rustc_resolve/src/imports.rs
+++ b/compiler/rustc_resolve/src/imports.rs
@@ -69,7 +69,6 @@ impl<'ra> PendingDecl<'ra> {
 }
 
 /// Contains data for specific kinds of imports.
-#[derive(Clone)]
 pub(crate) enum ImportKind<'ra> {
     Single {
         /// `source` in `use prefix::source as target`.
@@ -157,7 +156,7 @@ impl<'ra> std::fmt::Debug for ImportKind<'ra> {
 }
 
 /// One import.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub(crate) struct ImportData<'ra> {
     pub kind: ImportKind<'ra>,
 
@@ -280,7 +279,7 @@ impl<'ra> ImportData<'ra> {
 }
 
 /// Records information about the resolution of a name in a namespace of a module.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub(crate) struct NameResolution<'ra> {
     /// Single imports that may define the name in the namespace.
     /// Imports are arena-allocated, so it's ok to use pointers as keys.
@@ -322,7 +321,7 @@ impl<'ra> NameResolution<'ra> {
 
 /// An error that may be transformed into a diagnostic later. Used to combine multiple unresolved
 /// import errors within the same use tree into a single diagnostic.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub(crate) struct UnresolvedImportError {
     pub(crate) span: Span,
     pub(crate) label: Option<String>,
@@ -341,7 +340,7 @@ fn pub_use_of_private_extern_crate_hack(
     import: ImportSummary,
     decl: Decl<'_>,
 ) -> Option<LocalDefId> {
-    match (import.is_single, decl.kind) {
+    match (import.is_single, &decl.kind) {
         (true, DeclKind::Import { import: decl_import, .. })
             if let ImportKind::ExternCrate { def_id, .. } = decl_import.kind
                 && import.vis.is_public() =>

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -133,7 +133,7 @@ pub(super) struct MissingLifetime {
 
 /// Description of the lifetimes appearing in a function parameter.
 /// This is used to provide a literal explanation to the elision failure.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub(super) struct ElisionFnParameter {
     /// The index of the argument in the original definition.
     pub index: usize,

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -992,7 +992,7 @@ impl<'ra> fmt::Debug for LocalModule<'ra> {
 }
 
 /// Data associated with any name declaration.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 struct DeclData<'ra> {
     kind: DeclKind<'ra>,
     ambiguity: CmCell<Option<(Decl<'ra>, bool /*warning*/)>>,
@@ -1026,7 +1026,7 @@ impl std::hash::Hash for DeclData<'_> {
 }
 
 /// Name declaration kind.
-#[derive(Clone, Copy, Debug)]
+#[derive(Debug)]
 enum DeclKind<'ra> {
     /// The name declaration is a definition (possibly without a `DefId`),
     /// can be provided by source code or built into the language.

--- a/compiler/rustc_type_ir/src/binder.rs
+++ b/compiler/rustc_type_ir/src/binder.rs
@@ -448,6 +448,12 @@ impl<I: Interner, T> EarlyBinder<I, T> {
     }
 }
 
+impl<I: Interner> EarlyBinder<I, ty::TraitRef<I>> {
+    pub fn def_id(&self) -> I::TraitId {
+        self.value.def_id
+    }
+}
+
 impl<I: Interner, T> EarlyBinder<I, Option<T>> {
     pub fn transpose(self) -> Option<EarlyBinder<I, T>> {
         self.value.map(|value| EarlyBinder { value, _tcx: PhantomData })

--- a/library/std/src/sys/random/linux.rs
+++ b/library/std/src/sys/random/linux.rs
@@ -123,7 +123,9 @@ fn getrandom(mut bytes: &mut [u8], insecure: bool) {
                         GETRANDOM_AVAILABLE.store(false, Relaxed);
                         break;
                     }
-                    _ => panic!("failed to generate random data"),
+                    other => {
+                        panic!("failed to generate random data: errno={other:?}, flags={flags:?}")
+                    }
                 }
             }
         }

--- a/src/bootstrap/defaults/bootstrap.dist.toml
+++ b/src/bootstrap/defaults/bootstrap.dist.toml
@@ -26,6 +26,8 @@ download-rustc = false
 llvm-bitcode-linker = true
 # Required to make builds reproducible.
 remap-debuginfo = true
+# Compress debuginfo in generated artifacts to reduce their size
+compress-debuginfo = "zlib"
 
 [dist]
 # Use better compression when preparing tarballs.

--- a/src/bootstrap/src/core/builder/cargo.rs
+++ b/src/bootstrap/src/core/builder/cargo.rs
@@ -5,8 +5,8 @@ use std::path::{Path, PathBuf};
 use super::{Builder, Kind};
 use crate::core::build_steps::test;
 use crate::core::build_steps::tool::SourceType;
-use crate::core::config::SplitDebuginfo;
 use crate::core::config::flags::Color;
+use crate::core::config::{CompressDebuginfo, SplitDebuginfo};
 use crate::utils::build_stamp;
 use crate::utils::helpers::{self, LldThreads, check_cfg_arg, linker_flags};
 use crate::{
@@ -340,8 +340,13 @@ impl Cargo {
             self.rustdocflags.arg(&arg);
         }
 
-        if !builder.config.dry_run() && builder.cc[&target].args().iter().any(|arg| arg == "-gz") {
-            self.rustflags.arg("-Clink-arg=-gz");
+        if !builder.config.dry_run() {
+            match builder.config.compress_debuginfo(target) {
+                CompressDebuginfo::Zlib => {
+                    self.rustflags.arg("-Clink-arg=-Wl,--compress-debug-sections=zlib");
+                }
+                CompressDebuginfo::Off => {}
+            }
         }
 
         // Ignore linker warnings for now. These are complicated to fix and don't affect the build.

--- a/src/bootstrap/src/core/builder/cargo.rs
+++ b/src/bootstrap/src/core/builder/cargo.rs
@@ -343,7 +343,12 @@ impl Cargo {
         if !builder.config.dry_run() {
             match builder.config.compress_debuginfo(target) {
                 CompressDebuginfo::Zlib => {
-                    self.rustflags.arg("-Clink-arg=-Wl,--compress-debug-sections=zlib");
+                    // Do not enable Zlib compression on:
+                    // - Windows, because MSVC/PDB doesn't support it
+                    // - macOS, because its linker doesn't know the flag
+                    if !self.target.is_windows() && !self.target.is_apple() {
+                        self.rustflags.arg("-Clink-arg=-Wl,--compress-debug-sections=zlib");
+                    }
                 }
                 CompressDebuginfo::Off => {}
             }

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -49,8 +49,8 @@ use crate::core::config::toml::target::{
     DefaultLinuxLinkerOverride, Target, TomlTarget, default_linux_linker_overrides,
 };
 use crate::core::config::{
-    CompilerBuiltins, DebuginfoLevel, DryRun, GccCiMode, LlvmLibunwind, Merge, ReplaceOpt,
-    RustcLto, SplitDebuginfo, StringOrBool, threads_from_config,
+    CompilerBuiltins, CompressDebuginfo, DebuginfoLevel, DryRun, GccCiMode, LlvmLibunwind, Merge,
+    ReplaceOpt, RustcLto, SplitDebuginfo, StringOrBool, threads_from_config,
 };
 use crate::core::download::{
     DownloadContext, download_beta_toolchain, is_download_ci_available, maybe_download_rustfmt,
@@ -210,6 +210,7 @@ pub struct Config {
     pub rust_debuginfo_level_std: DebuginfoLevel,
     pub rust_debuginfo_level_tools: DebuginfoLevel,
     pub rust_debuginfo_level_tests: DebuginfoLevel,
+    pub rust_compress_debuginfo: CompressDebuginfo,
     pub rust_rpath: bool,
     pub rust_strip: bool,
     pub rust_frame_pointers: bool,
@@ -550,6 +551,7 @@ impl Config {
             debuginfo_level_std: rust_debuginfo_level_std,
             debuginfo_level_tools: rust_debuginfo_level_tools,
             debuginfo_level_tests: rust_debuginfo_level_tests,
+            compress_debuginfo: rust_compress_debuginfo,
             backtrace: rust_backtrace,
             incremental: rust_incremental,
             randomize_layout: rust_randomize_layout,
@@ -1469,6 +1471,7 @@ impl Config {
                 .unwrap_or(vec![CodegenBackendKind::Llvm]),
             rust_codegen_units: rust_codegen_units.map(threads_from_config),
             rust_codegen_units_std: rust_codegen_units_std.map(threads_from_config),
+            rust_compress_debuginfo: rust_compress_debuginfo.unwrap_or_default(),
             rust_debug_logging: rust_debug_logging
                 .or(rust_rustc_debug_assertions)
                 .unwrap_or(rust_debug == Some(true)),
@@ -1923,6 +1926,13 @@ impl Config {
             .get(&target)
             .and_then(|t| t.split_debuginfo)
             .unwrap_or_else(|| SplitDebuginfo::default_for_platform(target))
+    }
+
+    pub fn compress_debuginfo(&self, target: TargetSelection) -> CompressDebuginfo {
+        self.target_config
+            .get(&target)
+            .and_then(|t| t.compress_debuginfo)
+            .unwrap_or(self.rust_compress_debuginfo)
     }
 
     /// Checks if the given target is the same as the host target.

--- a/src/bootstrap/src/core/config/mod.rs
+++ b/src/bootstrap/src/core/config/mod.rs
@@ -32,6 +32,7 @@ use std::path::PathBuf;
 
 use build_helper::exit;
 pub use config::*;
+use serde::de::Unexpected;
 use serde::{Deserialize, Deserializer};
 use serde_derive::Deserialize;
 pub use target_selection::TargetSelection;
@@ -375,6 +376,53 @@ impl std::str::FromStr for SplitDebuginfo {
             "off" => Ok(SplitDebuginfo::Off),
             _ => Err(()),
         }
+    }
+}
+
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum CompressDebuginfo {
+    Zlib,
+    #[default]
+    Off,
+}
+
+impl CompressDebuginfo {
+    fn default_on() -> Self {
+        Self::Zlib
+    }
+}
+
+impl std::str::FromStr for CompressDebuginfo {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "zlib" => Ok(CompressDebuginfo::Zlib),
+            "off" => Ok(CompressDebuginfo::Off),
+            _ => Err(()),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for CompressDebuginfo {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        use serde::de::Error;
+
+        Ok(match Deserialize::deserialize(deserializer)? {
+            StringOrBool::Bool(value) => {
+                if value {
+                    CompressDebuginfo::default_on()
+                } else {
+                    CompressDebuginfo::Off
+                }
+            }
+            StringOrBool::String(value) => CompressDebuginfo::from_str(&value).map_err(|_| {
+                D::Error::invalid_value(Unexpected::Str(&value), &"`zlib` or `off`")
+            })?,
+        })
     }
 }
 

--- a/src/bootstrap/src/core/config/target_selection.rs
+++ b/src/bootstrap/src/core/config/target_selection.rs
@@ -82,6 +82,10 @@ impl TargetSelection {
         self.contains("windows")
     }
 
+    pub fn is_apple(&self) -> bool {
+        self.contains("apple")
+    }
+
     pub fn is_windows_gnu(&self) -> bool {
         self.ends_with("windows-gnu")
     }

--- a/src/bootstrap/src/core/config/toml/rust.rs
+++ b/src/bootstrap/src/core/config/toml/rust.rs
@@ -5,7 +5,7 @@ use build_helper::ci::CiEnv;
 use serde::{Deserialize, Deserializer};
 
 use crate::core::config::toml::TomlConfig;
-use crate::core::config::{DebuginfoLevel, Merge, ReplaceOpt, StringOrBool};
+use crate::core::config::{CompressDebuginfo, DebuginfoLevel, Merge, ReplaceOpt, StringOrBool};
 use crate::{BTreeSet, CodegenBackendKind, HashSet, PathBuf, TargetSelection, define_config, exit};
 
 define_config! {
@@ -28,6 +28,7 @@ define_config! {
         debuginfo_level_std: Option<DebuginfoLevel> = "debuginfo-level-std",
         debuginfo_level_tools: Option<DebuginfoLevel> = "debuginfo-level-tools",
         debuginfo_level_tests: Option<DebuginfoLevel> = "debuginfo-level-tests",
+        compress_debuginfo: Option<CompressDebuginfo> = "compress-debuginfo",
         backtrace: Option<bool> = "backtrace",
         incremental: Option<bool> = "incremental",
         default_linker: Option<String> = "default-linker",
@@ -322,6 +323,7 @@ pub fn check_incompatible_options_for_ci_rustc(
         randomize_layout,
         debug_logging,
         debuginfo_level_rustc,
+        compress_debuginfo,
         llvm_tools,
         llvm_bitcode_linker,
         stack_protector,
@@ -389,6 +391,7 @@ pub fn check_incompatible_options_for_ci_rustc(
 
     err!(current_rust_config.optimize, optimize, "rust");
     err!(current_rust_config.randomize_layout, randomize_layout, "rust");
+    err!(current_rust_config.compress_debuginfo, compress_debuginfo, "rust");
     err!(current_rust_config.debug_logging, debug_logging, "rust");
     err!(current_rust_config.debuginfo_level_rustc, debuginfo_level_rustc, "rust");
     err!(current_rust_config.rpath, rpath, "rust");

--- a/src/bootstrap/src/core/config/toml/target.rs
+++ b/src/bootstrap/src/core/config/toml/target.rs
@@ -15,7 +15,8 @@ use serde::de::Error;
 use serde::{Deserialize, Deserializer};
 
 use crate::core::config::{
-    CompilerBuiltins, LlvmLibunwind, Merge, ReplaceOpt, SplitDebuginfo, StringOrBool,
+    CompilerBuiltins, CompressDebuginfo, LlvmLibunwind, Merge, ReplaceOpt, SplitDebuginfo,
+    StringOrBool,
 };
 use crate::{CodegenBackendKind, HashSet, PathBuf, define_config, exit};
 
@@ -68,6 +69,7 @@ pub struct Target {
     pub default_linker_linux_override: DefaultLinuxLinkerOverride,
     pub linker: Option<PathBuf>,
     pub split_debuginfo: Option<SplitDebuginfo>,
+    pub compress_debuginfo: Option<CompressDebuginfo>,
     pub sanitizers: Option<bool>,
     pub profiler: Option<StringOrBool>,
     pub rpath: Option<bool>,

--- a/src/bootstrap/src/utils/cc_detect.rs
+++ b/src/bootstrap/src/utils/cc_detect.rs
@@ -102,17 +102,15 @@ pub fn fill_target_compiler(build: &mut Build, target: TargetSelection) {
     let config = build.config.target_config.get(&target);
     if let Some(cc) = config
         .and_then(|c| c.cc.clone())
-        .or_else(|| default_compiler(&mut cfg, Language::C, target, build))
+        .or_else(|| default_compiler(&cfg, Language::C, target, build))
     {
         cfg.compiler(cc);
     }
 
     let compiler = cfg.get_compiler();
-    let ar = if let ar @ Some(..) = config.and_then(|c| c.ar.clone()) {
-        ar
-    } else {
-        cfg.try_get_archiver().map(|c| PathBuf::from(c.get_program())).ok()
-    };
+    let ar = config
+        .and_then(|c| c.ar.clone())
+        .or_else(|| cfg.try_get_archiver().map(|c| PathBuf::from(c.get_program())).ok());
 
     build.cc.insert(target, compiler.clone());
     let mut cflags = build.cc_handled_clags(target, CLang::C);
@@ -124,7 +122,7 @@ pub fn fill_target_compiler(build: &mut Build, target: TargetSelection) {
     cfg.cpp(true);
     let cxx_configured = if let Some(cxx) = config
         .and_then(|c| c.cxx.clone())
-        .or_else(|| default_compiler(&mut cfg, Language::CPlusPlus, target, build))
+        .or_else(|| default_compiler(&cfg, Language::CPlusPlus, target, build))
     {
         cfg.compiler(cxx);
         true
@@ -160,7 +158,7 @@ pub fn fill_target_compiler(build: &mut Build, target: TargetSelection) {
 /// Determines the default compiler for a given target and language when not explicitly
 /// configured in `bootstrap.toml`.
 fn default_compiler(
-    cfg: &mut cc::Build,
+    cfg: &cc::Build,
     compiler: Language,
     target: TargetSelection,
     build: &Build,

--- a/src/bootstrap/src/utils/cc_detect.rs
+++ b/src/bootstrap/src/utils/cc_detect.rs
@@ -25,7 +25,7 @@ use std::collections::HashSet;
 use std::iter;
 use std::path::{Path, PathBuf};
 
-use crate::core::config::TargetSelection;
+use crate::core::config::{CompressDebuginfo, TargetSelection};
 use crate::utils::exec::{BootstrapCommand, command};
 use crate::{Build, CLang, GitRepo};
 
@@ -38,10 +38,16 @@ fn new_cc_build(build: &Build, target: TargetSelection) -> cc::Build {
         .debug(false)
         // We have to configure out_dir, otherwise flag_if_supported will not work
         .out_dir(build.tempdir().join("cc-rs-out-dir"))
-        // Compress debuginfo
-        .flag_if_supported("-gz")
         .target(&target.triple)
         .host(&build.host_target.triple);
+
+    match build.config.compress_debuginfo(target) {
+        CompressDebuginfo::Zlib => {
+            cfg.flag_if_supported("-gz");
+        }
+        CompressDebuginfo::Off => {}
+    }
+
     match build.crt_static(target) {
         Some(a) => {
             cfg.static_crt(a);

--- a/src/bootstrap/src/utils/cc_detect.rs
+++ b/src/bootstrap/src/utils/cc_detect.rs
@@ -36,6 +36,8 @@ fn new_cc_build(build: &Build, target: TargetSelection) -> cc::Build {
         .opt_level(2)
         .warnings(false)
         .debug(false)
+        // We have to configure out_dir, otherwise flag_if_supported will not work
+        .out_dir(build.tempdir().join("cc-rs-out-dir"))
         // Compress debuginfo
         .flag_if_supported("-gz")
         .target(&target.triple)

--- a/src/bootstrap/src/utils/cc_detect/tests.rs
+++ b/src/bootstrap/src/utils/cc_detect/tests.rs
@@ -86,7 +86,7 @@ fn test_default_compiler_wasi() {
     build.wasi_sdk_path = Some(wasi_sdk.clone());
 
     let mut cfg = cc::Build::new();
-    if let Some(result) = default_compiler(&mut cfg, Language::C, target.clone(), &build) {
+    if let Some(result) = default_compiler(&cfg, Language::C, target.clone(), &build) {
         let expected = {
             let compiler = format!("{}-clang", target.triple);
             wasi_sdk.join("bin").join(compiler)
@@ -105,7 +105,7 @@ fn test_default_compiler_fallback() {
     let build = Build::new(config);
     let target = TargetSelection::from_user("x86_64-unknown-linux-gnu");
     let mut cfg = cc::Build::new();
-    let result = default_compiler(&mut cfg, Language::C, target, &build);
+    let result = default_compiler(&cfg, Language::C, target, &build);
     assert!(result.is_none(), "default_compiler should return None for generic targets");
 }
 

--- a/src/bootstrap/src/utils/change_tracker.rs
+++ b/src/bootstrap/src/utils/change_tracker.rs
@@ -631,4 +631,9 @@ pub const CONFIG_CHANGE_HISTORY: &[ChangeInfo] = &[
         severity: ChangeSeverity::Info,
         summary: "New `--verbose-run-make-subprocess-output` flag for `x.py test` (defaults to true). Set `--verbose-run-make-subprocess-output=false` to suppress verbose subprocess output for passing run-make tests when using `--no-capture`.",
     },
+    ChangeInfo {
+        change_id: 158169,
+        severity: ChangeSeverity::Info,
+        summary: "New option `rust.compress-debuginfo` allows configuring whether Rust and C/C++ debuginfo should be compressed.",
+    },
 ];

--- a/src/ci/docker/host-x86_64/x86_64-gnu-distcheck/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-distcheck/Dockerfile
@@ -28,6 +28,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   xz-utils \
   libssl-dev \
   pkg-config \
+  zlib1g-dev \
   && rm -rf /var/lib/apt/lists/*
 
 COPY scripts/sccache.sh /scripts/

--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -145,6 +145,8 @@ if [ "$DEPLOY$DEPLOY_ALT" = "1" ]; then
   fi
 else
   RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --set rust.remap-debuginfo=false"
+  # No need to compress debuginfo for tests, and we do not want to depend on zlib
+  RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --set rust.compress-debuginfo=off"
 
   # We almost always want debug assertions enabled, but sometimes this takes too
   # long for too little benefit, so we just turn them off.

--- a/tests/ui/std/linux-getrandom-fallback.rs
+++ b/tests/ui/std/linux-getrandom-fallback.rs
@@ -1,5 +1,6 @@
 //@ only-linux
 //@ run-pass
+//@ needs-unwind
 
 #![feature(random)]
 #![feature(rustc_private)]


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#158169 (Fix debuginfo compression in bootstrap)
 - rust-lang/rust#158613 (Fix getrandom fallback test on platforms with `panic=abort`)
 - rust-lang/rust#158620 (Remove skip_norm_w/i/p().def_id with a helper)
 - rust-lang/rust#158633 (Remove unnecessary `Clone` derives on resolver types)
 - rust-lang/rust#158634 (Add missing `needs_drop` check to `DroplessArena`.)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=158169,158613,158620,158633,158634)
<!-- homu-ignore:end -->

