### PR TITLE
tidy: Use `empty_alternate = true` for triagebot mention glob check

### DIFF
--- a/src/tools/tidy/src/triagebot.rs
+++ b/src/tools/tidy/src/triagebot.rs
@@ -51,7 +51,12 @@ pub fn check(path: &Path, tidy_ctx: TidyCtx) {
                 // The full-path doesn't exists, maybe it's a glob, let's add it to the glob set builder
                 // to be checked against all the file and directories in the repository.
                 let trimmed_path = clean_path.trim_end_matches('/');
-                builder.add(globset::Glob::new(&format!("{trimmed_path}{{,/*}}")).unwrap());
+                builder.add(
+                    globset::GlobBuilder::new(&format!("{trimmed_path}{{,/*}}"))
+                        .empty_alternates(true)
+                        .build()
+                        .unwrap(),
+                );
                 glob_entries.push(clean_path.to_string());
             } else if is_in_submodule(Path::new(clean_path)) {
                 check.error(format!(


### PR DESCRIPTION
In accordance with triagebot's following line:
https://github.com/rust-lang/triagebot/blob/8fe35ac13efb881598a4f1d7768d5dee5a3fff09/src/handlers/mentions.rs#L217

Fixes a false positive tidy failure in https://github.com/rust-lang/rust/pull/158834#issuecomment-4888834955