### PR TITLE
Add `desktop` method to `CommandExt`

### DIFF
--- a/library/std/src/os/windows/process.rs
+++ b/library/std/src/os/windows/process.rs
@@ -174,6 +174,15 @@ pub impl(self) trait CommandExt {
     #[stable(feature = "windows_process_extensions", since = "1.16.0")]
     fn creation_flags(&mut self, flags: u32) -> &mut process::Command;
 
+    /// Places the child process on the desktop named `desktop` by setting the
+    /// `lpDesktop` field of the [STARTUPINFO][1] passed to `CreateProcess`.
+    ///
+    /// The name may be a desktop or a `window-station\desktop` path.
+    ///
+    /// [1]: <https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/ns-processthreadsapi-startupinfow>
+    #[unstable(feature = "windows_process_extensions_desktop", issue = "158852")]
+    fn desktop<S: AsRef<OsStr>>(&mut self, desktop: S) -> &mut process::Command;
+
     /// Sets the field `wShowWindow` of [STARTUPINFO][1] that is passed to `CreateProcess`.
     /// Allowed values are the ones listed in
     /// <https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-showwindow>
@@ -378,6 +387,11 @@ pub impl(self) trait CommandExt {
 impl CommandExt for process::Command {
     fn creation_flags(&mut self, flags: u32) -> &mut process::Command {
         self.as_inner_mut().creation_flags(flags);
+        self
+    }
+
+    fn desktop<S: AsRef<OsStr>>(&mut self, desktop: S) -> &mut process::Command {
+        self.as_inner_mut().desktop(desktop.as_ref());
         self
     }
 

--- a/library/std/src/sys/process/windows.rs
+++ b/library/std/src/sys/process/windows.rs
@@ -162,6 +162,7 @@ pub struct Command {
     startupinfo_untrusted_source: bool,
     startupinfo_force_feedback: Option<bool>,
     inherit_handles: bool,
+    desktop: Option<Vec<u16>>,
 }
 
 pub enum Stdio {
@@ -191,6 +192,7 @@ impl Command {
             startupinfo_untrusted_source: false,
             startupinfo_force_feedback: None,
             inherit_handles: true,
+            desktop: None,
         }
     }
 
@@ -215,6 +217,7 @@ impl Command {
     pub fn creation_flags(&mut self, flags: u32) {
         self.flags = flags;
     }
+
     pub fn show_window(&mut self, cmd_show: Option<u16>) {
         self.show_window = cmd_show;
     }
@@ -237,6 +240,10 @@ impl Command {
 
     pub fn startupinfo_force_feedback(&mut self, enabled: Option<bool>) {
         self.startupinfo_force_feedback = enabled;
+    }
+
+    pub fn desktop(&mut self, desktop: &OsStr) {
+        self.desktop = Some(desktop.encode_wide().chain([0]).collect());
     }
 
     pub fn get_program(&self) -> &OsStr {
@@ -389,6 +396,10 @@ impl Command {
                 si.dwFlags |= c::STARTF_FORCEOFFFEEDBACK;
             }
             None => {}
+        }
+
+        if let Some(desktop) = &mut self.desktop {
+            si.lpDesktop = desktop.as_mut_ptr();
         }
 
         let si_ptr: *mut c::STARTUPINFOW;

--- a/tests/ui/process/win-desktop.rs
+++ b/tests/ui/process/win-desktop.rs
@@ -1,0 +1,129 @@
+// Tests `desktop` by creating a new desktop, spawning a child process onto it
+// and checking that the child reports back the expected desktop name.
+
+//@ run-pass
+//@ only-windows
+//@ needs-subprocess
+//@ edition: 2024
+
+#![feature(windows_process_extensions_desktop)]
+
+use std::os::windows::process::CommandExt;
+use std::process::{Command, Stdio};
+use std::{env, io, process};
+
+fn main() {
+    if env::args().skip(1).any(|s| s == "--child") {
+        child();
+    } else {
+        parent();
+    }
+}
+
+fn parent() {
+    let exe = env::current_exe().unwrap();
+
+    // Create a uniquely named desktop on the current window station and keep the
+    // handle alive so the desktop is not destroyed while the child runs.
+    let desktop_name = format!("rust-test-desktop-{}", process::id());
+    let desktop_name_wide: Vec<u16> = desktop_name.encode_utf16().chain([0]).collect();
+    let hdesk = unsafe {
+        CreateDesktopW(
+            desktop_name_wide.as_ptr(),
+            core::ptr::null(),
+            core::ptr::null(),
+            0,
+            GENERIC_ALL,
+            core::ptr::null(),
+        )
+    };
+    assert!(!hdesk.is_null(), "CreateDesktopW failed: {:?}", io::Error::last_os_error());
+
+    // Spawning with `.desktop` should place the child on our new desktop.
+    let output = Command::new(&exe)
+        .arg("--child")
+        .desktop(&desktop_name)
+        .stdout(Stdio::piped())
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "child failed: {:?}", output);
+    let reported = String::from_utf8(output.stdout).unwrap();
+    assert!(
+        reported.trim().eq_ignore_ascii_case(&desktop_name),
+        "child ran on unexpected desktop: expected {:?}, got {:?}",
+        desktop_name,
+        reported.trim(),
+    );
+
+    // Without `.desktop` the child inherits the parent's desktop, which is
+    // not the one we just created.
+    let output = Command::new(&exe).arg("--child").stdout(Stdio::piped()).output().unwrap();
+    assert!(output.status.success(), "child failed: {:?}", output);
+    let reported = String::from_utf8(output.stdout).unwrap();
+    assert!(
+        !reported.trim().eq_ignore_ascii_case(&desktop_name),
+        "child unexpectedly ran on the created desktop {:?} without being asked to",
+        desktop_name,
+    );
+
+    unsafe { CloseDesktop(hdesk) };
+}
+
+/// Prints the name of the desktop the current process is running on.
+fn child() {
+    let hdesk = unsafe { GetThreadDesktop(GetCurrentThreadId()) };
+    assert!(!hdesk.is_null(), "GetThreadDesktop failed: {:?}", io::Error::last_os_error());
+
+    let mut buffer = [0u16; 256];
+    let mut needed = 0u32;
+    let ret = unsafe {
+        GetUserObjectInformationW(
+            hdesk,
+            UOI_NAME,
+            buffer.as_mut_ptr().cast(),
+            size_of_val(&buffer) as u32,
+            &raw mut needed,
+        )
+    };
+    assert_ne!(ret, 0, "GetUserObjectInformationW failed: {:?}", io::Error::last_os_error());
+
+    let len = buffer.iter().position(|&c| c == 0).unwrap_or(buffer.len());
+    let name = String::from_utf16(&buffer[..len]).unwrap();
+    print!("{name}");
+}
+
+// Windows API
+mod winapi {
+    use std::ffi::c_void;
+    use std::os::windows::raw::HANDLE;
+
+    pub const GENERIC_ALL: u32 = 0x10000000;
+    pub const UOI_NAME: i32 = 2;
+
+    #[link(name = "user32")]
+    unsafe extern "system" {
+        pub fn CreateDesktopW(
+            lpszDesktop: *const u16,
+            lpszDevice: *const u16,
+            pDevmode: *const c_void,
+            dwFlags: u32,
+            dwDesiredAccess: u32,
+            lpsa: *const c_void,
+        ) -> HANDLE;
+        pub fn CloseDesktop(hDesktop: HANDLE) -> i32;
+        pub fn GetThreadDesktop(dwThreadId: u32) -> HANDLE;
+        pub fn GetUserObjectInformationW(
+            hObj: HANDLE,
+            nIndex: i32,
+            pvInfo: *mut c_void,
+            nLength: u32,
+            lpnLengthNeeded: *mut u32,
+        ) -> i32;
+    }
+
+    #[link(name = "kernel32")]
+    unsafe extern "system" {
+        pub fn GetCurrentThreadId() -> u32;
+    }
+}
+use winapi::*;


### PR DESCRIPTION
This PR enables setting the `lpDesktop` field of the STARTUPINFO passed to the Windows `CreateProcess` API call by adding a `desktop`  builder method to the [Windows-specific CommandExt extension trait](https://doc.rust-lang.org/stable/std/os/windows/process/trait.CommandExt.html).

Accepted ACP: rust-lang/libs-team#221
Tracking issue: rust-lang/rust#158852

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
