### PR TITLE
add regression test for late-bound type method probe ICE

### DIFF
--- a/tests/ui/traits/late-bound-type-method-probe.rs
+++ b/tests/ui/traits/late-bound-type-method-probe.rs
@@ -1,0 +1,19 @@
+// A method probe involving a late-bound type parameter should report normal
+// diagnostics instead of ICEing while structurally normalizing obligations.
+
+#![feature(non_lifetime_binders)]
+#![allow(incomplete_features)]
+
+pub trait T {
+    fn t<Tail>(&self, _: F) {}
+    //~^ ERROR cannot find type `F` in this scope
+}
+
+pub fn crash<V>(v: &V)
+where
+    for<F> F: T + 'static,
+{
+    v.t(|| {});
+}
+
+fn main() {}

--- a/tests/ui/traits/late-bound-type-method-probe.stderr
+++ b/tests/ui/traits/late-bound-type-method-probe.stderr
@@ -1,0 +1,17 @@
+error[E0425]: cannot find type `F` in this scope
+  --> $DIR/late-bound-type-method-probe.rs:8:26
+   |
+LL |     fn t<Tail>(&self, _: F) {}
+   |                          ^
+   |
+  --> $SRC_DIR/core/src/ops/function.rs:LL:COL
+   |
+   = note: similarly named trait `Fn` defined here
+help: a trait with a similar name exists
+   |
+LL |     fn t<Tail>(&self, _: Fn) {}
+   |                           +
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0425`.


### PR DESCRIPTION
Closes rust-lang/rust#149014