### PR TITLE
Put `InhabitedPredicate::NotInModule` earlier in disjunction since it can be a lot faster

### DIFF
--- a/compiler/rustc_middle/src/ty/inhabitedness/mod.rs
+++ b/compiler/rustc_middle/src/ty/inhabitedness/mod.rs
@@ -93,7 +93,7 @@ impl<'tcx> VariantDef {
                 match field.vis {
                     Visibility::Public => pred,
                     Visibility::Restricted(from) => {
-                        pred.or(tcx, InhabitedPredicate::NotInModule(from))
+                        InhabitedPredicate::NotInModule(from).or(tcx, pred)
                     }
                 }
             }),


### PR DESCRIPTION
In my local testing, a simple reordering here can help *a lot* already in the regression reported in rust-lang/rust#141006, speeding up compilation roughly 7-8x, so I'd like to find out if this has any performance downsides.