### PR TITLE
Allow range-to-inclusive macro patterns

### DIFF
--- a/compiler/rustc_ast/src/token.rs
+++ b/compiler/rustc_ast/src/token.rs
@@ -712,6 +712,7 @@ impl Token {
             Literal(_) |                         // literal
             DotDot |                             // range pattern (future compat)
             DotDotDot |                          // range pattern (future compat)
+            DotDotEq |                           // range-to-inclusive pattern
             PathSep |                            // path
             Lt |                                 // path (UFCS constant)
             Shl => true,                         // path (double UFCS)

--- a/tests/ui/macros/range-to-inclusive-pat-issue-120737.rs
+++ b/tests/ui/macros/range-to-inclusive-pat-issue-120737.rs
@@ -1,0 +1,8 @@
+//@ check-pass
+
+// Ensure macro `:pat` fragments accept `..=` as a valid pattern start.
+
+fn main() {
+    assert!(matches!(2, ..=0 | 2));
+    assert!(matches!(0, ..=0));
+}


### PR DESCRIPTION
Fixes rust-lang/rust#120737