### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/compiler/rustc_arena/src/lib.rs
+++ b/compiler/rustc_arena/src/lib.rs
@@ -542,11 +542,12 @@ impl DroplessArena {
 
     #[inline]
     pub fn alloc_from_iter<T, I: IntoIterator<Item = T>>(&self, iter: I) -> &mut [T] {
+        assert!(!mem::needs_drop::<T>());
+        assert!(size_of::<T>() != 0);
+
         // Warning: this function is reentrant: `iter` could hold a reference to `&self` and
         // allocate additional elements while we're iterating.
         let iter = iter.into_iter();
-        assert!(size_of::<T>() != 0);
-        assert!(!mem::needs_drop::<T>());
 
         let size_hint = iter.size_hint();
 
@@ -577,6 +578,7 @@ impl DroplessArena {
     ) -> Result<&mut [T], E> {
         // Despite the similarity with `alloc_from_iter`, we cannot reuse their fast case, as we
         // cannot know the minimum length of the iterator in this case.
+        assert!(!mem::needs_drop::<T>());
         assert!(size_of::<T>() != 0);
 
         // Takes care of reentrancy.

--- a/compiler/rustc_ast_lowering/src/delegation.rs
+++ b/compiler/rustc_ast_lowering/src/delegation.rs
@@ -53,7 +53,7 @@ use rustc_middle::span_bug;
 use rustc_middle::ty::{Asyncness, PerOwnerResolverData};
 use rustc_span::def_id::{DefId, LocalDefId};
 use rustc_span::symbol::kw;
-use rustc_span::{ErrorGuaranteed, Ident, Span, Symbol};
+use rustc_span::{ErrorGuaranteed, Ident, Span, Symbol, sym};
 
 use crate::delegation::generics::{GenericsGenerationResult, GenericsGenerationResults};
 use crate::diagnostics::{
@@ -661,11 +661,34 @@ impl<'hir> LoweringContext<'_, 'hir> {
 
         let callee_path = self.arena.alloc(self.mk_expr(hir::ExprKind::Path(new_path), span));
         let args = self.arena.alloc_from_iter(args);
-        let call = self.arena.alloc(self.mk_expr(hir::ExprKind::Call(callee_path, args), span));
+        let call = self.mk_expr(hir::ExprKind::Call(callee_path, args), span);
+
+        let expr = if let Some((parent, of_trait)) = self.should_wrap_return_value(delegation) {
+            let res = Res::SelfTyAlias { alias_to: parent.to_def_id(), is_trait_impl: of_trait };
+            let ident = Ident::new(kw::SelfUpper, span);
+            let path = self.create_resolved_path(res, ident, span);
+
+            // FIXME(fn_delegation): add default `..` for all other fields.
+            let initializer = hir::ExprKind::Struct(
+                self.arena.alloc(path),
+                self.arena.alloc_slice(&[hir::ExprField {
+                    hir_id: self.next_id(),
+                    is_shorthand: false,
+                    ident: Ident::new(sym::integer(0), span),
+                    expr: self.arena.alloc(call),
+                    span,
+                }]),
+                hir::StructTailExpr::None,
+            );
+
+            self.arena.alloc(self.mk_expr(initializer, span))
+        } else {
+            self.arena.alloc(call)
+        };
 
         let block = self.arena.alloc(hir::Block {
             stmts,
-            expr: Some(call),
+            expr: Some(expr),
             hir_id: self.next_id(),
             rules: hir::BlockCheckMode::DefaultBlock,
             span,
@@ -673,6 +696,45 @@ impl<'hir> LoweringContext<'_, 'hir> {
         });
 
         (self.mk_expr(hir::ExprKind::Block(block, None), span), call.hir_id)
+    }
+
+    fn should_wrap_return_value(&self, delegation: &Delegation) -> Option<(LocalDefId, bool)> {
+        // Heuristic: don't do wrapping if there is no target expression.
+        if delegation.body.is_none() {
+            return None;
+        }
+
+        let tcx = self.tcx;
+        let parent = tcx.local_parent(self.owner.def_id);
+        let parent_kind = tcx.def_kind(parent);
+
+        // Apply wrapping for delegations inside
+        // 1) Trait impls, as the return type of both signature function
+        //    and generated delegation has `Self` generic param returned
+        //    (checked below).
+        //    FIXME(fn_delegation): think of enabling wrapping in more scenarios:
+        //      trait-(impl)-to-free
+        //      trait-(impl)-to-inherent
+        //      inherent-to-free
+        // 2) Inherent methods when delegating to trait, as we change the type of
+        //    `Self` to type of struct or enum we delegate from.
+        if !matches!(tcx.def_kind(parent), DefKind::Impl { .. }) {
+            return None;
+        }
+
+        let is_trait_impl = parent_kind == DefKind::Impl { of_trait: true };
+
+        // Check that delegation path resolves to a trait AssocFn, not to a free method.
+        Some((parent, is_trait_impl)).filter(|_| {
+            self.get_resolution_id(delegation.id).is_some_and(|id| {
+                tcx.def_kind(id) == DefKind::AssocFn
+                    // Check that the return type of the callee is `Self` param.
+                    // After previous check we are sure that `sig_id` and `delegation.id`
+                    // point to the same function.
+                    && tcx.def_kind(tcx.parent(id)) == DefKind::Trait
+                    && tcx.fn_sig(id).skip_binder().output().skip_binder().is_param(0)
+            })
+        })
     }
 
     fn process_segment(

--- a/compiler/rustc_ast_lowering/src/delegation/generics.rs
+++ b/compiler/rustc_ast_lowering/src/delegation/generics.rs
@@ -581,18 +581,27 @@ impl<'hir> LoweringContext<'_, 'hir> {
             p.def_id.to_def_id(),
         );
 
+        self.create_resolved_path(res, p.name.ident(), p.span)
+    }
+
+    pub(super) fn create_resolved_path(
+        &mut self,
+        res: Res,
+        ident: Ident,
+        span: Span,
+    ) -> hir::QPath<'hir> {
         hir::QPath::Resolved(
             None,
             self.arena.alloc(hir::Path {
                 segments: self.arena.alloc_slice(&[hir::PathSegment {
                     args: None,
                     hir_id: self.next_id(),
-                    ident: p.name.ident(),
+                    ident,
                     infer_args: false,
                     res,
                 }]),
                 res,
-                span: p.span,
+                span,
             }),
         )
     }

--- a/compiler/rustc_expand/src/base.rs
+++ b/compiler/rustc_expand/src/base.rs
@@ -1199,7 +1199,7 @@ pub trait LintStoreExpand {
 
 type LintStoreExpandDyn<'a> = Option<&'a (dyn LintStoreExpand + 'a)>;
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Default)]
 pub struct ModuleData {
     /// Path to the module starting from the crate name, like `my_crate::foo::bar`.
     pub mod_path: Vec<Ident>,

--- a/compiler/rustc_hir_analysis/src/check/check.rs
+++ b/compiler/rustc_hir_analysis/src/check/check.rs
@@ -839,9 +839,8 @@ pub(crate) fn check_item_type(tcx: TyCtxt<'_>, def_id: LocalDefId) -> Result<(),
             tcx.ensure_ok().associated_items(def_id);
             if of_trait {
                 let impl_trait_header = tcx.impl_trait_header(def_id);
-                res = res.and(tcx.ensure_result().coherent_trait(
-                    impl_trait_header.trait_ref.instantiate_identity().skip_norm_wip().def_id,
-                ));
+                res = res
+                    .and(tcx.ensure_result().coherent_trait(impl_trait_header.trait_ref.def_id()));
 
                 if res.is_ok() {
                     // Checking this only makes sense if the all trait impls satisfy basic

--- a/compiler/rustc_mir_transform/src/check_call_recursion.rs
+++ b/compiler/rustc_mir_transform/src/check_call_recursion.rs
@@ -45,7 +45,7 @@ impl<'tcx> MirLint<'tcx> for CheckDropRecursion {
         if let DefKind::AssocFn = tcx.def_kind(def_id)
         && let Some(impl_id) = tcx.trait_impl_of_assoc(def_id.to_def_id())
         && let trait_ref = tcx.impl_trait_ref(impl_id)
-        && tcx.is_lang_item(trait_ref.instantiate_identity().skip_norm_wip().def_id, LangItem::Drop)
+        && tcx.is_lang_item(trait_ref.def_id(), LangItem::Drop)
         // avoid erroneous `Drop` impls from causing ICEs below
         && let sig = tcx.fn_sig(def_id).instantiate_identity().skip_norm_wip()
         && sig.inputs().skip_binder().len() == 1

--- a/compiler/rustc_resolve/src/error_helper.rs
+++ b/compiler/rustc_resolve/src/error_helper.rs
@@ -109,7 +109,7 @@ impl TypoSuggestion {
 }
 
 /// A free importable items suggested in case of resolution failure.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub(crate) struct ImportSuggestion {
     pub did: Option<DefId>,
     pub descr: &'static str,

--- a/compiler/rustc_resolve/src/imports.rs
+++ b/compiler/rustc_resolve/src/imports.rs
@@ -69,7 +69,6 @@ impl<'ra> PendingDecl<'ra> {
 }
 
 /// Contains data for specific kinds of imports.
-#[derive(Clone)]
 pub(crate) enum ImportKind<'ra> {
     Single {
         /// `source` in `use prefix::source as target`.
@@ -157,7 +156,7 @@ impl<'ra> std::fmt::Debug for ImportKind<'ra> {
 }
 
 /// One import.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub(crate) struct ImportData<'ra> {
     pub kind: ImportKind<'ra>,
 
@@ -280,7 +279,7 @@ impl<'ra> ImportData<'ra> {
 }
 
 /// Records information about the resolution of a name in a namespace of a module.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub(crate) struct NameResolution<'ra> {
     /// Single imports that may define the name in the namespace.
     /// Imports are arena-allocated, so it's ok to use pointers as keys.
@@ -322,7 +321,7 @@ impl<'ra> NameResolution<'ra> {
 
 /// An error that may be transformed into a diagnostic later. Used to combine multiple unresolved
 /// import errors within the same use tree into a single diagnostic.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub(crate) struct UnresolvedImportError {
     pub(crate) span: Span,
     pub(crate) label: Option<String>,
@@ -341,7 +340,7 @@ fn pub_use_of_private_extern_crate_hack(
     import: ImportSummary,
     decl: Decl<'_>,
 ) -> Option<LocalDefId> {
-    match (import.is_single, decl.kind) {
+    match (import.is_single, &decl.kind) {
         (true, DeclKind::Import { import: decl_import, .. })
             if let ImportKind::ExternCrate { def_id, .. } = decl_import.kind
                 && import.vis.is_public() =>

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -133,7 +133,7 @@ pub(super) struct MissingLifetime {
 
 /// Description of the lifetimes appearing in a function parameter.
 /// This is used to provide a literal explanation to the elision failure.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub(super) struct ElisionFnParameter {
     /// The index of the argument in the original definition.
     pub index: usize,

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -992,7 +992,7 @@ impl<'ra> fmt::Debug for LocalModule<'ra> {
 }
 
 /// Data associated with any name declaration.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 struct DeclData<'ra> {
     kind: DeclKind<'ra>,
     ambiguity: CmCell<Option<(Decl<'ra>, bool /*warning*/)>>,
@@ -1026,7 +1026,7 @@ impl std::hash::Hash for DeclData<'_> {
 }
 
 /// Name declaration kind.
-#[derive(Clone, Copy, Debug)]
+#[derive(Debug)]
 enum DeclKind<'ra> {
     /// The name declaration is a definition (possibly without a `DefId`),
     /// can be provided by source code or built into the language.

--- a/compiler/rustc_type_ir/src/binder.rs
+++ b/compiler/rustc_type_ir/src/binder.rs
@@ -448,6 +448,12 @@ impl<I: Interner, T> EarlyBinder<I, T> {
     }
 }
 
+impl<I: Interner> EarlyBinder<I, ty::TraitRef<I>> {
+    pub fn def_id(&self) -> I::TraitId {
+        self.value.def_id
+    }
+}
+
 impl<I: Interner, T> EarlyBinder<I, Option<T>> {
     pub fn transpose(self) -> Option<EarlyBinder<I, T>> {
         self.value.map(|value| EarlyBinder { value, _tcx: PhantomData })

--- a/library/core/src/cmp.rs
+++ b/library/core/src/cmp.rs
@@ -26,7 +26,10 @@
 #![stable(feature = "rust1", since = "1.0.0")]
 
 mod bytewise;
+mod clamp;
 pub(crate) use bytewise::BytewiseEq;
+#[unstable(feature = "clamp_bounds", issue = "147781")]
+pub use clamp::ClampBounds;
 
 use self::Ordering::*;
 use crate::marker::{Destruct, PointeeSized};
@@ -1108,6 +1111,35 @@ pub const trait Ord: [const] Eq + [const] PartialOrd<Self> + PointeeSized {
         } else {
             self
         }
+    }
+
+    /// Restrict a value to a certain range.
+    ///
+    /// This is equal to `max`, `min`, or `clamp`, depending on whether the range is `min..`,
+    /// `..=max`, or `min..=max`, respectively. Exclusive ranges are not permitted.
+    ///
+    /// # Panics
+    ///
+    /// Panics on `min..=max` if `min > max`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(clamp_to)]
+    /// assert_eq!((-3).clamp_to(-2..=1), -2);
+    /// assert_eq!(0.clamp_to(-2..=1), 0);
+    /// assert_eq!(2.clamp_to(..=1), 1);
+    /// assert_eq!(5.clamp_to(7..), 7);
+    /// ```
+    #[must_use]
+    #[inline]
+    #[unstable(feature = "clamp_to", issue = "147781")]
+    fn clamp_to<R>(self, range: R) -> Self
+    where
+        Self: Sized + [const] Destruct,
+        R: [const] ClampBounds<Self>,
+    {
+        range.clamp(self)
     }
 }
 

--- a/library/core/src/cmp/clamp.rs
+++ b/library/core/src/cmp/clamp.rs
@@ -1,0 +1,100 @@
+use crate::marker::Destruct;
+use crate::ops::{RangeFrom, RangeFull, RangeInclusive, RangeToInclusive};
+
+/// Trait for ranges supported by [`Ord::clamp_to`].
+#[unstable(feature = "clamp_bounds", issue = "147781")]
+#[rustc_const_unstable(feature = "clamp_bounds", issue = "147781")]
+pub const trait ClampBounds<T>: Sized {
+    /// The implementation of [`Ord::clamp_to`].
+    fn clamp(self, value: T) -> T
+    where
+        T: [const] Destruct;
+}
+
+#[unstable(feature = "clamp_bounds", issue = "147781")]
+#[rustc_const_unstable(feature = "clamp_bounds", issue = "147781")]
+const impl<T> ClampBounds<T> for RangeFrom<T>
+where
+    T: [const] Ord,
+{
+    fn clamp(self, value: T) -> T
+    where
+        T: [const] Destruct,
+    {
+        value.max(self.start)
+    }
+}
+
+#[unstable(feature = "clamp_bounds", issue = "147781")]
+#[rustc_const_unstable(feature = "clamp_bounds", issue = "147781")]
+const impl<T> ClampBounds<T> for RangeToInclusive<T>
+where
+    T: [const] Ord,
+{
+    fn clamp(self, value: T) -> T
+    where
+        T: [const] Destruct,
+    {
+        value.min(self.end)
+    }
+}
+
+#[unstable(feature = "clamp_bounds", issue = "147781")]
+#[rustc_const_unstable(feature = "clamp_bounds", issue = "147781")]
+const impl<T> ClampBounds<T> for RangeInclusive<T>
+where
+    T: [const] Ord,
+{
+    fn clamp(self, value: T) -> T
+    where
+        T: [const] Destruct,
+    {
+        let (start, end) = self.into_inner();
+        value.clamp(start, end)
+    }
+}
+
+#[unstable(feature = "clamp_bounds", issue = "147781")]
+#[rustc_const_unstable(feature = "clamp_bounds", issue = "147781")]
+const impl<T> ClampBounds<T> for RangeFull {
+    fn clamp(self, value: T) -> T {
+        value
+    }
+}
+
+macro impl_for_float($t:ty) {
+    #[unstable(feature = "clamp_bounds", issue = "147781")]
+    #[rustc_const_unstable(feature = "clamp_bounds", issue = "147781")]
+    const impl ClampBounds<$t> for RangeFrom<$t> {
+        fn clamp(self, value: $t) -> $t {
+            assert!(!self.start.is_nan(), "start was NaN");
+            value.max(self.start)
+        }
+    }
+
+    #[unstable(feature = "clamp_bounds", issue = "147781")]
+    #[rustc_const_unstable(feature = "clamp_bounds", issue = "147781")]
+    const impl ClampBounds<$t> for RangeToInclusive<$t> {
+        fn clamp(self, value: $t) -> $t {
+            assert!(!self.end.is_nan(), "end was NaN");
+            value.min(self.end)
+        }
+    }
+
+    #[unstable(feature = "clamp_bounds", issue = "147781")]
+    #[rustc_const_unstable(feature = "clamp_bounds", issue = "147781")]
+    const impl ClampBounds<$t> for RangeInclusive<$t> {
+        fn clamp(self, value: $t) -> $t {
+            let (start, end) = self.into_inner();
+            assert!(start <= end, "start > end, or either was NaN");
+            value.clamp(start, end)
+        }
+    }
+}
+
+// #[unstable(feature = "f16", issue = "116909")]
+impl_for_float!(f16);
+impl_for_float!(f32);
+impl_for_float!(f64);
+// #[unstable(feature = "f128", issue = "116909")]
+impl_for_float!(f128);

--- a/library/core/src/num/f128.rs
+++ b/library/core/src/num/f128.rs
@@ -1455,6 +1455,41 @@ impl f128 {
         self.clamp(-limit, limit)
     }
 
+    /// Restrict a value to a certain range, unless it is NaN.
+    ///
+    /// This is largely equal to `max`, `min`, or `clamp`, depending on whether the range is
+    /// `min..`, `..=max`, or `min..=max`, respectively. However, unlike `max` and `min`, it will
+    /// panic if any bound is NaN.
+    ///
+    /// Note that this function returns NaN if the initial value was NaN as
+    /// well.
+    ///
+    /// Exclusive ranges are not permitted.
+    ///
+    /// # Panics
+    ///
+    /// Panics on `min..=max` if `min > max`, or if any bound is NaN.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(f128, clamp_to)]
+    /// assert_eq!((-3.0f128).clamp_to(-2.0..=1.0), -2.0);
+    /// assert_eq!(0.0f128.clamp_to(-2.0..=1.0), 0.0);
+    /// assert_eq!(2.0f128.clamp_to(..=1.0), 1.0);
+    /// assert_eq!(5.0f128.clamp_to(7.0..), 7.0);
+    /// assert!(f128::NAN.clamp_to(1.0..=2.0).is_nan());
+    /// ```
+    #[must_use]
+    #[inline]
+    #[unstable(feature = "clamp_to", issue = "147781")]
+    pub fn clamp_to<R>(self, range: R) -> Self
+    where
+        R: crate::cmp::ClampBounds<Self>,
+    {
+        range.clamp(self)
+    }
+
     /// Computes the absolute value of `self`.
     ///
     /// This function always returns the precise result.

--- a/library/core/src/num/f16.rs
+++ b/library/core/src/num/f16.rs
@@ -1441,6 +1441,41 @@ impl f16 {
         self.clamp(-limit, limit)
     }
 
+    /// Restrict a value to a certain range, unless it is NaN.
+    ///
+    /// This is largely equal to `max`, `min`, or `clamp`, depending on whether the range is
+    /// `min..`, `..=max`, or `min..=max`, respectively. However, unlike `max` and `min`, it will
+    /// panic if any bound is NaN.
+    ///
+    /// Note that this function returns NaN if the initial value was NaN as
+    /// well.
+    ///
+    /// Exclusive ranges are not permitted.
+    ///
+    /// # Panics
+    ///
+    /// Panics on `min..=max` if `min > max`, or if any bound is NaN.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(f16, clamp_to)]
+    /// assert_eq!((-3.0f16).clamp_to(-2.0..=1.0), -2.0);
+    /// assert_eq!(0.0f16.clamp_to(-2.0..=1.0), 0.0);
+    /// assert_eq!(2.0f16.clamp_to(..=1.0), 1.0);
+    /// assert_eq!(5.0f16.clamp_to(7.0..), 7.0);
+    /// assert!(f16::NAN.clamp_to(1.0..=2.0).is_nan());
+    /// ```
+    #[must_use]
+    #[inline]
+    #[unstable(feature = "clamp_to", issue = "147781")]
+    pub fn clamp_to<R>(self, range: R) -> Self
+    where
+        R: crate::cmp::ClampBounds<Self>,
+    {
+        range.clamp(self)
+    }
+
     /// Computes the absolute value of `self`.
     ///
     /// This function always returns the precise result.

--- a/library/core/src/num/f32.rs
+++ b/library/core/src/num/f32.rs
@@ -1609,6 +1609,41 @@ impl f32 {
         self.clamp(-limit, limit)
     }
 
+    /// Restrict a value to a certain range, unless it is NaN.
+    ///
+    /// This is largely equal to `max`, `min`, or `clamp`, depending on whether the range is
+    /// `min..`, `..=max`, or `min..=max`, respectively. However, unlike `max` and `min`, it will
+    /// panic if any bound is NaN.
+    ///
+    /// Note that this function returns NaN if the initial value was NaN as
+    /// well.
+    ///
+    /// Exclusive ranges are not permitted.
+    ///
+    /// # Panics
+    ///
+    /// Panics on `min..=max` if `min > max`, or if any bound is NaN.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(clamp_to)]
+    /// assert_eq!((-3.0f32).clamp_to(-2.0..=1.0), -2.0);
+    /// assert_eq!(0.0f32.clamp_to(-2.0..=1.0), 0.0);
+    /// assert_eq!(2.0f32.clamp_to(..=1.0), 1.0);
+    /// assert_eq!(5.0f32.clamp_to(7.0..), 7.0);
+    /// assert!(f32::NAN.clamp_to(1.0..=2.0).is_nan());
+    /// ```
+    #[must_use]
+    #[inline]
+    #[unstable(feature = "clamp_to", issue = "147781")]
+    pub fn clamp_to<R>(self, range: R) -> Self
+    where
+        R: crate::cmp::ClampBounds<Self>,
+    {
+        range.clamp(self)
+    }
+
     /// Computes the absolute value of `self`.
     ///
     /// This function always returns the precise result.

--- a/library/core/src/num/f64.rs
+++ b/library/core/src/num/f64.rs
@@ -1589,6 +1589,41 @@ impl f64 {
         self.clamp(-limit, limit)
     }
 
+    /// Restrict a value to a certain range, unless it is NaN.
+    ///
+    /// This is largely equal to `max`, `min`, or `clamp`, depending on whether the range is
+    /// `min..`, `..=max`, or `min..=max`, respectively. However, unlike `max` and `min`, it will
+    /// panic if any bound is NaN.
+    ///
+    /// Note that this function returns NaN if the initial value was NaN as
+    /// well.
+    ///
+    /// Exclusive ranges are not permitted.
+    ///
+    /// # Panics
+    ///
+    /// Panics on `min..=max` if `min > max`, or if any bound is NaN.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(clamp_to)]
+    /// assert_eq!((-3.0f64).clamp_to(-2.0..=1.0), -2.0);
+    /// assert_eq!(0.0f64.clamp_to(-2.0..=1.0), 0.0);
+    /// assert_eq!(2.0f64.clamp_to(..=1.0), 1.0);
+    /// assert_eq!(5.0f64.clamp_to(7.0..), 7.0);
+    /// assert!(f64::NAN.clamp_to(1.0..=2.0).is_nan());
+    /// ```
+    #[must_use]
+    #[inline]
+    #[unstable(feature = "clamp_to", issue = "147781")]
+    pub fn clamp_to<R>(self, range: R) -> Self
+    where
+        R: crate::cmp::ClampBounds<Self>,
+    {
+        range.clamp(self)
+    }
+
     /// Computes the absolute value of `self`.
     ///
     /// This function always returns the precise result.

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -2738,10 +2738,12 @@ impl<T> [T] {
 
     /// Returns a subslice with the prefix and suffix removed.
     ///
-    /// If the slice starts with `prefix` and ends with `suffix`, returns the subslice after the
-    /// prefix and before the suffix, wrapped in `Some`.
+    /// If the slice starts with `prefix`, ends with `suffix`, and
+    /// the prefix and suffix don't overlap, returns the subslice after
+    /// the prefix and before the suffix, wrapped in `Some`.
     ///
-    /// If the slice does not start with `prefix` or does not end with `suffix`, returns `None`.
+    /// If the slice does not start with `prefix`, does not end with `suffix`,
+    /// or the prefix and suffix overlap in the slice, returns `None`.
     ///
     /// # Examples
     ///
@@ -2754,6 +2756,7 @@ impl<T> [T] {
     /// assert_eq!(v.strip_circumfix(&[10], &[40]), None);
     /// assert_eq!(v.strip_circumfix(&[], &[40, 30]), Some(&[10, 50][..]));
     /// assert_eq!(v.strip_circumfix(&[10, 50], &[]), Some(&[40, 30][..]));
+    /// assert_eq!(v.strip_circumfix(&[10, 50, 40], &[50, 40, 30]), None);
     /// ```
     #[must_use = "returns the subslice without modifying the original"]
     #[stable(feature = "strip_circumfix", since = "CURRENT_RUSTC_VERSION")]

--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -2492,12 +2492,14 @@ impl str {
 
     /// Returns a string slice with the prefix and suffix removed.
     ///
-    /// If the string starts with the pattern `prefix` and ends with the pattern `suffix`, returns
+    /// If the string starts with the pattern `prefix` and ends with
+    /// the pattern `suffix`, and the prefix and suffix don't overlap, returns
     /// the substring after the prefix and before the suffix, wrapped in `Some`.
     /// Unlike [`trim_start_matches`] and [`trim_end_matches`], this method removes both the prefix
     /// and suffix exactly once.
     ///
-    /// If the string does not start with `prefix` or does not end with `suffix`, returns `None`.
+    /// If the string does not start with `prefix`, does not end with `suffix`,
+    /// or the prefix and suffix overlap in the string, returns `None`.
     ///
     /// Each [pattern] can be a `&str`, [`char`], a slice of [`char`]s, or a
     /// function or closure that determines if a character matches.
@@ -2513,6 +2515,7 @@ impl str {
     /// assert_eq!("bar:hello:foo".strip_circumfix("bar:", ":foo"), Some("hello"));
     /// assert_eq!("bar:foo".strip_circumfix("foo", "foo"), None);
     /// assert_eq!("foo:bar;".strip_circumfix("foo:", ';'), Some("bar"));
+    /// assert_eq!("foo:bar:baz".strip_circumfix("foo:bar:", ":bar:baz"), None);
     /// ```
     #[must_use = "this returns the remaining substring as a new slice, \
                   without modifying the original"]

--- a/library/coretests/tests/lib.rs
+++ b/library/coretests/tests/lib.rs
@@ -13,6 +13,7 @@
 #![feature(casefold)]
 #![feature(cfg_target_has_reliable_f16_f128)]
 #![feature(char_internals)]
+#![feature(clamp_to)]
 #![feature(clone_to_uninit)]
 #![feature(cmp_minmax)]
 #![feature(const_array)]

--- a/library/coretests/tests/num/floats.rs
+++ b/library/coretests/tests/num/floats.rs
@@ -1360,6 +1360,48 @@ float_test! {
 }
 
 float_test! {
+    name: clamp_to_min_greater_than_max,
+    attrs: {
+        const: #[cfg(false)],
+        f16: #[should_panic, cfg(target_has_reliable_f16)],
+        f32: #[should_panic],
+        f64: #[should_panic],
+        f128: #[should_panic, cfg(target_has_reliable_f128)],
+    },
+    test {
+        let _ = Float::ONE.clamp_to(3.0..=1.0);
+    }
+}
+
+float_test! {
+    name: clamp_to_min_is_nan,
+    attrs: {
+        const: #[cfg(false)],
+        f16: #[should_panic, cfg(target_has_reliable_f16)],
+        f32: #[should_panic],
+        f64: #[should_panic],
+        f128: #[should_panic, cfg(target_has_reliable_f128)],
+    },
+    test {
+        let _ = Float::ONE.clamp_to(Float::NAN..=1.0);
+    }
+}
+
+float_test! {
+    name: clamp_to_max_is_nan,
+    attrs: {
+        const: #[cfg(false)],
+        f16: #[should_panic, cfg(target_has_reliable_f16)],
+        f32: #[should_panic],
+        f64: #[should_panic],
+        f128: #[should_panic, cfg(target_has_reliable_f128)],
+    },
+    test {
+        let _ = Float::ONE.clamp_to(3.0..=Float::NAN);
+    }
+}
+
+float_test! {
     name: total_cmp,
     attrs: {
         // Miri only uses softfloats here, so that always works

--- a/library/std/src/sys/random/linux.rs
+++ b/library/std/src/sys/random/linux.rs
@@ -123,7 +123,9 @@ fn getrandom(mut bytes: &mut [u8], insecure: bool) {
                         GETRANDOM_AVAILABLE.store(false, Relaxed);
                         break;
                     }
-                    _ => panic!("failed to generate random data"),
+                    other => {
+                        panic!("failed to generate random data: errno={other:?}, flags={flags:?}")
+                    }
                 }
             }
         }

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -2580,31 +2580,52 @@ impl<'test> TestCx<'test> {
         // that actually appear in the output.
         // We use uppercase ALLOC to distinguish from the non-normalized version.
         {
-            let mut seen_allocs = indexmap::IndexSet::new();
+            match self.config.mode {
+                // Unfortunately, due to parallel frontend assigning alloc-ids
+                // nondeterministically we resort to dropping ids altogether for now
+                // in ui tests
+                TestMode::Ui => {
+                    // The alloc-id appears in pretty-printed allocations.
+                    normalized = static_regex!(
+                        r"╾─*(a(lloc)?|A(LLOC)?)\d+(\+0x[0-9a-f]+)?(<imm>)?( ?\(\d+ ptr bytes\))?─*╼"
+                    )
+                    .replace_all(&normalized, |_: &Captures<'_>| "╾ALLOC$ID╼".to_string())
+                    .into_owned();
 
-            // The alloc-id appears in pretty-printed allocations.
-            normalized = static_regex!(
-                r"╾─*a(lloc)?([0-9]+)(\+0x[0-9a-f]+)?(<imm>)?( \([0-9]+ ptr bytes\))?─*╼"
-            )
-            .replace_all(&normalized, |caps: &Captures<'_>| {
-                // Renumber the captured index.
-                let index = caps.get(2).unwrap().as_str().to_string();
-                let (index, _) = seen_allocs.insert_full(index);
-                let offset = caps.get(3).map_or("", |c| c.as_str());
-                let imm = caps.get(4).map_or("", |c| c.as_str());
-                // Do not bother keeping it pretty, just make it deterministic.
-                format!("╾ALLOC{index}{offset}{imm}╼")
-            })
-            .into_owned();
+                    // The alloc-id appears in a sentence.
+                    normalized = static_regex!(r"\b(alloc|ALLOC)\d+\b")
+                        .replace_all(&normalized, |_: &Captures<'_>| "ALLOC$ID".to_string())
+                        .into_owned();
+                }
+                // use consistent `AllocId`s in other test modes, where parallel frontend
+                // should not (theoretically) be an issue
+                _ => {
+                    let mut seen_allocs = indexmap::IndexSet::new();
+                    // The alloc-id appears in pretty-printed allocations.
+                    normalized = static_regex!(
+                        r"╾─*a(lloc)?([0-9]+)(\+0x[0-9a-f]+)?(<imm>)?( \([0-9]+ ptr bytes\))?─*╼"
+                    )
+                    .replace_all(&normalized, |caps: &Captures<'_>| {
+                        // Renumber the captured index.
+                        let index = caps.get(2).unwrap().as_str().to_string();
+                        let (index, _) = seen_allocs.insert_full(index);
+                        let offset = caps.get(3).map_or("", |c| c.as_str());
+                        let imm = caps.get(4).map_or("", |c| c.as_str());
+                        // Do not bother keeping it pretty, just make it deterministic.
+                        format!("╾ALLOC{index}{offset}{imm}╼")
+                    })
+                    .into_owned();
 
-            // The alloc-id appears in a sentence.
-            normalized = static_regex!(r"\balloc([0-9]+)\b")
-                .replace_all(&normalized, |caps: &Captures<'_>| {
-                    let index = caps.get(1).unwrap().as_str().to_string();
-                    let (index, _) = seen_allocs.insert_full(index);
-                    format!("ALLOC{index}")
-                })
-                .into_owned();
+                    // The alloc-id appears in a sentence.
+                    normalized = static_regex!(r"\balloc([0-9]+)\b")
+                        .replace_all(&normalized, |caps: &Captures<'_>| {
+                            let index = caps.get(1).unwrap().as_str().to_string();
+                            let (index, _) = seen_allocs.insert_full(index);
+                            format!("ALLOC{index}")
+                        })
+                        .into_owned();
+                }
+            }
         }
 
         // Custom normalization rules

--- a/tests/pretty/delegation/self-mapping-output.pp
+++ b/tests/pretty/delegation/self-mapping-output.pp
@@ -1,0 +1,44 @@
+#![attr = Feature([fn_delegation#0])]
+extern crate std;
+#[attr = PreludeImport]
+use ::std::prelude::rust_2015::*;
+//@ pretty-compare-only
+//@ pretty-mode:hir
+//@ pp-exact:self-mapping-output.pp
+
+
+trait Trait {
+    fn method(&self)
+    -> Self;
+    fn r#static()
+    -> Self;
+    fn raw_S(&self) -> S { S }
+}
+
+struct S;
+impl Trait for S {
+    fn method(&self) -> S { S }
+    fn r#static() -> S { S }
+}
+
+struct W(S);
+impl Trait for W {
+    #[attr = Inline(Hint)]
+    fn method(self: _) -> _ { Self { 0: Trait::method(self.0) } }
+    #[attr = Inline(Hint)]
+    fn r#static() -> _ { Trait::r#static() }
+    //~^ WARN: function cannot return without recursing [unconditional_recursion]
+    #[attr = Inline(Hint)]
+    fn raw_S(self: _) -> _ { Trait::raw_S(self.0) }
+}
+
+impl W {
+    #[attr = Inline(Hint)]
+    fn method(self: _) -> _ { Self { 0: Trait::method(self.0) } }
+    #[attr = Inline(Hint)]
+    fn r#static() -> _ { Trait::r#static() }
+    #[attr = Inline(Hint)]
+    fn raw_S(self: _) -> _ { Trait::raw_S(self.0) }
+}
+
+fn main() { }

--- a/tests/pretty/delegation/self-mapping-output.rs
+++ b/tests/pretty/delegation/self-mapping-output.rs
@@ -1,0 +1,33 @@
+//@ pretty-compare-only
+//@ pretty-mode:hir
+//@ pp-exact:self-mapping-output.pp
+
+#![feature(fn_delegation)]
+
+trait Trait {
+    fn method(&self) -> Self;
+    fn r#static() -> Self;
+    fn raw_S(&self) -> S { S }
+}
+
+struct S;
+impl Trait for S {
+    fn method(&self) -> S { S }
+    fn r#static() -> S { S }
+}
+
+struct W(S);
+impl Trait for W {
+    reuse Trait::method { self.0 }
+    reuse Trait::r#static;
+    //~^ WARN: function cannot return without recursing [unconditional_recursion]
+    reuse Trait::raw_S { self.0 }
+}
+
+impl W {
+    reuse Trait::method { self.0 }
+    reuse Trait::r#static;
+    reuse Trait::raw_S { self.0 }
+}
+
+fn main() {}

--- a/tests/ui/const-generics/issues/issue-100313.rs
+++ b/tests/ui/const-generics/issues/issue-100313.rs
@@ -15,7 +15,7 @@ impl<const B: &'static bool> T<B> {
 
 const _: () = {
     let x = T::<{ &true }>;
-    x.set_false(); //~ ERROR writing to ALLOC0 which is read-only
+    x.set_false(); //~ ERROR writing to ALLOC$ID which is read-only
 };
 
 fn main() {}

--- a/tests/ui/const-generics/issues/issue-100313.rs
+++ b/tests/ui/const-generics/issues/issue-100313.rs
@@ -1,5 +1,5 @@
 //@ dont-require-annotations: NOTE
-//@ ignore-parallel-frontend different alloc ids
+
 #![allow(incomplete_features)]
 #![feature(adt_const_params, unsized_const_params)]
 

--- a/tests/ui/const-generics/issues/issue-100313.stderr
+++ b/tests/ui/const-generics/issues/issue-100313.stderr
@@ -1,4 +1,4 @@
-error[E0080]: writing to ALLOC0 which is read-only
+error[E0080]: writing to ALLOC$ID which is read-only
   --> $DIR/issue-100313.rs:18:5
    |
 LL |     x.set_false();

--- a/tests/ui/const-generics/min_const_generics/invalid-patterns.32bit.stderr
+++ b/tests/ui/const-generics/min_const_generics/invalid-patterns.32bit.stderr
@@ -46,7 +46,7 @@ note: expected because of the type of the const parameter
 LL | fn get_flag<const FlagSet: bool, const ShortName: char>() -> Option<char> {
    |                                  ^^^^^^^^^^^^^^^^^^^^^
 
-error[E0080]: reading memory at ALLOC0[0x0..0x4], but memory is uninitialized at [0x1..0x4], and this operation requires initialized memory
+error[E0080]: reading memory at ALLOC$ID[0x0..0x4], but memory is uninitialized at [0x1..0x4], and this operation requires initialized memory
   --> $DIR/invalid-patterns.rs:40:32
    |
 LL |   get_flag::<false, { unsafe { char_raw.character } }>();
@@ -78,7 +78,7 @@ LL |   get_flag::<{ unsafe { bool_raw.boolean } }, { unsafe { char_raw.character
                42                                              │ B
            }
 
-error[E0080]: reading memory at ALLOC1[0x0..0x4], but memory is uninitialized at [0x1..0x4], and this operation requires initialized memory
+error[E0080]: reading memory at ALLOC$ID[0x0..0x4], but memory is uninitialized at [0x1..0x4], and this operation requires initialized memory
   --> $DIR/invalid-patterns.rs:44:58
    |
 LL |   get_flag::<{ unsafe { bool_raw.boolean } }, { unsafe { char_raw.character } }>();

--- a/tests/ui/const-generics/min_const_generics/invalid-patterns.64bit.stderr
+++ b/tests/ui/const-generics/min_const_generics/invalid-patterns.64bit.stderr
@@ -46,7 +46,7 @@ note: expected because of the type of the const parameter
 LL | fn get_flag<const FlagSet: bool, const ShortName: char>() -> Option<char> {
    |                                  ^^^^^^^^^^^^^^^^^^^^^
 
-error[E0080]: reading memory at ALLOC0[0x0..0x4], but memory is uninitialized at [0x1..0x4], and this operation requires initialized memory
+error[E0080]: reading memory at ALLOC$ID[0x0..0x4], but memory is uninitialized at [0x1..0x4], and this operation requires initialized memory
   --> $DIR/invalid-patterns.rs:40:32
    |
 LL |   get_flag::<false, { unsafe { char_raw.character } }>();
@@ -78,7 +78,7 @@ LL |   get_flag::<{ unsafe { bool_raw.boolean } }, { unsafe { char_raw.character
                42                                              │ B
            }
 
-error[E0080]: reading memory at ALLOC1[0x0..0x4], but memory is uninitialized at [0x1..0x4], and this operation requires initialized memory
+error[E0080]: reading memory at ALLOC$ID[0x0..0x4], but memory is uninitialized at [0x1..0x4], and this operation requires initialized memory
   --> $DIR/invalid-patterns.rs:44:58
    |
 LL |   get_flag::<{ unsafe { bool_raw.boolean } }, { unsafe { char_raw.character } }>();

--- a/tests/ui/const-generics/min_const_generics/invalid-patterns.rs
+++ b/tests/ui/const-generics/min_const_generics/invalid-patterns.rs
@@ -1,6 +1,6 @@
 //@ stderr-per-bitwidth
 //@ dont-require-annotations: NOTE
-//@ ignore-parallel-frontend different alloc ids
+
 use std::mem::transmute;
 
 fn get_flag<const FlagSet: bool, const ShortName: char>() -> Option<char> {

--- a/tests/ui/const-ptr/forbidden_slices.rs
+++ b/tests/ui/const-ptr/forbidden_slices.rs
@@ -1,7 +1,7 @@
 // Strip out raw byte dumps to make comparison platform-independent:
 //@ normalize-stderr: "(the raw bytes of the constant) \(size: [0-9]*, align: [0-9]*\)" -> "$1 (size: $$SIZE, align: $$ALIGN)"
 //@ normalize-stderr: "([0-9a-f][0-9a-f] |╾─*A(LLOC)?[0-9]+(\+[a-z0-9]+)?(<imm>)?─*╼ )+ *│.*" -> "HEX_DUMP"
-//@ ignore-parallel-frontend  different alloc ids
+
 #![feature(
     slice_from_ptr_range,
     const_slice_from_ptr_range,

--- a/tests/ui/const-ptr/forbidden_slices.stderr
+++ b/tests/ui/const-ptr/forbidden_slices.stderr
@@ -28,7 +28,7 @@ LL | pub static S2: &[u32] = unsafe { from_raw_parts(&D0, 2) };
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
+               ╾ALLOC$ID╼ HEX_DUMP
            }
 
 error[E0080]: constructing invalid value of type &[u8]: at .<deref>[0], encountered uninitialized memory, but expected an integer
@@ -39,7 +39,7 @@ LL | pub static S4: &[u8] = unsafe { from_raw_parts((&D1) as *const _ as _, 1) }
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
+               ╾ALLOC$ID╼ HEX_DUMP
            }
 
 error[E0080]: constructing invalid value of type &[u8]: at .<deref>[0], encountered a pointer, but expected an integer
@@ -52,7 +52,7 @@ LL | pub static S5: &[u8] = unsafe { from_raw_parts((&D3) as *const _ as _, size
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
+               ╾ALLOC$ID╼ HEX_DUMP
            }
 
 error[E0080]: constructing invalid value of type &[bool]: at .<deref>[0], encountered 0x11, but expected a boolean
@@ -63,7 +63,7 @@ LL | pub static S6: &[bool] = unsafe { from_raw_parts((&D0) as *const _ as _, 4)
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
+               ╾ALLOC$ID╼ HEX_DUMP
            }
 
 error[E0080]: constructing invalid value of type &[u16]: at .<deref>[1], encountered uninitialized memory, but expected an integer
@@ -74,7 +74,7 @@ LL | pub static S7: &[u16] = unsafe {
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
+               ╾ALLOC$ID╼ HEX_DUMP
            }
 
 error[E0080]: constructing invalid value of type &[u64]: encountered a dangling reference (going beyond the bounds of its allocation)
@@ -85,7 +85,7 @@ LL | pub static S8: &[u64] = unsafe {
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
+               ╾ALLOC$ID╼ HEX_DUMP
            }
 
 error[E0080]: constructing invalid value of type &[u32]: encountered a null reference
@@ -105,7 +105,7 @@ error[E0080]: evaluation panicked: assertion failed: 0 < pointee_size && pointee
 LL | pub static R1: &[()] = unsafe { from_ptr_range(ptr::null()..ptr::null()) }; // errors inside libcore
    |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `R1` failed here
 
-error[E0080]: in-bounds pointer arithmetic failed: attempting to offset pointer by 8 bytes, but got ALLOC10 which is only 4 bytes from the end of the allocation
+error[E0080]: in-bounds pointer arithmetic failed: attempting to offset pointer by 8 bytes, but got ALLOC$ID which is only 4 bytes from the end of the allocation
   --> $DIR/forbidden_slices.rs:54:25
    |
 LL |     from_ptr_range(ptr..ptr.add(2)) // errors inside libcore
@@ -119,7 +119,7 @@ LL | pub static R4: &[u8] = unsafe {
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
+               ╾ALLOC$ID╼ HEX_DUMP
            }
 
 error[E0080]: constructing invalid value of type &[u8]: at .<deref>[0], encountered a pointer, but expected an integer
@@ -132,7 +132,7 @@ LL | pub static R5: &[u8] = unsafe {
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
+               ╾ALLOC$ID╼ HEX_DUMP
            }
 
 error[E0080]: constructing invalid value of type &[bool]: at .<deref>[0], encountered 0x11, but expected a boolean
@@ -143,7 +143,7 @@ LL | pub static R6: &[bool] = unsafe {
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
+               ╾ALLOC$ID╼ HEX_DUMP
            }
 
 error[E0080]: constructing invalid value of type &[u16]: encountered an unaligned reference (required 2 byte alignment but found 1)
@@ -154,10 +154,10 @@ LL | pub static R7: &[u16] = unsafe {
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
+               ╾ALLOC$ID╼ HEX_DUMP
            }
 
-error[E0080]: in-bounds pointer arithmetic failed: attempting to offset pointer by 8 bytes, but got ALLOC11+0x1 which is only 7 bytes from the end of the allocation
+error[E0080]: in-bounds pointer arithmetic failed: attempting to offset pointer by 8 bytes, but got ALLOC$ID+0x1 which is only 7 bytes from the end of the allocation
   --> $DIR/forbidden_slices.rs:79:25
    |
 LL |     from_ptr_range(ptr..ptr.add(1))

--- a/tests/ui/const-ptr/out_of_bounds_read.rs
+++ b/tests/ui/const-ptr/out_of_bounds_read.rs
@@ -1,6 +1,6 @@
 fn main() {
     use std::ptr;
-//@ ignore-parallel-frontend different alloc ids
+
     const DATA: [u32; 1] = [42];
 
     const PAST_END_PTR: *const u32 = unsafe { DATA.as_ptr().add(1) };

--- a/tests/ui/const-ptr/out_of_bounds_read.stderr
+++ b/tests/ui/const-ptr/out_of_bounds_read.stderr
@@ -1,16 +1,16 @@
-error[E0080]: memory access failed: attempting to access 4 bytes, but got ALLOC0+0x4 which is at or beyond the end of the allocation of size 4 bytes
+error[E0080]: memory access failed: attempting to access 4 bytes, but got ALLOC$ID+0x4 which is at or beyond the end of the allocation of size 4 bytes
   --> $DIR/out_of_bounds_read.rs:8:33
    |
 LL |     const _READ: u32 = unsafe { ptr::read(PAST_END_PTR) };
    |                                 ^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `main::_READ` failed here
 
-error[E0080]: memory access failed: attempting to access 4 bytes, but got ALLOC0+0x4 which is at or beyond the end of the allocation of size 4 bytes
+error[E0080]: memory access failed: attempting to access 4 bytes, but got ALLOC$ID+0x4 which is at or beyond the end of the allocation of size 4 bytes
   --> $DIR/out_of_bounds_read.rs:10:39
    |
 LL |     const _CONST_READ: u32 = unsafe { PAST_END_PTR.read() };
    |                                       ^^^^^^^^^^^^^^^^^^^ evaluation of `main::_CONST_READ` failed here
 
-error[E0080]: memory access failed: attempting to access 4 bytes, but got ALLOC0+0x4 which is at or beyond the end of the allocation of size 4 bytes
+error[E0080]: memory access failed: attempting to access 4 bytes, but got ALLOC$ID+0x4 which is at or beyond the end of the allocation of size 4 bytes
   --> $DIR/out_of_bounds_read.rs:12:37
    |
 LL |     const _MUT_READ: u32 = unsafe { (PAST_END_PTR as *mut u32).read() };

--- a/tests/ui/consts/const-compare-bytes-ub.rs
+++ b/tests/ui/consts/const-compare-bytes-ub.rs
@@ -1,5 +1,5 @@
 //@ check-fail
-//@ ignore-parallel-frontend different alloc ids
+
 #![feature(core_intrinsics, const_cmp)]
 use std::intrinsics::compare_bytes;
 use std::mem::MaybeUninit;

--- a/tests/ui/consts/const-compare-bytes-ub.stderr
+++ b/tests/ui/consts/const-compare-bytes-ub.stderr
@@ -16,19 +16,19 @@ error[E0080]: memory access failed: attempting to access 1 byte, but got 0x1[noa
 LL |         compare_bytes(1 as *const u8, 2 as *const u8, 1)
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `main::DANGLING_PTR_NON_ZERO_LENGTH` failed here
 
-error[E0080]: memory access failed: attempting to access 4 bytes, but got ALLOC0 which is only 3 bytes from the end of the allocation
+error[E0080]: memory access failed: attempting to access 4 bytes, but got ALLOC$ID which is only 3 bytes from the end of the allocation
   --> $DIR/const-compare-bytes-ub.rs:21:9
    |
 LL |         compare_bytes([1, 2, 3].as_ptr(), [1, 2, 3, 4].as_ptr(), 4)
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `main::LHS_OUT_OF_BOUNDS` failed here
 
-error[E0080]: memory access failed: attempting to access 4 bytes, but got ALLOC1 which is only 3 bytes from the end of the allocation
+error[E0080]: memory access failed: attempting to access 4 bytes, but got ALLOC$ID which is only 3 bytes from the end of the allocation
   --> $DIR/const-compare-bytes-ub.rs:25:9
    |
 LL |         compare_bytes([1, 2, 3, 4].as_ptr(), [1, 2, 3].as_ptr(), 4)
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `main::RHS_OUT_OF_BOUNDS` failed here
 
-error[E0080]: reading memory at ALLOC2[0x0..0x1], but memory is uninitialized at [0x0..0x1], and this operation requires initialized memory
+error[E0080]: reading memory at ALLOC$ID[0x0..0x1], but memory is uninitialized at [0x0..0x1], and this operation requires initialized memory
   --> $DIR/const-compare-bytes-ub.rs:29:9
    |
 LL |         compare_bytes(MaybeUninit::uninit().as_ptr(), [1].as_ptr(), 1)
@@ -38,7 +38,7 @@ LL |         compare_bytes(MaybeUninit::uninit().as_ptr(), [1].as_ptr(), 1)
                __                                              │ ░
            }
 
-error[E0080]: reading memory at ALLOC3[0x0..0x1], but memory is uninitialized at [0x0..0x1], and this operation requires initialized memory
+error[E0080]: reading memory at ALLOC$ID[0x0..0x1], but memory is uninitialized at [0x0..0x1], and this operation requires initialized memory
   --> $DIR/const-compare-bytes-ub.rs:33:9
    |
 LL |         compare_bytes([1].as_ptr(), MaybeUninit::uninit().as_ptr(), 1)

--- a/tests/ui/consts/const-err-enum-discriminant.32bit.stderr
+++ b/tests/ui/consts/const-err-enum-discriminant.32bit.stderr
@@ -1,4 +1,4 @@
-error[E0080]: reading memory at ALLOC0[0x0..0x4], but memory is uninitialized at [0x0..0x4], and this operation requires initialized memory
+error[E0080]: reading memory at ALLOC$ID[0x0..0x4], but memory is uninitialized at [0x0..0x4], and this operation requires initialized memory
   --> $DIR/const-err-enum-discriminant.rs:10:21
    |
 LL |     Boo = [unsafe { Foo { b: () }.a }; 4][3],

--- a/tests/ui/consts/const-err-enum-discriminant.64bit.stderr
+++ b/tests/ui/consts/const-err-enum-discriminant.64bit.stderr
@@ -1,4 +1,4 @@
-error[E0080]: reading memory at ALLOC0[0x0..0x8], but memory is uninitialized at [0x0..0x8], and this operation requires initialized memory
+error[E0080]: reading memory at ALLOC$ID[0x0..0x8], but memory is uninitialized at [0x0..0x8], and this operation requires initialized memory
   --> $DIR/const-err-enum-discriminant.rs:10:21
    |
 LL |     Boo = [unsafe { Foo { b: () }.a }; 4][3],

--- a/tests/ui/consts/const-err-enum-discriminant.rs
+++ b/tests/ui/consts/const-err-enum-discriminant.rs
@@ -1,5 +1,5 @@
 //@ stderr-per-bitwidth
-//@ ignore-parallel-frontend different alloc ids
+
 #[derive(Copy, Clone)]
 union Foo {
     a: isize,

--- a/tests/ui/consts/const-eval/c-variadic-fail.rs
+++ b/tests/ui/consts/const-eval/c-variadic-fail.rs
@@ -138,7 +138,7 @@ fn use_after_free() {
             let ap = helper(1, 2, 3);
             let mut ap = std::mem::transmute::<_, VaList>(ap);
             ap.next_arg::<i32>();
-            //~^ ERROR memory access failed: ALLOC0 has been freed, so this pointer is dangling [E0080]
+            //~^ ERROR memory access failed: ALLOC$ID has been freed, so this pointer is dangling [E0080]
         }
     };
 }
@@ -160,7 +160,7 @@ fn manual_copy_drop() {
     }
 
     const { unsafe { helper(1, 2, 3) } };
-    //~^ ERROR using ALLOC0 as variable argument list pointer but it does not point to a variable argument list [E0080]
+    //~^ ERROR using ALLOC$ID as variable argument list pointer but it does not point to a variable argument list [E0080]
 }
 
 fn manual_copy_forget() {
@@ -176,7 +176,7 @@ fn manual_copy_forget() {
     }
 
     const { unsafe { helper(1, 2, 3) } };
-    //~^ ERROR using ALLOC0 as variable argument list pointer but it does not point to a variable argument list [E0080]
+    //~^ ERROR using ALLOC$ID as variable argument list pointer but it does not point to a variable argument list [E0080]
 }
 
 fn manual_copy_read() {
@@ -189,7 +189,7 @@ fn manual_copy_read() {
     }
 
     const { unsafe { helper(1, 2, 3) } };
-    //~^ ERROR using ALLOC0 as variable argument list pointer but it does not point to a variable argument list [E0080]
+    //~^ ERROR using ALLOC$ID as variable argument list pointer but it does not point to a variable argument list [E0080]
 }
 
 fn drop_of_invalid() {

--- a/tests/ui/consts/const-eval/c-variadic-fail.rs
+++ b/tests/ui/consts/const-eval/c-variadic-fail.rs
@@ -1,5 +1,5 @@
 //@ build-fail
-//@ ignore-parallel-frontend different alloc ids
+
 #![feature(c_variadic)]
 #![feature(const_c_variadic)]
 #![feature(const_trait_impl)]

--- a/tests/ui/consts/const-eval/c-variadic-fail.stderr
+++ b/tests/ui/consts/const-eval/c-variadic-fail.stderr
@@ -418,7 +418,7 @@ LL |     const { read_as::<*const fn(&'static ())>(std::ptr::dangling::<for<'a> 
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error[E0080]: memory access failed: ALLOC0 has been freed, so this pointer is dangling
+error[E0080]: memory access failed: ALLOC$ID has been freed, so this pointer is dangling
   --> $DIR/c-variadic-fail.rs:140:13
    |
 LL |             ap.next_arg::<i32>();
@@ -451,7 +451,7 @@ LL | |     };
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error[E0080]: using ALLOC1 as variable argument list pointer but it does not point to a variable argument list
+error[E0080]: using ALLOC$ID as variable argument list pointer but it does not point to a variable argument list
   --> $DIR/c-variadic-fail.rs:162:22
    |
 LL |     const { unsafe { helper(1, 2, 3) } };
@@ -483,7 +483,7 @@ LL |     const { unsafe { helper(1, 2, 3) } };
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error[E0080]: using ALLOC2 as variable argument list pointer but it does not point to a variable argument list
+error[E0080]: using ALLOC$ID as variable argument list pointer but it does not point to a variable argument list
   --> $DIR/c-variadic-fail.rs:178:22
    |
 LL |     const { unsafe { helper(1, 2, 3) } };
@@ -515,7 +515,7 @@ LL |     const { unsafe { helper(1, 2, 3) } };
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error[E0080]: using ALLOC3 as variable argument list pointer but it does not point to a variable argument list
+error[E0080]: using ALLOC$ID as variable argument list pointer but it does not point to a variable argument list
   --> $DIR/c-variadic-fail.rs:191:22
    |
 LL |     const { unsafe { helper(1, 2, 3) } };

--- a/tests/ui/consts/const-eval/const-pointer-values-in-various-types.64bit.stderr
+++ b/tests/ui/consts/const-eval/const-pointer-values-in-various-types.64bit.stderr
@@ -43,14 +43,14 @@ LL |     const I32_REF_U64_UNION: u64 = unsafe { Nonsense { int_32_ref: &3 }.uin
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
-error[E0080]: reading memory at ALLOC2[0x0..0x10], but memory is uninitialized at [0x8..0x10], and this operation requires initialized memory
+error[E0080]: reading memory at ALLOC$ID[0x0..0x10], but memory is uninitialized at [0x8..0x10], and this operation requires initialized memory
   --> $DIR/const-pointer-values-in-various-types.rs:42:47
    |
 LL |     const I32_REF_U128_UNION: u128 = unsafe { Nonsense { int_32_ref: &3 }.uint_128 };
    |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `main::I32_REF_U128_UNION` failed here
    |
    = note: the raw bytes of the constant (size: 16, align: 16) {
-               ╾ALLOC0<imm>╼ __ __ __ __ __ __ __ __ │ ╾──────╼░░░░░░░░
+               ╾ALLOC$ID╼ __ __ __ __ __ __ __ __ │ ╾──────╼░░░░░░░░
            }
 
 error[E0080]: unable to turn pointer into integer
@@ -89,14 +89,14 @@ LL |     const I32_REF_I64_UNION: i64 = unsafe { Nonsense { int_32_ref: &3 }.int
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
-error[E0080]: reading memory at ALLOC3[0x0..0x10], but memory is uninitialized at [0x8..0x10], and this operation requires initialized memory
+error[E0080]: reading memory at ALLOC$ID[0x0..0x10], but memory is uninitialized at [0x8..0x10], and this operation requires initialized memory
   --> $DIR/const-pointer-values-in-various-types.rs:57:47
    |
 LL |     const I32_REF_I128_UNION: i128 = unsafe { Nonsense { int_32_ref: &3 }.int_128 };
    |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `main::I32_REF_I128_UNION` failed here
    |
    = note: the raw bytes of the constant (size: 16, align: 16) {
-               ╾ALLOC1<imm>╼ __ __ __ __ __ __ __ __ │ ╾──────╼░░░░░░░░
+               ╾ALLOC$ID╼ __ __ __ __ __ __ __ __ │ ╾──────╼░░░░░░░░
            }
 
 error[E0080]: unable to turn pointer into integer

--- a/tests/ui/consts/const-eval/const-pointer-values-in-various-types.rs
+++ b/tests/ui/consts/const-eval/const-pointer-values-in-various-types.rs
@@ -1,7 +1,7 @@
 //@ only-x86_64
 //@ stderr-per-bitwidth
 //@ dont-require-annotations: NOTE
-//@ ignore-parallel-frontend different alloc ids
+
 #[repr(C)]
 union Nonsense {
     u: usize,

--- a/tests/ui/consts/const-eval/heap/alloc_intrinsic_uninit.32bit.stderr
+++ b/tests/ui/consts/const-eval/heap/alloc_intrinsic_uninit.32bit.stderr
@@ -6,7 +6,7 @@ LL | const BAR: &i32 = unsafe {
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 4, align: 4) {
-               ╾ALLOC0<imm>╼                                     │ ╾──╼
+               ╾ALLOC$ID╼                                     │ ╾──╼
            }
 
 error: aborting due to 1 previous error

--- a/tests/ui/consts/const-eval/heap/alloc_intrinsic_uninit.64bit.stderr
+++ b/tests/ui/consts/const-eval/heap/alloc_intrinsic_uninit.64bit.stderr
@@ -6,7 +6,7 @@ LL | const BAR: &i32 = unsafe {
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 8) {
-               ╾ALLOC0<imm>╼                         │ ╾──────╼
+               ╾ALLOC$ID╼                         │ ╾──────╼
            }
 
 error: aborting due to 1 previous error

--- a/tests/ui/consts/const-eval/heap/alloc_intrinsic_uninit.rs
+++ b/tests/ui/consts/const-eval/heap/alloc_intrinsic_uninit.rs
@@ -3,7 +3,7 @@
 #![feature(core_intrinsics)]
 #![feature(const_heap)]
 use std::intrinsics;
-//@ ignore-parallel-frontend different alloc ids
+
 const BAR: &i32 = unsafe { //~ ERROR: uninitialized memory
     // Make the pointer immutable to avoid errors related to mutable pointers in constants.
     &*(intrinsics::const_make_global(intrinsics::const_allocate(4, 4)) as *const i32)

--- a/tests/ui/consts/const-eval/heap/dealloc_intrinsic_dangling.rs
+++ b/tests/ui/consts/const-eval/heap/dealloc_intrinsic_dangling.rs
@@ -1,6 +1,6 @@
 #![feature(core_intrinsics)]
 #![feature(const_heap)]
-//@ ignore-parallel-frontend different alloc ids
+
 // Strip out raw byte dumps to make comparison platform-independent:
 //@ normalize-stderr: "(the raw bytes of the constant) \(size: [0-9]*, align: [0-9]*\)" -> "$1 (size: $$SIZE, align: $$ALIGN)"
 //@ normalize-stderr: "([0-9a-f][0-9a-f] |╾─*A(LLOC)?[0-9]+(\+[a-z0-9]+)?(<imm>)?─*╼ )+ *│.*" -> "HEX_DUMP"

--- a/tests/ui/consts/const-eval/heap/dealloc_intrinsic_dangling.rs
+++ b/tests/ui/consts/const-eval/heap/dealloc_intrinsic_dangling.rs
@@ -5,6 +5,7 @@
 //@ normalize-stderr: "(the raw bytes of the constant) \(size: [0-9]*, align: [0-9]*\)" -> "$1 (size: $$SIZE, align: $$ALIGN)"
 //@ normalize-stderr: "([0-9a-f][0-9a-f] |╾─*A(LLOC)?[0-9]+(\+[a-z0-9]+)?(<imm>)?─*╼ )+ *│.*" -> "HEX_DUMP"
 //@ normalize-stderr: "HEX_DUMP\s*\n\s*HEX_DUMP" -> "HEX_DUMP"
+//@ normalize-stderr: "╾ALLOC\$ID╼\s+│.*╾.*╼" -> "╾ALLOC$$ID╼ │ ╾─╼"
 
 use std::intrinsics;
 

--- a/tests/ui/consts/const-eval/heap/dealloc_intrinsic_dangling.stderr
+++ b/tests/ui/consts/const-eval/heap/dealloc_intrinsic_dangling.stderr
@@ -6,10 +6,10 @@ LL | const _X: &'static u8 = unsafe {
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
+               ╾ALLOC$ID╼                         │ ╾──────╼
            }
 
-error[E0080]: memory access failed: ALLOC1 has been freed, so this pointer is dangling
+error[E0080]: memory access failed: ALLOC$ID has been freed, so this pointer is dangling
   --> $DIR/dealloc_intrinsic_dangling.rs:22:5
    |
 LL |     *reference

--- a/tests/ui/consts/const-eval/heap/dealloc_intrinsic_dangling.stderr
+++ b/tests/ui/consts/const-eval/heap/dealloc_intrinsic_dangling.stderr
@@ -1,16 +1,16 @@
 error[E0080]: constructing invalid value of type &u8: encountered a dangling reference (use-after-free)
-  --> $DIR/dealloc_intrinsic_dangling.rs:11:1
+  --> $DIR/dealloc_intrinsic_dangling.rs:12:1
    |
 LL | const _X: &'static u8 = unsafe {
    | ^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               ╾ALLOC$ID╼                         │ ╾──────╼
+               ╾ALLOC$ID╼ │ ╾─╼
            }
 
 error[E0080]: memory access failed: ALLOC$ID has been freed, so this pointer is dangling
-  --> $DIR/dealloc_intrinsic_dangling.rs:22:5
+  --> $DIR/dealloc_intrinsic_dangling.rs:23:5
    |
 LL |     *reference
    |     ^^^^^^^^^^ evaluation of `_Y` failed here

--- a/tests/ui/consts/const-eval/heap/dealloc_intrinsic_duplicate.rs
+++ b/tests/ui/consts/const-eval/heap/dealloc_intrinsic_duplicate.rs
@@ -1,6 +1,6 @@
 #![feature(core_intrinsics)]
 #![feature(const_heap)]
-//@ ignore-parallel-frontend different alloc ids
+
 use std::intrinsics;
 
 const _X: () = unsafe {

--- a/tests/ui/consts/const-eval/heap/dealloc_intrinsic_duplicate.stderr
+++ b/tests/ui/consts/const-eval/heap/dealloc_intrinsic_duplicate.stderr
@@ -1,4 +1,4 @@
-error[E0080]: memory access failed: ALLOC0 has been freed, so this pointer is dangling
+error[E0080]: memory access failed: ALLOC$ID has been freed, so this pointer is dangling
   --> $DIR/dealloc_intrinsic_duplicate.rs:9:5
    |
 LL |     intrinsics::const_deallocate(ptr, 4, 4);

--- a/tests/ui/consts/const-eval/heap/dealloc_intrinsic_incorrect_layout.rs
+++ b/tests/ui/consts/const-eval/heap/dealloc_intrinsic_incorrect_layout.rs
@@ -1,6 +1,6 @@
 #![feature(core_intrinsics)]
 #![feature(const_heap)]
-//@ ignore-parallel-frontend different alloc ids
+
 use std::intrinsics;
 
 const _X: () = unsafe {

--- a/tests/ui/consts/const-eval/heap/dealloc_intrinsic_incorrect_layout.stderr
+++ b/tests/ui/consts/const-eval/heap/dealloc_intrinsic_incorrect_layout.stderr
@@ -1,16 +1,16 @@
-error[E0080]: incorrect layout on deallocation: ALLOC0 has size 4 and alignment 4, but gave size 4 and alignment 2
+error[E0080]: incorrect layout on deallocation: ALLOC$ID has size 4 and alignment 4, but gave size 4 and alignment 2
   --> $DIR/dealloc_intrinsic_incorrect_layout.rs:8:5
    |
 LL |     intrinsics::const_deallocate(ptr, 4, 2);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `_X` failed here
 
-error[E0080]: incorrect layout on deallocation: ALLOC1 has size 4 and alignment 4, but gave size 2 and alignment 4
+error[E0080]: incorrect layout on deallocation: ALLOC$ID has size 4 and alignment 4, but gave size 2 and alignment 4
   --> $DIR/dealloc_intrinsic_incorrect_layout.rs:13:5
    |
 LL |     intrinsics::const_deallocate(ptr, 2, 4);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `_Y` failed here
 
-error[E0080]: incorrect layout on deallocation: ALLOC2 has size 4 and alignment 4, but gave size 3 and alignment 4
+error[E0080]: incorrect layout on deallocation: ALLOC$ID has size 4 and alignment 4, but gave size 3 and alignment 4
   --> $DIR/dealloc_intrinsic_incorrect_layout.rs:19:5
    |
 LL |     intrinsics::const_deallocate(ptr, 3, 4);

--- a/tests/ui/consts/const-eval/heap/make-global-dangling.rs
+++ b/tests/ui/consts/const-eval/heap/make-global-dangling.rs
@@ -1,5 +1,5 @@
 // Ensure that we can't call `const_make_global` on dangling pointers.
-//@ ignore-parallel-frontend different alloc ids
+
 #![feature(core_intrinsics)]
 #![feature(const_heap)]
 

--- a/tests/ui/consts/const-eval/heap/make-global-other.rs
+++ b/tests/ui/consts/const-eval/heap/make-global-other.rs
@@ -9,7 +9,7 @@ const X: &i32 = &0;
 
 const Y: &i32 = unsafe {
     &*(intrinsics::const_make_global(X as *const i32 as *mut u8) as *const i32)
-    //~^ error: pointer passed to `const_make_global` does not point to a heap allocation: ALLOC0<imm>
+    //~^ error: pointer passed to `const_make_global` does not point to a heap allocation: ALLOC$ID
 };
 
 fn main() {}

--- a/tests/ui/consts/const-eval/heap/make-global-other.rs
+++ b/tests/ui/consts/const-eval/heap/make-global-other.rs
@@ -1,5 +1,5 @@
 // Ensure that we can't call `const_make_global` on pointers not in the current interpreter.
-//@ ignore-parallel-frontend different alloc ids
+
 #![feature(core_intrinsics)]
 #![feature(const_heap)]
 

--- a/tests/ui/consts/const-eval/heap/make-global-other.stderr
+++ b/tests/ui/consts/const-eval/heap/make-global-other.stderr
@@ -1,4 +1,4 @@
-error[E0080]: pointer passed to `const_make_global` does not point to a heap allocation: ALLOC0<imm>
+error[E0080]: pointer passed to `const_make_global` does not point to a heap allocation: ALLOC$ID<imm>
   --> $DIR/make-global-other.rs:11:8
    |
 LL |     &*(intrinsics::const_make_global(X as *const i32 as *mut u8) as *const i32)

--- a/tests/ui/consts/const-eval/heap/make-global-twice.rs
+++ b/tests/ui/consts/const-eval/heap/make-global-twice.rs
@@ -11,7 +11,7 @@ const Y: &i32 = unsafe {
     *i = 20;
     intrinsics::const_make_global(ptr);
     intrinsics::const_make_global(ptr);
-    //~^ error: attempting to call `const_make_global` twice on the same allocation ALLOC0
+    //~^ error: attempting to call `const_make_global` twice on the same allocation ALLOC$ID
     &*i
 };
 

--- a/tests/ui/consts/const-eval/heap/make-global-twice.rs
+++ b/tests/ui/consts/const-eval/heap/make-global-twice.rs
@@ -1,5 +1,5 @@
 // Ensure that we can't call `const_make_global` twice.
-//@ ignore-parallel-frontend different alloc ids
+
 #![feature(core_intrinsics)]
 #![feature(const_heap)]
 

--- a/tests/ui/consts/const-eval/heap/make-global-twice.stderr
+++ b/tests/ui/consts/const-eval/heap/make-global-twice.stderr
@@ -1,4 +1,4 @@
-error[E0080]: attempting to call `const_make_global` twice on the same allocation ALLOC0
+error[E0080]: attempting to call `const_make_global` twice on the same allocation ALLOC$ID
   --> $DIR/make-global-twice.rs:13:5
    |
 LL |     intrinsics::const_make_global(ptr);

--- a/tests/ui/consts/const-eval/heap/ptr_made_global_mutated.rs
+++ b/tests/ui/consts/const-eval/heap/ptr_made_global_mutated.rs
@@ -8,7 +8,7 @@ const A: &u8 = unsafe {
     *ptr = 1;
     let ptr: *const u8 = intrinsics::const_make_global(ptr);
     *(ptr as *mut u8) = 2;
-    //~^ error: writing to ALLOC0 which is read-only
+    //~^ error: writing to ALLOC$ID which is read-only
     &*ptr
 };
 

--- a/tests/ui/consts/const-eval/heap/ptr_made_global_mutated.rs
+++ b/tests/ui/consts/const-eval/heap/ptr_made_global_mutated.rs
@@ -2,7 +2,7 @@
 #![feature(core_intrinsics)]
 #![feature(const_heap)]
 use std::intrinsics;
-//@ ignore-parallel-frontend different alloc ids
+
 const A: &u8 = unsafe {
     let ptr = intrinsics::const_allocate(1, 1);
     *ptr = 1;

--- a/tests/ui/consts/const-eval/heap/ptr_made_global_mutated.stderr
+++ b/tests/ui/consts/const-eval/heap/ptr_made_global_mutated.stderr
@@ -1,4 +1,4 @@
-error[E0080]: writing to ALLOC0 which is read-only
+error[E0080]: writing to ALLOC$ID which is read-only
   --> $DIR/ptr_made_global_mutated.rs:10:5
    |
 LL |     *(ptr as *mut u8) = 2;

--- a/tests/ui/consts/const-eval/issue-49296.rs
+++ b/tests/ui/consts/const-eval/issue-49296.rs
@@ -1,5 +1,5 @@
 // issue-49296: Unsafe shenigans in constants can result in missing errors
-//@ ignore-parallel-frontend different alloc ids
+
 use std::mem::transmute;
 
 const fn wat(x: u64) -> &'static u64 {

--- a/tests/ui/consts/const-eval/issue-49296.stderr
+++ b/tests/ui/consts/const-eval/issue-49296.stderr
@@ -1,4 +1,4 @@
-error[E0080]: memory access failed: ALLOC0 has been freed, so this pointer is dangling
+error[E0080]: memory access failed: ALLOC$ID has been freed, so this pointer is dangling
   --> $DIR/issue-49296.rs:9:16
    |
 LL | const X: u64 = *wat(42);

--- a/tests/ui/consts/const-eval/ptr_fragments_mixed.rs
+++ b/tests/ui/consts/const-eval/ptr_fragments_mixed.rs
@@ -1,6 +1,6 @@
 //! This mixes fragments from different pointers, in a way that we should not accept.
 //! See <https://github.com/rust-lang/rust/issues/146291>.
-//@ ignore-parallel-frontend different alloc ids
+
 static A: u8 = 123;
 static B: u8 = 123;
 

--- a/tests/ui/consts/const-eval/ptr_fragments_mixed.stderr
+++ b/tests/ui/consts/const-eval/ptr_fragments_mixed.stderr
@@ -1,4 +1,4 @@
-error[E0080]: unable to read parts of a pointer from memory at ALLOC0
+error[E0080]: unable to read parts of a pointer from memory at ALLOC$ID
   --> $DIR/ptr_fragments_mixed.rs:19:9
    |
 LL |         y
@@ -7,7 +7,7 @@ LL |         y
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
-error[E0080]: unable to read parts of a pointer from memory at ALLOC1
+error[E0080]: unable to read parts of a pointer from memory at ALLOC$ID
   --> $DIR/ptr_fragments_mixed.rs:33:9
    |
 LL |         y

--- a/tests/ui/consts/const-eval/raw-bytes.32bit.stderr
+++ b/tests/ui/consts/const-eval/raw-bytes.32bit.stderr
@@ -1,5 +1,5 @@
 error[E0080]: constructing invalid value of type Enum: at .<enum-tag>, encountered 0x00000001, but expected a valid enum tag
-  --> $DIR/raw-bytes.rs:24:1
+  --> $DIR/raw-bytes.rs:23:1
    |
 LL | const BAD_ENUM: Enum = unsafe { mem::transmute(1usize) };
    | ^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
@@ -10,7 +10,7 @@ LL | const BAD_ENUM: Enum = unsafe { mem::transmute(1usize) };
            }
 
 error[E0080]: constructing invalid value of type Enum2: at .<enum-tag>, encountered 0x00000000, but expected a valid enum tag
-  --> $DIR/raw-bytes.rs:32:1
+  --> $DIR/raw-bytes.rs:31:1
    |
 LL | const BAD_ENUM2: Enum2 = unsafe { mem::transmute(0usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
@@ -21,7 +21,7 @@ LL | const BAD_ENUM2: Enum2 = unsafe { mem::transmute(0usize) };
            }
 
 error[E0080]: constructing invalid value of type UninhDiscriminant: at .<enum-tag>, encountered an uninhabited enum variant
-  --> $DIR/raw-bytes.rs:46:1
+  --> $DIR/raw-bytes.rs:45:1
    |
 LL | const BAD_UNINHABITED_VARIANT1: UninhDiscriminant = unsafe { mem::transmute(1u8) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
@@ -32,7 +32,7 @@ LL | const BAD_UNINHABITED_VARIANT1: UninhDiscriminant = unsafe { mem::transmute
            }
 
 error[E0080]: constructing invalid value of type UninhDiscriminant: at .<enum-tag>, encountered 0x03, but expected a valid enum tag
-  --> $DIR/raw-bytes.rs:48:1
+  --> $DIR/raw-bytes.rs:47:1
    |
 LL | const BAD_UNINHABITED_VARIANT2: UninhDiscriminant = unsafe { mem::transmute(3u8) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
@@ -43,7 +43,7 @@ LL | const BAD_UNINHABITED_VARIANT2: UninhDiscriminant = unsafe { mem::transmute
            }
 
 error[E0080]: constructing invalid value of type Option<(char, char)>: at .<enum-variant(Some)>.0.1, encountered 0xffffffff, but expected a valid unicode scalar value (in `0..=0x10FFFF` but not in `0xD800..=0xDFFF`)
-  --> $DIR/raw-bytes.rs:54:1
+  --> $DIR/raw-bytes.rs:53:1
    |
 LL | const BAD_OPTION_CHAR: Option<(char, char)> = Some(('x', unsafe { mem::transmute(!0u32) }));
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
@@ -54,7 +54,7 @@ LL | const BAD_OPTION_CHAR: Option<(char, char)> = Some(('x', unsafe { mem::tran
            }
 
 error[E0080]: constructing invalid value of type NonNull<u8>: at .pointer, encountered 0, but expected something greater or equal to 1
-  --> $DIR/raw-bytes.rs:59:1
+  --> $DIR/raw-bytes.rs:58:1
    |
 LL | const NULL_PTR: NonNull<u8> = unsafe { mem::transmute(0usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
@@ -65,7 +65,7 @@ LL | const NULL_PTR: NonNull<u8> = unsafe { mem::transmute(0usize) };
            }
 
 error[E0080]: constructing invalid value of type NonZero<u8>: at .0.0, encountered 0, but expected something greater or equal to 1
-  --> $DIR/raw-bytes.rs:62:1
+  --> $DIR/raw-bytes.rs:61:1
    |
 LL | const NULL_U8: NonZero<u8> = unsafe { mem::transmute(0u8) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
@@ -76,7 +76,7 @@ LL | const NULL_U8: NonZero<u8> = unsafe { mem::transmute(0u8) };
            }
 
 error[E0080]: constructing invalid value of type NonZero<usize>: at .0.0, encountered 0, but expected something greater or equal to 1
-  --> $DIR/raw-bytes.rs:64:1
+  --> $DIR/raw-bytes.rs:63:1
    |
 LL | const NULL_USIZE: NonZero<usize> = unsafe { mem::transmute(0usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
@@ -87,7 +87,7 @@ LL | const NULL_USIZE: NonZero<usize> = unsafe { mem::transmute(0usize) };
            }
 
 error[E0080]: constructing invalid value of type RestrictedRange1: at .0, encountered 42, but expected something in the range 10..=30
-  --> $DIR/raw-bytes.rs:68:1
+  --> $DIR/raw-bytes.rs:67:1
    |
 LL | const BAD_RANGE1: RestrictedRange1 = unsafe { RestrictedRange1(mem::transmute(42_u32)) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
@@ -98,7 +98,7 @@ LL | const BAD_RANGE1: RestrictedRange1 = unsafe { RestrictedRange1(mem::transmu
            }
 
 error[E0080]: constructing invalid value of type RestrictedRange2: at .0, encountered 20, but expected something less or equal to 10, or greater or equal to 30
-  --> $DIR/raw-bytes.rs:72:1
+  --> $DIR/raw-bytes.rs:71:1
    |
 LL | const BAD_RANGE2: RestrictedRange2 = unsafe { RestrictedRange2(mem::transmute(20_i32)) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
@@ -109,40 +109,40 @@ LL | const BAD_RANGE2: RestrictedRange2 = unsafe { RestrictedRange2(mem::transmu
            }
 
 error[E0080]: constructing invalid value of type NonNull<dyn Send>: at .pointer, encountered 0, but expected something greater or equal to 1
-  --> $DIR/raw-bytes.rs:75:1
+  --> $DIR/raw-bytes.rs:74:1
    |
 LL | const NULL_FAT_PTR: NonNull<dyn Send> = unsafe {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 4) {
-               00 00 00 00 ╾ALLOC_ID╼                         │ ....╾──╼
+               00 00 00 00 ╾ALLOC$ID╼                         │ ....╾──╼
            }
 
 error[E0080]: constructing invalid value of type &u16: encountered an unaligned reference (required 2 byte alignment but found 1)
-  --> $DIR/raw-bytes.rs:82:1
+  --> $DIR/raw-bytes.rs:81:1
    |
 LL | const UNALIGNED: &u16 = unsafe { mem::transmute(&[0u8; 4]) };
    | ^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 4, align: 4) {
-               ╾ALLOC_ID╼                                     │ ╾──╼
+               ╾ALLOC$ID╼                                     │ ╾──╼
            }
 
 error[E0080]: constructing invalid value of type Box<u16>: encountered an unaligned box (required 2 byte alignment but found 1)
-  --> $DIR/raw-bytes.rs:85:1
+  --> $DIR/raw-bytes.rs:84:1
    |
 LL | const UNALIGNED_BOX: Box<u16> = unsafe { mem::transmute(&[0u8; 4]) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 4, align: 4) {
-               ╾ALLOC_ID╼                                     │ ╾──╼
+               ╾ALLOC$ID╼                                     │ ╾──╼
            }
 
 error[E0080]: constructing invalid value of type &u16: encountered a null reference
-  --> $DIR/raw-bytes.rs:88:1
+  --> $DIR/raw-bytes.rs:87:1
    |
 LL | const NULL: &u16 = unsafe { mem::transmute(0usize) };
    | ^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
@@ -153,7 +153,7 @@ LL | const NULL: &u16 = unsafe { mem::transmute(0usize) };
            }
 
 error[E0080]: constructing invalid value of type Box<u16>: encountered a null box
-  --> $DIR/raw-bytes.rs:91:1
+  --> $DIR/raw-bytes.rs:90:1
    |
 LL | const NULL_BOX: Box<u16> = unsafe { mem::transmute(0usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
@@ -164,7 +164,7 @@ LL | const NULL_BOX: Box<u16> = unsafe { mem::transmute(0usize) };
            }
 
 error[E0080]: constructing invalid value of type &u8: encountered a dangling reference (0x539[noalloc] has no provenance)
-  --> $DIR/raw-bytes.rs:94:1
+  --> $DIR/raw-bytes.rs:93:1
    |
 LL | const USIZE_AS_REF: &'static u8 = unsafe { mem::transmute(1337usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
@@ -175,7 +175,7 @@ LL | const USIZE_AS_REF: &'static u8 = unsafe { mem::transmute(1337usize) };
            }
 
 error[E0080]: constructing invalid value of type Box<u8>: encountered a dangling box (0x539[noalloc] has no provenance)
-  --> $DIR/raw-bytes.rs:97:1
+  --> $DIR/raw-bytes.rs:96:1
    |
 LL | const USIZE_AS_BOX: Box<u8> = unsafe { mem::transmute(1337usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
@@ -186,7 +186,7 @@ LL | const USIZE_AS_BOX: Box<u8> = unsafe { mem::transmute(1337usize) };
            }
 
 error[E0080]: constructing invalid value of type fn(): encountered null pointer, but expected a function pointer
-  --> $DIR/raw-bytes.rs:100:1
+  --> $DIR/raw-bytes.rs:99:1
    |
 LL | const NULL_FN_PTR: fn() = unsafe { mem::transmute(0usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
@@ -197,7 +197,7 @@ LL | const NULL_FN_PTR: fn() = unsafe { mem::transmute(0usize) };
            }
 
 error[E0080]: constructing invalid value of type fn(): encountered 0xd[noalloc], but expected a function pointer
-  --> $DIR/raw-bytes.rs:102:1
+  --> $DIR/raw-bytes.rs:101:1
    |
 LL | const DANGLING_FN_PTR: fn() = unsafe { mem::transmute(13usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
@@ -207,19 +207,19 @@ LL | const DANGLING_FN_PTR: fn() = unsafe { mem::transmute(13usize) };
                0d 00 00 00                                     │ ....
            }
 
-error[E0080]: constructing invalid value of type fn(): encountered ALLOC3<imm>, but expected a function pointer
-  --> $DIR/raw-bytes.rs:104:1
+error[E0080]: constructing invalid value of type fn(): encountered ALLOC$ID<imm>, but expected a function pointer
+  --> $DIR/raw-bytes.rs:103:1
    |
 LL | const DATA_FN_PTR: fn() = unsafe { mem::transmute(&13) };
    | ^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 4, align: 4) {
-               ╾ALLOC_ID╼                                     │ ╾──╼
+               ╾ALLOC$ID╼                                     │ ╾──╼
            }
 
 error[E0080]: constructing invalid value of type &Bar: encountered a reference pointing to uninhabited type Bar
-  --> $DIR/raw-bytes.rs:110:1
+  --> $DIR/raw-bytes.rs:109:1
    |
 LL | const BAD_BAD_REF: &Bar = unsafe { mem::transmute(1usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
@@ -230,62 +230,62 @@ LL | const BAD_BAD_REF: &Bar = unsafe { mem::transmute(1usize) };
            }
 
 error[E0080]: constructing invalid value of type &str: encountered a dangling reference (going beyond the bounds of its allocation)
-  --> $DIR/raw-bytes.rs:134:1
+  --> $DIR/raw-bytes.rs:133:1
    |
 LL | const STR_TOO_LONG: &str = unsafe { mem::transmute((&42u8, 999usize)) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾ALLOC_ID╼ e7 03 00 00                         │ ╾──╼....
+               ╾ALLOC$ID╼ e7 03 00 00                         │ ╾──╼....
            }
 
 error[E0080]: constructing invalid value of type (&str,): at .0, encountered invalid reference metadata: slice is bigger than largest supported object
-  --> $DIR/raw-bytes.rs:136:1
+  --> $DIR/raw-bytes.rs:135:1
    |
 LL | const NESTED_STR_MUCH_TOO_LONG: (&str,) = (unsafe { mem::transmute((&42, usize::MAX)) },);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾ALLOC_ID╼ ff ff ff ff                         │ ╾──╼....
+               ╾ALLOC$ID╼ ff ff ff ff                         │ ╾──╼....
            }
 
 error[E0080]: constructing invalid value of type &MyStr: encountered invalid reference metadata: slice is bigger than largest supported object
-  --> $DIR/raw-bytes.rs:138:1
+  --> $DIR/raw-bytes.rs:137:1
    |
 LL | const MY_STR_MUCH_TOO_LONG: &MyStr = unsafe { mem::transmute((&42u8, usize::MAX)) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾ALLOC_ID╼ ff ff ff ff                         │ ╾──╼....
+               ╾ALLOC$ID╼ ff ff ff ff                         │ ╾──╼....
            }
 
 error[E0080]: constructing invalid value of type &str: at .<deref>, encountered uninitialized memory, but expected a string
-  --> $DIR/raw-bytes.rs:141:1
+  --> $DIR/raw-bytes.rs:140:1
    |
 LL | const STR_NO_INIT: &str = unsafe { mem::transmute::<&[_], _>(&[MaybeUninit::<u8> { uninit: () }]) };
    | ^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾ALLOC_ID╼ 01 00 00 00                         │ ╾──╼....
+               ╾ALLOC$ID╼ 01 00 00 00                         │ ╾──╼....
            }
 
 error[E0080]: constructing invalid value of type &MyStr: at .<deref>.0, encountered uninitialized memory, but expected a string
-  --> $DIR/raw-bytes.rs:143:1
+  --> $DIR/raw-bytes.rs:142:1
    |
 LL | const MYSTR_NO_INIT: &MyStr = unsafe { mem::transmute::<&[_], _>(&[MaybeUninit::<u8> { uninit: () }]) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾ALLOC_ID╼ 01 00 00 00                         │ ╾──╼....
+               ╾ALLOC$ID╼ 01 00 00 00                         │ ╾──╼....
            }
 
 error[E0080]: constructing invalid value of type &MyStr: at .<deref>.0, encountered a pointer, but expected a string
-  --> $DIR/raw-bytes.rs:145:1
+  --> $DIR/raw-bytes.rs:144:1
    |
 LL | const MYSTR_NO_INIT_ISSUE83182: &MyStr = unsafe { mem::transmute::<&[_], _>(&[&()]) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
@@ -294,172 +294,172 @@ LL | const MYSTR_NO_INIT_ISSUE83182: &MyStr = unsafe { mem::transmute::<&[_], _>
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾ALLOC_ID╼ 01 00 00 00                         │ ╾──╼....
+               ╾ALLOC$ID╼ 01 00 00 00                         │ ╾──╼....
            }
 
 error[E0080]: constructing invalid value of type &[u8]: encountered a dangling reference (going beyond the bounds of its allocation)
-  --> $DIR/raw-bytes.rs:149:1
+  --> $DIR/raw-bytes.rs:148:1
    |
 LL | const SLICE_TOO_LONG: &[u8] = unsafe { mem::transmute((&42u8, 999usize)) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾ALLOC_ID╼ e7 03 00 00                         │ ╾──╼....
+               ╾ALLOC$ID╼ e7 03 00 00                         │ ╾──╼....
            }
 
 error[E0080]: constructing invalid value of type &[u32]: encountered invalid reference metadata: slice is bigger than largest supported object
-  --> $DIR/raw-bytes.rs:151:1
+  --> $DIR/raw-bytes.rs:150:1
    |
 LL | const SLICE_TOO_LONG_OVERFLOW: &[u32] = unsafe { mem::transmute((&42u32, isize::MAX)) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾ALLOC_ID╼ ff ff ff 7f                         │ ╾──╼....
+               ╾ALLOC$ID╼ ff ff ff 7f                         │ ╾──╼....
            }
 
 error[E0080]: constructing invalid value of type Box<[u8]>: encountered a dangling box (going beyond the bounds of its allocation)
-  --> $DIR/raw-bytes.rs:154:1
+  --> $DIR/raw-bytes.rs:153:1
    |
 LL | const SLICE_TOO_LONG_BOX: Box<[u8]> = unsafe { mem::transmute((&42u8, 999usize)) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾ALLOC_ID╼ e7 03 00 00                         │ ╾──╼....
+               ╾ALLOC$ID╼ e7 03 00 00                         │ ╾──╼....
            }
 
 error[E0080]: constructing invalid value of type &[bool; 1]: at .<deref>[0], encountered 0x03, but expected a boolean
-  --> $DIR/raw-bytes.rs:157:1
+  --> $DIR/raw-bytes.rs:156:1
    |
 LL | const SLICE_CONTENT_INVALID: &[bool] = &[unsafe { mem::transmute(3u8) }];
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 4, align: 4) {
-               ╾ALLOC_ID╼                                     │ ╾──╼
+               ╾ALLOC$ID╼                                     │ ╾──╼
            }
 
 note: erroneous constant encountered
-  --> $DIR/raw-bytes.rs:157:40
+  --> $DIR/raw-bytes.rs:156:40
    |
 LL | const SLICE_CONTENT_INVALID: &[bool] = &[unsafe { mem::transmute(3u8) }];
    |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0080]: constructing invalid value of type &MySlice<[bool; 1]>: at .<deref>.0, encountered 0x03, but expected a boolean
-  --> $DIR/raw-bytes.rs:161:1
+  --> $DIR/raw-bytes.rs:160:1
    |
 LL | const MYSLICE_PREFIX_BAD: &MySliceBool = &MySlice(unsafe { mem::transmute(3u8) }, [false]);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 4, align: 4) {
-               ╾ALLOC_ID╼                                     │ ╾──╼
+               ╾ALLOC$ID╼                                     │ ╾──╼
            }
 
 note: erroneous constant encountered
-  --> $DIR/raw-bytes.rs:161:42
+  --> $DIR/raw-bytes.rs:160:42
    |
 LL | const MYSLICE_PREFIX_BAD: &MySliceBool = &MySlice(unsafe { mem::transmute(3u8) }, [false]);
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0080]: constructing invalid value of type &MySlice<[bool; 1]>: at .<deref>.1[0], encountered 0x03, but expected a boolean
-  --> $DIR/raw-bytes.rs:164:1
+  --> $DIR/raw-bytes.rs:163:1
    |
 LL | const MYSLICE_SUFFIX_BAD: &MySliceBool = &MySlice(true, [unsafe { mem::transmute(3u8) }]);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 4, align: 4) {
-               ╾ALLOC_ID╼                                     │ ╾──╼
+               ╾ALLOC$ID╼                                     │ ╾──╼
            }
 
 note: erroneous constant encountered
-  --> $DIR/raw-bytes.rs:164:42
+  --> $DIR/raw-bytes.rs:163:42
    |
 LL | const MYSLICE_SUFFIX_BAD: &MySliceBool = &MySlice(true, [unsafe { mem::transmute(3u8) }]);
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0080]: constructing invalid value of type W<&dyn Trait>: at .0, encountered ALLOC17<imm>, but expected a vtable pointer
-  --> $DIR/raw-bytes.rs:168:1
+error[E0080]: constructing invalid value of type W<&dyn Trait>: at .0, encountered ALLOC$ID<imm>, but expected a vtable pointer
+  --> $DIR/raw-bytes.rs:167:1
    |
 LL | const TRAIT_OBJ_SHORT_VTABLE_1: W<&dyn Trait> = unsafe { mem::transmute(W((&92u8, &3u8))) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾ALLOC_ID╼ ╾ALLOC_ID╼                         │ ╾──╼╾──╼
+               ╾ALLOC$ID╼ ╾ALLOC$ID╼                         │ ╾──╼╾──╼
            }
 
-error[E0080]: constructing invalid value of type W<&dyn Trait>: at .0, encountered ALLOC19<imm>, but expected a vtable pointer
-  --> $DIR/raw-bytes.rs:171:1
+error[E0080]: constructing invalid value of type W<&dyn Trait>: at .0, encountered ALLOC$ID<imm>, but expected a vtable pointer
+  --> $DIR/raw-bytes.rs:170:1
    |
 LL | const TRAIT_OBJ_SHORT_VTABLE_2: W<&dyn Trait> = unsafe { mem::transmute(W((&92u8, &3u64))) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾ALLOC_ID╼ ╾ALLOC_ID╼                         │ ╾──╼╾──╼
+               ╾ALLOC$ID╼ ╾ALLOC$ID╼                         │ ╾──╼╾──╼
            }
 
 error[E0080]: constructing invalid value of type W<&dyn Trait>: at .0, encountered 0x4[noalloc], but expected a vtable pointer
-  --> $DIR/raw-bytes.rs:174:1
+  --> $DIR/raw-bytes.rs:173:1
    |
 LL | const TRAIT_OBJ_INT_VTABLE: W<&dyn Trait> = unsafe { mem::transmute(W((&92u8, 4usize))) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾ALLOC_ID╼ 04 00 00 00                         │ ╾──╼....
+               ╾ALLOC$ID╼ 04 00 00 00                         │ ╾──╼....
            }
 
-error[E0080]: constructing invalid value of type W<&dyn Trait>: at .0, encountered ALLOC22<imm>, but expected a vtable pointer
-  --> $DIR/raw-bytes.rs:176:1
+error[E0080]: constructing invalid value of type W<&dyn Trait>: at .0, encountered ALLOC$ID<imm>, but expected a vtable pointer
+  --> $DIR/raw-bytes.rs:175:1
    |
 LL | const TRAIT_OBJ_BAD_DROP_FN_NOT_FN_PTR: W<&dyn Trait> = unsafe { mem::transmute(W((&92u8, &[&42u8; 8]))) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾ALLOC_ID╼ ╾ALLOC_ID╼                         │ ╾──╼╾──╼
+               ╾ALLOC$ID╼ ╾ALLOC$ID╼                         │ ╾──╼╾──╼
            }
 
 error[E0080]: constructing invalid value of type &dyn Trait: at .<deref>.<dyn-downcast(bool)>, encountered 0x03, but expected a boolean
-  --> $DIR/raw-bytes.rs:179:1
+  --> $DIR/raw-bytes.rs:178:1
    |
 LL | const TRAIT_OBJ_CONTENT_INVALID: &dyn Trait = unsafe { mem::transmute::<_, &bool>(&3u8) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾ALLOC_ID╼ ╾ALLOC_ID╼                         │ ╾──╼╾──╼
+               ╾ALLOC$ID╼ ╾ALLOC$ID╼                         │ ╾──╼╾──╼
            }
 
 error[E0080]: constructing invalid value of type *const dyn Trait: encountered null pointer, but expected a vtable pointer
-  --> $DIR/raw-bytes.rs:182:1
+  --> $DIR/raw-bytes.rs:181:1
    |
 LL | const RAW_TRAIT_OBJ_VTABLE_NULL: *const dyn Trait = unsafe { mem::transmute((&92u8, 0usize)) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾ALLOC_ID╼ 00 00 00 00                         │ ╾──╼....
+               ╾ALLOC$ID╼ 00 00 00 00                         │ ╾──╼....
            }
 
-error[E0080]: constructing invalid value of type *const dyn Trait: encountered ALLOC27<imm>, but expected a vtable pointer
-  --> $DIR/raw-bytes.rs:184:1
+error[E0080]: constructing invalid value of type *const dyn Trait: encountered ALLOC$ID<imm>, but expected a vtable pointer
+  --> $DIR/raw-bytes.rs:183:1
    |
 LL | const RAW_TRAIT_OBJ_VTABLE_INVALID: *const dyn Trait = unsafe { mem::transmute((&92u8, &3u64)) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾ALLOC_ID╼ ╾ALLOC_ID╼                         │ ╾──╼╾──╼
+               ╾ALLOC$ID╼ ╾ALLOC$ID╼                         │ ╾──╼╾──╼
            }
 
 error[E0080]: constructing invalid value of type &[!; 1]: encountered a reference pointing to uninhabited type [!; 1]
-  --> $DIR/raw-bytes.rs:188:1
+  --> $DIR/raw-bytes.rs:187:1
    |
 LL | const _: &[!; 1] = unsafe { &*(1_usize as *const [!; 1]) };
    | ^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
@@ -470,7 +470,7 @@ LL | const _: &[!; 1] = unsafe { &*(1_usize as *const [!; 1]) };
            }
 
 error[E0080]: constructing invalid value of type &[!]: at .<deref>[0], encountered a value of the never type `!`
-  --> $DIR/raw-bytes.rs:189:1
+  --> $DIR/raw-bytes.rs:188:1
    |
 LL | const _: &[!] = unsafe { &*(1_usize as *const [!; 1]) };
    | ^^^^^^^^^^^^^ it is undefined behavior to use this value
@@ -481,7 +481,7 @@ LL | const _: &[!] = unsafe { &*(1_usize as *const [!; 1]) };
            }
 
 error[E0080]: constructing invalid value of type &[!]: at .<deref>[0], encountered a value of the never type `!`
-  --> $DIR/raw-bytes.rs:190:1
+  --> $DIR/raw-bytes.rs:189:1
    |
 LL | const _: &[!] = unsafe { &*(1_usize as *const [!; 42]) };
    | ^^^^^^^^^^^^^ it is undefined behavior to use this value
@@ -492,18 +492,18 @@ LL | const _: &[!] = unsafe { &*(1_usize as *const [!; 42]) };
            }
 
 error[E0080]: constructing invalid value of type &[u8]: at .<deref>[0], encountered uninitialized memory, but expected an integer
-  --> $DIR/raw-bytes.rs:193:1
+  --> $DIR/raw-bytes.rs:192:1
    |
 LL | pub static S4: &[u8] = unsafe { from_raw_parts((&D1) as *const _ as _, 1) };
    | ^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾ALLOC_ID╼ 01 00 00 00                         │ ╾──╼....
+               ╾ALLOC$ID╼ 01 00 00 00                         │ ╾──╼....
            }
 
 error[E0080]: constructing invalid value of type &[u8]: at .<deref>[0], encountered a pointer, but expected an integer
-  --> $DIR/raw-bytes.rs:196:1
+  --> $DIR/raw-bytes.rs:195:1
    |
 LL | pub static S5: &[u8] = unsafe { from_raw_parts((&D3) as *const _ as _, mem::size_of::<&u32>()) };
    | ^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
@@ -512,44 +512,44 @@ LL | pub static S5: &[u8] = unsafe { from_raw_parts((&D3) as *const _ as _, mem:
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾ALLOC_ID╼ 04 00 00 00                         │ ╾──╼....
+               ╾ALLOC$ID╼ 04 00 00 00                         │ ╾──╼....
            }
 
 error[E0080]: constructing invalid value of type &[bool]: at .<deref>[0], encountered 0x11, but expected a boolean
-  --> $DIR/raw-bytes.rs:199:1
+  --> $DIR/raw-bytes.rs:198:1
    |
 LL | pub static S6: &[bool] = unsafe { from_raw_parts((&D0) as *const _ as _, 4) };
    | ^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾ALLOC_ID╼ 04 00 00 00                         │ ╾──╼....
+               ╾ALLOC$ID╼ 04 00 00 00                         │ ╾──╼....
            }
 
 error[E0080]: constructing invalid value of type &[u16]: at .<deref>[1], encountered uninitialized memory, but expected an integer
-  --> $DIR/raw-bytes.rs:203:1
+  --> $DIR/raw-bytes.rs:202:1
    |
 LL | pub static S7: &[u16] = unsafe {
    | ^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾ALLOC_ID+0x2╼ 04 00 00 00                         │ ╾──╼....
+               ╾ALLOC$ID╼ 04 00 00 00                         │ ╾──╼....
            }
 
 error[E0080]: constructing invalid value of type &[u8]: at .<deref>[0], encountered uninitialized memory, but expected an integer
-  --> $DIR/raw-bytes.rs:210:1
+  --> $DIR/raw-bytes.rs:209:1
    |
 LL | pub static R4: &[u8] = unsafe {
    | ^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾ALLOC_ID╼ 01 00 00 00                         │ ╾──╼....
+               ╾ALLOC$ID╼ 01 00 00 00                         │ ╾──╼....
            }
 
 error[E0080]: constructing invalid value of type &[u8]: at .<deref>[0], encountered a pointer, but expected an integer
-  --> $DIR/raw-bytes.rs:215:1
+  --> $DIR/raw-bytes.rs:214:1
    |
 LL | pub static R5: &[u8] = unsafe {
    | ^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
@@ -558,18 +558,18 @@ LL | pub static R5: &[u8] = unsafe {
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾ALLOC_ID╼ 04 00 00 00                         │ ╾──╼....
+               ╾ALLOC$ID╼ 04 00 00 00                         │ ╾──╼....
            }
 
 error[E0080]: constructing invalid value of type &[bool]: at .<deref>[0], encountered 0x11, but expected a boolean
-  --> $DIR/raw-bytes.rs:220:1
+  --> $DIR/raw-bytes.rs:219:1
    |
 LL | pub static R6: &[bool] = unsafe {
    | ^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾ALLOC_ID╼ 04 00 00 00                         │ ╾──╼....
+               ╾ALLOC$ID╼ 04 00 00 00                         │ ╾──╼....
            }
 
 error: aborting due to 50 previous errors

--- a/tests/ui/consts/const-eval/raw-bytes.64bit.stderr
+++ b/tests/ui/consts/const-eval/raw-bytes.64bit.stderr
@@ -1,5 +1,5 @@
 error[E0080]: constructing invalid value of type Enum: at .<enum-tag>, encountered 0x0000000000000001, but expected a valid enum tag
-  --> $DIR/raw-bytes.rs:24:1
+  --> $DIR/raw-bytes.rs:23:1
    |
 LL | const BAD_ENUM: Enum = unsafe { mem::transmute(1usize) };
    | ^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
@@ -10,7 +10,7 @@ LL | const BAD_ENUM: Enum = unsafe { mem::transmute(1usize) };
            }
 
 error[E0080]: constructing invalid value of type Enum2: at .<enum-tag>, encountered 0x0000000000000000, but expected a valid enum tag
-  --> $DIR/raw-bytes.rs:32:1
+  --> $DIR/raw-bytes.rs:31:1
    |
 LL | const BAD_ENUM2: Enum2 = unsafe { mem::transmute(0usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
@@ -21,7 +21,7 @@ LL | const BAD_ENUM2: Enum2 = unsafe { mem::transmute(0usize) };
            }
 
 error[E0080]: constructing invalid value of type UninhDiscriminant: at .<enum-tag>, encountered an uninhabited enum variant
-  --> $DIR/raw-bytes.rs:46:1
+  --> $DIR/raw-bytes.rs:45:1
    |
 LL | const BAD_UNINHABITED_VARIANT1: UninhDiscriminant = unsafe { mem::transmute(1u8) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
@@ -32,7 +32,7 @@ LL | const BAD_UNINHABITED_VARIANT1: UninhDiscriminant = unsafe { mem::transmute
            }
 
 error[E0080]: constructing invalid value of type UninhDiscriminant: at .<enum-tag>, encountered 0x03, but expected a valid enum tag
-  --> $DIR/raw-bytes.rs:48:1
+  --> $DIR/raw-bytes.rs:47:1
    |
 LL | const BAD_UNINHABITED_VARIANT2: UninhDiscriminant = unsafe { mem::transmute(3u8) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
@@ -43,7 +43,7 @@ LL | const BAD_UNINHABITED_VARIANT2: UninhDiscriminant = unsafe { mem::transmute
            }
 
 error[E0080]: constructing invalid value of type Option<(char, char)>: at .<enum-variant(Some)>.0.1, encountered 0xffffffff, but expected a valid unicode scalar value (in `0..=0x10FFFF` but not in `0xD800..=0xDFFF`)
-  --> $DIR/raw-bytes.rs:54:1
+  --> $DIR/raw-bytes.rs:53:1
    |
 LL | const BAD_OPTION_CHAR: Option<(char, char)> = Some(('x', unsafe { mem::transmute(!0u32) }));
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
@@ -54,7 +54,7 @@ LL | const BAD_OPTION_CHAR: Option<(char, char)> = Some(('x', unsafe { mem::tran
            }
 
 error[E0080]: constructing invalid value of type NonNull<u8>: at .pointer, encountered 0, but expected something greater or equal to 1
-  --> $DIR/raw-bytes.rs:59:1
+  --> $DIR/raw-bytes.rs:58:1
    |
 LL | const NULL_PTR: NonNull<u8> = unsafe { mem::transmute(0usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
@@ -65,7 +65,7 @@ LL | const NULL_PTR: NonNull<u8> = unsafe { mem::transmute(0usize) };
            }
 
 error[E0080]: constructing invalid value of type NonZero<u8>: at .0.0, encountered 0, but expected something greater or equal to 1
-  --> $DIR/raw-bytes.rs:62:1
+  --> $DIR/raw-bytes.rs:61:1
    |
 LL | const NULL_U8: NonZero<u8> = unsafe { mem::transmute(0u8) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
@@ -76,7 +76,7 @@ LL | const NULL_U8: NonZero<u8> = unsafe { mem::transmute(0u8) };
            }
 
 error[E0080]: constructing invalid value of type NonZero<usize>: at .0.0, encountered 0, but expected something greater or equal to 1
-  --> $DIR/raw-bytes.rs:64:1
+  --> $DIR/raw-bytes.rs:63:1
    |
 LL | const NULL_USIZE: NonZero<usize> = unsafe { mem::transmute(0usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
@@ -87,7 +87,7 @@ LL | const NULL_USIZE: NonZero<usize> = unsafe { mem::transmute(0usize) };
            }
 
 error[E0080]: constructing invalid value of type RestrictedRange1: at .0, encountered 42, but expected something in the range 10..=30
-  --> $DIR/raw-bytes.rs:68:1
+  --> $DIR/raw-bytes.rs:67:1
    |
 LL | const BAD_RANGE1: RestrictedRange1 = unsafe { RestrictedRange1(mem::transmute(42_u32)) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
@@ -98,7 +98,7 @@ LL | const BAD_RANGE1: RestrictedRange1 = unsafe { RestrictedRange1(mem::transmu
            }
 
 error[E0080]: constructing invalid value of type RestrictedRange2: at .0, encountered 20, but expected something less or equal to 10, or greater or equal to 30
-  --> $DIR/raw-bytes.rs:72:1
+  --> $DIR/raw-bytes.rs:71:1
    |
 LL | const BAD_RANGE2: RestrictedRange2 = unsafe { RestrictedRange2(mem::transmute(20_i32)) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
@@ -109,40 +109,40 @@ LL | const BAD_RANGE2: RestrictedRange2 = unsafe { RestrictedRange2(mem::transmu
            }
 
 error[E0080]: constructing invalid value of type NonNull<dyn Send>: at .pointer, encountered 0, but expected something greater or equal to 1
-  --> $DIR/raw-bytes.rs:75:1
+  --> $DIR/raw-bytes.rs:74:1
    |
 LL | const NULL_FAT_PTR: NonNull<dyn Send> = unsafe {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 16, align: 8) {
-               00 00 00 00 00 00 00 00 ╾ALLOC_ID╼ │ ........╾──────╼
+               00 00 00 00 00 00 00 00 ╾ALLOC$ID╼ │ ........╾──────╼
            }
 
 error[E0080]: constructing invalid value of type &u16: encountered an unaligned reference (required 2 byte alignment but found 1)
-  --> $DIR/raw-bytes.rs:82:1
+  --> $DIR/raw-bytes.rs:81:1
    |
 LL | const UNALIGNED: &u16 = unsafe { mem::transmute(&[0u8; 4]) };
    | ^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 8) {
-               ╾ALLOC_ID╼                         │ ╾──────╼
+               ╾ALLOC$ID╼                         │ ╾──────╼
            }
 
 error[E0080]: constructing invalid value of type Box<u16>: encountered an unaligned box (required 2 byte alignment but found 1)
-  --> $DIR/raw-bytes.rs:85:1
+  --> $DIR/raw-bytes.rs:84:1
    |
 LL | const UNALIGNED_BOX: Box<u16> = unsafe { mem::transmute(&[0u8; 4]) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 8) {
-               ╾ALLOC_ID╼                         │ ╾──────╼
+               ╾ALLOC$ID╼                         │ ╾──────╼
            }
 
 error[E0080]: constructing invalid value of type &u16: encountered a null reference
-  --> $DIR/raw-bytes.rs:88:1
+  --> $DIR/raw-bytes.rs:87:1
    |
 LL | const NULL: &u16 = unsafe { mem::transmute(0usize) };
    | ^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
@@ -153,7 +153,7 @@ LL | const NULL: &u16 = unsafe { mem::transmute(0usize) };
            }
 
 error[E0080]: constructing invalid value of type Box<u16>: encountered a null box
-  --> $DIR/raw-bytes.rs:91:1
+  --> $DIR/raw-bytes.rs:90:1
    |
 LL | const NULL_BOX: Box<u16> = unsafe { mem::transmute(0usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
@@ -164,7 +164,7 @@ LL | const NULL_BOX: Box<u16> = unsafe { mem::transmute(0usize) };
            }
 
 error[E0080]: constructing invalid value of type &u8: encountered a dangling reference (0x539[noalloc] has no provenance)
-  --> $DIR/raw-bytes.rs:94:1
+  --> $DIR/raw-bytes.rs:93:1
    |
 LL | const USIZE_AS_REF: &'static u8 = unsafe { mem::transmute(1337usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
@@ -175,7 +175,7 @@ LL | const USIZE_AS_REF: &'static u8 = unsafe { mem::transmute(1337usize) };
            }
 
 error[E0080]: constructing invalid value of type Box<u8>: encountered a dangling box (0x539[noalloc] has no provenance)
-  --> $DIR/raw-bytes.rs:97:1
+  --> $DIR/raw-bytes.rs:96:1
    |
 LL | const USIZE_AS_BOX: Box<u8> = unsafe { mem::transmute(1337usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
@@ -186,7 +186,7 @@ LL | const USIZE_AS_BOX: Box<u8> = unsafe { mem::transmute(1337usize) };
            }
 
 error[E0080]: constructing invalid value of type fn(): encountered null pointer, but expected a function pointer
-  --> $DIR/raw-bytes.rs:100:1
+  --> $DIR/raw-bytes.rs:99:1
    |
 LL | const NULL_FN_PTR: fn() = unsafe { mem::transmute(0usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
@@ -197,7 +197,7 @@ LL | const NULL_FN_PTR: fn() = unsafe { mem::transmute(0usize) };
            }
 
 error[E0080]: constructing invalid value of type fn(): encountered 0xd[noalloc], but expected a function pointer
-  --> $DIR/raw-bytes.rs:102:1
+  --> $DIR/raw-bytes.rs:101:1
    |
 LL | const DANGLING_FN_PTR: fn() = unsafe { mem::transmute(13usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
@@ -207,19 +207,19 @@ LL | const DANGLING_FN_PTR: fn() = unsafe { mem::transmute(13usize) };
                0d 00 00 00 00 00 00 00                         │ ........
            }
 
-error[E0080]: constructing invalid value of type fn(): encountered ALLOC3<imm>, but expected a function pointer
-  --> $DIR/raw-bytes.rs:104:1
+error[E0080]: constructing invalid value of type fn(): encountered ALLOC$ID<imm>, but expected a function pointer
+  --> $DIR/raw-bytes.rs:103:1
    |
 LL | const DATA_FN_PTR: fn() = unsafe { mem::transmute(&13) };
    | ^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 8) {
-               ╾ALLOC_ID╼                         │ ╾──────╼
+               ╾ALLOC$ID╼                         │ ╾──────╼
            }
 
 error[E0080]: constructing invalid value of type &Bar: encountered a reference pointing to uninhabited type Bar
-  --> $DIR/raw-bytes.rs:110:1
+  --> $DIR/raw-bytes.rs:109:1
    |
 LL | const BAD_BAD_REF: &Bar = unsafe { mem::transmute(1usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
@@ -230,62 +230,62 @@ LL | const BAD_BAD_REF: &Bar = unsafe { mem::transmute(1usize) };
            }
 
 error[E0080]: constructing invalid value of type &str: encountered a dangling reference (going beyond the bounds of its allocation)
-  --> $DIR/raw-bytes.rs:134:1
+  --> $DIR/raw-bytes.rs:133:1
    |
 LL | const STR_TOO_LONG: &str = unsafe { mem::transmute((&42u8, 999usize)) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾ALLOC_ID╼ e7 03 00 00 00 00 00 00 │ ╾──────╼........
+               ╾ALLOC$ID╼ e7 03 00 00 00 00 00 00 │ ╾──────╼........
            }
 
 error[E0080]: constructing invalid value of type (&str,): at .0, encountered invalid reference metadata: slice is bigger than largest supported object
-  --> $DIR/raw-bytes.rs:136:1
+  --> $DIR/raw-bytes.rs:135:1
    |
 LL | const NESTED_STR_MUCH_TOO_LONG: (&str,) = (unsafe { mem::transmute((&42, usize::MAX)) },);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾ALLOC_ID╼ ff ff ff ff ff ff ff ff │ ╾──────╼........
+               ╾ALLOC$ID╼ ff ff ff ff ff ff ff ff │ ╾──────╼........
            }
 
 error[E0080]: constructing invalid value of type &MyStr: encountered invalid reference metadata: slice is bigger than largest supported object
-  --> $DIR/raw-bytes.rs:138:1
+  --> $DIR/raw-bytes.rs:137:1
    |
 LL | const MY_STR_MUCH_TOO_LONG: &MyStr = unsafe { mem::transmute((&42u8, usize::MAX)) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾ALLOC_ID╼ ff ff ff ff ff ff ff ff │ ╾──────╼........
+               ╾ALLOC$ID╼ ff ff ff ff ff ff ff ff │ ╾──────╼........
            }
 
 error[E0080]: constructing invalid value of type &str: at .<deref>, encountered uninitialized memory, but expected a string
-  --> $DIR/raw-bytes.rs:141:1
+  --> $DIR/raw-bytes.rs:140:1
    |
 LL | const STR_NO_INIT: &str = unsafe { mem::transmute::<&[_], _>(&[MaybeUninit::<u8> { uninit: () }]) };
    | ^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾ALLOC_ID╼ 01 00 00 00 00 00 00 00 │ ╾──────╼........
+               ╾ALLOC$ID╼ 01 00 00 00 00 00 00 00 │ ╾──────╼........
            }
 
 error[E0080]: constructing invalid value of type &MyStr: at .<deref>.0, encountered uninitialized memory, but expected a string
-  --> $DIR/raw-bytes.rs:143:1
+  --> $DIR/raw-bytes.rs:142:1
    |
 LL | const MYSTR_NO_INIT: &MyStr = unsafe { mem::transmute::<&[_], _>(&[MaybeUninit::<u8> { uninit: () }]) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾ALLOC_ID╼ 01 00 00 00 00 00 00 00 │ ╾──────╼........
+               ╾ALLOC$ID╼ 01 00 00 00 00 00 00 00 │ ╾──────╼........
            }
 
 error[E0080]: constructing invalid value of type &MyStr: at .<deref>.0, encountered a pointer, but expected a string
-  --> $DIR/raw-bytes.rs:145:1
+  --> $DIR/raw-bytes.rs:144:1
    |
 LL | const MYSTR_NO_INIT_ISSUE83182: &MyStr = unsafe { mem::transmute::<&[_], _>(&[&()]) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
@@ -294,172 +294,172 @@ LL | const MYSTR_NO_INIT_ISSUE83182: &MyStr = unsafe { mem::transmute::<&[_], _>
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾ALLOC_ID╼ 01 00 00 00 00 00 00 00 │ ╾──────╼........
+               ╾ALLOC$ID╼ 01 00 00 00 00 00 00 00 │ ╾──────╼........
            }
 
 error[E0080]: constructing invalid value of type &[u8]: encountered a dangling reference (going beyond the bounds of its allocation)
-  --> $DIR/raw-bytes.rs:149:1
+  --> $DIR/raw-bytes.rs:148:1
    |
 LL | const SLICE_TOO_LONG: &[u8] = unsafe { mem::transmute((&42u8, 999usize)) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾ALLOC_ID╼ e7 03 00 00 00 00 00 00 │ ╾──────╼........
+               ╾ALLOC$ID╼ e7 03 00 00 00 00 00 00 │ ╾──────╼........
            }
 
 error[E0080]: constructing invalid value of type &[u32]: encountered invalid reference metadata: slice is bigger than largest supported object
-  --> $DIR/raw-bytes.rs:151:1
+  --> $DIR/raw-bytes.rs:150:1
    |
 LL | const SLICE_TOO_LONG_OVERFLOW: &[u32] = unsafe { mem::transmute((&42u32, isize::MAX)) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾ALLOC_ID╼ ff ff ff ff ff ff ff 7f │ ╾──────╼........
+               ╾ALLOC$ID╼ ff ff ff ff ff ff ff 7f │ ╾──────╼........
            }
 
 error[E0080]: constructing invalid value of type Box<[u8]>: encountered a dangling box (going beyond the bounds of its allocation)
-  --> $DIR/raw-bytes.rs:154:1
+  --> $DIR/raw-bytes.rs:153:1
    |
 LL | const SLICE_TOO_LONG_BOX: Box<[u8]> = unsafe { mem::transmute((&42u8, 999usize)) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾ALLOC_ID╼ e7 03 00 00 00 00 00 00 │ ╾──────╼........
+               ╾ALLOC$ID╼ e7 03 00 00 00 00 00 00 │ ╾──────╼........
            }
 
 error[E0080]: constructing invalid value of type &[bool; 1]: at .<deref>[0], encountered 0x03, but expected a boolean
-  --> $DIR/raw-bytes.rs:157:1
+  --> $DIR/raw-bytes.rs:156:1
    |
 LL | const SLICE_CONTENT_INVALID: &[bool] = &[unsafe { mem::transmute(3u8) }];
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 8) {
-               ╾ALLOC_ID╼                         │ ╾──────╼
+               ╾ALLOC$ID╼                         │ ╾──────╼
            }
 
 note: erroneous constant encountered
-  --> $DIR/raw-bytes.rs:157:40
+  --> $DIR/raw-bytes.rs:156:40
    |
 LL | const SLICE_CONTENT_INVALID: &[bool] = &[unsafe { mem::transmute(3u8) }];
    |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0080]: constructing invalid value of type &MySlice<[bool; 1]>: at .<deref>.0, encountered 0x03, but expected a boolean
-  --> $DIR/raw-bytes.rs:161:1
+  --> $DIR/raw-bytes.rs:160:1
    |
 LL | const MYSLICE_PREFIX_BAD: &MySliceBool = &MySlice(unsafe { mem::transmute(3u8) }, [false]);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 8) {
-               ╾ALLOC_ID╼                         │ ╾──────╼
+               ╾ALLOC$ID╼                         │ ╾──────╼
            }
 
 note: erroneous constant encountered
-  --> $DIR/raw-bytes.rs:161:42
+  --> $DIR/raw-bytes.rs:160:42
    |
 LL | const MYSLICE_PREFIX_BAD: &MySliceBool = &MySlice(unsafe { mem::transmute(3u8) }, [false]);
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0080]: constructing invalid value of type &MySlice<[bool; 1]>: at .<deref>.1[0], encountered 0x03, but expected a boolean
-  --> $DIR/raw-bytes.rs:164:1
+  --> $DIR/raw-bytes.rs:163:1
    |
 LL | const MYSLICE_SUFFIX_BAD: &MySliceBool = &MySlice(true, [unsafe { mem::transmute(3u8) }]);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 8) {
-               ╾ALLOC_ID╼                         │ ╾──────╼
+               ╾ALLOC$ID╼                         │ ╾──────╼
            }
 
 note: erroneous constant encountered
-  --> $DIR/raw-bytes.rs:164:42
+  --> $DIR/raw-bytes.rs:163:42
    |
 LL | const MYSLICE_SUFFIX_BAD: &MySliceBool = &MySlice(true, [unsafe { mem::transmute(3u8) }]);
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0080]: constructing invalid value of type W<&dyn Trait>: at .0, encountered ALLOC17<imm>, but expected a vtable pointer
-  --> $DIR/raw-bytes.rs:168:1
+error[E0080]: constructing invalid value of type W<&dyn Trait>: at .0, encountered ALLOC$ID<imm>, but expected a vtable pointer
+  --> $DIR/raw-bytes.rs:167:1
    |
 LL | const TRAIT_OBJ_SHORT_VTABLE_1: W<&dyn Trait> = unsafe { mem::transmute(W((&92u8, &3u8))) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾ALLOC_ID╼ ╾ALLOC_ID╼ │ ╾──────╼╾──────╼
+               ╾ALLOC$ID╼ ╾ALLOC$ID╼ │ ╾──────╼╾──────╼
            }
 
-error[E0080]: constructing invalid value of type W<&dyn Trait>: at .0, encountered ALLOC19<imm>, but expected a vtable pointer
-  --> $DIR/raw-bytes.rs:171:1
+error[E0080]: constructing invalid value of type W<&dyn Trait>: at .0, encountered ALLOC$ID<imm>, but expected a vtable pointer
+  --> $DIR/raw-bytes.rs:170:1
    |
 LL | const TRAIT_OBJ_SHORT_VTABLE_2: W<&dyn Trait> = unsafe { mem::transmute(W((&92u8, &3u64))) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾ALLOC_ID╼ ╾ALLOC_ID╼ │ ╾──────╼╾──────╼
+               ╾ALLOC$ID╼ ╾ALLOC$ID╼ │ ╾──────╼╾──────╼
            }
 
 error[E0080]: constructing invalid value of type W<&dyn Trait>: at .0, encountered 0x4[noalloc], but expected a vtable pointer
-  --> $DIR/raw-bytes.rs:174:1
+  --> $DIR/raw-bytes.rs:173:1
    |
 LL | const TRAIT_OBJ_INT_VTABLE: W<&dyn Trait> = unsafe { mem::transmute(W((&92u8, 4usize))) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾ALLOC_ID╼ 04 00 00 00 00 00 00 00 │ ╾──────╼........
+               ╾ALLOC$ID╼ 04 00 00 00 00 00 00 00 │ ╾──────╼........
            }
 
-error[E0080]: constructing invalid value of type W<&dyn Trait>: at .0, encountered ALLOC22<imm>, but expected a vtable pointer
-  --> $DIR/raw-bytes.rs:176:1
+error[E0080]: constructing invalid value of type W<&dyn Trait>: at .0, encountered ALLOC$ID<imm>, but expected a vtable pointer
+  --> $DIR/raw-bytes.rs:175:1
    |
 LL | const TRAIT_OBJ_BAD_DROP_FN_NOT_FN_PTR: W<&dyn Trait> = unsafe { mem::transmute(W((&92u8, &[&42u8; 8]))) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾ALLOC_ID╼ ╾ALLOC_ID╼ │ ╾──────╼╾──────╼
+               ╾ALLOC$ID╼ ╾ALLOC$ID╼ │ ╾──────╼╾──────╼
            }
 
 error[E0080]: constructing invalid value of type &dyn Trait: at .<deref>.<dyn-downcast(bool)>, encountered 0x03, but expected a boolean
-  --> $DIR/raw-bytes.rs:179:1
+  --> $DIR/raw-bytes.rs:178:1
    |
 LL | const TRAIT_OBJ_CONTENT_INVALID: &dyn Trait = unsafe { mem::transmute::<_, &bool>(&3u8) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾ALLOC_ID╼ ╾ALLOC_ID╼ │ ╾──────╼╾──────╼
+               ╾ALLOC$ID╼ ╾ALLOC$ID╼ │ ╾──────╼╾──────╼
            }
 
 error[E0080]: constructing invalid value of type *const dyn Trait: encountered null pointer, but expected a vtable pointer
-  --> $DIR/raw-bytes.rs:182:1
+  --> $DIR/raw-bytes.rs:181:1
    |
 LL | const RAW_TRAIT_OBJ_VTABLE_NULL: *const dyn Trait = unsafe { mem::transmute((&92u8, 0usize)) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾ALLOC_ID╼ 00 00 00 00 00 00 00 00 │ ╾──────╼........
+               ╾ALLOC$ID╼ 00 00 00 00 00 00 00 00 │ ╾──────╼........
            }
 
-error[E0080]: constructing invalid value of type *const dyn Trait: encountered ALLOC27<imm>, but expected a vtable pointer
-  --> $DIR/raw-bytes.rs:184:1
+error[E0080]: constructing invalid value of type *const dyn Trait: encountered ALLOC$ID<imm>, but expected a vtable pointer
+  --> $DIR/raw-bytes.rs:183:1
    |
 LL | const RAW_TRAIT_OBJ_VTABLE_INVALID: *const dyn Trait = unsafe { mem::transmute((&92u8, &3u64)) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾ALLOC_ID╼ ╾ALLOC_ID╼ │ ╾──────╼╾──────╼
+               ╾ALLOC$ID╼ ╾ALLOC$ID╼ │ ╾──────╼╾──────╼
            }
 
 error[E0080]: constructing invalid value of type &[!; 1]: encountered a reference pointing to uninhabited type [!; 1]
-  --> $DIR/raw-bytes.rs:188:1
+  --> $DIR/raw-bytes.rs:187:1
    |
 LL | const _: &[!; 1] = unsafe { &*(1_usize as *const [!; 1]) };
    | ^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
@@ -470,7 +470,7 @@ LL | const _: &[!; 1] = unsafe { &*(1_usize as *const [!; 1]) };
            }
 
 error[E0080]: constructing invalid value of type &[!]: at .<deref>[0], encountered a value of the never type `!`
-  --> $DIR/raw-bytes.rs:189:1
+  --> $DIR/raw-bytes.rs:188:1
    |
 LL | const _: &[!] = unsafe { &*(1_usize as *const [!; 1]) };
    | ^^^^^^^^^^^^^ it is undefined behavior to use this value
@@ -481,7 +481,7 @@ LL | const _: &[!] = unsafe { &*(1_usize as *const [!; 1]) };
            }
 
 error[E0080]: constructing invalid value of type &[!]: at .<deref>[0], encountered a value of the never type `!`
-  --> $DIR/raw-bytes.rs:190:1
+  --> $DIR/raw-bytes.rs:189:1
    |
 LL | const _: &[!] = unsafe { &*(1_usize as *const [!; 42]) };
    | ^^^^^^^^^^^^^ it is undefined behavior to use this value
@@ -492,18 +492,18 @@ LL | const _: &[!] = unsafe { &*(1_usize as *const [!; 42]) };
            }
 
 error[E0080]: constructing invalid value of type &[u8]: at .<deref>[0], encountered uninitialized memory, but expected an integer
-  --> $DIR/raw-bytes.rs:193:1
+  --> $DIR/raw-bytes.rs:192:1
    |
 LL | pub static S4: &[u8] = unsafe { from_raw_parts((&D1) as *const _ as _, 1) };
    | ^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾ALLOC_ID╼ 01 00 00 00 00 00 00 00 │ ╾──────╼........
+               ╾ALLOC$ID╼ 01 00 00 00 00 00 00 00 │ ╾──────╼........
            }
 
 error[E0080]: constructing invalid value of type &[u8]: at .<deref>[0], encountered a pointer, but expected an integer
-  --> $DIR/raw-bytes.rs:196:1
+  --> $DIR/raw-bytes.rs:195:1
    |
 LL | pub static S5: &[u8] = unsafe { from_raw_parts((&D3) as *const _ as _, mem::size_of::<&u32>()) };
    | ^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
@@ -512,44 +512,44 @@ LL | pub static S5: &[u8] = unsafe { from_raw_parts((&D3) as *const _ as _, mem:
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾ALLOC_ID╼ 08 00 00 00 00 00 00 00 │ ╾──────╼........
+               ╾ALLOC$ID╼ 08 00 00 00 00 00 00 00 │ ╾──────╼........
            }
 
 error[E0080]: constructing invalid value of type &[bool]: at .<deref>[0], encountered 0x11, but expected a boolean
-  --> $DIR/raw-bytes.rs:199:1
+  --> $DIR/raw-bytes.rs:198:1
    |
 LL | pub static S6: &[bool] = unsafe { from_raw_parts((&D0) as *const _ as _, 4) };
    | ^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾ALLOC_ID╼ 04 00 00 00 00 00 00 00 │ ╾──────╼........
+               ╾ALLOC$ID╼ 04 00 00 00 00 00 00 00 │ ╾──────╼........
            }
 
 error[E0080]: constructing invalid value of type &[u16]: at .<deref>[1], encountered uninitialized memory, but expected an integer
-  --> $DIR/raw-bytes.rs:203:1
+  --> $DIR/raw-bytes.rs:202:1
    |
 LL | pub static S7: &[u16] = unsafe {
    | ^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾ALLOC_ID+0x2╼ 04 00 00 00 00 00 00 00 │ ╾──────╼........
+               ╾ALLOC$ID╼ 04 00 00 00 00 00 00 00 │ ╾──────╼........
            }
 
 error[E0080]: constructing invalid value of type &[u8]: at .<deref>[0], encountered uninitialized memory, but expected an integer
-  --> $DIR/raw-bytes.rs:210:1
+  --> $DIR/raw-bytes.rs:209:1
    |
 LL | pub static R4: &[u8] = unsafe {
    | ^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾ALLOC_ID╼ 01 00 00 00 00 00 00 00 │ ╾──────╼........
+               ╾ALLOC$ID╼ 01 00 00 00 00 00 00 00 │ ╾──────╼........
            }
 
 error[E0080]: constructing invalid value of type &[u8]: at .<deref>[0], encountered a pointer, but expected an integer
-  --> $DIR/raw-bytes.rs:215:1
+  --> $DIR/raw-bytes.rs:214:1
    |
 LL | pub static R5: &[u8] = unsafe {
    | ^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
@@ -558,18 +558,18 @@ LL | pub static R5: &[u8] = unsafe {
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾ALLOC_ID╼ 08 00 00 00 00 00 00 00 │ ╾──────╼........
+               ╾ALLOC$ID╼ 08 00 00 00 00 00 00 00 │ ╾──────╼........
            }
 
 error[E0080]: constructing invalid value of type &[bool]: at .<deref>[0], encountered 0x11, but expected a boolean
-  --> $DIR/raw-bytes.rs:220:1
+  --> $DIR/raw-bytes.rs:219:1
    |
 LL | pub static R6: &[bool] = unsafe {
    | ^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾ALLOC_ID╼ 04 00 00 00 00 00 00 00 │ ╾──────╼........
+               ╾ALLOC$ID╼ 04 00 00 00 00 00 00 00 │ ╾──────╼........
            }
 
 error: aborting due to 50 previous errors

--- a/tests/ui/consts/const-eval/raw-bytes.rs
+++ b/tests/ui/consts/const-eval/raw-bytes.rs
@@ -1,7 +1,6 @@
 //@ stderr-per-bitwidth
 //@ ignore-endian-big
 // ignore-tidy-linelength
-//@ normalize-stderr: "╾─*ALLOC[0-9]+(\+[a-z0-9]+)?(<imm>)?─*╼" -> "╾ALLOC_ID$1╼"
 //@ dont-require-annotations: NOTE
 //@ ignore-parallel-frontend different alloc ids
 #![allow(invalid_value, unnecessary_transmutes)]

--- a/tests/ui/consts/const-eval/raw-bytes.rs
+++ b/tests/ui/consts/const-eval/raw-bytes.rs
@@ -2,7 +2,7 @@
 //@ ignore-endian-big
 // ignore-tidy-linelength
 //@ dont-require-annotations: NOTE
-//@ ignore-parallel-frontend different alloc ids
+
 #![allow(invalid_value, unnecessary_transmutes)]
 #![feature(never_type, rustc_attrs, ptr_metadata, slice_from_ptr_range, const_slice_from_ptr_range)]
 #![feature(pattern_types, pattern_type_macro)]

--- a/tests/ui/consts/const-eval/raw-pointer-ub.rs
+++ b/tests/ui/consts/const-eval/raw-pointer-ub.rs
@@ -4,7 +4,7 @@ const MISALIGNED_LOAD: () = unsafe {
     let _val = *ptr; //~NOTE: failed here
     //~^ERROR: based on pointer with alignment 1, but alignment 4 is required
 };
-//@ ignore-parallel-frontend different alloc ids
+
 const MISALIGNED_STORE: () = unsafe {
     let mut mem = [0u32; 8];
     let ptr = mem.as_mut_ptr().byte_add(1);

--- a/tests/ui/consts/const-eval/raw-pointer-ub.stderr
+++ b/tests/ui/consts/const-eval/raw-pointer-ub.stderr
@@ -25,7 +25,7 @@ error[E0080]: accessing memory based on pointer with alignment 4, but alignment 
 LL |     let _val = (*ptr).0;
    |                ^^^^^^^^ evaluation of `MISALIGNED_FIELD` failed here
 
-error[E0080]: memory access failed: attempting to access 8 bytes, but got ALLOC0 which is only 4 bytes from the end of the allocation
+error[E0080]: memory access failed: attempting to access 8 bytes, but got ALLOC$ID which is only 4 bytes from the end of the allocation
   --> $DIR/raw-pointer-ub.rs:40:16
    |
 LL |     let _val = *ptr;

--- a/tests/ui/consts/const-eval/read_partial_ptr.rs
+++ b/tests/ui/consts/const-eval/read_partial_ptr.rs
@@ -1,5 +1,5 @@
 //! Ensure we error when trying to load from a pointer whose provenance has been messed with.
-//@ ignore-parallel-frontend different alloc ids
+
 const PARTIAL_OVERWRITE: () = {
     let mut p = &42;
     // Overwrite one byte with a no-provenance value.

--- a/tests/ui/consts/const-eval/read_partial_ptr.stderr
+++ b/tests/ui/consts/const-eval/read_partial_ptr.stderr
@@ -1,4 +1,4 @@
-error[E0080]: unable to read parts of a pointer from memory at ALLOC0
+error[E0080]: unable to read parts of a pointer from memory at ALLOC$ID
   --> $DIR/read_partial_ptr.rs:10:13
    |
 LL |     let x = *p;
@@ -7,7 +7,7 @@ LL |     let x = *p;
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
-error[E0080]: unable to read parts of a pointer from memory at ALLOC1
+error[E0080]: unable to read parts of a pointer from memory at ALLOC$ID
   --> $DIR/read_partial_ptr.rs:23:13
    |
 LL |     let x = *p;
@@ -16,7 +16,7 @@ LL |     let x = *p;
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
-error[E0080]: unable to read parts of a pointer from memory at ALLOC2
+error[E0080]: unable to read parts of a pointer from memory at ALLOC$ID
   --> $DIR/read_partial_ptr.rs:34:13
    |
 LL |     let x = *p;
@@ -25,7 +25,7 @@ LL |     let x = *p;
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
-error[E0080]: unable to read parts of a pointer from memory at ALLOC3
+error[E0080]: unable to read parts of a pointer from memory at ALLOC$ID
   --> $DIR/read_partial_ptr.rs:46:13
    |
 LL |     let x = *p;

--- a/tests/ui/consts/const-eval/ub-enum-overwrite.rs
+++ b/tests/ui/consts/const-eval/ub-enum-overwrite.rs
@@ -2,7 +2,7 @@ enum E {
     A(u8),
     B,
 }
-//@ ignore-parallel-frontend different alloc ids
+
 const _: u8 = {
     let mut e = E::A(1);
     let p = if let E::A(x) = &mut e { x as *mut u8 } else { unreachable!() };

--- a/tests/ui/consts/const-eval/ub-enum-overwrite.stderr
+++ b/tests/ui/consts/const-eval/ub-enum-overwrite.stderr
@@ -1,4 +1,4 @@
-error[E0080]: reading memory at ALLOC0[0x1..0x2], but memory is uninitialized at [0x1..0x2], and this operation requires initialized memory
+error[E0080]: reading memory at ALLOC$ID[0x1..0x2], but memory is uninitialized at [0x1..0x2], and this operation requires initialized memory
   --> $DIR/ub-enum-overwrite.rs:11:14
    |
 LL |     unsafe { *p }

--- a/tests/ui/consts/const-eval/ub-enum.rs
+++ b/tests/ui/consts/const-eval/ub-enum.rs
@@ -4,7 +4,7 @@
 //@ normalize-stderr: "0x0+" -> "0x0"
 //@ normalize-stderr: "0x[0-9](\.\.|\])" -> "0x%$1"
 //@ dont-require-annotations: NOTE
-//@ ignore-parallel-frontend different alloc ids
+
 #![feature(never_type)]
 #![allow(invalid_value, unnecessary_transmutes)]
 

--- a/tests/ui/consts/const-eval/ub-enum.stderr
+++ b/tests/ui/consts/const-eval/ub-enum.stderr
@@ -56,7 +56,7 @@ LL | const BAD_ENUM2_WRAPPED: Wrap<Enum2> = unsafe { mem::transmute(&0) };
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
-error[E0080]: reading memory at ALLOC0[0x%..0x%], but memory is uninitialized at [0x%..0x%], and this operation requires initialized memory
+error[E0080]: reading memory at ALLOC$ID[0x%..0x%], but memory is uninitialized at [0x%..0x%], and this operation requires initialized memory
   --> $DIR/ub-enum.rs:62:41
    |
 LL | const BAD_ENUM2_UNDEF: Enum2 = unsafe { MaybeUninit { uninit: () }.init };

--- a/tests/ui/consts/const-eval/ub-incorrect-vtable.32bit.stderr
+++ b/tests/ui/consts/const-eval/ub-incorrect-vtable.32bit.stderr
@@ -1,4 +1,4 @@
-error[E0080]: constructing invalid value of type &dyn Trait: encountered ALLOC1<imm>, but expected a vtable pointer
+error[E0080]: constructing invalid value of type &dyn Trait: encountered ALLOC$ID<imm>, but expected a vtable pointer
   --> $DIR/ub-incorrect-vtable.rs:18:1
    |
 LL | const INVALID_VTABLE_ALIGNMENT: &dyn Trait =
@@ -6,10 +6,10 @@ LL | const INVALID_VTABLE_ALIGNMENT: &dyn Trait =
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾ALLOC0<imm>╼ ╾ALLOC1<imm>╼                         │ ╾──╼╾──╼
+               ╾ALLOC$ID╼ ╾ALLOC$ID╼                         │ ╾──╼╾──╼
            }
 
-error[E0080]: constructing invalid value of type &dyn Trait: encountered ALLOC3<imm>, but expected a vtable pointer
+error[E0080]: constructing invalid value of type &dyn Trait: encountered ALLOC$ID<imm>, but expected a vtable pointer
   --> $DIR/ub-incorrect-vtable.rs:22:1
    |
 LL | const INVALID_VTABLE_SIZE: &dyn Trait =
@@ -17,10 +17,10 @@ LL | const INVALID_VTABLE_SIZE: &dyn Trait =
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾ALLOC2<imm>╼ ╾ALLOC3<imm>╼                         │ ╾──╼╾──╼
+               ╾ALLOC$ID╼ ╾ALLOC$ID╼                         │ ╾──╼╾──╼
            }
 
-error[E0080]: constructing invalid value of type W<&dyn Trait>: at .0, encountered ALLOC5<imm>, but expected a vtable pointer
+error[E0080]: constructing invalid value of type W<&dyn Trait>: at .0, encountered ALLOC$ID<imm>, but expected a vtable pointer
   --> $DIR/ub-incorrect-vtable.rs:31:1
    |
 LL | const INVALID_VTABLE_ALIGNMENT_UB: W<&dyn Trait> =
@@ -28,10 +28,10 @@ LL | const INVALID_VTABLE_ALIGNMENT_UB: W<&dyn Trait> =
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾ALLOC4<imm>╼ ╾ALLOC5<imm>╼                         │ ╾──╼╾──╼
+               ╾ALLOC$ID╼ ╾ALLOC$ID╼                         │ ╾──╼╾──╼
            }
 
-error[E0080]: constructing invalid value of type W<&dyn Trait>: at .0, encountered ALLOC7<imm>, but expected a vtable pointer
+error[E0080]: constructing invalid value of type W<&dyn Trait>: at .0, encountered ALLOC$ID<imm>, but expected a vtable pointer
   --> $DIR/ub-incorrect-vtable.rs:35:1
    |
 LL | const INVALID_VTABLE_SIZE_UB: W<&dyn Trait> =
@@ -39,10 +39,10 @@ LL | const INVALID_VTABLE_SIZE_UB: W<&dyn Trait> =
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾ALLOC6<imm>╼ ╾ALLOC7<imm>╼                         │ ╾──╼╾──╼
+               ╾ALLOC$ID╼ ╾ALLOC$ID╼                         │ ╾──╼╾──╼
            }
 
-error[E0080]: constructing invalid value of type W<&dyn Trait>: at .0, encountered ALLOC9<imm>, but expected a vtable pointer
+error[E0080]: constructing invalid value of type W<&dyn Trait>: at .0, encountered ALLOC$ID<imm>, but expected a vtable pointer
   --> $DIR/ub-incorrect-vtable.rs:40:1
    |
 LL | const INVALID_VTABLE_UB: W<&dyn Trait> =
@@ -50,7 +50,7 @@ LL | const INVALID_VTABLE_UB: W<&dyn Trait> =
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾ALLOC8<imm>╼ ╾ALLOC9<imm>╼                         │ ╾──╼╾──╼
+               ╾ALLOC$ID╼ ╾ALLOC$ID╼                         │ ╾──╼╾──╼
            }
 
 error[E0080]: constructing invalid value of type Wide<'_>: at .1, encountered a dangling reference (going beyond the bounds of its allocation)
@@ -61,7 +61,7 @@ LL | const G: Wide = unsafe { Transmute { t: FOO }.u };
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾ALLOC10<imm>╼ ╾ALLOC11╼                         │ ╾──╼╾──╼
+               ╾ALLOC$ID╼ ╾ALLOC$ID╼                         │ ╾──╼╾──╼
            }
 
 error: aborting due to 6 previous errors

--- a/tests/ui/consts/const-eval/ub-incorrect-vtable.64bit.stderr
+++ b/tests/ui/consts/const-eval/ub-incorrect-vtable.64bit.stderr
@@ -1,4 +1,4 @@
-error[E0080]: constructing invalid value of type &dyn Trait: encountered ALLOC1<imm>, but expected a vtable pointer
+error[E0080]: constructing invalid value of type &dyn Trait: encountered ALLOC$ID<imm>, but expected a vtable pointer
   --> $DIR/ub-incorrect-vtable.rs:18:1
    |
 LL | const INVALID_VTABLE_ALIGNMENT: &dyn Trait =
@@ -6,10 +6,10 @@ LL | const INVALID_VTABLE_ALIGNMENT: &dyn Trait =
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾ALLOC0<imm>╼ ╾ALLOC1<imm>╼ │ ╾──────╼╾──────╼
+               ╾ALLOC$ID╼ ╾ALLOC$ID╼ │ ╾──────╼╾──────╼
            }
 
-error[E0080]: constructing invalid value of type &dyn Trait: encountered ALLOC3<imm>, but expected a vtable pointer
+error[E0080]: constructing invalid value of type &dyn Trait: encountered ALLOC$ID<imm>, but expected a vtable pointer
   --> $DIR/ub-incorrect-vtable.rs:22:1
    |
 LL | const INVALID_VTABLE_SIZE: &dyn Trait =
@@ -17,10 +17,10 @@ LL | const INVALID_VTABLE_SIZE: &dyn Trait =
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾ALLOC2<imm>╼ ╾ALLOC3<imm>╼ │ ╾──────╼╾──────╼
+               ╾ALLOC$ID╼ ╾ALLOC$ID╼ │ ╾──────╼╾──────╼
            }
 
-error[E0080]: constructing invalid value of type W<&dyn Trait>: at .0, encountered ALLOC5<imm>, but expected a vtable pointer
+error[E0080]: constructing invalid value of type W<&dyn Trait>: at .0, encountered ALLOC$ID<imm>, but expected a vtable pointer
   --> $DIR/ub-incorrect-vtable.rs:31:1
    |
 LL | const INVALID_VTABLE_ALIGNMENT_UB: W<&dyn Trait> =
@@ -28,10 +28,10 @@ LL | const INVALID_VTABLE_ALIGNMENT_UB: W<&dyn Trait> =
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾ALLOC4<imm>╼ ╾ALLOC5<imm>╼ │ ╾──────╼╾──────╼
+               ╾ALLOC$ID╼ ╾ALLOC$ID╼ │ ╾──────╼╾──────╼
            }
 
-error[E0080]: constructing invalid value of type W<&dyn Trait>: at .0, encountered ALLOC7<imm>, but expected a vtable pointer
+error[E0080]: constructing invalid value of type W<&dyn Trait>: at .0, encountered ALLOC$ID<imm>, but expected a vtable pointer
   --> $DIR/ub-incorrect-vtable.rs:35:1
    |
 LL | const INVALID_VTABLE_SIZE_UB: W<&dyn Trait> =
@@ -39,10 +39,10 @@ LL | const INVALID_VTABLE_SIZE_UB: W<&dyn Trait> =
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾ALLOC6<imm>╼ ╾ALLOC7<imm>╼ │ ╾──────╼╾──────╼
+               ╾ALLOC$ID╼ ╾ALLOC$ID╼ │ ╾──────╼╾──────╼
            }
 
-error[E0080]: constructing invalid value of type W<&dyn Trait>: at .0, encountered ALLOC9<imm>, but expected a vtable pointer
+error[E0080]: constructing invalid value of type W<&dyn Trait>: at .0, encountered ALLOC$ID<imm>, but expected a vtable pointer
   --> $DIR/ub-incorrect-vtable.rs:40:1
    |
 LL | const INVALID_VTABLE_UB: W<&dyn Trait> =
@@ -50,7 +50,7 @@ LL | const INVALID_VTABLE_UB: W<&dyn Trait> =
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾ALLOC8<imm>╼ ╾ALLOC9<imm>╼ │ ╾──────╼╾──────╼
+               ╾ALLOC$ID╼ ╾ALLOC$ID╼ │ ╾──────╼╾──────╼
            }
 
 error[E0080]: constructing invalid value of type Wide<'_>: at .1, encountered a dangling reference (going beyond the bounds of its allocation)
@@ -61,7 +61,7 @@ LL | const G: Wide = unsafe { Transmute { t: FOO }.u };
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾ALLOC10<imm>╼ ╾ALLOC11╼ │ ╾──────╼╾──────╼
+               ╾ALLOC$ID╼ ╾ALLOC$ID╼ │ ╾──────╼╾──────╼
            }
 
 error: aborting due to 6 previous errors

--- a/tests/ui/consts/const-eval/ub-incorrect-vtable.rs
+++ b/tests/ui/consts/const-eval/ub-incorrect-vtable.rs
@@ -12,7 +12,7 @@
 
 //@ stderr-per-bitwidth
 //@ dont-require-annotations: NOTE
-//@ ignore-parallel-frontend different alloc ids
+
 trait Trait {}
 
 const INVALID_VTABLE_ALIGNMENT: &dyn Trait =

--- a/tests/ui/consts/const-eval/ub-nonnull.rs
+++ b/tests/ui/consts/const-eval/ub-nonnull.rs
@@ -2,7 +2,7 @@
 //@ normalize-stderr: "(the raw bytes of the constant) \(size: [0-9]*, align: [0-9]*\)" -> "$1 (size: $$SIZE, align: $$ALIGN)"
 //@ normalize-stderr: "([0-9a-f][0-9a-f] |╾─*ALLOC[0-9]+(\+[a-z0-9]+)?─*╼ )+ *│.*" -> "HEX_DUMP"
 //@ dont-require-annotations: NOTE
-//@ ignore-parallel-frontend different alloc ids
+
 #![allow(invalid_value)] // make sure we cannot allow away the errors tested here
 #![feature(rustc_attrs, ptr_metadata)]
 

--- a/tests/ui/consts/const-eval/ub-nonnull.rs
+++ b/tests/ui/consts/const-eval/ub-nonnull.rs
@@ -1,6 +1,8 @@
 // Strip out raw byte dumps to make comparison platform-independent:
 //@ normalize-stderr: "(the raw bytes of the constant) \(size: [0-9]*, align: [0-9]*\)" -> "$1 (size: $$SIZE, align: $$ALIGN)"
 //@ normalize-stderr: "([0-9a-f][0-9a-f] |╾─*ALLOC[0-9]+(\+[a-z0-9]+)?─*╼ )+ *│.*" -> "HEX_DUMP"
+//@ normalize-stderr: "╾ALLOC\$ID╼\s+│.*╾.*╼" -> "╾ALLOC$$ID╼ │ ╾─╼"
+//@ normalize-stderr: "[0-9a-f][0-9a-f]( [0-9a-f][0-9a-f]){3,7} ╾ALLOC\$ID╼" -> "HEX_DUMP ╾ALLOC$$ID╼ │ ╾─╼"
 //@ dont-require-annotations: NOTE
 
 #![allow(invalid_value)] // make sure we cannot allow away the errors tested here

--- a/tests/ui/consts/const-eval/ub-nonnull.stderr
+++ b/tests/ui/consts/const-eval/ub-nonnull.stderr
@@ -9,7 +9,7 @@ LL | const NULL_PTR: NonNull<u8> = unsafe { mem::transmute(0usize) };
                HEX_DUMP
            }
 
-error[E0080]: in-bounds pointer arithmetic failed: attempting to offset pointer by 255 bytes, but got ALLOC2 which is only 1 byte from the end of the allocation
+error[E0080]: in-bounds pointer arithmetic failed: attempting to offset pointer by 255 bytes, but got ALLOC$ID which is only 1 byte from the end of the allocation
   --> $DIR/ub-nonnull.rs:22:29
    |
 LL |     let out_of_bounds_ptr = &ptr[255];
@@ -37,7 +37,7 @@ LL | const NULL_USIZE: NonZero<usize> = unsafe { mem::transmute(0usize) };
                HEX_DUMP
            }
 
-error[E0080]: reading memory at ALLOC3[0x0..0x1], but memory is uninitialized at [0x0..0x1], and this operation requires initialized memory
+error[E0080]: reading memory at ALLOC$ID[0x0..0x1], but memory is uninitialized at [0x0..0x1], and this operation requires initialized memory
   --> $DIR/ub-nonnull.rs:36:38
    |
 LL | const UNINIT: NonZero<u8> = unsafe { MaybeUninit { uninit: () }.init };
@@ -55,7 +55,7 @@ LL | const NULL_FAT_PTR: NonNull<dyn Send> = unsafe {
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
+               00 00 00 00 00 00 00 00 ╾ALLOC$ID╼ │ ........╾──────╼
            }
 
 error[E0080]: constructing invalid value of type NonNull<()>: at .pointer, encountered a maybe-null pointer, but expected something that is definitely non-zero
@@ -66,7 +66,7 @@ LL | const MAYBE_NULL_PTR: NonNull<()> = unsafe { mem::transmute((&raw const S).
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
+               ╾ALLOC$ID╼                         │ ╾──────╼
            }
 
 error: aborting due to 7 previous errors

--- a/tests/ui/consts/const-eval/ub-nonnull.stderr
+++ b/tests/ui/consts/const-eval/ub-nonnull.stderr
@@ -1,5 +1,5 @@
 error[E0080]: constructing invalid value of type NonNull<u8>: at .pointer, encountered 0, but expected something greater or equal to 1
-  --> $DIR/ub-nonnull.rs:16:1
+  --> $DIR/ub-nonnull.rs:18:1
    |
 LL | const NULL_PTR: NonNull<u8> = unsafe { mem::transmute(0usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
@@ -10,13 +10,13 @@ LL | const NULL_PTR: NonNull<u8> = unsafe { mem::transmute(0usize) };
            }
 
 error[E0080]: in-bounds pointer arithmetic failed: attempting to offset pointer by 255 bytes, but got ALLOC$ID which is only 1 byte from the end of the allocation
-  --> $DIR/ub-nonnull.rs:22:29
+  --> $DIR/ub-nonnull.rs:24:29
    |
 LL |     let out_of_bounds_ptr = &ptr[255];
    |                             ^^^^^^^^^ evaluation of `OUT_OF_BOUNDS_PTR` failed here
 
 error[E0080]: constructing invalid value of type NonZero<u8>: at .0.0, encountered 0, but expected something greater or equal to 1
-  --> $DIR/ub-nonnull.rs:26:1
+  --> $DIR/ub-nonnull.rs:28:1
    |
 LL | const NULL_U8: NonZero<u8> = unsafe { mem::transmute(0u8) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
@@ -27,7 +27,7 @@ LL | const NULL_U8: NonZero<u8> = unsafe { mem::transmute(0u8) };
            }
 
 error[E0080]: constructing invalid value of type NonZero<usize>: at .0.0, encountered 0, but expected something greater or equal to 1
-  --> $DIR/ub-nonnull.rs:28:1
+  --> $DIR/ub-nonnull.rs:30:1
    |
 LL | const NULL_USIZE: NonZero<usize> = unsafe { mem::transmute(0usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
@@ -38,7 +38,7 @@ LL | const NULL_USIZE: NonZero<usize> = unsafe { mem::transmute(0usize) };
            }
 
 error[E0080]: reading memory at ALLOC$ID[0x0..0x1], but memory is uninitialized at [0x0..0x1], and this operation requires initialized memory
-  --> $DIR/ub-nonnull.rs:36:38
+  --> $DIR/ub-nonnull.rs:38:38
    |
 LL | const UNINIT: NonZero<u8> = unsafe { MaybeUninit { uninit: () }.init };
    |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `UNINIT` failed here
@@ -48,25 +48,25 @@ LL | const UNINIT: NonZero<u8> = unsafe { MaybeUninit { uninit: () }.init };
            }
 
 error[E0080]: constructing invalid value of type NonNull<dyn Send>: at .pointer, encountered 0, but expected something greater or equal to 1
-  --> $DIR/ub-nonnull.rs:39:1
+  --> $DIR/ub-nonnull.rs:41:1
    |
 LL | const NULL_FAT_PTR: NonNull<dyn Send> = unsafe {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               00 00 00 00 00 00 00 00 ╾ALLOC$ID╼ │ ........╾──────╼
+               HEX_DUMP ╾ALLOC$ID╼ │ ╾─╼ │ ╾─╼
            }
 
 error[E0080]: constructing invalid value of type NonNull<()>: at .pointer, encountered a maybe-null pointer, but expected something that is definitely non-zero
-  --> $DIR/ub-nonnull.rs:47:1
+  --> $DIR/ub-nonnull.rs:49:1
    |
 LL | const MAYBE_NULL_PTR: NonNull<()> = unsafe { mem::transmute((&raw const S).wrapping_add(4)) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               ╾ALLOC$ID╼                         │ ╾──────╼
+               ╾ALLOC$ID╼ │ ╾─╼
            }
 
 error: aborting due to 7 previous errors

--- a/tests/ui/consts/const-eval/ub-ref-ptr.rs
+++ b/tests/ui/consts/const-eval/ub-ref-ptr.rs
@@ -6,7 +6,7 @@
 //@ normalize-stderr: "0x[0-9](\.\.|\])" -> "0x%$1"
 #![feature(pattern_types, pattern_type_macro)]
 #![allow(invalid_value)]
-//@ ignore-parallel-frontend different alloc ids
+
 use std::{mem, pat::pattern_type};
 
 #[repr(C)]

--- a/tests/ui/consts/const-eval/ub-ref-ptr.rs
+++ b/tests/ui/consts/const-eval/ub-ref-ptr.rs
@@ -4,6 +4,8 @@
 //@ normalize-stderr: "([0-9a-f][0-9a-f] |__ |╾─*ALLOC[0-9]+(\+[a-z0-9]+)?(<imm>)?─*╼ )+ *│.*" -> "HEX_DUMP"
 //@ dont-require-annotations: NOTE
 //@ normalize-stderr: "0x[0-9](\.\.|\])" -> "0x%$1"
+//@ normalize-stderr: "╾ALLOC\$ID╼\s+│.*╾.*╼" -> "╾ALLOC$$ID╼ │ ╾─╼"
+
 #![feature(pattern_types, pattern_type_macro)]
 #![allow(invalid_value)]
 

--- a/tests/ui/consts/const-eval/ub-ref-ptr.stderr
+++ b/tests/ui/consts/const-eval/ub-ref-ptr.stderr
@@ -6,7 +6,7 @@ LL | const UNALIGNED: &u16 = unsafe { mem::transmute(&[0u8; 4]) };
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
+               ╾ALLOC$ID╼                         │ ╾──────╼
            }
 
 error[E0080]: constructing invalid value of type Box<u16>: encountered an unaligned box (required 2 byte alignment but found 1)
@@ -17,7 +17,7 @@ LL | const UNALIGNED_BOX: Box<u16> = unsafe { mem::transmute(&[0u8; 4]) };
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
+               ╾ALLOC$ID╼                         │ ╾──────╼
            }
 
 error[E0080]: constructing invalid value of type &u16: encountered a null reference
@@ -50,7 +50,7 @@ LL | const MAYBE_NULL_BOX: Box<()> = unsafe { mem::transmute({
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
+               ╾ALLOC$ID╼                         │ ╾──────╼
            }
 
 error[E0080]: unable to turn pointer into integer
@@ -114,7 +114,7 @@ LL | const USIZE_AS_BOX: Box<u8> = unsafe { mem::transmute(1337usize) };
                HEX_DUMP
            }
 
-error[E0080]: reading memory at ALLOC5[0x%..0x%], but memory is uninitialized at [0x%..0x%], and this operation requires initialized memory
+error[E0080]: reading memory at ALLOC$ID[0x%..0x%], but memory is uninitialized at [0x%..0x%], and this operation requires initialized memory
   --> $DIR/ub-ref-ptr.rs:54:41
    |
 LL | const UNINIT_PTR: *const i32 = unsafe { MaybeUninit { uninit: () }.init };
@@ -135,7 +135,7 @@ LL | const NULL_FN_PTR: fn() = unsafe { mem::transmute(0usize) };
                HEX_DUMP
            }
 
-error[E0080]: reading memory at ALLOC6[0x%..0x%], but memory is uninitialized at [0x%..0x%], and this operation requires initialized memory
+error[E0080]: reading memory at ALLOC$ID[0x%..0x%], but memory is uninitialized at [0x%..0x%], and this operation requires initialized memory
   --> $DIR/ub-ref-ptr.rs:59:38
    |
 LL | const UNINIT_FN_PTR: fn() = unsafe { MaybeUninit { uninit: () }.init };
@@ -156,7 +156,7 @@ LL | const DANGLING_FN_PTR: fn() = unsafe { mem::transmute(13usize) };
                HEX_DUMP
            }
 
-error[E0080]: constructing invalid value of type fn(): encountered ALLOC3<imm>, but expected a function pointer
+error[E0080]: constructing invalid value of type fn(): encountered ALLOC$ID<imm>, but expected a function pointer
   --> $DIR/ub-ref-ptr.rs:63:1
    |
 LL | const DATA_FN_PTR: fn() = unsafe { mem::transmute(&13) };
@@ -164,10 +164,10 @@ LL | const DATA_FN_PTR: fn() = unsafe { mem::transmute(&13) };
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
+               ╾ALLOC$ID╼                         │ ╾──────╼
            }
 
-error[E0080]: constructing invalid value of type fn(): encountered ALLOC4+0xa, but expected a function pointer
+error[E0080]: constructing invalid value of type fn(): encountered ALLOC$ID+0xa, but expected a function pointer
   --> $DIR/ub-ref-ptr.rs:65:1
    |
 LL | const MAYBE_NULL_FN_PTR: fn() = unsafe { mem::transmute({
@@ -175,7 +175,7 @@ LL | const MAYBE_NULL_FN_PTR: fn() = unsafe { mem::transmute({
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
+               ╾ALLOC$ID╼                         │ ╾──────╼
            }
 
 error[E0080]: accessing memory based on pointer with alignment 1, but alignment 4 is required

--- a/tests/ui/consts/const-eval/ub-ref-ptr.stderr
+++ b/tests/ui/consts/const-eval/ub-ref-ptr.stderr
@@ -1,27 +1,27 @@
 error[E0080]: constructing invalid value of type &u16: encountered an unaligned reference (required 2 byte alignment but found 1)
-  --> $DIR/ub-ref-ptr.rs:18:1
+  --> $DIR/ub-ref-ptr.rs:20:1
    |
 LL | const UNALIGNED: &u16 = unsafe { mem::transmute(&[0u8; 4]) };
    | ^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               ╾ALLOC$ID╼                         │ ╾──────╼
+               ╾ALLOC$ID╼ │ ╾─╼
            }
 
 error[E0080]: constructing invalid value of type Box<u16>: encountered an unaligned box (required 2 byte alignment but found 1)
-  --> $DIR/ub-ref-ptr.rs:21:1
+  --> $DIR/ub-ref-ptr.rs:23:1
    |
 LL | const UNALIGNED_BOX: Box<u16> = unsafe { mem::transmute(&[0u8; 4]) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               ╾ALLOC$ID╼                         │ ╾──────╼
+               ╾ALLOC$ID╼ │ ╾─╼
            }
 
 error[E0080]: constructing invalid value of type &u16: encountered a null reference
-  --> $DIR/ub-ref-ptr.rs:24:1
+  --> $DIR/ub-ref-ptr.rs:26:1
    |
 LL | const NULL: &u16 = unsafe { mem::transmute(0usize) };
    | ^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
@@ -32,7 +32,7 @@ LL | const NULL: &u16 = unsafe { mem::transmute(0usize) };
            }
 
 error[E0080]: constructing invalid value of type Box<u16>: encountered a null box
-  --> $DIR/ub-ref-ptr.rs:27:1
+  --> $DIR/ub-ref-ptr.rs:29:1
    |
 LL | const NULL_BOX: Box<u16> = unsafe { mem::transmute(0usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
@@ -43,18 +43,18 @@ LL | const NULL_BOX: Box<u16> = unsafe { mem::transmute(0usize) };
            }
 
 error[E0080]: constructing invalid value of type Box<()>: encountered a maybe-null box
-  --> $DIR/ub-ref-ptr.rs:30:1
+  --> $DIR/ub-ref-ptr.rs:32:1
    |
 LL | const MAYBE_NULL_BOX: Box<()> = unsafe { mem::transmute({
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               ╾ALLOC$ID╼                         │ ╾──────╼
+               ╾ALLOC$ID╼ │ ╾─╼
            }
 
 error[E0080]: unable to turn pointer into integer
-  --> $DIR/ub-ref-ptr.rs:39:1
+  --> $DIR/ub-ref-ptr.rs:41:1
    |
 LL | const REF_AS_USIZE: usize = unsafe { mem::transmute(&0) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `REF_AS_USIZE` failed here
@@ -63,7 +63,7 @@ LL | const REF_AS_USIZE: usize = unsafe { mem::transmute(&0) };
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
 error[E0080]: unable to turn pointer into integer
-  --> $DIR/ub-ref-ptr.rs:42:39
+  --> $DIR/ub-ref-ptr.rs:44:39
    |
 LL | const REF_AS_USIZE_SLICE: &[usize] = &[unsafe { mem::transmute(&0) }];
    |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `REF_AS_USIZE_SLICE` failed here
@@ -72,13 +72,13 @@ LL | const REF_AS_USIZE_SLICE: &[usize] = &[unsafe { mem::transmute(&0) }];
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
 note: erroneous constant encountered
-  --> $DIR/ub-ref-ptr.rs:42:38
+  --> $DIR/ub-ref-ptr.rs:44:38
    |
 LL | const REF_AS_USIZE_SLICE: &[usize] = &[unsafe { mem::transmute(&0) }];
    |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0080]: unable to turn pointer into integer
-  --> $DIR/ub-ref-ptr.rs:45:86
+  --> $DIR/ub-ref-ptr.rs:47:86
    |
 LL | const REF_AS_USIZE_BOX_SLICE: Box<[usize]> = unsafe { mem::transmute::<&[usize], _>(&[mem::transmute(&0)]) };
    |                                                                                      ^^^^^^^^^^^^^^^^^^^^ evaluation of `REF_AS_USIZE_BOX_SLICE` failed here
@@ -87,13 +87,13 @@ LL | const REF_AS_USIZE_BOX_SLICE: Box<[usize]> = unsafe { mem::transmute::<&[us
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
 note: erroneous constant encountered
-  --> $DIR/ub-ref-ptr.rs:45:85
+  --> $DIR/ub-ref-ptr.rs:47:85
    |
 LL | const REF_AS_USIZE_BOX_SLICE: Box<[usize]> = unsafe { mem::transmute::<&[usize], _>(&[mem::transmute(&0)]) };
    |                                                                                     ^^^^^^^^^^^^^^^^^^^^^
 
 error[E0080]: constructing invalid value of type &u8: encountered a dangling reference (0x539[noalloc] has no provenance)
-  --> $DIR/ub-ref-ptr.rs:48:1
+  --> $DIR/ub-ref-ptr.rs:50:1
    |
 LL | const USIZE_AS_REF: &'static u8 = unsafe { mem::transmute(1337usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
@@ -104,7 +104,7 @@ LL | const USIZE_AS_REF: &'static u8 = unsafe { mem::transmute(1337usize) };
            }
 
 error[E0080]: constructing invalid value of type Box<u8>: encountered a dangling box (0x539[noalloc] has no provenance)
-  --> $DIR/ub-ref-ptr.rs:51:1
+  --> $DIR/ub-ref-ptr.rs:53:1
    |
 LL | const USIZE_AS_BOX: Box<u8> = unsafe { mem::transmute(1337usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
@@ -115,7 +115,7 @@ LL | const USIZE_AS_BOX: Box<u8> = unsafe { mem::transmute(1337usize) };
            }
 
 error[E0080]: reading memory at ALLOC$ID[0x%..0x%], but memory is uninitialized at [0x%..0x%], and this operation requires initialized memory
-  --> $DIR/ub-ref-ptr.rs:54:41
+  --> $DIR/ub-ref-ptr.rs:56:41
    |
 LL | const UNINIT_PTR: *const i32 = unsafe { MaybeUninit { uninit: () }.init };
    |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `UNINIT_PTR` failed here
@@ -125,7 +125,7 @@ LL | const UNINIT_PTR: *const i32 = unsafe { MaybeUninit { uninit: () }.init };
            }
 
 error[E0080]: constructing invalid value of type fn(): encountered null pointer, but expected a function pointer
-  --> $DIR/ub-ref-ptr.rs:57:1
+  --> $DIR/ub-ref-ptr.rs:59:1
    |
 LL | const NULL_FN_PTR: fn() = unsafe { mem::transmute(0usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
@@ -136,7 +136,7 @@ LL | const NULL_FN_PTR: fn() = unsafe { mem::transmute(0usize) };
            }
 
 error[E0080]: reading memory at ALLOC$ID[0x%..0x%], but memory is uninitialized at [0x%..0x%], and this operation requires initialized memory
-  --> $DIR/ub-ref-ptr.rs:59:38
+  --> $DIR/ub-ref-ptr.rs:61:38
    |
 LL | const UNINIT_FN_PTR: fn() = unsafe { MaybeUninit { uninit: () }.init };
    |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `UNINIT_FN_PTR` failed here
@@ -146,7 +146,7 @@ LL | const UNINIT_FN_PTR: fn() = unsafe { MaybeUninit { uninit: () }.init };
            }
 
 error[E0080]: constructing invalid value of type fn(): encountered 0xd[noalloc], but expected a function pointer
-  --> $DIR/ub-ref-ptr.rs:61:1
+  --> $DIR/ub-ref-ptr.rs:63:1
    |
 LL | const DANGLING_FN_PTR: fn() = unsafe { mem::transmute(13usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
@@ -157,29 +157,29 @@ LL | const DANGLING_FN_PTR: fn() = unsafe { mem::transmute(13usize) };
            }
 
 error[E0080]: constructing invalid value of type fn(): encountered ALLOC$ID<imm>, but expected a function pointer
-  --> $DIR/ub-ref-ptr.rs:63:1
+  --> $DIR/ub-ref-ptr.rs:65:1
    |
 LL | const DATA_FN_PTR: fn() = unsafe { mem::transmute(&13) };
    | ^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               ╾ALLOC$ID╼                         │ ╾──────╼
+               ╾ALLOC$ID╼ │ ╾─╼
            }
 
 error[E0080]: constructing invalid value of type fn(): encountered ALLOC$ID+0xa, but expected a function pointer
-  --> $DIR/ub-ref-ptr.rs:65:1
+  --> $DIR/ub-ref-ptr.rs:67:1
    |
 LL | const MAYBE_NULL_FN_PTR: fn() = unsafe { mem::transmute({
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               ╾ALLOC$ID╼                         │ ╾──────╼
+               ╾ALLOC$ID╼ │ ╾─╼
            }
 
 error[E0080]: accessing memory based on pointer with alignment 1, but alignment 4 is required
-  --> $DIR/ub-ref-ptr.rs:75:5
+  --> $DIR/ub-ref-ptr.rs:77:5
    |
 LL |     ptr.read();
    |     ^^^^^^^^^^ evaluation of `UNALIGNED_READ` failed here

--- a/tests/ui/consts/const-eval/ub-upvars.32bit.stderr
+++ b/tests/ui/consts/const-eval/ub-upvars.32bit.stderr
@@ -6,7 +6,7 @@ LL | const BAD_UPVAR: &dyn FnOnce() = &{
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾ALLOC0<imm>╼ ╾ALLOC1╼                         │ ╾──╼╾──╼
+               ╾ALLOC$ID╼ ╾ALLOC$ID╼                         │ ╾──╼╾──╼
            }
 
 error: aborting due to 1 previous error

--- a/tests/ui/consts/const-eval/ub-upvars.64bit.stderr
+++ b/tests/ui/consts/const-eval/ub-upvars.64bit.stderr
@@ -6,7 +6,7 @@ LL | const BAD_UPVAR: &dyn FnOnce() = &{
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾ALLOC0<imm>╼ ╾ALLOC1╼ │ ╾──────╼╾──────╼
+               ╾ALLOC$ID╼ ╾ALLOC$ID╼ │ ╾──────╼╾──────╼
            }
 
 error: aborting due to 1 previous error

--- a/tests/ui/consts/const-eval/ub-upvars.rs
+++ b/tests/ui/consts/const-eval/ub-upvars.rs
@@ -1,7 +1,7 @@
 //@ edition:2015..2021
 //@ stderr-per-bitwidth
 #![allow(invalid_value)] // make sure we cannot allow away the errors tested here
-//@ ignore-parallel-frontend different alloc ids
+
 use std::mem;
 
 const BAD_UPVAR: &dyn FnOnce() = &{ //~ ERROR null reference

--- a/tests/ui/consts/const-eval/ub-wide-ptr.rs
+++ b/tests/ui/consts/const-eval/ub-wide-ptr.rs
@@ -3,7 +3,7 @@
 #![feature(ptr_metadata)]
 
 use std::{ptr, mem};
-//@ ignore-parallel-frontend different alloc ids
+
 // Strip out raw byte dumps to make comparison platform-independent:
 //@ normalize-stderr: "(the raw bytes of the constant) \(size: [0-9]*, align: [0-9]*\)" -> "$1 (size: $$SIZE, align: $$ALIGN)"
 //@ normalize-stderr: "([0-9a-f][0-9a-f] |__ |╾─*ALLOC[0-9]+(\+[a-z0-9]+)?(<imm>)?─*╼ )+ *│.*" -> "HEX_DUMP"

--- a/tests/ui/consts/const-eval/ub-wide-ptr.rs
+++ b/tests/ui/consts/const-eval/ub-wide-ptr.rs
@@ -10,6 +10,7 @@ use std::{ptr, mem};
 //@ normalize-stderr: "offset \d+" -> "offset N"
 //@ normalize-stderr: "size \d+" -> "size N"
 //@ normalize-stderr: "0x[0-9](\.\.|\])" -> "0x%$1"
+//@ normalize-stderr: "╾ALLOC\$ID╼\s+│.*╾.*╼" -> "╾ALLOC$$ID╼ │ ╾─╼"
 //@ dont-require-annotations: NOTE
 
 /// A newtype wrapper to prevent MIR generation from inserting reborrows that would affect the error
@@ -136,7 +137,6 @@ const RAW_TRAIT_OBJ_VTABLE_INVALID: *const dyn Trait = unsafe { mem::transmute((
 const RAW_TRAIT_OBJ_CONTENT_INVALID: *const dyn Trait = unsafe { mem::transmute::<_, &bool>(&3u8) } as *const dyn Trait; // ok because raw
 // Officially blessed way to get the vtable
 const DYN_METADATA: ptr::DynMetadata<dyn Send> = ptr::metadata::<dyn Send>(ptr::null::<i32>());
-
 
 static mut RAW_TRAIT_OBJ_VTABLE_NULL_THROUGH_REF: *const dyn Trait = unsafe {
     mem::transmute::<_, &dyn Trait>((&92u8, 0usize))

--- a/tests/ui/consts/const-eval/ub-wide-ptr.stderr
+++ b/tests/ui/consts/const-eval/ub-wide-ptr.stderr
@@ -6,7 +6,7 @@ LL | const STR_TOO_LONG: &str = unsafe { mem::transmute((&42u8, 999usize)) };
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
+               ╾ALLOC$ID╼ HEX_DUMP
            }
 
 error[E0080]: constructing invalid value of type (&str,): at .0, encountered invalid reference metadata: slice is bigger than largest supported object
@@ -17,7 +17,7 @@ LL | const NESTED_STR_MUCH_TOO_LONG: (&str,) = (unsafe { mem::transmute((&42, us
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
+               ╾ALLOC$ID╼ HEX_DUMP
            }
 
 error[E0080]: unable to turn pointer into integer
@@ -46,7 +46,7 @@ LL | const MY_STR_MUCH_TOO_LONG: &MyStr = unsafe { mem::transmute((&42u8, usize:
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
+               ╾ALLOC$ID╼ HEX_DUMP
            }
 
 error[E0080]: constructing invalid value of type &str: at .<deref>, encountered uninitialized memory, but expected a string
@@ -57,7 +57,7 @@ LL | const STR_NO_INIT: &str = unsafe { mem::transmute::<&[_], _>(&[MaybeUninit:
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
+               ╾ALLOC$ID╼ HEX_DUMP
            }
 
 error[E0080]: constructing invalid value of type &MyStr: at .<deref>.0, encountered uninitialized memory, but expected a string
@@ -68,10 +68,10 @@ LL | const MYSTR_NO_INIT: &MyStr = unsafe { mem::transmute::<&[_], _>(&[MaybeUni
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
+               ╾ALLOC$ID╼ HEX_DUMP
            }
 
-error[E0080]: reading memory at ALLOC32[0x%..0x%], but memory is uninitialized at [0x%..0x%], and this operation requires initialized memory
+error[E0080]: reading memory at ALLOC$ID[0x%..0x%], but memory is uninitialized at [0x%..0x%], and this operation requires initialized memory
   --> $DIR/ub-wide-ptr.rs:64:1
    |
 LL | const SLICE_LENGTH_UNINIT: &[u8] = unsafe {
@@ -89,7 +89,7 @@ LL | const SLICE_TOO_LONG: &[u8] = unsafe { mem::transmute((&42u8, 999usize)) };
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
+               ╾ALLOC$ID╼ HEX_DUMP
            }
 
 error[E0080]: constructing invalid value of type &[u32]: encountered invalid reference metadata: slice is bigger than largest supported object
@@ -100,7 +100,7 @@ LL | const SLICE_TOO_LONG_OVERFLOW: &[u32] = unsafe { mem::transmute((&42u32, is
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
+               ╾ALLOC$ID╼ HEX_DUMP
            }
 
 error[E0080]: unable to turn pointer into integer
@@ -120,7 +120,7 @@ LL | const SLICE_TOO_LONG_BOX: Box<[u8]> = unsafe { mem::transmute((&42u8, 999us
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
+               ╾ALLOC$ID╼ HEX_DUMP
            }
 
 error[E0080]: unable to turn pointer into integer
@@ -140,7 +140,7 @@ LL | const SLICE_CONTENT_INVALID: &[bool] = &[unsafe { mem::transmute(3u8) }];
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
+               ╾ALLOC$ID╼                         │ ╾──────╼
            }
 
 note: erroneous constant encountered
@@ -157,7 +157,7 @@ LL | const MYSLICE_PREFIX_BAD: &MySliceBool = &MySlice(unsafe { mem::transmute(3
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
+               ╾ALLOC$ID╼                         │ ╾──────╼
            }
 
 note: erroneous constant encountered
@@ -174,7 +174,7 @@ LL | const MYSLICE_SUFFIX_BAD: &MySliceBool = &MySlice(true, [unsafe { mem::tran
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
+               ╾ALLOC$ID╼                         │ ╾──────╼
            }
 
 note: erroneous constant encountered
@@ -183,7 +183,7 @@ note: erroneous constant encountered
 LL | const MYSLICE_SUFFIX_BAD: &MySliceBool = &MySlice(true, [unsafe { mem::transmute(3u8) }]);
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0080]: reading memory at ALLOC33[0x%..0x%], but memory is uninitialized at [0x%..0x%], and this operation requires initialized memory
+error[E0080]: reading memory at ALLOC$ID[0x%..0x%], but memory is uninitialized at [0x%..0x%], and this operation requires initialized memory
   --> $DIR/ub-wide-ptr.rs:102:1
    |
 LL | const RAW_SLICE_LENGTH_UNINIT: *const [u8] = unsafe {
@@ -193,7 +193,7 @@ LL | const RAW_SLICE_LENGTH_UNINIT: *const [u8] = unsafe {
                HEX_DUMP
            }
 
-error[E0080]: constructing invalid value of type W<&dyn Trait>: at .0, encountered ALLOC12<imm>, but expected a vtable pointer
+error[E0080]: constructing invalid value of type W<&dyn Trait>: at .0, encountered ALLOC$ID<imm>, but expected a vtable pointer
   --> $DIR/ub-wide-ptr.rs:110:1
    |
 LL | const TRAIT_OBJ_SHORT_VTABLE_1: W<&dyn Trait> = unsafe { mem::transmute(W((&92u8, &3u8))) };
@@ -201,10 +201,10 @@ LL | const TRAIT_OBJ_SHORT_VTABLE_1: W<&dyn Trait> = unsafe { mem::transmute(W((
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
+               ╾ALLOC$ID╼ ╾ALLOC$ID╼ │ ╾──────╼╾──────╼
            }
 
-error[E0080]: constructing invalid value of type W<&dyn Trait>: at .0, encountered ALLOC14<imm>, but expected a vtable pointer
+error[E0080]: constructing invalid value of type W<&dyn Trait>: at .0, encountered ALLOC$ID<imm>, but expected a vtable pointer
   --> $DIR/ub-wide-ptr.rs:113:1
    |
 LL | const TRAIT_OBJ_SHORT_VTABLE_2: W<&dyn Trait> = unsafe { mem::transmute(W((&92u8, &3u64))) };
@@ -212,7 +212,7 @@ LL | const TRAIT_OBJ_SHORT_VTABLE_2: W<&dyn Trait> = unsafe { mem::transmute(W((
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
+               ╾ALLOC$ID╼ ╾ALLOC$ID╼ │ ╾──────╼╾──────╼
            }
 
 error[E0080]: constructing invalid value of type W<&dyn Trait>: at .0, encountered 0x4[noalloc], but expected a vtable pointer
@@ -223,10 +223,10 @@ LL | const TRAIT_OBJ_INT_VTABLE: W<&dyn Trait> = unsafe { mem::transmute(W((&92u
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
+               ╾ALLOC$ID╼ HEX_DUMP
            }
 
-error[E0080]: constructing invalid value of type &dyn Trait: encountered ALLOC17<imm>, but expected a vtable pointer
+error[E0080]: constructing invalid value of type &dyn Trait: encountered ALLOC$ID<imm>, but expected a vtable pointer
   --> $DIR/ub-wide-ptr.rs:118:1
    |
 LL | const TRAIT_OBJ_UNALIGNED_VTABLE: &dyn Trait = unsafe { mem::transmute((&92u8, &[0u8; 128])) };
@@ -234,10 +234,10 @@ LL | const TRAIT_OBJ_UNALIGNED_VTABLE: &dyn Trait = unsafe { mem::transmute((&92
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
+               ╾ALLOC$ID╼ ╾ALLOC$ID╼ │ ╾──────╼╾──────╼
            }
 
-error[E0080]: constructing invalid value of type &dyn Trait: encountered ALLOC19<imm>, but expected a vtable pointer
+error[E0080]: constructing invalid value of type &dyn Trait: encountered ALLOC$ID<imm>, but expected a vtable pointer
   --> $DIR/ub-wide-ptr.rs:120:1
    |
 LL | const TRAIT_OBJ_BAD_DROP_FN_NULL: &dyn Trait = unsafe { mem::transmute((&92u8, &[0usize; 8])) };
@@ -245,10 +245,10 @@ LL | const TRAIT_OBJ_BAD_DROP_FN_NULL: &dyn Trait = unsafe { mem::transmute((&92
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
+               ╾ALLOC$ID╼ ╾ALLOC$ID╼ │ ╾──────╼╾──────╼
            }
 
-error[E0080]: constructing invalid value of type &dyn Trait: encountered ALLOC21<imm>, but expected a vtable pointer
+error[E0080]: constructing invalid value of type &dyn Trait: encountered ALLOC$ID<imm>, but expected a vtable pointer
   --> $DIR/ub-wide-ptr.rs:122:1
    |
 LL | const TRAIT_OBJ_BAD_DROP_FN_INT: &dyn Trait = unsafe { mem::transmute((&92u8, &[1usize; 8])) };
@@ -256,10 +256,10 @@ LL | const TRAIT_OBJ_BAD_DROP_FN_INT: &dyn Trait = unsafe { mem::transmute((&92u
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
+               ╾ALLOC$ID╼ ╾ALLOC$ID╼ │ ╾──────╼╾──────╼
            }
 
-error[E0080]: constructing invalid value of type W<&dyn Trait>: at .0, encountered ALLOC23<imm>, but expected a vtable pointer
+error[E0080]: constructing invalid value of type W<&dyn Trait>: at .0, encountered ALLOC$ID<imm>, but expected a vtable pointer
   --> $DIR/ub-wide-ptr.rs:124:1
    |
 LL | const TRAIT_OBJ_BAD_DROP_FN_NOT_FN_PTR: W<&dyn Trait> = unsafe { mem::transmute(W((&92u8, &[&42u8; 8]))) };
@@ -267,7 +267,7 @@ LL | const TRAIT_OBJ_BAD_DROP_FN_NOT_FN_PTR: W<&dyn Trait> = unsafe { mem::trans
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
+               ╾ALLOC$ID╼ ╾ALLOC$ID╼ │ ╾──────╼╾──────╼
            }
 
 error[E0080]: constructing invalid value of type &dyn Trait: at .<deref>.<dyn-downcast(bool)>, encountered 0x03, but expected a boolean
@@ -278,7 +278,7 @@ LL | const TRAIT_OBJ_CONTENT_INVALID: &dyn Trait = unsafe { mem::transmute::<_, 
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
+               ╾ALLOC$ID╼ ╾ALLOC$ID╼ │ ╾──────╼╾──────╼
            }
 
 error[E0080]: constructing invalid value of type *const dyn Trait: encountered null pointer, but expected a vtable pointer
@@ -289,10 +289,10 @@ LL | const RAW_TRAIT_OBJ_VTABLE_NULL: *const dyn Trait = unsafe { mem::transmute
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
+               ╾ALLOC$ID╼ HEX_DUMP
            }
 
-error[E0080]: constructing invalid value of type *const dyn Trait: encountered ALLOC28<imm>, but expected a vtable pointer
+error[E0080]: constructing invalid value of type *const dyn Trait: encountered ALLOC$ID<imm>, but expected a vtable pointer
   --> $DIR/ub-wide-ptr.rs:134:1
    |
 LL | const RAW_TRAIT_OBJ_VTABLE_INVALID: *const dyn Trait = unsafe { mem::transmute((&92u8, &3u64)) };
@@ -300,7 +300,7 @@ LL | const RAW_TRAIT_OBJ_VTABLE_INVALID: *const dyn Trait = unsafe { mem::transm
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
+               ╾ALLOC$ID╼ ╾ALLOC$ID╼ │ ╾──────╼╾──────╼
            }
 
 error[E0080]: constructing invalid value of type *const dyn Trait: encountered null pointer, but expected a vtable pointer
@@ -311,10 +311,10 @@ LL | static mut RAW_TRAIT_OBJ_VTABLE_NULL_THROUGH_REF: *const dyn Trait = unsafe
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
+               ╾ALLOC$ID╼ HEX_DUMP
            }
 
-error[E0080]: constructing invalid value of type *const dyn Trait: encountered ALLOC31<imm>, but expected a vtable pointer
+error[E0080]: constructing invalid value of type *const dyn Trait: encountered ALLOC$ID<imm>, but expected a vtable pointer
   --> $DIR/ub-wide-ptr.rs:145:1
    |
 LL | static mut RAW_TRAIT_OBJ_VTABLE_INVALID_THROUGH_REF: *const dyn Trait = unsafe {
@@ -322,7 +322,7 @@ LL | static mut RAW_TRAIT_OBJ_VTABLE_INVALID_THROUGH_REF: *const dyn Trait = uns
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
+               ╾ALLOC$ID╼ ╾ALLOC$ID╼ │ ╾──────╼╾──────╼
            }
 
 error: aborting due to 29 previous errors

--- a/tests/ui/consts/const-eval/ub-wide-ptr.stderr
+++ b/tests/ui/consts/const-eval/ub-wide-ptr.stderr
@@ -1,5 +1,5 @@
 error[E0080]: constructing invalid value of type &str: encountered a dangling reference (going beyond the bounds of its allocation)
-  --> $DIR/ub-wide-ptr.rs:40:1
+  --> $DIR/ub-wide-ptr.rs:41:1
    |
 LL | const STR_TOO_LONG: &str = unsafe { mem::transmute((&42u8, 999usize)) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
@@ -10,7 +10,7 @@ LL | const STR_TOO_LONG: &str = unsafe { mem::transmute((&42u8, 999usize)) };
            }
 
 error[E0080]: constructing invalid value of type (&str,): at .0, encountered invalid reference metadata: slice is bigger than largest supported object
-  --> $DIR/ub-wide-ptr.rs:42:1
+  --> $DIR/ub-wide-ptr.rs:43:1
    |
 LL | const NESTED_STR_MUCH_TOO_LONG: (&str,) = (unsafe { mem::transmute((&42, usize::MAX)) },);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
@@ -21,7 +21,7 @@ LL | const NESTED_STR_MUCH_TOO_LONG: (&str,) = (unsafe { mem::transmute((&42, us
            }
 
 error[E0080]: unable to turn pointer into integer
-  --> $DIR/ub-wide-ptr.rs:45:1
+  --> $DIR/ub-wide-ptr.rs:46:1
    |
 LL | const STR_LENGTH_PTR: &str = unsafe { mem::transmute((&42u8, &3)) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `STR_LENGTH_PTR` failed here
@@ -30,7 +30,7 @@ LL | const STR_LENGTH_PTR: &str = unsafe { mem::transmute((&42u8, &3)) };
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
 error[E0080]: unable to turn pointer into integer
-  --> $DIR/ub-wide-ptr.rs:48:1
+  --> $DIR/ub-wide-ptr.rs:49:1
    |
 LL | const MY_STR_LENGTH_PTR: &MyStr = unsafe { mem::transmute((&42u8, &3)) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `MY_STR_LENGTH_PTR` failed here
@@ -39,7 +39,7 @@ LL | const MY_STR_LENGTH_PTR: &MyStr = unsafe { mem::transmute((&42u8, &3)) };
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
 error[E0080]: constructing invalid value of type &MyStr: encountered invalid reference metadata: slice is bigger than largest supported object
-  --> $DIR/ub-wide-ptr.rs:50:1
+  --> $DIR/ub-wide-ptr.rs:51:1
    |
 LL | const MY_STR_MUCH_TOO_LONG: &MyStr = unsafe { mem::transmute((&42u8, usize::MAX)) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
@@ -50,7 +50,7 @@ LL | const MY_STR_MUCH_TOO_LONG: &MyStr = unsafe { mem::transmute((&42u8, usize:
            }
 
 error[E0080]: constructing invalid value of type &str: at .<deref>, encountered uninitialized memory, but expected a string
-  --> $DIR/ub-wide-ptr.rs:54:1
+  --> $DIR/ub-wide-ptr.rs:55:1
    |
 LL | const STR_NO_INIT: &str = unsafe { mem::transmute::<&[_], _>(&[MaybeUninit::<u8> { uninit: () }]) };
    | ^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
@@ -61,7 +61,7 @@ LL | const STR_NO_INIT: &str = unsafe { mem::transmute::<&[_], _>(&[MaybeUninit:
            }
 
 error[E0080]: constructing invalid value of type &MyStr: at .<deref>.0, encountered uninitialized memory, but expected a string
-  --> $DIR/ub-wide-ptr.rs:57:1
+  --> $DIR/ub-wide-ptr.rs:58:1
    |
 LL | const MYSTR_NO_INIT: &MyStr = unsafe { mem::transmute::<&[_], _>(&[MaybeUninit::<u8> { uninit: () }]) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
@@ -72,7 +72,7 @@ LL | const MYSTR_NO_INIT: &MyStr = unsafe { mem::transmute::<&[_], _>(&[MaybeUni
            }
 
 error[E0080]: reading memory at ALLOC$ID[0x%..0x%], but memory is uninitialized at [0x%..0x%], and this operation requires initialized memory
-  --> $DIR/ub-wide-ptr.rs:64:1
+  --> $DIR/ub-wide-ptr.rs:65:1
    |
 LL | const SLICE_LENGTH_UNINIT: &[u8] = unsafe {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `SLICE_LENGTH_UNINIT` failed here
@@ -82,7 +82,7 @@ LL | const SLICE_LENGTH_UNINIT: &[u8] = unsafe {
            }
 
 error[E0080]: constructing invalid value of type &[u8]: encountered a dangling reference (going beyond the bounds of its allocation)
-  --> $DIR/ub-wide-ptr.rs:70:1
+  --> $DIR/ub-wide-ptr.rs:71:1
    |
 LL | const SLICE_TOO_LONG: &[u8] = unsafe { mem::transmute((&42u8, 999usize)) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
@@ -93,7 +93,7 @@ LL | const SLICE_TOO_LONG: &[u8] = unsafe { mem::transmute((&42u8, 999usize)) };
            }
 
 error[E0080]: constructing invalid value of type &[u32]: encountered invalid reference metadata: slice is bigger than largest supported object
-  --> $DIR/ub-wide-ptr.rs:73:1
+  --> $DIR/ub-wide-ptr.rs:74:1
    |
 LL | const SLICE_TOO_LONG_OVERFLOW: &[u32] = unsafe { mem::transmute((&42u32, isize::MAX)) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
@@ -104,7 +104,7 @@ LL | const SLICE_TOO_LONG_OVERFLOW: &[u32] = unsafe { mem::transmute((&42u32, is
            }
 
 error[E0080]: unable to turn pointer into integer
-  --> $DIR/ub-wide-ptr.rs:76:1
+  --> $DIR/ub-wide-ptr.rs:77:1
    |
 LL | const SLICE_LENGTH_PTR: &[u8] = unsafe { mem::transmute((&42u8, &3)) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `SLICE_LENGTH_PTR` failed here
@@ -113,7 +113,7 @@ LL | const SLICE_LENGTH_PTR: &[u8] = unsafe { mem::transmute((&42u8, &3)) };
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
 error[E0080]: constructing invalid value of type Box<[u8]>: encountered a dangling box (going beyond the bounds of its allocation)
-  --> $DIR/ub-wide-ptr.rs:79:1
+  --> $DIR/ub-wide-ptr.rs:80:1
    |
 LL | const SLICE_TOO_LONG_BOX: Box<[u8]> = unsafe { mem::transmute((&42u8, 999usize)) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
@@ -124,7 +124,7 @@ LL | const SLICE_TOO_LONG_BOX: Box<[u8]> = unsafe { mem::transmute((&42u8, 999us
            }
 
 error[E0080]: unable to turn pointer into integer
-  --> $DIR/ub-wide-ptr.rs:82:1
+  --> $DIR/ub-wide-ptr.rs:83:1
    |
 LL | const SLICE_LENGTH_PTR_BOX: Box<[u8]> = unsafe { mem::transmute((&42u8, &3)) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `SLICE_LENGTH_PTR_BOX` failed here
@@ -133,58 +133,58 @@ LL | const SLICE_LENGTH_PTR_BOX: Box<[u8]> = unsafe { mem::transmute((&42u8, &3)
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
 error[E0080]: constructing invalid value of type &[bool; 1]: at .<deref>[0], encountered 0x03, but expected a boolean
-  --> $DIR/ub-wide-ptr.rs:86:1
+  --> $DIR/ub-wide-ptr.rs:87:1
    |
 LL | const SLICE_CONTENT_INVALID: &[bool] = &[unsafe { mem::transmute(3u8) }];
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               ╾ALLOC$ID╼                         │ ╾──────╼
+               ╾ALLOC$ID╼ │ ╾─╼
            }
 
 note: erroneous constant encountered
-  --> $DIR/ub-wide-ptr.rs:86:40
+  --> $DIR/ub-wide-ptr.rs:87:40
    |
 LL | const SLICE_CONTENT_INVALID: &[bool] = &[unsafe { mem::transmute(3u8) }];
    |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0080]: constructing invalid value of type &MySlice<[bool; 1]>: at .<deref>.0, encountered 0x03, but expected a boolean
-  --> $DIR/ub-wide-ptr.rs:92:1
+  --> $DIR/ub-wide-ptr.rs:93:1
    |
 LL | const MYSLICE_PREFIX_BAD: &MySliceBool = &MySlice(unsafe { mem::transmute(3u8) }, [false]);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               ╾ALLOC$ID╼                         │ ╾──────╼
+               ╾ALLOC$ID╼ │ ╾─╼
            }
 
 note: erroneous constant encountered
-  --> $DIR/ub-wide-ptr.rs:92:42
+  --> $DIR/ub-wide-ptr.rs:93:42
    |
 LL | const MYSLICE_PREFIX_BAD: &MySliceBool = &MySlice(unsafe { mem::transmute(3u8) }, [false]);
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0080]: constructing invalid value of type &MySlice<[bool; 1]>: at .<deref>.1[0], encountered 0x03, but expected a boolean
-  --> $DIR/ub-wide-ptr.rs:95:1
+  --> $DIR/ub-wide-ptr.rs:96:1
    |
 LL | const MYSLICE_SUFFIX_BAD: &MySliceBool = &MySlice(true, [unsafe { mem::transmute(3u8) }]);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               ╾ALLOC$ID╼                         │ ╾──────╼
+               ╾ALLOC$ID╼ │ ╾─╼
            }
 
 note: erroneous constant encountered
-  --> $DIR/ub-wide-ptr.rs:95:42
+  --> $DIR/ub-wide-ptr.rs:96:42
    |
 LL | const MYSLICE_SUFFIX_BAD: &MySliceBool = &MySlice(true, [unsafe { mem::transmute(3u8) }]);
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0080]: reading memory at ALLOC$ID[0x%..0x%], but memory is uninitialized at [0x%..0x%], and this operation requires initialized memory
-  --> $DIR/ub-wide-ptr.rs:102:1
+  --> $DIR/ub-wide-ptr.rs:103:1
    |
 LL | const RAW_SLICE_LENGTH_UNINIT: *const [u8] = unsafe {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `RAW_SLICE_LENGTH_UNINIT` failed here
@@ -194,29 +194,29 @@ LL | const RAW_SLICE_LENGTH_UNINIT: *const [u8] = unsafe {
            }
 
 error[E0080]: constructing invalid value of type W<&dyn Trait>: at .0, encountered ALLOC$ID<imm>, but expected a vtable pointer
-  --> $DIR/ub-wide-ptr.rs:110:1
+  --> $DIR/ub-wide-ptr.rs:111:1
    |
 LL | const TRAIT_OBJ_SHORT_VTABLE_1: W<&dyn Trait> = unsafe { mem::transmute(W((&92u8, &3u8))) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               ╾ALLOC$ID╼ ╾ALLOC$ID╼ │ ╾──────╼╾──────╼
+               ╾ALLOC$ID╼ ╾ALLOC$ID╼ │ ╾─╼
            }
 
 error[E0080]: constructing invalid value of type W<&dyn Trait>: at .0, encountered ALLOC$ID<imm>, but expected a vtable pointer
-  --> $DIR/ub-wide-ptr.rs:113:1
+  --> $DIR/ub-wide-ptr.rs:114:1
    |
 LL | const TRAIT_OBJ_SHORT_VTABLE_2: W<&dyn Trait> = unsafe { mem::transmute(W((&92u8, &3u64))) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               ╾ALLOC$ID╼ ╾ALLOC$ID╼ │ ╾──────╼╾──────╼
+               ╾ALLOC$ID╼ ╾ALLOC$ID╼ │ ╾─╼
            }
 
 error[E0080]: constructing invalid value of type W<&dyn Trait>: at .0, encountered 0x4[noalloc], but expected a vtable pointer
-  --> $DIR/ub-wide-ptr.rs:116:1
+  --> $DIR/ub-wide-ptr.rs:117:1
    |
 LL | const TRAIT_OBJ_INT_VTABLE: W<&dyn Trait> = unsafe { mem::transmute(W((&92u8, 4usize))) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
@@ -227,62 +227,62 @@ LL | const TRAIT_OBJ_INT_VTABLE: W<&dyn Trait> = unsafe { mem::transmute(W((&92u
            }
 
 error[E0080]: constructing invalid value of type &dyn Trait: encountered ALLOC$ID<imm>, but expected a vtable pointer
-  --> $DIR/ub-wide-ptr.rs:118:1
+  --> $DIR/ub-wide-ptr.rs:119:1
    |
 LL | const TRAIT_OBJ_UNALIGNED_VTABLE: &dyn Trait = unsafe { mem::transmute((&92u8, &[0u8; 128])) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               ╾ALLOC$ID╼ ╾ALLOC$ID╼ │ ╾──────╼╾──────╼
+               ╾ALLOC$ID╼ ╾ALLOC$ID╼ │ ╾─╼
            }
 
 error[E0080]: constructing invalid value of type &dyn Trait: encountered ALLOC$ID<imm>, but expected a vtable pointer
-  --> $DIR/ub-wide-ptr.rs:120:1
+  --> $DIR/ub-wide-ptr.rs:121:1
    |
 LL | const TRAIT_OBJ_BAD_DROP_FN_NULL: &dyn Trait = unsafe { mem::transmute((&92u8, &[0usize; 8])) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               ╾ALLOC$ID╼ ╾ALLOC$ID╼ │ ╾──────╼╾──────╼
+               ╾ALLOC$ID╼ ╾ALLOC$ID╼ │ ╾─╼
            }
 
 error[E0080]: constructing invalid value of type &dyn Trait: encountered ALLOC$ID<imm>, but expected a vtable pointer
-  --> $DIR/ub-wide-ptr.rs:122:1
+  --> $DIR/ub-wide-ptr.rs:123:1
    |
 LL | const TRAIT_OBJ_BAD_DROP_FN_INT: &dyn Trait = unsafe { mem::transmute((&92u8, &[1usize; 8])) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               ╾ALLOC$ID╼ ╾ALLOC$ID╼ │ ╾──────╼╾──────╼
+               ╾ALLOC$ID╼ ╾ALLOC$ID╼ │ ╾─╼
            }
 
 error[E0080]: constructing invalid value of type W<&dyn Trait>: at .0, encountered ALLOC$ID<imm>, but expected a vtable pointer
-  --> $DIR/ub-wide-ptr.rs:124:1
+  --> $DIR/ub-wide-ptr.rs:125:1
    |
 LL | const TRAIT_OBJ_BAD_DROP_FN_NOT_FN_PTR: W<&dyn Trait> = unsafe { mem::transmute(W((&92u8, &[&42u8; 8]))) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               ╾ALLOC$ID╼ ╾ALLOC$ID╼ │ ╾──────╼╾──────╼
+               ╾ALLOC$ID╼ ╾ALLOC$ID╼ │ ╾─╼
            }
 
 error[E0080]: constructing invalid value of type &dyn Trait: at .<deref>.<dyn-downcast(bool)>, encountered 0x03, but expected a boolean
-  --> $DIR/ub-wide-ptr.rs:128:1
+  --> $DIR/ub-wide-ptr.rs:129:1
    |
 LL | const TRAIT_OBJ_CONTENT_INVALID: &dyn Trait = unsafe { mem::transmute::<_, &bool>(&3u8) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               ╾ALLOC$ID╼ ╾ALLOC$ID╼ │ ╾──────╼╾──────╼
+               ╾ALLOC$ID╼ ╾ALLOC$ID╼ │ ╾─╼
            }
 
 error[E0080]: constructing invalid value of type *const dyn Trait: encountered null pointer, but expected a vtable pointer
-  --> $DIR/ub-wide-ptr.rs:132:1
+  --> $DIR/ub-wide-ptr.rs:133:1
    |
 LL | const RAW_TRAIT_OBJ_VTABLE_NULL: *const dyn Trait = unsafe { mem::transmute((&92u8, 0usize)) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
@@ -293,14 +293,14 @@ LL | const RAW_TRAIT_OBJ_VTABLE_NULL: *const dyn Trait = unsafe { mem::transmute
            }
 
 error[E0080]: constructing invalid value of type *const dyn Trait: encountered ALLOC$ID<imm>, but expected a vtable pointer
-  --> $DIR/ub-wide-ptr.rs:134:1
+  --> $DIR/ub-wide-ptr.rs:135:1
    |
 LL | const RAW_TRAIT_OBJ_VTABLE_INVALID: *const dyn Trait = unsafe { mem::transmute((&92u8, &3u64)) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               ╾ALLOC$ID╼ ╾ALLOC$ID╼ │ ╾──────╼╾──────╼
+               ╾ALLOC$ID╼ ╾ALLOC$ID╼ │ ╾─╼
            }
 
 error[E0080]: constructing invalid value of type *const dyn Trait: encountered null pointer, but expected a vtable pointer
@@ -322,7 +322,7 @@ LL | static mut RAW_TRAIT_OBJ_VTABLE_INVALID_THROUGH_REF: *const dyn Trait = uns
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               ╾ALLOC$ID╼ ╾ALLOC$ID╼ │ ╾──────╼╾──────╼
+               ╾ALLOC$ID╼ ╾ALLOC$ID╼ │ ╾─╼
            }
 
 error: aborting due to 29 previous errors

--- a/tests/ui/consts/const-eval/union-const-eval-field.rs
+++ b/tests/ui/consts/const-eval/union-const-eval-field.rs
@@ -1,7 +1,7 @@
 //@ dont-require-annotations: NOTE
 //@ normalize-stderr: "(the raw bytes of the constant) \(size: [0-9]*, align: [0-9]*\)" -> "$1 (size: $$SIZE, align: $$ALIGN)"
 //@ normalize-stderr: "([[:xdigit:]]{2}\s){4}(__\s){4}\s+│\s+([?|\.]){4}\W{4}" -> "HEX_DUMP"
-//@ ignore-parallel-frontend different alloc ids
+
 type Field1 = i32;
 type Field2 = f32;
 type Field3 = i64;

--- a/tests/ui/consts/const-eval/union-const-eval-field.stderr
+++ b/tests/ui/consts/const-eval/union-const-eval-field.stderr
@@ -1,4 +1,4 @@
-error[E0080]: reading memory at ALLOC0[0x0..0x8], but memory is uninitialized at [0x4..0x8], and this operation requires initialized memory
+error[E0080]: reading memory at ALLOC$ID[0x0..0x8], but memory is uninitialized at [0x4..0x8], and this operation requires initialized memory
   --> $DIR/union-const-eval-field.rs:30:37
    |
 LL |     const FIELD3: Field3 = unsafe { UNION.field3 };

--- a/tests/ui/consts/const-eval/union-ice.rs
+++ b/tests/ui/consts/const-eval/union-ice.rs
@@ -1,5 +1,5 @@
 //@ only-x86_64
-//@ ignore-parallel-frontend different alloc ids
+
 type Field1 = i32;
 type Field3 = i64;
 

--- a/tests/ui/consts/const-eval/union-ice.stderr
+++ b/tests/ui/consts/const-eval/union-ice.stderr
@@ -1,4 +1,4 @@
-error[E0080]: reading memory at ALLOC0[0x0..0x8], but memory is uninitialized at [0x4..0x8], and this operation requires initialized memory
+error[E0080]: reading memory at ALLOC$ID[0x0..0x8], but memory is uninitialized at [0x4..0x8], and this operation requires initialized memory
   --> $DIR/union-ice.rs:14:33
    |
 LL | const FIELD3: Field3 = unsafe { UNION.field3 };
@@ -8,7 +8,7 @@ LL | const FIELD3: Field3 = unsafe { UNION.field3 };
                00 00 80 3f __ __ __ __                         │ ...?░░░░
            }
 
-error[E0080]: reading memory at ALLOC1[0x0..0x8], but memory is uninitialized at [0x4..0x8], and this operation requires initialized memory
+error[E0080]: reading memory at ALLOC$ID[0x0..0x8], but memory is uninitialized at [0x4..0x8], and this operation requires initialized memory
   --> $DIR/union-ice.rs:19:17
    |
 LL |     b: unsafe { UNION.field3 },
@@ -18,7 +18,7 @@ LL |     b: unsafe { UNION.field3 },
                00 00 80 3f __ __ __ __                         │ ...?░░░░
            }
 
-error[E0080]: reading memory at ALLOC2[0x0..0x8], but memory is uninitialized at [0x4..0x8], and this operation requires initialized memory
+error[E0080]: reading memory at ALLOC$ID[0x0..0x8], but memory is uninitialized at [0x4..0x8], and this operation requires initialized memory
   --> $DIR/union-ice.rs:31:18
    |
 LL |         unsafe { UNION.field3 },

--- a/tests/ui/consts/const-eval/union-ub.32bit.stderr
+++ b/tests/ui/consts/const-eval/union-ub.32bit.stderr
@@ -9,7 +9,7 @@ LL | const BAD_BOOL: bool = unsafe { DummyUnion { u8: 42 }.bool };
                2a                                              │ *
            }
 
-error[E0080]: reading memory at ALLOC0[0x0..0x1], but memory is uninitialized at [0x0..0x1], and this operation requires initialized memory
+error[E0080]: reading memory at ALLOC$ID[0x0..0x1], but memory is uninitialized at [0x0..0x1], and this operation requires initialized memory
   --> $DIR/union-ub.rs:35:36
    |
 LL | const UNINIT_BOOL: bool = unsafe { DummyUnion { unit: () }.bool };

--- a/tests/ui/consts/const-eval/union-ub.64bit.stderr
+++ b/tests/ui/consts/const-eval/union-ub.64bit.stderr
@@ -9,7 +9,7 @@ LL | const BAD_BOOL: bool = unsafe { DummyUnion { u8: 42 }.bool };
                2a                                              │ *
            }
 
-error[E0080]: reading memory at ALLOC0[0x0..0x1], but memory is uninitialized at [0x0..0x1], and this operation requires initialized memory
+error[E0080]: reading memory at ALLOC$ID[0x0..0x1], but memory is uninitialized at [0x0..0x1], and this operation requires initialized memory
   --> $DIR/union-ub.rs:35:36
    |
 LL | const UNINIT_BOOL: bool = unsafe { DummyUnion { unit: () }.bool };

--- a/tests/ui/consts/const-eval/union-ub.rs
+++ b/tests/ui/consts/const-eval/union-ub.rs
@@ -1,6 +1,6 @@
 //@ stderr-per-bitwidth
 //@ dont-require-annotations: NOTE
-//@ ignore-parallel-frontend different alloc ids
+
 #[repr(C)]
 union DummyUnion {
     unit: (),

--- a/tests/ui/consts/const-mut-refs/mut_ref_in_final.rs
+++ b/tests/ui/consts/const-mut-refs/mut_ref_in_final.rs
@@ -1,6 +1,7 @@
 //@ normalize-stderr: "(the raw bytes of the constant) \(size: [0-9]*, align: [0-9]*\)" -> "$1 (size: $$SIZE, align: $$ALIGN)"
 //@ normalize-stderr: "( 0x[0-9a-f][0-9a-f] │)? ([0-9a-f][0-9a-f] |__ |╾─*ALLOC[0-9]+(\+[a-z0-9]+)?(<imm>)?─*╼ )+ *│.*" -> " HEX_DUMP"
 //@ normalize-stderr: "HEX_DUMP\s*\n\s*HEX_DUMP" -> "HEX_DUMP"
+//@ normalize-stderr: "╾ALLOC\$ID╼\s+│.*╾.*╼" -> "╾ALLOC$$ID╼ │ ╾─╼"
 //@ dont-require-annotations: NOTE
 
 use std::cell::UnsafeCell;

--- a/tests/ui/consts/const-mut-refs/mut_ref_in_final.stderr
+++ b/tests/ui/consts/const-mut-refs/mut_ref_in_final.stderr
@@ -36,7 +36,7 @@ LL | const IMMUT_MUT_REF: &mut u16 = unsafe { mem::transmute(&13) };
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
+               ╾ALLOC$ID╼                         │ ╾──────╼
            }
 
 error[E0080]: constructing invalid value of type &mut u16: encountered mutable reference or box pointing to read-only memory
@@ -47,7 +47,7 @@ LL | static IMMUT_MUT_REF_STATIC: &mut u16 = unsafe { mem::transmute(&13) };
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
+               ╾ALLOC$ID╼                         │ ╾──────╼
            }
 
 error[E0716]: temporary value dropped while borrowed
@@ -150,7 +150,7 @@ LL |     const DANGLING: Option<&mut i32> = helper_dangling();
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
+               ╾ALLOC$ID╼                         │ ╾──────╼
            }
 
 error[E0080]: constructing invalid value of type Option<&mut i32>: at .<enum-variant(Some)>.0, encountered a dangling reference (use-after-free)
@@ -161,7 +161,7 @@ LL |     static DANGLING_STATIC: Option<&mut i32> = helper_dangling();
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
+               ╾ALLOC$ID╼                         │ ╾──────╼
            }
 
 error: aborting due to 16 previous errors

--- a/tests/ui/consts/const-mut-refs/mut_ref_in_final.stderr
+++ b/tests/ui/consts/const-mut-refs/mut_ref_in_final.stderr
@@ -1,5 +1,5 @@
 error[E0764]: mutable borrows of temporaries that have their lifetime extended until the end of the program are not allowed
-  --> $DIR/mut_ref_in_final.rs:15:21
+  --> $DIR/mut_ref_in_final.rs:16:21
    |
 LL | const B: *mut i32 = &mut 4;
    |                     ^^^^^^ this mutable borrow refers to such a temporary
@@ -9,7 +9,7 @@ LL | const B: *mut i32 = &mut 4;
    = help: if you really want global mutable state, try replacing the temporary by an interior mutable `static` or a `static mut`
 
 error[E0764]: mutable borrows of temporaries that have their lifetime extended until the end of the program are not allowed
-  --> $DIR/mut_ref_in_final.rs:21:35
+  --> $DIR/mut_ref_in_final.rs:22:35
    |
 LL | const B3: Option<&mut i32> = Some(&mut 42);
    |                                   ^^^^^^^ this mutable borrow refers to such a temporary
@@ -19,7 +19,7 @@ LL | const B3: Option<&mut i32> = Some(&mut 42);
    = help: if you really want global mutable state, try replacing the temporary by an interior mutable `static` or a `static mut`
 
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/mut_ref_in_final.rs:24:42
+  --> $DIR/mut_ref_in_final.rs:25:42
    |
 LL | const B4: Option<&mut i32> = helper(&mut 42);
    |                              ------------^^-
@@ -29,29 +29,29 @@ LL | const B4: Option<&mut i32> = helper(&mut 42);
    |                              using this value as a constant requires that borrow lasts for `'static`
 
 error[E0080]: constructing invalid value of type &mut u16: encountered mutable reference or box pointing to read-only memory
-  --> $DIR/mut_ref_in_final.rs:27:1
+  --> $DIR/mut_ref_in_final.rs:28:1
    |
 LL | const IMMUT_MUT_REF: &mut u16 = unsafe { mem::transmute(&13) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               ╾ALLOC$ID╼                         │ ╾──────╼
+               ╾ALLOC$ID╼ │ ╾─╼
            }
 
 error[E0080]: constructing invalid value of type &mut u16: encountered mutable reference or box pointing to read-only memory
-  --> $DIR/mut_ref_in_final.rs:29:1
+  --> $DIR/mut_ref_in_final.rs:30:1
    |
 LL | static IMMUT_MUT_REF_STATIC: &mut u16 = unsafe { mem::transmute(&13) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               ╾ALLOC$ID╼                         │ ╾──────╼
+               ╾ALLOC$ID╼ │ ╾─╼
            }
 
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/mut_ref_in_final.rs:52:65
+  --> $DIR/mut_ref_in_final.rs:53:65
    |
 LL | const FOO: NotAMutex<&mut i32> = NotAMutex(UnsafeCell::new(&mut 42));
    |                                  -------------------------------^^--
@@ -61,7 +61,7 @@ LL | const FOO: NotAMutex<&mut i32> = NotAMutex(UnsafeCell::new(&mut 42));
    |                                  using this value as a constant requires that borrow lasts for `'static`
 
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/mut_ref_in_final.rs:55:67
+  --> $DIR/mut_ref_in_final.rs:56:67
    |
 LL | static FOO2: NotAMutex<&mut i32> = NotAMutex(UnsafeCell::new(&mut 42));
    |                                    -------------------------------^^--
@@ -71,7 +71,7 @@ LL | static FOO2: NotAMutex<&mut i32> = NotAMutex(UnsafeCell::new(&mut 42));
    |                                    using this value as a static requires that borrow lasts for `'static`
 
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/mut_ref_in_final.rs:58:71
+  --> $DIR/mut_ref_in_final.rs:59:71
    |
 LL | static mut FOO3: NotAMutex<&mut i32> = NotAMutex(UnsafeCell::new(&mut 42));
    |                                        -------------------------------^^--
@@ -81,7 +81,7 @@ LL | static mut FOO3: NotAMutex<&mut i32> = NotAMutex(UnsafeCell::new(&mut 42));
    |                                        using this value as a static requires that borrow lasts for `'static`
 
 error[E0764]: mutable borrows of temporaries that have their lifetime extended until the end of the program are not allowed
-  --> $DIR/mut_ref_in_final.rs:71:53
+  --> $DIR/mut_ref_in_final.rs:72:53
    |
 LL | static RAW_MUT_CAST_S: SyncPtr<i32> = SyncPtr { x : &mut 42 as *mut _ as *const _ };
    |                                                     ^^^^^^^ this mutable borrow refers to such a temporary
@@ -91,7 +91,7 @@ LL | static RAW_MUT_CAST_S: SyncPtr<i32> = SyncPtr { x : &mut 42 as *mut _ as *c
    = help: if you really want global mutable state, try replacing the temporary by an interior mutable `static` or a `static mut`
 
 error[E0764]: mutable borrows of temporaries that have their lifetime extended until the end of the program are not allowed
-  --> $DIR/mut_ref_in_final.rs:73:54
+  --> $DIR/mut_ref_in_final.rs:74:54
    |
 LL | static RAW_MUT_COERCE_S: SyncPtr<i32> = SyncPtr { x: &mut 0 };
    |                                                      ^^^^^^ this mutable borrow refers to such a temporary
@@ -101,7 +101,7 @@ LL | static RAW_MUT_COERCE_S: SyncPtr<i32> = SyncPtr { x: &mut 0 };
    = help: if you really want global mutable state, try replacing the temporary by an interior mutable `static` or a `static mut`
 
 error[E0764]: mutable borrows of temporaries that have their lifetime extended until the end of the program are not allowed
-  --> $DIR/mut_ref_in_final.rs:75:52
+  --> $DIR/mut_ref_in_final.rs:76:52
    |
 LL | const RAW_MUT_CAST_C: SyncPtr<i32> = SyncPtr { x : &mut 42 as *mut _ as *const _ };
    |                                                    ^^^^^^^ this mutable borrow refers to such a temporary
@@ -111,7 +111,7 @@ LL | const RAW_MUT_CAST_C: SyncPtr<i32> = SyncPtr { x : &mut 42 as *mut _ as *co
    = help: if you really want global mutable state, try replacing the temporary by an interior mutable `static` or a `static mut`
 
 error[E0764]: mutable borrows of temporaries that have their lifetime extended until the end of the program are not allowed
-  --> $DIR/mut_ref_in_final.rs:77:53
+  --> $DIR/mut_ref_in_final.rs:78:53
    |
 LL | const RAW_MUT_COERCE_C: SyncPtr<i32> = SyncPtr { x: &mut 0 };
    |                                                     ^^^^^^ this mutable borrow refers to such a temporary
@@ -121,7 +121,7 @@ LL | const RAW_MUT_COERCE_C: SyncPtr<i32> = SyncPtr { x: &mut 0 };
    = help: if you really want global mutable state, try replacing the temporary by an interior mutable `static` or a `static mut`
 
 error[E0080]: constructing invalid value of type Option<&mut i32>: at .<enum-variant(Some)>.0, encountered a dangling reference (0x2a[noalloc] has no provenance)
-  --> $DIR/mut_ref_in_final.rs:86:5
+  --> $DIR/mut_ref_in_final.rs:87:5
    |
 LL |     const INT2PTR: Option<&mut i32> = helper_int2ptr();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
@@ -132,7 +132,7 @@ LL |     const INT2PTR: Option<&mut i32> = helper_int2ptr();
            }
 
 error[E0080]: constructing invalid value of type Option<&mut i32>: at .<enum-variant(Some)>.0, encountered a dangling reference (0x2a[noalloc] has no provenance)
-  --> $DIR/mut_ref_in_final.rs:87:5
+  --> $DIR/mut_ref_in_final.rs:88:5
    |
 LL |     static INT2PTR_STATIC: Option<&mut i32> = helper_int2ptr();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
@@ -143,25 +143,25 @@ LL |     static INT2PTR_STATIC: Option<&mut i32> = helper_int2ptr();
            }
 
 error[E0080]: constructing invalid value of type Option<&mut i32>: at .<enum-variant(Some)>.0, encountered a dangling reference (use-after-free)
-  --> $DIR/mut_ref_in_final.rs:93:5
+  --> $DIR/mut_ref_in_final.rs:94:5
    |
 LL |     const DANGLING: Option<&mut i32> = helper_dangling();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               ╾ALLOC$ID╼                         │ ╾──────╼
+               ╾ALLOC$ID╼ │ ╾─╼
            }
 
 error[E0080]: constructing invalid value of type Option<&mut i32>: at .<enum-variant(Some)>.0, encountered a dangling reference (use-after-free)
-  --> $DIR/mut_ref_in_final.rs:94:5
+  --> $DIR/mut_ref_in_final.rs:95:5
    |
 LL |     static DANGLING_STATIC: Option<&mut i32> = helper_dangling();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               ╾ALLOC$ID╼                         │ ╾──────╼
+               ╾ALLOC$ID╼ │ ╾─╼
            }
 
 error: aborting due to 16 previous errors

--- a/tests/ui/consts/const_refs_to_static_fail_invalid.rs
+++ b/tests/ui/consts/const_refs_to_static_fail_invalid.rs
@@ -1,5 +1,6 @@
 //@ normalize-stderr: "(the raw bytes of the constant) \(size: [0-9]*, align: [0-9]*\)" -> "$1 (size: $$SIZE, align: $$ALIGN)"
 //@ normalize-stderr: "([0-9a-f][0-9a-f] |╾─*ALLOC[0-9]+(\+[a-z0-9]+)?(<imm>)?─*╼ )+ *│.*" -> "HEX_DUMP"
+//@ normalize-stderr: "╾ALLOC\$ID╼\s+│.*╾.*╼" -> "╾ALLOC$$ID╼ │ ╾─╼"
 //@ dont-require-annotations: NOTE
 
 #![allow(static_mut_refs)]

--- a/tests/ui/consts/const_refs_to_static_fail_invalid.stderr
+++ b/tests/ui/consts/const_refs_to_static_fail_invalid.stderr
@@ -6,7 +6,7 @@ LL |     const C: &bool = unsafe { std::mem::transmute(&S) };
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
+               ╾ALLOC$ID╼                         │ ╾──────╼
            }
 
 error: constant extern_::C cannot be used as pattern

--- a/tests/ui/consts/const_refs_to_static_fail_invalid.stderr
+++ b/tests/ui/consts/const_refs_to_static_fail_invalid.stderr
@@ -1,16 +1,16 @@
 error[E0080]: constructing invalid value of type &bool: at .<deref>, encountered 0x0a, but expected a boolean
-  --> $DIR/const_refs_to_static_fail_invalid.rs:10:5
+  --> $DIR/const_refs_to_static_fail_invalid.rs:11:5
    |
 LL |     const C: &bool = unsafe { std::mem::transmute(&S) };
    |     ^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               ╾ALLOC$ID╼                         │ ╾──────╼
+               ╾ALLOC$ID╼ │ ╾─╼
            }
 
 error: constant extern_::C cannot be used as pattern
-  --> $DIR/const_refs_to_static_fail_invalid.rs:29:9
+  --> $DIR/const_refs_to_static_fail_invalid.rs:30:9
    |
 LL |         C => {}
    |         ^
@@ -18,7 +18,7 @@ LL |         C => {}
    = note: constants that reference mutable or external memory cannot be used as patterns
 
 error: constant mutable::C cannot be used as pattern
-  --> $DIR/const_refs_to_static_fail_invalid.rs:42:9
+  --> $DIR/const_refs_to_static_fail_invalid.rs:43:9
    |
 LL |         C => {}
    |         ^

--- a/tests/ui/consts/const_transmute_type_id7.rs
+++ b/tests/ui/consts/const_transmute_type_id7.rs
@@ -5,6 +5,8 @@
 //@ normalize-stderr: "\[&\(\); \d\]" -> "ARRAY"
 //@ normalize-stderr: "(the raw bytes of the constant) \(size: [0-9]*, align: [0-9]*\)" -> "$1 (size: $$SIZE, align: $$ALIGN)"
 //@ normalize-stderr: "([0-9a-f][0-9a-f] |╾─*A(LLOC)?[0-9]+(\+[a-z0-9]+)?(<imm>)?─*╼ )+ *│.*" -> "HEX_DUMP"
+//@ normalize-stderr: "(╾ALLOC\$ID╼ )+" -> "╾ALLOC$$IDs╼"
+//@ normalize-stderr: "╾[╼╾─]*╼" -> "╾─╼"
 
 #![feature(const_trait_impl, const_cmp)]
 

--- a/tests/ui/consts/const_transmute_type_id7.stderr
+++ b/tests/ui/consts/const_transmute_type_id7.stderr
@@ -6,7 +6,7 @@ LL | const A: [&(); 16 / size_of::<*const ()>()] = unsafe { transmute(TypeId::of
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
+               ╾ALLOC$ID╼ ╾ALLOC$ID╼ │ ╾──────╼╾──────╼
            }
 
 error: aborting due to 1 previous error

--- a/tests/ui/consts/const_transmute_type_id7.stderr
+++ b/tests/ui/consts/const_transmute_type_id7.stderr
@@ -1,12 +1,12 @@
 error[E0080]: constructing invalid value of type ARRAY: at [0], encountered a maybe-null reference
-  --> $DIR/const_transmute_type_id7.rs:14:1
+  --> $DIR/const_transmute_type_id7.rs:16:1
    |
 LL | const A: [&(); 16 / size_of::<*const ()>()] = unsafe { transmute(TypeId::of::<i32>()) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               ╾ALLOC$ID╼ ╾ALLOC$ID╼ │ ╾──────╼╾──────╼
+               ╾ALLOC$IDs╼│ ╾─╼
            }
 
 error: aborting due to 1 previous error

--- a/tests/ui/consts/copy-intrinsic.rs
+++ b/tests/ui/consts/copy-intrinsic.rs
@@ -1,6 +1,6 @@
 // ignore-tidy-linelength
 #![feature(core_intrinsics)]
-//@ ignore-parallel-frontend different alloc ids
+
 use std::intrinsics::{copy, copy_nonoverlapping};
 use std::mem;
 

--- a/tests/ui/consts/copy-intrinsic.stderr
+++ b/tests/ui/consts/copy-intrinsic.stderr
@@ -4,7 +4,7 @@ error[E0080]: memory access failed: attempting to access 4 bytes, but got 0x100[
 LL |     copy_nonoverlapping(0x100 as *const i32, dangle, 1);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `COPY_OOB_1` failed here
 
-error[E0080]: memory access failed: attempting to access 4 bytes, but got ALLOC0+0x28 which is at or beyond the end of the allocation of size 4 bytes
+error[E0080]: memory access failed: attempting to access 4 bytes, but got ALLOC$ID+0x28 which is at or beyond the end of the allocation of size 4 bytes
   --> $DIR/copy-intrinsic.rs:28:5
    |
 LL |     copy_nonoverlapping(dangle, 0x100 as *mut i32, 1);

--- a/tests/ui/consts/dangling-alloc-id-ice.rs
+++ b/tests/ui/consts/dangling-alloc-id-ice.rs
@@ -3,6 +3,7 @@
 //@ normalize-stderr: "(the raw bytes of the constant) \(size: [0-9]*, align: [0-9]*\)" -> "$1 (size: $$SIZE, align: $$ALIGN)"
 //@ normalize-stderr: "([0-9a-f][0-9a-f] |╾─*A(LLOC)?[0-9]+(\+[a-z0-9]+)?(<imm>)?─*╼ )+ *│.*" -> "HEX_DUMP"
 //@ normalize-stderr: "HEX_DUMP\s*\n\s*HEX_DUMP" -> "HEX_DUMP"
+//@ normalize-stderr: "╾ALLOC\$ID╼\s+│.*╾.*╼" -> "╾ALLOC$$ID╼ │ ╾─╼"
 
 union Foo<'a> {
     y: &'a (),

--- a/tests/ui/consts/dangling-alloc-id-ice.stderr
+++ b/tests/ui/consts/dangling-alloc-id-ice.stderr
@@ -6,7 +6,7 @@ LL | const FOO: &() = {
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
+               ╾ALLOC$ID╼                         │ ╾──────╼
            }
 
 error: aborting due to 1 previous error

--- a/tests/ui/consts/dangling-alloc-id-ice.stderr
+++ b/tests/ui/consts/dangling-alloc-id-ice.stderr
@@ -1,12 +1,12 @@
 error[E0080]: constructing invalid value of type &(): encountered a dangling reference (use-after-free)
-  --> $DIR/dangling-alloc-id-ice.rs:12:1
+  --> $DIR/dangling-alloc-id-ice.rs:13:1
    |
 LL | const FOO: &() = {
    | ^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               ╾ALLOC$ID╼                         │ ╾──────╼
+               ╾ALLOC$ID╼ │ ╾─╼
            }
 
 error: aborting due to 1 previous error

--- a/tests/ui/consts/dangling-zst-ice-issue-126393.rs
+++ b/tests/ui/consts/dangling-zst-ice-issue-126393.rs
@@ -2,6 +2,7 @@
 //@ normalize-stderr: "(the raw bytes of the constant) \(size: [0-9]*, align: [0-9]*\)" -> "$1 (size: $$SIZE, align: $$ALIGN)"
 //@ normalize-stderr: "([0-9a-f][0-9a-f] |╾─*A(LLOC)?[0-9]+(\+[a-z0-9]+)?(<imm>)?─*╼ )+ *│.*" -> "HEX_DUMP"
 //@ normalize-stderr: "HEX_DUMP\s*\n\s*HEX_DUMP" -> "HEX_DUMP"
+//@ normalize-stderr: "╾ALLOC\$ID╼\s+│.*╾.*╼" -> "╾ALLOC$$ID╼ │ ╾─╼"
 
 pub struct Wrapper;
 pub static MAGIC_FFI_REF: &'static Wrapper = unsafe {

--- a/tests/ui/consts/dangling-zst-ice-issue-126393.stderr
+++ b/tests/ui/consts/dangling-zst-ice-issue-126393.stderr
@@ -6,7 +6,7 @@ LL | pub static MAGIC_FFI_REF: &'static Wrapper = unsafe {
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
+               ╾ALLOC$ID╼                         │ ╾──────╼
            }
 
 error: aborting due to 1 previous error

--- a/tests/ui/consts/dangling-zst-ice-issue-126393.stderr
+++ b/tests/ui/consts/dangling-zst-ice-issue-126393.stderr
@@ -1,12 +1,12 @@
 error[E0080]: constructing invalid value of type &Wrapper: encountered a dangling reference (use-after-free)
-  --> $DIR/dangling-zst-ice-issue-126393.rs:7:1
+  --> $DIR/dangling-zst-ice-issue-126393.rs:8:1
    |
 LL | pub static MAGIC_FFI_REF: &'static Wrapper = unsafe {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               ╾ALLOC$ID╼                         │ ╾──────╼
+               ╾ALLOC$ID╼ │ ╾─╼
            }
 
 error: aborting due to 1 previous error

--- a/tests/ui/consts/interior-mut-const-via-union.32bit.stderr
+++ b/tests/ui/consts/interior-mut-const-via-union.32bit.stderr
@@ -6,7 +6,7 @@ LL | fn main() {
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 4, align: 4) {
-               ╾ALLOC0╼                                     │ ╾──╼
+               ╾ALLOC$ID╼                                     │ ╾──╼
            }
 
 note: erroneous constant encountered

--- a/tests/ui/consts/interior-mut-const-via-union.64bit.stderr
+++ b/tests/ui/consts/interior-mut-const-via-union.64bit.stderr
@@ -6,7 +6,7 @@ LL | fn main() {
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 8) {
-               ╾ALLOC0╼                         │ ╾──────╼
+               ╾ALLOC$ID╼                         │ ╾──────╼
            }
 
 note: erroneous constant encountered

--- a/tests/ui/consts/interior-mut-const-via-union.rs
+++ b/tests/ui/consts/interior-mut-const-via-union.rs
@@ -3,7 +3,7 @@
 //
 //@ build-fail
 //@ stderr-per-bitwidth
-//@ ignore-parallel-frontend different alloc ids
+
 use std::cell::Cell;
 use std::mem::ManuallyDrop;
 

--- a/tests/ui/consts/issue-63952.32bit.stderr
+++ b/tests/ui/consts/issue-63952.32bit.stderr
@@ -6,7 +6,7 @@ LL | const SLICE_WAY_TOO_LONG: &[u8] = unsafe {
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾ALLOC0<imm>╼ ff ff ff ff                         │ ╾──╼....
+               ╾ALLOC$ID╼ ff ff ff ff                         │ ╾──╼....
            }
 
 error: aborting due to 1 previous error

--- a/tests/ui/consts/issue-63952.64bit.stderr
+++ b/tests/ui/consts/issue-63952.64bit.stderr
@@ -6,7 +6,7 @@ LL | const SLICE_WAY_TOO_LONG: &[u8] = unsafe {
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾ALLOC0<imm>╼ ff ff ff ff ff ff ff ff │ ╾──────╼........
+               ╾ALLOC$ID╼ ff ff ff ff ff ff ff ff │ ╾──────╼........
            }
 
 error: aborting due to 1 previous error

--- a/tests/ui/consts/issue-63952.rs
+++ b/tests/ui/consts/issue-63952.rs
@@ -1,6 +1,6 @@
 // Regression test for #63952, shouldn't hang.
 //@ stderr-per-bitwidth
-//@ ignore-parallel-frontend different alloc ids
+
 #[repr(C)]
 #[derive(Copy, Clone)]
 struct SliceRepr {

--- a/tests/ui/consts/issue-79690.64bit.stderr
+++ b/tests/ui/consts/issue-79690.64bit.stderr
@@ -6,7 +6,7 @@ LL | const G: Fat = unsafe { Transmute { t: FOO }.u };
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾ALLOC0<imm>╼ ╾ALLOC1╼ │ ╾──────╼╾──────╼
+               ╾ALLOC$ID╼ ╾ALLOC$ID╼ │ ╾──────╼╾──────╼
            }
 
 error: aborting due to 1 previous error

--- a/tests/ui/consts/issue-79690.rs
+++ b/tests/ui/consts/issue-79690.rs
@@ -1,7 +1,7 @@
 //@ ignore-32bit
 // This test gives a different error on 32-bit architectures.
 //@ stderr-per-bitwidth
-//@ ignore-parallel-frontend different alloc ids
+
 union Transmute<T: Copy, U: Copy> {
     t: T,
     u: U,

--- a/tests/ui/consts/miri_unleashed/mutable_references.rs
+++ b/tests/ui/consts/miri_unleashed/mutable_references.rs
@@ -1,6 +1,7 @@
 //@ compile-flags: -Zunleash-the-miri-inside-of-you
 //@ normalize-stderr: "(the raw bytes of the constant) \(size: [0-9]*, align: [0-9]*\)" -> "$1 (size: $$SIZE, align: $$ALIGN)"
 //@ normalize-stderr: "([0-9a-f][0-9a-f] |╾─*ALLOC[0-9]+(\+[a-z0-9]+)?(<imm>)?─*╼ )+ *│.*" -> "HEX_DUMP"
+//@ normalize-stderr: "╾ALLOC\$ID╼\s+│.*╾.*╼" -> "╾ALLOC$$ID╼ │ ╾─╼"
 //@ dont-require-annotations: NOTE
 
 #![allow(static_mut_refs)]

--- a/tests/ui/consts/miri_unleashed/mutable_references.stderr
+++ b/tests/ui/consts/miri_unleashed/mutable_references.stderr
@@ -6,7 +6,7 @@ LL | static FOO: &&mut u32 = &&mut 42;
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
+               ╾ALLOC$ID╼                         │ ╾──────╼
            }
 
 error[E0080]: constructing invalid value of type &mut i32: encountered mutable reference or box pointing to read-only memory
@@ -17,7 +17,7 @@ LL | static OH_YES: &mut i32 = &mut 42;
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
+               ╾ALLOC$ID╼                         │ ╾──────╼
            }
 
 error: encountered mutable pointer in final value of static
@@ -40,7 +40,7 @@ LL | const BLUNT: &mut i32 = &mut 42;
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
+               ╾ALLOC$ID╼                         │ ╾──────╼
            }
 
 error[E0080]: constructing invalid value of type Meh: at .x.<deref>, encountered `UnsafeCell` in read-only memory
@@ -51,7 +51,7 @@ LL | static MEH: Meh = Meh { x: &UnsafeCell::new(42) };
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
+               ╾ALLOC$ID╼                         │ ╾──────╼
            }
 
 error[E0080]: constructing invalid value of type Meh: at .x.<deref>, encountered `UnsafeCell` in read-only memory
@@ -62,7 +62,7 @@ LL | const MUH: Meh = Meh {
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
+               ╾ALLOC$ID╼                         │ ╾──────╼
            }
 
 error[E0080]: constructing invalid value of type &dyn Sync: at .<deref>.<dyn-downcast(Synced)>.x, encountered `UnsafeCell` in read-only memory
@@ -73,7 +73,7 @@ LL | const SNEAKY: &dyn Sync = &Synced { x: UnsafeCell::new(42) };
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
+               ╾ALLOC$ID╼ ╾ALLOC$ID╼ │ ╾──────╼╾──────╼
            }
 
 error[E0080]: constructing invalid value of type &mut i32: encountered mutable reference or box pointing to read-only memory
@@ -84,7 +84,7 @@ LL | static mut MUT_TO_READONLY: &mut i32 = unsafe { &mut *(&READONLY as *const 
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
+               ╾ALLOC$ID╼                         │ ╾──────╼
            }
 
 error[E0080]: constant accesses mutable global memory

--- a/tests/ui/consts/miri_unleashed/mutable_references.stderr
+++ b/tests/ui/consts/miri_unleashed/mutable_references.stderr
@@ -1,124 +1,124 @@
 error[E0080]: constructing invalid value of type &&mut u32: at .<deref>, encountered mutable reference or box pointing to read-only memory
-  --> $DIR/mutable_references.rs:13:1
+  --> $DIR/mutable_references.rs:14:1
    |
 LL | static FOO: &&mut u32 = &&mut 42;
    | ^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               ╾ALLOC$ID╼                         │ ╾──────╼
+               ╾ALLOC$ID╼ │ ╾─╼
            }
 
 error[E0080]: constructing invalid value of type &mut i32: encountered mutable reference or box pointing to read-only memory
-  --> $DIR/mutable_references.rs:15:1
+  --> $DIR/mutable_references.rs:16:1
    |
 LL | static OH_YES: &mut i32 = &mut 42;
    | ^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               ╾ALLOC$ID╼                         │ ╾──────╼
+               ╾ALLOC$ID╼ │ ╾─╼
            }
 
 error: encountered mutable pointer in final value of static
-  --> $DIR/mutable_references.rs:17:1
+  --> $DIR/mutable_references.rs:18:1
    |
 LL | static BAR: &mut () = &mut ();
    | ^^^^^^^^^^^^^^^^^^^
 
 error: encountered mutable pointer in final value of static
-  --> $DIR/mutable_references.rs:22:1
+  --> $DIR/mutable_references.rs:23:1
    |
 LL | static BOO: &mut Foo<()> = &mut Foo(());
    | ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0080]: constructing invalid value of type &mut i32: encountered mutable reference or box pointing to read-only memory
-  --> $DIR/mutable_references.rs:25:1
+  --> $DIR/mutable_references.rs:26:1
    |
 LL | const BLUNT: &mut i32 = &mut 42;
    | ^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               ╾ALLOC$ID╼                         │ ╾──────╼
+               ╾ALLOC$ID╼ │ ╾─╼
            }
 
 error[E0080]: constructing invalid value of type Meh: at .x.<deref>, encountered `UnsafeCell` in read-only memory
-  --> $DIR/mutable_references.rs:40:1
+  --> $DIR/mutable_references.rs:41:1
    |
 LL | static MEH: Meh = Meh { x: &UnsafeCell::new(42) };
    | ^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               ╾ALLOC$ID╼                         │ ╾──────╼
+               ╾ALLOC$ID╼ │ ╾─╼
            }
 
 error[E0080]: constructing invalid value of type Meh: at .x.<deref>, encountered `UnsafeCell` in read-only memory
-  --> $DIR/mutable_references.rs:45:1
+  --> $DIR/mutable_references.rs:46:1
    |
 LL | const MUH: Meh = Meh {
    | ^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               ╾ALLOC$ID╼                         │ ╾──────╼
+               ╾ALLOC$ID╼ │ ╾─╼
            }
 
 error[E0080]: constructing invalid value of type &dyn Sync: at .<deref>.<dyn-downcast(Synced)>.x, encountered `UnsafeCell` in read-only memory
-  --> $DIR/mutable_references.rs:56:1
+  --> $DIR/mutable_references.rs:57:1
    |
 LL | const SNEAKY: &dyn Sync = &Synced { x: UnsafeCell::new(42) };
    | ^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               ╾ALLOC$ID╼ ╾ALLOC$ID╼ │ ╾──────╼╾──────╼
+               ╾ALLOC$ID╼ ╾ALLOC$ID╼ │ ╾─╼
            }
 
 error[E0080]: constructing invalid value of type &mut i32: encountered mutable reference or box pointing to read-only memory
-  --> $DIR/mutable_references.rs:62:1
+  --> $DIR/mutable_references.rs:63:1
    |
 LL | static mut MUT_TO_READONLY: &mut i32 = unsafe { &mut *(&READONLY as *const _ as *mut _) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               ╾ALLOC$ID╼                         │ ╾──────╼
+               ╾ALLOC$ID╼ │ ╾─╼
            }
 
 error[E0080]: constant accesses mutable global memory
-  --> $DIR/mutable_references.rs:73:43
+  --> $DIR/mutable_references.rs:74:43
    |
 LL | const POINTS_TO_MUTABLE2: &i32 = unsafe { &*MUTABLE_REF };
    |                                           ^^^^^^^^^^^^^ evaluation of `POINTS_TO_MUTABLE2` failed here
 
 error: encountered mutable pointer in final value of constant
-  --> $DIR/mutable_references.rs:76:1
+  --> $DIR/mutable_references.rs:77:1
    |
 LL | const POINTS_TO_MUTABLE_INNER: *const i32 = &mut 42 as *mut _ as *const _;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: encountered mutable pointer in final value of constant
-  --> $DIR/mutable_references.rs:79:1
+  --> $DIR/mutable_references.rs:80:1
    |
 LL | const POINTS_TO_MUTABLE_INNER2: *const i32 = &mut 42 as *const _;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: encountered mutable pointer in final value of constant
-  --> $DIR/mutable_references.rs:99:1
+  --> $DIR/mutable_references.rs:100:1
    |
 LL | const RAW_MUT_CAST: SyncPtr<i32> = SyncPtr { x: &mut 42 as *mut _ as *const _ };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: encountered mutable pointer in final value of constant
-  --> $DIR/mutable_references.rs:102:1
+  --> $DIR/mutable_references.rs:103:1
    |
 LL | const RAW_MUT_COERCE: SyncPtr<i32> = SyncPtr { x: &mut 0 };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0594]: cannot assign to `*OH_YES`, as `OH_YES` is an immutable static item
-  --> $DIR/mutable_references.rs:109:5
+  --> $DIR/mutable_references.rs:110:5
    |
 LL | static OH_YES: &mut i32 = &mut 42;
    | ----------------------- this `static` cannot be written to
@@ -129,72 +129,72 @@ LL |     *OH_YES = 99;
 warning: skipping const checks
    |
 help: skipping check that does not even have a feature gate
-  --> $DIR/mutable_references.rs:13:26
+  --> $DIR/mutable_references.rs:14:26
    |
 LL | static FOO: &&mut u32 = &&mut 42;
    |                          ^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/mutable_references.rs:15:27
+  --> $DIR/mutable_references.rs:16:27
    |
 LL | static OH_YES: &mut i32 = &mut 42;
    |                           ^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/mutable_references.rs:17:23
+  --> $DIR/mutable_references.rs:18:23
    |
 LL | static BAR: &mut () = &mut ();
    |                       ^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/mutable_references.rs:22:28
+  --> $DIR/mutable_references.rs:23:28
    |
 LL | static BOO: &mut Foo<()> = &mut Foo(());
    |                            ^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/mutable_references.rs:25:25
+  --> $DIR/mutable_references.rs:26:25
    |
 LL | const BLUNT: &mut i32 = &mut 42;
    |                         ^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/mutable_references.rs:40:28
+  --> $DIR/mutable_references.rs:41:28
    |
 LL | static MEH: Meh = Meh { x: &UnsafeCell::new(42) };
    |                            ^^^^^^^^^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/mutable_references.rs:47:8
+  --> $DIR/mutable_references.rs:48:8
    |
 LL |     x: &UnsafeCell::new(42),
    |        ^^^^^^^^^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/mutable_references.rs:56:27
+  --> $DIR/mutable_references.rs:57:27
    |
 LL | const SNEAKY: &dyn Sync = &Synced { x: UnsafeCell::new(42) };
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/mutable_references.rs:76:45
+  --> $DIR/mutable_references.rs:77:45
    |
 LL | const POINTS_TO_MUTABLE_INNER: *const i32 = &mut 42 as *mut _ as *const _;
    |                                             ^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/mutable_references.rs:79:46
+  --> $DIR/mutable_references.rs:80:46
    |
 LL | const POINTS_TO_MUTABLE_INNER2: *const i32 = &mut 42 as *const _;
    |                                              ^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/mutable_references.rs:84:47
+  --> $DIR/mutable_references.rs:85:47
    |
 LL | const INTERIOR_MUTABLE_BEHIND_RAW: *mut i32 = &UnsafeCell::new(42) as *const _ as *mut _;
    |                                               ^^^^^^^^^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/mutable_references.rs:96:51
+  --> $DIR/mutable_references.rs:97:51
    |
 LL | const RAW_SYNC: SyncPtr<AtomicI32> = SyncPtr { x: &AtomicI32::new(42) };
    |                                                   ^^^^^^^^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/mutable_references.rs:99:49
+  --> $DIR/mutable_references.rs:100:49
    |
 LL | const RAW_MUT_CAST: SyncPtr<i32> = SyncPtr { x: &mut 42 as *mut _ as *const _ };
    |                                                 ^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/mutable_references.rs:102:51
+  --> $DIR/mutable_references.rs:103:51
    |
 LL | const RAW_MUT_COERCE: SyncPtr<i32> = SyncPtr { x: &mut 0 };
    |                                                   ^^^^^^

--- a/tests/ui/consts/miri_unleashed/static-no-inner-mut.32bit.stderr
+++ b/tests/ui/consts/miri_unleashed/static-no-inner-mut.32bit.stderr
@@ -6,7 +6,7 @@ LL | static REF: &AtomicI32 = &AtomicI32::new(42);
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 4, align: 4) {
-               ╾ALLOC0╼                                     │ ╾──╼
+               ╾ALLOC$ID╼                                     │ ╾──╼
            }
 
 error[E0080]: constructing invalid value of type &mut i32: encountered mutable reference or box pointing to read-only memory
@@ -17,7 +17,7 @@ LL | static REFMUT: &mut i32 = &mut 0;
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 4, align: 4) {
-               ╾ALLOC1╼                                     │ ╾──╼
+               ╾ALLOC$ID╼                                     │ ╾──╼
            }
 
 error[E0080]: constructing invalid value of type &Atomic<i32>: at .<deref>.v, encountered `UnsafeCell` in read-only memory
@@ -28,7 +28,7 @@ LL | static REF2: &AtomicI32 = {let x = AtomicI32::new(42); &{x}};
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 4, align: 4) {
-               ╾ALLOC2╼                                     │ ╾──╼
+               ╾ALLOC$ID╼                                     │ ╾──╼
            }
 
 error[E0080]: constructing invalid value of type &mut i32: encountered mutable reference or box pointing to read-only memory
@@ -39,7 +39,7 @@ LL | static REFMUT2: &mut i32 = {let mut x = 0; &mut {x}};
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 4, align: 4) {
-               ╾ALLOC3╼                                     │ ╾──╼
+               ╾ALLOC$ID╼                                     │ ╾──╼
            }
 
 error: encountered mutable pointer in final value of static

--- a/tests/ui/consts/miri_unleashed/static-no-inner-mut.64bit.stderr
+++ b/tests/ui/consts/miri_unleashed/static-no-inner-mut.64bit.stderr
@@ -6,7 +6,7 @@ LL | static REF: &AtomicI32 = &AtomicI32::new(42);
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 8) {
-               ╾ALLOC0╼                         │ ╾──────╼
+               ╾ALLOC$ID╼                         │ ╾──────╼
            }
 
 error[E0080]: constructing invalid value of type &mut i32: encountered mutable reference or box pointing to read-only memory
@@ -17,7 +17,7 @@ LL | static REFMUT: &mut i32 = &mut 0;
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 8) {
-               ╾ALLOC1╼                         │ ╾──────╼
+               ╾ALLOC$ID╼                         │ ╾──────╼
            }
 
 error[E0080]: constructing invalid value of type &Atomic<i32>: at .<deref>.v, encountered `UnsafeCell` in read-only memory
@@ -28,7 +28,7 @@ LL | static REF2: &AtomicI32 = {let x = AtomicI32::new(42); &{x}};
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 8) {
-               ╾ALLOC2╼                         │ ╾──────╼
+               ╾ALLOC$ID╼                         │ ╾──────╼
            }
 
 error[E0080]: constructing invalid value of type &mut i32: encountered mutable reference or box pointing to read-only memory
@@ -39,7 +39,7 @@ LL | static REFMUT2: &mut i32 = {let mut x = 0; &mut {x}};
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 8) {
-               ╾ALLOC3╼                         │ ╾──────╼
+               ╾ALLOC$ID╼                         │ ╾──────╼
            }
 
 error: encountered mutable pointer in final value of static

--- a/tests/ui/consts/miri_unleashed/static-no-inner-mut.rs
+++ b/tests/ui/consts/miri_unleashed/static-no-inner-mut.rs
@@ -1,6 +1,6 @@
 //@ stderr-per-bitwidth
 //@ compile-flags: -Zunleash-the-miri-inside-of-you
-//@ ignore-parallel-frontend different alloc ids
+
 // All "inner" allocations that come with a `static` are interned immutably. This means it is
 // crucial that we do not accept any form of (interior) mutability there.
 use std::sync::atomic::*;

--- a/tests/ui/consts/missing_span_in_backtrace.rs
+++ b/tests/ui/consts/missing_span_in_backtrace.rs
@@ -1,7 +1,7 @@
 //! Check what happens when the error occurs inside a std function that we can't print the span of.
 //@ ignore-backends: gcc
 //@ compile-flags: -Z ui-testing=no --diagnostic-width=80
-//@ ignore-parallel-frontend different alloc ids
+
 use std::{
     mem::{self, MaybeUninit},
     ptr,

--- a/tests/ui/consts/missing_span_in_backtrace.stderr
+++ b/tests/ui/consts/missing_span_in_backtrace.stderr
@@ -1,4 +1,4 @@
-error[E0080]: memory access failed: attempting to access 1 byte, but got ALLOC0+0x4 which is at or beyond the end of the allocation of size 4 bytes
+error[E0080]: memory access failed: attempting to access 1 byte, but got ALLOC$ID+0x4 which is at or beyond the end of the allocation of size 4 bytes
   --> $DIR/missing_span_in_backtrace.rs:16:9
    |
 16 | / ...   ptr::swap_nonoverlapping(

--- a/tests/ui/consts/offset_ub.rs
+++ b/tests/ui/consts/offset_ub.rs
@@ -1,5 +1,5 @@
 use std::ptr;
-//@ ignore-parallel-frontend different alloc ids
+
 //@ normalize-stderr: "0xf+" -> "0xf..f"
 //@ normalize-stderr: "0x7f+" -> "0x7f..f"
 //@ normalize-stderr: "\d+ bytes" -> "$$BYTES bytes"

--- a/tests/ui/consts/offset_ub.stderr
+++ b/tests/ui/consts/offset_ub.stderr
@@ -1,16 +1,16 @@
-error[E0080]: in-bounds pointer arithmetic failed: attempting to offset pointer by -$BYTES bytes, but got ALLOC0 which is at the beginning of the allocation
+error[E0080]: in-bounds pointer arithmetic failed: attempting to offset pointer by -$BYTES bytes, but got ALLOC$ID which is at the beginning of the allocation
   --> $DIR/offset_ub.rs:8:46
    |
 LL | pub const BEFORE_START: *const u8 = unsafe { (&0u8 as *const u8).offset(-1) };
    |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `BEFORE_START` failed here
 
-error[E0080]: in-bounds pointer arithmetic failed: attempting to offset pointer by $BYTES bytes, but got ALLOC1 which is only 1 byte from the end of the allocation
+error[E0080]: in-bounds pointer arithmetic failed: attempting to offset pointer by $BYTES bytes, but got ALLOC$ID which is only 1 byte from the end of the allocation
   --> $DIR/offset_ub.rs:9:43
    |
 LL | pub const AFTER_END: *const u8 = unsafe { (&0u8 as *const u8).offset(2) };
    |                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `AFTER_END` failed here
 
-error[E0080]: in-bounds pointer arithmetic failed: attempting to offset pointer by $BYTES bytes, but got ALLOC2 which is only $BYTES bytes from the end of the allocation
+error[E0080]: in-bounds pointer arithmetic failed: attempting to offset pointer by $BYTES bytes, but got ALLOC$ID which is only $BYTES bytes from the end of the allocation
   --> $DIR/offset_ub.rs:10:45
    |
 LL | pub const AFTER_ARRAY: *const u8 = unsafe { [0u8; 100].as_ptr().offset(101) };
@@ -40,13 +40,13 @@ error[E0080]: in-bounds pointer arithmetic failed: attempting to offset pointer 
 LL | pub const UNDERFLOW_ADDRESS_SPACE: *const u8 = unsafe { (1 as *const u8).offset(-2) };
    |                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `UNDERFLOW_ADDRESS_SPACE` failed here
 
-error[E0080]: in-bounds pointer arithmetic failed: attempting to offset pointer by -$BYTES bytes, but got ALLOC3-0x2 which points to before the beginning of the allocation
+error[E0080]: in-bounds pointer arithmetic failed: attempting to offset pointer by -$BYTES bytes, but got ALLOC$ID-0x2 which points to before the beginning of the allocation
   --> $DIR/offset_ub.rs:16:49
    |
 LL | ...nst u8 = unsafe { [0u8; 1].as_ptr().wrapping_offset(-2).offset(-2) };
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `NEGATIVE_OFFSET` failed here
 
-error[E0080]: in-bounds pointer arithmetic failed: attempting to offset pointer by 1 byte, but got ALLOC4 which is at or beyond the end of the allocation of size $BYTES bytes
+error[E0080]: in-bounds pointer arithmetic failed: attempting to offset pointer by 1 byte, but got ALLOC$ID which is at or beyond the end of the allocation of size $BYTES bytes
   --> $DIR/offset_ub.rs:18:50
    |
 LL | pub const ZERO_SIZED_ALLOC: *const u8 = unsafe { [0u8; 0].as_ptr().offset(1) };

--- a/tests/ui/delegation/self-mapping-output-privacy.rs
+++ b/tests/ui/delegation/self-mapping-output-privacy.rs
@@ -1,0 +1,28 @@
+#![feature(fn_delegation)]
+
+trait Trait {
+    fn method(&self) -> Self;
+}
+
+pub struct S;
+impl Trait for S {
+    fn method(&self) -> S {
+        S
+    }
+}
+
+mod private {
+    pub struct W(super::S);
+}
+
+impl Trait for private::W {
+    reuse Trait::method { S }
+    //~^ ERROR: field `0` of struct `W` is private
+}
+
+impl private::W {
+    reuse Trait::method { S }
+    //~^ ERROR: field `0` of struct `W` is private
+}
+
+fn main() {}

--- a/tests/ui/delegation/self-mapping-output-privacy.stderr
+++ b/tests/ui/delegation/self-mapping-output-privacy.stderr
@@ -1,0 +1,15 @@
+error[E0451]: field `0` of struct `W` is private
+  --> $DIR/self-mapping-output-privacy.rs:19:18
+   |
+LL |     reuse Trait::method { S }
+   |                  ^^^^^^ private field
+
+error[E0451]: field `0` of struct `W` is private
+  --> $DIR/self-mapping-output-privacy.rs:24:18
+   |
+LL |     reuse Trait::method { S }
+   |                  ^^^^^^ private field
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0451`.

--- a/tests/ui/delegation/self-mapping-output.rs
+++ b/tests/ui/delegation/self-mapping-output.rs
@@ -1,0 +1,357 @@
+#![feature(fn_delegation)]
+
+mod success {
+    trait Trait {
+        fn method(&self) -> Self;
+        fn r#static() -> Self;
+        fn raw_S(&self) -> S { S }
+    }
+
+    struct S;
+    impl Trait for S {
+        fn method(&self) -> S { S }
+        fn r#static() -> S { S }
+    }
+
+    struct W(S);
+    impl Trait for W {
+        reuse Trait::method { self.0 }
+        reuse Trait::r#static;
+        //~^ WARN: function cannot return without recursing [unconditional_recursion]
+        reuse Trait::raw_S { self.0 }
+    }
+
+    impl W {
+        reuse Trait::method { self.0 }
+        reuse Trait::r#static;
+        reuse Trait::raw_S { self.0 }
+    }
+}
+
+mod success_non_field {
+    trait Trait {
+        fn method(&self) -> Self;
+        fn r#static() -> Self;
+        fn raw_S(&self) -> S { S }
+    }
+
+    struct S;
+    impl Trait for S {
+        fn method(&self) -> S { S }
+        fn r#static() -> S { S }
+    }
+
+    struct W(S);
+    impl Trait for W {
+        reuse Trait::method { S }
+        reuse Trait::r#static;
+        //~^ WARN: function cannot return without recursing [unconditional_recursion]
+        reuse Trait::raw_S { S }
+    }
+
+    impl W {
+        reuse Trait::method { S }
+        reuse Trait::r#static;
+        reuse Trait::raw_S { S }
+    }
+}
+
+mod success_generics {
+    trait Trait<'a, T, const N: usize> {
+        fn method(&self) -> Self;
+        fn r#static() -> Self;
+        fn raw_S(&self) -> S<'a, 'static, T, (), N, 123> {
+            S::<'a, 'static, T, (), N, 123>(std::marker::PhantomData)
+        }
+    }
+
+    struct S<'a, 'b, A, B, const N: usize, const M: usize>(
+        std::marker::PhantomData<&'a &'b (A, B, &'a [(); N], &'b [(); M])>
+    );
+
+    impl<'a, T, const N: usize> Trait<'a, T, N> for S<'a, 'static, T, (), N, 123> {
+        fn method(&self) -> S<'a, 'static, T, (), N, 123> {
+            S(std::marker::PhantomData)
+        }
+
+        fn r#static() -> S<'a, 'static, T, (), N, 123> { S(std::marker::PhantomData) }
+    }
+
+    struct W<'a, 'b, A, B, const N: usize, const M: usize>(S<'a, 'b, A, B, N, M>);
+    impl<'a, T, const N: usize> Trait<'a, T, N> for W<'a, 'static, T, (), N, 123> {
+        reuse Trait::<'a, T, N>::method { self.0 }
+        reuse Trait::<'a, T, N>::r#static;
+        //~^ WARN: function cannot return without recursing [unconditional_recursion]
+        reuse Trait::<'a, T, N>::raw_S { self.0 }
+    }
+
+    impl<'a, T, const N: usize> W<'a, 'static, T, (), N, 123> {
+        reuse Trait::<'a, T, N>::method { self.0 }
+        reuse Trait::<'a, T, N>::r#static;
+        reuse Trait::<'a, T, N>::raw_S { self.0 }
+    }
+}
+
+mod no_constructor {
+    trait Trait {
+        fn method(&self) -> Self;
+        fn r#static() -> Self;
+        fn raw_S(&self) -> S { S }
+    }
+
+    struct S;
+    impl Trait for S {
+        fn method(&self) -> S { S }
+        fn r#static() -> S { S }
+    }
+
+    struct W { s: S }
+    impl Trait for W {
+        reuse Trait::method { self.0 }
+        //~^ ERROR: no field `0` on type `&no_constructor::W`
+        //~| ERROR: struct `no_constructor::W` has no field named `0`
+        reuse Trait::r#static;
+        //~^ WARN: function cannot return without recursing [unconditional_recursion]
+        reuse Trait::raw_S { self.0 }
+        //~^ ERROR: no field `0` on type `&no_constructor::W`
+    }
+
+    impl W {
+        reuse Trait::method { self.0 }
+        //~^ ERROR: no field `0` on type `&no_constructor::W`
+        //~| ERROR: struct `no_constructor::W` has no field named `0`
+        reuse Trait::r#static;
+        reuse Trait::raw_S { self.0 }
+        //~^ ERROR: no field `0` on type `&no_constructor::W`
+    }
+}
+
+mod more_than_one_field {
+    trait Trait {
+        fn method(&self) -> Self;
+        fn r#static() -> Self;
+        fn raw_S(&self) -> S { S }
+    }
+
+    struct S;
+    impl Trait for S {
+        fn method(&self) -> S { S }
+        fn r#static() -> S { S }
+    }
+
+    struct W(S, S, S);
+    impl Trait for W {
+        reuse Trait::method { self.0 }
+        //~^ ERROR: missing fields `1` and `2` in initializer of `more_than_one_field::W`
+        reuse Trait::r#static;
+        //~^ WARN: function cannot return without recursing [unconditional_recursion]
+        reuse Trait::raw_S { self.0 }
+    }
+
+    impl W {
+        reuse Trait::method { self.0 }
+        //~^ ERROR: missing fields `1` and `2` in initializer of `more_than_one_field::W`
+        reuse Trait::r#static;
+        reuse Trait::raw_S { self.0 }
+    }
+}
+
+mod non_trait_path_reuse {
+    trait Trait {
+        fn method(&self) -> Self;
+        fn r#static() -> Self;
+        fn raw_S(&self) -> S { S }
+    }
+
+    mod to_reuse {
+        pub fn method(_: impl super::Trait) -> impl super::Trait {
+            super::S
+        }
+
+        pub fn r#static() -> impl super::Trait {
+            super::S
+        }
+    }
+
+    pub struct S;
+    impl Trait for S {
+        fn method(&self) -> S { S }
+        fn r#static() -> S { S }
+    }
+
+    struct W(S);
+    impl Trait for W {
+        reuse to_reuse::method { self.0 }
+        //~^ ERROR: mismatched types
+        reuse to_reuse::r#static;
+        //~^ ERROR: mismatched types
+    }
+
+    impl W {
+        reuse to_reuse::method { self.0 }
+        //~^ ERROR: no field `0` on type `impl super::Trait`
+        reuse to_reuse::r#static;
+    }
+}
+
+mod non_Self_return_type {
+    trait Trait {
+        fn method(&self) -> ();
+        fn r#static() -> ();
+        fn raw_S(&self) -> S { S }
+    }
+
+    struct S;
+    impl Trait for S {
+        fn method(&self) -> () { () }
+        fn r#static() -> () { () }
+        fn raw_S(&self) -> S { S }
+    }
+
+    struct W(());
+    impl Trait for W {
+        reuse Trait::method { self.0 }
+        //~^ ERROR: mismatched types
+
+        reuse Trait::r#static;
+        //~^ ERROR: type annotations needed
+
+        reuse Trait::raw_S { self.0 }
+        //~^ ERROR: mismatched types
+    }
+
+    impl W {
+        reuse Trait::method { self.0 }
+        //~^ ERROR: mismatched types
+
+        reuse Trait::r#static;
+        //~^ ERROR: type annotations needed
+
+        reuse Trait::raw_S { self.0 }
+        //~^ ERROR: mismatched types
+    }
+}
+
+mod wrong_return_type {
+    trait Trait {
+        fn method(&self) -> Self;
+        fn r#static() -> Self;
+        fn raw_S(&self) -> S { S }
+    }
+
+    struct F;
+    impl Trait for F {
+        fn method(&self) -> F { F }
+        fn r#static() -> F { F }
+    }
+
+    struct S;
+    impl Trait for S {
+        fn method(&self) -> S { S }
+        fn r#static() -> S { S }
+    }
+
+    struct W(S);
+    impl Trait for W {
+        reuse <F as Trait>::method { self.0 }
+        //~^ ERROR: mismatched types
+        //~| ERROR: mismatched types
+
+        reuse <F as Trait>::r#static;
+        //~^ ERROR: mismatched types
+
+        reuse <F as Trait>::raw_S { self.0 }
+        //~^ ERROR: mismatched types
+    }
+
+    impl W {
+        reuse <F as Trait>::method { self.0 }
+        //~^ ERROR: mismatched types
+        //~| ERROR: mismatched types
+
+        reuse <F as Trait>::r#static;
+        //~^ ERROR: mismatched types
+
+        reuse <F as Trait>::raw_S { self.0 }
+        //~^ ERROR: mismatched types
+    }
+}
+
+mod wrong_target_expression {
+    trait Trait {
+        fn method(&self) -> Self;
+        fn r#static() -> Self;
+        fn raw_S(&self) -> S { S }
+    }
+
+    struct S;
+    impl Trait for S {
+        fn method(&self) -> S { S }
+        fn r#static() -> S { S }
+    }
+
+    struct F;
+    impl Trait for F {
+        fn method(&self) -> F { F }
+        fn r#static() -> F { F }
+    }
+
+    struct W(S);
+    impl Trait for W {
+        reuse Trait::method { F }
+        //~^ ERROR: mismatched types
+
+        reuse Trait::r#static;
+        //~^ WARN: function cannot return without recursing [unconditional_recursion]
+        reuse Trait::raw_S { F }
+    }
+
+    impl W {
+        reuse Trait::method { F }
+        //~^ ERROR: mismatched types
+
+        reuse Trait::r#static;
+        reuse Trait::raw_S { F }
+    }
+}
+
+mod privacy {
+    trait Trait {
+        fn method(&self) -> Self;
+        fn r#static() -> Self;
+        fn raw_S(&self) -> S { S }
+    }
+
+    pub struct S;
+    impl Trait for S {
+        fn method(&self) -> S { S }
+        fn r#static() -> S { S }
+    }
+
+    mod private {
+        pub struct W(super::S);
+    }
+
+    impl Trait for private::W {
+        reuse Trait::method { self.0 }
+        //~^ ERROR: field `0` of struct `private::W` is private
+
+        reuse Trait::r#static;
+        //~^ WARN: function cannot return without recursing [unconditional_recursion]
+
+        reuse Trait::raw_S { self.0 }
+        //~^ ERROR: field `0` of struct `private::W` is private
+    }
+
+    impl private::W {
+        reuse Trait::method { self.0 }
+        //~^ ERROR: field `0` of struct `private::W` is private
+
+        reuse Trait::r#static;
+
+        reuse Trait::raw_S { self.0 }
+        //~^ ERROR: field `0` of struct `private::W` is private
+    }
+}
+
+fn main() {}

--- a/tests/ui/delegation/self-mapping-output.stderr
+++ b/tests/ui/delegation/self-mapping-output.stderr
@@ -1,0 +1,468 @@
+error[E0560]: struct `no_constructor::W` has no field named `0`
+  --> $DIR/self-mapping-output.rs:110:22
+   |
+LL |         reuse Trait::method { self.0 }
+   |                      ^^^^^^ unknown field
+   |
+help: a field with a similar name exists
+   |
+LL -         reuse Trait::method { self.0 }
+LL +         reuse Trait::s { self.0 }
+   |
+
+error[E0609]: no field `0` on type `&no_constructor::W`
+  --> $DIR/self-mapping-output.rs:110:36
+   |
+LL |         reuse Trait::method { self.0 }
+   |                                    ^ unknown field
+   |
+help: a field with a similar name exists
+   |
+LL -         reuse Trait::method { self.0 }
+LL +         reuse Trait::method { self.s }
+   |
+
+error[E0609]: no field `0` on type `&no_constructor::W`
+  --> $DIR/self-mapping-output.rs:115:35
+   |
+LL |         reuse Trait::raw_S { self.0 }
+   |                                   ^ unknown field
+   |
+help: a field with a similar name exists
+   |
+LL -         reuse Trait::raw_S { self.0 }
+LL +         reuse Trait::raw_S { self.s }
+   |
+
+error[E0560]: struct `no_constructor::W` has no field named `0`
+  --> $DIR/self-mapping-output.rs:120:22
+   |
+LL |         reuse Trait::method { self.0 }
+   |                      ^^^^^^ unknown field
+   |
+help: a field with a similar name exists
+   |
+LL -         reuse Trait::method { self.0 }
+LL +         reuse Trait::s { self.0 }
+   |
+
+error[E0609]: no field `0` on type `&no_constructor::W`
+  --> $DIR/self-mapping-output.rs:120:36
+   |
+LL |         reuse Trait::method { self.0 }
+   |                                    ^ unknown field
+   |
+help: a field with a similar name exists
+   |
+LL -         reuse Trait::method { self.0 }
+LL +         reuse Trait::method { self.s }
+   |
+
+error[E0609]: no field `0` on type `&no_constructor::W`
+  --> $DIR/self-mapping-output.rs:124:35
+   |
+LL |         reuse Trait::raw_S { self.0 }
+   |                                   ^ unknown field
+   |
+help: a field with a similar name exists
+   |
+LL -         reuse Trait::raw_S { self.0 }
+LL +         reuse Trait::raw_S { self.s }
+   |
+
+error[E0063]: missing fields `1` and `2` in initializer of `more_than_one_field::W`
+  --> $DIR/self-mapping-output.rs:144:22
+   |
+LL |         reuse Trait::method { self.0 }
+   |                      ^^^^^^ missing `1` and `2`
+
+error[E0063]: missing fields `1` and `2` in initializer of `more_than_one_field::W`
+  --> $DIR/self-mapping-output.rs:152:22
+   |
+LL |         reuse Trait::method { self.0 }
+   |                      ^^^^^^ missing `1` and `2`
+
+error[E0308]: mismatched types
+  --> $DIR/self-mapping-output.rs:184:25
+   |
+LL |         pub fn method(_: impl super::Trait) -> impl super::Trait {
+   |                                                ----------------- the found opaque type
+...
+LL |         reuse to_reuse::method { self.0 }
+   |                         ^^^^^^
+   |                         |
+   |                         expected `W`, found opaque type
+   |                         expected `non_trait_path_reuse::W` because of return type
+   |
+   = note:   expected struct `non_trait_path_reuse::W`
+           found opaque type `impl non_trait_path_reuse::Trait`
+
+error[E0308]: mismatched types
+  --> $DIR/self-mapping-output.rs:186:25
+   |
+LL |         pub fn r#static() -> impl super::Trait {
+   |                              ----------------- the found opaque type
+...
+LL |         reuse to_reuse::r#static;
+   |                         ^^^^^^^^
+   |                         |
+   |                         expected `W`, found opaque type
+   |                         expected `non_trait_path_reuse::W` because of return type
+   |
+   = note:   expected struct `non_trait_path_reuse::W`
+           found opaque type `impl non_trait_path_reuse::Trait`
+
+error[E0609]: no field `0` on type `impl super::Trait`
+  --> $DIR/self-mapping-output.rs:191:39
+   |
+LL |         reuse to_reuse::method { self.0 }
+   |                                       ^ unknown field
+
+error[E0308]: mismatched types
+  --> $DIR/self-mapping-output.rs:213:31
+   |
+LL |         reuse Trait::method { self.0 }
+   |                      ------   ^^^^^^ expected `&_`, found `()`
+   |                      |
+   |                      arguments to this function are incorrect
+   |
+   = note: expected reference `&_`
+              found unit type `()`
+note: method defined here
+  --> $DIR/self-mapping-output.rs:199:12
+   |
+LL |         fn method(&self) -> ();
+   |            ^^^^^^  ----
+help: consider borrowing here
+   |
+LL |         reuse Trait::method { &self.0 }
+   |                               +
+
+error[E0283]: type annotations needed
+  --> $DIR/self-mapping-output.rs:216:22
+   |
+LL |         reuse Trait::r#static;
+   |                      ^^^^^^^^ cannot infer type
+   |
+   = note: the type must implement `non_Self_return_type::Trait`
+help: the following types implement trait `non_Self_return_type::Trait`
+  --> $DIR/self-mapping-output.rs:205:5
+   |
+LL |     impl Trait for S {
+   |     ^^^^^^^^^^^^^^^^ `non_Self_return_type::S`
+...
+LL |     impl Trait for W {
+   |     ^^^^^^^^^^^^^^^^ `non_Self_return_type::W`
+
+error[E0308]: mismatched types
+  --> $DIR/self-mapping-output.rs:219:30
+   |
+LL |         reuse Trait::raw_S { self.0 }
+   |                      -----   ^^^^^^ expected `&_`, found `()`
+   |                      |
+   |                      arguments to this function are incorrect
+   |
+   = note: expected reference `&_`
+              found unit type `()`
+note: method defined here
+  --> $DIR/self-mapping-output.rs:201:12
+   |
+LL |         fn raw_S(&self) -> S { S }
+   |            ^^^^^ -----
+help: consider borrowing here
+   |
+LL |         reuse Trait::raw_S { &self.0 }
+   |                              +
+
+error[E0308]: mismatched types
+  --> $DIR/self-mapping-output.rs:224:31
+   |
+LL |         reuse Trait::method { self.0 }
+   |                      ------   ^^^^^^ expected `&_`, found `()`
+   |                      |
+   |                      arguments to this function are incorrect
+   |
+   = note: expected reference `&_`
+              found unit type `()`
+note: method defined here
+  --> $DIR/self-mapping-output.rs:199:12
+   |
+LL |         fn method(&self) -> ();
+   |            ^^^^^^  ----
+help: consider borrowing here
+   |
+LL |         reuse Trait::method { &self.0 }
+   |                               +
+
+error[E0283]: type annotations needed
+  --> $DIR/self-mapping-output.rs:227:22
+   |
+LL |         reuse Trait::r#static;
+   |                      ^^^^^^^^ cannot infer type
+   |
+   = note: the type must implement `non_Self_return_type::Trait`
+help: the following types implement trait `non_Self_return_type::Trait`
+  --> $DIR/self-mapping-output.rs:205:5
+   |
+LL |     impl Trait for S {
+   |     ^^^^^^^^^^^^^^^^ `non_Self_return_type::S`
+...
+LL |     impl Trait for W {
+   |     ^^^^^^^^^^^^^^^^ `non_Self_return_type::W`
+
+error[E0308]: mismatched types
+  --> $DIR/self-mapping-output.rs:230:30
+   |
+LL |         reuse Trait::raw_S { self.0 }
+   |                      -----   ^^^^^^ expected `&_`, found `()`
+   |                      |
+   |                      arguments to this function are incorrect
+   |
+   = note: expected reference `&_`
+              found unit type `()`
+note: method defined here
+  --> $DIR/self-mapping-output.rs:201:12
+   |
+LL |         fn raw_S(&self) -> S { S }
+   |            ^^^^^ -----
+help: consider borrowing here
+   |
+LL |         reuse Trait::raw_S { &self.0 }
+   |                              +
+
+error[E0308]: mismatched types
+  --> $DIR/self-mapping-output.rs:256:38
+   |
+LL |         reuse <F as Trait>::method { self.0 }
+   |                             ------   ^^^^^^ expected `&F`, found `&S`
+   |                             |
+   |                             arguments to this function are incorrect
+   |                             this return type influences the call expression's return type
+   |
+   = note: expected reference `&wrong_return_type::F`
+              found reference `&wrong_return_type::S`
+note: method defined here
+  --> $DIR/self-mapping-output.rs:237:12
+   |
+LL |         fn method(&self) -> Self;
+   |            ^^^^^^  ----
+
+error[E0308]: mismatched types
+  --> $DIR/self-mapping-output.rs:256:29
+   |
+LL |         reuse <F as Trait>::method { self.0 }
+   |                             ^^^^^^ expected `S`, found `F`
+
+error[E0308]: mismatched types
+  --> $DIR/self-mapping-output.rs:260:29
+   |
+LL |         reuse <F as Trait>::r#static;
+   |                             ^^^^^^^^
+   |                             |
+   |                             expected `W`, found `F`
+   |                             expected `wrong_return_type::W` because of return type
+
+error[E0308]: mismatched types
+  --> $DIR/self-mapping-output.rs:263:37
+   |
+LL |         reuse <F as Trait>::raw_S { self.0 }
+   |                             -----   ^^^^^^ expected `&F`, found `&S`
+   |                             |
+   |                             arguments to this function are incorrect
+   |
+   = note: expected reference `&wrong_return_type::F`
+              found reference `&wrong_return_type::S`
+note: method defined here
+  --> $DIR/self-mapping-output.rs:239:12
+   |
+LL |         fn raw_S(&self) -> S { S }
+   |            ^^^^^ -----
+
+error[E0308]: mismatched types
+  --> $DIR/self-mapping-output.rs:268:38
+   |
+LL |         reuse <F as Trait>::method { self.0 }
+   |                             ------   ^^^^^^ expected `&F`, found `&S`
+   |                             |
+   |                             arguments to this function are incorrect
+   |                             this return type influences the call expression's return type
+   |
+   = note: expected reference `&wrong_return_type::F`
+              found reference `&wrong_return_type::S`
+note: method defined here
+  --> $DIR/self-mapping-output.rs:237:12
+   |
+LL |         fn method(&self) -> Self;
+   |            ^^^^^^  ----
+
+error[E0308]: mismatched types
+  --> $DIR/self-mapping-output.rs:268:29
+   |
+LL |         reuse <F as Trait>::method { self.0 }
+   |                             ^^^^^^ expected `S`, found `F`
+
+error[E0308]: mismatched types
+  --> $DIR/self-mapping-output.rs:272:29
+   |
+LL |         reuse <F as Trait>::r#static;
+   |                             ^^^^^^^^
+   |                             |
+   |                             expected `W`, found `F`
+   |                             expected `wrong_return_type::W` because of return type
+
+error[E0308]: mismatched types
+  --> $DIR/self-mapping-output.rs:275:37
+   |
+LL |         reuse <F as Trait>::raw_S { self.0 }
+   |                             -----   ^^^^^^ expected `&F`, found `&S`
+   |                             |
+   |                             arguments to this function are incorrect
+   |
+   = note: expected reference `&wrong_return_type::F`
+              found reference `&wrong_return_type::S`
+note: method defined here
+  --> $DIR/self-mapping-output.rs:239:12
+   |
+LL |         fn raw_S(&self) -> S { S }
+   |            ^^^^^ -----
+
+error[E0308]: mismatched types
+  --> $DIR/self-mapping-output.rs:301:31
+   |
+LL |         reuse Trait::method { F }
+   |                      ------   ^ expected `&S`, found `&F`
+   |                      |
+   |                      arguments to this function are incorrect
+   |                      this return type influences the call expression's return type
+   |
+   = note: expected reference `&wrong_target_expression::S`
+              found reference `&wrong_target_expression::F`
+note: method defined here
+  --> $DIR/self-mapping-output.rs:282:12
+   |
+LL |         fn method(&self) -> Self;
+   |            ^^^^^^  ----
+
+error[E0308]: mismatched types
+  --> $DIR/self-mapping-output.rs:310:31
+   |
+LL |         reuse Trait::method { F }
+   |                      ------   ^ expected `&S`, found `&F`
+   |                      |
+   |                      arguments to this function are incorrect
+   |                      this return type influences the call expression's return type
+   |
+   = note: expected reference `&wrong_target_expression::S`
+              found reference `&wrong_target_expression::F`
+note: method defined here
+  --> $DIR/self-mapping-output.rs:282:12
+   |
+LL |         fn method(&self) -> Self;
+   |            ^^^^^^  ----
+
+error[E0616]: field `0` of struct `private::W` is private
+  --> $DIR/self-mapping-output.rs:336:36
+   |
+LL |         reuse Trait::method { self.0 }
+   |                                    ^ private field
+
+error[E0616]: field `0` of struct `private::W` is private
+  --> $DIR/self-mapping-output.rs:342:35
+   |
+LL |         reuse Trait::raw_S { self.0 }
+   |                                   ^ private field
+
+error[E0616]: field `0` of struct `private::W` is private
+  --> $DIR/self-mapping-output.rs:347:36
+   |
+LL |         reuse Trait::method { self.0 }
+   |                                    ^ private field
+
+error[E0616]: field `0` of struct `private::W` is private
+  --> $DIR/self-mapping-output.rs:352:35
+   |
+LL |         reuse Trait::raw_S { self.0 }
+   |                                   ^ private field
+
+warning: function cannot return without recursing
+  --> $DIR/self-mapping-output.rs:19:22
+   |
+LL |         reuse Trait::r#static;
+   |                      ^^^^^^^^
+   |                      |
+   |                      cannot return without recursing
+   |                      recursive call site
+   |
+   = help: a `loop` may express intention better if this is on purpose
+   = note: `#[warn(unconditional_recursion)]` on by default
+
+warning: function cannot return without recursing
+  --> $DIR/self-mapping-output.rs:47:22
+   |
+LL |         reuse Trait::r#static;
+   |                      ^^^^^^^^
+   |                      |
+   |                      cannot return without recursing
+   |                      recursive call site
+   |
+   = help: a `loop` may express intention better if this is on purpose
+
+warning: function cannot return without recursing
+  --> $DIR/self-mapping-output.rs:83:34
+   |
+LL |         reuse Trait::<'a, T, N>::r#static;
+   |                                  ^^^^^^^^
+   |                                  |
+   |                                  cannot return without recursing
+   |                                  recursive call site
+   |
+   = help: a `loop` may express intention better if this is on purpose
+
+warning: function cannot return without recursing
+  --> $DIR/self-mapping-output.rs:113:22
+   |
+LL |         reuse Trait::r#static;
+   |                      ^^^^^^^^
+   |                      |
+   |                      cannot return without recursing
+   |                      recursive call site
+   |
+   = help: a `loop` may express intention better if this is on purpose
+
+warning: function cannot return without recursing
+  --> $DIR/self-mapping-output.rs:146:22
+   |
+LL |         reuse Trait::r#static;
+   |                      ^^^^^^^^
+   |                      |
+   |                      cannot return without recursing
+   |                      recursive call site
+   |
+   = help: a `loop` may express intention better if this is on purpose
+
+warning: function cannot return without recursing
+  --> $DIR/self-mapping-output.rs:304:22
+   |
+LL |         reuse Trait::r#static;
+   |                      ^^^^^^^^
+   |                      |
+   |                      cannot return without recursing
+   |                      recursive call site
+   |
+   = help: a `loop` may express intention better if this is on purpose
+
+warning: function cannot return without recursing
+  --> $DIR/self-mapping-output.rs:339:22
+   |
+LL |         reuse Trait::r#static;
+   |                      ^^^^^^^^
+   |                      |
+   |                      cannot return without recursing
+   |                      recursive call site
+   |
+   = help: a `loop` may express intention better if this is on purpose
+
+error: aborting due to 31 previous errors; 7 warnings emitted
+
+Some errors have detailed explanations: E0063, E0283, E0308, E0560, E0609, E0616.
+For more information about an error, try `rustc --explain E0063`.

--- a/tests/ui/intrinsics/intrinsic-raw_eq-const-bad.rs
+++ b/tests/ui/intrinsics/intrinsic-raw_eq-const-bad.rs
@@ -1,6 +1,6 @@
 //@ normalize-stderr: "[[:xdigit:]]{2} __ ([[:xdigit:]]{2}\s){2}" -> "HEX_DUMP"
 #![feature(core_intrinsics)]
-//@ ignore-parallel-frontend different alloc ids
+
 const RAW_EQ_PADDING: bool = unsafe {
     std::intrinsics::raw_eq(&(1_u8, 2_u16), &(1_u8, 2_u16))
 //~^ ERROR requires initialized memory

--- a/tests/ui/intrinsics/intrinsic-raw_eq-const-bad.stderr
+++ b/tests/ui/intrinsics/intrinsic-raw_eq-const-bad.stderr
@@ -1,4 +1,4 @@
-error[E0080]: reading memory at ALLOC0[0x0..0x4], but memory is uninitialized at [0x1..0x2], and this operation requires initialized memory
+error[E0080]: reading memory at ALLOC$ID[0x0..0x4], but memory is uninitialized at [0x1..0x2], and this operation requires initialized memory
   --> $DIR/intrinsic-raw_eq-const-bad.rs:5:5
    |
 LL |     std::intrinsics::raw_eq(&(1_u8, 2_u16), &(1_u8, 2_u16))

--- a/tests/ui/statics/mutable_memory_validation.rs
+++ b/tests/ui/statics/mutable_memory_validation.rs
@@ -3,6 +3,7 @@
 // Strip out raw byte dumps to make comparison platform-independent:
 //@ normalize-stderr: "(the raw bytes of the constant) \(size: [0-9]*, align: [0-9]*\)" -> "$1 (size: $$SIZE, align: $$ALIGN)"
 //@ normalize-stderr: "([0-9a-f][0-9a-f] |╾─*A(LLOC)?[0-9]+(\+[a-z0-9]+)?(<imm>)?─*╼ )+ *│.*" -> "HEX_DUMP"
+//@ normalize-stderr: "╾ALLOC\$ID╼\s+│.*╾.*╼" -> "╾ALLOC$$ID╼ │ ╾─╼"
 
 use std::cell::UnsafeCell;
 

--- a/tests/ui/statics/mutable_memory_validation.stderr
+++ b/tests/ui/statics/mutable_memory_validation.stderr
@@ -6,7 +6,7 @@ LL | const MUH: Meh = Meh { x: unsafe { &mut *(&READONLY as *const _ as *mut _) 
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
+               ╾ALLOC$ID╼                         │ ╾──────╼
            }
 
 error: aborting due to 1 previous error

--- a/tests/ui/statics/mutable_memory_validation.stderr
+++ b/tests/ui/statics/mutable_memory_validation.stderr
@@ -1,12 +1,12 @@
 error[E0080]: constructing invalid value of type Meh: at .x.<deref>, encountered `UnsafeCell` in read-only memory
-  --> $DIR/mutable_memory_validation.rs:13:1
+  --> $DIR/mutable_memory_validation.rs:14:1
    |
 LL | const MUH: Meh = Meh { x: unsafe { &mut *(&READONLY as *const _ as *mut _) } };
    | ^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               ╾ALLOC$ID╼                         │ ╾──────╼
+               ╾ALLOC$ID╼ │ ╾─╼
            }
 
 error: aborting due to 1 previous error

--- a/tests/ui/std/linux-getrandom-fallback.rs
+++ b/tests/ui/std/linux-getrandom-fallback.rs
@@ -1,5 +1,6 @@
 //@ only-linux
 //@ run-pass
+//@ needs-unwind
 
 #![feature(random)]
 #![feature(rustc_private)]

--- a/tests/ui/type/pattern_types/validity.rs
+++ b/tests/ui/type/pattern_types/validity.rs
@@ -1,7 +1,7 @@
 //! Check that pattern types have their validity checked
 // Strip out raw byte dumps to make tests platform-independent:
 //@ normalize-stderr: "([[:xdigit:]]{2}\s){4,8}\s+│\s.{4,8}" -> "HEX_DUMP"
-//@ ignore-parallel-frontend different alloc ids
+
 #![feature(pattern_types, const_trait_impl, pattern_type_range_trait)]
 #![feature(pattern_type_macro)]
 

--- a/tests/ui/type/pattern_types/validity.stderr
+++ b/tests/ui/type/pattern_types/validity.stderr
@@ -9,7 +9,7 @@ LL | const BAD: pattern_type!(u32 is 1..) = unsafe { std::mem::transmute(0) };
                HEX_DUMP
            }
 
-error[E0080]: reading memory at ALLOC0[0x0..0x4], but memory is uninitialized at [0x0..0x4], and this operation requires initialized memory
+error[E0080]: reading memory at ALLOC$ID[0x0..0x4], but memory is uninitialized at [0x0..0x4], and this operation requires initialized memory
   --> $DIR/validity.rs:13:1
    |
 LL | const BAD_UNINIT: pattern_type!(u32 is 1..) =
@@ -50,7 +50,7 @@ LL | const BAD_FOO: Foo = Foo(Bar(unsafe { std::mem::transmute(0) }));
                HEX_DUMP
            }
 
-error[E0080]: reading memory at ALLOC1[0x0..0x4], but memory is uninitialized at [0x0..0x4], and this operation requires initialized memory
+error[E0080]: reading memory at ALLOC$ID[0x0..0x4], but memory is uninitialized at [0x0..0x4], and this operation requires initialized memory
   --> $DIR/validity.rs:29:1
    |
 LL | const CHAR_UNINIT: pattern_type!(char is 'A'..'Z') =


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#150075 (Implement clamp_to)
 - rust-lang/rust#156716 (tests: fix: parallel frontend test failures: different alloc ids)
 - rust-lang/rust#158397 (delegation: support simplest output `Self` mapping)
 - rust-lang/rust#158613 (Fix getrandom fallback test on platforms with `panic=abort`)
 - rust-lang/rust#158620 (Remove skip_norm_w/i/p().def_id with a helper)
 - rust-lang/rust#158633 (Remove unnecessary `Clone` derives on resolver types)
 - rust-lang/rust#158634 (Add missing `needs_drop` check to `DroplessArena`.)
 - rust-lang/rust#158647 (Document `strip_circumfix` behavior on overlapping prefix and suffix.)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=150075,156716,158397,158613,158620,158633,158634,158647)
<!-- homu-ignore:end -->

