### PR TITLE
Avoid ICE for `NonZero<char>` in improper_ctypes

### DIFF
--- a/compiler/rustc_lint/src/types.rs
+++ b/compiler/rustc_lint/src/types.rs
@@ -793,7 +793,7 @@ fn get_nullable_type<'tcx>(
             return get_nullable_type(tcx, typing_env, inner_field_ty);
         }
         ty::Pat(base, ..) => return get_nullable_type(tcx, typing_env, base),
-        ty::Int(_) | ty::Uint(_) | ty::RawPtr(..) => ty,
+        ty::Int(_) | ty::Uint(_) | ty::Char | ty::RawPtr(..) => ty,
         // As these types are always non-null, the nullable equivalent of
         // `Option<T>` of these types are their raw pointer counterparts.
         ty::Ref(_region, ty, mutbl) => Ty::new_ptr(tcx, ty, mutbl),
@@ -895,10 +895,14 @@ pub(crate) fn repr_nullable_ptr<'tcx>(
                     WrappingRange { start: 0, end }
                         if end == field_ty_scalar.size(&tcx).unsigned_int_max() - 1 =>
                     {
-                        return Some(get_nullable_type(tcx, typing_env, field_ty).unwrap());
+                        return Some(get_nullable_type(tcx, typing_env, field_ty).expect(
+                            "known non-null scalar type should have a nullable representation",
+                        ));
                     }
                     WrappingRange { start: 1, .. } => {
-                        return Some(get_nullable_type(tcx, typing_env, field_ty).unwrap());
+                        return Some(get_nullable_type(tcx, typing_env, field_ty).expect(
+                            "known non-null scalar type should have a nullable representation",
+                        ));
                     }
                     WrappingRange { start, end } => {
                         unreachable!("Unhandled start and end range: ({}, {})", start, end)

--- a/tests/ui/lint/improper-ctypes/nonzero-char.rs
+++ b/tests/ui/lint/improper-ctypes/nonzero-char.rs
@@ -1,0 +1,13 @@
+// Regression test for https://github.com/rust-lang/rust/issues/158511.
+
+#![allow(dead_code)]
+#![deny(improper_ctypes)]
+
+use std::num;
+
+extern "C" {
+    fn result_nonzero_u32_t(x: Result<num::NonZero<char>, ()>);
+    //~^ ERROR `extern` block uses type `char`, which is not FFI-safe
+}
+
+fn main() {}

--- a/tests/ui/lint/improper-ctypes/nonzero-char.stderr
+++ b/tests/ui/lint/improper-ctypes/nonzero-char.stderr
@@ -1,0 +1,16 @@
+error: `extern` block uses type `char`, which is not FFI-safe
+  --> $DIR/nonzero-char.rs:9:32
+   |
+LL |     fn result_nonzero_u32_t(x: Result<num::NonZero<char>, ()>);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
+   |
+   = help: consider using `u32` or `libc::wchar_t` instead
+   = note: the `char` type has no C equivalent
+note: the lint level is defined here
+  --> $DIR/nonzero-char.rs:4:9
+   |
+LL | #![deny(improper_ctypes)]
+   |         ^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Fixes rust-lang/rust#158511

This pr enables `get_nullable_type` to return `char` as the carrier for `NonZero<char>` and replaces the raw `unwrap()` with an `expect()` message.