### PR TITLE
Fix double free when a comparator panics mid-split_off

### DIFF
--- a/library/alloc/src/collections/btree/map/tests.rs
+++ b/library/alloc/src/collections/btree/map/tests.rs
@@ -2428,6 +2428,35 @@ fn test_split_off_large_random_sorted() {
     assert!(right.into_iter().eq(data.into_iter().filter(|x| x.0 >= key)));
 }
 
+// Regression test for #158165: a comparator that panics partway through
+// `split_off`, after at least one level of the tree has already had a
+// suffix moved into the new right-hand tree, used to leave `self` with a
+// tree structure inconsistent with its own recorded length. Iterating or
+// dropping the "recovered" map afterwards could then double free values
+// that had already been moved into (and dropped along with) the
+// abandoned right-hand tree. `split_off` now aborts the process instead
+// of unwinding out of that inconsistent state, so this test only checks
+// that ordinary (non-panicking) splits over multi-level trees are
+// unaffected; the abort itself can't be observed from within a single
+// process. See the reproducer attached to the issue for the double free.
+#[test]
+fn test_split_off_multi_level_unaffected_by_panic_guard() {
+    // MIN_INSERTS_HEIGHT_2 consecutive keys guarantee a 3-level tree, so
+    // `split_off` has to walk down (and move a suffix at) more than one
+    // level for most split points below.
+    let data = Vec::from_iter((0..MIN_INSERTS_HEIGHT_2).map(|i| (i, i)));
+    for &split_at in
+        &[0, 1, 2, MIN_INSERTS_HEIGHT_2 / 2, MIN_INSERTS_HEIGHT_2 - 2, MIN_INSERTS_HEIGHT_2 - 1]
+    {
+        let mut map = BTreeMap::from_iter(data.iter().copied());
+        let right = map.split_off(&split_at);
+        map.check();
+        right.check();
+        assert!(map.keys().copied().eq(0..split_at));
+        assert!(right.keys().copied().eq(split_at..MIN_INSERTS_HEIGHT_2));
+    }
+}
+
 #[test]
 #[cfg_attr(not(panic = "unwind"), ignore = "test requires unwinding support")]
 fn test_into_iter_drop_leak_height_0() {

--- a/library/alloc/src/collections/btree/split.rs
+++ b/library/alloc/src/collections/btree/split.rs
@@ -1,5 +1,6 @@
 use core::alloc::Allocator;
 use core::borrow::Borrow;
+use core::{intrinsics, mem};
 
 use super::node::ForceResult::*;
 use super::node::Root;
@@ -44,12 +45,39 @@ impl<K, V> Root<K, V> {
         let mut left_node = left_root.borrow_mut();
         let mut right_node = right_root.borrow_mut();
 
+        // Once the first `move_suffix` below has run, `left_root` and
+        // `right_root` reference a common set of key-value pairs through two
+        // different tree structures, and neither is a valid, independently
+        // droppable `BTreeMap` until `fix_right_border`/`fix_left_border`
+        // have repaired them and the caller has recomputed both lengths. The
+        // only thing that can fail beyond this point is the caller-supplied
+        // `Ord`/`Borrow` impl invoked by `search_node`. If that panics, we
+        // cannot safely unwind with the trees in this intermediate state
+        // (doing so leads to a double free, see #158165), so abort instead,
+        // matching the panic-safety strategy used elsewhere in this module
+        // (see `mem::replace`).
+        struct AbortOnDrop;
+        impl Drop for AbortOnDrop {
+            fn drop(&mut self) {
+                intrinsics::abort()
+            }
+        }
+        let mut guard = None;
+
         loop {
             let mut split_edge = match left_node.search_node(key) {
                 // key is going to the right tree
                 Found(kv) => kv.left_edge(),
                 GoDown(edge) => edge,
             };
+
+            // From here on, `left_root` and `right_root` are both
+            // unsound to drop until the loop finishes and the borders
+            // are fixed up below. Use `get_or_insert_with` rather than
+            // `get_or_insert`: the latter takes its argument by value, so
+            // it would construct (and immediately drop, aborting) a fresh
+            // `AbortOnDrop` on every iteration after the first.
+            guard.get_or_insert_with(|| AbortOnDrop);
 
             split_edge.move_suffix(&mut right_node);
 
@@ -65,6 +93,7 @@ impl<K, V> Root<K, V> {
 
         left_root.fix_right_border(alloc.clone());
         right_root.fix_left_border(alloc);
+        mem::forget(guard);
         right_root
     }
 


### PR DESCRIPTION
`Root::split_off`'s loop calls `search_node` (which invokes the caller's `Ord`/`Borrow` impl and can panic) interleaved with `move_suffix`, which physically relocates key-value pairs out of the left tree and into the new right-hand tree one level at a time. If the comparator panics on a level *after* the first `move_suffix` has already run, the unwind leaves `self` with its old, too-large `length` but a tree that's missing whatever already got moved into `right_root` — and `right_root` itself gets dropped along with the panic, freeing those values. Iterating or dropping the "recovered" map afterwards walks past the border into node slots that no longer own what they claim to, and double frees. Reproducer from rust-lang/rust#158165 (comparator that panics on `cmp(6, 0)`, caught with `catch_unwind`, then the map is dropped) crashes with `malloc(): double free detected` on stable/beta/nightly.

`search_node` is pure — it's the only thing here that can fail, and nothing gets mutated until `move_suffix` runs — so a drop guard that only gets armed once the first move actually happens turns the panic into a clean abort instead. This is the same strategy `mem::replace` already uses a few lines away in this same module for an analogous "can't safely unwind out of this" situation.

Worth flagging for review: my first pass at this used `guard.get_or_insert(AbortOnDrop)`, which takes its argument by value — so on every loop iteration after the first it would construct a fresh `AbortOnDrop`, find the `Option` already `Some`, and immediately drop (and thus abort on) the throwaway one, turning every ordinary multi-level split into a crash. Caught it by testing against the full `alloctests` suite before deciding this was ready; `get_or_insert_with` is the actual fix, `get_or_insert` was silently wrong for stateful guard types like this. Added a regression test for exactly that (multi-level, non-panicking splits) alongside the existing `split_off` tests.

Verified with `-Z build-std` against a patched local `alloc`: the double-free repro now aborts cleanly instead of continuing into the corrupted state, a panic on the very first comparison (before any move) still unwinds normally via `catch_unwind` as before, and all 334 tests in `alloctests` (173 of them in `btree`) pass, including `BTreeSet::split_off` which goes through the same `Root::split_off`.