### PR TITLE
Fix bootstrap submodule path prefix matching

### DIFF
--- a/src/bootstrap/src/utils/helpers.rs
+++ b/src/bootstrap/src/utils/helpers.rs
@@ -96,7 +96,11 @@ pub fn is_dylib(path: &Path) -> bool {
 
 /// Return the path to the containing submodule if available.
 pub fn submodule_path_of(builder: &Builder<'_>, path: &str) -> Option<String> {
-    let submodule_paths = builder.submodule_paths();
+    submodule_path_of_paths(builder.submodule_paths(), path)
+}
+
+fn submodule_path_of_paths(submodule_paths: &[String], path: &str) -> Option<String> {
+    let path = Path::new(path);
     submodule_paths.iter().find_map(|submodule_path| {
         if path.starts_with(submodule_path) { Some(submodule_path.to_string()) } else { None }
     })

--- a/src/bootstrap/src/utils/helpers/tests.rs
+++ b/src/bootstrap/src/utils/helpers/tests.rs
@@ -3,7 +3,7 @@ use std::io::Write;
 use std::path::PathBuf;
 
 use crate::utils::helpers::{
-    check_cfg_arg, extract_beta_rev, hex_encode, make, set_file_times, submodule_path_of,
+    check_cfg_arg, extract_beta_rev, hex_encode, make, set_file_times, submodule_path_of_paths,
     symlink_dir,
 };
 use crate::utils::tests::TestCtx;
@@ -101,19 +101,22 @@ fn test_set_file_times_sanity_check() {
 
 #[test]
 fn test_submodule_path_of() {
-    let config = TestCtx::new().config("build").create_config();
+    let submodules = vec!["src/tools/cargo".to_string(), "src/llvm-project".to_string()];
 
-    let build = crate::Build::new(config.clone());
-    let builder = crate::core::builder::Builder::new(&build);
-    assert_eq!(submodule_path_of(&builder, "invalid/path"), None);
-    assert_eq!(submodule_path_of(&builder, "src/tools/cargo"), Some("src/tools/cargo".to_string()));
+    assert_eq!(submodule_path_of_paths(&submodules, "invalid/path"), None);
     assert_eq!(
-        submodule_path_of(&builder, "src/llvm-project"),
+        submodule_path_of_paths(&submodules, "src/tools/cargo"),
+        Some("src/tools/cargo".to_string())
+    );
+    assert_eq!(
+        submodule_path_of_paths(&submodules, "src/llvm-project"),
         Some("src/llvm-project".to_string())
     );
     // Make sure subdirs are handled properly
     assert_eq!(
-        submodule_path_of(&builder, "src/tools/cargo/random-subdir"),
+        submodule_path_of_paths(&submodules, "src/tools/cargo/random-subdir"),
         Some("src/tools/cargo".to_string())
     );
+    // Make sure paths that only share a string prefix with a submodule are not matched.
+    assert_eq!(submodule_path_of_paths(&submodules, "src/tools/cargo-vendor"), None);
 }


### PR DESCRIPTION
Fixes bootstrap submodule detection to use path-component matching instead of raw string prefix matching.
This prevents paths like src/tools/cargo-vendor from being treated as inside the src/tools/cargo submodule.
Adds a regression test for sibling paths that only share a string prefix with a submodule path.