### PR TITLE
Revert "Remove redundant dyn-compatibility check."

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -772,6 +772,10 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                 }
 
                 ty::PredicateKind::DynCompatible(trait_def_id) => {
+                    // `DynCompatible` obligations are only emitted as
+                    // nested obligations of `WellFormed` goals. It is quite
+                    // rare, but possible, that we encounter them during
+                    // evaluation. See #158665 for more details here.
                     if self.tcx().is_dyn_compatible(trait_def_id) {
                         Ok(EvaluatedToOk)
                     } else {

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -771,10 +771,12 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                     Ok(EvaluatedToOkModuloRegions)
                 }
 
-                ty::PredicateKind::DynCompatible(_) => {
-                    bug!(
-                        "Obligation {obligation:?} should have been handled by fulfillment already."
-                    )
+                ty::PredicateKind::DynCompatible(trait_def_id) => {
+                    if self.tcx().is_dyn_compatible(trait_def_id) {
+                        Ok(EvaluatedToOk)
+                    } else {
+                        Ok(EvaluatedToErr)
+                    }
                 }
 
                 ty::PredicateKind::Clause(ty::ClauseKind::Projection(data)) => {

--- a/tests/ui/impl-trait/rpit/dyn-in-nested-rpit.rs
+++ b/tests/ui/impl-trait/rpit/dyn-in-nested-rpit.rs
@@ -1,0 +1,21 @@
+//! Regression test for <https://github.com/rust-lang/rust/issues/158656>.
+
+//@ revisions: current next
+//@[next] compile-flags: -Znext-solver
+//@ check-pass
+
+trait Trait {}
+
+trait WithAssoc {
+    type Assoc: ?Sized;
+}
+struct Thing;
+impl WithAssoc for Thing {
+    type Assoc = dyn Trait;
+}
+
+fn foo() -> impl WithAssoc<Assoc = impl Trait + ?Sized> {
+    Thing
+}
+
+fn main() {}


### PR DESCRIPTION
This reverts commit 5fad8a6a2313aa0c8d90197b55a0c644396fbc20.

Fixes rust-lang/rust#158656

See https://github.com/rust-lang/rust/pull/158665#discussion_r3511365673 for explanation.