### PR TITLE
delegation: support `Self` mapping adjustments for non-first arguments

### DIFF
--- a/compiler/rustc_ast_lowering/src/delegation/mod.rs
+++ b/compiler/rustc_ast_lowering/src/delegation/mod.rs
@@ -130,6 +130,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 hir::InferDelegationSig::Output(self.arena.alloc(hir::DelegationInfo {
                     call_expr_id,
                     call_path_res,
+                    arguments_to_map: res.sig_mapping.arguments_to_map.clone(),
                     child_seg_id: generics.child.args_segment_id,
                     child_seg_id_for_sig: generics.child.segment_id_for_sig(),
                     parent_seg_id_for_sig: generics.parent.segment_id_for_sig(),

--- a/compiler/rustc_ast_lowering/src/delegation/resolution.rs
+++ b/compiler/rustc_ast_lowering/src/delegation/resolution.rs
@@ -2,13 +2,13 @@ use std::ops::ControlFlow;
 
 use ast::visit::Visitor;
 use hir::def::DefKind;
-use rustc_ast as ast;
-use rustc_ast::*;
-use rustc_data_structures::fx::FxHashSet;
+use rustc_ast::{self as ast, Delegation, DelegationSource, NodeId};
+use rustc_data_structures::fx::{FxHashSet, FxIndexSet};
 use rustc_hir as hir;
+use rustc_middle::ty::Ty;
 use rustc_middle::{span_bug, ty};
 use rustc_span::def_id::{DefId, LocalDefId};
-use rustc_span::{ErrorGuaranteed, Span};
+use rustc_span::{ErrorGuaranteed, Span, kw};
 
 use crate::delegation::generics::GenericsGenerationResults;
 use crate::delegation::resolution::resolver::DelegationResolver;
@@ -34,7 +34,7 @@ pub(super) struct ParamInfo {
 #[derive(Default)]
 pub(super) struct SigMapping {
     pub map_return: bool,
-    pub arguments_to_map: FxHashSet<usize>,
+    pub arguments_to_map: FxIndexSet<usize>,
 }
 
 pub(super) struct DelegationResolution {
@@ -150,7 +150,7 @@ impl<'tcx> DelegationResolver<'_, 'tcx> {
             param_info: ParamInfo { param_count, c_variadic: sig.c_variadic(), splatted: None },
             source: delegation.source,
             call_path_res: self.get_resolution_id(delegation.id)?,
-            sig_mapping: self.create_self_mapping(
+            sig_mapping: self.create_sig_mapping(
                 delegation,
                 span,
                 should_generate_block,
@@ -210,6 +210,7 @@ impl<'tcx> DelegationResolver<'_, 'tcx> {
             let err = DelegationBlockSpecifiedWhenNoParams { span: block.span };
             return Err(tcx.dcx().emit_err(err));
         }
+
         struct DefinitionsFinder<'a, 'hir> {
             resolver: &'a DelegationResolver<'a, 'hir>,
         }
@@ -238,7 +239,7 @@ impl<'tcx> DelegationResolver<'_, 'tcx> {
         }
     }
 
-    fn create_self_mapping(
+    fn create_sig_mapping(
         &self,
         delegation: &Delegation,
         span: Span,
@@ -253,14 +254,17 @@ impl<'tcx> DelegationResolver<'_, 'tcx> {
         }
 
         if self.can_perform_self_mapping(delegation, parent)? {
+            // FIXME(fn_delegation): support heuristics for mapping of complex
+            // return types: `Self` -> `Box<Arc<Rc<Self>>>`
             mapping.map_return = sig.output().is_param(0);
 
+            let self_param = Ty::new_param(self.tcx(), 0, kw::SelfUpper);
             let arguments_to_map = sig
                 .inputs()
                 .iter()
                 .enumerate()
                 .skip(1) // Already checked above.
-                .filter_map(|(idx, param)| param.is_param(0).then_some(idx));
+                .filter_map(|(idx, param)| param.contains(self_param).then_some(idx));
 
             mapping.arguments_to_map.extend(arguments_to_map);
         }

--- a/compiler/rustc_hir/src/arena.rs
+++ b/compiler/rustc_hir/src/arena.rs
@@ -9,6 +9,7 @@ macro_rules! arena_types {
             [] attribute: rustc_hir::Attribute,
             [] owner_info: rustc_hir::OwnerInfo<'tcx>,
             [] macro_def: rustc_ast::MacroDef,
+            [] delegation_info: rustc_hir::DelegationInfo,
         ]);
     )
 }

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -17,6 +17,7 @@ pub use rustc_ast::{
     MetaItemInner, MetaItemLit, Movability, Mutability, Pinnedness, UnOp,
 };
 use rustc_data_structures::fingerprint::Fingerprint;
+use rustc_data_structures::fx::FxIndexSet;
 use rustc_data_structures::sorted_map::SortedMap;
 use rustc_data_structures::steal::Steal;
 use rustc_data_structures::tagged_ptr::TaggedRef;
@@ -3874,7 +3875,7 @@ pub enum DelegationSelfTyPropagationKind {
     SelfParam,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, StableHash)]
+#[derive(Debug, StableHash)]
 pub struct DelegationInfo {
     pub call_expr_id: HirId,
     pub call_path_res: DefId,
@@ -3893,16 +3894,18 @@ pub struct DelegationInfo {
 
     pub self_ty_propagation_kind: Option<DelegationSelfTyPropagationKind>,
     pub group_id: Option<(LocalExpnId, bool /* unused_target_expr */)>,
+
+    pub arguments_to_map: FxIndexSet<usize>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, StableHash)]
+#[derive(Debug, Clone, Copy, StableHash)]
 pub enum InferDelegationSig<'hir> {
     Input(usize),
     // Place delegation info here, as we always specify output type for delegations.
     Output(&'hir DelegationInfo),
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, StableHash)]
+#[derive(Debug, Clone, Copy, StableHash)]
 pub enum InferDelegation<'hir> {
     /// Infer the type of this `DefId` through `tcx.type_of(def_id).instantiate_identity()`,
     /// used for const types propagation.

--- a/compiler/rustc_hir_typeck/src/callee.rs
+++ b/compiler/rustc_hir_typeck/src/callee.rs
@@ -2,12 +2,13 @@ use std::iter;
 
 use rustc_abi::{CanonAbi, ExternAbi};
 use rustc_ast::util::parser::ExprPrecedence;
+use rustc_data_structures::fx::{FxHashMap, FxIndexSet};
 use rustc_errors::{Applicability, Diag, ErrorGuaranteed, StashKey, msg};
 use rustc_hir::def::{self, CtorKind, Namespace, Res};
 use rustc_hir::def_id::DefId;
 use rustc_hir::{self as hir, HirId, LangItem, find_attr};
 use rustc_hir_analysis::autoderef::Autoderef;
-use rustc_infer::infer::BoundRegionConversionTime;
+use rustc_infer::infer::{BoundRegionConversionTime, DefineOpaqueTypes};
 use rustc_infer::traits::{Obligation, ObligationCause, ObligationCauseCode};
 use rustc_middle::bug;
 use rustc_middle::ty::adjustment::{
@@ -629,8 +630,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     }
 
     /// Performs arguments check with an additional routine of adjusting the first argument,
-    /// so it corresponds to the first parameter of the function. We reuse adjustments
-    /// that are obtained from `probe_for_name`, where the first argument pretends to be
+    /// (and possibly other arguments) so it corresponds to the first parameter of the function.
+    /// We reuse adjustments that are obtained from `probe_for_name`, where the first argument pretends to be
     /// a receiver like in a method call. At this point this routine is used for delegations,
     /// as from this moment we always generate a call (earlier method calls were generated),
     /// so we can both propagate parent generics and get benefits from adjustments from method call.
@@ -659,58 +660,102 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             );
         };
 
-        let Some(scope) = self.get_scope_for_method_call_adjustments(call_expr, arg_exprs) else {
+        let Some((candidate_res, args_to_map)) =
+            self.get_info_for_method_call_adjustments(call_expr, arg_exprs)
+        else {
             return do_check();
         };
 
-        let first_expr = &arg_exprs[0];
-        let first_arg_type = self.check_expr(first_expr);
+        // After we found pick for first argument we need to resolve inference variables
+        // in order to find adjustments for other mapped arguments.
+        let mut resolved_inputs = vec![];
+        let mut prev_types = FxHashMap::default();
+        let formal_input_tys = fn_sig.inputs();
 
-        // Reuse method probing that is used during method call, as all this code pretends that
-        // we generated method call.
-        let pick = self.probe_for_name(
-            Mode::MethodCall,
-            Ident::dummy(),
-            None,
-            IsSuggestion(false),
-            first_arg_type,
-            call_expr.hir_id,
-            scope,
-        );
+        let args_to_map = arg_exprs
+            .iter()
+            .enumerate()
+            .filter(|(idx, _)| args_to_map.contains(idx))
+            .collect::<Vec<_>>();
 
-        let Ok(ref pick) = pick else { return do_check() };
+        for &(idx, arg) in &args_to_map {
+            let is_first_arg = idx == 0;
+            let self_ty_override = if is_first_arg { None } else { Some(resolved_inputs[idx]) };
+            let scope = ProbeScope::Single(candidate_res, self_ty_override);
+            let arg_type = self.check_expr(arg);
 
-        // Fool typechecker by placing an adjusted type of the first arg to avoid errors.
-        // We already wrote type of `first_expr` during `self.check_expr(first_expr)` above.
-        let first_arg_type = self
-            .typeck_results
-            .borrow_mut()
-            .node_types_mut()
-            .insert(first_expr.hir_id, pick.self_ty)
-            .expect("must be set");
+            // Reuse method probing that is used during method call, as all this code pretends that
+            // we generated method call.
+            let pick = self.probe_for_name(
+                Mode::MethodCall,
+                Ident::dummy(),
+                None,
+                IsSuggestion(false),
+                arg_type,
+                call_expr.hir_id,
+                scope,
+            );
+
+            let Ok(pick) = pick else { return do_check() };
+
+            if is_first_arg && args_to_map.len() > 1 {
+                // We successfully found a pick and adjustments for first argument,
+                // now we have to unify it with signature input in order to resolve
+                // all inference variables. After that we update input signature for
+                // adjustments search for mapped arguments.
+                let cause = self.cause(call_expr.span, ObligationCauseCode::Misc);
+                if self
+                    .at(&cause, self.param_env)
+                    .sup(DefineOpaqueTypes::Yes, formal_input_tys[0], pick.self_ty)
+                    .is_err()
+                {
+                    return do_check();
+                }
+
+                resolved_inputs = self.resolve_vars_if_possible(formal_input_tys.to_vec());
+            }
+
+            // Fool typechecker by placing an adjusted type of the first arg to avoid errors.
+            // We already wrote type of `first_expr` during `self.check_expr(first_expr)` above.
+            prev_types.insert(
+                arg.hir_id,
+                (
+                    self.typeck_results
+                        .borrow_mut()
+                        .node_types_mut()
+                        .insert(arg.hir_id, pick.self_ty)
+                        .expect("must be set"),
+                    pick,
+                ),
+            );
+        }
 
         do_check();
 
-        let mut results = self.typeck_results.borrow_mut();
+        for (_, arg) in args_to_map {
+            let mut results = self.typeck_results.borrow_mut();
+            let mut adjustments = results.adjustments_mut();
 
-        // Remove any added adjustments for `first_expr` during `do_check` and replace them with ours.
-        let mut adjustments = results.adjustments_mut();
-        let adjustments = adjustments.entry(first_expr.hir_id).or_default();
+            let (prev_type, pick) = prev_types.remove(&arg.hir_id).expect("must be in a map");
 
-        let mut ctx = ConfirmContext::new(self, first_expr.span, first_expr, first_expr);
-        *adjustments = ctx.create_ty_adjustments_from_pick(first_arg_type, pick).1;
+            // Remove any added adjustments for arg expression during `do_check` and replace them with ours.
+            let adjustments = adjustments.entry(arg.hir_id).or_default();
 
-        // Restore original first provided arg type.
-        results.node_types_mut().insert(first_expr.hir_id, first_arg_type);
+            let mut ctx = ConfirmContext::new(self, arg.span, arg, arg);
+            *adjustments = ctx.create_ty_adjustments_from_pick(prev_type, &pick).1;
+
+            // Restore original first provided arg type.
+            results.node_types_mut().insert(arg.hir_id, prev_type);
+        }
     }
 
     /// Gets scope for method-call like adjustments for the first argument of the call.
     /// Now only delegations are processed this way.
-    fn get_scope_for_method_call_adjustments(
+    fn get_info_for_method_call_adjustments(
         &self,
         call_expr: &'tcx hir::Expr<'tcx>,
         arg_exprs: &'tcx [hir::Expr<'tcx>],
-    ) -> Option<ProbeScope> {
+    ) -> Option<(DefId, &FxIndexSet<usize>)> {
         // Check that we are inside delegation and processing its call. First, we check that
         // the parent of call expr. is delegation and then make sure that it is compiler-generated
         // by comparing their hir ids (otherwise we will encounter errors in nested delegations,
@@ -732,7 +777,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             return None;
         }
 
-        Some(ProbeScope::Single(info.call_path_res))
+        Some((info.call_path_res, &info.arguments_to_map))
     }
 
     /// Attempts to reinterpret `method(rcvr, args...)` as `rcvr.method(args...)`

--- a/compiler/rustc_hir_typeck/src/method/mod.rs
+++ b/compiler/rustc_hir_typeck/src/method/mod.rs
@@ -183,7 +183,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         args: &'tcx [hir::Expr<'tcx>],
     ) -> Result<MethodCallee<'tcx>, MethodError<'tcx>> {
         let scope = if let Some(only_method) = segment.res.opt_def_id() {
-            ProbeScope::Single(only_method)
+            ProbeScope::Single(only_method, None)
         } else {
             ProbeScope::TraitsInScope
         };
@@ -283,7 +283,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         method_name: Ident,
         self_ty: Ty<'tcx>,
         call_expr: &hir::Expr<'_>,
-        scope: ProbeScope,
+        scope: ProbeScope<'tcx>,
     ) -> probe::PickResult<'tcx> {
         let pick = self.probe_for_name(
             probe::Mode::MethodCall,
@@ -303,7 +303,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         method_name: Ident,
         self_ty: Ty<'tcx>,
         call_expr: &hir::Expr<'_>,
-        scope: ProbeScope,
+        scope: ProbeScope<'tcx>,
         return_type: Option<Ty<'tcx>>,
     ) -> probe::PickResult<'tcx> {
         let pick = self.probe_for_name(

--- a/compiler/rustc_hir_typeck/src/method/probe.rs
+++ b/compiler/rustc_hir_typeck/src/method/probe.rs
@@ -86,6 +86,15 @@ pub(crate) struct ProbeContext<'a, 'tcx> {
     /// machinery, since we don't particularly care about, for example, similarly named
     /// candidates if we're *reporting* similarly named candidates.
     is_suggestion: IsSuggestion,
+
+    /// Hack for applying method probing routine for arbitrary types
+    /// in order to get adjustments as if they were at receiver position.
+    /// Used only for delegation's `Self` arguments mapping.
+    /// FIXME(fn_delegation): now this hack is used, however in perfect world
+    /// we would like to separate adjustments finding logic from probe context,
+    /// if we do so we will be able to find wanted adjustments given only two
+    /// types without reusing the whole method probing routine
+    self_ty_override: Option<Ty<'tcx>>,
 }
 
 impl<'a, 'tcx> Deref for ProbeContext<'a, 'tcx> {
@@ -259,10 +268,10 @@ pub(crate) enum Mode {
     Path,
 }
 
-#[derive(PartialEq, Eq, Copy, Clone, Debug)]
-pub(crate) enum ProbeScope {
+#[derive(PartialEq, Eq, Debug)]
+pub(crate) enum ProbeScope<'tcx> {
     // Single candidate coming from pre-resolved delegation method.
-    Single(DefId),
+    Single(DefId, Option<Ty<'tcx>> /* self_ty override */),
 
     // Assemble candidates coming only from traits in scope.
     TraitsInScope,
@@ -330,7 +339,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         is_suggestion: IsSuggestion,
         self_ty: Ty<'tcx>,
         scope_expr_id: HirId,
-        scope: ProbeScope,
+        scope: ProbeScope<'tcx>,
     ) -> PickResult<'tcx> {
         self.probe_op(
             item_name.span,
@@ -354,7 +363,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         is_suggestion: IsSuggestion,
         self_ty: Ty<'tcx>,
         scope_expr_id: HirId,
-        scope: ProbeScope,
+        scope: ProbeScope<'tcx>,
     ) -> Result<Vec<Candidate<'tcx>>, MethodError<'tcx>> {
         self.probe_op(
             item_name.span,
@@ -384,7 +393,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         is_suggestion: IsSuggestion,
         self_ty: Ty<'tcx>,
         scope_expr_id: HirId,
-        scope: ProbeScope,
+        scope: ProbeScope<'tcx>,
         op: OP,
     ) -> Result<R, MethodError<'tcx>>
     where
@@ -556,7 +565,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     probe_cx.assemble_inherent_candidates();
                     probe_cx.assemble_extension_candidates_for_all_traits();
                 }
-                ProbeScope::Single(def_id) => {
+                ProbeScope::Single(def_id, self_ty_override) => {
                     let item = self.tcx.associated_item(def_id);
                     // FIXME(fn_delegation): Delegation to inherent methods is not yet supported.
                     assert_eq!(item.container, AssocContainer::Trait);
@@ -567,6 +576,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     let trait_args = self.fresh_args_for_item(trait_span, trait_def_id);
                     let trait_ref = ty::TraitRef::new_from_args(self.tcx, trait_def_id, trait_args);
 
+                    probe_cx.self_ty_override = self_ty_override;
                     probe_cx.push_candidate(
                         Candidate {
                             item,
@@ -782,6 +792,7 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
             static_candidates: RefCell::new(Vec::new()),
             scope_expr_id,
             is_suggestion,
+            self_ty_override: None,
         }
     }
 
@@ -1936,7 +1947,6 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
         }
     }
 
-    #[instrument(level = "debug", skip(self, possibly_unsatisfied_predicates), ret)]
     fn consider_probe(
         &self,
         self_ty: Ty<'tcx>,
@@ -2544,7 +2554,7 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
     ) -> (Ty<'tcx>, Option<Ty<'tcx>>) {
         if item.is_fn() && self.mode == Mode::MethodCall {
             let sig = self.xform_method_sig(item.def_id, args);
-            (sig.inputs()[0], Some(sig.output()))
+            (self.self_ty_override.unwrap_or(sig.inputs()[0]), Some(sig.output()))
         } else {
             (impl_ty, None)
         }

--- a/tests/ui/delegation/self-mapping-arguments-errors.rs
+++ b/tests/ui/delegation/self-mapping-arguments-errors.rs
@@ -44,4 +44,29 @@ mod complex_Self_doesnt_map {
     //~^ ERROR: mismatched types
 }
 
+// FIXME(fn_delegation): support heuristics to wrap return value
+// with complex type (`Box<Rc<Self>>`).
+mod return_type_self_mapping_produces_error {
+    trait MyAdd {
+        fn add(self, other: Self) -> Self;
+    }
+
+    impl MyAdd for usize {
+        fn add(self, other: Self) -> Self { self + other }
+    }
+
+    #[derive(Eq, PartialEq, Debug)]
+    struct W(Box<usize>);
+    reuse impl MyAdd for W { //~ ERROR: mismatched types
+        println!("{self:?}");
+        let _x = 213;
+
+        self.0
+    }
+
+    pub fn check() {
+        assert_eq!(W(Box::new(5)).add(W(Box::new(5))), W(Box::new(10)));
+    }
+}
+
 fn main() {}

--- a/tests/ui/delegation/self-mapping-arguments-errors.stderr
+++ b/tests/ui/delegation/self-mapping-arguments-errors.stderr
@@ -75,24 +75,65 @@ LL +     }, ())
    |
 
 error[E0308]: mismatched types
-  --> $DIR/self-mapping-arguments-errors.rs:43:5
+  --> $DIR/self-mapping-arguments-errors.rs:43:30
    |
 LL |     reuse impl MyAdd for W { self.0 }
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |     |
-   |     expected `Box<usize>`, found `Box<W>`
+   |     -------------------------^^^^^^--
+   |     |                        |
+   |     |                        expected `Box<usize>`, found `usize`
    |     arguments to this function are incorrect
    |     this return type influences the call expression's return type
    |
+note: there is a field `0` on `Box<complex_Self_doesnt_map::W>` with type `std::ptr::Unique<complex_Self_doesnt_map::W>` but it is private; `0` from `complex_Self_doesnt_map::W` was accessed through auto-deref instead
+  --> $SRC_DIR/alloc/src/boxed.rs:LL:COL
+   |
+   = note: in this struct
+  ::: $SRC_DIR/alloc/src/boxed.rs:LL:COL
+   |
+   = note: if this field wasn't private, it would be accessible
+   |
+  ::: $DIR/self-mapping-arguments-errors.rs:42:12
+   |
+LL |     struct W(usize);
+   |            - ----- this is the field that was accessed
+   |            |
+   |            this struct is accessible through auto-deref
    = note: expected struct `Box<usize>`
-              found struct `Box<complex_Self_doesnt_map::W>`
+                found type `usize`
+   = note: for more on the distinction between the stack and the heap, read https://doc.rust-lang.org/book/ch15-01-box.html, https://doc.rust-lang.org/rust-by-example/std/box.html, and https://doc.rust-lang.org/std/boxed/index.html
 note: method defined here
   --> $DIR/self-mapping-arguments-errors.rs:34:12
    |
 LL |         fn add(self, other: Box<Self>) -> Self;
    |            ^^^       -----
+help: store this in the heap by calling `Box::new`
+   |
+LL |     reuse impl MyAdd for W { Box::new(self.0) }
+   |                              +++++++++      +
 
-error: aborting due to 5 previous errors
+error[E0308]: mismatched types
+  --> $DIR/self-mapping-arguments-errors.rs:60:5
+   |
+LL | /     reuse impl MyAdd for W {
+LL | |         println!("{self:?}");
+LL | |         let _x = 213;
+...  |
+LL | |     }
+   | |_____^ expected `Box<usize>`, found `usize`
+   |
+   = note: expected struct `Box<usize>`
+                found type `usize`
+   = note: for more on the distinction between the stack and the heap, read https://doc.rust-lang.org/book/ch15-01-box.html, https://doc.rust-lang.org/rust-by-example/std/box.html, and https://doc.rust-lang.org/std/boxed/index.html
+help: store this in the heap by calling `Box::new`
+   |
+LL ~     Box::new(reuse impl MyAdd for W {
+LL |         println!("{self:?}");
+...
+LL |         self.0
+LL ~     })
+   |
+
+error: aborting due to 6 previous errors
 
 Some errors have detailed explanations: E0061, E0186, E0277, E0308.
 For more information about an error, try `rustc --explain E0061`.

--- a/tests/ui/delegation/self-mapping-arguments.rs
+++ b/tests/ui/delegation/self-mapping-arguments.rs
@@ -53,7 +53,189 @@ mod arguments_mapping_works_without_return_self {
     }
 }
 
+// Test simple mapping: Box<Self> -> Self.
+mod default_test_args_adjustments {
+    trait MyAdd {
+        fn add(self, other: Self);
+    }
+
+    impl MyAdd for usize {
+        fn add(self, other: Self) { println!("{}", self + other); }
+    }
+
+    #[derive(Eq, PartialEq, Debug)]
+    struct W(Box<usize>);
+    reuse impl MyAdd for W {
+        println!("{self:?}");
+        let _x = 213;
+
+        self.0
+    }
+
+    pub fn check() {
+        assert_eq!(W(Box::new(5)).add(W(Box::new(5))), ());
+    }
+}
+
+// Test a bit more complex mappings:
+// `Rc<Arc<Rc<Arc<Rc<usize>>>>>` -> `&Arc<Rc<Self>>`
+// `Rc<Arc<Rc<Arc<Rc<usize>>>>>` -> `&Arc<Rc<Arc<Rc<Self>>>>`
+// `Rc<Arc<Rc<Arc<Rc<usize>>>>>` -> `&Self`
+mod default_test_args_adjustments_2 {
+    use std::sync::Arc;
+    use std::rc::Rc;
+
+    trait MyAdd {
+        fn add(&self, other: &Arc<Rc<Self>>, another_other: &Arc<Rc<Arc<Rc<Self>>>>);
+    }
+
+    impl MyAdd for usize {
+        fn add(&self, other: &Arc<Rc<Self>>, another_other: &Arc<Rc<Arc<Rc<Self>>>>) {
+            println!("{}", *self + ***other + *****another_other);
+        }
+    }
+
+    #[derive(Eq, PartialEq, Debug)]
+    struct W(Rc<Arc<Rc<Arc<Rc<usize>>>>>);
+    reuse impl MyAdd for W {
+        println!("{self:?}");
+        let _x = 213;
+
+        self.0
+    }
+
+    pub fn check() {
+        fn w(x: usize) -> W {
+            W(Rc::new(Arc::new(Rc::new(Arc::new(Rc::new(x))))))
+        }
+        assert_eq!(
+            w(10).add(
+                &Arc::new(Rc::new(w(10))),
+                &Arc::new(Rc::new(Arc::new(Rc::new(w(10)))))
+            ),
+            ()
+        );
+    }
+}
+
+// Same as previous test by with more arguments and receiver is complex: `&Arc<Rc<Self>>`.
+mod default_test_args_adjustments_3 {
+    use std::sync::Arc;
+    use std::rc::Rc;
+
+    trait MyAdd {
+        fn add(self: &Arc<Rc<Self>>, a: &Arc<Rc<Self>>, b: &Arc<Rc<Arc<Rc<Self>>>>);
+    }
+
+    impl MyAdd for usize {
+        fn add(self: &Arc<Rc<Self>>, a: &Arc<Rc<Self>>, b: &Arc<Rc<Arc<Rc<Self>>>>) {
+            println!("{}", ***self + ***a + *****b);
+        }
+    }
+
+    #[derive(Eq, PartialEq, Debug)]
+    struct W(Rc<Arc<Rc<Arc<Rc<usize>>>>>);
+    reuse impl MyAdd for W {
+        println!("{self:?}");
+        let _x = 213;
+
+        self.0
+    }
+
+    pub fn check() {
+        fn w(x: usize) -> W {
+            W(Rc::new(Arc::new(Rc::new(Arc::new(Rc::new(x))))))
+        }
+        assert_eq!(
+            Arc::new(Rc::new(w(15))).add(
+                &Arc::new(Rc::new(w(15))),
+                &Arc::new(Rc::new(Arc::new(Rc::new(w(15)))))
+            ),
+            ()
+        );
+    }
+}
+
+// Test mappings from `Box<Box<Box<usize>>>` to `Self`, `&mut Self`, `&Self`.
+mod default_test_args_adjustments_4 {
+    trait MyAdd {
+        fn add(self: &Self, other: &mut Self, another_other: Self);
+    }
+
+    impl MyAdd for usize {
+        fn add(self: &Self, other: &mut Self, another_other: Self) {
+            println!("{}", *self + *other + another_other);
+        }
+    }
+
+    #[derive(Eq, PartialEq, Debug)]
+    struct W(Box<Box<Box<usize>>>);
+    reuse impl MyAdd for W {
+        println!("{self:?}");
+        let _x = 213;
+
+        self.0
+    }
+
+    pub fn check() {
+        fn w(x: usize) -> W {
+            W(Box::new(Box::new(Box::new(x))))
+        }
+        assert_eq!(
+            w(20).add(&mut w(20), w(20)),
+            ()
+        );
+    }
+}
+
+// Add non-Self args (`a: ()`, `b: impl MyAdd`) to ensure that mapping
+// is not applied to them.
+mod default_test_with_non_self_args {
+    trait MyAdd: std::fmt::Debug {
+        fn add(self, a: (), other: Self, b: impl MyAdd) -> Self;
+    }
+
+    impl MyAdd for usize {
+        fn add(self, a: (), other: usize, b: impl MyAdd) -> usize {
+            println!("Non-self arg a: {a:?}");
+            println!("Non-self arg b: {b:?}");
+            self + other
+        }
+    }
+
+    #[derive(Eq, PartialEq, Debug)]
+    struct W(usize);
+    reuse impl MyAdd for W {
+        println!("{self:?}");
+        let _x = 213;
+
+        self.0
+    }
+
+    pub fn check() {
+        assert_eq!(W(1).add((), W(2), 123), W(3))
+    }
+}
+
 fn main() {
+    println!("default_test");
     default_test::check();
+
+    println!("arguments_mapping_works_without_return_self");
     arguments_mapping_works_without_return_self::check();
+
+    println!("default_test_args_adjustments");
+    default_test_args_adjustments::check();
+
+    println!("default_test_args_adjustments_2");
+    default_test_args_adjustments_2::check();
+
+    println!("default_test_args_adjustments_3");
+    default_test_args_adjustments_3::check();
+
+    println!("default_test_args_adjustments_4");
+    default_test_args_adjustments_4::check();
+
+    println!("default_test_with_non_self_args");
+    default_test_with_non_self_args::check();
 }

--- a/tests/ui/delegation/self-mapping-arguments.run.stdout
+++ b/tests/ui/delegation/self-mapping-arguments.run.stdout
@@ -1,5 +1,31 @@
+default_test
 W(1)
 W(2)
+arguments_mapping_works_without_return_self
 W(2)
 W(10)
 12
+default_test_args_adjustments
+W(5)
+W(5)
+10
+default_test_args_adjustments_2
+W(10)
+W(10)
+W(10)
+30
+default_test_args_adjustments_3
+W(15)
+W(15)
+W(15)
+45
+default_test_args_adjustments_4
+W(20)
+W(20)
+W(20)
+60
+default_test_with_non_self_args
+W(1)
+W(2)
+Non-self arg a: ()
+Non-self arg b: 123


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/158945)*
<!-- homu-ignore:end -->

This PR implements initial version of Self mapping adjustments of all arguments that are needed to be mapped. The method probing routine is reused in order to find adjustments for each mapped argument, then they are processed in the same way the receiver is processed in delegation. The current solution is a bit hacky, explained in the comment:
```rust
/// Hack for applying method probing routine for arbitrary types
/// in order to get adjustments as if they were at receiver position.
/// Used only for delegation's `Self` arguments mapping.
/// FIXME(fn_delegation): now this hack is used, however in perfect world
/// we would like to separate adjustments finding logic from probe context,
/// if we do so we will be able to find wanted adjustments given only two
/// types without reusing the whole method probing routine
```

The next part of Self mapping is to support heuristics to map complex return types: `Self` -> `Box<Arc<Self>>`.

Part of rust-lang/rust#118212.
r? @petrochenkov