### PR TITLE
cleanup: upstream dropped AMX-TF32

### DIFF
--- a/compiler/rustc_target/src/target_features.rs
+++ b/compiler/rustc_target/src/target_features.rs
@@ -423,7 +423,6 @@ static X86_FEATURES: &[(&str, Stability, ImpliedFeatures)] = &[
     ("amx-fp16", Unstable(sym::x86_amx_intrinsics), &["amx-tile"]),
     ("amx-int8", Unstable(sym::x86_amx_intrinsics), &["amx-tile"]),
     ("amx-movrs", Unstable(sym::x86_amx_intrinsics), &["amx-tile"]),
-    ("amx-tf32", Unstable(sym::x86_amx_intrinsics), &["amx-tile"]),
     ("amx-tile", Unstable(sym::x86_amx_intrinsics), &[]),
     ("apxf", Unstable(sym::apx_target_feature), &[]),
     ("avx", Stable, &["sse4.2"]),

--- a/library/std_detect/src/detect/arch/x86.rs
+++ b/library/std_detect/src/detect/arch/x86.rs
@@ -228,8 +228,6 @@ features! {
     /// AMX-FP8 (Float8 Operations)
     @FEATURE: #[unstable(feature = "x86_amx_intrinsics", issue = "126622")] amx_movrs: "amx-movrs";
     /// AMX-MOVRS (Matrix MOVERS operations)
-    @FEATURE: #[unstable(feature = "x86_amx_intrinsics", issue = "126622")] amx_tf32: "amx-tf32";
-    /// AMX-TF32 (TensorFloat32 Operations)
     @FEATURE: #[unstable(feature = "apx_target_feature", issue = "139284")] apxf: "apxf";
     /// APX-F (Advanced Performance Extensions - Foundation)
     @FEATURE: #[unstable(feature = "avx10_target_feature", issue = "138843")] avx10_1: "avx10.1";

--- a/library/std_detect/src/detect/os/x86.rs
+++ b/library/std_detect/src/detect/os/x86.rs
@@ -216,7 +216,6 @@ pub(crate) fn detect_features() -> cache::Initializer {
                             __cpuid_count(0x1e_u32, 1);
 
                         enable(amx_feature_flags_eax, 4, Feature::amx_fp8);
-                        enable(amx_feature_flags_eax, 6, Feature::amx_tf32);
                         enable(amx_feature_flags_eax, 7, Feature::amx_avx512);
                         enable(amx_feature_flags_eax, 8, Feature::amx_movrs);
                     }

--- a/tests/ui/check-cfg/target_feature.stderr
+++ b/tests/ui/check-cfg/target_feature.stderr
@@ -28,7 +28,6 @@ LL |     cfg!(target_feature = "_UNEXPECTED_VALUE");
 `amx-fp8`
 `amx-int8`
 `amx-movrs`
-`amx-tf32`
 `amx-tile`
 `apxf`
 `atomics`


### PR DESCRIPTION
LLVM recently dropped x86 AMX-TF32 https://github.com/llvm/llvm-project/pull/207673. This is a cleanup similar to https://github.com/rust-lang/rust/pull/148338.

@rustbot label llvm-main
r? @durin42 