### PR TITLE
borrowck: Inline `free_region_constraint_info()` to simplify the code

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/explain_borrow.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/explain_borrow.rs
@@ -12,7 +12,7 @@ use rustc_middle::mir::{
     Operand, Place, Rvalue, Statement, StatementKind, TerminatorKind,
 };
 use rustc_middle::ty::adjustment::PointerCoercion;
-use rustc_middle::ty::{self, RegionVid, Ty, TyCtxt};
+use rustc_middle::ty::{self, Ty, TyCtxt};
 use rustc_span::{DesugaringKind, Span, kw, sym};
 use rustc_trait_selection::error_reporting::traits::FindExprBySpan;
 use rustc_trait_selection::error_reporting::traits::call_kind::CallKind;
@@ -574,24 +574,6 @@ fn suggest_rewrite_if_let<G: EmissionGuarantee>(
 }
 
 impl<'tcx> MirBorrowckCtxt<'_, '_, 'tcx> {
-    fn free_region_constraint_info(
-        &self,
-        borrow_region: RegionVid,
-        outlived_region: RegionVid,
-    ) -> (ConstraintCategory<'tcx>, bool, Span, Option<RegionName>, Vec<OutlivesConstraint<'tcx>>)
-    {
-        let (blame_constraint, path) = self.regioncx.best_blame_constraint(
-            borrow_region,
-            NllRegionVariableOrigin::FreeRegion,
-            outlived_region,
-        );
-        let BlameConstraint { category, from_closure, span, .. } = blame_constraint;
-
-        let outlived_fr_name = self.give_region_a_name(outlived_region);
-
-        (category, from_closure, span, outlived_fr_name, path)
-    }
-
     /// Returns structured explanation for *why* the borrow contains the
     /// point from `location`. This is key for the "3-point errors"
     /// [described in the NLL RFC][d].
@@ -707,9 +689,14 @@ impl<'tcx> MirBorrowckCtxt<'_, '_, 'tcx> {
                 // Here, under NLL: no cause was found. Under polonius: no cause was found, or a
                 // boring local was found, which we ignore like NLLs do to match its diagnostics.
                 if let Some(region) = self.regioncx.to_error_region_vid(borrow_region_vid) {
-                    let (category, from_closure, span, region_name, path) =
-                        self.free_region_constraint_info(borrow_region_vid, region);
-                    if let Some(region_name) = region_name {
+                    let (blame_constraint, path) = self.regioncx.best_blame_constraint(
+                        borrow_region_vid,
+                        NllRegionVariableOrigin::FreeRegion,
+                        region,
+                    );
+                    let BlameConstraint { category, from_closure, span, .. } = blame_constraint;
+
+                    if let Some(region_name) = self.give_region_a_name(region) {
                         let opt_place_desc = self.describe_place(borrow.borrowed_place.as_ref());
                         BorrowExplanation::MustBeValidFor {
                             category,


### PR DESCRIPTION
For reference, the helper function was introduced in 2a3969a3f7077. But, the code becomes simpler if we remove the helper function, so let's remove it.

This takes us one step closer (this is commit 3 of 4) towards the end result illustrated in https://github.com/rust-lang/rust/pull/158623.
