### PR TITLE
Fix the span for parameter suggestion 

### DIFF
--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -3410,6 +3410,7 @@ impl<'a> Parser<'a> {
                 let (pat, colon) = this.parse_fn_param_pat_colon()?;
                 if !colon {
                     let mut err = this.unexpected().unwrap_err();
+                    let pat_span = pat.span;
                     return if let Some(ident) = this.parameter_without_type(
                         &mut err,
                         pat,
@@ -3418,7 +3419,9 @@ impl<'a> Parser<'a> {
                         fn_parse_mode,
                     ) {
                         let guar = err.emit();
-                        Ok((dummy_arg(ident, guar), Trailing::No, UsePreAttrPos::No))
+                        let mut arg = dummy_arg(ident, guar);
+                        arg.span = pat_span;
+                        Ok((arg, Trailing::No, UsePreAttrPos::No))
                     } else {
                         Err(err)
                     };

--- a/tests/ui/suggestions/suggest-add-self-issue-131084.rs
+++ b/tests/ui/suggestions/suggest-add-self-issue-131084.rs
@@ -11,6 +11,18 @@ impl SomeStruct {
         self
         //~^ ERROR expected value, found module `self`
     }
+
+    fn mut_param(mut some_name) {
+        //~^ ERROR expected one of `:`, `@`, or `|`, found `)`
+        self
+        //~^ ERROR expected value, found module `self`
+    }
+
+    fn type_before_name(String s) {
+        //~^ ERROR expected one of `:`, `@`, or `|`, found `s`
+        self
+        //~^ ERROR expected value, found module `self`
+    }
 }
 
 fn main() {}

--- a/tests/ui/suggestions/suggest-add-self-issue-131084.rs
+++ b/tests/ui/suggestions/suggest-add-self-issue-131084.rs
@@ -1,0 +1,16 @@
+//@ check-fail
+
+// A recovered `&param` should not make the missing-`self` suggestion insert
+// the receiver after the leading `&`.
+
+struct SomeStruct;
+
+impl SomeStruct {
+    fn some_fn(&some_name) {
+        //~^ ERROR expected one of `:`, `@`, or `|`, found `)`
+        self
+        //~^ ERROR expected value, found module `self`
+    }
+}
+
+fn main() {}

--- a/tests/ui/suggestions/suggest-add-self-issue-131084.stderr
+++ b/tests/ui/suggestions/suggest-add-self-issue-131084.stderr
@@ -18,6 +18,34 @@ help: if this is a type, explicitly ignore the parameter name
 LL |     fn some_fn(_: &some_name) {
    |                ++
 
+error: expected one of `:`, `@`, or `|`, found `)`
+  --> $DIR/suggest-add-self-issue-131084.rs:15:31
+   |
+LL |     fn mut_param(mut some_name) {
+   |                               ^ expected one of `:`, `@`, or `|`
+   |
+help: if this is a `self` type, give it a parameter name
+   |
+LL |     fn mut_param(self: mut some_name) {
+   |                  +++++
+help: if this is a parameter name, give it a type
+   |
+LL |     fn mut_param(mut some_name: TypeName) {
+   |                               ++++++++++
+help: if this is a type, explicitly ignore the parameter name
+   |
+LL |     fn mut_param(_: mut some_name) {
+   |                  ++
+
+error: expected one of `:`, `@`, or `|`, found `s`
+  --> $DIR/suggest-add-self-issue-131084.rs:21:32
+   |
+LL |     fn type_before_name(String s) {
+   |                         -------^
+   |                         |      |
+   |                         |      expected one of `:`, `@`, or `|`
+   |                         help: declare the type after the parameter binding: `<identifier>: <type>`
+
 error[E0424]: expected value, found module `self`
   --> $DIR/suggest-add-self-issue-131084.rs:11:9
    |
@@ -32,6 +60,34 @@ help: add a `self` receiver parameter to make the associated `fn` a method
 LL |     fn some_fn(&self, &some_name) {
    |                ++++++
 
-error: aborting due to 2 previous errors
+error[E0424]: expected value, found module `self`
+  --> $DIR/suggest-add-self-issue-131084.rs:17:9
+   |
+LL |     fn mut_param(mut some_name) {
+   |        --------- this function doesn't have a `self` parameter
+LL |
+LL |         self
+   |         ^^^^ `self` value is a keyword only available in methods with a `self` parameter
+   |
+help: add a `self` receiver parameter to make the associated `fn` a method
+   |
+LL |     fn mut_param(&self, mut some_name) {
+   |                  ++++++
+
+error[E0424]: expected value, found module `self`
+  --> $DIR/suggest-add-self-issue-131084.rs:23:9
+   |
+LL |     fn type_before_name(String s) {
+   |        ---------------- this function doesn't have a `self` parameter
+LL |
+LL |         self
+   |         ^^^^ `self` value is a keyword only available in methods with a `self` parameter
+   |
+help: add a `self` receiver parameter to make the associated `fn` a method
+   |
+LL |     fn type_before_name(&self, String s) {
+   |                         ++++++
+
+error: aborting due to 6 previous errors
 
 For more information about this error, try `rustc --explain E0424`.

--- a/tests/ui/suggestions/suggest-add-self-issue-131084.stderr
+++ b/tests/ui/suggestions/suggest-add-self-issue-131084.stderr
@@ -29,8 +29,8 @@ LL |         self
    |
 help: add a `self` receiver parameter to make the associated `fn` a method
    |
-LL |     fn some_fn(&&self, some_name) {
-   |                 ++++++
+LL |     fn some_fn(&self, &some_name) {
+   |                ++++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/suggestions/suggest-add-self-issue-131084.stderr
+++ b/tests/ui/suggestions/suggest-add-self-issue-131084.stderr
@@ -1,0 +1,37 @@
+error: expected one of `:`, `@`, or `|`, found `)`
+  --> $DIR/suggest-add-self-issue-131084.rs:9:26
+   |
+LL |     fn some_fn(&some_name) {
+   |                          ^ expected one of `:`, `@`, or `|`
+   |
+help: if this is a `self` type, give it a parameter name
+   |
+LL |     fn some_fn(self: &some_name) {
+   |                +++++
+help: if this is a parameter name, give it a type
+   |
+LL -     fn some_fn(&some_name) {
+LL +     fn some_fn(some_name: &TypeName) {
+   |
+help: if this is a type, explicitly ignore the parameter name
+   |
+LL |     fn some_fn(_: &some_name) {
+   |                ++
+
+error[E0424]: expected value, found module `self`
+  --> $DIR/suggest-add-self-issue-131084.rs:11:9
+   |
+LL |     fn some_fn(&some_name) {
+   |        ------- this function doesn't have a `self` parameter
+LL |
+LL |         self
+   |         ^^^^ `self` value is a keyword only available in methods with a `self` parameter
+   |
+help: add a `self` receiver parameter to make the associated `fn` a method
+   |
+LL |     fn some_fn(&&self, some_name) {
+   |                 ++++++
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0424`.


### PR DESCRIPTION
Fixes rust-lang/rust#131084 

Previously, the recovered parameter span could point only at the inner identifier, so the suggestion was inserted after the leading `&`, produced a werid `&&self`.

The fix keeps the recovered parameter's full span on `Param.span`


r? @nnethercote 

the second commit shows the diff of stderr.