### PR TITLE
hook intrinsic-test into aarch64-gnu

### DIFF
--- a/src/ci/docker/host-aarch64/aarch64-gnu/Dockerfile
+++ b/src/ci/docker/host-aarch64/aarch64-gnu/Dockerfile
@@ -26,4 +26,5 @@ ENV RUST_CONFIGURE_ARGS="--build=aarch64-unknown-linux-gnu \
  --enable-profiler \
  --enable-compiler-docs"
 ENV SCRIPT="python3 ../x.py --stage 2 test && \
-  python3 ../x.py --stage 2 test src/tools/cargo"
+  python3 ../x.py --stage 2 test src/tools/cargo && \
+  python3 ../x.py --stage 2 test library/stdarch/crates/intrinsic-test"


### PR DESCRIPTION
This PR hooks intrinsic-test into aarch64-gnu docker job . 

So stdarch's aarch64 intrinsics get coverage in rustc CI.

r? @Kobzol