### PR TITLE
std: make remove_dir_all() fix up directory permissions on EACCES

### DIFF
--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -3159,6 +3159,12 @@ pub fn remove_dir<P: AsRef<Path>>(path: P) -> io::Result<()> {
 /// - "Windows": This function currently corresponds to `CreateFileW`,
 /// `GetFileInformationByHandleEx`, `SetFileInformationByHandle`, and `NtCreateFile`.
 ///
+/// On Unix-family platforms, if removing an entry fails due to missing permissions on a
+/// directory that is itself part of the tree being removed, this function currently tries to
+/// add the owner read, write and search permission bits to that directory (as if by
+/// `chmod u+rwx`) and retries, provided the directory is owned by the caller's effective user
+/// ID. This mirrors Windows, where files are removed regardless of their read-only attribute.
+///
 /// ## Time-of-check to time-of-use (TOCTOU) race conditions
 /// See the [module-level TOCTOU explanation](self#time-of-check-to-time-of-use-toctou).
 ///

--- a/library/std/src/fs/tests.rs
+++ b/library/std/src/fs/tests.rs
@@ -931,6 +931,48 @@ fn recursive_rmdir_of_symlink() {
 }
 
 #[test]
+// The fallback implementation used on these targets does not attempt to fix up permissions,
+// and neither does the stubbed-out fixup on l4re and nuttx.
+#[cfg(all(
+    unix,
+    not(any(
+        target_os = "espidf",
+        target_os = "horizon",
+        target_os = "l4re",
+        target_os = "nto",
+        target_os = "nuttx",
+        target_os = "qnx",
+        target_os = "redox",
+        target_os = "vita",
+        target_os = "vxworks",
+        target_os = "emscripten",
+    ))
+))]
+#[cfg_attr(miri, ignore = "Miri uses the fallback implementation, which does not fix permissions")]
+fn recursive_rmdir_inaccessible_dirs() {
+    use crate::os::unix::fs::PermissionsExt;
+
+    // Removing a tree containing directories that lack owner permissions should succeed by
+    // temporarily adding the missing permission bits, like `rm -rf` combined with `chmod`.
+    // (When running as root the permissions never get in the way, which keeps this test valid.)
+    let tmpdir = tmpdir();
+    let root = tmpdir.join("root");
+    let readonly = root.join("readonly");
+    let inaccessible = root.join("inaccessible");
+    check!(fs::create_dir_all(&readonly));
+    check!(check!(File::create(readonly.join("file"))).write(b"foo"));
+    check!(fs::create_dir(&inaccessible));
+    check!(check!(File::create(inaccessible.join("file"))).write(b"foo"));
+    // Unlinking readonly/file requires write permission on the readonly directory.
+    check!(fs::set_permissions(&readonly, fs::Permissions::from_mode(0o555)));
+    // Recursing into inaccessible requires read and search permission on it.
+    check!(fs::set_permissions(&inaccessible, fs::Permissions::from_mode(0)));
+
+    check!(fs::remove_dir_all(&root));
+    assert!(!root.exists());
+}
+
+#[test]
 fn recursive_rmdir_of_file_fails() {
     // test we do not delete a directly specified file.
     let tmpdir = tmpdir();

--- a/library/std/src/sys/fs/unix.rs
+++ b/library/std/src/sys/fs/unix.rs
@@ -2475,6 +2475,153 @@ mod remove_dir_impl {
         Ok(unsafe { OwnedFd::from_raw_fd(fd) })
     }
 
+    // Helpers to recover from EACCES by adding the owner permission bits to
+    // directories that are scheduled for deletion anyway, so that a tree
+    // containing e.g. read-only directories can still be deleted by its owner.
+    // Only directories owned by the caller's effective user ID are modified,
+    // and the mode is restored if the retried operation still fails.
+    #[cfg(not(any(target_os = "l4re", target_os = "nuttx", target_os = "wasi")))]
+    mod chmod_harder {
+        #[cfg(not(any(
+            all(target_os = "linux", not(target_env = "musl")),
+            target_os = "hurd"
+        )))]
+        use libc::fstatat as fstatat64;
+        #[cfg(any(all(target_os = "linux", not(target_env = "musl")), target_os = "hurd"))]
+        use libc::fstatat64;
+        use libc::mode_t;
+
+        use super::super::{fstat64, stat64};
+        use super::RawFd;
+        use crate::ffi::CStr;
+        use crate::mem;
+
+        // Returns the old and the new mode with the owner read/write/search
+        // bits added, if adding them could make an EACCES failure go away.
+        fn patched_mode(st: &stat64) -> Option<(mode_t, mode_t)> {
+            let mode = st.st_mode as mode_t;
+            if mode & libc::S_IFMT != libc::S_IFDIR
+                || mode & 0o700 == 0o700
+                || st.st_uid != unsafe { libc::geteuid() }
+            {
+                return None;
+            }
+            Some((mode & 0o7777, (mode | 0o700) & 0o7777))
+        }
+
+        // Returns the old mode on success.
+        pub(super) fn add_owner_rwx(fd: RawFd) -> Option<mode_t> {
+            unsafe {
+                let mut st: stat64 = mem::zeroed();
+                if fstat64(fd, &mut st) < 0 {
+                    return None;
+                }
+                let (old_mode, new_mode) = patched_mode(&st)?;
+                if libc::fchmod(fd, new_mode) < 0 { None } else { Some(old_mode) }
+            }
+        }
+
+        pub(super) fn restore_mode(fd: RawFd, mode: mode_t) {
+            unsafe { libc::fchmod(fd, mode) };
+        }
+
+        // Returns the old mode on success.
+        pub(super) fn add_owner_rwx_at(parent_fd: Option<RawFd>, path: &CStr) -> Option<mode_t> {
+            unsafe {
+                let dirfd = parent_fd.unwrap_or(libc::AT_FDCWD);
+                let mut st: stat64 = mem::zeroed();
+                if fstatat64(dirfd, path.as_ptr(), &mut st, libc::AT_SYMLINK_NOFOLLOW) < 0 {
+                    return None;
+                }
+                let (old_mode, new_mode) = patched_mode(&st)?;
+                // AT_SYMLINK_NOFOLLOW ensures we cannot be tricked into changing the mode of a
+                // directory elsewhere through a concurrently swapped-in symlink. Platforms that
+                // do not support the flag for fchmodat() fail, keeping the original error.
+                if libc::fchmodat(dirfd, path.as_ptr(), new_mode, libc::AT_SYMLINK_NOFOLLOW) < 0 {
+                    return None;
+                }
+                Some(old_mode)
+            }
+        }
+
+        pub(super) fn restore_mode_at(parent_fd: Option<RawFd>, path: &CStr, mode: mode_t) {
+            unsafe {
+                libc::fchmodat(
+                    parent_fd.unwrap_or(libc::AT_FDCWD),
+                    path.as_ptr(),
+                    mode,
+                    libc::AT_SYMLINK_NOFOLLOW,
+                );
+            }
+        }
+    }
+
+    // No permission fixups on platforms without a UNIX permission model (WASI)
+    // or without the required libc functions (l4re, NuttX).
+    #[cfg(any(target_os = "l4re", target_os = "nuttx", target_os = "wasi"))]
+    mod chmod_harder {
+        use libc::mode_t;
+
+        use super::RawFd;
+        use crate::ffi::CStr;
+
+        pub(super) fn add_owner_rwx(_fd: RawFd) -> Option<mode_t> {
+            None
+        }
+
+        pub(super) fn restore_mode(_fd: RawFd, _mode: mode_t) {}
+
+        pub(super) fn add_owner_rwx_at(_parent_fd: Option<RawFd>, _path: &CStr) -> Option<mode_t> {
+            None
+        }
+
+        pub(super) fn restore_mode_at(_parent_fd: Option<RawFd>, _path: &CStr, _mode: mode_t) {}
+    }
+
+    // Like unlinkat(), but on EACCES tries adding the owner permission bits to
+    // the parent directory and retries. The parent's mode is not restored on
+    // success: it is scheduled for deletion itself, and further entries may
+    // need the added permission bits as well.
+    fn unlinkat_harder(parent_fd: RawFd, path: &CStr, flags: libc::c_int) -> io::Result<()> {
+        match cvt(unsafe { unlinkat(parent_fd, path.as_ptr(), flags) }) {
+            Err(err) if err.raw_os_error() == Some(libc::EACCES) => {
+                let Some(old_mode) = chmod_harder::add_owner_rwx(parent_fd) else {
+                    return Err(err);
+                };
+                cvt(unsafe { unlinkat(parent_fd, path.as_ptr(), flags) })
+                    .map(drop)
+                    .inspect_err(|_| chmod_harder::restore_mode(parent_fd, old_mode))
+            }
+            result => result.map(drop),
+        }
+    }
+
+    // Like openat_nofollow_dironly(), but on EACCES tries adding the owner
+    // permission bits to the parent directory (needed to resolve `path`) as
+    // well as the directory itself (needed to list and remove its entries)
+    // and retries.
+    fn openat_nofollow_dironly_harder(
+        parent_fd: Option<RawFd>,
+        path: &CStr,
+    ) -> io::Result<OwnedFd> {
+        match openat_nofollow_dironly(parent_fd, path) {
+            Err(err) if err.raw_os_error() == Some(libc::EACCES) => {
+                let parent_patched = parent_fd
+                    .is_some_and(|parent_fd| chmod_harder::add_owner_rwx(parent_fd).is_some());
+                let old_mode = chmod_harder::add_owner_rwx_at(parent_fd, path);
+                if !parent_patched && old_mode.is_none() {
+                    return Err(err);
+                }
+                openat_nofollow_dironly(parent_fd, path).inspect_err(|_| {
+                    if let Some(old_mode) = old_mode {
+                        chmod_harder::restore_mode_at(parent_fd, path, old_mode);
+                    }
+                })
+            }
+            result => result,
+        }
+    }
+
     fn fdreaddir(dir_fd: OwnedFd) -> io::Result<(ReadDir, RawFd)> {
         let ptr = unsafe { fdopendir(dir_fd.as_raw_fd()) };
         if ptr.is_null() {
@@ -2528,15 +2675,13 @@ mod remove_dir_impl {
 
     fn remove_dir_all_recursive(parent_fd: Option<RawFd>, path: &CStr) -> io::Result<()> {
         // try opening as directory
-        let fd = match openat_nofollow_dironly(parent_fd, &path) {
+        let fd = match openat_nofollow_dironly_harder(parent_fd, &path) {
             Err(err) if matches!(err.raw_os_error(), Some(libc::ENOTDIR | libc::ELOOP)) => {
                 // not a directory - don't traverse further
                 // (for symlinks, older Linux kernels may return ELOOP instead of ENOTDIR)
                 return match parent_fd {
                     // unlink...
-                    Some(parent_fd) => {
-                        cvt(unsafe { unlinkat(parent_fd, path.as_ptr(), 0) }).map(drop)
-                    }
+                    Some(parent_fd) => unlinkat_harder(parent_fd, path, 0),
                     // ...unless this was supposed to be the deletion root directory
                     None => Err(err),
                 };
@@ -2568,7 +2713,7 @@ mod remove_dir_impl {
                         remove_dir_all_recursive(Some(fd), child_name)?;
                     }
                     Some(false) => {
-                        cvt(unsafe { unlinkat(fd, child_name.as_ptr(), 0) })?;
+                        unlinkat_harder(fd, child_name, 0)?;
                     }
                     None => {
                         // POSIX specifies that calling unlink()/unlinkat(..., 0) on a directory can succeed
@@ -2585,9 +2730,14 @@ mod remove_dir_impl {
         }
 
         // unlink the directory after removing its contents
-        ignore_notfound(cvt(unsafe {
-            unlinkat(parent_fd.unwrap_or(libc::AT_FDCWD), path.as_ptr(), libc::AT_REMOVEDIR)
-        }))?;
+        ignore_notfound(match parent_fd {
+            // The parent directory is scheduled for deletion too, so its
+            // permissions may be fixed up to make the unlink succeed...
+            Some(parent_fd) => unlinkat_harder(parent_fd, path, libc::AT_REMOVEDIR),
+            // ...but the parent of the deletion root is not ours to modify.
+            None => cvt(unsafe { unlinkat(libc::AT_FDCWD, path.as_ptr(), libc::AT_REMOVEDIR) })
+                .map(drop),
+        })?;
         Ok(())
     }
 


### PR DESCRIPTION
Removing a directory entry requires write and search permission on the containing directory, and recursing into a directory requires read and search permission on it. A tree containing directories without these permissions could previously only be deleted by first running the equivalent of chmod -R u+rwx on it, even though its owner may unlink it.

On Unix, when unlinkat() or openat() fail with EACCES during remove_dir_all(), try adding the owner read/write/search bits to the affected directory and retry. The mode is only changed for directories owned by the caller's effective user ID (chmod would fail otherwise anyway), only for directories that are themselves scheduled for deletion, and is restored if the retried operation still fails. The chmod is performed either through an already-open file descriptor or with fchmodat(AT_SYMLINK_NOFOLLOW) so that a concurrently swapped-in symlink cannot redirect it to a directory outside the tree.

This also brings the Unix behavior closer to Windows, where files are deleted regardless of their read-only attribute.

WASI, l4re and NuttX keep the old behavior since they lack the required libc functions.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
