### PR TITLE
Implement feature `char_to_u32`

### DIFF
--- a/library/core/src/char/methods.rs
+++ b/library/core/src/char/methods.rs
@@ -1812,6 +1812,28 @@ impl char {
         ToCasefold(CaseMappingIter::new(conversions::to_casefold(self)))
     }
 
+    /// Returns the code point value as a `u32`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(char_to_u32)]
+    ///
+    /// let ascii = 'a';
+    /// let heart = '❤';
+    ///
+    /// assert_eq!(ascii.to_u32(), 97_u32);
+    /// assert_eq!(heart.to_u32(), 0x2764_u32);
+    /// ```
+    #[must_use = "this returns the result of the operation, \
+                  without modifying the original"]
+    #[unstable(feature = "char_to_u32", issue = "158938")]
+    #[rustc_const_unstable(feature = "char_to_u32", issue = "158938")]
+    #[inline(always)]
+    pub const fn to_u32(self) -> u32 {
+        self as u32
+    }
+
     /// Checks if the value is within the ASCII range.
     ///
     /// # Examples


### PR DESCRIPTION
Accepted ACP: https://github.com/rust-lang/libs-team/issues/778#issuecomment-4906829734
Tracking issue: https://github.com/rust-lang/rust/issues/158938

Add method `char::to_u32` which returns the underlying value of `char`.
