### PR TITLE
rustdoc: Fix crash when trying to inline foreign item which cannot have attributes

### DIFF
--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -681,21 +681,26 @@ fn build_module(
 // We are only interested into `Res::Def`. And in there, we only want "items" which get their own
 //  rustdoc page. So not `DefKind::Ctor` for example (which is returned by `tcx.module_children()`).
 fn should_ignore_res(res: Res) -> bool {
+    !matches!(res, Res::Def(def_kind, _) if !should_ignore_def_kind(def_kind))
+}
+
+fn should_ignore_def_kind(kind: DefKind) -> bool {
     !matches!(
-        res,
-        Res::Def(DefKind::Trait, _)
-            | Res::Def(DefKind::TraitAlias, _)
-            | Res::Def(DefKind::Fn, _)
-            | Res::Def(DefKind::Struct, _)
-            | Res::Def(DefKind::Union, _)
-            | Res::Def(DefKind::TyAlias, _)
-            | Res::Def(DefKind::Enum, _)
-            | Res::Def(DefKind::ForeignTy, _)
-            | Res::Def(DefKind::Variant, _)
-            | Res::Def(DefKind::Mod, _)
-            | Res::Def(DefKind::Static { .. }, _)
-            | Res::Def(DefKind::Const { .. }, _)
-            | Res::Def(DefKind::Macro(_), _)
+        kind,
+        DefKind::Trait
+            | DefKind::TraitAlias
+            | DefKind::Fn
+            | DefKind::Struct
+            | DefKind::Union
+            | DefKind::TyAlias
+            | DefKind::Enum
+            | DefKind::ForeignTy
+            | DefKind::Variant
+            | DefKind::Mod
+            | DefKind::Static { .. }
+            | DefKind::Const { .. }
+            | DefKind::Macro(_)
+            | DefKind::Use
     )
 }
 
@@ -770,13 +775,15 @@ fn build_module_items(
         } else if let Some(def_id) = res.opt_def_id()
             && let Some(reexport) = item.reexport_chain.first()
             && let Some(reexport_def_id) = reexport.id()
+            && !should_ignore_def_kind(cx.tcx.def_kind(reexport_def_id))
             && find_attr!(
                 load_attrs(cx.tcx, reexport_def_id),
                 Doc(d)
                 if d.inline.first().is_some_and(|(inline, _)| *inline == hir::attrs::DocInline::NoInline)
             )
         {
-            if should_ignore_res(res) {
+            // We don't inline foreign `use`.
+            if should_ignore_res(res) || matches!(res, Res::Def(DefKind::Use, _)) {
                 continue;
             }
             // This item is reexported as `no_inline` so it shouldn't be inlined.

--- a/tests/rustdoc-html/reexport/auxiliary/glob-import.rs
+++ b/tests/rustdoc-html/reexport/auxiliary/glob-import.rs
@@ -1,0 +1,1 @@
+pub extern crate std as wgc;

--- a/tests/rustdoc-html/reexport/glob-import.rs
+++ b/tests/rustdoc-html/reexport/glob-import.rs
@@ -1,0 +1,17 @@
+// This test ensures that inlining a foreign crate through a glob import doesn't
+// panic (because we're trying to retrieve attributes from an item which doesn't
+// have attributes).
+// Regression test for <https://github.com/rust-lang/rust/issues/158686>.
+
+//@ aux-build: glob-import.rs
+
+#![crate_name = "foo"]
+
+extern crate glob_import;
+
+//@ has 'foo/index.html'
+// There should be only one item listed: `wgc` (the only `glob-import` dep public item).
+//@ count - '//*[@id="main-content"]/h2[@class="section-header"]' 1
+//@ count - '//*[@id="main-content"]/dl[@class="item-table"]/dt' 1
+
+pub use glob_import::*;


### PR DESCRIPTION
Fixes rust-lang/rust#158686.

Problem was that there was no filtering made on the `reexport_chain` items before we tried to query its attributes. And if it's an item which cannot have attributes, it crashed.

r? @Urgau 