### PR TITLE
Disable `f128` support on wasm

### DIFF
--- a/compiler/rustc_codegen_llvm/src/llvm_util.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm_util.rs
@@ -401,6 +401,8 @@ fn update_target_reliable_float_cfg(sess: &Session, cfg: &mut TargetConfig) {
         (Arch::X86_64, Os::Windows) if *target_env == Env::Gnu && *target_abi != CfgAbi::Llvm => {
             false
         }
+        // Missing intrinsic <https://github.com/rust-lang/rust/issues/158673>
+        (Arch::Wasm32 | Arch::Wasm64, _) => false,
         // There are no known problems on other platforms, so the only requirement is that symbols
         // are available. `compiler-builtins` provides all symbols required for core `f128`
         // support, so this should work for everything else.


### PR DESCRIPTION
See https://github.com/rust-lang/rust/pull/150075#issuecomment-4858915624 for the motivation.