### PR TITLE
tests: catch up with LLVM returning f128 on the stack

### DIFF
--- a/tests/assembly-llvm/x86_64-windows-float-abi.rs
+++ b/tests/assembly-llvm/x86_64-windows-float-abi.rs
@@ -3,6 +3,9 @@
 //@ compile-flags: --target x86_64-pc-windows-msvc
 //@ needs-llvm-components: x86
 //@ add-minicore
+//@ revisions: LLVM22 LLVM23
+//@ [LLVM22] max-llvm-major-version: 22
+//@ [LLVM23] min-llvm-version: 23
 
 #![feature(f16, f128)]
 #![feature(no_core)]
@@ -37,8 +40,12 @@ pub extern "C" fn second_f64(_: f64, x: f64) -> f64 {
 }
 
 // CHECK-LABEL: second_f128
-// CHECK: movaps (%rdx), %xmm0
-// CHECK-NEXT: retq
+// LLVM22: movaps (%rdx), %xmm0
+// LLVM22-NEXT: retq
+// LLVM23: movq %rcx, %rax
+// LLVM23-NEXT: movaps (%r8), %xmm0
+// LLVM23-NEXT: movaps %xmm0, (%rcx)
+// LLVM23-NEXT: retq
 #[no_mangle]
 pub extern "C" fn second_f128(_: f128, x: f128) -> f128 {
     x


### PR DESCRIPTION
In LLVM 22 the x64 MSVC ABI wasn't matched and f128 was being directly returned in %xmm0, but now it correctly returns the value via a pointer.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
