### PR TITLE
Fix hTargetProcessHandle Win32 API in error message

### DIFF
--- a/src/tools/miri/src/shims/windows/handle.rs
+++ b/src/tools/miri/src/shims/windows/handle.rs
@@ -287,7 +287,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
         if target_proc != Handle::Pseudo(PseudoHandle::CurrentProcess) {
             throw_unsup_format!(
-                "`DuplicateHandle` `hSourceProcessHandle` parameter is not the current process, which is unsupported"
+                "`DuplicateHandle` `hTargetProcessHandle` parameter is not the current process, which is unsupported"
             );
         }
 


### PR DESCRIPTION
Per https://learn.microsoft.com/en-us/windows/win32/api/handleapi/nf-handleapi-duplicatehandle, the `hSourceProcessHandle` should be `hTargetProcessHandle` here since `target_proc` is being compared.