### PR TITLE
Fix coroutine MIR saved local remapping

### DIFF
--- a/compiler/rustc_mir_dataflow/src/impls/storage_liveness.rs
+++ b/compiler/rustc_mir_dataflow/src/impls/storage_liveness.rs
@@ -155,7 +155,6 @@ impl<'tcx> Analysis<'tcx> for MaybeRequiresStorage<'_, 'tcx> {
         match &stmt.kind {
             StatementKind::StorageDead(l) => state.kill(*l),
 
-            // If a place is assigned to in a statement, it needs storage for that statement.
             StatementKind::Assign((place, _)) => {
                 state.gen_(place.local);
             }
@@ -180,12 +179,35 @@ impl<'tcx> Analysis<'tcx> for MaybeRequiresStorage<'_, 'tcx> {
     fn apply_primary_statement_effect(
         &self,
         state: &mut Self::Domain,
-        _: &Statement<'tcx>,
+        stmt: &Statement<'tcx>,
         loc: Location,
     ) {
         // If we move from a place then it only stops needing storage *after*
         // that statement.
         self.check_for_move(state, loc);
+
+        match &stmt.kind {
+            // If a place is assigned to in a statement, it needs storage after that statement.
+            // Even if the place was moved from in the rvalue (e.g. `x = x + 1` or `x = f(move x)`),
+            // the assignment restores a valid value into the place.
+            StatementKind::Assign((place, _)) => {
+                state.gen_(place.local);
+            }
+            StatementKind::SetDiscriminant { place, .. } => {
+                state.gen_(place.local);
+            }
+
+            StatementKind::StorageDead(_)
+            | StatementKind::AscribeUserType(..)
+            | StatementKind::PlaceMention(..)
+            | StatementKind::Coverage(..)
+            | StatementKind::FakeRead(..)
+            | StatementKind::ConstEvalCounter
+            | StatementKind::Nop
+            | StatementKind::Intrinsic(..)
+            | StatementKind::BackwardIncompatibleDropHint { .. }
+            | StatementKind::StorageLive(..) => {}
+        }
     }
 
     fn apply_early_terminator_effect(

--- a/compiler/rustc_mir_transform/src/coroutine/mod.rs
+++ b/compiler/rustc_mir_transform/src/coroutine/mod.rs
@@ -79,6 +79,7 @@ use rustc_span::def_id::DefId;
 use tracing::{debug, instrument};
 
 use crate::deref_separator::deref_finder;
+use crate::patch::MirPatch;
 use crate::{abort_unwinding_calls, pass_manager as pm, simplify};
 
 pub(super) struct StateTransform;
@@ -199,6 +200,8 @@ struct TransformVisitor<'tcx> {
     old_yield_ty: Ty<'tcx>,
 
     old_ret_ty: Ty<'tcx>,
+
+    patch: Option<MirPatch<'tcx>>,
 }
 
 impl<'tcx> TransformVisitor<'tcx> {
@@ -408,10 +411,50 @@ impl<'tcx> MutVisitor<'tcx> for TransformVisitor<'tcx> {
     }
 
     #[tracing::instrument(level = "trace", skip(self), ret)]
-    fn visit_place(&mut self, place: &mut Place<'tcx>, _: PlaceContext, _location: Location) {
+    fn visit_place(&mut self, place: &mut Place<'tcx>, _: PlaceContext, location: Location) {
         // Replace an Local in the remap with a coroutine struct access
         if let Some(&Some((ty, variant_index, idx))) = self.remap.get(place.local) {
             replace_base(place, self.make_field(variant_index, idx, ty), self.tcx);
+        }
+        if let Some(new_projection) = self.process_projection(&place.projection, location) {
+            place.projection = self.tcx.mk_place_elems(&new_projection);
+        }
+    }
+
+    fn process_projection_elem(
+        &mut self,
+        elem: PlaceElem<'tcx>,
+        location: Location,
+    ) -> Option<PlaceElem<'tcx>> {
+        match elem {
+            PlaceElem::Index(local) => {
+                if let Some(&Some((ty, variant, idx))) = self.remap.get(local) {
+                    // `PlaceElem::Index` only accepts a `Local`, not an arbitrary `Place`.
+                    // If the local in indexing was saved across a yield point and remapped to a
+                    // coroutine struct field, we cannot inline the struct field access into
+                    // the index projection.
+                    // For example, an local storing the counter to track which element to drop in
+                    // an array is one such case.
+                    //
+                    // Instead, we inject an assignment before this location to restore the
+                    // saved local from the coroutine struct (`local = copy $projection`),
+                    // and leave the `PlaceElem::Index(local)` projection unchanged.
+                    let field = self.make_field(variant, idx, ty);
+                    self.patch.as_mut().unwrap().add_assign(
+                        location,
+                        Place::from(local),
+                        Rvalue::Use(Operand::Copy(field), WithRetag::No),
+                    );
+                }
+                None
+            }
+            PlaceElem::Field(..)
+            | PlaceElem::OpaqueCast(..)
+            | PlaceElem::UnwrapUnsafeBinder(..)
+            | PlaceElem::Deref
+            | PlaceElem::ConstantIndex { .. }
+            | PlaceElem::Subslice { .. }
+            | PlaceElem::Downcast(..) => None,
         }
     }
 
@@ -1096,6 +1139,7 @@ impl<'tcx> crate::MirPass<'tcx> for StateTransform {
             new_ret_local,
             old_ret_ty,
             old_yield_ty,
+            patch: Some(MirPatch::new(body)),
         };
         transform.visit_body(body);
 
@@ -1116,6 +1160,7 @@ impl<'tcx> crate::MirPass<'tcx> for StateTransform {
                 Some(Statement::new(source_info, assign))
             }),
         );
+        transform.patch.take().unwrap().apply(body);
 
         // Remove the context argument within generator bodies.
         if matches!(coroutine_kind, CoroutineKind::Desugared(CoroutineDesugaring::Gen, _)) {

--- a/tests/mir-opt/coroutine/async_drop.array-{closure#0}.ElaborateDrops.diff
+++ b/tests/mir-opt/coroutine/async_drop.array-{closure#0}.ElaborateDrops.diff
@@ -1,0 +1,220 @@
+- // MIR for `array::{closure#0}` before ElaborateDrops
++ // MIR for `array::{closure#0}` after ElaborateDrops
+  
+  fn array::{closure#0}(_1: {async fn body of array()}, _2: std::future::ResumeTy) -> ()
+  yields ()
+   {
+      debug _task_context => _2;
+      let mut _0: ();
+      let _3: [AsyncInt; 2];
+      let mut _4: AsyncInt;
+      let mut _5: AsyncInt;
++     let mut _6: impl std::future::Future<Output = ()>;
++     let mut _7: std::future::ResumeTy;
++     let mut _8: std::task::Poll<()>;
++     let mut _9: isize;
++     let mut _10: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
++     let mut _11: &mut std::task::Context<'_>;
++     let mut _12: std::future::ResumeTy;
++     let mut _13: &mut impl std::future::Future<Output = ()>;
++     let mut _14: std::future::ResumeTy;
++     let mut _15: std::task::Poll<()>;
++     let mut _16: isize;
++     let mut _17: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
++     let mut _18: &mut std::task::Context<'_>;
++     let mut _19: std::future::ResumeTy;
++     let mut _20: &mut impl std::future::Future<Output = ()>;
++     let mut _21: std::pin::Pin<&mut [AsyncInt; 2]>;
++     let mut _22: &mut [AsyncInt; 2];
+      scope 1 {
+          debug array => _3;
+      }
+  
+      bb0: {
+          StorageLive(_3);
+          StorageLive(_4);
+          _4 = AsyncInt(const 1_i32);
+          StorageLive(_5);
+          _5 = AsyncInt(const 2_i32);
+          _3 = [move _4, move _5];
+-         drop(_5) -> [return: bb1, unwind: bb9, drop: bb5];
++         goto -> bb1;
+      }
+  
+      bb1: {
+          StorageDead(_5);
+-         drop(_4) -> [return: bb2, unwind: bb10, drop: bb6];
++         goto -> bb2;
+      }
+  
+      bb2: {
+          StorageDead(_4);
+          _0 = const ();
+-         drop(_3) -> [return: bb3, unwind: bb11, drop: bb7];
++         goto -> bb34;
+      }
+  
+      bb3: {
+          StorageDead(_3);
+-         drop(_1) -> [return: bb4, drop: bb8, unwind continue];
++         drop(_1) -> [return: bb4, unwind: bb12];
+      }
+  
+      bb4: {
+          return;
+      }
+  
+      bb5: {
+          StorageDead(_5);
+-         drop(_4) -> [return: bb6, unwind: bb13];
++         goto -> bb6;
+      }
+  
+      bb6: {
+          StorageDead(_4);
+          goto -> bb7;
+      }
+  
+      bb7: {
+          StorageDead(_3);
+-         drop(_1) -> [return: bb8, unwind continue];
++         goto -> bb8;
+      }
+  
+      bb8: {
+          coroutine_drop;
+      }
+  
+      bb9 (cleanup): {
+          StorageDead(_5);
+-         drop(_4) -> [return: bb10, unwind terminate(cleanup)];
++         goto -> bb10;
+      }
+  
+      bb10 (cleanup): {
+          StorageDead(_4);
+          goto -> bb11;
+      }
+  
+      bb11 (cleanup): {
+          StorageDead(_3);
+          drop(_1) -> [return: bb12, unwind terminate(cleanup)];
+      }
+  
+      bb12 (cleanup): {
+          resume;
+      }
+  
+      bb13 (cleanup): {
+          StorageDead(_4);
+          StorageDead(_3);
+-         drop(_1) -> [return: bb12, unwind terminate(cleanup)];
++         goto -> bb12;
++     }
++ 
++     bb14: {
++         StorageDead(_6);
++         goto -> bb3;
++     }
++ 
++     bb15: {
++         StorageDead(_6);
++         goto -> bb7;
++     }
++ 
++     bb16 (cleanup): {
++         StorageDead(_6);
++         goto -> bb11;
++     }
++ 
++     bb17: {
++         assert(const false, "`async fn` resumed after async drop") -> [success: bb17, unwind: bb16];
++     }
++ 
++     bb18: {
++         _2 = move _7;
++         StorageDead(_7);
++         goto -> bb17;
++     }
++ 
++     bb19: {
++         _2 = move _7;
++         StorageDead(_7);
++         goto -> bb25;
++     }
++ 
++     bb20: {
++         StorageLive(_7);
++         _7 = yield(const ()) -> [resume: bb18, drop: bb19];
++     }
++ 
++     bb21: {
++         unreachable;
++     }
++ 
++     bb22: {
++         _9 = discriminant(_8);
++         switchInt(move _9) -> [0: bb15, 1: bb20, otherwise: bb21];
++     }
++ 
++     bb23: {
++         _8 = <impl Future<Output = ()> as Future>::poll(move _10, move _11) -> [return: bb22, unwind: bb16];
++     }
++ 
++     bb24: {
++         _12 = move _2;
++         _11 = std::future::get_context::<'_, '_>(move _12) -> [return: bb23, unwind: bb16];
++     }
++ 
++     bb25: {
++         _13 = &mut _6;
++         _10 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _13) -> [return: bb24, unwind: bb16];
++     }
++ 
++     bb26: {
++         _2 = move _14;
++         StorageDead(_14);
++         goto -> bb32;
++     }
++ 
++     bb27: {
++         _2 = move _14;
++         StorageDead(_14);
++         goto -> bb25;
++     }
++ 
++     bb28: {
++         StorageLive(_14);
++         _14 = yield(const ()) -> [resume: bb26, drop: bb27];
++     }
++ 
++     bb29: {
++         _16 = discriminant(_15);
++         switchInt(move _16) -> [0: bb14, 1: bb28, otherwise: bb21];
++     }
++ 
++     bb30: {
++         _15 = <impl Future<Output = ()> as Future>::poll(move _17, move _18) -> [return: bb29, unwind: bb16];
++     }
++ 
++     bb31: {
++         _19 = move _2;
++         _18 = std::future::get_context::<'_, '_>(move _19) -> [return: bb30, unwind: bb16];
++     }
++ 
++     bb32: {
++         _20 = &mut _6;
++         _17 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _20) -> [return: bb31, unwind: bb16];
++     }
++ 
++     bb33: {
++         StorageLive(_6);
++         _6 = async_drop_in_place::<[AsyncInt; 2]>(copy (_21.0: &mut [AsyncInt; 2])) -> [return: bb32, unwind: bb16];
++     }
++ 
++     bb34: {
++         _22 = &mut _3;
++         _21 = Pin::<&mut [AsyncInt; 2]>::new_unchecked(move _22) -> [return: bb33, unwind: bb11];
+      }
+  }
+  

--- a/tests/mir-opt/coroutine/async_drop.array-{closure#0}.StateTransform.diff
+++ b/tests/mir-opt/coroutine/async_drop.array-{closure#0}.StateTransform.diff
@@ -1,0 +1,273 @@
+- // MIR for `array::{closure#0}` before StateTransform
++ // MIR for `array::{closure#0}` after StateTransform
+  
+- fn array::{closure#0}(_1: {async fn body of array()}, _2: std::future::ResumeTy) -> ()
+- yields ()
+-  {
+-     debug _task_context => _2;
+-     let mut _0: ();
++ fn array::{closure#0}(_1: Pin<&mut {async fn body of array()}>, _2: &mut Context<'_>) -> Poll<()> {
++     coroutine layout {
++         field _s0: ();
++         field _s1: [AsyncInt; 2];
++         field _s2: impl Future<Output = ()>;
++         variant_fields = {
++             Unresumed(0): [],
++             Returned (1): [],
++             Panicked (2): [],
++             Suspend0 (3): [_s1, _s2],
++             Suspend1 (4): [_s0, _s1, _s2],
++         }
++         storage_conflicts = BitMatrix(3x3) {(_s0, _s0), (_s0, _s1), (_s0, _s2), (_s1, _s0), (_s1, _s1), (_s1, _s2), (_s2, _s0), (_s2, _s1), (_s2, _s2)}
++     }
++     debug _task_context => _26;
++     coroutine debug array => _s1;
++     let mut _0: std::task::Poll<()>;
+      let _3: [AsyncInt; 2];
+      let mut _4: AsyncInt;
+      let mut _5: AsyncInt;
+      let mut _6: impl std::future::Future<Output = ()>;
+      let mut _7: std::future::ResumeTy;
+      let mut _8: std::task::Poll<()>;
+      let mut _9: isize;
+      let mut _10: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
+      let mut _11: &mut std::task::Context<'_>;
+      let mut _12: std::future::ResumeTy;
+      let mut _13: &mut impl std::future::Future<Output = ()>;
+      let mut _14: std::future::ResumeTy;
+      let mut _15: std::task::Poll<()>;
+      let mut _16: isize;
+      let mut _17: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
+      let mut _18: &mut std::task::Context<'_>;
+      let mut _19: std::future::ResumeTy;
+      let mut _20: &mut impl std::future::Future<Output = ()>;
+      let mut _21: std::pin::Pin<&mut [AsyncInt; 2]>;
+      let mut _22: &mut [AsyncInt; 2];
++     let mut _23: ();
++     let mut _24: u32;
++     let mut _25: &mut {async fn body of array()};
++     let mut _26: std::future::ResumeTy;
++     let mut _27: std::ptr::NonNull<std::task::Context<'_>>;
+      scope 1 {
+-         debug array => _3;
++         debug array => (((*_25) as variant#4).1: [AsyncInt; 2]);
+      }
+  
+      bb0: {
+-         StorageLive(_3);
+-         StorageLive(_4);
+-         _4 = AsyncInt(const 1_i32);
+-         StorageLive(_5);
+-         _5 = AsyncInt(const 2_i32);
+-         _3 = [move _4, move _5];
+-         goto -> bb1;
++         _27 = move _2 as std::ptr::NonNull<std::task::Context<'_>> (Transmute);
++         _26 = std::future::ResumeTy(move _27);
++         _25 = copy (_1.0: &mut {async fn body of array()});
++         _24 = discriminant((*_25));
++         switchInt(move _24) -> [0: bb26, 1: bb25, 2: bb24, 3: bb22, 4: bb23, otherwise: bb11];
+      }
+  
+      bb1: {
+          StorageDead(_5);
+          goto -> bb2;
+      }
+  
+      bb2: {
+          StorageDead(_4);
+-         _0 = const ();
+-         goto -> bb29;
++         (((*_25) as variant#4).0: ()) = const ();
++         goto -> bb19;
+      }
+  
+      bb3: {
+-         StorageDead(_3);
+-         drop(_1) -> [return: bb4, unwind: bb8];
++         nop;
++         goto -> bb20;
+      }
+  
+      bb4: {
++         _0 = Poll::<()>::Ready(move (((*_25) as variant#4).0: ()));
++         discriminant((*_25)) = 1;
+          return;
+      }
+  
+-     bb5: {
+-         StorageDead(_3);
++     bb5 (cleanup): {
++         nop;
+          goto -> bb6;
+      }
+  
+-     bb6: {
+-         coroutine_drop;
++     bb6 (cleanup): {
++         goto -> bb21;
+      }
+  
+-     bb7 (cleanup): {
+-         StorageDead(_3);
+-         drop(_1) -> [return: bb8, unwind terminate(cleanup)];
++     bb7: {
++         nop;
++         goto -> bb3;
+      }
+  
+      bb8 (cleanup): {
+-         resume;
++         nop;
++         goto -> bb5;
+      }
+  
+      bb9: {
+-         StorageDead(_6);
+-         goto -> bb3;
++         assert(const false, "`async fn` resumed after async drop") -> [success: bb9, unwind: bb8];
+      }
+  
+      bb10: {
+-         StorageDead(_6);
+-         goto -> bb5;
++         _26 = move _7;
++         StorageDead(_7);
++         goto -> bb9;
+      }
+  
+-     bb11 (cleanup): {
+-         StorageDead(_6);
+-         goto -> bb7;
++     bb11: {
++         unreachable;
+      }
+  
+      bb12: {
+-         assert(const false, "`async fn` resumed after async drop") -> [success: bb12, unwind: bb11];
++         _26 = move _14;
++         StorageDead(_14);
++         goto -> bb17;
+      }
+  
+      bb13: {
+-         _2 = move _7;
+-         StorageDead(_7);
+-         goto -> bb12;
++         StorageLive(_14);
++         _0 = Poll::<()>::Pending;
++         StorageDead(_14);
++         discriminant((*_25)) = 4;
++         return;
+      }
+  
+      bb14: {
+-         _2 = move _7;
+-         StorageDead(_7);
+-         goto -> bb20;
++         _16 = discriminant(_15);
++         switchInt(move _16) -> [0: bb7, 1: bb13, otherwise: bb11];
+      }
+  
+      bb15: {
+-         StorageLive(_7);
+-         _7 = yield(const ()) -> [resume: bb13, drop: bb14];
++         _15 = <impl Future<Output = ()> as Future>::poll(move _17, move _18) -> [return: bb14, unwind: bb8];
+      }
+  
+      bb16: {
+-         unreachable;
++         _19 = move _26;
++         _18 = copy (_19.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
++         goto -> bb15;
+      }
+  
+      bb17: {
+-         _9 = discriminant(_8);
+-         switchInt(move _9) -> [0: bb10, 1: bb15, otherwise: bb16];
++         _20 = &mut (((*_25) as variant#4).2: impl std::future::Future<Output = ()>);
++         _17 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _20) -> [return: bb16, unwind: bb8];
+      }
+  
+      bb18: {
+-         _8 = <impl Future<Output = ()> as Future>::poll(move _10, move _11) -> [return: bb17, unwind: bb11];
++         nop;
++         (((*_25) as variant#4).2: impl std::future::Future<Output = ()>) = async_drop_in_place::<[AsyncInt; 2]>(copy (_21.0: &mut [AsyncInt; 2])) -> [return: bb17, unwind: bb8];
+      }
+  
+      bb19: {
+-         _12 = move _2;
+-         _11 = std::future::get_context::<'_, '_>(move _12) -> [return: bb18, unwind: bb11];
++         _22 = &mut (((*_25) as variant#4).1: [AsyncInt; 2]);
++         _21 = Pin::<&mut [AsyncInt; 2]>::new_unchecked(move _22) -> [return: bb18, unwind: bb5];
+      }
+  
+      bb20: {
+-         _13 = &mut _6;
+-         _10 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _13) -> [return: bb19, unwind: bb11];
++         goto -> bb4;
+      }
+  
+-     bb21: {
+-         _2 = move _14;
+-         StorageDead(_14);
+-         goto -> bb27;
++     bb21 (cleanup): {
++         discriminant((*_25)) = 2;
++         resume;
+      }
+  
+      bb22: {
+-         _2 = move _14;
+-         StorageDead(_14);
+-         goto -> bb20;
++         StorageLive(_7);
++         _7 = move _26;
++         goto -> bb10;
+      }
+  
+      bb23: {
+          StorageLive(_14);
+-         _14 = yield(const ()) -> [resume: bb21, drop: bb22];
++         _14 = move _26;
++         goto -> bb12;
+      }
+  
+      bb24: {
+-         _16 = discriminant(_15);
+-         switchInt(move _16) -> [0: bb9, 1: bb23, otherwise: bb16];
++         assert(const false, "`async fn` resumed after panicking") -> [success: bb24, unwind continue];
+      }
+  
+      bb25: {
+-         _15 = <impl Future<Output = ()> as Future>::poll(move _17, move _18) -> [return: bb24, unwind: bb11];
++         assert(const false, "`async fn` resumed after completion") -> [success: bb25, unwind continue];
+      }
+  
+      bb26: {
+-         _19 = move _2;
+-         _18 = std::future::get_context::<'_, '_>(move _19) -> [return: bb25, unwind: bb11];
+-     }
+- 
+-     bb27: {
+-         _20 = &mut _6;
+-         _17 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _20) -> [return: bb26, unwind: bb11];
+-     }
+- 
+-     bb28: {
+-         StorageLive(_6);
+-         _6 = async_drop_in_place::<[AsyncInt; 2]>(copy (_21.0: &mut [AsyncInt; 2])) -> [return: bb27, unwind: bb11];
+-     }
+- 
+-     bb29: {
+-         _22 = &mut _3;
+-         _21 = Pin::<&mut [AsyncInt; 2]>::new_unchecked(move _22) -> [return: bb28, unwind: bb7];
++         nop;
++         StorageLive(_4);
++         _4 = AsyncInt(const 1_i32);
++         StorageLive(_5);
++         _5 = AsyncInt(const 2_i32);
++         (((*_25) as variant#4).1: [AsyncInt; 2]) = [move _4, move _5];
++         goto -> bb1;
+      }
+  }
+  

--- a/tests/mir-opt/coroutine/async_drop.array-{closure#0}.coroutine_drop_async.0.mir
+++ b/tests/mir-opt/coroutine/async_drop.array-{closure#0}.coroutine_drop_async.0.mir
@@ -1,0 +1,154 @@
+// MIR for `array::{closure#0}` 0 coroutine_drop_async
+
+fn array::{closure#0}(_1: Pin<&mut {async fn body of array()}>, _2: &mut Context<'_>) -> Poll<()> {
+    debug _task_context => _26;
+    let mut _0: std::task::Poll<()>;
+    let _3: [AsyncInt; 2];
+    let mut _4: AsyncInt;
+    let mut _5: AsyncInt;
+    let mut _6: impl std::future::Future<Output = ()>;
+    let mut _7: std::future::ResumeTy;
+    let mut _8: std::task::Poll<()>;
+    let mut _9: isize;
+    let mut _10: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
+    let mut _11: &mut std::task::Context<'_>;
+    let mut _12: std::future::ResumeTy;
+    let mut _13: &mut impl std::future::Future<Output = ()>;
+    let mut _14: std::future::ResumeTy;
+    let mut _15: std::task::Poll<()>;
+    let mut _16: isize;
+    let mut _17: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
+    let mut _18: &mut std::task::Context<'_>;
+    let mut _19: std::future::ResumeTy;
+    let mut _20: &mut impl std::future::Future<Output = ()>;
+    let mut _21: std::pin::Pin<&mut [AsyncInt; 2]>;
+    let mut _22: &mut [AsyncInt; 2];
+    let mut _23: ();
+    let mut _24: u32;
+    let mut _25: &mut {async fn body of array()};
+    let mut _26: std::future::ResumeTy;
+    let mut _27: std::ptr::NonNull<std::task::Context<'_>>;
+    scope 1 {
+        debug array => (((*_25) as variant#4).1: [AsyncInt; 2]);
+    }
+
+    bb0: {
+        _27 = move _2 as std::ptr::NonNull<std::task::Context<'_>> (Transmute);
+        _26 = std::future::ResumeTy(move _27);
+        _25 = copy (_1.0: &mut {async fn body of array()});
+        _24 = discriminant((*_25));
+        switchInt(move _24) -> [0: bb16, 2: bb21, 3: bb19, 4: bb20, otherwise: bb22];
+    }
+
+    bb1: {
+        nop;
+        goto -> bb2;
+    }
+
+    bb2: {
+        _0 = Poll::<()>::Ready(const ());
+        return;
+    }
+
+    bb3 (cleanup): {
+        nop;
+        goto -> bb4;
+    }
+
+    bb4 (cleanup): {
+        goto -> bb18;
+    }
+
+    bb5: {
+        nop;
+        goto -> bb1;
+    }
+
+    bb6 (cleanup): {
+        nop;
+        goto -> bb3;
+    }
+
+    bb7: {
+        _26 = move _7;
+        StorageDead(_7);
+        goto -> bb13;
+    }
+
+    bb8: {
+        StorageLive(_7);
+        _0 = Poll::<()>::Pending;
+        StorageDead(_7);
+        discriminant((*_25)) = 3;
+        return;
+    }
+
+    bb9: {
+        unreachable;
+    }
+
+    bb10: {
+        _9 = discriminant(_8);
+        switchInt(move _9) -> [0: bb5, 1: bb8, otherwise: bb9];
+    }
+
+    bb11: {
+        _8 = <impl Future<Output = ()> as Future>::poll(move _10, move _11) -> [return: bb10, unwind: bb6];
+    }
+
+    bb12: {
+        _12 = move _26;
+        _11 = copy (_12.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
+        goto -> bb11;
+    }
+
+    bb13: {
+        _13 = &mut (((*_25) as variant#4).2: impl std::future::Future<Output = ()>);
+        _10 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _13) -> [return: bb12, unwind: bb6];
+    }
+
+    bb14: {
+        _26 = move _14;
+        StorageDead(_14);
+        goto -> bb13;
+    }
+
+    bb15: {
+        _0 = Poll::<()>::Ready(const ());
+        return;
+    }
+
+    bb16: {
+        goto -> bb17;
+    }
+
+    bb17: {
+        goto -> bb15;
+    }
+
+    bb18 (cleanup): {
+        discriminant((*_25)) = 2;
+        resume;
+    }
+
+    bb19: {
+        StorageLive(_7);
+        _7 = move _26;
+        goto -> bb7;
+    }
+
+    bb20: {
+        StorageLive(_14);
+        _14 = move _26;
+        goto -> bb14;
+    }
+
+    bb21: {
+        assert(const false, "`async fn` resumed after panicking") -> [success: bb21, unwind continue];
+    }
+
+    bb22: {
+        _0 = Poll::<()>::Ready(const ());
+        return;
+    }
+}

--- a/tests/mir-opt/coroutine/async_drop.core.future-async_drop-async_drop_in_place-{closure#0}.[AsyncInt;2].StateTransform.diff
+++ b/tests/mir-opt/coroutine/async_drop.core.future-async_drop-async_drop_in_place-{closure#0}.[AsyncInt;2].StateTransform.diff
@@ -1,0 +1,357 @@
+- // MIR for `std::future::async_drop_in_place::{closure#0}` before StateTransform
++ // MIR for `std::future::async_drop_in_place::{closure#0}` after StateTransform
+  
+- fn async_drop_in_place::{closure#0}(_1: {async fn body of async_drop_in_place<[AsyncInt; 2]>()}, _2: std::future::ResumeTy) -> ()
+- yields ()
+-  {
+-     let mut _0: ();
++ fn async_drop_in_place::{closure#0}(_1: Pin<&mut {async fn body of async_drop_in_place<[AsyncInt; 2]>()}>, _2: &mut Context<'_>) -> Poll<()> {
++     coroutine layout {
++         field _s0: *mut [AsyncInt];
++         field _s1: usize;
++         field _s2: usize;
++         field _s3: impl Future<Output = ()>;
++         field _s4: impl Future<Output = ()>;
++         variant_fields = {
++             Unresumed(0): [],
++             Returned (1): [],
++             Panicked (2): [],
++             Suspend0 (3): [_s0, _s1, _s2, _s3],
++             Suspend1 (4): [_s0, _s1, _s2, _s4],
++             Suspend2 (5): [_s0, _s1, _s2, _s4],
++         }
++         storage_conflicts = BitMatrix(5x5) {(_s0, _s0), (_s0, _s1), (_s0, _s2), (_s0, _s3), (_s0, _s4), (_s1, _s0), (_s1, _s1), (_s1, _s2), (_s1, _s3), (_s1, _s4), (_s2, _s0), (_s2, _s1), (_s2, _s2), (_s2, _s3), (_s2, _s4), (_s3, _s0), (_s3, _s1), (_s3, _s2), (_s3, _s3), (_s4, _s0), (_s4, _s1), (_s4, _s2), (_s4, _s4)}
++     }
++     let mut _0: std::task::Poll<()>;
+      let mut _3: &mut [AsyncInt; 2];
+      let mut _4: *mut [AsyncInt; 2];
+      let mut _5: *mut [AsyncInt];
+      let mut _6: usize;
+      let mut _7: usize;
+      let mut _8: *mut AsyncInt;
+      let mut _9: bool;
+      let mut _10: *mut AsyncInt;
+      let mut _11: bool;
+      let mut _12: impl std::future::Future<Output = ()>;
+      let mut _13: std::future::ResumeTy;
+      let mut _14: std::task::Poll<()>;
+      let mut _15: isize;
+      let mut _16: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
+      let mut _17: &mut std::task::Context<'_>;
+      let mut _18: std::future::ResumeTy;
+      let mut _19: &mut impl std::future::Future<Output = ()>;
+      let mut _20: std::pin::Pin<&mut AsyncInt>;
+      let mut _21: &mut AsyncInt;
+      let mut _22: *mut AsyncInt;
+      let mut _23: bool;
+      let mut _24: impl std::future::Future<Output = ()>;
+      let mut _25: std::future::ResumeTy;
+      let mut _26: std::task::Poll<()>;
+      let mut _27: isize;
+      let mut _28: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
+      let mut _29: &mut std::task::Context<'_>;
+      let mut _30: std::future::ResumeTy;
+      let mut _31: &mut impl std::future::Future<Output = ()>;
+      let mut _32: std::future::ResumeTy;
+      let mut _33: std::task::Poll<()>;
+      let mut _34: isize;
+      let mut _35: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
+      let mut _36: &mut std::task::Context<'_>;
+      let mut _37: std::future::ResumeTy;
+      let mut _38: &mut impl std::future::Future<Output = ()>;
+      let mut _39: std::pin::Pin<&mut AsyncInt>;
+      let mut _40: &mut AsyncInt;
++     let mut _41: ();
++     let mut _42: u32;
++     let mut _43: &mut {async fn body of std::future::async_drop_in_place<[AsyncInt; 2]>()};
++     let mut _44: *mut [AsyncInt];
++     let mut _45: *mut [AsyncInt];
++     let _46: std::future::ResumeTy;
++     let mut _47: std::ptr::NonNull<std::task::Context<'_>>;
+  
+      bb0: {
+-         _3 = move (_1.0: &mut [AsyncInt; 2]);
+-         _4 = &raw mut (*_3);
+-         _5 = move _4 as *mut [AsyncInt] (PointerCoercion(Unsize, Implicit));
+-         _6 = PtrMetadata(copy _5);
+-         _7 = const 0_usize;
+-         goto -> bb20;
++         _47 = move _2 as std::ptr::NonNull<std::task::Context<'_>> (Transmute);
++         _46 = std::future::ResumeTy(move _47);
++         _43 = copy (_1.0: &mut {async fn body of std::future::async_drop_in_place<[AsyncInt; 2]>()});
++         _42 = discriminant((*_43));
++         switchInt(move _42) -> [0: bb28, 1: bb27, 2: bb26, 3: bb23, 4: bb24, 5: bb25, otherwise: bb8];
+      }
+  
+      bb1: {
++         _0 = Poll::<()>::Ready(move _41);
++         discriminant((*_43)) = 1;
+          return;
+      }
+  
+      bb2 (cleanup): {
+-         resume;
++         goto -> bb22;
+      }
+  
+      bb3 (cleanup): {
+-         _8 = &raw mut (*_5)[_7];
+-         _7 = Add(move _7, const 1_usize);
++         _7 = no_retag copy (((*_43) as variant#5).2: usize);
++         _44 = no_retag copy (((*_43) as variant#5).0: *mut [AsyncInt]);
++         _8 = &raw mut (*_44)[_7];
++         (((*_43) as variant#5).2: usize) = Add(move (((*_43) as variant#5).2: usize), const 1_usize);
+          drop((*_8)) -> [return: bb4, unwind terminate(cleanup)];
+      }
+  
+      bb4 (cleanup): {
+-         _9 = Eq(copy _7, copy _6);
++         _9 = Eq(copy (((*_43) as variant#5).2: usize), copy (((*_43) as variant#5).1: usize));
+          switchInt(move _9) -> [0: bb3, otherwise: bb2];
+      }
+  
+-     bb5: {
+-         _10 = &raw mut (*_5)[_7];
+-         _7 = Add(move _7, const 1_usize);
+-         _21 = &mut (*_10);
+-         _20 = Pin::<&mut AsyncInt>::new_unchecked(move _21) -> [return: bb18, unwind: bb4];
++     bb5 (cleanup): {
++         nop;
++         goto -> bb4;
+      }
+  
+      bb6: {
+-         _11 = Eq(copy _7, copy _6);
+-         switchInt(move _11) -> [0: bb5, otherwise: bb1];
++         assert(const false, "`async fn` resumed after async drop") -> [success: bb6, unwind: bb5];
+      }
+  
+      bb7: {
+-         StorageDead(_12);
++         _46 = move _13;
++         StorageDead(_13);
+          goto -> bb6;
+      }
+  
+-     bb8 (cleanup): {
+-         StorageDead(_12);
+-         goto -> bb4;
++     bb8: {
++         unreachable;
+      }
+  
+      bb9: {
+-         assert(const false, "`async fn` resumed after async drop") -> [success: bb9, unwind: bb8];
++         _7 = no_retag copy (((*_43) as variant#5).2: usize);
++         _45 = no_retag copy (((*_43) as variant#5).0: *mut [AsyncInt]);
++         _22 = &raw mut (*_45)[_7];
++         (((*_43) as variant#5).2: usize) = Add(move (((*_43) as variant#5).2: usize), const 1_usize);
++         _40 = &mut (*_22);
++         _39 = Pin::<&mut AsyncInt>::new_unchecked(move _40) -> [return: bb21, unwind: bb4];
+      }
+  
+      bb10: {
+-         _2 = move _13;
+-         StorageDead(_13);
+-         goto -> bb9;
++         _23 = Eq(copy (((*_43) as variant#5).2: usize), copy (((*_43) as variant#5).1: usize));
++         switchInt(move _23) -> [0: bb9, otherwise: bb1];
+      }
+  
+      bb11: {
+-         _2 = move _13;
+-         StorageDead(_13);
+-         goto -> bb17;
++         nop;
++         goto -> bb10;
+      }
+  
+-     bb12: {
+-         StorageLive(_13);
+-         _13 = yield(const ()) -> [resume: bb10, drop: bb11];
++     bb12 (cleanup): {
++         nop;
++         goto -> bb4;
+      }
+  
+      bb13: {
+-         unreachable;
++         assert(const false, "`async fn` resumed after async drop") -> [success: bb13, unwind: bb12];
+      }
+  
+      bb14: {
+-         _15 = discriminant(_14);
+-         switchInt(move _15) -> [0: bb7, 1: bb12, otherwise: bb13];
++         _46 = move _25;
++         StorageDead(_25);
++         goto -> bb13;
+      }
+  
+      bb15: {
+-         _14 = <impl Future<Output = ()> as Future>::poll(move _16, move _17) -> [return: bb14, unwind: bb8];
++         _46 = move _32;
++         StorageDead(_32);
++         goto -> bb20;
+      }
+  
+      bb16: {
+-         _18 = move _2;
+-         _17 = std::future::get_context::<'_, '_>(move _18) -> [return: bb15, unwind: bb8];
++         StorageLive(_32);
++         _0 = Poll::<()>::Pending;
++         StorageDead(_32);
++         discriminant((*_43)) = 5;
++         return;
+      }
+  
+      bb17: {
+-         _19 = &mut _12;
+-         _16 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _19) -> [return: bb16, unwind: bb8];
++         _34 = discriminant(_33);
++         switchInt(move _34) -> [0: bb11, 1: bb16, otherwise: bb8];
+      }
+  
+      bb18: {
+-         StorageLive(_12);
+-         _12 = async_drop_in_place::<AsyncInt>(copy (_20.0: &mut AsyncInt)) -> [return: bb17, unwind: bb8];
++         _33 = <impl Future<Output = ()> as Future>::poll(move _35, move _36) -> [return: bb17, unwind: bb12];
+      }
+  
+      bb19: {
+-         _22 = &raw mut (*_5)[_7];
+-         _7 = Add(move _7, const 1_usize);
+-         _40 = &mut (*_22);
+-         _39 = Pin::<&mut AsyncInt>::new_unchecked(move _40) -> [return: bb39, unwind: bb4];
++         _37 = move _46;
++         _36 = copy (_37.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
++         goto -> bb18;
+      }
+  
+      bb20: {
+-         _23 = Eq(copy _7, copy _6);
+-         switchInt(move _23) -> [0: bb19, otherwise: bb1];
++         _38 = &mut (((*_43) as variant#5).3: impl std::future::Future<Output = ()>);
++         _35 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _38) -> [return: bb19, unwind: bb12];
+      }
+  
+      bb21: {
+-         StorageDead(_24);
+-         goto -> bb20;
++         nop;
++         (((*_43) as variant#5).3: impl std::future::Future<Output = ()>) = async_drop_in_place::<AsyncInt>(copy (_39.0: &mut AsyncInt)) -> [return: bb20, unwind: bb12];
+      }
+  
+-     bb22: {
+-         StorageDead(_24);
+-         goto -> bb6;
++     bb22 (cleanup): {
++         discriminant((*_43)) = 2;
++         resume;
+      }
+  
+-     bb23 (cleanup): {
+-         StorageDead(_24);
+-         goto -> bb4;
++     bb23: {
++         StorageLive(_13);
++         _13 = move _46;
++         goto -> bb7;
+      }
+  
+      bb24: {
+-         assert(const false, "`async fn` resumed after async drop") -> [success: bb24, unwind: bb23];
++         StorageLive(_25);
++         _25 = move _46;
++         goto -> bb14;
+      }
+  
+      bb25: {
+-         _2 = move _25;
+-         StorageDead(_25);
+-         goto -> bb24;
++         StorageLive(_32);
++         _32 = move _46;
++         goto -> bb15;
+      }
+  
+      bb26: {
+-         _2 = move _25;
+-         StorageDead(_25);
+-         goto -> bb31;
++         assert(const false, "`async fn` resumed after panicking") -> [success: bb26, unwind continue];
+      }
+  
+      bb27: {
+-         StorageLive(_25);
+-         _25 = yield(const ()) -> [resume: bb25, drop: bb26];
++         _0 = Poll::<()>::Ready(const ());
++         return;
+      }
+  
+      bb28: {
+-         _27 = discriminant(_26);
+-         switchInt(move _27) -> [0: bb22, 1: bb27, otherwise: bb13];
+-     }
+- 
+-     bb29: {
+-         _26 = <impl Future<Output = ()> as Future>::poll(move _28, move _29) -> [return: bb28, unwind: bb23];
+-     }
+- 
+-     bb30: {
+-         _30 = move _2;
+-         _29 = std::future::get_context::<'_, '_>(move _30) -> [return: bb29, unwind: bb23];
+-     }
+- 
+-     bb31: {
+-         _31 = &mut _24;
+-         _28 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _31) -> [return: bb30, unwind: bb23];
+-     }
+- 
+-     bb32: {
+-         _2 = move _32;
+-         StorageDead(_32);
+-         goto -> bb38;
+-     }
+- 
+-     bb33: {
+-         _2 = move _32;
+-         StorageDead(_32);
+-         goto -> bb31;
+-     }
+- 
+-     bb34: {
+-         StorageLive(_32);
+-         _32 = yield(const ()) -> [resume: bb32, drop: bb33];
+-     }
+- 
+-     bb35: {
+-         _34 = discriminant(_33);
+-         switchInt(move _34) -> [0: bb21, 1: bb34, otherwise: bb13];
+-     }
+- 
+-     bb36: {
+-         _33 = <impl Future<Output = ()> as Future>::poll(move _35, move _36) -> [return: bb35, unwind: bb23];
+-     }
+- 
+-     bb37: {
+-         _37 = move _2;
+-         _36 = std::future::get_context::<'_, '_>(move _37) -> [return: bb36, unwind: bb23];
+-     }
+- 
+-     bb38: {
+-         _38 = &mut _24;
+-         _35 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _38) -> [return: bb37, unwind: bb23];
+-     }
+- 
+-     bb39: {
+-         StorageLive(_24);
+-         _24 = async_drop_in_place::<AsyncInt>(copy (_39.0: &mut AsyncInt)) -> [return: bb38, unwind: bb23];
++         _3 = move ((*_43).0: &mut [AsyncInt; 2]);
++         _4 = &raw mut (*_3);
++         (((*_43) as variant#5).0: *mut [AsyncInt]) = move _4 as *mut [AsyncInt] (PointerCoercion(Unsize, Implicit));
++         (((*_43) as variant#5).1: usize) = PtrMetadata(copy (((*_43) as variant#5).0: *mut [AsyncInt]));
++         (((*_43) as variant#5).2: usize) = const 0_usize;
++         goto -> bb10;
+      }
+  }
+  

--- a/tests/mir-opt/coroutine/async_drop.elaborate_drops-{closure#0}.ElaborateDrops.diff
+++ b/tests/mir-opt/coroutine/async_drop.elaborate_drops-{closure#0}.ElaborateDrops.diff
@@ -33,8 +33,8 @@
 +     let mut _39: &mut std::task::Context<'_>;
 +     let mut _40: std::future::ResumeTy;
 +     let mut _41: &mut impl std::future::Future<Output = ()>;
-+     let mut _42: std::pin::Pin<&mut {async closure@$DIR/async_drop.rs:78:27: 78:35}>;
-+     let mut _43: &mut {async closure@$DIR/async_drop.rs:78:27: 78:35};
++     let mut _42: std::pin::Pin<&mut {async closure@$DIR/async_drop.rs:86:27: 86:35}>;
++     let mut _43: &mut {async closure@$DIR/async_drop.rs:86:27: 86:35};
 +     let mut _44: impl std::future::Future<Output = ()>;
 +     let mut _45: std::future::ResumeTy;
 +     let mut _46: std::task::Poll<()>;
@@ -50,8 +50,8 @@
 +     let mut _56: &mut std::task::Context<'_>;
 +     let mut _57: std::future::ResumeTy;
 +     let mut _58: &mut impl std::future::Future<Output = ()>;
-+     let mut _59: std::pin::Pin<&mut {closure@$DIR/async_drop.rs:70:25: 70:27}>;
-+     let mut _60: &mut {closure@$DIR/async_drop.rs:70:25: 70:27};
++     let mut _59: std::pin::Pin<&mut {closure@$DIR/async_drop.rs:78:25: 78:27}>;
++     let mut _60: &mut {closure@$DIR/async_drop.rs:78:25: 78:27};
 +     let mut _61: impl std::future::Future<Output = ()>;
 +     let mut _62: std::future::ResumeTy;
 +     let mut _63: std::task::Poll<()>;
@@ -200,13 +200,13 @@
                                           let _23: AsyncInt;
                                           scope 10 {
                                               debug foo => _23;
-                                              let _24: {closure@$DIR/async_drop.rs:70:25: 70:27};
+                                              let _24: {closure@$DIR/async_drop.rs:78:25: 78:27};
                                               scope 11 {
                                                   debug async_closure => _24;
                                                   let _25: AsyncInt;
                                                   scope 12 {
                                                       debug foo => _25;
-                                                      let _26: {async closure@$DIR/async_drop.rs:78:27: 78:35};
+                                                      let _26: {async closure@$DIR/async_drop.rs:86:27: 86:35};
                                                       scope 13 {
                                                           debug async_coroutine => _26;
                                                       }
@@ -321,11 +321,11 @@
           StorageLive(_23);
           _23 = AsyncInt(const 14_i32);
           StorageLive(_24);
-          _24 = {closure@$DIR/async_drop.rs:70:25: 70:27} { foo: move _23 };
+          _24 = {closure@$DIR/async_drop.rs:78:25: 78:27} { foo: move _23 };
           StorageLive(_25);
           _25 = AsyncInt(const 15_i32);
           StorageLive(_26);
-          _26 = {closure@$DIR/async_drop.rs:78:27: 78:35} { foo: move _25 };
+          _26 = {closure@$DIR/async_drop.rs:86:27: 86:35} { foo: move _25 };
           _0 = const ();
 -         drop(_26) -> [return: bb10, unwind: bb44, drop: bb23];
 +         goto -> bb103;
@@ -838,12 +838,12 @@
 + 
 +     bb102: {
 +         StorageLive(_27);
-+         _27 = async_drop_in_place::<{async closure@$DIR/async_drop.rs:78:27: 78:35}>(copy (_42.0: &mut {async closure@$DIR/async_drop.rs:78:27: 78:35})) -> [return: bb101, unwind: bb85];
++         _27 = async_drop_in_place::<{async closure@$DIR/async_drop.rs:86:27: 86:35}>(copy (_42.0: &mut {async closure@$DIR/async_drop.rs:86:27: 86:35})) -> [return: bb101, unwind: bb85];
 +     }
 + 
 +     bb103: {
 +         _43 = &mut _26;
-+         _42 = Pin::<&mut {async closure@$DIR/async_drop.rs:78:27: 78:35}>::new_unchecked(move _43) -> [return: bb102, unwind: bb44];
++         _42 = Pin::<&mut {async closure@$DIR/async_drop.rs:86:27: 86:35}>::new_unchecked(move _43) -> [return: bb102, unwind: bb44];
 +     }
 + 
 +     bb104: {
@@ -939,12 +939,12 @@
 + 
 +     bb122: {
 +         StorageLive(_44);
-+         _44 = async_drop_in_place::<{closure@$DIR/async_drop.rs:70:25: 70:27}>(copy (_59.0: &mut {closure@$DIR/async_drop.rs:70:25: 70:27})) -> [return: bb121, unwind: bb106];
++         _44 = async_drop_in_place::<{closure@$DIR/async_drop.rs:78:25: 78:27}>(copy (_59.0: &mut {closure@$DIR/async_drop.rs:78:25: 78:27})) -> [return: bb121, unwind: bb106];
 +     }
 + 
 +     bb123: {
 +         _60 = &mut _24;
-+         _59 = Pin::<&mut {closure@$DIR/async_drop.rs:70:25: 70:27}>::new_unchecked(move _60) -> [return: bb122, unwind: bb46];
++         _59 = Pin::<&mut {closure@$DIR/async_drop.rs:78:25: 78:27}>::new_unchecked(move _60) -> [return: bb122, unwind: bb46];
 +     }
 + 
 +     bb124: {

--- a/tests/mir-opt/coroutine/async_drop.elaborate_drops-{closure#0}.StateTransform.diff
+++ b/tests/mir-opt/coroutine/async_drop.elaborate_drops-{closure#0}.StateTransform.diff
@@ -17,8 +17,8 @@
 +         field _s6: AsyncEnum;
 +         field _s7: AsyncInt;
 +         field _s8: AsyncReference<'_>;
-+         field _s9: {closure@$DIR/async_drop.rs:70:25: 70:27};
-+         field _s10: {async closure@$DIR/async_drop.rs:78:27: 78:35};
++         field _s9: {closure@$DIR/async_drop.rs:78:25: 78:27};
++         field _s10: {async closure@$DIR/async_drop.rs:86:27: 86:35};
 +         field _s11: impl Future<Output = ()>;
 +         field _s12: impl Future<Output = ()>;
 +         field _s13: impl Future<Output = ()>;
@@ -83,8 +83,8 @@
       let mut _39: &mut std::task::Context<'_>;
       let mut _40: std::future::ResumeTy;
       let mut _41: &mut impl std::future::Future<Output = ()>;
-      let mut _42: std::pin::Pin<&mut {async closure@$DIR/async_drop.rs:78:27: 78:35}>;
-      let mut _43: &mut {async closure@$DIR/async_drop.rs:78:27: 78:35};
+      let mut _42: std::pin::Pin<&mut {async closure@$DIR/async_drop.rs:86:27: 86:35}>;
+      let mut _43: &mut {async closure@$DIR/async_drop.rs:86:27: 86:35};
       let mut _44: impl std::future::Future<Output = ()>;
       let mut _45: std::future::ResumeTy;
       let mut _46: std::task::Poll<()>;
@@ -100,8 +100,8 @@
       let mut _56: &mut std::task::Context<'_>;
       let mut _57: std::future::ResumeTy;
       let mut _58: &mut impl std::future::Future<Output = ()>;
-      let mut _59: std::pin::Pin<&mut {closure@$DIR/async_drop.rs:70:25: 70:27}>;
-      let mut _60: &mut {closure@$DIR/async_drop.rs:70:25: 70:27};
+      let mut _59: std::pin::Pin<&mut {closure@$DIR/async_drop.rs:78:25: 78:27}>;
+      let mut _60: &mut {closure@$DIR/async_drop.rs:78:25: 78:27};
       let mut _61: impl std::future::Future<Output = ()>;
       let mut _62: std::future::ResumeTy;
       let mut _63: std::task::Poll<()>;
@@ -271,18 +271,18 @@
                                           scope 10 {
                                               debug foo => _23;
 +                                             coroutine debug async_closure => _s9;
-                                              let _24: {closure@$DIR/async_drop.rs:70:25: 70:27};
+                                              let _24: {closure@$DIR/async_drop.rs:78:25: 78:27};
                                               scope 11 {
 -                                                 debug async_closure => _24;
-+                                                 debug async_closure => (((*_182) as variant#6).9: {closure@$DIR/async_drop.rs:70:25: 70:27});
++                                                 debug async_closure => (((*_182) as variant#6).9: {closure@$DIR/async_drop.rs:78:25: 78:27});
                                                   let _25: AsyncInt;
                                                   scope 12 {
                                                       debug foo => _25;
 +                                                     coroutine debug async_coroutine => _s10;
-                                                      let _26: {async closure@$DIR/async_drop.rs:78:27: 78:35};
+                                                      let _26: {async closure@$DIR/async_drop.rs:86:27: 86:35};
                                                       scope 13 {
 -                                                         debug async_coroutine => _26;
-+                                                         debug async_coroutine => (((*_182) as variant#4).10: {async closure@$DIR/async_drop.rs:78:27: 78:35});
++                                                         debug async_coroutine => (((*_182) as variant#4).10: {async closure@$DIR/async_drop.rs:86:27: 86:35});
                                                       }
                                                   }
                                               }
@@ -404,17 +404,17 @@
           StorageLive(_23);
           _23 = AsyncInt(const 14_i32);
 -         StorageLive(_24);
--         _24 = {closure@$DIR/async_drop.rs:70:25: 70:27} { foo: move _23 };
+-         _24 = {closure@$DIR/async_drop.rs:78:25: 78:27} { foo: move _23 };
 +         nop;
-+         (((*_182) as variant#6).9: {closure@$DIR/async_drop.rs:70:25: 70:27}) = {closure@$DIR/async_drop.rs:70:25: 70:27} { foo: move _23 };
++         (((*_182) as variant#6).9: {closure@$DIR/async_drop.rs:78:25: 78:27}) = {closure@$DIR/async_drop.rs:78:25: 78:27} { foo: move _23 };
           StorageLive(_25);
           _25 = AsyncInt(const 15_i32);
 -         StorageLive(_26);
--         _26 = {closure@$DIR/async_drop.rs:78:27: 78:35} { foo: move _25 };
+-         _26 = {closure@$DIR/async_drop.rs:86:27: 86:35} { foo: move _25 };
 -         _0 = const ();
 -         goto -> bb72;
 +         nop;
-+         (((*_182) as variant#4).10: {async closure@$DIR/async_drop.rs:78:27: 78:35}) = {closure@$DIR/async_drop.rs:78:27: 78:35} { foo: move _25 };
++         (((*_182) as variant#4).10: {async closure@$DIR/async_drop.rs:86:27: 86:35}) = {closure@$DIR/async_drop.rs:86:27: 86:35} { foo: move _25 };
 +         (((*_182) as variant#20).0: ()) = const ();
 +         goto -> bb51;
       }
@@ -517,7 +517,7 @@
 +     bb24 (cleanup): {
           StorageDead(_25);
 -         goto -> bb25;
-+         drop((((*_182) as variant#6).9: {closure@$DIR/async_drop.rs:70:25: 70:27})) -> [return: bb25, unwind terminate(cleanup)];
++         drop((((*_182) as variant#6).9: {closure@$DIR/async_drop.rs:78:25: 78:27})) -> [return: bb25, unwind terminate(cleanup)];
       }
   
 -     bb25: {
@@ -720,14 +720,14 @@
 -         drop(_1) -> [return: bb51, unwind terminate(cleanup)];
 +     bb50: {
 +         nop;
-+         (((*_182) as variant#4).11: impl std::future::Future<Output = ()>) = async_drop_in_place::<{async closure@$DIR/async_drop.rs:78:27: 78:35}>(copy (_42.0: &mut {async closure@$DIR/async_drop.rs:78:27: 78:35})) -> [return: bb49, unwind: bb40];
++         (((*_182) as variant#4).11: impl std::future::Future<Output = ()>) = async_drop_in_place::<{async closure@$DIR/async_drop.rs:86:27: 86:35}>(copy (_42.0: &mut {async closure@$DIR/async_drop.rs:86:27: 86:35})) -> [return: bb49, unwind: bb40];
       }
   
 -     bb51 (cleanup): {
 -         resume;
 +     bb51: {
-+         _43 = &mut (((*_182) as variant#4).10: {async closure@$DIR/async_drop.rs:78:27: 78:35});
-+         _42 = Pin::<&mut {async closure@$DIR/async_drop.rs:78:27: 78:35}>::new_unchecked(move _43) -> [return: bb50, unwind: bb23];
++         _43 = &mut (((*_182) as variant#4).10: {async closure@$DIR/async_drop.rs:86:27: 86:35});
++         _42 = Pin::<&mut {async closure@$DIR/async_drop.rs:86:27: 86:35}>::new_unchecked(move _43) -> [return: bb50, unwind: bb23];
       }
   
       bb52: {
@@ -811,14 +811,14 @@
 -         _33 = move _2;
 -         _32 = std::future::get_context::<'_, '_>(move _33) -> [return: bb61, unwind: bb54];
 +         nop;
-+         (((*_182) as variant#6).10: impl std::future::Future<Output = ()>) = async_drop_in_place::<{closure@$DIR/async_drop.rs:70:25: 70:27}>(copy (_59.0: &mut {closure@$DIR/async_drop.rs:70:25: 70:27})) -> [return: bb61, unwind: bb53];
++         (((*_182) as variant#6).10: impl std::future::Future<Output = ()>) = async_drop_in_place::<{closure@$DIR/async_drop.rs:78:25: 78:27}>(copy (_59.0: &mut {closure@$DIR/async_drop.rs:78:25: 78:27})) -> [return: bb61, unwind: bb53];
       }
   
       bb63: {
 -         _34 = &mut _27;
 -         _31 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _34) -> [return: bb62, unwind: bb54];
-+         _60 = &mut (((*_182) as variant#6).9: {closure@$DIR/async_drop.rs:70:25: 70:27});
-+         _59 = Pin::<&mut {closure@$DIR/async_drop.rs:70:25: 70:27}>::new_unchecked(move _60) -> [return: bb62, unwind: bb25];
++         _60 = &mut (((*_182) as variant#6).9: {closure@$DIR/async_drop.rs:78:25: 78:27});
++         _59 = Pin::<&mut {closure@$DIR/async_drop.rs:78:25: 78:27}>::new_unchecked(move _60) -> [return: bb62, unwind: bb25];
       }
   
       bb64: {
@@ -879,13 +879,13 @@
   
       bb71: {
 -         StorageLive(_27);
--         _27 = async_drop_in_place::<{async closure@$DIR/async_drop.rs:78:27: 78:35}>(copy (_42.0: &mut {async closure@$DIR/async_drop.rs:78:27: 78:35})) -> [return: bb70, unwind: bb54];
+-         _27 = async_drop_in_place::<{async closure@$DIR/async_drop.rs:86:27: 86:35}>(copy (_42.0: &mut {async closure@$DIR/async_drop.rs:86:27: 86:35})) -> [return: bb70, unwind: bb54];
 +         _70 = <impl Future<Output = ()> as Future>::poll(move _72, move _73) -> [return: bb70, unwind: bb65];
       }
   
       bb72: {
 -         _43 = &mut _26;
--         _42 = Pin::<&mut {async closure@$DIR/async_drop.rs:78:27: 78:35}>::new_unchecked(move _43) -> [return: bb71, unwind: bb36];
+-         _42 = Pin::<&mut {async closure@$DIR/async_drop.rs:86:27: 86:35}>::new_unchecked(move _43) -> [return: bb71, unwind: bb36];
 +         _74 = move _183;
 +         _73 = copy (_74.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
 +         goto -> bb71;
@@ -1027,7 +1027,7 @@
   
       bb91: {
 -         StorageLive(_44);
--         _44 = async_drop_in_place::<{closure@$DIR/async_drop.rs:70:25: 70:27}>(copy (_59.0: &mut {closure@$DIR/async_drop.rs:70:25: 70:27})) -> [return: bb90, unwind: bb75];
+-         _44 = async_drop_in_place::<{closure@$DIR/async_drop.rs:78:25: 78:27}>(copy (_59.0: &mut {closure@$DIR/async_drop.rs:78:25: 78:27})) -> [return: bb90, unwind: bb75];
 +         _183 = move _96;
 +         StorageDead(_96);
 +         goto -> bb90;
@@ -1035,7 +1035,7 @@
   
       bb92: {
 -         _60 = &mut _24;
--         _59 = Pin::<&mut {closure@$DIR/async_drop.rs:70:25: 70:27}>::new_unchecked(move _60) -> [return: bb91, unwind: bb38];
+-         _59 = Pin::<&mut {closure@$DIR/async_drop.rs:78:25: 78:27}>::new_unchecked(move _60) -> [return: bb91, unwind: bb38];
 +         _183 = move _103;
 +         StorageDead(_103);
 +         goto -> bb97;

--- a/tests/mir-opt/coroutine/async_drop.rs
+++ b/tests/mir-opt/coroutine/async_drop.rs
@@ -51,6 +51,14 @@ async fn double() {
     let async_int_again = AsyncInt(0);
 }
 
+// EMIT_MIR async_drop.array-{closure#0}.ElaborateDrops.diff
+// EMIT_MIR async_drop.array-{closure#0}.StateTransform.diff
+// EMIT_MIR async_drop.array-{closure#0}.coroutine_drop_async.0.mir
+// EMIT_MIR core.future-async_drop-async_drop_in_place-{closure#0}.[AsyncInt;2].StateTransform.diff
+async fn array() {
+    let array = [AsyncInt(1), AsyncInt(2)];
+}
+
 // EMIT_MIR async_drop.elaborate_drops-{closure#0}.ElaborateDrops.diff
 // EMIT_MIR async_drop.elaborate_drops-{closure#0}.StateTransform.diff
 async fn elaborate_drops() {
@@ -90,6 +98,7 @@ fn main() {
 
     let i = 13;
     let fut = pin!(async {
+        array().await;
         elaborate_drops().await;
 
         test_async_drop(Int(0)).await;

--- a/tests/ui/async-await/async-drop/async-drop-array-step.rs
+++ b/tests/ui/async-await/async-drop/async-drop-array-step.rs
@@ -1,0 +1,94 @@
+//@ run-pass
+//@ check-run-results
+//@ edition: 2021
+
+#![feature(async_drop)]
+#![allow(incomplete_features)]
+
+use std::future::{async_drop_in_place, AsyncDrop, Future};
+use std::mem::ManuallyDrop;
+use std::pin::{pin, Pin};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{mpsc, Arc};
+use std::task::{Context, Poll, Wake, Waker};
+
+static DROP_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+struct YieldOnce(bool);
+
+impl Future for YieldOnce {
+    type Output = ();
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+        if !self.0 {
+            self.0 = true;
+            cx.waker().wake_by_ref();
+            Poll::Pending
+        } else {
+            Poll::Ready(())
+        }
+    }
+}
+
+struct Item(usize);
+
+impl Drop for Item {
+    fn drop(&mut self) {}
+}
+
+impl AsyncDrop for Item {
+    async fn drop(self: Pin<&mut Self>) {
+        let count = DROP_COUNT.fetch_add(1, Ordering::Relaxed);
+        if count >= 8 {
+            panic!("Infinite loop detected: array drop index reset across yield points!");
+        }
+        YieldOnce(false).await;
+        println!("Dropping {}", self.0);
+    }
+}
+
+fn block_on<F: Future>(fut_unpin: F) -> F::Output {
+    let mut fut_pin = pin!(ManuallyDrop::new(fut_unpin));
+    let mut fut: Pin<&mut F> = unsafe {
+        Pin::map_unchecked_mut(fut_pin.as_mut(), |x| &mut **x)
+    };
+    let (waker, rx) = simple_waker();
+    let mut context = Context::from_waker(&waker);
+    let rv = loop {
+        match fut.as_mut().poll(&mut context) {
+            Poll::Ready(out) => break out,
+            Poll::Pending => rx.try_recv().unwrap(),
+        }
+    };
+    let drop_fut_unpin = unsafe { async_drop_in_place(fut.get_unchecked_mut()) };
+    let mut drop_fut = pin!(drop_fut_unpin);
+    loop {
+        match drop_fut.as_mut().poll(&mut context) {
+            Poll::Ready(()) => break,
+            Poll::Pending => rx.try_recv().unwrap(),
+        }
+    }
+    rv
+}
+
+fn simple_waker() -> (Waker, mpsc::Receiver<()>) {
+    struct SimpleWaker {
+        tx: mpsc::Sender<()>,
+    }
+
+    impl Wake for SimpleWaker {
+        fn wake(self: Arc<Self>) {
+            self.tx.send(()).unwrap();
+        }
+    }
+
+    let (tx, rx) = mpsc::channel();
+    (Waker::from(Arc::new(SimpleWaker { tx })), rx)
+}
+
+async fn run() {
+    let _arr: [Item; 4] = [Item(0), Item(1), Item(2), Item(3)];
+}
+
+fn main() {
+    block_on(run());
+}

--- a/tests/ui/async-await/async-drop/async-drop-array-step.run.stdout
+++ b/tests/ui/async-await/async-drop/async-drop-array-step.run.stdout
@@ -1,0 +1,4 @@
+Dropping 0
+Dropping 1
+Dropping 2
+Dropping 3

--- a/tests/ui/async-await/async-drop/async-drop-initial.rs
+++ b/tests/ui/async-await/async-drop/async-drop-initial.rs
@@ -54,7 +54,7 @@ fn main() {
     let fut = pin!(async {
         test_async_drop(Int(0), 16).await;
         test_async_drop(AsyncInt(0), 32).await;
-        test_async_drop([AsyncInt(1), AsyncInt(2)], 104).await;
+        test_async_drop([AsyncInt(1), AsyncInt(2)], 112).await;
         test_async_drop((AsyncInt(3), AsyncInt(4)), 120).await;
         test_async_drop(5, 16).await;
         let j = 42;


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/158655)*
<!-- homu-ignore:end -->

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

The unsound analysis was found while I was working on the `async-drop` code. Apparently the counter variable in the array drop glue is not correctly identified as a saved local.

Also we did not patch up indices in `ProjectionElem::Index` when they are saved locals.

The reproduction is in the older commit with the expected output.