### PR TITLE
Clarify transmute example comment

### DIFF
--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -825,7 +825,7 @@ pub const fn forget<T: ?Sized>(_: T);
 ///     unsafe {
 ///         let ptr = slice.as_mut_ptr();
 ///         // This now has three mutable references pointing at the same
-///         // memory. `slice`, the rvalue ret.0, and the rvalue ret.1.
+///         // memory: `slice`, `ret.0`, and `ret.1`.
 ///         // `slice` is never used after `let ptr = ...`, and so one can
 ///         // treat it as "dead", and therefore, you only have two real
 ///         // mutable slices.


### PR DESCRIPTION
Fixes rust-lang/rust#153350.

This updates the `transmute` docs example comment to avoid calling `ret.0` and `ret.1` rvalues. The example itself is unchanged.

Verification:
- `git diff --check`
