### PR TITLE
Update `FIXME(static_mut_refs)` comments

### DIFF
--- a/library/std/src/sync/mod.rs
+++ b/library/std/src/sync/mod.rs
@@ -9,7 +9,7 @@
 //! Consider the following code, operating on some global static variables:
 //!
 //! ```rust
-//! // FIXME(static_mut_refs): Do not allow `static_mut_refs` lint
+//! // FIXME(static_mut_refs): use raw pointers instead of references
 //! #![allow(static_mut_refs)]
 //!
 //! static mut A: u32 = 0;

--- a/library/std/src/sys/alloc/vexos.rs
+++ b/library/std/src/sys/alloc/vexos.rs
@@ -1,4 +1,4 @@
-// FIXME(static_mut_refs): Do not allow `static_mut_refs` lint
+// FIXME(static_mut_refs): use raw pointers instead of references
 #![allow(static_mut_refs)]
 
 use crate::alloc::{GlobalAlloc, Layout, System};

--- a/library/std/src/sys/alloc/xous.rs
+++ b/library/std/src/sys/alloc/xous.rs
@@ -1,4 +1,4 @@
-// FIXME(static_mut_refs): Do not allow `static_mut_refs` lint
+// FIXME(static_mut_refs): use raw pointers instead of references
 #![allow(static_mut_refs)]
 
 use crate::alloc::{GlobalAlloc, Layout, System};

--- a/library/std/tests/thread_local/tests.rs
+++ b/library/std/tests/thread_local/tests.rs
@@ -110,7 +110,7 @@ fn smoke_dtor() {
 
 #[test]
 fn circular() {
-    // FIXME(static_mut_refs): Do not allow `static_mut_refs` lint
+    // FIXME(static_mut_refs): use raw pointers instead of references
     #![allow(static_mut_refs)]
 
     struct S1(&'static LocalKey<UnsafeCell<Option<S1>>>, &'static LocalKey<UnsafeCell<Option<S2>>>);

--- a/src/tools/clippy/tests/ui/redundant_static_lifetimes.fixed
+++ b/src/tools/clippy/tests/ui/redundant_static_lifetimes.fixed
@@ -1,5 +1,5 @@
 #![allow(unused)]
-// FIXME(static_mut_refs): Do not allow `static_mut_refs` lint
+// FIXME(static_mut_refs): use raw pointers instead of references
 #![allow(static_mut_refs)]
 
 #[derive(Debug)]

--- a/src/tools/clippy/tests/ui/redundant_static_lifetimes.rs
+++ b/src/tools/clippy/tests/ui/redundant_static_lifetimes.rs
@@ -1,5 +1,5 @@
 #![allow(unused)]
-// FIXME(static_mut_refs): Do not allow `static_mut_refs` lint
+// FIXME(static_mut_refs): use raw pointers instead of references
 #![allow(static_mut_refs)]
 
 #[derive(Debug)]

--- a/src/tools/clippy/tests/ui/useless_conversion.fixed
+++ b/src/tools/clippy/tests/ui/useless_conversion.fixed
@@ -1,7 +1,7 @@
 #![deny(clippy::useless_conversion)]
 #![allow(clippy::into_iter_on_ref)]
 #![allow(clippy::needless_ifs, clippy::unnecessary_wraps, unused)]
-// FIXME(static_mut_refs): Do not allow `static_mut_refs` lint
+// FIXME(static_mut_refs): use raw pointers instead of references
 #![allow(static_mut_refs)]
 
 use std::ops::ControlFlow;

--- a/src/tools/clippy/tests/ui/useless_conversion.rs
+++ b/src/tools/clippy/tests/ui/useless_conversion.rs
@@ -1,7 +1,7 @@
 #![deny(clippy::useless_conversion)]
 #![allow(clippy::into_iter_on_ref)]
 #![allow(clippy::needless_ifs, clippy::unnecessary_wraps, unused)]
-// FIXME(static_mut_refs): Do not allow `static_mut_refs` lint
+// FIXME(static_mut_refs): use raw pointers instead of references
 #![allow(static_mut_refs)]
 
 use std::ops::ControlFlow;

--- a/src/tools/miri/tests/pass-dep/concurrency/linux-futex.rs
+++ b/src/tools/miri/tests/pass-dep/concurrency/linux-futex.rs
@@ -1,7 +1,7 @@
 //@only-target: linux android
 //@compile-flags: -Zmiri-disable-isolation
 
-// FIXME(static_mut_refs): Do not allow `static_mut_refs` lint
+// FIXME(static_mut_refs): use raw pointers instead of references
 #![allow(static_mut_refs)]
 
 use std::mem::MaybeUninit;

--- a/src/tools/miri/tests/pass-dep/concurrency/tls_pthread_drop_order.rs
+++ b/src/tools/miri/tests/pass-dep/concurrency/tls_pthread_drop_order.rs
@@ -5,7 +5,7 @@
 //! the fallback path in `guard::key::enable`, which uses a *single* pthread_key
 //! to manage a thread-local list of dtors to call.
 
-// FIXME(static_mut_refs): Do not allow `static_mut_refs` lint
+// FIXME(static_mut_refs): use raw pointers instead of references
 #![allow(static_mut_refs)]
 
 use std::{mem, ptr};

--- a/src/tools/miri/tests/pass-dep/libc/libc-eventfd.rs
+++ b/src/tools/miri/tests/pass-dep/libc/libc-eventfd.rs
@@ -3,7 +3,7 @@
 //@compile-flags: -Zmiri-deterministic-concurrency
 //@run-native
 
-// FIXME(static_mut_refs): Do not allow `static_mut_refs` lint
+// FIXME(static_mut_refs): use raw pointers instead of references
 #![allow(static_mut_refs)]
 
 use std::{io, thread};

--- a/src/tools/miri/tests/pass-dep/libc/libc-pipe.rs
+++ b/src/tools/miri/tests/pass-dep/libc/libc-pipe.rs
@@ -69,7 +69,7 @@ fn test_pipe_threaded() {
     thread2.join().unwrap();
 }
 
-// FIXME(static_mut_refs): Do not allow `static_mut_refs` lint
+// FIXME(static_mut_refs): use raw pointers instead of references
 #[allow(static_mut_refs)]
 fn test_race() {
     static mut VAL: u8 = 0;

--- a/src/tools/miri/tests/pass-dep/libc/libc-socketpair.rs
+++ b/src/tools/miri/tests/pass-dep/libc/libc-socketpair.rs
@@ -3,7 +3,7 @@
 //@compile-flags: -Zmiri-deterministic-concurrency
 //@run-native
 
-// FIXME(static_mut_refs): Do not allow `static_mut_refs` lint
+// FIXME(static_mut_refs): use raw pointers instead of references
 #![allow(static_mut_refs)]
 
 use std::thread;

--- a/src/tools/miri/tests/pass/atomic.rs
+++ b/src/tools/miri/tests/pass/atomic.rs
@@ -3,7 +3,7 @@
 //@[tree]compile-flags: -Zmiri-tree-borrows
 //@compile-flags: -Zmiri-strict-provenance
 
-// FIXME(static_mut_refs): Do not allow `static_mut_refs` lint
+// FIXME(static_mut_refs): use raw pointers instead of references
 #![allow(static_mut_refs)]
 
 use std::sync::atomic::Ordering::*;

--- a/src/tools/miri/tests/pass/static_memory_modification.rs
+++ b/src/tools/miri/tests/pass/static_memory_modification.rs
@@ -1,4 +1,4 @@
-// FIXME(static_mut_refs): Do not allow `static_mut_refs` lint
+// FIXME(static_mut_refs): use raw pointers instead of references
 #![allow(static_mut_refs)]
 
 use std::sync::atomic::{AtomicUsize, Ordering};

--- a/src/tools/miri/tests/pass/static_mut.rs
+++ b/src/tools/miri/tests/pass/static_mut.rs
@@ -1,4 +1,4 @@
-// FIXME(static_mut_refs): Do not allow `static_mut_refs` lint
+// FIXME(static_mut_refs): use raw pointers instead of references
 #![allow(static_mut_refs)]
 
 use std::ptr::addr_of;

--- a/src/tools/miri/tests/pass/tls/tls_static.rs
+++ b/src/tools/miri/tests/pass/tls/tls_static.rs
@@ -8,7 +8,7 @@
 //! dereferencing the pointer on `t2` resolves to `t1`'s thread-local. In this
 //! test, we also check that thread-locals act as per-thread statics.
 
-// FIXME(static_mut_refs): Do not allow `static_mut_refs` lint
+// FIXME(static_mut_refs): use raw pointers instead of references
 #![allow(static_mut_refs)]
 #![feature(thread_local)]
 

--- a/tests/ui/abi/statics/static-mut-foreign.rs
+++ b/tests/ui/abi/statics/static-mut-foreign.rs
@@ -3,7 +3,7 @@
 // statics cannot. This ensures that there's some form of error if this is
 // attempted.
 
-// FIXME(static_mut_refs): Do not allow `static_mut_refs` lint
+// FIXME(static_mut_refs): use raw pointers instead of references
 #![allow(static_mut_refs)]
 
 use std::ffi::c_int;

--- a/tests/ui/array-slice-vec/slice-panic-1.rs
+++ b/tests/ui/array-slice-vec/slice-panic-1.rs
@@ -5,7 +5,7 @@
 
 // Test that if a slicing expr[..] fails, the correct cleanups happen.
 
-// FIXME(static_mut_refs): this could use an atomic
+// FIXME(static_mut_refs): use raw pointers instead of references
 #![allow(static_mut_refs)]
 
 use std::thread;

--- a/tests/ui/array-slice-vec/slice-panic-2.rs
+++ b/tests/ui/array-slice-vec/slice-panic-2.rs
@@ -5,7 +5,7 @@
 
 // Test that if a slicing expr[..] fails, the correct cleanups happen.
 
-// FIXME(static_mut_refs): this could use an atomic
+// FIXME(static_mut_refs): use raw pointers instead of references
 #![allow(static_mut_refs)]
 
 use std::thread;

--- a/tests/ui/array-slice-vec/slice.rs
+++ b/tests/ui/array-slice-vec/slice.rs
@@ -3,7 +3,7 @@
 
 // Test slicing sugar.
 
-// FIXME(static_mut_refs): this could use an atomic
+// FIXME(static_mut_refs): use raw pointers instead of references
 #![allow(static_mut_refs)]
 
 extern crate core;

--- a/tests/ui/async-await/issues/issue-67611-static-mut-refs.rs
+++ b/tests/ui/async-await/issues/issue-67611-static-mut-refs.rs
@@ -1,7 +1,7 @@
 //@ build-pass
 //@ edition:2018
 
-// FIXME(static_mut_refs): Do not allow `static_mut_refs` lint
+// FIXME(static_mut_refs): use raw pointers instead of references
 #![allow(static_mut_refs)]
 
 static mut A: [i32; 5] = [1, 2, 3, 4, 5];

--- a/tests/ui/binding/order-drop-with-match.rs
+++ b/tests/ui/binding/order-drop-with-match.rs
@@ -5,7 +5,7 @@
 // in ORDER matching up to when it ran.
 // Correct order is: matched, inner, outer
 
-// FIXME(static_mut_refs): Do not allow `static_mut_refs` lint
+// FIXME(static_mut_refs): use raw pointers instead of references
 #![allow(static_mut_refs)]
 
 static mut ORDER: [usize; 3] = [0, 0, 0];

--- a/tests/ui/binding/ref-pattern-drop-behavior-8860.rs
+++ b/tests/ui/binding/ref-pattern-drop-behavior-8860.rs
@@ -1,6 +1,6 @@
 // https://github.com/rust-lang/rust/issues/8860
 //@ run-pass
-// FIXME(static_mut_refs): this could use an atomic
+// FIXME(static_mut_refs): use raw pointers instead of references
 #![allow(static_mut_refs)]
 #![allow(dead_code)]
 

--- a/tests/ui/consts/static-mut-refs.rs
+++ b/tests/ui/consts/static-mut-refs.rs
@@ -1,7 +1,7 @@
 //@ run-pass
 #![allow(dead_code)]
 
-// FIXME(static_mut_refs): Do not allow `static_mut_refs` lint
+// FIXME(static_mut_refs): use raw pointers instead of references
 #![allow(static_mut_refs)]
 
 // Checks that mutable static items can have mutable slices and other references

--- a/tests/ui/coroutine/static-mut-reference-across-yield.rs
+++ b/tests/ui/coroutine/static-mut-reference-across-yield.rs
@@ -1,7 +1,7 @@
 //@ build-pass
 
 #![feature(coroutines, stmt_expr_attributes)]
-// FIXME(static_mut_refs): Do not allow `static_mut_refs` lint
+// FIXME(static_mut_refs): use raw pointers instead of references
 #![allow(static_mut_refs)]
 
 static mut A: [i32; 5] = [1, 2, 3, 4, 5];

--- a/tests/ui/drop/conditional-drop-10734.rs
+++ b/tests/ui/drop/conditional-drop-10734.rs
@@ -3,7 +3,7 @@
 //@ run-pass
 #![allow(non_upper_case_globals)]
 
-// FIXME(static_mut_refs): this could use an atomic
+// FIXME(static_mut_refs): use raw pointers instead of references
 #![allow(static_mut_refs)]
 
 static mut drop_count: usize = 0;

--- a/tests/ui/drop/destructor-run-for-expression-4734.rs
+++ b/tests/ui/drop/destructor-run-for-expression-4734.rs
@@ -4,7 +4,7 @@
 // Ensures that destructors are run for expressions of the form "e;" where
 // `e` is a type which requires a destructor.
 
-// FIXME(static_mut_refs): Do not allow `static_mut_refs` lint
+// FIXME(static_mut_refs): use raw pointers instead of references
 #![allow(static_mut_refs)]
 #![allow(path_statements)]
 

--- a/tests/ui/drop/destructor-run-for-let-ignore-6892.rs
+++ b/tests/ui/drop/destructor-run-for-let-ignore-6892.rs
@@ -4,7 +4,7 @@
 // Ensures that destructors are run for expressions of the form "let _ = e;"
 // where `e` is a type which requires a destructor.
 
-// FIXME(static_mut_refs): Do not allow `static_mut_refs` lint
+// FIXME(static_mut_refs): use raw pointers instead of references
 #![allow(static_mut_refs)]
 
 struct Foo;

--- a/tests/ui/drop/drop-count-assertion-16151.rs
+++ b/tests/ui/drop/drop-count-assertion-16151.rs
@@ -1,7 +1,7 @@
 // https://github.com/rust-lang/rust/issues/16151
 //@ run-pass
 
-// FIXME(static_mut_refs): Do not allow `static_mut_refs` lint
+// FIXME(static_mut_refs): use raw pointers instead of references
 #![allow(static_mut_refs)]
 
 use std::mem;

--- a/tests/ui/drop/drop-struct-as-object.rs
+++ b/tests/ui/drop/drop-struct-as-object.rs
@@ -5,7 +5,7 @@
 // Test that destructor on a struct runs successfully after the struct
 // is boxed and converted to an object.
 
-// FIXME(static_mut_refs): this could use an atomic
+// FIXME(static_mut_refs): use raw pointers instead of references
 #![allow(static_mut_refs)]
 
 static mut value: usize = 0;

--- a/tests/ui/drop/generic-drop-trait-bound-15858.rs
+++ b/tests/ui/drop/generic-drop-trait-bound-15858.rs
@@ -1,7 +1,7 @@
 //! Regression test for https://github.com/rust-lang/rust/issues/15858
 
 //@ run-pass
-// FIXME(static_mut_refs): this could use an atomic
+// FIXME(static_mut_refs): use raw pointers instead of references
 #![allow(static_mut_refs)]
 static mut DROP_RAN: bool = false;
 

--- a/tests/ui/drop/issue-23338-ensure-param-drop-order.rs
+++ b/tests/ui/drop/issue-23338-ensure-param-drop-order.rs
@@ -1,6 +1,6 @@
 //@ run-pass
 #![allow(non_upper_case_globals)]
-// FIXME(static_mut_refs): Do not allow `static_mut_refs` lint
+// FIXME(static_mut_refs): use raw pointers instead of references
 #![allow(static_mut_refs)]
 
 // This test is ensuring that parameters are indeed dropped after

--- a/tests/ui/drop/issue-23611-enum-swap-in-drop.rs
+++ b/tests/ui/drop/issue-23611-enum-swap-in-drop.rs
@@ -1,6 +1,6 @@
 //@ run-pass
 #![allow(non_upper_case_globals)]
-// FIXME(static_mut_refs): Do not allow `static_mut_refs` lint
+// FIXME(static_mut_refs): use raw pointers instead of references
 #![allow(static_mut_refs)]
 
 // Issue 23611: this test is ensuring that, for an instance `X` of the

--- a/tests/ui/drop/issue-48962.rs
+++ b/tests/ui/drop/issue-48962.rs
@@ -1,7 +1,7 @@
 //@ run-pass
 #![allow(unused_must_use)]
 // Test that we are able to reinitialize box with moved referent
-// FIXME(static_mut_refs): Do not allow `static_mut_refs` lint
+// FIXME(static_mut_refs): use raw pointers instead of references
 #![allow(static_mut_refs)]
 
 static mut ORDER: [usize; 3] = [0, 0, 0];

--- a/tests/ui/drop/repeat-drop.rs
+++ b/tests/ui/drop/repeat-drop.rs
@@ -3,7 +3,7 @@
 
 #![allow(dropping_references, dropping_copy_types)]
 
-// FIXME(static_mut_refs): this could use an atomic
+// FIXME(static_mut_refs): use raw pointers instead of references
 #![allow(static_mut_refs)]
 
 static mut CHECK: usize = 0;

--- a/tests/ui/drop/same-alloca-reassigned-match-binding-16151.rs
+++ b/tests/ui/drop/same-alloca-reassigned-match-binding-16151.rs
@@ -2,7 +2,7 @@
 
 //@ run-pass
 
-// FIXME(static_mut_refs): Do not allow `static_mut_refs` lint
+// FIXME(static_mut_refs): use raw pointers instead of references
 #![allow(static_mut_refs)]
 
 use std::mem;

--- a/tests/ui/drop/static-issue-17302.rs
+++ b/tests/ui/drop/static-issue-17302.rs
@@ -1,6 +1,6 @@
 //@ run-pass
 
-// FIXME(static_mut_refs): Do not allow `static_mut_refs` lint
+// FIXME(static_mut_refs): use raw pointers instead of references
 #![allow(static_mut_refs)]
 
 static mut DROPPED: [bool; 2] = [false, false];

--- a/tests/ui/for-loop-while/cleanup-rvalue-during-if-and-while.rs
+++ b/tests/ui/for-loop-while/cleanup-rvalue-during-if-and-while.rs
@@ -2,7 +2,7 @@
 // This test verifies that temporaries created for `while`'s and `if`
 // conditions are dropped after the condition is evaluated.
 
-// FIXME(static_mut_refs): this could use an atomic
+// FIXME(static_mut_refs): use raw pointers instead of references
 #![allow(static_mut_refs)]
 
 struct Temporary;

--- a/tests/ui/functional-struct-update/functional-struct-update-respects-privacy.rs
+++ b/tests/ui/functional-struct-update/functional-struct-update-respects-privacy.rs
@@ -3,7 +3,7 @@
 // The `foo` module attempts to maintains an invariant that each `S`
 // has a unique `u64` id.
 
-// FIXME(static_mut_refs): Do not allow `static_mut_refs` lint
+// FIXME(static_mut_refs): use raw pointers instead of references
 #![allow(static_mut_refs)]
 
 use self::foo::S;

--- a/tests/ui/linkage-attr/link-section-placement.rs
+++ b/tests/ui/linkage-attr/link-section-placement.rs
@@ -3,7 +3,7 @@
 //@ run-pass
 
 #![feature(cfg_target_object_format)]
-// FIXME(static_mut_refs): Do not allow `static_mut_refs` lint
+// FIXME(static_mut_refs): use raw pointers instead of references
 #![allow(static_mut_refs)]
 #![allow(non_upper_case_globals)]
 

--- a/tests/ui/linkage-attr/linkage-attr-mutable-static.rs
+++ b/tests/ui/linkage-attr/linkage-attr-mutable-static.rs
@@ -2,7 +2,7 @@
 //! them at runtime, so deny mutable statics with #[linkage].
 
 #![feature(linkage)]
-// FIXME(static_mut_refs): Do not allow `static_mut_refs` lint
+// FIXME(static_mut_refs): use raw pointers instead of references
 #![allow(static_mut_refs)]
 
 fn main() {

--- a/tests/ui/lto/lto-still-runs-thread-dtors.rs
+++ b/tests/ui/lto/lto-still-runs-thread-dtors.rs
@@ -4,7 +4,7 @@
 //@ needs-threads
 //@ ignore-backends: gcc
 
-// FIXME(static_mut_refs): this could use an atomic
+// FIXME(static_mut_refs): use raw pointers instead of references
 #![allow(static_mut_refs)]
 
 use std::thread;

--- a/tests/ui/methods/method-self-arg-trait.rs
+++ b/tests/ui/methods/method-self-arg-trait.rs
@@ -1,7 +1,7 @@
 //@ run-pass
 // Test method calls with self as an argument
 
-// FIXME(static_mut_refs): Do not allow `static_mut_refs` lint
+// FIXME(static_mut_refs): use raw pointers instead of references
 #![allow(static_mut_refs)]
 
 static mut COUNT: u64 = 1;

--- a/tests/ui/methods/method-self-arg.rs
+++ b/tests/ui/methods/method-self-arg.rs
@@ -1,7 +1,7 @@
 //@ run-pass
 // Test method calls with self as an argument
 
-// FIXME(static_mut_refs): Do not allow `static_mut_refs` lint
+// FIXME(static_mut_refs): use raw pointers instead of references
 #![allow(static_mut_refs)]
 
 static mut COUNT: usize = 1;

--- a/tests/ui/mir/mir_early_return_scope.rs
+++ b/tests/ui/mir/mir_early_return_scope.rs
@@ -1,6 +1,6 @@
 //@ run-pass
 #![allow(unused_variables)]
-// FIXME(static_mut_refs): this could use an atomic
+// FIXME(static_mut_refs): use raw pointers instead of references
 #![allow(static_mut_refs)]
 static mut DROP: bool = false;
 

--- a/tests/ui/nll/issue-69114-static-mut-ty.rs
+++ b/tests/ui/nll/issue-69114-static-mut-ty.rs
@@ -1,6 +1,6 @@
 // Check that borrowck ensures that `static mut` items have the expected type.
 
-// FIXME(static_mut_refs): Do not allow `static_mut_refs` lint
+// FIXME(static_mut_refs): use raw pointers instead of references
 #![allow(static_mut_refs)]
 
 static FOO: u8 = 42;

--- a/tests/ui/numbers-arithmetic/shift-near-oflo.rs
+++ b/tests/ui/numbers-arithmetic/shift-near-oflo.rs
@@ -1,7 +1,7 @@
 //@ run-pass
 //@ compile-flags: -C debug-assertions
 
-// FIXME(static_mut_refs): Do not allow `static_mut_refs` lint
+// FIXME(static_mut_refs): use raw pointers instead of references
 #![allow(static_mut_refs)]
 
 // Check that we do *not* overflow on a number of edge cases.

--- a/tests/ui/self/where-for-self.rs
+++ b/tests/ui/self/where-for-self.rs
@@ -2,7 +2,7 @@
 // Test that we can quantify lifetimes outside a constraint (i.e., including
 // the self type) in a where clause.
 
-// FIXME(static_mut_refs): this could use an atomic
+// FIXME(static_mut_refs): use raw pointers instead of references
 #![allow(static_mut_refs)]
 
 static mut COUNT: u32 = 1;

--- a/tests/ui/thread-local/thread-local-issue-37508.rs
+++ b/tests/ui/thread-local/thread-local-issue-37508.rs
@@ -4,7 +4,7 @@
 //
 // Regression test for issue #37508
 
-// FIXME(static_mut_refs): Do not allow `static_mut_refs` lint
+// FIXME(static_mut_refs): use raw pointers instead of references
 #![allow(static_mut_refs)]
 
 #![no_main]

--- a/tests/ui/traits/impl.rs
+++ b/tests/ui/traits/impl.rs
@@ -3,7 +3,7 @@
 
 //@ aux-build:traitimpl.rs
 
-// FIXME(static_mut_refs): this could use an atomic
+// FIXME(static_mut_refs): use raw pointers instead of references
 #![allow(static_mut_refs)]
 
 extern crate traitimpl;

--- a/tests/ui/union/union-drop-assign.rs
+++ b/tests/ui/union/union-drop-assign.rs
@@ -3,7 +3,7 @@
 
 // Drop works for union itself.
 
-// FIXME(static_mut_refs): this could use an atomic
+// FIXME(static_mut_refs): use raw pointers instead of references
 #![allow(static_mut_refs)]
 
 use std::mem::ManuallyDrop;

--- a/tests/ui/union/union-drop.rs
+++ b/tests/ui/union/union-drop.rs
@@ -2,7 +2,7 @@
 
 #![allow(dead_code)]
 #![allow(unused_variables)]
-// FIXME(static_mut_refs): this could use an atomic
+// FIXME(static_mut_refs): use raw pointers instead of references
 #![allow(static_mut_refs)]
 
 // Drop works for union itself.


### PR DESCRIPTION
Close rust-lang/rust#125035 

Update `FIXME(static_mut_refs)` comment to say: use raw pointers instead of references.

r? @RalfJung

