### PR TITLE
Fix ICE on non-ident path in `doc(auto_cfg values)`

### DIFF
--- a/compiler/rustc_attr_parsing/src/attributes/doc.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/doc.rs
@@ -348,8 +348,11 @@ impl DocParser {
                 // If it's a list, then only `any()` and `none()` are allowed and they must not
                 // contain any item.
                 MetaItemOrLitParser::MetaItemParser(sub_item) => {
-                    if let Some(ident) = sub_item.ident()
-                        && [sym::any, sym::none].contains(&ident.name)
+                    let Some(ident) = sub_item.ident() else {
+                        cx.adcx().expected_identifier(sub_item.path().span());
+                        continue;
+                    };
+                    if [sym::any, sym::none].contains(&ident.name)
                         && let ArgParser::List(list) = sub_item.args()
                         && list.mixed().count() == 0
                     {
@@ -371,9 +374,7 @@ impl DocParser {
                     } else {
                         cx.emit_lint(
                             rustc_session::lint::builtin::INVALID_DOC_ATTRIBUTES,
-                            DocAutoCfgHideShowUnexpectedItem {
-                                attr_name: sub_item.ident().unwrap().name,
-                            },
+                            DocAutoCfgHideShowUnexpectedItem { attr_name: ident.name },
                             sub_item.span(),
                         );
                     }

--- a/tests/rustdoc-ui/doc-auto-cfg-values-non-ident.rs
+++ b/tests/rustdoc-ui/doc-auto-cfg-values-non-ident.rs
@@ -1,0 +1,7 @@
+// Regression test for https://github.com/rust-lang/rust/issues/158744.
+
+#![feature(doc_cfg)]
+
+#[doc(auto_cfg(hide(a, values(::b))))]
+//~^ ERROR malformed `doc` attribute input
+fn f() {}

--- a/tests/rustdoc-ui/doc-auto-cfg-values-non-ident.stderr
+++ b/tests/rustdoc-ui/doc-auto-cfg-values-non-ident.stderr
@@ -1,0 +1,11 @@
+error[E0565]: malformed `doc` attribute input
+  --> $DIR/doc-auto-cfg-values-non-ident.rs:5:1
+   |
+LL | #[doc(auto_cfg(hide(a, values(::b))))]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---^^^^^
+   |                               |
+   |                               expected a valid identifier here
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0565`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Fixes rust-lang/rust#158744

`#[doc(auto_cfg(hide(a, values(::b))))]` could ICE while parsing `values(...)` because the malformed nested meta item did not have a single identifier, but the error path still called `unwrap()` on `sub_item.ident()`.