### PR TITLE
Add supplementary information for get_unchecked(mut)

### DIFF
--- a/library/core/src/ptr/const_ptr.rs
+++ b/library/core/src/ptr/const_ptr.rs
@@ -1497,9 +1497,10 @@ impl<T> *const [T] {
     /// Returns a raw pointer to an element or subslice, without doing bounds
     /// checking.
     ///
-    /// Calling this method with an out-of-bounds index or when `self` is not dereferenceable
+    /// Calling this method with an [out-of-bounds index] or when `self` is not dereferenceable
     /// is *[undefined behavior]* even if the resulting pointer is not used.
     ///
+    /// [out-of-bounds index]: #method.add
     /// [undefined behavior]: https://doc.rust-lang.org/reference/behavior-considered-undefined.html
     ///
     /// # Examples

--- a/library/core/src/ptr/non_null.rs
+++ b/library/core/src/ptr/non_null.rs
@@ -1573,9 +1573,10 @@ impl<T> NonNull<[T]> {
     /// Returns a raw pointer to an element or subslice, without doing bounds
     /// checking.
     ///
-    /// Calling this method with an out-of-bounds index or when `self` is not dereferenceable
+    /// Calling this method with an [out-of-bounds index] or when `self` is not dereferenceable
     /// is *[undefined behavior]* even if the resulting pointer is not used.
     ///
+    /// [out-of-bounds index]: #method.add
     /// [undefined behavior]: https://doc.rust-lang.org/reference/behavior-considered-undefined.html
     ///
     /// # Examples


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Tracking issue: rust-lang/rust#74265

This PR makes the safety documentation for raw pointer and NonNull `get_unchecked(_mut)` APIs more consistent.

Currently, `*mut [T]::get_unchecked_mut` links `out-of-bounds index` to the `add` method, but the corresponding docs for `*const[T]::get_unchecked` and `NonNull<[T]>::get_unchecked_mut` use plain text for the same safety condition.

This PR updates those two docs to link `out-of-bounds index` to `#method.add`, matching the existing wording and link style used by `*mut [T]::get_unchecked_mut`.

This is a documentation-only change.

I also noticed that similar wording in the following APIs currently does not link `out-of-bounds index`:

- [slice::get_unchecked](https://doc.rust-lang.org/core/primitive.slice.html#method.get_unchecked)
- [slice::get_unchecked_mut](https://doc.rust-lang.org/core/primitive.slice.html#method.get_unchecked_mut)
- [core::slice::SliceIndex::get_unchecked](https://doc.rust-lang.org/core/slice/trait.SliceIndex.html#tymethod.get_unchecked)
- [core::slice::SliceIndex::get_unchecked_mut](https://doc.rust-lang.org/core/slice/trait.SliceIndex.html#tymethod.get_unchecked_mut)

I did not update those in this PR because I am not sure which target would be the most appropriate link for those APIs. If there is a preferred link target for these slice and `SliceIndex` docs, I would be happy to update them and merge the updates in this PR.