### PR TITLE
Improve `-Zls` diagnostic message on `.rs` files

### DIFF
--- a/compiler/rustc_driver_impl/src/lib.rs
+++ b/compiler/rustc_driver_impl/src/lib.rs
@@ -598,25 +598,28 @@ fn list_metadata(sess: &Session, metadata_loader: &dyn MetadataLoader) {
     match sess.io.input {
         Input::File(ref path) => {
             let mut v = Vec::new();
-            if locator::list_file_metadata(
+            if let Err(error) = locator::list_file_metadata(
                 &sess.target,
                 path,
                 metadata_loader,
                 &mut v,
                 &sess.opts.unstable_opts.ls,
                 sess.cfg_version,
-            )
-            .is_err()
-                && path.extension().is_some_and(|extension| extension == "rs")
-            {
-                let mut err = sess
-                    .dcx()
-                    .struct_fatal("`-Zls` takes a `.rmeta` file as input, not a source file");
-                if rustc_session::utils::was_invoked_from_cargo() {
-                    // Give a Cargo-tailored suggestion if we're coming from Cargo
-                    err.note("use `rustc +nightly -Zls=... path/to/file.rmeta` directly, instead of going through Cargo");
+            ) {
+                // If the panic comes from the input being the wrong file, direct the user to .rmeta files
+                if path.extension().is_some_and(|extension| extension == "rs") {
+                    let mut err = sess
+                        .dcx()
+                        .struct_fatal("`-Zls` takes a `.rmeta` file as input, not a source file");
+                    if rustc_session::utils::was_invoked_from_cargo() {
+                        // Give a Cargo-tailored suggestion if we're coming from Cargo
+                        err.note("use `rustc +nightly -Zls=... path/to/file.rmeta` directly, instead of going through Cargo");
+                    }
+                    err.emit();
                 }
-                err.emit();
+
+                // Else, just panic (This shouldn't be reached);
+                panic!("{error}");
             }
             safe_println!("{}", String::from_utf8(v).unwrap());
         }

--- a/compiler/rustc_driver_impl/src/lib.rs
+++ b/compiler/rustc_driver_impl/src/lib.rs
@@ -597,6 +597,16 @@ fn process_rlink(sess: &Session, compiler: &interface::Compiler) {
 fn list_metadata(sess: &Session, metadata_loader: &dyn MetadataLoader) {
     match sess.io.input {
         Input::File(ref path) => {
+            if path.extension().is_some_and(|extension| extension == "rs") {
+                let mut err = sess
+                    .dcx()
+                    .struct_fatal("`-Zls` takes a `.rmeta` file as input, not a source file");
+                if rustc_session::utils::was_invoked_from_cargo() {
+                    // Give a Cargo-tailored suggestion if we're coming from Cargo
+                    err.note("use `rustc +nightly -Zls=... path/to/file.rmeta` directly, instead of going through Cargo");
+                }
+                err.emit();
+            }
             let mut v = Vec::new();
             locator::list_file_metadata(
                 &sess.target,

--- a/compiler/rustc_driver_impl/src/lib.rs
+++ b/compiler/rustc_driver_impl/src/lib.rs
@@ -606,7 +606,6 @@ fn list_metadata(sess: &Session, metadata_loader: &dyn MetadataLoader) {
                 &sess.opts.unstable_opts.ls,
                 sess.cfg_version,
             ) {
-                // If the panic comes from the input being the wrong file, direct the user to .rmeta files
                 if path.extension().is_some_and(|extension| extension == "rs") {
                     let mut err = sess
                         .dcx()
@@ -617,9 +616,7 @@ fn list_metadata(sess: &Session, metadata_loader: &dyn MetadataLoader) {
                     }
                     err.emit();
                 }
-
-                // Else, just panic (This shouldn't be reached);
-                panic!("{error}");
+                sess.dcx().fatal(error.to_string());
             }
             safe_println!("{}", String::from_utf8(v).unwrap());
         }

--- a/compiler/rustc_driver_impl/src/lib.rs
+++ b/compiler/rustc_driver_impl/src/lib.rs
@@ -597,7 +597,18 @@ fn process_rlink(sess: &Session, compiler: &interface::Compiler) {
 fn list_metadata(sess: &Session, metadata_loader: &dyn MetadataLoader) {
     match sess.io.input {
         Input::File(ref path) => {
-            if path.extension().is_some_and(|extension| extension == "rs") {
+            let mut v = Vec::new();
+            if locator::list_file_metadata(
+                &sess.target,
+                path,
+                metadata_loader,
+                &mut v,
+                &sess.opts.unstable_opts.ls,
+                sess.cfg_version,
+            )
+            .is_err()
+                && path.extension().is_some_and(|extension| extension == "rs")
+            {
                 let mut err = sess
                     .dcx()
                     .struct_fatal("`-Zls` takes a `.rmeta` file as input, not a source file");
@@ -607,16 +618,6 @@ fn list_metadata(sess: &Session, metadata_loader: &dyn MetadataLoader) {
                 }
                 err.emit();
             }
-            let mut v = Vec::new();
-            locator::list_file_metadata(
-                &sess.target,
-                path,
-                metadata_loader,
-                &mut v,
-                &sess.opts.unstable_opts.ls,
-                sess.cfg_version,
-            )
-            .unwrap();
             safe_println!("{}", String::from_utf8(v).unwrap());
         }
         Input::Str { .. } => {

--- a/compiler/rustc_metadata/src/locator.rs
+++ b/compiler/rustc_metadata/src/locator.rs
@@ -213,7 +213,7 @@
 //! metadata::locator or metadata::creader for all the juicy details!
 
 use std::borrow::Cow;
-use std::io::{self, Result as IoResult, Write};
+use std::io::{self, Error as IoError, ErrorKind as IoErrorKind, Result as IoResult, Write};
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::{cmp, fmt};
@@ -963,7 +963,10 @@ pub fn list_file_metadata(
     let flavor = get_flavor_from_path(path);
     match get_metadata_section(target, flavor, path, metadata_loader, cfg_version, None) {
         Ok(metadata) => metadata.list_crate_metadata(out, ls_kinds),
-        Err(msg) => write!(out, "{msg}\n"),
+        Err(msg) => {
+            let _ = write!(out, "{msg}");
+            Err(IoError::new(IoErrorKind::Other, msg.to_string()))
+        }
     }
 }
 

--- a/compiler/rustc_metadata/src/locator.rs
+++ b/compiler/rustc_metadata/src/locator.rs
@@ -963,10 +963,7 @@ pub fn list_file_metadata(
     let flavor = get_flavor_from_path(path);
     match get_metadata_section(target, flavor, path, metadata_loader, cfg_version, None) {
         Ok(metadata) => metadata.list_crate_metadata(out, ls_kinds),
-        Err(msg) => {
-            let _ = write!(out, "{msg}");
-            Err(IoError::new(IoErrorKind::Other, msg.to_string()))
-        }
+        Err(msg) => Err(IoError::new(IoErrorKind::Other, msg.to_string())),
     }
 }
 

--- a/src/doc/unstable-book/src/compiler-flags/ls.md
+++ b/src/doc/unstable-book/src/compiler-flags/ls.md
@@ -12,7 +12,7 @@ Allowed values are:
 
 - `root`: Crate info.
 - `lang_items`: Language items used and missing, if any.
-- `features`: Library features used.
+- `features`: Library features defined via the `#[stable]` and `#[unstable]` internal attributes.
 - `items`: All items (such as modules, functions...) in the crate, including attributes like their visibility
 - `all`: All of the above
 

--- a/src/doc/unstable-book/src/compiler-flags/ls.md
+++ b/src/doc/unstable-book/src/compiler-flags/ls.md
@@ -1,0 +1,17 @@
+# `ls`
+
+---
+
+Option `-Zls` instructs the compiler to list all metadata from a given metadata file (i.e. files with the `.rmeta` extension).
+
+This allows for debugging the metadata emitted by an earlier compilation.
+
+Note that, while `rustc` usually works with `.rs` files, this option is meant purely for analyzing `.rmeta` files, and does not produce any compilation artifact.
+
+## Example
+
+```sh
+rustc +nightly -Zls=all target/debug/deps/libmy_crate-*.rmeta
+```
+
+This lists to stdout all metadata from the given `.rmeta` file

--- a/src/doc/unstable-book/src/compiler-flags/ls.md
+++ b/src/doc/unstable-book/src/compiler-flags/ls.md
@@ -8,6 +8,14 @@ This allows for debugging the metadata emitted by an earlier compilation.
 
 Note that, while `rustc` usually works with `.rs` files, this option is meant purely for analyzing `.rmeta` files, and does not produce any compilation artifact.
 
+Allowed values are:
+
+- `root`: Crate info.
+- `lang_items`: Language items used and missing, if any.
+- `features`: Library features used.
+- `items`: All items (such as modules, functions...) in the crate, including attributes like their visibility
+- `all`: All of the above
+
 ## Example
 
 ```sh

--- a/tests/run-make/ls-metadata/rmake.rs
+++ b/tests/run-make/ls-metadata/rmake.rs
@@ -10,7 +10,7 @@ use run_make_support::{rfs, rustc};
 
 fn main() {
     rustc().input("foo.rs").run();
-    rustc().arg("-Zls=root").input("foo").run();
+    rustc().arg("-Zls=root").input("foo").run_fail();
     rfs::create_file("bar");
-    rustc().arg("-Zls=root").input("bar").run();
+    rustc().arg("-Zls=root").input("bar").run_fail();
 }


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/158859)*
<!-- homu-ignore:end -->

Refer the user to use `rustc -Zls` on `.rmeta` files instead of `.rs` files. And if they're using cargo, warn them to use rustc directly.

> [!IMPORTANT]
> First few comments in this pull request refer to changing the flag itself to work on source files. This was instead overruled to warn the user about executing on `.rmeta` files instead of `.rs` files.

<details><summary>Old description</summary>
<p>
This unstable option has been broken since forever (more than 2.5 years,
at least), but it's exactly what I need for debugging the new
incremental system, so rather than removing it I opted for fixing it.

The issue was that we were feeding the source file like, `src/lib.rs` instead of the `.rmeta` file. So literally every use of `-Zls=..` was returning  `invalid metadata version found: ..`

This PR also includes some testing.

Relevant for https://github.com/rust-lang/rust-project-goals/issues/641.

</p>
</details> 