### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6278,9 +6278,9 @@ dependencies = [
 
 [[package]]
 name = "wasi-preview1-component-adapter-provider"
-version = "44.0.2"
+version = "46.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2211ca2d69a88055eefb06bad741dde3180c9d4020f7e42fea72caba83f9c10c"
+checksum = "1b6c48003fe59c201c97a7786ff55feabe6b6f83b598aa9ff5bcc4f94d940bf3"
 
 [[package]]
 name = "wasip2"
@@ -6347,9 +6347,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-component-ld"
-version = "0.5.25"
+version = "0.5.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee72c06c556db23aca2d29e1e183d96efdffa7110b24915629a5091de600a894"
+checksum = "51a12709376d4ce64f472699500db3b0e5902cc2bef16fb6ca3098bfdac032fa"
 dependencies = [
  "anyhow",
  "clap",
@@ -6358,12 +6358,12 @@ dependencies = [
  "libc",
  "tempfile",
  "wasi-preview1-component-adapter-provider",
- "wasmparser 0.252.0",
+ "wasmparser 0.253.0",
  "wat",
  "windows-sys 0.61.2",
  "winsplit",
- "wit-component 0.252.0",
- "wit-parser 0.252.0",
+ "wit-component 0.253.0",
+ "wit-parser 0.253.0",
 ]
 
 [[package]]
@@ -6395,12 +6395,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.252.0"
+version = "0.253.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8185ae345fa5687c054626ff9a50e7089797a343d9904d1dc9820eb4c4d3196f"
+checksum = "59972d6cd272259de647b7c1f1912e45e289c75ffd4be04e10695507cd7e1b59"
 dependencies = [
  "leb128fmt",
- "wasmparser 0.252.0",
+ "wasmparser 0.253.0",
 ]
 
 [[package]]
@@ -6417,14 +6417,14 @@ dependencies = [
 
 [[package]]
 name = "wasm-metadata"
-version = "0.252.0"
+version = "0.253.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b7e08e02a3cd55bf778009d4cd6faae50da011f293644daf78a531a32d6d142"
+checksum = "b3f45816ef616806f48498bcd831377de578c4fa51db0c83ab8ceb78cc13523b"
 dependencies = [
  "anyhow",
  "indexmap",
- "wasm-encoder 0.252.0",
- "wasmparser 0.252.0",
+ "wasm-encoder 0.253.0",
+ "wasmparser 0.253.0",
 ]
 
 [[package]]
@@ -6461,9 +6461,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.252.0"
+version = "0.253.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3eb099dcadcde5be9eef55e3a337128efd4e44b4c93122487e4d2e4e1c6627c"
+checksum = "19db11f87d2486580e1e8b6f494c54df7e0566b87d0b599db843c24019667339"
 dependencies = [
  "bitflags",
  "hashbrown 0.17.0",
@@ -6474,22 +6474,22 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "252.0.0"
+version = "253.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "942a3449d6a593fccc111a6241c8df52bda168af30e40bf9580d4394d7374c65"
+checksum = "d3264542f8965c5d84fb1085d924bfba9a6314bb228eff13a2de14d7627664d0"
 dependencies = [
  "bumpalo",
  "leb128fmt",
  "memchr",
  "unicode-width 0.2.2",
- "wasm-encoder 0.252.0",
+ "wasm-encoder 0.253.0",
 ]
 
 [[package]]
 name = "wat"
-version = "1.252.0"
+version = "1.253.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c72a4ba7088f7bac94cf516e49882bdf97068904a563768cf249efc839ec42cb"
+checksum = "4bfc5ce906144200c972ec617470aa35bd847472e170b26dde3e80541c674055"
 dependencies = [
  "wast",
 ]
@@ -6925,9 +6925,9 @@ dependencies = [
 
 [[package]]
 name = "wit-component"
-version = "0.252.0"
+version = "0.253.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76db0662b590f45d33d0e363fa13539a5a1eecd35d5a12fe208c335461c1053d"
+checksum = "dbbd2500ac3488489ee8c6e59b79d7e47e6da5bfb019efd35d5dca57b78af624"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -6936,10 +6936,10 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder 0.252.0",
- "wasm-metadata 0.252.0",
- "wasmparser 0.252.0",
- "wit-parser 0.252.0",
+ "wasm-encoder 0.253.0",
+ "wasm-metadata 0.253.0",
+ "wasmparser 0.253.0",
+ "wit-parser 0.253.0",
 ]
 
 [[package]]
@@ -6962,9 +6962,9 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.252.0"
+version = "0.253.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4266bea110371c620ccf3201c5023676046bc4556e5c7cfb5d500bda5ebc162d"
+checksum = "4d997b8e5920fcbeec742b58e583325d6419a6aca617ae8075c406a61c65ba8a"
 dependencies = [
  "anyhow",
  "hashbrown 0.17.0",
@@ -6976,7 +6976,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-ident",
- "wasmparser 0.252.0",
+ "wasmparser 0.253.0",
 ]
 
 [[package]]

--- a/compiler/rustc_abi/src/callconv.rs
+++ b/compiler/rustc_abi/src/callconv.rs
@@ -89,7 +89,7 @@ impl<'a, Ty> TyAndLayout<'a, Ty> {
                 unreachable!("`homogeneous_aggregate` should not be called for scalable vectors")
             }
 
-            BackendRepr::ScalarPair(..) | BackendRepr::Memory { sized: true } => {
+            BackendRepr::ScalarPair { .. } | BackendRepr::Memory { sized: true } => {
                 // Helper for computing `homogeneous_aggregate`, allowing a custom
                 // starting offset (used below for handling variants).
                 let from_fields_at =

--- a/compiler/rustc_abi/src/layout.rs
+++ b/compiler/rustc_abi/src/layout.rs
@@ -476,7 +476,7 @@ impl<Cx: HasDataLayout> LayoutCalculator<Cx> {
             Err(AbiMismatch) | Ok(None) => BackendRepr::Memory { sized: true },
             Ok(Some((repr, _))) => match repr {
                 // Mismatched alignment (e.g. union is #[repr(packed)]): disable opt
-                BackendRepr::Scalar(_) | BackendRepr::ScalarPair(_, _)
+                BackendRepr::Scalar(_) | BackendRepr::ScalarPair { .. }
                     if repr.scalar_platform_align(dl).unwrap() != align =>
                 {
                     BackendRepr::Memory { sized: true }
@@ -489,7 +489,7 @@ impl<Cx: HasDataLayout> LayoutCalculator<Cx> {
                 }
                 // the alignment tests passed and we can use this
                 BackendRepr::Scalar(..)
-                | BackendRepr::ScalarPair(..)
+                | BackendRepr::ScalarPair { .. }
                 | BackendRepr::SimdVector { .. }
                 | BackendRepr::SimdScalableVector { .. }
                 | BackendRepr::Memory { .. } => repr,
@@ -558,7 +558,7 @@ impl<Cx: HasDataLayout> LayoutCalculator<Cx> {
             };
             match &mut st.backend_repr {
                 BackendRepr::Scalar(scalar) => hide_niches(scalar),
-                BackendRepr::ScalarPair(a, b) => {
+                BackendRepr::ScalarPair { a, b, b_offset: _ } => {
                     hide_niches(a);
                     hide_niches(b);
                 }
@@ -701,13 +701,21 @@ impl<Cx: HasDataLayout> LayoutCalculator<Cx> {
                     // When the total alignment and size match, we can use the
                     // same ABI as the scalar variant with the reserved niche.
                     BackendRepr::Scalar(_) => BackendRepr::Scalar(niche_scalar),
-                    BackendRepr::ScalarPair(first, second) => {
+                    BackendRepr::ScalarPair { a: first, b: second, b_offset } => {
                         // Only the niche is guaranteed to be initialised,
                         // so use union layouts for the other primitive.
                         if niche_offset == Size::ZERO {
-                            BackendRepr::ScalarPair(niche_scalar, second.to_union())
+                            BackendRepr::ScalarPair {
+                                a: niche_scalar,
+                                b: second.to_union(),
+                                b_offset,
+                            }
                         } else {
-                            BackendRepr::ScalarPair(first.to_union(), niche_scalar)
+                            BackendRepr::ScalarPair {
+                                a: first.to_union(),
+                                b: niche_scalar,
+                                b_offset,
+                            }
                         }
                     }
                     _ => BackendRepr::Memory { sized: true },
@@ -1037,7 +1045,7 @@ impl<Cx: HasDataLayout> LayoutCalculator<Cx> {
         // If we pick a "clever" (by-value) ABI, we might have to adjust the ABI of the
         // variants to ensure they are consistent. This is because a downcast is
         // semantically a NOP, and thus should not affect layout.
-        if matches!(abi, BackendRepr::Scalar(..) | BackendRepr::ScalarPair(..)) {
+        if matches!(abi, BackendRepr::Scalar(..) | BackendRepr::ScalarPair { .. }) {
             for variant in &mut layout_variants {
                 // We only do this for variants with fields; the others are not accessed anyway.
                 // Also do not overwrite any already existing "clever" ABIs.
@@ -1354,7 +1362,7 @@ impl<Cx: HasDataLayout> LayoutCalculator<Cx> {
                             }
                             // But scalar pairs are Rust-specific and get
                             // treated as aggregates by C ABIs anyway.
-                            BackendRepr::ScalarPair(..) => {
+                            BackendRepr::ScalarPair { .. } => {
                                 abi = field.backend_repr;
                             }
                             _ => {}

--- a/compiler/rustc_abi/src/layout/simple.rs
+++ b/compiler/rustc_abi/src/layout/simple.rs
@@ -110,7 +110,7 @@ impl<FieldIdx: Idx, VariantIdx: Idx> LayoutData<FieldIdx, VariantIdx> {
                 offsets: [Size::ZERO, b_offset].into(),
                 in_memory_order: [FieldIdx::new(0), FieldIdx::new(1)].into(),
             },
-            backend_repr: BackendRepr::ScalarPair(a, b),
+            backend_repr: BackendRepr::ScalarPair { a, b, b_offset },
             largest_niche,
             uninhabited: false,
             align: AbiAlign::new(align),

--- a/compiler/rustc_abi/src/lib.rs
+++ b/compiler/rustc_abi/src/lib.rs
@@ -1796,14 +1796,18 @@ impl IntoDiagArg for NumScalableVectors {
 pub enum BackendRepr {
     Scalar(Scalar),
     /// The data contained in this type can be entirely represented by two scalars.
-    /// The two scalars are listed in *memory* order, so the first is at offset zero
-    /// and the second at a non-zero offset.
+    /// The two scalars are listed in *memory* order, so `a` is at offset zero
+    /// and `b` is at non-zero offset `b_offset`.
     /// These need not be `FieldIdx(0)` and `FieldIdx(1)`.
     ///
-    /// As of June 2026 the offset to the second scalar is the size of the first
-    /// scalar rounded up to the platform alignment of the second scalar.
+    /// As of June 2026 the `b_offset` is always the size of the `a`
+    /// scalar rounded up to the platform alignment of the `b` scalar.
     /// That may soon change, however; see MCP#1007.
-    ScalarPair(Scalar, Scalar),
+    ScalarPair {
+        a: Scalar,
+        b: Scalar,
+        b_offset: Size,
+    },
     SimdScalableVector {
         element: Scalar,
         count: u64,
@@ -1826,7 +1830,7 @@ impl BackendRepr {
     pub fn is_unsized(&self) -> bool {
         match *self {
             BackendRepr::Scalar(_)
-            | BackendRepr::ScalarPair(..)
+            | BackendRepr::ScalarPair { .. }
             // FIXME(rustc_scalable_vector): Scalable vectors are `Sized` while the
             // `sized_hierarchy` feature is not yet fully implemented. After `sized_hierarchy` is
             // fully implemented, scalable vectors will remain `Sized`, they just won't be
@@ -1875,7 +1879,7 @@ impl BackendRepr {
     pub fn scalar_platform_align<C: HasDataLayout>(&self, cx: &C) -> Option<Align> {
         match *self {
             BackendRepr::Scalar(s) => Some(s.default_align(cx).abi),
-            BackendRepr::ScalarPair(s1, s2) => {
+            BackendRepr::ScalarPair { a: s1, b: s2, b_offset: _ } => {
                 Some(s1.default_align(cx).max(s2.default_align(cx)).abi)
             }
             // The align of a Vector can vary in surprising ways
@@ -1893,8 +1897,7 @@ impl BackendRepr {
             // No padding in scalars.
             BackendRepr::Scalar(s) => Some(s.size(cx)),
             // May have some padding between the pair.
-            BackendRepr::ScalarPair(s1, s2) => {
-                let field2_offset = s1.size(cx).align_to(s2.default_align(cx).abi);
+            BackendRepr::ScalarPair { a: _, b: s2, b_offset: field2_offset } => {
                 let size = (field2_offset + s2.size(cx)).align_to(
                     self.scalar_platform_align(cx)
                         // We absolutely must have an answer here or everything is FUBAR.
@@ -1913,8 +1916,8 @@ impl BackendRepr {
     pub fn to_union(&self) -> Self {
         match *self {
             BackendRepr::Scalar(s) => BackendRepr::Scalar(s.to_union()),
-            BackendRepr::ScalarPair(s1, s2) => {
-                BackendRepr::ScalarPair(s1.to_union(), s2.to_union())
+            BackendRepr::ScalarPair { a: s1, b: s2, b_offset } => {
+                BackendRepr::ScalarPair { a: s1.to_union(), b: s2.to_union(), b_offset }
             }
             BackendRepr::SimdVector { element, count } => {
                 BackendRepr::SimdVector { element: element.to_union(), count }
@@ -1939,8 +1942,13 @@ impl BackendRepr {
                 BackendRepr::SimdVector { element: element_l, count: count_l },
                 BackendRepr::SimdVector { element: element_r, count: count_r },
             ) => element_l.primitive() == element_r.primitive() && count_l == count_r,
-            (BackendRepr::ScalarPair(l1, l2), BackendRepr::ScalarPair(r1, r2)) => {
-                l1.primitive() == r1.primitive() && l2.primitive() == r2.primitive()
+            (
+                BackendRepr::ScalarPair { a: l1, b: l2, b_offset: l_offset },
+                BackendRepr::ScalarPair { a: r1, b: r2, b_offset: r_offset },
+            ) => {
+                l1.primitive() == r1.primitive()
+                    && l2.primitive() == r2.primitive()
+                    && l_offset == r_offset
             }
             // Everything else must be strictly identical.
             _ => self == other,
@@ -2180,7 +2188,7 @@ impl<FieldIdx: Idx, VariantIdx: Idx> LayoutData<FieldIdx, VariantIdx> {
             BackendRepr::Scalar(_)
             | BackendRepr::SimdVector { .. }
             | BackendRepr::SimdScalableVector { .. } => false,
-            BackendRepr::ScalarPair(..) | BackendRepr::Memory { .. } => true,
+            BackendRepr::ScalarPair { .. } | BackendRepr::Memory { .. } => true,
         }
     }
 
@@ -2294,7 +2302,7 @@ impl<FieldIdx: Idx, VariantIdx: Idx> LayoutData<FieldIdx, VariantIdx> {
     pub fn is_zst(&self) -> bool {
         match self.backend_repr {
             BackendRepr::Scalar(_)
-            | BackendRepr::ScalarPair(..)
+            | BackendRepr::ScalarPair { .. }
             | BackendRepr::SimdScalableVector { .. }
             | BackendRepr::SimdVector { .. } => false,
             BackendRepr::Memory { sized } => sized && self.size.bytes() == 0,

--- a/compiler/rustc_codegen_cranelift/src/abi/mod.rs
+++ b/compiler/rustc_codegen_cranelift/src/abi/mod.rs
@@ -220,7 +220,7 @@ fn make_local_place<'tcx>(
         );
     }
     let place = if is_ssa {
-        if let BackendRepr::ScalarPair(_, _) = layout.backend_repr {
+        if let BackendRepr::ScalarPair { a: _, b: _, b_offset: _ } = layout.backend_repr {
             CPlace::new_var_pair(fx, local, layout)
         } else {
             CPlace::new_var(fx, local, layout)

--- a/compiler/rustc_codegen_cranelift/src/abi/pass_mode.rs
+++ b/compiler/rustc_codegen_cranelift/src/abi/pass_mode.rs
@@ -112,7 +112,7 @@ impl<'tcx> ArgAbiExt<'tcx> for ArgAbi<'tcx, Ty<'tcx>> {
                 _ => unreachable!("{:?}", self.layout.backend_repr),
             },
             PassMode::Pair(attrs_a, attrs_b) => match self.layout.backend_repr {
-                BackendRepr::ScalarPair(a, b) => {
+                BackendRepr::ScalarPair { a, b, b_offset: _ } => {
                     let a = scalar_to_clif_type(tcx, a);
                     let b = scalar_to_clif_type(tcx, b);
                     smallvec![
@@ -167,7 +167,7 @@ impl<'tcx> ArgAbiExt<'tcx> for ArgAbi<'tcx, Ty<'tcx>> {
                 _ => unreachable!("{:?}", self.layout.backend_repr),
             },
             PassMode::Pair(attrs_a, attrs_b) => match self.layout.backend_repr {
-                BackendRepr::ScalarPair(a, b) => {
+                BackendRepr::ScalarPair { a, b, b_offset: _ } => {
                     let a = scalar_to_clif_type(tcx, a);
                     let b = scalar_to_clif_type(tcx, b);
                     (

--- a/compiler/rustc_codegen_cranelift/src/base.rs
+++ b/compiler/rustc_codegen_cranelift/src/base.rs
@@ -695,7 +695,7 @@ fn codegen_stmt<'tcx>(fx: &mut FunctionCx<'_, '_, 'tcx>, cur_block: Block, stmt:
                         }
                         UnOp::PtrMetadata => match layout.backend_repr {
                             BackendRepr::Scalar(_) => CValue::zst(dest_layout),
-                            BackendRepr::ScalarPair(_, _) => {
+                            BackendRepr::ScalarPair { a: _, b: _, b_offset: _ } => {
                                 CValue::by_val(operand.load_scalar_pair(fx).1, dest_layout)
                             }
                             _ => bug!("Unexpected `PtrToMetadata` operand: {operand:?}"),

--- a/compiler/rustc_codegen_cranelift/src/intrinsics/mod.rs
+++ b/compiler/rustc_codegen_cranelift/src/intrinsics/mod.rs
@@ -572,7 +572,9 @@ fn codegen_regular_intrinsic_call<'tcx>(
             let layout = fx.layout_of(generic_args.type_at(0));
             // Note: Can't use is_unsized here as truly unsized types need to take the fixed size
             // branch
-            let meta = if let BackendRepr::ScalarPair(_, _) = ptr.layout().backend_repr {
+            let meta = if let BackendRepr::ScalarPair { a: _, b: _, b_offset: _ } =
+                ptr.layout().backend_repr
+            {
                 Some(ptr.load_scalar_pair(fx).1)
             } else {
                 None
@@ -586,7 +588,9 @@ fn codegen_regular_intrinsic_call<'tcx>(
             let layout = fx.layout_of(generic_args.type_at(0));
             // Note: Can't use is_unsized here as truly unsized types need to take the fixed size
             // branch
-            let meta = if let BackendRepr::ScalarPair(_, _) = ptr.layout().backend_repr {
+            let meta = if let BackendRepr::ScalarPair { a: _, b: _, b_offset: _ } =
+                ptr.layout().backend_repr
+            {
                 Some(ptr.load_scalar_pair(fx).1)
             } else {
                 None

--- a/compiler/rustc_codegen_cranelift/src/value_and_place.rs
+++ b/compiler/rustc_codegen_cranelift/src/value_and_place.rs
@@ -55,8 +55,7 @@ fn codegen_field<'tcx>(
     }
 }
 
-fn scalar_pair_calculate_b_offset(tcx: TyCtxt<'_>, a_scalar: Scalar, b_scalar: Scalar) -> Offset32 {
-    let b_offset = a_scalar.size(&tcx).align_to(b_scalar.default_align(&tcx).abi);
+fn scalar_pair_convert_b_offset(b_offset: Size) -> Offset32 {
     Offset32::new(b_offset.bytes().try_into().unwrap())
 }
 
@@ -159,11 +158,11 @@ impl<'tcx> CValue<'tcx> {
         let layout = self.1;
         match self.0 {
             CValueInner::ByRef(ptr, None) => {
-                let (a_scalar, b_scalar) = match layout.backend_repr {
-                    BackendRepr::ScalarPair(a, b) => (a, b),
+                let (a_scalar, b_scalar, b_offset) = match layout.backend_repr {
+                    BackendRepr::ScalarPair { a, b, b_offset } => (a, b, b_offset),
                     _ => unreachable!("load_scalar_pair({:?})", self),
                 };
-                let b_offset = scalar_pair_calculate_b_offset(fx.tcx, a_scalar, b_scalar);
+                let b_offset = scalar_pair_convert_b_offset(b_offset);
                 let clif_ty1 = scalar_to_clif_type(fx.tcx, a_scalar);
                 let clif_ty2 = scalar_to_clif_type(fx.tcx, b_scalar);
                 let mut flags = MemFlags::new();
@@ -189,7 +188,7 @@ impl<'tcx> CValue<'tcx> {
         match self.0 {
             CValueInner::ByVal(_) => unreachable!(),
             CValueInner::ByValPair(val1, val2) => match layout.backend_repr {
-                BackendRepr::ScalarPair(_, _) => {
+                BackendRepr::ScalarPair { a: _, b: _, b_offset: _ } => {
                     let val = match field.as_u32() {
                         0 => val1,
                         1 => val2,
@@ -580,7 +579,7 @@ impl<'tcx> CPlace<'tcx> {
             }
             CPlaceInner::VarPair(_local, var1, var2) => {
                 let (data1, data2) = match from.1.backend_repr {
-                    BackendRepr::ScalarPair(_, _) => {
+                    BackendRepr::ScalarPair { a: _, b: _, b_offset: _ } => {
                         CValue(from.0, dst_layout).load_scalar_pair(fx)
                     }
                     _ => {
@@ -607,9 +606,8 @@ impl<'tcx> CPlace<'tcx> {
                         to_ptr.store(fx, val, flags);
                     }
                     CValueInner::ByValPair(val1, val2) => match from.layout().backend_repr {
-                        BackendRepr::ScalarPair(a_scalar, b_scalar) => {
-                            let b_offset =
-                                scalar_pair_calculate_b_offset(fx.tcx, a_scalar, b_scalar);
+                        BackendRepr::ScalarPair { a: _, b: _, b_offset } => {
+                            let b_offset = scalar_pair_convert_b_offset(b_offset);
                             to_ptr.store(fx, val1, flags);
                             to_ptr.offset(fx, b_offset).store(fx, val2, flags);
                         }
@@ -627,9 +625,8 @@ impl<'tcx> CPlace<'tcx> {
                                 to_ptr.store(fx, val, flags);
                                 return;
                             }
-                            BackendRepr::ScalarPair(a_scalar, b_scalar) => {
-                                let b_offset =
-                                    scalar_pair_calculate_b_offset(fx.tcx, a_scalar, b_scalar);
+                            BackendRepr::ScalarPair { a: _, b: _, b_offset } => {
+                                let b_offset = scalar_pair_convert_b_offset(b_offset);
                                 let (val1, val2) = from.load_scalar_pair(fx);
                                 to_ptr.store(fx, val1, flags);
                                 to_ptr.offset(fx, b_offset).store(fx, val2, flags);

--- a/compiler/rustc_codegen_cranelift/src/vtable.rs
+++ b/compiler/rustc_codegen_cranelift/src/vtable.rs
@@ -56,13 +56,14 @@ pub(crate) fn get_ptr_and_method_ref<'tcx>(
         }
     }
 
-    let (ptr, vtable) = if let BackendRepr::ScalarPair(_, _) = arg.layout().backend_repr {
-        let (ptr, vtable) = arg.load_scalar_pair(fx);
-        (Pointer::new(ptr), vtable)
-    } else {
-        let (ptr, vtable) = arg.try_to_ptr().unwrap();
-        (ptr, vtable.unwrap())
-    };
+    let (ptr, vtable) =
+        if let BackendRepr::ScalarPair { a: _, b: _, b_offset: _ } = arg.layout().backend_repr {
+            let (ptr, vtable) = arg.load_scalar_pair(fx);
+            (Pointer::new(ptr), vtable)
+        } else {
+            let (ptr, vtable) = arg.try_to_ptr().unwrap();
+            (ptr, vtable.unwrap())
+        };
 
     let usize_size = fx.layout_of(fx.tcx.types.usize).size.bytes();
     let func_ref = fx.bcx.ins().load(

--- a/compiler/rustc_codegen_gcc/src/builder.rs
+++ b/compiler/rustc_codegen_gcc/src/builder.rs
@@ -1064,9 +1064,9 @@ impl<'a, 'gcc, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'gcc, 'tcx> {
                     load
                 },
             )
-        } else if let abi::BackendRepr::ScalarPair(ref a, ref b) = place.layout.backend_repr {
-            let b_offset = a.size(self).align_to(b.default_align(self).abi);
-
+        } else if let abi::BackendRepr::ScalarPair { ref a, ref b, b_offset } =
+            place.layout.backend_repr
+        {
             let mut load = |i, scalar: &abi::Scalar, align| {
                 let ptr = if i == 0 {
                     place.val.llval

--- a/compiler/rustc_codegen_gcc/src/intrinsic/mod.rs
+++ b/compiler/rustc_codegen_gcc/src/intrinsic/mod.rs
@@ -485,7 +485,7 @@ impl<'a, 'gcc, 'tcx> IntrinsicCallBuilderMethods<'tcx> for Builder<'a, 'gcc, 'tc
                 let tp_ty = fn_args.type_at(0);
                 let layout = self.layout_of(tp_ty).layout;
                 let _use_integer_compare = match layout.backend_repr() {
-                    Scalar(_) | ScalarPair(_, _) => true,
+                    Scalar(_) | ScalarPair { a: _, b: _, b_offset: _ } => true,
                     SimdVector { .. } | SimdScalableVector { .. } => false,
                     Memory { .. } => {
                         // For rusty ABIs, small aggregates are actually passed

--- a/compiler/rustc_codegen_gcc/src/type_of.rs
+++ b/compiler/rustc_codegen_gcc/src/type_of.rs
@@ -75,7 +75,7 @@ fn uncached_gcc_type<'gcc, 'tcx>(
                 };
             return cx.context.new_vector_type(element, count);
         }
-        BackendRepr::ScalarPair(..) => {
+        BackendRepr::ScalarPair { .. } => {
             return cx.type_struct(
                 &[
                     layout.scalar_pair_element_gcc_type(cx, 0),
@@ -182,13 +182,13 @@ impl<'tcx> LayoutGccExt<'tcx> for TyAndLayout<'tcx> {
             BackendRepr::Scalar(_) | BackendRepr::SimdVector { .. } => true,
             // FIXME(rustc_scalable_vector): Not yet implemented in rustc_codegen_gcc.
             BackendRepr::SimdScalableVector { .. } => todo!(),
-            BackendRepr::ScalarPair(..) | BackendRepr::Memory { .. } => false,
+            BackendRepr::ScalarPair { .. } | BackendRepr::Memory { .. } => false,
         }
     }
 
     fn is_gcc_scalar_pair(&self) -> bool {
         match self.backend_repr {
-            BackendRepr::ScalarPair(..) => true,
+            BackendRepr::ScalarPair { .. } => true,
             BackendRepr::Scalar(_)
             | BackendRepr::SimdVector { .. }
             | BackendRepr::SimdScalableVector { .. }
@@ -308,8 +308,8 @@ impl<'tcx> LayoutGccExt<'tcx> for TyAndLayout<'tcx> {
         // This must produce the same result for `repr(transparent)` wrappers as for the inner type!
         // In other words, this should generally not look at the type at all, but only at the
         // layout.
-        let (a, b) = match self.backend_repr {
-            BackendRepr::ScalarPair(ref a, ref b) => (a, b),
+        let (a, b, b_offset) = match self.backend_repr {
+            BackendRepr::ScalarPair { ref a, ref b, b_offset } => (a, b, b_offset),
             _ => bug!("TyAndLayout::scalar_pair_element_llty({:?}): not applicable", self),
         };
         let scalar = [a, b][index];
@@ -325,8 +325,7 @@ impl<'tcx> LayoutGccExt<'tcx> for TyAndLayout<'tcx> {
             return cx.type_i1();
         }
 
-        let offset =
-            if index == 0 { Size::ZERO } else { a.size(cx).align_to(b.default_align(cx).abi) };
+        let offset = if index == 0 { Size::ZERO } else { b_offset };
         self.scalar_gcc_type_at(cx, scalar, offset)
     }
 

--- a/compiler/rustc_codegen_llvm/src/abi.rs
+++ b/compiler/rustc_codegen_llvm/src/abi.rs
@@ -551,7 +551,9 @@ impl<'ll, 'tcx> FnAbiLlvmExt<'ll, 'tcx> for FnAbi<'tcx, Ty<'tcx>> {
                 PassMode::Pair(a, b) => {
                     let i = apply(a);
                     let ii = apply(b);
-                    if let BackendRepr::ScalarPair(scalar_a, scalar_b) = arg.layout.backend_repr {
+                    if let BackendRepr::ScalarPair { a: scalar_a, b: scalar_b, b_offset: _ } =
+                        arg.layout.backend_repr
+                    {
                         apply_range_attr(llvm::AttributePlace::Argument(i), scalar_a);
                         let primitive_b = scalar_b.primitive();
                         let scalar_b = if let rustc_abi::Primitive::Int(int, false) = primitive_b

--- a/compiler/rustc_codegen_llvm/src/builder.rs
+++ b/compiler/rustc_codegen_llvm/src/builder.rs
@@ -793,9 +793,7 @@ impl<'a, 'll, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
                 }
             });
             OperandValue::Immediate(llval)
-        } else if let abi::BackendRepr::ScalarPair(a, b) = place.layout.backend_repr {
-            let b_offset = a.size(self).align_to(b.default_align(self).abi);
-
+        } else if let abi::BackendRepr::ScalarPair { a, b, b_offset } = place.layout.backend_repr {
             let mut load = |i, scalar: abi::Scalar, layout, align, offset| {
                 let llptr = if i == 0 {
                     place.val.llval

--- a/compiler/rustc_codegen_llvm/src/builder/autodiff.rs
+++ b/compiler/rustc_codegen_llvm/src/builder/autodiff.rs
@@ -118,7 +118,9 @@ pub(crate) fn adjust_activity_to_abi<'tcx>(
         // If the argument is lowered as a `ScalarPair`, we need to duplicate its activity.
         // Otherwise, the number of activities won't match the number of LLVM arguments and
         // this will lead to errors when verifying the Enzyme call.
-        if let rustc_abi::BackendRepr::ScalarPair(_, _) = layout.backend_repr() {
+        if let rustc_abi::BackendRepr::ScalarPair { a: _, b: _, b_offset: _ } =
+            layout.backend_repr()
+        {
             new_activities.push(da[i].clone());
             new_positions.push(i + 1 - del_activities);
         }

--- a/compiler/rustc_codegen_llvm/src/intrinsic.rs
+++ b/compiler/rustc_codegen_llvm/src/intrinsic.rs
@@ -574,7 +574,7 @@ impl<'ll, 'tcx> IntrinsicCallBuilderMethods<'tcx> for Builder<'_, 'll, 'tcx> {
                 let tp_ty = fn_args.type_at(0);
                 let layout = self.layout_of(tp_ty).layout;
                 let use_integer_compare = match layout.backend_repr() {
-                    Scalar(_) | ScalarPair(_, _) => true,
+                    Scalar(_) | ScalarPair { a: _, b: _, b_offset: _ } => true,
                     SimdVector { .. } => false,
                     SimdScalableVector { .. } => {
                         let err = tcx.dcx().emit_err(InvalidMonomorphization::NonScalableType {

--- a/compiler/rustc_codegen_llvm/src/type_of.rs
+++ b/compiler/rustc_codegen_llvm/src/type_of.rs
@@ -73,7 +73,7 @@ fn uncached_llvm_type<'a, 'tcx>(
                 _ => bug!("`#[rustc_scalable_vector]` tuple struct with too many fields"),
             };
         }
-        BackendRepr::Memory { .. } | BackendRepr::ScalarPair(..) => {}
+        BackendRepr::Memory { .. } | BackendRepr::ScalarPair { .. } => {}
     }
 
     let name = match layout.ty.kind() {
@@ -228,13 +228,13 @@ impl<'tcx> LayoutLlvmExt<'tcx> for TyAndLayout<'tcx> {
             BackendRepr::Scalar(_)
             | BackendRepr::SimdVector { .. }
             | BackendRepr::SimdScalableVector { .. } => true,
-            BackendRepr::ScalarPair(..) | BackendRepr::Memory { .. } => false,
+            BackendRepr::ScalarPair { .. } | BackendRepr::Memory { .. } => false,
         }
     }
 
     fn is_llvm_scalar_pair(&self) -> bool {
         match self.backend_repr {
-            BackendRepr::ScalarPair(..) => true,
+            BackendRepr::ScalarPair { .. } => true,
             BackendRepr::Scalar(_)
             | BackendRepr::SimdVector { .. }
             | BackendRepr::SimdScalableVector { .. }
@@ -313,7 +313,7 @@ impl<'tcx> LayoutLlvmExt<'tcx> for TyAndLayout<'tcx> {
                     return cx.type_i1();
                 }
             }
-            BackendRepr::ScalarPair(..) => {
+            BackendRepr::ScalarPair { .. } => {
                 // An immediate pair always contains just the two elements, without any padding
                 // filler, as it should never be stored to memory.
                 return cx.type_struct(
@@ -346,7 +346,7 @@ impl<'tcx> LayoutLlvmExt<'tcx> for TyAndLayout<'tcx> {
         // This must produce the same result for `repr(transparent)` wrappers as for the inner type!
         // In other words, this should generally not look at the type at all, but only at the
         // layout.
-        let BackendRepr::ScalarPair(a, b) = self.backend_repr else {
+        let BackendRepr::ScalarPair { a, b, b_offset: _ } = self.backend_repr else {
             bug!("TyAndLayout::scalar_pair_element_llty({:?}): not applicable", self);
         };
         let scalar = [a, b][index];

--- a/compiler/rustc_codegen_llvm/src/va_arg.rs
+++ b/compiler/rustc_codegen_llvm/src/va_arg.rs
@@ -564,7 +564,7 @@ fn emit_x86_64_sysv64_va_arg<'ll, 'tcx>(
         BackendRepr::Scalar(scalar) => {
             registers_for_primitive(scalar.primitive());
         }
-        BackendRepr::ScalarPair(scalar1, scalar2) => {
+        BackendRepr::ScalarPair { a: scalar1, b: scalar2, b_offset: _ } => {
             registers_for_primitive(scalar1.primitive());
             registers_for_primitive(scalar2.primitive());
         }
@@ -641,7 +641,7 @@ fn emit_x86_64_sysv64_va_arg<'ll, 'tcx>(
             }
             Primitive::Float(_) => bx.inbounds_ptradd(reg_save_area_v, fp_offset_v),
         },
-        BackendRepr::ScalarPair(scalar1, scalar2) => {
+        BackendRepr::ScalarPair { a: scalar1, b: scalar2, b_offset: offset } => {
             let ty_lo = bx.cx().scalar_pair_element_backend_type(layout, 0, false);
             let ty_hi = bx.cx().scalar_pair_element_backend_type(layout, 1, false);
 
@@ -665,9 +665,8 @@ fn emit_x86_64_sysv64_va_arg<'ll, 'tcx>(
                     let reg_lo = bx.load(ty_lo, reg_lo_addr, align_lo);
                     let reg_hi = bx.load(ty_hi, reg_hi_addr, align_hi);
 
-                    let offset = scalar1.size(bx.cx).align_to(align_hi).bytes();
                     let field0 = tmp;
-                    let field1 = bx.inbounds_ptradd(tmp, bx.const_u32(offset as u32));
+                    let field1 = bx.inbounds_ptradd(tmp, bx.const_u32(offset.bytes() as u32));
 
                     bx.store(reg_lo, field0, align);
                     bx.store(reg_hi, field1, align);
@@ -688,9 +687,8 @@ fn emit_x86_64_sysv64_va_arg<'ll, 'tcx>(
                     let reg_lo = bx.load(ty_lo, reg_lo_addr, align_lo);
                     let reg_hi = bx.load(ty_hi, reg_hi_addr, align_hi);
 
-                    let offset = scalar1.size(bx.cx).align_to(align_hi).bytes();
                     let field0 = tmp;
-                    let field1 = bx.inbounds_ptradd(tmp, bx.const_u32(offset as u32));
+                    let field1 = bx.inbounds_ptradd(tmp, bx.const_u32(offset.bytes() as u32));
 
                     bx.store(reg_lo, field0, align_lo);
                     bx.store(reg_hi, field1, align_hi);

--- a/compiler/rustc_codegen_ssa/src/base.rs
+++ b/compiler/rustc_codegen_ssa/src/base.rs
@@ -883,6 +883,10 @@ pub fn codegen_crate<
 /// unlinkable calls.
 ///
 /// Note that calls to LLVM intrinsics are uniquely okay because they won't make it to the linker.
+/// Note also that calls to foreign items that are actually exported by the local crate are also
+/// okay. This situation arises because compiler-builtins calls functions in core that are
+/// `#[inline]` wrappers for `extern "C"` declarations in core, which resolve to a symbol exported
+/// by compiler-builtins.
 pub fn is_call_from_compiler_builtins_to_upstream_monomorphization<'tcx>(
     tcx: TyCtxt<'tcx>,
     instance: Instance<'tcx>,
@@ -895,11 +899,19 @@ pub fn is_call_from_compiler_builtins_to_upstream_monomorphization<'tcx>(
         }
     }
 
+    fn is_extern_call_to_local_crate<'tcx>(tcx: TyCtxt<'tcx>, instance: Instance<'tcx>) -> bool {
+        tcx.is_foreign_item(instance.def_id())
+            && tcx.exported_non_generic_symbols(LOCAL_CRATE).iter().any(|(sym, _info)| {
+                sym.symbol_name_for_local_instance(tcx) == tcx.symbol_name(instance)
+            })
+    }
+
     let def_id = instance.def_id();
     !def_id.is_local()
         && tcx.is_compiler_builtins(LOCAL_CRATE)
         && !is_llvm_intrinsic(tcx, def_id)
         && !tcx.should_codegen_locally(instance)
+        && !is_extern_call_to_local_crate(tcx, instance)
 }
 
 impl CrateInfo {

--- a/compiler/rustc_codegen_ssa/src/base.rs
+++ b/compiler/rustc_codegen_ssa/src/base.rs
@@ -877,9 +877,9 @@ pub fn codegen_crate<
 /// Returns whether a call from the current crate to the [`Instance`] would produce a call
 /// from `compiler_builtins` to a symbol the linker must resolve.
 ///
-/// Such calls from `compiler_bultins` are effectively impossible for the linker to handle. Some
+/// Such calls from `compiler_builtins` are effectively impossible for the linker to handle. Some
 /// linkers will optimize such that dead calls to unresolved symbols are not an error, but this is
-/// not guaranteed. So we used this function in codegen backends to ensure we do not generate any
+/// not guaranteed. So we use this function in codegen backends to ensure we do not generate any
 /// unlinkable calls.
 ///
 /// Note that calls to LLVM intrinsics are uniquely okay because they won't make it to the linker.

--- a/compiler/rustc_codegen_ssa/src/mir/debuginfo.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/debuginfo.rs
@@ -611,7 +611,9 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                         // be marked as a `LocalVariable` for MSVC debuggers to visualize
                         // their data correctly. (See #81894 & #88625)
                         let var_ty_layout = self.cx.layout_of(var_ty);
-                        if let BackendRepr::ScalarPair(_, _) = var_ty_layout.backend_repr {
+                        if let BackendRepr::ScalarPair { a: _, b: _, b_offset: _ } =
+                            var_ty_layout.backend_repr
+                        {
                             VariableKind::LocalVariable
                         } else {
                             VariableKind::ArgumentVariable(arg_index)

--- a/compiler/rustc_codegen_ssa/src/mir/naked_asm.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/naked_asm.rs
@@ -441,7 +441,7 @@ fn wasm_type<'tcx>(signature: &mut String, arg_abi: &ArgAbi<'_, Ty<'tcx>>, ptr_t
             signature.push_str(direct_type);
         }
         PassMode::Pair(_, _) => match arg_abi.layout.backend_repr {
-            BackendRepr::ScalarPair(a, b) => {
+            BackendRepr::ScalarPair { a, b, b_offset: _ } => {
                 signature.push_str(wasm_primitive(a.primitive(), ptr_type));
                 signature.push_str(", ");
                 signature.push_str(wasm_primitive(b.primitive(), ptr_type));

--- a/compiler/rustc_codegen_ssa/src/mir/operand.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/operand.rs
@@ -168,7 +168,9 @@ impl<'a, 'tcx, V: CodegenObject> OperandRef<'tcx, V> {
             }
             ConstValue::ZeroSized => return OperandRef::zero_sized(layout),
             ConstValue::Slice { alloc_id, meta } => {
-                let BackendRepr::ScalarPair(a_scalar, _) = layout.backend_repr else {
+                let BackendRepr::ScalarPair { a: a_scalar, b: _, b_offset: _ } =
+                    layout.backend_repr
+                else {
                     bug!("from_const: invalid ScalarPair layout: {:#?}", layout);
                 };
                 let a = Scalar::from_pointer(Pointer::new(alloc_id.into(), Size::ZERO), &bx.tcx());
@@ -222,12 +224,12 @@ impl<'a, 'tcx, V: CodegenObject> OperandRef<'tcx, V> {
                 let val = read_scalar(offset, size, s, bx.immediate_backend_type(layout));
                 OperandRef { val: OperandValue::Immediate(val), layout, move_annotation: None }
             }
-            BackendRepr::ScalarPair(
-                a @ abi::Scalar::Initialized { .. },
-                b @ abi::Scalar::Initialized { .. },
-            ) => {
+            BackendRepr::ScalarPair {
+                a: a @ abi::Scalar::Initialized { .. },
+                b: b @ abi::Scalar::Initialized { .. },
+                b_offset,
+            } => {
                 let (a_size, b_size) = (a.size(bx), b.size(bx));
-                let b_offset = (offset + a_size).align_to(b.default_align(bx).abi);
                 assert!(b_offset.bytes() > 0);
                 let a_val = read_scalar(
                     offset,
@@ -345,7 +347,7 @@ impl<'a, 'tcx, V: CodegenObject> OperandRef<'tcx, V> {
         llval: V,
         layout: TyAndLayout<'tcx>,
     ) -> Self {
-        let val = if let BackendRepr::ScalarPair(..) = layout.backend_repr {
+        let val = if let BackendRepr::ScalarPair { .. } = layout.backend_repr {
             debug!("Operand::from_immediate_or_packed_pair: unpacking {:?} @ {:?}", llval, layout);
 
             // Deconstruct the immediate aggregate.
@@ -383,12 +385,15 @@ impl<'a, 'tcx, V: CodegenObject> OperandRef<'tcx, V> {
         } else {
             let (in_scalar, imm) = match (self.val, self.layout.backend_repr) {
                 // Extract a scalar component from a pair.
-                (OperandValue::Pair(a_llval, b_llval), BackendRepr::ScalarPair(a, b)) => {
+                (
+                    OperandValue::Pair(a_llval, b_llval),
+                    BackendRepr::ScalarPair { a, b, b_offset },
+                ) => {
                     if offset.bytes() == 0 {
                         assert_eq!(field.size, a.size(bx.cx()));
                         (Some(a), a_llval)
                     } else {
-                        assert_eq!(offset, a.size(bx.cx()).align_to(b.default_align(bx.cx()).abi));
+                        assert_eq!(offset, b_offset);
                         assert_eq!(field.size, b.size(bx.cx()));
                         (Some(b), b_llval)
                     }
@@ -419,7 +424,7 @@ impl<'a, 'tcx, V: CodegenObject> OperandRef<'tcx, V> {
                         imm
                     }
                 }
-                BackendRepr::ScalarPair(_, _)
+                BackendRepr::ScalarPair { a: _, b: _, b_offset: _ }
                 | BackendRepr::Memory { .. }
                 | BackendRepr::SimdScalableVector { .. } => bug!(),
             })
@@ -705,7 +710,7 @@ impl<'a, 'tcx, V: CodegenObject> OperandRefBuilder<'tcx, V> {
         let val = match layout.backend_repr {
             BackendRepr::Memory { .. } if layout.is_zst() => OperandValueBuilder::ZeroSized,
             BackendRepr::Scalar(s) => OperandValueBuilder::Immediate(Either::Right(s)),
-            BackendRepr::ScalarPair(a, b) => {
+            BackendRepr::ScalarPair { a, b, b_offset: _ } => {
                 OperandValueBuilder::Pair(Either::Right(a), Either::Right(b))
             }
             BackendRepr::SimdVector { .. } | BackendRepr::SimdScalableVector { .. } => {
@@ -733,7 +738,7 @@ impl<'a, 'tcx, V: CodegenObject> OperandRefBuilder<'tcx, V> {
             (OperandValue::Immediate(v), BackendRepr::SimdVector { .. }) => {
                 OperandValueBuilder::Vector(Either::Left(v))
             }
-            (OperandValue::Pair(a, b), BackendRepr::ScalarPair(_, _)) => {
+            (OperandValue::Pair(a, b), BackendRepr::ScalarPair { a: _, b: _, b_offset: _ }) => {
                 OperandValueBuilder::Pair(Either::Left(a), Either::Left(b))
             }
             (_, BackendRepr::Memory { .. }) => {
@@ -810,17 +815,18 @@ impl<'a, 'tcx, V: CodegenObject> OperandRefBuilder<'tcx, V> {
                     bug!("Tried to insert {field_operand:?} into {variant:?}.{field:?} of {self:?}")
                 }
             },
-            (OperandValue::Pair(a, b), BackendRepr::ScalarPair(from_sa, from_sb)) => {
-                match &mut self.val {
-                    OperandValueBuilder::Pair(fst @ Either::Right(_), snd @ Either::Right(_)) => {
-                        update(fst, a, from_sa);
-                        update(snd, b, from_sb);
-                    }
-                    _ => bug!(
-                        "Tried to insert {field_operand:?} into {variant:?}.{field:?} of {self:?}"
-                    ),
+            (
+                OperandValue::Pair(a, b),
+                BackendRepr::ScalarPair { a: from_sa, b: from_sb, b_offset: _ },
+            ) => match &mut self.val {
+                OperandValueBuilder::Pair(fst @ Either::Right(_), snd @ Either::Right(_)) => {
+                    update(fst, a, from_sa);
+                    update(snd, b, from_sb);
                 }
-            }
+                _ => {
+                    bug!("Tried to insert {field_operand:?} into {variant:?}.{field:?} of {self:?}")
+                }
+            },
             (OperandValue::Ref(place), BackendRepr::Memory { .. }) => match &mut self.val {
                 OperandValueBuilder::Vector(val @ Either::Right(())) => {
                     let ibty = bx.cx().immediate_backend_type(self.layout);
@@ -1008,10 +1014,10 @@ impl<'a, 'tcx, V: CodegenObject> OperandValue<V> {
                 bx.store_with_flags(val, dest.val.llval, dest.val.align, flags);
             }
             OperandValue::Pair(a, b) => {
-                let BackendRepr::ScalarPair(a_scalar, b_scalar) = dest.layout.backend_repr else {
+                let BackendRepr::ScalarPair { a: _, b: _, b_offset } = dest.layout.backend_repr
+                else {
                     bug!("store_with_flags: invalid ScalarPair layout: {:#?}", dest.layout);
                 };
-                let b_offset = a_scalar.size(bx).align_to(b_scalar.default_align(bx).abi);
 
                 let val = bx.from_immediate(a);
                 let align = dest.val.align;

--- a/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
@@ -36,7 +36,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                 // semantics regarding when assignment operators allow overlap of LHS and RHS.
                 if matches!(
                     cg_operand.layout.backend_repr,
-                    BackendRepr::Scalar(..) | BackendRepr::ScalarPair(..),
+                    BackendRepr::Scalar(..) | BackendRepr::ScalarPair { .. },
                 ) {
                     debug_assert!(!matches!(cg_operand.val, OperandValue::Ref(..)));
                 }
@@ -323,9 +323,12 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
             }
             (
                 OperandValue::Pair(imm_a, imm_b),
-                abi::BackendRepr::ScalarPair(in_a, in_b),
-                abi::BackendRepr::ScalarPair(out_a, out_b),
-            ) if in_a.size(cx) == out_a.size(cx) && in_b.size(cx) == out_b.size(cx) => {
+                abi::BackendRepr::ScalarPair { a: in_a, b: in_b, b_offset: in_offset },
+                abi::BackendRepr::ScalarPair { a: out_a, b: out_b, b_offset: out_offset },
+            ) if in_a.size(cx) == out_a.size(cx)
+                && in_b.size(cx) == out_b.size(cx)
+                && in_offset == out_offset =>
+            {
                 OperandValue::Pair(
                     transmute_scalar(bx, imm_a, in_a, out_a),
                     transmute_scalar(bx, imm_b, in_b, out_b),

--- a/compiler/rustc_const_eval/src/const_eval/valtrees.rs
+++ b/compiler/rustc_const_eval/src/const_eval/valtrees.rs
@@ -136,7 +136,7 @@ fn const_to_valtree_inner<'tcx>(
             let val = ecx.read_immediate(place).report_err()?;
             // We could allow wide raw pointers where both sides are integers in the future,
             // but for now we reject them.
-            if matches!(val.layout.backend_repr, BackendRepr::ScalarPair(..)) {
+            if matches!(val.layout.backend_repr, BackendRepr::ScalarPair { .. }) {
                 Err(ValTreeCreationError::NonSupportedType(ty))
             } else {
                 let val = val.to_scalar();

--- a/compiler/rustc_const_eval/src/interpret/operand.rs
+++ b/compiler/rustc_const_eval/src/interpret/operand.rs
@@ -84,7 +84,7 @@ impl<Prov: Provenance> Immediate<Prov> {
     pub fn to_scalar(self) -> Scalar<Prov> {
         match self {
             Immediate::Scalar(val) => val,
-            Immediate::ScalarPair(..) => bug!("Got a scalar pair where a scalar was expected"),
+            Immediate::ScalarPair { .. } => bug!("Got a scalar pair where a scalar was expected"),
             Immediate::Uninit => bug!("Got uninit where a scalar was expected"),
         }
     }
@@ -129,7 +129,10 @@ impl<Prov: Provenance> Immediate<Prov> {
                     );
                 }
             }
-            (Immediate::ScalarPair(a_val, b_val), BackendRepr::ScalarPair(a, b)) => {
+            (
+                Immediate::ScalarPair(a_val, b_val),
+                BackendRepr::ScalarPair { a, b, b_offset: _ },
+            ) => {
                 assert_eq!(
                     a_val.size(),
                     a.size(cx),
@@ -263,7 +266,7 @@ impl<'tcx, Prov: Provenance> ImmTy<'tcx, Prov> {
     #[inline]
     pub fn from_scalar_pair(a: Scalar<Prov>, b: Scalar<Prov>, layout: TyAndLayout<'tcx>) -> Self {
         debug_assert!(
-            matches!(layout.backend_repr, BackendRepr::ScalarPair(..)),
+            matches!(layout.backend_repr, BackendRepr::ScalarPair { .. }),
             "`ImmTy::from_scalar_pair` on non-scalar-pair layout"
         );
         let imm = Immediate::ScalarPair(a, b);
@@ -276,7 +279,7 @@ impl<'tcx, Prov: Provenance> ImmTy<'tcx, Prov> {
         debug_assert!(
             match (imm, layout.backend_repr) {
                 (Immediate::Scalar(..), BackendRepr::Scalar(..)) => true,
-                (Immediate::ScalarPair(..), BackendRepr::ScalarPair(..)) => true,
+                (Immediate::ScalarPair { .. }, BackendRepr::ScalarPair { .. }) => true,
                 (Immediate::Uninit, _) if layout.is_sized() => true,
                 _ => false,
             },
@@ -415,14 +418,15 @@ impl<'tcx, Prov: Provenance> ImmTy<'tcx, Prov> {
                 **self
             }
             // extract fields from types with `ScalarPair` ABI
-            (Immediate::ScalarPair(a_val, b_val), BackendRepr::ScalarPair(a, b)) => {
-                Immediate::from(if offset.bytes() == 0 {
-                    a_val
-                } else {
-                    assert_eq!(offset, a.size(cx).align_to(b.default_align(cx).abi));
-                    b_val
-                })
-            }
+            (
+                Immediate::ScalarPair(a_val, b_val),
+                BackendRepr::ScalarPair { a: _, b: _, b_offset },
+            ) => Immediate::from(if offset.bytes() == 0 {
+                a_val
+            } else {
+                assert_eq!(offset, b_offset);
+                b_val
+            }),
             // everything else is a bug
             _ => bug!(
                 "invalid field access on immediate {} at offset {}, original layout {:#?}",
@@ -606,15 +610,15 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                 )?;
                 Some(ImmTy::from_scalar(scalar, mplace.layout))
             }
-            BackendRepr::ScalarPair(
-                abi::Scalar::Initialized { value: a, .. },
-                abi::Scalar::Initialized { value: b, .. },
-            ) => {
+            BackendRepr::ScalarPair {
+                a: abi::Scalar::Initialized { value: a, .. },
+                b: abi::Scalar::Initialized { value: b, .. },
+                b_offset,
+            } => {
                 // We checked `ptr_align` above, so all fields will have the alignment they need.
                 // We would anyway check against `ptr_align.restrict_for_offset(b_offset)`,
                 // which `ptr.offset(b_offset)` cannot possibly fail to satisfy.
                 let (a_size, b_size) = (a.size(self), b.size(self));
-                let b_offset = a_size.align_to(b.default_align(self).abi);
                 assert!(b_offset.bytes() > 0); // in `operand_field` we use the offset to tell apart the fields
                 let a_val = alloc.read_scalar(
                     alloc_range(Size::ZERO, a_size),
@@ -668,10 +672,11 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         if !matches!(
             op.layout().backend_repr,
             BackendRepr::Scalar(abi::Scalar::Initialized { .. })
-                | BackendRepr::ScalarPair(
-                    abi::Scalar::Initialized { .. },
-                    abi::Scalar::Initialized { .. }
-                )
+                | BackendRepr::ScalarPair {
+                    a: abi::Scalar::Initialized { .. },
+                    b: abi::Scalar::Initialized { .. },
+                    b_offset: _,
+                }
         ) {
             span_bug!(self.cur_span(), "primitive read not possible for type: {}", op.layout().ty);
         }

--- a/compiler/rustc_const_eval/src/interpret/place.rs
+++ b/compiler/rustc_const_eval/src/interpret/place.rs
@@ -713,7 +713,6 @@ where
         // to handle padding properly, which is only correct if we never look at this data with the
         // wrong type.
 
-        let tcx = *self.tcx;
         let will_later_validate = M::enforce_validity(self, layout);
         let Some(mut alloc) = self.get_place_alloc_mut(&MPlaceTy { mplace: dest, layout })? else {
             // zero-sized access
@@ -725,7 +724,7 @@ where
                 alloc.write_scalar(alloc_range(Size::ZERO, scalar.size()), scalar)?;
             }
             Immediate::ScalarPair(a_val, b_val) => {
-                let BackendRepr::ScalarPair(_a, b) = layout.backend_repr else {
+                let BackendRepr::ScalarPair { a: _, b: _, b_offset } = layout.backend_repr else {
                     span_bug!(
                         self.cur_span(),
                         "write_immediate_to_mplace: invalid ScalarPair layout: {:#?}",
@@ -733,7 +732,6 @@ where
                     )
                 };
                 let a_size = a_val.size();
-                let b_offset = a_size.align_to(b.default_align(&tcx).abi);
                 assert!(b_offset.bytes() > 0); // in `operand_field` we use the offset to tell apart the fields
 
                 // It is tempting to verify `b_offset` against `layout.fields.offset(1)`,
@@ -902,17 +900,19 @@ where
         // padding in the target independent of layout choices.
         let src_has_padding = match src.layout().backend_repr {
             BackendRepr::Scalar(_) => false,
-            BackendRepr::ScalarPair(left, right)
+            BackendRepr::ScalarPair { a: left, b: right, b_offset: _ }
                 if matches!(src.layout().ty.kind(), ty::Ref(..) | ty::RawPtr(..)) =>
             {
                 // Wide pointers never have padding, so we can avoid calling `size()`.
                 debug_assert_eq!(left.size(self) + right.size(self), src.layout().size);
                 false
             }
-            BackendRepr::ScalarPair(left, right) => {
+            BackendRepr::ScalarPair { a: left, b: right, b_offset: _ } => {
                 let left_size = left.size(self);
                 let right_size = right.size(self);
                 // We have padding if the sizes don't add up to the total.
+                // (Why don't we need to check the offset?  The scalars don't overlap so no padding
+                // implies `b_offset == left_size`, which would be superfluous to check explicitly.)
                 left_size + right_size != src.layout().size
             }
             // Everything else can only exist in memory anyway, so it doesn't matter.

--- a/compiler/rustc_const_eval/src/interpret/place.rs
+++ b/compiler/rustc_const_eval/src/interpret/place.rs
@@ -732,6 +732,7 @@ where
                     )
                 };
                 let a_size = a_val.size();
+                let b_size = b_val.size();
                 assert!(b_offset.bytes() > 0); // in `operand_field` we use the offset to tell apart the fields
 
                 // It is tempting to verify `b_offset` against `layout.fields.offset(1)`,
@@ -742,12 +743,12 @@ where
                 // destination now to ensure that no stray pointer fragments are being
                 // preserved (see <https://github.com/rust-lang/rust/issues/148470>).
                 // We can skip this if there is no padding (e.g. for wide pointers).
-                if !will_later_validate && a_size + b_val.size() != layout.size {
+                if !will_later_validate && a_size + b_size != layout.size {
                     alloc.write_uninit_full();
                 }
 
                 alloc.write_scalar(alloc_range(Size::ZERO, a_size), a_val)?;
-                alloc.write_scalar(alloc_range(b_offset, b_val.size()), b_val)?;
+                alloc.write_scalar(alloc_range(b_offset, b_size), b_val)?;
             }
             Immediate::Uninit => alloc.write_uninit_full(),
         }

--- a/compiler/rustc_const_eval/src/interpret/validity.rs
+++ b/compiler/rustc_const_eval/src/interpret/validity.rs
@@ -1397,7 +1397,7 @@ impl<'rt, 'tcx, M: Machine<'tcx>> ValueVisitor<'tcx, M> for ValidityVisitor<'rt,
                                 self.path,
                                 Uninit { expected }
                             ),
-                        Immediate::Scalar(..) | Immediate::ScalarPair(..) =>
+                        Immediate::Scalar(..) | Immediate::ScalarPair { .. } =>
                             bug!("arrays/slices can never have Scalar/ScalarPair layout"),
                     }
                 };
@@ -1486,7 +1486,7 @@ impl<'rt, 'tcx, M: Machine<'tcx>> ValueVisitor<'tcx, M> for ValidityVisitor<'rt,
                             self.visit_scalar(scalar, scalar_layout)?;
                         }
                     }
-                    BackendRepr::ScalarPair(a_layout, b_layout) => {
+                    BackendRepr::ScalarPair { a: a_layout, b: b_layout, b_offset: _ } => {
                         // We can only proceed if *both* scalars need to be initialized.
                         // FIXME: find a way to also check ScalarPair when one side can be uninit but
                         // the other must be init.
@@ -1545,7 +1545,7 @@ impl<'rt, 'tcx, M: Machine<'tcx>> ValueVisitor<'tcx, M> for ValidityVisitor<'rt,
                             .expect("the above checks should have fully handled this situation");
                     }
                 }
-                BackendRepr::ScalarPair(a_layout, b_layout) => {
+                BackendRepr::ScalarPair { a: a_layout, b: b_layout, b_offset: _ } => {
                     // We can only proceed if *both* scalars need to be initialized.
                     // FIXME: find a way to also check ScalarPair when one side can be uninit but
                     // the other must be init.

--- a/compiler/rustc_const_eval/src/util/check_validity_requirement.rs
+++ b/compiler/rustc_const_eval/src/util/check_validity_requirement.rs
@@ -121,7 +121,7 @@ fn check_validity_requirement_lax<'tcx>(
     let valid = !this.is_uninhabited() // definitely UB if uninhabited
         && match this.backend_repr {
             BackendRepr::Scalar(s) => scalar_allows_raw_init(s),
-            BackendRepr::ScalarPair(s1, s2) => {
+            BackendRepr::ScalarPair { a: s1, b: s2, b_offset: _ } => {
                 scalar_allows_raw_init(s1) && scalar_allows_raw_init(s2)
             }
             BackendRepr::SimdVector { element: s, count } => count == 0 || scalar_allows_raw_init(s),

--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -2438,7 +2438,7 @@ impl<'tcx> LateLintPass<'tcx> for InvalidValue {
 
             // Check if this ADT has a constrained layout (like `NonNull` and friends).
             if let Ok(layout) = cx.tcx.layout_of(cx.typing_env().as_query_input(ty)) {
-                if let BackendRepr::Scalar(scalar) | BackendRepr::ScalarPair(scalar, _) =
+                if let BackendRepr::Scalar(scalar) | BackendRepr::ScalarPair { a: scalar, .. } =
                     &layout.backend_repr
                 {
                     let range = scalar.valid_range(cx);

--- a/compiler/rustc_middle/src/ty/offload_meta.rs
+++ b/compiler/rustc_middle/src/ty/offload_meta.rs
@@ -76,7 +76,7 @@ impl OffloadMetadata {
         Ty<'tcx>: TyAbiInterface<'tcx, C>,
     {
         match arg_abi.layout.backend_repr {
-            BackendRepr::ScalarPair(_, _) => (0..2)
+            BackendRepr::ScalarPair { a: _, b: _, b_offset: _ } => (0..2)
                 .map(|i| {
                     let ty = arg_abi.layout.field(cx, i).ty;
                     (OffloadMetadata::from_ty(tcx, ty), ty)

--- a/compiler/rustc_mir_dataflow/src/impls/storage_liveness.rs
+++ b/compiler/rustc_mir_dataflow/src/impls/storage_liveness.rs
@@ -155,7 +155,6 @@ impl<'tcx> Analysis<'tcx> for MaybeRequiresStorage<'_, 'tcx> {
         match &stmt.kind {
             StatementKind::StorageDead(l) => state.kill(*l),
 
-            // If a place is assigned to in a statement, it needs storage for that statement.
             StatementKind::Assign((place, _)) => {
                 state.gen_(place.local);
             }
@@ -180,12 +179,35 @@ impl<'tcx> Analysis<'tcx> for MaybeRequiresStorage<'_, 'tcx> {
     fn apply_primary_statement_effect(
         &self,
         state: &mut Self::Domain,
-        _: &Statement<'tcx>,
+        stmt: &Statement<'tcx>,
         loc: Location,
     ) {
         // If we move from a place then it only stops needing storage *after*
         // that statement.
         self.check_for_move(state, loc);
+
+        match &stmt.kind {
+            // If a place is assigned to in a statement, it needs storage after that statement.
+            // Even if the place was moved from in the rvalue (e.g. `x = x + 1` or `x = f(move x)`),
+            // the assignment restores a valid value into the place.
+            StatementKind::Assign((place, _)) => {
+                state.gen_(place.local);
+            }
+            StatementKind::SetDiscriminant { place, .. } => {
+                state.gen_(place.local);
+            }
+
+            StatementKind::StorageDead(_)
+            | StatementKind::AscribeUserType(..)
+            | StatementKind::PlaceMention(..)
+            | StatementKind::Coverage(..)
+            | StatementKind::FakeRead(..)
+            | StatementKind::ConstEvalCounter
+            | StatementKind::Nop
+            | StatementKind::Intrinsic(..)
+            | StatementKind::BackwardIncompatibleDropHint { .. }
+            | StatementKind::StorageLive(..) => {}
+        }
     }
 
     fn apply_early_terminator_effect(

--- a/compiler/rustc_mir_transform/src/coroutine/mod.rs
+++ b/compiler/rustc_mir_transform/src/coroutine/mod.rs
@@ -79,6 +79,7 @@ use rustc_span::def_id::DefId;
 use tracing::{debug, instrument};
 
 use crate::deref_separator::deref_finder;
+use crate::patch::MirPatch;
 use crate::{abort_unwinding_calls, pass_manager as pm, simplify};
 
 pub(super) struct StateTransform;
@@ -199,6 +200,8 @@ struct TransformVisitor<'tcx> {
     old_yield_ty: Ty<'tcx>,
 
     old_ret_ty: Ty<'tcx>,
+
+    patch: Option<MirPatch<'tcx>>,
 }
 
 impl<'tcx> TransformVisitor<'tcx> {
@@ -408,10 +411,50 @@ impl<'tcx> MutVisitor<'tcx> for TransformVisitor<'tcx> {
     }
 
     #[tracing::instrument(level = "trace", skip(self), ret)]
-    fn visit_place(&mut self, place: &mut Place<'tcx>, _: PlaceContext, _location: Location) {
+    fn visit_place(&mut self, place: &mut Place<'tcx>, _: PlaceContext, location: Location) {
         // Replace an Local in the remap with a coroutine struct access
         if let Some(&Some((ty, variant_index, idx))) = self.remap.get(place.local) {
             replace_base(place, self.make_field(variant_index, idx, ty), self.tcx);
+        }
+        if let Some(new_projection) = self.process_projection(&place.projection, location) {
+            place.projection = self.tcx.mk_place_elems(&new_projection);
+        }
+    }
+
+    fn process_projection_elem(
+        &mut self,
+        elem: PlaceElem<'tcx>,
+        location: Location,
+    ) -> Option<PlaceElem<'tcx>> {
+        match elem {
+            PlaceElem::Index(local) => {
+                if let Some(&Some((ty, variant, idx))) = self.remap.get(local) {
+                    // `PlaceElem::Index` only accepts a `Local`, not an arbitrary `Place`.
+                    // If the local in indexing was saved across a yield point and remapped to a
+                    // coroutine struct field, we cannot inline the struct field access into
+                    // the index projection.
+                    // For example, an local storing the counter to track which element to drop in
+                    // an array is one such case.
+                    //
+                    // Instead, we inject an assignment before this location to restore the
+                    // saved local from the coroutine struct (`local = copy $projection`),
+                    // and leave the `PlaceElem::Index(local)` projection unchanged.
+                    let field = self.make_field(variant, idx, ty);
+                    self.patch.as_mut().unwrap().add_assign(
+                        location,
+                        Place::from(local),
+                        Rvalue::Use(Operand::Copy(field), WithRetag::No),
+                    );
+                }
+                None
+            }
+            PlaceElem::Field(..)
+            | PlaceElem::OpaqueCast(..)
+            | PlaceElem::UnwrapUnsafeBinder(..)
+            | PlaceElem::Deref
+            | PlaceElem::ConstantIndex { .. }
+            | PlaceElem::Subslice { .. }
+            | PlaceElem::Downcast(..) => None,
         }
     }
 
@@ -1096,6 +1139,7 @@ impl<'tcx> crate::MirPass<'tcx> for StateTransform {
             new_ret_local,
             old_ret_ty,
             old_yield_ty,
+            patch: Some(MirPatch::new(body)),
         };
         transform.visit_body(body);
 
@@ -1116,6 +1160,7 @@ impl<'tcx> crate::MirPass<'tcx> for StateTransform {
                 Some(Statement::new(source_info, assign))
             }),
         );
+        transform.patch.take().unwrap().apply(body);
 
         // Remove the context argument within generator bodies.
         if matches!(coroutine_kind, CoroutineKind::Desugared(CoroutineDesugaring::Gen, _)) {

--- a/compiler/rustc_mir_transform/src/dataflow_const_prop.rs
+++ b/compiler/rustc_mir_transform/src/dataflow_const_prop.rs
@@ -647,7 +647,7 @@ impl<'a, 'tcx> ConstAnalysis<'a, 'tcx> {
                     // a pair and sometimes not. But as a hack we always return a pair
                     // and just make the 2nd component `Bottom` when it does not exist.
                     Some(val) => {
-                        if matches!(val.layout.backend_repr, BackendRepr::ScalarPair(..)) {
+                        if matches!(val.layout.backend_repr, BackendRepr::ScalarPair { .. }) {
                             let (val, overflow) = val.to_scalar_pair();
                             (FlatSet::Elem(val), FlatSet::Elem(overflow))
                         } else {
@@ -814,7 +814,7 @@ impl<'a, 'tcx> Collector<'a, 'tcx> {
             return Some(Const::Val(ConstValue::Scalar(value), ty));
         }
 
-        if matches!(layout.backend_repr, BackendRepr::Scalar(..) | BackendRepr::ScalarPair(..)) {
+        if matches!(layout.backend_repr, BackendRepr::Scalar(..) | BackendRepr::ScalarPair { .. }) {
             let alloc_id = ecx
                 .intern_with_temp_alloc(layout, |ecx, dest| {
                     try_write_constant(ecx, dest, place, ty, state, map)

--- a/compiler/rustc_mir_transform/src/gvn.rs
+++ b/compiler/rustc_mir_transform/src/gvn.rs
@@ -608,7 +608,7 @@ impl<'body, 'a, 'tcx> VnState<'body, 'a, 'tcx> {
                 let fields =
                     fields.iter().map(|&f| self.eval_to_const(f)).collect::<Option<Vec<_>>>()?;
                 let variant = if ty.ty.is_enum() { Some(variant) } else { None };
-                let (BackendRepr::Scalar(..) | BackendRepr::ScalarPair(..)) = ty.backend_repr
+                let (BackendRepr::Scalar(..) | BackendRepr::ScalarPair { .. }) = ty.backend_repr
                 else {
                     return None;
                 };
@@ -639,7 +639,7 @@ impl<'body, 'a, 'tcx> VnState<'body, 'a, 'tcx> {
                     ImmTy::from_immediate(Immediate::Uninit, ty).into()
                 } else if matches!(
                     ty.backend_repr,
-                    BackendRepr::Scalar(..) | BackendRepr::ScalarPair(..)
+                    BackendRepr::Scalar(..) | BackendRepr::ScalarPair { .. }
                 ) {
                     let dest = self.ecx.allocate(ty, MemoryKind::Stack).discard_err()?;
                     let field_dest = self.ecx.project_field(&dest, active_field).discard_err()?;
@@ -738,11 +738,15 @@ impl<'body, 'a, 'tcx> VnState<'body, 'a, 'tcx> {
                                 s1.size(&self.ecx) == s2.size(&self.ecx)
                                     && !matches!(s1.primitive(), Primitive::Pointer(..))
                             }
-                            (BackendRepr::ScalarPair(a1, b1), BackendRepr::ScalarPair(a2, b2)) => {
+                            (
+                                BackendRepr::ScalarPair { a: a1, b: b1, b_offset: b1_offset },
+                                BackendRepr::ScalarPair { a: a2, b: b2, b_offset: b2_offset },
+                            ) => {
                                 a1.size(&self.ecx) == a2.size(&self.ecx)
                                     && b1.size(&self.ecx) == b2.size(&self.ecx)
-                                    // The alignment of the second component determines its offset, so that also needs to match.
-                                    && b1.default_align(&self.ecx) == b2.default_align(&self.ecx)
+                                    // The first component is always at offset zero, but the offset to the second
+                                    // component needs to match as well for us to be able to transmute.
+                                    && b1_offset == b2_offset
                                     // None of the inputs may be a pointer.
                                     && !matches!(a1.primitive(), Primitive::Pointer(..))
                                     && !matches!(b1.primitive(), Primitive::Pointer(..))
@@ -1804,7 +1808,9 @@ impl<'body, 'a, 'tcx> VnState<'body, 'a, 'tcx> {
                     true
                 }
             }
-            BackendRepr::ScalarPair(a, b) => {
+            BackendRepr::ScalarPair { a, b, b_offset: _ } => {
+                // The offset is irrelevant to niches since it can only cause padding,
+                // which can never have a niche since it's uninitialized.
                 !a.is_always_valid(&self.ecx) || !b.is_always_valid(&self.ecx)
             }
             BackendRepr::SimdVector { .. }
@@ -1902,7 +1908,10 @@ fn op_to_prop_const<'tcx>(
     // But we *do* want to synthesize any size constant if it is entirely uninit because that
     // benefits codegen, which has special handling for them.
     if !op.is_immediate_uninit()
-        && !matches!(op.layout.backend_repr, BackendRepr::Scalar(..) | BackendRepr::ScalarPair(..))
+        && !matches!(
+            op.layout.backend_repr,
+            BackendRepr::Scalar(..) | BackendRepr::ScalarPair { .. }
+        )
     {
         return None;
     }

--- a/compiler/rustc_mir_transform/src/known_panics_lint.rs
+++ b/compiler/rustc_mir_transform/src/known_panics_lint.rs
@@ -563,7 +563,7 @@ impl<'mir, 'tcx> ConstPropagator<'mir, 'tcx> {
                 let right = self.use_ecx(|this| this.ecx.read_immediate(&right))?;
 
                 let val = self.use_ecx(|this| this.ecx.binary_op(bin_op, &left, &right))?;
-                if matches!(val.layout.backend_repr, BackendRepr::ScalarPair(..)) {
+                if matches!(val.layout.backend_repr, BackendRepr::ScalarPair { .. }) {
                     // FIXME `Value` should properly support pairs in `Immediate`... but currently
                     // it does not.
                     let (val, overflow) = val.to_pair(&self.ecx);
@@ -629,7 +629,7 @@ impl<'mir, 'tcx> ConstPropagator<'mir, 'tcx> {
                     // so bail out if the target is not one.
                     match (value.layout.backend_repr, to.backend_repr) {
                         (BackendRepr::Scalar(..), BackendRepr::Scalar(..)) => {}
-                        (BackendRepr::ScalarPair(..), BackendRepr::ScalarPair(..)) => {}
+                        (BackendRepr::ScalarPair { .. }, BackendRepr::ScalarPair { .. }) => {}
                         _ => return None,
                     }
 

--- a/compiler/rustc_public/src/abi.rs
+++ b/compiler/rustc_public/src/abi.rs
@@ -241,7 +241,11 @@ pub struct NumScalableVectors(pub(crate) u8);
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize)]
 pub enum ValueAbi {
     Scalar(Scalar),
-    ScalarPair(Scalar, Scalar),
+    ScalarPair {
+        a: Scalar,
+        b: Scalar,
+        b_offset: Size,
+    },
     Vector {
         element: Scalar,
         count: u64,
@@ -262,7 +266,7 @@ impl ValueAbi {
     pub fn is_unsized(&self) -> bool {
         match *self {
             ValueAbi::Scalar(_)
-            | ValueAbi::ScalarPair(..)
+            | ValueAbi::ScalarPair { .. }
             | ValueAbi::Vector { .. }
             // FIXME(rustc_scalable_vector): Scalable vectors are `Sized` while the
             // `sized_hierarchy` feature is not yet fully implemented. After `sized_hierarchy` is

--- a/compiler/rustc_public/src/unstable/convert/stable/abi.rs
+++ b/compiler/rustc_public/src/unstable/convert/stable/abi.rs
@@ -271,8 +271,12 @@ impl<'tcx> Stable<'tcx> for rustc_abi::BackendRepr {
     ) -> Self::T {
         match *self {
             rustc_abi::BackendRepr::Scalar(scalar) => ValueAbi::Scalar(scalar.stable(tables, cx)),
-            rustc_abi::BackendRepr::ScalarPair(first, second) => {
-                ValueAbi::ScalarPair(first.stable(tables, cx), second.stable(tables, cx))
+            rustc_abi::BackendRepr::ScalarPair { a: first, b: second, b_offset: second_offset } => {
+                ValueAbi::ScalarPair {
+                    a: first.stable(tables, cx),
+                    b: second.stable(tables, cx),
+                    b_offset: second_offset.stable(tables, cx),
+                }
             }
             rustc_abi::BackendRepr::SimdVector { element, count } => {
                 ValueAbi::Vector { element: element.stable(tables, cx), count }

--- a/compiler/rustc_target/src/callconv/aarch64.rs
+++ b/compiler/rustc_target/src/callconv/aarch64.rs
@@ -56,7 +56,7 @@ fn softfloat_float_abi<Ty>(target: &Target, arg: &mut ArgAbi<'_, Ty>) {
         && let Primitive::Float(f) = s.primitive()
     {
         arg.cast_to(Reg { kind: RegKind::Integer, size: f.size() });
-    } else if let BackendRepr::ScalarPair(s1, s2) = arg.layout.backend_repr
+    } else if let BackendRepr::ScalarPair { a: s1, b: s2, b_offset: _ } = arg.layout.backend_repr
         && (matches!(s1.primitive(), Primitive::Float(_))
             || matches!(s2.primitive(), Primitive::Float(_)))
     {

--- a/compiler/rustc_target/src/callconv/loongarch.rs
+++ b/compiler/rustc_target/src/callconv/loongarch.rs
@@ -89,7 +89,7 @@ where
             return Err(CannotUseFpConv);
         }
         BackendRepr::SimdScalableVector { .. } => panic!("scalable vectors are unsupported"),
-        BackendRepr::ScalarPair(..) | BackendRepr::Memory { .. } => match arg_layout.fields {
+        BackendRepr::ScalarPair { .. } | BackendRepr::Memory { .. } => match arg_layout.fields {
             FieldsShape::Primitive => {
                 unreachable!("aggregates can't have `FieldsShape::Primitive`")
             }

--- a/compiler/rustc_target/src/callconv/mod.rs
+++ b/compiler/rustc_target/src/callconv/mod.rs
@@ -390,17 +390,15 @@ impl<'a, Ty: fmt::Display> fmt::Debug for ArgAbi<'a, Ty> {
 impl<'a, Ty> ArgAbi<'a, Ty> {
     /// This defines the "default ABI" for that type, that is then later adjusted in `fn_abi_adjust_for_abi`.
     pub fn new(
-        cx: &impl HasDataLayout,
         layout: TyAndLayout<'a, Ty>,
         scalar_attrs: impl Fn(Scalar, Size) -> ArgAttributes,
     ) -> Self {
         let mode = match layout.backend_repr {
             _ if layout.is_zst() => PassMode::Ignore,
             BackendRepr::Scalar(scalar) => PassMode::Direct(scalar_attrs(scalar, Size::ZERO)),
-            BackendRepr::ScalarPair(a, b) => PassMode::Pair(
-                scalar_attrs(a, Size::ZERO),
-                scalar_attrs(b, a.size(cx).align_to(b.default_align(cx).abi)),
-            ),
+            BackendRepr::ScalarPair { a, b, b_offset } => {
+                PassMode::Pair(scalar_attrs(a, Size::ZERO), scalar_attrs(b, b_offset))
+            }
             BackendRepr::SimdVector { .. } => PassMode::Direct(ArgAttributes::new()),
             BackendRepr::Memory { .. } => Self::indirect_pass_mode(&layout),
             BackendRepr::SimdScalableVector { .. } => PassMode::Direct(ArgAttributes::new()),
@@ -877,7 +875,7 @@ where
 {
     match layout.backend_repr {
         BackendRepr::Scalar(scalar) => !scalar.is_uninit_valid(),
-        BackendRepr::ScalarPair(s1, s2) => {
+        BackendRepr::ScalarPair { a: s1, b: s2, b_offset: _ } => {
             !s1.is_uninit_valid()
                 && !s2.is_uninit_valid()
                 // Ensure there is no padding.

--- a/compiler/rustc_target/src/callconv/riscv.rs
+++ b/compiler/rustc_target/src/callconv/riscv.rs
@@ -94,7 +94,7 @@ where
         BackendRepr::SimdVector { .. } | BackendRepr::SimdScalableVector { .. } => {
             return Err(CannotUseFpConv);
         }
-        BackendRepr::ScalarPair(..) | BackendRepr::Memory { .. } => match arg_layout.fields {
+        BackendRepr::ScalarPair { .. } | BackendRepr::Memory { .. } => match arg_layout.fields {
             FieldsShape::Primitive => {
                 unreachable!("aggregates can't have `FieldsShape::Primitive`")
             }

--- a/compiler/rustc_target/src/callconv/sparc64.rs
+++ b/compiler/rustc_target/src/callconv/sparc64.rs
@@ -67,7 +67,7 @@ fn classify<'a, Ty, C>(
         },
         BackendRepr::SimdVector { .. } => {}
         BackendRepr::SimdScalableVector { .. } => {}
-        BackendRepr::ScalarPair(..) | BackendRepr::Memory { .. } => match arg_layout.fields {
+        BackendRepr::ScalarPair { .. } | BackendRepr::Memory { .. } => match arg_layout.fields {
             FieldsShape::Primitive => {
                 unreachable!("aggregates can't have `FieldsShape::Primitive`")
             }

--- a/compiler/rustc_target/src/callconv/x86.rs
+++ b/compiler/rustc_target/src/callconv/x86.rs
@@ -92,7 +92,7 @@ where
                 Ty: TyAbiInterface<'a, C> + Copy,
             {
                 match layout.backend_repr {
-                    BackendRepr::Scalar(_) | BackendRepr::ScalarPair(..) => false,
+                    BackendRepr::Scalar(_) | BackendRepr::ScalarPair { .. } => false,
                     BackendRepr::SimdVector { .. } => true,
                     BackendRepr::Memory { .. } => {
                         for i in 0..layout.fields.count() {
@@ -211,7 +211,7 @@ where
     if !fn_abi.ret.is_ignore() {
         let has_float = match fn_abi.ret.layout.backend_repr {
             BackendRepr::Scalar(s) => matches!(s.primitive(), Primitive::Float(_)),
-            BackendRepr::ScalarPair(s1, s2) => {
+            BackendRepr::ScalarPair { a: s1, b: s2, b_offset: _ } => {
                 matches!(s1.primitive(), Primitive::Float(_))
                     || matches!(s2.primitive(), Primitive::Float(_))
             }

--- a/compiler/rustc_target/src/callconv/x86_64.rs
+++ b/compiler/rustc_target/src/callconv/x86_64.rs
@@ -61,7 +61,7 @@ where
 
             BackendRepr::SimdScalableVector { .. } => panic!("scalable vectors are unsupported"),
 
-            BackendRepr::ScalarPair(..) | BackendRepr::Memory { .. } => {
+            BackendRepr::ScalarPair { .. } | BackendRepr::Memory { .. } => {
                 for i in 0..layout.fields.count() {
                     let field_off = off + layout.fields.offset(i);
                     classify(cx, layout.field(cx, i), cls, field_off)?;

--- a/compiler/rustc_target/src/callconv/x86_win64.rs
+++ b/compiler/rustc_target/src/callconv/x86_win64.rs
@@ -12,7 +12,7 @@ where
     let fixup = |a: &mut ArgAbi<'_, Ty>, is_ret: bool| {
         match a.layout.backend_repr {
             BackendRepr::Memory { sized: false } => {}
-            BackendRepr::ScalarPair(..) | BackendRepr::Memory { sized: true } => {
+            BackendRepr::ScalarPair { .. } | BackendRepr::Memory { sized: true } => {
                 match a.layout.size.bits() {
                     8 => a.cast_to(Reg::i8()),
                     16 => a.cast_to(Reg::i16()),

--- a/compiler/rustc_ty_utils/src/abi.rs
+++ b/compiler/rustc_ty_utils/src/abi.rs
@@ -486,7 +486,7 @@ fn fn_abi_sanity_check<'tcx>(
                     BackendRepr::Scalar(_)
                     | BackendRepr::SimdVector { .. }
                     | BackendRepr::SimdScalableVector { .. } => {}
-                    BackendRepr::ScalarPair(..) => {
+                    BackendRepr::ScalarPair { .. } => {
                         panic!("`PassMode::Direct` used for ScalarPair type {}", arg.layout.ty)
                     }
                     BackendRepr::Memory { sized } => {
@@ -513,7 +513,7 @@ fn fn_abi_sanity_check<'tcx>(
                 // Similar to `Direct`, we need to make sure that backends use `layout.backend_repr`
                 // and ignore the rest of the layout.
                 assert!(
-                    matches!(arg.layout.backend_repr, BackendRepr::ScalarPair(..)),
+                    matches!(arg.layout.backend_repr, BackendRepr::ScalarPair { .. }),
                     "PassMode::Pair for type {}",
                     arg.layout.ty
                 );
@@ -612,7 +612,7 @@ fn fn_abi_new_uncached<'tcx>(
             layout
         };
 
-        Ok(ArgAbi::new(cx, layout, |scalar, offset| {
+        Ok(ArgAbi::new(layout, |scalar, offset| {
             arg_attrs_for_rust_scalar(*cx, scalar, layout, offset, is_return, determined_fn_def_id)
         }))
     };
@@ -741,7 +741,7 @@ fn make_thin_self_ptr<'tcx>(
         Ty::new_mut_ptr(tcx, layout.ty)
     } else {
         match layout.backend_repr {
-            BackendRepr::ScalarPair(..) | BackendRepr::Scalar(..) => (),
+            BackendRepr::ScalarPair { .. } | BackendRepr::Scalar(..) => (),
             _ => bug!("receiver type has unsupported layout: {:?}", layout),
         }
 

--- a/compiler/rustc_ty_utils/src/layout.rs
+++ b/compiler/rustc_ty_utils/src/layout.rs
@@ -291,7 +291,8 @@ fn layout_of_uncached<'tcx>(
                     }
                 }
                 ty::PatternKind::NotNull => {
-                    if let BackendRepr::Scalar(scalar) | BackendRepr::ScalarPair(scalar, _) =
+                    if let BackendRepr::Scalar(scalar)
+                    | BackendRepr::ScalarPair { a: scalar, b: _, b_offset: _ } =
                         &mut layout.backend_repr
                     {
                         scalar.valid_range_mut().start = 1;

--- a/compiler/rustc_ty_utils/src/layout/invariant.rs
+++ b/compiler/rustc_ty_utils/src/layout/invariant.rs
@@ -158,14 +158,20 @@ pub(super) fn layout_sanity_check<'tcx>(cx: &LayoutCx<'tcx>, layout: &TyAndLayou
                     }
                 }
             }
-            BackendRepr::ScalarPair(scalar1, scalar2) => {
+            BackendRepr::ScalarPair { a: scalar1, b: scalar2, b_offset } => {
                 // Check that the underlying pair of fields matches.
                 let inner = skip_newtypes(cx, layout);
                 assert!(
-                    matches!(inner.layout.backend_repr(), BackendRepr::ScalarPair(..)),
+                    matches!(inner.layout.backend_repr(), BackendRepr::ScalarPair { .. }),
                     "`ScalarPair` type {} is newtype around non-`ScalarPair` type {}",
                     layout.ty,
                     inner.ty
+                );
+                // `a` is at memory offset zero, so to keep them from overlapping the offset
+                // to `b` must be at least as much as the size of `a`.
+                assert!(
+                    b_offset >= scalar1.size(cx),
+                    "`ScalarPair` scalars are overlapping in {layout:?}",
                 );
                 if matches!(inner.layout.variants(), Variants::Multiple { .. }) {
                     // FIXME: ScalarPair for enums is enormously complicated and it is very hard
@@ -233,6 +239,10 @@ pub(super) fn layout_sanity_check<'tcx>(cx: &LayoutCx<'tcx>, layout: &TyAndLayou
                 assert_eq!(
                     offset2, field2_offset,
                     "`ScalarPair` second field at bad offset in {inner:#?}",
+                );
+                assert_eq!(
+                    b_offset, field2_offset,
+                    "`ScalarPair` with inconsistent b_offset in {inner:#?}",
                 );
                 assert_eq!(
                     field2.size, size2,
@@ -325,8 +335,11 @@ pub(super) fn layout_sanity_check<'tcx>(cx: &LayoutCx<'tcx>, layout: &TyAndLayou
                 };
                 let abi_coherent = match (layout.backend_repr, variant.backend_repr) {
                     (BackendRepr::Scalar(s1), BackendRepr::Scalar(s2)) => scalar_coherent(s1, s2),
-                    (BackendRepr::ScalarPair(a1, b1), BackendRepr::ScalarPair(a2, b2)) => {
-                        scalar_coherent(a1, a2) && scalar_coherent(b1, b2)
+                    (
+                        BackendRepr::ScalarPair { a: a1, b: b1, b_offset: b1_offset },
+                        BackendRepr::ScalarPair { a: a2, b: b2, b_offset: b2_offset },
+                    ) => {
+                        scalar_coherent(a1, a2) && scalar_coherent(b1, b2) && b1_offset == b2_offset
                     }
                     (BackendRepr::Memory { .. }, _) => true,
                     _ => false,

--- a/library/alloc/src/collections/vec_deque/mod.rs
+++ b/library/alloc/src/collections/vec_deque/mod.rs
@@ -1366,6 +1366,7 @@ impl<T, A: Allocator> VecDeque<T, A> {
     /// buf.truncate(1);
     /// assert_eq!(buf, [5]);
     /// ```
+    #[doc(alias = "retain_front")]
     #[stable(feature = "deque_extras", since = "1.16.0")]
     pub fn truncate(&mut self, len: usize) {
         /// Runs the destructor for all items in the slice when it gets dropped (normally or
@@ -1420,7 +1421,6 @@ impl<T, A: Allocator> VecDeque<T, A> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(vec_deque_truncate_front)]
     /// use std::collections::VecDeque;
     ///
     /// let mut buf = VecDeque::new();
@@ -1429,11 +1429,12 @@ impl<T, A: Allocator> VecDeque<T, A> {
     /// buf.push_front(15);
     /// assert_eq!(buf, [15, 10, 5]);
     /// assert_eq!(buf.as_slices(), (&[15, 10, 5][..], &[][..]));
-    /// buf.truncate_front(1);
+    /// buf.retain_back(1);
     /// assert_eq!(buf.as_slices(), (&[5][..], &[][..]));
     /// ```
-    #[unstable(feature = "vec_deque_truncate_front", issue = "140667")]
-    pub fn truncate_front(&mut self, len: usize) {
+    #[doc(alias = "truncate_front")]
+    #[stable(feature = "vec_deque_truncate_front", since = "CURRENT_RUSTC_VERSION")]
+    pub fn retain_back(&mut self, len: usize) {
         /// Runs the destructor for all items in the slice when it gets dropped (normally or
         /// during unwinding).
         struct Dropper<'a, T>(&'a mut [T]);

--- a/library/alloctests/tests/lib.rs
+++ b/library/alloctests/tests/lib.rs
@@ -36,7 +36,6 @@
 #![feature(str_as_str)]
 #![feature(strict_provenance_lints)]
 #![feature(string_replace_in_place)]
-#![feature(vec_deque_truncate_front)]
 #![feature(unique_rc_arc)]
 #![feature(macro_metavar_expr_concat)]
 #![feature(vec_peek_mut)]

--- a/library/alloctests/tests/vec_deque.rs
+++ b/library/alloctests/tests/vec_deque.rs
@@ -1635,7 +1635,7 @@ fn truncate_leak() {
 
 #[test]
 #[cfg_attr(not(panic = "unwind"), ignore = "test requires unwinding support")]
-fn truncate_front_leak() {
+fn retain_back_leak() {
     struct_with_counted_drop!(D(bool), DROPS => |this: &D| if this.0 { panic!("panic in `drop`"); } );
 
     let mut q = VecDeque::new();
@@ -1648,7 +1648,7 @@ fn truncate_front_leak() {
     q.push_front(D(false));
     q.push_front(D(false));
 
-    catch_unwind(AssertUnwindSafe(|| q.truncate_front(1))).ok();
+    catch_unwind(AssertUnwindSafe(|| q.retain_back(1))).ok();
 
     assert_eq!(DROPS.get(), 7);
 }
@@ -1817,20 +1817,20 @@ fn test_collect_from_into_iter_keeps_allocation() {
 }
 
 #[test]
-fn test_truncate_front() {
+fn test_retain_back() {
     let mut v = VecDeque::with_capacity(13);
     v.extend(0..7);
     assert_eq!(v.as_slices(), ([0, 1, 2, 3, 4, 5, 6].as_slice(), [].as_slice()));
-    v.truncate_front(10);
+    v.retain_back(10);
     assert_eq!(v.len(), 7);
     assert_eq!(v.as_slices(), ([0, 1, 2, 3, 4, 5, 6].as_slice(), [].as_slice()));
-    v.truncate_front(7);
+    v.retain_back(7);
     assert_eq!(v.len(), 7);
     assert_eq!(v.as_slices(), ([0, 1, 2, 3, 4, 5, 6].as_slice(), [].as_slice()));
-    v.truncate_front(3);
+    v.retain_back(3);
     assert_eq!(v.as_slices(), ([4, 5, 6].as_slice(), [].as_slice()));
     assert_eq!(v.len(), 3);
-    v.truncate_front(0);
+    v.retain_back(0);
     assert_eq!(v.as_slices(), ([].as_slice(), [].as_slice()));
     assert_eq!(v.len(), 0);
 
@@ -1841,13 +1841,13 @@ fn test_truncate_front() {
     v.push_front(8);
     v.push_front(7);
     assert_eq!(v.as_slices(), ([7, 8, 9].as_slice(), [0, 1, 2, 3, 4, 5, 6].as_slice()));
-    v.truncate_front(12);
+    v.retain_back(12);
     assert_eq!(v.as_slices(), ([7, 8, 9].as_slice(), [0, 1, 2, 3, 4, 5, 6].as_slice()));
-    v.truncate_front(10);
+    v.retain_back(10);
     assert_eq!(v.as_slices(), ([7, 8, 9].as_slice(), [0, 1, 2, 3, 4, 5, 6].as_slice()));
-    v.truncate_front(8);
+    v.retain_back(8);
     assert_eq!(v.as_slices(), ([9].as_slice(), [0, 1, 2, 3, 4, 5, 6].as_slice()));
-    v.truncate_front(5);
+    v.retain_back(5);
     assert_eq!(v.as_slices(), ([2, 3, 4, 5, 6].as_slice(), [].as_slice()));
 }
 
@@ -1855,7 +1855,7 @@ fn test_truncate_front() {
 fn test_extend_from_within() {
     let mut v = VecDeque::with_capacity(8);
     v.extend(0..6);
-    v.truncate_front(4);
+    v.retain_back(4);
     assert_eq!(v, [2, 3, 4, 5]);
     v.extend_from_within(1..4);
     assert_eq!(v, [2, 3, 4, 5, 3, 4, 5]);
@@ -1915,7 +1915,7 @@ fn test_extend_from_within_clone() {
         panic: false,
     }));
     // remove the dummy elements
-    v.truncate_front(4);
+    v.retain_back(4);
     assert_eq!(v.iter().map(|tr| tr.id).collect::<Vec<_>>(), [0, 1, 2, 3]);
 
     v.extend_from_within(2..);
@@ -1947,7 +1947,7 @@ fn test_extend_from_within_clone_panic() {
         panic: false,
     }));
     // remove the dummy elements
-    v.truncate_front(4);
+    v.retain_back(4);
     assert_eq!(v.iter().map(|tr| tr.id).collect::<Vec<_>>(), [0, 1, 2, 3]);
 
     // panic after wrapping
@@ -1963,7 +1963,7 @@ fn test_extend_from_within_clone_panic() {
     // nothing should have been dropped
     assert_eq!(drop_count.get(), 0);
 
-    v.truncate_front(2);
+    v.retain_back(2);
     assert_eq!(drop_count.get(), 4);
     assert_eq!(v.iter().map(|tr| tr.id).collect::<Vec<_>>(), [0, 1]);
 
@@ -1985,7 +1985,7 @@ fn test_extend_from_within_clone_panic() {
 fn test_prepend_from_within() {
     let mut v = VecDeque::with_capacity(8);
     v.extend(0..6);
-    v.truncate_front(4);
+    v.retain_back(4);
     v.prepend_from_within(..=0);
     assert_eq!(v.as_slices(), ([2, 2, 3, 4, 5].as_slice(), [].as_slice()));
     v.prepend_from_within(2..);
@@ -2007,7 +2007,7 @@ fn test_prepend_from_within_clone() {
         panic: false,
     }));
     // remove the dummy elements
-    v.truncate_front(4);
+    v.retain_back(4);
     assert_eq!(v.iter().map(|tr| tr.id).collect::<Vec<_>>(), [0, 1, 2, 3]);
 
     v.prepend_from_within(..2);
@@ -2034,7 +2034,7 @@ fn test_prepend_from_within_clone_panic() {
         panic: false,
     }));
     // remove the dummy elements
-    v.truncate_front(4);
+    v.retain_back(4);
     assert_eq!(v.iter().map(|tr| tr.id).collect::<Vec<_>>(), [0, 1, 2, 3]);
 
     // panic after wrapping
@@ -2050,7 +2050,7 @@ fn test_prepend_from_within_clone_panic() {
     // nothing should have been dropped
     assert_eq!(drop_count.get(), 0);
 
-    v.truncate_front(2);
+    v.retain_back(2);
     assert_eq!(drop_count.get(), 4);
     assert_eq!(v.iter().map(|tr| tr.id).collect::<Vec<_>>(), [2, 3]);
 
@@ -2071,7 +2071,7 @@ fn test_prepend_from_within_clone_panic() {
 #[test]
 fn test_extend_and_prepend_from_within() {
     let mut v = ('0'..='9').map(String::from).collect::<VecDeque<_>>();
-    v.truncate_front(5);
+    v.retain_back(5);
     v.extend_from_within(4..);
     v.prepend_from_within(..2);
     assert_eq!(v.iter().map(|s| &**s).collect::<String>(), "56567899");
@@ -2095,7 +2095,7 @@ fn test_extend_front() {
     let mut v = VecDeque::with_capacity(8);
     let cap = v.capacity();
     v.extend(0..4);
-    v.truncate_front(2);
+    v.retain_back(2);
     v.extend_front(4..8);
     assert_eq!(v.as_slices(), ([7, 6].as_slice(), [5, 4, 2, 3].as_slice()));
     assert_eq!(v.capacity(), cap);

--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -55,6 +55,7 @@
 
 use crate::ffi::{VaArgSafe, VaList};
 use crate::marker::{ConstParamTy, DiscriminantKind, PointeeSized, Tuple};
+use crate::num::imp::libm;
 use crate::{mem, ptr};
 
 mod bounds;
@@ -1083,233 +1084,329 @@ pub fn powif128(a: f128, x: i32) -> f128;
 ///
 /// The stabilized version of this intrinsic is
 /// [`f16::sin`](../../std/primitive.f16.html#method.sin)
+#[inline]
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub fn sinf16(x: f16) -> f16;
+pub fn sinf16(x: f16) -> f16 {
+    libm::likely_available::sinf(x as f32) as f16
+}
 /// Returns the sine of an `f32`.
 ///
 /// The stabilized version of this intrinsic is
 /// [`f32::sin`](../../std/primitive.f32.html#method.sin)
+#[inline]
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub fn sinf32(x: f32) -> f32;
+pub fn sinf32(x: f32) -> f32 {
+    libm::likely_available::sinf(x)
+}
 /// Returns the sine of an `f64`.
 ///
 /// The stabilized version of this intrinsic is
 /// [`f64::sin`](../../std/primitive.f64.html#method.sin)
+#[inline]
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub fn sinf64(x: f64) -> f64;
+pub fn sinf64(x: f64) -> f64 {
+    libm::likely_available::sin(x)
+}
 /// Returns the sine of an `f128`.
 ///
 /// The stabilized version of this intrinsic is
 /// [`f128::sin`](../../std/primitive.f128.html#method.sin)
+#[inline]
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub fn sinf128(x: f128) -> f128;
+pub fn sinf128(x: f128) -> f128 {
+    libm::maybe_available::sinf128(x)
+}
 
 /// Returns the cosine of an `f16`.
 ///
 /// The stabilized version of this intrinsic is
 /// [`f16::cos`](../../std/primitive.f16.html#method.cos)
+#[inline]
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub fn cosf16(x: f16) -> f16;
+pub fn cosf16(x: f16) -> f16 {
+    libm::likely_available::cosf(x as f32) as f16
+}
 /// Returns the cosine of an `f32`.
 ///
 /// The stabilized version of this intrinsic is
 /// [`f32::cos`](../../std/primitive.f32.html#method.cos)
+#[inline]
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub fn cosf32(x: f32) -> f32;
+pub fn cosf32(x: f32) -> f32 {
+    libm::likely_available::cosf(x)
+}
 /// Returns the cosine of an `f64`.
 ///
 /// The stabilized version of this intrinsic is
 /// [`f64::cos`](../../std/primitive.f64.html#method.cos)
+#[inline]
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub fn cosf64(x: f64) -> f64;
+pub fn cosf64(x: f64) -> f64 {
+    libm::likely_available::cos(x)
+}
 /// Returns the cosine of an `f128`.
 ///
 /// The stabilized version of this intrinsic is
 /// [`f128::cos`](../../std/primitive.f128.html#method.cos)
+#[inline]
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub fn cosf128(x: f128) -> f128;
+pub fn cosf128(x: f128) -> f128 {
+    libm::maybe_available::cosf128(x)
+}
 
 /// Raises an `f16` to an `f16` power.
 ///
 /// The stabilized version of this intrinsic is
 /// [`f16::powf`](../../std/primitive.f16.html#method.powf)
+#[inline]
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub fn powf16(a: f16, x: f16) -> f16;
+pub fn powf16(a: f16, x: f16) -> f16 {
+    libm::likely_available::powf(a as f32, x as f32) as f16
+}
 /// Raises an `f32` to an `f32` power.
 ///
 /// The stabilized version of this intrinsic is
 /// [`f32::powf`](../../std/primitive.f32.html#method.powf)
+#[inline]
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub fn powf32(a: f32, x: f32) -> f32;
+pub fn powf32(a: f32, x: f32) -> f32 {
+    libm::likely_available::powf(a, x)
+}
 /// Raises an `f64` to an `f64` power.
 ///
 /// The stabilized version of this intrinsic is
 /// [`f64::powf`](../../std/primitive.f64.html#method.powf)
+#[inline]
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub fn powf64(a: f64, x: f64) -> f64;
+pub fn powf64(a: f64, x: f64) -> f64 {
+    libm::likely_available::pow(a, x)
+}
 /// Raises an `f128` to an `f128` power.
 ///
 /// The stabilized version of this intrinsic is
 /// [`f128::powf`](../../std/primitive.f128.html#method.powf)
+#[inline]
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub fn powf128(a: f128, x: f128) -> f128;
+pub fn powf128(a: f128, x: f128) -> f128 {
+    libm::maybe_available::powf128(a, x)
+}
 
 /// Returns the exponential of an `f16`.
 ///
 /// The stabilized version of this intrinsic is
 /// [`f16::exp`](../../std/primitive.f16.html#method.exp)
+#[inline]
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub fn expf16(x: f16) -> f16;
+pub fn expf16(x: f16) -> f16 {
+    libm::likely_available::expf(x as f32) as f16
+}
 /// Returns the exponential of an `f32`.
 ///
 /// The stabilized version of this intrinsic is
 /// [`f32::exp`](../../std/primitive.f32.html#method.exp)
+#[inline]
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub fn expf32(x: f32) -> f32;
+pub fn expf32(x: f32) -> f32 {
+    libm::likely_available::expf(x)
+}
 /// Returns the exponential of an `f64`.
 ///
 /// The stabilized version of this intrinsic is
 /// [`f64::exp`](../../std/primitive.f64.html#method.exp)
+#[inline]
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub fn expf64(x: f64) -> f64;
+pub fn expf64(x: f64) -> f64 {
+    libm::likely_available::exp(x)
+}
 /// Returns the exponential of an `f128`.
 ///
 /// The stabilized version of this intrinsic is
 /// [`f128::exp`](../../std/primitive.f128.html#method.exp)
+#[inline]
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub fn expf128(x: f128) -> f128;
+pub fn expf128(x: f128) -> f128 {
+    libm::maybe_available::expf128(x)
+}
 
 /// Returns 2 raised to the power of an `f16`.
 ///
 /// The stabilized version of this intrinsic is
 /// [`f16::exp2`](../../std/primitive.f16.html#method.exp2)
+#[inline]
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub fn exp2f16(x: f16) -> f16;
+pub fn exp2f16(x: f16) -> f16 {
+    libm::likely_available::exp2f(x as f32) as f16
+}
 /// Returns 2 raised to the power of an `f32`.
 ///
 /// The stabilized version of this intrinsic is
 /// [`f32::exp2`](../../std/primitive.f32.html#method.exp2)
+#[inline]
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub fn exp2f32(x: f32) -> f32;
+pub fn exp2f32(x: f32) -> f32 {
+    libm::likely_available::exp2f(x)
+}
 /// Returns 2 raised to the power of an `f64`.
 ///
 /// The stabilized version of this intrinsic is
 /// [`f64::exp2`](../../std/primitive.f64.html#method.exp2)
+#[inline]
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub fn exp2f64(x: f64) -> f64;
+pub fn exp2f64(x: f64) -> f64 {
+    libm::likely_available::exp2(x)
+}
 /// Returns 2 raised to the power of an `f128`.
 ///
 /// The stabilized version of this intrinsic is
 /// [`f128::exp2`](../../std/primitive.f128.html#method.exp2)
+#[inline]
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub fn exp2f128(x: f128) -> f128;
+pub fn exp2f128(x: f128) -> f128 {
+    libm::maybe_available::exp2f128(x)
+}
 
 /// Returns the natural logarithm of an `f16`.
 ///
 /// The stabilized version of this intrinsic is
 /// [`f16::ln`](../../std/primitive.f16.html#method.ln)
+#[inline]
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub fn logf16(x: f16) -> f16;
+pub fn logf16(x: f16) -> f16 {
+    libm::likely_available::logf(x as f32) as f16
+}
 /// Returns the natural logarithm of an `f32`.
 ///
 /// The stabilized version of this intrinsic is
 /// [`f32::ln`](../../std/primitive.f32.html#method.ln)
+#[inline]
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub fn logf32(x: f32) -> f32;
+pub fn logf32(x: f32) -> f32 {
+    libm::likely_available::logf(x)
+}
 /// Returns the natural logarithm of an `f64`.
 ///
 /// The stabilized version of this intrinsic is
 /// [`f64::ln`](../../std/primitive.f64.html#method.ln)
+#[inline]
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub fn logf64(x: f64) -> f64;
+pub fn logf64(x: f64) -> f64 {
+    libm::likely_available::log(x)
+}
 /// Returns the natural logarithm of an `f128`.
 ///
 /// The stabilized version of this intrinsic is
 /// [`f128::ln`](../../std/primitive.f128.html#method.ln)
+#[inline]
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub fn logf128(x: f128) -> f128;
+pub fn logf128(x: f128) -> f128 {
+    libm::maybe_available::logf128(x)
+}
 
 /// Returns the base 10 logarithm of an `f16`.
 ///
 /// The stabilized version of this intrinsic is
 /// [`f16::log10`](../../std/primitive.f16.html#method.log10)
+#[inline]
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub fn log10f16(x: f16) -> f16;
+pub fn log10f16(x: f16) -> f16 {
+    libm::likely_available::log10f(x as f32) as f16
+}
 /// Returns the base 10 logarithm of an `f32`.
 ///
 /// The stabilized version of this intrinsic is
 /// [`f32::log10`](../../std/primitive.f32.html#method.log10)
+#[inline]
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub fn log10f32(x: f32) -> f32;
+pub fn log10f32(x: f32) -> f32 {
+    libm::likely_available::log10f(x)
+}
 /// Returns the base 10 logarithm of an `f64`.
 ///
 /// The stabilized version of this intrinsic is
 /// [`f64::log10`](../../std/primitive.f64.html#method.log10)
+#[inline]
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub fn log10f64(x: f64) -> f64;
+pub fn log10f64(x: f64) -> f64 {
+    libm::likely_available::log10(x)
+}
 /// Returns the base 10 logarithm of an `f128`.
 ///
 /// The stabilized version of this intrinsic is
 /// [`f128::log10`](../../std/primitive.f128.html#method.log10)
+#[inline]
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub fn log10f128(x: f128) -> f128;
+pub fn log10f128(x: f128) -> f128 {
+    libm::maybe_available::log10f128(x)
+}
 
 /// Returns the base 2 logarithm of an `f16`.
 ///
 /// The stabilized version of this intrinsic is
 /// [`f16::log2`](../../std/primitive.f16.html#method.log2)
+#[inline]
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub fn log2f16(x: f16) -> f16;
+pub fn log2f16(x: f16) -> f16 {
+    libm::likely_available::log2f(x as f32) as f16
+}
 /// Returns the base 2 logarithm of an `f32`.
 ///
 /// The stabilized version of this intrinsic is
 /// [`f32::log2`](../../std/primitive.f32.html#method.log2)
+#[inline]
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub fn log2f32(x: f32) -> f32;
+pub fn log2f32(x: f32) -> f32 {
+    libm::likely_available::log2f(x)
+}
 /// Returns the base 2 logarithm of an `f64`.
 ///
 /// The stabilized version of this intrinsic is
 /// [`f64::log2`](../../std/primitive.f64.html#method.log2)
+#[inline]
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub fn log2f64(x: f64) -> f64;
+pub fn log2f64(x: f64) -> f64 {
+    libm::likely_available::log2(x)
+}
 /// Returns the base 2 logarithm of an `f128`.
 ///
 /// The stabilized version of this intrinsic is
 /// [`f128::log2`](../../std/primitive.f128.html#method.log2)
+#[inline]
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub fn log2f128(x: f128) -> f128;
+pub fn log2f128(x: f128) -> f128 {
+    libm::maybe_available::log2f128(x)
+}
 
 /// Returns `a * b + c` for `f16` values.
 ///

--- a/library/core/src/num/imp/libm.rs
+++ b/library/core/src/num/imp/libm.rs
@@ -1,11 +1,157 @@
 //! Bindings to math functions provided by the system `libm` or by the `libm` crate, exposed
 //! via `compiler-builtins`.
+//!
+//! The functions in the root of this module are "guaranteed" to be available; see the
+//! `full_availability` module in compiler-builtins for details.
 
 // SAFETY: These symbols have standard interfaces in C and are defined by `libm`, or are
 // provided by `compiler-builtins` on unsupported platforms.
+#[allow(dead_code)] // This list reflects what is available rather than what is consumed.
 unsafe extern "C" {
-    pub(crate) safe fn cbrt(n: f64) -> f64;
+    pub(crate) safe fn cbrt(x: f64) -> f64;
     pub(crate) safe fn cbrtf(n: f32) -> f32;
+    pub(crate) safe fn ceil(x: f64) -> f64;
+    pub(crate) safe fn ceilf(x: f32) -> f32;
+    pub(crate) safe fn ceilf128(x: f128) -> f128;
+    pub(crate) safe fn ceilf16(x: f16) -> f16;
+    pub(crate) safe fn copysign(x: f64, y: f64) -> f64;
+    pub(crate) safe fn copysignf(x: f32, y: f32) -> f32;
+    pub(crate) safe fn copysignf128(x: f128, y: f128) -> f128;
+    pub(crate) safe fn copysignf16(x: f16, y: f16) -> f16;
+    pub(crate) safe fn fabs(x: f64) -> f64;
+    pub(crate) safe fn fabsf(x: f32) -> f32;
+    pub(crate) safe fn fabsf128(x: f128) -> f128;
+    pub(crate) safe fn fabsf16(x: f16) -> f16;
     pub(crate) safe fn fdim(a: f64, b: f64) -> f64;
     pub(crate) safe fn fdimf(a: f32, b: f32) -> f32;
+    pub(crate) safe fn fdimf128(x: f128, y: f128) -> f128;
+    pub(crate) safe fn fdimf16(x: f16, y: f16) -> f16;
+    pub(crate) safe fn floor(x: f64) -> f64;
+    pub(crate) safe fn floorf(x: f32) -> f32;
+    pub(crate) safe fn floorf128(x: f128) -> f128;
+    pub(crate) safe fn floorf16(x: f16) -> f16;
+    pub(crate) safe fn fma(x: f64, y: f64, z: f64) -> f64;
+    pub(crate) safe fn fmaf(x: f32, y: f32, z: f32) -> f32;
+    pub(crate) safe fn fmaf128(x: f128, y: f128, z: f128) -> f128;
+    pub(crate) safe fn fmax(x: f64, y: f64) -> f64;
+    pub(crate) safe fn fmaxf(x: f32, y: f32) -> f32;
+    pub(crate) safe fn fmaxf128(x: f128, y: f128) -> f128;
+    pub(crate) safe fn fmaxf16(x: f16, y: f16) -> f16;
+    pub(crate) safe fn fmaximum(x: f64, y: f64) -> f64;
+    pub(crate) safe fn fmaximumf(x: f32, y: f32) -> f32;
+    pub(crate) safe fn fmaximumf128(x: f128, y: f128) -> f128;
+    pub(crate) safe fn fmaximumf16(x: f16, y: f16) -> f16;
+    pub(crate) safe fn fmin(x: f64, y: f64) -> f64;
+    pub(crate) safe fn fminf(x: f32, y: f32) -> f32;
+    pub(crate) safe fn fminf128(x: f128, y: f128) -> f128;
+    pub(crate) safe fn fminf16(x: f16, y: f16) -> f16;
+    pub(crate) safe fn fminimum(x: f64, y: f64) -> f64;
+    pub(crate) safe fn fminimumf(x: f32, y: f32) -> f32;
+    pub(crate) safe fn fminimumf128(x: f128, y: f128) -> f128;
+    pub(crate) safe fn fminimumf16(x: f16, y: f16) -> f16;
+    pub(crate) safe fn fmod(x: f64, y: f64) -> f64;
+    pub(crate) safe fn fmodf(x: f32, y: f32) -> f32;
+    pub(crate) safe fn fmodf128(x: f128, y: f128) -> f128;
+    pub(crate) safe fn fmodf16(x: f16, y: f16) -> f16;
+    pub(crate) safe fn rint(x: f64) -> f64;
+    pub(crate) safe fn rintf(x: f32) -> f32;
+    pub(crate) safe fn rintf128(x: f128) -> f128;
+    pub(crate) safe fn rintf16(x: f16) -> f16;
+    pub(crate) safe fn round(x: f64) -> f64;
+    pub(crate) safe fn roundeven(x: f64) -> f64;
+    pub(crate) safe fn roundevenf(x: f32) -> f32;
+    pub(crate) safe fn roundevenf128(x: f128) -> f128;
+    pub(crate) safe fn roundevenf16(x: f16) -> f16;
+    pub(crate) safe fn roundf(x: f32) -> f32;
+    pub(crate) safe fn roundf128(x: f128) -> f128;
+    pub(crate) safe fn roundf16(x: f16) -> f16;
+    pub(crate) safe fn sqrt(x: f64) -> f64;
+    pub(crate) safe fn sqrtf(x: f32) -> f32;
+    pub(crate) safe fn sqrtf128(x: f128) -> f128;
+    pub(crate) safe fn sqrtf16(x: f16) -> f16;
+    pub(crate) safe fn trunc(x: f64) -> f64;
+    pub(crate) safe fn truncf(x: f32) -> f32;
+    pub(crate) safe fn truncf128(x: f128) -> f128;
+    pub(crate) safe fn truncf16(x: f16) -> f16;
+}
+
+/// These symbols will be available when `std` is available, and on many no-std platforms. However,
+/// since this isn't a guarantee, we cannot rely on them for stable implementations.
+pub(crate) mod likely_available {
+    #[allow(dead_code)]
+    unsafe extern "C" {
+        pub(crate) safe fn acos(x: f64) -> f64;
+        pub(crate) safe fn acosf(n: f32) -> f32;
+        pub(crate) safe fn asin(x: f64) -> f64;
+        pub(crate) safe fn asinf(n: f32) -> f32;
+        pub(crate) safe fn atan(x: f64) -> f64;
+        pub(crate) safe fn atan2(x: f64, y: f64) -> f64;
+        pub(crate) safe fn atan2f(a: f32, b: f32) -> f32;
+        pub(crate) safe fn atanf(n: f32) -> f32;
+        pub(crate) safe fn cos(x: f64) -> f64;
+        pub(crate) safe fn cosf(x: f32) -> f32;
+        pub(crate) safe fn cosh(x: f64) -> f64;
+        pub(crate) safe fn coshf(n: f32) -> f32;
+        pub(crate) safe fn erf(x: f64) -> f64;
+        pub(crate) safe fn erfc(x: f64) -> f64;
+        pub(crate) safe fn erfcf(x: f32) -> f32;
+        pub(crate) safe fn erff(x: f32) -> f32;
+        pub(crate) safe fn exp(x: f64) -> f64;
+        pub(crate) safe fn exp2(x: f64) -> f64;
+        pub(crate) safe fn exp2f(x: f32) -> f32;
+        pub(crate) safe fn expf(x: f32) -> f32;
+        pub(crate) safe fn expm1(x: f64) -> f64;
+        pub(crate) safe fn expm1f(n: f32) -> f32;
+        pub(crate) safe fn hypot(x: f64, y: f64) -> f64;
+        pub(crate) safe fn hypotf(x: f32, y: f32) -> f32;
+        pub(crate) safe fn ldexp(f: f64, n: i32) -> f64;
+        pub(crate) safe fn ldexpf(f: f32, n: i32) -> f32;
+        pub(crate) safe fn log(x: f64) -> f64;
+        pub(crate) safe fn log10(x: f64) -> f64;
+        pub(crate) safe fn log10f(x: f32) -> f32;
+        pub(crate) safe fn log1p(x: f64) -> f64;
+        pub(crate) safe fn log1pf(n: f32) -> f32;
+        pub(crate) safe fn log2(x: f64) -> f64;
+        pub(crate) safe fn log2f(x: f32) -> f32;
+        pub(crate) safe fn logf(x: f32) -> f32;
+        pub(crate) safe fn pow(x: f64, y: f64) -> f64;
+        pub(crate) safe fn powf(x: f32, y: f32) -> f32;
+        pub(crate) safe fn sin(x: f64) -> f64;
+        pub(crate) safe fn sinf(x: f32) -> f32;
+        pub(crate) safe fn sinh(x: f64) -> f64;
+        pub(crate) safe fn sinhf(n: f32) -> f32;
+        pub(crate) safe fn tan(x: f64) -> f64;
+        pub(crate) safe fn tanf(n: f32) -> f32;
+        pub(crate) safe fn tanh(x: f64) -> f64;
+        pub(crate) safe fn tanhf(n: f32) -> f32;
+        pub(crate) safe fn tgamma(x: f64) -> f64;
+        pub(crate) safe fn tgammaf(x: f32) -> f32;
+    }
+}
+
+/// These symbols exist on some platforms but do not have a compiler-builtins fallback.
+pub(crate) mod maybe_available {
+    #[allow(dead_code)]
+    unsafe extern "C" {
+        pub(crate) safe fn acosf128(x: f128) -> f128;
+        pub(crate) safe fn asinf128(x: f128) -> f128;
+        pub(crate) safe fn atanf128(x: f128) -> f128;
+        pub(crate) safe fn cbrtf128(x: f128) -> f128;
+        pub(crate) safe fn cosf128(x: f128) -> f128;
+        pub(crate) safe fn erff128(x: f128) -> f128;
+        pub(crate) safe fn expf128(x: f128) -> f128;
+        pub(crate) safe fn exp2f128(x: f128) -> f128;
+        pub(crate) safe fn expm1f128(x: f128) -> f128;
+        pub(crate) safe fn hypotf128(x: f128, y: f128) -> f128;
+        pub(crate) safe fn ldexpf128(f: f128, n: i32) -> f128;
+        pub(crate) safe fn log10f128(x: f128) -> f128;
+        pub(crate) safe fn log1pf128(x: f128) -> f128;
+        pub(crate) safe fn log2f128(x: f128) -> f128;
+        pub(crate) safe fn logf128(x: f128) -> f128;
+        pub(crate) safe fn powf128(x: f128, y: f128) -> f128;
+        pub(crate) safe fn sinf128(x: f128) -> f128;
+        pub(crate) safe fn tanf128(x: f128) -> f128;
+        pub(crate) safe fn tanhf128(x: f128) -> f128;
+        pub(crate) safe fn tgammaf128(x: f128) -> f128;
+    }
 }

--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -2392,7 +2392,7 @@ macro_rules! int_impl {
         ///
         /// Beware that, unlike most other `wrapping_*` methods on integers, this
         /// does *not* give the same result as doing the shift in infinite precision
-        /// then truncating as needed.  The behaviour matches what shift instructions
+        /// then truncating as needed. Instead, the behaviour of this method matches what shift instructions
         /// do on many processors, and is what the `<<` operator does when overflow
         /// checks are disabled, but numerically it's weird.  Consider, instead,
         /// using [`Self::unbounded_shl`] which has nicer behaviour.
@@ -2429,7 +2429,7 @@ macro_rules! int_impl {
         ///
         /// Beware that, unlike most other `wrapping_*` methods on integers, this
         /// does *not* give the same result as doing the shift in infinite precision
-        /// then truncating as needed.  The behaviour matches what shift instructions
+        /// then truncating as needed. Instead, the behaviour of this method matches what shift instructions
         /// do on many processors, and is what the `>>` operator does when overflow
         /// checks are disabled, but numerically it's weird.  Consider, instead,
         /// using [`Self::unbounded_shr`] which has nicer behaviour.

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -2827,7 +2827,7 @@ macro_rules! uint_impl {
         ///
         /// Beware that, unlike most other `wrapping_*` methods on integers, this
         /// does *not* give the same result as doing the shift in infinite precision
-        /// then truncating as needed.  The behaviour matches what shift instructions
+        /// then truncating as needed. Instead, the behaviour of this method matches what shift instructions
         /// do on many processors, and is what the `<<` operator does when overflow
         /// checks are disabled, but numerically it's weird.  Consider, instead,
         /// using [`Self::unbounded_shl`] which has nicer behaviour.
@@ -2871,7 +2871,7 @@ macro_rules! uint_impl {
         ///
         /// Beware that, unlike most other `wrapping_*` methods on integers, this
         /// does *not* give the same result as doing the shift in infinite precision
-        /// then truncating as needed.  The behaviour matches what shift instructions
+        /// then truncating as needed. Instead, the behaviour of this method matches what shift instructions
         /// do on many processors, and is what the `>>` operator does when overflow
         /// checks are disabled, but numerically it's weird.  Consider, instead,
         /// using [`Self::unbounded_shr`] which has nicer behaviour.

--- a/library/std/src/os/fd/owned.rs
+++ b/library/std/src/os/fd/owned.rs
@@ -12,7 +12,7 @@ use crate::fs;
 use crate::marker::PhantomData;
 use crate::mem::ManuallyDrop;
 #[cfg(not(any(
-    target_arch = "wasm32",
+    all(target_arch = "wasm32", not(target_os = "emscripten")),
     target_env = "sgx",
     target_os = "hermit",
     target_os = "trusty",
@@ -104,7 +104,7 @@ impl BorrowedFd<'_> {
     /// Creates a new `OwnedFd` instance that shares the same underlying file
     /// description as the existing `BorrowedFd` instance.
     #[cfg(not(any(
-        target_arch = "wasm32",
+        all(target_arch = "wasm32", not(target_os = "emscripten")),
         target_os = "hermit",
         target_os = "trusty",
         target_os = "motor"
@@ -131,7 +131,11 @@ impl BorrowedFd<'_> {
 
     /// Creates a new `OwnedFd` instance that shares the same underlying file
     /// description as the existing `BorrowedFd` instance.
-    #[cfg(any(target_arch = "wasm32", target_os = "hermit", target_os = "trusty"))]
+    #[cfg(any(
+        all(target_arch = "wasm32", not(target_os = "emscripten")),
+        target_os = "hermit",
+        target_os = "trusty"
+    ))]
     #[stable(feature = "io_safety", since = "1.63.0")]
     pub fn try_clone_to_owned(&self) -> io::Result<OwnedFd> {
         Err(io::Error::UNSUPPORTED_PLATFORM)

--- a/library/std/src/os/unix/io/mod.rs
+++ b/library/std/src/os/unix/io/mod.rs
@@ -214,7 +214,7 @@ fn replace_stdio_fd(this: BorrowedFd<'_>, other: OwnedFd) -> io::Result<()> {
             cvt(unsafe { libc::__wasilibc_fd_renumber(other.as_raw_fd(), this.as_raw_fd()) }).map(|_| ())
         }
         not(any(
-            target_arch = "wasm32",
+            all(target_arch = "wasm32", not(target_os = "emscripten")),
             target_os = "hermit",
             target_os = "trusty",
             target_os = "motor"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "browser-ui-test": "^0.24.0",
+    "browser-ui-test": "^0.24.1",
     "es-check": "^9.4.4",
     "eslint": "^8.57.1",
     "typescript": "^5.8.3"

--- a/src/ci/docker/host-x86_64/x86_64-gnu-miri/check-miri.sh
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-miri/check-miri.sh
@@ -15,14 +15,6 @@ if [ -z "${PR_CI_JOB:-}" ]; then
 else
     python3 "$X_PY" test --stage 2 src/tools/miri src/tools/miri/cargo-miri
 fi
-# We re-run the test suite for a chance to find bugs in the intrinsic fallback bodies and in MIR
-# optimizations. This can miss UB, so we only run the "pass" tests. We need to enable debug
-# assertions as `-O` disables them but some tests rely on them. We also set a cfg flag so tests can
-# adjust their expectations if needed. This can change the output of the tests so we ignore that,
-# we only ensure that all assertions still pass.
-MIRIFLAGS="-Zmiri-force-intrinsic-fallback --cfg force_intrinsic_fallback -O -Zmir-opt-level=4 -Cdebug-assertions=yes" \
-  MIRI_SKIP_UI_CHECKS=1 \
-  python3 "$X_PY" test --stage 2 src/tools/miri -- tests/pass tests/panic
 # We natively run this script on x86_64-unknown-linux-gnu and x86_64-pc-windows-msvc.
 # Also cover some other targets via cross-testing, in particular all tier 1 targets.
 case $HOST_TARGET in

--- a/src/tools/clippy/clippy_utils/src/ty/mod.rs
+++ b/src/tools/clippy/clippy_utils/src/ty/mod.rs
@@ -525,7 +525,7 @@ fn is_uninit_value_valid_for_layout<'tcx>(cx: &LateContext<'tcx>, layout: TyAndL
 
     match layout.layout.backend_repr {
         BackendRepr::Scalar(s) => s.is_uninit_valid(),
-        BackendRepr::ScalarPair(a, b) => a.is_uninit_valid() && b.is_uninit_valid(),
+        BackendRepr::ScalarPair { a, b, b_offset: _ } => a.is_uninit_valid() && b.is_uninit_valid(),
         BackendRepr::SimdVector { element, count } => count == 0 || element.is_uninit_valid(),
         BackendRepr::SimdScalableVector { element, .. } => element.is_uninit_valid(),
         // Here validity is determined by the structural fields instead.

--- a/src/tools/miri/src/shims/native_lib/mod.rs
+++ b/src/tools/miri/src/shims/native_lib/mod.rs
@@ -313,7 +313,8 @@ trait EvalContextExtPriv<'tcx>: crate::MiriInterpCxExt<'tcx> {
                     Immediate::ScalarPair(sc_first, sc_second) => {
                         // The first scalar has an offset of zero; compute the offset of the 2nd.
                         let ofs_second = {
-                            let rustc_abi::BackendRepr::ScalarPair(a, b) = imm.layout.backend_repr
+                            let rustc_abi::BackendRepr::ScalarPair { a: _, b: _, b_offset } =
+                                imm.layout.backend_repr
                             else {
                                 span_bug!(
                                     this.cur_span(),
@@ -321,7 +322,7 @@ trait EvalContextExtPriv<'tcx>: crate::MiriInterpCxExt<'tcx> {
                                     imm.layout
                                 )
                             };
-                            a.size(this).align_to(b.default_align(this).abi).bytes_usize()
+                            b_offset.bytes_usize()
                         };
 
                         write_scalar(this, sc_first, 0)?;

--- a/src/tools/wasm-component-ld/Cargo.toml
+++ b/src/tools/wasm-component-ld/Cargo.toml
@@ -10,4 +10,4 @@ name = "wasm-component-ld"
 path = "src/main.rs"
 
 [dependencies]
-wasm-component-ld = "0.5.25"
+wasm-component-ld = "0.5.26"

--- a/tests/mir-opt/coroutine/async_drop.array-{closure#0}.ElaborateDrops.diff
+++ b/tests/mir-opt/coroutine/async_drop.array-{closure#0}.ElaborateDrops.diff
@@ -1,0 +1,220 @@
+- // MIR for `array::{closure#0}` before ElaborateDrops
++ // MIR for `array::{closure#0}` after ElaborateDrops
+  
+  fn array::{closure#0}(_1: {async fn body of array()}, _2: std::future::ResumeTy) -> ()
+  yields ()
+   {
+      debug _task_context => _2;
+      let mut _0: ();
+      let _3: [AsyncInt; 2];
+      let mut _4: AsyncInt;
+      let mut _5: AsyncInt;
++     let mut _6: impl std::future::Future<Output = ()>;
++     let mut _7: std::future::ResumeTy;
++     let mut _8: std::task::Poll<()>;
++     let mut _9: isize;
++     let mut _10: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
++     let mut _11: &mut std::task::Context<'_>;
++     let mut _12: std::future::ResumeTy;
++     let mut _13: &mut impl std::future::Future<Output = ()>;
++     let mut _14: std::future::ResumeTy;
++     let mut _15: std::task::Poll<()>;
++     let mut _16: isize;
++     let mut _17: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
++     let mut _18: &mut std::task::Context<'_>;
++     let mut _19: std::future::ResumeTy;
++     let mut _20: &mut impl std::future::Future<Output = ()>;
++     let mut _21: std::pin::Pin<&mut [AsyncInt; 2]>;
++     let mut _22: &mut [AsyncInt; 2];
+      scope 1 {
+          debug array => _3;
+      }
+  
+      bb0: {
+          StorageLive(_3);
+          StorageLive(_4);
+          _4 = AsyncInt(const 1_i32);
+          StorageLive(_5);
+          _5 = AsyncInt(const 2_i32);
+          _3 = [move _4, move _5];
+-         drop(_5) -> [return: bb1, unwind: bb9, drop: bb5];
++         goto -> bb1;
+      }
+  
+      bb1: {
+          StorageDead(_5);
+-         drop(_4) -> [return: bb2, unwind: bb10, drop: bb6];
++         goto -> bb2;
+      }
+  
+      bb2: {
+          StorageDead(_4);
+          _0 = const ();
+-         drop(_3) -> [return: bb3, unwind: bb11, drop: bb7];
++         goto -> bb34;
+      }
+  
+      bb3: {
+          StorageDead(_3);
+-         drop(_1) -> [return: bb4, drop: bb8, unwind continue];
++         drop(_1) -> [return: bb4, unwind: bb12];
+      }
+  
+      bb4: {
+          return;
+      }
+  
+      bb5: {
+          StorageDead(_5);
+-         drop(_4) -> [return: bb6, unwind: bb13];
++         goto -> bb6;
+      }
+  
+      bb6: {
+          StorageDead(_4);
+          goto -> bb7;
+      }
+  
+      bb7: {
+          StorageDead(_3);
+-         drop(_1) -> [return: bb8, unwind continue];
++         goto -> bb8;
+      }
+  
+      bb8: {
+          coroutine_drop;
+      }
+  
+      bb9 (cleanup): {
+          StorageDead(_5);
+-         drop(_4) -> [return: bb10, unwind terminate(cleanup)];
++         goto -> bb10;
+      }
+  
+      bb10 (cleanup): {
+          StorageDead(_4);
+          goto -> bb11;
+      }
+  
+      bb11 (cleanup): {
+          StorageDead(_3);
+          drop(_1) -> [return: bb12, unwind terminate(cleanup)];
+      }
+  
+      bb12 (cleanup): {
+          resume;
+      }
+  
+      bb13 (cleanup): {
+          StorageDead(_4);
+          StorageDead(_3);
+-         drop(_1) -> [return: bb12, unwind terminate(cleanup)];
++         goto -> bb12;
++     }
++ 
++     bb14: {
++         StorageDead(_6);
++         goto -> bb3;
++     }
++ 
++     bb15: {
++         StorageDead(_6);
++         goto -> bb7;
++     }
++ 
++     bb16 (cleanup): {
++         StorageDead(_6);
++         goto -> bb11;
++     }
++ 
++     bb17: {
++         assert(const false, "`async fn` resumed after async drop") -> [success: bb17, unwind: bb16];
++     }
++ 
++     bb18: {
++         _2 = move _7;
++         StorageDead(_7);
++         goto -> bb17;
++     }
++ 
++     bb19: {
++         _2 = move _7;
++         StorageDead(_7);
++         goto -> bb25;
++     }
++ 
++     bb20: {
++         StorageLive(_7);
++         _7 = yield(const ()) -> [resume: bb18, drop: bb19];
++     }
++ 
++     bb21: {
++         unreachable;
++     }
++ 
++     bb22: {
++         _9 = discriminant(_8);
++         switchInt(move _9) -> [0: bb15, 1: bb20, otherwise: bb21];
++     }
++ 
++     bb23: {
++         _8 = <impl Future<Output = ()> as Future>::poll(move _10, move _11) -> [return: bb22, unwind: bb16];
++     }
++ 
++     bb24: {
++         _12 = move _2;
++         _11 = std::future::get_context::<'_, '_>(move _12) -> [return: bb23, unwind: bb16];
++     }
++ 
++     bb25: {
++         _13 = &mut _6;
++         _10 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _13) -> [return: bb24, unwind: bb16];
++     }
++ 
++     bb26: {
++         _2 = move _14;
++         StorageDead(_14);
++         goto -> bb32;
++     }
++ 
++     bb27: {
++         _2 = move _14;
++         StorageDead(_14);
++         goto -> bb25;
++     }
++ 
++     bb28: {
++         StorageLive(_14);
++         _14 = yield(const ()) -> [resume: bb26, drop: bb27];
++     }
++ 
++     bb29: {
++         _16 = discriminant(_15);
++         switchInt(move _16) -> [0: bb14, 1: bb28, otherwise: bb21];
++     }
++ 
++     bb30: {
++         _15 = <impl Future<Output = ()> as Future>::poll(move _17, move _18) -> [return: bb29, unwind: bb16];
++     }
++ 
++     bb31: {
++         _19 = move _2;
++         _18 = std::future::get_context::<'_, '_>(move _19) -> [return: bb30, unwind: bb16];
++     }
++ 
++     bb32: {
++         _20 = &mut _6;
++         _17 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _20) -> [return: bb31, unwind: bb16];
++     }
++ 
++     bb33: {
++         StorageLive(_6);
++         _6 = async_drop_in_place::<[AsyncInt; 2]>(copy (_21.0: &mut [AsyncInt; 2])) -> [return: bb32, unwind: bb16];
++     }
++ 
++     bb34: {
++         _22 = &mut _3;
++         _21 = Pin::<&mut [AsyncInt; 2]>::new_unchecked(move _22) -> [return: bb33, unwind: bb11];
+      }
+  }
+  

--- a/tests/mir-opt/coroutine/async_drop.array-{closure#0}.StateTransform.diff
+++ b/tests/mir-opt/coroutine/async_drop.array-{closure#0}.StateTransform.diff
@@ -1,0 +1,273 @@
+- // MIR for `array::{closure#0}` before StateTransform
++ // MIR for `array::{closure#0}` after StateTransform
+  
+- fn array::{closure#0}(_1: {async fn body of array()}, _2: std::future::ResumeTy) -> ()
+- yields ()
+-  {
+-     debug _task_context => _2;
+-     let mut _0: ();
++ fn array::{closure#0}(_1: Pin<&mut {async fn body of array()}>, _2: &mut Context<'_>) -> Poll<()> {
++     coroutine layout {
++         field _s0: ();
++         field _s1: [AsyncInt; 2];
++         field _s2: impl Future<Output = ()>;
++         variant_fields = {
++             Unresumed(0): [],
++             Returned (1): [],
++             Panicked (2): [],
++             Suspend0 (3): [_s1, _s2],
++             Suspend1 (4): [_s0, _s1, _s2],
++         }
++         storage_conflicts = BitMatrix(3x3) {(_s0, _s0), (_s0, _s1), (_s0, _s2), (_s1, _s0), (_s1, _s1), (_s1, _s2), (_s2, _s0), (_s2, _s1), (_s2, _s2)}
++     }
++     debug _task_context => _26;
++     coroutine debug array => _s1;
++     let mut _0: std::task::Poll<()>;
+      let _3: [AsyncInt; 2];
+      let mut _4: AsyncInt;
+      let mut _5: AsyncInt;
+      let mut _6: impl std::future::Future<Output = ()>;
+      let mut _7: std::future::ResumeTy;
+      let mut _8: std::task::Poll<()>;
+      let mut _9: isize;
+      let mut _10: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
+      let mut _11: &mut std::task::Context<'_>;
+      let mut _12: std::future::ResumeTy;
+      let mut _13: &mut impl std::future::Future<Output = ()>;
+      let mut _14: std::future::ResumeTy;
+      let mut _15: std::task::Poll<()>;
+      let mut _16: isize;
+      let mut _17: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
+      let mut _18: &mut std::task::Context<'_>;
+      let mut _19: std::future::ResumeTy;
+      let mut _20: &mut impl std::future::Future<Output = ()>;
+      let mut _21: std::pin::Pin<&mut [AsyncInt; 2]>;
+      let mut _22: &mut [AsyncInt; 2];
++     let mut _23: ();
++     let mut _24: u32;
++     let mut _25: &mut {async fn body of array()};
++     let mut _26: std::future::ResumeTy;
++     let mut _27: std::ptr::NonNull<std::task::Context<'_>>;
+      scope 1 {
+-         debug array => _3;
++         debug array => (((*_25) as variant#4).1: [AsyncInt; 2]);
+      }
+  
+      bb0: {
+-         StorageLive(_3);
+-         StorageLive(_4);
+-         _4 = AsyncInt(const 1_i32);
+-         StorageLive(_5);
+-         _5 = AsyncInt(const 2_i32);
+-         _3 = [move _4, move _5];
+-         goto -> bb1;
++         _27 = move _2 as std::ptr::NonNull<std::task::Context<'_>> (Transmute);
++         _26 = std::future::ResumeTy(move _27);
++         _25 = copy (_1.0: &mut {async fn body of array()});
++         _24 = discriminant((*_25));
++         switchInt(move _24) -> [0: bb26, 1: bb25, 2: bb24, 3: bb22, 4: bb23, otherwise: bb11];
+      }
+  
+      bb1: {
+          StorageDead(_5);
+          goto -> bb2;
+      }
+  
+      bb2: {
+          StorageDead(_4);
+-         _0 = const ();
+-         goto -> bb29;
++         (((*_25) as variant#4).0: ()) = const ();
++         goto -> bb19;
+      }
+  
+      bb3: {
+-         StorageDead(_3);
+-         drop(_1) -> [return: bb4, unwind: bb8];
++         nop;
++         goto -> bb20;
+      }
+  
+      bb4: {
++         _0 = Poll::<()>::Ready(move (((*_25) as variant#4).0: ()));
++         discriminant((*_25)) = 1;
+          return;
+      }
+  
+-     bb5: {
+-         StorageDead(_3);
++     bb5 (cleanup): {
++         nop;
+          goto -> bb6;
+      }
+  
+-     bb6: {
+-         coroutine_drop;
++     bb6 (cleanup): {
++         goto -> bb21;
+      }
+  
+-     bb7 (cleanup): {
+-         StorageDead(_3);
+-         drop(_1) -> [return: bb8, unwind terminate(cleanup)];
++     bb7: {
++         nop;
++         goto -> bb3;
+      }
+  
+      bb8 (cleanup): {
+-         resume;
++         nop;
++         goto -> bb5;
+      }
+  
+      bb9: {
+-         StorageDead(_6);
+-         goto -> bb3;
++         assert(const false, "`async fn` resumed after async drop") -> [success: bb9, unwind: bb8];
+      }
+  
+      bb10: {
+-         StorageDead(_6);
+-         goto -> bb5;
++         _26 = move _7;
++         StorageDead(_7);
++         goto -> bb9;
+      }
+  
+-     bb11 (cleanup): {
+-         StorageDead(_6);
+-         goto -> bb7;
++     bb11: {
++         unreachable;
+      }
+  
+      bb12: {
+-         assert(const false, "`async fn` resumed after async drop") -> [success: bb12, unwind: bb11];
++         _26 = move _14;
++         StorageDead(_14);
++         goto -> bb17;
+      }
+  
+      bb13: {
+-         _2 = move _7;
+-         StorageDead(_7);
+-         goto -> bb12;
++         StorageLive(_14);
++         _0 = Poll::<()>::Pending;
++         StorageDead(_14);
++         discriminant((*_25)) = 4;
++         return;
+      }
+  
+      bb14: {
+-         _2 = move _7;
+-         StorageDead(_7);
+-         goto -> bb20;
++         _16 = discriminant(_15);
++         switchInt(move _16) -> [0: bb7, 1: bb13, otherwise: bb11];
+      }
+  
+      bb15: {
+-         StorageLive(_7);
+-         _7 = yield(const ()) -> [resume: bb13, drop: bb14];
++         _15 = <impl Future<Output = ()> as Future>::poll(move _17, move _18) -> [return: bb14, unwind: bb8];
+      }
+  
+      bb16: {
+-         unreachable;
++         _19 = move _26;
++         _18 = copy (_19.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
++         goto -> bb15;
+      }
+  
+      bb17: {
+-         _9 = discriminant(_8);
+-         switchInt(move _9) -> [0: bb10, 1: bb15, otherwise: bb16];
++         _20 = &mut (((*_25) as variant#4).2: impl std::future::Future<Output = ()>);
++         _17 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _20) -> [return: bb16, unwind: bb8];
+      }
+  
+      bb18: {
+-         _8 = <impl Future<Output = ()> as Future>::poll(move _10, move _11) -> [return: bb17, unwind: bb11];
++         nop;
++         (((*_25) as variant#4).2: impl std::future::Future<Output = ()>) = async_drop_in_place::<[AsyncInt; 2]>(copy (_21.0: &mut [AsyncInt; 2])) -> [return: bb17, unwind: bb8];
+      }
+  
+      bb19: {
+-         _12 = move _2;
+-         _11 = std::future::get_context::<'_, '_>(move _12) -> [return: bb18, unwind: bb11];
++         _22 = &mut (((*_25) as variant#4).1: [AsyncInt; 2]);
++         _21 = Pin::<&mut [AsyncInt; 2]>::new_unchecked(move _22) -> [return: bb18, unwind: bb5];
+      }
+  
+      bb20: {
+-         _13 = &mut _6;
+-         _10 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _13) -> [return: bb19, unwind: bb11];
++         goto -> bb4;
+      }
+  
+-     bb21: {
+-         _2 = move _14;
+-         StorageDead(_14);
+-         goto -> bb27;
++     bb21 (cleanup): {
++         discriminant((*_25)) = 2;
++         resume;
+      }
+  
+      bb22: {
+-         _2 = move _14;
+-         StorageDead(_14);
+-         goto -> bb20;
++         StorageLive(_7);
++         _7 = move _26;
++         goto -> bb10;
+      }
+  
+      bb23: {
+          StorageLive(_14);
+-         _14 = yield(const ()) -> [resume: bb21, drop: bb22];
++         _14 = move _26;
++         goto -> bb12;
+      }
+  
+      bb24: {
+-         _16 = discriminant(_15);
+-         switchInt(move _16) -> [0: bb9, 1: bb23, otherwise: bb16];
++         assert(const false, "`async fn` resumed after panicking") -> [success: bb24, unwind continue];
+      }
+  
+      bb25: {
+-         _15 = <impl Future<Output = ()> as Future>::poll(move _17, move _18) -> [return: bb24, unwind: bb11];
++         assert(const false, "`async fn` resumed after completion") -> [success: bb25, unwind continue];
+      }
+  
+      bb26: {
+-         _19 = move _2;
+-         _18 = std::future::get_context::<'_, '_>(move _19) -> [return: bb25, unwind: bb11];
+-     }
+- 
+-     bb27: {
+-         _20 = &mut _6;
+-         _17 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _20) -> [return: bb26, unwind: bb11];
+-     }
+- 
+-     bb28: {
+-         StorageLive(_6);
+-         _6 = async_drop_in_place::<[AsyncInt; 2]>(copy (_21.0: &mut [AsyncInt; 2])) -> [return: bb27, unwind: bb11];
+-     }
+- 
+-     bb29: {
+-         _22 = &mut _3;
+-         _21 = Pin::<&mut [AsyncInt; 2]>::new_unchecked(move _22) -> [return: bb28, unwind: bb7];
++         nop;
++         StorageLive(_4);
++         _4 = AsyncInt(const 1_i32);
++         StorageLive(_5);
++         _5 = AsyncInt(const 2_i32);
++         (((*_25) as variant#4).1: [AsyncInt; 2]) = [move _4, move _5];
++         goto -> bb1;
+      }
+  }
+  

--- a/tests/mir-opt/coroutine/async_drop.array-{closure#0}.coroutine_drop_async.0.mir
+++ b/tests/mir-opt/coroutine/async_drop.array-{closure#0}.coroutine_drop_async.0.mir
@@ -1,0 +1,154 @@
+// MIR for `array::{closure#0}` 0 coroutine_drop_async
+
+fn array::{closure#0}(_1: Pin<&mut {async fn body of array()}>, _2: &mut Context<'_>) -> Poll<()> {
+    debug _task_context => _26;
+    let mut _0: std::task::Poll<()>;
+    let _3: [AsyncInt; 2];
+    let mut _4: AsyncInt;
+    let mut _5: AsyncInt;
+    let mut _6: impl std::future::Future<Output = ()>;
+    let mut _7: std::future::ResumeTy;
+    let mut _8: std::task::Poll<()>;
+    let mut _9: isize;
+    let mut _10: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
+    let mut _11: &mut std::task::Context<'_>;
+    let mut _12: std::future::ResumeTy;
+    let mut _13: &mut impl std::future::Future<Output = ()>;
+    let mut _14: std::future::ResumeTy;
+    let mut _15: std::task::Poll<()>;
+    let mut _16: isize;
+    let mut _17: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
+    let mut _18: &mut std::task::Context<'_>;
+    let mut _19: std::future::ResumeTy;
+    let mut _20: &mut impl std::future::Future<Output = ()>;
+    let mut _21: std::pin::Pin<&mut [AsyncInt; 2]>;
+    let mut _22: &mut [AsyncInt; 2];
+    let mut _23: ();
+    let mut _24: u32;
+    let mut _25: &mut {async fn body of array()};
+    let mut _26: std::future::ResumeTy;
+    let mut _27: std::ptr::NonNull<std::task::Context<'_>>;
+    scope 1 {
+        debug array => (((*_25) as variant#4).1: [AsyncInt; 2]);
+    }
+
+    bb0: {
+        _27 = move _2 as std::ptr::NonNull<std::task::Context<'_>> (Transmute);
+        _26 = std::future::ResumeTy(move _27);
+        _25 = copy (_1.0: &mut {async fn body of array()});
+        _24 = discriminant((*_25));
+        switchInt(move _24) -> [0: bb16, 2: bb21, 3: bb19, 4: bb20, otherwise: bb22];
+    }
+
+    bb1: {
+        nop;
+        goto -> bb2;
+    }
+
+    bb2: {
+        _0 = Poll::<()>::Ready(const ());
+        return;
+    }
+
+    bb3 (cleanup): {
+        nop;
+        goto -> bb4;
+    }
+
+    bb4 (cleanup): {
+        goto -> bb18;
+    }
+
+    bb5: {
+        nop;
+        goto -> bb1;
+    }
+
+    bb6 (cleanup): {
+        nop;
+        goto -> bb3;
+    }
+
+    bb7: {
+        _26 = move _7;
+        StorageDead(_7);
+        goto -> bb13;
+    }
+
+    bb8: {
+        StorageLive(_7);
+        _0 = Poll::<()>::Pending;
+        StorageDead(_7);
+        discriminant((*_25)) = 3;
+        return;
+    }
+
+    bb9: {
+        unreachable;
+    }
+
+    bb10: {
+        _9 = discriminant(_8);
+        switchInt(move _9) -> [0: bb5, 1: bb8, otherwise: bb9];
+    }
+
+    bb11: {
+        _8 = <impl Future<Output = ()> as Future>::poll(move _10, move _11) -> [return: bb10, unwind: bb6];
+    }
+
+    bb12: {
+        _12 = move _26;
+        _11 = copy (_12.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
+        goto -> bb11;
+    }
+
+    bb13: {
+        _13 = &mut (((*_25) as variant#4).2: impl std::future::Future<Output = ()>);
+        _10 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _13) -> [return: bb12, unwind: bb6];
+    }
+
+    bb14: {
+        _26 = move _14;
+        StorageDead(_14);
+        goto -> bb13;
+    }
+
+    bb15: {
+        _0 = Poll::<()>::Ready(const ());
+        return;
+    }
+
+    bb16: {
+        goto -> bb17;
+    }
+
+    bb17: {
+        goto -> bb15;
+    }
+
+    bb18 (cleanup): {
+        discriminant((*_25)) = 2;
+        resume;
+    }
+
+    bb19: {
+        StorageLive(_7);
+        _7 = move _26;
+        goto -> bb7;
+    }
+
+    bb20: {
+        StorageLive(_14);
+        _14 = move _26;
+        goto -> bb14;
+    }
+
+    bb21: {
+        assert(const false, "`async fn` resumed after panicking") -> [success: bb21, unwind continue];
+    }
+
+    bb22: {
+        _0 = Poll::<()>::Ready(const ());
+        return;
+    }
+}

--- a/tests/mir-opt/coroutine/async_drop.core.future-async_drop-async_drop_in_place-{closure#0}.[AsyncInt;2].StateTransform.diff
+++ b/tests/mir-opt/coroutine/async_drop.core.future-async_drop-async_drop_in_place-{closure#0}.[AsyncInt;2].StateTransform.diff
@@ -1,0 +1,357 @@
+- // MIR for `std::future::async_drop_in_place::{closure#0}` before StateTransform
++ // MIR for `std::future::async_drop_in_place::{closure#0}` after StateTransform
+  
+- fn async_drop_in_place::{closure#0}(_1: {async fn body of async_drop_in_place<[AsyncInt; 2]>()}, _2: std::future::ResumeTy) -> ()
+- yields ()
+-  {
+-     let mut _0: ();
++ fn async_drop_in_place::{closure#0}(_1: Pin<&mut {async fn body of async_drop_in_place<[AsyncInt; 2]>()}>, _2: &mut Context<'_>) -> Poll<()> {
++     coroutine layout {
++         field _s0: *mut [AsyncInt];
++         field _s1: usize;
++         field _s2: usize;
++         field _s3: impl Future<Output = ()>;
++         field _s4: impl Future<Output = ()>;
++         variant_fields = {
++             Unresumed(0): [],
++             Returned (1): [],
++             Panicked (2): [],
++             Suspend0 (3): [_s0, _s1, _s2, _s3],
++             Suspend1 (4): [_s0, _s1, _s2, _s4],
++             Suspend2 (5): [_s0, _s1, _s2, _s4],
++         }
++         storage_conflicts = BitMatrix(5x5) {(_s0, _s0), (_s0, _s1), (_s0, _s2), (_s0, _s3), (_s0, _s4), (_s1, _s0), (_s1, _s1), (_s1, _s2), (_s1, _s3), (_s1, _s4), (_s2, _s0), (_s2, _s1), (_s2, _s2), (_s2, _s3), (_s2, _s4), (_s3, _s0), (_s3, _s1), (_s3, _s2), (_s3, _s3), (_s4, _s0), (_s4, _s1), (_s4, _s2), (_s4, _s4)}
++     }
++     let mut _0: std::task::Poll<()>;
+      let mut _3: &mut [AsyncInt; 2];
+      let mut _4: *mut [AsyncInt; 2];
+      let mut _5: *mut [AsyncInt];
+      let mut _6: usize;
+      let mut _7: usize;
+      let mut _8: *mut AsyncInt;
+      let mut _9: bool;
+      let mut _10: *mut AsyncInt;
+      let mut _11: bool;
+      let mut _12: impl std::future::Future<Output = ()>;
+      let mut _13: std::future::ResumeTy;
+      let mut _14: std::task::Poll<()>;
+      let mut _15: isize;
+      let mut _16: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
+      let mut _17: &mut std::task::Context<'_>;
+      let mut _18: std::future::ResumeTy;
+      let mut _19: &mut impl std::future::Future<Output = ()>;
+      let mut _20: std::pin::Pin<&mut AsyncInt>;
+      let mut _21: &mut AsyncInt;
+      let mut _22: *mut AsyncInt;
+      let mut _23: bool;
+      let mut _24: impl std::future::Future<Output = ()>;
+      let mut _25: std::future::ResumeTy;
+      let mut _26: std::task::Poll<()>;
+      let mut _27: isize;
+      let mut _28: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
+      let mut _29: &mut std::task::Context<'_>;
+      let mut _30: std::future::ResumeTy;
+      let mut _31: &mut impl std::future::Future<Output = ()>;
+      let mut _32: std::future::ResumeTy;
+      let mut _33: std::task::Poll<()>;
+      let mut _34: isize;
+      let mut _35: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
+      let mut _36: &mut std::task::Context<'_>;
+      let mut _37: std::future::ResumeTy;
+      let mut _38: &mut impl std::future::Future<Output = ()>;
+      let mut _39: std::pin::Pin<&mut AsyncInt>;
+      let mut _40: &mut AsyncInt;
++     let mut _41: ();
++     let mut _42: u32;
++     let mut _43: &mut {async fn body of std::future::async_drop_in_place<[AsyncInt; 2]>()};
++     let mut _44: *mut [AsyncInt];
++     let mut _45: *mut [AsyncInt];
++     let _46: std::future::ResumeTy;
++     let mut _47: std::ptr::NonNull<std::task::Context<'_>>;
+  
+      bb0: {
+-         _3 = move (_1.0: &mut [AsyncInt; 2]);
+-         _4 = &raw mut (*_3);
+-         _5 = move _4 as *mut [AsyncInt] (PointerCoercion(Unsize, Implicit));
+-         _6 = PtrMetadata(copy _5);
+-         _7 = const 0_usize;
+-         goto -> bb20;
++         _47 = move _2 as std::ptr::NonNull<std::task::Context<'_>> (Transmute);
++         _46 = std::future::ResumeTy(move _47);
++         _43 = copy (_1.0: &mut {async fn body of std::future::async_drop_in_place<[AsyncInt; 2]>()});
++         _42 = discriminant((*_43));
++         switchInt(move _42) -> [0: bb28, 1: bb27, 2: bb26, 3: bb23, 4: bb24, 5: bb25, otherwise: bb8];
+      }
+  
+      bb1: {
++         _0 = Poll::<()>::Ready(move _41);
++         discriminant((*_43)) = 1;
+          return;
+      }
+  
+      bb2 (cleanup): {
+-         resume;
++         goto -> bb22;
+      }
+  
+      bb3 (cleanup): {
+-         _8 = &raw mut (*_5)[_7];
+-         _7 = Add(move _7, const 1_usize);
++         _7 = no_retag copy (((*_43) as variant#5).2: usize);
++         _44 = no_retag copy (((*_43) as variant#5).0: *mut [AsyncInt]);
++         _8 = &raw mut (*_44)[_7];
++         (((*_43) as variant#5).2: usize) = Add(move (((*_43) as variant#5).2: usize), const 1_usize);
+          drop((*_8)) -> [return: bb4, unwind terminate(cleanup)];
+      }
+  
+      bb4 (cleanup): {
+-         _9 = Eq(copy _7, copy _6);
++         _9 = Eq(copy (((*_43) as variant#5).2: usize), copy (((*_43) as variant#5).1: usize));
+          switchInt(move _9) -> [0: bb3, otherwise: bb2];
+      }
+  
+-     bb5: {
+-         _10 = &raw mut (*_5)[_7];
+-         _7 = Add(move _7, const 1_usize);
+-         _21 = &mut (*_10);
+-         _20 = Pin::<&mut AsyncInt>::new_unchecked(move _21) -> [return: bb18, unwind: bb4];
++     bb5 (cleanup): {
++         nop;
++         goto -> bb4;
+      }
+  
+      bb6: {
+-         _11 = Eq(copy _7, copy _6);
+-         switchInt(move _11) -> [0: bb5, otherwise: bb1];
++         assert(const false, "`async fn` resumed after async drop") -> [success: bb6, unwind: bb5];
+      }
+  
+      bb7: {
+-         StorageDead(_12);
++         _46 = move _13;
++         StorageDead(_13);
+          goto -> bb6;
+      }
+  
+-     bb8 (cleanup): {
+-         StorageDead(_12);
+-         goto -> bb4;
++     bb8: {
++         unreachable;
+      }
+  
+      bb9: {
+-         assert(const false, "`async fn` resumed after async drop") -> [success: bb9, unwind: bb8];
++         _7 = no_retag copy (((*_43) as variant#5).2: usize);
++         _45 = no_retag copy (((*_43) as variant#5).0: *mut [AsyncInt]);
++         _22 = &raw mut (*_45)[_7];
++         (((*_43) as variant#5).2: usize) = Add(move (((*_43) as variant#5).2: usize), const 1_usize);
++         _40 = &mut (*_22);
++         _39 = Pin::<&mut AsyncInt>::new_unchecked(move _40) -> [return: bb21, unwind: bb4];
+      }
+  
+      bb10: {
+-         _2 = move _13;
+-         StorageDead(_13);
+-         goto -> bb9;
++         _23 = Eq(copy (((*_43) as variant#5).2: usize), copy (((*_43) as variant#5).1: usize));
++         switchInt(move _23) -> [0: bb9, otherwise: bb1];
+      }
+  
+      bb11: {
+-         _2 = move _13;
+-         StorageDead(_13);
+-         goto -> bb17;
++         nop;
++         goto -> bb10;
+      }
+  
+-     bb12: {
+-         StorageLive(_13);
+-         _13 = yield(const ()) -> [resume: bb10, drop: bb11];
++     bb12 (cleanup): {
++         nop;
++         goto -> bb4;
+      }
+  
+      bb13: {
+-         unreachable;
++         assert(const false, "`async fn` resumed after async drop") -> [success: bb13, unwind: bb12];
+      }
+  
+      bb14: {
+-         _15 = discriminant(_14);
+-         switchInt(move _15) -> [0: bb7, 1: bb12, otherwise: bb13];
++         _46 = move _25;
++         StorageDead(_25);
++         goto -> bb13;
+      }
+  
+      bb15: {
+-         _14 = <impl Future<Output = ()> as Future>::poll(move _16, move _17) -> [return: bb14, unwind: bb8];
++         _46 = move _32;
++         StorageDead(_32);
++         goto -> bb20;
+      }
+  
+      bb16: {
+-         _18 = move _2;
+-         _17 = std::future::get_context::<'_, '_>(move _18) -> [return: bb15, unwind: bb8];
++         StorageLive(_32);
++         _0 = Poll::<()>::Pending;
++         StorageDead(_32);
++         discriminant((*_43)) = 5;
++         return;
+      }
+  
+      bb17: {
+-         _19 = &mut _12;
+-         _16 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _19) -> [return: bb16, unwind: bb8];
++         _34 = discriminant(_33);
++         switchInt(move _34) -> [0: bb11, 1: bb16, otherwise: bb8];
+      }
+  
+      bb18: {
+-         StorageLive(_12);
+-         _12 = async_drop_in_place::<AsyncInt>(copy (_20.0: &mut AsyncInt)) -> [return: bb17, unwind: bb8];
++         _33 = <impl Future<Output = ()> as Future>::poll(move _35, move _36) -> [return: bb17, unwind: bb12];
+      }
+  
+      bb19: {
+-         _22 = &raw mut (*_5)[_7];
+-         _7 = Add(move _7, const 1_usize);
+-         _40 = &mut (*_22);
+-         _39 = Pin::<&mut AsyncInt>::new_unchecked(move _40) -> [return: bb39, unwind: bb4];
++         _37 = move _46;
++         _36 = copy (_37.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
++         goto -> bb18;
+      }
+  
+      bb20: {
+-         _23 = Eq(copy _7, copy _6);
+-         switchInt(move _23) -> [0: bb19, otherwise: bb1];
++         _38 = &mut (((*_43) as variant#5).3: impl std::future::Future<Output = ()>);
++         _35 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _38) -> [return: bb19, unwind: bb12];
+      }
+  
+      bb21: {
+-         StorageDead(_24);
+-         goto -> bb20;
++         nop;
++         (((*_43) as variant#5).3: impl std::future::Future<Output = ()>) = async_drop_in_place::<AsyncInt>(copy (_39.0: &mut AsyncInt)) -> [return: bb20, unwind: bb12];
+      }
+  
+-     bb22: {
+-         StorageDead(_24);
+-         goto -> bb6;
++     bb22 (cleanup): {
++         discriminant((*_43)) = 2;
++         resume;
+      }
+  
+-     bb23 (cleanup): {
+-         StorageDead(_24);
+-         goto -> bb4;
++     bb23: {
++         StorageLive(_13);
++         _13 = move _46;
++         goto -> bb7;
+      }
+  
+      bb24: {
+-         assert(const false, "`async fn` resumed after async drop") -> [success: bb24, unwind: bb23];
++         StorageLive(_25);
++         _25 = move _46;
++         goto -> bb14;
+      }
+  
+      bb25: {
+-         _2 = move _25;
+-         StorageDead(_25);
+-         goto -> bb24;
++         StorageLive(_32);
++         _32 = move _46;
++         goto -> bb15;
+      }
+  
+      bb26: {
+-         _2 = move _25;
+-         StorageDead(_25);
+-         goto -> bb31;
++         assert(const false, "`async fn` resumed after panicking") -> [success: bb26, unwind continue];
+      }
+  
+      bb27: {
+-         StorageLive(_25);
+-         _25 = yield(const ()) -> [resume: bb25, drop: bb26];
++         _0 = Poll::<()>::Ready(const ());
++         return;
+      }
+  
+      bb28: {
+-         _27 = discriminant(_26);
+-         switchInt(move _27) -> [0: bb22, 1: bb27, otherwise: bb13];
+-     }
+- 
+-     bb29: {
+-         _26 = <impl Future<Output = ()> as Future>::poll(move _28, move _29) -> [return: bb28, unwind: bb23];
+-     }
+- 
+-     bb30: {
+-         _30 = move _2;
+-         _29 = std::future::get_context::<'_, '_>(move _30) -> [return: bb29, unwind: bb23];
+-     }
+- 
+-     bb31: {
+-         _31 = &mut _24;
+-         _28 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _31) -> [return: bb30, unwind: bb23];
+-     }
+- 
+-     bb32: {
+-         _2 = move _32;
+-         StorageDead(_32);
+-         goto -> bb38;
+-     }
+- 
+-     bb33: {
+-         _2 = move _32;
+-         StorageDead(_32);
+-         goto -> bb31;
+-     }
+- 
+-     bb34: {
+-         StorageLive(_32);
+-         _32 = yield(const ()) -> [resume: bb32, drop: bb33];
+-     }
+- 
+-     bb35: {
+-         _34 = discriminant(_33);
+-         switchInt(move _34) -> [0: bb21, 1: bb34, otherwise: bb13];
+-     }
+- 
+-     bb36: {
+-         _33 = <impl Future<Output = ()> as Future>::poll(move _35, move _36) -> [return: bb35, unwind: bb23];
+-     }
+- 
+-     bb37: {
+-         _37 = move _2;
+-         _36 = std::future::get_context::<'_, '_>(move _37) -> [return: bb36, unwind: bb23];
+-     }
+- 
+-     bb38: {
+-         _38 = &mut _24;
+-         _35 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _38) -> [return: bb37, unwind: bb23];
+-     }
+- 
+-     bb39: {
+-         StorageLive(_24);
+-         _24 = async_drop_in_place::<AsyncInt>(copy (_39.0: &mut AsyncInt)) -> [return: bb38, unwind: bb23];
++         _3 = move ((*_43).0: &mut [AsyncInt; 2]);
++         _4 = &raw mut (*_3);
++         (((*_43) as variant#5).0: *mut [AsyncInt]) = move _4 as *mut [AsyncInt] (PointerCoercion(Unsize, Implicit));
++         (((*_43) as variant#5).1: usize) = PtrMetadata(copy (((*_43) as variant#5).0: *mut [AsyncInt]));
++         (((*_43) as variant#5).2: usize) = const 0_usize;
++         goto -> bb10;
+      }
+  }
+  

--- a/tests/mir-opt/coroutine/async_drop.elaborate_drops-{closure#0}.ElaborateDrops.diff
+++ b/tests/mir-opt/coroutine/async_drop.elaborate_drops-{closure#0}.ElaborateDrops.diff
@@ -33,8 +33,8 @@
 +     let mut _39: &mut std::task::Context<'_>;
 +     let mut _40: std::future::ResumeTy;
 +     let mut _41: &mut impl std::future::Future<Output = ()>;
-+     let mut _42: std::pin::Pin<&mut {async closure@$DIR/async_drop.rs:78:27: 78:35}>;
-+     let mut _43: &mut {async closure@$DIR/async_drop.rs:78:27: 78:35};
++     let mut _42: std::pin::Pin<&mut {async closure@$DIR/async_drop.rs:86:27: 86:35}>;
++     let mut _43: &mut {async closure@$DIR/async_drop.rs:86:27: 86:35};
 +     let mut _44: impl std::future::Future<Output = ()>;
 +     let mut _45: std::future::ResumeTy;
 +     let mut _46: std::task::Poll<()>;
@@ -50,8 +50,8 @@
 +     let mut _56: &mut std::task::Context<'_>;
 +     let mut _57: std::future::ResumeTy;
 +     let mut _58: &mut impl std::future::Future<Output = ()>;
-+     let mut _59: std::pin::Pin<&mut {closure@$DIR/async_drop.rs:70:25: 70:27}>;
-+     let mut _60: &mut {closure@$DIR/async_drop.rs:70:25: 70:27};
++     let mut _59: std::pin::Pin<&mut {closure@$DIR/async_drop.rs:78:25: 78:27}>;
++     let mut _60: &mut {closure@$DIR/async_drop.rs:78:25: 78:27};
 +     let mut _61: impl std::future::Future<Output = ()>;
 +     let mut _62: std::future::ResumeTy;
 +     let mut _63: std::task::Poll<()>;
@@ -200,13 +200,13 @@
                                           let _23: AsyncInt;
                                           scope 10 {
                                               debug foo => _23;
-                                              let _24: {closure@$DIR/async_drop.rs:70:25: 70:27};
+                                              let _24: {closure@$DIR/async_drop.rs:78:25: 78:27};
                                               scope 11 {
                                                   debug async_closure => _24;
                                                   let _25: AsyncInt;
                                                   scope 12 {
                                                       debug foo => _25;
-                                                      let _26: {async closure@$DIR/async_drop.rs:78:27: 78:35};
+                                                      let _26: {async closure@$DIR/async_drop.rs:86:27: 86:35};
                                                       scope 13 {
                                                           debug async_coroutine => _26;
                                                       }
@@ -321,11 +321,11 @@
           StorageLive(_23);
           _23 = AsyncInt(const 14_i32);
           StorageLive(_24);
-          _24 = {closure@$DIR/async_drop.rs:70:25: 70:27} { foo: move _23 };
+          _24 = {closure@$DIR/async_drop.rs:78:25: 78:27} { foo: move _23 };
           StorageLive(_25);
           _25 = AsyncInt(const 15_i32);
           StorageLive(_26);
-          _26 = {closure@$DIR/async_drop.rs:78:27: 78:35} { foo: move _25 };
+          _26 = {closure@$DIR/async_drop.rs:86:27: 86:35} { foo: move _25 };
           _0 = const ();
 -         drop(_26) -> [return: bb10, unwind: bb44, drop: bb23];
 +         goto -> bb103;
@@ -838,12 +838,12 @@
 + 
 +     bb102: {
 +         StorageLive(_27);
-+         _27 = async_drop_in_place::<{async closure@$DIR/async_drop.rs:78:27: 78:35}>(copy (_42.0: &mut {async closure@$DIR/async_drop.rs:78:27: 78:35})) -> [return: bb101, unwind: bb85];
++         _27 = async_drop_in_place::<{async closure@$DIR/async_drop.rs:86:27: 86:35}>(copy (_42.0: &mut {async closure@$DIR/async_drop.rs:86:27: 86:35})) -> [return: bb101, unwind: bb85];
 +     }
 + 
 +     bb103: {
 +         _43 = &mut _26;
-+         _42 = Pin::<&mut {async closure@$DIR/async_drop.rs:78:27: 78:35}>::new_unchecked(move _43) -> [return: bb102, unwind: bb44];
++         _42 = Pin::<&mut {async closure@$DIR/async_drop.rs:86:27: 86:35}>::new_unchecked(move _43) -> [return: bb102, unwind: bb44];
 +     }
 + 
 +     bb104: {
@@ -939,12 +939,12 @@
 + 
 +     bb122: {
 +         StorageLive(_44);
-+         _44 = async_drop_in_place::<{closure@$DIR/async_drop.rs:70:25: 70:27}>(copy (_59.0: &mut {closure@$DIR/async_drop.rs:70:25: 70:27})) -> [return: bb121, unwind: bb106];
++         _44 = async_drop_in_place::<{closure@$DIR/async_drop.rs:78:25: 78:27}>(copy (_59.0: &mut {closure@$DIR/async_drop.rs:78:25: 78:27})) -> [return: bb121, unwind: bb106];
 +     }
 + 
 +     bb123: {
 +         _60 = &mut _24;
-+         _59 = Pin::<&mut {closure@$DIR/async_drop.rs:70:25: 70:27}>::new_unchecked(move _60) -> [return: bb122, unwind: bb46];
++         _59 = Pin::<&mut {closure@$DIR/async_drop.rs:78:25: 78:27}>::new_unchecked(move _60) -> [return: bb122, unwind: bb46];
 +     }
 + 
 +     bb124: {

--- a/tests/mir-opt/coroutine/async_drop.elaborate_drops-{closure#0}.StateTransform.diff
+++ b/tests/mir-opt/coroutine/async_drop.elaborate_drops-{closure#0}.StateTransform.diff
@@ -17,8 +17,8 @@
 +         field _s6: AsyncEnum;
 +         field _s7: AsyncInt;
 +         field _s8: AsyncReference<'_>;
-+         field _s9: {closure@$DIR/async_drop.rs:70:25: 70:27};
-+         field _s10: {async closure@$DIR/async_drop.rs:78:27: 78:35};
++         field _s9: {closure@$DIR/async_drop.rs:78:25: 78:27};
++         field _s10: {async closure@$DIR/async_drop.rs:86:27: 86:35};
 +         field _s11: impl Future<Output = ()>;
 +         field _s12: impl Future<Output = ()>;
 +         field _s13: impl Future<Output = ()>;
@@ -83,8 +83,8 @@
       let mut _39: &mut std::task::Context<'_>;
       let mut _40: std::future::ResumeTy;
       let mut _41: &mut impl std::future::Future<Output = ()>;
-      let mut _42: std::pin::Pin<&mut {async closure@$DIR/async_drop.rs:78:27: 78:35}>;
-      let mut _43: &mut {async closure@$DIR/async_drop.rs:78:27: 78:35};
+      let mut _42: std::pin::Pin<&mut {async closure@$DIR/async_drop.rs:86:27: 86:35}>;
+      let mut _43: &mut {async closure@$DIR/async_drop.rs:86:27: 86:35};
       let mut _44: impl std::future::Future<Output = ()>;
       let mut _45: std::future::ResumeTy;
       let mut _46: std::task::Poll<()>;
@@ -100,8 +100,8 @@
       let mut _56: &mut std::task::Context<'_>;
       let mut _57: std::future::ResumeTy;
       let mut _58: &mut impl std::future::Future<Output = ()>;
-      let mut _59: std::pin::Pin<&mut {closure@$DIR/async_drop.rs:70:25: 70:27}>;
-      let mut _60: &mut {closure@$DIR/async_drop.rs:70:25: 70:27};
+      let mut _59: std::pin::Pin<&mut {closure@$DIR/async_drop.rs:78:25: 78:27}>;
+      let mut _60: &mut {closure@$DIR/async_drop.rs:78:25: 78:27};
       let mut _61: impl std::future::Future<Output = ()>;
       let mut _62: std::future::ResumeTy;
       let mut _63: std::task::Poll<()>;
@@ -271,18 +271,18 @@
                                           scope 10 {
                                               debug foo => _23;
 +                                             coroutine debug async_closure => _s9;
-                                              let _24: {closure@$DIR/async_drop.rs:70:25: 70:27};
+                                              let _24: {closure@$DIR/async_drop.rs:78:25: 78:27};
                                               scope 11 {
 -                                                 debug async_closure => _24;
-+                                                 debug async_closure => (((*_182) as variant#6).9: {closure@$DIR/async_drop.rs:70:25: 70:27});
++                                                 debug async_closure => (((*_182) as variant#6).9: {closure@$DIR/async_drop.rs:78:25: 78:27});
                                                   let _25: AsyncInt;
                                                   scope 12 {
                                                       debug foo => _25;
 +                                                     coroutine debug async_coroutine => _s10;
-                                                      let _26: {async closure@$DIR/async_drop.rs:78:27: 78:35};
+                                                      let _26: {async closure@$DIR/async_drop.rs:86:27: 86:35};
                                                       scope 13 {
 -                                                         debug async_coroutine => _26;
-+                                                         debug async_coroutine => (((*_182) as variant#4).10: {async closure@$DIR/async_drop.rs:78:27: 78:35});
++                                                         debug async_coroutine => (((*_182) as variant#4).10: {async closure@$DIR/async_drop.rs:86:27: 86:35});
                                                       }
                                                   }
                                               }
@@ -404,17 +404,17 @@
           StorageLive(_23);
           _23 = AsyncInt(const 14_i32);
 -         StorageLive(_24);
--         _24 = {closure@$DIR/async_drop.rs:70:25: 70:27} { foo: move _23 };
+-         _24 = {closure@$DIR/async_drop.rs:78:25: 78:27} { foo: move _23 };
 +         nop;
-+         (((*_182) as variant#6).9: {closure@$DIR/async_drop.rs:70:25: 70:27}) = {closure@$DIR/async_drop.rs:70:25: 70:27} { foo: move _23 };
++         (((*_182) as variant#6).9: {closure@$DIR/async_drop.rs:78:25: 78:27}) = {closure@$DIR/async_drop.rs:78:25: 78:27} { foo: move _23 };
           StorageLive(_25);
           _25 = AsyncInt(const 15_i32);
 -         StorageLive(_26);
--         _26 = {closure@$DIR/async_drop.rs:78:27: 78:35} { foo: move _25 };
+-         _26 = {closure@$DIR/async_drop.rs:86:27: 86:35} { foo: move _25 };
 -         _0 = const ();
 -         goto -> bb72;
 +         nop;
-+         (((*_182) as variant#4).10: {async closure@$DIR/async_drop.rs:78:27: 78:35}) = {closure@$DIR/async_drop.rs:78:27: 78:35} { foo: move _25 };
++         (((*_182) as variant#4).10: {async closure@$DIR/async_drop.rs:86:27: 86:35}) = {closure@$DIR/async_drop.rs:86:27: 86:35} { foo: move _25 };
 +         (((*_182) as variant#20).0: ()) = const ();
 +         goto -> bb51;
       }
@@ -517,7 +517,7 @@
 +     bb24 (cleanup): {
           StorageDead(_25);
 -         goto -> bb25;
-+         drop((((*_182) as variant#6).9: {closure@$DIR/async_drop.rs:70:25: 70:27})) -> [return: bb25, unwind terminate(cleanup)];
++         drop((((*_182) as variant#6).9: {closure@$DIR/async_drop.rs:78:25: 78:27})) -> [return: bb25, unwind terminate(cleanup)];
       }
   
 -     bb25: {
@@ -720,14 +720,14 @@
 -         drop(_1) -> [return: bb51, unwind terminate(cleanup)];
 +     bb50: {
 +         nop;
-+         (((*_182) as variant#4).11: impl std::future::Future<Output = ()>) = async_drop_in_place::<{async closure@$DIR/async_drop.rs:78:27: 78:35}>(copy (_42.0: &mut {async closure@$DIR/async_drop.rs:78:27: 78:35})) -> [return: bb49, unwind: bb40];
++         (((*_182) as variant#4).11: impl std::future::Future<Output = ()>) = async_drop_in_place::<{async closure@$DIR/async_drop.rs:86:27: 86:35}>(copy (_42.0: &mut {async closure@$DIR/async_drop.rs:86:27: 86:35})) -> [return: bb49, unwind: bb40];
       }
   
 -     bb51 (cleanup): {
 -         resume;
 +     bb51: {
-+         _43 = &mut (((*_182) as variant#4).10: {async closure@$DIR/async_drop.rs:78:27: 78:35});
-+         _42 = Pin::<&mut {async closure@$DIR/async_drop.rs:78:27: 78:35}>::new_unchecked(move _43) -> [return: bb50, unwind: bb23];
++         _43 = &mut (((*_182) as variant#4).10: {async closure@$DIR/async_drop.rs:86:27: 86:35});
++         _42 = Pin::<&mut {async closure@$DIR/async_drop.rs:86:27: 86:35}>::new_unchecked(move _43) -> [return: bb50, unwind: bb23];
       }
   
       bb52: {
@@ -811,14 +811,14 @@
 -         _33 = move _2;
 -         _32 = std::future::get_context::<'_, '_>(move _33) -> [return: bb61, unwind: bb54];
 +         nop;
-+         (((*_182) as variant#6).10: impl std::future::Future<Output = ()>) = async_drop_in_place::<{closure@$DIR/async_drop.rs:70:25: 70:27}>(copy (_59.0: &mut {closure@$DIR/async_drop.rs:70:25: 70:27})) -> [return: bb61, unwind: bb53];
++         (((*_182) as variant#6).10: impl std::future::Future<Output = ()>) = async_drop_in_place::<{closure@$DIR/async_drop.rs:78:25: 78:27}>(copy (_59.0: &mut {closure@$DIR/async_drop.rs:78:25: 78:27})) -> [return: bb61, unwind: bb53];
       }
   
       bb63: {
 -         _34 = &mut _27;
 -         _31 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _34) -> [return: bb62, unwind: bb54];
-+         _60 = &mut (((*_182) as variant#6).9: {closure@$DIR/async_drop.rs:70:25: 70:27});
-+         _59 = Pin::<&mut {closure@$DIR/async_drop.rs:70:25: 70:27}>::new_unchecked(move _60) -> [return: bb62, unwind: bb25];
++         _60 = &mut (((*_182) as variant#6).9: {closure@$DIR/async_drop.rs:78:25: 78:27});
++         _59 = Pin::<&mut {closure@$DIR/async_drop.rs:78:25: 78:27}>::new_unchecked(move _60) -> [return: bb62, unwind: bb25];
       }
   
       bb64: {
@@ -879,13 +879,13 @@
   
       bb71: {
 -         StorageLive(_27);
--         _27 = async_drop_in_place::<{async closure@$DIR/async_drop.rs:78:27: 78:35}>(copy (_42.0: &mut {async closure@$DIR/async_drop.rs:78:27: 78:35})) -> [return: bb70, unwind: bb54];
+-         _27 = async_drop_in_place::<{async closure@$DIR/async_drop.rs:86:27: 86:35}>(copy (_42.0: &mut {async closure@$DIR/async_drop.rs:86:27: 86:35})) -> [return: bb70, unwind: bb54];
 +         _70 = <impl Future<Output = ()> as Future>::poll(move _72, move _73) -> [return: bb70, unwind: bb65];
       }
   
       bb72: {
 -         _43 = &mut _26;
--         _42 = Pin::<&mut {async closure@$DIR/async_drop.rs:78:27: 78:35}>::new_unchecked(move _43) -> [return: bb71, unwind: bb36];
+-         _42 = Pin::<&mut {async closure@$DIR/async_drop.rs:86:27: 86:35}>::new_unchecked(move _43) -> [return: bb71, unwind: bb36];
 +         _74 = move _183;
 +         _73 = copy (_74.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
 +         goto -> bb71;
@@ -1027,7 +1027,7 @@
   
       bb91: {
 -         StorageLive(_44);
--         _44 = async_drop_in_place::<{closure@$DIR/async_drop.rs:70:25: 70:27}>(copy (_59.0: &mut {closure@$DIR/async_drop.rs:70:25: 70:27})) -> [return: bb90, unwind: bb75];
+-         _44 = async_drop_in_place::<{closure@$DIR/async_drop.rs:78:25: 78:27}>(copy (_59.0: &mut {closure@$DIR/async_drop.rs:78:25: 78:27})) -> [return: bb90, unwind: bb75];
 +         _183 = move _96;
 +         StorageDead(_96);
 +         goto -> bb90;
@@ -1035,7 +1035,7 @@
   
       bb92: {
 -         _60 = &mut _24;
--         _59 = Pin::<&mut {closure@$DIR/async_drop.rs:70:25: 70:27}>::new_unchecked(move _60) -> [return: bb91, unwind: bb38];
+-         _59 = Pin::<&mut {closure@$DIR/async_drop.rs:78:25: 78:27}>::new_unchecked(move _60) -> [return: bb91, unwind: bb38];
 +         _183 = move _103;
 +         StorageDead(_103);
 +         goto -> bb97;

--- a/tests/mir-opt/coroutine/async_drop.rs
+++ b/tests/mir-opt/coroutine/async_drop.rs
@@ -51,6 +51,14 @@ async fn double() {
     let async_int_again = AsyncInt(0);
 }
 
+// EMIT_MIR async_drop.array-{closure#0}.ElaborateDrops.diff
+// EMIT_MIR async_drop.array-{closure#0}.StateTransform.diff
+// EMIT_MIR async_drop.array-{closure#0}.coroutine_drop_async.0.mir
+// EMIT_MIR core.future-async_drop-async_drop_in_place-{closure#0}.[AsyncInt;2].StateTransform.diff
+async fn array() {
+    let array = [AsyncInt(1), AsyncInt(2)];
+}
+
 // EMIT_MIR async_drop.elaborate_drops-{closure#0}.ElaborateDrops.diff
 // EMIT_MIR async_drop.elaborate_drops-{closure#0}.StateTransform.diff
 async fn elaborate_drops() {
@@ -90,6 +98,7 @@ fn main() {
 
     let i = 13;
     let fut = pin!(async {
+        array().await;
         elaborate_drops().await;
 
         test_async_drop(Int(0)).await;

--- a/tests/ui/async-await/async-drop/async-drop-array-step.rs
+++ b/tests/ui/async-await/async-drop/async-drop-array-step.rs
@@ -1,0 +1,94 @@
+//@ run-pass
+//@ check-run-results
+//@ edition: 2021
+
+#![feature(async_drop)]
+#![allow(incomplete_features)]
+
+use std::future::{async_drop_in_place, AsyncDrop, Future};
+use std::mem::ManuallyDrop;
+use std::pin::{pin, Pin};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{mpsc, Arc};
+use std::task::{Context, Poll, Wake, Waker};
+
+static DROP_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+struct YieldOnce(bool);
+
+impl Future for YieldOnce {
+    type Output = ();
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+        if !self.0 {
+            self.0 = true;
+            cx.waker().wake_by_ref();
+            Poll::Pending
+        } else {
+            Poll::Ready(())
+        }
+    }
+}
+
+struct Item(usize);
+
+impl Drop for Item {
+    fn drop(&mut self) {}
+}
+
+impl AsyncDrop for Item {
+    async fn drop(self: Pin<&mut Self>) {
+        let count = DROP_COUNT.fetch_add(1, Ordering::Relaxed);
+        if count >= 8 {
+            panic!("Infinite loop detected: array drop index reset across yield points!");
+        }
+        YieldOnce(false).await;
+        println!("Dropping {}", self.0);
+    }
+}
+
+fn block_on<F: Future>(fut_unpin: F) -> F::Output {
+    let mut fut_pin = pin!(ManuallyDrop::new(fut_unpin));
+    let mut fut: Pin<&mut F> = unsafe {
+        Pin::map_unchecked_mut(fut_pin.as_mut(), |x| &mut **x)
+    };
+    let (waker, rx) = simple_waker();
+    let mut context = Context::from_waker(&waker);
+    let rv = loop {
+        match fut.as_mut().poll(&mut context) {
+            Poll::Ready(out) => break out,
+            Poll::Pending => rx.try_recv().unwrap(),
+        }
+    };
+    let drop_fut_unpin = unsafe { async_drop_in_place(fut.get_unchecked_mut()) };
+    let mut drop_fut = pin!(drop_fut_unpin);
+    loop {
+        match drop_fut.as_mut().poll(&mut context) {
+            Poll::Ready(()) => break,
+            Poll::Pending => rx.try_recv().unwrap(),
+        }
+    }
+    rv
+}
+
+fn simple_waker() -> (Waker, mpsc::Receiver<()>) {
+    struct SimpleWaker {
+        tx: mpsc::Sender<()>,
+    }
+
+    impl Wake for SimpleWaker {
+        fn wake(self: Arc<Self>) {
+            self.tx.send(()).unwrap();
+        }
+    }
+
+    let (tx, rx) = mpsc::channel();
+    (Waker::from(Arc::new(SimpleWaker { tx })), rx)
+}
+
+async fn run() {
+    let _arr: [Item; 4] = [Item(0), Item(1), Item(2), Item(3)];
+}
+
+fn main() {
+    block_on(run());
+}

--- a/tests/ui/async-await/async-drop/async-drop-array-step.run.stdout
+++ b/tests/ui/async-await/async-drop/async-drop-array-step.run.stdout
@@ -1,0 +1,4 @@
+Dropping 0
+Dropping 1
+Dropping 2
+Dropping 3

--- a/tests/ui/async-await/async-drop/async-drop-initial.rs
+++ b/tests/ui/async-await/async-drop/async-drop-initial.rs
@@ -54,7 +54,7 @@ fn main() {
     let fut = pin!(async {
         test_async_drop(Int(0), 16).await;
         test_async_drop(AsyncInt(0), 32).await;
-        test_async_drop([AsyncInt(1), AsyncInt(2)], 104).await;
+        test_async_drop([AsyncInt(1), AsyncInt(2)], 112).await;
         test_async_drop((AsyncInt(3), AsyncInt(4)), 120).await;
         test_async_drop(5, 16).await;
         let j = 42;

--- a/tests/ui/layout/debug.stderr
+++ b/tests/ui/layout/debug.stderr
@@ -102,22 +102,23 @@ error: layout_of(S) = Layout {
            align: AbiAlign {
                abi: Align(4 bytes),
            },
-           backend_repr: ScalarPair(
-               Initialized {
+           backend_repr: ScalarPair {
+               a: Initialized {
                    value: Int(
                        I32,
                        true,
                    ),
                    valid_range: 0..=4294967295,
                },
-               Initialized {
+               b: Initialized {
                    value: Int(
                        I32,
                        true,
                    ),
                    valid_range: 0..=4294967295,
                },
-           ),
+               b_offset: Size(4 bytes),
+           },
            fields: Arbitrary {
                offsets: [
                    Size(0 bytes),
@@ -174,22 +175,23 @@ error: layout_of(Result<i32, i32>) = Layout {
            align: AbiAlign {
                abi: Align(4 bytes),
            },
-           backend_repr: ScalarPair(
-               Initialized {
+           backend_repr: ScalarPair {
+               a: Initialized {
                    value: Int(
                        I32,
                        false,
                    ),
                    valid_range: 0..=1,
                },
-               Initialized {
+               b: Initialized {
                    value: Int(
                        I32,
                        true,
                    ),
                    valid_range: 0..=4294967295,
                },
-           ),
+               b_offset: Size(4 bytes),
+           },
            fields: Arbitrary {
                offsets: [
                    Size(0 bytes),
@@ -222,22 +224,23 @@ error: layout_of(Result<i32, i32>) = Layout {
                variants: [
                    VariantLayout {
                        size: Size(8 bytes),
-                       backend_repr: ScalarPair(
-                           Initialized {
+                       backend_repr: ScalarPair {
+                           a: Initialized {
                                value: Int(
                                    I32,
                                    false,
                                ),
                                valid_range: 0..=1,
                            },
-                           Initialized {
+                           b: Initialized {
                                value: Int(
                                    I32,
                                    true,
                                ),
                                valid_range: 0..=4294967295,
                            },
-                       ),
+                           b_offset: Size(4 bytes),
+                       },
                        field_offsets: [
                            Size(4 bytes),
                        ],
@@ -249,22 +252,23 @@ error: layout_of(Result<i32, i32>) = Layout {
                    },
                    VariantLayout {
                        size: Size(8 bytes),
-                       backend_repr: ScalarPair(
-                           Initialized {
+                       backend_repr: ScalarPair {
+                           a: Initialized {
                                value: Int(
                                    I32,
                                    false,
                                ),
                                valid_range: 0..=1,
                            },
-                           Initialized {
+                           b: Initialized {
                                value: Int(
                                    I32,
                                    true,
                                ),
                                valid_range: 0..=4294967295,
                            },
-                       ),
+                           b_offset: Size(4 bytes),
+                       },
                        field_offsets: [
                            Size(4 bytes),
                        ],

--- a/tests/ui/layout/enum-scalar-pair-int-ptr.rs
+++ b/tests/ui/layout/enum-scalar-pair-int-ptr.rs
@@ -1,6 +1,7 @@
 //@ normalize-stderr: "pref: Align\([1-8] bytes\)" -> "pref: $$PREF_ALIGN"
 //@ normalize-stderr: "Int\(I[0-9]+," -> "Int(I?,"
 //@ normalize-stderr: "valid_range: 0..=[0-9]+" -> "valid_range: $$VALID_RANGE"
+//@ normalize-stderr: "b_offset: Size\([0-9]+ bytes\)" -> "b_offset: Size(? bytes)"
 
 //! Enum layout tests related to scalar pairs with an int/ptr common primitive.
 

--- a/tests/ui/layout/enum-scalar-pair-int-ptr.stderr
+++ b/tests/ui/layout/enum-scalar-pair-int-ptr.stderr
@@ -1,11 +1,11 @@
-error: backend_repr: ScalarPair(Initialized { value: Int(I?, false), valid_range: $VALID_RANGE }, Initialized { value: Pointer(AddressSpace(0)), valid_range: $VALID_RANGE })
-  --> $DIR/enum-scalar-pair-int-ptr.rs:12:1
+error: backend_repr: ScalarPair { a: Initialized { value: Int(I?, false), valid_range: $VALID_RANGE }, b: Initialized { value: Pointer(AddressSpace(0)), valid_range: $VALID_RANGE }, b_offset: Size(? bytes) }
+  --> $DIR/enum-scalar-pair-int-ptr.rs:13:1
    |
 LL | enum ScalarPairPointerWithInt {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: backend_repr: Memory { sized: true }
-  --> $DIR/enum-scalar-pair-int-ptr.rs:21:1
+  --> $DIR/enum-scalar-pair-int-ptr.rs:22:1
    |
 LL | enum NotScalarPairPointerWithSmallerInt {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/layout/enum.stderr
+++ b/tests/ui/layout/enum.stderr
@@ -10,7 +10,7 @@ error: size: Size(16 bytes)
 LL | enum UninhabitedVariantSpace {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: backend_repr: ScalarPair(Initialized { value: Int(I8, false), valid_range: 0..=1 }, Initialized { value: Int(I8, false), valid_range: 0..=255 })
+error: backend_repr: ScalarPair { a: Initialized { value: Int(I8, false), valid_range: 0..=1 }, b: Initialized { value: Int(I8, false), valid_range: 0..=255 }, b_offset: Size(1 bytes) }
   --> $DIR/enum.rs:21:1
    |
 LL | enum ScalarPairDifferingSign {

--- a/tests/ui/layout/issue-96158-scalarpair-payload-might-be-uninit.stderr
+++ b/tests/ui/layout/issue-96158-scalarpair-payload-might-be-uninit.stderr
@@ -3,21 +3,22 @@ error: layout_of(MissingPayloadField) = Layout {
            align: AbiAlign {
                abi: Align(1 bytes),
            },
-           backend_repr: ScalarPair(
-               Initialized {
+           backend_repr: ScalarPair {
+               a: Initialized {
                    value: Int(
                        I8,
                        false,
                    ),
                    valid_range: 0..=1,
                },
-               Union {
+               b: Union {
                    value: Int(
                        I8,
                        false,
                    ),
                },
-           ),
+               b_offset: Size(1 bytes),
+           },
            fields: Arbitrary {
                offsets: [
                    Size(0 bytes),
@@ -50,21 +51,22 @@ error: layout_of(MissingPayloadField) = Layout {
                variants: [
                    VariantLayout {
                        size: Size(2 bytes),
-                       backend_repr: ScalarPair(
-                           Initialized {
+                       backend_repr: ScalarPair {
+                           a: Initialized {
                                value: Int(
                                    I8,
                                    false,
                                ),
                                valid_range: 0..=1,
                            },
-                           Union {
+                           b: Union {
                                value: Int(
                                    I8,
                                    false,
                                ),
                            },
-                       ),
+                           b_offset: Size(1 bytes),
+                       },
                        field_offsets: [
                            Size(1 bytes),
                        ],
@@ -100,22 +102,23 @@ error: layout_of(CommonPayloadField) = Layout {
            align: AbiAlign {
                abi: Align(1 bytes),
            },
-           backend_repr: ScalarPair(
-               Initialized {
+           backend_repr: ScalarPair {
+               a: Initialized {
                    value: Int(
                        I8,
                        false,
                    ),
                    valid_range: 0..=1,
                },
-               Initialized {
+               b: Initialized {
                    value: Int(
                        I8,
                        false,
                    ),
                    valid_range: 0..=255,
                },
-           ),
+               b_offset: Size(1 bytes),
+           },
            fields: Arbitrary {
                offsets: [
                    Size(0 bytes),
@@ -148,22 +151,23 @@ error: layout_of(CommonPayloadField) = Layout {
                variants: [
                    VariantLayout {
                        size: Size(2 bytes),
-                       backend_repr: ScalarPair(
-                           Initialized {
+                       backend_repr: ScalarPair {
+                           a: Initialized {
                                value: Int(
                                    I8,
                                    false,
                                ),
                                valid_range: 0..=1,
                            },
-                           Initialized {
+                           b: Initialized {
                                value: Int(
                                    I8,
                                    false,
                                ),
                                valid_range: 0..=255,
                            },
-                       ),
+                           b_offset: Size(1 bytes),
+                       },
                        field_offsets: [
                            Size(1 bytes),
                        ],
@@ -175,22 +179,23 @@ error: layout_of(CommonPayloadField) = Layout {
                    },
                    VariantLayout {
                        size: Size(2 bytes),
-                       backend_repr: ScalarPair(
-                           Initialized {
+                       backend_repr: ScalarPair {
+                           a: Initialized {
                                value: Int(
                                    I8,
                                    false,
                                ),
                                valid_range: 0..=1,
                            },
-                           Initialized {
+                           b: Initialized {
                                value: Int(
                                    I8,
                                    false,
                                ),
                                valid_range: 0..=255,
                            },
-                       ),
+                           b_offset: Size(1 bytes),
+                       },
                        field_offsets: [
                            Size(1 bytes),
                        ],
@@ -216,21 +221,22 @@ error: layout_of(CommonPayloadFieldIsMaybeUninit) = Layout {
            align: AbiAlign {
                abi: Align(1 bytes),
            },
-           backend_repr: ScalarPair(
-               Initialized {
+           backend_repr: ScalarPair {
+               a: Initialized {
                    value: Int(
                        I8,
                        false,
                    ),
                    valid_range: 0..=1,
                },
-               Union {
+               b: Union {
                    value: Int(
                        I8,
                        false,
                    ),
                },
-           ),
+               b_offset: Size(1 bytes),
+           },
            fields: Arbitrary {
                offsets: [
                    Size(0 bytes),
@@ -263,21 +269,22 @@ error: layout_of(CommonPayloadFieldIsMaybeUninit) = Layout {
                variants: [
                    VariantLayout {
                        size: Size(2 bytes),
-                       backend_repr: ScalarPair(
-                           Initialized {
+                       backend_repr: ScalarPair {
+                           a: Initialized {
                                value: Int(
                                    I8,
                                    false,
                                ),
                                valid_range: 0..=1,
                            },
-                           Union {
+                           b: Union {
                                value: Int(
                                    I8,
                                    false,
                                ),
                            },
-                       ),
+                           b_offset: Size(1 bytes),
+                       },
                        field_offsets: [
                            Size(1 bytes),
                        ],
@@ -289,21 +296,22 @@ error: layout_of(CommonPayloadFieldIsMaybeUninit) = Layout {
                    },
                    VariantLayout {
                        size: Size(2 bytes),
-                       backend_repr: ScalarPair(
-                           Initialized {
+                       backend_repr: ScalarPair {
+                           a: Initialized {
                                value: Int(
                                    I8,
                                    false,
                                ),
                                valid_range: 0..=1,
                            },
-                           Union {
+                           b: Union {
                                value: Int(
                                    I8,
                                    false,
                                ),
                            },
-                       ),
+                           b_offset: Size(1 bytes),
+                       },
                        field_offsets: [
                            Size(1 bytes),
                        ],
@@ -329,21 +337,22 @@ error: layout_of(NicheFirst) = Layout {
            align: AbiAlign {
                abi: Align(1 bytes),
            },
-           backend_repr: ScalarPair(
-               Initialized {
+           backend_repr: ScalarPair {
+               a: Initialized {
                    value: Int(
                        I8,
                        false,
                    ),
                    valid_range: 0..=4,
                },
-               Union {
+               b: Union {
                    value: Int(
                        I8,
                        false,
                    ),
                },
-           ),
+               b_offset: Size(1 bytes),
+           },
            fields: Arbitrary {
                offsets: [
                    Size(0 bytes),
@@ -380,22 +389,23 @@ error: layout_of(NicheFirst) = Layout {
                variants: [
                    VariantLayout {
                        size: Size(2 bytes),
-                       backend_repr: ScalarPair(
-                           Initialized {
+                       backend_repr: ScalarPair {
+                           a: Initialized {
                                value: Int(
                                    I8,
                                    false,
                                ),
                                valid_range: 0..=2,
                            },
-                           Initialized {
+                           b: Initialized {
                                value: Int(
                                    I8,
                                    false,
                                ),
                                valid_range: 0..=255,
                            },
-                       ),
+                           b_offset: Size(1 bytes),
+                       },
                        field_offsets: [
                            Size(0 bytes),
                            Size(1 bytes),
@@ -452,21 +462,22 @@ error: layout_of(NicheSecond) = Layout {
            align: AbiAlign {
                abi: Align(1 bytes),
            },
-           backend_repr: ScalarPair(
-               Initialized {
+           backend_repr: ScalarPair {
+               a: Initialized {
                    value: Int(
                        I8,
                        false,
                    ),
                    valid_range: 0..=4,
                },
-               Union {
+               b: Union {
                    value: Int(
                        I8,
                        false,
                    ),
                },
-           ),
+               b_offset: Size(1 bytes),
+           },
            fields: Arbitrary {
                offsets: [
                    Size(0 bytes),
@@ -503,22 +514,23 @@ error: layout_of(NicheSecond) = Layout {
                variants: [
                    VariantLayout {
                        size: Size(2 bytes),
-                       backend_repr: ScalarPair(
-                           Initialized {
+                       backend_repr: ScalarPair {
+                           a: Initialized {
                                value: Int(
                                    I8,
                                    false,
                                ),
                                valid_range: 0..=2,
                            },
-                           Initialized {
+                           b: Initialized {
                                value: Int(
                                    I8,
                                    false,
                                ),
                                valid_range: 0..=255,
                            },
-                       ),
+                           b_offset: Size(1 bytes),
+                       },
                        field_offsets: [
                            Size(1 bytes),
                            Size(0 bytes),

--- a/tests/ui/repr/repr-c-dead-variants.aarch64-unknown-linux-gnu.stderr
+++ b/tests/ui/repr/repr-c-dead-variants.aarch64-unknown-linux-gnu.stderr
@@ -78,21 +78,22 @@ error: layout_of(TwoVariants) = Layout {
            align: AbiAlign {
                abi: Align(4 bytes),
            },
-           backend_repr: ScalarPair(
-               Initialized {
+           backend_repr: ScalarPair {
+               a: Initialized {
                    value: Int(
                        I32,
                        false,
                    ),
                    valid_range: 0..=1,
                },
-               Union {
+               b: Union {
                    value: Int(
                        I8,
                        false,
                    ),
                },
-           ),
+               b_offset: Size(4 bytes),
+           },
            fields: Arbitrary {
                offsets: [
                    Size(0 bytes),
@@ -125,21 +126,22 @@ error: layout_of(TwoVariants) = Layout {
                variants: [
                    VariantLayout {
                        size: Size(8 bytes),
-                       backend_repr: ScalarPair(
-                           Initialized {
+                       backend_repr: ScalarPair {
+                           a: Initialized {
                                value: Int(
                                    I32,
                                    false,
                                ),
                                valid_range: 0..=1,
                            },
-                           Union {
+                           b: Union {
                                value: Int(
                                    I8,
                                    false,
                                ),
                            },
-                       ),
+                           b_offset: Size(4 bytes),
+                       },
                        field_offsets: [
                            Size(4 bytes),
                        ],
@@ -151,21 +153,22 @@ error: layout_of(TwoVariants) = Layout {
                    },
                    VariantLayout {
                        size: Size(8 bytes),
-                       backend_repr: ScalarPair(
-                           Initialized {
+                       backend_repr: ScalarPair {
+                           a: Initialized {
                                value: Int(
                                    I32,
                                    false,
                                ),
                                valid_range: 0..=1,
                            },
-                           Union {
+                           b: Union {
                                value: Int(
                                    I8,
                                    false,
                                ),
                            },
-                       ),
+                           b_offset: Size(4 bytes),
+                       },
                        field_offsets: [
                            Size(4 bytes),
                        ],

--- a/tests/ui/repr/repr-c-dead-variants.armebv7r-none-eabi.stderr
+++ b/tests/ui/repr/repr-c-dead-variants.armebv7r-none-eabi.stderr
@@ -78,21 +78,22 @@ error: layout_of(TwoVariants) = Layout {
            align: AbiAlign {
                abi: Align(1 bytes),
            },
-           backend_repr: ScalarPair(
-               Initialized {
+           backend_repr: ScalarPair {
+               a: Initialized {
                    value: Int(
                        I8,
                        false,
                    ),
                    valid_range: 0..=1,
                },
-               Union {
+               b: Union {
                    value: Int(
                        I8,
                        false,
                    ),
                },
-           ),
+               b_offset: Size(1 bytes),
+           },
            fields: Arbitrary {
                offsets: [
                    Size(0 bytes),
@@ -125,21 +126,22 @@ error: layout_of(TwoVariants) = Layout {
                variants: [
                    VariantLayout {
                        size: Size(2 bytes),
-                       backend_repr: ScalarPair(
-                           Initialized {
+                       backend_repr: ScalarPair {
+                           a: Initialized {
                                value: Int(
                                    I8,
                                    false,
                                ),
                                valid_range: 0..=1,
                            },
-                           Union {
+                           b: Union {
                                value: Int(
                                    I8,
                                    false,
                                ),
                            },
-                       ),
+                           b_offset: Size(1 bytes),
+                       },
                        field_offsets: [
                            Size(1 bytes),
                        ],
@@ -151,21 +153,22 @@ error: layout_of(TwoVariants) = Layout {
                    },
                    VariantLayout {
                        size: Size(2 bytes),
-                       backend_repr: ScalarPair(
-                           Initialized {
+                       backend_repr: ScalarPair {
+                           a: Initialized {
                                value: Int(
                                    I8,
                                    false,
                                ),
                                valid_range: 0..=1,
                            },
-                           Union {
+                           b: Union {
                                value: Int(
                                    I8,
                                    false,
                                ),
                            },
-                       ),
+                           b_offset: Size(1 bytes),
+                       },
                        field_offsets: [
                            Size(1 bytes),
                        ],

--- a/tests/ui/repr/repr-c-dead-variants.i686-pc-windows-msvc.stderr
+++ b/tests/ui/repr/repr-c-dead-variants.i686-pc-windows-msvc.stderr
@@ -78,21 +78,22 @@ error: layout_of(TwoVariants) = Layout {
            align: AbiAlign {
                abi: Align(4 bytes),
            },
-           backend_repr: ScalarPair(
-               Initialized {
+           backend_repr: ScalarPair {
+               a: Initialized {
                    value: Int(
                        I32,
                        false,
                    ),
                    valid_range: 0..=1,
                },
-               Union {
+               b: Union {
                    value: Int(
                        I8,
                        false,
                    ),
                },
-           ),
+               b_offset: Size(4 bytes),
+           },
            fields: Arbitrary {
                offsets: [
                    Size(0 bytes),
@@ -125,21 +126,22 @@ error: layout_of(TwoVariants) = Layout {
                variants: [
                    VariantLayout {
                        size: Size(8 bytes),
-                       backend_repr: ScalarPair(
-                           Initialized {
+                       backend_repr: ScalarPair {
+                           a: Initialized {
                                value: Int(
                                    I32,
                                    false,
                                ),
                                valid_range: 0..=1,
                            },
-                           Union {
+                           b: Union {
                                value: Int(
                                    I8,
                                    false,
                                ),
                            },
-                       ),
+                           b_offset: Size(4 bytes),
+                       },
                        field_offsets: [
                            Size(4 bytes),
                        ],
@@ -151,21 +153,22 @@ error: layout_of(TwoVariants) = Layout {
                    },
                    VariantLayout {
                        size: Size(8 bytes),
-                       backend_repr: ScalarPair(
-                           Initialized {
+                       backend_repr: ScalarPair {
+                           a: Initialized {
                                value: Int(
                                    I32,
                                    false,
                                ),
                                valid_range: 0..=1,
                            },
-                           Union {
+                           b: Union {
                                value: Int(
                                    I8,
                                    false,
                                ),
                            },
-                       ),
+                           b_offset: Size(4 bytes),
+                       },
                        field_offsets: [
                            Size(4 bytes),
                        ],

--- a/tests/ui/repr/repr-c-dead-variants.x86_64-unknown-linux-gnu.stderr
+++ b/tests/ui/repr/repr-c-dead-variants.x86_64-unknown-linux-gnu.stderr
@@ -78,21 +78,22 @@ error: layout_of(TwoVariants) = Layout {
            align: AbiAlign {
                abi: Align(4 bytes),
            },
-           backend_repr: ScalarPair(
-               Initialized {
+           backend_repr: ScalarPair {
+               a: Initialized {
                    value: Int(
                        I32,
                        false,
                    ),
                    valid_range: 0..=1,
                },
-               Union {
+               b: Union {
                    value: Int(
                        I8,
                        false,
                    ),
                },
-           ),
+               b_offset: Size(4 bytes),
+           },
            fields: Arbitrary {
                offsets: [
                    Size(0 bytes),
@@ -125,21 +126,22 @@ error: layout_of(TwoVariants) = Layout {
                variants: [
                    VariantLayout {
                        size: Size(8 bytes),
-                       backend_repr: ScalarPair(
-                           Initialized {
+                       backend_repr: ScalarPair {
+                           a: Initialized {
                                value: Int(
                                    I32,
                                    false,
                                ),
                                valid_range: 0..=1,
                            },
-                           Union {
+                           b: Union {
                                value: Int(
                                    I8,
                                    false,
                                ),
                            },
-                       ),
+                           b_offset: Size(4 bytes),
+                       },
                        field_offsets: [
                            Size(4 bytes),
                        ],
@@ -151,21 +153,22 @@ error: layout_of(TwoVariants) = Layout {
                    },
                    VariantLayout {
                        size: Size(8 bytes),
-                       backend_repr: ScalarPair(
-                           Initialized {
+                       backend_repr: ScalarPair {
+                           a: Initialized {
                                value: Int(
                                    I32,
                                    false,
                                ),
                                valid_range: 0..=1,
                            },
-                           Union {
+                           b: Union {
                                value: Int(
                                    I8,
                                    false,
                                ),
                            },
-                       ),
+                           b_offset: Size(4 bytes),
+                       },
                        field_offsets: [
                            Size(4 bytes),
                        ],

--- a/tests/ui/repr/repr-c-int-dead-variants.stderr
+++ b/tests/ui/repr/repr-c-int-dead-variants.stderr
@@ -78,21 +78,22 @@ error: layout_of(TwoVariantsU8) = Layout {
            align: AbiAlign {
                abi: Align(1 bytes),
            },
-           backend_repr: ScalarPair(
-               Initialized {
+           backend_repr: ScalarPair {
+               a: Initialized {
                    value: Int(
                        I8,
                        false,
                    ),
                    valid_range: 0..=1,
                },
-               Union {
+               b: Union {
                    value: Int(
                        I8,
                        false,
                    ),
                },
-           ),
+               b_offset: Size(1 bytes),
+           },
            fields: Arbitrary {
                offsets: [
                    Size(0 bytes),
@@ -125,21 +126,22 @@ error: layout_of(TwoVariantsU8) = Layout {
                variants: [
                    VariantLayout {
                        size: Size(2 bytes),
-                       backend_repr: ScalarPair(
-                           Initialized {
+                       backend_repr: ScalarPair {
+                           a: Initialized {
                                value: Int(
                                    I8,
                                    false,
                                ),
                                valid_range: 0..=1,
                            },
-                           Union {
+                           b: Union {
                                value: Int(
                                    I8,
                                    false,
                                ),
                            },
-                       ),
+                           b_offset: Size(1 bytes),
+                       },
                        field_offsets: [
                            Size(1 bytes),
                        ],
@@ -151,21 +153,22 @@ error: layout_of(TwoVariantsU8) = Layout {
                    },
                    VariantLayout {
                        size: Size(2 bytes),
-                       backend_repr: ScalarPair(
-                           Initialized {
+                       backend_repr: ScalarPair {
+                           a: Initialized {
                                value: Int(
                                    I8,
                                    false,
                                ),
                                valid_range: 0..=1,
                            },
-                           Union {
+                           b: Union {
                                value: Int(
                                    I8,
                                    false,
                                ),
                            },
-                       ),
+                           b_offset: Size(1 bytes),
+                       },
                        field_offsets: [
                            Size(1 bytes),
                        ],

--- a/tests/ui/type/pattern_types/non_null.stderr
+++ b/tests/ui/type/pattern_types/non_null.stderr
@@ -143,8 +143,8 @@ error: layout_of((*const [u8]) is !null) = Layout {
            align: AbiAlign {
                abi: Align(8 bytes),
            },
-           backend_repr: ScalarPair(
-               Initialized {
+           backend_repr: ScalarPair {
+               a: Initialized {
                    value: Pointer(
                        AddressSpace(
                            0,
@@ -152,14 +152,15 @@ error: layout_of((*const [u8]) is !null) = Layout {
                    ),
                    valid_range: 1..=18446744073709551615,
                },
-               Initialized {
+               b: Initialized {
                    value: Int(
                        I64,
                        false,
                    ),
                    valid_range: 0..=18446744073709551615,
                },
-           ),
+               b_offset: Size(8 bytes),
+           },
            fields: Arbitrary {
                offsets: [
                    Size(0 bytes),

--- a/yarn.lock
+++ b/yarn.lock
@@ -74,18 +74,18 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@puppeteer/browsers@3.0.4":
-  version "3.0.4"
-  resolved "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-3.0.4.tgz"
-  integrity sha512-HGM8iAmGTf+Y7t0373szVbTmt3d7vPkYL/1bpOkOFO0YUYLgSeuYBCzESklogNPvOBnZ/MRD5f07OkpqH1trtA==
+"@puppeteer/browsers@3.0.6":
+  version "3.0.6"
+  resolved "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-3.0.6.tgz"
+  integrity sha512-B/gKoqlFkzhvzsI6jo9K1cZz9o5ypviVv/xu8CwA4grZzyVwN+XfkT+tu8T1zrauuEXv6VhS2oGX+6NL95WcKA==
   dependencies:
     modern-tar "^0.7.6"
-    yargs "^17.7.2"
+    yargs "^18.0.0"
 
 "@ungap/structured-clone@^1.2.0":
-  version "1.3.1"
-  resolved "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz"
-  integrity sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==
+  version "1.3.0"
+  resolved "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz"
+  integrity sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==
 
 acorn-jsx@^5.3.2:
   version "5.3.2"
@@ -112,12 +112,22 @@ ansi-regex@^5.0.1:
   resolved "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
 
-ansi-styles@^4.0.0, ansi-styles@^4.1.0:
+ansi-regex@^6.2.2:
+  version "6.2.2"
+  resolved "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz"
+  integrity sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==
+
+ansi-styles@^4.1.0:
   version "4.3.0"
   resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz"
   integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
   dependencies:
     color-convert "^2.0.1"
+
+ansi-styles@^6.2.1:
+  version "6.2.3"
+  resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz"
+  integrity sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==
 
 argparse@^2.0.1:
   version "2.0.1"
@@ -130,9 +140,9 @@ balanced-match@^1.0.0:
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
 brace-expansion@^1.1.7:
-  version "1.1.15"
-  resolved "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz"
-  integrity sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==
+  version "1.1.14"
+  resolved "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz"
+  integrity sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
@@ -144,10 +154,10 @@ braces@^3.0.3:
   dependencies:
     fill-range "^7.1.1"
 
-browser-ui-test@^0.24.0:
-  version "0.24.0"
-  resolved "https://registry.npmjs.org/browser-ui-test/-/browser-ui-test-0.24.0.tgz"
-  integrity sha512-jVpAdq/M1cCHG/2K6pAS8NUYJ6BcNSHune72JOheeoASk+oLuGcWcY1SalYAdkWet3dlyfUSyKKtq+DDjYgdVg==
+browser-ui-test@^0.24.1:
+  version "0.24.1"
+  resolved "https://registry.yarnpkg.com/browser-ui-test/-/browser-ui-test-0.24.1.tgz#1b186b652e2c6593ae1d698408d0e6ba0f32bff5"
+  integrity sha512-+S+gDOxc7GGfDUmZeRUcCAUzBVbD6qS7TzZSg1CFN/lgJyXf2MCG8CUbvHTsEi/oG5Iuuza1XzKDPpAAvfSUNw==
   dependencies:
     css-unit-converter "^1.1.2"
     pngjs "^3.4.0"
@@ -175,14 +185,14 @@ chromium-bidi@16.0.1:
     mitt "^3.0.1"
     zod "^3.24.1"
 
-cliui@^8.0.1:
-  version "8.0.1"
-  resolved "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz"
-  integrity sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==
+cliui@^9.0.1:
+  version "9.0.1"
+  resolved "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz"
+  integrity sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==
   dependencies:
-    string-width "^4.2.0"
-    strip-ansi "^6.0.1"
-    wrap-ansi "^7.0.0"
+    string-width "^7.2.0"
+    strip-ansi "^7.1.0"
+    wrap-ansi "^9.0.0"
 
 color-convert@^2.0.1:
   version "2.0.1"
@@ -227,10 +237,10 @@ deep-is@^0.1.3:
   resolved "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz"
   integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
 
-devtools-protocol@0.0.1624250:
-  version "0.0.1624250"
-  resolved "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1624250.tgz"
-  integrity sha512-YFAat/lOiIk0ARmBweG+ygrEcbZrq5B9urRyUoeQKp53MlidHXE2TmTbxKcaXoQj7u/aX+jebDO4BW55rs0WwA==
+devtools-protocol@0.0.1638949:
+  version "0.0.1638949"
+  resolved "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1638949.tgz"
+  integrity sha512-mXwg4Fqnv0WR4iuAT/gYUmctNkjILwXFHyZ+m7Ty1dfr0ezZt2U3gnrrJTfRobJTHoXf+IbuFvFITzLrLFjwJA==
 
 doctrine@^3.0.0:
   version "3.0.0"
@@ -239,10 +249,10 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
-emoji-regex@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz"
-  integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
+emoji-regex@^10.3.0:
+  version "10.6.0"
+  resolved "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz"
+  integrity sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==
 
 es-check@^9.4.4:
   version "9.6.4"
@@ -431,6 +441,11 @@ get-caller-file@^2.0.5:
   resolved "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
+get-east-asian-width@^1.0.0:
+  version "1.6.0"
+  resolved "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz"
+  integrity sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==
+
 glob-parent@^5.1.2:
   version "5.1.2"
   resolved "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz"
@@ -510,11 +525,6 @@ is-extglob@^2.1.1:
   resolved "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz"
   integrity sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==
 
-is-fullwidth-code-point@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz"
-  integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
-
 is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3:
   version "4.0.3"
   resolved "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz"
@@ -538,9 +548,9 @@ isexe@^2.0.0:
   integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
 
 js-yaml@^4.1.0:
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz"
-  integrity sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==
+  version "4.1.1"
+  resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz"
+  integrity sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==
   dependencies:
     argparse "^2.0.1"
 
@@ -706,28 +716,28 @@ punycode@^2.1.0:
   resolved "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz"
   integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
 
-puppeteer-core@25.1.0:
-  version "25.1.0"
-  resolved "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-25.1.0.tgz"
-  integrity sha512-jKzy5y4WG6uNuFbTWgW1D7mqoT9o0nllc/6a1DGF775T1mPmgw3scdFEtEq67yVFikavQmbYq6NLfbTfxHSlqQ==
+puppeteer-core@25.3.0:
+  version "25.3.0"
+  resolved "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-25.3.0.tgz"
+  integrity sha512-fm+wpUr2oigH1PXZvwgATrM2tYWHMDG8ASzTEe9uukCye4X5Ldx1K5BTHPFKITrIWvQQAQ256d1NpbEveBcKjA==
   dependencies:
-    "@puppeteer/browsers" "3.0.4"
+    "@puppeteer/browsers" "3.0.6"
     chromium-bidi "16.0.1"
-    devtools-protocol "0.0.1624250"
+    devtools-protocol "0.0.1638949"
     typed-query-selector "^2.12.2"
     webdriver-bidi-protocol "0.4.2"
     ws "^8.21.0"
 
 puppeteer@^25.1.0:
-  version "25.1.0"
-  resolved "https://registry.npmjs.org/puppeteer/-/puppeteer-25.1.0.tgz"
-  integrity sha512-7L6/0JM7XStK99lIL4xQySyNEXNfII6pk0BxkI5kKBTOhR7AsoQiv067YTsE/rIXxQiq9ajlO4WcqBjS/FWK1A==
+  version "25.3.0"
+  resolved "https://registry.npmjs.org/puppeteer/-/puppeteer-25.3.0.tgz"
+  integrity sha512-O1tx8S315aw8eI99HZ5ZNcVEzJ9+jKF//eO5UvfZ3cXJ6okZ5sX3Y50u7DJaM+ewEK4LqXP068tBhfRaWikj+g==
   dependencies:
-    "@puppeteer/browsers" "3.0.4"
+    "@puppeteer/browsers" "3.0.6"
     chromium-bidi "16.0.1"
-    devtools-protocol "0.0.1624250"
+    devtools-protocol "0.0.1638949"
     lilconfig "^3.1.3"
-    puppeteer-core "25.1.0"
+    puppeteer-core "25.3.0"
     typed-query-selector "^2.12.2"
 
 queue-microtask@^1.2.2:
@@ -739,11 +749,6 @@ readline-sync@^1.4.10:
   version "1.4.10"
   resolved "https://registry.npmjs.org/readline-sync/-/readline-sync-1.4.10.tgz"
   integrity sha512-gNva8/6UAe8QYepIQH/jQ2qn91Qj0B9sYjMBBs3QOB8F2CXcKgLxQaJRP76sWVRQt+QU+8fAkCbCvjjMFu7Ycw==
-
-require-directory@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz"
-  integrity sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==
 
 resolve-from@^4.0.0:
   version "4.0.0"
@@ -781,21 +786,28 @@ shebang-regex@^3.0.0:
   resolved "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+string-width@^7.0.0, string-width@^7.2.0:
+  version "7.2.0"
+  resolved "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz"
+  integrity sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==
   dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
+    emoji-regex "^10.3.0"
+    get-east-asian-width "^1.0.0"
+    strip-ansi "^7.1.0"
 
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
   dependencies:
     ansi-regex "^5.0.1"
+
+strip-ansi@^7.1.0:
+  version "7.2.0"
+  resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz"
+  integrity sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==
+  dependencies:
+    ansi-regex "^6.2.2"
 
 strip-json-comments@^3.1.1:
   version "3.1.1"
@@ -867,14 +879,14 @@ word-wrap@^1.2.5:
   resolved "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+wrap-ansi@^9.0.0:
+  version "9.0.2"
+  resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz"
+  integrity sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==
   dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
+    ansi-styles "^6.2.1"
+    string-width "^7.0.0"
+    strip-ansi "^7.1.0"
 
 wrappy@1:
   version "1.0.2"
@@ -891,23 +903,22 @@ y18n@^5.0.5:
   resolved "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz"
   integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
 
-yargs-parser@^21.1.1:
-  version "21.1.1"
-  resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz"
-  integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
+yargs-parser@^22.0.0:
+  version "22.0.0"
+  resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz"
+  integrity sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==
 
-yargs@^17.7.2:
-  version "17.7.2"
-  resolved "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz"
-  integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==
+yargs@^18.0.0:
+  version "18.0.0"
+  resolved "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz"
+  integrity sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==
   dependencies:
-    cliui "^8.0.1"
+    cliui "^9.0.1"
     escalade "^3.1.1"
     get-caller-file "^2.0.5"
-    require-directory "^2.1.1"
-    string-width "^4.2.3"
+    string-width "^7.2.0"
     y18n "^5.0.5"
-    yargs-parser "^21.1.1"
+    yargs-parser "^22.0.0"
 
 yocto-queue@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#150946 (intrinsics: Add a fallback for non-const libm float functions)
 - rust-lang/rust#158655 (Fix coroutine MIR saved local remapping)
 - rust-lang/rust#158666 (Carry the `b_offset` inside `BackendRepr::ScalarPair`)
 - rust-lang/rust#158920 (Update wasm-component-ld to 0.5.26)
 - rust-lang/rust#158926 (wrapping_sh* methods: clarify underspecified reference)
 - rust-lang/rust#151379 (Stabilize `VecDeque::retain_back` from `truncate_front`)
 - rust-lang/rust#158913 (Update `browser-ui-test` version to `0.24.1`)
 - rust-lang/rust#158935 (std: support real fd methods on Emscripten)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=150946,158655,158666,158920,158926,151379,158913,158935)
<!-- homu-ignore:end -->

