### PR TITLE
Avoid final override ICE for RPITIT associated types

### DIFF
--- a/compiler/rustc_hir_analysis/src/check/check.rs
+++ b/compiler/rustc_hir_analysis/src/check/check.rs
@@ -1254,7 +1254,7 @@ fn check_overriding_final_trait_item<'tcx>(
     trait_item: ty::AssocItem,
     impl_item: ty::AssocItem,
 ) {
-    if trait_item.defaultness(tcx).is_final() {
+    if trait_item.is_fn() && trait_item.defaultness(tcx).is_final() {
         tcx.dcx().emit_err(diagnostics::OverridingFinalTraitFunction {
             impl_span: tcx.def_span(impl_item.def_id),
             trait_span: tcx.def_span(trait_item.def_id),

--- a/tests/ui/traits/final/overriding-rpitit.rs
+++ b/tests/ui/traits/final/overriding-rpitit.rs
@@ -1,0 +1,18 @@
+#![feature(final_associated_functions)]
+
+// Regression test for https://github.com/rust-lang/rust/issues/158824.
+
+trait Item {
+    final fn bar() -> impl Clone {
+        todo!()
+    }
+}
+
+struct Foo;
+
+impl Item for Foo {
+    fn bar() -> impl Clone {}
+    //~^ ERROR cannot override `bar` because it already has a `final` definition in the trait
+}
+
+fn main() {}

--- a/tests/ui/traits/final/overriding-rpitit.stderr
+++ b/tests/ui/traits/final/overriding-rpitit.stderr
@@ -1,0 +1,14 @@
+error: cannot override `bar` because it already has a `final` definition in the trait
+  --> $DIR/overriding-rpitit.rs:14:5
+   |
+LL |     fn bar() -> impl Clone {}
+   |     ^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: `bar` is marked final here
+  --> $DIR/overriding-rpitit.rs:6:5
+   |
+LL |     final fn bar() -> impl Clone {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Fixes rust-lang/rust#158824

`check_overriding_final_trait_item` was running for every associated item in an impl, including the synthetic anonymous associated type generated for RPITIT.