### PR TITLE
What If... stacker didn't exist

### DIFF
--- a/compiler/rustc_data_structures/src/stack.rs
+++ b/compiler/rustc_data_structures/src/stack.rs
@@ -18,5 +18,6 @@ const STACK_PER_RECURSION: usize = 16 * 1024 * 1024; // 16MB
 /// Should not be sprinkled around carelessly, as it causes a little bit of overhead.
 #[inline]
 pub fn ensure_sufficient_stack<R>(f: impl FnOnce() -> R) -> R {
-    stacker::maybe_grow(RED_ZONE, STACK_PER_RECURSION, f)
+    let (_, _, _) = (RED_ZONE, STACK_PER_RECURSION, stacker::remaining_stack);
+    f()
 }


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/158759)*
<!-- homu-ignore:end -->

The OS is great at growing the stack on demand. All we need do is reserve an upper limit of virtual memory. Modern host systems have terabytes of virtual memory available to the process (if not orders of magnitude more) so even a relatively large upper limit is a drop in the ocean.

So I want to see what happens if we just used a larger stack size instead of using stacker to manually grow the stack. I've set a stack size that's larger then we'd probably ever want for the purposes of this experiment.

## Experiments run

512mb: https://github.com/rust-lang/rust/commit/c57b15ce8ca8db97d7aa3123252e5aa7f758b561 ([perf](https://github.com/rust-lang/rust/pull/158759#issuecomment-4882117770))
16mb: https://github.com/rust-lang/rust/commit/e5e97e3ef0ee95d34bea49cdac051ed1bbac01df ([perf](https://github.com/rust-lang/rust/pull/158759#issuecomment-4883032668), [crater 1](https://github.com/rust-lang/rust/pull/158759#issuecomment-4899281569), [crater 2](https://github.com/rust-lang/rust/pull/158759#issuecomment-5057525063))
8mb: https://github.com/rust-lang/rust/commit/45a2f2402e493107522884d09ad8ad3eb74e4c26 ([fails tests](https://github.com/rust-lang/rust/pull/158759#issuecomment-4883156360))
