### PR TITLE
Avoid underflow for splatted rust-call receivers

### DIFF
--- a/compiler/rustc_hir_analysis/src/check/wfcheck.rs
+++ b/compiler/rustc_hir_analysis/src/check/wfcheck.rs
@@ -1653,16 +1653,6 @@ fn check_fn_or_method<'tcx>(
         let span = tcx.def_span(def_id);
         let has_implicit_self = hir_decl.implicit_self().has_implicit_self();
         let mut inputs = sig.inputs().iter().skip(if has_implicit_self { 1 } else { 0 });
-        // FIXME(splat): support the rest of closure splatting, or replace this code with an error
-        if let Some(mut splatted_arg_index) = sig.splatted() {
-            let mut inputs_count = sig.inputs().len();
-            if has_implicit_self {
-                splatted_arg_index = splatted_arg_index.strict_sub(1);
-                inputs_count = inputs_count.strict_sub(1);
-            }
-            debug!(?splatted_arg_index, ?inputs_count, ?has_implicit_self, ?sig);
-            sig = sig.set_splatted(Some(splatted_arg_index), inputs_count).unwrap();
-        }
         // Check that the argument is a tuple and is sized
         if let Some(ty) = inputs.next() {
             wfcx.register_bound(

--- a/tests/ui/splat/splat-self-rust-call-issue-158800.rs
+++ b/tests/ui/splat/splat-self-rust-call-issue-158800.rs
@@ -1,0 +1,16 @@
+//! Regression test for `#[splat] self` in a rust-call method not ICEing in WF
+//! checking.
+
+#![feature(splat)]
+#![feature(unboxed_closures)]
+#![allow(incomplete_features)]
+
+impl<T> dyn FnOnce(T) -> () {
+    //~^ ERROR cannot define inherent `impl` for a type outside of the crate
+    extern "rust-call" fn call_once(#[splat] self) {}
+    //~^ ERROR `#[splat]` is not allowed in the arguments of functions with the `rust-call` ABI
+    //~| ERROR functions with the "rust-call" ABI must take a single non-self tuple argument
+    //~| ERROR the size for values of type `(dyn FnOnce(T) + 'static)` cannot be known
+}
+
+fn main() {}

--- a/tests/ui/splat/splat-self-rust-call-issue-158800.stderr
+++ b/tests/ui/splat/splat-self-rust-call-issue-158800.stderr
@@ -1,0 +1,40 @@
+error: `#[splat]` is not allowed in the arguments of functions with the `rust-call` ABI
+  --> $DIR/splat-self-rust-call-issue-158800.rs:10:5
+   |
+LL |     extern "rust-call" fn call_once(#[splat] self) {}
+   |     ^^^^^^^^^^^^^^^^^^              ^^^^^^^^
+   |
+   = help: remove `#[splat]` or change the ABI
+
+error: functions with the "rust-call" ABI must take a single non-self tuple argument
+  --> $DIR/splat-self-rust-call-issue-158800.rs:10:46
+   |
+LL |     extern "rust-call" fn call_once(#[splat] self) {}
+   |                                              ^^^^
+
+error[E0116]: cannot define inherent `impl` for a type outside of the crate where the type is defined
+  --> $DIR/splat-self-rust-call-issue-158800.rs:8:1
+   |
+LL | impl<T> dyn FnOnce(T) -> () {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl for type defined outside of crate
+   |
+   = help: consider defining a trait and implementing it for the type or using a newtype wrapper like `struct MyType(ExternalType);` and implement it
+   = note: for more details about the orphan rules, see <https://doc.rust-lang.org/reference/items/implementations.html?highlight=orphan#orphan-rules>
+
+error[E0277]: the size for values of type `(dyn FnOnce(T) + 'static)` cannot be known at compilation time
+  --> $DIR/splat-self-rust-call-issue-158800.rs:10:46
+   |
+LL |     extern "rust-call" fn call_once(#[splat] self) {}
+   |                                              ^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `(dyn FnOnce(T) + 'static)`
+   = help: unsized fn params are gated as an unstable feature
+help: function arguments must have a statically known size, borrowed types always have a known size
+   |
+LL |     extern "rust-call" fn call_once(#[splat] &self) {}
+   |                                              +
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0116, E0277.
+For more information about an error, try `rustc --explain E0116`.


### PR DESCRIPTION
Fixes rust-lang/rust#158800

We alreay have proper error for `#[splat] self` in following code, so here we just need to avoid the overflow.

cc @teor2345
