### PR TITLE
Fix bad span of well-formed evaluation overflow

### DIFF
--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -735,6 +735,11 @@ impl<'tcx> InferCtxt<'tcx> {
         self.inner.borrow_mut().type_variables().var_origin(vid)
     }
 
+    /// Returns the instantiation span of the type variable identified by `vid`.
+    pub fn type_var_instantiate_span(&self, vid: TyVid) -> Option<Span> {
+        self.inner.borrow_mut().type_variables().instantiate_span(vid)
+    }
+
     /// Returns the origin of the float type variable identified by `vid`.
     ///
     /// No attempt is made to resolve `vid` to its root variable.

--- a/compiler/rustc_infer/src/infer/relate/generalize.rs
+++ b/compiler/rustc_infer/src/infer/relate/generalize.rs
@@ -154,7 +154,7 @@ impl<'tcx> InferCtxt<'tcx> {
         )?;
 
         // Constrain `b_vid` to the generalized type `generalized_term`.
-        self.union_var_term(target_vid, generalized_term);
+        self.union_var_term(target_vid, generalized_term, relation.span());
 
         // Finally, relate `generalized_term` to `source_term`, as described in previous comment.
         //
@@ -265,13 +265,13 @@ impl<'tcx> InferCtxt<'tcx> {
 
     /// This is a thin wrapper around inserting into the var tables. You probably want
     /// [`Self::instantiate_var`] instead, which calls this method.
-    fn union_var_term(&self, l: TermVid, r: ty::Term<'tcx>) {
+    fn union_var_term(&self, l: TermVid, r: ty::Term<'tcx>, span: Span) {
         match (l, r.kind()) {
             (TermVid::Ty(l), ty::TermKind::Ty(r)) => {
                 if let Some(r) = r.ty_vid() {
                     self.inner.borrow_mut().type_variables().equate(l, r)
                 } else {
-                    self.inner.borrow_mut().type_variables().instantiate(l, r)
+                    self.inner.borrow_mut().type_variables().instantiate(l, r, span)
                 }
             }
             (TermVid::Const(l), ty::TermKind::Const(r)) => {

--- a/compiler/rustc_infer/src/infer/type_variable.rs
+++ b/compiler/rustc_infer/src/infer/type_variable.rs
@@ -113,6 +113,7 @@ pub struct FloatVariableOrigin {
 #[derive(Clone)]
 pub(crate) struct TypeVariableData {
     origin: TypeVariableOrigin,
+    instantiate_span: Option<Span>,
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -191,7 +192,7 @@ impl<'tcx> TypeVariableTable<'_, 'tcx> {
     /// Instantiates `vid` with the type `ty`.
     ///
     /// Precondition: `vid` must not have been previously instantiated.
-    pub(crate) fn instantiate(&mut self, vid: ty::TyVid, ty: Ty<'tcx>) {
+    pub(crate) fn instantiate(&mut self, vid: ty::TyVid, ty: Ty<'tcx>, instantiate_span: Span) {
         let vid = self.root_var(vid);
         debug_assert!(!ty.is_ty_var(), "instantiating ty var with var: {vid:?} {ty:?}");
         debug_assert!(self.probe(vid).is_unknown());
@@ -201,6 +202,7 @@ impl<'tcx> TypeVariableTable<'_, 'tcx> {
             self.eq_relations().probe_value(vid)
         );
         self.eq_relations().union_value(vid, TypeVariableValue::Known { value: ty });
+        self.storage.values[vid].instantiate_span = Some(instantiate_span);
     }
 
     /// Creates a new type variable.
@@ -223,7 +225,7 @@ impl<'tcx> TypeVariableTable<'_, 'tcx> {
         let sub_key = self.sub_unification_table().new_key(());
         debug_assert_eq!(eq_key.vid, sub_key.vid);
 
-        let index = self.storage.values.push(TypeVariableData { origin });
+        let index = self.storage.values.push(TypeVariableData { origin, instantiate_span: None });
         debug_assert_eq!(eq_key.vid, index);
 
         debug!("new_var(index={:?}, universe={:?}, origin={:?})", eq_key.vid, universe, origin);
@@ -234,6 +236,15 @@ impl<'tcx> TypeVariableTable<'_, 'tcx> {
     /// Returns the number of type variables created thus far.
     pub(crate) fn num_vars(&self) -> usize {
         self.storage.values.len()
+    }
+
+    /// Returns the instantiation span of `vid`, if any.
+    pub(crate) fn instantiate_span(&mut self, vid: ty::TyVid) -> Option<Span> {
+        let vid = self.root_var(vid);
+        match self.probe(vid) {
+            TypeVariableValue::Known { .. } => self.storage.values[vid].instantiate_span,
+            TypeVariableValue::Unknown { .. } => None,
+        }
     }
 
     /// Returns the "root" variable of `vid` in the `eq_relations`

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/overflow.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/overflow.rs
@@ -142,11 +142,25 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
     where
         T: Upcast<TyCtxt<'tcx>, ty::Predicate<'tcx>> + Clone,
     {
+        // Try to use better span rather than obligation.cause.span
         let predicate = obligation.predicate.clone().upcast(self.tcx);
         let predicate = self.resolve_vars_if_possible(predicate);
+        let span = if let ty::PredicateKind::Clause(ty::ClauseKind::WellFormed(term)) =
+            predicate.kind().skip_binder()
+            && let Some(ty) = term.as_type()
+            && let Some(vid) = ty.peel_refs().ty_vid()
+        {
+            self.infcx.type_var_instantiate_span(vid).unwrap_or_else(|| {
+                let span = self.infcx.type_var_origin(vid).span;
+                if span.is_dummy() { obligation.cause.span } else { span }
+            })
+        } else {
+            obligation.cause.span
+        };
+
         self.report_overflow_error(
             OverflowCause::TraitSolver(predicate),
-            obligation.cause.span,
+            span,
             suggest_increasing_limit,
             |err| {
                 self.note_obligation_cause_code(

--- a/tests/ui/wf/wf-overflow-span.rs
+++ b/tests/ui/wf/wf-overflow-span.rs
@@ -1,0 +1,7 @@
+fn main() {
+    let mut samples = Vec::new();
+    let packet_buf = Vec::new();
+    samples.extend(packet_buf.iter().map(|x| [x, x]));
+    //~^ ERROR overflow evaluating whether `&_` is well-formed
+    samples.extend(packet_buf.chunks_exact(1).map(|x| [x[0], x[0]]));
+}

--- a/tests/ui/wf/wf-overflow-span.stderr
+++ b/tests/ui/wf/wf-overflow-span.stderr
@@ -1,0 +1,9 @@
+error[E0275]: overflow evaluating whether `&_` is well-formed
+  --> $DIR/wf-overflow-span.rs:4:50
+   |
+LL |     samples.extend(packet_buf.iter().map(|x| [x, x]));
+   |                                                  ^
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0275`.


### PR DESCRIPTION
Fixes rust-lang/rust#157619

Refine bad span of well-formed evaluation overflow

