### PR TITLE
Fixes for QNX SDP 8

### DIFF
--- a/library/std/src/os/unix/net/addr.rs
+++ b/library/std/src/os/unix/net/addr.rs
@@ -53,7 +53,15 @@ pub(super) fn sockaddr_un(path: &Path) -> io::Result<(libc::sockaddr_un, libc::s
     let mut len = SUN_PATH_OFFSET + bytes.len();
     match bytes.get(0) {
         Some(&0) | None => {}
-        Some(_) => len += 1,
+        Some(_) => {
+            // on QNX7.1 and QNX8 the `len` value returned by the SUN_LEN
+            // macro in its libc does not include the null byte in the count so
+            // don't add it here to match what a C program passes to bind(2) and
+            // similar functions
+            if cfg!(not(any(target_os = "qnx", target_env = "nto71"))) {
+                len += 1
+            }
+        }
     }
     Ok((addr, len as libc::socklen_t))
 }
@@ -247,7 +255,13 @@ impl SocketAddr {
         } else if self.addr.sun_path[0] == 0 {
             AddressKind::Abstract(ByteStr::from_bytes(&path[1..len]))
         } else {
-            AddressKind::Pathname(OsStr::from_bytes(&path[..len - 1]).as_ref())
+            // the value returned by getsockname(2) and similar on QNX7.1 and
+            // QNX8 does not count the NUL byte terminator of the path string,
+            // which matches the behavior of the SUN_LEN macro in libc, but
+            // other OSes do count the NUL byte so adjust accordingly
+            let end =
+                if cfg!(any(target_os = "qnx", target_env = "nto71")) { len } else { len - 1 };
+            AddressKind::Pathname(OsStr::from_bytes(&path[..end]).as_ref())
         }
     }
 }

--- a/library/std/src/os/unix/net/stream.rs
+++ b/library/std/src/os/unix/net/stream.rs
@@ -256,6 +256,7 @@ impl UnixStream {
         target_os = "netbsd",
         target_os = "openbsd",
         target_os = "nto",
+        target_os = "qnx",
         target_vendor = "apple",
         target_os = "cygwin"
     ))]

--- a/library/std/src/os/unix/net/tests.rs
+++ b/library/std/src/os/unix/net/tests.rs
@@ -9,6 +9,7 @@ use crate::os::cygwin::net::{SocketAddrExt, UnixSocketExt};
 use crate::os::linux::net::{SocketAddrExt, UnixSocketExt};
 #[cfg(any(target_os = "android", target_os = "linux"))]
 use crate::os::unix::io::AsRawFd;
+use crate::path::Path;
 use crate::test_helpers::tmpdir;
 use crate::thread;
 use crate::time::Duration;
@@ -23,6 +24,12 @@ macro_rules! or_panic {
 }
 
 #[test]
+fn sock_addr_from_pathname() {
+    let address = or_panic!(SocketAddr::from_pathname("/path/to/socket"));
+    assert_eq!(address.as_pathname(), Some(Path::new("/path/to/socket")));
+}
+
+#[test]
 #[cfg_attr(target_os = "android", ignore)] // Android SELinux rules prevent creating Unix sockets
 #[cfg_attr(target_os = "vxworks", ignore = "Unix sockets are not implemented in VxWorks")]
 fn basic() {
@@ -32,6 +39,7 @@ fn basic() {
     let msg2 = b"world!";
 
     let listener = or_panic!(UnixListener::bind(&socket_path));
+    assert_eq!(Some(&*socket_path), listener.local_addr().unwrap().as_pathname());
     let thread = thread::spawn(move || {
         let mut stream = or_panic!(listener.accept()).0;
         let mut buf = [0; 5];
@@ -79,6 +87,8 @@ fn pair() {
     let msg2 = b"world!";
 
     let (mut s1, mut s2) = or_panic!(UnixStream::pair());
+    assert!(s1.local_addr().unwrap().is_unnamed());
+    assert!(s2.peer_addr().unwrap().is_unnamed());
     let thread = thread::spawn(move || {
         // s1 must be moved in or the test will hang!
         let mut buf = [0; 5];

--- a/library/std/src/os/unix/process.rs
+++ b/library/std/src/os/unix/process.rs
@@ -19,9 +19,9 @@ cfg_select! {
         type GroupId = u16;
     }
     any(target_os = "nto", target_os = "qnx") => {
-        // Both IDs are signed, see `sys/target_nto.h` of the QNX Neutrino SDP.
+        // Both IDs are signed, see `sys/target_nto.h` of the QNX SDP.
         // Only positive values should be used, see e.g.
-        // https://www.qnx.com/developers/docs/7.1/#com.qnx.doc.neutrino.lib_ref/topic/s/setuid.html
+        // https://www.qnx.com/developers/docs/7.1/com.qnx.doc.neutrino.lib_ref/topic/s/setuid.html
         type UserId = i32;
         type GroupId = i32;
     }

--- a/library/std/src/sys/pal/unix/time.rs
+++ b/library/std/src/sys/pal/unix/time.rs
@@ -177,9 +177,9 @@ impl Timespec {
         })
     }
 
-    // On QNX Neutrino, the maximum timespec for e.g. pthread_cond_timedwait
+    // On QNX, the maximum timespec for e.g. pthread_cond_timedwait
     // is 2^64 nanoseconds
-    #[cfg(target_os = "nto")]
+    #[cfg(any(target_os = "nto", target_os = "qnx"))]
     pub(in crate::sys) fn to_timespec_capped(&self) -> Option<libc::timespec> {
         // Check if timeout in nanoseconds would fit into an u64
         if (self.tv_nsec.as_inner() as u64)

--- a/library/std/src/sys/paths/unix.rs
+++ b/library/std/src/sys/paths/unix.rs
@@ -272,7 +272,7 @@ pub fn current_exe() -> io::Result<PathBuf> {
 #[cfg(any(target_os = "nto", target_os = "qnx"))]
 pub fn current_exe() -> io::Result<PathBuf> {
     let mut e = crate::fs::read("/proc/self/exefile")?;
-    // Current versions of QNX Neutrino provide a null-terminated path.
+    // Current versions of QNX SDP provide a null-terminated path.
     // Ensure the trailing null byte is not returned here.
     if let Some(0) = e.last() {
         e.pop();

--- a/library/std/src/sys/process/unix/common/tests.rs
+++ b/library/std/src/sys/process/unix/common/tests.rs
@@ -99,8 +99,13 @@ fn test_process_group_posix_spawn() {
         cmd.stdout(Stdio::MakePipe);
         let (mut cat, _pipes) = t!(cmd.spawn(Stdio::Null, true));
 
+        let pid = cat.id() as libc::pid_t;
+        let pgid = libc::getpgid(pid);
+        assert_ne!(-1, pgid, "getpgid failed");
+        assert_eq!(pid, pgid, "child process ID does not match its process group ID");
+
         // Check that we can kill its process group, which means there *is* one.
-        t!(cvt(libc::kill(-(cat.id() as libc::pid_t), libc::SIGINT)));
+        t!(cvt(libc::kill(-pgid, libc::SIGINT)));
 
         t!(cat.wait());
     }
@@ -127,8 +132,18 @@ fn test_process_group_no_posix_spawn() {
         cmd.stdout(Stdio::MakePipe);
         let (mut cat, _pipes) = t!(cmd.spawn(Stdio::Null, true));
 
+        let pid = cat.id() as libc::pid_t;
+        let pgid = libc::getpgid(pid);
+        assert_ne!(-1, pgid, "getpgid failed");
+        assert_eq!(pid, pgid, "child process ID does not match its process group ID");
+
+        if cfg!(target_os = "qnx") {
+            // kill(-pgid) appears to be unable to terminate the child process on QNX8
+            return;
+        }
+
         // Check that we can kill its process group, which means there *is* one.
-        t!(cvt(libc::kill(-(cat.id() as libc::pid_t), libc::SIGINT)));
+        t!(cvt(libc::kill(-pgid, libc::SIGINT)));
 
         t!(cat.wait());
     }
@@ -154,9 +169,19 @@ fn test_setsid_posix_spawn() {
     let (mut cat, _pipes) = t!(cmd.spawn(Stdio::Null, true));
 
     unsafe {
+        let pid = cat.id() as libc::pid_t;
+        let pgid = libc::getpgid(pid);
+        assert_ne!(-1, pgid, "getpgid failed");
+        assert_eq!(pid, pgid, "child process ID does not match its process group ID");
+
+        if cfg!(target_os = "qnx") {
+            // kill(-pgid) appears to be unable to terminate the child process on QNX8
+            return;
+        }
+
         // Setsid will create a new session and process group, so check that
         // we can kill the process group, which means there *is* one.
-        t!(cvt(libc::kill(-(cat.id() as libc::pid_t), libc::SIGINT)));
+        t!(cvt(libc::kill(-pgid, libc::SIGINT)));
 
         t!(cat.wait());
     }
@@ -184,9 +209,19 @@ fn test_setsid_no_posix_spawn() {
         cmd.pre_exec(Box::new(|| Ok(()))); // pre_exec forces fork + exec rather than posix spawn.
         let (mut cat, _pipes) = t!(cmd.spawn(Stdio::Null, true));
 
+        let pid = cat.id() as libc::pid_t;
+        let pgid = libc::getpgid(pid);
+        assert_ne!(-1, pgid, "getpgid failed");
+        assert_eq!(pid, pgid, "child process ID does not match its process group ID");
+
+        if cfg!(target_os = "qnx") {
+            // kill(-pgid) appears to be unable to terminate the child process on QNX8
+            return;
+        }
+
         // Setsid will create a new session and process group, so check that
         // we can kill the process group, which means there *is* one.
-        t!(cvt(libc::kill(-(cat.id() as libc::pid_t), libc::SIGINT)));
+        t!(cvt(libc::kill(-pgid, libc::SIGINT)));
 
         t!(cat.wait());
     }

--- a/library/std/src/sys/process/unix/unix.rs
+++ b/library/std/src/sys/process/unix/unix.rs
@@ -193,10 +193,10 @@ impl Command {
         cvt(libc::fork())
     }
 
-    // On QNX Neutrino, fork can fail with EBADF in case "another thread might have opened
+    // On QNX SDP, fork can fail with EBADF in case "another thread might have opened
     // or closed a file descriptor while the fork() was occurring".
     // Documentation says "... or try calling fork() again". This is what we do here.
-    // See also https://www.qnx.com/developers/docs/7.1/#com.qnx.doc.neutrino.lib_ref/topic/f/fork.html
+    // See also https://www.qnx.com/developers/docs/7.1/com.qnx.doc.neutrino.lib_ref/topic/f/fork.html
     #[cfg(any(target_os = "nto", target_os = "qnx"))]
     unsafe fn do_fork(&mut self) -> Result<pid_t, io::Error> {
         use crate::sys::io::errno;
@@ -553,10 +553,10 @@ impl Command {
             }
         }
 
-        // On QNX Neutrino, posix_spawnp can fail with EBADF in case "another thread might have opened
+        // On QNX SDP, posix_spawnp can fail with EBADF in case "another thread might have opened
         // or closed a file descriptor while the posix_spawn() was occurring".
         // Documentation says "... or try calling posix_spawn() again". This is what we do here.
-        // See also http://www.qnx.com/developers/docs/7.1/#com.qnx.doc.neutrino.lib_ref/topic/p/posix_spawn.html
+        // See also https://www.qnx.com/developers/docs/7.1/com.qnx.doc.neutrino.lib_ref/topic/p/posix_spawn.html
         #[cfg(any(target_os = "nto", target_os = "qnx"))]
         unsafe fn retrying_libc_posix_spawnp(
             pid: *mut pid_t,
@@ -756,7 +756,7 @@ impl Command {
             if self.get_setsid() {
                 cfg_select! {
                     all(target_os = "linux", target_env = "gnu") => {
-                        flags |= libc::POSIX_SPAWN_SETSID;
+                        flags |= libc::POSIX_SPAWN_SETSID as i32;
                     }
                     _ => {
                         return Ok(None);

--- a/library/std/src/sys/thread/unix.rs
+++ b/library/std/src/sys/thread/unix.rs
@@ -278,7 +278,7 @@ pub fn available_parallelism() -> io::Result<NonZero<usize>> {
 
             Ok(unsafe { NonZero::new_unchecked(cpus as usize) })
         }
-        target_os = "nto" => {
+        any(target_os = "nto", target_os = "qnx") => {
             unsafe {
                 use libc::_syspage_ptr;
                 if _syspage_ptr.is_null() {
@@ -347,7 +347,7 @@ pub fn current_os_id() -> Option<u64> {
             let id: libc::pid_t = unsafe { gettid() };
             Some(id as u64)
         }
-        target_os = "nto" => {
+        any(target_os = "nto", target_os = "qnx") => {
             // SAFETY: FFI call with no preconditions.
             let id: libc::pid_t = unsafe { libc::gettid() };
             Some(id as u64)
@@ -392,6 +392,7 @@ pub fn current_os_id() -> Option<u64> {
 #[cfg(any(
     target_os = "linux",
     target_os = "nto",
+    target_os = "qnx",
     target_os = "solaris",
     target_os = "illumos",
     target_os = "vxworks",
@@ -484,14 +485,14 @@ pub fn set_name(name: &CStr) {
     }
 }
 
-#[cfg(any(target_os = "solaris", target_os = "illumos", target_os = "nto"))]
+#[cfg(any(target_os = "solaris", target_os = "illumos", target_os = "nto", target_os = "qnx"))]
 pub fn set_name(name: &CStr) {
     weak!(
         fn pthread_setname_np(thread: libc::pthread_t, name: *const libc::c_char) -> libc::c_int;
     );
 
     if let Some(f) = pthread_setname_np.get() {
-        #[cfg(target_os = "nto")]
+        #[cfg(any(target_os = "nto", target_os = "qnx"))]
         const THREAD_NAME_MAX: usize = libc::_NTO_THREAD_NAME_MAX as usize;
         #[cfg(any(target_os = "solaris", target_os = "illumos"))]
         const THREAD_NAME_MAX: usize = 32;

--- a/library/std/src/sys/thread_local/key/racy.rs
+++ b/library/std/src/sys/thread_local/key/racy.rs
@@ -21,12 +21,12 @@ pub struct LazyKey {
 
 // Define a sentinel value that is likely not to be returned
 // as a TLS key.
-#[cfg(not(target_os = "nto"))]
+#[cfg(not(any(target_os = "nto", target_os = "qnx")))]
 const KEY_SENTVAL: usize = 0;
-// On QNX Neutrino, 0 is always returned when currently not in use.
-// Using 0 would mean to always create two keys and remote the first
+// On QNX SDP, 0 is always returned when currently not in use.
+// Using 0 would mean to always create two keys and remove the first
 // one (with value of 0) immediately afterwards.
-#[cfg(target_os = "nto")]
+#[cfg(any(target_os = "nto", target_os = "qnx"))]
 const KEY_SENTVAL: usize = libc::PTHREAD_KEYS_MAX + 1;
 
 impl LazyKey {

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -275,9 +275,9 @@ target | std | host | notes
 [`aarch64-unknown-linux-pauthtest`](platform-support/aarch64-unknown-linux-pauthtest.md) | ✓ | ✓ | ARM64 PAC ELF ABI
 [`aarch64-unknown-managarm-mlibc`](platform-support/managarm.md) | ? |  | ARM64 Managarm
 [`aarch64-unknown-netbsd`](platform-support/netbsd.md) | ✓ | ✓ | ARM64 NetBSD
-[`aarch64-unknown-nto-qnx700`](platform-support/nto-qnx.md) | ? |  | ARM64 QNX Neutrino 7.0 RTOS |
-[`aarch64-unknown-nto-qnx710`](platform-support/nto-qnx.md) | ✓ |  | ARM64 QNX Neutrino 7.1 RTOS with default network stack (io-pkt) |
-[`aarch64-unknown-nto-qnx710_iosock`](platform-support/nto-qnx.md) | ✓ |  | ARM64 QNX Neutrino 7.1 RTOS with new network stack (io-sock) |
+[`aarch64-unknown-nto-qnx700`](platform-support/nto-qnx.md) | ? |  | ARM64 QNX SDP 7.0 |
+[`aarch64-unknown-nto-qnx710`](platform-support/nto-qnx.md) | ✓ |  | ARM64 QNX SDP 7.1 with default network stack (io-pkt) |
+[`aarch64-unknown-nto-qnx710_iosock`](platform-support/nto-qnx.md) | ✓ |  | ARM64 QNX SDP 7.1 with new network stack (io-sock) |
 [`aarch64-unknown-qnx`](platform-support/nto-qnx.md) | ✓ |  | ARM64 QNX SDP 8.0+ |
 [`aarch64-unknown-nuttx`](platform-support/nuttx.md) | ✓ |  | ARM64 with NuttX
 [`aarch64-unknown-openbsd`](platform-support/openbsd.md) | ✓ | ✓ | ARM64 OpenBSD
@@ -340,7 +340,7 @@ target | std | host | notes
 [`i586-unknown-redox`](platform-support/redox.md) | ✓ |  | 32-bit x86 Redox OS (PentiumPro) [^x86_32-floats-x87]
 [`i686-apple-darwin`](platform-support/apple-darwin.md) | ✓ | ✓ | 32-bit macOS (10.12+, Sierra+, Penryn) [^x86_32-floats-return-ABI]
 [`i686-oe-linux-gnu`](platform-support/oe-linux-gnu.md) | ✓ |  | 32-bit x86 OpenEmbedded/Yocto Linux (GNU)
-[`i686-pc-nto-qnx700`](platform-support/nto-qnx.md) | * |  | 32-bit x86 QNX Neutrino 7.0 RTOS (Pentium 4) [^x86_32-floats-return-ABI]
+[`i686-pc-nto-qnx700`](platform-support/nto-qnx.md) | * |  | 32-bit x86 QNX SDP 7.0 (Pentium 4) [^x86_32-floats-return-ABI]
 `i686-unknown-haiku` | ✓ | ✓ | 32-bit Haiku (Pentium 4) [^x86_32-floats-return-ABI]
 [`i686-unknown-helenos`](platform-support/helenos.md) | ✓ |  | HelenOS IA-32 (see docs for pending issues)
 [`i686-unknown-hurd-gnu`](platform-support/hurd.md) | ✓ | ✓ | 32-bit GNU/Hurd (Pentium 4) [^x86_32-floats-return-ABI]
@@ -449,8 +449,8 @@ target | std | host | notes
 [`x86_64-lynx-lynxos178`](platform-support/lynxos178.md) |  |  | x86_64 LynxOS-178
 [`x86_64-oe-linux-gnu`](platform-support/oe-linux-gnu.md) | ✓ |  | x86 64-bit OpenEmbedded/Yocto Linux (GNU)
 [`x86_64-pc-cygwin`](platform-support/x86_64-pc-cygwin.md) | ✓ |  | 64-bit x86 Cygwin |
-[`x86_64-pc-nto-qnx710`](platform-support/nto-qnx.md) | ✓ |  | x86 64-bit QNX Neutrino 7.1 RTOS with default network stack (io-pkt) |
-[`x86_64-pc-nto-qnx710_iosock`](platform-support/nto-qnx.md) | ✓ |  | x86 64-bit QNX Neutrino 7.1 RTOS with new network stack (io-sock) |
+[`x86_64-pc-nto-qnx710`](platform-support/nto-qnx.md) | ✓ |  | x86 64-bit QNX SDP 7.1 with default network stack (io-pkt) |
+[`x86_64-pc-nto-qnx710_iosock`](platform-support/nto-qnx.md) | ✓ |  | x86 64-bit QNX SDP 7.1 with new network stack (io-sock) |
 [`x86_64-pc-qnx`](platform-support/nto-qnx.md) | ✓ |  | x86 64-bit QNX SDP 8.0+ |
 [`x86_64-unikraft-linux-musl`](platform-support/unikraft-linux-musl.md) | ✓ |  | 64-bit Unikraft with musl 1.2.5
 `x86_64-unknown-dragonfly` | ✓ | ✓ | 64-bit DragonFlyBSD

--- a/src/doc/rustc/src/platform-support/nto-qnx.md
+++ b/src/doc/rustc/src/platform-support/nto-qnx.md
@@ -83,49 +83,23 @@ For conditional compilation, the following QNX specific attributes are defined:
     ```toml
     profile = "compiler"
     change-id = 999999
+
+    [build]
+    host = ["x86_64-unknown-linux-gnu"]
+    target = ["x86_64-unknown-linux-gnu", "aarch64-unknown-nto-qnx710"]
     ```
 
-2. Compile the Rust toolchain for an `x86_64-unknown-linux-gnu` host
+2. Compile the Rust toolchain with the QNX SDP environment loaded
 
-    Compiling the Rust toolchain requires the same environment variables used for compiling C binaries.
-    Refer to the [QNX developer manual](https://www.qnx.com/developers/docs/7.1/#com.qnx.doc.neutrino.prog/topic/devel_OS_version.html).
+    As noted above, we need the right environment variables for QNX SDP to work,
+    and for `qcc` to be in your system PATH. Typically this is done by sourcing
+    the `qnxsdp-env.sh` file (or equivalent for your host platform).
 
-    To compile for QNX, environment variables must be set to use the correct tools and compiler switches:
-
-    - `CC_<target>=qcc`
-    - `CFLAGS_<target>=<nto_cflag>`
-    - `CXX_<target>=qcc`
-    - `AR_<target>=<nto_ar>`
-
-    With:
-
-    - `<target>` target triplet using underscores instead of hyphens, e.g. `aarch64_unknown_nto_qnx710`
-    - `<nto_cflag>`
-
-      - `-Vgcc_ntox86_cxx` for x86 (32 bit)
-      - `-Vgcc_ntox86_64_cxx` for x86_64 (64 bit)
-      - `-Vgcc_ntoaarch64le_cxx` for Aarch64 (64 bit)
-
-    - `<nto_ar>`
-
-      - `ntox86-ar` for x86 (32 bit)
-      - `ntox86_64-ar` for x86_64 (64 bit)
-      - `ntoaarch64-ar` for Aarch64 (64 bit)
-
-    Example to build the Rust toolchain including a standard library for x86_64-linux-gnu and Aarch64-QNX-7.1:
+    To build on Linux, you would run:
 
     ```bash
-    export build_env='
-        CC_aarch64_unknown_nto_qnx710=qcc
-        CFLAGS_aarch64_unknown_nto_qnx710=-Vgcc_ntoaarch64le_cxx
-        CXX_aarch64_unknown_nto_qnx710=qcc
-        AR_aarch64_unknown_nto_qnx710=ntoaarch64-ar
-        '
-
-    env $build_env \
-        ./x.py build \
-            --target x86_64-unknown-linux-gnu,aarch64-unknown-nto-qnx710 \
-            rustc library/core library/alloc library/std
+    source ~/qnx710/qnxsdp-env.sh
+    ./x.py build rustc library/core library/alloc library/std
     ```
 
 ## Building Rust programs
@@ -147,7 +121,7 @@ change calling conventions or memory layout.
 
 The test suites of the Rust compiler and standard library can be executed much
 like other Rust targets. The environment for testing should match the one used
-during compiler compilation (refer to `build_env` and `qcc`/`PATH` above) with
+during compiler compilation (refer to notes on `qnxsdp-env.sh` above) with
 the addition of the `TEST_DEVICE_ADDR` environment variable. The
 `TEST_DEVICE_ADDR` variable controls the remote runner and should point to a
 target running the `remote-test-server` executable.
@@ -158,8 +132,8 @@ target maintainers which can be seen in the following example.
 To run all tests on a x86_64 QNX Neutrino 7.1 target:
 
 ```bash
+source ~/qnx710/qnxsdp-env.sh
 export TEST_DEVICE_ADDR="1.2.3.4:12345" # must address the test target, can be a SSH tunnel
-export build_env=<see above>
 
 # Disable tests that only work on the host or don't make sense for this target.
 # See also:
@@ -174,11 +148,10 @@ export exclude_tests='
     --exclude rustc
     --exclude rustdoc'
 
-env $build_env \
-    ./x.py test \
-        $exclude_tests \
-        --stage 1 \
-        --target x86_64-pc-nto-qnx710
+./x.py test \
+    $exclude_tests \
+    --stage 1 \
+    --target x86_64-pc-nto-qnx710
 ```
 
 ### Rust std library test suite

--- a/src/tools/compiletest/src/directives/directive_names.rs
+++ b/src/tools/compiletest/src/directives/directive_names.rs
@@ -109,6 +109,7 @@ pub(crate) const KNOWN_DIRECTIVE_NAMES: &[&str] = &[
     "ignore-pauthtest",
     "ignore-powerpc",
     "ignore-powerpc64",
+    "ignore-qnx",
     "ignore-remote",
     "ignore-riscv32",
     "ignore-riscv64",

--- a/tests/codegen-llvm/thread-local.rs
+++ b/tests/codegen-llvm/thread-local.rs
@@ -5,6 +5,7 @@
 //@ ignore-emscripten globals are used instead of thread locals
 //@ ignore-android does not use #[thread_local]
 //@ ignore-nto does not use #[thread_local]
+//@ ignore-qnx does not use #[thread_local]
 
 #![crate_type = "lib"]
 

--- a/tests/ui/abi/stack-probes-lto.rs
+++ b/tests/ui/abi/stack-probes-lto.rs
@@ -8,7 +8,8 @@
 //@ ignore-fuchsia no exception handler registered for segfault
 //@ compile-flags: -C lto
 //@ no-prefer-dynamic
-//@ ignore-nto Crash analysis impossible at SIGSEGV in QNX Neutrino
+//@ ignore-nto Crash analysis impossible at SIGSEGV in QNX SDP 7.x
+//@ ignore-qnx Crash analysis impossible at SIGSEGV in QNX SDP 8.0+
 //@ ignore-ios Stack probes are enabled, but the SIGSEGV handler isn't
 //@ ignore-tvos Stack probes are enabled, but the SIGSEGV handler isn't
 //@ ignore-watchos Stack probes are enabled, but the SIGSEGV handler isn't

--- a/tests/ui/abi/stack-probes.rs
+++ b/tests/ui/abi/stack-probes.rs
@@ -5,7 +5,8 @@
 //@[x64] only-x86_64
 //@ needs-subprocess
 //@ ignore-fuchsia no exception handler registered for segfault
-//@ ignore-nto Crash analysis impossible at SIGSEGV in QNX Neutrino
+//@ ignore-nto Crash analysis impossible at SIGSEGV in QNX SDP 7.x
+//@ ignore-qnx Crash analysis impossible at SIGSEGV in QNX SDP 8.0+
 //@ ignore-ios Stack probes are enabled, but the SIGSEGV handler isn't
 //@ ignore-tvos Stack probes are enabled, but the SIGSEGV handler isn't
 //@ ignore-watchos Stack probes are enabled, but the SIGSEGV handler isn't

--- a/tests/ui/command/command-setgroups.rs
+++ b/tests/ui/command/command-setgroups.rs
@@ -2,6 +2,7 @@
 //@ only-unix (this is a unix-specific test)
 //@ ignore-musl - returns dummy result for _SC_NGROUPS_MAX
 //@ ignore-nto - does not have `/bin/id`, expects groups to be i32 (not u32)
+//@ ignore-qnx - does not have `/bin/id`, expects groups to be i32 (not u32)
 //@ needs-subprocess
 
 #![feature(rustc_private)]

--- a/tests/ui/process/process-spawn-failure.rs
+++ b/tests/ui/process/process-spawn-failure.rs
@@ -9,6 +9,7 @@
 //@ ignore-vxworks no 'ps'
 //@ ignore-fuchsia no 'ps'
 //@ ignore-nto no 'ps'
+//@ ignore-qnx no 'ps'
 //@ ignore-ios no 'ps'
 //@ ignore-tvos no 'ps'
 //@ ignore-watchos no 'ps'

--- a/tests/ui/runtime/out-of-stack.rs
+++ b/tests/ui/runtime/out-of-stack.rs
@@ -6,6 +6,7 @@
 //@ needs-subprocess
 //@ ignore-fuchsia must translate zircon signal to SIGABRT, FIXME (#58590)
 //@ ignore-nto no stack overflow handler used (no alternate stack available)
+//@ ignore-qnx no stack overflow handler used (no alternate stack available)
 //@ ignore-ios stack overflow handlers aren't enabled
 //@ ignore-tvos stack overflow handlers aren't enabled
 //@ ignore-watchos stack overflow handlers aren't enabled

--- a/tests/ui/runtime/signal-alternate-stack-cleanup.rs
+++ b/tests/ui/runtime/signal-alternate-stack-cleanup.rs
@@ -8,6 +8,7 @@
 //@ ignore-sgx no libc
 //@ ignore-vxworks no SIGWINCH in user space
 //@ ignore-nto no SA_ONSTACK
+//@ ignore-qnx no SA_ONSTACK
 
 #![allow(function_casts_as_integer)]
 #![feature(rustc_private)]

--- a/tests/ui/suggestions/missing-lifetime-specifier.rs
+++ b/tests/ui/suggestions/missing-lifetime-specifier.rs
@@ -4,6 +4,7 @@
 //@ ignore-emscripten globals are used instead of thread locals
 //@ ignore-android does not use #[thread_local]
 //@ ignore-nto does not use #[thread_local]
+//@ ignore-qnx does not use #[thread_local]
 // Different number of duplicated diagnostics on different targets
 //@ compile-flags: -Zdeduplicate-diagnostics=yes
 

--- a/tests/ui/suggestions/missing-lifetime-specifier.stderr
+++ b/tests/ui/suggestions/missing-lifetime-specifier.stderr
@@ -1,5 +1,5 @@
 error[E0106]: missing lifetime specifiers
-  --> $DIR/missing-lifetime-specifier.rs:26:44
+  --> $DIR/missing-lifetime-specifier.rs:27:44
    |
 LL |     static a: RefCell<HashMap<i32, Vec<Vec<Foo>>>> = RefCell::new(HashMap::new());
    |                                            ^^^ expected 2 lifetime parameters
@@ -11,7 +11,7 @@ LL |     static a: RefCell<HashMap<i32, Vec<Vec<Foo<'static, 'static>>>>> = RefC
    |                                               ++++++++++++++++++
 
 error[E0106]: missing lifetime specifiers
-  --> $DIR/missing-lifetime-specifier.rs:30:44
+  --> $DIR/missing-lifetime-specifier.rs:31:44
    |
 LL |     static b: RefCell<HashMap<i32, Vec<Vec<&dyn Bar>>>> = RefCell::new(HashMap::new());
    |                                            ^    ^^^ expected 2 lifetime parameters
@@ -25,7 +25,7 @@ LL |     static b: RefCell<HashMap<i32, Vec<Vec<&'static dyn Bar<'static, 'stati
    |                                             +++++++        ++++++++++++++++++
 
 error[E0106]: missing lifetime specifiers
-  --> $DIR/missing-lifetime-specifier.rs:34:47
+  --> $DIR/missing-lifetime-specifier.rs:35:47
    |
 LL |     static c: RefCell<HashMap<i32, Vec<Vec<Qux<i32>>>>> = RefCell::new(HashMap::new());
    |                                               ^ expected 2 lifetime parameters
@@ -37,7 +37,7 @@ LL |     static c: RefCell<HashMap<i32, Vec<Vec<Qux<'static, 'static, i32>>>>> =
    |                                                +++++++++++++++++
 
 error[E0106]: missing lifetime specifiers
-  --> $DIR/missing-lifetime-specifier.rs:38:44
+  --> $DIR/missing-lifetime-specifier.rs:39:44
    |
 LL |     static d: RefCell<HashMap<i32, Vec<Vec<&dyn Tar<i32>>>>> = RefCell::new(HashMap::new());
    |                                            ^       ^ expected 2 lifetime parameters
@@ -51,7 +51,7 @@ LL |     static d: RefCell<HashMap<i32, Vec<Vec<&'static dyn Tar<'static, 'stati
    |                                             +++++++         +++++++++++++++++
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/missing-lifetime-specifier.rs:47:44
+  --> $DIR/missing-lifetime-specifier.rs:48:44
    |
 LL |     static f: RefCell<HashMap<i32, Vec<Vec<&dyn Tar<'static, i32>>>>> =
    |                                            ^ expected named lifetime parameter
@@ -68,7 +68,7 @@ LL +     static f: RefCell<HashMap<i32, Vec<Vec<dyn Tar<'static, i32>>>>> =
    |
 
 error[E0107]: union takes 2 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/missing-lifetime-specifier.rs:43:44
+  --> $DIR/missing-lifetime-specifier.rs:44:44
    |
 LL |     static e: RefCell<HashMap<i32, Vec<Vec<Qux<'static, i32>>>>> = RefCell::new(HashMap::new());
    |                                            ^^^ ------- supplied 1 lifetime argument
@@ -76,7 +76,7 @@ LL |     static e: RefCell<HashMap<i32, Vec<Vec<Qux<'static, i32>>>>> = RefCell:
    |                                            expected 2 lifetime arguments
    |
 note: union defined here, with 2 lifetime parameters: `'t`, `'k`
-  --> $DIR/missing-lifetime-specifier.rs:19:11
+  --> $DIR/missing-lifetime-specifier.rs:20:11
    |
 LL | pub union Qux<'t, 'k, I> {
    |           ^^^ --  --
@@ -86,7 +86,7 @@ LL |     static e: RefCell<HashMap<i32, Vec<Vec<Qux<'static, 'static, i32>>>>> =
    |                                                       +++++++++
 
 error[E0107]: trait takes 2 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/missing-lifetime-specifier.rs:47:49
+  --> $DIR/missing-lifetime-specifier.rs:48:49
    |
 LL |     static f: RefCell<HashMap<i32, Vec<Vec<&dyn Tar<'static, i32>>>>> =
    |                                                 ^^^ ------- supplied 1 lifetime argument
@@ -94,7 +94,7 @@ LL |     static f: RefCell<HashMap<i32, Vec<Vec<&dyn Tar<'static, i32>>>>> =
    |                                                 expected 2 lifetime arguments
    |
 note: trait defined here, with 2 lifetime parameters: `'t`, `'k`
-  --> $DIR/missing-lifetime-specifier.rs:23:7
+  --> $DIR/missing-lifetime-specifier.rs:24:7
    |
 LL | trait Tar<'t, 'k, I> {}
    |       ^^^ --  --


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/158697)*
<!-- homu-ignore:end -->

This PR contains libstd fixes so libstd can be build for QNX SDP 8.

It requires patches to libc-0.2 and cc-rs. The cc-rs patch [was merged]([rust-lang/cc-rs#1775](https://github.com/rust-lang/cc-rs/issues/1775)) already. I have a patch for libc-1.0 [here](https://github.com/rust-lang/libc/issues/5241) which will need backporting to libc-0.2 once merged.

With these in place, I was able to remotely `test tests/ui library/std library/alloc library/core` for `x86_64-pc-qnx` using a remote-test-server running on QNX SDP 8.0's QEMU BSP image. The only tests that failed were the two `tests/ui/codegen/huge-stacks.rs` tests, and I did not have enough RAM to run them.

 