### PR TITLE
Normalize field type for InhabitedPredicate

### DIFF
--- a/compiler/rustc_middle/src/ty/inhabitedness/inhabited_predicate.rs
+++ b/compiler/rustc_middle/src/ty/inhabitedness/inhabited_predicate.rs
@@ -267,10 +267,7 @@ impl<'tcx> InhabitedPredicate<'tcx> {
                 Some(InhabitedPredicate::True) => Some(InhabitedPredicate::True),
                 Some(a) => Some(a.or(tcx, b.instantiate_opt(tcx, args).unwrap_or(b))),
             },
-            Self::True | Self::False | Self::NotInModule(_) => None,
-            Self::OpaqueType(_) => {
-                bug!("unexpected OpaqueType in InhabitedPredicate");
-            }
+            Self::True | Self::False | Self::NotInModule(_) | Self::OpaqueType(_) => None,
         }
     }
 }

--- a/compiler/rustc_middle/src/ty/inhabitedness/mod.rs
+++ b/compiler/rustc_middle/src/ty/inhabitedness/mod.rs
@@ -47,7 +47,7 @@ use rustc_type_ir::TyKind::*;
 use tracing::instrument;
 
 use crate::query::Providers;
-use crate::ty::{self, DefId, Ty, TyCtxt, TypeVisitableExt, VariantDef, Visibility};
+use crate::ty::{self, DefId, Ty, TyCtxt, TypeVisitableExt, TypingEnv, VariantDef, Visibility};
 
 pub mod inhabited_predicate;
 
@@ -82,11 +82,12 @@ impl<'tcx> VariantDef {
         InhabitedPredicate::all(
             tcx,
             self.fields.iter().map(|field| {
-                let pred = tcx
-                    .type_of(field.did)
-                    .instantiate_identity()
-                    .skip_norm_wip()
-                    .inhabited_predicate(tcx);
+                let field_ty = tcx.normalize_erasing_regions(
+                    TypingEnv::non_body_analysis(tcx, adt.did()),
+                    tcx.type_of(field.did).instantiate_identity(),
+                );
+                let pred = field_ty.inhabited_predicate(tcx);
+
                 if adt.is_enum() {
                     return pred;
                 }


### PR DESCRIPTION
Normalizing the field type can sometimes lead to a simpler `InhabitedPredicate`. For instance if a projection alias can be resolved.