### PR TITLE
diagnostics: fix `let x: vec![]` suggestion pointing into stdlib

### DIFF
--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/errors.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/errors.rs
@@ -2055,3 +2055,21 @@ fn assoc_tag_str(assoc_tag: ty::AssocTag) -> &'static str {
         ty::AssocTag::Type => "type",
     }
 }
+
+/// Computes the `pat.between(ty)` span for the "use `=`" suggestion on `let pat: ty`.
+/// Returns `None` if `pat` and `ty` are in incompatible macro contexts (e.g. `pat` is a
+/// metavariable from the call site while `ty` lives in the macro body), in which case no
+/// suggestion is emitted.
+pub(crate) fn eq_ctxt_suggestion_span(pat: Span, ty: Span) -> Option<Span> {
+    if let Some(ty2) = ty.find_ancestor_in_same_ctxt(pat)
+        && pat.hi() <= ty2.lo()
+    {
+        return Some(pat.between(ty2));
+    }
+    if let Some(pat2) = pat.find_ancestor_in_same_ctxt(ty)
+        && pat2.hi() <= ty.lo()
+    {
+        return Some(pat2.between(ty));
+    }
+    None
+}

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
@@ -3290,18 +3290,18 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                         .next()
                 {
                     // `let x: S::new(valid_in_ty_ctxt);` -> `let x = S::new(valid_in_ty_ctxt);`
-                    let err = tcx
-                        .dcx()
-                        .struct_span_err(
-                            hir_ty.span,
-                            "expected type, found associated function call",
-                        )
-                        .with_span_suggestion_verbose(
-                            stmt.pat.span.between(hir_ty.span),
+                    let mut err = tcx.dcx().struct_span_err(
+                        hir_ty.span,
+                        "expected type, found associated function call",
+                    );
+                    if let Some(between) = eq_ctxt_suggestion_span(stmt.pat.span, hir_ty.span) {
+                        err.span_suggestion_verbose(
+                            between,
                             "use `=` if you meant to assign",
-                            " = ".to_string(),
+                            " = ",
                             Applicability::MaybeIncorrect,
                         );
+                    }
                     self.dcx().try_steal_replace_and_emit_err(
                         hir_ty.span,
                         StashKey::ReturnTypeNotation,
@@ -3316,18 +3316,18 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                 {
                     // `let x: i32::something(valid_in_ty_ctxt);` -> `let x = i32::something(valid_in_ty_ctxt);`
                     // FIXME: Check that `something` is a valid function in `i32`.
-                    let err = tcx
-                        .dcx()
-                        .struct_span_err(
-                            hir_ty.span,
-                            "expected type, found associated function call",
-                        )
-                        .with_span_suggestion_verbose(
-                            stmt.pat.span.between(hir_ty.span),
+                    let mut err = tcx.dcx().struct_span_err(
+                        hir_ty.span,
+                        "expected type, found associated function call",
+                    );
+                    if let Some(between) = eq_ctxt_suggestion_span(stmt.pat.span, hir_ty.span) {
+                        err.span_suggestion_verbose(
+                            between,
                             "use `=` if you meant to assign",
-                            " = ".to_string(),
+                            " = ",
                             Applicability::MaybeIncorrect,
                         );
+                    }
                     self.dcx().try_steal_replace_and_emit_err(
                         hir_ty.span,
                         StashKey::ReturnTypeNotation,
@@ -3812,4 +3812,22 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
         let adt_ty = Ty::new_adt(tcx, adt_def, args);
         ty::Const::new_value(tcx, valtree, adt_ty)
     }
+}
+
+/// Computes the `pat.between(ty)` span for the "use `=`" suggestion on `let pat: ty`.
+/// Returns `None` if `pat` and `ty` are in incompatible macro contexts (e.g. `pat` is a
+/// metavariable from the call site while `ty` lives in the macro body), in which case no
+/// suggestion is emitted.
+fn eq_ctxt_suggestion_span(pat: Span, ty: Span) -> Option<Span> {
+    if let Some(ty2) = ty.find_ancestor_in_same_ctxt(pat)
+        && pat.hi() <= ty2.lo()
+    {
+        return Some(pat.between(ty2));
+    }
+    if let Some(pat2) = pat.find_ancestor_in_same_ctxt(ty)
+        && pat2.hi() <= ty.lo()
+    {
+        return Some(pat2.between(ty));
+    }
+    None
 }

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
@@ -56,7 +56,9 @@ use tracing::{debug, instrument};
 use crate::check::check_abi;
 use crate::check_c_variadic_abi;
 use crate::diagnostics::{self, BadReturnTypeNotation, NoFieldOnType, NoVariantNamed};
-use crate::hir_ty_lowering::errors::{GenericsArgsErrExtend, prohibit_assoc_item_constraint};
+use crate::hir_ty_lowering::errors::{
+    GenericsArgsErrExtend, eq_ctxt_suggestion_span, prohibit_assoc_item_constraint,
+};
 use crate::hir_ty_lowering::generics::{check_generic_arg_count, lower_generic_args};
 use crate::middle::resolve_bound_vars as rbv;
 
@@ -3302,18 +3304,18 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                         .next()
                 {
                     // `let x: S::new(valid_in_ty_ctxt);` -> `let x = S::new(valid_in_ty_ctxt);`
-                    let err = tcx
-                        .dcx()
-                        .struct_span_err(
-                            hir_ty.span,
-                            "expected type, found associated function call",
-                        )
-                        .with_span_suggestion_verbose(
-                            stmt.pat.span.between(hir_ty.span),
+                    let mut err = tcx.dcx().struct_span_err(
+                        hir_ty.span,
+                        "expected type, found associated function call",
+                    );
+                    if let Some(between) = eq_ctxt_suggestion_span(stmt.pat.span, hir_ty.span) {
+                        err.span_suggestion_verbose(
+                            between,
                             "use `=` if you meant to assign",
-                            " = ".to_string(),
+                            " = ",
                             Applicability::MaybeIncorrect,
                         );
+                    }
                     self.dcx().try_steal_replace_and_emit_err(
                         hir_ty.span,
                         StashKey::ReturnTypeNotation,
@@ -3328,18 +3330,18 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                 {
                     // `let x: i32::something(valid_in_ty_ctxt);` -> `let x = i32::something(valid_in_ty_ctxt);`
                     // FIXME: Check that `something` is a valid function in `i32`.
-                    let err = tcx
-                        .dcx()
-                        .struct_span_err(
-                            hir_ty.span,
-                            "expected type, found associated function call",
-                        )
-                        .with_span_suggestion_verbose(
-                            stmt.pat.span.between(hir_ty.span),
+                    let mut err = tcx.dcx().struct_span_err(
+                        hir_ty.span,
+                        "expected type, found associated function call",
+                    );
+                    if let Some(between) = eq_ctxt_suggestion_span(stmt.pat.span, hir_ty.span) {
+                        err.span_suggestion_verbose(
+                            between,
                             "use `=` if you meant to assign",
-                            " = ".to_string(),
+                            " = ",
                             Applicability::MaybeIncorrect,
                         );
+                    }
                     self.dcx().try_steal_replace_and_emit_err(
                         hir_ty.span,
                         StashKey::ReturnTypeNotation,

--- a/tests/ui/suggestions/let-binding-init-expr-as-ty.rs
+++ b/tests/ui/suggestions/let-binding-init-expr-as-ty.rs
@@ -28,6 +28,17 @@ fn main() {
     //~^ ERROR return type notation is experimental
     let x: S::new(()); //~ ERROR expected type, found associated function call
 
+    // Macros — suggestion must point at user code, not the macro definition (#158834)
+    let x: vec![]; //~ ERROR expected type, found associated function call
+
+    // When the `let` is inside a macro, no suggestion should be emitted at the call site
+    macro_rules! make {
+        ($pat:pat) => {
+            let $pat: Vec::new(); //~ ERROR expected type, found associated function call
+        };
+    }
+    make!(_);
+
     // Literals
     let x: 42; //~ ERROR expected type, found `42`
     let x: ""; //~ ERROR expected type, found `""`

--- a/tests/ui/suggestions/let-binding-init-expr-as-ty.rs
+++ b/tests/ui/suggestions/let-binding-init-expr-as-ty.rs
@@ -28,6 +28,17 @@ fn main() {
     //~^ ERROR return type notation is experimental
     let x: S::new(()); //~ ERROR expected type, found associated function call
 
+    // Macros — suggestion must point at user code, not the macro definition (#158492)
+    let x: vec![]; //~ ERROR expected type, found associated function call
+
+    // When the `let` is inside a macro, no suggestion should be emitted at the call site
+    macro_rules! make {
+        ($pat:pat) => {
+            let $pat: Vec::new(); //~ ERROR expected type, found associated function call
+        };
+    }
+    make!(_);
+
     // Literals
     let x: 42; //~ ERROR expected type, found `42`
     let x: ""; //~ ERROR expected type, found `""`

--- a/tests/ui/suggestions/let-binding-init-expr-as-ty.stderr
+++ b/tests/ui/suggestions/let-binding-init-expr-as-ty.stderr
@@ -1,5 +1,5 @@
 error: expected type, found `42`
-  --> $DIR/let-binding-init-expr-as-ty.rs:32:12
+  --> $DIR/let-binding-init-expr-as-ty.rs:43:12
    |
 LL |     let x: 42;
    |          - ^^ expected type
@@ -13,7 +13,7 @@ LL +     let x = 42;
    |
 
 error: expected type, found `""`
-  --> $DIR/let-binding-init-expr-as-ty.rs:33:12
+  --> $DIR/let-binding-init-expr-as-ty.rs:44:12
    |
 LL |     let x: "";
    |          - ^^ expected type
@@ -39,7 +39,7 @@ LL +     let foo = i32::from_be(num);
    |
 
 error[E0573]: expected type, found function `bar`
-  --> $DIR/let-binding-init-expr-as-ty.rs:36:12
+  --> $DIR/let-binding-init-expr-as-ty.rs:47:12
    |
 LL |     let x: bar();
    |            ^^^^^ not a type
@@ -51,13 +51,13 @@ LL +     let x = bar();
    |
 
 error[E0573]: expected type, found function `bar`
-  --> $DIR/let-binding-init-expr-as-ty.rs:37:12
+  --> $DIR/let-binding-init-expr-as-ty.rs:48:12
    |
 LL |     let x: bar;
    |            ^^^ not a type
 
 error[E0573]: expected type, found local variable `x`
-  --> $DIR/let-binding-init-expr-as-ty.rs:40:12
+  --> $DIR/let-binding-init-expr-as-ty.rs:51:12
    |
 LL | struct K(S::new(()));
    | --------------------- similarly named struct `K` defined here
@@ -153,7 +153,30 @@ LL -     let x: S::new(());
 LL +     let x = S::new(());
    |
 
-error: aborting due to 13 previous errors
+error: expected type, found associated function call
+  --> $DIR/let-binding-init-expr-as-ty.rs:32:12
+   |
+LL |     let x: vec![];
+   |            ^^^^^^
+   |
+help: use `=` if you meant to assign
+   |
+LL -     let x: vec![];
+LL +     let x = vec![];
+   |
+
+error: expected type, found associated function call
+  --> $DIR/let-binding-init-expr-as-ty.rs:37:23
+   |
+LL |             let $pat: Vec::new();
+   |                       ^^^^^^^^^^
+...
+LL |     make!(_);
+   |     -------- in this macro invocation
+   |
+   = note: this error originates in the macro `make` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 15 previous errors
 
 Some errors have detailed explanations: E0573, E0658.
 For more information about an error, try `rustc --explain E0573`.

--- a/tests/ui/suggestions/let-binding-init-expr-as-ty.stderr
+++ b/tests/ui/suggestions/let-binding-init-expr-as-ty.stderr
@@ -1,5 +1,5 @@
 error: expected type, found `42`
-  --> $DIR/let-binding-init-expr-as-ty.rs:32:12
+  --> $DIR/let-binding-init-expr-as-ty.rs:43:12
    |
 LL |     let x: 42;
    |          - ^^ expected type
@@ -13,7 +13,7 @@ LL +     let x = 42;
    |
 
 error: expected type, found `""`
-  --> $DIR/let-binding-init-expr-as-ty.rs:33:12
+  --> $DIR/let-binding-init-expr-as-ty.rs:44:12
    |
 LL |     let x: "";
    |          - ^^ expected type
@@ -40,7 +40,7 @@ LL +     let foo = i32::from_be(num);
    |
 
 error[E0573]: cannot find type `bar` in this scope
-  --> $DIR/let-binding-init-expr-as-ty.rs:36:12
+  --> $DIR/let-binding-init-expr-as-ty.rs:47:12
    |
 LL |     let x: bar();
    |            ^^^ not found in this scope
@@ -53,7 +53,7 @@ LL +     let x = bar();
    |
 
 error[E0573]: cannot find type `bar` in this scope
-  --> $DIR/let-binding-init-expr-as-ty.rs:37:12
+  --> $DIR/let-binding-init-expr-as-ty.rs:48:12
    |
 LL |     let x: bar;
    |            ^^^ not found in this scope
@@ -61,7 +61,7 @@ LL |     let x: bar;
    = note: a function named `bar` exists in another namespace
 
 error[E0573]: cannot find type `x` in this scope
-  --> $DIR/let-binding-init-expr-as-ty.rs:40:12
+  --> $DIR/let-binding-init-expr-as-ty.rs:51:12
    |
 LL | struct K(S::new(()));
    | --------------------- similarly named struct `K` defined here
@@ -158,7 +158,30 @@ LL -     let x: S::new(());
 LL +     let x = S::new(());
    |
 
-error: aborting due to 13 previous errors
+error: expected type, found associated function call
+  --> $DIR/let-binding-init-expr-as-ty.rs:32:12
+   |
+LL |     let x: vec![];
+   |            ^^^^^^
+   |
+help: use `=` if you meant to assign
+   |
+LL -     let x: vec![];
+LL +     let x = vec![];
+   |
+
+error: expected type, found associated function call
+  --> $DIR/let-binding-init-expr-as-ty.rs:37:23
+   |
+LL |             let $pat: Vec::new();
+   |                       ^^^^^^^^^^
+...
+LL |     make!(_);
+   |     -------- in this macro invocation
+   |
+   = note: this error originates in the macro `make` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 15 previous errors
 
 Some errors have detailed explanations: E0573, E0658.
 For more information about an error, try `rustc --explain E0573`.


### PR DESCRIPTION
# Fixes rust-lang/rust#158492

When a macro call like `vec![]` appears in type position (`let x: vec![];`), the compiler correctly detects the likely typo (`:` instead of `=`), but emits a broken suggestion pointing into the standard library (`library/alloc/src/macros.rs:44`) instead of the user's own code.

## Root cause

After macro expansion, `vec![]` becomes `Vec::new()`. The HIR type node's span therefore points to the expanded code inside the macro definition rather than the original `vec![]` call site.

The suggestion span was computed as:

`stmt.pat.span.between(hir_ty.span)`

This creates a span crossing from the user's code into the standard library, causing the suggestion renderer to display the standard library location.

## Fix

Compute the span using `find_ancestor_in_same_ctxt` so that the pattern and type are resolved into a common syntax context before calling `between`.

For `let x: vec![];`, this walks the type's span up the expansion chain until it reaches the user's file, keeping the suggestion within a single file.

This also handles the reverse case, which `source_callsite` alone does not: when the `let` itself comes from a macro body while the pattern is a call-site metavariable, there is no common context. In that case, no suggestion is emitted rather than producing a nonsensical one.

## Before

```text
help: use `=` if you meant to assign
  --> library/alloc/src/macros.rs:44:9
   |
44 -         $crate::vec::Vec::new()
44 +          =
```

## After

```text
help: use `=` if you meant to assign
   |
LL -     let x: vec![];
LL +     let x = vec![];
```

## Tests

Two test cases were added to `tests/ui/suggestions/let-binding-init-expr-as-ty.rs`, which already covers the related `let x: Vec::new()` and `let x: S::new(())` cases:

1. The `vec![]` case described above.
2. A `let` inside a `macro_rules!` body where no suggestion should be emitted.

## Note on file layout

The new `eq_ctxt_suggestion_span` helper lives in `hir_ty_lowering/errors.rs` rather than next to its callers in `mod.rs`.

`mod.rs` was already within a few lines of tidy's 3000-line limit, so keeping the helper there caused the style check to fail.

This is pure code motion with no behavior change.