### PR TITLE
resolver: don't use `Finalize` when resolving visibilities during AST expansion

### DIFF
--- a/compiler/rustc_resolve/src/build_reduced_graph.rs
+++ b/compiler/rustc_resolve/src/build_reduced_graph.rs
@@ -475,7 +475,7 @@ impl<'a, 'ra, 'tcx> DefCollector<'a, 'ra, 'tcx> {
     }
 
     fn resolve_visibility(&mut self, vis: &ast::Visibility) -> Visibility {
-        match self.r.try_resolve_visibility(&self.parent_scope, vis, true) {
+        match self.r.try_resolve_visibility(&self.parent_scope, vis, false) {
             Ok(vis) => vis,
             Err(error) => {
                 self.r.delayed_vis_resolution_errors.push(DelayedVisResolutionError {

--- a/compiler/rustc_resolve/src/ident.rs
+++ b/compiler/rustc_resolve/src/ident.rs
@@ -1154,6 +1154,8 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             resolution.as_ref().and_then(|r| r.non_glob_decl).filter(|b| Some(*b) != ignore_decl);
 
         if let Some(finalize) = finalize {
+            // finalize implies that the module is fully expanded
+            assert!(!module.has_unexpanded_invocations());
             return self.get_mut().finalize_module_binding(
                 ident,
                 orig_ident_span,
@@ -1218,6 +1220,8 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             resolution.as_ref().and_then(|r| r.glob_decl).filter(|b| Some(*b) != ignore_decl);
 
         if let Some(finalize) = finalize {
+            // finalize implies that the module is fully expanded
+            assert!(!module.has_unexpanded_invocations());
             return self.get_mut().finalize_module_binding(
                 ident,
                 orig_ident_span,


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

During AST expansion we need to resolve visibilities of items. It uses `Finalize` to make sure to get a definite result on the resolution (a sort of hacky way). this pr disables the use of `Finalize` as it contradicts the invariant proposed by it:
```rust
/// Invariant: if `Finalize` is used, expansion and import resolution must be complete.
struct Finalize { ... }
```

