### PR TITLE
Fix ICE in `write_interface` when the interface file can't be written

### DIFF
--- a/compiler/rustc_interface/src/diagnostics.rs
+++ b/compiler/rustc_interface/src/diagnostics.rs
@@ -84,7 +84,7 @@ pub(crate) struct TempsDirError;
 pub(crate) struct OutDirError;
 
 #[derive(Diagnostic)]
-#[diag("failed to write file {$path}: {$error}\"")]
+#[diag("failed to write file {$path}: {$error}")]
 pub(crate) struct FailedWritingFile<'a> {
     pub path: &'a Path,
     pub error: io::Error,

--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -881,9 +881,11 @@ pub fn write_interface<'tcx>(tcx: TyCtxt<'tcx>) {
         &tcx.sess.psess.attr_id_generator,
     );
     let export_output = tcx.output_filenames(()).interface_path();
-    let mut file = fs::File::create_buffered(export_output).unwrap();
-    if let Err(err) = write!(file, "{}", krate) {
-        tcx.dcx().fatal(format!("error writing interface file: {}", err));
+    let mut file = fs::File::create_buffered(&export_output).unwrap_or_else(|error| {
+        tcx.dcx().emit_fatal(diagnostics::FailedWritingFile { path: &export_output, error })
+    });
+    if let Err(error) = write!(file, "{}", krate) {
+        tcx.dcx().emit_fatal(diagnostics::FailedWritingFile { path: &export_output, error });
     }
 }
 

--- a/compiler/rustc_middle/src/error.rs
+++ b/compiler/rustc_middle/src/error.rs
@@ -18,7 +18,7 @@ pub(crate) struct DropCheckOverflow<'tcx> {
 }
 
 #[derive(Diagnostic)]
-#[diag("failed to write file {$path}: {$error}\"")]
+#[diag("failed to write file {$path}: {$error}")]
 pub(crate) struct FailedWritingFile<'a> {
     pub path: &'a Path,
     pub error: io::Error,

--- a/tests/run-make/export/write-interface-nonexistent-dir/libr.rs
+++ b/tests/run-make/export/write-interface-nonexistent-dir/libr.rs
@@ -1,0 +1,13 @@
+#![feature(export_stable)]
+#![crate_type = "sdylib"]
+
+pub mod m {
+    #[repr(C)]
+    pub struct S {
+        pub x: i32,
+    }
+
+    pub extern "C" fn foo1(x: S) -> i32 {
+        x.x
+    }
+}

--- a/tests/run-make/export/write-interface-nonexistent-dir/rmake.rs
+++ b/tests/run-make/export/write-interface-nonexistent-dir/rmake.rs
@@ -1,0 +1,18 @@
+// Regression test for <https://github.com/rust-lang/rust/issues/143981>.
+
+//@ ignore-cross-compile
+
+// NOTE: `sdylib`'s platform support is basically that of `dylib`.
+//@ needs-crate-type: dylib
+
+use run_make_support::rustc;
+
+fn main() {
+    rustc()
+        .input("libr.rs")
+        .output("does-not-exist/output")
+        .run_fail()
+        .assert_exit_code(1)
+        .assert_stderr_contains("failed to write file")
+        .assert_not_ice();
+}


### PR DESCRIPTION
Fixes rust-lang/rust#143981.

`write_interface` opened the `sdylib` interface file with `fs::File::create_buffered(...).unwrap()`, so any failure to create it (like `-o` into a non-existent or unwritable directory) will ICE instead of reporting a normal error. Emit `FailedWritingFile` instead, matching the rlink and dep-graph write paths.

Also drop a stray trailing `"` from the `FailedWritingFile` in `diagnostic.rs` and `error.rs`.
