### PR TITLE
Rename some `body_id` to `body_def_id`

### DIFF
--- a/compiler/rustc_hir_analysis/src/autoderef.rs
+++ b/compiler/rustc_hir_analysis/src/autoderef.rs
@@ -34,7 +34,7 @@ pub struct Autoderef<'a, 'tcx> {
     // Meta infos:
     infcx: &'a InferCtxt<'tcx>,
     span: Span,
-    body_id: LocalDefId,
+    body_def_id: LocalDefId,
     param_env: ty::ParamEnv<'tcx>,
 
     // Current state:
@@ -119,7 +119,7 @@ impl<'a, 'tcx> Autoderef<'a, 'tcx> {
         Autoderef {
             infcx,
             span,
-            body_id: body_def_id,
+            body_def_id,
             param_env,
             state: AutoderefSnapshot {
                 steps: vec![],
@@ -149,7 +149,7 @@ impl<'a, 'tcx> Autoderef<'a, 'tcx> {
             (tcx.lang_items().deref_trait()?, tcx.lang_items().deref_target()?)
         };
         let trait_ref = ty::TraitRef::new(tcx, trait_def_id, [ty]);
-        let cause = traits::ObligationCause::misc(self.span, self.body_id);
+        let cause = traits::ObligationCause::misc(self.span, self.body_def_id);
         let obligation = traits::Obligation::new(
             tcx,
             cause.clone(),
@@ -181,7 +181,7 @@ impl<'a, 'tcx> Autoderef<'a, 'tcx> {
     ) -> Option<(Ty<'tcx>, PredicateObligations<'tcx>)> {
         let ocx = ObligationCtxt::new(self.infcx);
         let normalized_ty = ocx.normalize(
-            &traits::ObligationCause::misc(self.span, self.body_id),
+            &traits::ObligationCause::misc(self.span, self.body_def_id),
             self.param_env,
             ty,
         );

--- a/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
+++ b/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
@@ -177,10 +177,10 @@ fn compare_method_predicate_entailment<'tcx>(
     trait_m: ty::AssocItem,
     impl_trait_ref: ty::TraitRef<'tcx>,
 ) -> Result<(), ErrorGuaranteed> {
-    // This node-id should be used for the `body_id` field on each
+    // This node-id should be used for the `body_def_id` field on each
     // `ObligationCause` (and the `FnCtxt`).
     //
-    // FIXME(@lcnr): remove that after removing `cause.body_id` from
+    // FIXME(@lcnr): remove that after removing `cause.body_def_id` from
     // obligations.
     let impl_m_def_id = impl_m.def_id.expect_local();
     let impl_m_span = tcx.def_span(impl_m_def_id);
@@ -798,7 +798,7 @@ struct ImplTraitInTraitCollector<'a, 'tcx, E> {
     types: FxIndexMap<DefId, (Ty<'tcx>, ty::GenericArgsRef<'tcx>)>,
     span: Span,
     param_env: ty::ParamEnv<'tcx>,
-    body_id: LocalDefId,
+    impl_m_id: LocalDefId,
 }
 
 impl<'a, 'tcx, E> ImplTraitInTraitCollector<'a, 'tcx, E>
@@ -809,9 +809,9 @@ where
         ocx: &'a ObligationCtxt<'a, 'tcx, E>,
         span: Span,
         param_env: ty::ParamEnv<'tcx>,
-        body_id: LocalDefId,
+        impl_m_id: LocalDefId,
     ) -> Self {
-        ImplTraitInTraitCollector { ocx, types: FxIndexMap::default(), span, param_env, body_id }
+        ImplTraitInTraitCollector { ocx, types: FxIndexMap::default(), span, param_env, impl_m_id }
     }
 }
 
@@ -847,7 +847,7 @@ where
             {
                 let pred = pred.fold_with(self);
                 let pred = self.ocx.normalize(
-                    &ObligationCause::misc(self.span, self.body_id),
+                    &ObligationCause::misc(self.span, self.impl_m_id),
                     self.param_env,
                     Unnormalized::new_wip(pred),
                 );
@@ -856,7 +856,7 @@ where
                     self.cx(),
                     ObligationCause::new(
                         self.span,
-                        self.body_id,
+                        self.impl_m_id,
                         ObligationCauseCode::WhereClause(def_id, pred_span),
                     ),
                     self.param_env,
@@ -2346,7 +2346,7 @@ fn compare_type_predicate_entailment<'tcx>(
         return Ok(());
     }
 
-    // This `DefId` should be used for the `body_id` field on each
+    // This `DefId` should be used for the `body_def_id` field on each
     // `ObligationCause` (and the `FnCtxt`). This is what
     // `regionck_item` expects.
     let impl_ty_def_id = impl_ty.def_id.expect_local();

--- a/compiler/rustc_hir_typeck/src/_match.rs
+++ b/compiler/rustc_hir_typeck/src/_match.rs
@@ -216,7 +216,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         prior_arm: Option<(Option<hir::HirId>, Ty<'tcx>, Span)>,
     ) {
         // First, check that we're actually in the tail of a function.
-        let Some(body) = self.tcx.hir_maybe_body_owned_by(self.body_id) else {
+        let Some(body) = self.tcx.hir_maybe_body_owned_by(self.body_def_id) else {
             return;
         };
         let hir::ExprKind::Block(block, _) = body.value.kind else {
@@ -233,7 +233,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         // Next, make sure that we have no type expectation.
         let Some(ret) =
-            self.tcx.hir_node_by_def_id(self.body_id).fn_decl().map(|decl| decl.output.span())
+            self.tcx.hir_node_by_def_id(self.body_def_id).fn_decl().map(|decl| decl.output.span())
         else {
             return;
         };

--- a/compiler/rustc_hir_typeck/src/autoderef.rs
+++ b/compiler/rustc_hir_typeck/src/autoderef.rs
@@ -15,7 +15,7 @@ use super::{FnCtxt, PlaceOp};
 
 impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     pub(crate) fn autoderef(&'a self, span: Span, base_ty: Ty<'tcx>) -> Autoderef<'a, 'tcx> {
-        Autoderef::new(self, self.param_env, self.body_id, span, base_ty)
+        Autoderef::new(self, self.param_env, self.body_def_id, span, base_ty)
     }
 
     pub(crate) fn try_overloaded_deref(

--- a/compiler/rustc_hir_typeck/src/callee.rs
+++ b/compiler/rustc_hir_typeck/src/callee.rs
@@ -39,11 +39,11 @@ pub(crate) fn check_legal_trait_for_method_call(
     receiver: Option<Span>,
     expr_span: Span,
     trait_id: DefId,
-    body_id: DefId,
+    body_def_id: DefId,
 ) -> Result<(), ErrorGuaranteed> {
     if tcx.is_lang_item(trait_id, LangItem::Drop)
         // Allow calling `Drop::pin_drop` in `Drop::drop`
-        && !tcx.is_lang_item(tcx.parent(body_id), LangItem::Drop)
+        && !tcx.is_lang_item(tcx.parent(body_def_id), LangItem::Drop)
     {
         let sugg = if let Some(receiver) = receiver.filter(|s| !s.is_empty()) {
             diagnostics::ExplicitDestructorCallSugg::Snippet {
@@ -1042,7 +1042,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         callee_did: DefId,
         callee_args: GenericArgsRef<'tcx>,
     ) {
-        let const_context = self.tcx.hir_body_const_context(self.body_id);
+        let const_context = self.tcx.hir_body_const_context(self.body_def_id);
 
         if let hir::Constness::Const { always: true } = self.tcx.constness(callee_did) {
             match const_context {
@@ -1062,7 +1062,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         }
 
         // If we have `rustc_do_not_const_check`, do not check `[const]` bounds.
-        if self.has_rustc_attrs && find_attr!(self.tcx, self.body_id, RustcDoNotConstCheck) {
+        if self.has_rustc_attrs && find_attr!(self.tcx, self.body_def_id, RustcDoNotConstCheck) {
             return;
         }
 

--- a/compiler/rustc_hir_typeck/src/cast.rs
+++ b/compiler/rustc_hir_typeck/src/cast.rs
@@ -64,7 +64,7 @@ pub(crate) struct CastCheck<'tcx> {
     cast_ty: Ty<'tcx>,
     cast_span: Span,
     span: Span,
-    pub body_id: LocalDefId,
+    pub body_def_id: LocalDefId,
 }
 
 /// The kind of pointer and associated metadata (thin, length or vtable) - we
@@ -247,8 +247,15 @@ impl<'a, 'tcx> CastCheck<'tcx> {
         span: Span,
     ) -> Result<CastCheck<'tcx>, ErrorGuaranteed> {
         let expr_span = expr.span.find_ancestor_inside(span).unwrap_or(expr.span);
-        let check =
-            CastCheck { expr, expr_ty, expr_span, cast_ty, cast_span, span, body_id: fcx.body_id };
+        let check = CastCheck {
+            expr,
+            expr_ty,
+            expr_span,
+            cast_ty,
+            cast_span,
+            span,
+            body_def_id: fcx.body_def_id,
+        };
 
         // For better error messages, check for some obviously unsized
         // cases now. We do a more thorough check at the end, once

--- a/compiler/rustc_hir_typeck/src/coercion.rs
+++ b/compiler/rustc_hir_typeck/src/coercion.rs
@@ -1258,7 +1258,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let sig = if fn_attrs.safe_target_features {
             // Allow the coercion if the current function has all the features that would be
             // needed to call the coercee safely.
-            match tcx.adjust_target_feature_sig(def_id, sig, self.body_id.into()) {
+            match tcx.adjust_target_feature_sig(def_id, sig, self.body_def_id.into()) {
                 Some(adjusted_sig) => adjusted_sig,
                 None if matches!(expected_safety, Some(hir::Safety::Safe)) => {
                     return Err(TypeError::TargetFeatureCast(def_id));
@@ -1477,12 +1477,12 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 pub fn can_coerce<'tcx>(
     tcx: TyCtxt<'tcx>,
     param_env: ty::ParamEnv<'tcx>,
-    body_id: LocalDefId,
+    body_def_id: LocalDefId,
     ty: Ty<'tcx>,
     output_ty: Ty<'tcx>,
 ) -> bool {
-    let root_ctxt = crate::typeck_root_ctxt::TypeckRootCtxt::new(tcx, body_id);
-    let fn_ctxt = FnCtxt::new(&root_ctxt, param_env, body_id);
+    let root_ctxt = crate::typeck_root_ctxt::TypeckRootCtxt::new(tcx, body_def_id);
+    let fn_ctxt = FnCtxt::new(&root_ctxt, param_env, body_def_id);
     fn_ctxt.may_coerce(ty, output_ty)
 }
 
@@ -2057,7 +2057,7 @@ impl<'tcx> CoerceMany<'tcx> {
         if due_to_block
             && let Some(expr) = expression
             && let Some(parent_fn_decl) =
-                fcx.tcx.hir_fn_decl_by_hir_id(fcx.tcx.local_def_id_to_hir_id(fcx.body_id))
+                fcx.tcx.hir_fn_decl_by_hir_id(fcx.tcx.local_def_id_to_hir_id(fcx.body_def_id))
         {
             fcx.suggest_missing_break_or_return_expr(
                 &mut err,
@@ -2066,14 +2066,14 @@ impl<'tcx> CoerceMany<'tcx> {
                 expected,
                 found,
                 block_or_return_id,
-                fcx.body_id,
+                fcx.body_def_id,
             );
         }
 
         let is_return_position = fcx
             .tcx
             .hir_get_fn_id_for_return_block(block_or_return_id)
-            .is_some_and(|fn_id| fn_id == fcx.tcx.local_def_id_to_hir_id(fcx.body_id));
+            .is_some_and(|fn_id| fn_id == fcx.tcx.local_def_id_to_hir_id(fcx.body_def_id));
 
         if is_return_position
             && let Some(sp) = fcx.ret_coercion_span.get()
@@ -2083,7 +2083,7 @@ impl<'tcx> CoerceMany<'tcx> {
             // may occur at the first return expression we see in the closure
             // (if it conflicts with the declared return type). Skip adding a
             // note in this case, since it would be incorrect.
-            && let Some(fn_sig) = fcx.body_fn_sig()
+            && let Some(fn_sig) = fcx.fn_sig()
             && fn_sig.output().is_ty_var()
         {
             err.span_note(sp, format!("return type inferred to be `{expected}` here"));
@@ -2096,7 +2096,7 @@ impl<'tcx> CoerceMany<'tcx> {
     /// sure we consider `dyn Trait: Sized` where clauses, which are trivially
     /// false but technically valid for typeck.
     fn is_return_ty_definitely_unsized(&self, fcx: &FnCtxt<'_, 'tcx>) -> bool {
-        if let Some(sig) = fcx.body_fn_sig() {
+        if let Some(sig) = fcx.fn_sig() {
             !fcx.predicate_may_hold(&Obligation::new(
                 fcx.tcx,
                 ObligationCause::dummy(),

--- a/compiler/rustc_hir_typeck/src/demand.rs
+++ b/compiler/rustc_hir_typeck/src/demand.rs
@@ -332,7 +332,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         }
 
         let mut expr_finder = FindExprs { hir_id: local_hir_id, uses: init.into_iter().collect() };
-        let body = self.tcx.hir_body_owned_by(self.body_id);
+        let body = self.tcx.hir_body_owned_by(self.body_def_id);
         expr_finder.visit_expr(body.value);
 
         // Replaces all of the variables in the given type with a fresh inference variable.

--- a/compiler/rustc_hir_typeck/src/expectation.rs
+++ b/compiler/rustc_hir_typeck/src/expectation.rs
@@ -76,9 +76,9 @@ impl<'a, 'tcx> Expectation<'tcx> {
     pub(super) fn rvalue_hint(fcx: &FnCtxt<'a, 'tcx>, ty: Ty<'tcx>) -> Expectation<'tcx> {
         let span = match ty.kind() {
             ty::Adt(adt_def, _) => fcx.tcx.def_span(adt_def.did()),
-            _ => fcx.tcx.def_span(fcx.body_id),
+            _ => fcx.tcx.def_span(fcx.body_def_id),
         };
-        let cause = ObligationCause::misc(span, fcx.body_id);
+        let cause = ObligationCause::misc(span, fcx.body_def_id);
 
         // FIXME(#155345): Missing normalization call
         match fcx.tcx.struct_tail_raw(ty, &cause, |ty| ty.skip_normalization(), || {}).kind() {

--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -965,7 +965,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             return_expr_ty,
         );
 
-        if let Some(fn_sig) = self.body_fn_sig()
+        if let Some(fn_sig) = self.fn_sig()
             && fn_sig.output().has_opaque_types()
         {
             // Point any obligations that were registered due to opaque type
@@ -2764,8 +2764,11 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         return Ty::new_error(self.tcx(), guar);
                     }
 
-                    let (ident, def_scope) =
-                        self.tcx.adjust_ident_and_get_scope(field, base_def.did(), self.body_id);
+                    let (ident, def_scope) = self.tcx.adjust_ident_and_get_scope(
+                        field,
+                        base_def.did(),
+                        self.body_def_id,
+                    );
 
                     if let Some((idx, field)) = self.find_adt_field(*base_def, ident) {
                         self.write_field_index(expr.hir_id, idx);
@@ -2938,7 +2941,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             field_ident.span,
             "field not available in `impl Future`, but it is available in its `Output`",
         );
-        match self.tcx.coroutine_kind(self.body_id) {
+        match self.tcx.coroutine_kind(self.body_def_id) {
             Some(hir::CoroutineKind::Desugared(hir::CoroutineDesugaring::Async, _)) => {
                 err.span_suggestion_verbose(
                     base.span.shrink_to_hi(),
@@ -2949,7 +2952,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             }
             _ => {
                 let mut span: MultiSpan = base.span.into();
-                span.push_span_label(self.tcx.def_span(self.body_id), "this is not `async`");
+                span.push_span_label(self.tcx.def_span(self.body_def_id), "this is not `async`");
                 err.span_note(
                     span,
                     "this implements `Future` and its output type has the field, \
@@ -3119,7 +3122,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     }
 
     fn point_at_param_definition(&self, err: &mut Diag<'_>, param: ty::ParamTy) {
-        let generics = self.tcx.generics_of(self.body_id);
+        let generics = self.tcx.generics_of(self.body_def_id);
         let generic_param = generics.type_param(param, self.tcx);
         if let ty::GenericParamDefKind::Type { synthetic: true, .. } = generic_param.kind {
             return;
@@ -3703,7 +3706,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
     fn check_expr_asm(&self, asm: &'tcx hir::InlineAsm<'tcx>, span: Span) -> Ty<'tcx> {
         if let rustc_ast::AsmMacro::NakedAsm = asm.asm_macro {
-            if !find_attr!(self.tcx, self.body_id, Naked(..)) {
+            if !find_attr!(self.tcx, self.body_def_id, Naked(..)) {
                 self.tcx.dcx().emit_err(NakedAsmOutsideNakedFn { span });
             }
         }
@@ -3802,8 +3805,11 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         .emit();
                         break;
                     };
-                    let (subident, sub_def_scope) =
-                        self.tcx.adjust_ident_and_get_scope(subfield, variant.def_id, self.body_id);
+                    let (subident, sub_def_scope) = self.tcx.adjust_ident_and_get_scope(
+                        subfield,
+                        variant.def_id,
+                        self.body_def_id,
+                    );
 
                     let Some((subindex, field)) = variant
                         .fields
@@ -3854,7 +3860,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     let (ident, def_scope) = self.tcx.adjust_ident_and_get_scope(
                         field,
                         container_def.did(),
-                        self.body_id,
+                        self.body_def_id,
                     );
 
                     let fields = &container_def.non_enum_variant().fields;

--- a/compiler/rustc_hir_typeck/src/expr_use_visitor.rs
+++ b/compiler/rustc_hir_typeck/src/expr_use_visitor.rs
@@ -217,7 +217,7 @@ impl<'tcx> TypeInformationCtxt<'tcx> for &FnCtxt<'_, 'tcx> {
     }
 
     fn body_owner_def_id(&self) -> LocalDefId {
-        self.body_id
+        self.body_def_id
     }
 
     fn tcx(&self) -> TyCtxt<'tcx> {

--- a/compiler/rustc_hir_typeck/src/fallback.rs
+++ b/compiler/rustc_hir_typeck/src/fallback.rs
@@ -293,7 +293,7 @@ impl<'tcx> FnCtxt<'_, 'tcx> {
         root_vid: ty::TyVid,
     ) {
         let unsafe_infer_vars = unsafe_infer_vars.get_or_init(|| {
-            let unsafe_infer_vars = compute_unsafe_infer_vars(self, self.body_id);
+            let unsafe_infer_vars = compute_unsafe_infer_vars(self, self.body_def_id);
             debug!(?unsafe_infer_vars);
             unsafe_infer_vars
         });
@@ -378,8 +378,8 @@ impl<'tcx> FnCtxt<'_, 'tcx> {
             let sugg = self.try_to_suggest_annotations(diverging_vids, coercions);
             self.tcx.emit_node_span_lint(
                 lint::builtin::DEPENDENCY_ON_UNIT_NEVER_TYPE_FALLBACK,
-                self.tcx.local_def_id_to_hir_id(self.body_id),
-                self.tcx.def_span(self.body_id),
+                self.tcx.local_def_id_to_hir_id(self.body_def_id),
+                self.tcx.def_span(self.body_def_id),
                 diagnostics::DependencyOnUnitNeverTypeFallback {
                     obligation_span: never_error.obligation.cause.span,
                     obligation: never_error.obligation.predicate,
@@ -446,8 +446,7 @@ impl<'tcx> FnCtxt<'_, 'tcx> {
         diverging_vids: &[ty::TyVid],
         coercions: &VecGraph<ty::TyVid, true>,
     ) -> diagnostics::SuggestAnnotations {
-        let body =
-            self.tcx.hir_maybe_body_owned_by(self.body_id).expect("body id must have an owner");
+        let body = self.tcx.hir_body_owned_by(self.body_def_id);
         // For each diverging var, look through the HIR for a place to give it
         // a type annotation. We do this per var because we only really need one
         // suggestion to influence a var to be `()`.
@@ -633,9 +632,9 @@ pub(crate) enum UnsafeUseReason {
 /// `compute_unsafe_infer_vars` will return `{ id(?X) -> (hir_id, span, Call) }`
 fn compute_unsafe_infer_vars<'a, 'tcx>(
     fcx: &'a FnCtxt<'a, 'tcx>,
-    body_id: LocalDefId,
+    body_def_id: LocalDefId,
 ) -> UnordMap<ty::TyVid, (HirId, Span, UnsafeUseReason)> {
-    let body = fcx.tcx.hir_maybe_body_owned_by(body_id).expect("body id must have an owner");
+    let body = fcx.tcx.hir_body_owned_by(body_def_id);
     let mut res = UnordMap::default();
 
     struct UnsafeInferVarsVisitor<'a, 'tcx> {
@@ -763,7 +762,7 @@ fn compute_unsafe_infer_vars<'a, 'tcx>(
 
     UnsafeInferVarsVisitor { fcx, res: &mut res }.visit_expr(&body.value);
 
-    debug!(?res, "collected the following unsafe vars for {body_id:?}");
+    debug!(?res, "collected the following unsafe vars for {body_def_id:?}");
 
     res
 }

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
@@ -213,7 +213,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 // let it keep doing that and just ensure that compilation won't succeed.
                 self.dcx().span_delayed_bug(
                     self.tcx.hir_span(id),
-                    format!("`{prev}` overridden by `{ty}` for {id:?} in {:?}", self.body_id),
+                    format!("`{prev}` overridden by `{ty}` for {id:?} in {:?}", self.body_def_id),
                 );
             }
         }
@@ -1070,7 +1070,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             arg_span,
                             span,
                             container_id,
-                            self.body_id.to_def_id(),
+                            self.body_def_id.to_def_id(),
                         ) {
                             self.set_tainted_by_errors(e);
                         }
@@ -1192,7 +1192,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             // error in `validate_res_from_ribs` -- it's just difficult to tell whether the
             // self type has any generic types during rustc_resolve, which is what we use
             // to determine if this is a hard error or warning.
-            if std::iter::successors(Some(self.body_id.to_def_id()), |&def_id| {
+            if std::iter::successors(Some(self.body_def_id.to_def_id()), |&def_id| {
                 self.tcx.generics_of(def_id).parent
             })
             .all(|def_id| def_id != impl_def_id)
@@ -1534,7 +1534,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let guar = self.tainted_by_errors().unwrap_or_else(|| {
             self.err_ctxt()
                 .emit_inference_failure_err(
-                    self.body_id,
+                    self.body_def_id,
                     sp,
                     ty.into(),
                     TypeAnnotationNeeded::E0282,
@@ -1560,7 +1560,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             let e = self.tainted_by_errors().unwrap_or_else(|| {
                 self.err_ctxt()
                     .emit_inference_failure_err(
-                        self.body_id,
+                        self.body_def_id,
                         sp,
                         ct.into(),
                         TypeAnnotationNeeded::E0282,

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
@@ -68,9 +68,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let mut deferred_cast_checks = self.root_ctxt.deferred_cast_checks.borrow_mut();
         debug!("FnCtxt::check_casts: {} deferred checks", deferred_cast_checks.len());
         for cast in deferred_cast_checks.drain(..) {
-            let body_id = std::mem::replace(&mut self.body_id, cast.body_id);
+            let body_def_id = std::mem::replace(&mut self.body_def_id, cast.body_def_id);
             cast.check(self);
-            self.body_id = body_id;
+            self.body_def_id = body_def_id;
         }
     }
 
@@ -346,7 +346,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             // in `execute_delegation_aware_arguments_check`.
             let checked_ty = self
                 .tcx
-                .hir_opt_delegation_info(self.body_id)
+                .hir_opt_delegation_info(self.body_def_id)
                 .and_then(|_| self.typeck_results.borrow().node_type_opt(provided_arg.hir_id))
                 .unwrap_or_else(|| self.check_expr_with_expectation(provided_arg, expectation));
 
@@ -1627,7 +1627,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             let callee_ty = callee_ty.peel_refs();
             match *callee_ty.kind() {
                 ty::Param(param) => {
-                    let param = self.tcx.generics_of(self.body_id).type_param(param, self.tcx);
+                    let param = self.tcx.generics_of(self.body_def_id).type_param(param, self.tcx);
                     if param.kind.is_synthetic() {
                         // if it's `impl Fn() -> ..` then just fall down to the def-id based logic
                         def_id = param.def_id;
@@ -1636,7 +1636,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         // and point at that.
                         let instantiated = self
                             .tcx
-                            .explicit_predicates_of(self.body_id)
+                            .explicit_predicates_of(self.body_def_id)
                             .instantiate_identity(self.tcx);
                         // FIXME(compiler-errors): This could be problematic if something has two
                         // fn-like predicates with different args, but callable types really never

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/mod.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/mod.rs
@@ -43,7 +43,7 @@ use crate::{CoroutineTypes, Diverges, EnclosingBreakables, TypeckRootCtxt};
 ///
 /// [`InferCtxt`]: infer::InferCtxt
 pub(crate) struct FnCtxt<'a, 'tcx> {
-    pub(super) body_id: LocalDefId,
+    pub(super) body_def_id: LocalDefId,
 
     /// The parameter environment used for proving trait obligations
     /// in this function. This can change when we descend into
@@ -138,12 +138,12 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     pub(crate) fn new(
         root_ctxt: &'a TypeckRootCtxt<'tcx>,
         param_env: ty::ParamEnv<'tcx>,
-        body_id: LocalDefId,
+        body_def_id: LocalDefId,
     ) -> FnCtxt<'a, 'tcx> {
         let (diverging_fallback_behavior, diverging_block_behavior) =
             never_type_behavior(root_ctxt.tcx);
         FnCtxt {
-            body_id,
+            body_def_id,
             param_env,
             ret_coercion: None,
             ret_coercion_span: Cell::new(None),
@@ -179,7 +179,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         span: Span,
         code: ObligationCauseCode<'tcx>,
     ) -> ObligationCause<'tcx> {
-        ObligationCause::new(span, self.body_id, code)
+        ObligationCause::new(span, self.body_def_id, code)
     }
 
     pub(crate) fn misc(&self, span: Span) -> ObligationCause<'tcx> {
@@ -230,7 +230,7 @@ impl<'tcx> HirTyLowerer<'tcx> for FnCtxt<'_, 'tcx> {
     }
 
     fn item_def_id(&self) -> LocalDefId {
-        self.body_id
+        self.body_def_id
     }
 
     fn re_infer(&self, span: Span, reason: RegionInferReason<'_>) -> ty::Region<'tcx> {

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
@@ -40,11 +40,11 @@ use crate::method::probe;
 use crate::method::probe::{IsSuggestion, Mode, ProbeScope};
 
 impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
-    pub(crate) fn body_fn_sig(&self) -> Option<ty::FnSig<'tcx>> {
+    pub(crate) fn fn_sig(&self) -> Option<ty::FnSig<'tcx>> {
         self.typeck_results
             .borrow()
             .liberated_fn_sigs()
-            .get(self.tcx.local_def_id_to_hir_id(self.body_id))
+            .get(self.tcx.local_def_id_to_hir_id(self.body_def_id))
             .copied()
     }
 
@@ -170,7 +170,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         &self,
         ty: Ty<'tcx>,
     ) -> Option<(DefIdOrName, Ty<'tcx>, Vec<Ty<'tcx>>)> {
-        self.err_ctxt().extract_callable_info(self.body_id, self.param_env, ty)
+        self.err_ctxt().extract_callable_info(self.body_def_id, self.param_env, ty)
     }
 
     pub(crate) fn suggest_two_fn_call(
@@ -2292,7 +2292,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             return false;
         };
         let ret_ty_matches = |diagnostic_item| {
-            let Some(sig) = self.body_fn_sig() else {
+            let Some(sig) = self.fn_sig() else {
                 return false;
             };
             let ty::Adt(kind, _) = sig.output().kind() else {

--- a/compiler/rustc_hir_typeck/src/gather_locals.rs
+++ b/compiler/rustc_hir_typeck/src/gather_locals.rs
@@ -193,7 +193,7 @@ impl<'a, 'tcx> Visitor<'tcx> for GatherLocalsVisitor<'a, 'tcx> {
                         // ascription, or if it's an implicit `self` parameter
                         ObligationCauseCode::SizedArgumentType(
                             if ty_span == ident.span
-                                && self.fcx.tcx.is_closure_like(self.fcx.body_id.into())
+                                && self.fcx.tcx.is_closure_like(self.fcx.body_def_id.into())
                             {
                                 None
                             } else {

--- a/compiler/rustc_hir_typeck/src/lib.rs
+++ b/compiler/rustc_hir_typeck/src/lib.rs
@@ -378,7 +378,7 @@ fn extend_err_with_const_context(
 
 fn infer_type_if_missing<'tcx>(fcx: &FnCtxt<'_, 'tcx>, node: Node<'tcx>) -> Option<Ty<'tcx>> {
     let tcx = fcx.tcx;
-    let def_id = fcx.body_id;
+    let def_id = fcx.body_def_id;
     let expected_type = if let Some(&hir::Ty { kind: hir::TyKind::Infer(()), span, .. }) = node.ty()
     {
         if let Some(item) = tcx.opt_associated_item(def_id.into())

--- a/compiler/rustc_hir_typeck/src/method/confirm.rs
+++ b/compiler/rustc_hir_typeck/src/method/confirm.rs
@@ -702,7 +702,7 @@ impl<'a, 'tcx> ConfirmContext<'a, 'tcx> {
                 Some(self.self_expr.span),
                 self.call_expr.span,
                 trait_def_id,
-                self.body_id.to_def_id(),
+                self.body_def_id.to_def_id(),
             )
         {
             self.set_tainted_by_errors(e);

--- a/compiler/rustc_hir_typeck/src/method/probe.rs
+++ b/compiler/rustc_hir_typeck/src/method/probe.rs
@@ -511,7 +511,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             && !self.tcx.features().arbitrary_self_types();
 
                         let mut err = self.err_ctxt().emit_inference_failure_err(
-                            self.body_id,
+                            self.body_def_id,
                             err_span,
                             ty.into(),
                             TypeAnnotationNeeded::E0282,
@@ -811,7 +811,8 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
         let is_accessible = if let Some(name) = self.method_name {
             let item = candidate.item;
             let container_id = item.container_id(self.tcx);
-            let def_scope = self.tcx.adjust_ident_and_get_scope(name, container_id, self.body_id).1;
+            let def_scope =
+                self.tcx.adjust_ident_and_get_scope(name, container_id, self.body_def_id).1;
             item.visibility(self.tcx).is_accessible_from(def_scope, self.tcx)
         } else {
             true

--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -160,7 +160,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         match *ty.peel_refs().kind() {
             ty::Param(param) => {
-                let generics = self.tcx.generics_of(self.body_id);
+                let generics = self.tcx.generics_of(self.body_def_id);
                 let generic_param = generics.type_param(param, self.tcx);
                 for unsatisfied in unsatisfied_predicates.iter() {
                     // The parameter implements `IntoIterator`
@@ -634,7 +634,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         impl<'a, 'tcx> LetVisitor<'a, 'tcx> {
             // Check scope of binding.
             fn is_sub_scope(&self, sub_id: hir::ItemLocalId, super_id: hir::ItemLocalId) -> bool {
-                let scope_tree = self.fcx.tcx.region_scope_tree(self.fcx.body_id);
+                let scope_tree = self.fcx.tcx.region_scope_tree(self.fcx.body_def_id);
                 if let Some(sub_var_scope) = scope_tree.var_scope(sub_id)
                     && let Some(super_var_scope) = scope_tree.var_scope(super_id)
                     && scope_tree.is_subscope_of(sub_var_scope, super_var_scope)
@@ -742,7 +742,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             && let hir::def::Res::Local(recv_id) = path.res
             && let Some(segment) = path.segments.first()
         {
-            let body = self.tcx.hir_body_owned_by(self.body_id);
+            let body = self.tcx.hir_body_owned_by(self.body_def_id);
 
             if let Node::Expr(call_expr) = self.tcx.parent_hir_node(rcvr.hir_id) {
                 let mut let_visitor = LetVisitor {
@@ -1148,7 +1148,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     ) {
         let mut ty_span = match rcvr_ty.kind() {
             ty::Param(param_type) => {
-                Some(param_type.span_from_generics(self.tcx, self.body_id.to_def_id()))
+                Some(param_type.span_from_generics(self.tcx, self.body_def_id.to_def_id()))
             }
             ty::Adt(def, _) if def.did().is_local() => Some(self.tcx.def_span(def.did())),
             _ => None,
@@ -1779,7 +1779,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         ty::Param(_) => {
                             // Account for `fn` items like in `issue-35677.rs` to
                             // suggest restricting its type params.
-                            Some(self.tcx.hir_node_by_def_id(self.body_id))
+                            Some(self.tcx.hir_node_by_def_id(self.body_def_id))
                         }
                         ty::Adt(def, _) => {
                             def.did().as_local().map(|def_id| self.tcx.hir_node_by_def_id(def_id))
@@ -2842,7 +2842,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 _ => None,
             });
         if let Some((field, field_ty)) = field_receiver {
-            let scope = tcx.parent_module_from_def_id(self.body_id);
+            let scope = tcx.parent_module_from_def_id(self.body_def_id);
             let is_accessible = field.vis.is_accessible_from(scope, tcx);
 
             if is_accessible {
@@ -3147,7 +3147,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             seg1.ident.span,
             StashKey::CallAssocMethod,
             |err| {
-                let body = self.tcx.hir_body_owned_by(self.body_id);
+                let body = self.tcx.hir_body_owned_by(self.body_def_id);
                 struct LetVisitor {
                     ident_name: Symbol,
                 }
@@ -3997,7 +3997,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     {
         let parent_map = self.tcx.visible_parent_map(());
 
-        let scope = self.tcx.parent_module_from_def_id(self.body_id);
+        let scope = self.tcx.parent_module_from_def_id(self.body_def_id);
         let (accessible_candidates, inaccessible_candidates): (Vec<_>, Vec<_>) =
             candidates.into_iter().partition(|id| {
                 let vis = self.tcx.visibility(*id);
@@ -4555,7 +4555,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             };
             // Obtain the span for `param` and use it for a structured suggestion.
             if let Some(param) = param_type {
-                let generics = self.tcx.generics_of(self.body_id.to_def_id());
+                let generics = self.tcx.generics_of(self.body_def_id.to_def_id());
                 let type_param = generics.type_param(param, self.tcx);
                 let tcx = self.tcx;
                 if let Some(def_id) = type_param.def_id.as_local() {

--- a/compiler/rustc_hir_typeck/src/op.rs
+++ b/compiler/rustc_hir_typeck/src/op.rs
@@ -517,7 +517,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                 &mut err,
                                 trait_pred,
                                 output_associated_item,
-                                self.body_id,
+                                self.body_def_id,
                             );
                         }
                     }
@@ -1004,7 +1004,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                 &mut err,
                                 pred,
                                 None,
-                                self.body_id,
+                                self.body_def_id,
                             );
                         }
                     }

--- a/compiler/rustc_hir_typeck/src/opaque_types.rs
+++ b/compiler/rustc_hir_typeck/src/opaque_types.rs
@@ -163,13 +163,18 @@ impl<'tcx> FnCtxt<'_, 'tcx> {
                     if let Some(guar) = self.tainted_by_errors() {
                         guar
                     } else {
-                        report_item_does_not_constrain_error(self.tcx, self.body_id, def_id, None)
+                        report_item_does_not_constrain_error(
+                            self.tcx,
+                            self.body_def_id,
+                            def_id,
+                            None,
+                        )
                     }
                 }
                 UsageKind::NonDefiningUse(opaque_type_key, hidden_type) => {
                     report_item_does_not_constrain_error(
                         self.tcx,
-                        self.body_id,
+                        self.body_def_id,
                         def_id,
                         Some((opaque_type_key, hidden_type.span)),
                     )
@@ -186,7 +191,7 @@ impl<'tcx> FnCtxt<'_, 'tcx> {
                             .unwrap_or_else(|| hidden_type.ty.into());
                         self.err_ctxt()
                             .emit_inference_failure_err(
-                                self.body_id,
+                                self.body_def_id,
                                 hidden_type.span,
                                 infer_var,
                                 TypeAnnotationNeeded::E0282,
@@ -235,7 +240,7 @@ impl<'tcx> FnCtxt<'_, 'tcx> {
             return UsageKind::UnconstrainedHiddenType(hidden_type);
         }
 
-        let cause = ObligationCause::misc(hidden_type.span, self.body_id);
+        let cause = ObligationCause::misc(hidden_type.span, self.body_def_id);
         let at = self.at(&cause, self.param_env);
         let hidden_type = match solve::deeply_normalize(at, Unnormalized::new_wip(hidden_type)) {
             Ok(hidden_type) => hidden_type,

--- a/compiler/rustc_hir_typeck/src/writeback.rs
+++ b/compiler/rustc_hir_typeck/src/writeback.rs
@@ -948,8 +948,8 @@ impl<'cx, 'tcx> Resolver<'cx, 'tcx> {
         // We must deeply normalize in the new solver, since later lints expect
         // that types that show up in the typeck are fully normalized.
         let mut value = if self.should_normalize && self.fcx.next_trait_solver() {
-            let body_id = tcx.hir_body_owner_def_id(self.body.id());
-            let cause = ObligationCause::misc(self.span.to_span(tcx), body_id);
+            let body_def_id = tcx.hir_body_owner_def_id(self.body.id());
+            let cause = ObligationCause::misc(self.span.to_span(tcx), body_def_id);
             let at = self.fcx.at(&cause, self.fcx.param_env);
             let universes = vec![None; outer_exclusive_binder(&value).as_usize()];
             match solve::deeply_normalize_with_skipped_universes_and_ambiguous_coroutine_goals(

--- a/compiler/rustc_infer/src/infer/opaque_types/mod.rs
+++ b/compiler/rustc_infer/src/infer/opaque_types/mod.rs
@@ -26,7 +26,7 @@ impl<'tcx> InferCtxt<'tcx> {
     pub fn replace_opaque_types_with_inference_vars<T: TypeFoldable<TyCtxt<'tcx>>>(
         &self,
         value: T,
-        body_id: LocalDefId,
+        body_def_id: LocalDefId,
         span: Span,
         param_env: ty::ParamEnv<'tcx>,
     ) -> InferOk<'tcx, T> {
@@ -60,7 +60,7 @@ impl<'tcx> InferCtxt<'tcx> {
                                     self.tcx,
                                     ObligationCause::new(
                                         span,
-                                        body_id,
+                                        body_def_id,
                                         traits::ObligationCauseCode::OpaqueReturnType(None),
                                     ),
                                     goal.param_env,

--- a/compiler/rustc_infer/src/traits/mod.rs
+++ b/compiler/rustc_infer/src/traits/mod.rs
@@ -158,11 +158,11 @@ impl<'tcx, O> Obligation<'tcx, O> {
     pub fn misc(
         tcx: TyCtxt<'tcx>,
         span: Span,
-        body_id: LocalDefId,
+        body_def_id: LocalDefId,
         param_env: ty::ParamEnv<'tcx>,
         trait_ref: impl Upcast<TyCtxt<'tcx>, O>,
     ) -> Obligation<'tcx, O> {
-        Obligation::new(tcx, ObligationCause::misc(span, body_id), param_env, trait_ref)
+        Obligation::new(tcx, ObligationCause::misc(span, body_def_id), param_env, trait_ref)
     }
 
     pub fn with<P>(

--- a/compiler/rustc_middle/src/traits/mod.rs
+++ b/compiler/rustc_middle/src/traits/mod.rs
@@ -44,13 +44,13 @@ use crate::ty::{self, AdtKind, GenericArgsRef, Ty};
 pub struct ObligationCause<'tcx> {
     pub span: Span,
 
-    /// The ID of the fn body that triggered this obligation. This is
+    /// The ID of the fn that triggered this obligation. This is
     /// used for region obligations to determine the precise
     /// environment in which the region obligation should be evaluated
     /// (in particular, closures can add new assumptions). See the
     /// field `region_obligations` of the `FulfillmentContext` for more
     /// information.
-    pub body_id: LocalDefId,
+    pub body_def_id: LocalDefId,
 
     code: ObligationCauseCodeHandle<'tcx>,
 }
@@ -62,7 +62,7 @@ pub struct ObligationCause<'tcx> {
 // which is hashed as an interned pointer. See #90996.
 impl Hash for ObligationCause<'_> {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.body_id.hash(state);
+        self.body_def_id.hash(state);
         self.span.hash(state);
     }
 }
@@ -71,14 +71,14 @@ impl<'tcx> ObligationCause<'tcx> {
     #[inline]
     pub fn new(
         span: Span,
-        body_id: LocalDefId,
+        body_def_id: LocalDefId,
         code: ObligationCauseCode<'tcx>,
     ) -> ObligationCause<'tcx> {
-        ObligationCause { span, body_id, code: code.into() }
+        ObligationCause { span, body_def_id, code: code.into() }
     }
 
-    pub fn misc(span: Span, body_id: LocalDefId) -> ObligationCause<'tcx> {
-        ObligationCause::new(span, body_id, ObligationCauseCode::Misc)
+    pub fn misc(span: Span, body_def_id: LocalDefId) -> ObligationCause<'tcx> {
+        ObligationCause::new(span, body_def_id, ObligationCauseCode::Misc)
     }
 
     #[inline(always)]
@@ -88,7 +88,7 @@ impl<'tcx> ObligationCause<'tcx> {
 
     #[inline(always)]
     pub fn dummy_with_span(span: Span) -> ObligationCause<'tcx> {
-        ObligationCause { span, body_id: CRATE_DEF_ID, code: Default::default() }
+        ObligationCause { span, body_def_id: CRATE_DEF_ID, code: Default::default() }
     }
 
     #[inline]

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/mod.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/mod.rs
@@ -1813,7 +1813,8 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             }
         }
 
-        let body_owner_def_id = (cause.body_id != CRATE_DEF_ID).then(|| cause.body_id.to_def_id());
+        let body_owner_def_id =
+            (cause.body_def_id != CRATE_DEF_ID).then(|| cause.body_def_id.to_def_id());
         self.note_and_explain_type_err(diag, terr, cause, span, body_owner_def_id);
         if let Some(exp_found) = exp_found
             && let exp_found = TypeError::Sorts(exp_found)
@@ -1945,7 +1946,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         let TypeError::ArraySize(sz) = terr else {
             return None;
         };
-        let tykind = match self.tcx.hir_node_by_def_id(trace.cause.body_id) {
+        let tykind = match self.tcx.hir_node_by_def_id(trace.cause.body_def_id) {
             hir::Node::Item(hir::Item {
                 kind: hir::ItemKind::Fn { body: body_id, .. }, ..
             }) => {

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/suggest.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/suggest.rs
@@ -173,7 +173,7 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
             exp_span, exp_found.expected, exp_found.found,
         );
 
-        match self.tcx.coroutine_kind(cause.body_id) {
+        match self.tcx.coroutine_kind(cause.body_def_id) {
             Some(hir::CoroutineKind::Desugared(
                 hir::CoroutineDesugaring::Async | hir::CoroutineDesugaring::AsyncGen,
                 _,
@@ -636,7 +636,7 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
             }
         }
 
-        self.tcx.hir_maybe_body_owned_by(cause.body_id).and_then(|body| {
+        self.tcx.hir_maybe_body_owned_by(cause.body_def_id).and_then(|body| {
             IfVisitor { err_span: span, found_if: false }
                 .visit_body(&body)
                 .is_break()

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/ambiguity.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/ambiguity.rs
@@ -144,14 +144,14 @@ pub fn compute_applicable_impls_for_diagnostics<'tcx>(
         },
     );
 
-    // If our `body_id` has been set (and isn't just from a dummy obligation cause),
+    // If our `body_def_id` has been set (and isn't just from a dummy obligation cause),
     // then try to look for a param-env clause that would apply. The way we compute
     // this is somewhat manual, since we need the spans, so we elaborate this directly
     // from `predicates_of` rather than actually looking at the param-env which
     // otherwise would be more appropriate.
-    let body_id = obligation.cause.body_id;
-    if body_id != CRATE_DEF_ID {
-        let predicates = tcx.predicates_of(body_id.to_def_id()).instantiate_identity(tcx);
+    let body_def_id = obligation.cause.body_def_id;
+    if body_def_id != CRATE_DEF_ID {
+        let predicates = tcx.predicates_of(body_def_id.to_def_id()).instantiate_identity(tcx);
         for (pred, span) in
             elaborate(tcx, predicates.into_iter().map(|(c, s)| (c.skip_norm_wip(), s)))
         {
@@ -231,7 +231,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     return match self.tainted_by_errors() {
                         None => self
                             .emit_inference_failure_err(
-                                obligation.cause.body_id,
+                                obligation.cause.body_def_id,
                                 span,
                                 trait_pred.self_ty().skip_binder().into(),
                                 TypeAnnotationNeeded::E0282,
@@ -285,7 +285,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                         })
                         .collect();
                     self.emit_inference_failure_err_with_type_hint(
-                        obligation.cause.body_id,
+                        obligation.cause.body_def_id,
                         span,
                         term,
                         TypeAnnotationNeeded::E0283,
@@ -369,7 +369,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                             impl_candidates.as_slice(),
                             obligation,
                             trait_pred,
-                            obligation.cause.body_id,
+                            obligation.cause.body_def_id,
                             &mut err,
                             false,
                             obligation.param_env,
@@ -384,7 +384,8 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 }
 
                 if term.is_some_and(|term| term.as_type().is_some())
-                    && let Some(body) = self.tcx.hir_maybe_body_owned_by(obligation.cause.body_id)
+                    && let Some(body) =
+                        self.tcx.hir_maybe_body_owned_by(obligation.cause.body_def_id)
                 {
                     let mut expr_finder = FindExprBySpan::new(span, self.tcx);
                     expr_finder.visit_expr(&body.value);
@@ -546,7 +547,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 }
 
                 self.emit_inference_failure_err(
-                    obligation.cause.body_id,
+                    obligation.cause.body_def_id,
                     span,
                     term,
                     TypeAnnotationNeeded::E0282,
@@ -565,7 +566,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 // both must be type variables, or the other would've been instantiated
                 assert!(a.is_ty_var() && b.is_ty_var());
                 self.emit_inference_failure_err(
-                    obligation.cause.body_id,
+                    obligation.cause.body_def_id,
                     span,
                     a.into(),
                     TypeAnnotationNeeded::E0282,
@@ -599,7 +600,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 let predicate = self.tcx.short_string(predicate, &mut long_ty_path);
                 if let Some(term) = term {
                     self.emit_inference_failure_err(
-                        obligation.cause.body_id,
+                        obligation.cause.body_def_id,
                         span,
                         term,
                         TypeAnnotationNeeded::E0284,
@@ -631,7 +632,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     data.walk().filter_map(ty::GenericArg::as_term).find(|term| term.is_infer());
                 if let Some(term) = term {
                     self.emit_inference_failure_err(
-                        obligation.cause.body_id,
+                        obligation.cause.body_def_id,
                         span,
                         term,
                         TypeAnnotationNeeded::E0284,
@@ -653,7 +654,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
 
             ty::PredicateKind::Clause(ty::ClauseKind::ConstArgHasType(ct, ..)) => self
                 .emit_inference_failure_err(
-                    obligation.cause.body_id,
+                    obligation.cause.body_def_id,
                     span,
                     ct.into(),
                     TypeAnnotationNeeded::E0284,

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -468,7 +468,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                             }
                         }
                         if let Some(s) = parent_label {
-                            let body = obligation.cause.body_id;
+                            let body = obligation.cause.body_def_id;
                             err.span_label(tcx.def_span(body), s);
                         }
 
@@ -689,7 +689,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                             violations,
                         );
                         if let hir::Node::Item(item) =
-                            self.tcx.hir_node_by_def_id(obligation.cause.body_id)
+                            self.tcx.hir_node_by_def_id(obligation.cause.body_def_id)
                             && let hir::ItemKind::Impl(impl_) = item.kind
                             && let None = impl_.of_trait
                             && let hir::TyKind::TraitObject(_, tagged_ptr) = impl_.self_ty.kind
@@ -949,7 +949,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             }
         } else if let ty::Param(param) = trait_ref.self_ty().skip_binder().kind()
             && let Some(generics) =
-                self.tcx.hir_node_by_def_id(main_obligation.cause.body_id).generics()
+                self.tcx.hir_node_by_def_id(main_obligation.cause.body_def_id).generics()
         {
             let constraint = ty::print::with_no_trimmed_paths!(format!(
                 "[const] {}",
@@ -1144,7 +1144,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 }
             }
         }
-        let hir_id = self.tcx.local_def_id_to_hir_id(obligation.cause.body_id);
+        let hir_id = self.tcx.local_def_id_to_hir_id(obligation.cause.body_def_id);
         let Some(body_id) = self.tcx.hir_node(hir_id).body_id() else { return (false, false) };
         let ControlFlow::Break(expr) =
             (FindMethodSubexprOfTry { search_span: span }).visit_body(self.tcx.hir_body(body_id))
@@ -1382,7 +1382,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         ty: Ty<'tcx>,
         obligation: &PredicateObligation<'tcx>,
     ) -> Diag<'a> {
-        let def_id = obligation.cause.body_id;
+        let def_id = obligation.cause.body_def_id;
         let span = self.tcx.ty_span(def_id);
 
         let mut file = None;
@@ -2869,7 +2869,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         // message, and fall back to regular note otherwise.
         if !self.maybe_note_obligation_cause_for_async_await(err, obligation) {
             self.note_obligation_cause_code(
-                obligation.cause.body_id,
+                obligation.cause.body_def_id,
                 err,
                 obligation.predicate,
                 obligation.param_env,
@@ -2884,7 +2884,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 obligation.cause.code(),
             );
             self.suggest_borrow_for_unsized_closure_return(
-                obligation.cause.body_id,
+                obligation.cause.body_def_id,
                 err,
                 obligation.predicate,
             );
@@ -3211,7 +3211,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         is_fn_trait: bool,
         suggested: bool,
     ) {
-        let body_def_id = obligation.cause.body_id;
+        let body_def_id = obligation.cause.body_def_id;
         let span = if let ObligationCauseCode::BinOp { rhs_span, .. } = obligation.cause.code() {
             *rhs_span
         } else {
@@ -3242,7 +3242,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 err,
                 trait_predicate,
                 None,
-                obligation.cause.body_id,
+                obligation.cause.body_def_id,
             );
         } else if trait_def_id.is_local()
             && self.tcx.trait_impls_of(trait_def_id).is_empty()
@@ -3798,7 +3798,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                         {
                             trait_item_def_id.as_local()
                         } else {
-                            Some(obligation.cause.body_id)
+                            Some(obligation.cause.body_def_id)
                         };
                         if let Some(suggestion_def_id) = suggestion_def_id
                             && let Some(generics) = self.tcx.hir_get_generics(suggestion_def_id)

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/mod.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/mod.rs
@@ -340,7 +340,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 | ObligationCauseCode::WhereClauseInExpr(..) = code
                 {
                     self.note_obligation_cause_code(
-                        error.obligation.cause.body_id,
+                        error.obligation.cause.body_def_id,
                         &mut diag,
                         error.obligation.predicate,
                         error.obligation.param_env,

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/on_unimplemented.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/on_unimplemented.rs
@@ -72,7 +72,7 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
         // FIXME(-Zlower-impl-trait-in-trait-to-assoc-ty): HIR is not present for RPITITs,
         // but I guess we could synthesize one here. We don't see any errors that rely on
         // that yet, though.
-        let item_context = self.describe_enclosure(obligation.cause.body_id).unwrap_or("");
+        let item_context = self.describe_enclosure(obligation.cause.body_def_id).unwrap_or("");
 
         let direct = match obligation.cause.code() {
             ObligationCauseCode::BuiltinDerived(..)

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/overflow.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/overflow.rs
@@ -150,7 +150,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             suggest_increasing_limit,
             |err| {
                 self.note_obligation_cause_code(
-                    obligation.cause.body_id,
+                    obligation.cause.body_def_id,
                     err,
                     predicate,
                     obligation.param_env,

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
@@ -285,7 +285,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         }
 
         if !cause.span.is_dummy()
-            && let Some(body) = self.tcx.hir_maybe_body_owned_by(cause.body_id)
+            && let Some(body) = self.tcx.hir_maybe_body_owned_by(cause.body_def_id)
         {
             let mut expr_finder = FindExprBySpan::new(cause.span, self.tcx);
             expr_finder.visit_body(body);
@@ -467,7 +467,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         err: &mut Diag<'_>,
         trait_pred: ty::PolyTraitPredicate<'tcx>,
         associated_ty: Option<(&'static str, Ty<'tcx>)>,
-        mut body_id: LocalDefId,
+        mut body_def_id: LocalDefId,
     ) {
         if trait_pred.skip_binder().polarity != ty::PredicatePolarity::Positive {
             return;
@@ -494,7 +494,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         // FIXME: Add check for trait bound that is already present, particularly `?Sized` so we
         //        don't suggest `T: Sized + ?Sized`.
         loop {
-            let node = self.tcx.hir_node_by_def_id(body_id);
+            let node = self.tcx.hir_node_by_def_id(body_def_id);
             match node {
                 hir::Node::Item(hir::Item {
                     kind: hir::ItemKind::Trait { ident, generics, bounds, .. },
@@ -504,7 +504,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     // Restricting `Self` for a single method.
                     suggest_restriction(
                         self.tcx,
-                        body_id,
+                        body_def_id,
                         generics,
                         "`Self`",
                         err,
@@ -524,7 +524,14 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     assert!(param_ty);
                     // Restricting `Self` for a single method.
                     suggest_restriction(
-                        self.tcx, body_id, generics, "`Self`", err, None, projection, trait_pred,
+                        self.tcx,
+                        body_def_id,
+                        generics,
+                        "`Self`",
+                        err,
+                        None,
+                        projection,
+                        trait_pred,
                         None,
                     );
                     return;
@@ -547,7 +554,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     // Missing restriction on associated type of type parameter (unmet projection).
                     suggest_restriction(
                         self.tcx,
-                        body_id,
+                        body_def_id,
                         generics,
                         "the associated type",
                         err,
@@ -567,7 +574,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     // Missing restriction on associated type of type parameter (unmet projection).
                     suggest_restriction(
                         self.tcx,
-                        body_id,
+                        body_def_id,
                         generics,
                         "the associated type",
                         err,
@@ -687,7 +694,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
 
                 _ => {}
             }
-            body_id = self.tcx.local_parent(body_id);
+            body_def_id = self.tcx.local_parent(body_def_id);
         }
     }
 
@@ -1024,7 +1031,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         );
 
         let Some((def_id_or_name, output, inputs)) =
-            self.extract_callable_info(obligation.cause.body_id, obligation.param_env, self_ty)
+            self.extract_callable_info(obligation.cause.body_def_id, obligation.param_env, self_ty)
         else {
             return false;
         };
@@ -1232,7 +1239,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         // Wrap method receivers and `&`-references in parens.
         let suggestion = if self.tcx.sess.source_map().span_followed_by(span, ".").is_some() {
             parenthesized_cast(span)
-        } else if let Some(body) = self.tcx.hir_maybe_body_owned_by(obligation.cause.body_id) {
+        } else if let Some(body) = self.tcx.hir_maybe_body_owned_by(obligation.cause.body_def_id) {
             let mut expr_finder = FindExprBySpan::new(span, self.tcx);
             expr_finder.visit_expr(body.value);
             if let Some(expr) = expr_finder.result
@@ -1271,7 +1278,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             span.remove_mark();
         }
         let mut expr_finder = FindExprBySpan::new(span, self.tcx);
-        let Some(body) = self.tcx.hir_maybe_body_owned_by(obligation.cause.body_id) else {
+        let Some(body) = self.tcx.hir_maybe_body_owned_by(obligation.cause.body_def_id) else {
             return;
         };
         expr_finder.visit_expr(body.value);
@@ -1350,7 +1357,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
     ) -> bool {
         let self_ty = self.resolve_vars_if_possible(trait_pred.self_ty());
         self.enter_forall(self_ty, |ty: Ty<'_>| {
-            let Some(generics) = self.tcx.hir_get_generics(obligation.cause.body_id) else {
+            let Some(generics) = self.tcx.hir_get_generics(obligation.cause.body_def_id) else {
                 return false;
             };
             let ty::Ref(_, inner_ty, hir::Mutability::Not) = ty.kind() else { return false };
@@ -1444,7 +1451,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
     /// because the callable type must also be well-formed to be called.
     pub fn extract_callable_info(
         &self,
-        body_id: LocalDefId,
+        body_def_id: LocalDefId,
         param_env: ty::ParamEnv<'tcx>,
         found: Ty<'tcx>,
     ) -> Option<(DefIdOrName, Ty<'tcx>, Vec<Ty<'tcx>>)> {
@@ -1526,7 +1533,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     }
                 }),
                 ty::Param(param) => {
-                    let generics = self.tcx.generics_of(body_id);
+                    let generics = self.tcx.generics_of(body_def_id);
                     let name = if generics.count() > param.index as usize
                         && let def = generics.param_at(param.index as usize, self.tcx)
                         && matches!(def.kind, ty::GenericParamDefKind::Type { .. })
@@ -1597,7 +1604,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         };
         let (Some(typeck_results), Some(body)) = (
             self.typeck_results.as_ref(),
-            self.tcx.hir_maybe_body_owned_by(obligation.cause.body_id),
+            self.tcx.hir_maybe_body_owned_by(obligation.cause.body_def_id),
         ) else {
             return true;
         };
@@ -1859,7 +1866,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             // Issue #104961, we need to add parentheses properly for compound expressions
             // for example, `x.starts_with("hi".to_string() + "you")`
             // should be `x.starts_with(&("hi".to_string() + "you"))`
-            let Some(body) = self.tcx.hir_maybe_body_owned_by(obligation.cause.body_id) else {
+            let Some(body) = self.tcx.hir_maybe_body_owned_by(obligation.cause.body_def_id) else {
                 return false;
             };
             let mut expr_finder = FindExprBySpan::new(span, self.tcx);
@@ -2085,7 +2092,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             span.remove_mark();
         }
         let mut expr_finder = super::FindExprBySpan::new(span, self.tcx);
-        let Some(body) = self.tcx.hir_maybe_body_owned_by(obligation.cause.body_id) else {
+        let Some(body) = self.tcx.hir_maybe_body_owned_by(obligation.cause.body_def_id) else {
             return false;
         };
         expr_finder.visit_expr(body.value);
@@ -2413,7 +2420,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         span: Span,
         trait_pred: ty::PolyTraitPredicate<'tcx>,
     ) -> bool {
-        let node = self.tcx.hir_node_by_def_id(obligation.cause.body_id);
+        let node = self.tcx.hir_node_by_def_id(obligation.cause.body_def_id);
         if let hir::Node::Item(hir::Item { kind: hir::ItemKind::Fn {sig, body: body_id, .. }, .. }) = node
             && let hir::ExprKind::Block(blk, _) = &self.tcx.hir_body(*body_id).value.kind
             && sig.decl.output.span().overlaps(span)
@@ -2449,7 +2456,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
 
     pub(super) fn suggest_borrow_for_unsized_closure_return<G: EmissionGuarantee>(
         &self,
-        body_id: LocalDefId,
+        body_def_id: LocalDefId,
         err: &mut Diag<'_, G>,
         predicate: ty::Predicate<'tcx>,
     ) {
@@ -2463,10 +2470,10 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         let Some(span) = err.span.primary_span() else {
             return;
         };
-        let Some(node_body_id) = self.tcx.hir_node_by_def_id(body_id).body_id() else {
+        let Some(body_id) = self.tcx.hir_node_by_def_id(body_def_id).body_id() else {
             return;
         };
-        let body = self.tcx.hir_body(node_body_id);
+        let body = self.tcx.hir_body(body_id);
         let mut expr_finder = FindExprBySpan::new(span, self.tcx);
         expr_finder.visit_expr(body.value);
         let Some(expr) = expr_finder.result else {
@@ -2503,7 +2510,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
 
     pub(super) fn return_type_span(&self, obligation: &PredicateObligation<'tcx>) -> Option<Span> {
         let hir::Node::Item(hir::Item { kind: hir::ItemKind::Fn { sig, .. }, .. }) =
-            self.tcx.hir_node_by_def_id(obligation.cause.body_id)
+            self.tcx.hir_node_by_def_id(obligation.cause.body_def_id)
         else {
             return None;
         };
@@ -2529,7 +2536,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         if let Node::Item(hir::Item { kind: hir::ItemKind::Fn { sig: fn_sig, .. }, .. })
         | Node::ImplItem(hir::ImplItem { kind: hir::ImplItemKind::Fn(fn_sig, _), .. })
         | Node::TraitItem(hir::TraitItem { kind: hir::TraitItemKind::Fn(fn_sig, _), .. }) =
-            self.tcx.hir_node_by_def_id(obligation.cause.body_id)
+            self.tcx.hir_node_by_def_id(obligation.cause.body_def_id)
             && let hir::FnRetTy::Return(ty) = fn_sig.decl.output
             && let hir::TyKind::Path(qpath) = ty.kind
             && let hir::QPath::Resolved(None, path) = qpath
@@ -2559,8 +2566,8 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
 
         let mut span = obligation.cause.span;
         let mut is_async_fn_return = false;
-        if let DefKind::Closure = self.tcx.def_kind(obligation.cause.body_id)
-            && let parent = self.tcx.local_parent(obligation.cause.body_id)
+        if let DefKind::Closure = self.tcx.def_kind(obligation.cause.body_def_id)
+            && let parent = self.tcx.local_parent(obligation.cause.body_def_id)
             && let DefKind::Fn | DefKind::AssocFn = self.tcx.def_kind(parent)
             && self.tcx.asyncness(parent).is_async()
             && let Node::Item(hir::Item { kind: hir::ItemKind::Fn { sig: fn_sig, .. }, .. })
@@ -2577,11 +2584,11 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             is_async_fn_return = true;
             err.span(span);
         }
-        let body = self.tcx.hir_body_owned_by(obligation.cause.body_id);
+        let body = self.tcx.hir_body_owned_by(obligation.cause.body_def_id);
 
         if !is_async_fn_return
             && let Node::Expr(hir::Expr { kind: hir::ExprKind::Closure(closure), .. }) =
-                self.tcx.hir_node_by_def_id(obligation.cause.body_id)
+                self.tcx.hir_node_by_def_id(obligation.cause.body_def_id)
             && matches!(closure.fn_decl.output, hir::FnRetTy::DefaultReturn(_))
         {
             return true;
@@ -3447,7 +3454,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         // bound that introduced the obligation (e.g. `T: Send`).
         debug!(?next_code);
         self.note_obligation_cause_code(
-            obligation.cause.body_id,
+            obligation.cause.body_def_id,
             err,
             obligation.predicate,
             obligation.param_env,
@@ -3459,7 +3466,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
 
     pub(super) fn note_obligation_cause_code<G: EmissionGuarantee, T>(
         &self,
-        body_id: LocalDefId,
+        body_def_id: LocalDefId,
         err: &mut Diag<'_, G>,
         predicate: T,
         param_env: ty::ParamEnv<'tcx>,
@@ -4125,7 +4132,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     // #74711: avoid a stack overflow
                     ensure_sufficient_stack(|| {
                         self.note_obligation_cause_code(
-                            body_id,
+                            body_def_id,
                             err,
                             parent_predicate,
                             param_env,
@@ -4137,7 +4144,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 } else {
                     ensure_sufficient_stack(|| {
                         self.note_obligation_cause_code(
-                            body_id,
+                            body_def_id,
                             err,
                             parent_predicate,
                             param_env,
@@ -4167,7 +4174,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     // Skip PinDerefMutHelper in suggestions, but still show downstream suggestions.
                     ensure_sufficient_stack(|| {
                         self.note_obligation_cause_code(
-                            body_id,
+                            body_def_id,
                             err,
                             parent_predicate,
                             param_env,
@@ -4321,7 +4328,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 // #74711: avoid a stack overflow
                 ensure_sufficient_stack(|| {
                     self.note_obligation_cause_code(
-                        body_id,
+                        body_def_id,
                         err,
                         parent_predicate,
                         param_env,
@@ -4364,7 +4371,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 }
                 ensure_sufficient_stack(|| {
                     self.note_obligation_cause_code(
-                        body_id,
+                        body_def_id,
                         err,
                         data.derived.parent_host_pred,
                         param_env,
@@ -4377,7 +4384,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             ObligationCauseCode::BuiltinDerivedHost(ref data) => {
                 ensure_sufficient_stack(|| {
                     self.note_obligation_cause_code(
-                        body_id,
+                        body_def_id,
                         err,
                         data.parent_host_pred,
                         param_env,
@@ -4393,7 +4400,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 // #74711: avoid a stack overflow
                 ensure_sufficient_stack(|| {
                     self.note_obligation_cause_code(
-                        body_id,
+                        body_def_id,
                         err,
                         parent_predicate,
                         param_env,
@@ -4407,7 +4414,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 // #74711: avoid a stack overflow
                 ensure_sufficient_stack(|| {
                     self.note_obligation_cause_code(
-                        body_id,
+                        body_def_id,
                         err,
                         predicate,
                         param_env,
@@ -4427,7 +4434,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 arg_hir_id, call_hir_id, ref parent_code, ..
             } => {
                 self.note_function_argument_obligation(
-                    body_id,
+                    body_def_id,
                     err,
                     arg_hir_id,
                     parent_code,
@@ -4437,7 +4444,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 );
                 ensure_sufficient_stack(|| {
                     self.note_obligation_cause_code(
-                        body_id,
+                        body_def_id,
                         err,
                         predicate,
                         param_env,
@@ -4481,7 +4488,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 let (expr_ty, expr) = if let Some((expr_ty, hir_id)) = expr_info {
                     let expr = tcx.hir_expect_expr(hir_id);
                     (expr_ty, expr)
-                } else if let Some(body_id) = tcx.hir_node_by_def_id(body_id).body_id()
+                } else if let Some(body_id) = tcx.hir_node_by_def_id(body_def_id).body_id()
                     && let body = tcx.hir_body(body_id)
                     && let hir::ExprKind::Block(block, _) = body.value.kind
                     && let Some(expr) = block.expr
@@ -4579,7 +4586,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             && let Ok(snippet) = self.tcx.sess.source_map().span_to_snippet(span)
             && snippet.ends_with('?')
         {
-            match self.tcx.coroutine_kind(obligation.cause.body_id) {
+            match self.tcx.coroutine_kind(obligation.cause.body_def_id) {
                 Some(hir::CoroutineKind::Desugared(hir::CoroutineDesugaring::Async, _)) => {
                     err.span_suggestion_verbose(
                         span.with_hi(span.hi() - BytePos(1)).shrink_to_hi(),
@@ -4591,7 +4598,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 _ => {
                     let mut span: MultiSpan = span.with_lo(span.hi() - BytePos(1)).into();
                     span.push_span_label(
-                        self.tcx.def_span(obligation.cause.body_id),
+                        self.tcx.def_span(obligation.cause.body_def_id),
                         "this is not `async`",
                     );
                     err.span_note(
@@ -4732,7 +4739,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
 
     fn note_function_argument_obligation<G: EmissionGuarantee>(
         &self,
-        body_id: LocalDefId,
+        body_def_id: LocalDefId,
         err: &mut Diag<'_, G>,
         arg_hir_id: HirId,
         parent_code: &ObligationCauseCode<'tcx>,
@@ -4749,7 +4756,11 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 && let Some(failed_pred) = failed_pred.as_trait_clause()
                 && let pred = failed_pred.map_bound(|pred| pred.with_replaced_self_ty(tcx, ty))
                 && self.predicate_must_hold_modulo_regions(&Obligation::misc(
-                    tcx, expr.span, body_id, param_env, pred,
+                    tcx,
+                    expr.span,
+                    body_def_id,
+                    param_env,
+                    pred,
                 ))
                 && expr.span.hi() != rcvr.span.hi()
             {
@@ -4882,7 +4893,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                         for (expected, actual) in zipped {
                             self.probe(|_| {
                                 match self
-                                    .at(&ObligationCause::misc(expr.span, body_id), param_env)
+                                    .at(&ObligationCause::misc(expr.span, body_def_id), param_env)
                                     // Doesn't actually matter if we define opaque types here, this is just used for
                                     // diagnostics, and the result is never kept around.
                                     .eq(DefineOpaqueTypes::Yes, expected, actual)
@@ -5870,7 +5881,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             }
         }
 
-        let node = self.tcx.hir_node_by_def_id(obligation.cause.body_id);
+        let node = self.tcx.hir_node_by_def_id(obligation.cause.body_def_id);
         if let Some((fn_decl, body_id)) = choose_suggest_items(self.tcx, node)
             && let hir::FnRetTy::DefaultReturn(ret_span) = fn_decl.output
             && self.tcx.is_diagnostic_item(sym::FromResidual, trait_pred.def_id())

--- a/compiler/rustc_trait_selection/src/regions.rs
+++ b/compiler/rustc_trait_selection/src/regions.rs
@@ -14,16 +14,16 @@ use crate::traits::outlives_bounds::InferCtxtExt;
 impl<'tcx> OutlivesEnvironment<'tcx> {
     fn new(
         infcx: &InferCtxt<'tcx>,
-        body_id: LocalDefId,
+        body_def_id: LocalDefId,
         param_env: ty::ParamEnv<'tcx>,
         assumed_wf_tys: impl IntoIterator<Item = Ty<'tcx>>,
     ) -> Self {
-        Self::new_with_implied_bounds_compat(infcx, body_id, param_env, assumed_wf_tys, false)
+        Self::new_with_implied_bounds_compat(infcx, body_def_id, param_env, assumed_wf_tys, false)
     }
 
     fn new_with_implied_bounds_compat(
         infcx: &InferCtxt<'tcx>,
-        body_id: LocalDefId,
+        body_def_id: LocalDefId,
         param_env: ty::ParamEnv<'tcx>,
         assumed_wf_tys: impl IntoIterator<Item = Ty<'tcx>>,
         disable_implied_bounds_hack: bool,
@@ -60,7 +60,7 @@ impl<'tcx> OutlivesEnvironment<'tcx> {
             param_env,
             bounds,
             infcx.implied_bounds_tys(
-                body_id,
+                body_def_id,
                 param_env,
                 assumed_wf_tys,
                 disable_implied_bounds_hack,
@@ -82,13 +82,13 @@ impl<'tcx> InferCtxt<'tcx> {
     /// This function assumes that all infer variables are already constrained.
     fn resolve_regions(
         &self,
-        body_id: LocalDefId,
+        body_def_id: LocalDefId,
         param_env: ty::ParamEnv<'tcx>,
         assumed_wf_tys: impl IntoIterator<Item = Ty<'tcx>>,
     ) -> Vec<RegionResolutionError<'tcx>> {
         self.resolve_regions_with_outlives_env(
-            &OutlivesEnvironment::new(self, body_id, param_env, assumed_wf_tys),
-            self.tcx.def_span(body_id),
+            &OutlivesEnvironment::new(self, body_def_id, param_env, assumed_wf_tys),
+            self.tcx.def_span(body_def_id),
         )
     }
 

--- a/compiler/rustc_trait_selection/src/solve/fulfill/derive_errors.rs
+++ b/compiler/rustc_trait_selection/src/solve/fulfill/derive_errors.rs
@@ -258,10 +258,11 @@ impl<'tcx> BestObligation<'tcx> {
     ) -> ControlFlow<PredicateObligation<'tcx>> {
         let infcx = candidate.goal().infcx();
         let param_env = candidate.goal().goal().param_env;
-        let body_id = self.obligation.cause.body_id;
+        let body_def_id = self.obligation.cause.body_def_id;
 
-        for obligation in wf::unnormalized_obligations(infcx, param_env, term, self.span(), body_id)
-            .into_flat_iter()
+        for obligation in
+            wf::unnormalized_obligations(infcx, param_env, term, self.span(), body_def_id)
+                .into_flat_iter()
         {
             let nested_goal = candidate.instantiate_proof_tree_for_nested_goal(
                 GoalSource::Misc,

--- a/compiler/rustc_trait_selection/src/traits/effects.rs
+++ b/compiler/rustc_trait_selection/src/traits/effects.rs
@@ -574,7 +574,7 @@ fn evaluate_host_effect_for_fn_goal<'tcx>(
             .map(|(c, span)| {
                 let code = ObligationCauseCode::WhereClause(def, span);
                 let cause =
-                    ObligationCause::new(obligation.cause.span, obligation.cause.body_id, code);
+                    ObligationCause::new(obligation.cause.span, obligation.cause.body_def_id, code);
                 Obligation::new(
                     tcx,
                     cause,

--- a/compiler/rustc_trait_selection/src/traits/engine.rs
+++ b/compiler/rustc_trait_selection/src/traits/engine.rs
@@ -246,15 +246,15 @@ where
     /// will result in region constraints getting ignored.
     pub fn resolve_regions_and_report_errors(
         self,
-        body_id: LocalDefId,
+        body_def_id: LocalDefId,
         param_env: ty::ParamEnv<'tcx>,
         assumed_wf_tys: impl IntoIterator<Item = Ty<'tcx>>,
     ) -> Result<(), ErrorGuaranteed> {
-        let errors = self.infcx.resolve_regions(body_id, param_env, assumed_wf_tys);
+        let errors = self.infcx.resolve_regions(body_def_id, param_env, assumed_wf_tys);
         if errors.is_empty() {
             Ok(())
         } else {
-            Err(self.infcx.err_ctxt().report_region_errors(body_id, &errors))
+            Err(self.infcx.err_ctxt().report_region_errors(body_def_id, &errors))
         }
     }
 
@@ -265,11 +265,11 @@ where
     #[must_use]
     pub fn resolve_regions(
         self,
-        body_id: LocalDefId,
+        body_def_id: LocalDefId,
         param_env: ty::ParamEnv<'tcx>,
         assumed_wf_tys: impl IntoIterator<Item = Ty<'tcx>>,
     ) -> Vec<RegionResolutionError<'tcx>> {
-        self.infcx.resolve_regions(body_id, param_env, assumed_wf_tys)
+        self.infcx.resolve_regions(body_def_id, param_env, assumed_wf_tys)
     }
 }
 

--- a/compiler/rustc_trait_selection/src/traits/fulfill.rs
+++ b/compiler/rustc_trait_selection/src/traits/fulfill.rs
@@ -611,7 +611,7 @@ impl<'a, 'tcx> ObligationProcessor for FulfillProcessor<'a, 'tcx> {
                     match wf::obligations(
                         self.selcx.infcx,
                         obligation.param_env,
-                        obligation.cause.body_id,
+                        obligation.cause.body_def_id,
                         obligation.recursion_depth + 1,
                         term,
                         obligation.cause.span,

--- a/compiler/rustc_trait_selection/src/traits/misc.rs
+++ b/compiler/rustc_trait_selection/src/traits/misc.rs
@@ -190,7 +190,7 @@ pub fn type_allowed_to_implement_const_param_ty<'tcx>(
         }
 
         // Check regions assuming the self type of the impl is WF
-        let errors = infcx.resolve_regions(parent_cause.body_id, param_env, [self_type]);
+        let errors = infcx.resolve_regions(parent_cause.body_def_id, param_env, [self_type]);
         if !errors.is_empty() {
             infringing_inner_tys.push((inner_ty, InfringingFieldsReason::Regions(errors)));
             continue;
@@ -279,7 +279,7 @@ pub fn all_fields_implement_trait<'tcx>(
             }
 
             // Check regions assuming the self type of the impl is WF
-            let errors = infcx.resolve_regions(parent_cause.body_id, param_env, [self_type]);
+            let errors = infcx.resolve_regions(parent_cause.body_def_id, param_env, [self_type]);
             if !errors.is_empty() {
                 infringing.push((field, ty, InfringingFieldsReason::Regions(errors)));
             }

--- a/compiler/rustc_trait_selection/src/traits/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/mod.rs
@@ -300,7 +300,7 @@ fn do_normalize_predicates<'tcx>(
     //
     // This is required by trait-system-refactor-initiative#166. The new solver encounters
     // this more frequently as we entirely ignore outlives predicates with the old solver.
-    let _errors = infcx.resolve_regions(cause.body_id, elaborated_env, []);
+    let _errors = infcx.resolve_regions(cause.body_def_id, elaborated_env, []);
     match infcx.fully_resolve(predicates) {
         Ok(predicates) => Ok(predicates),
         Err(fixup_err) => {

--- a/compiler/rustc_trait_selection/src/traits/outlives_bounds.rs
+++ b/compiler/rustc_trait_selection/src/traits/outlives_bounds.rs
@@ -27,15 +27,15 @@ use crate::traits::ObligationCause;
 /// # Parameters
 ///
 /// - `param_env`, the where-clauses in scope
-/// - `body_id`, the body-id to use when normalizing assoc types.
+/// - `body_def_id`, the body_def_id to use when normalizing assoc types.
 ///   Note that this may cause outlives obligations to be injected
 ///   into the inference context with this body-id.
 /// - `ty`, the type that we are supposed to assume is WF.
-#[instrument(level = "debug", skip(infcx, param_env, body_id), ret)]
+#[instrument(level = "debug", skip(infcx, param_env, body_def_id), ret)]
 fn implied_outlives_bounds<'a, 'tcx>(
     infcx: &'a InferCtxt<'tcx>,
     param_env: ty::ParamEnv<'tcx>,
-    body_id: LocalDefId,
+    body_def_id: LocalDefId,
     ty: Ty<'tcx>,
     disable_implied_bounds_hack: bool,
 ) -> Vec<OutlivesBound<'tcx>> {
@@ -60,7 +60,7 @@ fn implied_outlives_bounds<'a, 'tcx>(
     };
 
     let mut constraints = QueryRegionConstraints::default();
-    let span = infcx.tcx.def_span(body_id);
+    let span = infcx.tcx.def_span(body_def_id);
     let Ok(InferOk { value: mut bounds, obligations }) = infcx
         .instantiate_nll_query_response_and_region_obligations(
             &ObligationCause::dummy_with_span(span),
@@ -83,7 +83,7 @@ fn implied_outlives_bounds<'a, 'tcx>(
         // We otherwise would get spurious errors if normalizing an implied
         // outlives bound required proving some higher-ranked coroutine obl.
         let QueryRegionConstraints { constraints, assumptions: _ } = constraints;
-        let cause = ObligationCause::misc(span, body_id);
+        let cause = ObligationCause::misc(span, body_def_id);
         for &QueryRegionConstraint { constraint, visible_for_leak_check: vis, .. } in &constraints {
             match constraint {
                 ty::RegionConstraint::Outlives(predicate) => {
@@ -105,13 +105,13 @@ impl<'tcx> InferCtxt<'tcx> {
     /// instead if you're interested in the implied bounds for a given signature.
     fn implied_bounds_tys<Tys: IntoIterator<Item = Ty<'tcx>>>(
         &self,
-        body_id: LocalDefId,
+        body_def_id: LocalDefId,
         param_env: ParamEnv<'tcx>,
         tys: Tys,
         disable_implied_bounds_hack: bool,
     ) -> impl Iterator<Item = OutlivesBound<'tcx>> {
         tys.into_iter().flat_map(move |ty| {
-            implied_outlives_bounds(self, param_env, body_id, ty, disable_implied_bounds_hack)
+            implied_outlives_bounds(self, param_env, body_def_id, ty, disable_implied_bounds_hack)
         })
     }
 }

--- a/compiler/rustc_trait_selection/src/traits/project.rs
+++ b/compiler/rustc_trait_selection/src/traits/project.rs
@@ -230,7 +230,7 @@ fn project_and_unify_term<'cx, 'tcx>(
     let InferOk { value: actual, obligations: new } =
         selcx.infcx.replace_opaque_types_with_inference_vars(
             actual,
-            obligation.cause.body_id,
+            obligation.cause.body_def_id,
             obligation.cause.span,
             obligation.param_env,
         );
@@ -557,7 +557,7 @@ pub fn normalize_inherent_projection<'a, 'b, 'tcx>(
 
         let nested_cause = ObligationCause::new(
             cause.span,
-            cause.body_id,
+            cause.body_def_id,
             // FIXME(inherent_associated_types): Since we can't pass along the self type to the
             // cause code, inherent projections will be printed with identity instantiation in
             // diagnostics which is not ideal.
@@ -2149,7 +2149,7 @@ fn assoc_term_own_obligations<'cx, 'tcx>(
         } else {
             ObligationCause::new(
                 obligation.cause.span,
-                obligation.cause.body_id,
+                obligation.cause.body_def_id,
                 ObligationCauseCode::WhereClause(def_id, span),
             )
         };

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -727,7 +727,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                     match wf::obligations(
                         self.infcx,
                         obligation.param_env,
-                        obligation.cause.body_id,
+                        obligation.cause.body_def_id,
                         obligation.recursion_depth + 1,
                         term,
                         obligation.cause.span,
@@ -2557,7 +2557,7 @@ impl<'tcx> SelectionContext<'_, 'tcx> {
 
         let cause = ObligationCause::new(
             obligation.cause.span,
-            obligation.cause.body_id,
+            obligation.cause.body_def_id,
             ObligationCauseCode::MatchImpl(obligation.cause.clone(), impl_def_id),
         );
 

--- a/compiler/rustc_trait_selection/src/traits/wf.rs
+++ b/compiler/rustc_trait_selection/src/traits/wf.rs
@@ -30,7 +30,7 @@ use crate::traits;
 pub fn obligations<'tcx>(
     infcx: &InferCtxt<'tcx>,
     param_env: ty::ParamEnv<'tcx>,
-    body_id: LocalDefId,
+    body_def_id: LocalDefId,
     recursion_depth: usize,
     term: Term<'tcx>,
     span: Span,
@@ -72,17 +72,17 @@ pub fn obligations<'tcx>(
     let mut wf = WfPredicates {
         infcx,
         param_env,
-        body_id,
+        body_def_id,
         span,
         out: PredicateObligations::new(),
         recursion_depth,
         item: None,
     };
     wf.add_wf_preds_for_term(term);
-    debug!("wf::obligations({:?}, body_id={:?}) = {:?}", term, body_id, wf.out);
+    debug!("wf::obligations({:?}, body_def_id={:?}) = {:?}", term, body_def_id, wf.out);
 
     let result = wf.normalize(infcx);
-    debug!("wf::obligations({:?}, body_id={:?}) ~~> {:?}", term, body_id, result);
+    debug!("wf::obligations({:?}, body_def_id={:?}) ~~> {:?}", term, body_def_id, result);
     Some(result)
 }
 
@@ -95,7 +95,7 @@ pub fn unnormalized_obligations<'tcx>(
     param_env: ty::ParamEnv<'tcx>,
     term: Term<'tcx>,
     span: Span,
-    body_id: LocalDefId,
+    body_def_id: LocalDefId,
 ) -> Option<PredicateObligations<'tcx>> {
     debug_assert_eq!(term, infcx.resolve_vars_if_possible(term));
 
@@ -109,7 +109,7 @@ pub fn unnormalized_obligations<'tcx>(
     let mut wf = WfPredicates {
         infcx,
         param_env,
-        body_id,
+        body_def_id,
         span,
         out: PredicateObligations::new(),
         recursion_depth: 0,
@@ -126,7 +126,7 @@ pub fn unnormalized_obligations<'tcx>(
 pub fn trait_obligations<'tcx>(
     infcx: &InferCtxt<'tcx>,
     param_env: ty::ParamEnv<'tcx>,
-    body_id: LocalDefId,
+    body_def_id: LocalDefId,
     trait_pred: ty::TraitPredicate<'tcx>,
     span: Span,
     item: &'tcx hir::Item<'tcx>,
@@ -134,7 +134,7 @@ pub fn trait_obligations<'tcx>(
     let mut wf = WfPredicates {
         infcx,
         param_env,
-        body_id,
+        body_def_id,
         span,
         out: PredicateObligations::new(),
         recursion_depth: 0,
@@ -154,14 +154,14 @@ pub fn trait_obligations<'tcx>(
 pub fn clause_obligations<'tcx>(
     infcx: &InferCtxt<'tcx>,
     param_env: ty::ParamEnv<'tcx>,
-    body_id: LocalDefId,
+    body_def_id: LocalDefId,
     clause: ty::Clause<'tcx>,
     span: Span,
 ) -> PredicateObligations<'tcx> {
     let mut wf = WfPredicates {
         infcx,
         param_env,
-        body_id,
+        body_def_id,
         span,
         out: PredicateObligations::new(),
         recursion_depth: 0,
@@ -205,7 +205,7 @@ pub fn clause_obligations<'tcx>(
 struct WfPredicates<'a, 'tcx> {
     infcx: &'a InferCtxt<'tcx>,
     param_env: ty::ParamEnv<'tcx>,
-    body_id: LocalDefId,
+    body_def_id: LocalDefId,
     span: Span,
     out: PredicateObligations<'tcx>,
     recursion_depth: usize,
@@ -334,7 +334,7 @@ impl<'a, 'tcx> WfPredicates<'a, 'tcx> {
     }
 
     fn cause(&self, code: traits::ObligationCauseCode<'tcx>) -> traits::ObligationCause<'tcx> {
-        traits::ObligationCause::new(self.span, self.body_id, code)
+        traits::ObligationCause::new(self.span, self.body_def_id, code)
     }
 
     fn normalize(self, infcx: &InferCtxt<'tcx>) -> PredicateObligations<'tcx> {
@@ -423,7 +423,7 @@ impl<'a, 'tcx> WfPredicates<'a, 'tcx> {
                 .filter_map(|(i, arg)| arg.as_term().map(|t| (i, t)))
                 .filter(|(_, term)| !term.has_escaping_bound_vars())
                 .map(|(i, term)| {
-                    let mut cause = traits::ObligationCause::misc(self.span, self.body_id);
+                    let mut cause = traits::ObligationCause::misc(self.span, self.body_def_id);
                     // The first arg is the self ty - use the correct span for it.
                     if i == 0 {
                         if let Some(hir::ItemKind::Impl(hir::Impl { self_ty, .. })) =

--- a/compiler/rustc_ty_utils/src/ty.rs
+++ b/compiler/rustc_ty_utils/src/ty.rs
@@ -196,12 +196,11 @@ fn param_env(tcx: TyCtxt<'_>, def_id: DefId) -> ty::ParamEnv<'_> {
         ));
     }
 
-    let local_did = def_id.as_local();
+    let local_did = def_id.as_local().unwrap_or(CRATE_DEF_ID);
 
     let unnormalized_env = ty::ParamEnv::new(tcx.mk_clauses(&predicates));
 
-    let body_id = local_did.unwrap_or(CRATE_DEF_ID);
-    let cause = traits::ObligationCause::misc(tcx.def_span(def_id), body_id);
+    let cause = traits::ObligationCause::misc(tcx.def_span(def_id), local_did);
     traits::normalize_param_env_or_error(tcx, unnormalized_env, cause)
 }
 

--- a/tests/ui/dyn-compatibility/ice-generics-of-crate-root-152335.rs
+++ b/tests/ui/dyn-compatibility/ice-generics-of-crate-root-152335.rs
@@ -1,7 +1,7 @@
 // Regression test for #152335.
 // The compiler used to ICE in `generics_of` when `note_and_explain_type_err`
 // was called with `CRATE_DEF_ID` as the body owner during dyn-compatibility
-// checking. This happened because `ObligationCause::dummy()` sets `body_id`
+// checking. This happened because `ObligationCause::dummy()` sets `body_def_id`
 // to `CRATE_DEF_ID`, and error reporting tried to look up generics on it.
 
 struct ActuallySuper;


### PR DESCRIPTION
Since body IDs and item IDs are distinct things, try to use names that do not conflate them. `body_def_id` is a little easier to read as "body-owning definition ID" whereas `body_id` is hard not to just read as "body ID".


Related: rust-lang/rust#158611 - I noticed this afterwards. I suspect that `FnCtxt` ought to keep `body_def_id` but maybe add `body_id: BodyId` in addition.