### PR TITLE
Clarify that `LocalKey::try_with` may return `AccessError`

### DIFF
--- a/library/std/src/thread/local.rs
+++ b/library/std/src/thread/local.rs
@@ -434,7 +434,7 @@ impl<T: 'static> LocalKey<T> {
     ///
     /// This will lazily initialize the value if this thread has not referenced
     /// this key yet. If the key has been destroyed (which may happen if this is called
-    /// in a destructor), this function will return an [`AccessError`].
+    /// in a destructor), this function may return an [`AccessError`].
     ///
     /// # Panics
     ///


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

The docs for `LocalKey::try_with` state that the function *will* return an `AccessError` when the key has been destroyed. That's not actually guaranteed:

- `LocalKey::with` uses `try_with` internally and its docs explicitly acknowledge that it does not always panic when the destructor has run. If `try_with` really did detect every destroyed thread-local, `with` could always panic.
- The top-level `LocalKey` docs already note: "On all platforms it's possible for TLS to re-initialize other TLS slots during destruction."

Change *will* to *may* to accurately reflect the best-effort nature of the destroyed-key check.

Closes rust-lang/rust#157889

@rustbot label +A-docs