### PR TITLE
Avoid unused braces lint for macro generated arguments

### DIFF
--- a/compiler/rustc_lint/src/unused.rs
+++ b/compiler/rustc_lint/src/unused.rs
@@ -417,13 +417,19 @@ trait UnusedDelimLint {
             }
             // either function/method call, or something this lint doesn't care about
             ref call_or_other => {
-                let (args_to_check, ctx) = match *call_or_other {
-                    Call(_, ref args) => (&args[..], UnusedDelimsCtx::FunctionArg),
-                    MethodCall(ref call) => (&call.args[..], UnusedDelimsCtx::MethodArg),
+                let (args_to_check, ctx, callee_from_expansion) = match *call_or_other {
+                    Call(ref callee, ref args) => {
+                        (&args[..], UnusedDelimsCtx::FunctionArg, callee.span.from_expansion())
+                    }
+                    MethodCall(ref call) => (
+                        &call.args[..],
+                        UnusedDelimsCtx::MethodArg,
+                        call.seg.ident.span.from_expansion(),
+                    ),
                     Closure(ref closure)
                         if matches!(closure.fn_decl.output, FnRetTy::Default(_)) =>
                     {
-                        (&[closure.body.clone()][..], UnusedDelimsCtx::ClosureBody)
+                        (&[closure.body.clone()][..], UnusedDelimsCtx::ClosureBody, false)
                     }
                     // actual catch-all arm
                     _ => {
@@ -438,6 +444,11 @@ trait UnusedDelimLint {
                     return;
                 }
                 for arg in args_to_check {
+                    // Whether an expression is wrapped in a block can change which `macro_rules!`
+                    // arm is taken. Don't report the braces as unused in that case. (Issue #158747)
+                    if callee_from_expansion && Self::block_wraps_expanded_expr(arg) {
+                        continue;
+                    }
                     self.check_unused_delims_expr(cx, arg, ctx, false, None, None, false);
                 }
                 return;
@@ -515,6 +526,20 @@ trait UnusedDelimLint {
             None,
             false,
         );
+    }
+
+    // Returns true for a user-written block whose only expression came from a macro expansion.
+    fn block_wraps_expanded_expr(value: &ast::Expr) -> bool {
+        if let ast::ExprKind::Block(ref block, None) = value.kind
+            && block.rules == ast::BlockCheckMode::Default
+            && !value.span.from_expansion()
+            && let [stmt] = block.stmts.as_slice()
+            && let ast::StmtKind::Expr(ref expr) = stmt.kind
+        {
+            expr.span.from_expansion()
+        } else {
+            false
+        }
     }
 }
 

--- a/tests/ui/lint/unused-braces-macro-arg-issue-158747.fixed
+++ b/tests/ui/lint/unused-braces-macro-arg-issue-158747.fixed
@@ -1,0 +1,40 @@
+//@ check-pass
+//@ run-rustfix
+
+// Removing block braces can change how macro-generated calls match macro arguments.
+
+#![warn(unused_braces)]
+
+macro_rules! type_or_expr {
+    ($x:ty) => {
+        identity(stringify!($x))
+    };
+    ($x:expr) => {
+        identity($x)
+    };
+}
+
+macro_rules! call_expr {
+    ($e:expr) => {
+        identity($e)
+    };
+}
+
+macro_rules! call_block {
+    ($b:block) => {
+        identity($b)
+    };
+}
+
+fn identity<T>(x: T) -> T {
+    x
+}
+
+fn main() {
+    // should not warn
+    let _ = type_or_expr!({ format!("{}", 1) });
+    // should not warn
+    let _ = call_expr!(1);
+    //~^ WARN unnecessary braces around function argument
+    let _ = call_block!({ 1 });
+}

--- a/tests/ui/lint/unused-braces-macro-arg-issue-158747.rs
+++ b/tests/ui/lint/unused-braces-macro-arg-issue-158747.rs
@@ -1,0 +1,40 @@
+//@ check-pass
+//@ run-rustfix
+
+// Removing block braces can change how macro-generated calls match macro arguments.
+
+#![warn(unused_braces)]
+
+macro_rules! type_or_expr {
+    ($x:ty) => {
+        identity(stringify!($x))
+    };
+    ($x:expr) => {
+        identity($x)
+    };
+}
+
+macro_rules! call_expr {
+    ($e:expr) => {
+        identity($e)
+    };
+}
+
+macro_rules! call_block {
+    ($b:block) => {
+        identity($b)
+    };
+}
+
+fn identity<T>(x: T) -> T {
+    x
+}
+
+fn main() {
+    // should not warn
+    let _ = type_or_expr!({ format!("{}", 1) });
+    // should not warn
+    let _ = call_expr!({ 1 });
+    //~^ WARN unnecessary braces around function argument
+    let _ = call_block!({ 1 });
+}

--- a/tests/ui/lint/unused-braces-macro-arg-issue-158747.stderr
+++ b/tests/ui/lint/unused-braces-macro-arg-issue-158747.stderr
@@ -1,0 +1,19 @@
+warning: unnecessary braces around function argument
+  --> $DIR/unused-braces-macro-arg-issue-158747.rs:37:24
+   |
+LL |     let _ = call_expr!({ 1 });
+   |                        ^^ ^^
+   |
+note: the lint level is defined here
+  --> $DIR/unused-braces-macro-arg-issue-158747.rs:6:9
+   |
+LL | #![warn(unused_braces)]
+   |         ^^^^^^^^^^^^^
+help: remove these braces
+   |
+LL -     let _ = call_expr!({ 1 });
+LL +     let _ = call_expr!(1);
+   |
+
+warning: 1 warning emitted
+


### PR DESCRIPTION
Fixes rust-lang/rust#158747

This changes the `unused_braces` lint to avoid suggesting brace removal for macro arguments when those braces may affect `macro_rules!`.

But the fragment kind matters:

- `$e:expr` matches an expression. Both `1` and `{ 1 }` are expressions, so removing braces can still leave the macro matching the same kind of input.
- `$b:block` only matches a block expression written with braces. `{ 1 }` matches, but `1` does not.

So `call_expr!({ 1 })` can usually be simplified to `call_expr!(1)`, while `call_block!({ 1 })` cannot.

It seems a more concrect report need a full `macro_rules!` matcher analysis, that seems too heavy for `unused` lint. 