### PR TITLE
Fix ICE when projecting DiscriminantKind through unsafe binders

### DIFF
--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -1717,7 +1717,7 @@ impl<'tcx> Ty<'tcx> {
             ty::Adt(adt, _) if adt.is_enum() => adt.repr().discr_type().to_ty(tcx),
             ty::Coroutine(_, args) => args.as_coroutine().discr_ty(tcx),
 
-            ty::Param(_) | ty::Alias(..) | ty::Infer(ty::TyVar(_)) => {
+            ty::Param(_) | ty::Placeholder(_) | ty::Alias(..) | ty::Infer(ty::TyVar(_)) => {
                 let assoc_items = tcx.associated_item_def_ids(
                     tcx.require_lang_item(hir::LangItem::DiscriminantKind, DUMMY_SP),
                 );
@@ -1757,9 +1757,7 @@ impl<'tcx> Ty<'tcx> {
             | ty::Error(_)
             | ty::Infer(IntVar(_) | FloatVar(_)) => tcx.types.u8,
 
-            ty::Bound(..)
-            | ty::Placeholder(_)
-            | ty::Infer(FreshTy(_) | ty::FreshIntTy(_) | ty::FreshFloatTy(_)) => {
+            ty::Bound(..) | ty::Infer(FreshTy(_) | ty::FreshIntTy(_) | ty::FreshFloatTy(_)) => {
                 bug!("`discriminant_ty` applied to unexpected type: {:?}", self)
             }
         }

--- a/compiler/rustc_next_trait_solver/src/solve/normalizes_to.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/normalizes_to.rs
@@ -1001,12 +1001,8 @@ where
             | ty::Slice(_)
             | ty::Dynamic(_, _)
             | ty::Tuple(_)
+            | ty::UnsafeBinder(_)
             | ty::Error(_) => self_ty.discriminant_ty(ecx.cx()),
-
-            ty::UnsafeBinder(_) => {
-                // FIXME(unsafe_binders): instantiate this with placeholders?? i guess??
-                todo!("discr subgoal...")
-            }
 
             // Given an alias, parameter, or placeholder we add an impl candidate normalizing to a rigid
             // alias. In case there's a where-bound further constraining this alias it is preferred over

--- a/compiler/rustc_trait_selection/src/traits/project.rs
+++ b/compiler/rustc_trait_selection/src/traits/project.rs
@@ -1081,10 +1081,9 @@ fn assemble_candidates_from_impls<'cx, 'tcx>(
                         | ty::CoroutineWitness(..)
                         | ty::Never
                         | ty::Tuple(..)
+                        | ty::UnsafeBinder(_)
                         // Integers and floats always have `u8` as their discriminant.
                         | ty::Infer(ty::InferTy::IntVar(_) | ty::InferTy::FloatVar(..)) => true,
-
-                        ty::UnsafeBinder(_) => todo!("FIXME(unsafe_binder)"),
 
                         // type parameters, opaques, and unnormalized projections don't have
                         // a known discriminant and may need to be normalized further or rely

--- a/tests/ui/unsafe-binders/discriminant-kind.rs
+++ b/tests/ui/unsafe-binders/discriminant-kind.rs
@@ -1,0 +1,12 @@
+// Regression test for https://github.com/rust-lang/rust/issues/158839
+//@ check-pass
+//@ revisions: current next
+//@ [next] compile-flags: -Znext-solver=globally
+
+#![feature(unsafe_binders)]
+
+fn foo<T: std::marker::Copy>(x: unsafe<> T) {
+    std::mem::discriminant(&x);
+}
+
+fn main() {}


### PR DESCRIPTION
`Ty::discriminant_ty` already forwards through `UnsafeBinder` to the erased inner type (see https://github.com/rust-lang/rust/commit/35693778e81). The old and new trait solvers still hit `todo!`s when assembling/normalizing `<unsafe<> T as DiscriminantKind>::Discriminant`.

Fixes rust-lang/rust#158839 