### PR TITLE
Filter host libstdc++ ABI flag in rustc_llvm cross builds

### DIFF
--- a/compiler/rustc_llvm/build.rs
+++ b/compiler/rustc_llvm/build.rs
@@ -160,6 +160,12 @@ impl<'a> IntoIterator for &'a LlvmConfigOutput {
     }
 }
 
+fn is_libstdcxx_cxx11_abi_flag(flag: &str) -> bool {
+    flag == "-D_GLIBCXX_USE_CXX11_ABI"
+        || flag.starts_with("-D_GLIBCXX_USE_CXX11_ABI=")
+        || flag == "-U_GLIBCXX_USE_CXX11_ABI"
+}
+
 fn main() {
     if cfg!(feature = "check_only") {
         return;
@@ -252,6 +258,14 @@ fn main() {
     for flag in &cxxflags {
         // Ignore flags like `-m64` when we're doing a cross build
         if is_crossed && flag.starts_with("-m") {
+            continue;
+        }
+
+        // This is a libstdc++ implementation detail for the C++ library that
+        // built the runnable llvm-config. When cross-compiling, target LLVM may
+        // have been built against a target libstdc++ with a different default.
+        // Let the target compiler/toolchain select its ABI instead.
+        if is_crossed && is_libstdcxx_cxx11_abi_flag(flag.as_ref()) {
             continue;
         }
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

`compiler/rustc_llvm/build.rs` invokes `llvm-config` for the build host machine in cross compilation scenarios. In particular, the normal LLVM configuration on Linux sets `_GLIBCXX_USE_CXX11_ABI=1` and those flags would then pollute C++ wrapper objects being compiled for the target.

This patch makes `rustc_llvm` avoid propagating that macro when cross-compiling. This follows the existing pattern in `rustc_llvm/build.rs`, which already treats parts of cross `llvm-config` output as host-specific by filtering `-m*` flags and rewriting include paths. Although I think the more appropriate approach is to use a separate target LLVM C++ flags setting.

This currently affects Haiku rustc cross-compilation from Linux hosts. The Haiku target currently uses the old libstdc++ string ABI by default and that creates an ABI mismatch. I currently work around this locally by setting environment variable `CXXFLAGS_x86_64_unknown_haiku=-D_GLIBCXX_USE_CXX11_ABI=0`.