### PR TITLE
Simplify `Option::into_flat_iter` signature

### DIFF
--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -2082,10 +2082,7 @@ impl<T: IntoIterator> Option<T> {
     /// assert_eq!(o2.into_flat_iter().collect::<Vec<_>>(), Vec::<&usize>::new());
     /// ```
     #[unstable(feature = "option_into_flat_iter", issue = "148441")]
-    pub fn into_flat_iter<A>(self) -> OptionFlatten<A>
-    where
-        T: IntoIterator<IntoIter = A>,
-    {
+    pub fn into_flat_iter(self) -> OptionFlatten<T::IntoIter> {
         OptionFlatten { iter: self.map(IntoIterator::into_iter) }
     }
 }


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
```diff
impl<T: IntoIterator> Option<T> {
-    pub fn into_flat_iter<A>(self) -> OptionFlatten<A>
-    where
-        T: IntoIterator<IntoIter = A>,
+    pub fn into_flat_iter(self) -> OptionFlatten<T::IntoIter> {
}
```

This is marked as an unresolved question (https://github.com/rust-lang/rust/issues/148441, https://github.com/rust-lang/rust/pull/148487#discussion_r2594634438), but I cannot come up with any reason to have this generic.