### PR TITLE
std: optimize Path::eq and PathBuf::eq with a fast byte-level path

### DIFF
--- a/library/std/benches/path.rs
+++ b/library/std/benches/path.rs
@@ -131,3 +131,27 @@ fn bench_hash_path_long(b: &mut test::Bencher) {
 
     black_box(hasher.finish());
 }
+
+#[bench]
+fn bench_path_eq_identical(b: &mut test::Bencher) {
+    let s = "/my/home/is/my/castle/and/my/castle/has/a/rusty/workbench/file.rs";
+    // Use two distinct heap allocations so memcmp cannot short-circuit on pointer equality.
+    let p1 = PathBuf::from(s);
+    let p2 = PathBuf::from(s);
+    b.iter(|| black_box(p1.as_path()) == black_box(p2.as_path()));
+}
+
+#[bench]
+fn bench_path_eq_different_len(b: &mut test::Bencher) {
+    let a = Path::new("/my/home/is/my/castle/and/my/castle/has/a/rusty/workbench/short.rs");
+    let b_path =
+        Path::new("/my/home/is/my/castle/and/my/castle/has/a/rusty/workbench/longer_name.rs");
+    b.iter(|| black_box(a) == black_box(b_path));
+}
+
+#[bench]
+fn bench_path_eq_same_len_differ(b: &mut test::Bencher) {
+    let a = Path::new("/my/home/is/my/castle/and/my/castle/has/a/rusty/workbench/aaa.rs");
+    let b_path = Path::new("/my/home/is/my/castle/and/my/castle/has/a/rusty/workbench/zzz.rs");
+    b.iter(|| black_box(a) == black_box(b_path));
+}

--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -2245,7 +2245,9 @@ impl ToOwned for Path {
 impl PartialEq for PathBuf {
     #[inline]
     fn eq(&self, other: &PathBuf) -> bool {
-        self.components() == other.components()
+        // Identical byte sequences always produce identical component sequences,
+        // so skip the more expensive component-wise comparison in that case.
+        self.as_os_str() == other.as_os_str() || self.components() == other.components()
     }
 }
 
@@ -3754,7 +3756,9 @@ impl fmt::Display for Display<'_> {
 impl PartialEq for Path {
     #[inline]
     fn eq(&self, other: &Path) -> bool {
-        self.components() == other.components()
+        // Identical byte sequences always produce identical component sequences,
+        // so skip the more expensive component-wise comparison in that case.
+        self.as_os_str() == other.as_os_str() || self.components() == other.components()
     }
 }
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/158895)*
<!-- homu-ignore:end -->

Fixes rust-lang/rust#154521

## Motivation

`Path::eq` compares paths by constructing two `Components` iterators and
comparing them component-by-component. For the common case where two paths
have identical byte representations (e.g. hash map lookups, deduplication),
this creates unnecessary overhead: two `Components` structs are allocated, the
`parse_prefix` / `has_physical_root` initialization runs, and the five-field
fast path check in `Components::eq` executes - all before the eventual
`self.path == other.path` byte comparison that determines the result.

Since identical byte sequences always produce identical component sequences
(component parsing is deterministic), we can short-circuit `PartialEq::eq`
at the `OsStr` level for this common case. The fall-through to
`self.components() == other.components()` preserves the correct semantics for
paths that differ only in normalization (e.g. `/a//b` vs `/a/b`, `foo/` vs `foo`).

## Changes

- `Path::eq`: add `self.as_os_str() == other.as_os_str()` fast path.
- `PathBuf::eq`: same.
- `library/std/benches/path.rs`: add three targeted equality benchmarks
  (`identical`, `different_len`, `same_len_differ`) to exercise the new path.

## Correctness

The `Hash` + `PartialEq` invariant is preserved: if `as_os_str()` returns
`true`, the two byte slices are identical, which implies identical components
and thus the same hash. If it returns `false`, we fall back to the existing
component comparison, which is unchanged.