### PR TITLE
Tell stacker about the correct initial stack size

### DIFF
--- a/compiler/rustc_data_structures/src/stack.rs
+++ b/compiler/rustc_data_structures/src/stack.rs
@@ -1,15 +1,16 @@
+use std::sync::OnceLock;
+
 // This is the amount of bytes that need to be left on the stack before increasing the size.
 // It must be at least as large as the stack required by any code that does not call
 // `ensure_sufficient_stack`.
 const RED_ZONE: usize = 100 * 1024; // 100k
 
-// Only the first stack that is pushed, grows exponentially (2^n * STACK_PER_RECURSION) from then
-// on. This flag has performance relevant characteristics. Don't set it too high.
-#[cfg(not(target_os = "aix"))]
-const STACK_PER_RECURSION: usize = 1024 * 1024; // 1MB
-// LLVM for AIX doesn't feature TCO, increase recursion size for workaround.
-#[cfg(target_os = "aix")]
-const STACK_PER_RECURSION: usize = 16 * 1024 * 1024; // 16MB
+// The initial stack size, stacker will double the size of the stack starting from this value.
+// If stacker doesn't support the platform and this value is less than the actual stack size,
+// stacker can actually shrink the stack.
+// STACK_SIZE is initialized in rustc_interface, based on RUST_MIN_STACK.
+pub static STACK_SIZE: OnceLock<usize> = OnceLock::new();
+pub const DEFAULT_STACK_SIZE: usize = 8 * 1024 * 1024;
 
 /// Grows the stack on demand to prevent stack overflow. Call this in strategic locations
 /// to "break up" recursive calls. E.g. almost any call to `visit_expr` or equivalent can benefit
@@ -18,5 +19,6 @@ const STACK_PER_RECURSION: usize = 16 * 1024 * 1024; // 16MB
 /// Should not be sprinkled around carelessly, as it causes a little bit of overhead.
 #[inline]
 pub fn ensure_sufficient_stack<R>(f: impl FnOnce() -> R) -> R {
-    stacker::maybe_grow(RED_ZONE, STACK_PER_RECURSION, f)
+    let initial_stack_size = STACK_SIZE.get().copied().unwrap_or(DEFAULT_STACK_SIZE);
+    stacker::maybe_grow(RED_ZONE, initial_stack_size, f)
 }

--- a/compiler/rustc_interface/src/util.rs
+++ b/compiler/rustc_interface/src/util.rs
@@ -102,8 +102,7 @@ pub(crate) fn check_abi_required_features(sess: &Session) {
     }
 }
 
-pub static STACK_SIZE: OnceLock<usize> = OnceLock::new();
-pub const DEFAULT_STACK_SIZE: usize = 8 * 1024 * 1024;
+pub use rustc_data_structures::stack::{DEFAULT_STACK_SIZE, STACK_SIZE};
 
 fn init_stack_size(early_dcx: &EarlyDiagCtxt) -> usize {
     // Obey the environment setting or default


### PR DESCRIPTION
I've been debugging https://github.com/rust-lang/rust/issues/138889, and I think this is a fix.

Android is not supported by `stacker`. So it ends up in the fallback case, where `stacker` cannot determine what the initial stack size is. So the first call to `stacker::maybe_grow` allocates a stack of the passed-in size. On Android, this would immediately shrink the initial stack size from 8 MB from 1 MB, and then we blow the (now much smaller) stack with recursive calls.

I think the problem in the compiler is that we should never pass `stacker::maybe_grow` a stack size that is smaller than the current stack, so I've moved code around so that the `STACK_SIZE` static that we set when the compiler is initialized in `rustc_interface` can be shared by `rustc_data_structures`.

---

I think the `cfg(aix)` was added in https://github.com/rust-lang/rust/pull/131116 to fix the same problem, so it shouldn't be required anymore. `target_os = "aix"` is also unsupported by `stacker`.