### PR TITLE
cranelift: fix backend limit diagnostics

### DIFF
--- a/compiler/rustc_codegen_cranelift/build_system/tests.rs
+++ b/compiler/rustc_codegen_cranelift/build_system/tests.rs
@@ -91,6 +91,30 @@ const BASE_SYSROOT_SUITE: &[TestCase] = &[
     TestCase::build_bin_and_run("aot.neon", "example/neon.rs", &[]),
     TestCase::build_bin_and_run("aot.gen_block_iterate", "example/gen_block_iterate.rs", &[]),
     TestCase::build_bin_and_run("aot.raw-dylib", "example/raw-dylib.rs", &[]),
+    TestCase::custom("aot.large-byval-align", &|runner| {
+        let output = runner
+            .rustc_command(["example/large-byval-align.rs", "--crate-type", "lib", "-Copt-level=0"])
+            .output()
+            .expect("failed to run rustc");
+        assert!(
+            !output.status.success(),
+            "expected large-byval-align.rs to exceed a backend implementation limit"
+        );
+
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            stderr.contains("backend implementation limit exceeded"),
+            "expected backend implementation limit error, got:\n{stderr}"
+        );
+        assert!(
+            !stderr.contains("internal compiler error"),
+            "backend implementation limit should not ICE:\n{stderr}"
+        );
+        assert!(
+            !stderr.contains("expected abort due to worker thread errors"),
+            "worker thread fatal should be reported through diagnostics:\n{stderr}"
+        );
+    }),
     TestCase::custom("test.sysroot", &|runner| {
         apply_patches(
             &runner.dirs,

--- a/compiler/rustc_codegen_cranelift/build_system/tests.rs
+++ b/compiler/rustc_codegen_cranelift/build_system/tests.rs
@@ -92,6 +92,11 @@ const BASE_SYSROOT_SUITE: &[TestCase] = &[
     TestCase::build_bin_and_run("aot.gen_block_iterate", "example/gen_block_iterate.rs", &[]),
     TestCase::build_bin_and_run("aot.raw-dylib", "example/raw-dylib.rs", &[]),
     TestCase::custom("aot.large-byval-align", &|runner| {
+        if !runner.target_compiler.triple.starts_with("x86_64") {
+            eprintln!("Skipping large-byval-align test: only x86_64 hits the Cranelift limit");
+            return;
+        }
+
         let output = runner
             .rustc_command(["example/large-byval-align.rs", "--crate-type", "lib", "-Copt-level=0"])
             .output()

--- a/compiler/rustc_codegen_cranelift/config.txt
+++ b/compiler/rustc_codegen_cranelift/config.txt
@@ -31,6 +31,7 @@ aot.issue-59326
 aot.neon
 aot.gen_block_iterate
 aot.raw-dylib
+aot.large-byval-align
 test.sysroot
 
 testsuite.extended_sysroot

--- a/compiler/rustc_codegen_cranelift/example/large-byval-align.rs
+++ b/compiler/rustc_codegen_cranelift/example/large-byval-align.rs
@@ -1,0 +1,6 @@
+#[allow(dead_code)]
+#[repr(align(536870912))]
+pub struct A(i64);
+
+#[allow(improper_ctypes_definitions, unused_variables)]
+pub extern "C" fn foo(x: A) {}

--- a/compiler/rustc_codegen_cranelift/src/base.rs
+++ b/compiler/rustc_codegen_cranelift/src/base.rs
@@ -7,6 +7,7 @@ use cranelift_module::ModuleError;
 use rustc_ast::InlineAsmOptions;
 use rustc_codegen_ssa::base::is_call_from_compiler_builtins_to_upstream_monomorphization;
 use rustc_data_structures::profiling::SelfProfilerRef;
+use rustc_errors::DiagCtxtHandle;
 use rustc_index::IndexVec;
 use rustc_middle::ty::TypeVisitableExt;
 use rustc_middle::ty::adjustment::PointerCoercion;
@@ -148,6 +149,7 @@ pub(crate) fn codegen_fn<'tcx>(
 
 pub(crate) fn compile_fn(
     prof: &SelfProfilerRef,
+    dcx: DiagCtxtHandle<'_>,
     output_filenames: &OutputFilenames,
     should_write_ir: bool,
     cached_context: &mut Context,
@@ -200,25 +202,19 @@ pub(crate) fn compile_fn(
         match module.define_function(codegened_func.func_id, context) {
             Ok(()) => {}
             Err(ModuleError::Compilation(CodegenError::ImplLimitExceeded)) => {
-                let early_dcx = rustc_session::EarlyDiagCtxt::new(
-                    rustc_session::config::ErrorOutputType::default(),
-                );
-                early_dcx.early_fatal(format!(
+                dcx.fatal(format!(
                     "backend implementation limit exceeded while compiling {name}",
                     name = codegened_func.symbol_name
                 ));
             }
             Err(ModuleError::Compilation(CodegenError::Verifier(err))) => {
-                let early_dcx = rustc_session::EarlyDiagCtxt::new(
-                    rustc_session::config::ErrorOutputType::default(),
-                );
-                let _ = early_dcx.early_err(format!("{:?}", err));
+                let raw_error = format!("{:?}", err);
                 let pretty_error = cranelift_codegen::print_errors::pretty_verifier_error(
                     &context.func,
                     Some(Box::new(&clif_comments)),
                     err,
                 );
-                early_dcx.early_fatal(format!("cranelift verify error:\n{}", pretty_error));
+                dcx.fatal(format!("cranelift verify error:\n{raw_error}\n{pretty_error}"));
             }
             Err(err) => {
                 panic!("Error while defining {name}: {err:?}", name = codegened_func.symbol_name);

--- a/compiler/rustc_codegen_cranelift/src/driver/aot.rs
+++ b/compiler/rustc_codegen_cranelift/src/driver/aot.rs
@@ -17,7 +17,7 @@ use rustc_codegen_ssa::back::write::{
 use rustc_codegen_ssa::traits::{ExtraBackendMethods, WriteBackendMethods};
 use rustc_codegen_ssa::{CompiledModule, ModuleCodegen, ModuleKind};
 use rustc_data_structures::profiling::SelfProfilerRef;
-use rustc_errors::DiagCtxt;
+use rustc_errors::{DiagCtxt, DiagCtxtHandle};
 use rustc_hir::attrs::Linkage as RLinkage;
 use rustc_middle::dep_graph::WorkProduct;
 use rustc_middle::middle::codegen_fn_attrs::CodegenFnAttrFlags;
@@ -205,6 +205,7 @@ fn codegen_cgu(tcx: TyCtxt<'_>, cgu_name: Symbol) -> AotModule {
 
 fn compile_cgu(
     prof: &SelfProfilerRef,
+    dcx: DiagCtxtHandle<'_>,
     output_filenames: &OutputFilenames,
     should_write_ir: bool,
     mut aot_module: AotModule,
@@ -220,6 +221,7 @@ fn compile_cgu(
         for codegened_func in aot_module.codegened_functions {
             crate::base::compile_fn(
                 &prof,
+                dcx,
                 &output_filenames,
                 should_write_ir,
                 &mut cached_context,
@@ -373,18 +375,17 @@ impl WriteBackendMethods for AotDriver {
         module: ModuleCodegen<Self::Module>,
         config: &ModuleConfig,
     ) -> CompiledModule {
+        let dcx = DiagCtxt::new(Box::new(shared_emitter.clone()));
         compile_cgu(
             prof,
+            dcx.handle(),
             &cgcx.output_filenames,
             config.emit_ir,
             module.module_llvm,
             module.name,
             module.kind,
         )
-        .unwrap_or_else(|err| {
-            let dcx = DiagCtxt::new(Box::new(shared_emitter.clone()));
-            dcx.handle().fatal(err)
-        })
+        .unwrap_or_else(|err| dcx.handle().fatal(err))
     }
 
     fn serialize_module(_module: Self::Module, _is_thin: bool) -> Self::ModuleBuffer {

--- a/compiler/rustc_codegen_cranelift/src/driver/jit.rs
+++ b/compiler/rustc_codegen_cranelift/src/driver/jit.rs
@@ -157,6 +157,7 @@ fn codegen_and_compile_fn<'tcx>(
         let mut global_asm = String::new();
         crate::base::compile_fn(
             &tcx.prof,
+            tcx.dcx(),
             output_filenames,
             should_write_ir,
             cached_context,

--- a/tests/ui/abi/large-byval-align-cranelift.rs
+++ b/tests/ui/abi/large-byval-align-cranelift.rs
@@ -1,0 +1,14 @@
+//@ needs-backends: cranelift
+//@ compile-flags: -Copt-level=0
+//@ build-fail
+//@ only-x86_64
+//@ normalize-stderr: "while compiling .*foo.*" -> "while compiling SYMBOL"
+
+#![crate_type = "lib"]
+
+#[allow(dead_code)]
+#[repr(align(536870912))]
+pub struct A(i64);
+
+#[allow(improper_ctypes_definitions, unused_variables)]
+pub extern "C" fn foo(x: A) {}

--- a/tests/ui/abi/large-byval-align-cranelift.stderr
+++ b/tests/ui/abi/large-byval-align-cranelift.stderr
@@ -1,0 +1,3 @@
+error: backend implementation limit exceeded while compiling SYMBOL
+
+error: aborting due to 1 previous error


### PR DESCRIPTION
fixes rust-lang/rust#158801

cg_clif was reporting cranelift impl-limit failures through earlydiagctxt. that printed the backend error, but it never reached the session dcx, so join_codegen could still hit the worker-thread ice.

the fix routes those failures through the shared emitter/session dcx path. verifier failures also use one fatal diagnostic, so the pretty verifier text does not get lost behind an earlier queued error.

imo this is the least weird fix because the backend limit itself is fine; the bad part was the diagnostic plumbing. i added both a cg_clif harness check and a cranelift-gated ui fixture. idk if we keep both forever, but they make the regression pretty obvious. ltm if you want the ui one dropped.