### PR TITLE
Do not build the compiler when invoking `x perf compare`

### DIFF
--- a/src/bootstrap/src/core/build_steps/perf.rs
+++ b/src/bootstrap/src/core/build_steps/perf.rs
@@ -140,32 +140,6 @@ pub fn perf(builder: &Builder<'_>, args: &PerfArgs) {
         target: builder.config.host_target,
     });
 
-    let is_profiling = match &args.cmd {
-        PerfCommand::Eprintln { .. }
-        | PerfCommand::Samply { .. }
-        | PerfCommand::Cachegrind { .. } => true,
-        PerfCommand::Benchmark { .. } | PerfCommand::Compare { .. } => false,
-    };
-    if is_profiling && builder.build.config.rust_debuginfo_level_rustc == DebuginfoLevel::None {
-        builder.info(r#"WARNING: You are compiling rustc without debuginfo, this will make profiling less useful.
-Consider setting `rust.debuginfo-level = 1` in `bootstrap.toml`."#);
-    }
-
-    let compiler = builder.compiler(builder.top_stage, builder.config.host_target);
-    builder.std(compiler, builder.config.host_target);
-
-    if let Some(opts) = args.cmd.shared_opts()
-        && opts.profiles.contains(&Profile::Doc)
-    {
-        builder.ensure(Rustdoc { target_compiler: compiler });
-    }
-
-    let sysroot = builder.ensure(Sysroot::new(compiler));
-    let mut rustc = sysroot.clone();
-    rustc.push("bin");
-    rustc.push("rustc");
-    rustc.set_extension(EXE_EXTENSION);
-
     let rustc_perf_dir = builder.build.tempdir().join("rustc-perf");
     let results_dir = rustc_perf_dir.join("results");
     builder.create_dir(&results_dir);
@@ -177,6 +151,35 @@ Consider setting `rust.debuginfo-level = 1` in `bootstrap.toml`."#);
     cmd.current_dir(builder.src.join("src/tools/rustc-perf"));
 
     let db_path = results_dir.join("results.db");
+
+    let is_profiling = match &args.cmd {
+        PerfCommand::Eprintln { .. }
+        | PerfCommand::Samply { .. }
+        | PerfCommand::Cachegrind { .. } => true,
+        PerfCommand::Benchmark { .. } | PerfCommand::Compare { .. } => false,
+    };
+    if is_profiling && builder.build.config.rust_debuginfo_level_rustc == DebuginfoLevel::None {
+        builder.info(r#"WARNING: You are compiling rustc without debuginfo, this will make profiling less useful.
+Consider setting `rust.debuginfo-level = 1` in `bootstrap.toml`."#);
+    }
+
+    let prepare_rustc = || {
+        let compiler = builder.compiler(builder.top_stage, builder.config.host_target);
+        builder.std(compiler, builder.config.host_target);
+
+        if let Some(opts) = args.cmd.shared_opts()
+            && opts.profiles.contains(&Profile::Doc)
+        {
+            builder.ensure(Rustdoc { target_compiler: compiler });
+        }
+
+        let sysroot = builder.ensure(Sysroot::new(compiler));
+        let mut rustc = sysroot.clone();
+        rustc.push("bin");
+        rustc.push("rustc");
+        rustc.set_extension(EXE_EXTENSION);
+        rustc
+    };
 
     match &args.cmd {
         PerfCommand::Eprintln { opts }
@@ -191,7 +194,7 @@ Consider setting `rust.debuginfo-level = 1` in `bootstrap.toml`."#);
             });
 
             cmd.arg("--out-dir").arg(&results_dir);
-            cmd.arg(rustc);
+            cmd.arg(prepare_rustc());
 
             apply_shared_opts(&mut cmd, opts);
             cmd.run(builder);
@@ -202,7 +205,7 @@ Consider setting `rust.debuginfo-level = 1` in `bootstrap.toml`."#);
             cmd.arg("bench_local");
             cmd.arg("--db").arg(&db_path);
             cmd.arg("--id").arg(id);
-            cmd.arg(rustc);
+            cmd.arg(prepare_rustc());
 
             apply_shared_opts(&mut cmd, opts);
             cmd.run(builder);


### PR DESCRIPTION
It's wasteful, and can interfere e.g. with workflows where you use `--keep-stage 1` to avoid rebuilding the standard library. If you forgot to specify that flag and use `x perf compare`, it would go build the standard library, which doesn't really make sense. That doesn't happen anymore with this PR.
