### PR TITLE
bootstrap: only encode RUSTFLAGS when a flag contains a space

### DIFF
--- a/src/bootstrap/src/core/builder/cargo.rs
+++ b/src/bootstrap/src/core/builder/cargo.rs
@@ -78,6 +78,26 @@ impl Rustflags {
     }
 }
 
+/// Picks the environment variable and value to pass a set of [`Rustflags`] to cargo.
+///
+/// `flags` is the `\x1f`-separated string built by [`Rustflags`]. We prefer the plain,
+/// space-separated form (`RUSTFLAGS`/`RUSTDOCFLAGS`) so the command stays readable and
+/// copy-pasteable in bootstrap's debug output, and only fall back to the `CARGO_ENCODED_*` form
+/// (which keeps the `\x1f` separators) when a flag value contains a space that the plain,
+/// whitespace-split form can't represent. See <https://github.com/rust-lang/rust/issues/158749>.
+pub(super) fn flags_env(
+    plain: &'static str,
+    encoded: &'static str,
+    flags: &str,
+) -> (&'static str, String) {
+    // A space can only appear inside a flag value, since the separators are `\x1f`.
+    if flags.contains(' ') {
+        (encoded, flags.to_string())
+    } else {
+        (plain, flags.replace('\x1f', " "))
+    }
+}
+
 /// Flags that are passed to the `rustc` shim binary. These flags will only be applied when
 /// compiling host code, i.e. when `--target` is unset.
 #[derive(Debug, Default)]
@@ -465,21 +485,25 @@ impl From<Cargo> for BootstrapCommand {
 
         cargo.command.args(cargo.args);
 
-        // Always unset the plain RUSTFLAGS/RUSTDOCFLAGS so that downstream
-        // tools (e.g. build.rs scripts) see only the encoded form. Any flags
-        // from the caller's environment have already been folded into the
-        // Rustflags struct via `propagate_cargo_env`.
+        // Unset any inherited flag variables (plain and encoded) so cargo uses only the flags
+        // bootstrap sets below. Flags from the caller's environment have already been folded into
+        // the Rustflags struct via `propagate_cargo_env`. This also matters because we may set the
+        // plain form below, which cargo ignores when `CARGO_ENCODED_RUSTFLAGS` is also present.
         cargo.command.env_remove("RUSTFLAGS");
+        cargo.command.env_remove("CARGO_ENCODED_RUSTFLAGS");
         cargo.command.env_remove("RUSTDOCFLAGS");
+        cargo.command.env_remove("CARGO_ENCODED_RUSTDOCFLAGS");
 
-        let rustflags = &cargo.rustflags.0;
-        if !rustflags.is_empty() {
-            cargo.command.env("CARGO_ENCODED_RUSTFLAGS", rustflags);
+        if !cargo.rustflags.0.is_empty() {
+            let (var, value) =
+                flags_env("RUSTFLAGS", "CARGO_ENCODED_RUSTFLAGS", &cargo.rustflags.0);
+            cargo.command.env(var, value);
         }
 
-        let rustdocflags = &cargo.rustdocflags.0;
-        if !rustdocflags.is_empty() {
-            cargo.command.env("CARGO_ENCODED_RUSTDOCFLAGS", rustdocflags);
+        if !cargo.rustdocflags.0.is_empty() {
+            let (var, value) =
+                flags_env("RUSTDOCFLAGS", "CARGO_ENCODED_RUSTDOCFLAGS", &cargo.rustdocflags.0);
+            cargo.command.env(var, value);
         }
 
         let encoded_hostflags = cargo.hostflags.encode();

--- a/src/bootstrap/src/core/builder/tests.rs
+++ b/src/bootstrap/src/core/builder/tests.rs
@@ -3349,3 +3349,26 @@ fn render_compiler(compiler: Compiler, config: &RenderConfig) -> String {
 fn host_target() -> String {
     get_host_target().to_string()
 }
+
+#[test]
+fn flags_env_prefers_plain_form_without_spaces() {
+    use super::cargo::flags_env;
+
+    // No flag value contains a space, so use the readable, copy-pasteable plain form
+    // rather than the `\x1f`-separated encoded form (rust-lang/rust#158749).
+    assert_eq!(
+        flags_env("RUSTFLAGS", "CARGO_ENCODED_RUSTFLAGS", "--cfg=foo\u{1f}-Cdebuginfo=0"),
+        ("RUSTFLAGS", "--cfg=foo -Cdebuginfo=0".to_string()),
+    );
+
+    // A flag value contains a space (e.g. an `-L` path), which the whitespace-split plain
+    // form can't represent, so keep the encoded form.
+    assert_eq!(
+        flags_env(
+            "RUSTFLAGS",
+            "CARGO_ENCODED_RUSTFLAGS",
+            "-Clink-arg=-L/opt/my libs\u{1f}--cfg=foo"
+        ),
+        ("CARGO_ENCODED_RUSTFLAGS", "-Clink-arg=-L/opt/my libs\u{1f}--cfg=foo".to_string()),
+    );
+}


### PR DESCRIPTION
Fixes rust-lang/rust#158749

Since rust-lang/rust#158073, bootstrap passes rustc and rustdoc flags to cargo through `CARGO_ENCODED_RUSTFLAGS` / `CARGO_ENCODED_RUSTDOCFLAGS`, whose values are `\x1f`-separated. When a command fails and gets debug-printed, that separator shows up as `\u{1f}`, e.g.:

```
CARGO_ENCODED_RUSTDOCFLAGS="--cfg=windows_raw_dylib\u{1f}-Csymbol-mangling-version=v0\u{1f}..."
```

which isn't a valid escape in bash/zsh, so the printed command can't be copy-pasted.

The encoded form is only needed when a flag value contains a space (the case rust-lang/rust#158073 fixed, e.g. an `-L` path from `llvm-config --libdir` under a directory whose name has a space). Cargo splits `RUSTFLAGS` on spaces, so when no flag contains one the plain, space-separated `RUSTFLAGS`/`RUSTDOCFLAGS` form is equivalent and stays readable. This uses the plain form in that case and only falls back to the encoded form when a flag actually contains a space.

It also clears any inherited `CARGO_ENCODED_RUSTFLAGS`/`CARGO_ENCODED_RUSTDOCFLAGS`, since cargo prefers the encoded variable over the plain one and the plain form would otherwise be ignored.

r? @Mark-Simulacrum
