### PR TITLE
enable `do_not_recommend` attr for method call errors in current solver

### DIFF
--- a/compiler/rustc_hir_typeck/src/method/probe.rs
+++ b/compiler/rustc_hir_typeck/src/method/probe.rs
@@ -1880,7 +1880,7 @@ impl<'tcx> Pick<'tcx> {
 }
 
 impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
-    fn select_trait_candidate(
+    fn select_trait_candidate_for_diagnostics(
         &self,
         trait_ref: ty::TraitRef<'tcx>,
     ) -> traits::SelectionResult<'tcx, traits::Selection<'tcx>> {
@@ -1920,7 +1920,7 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
                     xform_self_ty,
                     self_ty,
                 );
-                match self.select_trait_candidate(trait_ref) {
+                match self.select_trait_candidate_for_diagnostics(trait_ref) {
                     Ok(Some(traits::ImplSource::UserDefined(ref impl_data))) => {
                         // If only a single impl matches, make the error message point
                         // to that impl.
@@ -2089,7 +2089,9 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
                         ocx.register_obligation(obligation);
                     } else {
                         result = ProbeResult::NoMatch;
-                        if let Ok(Some(candidate)) = self.select_trait_candidate(trait_ref) {
+                        if let Ok(Some(candidate)) =
+                            self.select_trait_candidate_for_diagnostics(trait_ref)
+                        {
                             for nested_obligation in candidate.nested_obligations() {
                                 if !self.infcx.predicate_may_hold(&nested_obligation) {
                                     possibly_unsatisfied_predicates.push((

--- a/compiler/rustc_hir_typeck/src/method/probe.rs
+++ b/compiler/rustc_hir_typeck/src/method/probe.rs
@@ -1886,7 +1886,13 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
     ) -> traits::SelectionResult<'tcx, traits::Selection<'tcx>> {
         let obligation =
             traits::Obligation::new(self.tcx, self.misc(self.span), self.param_env, trait_ref);
-        traits::SelectionContext::new(self).select(&obligation)
+        let candidate = traits::SelectionContext::new(self).select(&obligation);
+        if let Ok(Some(traits::ImplSource::UserDefined(impl_source_user_defined_data))) = &candidate
+            && self.infcx.tcx.do_not_recommend_impl(impl_source_user_defined_data.impl_def_id)
+        {
+            return Err(traits::SelectionError::Unimplemented);
+        }
+        candidate
     }
 
     /// Used for ambiguous method call error reporting. Uses probing that throws away the result internally,

--- a/tests/ui/diagnostic_namespace/do_not_recommend/auxiliary/foreign_blanket_impl.rs
+++ b/tests/ui/diagnostic_namespace/do_not_recommend/auxiliary/foreign_blanket_impl.rs
@@ -1,0 +1,10 @@
+pub struct ForeignType<T>(pub T);
+
+pub trait DoNotMentionThis {}
+
+#[diagnostic::do_not_recommend]
+impl<T: DoNotMentionThis> Clone for ForeignType<T> {
+    fn clone(&self) -> Self {
+        todo!()
+    }
+}

--- a/tests/ui/diagnostic_namespace/do_not_recommend/method_call.current.stderr
+++ b/tests/ui/diagnostic_namespace/do_not_recommend/method_call.current.stderr
@@ -4,20 +4,11 @@ error[E0277]: the trait bound `ForeignType<u8>: Clone` is not satisfied
 LL |         let _ = Clone::clone(&f);
    |                              ^^ the trait `Clone` is not implemented for `ForeignType<u8>`
 
-error[E0599]: the method `clone` exists for struct `ForeignType<u8>`, but its trait bounds were not satisfied
+error[E0599]: no method named `clone` found for struct `ForeignType<T>` in the current scope
   --> $DIR/method_call.rs:24:19
    |
 LL |         let _ = f.clone();
-   |                   ^^^^^ method cannot be called on `ForeignType<u8>` due to unsatisfied trait bounds
-   |
-  ::: $DIR/auxiliary/foreign_blanket_impl.rs:1:1
-   |
-LL | pub struct ForeignType<T>(pub T);
-   | ------------------------- doesn't satisfy `ForeignType<u8>: Clone`
-   |
-   = note: the following trait bounds were not satisfied:
-           `u8: DoNotMentionThis`
-           which is required by `ForeignType<u8>: Clone`
+   |                   ^^^^^ method not found in `ForeignType<u8>`
 
 error[E0277]: the trait bound `LocalType<u8>: Clone` is not satisfied
   --> $DIR/method_call.rs:31:30
@@ -31,22 +22,15 @@ LL + #[derive(Clone)]
 LL | pub struct LocalType<T>(pub T);
    |
 
-error[E0599]: the method `clone` exists for struct `LocalType<u8>`, but its trait bounds were not satisfied
+error[E0599]: no method named `clone` found for struct `LocalType<T>` in the current scope
   --> $DIR/method_call.rs:34:19
    |
 LL | pub struct LocalType<T>(pub T);
-   | ----------------------- method `clone` not found for this struct because it doesn't satisfy `LocalType<u8>: Clone`
+   | ----------------------- method `clone` not found for this struct
 ...
 LL |         let _ = l.clone();
-   |                   ^^^^^ method cannot be called on `LocalType<u8>` due to unsatisfied trait bounds
+   |                   ^^^^^ method not found in `LocalType<u8>`
    |
-note: trait bound `u8: DoNotMentionThis` was not satisfied
-  --> $DIR/method_call.rs:12:9
-   |
-LL | impl<T: DoNotMentionThis> Clone for LocalType<T> {
-   |         ^^^^^^^^^^^^^^^^  -----     ------------
-   |         |
-   |         unsatisfied trait bound introduced here
    = help: items from traits can only be used if the trait is implemented and in scope
    = note: the following trait defines an item `clone`, perhaps you need to implement it:
            candidate #1: `Clone`

--- a/tests/ui/diagnostic_namespace/do_not_recommend/method_call.current.stderr
+++ b/tests/ui/diagnostic_namespace/do_not_recommend/method_call.current.stderr
@@ -1,0 +1,57 @@
+error[E0277]: the trait bound `ForeignType<u8>: Clone` is not satisfied
+  --> $DIR/method_call.rs:21:30
+   |
+LL |         let _ = Clone::clone(&f);
+   |                              ^^ the trait `Clone` is not implemented for `ForeignType<u8>`
+
+error[E0599]: the method `clone` exists for struct `ForeignType<u8>`, but its trait bounds were not satisfied
+  --> $DIR/method_call.rs:24:19
+   |
+LL |         let _ = f.clone();
+   |                   ^^^^^ method cannot be called on `ForeignType<u8>` due to unsatisfied trait bounds
+   |
+  ::: $DIR/auxiliary/foreign_blanket_impl.rs:1:1
+   |
+LL | pub struct ForeignType<T>(pub T);
+   | ------------------------- doesn't satisfy `ForeignType<u8>: Clone`
+   |
+   = note: the following trait bounds were not satisfied:
+           `u8: DoNotMentionThis`
+           which is required by `ForeignType<u8>: Clone`
+
+error[E0277]: the trait bound `LocalType<u8>: Clone` is not satisfied
+  --> $DIR/method_call.rs:31:30
+   |
+LL |         let _ = Clone::clone(&l);
+   |                              ^^ the trait `Clone` is not implemented for `LocalType<u8>`
+   |
+help: consider annotating `LocalType<u8>` with `#[derive(Clone)]`
+   |
+LL + #[derive(Clone)]
+LL | pub struct LocalType<T>(pub T);
+   |
+
+error[E0599]: the method `clone` exists for struct `LocalType<u8>`, but its trait bounds were not satisfied
+  --> $DIR/method_call.rs:34:19
+   |
+LL | pub struct LocalType<T>(pub T);
+   | ----------------------- method `clone` not found for this struct because it doesn't satisfy `LocalType<u8>: Clone`
+...
+LL |         let _ = l.clone();
+   |                   ^^^^^ method cannot be called on `LocalType<u8>` due to unsatisfied trait bounds
+   |
+note: trait bound `u8: DoNotMentionThis` was not satisfied
+  --> $DIR/method_call.rs:12:9
+   |
+LL | impl<T: DoNotMentionThis> Clone for LocalType<T> {
+   |         ^^^^^^^^^^^^^^^^  -----     ------------
+   |         |
+   |         unsatisfied trait bound introduced here
+   = help: items from traits can only be used if the trait is implemented and in scope
+   = note: the following trait defines an item `clone`, perhaps you need to implement it:
+           candidate #1: `Clone`
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0277, E0599.
+For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/diagnostic_namespace/do_not_recommend/method_call.next.stderr
+++ b/tests/ui/diagnostic_namespace/do_not_recommend/method_call.next.stderr
@@ -1,0 +1,45 @@
+error[E0277]: the trait bound `ForeignType<u8>: Clone` is not satisfied
+  --> $DIR/method_call.rs:21:30
+   |
+LL |         let _ = Clone::clone(&f);
+   |                 ------------ ^^ the trait `Clone` is not implemented for `ForeignType<u8>`
+   |                 |
+   |                 required by a bound introduced by this call
+
+error[E0599]: no method named `clone` found for struct `ForeignType<T>` in the current scope
+  --> $DIR/method_call.rs:24:19
+   |
+LL |         let _ = f.clone();
+   |                   ^^^^^ method not found in `ForeignType<u8>`
+
+error[E0277]: the trait bound `LocalType<u8>: Clone` is not satisfied
+  --> $DIR/method_call.rs:31:30
+   |
+LL |         let _ = Clone::clone(&l);
+   |                 ------------ ^^ the trait `Clone` is not implemented for `LocalType<u8>`
+   |                 |
+   |                 required by a bound introduced by this call
+   |
+help: consider annotating `LocalType<u8>` with `#[derive(Clone)]`
+   |
+LL + #[derive(Clone)]
+LL | pub struct LocalType<T>(pub T);
+   |
+
+error[E0599]: no method named `clone` found for struct `LocalType<T>` in the current scope
+  --> $DIR/method_call.rs:34:19
+   |
+LL | pub struct LocalType<T>(pub T);
+   | ----------------------- method `clone` not found for this struct
+...
+LL |         let _ = l.clone();
+   |                   ^^^^^ method not found in `LocalType<u8>`
+   |
+   = help: items from traits can only be used if the trait is implemented and in scope
+   = note: the following trait defines an item `clone`, perhaps you need to implement it:
+           candidate #1: `Clone`
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0277, E0599.
+For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/diagnostic_namespace/do_not_recommend/method_call.rs
+++ b/tests/ui/diagnostic_namespace/do_not_recommend/method_call.rs
@@ -1,0 +1,38 @@
+//@aux-build:foreign_blanket_impl.rs
+//@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@[next] compile-flags: -Znext-solver
+
+extern crate foreign_blanket_impl;
+use foreign_blanket_impl::{DoNotMentionThis, ForeignType};
+
+pub struct LocalType<T>(pub T);
+
+#[diagnostic::do_not_recommend]
+impl<T: DoNotMentionThis> Clone for LocalType<T> {
+    fn clone(&self) -> Self {
+        todo!()
+    }
+}
+
+fn main() {
+    {
+        let f = ForeignType(42_u8);
+        let _ = Clone::clone(&f);
+        //~^ERROR the trait bound `ForeignType<u8>: Clone` is not satisfied [E0277]
+
+        let _ = f.clone();
+        //[next]~^ERROR no method named `clone` found for struct `ForeignType<T>` in the current scope [E0599]
+        //[current]~^^ERROR the method `clone` exists for struct `ForeignType<u8>`, but its trait bounds were not satisfied [E0599]
+    }
+
+    {
+        let l = LocalType(42_u8);
+        let _ = Clone::clone(&l);
+        //~^ERROR the trait bound `LocalType<u8>: Clone` is not satisfied [E0277]
+
+        let _ = l.clone();
+        //[next]~^ERROR no method named `clone` found for struct `LocalType<T>` in the current scope [E0599]
+        //[current]~^^ERROR the method `clone` exists for struct `LocalType<u8>`, but its trait bounds were not satisfied [E0599]
+    }
+}

--- a/tests/ui/diagnostic_namespace/do_not_recommend/method_call.rs
+++ b/tests/ui/diagnostic_namespace/do_not_recommend/method_call.rs
@@ -2,7 +2,7 @@
 //@ revisions: current next
 //@ ignore-compare-mode-next-solver (explicit revisions)
 //@[next] compile-flags: -Znext-solver
-
+//@forbid-output: DoNotMentionThis
 extern crate foreign_blanket_impl;
 use foreign_blanket_impl::{DoNotMentionThis, ForeignType};
 
@@ -22,8 +22,8 @@ fn main() {
         //~^ERROR the trait bound `ForeignType<u8>: Clone` is not satisfied [E0277]
 
         let _ = f.clone();
-        //[next]~^ERROR no method named `clone` found for struct `ForeignType<T>` in the current scope [E0599]
-        //[current]~^^ERROR the method `clone` exists for struct `ForeignType<u8>`, but its trait bounds were not satisfied [E0599]
+        //~^ERROR no method named `clone` found for struct `ForeignType<T>` in the current scope [E0599]
+
     }
 
     {
@@ -32,7 +32,7 @@ fn main() {
         //~^ERROR the trait bound `LocalType<u8>: Clone` is not satisfied [E0277]
 
         let _ = l.clone();
-        //[next]~^ERROR no method named `clone` found for struct `LocalType<T>` in the current scope [E0599]
-        //[current]~^^ERROR the method `clone` exists for struct `LocalType<u8>`, but its trait bounds were not satisfied [E0599]
+        //~^ERROR no method named `clone` found for struct `LocalType<T>` in the current scope [E0599]
+        
     }
 }

--- a/tests/ui/diagnostic_namespace/do_not_recommend/method_call.rs
+++ b/tests/ui/diagnostic_namespace/do_not_recommend/method_call.rs
@@ -33,6 +33,6 @@ fn main() {
 
         let _ = l.clone();
         //~^ERROR no method named `clone` found for struct `LocalType<T>` in the current scope [E0599]
-        
+
     }
 }


### PR DESCRIPTION
This should help with https://github.com/rust-lang/rust/pull/146381#discussion_r2637232469

The logic is mostly copied from the `apply_do_not_recommend` function.

r? @khyperia :3