### PR TITLE
Remove some AST `tokens` fields

### DIFF
--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -97,7 +97,6 @@ pub struct Path {
     /// The segments in the path: the things separated by `::`.
     /// Global paths begin with `kw::PathRoot`.
     pub segments: ThinVec<PathSegment>,
-    pub tokens: Option<LazyAttrTokenStream>,
 }
 
 // Succeeds if the path has a single segment that is arg-free and matches the given symbol.
@@ -135,7 +134,7 @@ impl Path {
     /// Convert a span and an identifier to the corresponding
     /// one-segment path.
     pub fn from_ident(ident: Ident) -> Path {
-        Path { segments: thin_vec![PathSegment::from_ident(ident)], span: ident.span, tokens: None }
+        Path { segments: thin_vec![PathSegment::from_ident(ident)], span: ident.span }
     }
 
     pub fn is_global(&self) -> bool {
@@ -616,7 +615,6 @@ pub struct Block {
     /// Distinguishes between `unsafe { ... }` and `{ ... }`.
     pub rules: BlockCheckMode,
     pub span: Span,
-    pub tokens: Option<LazyAttrTokenStream>,
 }
 
 /// A match pattern.
@@ -627,7 +625,6 @@ pub struct Pat {
     pub id: NodeId,
     pub kind: PatKind,
     pub span: Span,
-    pub tokens: Option<LazyAttrTokenStream>,
 }
 
 impl Pat {
@@ -663,7 +660,7 @@ impl Pat {
             _ => return None,
         };
 
-        Some(Box::new(Ty { kind, id: self.id, span: self.span, tokens: None }))
+        Some(Box::new(Ty { kind, id: self.id, span: self.span }))
     }
 
     /// Walk top-down and call `it` in each place where a pattern occurs
@@ -1533,7 +1530,7 @@ impl Expr {
             _ => return None,
         };
 
-        Some(Box::new(Ty { kind, id: self.id, span: self.span, tokens: None }))
+        Some(Box::new(Ty { kind, id: self.id, span: self.span }))
     }
 
     pub fn precedence(&self) -> ExprPrecedence {
@@ -2443,17 +2440,11 @@ pub struct Ty {
     pub id: NodeId,
     pub kind: TyKind,
     pub span: Span,
-    pub tokens: Option<LazyAttrTokenStream>,
 }
 
 impl Clone for Ty {
     fn clone(&self) -> Self {
-        ensure_sufficient_stack(|| Self {
-            id: self.id,
-            kind: self.kind.clone(),
-            span: self.span,
-            tokens: self.tokens.clone(),
-        })
+        ensure_sufficient_stack(|| Self { id: self.id, kind: self.kind.clone(), span: self.span })
     }
 }
 
@@ -2990,12 +2981,8 @@ impl Param {
     /// Builds a `Param` object from `ExplicitSelf`.
     pub fn from_self(attrs: AttrVec, eself: ExplicitSelf, eself_ident: Ident) -> Param {
         let span = eself.span.to(eself_ident.span);
-        let infer_ty = Box::new(Ty {
-            id: DUMMY_NODE_ID,
-            kind: TyKind::ImplicitSelf,
-            span: eself_ident.span,
-            tokens: None,
-        });
+        let infer_ty =
+            Box::new(Ty { id: DUMMY_NODE_ID, kind: TyKind::ImplicitSelf, span: eself_ident.span });
         let (mutbl, ty) = match eself.node {
             SelfKind::Explicit(ty, mutbl) => (mutbl, ty),
             SelfKind::Value(mutbl) => (mutbl, infer_ty),
@@ -3005,7 +2992,6 @@ impl Param {
                     id: DUMMY_NODE_ID,
                     kind: TyKind::Ref(lt, MutTy { ty: infer_ty, mutbl }),
                     span,
-                    tokens: None,
                 }),
             ),
             SelfKind::Pinned(lt, mutbl) => (
@@ -3014,7 +3000,6 @@ impl Param {
                     id: DUMMY_NODE_ID,
                     kind: TyKind::PinnedRef(lt, MutTy { ty: infer_ty, mutbl }),
                     span,
-                    tokens: None,
                 }),
             ),
         };
@@ -3024,7 +3009,6 @@ impl Param {
                 id: DUMMY_NODE_ID,
                 kind: PatKind::Ident(BindingMode(ByRef::No, mutbl), eself_ident, None),
                 span,
-                tokens: None,
             }),
             span,
             ty,
@@ -3583,7 +3567,6 @@ impl PolyTraitRef {
 pub struct Visibility {
     pub kind: VisibilityKind,
     pub span: Span,
-    pub tokens: Option<LazyAttrTokenStream>,
 }
 
 #[derive(Clone, Encodable, Decodable, Debug, Walkable)]
@@ -4387,44 +4370,44 @@ mod size_asserts {
 
     use super::*;
     // tidy-alphabetical-start
-    static_assert_size!(AssocItem, 80);
+    static_assert_size!(AssocItem, 72);
     static_assert_size!(AssocItemKind, 16);
     static_assert_size!(AttrKind, 16);
     static_assert_size!(Attribute, 32);
-    static_assert_size!(Block, 32);
+    static_assert_size!(Block, 24);
     static_assert_size!(Expr, 72);
     static_assert_size!(ExprKind, 40);
     static_assert_size!(Fn, 192);
     static_assert_size!(FnDecl, 24);
     static_assert_size!(FnHeader, 76);
     static_assert_size!(FnSig, 96);
-    static_assert_size!(ForeignItem, 80);
+    static_assert_size!(ForeignItem, 72);
     static_assert_size!(ForeignItemKind, 16);
     static_assert_size!(GenericArg, 24);
     static_assert_size!(GenericArgs, 40);
-    static_assert_size!(GenericBound, 88);
+    static_assert_size!(GenericBound, 80);
     static_assert_size!(GenericParam, 80);
     static_assert_size!(Generics, 40);
     static_assert_size!(Impl, 80);
-    static_assert_size!(Item, 152);
+    static_assert_size!(Item, 144);
     static_assert_size!(ItemKind, 88);
     static_assert_size!(Lifetime, 16);
     static_assert_size!(LitKind, 24);
     static_assert_size!(Local, 96);
-    static_assert_size!(MetaItem, 88);
+    static_assert_size!(MetaItem, 80);
     static_assert_size!(MetaItemKind, 40);
     static_assert_size!(MetaItemLit, 40);
-    static_assert_size!(NormalAttr, 88);
+    static_assert_size!(NormalAttr, 80);
     static_assert_size!(Param, 40);
-    static_assert_size!(Pat, 80);
-    static_assert_size!(PatKind, 56);
-    static_assert_size!(Path, 24);
+    static_assert_size!(Pat, 64);
+    static_assert_size!(PatKind, 48);
+    static_assert_size!(Path, 16);
     static_assert_size!(PathSegment, 24);
     static_assert_size!(QSelf, 24);
     static_assert_size!(Stmt, 32);
     static_assert_size!(StmtKind, 16);
-    static_assert_size!(TraitImplHeader, 72);
-    static_assert_size!(Ty, 64);
+    static_assert_size!(TraitImplHeader, 64);
+    static_assert_size!(Ty, 56);
     static_assert_size!(TyKind, 40);
     // tidy-alphabetical-end
 }

--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -4417,6 +4417,7 @@ mod size_asserts {
     static_assert_size!(MetaItem, 88);
     static_assert_size!(MetaItemKind, 40);
     static_assert_size!(MetaItemLit, 40);
+    static_assert_size!(NormalAttr, 88);
     static_assert_size!(Param, 40);
     static_assert_size!(Pat, 80);
     static_assert_size!(PatKind, 56);

--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -2628,7 +2628,6 @@ pub struct TyPat {
     pub id: NodeId,
     pub kind: TyPatKind,
     pub span: Span,
-    pub tokens: Option<LazyAttrTokenStream>,
 }
 
 /// All the different flavors of pattern that Rust recognizes.
@@ -3604,14 +3603,12 @@ impl VisibilityKind {
 pub struct ImplRestriction {
     pub kind: RestrictionKind,
     pub span: Span,
-    pub tokens: Option<LazyAttrTokenStream>,
 }
 
 #[derive(Clone, Encodable, Decodable, Debug, Walkable)]
 pub struct MutRestriction {
     pub kind: RestrictionKind,
     pub span: Span,
-    pub tokens: Option<LazyAttrTokenStream>,
 }
 
 #[derive(Clone, Encodable, Decodable, Debug, Walkable)]

--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -3438,7 +3438,6 @@ impl NormalAttr {
                 unsafety: Safety::Default,
                 path: Path::from_ident(ident),
                 args: AttrItemKind::Unparsed(AttrArgs::Empty),
-                tokens: None,
             },
             tokens: None,
         }
@@ -3450,8 +3449,6 @@ pub struct AttrItem {
     pub unsafety: Safety,
     pub path: Path,
     pub args: AttrItemKind,
-    // Tokens for the meta item, e.g. just the `foo` within `#[foo]` or `#![foo]`.
-    pub tokens: Option<LazyAttrTokenStream>,
 }
 
 /// Some attributes are stored in a parsed form, for performance reasons.
@@ -4397,7 +4394,7 @@ mod size_asserts {
     static_assert_size!(MetaItem, 80);
     static_assert_size!(MetaItemKind, 40);
     static_assert_size!(MetaItemLit, 40);
-    static_assert_size!(NormalAttr, 80);
+    static_assert_size!(NormalAttr, 72);
     static_assert_size!(Param, 40);
     static_assert_size!(Pat, 64);
     static_assert_size!(PatKind, 48);

--- a/compiler/rustc_ast/src/ast_traits.rs
+++ b/compiler/rustc_ast/src/ast_traits.rs
@@ -97,7 +97,7 @@ macro_rules! impl_has_tokens_none {
     };
 }
 
-impl_has_tokens!(AssocItem, AttrItem, Expr, ForeignItem, Item);
+impl_has_tokens!(AssocItem, Expr, ForeignItem, Item);
 impl_has_tokens_none!(
     Arm,
     ExprField,

--- a/compiler/rustc_ast/src/ast_traits.rs
+++ b/compiler/rustc_ast/src/ast_traits.rs
@@ -8,8 +8,8 @@ use std::marker::PhantomData;
 use crate::tokenstream::LazyAttrTokenStream;
 use crate::{
     Arm, AssocItem, AttrItem, AttrKind, AttrVec, Attribute, Block, Crate, Expr, ExprField,
-    FieldDef, ForeignItem, GenericParam, ImplRestriction, Item, MutRestriction, NodeId, Param, Pat,
-    PatField, Path, Stmt, StmtKind, Ty, Variant, Visibility, WherePredicate,
+    FieldDef, ForeignItem, GenericParam, Item, NodeId, Param, Pat, PatField, Path, Stmt, StmtKind,
+    Ty, Variant, Visibility, WherePredicate,
 };
 
 /// A trait for AST nodes having an ID.
@@ -97,20 +97,7 @@ macro_rules! impl_has_tokens_none {
     };
 }
 
-impl_has_tokens!(
-    AssocItem,
-    AttrItem,
-    Block,
-    Expr,
-    ForeignItem,
-    Item,
-    Pat,
-    Path,
-    Ty,
-    Visibility,
-    ImplRestriction,
-    MutRestriction,
-);
+impl_has_tokens!(AssocItem, AttrItem, Block, Expr, ForeignItem, Item, Pat, Path, Ty, Visibility);
 impl_has_tokens_none!(
     Arm,
     ExprField,
@@ -255,17 +242,7 @@ impl_has_attrs!(
     Variant,
     WherePredicate,
 );
-impl_has_attrs_none!(
-    Attribute,
-    AttrItem,
-    Block,
-    Pat,
-    Path,
-    Ty,
-    Visibility,
-    ImplRestriction,
-    MutRestriction
-);
+impl_has_attrs_none!(Attribute, AttrItem, Block, Pat, Path, Ty, Visibility);
 
 impl<T: HasAttrs> HasAttrs for Box<T> {
     const SUPPORTS_CUSTOM_INNER_ATTRS: bool = T::SUPPORTS_CUSTOM_INNER_ATTRS;

--- a/compiler/rustc_ast/src/ast_traits.rs
+++ b/compiler/rustc_ast/src/ast_traits.rs
@@ -5,7 +5,7 @@
 use std::fmt;
 use std::marker::PhantomData;
 
-use crate::tokenstream::LazyAttrTokenStream;
+use crate::tokenstream::{LazyAttrTokenStream, WithTokens};
 use crate::{
     Arm, AssocItem, AttrItem, AttrKind, AttrVec, Attribute, Block, Crate, Expr, ExprField,
     FieldDef, ForeignItem, GenericParam, Item, NodeId, Param, Pat, PatField, Path, Stmt, StmtKind,
@@ -97,7 +97,7 @@ macro_rules! impl_has_tokens_none {
     };
 }
 
-impl_has_tokens!(AssocItem, AttrItem, Block, Expr, ForeignItem, Item, Pat, Path, Ty, Visibility);
+impl_has_tokens!(AssocItem, AttrItem, Expr, ForeignItem, Item);
 impl_has_tokens_none!(
     Arm,
     ExprField,
@@ -108,6 +108,15 @@ impl_has_tokens_none!(
     Variant,
     WherePredicate
 );
+
+impl<T> HasTokens for WithTokens<T> {
+    fn tokens(&self) -> Option<&LazyAttrTokenStream> {
+        self.tokens.as_ref()
+    }
+    fn tokens_mut(&mut self) -> Option<&mut Option<LazyAttrTokenStream>> {
+        Some(&mut self.tokens)
+    }
+}
 
 impl<T: HasTokens> HasTokens for Option<T> {
     fn tokens(&self) -> Option<&LazyAttrTokenStream> {
@@ -243,6 +252,16 @@ impl_has_attrs!(
     WherePredicate,
 );
 impl_has_attrs_none!(Attribute, AttrItem, Block, Pat, Path, Ty, Visibility);
+
+impl<T: HasAttrs> HasAttrs for WithTokens<T> {
+    const SUPPORTS_CUSTOM_INNER_ATTRS: bool = T::SUPPORTS_CUSTOM_INNER_ATTRS;
+    fn attrs(&self) -> &[Attribute] {
+        self.node.attrs()
+    }
+    fn visit_attrs(&mut self, f: impl FnOnce(&mut AttrVec)) {
+        self.node.visit_attrs(f);
+    }
+}
 
 impl<T: HasAttrs> HasAttrs for Box<T> {
     const SUPPORTS_CUSTOM_INNER_ATTRS: bool = T::SUPPORTS_CUSTOM_INNER_ATTRS;

--- a/compiler/rustc_ast/src/attr/mod.rs
+++ b/compiler/rustc_ast/src/attr/mod.rs
@@ -515,7 +515,7 @@ impl MetaItem {
                     iter.next();
                 }
                 let span = span.with_hi(segments.last().unwrap().ident.span.hi());
-                Path { span, segments, tokens: None }
+                Path { span, segments }
             }
             Some(TokenTree::Delimited(
                 _span,

--- a/compiler/rustc_ast/src/attr/mod.rs
+++ b/compiler/rustc_ast/src/attr/mod.rs
@@ -747,7 +747,7 @@ fn mk_attr(
 ) -> Attribute {
     mk_attr_from_item(
         g,
-        AttrItem { unsafety, path, args: AttrItemKind::Unparsed(args), tokens: None },
+        AttrItem { unsafety, path, args: AttrItemKind::Unparsed(args) },
         None,
         style,
         span,

--- a/compiler/rustc_ast/src/tokenstream.rs
+++ b/compiler/rustc_ast/src/tokenstream.rs
@@ -102,6 +102,10 @@ impl<T> WithTokens<T> {
     pub fn new(node: T) -> WithTokens<T> {
         WithTokens { node, tokens: None }
     }
+
+    pub fn map<U>(self, f: impl FnOnce(T) -> U) -> WithTokens<U> {
+        WithTokens { node: f(self.node), tokens: self.tokens }
+    }
 }
 
 /// A lazy version of [`AttrTokenStream`], which defers creation of an actual

--- a/compiler/rustc_ast/src/tokenstream.rs
+++ b/compiler/rustc_ast/src/tokenstream.rs
@@ -92,6 +92,18 @@ impl TokenTree {
     }
 }
 
+#[derive(Clone, Debug)]
+pub struct WithTokens<T> {
+    pub node: T,
+    pub tokens: Option<LazyAttrTokenStream>,
+}
+
+impl<T> WithTokens<T> {
+    pub fn new(node: T) -> WithTokens<T> {
+        WithTokens { node, tokens: None }
+    }
+}
+
 /// A lazy version of [`AttrTokenStream`], which defers creation of an actual
 /// `AttrTokenStream` until it is needed.
 #[derive(Clone)]

--- a/compiler/rustc_ast_lowering/src/item.rs
+++ b/compiler/rustc_ast_lowering/src/item.rs
@@ -248,11 +248,8 @@ impl<'hir> LoweringContext<'_, 'hir> {
             }
             ItemKind::Use(use_tree) => {
                 // Start with an empty prefix.
-                let prefix = Path {
-                    segments: ThinVec::new(),
-                    span: use_tree.prefix.span.shrink_to_lo(),
-                    tokens: None,
-                };
+                let prefix =
+                    Path { segments: ThinVec::new(), span: use_tree.prefix.span.shrink_to_lo() };
 
                 self.lower_use_tree(use_tree, &prefix, id, vis_span, attrs)
             }
@@ -609,7 +606,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 let mut ident = tree.ident();
 
                 // First, apply the prefix to the path.
-                let mut path = Path { segments, span: path.span, tokens: None };
+                let mut path = Path { segments, span: path.span };
 
                 // Correctly resolve `self` imports.
                 if path.segments.len() > 1
@@ -644,7 +641,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                     }
                     _ => span_bug!(path.span, "bad glob res {:?}", res),
                 };
-                let path = Path { segments, span: path.span, tokens: None };
+                let path = Path { segments, span: path.span };
                 let path = self.lower_use_path(res, &path, ParamMode::Explicit);
                 hir::ItemKind::Use(path, hir::UseKind::Glob)
             }
@@ -674,7 +671,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 // `ListStem`).
 
                 let span = prefix.span.to(path.span);
-                let prefix = Path { segments, span, tokens: None };
+                let prefix = Path { segments, span };
 
                 // Add all the nested `PathListItem`s to the HIR.
                 for &(ref use_tree, id) in trees {

--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -557,11 +557,11 @@ fn index_ast<'tcx>(
                 attrs: AttrVec::default(),
                 id,
                 span,
-                vis: Visibility { kind: VisibilityKind::Public, span, tokens: None },
+                vis: Visibility { kind: VisibilityKind::Public, span },
                 // Lacking a better choice, we replace the contents with a macro call.
                 // Unexpanded macros should never reach lowering, so this is not confusing.
                 kind: dummy(Box::new(MacCall {
-                    path: Path { span, segments: thin_vec![], tokens: None },
+                    path: Path { span, segments: thin_vec![] },
                     args: Box::new(DelimArgs {
                         dspan: DelimSpan::from_single(span),
                         delim: Delimiter::Parenthesis,

--- a/compiler/rustc_ast_pretty/src/pprust/tests.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/tests.rs
@@ -49,11 +49,7 @@ fn test_variant_to_string() {
 
         let var = ast::Variant {
             ident,
-            vis: ast::Visibility {
-                span: DUMMY_SP,
-                kind: ast::VisibilityKind::Inherited,
-                tokens: None,
-            },
+            vis: ast::Visibility { span: DUMMY_SP, kind: ast::VisibilityKind::Inherited },
             attrs: ast::AttrVec::new(),
             id: ast::DUMMY_NODE_ID,
             data: ast::VariantData::Unit(ast::DUMMY_NODE_ID),
@@ -77,12 +73,10 @@ fn test_field_view() {
                     id: ast::DUMMY_NODE_ID,
                     kind: ast::TyKind::Dummy,
                     span: DUMMY_SP,
-                    tokens: None,
                 }),
                 thin_vec![Ident::from_str("milhouse"), Ident::from_str("apu")],
             ),
             span: DUMMY_SP,
-            tokens: None,
         };
 
         let ty_str = ty_to_string(&ty);

--- a/compiler/rustc_attr_parsing/src/attributes/cfg.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/cfg.rs
@@ -1,7 +1,7 @@
 use std::convert::identity;
 
 use rustc_ast::token::Delimiter;
-use rustc_ast::tokenstream::DelimSpan;
+use rustc_ast::tokenstream::{DelimSpan, WithTokens};
 use rustc_ast::{AttrItem, Attribute, LitKind, ast, token};
 use rustc_errors::{Applicability, Diagnostic, PResult, msg};
 use rustc_feature::{Features, GatedCfg, find_gated_cfg};
@@ -319,7 +319,7 @@ pub fn parse_cfg_attr(
     sess: &Session,
     features: Option<&Features>,
     lint_node_id: ast::NodeId,
-) -> Option<(CfgEntry, Vec<(AttrItem, Span)>)> {
+) -> Option<(CfgEntry, Vec<(WithTokens<AttrItem>, Span)>)> {
     match cfg_attr.get_normal_item().args.unparsed_ref().unwrap() {
         ast::AttrArgs::Delimited(ast::DelimArgs { dspan, delim, tokens }) if !tokens.is_empty() => {
             check_cfg_attr_bad_delim(&sess.psess, *dspan, *delim);
@@ -393,7 +393,7 @@ fn parse_cfg_attr_internal<'a>(
     features: Option<&Features>,
     lint_node_id: ast::NodeId,
     attribute: &Attribute,
-) -> PResult<'a, (CfgEntry, Vec<(ast::AttrItem, Span)>)> {
+) -> PResult<'a, (CfgEntry, Vec<(WithTokens<ast::AttrItem>, Span)>)> {
     // Parse cfg predicate
     let pred_start = parser.token.span;
     let meta = MetaItemOrLitParser::parse_single(

--- a/compiler/rustc_builtin_macros/src/asm.rs
+++ b/compiler/rustc_builtin_macros/src/asm.rs
@@ -657,7 +657,6 @@ pub(super) fn expand_global_asm<'cx>(
                     vis: ast::Visibility {
                         span: sp.shrink_to_lo(),
                         kind: ast::VisibilityKind::Inherited,
-                        tokens: None,
                     },
                     span: sp,
                     tokens: None,

--- a/compiler/rustc_builtin_macros/src/assert.rs
+++ b/compiler/rustc_builtin_macros/src/assert.rs
@@ -41,7 +41,6 @@ pub(crate) fn expand_assert<'cx>(
                     .into_iter()
                     .map(|ident| PathSegment::from_ident(ident))
                     .collect(),
-                tokens: None,
             }
         } else {
             // Before edition 2021, we call `panic!()` unqualified,

--- a/compiler/rustc_builtin_macros/src/autodiff.rs
+++ b/compiler/rustc_builtin_macros/src/autodiff.rs
@@ -362,7 +362,6 @@ mod llvm_enzyme {
             unsafety: ast::Safety::Default,
             path: ast::Path::from_ident(Ident::with_dummy_span(sym::inline)),
             args: rustc_ast::ast::AttrItemKind::Unparsed(ast::AttrArgs::Delimited(never_arg)),
-            tokens: None,
         };
         let inline_never_attr = Box::new(ast::NormalAttr { item: inline_item, tokens: None });
         let new_id = ecx.sess.psess.attr_id_generator.mk_attr_id();

--- a/compiler/rustc_builtin_macros/src/autodiff.rs
+++ b/compiler/rustc_builtin_macros/src/autodiff.rs
@@ -626,7 +626,7 @@ mod llvm_enzyme {
             thin_vec![segment]
         };
 
-        let path = Path { span, segments, tokens: None };
+        let path = Path { span, segments };
 
         ecx.expr_path(path)
     }
@@ -738,7 +738,6 @@ mod llvm_enzyme {
                             id: ast::DUMMY_NODE_ID,
                             kind: PatKind::Ident(BindingMode::NONE, ident, None),
                             span: shadow_arg.pat.span,
-                            tokens: shadow_arg.pat.tokens.clone(),
                         });
                         d_inputs.push(shadow_arg.clone());
                     }
@@ -770,7 +769,6 @@ mod llvm_enzyme {
                             id: ast::DUMMY_NODE_ID,
                             kind: PatKind::Ident(BindingMode::NONE, ident, None),
                             span: shadow_arg.pat.span,
-                            tokens: shadow_arg.pat.tokens.clone(),
                         });
                         d_inputs.push(shadow_arg.clone());
                     }
@@ -814,7 +812,6 @@ mod llvm_enzyme {
                             id: ast::DUMMY_NODE_ID,
                             kind: PatKind::Ident(BindingMode::NONE, ident, None),
                             span: ty.span,
-                            tokens: None,
                         }),
                         id: ast::DUMMY_NODE_ID,
                         span: ty.span,
@@ -834,12 +831,7 @@ mod llvm_enzyme {
                 FnRetTy::Default(span) => {
                     // We want to return std::hint::black_box(()).
                     let kind = TyKind::Tup(ThinVec::new());
-                    let ty = Box::new(rustc_ast::Ty {
-                        kind,
-                        id: ast::DUMMY_NODE_ID,
-                        span,
-                        tokens: None,
-                    });
+                    let ty = Box::new(rustc_ast::Ty { kind, id: ast::DUMMY_NODE_ID, span });
                     d_decl.output = FnRetTy::Ty(ty.clone());
                     assert!(matches!(x.ret_activity, DiffActivity::None));
                     // this won't be used below, so any type would be fine.
@@ -860,7 +852,7 @@ mod llvm_enzyme {
                     };
                     TyKind::Array(ty.clone(), anon_const)
                 };
-                let ty = Box::new(rustc_ast::Ty { kind, id: ty.id, span: ty.span, tokens: None });
+                let ty = Box::new(rustc_ast::Ty { kind, id: ty.id, span: ty.span });
                 d_decl.output = FnRetTy::Ty(ty);
             }
             if matches!(x.ret_activity, DiffActivity::DualOnly | DiffActivity::DualvOnly) {
@@ -873,8 +865,7 @@ mod llvm_enzyme {
                         value: ecx.expr_usize(span, x.width as usize),
                     };
                     let kind = TyKind::Array(ty.clone(), anon_const);
-                    let ty =
-                        Box::new(rustc_ast::Ty { kind, id: ty.id, span: ty.span, tokens: None });
+                    let ty = Box::new(rustc_ast::Ty { kind, id: ty.id, span: ty.span });
                     d_decl.output = FnRetTy::Ty(ty);
                 }
             }
@@ -896,14 +887,14 @@ mod llvm_enzyme {
                         act_ret.insert(0, ty.clone());
                     }
                     let kind = TyKind::Tup(act_ret);
-                    Box::new(rustc_ast::Ty { kind, id: ty.id, span: ty.span, tokens: None })
+                    Box::new(rustc_ast::Ty { kind, id: ty.id, span: ty.span })
                 }
                 FnRetTy::Default(span) => {
                     if act_ret.len() == 1 {
                         act_ret[0].clone()
                     } else {
                         let kind = TyKind::Tup(act_ret.iter().map(|arg| arg.clone()).collect());
-                        Box::new(rustc_ast::Ty { kind, id: ast::DUMMY_NODE_ID, span, tokens: None })
+                        Box::new(rustc_ast::Ty { kind, id: ast::DUMMY_NODE_ID, span })
                     }
                 }
             };

--- a/compiler/rustc_builtin_macros/src/deriving/generic/mod.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/generic/mod.rs
@@ -609,7 +609,6 @@ impl<'a> TraitDef<'a> {
                 vis: ast::Visibility {
                     span: self.span.shrink_to_lo(),
                     kind: ast::VisibilityKind::Inherited,
-                    tokens: None,
                 },
                 attrs: ast::AttrVec::new(),
                 kind: ast::AssocItemKind::Type(Box::new(ast::TyAlias {
@@ -1080,11 +1079,7 @@ impl<'a> MethodDef<'a> {
             id: ast::DUMMY_NODE_ID,
             attrs: self.attributes.clone(),
             span,
-            vis: ast::Visibility {
-                span: trait_lo_sp,
-                kind: ast::VisibilityKind::Inherited,
-                tokens: None,
-            },
+            vis: ast::Visibility { span: trait_lo_sp, kind: ast::VisibilityKind::Inherited },
             kind: ast::AssocItemKind::Fn(Box::new(ast::Fn {
                 defaultness,
                 sig,

--- a/compiler/rustc_builtin_macros/src/deriving/generic/mod.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/generic/mod.rs
@@ -830,7 +830,6 @@ impl<'a> TraitDef<'a> {
                                 .collect(),
                             },
                         )),
-                        tokens: None,
                     },
                     self.span,
                 ),

--- a/compiler/rustc_builtin_macros/src/deriving/mod.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/mod.rs
@@ -109,7 +109,6 @@ fn call_unreachable(cx: &ExtCtxt<'_>, span: Span) -> Box<ast::Expr> {
         id: ast::DUMMY_NODE_ID,
         rules: ast::BlockCheckMode::Unsafe(ast::CompilerGenerated),
         span,
-        tokens: None,
     }))
 }
 

--- a/compiler/rustc_builtin_macros/src/direct_const_arg.rs
+++ b/compiler/rustc_builtin_macros/src/direct_const_arg.rs
@@ -28,12 +28,7 @@ pub(crate) fn expand<'cx>(
             attrs: Default::default(),
             tokens: None,
         })),
-        ty: Some(Box::new(ast::Ty {
-            id,
-            kind: ast::TyKind::DirectConstArg(expr),
-            span,
-            tokens: None,
-        })),
+        ty: Some(Box::new(ast::Ty { id, kind: ast::TyKind::DirectConstArg(expr), span })),
         ..Default::default()
     }))
 }

--- a/compiler/rustc_builtin_macros/src/edition_panic.rs
+++ b/compiler/rustc_builtin_macros/src/edition_panic.rs
@@ -55,7 +55,6 @@ fn expand<'cx>(
                         .into_iter()
                         .map(|ident| PathSegment::from_ident(ident))
                         .collect(),
-                    tokens: None,
                 },
                 args: Box::new(DelimArgs {
                     dspan: DelimSpan::from_single(sp),

--- a/compiler/rustc_builtin_macros/src/eii.rs
+++ b/compiler/rustc_builtin_macros/src/eii.rs
@@ -464,7 +464,7 @@ fn generate_attribute_macro_to_implement(
         id: ast::DUMMY_NODE_ID,
         span,
         // pub
-        vis: ast::Visibility { span, kind: ast::VisibilityKind::Public, tokens: None },
+        vis: ast::Visibility { span, kind: ast::VisibilityKind::Public },
         kind: ast::ItemKind::MacroDef(
             // macro macro_name
             macro_name,

--- a/compiler/rustc_builtin_macros/src/offload.rs
+++ b/compiler/rustc_builtin_macros/src/offload.rs
@@ -119,7 +119,6 @@ pub(crate) fn expand_kernel(
         unsafety: ast::Safety::Unsafe(span),
         path: ast::Path::from_ident(Ident::new(sym::no_mangle, span)),
         args: ast::AttrItemKind::Unparsed(ast::AttrArgs::Empty),
-        tokens: None,
     };
 
     let no_mangle_attr = Box::new(ast::NormalAttr { item: unsafe_item, tokens: None });
@@ -184,7 +183,6 @@ pub(crate) fn expand_kernel(
         unsafety: ast::Safety::Default,
         path: ast::Path::from_ident(Ident::with_dummy_span(sym::inline)),
         args: rustc_ast::ast::AttrItemKind::Unparsed(ast::AttrArgs::Delimited(never_arg)),
-        tokens: None,
     };
     let inline_never_attr = Box::new(ast::NormalAttr { item: inline_item, tokens: None });
 

--- a/compiler/rustc_builtin_macros/src/pattern_type.rs
+++ b/compiler/rustc_builtin_macros/src/pattern_type.rs
@@ -54,7 +54,7 @@ fn parse_pat_ty<'a>(
 }
 
 fn ty_pat(kind: TyPatKind, span: Span) -> TyPat {
-    TyPat { id: DUMMY_NODE_ID, kind, span, tokens: None }
+    TyPat { id: DUMMY_NODE_ID, kind, span }
 }
 
 fn pat_to_ty_pat(cx: &mut ExtCtxt<'_>, pat: ast::Pat) -> TyPat {

--- a/compiler/rustc_builtin_macros/src/test.rs
+++ b/compiler/rustc_builtin_macros/src/test.rs
@@ -65,11 +65,7 @@ pub(crate) fn expand_test_case(
                 &ecx.current_expansion.module.mod_path[1..],
                 ident,
             ));
-            item.vis = ast::Visibility {
-                span: item.vis.span,
-                kind: ast::VisibilityKind::Public,
-                tokens: None,
-            };
+            item.vis = ast::Visibility { span: item.vis.span, kind: ast::VisibilityKind::Public };
             item.attrs.push(ecx.attr_name_value_str(sym::rustc_test_marker, test_path_symbol, sp));
         }
         _ => {}

--- a/compiler/rustc_builtin_macros/src/test_harness.rs
+++ b/compiler/rustc_builtin_macros/src/test_harness.rs
@@ -355,7 +355,7 @@ fn mk_main(cx: &mut TestCtxt<'_>) -> Box<ast::Item> {
         attrs: thin_vec![main_attr, coverage_attr, doc_hidden_attr],
         id: ast::DUMMY_NODE_ID,
         kind: main,
-        vis: ast::Visibility { span: sp, kind: ast::VisibilityKind::Public, tokens: None },
+        vis: ast::Visibility { span: sp, kind: ast::VisibilityKind::Public },
         span: sp,
         tokens: None,
     });

--- a/compiler/rustc_expand/src/base.rs
+++ b/compiler/rustc_expand/src/base.rs
@@ -542,7 +542,6 @@ impl MacResult for MacEager {
                     id: ast::DUMMY_NODE_ID,
                     span: e.span,
                     kind: PatKind::Expr(e),
-                    tokens: None,
                 }));
             }
         }
@@ -598,12 +597,7 @@ impl MacResult for DummyResult {
     }
 
     fn make_pat(self: Box<DummyResult>) -> Option<Box<ast::Pat>> {
-        Some(Box::new(ast::Pat {
-            id: ast::DUMMY_NODE_ID,
-            kind: PatKind::Wild,
-            span: self.span,
-            tokens: None,
-        }))
+        Some(Box::new(ast::Pat { id: ast::DUMMY_NODE_ID, kind: PatKind::Wild, span: self.span }))
     }
 
     fn make_items(self: Box<DummyResult>) -> Option<SmallVec<[Box<ast::Item>; 1]>> {
@@ -642,7 +636,6 @@ impl MacResult for DummyResult {
             id: ast::DUMMY_NODE_ID,
             kind: ast::TyKind::Tup(ThinVec::new()),
             span: self.span,
-            tokens: None,
         }))
     }
 

--- a/compiler/rustc_expand/src/build.rs
+++ b/compiler/rustc_expand/src/build.rs
@@ -48,7 +48,7 @@ impl<'a> ExtCtxt<'a> {
             id: ast::DUMMY_NODE_ID,
             args,
         });
-        ast::Path { span, segments, tokens: None }
+        ast::Path { span, segments }
     }
 
     pub fn macro_call(
@@ -73,7 +73,7 @@ impl<'a> ExtCtxt<'a> {
     }
 
     pub fn ty(&self, span: Span, kind: ast::TyKind) -> Box<ast::Ty> {
-        Box::new(ast::Ty { id: ast::DUMMY_NODE_ID, span, kind, tokens: None })
+        Box::new(ast::Ty { id: ast::DUMMY_NODE_ID, span, kind })
     }
 
     pub fn ty_infer(&self, span: Span) -> Box<ast::Ty> {
@@ -287,13 +287,7 @@ impl<'a> ExtCtxt<'a> {
         )
     }
     pub fn block(&self, span: Span, stmts: ThinVec<ast::Stmt>) -> Box<ast::Block> {
-        Box::new(ast::Block {
-            stmts,
-            id: ast::DUMMY_NODE_ID,
-            rules: BlockCheckMode::Default,
-            span,
-            tokens: None,
-        })
+        Box::new(ast::Block { stmts, id: ast::DUMMY_NODE_ID, rules: BlockCheckMode::Default, span })
     }
 
     pub fn expr(&self, span: Span, kind: ast::ExprKind) -> Box<ast::Expr> {
@@ -532,7 +526,7 @@ impl<'a> ExtCtxt<'a> {
     }
 
     pub fn pat(&self, span: Span, kind: PatKind) -> ast::Pat {
-        ast::Pat { id: ast::DUMMY_NODE_ID, kind, span, tokens: None }
+        ast::Pat { id: ast::DUMMY_NODE_ID, kind, span }
     }
     pub fn pat_wild(&self, span: Span) -> ast::Pat {
         self.pat(span, PatKind::Wild)
@@ -688,7 +682,6 @@ impl<'a> ExtCtxt<'a> {
             vis: ast::Visibility {
                 span: span.shrink_to_lo(),
                 kind: ast::VisibilityKind::Inherited,
-                tokens: None,
             },
             span,
             tokens: None,

--- a/compiler/rustc_expand/src/config.rs
+++ b/compiler/rustc_expand/src/config.rs
@@ -4,7 +4,7 @@ use std::iter;
 
 use rustc_ast::token::{Delimiter, Token, TokenKind};
 use rustc_ast::tokenstream::{
-    AttrTokenStream, AttrTokenTree, LazyAttrTokenStream, Spacing, TokenTree,
+    AttrTokenStream, AttrTokenTree, LazyAttrTokenStream, Spacing, TokenTree, WithTokens,
 };
 use rustc_ast::{
     self as ast, AttrItemKind, AttrKind, AttrStyle, Attribute, EarlyParsedAttribute, HasAttrs,
@@ -308,7 +308,7 @@ impl<'a> StripUnconfigured<'a> {
     fn expand_cfg_attr_item(
         &self,
         cfg_attr: &Attribute,
-        (item, item_span): (ast::AttrItem, Span),
+        (attr_item, attr_item_span): (WithTokens<ast::AttrItem>, Span),
     ) -> Attribute {
         // Convert `#[cfg_attr(pred, attr)]` to `#[attr]`.
 
@@ -345,19 +345,20 @@ impl<'a> StripUnconfigured<'a> {
             delim_span,
             delim_spacing,
             Delimiter::Bracket,
-            item.tokens
+            attr_item
+                .tokens
                 .as_ref()
-                .unwrap_or_else(|| panic!("Missing tokens for {item:?}"))
+                .unwrap_or_else(|| panic!("Missing tokens for {:?}", attr_item.node))
                 .to_attr_token_stream(),
         ));
 
-        let tokens = Some(LazyAttrTokenStream::new_direct(AttrTokenStream::new(trees)));
+        let attr_tokens = Some(LazyAttrTokenStream::new_direct(AttrTokenStream::new(trees)));
         let attr = ast::attr::mk_attr_from_item(
             &self.sess.psess.attr_id_generator,
-            item,
-            tokens,
+            attr_item.node,
+            attr_tokens,
             cfg_attr.style,
-            item_span,
+            attr_item_span,
         );
         if attr.has_name(sym::crate_type) {
             self.sess.dcx().emit_err(CrateTypeInCfgAttr { span: attr.span });

--- a/compiler/rustc_expand/src/expand.rs
+++ b/compiler/rustc_expand/src/expand.rs
@@ -2065,23 +2065,13 @@ impl DummyAstNode for ast::Crate {
 
 impl DummyAstNode for ast::Ty {
     fn dummy() -> Self {
-        ast::Ty {
-            id: DUMMY_NODE_ID,
-            kind: TyKind::Dummy,
-            span: Default::default(),
-            tokens: Default::default(),
-        }
+        ast::Ty { id: DUMMY_NODE_ID, kind: TyKind::Dummy, span: Default::default() }
     }
 }
 
 impl DummyAstNode for ast::Pat {
     fn dummy() -> Self {
-        ast::Pat {
-            id: DUMMY_NODE_ID,
-            kind: PatKind::Wild,
-            span: Default::default(),
-            tokens: Default::default(),
-        }
+        ast::Pat { id: DUMMY_NODE_ID, kind: PatKind::Wild, span: Default::default() }
     }
 }
 

--- a/compiler/rustc_expand/src/mbe/transcribe.rs
+++ b/compiler/rustc_expand/src/mbe/transcribe.rs
@@ -545,9 +545,9 @@ fn transcribe_pnr<'tx>(
             mk_delimited(ty.node.span, MetaVarKind::Ty { is_path }, TokenStream::from_ast(ty))
         }
         ParseNtResult::Meta(attr_item) => {
-            let has_meta_form = attr_item.meta_kind().is_some();
+            let has_meta_form = attr_item.node.meta_kind().is_some();
             mk_delimited(
-                attr_item.span(),
+                attr_item.node.span(),
                 MetaVarKind::Meta { has_meta_form },
                 TokenStream::from_ast(attr_item),
             )

--- a/compiler/rustc_expand/src/mbe/transcribe.rs
+++ b/compiler/rustc_expand/src/mbe/transcribe.rs
@@ -505,7 +505,7 @@ fn transcribe_pnr<'tx>(
             mk_delimited(item.span, MetaVarKind::Item, TokenStream::from_ast(item))
         }
         ParseNtResult::Block(block) => {
-            mk_delimited(block.span, MetaVarKind::Block, TokenStream::from_ast(block))
+            mk_delimited(block.node.span, MetaVarKind::Block, TokenStream::from_ast(block))
         }
         ParseNtResult::Stmt(stmt) => {
             let stream = if let StmtKind::Empty = stmt.kind {
@@ -517,7 +517,7 @@ fn transcribe_pnr<'tx>(
             mk_delimited(stmt.span, MetaVarKind::Stmt, stream)
         }
         ParseNtResult::Pat(pat, pat_kind) => {
-            mk_delimited(pat.span, MetaVarKind::Pat(*pat_kind), TokenStream::from_ast(pat))
+            mk_delimited(pat.node.span, MetaVarKind::Pat(*pat_kind), TokenStream::from_ast(pat))
         }
         ParseNtResult::Expr(expr, kind) => {
             let (can_begin_literal_maybe_minus, can_begin_string_literal) = match &expr.kind {
@@ -541,8 +541,8 @@ fn transcribe_pnr<'tx>(
             mk_delimited(lit.span, MetaVarKind::Literal, TokenStream::from_ast(lit))
         }
         ParseNtResult::Ty(ty) => {
-            let is_path = matches!(&ty.kind, TyKind::Path(None, _path));
-            mk_delimited(ty.span, MetaVarKind::Ty { is_path }, TokenStream::from_ast(ty))
+            let is_path = matches!(&ty.node.kind, TyKind::Path(None, _path));
+            mk_delimited(ty.node.span, MetaVarKind::Ty { is_path }, TokenStream::from_ast(ty))
         }
         ParseNtResult::Meta(attr_item) => {
             let has_meta_form = attr_item.meta_kind().is_some();
@@ -553,10 +553,10 @@ fn transcribe_pnr<'tx>(
             )
         }
         ParseNtResult::Path(path) => {
-            mk_delimited(path.span, MetaVarKind::Path, TokenStream::from_ast(path))
+            mk_delimited(path.node.span, MetaVarKind::Path, TokenStream::from_ast(path))
         }
         ParseNtResult::Vis(vis) => {
-            mk_delimited(vis.span, MetaVarKind::Vis, TokenStream::from_ast(vis))
+            mk_delimited(vis.node.span, MetaVarKind::Vis, TokenStream::from_ast(vis))
         }
         ParseNtResult::Guard(guard) => {
             // FIXME(macro_guard_matcher):

--- a/compiler/rustc_expand/src/placeholders.rs
+++ b/compiler/rustc_expand/src/placeholders.rs
@@ -189,7 +189,6 @@ pub(crate) fn placeholder(
             mut_restriction: ast::MutRestriction {
                 kind: ast::RestrictionKind::Unrestricted,
                 span: DUMMY_SP,
-                tokens: None,
             },
             safety: Safety::Default,
             default: None,

--- a/compiler/rustc_expand/src/placeholders.rs
+++ b/compiler/rustc_expand/src/placeholders.rs
@@ -16,7 +16,7 @@ pub(crate) fn placeholder(
 ) -> AstFragment {
     fn mac_placeholder() -> Box<ast::MacCall> {
         Box::new(ast::MacCall {
-            path: ast::Path { span: DUMMY_SP, segments: ThinVec::new(), tokens: None },
+            path: ast::Path { span: DUMMY_SP, segments: ThinVec::new() },
             args: Box::new(ast::DelimArgs {
                 dspan: ast::tokenstream::DelimSpan::dummy(),
                 delim: Delimiter::Parenthesis,
@@ -27,11 +27,8 @@ pub(crate) fn placeholder(
 
     let ident = Ident::dummy();
     let attrs = ast::AttrVec::new();
-    let vis = vis.unwrap_or(ast::Visibility {
-        span: DUMMY_SP,
-        kind: ast::VisibilityKind::Inherited,
-        tokens: None,
-    });
+    let vis =
+        vis.unwrap_or(ast::Visibility { span: DUMMY_SP, kind: ast::VisibilityKind::Inherited });
     let span = DUMMY_SP;
     let expr_placeholder = || {
         Box::new(ast::Expr {
@@ -42,17 +39,8 @@ pub(crate) fn placeholder(
             tokens: None,
         })
     };
-    let ty = || {
-        Box::new(ast::Ty { id, kind: ast::TyKind::MacCall(mac_placeholder()), span, tokens: None })
-    };
-    let pat = || {
-        Box::new(ast::Pat {
-            id,
-            kind: ast::PatKind::MacCall(mac_placeholder()),
-            span,
-            tokens: None,
-        })
-    };
+    let ty = || Box::new(ast::Ty { id, kind: ast::TyKind::MacCall(mac_placeholder()), span });
+    let pat = || Box::new(ast::Pat { id, kind: ast::PatKind::MacCall(mac_placeholder()), span });
 
     match kind {
         AstFragmentKind::Crate => AstFragment::Crate(ast::Crate {
@@ -115,13 +103,11 @@ pub(crate) fn placeholder(
             id,
             span,
             kind: ast::PatKind::MacCall(mac_placeholder()),
-            tokens: None,
         })),
         AstFragmentKind::Ty => AstFragment::Ty(Box::new(ast::Ty {
             id,
             span,
             kind: ast::TyKind::MacCall(mac_placeholder()),
-            tokens: None,
         })),
         AstFragmentKind::Stmts => AstFragment::Stmts(smallvec![{
             let mac = Box::new(ast::MacCallStmt {

--- a/compiler/rustc_hir_pretty/src/lib.rs
+++ b/compiler/rustc_hir_pretty/src/lib.rs
@@ -143,7 +143,6 @@ impl<'a> State<'a> {
                     id: DUMMY_NODE_ID,
                 })
                 .collect(),
-            tokens: None,
         };
 
         match &item.args {

--- a/compiler/rustc_parse/src/parser/attr.rs
+++ b/compiler/rustc_parse/src/parser/attr.rs
@@ -1,6 +1,6 @@
 use rustc_ast as ast;
 use rustc_ast::token::{self, MetaVarKind};
-use rustc_ast::tokenstream::ParserRange;
+use rustc_ast::tokenstream::{ParserRange, WithTokens};
 use rustc_ast::{AttrItemKind, Attribute, attr};
 use rustc_errors::codes::*;
 use rustc_errors::{Diag, PResult, msg};
@@ -153,7 +153,15 @@ impl<'a> Parser<'a> {
                 );
             }
             bracket_res?;
-            let item = this.parse_attr_item(ForceCollect::No)?;
+
+            let attr_item = this.parse_attr_item(ForceCollect::No)?;
+            // `attr_item` will never have tokens: within `parse_attr_item`, `collect_tokens`
+            // attaches tokens only if:
+            // - `ForceCollect::Yes` is passed (not true), or
+            // - attributes on the parsed node require tokens (not true, because attr items can't
+            //   have attributes of their own, hence the empty `HasAttrs` impl for `AttrItem`).
+            assert!(attr_item.tokens.is_none());
+
             this.expect(exp!(CloseBracket))?;
             let attr_sp = lo.to(this.prev_token.span);
 
@@ -162,11 +170,17 @@ impl<'a> Parser<'a> {
                 this.error_on_forbidden_inner_attr(
                     attr_sp,
                     inner_parse_policy,
-                    item.is_valid_for_outer_style(),
+                    attr_item.node.is_valid_for_outer_style(),
                 );
             }
 
-            Ok(attr::mk_attr_from_item(&self.psess.attr_id_generator, item, None, style, attr_sp))
+            Ok(attr::mk_attr_from_item(
+                &self.psess.attr_id_generator,
+                attr_item.node,
+                None,
+                style,
+                attr_sp,
+            ))
         })
     }
 
@@ -308,7 +322,10 @@ impl<'a> Parser<'a> {
     ///     PATH
     ///     PATH `=` UNSUFFIXED_LIT
     /// The delimiters or `=` are still put into the resulting token stream.
-    pub fn parse_attr_item(&mut self, force_collect: ForceCollect) -> PResult<'a, ast::AttrItem> {
+    pub fn parse_attr_item(
+        &mut self,
+        force_collect: ForceCollect,
+    ) -> PResult<'a, WithTokens<ast::AttrItem>> {
         if let Some(item) = self.eat_metavar_seq_with_matcher(
             |mv_kind| matches!(mv_kind, MetaVarKind::Meta { .. }),
             |this| this.parse_attr_item(force_collect),
@@ -333,7 +350,11 @@ impl<'a> Parser<'a> {
                 this.expect(exp!(CloseParen))?;
             }
             Ok((
-                ast::AttrItem { unsafety, path, args: AttrItemKind::Unparsed(args), tokens: None },
+                WithTokens::new(ast::AttrItem {
+                    unsafety,
+                    path,
+                    args: AttrItemKind::Unparsed(args),
+                }),
                 Trailing::No,
                 UsePreAttrPos::No,
             ))
@@ -426,7 +447,8 @@ impl<'a> Parser<'a> {
                     .eat_metavar_seq(MetaVarKind::Meta { has_meta_form: true }, |this| {
                         this.parse_attr_item(ForceCollect::No)
                     })
-                    .unwrap();
+                    .unwrap()
+                    .node;
                 Ok(attr_item.meta(attr_item.path.span).unwrap())
             } else {
                 self.unexpected_any()

--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -53,9 +53,8 @@ pub(super) fn dummy_arg(ident: Ident, guar: ErrorGuaranteed) -> Param {
         id: ast::DUMMY_NODE_ID,
         kind: PatKind::Ident(BindingMode::NONE, ident, None),
         span: ident.span,
-        tokens: None,
     });
-    let ty = Ty { kind: TyKind::Err(guar), span: ident.span, id: ast::DUMMY_NODE_ID, tokens: None };
+    let ty = Ty { kind: TyKind::Err(guar), span: ident.span, id: ast::DUMMY_NODE_ID };
     Param {
         attrs: AttrVec::default(),
         id: ast::DUMMY_NODE_ID,
@@ -88,12 +87,7 @@ impl RecoverQPath for Ty {
         Some(Box::new(self.clone()))
     }
     fn recovered(qself: Option<Box<QSelf>>, path: ast::Path) -> Self {
-        Self {
-            span: path.span,
-            kind: TyKind::Path(qself, path),
-            id: ast::DUMMY_NODE_ID,
-            tokens: None,
-        }
+        Self { span: path.span, kind: TyKind::Path(qself, path), id: ast::DUMMY_NODE_ID }
     }
 }
 
@@ -103,12 +97,7 @@ impl RecoverQPath for Pat {
         self.to_ty()
     }
     fn recovered(qself: Option<Box<QSelf>>, path: ast::Path) -> Self {
-        Self {
-            span: path.span,
-            kind: PatKind::Path(qself, path),
-            id: ast::DUMMY_NODE_ID,
-            tokens: None,
-        }
+        Self { span: path.span, kind: PatKind::Path(qself, path), id: ast::DUMMY_NODE_ID }
     }
 }
 
@@ -982,11 +971,7 @@ impl<'a> Parser<'a> {
             // }
             debug!(?maybe_struct_name, ?self.token);
             let mut snapshot = self.create_snapshot_for_diagnostic();
-            let path = Path {
-                segments: ThinVec::new(),
-                span: self.prev_token.span.shrink_to_lo(),
-                tokens: None,
-            };
+            let path = Path { segments: ThinVec::new(), span: self.prev_token.span.shrink_to_lo() };
             let struct_expr = snapshot.parse_expr_struct(None, path, false);
             let block_tail = self.parse_block_tail(lo, s, AttemptLocalParseRecovery::No);
             return Some(match (struct_expr, block_tail) {
@@ -1858,7 +1843,7 @@ impl<'a> Parser<'a> {
     ) -> PResult<'a, T> {
         self.expect(exp!(PathSep))?;
 
-        let mut path = ast::Path { segments: ThinVec::new(), span: DUMMY_SP, tokens: None };
+        let mut path = ast::Path { segments: ThinVec::new(), span: DUMMY_SP };
         self.parse_path_segments(&mut path.segments, T::PATH_STYLE, None)?;
         path.span = ty_span.to(self.prev_token.span);
 
@@ -2401,12 +2386,7 @@ impl<'a> Parser<'a> {
         self.dcx().emit_err(PatternMethodParamWithoutBody { span: pat.span });
 
         // Pretend the pattern is `_`, to avoid duplicate errors from AST validation.
-        let pat = Box::new(Pat {
-            kind: PatKind::Wild,
-            span: pat.span,
-            id: ast::DUMMY_NODE_ID,
-            tokens: None,
-        });
+        let pat = Box::new(Pat { kind: PatKind::Wild, span: pat.span, id: ast::DUMMY_NODE_ID });
         Ok((pat, ty))
     }
 
@@ -2811,7 +2791,6 @@ impl<'a> Parser<'a> {
                                                     PathSegment::from_ident(*old_ident),
                                                     PathSegment::from_ident(*ident),
                                                 ],
-                                                tokens: None,
                                             },
                                         );
                                         first_pat = self.mk_pat(new_span, path);
@@ -2822,7 +2801,7 @@ impl<'a> Parser<'a> {
                                         segments.push(PathSegment::from_ident(*ident));
                                         let path = PatKind::Path(
                                             old_qself.clone(),
-                                            Path { span: new_span, segments, tokens: None },
+                                            Path { span: new_span, segments },
                                         );
                                         first_pat = self.mk_pat(new_span, path);
                                         show_sugg = true;

--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -862,11 +862,7 @@ impl<'a> Parser<'a> {
             attrs: Default::default(),
             span: whole_reuse_span,
             tokens: None,
-            vis: Visibility {
-                kind: VisibilityKind::Inherited,
-                span: whole_reuse_span,
-                tokens: None,
-            },
+            vis: Visibility { kind: VisibilityKind::Inherited, span: whole_reuse_span },
             kind: AssocItemKind::DelegationMac(Box::new(DelegationMac {
                 qself: None,
                 prefix: of_trait.trait_ref.path.clone(),
@@ -1298,8 +1294,7 @@ impl<'a> Parser<'a> {
     fn parse_use_tree(&mut self) -> PResult<'a, UseTree> {
         let lo = self.token.span;
 
-        let mut prefix =
-            ast::Path { segments: ThinVec::new(), span: lo.shrink_to_lo(), tokens: None };
+        let mut prefix = ast::Path { segments: ThinVec::new(), span: lo.shrink_to_lo() };
         let kind =
             if self.check(exp!(OpenBrace)) || self.check(exp!(Star)) || self.is_import_coupler() {
                 // `use *;` or `use ::*;` or `use {...};` or `use ::{...};`
@@ -1791,7 +1786,7 @@ impl<'a> Parser<'a> {
 
         // The user intended that the type be inferred,
         // so treat this as if the user wrote e.g. `const A: _ = expr;`.
-        Box::new(Ty { kind: TyKind::Infer, span, id: ast::DUMMY_NODE_ID, tokens: None })
+        Box::new(Ty { kind: TyKind::Infer, span, id: ast::DUMMY_NODE_ID })
     }
 
     /// Parses an enum declaration.
@@ -2400,8 +2395,7 @@ impl<'a> Parser<'a> {
         {
             let snapshot = self.create_snapshot_for_diagnostic();
             let err = if self.check_fn_front_matter(false, Case::Sensitive) {
-                let inherited_vis =
-                    Visibility { span: DUMMY_SP, kind: VisibilityKind::Inherited, tokens: None };
+                let inherited_vis = Visibility { span: DUMMY_SP, kind: VisibilityKind::Inherited };
                 // We use `parse_fn` to get a span for the function
                 let fn_parse_mode =
                     FnParseMode { req_name: |_, _| true, context: FnContext::Free, req_body: true };

--- a/compiler/rustc_parse/src/parser/mod.rs
+++ b/compiler/rustc_parse/src/parser/mod.rs
@@ -1835,7 +1835,8 @@ pub enum ParseNtResult {
     Expr(Box<ast::Expr>, NtExprKind),
     Literal(Box<ast::Expr>),
     Ty(WithTokens<Box<ast::Ty>>),
-    Meta(Box<ast::AttrItem>),
+    // These tokens are for the attr item, e.g. just the `foo` within `#[foo]` or `#![foo]`.
+    Meta(WithTokens<Box<ast::AttrItem>>),
     Path(WithTokens<Box<ast::Path>>),
     Vis(WithTokens<Box<ast::Visibility>>),
     Guard(Box<ast::Guard>),

--- a/compiler/rustc_parse/src/parser/mod.rs
+++ b/compiler/rustc_parse/src/parser/mod.rs
@@ -1565,12 +1565,11 @@ impl<'a> Parser<'a> {
         if self.eat_keyword(exp!(Impl)) {
             let (kind, span, gated_span) = self.parse_restriction(ParsingRestrictionKind::Impl)?;
             self.psess.gated_spans.gate(sym::impl_restriction, gated_span);
-            return Ok(ImplRestriction { kind, span, tokens: None });
+            return Ok(ImplRestriction { kind, span });
         }
         Ok(ImplRestriction {
             kind: RestrictionKind::Unrestricted,
             span: self.token.span.shrink_to_lo(),
-            tokens: None,
         })
     }
 
@@ -1580,12 +1579,11 @@ impl<'a> Parser<'a> {
         if self.eat_keyword(exp!(Mut)) {
             let (kind, span, gated_span) = self.parse_restriction(ParsingRestrictionKind::Mut)?;
             self.psess.gated_spans.gate(sym::mut_restriction, gated_span);
-            return Ok(MutRestriction { kind, span, tokens: None });
+            return Ok(MutRestriction { kind, span });
         }
         Ok(MutRestriction {
             kind: RestrictionKind::Unrestricted,
             span: self.token.span.shrink_to_lo(),
-            tokens: None,
         })
     }
 

--- a/compiler/rustc_parse/src/parser/mod.rs
+++ b/compiler/rustc_parse/src/parser/mod.rs
@@ -30,6 +30,7 @@ use rustc_ast::token::{
 };
 use rustc_ast::tokenstream::{
     ParserRange, ParserReplacement, Spacing, TokenCursor, TokenStream, TokenTree, TokenTreeCursor,
+    WithTokens,
 };
 use rustc_ast::util::case::Case;
 use rustc_ast::util::classify;
@@ -1492,7 +1493,6 @@ impl<'a> Parser<'a> {
             return Ok(Visibility {
                 span: self.token.span.shrink_to_lo(),
                 kind: VisibilityKind::Inherited,
-                tokens: None,
             });
         }
         let lo = self.prev_token.span;
@@ -1513,11 +1513,7 @@ impl<'a> Parser<'a> {
                     id: ast::DUMMY_NODE_ID,
                     shorthand: false,
                 };
-                return Ok(Visibility {
-                    span: lo.to(self.prev_token.span),
-                    kind: vis,
-                    tokens: None,
-                });
+                return Ok(Visibility { span: lo.to(self.prev_token.span), kind: vis });
             } else if self.look_ahead(2, |t| t == &token::CloseParen)
                 && self.is_keyword_ahead(1, &[kw::Crate, kw::Super, kw::SelfLower])
             {
@@ -1530,11 +1526,7 @@ impl<'a> Parser<'a> {
                     id: ast::DUMMY_NODE_ID,
                     shorthand: true,
                 };
-                return Ok(Visibility {
-                    span: lo.to(self.prev_token.span),
-                    kind: vis,
-                    tokens: None,
-                });
+                return Ok(Visibility { span: lo.to(self.prev_token.span), kind: vis });
             } else if let FollowedByType::No = fbt {
                 // Provide this diagnostic if a type cannot follow;
                 // in particular, if this is not a tuple struct.
@@ -1543,7 +1535,7 @@ impl<'a> Parser<'a> {
             }
         }
 
-        Ok(Visibility { span: lo, kind: VisibilityKind::Public, tokens: None })
+        Ok(Visibility { span: lo, kind: VisibilityKind::Public })
     }
 
     /// Recovery for e.g. `pub(something) fn ...` or `struct X { pub(something) y: Z }`
@@ -1826,21 +1818,25 @@ impl<'a> Parser<'a> {
     }
 }
 
-// Metavar captures of various kinds.
+// Metavar captures of various kinds. The more complex node kinds (e.g. `Item`, `Expr`) store
+// tokens in the node itself because those tokens are needed for non-terminal parsing and for other
+// reasons (e.g. cfg expansion). Simpler node kinds (e.g. `Block`, `Path`) only need tokens for
+// non-terminal parsing so here they store the tokens next to the node, keeping the node size
+// smaller.
 #[derive(Clone, Debug)]
 pub enum ParseNtResult {
     Tt(TokenTree),
     Ident(Ident, IdentIsRaw),
     Lifetime(Ident, IdentIsRaw),
     Item(Box<ast::Item>),
-    Block(Box<ast::Block>),
+    Block(WithTokens<Box<ast::Block>>),
     Stmt(Box<ast::Stmt>),
-    Pat(Box<ast::Pat>, NtPatKind),
+    Pat(WithTokens<Box<ast::Pat>>, NtPatKind),
     Expr(Box<ast::Expr>, NtExprKind),
     Literal(Box<ast::Expr>),
-    Ty(Box<ast::Ty>),
+    Ty(WithTokens<Box<ast::Ty>>),
     Meta(Box<ast::AttrItem>),
-    Path(Box<ast::Path>),
-    Vis(Box<ast::Visibility>),
+    Path(WithTokens<Box<ast::Path>>),
+    Vis(WithTokens<Box<ast::Visibility>>),
     Guard(Box<ast::Guard>),
 }

--- a/compiler/rustc_parse/src/parser/nonterminal.rs
+++ b/compiler/rustc_parse/src/parser/nonterminal.rs
@@ -1,6 +1,7 @@
 use rustc_ast::token::NtExprKind::*;
 use rustc_ast::token::NtPatKind::*;
 use rustc_ast::token::{self, InvisibleOrigin, MetaVarKind, NonterminalKind, Token};
+use rustc_ast::tokenstream::WithTokens;
 use rustc_ast_pretty::pprust;
 use rustc_errors::PResult;
 use rustc_span::{Ident, kw};
@@ -134,7 +135,9 @@ impl<'a> Parser<'a> {
             NonterminalKind::Block => {
                 // While a block *expression* may have attributes (e.g. `#[my_attr] { ... }`),
                 // the ':block' matcher does not support them
-                Ok(ParseNtResult::Block(self.collect_tokens_no_attrs(|this| this.parse_block())?))
+                Ok(ParseNtResult::Block(self.collect_tokens_no_attrs(|this| {
+                    this.parse_block().map(|block| WithTokens::new(block))
+                })?))
             }
             NonterminalKind::Stmt => match self.parse_stmt(ForceCollect::Yes)? {
                 Some(stmt) => Ok(ParseNtResult::Stmt(Box::new(stmt))),
@@ -143,16 +146,18 @@ impl<'a> Parser<'a> {
                 }
             },
             NonterminalKind::Pat(pat_kind) => Ok(ParseNtResult::Pat(
-                self.collect_tokens_no_attrs(|this| match pat_kind {
-                    PatParam { .. } => this.parse_pat_no_top_alt(None, None),
-                    PatWithOr => this.parse_pat_no_top_guard(
-                        None,
-                        RecoverComma::No,
-                        RecoverColon::No,
-                        CommaRecoveryMode::EitherTupleOrPipe,
-                    ),
-                })
-                .map(Box::new)?,
+                self.collect_tokens_no_attrs(|this| {
+                    match pat_kind {
+                        PatParam { .. } => this.parse_pat_no_top_alt(None, None),
+                        PatWithOr => this.parse_pat_no_top_guard(
+                            None,
+                            RecoverComma::No,
+                            RecoverColon::No,
+                            CommaRecoveryMode::EitherTupleOrPipe,
+                        ),
+                    }
+                    .map(|pat| WithTokens::new(Box::new(pat)))
+                })?,
                 pat_kind,
             )),
             NonterminalKind::Expr(expr_kind) => {
@@ -164,9 +169,9 @@ impl<'a> Parser<'a> {
                     self.collect_tokens_no_attrs(|this| this.parse_literal_maybe_minus())?,
                 ))
             }
-            NonterminalKind::Ty => Ok(ParseNtResult::Ty(
-                self.collect_tokens_no_attrs(|this| this.parse_ty_no_question_mark_recover())?,
-            )),
+            NonterminalKind::Ty => Ok(ParseNtResult::Ty(self.collect_tokens_no_attrs(|this| {
+                this.parse_ty_no_question_mark_recover().map(|ty| WithTokens::new(ty))
+            })?)),
             // This could be handled like a token, since it is one.
             NonterminalKind::Ident => {
                 if let Some((ident, is_raw)) = get_macro_ident(&self.token) {
@@ -179,15 +184,20 @@ impl<'a> Parser<'a> {
                     }))
                 }
             }
-            NonterminalKind::Path => Ok(ParseNtResult::Path(Box::new(
-                self.collect_tokens_no_attrs(|this| this.parse_path(PathStyle::Type))?,
-            ))),
+            NonterminalKind::Path => {
+                Ok(ParseNtResult::Path(self.collect_tokens_no_attrs(|this| {
+                    this.parse_path(PathStyle::Type).map(|path| WithTokens::new(Box::new(path)))
+                })?))
+            }
             NonterminalKind::Meta => {
                 Ok(ParseNtResult::Meta(Box::new(self.parse_attr_item(ForceCollect::Yes)?)))
             }
-            NonterminalKind::Vis => Ok(ParseNtResult::Vis(Box::new(
-                self.collect_tokens_no_attrs(|this| this.parse_visibility(FollowedByType::Yes))?,
-            ))),
+            NonterminalKind::Vis => {
+                Ok(ParseNtResult::Vis(self.collect_tokens_no_attrs(|this| {
+                    this.parse_visibility(FollowedByType::Yes)
+                        .map(|vis| WithTokens::new(Box::new(vis)))
+                })?))
+            }
             NonterminalKind::Lifetime => {
                 // We want to keep `'keyword` parsing, just like `keyword` is still
                 // an ident for nonterminal purposes.

--- a/compiler/rustc_parse/src/parser/nonterminal.rs
+++ b/compiler/rustc_parse/src/parser/nonterminal.rs
@@ -189,9 +189,9 @@ impl<'a> Parser<'a> {
                     this.parse_path(PathStyle::Type).map(|path| WithTokens::new(Box::new(path)))
                 })?))
             }
-            NonterminalKind::Meta => {
-                Ok(ParseNtResult::Meta(Box::new(self.parse_attr_item(ForceCollect::Yes)?)))
-            }
+            NonterminalKind::Meta => Ok(ParseNtResult::Meta(
+                self.parse_attr_item(ForceCollect::Yes)?.map(|item| Box::new(item)),
+            )),
             NonterminalKind::Vis => {
                 Ok(ParseNtResult::Vis(self.collect_tokens_no_attrs(|this| {
                     this.parse_visibility(FollowedByType::Yes)

--- a/compiler/rustc_parse/src/parser/pat.rs
+++ b/compiler/rustc_parse/src/parser/pat.rs
@@ -1785,6 +1785,6 @@ impl<'a> Parser<'a> {
     }
 
     pub(super) fn mk_pat(&self, span: Span, kind: PatKind) -> Pat {
-        Pat { kind, span, id: ast::DUMMY_NODE_ID, tokens: None }
+        Pat { kind, span, id: ast::DUMMY_NODE_ID }
     }
 }

--- a/compiler/rustc_parse/src/parser/path.rs
+++ b/compiler/rustc_parse/src/parser/path.rs
@@ -92,7 +92,7 @@ impl<'a> Parser<'a> {
             path_span = path_lo.to(self.prev_token.span);
         } else {
             path_span = self.token.span.to(self.token.span);
-            path = ast::Path { segments: ThinVec::new(), span: path_span, tokens: None };
+            path = ast::Path { segments: ThinVec::new(), span: path_span };
         }
 
         // See doc comment for `unmatched_angle_bracket_count`.
@@ -112,10 +112,7 @@ impl<'a> Parser<'a> {
             self.parse_path_segments(&mut path.segments, style, None)?;
         }
 
-        Ok((
-            qself,
-            Path { segments: path.segments, span: lo.to(self.prev_token.span), tokens: None },
-        ))
+        Ok((qself, Path { segments: path.segments, span: lo.to(self.prev_token.span) }))
     }
 
     /// Recover from an invalid single colon, when the user likely meant a qualified path.
@@ -221,7 +218,7 @@ impl<'a> Parser<'a> {
             segments.push(PathSegment::path_root(lo.shrink_to_lo().with_ctxt(mod_sep_ctxt)));
         }
         self.parse_path_segments(&mut segments, style, ty_generics)?;
-        Ok(Path { segments, span: lo.to(self.prev_token.span), tokens: None })
+        Ok(Path { segments, span: lo.to(self.prev_token.span) })
     }
 
     pub(super) fn parse_path_segments(

--- a/compiler/rustc_parse/src/parser/stmt.rs
+++ b/compiler/rustc_parse/src/parser/stmt.rs
@@ -1165,7 +1165,7 @@ impl<'a> Parser<'a> {
         rules: BlockCheckMode,
         span: Span,
     ) -> Box<Block> {
-        Box::new(Block { stmts, id: DUMMY_NODE_ID, rules, span, tokens: None })
+        Box::new(Block { stmts, id: DUMMY_NODE_ID, rules, span })
     }
 
     pub(super) fn mk_stmt(&self, span: Span, kind: StmtKind) -> Stmt {

--- a/compiler/rustc_parse/src/parser/ty.rs
+++ b/compiler/rustc_parse/src/parser/ty.rs
@@ -871,7 +871,6 @@ impl<'a> Parser<'a> {
         let inherited_vis = rustc_ast::Visibility {
             span: rustc_span::DUMMY_SP,
             kind: rustc_ast::VisibilityKind::Inherited,
-            tokens: None,
         };
         let span_start = self.token.span;
         let ast::FnHeader { ext, safety, .. } = self.parse_fn_front_matter(
@@ -1458,7 +1457,6 @@ impl<'a> Parser<'a> {
                             }
                         ))),
                     }],
-                    tokens: None,
                 })
             }
             Err(diag) => {
@@ -1643,6 +1641,6 @@ impl<'a> Parser<'a> {
     }
 
     pub(super) fn mk_ty(&self, span: Span, kind: TyKind) -> Box<Ty> {
-        Box::new(Ty { kind, span, id: ast::DUMMY_NODE_ID, tokens: None })
+        Box::new(Ty { kind, span, id: ast::DUMMY_NODE_ID })
     }
 }

--- a/compiler/rustc_resolve/src/error_helper.rs
+++ b/compiler/rustc_resolve/src/error_helper.rs
@@ -1690,7 +1690,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                     segms.append(&mut path_segments.clone());
 
                     segms.push(ast::PathSegment::from_ident(ident.orig(orig_ident_span)));
-                    let path = Path { span: name_binding.span, segments: segms, tokens: None };
+                    let path = Path { span: name_binding.span, segments: segms };
 
                     if child_accessible
                         // Remove invisible match if exists
@@ -2513,7 +2513,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             return;
         }
 
-        suggestion.path = Path { span: suggestion.path.span, segments: new_segments, tokens: None };
+        suggestion.path = Path { span: suggestion.path.span, segments: new_segments };
     }
 
     fn report_privacy_error(&mut self, privacy_error: &PrivacyError<'ra>) {
@@ -2902,7 +2902,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                         .unwrap_or_default();
                     let segments =
                         (start_index..len).map(|s| candidate.path.segments[s].clone()).collect();
-                    Path { segments, span: Span::default(), tokens: None }
+                    Path { segments, span: Span::default() }
                 };
                 (
                     message,

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -104,7 +104,6 @@ fn import_candidate_to_enum_paths(suggestion: &ImportSuggestion) -> (String, Str
     let enum_path = ast::Path {
         span: suggestion.path.span,
         segments: suggestion.path.segments[0..path_len - 1].iter().cloned().collect(),
-        tokens: None,
     };
     let enum_path_string = path_names_to_string(&enum_path);
 
@@ -3034,8 +3033,7 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
                     let doc_visible = doc_visible
                         && (module_def_id.is_local() || !r.tcx.is_doc_hidden(module_def_id));
                     if module_def_id == def_id {
-                        let path =
-                            Path { span: name_binding.span, segments: path_segments, tokens: None };
+                        let path = Path { span: name_binding.span, segments: path_segments };
                         result = Some((
                             r.expect_module(module_def_id),
                             ImportSuggestion {
@@ -3070,7 +3068,7 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
                 if let Res::Def(DefKind::Ctor(CtorOf::Variant, kind), def_id) = name_binding.res() {
                     let mut segms = enum_import_suggestion.path.segments.clone();
                     segms.push(ast::PathSegment::from_ident(ident.orig(orig_ident_span)));
-                    let path = Path { span: name_binding.span, segments: segms, tokens: None };
+                    let path = Path { span: name_binding.span, segments: segms };
                     variants.push((path, def_id, kind));
                 }
             });
@@ -4495,7 +4493,6 @@ fn mk_where_bound_predicate(
                     kind: ast::TyKind::Path(None, poly_trait_ref.trait_ref.path.clone()),
                     id: DUMMY_NODE_ID,
                     span: DUMMY_SP,
-                    tokens: None,
                 })),
             },
             span: DUMMY_SP,
@@ -4526,7 +4523,7 @@ fn mk_where_bound_predicate(
             bound_generic_params: ThinVec::new(),
             modifiers: ast::TraitBoundModifiers::NONE,
             trait_ref: ast::TraitRef {
-                path: ast::Path { segments: modified_segments, span: DUMMY_SP, tokens: None },
+                path: ast::Path { segments: modified_segments, span: DUMMY_SP },
                 ref_id: DUMMY_NODE_ID,
             },
             span: DUMMY_SP,

--- a/src/tools/clippy/clippy_lints/src/unnested_or_patterns.rs
+++ b/src/tools/clippy/clippy_lints/src/unnested_or_patterns.rs
@@ -382,7 +382,6 @@ fn take_pat(from: &mut Pat) -> Pat {
         id: DUMMY_NODE_ID,
         kind: Wild,
         span: DUMMY_SP,
-        tokens: None,
     };
     mem::replace(from, dummy)
 }

--- a/src/tools/rustfmt/src/closures.rs
+++ b/src/tools/rustfmt/src/closures.rs
@@ -174,7 +174,6 @@ fn rewrite_closure_with_block(
         }],
         id: ast::NodeId::root(),
         rules: ast::BlockCheckMode::Default,
-        tokens: None,
         span: body
             .attrs
             .first()

--- a/src/tools/rustfmt/src/items.rs
+++ b/src/tools/rustfmt/src/items.rs
@@ -39,7 +39,6 @@ use crate::visitor::FmtVisitor;
 const DEFAULT_VISIBILITY: ast::Visibility = ast::Visibility {
     kind: ast::VisibilityKind::Inherited,
     span: DUMMY_SP,
-    tokens: None,
 };
 
 fn type_annotation_separator(config: &Config) -> &str {

--- a/src/tools/rustfmt/src/macros.rs
+++ b/src/tools/rustfmt/src/macros.rs
@@ -404,7 +404,6 @@ fn rewrite_empty_macro_def_body(
         id: rustc_ast::node_id::DUMMY_NODE_ID,
         rules: ast::BlockCheckMode::Default,
         span,
-        tokens: None,
     };
     block.rewrite_result(context, shape)
 }

--- a/tests/ui-fulldeps/pprust-expr-roundtrip.rs
+++ b/tests/ui-fulldeps/pprust-expr-roundtrip.rs
@@ -111,7 +111,6 @@ fn iter_exprs(depth: usize, f: &mut dyn FnMut(Box<Expr>)) {
                     id: DUMMY_NODE_ID,
                     rules: BlockCheckMode::Default,
                     span: DUMMY_SP,
-                    tokens: None,
                 });
                 iter_exprs(depth - 1, &mut |e| g(ExprKind::If(e, block.clone(), None)));
             }
@@ -175,7 +174,6 @@ fn iter_exprs(depth: usize, f: &mut dyn FnMut(Box<Expr>)) {
                     id: DUMMY_NODE_ID,
                     kind: PatKind::Wild,
                     span: DUMMY_SP,
-                    tokens: None,
                 });
                 iter_exprs(depth - 1, &mut |e| {
                     g(ExprKind::Let(pat.clone(), e, DUMMY_SP, Recovered::No))

--- a/tests/ui-fulldeps/pprust-expr-roundtrip.rs
+++ b/tests/ui-fulldeps/pprust-expr-roundtrip.rs
@@ -49,7 +49,7 @@ fn expr(kind: ExprKind) -> Box<Expr> {
 
 fn make_x() -> Box<Expr> {
     let seg = PathSegment::from_ident(Ident::from_str("x"));
-    let path = Path { segments: thin_vec![seg], span: DUMMY_SP, tokens: None };
+    let path = Path { segments: thin_vec![seg], span: DUMMY_SP };
     expr(ExprKind::Path(None, path))
 }
 

--- a/tests/ui/stats/input-stats.stderr
+++ b/tests/ui/stats/input-stats.stderr
@@ -33,7 +33,7 @@ ast-stats - Trait                    352 (NN.N%)             4
 ast-stats AssocItem                320 (NN.N%)             4            80
 ast-stats - Fn                       160 (NN.N%)             2
 ast-stats - Type                     160 (NN.N%)             2
-ast-stats FieldDef                 272 (NN.N%)             2           136
+ast-stats FieldDef                 256 (NN.N%)             2           128
 ast-stats Variant                  208 (NN.N%)             2           104
 ast-stats Block                    192 (NN.N%)             6            32
 ast-stats Stmt                     160 (NN.N%)             5            32
@@ -57,7 +57,7 @@ ast-stats GenericArgs               40 (NN.N%)             1            40
 ast-stats - AngleBracketed            40 (NN.N%)             1
 ast-stats Crate                     40 (NN.N%)             1            40
 ast-stats ----------------------------------------------------------------
-ast-stats Total                  7_528                   127
+ast-stats Total                  7_512                   127
 ast-stats ================================================================
 hir-stats ================================================================
 hir-stats HIR STATS: input_stats

--- a/tests/ui/stats/input-stats.stderr
+++ b/tests/ui/stats/input-stats.stderr
@@ -2,20 +2,20 @@ ast-stats ================================================================
 ast-stats POST EXPANSION AST STATS: input_stats
 ast-stats Name                Accumulated Size         Count     Item Size
 ast-stats ----------------------------------------------------------------
-ast-stats Item                   1_672 (NN.N%)            11           152
-ast-stats - Enum                     152 (NN.N%)             1
-ast-stats - ExternCrate              152 (NN.N%)             1
-ast-stats - ForeignMod               152 (NN.N%)             1
-ast-stats - Impl                     152 (NN.N%)             1
-ast-stats - Trait                    152 (NN.N%)             1
-ast-stats - Fn                       304 (NN.N%)             2
-ast-stats - Use                      608 (NN.N%)             4
-ast-stats Ty                       896 (NN.N%)            14            64
-ast-stats - Ptr                       64 (NN.N%)             1
-ast-stats - Ref                       64 (NN.N%)             1
-ast-stats - ImplicitSelf             128 (NN.N%)             2
-ast-stats - Path                     640 (NN.N%)            10
+ast-stats Item                   1_584 (NN.N%)            11           144
+ast-stats - Enum                     144 (NN.N%)             1
+ast-stats - ExternCrate              144 (NN.N%)             1
+ast-stats - ForeignMod               144 (NN.N%)             1
+ast-stats - Impl                     144 (NN.N%)             1
+ast-stats - Trait                    144 (NN.N%)             1
+ast-stats - Fn                       288 (NN.N%)             2
+ast-stats - Use                      576 (NN.N%)             4
 ast-stats PathSegment              864 (NN.N%)            36            24
+ast-stats Ty                       784 (NN.N%)            14            56
+ast-stats - Ptr                       56 (NN.N%)             1
+ast-stats - Ref                       56 (NN.N%)             1
+ast-stats - ImplicitSelf             112 (NN.N%)             2
+ast-stats - Path                     560 (NN.N%)            10
 ast-stats Expr                     648 (NN.N%)             9            72
 ast-stats - InlineAsm                 72 (NN.N%)             1
 ast-stats - Match                     72 (NN.N%)             1
@@ -23,24 +23,24 @@ ast-stats - Path                      72 (NN.N%)             1
 ast-stats - Struct                    72 (NN.N%)             1
 ast-stats - Lit                      144 (NN.N%)             2
 ast-stats - Block                    216 (NN.N%)             3
-ast-stats Pat                      560 (NN.N%)             7            80
-ast-stats - Struct                    80 (NN.N%)             1
-ast-stats - Wild                      80 (NN.N%)             1
-ast-stats - Ident                    400 (NN.N%)             5
+ast-stats Pat                      448 (NN.N%)             7            64
+ast-stats - Struct                    64 (NN.N%)             1
+ast-stats - Wild                      64 (NN.N%)             1
+ast-stats - Ident                    320 (NN.N%)             5
 ast-stats GenericParam             400 (NN.N%)             5            80
-ast-stats GenericBound             352 (NN.N%)             4            88
-ast-stats - Trait                    352 (NN.N%)             4
-ast-stats AssocItem                320 (NN.N%)             4            80
-ast-stats - Fn                       160 (NN.N%)             2
-ast-stats - Type                     160 (NN.N%)             2
-ast-stats FieldDef                 256 (NN.N%)             2           128
-ast-stats Variant                  208 (NN.N%)             2           104
-ast-stats Block                    192 (NN.N%)             6            32
+ast-stats GenericBound             320 (NN.N%)             4            80
+ast-stats - Trait                    320 (NN.N%)             4
+ast-stats AssocItem                288 (NN.N%)             4            72
+ast-stats - Fn                       144 (NN.N%)             2
+ast-stats - Type                     144 (NN.N%)             2
+ast-stats FieldDef                 240 (NN.N%)             2           120
+ast-stats Variant                  192 (NN.N%)             2            96
 ast-stats Stmt                     160 (NN.N%)             5            32
 ast-stats - Let                       32 (NN.N%)             1
 ast-stats - Semi                      32 (NN.N%)             1
 ast-stats - Expr                      96 (NN.N%)             3
 ast-stats Param                    160 (NN.N%)             4            40
+ast-stats Block                    144 (NN.N%)             6            24
 ast-stats Attribute                128 (NN.N%)             4            32
 ast-stats - DocComment                32 (NN.N%)             1
 ast-stats - Normal                    96 (NN.N%)             3
@@ -48,8 +48,8 @@ ast-stats InlineAsm                120 (NN.N%)             1           120
 ast-stats FnDecl                   120 (NN.N%)             5            24
 ast-stats Local                     96 (NN.N%)             1            96
 ast-stats Arm                       96 (NN.N%)             2            48
-ast-stats ForeignItem               80 (NN.N%)             1            80
-ast-stats - Fn                        80 (NN.N%)             1
+ast-stats ForeignItem               72 (NN.N%)             1            72
+ast-stats - Fn                        72 (NN.N%)             1
 ast-stats WherePredicate            56 (NN.N%)             1            56
 ast-stats - BoundPredicate            56 (NN.N%)             1
 ast-stats ExprField                 48 (NN.N%)             1            48
@@ -57,7 +57,7 @@ ast-stats GenericArgs               40 (NN.N%)             1            40
 ast-stats - AngleBracketed            40 (NN.N%)             1
 ast-stats Crate                     40 (NN.N%)             1            40
 ast-stats ----------------------------------------------------------------
-ast-stats Total                  7_512                   127
+ast-stats Total                  7_048                   127
 ast-stats ================================================================
 hir-stats ================================================================
 hir-stats HIR STATS: input_stats


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/158942)*
<!-- homu-ignore:end -->

This commit removes/moves the `tokens` field from various AST node types, shrinking them. Details in individual commits.