### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/bootstrap.example.toml
+++ b/bootstrap.example.toml
@@ -697,6 +697,13 @@
 # FIXME(#61117): Some tests fail when this option is enabled.
 #rust.debuginfo-level-tests = 0
 
+# Compress debuginfo of Rust and C/C++ code.
+# Valid options:
+# - "off" or false: disable compression
+# - true: compress debuginfo with the default compression method (currently zlib)
+# - "zlib": compress debuginfo with zlib
+#rust.compress-debuginfo = "off"
+
 # Should rustc and the standard library be built with split debuginfo? Default
 # is platform dependent.
 #
@@ -1018,6 +1025,13 @@
 # producing a `.pdb` file. On Windows GNU rustc doesn't support splitting debuginfo,
 # and enabling it causes issues.
 #split-debuginfo = if linux || windows-gnu { off } else if windows-msvc { packed } else if apple { unpacked }
+
+# Compress debuginfo for Rust and C/C++ code of this target.
+# Valid options:
+# - "off" or false: disable compression
+# - true: compress debuginfo with the default compression method (currently zlib)
+# - "zlib": compress debuginfo with zlib
+#compress-debuginfo = "off"
 
 # Path to the `llvm-config` binary of the installation of a custom LLVM to link
 # against. Note that if this is specified we don't compile LLVM at all for this

--- a/compiler/rustc_arena/src/lib.rs
+++ b/compiler/rustc_arena/src/lib.rs
@@ -542,11 +542,12 @@ impl DroplessArena {
 
     #[inline]
     pub fn alloc_from_iter<T, I: IntoIterator<Item = T>>(&self, iter: I) -> &mut [T] {
+        assert!(!mem::needs_drop::<T>());
+        assert!(size_of::<T>() != 0);
+
         // Warning: this function is reentrant: `iter` could hold a reference to `&self` and
         // allocate additional elements while we're iterating.
         let iter = iter.into_iter();
-        assert!(size_of::<T>() != 0);
-        assert!(!mem::needs_drop::<T>());
 
         let size_hint = iter.size_hint();
 
@@ -577,6 +578,7 @@ impl DroplessArena {
     ) -> Result<&mut [T], E> {
         // Despite the similarity with `alloc_from_iter`, we cannot reuse their fast case, as we
         // cannot know the minimum length of the iterator in this case.
+        assert!(!mem::needs_drop::<T>());
         assert!(size_of::<T>() != 0);
 
         // Takes care of reentrancy.

--- a/compiler/rustc_ast_lowering/src/delegation.rs
+++ b/compiler/rustc_ast_lowering/src/delegation.rs
@@ -53,7 +53,7 @@ use rustc_middle::span_bug;
 use rustc_middle::ty::{Asyncness, PerOwnerResolverData};
 use rustc_span::def_id::{DefId, LocalDefId};
 use rustc_span::symbol::kw;
-use rustc_span::{ErrorGuaranteed, Ident, Span, Symbol};
+use rustc_span::{ErrorGuaranteed, Ident, Span, Symbol, sym};
 
 use crate::delegation::generics::{GenericsGenerationResult, GenericsGenerationResults};
 use crate::diagnostics::{
@@ -661,11 +661,34 @@ impl<'hir> LoweringContext<'_, 'hir> {
 
         let callee_path = self.arena.alloc(self.mk_expr(hir::ExprKind::Path(new_path), span));
         let args = self.arena.alloc_from_iter(args);
-        let call = self.arena.alloc(self.mk_expr(hir::ExprKind::Call(callee_path, args), span));
+        let call = self.mk_expr(hir::ExprKind::Call(callee_path, args), span);
+
+        let expr = if let Some((parent, of_trait)) = self.should_wrap_return_value(delegation) {
+            let res = Res::SelfTyAlias { alias_to: parent.to_def_id(), is_trait_impl: of_trait };
+            let ident = Ident::new(kw::SelfUpper, span);
+            let path = self.create_resolved_path(res, ident, span);
+
+            // FIXME(fn_delegation): add default `..` for all other fields.
+            let initializer = hir::ExprKind::Struct(
+                self.arena.alloc(path),
+                self.arena.alloc_slice(&[hir::ExprField {
+                    hir_id: self.next_id(),
+                    is_shorthand: false,
+                    ident: Ident::new(sym::integer(0), span),
+                    expr: self.arena.alloc(call),
+                    span,
+                }]),
+                hir::StructTailExpr::None,
+            );
+
+            self.arena.alloc(self.mk_expr(initializer, span))
+        } else {
+            self.arena.alloc(call)
+        };
 
         let block = self.arena.alloc(hir::Block {
             stmts,
-            expr: Some(call),
+            expr: Some(expr),
             hir_id: self.next_id(),
             rules: hir::BlockCheckMode::DefaultBlock,
             span,
@@ -673,6 +696,45 @@ impl<'hir> LoweringContext<'_, 'hir> {
         });
 
         (self.mk_expr(hir::ExprKind::Block(block, None), span), call.hir_id)
+    }
+
+    fn should_wrap_return_value(&self, delegation: &Delegation) -> Option<(LocalDefId, bool)> {
+        // Heuristic: don't do wrapping if there is no target expression.
+        if delegation.body.is_none() {
+            return None;
+        }
+
+        let tcx = self.tcx;
+        let parent = tcx.local_parent(self.owner.def_id);
+        let parent_kind = tcx.def_kind(parent);
+
+        // Apply wrapping for delegations inside
+        // 1) Trait impls, as the return type of both signature function
+        //    and generated delegation has `Self` generic param returned
+        //    (checked below).
+        //    FIXME(fn_delegation): think of enabling wrapping in more scenarios:
+        //      trait-(impl)-to-free
+        //      trait-(impl)-to-inherent
+        //      inherent-to-free
+        // 2) Inherent methods when delegating to trait, as we change the type of
+        //    `Self` to type of struct or enum we delegate from.
+        if !matches!(tcx.def_kind(parent), DefKind::Impl { .. }) {
+            return None;
+        }
+
+        let is_trait_impl = parent_kind == DefKind::Impl { of_trait: true };
+
+        // Check that delegation path resolves to a trait AssocFn, not to a free method.
+        Some((parent, is_trait_impl)).filter(|_| {
+            self.get_resolution_id(delegation.id).is_some_and(|id| {
+                tcx.def_kind(id) == DefKind::AssocFn
+                    // Check that the return type of the callee is `Self` param.
+                    // After previous check we are sure that `sig_id` and `delegation.id`
+                    // point to the same function.
+                    && tcx.def_kind(tcx.parent(id)) == DefKind::Trait
+                    && tcx.fn_sig(id).skip_binder().output().skip_binder().is_param(0)
+            })
+        })
     }
 
     fn process_segment(

--- a/compiler/rustc_ast_lowering/src/delegation/generics.rs
+++ b/compiler/rustc_ast_lowering/src/delegation/generics.rs
@@ -581,18 +581,27 @@ impl<'hir> LoweringContext<'_, 'hir> {
             p.def_id.to_def_id(),
         );
 
+        self.create_resolved_path(res, p.name.ident(), p.span)
+    }
+
+    pub(super) fn create_resolved_path(
+        &mut self,
+        res: Res,
+        ident: Ident,
+        span: Span,
+    ) -> hir::QPath<'hir> {
         hir::QPath::Resolved(
             None,
             self.arena.alloc(hir::Path {
                 segments: self.arena.alloc_slice(&[hir::PathSegment {
                     args: None,
                     hir_id: self.next_id(),
-                    ident: p.name.ident(),
+                    ident,
                     infer_args: false,
                     res,
                 }]),
                 res,
-                span: p.span,
+                span,
             }),
         )
     }

--- a/compiler/rustc_expand/src/base.rs
+++ b/compiler/rustc_expand/src/base.rs
@@ -1199,7 +1199,7 @@ pub trait LintStoreExpand {
 
 type LintStoreExpandDyn<'a> = Option<&'a (dyn LintStoreExpand + 'a)>;
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Default)]
 pub struct ModuleData {
     /// Path to the module starting from the crate name, like `my_crate::foo::bar`.
     pub mod_path: Vec<Ident>,

--- a/compiler/rustc_hir_analysis/src/check/check.rs
+++ b/compiler/rustc_hir_analysis/src/check/check.rs
@@ -839,9 +839,8 @@ pub(crate) fn check_item_type(tcx: TyCtxt<'_>, def_id: LocalDefId) -> Result<(),
             tcx.ensure_ok().associated_items(def_id);
             if of_trait {
                 let impl_trait_header = tcx.impl_trait_header(def_id);
-                res = res.and(tcx.ensure_result().coherent_trait(
-                    impl_trait_header.trait_ref.instantiate_identity().skip_norm_wip().def_id,
-                ));
+                res = res
+                    .and(tcx.ensure_result().coherent_trait(impl_trait_header.trait_ref.def_id()));
 
                 if res.is_ok() {
                     // Checking this only makes sense if the all trait impls satisfy basic

--- a/compiler/rustc_mir_transform/src/check_call_recursion.rs
+++ b/compiler/rustc_mir_transform/src/check_call_recursion.rs
@@ -45,7 +45,7 @@ impl<'tcx> MirLint<'tcx> for CheckDropRecursion {
         if let DefKind::AssocFn = tcx.def_kind(def_id)
         && let Some(impl_id) = tcx.trait_impl_of_assoc(def_id.to_def_id())
         && let trait_ref = tcx.impl_trait_ref(impl_id)
-        && tcx.is_lang_item(trait_ref.instantiate_identity().skip_norm_wip().def_id, LangItem::Drop)
+        && tcx.is_lang_item(trait_ref.def_id(), LangItem::Drop)
         // avoid erroneous `Drop` impls from causing ICEs below
         && let sig = tcx.fn_sig(def_id).instantiate_identity().skip_norm_wip()
         && sig.inputs().skip_binder().len() == 1

--- a/compiler/rustc_resolve/src/error_helper.rs
+++ b/compiler/rustc_resolve/src/error_helper.rs
@@ -109,7 +109,7 @@ impl TypoSuggestion {
 }
 
 /// A free importable items suggested in case of resolution failure.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub(crate) struct ImportSuggestion {
     pub did: Option<DefId>,
     pub descr: &'static str,

--- a/compiler/rustc_resolve/src/imports.rs
+++ b/compiler/rustc_resolve/src/imports.rs
@@ -69,7 +69,6 @@ impl<'ra> PendingDecl<'ra> {
 }
 
 /// Contains data for specific kinds of imports.
-#[derive(Clone)]
 pub(crate) enum ImportKind<'ra> {
     Single {
         /// `source` in `use prefix::source as target`.
@@ -157,7 +156,7 @@ impl<'ra> std::fmt::Debug for ImportKind<'ra> {
 }
 
 /// One import.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub(crate) struct ImportData<'ra> {
     pub kind: ImportKind<'ra>,
 
@@ -280,7 +279,7 @@ impl<'ra> ImportData<'ra> {
 }
 
 /// Records information about the resolution of a name in a namespace of a module.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub(crate) struct NameResolution<'ra> {
     /// Single imports that may define the name in the namespace.
     /// Imports are arena-allocated, so it's ok to use pointers as keys.
@@ -322,7 +321,7 @@ impl<'ra> NameResolution<'ra> {
 
 /// An error that may be transformed into a diagnostic later. Used to combine multiple unresolved
 /// import errors within the same use tree into a single diagnostic.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub(crate) struct UnresolvedImportError {
     pub(crate) span: Span,
     pub(crate) label: Option<String>,
@@ -341,7 +340,7 @@ fn pub_use_of_private_extern_crate_hack(
     import: ImportSummary,
     decl: Decl<'_>,
 ) -> Option<LocalDefId> {
-    match (import.is_single, decl.kind) {
+    match (import.is_single, &decl.kind) {
         (true, DeclKind::Import { import: decl_import, .. })
             if let ImportKind::ExternCrate { def_id, .. } = decl_import.kind
                 && import.vis.is_public() =>

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -133,7 +133,7 @@ pub(super) struct MissingLifetime {
 
 /// Description of the lifetimes appearing in a function parameter.
 /// This is used to provide a literal explanation to the elision failure.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub(super) struct ElisionFnParameter {
     /// The index of the argument in the original definition.
     pub index: usize,

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -992,7 +992,7 @@ impl<'ra> fmt::Debug for LocalModule<'ra> {
 }
 
 /// Data associated with any name declaration.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 struct DeclData<'ra> {
     kind: DeclKind<'ra>,
     ambiguity: CmCell<Option<(Decl<'ra>, bool /*warning*/)>>,
@@ -1026,7 +1026,7 @@ impl std::hash::Hash for DeclData<'_> {
 }
 
 /// Name declaration kind.
-#[derive(Clone, Copy, Debug)]
+#[derive(Debug)]
 enum DeclKind<'ra> {
     /// The name declaration is a definition (possibly without a `DefId`),
     /// can be provided by source code or built into the language.

--- a/compiler/rustc_type_ir/src/binder.rs
+++ b/compiler/rustc_type_ir/src/binder.rs
@@ -448,6 +448,12 @@ impl<I: Interner, T> EarlyBinder<I, T> {
     }
 }
 
+impl<I: Interner> EarlyBinder<I, ty::TraitRef<I>> {
+    pub fn def_id(&self) -> I::TraitId {
+        self.value.def_id
+    }
+}
+
 impl<I: Interner, T> EarlyBinder<I, Option<T>> {
     pub fn transpose(self) -> Option<EarlyBinder<I, T>> {
         self.value.map(|value| EarlyBinder { value, _tcx: PhantomData })

--- a/library/core/src/cmp.rs
+++ b/library/core/src/cmp.rs
@@ -26,7 +26,10 @@
 #![stable(feature = "rust1", since = "1.0.0")]
 
 mod bytewise;
+mod clamp;
 pub(crate) use bytewise::BytewiseEq;
+#[unstable(feature = "clamp_bounds", issue = "147781")]
+pub use clamp::ClampBounds;
 
 use self::Ordering::*;
 use crate::marker::{Destruct, PointeeSized};
@@ -1108,6 +1111,35 @@ pub const trait Ord: [const] Eq + [const] PartialOrd<Self> + PointeeSized {
         } else {
             self
         }
+    }
+
+    /// Restrict a value to a certain range.
+    ///
+    /// This is equal to `max`, `min`, or `clamp`, depending on whether the range is `min..`,
+    /// `..=max`, or `min..=max`, respectively. Exclusive ranges are not permitted.
+    ///
+    /// # Panics
+    ///
+    /// Panics on `min..=max` if `min > max`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(clamp_to)]
+    /// assert_eq!((-3).clamp_to(-2..=1), -2);
+    /// assert_eq!(0.clamp_to(-2..=1), 0);
+    /// assert_eq!(2.clamp_to(..=1), 1);
+    /// assert_eq!(5.clamp_to(7..), 7);
+    /// ```
+    #[must_use]
+    #[inline]
+    #[unstable(feature = "clamp_to", issue = "147781")]
+    fn clamp_to<R>(self, range: R) -> Self
+    where
+        Self: Sized + [const] Destruct,
+        R: [const] ClampBounds<Self>,
+    {
+        range.clamp(self)
     }
 }
 

--- a/library/core/src/cmp/clamp.rs
+++ b/library/core/src/cmp/clamp.rs
@@ -1,0 +1,100 @@
+use crate::marker::Destruct;
+use crate::ops::{RangeFrom, RangeFull, RangeInclusive, RangeToInclusive};
+
+/// Trait for ranges supported by [`Ord::clamp_to`].
+#[unstable(feature = "clamp_bounds", issue = "147781")]
+#[rustc_const_unstable(feature = "clamp_bounds", issue = "147781")]
+pub const trait ClampBounds<T>: Sized {
+    /// The implementation of [`Ord::clamp_to`].
+    fn clamp(self, value: T) -> T
+    where
+        T: [const] Destruct;
+}
+
+#[unstable(feature = "clamp_bounds", issue = "147781")]
+#[rustc_const_unstable(feature = "clamp_bounds", issue = "147781")]
+const impl<T> ClampBounds<T> for RangeFrom<T>
+where
+    T: [const] Ord,
+{
+    fn clamp(self, value: T) -> T
+    where
+        T: [const] Destruct,
+    {
+        value.max(self.start)
+    }
+}
+
+#[unstable(feature = "clamp_bounds", issue = "147781")]
+#[rustc_const_unstable(feature = "clamp_bounds", issue = "147781")]
+const impl<T> ClampBounds<T> for RangeToInclusive<T>
+where
+    T: [const] Ord,
+{
+    fn clamp(self, value: T) -> T
+    where
+        T: [const] Destruct,
+    {
+        value.min(self.end)
+    }
+}
+
+#[unstable(feature = "clamp_bounds", issue = "147781")]
+#[rustc_const_unstable(feature = "clamp_bounds", issue = "147781")]
+const impl<T> ClampBounds<T> for RangeInclusive<T>
+where
+    T: [const] Ord,
+{
+    fn clamp(self, value: T) -> T
+    where
+        T: [const] Destruct,
+    {
+        let (start, end) = self.into_inner();
+        value.clamp(start, end)
+    }
+}
+
+#[unstable(feature = "clamp_bounds", issue = "147781")]
+#[rustc_const_unstable(feature = "clamp_bounds", issue = "147781")]
+const impl<T> ClampBounds<T> for RangeFull {
+    fn clamp(self, value: T) -> T {
+        value
+    }
+}
+
+macro impl_for_float($t:ty) {
+    #[unstable(feature = "clamp_bounds", issue = "147781")]
+    #[rustc_const_unstable(feature = "clamp_bounds", issue = "147781")]
+    const impl ClampBounds<$t> for RangeFrom<$t> {
+        fn clamp(self, value: $t) -> $t {
+            assert!(!self.start.is_nan(), "start was NaN");
+            value.max(self.start)
+        }
+    }
+
+    #[unstable(feature = "clamp_bounds", issue = "147781")]
+    #[rustc_const_unstable(feature = "clamp_bounds", issue = "147781")]
+    const impl ClampBounds<$t> for RangeToInclusive<$t> {
+        fn clamp(self, value: $t) -> $t {
+            assert!(!self.end.is_nan(), "end was NaN");
+            value.min(self.end)
+        }
+    }
+
+    #[unstable(feature = "clamp_bounds", issue = "147781")]
+    #[rustc_const_unstable(feature = "clamp_bounds", issue = "147781")]
+    const impl ClampBounds<$t> for RangeInclusive<$t> {
+        fn clamp(self, value: $t) -> $t {
+            let (start, end) = self.into_inner();
+            assert!(start <= end, "start > end, or either was NaN");
+            value.clamp(start, end)
+        }
+    }
+}
+
+// #[unstable(feature = "f16", issue = "116909")]
+impl_for_float!(f16);
+impl_for_float!(f32);
+impl_for_float!(f64);
+// #[unstable(feature = "f128", issue = "116909")]
+impl_for_float!(f128);

--- a/library/core/src/num/f128.rs
+++ b/library/core/src/num/f128.rs
@@ -1455,6 +1455,41 @@ impl f128 {
         self.clamp(-limit, limit)
     }
 
+    /// Restrict a value to a certain range, unless it is NaN.
+    ///
+    /// This is largely equal to `max`, `min`, or `clamp`, depending on whether the range is
+    /// `min..`, `..=max`, or `min..=max`, respectively. However, unlike `max` and `min`, it will
+    /// panic if any bound is NaN.
+    ///
+    /// Note that this function returns NaN if the initial value was NaN as
+    /// well.
+    ///
+    /// Exclusive ranges are not permitted.
+    ///
+    /// # Panics
+    ///
+    /// Panics on `min..=max` if `min > max`, or if any bound is NaN.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(f128, clamp_to)]
+    /// assert_eq!((-3.0f128).clamp_to(-2.0..=1.0), -2.0);
+    /// assert_eq!(0.0f128.clamp_to(-2.0..=1.0), 0.0);
+    /// assert_eq!(2.0f128.clamp_to(..=1.0), 1.0);
+    /// assert_eq!(5.0f128.clamp_to(7.0..), 7.0);
+    /// assert!(f128::NAN.clamp_to(1.0..=2.0).is_nan());
+    /// ```
+    #[must_use]
+    #[inline]
+    #[unstable(feature = "clamp_to", issue = "147781")]
+    pub fn clamp_to<R>(self, range: R) -> Self
+    where
+        R: crate::cmp::ClampBounds<Self>,
+    {
+        range.clamp(self)
+    }
+
     /// Computes the absolute value of `self`.
     ///
     /// This function always returns the precise result.

--- a/library/core/src/num/f16.rs
+++ b/library/core/src/num/f16.rs
@@ -1441,6 +1441,41 @@ impl f16 {
         self.clamp(-limit, limit)
     }
 
+    /// Restrict a value to a certain range, unless it is NaN.
+    ///
+    /// This is largely equal to `max`, `min`, or `clamp`, depending on whether the range is
+    /// `min..`, `..=max`, or `min..=max`, respectively. However, unlike `max` and `min`, it will
+    /// panic if any bound is NaN.
+    ///
+    /// Note that this function returns NaN if the initial value was NaN as
+    /// well.
+    ///
+    /// Exclusive ranges are not permitted.
+    ///
+    /// # Panics
+    ///
+    /// Panics on `min..=max` if `min > max`, or if any bound is NaN.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(f16, clamp_to)]
+    /// assert_eq!((-3.0f16).clamp_to(-2.0..=1.0), -2.0);
+    /// assert_eq!(0.0f16.clamp_to(-2.0..=1.0), 0.0);
+    /// assert_eq!(2.0f16.clamp_to(..=1.0), 1.0);
+    /// assert_eq!(5.0f16.clamp_to(7.0..), 7.0);
+    /// assert!(f16::NAN.clamp_to(1.0..=2.0).is_nan());
+    /// ```
+    #[must_use]
+    #[inline]
+    #[unstable(feature = "clamp_to", issue = "147781")]
+    pub fn clamp_to<R>(self, range: R) -> Self
+    where
+        R: crate::cmp::ClampBounds<Self>,
+    {
+        range.clamp(self)
+    }
+
     /// Computes the absolute value of `self`.
     ///
     /// This function always returns the precise result.

--- a/library/core/src/num/f32.rs
+++ b/library/core/src/num/f32.rs
@@ -1609,6 +1609,41 @@ impl f32 {
         self.clamp(-limit, limit)
     }
 
+    /// Restrict a value to a certain range, unless it is NaN.
+    ///
+    /// This is largely equal to `max`, `min`, or `clamp`, depending on whether the range is
+    /// `min..`, `..=max`, or `min..=max`, respectively. However, unlike `max` and `min`, it will
+    /// panic if any bound is NaN.
+    ///
+    /// Note that this function returns NaN if the initial value was NaN as
+    /// well.
+    ///
+    /// Exclusive ranges are not permitted.
+    ///
+    /// # Panics
+    ///
+    /// Panics on `min..=max` if `min > max`, or if any bound is NaN.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(clamp_to)]
+    /// assert_eq!((-3.0f32).clamp_to(-2.0..=1.0), -2.0);
+    /// assert_eq!(0.0f32.clamp_to(-2.0..=1.0), 0.0);
+    /// assert_eq!(2.0f32.clamp_to(..=1.0), 1.0);
+    /// assert_eq!(5.0f32.clamp_to(7.0..), 7.0);
+    /// assert!(f32::NAN.clamp_to(1.0..=2.0).is_nan());
+    /// ```
+    #[must_use]
+    #[inline]
+    #[unstable(feature = "clamp_to", issue = "147781")]
+    pub fn clamp_to<R>(self, range: R) -> Self
+    where
+        R: crate::cmp::ClampBounds<Self>,
+    {
+        range.clamp(self)
+    }
+
     /// Computes the absolute value of `self`.
     ///
     /// This function always returns the precise result.

--- a/library/core/src/num/f64.rs
+++ b/library/core/src/num/f64.rs
@@ -1589,6 +1589,41 @@ impl f64 {
         self.clamp(-limit, limit)
     }
 
+    /// Restrict a value to a certain range, unless it is NaN.
+    ///
+    /// This is largely equal to `max`, `min`, or `clamp`, depending on whether the range is
+    /// `min..`, `..=max`, or `min..=max`, respectively. However, unlike `max` and `min`, it will
+    /// panic if any bound is NaN.
+    ///
+    /// Note that this function returns NaN if the initial value was NaN as
+    /// well.
+    ///
+    /// Exclusive ranges are not permitted.
+    ///
+    /// # Panics
+    ///
+    /// Panics on `min..=max` if `min > max`, or if any bound is NaN.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(clamp_to)]
+    /// assert_eq!((-3.0f64).clamp_to(-2.0..=1.0), -2.0);
+    /// assert_eq!(0.0f64.clamp_to(-2.0..=1.0), 0.0);
+    /// assert_eq!(2.0f64.clamp_to(..=1.0), 1.0);
+    /// assert_eq!(5.0f64.clamp_to(7.0..), 7.0);
+    /// assert!(f64::NAN.clamp_to(1.0..=2.0).is_nan());
+    /// ```
+    #[must_use]
+    #[inline]
+    #[unstable(feature = "clamp_to", issue = "147781")]
+    pub fn clamp_to<R>(self, range: R) -> Self
+    where
+        R: crate::cmp::ClampBounds<Self>,
+    {
+        range.clamp(self)
+    }
+
     /// Computes the absolute value of `self`.
     ///
     /// This function always returns the precise result.

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -2738,10 +2738,12 @@ impl<T> [T] {
 
     /// Returns a subslice with the prefix and suffix removed.
     ///
-    /// If the slice starts with `prefix` and ends with `suffix`, returns the subslice after the
-    /// prefix and before the suffix, wrapped in `Some`.
+    /// If the slice starts with `prefix`, ends with `suffix`, and
+    /// the prefix and suffix don't overlap, returns the subslice after
+    /// the prefix and before the suffix, wrapped in `Some`.
     ///
-    /// If the slice does not start with `prefix` or does not end with `suffix`, returns `None`.
+    /// If the slice does not start with `prefix`, does not end with `suffix`,
+    /// or the prefix and suffix overlap in the slice, returns `None`.
     ///
     /// # Examples
     ///
@@ -2754,6 +2756,7 @@ impl<T> [T] {
     /// assert_eq!(v.strip_circumfix(&[10], &[40]), None);
     /// assert_eq!(v.strip_circumfix(&[], &[40, 30]), Some(&[10, 50][..]));
     /// assert_eq!(v.strip_circumfix(&[10, 50], &[]), Some(&[40, 30][..]));
+    /// assert_eq!(v.strip_circumfix(&[10, 50, 40], &[50, 40, 30]), None);
     /// ```
     #[must_use = "returns the subslice without modifying the original"]
     #[stable(feature = "strip_circumfix", since = "CURRENT_RUSTC_VERSION")]

--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -2492,12 +2492,14 @@ impl str {
 
     /// Returns a string slice with the prefix and suffix removed.
     ///
-    /// If the string starts with the pattern `prefix` and ends with the pattern `suffix`, returns
+    /// If the string starts with the pattern `prefix` and ends with
+    /// the pattern `suffix`, and the prefix and suffix don't overlap, returns
     /// the substring after the prefix and before the suffix, wrapped in `Some`.
     /// Unlike [`trim_start_matches`] and [`trim_end_matches`], this method removes both the prefix
     /// and suffix exactly once.
     ///
-    /// If the string does not start with `prefix` or does not end with `suffix`, returns `None`.
+    /// If the string does not start with `prefix`, does not end with `suffix`,
+    /// or the prefix and suffix overlap in the string, returns `None`.
     ///
     /// Each [pattern] can be a `&str`, [`char`], a slice of [`char`]s, or a
     /// function or closure that determines if a character matches.
@@ -2513,6 +2515,7 @@ impl str {
     /// assert_eq!("bar:hello:foo".strip_circumfix("bar:", ":foo"), Some("hello"));
     /// assert_eq!("bar:foo".strip_circumfix("foo", "foo"), None);
     /// assert_eq!("foo:bar;".strip_circumfix("foo:", ';'), Some("bar"));
+    /// assert_eq!("foo:bar:baz".strip_circumfix("foo:bar:", ":bar:baz"), None);
     /// ```
     #[must_use = "this returns the remaining substring as a new slice, \
                   without modifying the original"]

--- a/library/coretests/tests/lib.rs
+++ b/library/coretests/tests/lib.rs
@@ -13,6 +13,7 @@
 #![feature(casefold)]
 #![feature(cfg_target_has_reliable_f16_f128)]
 #![feature(char_internals)]
+#![feature(clamp_to)]
 #![feature(clone_to_uninit)]
 #![feature(cmp_minmax)]
 #![feature(const_array)]

--- a/library/coretests/tests/num/floats.rs
+++ b/library/coretests/tests/num/floats.rs
@@ -1360,6 +1360,48 @@ float_test! {
 }
 
 float_test! {
+    name: clamp_to_min_greater_than_max,
+    attrs: {
+        const: #[cfg(false)],
+        f16: #[should_panic, cfg(target_has_reliable_f16)],
+        f32: #[should_panic],
+        f64: #[should_panic],
+        f128: #[should_panic, cfg(target_has_reliable_f128)],
+    },
+    test {
+        let _ = Float::ONE.clamp_to(3.0..=1.0);
+    }
+}
+
+float_test! {
+    name: clamp_to_min_is_nan,
+    attrs: {
+        const: #[cfg(false)],
+        f16: #[should_panic, cfg(target_has_reliable_f16)],
+        f32: #[should_panic],
+        f64: #[should_panic],
+        f128: #[should_panic, cfg(target_has_reliable_f128)],
+    },
+    test {
+        let _ = Float::ONE.clamp_to(Float::NAN..=1.0);
+    }
+}
+
+float_test! {
+    name: clamp_to_max_is_nan,
+    attrs: {
+        const: #[cfg(false)],
+        f16: #[should_panic, cfg(target_has_reliable_f16)],
+        f32: #[should_panic],
+        f64: #[should_panic],
+        f128: #[should_panic, cfg(target_has_reliable_f128)],
+    },
+    test {
+        let _ = Float::ONE.clamp_to(3.0..=Float::NAN);
+    }
+}
+
+float_test! {
     name: total_cmp,
     attrs: {
         // Miri only uses softfloats here, so that always works

--- a/library/std/src/sys/random/linux.rs
+++ b/library/std/src/sys/random/linux.rs
@@ -123,7 +123,9 @@ fn getrandom(mut bytes: &mut [u8], insecure: bool) {
                         GETRANDOM_AVAILABLE.store(false, Relaxed);
                         break;
                     }
-                    _ => panic!("failed to generate random data"),
+                    other => {
+                        panic!("failed to generate random data: errno={other:?}, flags={flags:?}")
+                    }
                 }
             }
         }

--- a/src/bootstrap/defaults/bootstrap.dist.toml
+++ b/src/bootstrap/defaults/bootstrap.dist.toml
@@ -26,6 +26,8 @@ download-rustc = false
 llvm-bitcode-linker = true
 # Required to make builds reproducible.
 remap-debuginfo = true
+# Compress debuginfo in generated artifacts to reduce their size
+compress-debuginfo = "zlib"
 
 [dist]
 # Use better compression when preparing tarballs.

--- a/src/bootstrap/src/core/builder/cargo.rs
+++ b/src/bootstrap/src/core/builder/cargo.rs
@@ -5,8 +5,8 @@ use std::path::{Path, PathBuf};
 use super::{Builder, Kind};
 use crate::core::build_steps::test;
 use crate::core::build_steps::tool::SourceType;
-use crate::core::config::SplitDebuginfo;
 use crate::core::config::flags::Color;
+use crate::core::config::{CompressDebuginfo, SplitDebuginfo};
 use crate::utils::build_stamp;
 use crate::utils::helpers::{self, LldThreads, check_cfg_arg, linker_flags};
 use crate::{
@@ -340,8 +340,13 @@ impl Cargo {
             self.rustdocflags.arg(&arg);
         }
 
-        if !builder.config.dry_run() && builder.cc[&target].args().iter().any(|arg| arg == "-gz") {
-            self.rustflags.arg("-Clink-arg=-gz");
+        if !builder.config.dry_run() {
+            match builder.config.compress_debuginfo(target) {
+                CompressDebuginfo::Zlib => {
+                    self.rustflags.arg("-Clink-arg=-Wl,--compress-debug-sections=zlib");
+                }
+                CompressDebuginfo::Off => {}
+            }
         }
 
         // Ignore linker warnings for now. These are complicated to fix and don't affect the build.

--- a/src/bootstrap/src/core/builder/cargo.rs
+++ b/src/bootstrap/src/core/builder/cargo.rs
@@ -343,7 +343,12 @@ impl Cargo {
         if !builder.config.dry_run() {
             match builder.config.compress_debuginfo(target) {
                 CompressDebuginfo::Zlib => {
-                    self.rustflags.arg("-Clink-arg=-Wl,--compress-debug-sections=zlib");
+                    // Do not enable Zlib compression on:
+                    // - Windows, because MSVC/PDB doesn't support it
+                    // - macOS, because its linker doesn't know the flag
+                    if !self.target.is_windows() && !self.target.is_apple() {
+                        self.rustflags.arg("-Clink-arg=-Wl,--compress-debug-sections=zlib");
+                    }
                 }
                 CompressDebuginfo::Off => {}
             }

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -49,8 +49,8 @@ use crate::core::config::toml::target::{
     DefaultLinuxLinkerOverride, Target, TomlTarget, default_linux_linker_overrides,
 };
 use crate::core::config::{
-    CompilerBuiltins, DebuginfoLevel, DryRun, GccCiMode, LlvmLibunwind, Merge, ReplaceOpt,
-    RustcLto, SplitDebuginfo, StringOrBool, threads_from_config,
+    CompilerBuiltins, CompressDebuginfo, DebuginfoLevel, DryRun, GccCiMode, LlvmLibunwind, Merge,
+    ReplaceOpt, RustcLto, SplitDebuginfo, StringOrBool, threads_from_config,
 };
 use crate::core::download::{
     DownloadContext, download_beta_toolchain, is_download_ci_available, maybe_download_rustfmt,
@@ -210,6 +210,7 @@ pub struct Config {
     pub rust_debuginfo_level_std: DebuginfoLevel,
     pub rust_debuginfo_level_tools: DebuginfoLevel,
     pub rust_debuginfo_level_tests: DebuginfoLevel,
+    pub rust_compress_debuginfo: CompressDebuginfo,
     pub rust_rpath: bool,
     pub rust_strip: bool,
     pub rust_frame_pointers: bool,
@@ -550,6 +551,7 @@ impl Config {
             debuginfo_level_std: rust_debuginfo_level_std,
             debuginfo_level_tools: rust_debuginfo_level_tools,
             debuginfo_level_tests: rust_debuginfo_level_tests,
+            compress_debuginfo: rust_compress_debuginfo,
             backtrace: rust_backtrace,
             incremental: rust_incremental,
             randomize_layout: rust_randomize_layout,
@@ -1469,6 +1471,7 @@ impl Config {
                 .unwrap_or(vec![CodegenBackendKind::Llvm]),
             rust_codegen_units: rust_codegen_units.map(threads_from_config),
             rust_codegen_units_std: rust_codegen_units_std.map(threads_from_config),
+            rust_compress_debuginfo: rust_compress_debuginfo.unwrap_or_default(),
             rust_debug_logging: rust_debug_logging
                 .or(rust_rustc_debug_assertions)
                 .unwrap_or(rust_debug == Some(true)),
@@ -1923,6 +1926,13 @@ impl Config {
             .get(&target)
             .and_then(|t| t.split_debuginfo)
             .unwrap_or_else(|| SplitDebuginfo::default_for_platform(target))
+    }
+
+    pub fn compress_debuginfo(&self, target: TargetSelection) -> CompressDebuginfo {
+        self.target_config
+            .get(&target)
+            .and_then(|t| t.compress_debuginfo)
+            .unwrap_or(self.rust_compress_debuginfo)
     }
 
     /// Checks if the given target is the same as the host target.

--- a/src/bootstrap/src/core/config/mod.rs
+++ b/src/bootstrap/src/core/config/mod.rs
@@ -32,6 +32,7 @@ use std::path::PathBuf;
 
 use build_helper::exit;
 pub use config::*;
+use serde::de::Unexpected;
 use serde::{Deserialize, Deserializer};
 use serde_derive::Deserialize;
 pub use target_selection::TargetSelection;
@@ -375,6 +376,53 @@ impl std::str::FromStr for SplitDebuginfo {
             "off" => Ok(SplitDebuginfo::Off),
             _ => Err(()),
         }
+    }
+}
+
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum CompressDebuginfo {
+    Zlib,
+    #[default]
+    Off,
+}
+
+impl CompressDebuginfo {
+    fn default_on() -> Self {
+        Self::Zlib
+    }
+}
+
+impl std::str::FromStr for CompressDebuginfo {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "zlib" => Ok(CompressDebuginfo::Zlib),
+            "off" => Ok(CompressDebuginfo::Off),
+            _ => Err(()),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for CompressDebuginfo {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        use serde::de::Error;
+
+        Ok(match Deserialize::deserialize(deserializer)? {
+            StringOrBool::Bool(value) => {
+                if value {
+                    CompressDebuginfo::default_on()
+                } else {
+                    CompressDebuginfo::Off
+                }
+            }
+            StringOrBool::String(value) => CompressDebuginfo::from_str(&value).map_err(|_| {
+                D::Error::invalid_value(Unexpected::Str(&value), &"`zlib` or `off`")
+            })?,
+        })
     }
 }
 

--- a/src/bootstrap/src/core/config/target_selection.rs
+++ b/src/bootstrap/src/core/config/target_selection.rs
@@ -82,6 +82,10 @@ impl TargetSelection {
         self.contains("windows")
     }
 
+    pub fn is_apple(&self) -> bool {
+        self.contains("apple")
+    }
+
     pub fn is_windows_gnu(&self) -> bool {
         self.ends_with("windows-gnu")
     }

--- a/src/bootstrap/src/core/config/toml/rust.rs
+++ b/src/bootstrap/src/core/config/toml/rust.rs
@@ -5,7 +5,7 @@ use build_helper::ci::CiEnv;
 use serde::{Deserialize, Deserializer};
 
 use crate::core::config::toml::TomlConfig;
-use crate::core::config::{DebuginfoLevel, Merge, ReplaceOpt, StringOrBool};
+use crate::core::config::{CompressDebuginfo, DebuginfoLevel, Merge, ReplaceOpt, StringOrBool};
 use crate::{BTreeSet, CodegenBackendKind, HashSet, PathBuf, TargetSelection, define_config, exit};
 
 define_config! {
@@ -28,6 +28,7 @@ define_config! {
         debuginfo_level_std: Option<DebuginfoLevel> = "debuginfo-level-std",
         debuginfo_level_tools: Option<DebuginfoLevel> = "debuginfo-level-tools",
         debuginfo_level_tests: Option<DebuginfoLevel> = "debuginfo-level-tests",
+        compress_debuginfo: Option<CompressDebuginfo> = "compress-debuginfo",
         backtrace: Option<bool> = "backtrace",
         incremental: Option<bool> = "incremental",
         default_linker: Option<String> = "default-linker",
@@ -322,6 +323,7 @@ pub fn check_incompatible_options_for_ci_rustc(
         randomize_layout,
         debug_logging,
         debuginfo_level_rustc,
+        compress_debuginfo,
         llvm_tools,
         llvm_bitcode_linker,
         stack_protector,
@@ -389,6 +391,7 @@ pub fn check_incompatible_options_for_ci_rustc(
 
     err!(current_rust_config.optimize, optimize, "rust");
     err!(current_rust_config.randomize_layout, randomize_layout, "rust");
+    err!(current_rust_config.compress_debuginfo, compress_debuginfo, "rust");
     err!(current_rust_config.debug_logging, debug_logging, "rust");
     err!(current_rust_config.debuginfo_level_rustc, debuginfo_level_rustc, "rust");
     err!(current_rust_config.rpath, rpath, "rust");

--- a/src/bootstrap/src/core/config/toml/target.rs
+++ b/src/bootstrap/src/core/config/toml/target.rs
@@ -15,7 +15,8 @@ use serde::de::Error;
 use serde::{Deserialize, Deserializer};
 
 use crate::core::config::{
-    CompilerBuiltins, LlvmLibunwind, Merge, ReplaceOpt, SplitDebuginfo, StringOrBool,
+    CompilerBuiltins, CompressDebuginfo, LlvmLibunwind, Merge, ReplaceOpt, SplitDebuginfo,
+    StringOrBool,
 };
 use crate::{CodegenBackendKind, HashSet, PathBuf, define_config, exit};
 
@@ -68,6 +69,7 @@ pub struct Target {
     pub default_linker_linux_override: DefaultLinuxLinkerOverride,
     pub linker: Option<PathBuf>,
     pub split_debuginfo: Option<SplitDebuginfo>,
+    pub compress_debuginfo: Option<CompressDebuginfo>,
     pub sanitizers: Option<bool>,
     pub profiler: Option<StringOrBool>,
     pub rpath: Option<bool>,

--- a/src/bootstrap/src/utils/cc_detect.rs
+++ b/src/bootstrap/src/utils/cc_detect.rs
@@ -102,17 +102,15 @@ pub fn fill_target_compiler(build: &mut Build, target: TargetSelection) {
     let config = build.config.target_config.get(&target);
     if let Some(cc) = config
         .and_then(|c| c.cc.clone())
-        .or_else(|| default_compiler(&mut cfg, Language::C, target, build))
+        .or_else(|| default_compiler(&cfg, Language::C, target, build))
     {
         cfg.compiler(cc);
     }
 
     let compiler = cfg.get_compiler();
-    let ar = if let ar @ Some(..) = config.and_then(|c| c.ar.clone()) {
-        ar
-    } else {
-        cfg.try_get_archiver().map(|c| PathBuf::from(c.get_program())).ok()
-    };
+    let ar = config
+        .and_then(|c| c.ar.clone())
+        .or_else(|| cfg.try_get_archiver().map(|c| PathBuf::from(c.get_program())).ok());
 
     build.cc.insert(target, compiler.clone());
     let mut cflags = build.cc_handled_clags(target, CLang::C);
@@ -124,7 +122,7 @@ pub fn fill_target_compiler(build: &mut Build, target: TargetSelection) {
     cfg.cpp(true);
     let cxx_configured = if let Some(cxx) = config
         .and_then(|c| c.cxx.clone())
-        .or_else(|| default_compiler(&mut cfg, Language::CPlusPlus, target, build))
+        .or_else(|| default_compiler(&cfg, Language::CPlusPlus, target, build))
     {
         cfg.compiler(cxx);
         true
@@ -160,7 +158,7 @@ pub fn fill_target_compiler(build: &mut Build, target: TargetSelection) {
 /// Determines the default compiler for a given target and language when not explicitly
 /// configured in `bootstrap.toml`.
 fn default_compiler(
-    cfg: &mut cc::Build,
+    cfg: &cc::Build,
     compiler: Language,
     target: TargetSelection,
     build: &Build,

--- a/src/bootstrap/src/utils/cc_detect.rs
+++ b/src/bootstrap/src/utils/cc_detect.rs
@@ -25,7 +25,7 @@ use std::collections::HashSet;
 use std::iter;
 use std::path::{Path, PathBuf};
 
-use crate::core::config::TargetSelection;
+use crate::core::config::{CompressDebuginfo, TargetSelection};
 use crate::utils::exec::{BootstrapCommand, command};
 use crate::{Build, CLang, GitRepo};
 
@@ -38,10 +38,16 @@ fn new_cc_build(build: &Build, target: TargetSelection) -> cc::Build {
         .debug(false)
         // We have to configure out_dir, otherwise flag_if_supported will not work
         .out_dir(build.tempdir().join("cc-rs-out-dir"))
-        // Compress debuginfo
-        .flag_if_supported("-gz")
         .target(&target.triple)
         .host(&build.host_target.triple);
+
+    match build.config.compress_debuginfo(target) {
+        CompressDebuginfo::Zlib => {
+            cfg.flag_if_supported("-gz");
+        }
+        CompressDebuginfo::Off => {}
+    }
+
     match build.crt_static(target) {
         Some(a) => {
             cfg.static_crt(a);

--- a/src/bootstrap/src/utils/cc_detect.rs
+++ b/src/bootstrap/src/utils/cc_detect.rs
@@ -36,6 +36,8 @@ fn new_cc_build(build: &Build, target: TargetSelection) -> cc::Build {
         .opt_level(2)
         .warnings(false)
         .debug(false)
+        // We have to configure out_dir, otherwise flag_if_supported will not work
+        .out_dir(build.tempdir().join("cc-rs-out-dir"))
         // Compress debuginfo
         .flag_if_supported("-gz")
         .target(&target.triple)

--- a/src/bootstrap/src/utils/cc_detect/tests.rs
+++ b/src/bootstrap/src/utils/cc_detect/tests.rs
@@ -86,7 +86,7 @@ fn test_default_compiler_wasi() {
     build.wasi_sdk_path = Some(wasi_sdk.clone());
 
     let mut cfg = cc::Build::new();
-    if let Some(result) = default_compiler(&mut cfg, Language::C, target.clone(), &build) {
+    if let Some(result) = default_compiler(&cfg, Language::C, target.clone(), &build) {
         let expected = {
             let compiler = format!("{}-clang", target.triple);
             wasi_sdk.join("bin").join(compiler)
@@ -105,7 +105,7 @@ fn test_default_compiler_fallback() {
     let build = Build::new(config);
     let target = TargetSelection::from_user("x86_64-unknown-linux-gnu");
     let mut cfg = cc::Build::new();
-    let result = default_compiler(&mut cfg, Language::C, target, &build);
+    let result = default_compiler(&cfg, Language::C, target, &build);
     assert!(result.is_none(), "default_compiler should return None for generic targets");
 }
 

--- a/src/bootstrap/src/utils/change_tracker.rs
+++ b/src/bootstrap/src/utils/change_tracker.rs
@@ -631,4 +631,9 @@ pub const CONFIG_CHANGE_HISTORY: &[ChangeInfo] = &[
         severity: ChangeSeverity::Info,
         summary: "New `--verbose-run-make-subprocess-output` flag for `x.py test` (defaults to true). Set `--verbose-run-make-subprocess-output=false` to suppress verbose subprocess output for passing run-make tests when using `--no-capture`.",
     },
+    ChangeInfo {
+        change_id: 158169,
+        severity: ChangeSeverity::Info,
+        summary: "New option `rust.compress-debuginfo` allows configuring whether Rust and C/C++ debuginfo should be compressed.",
+    },
 ];

--- a/src/ci/docker/host-x86_64/x86_64-gnu-distcheck/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-distcheck/Dockerfile
@@ -28,6 +28,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   xz-utils \
   libssl-dev \
   pkg-config \
+  zlib1g-dev \
   && rm -rf /var/lib/apt/lists/*
 
 COPY scripts/sccache.sh /scripts/

--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -145,6 +145,8 @@ if [ "$DEPLOY$DEPLOY_ALT" = "1" ]; then
   fi
 else
   RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --set rust.remap-debuginfo=false"
+  # No need to compress debuginfo for tests, and we do not want to depend on zlib
+  RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --set rust.compress-debuginfo=off"
 
   # We almost always want debug assertions enabled, but sometimes this takes too
   # long for too little benefit, so we just turn them off.

--- a/tests/pretty/delegation/self-mapping-output.pp
+++ b/tests/pretty/delegation/self-mapping-output.pp
@@ -1,0 +1,44 @@
+#![attr = Feature([fn_delegation#0])]
+extern crate std;
+#[attr = PreludeImport]
+use ::std::prelude::rust_2015::*;
+//@ pretty-compare-only
+//@ pretty-mode:hir
+//@ pp-exact:self-mapping-output.pp
+
+
+trait Trait {
+    fn method(&self)
+    -> Self;
+    fn r#static()
+    -> Self;
+    fn raw_S(&self) -> S { S }
+}
+
+struct S;
+impl Trait for S {
+    fn method(&self) -> S { S }
+    fn r#static() -> S { S }
+}
+
+struct W(S);
+impl Trait for W {
+    #[attr = Inline(Hint)]
+    fn method(self: _) -> _ { Self { 0: Trait::method(self.0) } }
+    #[attr = Inline(Hint)]
+    fn r#static() -> _ { Trait::r#static() }
+    //~^ WARN: function cannot return without recursing [unconditional_recursion]
+    #[attr = Inline(Hint)]
+    fn raw_S(self: _) -> _ { Trait::raw_S(self.0) }
+}
+
+impl W {
+    #[attr = Inline(Hint)]
+    fn method(self: _) -> _ { Self { 0: Trait::method(self.0) } }
+    #[attr = Inline(Hint)]
+    fn r#static() -> _ { Trait::r#static() }
+    #[attr = Inline(Hint)]
+    fn raw_S(self: _) -> _ { Trait::raw_S(self.0) }
+}
+
+fn main() { }

--- a/tests/pretty/delegation/self-mapping-output.rs
+++ b/tests/pretty/delegation/self-mapping-output.rs
@@ -1,0 +1,33 @@
+//@ pretty-compare-only
+//@ pretty-mode:hir
+//@ pp-exact:self-mapping-output.pp
+
+#![feature(fn_delegation)]
+
+trait Trait {
+    fn method(&self) -> Self;
+    fn r#static() -> Self;
+    fn raw_S(&self) -> S { S }
+}
+
+struct S;
+impl Trait for S {
+    fn method(&self) -> S { S }
+    fn r#static() -> S { S }
+}
+
+struct W(S);
+impl Trait for W {
+    reuse Trait::method { self.0 }
+    reuse Trait::r#static;
+    //~^ WARN: function cannot return without recursing [unconditional_recursion]
+    reuse Trait::raw_S { self.0 }
+}
+
+impl W {
+    reuse Trait::method { self.0 }
+    reuse Trait::r#static;
+    reuse Trait::raw_S { self.0 }
+}
+
+fn main() {}

--- a/tests/ui/delegation/self-mapping-output-privacy.rs
+++ b/tests/ui/delegation/self-mapping-output-privacy.rs
@@ -1,0 +1,28 @@
+#![feature(fn_delegation)]
+
+trait Trait {
+    fn method(&self) -> Self;
+}
+
+pub struct S;
+impl Trait for S {
+    fn method(&self) -> S {
+        S
+    }
+}
+
+mod private {
+    pub struct W(super::S);
+}
+
+impl Trait for private::W {
+    reuse Trait::method { S }
+    //~^ ERROR: field `0` of struct `W` is private
+}
+
+impl private::W {
+    reuse Trait::method { S }
+    //~^ ERROR: field `0` of struct `W` is private
+}
+
+fn main() {}

--- a/tests/ui/delegation/self-mapping-output-privacy.stderr
+++ b/tests/ui/delegation/self-mapping-output-privacy.stderr
@@ -1,0 +1,15 @@
+error[E0451]: field `0` of struct `W` is private
+  --> $DIR/self-mapping-output-privacy.rs:19:18
+   |
+LL |     reuse Trait::method { S }
+   |                  ^^^^^^ private field
+
+error[E0451]: field `0` of struct `W` is private
+  --> $DIR/self-mapping-output-privacy.rs:24:18
+   |
+LL |     reuse Trait::method { S }
+   |                  ^^^^^^ private field
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0451`.

--- a/tests/ui/delegation/self-mapping-output.rs
+++ b/tests/ui/delegation/self-mapping-output.rs
@@ -1,0 +1,357 @@
+#![feature(fn_delegation)]
+
+mod success {
+    trait Trait {
+        fn method(&self) -> Self;
+        fn r#static() -> Self;
+        fn raw_S(&self) -> S { S }
+    }
+
+    struct S;
+    impl Trait for S {
+        fn method(&self) -> S { S }
+        fn r#static() -> S { S }
+    }
+
+    struct W(S);
+    impl Trait for W {
+        reuse Trait::method { self.0 }
+        reuse Trait::r#static;
+        //~^ WARN: function cannot return without recursing [unconditional_recursion]
+        reuse Trait::raw_S { self.0 }
+    }
+
+    impl W {
+        reuse Trait::method { self.0 }
+        reuse Trait::r#static;
+        reuse Trait::raw_S { self.0 }
+    }
+}
+
+mod success_non_field {
+    trait Trait {
+        fn method(&self) -> Self;
+        fn r#static() -> Self;
+        fn raw_S(&self) -> S { S }
+    }
+
+    struct S;
+    impl Trait for S {
+        fn method(&self) -> S { S }
+        fn r#static() -> S { S }
+    }
+
+    struct W(S);
+    impl Trait for W {
+        reuse Trait::method { S }
+        reuse Trait::r#static;
+        //~^ WARN: function cannot return without recursing [unconditional_recursion]
+        reuse Trait::raw_S { S }
+    }
+
+    impl W {
+        reuse Trait::method { S }
+        reuse Trait::r#static;
+        reuse Trait::raw_S { S }
+    }
+}
+
+mod success_generics {
+    trait Trait<'a, T, const N: usize> {
+        fn method(&self) -> Self;
+        fn r#static() -> Self;
+        fn raw_S(&self) -> S<'a, 'static, T, (), N, 123> {
+            S::<'a, 'static, T, (), N, 123>(std::marker::PhantomData)
+        }
+    }
+
+    struct S<'a, 'b, A, B, const N: usize, const M: usize>(
+        std::marker::PhantomData<&'a &'b (A, B, &'a [(); N], &'b [(); M])>
+    );
+
+    impl<'a, T, const N: usize> Trait<'a, T, N> for S<'a, 'static, T, (), N, 123> {
+        fn method(&self) -> S<'a, 'static, T, (), N, 123> {
+            S(std::marker::PhantomData)
+        }
+
+        fn r#static() -> S<'a, 'static, T, (), N, 123> { S(std::marker::PhantomData) }
+    }
+
+    struct W<'a, 'b, A, B, const N: usize, const M: usize>(S<'a, 'b, A, B, N, M>);
+    impl<'a, T, const N: usize> Trait<'a, T, N> for W<'a, 'static, T, (), N, 123> {
+        reuse Trait::<'a, T, N>::method { self.0 }
+        reuse Trait::<'a, T, N>::r#static;
+        //~^ WARN: function cannot return without recursing [unconditional_recursion]
+        reuse Trait::<'a, T, N>::raw_S { self.0 }
+    }
+
+    impl<'a, T, const N: usize> W<'a, 'static, T, (), N, 123> {
+        reuse Trait::<'a, T, N>::method { self.0 }
+        reuse Trait::<'a, T, N>::r#static;
+        reuse Trait::<'a, T, N>::raw_S { self.0 }
+    }
+}
+
+mod no_constructor {
+    trait Trait {
+        fn method(&self) -> Self;
+        fn r#static() -> Self;
+        fn raw_S(&self) -> S { S }
+    }
+
+    struct S;
+    impl Trait for S {
+        fn method(&self) -> S { S }
+        fn r#static() -> S { S }
+    }
+
+    struct W { s: S }
+    impl Trait for W {
+        reuse Trait::method { self.0 }
+        //~^ ERROR: no field `0` on type `&no_constructor::W`
+        //~| ERROR: struct `no_constructor::W` has no field named `0`
+        reuse Trait::r#static;
+        //~^ WARN: function cannot return without recursing [unconditional_recursion]
+        reuse Trait::raw_S { self.0 }
+        //~^ ERROR: no field `0` on type `&no_constructor::W`
+    }
+
+    impl W {
+        reuse Trait::method { self.0 }
+        //~^ ERROR: no field `0` on type `&no_constructor::W`
+        //~| ERROR: struct `no_constructor::W` has no field named `0`
+        reuse Trait::r#static;
+        reuse Trait::raw_S { self.0 }
+        //~^ ERROR: no field `0` on type `&no_constructor::W`
+    }
+}
+
+mod more_than_one_field {
+    trait Trait {
+        fn method(&self) -> Self;
+        fn r#static() -> Self;
+        fn raw_S(&self) -> S { S }
+    }
+
+    struct S;
+    impl Trait for S {
+        fn method(&self) -> S { S }
+        fn r#static() -> S { S }
+    }
+
+    struct W(S, S, S);
+    impl Trait for W {
+        reuse Trait::method { self.0 }
+        //~^ ERROR: missing fields `1` and `2` in initializer of `more_than_one_field::W`
+        reuse Trait::r#static;
+        //~^ WARN: function cannot return without recursing [unconditional_recursion]
+        reuse Trait::raw_S { self.0 }
+    }
+
+    impl W {
+        reuse Trait::method { self.0 }
+        //~^ ERROR: missing fields `1` and `2` in initializer of `more_than_one_field::W`
+        reuse Trait::r#static;
+        reuse Trait::raw_S { self.0 }
+    }
+}
+
+mod non_trait_path_reuse {
+    trait Trait {
+        fn method(&self) -> Self;
+        fn r#static() -> Self;
+        fn raw_S(&self) -> S { S }
+    }
+
+    mod to_reuse {
+        pub fn method(_: impl super::Trait) -> impl super::Trait {
+            super::S
+        }
+
+        pub fn r#static() -> impl super::Trait {
+            super::S
+        }
+    }
+
+    pub struct S;
+    impl Trait for S {
+        fn method(&self) -> S { S }
+        fn r#static() -> S { S }
+    }
+
+    struct W(S);
+    impl Trait for W {
+        reuse to_reuse::method { self.0 }
+        //~^ ERROR: mismatched types
+        reuse to_reuse::r#static;
+        //~^ ERROR: mismatched types
+    }
+
+    impl W {
+        reuse to_reuse::method { self.0 }
+        //~^ ERROR: no field `0` on type `impl super::Trait`
+        reuse to_reuse::r#static;
+    }
+}
+
+mod non_Self_return_type {
+    trait Trait {
+        fn method(&self) -> ();
+        fn r#static() -> ();
+        fn raw_S(&self) -> S { S }
+    }
+
+    struct S;
+    impl Trait for S {
+        fn method(&self) -> () { () }
+        fn r#static() -> () { () }
+        fn raw_S(&self) -> S { S }
+    }
+
+    struct W(());
+    impl Trait for W {
+        reuse Trait::method { self.0 }
+        //~^ ERROR: mismatched types
+
+        reuse Trait::r#static;
+        //~^ ERROR: type annotations needed
+
+        reuse Trait::raw_S { self.0 }
+        //~^ ERROR: mismatched types
+    }
+
+    impl W {
+        reuse Trait::method { self.0 }
+        //~^ ERROR: mismatched types
+
+        reuse Trait::r#static;
+        //~^ ERROR: type annotations needed
+
+        reuse Trait::raw_S { self.0 }
+        //~^ ERROR: mismatched types
+    }
+}
+
+mod wrong_return_type {
+    trait Trait {
+        fn method(&self) -> Self;
+        fn r#static() -> Self;
+        fn raw_S(&self) -> S { S }
+    }
+
+    struct F;
+    impl Trait for F {
+        fn method(&self) -> F { F }
+        fn r#static() -> F { F }
+    }
+
+    struct S;
+    impl Trait for S {
+        fn method(&self) -> S { S }
+        fn r#static() -> S { S }
+    }
+
+    struct W(S);
+    impl Trait for W {
+        reuse <F as Trait>::method { self.0 }
+        //~^ ERROR: mismatched types
+        //~| ERROR: mismatched types
+
+        reuse <F as Trait>::r#static;
+        //~^ ERROR: mismatched types
+
+        reuse <F as Trait>::raw_S { self.0 }
+        //~^ ERROR: mismatched types
+    }
+
+    impl W {
+        reuse <F as Trait>::method { self.0 }
+        //~^ ERROR: mismatched types
+        //~| ERROR: mismatched types
+
+        reuse <F as Trait>::r#static;
+        //~^ ERROR: mismatched types
+
+        reuse <F as Trait>::raw_S { self.0 }
+        //~^ ERROR: mismatched types
+    }
+}
+
+mod wrong_target_expression {
+    trait Trait {
+        fn method(&self) -> Self;
+        fn r#static() -> Self;
+        fn raw_S(&self) -> S { S }
+    }
+
+    struct S;
+    impl Trait for S {
+        fn method(&self) -> S { S }
+        fn r#static() -> S { S }
+    }
+
+    struct F;
+    impl Trait for F {
+        fn method(&self) -> F { F }
+        fn r#static() -> F { F }
+    }
+
+    struct W(S);
+    impl Trait for W {
+        reuse Trait::method { F }
+        //~^ ERROR: mismatched types
+
+        reuse Trait::r#static;
+        //~^ WARN: function cannot return without recursing [unconditional_recursion]
+        reuse Trait::raw_S { F }
+    }
+
+    impl W {
+        reuse Trait::method { F }
+        //~^ ERROR: mismatched types
+
+        reuse Trait::r#static;
+        reuse Trait::raw_S { F }
+    }
+}
+
+mod privacy {
+    trait Trait {
+        fn method(&self) -> Self;
+        fn r#static() -> Self;
+        fn raw_S(&self) -> S { S }
+    }
+
+    pub struct S;
+    impl Trait for S {
+        fn method(&self) -> S { S }
+        fn r#static() -> S { S }
+    }
+
+    mod private {
+        pub struct W(super::S);
+    }
+
+    impl Trait for private::W {
+        reuse Trait::method { self.0 }
+        //~^ ERROR: field `0` of struct `private::W` is private
+
+        reuse Trait::r#static;
+        //~^ WARN: function cannot return without recursing [unconditional_recursion]
+
+        reuse Trait::raw_S { self.0 }
+        //~^ ERROR: field `0` of struct `private::W` is private
+    }
+
+    impl private::W {
+        reuse Trait::method { self.0 }
+        //~^ ERROR: field `0` of struct `private::W` is private
+
+        reuse Trait::r#static;
+
+        reuse Trait::raw_S { self.0 }
+        //~^ ERROR: field `0` of struct `private::W` is private
+    }
+}
+
+fn main() {}

--- a/tests/ui/delegation/self-mapping-output.stderr
+++ b/tests/ui/delegation/self-mapping-output.stderr
@@ -1,0 +1,468 @@
+error[E0560]: struct `no_constructor::W` has no field named `0`
+  --> $DIR/self-mapping-output.rs:110:22
+   |
+LL |         reuse Trait::method { self.0 }
+   |                      ^^^^^^ unknown field
+   |
+help: a field with a similar name exists
+   |
+LL -         reuse Trait::method { self.0 }
+LL +         reuse Trait::s { self.0 }
+   |
+
+error[E0609]: no field `0` on type `&no_constructor::W`
+  --> $DIR/self-mapping-output.rs:110:36
+   |
+LL |         reuse Trait::method { self.0 }
+   |                                    ^ unknown field
+   |
+help: a field with a similar name exists
+   |
+LL -         reuse Trait::method { self.0 }
+LL +         reuse Trait::method { self.s }
+   |
+
+error[E0609]: no field `0` on type `&no_constructor::W`
+  --> $DIR/self-mapping-output.rs:115:35
+   |
+LL |         reuse Trait::raw_S { self.0 }
+   |                                   ^ unknown field
+   |
+help: a field with a similar name exists
+   |
+LL -         reuse Trait::raw_S { self.0 }
+LL +         reuse Trait::raw_S { self.s }
+   |
+
+error[E0560]: struct `no_constructor::W` has no field named `0`
+  --> $DIR/self-mapping-output.rs:120:22
+   |
+LL |         reuse Trait::method { self.0 }
+   |                      ^^^^^^ unknown field
+   |
+help: a field with a similar name exists
+   |
+LL -         reuse Trait::method { self.0 }
+LL +         reuse Trait::s { self.0 }
+   |
+
+error[E0609]: no field `0` on type `&no_constructor::W`
+  --> $DIR/self-mapping-output.rs:120:36
+   |
+LL |         reuse Trait::method { self.0 }
+   |                                    ^ unknown field
+   |
+help: a field with a similar name exists
+   |
+LL -         reuse Trait::method { self.0 }
+LL +         reuse Trait::method { self.s }
+   |
+
+error[E0609]: no field `0` on type `&no_constructor::W`
+  --> $DIR/self-mapping-output.rs:124:35
+   |
+LL |         reuse Trait::raw_S { self.0 }
+   |                                   ^ unknown field
+   |
+help: a field with a similar name exists
+   |
+LL -         reuse Trait::raw_S { self.0 }
+LL +         reuse Trait::raw_S { self.s }
+   |
+
+error[E0063]: missing fields `1` and `2` in initializer of `more_than_one_field::W`
+  --> $DIR/self-mapping-output.rs:144:22
+   |
+LL |         reuse Trait::method { self.0 }
+   |                      ^^^^^^ missing `1` and `2`
+
+error[E0063]: missing fields `1` and `2` in initializer of `more_than_one_field::W`
+  --> $DIR/self-mapping-output.rs:152:22
+   |
+LL |         reuse Trait::method { self.0 }
+   |                      ^^^^^^ missing `1` and `2`
+
+error[E0308]: mismatched types
+  --> $DIR/self-mapping-output.rs:184:25
+   |
+LL |         pub fn method(_: impl super::Trait) -> impl super::Trait {
+   |                                                ----------------- the found opaque type
+...
+LL |         reuse to_reuse::method { self.0 }
+   |                         ^^^^^^
+   |                         |
+   |                         expected `W`, found opaque type
+   |                         expected `non_trait_path_reuse::W` because of return type
+   |
+   = note:   expected struct `non_trait_path_reuse::W`
+           found opaque type `impl non_trait_path_reuse::Trait`
+
+error[E0308]: mismatched types
+  --> $DIR/self-mapping-output.rs:186:25
+   |
+LL |         pub fn r#static() -> impl super::Trait {
+   |                              ----------------- the found opaque type
+...
+LL |         reuse to_reuse::r#static;
+   |                         ^^^^^^^^
+   |                         |
+   |                         expected `W`, found opaque type
+   |                         expected `non_trait_path_reuse::W` because of return type
+   |
+   = note:   expected struct `non_trait_path_reuse::W`
+           found opaque type `impl non_trait_path_reuse::Trait`
+
+error[E0609]: no field `0` on type `impl super::Trait`
+  --> $DIR/self-mapping-output.rs:191:39
+   |
+LL |         reuse to_reuse::method { self.0 }
+   |                                       ^ unknown field
+
+error[E0308]: mismatched types
+  --> $DIR/self-mapping-output.rs:213:31
+   |
+LL |         reuse Trait::method { self.0 }
+   |                      ------   ^^^^^^ expected `&_`, found `()`
+   |                      |
+   |                      arguments to this function are incorrect
+   |
+   = note: expected reference `&_`
+              found unit type `()`
+note: method defined here
+  --> $DIR/self-mapping-output.rs:199:12
+   |
+LL |         fn method(&self) -> ();
+   |            ^^^^^^  ----
+help: consider borrowing here
+   |
+LL |         reuse Trait::method { &self.0 }
+   |                               +
+
+error[E0283]: type annotations needed
+  --> $DIR/self-mapping-output.rs:216:22
+   |
+LL |         reuse Trait::r#static;
+   |                      ^^^^^^^^ cannot infer type
+   |
+   = note: the type must implement `non_Self_return_type::Trait`
+help: the following types implement trait `non_Self_return_type::Trait`
+  --> $DIR/self-mapping-output.rs:205:5
+   |
+LL |     impl Trait for S {
+   |     ^^^^^^^^^^^^^^^^ `non_Self_return_type::S`
+...
+LL |     impl Trait for W {
+   |     ^^^^^^^^^^^^^^^^ `non_Self_return_type::W`
+
+error[E0308]: mismatched types
+  --> $DIR/self-mapping-output.rs:219:30
+   |
+LL |         reuse Trait::raw_S { self.0 }
+   |                      -----   ^^^^^^ expected `&_`, found `()`
+   |                      |
+   |                      arguments to this function are incorrect
+   |
+   = note: expected reference `&_`
+              found unit type `()`
+note: method defined here
+  --> $DIR/self-mapping-output.rs:201:12
+   |
+LL |         fn raw_S(&self) -> S { S }
+   |            ^^^^^ -----
+help: consider borrowing here
+   |
+LL |         reuse Trait::raw_S { &self.0 }
+   |                              +
+
+error[E0308]: mismatched types
+  --> $DIR/self-mapping-output.rs:224:31
+   |
+LL |         reuse Trait::method { self.0 }
+   |                      ------   ^^^^^^ expected `&_`, found `()`
+   |                      |
+   |                      arguments to this function are incorrect
+   |
+   = note: expected reference `&_`
+              found unit type `()`
+note: method defined here
+  --> $DIR/self-mapping-output.rs:199:12
+   |
+LL |         fn method(&self) -> ();
+   |            ^^^^^^  ----
+help: consider borrowing here
+   |
+LL |         reuse Trait::method { &self.0 }
+   |                               +
+
+error[E0283]: type annotations needed
+  --> $DIR/self-mapping-output.rs:227:22
+   |
+LL |         reuse Trait::r#static;
+   |                      ^^^^^^^^ cannot infer type
+   |
+   = note: the type must implement `non_Self_return_type::Trait`
+help: the following types implement trait `non_Self_return_type::Trait`
+  --> $DIR/self-mapping-output.rs:205:5
+   |
+LL |     impl Trait for S {
+   |     ^^^^^^^^^^^^^^^^ `non_Self_return_type::S`
+...
+LL |     impl Trait for W {
+   |     ^^^^^^^^^^^^^^^^ `non_Self_return_type::W`
+
+error[E0308]: mismatched types
+  --> $DIR/self-mapping-output.rs:230:30
+   |
+LL |         reuse Trait::raw_S { self.0 }
+   |                      -----   ^^^^^^ expected `&_`, found `()`
+   |                      |
+   |                      arguments to this function are incorrect
+   |
+   = note: expected reference `&_`
+              found unit type `()`
+note: method defined here
+  --> $DIR/self-mapping-output.rs:201:12
+   |
+LL |         fn raw_S(&self) -> S { S }
+   |            ^^^^^ -----
+help: consider borrowing here
+   |
+LL |         reuse Trait::raw_S { &self.0 }
+   |                              +
+
+error[E0308]: mismatched types
+  --> $DIR/self-mapping-output.rs:256:38
+   |
+LL |         reuse <F as Trait>::method { self.0 }
+   |                             ------   ^^^^^^ expected `&F`, found `&S`
+   |                             |
+   |                             arguments to this function are incorrect
+   |                             this return type influences the call expression's return type
+   |
+   = note: expected reference `&wrong_return_type::F`
+              found reference `&wrong_return_type::S`
+note: method defined here
+  --> $DIR/self-mapping-output.rs:237:12
+   |
+LL |         fn method(&self) -> Self;
+   |            ^^^^^^  ----
+
+error[E0308]: mismatched types
+  --> $DIR/self-mapping-output.rs:256:29
+   |
+LL |         reuse <F as Trait>::method { self.0 }
+   |                             ^^^^^^ expected `S`, found `F`
+
+error[E0308]: mismatched types
+  --> $DIR/self-mapping-output.rs:260:29
+   |
+LL |         reuse <F as Trait>::r#static;
+   |                             ^^^^^^^^
+   |                             |
+   |                             expected `W`, found `F`
+   |                             expected `wrong_return_type::W` because of return type
+
+error[E0308]: mismatched types
+  --> $DIR/self-mapping-output.rs:263:37
+   |
+LL |         reuse <F as Trait>::raw_S { self.0 }
+   |                             -----   ^^^^^^ expected `&F`, found `&S`
+   |                             |
+   |                             arguments to this function are incorrect
+   |
+   = note: expected reference `&wrong_return_type::F`
+              found reference `&wrong_return_type::S`
+note: method defined here
+  --> $DIR/self-mapping-output.rs:239:12
+   |
+LL |         fn raw_S(&self) -> S { S }
+   |            ^^^^^ -----
+
+error[E0308]: mismatched types
+  --> $DIR/self-mapping-output.rs:268:38
+   |
+LL |         reuse <F as Trait>::method { self.0 }
+   |                             ------   ^^^^^^ expected `&F`, found `&S`
+   |                             |
+   |                             arguments to this function are incorrect
+   |                             this return type influences the call expression's return type
+   |
+   = note: expected reference `&wrong_return_type::F`
+              found reference `&wrong_return_type::S`
+note: method defined here
+  --> $DIR/self-mapping-output.rs:237:12
+   |
+LL |         fn method(&self) -> Self;
+   |            ^^^^^^  ----
+
+error[E0308]: mismatched types
+  --> $DIR/self-mapping-output.rs:268:29
+   |
+LL |         reuse <F as Trait>::method { self.0 }
+   |                             ^^^^^^ expected `S`, found `F`
+
+error[E0308]: mismatched types
+  --> $DIR/self-mapping-output.rs:272:29
+   |
+LL |         reuse <F as Trait>::r#static;
+   |                             ^^^^^^^^
+   |                             |
+   |                             expected `W`, found `F`
+   |                             expected `wrong_return_type::W` because of return type
+
+error[E0308]: mismatched types
+  --> $DIR/self-mapping-output.rs:275:37
+   |
+LL |         reuse <F as Trait>::raw_S { self.0 }
+   |                             -----   ^^^^^^ expected `&F`, found `&S`
+   |                             |
+   |                             arguments to this function are incorrect
+   |
+   = note: expected reference `&wrong_return_type::F`
+              found reference `&wrong_return_type::S`
+note: method defined here
+  --> $DIR/self-mapping-output.rs:239:12
+   |
+LL |         fn raw_S(&self) -> S { S }
+   |            ^^^^^ -----
+
+error[E0308]: mismatched types
+  --> $DIR/self-mapping-output.rs:301:31
+   |
+LL |         reuse Trait::method { F }
+   |                      ------   ^ expected `&S`, found `&F`
+   |                      |
+   |                      arguments to this function are incorrect
+   |                      this return type influences the call expression's return type
+   |
+   = note: expected reference `&wrong_target_expression::S`
+              found reference `&wrong_target_expression::F`
+note: method defined here
+  --> $DIR/self-mapping-output.rs:282:12
+   |
+LL |         fn method(&self) -> Self;
+   |            ^^^^^^  ----
+
+error[E0308]: mismatched types
+  --> $DIR/self-mapping-output.rs:310:31
+   |
+LL |         reuse Trait::method { F }
+   |                      ------   ^ expected `&S`, found `&F`
+   |                      |
+   |                      arguments to this function are incorrect
+   |                      this return type influences the call expression's return type
+   |
+   = note: expected reference `&wrong_target_expression::S`
+              found reference `&wrong_target_expression::F`
+note: method defined here
+  --> $DIR/self-mapping-output.rs:282:12
+   |
+LL |         fn method(&self) -> Self;
+   |            ^^^^^^  ----
+
+error[E0616]: field `0` of struct `private::W` is private
+  --> $DIR/self-mapping-output.rs:336:36
+   |
+LL |         reuse Trait::method { self.0 }
+   |                                    ^ private field
+
+error[E0616]: field `0` of struct `private::W` is private
+  --> $DIR/self-mapping-output.rs:342:35
+   |
+LL |         reuse Trait::raw_S { self.0 }
+   |                                   ^ private field
+
+error[E0616]: field `0` of struct `private::W` is private
+  --> $DIR/self-mapping-output.rs:347:36
+   |
+LL |         reuse Trait::method { self.0 }
+   |                                    ^ private field
+
+error[E0616]: field `0` of struct `private::W` is private
+  --> $DIR/self-mapping-output.rs:352:35
+   |
+LL |         reuse Trait::raw_S { self.0 }
+   |                                   ^ private field
+
+warning: function cannot return without recursing
+  --> $DIR/self-mapping-output.rs:19:22
+   |
+LL |         reuse Trait::r#static;
+   |                      ^^^^^^^^
+   |                      |
+   |                      cannot return without recursing
+   |                      recursive call site
+   |
+   = help: a `loop` may express intention better if this is on purpose
+   = note: `#[warn(unconditional_recursion)]` on by default
+
+warning: function cannot return without recursing
+  --> $DIR/self-mapping-output.rs:47:22
+   |
+LL |         reuse Trait::r#static;
+   |                      ^^^^^^^^
+   |                      |
+   |                      cannot return without recursing
+   |                      recursive call site
+   |
+   = help: a `loop` may express intention better if this is on purpose
+
+warning: function cannot return without recursing
+  --> $DIR/self-mapping-output.rs:83:34
+   |
+LL |         reuse Trait::<'a, T, N>::r#static;
+   |                                  ^^^^^^^^
+   |                                  |
+   |                                  cannot return without recursing
+   |                                  recursive call site
+   |
+   = help: a `loop` may express intention better if this is on purpose
+
+warning: function cannot return without recursing
+  --> $DIR/self-mapping-output.rs:113:22
+   |
+LL |         reuse Trait::r#static;
+   |                      ^^^^^^^^
+   |                      |
+   |                      cannot return without recursing
+   |                      recursive call site
+   |
+   = help: a `loop` may express intention better if this is on purpose
+
+warning: function cannot return without recursing
+  --> $DIR/self-mapping-output.rs:146:22
+   |
+LL |         reuse Trait::r#static;
+   |                      ^^^^^^^^
+   |                      |
+   |                      cannot return without recursing
+   |                      recursive call site
+   |
+   = help: a `loop` may express intention better if this is on purpose
+
+warning: function cannot return without recursing
+  --> $DIR/self-mapping-output.rs:304:22
+   |
+LL |         reuse Trait::r#static;
+   |                      ^^^^^^^^
+   |                      |
+   |                      cannot return without recursing
+   |                      recursive call site
+   |
+   = help: a `loop` may express intention better if this is on purpose
+
+warning: function cannot return without recursing
+  --> $DIR/self-mapping-output.rs:339:22
+   |
+LL |         reuse Trait::r#static;
+   |                      ^^^^^^^^
+   |                      |
+   |                      cannot return without recursing
+   |                      recursive call site
+   |
+   = help: a `loop` may express intention better if this is on purpose
+
+error: aborting due to 31 previous errors; 7 warnings emitted
+
+Some errors have detailed explanations: E0063, E0283, E0308, E0560, E0609, E0616.
+For more information about an error, try `rustc --explain E0063`.

--- a/tests/ui/std/linux-getrandom-fallback.rs
+++ b/tests/ui/std/linux-getrandom-fallback.rs
@@ -1,5 +1,6 @@
 //@ only-linux
 //@ run-pass
+//@ needs-unwind
 
 #![feature(random)]
 #![feature(rustc_private)]


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#150075 (Implement clamp_to)
 - rust-lang/rust#158169 (Fix debuginfo compression in bootstrap)
 - rust-lang/rust#158397 (delegation: support simplest output `Self` mapping)
 - rust-lang/rust#158613 (Fix getrandom fallback test on platforms with `panic=abort`)
 - rust-lang/rust#158620 (Remove skip_norm_w/i/p().def_id with a helper)
 - rust-lang/rust#158633 (Remove unnecessary `Clone` derives on resolver types)
 - rust-lang/rust#158634 (Add missing `needs_drop` check to `DroplessArena`.)
 - rust-lang/rust#158647 (Document `strip_circumfix` behavior on overlapping prefix and suffix.)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=150075,158169,158397,158613,158620,158633,158634,158647)
<!-- homu-ignore:end -->

