### PR TITLE
Clarify `as_uninit_mut` may point to uninitialized memory

### DIFF
--- a/library/core/src/ptr/mut_ptr.rs
+++ b/library/core/src/ptr/mut_ptr.rs
@@ -638,6 +638,8 @@ impl<T: PointeeSized> *mut T {
     ///
     /// When calling this method, you have to ensure that *either* the pointer is null *or*
     /// the pointer is [convertible to a reference](crate::ptr#pointer-to-reference-conversion).
+    /// Note that because the created reference is to `MaybeUninit<T>`, the
+    /// source pointer can point to uninitialized memory.
     ///
     /// # Panics during const evaluation
     ///


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Tracking issue: rust-lang/rust#75402

This PR clarifies the safety documentation for `*mut T::as_uninit_mut`.

Unlike `as_mut`, this method creates a reference to `MaybeUninit<T>`, so the source pointer may point to uninitialized memory. The pointer still must either be null or satisfy the pointer-to-reference conversion requirements.

After adding the supplementary information, the safety documentation of `*mut T::as_uninit_mut` is consistent with `*mut T::as_uninit_ref`, `*const T::as_uninit_ref` and `std::ptr::NonNull::as_uninit_mut`.

This is a documentation-only change.

Tests were not added because this only updates API docs.