### PR TITLE
Produce an error when `#[inline]` and `#[rust_force_inline]` are used together

### DIFF
--- a/compiler/rustc_attr_parsing/src/attributes/inline.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/inline.rs
@@ -1,12 +1,10 @@
-// FIXME(jdonszelmann): merge these two parsers and error when both attributes are present here.
-//                      note: need to model better how duplicate attr errors work when not using
-//                      SingleAttributeParser which is what we have two of here.
-
 use rustc_feature::AttributeStability;
 use rustc_hir::attrs::{AttributeKind, InlineAttr};
+use rustc_hir::find_attr;
 use rustc_session::lint::builtin::ILL_FORMED_ATTRIBUTE_INPUT;
 
 use super::prelude::*;
+use crate::session_diagnostics::InlineForceInlineConflict;
 
 pub(crate) struct InlineParser;
 
@@ -93,5 +91,17 @@ impl SingleAttributeParser for RustcForceInlineParser {
             InlineAttr::Force { attr_span: cx.attr_span, reason },
             cx.attr_span,
         ))
+    }
+
+    fn finalize_check(cx: &FinalizeCheckContext<'_, '_>, attr_span: Span) {
+        let Some(inline_span) = find_attr!(cx.parsed_attrs, Inline(attr, span) if !matches!(attr, InlineAttr::Force { .. }) => span)
+        else {
+            return;
+        };
+
+        cx.emit_err(InlineForceInlineConflict {
+            inline_span: *inline_span,
+            force_inline_span: attr_span,
+        });
     }
 }

--- a/compiler/rustc_attr_parsing/src/session_diagnostics.rs
+++ b/compiler/rustc_attr_parsing/src/session_diagnostics.rs
@@ -14,6 +14,15 @@ use crate::AttributeTemplate;
 use crate::context::Suggestion;
 
 #[derive(Diagnostic)]
+#[diag("`#[rustc_force_inline]` and `#[inline]` cannot be used together")]
+pub(crate) struct InlineForceInlineConflict {
+    #[primary_span]
+    pub force_inline_span: Span,
+    #[label("the inline attribute is specified here")]
+    pub inline_span: Span,
+}
+
+#[derive(Diagnostic)]
 #[diag("`#[ffi_const]` function cannot be `#[ffi_pure]`", code = E0757)]
 pub(crate) struct BothFfiConstAndPure {
     #[primary_span]

--- a/tests/ui/attributes/inline/rustc-force-inline-conflict-with-inline.rs
+++ b/tests/ui/attributes/inline/rustc-force-inline-conflict-with-inline.rs
@@ -1,0 +1,11 @@
+#![feature(rustc_attrs)]
+
+#[inline] //~ NOTE: the inline attribute is specified here
+#[rustc_force_inline] //~ ERROR: cannot be used together
+fn foo() {}
+
+#[rustc_force_inline] //~ ERROR: cannot be used together
+#[inline] //~ NOTE: the inline attribute is specified here
+fn bar() {}
+
+fn main() {}

--- a/tests/ui/attributes/inline/rustc-force-inline-conflict-with-inline.stderr
+++ b/tests/ui/attributes/inline/rustc-force-inline-conflict-with-inline.stderr
@@ -1,0 +1,18 @@
+error: `#[rustc_force_inline]` and `#[inline]` cannot be used together
+  --> $DIR/rustc-force-inline-conflict-with-inline.rs:4:1
+   |
+LL | #[inline]
+   | --------- the inline attribute is specified here
+LL | #[rustc_force_inline]
+   | ^^^^^^^^^^^^^^^^^^^^^
+
+error: `#[rustc_force_inline]` and `#[inline]` cannot be used together
+  --> $DIR/rustc-force-inline-conflict-with-inline.rs:7:1
+   |
+LL | #[rustc_force_inline]
+   | ^^^^^^^^^^^^^^^^^^^^^
+LL | #[inline]
+   | --------- the inline attribute is specified here
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/158814)*
<!-- homu-ignore:end -->

### Merged RustcForceInline & Inline Attribute Parsers

I've been reading [https://github.com/rust-lang/rust/issues/153101](https://github.com/rust-lang/rust/issues/153101), https://github.com/rust-lang/rust/issues/131229 and I came across with this comment in `compiler/rustc_attr_parsing/src/attributes/inline.rs`:

```rust
// FIXME(jdonszelmann): merge these two parsers and error when both attributes are present here.
//                      note: need to model better how duplicate attr errors work when not using
//                      SingleAttributeParser which is what we have two of here.

```

Having separate `SingleAttributeParser` implementations for `#[rustc_force_inline]` and `#[inline(...)]` meant the compiler wasn't able to recognize cases where both of them were used together on the same item, for example:

```rust
#![feature(rustc_attrs)]

#[rustc_force_inline]
#[inline]
fn foo() {}

fn main() {}
```

<img width="1222" height="915" alt="image" src="https://github.com/user-attachments/assets/69d4e3b0-bc21-4679-8f3d-017f9fe152fb" />

This case was previously considered allowed, which is not correct.

My changes replace the distinct attribute parsers with a single unified `AttributeParser` implementation for `InlineParser`, handling both attributes together in a single pass. By consolidating the logic, the parser now tracks the state of both attributes side-by-side using an `AcceptMapping` and introduces a new session diagnostic, `InlineForceInlineConflict`, which is explicitly triggered in the `finalize` step if a user attempts to combine them. 

An added benefit of catching this conflict early during the parsing phase is that it prevents downstream validation passes (like `check_attr`) from triggering redundant errors on malformed or incorrectly placed attributes, which naturally cleans up and streamlines our compiler stderr output as reflected in the updated UI test baselines.

**This is my very first PR on rustc**, and I am incredibly grateful to @hkalbasi, who heavily guided me through the codebase and helped make this change possible! 

Sincerely looking for your feedback and thoughts on this, let me know if there is something need to be changed.