### PR TITLE
Temporarily disable `armhf-gnu`

### DIFF
--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -211,8 +211,12 @@ auto:
   - name: arm-android
     <<: *job-linux-4c
 
-  - name: armhf-gnu
-    <<: *job-linux-4c
+    # FIXME(#158716): `armhf-gnu` is temporarily disabled because the job
+    # directly uses kernel.org mirror artifacts but we didn't mirror them in
+    # our own ci-mirrors, and kernel.org mirror infra haven't fully recovered
+    # yet.
+  #- name: armhf-gnu
+  #  <<: *job-linux-4c
 
   - name: dist-aarch64-linux
     env:


### PR DESCRIPTION
## Summary

`armhf-gnu` directly uses kernel.org mirror artifacts, but the kernel mirror infra had an incident and full artifacts have not yet recovered.

The job exercises `arm-unknown-linux-gnueabihf` (Tier 2 with host tools, see <https://doc.rust-lang.org/rustc/platform-support.html#tier-2-with-host-tools>). We are only disabling the `armhf-gnu` test job, the `dist-armhf-linux` job is not affected (i.e. we are still building its artifacts).

## Context

See [#t-infra > kernel.org is borked](https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/kernel.2Eorg.20is.20borked/with/607989491).

Tracked by rust-lang/rust#158716