### PR TITLE
add core test run with `-Zforce-intrinsic-fallback`

### DIFF
--- a/src/ci/docker/scripts/x86_64-gnu-llvm3.sh
+++ b/src/ci/docker/scripts/x86_64-gnu-llvm3.sh
@@ -19,3 +19,7 @@ set -ex
 # Rebuild the stdlib with the size optimizations enabled and run tests again.
 RUSTFLAGS_NOT_BOOTSTRAP="--cfg feature=\"optimize_for_size\"" ../x.py --stage 1 test \
     library/std library/alloc library/core
+
+# Rebuild the stdlib forcing the use of intrinsic fallbacks and run core tests again.
+RUSTFLAGS_NOT_BOOTSTRAP="-Zforce-intrinsic-fallback" ../x.py --stage 1 test \
+    library/core


### PR DESCRIPTION
Some discussion at [#t-infra > CI for -Zforce-intrinsic-fallback](https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/CI.20for.20-Zforce-intrinsic-fallback/with/608129693).

In https://github.com/rust-lang/rust/pull/158377 we added `-Zforce-intrinsic-fallback` which will use an intrinsic's fallback body if there is one. 

I'm basing this on https://github.com/rust-lang/rust/pull/125011, but for now only run the core tests which I think should be sufficient? But maybe I'm missing something, or maybe the alloc/std tests are fast enough that we might as well run them.

One concern I have is how clearly it is reported that the `optimize_for_size` or `-Zforce-intrinsic-fallback` runs fail. Because in those cases the standard run succeeded, and so if you miss that an extra flag was passed that can waste a lot of debugging time.

r? Kobzol 