### PR TITLE
Make the ordering of non-terminal binds in ambiguity error messages deterministic

### DIFF
--- a/compiler/rustc_expand/src/mbe/macro_parser.rs
+++ b/compiler/rustc_expand/src/mbe/macro_parser.rs
@@ -696,11 +696,15 @@ impl TtParser {
     }
 
     fn ambiguity_error<'matcher, T: Tracker<'matcher>>(
-        &self,
+        &mut self,
         parser: &Parser<'_>,
         matcher: &'matcher [MatcherLoc],
         track: &mut T,
     ) -> NamedParseResult<T::Failure> {
+        // Use a reasonable and deterministic ordering for data in the error message.
+        self.bb_mps.sort_unstable_by_key(|mp| mp.idx);
+        self.next_mps.sort_unstable_by_key(|mp| mp.idx);
+
         let bb_locs = self.bb_mps.iter().map(|mp| &matcher[mp.idx]);
         let next_locs = self.next_mps.iter().map(|mp| &matcher[mp.idx]);
         track.ambiguity(parser, bb_locs, next_locs);

--- a/tests/ui/macros/local-ambiguity-option-ordering.rs
+++ b/tests/ui/macros/local-ambiguity-option-ordering.rs
@@ -1,0 +1,49 @@
+// Test the order in which meta-variable options causing ambiguity are presented in error messages.
+
+#![crate_type = "lib"]
+
+macro_rules! ambiguity_1 {
+    ($($i:ident)* $j:ident) => {};
+}
+
+ambiguity_1!(error); //~ ERROR local ambiguity
+
+macro_rules! ambiguity_2 {
+    ( $( $( ; $i:ident )? $( $j:ident )? ; )* ) => {};
+}
+
+ambiguity_2!( ; error ); //~ ERROR local ambiguity
+//
+// Parse tree:
+// - `$(...)*`:
+// - Try one repetition
+//   - `$(; $i)?`:
+//   - Try entering
+//     - Parse `;`
+// ----> `$i` can parse `error`
+//   - Try ignoring
+//     - `$($j)?`:
+//     - Try entering
+//       - `$j` cannot parse `;`
+//       - failure
+//     - Try ignoring
+//       - Parse `;`
+//       - `$(...)*`:
+//       - Try another repetition
+//         - `$(; $i)?`:
+//         - Try entering
+//           - Cannot parse `;`
+//           - failure
+//         - Try ignoring
+//           - `$($j)?`:
+//           - Try entering
+// ------------> `$j` can parse `error`
+//           - Try ignoring
+//             - Cannot parse `;`
+//             - failure
+//       - Try ignoring
+//         - EOF vs `error`
+//         - failure
+// - Try no repetitions
+//   - EOF vs `;`
+//   - failure

--- a/tests/ui/macros/local-ambiguity-option-ordering.stderr
+++ b/tests/ui/macros/local-ambiguity-option-ordering.stderr
@@ -4,7 +4,7 @@ error: local ambiguity when calling macro `ambiguity_1`: multiple parsing option
 LL | ambiguity_1!(error);
    |              ^^^^^
 
-error: local ambiguity when calling macro `ambiguity_2`: multiple parsing options: built-in NTs ident ('j') or ident ('i').
+error: local ambiguity when calling macro `ambiguity_2`: multiple parsing options: built-in NTs ident ('i') or ident ('j').
   --> $DIR/local-ambiguity-option-ordering.rs:15:17
    |
 LL | ambiguity_2!( ; error );

--- a/tests/ui/macros/local-ambiguity-option-ordering.stderr
+++ b/tests/ui/macros/local-ambiguity-option-ordering.stderr
@@ -1,0 +1,14 @@
+error: local ambiguity when calling macro `ambiguity_1`: multiple parsing options: built-in NTs ident ('i') or ident ('j').
+  --> $DIR/local-ambiguity-option-ordering.rs:9:14
+   |
+LL | ambiguity_1!(error);
+   |              ^^^^^
+
+error: local ambiguity when calling macro `ambiguity_2`: multiple parsing options: built-in NTs ident ('j') or ident ('i').
+  --> $DIR/local-ambiguity-option-ordering.rs:15:17
+   |
+LL | ambiguity_2!( ; error );
+   |                 ^^^^^
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
My next PR will rework macro parsing to use a DFS approach instead of a BFS. It will change the order in which the parsing space is explored, and while this does not change the behavior of parsing in success cases, it did cause changes to some error messages; in particular, when an ambiguity error occurs, it would sometimes report non-terminal binds in a different order (e.g. in ```error: local ambiguity when calling macro `foo`: multiple parsing options: built-in NTs ident ('i') or ident ('j').```). I realized that the current macro parsing code does not enforce a particular order for those binds, so this PR 1) adds a test case for strange bind orderings and 2) makes the bind ordering deterministic (in line with the ordering of those binds in the macro definition, which was how binds tended to be ordered anyway).

Ideally reviewed commit-by-commit.

r? @nnethercote