### PR TITLE
Add PartialEq<Vec<U>> for [T; N] and &[T; N]

### DIFF
--- a/library/alloc/src/vec/partial_eq.rs
+++ b/library/alloc/src/vec/partial_eq.rs
@@ -34,12 +34,12 @@ __impl_slice_eq1! { [] Cow<'_, [T]>, &[U] where T: Clone, #[stable(feature = "ru
 __impl_slice_eq1! { [] Cow<'_, [T]>, &mut [U] where T: Clone, #[stable(feature = "rust1", since = "1.0.0")] }
 __impl_slice_eq1! { const, [A: Allocator, const N: usize] Vec<T, A>, [U; N], #[rustc_const_unstable(feature = "const_cmp", issue = "143800")] #[stable(feature = "rust1", since = "1.0.0")] }
 __impl_slice_eq1! { const, [A: Allocator, const N: usize] Vec<T, A>, &[U; N], #[rustc_const_unstable(feature = "const_cmp", issue = "143800")] #[stable(feature = "rust1", since = "1.0.0")] }
+__impl_slice_eq1! { const, [const N: usize] [T; N], Vec<U>, #[rustc_const_unstable(feature = "const_cmp", issue = "143800")] #[stable(feature = "array_vec_partialeq", since = "CURRENT_RUSTC_VERSION")] }
+__impl_slice_eq1! { const, [const N: usize] &[T; N], Vec<U>, #[rustc_const_unstable(feature = "const_cmp", issue = "143800")] #[stable(feature = "array_vec_partialeq", since = "CURRENT_RUSTC_VERSION")] }
 
 // NOTE: some less important impls are omitted to reduce code bloat
 // FIXME(Centril): Reconsider this?
 //__impl_slice_eq1! { [const N: usize] Vec<A>, &mut [B; N], }
-//__impl_slice_eq1! { [const N: usize] [A; N], Vec<B>, }
-//__impl_slice_eq1! { [const N: usize] &[A; N], Vec<B>, }
 //__impl_slice_eq1! { [const N: usize] &mut [A; N], Vec<B>, }
 //__impl_slice_eq1! { [const N: usize] Cow<'a, [A]>, [B; N], }
 //__impl_slice_eq1! { [const N: usize] Cow<'a, [A]>, &[B; N], }

--- a/tests/ui/array-vec-partialeq.rs
+++ b/tests/ui/array-vec-partialeq.rs
@@ -1,0 +1,12 @@
+//@ check-pass
+
+fn main() {
+    let x = vec![1];
+    let y = [1];
+    assert!(x == y);
+    assert!(y == x);
+
+    let z = [1, 2, 3];
+    assert!(z == vec![1, 2, 3]);
+    assert!(&z == vec![1, 2, 3]);
+}

--- a/tests/ui/consts/too_generic_eval_ice.current.stderr
+++ b/tests/ui/consts/too_generic_eval_ice.current.stderr
@@ -30,6 +30,7 @@ LL |         [5; Self::HOST_SIZE] == [6; 0]
    |
    = help: the trait `PartialEq<[{integer}; 0]>` is not implemented for `[{integer}; Self::HOST_SIZE]`
    = help: the following other types implement trait `PartialEq<Rhs>`:
+             `&[T; N]` implements `PartialEq<Vec<U>>`
              `&[T]` implements `PartialEq<Vec<U, A>>`
              `&[T]` implements `PartialEq<[U; N]>`
              `&[u8; N]` implements `PartialEq<ByteStr>`
@@ -37,8 +38,7 @@ LL |         [5; Self::HOST_SIZE] == [6; 0]
              `&[u8]` implements `PartialEq<ByteStr>`
              `&[u8]` implements `PartialEq<ByteString>`
              `&mut [T]` implements `PartialEq<Vec<U, A>>`
-             `&mut [T]` implements `PartialEq<[U; N]>`
-           and 11 others
+           and 13 others
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/macros/assert-ne-no-invalid-help-issue-146204.stderr
+++ b/tests/ui/macros/assert-ne-no-invalid-help-issue-146204.stderr
@@ -6,6 +6,7 @@ LL |     assert_ne!(buf, b"----");
    |
    = help: the trait `PartialEq<&[u8; 4]>` is not implemented for `[u8; 4]`
    = help: the following other types implement trait `PartialEq<Rhs>`:
+             `&[T; N]` implements `PartialEq<Vec<U>>`
              `&[T]` implements `PartialEq<Vec<U, A>>`
              `&[T]` implements `PartialEq<[U; N]>`
              `&[u8; N]` implements `PartialEq<ByteStr>`
@@ -13,8 +14,7 @@ LL |     assert_ne!(buf, b"----");
              `&[u8]` implements `PartialEq<ByteStr>`
              `&[u8]` implements `PartialEq<ByteString>`
              `&mut [T]` implements `PartialEq<Vec<U, A>>`
-             `&mut [T]` implements `PartialEq<[U; N]>`
-           and 11 others
+           and 13 others
 
 error[E0277]: can't compare `[u8; 4]` with `&[u8; 4]`
   --> $DIR/assert-ne-no-invalid-help-issue-146204.rs:19:5
@@ -24,6 +24,7 @@ LL |     assert_eq!(buf, b"----");
    |
    = help: the trait `PartialEq<&[u8; 4]>` is not implemented for `[u8; 4]`
    = help: the following other types implement trait `PartialEq<Rhs>`:
+             `&[T; N]` implements `PartialEq<Vec<U>>`
              `&[T]` implements `PartialEq<Vec<U, A>>`
              `&[T]` implements `PartialEq<[U; N]>`
              `&[u8; N]` implements `PartialEq<ByteStr>`
@@ -31,8 +32,7 @@ LL |     assert_eq!(buf, b"----");
              `&[u8]` implements `PartialEq<ByteStr>`
              `&[u8]` implements `PartialEq<ByteString>`
              `&mut [T]` implements `PartialEq<Vec<U, A>>`
-             `&mut [T]` implements `PartialEq<[U; N]>`
-           and 11 others
+           and 13 others
 
 error[E0277]: can't compare `[u8; 4]` with `&[u8; 4]`
   --> $DIR/assert-ne-no-invalid-help-issue-146204.rs:5:30


### PR DESCRIPTION
Enable comparing arrays with `Vec` in both directions.

`Vec<T> == [U; N]` already works, but `[T; N] == Vec<U>` did not compile.
This adds the missing symmetric impls using the existing `__impl_slice_eq1`
macro.

Fixes rust-lang/rust#149017

## Test plan
- Added `tests/ui/array-vec-partialeq.rs` (`//@ check-pass`)
- Updated UI test stderr files for trait suggestion output changes

@rustbot ready