### PR TITLE
Retarget E0282 to the ambiguous projection input

### DIFF
--- a/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
@@ -1528,11 +1528,12 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     #[cold]
     pub(crate) fn type_must_be_known_at_this_point(&self, sp: Span, ty: Ty<'tcx>) -> Ty<'tcx> {
         let guar = self.tainted_by_errors().unwrap_or_else(|| {
+            let report_term = self.ambiguous_projection_input(ty).unwrap_or(ty);
             self.err_ctxt()
                 .emit_inference_failure_err(
                     self.body_id,
                     sp,
-                    ty.into(),
+                    report_term.into(),
                     TypeAnnotationNeeded::E0282,
                     true,
                 )

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/inspect_obligations.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/inspect_obligations.rs
@@ -1,5 +1,6 @@
 //! A utility module to inspect currently ambiguous obligations in the current context.
 
+use rustc_data_structures::fx::FxHashSet;
 use rustc_data_structures::unord::UnordSet;
 use rustc_hir::def_id::DefId;
 use rustc_infer::traits::{self, ObligationCause, PredicateObligations};
@@ -112,6 +113,139 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             !obligation.predicate.has_placeholders()
         });
         obligations_for_self_ty
+    }
+
+    /// When we're about to emit `E0282` for a bare type inference variable `ty`,
+    /// find a better variable to blame: the unresolved input of a stalled
+    /// associated-type projection whose output is (equivalent to) `ty`.
+    ///
+    /// E.g. in `v.get(x.into())` with `v: Vec<Foo>`, `get` returns
+    /// `Option<&<?I as SliceIndex<[Foo]>>::Output>`. If `?I` (the `.into()` target)
+    /// is unknown we get stuck on the output `?Out` at a later use. `?Out` has no
+    /// annotatable source but `?I` does, so we blame `?I` instead. See #146126.
+    ///
+    /// Returns `None` unless `ty` is the output of such a stalled *trait* projection
+    /// with a bare inference-variable input. Type variables only (not consts).
+    #[instrument(level = "debug", skip(self), ret)]
+    pub(crate) fn ambiguous_projection_input(&self, ty: Ty<'tcx>) -> Option<Ty<'tcx>> {
+        // Follow chains of stalled projections (e.g. `x.into().into()`) for a few
+        // hops. The bound keeps this cheap and guarantees termination; every known
+        // case needs a single hop.
+        const MAX_HOPS: usize = 4;
+
+        let mut current = self.shallow_resolve(ty);
+        let mut result = None;
+
+        for _ in 0..MAX_HOPS {
+            let ty::Infer(ty::TyVar(cur_vid)) = *current.kind() else { break };
+
+            let obligations = self.fulfillment_cx.borrow().pending_obligations();
+
+            // The stuck variable is often only a `Subtype`/`Coerce` sibling of the
+            // projection output, not the output itself. Follow those relations to a
+            // fixpoint to collect every variable holding the same value.
+            let mut related: FxHashSet<ty::TyVid> = FxHashSet::default();
+            related.insert(self.root_var(cur_vid));
+            loop {
+                let mut changed = false;
+                for obligation in &obligations {
+                    let predicate = self.resolve_vars_if_possible(obligation.predicate);
+                    let Some(kind) = predicate.kind().no_bound_vars() else { continue };
+                    let (a, b) = match kind {
+                        ty::PredicateKind::Subtype(p) => (p.a, p.b),
+                        ty::PredicateKind::Coerce(p) => (p.a, p.b),
+                        _ => continue,
+                    };
+                    if let (ty::Infer(ty::TyVar(av)), ty::Infer(ty::TyVar(bv))) =
+                        (self.shallow_resolve(a).kind(), self.shallow_resolve(b).kind())
+                    {
+                        let (ar, br) = (self.root_var(*av), self.root_var(*bv));
+                        if related.contains(&ar) != related.contains(&br) {
+                            related.insert(ar);
+                            related.insert(br);
+                            changed = true;
+                        }
+                    }
+                }
+                if !changed {
+                    break;
+                }
+            }
+
+            // Find stalled *trait* projections whose output is in `related` and
+            // collect their distinct unresolved inputs. (Only trait projections:
+            // their input is well-defined; inherent/opaque/free aliases aren't.)
+            // Retarget only if exactly one input turns up; otherwise blaming a
+            // single one would be arbitrary, so leave the diagnostic unchanged.
+            let mut candidate_roots: FxHashSet<ty::TyVid> = FxHashSet::default();
+            let mut candidate = None;
+            for obligation in &obligations {
+                let predicate = self.resolve_vars_if_possible(obligation.predicate);
+                let Some(kind) = predicate.kind().no_bound_vars() else { continue };
+
+                let (alias_args, term) = match kind {
+                    ty::PredicateKind::Clause(ty::ClauseKind::Projection(pred))
+                        if pred.projection_term.kind.is_trait_projection() =>
+                    {
+                        (pred.projection_term.args, pred.term)
+                    }
+                    ty::PredicateKind::NormalizesTo(pred)
+                        if pred.alias.kind.is_trait_projection() =>
+                    {
+                        (pred.alias.args, pred.term)
+                    }
+                    ty::PredicateKind::AliasRelate(lhs, rhs, _) => {
+                        if let Some(lhs_ty) = lhs.as_type()
+                            && let ty::Alias(_, alias) = *self.shallow_resolve(lhs_ty).kind()
+                            && matches!(alias.kind, ty::AliasTyKind::Projection { .. })
+                        {
+                            (alias.args, rhs)
+                        } else if let Some(rhs_ty) = rhs.as_type()
+                            && let ty::Alias(_, alias) = *self.shallow_resolve(rhs_ty).kind()
+                            && matches!(alias.kind, ty::AliasTyKind::Projection { .. })
+                        {
+                            (alias.args, lhs)
+                        } else {
+                            continue;
+                        }
+                    }
+                    _ => continue,
+                };
+
+                // The output must be (equivalent to) the stuck variable.
+                let Some(term_ty) = term.as_type() else { continue };
+                let ty::Infer(ty::TyVar(term_vid)) = *self.shallow_resolve(term_ty).kind() else {
+                    continue;
+                };
+                if !related.contains(&self.root_var(term_vid)) {
+                    continue;
+                }
+
+                // Blame the first input that is still an unresolved variable. Args
+                // are `[Self, trait args.., assoc args..]`, so this prefers `Self`,
+                // e.g. `?input` of `<?input as SliceIndex<_>>::Output`.
+                for arg in alias_args {
+                    if let Some(arg_ty) = arg.as_type() {
+                        let arg_ty = self.shallow_resolve(arg_ty);
+                        if let ty::Infer(ty::TyVar(vid)) = arg_ty.kind() {
+                            if candidate_roots.insert(self.root_var(*vid)) {
+                                candidate = Some(arg_ty);
+                            }
+                            break;
+                        }
+                    }
+                }
+            }
+
+            match candidate {
+                Some(input) if candidate_roots.len() == 1 => {
+                    result = Some(input);
+                    current = input;
+                }
+                _ => break,
+            }
+        }
+        result
     }
 
     /// Only needed for the `From<{float}>` for `f32` type fallback.

--- a/tests/ui/cast/issue-85586.rs
+++ b/tests/ui/cast/issue-85586.rs
@@ -6,5 +6,5 @@
 fn main() {
     let a = [1, 2, 3].iter().sum();
     let b = (a + 1) as usize;
-    //~^ ERROR: type annotations needed [E0282]
+    //~^^ ERROR: type annotations needed [E0282]
 }

--- a/tests/ui/cast/issue-85586.stderr
+++ b/tests/ui/cast/issue-85586.stderr
@@ -1,8 +1,15 @@
 error[E0282]: type annotations needed
-  --> $DIR/issue-85586.rs:8:13
+  --> $DIR/issue-85586.rs:7:9
    |
+LL |     let a = [1, 2, 3].iter().sum();
+   |         ^
 LL |     let b = (a + 1) as usize;
-   |             ^^^^^^^ cannot infer type
+   |             ------- type must be known at this point
+   |
+help: consider giving `a` an explicit type
+   |
+LL |     let a: /* Type */ = [1, 2, 3].iter().sum();
+   |          ++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/type-inference/ambiguous-into-arg-projection-multi.rs
+++ b/tests/ui/type-inference/ambiguous-into-arg-projection-multi.rs
@@ -1,0 +1,23 @@
+// Regression test for the uniqueness guard added alongside the #146126 fix.
+//
+// The E0282 retargeting heuristic walks from a stuck inference variable, through
+// `Subtype`/`Coerce` relations, to a stalled associated type projection, and
+// blames that projection's unresolved input. When *several* distinct projections
+// end up in the same inference "component" (here two different `.get(_.into())`
+// results joined by an `if`/`else`), there is no single obvious culprit, so the
+// heuristic must bail out and leave the ordinary "type annotations needed"
+// diagnostic in place rather than arbitrarily blaming one of them.
+
+struct Foo {
+    f: Option<i32>,
+}
+
+fn main() {
+    let a = vec![Foo { f: Some(1) }];
+    let b = vec![Foo { f: Some(2) }];
+    let x = if true { a.get(0u8.into()) } else { b.get(0u8.into()) };
+    //~^ ERROR type annotations needed
+    if let Some(y) = x {
+        if let Some(_f) = y.f {}
+    }
+}

--- a/tests/ui/type-inference/ambiguous-into-arg-projection-multi.stderr
+++ b/tests/ui/type-inference/ambiguous-into-arg-projection-multi.stderr
@@ -1,0 +1,17 @@
+error[E0282]: type annotations needed for `Option<&_>`
+  --> $DIR/ambiguous-into-arg-projection-multi.rs:18:9
+   |
+LL |     let x = if true { a.get(0u8.into()) } else { b.get(0u8.into()) };
+   |         ^
+...
+LL |         if let Some(_f) = y.f {}
+   |                           --- type must be known at this point
+   |
+help: consider giving `x` an explicit type, where the placeholder `_` is specified
+   |
+LL |     let x: Option<&_> = if true { a.get(0u8.into()) } else { b.get(0u8.into()) };
+   |          ++++++++++++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0282`.

--- a/tests/ui/type-inference/ambiguous-into-arg-projection.current.stderr
+++ b/tests/ui/type-inference/ambiguous-into-arg-projection.current.stderr
@@ -1,0 +1,17 @@
+error[E0282]: type annotations needed
+  --> $DIR/ambiguous-into-arg-projection.rs:21:24
+   |
+LL |     if let Some(x) = v.get(0_i16.into()) {
+   |                        ^^^ cannot infer type of the type parameter `I` declared on the method `get`
+LL |
+LL |         if let Some(f) = x.f {
+   |                          --- type must be known at this point
+   |
+help: consider specifying a concrete type for the type parameter `I`
+   |
+LL |     if let Some(x) = v.get::</* Type */>(0_i16.into()) {
+   |                           ++++++++++++++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0282`.

--- a/tests/ui/type-inference/ambiguous-into-arg-projection.next.stderr
+++ b/tests/ui/type-inference/ambiguous-into-arg-projection.next.stderr
@@ -1,0 +1,17 @@
+error[E0282]: type annotations needed
+  --> $DIR/ambiguous-into-arg-projection.rs:21:24
+   |
+LL |     if let Some(x) = v.get(0_i16.into()) {
+   |                        ^^^ cannot infer type of the type parameter `I` declared on the method `get`
+LL |
+LL |         if let Some(f) = x.f {
+   |                          --- type must be known at this point
+   |
+help: consider specifying a concrete type for the type parameter `I`
+   |
+LL |     if let Some(x) = v.get::</* Type */>(0_i16.into()) {
+   |                           ++++++++++++++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0282`.

--- a/tests/ui/type-inference/ambiguous-into-arg-projection.rs
+++ b/tests/ui/type-inference/ambiguous-into-arg-projection.rs
@@ -1,0 +1,31 @@
+//@ revisions: current next
+//@[next] compile-flags: -Znext-solver
+// Regression test for #146126.
+//
+// When the target type of a `.into()` passed as an argument to a generic method
+// (here `<[T]>::get`, whose return type is the associated type projection
+// `<I as SliceIndex<[T]>>::Output`) cannot be inferred, the ambiguity used to be
+// reported against a downstream use of the call's result (the `x.f` field
+// access) instead of the `.into()` that is its actual source.
+//
+// Check that the error now points inside `v.get(0_i16.into())`, not at `x.f`.
+// The `next` revision exercises the `-Znext-solver` code paths (`NormalizesTo` /
+// `AliasRelate` obligations) of the retargeting heuristic.
+
+struct Foo {
+    f: Option<i32>,
+}
+
+fn main() {
+    let v = vec![Foo { f: Some(1) }];
+    if let Some(x) = v.get(0_i16.into()) {
+        //~^ ERROR type annotations needed
+        if let Some(f) = x.f {
+            println!("{}", f);
+        } else {
+            println!("not present");
+        }
+    } else {
+        println!("bad index");
+    }
+}

--- a/tests/ui/type-inference/index-expr-ambiguous-type.stderr
+++ b/tests/ui/type-inference/index-expr-ambiguous-type.stderr
@@ -2,7 +2,13 @@ error[E0282]: type annotations needed
   --> $DIR/index-expr-ambiguous-type.rs:9:34
    |
 LL |     let _foo = [1, 2, 3][bad_idx.into()] as i32;
-   |                                  ^^^^ cannot infer type
+   |                                  ^^^^
+   |
+help: try using a fully qualified path to specify the expected types
+   |
+LL -     let _foo = [1, 2, 3][bad_idx.into()] as i32;
+LL +     let _foo = [1, 2, 3][<u8 as Into<T>>::into(bad_idx)] as i32;
+   |
 
 error[E0284]: type annotations needed
   --> $DIR/index-expr-ambiguous-type.rs:15:38

--- a/tests/ui/typeck/issue-65611.rs
+++ b/tests/ui/typeck/issue-65611.rs
@@ -57,6 +57,6 @@ impl<A: Array> ArrayVec<A> {
 fn main() {
     let mut buffer = ArrayVec::new();
     let x = buffer.last().unwrap().0.clone();
-    //~^ ERROR type annotations needed
+    //~^^ ERROR type annotations needed
     buffer.reverse();
 }

--- a/tests/ui/typeck/issue-65611.stderr
+++ b/tests/ui/typeck/issue-65611.stderr
@@ -1,8 +1,15 @@
-error[E0282]: type annotations needed
-  --> $DIR/issue-65611.rs:59:13
+error[E0282]: type annotations needed for `ArrayVec<_>`
+  --> $DIR/issue-65611.rs:58:9
    |
+LL |     let mut buffer = ArrayVec::new();
+   |         ^^^^^^^^^^
 LL |     let x = buffer.last().unwrap().0.clone();
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type for type parameter `T`
+   |             ------------------------ type must be known at this point
+   |
+help: consider giving `buffer` an explicit type, where the type for type parameter `A` is specified
+   |
+LL |     let mut buffer: ArrayVec<A> = ArrayVec::new();
+   |                   +++++++++++++
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
Fixes rust-lang/rust#146126.

## Problem

When the target type of a `.into()` argument to a generic method can't be
inferred, `E0282: type annotations needed` was reported at a *downstream use* of
the result instead of the `.into()` that caused the ambiguity.

For `v.get(0_i16.into())` with `v: Vec<Foo>`, `get` returns
`Option<&<?I as SliceIndex<[Foo]>>::Output>`. `?I` is ambiguous, so the stuck
projection output only surfaces later, e.g. at an `x.f` field access, which has
nothing to annotate.

## Fix

Before emitting `E0282`, `type_must_be_known_at_this_point` calls a new helper
`ambiguous_projection_input`: it walks from the stuck variable through pending
`Subtype`/`Coerce` relations, finds a stalled trait projection whose output
lands in that set, and blames the projection's unresolved input (`?I`) instead.
It handles both solvers (`Projection`, and `NormalizesTo`/`AliasRelate`), bails
unless there is exactly one candidate, and is bounded to a few hops.

The error now points at `v.get(...)` with a "specify a concrete type for `I`"
suggestion.

## Tests

- `ambiguous-into-arg-projection.rs`: the rust-lang/rust#146126 repro (`current`/`next`
  revisions cover both solvers).
- `ambiguous-into-arg-projection-multi.rs`: the single-candidate guard, where
  two `.get(_.into())` results joined by `if`/`else` must leave the ordinary
  diagnostic in place.

Incidental improvements (error now lands on the real source): `cast/issue-85586`,
`typeck/issue-65611`, `type-inference/index-expr-ambiguous-type`.