### PR TITLE
delegation: add constraints to new generic args

### DIFF
--- a/compiler/rustc_ast_lowering/src/delegation/mod.rs
+++ b/compiler/rustc_ast_lowering/src/delegation/mod.rs
@@ -453,11 +453,14 @@ impl<'hir> LoweringContext<'_, 'hir> {
             })
             .unwrap_or_else(|| self.arena.alloc_from_iter(args_iter.consume_all(self)));
 
+        // Do not omit constraints as there might be some and they must be present in HIR (#158812).
+        let has_constraints = segment.args.is_some_and(|a| !a.constraints.is_empty());
+
         // Needed for better error messages (`trait-impl-wrong-args-count.rs` test).
-        segment.args = (!new_args.is_empty()).then(|| {
+        segment.args = (has_constraints || !new_args.is_empty()).then(|| {
             &*self.arena.alloc(hir::GenericArgs {
                 args: new_args,
-                constraints: &[],
+                constraints: segment.args.map(|a| a.constraints).unwrap_or(&[]),
                 parenthesized: hir::GenericArgsParentheses::No,
                 span_ext: segment.args.map_or(span, |args| args.span_ext),
             })

--- a/tests/ui/delegation/constraints-in-generic-args-ice-158812.rs
+++ b/tests/ui/delegation/constraints-in-generic-args-ice-158812.rs
@@ -1,0 +1,13 @@
+#![feature(fn_delegation)]
+
+pub trait Trait<'a> {
+    fn foo(&self);
+}
+
+pub struct S<'a, A>(&'a A);
+impl<'a, A> Trait<'a> for S<'a, A> {
+    reuse Trait::<A = ()>::foo;
+    //~^ ERROR: associated item constraints are not allowed here
+}
+
+fn main() {}

--- a/tests/ui/delegation/constraints-in-generic-args-ice-158812.stderr
+++ b/tests/ui/delegation/constraints-in-generic-args-ice-158812.stderr
@@ -1,0 +1,9 @@
+error[E0229]: associated item constraints are not allowed here
+  --> $DIR/constraints-in-generic-args-ice-158812.rs:9:19
+   |
+LL |     reuse Trait::<A = ()>::foo;
+   |                   ^^^^^^ associated item constraint not allowed here
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0229`.


### PR DESCRIPTION
Constraints were not added to new generic args which caused them to be missing from HIR and this produced ICE.

Fixes rust-lang/rust#158812. Part of rust-lang/rust#118212.
r? @petrochenkov