### PR TITLE
fix: emit diagnostic for AVR target without target-cpu

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/metadata.rs
+++ b/compiler/rustc_codegen_ssa/src/back/metadata.rs
@@ -24,6 +24,7 @@ use rustc_target::spec::{CfgAbi, LlvmAbi, Os, RelocModel, Target, ef_avr_arch};
 use tracing::debug;
 
 use super::apple;
+use crate::errors;
 
 /// The default metadata loader. This is used by cg_llvm and cg_clif.
 ///
@@ -370,7 +371,7 @@ pub(super) fn elf_e_flags(architecture: Architecture, sess: &Session) -> u32 {
             if let Some(ref cpu) = sess.opts.cg.target_cpu {
                 ef_avr_arch(cpu)
             } else {
-                bug!("AVR CPU not explicitly specified")
+                sess.dcx().emit_fatal(errors::CpuRequired)
             }
         }
         Architecture::Csky => {

--- a/tests/run-make/avr-custom-target-missing-cpu/avr-custom-missing-cpu.json
+++ b/tests/run-make/avr-custom-target-missing-cpu/avr-custom-missing-cpu.json
@@ -1,0 +1,33 @@
+{
+  "arch": "avr",
+  "atomic-cas": false,
+  "crt-objects-fallback": "false",
+  "data-layout": "e-P1-p:16:8-i8:8-i16:8-i32:8-i64:8-f32:8-f64:8-n8:16-a:8",
+  "eh-frame-header": false,
+  "exe-suffix": ".elf",
+  "late-link-args": {
+    "gnu-cc": [
+      "-lgcc"
+    ],
+    "gnu-lld-cc": [
+      "-lgcc"
+    ]
+  },
+  "linker": "avr-gcc",
+  "linker-flavor": "gnu-cc",
+  "llvm-target": "avr-unknown-unknown",
+  "max-atomic-width": 16,
+  "metadata": {
+    "description": null,
+    "host_tools": false,
+    "std": false,
+    "tier": 3
+  },
+  "pre-link-args": {
+    "gnu-cc": [],
+    "gnu-lld-cc": []
+  },
+  "relocation-model": "static",
+  "target-c-int-width": 16,
+  "target-pointer-width": 16
+}

--- a/tests/run-make/avr-custom-target-missing-cpu/foo.rs
+++ b/tests/run-make/avr-custom-target-missing-cpu/foo.rs
@@ -1,0 +1,13 @@
+#![feature(no_core, lang_items)]
+#![no_core]
+
+#[lang = "pointee_sized"]
+pub trait PointeeSized {}
+
+#[lang = "meta_sized"]
+pub trait MetaSized: PointeeSized {}
+
+#[lang = "sized"]
+trait Sized {}
+
+pub fn foo() {}

--- a/tests/run-make/avr-custom-target-missing-cpu/rmake.rs
+++ b/tests/run-make/avr-custom-target-missing-cpu/rmake.rs
@@ -1,0 +1,16 @@
+// Custom AVR targets can reach ELF e_flags emission without an explicit CPU
+// Make sure that reports the normal missing-CPU diagnostic instead of ICEing
+//
+//@ needs-llvm-components: avr
+
+use run_make_support::rustc;
+
+fn main() {
+    rustc()
+        .arg("-Zunstable-options")
+        .input("foo.rs")
+        .target("avr-custom-missing-cpu.json")
+        .crate_type("lib")
+        .run_fail()
+        .assert_stderr_contains("target requires explicitly specifying a cpu with `-C target-cpu`");
+}


### PR DESCRIPTION
Fixes rust-lang/rust#139223