### PR TITLE
borrowck: Keep returned `path` from `best_blame_constraint()` consistent

### DIFF
--- a/compiler/rustc_borrowck/src/region_infer/mod.rs
+++ b/compiler/rustc_borrowck/src/region_infer/mod.rs
@@ -1630,7 +1630,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
         });
 
         // Edge case: it's possible that `'from_region` is an unnameable placeholder.
-        let path = if let Some(unnameable) = due_to_placeholder_outlives
+        let mut path = if let Some(unnameable) = due_to_placeholder_outlives
             && unnameable != from_region
         {
             // We ignore the extra edges due to unnameable placeholders to get
@@ -1799,10 +1799,9 @@ impl<'tcx> RegionInferenceContext<'tcx> {
                 if let ConstraintCategory::ClosureUpvar(f) = p.category { Some(f) } else { None }
             })
         {
-            OutlivesConstraint {
-                category: ConstraintCategory::Return(ReturnConstraint::ClosureUpvar(field)),
-                ..path[best_choice]
-            }
+            path[best_choice].category =
+                ConstraintCategory::Return(ReturnConstraint::ClosureUpvar(field));
+            path[best_choice]
         } else {
             path[best_choice]
         };


### PR DESCRIPTION
The function `fn best_blame_constraint()` returns a `Vec<OutlivesConstraint>` and a `BlameConstraint`. The `BlameConstraint` is really just a slimmed down version of an `OutlivesConstraint`. So we can remove `BlameConstraint` entirely and instead return `Vec<OutlivesConstraint>` and an index into that `Vec`. (Encapsulated in a struct for nice ergonomics.)

To prepare for that, change the code to adjust `Vec<OutlivesConstraint>` in-place and return info about the adjusted element, rather than returning info for a newly created "fake" `OutlivesConstraint`.

It is slightly sad that we make `path` `mut`, but I think we can live with that. Diagnostics tests will surely catch if someone messes up because of that.

This takes us one step closer (this is commit 2 of 4) towards the end result illustrated in https://github.com/rust-lang/rust/pull/158623.

