### PR TITLE
Carry the `b_offset` inside `BackendRepr::ScalarPair`

### DIFF
--- a/compiler/rustc_abi/src/callconv.rs
+++ b/compiler/rustc_abi/src/callconv.rs
@@ -89,7 +89,7 @@ impl<'a, Ty> TyAndLayout<'a, Ty> {
                 unreachable!("`homogeneous_aggregate` should not be called for scalable vectors")
             }
 
-            BackendRepr::ScalarPair(..) | BackendRepr::Memory { sized: true } => {
+            BackendRepr::ScalarPair { .. } | BackendRepr::Memory { sized: true } => {
                 // Helper for computing `homogeneous_aggregate`, allowing a custom
                 // starting offset (used below for handling variants).
                 let from_fields_at =

--- a/compiler/rustc_abi/src/layout.rs
+++ b/compiler/rustc_abi/src/layout.rs
@@ -476,7 +476,7 @@ impl<Cx: HasDataLayout> LayoutCalculator<Cx> {
             Err(AbiMismatch) | Ok(None) => BackendRepr::Memory { sized: true },
             Ok(Some((repr, _))) => match repr {
                 // Mismatched alignment (e.g. union is #[repr(packed)]): disable opt
-                BackendRepr::Scalar(_) | BackendRepr::ScalarPair(_, _)
+                BackendRepr::Scalar(_) | BackendRepr::ScalarPair { .. }
                     if repr.scalar_platform_align(dl).unwrap() != align =>
                 {
                     BackendRepr::Memory { sized: true }
@@ -489,7 +489,7 @@ impl<Cx: HasDataLayout> LayoutCalculator<Cx> {
                 }
                 // the alignment tests passed and we can use this
                 BackendRepr::Scalar(..)
-                | BackendRepr::ScalarPair(..)
+                | BackendRepr::ScalarPair { .. }
                 | BackendRepr::SimdVector { .. }
                 | BackendRepr::SimdScalableVector { .. }
                 | BackendRepr::Memory { .. } => repr,
@@ -558,7 +558,7 @@ impl<Cx: HasDataLayout> LayoutCalculator<Cx> {
             };
             match &mut st.backend_repr {
                 BackendRepr::Scalar(scalar) => hide_niches(scalar),
-                BackendRepr::ScalarPair(a, b) => {
+                BackendRepr::ScalarPair { a, b, b_offset: _ } => {
                     hide_niches(a);
                     hide_niches(b);
                 }
@@ -701,13 +701,21 @@ impl<Cx: HasDataLayout> LayoutCalculator<Cx> {
                     // When the total alignment and size match, we can use the
                     // same ABI as the scalar variant with the reserved niche.
                     BackendRepr::Scalar(_) => BackendRepr::Scalar(niche_scalar),
-                    BackendRepr::ScalarPair(first, second) => {
+                    BackendRepr::ScalarPair { a: first, b: second, b_offset } => {
                         // Only the niche is guaranteed to be initialised,
                         // so use union layouts for the other primitive.
                         if niche_offset == Size::ZERO {
-                            BackendRepr::ScalarPair(niche_scalar, second.to_union())
+                            BackendRepr::ScalarPair {
+                                a: niche_scalar,
+                                b: second.to_union(),
+                                b_offset,
+                            }
                         } else {
-                            BackendRepr::ScalarPair(first.to_union(), niche_scalar)
+                            BackendRepr::ScalarPair {
+                                a: first.to_union(),
+                                b: niche_scalar,
+                                b_offset,
+                            }
                         }
                     }
                     _ => BackendRepr::Memory { sized: true },
@@ -1037,7 +1045,7 @@ impl<Cx: HasDataLayout> LayoutCalculator<Cx> {
         // If we pick a "clever" (by-value) ABI, we might have to adjust the ABI of the
         // variants to ensure they are consistent. This is because a downcast is
         // semantically a NOP, and thus should not affect layout.
-        if matches!(abi, BackendRepr::Scalar(..) | BackendRepr::ScalarPair(..)) {
+        if matches!(abi, BackendRepr::Scalar(..) | BackendRepr::ScalarPair { .. }) {
             for variant in &mut layout_variants {
                 // We only do this for variants with fields; the others are not accessed anyway.
                 // Also do not overwrite any already existing "clever" ABIs.
@@ -1354,7 +1362,7 @@ impl<Cx: HasDataLayout> LayoutCalculator<Cx> {
                             }
                             // But scalar pairs are Rust-specific and get
                             // treated as aggregates by C ABIs anyway.
-                            BackendRepr::ScalarPair(..) => {
+                            BackendRepr::ScalarPair { .. } => {
                                 abi = field.backend_repr;
                             }
                             _ => {}

--- a/compiler/rustc_abi/src/layout/simple.rs
+++ b/compiler/rustc_abi/src/layout/simple.rs
@@ -110,7 +110,7 @@ impl<FieldIdx: Idx, VariantIdx: Idx> LayoutData<FieldIdx, VariantIdx> {
                 offsets: [Size::ZERO, b_offset].into(),
                 in_memory_order: [FieldIdx::new(0), FieldIdx::new(1)].into(),
             },
-            backend_repr: BackendRepr::ScalarPair(a, b),
+            backend_repr: BackendRepr::ScalarPair { a, b, b_offset },
             largest_niche,
             uninhabited: false,
             align: AbiAlign::new(align),

--- a/compiler/rustc_abi/src/lib.rs
+++ b/compiler/rustc_abi/src/lib.rs
@@ -1796,14 +1796,18 @@ impl IntoDiagArg for NumScalableVectors {
 pub enum BackendRepr {
     Scalar(Scalar),
     /// The data contained in this type can be entirely represented by two scalars.
-    /// The two scalars are listed in *memory* order, so the first is at offset zero
-    /// and the second at a non-zero offset.
+    /// The two scalars are listed in *memory* order, so `a` is at offset zero
+    /// and `b` is at non-zero offset `b_offset`.
     /// These need not be `FieldIdx(0)` and `FieldIdx(1)`.
     ///
-    /// As of June 2026 the offset to the second scalar is the size of the first
-    /// scalar rounded up to the platform alignment of the second scalar.
+    /// As of June 2026 the `b_offset` is always the size of the `a`
+    /// scalar rounded up to the platform alignment of the `b` scalar.
     /// That may soon change, however; see MCP#1007.
-    ScalarPair(Scalar, Scalar),
+    ScalarPair {
+        a: Scalar,
+        b: Scalar,
+        b_offset: Size,
+    },
     SimdScalableVector {
         element: Scalar,
         count: u64,
@@ -1826,7 +1830,7 @@ impl BackendRepr {
     pub fn is_unsized(&self) -> bool {
         match *self {
             BackendRepr::Scalar(_)
-            | BackendRepr::ScalarPair(..)
+            | BackendRepr::ScalarPair { .. }
             // FIXME(rustc_scalable_vector): Scalable vectors are `Sized` while the
             // `sized_hierarchy` feature is not yet fully implemented. After `sized_hierarchy` is
             // fully implemented, scalable vectors will remain `Sized`, they just won't be
@@ -1875,7 +1879,7 @@ impl BackendRepr {
     pub fn scalar_platform_align<C: HasDataLayout>(&self, cx: &C) -> Option<Align> {
         match *self {
             BackendRepr::Scalar(s) => Some(s.default_align(cx).abi),
-            BackendRepr::ScalarPair(s1, s2) => {
+            BackendRepr::ScalarPair { a: s1, b: s2, b_offset: _ } => {
                 Some(s1.default_align(cx).max(s2.default_align(cx)).abi)
             }
             // The align of a Vector can vary in surprising ways
@@ -1893,8 +1897,7 @@ impl BackendRepr {
             // No padding in scalars.
             BackendRepr::Scalar(s) => Some(s.size(cx)),
             // May have some padding between the pair.
-            BackendRepr::ScalarPair(s1, s2) => {
-                let field2_offset = s1.size(cx).align_to(s2.default_align(cx).abi);
+            BackendRepr::ScalarPair { a: _, b: s2, b_offset: field2_offset } => {
                 let size = (field2_offset + s2.size(cx)).align_to(
                     self.scalar_platform_align(cx)
                         // We absolutely must have an answer here or everything is FUBAR.
@@ -1913,8 +1916,8 @@ impl BackendRepr {
     pub fn to_union(&self) -> Self {
         match *self {
             BackendRepr::Scalar(s) => BackendRepr::Scalar(s.to_union()),
-            BackendRepr::ScalarPair(s1, s2) => {
-                BackendRepr::ScalarPair(s1.to_union(), s2.to_union())
+            BackendRepr::ScalarPair { a: s1, b: s2, b_offset } => {
+                BackendRepr::ScalarPair { a: s1.to_union(), b: s2.to_union(), b_offset }
             }
             BackendRepr::SimdVector { element, count } => {
                 BackendRepr::SimdVector { element: element.to_union(), count }
@@ -1939,8 +1942,13 @@ impl BackendRepr {
                 BackendRepr::SimdVector { element: element_l, count: count_l },
                 BackendRepr::SimdVector { element: element_r, count: count_r },
             ) => element_l.primitive() == element_r.primitive() && count_l == count_r,
-            (BackendRepr::ScalarPair(l1, l2), BackendRepr::ScalarPair(r1, r2)) => {
-                l1.primitive() == r1.primitive() && l2.primitive() == r2.primitive()
+            (
+                BackendRepr::ScalarPair { a: l1, b: l2, b_offset: l_offset },
+                BackendRepr::ScalarPair { a: r1, b: r2, b_offset: r_offset },
+            ) => {
+                l1.primitive() == r1.primitive()
+                    && l2.primitive() == r2.primitive()
+                    && l_offset == r_offset
             }
             // Everything else must be strictly identical.
             _ => self == other,
@@ -2180,7 +2188,7 @@ impl<FieldIdx: Idx, VariantIdx: Idx> LayoutData<FieldIdx, VariantIdx> {
             BackendRepr::Scalar(_)
             | BackendRepr::SimdVector { .. }
             | BackendRepr::SimdScalableVector { .. } => false,
-            BackendRepr::ScalarPair(..) | BackendRepr::Memory { .. } => true,
+            BackendRepr::ScalarPair { .. } | BackendRepr::Memory { .. } => true,
         }
     }
 
@@ -2294,7 +2302,7 @@ impl<FieldIdx: Idx, VariantIdx: Idx> LayoutData<FieldIdx, VariantIdx> {
     pub fn is_zst(&self) -> bool {
         match self.backend_repr {
             BackendRepr::Scalar(_)
-            | BackendRepr::ScalarPair(..)
+            | BackendRepr::ScalarPair { .. }
             | BackendRepr::SimdScalableVector { .. }
             | BackendRepr::SimdVector { .. } => false,
             BackendRepr::Memory { sized } => sized && self.size.bytes() == 0,

--- a/compiler/rustc_codegen_cranelift/src/abi/mod.rs
+++ b/compiler/rustc_codegen_cranelift/src/abi/mod.rs
@@ -220,7 +220,7 @@ fn make_local_place<'tcx>(
         );
     }
     let place = if is_ssa {
-        if let BackendRepr::ScalarPair(_, _) = layout.backend_repr {
+        if let BackendRepr::ScalarPair { a: _, b: _, b_offset: _ } = layout.backend_repr {
             CPlace::new_var_pair(fx, local, layout)
         } else {
             CPlace::new_var(fx, local, layout)

--- a/compiler/rustc_codegen_cranelift/src/abi/pass_mode.rs
+++ b/compiler/rustc_codegen_cranelift/src/abi/pass_mode.rs
@@ -112,7 +112,7 @@ impl<'tcx> ArgAbiExt<'tcx> for ArgAbi<'tcx, Ty<'tcx>> {
                 _ => unreachable!("{:?}", self.layout.backend_repr),
             },
             PassMode::Pair(attrs_a, attrs_b) => match self.layout.backend_repr {
-                BackendRepr::ScalarPair(a, b) => {
+                BackendRepr::ScalarPair { a, b, b_offset: _ } => {
                     let a = scalar_to_clif_type(tcx, a);
                     let b = scalar_to_clif_type(tcx, b);
                     smallvec![
@@ -167,7 +167,7 @@ impl<'tcx> ArgAbiExt<'tcx> for ArgAbi<'tcx, Ty<'tcx>> {
                 _ => unreachable!("{:?}", self.layout.backend_repr),
             },
             PassMode::Pair(attrs_a, attrs_b) => match self.layout.backend_repr {
-                BackendRepr::ScalarPair(a, b) => {
+                BackendRepr::ScalarPair { a, b, b_offset: _ } => {
                     let a = scalar_to_clif_type(tcx, a);
                     let b = scalar_to_clif_type(tcx, b);
                     (

--- a/compiler/rustc_codegen_cranelift/src/base.rs
+++ b/compiler/rustc_codegen_cranelift/src/base.rs
@@ -695,7 +695,7 @@ fn codegen_stmt<'tcx>(fx: &mut FunctionCx<'_, '_, 'tcx>, cur_block: Block, stmt:
                         }
                         UnOp::PtrMetadata => match layout.backend_repr {
                             BackendRepr::Scalar(_) => CValue::zst(dest_layout),
-                            BackendRepr::ScalarPair(_, _) => {
+                            BackendRepr::ScalarPair { a: _, b: _, b_offset: _ } => {
                                 CValue::by_val(operand.load_scalar_pair(fx).1, dest_layout)
                             }
                             _ => bug!("Unexpected `PtrToMetadata` operand: {operand:?}"),

--- a/compiler/rustc_codegen_cranelift/src/intrinsics/mod.rs
+++ b/compiler/rustc_codegen_cranelift/src/intrinsics/mod.rs
@@ -572,7 +572,9 @@ fn codegen_regular_intrinsic_call<'tcx>(
             let layout = fx.layout_of(generic_args.type_at(0));
             // Note: Can't use is_unsized here as truly unsized types need to take the fixed size
             // branch
-            let meta = if let BackendRepr::ScalarPair(_, _) = ptr.layout().backend_repr {
+            let meta = if let BackendRepr::ScalarPair { a: _, b: _, b_offset: _ } =
+                ptr.layout().backend_repr
+            {
                 Some(ptr.load_scalar_pair(fx).1)
             } else {
                 None
@@ -586,7 +588,9 @@ fn codegen_regular_intrinsic_call<'tcx>(
             let layout = fx.layout_of(generic_args.type_at(0));
             // Note: Can't use is_unsized here as truly unsized types need to take the fixed size
             // branch
-            let meta = if let BackendRepr::ScalarPair(_, _) = ptr.layout().backend_repr {
+            let meta = if let BackendRepr::ScalarPair { a: _, b: _, b_offset: _ } =
+                ptr.layout().backend_repr
+            {
                 Some(ptr.load_scalar_pair(fx).1)
             } else {
                 None

--- a/compiler/rustc_codegen_cranelift/src/value_and_place.rs
+++ b/compiler/rustc_codegen_cranelift/src/value_and_place.rs
@@ -55,8 +55,7 @@ fn codegen_field<'tcx>(
     }
 }
 
-fn scalar_pair_calculate_b_offset(tcx: TyCtxt<'_>, a_scalar: Scalar, b_scalar: Scalar) -> Offset32 {
-    let b_offset = a_scalar.size(&tcx).align_to(b_scalar.default_align(&tcx).abi);
+fn scalar_pair_convert_b_offset(b_offset: Size) -> Offset32 {
     Offset32::new(b_offset.bytes().try_into().unwrap())
 }
 
@@ -159,11 +158,11 @@ impl<'tcx> CValue<'tcx> {
         let layout = self.1;
         match self.0 {
             CValueInner::ByRef(ptr, None) => {
-                let (a_scalar, b_scalar) = match layout.backend_repr {
-                    BackendRepr::ScalarPair(a, b) => (a, b),
+                let (a_scalar, b_scalar, b_offset) = match layout.backend_repr {
+                    BackendRepr::ScalarPair { a, b, b_offset } => (a, b, b_offset),
                     _ => unreachable!("load_scalar_pair({:?})", self),
                 };
-                let b_offset = scalar_pair_calculate_b_offset(fx.tcx, a_scalar, b_scalar);
+                let b_offset = scalar_pair_convert_b_offset(b_offset);
                 let clif_ty1 = scalar_to_clif_type(fx.tcx, a_scalar);
                 let clif_ty2 = scalar_to_clif_type(fx.tcx, b_scalar);
                 let mut flags = MemFlags::new();
@@ -189,7 +188,7 @@ impl<'tcx> CValue<'tcx> {
         match self.0 {
             CValueInner::ByVal(_) => unreachable!(),
             CValueInner::ByValPair(val1, val2) => match layout.backend_repr {
-                BackendRepr::ScalarPair(_, _) => {
+                BackendRepr::ScalarPair { a: _, b: _, b_offset: _ } => {
                     let val = match field.as_u32() {
                         0 => val1,
                         1 => val2,
@@ -580,7 +579,7 @@ impl<'tcx> CPlace<'tcx> {
             }
             CPlaceInner::VarPair(_local, var1, var2) => {
                 let (data1, data2) = match from.1.backend_repr {
-                    BackendRepr::ScalarPair(_, _) => {
+                    BackendRepr::ScalarPair { a: _, b: _, b_offset: _ } => {
                         CValue(from.0, dst_layout).load_scalar_pair(fx)
                     }
                     _ => {
@@ -607,9 +606,8 @@ impl<'tcx> CPlace<'tcx> {
                         to_ptr.store(fx, val, flags);
                     }
                     CValueInner::ByValPair(val1, val2) => match from.layout().backend_repr {
-                        BackendRepr::ScalarPair(a_scalar, b_scalar) => {
-                            let b_offset =
-                                scalar_pair_calculate_b_offset(fx.tcx, a_scalar, b_scalar);
+                        BackendRepr::ScalarPair { a: _, b: _, b_offset } => {
+                            let b_offset = scalar_pair_convert_b_offset(b_offset);
                             to_ptr.store(fx, val1, flags);
                             to_ptr.offset(fx, b_offset).store(fx, val2, flags);
                         }
@@ -627,9 +625,8 @@ impl<'tcx> CPlace<'tcx> {
                                 to_ptr.store(fx, val, flags);
                                 return;
                             }
-                            BackendRepr::ScalarPair(a_scalar, b_scalar) => {
-                                let b_offset =
-                                    scalar_pair_calculate_b_offset(fx.tcx, a_scalar, b_scalar);
+                            BackendRepr::ScalarPair { a: _, b: _, b_offset } => {
+                                let b_offset = scalar_pair_convert_b_offset(b_offset);
                                 let (val1, val2) = from.load_scalar_pair(fx);
                                 to_ptr.store(fx, val1, flags);
                                 to_ptr.offset(fx, b_offset).store(fx, val2, flags);

--- a/compiler/rustc_codegen_cranelift/src/vtable.rs
+++ b/compiler/rustc_codegen_cranelift/src/vtable.rs
@@ -56,13 +56,14 @@ pub(crate) fn get_ptr_and_method_ref<'tcx>(
         }
     }
 
-    let (ptr, vtable) = if let BackendRepr::ScalarPair(_, _) = arg.layout().backend_repr {
-        let (ptr, vtable) = arg.load_scalar_pair(fx);
-        (Pointer::new(ptr), vtable)
-    } else {
-        let (ptr, vtable) = arg.try_to_ptr().unwrap();
-        (ptr, vtable.unwrap())
-    };
+    let (ptr, vtable) =
+        if let BackendRepr::ScalarPair { a: _, b: _, b_offset: _ } = arg.layout().backend_repr {
+            let (ptr, vtable) = arg.load_scalar_pair(fx);
+            (Pointer::new(ptr), vtable)
+        } else {
+            let (ptr, vtable) = arg.try_to_ptr().unwrap();
+            (ptr, vtable.unwrap())
+        };
 
     let usize_size = fx.layout_of(fx.tcx.types.usize).size.bytes();
     let func_ref = fx.bcx.ins().load(

--- a/compiler/rustc_codegen_gcc/src/builder.rs
+++ b/compiler/rustc_codegen_gcc/src/builder.rs
@@ -1064,9 +1064,9 @@ impl<'a, 'gcc, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'gcc, 'tcx> {
                     load
                 },
             )
-        } else if let abi::BackendRepr::ScalarPair(ref a, ref b) = place.layout.backend_repr {
-            let b_offset = a.size(self).align_to(b.default_align(self).abi);
-
+        } else if let abi::BackendRepr::ScalarPair { ref a, ref b, b_offset } =
+            place.layout.backend_repr
+        {
             let mut load = |i, scalar: &abi::Scalar, align| {
                 let ptr = if i == 0 {
                     place.val.llval

--- a/compiler/rustc_codegen_gcc/src/intrinsic/mod.rs
+++ b/compiler/rustc_codegen_gcc/src/intrinsic/mod.rs
@@ -485,7 +485,7 @@ impl<'a, 'gcc, 'tcx> IntrinsicCallBuilderMethods<'tcx> for Builder<'a, 'gcc, 'tc
                 let tp_ty = fn_args.type_at(0);
                 let layout = self.layout_of(tp_ty).layout;
                 let _use_integer_compare = match layout.backend_repr() {
-                    Scalar(_) | ScalarPair(_, _) => true,
+                    Scalar(_) | ScalarPair { a: _, b: _, b_offset: _ } => true,
                     SimdVector { .. } | SimdScalableVector { .. } => false,
                     Memory { .. } => {
                         // For rusty ABIs, small aggregates are actually passed

--- a/compiler/rustc_codegen_gcc/src/type_of.rs
+++ b/compiler/rustc_codegen_gcc/src/type_of.rs
@@ -75,7 +75,7 @@ fn uncached_gcc_type<'gcc, 'tcx>(
                 };
             return cx.context.new_vector_type(element, count);
         }
-        BackendRepr::ScalarPair(..) => {
+        BackendRepr::ScalarPair { .. } => {
             return cx.type_struct(
                 &[
                     layout.scalar_pair_element_gcc_type(cx, 0),
@@ -182,13 +182,13 @@ impl<'tcx> LayoutGccExt<'tcx> for TyAndLayout<'tcx> {
             BackendRepr::Scalar(_) | BackendRepr::SimdVector { .. } => true,
             // FIXME(rustc_scalable_vector): Not yet implemented in rustc_codegen_gcc.
             BackendRepr::SimdScalableVector { .. } => todo!(),
-            BackendRepr::ScalarPair(..) | BackendRepr::Memory { .. } => false,
+            BackendRepr::ScalarPair { .. } | BackendRepr::Memory { .. } => false,
         }
     }
 
     fn is_gcc_scalar_pair(&self) -> bool {
         match self.backend_repr {
-            BackendRepr::ScalarPair(..) => true,
+            BackendRepr::ScalarPair { .. } => true,
             BackendRepr::Scalar(_)
             | BackendRepr::SimdVector { .. }
             | BackendRepr::SimdScalableVector { .. }
@@ -308,8 +308,8 @@ impl<'tcx> LayoutGccExt<'tcx> for TyAndLayout<'tcx> {
         // This must produce the same result for `repr(transparent)` wrappers as for the inner type!
         // In other words, this should generally not look at the type at all, but only at the
         // layout.
-        let (a, b) = match self.backend_repr {
-            BackendRepr::ScalarPair(ref a, ref b) => (a, b),
+        let (a, b, b_offset) = match self.backend_repr {
+            BackendRepr::ScalarPair { ref a, ref b, b_offset } => (a, b, b_offset),
             _ => bug!("TyAndLayout::scalar_pair_element_llty({:?}): not applicable", self),
         };
         let scalar = [a, b][index];
@@ -325,8 +325,7 @@ impl<'tcx> LayoutGccExt<'tcx> for TyAndLayout<'tcx> {
             return cx.type_i1();
         }
 
-        let offset =
-            if index == 0 { Size::ZERO } else { a.size(cx).align_to(b.default_align(cx).abi) };
+        let offset = if index == 0 { Size::ZERO } else { b_offset };
         self.scalar_gcc_type_at(cx, scalar, offset)
     }
 

--- a/compiler/rustc_codegen_llvm/src/abi.rs
+++ b/compiler/rustc_codegen_llvm/src/abi.rs
@@ -551,7 +551,9 @@ impl<'ll, 'tcx> FnAbiLlvmExt<'ll, 'tcx> for FnAbi<'tcx, Ty<'tcx>> {
                 PassMode::Pair(a, b) => {
                     let i = apply(a);
                     let ii = apply(b);
-                    if let BackendRepr::ScalarPair(scalar_a, scalar_b) = arg.layout.backend_repr {
+                    if let BackendRepr::ScalarPair { a: scalar_a, b: scalar_b, b_offset: _ } =
+                        arg.layout.backend_repr
+                    {
                         apply_range_attr(llvm::AttributePlace::Argument(i), scalar_a);
                         let primitive_b = scalar_b.primitive();
                         let scalar_b = if let rustc_abi::Primitive::Int(int, false) = primitive_b

--- a/compiler/rustc_codegen_llvm/src/builder.rs
+++ b/compiler/rustc_codegen_llvm/src/builder.rs
@@ -793,9 +793,7 @@ impl<'a, 'll, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
                 }
             });
             OperandValue::Immediate(llval)
-        } else if let abi::BackendRepr::ScalarPair(a, b) = place.layout.backend_repr {
-            let b_offset = a.size(self).align_to(b.default_align(self).abi);
-
+        } else if let abi::BackendRepr::ScalarPair { a, b, b_offset } = place.layout.backend_repr {
             let mut load = |i, scalar: abi::Scalar, layout, align, offset| {
                 let llptr = if i == 0 {
                     place.val.llval

--- a/compiler/rustc_codegen_llvm/src/builder/autodiff.rs
+++ b/compiler/rustc_codegen_llvm/src/builder/autodiff.rs
@@ -118,7 +118,9 @@ pub(crate) fn adjust_activity_to_abi<'tcx>(
         // If the argument is lowered as a `ScalarPair`, we need to duplicate its activity.
         // Otherwise, the number of activities won't match the number of LLVM arguments and
         // this will lead to errors when verifying the Enzyme call.
-        if let rustc_abi::BackendRepr::ScalarPair(_, _) = layout.backend_repr() {
+        if let rustc_abi::BackendRepr::ScalarPair { a: _, b: _, b_offset: _ } =
+            layout.backend_repr()
+        {
             new_activities.push(da[i].clone());
             new_positions.push(i + 1 - del_activities);
         }

--- a/compiler/rustc_codegen_llvm/src/intrinsic.rs
+++ b/compiler/rustc_codegen_llvm/src/intrinsic.rs
@@ -574,7 +574,7 @@ impl<'ll, 'tcx> IntrinsicCallBuilderMethods<'tcx> for Builder<'_, 'll, 'tcx> {
                 let tp_ty = fn_args.type_at(0);
                 let layout = self.layout_of(tp_ty).layout;
                 let use_integer_compare = match layout.backend_repr() {
-                    Scalar(_) | ScalarPair(_, _) => true,
+                    Scalar(_) | ScalarPair { a: _, b: _, b_offset: _ } => true,
                     SimdVector { .. } => false,
                     SimdScalableVector { .. } => {
                         let err = tcx.dcx().emit_err(InvalidMonomorphization::NonScalableType {

--- a/compiler/rustc_codegen_llvm/src/type_of.rs
+++ b/compiler/rustc_codegen_llvm/src/type_of.rs
@@ -73,7 +73,7 @@ fn uncached_llvm_type<'a, 'tcx>(
                 _ => bug!("`#[rustc_scalable_vector]` tuple struct with too many fields"),
             };
         }
-        BackendRepr::Memory { .. } | BackendRepr::ScalarPair(..) => {}
+        BackendRepr::Memory { .. } | BackendRepr::ScalarPair { .. } => {}
     }
 
     let name = match layout.ty.kind() {
@@ -228,13 +228,13 @@ impl<'tcx> LayoutLlvmExt<'tcx> for TyAndLayout<'tcx> {
             BackendRepr::Scalar(_)
             | BackendRepr::SimdVector { .. }
             | BackendRepr::SimdScalableVector { .. } => true,
-            BackendRepr::ScalarPair(..) | BackendRepr::Memory { .. } => false,
+            BackendRepr::ScalarPair { .. } | BackendRepr::Memory { .. } => false,
         }
     }
 
     fn is_llvm_scalar_pair(&self) -> bool {
         match self.backend_repr {
-            BackendRepr::ScalarPair(..) => true,
+            BackendRepr::ScalarPair { .. } => true,
             BackendRepr::Scalar(_)
             | BackendRepr::SimdVector { .. }
             | BackendRepr::SimdScalableVector { .. }
@@ -313,7 +313,7 @@ impl<'tcx> LayoutLlvmExt<'tcx> for TyAndLayout<'tcx> {
                     return cx.type_i1();
                 }
             }
-            BackendRepr::ScalarPair(..) => {
+            BackendRepr::ScalarPair { .. } => {
                 // An immediate pair always contains just the two elements, without any padding
                 // filler, as it should never be stored to memory.
                 return cx.type_struct(
@@ -346,7 +346,7 @@ impl<'tcx> LayoutLlvmExt<'tcx> for TyAndLayout<'tcx> {
         // This must produce the same result for `repr(transparent)` wrappers as for the inner type!
         // In other words, this should generally not look at the type at all, but only at the
         // layout.
-        let BackendRepr::ScalarPair(a, b) = self.backend_repr else {
+        let BackendRepr::ScalarPair { a, b, b_offset: _ } = self.backend_repr else {
             bug!("TyAndLayout::scalar_pair_element_llty({:?}): not applicable", self);
         };
         let scalar = [a, b][index];

--- a/compiler/rustc_codegen_llvm/src/va_arg.rs
+++ b/compiler/rustc_codegen_llvm/src/va_arg.rs
@@ -564,7 +564,7 @@ fn emit_x86_64_sysv64_va_arg<'ll, 'tcx>(
         BackendRepr::Scalar(scalar) => {
             registers_for_primitive(scalar.primitive());
         }
-        BackendRepr::ScalarPair(scalar1, scalar2) => {
+        BackendRepr::ScalarPair { a: scalar1, b: scalar2, b_offset: _ } => {
             registers_for_primitive(scalar1.primitive());
             registers_for_primitive(scalar2.primitive());
         }
@@ -641,7 +641,7 @@ fn emit_x86_64_sysv64_va_arg<'ll, 'tcx>(
             }
             Primitive::Float(_) => bx.inbounds_ptradd(reg_save_area_v, fp_offset_v),
         },
-        BackendRepr::ScalarPair(scalar1, scalar2) => {
+        BackendRepr::ScalarPair { a: scalar1, b: scalar2, b_offset: offset } => {
             let ty_lo = bx.cx().scalar_pair_element_backend_type(layout, 0, false);
             let ty_hi = bx.cx().scalar_pair_element_backend_type(layout, 1, false);
 
@@ -665,9 +665,8 @@ fn emit_x86_64_sysv64_va_arg<'ll, 'tcx>(
                     let reg_lo = bx.load(ty_lo, reg_lo_addr, align_lo);
                     let reg_hi = bx.load(ty_hi, reg_hi_addr, align_hi);
 
-                    let offset = scalar1.size(bx.cx).align_to(align_hi).bytes();
                     let field0 = tmp;
-                    let field1 = bx.inbounds_ptradd(tmp, bx.const_u32(offset as u32));
+                    let field1 = bx.inbounds_ptradd(tmp, bx.const_u32(offset.bytes() as u32));
 
                     bx.store(reg_lo, field0, align);
                     bx.store(reg_hi, field1, align);
@@ -688,9 +687,8 @@ fn emit_x86_64_sysv64_va_arg<'ll, 'tcx>(
                     let reg_lo = bx.load(ty_lo, reg_lo_addr, align_lo);
                     let reg_hi = bx.load(ty_hi, reg_hi_addr, align_hi);
 
-                    let offset = scalar1.size(bx.cx).align_to(align_hi).bytes();
                     let field0 = tmp;
-                    let field1 = bx.inbounds_ptradd(tmp, bx.const_u32(offset as u32));
+                    let field1 = bx.inbounds_ptradd(tmp, bx.const_u32(offset.bytes() as u32));
 
                     bx.store(reg_lo, field0, align_lo);
                     bx.store(reg_hi, field1, align_hi);

--- a/compiler/rustc_codegen_ssa/src/mir/debuginfo.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/debuginfo.rs
@@ -611,7 +611,9 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                         // be marked as a `LocalVariable` for MSVC debuggers to visualize
                         // their data correctly. (See #81894 & #88625)
                         let var_ty_layout = self.cx.layout_of(var_ty);
-                        if let BackendRepr::ScalarPair(_, _) = var_ty_layout.backend_repr {
+                        if let BackendRepr::ScalarPair { a: _, b: _, b_offset: _ } =
+                            var_ty_layout.backend_repr
+                        {
                             VariableKind::LocalVariable
                         } else {
                             VariableKind::ArgumentVariable(arg_index)

--- a/compiler/rustc_codegen_ssa/src/mir/naked_asm.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/naked_asm.rs
@@ -441,7 +441,7 @@ fn wasm_type<'tcx>(signature: &mut String, arg_abi: &ArgAbi<'_, Ty<'tcx>>, ptr_t
             signature.push_str(direct_type);
         }
         PassMode::Pair(_, _) => match arg_abi.layout.backend_repr {
-            BackendRepr::ScalarPair(a, b) => {
+            BackendRepr::ScalarPair { a, b, b_offset: _ } => {
                 signature.push_str(wasm_primitive(a.primitive(), ptr_type));
                 signature.push_str(", ");
                 signature.push_str(wasm_primitive(b.primitive(), ptr_type));

--- a/compiler/rustc_codegen_ssa/src/mir/operand.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/operand.rs
@@ -168,7 +168,9 @@ impl<'a, 'tcx, V: CodegenObject> OperandRef<'tcx, V> {
             }
             ConstValue::ZeroSized => return OperandRef::zero_sized(layout),
             ConstValue::Slice { alloc_id, meta } => {
-                let BackendRepr::ScalarPair(a_scalar, _) = layout.backend_repr else {
+                let BackendRepr::ScalarPair { a: a_scalar, b: _, b_offset: _ } =
+                    layout.backend_repr
+                else {
                     bug!("from_const: invalid ScalarPair layout: {:#?}", layout);
                 };
                 let a = Scalar::from_pointer(Pointer::new(alloc_id.into(), Size::ZERO), &bx.tcx());
@@ -222,12 +224,12 @@ impl<'a, 'tcx, V: CodegenObject> OperandRef<'tcx, V> {
                 let val = read_scalar(offset, size, s, bx.immediate_backend_type(layout));
                 OperandRef { val: OperandValue::Immediate(val), layout, move_annotation: None }
             }
-            BackendRepr::ScalarPair(
-                a @ abi::Scalar::Initialized { .. },
-                b @ abi::Scalar::Initialized { .. },
-            ) => {
+            BackendRepr::ScalarPair {
+                a: a @ abi::Scalar::Initialized { .. },
+                b: b @ abi::Scalar::Initialized { .. },
+                b_offset,
+            } => {
                 let (a_size, b_size) = (a.size(bx), b.size(bx));
-                let b_offset = (offset + a_size).align_to(b.default_align(bx).abi);
                 assert!(b_offset.bytes() > 0);
                 let a_val = read_scalar(
                     offset,
@@ -345,7 +347,7 @@ impl<'a, 'tcx, V: CodegenObject> OperandRef<'tcx, V> {
         llval: V,
         layout: TyAndLayout<'tcx>,
     ) -> Self {
-        let val = if let BackendRepr::ScalarPair(..) = layout.backend_repr {
+        let val = if let BackendRepr::ScalarPair { .. } = layout.backend_repr {
             debug!("Operand::from_immediate_or_packed_pair: unpacking {:?} @ {:?}", llval, layout);
 
             // Deconstruct the immediate aggregate.
@@ -383,12 +385,15 @@ impl<'a, 'tcx, V: CodegenObject> OperandRef<'tcx, V> {
         } else {
             let (in_scalar, imm) = match (self.val, self.layout.backend_repr) {
                 // Extract a scalar component from a pair.
-                (OperandValue::Pair(a_llval, b_llval), BackendRepr::ScalarPair(a, b)) => {
+                (
+                    OperandValue::Pair(a_llval, b_llval),
+                    BackendRepr::ScalarPair { a, b, b_offset },
+                ) => {
                     if offset.bytes() == 0 {
                         assert_eq!(field.size, a.size(bx.cx()));
                         (Some(a), a_llval)
                     } else {
-                        assert_eq!(offset, a.size(bx.cx()).align_to(b.default_align(bx.cx()).abi));
+                        assert_eq!(offset, b_offset);
                         assert_eq!(field.size, b.size(bx.cx()));
                         (Some(b), b_llval)
                     }
@@ -419,7 +424,7 @@ impl<'a, 'tcx, V: CodegenObject> OperandRef<'tcx, V> {
                         imm
                     }
                 }
-                BackendRepr::ScalarPair(_, _)
+                BackendRepr::ScalarPair { a: _, b: _, b_offset: _ }
                 | BackendRepr::Memory { .. }
                 | BackendRepr::SimdScalableVector { .. } => bug!(),
             })
@@ -705,7 +710,7 @@ impl<'a, 'tcx, V: CodegenObject> OperandRefBuilder<'tcx, V> {
         let val = match layout.backend_repr {
             BackendRepr::Memory { .. } if layout.is_zst() => OperandValueBuilder::ZeroSized,
             BackendRepr::Scalar(s) => OperandValueBuilder::Immediate(Either::Right(s)),
-            BackendRepr::ScalarPair(a, b) => {
+            BackendRepr::ScalarPair { a, b, b_offset: _ } => {
                 OperandValueBuilder::Pair(Either::Right(a), Either::Right(b))
             }
             BackendRepr::SimdVector { .. } | BackendRepr::SimdScalableVector { .. } => {
@@ -733,7 +738,7 @@ impl<'a, 'tcx, V: CodegenObject> OperandRefBuilder<'tcx, V> {
             (OperandValue::Immediate(v), BackendRepr::SimdVector { .. }) => {
                 OperandValueBuilder::Vector(Either::Left(v))
             }
-            (OperandValue::Pair(a, b), BackendRepr::ScalarPair(_, _)) => {
+            (OperandValue::Pair(a, b), BackendRepr::ScalarPair { a: _, b: _, b_offset: _ }) => {
                 OperandValueBuilder::Pair(Either::Left(a), Either::Left(b))
             }
             (_, BackendRepr::Memory { .. }) => {
@@ -810,17 +815,18 @@ impl<'a, 'tcx, V: CodegenObject> OperandRefBuilder<'tcx, V> {
                     bug!("Tried to insert {field_operand:?} into {variant:?}.{field:?} of {self:?}")
                 }
             },
-            (OperandValue::Pair(a, b), BackendRepr::ScalarPair(from_sa, from_sb)) => {
-                match &mut self.val {
-                    OperandValueBuilder::Pair(fst @ Either::Right(_), snd @ Either::Right(_)) => {
-                        update(fst, a, from_sa);
-                        update(snd, b, from_sb);
-                    }
-                    _ => bug!(
-                        "Tried to insert {field_operand:?} into {variant:?}.{field:?} of {self:?}"
-                    ),
+            (
+                OperandValue::Pair(a, b),
+                BackendRepr::ScalarPair { a: from_sa, b: from_sb, b_offset: _ },
+            ) => match &mut self.val {
+                OperandValueBuilder::Pair(fst @ Either::Right(_), snd @ Either::Right(_)) => {
+                    update(fst, a, from_sa);
+                    update(snd, b, from_sb);
                 }
-            }
+                _ => {
+                    bug!("Tried to insert {field_operand:?} into {variant:?}.{field:?} of {self:?}")
+                }
+            },
             (OperandValue::Ref(place), BackendRepr::Memory { .. }) => match &mut self.val {
                 OperandValueBuilder::Vector(val @ Either::Right(())) => {
                     let ibty = bx.cx().immediate_backend_type(self.layout);
@@ -1008,10 +1014,10 @@ impl<'a, 'tcx, V: CodegenObject> OperandValue<V> {
                 bx.store_with_flags(val, dest.val.llval, dest.val.align, flags);
             }
             OperandValue::Pair(a, b) => {
-                let BackendRepr::ScalarPair(a_scalar, b_scalar) = dest.layout.backend_repr else {
+                let BackendRepr::ScalarPair { a: _, b: _, b_offset } = dest.layout.backend_repr
+                else {
                     bug!("store_with_flags: invalid ScalarPair layout: {:#?}", dest.layout);
                 };
-                let b_offset = a_scalar.size(bx).align_to(b_scalar.default_align(bx).abi);
 
                 let val = bx.from_immediate(a);
                 let align = dest.val.align;

--- a/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
@@ -36,7 +36,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                 // semantics regarding when assignment operators allow overlap of LHS and RHS.
                 if matches!(
                     cg_operand.layout.backend_repr,
-                    BackendRepr::Scalar(..) | BackendRepr::ScalarPair(..),
+                    BackendRepr::Scalar(..) | BackendRepr::ScalarPair { .. },
                 ) {
                     debug_assert!(!matches!(cg_operand.val, OperandValue::Ref(..)));
                 }
@@ -323,9 +323,12 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
             }
             (
                 OperandValue::Pair(imm_a, imm_b),
-                abi::BackendRepr::ScalarPair(in_a, in_b),
-                abi::BackendRepr::ScalarPair(out_a, out_b),
-            ) if in_a.size(cx) == out_a.size(cx) && in_b.size(cx) == out_b.size(cx) => {
+                abi::BackendRepr::ScalarPair { a: in_a, b: in_b, b_offset: in_offset },
+                abi::BackendRepr::ScalarPair { a: out_a, b: out_b, b_offset: out_offset },
+            ) if in_a.size(cx) == out_a.size(cx)
+                && in_b.size(cx) == out_b.size(cx)
+                && in_offset == out_offset =>
+            {
                 OperandValue::Pair(
                     transmute_scalar(bx, imm_a, in_a, out_a),
                     transmute_scalar(bx, imm_b, in_b, out_b),

--- a/compiler/rustc_const_eval/src/const_eval/valtrees.rs
+++ b/compiler/rustc_const_eval/src/const_eval/valtrees.rs
@@ -136,7 +136,7 @@ fn const_to_valtree_inner<'tcx>(
             let val = ecx.read_immediate(place).report_err()?;
             // We could allow wide raw pointers where both sides are integers in the future,
             // but for now we reject them.
-            if matches!(val.layout.backend_repr, BackendRepr::ScalarPair(..)) {
+            if matches!(val.layout.backend_repr, BackendRepr::ScalarPair { .. }) {
                 Err(ValTreeCreationError::NonSupportedType(ty))
             } else {
                 let val = val.to_scalar();

--- a/compiler/rustc_const_eval/src/interpret/operand.rs
+++ b/compiler/rustc_const_eval/src/interpret/operand.rs
@@ -84,7 +84,7 @@ impl<Prov: Provenance> Immediate<Prov> {
     pub fn to_scalar(self) -> Scalar<Prov> {
         match self {
             Immediate::Scalar(val) => val,
-            Immediate::ScalarPair(..) => bug!("Got a scalar pair where a scalar was expected"),
+            Immediate::ScalarPair { .. } => bug!("Got a scalar pair where a scalar was expected"),
             Immediate::Uninit => bug!("Got uninit where a scalar was expected"),
         }
     }
@@ -129,7 +129,10 @@ impl<Prov: Provenance> Immediate<Prov> {
                     );
                 }
             }
-            (Immediate::ScalarPair(a_val, b_val), BackendRepr::ScalarPair(a, b)) => {
+            (
+                Immediate::ScalarPair(a_val, b_val),
+                BackendRepr::ScalarPair { a, b, b_offset: _ },
+            ) => {
                 assert_eq!(
                     a_val.size(),
                     a.size(cx),
@@ -263,7 +266,7 @@ impl<'tcx, Prov: Provenance> ImmTy<'tcx, Prov> {
     #[inline]
     pub fn from_scalar_pair(a: Scalar<Prov>, b: Scalar<Prov>, layout: TyAndLayout<'tcx>) -> Self {
         debug_assert!(
-            matches!(layout.backend_repr, BackendRepr::ScalarPair(..)),
+            matches!(layout.backend_repr, BackendRepr::ScalarPair { .. }),
             "`ImmTy::from_scalar_pair` on non-scalar-pair layout"
         );
         let imm = Immediate::ScalarPair(a, b);
@@ -276,7 +279,7 @@ impl<'tcx, Prov: Provenance> ImmTy<'tcx, Prov> {
         debug_assert!(
             match (imm, layout.backend_repr) {
                 (Immediate::Scalar(..), BackendRepr::Scalar(..)) => true,
-                (Immediate::ScalarPair(..), BackendRepr::ScalarPair(..)) => true,
+                (Immediate::ScalarPair { .. }, BackendRepr::ScalarPair { .. }) => true,
                 (Immediate::Uninit, _) if layout.is_sized() => true,
                 _ => false,
             },
@@ -415,14 +418,15 @@ impl<'tcx, Prov: Provenance> ImmTy<'tcx, Prov> {
                 **self
             }
             // extract fields from types with `ScalarPair` ABI
-            (Immediate::ScalarPair(a_val, b_val), BackendRepr::ScalarPair(a, b)) => {
-                Immediate::from(if offset.bytes() == 0 {
-                    a_val
-                } else {
-                    assert_eq!(offset, a.size(cx).align_to(b.default_align(cx).abi));
-                    b_val
-                })
-            }
+            (
+                Immediate::ScalarPair(a_val, b_val),
+                BackendRepr::ScalarPair { a: _, b: _, b_offset },
+            ) => Immediate::from(if offset.bytes() == 0 {
+                a_val
+            } else {
+                assert_eq!(offset, b_offset);
+                b_val
+            }),
             // everything else is a bug
             _ => bug!(
                 "invalid field access on immediate {} at offset {}, original layout {:#?}",
@@ -606,15 +610,15 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                 )?;
                 Some(ImmTy::from_scalar(scalar, mplace.layout))
             }
-            BackendRepr::ScalarPair(
-                abi::Scalar::Initialized { value: a, .. },
-                abi::Scalar::Initialized { value: b, .. },
-            ) => {
+            BackendRepr::ScalarPair {
+                a: abi::Scalar::Initialized { value: a, .. },
+                b: abi::Scalar::Initialized { value: b, .. },
+                b_offset,
+            } => {
                 // We checked `ptr_align` above, so all fields will have the alignment they need.
                 // We would anyway check against `ptr_align.restrict_for_offset(b_offset)`,
                 // which `ptr.offset(b_offset)` cannot possibly fail to satisfy.
                 let (a_size, b_size) = (a.size(self), b.size(self));
-                let b_offset = a_size.align_to(b.default_align(self).abi);
                 assert!(b_offset.bytes() > 0); // in `operand_field` we use the offset to tell apart the fields
                 let a_val = alloc.read_scalar(
                     alloc_range(Size::ZERO, a_size),
@@ -668,10 +672,11 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         if !matches!(
             op.layout().backend_repr,
             BackendRepr::Scalar(abi::Scalar::Initialized { .. })
-                | BackendRepr::ScalarPair(
-                    abi::Scalar::Initialized { .. },
-                    abi::Scalar::Initialized { .. }
-                )
+                | BackendRepr::ScalarPair {
+                    a: abi::Scalar::Initialized { .. },
+                    b: abi::Scalar::Initialized { .. },
+                    b_offset: _,
+                }
         ) {
             span_bug!(self.cur_span(), "primitive read not possible for type: {}", op.layout().ty);
         }

--- a/compiler/rustc_const_eval/src/interpret/place.rs
+++ b/compiler/rustc_const_eval/src/interpret/place.rs
@@ -713,7 +713,6 @@ where
         // to handle padding properly, which is only correct if we never look at this data with the
         // wrong type.
 
-        let tcx = *self.tcx;
         let will_later_validate = M::enforce_validity(self, layout);
         let Some(mut alloc) = self.get_place_alloc_mut(&MPlaceTy { mplace: dest, layout })? else {
             // zero-sized access
@@ -725,7 +724,7 @@ where
                 alloc.write_scalar(alloc_range(Size::ZERO, scalar.size()), scalar)?;
             }
             Immediate::ScalarPair(a_val, b_val) => {
-                let BackendRepr::ScalarPair(_a, b) = layout.backend_repr else {
+                let BackendRepr::ScalarPair { a: _, b: _, b_offset } = layout.backend_repr else {
                     span_bug!(
                         self.cur_span(),
                         "write_immediate_to_mplace: invalid ScalarPair layout: {:#?}",
@@ -733,7 +732,6 @@ where
                     )
                 };
                 let a_size = a_val.size();
-                let b_offset = a_size.align_to(b.default_align(&tcx).abi);
                 assert!(b_offset.bytes() > 0); // in `operand_field` we use the offset to tell apart the fields
 
                 // It is tempting to verify `b_offset` against `layout.fields.offset(1)`,
@@ -902,17 +900,19 @@ where
         // padding in the target independent of layout choices.
         let src_has_padding = match src.layout().backend_repr {
             BackendRepr::Scalar(_) => false,
-            BackendRepr::ScalarPair(left, right)
+            BackendRepr::ScalarPair { a: left, b: right, b_offset: _ }
                 if matches!(src.layout().ty.kind(), ty::Ref(..) | ty::RawPtr(..)) =>
             {
                 // Wide pointers never have padding, so we can avoid calling `size()`.
                 debug_assert_eq!(left.size(self) + right.size(self), src.layout().size);
                 false
             }
-            BackendRepr::ScalarPair(left, right) => {
+            BackendRepr::ScalarPair { a: left, b: right, b_offset: _ } => {
                 let left_size = left.size(self);
                 let right_size = right.size(self);
                 // We have padding if the sizes don't add up to the total.
+                // (Why don't we need to check the offset?  The scalars don't overlap so no padding
+                // implies `b_offset == left_size`, which would be superfluous to check explicitly.)
                 left_size + right_size != src.layout().size
             }
             // Everything else can only exist in memory anyway, so it doesn't matter.

--- a/compiler/rustc_const_eval/src/interpret/place.rs
+++ b/compiler/rustc_const_eval/src/interpret/place.rs
@@ -732,6 +732,7 @@ where
                     )
                 };
                 let a_size = a_val.size();
+                let b_size = b_val.size();
                 assert!(b_offset.bytes() > 0); // in `operand_field` we use the offset to tell apart the fields
 
                 // It is tempting to verify `b_offset` against `layout.fields.offset(1)`,
@@ -742,12 +743,12 @@ where
                 // destination now to ensure that no stray pointer fragments are being
                 // preserved (see <https://github.com/rust-lang/rust/issues/148470>).
                 // We can skip this if there is no padding (e.g. for wide pointers).
-                if !will_later_validate && a_size + b_val.size() != layout.size {
+                if !will_later_validate && a_size + b_size != layout.size {
                     alloc.write_uninit_full();
                 }
 
                 alloc.write_scalar(alloc_range(Size::ZERO, a_size), a_val)?;
-                alloc.write_scalar(alloc_range(b_offset, b_val.size()), b_val)?;
+                alloc.write_scalar(alloc_range(b_offset, b_size), b_val)?;
             }
             Immediate::Uninit => alloc.write_uninit_full(),
         }

--- a/compiler/rustc_const_eval/src/interpret/validity.rs
+++ b/compiler/rustc_const_eval/src/interpret/validity.rs
@@ -1397,7 +1397,7 @@ impl<'rt, 'tcx, M: Machine<'tcx>> ValueVisitor<'tcx, M> for ValidityVisitor<'rt,
                                 self.path,
                                 Uninit { expected }
                             ),
-                        Immediate::Scalar(..) | Immediate::ScalarPair(..) =>
+                        Immediate::Scalar(..) | Immediate::ScalarPair { .. } =>
                             bug!("arrays/slices can never have Scalar/ScalarPair layout"),
                     }
                 };
@@ -1486,7 +1486,7 @@ impl<'rt, 'tcx, M: Machine<'tcx>> ValueVisitor<'tcx, M> for ValidityVisitor<'rt,
                             self.visit_scalar(scalar, scalar_layout)?;
                         }
                     }
-                    BackendRepr::ScalarPair(a_layout, b_layout) => {
+                    BackendRepr::ScalarPair { a: a_layout, b: b_layout, b_offset: _ } => {
                         // We can only proceed if *both* scalars need to be initialized.
                         // FIXME: find a way to also check ScalarPair when one side can be uninit but
                         // the other must be init.
@@ -1545,7 +1545,7 @@ impl<'rt, 'tcx, M: Machine<'tcx>> ValueVisitor<'tcx, M> for ValidityVisitor<'rt,
                             .expect("the above checks should have fully handled this situation");
                     }
                 }
-                BackendRepr::ScalarPair(a_layout, b_layout) => {
+                BackendRepr::ScalarPair { a: a_layout, b: b_layout, b_offset: _ } => {
                     // We can only proceed if *both* scalars need to be initialized.
                     // FIXME: find a way to also check ScalarPair when one side can be uninit but
                     // the other must be init.

--- a/compiler/rustc_const_eval/src/util/check_validity_requirement.rs
+++ b/compiler/rustc_const_eval/src/util/check_validity_requirement.rs
@@ -121,7 +121,7 @@ fn check_validity_requirement_lax<'tcx>(
     let valid = !this.is_uninhabited() // definitely UB if uninhabited
         && match this.backend_repr {
             BackendRepr::Scalar(s) => scalar_allows_raw_init(s),
-            BackendRepr::ScalarPair(s1, s2) => {
+            BackendRepr::ScalarPair { a: s1, b: s2, b_offset: _ } => {
                 scalar_allows_raw_init(s1) && scalar_allows_raw_init(s2)
             }
             BackendRepr::SimdVector { element: s, count } => count == 0 || scalar_allows_raw_init(s),

--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -2438,7 +2438,7 @@ impl<'tcx> LateLintPass<'tcx> for InvalidValue {
 
             // Check if this ADT has a constrained layout (like `NonNull` and friends).
             if let Ok(layout) = cx.tcx.layout_of(cx.typing_env().as_query_input(ty)) {
-                if let BackendRepr::Scalar(scalar) | BackendRepr::ScalarPair(scalar, _) =
+                if let BackendRepr::Scalar(scalar) | BackendRepr::ScalarPair { a: scalar, .. } =
                     &layout.backend_repr
                 {
                     let range = scalar.valid_range(cx);

--- a/compiler/rustc_middle/src/ty/offload_meta.rs
+++ b/compiler/rustc_middle/src/ty/offload_meta.rs
@@ -76,7 +76,7 @@ impl OffloadMetadata {
         Ty<'tcx>: TyAbiInterface<'tcx, C>,
     {
         match arg_abi.layout.backend_repr {
-            BackendRepr::ScalarPair(_, _) => (0..2)
+            BackendRepr::ScalarPair { a: _, b: _, b_offset: _ } => (0..2)
                 .map(|i| {
                     let ty = arg_abi.layout.field(cx, i).ty;
                     (OffloadMetadata::from_ty(tcx, ty), ty)

--- a/compiler/rustc_mir_transform/src/dataflow_const_prop.rs
+++ b/compiler/rustc_mir_transform/src/dataflow_const_prop.rs
@@ -647,7 +647,7 @@ impl<'a, 'tcx> ConstAnalysis<'a, 'tcx> {
                     // a pair and sometimes not. But as a hack we always return a pair
                     // and just make the 2nd component `Bottom` when it does not exist.
                     Some(val) => {
-                        if matches!(val.layout.backend_repr, BackendRepr::ScalarPair(..)) {
+                        if matches!(val.layout.backend_repr, BackendRepr::ScalarPair { .. }) {
                             let (val, overflow) = val.to_scalar_pair();
                             (FlatSet::Elem(val), FlatSet::Elem(overflow))
                         } else {
@@ -814,7 +814,7 @@ impl<'a, 'tcx> Collector<'a, 'tcx> {
             return Some(Const::Val(ConstValue::Scalar(value), ty));
         }
 
-        if matches!(layout.backend_repr, BackendRepr::Scalar(..) | BackendRepr::ScalarPair(..)) {
+        if matches!(layout.backend_repr, BackendRepr::Scalar(..) | BackendRepr::ScalarPair { .. }) {
             let alloc_id = ecx
                 .intern_with_temp_alloc(layout, |ecx, dest| {
                     try_write_constant(ecx, dest, place, ty, state, map)

--- a/compiler/rustc_mir_transform/src/gvn.rs
+++ b/compiler/rustc_mir_transform/src/gvn.rs
@@ -608,7 +608,7 @@ impl<'body, 'a, 'tcx> VnState<'body, 'a, 'tcx> {
                 let fields =
                     fields.iter().map(|&f| self.eval_to_const(f)).collect::<Option<Vec<_>>>()?;
                 let variant = if ty.ty.is_enum() { Some(variant) } else { None };
-                let (BackendRepr::Scalar(..) | BackendRepr::ScalarPair(..)) = ty.backend_repr
+                let (BackendRepr::Scalar(..) | BackendRepr::ScalarPair { .. }) = ty.backend_repr
                 else {
                     return None;
                 };
@@ -639,7 +639,7 @@ impl<'body, 'a, 'tcx> VnState<'body, 'a, 'tcx> {
                     ImmTy::from_immediate(Immediate::Uninit, ty).into()
                 } else if matches!(
                     ty.backend_repr,
-                    BackendRepr::Scalar(..) | BackendRepr::ScalarPair(..)
+                    BackendRepr::Scalar(..) | BackendRepr::ScalarPair { .. }
                 ) {
                     let dest = self.ecx.allocate(ty, MemoryKind::Stack).discard_err()?;
                     let field_dest = self.ecx.project_field(&dest, active_field).discard_err()?;
@@ -738,11 +738,15 @@ impl<'body, 'a, 'tcx> VnState<'body, 'a, 'tcx> {
                                 s1.size(&self.ecx) == s2.size(&self.ecx)
                                     && !matches!(s1.primitive(), Primitive::Pointer(..))
                             }
-                            (BackendRepr::ScalarPair(a1, b1), BackendRepr::ScalarPair(a2, b2)) => {
+                            (
+                                BackendRepr::ScalarPair { a: a1, b: b1, b_offset: b1_offset },
+                                BackendRepr::ScalarPair { a: a2, b: b2, b_offset: b2_offset },
+                            ) => {
                                 a1.size(&self.ecx) == a2.size(&self.ecx)
                                     && b1.size(&self.ecx) == b2.size(&self.ecx)
-                                    // The alignment of the second component determines its offset, so that also needs to match.
-                                    && b1.default_align(&self.ecx) == b2.default_align(&self.ecx)
+                                    // The first component is always at offset zero, but the offset to the second
+                                    // component needs to match as well for us to be able to transmute.
+                                    && b1_offset == b2_offset
                                     // None of the inputs may be a pointer.
                                     && !matches!(a1.primitive(), Primitive::Pointer(..))
                                     && !matches!(b1.primitive(), Primitive::Pointer(..))
@@ -1804,7 +1808,9 @@ impl<'body, 'a, 'tcx> VnState<'body, 'a, 'tcx> {
                     true
                 }
             }
-            BackendRepr::ScalarPair(a, b) => {
+            BackendRepr::ScalarPair { a, b, b_offset: _ } => {
+                // The offset is irrelevant to niches since it can only cause padding,
+                // which can never have a niche since it's uninitialized.
                 !a.is_always_valid(&self.ecx) || !b.is_always_valid(&self.ecx)
             }
             BackendRepr::SimdVector { .. }
@@ -1902,7 +1908,10 @@ fn op_to_prop_const<'tcx>(
     // But we *do* want to synthesize any size constant if it is entirely uninit because that
     // benefits codegen, which has special handling for them.
     if !op.is_immediate_uninit()
-        && !matches!(op.layout.backend_repr, BackendRepr::Scalar(..) | BackendRepr::ScalarPair(..))
+        && !matches!(
+            op.layout.backend_repr,
+            BackendRepr::Scalar(..) | BackendRepr::ScalarPair { .. }
+        )
     {
         return None;
     }

--- a/compiler/rustc_mir_transform/src/known_panics_lint.rs
+++ b/compiler/rustc_mir_transform/src/known_panics_lint.rs
@@ -563,7 +563,7 @@ impl<'mir, 'tcx> ConstPropagator<'mir, 'tcx> {
                 let right = self.use_ecx(|this| this.ecx.read_immediate(&right))?;
 
                 let val = self.use_ecx(|this| this.ecx.binary_op(bin_op, &left, &right))?;
-                if matches!(val.layout.backend_repr, BackendRepr::ScalarPair(..)) {
+                if matches!(val.layout.backend_repr, BackendRepr::ScalarPair { .. }) {
                     // FIXME `Value` should properly support pairs in `Immediate`... but currently
                     // it does not.
                     let (val, overflow) = val.to_pair(&self.ecx);
@@ -629,7 +629,7 @@ impl<'mir, 'tcx> ConstPropagator<'mir, 'tcx> {
                     // so bail out if the target is not one.
                     match (value.layout.backend_repr, to.backend_repr) {
                         (BackendRepr::Scalar(..), BackendRepr::Scalar(..)) => {}
-                        (BackendRepr::ScalarPair(..), BackendRepr::ScalarPair(..)) => {}
+                        (BackendRepr::ScalarPair { .. }, BackendRepr::ScalarPair { .. }) => {}
                         _ => return None,
                     }
 

--- a/compiler/rustc_public/src/abi.rs
+++ b/compiler/rustc_public/src/abi.rs
@@ -241,7 +241,11 @@ pub struct NumScalableVectors(pub(crate) u8);
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize)]
 pub enum ValueAbi {
     Scalar(Scalar),
-    ScalarPair(Scalar, Scalar),
+    ScalarPair {
+        a: Scalar,
+        b: Scalar,
+        b_offset: Size,
+    },
     Vector {
         element: Scalar,
         count: u64,
@@ -262,7 +266,7 @@ impl ValueAbi {
     pub fn is_unsized(&self) -> bool {
         match *self {
             ValueAbi::Scalar(_)
-            | ValueAbi::ScalarPair(..)
+            | ValueAbi::ScalarPair { .. }
             | ValueAbi::Vector { .. }
             // FIXME(rustc_scalable_vector): Scalable vectors are `Sized` while the
             // `sized_hierarchy` feature is not yet fully implemented. After `sized_hierarchy` is

--- a/compiler/rustc_public/src/unstable/convert/stable/abi.rs
+++ b/compiler/rustc_public/src/unstable/convert/stable/abi.rs
@@ -271,8 +271,12 @@ impl<'tcx> Stable<'tcx> for rustc_abi::BackendRepr {
     ) -> Self::T {
         match *self {
             rustc_abi::BackendRepr::Scalar(scalar) => ValueAbi::Scalar(scalar.stable(tables, cx)),
-            rustc_abi::BackendRepr::ScalarPair(first, second) => {
-                ValueAbi::ScalarPair(first.stable(tables, cx), second.stable(tables, cx))
+            rustc_abi::BackendRepr::ScalarPair { a: first, b: second, b_offset: second_offset } => {
+                ValueAbi::ScalarPair {
+                    a: first.stable(tables, cx),
+                    b: second.stable(tables, cx),
+                    b_offset: second_offset.stable(tables, cx),
+                }
             }
             rustc_abi::BackendRepr::SimdVector { element, count } => {
                 ValueAbi::Vector { element: element.stable(tables, cx), count }

--- a/compiler/rustc_target/src/callconv/aarch64.rs
+++ b/compiler/rustc_target/src/callconv/aarch64.rs
@@ -56,7 +56,7 @@ fn softfloat_float_abi<Ty>(target: &Target, arg: &mut ArgAbi<'_, Ty>) {
         && let Primitive::Float(f) = s.primitive()
     {
         arg.cast_to(Reg { kind: RegKind::Integer, size: f.size() });
-    } else if let BackendRepr::ScalarPair(s1, s2) = arg.layout.backend_repr
+    } else if let BackendRepr::ScalarPair { a: s1, b: s2, b_offset: _ } = arg.layout.backend_repr
         && (matches!(s1.primitive(), Primitive::Float(_))
             || matches!(s2.primitive(), Primitive::Float(_)))
     {

--- a/compiler/rustc_target/src/callconv/loongarch.rs
+++ b/compiler/rustc_target/src/callconv/loongarch.rs
@@ -89,7 +89,7 @@ where
             return Err(CannotUseFpConv);
         }
         BackendRepr::SimdScalableVector { .. } => panic!("scalable vectors are unsupported"),
-        BackendRepr::ScalarPair(..) | BackendRepr::Memory { .. } => match arg_layout.fields {
+        BackendRepr::ScalarPair { .. } | BackendRepr::Memory { .. } => match arg_layout.fields {
             FieldsShape::Primitive => {
                 unreachable!("aggregates can't have `FieldsShape::Primitive`")
             }

--- a/compiler/rustc_target/src/callconv/mod.rs
+++ b/compiler/rustc_target/src/callconv/mod.rs
@@ -390,17 +390,15 @@ impl<'a, Ty: fmt::Display> fmt::Debug for ArgAbi<'a, Ty> {
 impl<'a, Ty> ArgAbi<'a, Ty> {
     /// This defines the "default ABI" for that type, that is then later adjusted in `fn_abi_adjust_for_abi`.
     pub fn new(
-        cx: &impl HasDataLayout,
         layout: TyAndLayout<'a, Ty>,
         scalar_attrs: impl Fn(Scalar, Size) -> ArgAttributes,
     ) -> Self {
         let mode = match layout.backend_repr {
             _ if layout.is_zst() => PassMode::Ignore,
             BackendRepr::Scalar(scalar) => PassMode::Direct(scalar_attrs(scalar, Size::ZERO)),
-            BackendRepr::ScalarPair(a, b) => PassMode::Pair(
-                scalar_attrs(a, Size::ZERO),
-                scalar_attrs(b, a.size(cx).align_to(b.default_align(cx).abi)),
-            ),
+            BackendRepr::ScalarPair { a, b, b_offset } => {
+                PassMode::Pair(scalar_attrs(a, Size::ZERO), scalar_attrs(b, b_offset))
+            }
             BackendRepr::SimdVector { .. } => PassMode::Direct(ArgAttributes::new()),
             BackendRepr::Memory { .. } => Self::indirect_pass_mode(&layout),
             BackendRepr::SimdScalableVector { .. } => PassMode::Direct(ArgAttributes::new()),
@@ -877,7 +875,7 @@ where
 {
     match layout.backend_repr {
         BackendRepr::Scalar(scalar) => !scalar.is_uninit_valid(),
-        BackendRepr::ScalarPair(s1, s2) => {
+        BackendRepr::ScalarPair { a: s1, b: s2, b_offset: _ } => {
             !s1.is_uninit_valid()
                 && !s2.is_uninit_valid()
                 // Ensure there is no padding.

--- a/compiler/rustc_target/src/callconv/riscv.rs
+++ b/compiler/rustc_target/src/callconv/riscv.rs
@@ -94,7 +94,7 @@ where
         BackendRepr::SimdVector { .. } | BackendRepr::SimdScalableVector { .. } => {
             return Err(CannotUseFpConv);
         }
-        BackendRepr::ScalarPair(..) | BackendRepr::Memory { .. } => match arg_layout.fields {
+        BackendRepr::ScalarPair { .. } | BackendRepr::Memory { .. } => match arg_layout.fields {
             FieldsShape::Primitive => {
                 unreachable!("aggregates can't have `FieldsShape::Primitive`")
             }

--- a/compiler/rustc_target/src/callconv/sparc64.rs
+++ b/compiler/rustc_target/src/callconv/sparc64.rs
@@ -67,7 +67,7 @@ fn classify<'a, Ty, C>(
         },
         BackendRepr::SimdVector { .. } => {}
         BackendRepr::SimdScalableVector { .. } => {}
-        BackendRepr::ScalarPair(..) | BackendRepr::Memory { .. } => match arg_layout.fields {
+        BackendRepr::ScalarPair { .. } | BackendRepr::Memory { .. } => match arg_layout.fields {
             FieldsShape::Primitive => {
                 unreachable!("aggregates can't have `FieldsShape::Primitive`")
             }

--- a/compiler/rustc_target/src/callconv/x86.rs
+++ b/compiler/rustc_target/src/callconv/x86.rs
@@ -92,7 +92,7 @@ where
                 Ty: TyAbiInterface<'a, C> + Copy,
             {
                 match layout.backend_repr {
-                    BackendRepr::Scalar(_) | BackendRepr::ScalarPair(..) => false,
+                    BackendRepr::Scalar(_) | BackendRepr::ScalarPair { .. } => false,
                     BackendRepr::SimdVector { .. } => true,
                     BackendRepr::Memory { .. } => {
                         for i in 0..layout.fields.count() {
@@ -211,7 +211,7 @@ where
     if !fn_abi.ret.is_ignore() {
         let has_float = match fn_abi.ret.layout.backend_repr {
             BackendRepr::Scalar(s) => matches!(s.primitive(), Primitive::Float(_)),
-            BackendRepr::ScalarPair(s1, s2) => {
+            BackendRepr::ScalarPair { a: s1, b: s2, b_offset: _ } => {
                 matches!(s1.primitive(), Primitive::Float(_))
                     || matches!(s2.primitive(), Primitive::Float(_))
             }

--- a/compiler/rustc_target/src/callconv/x86_64.rs
+++ b/compiler/rustc_target/src/callconv/x86_64.rs
@@ -61,7 +61,7 @@ where
 
             BackendRepr::SimdScalableVector { .. } => panic!("scalable vectors are unsupported"),
 
-            BackendRepr::ScalarPair(..) | BackendRepr::Memory { .. } => {
+            BackendRepr::ScalarPair { .. } | BackendRepr::Memory { .. } => {
                 for i in 0..layout.fields.count() {
                     let field_off = off + layout.fields.offset(i);
                     classify(cx, layout.field(cx, i), cls, field_off)?;

--- a/compiler/rustc_target/src/callconv/x86_win64.rs
+++ b/compiler/rustc_target/src/callconv/x86_win64.rs
@@ -12,7 +12,7 @@ where
     let fixup = |a: &mut ArgAbi<'_, Ty>, is_ret: bool| {
         match a.layout.backend_repr {
             BackendRepr::Memory { sized: false } => {}
-            BackendRepr::ScalarPair(..) | BackendRepr::Memory { sized: true } => {
+            BackendRepr::ScalarPair { .. } | BackendRepr::Memory { sized: true } => {
                 match a.layout.size.bits() {
                     8 => a.cast_to(Reg::i8()),
                     16 => a.cast_to(Reg::i16()),

--- a/compiler/rustc_ty_utils/src/abi.rs
+++ b/compiler/rustc_ty_utils/src/abi.rs
@@ -486,7 +486,7 @@ fn fn_abi_sanity_check<'tcx>(
                     BackendRepr::Scalar(_)
                     | BackendRepr::SimdVector { .. }
                     | BackendRepr::SimdScalableVector { .. } => {}
-                    BackendRepr::ScalarPair(..) => {
+                    BackendRepr::ScalarPair { .. } => {
                         panic!("`PassMode::Direct` used for ScalarPair type {}", arg.layout.ty)
                     }
                     BackendRepr::Memory { sized } => {
@@ -513,7 +513,7 @@ fn fn_abi_sanity_check<'tcx>(
                 // Similar to `Direct`, we need to make sure that backends use `layout.backend_repr`
                 // and ignore the rest of the layout.
                 assert!(
-                    matches!(arg.layout.backend_repr, BackendRepr::ScalarPair(..)),
+                    matches!(arg.layout.backend_repr, BackendRepr::ScalarPair { .. }),
                     "PassMode::Pair for type {}",
                     arg.layout.ty
                 );
@@ -612,7 +612,7 @@ fn fn_abi_new_uncached<'tcx>(
             layout
         };
 
-        Ok(ArgAbi::new(cx, layout, |scalar, offset| {
+        Ok(ArgAbi::new(layout, |scalar, offset| {
             arg_attrs_for_rust_scalar(*cx, scalar, layout, offset, is_return, determined_fn_def_id)
         }))
     };
@@ -741,7 +741,7 @@ fn make_thin_self_ptr<'tcx>(
         Ty::new_mut_ptr(tcx, layout.ty)
     } else {
         match layout.backend_repr {
-            BackendRepr::ScalarPair(..) | BackendRepr::Scalar(..) => (),
+            BackendRepr::ScalarPair { .. } | BackendRepr::Scalar(..) => (),
             _ => bug!("receiver type has unsupported layout: {:?}", layout),
         }
 

--- a/compiler/rustc_ty_utils/src/layout.rs
+++ b/compiler/rustc_ty_utils/src/layout.rs
@@ -291,7 +291,8 @@ fn layout_of_uncached<'tcx>(
                     }
                 }
                 ty::PatternKind::NotNull => {
-                    if let BackendRepr::Scalar(scalar) | BackendRepr::ScalarPair(scalar, _) =
+                    if let BackendRepr::Scalar(scalar)
+                    | BackendRepr::ScalarPair { a: scalar, b: _, b_offset: _ } =
                         &mut layout.backend_repr
                     {
                         scalar.valid_range_mut().start = 1;

--- a/compiler/rustc_ty_utils/src/layout/invariant.rs
+++ b/compiler/rustc_ty_utils/src/layout/invariant.rs
@@ -158,14 +158,20 @@ pub(super) fn layout_sanity_check<'tcx>(cx: &LayoutCx<'tcx>, layout: &TyAndLayou
                     }
                 }
             }
-            BackendRepr::ScalarPair(scalar1, scalar2) => {
+            BackendRepr::ScalarPair { a: scalar1, b: scalar2, b_offset } => {
                 // Check that the underlying pair of fields matches.
                 let inner = skip_newtypes(cx, layout);
                 assert!(
-                    matches!(inner.layout.backend_repr(), BackendRepr::ScalarPair(..)),
+                    matches!(inner.layout.backend_repr(), BackendRepr::ScalarPair { .. }),
                     "`ScalarPair` type {} is newtype around non-`ScalarPair` type {}",
                     layout.ty,
                     inner.ty
+                );
+                // `a` is at memory offset zero, so to keep them from overlapping the offset
+                // to `b` must be at least as much as the size of `a`.
+                assert!(
+                    b_offset >= scalar1.size(cx),
+                    "`ScalarPair` scalars are overlapping in {layout:?}",
                 );
                 if matches!(inner.layout.variants(), Variants::Multiple { .. }) {
                     // FIXME: ScalarPair for enums is enormously complicated and it is very hard
@@ -233,6 +239,10 @@ pub(super) fn layout_sanity_check<'tcx>(cx: &LayoutCx<'tcx>, layout: &TyAndLayou
                 assert_eq!(
                     offset2, field2_offset,
                     "`ScalarPair` second field at bad offset in {inner:#?}",
+                );
+                assert_eq!(
+                    b_offset, field2_offset,
+                    "`ScalarPair` with inconsistent b_offset in {inner:#?}",
                 );
                 assert_eq!(
                     field2.size, size2,
@@ -325,8 +335,11 @@ pub(super) fn layout_sanity_check<'tcx>(cx: &LayoutCx<'tcx>, layout: &TyAndLayou
                 };
                 let abi_coherent = match (layout.backend_repr, variant.backend_repr) {
                     (BackendRepr::Scalar(s1), BackendRepr::Scalar(s2)) => scalar_coherent(s1, s2),
-                    (BackendRepr::ScalarPair(a1, b1), BackendRepr::ScalarPair(a2, b2)) => {
-                        scalar_coherent(a1, a2) && scalar_coherent(b1, b2)
+                    (
+                        BackendRepr::ScalarPair { a: a1, b: b1, b_offset: b1_offset },
+                        BackendRepr::ScalarPair { a: a2, b: b2, b_offset: b2_offset },
+                    ) => {
+                        scalar_coherent(a1, a2) && scalar_coherent(b1, b2) && b1_offset == b2_offset
                     }
                     (BackendRepr::Memory { .. }, _) => true,
                     _ => false,

--- a/src/tools/clippy/clippy_utils/src/ty/mod.rs
+++ b/src/tools/clippy/clippy_utils/src/ty/mod.rs
@@ -525,7 +525,7 @@ fn is_uninit_value_valid_for_layout<'tcx>(cx: &LateContext<'tcx>, layout: TyAndL
 
     match layout.layout.backend_repr {
         BackendRepr::Scalar(s) => s.is_uninit_valid(),
-        BackendRepr::ScalarPair(a, b) => a.is_uninit_valid() && b.is_uninit_valid(),
+        BackendRepr::ScalarPair { a, b, b_offset: _ } => a.is_uninit_valid() && b.is_uninit_valid(),
         BackendRepr::SimdVector { element, count } => count == 0 || element.is_uninit_valid(),
         BackendRepr::SimdScalableVector { element, .. } => element.is_uninit_valid(),
         // Here validity is determined by the structural fields instead.

--- a/src/tools/miri/src/shims/native_lib/mod.rs
+++ b/src/tools/miri/src/shims/native_lib/mod.rs
@@ -313,7 +313,8 @@ trait EvalContextExtPriv<'tcx>: crate::MiriInterpCxExt<'tcx> {
                     Immediate::ScalarPair(sc_first, sc_second) => {
                         // The first scalar has an offset of zero; compute the offset of the 2nd.
                         let ofs_second = {
-                            let rustc_abi::BackendRepr::ScalarPair(a, b) = imm.layout.backend_repr
+                            let rustc_abi::BackendRepr::ScalarPair { a: _, b: _, b_offset } =
+                                imm.layout.backend_repr
                             else {
                                 span_bug!(
                                     this.cur_span(),
@@ -321,7 +322,7 @@ trait EvalContextExtPriv<'tcx>: crate::MiriInterpCxExt<'tcx> {
                                     imm.layout
                                 )
                             };
-                            a.size(this).align_to(b.default_align(this).abi).bytes_usize()
+                            b_offset.bytes_usize()
                         };
 
                         write_scalar(this, sc_first, 0)?;

--- a/tests/ui/layout/debug.stderr
+++ b/tests/ui/layout/debug.stderr
@@ -102,22 +102,23 @@ error: layout_of(S) = Layout {
            align: AbiAlign {
                abi: Align(4 bytes),
            },
-           backend_repr: ScalarPair(
-               Initialized {
+           backend_repr: ScalarPair {
+               a: Initialized {
                    value: Int(
                        I32,
                        true,
                    ),
                    valid_range: 0..=4294967295,
                },
-               Initialized {
+               b: Initialized {
                    value: Int(
                        I32,
                        true,
                    ),
                    valid_range: 0..=4294967295,
                },
-           ),
+               b_offset: Size(4 bytes),
+           },
            fields: Arbitrary {
                offsets: [
                    Size(0 bytes),
@@ -174,22 +175,23 @@ error: layout_of(Result<i32, i32>) = Layout {
            align: AbiAlign {
                abi: Align(4 bytes),
            },
-           backend_repr: ScalarPair(
-               Initialized {
+           backend_repr: ScalarPair {
+               a: Initialized {
                    value: Int(
                        I32,
                        false,
                    ),
                    valid_range: 0..=1,
                },
-               Initialized {
+               b: Initialized {
                    value: Int(
                        I32,
                        true,
                    ),
                    valid_range: 0..=4294967295,
                },
-           ),
+               b_offset: Size(4 bytes),
+           },
            fields: Arbitrary {
                offsets: [
                    Size(0 bytes),
@@ -222,22 +224,23 @@ error: layout_of(Result<i32, i32>) = Layout {
                variants: [
                    VariantLayout {
                        size: Size(8 bytes),
-                       backend_repr: ScalarPair(
-                           Initialized {
+                       backend_repr: ScalarPair {
+                           a: Initialized {
                                value: Int(
                                    I32,
                                    false,
                                ),
                                valid_range: 0..=1,
                            },
-                           Initialized {
+                           b: Initialized {
                                value: Int(
                                    I32,
                                    true,
                                ),
                                valid_range: 0..=4294967295,
                            },
-                       ),
+                           b_offset: Size(4 bytes),
+                       },
                        field_offsets: [
                            Size(4 bytes),
                        ],
@@ -249,22 +252,23 @@ error: layout_of(Result<i32, i32>) = Layout {
                    },
                    VariantLayout {
                        size: Size(8 bytes),
-                       backend_repr: ScalarPair(
-                           Initialized {
+                       backend_repr: ScalarPair {
+                           a: Initialized {
                                value: Int(
                                    I32,
                                    false,
                                ),
                                valid_range: 0..=1,
                            },
-                           Initialized {
+                           b: Initialized {
                                value: Int(
                                    I32,
                                    true,
                                ),
                                valid_range: 0..=4294967295,
                            },
-                       ),
+                           b_offset: Size(4 bytes),
+                       },
                        field_offsets: [
                            Size(4 bytes),
                        ],

--- a/tests/ui/layout/enum-scalar-pair-int-ptr.rs
+++ b/tests/ui/layout/enum-scalar-pair-int-ptr.rs
@@ -1,6 +1,7 @@
 //@ normalize-stderr: "pref: Align\([1-8] bytes\)" -> "pref: $$PREF_ALIGN"
 //@ normalize-stderr: "Int\(I[0-9]+," -> "Int(I?,"
 //@ normalize-stderr: "valid_range: 0..=[0-9]+" -> "valid_range: $$VALID_RANGE"
+//@ normalize-stderr: "b_offset: Size\([0-9]+ bytes\)" -> "b_offset: Size(? bytes)"
 
 //! Enum layout tests related to scalar pairs with an int/ptr common primitive.
 

--- a/tests/ui/layout/enum-scalar-pair-int-ptr.stderr
+++ b/tests/ui/layout/enum-scalar-pair-int-ptr.stderr
@@ -1,11 +1,11 @@
-error: backend_repr: ScalarPair(Initialized { value: Int(I?, false), valid_range: $VALID_RANGE }, Initialized { value: Pointer(AddressSpace(0)), valid_range: $VALID_RANGE })
-  --> $DIR/enum-scalar-pair-int-ptr.rs:12:1
+error: backend_repr: ScalarPair { a: Initialized { value: Int(I?, false), valid_range: $VALID_RANGE }, b: Initialized { value: Pointer(AddressSpace(0)), valid_range: $VALID_RANGE }, b_offset: Size(? bytes) }
+  --> $DIR/enum-scalar-pair-int-ptr.rs:13:1
    |
 LL | enum ScalarPairPointerWithInt {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: backend_repr: Memory { sized: true }
-  --> $DIR/enum-scalar-pair-int-ptr.rs:21:1
+  --> $DIR/enum-scalar-pair-int-ptr.rs:22:1
    |
 LL | enum NotScalarPairPointerWithSmallerInt {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/layout/enum.stderr
+++ b/tests/ui/layout/enum.stderr
@@ -10,7 +10,7 @@ error: size: Size(16 bytes)
 LL | enum UninhabitedVariantSpace {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: backend_repr: ScalarPair(Initialized { value: Int(I8, false), valid_range: 0..=1 }, Initialized { value: Int(I8, false), valid_range: 0..=255 })
+error: backend_repr: ScalarPair { a: Initialized { value: Int(I8, false), valid_range: 0..=1 }, b: Initialized { value: Int(I8, false), valid_range: 0..=255 }, b_offset: Size(1 bytes) }
   --> $DIR/enum.rs:21:1
    |
 LL | enum ScalarPairDifferingSign {

--- a/tests/ui/layout/issue-96158-scalarpair-payload-might-be-uninit.stderr
+++ b/tests/ui/layout/issue-96158-scalarpair-payload-might-be-uninit.stderr
@@ -3,21 +3,22 @@ error: layout_of(MissingPayloadField) = Layout {
            align: AbiAlign {
                abi: Align(1 bytes),
            },
-           backend_repr: ScalarPair(
-               Initialized {
+           backend_repr: ScalarPair {
+               a: Initialized {
                    value: Int(
                        I8,
                        false,
                    ),
                    valid_range: 0..=1,
                },
-               Union {
+               b: Union {
                    value: Int(
                        I8,
                        false,
                    ),
                },
-           ),
+               b_offset: Size(1 bytes),
+           },
            fields: Arbitrary {
                offsets: [
                    Size(0 bytes),
@@ -50,21 +51,22 @@ error: layout_of(MissingPayloadField) = Layout {
                variants: [
                    VariantLayout {
                        size: Size(2 bytes),
-                       backend_repr: ScalarPair(
-                           Initialized {
+                       backend_repr: ScalarPair {
+                           a: Initialized {
                                value: Int(
                                    I8,
                                    false,
                                ),
                                valid_range: 0..=1,
                            },
-                           Union {
+                           b: Union {
                                value: Int(
                                    I8,
                                    false,
                                ),
                            },
-                       ),
+                           b_offset: Size(1 bytes),
+                       },
                        field_offsets: [
                            Size(1 bytes),
                        ],
@@ -100,22 +102,23 @@ error: layout_of(CommonPayloadField) = Layout {
            align: AbiAlign {
                abi: Align(1 bytes),
            },
-           backend_repr: ScalarPair(
-               Initialized {
+           backend_repr: ScalarPair {
+               a: Initialized {
                    value: Int(
                        I8,
                        false,
                    ),
                    valid_range: 0..=1,
                },
-               Initialized {
+               b: Initialized {
                    value: Int(
                        I8,
                        false,
                    ),
                    valid_range: 0..=255,
                },
-           ),
+               b_offset: Size(1 bytes),
+           },
            fields: Arbitrary {
                offsets: [
                    Size(0 bytes),
@@ -148,22 +151,23 @@ error: layout_of(CommonPayloadField) = Layout {
                variants: [
                    VariantLayout {
                        size: Size(2 bytes),
-                       backend_repr: ScalarPair(
-                           Initialized {
+                       backend_repr: ScalarPair {
+                           a: Initialized {
                                value: Int(
                                    I8,
                                    false,
                                ),
                                valid_range: 0..=1,
                            },
-                           Initialized {
+                           b: Initialized {
                                value: Int(
                                    I8,
                                    false,
                                ),
                                valid_range: 0..=255,
                            },
-                       ),
+                           b_offset: Size(1 bytes),
+                       },
                        field_offsets: [
                            Size(1 bytes),
                        ],
@@ -175,22 +179,23 @@ error: layout_of(CommonPayloadField) = Layout {
                    },
                    VariantLayout {
                        size: Size(2 bytes),
-                       backend_repr: ScalarPair(
-                           Initialized {
+                       backend_repr: ScalarPair {
+                           a: Initialized {
                                value: Int(
                                    I8,
                                    false,
                                ),
                                valid_range: 0..=1,
                            },
-                           Initialized {
+                           b: Initialized {
                                value: Int(
                                    I8,
                                    false,
                                ),
                                valid_range: 0..=255,
                            },
-                       ),
+                           b_offset: Size(1 bytes),
+                       },
                        field_offsets: [
                            Size(1 bytes),
                        ],
@@ -216,21 +221,22 @@ error: layout_of(CommonPayloadFieldIsMaybeUninit) = Layout {
            align: AbiAlign {
                abi: Align(1 bytes),
            },
-           backend_repr: ScalarPair(
-               Initialized {
+           backend_repr: ScalarPair {
+               a: Initialized {
                    value: Int(
                        I8,
                        false,
                    ),
                    valid_range: 0..=1,
                },
-               Union {
+               b: Union {
                    value: Int(
                        I8,
                        false,
                    ),
                },
-           ),
+               b_offset: Size(1 bytes),
+           },
            fields: Arbitrary {
                offsets: [
                    Size(0 bytes),
@@ -263,21 +269,22 @@ error: layout_of(CommonPayloadFieldIsMaybeUninit) = Layout {
                variants: [
                    VariantLayout {
                        size: Size(2 bytes),
-                       backend_repr: ScalarPair(
-                           Initialized {
+                       backend_repr: ScalarPair {
+                           a: Initialized {
                                value: Int(
                                    I8,
                                    false,
                                ),
                                valid_range: 0..=1,
                            },
-                           Union {
+                           b: Union {
                                value: Int(
                                    I8,
                                    false,
                                ),
                            },
-                       ),
+                           b_offset: Size(1 bytes),
+                       },
                        field_offsets: [
                            Size(1 bytes),
                        ],
@@ -289,21 +296,22 @@ error: layout_of(CommonPayloadFieldIsMaybeUninit) = Layout {
                    },
                    VariantLayout {
                        size: Size(2 bytes),
-                       backend_repr: ScalarPair(
-                           Initialized {
+                       backend_repr: ScalarPair {
+                           a: Initialized {
                                value: Int(
                                    I8,
                                    false,
                                ),
                                valid_range: 0..=1,
                            },
-                           Union {
+                           b: Union {
                                value: Int(
                                    I8,
                                    false,
                                ),
                            },
-                       ),
+                           b_offset: Size(1 bytes),
+                       },
                        field_offsets: [
                            Size(1 bytes),
                        ],
@@ -329,21 +337,22 @@ error: layout_of(NicheFirst) = Layout {
            align: AbiAlign {
                abi: Align(1 bytes),
            },
-           backend_repr: ScalarPair(
-               Initialized {
+           backend_repr: ScalarPair {
+               a: Initialized {
                    value: Int(
                        I8,
                        false,
                    ),
                    valid_range: 0..=4,
                },
-               Union {
+               b: Union {
                    value: Int(
                        I8,
                        false,
                    ),
                },
-           ),
+               b_offset: Size(1 bytes),
+           },
            fields: Arbitrary {
                offsets: [
                    Size(0 bytes),
@@ -380,22 +389,23 @@ error: layout_of(NicheFirst) = Layout {
                variants: [
                    VariantLayout {
                        size: Size(2 bytes),
-                       backend_repr: ScalarPair(
-                           Initialized {
+                       backend_repr: ScalarPair {
+                           a: Initialized {
                                value: Int(
                                    I8,
                                    false,
                                ),
                                valid_range: 0..=2,
                            },
-                           Initialized {
+                           b: Initialized {
                                value: Int(
                                    I8,
                                    false,
                                ),
                                valid_range: 0..=255,
                            },
-                       ),
+                           b_offset: Size(1 bytes),
+                       },
                        field_offsets: [
                            Size(0 bytes),
                            Size(1 bytes),
@@ -452,21 +462,22 @@ error: layout_of(NicheSecond) = Layout {
            align: AbiAlign {
                abi: Align(1 bytes),
            },
-           backend_repr: ScalarPair(
-               Initialized {
+           backend_repr: ScalarPair {
+               a: Initialized {
                    value: Int(
                        I8,
                        false,
                    ),
                    valid_range: 0..=4,
                },
-               Union {
+               b: Union {
                    value: Int(
                        I8,
                        false,
                    ),
                },
-           ),
+               b_offset: Size(1 bytes),
+           },
            fields: Arbitrary {
                offsets: [
                    Size(0 bytes),
@@ -503,22 +514,23 @@ error: layout_of(NicheSecond) = Layout {
                variants: [
                    VariantLayout {
                        size: Size(2 bytes),
-                       backend_repr: ScalarPair(
-                           Initialized {
+                       backend_repr: ScalarPair {
+                           a: Initialized {
                                value: Int(
                                    I8,
                                    false,
                                ),
                                valid_range: 0..=2,
                            },
-                           Initialized {
+                           b: Initialized {
                                value: Int(
                                    I8,
                                    false,
                                ),
                                valid_range: 0..=255,
                            },
-                       ),
+                           b_offset: Size(1 bytes),
+                       },
                        field_offsets: [
                            Size(1 bytes),
                            Size(0 bytes),

--- a/tests/ui/repr/repr-c-dead-variants.aarch64-unknown-linux-gnu.stderr
+++ b/tests/ui/repr/repr-c-dead-variants.aarch64-unknown-linux-gnu.stderr
@@ -78,21 +78,22 @@ error: layout_of(TwoVariants) = Layout {
            align: AbiAlign {
                abi: Align(4 bytes),
            },
-           backend_repr: ScalarPair(
-               Initialized {
+           backend_repr: ScalarPair {
+               a: Initialized {
                    value: Int(
                        I32,
                        false,
                    ),
                    valid_range: 0..=1,
                },
-               Union {
+               b: Union {
                    value: Int(
                        I8,
                        false,
                    ),
                },
-           ),
+               b_offset: Size(4 bytes),
+           },
            fields: Arbitrary {
                offsets: [
                    Size(0 bytes),
@@ -125,21 +126,22 @@ error: layout_of(TwoVariants) = Layout {
                variants: [
                    VariantLayout {
                        size: Size(8 bytes),
-                       backend_repr: ScalarPair(
-                           Initialized {
+                       backend_repr: ScalarPair {
+                           a: Initialized {
                                value: Int(
                                    I32,
                                    false,
                                ),
                                valid_range: 0..=1,
                            },
-                           Union {
+                           b: Union {
                                value: Int(
                                    I8,
                                    false,
                                ),
                            },
-                       ),
+                           b_offset: Size(4 bytes),
+                       },
                        field_offsets: [
                            Size(4 bytes),
                        ],
@@ -151,21 +153,22 @@ error: layout_of(TwoVariants) = Layout {
                    },
                    VariantLayout {
                        size: Size(8 bytes),
-                       backend_repr: ScalarPair(
-                           Initialized {
+                       backend_repr: ScalarPair {
+                           a: Initialized {
                                value: Int(
                                    I32,
                                    false,
                                ),
                                valid_range: 0..=1,
                            },
-                           Union {
+                           b: Union {
                                value: Int(
                                    I8,
                                    false,
                                ),
                            },
-                       ),
+                           b_offset: Size(4 bytes),
+                       },
                        field_offsets: [
                            Size(4 bytes),
                        ],

--- a/tests/ui/repr/repr-c-dead-variants.armebv7r-none-eabi.stderr
+++ b/tests/ui/repr/repr-c-dead-variants.armebv7r-none-eabi.stderr
@@ -78,21 +78,22 @@ error: layout_of(TwoVariants) = Layout {
            align: AbiAlign {
                abi: Align(1 bytes),
            },
-           backend_repr: ScalarPair(
-               Initialized {
+           backend_repr: ScalarPair {
+               a: Initialized {
                    value: Int(
                        I8,
                        false,
                    ),
                    valid_range: 0..=1,
                },
-               Union {
+               b: Union {
                    value: Int(
                        I8,
                        false,
                    ),
                },
-           ),
+               b_offset: Size(1 bytes),
+           },
            fields: Arbitrary {
                offsets: [
                    Size(0 bytes),
@@ -125,21 +126,22 @@ error: layout_of(TwoVariants) = Layout {
                variants: [
                    VariantLayout {
                        size: Size(2 bytes),
-                       backend_repr: ScalarPair(
-                           Initialized {
+                       backend_repr: ScalarPair {
+                           a: Initialized {
                                value: Int(
                                    I8,
                                    false,
                                ),
                                valid_range: 0..=1,
                            },
-                           Union {
+                           b: Union {
                                value: Int(
                                    I8,
                                    false,
                                ),
                            },
-                       ),
+                           b_offset: Size(1 bytes),
+                       },
                        field_offsets: [
                            Size(1 bytes),
                        ],
@@ -151,21 +153,22 @@ error: layout_of(TwoVariants) = Layout {
                    },
                    VariantLayout {
                        size: Size(2 bytes),
-                       backend_repr: ScalarPair(
-                           Initialized {
+                       backend_repr: ScalarPair {
+                           a: Initialized {
                                value: Int(
                                    I8,
                                    false,
                                ),
                                valid_range: 0..=1,
                            },
-                           Union {
+                           b: Union {
                                value: Int(
                                    I8,
                                    false,
                                ),
                            },
-                       ),
+                           b_offset: Size(1 bytes),
+                       },
                        field_offsets: [
                            Size(1 bytes),
                        ],

--- a/tests/ui/repr/repr-c-dead-variants.i686-pc-windows-msvc.stderr
+++ b/tests/ui/repr/repr-c-dead-variants.i686-pc-windows-msvc.stderr
@@ -78,21 +78,22 @@ error: layout_of(TwoVariants) = Layout {
            align: AbiAlign {
                abi: Align(4 bytes),
            },
-           backend_repr: ScalarPair(
-               Initialized {
+           backend_repr: ScalarPair {
+               a: Initialized {
                    value: Int(
                        I32,
                        false,
                    ),
                    valid_range: 0..=1,
                },
-               Union {
+               b: Union {
                    value: Int(
                        I8,
                        false,
                    ),
                },
-           ),
+               b_offset: Size(4 bytes),
+           },
            fields: Arbitrary {
                offsets: [
                    Size(0 bytes),
@@ -125,21 +126,22 @@ error: layout_of(TwoVariants) = Layout {
                variants: [
                    VariantLayout {
                        size: Size(8 bytes),
-                       backend_repr: ScalarPair(
-                           Initialized {
+                       backend_repr: ScalarPair {
+                           a: Initialized {
                                value: Int(
                                    I32,
                                    false,
                                ),
                                valid_range: 0..=1,
                            },
-                           Union {
+                           b: Union {
                                value: Int(
                                    I8,
                                    false,
                                ),
                            },
-                       ),
+                           b_offset: Size(4 bytes),
+                       },
                        field_offsets: [
                            Size(4 bytes),
                        ],
@@ -151,21 +153,22 @@ error: layout_of(TwoVariants) = Layout {
                    },
                    VariantLayout {
                        size: Size(8 bytes),
-                       backend_repr: ScalarPair(
-                           Initialized {
+                       backend_repr: ScalarPair {
+                           a: Initialized {
                                value: Int(
                                    I32,
                                    false,
                                ),
                                valid_range: 0..=1,
                            },
-                           Union {
+                           b: Union {
                                value: Int(
                                    I8,
                                    false,
                                ),
                            },
-                       ),
+                           b_offset: Size(4 bytes),
+                       },
                        field_offsets: [
                            Size(4 bytes),
                        ],

--- a/tests/ui/repr/repr-c-dead-variants.x86_64-unknown-linux-gnu.stderr
+++ b/tests/ui/repr/repr-c-dead-variants.x86_64-unknown-linux-gnu.stderr
@@ -78,21 +78,22 @@ error: layout_of(TwoVariants) = Layout {
            align: AbiAlign {
                abi: Align(4 bytes),
            },
-           backend_repr: ScalarPair(
-               Initialized {
+           backend_repr: ScalarPair {
+               a: Initialized {
                    value: Int(
                        I32,
                        false,
                    ),
                    valid_range: 0..=1,
                },
-               Union {
+               b: Union {
                    value: Int(
                        I8,
                        false,
                    ),
                },
-           ),
+               b_offset: Size(4 bytes),
+           },
            fields: Arbitrary {
                offsets: [
                    Size(0 bytes),
@@ -125,21 +126,22 @@ error: layout_of(TwoVariants) = Layout {
                variants: [
                    VariantLayout {
                        size: Size(8 bytes),
-                       backend_repr: ScalarPair(
-                           Initialized {
+                       backend_repr: ScalarPair {
+                           a: Initialized {
                                value: Int(
                                    I32,
                                    false,
                                ),
                                valid_range: 0..=1,
                            },
-                           Union {
+                           b: Union {
                                value: Int(
                                    I8,
                                    false,
                                ),
                            },
-                       ),
+                           b_offset: Size(4 bytes),
+                       },
                        field_offsets: [
                            Size(4 bytes),
                        ],
@@ -151,21 +153,22 @@ error: layout_of(TwoVariants) = Layout {
                    },
                    VariantLayout {
                        size: Size(8 bytes),
-                       backend_repr: ScalarPair(
-                           Initialized {
+                       backend_repr: ScalarPair {
+                           a: Initialized {
                                value: Int(
                                    I32,
                                    false,
                                ),
                                valid_range: 0..=1,
                            },
-                           Union {
+                           b: Union {
                                value: Int(
                                    I8,
                                    false,
                                ),
                            },
-                       ),
+                           b_offset: Size(4 bytes),
+                       },
                        field_offsets: [
                            Size(4 bytes),
                        ],

--- a/tests/ui/repr/repr-c-int-dead-variants.stderr
+++ b/tests/ui/repr/repr-c-int-dead-variants.stderr
@@ -78,21 +78,22 @@ error: layout_of(TwoVariantsU8) = Layout {
            align: AbiAlign {
                abi: Align(1 bytes),
            },
-           backend_repr: ScalarPair(
-               Initialized {
+           backend_repr: ScalarPair {
+               a: Initialized {
                    value: Int(
                        I8,
                        false,
                    ),
                    valid_range: 0..=1,
                },
-               Union {
+               b: Union {
                    value: Int(
                        I8,
                        false,
                    ),
                },
-           ),
+               b_offset: Size(1 bytes),
+           },
            fields: Arbitrary {
                offsets: [
                    Size(0 bytes),
@@ -125,21 +126,22 @@ error: layout_of(TwoVariantsU8) = Layout {
                variants: [
                    VariantLayout {
                        size: Size(2 bytes),
-                       backend_repr: ScalarPair(
-                           Initialized {
+                       backend_repr: ScalarPair {
+                           a: Initialized {
                                value: Int(
                                    I8,
                                    false,
                                ),
                                valid_range: 0..=1,
                            },
-                           Union {
+                           b: Union {
                                value: Int(
                                    I8,
                                    false,
                                ),
                            },
-                       ),
+                           b_offset: Size(1 bytes),
+                       },
                        field_offsets: [
                            Size(1 bytes),
                        ],
@@ -151,21 +153,22 @@ error: layout_of(TwoVariantsU8) = Layout {
                    },
                    VariantLayout {
                        size: Size(2 bytes),
-                       backend_repr: ScalarPair(
-                           Initialized {
+                       backend_repr: ScalarPair {
+                           a: Initialized {
                                value: Int(
                                    I8,
                                    false,
                                ),
                                valid_range: 0..=1,
                            },
-                           Union {
+                           b: Union {
                                value: Int(
                                    I8,
                                    false,
                                ),
                            },
-                       ),
+                           b_offset: Size(1 bytes),
+                       },
                        field_offsets: [
                            Size(1 bytes),
                        ],

--- a/tests/ui/type/pattern_types/non_null.stderr
+++ b/tests/ui/type/pattern_types/non_null.stderr
@@ -143,8 +143,8 @@ error: layout_of((*const [u8]) is !null) = Layout {
            align: AbiAlign {
                abi: Align(8 bytes),
            },
-           backend_repr: ScalarPair(
-               Initialized {
+           backend_repr: ScalarPair {
+               a: Initialized {
                    value: Pointer(
                        AddressSpace(
                            0,
@@ -152,14 +152,15 @@ error: layout_of((*const [u8]) is !null) = Layout {
                    ),
                    valid_range: 1..=18446744073709551615,
                },
-               Initialized {
+               b: Initialized {
                    value: Int(
                        I64,
                        false,
                    ),
                    valid_range: 0..=18446744073709551615,
                },
-           ),
+               b_offset: Size(8 bytes),
+           },
            fields: Arbitrary {
                offsets: [
                    Size(0 bytes),


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/158666)*
<!-- homu-ignore:end -->

Inspired by https://github.com/rust-lang/compiler-team/issues/1007 but doesn't actually change any of the layout rules just yet.

This turned out to be a nice change even if we didn't use the extra flexibility, IMHO, because it allowed so many things like

```diff
@@ -222,12 +224,12 @@ fn from_const_alloc<Bx: BuilderMethods<'a, 'tcx, Value = V>>(
                 let val = read_scalar(offset, size, s, bx.immediate_backend_type(layout));
                 OperandRef { val: OperandValue::Immediate(val), layout, move_annotation: None }
             }
-            BackendRepr::ScalarPair(
-                a @ abi::Scalar::Initialized { .. },
-                b @ abi::Scalar::Initialized { .. },
-            ) => {
+            BackendRepr::ScalarPair {
+                a: a @ abi::Scalar::Initialized { .. },
+                b: b @ abi::Scalar::Initialized { .. },
+                b_offset,
+            } => {
                 let (a_size, b_size) = (a.size(bx), b.size(bx));
-                let b_offset = (offset + a_size).align_to(b.default_align(bx).abi);
                 assert!(b_offset.bytes() > 0);
                 let a_val = read_scalar(
                     offset,
```

as *oh my* was that little magic incantation copy-pasted all over the place.

Apologies for the pretty-giant PR.  I tried to make it as direct a change as I could: if it was `(..)` before it's `{ .. }` now, if it was `(_, _)` before it's `{ a: _, b: _, b_offset: _ }` now.  I kept the names the same so the code lines were unchanged even if normally I might have just renamed things, etc.  I'll add some inline notes for places of particular interest.

r? @workingjubilee 
