### PR TITLE
Inline some `Symbol` functions

### DIFF
--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -2655,6 +2655,7 @@ impl Symbol {
 
     /// Maps a string to its interned representation.
     #[rustc_diagnostic_item = "SymbolIntern"]
+    #[inline]
     pub fn intern(str: &str) -> Self {
         with_session_globals(|session_globals| session_globals.symbol_interner.intern_str(str))
     }
@@ -2667,6 +2668,7 @@ impl Symbol {
     /// interner. Interners are long-lived, and there are very few of them, and
     /// this function is typically used for short-lived things, so in practice
     /// it works out ok.
+    #[inline]
     pub fn as_str(&self) -> &str {
         with_session_globals(|session_globals| unsafe {
             std::mem::transmute::<&str, &str>(session_globals.symbol_interner.get_str(*self))


### PR DESCRIPTION
I noticed in some profiles that de-interning the symbols was relatively hot. I was trying to experiment with some sharding scheme, where the symbols would be split into N interners based on their first character, but I couldn't get it to work, probably due to some complexities around pre-interned `'static` keywords and symbol comparison.

So I at least tried interning these two functions, which seems to produce very minor perf. gains on instruction counts.

r? @nnethercote
