### PR TITLE
Add regression test for builtin attr macro values

### DIFF
--- a/tests/ui/attributes/builtin-attr-macro-value-issue-145922.rs
+++ b/tests/ui/attributes/builtin-attr-macro-value-issue-145922.rs
@@ -1,0 +1,34 @@
+//@ check-pass
+#![allow(unused_attributes, unused_macros)]
+
+// Regression test for #145922.
+// This used to create a delayed ICE while parsing builtin attributes.
+#[crate_type = concat!("my", "crate")]
+macro_rules! foo {
+    () => {
+        32
+    };
+}
+
+#[recursion_limit = concat!("1", "2")]
+macro_rules! baz {
+    () => {
+        32
+    };
+}
+
+#[type_length_limit = concat!("1", "2")]
+macro_rules! qux {
+    () => {
+        32
+    };
+}
+
+#[windows_subsystem = concat!("cons", "ole")]
+macro_rules! bar {
+    () => {
+        32
+    };
+}
+
+fn main() {}


### PR DESCRIPTION
Adds a UI regression test for rust-lang/rust#145922

The test covers builtin attributes whose value is a macro call on a macro item, including the extra attributes mentioned in the issue thread. `windows_subsystem` still emits its normal malformed-attribute error; the other cases make sure they don't regress into the delayed ICE again

Fixes rust-lang/rust#145922

Tested:
- `python3 x.py test tests/ui/attributes/builtin-attr-macro-value-issue-145922.rs --force-rerun -j 2`
- `python3 x.py test tidy -j 2`