### PR TITLE
Remove unnecessary `Hash` derives from MIR types

### DIFF
--- a/compiler/rustc_middle/src/mir/consts.rs
+++ b/compiler/rustc_middle/src/mir/consts.rs
@@ -18,7 +18,7 @@ use crate::ty::{self, ConstKind, GenericArgsRef, ScalarInt, Ty, TyCtxt};
 /// Represents the result of const evaluation via the `eval_to_allocation` query.
 /// Not to be confused with `ConstAllocation`, which directly refers to the underlying data!
 /// Here we indirect via an `AllocId`.
-#[derive(Copy, Clone, StableHash, TyEncodable, TyDecodable, Debug, Hash, Eq, PartialEq)]
+#[derive(Copy, Clone, StableHash, TyEncodable, TyDecodable, Debug, Eq, PartialEq)]
 pub struct ConstAlloc<'tcx> {
     /// The value lives here, at offset 0, and that allocation definitely is an `AllocKind::Memory`
     /// (so you can use `AllocMap::unwrap_memory`).

--- a/compiler/rustc_middle/src/mir/coverage.rs
+++ b/compiler/rustc_middle/src/mir/coverage.rs
@@ -70,7 +70,7 @@ impl Debug for CovTerm {
     }
 }
 
-#[derive(Clone, PartialEq, TyEncodable, TyDecodable, Hash, StableHash)]
+#[derive(Clone, PartialEq, TyEncodable, TyDecodable, StableHash)]
 pub enum CoverageKind {
     /// Marks a span that might otherwise not be represented in MIR, so that
     /// coverage instrumentation can associate it with its enclosing block/BCB.

--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -1558,7 +1558,7 @@ impl UserTypeProjections {
 /// * `let (x, _): T = ...` -- here, the `projs` vector would contain
 ///   `field[0]` (aka `.0`), indicating that the type of `s` is
 ///   determined by finding the type of the `.0` field from `T`.
-#[derive(Clone, Debug, TyEncodable, TyDecodable, Hash, StableHash, PartialEq)]
+#[derive(Clone, Debug, TyEncodable, TyDecodable, StableHash, PartialEq)]
 #[derive(TypeFoldable, TypeVisitable)]
 pub struct UserTypeProjection {
     pub base: UserTypeAnnotationIndex,

--- a/compiler/rustc_middle/src/mir/syntax.rs
+++ b/compiler/rustc_middle/src/mir/syntax.rs
@@ -300,7 +300,7 @@ pub enum FakeBorrowKind {
 /// Not all of these are allowed at every [`MirPhase`]. Check the documentation there to see which
 /// ones you do not have to worry about. The MIR validator will generally enforce such restrictions,
 /// causing an ICE if they are violated.
-#[derive(Clone, PartialEq, TyEncodable, TyDecodable, Hash, StableHash)]
+#[derive(Clone, PartialEq, TyEncodable, TyDecodable, StableHash)]
 #[derive(TypeFoldable, TypeVisitable)]
 pub enum StatementKind<'tcx> {
     /// Assign statements roughly correspond to an assignment in Rust proper (`x = ...`) except
@@ -455,17 +455,8 @@ pub enum StatementKind<'tcx> {
     },
 }
 
-#[derive(
-    Clone,
-    TyEncodable,
-    TyDecodable,
-    Debug,
-    PartialEq,
-    Hash,
-    StableHash,
-    TypeFoldable,
-    TypeVisitable
-)]
+#[derive(Clone, TyEncodable, TyDecodable, Debug, PartialEq, StableHash)]
+#[derive(TypeFoldable, TypeVisitable)]
 pub enum NonDivergingIntrinsic<'tcx> {
     /// Denotes a call to the intrinsic function `assume`.
     ///
@@ -492,7 +483,7 @@ pub enum NonDivergingIntrinsic<'tcx> {
 }
 
 /// Describes whether this operand use performs a retag.
-#[derive(Copy, Clone, TyEncodable, TyDecodable, Debug, PartialEq, Eq, Hash, StableHash)]
+#[derive(Copy, Clone, TyEncodable, TyDecodable, Debug, PartialEq, Eq, StableHash)]
 #[rustc_pass_by_value]
 pub enum WithRetag {
     Yes,
@@ -511,7 +502,7 @@ impl WithRetag {
 }
 
 /// The `FakeReadCause` describes the type of pattern why a FakeRead statement exists.
-#[derive(Copy, Clone, TyEncodable, TyDecodable, Debug, Hash, StableHash, PartialEq)]
+#[derive(Copy, Clone, TyEncodable, TyDecodable, Debug, StableHash, PartialEq)]
 pub enum FakeReadCause {
     /// A fake read injected into a match guard to ensure that the discriminants
     /// that are being matched on aren't modified while the match guard is being
@@ -617,7 +608,7 @@ pub enum FakeReadCause {
     ForIndex,
 }
 
-#[derive(Clone, Debug, PartialEq, TyEncodable, TyDecodable, Hash, StableHash)]
+#[derive(Clone, Debug, PartialEq, TyEncodable, TyDecodable, StableHash)]
 #[derive(TypeFoldable, TypeVisitable)]
 pub struct CopyNonOverlapping<'tcx> {
     pub src: Operand<'tcx>,
@@ -628,7 +619,7 @@ pub struct CopyNonOverlapping<'tcx> {
 
 /// Represents how a [`TerminatorKind::Call`] was constructed.
 /// Used only for diagnostics.
-#[derive(Clone, Copy, TyEncodable, TyDecodable, Debug, PartialEq, Hash, StableHash)]
+#[derive(Clone, Copy, TyEncodable, TyDecodable, Debug, PartialEq, StableHash)]
 #[derive(TypeFoldable, TypeVisitable)]
 pub enum CallSource {
     /// This came from something such as `a > b` or `a + b`. In THIR, if `from_hir_call`
@@ -648,7 +639,7 @@ pub enum CallSource {
     Normal,
 }
 
-#[derive(Clone, Copy, Debug, TyEncodable, TyDecodable, Hash, StableHash, PartialEq)]
+#[derive(Clone, Copy, Debug, TyEncodable, TyDecodable, StableHash, PartialEq)]
 #[derive(TypeFoldable, TypeVisitable)]
 /// The macro that an inline assembly block was created by
 pub enum InlineAsmMacro {
@@ -688,7 +679,7 @@ pub enum InlineAsmMacro {
 ///     deleting self edges and duplicate edges in the process. Now remove all vertices from `G`
 ///     that are not cleanup vertices or are not reachable. The resulting graph must be an inverted
 ///     tree, that is each vertex may have at most one successor and there may be no cycles.
-#[derive(Clone, TyEncodable, TyDecodable, Hash, StableHash, PartialEq, TypeFoldable, TypeVisitable)]
+#[derive(Clone, TyEncodable, TyDecodable, StableHash, PartialEq, TypeFoldable, TypeVisitable)]
 pub enum TerminatorKind<'tcx> {
     /// Block has one successor; we continue execution there.
     Goto { target: BasicBlock },
@@ -973,22 +964,13 @@ pub enum TerminatorKind<'tcx> {
     },
 }
 
-#[derive(
-    Clone,
-    Debug,
-    TyEncodable,
-    TyDecodable,
-    Hash,
-    StableHash,
-    PartialEq,
-    TypeFoldable,
-    TypeVisitable
-)]
+#[derive(Clone, Debug, TyEncodable, TyDecodable, StableHash, PartialEq)]
+#[derive(TypeFoldable, TypeVisitable)]
 pub enum BackwardIncompatibleDropReason {
     Edition2024,
 }
 
-#[derive(Debug, Clone, TyEncodable, TyDecodable, Hash, StableHash, PartialEq)]
+#[derive(Debug, Clone, TyEncodable, TyDecodable, StableHash, PartialEq)]
 pub struct SwitchTargets {
     /// Possible values. For each value, the location to branch to is found in
     /// the corresponding element in the `targets` vector.
@@ -1018,7 +1000,7 @@ pub struct SwitchTargets {
 }
 
 /// Action to be taken when a stack unwind happens.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, TyEncodable, TyDecodable, Hash, StableHash)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, TyEncodable, TyDecodable, StableHash)]
 #[derive(TypeFoldable, TypeVisitable)]
 pub enum UnwindAction {
     /// No action is to be taken. Continue unwinding.
@@ -1037,7 +1019,7 @@ pub enum UnwindAction {
 }
 
 /// The reason we are terminating the process during unwinding.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, TyEncodable, TyDecodable, Hash, StableHash)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, TyEncodable, TyDecodable, StableHash)]
 #[derive(TypeFoldable, TypeVisitable)]
 pub enum UnwindTerminateReason {
     /// Unwinding is just not possible given the ABI of this function.
@@ -1048,7 +1030,7 @@ pub enum UnwindTerminateReason {
 }
 
 /// Information about an assertion failure.
-#[derive(Clone, Hash, StableHash, PartialEq, Debug)]
+#[derive(Clone, StableHash, PartialEq, Debug)]
 #[derive(TyEncodable, TyDecodable, TypeFoldable, TypeVisitable)]
 pub enum AssertKind<O> {
     BoundsCheck { len: O, index: O },
@@ -1064,7 +1046,7 @@ pub enum AssertKind<O> {
     InvalidEnumConstruction(O),
 }
 
-#[derive(Clone, Debug, PartialEq, TyEncodable, TyDecodable, Hash, StableHash)]
+#[derive(Clone, Debug, PartialEq, TyEncodable, TyDecodable, StableHash)]
 #[derive(TypeFoldable, TypeVisitable)]
 pub enum InlineAsmOperand<'tcx> {
     In {
@@ -1292,7 +1274,7 @@ pub type PlaceElem<'tcx> = ProjectionElem<Local, Ty<'tcx>>;
 /// **Needs clarification:** Is loading a place that has its variant index set well-formed? Miri
 /// currently implements it, but it seems like this may be something to check against in the
 /// validator.
-#[derive(Clone, PartialEq, TyEncodable, TyDecodable, Hash, StableHash, TypeFoldable, TypeVisitable)]
+#[derive(Clone, PartialEq, TyEncodable, TyDecodable, StableHash, TypeFoldable, TypeVisitable)]
 pub enum Operand<'tcx> {
     /// Creates a value by loading the given place.
     ///
@@ -1327,7 +1309,7 @@ pub enum Operand<'tcx> {
     RuntimeChecks(RuntimeChecks),
 }
 
-#[derive(Clone, Copy, PartialEq, TyEncodable, TyDecodable, Hash, StableHash)]
+#[derive(Clone, Copy, PartialEq, TyEncodable, TyDecodable, StableHash)]
 #[derive(TypeFoldable, TypeVisitable)]
 pub struct ConstOperand<'tcx> {
     pub span: Span,
@@ -1352,7 +1334,7 @@ pub struct ConstOperand<'tcx> {
 /// Computing any rvalue begins by evaluating the places and operands in some order (**Needs
 /// clarification**: Which order?). These are then used to produce a "value" - the same kind of
 /// value that an [`Operand`] produces.
-#[derive(Clone, TyEncodable, TyDecodable, Hash, StableHash, PartialEq, TypeFoldable, TypeVisitable)]
+#[derive(Clone, TyEncodable, TyDecodable, StableHash, PartialEq, TypeFoldable, TypeVisitable)]
 pub enum Rvalue<'tcx> {
     /// Yields the operand unchanged, except for a potential retag.
     Use(Operand<'tcx>, WithRetag),
@@ -1534,7 +1516,7 @@ pub enum CoercionSource {
     Implicit,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, TyEncodable, TyDecodable, Hash, StableHash)]
+#[derive(Clone, Debug, PartialEq, Eq, TyEncodable, TyDecodable, StableHash)]
 #[derive(TypeFoldable, TypeVisitable)]
 pub enum AggregateKind<'tcx> {
     /// The type is of the element
@@ -1703,7 +1685,7 @@ pub enum BinOp {
 
 // Assignment operators, e.g. `+=`. See comments on the corresponding variants
 // in `BinOp` for details.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, StableHash)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, StableHash)]
 pub enum AssignOp {
     AddAssign,
     SubAssign,


### PR DESCRIPTION
This starts with `StatementKind` and `TerminatorKind`; they don't need hashing. That then allows the removal of the `Hash` impl of various other types.

r? @dingxiangfei2009 