### PR TITLE
merge DefKind::InlineConst into AnonConst

### DIFF
--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -2916,7 +2916,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 // Do not use lower_anon_const_to_const_arg, as that attempts to represent the body
                 // directly. Instead, force an anon const.
                 let def_id = self.local_def_id(anon_const.id);
-                assert_eq!(DefKind::InlineConst, self.tcx.def_kind(def_id));
+                assert_eq!(DefKind::AnonConst, self.tcx.def_kind(def_id));
                 let lowered_anon = self.lower_anon_const_to_anon_const(anon_const, span);
                 ConstArg {
                     hir_id: self.lower_node_id(node_id),

--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -1709,7 +1709,9 @@ impl<'a, 'tcx> Visitor<'tcx> for TypeChecker<'a, 'tcx> {
                 if uv.promoted.is_none() {
                     let tcx = self.tcx();
                     let def_id = uv.def;
-                    if tcx.def_kind(def_id) == DefKind::InlineConst {
+                    if tcx.def_kind(def_id) == DefKind::AnonConst
+                        && tcx.anon_const_kind(def_id) == ty::AnonConstKind::NonTypeSystemInline
+                    {
                         let def_id = def_id.expect_local();
                         let predicates = self.prove_closure_bounds(tcx, def_id, uv.args, location);
                         self.normalize_and_prove_instantiated_predicates(
@@ -2653,7 +2655,11 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
                 // length as the `typeck_root_args`.
                 &args[..typeck_root_args.len()]
             }
-            DefKind::InlineConst => args.as_inline_const().parent_args(),
+            DefKind::AnonConst
+                if tcx.anon_const_kind(def_id) == ty::AnonConstKind::NonTypeSystemInline =>
+            {
+                args.as_inline_const().parent_args()
+            }
             other => bug!("unexpected item {:?}", other),
         };
         let parent_args = tcx.mk_args(parent_args);

--- a/compiler/rustc_borrowck/src/universal_regions.rs
+++ b/compiler/rustc_borrowck/src/universal_regions.rs
@@ -615,7 +615,10 @@ impl<'cx, 'tcx> UniversalRegionsBuilder<'cx, 'tcx> {
 
             BodyOwnerKind::Const { .. } | BodyOwnerKind::Static(..) => {
                 match tcx.def_kind(self.mir_def) {
-                    DefKind::InlineConst if !tcx.is_type_system_inline_const(self.mir_def) => {
+                    DefKind::AnonConst
+                        if tcx.anon_const_kind(self.mir_def)
+                            == ty::AnonConstKind::NonTypeSystemInline =>
+                    {
                         // This is required for `AscribeUserType` canonical query, which will call
                         // `type_of(inline_const_def_id)`. That `type_of` would inject erased lifetimes
                         // into borrowck, which is ICE #78174.

--- a/compiler/rustc_const_eval/src/const_eval/eval_queries.rs
+++ b/compiler/rustc_const_eval/src/const_eval/eval_queries.rs
@@ -64,7 +64,6 @@ fn setup_for_eval<'tcx>(
                     | DefKind::Static { .. }
                     | DefKind::ConstParam
                     | DefKind::AnonConst
-                    | DefKind::InlineConst
                     | DefKind::AssocConst { .. }
             ),
         "Unexpected DefKind: {:?}",

--- a/compiler/rustc_hir/src/def.rs
+++ b/compiler/rustc_hir/src/def.rs
@@ -165,7 +165,8 @@ pub enum DefKind {
     Use,
     /// An `extern` block.
     ForeignMod,
-    /// Anonymous constant, e.g. the `1 + 2` in `[u8; 1 + 2]`.
+    /// Anonymous constant, e.g. the `1 + 2` in `[u8; 1 + 2]` or `enum E { A = 1 + 2 }`, or an
+    /// inline constant, e.g. `const { 1 + 2 }`.
     ///
     /// Not all anon-consts are actually still relevant in the HIR. We lower
     /// trivial const-arguments directly to `hir::ConstArgKind::Path`, at which
@@ -176,8 +177,6 @@ pub enum DefKind {
     /// constants should only be reachable by iterating all definitions of a
     /// given crate, you should not have to worry about this.
     AnonConst,
-    /// An inline constant, e.g. `const { 1 + 2 }`
-    InlineConst,
     /// Opaque type, aka `impl Trait`.
     OpaqueTy,
     /// A field in a struct, enum or union. e.g.
@@ -239,7 +238,6 @@ impl DefKind {
             DefKind::Use => "import",
             DefKind::ForeignMod => "foreign module",
             DefKind::AnonConst => "constant expression",
-            DefKind::InlineConst => "inline constant",
             DefKind::Field => "field",
             DefKind::Impl { .. } => "implementation",
             DefKind::Closure => "closure",
@@ -263,7 +261,6 @@ impl DefKind {
             | DefKind::OpaqueTy
             | DefKind::Impl { .. }
             | DefKind::Use
-            | DefKind::InlineConst
             | DefKind::ExternCrate => "an",
             DefKind::Macro(kinds) => kinds.article(),
             _ => "a",
@@ -296,7 +293,6 @@ impl DefKind {
 
             // Not namespaced.
             DefKind::AnonConst
-            | DefKind::InlineConst
             | DefKind::Field
             | DefKind::LifetimeParam
             | DefKind::ExternCrate
@@ -343,7 +339,6 @@ impl DefKind {
             DefKind::Use => DefPathData::Use,
             DefKind::ForeignMod => DefPathData::ForeignMod,
             DefKind::AnonConst => DefPathData::AnonConst,
-            DefKind::InlineConst => DefPathData::AnonConst,
             DefKind::OpaqueTy => DefPathData::OpaqueTy,
             DefKind::GlobalAsm => DefPathData::GlobalAsm,
             DefKind::Impl { .. } => DefPathData::Impl,
@@ -390,7 +385,6 @@ impl DefKind {
             | DefKind::Fn
             | DefKind::ForeignTy
             | DefKind::Impl { .. }
-            | DefKind::InlineConst
             | DefKind::OpaqueTy
             | DefKind::Static { .. }
             | DefKind::Struct
@@ -443,7 +437,6 @@ impl DefKind {
             | DefKind::ConstParam
             | DefKind::LifetimeParam
             | DefKind::AnonConst
-            | DefKind::InlineConst
             | DefKind::GlobalAsm
             | DefKind::ExternCrate => false,
         }

--- a/compiler/rustc_hir_analysis/src/check/check.rs
+++ b/compiler/rustc_hir_analysis/src/check/check.rs
@@ -1171,7 +1171,6 @@ pub(crate) fn check_item_type(tcx: TyCtxt<'_>, def_id: LocalDefId) -> Result<(),
 
         // These have no wf checks
         DefKind::AnonConst
-        | DefKind::InlineConst
         | DefKind::ExternCrate
         | DefKind::Macro(..)
         | DefKind::Use

--- a/compiler/rustc_hir_analysis/src/check/wfcheck.rs
+++ b/compiler/rustc_hir_analysis/src/check/wfcheck.rs
@@ -2406,7 +2406,6 @@ fn lint_redundant_lifetimes<'tcx>(
         | DefKind::Use
         | DefKind::ForeignMod
         | DefKind::AnonConst
-        | DefKind::InlineConst
         | DefKind::OpaqueTy
         | DefKind::Field
         | DefKind::LifetimeParam

--- a/compiler/rustc_hir_analysis/src/collect.rs
+++ b/compiler/rustc_hir_analysis/src/collect.rs
@@ -1635,13 +1635,12 @@ fn const_param_default<'tcx>(
 }
 
 fn anon_const_kind<'tcx>(tcx: TyCtxt<'tcx>, def: LocalDefId) -> ty::AnonConstKind {
-    debug_assert_matches!(tcx.def_kind(def), DefKind::AnonConst | DefKind::InlineConst);
+    debug_assert_matches!(tcx.def_kind(def), DefKind::AnonConst);
     let hir_id = tcx.local_def_id_to_hir_id(def);
-    let const_arg_id = tcx.parent_hir_id(hir_id);
-    match tcx.hir_node(const_arg_id) {
+    let parent_node_id = tcx.parent_hir_id(hir_id);
+    match tcx.hir_node(parent_node_id) {
         hir::Node::ConstArg(const_arg) => {
             debug_assert_matches!(const_arg.kind, hir::ConstArgKind::Anon(hir::AnonConst { def_id, .. }) if *def_id == def);
-            let parent_hir_node = tcx.hir_node(tcx.parent_hir_id(const_arg_id));
             if tcx.features().generic_const_exprs() {
                 ty::AnonConstKind::GCE
             } else if tcx.features().min_generic_const_args() {
@@ -1649,15 +1648,19 @@ fn anon_const_kind<'tcx>(tcx: TyCtxt<'tcx>, def: LocalDefId) -> ty::AnonConstKin
             } else if let hir::Node::Expr(hir::Expr {
                 kind: hir::ExprKind::Repeat(_, repeat_count),
                 ..
-            }) = parent_hir_node
-                && repeat_count.hir_id == const_arg_id
+            }) = tcx.parent_hir_node(parent_node_id)
+                && repeat_count.hir_id == parent_node_id
             {
                 ty::AnonConstKind::RepeatExprCount
             } else {
                 ty::AnonConstKind::MCG
             }
         }
-        _ => ty::AnonConstKind::NonTypeSystem,
+        hir::Node::Expr(hir::Expr {
+            kind: hir::ExprKind::ConstBlock(..) | hir::ExprKind::InlineAsm(..),
+            ..
+        }) => ty::AnonConstKind::NonTypeSystemInline,
+        _ => ty::AnonConstKind::NonTypeSystemAnon,
     }
 }
 

--- a/compiler/rustc_hir_analysis/src/collect/generics_of.rs
+++ b/compiler/rustc_hir_analysis/src/collect/generics_of.rs
@@ -162,13 +162,17 @@ pub(super) fn generics_of(tcx: TyCtxt<'_>, def_id: LocalDefId) -> ty::Generics {
                 ty::AnonConstKind::GCE => Some(parent_did),
 
                 // Field defaults are allowed to use generic parameters, e.g. `field: u32 = /*defid: N + 1*/`
-                ty::AnonConstKind::NonTypeSystem
+                ty::AnonConstKind::NonTypeSystemAnon
                     if matches!(tcx.parent_hir_node(hir_id), Node::TyPat(_) | Node::Field(_)) =>
                 {
                     Some(parent_did)
                 }
                 // Default to no generic parameters for other kinds of anon consts
-                ty::AnonConstKind::NonTypeSystem => None,
+                ty::AnonConstKind::NonTypeSystemAnon => None,
+                ty::AnonConstKind::NonTypeSystemInline => span_bug!(
+                    tcx.def_span(def_id),
+                    "a DefKind::AnonConst with a HIR parent of hir::Node::AnonConst should never be an AnonConstKind::NonTypeSystemInline"
+                ),
             }
         }
         Node::ConstBlock(_)

--- a/compiler/rustc_hir_analysis/src/collect/resolve_bound_vars.rs
+++ b/compiler/rustc_hir_analysis/src/collect/resolve_bound_vars.rs
@@ -1956,7 +1956,6 @@ impl<'a, 'tcx> BoundVarContext<'a, 'tcx> {
             | DefKind::ForeignTy
             | DefKind::GlobalAsm
             | DefKind::Impl { .. }
-            | DefKind::InlineConst
             | DefKind::LifetimeParam
             | DefKind::Macro(_)
             | DefKind::Mod

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
@@ -509,22 +509,20 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
     /// contains params). Those cases are handled by `check_param_uses_if_mcg`.
     fn anon_const_forbids_generic_params(&self) -> Option<ForbidParamContext> {
         let tcx = self.tcx();
-        let parent_def_id = self.item_def_id();
+        let item_def_id = self.item_def_id();
 
         // Inline consts and closures can be nested inside anon consts that forbid generic
         // params (e.g. an enum discriminant). Walk up the def parent chain to find the
         // nearest enclosing AnonConst and use that to determine the context.
-        let parent_def_id = tcx.typeck_root_def_id(parent_def_id.into());
+        let anon_const_def_id = tcx.typeck_root_def_id_local(item_def_id);
 
-        let anon_const_def_id = match tcx.def_kind(parent_def_id) {
-            DefKind::AnonConst => parent_def_id,
-            DefKind::InlineConst if tcx.is_type_system_inline_const(parent_def_id) => parent_def_id,
-            _ => return None,
-        };
+        if tcx.def_kind(anon_const_def_id) != DefKind::AnonConst {
+            return None;
+        }
 
         match tcx.anon_const_kind(anon_const_def_id) {
             ty::AnonConstKind::MCG => Some(ForbidParamContext::ConstArgument),
-            ty::AnonConstKind::NonTypeSystem => {
+            ty::AnonConstKind::NonTypeSystemAnon => {
                 // NonTypeSystem anon consts only have accessible generic parameters in specific
                 // positions (ty patterns and field defaults — see `generics_of`). In all other
                 // positions (e.g. enum discriminants) generic parameters are not in scope.
@@ -534,7 +532,9 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                     None
                 }
             }
-            ty::AnonConstKind::GCE | ty::AnonConstKind::RepeatExprCount => None,
+            ty::AnonConstKind::NonTypeSystemInline
+            | ty::AnonConstKind::GCE
+            | ty::AnonConstKind::RepeatExprCount => None,
         }
     }
 
@@ -2975,7 +2975,6 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                 | DefKind::Use
                 | DefKind::ForeignMod
                 | DefKind::AnonConst
-                | DefKind::InlineConst
                 | DefKind::Field
                 | DefKind::Impl { .. }
                 | DefKind::Closure

--- a/compiler/rustc_hir_analysis/src/lib.rs
+++ b/compiler/rustc_hir_analysis/src/lib.rs
@@ -191,7 +191,7 @@ pub fn check_crate(tcx: TyCtxt<'_>) {
         // `feed_anon_const_type`.
         // Also skip items for which typeck forwards to parent typeck.
         if !(def_kind == DefKind::AnonConst
-            || def_kind == DefKind::InlineConst && tcx.is_type_system_inline_const(item_def_id)
+            && tcx.anon_const_kind(item_def_id) != ty::AnonConstKind::NonTypeSystemInline
             || tcx.is_typeck_child(item_def_id.to_def_id()))
         {
             tcx.ensure_ok().typeck(item_def_id);

--- a/compiler/rustc_hir_typeck/src/loops.rs
+++ b/compiler/rustc_hir_typeck/src/loops.rs
@@ -84,11 +84,6 @@ pub(crate) fn check<'tcx>(tcx: TyCtxt<'tcx>, def_id: LocalDefId, body: &'tcx hir
         CheckLoopVisitor { tcx, cx_stack: vec![Normal], block_breaks: Default::default() };
     let cx = match tcx.def_kind(def_id) {
         DefKind::AnonConst => AnonConst,
-        DefKind::InlineConst => {
-            // only type system inline consts are typeck roots
-            debug_assert!(tcx.is_type_system_inline_const(def_id));
-            ConstBlock
-        }
         _ => Fn,
     };
     check.with_context(cx, |v| v.visit_body(body));

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -916,7 +916,6 @@ fn should_encode_span(def_kind: DefKind) -> bool {
         | DefKind::ExternCrate
         | DefKind::Use
         | DefKind::AnonConst
-        | DefKind::InlineConst
         | DefKind::OpaqueTy
         | DefKind::Field
         | DefKind::Impl { .. }
@@ -962,7 +961,6 @@ fn should_encode_attrs(def_kind: DefKind) -> bool {
         | DefKind::ExternCrate
         | DefKind::ForeignMod
         | DefKind::AnonConst
-        | DefKind::InlineConst
         | DefKind::OpaqueTy
         | DefKind::LifetimeParam
         | DefKind::Static { nested: true, .. }
@@ -996,7 +994,6 @@ fn should_encode_expn_that_defined(def_kind: DefKind) -> bool {
         | DefKind::Use
         | DefKind::ForeignMod
         | DefKind::AnonConst
-        | DefKind::InlineConst
         | DefKind::OpaqueTy
         | DefKind::Field
         | DefKind::LifetimeParam
@@ -1032,7 +1029,6 @@ fn should_encode_visibility(def_kind: DefKind) -> bool {
         | DefKind::ConstParam
         | DefKind::LifetimeParam
         | DefKind::AnonConst
-        | DefKind::InlineConst
         | DefKind::Static { nested: true, .. }
         | DefKind::OpaqueTy
         | DefKind::GlobalAsm
@@ -1071,7 +1067,6 @@ fn should_encode_stability(def_kind: DefKind) -> bool {
         DefKind::Use
         | DefKind::LifetimeParam
         | DefKind::AnonConst
-        | DefKind::InlineConst
         | DefKind::GlobalAsm
         | DefKind::Closure
         | DefKind::ExternCrate
@@ -1108,10 +1103,7 @@ fn should_encode_mir(
         // instance_mir uses mir_for_ctfe rather than optimized_mir for constructors
         DefKind::Ctor(_, _) => (true, false),
         // Constants
-        DefKind::AnonConst
-        | DefKind::InlineConst
-        | DefKind::AssocConst { .. }
-        | DefKind::Const { .. } => (true, false),
+        DefKind::AnonConst | DefKind::AssocConst { .. } | DefKind::Const { .. } => (true, false),
         // Coroutines require optimized MIR to compute layout.
         DefKind::Closure if tcx.is_coroutine(def_id.to_def_id()) => (false, true),
         DefKind::SyntheticCoroutineBody => (false, true),
@@ -1165,7 +1157,6 @@ fn should_encode_variances<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId, def_kind: Def
         | DefKind::Use
         | DefKind::LifetimeParam
         | DefKind::AnonConst
-        | DefKind::InlineConst
         | DefKind::GlobalAsm
         | DefKind::Closure
         | DefKind::ExternCrate
@@ -1191,7 +1182,6 @@ fn should_encode_generics(def_kind: DefKind) -> bool {
         | DefKind::AssocFn
         | DefKind::AssocConst { .. }
         | DefKind::AnonConst
-        | DefKind::InlineConst
         | DefKind::OpaqueTy
         | DefKind::Impl { .. }
         | DefKind::Field
@@ -1228,7 +1218,6 @@ fn should_encode_type(tcx: TyCtxt<'_>, def_id: LocalDefId, def_kind: DefKind) ->
         | DefKind::Closure
         | DefKind::ConstParam
         | DefKind::AnonConst
-        | DefKind::InlineConst
         | DefKind::SyntheticCoroutineBody => true,
 
         DefKind::OpaqueTy => {
@@ -1290,7 +1279,6 @@ fn should_encode_fn_sig(def_kind: DefKind) -> bool {
         | DefKind::Closure
         | DefKind::ConstParam
         | DefKind::AnonConst
-        | DefKind::InlineConst
         | DefKind::AssocTy
         | DefKind::TyParam
         | DefKind::Trait
@@ -1327,7 +1315,6 @@ fn should_encode_constness(def_kind: DefKind) -> bool {
         | DefKind::Impl { .. }
         | DefKind::ForeignTy
         | DefKind::ConstParam
-        | DefKind::InlineConst
         | DefKind::AssocTy
         | DefKind::TyParam
         | DefKind::Trait
@@ -1348,10 +1335,7 @@ fn should_encode_constness(def_kind: DefKind) -> bool {
 fn should_encode_const(def_kind: DefKind) -> bool {
     match def_kind {
         // FIXME(mgca): should we remove Const and AssocConst here?
-        DefKind::Const { .. }
-        | DefKind::AssocConst { .. }
-        | DefKind::AnonConst
-        | DefKind::InlineConst => true,
+        DefKind::Const { .. } | DefKind::AssocConst { .. } | DefKind::AnonConst => true,
 
         DefKind::Struct
         | DefKind::Union
@@ -1624,7 +1608,7 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
                     ty::AssocContainer::TraitImpl(_) => {}
                 }
             }
-            if let DefKind::AnonConst | DefKind::InlineConst = def_kind {
+            if let DefKind::AnonConst = def_kind {
                 record!(self.tables.anon_const_kind[def_id] <- self.tcx.anon_const_kind(def_id));
             }
             if should_encode_const_of_item(self.tcx, def_id, def_kind) {

--- a/compiler/rustc_metadata/src/rmeta/table.rs
+++ b/compiler/rustc_metadata/src/rmeta/table.rs
@@ -175,7 +175,6 @@ fixed_size_enum! {
         ( Use                                      )
         ( ForeignMod                               )
         ( AnonConst                                )
-        ( InlineConst                              )
         ( OpaqueTy                                 )
         ( Field                                    )
         ( LifetimeParam                            )

--- a/compiler/rustc_middle/src/hir/map.rs
+++ b/compiler/rustc_middle/src/hir/map.rs
@@ -322,10 +322,12 @@ impl<'tcx> TyCtxt<'tcx> {
     pub fn hir_body_owner_kind(self, def_id: impl Into<DefId>) -> BodyOwnerKind {
         let def_id = def_id.into();
         match self.def_kind(def_id) {
-            DefKind::Const { .. } | DefKind::AssocConst { .. } | DefKind::AnonConst => {
+            DefKind::Const { .. } | DefKind::AssocConst { .. } => {
                 BodyOwnerKind::Const { inline: false }
             }
-            DefKind::InlineConst => BodyOwnerKind::Const { inline: true },
+            DefKind::AnonConst => BodyOwnerKind::Const {
+                inline: self.anon_const_kind(def_id) == ty::AnonConstKind::NonTypeSystemInline,
+            },
             DefKind::Ctor(..) | DefKind::Fn | DefKind::AssocFn => BodyOwnerKind::Fn,
             DefKind::Closure | DefKind::SyntheticCoroutineBody => BodyOwnerKind::Closure,
             DefKind::Static { safety: _, mutability, nested: false } => {
@@ -1106,12 +1108,6 @@ impl<'tcx> TyCtxt<'tcx> {
             }) => Some(*param_id),
             _ => None,
         }
-    }
-
-    pub fn is_type_system_inline_const(self, def_id: impl IntoQueryKey<DefId>) -> bool {
-        let def_id = def_id.into_query_key();
-        debug_assert_eq!(self.def_kind(def_id), DefKind::InlineConst);
-        self.anon_const_kind(def_id) != ty::AnonConstKind::NonTypeSystem
     }
 
     pub fn hir_maybe_get_struct_pattern_shorthand_field(self, expr: &Expr<'_>) -> Option<Symbol> {

--- a/compiler/rustc_middle/src/mir/pretty.rs
+++ b/compiler/rustc_middle/src/mir/pretty.rs
@@ -693,8 +693,8 @@ fn write_mir_sig(tcx: TyCtxt<'_>, body: &Body<'_>, w: &mut dyn io::Write) -> io:
             write!(w, "static mut ")?
         }
         (_, _) if is_function => write!(w, "fn ")?,
-        // things like anon const, not an item
-        (DefKind::AnonConst | DefKind::InlineConst, _) => {}
+        // anon consts are not an item and have no sig
+        (DefKind::AnonConst, _) => {}
         // `global_asm!` have fake bodies, which we may dump after mir-build
         (DefKind::GlobalAsm, _) => {}
         _ => bug!("Unexpected def kind {:?}", kind),

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -601,14 +601,8 @@ impl<'tcx> TyCtxt<'tcx> {
     /// effect. However, we do not want this as a general capability, so this interface restricts
     /// to the only allowed case.
     pub fn feed_anon_const_type(self, key: LocalDefId, value: ty::EarlyBinder<'tcx, Ty<'tcx>>) {
-        if cfg!(debug_assertions) {
-            match self.def_kind(key) {
-                DefKind::AnonConst => (),
-                DefKind::InlineConst => assert!(self.is_type_system_inline_const(key)),
-                def_kind => bug!("unexpected DefKind in feed_anon_const_type: {def_kind:?}"),
-            }
-        }
-
+        debug_assert_eq!(self.def_kind(key), DefKind::AnonConst);
+        debug_assert!(self.anon_const_kind(key) != ty::AnonConstKind::NonTypeSystemInline);
         TyCtxtFeed { tcx: self, key }.type_of(value)
     }
 
@@ -855,7 +849,6 @@ impl<'tcx> TyCtxt<'tcx> {
             DefKind::AnonConst
                 | DefKind::AssocConst { .. }
                 | DefKind::Const { .. }
-                | DefKind::InlineConst
                 | DefKind::GlobalAsm
         ) {
             CodegenFnAttrs::EMPTY

--- a/compiler/rustc_middle/src/ty/context/impl_interner.rs
+++ b/compiler/rustc_middle/src/ty/context/impl_interner.rs
@@ -218,7 +218,7 @@ impl<'tcx> Interner for TyCtxt<'tcx> {
                 }
             }
             DefKind::Const { .. } => ty::AliasConstKind::Free { def_id },
-            DefKind::AnonConst | DefKind::InlineConst | DefKind::Ctor(_, CtorKind::Const) => {
+            DefKind::AnonConst | DefKind::Ctor(_, CtorKind::Const) => {
                 ty::AliasConstKind::Anon { def_id }
             }
             kind => bug!("unexpected DefKind in AliasConst: {kind:?}"),
@@ -244,7 +244,7 @@ impl<'tcx> Interner for TyCtxt<'tcx> {
             DefKind::OpaqueTy => ty::AliasTermKind::OpaqueTy { def_id },
             DefKind::TyAlias => ty::AliasTermKind::FreeTy { def_id },
             DefKind::Const { .. } => ty::AliasTermKind::FreeConst { def_id },
-            DefKind::AnonConst | DefKind::InlineConst | DefKind::Ctor(_, CtorKind::Const) => {
+            DefKind::AnonConst | DefKind::Ctor(_, CtorKind::Const) => {
                 ty::AliasTermKind::AnonConst { def_id }
             }
             kind => bug!("unexpected DefKind in AliasTy: {kind:?}"),

--- a/compiler/rustc_middle/src/ty/instance.rs
+++ b/compiler/rustc_middle/src/ty/instance.rs
@@ -557,7 +557,6 @@ impl<'tcx> Instance<'tcx> {
                 | DefKind::Const { .. }
                 | DefKind::AssocConst { .. }
                 | DefKind::AnonConst
-                | DefKind::InlineConst
                 | DefKind::Static { .. }
                 | DefKind::Ctor(_, CtorKind::Fn)
                 | DefKind::Closure

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -1819,8 +1819,7 @@ impl<'tcx> TyCtxt<'tcx> {
                     | DefKind::Static { .. }
                     | DefKind::AssocConst { .. }
                     | DefKind::Ctor(..)
-                    | DefKind::AnonConst
-                    | DefKind::InlineConst => self.mir_for_ctfe(def),
+                    | DefKind::AnonConst => self.mir_for_ctfe(def),
                     DefKind::Fn | DefKind::AssocFn
                         if matches!(
                             self.constness(def),
@@ -2260,7 +2259,6 @@ impl<'tcx> TyCtxt<'tcx> {
             | DefKind::Use
             | DefKind::ForeignMod
             | DefKind::AnonConst
-            | DefKind::InlineConst
             | DefKind::Field
             | DefKind::LifetimeParam
             | DefKind::GlobalAsm

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -681,7 +681,6 @@ impl<'tcx> Ty<'tcx> {
                 | DefKind::Use
                 | DefKind::ForeignMod
                 | DefKind::AnonConst
-                | DefKind::InlineConst
                 | DefKind::OpaqueTy
                 | DefKind::Field
                 | DefKind::LifetimeParam

--- a/compiler/rustc_middle/src/ty/util.rs
+++ b/compiler/rustc_middle/src/ty/util.rs
@@ -598,7 +598,9 @@ impl<'tcx> TyCtxt<'tcx> {
     /// type-checking context, i.e. closure, coroutine or inline const.
     pub fn is_typeck_child(self, def_id: DefId) -> bool {
         match self.def_kind(def_id) {
-            DefKind::InlineConst => !self.is_type_system_inline_const(def_id),
+            DefKind::AnonConst => {
+                self.anon_const_kind(def_id) == ty::AnonConstKind::NonTypeSystemInline
+            }
             DefKind::Closure | DefKind::SyntheticCoroutineBody => true,
             DefKind::Mod
             | DefKind::Struct
@@ -622,7 +624,6 @@ impl<'tcx> TyCtxt<'tcx> {
             | DefKind::ExternCrate
             | DefKind::Use
             | DefKind::ForeignMod
-            | DefKind::AnonConst
             | DefKind::OpaqueTy
             | DefKind::Field
             | DefKind::LifetimeParam

--- a/compiler/rustc_mir_build/src/builder/mod.rs
+++ b/compiler/rustc_mir_build/src/builder/mod.rs
@@ -627,7 +627,6 @@ fn construct_error(tcx: TyCtxt<'_>, def_id: LocalDefId, guar: ErrorGuaranteed) -
         DefKind::Const { .. }
         | DefKind::AssocConst { .. }
         | DefKind::AnonConst
-        | DefKind::InlineConst
         | DefKind::Static { .. }
         | DefKind::GlobalAsm => {
             (vec![], tcx.type_of(def_id).instantiate_identity().skip_norm_wip(), None)

--- a/compiler/rustc_mir_transform/src/lib.rs
+++ b/compiler/rustc_mir_transform/src/lib.rs
@@ -448,7 +448,6 @@ fn mir_promoted(
         DefKind::AssocConst { .. }
         | DefKind::Const { .. }
         | DefKind::Static { .. }
-        | DefKind::InlineConst
         | DefKind::AnonConst => tcx.mir_const_qualif(def),
         _ => ConstQualifs::default(),
     };

--- a/compiler/rustc_mir_transform/src/promote_consts.rs
+++ b/compiler/rustc_mir_transform/src/promote_consts.rs
@@ -704,7 +704,10 @@ impl<'tcx> Validator<'_, 'tcx> {
             // const function that uses that constant, again requiring evaluation of the constant.
             // However, this form of cycle renders both the constant and function unusable in
             // general, so we don't need to special-case it here.
-            Const::Unevaluated(uc, _) => self.tcx.def_kind(uc.def) != DefKind::InlineConst,
+            Const::Unevaluated(uc, _) => {
+                self.tcx.def_kind(uc.def) != DefKind::AnonConst
+                    || self.tcx.anon_const_kind(uc.def) != ty::AnonConstKind::NonTypeSystemInline
+            }
         }
     }
 }

--- a/compiler/rustc_mir_transform/src/trivial_const.rs
+++ b/compiler/rustc_mir_transform/src/trivial_const.rs
@@ -6,7 +6,7 @@ use rustc_middle::mir::{
     Body, Const, ConstValue, Operand, Place, RETURN_PLACE, Rvalue, START_BLOCK, StatementKind,
     TerminatorKind, UnevaluatedConst,
 };
-use rustc_middle::ty::{Ty, TyCtxt, TypeVisitableExt};
+use rustc_middle::ty::{AnonConstKind, Ty, TyCtxt, TypeVisitableExt};
 
 /// If the given def is a trivial const, returns the value and type the const evaluates to.
 ///
@@ -53,8 +53,8 @@ where
     B: Deref<Target = Body<'tcx>>,
 {
     match tcx.def_kind(def) {
-        DefKind::AssocConst { .. } | DefKind::Const { .. } | DefKind::AnonConst => (),
-        DefKind::InlineConst if tcx.is_type_system_inline_const(def) => (),
+        DefKind::AssocConst { .. } | DefKind::Const { .. } => (),
+        DefKind::AnonConst if tcx.anon_const_kind(def) != AnonConstKind::NonTypeSystemInline => (),
         _ => return None,
     }
 

--- a/compiler/rustc_passes/src/dead.rs
+++ b/compiler/rustc_passes/src/dead.rs
@@ -56,7 +56,6 @@ fn should_explore(tcx: TyCtxt<'_>, def_id: LocalDefId) -> bool {
         | DefKind::Impl { .. }
         | DefKind::OpaqueTy
         | DefKind::AnonConst
-        | DefKind::InlineConst
         | DefKind::ExternCrate
         | DefKind::Use
         | DefKind::Ctor(..)

--- a/compiler/rustc_privacy/src/lib.rs
+++ b/compiler/rustc_privacy/src/lib.rs
@@ -712,7 +712,6 @@ impl<'tcx> EmbargoVisitor<'tcx> {
             | DefKind::AssocConst { .. }
             | DefKind::TyParam
             | DefKind::AnonConst
-            | DefKind::InlineConst
             | DefKind::OpaqueTy
             | DefKind::Closure
             | DefKind::SyntheticCoroutineBody
@@ -814,7 +813,6 @@ impl ReachEverythingInTheInterfaceVisitor<'_, '_> {
             | DefKind::Macro(_)
             | DefKind::TyParam
             | DefKind::AnonConst
-            | DefKind::InlineConst
             | DefKind::OpaqueTy
             | DefKind::SyntheticCoroutineBody
             | DefKind::ConstParam

--- a/compiler/rustc_public/src/unstable/mod.rs
+++ b/compiler/rustc_public/src/unstable/mod.rs
@@ -126,10 +126,7 @@ pub(crate) fn new_item_kind(kind: DefKind) -> ItemKind {
         DefKind::Closure | DefKind::AssocFn | DefKind::Fn | DefKind::SyntheticCoroutineBody => {
             ItemKind::Fn
         }
-        DefKind::Const { .. }
-        | DefKind::InlineConst
-        | DefKind::AssocConst { .. }
-        | DefKind::AnonConst => ItemKind::Const,
+        DefKind::Const { .. } | DefKind::AssocConst { .. } | DefKind::AnonConst => ItemKind::Const,
         DefKind::Static { .. } => ItemKind::Static,
         DefKind::Ctor(_, rustc_hir::def::CtorKind::Const) => ItemKind::Ctor(CtorKind::Const),
         DefKind::Ctor(_, rustc_hir::def::CtorKind::Fn) => ItemKind::Ctor(CtorKind::Fn),

--- a/compiler/rustc_resolve/src/build_reduced_graph.rs
+++ b/compiler/rustc_resolve/src/build_reduced_graph.rs
@@ -443,7 +443,6 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 | DefKind::Use
                 | DefKind::ForeignMod
                 | DefKind::AnonConst
-                | DefKind::InlineConst
                 | DefKind::Field
                 | DefKind::LifetimeParam
                 | DefKind::GlobalAsm

--- a/compiler/rustc_resolve/src/def_collector.rs
+++ b/compiler/rustc_resolve/src/def_collector.rs
@@ -423,8 +423,6 @@ impl<'a, 'ra, 'tcx> visit::Visitor<'a> for DefCollector<'a, 'ra, 'tcx> {
     }
 
     fn visit_anon_const(&mut self, constant: &'a AnonConst) {
-        // Note that `visit_anon_const` is skipped for AnonConst nodes wrapped in an
-        // ExprKind::ConstBlock - these are handled in visit_expr, and are DefKind::InlineConst.
         let parent =
             self.create_def(constant.id, None, DefKind::AnonConst, constant.value.span).def_id();
         self.with_parent(parent, |this| visit::walk_anon_const(this, constant));
@@ -442,17 +440,6 @@ impl<'a, 'ra, 'tcx> visit::Visitor<'a> for DefCollector<'a, 'ra, 'tcx> {
             ExprKind::Closure(..) | ExprKind::Gen(..) => {
                 let def = self.create_def(expr.id, None, DefKind::Closure, expr.span).def_id();
                 self.with_parent(def, |this| visit::walk_expr(this, expr));
-            }
-            ExprKind::ConstBlock(constant) => {
-                for attr in &expr.attrs {
-                    visit::walk_attribute(self, attr);
-                }
-
-                let def = self
-                    .create_def(constant.id, None, DefKind::InlineConst, constant.value.span)
-                    .def_id();
-                // use specifically walk_anon_const, not walk_expr, to skip self.visit_anon_const
-                self.with_parent(def, |this| visit::walk_anon_const(this, constant));
             }
             _ => visit::walk_expr(self, expr),
         }
@@ -606,12 +593,7 @@ impl<'a, 'ra, 'tcx> visit::Visitor<'a> for DefCollector<'a, 'ra, 'tcx> {
                 }
                 InlineAsmOperand::Const { anon_const } => {
                     let def = self
-                        .create_def(
-                            anon_const.id,
-                            None,
-                            DefKind::InlineConst,
-                            anon_const.value.span,
-                        )
+                        .create_def(anon_const.id, None, DefKind::AnonConst, anon_const.value.span)
                         .def_id();
                     self.with_parent(def, |this| visit::walk_anon_const(this, anon_const));
                 }

--- a/compiler/rustc_trait_selection/src/traits/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/mod.rs
@@ -670,8 +670,12 @@ pub fn try_evaluate_const<'tcx>(
 
                     (args, typing_env)
                 }
-                Some((_, ty::AnonConstKind::MCG))
-                | Some((_, ty::AnonConstKind::NonTypeSystem))
+                Some((
+                    _,
+                    ty::AnonConstKind::MCG
+                    | ty::AnonConstKind::NonTypeSystemAnon
+                    | ty::AnonConstKind::NonTypeSystemInline,
+                ))
                 | None => {
                     // We are only dealing with "truly" generic/uninferred constants here:
                     // - GCEConsts have been handled separately

--- a/compiler/rustc_ty_utils/src/consts.rs
+++ b/compiler/rustc_ty_utils/src/consts.rs
@@ -367,7 +367,7 @@ fn thir_abstract_const<'tcx>(
         // we want to look into them or treat them as opaque projections.
         //
         // Right now we do neither of that and simply always fail to unify them.
-        DefKind::AnonConst | DefKind::InlineConst => (),
+        DefKind::AnonConst => (),
         _ => return Ok(None),
     }
 

--- a/compiler/rustc_ty_utils/src/implied_bounds.rs
+++ b/compiler/rustc_ty_utils/src/implied_bounds.rs
@@ -130,7 +130,6 @@ fn assumed_wf_types<'tcx>(tcx: TyCtxt<'tcx>, def_id: LocalDefId) -> &'tcx [(Ty<'
         DefKind::Static { .. }
         | DefKind::Const { .. }
         | DefKind::AnonConst
-        | DefKind::InlineConst
         | DefKind::Struct
         | DefKind::Union
         | DefKind::Enum

--- a/compiler/rustc_ty_utils/src/opaque_types.rs
+++ b/compiler/rustc_ty_utils/src/opaque_types.rs
@@ -336,10 +336,12 @@ fn opaque_types_defined_by<'tcx>(
         | DefKind::Static { .. }
         | DefKind::Const { .. }
         | DefKind::AssocConst { .. }
-        | DefKind::AnonConst
-        | DefKind::InlineConst => {
+        | DefKind::AnonConst => {
             // Non-type-system inline consts should be caught by `if tcx.is_typeck_child` above
-            debug_assert!(kind != DefKind::InlineConst || tcx.is_type_system_inline_const(item));
+            debug_assert!(
+                kind != DefKind::AnonConst
+                    || tcx.anon_const_kind(item) != ty::AnonConstKind::NonTypeSystemInline
+            );
 
             collector.collect_taits_declared_in_body();
         }

--- a/compiler/rustc_ty_utils/src/sig_types.rs
+++ b/compiler/rustc_ty_utils/src/sig_types.rs
@@ -64,9 +64,16 @@ pub fn walk_types<'tcx, V: SpannedTypeVisitor<'tcx>>(
         | DefKind::AssocTy
         | DefKind::Static { .. }
         | DefKind::Const { .. }
-        | DefKind::AssocConst { .. }
-        | DefKind::AnonConst => return visit_alias(),
-        DefKind::InlineConst if tcx.is_type_system_inline_const(item) => return visit_alias(),
+        | DefKind::AssocConst { .. } => return visit_alias(),
+        DefKind::AnonConst
+            if tcx.anon_const_kind(item) != ty::AnonConstKind::NonTypeSystemInline =>
+        {
+            return visit_alias();
+        }
+        // These are not part of a public API, they can only appear as hidden types, and there
+        // the interesting parts are solely in the signature of the containing item's opaque type
+        // or dyn type.
+        DefKind::AnonConst | DefKind::Closure | DefKind::SyntheticCoroutineBody => {}
         DefKind::OpaqueTy => {
             for (pred, span) in tcx
                 .explicit_item_bounds(item)
@@ -93,10 +100,6 @@ pub fn walk_types<'tcx, V: SpannedTypeVisitor<'tcx>>(
                 try_visit!(visitor.visit(span, pred.skip_norm_wip()));
             }
         }
-        // These are not part of a public API, they can only appear as hidden types, and there
-        // the interesting parts are solely in the signature of the containing item's opaque type
-        // or dyn type.
-        DefKind::InlineConst | DefKind::Closure | DefKind::SyntheticCoroutineBody => {}
         DefKind::Impl { of_trait } => {
             if of_trait {
                 let span = tcx

--- a/compiler/rustc_type_ir/src/const_kind.rs
+++ b/compiler/rustc_type_ir/src/const_kind.rs
@@ -266,10 +266,15 @@ pub enum AnonConstKind {
     /// `feature(generic_const_exprs)` anon consts are allowed to use arbitrary generic parameters in scope
     GCE,
     /// stable `min_const_generics` anon consts are not allowed to use any generic parameters
+    ///
+    /// under `feature(min_generic_const_args)`, these may be inline consts as well, and should be
+    /// treated the same as anon consts.
     MCG,
     /// anon consts used as the length of a repeat expr are syntactically allowed to use generic parameters
     /// but must not depend on the actual instantiation. See #76200 for more information
     RepeatExprCount,
     /// anon consts outside of the type system, e.g. enum discriminants
-    NonTypeSystem,
+    NonTypeSystemAnon,
+    /// inline consts outside of the type system
+    NonTypeSystemInline,
 }

--- a/src/librustdoc/formats/item_type.rs
+++ b/src/librustdoc/formats/item_type.rs
@@ -192,7 +192,6 @@ impl ItemType {
             | DefKind::Use
             | DefKind::ForeignMod
             | DefKind::AnonConst
-            | DefKind::InlineConst
             | DefKind::OpaqueTy
             | DefKind::LifetimeParam
             | DefKind::GlobalAsm

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -2208,8 +2208,7 @@ fn resolution_failure(
                             | Use
                             | LifetimeParam
                             | Ctor(_, _)
-                            | AnonConst
-                            | InlineConst => {
+                            | AnonConst => {
                                 let note = assoc_item_not_allowed(res);
                                 if let Some(span) = sp {
                                     diag.span_label(span, note);

--- a/src/tools/clippy/clippy_lints/src/manual_float_methods.rs
+++ b/src/tools/clippy/clippy_lints/src/manual_float_methods.rs
@@ -122,7 +122,6 @@ fn is_not_const(tcx: TyCtxt<'_>, def_id: DefId) -> bool {
         | DefKind::TyParam => true,
 
         DefKind::AnonConst
-        | DefKind::InlineConst
         | DefKind::Const { .. }
         | DefKind::ConstParam
         | DefKind::Static { .. }

--- a/src/tools/clippy/clippy_lints/src/matches/match_wild_enum.rs
+++ b/src/tools/clippy/clippy_lints/src/matches/match_wild_enum.rs
@@ -67,10 +67,7 @@ pub(crate) fn check(cx: &LateContext<'_>, ex: &Expr<'_>, arms: &[Arm<'_>]) {
                 }) => {
                     // FIXME(clippy): don't you want to use the hir id of the peeled pat?
                     let id = match cx.qpath_res(path, *hir_id) {
-                        Res::Def(
-                            DefKind::Const { .. } | DefKind::ConstParam | DefKind::AnonConst | DefKind::InlineConst,
-                            _,
-                        ) => return,
+                        Res::Def(DefKind::Const { .. } | DefKind::ConstParam | DefKind::AnonConst, _) => return,
                         Res::Def(_, id) => id,
                         _ => return,
                     };

--- a/tests/ui/lint/non-local-defs/consts.stderr
+++ b/tests/ui/lint/non-local-defs/consts.stderr
@@ -71,7 +71,7 @@ LL | |             fn hoo() {}
 ...  |
 LL | |         1
 LL | |     };
-   | |_____- move the `impl` block outside of this inline constant `<unnameable>` and up 2 bodies
+   | |_____- move the `impl` block outside of this constant expression `<unnameable>` and up 2 bodies
    |
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/158767)*
<!-- homu-ignore:end -->

This is a closely related followup to https://github.com/rust-lang/rust/pull/158375 (a condition of merging that PR was doing this as a followup)

This merge conflicts with https://github.com/rust-lang/rust/pull/158617 ; prefer merging that one first please~

This PR is within the general goal of const generics / `generic_const_args` and perhaps specifically https://github.com/rust-lang/project-const-generics/issues/108 but is mostly a code cleanup rather than implementing any particular feature

---

Anon consts (the `1 + 2` in `let x: [u8; 1 + 2];`) are closely related to inline consts (the `const {}` in `let x = const { 1 + 2 };`). They are especially related now that both can be used in the type system (by the above PR) and should be treated identically in that scenario. In general, they should be treated the same, as evidenced by the number of matches touched in this PR that just match on both. This PR merges the two DefKinds into one, mostly arbitrarily and bikesheddily choosing to use the name `AnonConst` for the merged concept (e.g. both `DefKind::InlineConst` and `DefKind::AnonConst` used `ast::AnonConst`, so `ast::AnonConst` should probably be named whatever the merged `DefKind` concept is named).

When you absolute must distinguish between the two, `tcx.anon_const_kind` allows you to do so - however, anon consts/inline consts in the type system intentionally appear identically under `anon_const_kind`. Indeed, the places where we distinguish between the two raised my eyebrows a few times when doing this PR, and being a little more explicit and loud about it is helpful for code clarity, IMO.

r? @BoxyUwU