### PR TITLE
std: use `readdir` on nearly all UNIX platforms

### DIFF
--- a/library/std/src/sys/fs/unix.rs
+++ b/library/std/src/sys/fs/unix.rs
@@ -21,42 +21,6 @@ use libc::dirfd;
 use libc::fstatat as fstatat64;
 #[cfg(any(all(target_os = "linux", not(target_env = "musl")), target_os = "hurd"))]
 use libc::fstatat64;
-#[cfg(any(
-    target_os = "aix",
-    target_os = "android",
-    target_os = "freebsd",
-    target_os = "fuchsia",
-    target_os = "illumos",
-    target_os = "nto",
-    target_os = "qnx",
-    target_os = "redox",
-    target_os = "solaris",
-    target_os = "vita",
-    target_os = "wasi",
-    all(target_os = "linux", target_env = "musl"),
-))]
-use libc::readdir as readdir64;
-#[cfg(not(any(
-    target_os = "aix",
-    target_os = "android",
-    target_os = "freebsd",
-    target_os = "fuchsia",
-    target_os = "hurd",
-    target_os = "illumos",
-    target_os = "l4re",
-    target_os = "linux",
-    target_os = "nto",
-    target_os = "qnx",
-    target_os = "redox",
-    target_os = "solaris",
-    target_os = "vita",
-    target_os = "wasi",
-)))]
-use libc::readdir_r as readdir64_r;
-#[cfg(any(all(target_os = "linux", not(target_env = "musl")), target_os = "hurd"))]
-use libc::readdir64;
-#[cfg(target_os = "l4re")]
-use libc::readdir64_r;
 use libc::{c_int, mode_t};
 #[cfg(target_os = "android")]
 use libc::{
@@ -426,21 +390,6 @@ fn get_path_from_fd(fd: c_int) -> Option<PathBuf> {
     get_path(fd)
 }
 
-#[cfg(any(
-    target_os = "aix",
-    target_os = "android",
-    target_os = "freebsd",
-    target_os = "fuchsia",
-    target_os = "hurd",
-    target_os = "illumos",
-    target_os = "linux",
-    target_os = "nto",
-    target_os = "qnx",
-    target_os = "redox",
-    target_os = "solaris",
-    target_os = "vita",
-    target_os = "wasi",
-))]
 pub struct DirEntry {
     dir: Arc<InnerReadDir>,
     entry: dirent64_min,
@@ -453,53 +402,19 @@ pub struct DirEntry {
 // Define a minimal subset of fields we need from `dirent64`, especially since
 // we're not using the immediate `d_name` on these targets. Keeping this as an
 // `entry` field in `DirEntry` helps reduce the `cfg` boilerplate elsewhere.
-#[cfg(any(
-    target_os = "aix",
-    target_os = "android",
-    target_os = "freebsd",
-    target_os = "fuchsia",
-    target_os = "hurd",
-    target_os = "illumos",
-    target_os = "linux",
-    target_os = "nto",
-    target_os = "qnx",
-    target_os = "redox",
-    target_os = "solaris",
-    target_os = "vita",
-    target_os = "wasi",
-))]
 struct dirent64_min {
     d_ino: u64,
     #[cfg(not(any(
         target_os = "solaris",
         target_os = "illumos",
+        target_os = "haiku",
+        target_os = "vxworks",
         target_os = "aix",
         target_os = "nto",
         target_os = "qnx",
         target_os = "vita",
     )))]
     d_type: u8,
-}
-
-#[cfg(not(any(
-    target_os = "aix",
-    target_os = "android",
-    target_os = "freebsd",
-    target_os = "fuchsia",
-    target_os = "hurd",
-    target_os = "illumos",
-    target_os = "linux",
-    target_os = "nto",
-    target_os = "qnx",
-    target_os = "redox",
-    target_os = "solaris",
-    target_os = "vita",
-    target_os = "wasi",
-)))]
-pub struct DirEntry {
-    dir: Arc<InnerReadDir>,
-    // The full entry includes a fixed-length `d_name`.
-    entry: dirent64,
 }
 
 #[derive(Clone)]
@@ -880,48 +795,87 @@ impl fmt::Debug for ReadDir {
 impl Iterator for ReadDir {
     type Item = io::Result<DirEntry>;
 
-    #[cfg(any(
-        target_os = "aix",
-        target_os = "android",
-        target_os = "freebsd",
-        target_os = "fuchsia",
-        target_os = "hurd",
-        target_os = "illumos",
-        target_os = "linux",
-        target_os = "nto",
-        target_os = "qnx",
-        target_os = "redox",
-        target_os = "solaris",
-        target_os = "vita",
-        target_os = "wasi",
-    ))]
     fn next(&mut self) -> Option<io::Result<DirEntry>> {
-        use crate::sys::io::{errno, set_errno};
-
         if self.end_of_stream {
             return None;
         }
 
         unsafe {
             loop {
-                // As of POSIX.1-2017, readdir() is not required to be thread safe; only
-                // readdir_r() is. However, readdir_r() cannot correctly handle platforms
-                // with unlimited or variable NAME_MAX. Many modern platforms guarantee
-                // thread safety for readdir() as long an individual DIR* is not accessed
-                // concurrently, which is sufficient for Rust.
-                set_errno(0);
-                let entry_ptr: *const dirent64 = readdir64(self.inner.dirp.0);
-                if entry_ptr.is_null() {
-                    // We either encountered an error, or reached the end. Either way,
-                    // the next call to next() should return None.
-                    self.end_of_stream = true;
+                // POSIX.1-2024 formalized what was already guaranteed by a lot
+                // of implementations and required readdir() to be thread-safe as
+                // long as an individual DIR* is not accessed concurrently. Taking
+                // a mutable reference to the `ReadDir` iterator prevents that.
+                // Even POSIX.1-1994 specified that the data in the returned
+                // dirent
+                // > is not overwritten by another call to readdir() on a
+                // > different directory stream.
+                //
+                // and that guarantee together with the requirement that the
+                // underlying syscalls need to be thread-safe because of readdir_r
+                // make it very unlikely for an implementation to be non-conforming.
+                // Nevertheless, there are still some platforms where we either
+                // cannot confirm `readdir` to be thread-safe or know that it
+                // isn't.
+                cfg_select! {
+                    any(
+                        target_os = "espidf", // readdir truly isn't thread-safe.
+                        target_os = "lynxos178",
+                        target_os = "qurt",
+                        target_os = "rtems",
+                        target_os = "vxworks",
+                    ) => {
+                        use crate::mem::MaybeUninit;
 
-                    // To distinguish between errors and end-of-directory, we had to clear
-                    // errno beforehand to check for an error now.
-                    return match errno() {
-                        0 => None,
-                        e => Some(Err(Error::from_raw_os_error(e))),
-                    };
+                        let mut entry = MaybeUninit::uninit();
+                        let mut entry_ptr: *mut dirent64 = ptr::null_mut();
+                        let err = libc::readdir_r(self.inner.dirp.0, entry.as_mut_ptr(), &mut entry_ptr);
+                        if err != 0 {
+                            if entry_ptr.is_null() {
+                                // We encountered an error (which will be returned in this iteration), but
+                                // we also reached the end of the directory stream. The `end_of_stream`
+                                // flag is enabled to make sure that we return `None` in the next iteration
+                                // (instead of looping forever)
+                                self.end_of_stream = true;
+                            }
+                            return Some(Err(Error::from_raw_os_error(err)));
+                        }
+                        if entry_ptr.is_null() {
+                            return None;
+                        }
+
+                        let entry_ptr = entry_ptr.cast_const();
+                    }
+                    _ => {
+                        #[cfg(not(any(
+                            all(target_os = "linux", not(target_env = "musl")),
+                            target_os = "hurd",
+                            target_os = "l4re",
+                        )))]
+                        use libc::readdir as readdir64;
+                        #[cfg(any(
+                            all(target_os = "linux", not(target_env = "musl")),
+                            target_os = "hurd",
+                            target_os = "l4re"
+                        ))]
+                        use libc::readdir64;
+                        use crate::sys::io::{errno, set_errno};
+
+                        set_errno(0);
+                        let entry_ptr: *const dirent64 = readdir64(self.inner.dirp.0);
+                        if entry_ptr.is_null() {
+                            // We either encountered an error, or reached the end. Either way,
+                            // the next call to next() should return None.
+                            self.end_of_stream = true;
+
+                            // To distinguish between errors and end-of-directory, we had to clear
+                            // errno beforehand to check for an error now.
+                            return match errno() {
+                                0 => None,
+                                e => Some(Err(Error::from_raw_os_error(e))),
+                            };
+                        }
+                    }
                 }
 
                 // The dirent64 struct is a weird imaginary thing that isn't ever supposed
@@ -952,75 +906,43 @@ impl Iterator for ReadDir {
                 // When loading from a field, we can skip the `&raw const`; `(*entry_ptr).d_ino` as
                 // a value expression will do the right thing: `byte_offset` to the field and then
                 // only access those bytes.
-                #[cfg(not(target_os = "vita"))]
                 let entry = dirent64_min {
-                    #[cfg(target_os = "freebsd")]
+                    #[cfg(any(
+                        target_os = "dragonfly",
+                        target_os = "freebsd",
+                        target_os = "netbsd",
+                        target_os = "openbsd",
+                    ))]
                     d_ino: (*entry_ptr).d_fileno,
-                    #[cfg(not(target_os = "freebsd"))]
+                    #[cfg(any(target_os = "nuttx", target_os = "vita",))]
+                    d_ino: 0,
+                    #[cfg(not(any(
+                        target_os = "dragonfly",
+                        target_os = "freebsd",
+                        target_os = "netbsd",
+                        target_os = "nuttx",
+                        target_os = "openbsd",
+                        target_os = "vita",
+                    )))]
                     d_ino: (*entry_ptr).d_ino as u64,
                     #[cfg(not(any(
                         target_os = "solaris",
                         target_os = "illumos",
+                        target_os = "haiku",
+                        target_os = "vxworks",
                         target_os = "aix",
                         target_os = "nto",
                         target_os = "qnx",
+                        target_os = "vita",
                     )))]
                     d_type: (*entry_ptr).d_type as u8,
                 };
-
-                #[cfg(target_os = "vita")]
-                let entry = dirent64_min { d_ino: 0u64 };
 
                 return Some(Ok(DirEntry {
                     entry,
                     name: name.to_owned(),
                     dir: Arc::clone(&self.inner),
                 }));
-            }
-        }
-    }
-
-    #[cfg(not(any(
-        target_os = "aix",
-        target_os = "android",
-        target_os = "freebsd",
-        target_os = "fuchsia",
-        target_os = "hurd",
-        target_os = "illumos",
-        target_os = "linux",
-        target_os = "nto",
-        target_os = "qnx",
-        target_os = "redox",
-        target_os = "solaris",
-        target_os = "vita",
-        target_os = "wasi",
-    )))]
-    fn next(&mut self) -> Option<io::Result<DirEntry>> {
-        if self.end_of_stream {
-            return None;
-        }
-
-        unsafe {
-            let mut ret = DirEntry { entry: mem::zeroed(), dir: Arc::clone(&self.inner) };
-            let mut entry_ptr = ptr::null_mut();
-            loop {
-                let err = readdir64_r(self.inner.dirp.0, &mut ret.entry, &mut entry_ptr);
-                if err != 0 {
-                    if entry_ptr.is_null() {
-                        // We encountered an error (which will be returned in this iteration), but
-                        // we also reached the end of the directory stream. The `end_of_stream`
-                        // flag is enabled to make sure that we return `None` in the next iteration
-                        // (instead of looping forever)
-                        self.end_of_stream = true;
-                    }
-                    return Some(Err(Error::from_raw_os_error(err)));
-                }
-                if entry_ptr.is_null() {
-                    return None;
-                }
-                if ret.name_bytes() != b"." && ret.name_bytes() != b".." {
-                    return Some(Ok(ret));
-                }
             }
         }
     }
@@ -1102,7 +1024,7 @@ impl DirEntry {
     ))]
     pub fn metadata(&self) -> io::Result<FileAttr> {
         let fd = cvt(unsafe { dirfd(self.dir.dirp.0) })?;
-        let name = self.name_cstr().as_ptr();
+        let name = self.name.as_ptr();
 
         cfg_has_statx! {
             if let Some(ret) = unsafe { try_statx(
@@ -1172,110 +1094,12 @@ impl DirEntry {
         }
     }
 
-    #[cfg(any(
-        target_os = "aix",
-        target_os = "android",
-        target_os = "cygwin",
-        target_os = "emscripten",
-        target_os = "espidf",
-        target_os = "freebsd",
-        target_os = "fuchsia",
-        target_os = "haiku",
-        target_os = "horizon",
-        target_os = "hurd",
-        target_os = "illumos",
-        target_os = "l4re",
-        target_os = "linux",
-        target_os = "nto",
-        target_os = "qnx",
-        target_os = "redox",
-        target_os = "rtems",
-        target_os = "solaris",
-        target_os = "vita",
-        target_os = "vxworks",
-        target_os = "wasi",
-        target_vendor = "apple",
-    ))]
     pub fn ino(&self) -> u64 {
-        self.entry.d_ino as u64
-    }
-
-    #[cfg(any(target_os = "openbsd", target_os = "netbsd", target_os = "dragonfly"))]
-    pub fn ino(&self) -> u64 {
-        self.entry.d_fileno as u64
-    }
-
-    #[cfg(target_os = "nuttx")]
-    pub fn ino(&self) -> u64 {
-        // Leave this 0 for now, as NuttX does not provide an inode number
-        // in its directory entries.
-        0
-    }
-
-    #[cfg(any(
-        target_os = "netbsd",
-        target_os = "openbsd",
-        target_os = "dragonfly",
-        target_vendor = "apple",
-    ))]
-    fn name_bytes(&self) -> &[u8] {
-        use crate::slice;
-        unsafe {
-            slice::from_raw_parts(
-                self.entry.d_name.as_ptr() as *const u8,
-                self.entry.d_namlen as usize,
-            )
-        }
-    }
-    #[cfg(not(any(
-        target_os = "netbsd",
-        target_os = "openbsd",
-        target_os = "dragonfly",
-        target_vendor = "apple",
-    )))]
-    fn name_bytes(&self) -> &[u8] {
-        self.name_cstr().to_bytes()
-    }
-
-    #[cfg(not(any(
-        target_os = "android",
-        target_os = "freebsd",
-        target_os = "linux",
-        target_os = "solaris",
-        target_os = "illumos",
-        target_os = "fuchsia",
-        target_os = "redox",
-        target_os = "aix",
-        target_os = "nto",
-        target_os = "qnx",
-        target_os = "vita",
-        target_os = "hurd",
-        target_os = "wasi",
-    )))]
-    fn name_cstr(&self) -> &CStr {
-        unsafe { CStr::from_ptr(self.entry.d_name.as_ptr()) }
-    }
-    #[cfg(any(
-        target_os = "android",
-        target_os = "freebsd",
-        target_os = "linux",
-        target_os = "solaris",
-        target_os = "illumos",
-        target_os = "fuchsia",
-        target_os = "redox",
-        target_os = "aix",
-        target_os = "nto",
-        target_os = "qnx",
-        target_os = "vita",
-        target_os = "hurd",
-        target_os = "wasi",
-    ))]
-    fn name_cstr(&self) -> &CStr {
-        &self.name
+        self.entry.d_ino
     }
 
     pub fn file_name_os_str(&self) -> &OsStr {
-        OsStr::from_bytes(self.name_bytes())
+        OsStr::from_bytes(self.name.as_bytes())
     }
 }
 
@@ -2611,24 +2435,23 @@ mod remove_dir_impl {
 
         for child in dir {
             let child = child?;
-            let child_name = child.name_cstr();
             // we need an inner try block, because if one of these
             // directories has already been deleted, then we need to
             // continue the loop, not return ok.
             let result: io::Result<()> = try {
                 match is_dir(&child) {
                     Some(true) => {
-                        remove_dir_all_recursive(Some(fd), child_name)?;
+                        remove_dir_all_recursive(Some(fd), &child.name)?;
                     }
                     Some(false) => {
-                        cvt(unsafe { unlinkat(fd, child_name.as_ptr(), 0) })?;
+                        cvt(unsafe { unlinkat(fd, child.name.as_ptr(), 0) })?;
                     }
                     None => {
                         // POSIX specifies that calling unlink()/unlinkat(..., 0) on a directory can succeed
                         // if the process has the appropriate privileges. This however can causing orphaned
                         // directories requiring an fsck e.g. on Solaris and Illumos. So we try recursing
                         // into it first instead of trying to unlink() it.
-                        remove_dir_all_recursive(Some(fd), child_name)?;
+                        remove_dir_all_recursive(Some(fd), &child.name)?;
                     }
                 }
             };

--- a/library/std/src/sys/io/error/unix.rs
+++ b/library/std/src/sys/io/error/unix.rs
@@ -60,11 +60,13 @@ pub fn errno() -> i32 {
 // needed for readdir and syscall!
 #[cfg(not(any(
     target_os = "dragonfly",
-    target_os = "vxworks",
+    target_os = "espidf",
+    target_os = "lynxos178",
+    target_os = "qurt",
     target_os = "rtems",
+    target_os = "vxworks",
     target_os = "wasi",
 )))]
-#[allow(dead_code)] // but not all target cfgs actually end up using it
 #[inline]
 pub fn set_errno(e: i32) {
     unsafe { *errno_location() = e as c_int }
@@ -92,14 +94,13 @@ pub fn errno() -> i32 {
 pub fn errno() -> i32 {
     unsafe extern "C" {
         #[thread_local]
-        static errno: c_int;
+        static mut errno: c_int;
     }
 
     unsafe { errno as i32 }
 }
 
 #[cfg(target_os = "dragonfly")]
-#[allow(dead_code)]
 #[inline]
 pub fn set_errno(e: i32) {
     unsafe extern "C" {
@@ -107,9 +108,7 @@ pub fn set_errno(e: i32) {
         static mut errno: c_int;
     }
 
-    unsafe {
-        errno = e;
-    }
+    unsafe { errno = e };
 }
 
 #[cfg(target_os = "wasi")]

--- a/library/std/src/sys/io/mod.rs
+++ b/library/std/src/sys/io/mod.rs
@@ -37,9 +37,17 @@ pub use alloc_crate::io::DEFAULT_BUF_SIZE;
     not(any(target_os = "dragonfly", target_os = "vxworks", target_os = "rtems"))
 ))]
 pub use error::errno_location;
-#[cfg_attr(not(target_os = "linux"), allow(unused_imports))]
 #[cfg(any(
-    all(target_family = "unix", not(any(target_os = "vxworks", target_os = "rtems"))),
+    all(
+        target_family = "unix",
+        not(any(
+            target_os = "espidf",
+            target_os = "lynxos178",
+            target_os = "qurt",
+            target_os = "rtems",
+            target_os = "vxworks",
+        ))
+    ),
     target_os = "wasi",
 ))]
 pub use error::set_errno;

--- a/src/tools/miri/src/shims/unix/fs.rs
+++ b/src/tools/miri/src/shims/unix/fs.rs
@@ -1117,9 +1117,9 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
         if !matches!(
             &this.tcx.sess.target.os,
-            Os::Linux | Os::Android | Os::Solaris | Os::Illumos | Os::FreeBsd
+            Os::Linux | Os::Android | Os::Solaris | Os::Illumos | Os::FreeBsd | Os::MacOs
         ) {
-            panic!("`readdir` should not be called on {}", this.tcx.sess.target.os);
+            throw_unsup_format!("`readdir` is not yet supported on {}", this.tcx.sess.target.os);
         }
 
         let dirp = this.read_target_usize(dirp_op)?;
@@ -1170,6 +1170,16 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 //     pub d_namlen: uint8_t,
                 //     pub d_name: [c_char; 256],
                 // }
+                //
+                // On macOS:
+                // pub struct dirent {
+                //     pub d_ino: u64,
+                //     pub d_seekoff: u64,
+                //     pub d_reclen: u16,
+                //     pub d_namlen: u16,
+                //     pub d_type: u8,
+                //     pub d_name: [c_char; 1024],
+                // }
 
                 // We just use the pointee type here since determining the right pointee type
                 // independently is highly non-trivial: it depends on which exact alias of the
@@ -1212,6 +1222,9 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // Write "optional" fields.
                 if let Some(d_off) = this.try_project_field_named(&entry, "d_off")? {
                     this.write_null(&d_off)?;
+                }
+                if let Some(d_seekoff) = this.try_project_field_named(&entry, "d_seekoff")? {
+                    this.write_null(&d_seekoff)?;
                 }
                 if let Some(d_namlen) = this.try_project_field_named(&entry, "d_namlen")? {
                     this.write_int(name_len.strict_sub(1), &d_namlen)?;

--- a/src/tools/miri/src/shims/unix/macos/foreign_items.rs
+++ b/src/tools/miri/src/shims/unix/macos/foreign_items.rs
@@ -67,6 +67,10 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 let result = this.opendir(name)?;
                 this.write_scalar(result, dest)?;
             }
+            "readdir$INODE64" => {
+                let [dirp] = this.check_shim_sig_lenient(abi, CanonAbi::C, link_name, args)?;
+                this.readdir(dirp, dest)?;
+            }
             "readdir_r" | "readdir_r$INODE64" => {
                 let [dirp, entry, result] =
                     this.check_shim_sig_lenient(abi, CanonAbi::C, link_name, args)?;

--- a/src/tools/miri/tests/pass-dep/libc/libc-fs.rs
+++ b/src/tools/miri/tests/pass-dep/libc/libc-fs.rs
@@ -60,6 +60,8 @@ fn main() {
     test_ioctl();
     test_opendir_closedir();
     test_readdir();
+    #[cfg(target_os = "macos")]
+    test_readdir_r();
     #[cfg(target_os = "linux")]
     test_statx_on_file_path();
     #[cfg(target_os = "linux")]
@@ -1002,22 +1004,51 @@ fn test_readdir() {
         assert!(!dirp.is_null());
         let mut entries = Vec::new();
         loop {
-            cfg_select! {
-                target_os = "macos" => {
-                    // On macos we only support readdir_r as that's what std uses there.
-                    use std::mem::MaybeUninit;
-
-                    use libc::dirent;
-                    let mut entry: MaybeUninit<dirent> = MaybeUninit::uninit();
-                    let mut result: *mut dirent = std::ptr::null_mut();
-                    let ret = libc::readdir_r(dirp, entry.as_mut_ptr(), &mut result);
-                    assert_eq!(ret, 0);
-                    let entry_ptr = result;
-                }
-                _ => {
-                    let entry_ptr = libc::readdir(dirp);
-                }
+            let entry_ptr = libc::readdir(dirp);
+            if entry_ptr.is_null() {
+                break;
             }
+            let name_ptr = std::ptr::addr_of!((*entry_ptr).d_name) as *const libc::c_char;
+            let name = CStr::from_ptr(name_ptr);
+            let name_str = name.to_string_lossy();
+            entries.push(name_str.into_owned());
+        }
+        assert_eq!(libc::closedir(dirp), 0);
+        entries.sort();
+        assert_eq!(&entries, &[".", "..", "file1.txt", "file2.txt"]);
+    }
+
+    remove_file(&file1).unwrap();
+    remove_file(&file2).unwrap();
+    remove_dir(&dir_path).unwrap();
+}
+
+#[cfg(target_os = "macos")]
+fn test_readdir_r() {
+    use std::fs::{create_dir, remove_dir, write};
+    use std::mem::MaybeUninit;
+
+    let dir_path = utils::prepare_dir("miri_test_libc_readdir_r");
+    create_dir(&dir_path).ok();
+
+    // Create test files
+    let file1 = dir_path.join("file1.txt");
+    let file2 = dir_path.join("file2.txt");
+    write(&file1, b"content1").unwrap();
+    write(&file2, b"content2").unwrap();
+
+    let c_path = CString::new(dir_path.as_os_str().as_bytes()).unwrap();
+
+    unsafe {
+        let dirp = libc::opendir(c_path.as_ptr());
+        assert!(!dirp.is_null());
+        let mut entries = Vec::new();
+        loop {
+            let mut entry: MaybeUninit<libc::dirent> = MaybeUninit::uninit();
+            let mut result: *mut libc::dirent = std::ptr::null_mut();
+            let ret = libc::readdir_r(dirp, entry.as_mut_ptr(), &mut result);
+            assert_eq!(ret, 0);
+            let entry_ptr = result;
             if entry_ptr.is_null() {
                 break;
             }

--- a/src/tools/miri/tests/pass-dep/libc/libc-fs.rs
+++ b/src/tools/miri/tests/pass-dep/libc/libc-fs.rs
@@ -1023,6 +1023,8 @@ fn test_readdir() {
     remove_dir(&dir_path).unwrap();
 }
 
+// We only support `readdir_r` on macOS.
+// (It is deprecated so we don't want to add more support.)
 #[cfg(target_os = "macos")]
 fn test_readdir_r() {
     use std::fs::{create_dir, remove_dir, write};


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/158727)*
<!-- homu-ignore:end -->

POSIX.1-2024 [formalised](https://pubs.opengroup.org/onlinepubs/9799919799/functions/readdir.html) what was already guaranteed by a lot of implementations and required `readdir` to be thread-safe as long as an individual `DIR*` is not accessed concurrently (which `ReadDir::next` ensures by taking a mutable reference). But since our `read_dir` implementation predates that standard, we currently only utilise `readdir` on the platforms that guarantee thread-safety in their documentation. On other implementations – notably macOS – we use the `readdir_r` function, which was always required to be thread-safe but is problematic because it cannot handle directory entries with names longer than `NAME_MAX`.

However, even the first POSIX issue, POSIX.1-1994, specified that the data in the returned `dirent`
> is not overwritten by another call to readdir() on a different directory stream.

and that guarantee together with the requirement that the underlying syscalls need to be thread-safe already because of `readdir_r` result in `readdir` being thread-safe on nearly all implementations, even if they predate POSIX.1-2024. Given the now formalised guarantee I think it safe to assume that currently thread-safe implementations will not be changed in a way that violates thread-safety.

CC T-libs, do you agree?
@rustbot label +I-libs-nominated

I thus looked at the `readdir` implementation of all the UNIXes currently utilising `readdir_r` to check for thread-safety:
- [x] [Apple platforms](https://github.com/apple-oss-distributions/Libc/blob/8a5571058ea8cf099279d8df1602958327b1d400/gen.subproj/readdir.c), starting with Mac OS X 10.0. While the original implementation did not use any synchronisation, it only modifies data of the `DIR*` it acts on.
- [x] [Cygwin](https://github.com/cygwin/cygwin/blob/854594be786023d7e92c9352d8f54e64f9fb36eb/winsup/cygwin/dir.cc): same thing.
- [x] [Dragonfly](https://github.com/DragonFlyBSD/DragonFlyBSD/blob/2e3a87ce41bfdf759c1936e31cd8cb7be0a9c1cc/lib/libc/gen/readdir.c) uses locks.
- [x] [L4Re](https://github.com/kernkonzept/l4re-core/blob/b6f7495bb8b010c6d0f2d44a25c61885a6ac7ac1/libc/musl/contrib/musl/src/dirent/readdir.c): only modifies the passed `DIR*`.
- [ ] LynxOS: closed-source, the [documentation](https://www-f9.ijs.si/~rok/detectors/doc/LynxOS-2.5.0/LynxOS_Documentation.html) says that `readdir` is not reentrant. CC @rfatykhov-lynx
- [x] [Managarm](https://github.com/managarm/mlibc/blob/368a00fa3ab482a76fbc2fb04afc188c6ff2407b/options/posix/generic/dirent.cpp): only modifies the passed `DIR*`.
- [x] [NetBSD](https://github.com/NetBSD/src/blob/3604f3d8178e005847b7c7a1c4e4fa20838cecb8/lib/libc/gen/readdir.c): either uses locks depending on configuration, or only modifies the passed `DIR* `.
- [x] [OpenBSD](https://github.com/openbsd/src/blob/394336142320c7c38e2361c4293df4c86626668e/lib/libc/gen/readdir.c): uses locks.
- [x] [Unikraft](https://github.com/unikraft/unikraft/blob/be744898b6947824e367e01765703401e08ce3c5/lib/nolibc/musl-imported/src/dirent/readdir.c)
- [ ] VxWorks: closed-source, the [documentation](https://archive.org/details/manualzilla-id-5786163) does not make any reference to thread-safety. CC @biabbas @hax0kartik
- [x] QNX: the [documentation](https://www.qnx.com/developers/docs/8.0/com.qnx.doc.neutrino.lib_ref/topic/r/readdir.html) gives the same guarantee as POSIX.1-2024.
- [x] [NuttX](https://github.com/apache/nuttx/blob/9a4114a9d3e06e47cab2c15e00b2b29c17c10b10/libs/libc/dirent/lib_readdir.c):  only modifies the passed `DIR*`.
- [x] 3DS: the underlying [directory read implementation in libctru](https://github.com/devkitPro/libctru/blob/36fe1ada5b7ebe53ba4decda36d764a55f8fefb6/libctru/source/services/fs.c#L1835-L1850) is thread-safe
- [ ] RTEMS: I'm unable to find the implementation. CC @thesummer
- [ ] QuRT: CC @androm3da
- [ ] ESP-IDF: `readdir` is *not* thread-safe (at least on FAT) due to [caching file metadata in the VFS context without locks](https://github.com/espressif/esp-idf/blob/fa8039b5cadb6e85dd830ff8c2c4bd73b6538aee/components/fatfs/vfs/vfs_fat.c#L976). [`opendir`](https://github.com/espressif/esp-idf/blob/fa8039b5cadb6e85dd830ff8c2c4bd73b6538aee/components/fatfs/vfs/vfs_fat.c#L924) does the same thing, too?! And the cache is never invalidated, even when the file is deleted?! Honestly, this is just broken... CC @ivmarkov @MabezDev @SergioGasquez
- [x] [Emscripten](https://github.com/emscripten-core/emscripten/blob/f351c42755ad56323f0bb3b2195ca50e35650496/system/lib/libc/musl/src/dirent/readdir.c): derived from musl, only modifies the current `DIR*`.

On the implementations where I couldn't confirm thread-safety `ReadDir` will still use `readdir_r`, but I've changed the code so that this edge-case is limited to `ReadDir::next`. All other platforms now use `readdir`.