### PR TITLE
reject reborrowing when the target has no lifetime generic arg

### DIFF
--- a/compiler/rustc_hir_typeck/src/coercion.rs
+++ b/compiler/rustc_hir_typeck/src/coercion.rs
@@ -54,7 +54,7 @@ use rustc_middle::ty::adjustment::{
     PointerCoercion,
 };
 use rustc_middle::ty::error::TypeError;
-use rustc_middle::ty::{self, Ty, TyCtxt, TypeVisitableExt, Unnormalized};
+use rustc_middle::ty::{self, AdtDef, Ty, TyCtxt, TypeVisitableExt, Unnormalized};
 use rustc_span::{BytePos, DUMMY_SP, Span};
 use rustc_trait_selection::infer::InferCtxtExt as _;
 use rustc_trait_selection::solve::inspect::{self, InferCtxtProofTreeExt, ProofTreeVisitor};
@@ -950,6 +950,21 @@ impl<'f, 'tcx> Coerce<'f, 'tcx> {
         Ok(coerce)
     }
 
+    /// Get the AdtDefs for the reborrowing if they're reborrowable
+    fn reborrow_def(
+        &self,
+        a: Ty<'tcx>,
+        b: Ty<'tcx>,
+    ) -> RelateResult<'tcx, (AdtDef<'tcx>, AdtDef<'tcx>)> {
+        let (ty::Adt(a_def, _), ty::Adt(b_def, b_args)) = (*a.kind(), *b.kind()) else {
+            return Err(TypeError::Mismatch);
+        };
+        match b_args.get(0).map(|r| r.kind()) {
+            Some(ty::GenericArgKind::Lifetime(_)) => Ok((a_def, b_def)),
+            _ => Err(TypeError::Mismatch),
+        }
+    }
+
     /// Applies generic exclusive reborrowing on type implementing `Reborrow`.
     #[instrument(skip(self), level = "trace")]
     fn coerce_reborrow(&self, a: Ty<'tcx>, b: Ty<'tcx>) -> CoerceResult<'tcx> {
@@ -957,9 +972,8 @@ impl<'f, 'tcx> Coerce<'f, 'tcx> {
         debug_assert!(self.shallow_resolve(b) == b);
 
         // We need to make sure the two types are compatible for reborrow.
-        let (ty::Adt(a_def, _), ty::Adt(b_def, _)) = (a.kind(), b.kind()) else {
-            return Err(TypeError::Mismatch);
-        };
+        let (a_def, b_def) = self.reborrow_def(a, b)?;
+
         if a_def.did() == b_def.did() {
             // Reborrow is applicable here
             self.unify_and(
@@ -982,9 +996,7 @@ impl<'f, 'tcx> Coerce<'f, 'tcx> {
         debug_assert!(self.shallow_resolve(b) == b);
 
         // We need to make sure the two types are compatible for reborrow.
-        let (ty::Adt(a_def, _), ty::Adt(b_def, _)) = (a.kind(), b.kind()) else {
-            return Err(TypeError::Mismatch);
-        };
+        let (a_def, b_def) = self.reborrow_def(a, b)?;
         if a_def.did() == b_def.did() {
             // CoerceShared cannot be T -> T.
             return Err(TypeError::Mismatch);

--- a/tests/ui/reborrow/reborrow-no-lifetime-rejected.rs
+++ b/tests/ui/reborrow/reborrow-no-lifetime-rejected.rs
@@ -1,0 +1,14 @@
+//@ check-fail
+
+#![feature(reborrow)]
+
+use std::marker::Reborrow;
+
+struct Thing;
+impl<'a> Reborrow for Thing {}
+//~^ ERROR implementing `Reborrow` does not allow multiple lifetimes or fields to be coerced
+fn foo(_: Thing) {}
+fn main() {
+    let x = Thing;
+    foo(x);
+}

--- a/tests/ui/reborrow/reborrow-no-lifetime-rejected.stderr
+++ b/tests/ui/reborrow/reborrow-no-lifetime-rejected.stderr
@@ -1,0 +1,8 @@
+error: implementing `Reborrow` does not allow multiple lifetimes or fields to be coerced
+  --> $DIR/reborrow-no-lifetime-rejected.rs:8:1
+   |
+LL | impl<'a> Reborrow for Thing {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
suppresses the ICE in rust-lang/rust#156307 and rust-lang/rust#156308, but doesn't fix the problem that reborrowing is conflict with moving.

Reborrow traits experiment: https://github.com/rust-lang/rust/issues/145612

fixes rust-lang/rust#156307.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
