### PR TITLE
[perf] Specialize common `(1, 1)` case for arg unification.

### DIFF
--- a/compiler/rustc_type_ir/src/fast_reject.rs
+++ b/compiler/rustc_type_ir/src/fast_reject.rs
@@ -233,7 +233,7 @@ impl<I: Interner, const INSTANTIATE_LHS_WITH_INFER: bool, const INSTANTIATE_RHS_
         // No need to decrement the depth here as this function is only
         // recursively reachable via `types_may_unify_inner` which already
         // increments the depth for us.
-        iter::zip(obligation_args.iter(), impl_args.iter()).all(|(obl, imp)| {
+        let may_unify = |(obl, imp): (I::GenericArg, I::GenericArg)| {
             match (obl.kind(), imp.kind()) {
                 // We don't fast reject based on regions.
                 (ty::GenericArgKind::Lifetime(_), ty::GenericArgKind::Lifetime(_)) => true,
@@ -245,7 +245,14 @@ impl<I: Interner, const INSTANTIATE_LHS_WITH_INFER: bool, const INSTANTIATE_RHS_
                 }
                 _ => panic!("kind mismatch: {obl:?} {imp:?}"),
             }
-        })
+        };
+
+        // Specialize the common `(1, 1)` case to avoid iterator machinery.
+        if let ([obl], [imp]) = (obligation_args.as_slice(), impl_args.as_slice()) {
+            return may_unify((*obl, *imp));
+        }
+
+        iter::zip(obligation_args.iter(), impl_args.iter()).all(may_unify)
     }
 
     fn types_may_unify_inner(self, lhs: I::Ty, rhs: I::Ty, depth: usize) -> bool {


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/158865)*
<!-- homu-ignore:end -->

While `DeepRejectCtxt::args_may_unify_inner` might be called with different numbers of obligation and impl args, the `(1, 1)` length case is very common: single-generic-param ADTs, trait references whose only generic is `Self`, etc.

Offer a fast path for that simple case, so that we avoid invoking `iter::zip(...).all(predicate)` iterator machinery given that it isn't necessary there.

We considered, and ultimately rejected, adding a separate specialization for the `(0, 0)` case since benchmarks indicated it wasn't cost-effective.

r? @oli-obk

**AI disclosure:** The optimization opportunity here was discovered as part of a systematic probe for missed optimizations utilizing both traditional and AI tools. The code here was initially prototyped and vetted by AI tools, followed by additional manual work. I secured approval in advance from the designated reviewer. I stand behind the quality of the code I'm submitting, and I vouch it's as good or better compared to if I had written every line by my own hand.