### PR TITLE
Closures inherit #[optimize] from the enclosing function by default.

### DIFF
--- a/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
+++ b/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
@@ -1,7 +1,7 @@
 use rustc_abi::{Align, ExternAbi};
 use rustc_hir::attrs::{
     AttributeKind, EiiImplResolution, InlineAttr, InstrumentFnAttr as HirInstrumentFnAttr, Linkage,
-    RtsanSetting, UsedBy,
+    OptimizeAttr, RtsanSetting, UsedBy,
 };
 use rustc_hir::def::DefKind;
 use rustc_hir::def_id::{DefId, LOCAL_CRATE, LocalDefId};
@@ -351,6 +351,17 @@ fn apply_overrides(tcx: TyCtxt<'_>, did: LocalDefId, codegen_fn_attrs: &mut Code
             codegen_fn_attrs
                 .target_features
                 .extend(tcx.codegen_fn_attrs(owner_id).target_features.iter().copied());
+        }
+    }
+
+    // Closures inherit `#[optimize]` annotations.
+    if tcx.is_closure_like(did.to_def_id()) {
+        let owner_id = tcx.parent(did.to_def_id());
+        if tcx.def_kind(owner_id).has_codegen_attrs() {
+            let owner_attrs = tcx.codegen_fn_attrs(owner_id);
+            if codegen_fn_attrs.optimize == OptimizeAttr::Default {
+                codegen_fn_attrs.optimize = owner_attrs.optimize;
+            }
         }
     }
 

--- a/tests/codegen-llvm/optimize-closures-inheritance.rs
+++ b/tests/codegen-llvm/optimize-closures-inheritance.rs
@@ -1,0 +1,49 @@
+//! Ensure that `#[optimize]` applied to an outer function is inherited by closures
+//! and their coercion shims, unless overridden by an explicit `#[optimize]` on the closure.
+
+//@ compile-flags: -C no-prepopulate-passes
+
+#![feature(optimize_attribute)]
+#![crate_type = "lib"]
+
+// CHECK-DAG: define{{.*}}test_none{{.*}}call_once{{.*}}#[[ATTR_NONE:[0-9]+]]
+// CHECK-DAG: define{{.*}}test_size{{.*}}call_once{{.*}}#[[ATTR_SIZE:[0-9]+]]
+// CHECK-DAG: define{{.*}}test_override_size{{.*}}call_once{{.*}}#[[ATTR_SIZE]]
+// CHECK-DAG: define{{.*}}test_override_none{{.*}}call_once{{.*}}#[[ATTR_NONE]]
+
+// CHECK-DAG: attributes #[[ATTR_NONE]] = { {{.*}}optnone{{.*}} }
+// CHECK-DAG: attributes #[[ATTR_SIZE]] = { {{.*}}optsize{{.*}} }
+
+#[optimize(none)]
+#[no_mangle]
+pub fn test_none() -> fn() {
+    let closure = || ();
+    closure
+}
+
+#[optimize(size)]
+#[no_mangle]
+pub fn test_size() -> fn() {
+    let closure = || ();
+    closure
+}
+
+#[optimize(none)]
+#[no_mangle]
+pub fn test_override_size() -> fn() {
+    let closure = {
+        #[optimize(size)]
+        || ()
+    };
+    closure
+}
+
+#[optimize(size)]
+#[no_mangle]
+pub fn test_override_none() -> fn() {
+    let closure = {
+        #[optimize(none)]
+        || ()
+    };
+    closure
+}


### PR DESCRIPTION
Tracking issue: https://github.com/rust-lang/rust/issues/54882
Stabilization PR: https://github.com/rust-lang/rust/pull/157273