### PR TITLE
remove blanket-Freeze for PhantomData

### DIFF
--- a/compiler/rustc_codegen_cranelift/example/mini_core.rs
+++ b/compiler/rustc_codegen_cranelift/example/mini_core.rs
@@ -132,7 +132,6 @@ unsafe impl<T: Sync, const N: usize> Sync for [T; N] {}
 #[lang = "freeze"]
 pub unsafe auto trait Freeze {}
 
-unsafe impl<T: PointeeSized> Freeze for PhantomData<T> {}
 unsafe impl<T: PointeeSized> Freeze for *const T {}
 unsafe impl<T: PointeeSized> Freeze for *mut T {}
 unsafe impl<T: PointeeSized> Freeze for &T {}

--- a/compiler/rustc_codegen_gcc/example/mini_core.rs
+++ b/compiler/rustc_codegen_gcc/example/mini_core.rs
@@ -139,7 +139,6 @@ unsafe impl Sync for [u8; 16] {}
 #[lang = "freeze"]
 pub unsafe auto trait Freeze {}
 
-unsafe impl<T: PointeeSized> Freeze for PhantomData<T> {}
 unsafe impl<T: PointeeSized> Freeze for *const T {}
 unsafe impl<T: PointeeSized> Freeze for *mut T {}
 unsafe impl<T: PointeeSized> Freeze for &T {}

--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -322,7 +322,7 @@ pub struct Rc<
     #[unstable(feature = "allocator_api", issue = "32838")] A: Allocator = Global,
 > {
     ptr: NonNull<RcInner<T>>,
-    phantom: PhantomData<RcInner<T>>,
+    phantom: PhantomData<Box<RcInner<T>>>,
     alloc: A,
 }
 

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -271,7 +271,7 @@ pub struct Arc<
     #[unstable(feature = "allocator_api", issue = "32838")] A: Allocator = Global,
 > {
     ptr: NonNull<ArcInner<T>>,
-    phantom: PhantomData<ArcInner<T>>,
+    phantom: PhantomData<Box<ArcInner<T>>>,
     alloc: A,
 }
 
@@ -4380,7 +4380,7 @@ pub struct UniqueArc<
 > {
     ptr: NonNull<ArcInner<T>>,
     // Define the ownership of `ArcInner<T>` for drop-check
-    _marker: PhantomData<ArcInner<T>>,
+    _marker: PhantomData<Box<ArcInner<T>>>,
     // Invariance is necessary for soundness: once other `Weak`
     // references exist, we already have a form of shared mutability!
     _marker2: PhantomData<*mut T>,

--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -910,7 +910,6 @@ impl<T: PointeeSized> !Freeze for UnsafeCell<T> {}
 marker_impls! {
     #[unstable(feature = "freeze", issue = "121675")]
     unsafe Freeze for
-        {T: PointeeSized} PhantomData<T>,
         {T: PointeeSized} *const T,
         {T: PointeeSized} *mut T,
         {T: PointeeSized} &T,

--- a/library/core/src/ptr/unique.rs
+++ b/library/core/src/ptr/unique.rs
@@ -1,6 +1,6 @@
 use crate::clone::TrivialClone;
 use crate::fmt;
-use crate::marker::{PhantomData, PointeeSized, Unsize};
+use crate::marker::{Freeze, PhantomData, PointeeSized, Unsize};
 use crate::ops::{CoerceUnsized, DispatchFromDyn};
 use crate::ptr::NonNull;
 
@@ -55,6 +55,11 @@ unsafe impl<T: Send + PointeeSized> Send for Unique<T> {}
 /// `Unique` must enforce it.
 #[unstable(feature = "ptr_internals", issue = "none")]
 unsafe impl<T: Sync + PointeeSized> Sync for Unique<T> {}
+
+/// `Unique` pointers are always `Freeze` since any interior mutability that might exist in `T` is
+/// masked by the pointer indirection.
+#[unstable(feature = "ptr_internals", issue = "none")]
+unsafe impl<T: ?Sized> Freeze for Unique<T> {}
 
 #[unstable(feature = "ptr_internals", issue = "none")]
 impl<T: Sized> Unique<T> {

--- a/tests/ui/abi/compatibility.rs
+++ b/tests/ui/abi/compatibility.rs
@@ -119,7 +119,7 @@ mod prelude {
     }
     pub struct Rc<T: ?Sized, A = Global> {
         ptr: NonNull<RcInner<T>>,
-        phantom: PhantomData<RcInner<T>>,
+        phantom: PhantomData<Box<RcInner<T>>>,
         alloc: A,
     }
 
@@ -133,7 +133,7 @@ mod prelude {
     }
     pub struct Arc<T: ?Sized, A = Global> {
         ptr: NonNull<ArcInner<T>>,
-        phantom: PhantomData<ArcInner<T>>,
+        phantom: PhantomData<Box<ArcInner<T>>>,
         alloc: A,
     }
 }

--- a/tests/ui/unsafe-cell/phantom-data-not-freeze.rs
+++ b/tests/ui/unsafe-cell/phantom-data-not-freeze.rs
@@ -1,0 +1,15 @@
+use std::cell::UnsafeCell;
+use std::marker::PhantomData;
+
+// This checks that `PhantomData` does not entirely mask interior mutability.
+
+trait Trait {
+    const C: (u32, PhantomData<UnsafeCell<u32>>);
+}
+
+fn bar<T: Trait>() {
+    let x: &'static (u32, PhantomData<UnsafeCell<u32>>) = &T::C;
+    //~^ ERROR: dropped while borrowed
+}
+
+fn main() {}

--- a/tests/ui/unsafe-cell/phantom-data-not-freeze.stderr
+++ b/tests/ui/unsafe-cell/phantom-data-not-freeze.stderr
@@ -1,0 +1,14 @@
+error[E0716]: temporary value dropped while borrowed
+  --> $DIR/phantom-data-not-freeze.rs:11:60
+   |
+LL |     let x: &'static (u32, PhantomData<UnsafeCell<u32>>) = &T::C;
+   |            --------------------------------------------    ^^^^ creates a temporary value which is freed while still in use
+   |            |
+   |            type annotation requires that borrow lasts for `'static`
+LL |
+LL | }
+   | - temporary value is freed at the end of this statement
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0716`.


### PR DESCRIPTION
At @RalfJung's request, I ported rust-lang/rust#114559 over so that a new crater run can be performed, as the last known run is 3 years old.

Here's what @RalfJung said back then about that previous PR.

> The exact behavior of types that are only partially covered by UnsafeCell is still https://github.com/rust-lang/unsafe-code-guidelines/issues/236. So we shouldn't rush to the conclusion that PhantomData<UnsafeCell<T>> has no interior mutability. Let's take back that blanket impl. This will need a crater run because it is a breaking change -- but the locations where Freeze makes the difference are few and far between, so the impact is likely to be low. (UnsafeCell is also !Sync and that has the much bigger impact, and is not masked by PhantomData.)
>
> I couldn't find an existing ui test folder that fits, so I created a new one. tidy doesn't seem to like that though, it complains about new files and new folders, which is kind of counterproductive? I had to silence it the hard way.