### PR TITLE
Get rid of `StructurallyRelateAliases`

### DIFF
--- a/compiler/rustc_borrowck/src/type_check/relate_tys.rs
+++ b/compiler/rustc_borrowck/src/type_check/relate_tys.rs
@@ -1,9 +1,7 @@
 use rustc_data_structures::fx::FxHashMap;
 use rustc_errors::ErrorGuaranteed;
 use rustc_hir::def_id::DefId;
-use rustc_infer::infer::relate::{
-    PredicateEmittingRelation, Relate, RelateResult, StructurallyRelateAliases, TypeRelation,
-};
+use rustc_infer::infer::relate::{PredicateEmittingRelation, Relate, RelateResult, TypeRelation};
 use rustc_infer::infer::{InferCtxt, NllRegionVariableOrigin};
 use rustc_infer::traits::Obligation;
 use rustc_infer::traits::solve::Goal;
@@ -550,10 +548,6 @@ impl<'b, 'tcx> TypeRelation<TyCtxt<'tcx>> for NllTypeRelating<'_, 'b, 'tcx> {
 impl<'b, 'tcx> PredicateEmittingRelation<InferCtxt<'tcx>> for NllTypeRelating<'_, 'b, 'tcx> {
     fn span(&self) -> Span {
         self.locations.span(self.type_checker.body)
-    }
-
-    fn structurally_relate_aliases(&self) -> StructurallyRelateAliases {
-        StructurallyRelateAliases::No
     }
 
     fn param_env(&self) -> ty::ParamEnv<'tcx> {

--- a/compiler/rustc_infer/src/infer/context.rs
+++ b/compiler/rustc_infer/src/infer/context.rs
@@ -255,21 +255,13 @@ impl<'tcx> rustc_type_ir::InferCtxtLike for InferCtxt<'tcx> {
     }
 
     fn instantiate_ty_var_raw(&self, vid: ty::TyVid, ty: Ty<'tcx>) {
-        let ty = ty.fold_with(&mut LowerUniverseFolder {
-            infcx: self,
-            for_universe: self.try_resolve_ty_var(vid).unwrap_err(),
-            cache: Default::default(),
-        });
+        let ty = lower_universe(self, self.try_resolve_ty_var(vid).unwrap_err(), ty);
 
         self.inner.borrow_mut().type_variables().instantiate(vid, ty);
     }
 
     fn instantiate_const_var_raw(&self, vid: ty::ConstVid, ct: ty::Const<'tcx>) {
-        let ct = ct.fold_with(&mut LowerUniverseFolder {
-            infcx: self,
-            for_universe: self.try_resolve_const_var(vid).unwrap_err(),
-            cache: Default::default(),
-        });
+        let ct = lower_universe(self, self.try_resolve_const_var(vid).unwrap_err(), ct);
 
         self.inner
             .borrow_mut()
@@ -438,6 +430,33 @@ impl<'tcx> rustc_type_ir::InferCtxtLike for InferCtxt<'tcx> {
     }
 }
 
+fn lower_universe<'tcx, T: TypeFoldable<TyCtxt<'tcx>> + Copy>(
+    infcx: &InferCtxt<'tcx>,
+    for_universe: ty::UniverseIndex,
+    value: T,
+) -> T {
+    let value = value.fold_with(&mut LowerUniverseFolder {
+        infcx,
+        for_universe,
+        cache: Default::default(),
+    });
+
+    // This assertion is needed because we don't lower the universes of placeholders
+    // in the folder.
+    #[cfg(debug_assertions)]
+    {
+        let value_universe = ty::max_universe(infcx, value);
+        assert!(
+            for_universe.can_name(value_universe),
+            "variable in universe {:?} can't name value in universe {:?}",
+            for_universe,
+            value_universe,
+        );
+    }
+
+    value
+}
+
 /// Canonicalizing inputs puts all inference variables and placeholders
 /// into the root universe.
 ///
@@ -487,15 +506,6 @@ impl<'a, 'tcx> ty::TypeFolder<TyCtxt<'tcx>> for LowerUniverseFolder<'a, 'tcx> {
                     }
                 }
             }
-            ty::Placeholder(p) => {
-                debug_assert!(
-                    self.for_universe.can_name(p.universe),
-                    "variable in universe {:?} can't name type in universe {:?}",
-                    self.for_universe,
-                    p.universe
-                );
-                t
-            }
             _ => t.super_fold_with(self),
         };
 
@@ -531,15 +541,6 @@ impl<'a, 'tcx> ty::TypeFolder<TyCtxt<'tcx>> for LowerUniverseFolder<'a, 'tcx> {
 
                     ty::Const::new_var(self.cx(), new_var_id)
                 }
-            }
-            ty::ConstKind::Placeholder(p) => {
-                debug_assert!(
-                    self.for_universe.can_name(p.universe),
-                    "variable in universe {:?} can't name const in universe {:?}",
-                    self.for_universe,
-                    p.universe
-                );
-                c
             }
             _ => c.super_fold_with(self),
         }

--- a/compiler/rustc_infer/src/infer/context.rs
+++ b/compiler/rustc_infer/src/infer/context.rs
@@ -1,14 +1,17 @@
 //! Definition of `InferCtxtLike` from the librarified type layer.
+use rustc_data_structures::sso::SsoHashMap;
 use rustc_hir::def_id::DefId;
 use rustc_middle::traits::ObligationCause;
 use rustc_middle::ty::relate::RelateResult;
 use rustc_middle::ty::relate::combine::PredicateEmittingRelation;
 use rustc_middle::ty::{self, Ty, TyCtxt, TypeFoldable};
 use rustc_span::{DUMMY_SP, ErrorGuaranteed, Span};
+use rustc_type_ir::{TypeSuperFoldable, TypeVisitableExt};
 
+use super::type_variable::TypeVariableValue;
 use super::{
-    BoundRegionConversionTime, InferCtxt, OpaqueTypeStorageEntries, RegionVariableOrigin,
-    SubregionOrigin,
+    BoundRegionConversionTime, ConstVariableValue, InferCtxt, OpaqueTypeStorageEntries,
+    RegionVariableOrigin, SubregionOrigin,
 };
 
 impl<'tcx> rustc_type_ir::InferCtxtLike for InferCtxt<'tcx> {
@@ -251,7 +254,30 @@ impl<'tcx> rustc_type_ir::InferCtxtLike for InferCtxt<'tcx> {
         self.inner.borrow_mut().const_unification_table().union(a, b);
     }
 
-    fn instantiate_ty_var_raw<R: PredicateEmittingRelation<Self>>(
+    fn instantiate_ty_var_raw(&self, vid: ty::TyVid, ty: Ty<'tcx>) {
+        let ty = ty.fold_with(&mut LowerUniverseFolder {
+            infcx: self,
+            for_universe: self.try_resolve_ty_var(vid).unwrap_err(),
+            cache: Default::default(),
+        });
+
+        self.inner.borrow_mut().type_variables().instantiate(vid, ty);
+    }
+
+    fn instantiate_const_var_raw(&self, vid: ty::ConstVid, ct: ty::Const<'tcx>) {
+        let ct = ct.fold_with(&mut LowerUniverseFolder {
+            infcx: self,
+            for_universe: self.try_resolve_const_var(vid).unwrap_err(),
+            cache: Default::default(),
+        });
+
+        self.inner
+            .borrow_mut()
+            .const_unification_table()
+            .union_value(vid, ConstVariableValue::Known { value: ct });
+    }
+
+    fn instantiate_ty_var<R: PredicateEmittingRelation<Self>>(
         &self,
         relation: &mut R,
         target_is_expected: bool,
@@ -276,7 +302,7 @@ impl<'tcx> rustc_type_ir::InferCtxtLike for InferCtxt<'tcx> {
         self.inner.borrow_mut().float_unification_table().union_value(vid, value);
     }
 
-    fn instantiate_const_var_raw<R: PredicateEmittingRelation<Self>>(
+    fn instantiate_const_var<R: PredicateEmittingRelation<Self>>(
         &self,
         relation: &mut R,
         target_is_expected: bool,
@@ -409,5 +435,139 @@ impl<'tcx> rustc_type_ir::InferCtxtLike for InferCtxt<'tcx> {
 
     fn reset_opaque_types(&self) {
         let _ = self.take_opaque_types();
+    }
+}
+
+/// Canonicalizing inputs puts all inference variables and placeholders
+/// into the root universe.
+///
+/// This means when instantiating the query response we need to pull
+/// down the universe of returned `var_values` to the universe of
+/// the inference variable in `orig_values`.
+///
+/// This folder is similar to the `Generalizer`, except that it simply
+/// structurally folds non-rigid aliases as these should have already
+/// been generalized in the query so we shouldn't try to do it again.
+struct LowerUniverseFolder<'a, 'tcx> {
+    infcx: &'a InferCtxt<'tcx>,
+    for_universe: ty::UniverseIndex,
+    cache: SsoHashMap<Ty<'tcx>, Ty<'tcx>>,
+}
+impl<'a, 'tcx> ty::TypeFolder<TyCtxt<'tcx>> for LowerUniverseFolder<'a, 'tcx> {
+    fn cx(&self) -> TyCtxt<'tcx> {
+        self.infcx.tcx
+    }
+
+    fn fold_ty(&mut self, t: Ty<'tcx>) -> Ty<'tcx> {
+        if !(t.has_free_regions() || t.has_infer()) {
+            return t;
+        }
+
+        if let Some(&answer) = self.cache.get(&t) {
+            return answer;
+        }
+
+        let folded = match t.kind() {
+            ty::Infer(ty::TyVar(vid)) => {
+                let vid = self.infcx.root_var(*vid);
+                let probe = self.infcx.inner.borrow_mut().type_variables().probe(vid);
+                match probe {
+                    TypeVariableValue::Known { value: u } => u.super_fold_with(self),
+                    TypeVariableValue::Unknown { universe } => {
+                        if self.for_universe.can_name(universe) {
+                            t
+                        } else {
+                            let mut inner = self.infcx.inner.borrow_mut();
+                            let origin = inner.type_variables().var_origin(vid);
+                            let new_var_id =
+                                inner.type_variables().new_var(self.for_universe, origin);
+                            inner.type_variables().equate(vid, new_var_id);
+                            Ty::new_var(self.cx(), new_var_id)
+                        }
+                    }
+                }
+            }
+            ty::Placeholder(p) => {
+                debug_assert!(
+                    self.for_universe.can_name(p.universe),
+                    "variable in universe {:?} can't name type in universe {:?}",
+                    self.for_universe,
+                    p.universe
+                );
+                t
+            }
+            _ => t.super_fold_with(self),
+        };
+
+        self.cache.insert(t, folded);
+        folded
+    }
+
+    fn fold_const(&mut self, c: ty::Const<'tcx>) -> ty::Const<'tcx> {
+        if !(c.has_free_regions() || c.has_infer()) {
+            return c;
+        }
+
+        match c.kind() {
+            ty::ConstKind::Infer(ty::InferConst::Var(vid)) => {
+                let vid = self.infcx.root_const_var(vid);
+                let universe = self.infcx.try_resolve_const_var(vid).unwrap_err();
+                if self.for_universe.can_name(universe) {
+                    c
+                } else {
+                    let origin = self.infcx.const_var_origin(vid).unwrap();
+                    let new_var_id = self
+                        .infcx
+                        .inner
+                        .borrow_mut()
+                        .const_unification_table()
+                        .new_key(ConstVariableValue::Unknown {
+                            origin,
+                            universe: self.for_universe,
+                        })
+                        .vid;
+
+                    self.infcx.inner.borrow_mut().const_unification_table().union(vid, new_var_id);
+
+                    ty::Const::new_var(self.cx(), new_var_id)
+                }
+            }
+            ty::ConstKind::Placeholder(p) => {
+                debug_assert!(
+                    self.for_universe.can_name(p.universe),
+                    "variable in universe {:?} can't name const in universe {:?}",
+                    self.for_universe,
+                    p.universe
+                );
+                c
+            }
+            _ => c.super_fold_with(self),
+        }
+    }
+
+    fn fold_region(&mut self, r: ty::Region<'tcx>) -> ty::Region<'tcx> {
+        match r.kind() {
+            ty::ReBound(..) | ty::ReErased => r,
+            _ => {
+                let r_universe = self.infcx.universe_of_region(r);
+                if self.for_universe.can_name(r_universe) {
+                    r
+                } else {
+                    // FIXME: unfortunately we lose the relating span here unless we take another
+                    // argument.
+                    let new_region = self.infcx.next_region_var_in_universe(
+                        RegionVariableOrigin::Misc(DUMMY_SP),
+                        self.for_universe,
+                    );
+                    self.infcx.equate_regions(
+                        SubregionOrigin::RelateRegionParamBound(DUMMY_SP, None),
+                        r,
+                        new_region,
+                        ty::VisibleForLeakCheck::Yes,
+                    );
+                    new_region
+                }
+            }
+        }
     }
 }

--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -10,7 +10,6 @@ pub use opaque_types::{OpaqueTypeStorage, OpaqueTypeStorageEntries, OpaqueTypeTa
 use region_constraints::{
     GenericKind, RegionConstraintCollector, RegionConstraintStorage, VarInfos, VerifyBound,
 };
-pub use relate::StructurallyRelateAliases;
 pub use relate::combine::PredicateEmittingRelation;
 use rustc_data_structures::fx::{FxHashSet, FxIndexMap};
 use rustc_data_structures::undo_log::{Rollback, UndoLogs};

--- a/compiler/rustc_infer/src/infer/relate/generalize.rs
+++ b/compiler/rustc_infer/src/infer/relate/generalize.rs
@@ -9,9 +9,7 @@ use rustc_middle::ty::{self, InferConst, Term, Ty, TyCtxt, TypeVisitableExt};
 use rustc_span::Span;
 use tracing::{debug, instrument, warn};
 
-use super::{
-    PredicateEmittingRelation, Relate, RelateResult, StructurallyRelateAliases, TypeRelation,
-};
+use super::{PredicateEmittingRelation, Relate, RelateResult, TypeRelation};
 use crate::infer::type_variable::TypeVariableValue;
 use crate::infer::unify_key::ConstVariableValue;
 use crate::infer::{InferCtxt, RegionVariableOrigin, relate};
@@ -142,13 +140,8 @@ impl<'tcx> InferCtxt<'tcx> {
         //
         // We then relate `generalized_term <: source_term`, adding constraints like `'x: '?2` and
         // `?1 <: ?3`.
-        let Generalization { value_may_be_infer: generalized_term } = self.generalize(
-            relation.span(),
-            relation.structurally_relate_aliases(),
-            target_vid,
-            instantiation_variance,
-            source_term,
-        )?;
+        let Generalization { value_may_be_infer: generalized_term } =
+            self.generalize(relation.span(), target_vid, instantiation_variance, source_term)?;
 
         // Constrain `b_vid` to the generalized type `generalized_term`.
         self.union_var_term(target_vid, generalized_term);
@@ -326,7 +319,6 @@ impl<'tcx> InferCtxt<'tcx> {
     fn generalize(
         &self,
         span: Span,
-        structurally_relate_aliases: StructurallyRelateAliases,
         target_vid: TermVid,
         ambient_variance: ty::Variance,
         source_term: Term<'tcx>,
@@ -345,7 +337,6 @@ impl<'tcx> InferCtxt<'tcx> {
         let mut generalizer = Generalizer {
             infcx: self,
             span,
-            structurally_relate_aliases,
             root_vid,
             for_universe,
             root_term: source_term,
@@ -376,10 +367,6 @@ struct Generalizer<'me, 'tcx> {
     infcx: &'me InferCtxt<'tcx>,
 
     span: Span,
-
-    /// Whether aliases should be related structurally. If not, we have to
-    /// be careful when generalizing aliases.
-    structurally_relate_aliases: StructurallyRelateAliases,
 
     /// The vid of the type variable that is in the process of being
     /// instantiated. If we find this within the value we are folding,
@@ -634,12 +621,9 @@ impl<'tcx> TypeRelation<TyCtxt<'tcx>> for Generalizer<'_, 'tcx> {
 
             // We only need to be careful with potentially normalizeable
             // aliases here. See `generalize_alias_term` for more information.
-            ty::Alias(ty::IsRigid::No, data) => match self.structurally_relate_aliases {
-                StructurallyRelateAliases::No => {
-                    self.generalize_alias_term(data.into()).map(|v| v.expect_type())
-                }
-                StructurallyRelateAliases::Yes => relate::structurally_relate_tys(self, t, t),
-            },
+            ty::Alias(ty::IsRigid::No, data) => {
+                self.generalize_alias_term(data.into()).map(|v| v.expect_type())
+            }
 
             _ => relate::structurally_relate_tys(self, t, t),
         }?;
@@ -748,33 +732,30 @@ impl<'tcx> TypeRelation<TyCtxt<'tcx>> for Generalizer<'_, 'tcx> {
             // FIXME: Alias consts are also not rigid, so the current
             // approach of always relating them structurally is incomplete.
             //
-            // FIXME: replace the StructurallyRelateAliases::Yes branch with
+            // FIXME: replace the `else` branch with
             // `structurally_relate_consts` once it is fully structural.
             //
             // We only need to be careful with potentially normalizeable
             // aliases here. See `generalize_alias_term` for more information.
             ty::ConstKind::Alias(ty::IsRigid::No, alias_const) => {
-                match self.structurally_relate_aliases {
-                    // Hack: Fall back to old behavior if GCE is enabled (it used to just be the Yes
-                    // path), as doing this new No path breaks some GCE things. I expect GCE to be
-                    // ripped out soon so this shouldn't matter soon.
-                    StructurallyRelateAliases::No if !tcx.features().generic_const_exprs() => {
-                        self.generalize_alias_term(alias_const.into()).map(|v| v.expect_const())
-                    }
-                    _ => {
-                        let ty::AliasConst { kind, args, .. } = alias_const;
-                        let args = self.relate_with_variance(
-                            ty::Invariant,
-                            ty::VarianceDiagInfo::default(),
-                            args,
-                            args,
-                        )?;
-                        Ok(ty::Const::new_alias(
-                            tcx,
-                            ty::IsRigid::No,
-                            ty::AliasConst::new(tcx, kind, args),
-                        ))
-                    }
+                // Hack: Fall back to old behavior if GCE is enabled (it used to just be the Yes
+                // path), as doing this new No path breaks some GCE things. I expect GCE to be
+                // ripped out soon so this shouldn't matter soon.
+                if !tcx.features().generic_const_exprs() {
+                    self.generalize_alias_term(alias_const.into()).map(|v| v.expect_const())
+                } else {
+                    let ty::AliasConst { kind, args, .. } = alias_const;
+                    let args = self.relate_with_variance(
+                        ty::Invariant,
+                        ty::VarianceDiagInfo::default(),
+                        args,
+                        args,
+                    )?;
+                    Ok(ty::Const::new_alias(
+                        tcx,
+                        ty::IsRigid::No,
+                        ty::AliasConst::new(tcx, kind, args),
+                    ))
                 }
             }
             ty::ConstKind::Placeholder(placeholder) => {

--- a/compiler/rustc_infer/src/infer/relate/generalize.rs
+++ b/compiler/rustc_infer/src/infer/relate/generalize.rs
@@ -297,6 +297,12 @@ impl<'tcx> InferCtxt<'tcx> {
                 if let Some(r) = r.ty_vid() {
                     self.inner.borrow_mut().type_variables().equate(l, r)
                 } else {
+                    // Ideally, we put this assert into `type_variables().instantiate()`.
+                    // But we can't pass the infcx into it as the infcx is already
+                    // mutably borrowed.
+                    debug_assert!(
+                        self.try_resolve_ty_var(l).unwrap_err().can_name(ty::max_universe(self, r))
+                    );
                     self.inner.borrow_mut().type_variables().instantiate(l, r)
                 }
             }
@@ -304,6 +310,11 @@ impl<'tcx> InferCtxt<'tcx> {
                 if let Some(r) = r.ct_vid() {
                     self.inner.borrow_mut().const_unification_table().union(l, r)
                 } else {
+                    debug_assert!(
+                        self.try_resolve_const_var(l)
+                            .unwrap_err()
+                            .can_name(ty::max_universe(self, r))
+                    );
                     self.inner
                         .borrow_mut()
                         .const_unification_table()

--- a/compiler/rustc_infer/src/infer/relate/lattice.rs
+++ b/compiler/rustc_infer/src/infer/relate/lattice.rs
@@ -25,7 +25,6 @@ use rustc_middle::ty::{self, Ty, TyCtxt, TyVar, TypeVisitableExt};
 use rustc_span::Span;
 use tracing::{debug, instrument};
 
-use super::StructurallyRelateAliases;
 use super::combine::PredicateEmittingRelation;
 use crate::infer::{DefineOpaqueTypes, InferCtxt, SubregionOrigin, TypeTrace};
 use crate::traits::{Obligation, PredicateObligations};
@@ -261,10 +260,6 @@ impl<'infcx, 'tcx> LatticeOp<'infcx, 'tcx> {
 impl<'tcx> PredicateEmittingRelation<InferCtxt<'tcx>> for LatticeOp<'_, 'tcx> {
     fn span(&self) -> Span {
         self.trace.span()
-    }
-
-    fn structurally_relate_aliases(&self) -> StructurallyRelateAliases {
-        StructurallyRelateAliases::No
     }
 
     fn param_env(&self) -> ty::ParamEnv<'tcx> {

--- a/compiler/rustc_infer/src/infer/relate/type_relating.rs
+++ b/compiler/rustc_infer/src/infer/relate/type_relating.rs
@@ -7,7 +7,7 @@ use rustc_span::Span;
 use tracing::{debug, instrument};
 
 use crate::infer::BoundRegionConversionTime::HigherRankedType;
-use crate::infer::relate::{PredicateEmittingRelation, StructurallyRelateAliases};
+use crate::infer::relate::PredicateEmittingRelation;
 use crate::infer::{DefineOpaqueTypes, InferCtxt, SubregionOrigin, TypeTrace};
 use crate::traits::{Obligation, PredicateObligations};
 
@@ -358,10 +358,6 @@ impl<'tcx> PredicateEmittingRelation<InferCtxt<'tcx>> for TypeRelating<'_, 'tcx>
 
     fn param_env(&self) -> ty::ParamEnv<'tcx> {
         self.param_env
-    }
-
-    fn structurally_relate_aliases(&self) -> StructurallyRelateAliases {
-        StructurallyRelateAliases::No
     }
 
     fn register_predicates(

--- a/compiler/rustc_next_trait_solver/src/canonical/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/canonical/mod.rs
@@ -15,8 +15,7 @@ use canonicalizer::Canonicalizer;
 use rustc_index::IndexVec;
 use rustc_type_ir::inherent::*;
 use rustc_type_ir::relate::{
-    self, Relate, RelateResult, StructurallyRelateAliases, TypeRelation,
-    VarianceDiagInfo, relate_args_invariantly,
+    self, Relate, RelateResult, TypeRelation, VarianceDiagInfo, relate_args_invariantly,
 };
 use rustc_type_ir::{
     self as ty, Canonical, CanonicalVarKind, CanonicalVarValues, InferCtxtLike, Interner,

--- a/compiler/rustc_next_trait_solver/src/canonical/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/canonical/mod.rs
@@ -14,7 +14,10 @@ use std::iter;
 use canonicalizer::Canonicalizer;
 use rustc_index::IndexVec;
 use rustc_type_ir::inherent::*;
-use rustc_type_ir::relate::solver_relating::RelateExt;
+use rustc_type_ir::relate::{
+    self, Relate, RelateResult, StructurallyRelateAliases, TypeRelation,
+    VarianceDiagInfo, relate_args_invariantly,
+};
 use rustc_type_ir::{
     self as ty, Canonical, CanonicalVarKind, CanonicalVarValues, InferCtxtLike, Interner,
     TypeFoldable, TypingMode, TypingModeEqWrapper,
@@ -246,6 +249,199 @@ where
     })
 }
 
+/// Enforce that `a` is equal to `b`.
+///
+/// In normal type relating, we don't structurally relate non-rigid aliases
+/// as they can be normalized to any type. So we emit projection obligations to
+/// defer the checks. E.g. in `infcx.eq` or `infcx.relate`.
+/// But when unifying query response with original vars, we want to directly
+/// set the original vars to values in response.
+///
+/// Therefore this type relation is created to **always** structurally relate
+/// aliases, or more specifically, structurally eq everything.
+struct ResponseRelating<'infcx, Infcx, I: Interner> {
+    infcx: &'infcx Infcx,
+    span: I::Span,
+}
+
+impl<'infcx, Infcx, I> ResponseRelating<'infcx, Infcx, I>
+where
+    Infcx: InferCtxtLike<Interner = I>,
+    I: Interner,
+{
+    fn new(infcx: &'infcx Infcx, span: I::Span) -> Self {
+        ResponseRelating { infcx, span }
+    }
+}
+
+impl<Infcx, I> TypeRelation<I> for ResponseRelating<'_, Infcx, I>
+where
+    Infcx: InferCtxtLike<Interner = I>,
+    I: Interner,
+{
+    fn cx(&self) -> I {
+        self.infcx.cx()
+    }
+
+    fn relate_ty_args(
+        &mut self,
+        a_ty: I::Ty,
+        _b_ty: I::Ty,
+        _def_id: I::DefId,
+        a_args: I::GenericArgs,
+        b_args: I::GenericArgs,
+        _: impl FnOnce(I::GenericArgs) -> I::Ty,
+    ) -> RelateResult<I, I::Ty> {
+        relate_args_invariantly(self, a_args, b_args)?;
+        Ok(a_ty)
+    }
+    fn relate_with_variance<T: Relate<I>>(
+        &mut self,
+        _variance: ty::Variance,
+        _info: VarianceDiagInfo<I>,
+        a: T,
+        b: T,
+    ) -> RelateResult<I, T> {
+        self.relate(a, b)
+    }
+
+    #[instrument(skip(self), level = "trace")]
+    fn tys(&mut self, a: I::Ty, b: I::Ty) -> RelateResult<I, I::Ty> {
+        if a == b {
+            return Ok(a);
+        }
+
+        let infcx = self.infcx;
+        let a = infcx.shallow_resolve(a);
+        let b = infcx.shallow_resolve(b);
+
+        match (a.kind(), b.kind()) {
+            (ty::Infer(ty::TyVar(a_id)), ty::Infer(ty::TyVar(b_id))) => {
+                infcx.equate_ty_vids_raw(a_id, b_id);
+            }
+
+            (ty::Infer(ty::TyVar(a_vid)), _) => {
+                infcx.instantiate_ty_var_raw(a_vid, b);
+            }
+
+            (_, ty::Infer(ty::TyVar(b_vid))) => {
+                infcx.instantiate_ty_var_raw(b_vid, a);
+            }
+
+            (ty::Error(e), _) | (_, ty::Error(e)) => {
+                infcx.set_tainted_by_errors(e);
+                return Ok(Ty::new_error(infcx.cx(), e));
+            }
+
+            // FIXME: Share the arms below with `super_combine_tys`.
+            // We can't use `super_combine_tys` here because we want to support
+            // values with escaping bound vars so that we can avoid
+            // instantiating binders when relating them.
+            //
+            // Relate integral variables to other types
+            (ty::Infer(ty::IntVar(a_id)), ty::Infer(ty::IntVar(b_id))) => {
+                infcx.equate_int_vids_raw(a_id, b_id);
+            }
+            (ty::Infer(ty::IntVar(v_id)), ty::Int(v)) => {
+                infcx.instantiate_int_var_raw(v_id, ty::IntVarValue::IntType(v));
+            }
+            (ty::Int(v), ty::Infer(ty::IntVar(v_id))) => {
+                infcx.instantiate_int_var_raw(v_id, ty::IntVarValue::IntType(v));
+            }
+            (ty::Infer(ty::IntVar(v_id)), ty::Uint(v)) => {
+                infcx.instantiate_int_var_raw(v_id, ty::IntVarValue::UintType(v));
+            }
+            (ty::Uint(v), ty::Infer(ty::IntVar(v_id))) => {
+                infcx.instantiate_int_var_raw(v_id, ty::IntVarValue::UintType(v));
+            }
+
+            // Relate floating-point variables to other types
+            (ty::Infer(ty::FloatVar(a_id)), ty::Infer(ty::FloatVar(b_id))) => {
+                infcx.equate_float_vids_raw(a_id, b_id);
+            }
+            (ty::Infer(ty::FloatVar(v_id)), ty::Float(v)) => {
+                infcx.instantiate_float_var_raw(v_id, ty::FloatVarValue::Known(v));
+            }
+            (ty::Float(v), ty::Infer(ty::FloatVar(v_id))) => {
+                infcx.instantiate_float_var_raw(v_id, ty::FloatVarValue::Known(v));
+            }
+
+            (_, ty::Infer(ty::FreshTy(_) | ty::FreshIntTy(_) | ty::FreshFloatTy(_)))
+            | (ty::Infer(ty::FreshTy(_) | ty::FreshIntTy(_) | ty::FreshFloatTy(_)), _) => {
+                panic!("We do not expect to encounter `Fresh` variables in the new solver")
+            }
+
+            _ => {
+                relate::structurally_relate_tys(self, a, b)?;
+            }
+        }
+
+        Ok(a)
+    }
+
+    #[instrument(skip(self), level = "trace")]
+    fn regions(&mut self, a: I::Region, b: I::Region) -> RelateResult<I, I::Region> {
+        self.infcx.equate_regions(a, b, VisibleForLeakCheck::Yes, self.span);
+
+        Ok(a)
+    }
+
+    #[instrument(skip(self), level = "trace")]
+    fn consts(&mut self, a: I::Const, b: I::Const) -> RelateResult<I, I::Const> {
+        if a == b {
+            return Ok(a);
+        }
+
+        let infcx = self.infcx;
+        // FIXME: make this a debug_assert.
+        // Currently proof tree evaluation can unify infer vars in original
+        // vars while not resolving them.
+        // See `tests/ui/traits/next-solver/transmute-from-async-closure.rs`
+        let a = infcx.shallow_resolve_const(a);
+        debug_assert_eq!(b, infcx.shallow_resolve_const(b));
+        match (a.kind(), b.kind()) {
+            (
+                ty::ConstKind::Infer(ty::InferConst::Var(a_vid)),
+                ty::ConstKind::Infer(ty::InferConst::Var(b_vid)),
+            ) => {
+                infcx.equate_const_vids_raw(a_vid, b_vid);
+            }
+
+            (ty::ConstKind::Infer(ty::InferConst::Var(a_vid)), _) => {
+                infcx.instantiate_const_var_raw(a_vid, b);
+            }
+
+            (_, ty::ConstKind::Infer(ty::InferConst::Var(b_vid))) => {
+                infcx.instantiate_const_var_raw(b_vid, a);
+            }
+
+            _ => {
+                relate::structurally_relate_consts(self, a, b)?;
+            }
+        }
+
+        Ok(a)
+    }
+
+    fn binders<T>(
+        &mut self,
+        a: ty::Binder<I, T>,
+        b: ty::Binder<I, T>,
+    ) -> RelateResult<I, ty::Binder<I, T>>
+    where
+        T: Relate<I>,
+    {
+        if a == b {
+            return Ok(a);
+        }
+
+        debug_assert_eq!(a.bound_vars(), b.bound_vars());
+        self.relate(a.skip_binder(), b.skip_binder())?;
+
+        Ok(a)
+    }
+}
+
 /// Unify the `original_values` with the `var_values` returned by the canonical query..
 ///
 /// This assumes that this unification will always succeed. This is the case when
@@ -272,9 +468,8 @@ fn unify_query_var_values<D, I>(
     assert_eq!(original_values.len(), var_values.len());
 
     for (&orig, response) in iter::zip(original_values, var_values.var_values.iter()) {
-        let goals =
-            delegate.eq_structurally_relating_aliases(param_env, orig, response, span).unwrap();
-        assert!(goals.is_empty());
+        let mut must_eq = ResponseRelating::new(&**delegate, span);
+        must_eq.relate(orig, response).unwrap();
     }
 }
 

--- a/compiler/rustc_type_ir/src/infer_ctxt.rs
+++ b/compiler/rustc_type_ir/src/infer_ctxt.rs
@@ -427,7 +427,13 @@ pub trait InferCtxtLike: Sized {
     fn equate_float_vids_raw(&self, a: ty::FloatVid, b: ty::FloatVid);
     fn equate_const_vids_raw(&self, a: ty::ConstVid, b: ty::ConstVid);
 
-    fn instantiate_ty_var_raw<R: PredicateEmittingRelation<Self>>(
+    /// Use `instantiate_ty_var` instead unless you have reasons to skip
+    /// generalization.
+    fn instantiate_ty_var_raw(&self, vid: ty::TyVid, ty: <Self::Interner as Interner>::Ty);
+    /// Use `instantiate_const_var` instead unless you have reasons to skip
+    /// generalization.
+    fn instantiate_const_var_raw(&self, vid: ty::ConstVid, ct: <Self::Interner as Interner>::Const);
+    fn instantiate_ty_var<R: PredicateEmittingRelation<Self>>(
         &self,
         relation: &mut R,
         target_is_expected: bool,
@@ -437,7 +443,7 @@ pub trait InferCtxtLike: Sized {
     ) -> RelateResult<Self::Interner, ()>;
     fn instantiate_int_var_raw(&self, vid: ty::IntVid, value: ty::IntVarValue);
     fn instantiate_float_var_raw(&self, vid: ty::FloatVid, value: ty::FloatVarValue);
-    fn instantiate_const_var_raw<R: PredicateEmittingRelation<Self>>(
+    fn instantiate_const_var<R: PredicateEmittingRelation<Self>>(
         &self,
         relation: &mut R,
         target_is_expected: bool,

--- a/compiler/rustc_type_ir/src/relate.rs
+++ b/compiler/rustc_type_ir/src/relate.rs
@@ -14,18 +14,6 @@ pub mod solver_relating;
 
 pub type RelateResult<I, T> = Result<T, TypeError<I>>;
 
-/// Whether aliases should be related structurally or not. Used
-/// to adjust the behavior of generalization and combine.
-///
-/// This should always be `No` unless in a few special-cases when
-/// instantiating canonical responses and in the new solver. Each
-/// such case should have a comment explaining why it is used.
-#[derive(Debug, Copy, Clone)]
-pub enum StructurallyRelateAliases {
-    Yes,
-    No,
-}
-
 /// Extra information about why we ended up with a particular variance.
 /// This is only used to add more information to error messages, and
 /// has no effect on soundness. While choosing the 'wrong' `VarianceDiagInfo`

--- a/compiler/rustc_type_ir/src/relate/combine.rs
+++ b/compiler/rustc_type_ir/src/relate/combine.rs
@@ -3,8 +3,7 @@ use std::iter;
 use tracing::debug;
 
 use super::{
-    ExpectedFound, RelateResult, StructurallyRelateAliases, TypeRelation,
-    structurally_relate_consts, structurally_relate_tys,
+    ExpectedFound, RelateResult, TypeRelation, structurally_relate_consts, structurally_relate_tys,
 };
 use crate::error::TypeError;
 use crate::inherent::*;
@@ -22,11 +21,6 @@ where
     fn span(&self) -> I::Span;
 
     fn param_env(&self) -> I::ParamEnv;
-
-    /// Whether aliases should be related structurally. This is pretty much
-    /// always `No` unless you're equating in some specific locations of the
-    /// new solver. See the comments in these use-cases for more details.
-    fn structurally_relate_aliases(&self) -> StructurallyRelateAliases;
 
     /// Register obligations that must hold in order for this relation to hold
     fn register_goals(&mut self, obligations: impl IntoIterator<Item = Goal<I, I::Predicate>>);
@@ -115,8 +109,7 @@ where
         }
 
         (ty::Alias(ty::IsRigid::No, alias), _) | (_, ty::Alias(ty::IsRigid::No, alias))
-            if infcx.next_trait_solver()
-                && let StructurallyRelateAliases::No = relation.structurally_relate_aliases() =>
+            if infcx.next_trait_solver() =>
         {
             // If both sides are aliases, arbitrarily do the LHS first
             let terms_are_inverted = !matches!(a.kind(), ty::Alias(ty::IsRigid::No, _));
@@ -249,8 +242,7 @@ where
 
         (ty::ConstKind::Alias(ty::IsRigid::No, alias), _)
         | (_, ty::ConstKind::Alias(ty::IsRigid::No, alias))
-            if (infcx.cx().features().generic_const_exprs() || infcx.next_trait_solver())
-                && let StructurallyRelateAliases::No = relation.structurally_relate_aliases() =>
+            if (infcx.cx().features().generic_const_exprs() || infcx.next_trait_solver()) =>
         {
             if infcx.next_trait_solver() {
                 let other = if matches!(a.kind(), ty::ConstKind::Alias(..)) { b } else { a };

--- a/compiler/rustc_type_ir/src/relate/combine.rs
+++ b/compiler/rustc_type_ir/src/relate/combine.rs
@@ -238,12 +238,12 @@ where
         }
 
         (ty::ConstKind::Infer(ty::InferConst::Var(vid)), _) => {
-            infcx.instantiate_const_var_raw(relation, true, vid, b)?;
+            infcx.instantiate_const_var(relation, true, vid, b)?;
             Ok(b)
         }
 
         (_, ty::ConstKind::Infer(ty::InferConst::Var(vid))) => {
-            infcx.instantiate_const_var_raw(relation, false, vid, a)?;
+            infcx.instantiate_const_var(relation, false, vid, a)?;
             Ok(a)
         }
 

--- a/compiler/rustc_type_ir/src/relate/solver_relating.rs
+++ b/compiler/rustc_type_ir/src/relate/solver_relating.rs
@@ -19,17 +19,6 @@ pub trait RelateExt: InferCtxtLike {
         Vec<Goal<Self::Interner, <Self::Interner as Interner>::Predicate>>,
         TypeError<Self::Interner>,
     >;
-
-    fn eq_structurally_relating_aliases<T: Relate<Self::Interner>>(
-        &self,
-        param_env: <Self::Interner as Interner>::ParamEnv,
-        lhs: T,
-        rhs: T,
-        span: <Self::Interner as Interner>::Span,
-    ) -> Result<
-        Vec<Goal<Self::Interner, <Self::Interner as Interner>::Predicate>>,
-        TypeError<Self::Interner>,
-    >;
 }
 
 impl<Infcx: InferCtxtLike> RelateExt for Infcx {
@@ -44,29 +33,7 @@ impl<Infcx: InferCtxtLike> RelateExt for Infcx {
         Vec<Goal<Self::Interner, <Self::Interner as Interner>::Predicate>>,
         TypeError<Self::Interner>,
     > {
-        let mut relate =
-            SolverRelating::new(self, StructurallyRelateAliases::No, variance, param_env, span);
-        relate.relate(lhs, rhs)?;
-        Ok(relate.goals)
-    }
-
-    fn eq_structurally_relating_aliases<T: Relate<Self::Interner>>(
-        &self,
-        param_env: <Self::Interner as Interner>::ParamEnv,
-        lhs: T,
-        rhs: T,
-        span: <Self::Interner as Interner>::Span,
-    ) -> Result<
-        Vec<Goal<Self::Interner, <Self::Interner as Interner>::Predicate>>,
-        TypeError<Self::Interner>,
-    > {
-        let mut relate = SolverRelating::new(
-            self,
-            StructurallyRelateAliases::Yes,
-            ty::Invariant,
-            param_env,
-            span,
-        );
+        let mut relate = SolverRelating::new(self, variance, param_env, span);
         relate.relate(lhs, rhs)?;
         Ok(relate.goals)
     }
@@ -76,7 +43,6 @@ impl<Infcx: InferCtxtLike> RelateExt for Infcx {
 pub struct SolverRelating<'infcx, Infcx, I: Interner> {
     infcx: &'infcx Infcx,
     // Immutable fields.
-    structurally_relate_aliases: StructurallyRelateAliases,
     param_env: I::ParamEnv,
     span: I::Span,
     // Mutable fields.
@@ -114,14 +80,12 @@ where
 {
     pub fn new(
         infcx: &'infcx Infcx,
-        structurally_relate_aliases: StructurallyRelateAliases,
         ambient_variance: ty::Variance,
         param_env: I::ParamEnv,
         span: I::Span,
     ) -> Self {
         SolverRelating {
             infcx,
-            structurally_relate_aliases,
             span,
             ambient_variance,
             param_env,
@@ -364,10 +328,6 @@ where
 
     fn param_env(&self) -> I::ParamEnv {
         self.param_env
-    }
-
-    fn structurally_relate_aliases(&self) -> StructurallyRelateAliases {
-        self.structurally_relate_aliases
     }
 
     fn register_predicates(

--- a/compiler/rustc_type_ir/src/relate/solver_relating.rs
+++ b/compiler/rustc_type_ir/src/relate/solver_relating.rs
@@ -230,10 +230,10 @@ where
             }
 
             (ty::Infer(ty::TyVar(a_vid)), _) => {
-                infcx.instantiate_ty_var_raw(self, true, a_vid, self.ambient_variance, b)?;
+                infcx.instantiate_ty_var(self, true, a_vid, self.ambient_variance, b)?;
             }
             (_, ty::Infer(ty::TyVar(b_vid))) => {
-                infcx.instantiate_ty_var_raw(
+                infcx.instantiate_ty_var(
                     self,
                     false,
                     b_vid,

--- a/compiler/rustc_type_ir/src/universe.rs
+++ b/compiler/rustc_type_ir/src/universe.rs
@@ -1,5 +1,6 @@
 use tracing::{debug, instrument};
 
+use crate::data_structures::HashSet;
 use crate::inherent::*;
 use crate::visit::TypeVisitableExt;
 use crate::{
@@ -49,29 +50,40 @@ fn max_universe_inner<
     infcx: &Infcx,
     t: T,
 ) -> UniverseIndex {
-    if !MaxUniverse::<Infcx, VISIT_PLACEHOLDER, VISIT_INFER>::needs_visit(&t) {
+    if !MaxUniverse::<Infcx, I, VISIT_PLACEHOLDER, VISIT_INFER>::needs_visit(&t) {
         return UniverseIndex::ROOT;
     }
 
-    let mut visitor = MaxUniverse::<_, VISIT_PLACEHOLDER, VISIT_INFER>::new(infcx);
-    // FIXME: make this a debug_assert and let callers resolve vars if there's
-    // perf win here.
+    let mut visitor = MaxUniverse::<_, _, VISIT_PLACEHOLDER, VISIT_INFER>::new(infcx);
+    // FIXME: make this a debug_assert and let callers resolve vars. Then the input only needs to
+    // be `TypeVisitable`.
     let t = infcx.resolve_vars_if_possible(t);
     t.visit_with(&mut visitor);
     visitor.max_universe()
 }
 
-struct MaxUniverse<'a, Infcx: InferCtxtLike, const VISIT_PLACEHOLDER: bool, const VISIT_INFER: bool>
-{
+struct MaxUniverse<
+    'a,
+    Infcx: InferCtxtLike<Interner = I>,
+    I: Interner,
+    const VISIT_PLACEHOLDER: bool,
+    const VISIT_INFER: bool,
+> {
     max_universe: UniverseIndex,
     infcx: &'a Infcx,
+    cache: HashSet<I::Ty>,
 }
 
-impl<'a, Infcx: InferCtxtLike, const VISIT_PLACEHOLDER: bool, const VISIT_INFER: bool>
-    MaxUniverse<'a, Infcx, VISIT_PLACEHOLDER, VISIT_INFER>
+impl<
+    'a,
+    Infcx: InferCtxtLike<Interner = I>,
+    I: Interner,
+    const VISIT_PLACEHOLDER: bool,
+    const VISIT_INFER: bool,
+> MaxUniverse<'a, Infcx, I, VISIT_PLACEHOLDER, VISIT_INFER>
 {
     fn new(infcx: &'a Infcx) -> Self {
-        MaxUniverse { infcx, max_universe: UniverseIndex::ROOT }
+        MaxUniverse { infcx, max_universe: UniverseIndex::ROOT, cache: Default::default() }
     }
 
     fn max_universe(self) -> UniverseIndex {
@@ -79,7 +91,7 @@ impl<'a, Infcx: InferCtxtLike, const VISIT_PLACEHOLDER: bool, const VISIT_INFER:
     }
 
     #[instrument(ret, level = "debug")]
-    fn needs_visit<T: TypeVisitable<I>, I: Interner>(t: &T) -> bool {
+    fn needs_visit<T: TypeVisitable<I>>(t: &T) -> bool {
         (VISIT_PLACEHOLDER && t.has_placeholders()) || (VISIT_INFER && t.has_infer())
     }
 }
@@ -90,12 +102,16 @@ impl<
     I: Interner,
     const VISIT_PLACEHOLDER: bool,
     const VISIT_INFER: bool,
-> TypeVisitor<I> for MaxUniverse<'a, Infcx, VISIT_PLACEHOLDER, VISIT_INFER>
+> TypeVisitor<I> for MaxUniverse<'a, Infcx, I, VISIT_PLACEHOLDER, VISIT_INFER>
 {
     type Result = ();
 
     fn visit_ty(&mut self, t: I::Ty) {
         if !Self::needs_visit(&t) {
+            return;
+        }
+
+        if self.cache.contains(&t) {
             return;
         }
 
@@ -110,6 +126,8 @@ impl<
             }
             _ => t.super_visit_with(self),
         }
+
+        assert!(self.cache.insert(t), "we shouldn't visit {t:?} twice");
     }
 
     fn visit_const(&mut self, c: I::Const) {


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/158731)*
<!-- homu-ignore:end -->

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
Part of rust-lang/rust#155345

Finally we can get rid of the last use of `StructurallyRelateAliases::Yes`.

r? lcnr