### PR TITLE
fix: remove alias rigid before calling `relate`

### DIFF
--- a/compiler/rustc_trait_selection/src/error_reporting/infer/mod.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/mod.rs
@@ -2262,6 +2262,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
     /// Float types, respectively). When comparing two ADTs, these rules apply recursively.
     pub fn same_type_modulo_infer<T: relate::Relate<TyCtxt<'tcx>>>(&self, a: T, b: T) -> bool {
         let (a, b) = self.resolve_vars_if_possible((a, b));
+        let (a, b) = ty::set_aliases_to_non_rigid(self.tcx, (a, b)).skip_norm_wip();
         SameTypeModuloInfer(self).relate(a, b).is_ok()
     }
 }

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/mod.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/mod.rs
@@ -2262,7 +2262,6 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
     /// Float types, respectively). When comparing two ADTs, these rules apply recursively.
     pub fn same_type_modulo_infer<T: relate::Relate<TyCtxt<'tcx>>>(&self, a: T, b: T) -> bool {
         let (a, b) = self.resolve_vars_if_possible((a, b));
-        let (a, b) = ty::set_aliases_to_non_rigid(self.tcx, (a, b)).skip_norm_wip();
         SameTypeModuloInfer(self).relate(a, b).is_ok()
     }
 }
@@ -2312,6 +2311,12 @@ impl<'tcx> TypeRelation<TyCtxt<'tcx>> for SameTypeModuloInfer<'_, 'tcx> {
             | (ty::Infer(ty::InferTy::TyVar(_)), _)
             | (_, ty::Infer(ty::InferTy::TyVar(_))) => Ok(a),
             (ty::Infer(_), _) | (_, ty::Infer(_)) => Err(TypeError::Mismatch),
+            // Whether an alias is marked as `IsRigid::Yes` depends on inference progress.
+            // A comparison modulo inference must therefore ignore it.
+            (ty::Alias(_, alias_a), ty::Alias(_, alias_b)) => {
+                self.relate(*alias_a, *alias_b)?;
+                Ok(a)
+            }
             _ => relate::structurally_relate_tys(self, a, b),
         }
     }

--- a/tests/ui/traits/next-solver/rigid-alias-in-same-type-modulo-infer-158773.rs
+++ b/tests/ui/traits/next-solver/rigid-alias-in-same-type-modulo-infer-158773.rs
@@ -1,0 +1,17 @@
+// Regression test for #158773.
+// This test is cited from #158773.
+//@ compile-flags: -Znext-solver=globally
+
+trait HasLifetime {
+    type AtLifetime<'a>;
+}
+
+pub struct ExistentialLifetime<S: HasLifetime>(S::AtLifetime<'static>);
+
+impl<S: HasLifetime> ExistentialLifetime<S> {
+    fn new() -> ExistentialLifetime<S> {
+        ExistentialLifetime(ExistentialLifetime(())) //~ ERROR: type mismatch resolving `<S as HasLifetime>::AtLifetime<'static> == ExistentialLifetime<_>` [E0271]
+    }
+}
+
+fn main() {}

--- a/tests/ui/traits/next-solver/rigid-alias-in-same-type-modulo-infer-158773.rs
+++ b/tests/ui/traits/next-solver/rigid-alias-in-same-type-modulo-infer-158773.rs
@@ -1,5 +1,3 @@
-// Regression test for #158773.
-// This test is cited from #158773.
 //@ compile-flags: -Znext-solver=globally
 
 trait HasLifetime {

--- a/tests/ui/traits/next-solver/rigid-alias-in-same-type-modulo-infer-158773.stderr
+++ b/tests/ui/traits/next-solver/rigid-alias-in-same-type-modulo-infer-158773.stderr
@@ -1,5 +1,5 @@
 error[E0271]: type mismatch resolving `<S as HasLifetime>::AtLifetime<'static> == ExistentialLifetime<_>`
-  --> $DIR/rigid-alias-in-same-type-modulo-infer-158773.rs:13:9
+  --> $DIR/rigid-alias-in-same-type-modulo-infer-158773.rs:11:9
    |
 LL | ...   ExistentialLifetime(ExistentialLifetime(()))
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `ExistentialLifetime<_>`, found associated type

--- a/tests/ui/traits/next-solver/rigid-alias-in-same-type-modulo-infer-158773.stderr
+++ b/tests/ui/traits/next-solver/rigid-alias-in-same-type-modulo-infer-158773.stderr
@@ -1,0 +1,16 @@
+error[E0271]: type mismatch resolving `<S as HasLifetime>::AtLifetime<'static> == ExistentialLifetime<_>`
+  --> $DIR/rigid-alias-in-same-type-modulo-infer-158773.rs:13:9
+   |
+LL | ...   ExistentialLifetime(ExistentialLifetime(()))
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `ExistentialLifetime<_>`, found associated type
+   |
+   = note:       expected struct `ExistentialLifetime<_>`
+           found associated type `<S as HasLifetime>::AtLifetime<'static>`
+help: consider constraining the associated type `<S as HasLifetime>::AtLifetime<'static>` to `ExistentialLifetime<_>`
+   |
+LL | impl<S: HasLifetime<AtLifetime<'static> = ExistentialLifetime<_>>> ExistentialLifetime<S> {
+   |                    ++++++++++++++++++++++++++++++++++++++++++++++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0271`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

This PR fixes rust-lang/rust#158773.
This fix resolves regression from at least nightly 1.96.0, as I checked.

# Cause of issue

In the current code, `relate(a, b)` is called on the type `SameTypeModuloInfer`, which is outside of the trait resolver.
So the rigid should be removed.

I inserted `ty::set_aliases_to_non_rigid` before calling `relate` method and now it works correctly.