### PR TITLE
Avoid delayed bug for disabled on_type_error arguments

### DIFF
--- a/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_type_error.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_type_error.rs
@@ -18,6 +18,8 @@ pub(crate) struct OnTypeErrorParser {
 impl OnTypeErrorParser {
     fn parse<'sess>(&mut self, cx: &mut AcceptContext<'_, 'sess>, args: &ArgParser, mode: Mode) {
         if !cx.features().diagnostic_on_type_error() {
+            // `UnknownDiagnosticAttribute` is emitted in rustc_resolve/macros.rs
+            args.ignore_args();
             return;
         }
 

--- a/tests/ui/feature-gates/feature-gate-diagnostic-on-type-error-malformed-args.rs
+++ b/tests/ui/feature-gates/feature-gate-diagnostic-on-type-error-malformed-args.rs
@@ -1,0 +1,9 @@
+//@ check-pass
+
+// Regression test for https://github.com/rust-lang/rust/issues/158628.
+
+#[diagnostic::on_type_error(unknown = "")]
+//~^ WARN unknown diagnostic attribute
+pub struct Foo {}
+
+fn main() {}

--- a/tests/ui/feature-gates/feature-gate-diagnostic-on-type-error-malformed-args.stderr
+++ b/tests/ui/feature-gates/feature-gate-diagnostic-on-type-error-malformed-args.stderr
@@ -1,0 +1,11 @@
+warning: unknown diagnostic attribute
+  --> $DIR/feature-gate-diagnostic-on-type-error-malformed-args.rs:5:15
+   |
+LL | #[diagnostic::on_type_error(unknown = "")]
+   |               ^^^^^^^^^^^^^
+   |
+   = help: add `#![feature(diagnostic_on_type_error)]` to the crate attributes to enable
+   = note: `#[warn(unknown_diagnostic_attributes)]` (part of `#[warn(unknown_or_malformed_diagnostic_attributes)]`) on by default
+
+warning: 1 warning emitted
+


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Fixes rust-lang/rust#158628

This updates the disabled-feature path to call `args.ignore_args()`, matching the behavior of other diagnostic attributes.

example: https://github.com/rust-lang/rust/blob/c397dae808f70caebab1fc4e11b3edf7e59f58c7/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_unknown.rs#L13-L21