### PR TITLE
std: fix Xous UDP send_to length mismatch and truncation

### DIFF
--- a/library/std/src/sys/net/connection/xous/udp.rs
+++ b/library/std/src/sys/net/connection/xous/udp.rs
@@ -241,13 +241,12 @@ impl UdpSocket {
                 }
             }
         }
-        let len = buf.len() as u16;
-        let len_bytes = len.to_le_bytes();
+        let header_len = 21;
+        let len = buf.len().min(tx_req.raw.len() - header_len);
+        let len_bytes = (len as u16).to_le_bytes();
         tx_req.raw[19] = len_bytes[0];
         tx_req.raw[20] = len_bytes[1];
-        for (&s, d) in buf.iter().zip(tx_req.raw[21..].iter_mut()) {
-            *d = s;
-        }
+        tx_req.raw[header_len..header_len + len].copy_from_slice(&buf[..len]);
 
         // let buf = unsafe {
         //     xous::MemoryRange::new(
@@ -306,7 +305,7 @@ impl UdpSocket {
                         }
                     } else {
                         // no error
-                        return Ok(len as usize);
+                        return Ok(len);
                     }
                 }
                 Err(crate::os::xous::ffi::Error::ServerQueueFull) => {


### PR DESCRIPTION
Cap the payload length to the buffer capacity so the declared length, bytes copied, and returned count agree, matching TcpStream::write.