### PR TITLE
Weaken guarantee for `From<legacy::RangeInclusive> for RangeInclusive`

### DIFF
--- a/library/core/src/range.rs
+++ b/library/core/src/range.rs
@@ -402,7 +402,8 @@ const impl<T> From<legacy::RangeInclusive<T>> for RangeInclusive<T> {
     ///
     /// # Panics
     ///
-    /// Panics if the legacy range iterator has been exhausted.
+    /// If the legacy range iterator has been exhausted,
+    /// this function will either panic or return an empty range.
     ///
     /// # Examples
     ///
@@ -419,19 +420,16 @@ const impl<T> From<legacy::RangeInclusive<T>> for RangeInclusive<T> {
     /// assert_eq!((empty.start, empty.last), (0, 0));
     /// ```
     ///
-    /// ```should_panic
+    /// ```
     /// use core::range::legacy;
     /// use core::range::RangeInclusive;
+    /// use std::panic::catch_unwind;
     ///
     /// let mut exhausted: legacy::RangeInclusive<i32> = 0..=0;
     /// exhausted.next();
-    /// # if exhausted.is_empty() {
-    /// # // assert!s don't work correctly in `should_panic` doctests since you
-    /// # // can't assert the panic message. Skip the rest of the test instead,
-    /// # // so that the expected panic doesn't happen and the test fails.
-    /// assert!(exhausted.is_empty());
-    /// let _ = RangeInclusive::from(exhausted); // this panics
-    /// # }
+    /// let result = catch_unwind(|| RangeInclusive::from(exhausted));
+    /// // The `from` call either panicked or returned an empty range.
+    /// assert!(result.is_err() || result.is_ok_and(|range| range.is_empty()));
     /// ```
     #[inline]
     fn from(value: legacy::RangeInclusive<T>) -> Self {

--- a/library/core/src/range.rs
+++ b/library/core/src/range.rs
@@ -421,6 +421,10 @@ const impl<T> From<legacy::RangeInclusive<T>> for RangeInclusive<T> {
     /// ```
     ///
     /// ```
+    /// # // This test requires unwinding to work.
+    /// # // Disable it when unwinding isn't available.
+    /// # #[cfg(panic = "unwind")]
+    /// # fn main() {
     /// use core::range::legacy;
     /// use core::range::RangeInclusive;
     /// use std::panic::catch_unwind;
@@ -430,6 +434,9 @@ const impl<T> From<legacy::RangeInclusive<T>> for RangeInclusive<T> {
     /// let result = catch_unwind(|| RangeInclusive::from(exhausted));
     /// // The `from` call either panicked or returned an empty range.
     /// assert!(result.is_err() || result.is_ok_and(|range| range.is_empty()));
+    /// # }
+    /// # #[cfg(not(panic = "unwind"))]
+    /// # fn main() {}
     /// ```
     #[inline]
     fn from(value: legacy::RangeInclusive<T>) -> Self {


### PR DESCRIPTION
As per https://github.com/rust-lang/rust/pull/155114#issuecomment-4845403701, this `From` impl no longer guarantees panicking for exhausted iterators. Instead, it only guarantees that the conversion will either panic or produce an empty range.

This is done so that we can optimize the implementation of `legacy::RangeInclusive` in a way such that we cannot check if it has been exhausted in a generic context without a `Step` and/or `PartialOrd` bound.

If this PR and/or rust-lang/rust#155114 merges after the 1.98.0 beta branch promotion from the main branch, then this will need a beta backport, since this PR changes the stable guarantee previously made in rust-lang/rust#155421.

This PR conflicts with and/or blocks rust-lang/rust#155114.