### PR TITLE
 Enable thread_local for OpenHarmony

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/linker.rs
+++ b/compiler/rustc_codegen_ssa/src/back/linker.rs
@@ -18,7 +18,9 @@ use rustc_middle::middle::exported_symbols::{
 use rustc_middle::ty::{SymbolName, TyCtxt};
 use rustc_session::Session;
 use rustc_session::config::{self, CrateType, DebugInfo, LinkerPluginLto, Lto, OptLevel, Strip};
-use rustc_target::spec::{Arch, Cc, CfgAbi, LinkOutputKind, LinkerFlavor, Lld, Os};
+use rustc_target::spec::{
+    Arch, BinaryFormat, Cc, CfgAbi, LinkOutputKind, LinkerFlavor, Lld, Os, TlsModel,
+};
 use tracing::{debug, warn};
 
 use super::command::Command;
@@ -874,6 +876,17 @@ impl<'a> Linker for GccLinker<'a> {
                     for sym in symbols {
                         debug!("    {};", sym.name);
                         writeln!(f, "    {};", sym.name)?;
+                    }
+                    // Cygwin don't need this as PE/Coff don't have weak symbols
+                    if self.sess.target.tls_model == TlsModel::Emulated
+                        && self.sess.target.binary_format == BinaryFormat::Elf
+                    {
+                        let has_tls = symbols.iter().any(|s| s.kind == SymbolExportKind::Tls);
+                        if has_tls {
+                            // use `*` wildcard to avoid error with `--no-undefined-version`
+                            debug!("    __emutls_get_address*;");
+                            writeln!(f, "    __emutls_get_address*;")?;
+                        }
                     }
                 }
                 writeln!(f, "\n  local:\n    *;\n}};")?;

--- a/compiler/rustc_target/src/spec/base/linux_ohos.rs
+++ b/compiler/rustc_target/src/spec/base/linux_ohos.rs
@@ -5,7 +5,7 @@ pub(crate) fn opts() -> TargetOptions {
         env: Env::Ohos,
         crt_static_default: false,
         tls_model: TlsModel::Emulated,
-        has_thread_local: false,
+        has_thread_local: true,
         ..base::linux::opts()
     }
 }


### PR DESCRIPTION
I have run ui test on OpenHarmony 6.1.1 (HarmonyOS 6.1.0.130 SP15) and no regression was found.

A small performance test shows some improvement:

```rust
const ITERATIONS: usize = 10_000_000;

thread_local! {
    static TLS_CELL: Cell<usize> = Cell::new(0);
}

fn main() {
    for _ in 0..ITERATIONS {
        TLS_CELL.with(|cell| {
            let v = cell.get();
            cell.set(v + 1);
            black_box(v);
        });
    }
}
```

* Old: 407.5ms
* New: 366.5ms

This also fix potential `fatal runtime error: out of TLS keys, aborting` issues