### PR TITLE
Fix rustdoc ICE on deprecated note in inlined re-export chain

### DIFF
--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -31,7 +31,7 @@ use smallvec::{SmallVec, smallvec};
 use tracing::{debug, info, instrument, trace};
 
 use crate::clean::utils::find_nearest_parent_module;
-use crate::clean::{self, Crate, Item, ItemId, ItemLink, PrimitiveType};
+use crate::clean::{self, Crate, Item, ItemId, ItemLink, PrimitiveType, reexport_chain};
 use crate::core::DocContext;
 use crate::html::markdown::{MarkdownLink, MarkdownLinkRange, markdown_links};
 use crate::lint::{BROKEN_INTRA_DOC_LINKS, PRIVATE_INTRA_DOC_LINKS};
@@ -1148,10 +1148,19 @@ impl LinkCollector<'_, '_> {
             // `use` statement, we need to use the `def_id` of the `use` statement, not the
             // inlined item.
             // <https://github.com/rust-lang/rust/pull/151120>
-            let item_id = if let Some(inline_stmt_id) = item.inline_stmt_id
-                && find_attr!(tcx, inline_stmt_id, Deprecated { span, ..} if span == depr_span)
-            {
-                inline_stmt_id.to_def_id()
+            let item_id = if let Some(inline_stmt_id) = item.inline_stmt_id {
+                let target_def_id = item.item_id.expect_def_id();
+                reexport_chain(tcx, inline_stmt_id, target_def_id)
+                    .iter()
+                    .flat_map(|reexport| reexport.id())
+                    .find(|&reexport_def_id| {
+                        find_attr!(
+                            tcx,
+                            reexport_def_id,
+                            Deprecated { span, .. } if span == depr_span
+                        )
+                    })
+                    .unwrap_or(target_def_id)
             } else {
                 item.item_id.expect_def_id()
             };

--- a/tests/rustdoc-ui/intra-doc/deprecated-note-from-inlined-reexport-chain.rs
+++ b/tests/rustdoc-ui/intra-doc/deprecated-note-from-inlined-reexport-chain.rs
@@ -1,0 +1,18 @@
+//@ check-pass
+
+// Regression test for https://github.com/rust-lang/rust/issues/158745.
+// This checks that rustdoc resolves intra-doc links in deprecation notes using
+// the re-export that carries the attribute, even when that re-export is later
+// inlined through another re-export.
+
+#![deny(rustdoc::broken_intra_doc_links)]
+
+mod bar {
+    pub struct A;
+}
+
+#[deprecated(note = "[std::io::ErrorKind::NotFound]")]
+pub use bar::A;
+
+#[doc(inline)]
+pub use A as X;


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Fixes rust-lang/rust#158745