### PR TITLE
Fix splat v0 mangling

### DIFF
--- a/compiler/rustc_symbol_mangling/src/v0.rs
+++ b/compiler/rustc_symbol_mangling/src/v0.rs
@@ -566,6 +566,7 @@ impl<'tcx> Printer<'tcx> for V0SymbolMangler<'tcx> {
             }
 
             ty::FnPtr(sig_tys, hdr) => {
+                let splatted_arg_index = hdr.splatted().map(usize::from);
                 let sig = sig_tys.with(hdr);
                 self.push("F");
                 self.wrap_binder(&sig, |p, sig| {
@@ -585,7 +586,15 @@ impl<'tcx> Printer<'tcx> for V0SymbolMangler<'tcx> {
                             }
                         }
                     }
-                    for &ty in sig.inputs() {
+                    for (i, &ty) in sig.inputs().iter().enumerate() {
+                        if splatted_arg_index == Some(i) {
+                            // The splat feature is unstable and its mangling is subject to change
+                            // FIXME(splat):
+                            // - for efficiency we might want to use a letter that can't occur in any type, rather than
+                            //   taking an unused letter
+                            // - splat isn't implemented for legacy mangling
+                            p.push("w");
+                        }
                         ty.print(p)?;
                     }
                     if sig.c_variadic() {

--- a/compiler/rustc_type_ir/src/ty_kind.rs
+++ b/compiler/rustc_type_ir/src/ty_kind.rs
@@ -1403,6 +1403,10 @@ impl<I: Interner> FnHeader<I> {
         self.fn_sig_kind.abi()
     }
 
+    pub fn splatted(self) -> Option<u8> {
+        self.fn_sig_kind.splatted()
+    }
+
     /// Create a new safe FnHeader with the `extern "Rust"` ABI, that isn't C-style variadic or splatted.
     pub fn dummy() -> Self {
         Self { fn_sig_kind: FnSigKind::dummy() }

--- a/src/doc/rustc/src/symbol-mangling/v0.md
+++ b/src/doc/rustc/src/symbol-mangling/v0.md
@@ -704,6 +704,7 @@ A *placeholder* may occur in circumstances where a type or const value is not re
 [array-type]: #array-type
 [slice-type]: #slice-type
 [tuple-type]: #tuple-type
+[splatted-type]: #splatted-type
 [ref-type]: #ref-type
 [mut-ref-type]: #mut-ref-type
 [const-ptr-type]: #const-ptr-type
@@ -717,6 +718,7 @@ A *placeholder* may occur in circumstances where a type or const value is not re
 > &nbsp;&nbsp; | *[array-type]* \
 > &nbsp;&nbsp; | *[slice-type]* \
 > &nbsp;&nbsp; | *[tuple-type]* \
+> &nbsp;&nbsp; | *[splatted-type]* \
 > &nbsp;&nbsp; | *[ref-type]* \
 > &nbsp;&nbsp; | *[mut-ref-type]* \
 > &nbsp;&nbsp; | *[const-ptr-type]* \
@@ -775,6 +777,14 @@ Remaining primitives are encoded as a crate production, e.g. `C4f128`.
   The tag `T` is followed by one or more <em>[type]</em>s indicating the type of each field, followed by a terminating `E` character.
 
   Note that a zero-length tuple (unit) is encoded with the `u` *[basic-type]*.
+
+* `w` — A [splatted type][tracking-splat] `#[splat] T`.
+
+  > <span id="splatted-type">splatted-type</span> → `w` {*[type]*}
+
+  The tag `w` is followed by the *[type]* being splatted.
+
+  Note that the splat feature is unstable and subject to change or removal.
 
 * `R` — A [reference][reference-shared-reference] `&T`.
 
@@ -1268,3 +1278,4 @@ The compiler has some latitude in how an entity is encoded as long as the symbol
 [reference-traits]: ../../reference/items/traits.html
 [reference-tuple]: ../../reference/types/tuple.html
 [reference-types]: ../../reference/types.html
+[tracking-splat]: https://github.com/rust-lang/rust/issues/153629

--- a/src/doc/rustc/src/symbol-mangling/v0.md
+++ b/src/doc/rustc/src/symbol-mangling/v0.md
@@ -842,7 +842,7 @@ Remaining primitives are encoded as a crate production, e.g. `C4f128`.
 [fn-sig]: #fn-sig
 [abi]: #abi
 
-* `W` — A [pattern-type][pattern-tpye] `u32 is 0..100`.
+* `W` — A [pattern-type][pattern-type] `u32 is 0..100`.
   > <span id="pattern-type">pattern-type</span> → `W` *[pattern-kind]*
   >
   > <span id="pattern-kind">pattern-kind</span> → \

--- a/tests/ui/splat/splat-mangling-issue-158644.rs
+++ b/tests/ui/splat/splat-mangling-issue-158644.rs
@@ -1,0 +1,18 @@
+//! Test that splat influences symbol mangling, regression test for #158644
+//@ revisions: default legacy v0
+//@ [default] compile-flags: -C opt-level=0
+//@ [legacy] compile-flags: -C opt-level=0 -Z unstable-options -Csymbol-mangling-version=legacy
+//@ [v0] compile-flags: -C opt-level=0 -Z unstable-options -Csymbol-mangling-version=v0
+//@ run-fail
+//@ incremental
+
+#![allow(incomplete_features)]
+#![feature(splat)]
+
+fn main() {
+    #[rustfmt::skip]
+    let _x: fn(#[splat] (i32,)) = None.unwrap();
+
+    let x: fn((i32,)) = None.unwrap();
+    x((1,));
+}

--- a/tests/ui/splat/splat-mangling.default.stderr
+++ b/tests/ui/splat/splat-mangling.default.stderr
@@ -1,0 +1,4 @@
+error: symbol `_RNvMNtCsCRATE_HASH_4core6optionINtB2_6OptionFTlEEuE6unwrapCsCRATE_HASH_14splat_mangling` is already defined
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/splat/splat-mangling.legacy.stderr
+++ b/tests/ui/splat/splat-mangling.legacy.stderr
@@ -1,142 +1,142 @@
-error: symbol-name(_RMNvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeFwThmEEuE)
+error: symbol-name(_ZN14splat_mangling4main66Type$LT$fn$LP$$C$$u20$$u23$$u5b$splat$u5d$$LP$u8$C$u32$RP$$RP$$GT$17hCRATE_HASHE)
   --> $DIR/splat-mangling.rs:22:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: demangling(<splat_mangling[CRATE_HASH]::main::Type<fn(#[splat] (u8, u32))>>)
+error: demangling(splat_mangling::main::Type<fn(, #[splat](u8,u32))>::hCRATE_HASH)
   --> $DIR/splat-mangling.rs:22:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: demangling-alt(<splat_mangling::main::Type<fn(#[splat] (u8, u32))>>)
+error: demangling-alt(splat_mangling::main::Type<fn(, #[splat](u8,u32))>)
   --> $DIR/splat-mangling.rs:22:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: symbol-name(_RMs_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeFThmEEuE)
+error: symbol-name(_ZN14splat_mangling4main38Type$LT$fn$LP$$LP$u8$C$u32$RP$$RP$$GT$17hCRATE_HASHE)
   --> $DIR/splat-mangling.rs:32:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: demangling(<splat_mangling[CRATE_HASH]::main::Type<fn((u8, u32))>>)
+error: demangling(splat_mangling::main::Type<fn((u8,u32))>::hCRATE_HASH)
   --> $DIR/splat-mangling.rs:32:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: demangling-alt(<splat_mangling::main::Type<fn((u8, u32))>>)
+error: demangling-alt(splat_mangling::main::Type<fn((u8,u32))>)
   --> $DIR/splat-mangling.rs:32:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: symbol-name(_RMs0_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeFwTThmEEEuE)
+error: symbol-name(_ZN14splat_mangling4main77Type$LT$fn$LP$$C$$u20$$u23$$u5b$splat$u5d$$LP$$LP$u8$C$u32$RP$$C$$RP$$RP$$GT$17hCRATE_HASHE)
   --> $DIR/splat-mangling.rs:42:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: demangling(<splat_mangling[CRATE_HASH]::main::Type<fn(#[splat] ((u8, u32),))>>)
+error: demangling(splat_mangling::main::Type<fn(, #[splat]((u8,u32),))>::hCRATE_HASH)
   --> $DIR/splat-mangling.rs:42:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: demangling-alt(<splat_mangling::main::Type<fn(#[splat] ((u8, u32),))>>)
+error: demangling-alt(splat_mangling::main::Type<fn(, #[splat]((u8,u32),))>)
   --> $DIR/splat-mangling.rs:42:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: symbol-name(_RMs1_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeFTThmEEEuE)
+error: symbol-name(_ZN14splat_mangling4main49Type$LT$fn$LP$$LP$$LP$u8$C$u32$RP$$C$$RP$$RP$$GT$17hCRATE_HASHE)
   --> $DIR/splat-mangling.rs:52:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: demangling(<splat_mangling[CRATE_HASH]::main::Type<fn(((u8, u32),))>>)
+error: demangling(splat_mangling::main::Type<fn(((u8,u32),))>::hCRATE_HASH)
   --> $DIR/splat-mangling.rs:52:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: demangling-alt(<splat_mangling::main::Type<fn(((u8, u32),))>>)
+error: demangling-alt(splat_mangling::main::Type<fn(((u8,u32),))>)
   --> $DIR/splat-mangling.rs:52:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: symbol-name(_RMs2_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypePFwTmaEEuE)
+error: symbol-name(_ZN14splat_mangling4main80Type$LT$$BP$const$u20$fn$LP$$C$$u20$$u23$$u5b$splat$u5d$$LP$u32$C$i8$RP$$RP$$GT$17hCRATE_HASHE)
   --> $DIR/splat-mangling.rs:62:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: demangling(<splat_mangling[CRATE_HASH]::main::Type<*const fn(#[splat] (u32, i8))>>)
+error: demangling(splat_mangling::main::Type<*const fn(, #[splat](u32,i8))>::hCRATE_HASH)
   --> $DIR/splat-mangling.rs:62:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: demangling-alt(<splat_mangling::main::Type<*const fn(#[splat] (u32, i8))>>)
+error: demangling-alt(splat_mangling::main::Type<*const fn(, #[splat](u32,i8))>)
   --> $DIR/splat-mangling.rs:62:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: symbol-name(_RMs3_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypePFTmaEEuE)
+error: symbol-name(_ZN14splat_mangling4main52Type$LT$$BP$const$u20$fn$LP$$LP$u32$C$i8$RP$$RP$$GT$17hCRATE_HASHE)
   --> $DIR/splat-mangling.rs:72:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: demangling(<splat_mangling[CRATE_HASH]::main::Type<*const fn((u32, i8))>>)
+error: demangling(splat_mangling::main::Type<*const fn((u32,i8))>::hCRATE_HASH)
   --> $DIR/splat-mangling.rs:72:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: demangling-alt(<splat_mangling::main::Type<*const fn((u32, i8))>>)
+error: demangling-alt(splat_mangling::main::Type<*const fn((u32,i8))>)
   --> $DIR/splat-mangling.rs:72:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: symbol-name(_RMs4_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeFwTmaEdEuE)
+error: symbol-name(_ZN14splat_mangling4main72Type$LT$fn$LP$$C$$u20$$u23$$u5b$splat$u5d$$LP$u32$C$i8$RP$$C$f64$RP$$GT$17hCRATE_HASHE)
   --> $DIR/splat-mangling.rs:82:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: demangling(<splat_mangling[CRATE_HASH]::main::Type<fn(#[splat] (u32, i8), f64)>>)
+error: demangling(splat_mangling::main::Type<fn(, #[splat](u32,i8),f64)>::hCRATE_HASH)
   --> $DIR/splat-mangling.rs:82:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: demangling-alt(<splat_mangling::main::Type<fn(#[splat] (u32, i8), f64)>>)
+error: demangling-alt(splat_mangling::main::Type<fn(, #[splat](u32,i8),f64)>)
   --> $DIR/splat-mangling.rs:82:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: symbol-name(_RMs5_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeFTmaEdEuE)
+error: symbol-name(_ZN14splat_mangling4main44Type$LT$fn$LP$$LP$u32$C$i8$RP$$C$f64$RP$$GT$17hCRATE_HASHE)
   --> $DIR/splat-mangling.rs:92:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: demangling(<splat_mangling[CRATE_HASH]::main::Type<fn((u32, i8), f64)>>)
+error: demangling(splat_mangling::main::Type<fn((u32,i8),f64)>::hCRATE_HASH)
   --> $DIR/splat-mangling.rs:92:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: demangling-alt(<splat_mangling::main::Type<fn((u32, i8), f64)>>)
+error: demangling-alt(splat_mangling::main::Type<fn((u32,i8),f64)>)
   --> $DIR/splat-mangling.rs:92:5
    |
 LL |     #[rustc_dump_symbol_name]

--- a/tests/ui/splat/splat-mangling.rs
+++ b/tests/ui/splat/splat-mangling.rs
@@ -1,0 +1,24 @@
+//! Test that splat influences symbol mangling.
+//@ revisions: default legacy v0
+//@ [default] compile-flags: -C opt-level=0
+//@ [legacy] compile-flags: -C opt-level=0 -Z unstable-options -Csymbol-mangling-version=legacy
+//@ [v0] compile-flags: -C opt-level=0 -Z unstable-options -Csymbol-mangling-version=v0
+//@ [default] build-fail
+//@ [legacy] run-fail
+//@ [v0] build-fail
+//@ incremental
+
+#![allow(incomplete_features)]
+#![feature(splat)]
+
+fn main() {
+    // Bug #158603 regression test variants
+    #[rustfmt::skip]
+    let _x: fn(#[splat] (i32,)) = None.unwrap();
+
+    //@ [default] regex-error-pattern: symbol `.*Option.*unwrap.*splat_mangling` is already defined
+    //@ [v0] regex-error-pattern: symbol `.*Option.*unwrap.*splat_mangling` is already defined
+    //[default,v0]~? ERROR: is already defined
+    let x: fn((i32,)) = None.unwrap();
+    x((1,));
+}

--- a/tests/ui/splat/splat-mangling.rs
+++ b/tests/ui/splat/splat-mangling.rs
@@ -1,24 +1,100 @@
-//! Test that splat influences symbol mangling.
+//! Test for splat symbol mangling.
 //@ revisions: default legacy v0
 //@ [default] compile-flags: -C opt-level=0
 //@ [legacy] compile-flags: -C opt-level=0 -Z unstable-options -Csymbol-mangling-version=legacy
 //@ [v0] compile-flags: -C opt-level=0 -Z unstable-options -Csymbol-mangling-version=v0
-//@ [default] build-fail
-//@ [legacy] run-fail
-//@ [v0] build-fail
-//@ incremental
+//@ build-fail
+
+// CRATE_HASH normalization doesn't seem to work on some of these symbol logs
+//@ normalize-stderr: "splat_mangling\[([0-9a-f]{16})\]::" -> "splat_mangling[CRATE_HASH]::"
+//@ normalize-stderr: "h([0-9a-f]{16})E\)" -> "hCRATE_HASHE)"
+//@ normalize-stderr: "::h([0-9a-f]{16})\)" -> "::hCRATE_HASH)"
 
 #![allow(incomplete_features)]
-#![feature(splat)]
+#![feature(splat, rustc_attrs)]
 
 fn main() {
-    // Bug #158603 regression test variants
-    #[rustfmt::skip]
-    let _x: fn(#[splat] (i32,)) = None.unwrap();
+    struct Type<T: ?Sized>(T);
 
-    //@ [default] regex-error-pattern: symbol `.*Option.*unwrap.*splat_mangling` is already defined
-    //@ [v0] regex-error-pattern: symbol `.*Option.*unwrap.*splat_mangling` is already defined
-    //[default,v0]~? ERROR: is already defined
-    let x: fn((i32,)) = None.unwrap();
-    x((1,));
+    // FIXME(rustfmt): the attribute gets deleted by rustfmt
+    #[rustfmt::skip]
+    // FIXME(splat, legacy mangling): the first comma is in the wrong place
+    #[rustc_dump_symbol_name]
+           //[legacy]~^ ERROR symbol-name(_ZN14splat_mangling4main66Type$LT$fn$LP$$C$$u20$$u23$$u5b$splat$u5d$$LP$u8$C$u32$RP$$RP$$GT
+           //[legacy]~| ERROR demangling(splat_mangling::main::Type<fn(, #[splat](u8,u32))>::
+           //[legacy]~| ERROR demangling-alt(splat_mangling::main::Type<fn(, #[splat](u8,u32))>)
+    //[v0,default]~^^^^ ERROR symbol-name(_RMNvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeFwThmEEuE)
+       //[v0,default]~| ERROR demangling(<splat_mangling[
+       //[v0,default]~| ERROR demangling-alt(<splat_mangling::main::Type<fn(#[splat] (u8, u32))>>)
+    impl Type<fn(#[splat] (u8, u32))> {}
+
+    #[rustfmt::skip]
+    #[rustc_dump_symbol_name]
+           //[legacy]~^ ERROR symbol-name(_ZN14splat_mangling4main38Type$LT$fn$LP$$LP$u8$C$u32$RP$$RP$$GT
+           //[legacy]~| ERROR demangling(splat_mangling::main::Type<fn((u8,u32))>::
+           //[legacy]~| ERROR demangling-alt(splat_mangling::main::Type<fn((u8,u32))>)
+    //[v0,default]~^^^^ ERROR symbol-name(_RMs_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeFThmEEuE)
+       //[v0,default]~| ERROR demangling(<splat_mangling[
+       //[v0,default]~| ERROR demangling-alt(<splat_mangling::main::Type<fn((u8, u32))>>)
+    impl Type<fn((u8, u32))> {}
+
+    #[rustfmt::skip]
+    #[rustc_dump_symbol_name]
+           //[legacy]~^ ERROR symbol-name(_ZN14splat_mangling4main77Type$LT$fn$LP$$C$$u20$$u23$$u5b$splat$u5d$$LP$$LP$u8$C$u32$RP$$C$$RP$$RP$$GT
+           //[legacy]~| ERROR demangling(splat_mangling::main::Type<fn(, #[splat]((u8,u32),))>::
+           //[legacy]~| ERROR demangling-alt(splat_mangling::main::Type<fn(, #[splat]((u8,u32),))>)
+    //[v0,default]~^^^^ ERROR symbol-name(_RMs0_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeFwTThmEEEuE)
+       //[v0,default]~| ERROR demangling(<splat_mangling[
+       //[v0,default]~| ERROR demangling-alt(<splat_mangling::main::Type<fn(#[splat] ((u8, u32),))>>)
+    impl Type<fn(#[splat] ((u8, u32),))> {}
+
+    #[rustfmt::skip]
+    #[rustc_dump_symbol_name]
+           //[legacy]~^ ERROR symbol-name(_ZN14splat_mangling4main49Type$LT$fn$LP$$LP$$LP$u8$C$u32$RP$$C$$RP$$RP$$GT
+           //[legacy]~| ERROR demangling(splat_mangling::main::Type<fn(((u8,u32),))>::
+           //[legacy]~| ERROR demangling-alt(splat_mangling::main::Type<fn(((u8,u32),))>)
+    //[v0,default]~^^^^ ERROR symbol-name(_RMs1_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeFTThmEEEuE)
+       //[v0,default]~| ERROR demangling(<splat_mangling[
+       //[v0,default]~| ERROR demangling-alt(<splat_mangling::main::Type<fn(((u8, u32),))>>)
+    impl Type<fn(((u8, u32),))> {}
+
+    #[rustfmt::skip]
+    #[rustc_dump_symbol_name]
+           //[legacy]~^ ERROR symbol-name(_ZN14splat_mangling4main80Type$LT$$BP$const$u20$fn$LP$$C$$u20$$u23$$u5b$splat$u5d$$LP$u32$C$i8$RP$$RP$$GT
+           //[legacy]~| ERROR demangling(splat_mangling::main::Type<*const fn(, #[splat](u32,i8))>::
+           //[legacy]~| ERROR demangling-alt(splat_mangling::main::Type<*const fn(, #[splat](u32,i8))>)
+    //[v0,default]~^^^^ ERROR symbol-name(_RMs2_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypePFwTmaEEuE)
+       //[v0,default]~| ERROR demangling(<splat_mangling[
+       //[v0,default]~| ERROR demangling-alt(<splat_mangling::main::Type<*const fn(#[splat] (u32, i8))>>)
+    impl Type<*const fn(#[splat] (u32, i8))> {}
+
+    #[rustfmt::skip]
+    #[rustc_dump_symbol_name]
+           //[legacy]~^ ERROR symbol-name(_ZN14splat_mangling4main52Type$LT$$BP$const$u20$fn$LP$$LP$u32$C$i8$RP$$RP$$GT
+           //[legacy]~| ERROR demangling(splat_mangling::main::Type<*const fn((u32,i8))>::
+           //[legacy]~| ERROR demangling-alt(splat_mangling::main::Type<*const fn((u32,i8))>)
+    //[v0,default]~^^^^ ERROR symbol-name(_RMs3_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypePFTmaEEuE)
+       //[v0,default]~| ERROR demangling(<splat_mangling[
+       //[v0,default]~| ERROR demangling-alt(<splat_mangling::main::Type<*const fn((u32, i8))>>)
+    impl Type<*const fn((u32, i8))> {}
+
+    #[rustfmt::skip]
+    #[rustc_dump_symbol_name]
+           //[legacy]~^ ERROR symbol-name(_ZN14splat_mangling4main72Type$LT$fn$LP$$C$$u20$$u23$$u5b$splat$u5d$$LP$u32$C$i8$RP$$C$f64$RP$$GT
+           //[legacy]~| ERROR demangling(splat_mangling::main::Type<fn(, #[splat](u32,i8),f64)>::
+           //[legacy]~| ERROR demangling-alt(splat_mangling::main::Type<fn(, #[splat](u32,i8),f64)>)
+    //[v0,default]~^^^^ ERROR symbol-name(_RMs4_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeFwTmaEdEuE)
+       //[v0,default]~| ERROR demangling(<splat_mangling[
+       //[v0,default]~| ERROR demangling-alt(<splat_mangling::main::Type<fn(#[splat] (u32, i8), f64)>>)
+    impl Type<fn(#[splat] (u32, i8), f64)> {}
+
+    #[rustfmt::skip]
+    #[rustc_dump_symbol_name]
+           //[legacy]~^ ERROR symbol-name(_ZN14splat_mangling4main44Type$LT$fn$LP$$LP$u32$C$i8$RP$$C$f64$RP$$GT
+           //[legacy]~| ERROR demangling(splat_mangling::main::Type<fn((u32,i8),f64)>::
+           //[legacy]~| ERROR demangling-alt(splat_mangling::main::Type<fn((u32,i8),f64)>)
+    //[v0,default]~^^^^ ERROR symbol-name(_RMs5_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeFTmaEdEuE)
+       //[v0,default]~| ERROR demangling(<splat_mangling[
+       //[v0,default]~| ERROR demangling-alt(<splat_mangling::main::Type<fn((u32, i8), f64)>>)
+    impl Type<fn((u32, i8), f64)> {}
 }

--- a/tests/ui/splat/splat-mangling.v0.stderr
+++ b/tests/ui/splat/splat-mangling.v0.stderr
@@ -1,4 +1,146 @@
-error: symbol `_RNvMNtCsCRATE_HASH_4core6optionINtB2_6OptionFTlEEuE6unwrapCsCRATE_HASH_14splat_mangling` is already defined
+error: symbol-name(_RMNvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeFwThmEEuE)
+  --> $DIR/splat-mangling.rs:22:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 1 previous error
+error: demangling(<splat_mangling[CRATE_HASH]::main::Type<fn(#[splat] (u8, u32))>>)
+  --> $DIR/splat-mangling.rs:22:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: demangling-alt(<splat_mangling::main::Type<fn(#[splat] (u8, u32))>>)
+  --> $DIR/splat-mangling.rs:22:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: symbol-name(_RMs_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeFThmEEuE)
+  --> $DIR/splat-mangling.rs:32:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: demangling(<splat_mangling[CRATE_HASH]::main::Type<fn((u8, u32))>>)
+  --> $DIR/splat-mangling.rs:32:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: demangling-alt(<splat_mangling::main::Type<fn((u8, u32))>>)
+  --> $DIR/splat-mangling.rs:32:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: symbol-name(_RMs0_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeFwTThmEEEuE)
+  --> $DIR/splat-mangling.rs:42:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: demangling(<splat_mangling[CRATE_HASH]::main::Type<fn(#[splat] ((u8, u32),))>>)
+  --> $DIR/splat-mangling.rs:42:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: demangling-alt(<splat_mangling::main::Type<fn(#[splat] ((u8, u32),))>>)
+  --> $DIR/splat-mangling.rs:42:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: symbol-name(_RMs1_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeFTThmEEEuE)
+  --> $DIR/splat-mangling.rs:52:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: demangling(<splat_mangling[CRATE_HASH]::main::Type<fn(((u8, u32),))>>)
+  --> $DIR/splat-mangling.rs:52:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: demangling-alt(<splat_mangling::main::Type<fn(((u8, u32),))>>)
+  --> $DIR/splat-mangling.rs:52:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: symbol-name(_RMs2_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypePFwTmaEEuE)
+  --> $DIR/splat-mangling.rs:62:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: demangling(<splat_mangling[CRATE_HASH]::main::Type<*const fn(#[splat] (u32, i8))>>)
+  --> $DIR/splat-mangling.rs:62:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: demangling-alt(<splat_mangling::main::Type<*const fn(#[splat] (u32, i8))>>)
+  --> $DIR/splat-mangling.rs:62:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: symbol-name(_RMs3_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypePFTmaEEuE)
+  --> $DIR/splat-mangling.rs:72:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: demangling(<splat_mangling[CRATE_HASH]::main::Type<*const fn((u32, i8))>>)
+  --> $DIR/splat-mangling.rs:72:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: demangling-alt(<splat_mangling::main::Type<*const fn((u32, i8))>>)
+  --> $DIR/splat-mangling.rs:72:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: symbol-name(_RMs4_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeFwTmaEdEuE)
+  --> $DIR/splat-mangling.rs:82:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: demangling(<splat_mangling[CRATE_HASH]::main::Type<fn(#[splat] (u32, i8), f64)>>)
+  --> $DIR/splat-mangling.rs:82:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: demangling-alt(<splat_mangling::main::Type<fn(#[splat] (u32, i8), f64)>>)
+  --> $DIR/splat-mangling.rs:82:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: symbol-name(_RMs5_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeFTmaEdEuE)
+  --> $DIR/splat-mangling.rs:92:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: demangling(<splat_mangling[CRATE_HASH]::main::Type<fn((u32, i8), f64)>>)
+  --> $DIR/splat-mangling.rs:92:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: demangling-alt(<splat_mangling::main::Type<fn((u32, i8), f64)>>)
+  --> $DIR/splat-mangling.rs:92:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 24 previous errors
 

--- a/tests/ui/splat/splat-mangling.v0.stderr
+++ b/tests/ui/splat/splat-mangling.v0.stderr
@@ -1,0 +1,4 @@
+error: symbol `_RNvMNtCsCRATE_HASH_4core6optionINtB2_6OptionFTlEEuE6unwrapCsCRATE_HASH_14splat_mangling` is already defined
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/158890)*
<!-- homu-ignore:end -->

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Tracking issue: rust-lang/rust#153629

Typecheck considers a splatted and non-splatted function as distinct types, so mangling has to include splatting. If it doesn't, we get symbol clashes. See the ticket and the tests in this PR for details.

Demangling PR: https://github.com/rust-lang/rustc-demangle/pull/90
Demangling in rust-lang/rust PR: https://github.com/rust-lang/rust/pull/159202

@rustbot label +C-bug +F-splat +T-compiler +A-name-mangling

Fixes rust-lang/rust#158644

This PR was based on rust-lang/rust#159202, so we waited for that PR to merge first, then rebased this one.