### PR TITLE
Fix FutureDropPoll shim for by-move async closures

### DIFF
--- a/compiler/rustc_mir_transform/src/shim/async_destructor_ctor.rs
+++ b/compiler/rustc_mir_transform/src/shim/async_destructor_ctor.rs
@@ -204,8 +204,23 @@ fn build_adrop_for_coroutine_shim<'tcx>(
     let ty::Coroutine(coroutine_def_id, impl_args) = impl_ty.kind() else {
         bug!("build_adrop_for_coroutine_shim not for coroutine impl type: ({:?})", shim);
     };
+    let ty::Coroutine(_, id_args) = *tcx.type_of(*coroutine_def_id).skip_binder().kind() else {
+        bug!()
+    };
     let source_info = SourceInfo::outermost(span);
-    let body = tcx.optimized_mir(*coroutine_def_id).future_drop_poll().unwrap();
+
+    // If the kind tys differ, we must use the by-move body
+    let def_id = if id_args.as_coroutine().kind_ty() == impl_args.as_coroutine().kind_ty() {
+        *coroutine_def_id
+    } else {
+        assert_eq!(
+            impl_args.as_coroutine().kind_ty().to_opt_closure_kind().unwrap(),
+            ty::ClosureKind::FnOnce
+        );
+
+        tcx.coroutine_by_move_body_def_id(*coroutine_def_id)
+    };
+    let body = tcx.optimized_mir(def_id).future_drop_poll().unwrap();
     let mut body: Body<'tcx> =
         EarlyBinder::bind(tcx, body.clone()).instantiate(tcx, impl_args).skip_norm_wip();
     body.source.instance = ty::InstanceKind::Shim(shim);

--- a/tests/ui/async-await/async-drop/async-drop-future-drop-poll.rs
+++ b/tests/ui/async-await/async-drop/async-drop-future-drop-poll.rs
@@ -1,0 +1,17 @@
+// Regression test for #142559
+//@ build-pass
+//@ compile-flags: --crate-type=lib
+#![feature(async_drop)]
+#![allow(incomplete_features)]
+
+//@ edition: 2024
+
+async fn run<F: Future>(f: impl Fn() -> F) {
+    f().await;
+}
+
+pub async fn async_drop_async_closure() {
+    let x = async || async {}.await;
+
+    run(x).await;
+}


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Related rust-lang/rust#142559

When the coroutine is coroutine-closures, `build_adrop_for_coroutine_shim` used the the ref of the coroutine body.

This PR uses `coroutine_by_move_body_def_id` to fetch the by-move body.
(matching the existing `DropGlue` behavior in `shim.rs`)