### PR TITLE
Emit llvm dereferenceable in more cases on newer LLVM versions

### DIFF
--- a/compiler/rustc_codegen_llvm/src/abi.rs
+++ b/compiler/rustc_codegen_llvm/src/abi.rs
@@ -79,9 +79,11 @@ fn get_attrs<'ll>(this: &ArgAttributes, cx: &CodegenCx<'ll, '_>) -> SmallVec<[&'
     // Only apply remaining attributes when optimizing
     if cx.sess().opts.optimize != config::OptLevel::No {
         let deref = this.pointee_size.bytes();
-        // dereferenceable in LLVM currently implies nofree, so only emit dereferenceable if nofree
+        // Prior to <https://github.com/llvm/llvm-project/pull/204795> dereferenceable in LLVM
+        // implied nofree, so only emit dereferenceable on older versions of LLVM if nofree
         // is also set.
-        if deref != 0 && regular.contains(ArgAttribute::NoFree) {
+        let llvm_version = crate::llvm_util::get_version();
+        if deref != 0 && (llvm_version >= (23, 0, 0) || regular.contains(ArgAttribute::NoFree)) {
             if regular.contains(ArgAttribute::NonNull) {
                 attrs.push(llvm::CreateDereferenceableAttr(cx.llcx, deref));
             } else {

--- a/tests/codegen-llvm/drop-in-place-noalias.rs
+++ b/tests/codegen-llvm/drop-in-place-noalias.rs
@@ -1,4 +1,10 @@
 //@ compile-flags: -Copt-level=3 -C no-prepopulate-passes
+//
+// LLVM23 changed the meanign of "dereferenceable", allowing us to apply it in more cases,
+// see <https://github.com/rust-lang/rust/pull/158863>.
+//@ revisions: LLVM22 LLVM23
+//@ [LLVM22] max-llvm-major-version: 22
+//@ [LLVM23] min-llvm-version: 23
 
 // Tests that the compiler can apply `noalias` and other &mut attributes to `drop_in_place`.
 // Note that non-Unpin types should not get `noalias`, matching &mut behavior.
@@ -9,7 +15,8 @@ use std::marker::PhantomPinned;
 
 // CHECK: define internal void @{{.*}}core{{.*}}ptr{{.*}}drop_in_place{{.*}}StructUnpin{{.*}}(ptr noalias nofree noundef align 4 dereferenceable(12) %{{.+}})
 
-// CHECK: define internal void @{{.*}}core{{.*}}ptr{{.*}}drop_in_place{{.*}}StructNotUnpin{{.*}}(ptr noundef nonnull align 4 %{{.+}})
+// LLVM22: define internal void @{{.*}}core{{.*}}ptr{{.*}}drop_in_place{{.*}}StructNotUnpin{{.*}}(ptr noundef nonnull align 4 %{{.+}})
+// LLVM23: define internal void @{{.*}}core{{.*}}ptr{{.*}}drop_in_place{{.*}}StructNotUnpin{{.*}}(ptr noundef align 4 dereferenceable(12) %{{.+}})
 
 pub struct StructUnpin {
     a: i32,

--- a/tests/codegen-llvm/function-arguments.rs
+++ b/tests/codegen-llvm/function-arguments.rs
@@ -1,4 +1,11 @@
 //@ compile-flags: -Copt-level=3 -C no-prepopulate-passes
+//
+// LLVM23 changed the meanign of "dereferenceable", allowing us to apply it in more cases,
+// see <https://github.com/rust-lang/rust/pull/158863>.
+//@ revisions: LLVM22 LLVM23
+//@ [LLVM22] max-llvm-major-version: 22
+//@ [LLVM23] min-llvm-version: 23
+
 #![crate_type = "lib"]
 #![feature(rustc_attrs)]
 #![feature(allocator_api, unsafe_unpin)]
@@ -84,13 +91,15 @@ pub fn option_nonzero_int(x: Option<NonZero<u64>>) -> Option<NonZero<u64>> {
 #[no_mangle]
 pub fn readonly_borrow(_: &i32) {}
 
-// CHECK: noundef nonnull align 4 ptr @readonly_borrow_ret()
+// LLVM22: noundef nonnull align 4 ptr @readonly_borrow_ret()
+// LLVM23: noundef align 4 dereferenceable(4) ptr @readonly_borrow_ret()
 #[no_mangle]
 pub fn readonly_borrow_ret() -> &'static i32 {
     loop {}
 }
 
-// CHECK: @unsafe_borrow(ptr noundef nonnull align 2 %_1)
+// LLVM22: @unsafe_borrow(ptr noundef nonnull align 2 %_1)
+// LLVM23: @unsafe_borrow(ptr noundef align 2 dereferenceable(2) %_1)
 // unsafe interior means this isn't actually readonly and there may be aliases ...
 #[no_mangle]
 pub fn unsafe_borrow(_: &UnsafeInner) {}
@@ -104,16 +113,18 @@ pub fn mutable_unsafe_borrow(_: &mut UnsafeInner) {}
 #[no_mangle]
 pub fn mutable_borrow(_: &mut i32) {}
 
-// CHECK: noundef nonnull align 4 ptr @mutable_borrow_ret()
+// LLVM22: noundef nonnull align 4 ptr @mutable_borrow_ret()
+// LLVM23: noundef align 4 dereferenceable(4) ptr @mutable_borrow_ret()
 #[no_mangle]
 pub fn mutable_borrow_ret() -> &'static mut i32 {
     loop {}
 }
 
 #[no_mangle]
-// CHECK: @mutable_notunpin_borrow(ptr noundef nonnull align 4 %_1)
+// LLVM22: @mutable_notunpin_borrow(ptr noundef nonnull align 4 %_1)
+// LLVM23: @mutable_notunpin_borrow(ptr noundef align 4 dereferenceable(4) %_1)
 // This one is *not* `noalias` because it might be self-referential.
-// It is also not `dereferenceable` due to
+// It is also not `dereferenceable` prior to LLVM23 due to
 // <https://github.com/rust-lang/unsafe-code-guidelines/issues/381>.
 pub fn mutable_notunpin_borrow(_: &mut NotUnpin) {}
 
@@ -147,8 +158,9 @@ pub fn raw_struct(_: *const S) {}
 pub fn raw_option_nonnull_struct(_: Option<NonNull<S>>) {}
 
 // `Box` can get deallocated during execution of the function, so it should
-// not get `dereferenceable`.
-// CHECK: noundef nonnull align 4 ptr @_box(ptr noalias noundef nonnull align 4 %x)
+// not get `nofree` (or `dereferenceable` prior to LLVM23).
+// LLVM22: noundef nonnull align 4 ptr @_box(ptr noalias noundef nonnull align 4 %x)
+// LLVM23: noundef align 4 dereferenceable(4) ptr @_box(ptr noalias noundef align 4 dereferenceable(4) %x)
 #[no_mangle]
 pub fn _box(x: Box<i32>) -> Box<i32> {
     x
@@ -157,13 +169,15 @@ pub fn _box(x: Box<i32>) -> Box<i32> {
 // With a custom allocator, it should *not* have `noalias`. (See
 // <https://github.com/rust-lang/miri/issues/3341> for why.) The second argument is the allocator,
 // which is a reference here that still carries `noalias` as usual.
-// CHECK: @_box_custom(ptr noundef nonnull align 4 %x.0, ptr noalias nofree noundef nonnull readonly{{( captures\(address, read_provenance\))?}} %x.1)
+// LLVM22: @_box_custom(ptr noundef nonnull align 4 %x.0, ptr noalias nofree noundef nonnull readonly{{( captures\(address, read_provenance\))?}} %x.1)
+// LLVM23: @_box_custom(ptr noundef align 4 dereferenceable(4) %x.0, ptr noalias nofree noundef nonnull readonly{{( captures\(address, read_provenance\))?}} %x.1)
 #[no_mangle]
 pub fn _box_custom(x: Box<i32, &std::alloc::Global>) {
     drop(x)
 }
 
-// CHECK: noundef nonnull align 4 ptr @notunpin_box(ptr noundef nonnull align 4 %x)
+// LLVM22: noundef nonnull align 4 ptr @notunpin_box(ptr noundef nonnull align 4 %x)
+// LLVM23: noundef align 4 dereferenceable(4) ptr @notunpin_box(ptr noundef align 4 dereferenceable(4) %x)
 #[no_mangle]
 pub fn notunpin_box(x: Box<NotUnpin>) -> Box<NotUnpin> {
     x
@@ -238,14 +252,16 @@ pub fn trait_box_pin1(_: Box<dyn Drop + Unpin>) {}
 pub fn trait_box_pin2(_: Box<dyn Drop + UnsafeUnpin>) {}
 
 // Same for mutable references (with a non-zero minimal size so that we also see the
-// `dereferenceable` disappear).
+// `dereferenceable` disappear prior to llvm23).
 // CHECK: @trait_mutref(ptr noalias nofree noundef align 4 dereferenceable(4){{( %_1.0)?}}, {{.+}} noalias nofree noundef readonly align {{.*}} dereferenceable({{.*}}){{( %_1.1)?}})
 #[no_mangle]
 pub fn trait_mutref(_: &mut (i32, dyn Drop + Unpin + UnsafeUnpin)) {}
-// CHECK: @trait_mutref_pin1(ptr noundef nonnull align 4{{( %_1.0)?}}, {{.+}} noalias nofree noundef readonly align {{.*}} dereferenceable({{.*}}){{( %_1.1)?}})
+// LLVM22: @trait_mutref_pin1(ptr noundef nonnull align 4{{( %_1.0)?}}, {{.+}} noalias nofree noundef readonly align {{.*}} dereferenceable({{.*}}){{( %_1.1)?}})
+// LLVM23: @trait_mutref_pin1(ptr noundef align 4 dereferenceable(4){{( %_1.0)?}}, {{.+}} noalias nofree noundef readonly align {{.*}} dereferenceable({{.*}}){{( %_1.1)?}})
 #[no_mangle]
 pub fn trait_mutref_pin1(_: &mut (i32, dyn Drop + Unpin)) {}
-// CHECK: @trait_mutref_pin2(ptr noundef nonnull align 4{{( %_1.0)?}}, {{.+}} noalias nofree noundef readonly align {{.*}} dereferenceable({{.*}}){{( %_1.1)?}})
+// LLVM22: @trait_mutref_pin2(ptr noundef nonnull align 4{{( %_1.0)?}}, {{.+}} noalias nofree noundef readonly align {{.*}} dereferenceable({{.*}}){{( %_1.1)?}})
+// LLVM23: @trait_mutref_pin2(ptr noundef align 4 dereferenceable(4){{( %_1.0)?}}, {{.+}} noalias nofree noundef readonly align {{.*}} dereferenceable({{.*}}){{( %_1.1)?}})
 #[no_mangle]
 pub fn trait_mutref_pin2(_: &mut (i32, dyn Drop + UnsafeUnpin)) {}
 

--- a/tests/codegen-llvm/llvm-writable.rs
+++ b/tests/codegen-llvm/llvm-writable.rs
@@ -1,6 +1,13 @@
 //! The tests here test that the `-Zllvm-writable` flag and
 //! the `#[rustc_no_writable]` attribute have the desired effect.
+//
 //@ compile-flags: -Copt-level=3 -C no-prepopulate-passes -Zllvm-writable
+//
+// LLVM23 changed the meanign of "dereferenceable", allowing us to apply it in more cases,
+// see <https://github.com/rust-lang/rust/pull/158863>.
+//@ revisions: LLVM22 LLVM23
+//@ [LLVM22] max-llvm-major-version: 22
+//@ [LLVM23] min-llvm-version: 23
 #![crate_type = "lib"]
 #![feature(rustc_attrs, unsafe_pinned)]
 
@@ -16,11 +23,13 @@ pub fn mutable_unsafe_borrow(_: &mut std::cell::UnsafeCell<i16>) {}
 #[no_mangle]
 pub fn option_borrow_mut(_: Option<&mut i32>) {}
 
-// CHECK: @box_moved(ptr noalias noundef nonnull align 4 %0)
+// LLVM22: @box_moved(ptr noalias noundef nonnull align 4 %0)
+// LLVM23: @box_moved(ptr noalias noundef align 4 dereferenceable(4) %0)
 #[no_mangle]
 pub fn box_moved(_: Box<i32>) {}
 
-// CHECK: @unsafe_pinned_borrow_mut(ptr noundef nonnull align 4 %_1)
+// LLVM22: @unsafe_pinned_borrow_mut(ptr noundef nonnull align 4 %_1)
+// LLVM23: @unsafe_pinned_borrow_mut(ptr noundef align 4 dereferenceable(4) %_1)
 #[no_mangle]
 pub fn unsafe_pinned_borrow_mut(_: &mut std::pin::UnsafePinned<i32>) {}
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/158863)*
<!-- homu-ignore:end -->

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

On llvm >= 23 emit `dereferenceable` even without `nofree`, since https://github.com/llvm/llvm-project/pull/204795 makes `dereferenceable` act "at a point" / not imply `nofree`.

r? nikic

I thought this will be a bit harder change, but since your refactoring in rust-lang/rust#156281 it's actually trivial ^^'

Draft because I don't think this can be tested prior to LLVM update. I'm also not sure if the version check I did is the appropriate one...

cc @RalfJung 