### PR TITLE
Replace `static mut` with `SyncUnsafeCell` in std

### DIFF
--- a/library/std/src/sync/mod.rs
+++ b/library/std/src/sync/mod.rs
@@ -9,21 +9,22 @@
 //! Consider the following code, operating on some global static variables:
 //!
 //! ```rust
-//! // FIXME(static_mut_refs): Do not allow `static_mut_refs` lint
-//! #![allow(static_mut_refs)]
+//! #![feature(sync_unsafe_cell)]
 //!
-//! static mut A: u32 = 0;
-//! static mut B: u32 = 0;
-//! static mut C: u32 = 0;
+//! use std::cell::SyncUnsafeCell;
+//!
+//! static A: SyncUnsafeCell<u32> = SyncUnsafeCell::new(0);
+//! static B: SyncUnsafeCell<u32> = SyncUnsafeCell::new(0);
+//! static C: SyncUnsafeCell<u32> = SyncUnsafeCell::new(0);
 //!
 //! fn main() {
 //!     unsafe {
-//!         A = 3;
-//!         B = 4;
-//!         A = A + B;
-//!         C = B;
-//!         println!("{A} {B} {C}");
-//!         C = A;
+//!         *A.get() = 3;
+//!         *B.get() = 4;
+//!         *A.get() = *A.get() + *B.get();
+//!         *C.get() = *B.get();
+//!         println!("{} {} {}", *A.get(), *B.get(), *C.get());
+//!         *C.get() = *A.get();
 //!     }
 //! }
 //! ```

--- a/library/std/src/sys/alloc/vexos.rs
+++ b/library/std/src/sys/alloc/vexos.rs
@@ -1,5 +1,4 @@
-// FIXME(static_mut_refs): Do not allow `static_mut_refs` lint
-#![allow(static_mut_refs)]
+use core::cell::SyncUnsafeCell;
 
 use crate::alloc::{GlobalAlloc, Layout, System};
 use crate::ptr;
@@ -11,7 +10,11 @@ unsafe extern "C" {
     static mut __heap_end: u8;
 }
 
-static mut DLMALLOC: dlmalloc::Dlmalloc<Vexos> = dlmalloc::Dlmalloc::new_with_allocator(Vexos);
+struct SyncDlmalloc(dlmalloc::Dlmalloc<Vexos>);
+unsafe impl Sync for SyncDlmalloc {}
+
+static DLMALLOC: SyncUnsafeCell<SyncDlmalloc> =
+    SyncUnsafeCell::new(SyncDlmalloc(dlmalloc::Dlmalloc::new_with_allocator(Vexos)));
 
 struct Vexos;
 
@@ -67,7 +70,7 @@ unsafe impl GlobalAlloc for System {
         // SAFETY: DLMALLOC access is guaranteed to be safe because we are a single-threaded target, which
         // guarantees unique and non-reentrant access to the allocator. As such, no allocator lock is used.
         // Calling malloc() is safe because preconditions on this function match the trait method preconditions.
-        unsafe { DLMALLOC.malloc(layout.size(), layout.align()) }
+        unsafe { (*DLMALLOC.get()).0.malloc(layout.size(), layout.align()) }
     }
 
     #[inline]
@@ -75,7 +78,7 @@ unsafe impl GlobalAlloc for System {
         // SAFETY: DLMALLOC access is guaranteed to be safe because we are a single-threaded target, which
         // guarantees unique and non-reentrant access to the allocator. As such, no allocator lock is used.
         // Calling calloc() is safe because preconditions on this function match the trait method preconditions.
-        unsafe { DLMALLOC.calloc(layout.size(), layout.align()) }
+        unsafe { (*DLMALLOC.get()).0.calloc(layout.size(), layout.align()) }
     }
 
     #[inline]
@@ -83,7 +86,7 @@ unsafe impl GlobalAlloc for System {
         // SAFETY: DLMALLOC access is guaranteed to be safe because we are a single-threaded target, which
         // guarantees unique and non-reentrant access to the allocator. As such, no allocator lock is used.
         // Calling free() is safe because preconditions on this function match the trait method preconditions.
-        unsafe { DLMALLOC.free(ptr, layout.size(), layout.align()) }
+        unsafe { (*DLMALLOC.get()).0.free(ptr, layout.size(), layout.align()) }
     }
 
     #[inline]
@@ -91,6 +94,6 @@ unsafe impl GlobalAlloc for System {
         // SAFETY: DLMALLOC access is guaranteed to be safe because we are a single-threaded target, which
         // guarantees unique and non-reentrant access to the allocator. As such, no allocator lock is used.
         // Calling realloc() is safe because preconditions on this function match the trait method preconditions.
-        unsafe { DLMALLOC.realloc(ptr, layout.size(), layout.align(), new_size) }
+        unsafe { (*DLMALLOC.get()).0.realloc(ptr, layout.size(), layout.align(), new_size) }
     }
 }

--- a/library/std/src/sys/alloc/xous.rs
+++ b/library/std/src/sys/alloc/xous.rs
@@ -1,16 +1,19 @@
-// FIXME(static_mut_refs): Do not allow `static_mut_refs` lint
-#![allow(static_mut_refs)]
+use core::cell::SyncUnsafeCell;
 
 use crate::alloc::{GlobalAlloc, Layout, System};
 
+struct SyncDlmalloc(dlmalloc::Dlmalloc);
+unsafe impl Sync for SyncDlmalloc {}
+
 #[cfg(not(test))]
 #[unsafe(export_name = "_ZN16__rust_internals3std3sys4xous5alloc8DLMALLOCE")]
-static mut DLMALLOC: dlmalloc::Dlmalloc = dlmalloc::Dlmalloc::new();
+static DLMALLOC: SyncUnsafeCell<SyncDlmalloc> =
+    SyncUnsafeCell::new(SyncDlmalloc(dlmalloc::Dlmalloc::new()));
 
 #[cfg(test)]
 unsafe extern "Rust" {
     #[link_name = "_ZN16__rust_internals3std3sys4xous5alloc8DLMALLOCE"]
-    static mut DLMALLOC: dlmalloc::Dlmalloc;
+    static DLMALLOC: SyncUnsafeCell<SyncDlmalloc>;
 }
 
 #[stable(feature = "alloc_system_type", since = "1.28.0")]
@@ -20,7 +23,7 @@ unsafe impl GlobalAlloc for System {
         // SAFETY: DLMALLOC access is guaranteed to be safe because the lock gives us unique and non-reentrant access.
         // Calling malloc() is safe because preconditions on this function match the trait method preconditions.
         let _lock = lock::lock();
-        unsafe { DLMALLOC.malloc(layout.size(), layout.align()) }
+        unsafe { (*DLMALLOC.get()).0.malloc(layout.size(), layout.align()) }
     }
 
     #[inline]
@@ -28,7 +31,7 @@ unsafe impl GlobalAlloc for System {
         // SAFETY: DLMALLOC access is guaranteed to be safe because the lock gives us unique and non-reentrant access.
         // Calling calloc() is safe because preconditions on this function match the trait method preconditions.
         let _lock = lock::lock();
-        unsafe { DLMALLOC.calloc(layout.size(), layout.align()) }
+        unsafe { (*DLMALLOC.get()).0.calloc(layout.size(), layout.align()) }
     }
 
     #[inline]
@@ -36,7 +39,7 @@ unsafe impl GlobalAlloc for System {
         // SAFETY: DLMALLOC access is guaranteed to be safe because the lock gives us unique and non-reentrant access.
         // Calling free() is safe because preconditions on this function match the trait method preconditions.
         let _lock = lock::lock();
-        unsafe { DLMALLOC.free(ptr, layout.size(), layout.align()) }
+        unsafe { (*DLMALLOC.get()).0.free(ptr, layout.size(), layout.align()) }
     }
 
     #[inline]
@@ -44,7 +47,7 @@ unsafe impl GlobalAlloc for System {
         // SAFETY: DLMALLOC access is guaranteed to be safe because the lock gives us unique and non-reentrant access.
         // Calling realloc() is safe because preconditions on this function match the trait method preconditions.
         let _lock = lock::lock();
-        unsafe { DLMALLOC.realloc(ptr, layout.size(), layout.align(), new_size) }
+        unsafe { (*DLMALLOC.get()).0.realloc(ptr, layout.size(), layout.align(), new_size) }
     }
 }
 


### PR DESCRIPTION
Updates rust-lang/rust#125035

The `static_mut_refs` lint now deny against creating references to `static mut`, so migrate the remaining internal uses to `SyncUnsafeCell`, which provides interior mutability without the aliasing hazards.
