### PR TITLE
adjust f128 windows abi for LLVM 23

### DIFF
--- a/compiler/rustc_codegen_cranelift/src/abi/mod.rs
+++ b/compiler/rustc_codegen_cranelift/src/abi/mod.rs
@@ -139,13 +139,19 @@ impl<'tcx> FunctionCx<'_, '_, 'tcx> {
         mut returns: Vec<AbiParam>,
         args: &[Value],
     ) -> Cow<'_, [Value]> {
-        // Pass i128 arguments by-ref on Windows.
+        // On x86_64 Windows f128 is passed and returned indirectly (sret in LLVM terminology).
+        let indirect_f128 =
+            self.tcx.sess.target.is_like_windows && self.tcx.sess.target.arch == Arch::X86_64;
+
+        // Pass i128 (and, on x86_64 Windows, f128) arguments by-ref.
         let (params, args): (Vec<_>, Cow<'_, [_]>) = if self.tcx.sess.target.is_like_windows {
             let (params, args): (Vec<_>, Vec<_>) = params
                 .into_iter()
                 .zip(args)
                 .map(|(param, &arg)| {
-                    if param.value_type == types::I128 {
+                    if param.value_type == types::I128
+                        || (indirect_f128 && param.value_type == types::F128)
+                    {
                         let arg_ptr = self.create_stack_slot(16, 16);
                         arg_ptr.store(self, arg, MemFlags::trusted());
                         (AbiParam::new(self.pointer_type), arg_ptr.get_addr(self))
@@ -161,6 +167,7 @@ impl<'tcx> FunctionCx<'_, '_, 'tcx> {
         };
 
         let ret_single_i128 = returns.len() == 1 && returns[0].value_type == types::I128;
+        let ret_single_f128 = returns.len() == 1 && returns[0].value_type == types::F128;
         if ret_single_i128 && self.tcx.sess.target.is_like_windows {
             // Return i128 using the vector ABI on Windows
             returns[0].value_type = types::I64X2;
@@ -168,8 +175,11 @@ impl<'tcx> FunctionCx<'_, '_, 'tcx> {
             let ret = self.lib_call_unadjusted(name, params, returns, &args)[0];
 
             Cow::Owned(vec![codegen_bitcast(self, types::I128, ret)])
-        } else if ret_single_i128 && self.tcx.sess.target.arch == Arch::S390x {
-            // Return i128 using a return area pointer on s390x.
+        } else if (ret_single_i128 && self.tcx.sess.target.arch == Arch::S390x)
+            || (ret_single_f128 && indirect_f128)
+        {
+            // Return x86_64 Windows f128 and s390x i128 indirectly (sret in LLVM terminology).
+            let ret_ty = returns[0].value_type;
             let mut params = params;
             let mut args = args.to_vec();
 
@@ -179,7 +189,7 @@ impl<'tcx> FunctionCx<'_, '_, 'tcx> {
 
             self.lib_call_unadjusted(name, params, vec![], &args);
 
-            Cow::Owned(vec![ret_ptr.load(self, types::I128, MemFlags::trusted())])
+            Cow::Owned(vec![ret_ptr.load(self, ret_ty, MemFlags::trusted())])
         } else {
             Cow::Borrowed(self.lib_call_unadjusted(name, params, returns, &args))
         }

--- a/compiler/rustc_codegen_llvm/src/llvm_util.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm_util.rs
@@ -369,7 +369,8 @@ fn update_target_reliable_float_cfg(sess: &Session, cfg: &mut TargetConfig) {
     cfg.has_reliable_f16 = match (target_arch, target_os) {
         // Unsupported <https://github.com/llvm/llvm-project/issues/94434> (fixed in llvm22)
         (Arch::Arm64EC, _) if major < 22 => false,
-        // MinGW ABI bugs <https://gcc.gnu.org/bugzilla/show_bug.cgi?id=115054>
+        // MinGW ABI bugs <https://gcc.gnu.org/bugzilla/show_bug.cgi?id=115054> resolved in GCC 16
+        // but our toolchain hasn't been updated.
         (Arch::X86_64, Os::Windows) if *target_env == Env::Gnu && *target_abi != CfgAbi::Llvm => {
             false
         }
@@ -397,8 +398,10 @@ fn update_target_reliable_float_cfg(sess: &Session, cfg: &mut TargetConfig) {
         (Arch::PowerPC | Arch::PowerPC64, _) => false,
         // ABI unsupported  <https://github.com/llvm/llvm-project/issues/41838> (fixed in llvm22)
         (Arch::Sparc, _) if major < 22 => false,
-        // MinGW ABI bugs <https://gcc.gnu.org/bugzilla/show_bug.cgi?id=115054>
-        (Arch::X86_64, Os::Windows) if *target_env == Env::Gnu && *target_abi != CfgAbi::Llvm => {
+        // MinGW ABI bugs <https://gcc.gnu.org/bugzilla/show_bug.cgi?id=115054> (fixed in llvm23)
+        (Arch::X86_64, Os::Windows)
+            if *target_env == Env::Gnu && *target_abi != CfgAbi::Llvm && major < 23 =>
+        {
             false
         }
         // There are no known problems on other platforms, so the only requirement is that symbols

--- a/compiler/rustc_target/src/callconv/x86_win64.rs
+++ b/compiler/rustc_target/src/callconv/x86_win64.rs
@@ -1,4 +1,4 @@
-use rustc_abi::{BackendRepr, Float, Integer, Primitive, Size, TyAbiInterface};
+use rustc_abi::{BackendRepr, Integer, Primitive, Size, TyAbiInterface};
 
 use crate::callconv::{ArgAbi, FnAbi, Reg};
 use crate::spec::{HasTargetSpec, RustcAbi};
@@ -35,11 +35,7 @@ where
                         // FIXME(#134288): This may change for the `-msvc` targets in the future.
                         a.cast_to(Reg::opaque_vector(Size::from_bits(128)));
                     }
-                } else if a.layout.size.bytes() > 8
-                    && !matches!(scalar.primitive(), Primitive::Float(Float::F128))
-                {
-                    // Match what LLVM does for `f128` so that `compiler-builtins` builtins match up
-                    // with what LLVM expects.
+                } else if a.layout.size.bytes() > 8 {
                     a.make_indirect();
                 } else {
                     a.extend_integer_width_to(32);

--- a/tests/assembly-llvm/x86_64-windows-float-abi.rs
+++ b/tests/assembly-llvm/x86_64-windows-float-abi.rs
@@ -3,9 +3,6 @@
 //@ compile-flags: --target x86_64-pc-windows-msvc
 //@ needs-llvm-components: x86
 //@ add-minicore
-//@ revisions: LLVM22 LLVM23
-//@ [LLVM22] max-llvm-major-version: 22
-//@ [LLVM23] min-llvm-version: 23
 
 #![feature(f16, f128)]
 #![feature(no_core)]
@@ -40,12 +37,10 @@ pub extern "C" fn second_f64(_: f64, x: f64) -> f64 {
 }
 
 // CHECK-LABEL: second_f128
-// LLVM22: movaps (%rdx), %xmm0
-// LLVM22-NEXT: retq
-// LLVM23: movq %rcx, %rax
-// LLVM23-NEXT: movaps (%r8), %xmm0
-// LLVM23-NEXT: movaps %xmm0, (%rcx)
-// LLVM23-NEXT: retq
+// CHECK: movq %rcx, %rax
+// CHECK-NEXT: movaps (%r8), %xmm0
+// CHECK-NEXT: movaps %xmm0, (%rcx)
+// CHECK-NEXT: retq
 #[no_mangle]
 pub extern "C" fn second_f128(_: f128, x: f128) -> f128 {
     x


### PR DESCRIPTION
as of LLVM 23, sret is now used to return f128, now matching GCC

- https://github.com/llvm/llvm-project/pull/204887

Let's see if this change breaks anything, if not we can have it tested with the LLVM 23 setup.