### PR TITLE
perf: Rework read deduplication with pooled read recorders

### DIFF
--- a/compiler/rustc_middle/src/dep_graph/edges.rs
+++ b/compiler/rustc_middle/src/dep_graph/edges.rs
@@ -1,72 +1,110 @@
-use std::hash::{Hash, Hasher};
-use std::ops::Deref;
+//! How a task's reads are recorded and deduplicated into the edge list of its node.
 
-use smallvec::SmallVec;
+use rustc_data_structures::fx::FxHashSet;
+use rustc_data_structures::sync::Lock;
 
-use crate::dep_graph::DepNodeIndex;
+use super::DepNodeIndex;
 
-#[derive(Default, Debug)]
-pub(crate) struct EdgesVec {
-    max: u32,
-    edges: SmallVec<[DepNodeIndex; 8]>,
+/// How many reads fit in [`TaskReads::Small`]'s inline buffer.
+pub(crate) const SMALL_READS_MAX: usize = 16;
+
+/// The reads recorded by one task so far, deduplicated and in first-read order.
+#[derive(Debug)]
+pub(crate) enum TaskReads {
+    /// The first few reads, deduplicated by a linear scan. Most tasks never outgrow this.
+    Small { len: u8, buf: [DepNodeIndex; SMALL_READS_MAX] },
+
+    /// The reads of a task that outgrew the inline buffer.
+    Recorded(ReadsRecorder),
 }
 
-impl Hash for EdgesVec {
-    #[inline]
-    fn hash<H: Hasher>(&self, hasher: &mut H) {
-        Hash::hash(&self.edges, hasher)
-    }
-}
-
-impl EdgesVec {
+impl TaskReads {
     #[inline]
     pub(crate) fn new() -> Self {
-        Self::default()
+        TaskReads::Small { len: 0, buf: [DepNodeIndex::ZERO; SMALL_READS_MAX] }
     }
 
+    /// Records a read and returns whether it was new for the task. The pool provides a
+    /// recorder when the task outgrows the inline buffer.
     #[inline]
-    pub(crate) fn push(&mut self, edge: DepNodeIndex) {
-        self.max = self.max.max(edge.as_u32());
-        self.edges.push(edge);
-    }
-
-    #[inline]
-    pub(crate) fn max_index(&self) -> u32 {
-        self.max
-    }
-}
-
-impl Deref for EdgesVec {
-    type Target = [DepNodeIndex];
-
-    #[inline]
-    fn deref(&self) -> &Self::Target {
-        self.edges.as_slice()
-    }
-}
-
-impl FromIterator<DepNodeIndex> for EdgesVec {
-    #[inline]
-    fn from_iter<T>(iter: T) -> Self
-    where
-        T: IntoIterator<Item = DepNodeIndex>,
-    {
-        let mut vec = EdgesVec::new();
-        for index in iter {
-            vec.push(index)
+    pub(crate) fn insert(&mut self, index: DepNodeIndex, pool: &Lock<Vec<ReadsRecorder>>) -> bool {
+        match self {
+            TaskReads::Recorded(recorder) => recorder.insert(index),
+            TaskReads::Small { len, buf } => {
+                let n = usize::from(*len);
+                if buf[..n].contains(&index) {
+                    false
+                } else if n < SMALL_READS_MAX {
+                    buf[n] = index;
+                    *len += 1;
+                    true
+                } else {
+                    // The inline buffer is full: move the reads into a pooled recorder.
+                    let seed = *buf;
+                    let mut recorder = pool.lock().pop().unwrap_or_default();
+                    recorder.clear();
+                    recorder.seed(&seed);
+                    recorder.insert(index);
+                    *self = TaskReads::Recorded(recorder);
+                    true
+                }
+            }
         }
-        vec
+    }
+
+    /// The task's deduplicated reads, in first-read order.
+    #[inline]
+    pub(crate) fn edges(&self) -> &[DepNodeIndex] {
+        match self {
+            TaskReads::Small { len, buf } => &buf[..usize::from(*len)],
+            TaskReads::Recorded(recorder) => &recorder.reads,
+        }
     }
 }
 
-impl Extend<DepNodeIndex> for EdgesVec {
+/// Records the reads of a task with many reads.
+///
+/// Recorders are pooled globally, reusing the read list and hash set allocations
+/// across tasks.
+#[derive(Debug, Default)]
+pub(crate) struct ReadsRecorder {
+    /// The deduplicated reads, in first-read order.
+    reads: Vec<DepNodeIndex>,
+    seen: FxHashSet<DepNodeIndex>,
+}
+
+impl ReadsRecorder {
+    /// Seeds a fresh recorder with reads that are already known to be distinct.
+    fn seed(&mut self, reads: &[DepNodeIndex]) {
+        debug_assert!(self.reads.is_empty());
+        self.seen.extend(reads);
+        self.reads.extend_from_slice(reads);
+    }
+
+    /// Records a read of `index` and returns whether it was new for the current task.
     #[inline]
-    fn extend<T>(&mut self, iter: T)
-    where
-        T: IntoIterator<Item = DepNodeIndex>,
-    {
-        for elem in iter {
-            self.push(elem);
+    fn insert(&mut self, index: DepNodeIndex) -> bool {
+        let new = self.seen.insert(index);
+        if new {
+            self.reads.push(index);
+        }
+        new
+    }
+
+    /// Prepares the recorder for a new task, keeping the backing allocations.
+    fn clear(&mut self) {
+        self.reads.clear();
+        self.seen.clear();
+    }
+
+    /// Returns a finished task's recorder to the pool. The cap keeps deeply nested tasks
+    /// from growing the pool without bound.
+    #[inline]
+    pub(crate) fn release(self, pool: &Lock<Vec<ReadsRecorder>>) {
+        const MAX_POOLED_RECORDERS: usize = 4;
+        let mut pool = pool.lock();
+        if pool.len() < MAX_POOLED_RECORDERS {
+            pool.push(self);
         }
     }
 }

--- a/compiler/rustc_middle/src/dep_graph/graph.rs
+++ b/compiler/rustc_middle/src/dep_graph/graph.rs
@@ -18,14 +18,15 @@ use rustc_macros::{Decodable, Encodable};
 use rustc_serialize::opaque::{FileEncodeResult, FileEncoder};
 use rustc_session::Session;
 use rustc_span::Symbol;
+use smallvec::SmallVec;
 use tracing::instrument;
 #[cfg(debug_assertions)]
 use {super::debug::EdgeFilter, std::env};
 
+use super::edges::{ReadsRecorder, SMALL_READS_MAX, TaskReads};
 use super::retained::RetainedDepGraph;
 use super::serialized::{GraphEncoder, SerializedDepGraph, SerializedDepNodeIndex};
 use super::{DepKind, DepNode, WorkProductId, read_deps, with_deps};
-use crate::dep_graph::edges::EdgesVec;
 use crate::ich::StableHashState;
 use crate::ty::TyCtxt;
 use crate::verify_ich::incremental_verify_ich;
@@ -155,6 +156,10 @@ pub struct DepGraphData {
 
     /// Per-worker edge buffer amortized across `try_mark_green` calls.
     green_edge_buf: WorkerLocal<Cell<Vec<DepNodeIndex>>>,
+
+    /// Pool of read recorders, amortized across tasks. Global rather than per worker so the
+    /// retained memory is bounded by the total number of concurrently recording tasks.
+    read_recorder_pool: Lock<Vec<ReadsRecorder>>,
 }
 
 pub fn hash_result<R>(hcx: &mut StableHashState<'_>, result: &R) -> Fingerprint
@@ -183,7 +188,7 @@ impl DepGraph {
         // Instantiate a node with zero dependencies only once for anonymous queries.
         let _green_node_index = current.alloc_new_node(
             DepNode { kind: DepKind::AnonZeroDeps, key_fingerprint: current.anon_id_seed.into() },
-            EdgesVec::new(),
+            &[],
             Fingerprint::ZERO,
         );
         assert_eq!(_green_node_index, DepNodeIndex::SINGLETON_ZERO_DEPS_ANON_NODE);
@@ -193,7 +198,7 @@ impl DepGraph {
         // ensure that their dependency list will never be all-green.
         let red_node_index = current.alloc_new_node(
             DepNode { kind: DepKind::Red, key_fingerprint: Fingerprint::ZERO.into() },
-            EdgesVec::new(),
+            &[],
             Fingerprint::ZERO,
         );
         assert_eq!(red_node_index, DepNodeIndex::FOREVER_RED_NODE);
@@ -212,6 +217,7 @@ impl DepGraph {
                 colors,
                 debug_loaded_from_disk: Default::default(),
                 green_edge_buf: WorkerLocal::default(),
+                read_recorder_pool: Lock::new(Vec::new()),
             })),
             virtual_dep_node_index: Arc::new(AtomicU32::new(0)),
         }
@@ -378,19 +384,22 @@ impl DepGraphData {
             format!("forcing query with already existing `DepNode`: {dep_node:?}")
         });
 
-        let (result, edges) = if tcx.is_eval_always(dep_node.kind) {
-            (with_deps(TaskDepsRef::EvalAlways, op), EdgesVec::new())
+        let (result, task_deps) = if tcx.is_eval_always(dep_node.kind) {
+            (with_deps(TaskDepsRef::EvalAlways, op), None)
         } else {
             let task_deps = Lock::new(TaskDeps::new(
                 #[cfg(debug_assertions)]
                 Some(dep_node),
-                0,
             ));
-            (with_deps(TaskDepsRef::Allow(&task_deps), op), task_deps.into_inner().reads)
+            (with_deps(TaskDepsRef::Allow(&task_deps), op), Some(task_deps.into_inner()))
         };
 
+        let edges: &[DepNodeIndex] = task_deps.as_ref().map_or(&[], |deps| deps.edges());
         let dep_node_index =
             self.hash_result_and_alloc_node(tcx, dep_node, edges, &result, hash_result);
+        if let Some(TaskDeps { reads: TaskReads::Recorded(recorder), .. }) = task_deps {
+            recorder.release(&self.read_recorder_pool);
+        }
 
         (result, dep_node_index)
     }
@@ -416,16 +425,13 @@ impl DepGraphData {
     {
         debug_assert!(!tcx.is_eval_always(dep_kind));
 
-        // Large numbers of reads are common enough here that pre-sizing `read_set`
-        // to 128 actually helps perf on some benchmarks.
         let task_deps = Lock::new(TaskDeps::new(
             #[cfg(debug_assertions)]
             None,
-            128,
         ));
         let result = with_deps(TaskDepsRef::Allow(&task_deps), op);
         let task_deps = task_deps.into_inner();
-        let reads = task_deps.reads;
+        let reads = task_deps.edges();
 
         let dep_node_index = match reads.len() {
             0 => {
@@ -470,6 +476,10 @@ impl DepGraphData {
             }
         };
 
+        if let TaskReads::Recorded(recorder) = task_deps.reads {
+            recorder.release(&self.read_recorder_pool);
+        }
+
         (result, dep_node_index)
     }
 
@@ -478,7 +488,7 @@ impl DepGraphData {
         &self,
         tcx: TyCtxt<'tcx>,
         node: DepNode,
-        edges: EdgesVec,
+        edges: &[DepNodeIndex],
         result: &R,
         hash_result: Option<fn(&mut StableHashState<'_>, &R) -> Fingerprint>,
     ) -> DepNodeIndex {
@@ -516,20 +526,8 @@ impl DepGraph {
                     data.current.total_read_count.fetch_add(1, Ordering::Relaxed);
                 }
 
-                // Has `dep_node_index` been seen before? Use either a linear scan or a hashset
-                // lookup to determine this. See `TaskDeps::read_set` for details.
-                let new_read = if task_deps.reads.len() <= TaskDeps::LINEAR_SCAN_MAX {
-                    !task_deps.reads.contains(&dep_node_index)
-                } else {
-                    task_deps.read_set.insert(dep_node_index)
-                };
+                let new_read = task_deps.reads.insert(dep_node_index, &data.read_recorder_pool);
                 if new_read {
-                    task_deps.reads.push(dep_node_index);
-                    if task_deps.reads.len() == TaskDeps::LINEAR_SCAN_MAX + 1 {
-                        // Fill `read_set` with what we have so far. Future lookups will use it.
-                        task_deps.read_set.extend(task_deps.reads.iter().copied());
-                    }
-
                     #[cfg(debug_assertions)]
                     {
                         if let Some(target) = task_deps.node
@@ -640,11 +638,14 @@ impl DepGraph {
                 }
             }
 
-            let mut edges = EdgesVec::new();
+            // `read_deps` calls the closure exactly once, with the current task's deps.
+            let mut reads = SmallVec::<[DepNodeIndex; SMALL_READS_MAX]>::new();
             read_deps(|task_deps| match task_deps {
-                TaskDepsRef::Allow(deps) => edges.extend(deps.lock().reads.iter().copied()),
+                TaskDepsRef::Allow(deps) => {
+                    reads = SmallVec::from_slice(deps.lock().edges());
+                }
                 TaskDepsRef::EvalAlways => {
-                    edges.push(DepNodeIndex::FOREVER_RED_NODE);
+                    reads.push(DepNodeIndex::FOREVER_RED_NODE);
                 }
                 TaskDepsRef::Ignore => {}
                 TaskDepsRef::Forbid => {
@@ -652,7 +653,7 @@ impl DepGraph {
                 }
             });
 
-            data.hash_result_and_alloc_node(tcx, node, edges, result, hash_result)
+            data.hash_result_and_alloc_node(tcx, node, &reads, result, hash_result)
         } else {
             // Incremental compilation is turned off. We just execute the task
             // without tracking. We still provide a dep-node index that uniquely
@@ -730,7 +731,7 @@ impl DepGraphData {
             Fingerprint::ZERO,
             // We want the side effect node to always be red so it will be forced and run the
             // side effect.
-            std::iter::once(DepNodeIndex::FOREVER_RED_NODE).collect(),
+            &[DepNodeIndex::FOREVER_RED_NODE],
         );
         tcx.query_system.side_effects.borrow_mut().insert(dep_node_index, side_effect);
         dep_node_index
@@ -760,7 +761,7 @@ impl DepGraphData {
                     key_fingerprint: PackedFingerprint::from(Fingerprint::ZERO),
                 },
                 Fingerprint::ZERO,
-                std::iter::once(DepNodeIndex::FOREVER_RED_NODE).collect(),
+                &[DepNodeIndex::FOREVER_RED_NODE],
                 true,
             );
 
@@ -781,7 +782,7 @@ impl DepGraphData {
     fn alloc_and_color_node(
         &self,
         key: DepNode,
-        edges: EdgesVec,
+        edges: &[DepNodeIndex],
         value_fingerprint: Option<Fingerprint>,
     ) -> DepNodeIndex {
         if let Some(prev_index) = self.previous.node_to_index_opt(&key) {
@@ -1256,7 +1257,7 @@ impl CurrentDepGraph {
     fn alloc_new_node(
         &self,
         key: DepNode,
-        edges: EdgesVec,
+        edges: &[DepNodeIndex],
         value_fingerprint: Fingerprint,
     ) -> DepNodeIndex {
         let dep_node_index = self.encoder.send_new(key, value_fingerprint, edges);
@@ -1294,29 +1295,23 @@ pub struct TaskDeps {
     #[cfg(debug_assertions)]
     node: Option<DepNode>,
 
-    /// A vector of `DepNodeIndex`, basically. Contains no duplicates.
-    reads: EdgesVec,
-
-    /// When adding a new edge to `reads` in `DepGraph::read_index` we must determine if the edge
-    /// has been seen before. We just do a linear scan of `reads` if its length is less than or
-    /// equal to `LINEAR_SCAN_MAX`. Otherwise, we use this hashset for better performance. Note:
-    /// `reads` is always the canonical edges representation; this field is just to speed up the
-    /// seen-before test.
-    read_set: FxHashSet<DepNodeIndex>,
+    reads: TaskReads,
 }
 
 impl TaskDeps {
-    /// See `TaskDeps::read_set` above.
-    const LINEAR_SCAN_MAX: usize = 16;
-
     #[inline]
-    fn new(#[cfg(debug_assertions)] node: Option<DepNode>, read_set_capacity: usize) -> Self {
+    fn new(#[cfg(debug_assertions)] node: Option<DepNode>) -> Self {
         TaskDeps {
             #[cfg(debug_assertions)]
             node,
-            reads: EdgesVec::new(),
-            read_set: FxHashSet::with_capacity_and_hasher(read_set_capacity, Default::default()),
+            reads: TaskReads::new(),
         }
+    }
+
+    /// The task's deduplicated reads, in first-read order.
+    #[inline]
+    fn edges(&self) -> &[DepNodeIndex] {
+        self.reads.edges()
     }
 }
 

--- a/compiler/rustc_middle/src/dep_graph/serialized.rs
+++ b/compiler/rustc_middle/src/dep_graph/serialized.rs
@@ -19,7 +19,7 @@
 //! index in that node's edge list. We effectively ignore that an edge index of 0 could be
 //! encoded with 0 bytes in order to not require 3 bits to store the byte width of the edges.
 //! The overhead of calculating the correct byte width for each edge is mitigated by
-//! building edge lists with [`EdgesVec`] which keeps a running max of the edges in a node.
+//! computing the max of the edge list once per node instead of per edge.
 //!
 //! When we decode this data, we do not immediately create [`SerializedDepNodeIndex`] and
 //! instead keep the data in its denser serialized form which lets us turn our on-disk size
@@ -61,7 +61,6 @@ use tracing::{debug, instrument};
 use super::graph::{CurrentDepGraph, DepNodeColorMap, DesiredColor, TrySetColorResult};
 use super::retained::RetainedDepGraph;
 use super::{DepKind, DepNode, DepNodeIndex};
-use crate::dep_graph::edges::EdgesVec;
 
 // The maximum value of `SerializedDepNodeIndex` leaves the upper two bits
 // unused so that we can store multiple index types in `CompressedHybridIndex`,
@@ -562,22 +561,19 @@ impl SerializedNodeHeader {
 }
 
 #[derive(Debug)]
-struct NodeInfo {
+struct NodeInfo<'a> {
     node: DepNode,
     value_fingerprint: Fingerprint,
-    edges: EdgesVec,
+    edges: &'a [DepNodeIndex],
 }
 
-impl NodeInfo {
+impl NodeInfo<'_> {
     fn encode(&self, e: &mut MemEncoder, index: DepNodeIndex) {
-        let NodeInfo { ref node, value_fingerprint, ref edges } = *self;
-        let header = SerializedNodeHeader::new(
-            node,
-            index,
-            value_fingerprint,
-            edges.max_index(),
-            edges.len(),
-        );
+        let NodeInfo { ref node, value_fingerprint, edges } = *self;
+        // The largest index picks the byte width of the edge list.
+        let edge_max = edges.iter().map(|e| e.as_u32()).max().unwrap_or(0);
+        let header =
+            SerializedNodeHeader::new(node, index, value_fingerprint, edge_max, edges.len());
         e.write_array(header.bytes);
 
         if header.len().is_none() {
@@ -592,43 +588,6 @@ impl NodeInfo {
                 bytes_per_index
             });
         }
-    }
-
-    /// Encode a node that was promoted from the previous graph. It reads the edges directly from
-    /// the previous dep graph and expects all edges to already have a new dep node index assigned.
-    /// This avoids the overhead of constructing `EdgesVec`, which would be needed to call `encode`.
-    #[inline]
-    fn encode_promoted(
-        e: &mut MemEncoder,
-        node: &DepNode,
-        index: DepNodeIndex,
-        value_fingerprint: Fingerprint,
-        edges: &[DepNodeIndex],
-    ) -> usize {
-        let edge_count = edges.len();
-
-        // Find the highest edge in the new dep node indices
-        let edge_max = edges.iter().map(|x| x.as_u32()).max().unwrap_or(0);
-
-        let header =
-            SerializedNodeHeader::new(node, index, value_fingerprint, edge_max, edge_count);
-        e.write_array(header.bytes);
-
-        if header.len().is_none() {
-            // The edges are all unique and the number of unique indices is less than u32::MAX.
-            e.emit_u32(edge_count.try_into().unwrap());
-        }
-
-        let bytes_per_index = header.bytes_per_index();
-        for edge in edges {
-            let edge = edge.as_u32();
-            e.write_with(|dest| {
-                *dest = edge.to_le_bytes();
-                bytes_per_index
-            });
-        }
-
-        edge_count
     }
 }
 
@@ -770,21 +729,18 @@ impl EncoderState {
     fn encode_node(
         &self,
         index: DepNodeIndex,
-        node: &NodeInfo,
+        node: &NodeInfo<'_>,
         retained_graph: &Option<Lock<RetainedDepGraph>>,
         local: &mut LocalEncoderState,
     ) {
         node.encode(&mut local.encoder, index);
         self.flush_mem_encoder(&mut *local);
-        self.record(&node.node, index, node.edges.len(), &node.edges, retained_graph, &mut *local);
+        self.record(&node.node, index, node.edges.len(), node.edges, retained_graph, &mut *local);
     }
 
-    /// Encodes a node that was promoted from the previous graph. It reads the information directly from
-    /// the previous dep graph for performance reasons.
-    ///
-    /// This differs from `encode_node` where you have to explicitly provide the relevant `NodeInfo`.
-    ///
-    /// It expects all edges to already have a new dep node index assigned.
+    /// Encodes a node that was promoted from the previous graph, reading the node and its
+    /// fingerprint directly from the previous dep graph. It expects all edges to already
+    /// have a new dep node index assigned.
     #[inline]
     fn encode_promoted_node(
         &self,
@@ -794,12 +750,12 @@ impl EncoderState {
         local: &mut LocalEncoderState,
         edges: &[DepNodeIndex],
     ) {
-        let node = self.previous.index_to_node(prev_index);
-        let value_fingerprint = self.previous.value_fingerprint_for_index(prev_index);
-        let edge_count =
-            NodeInfo::encode_promoted(&mut local.encoder, node, index, value_fingerprint, edges);
-        self.flush_mem_encoder(&mut *local);
-        self.record(node, index, edge_count, edges, retained_graph, &mut *local);
+        let node = NodeInfo {
+            node: *self.previous.index_to_node(prev_index),
+            value_fingerprint: self.previous.value_fingerprint_for_index(prev_index),
+            edges,
+        };
+        self.encode_node(index, &node, retained_graph, local);
     }
 
     fn finish(&self, profiler: &SelfProfilerRef, current: &CurrentDepGraph) -> FileEncodeResult {
@@ -957,7 +913,7 @@ impl GraphEncoder {
         &self,
         node: DepNode,
         value_fingerprint: Fingerprint,
-        edges: EdgesVec,
+        edges: &[DepNodeIndex],
     ) -> DepNodeIndex {
         let _prof_timer = self.profiler.generic_activity("incr_comp_encode_dep_graph");
         let node = NodeInfo { node, value_fingerprint, edges };
@@ -977,7 +933,7 @@ impl GraphEncoder {
         colors: &DepNodeColorMap,
         node: DepNode,
         value_fingerprint: Fingerprint,
-        edges: EdgesVec,
+        edges: &[DepNodeIndex],
         is_green: bool,
     ) -> DepNodeIndex {
         let _prof_timer = self.profiler.generic_activity("incr_comp_encode_dep_graph");


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/158794)*
<!-- homu-ignore:end -->

Every dependency read goes through DepGraph::read_index, which must decide whether the current task has already recorded the read. Small tasks used a linear scan; larger ones built an FxHashSet, rebuilt for every task and rehashed as it grew, while the reads themselves were collected in an EdgesVec allocated and freed per task.

Larger tasks now reuse a recorder from a global pool, so the hash set and read list allocations are amortized across tasks. EdgesVec is removed.