### PR TITLE
Support underscore as associated const name

### DIFF
--- a/compiler/rustc_ast_passes/src/ast_validation.rs
+++ b/compiler/rustc_ast_passes/src/ast_validation.rs
@@ -1072,11 +1072,19 @@ impl<'a> AstValidator<'a> {
         }
     }
 
-    fn check_item_named(&self, ident: Ident, kind: &str) {
+    fn check_item_named(&self, ident: Ident, kind: &str, ctxt: AssocCtxt) {
         if ident.name != kw::Underscore {
             return;
         }
-        self.dcx().emit_err(diagnostics::ItemUnderscore { span: ident.span, kind });
+
+        if !self.features.enabled(sym::associated_const_underscore)
+            && matches!(ctxt, AssocCtxt::Impl { of_trait: false })
+        {
+            let msg = format!("naming associated constants with `_` is unstable");
+            feature_err(&self.sess, sym::associated_const_underscore, ident.span, msg).emit();
+        } else if !matches!(ctxt, AssocCtxt::Impl { of_trait: false }) {
+            self.dcx().emit_err(diagnostics::ItemUnderscore { span: ident.span, kind });
+        }
     }
 
     fn check_nomangle_item_asciionly(&self, ident: Ident, item_span: Span) {
@@ -2163,7 +2171,7 @@ impl Visitor<'_> for AstValidator<'_> {
         }
 
         if let AssocItemKind::Const(ci) = &item.kind {
-            self.check_item_named(ci.ident, "const");
+            self.check_item_named(ci.ident, "const", ctxt);
         }
 
         let parent_is_const =

--- a/compiler/rustc_ast_passes/src/ast_validation.rs
+++ b/compiler/rustc_ast_passes/src/ast_validation.rs
@@ -1049,11 +1049,19 @@ impl<'a> AstValidator<'a> {
         }
     }
 
-    fn check_item_named(&self, ident: Ident, kind: &str) {
+    fn check_item_named(&self, ident: Ident, kind: &str, ctxt: AssocCtxt) {
         if ident.name != kw::Underscore {
             return;
         }
-        self.dcx().emit_err(diagnostics::ItemUnderscore { span: ident.span, kind });
+
+        if !self.features.enabled(sym::associated_const_underscore)
+            && matches!(ctxt, AssocCtxt::Impl { of_trait: false })
+        {
+            let msg = format!("naming associated constants with `_` is unstable");
+            feature_err(&self.sess, sym::associated_const_underscore, ident.span, msg).emit();
+        } else if !matches!(ctxt, AssocCtxt::Impl { of_trait: false }) {
+            self.dcx().emit_err(diagnostics::ItemUnderscore { span: ident.span, kind });
+        }
     }
 
     fn check_nomangle_item_asciionly(&self, ident: Ident, item_span: Span) {
@@ -2139,7 +2147,7 @@ impl Visitor<'_> for AstValidator<'_> {
         }
 
         if let AssocItemKind::Const(ci) = &item.kind {
-            self.check_item_named(ci.ident, "const");
+            self.check_item_named(ci.ident, "const", ctxt);
         }
 
         let parent_is_const =

--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -408,6 +408,8 @@ declare_features! (
     (unstable, asm_goto_with_outputs, "1.85.0", Some(119364)),
     /// Allows the `may_unwind` option in inline assembly.
     (unstable, asm_unwind, "1.58.0", Some(93334)),
+    /// Allows `_` for the name of associated constants.
+    (unstable, associated_const_underscore, "CURRENT_RUSTC_VERSION", Some(158944)),
     /// Allows associated type defaults.
     (unstable, associated_type_defaults, "1.2.0", Some(29661)),
     /// Allows implementing `AsyncDrop`.

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -3065,6 +3065,13 @@ impl<'hir> ImplItem<'hir> {
         ImplItemId { owner_id: self.owner_id }
     }
 
+    /// Returns whether this is an anonymous associated constant in an inherent impl.
+    pub fn is_anon_const(&self) -> bool {
+        matches!(self.impl_kind, ImplItemImplKind::Inherent { .. })
+            && matches!(self.kind, ImplItemKind::Const(..))
+            && self.ident.name == kw::Underscore
+    }
+
     pub fn vis_span(&self) -> Option<Span> {
         match self.impl_kind {
             ImplItemImplKind::Trait { .. } => None,

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -3414,6 +3414,13 @@ impl<'hir> ImplItem<'hir> {
         ImplItemId { owner_id: self.owner_id }
     }
 
+    /// Returns whether this is an anonymous associated constant in an inherent impl.
+    pub fn is_anon_const(&self) -> bool {
+        matches!(self.impl_kind, ImplItemImplKind::Inherent { .. })
+            && matches!(self.kind, ImplItemKind::Const(..))
+            && self.ident.name == kw::Underscore
+    }
+
     pub fn vis_span(&self) -> Option<Span> {
         match self.impl_kind {
             ImplItemImplKind::Trait { .. } => None,

--- a/compiler/rustc_hir_analysis/src/check/mod.rs
+++ b/compiler/rustc_hir_analysis/src/check/mod.rs
@@ -615,7 +615,8 @@ fn suggestion_signature<'tcx>(
             );
             format!("type {}{generics} = /* Type */{where_clauses};", assoc.name())
         }
-        ty::AssocKind::Const { name, .. } => {
+        ty::AssocKind::Const { .. } => {
+            let name = assoc.name();
             let ty = tcx.type_of(assoc.def_id).instantiate_identity().skip_norm_wip();
             let val = tcx
                 .infer_ctxt()

--- a/compiler/rustc_hir_analysis/src/coherence/inherent_impls_overlap.rs
+++ b/compiler/rustc_hir_analysis/src/coherence/inherent_impls_overlap.rs
@@ -49,7 +49,7 @@ impl<'tcx> InherentOverlapChecker<'tcx> {
             std::mem::swap(&mut impl_items1, &mut impl_items2);
         }
 
-        for &item1 in impl_items1.in_definition_order() {
+        for &item1 in impl_items1.named_items() {
             let collision = impl_items2
                 .filter_by_name_unhygienic(item1.name())
                 .any(|&item2| self.compare_hygienically(item1, item2));
@@ -74,7 +74,7 @@ impl<'tcx> InherentOverlapChecker<'tcx> {
 
         let mut seen_items = FxIndexMap::default();
         let mut res = Ok(());
-        for impl_item in impl_items.in_definition_order() {
+        for &impl_item in impl_items.named_items() {
             let span = self.tcx.def_span(impl_item.def_id);
             let ident = impl_item.ident(self.tcx);
 
@@ -111,7 +111,7 @@ impl<'tcx> InherentOverlapChecker<'tcx> {
         let impl_items2 = self.tcx.associated_items(impl2);
 
         let mut res = Ok(());
-        for &item1 in impl_items1.in_definition_order() {
+        for &item1 in impl_items1.named_items() {
             let collision = impl_items2
                 .filter_by_name_unhygienic(item1.name())
                 .find(|&&item2| self.compare_hygienically(item1, item2));
@@ -228,7 +228,7 @@ impl<'tcx> InherentOverlapChecker<'tcx> {
                 // First obtain a list of existing connected region ids
                 let mut idents_to_add = SmallVec::<[Symbol; 8]>::new();
                 let mut ids = impl_items
-                    .in_definition_order()
+                    .named_items()
                     .filter_map(|item| {
                         let entry = connected_region_ids.entry(item.name());
                         if let IndexEntry::Occupied(e) = &entry {

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/errors.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/errors.rs
@@ -207,10 +207,8 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
 
         let wider_candidate_names: Vec<_> = visible_traits
             .iter()
-            .flat_map(|trait_def_id| tcx.associated_items(*trait_def_id).in_definition_order())
-            .filter_map(|item| {
-                (!item.is_impl_trait_in_trait() && item.tag() == assoc_tag).then(|| item.name())
-            })
+            .flat_map(|trait_def_id| tcx.associated_items(*trait_def_id).named_items())
+            .filter_map(|item| (item.tag() == assoc_tag).then(|| item.name()))
             .collect();
 
         if let Some(suggested_name) =

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/errors.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/errors.rs
@@ -206,10 +206,8 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
 
         let wider_candidate_names: Vec<_> = visible_traits
             .iter()
-            .flat_map(|trait_def_id| tcx.associated_items(*trait_def_id).in_definition_order())
-            .filter_map(|item| {
-                (!item.is_impl_trait_in_trait() && item.tag() == assoc_tag).then(|| item.name())
-            })
+            .flat_map(|trait_def_id| tcx.associated_items(*trait_def_id).named_items())
+            .filter_map(|item| (item.tag() == assoc_tag).then(|| item.name()))
             .collect();
 
         if let Some(suggested_name) =

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
@@ -287,7 +287,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         let Some(iterator_item_id) = tcx
             .associated_items(iterator_trait_id)
-            .in_definition_order()
+            .named_items()
             .find(|item| item.name() == sym::Item)
             .map(|item| item.def_id)
         else {

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
@@ -288,7 +288,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         let Some(iterator_item_id) = tcx
             .associated_items(iterator_trait_id)
-            .in_definition_order()
+            .named_items()
             .find(|item| item.name() == sym::Item)
             .map(|item| item.def_id)
         else {

--- a/compiler/rustc_hir_typeck/src/method/probe.rs
+++ b/compiler/rustc_hir_typeck/src/method/probe.rs
@@ -1885,7 +1885,8 @@ impl<'tcx> Pick<'tcx> {
                             tcx.def_path_str(this.item.def_id),
                         ));
                     }
-                    (ty::AssocKind::Const { name, .. }, ty::AssocContainer::Trait) => {
+                    (ty::AssocKind::Const { .. }, ty::AssocContainer::Trait) => {
+                        let name = this.item.name();
                         let def_id = this.item.container_id(tcx);
                         lint.span_suggestion(
                             span,
@@ -2675,7 +2676,7 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
                 let max_dist = max(name.as_str().len(), 3) / 3;
                 self.tcx
                     .associated_items(def_id)
-                    .in_definition_order()
+                    .named_items()
                     .filter(|x| {
                         if !self.is_relevant_kind_for_mode(x.kind) {
                             return false;

--- a/compiler/rustc_hir_typeck/src/method/probe.rs
+++ b/compiler/rustc_hir_typeck/src/method/probe.rs
@@ -1884,7 +1884,8 @@ impl<'tcx> Pick<'tcx> {
                             tcx.def_path_str(this.item.def_id),
                         ));
                     }
-                    (ty::AssocKind::Const { name, .. }, ty::AssocContainer::Trait) => {
+                    (ty::AssocKind::Const { .. }, ty::AssocContainer::Trait) => {
+                        let name = this.item.name();
                         let def_id = this.item.container_id(tcx);
                         lint.span_suggestion(
                             span,
@@ -2674,7 +2675,7 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
                 let max_dist = max(name.as_str().len(), 3) / 3;
                 self.tcx
                     .associated_items(def_id)
-                    .in_definition_order()
+                    .named_items()
                     .filter(|x| {
                         if !self.is_relevant_kind_for_mode(x.kind) {
                             return false;

--- a/compiler/rustc_metadata/src/rmeta/decoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder.rs
@@ -1400,7 +1400,12 @@ impl CrateMetadata {
     fn get_associated_item(&self, tcx: TyCtxt<'_>, id: DefIndex) -> ty::AssocItem {
         let kind = match self.def_kind(id) {
             DefKind::AssocConst { is_type_const } => {
-                ty::AssocKind::Const { name: self.item_name(id), is_type_const }
+                let data = if self.root.tables.is_anon_assoc_const.get(self, id) {
+                    ty::AssocConstData::Anonymous
+                } else {
+                    ty::AssocConstData::Named(self.item_name(id))
+                };
+                ty::AssocKind::Const { data, is_type_const }
             }
             DefKind::AssocFn => ty::AssocKind::Fn {
                 name: self.item_name(id),

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -1779,6 +1779,10 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
 
         record!(self.tables.assoc_container[def_id] <- item.container);
 
+        if item.is_anon_const() {
+            self.tables.is_anon_assoc_const.set(def_id.index, true);
+        }
+
         if let AssocContainer::Trait = item.container
             && item.is_type()
         {

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -1775,6 +1775,10 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
 
         record!(self.tables.assoc_container[def_id] <- item.container);
 
+        if item.is_anon_const() {
+            self.tables.is_anon_assoc_const.set(def_id.index, true);
+        }
+
         if let AssocContainer::Trait = item.container
             && item.is_type()
         {

--- a/compiler/rustc_metadata/src/rmeta/mod.rs
+++ b/compiler/rustc_metadata/src/rmeta/mod.rs
@@ -402,6 +402,7 @@ define_tables! {
     explicit_implied_const_bounds: Table<DefIndex, LazyArray<(ty::PolyTraitRef<'static>, Span)>>,
     inherent_impls: Table<DefIndex, LazyArray<DefIndex>>,
     opt_rpitit_info: Table<DefIndex, Option<LazyValue<ty::ImplTraitInTraitData>>>,
+    is_anon_assoc_const: Table<DefIndex, bool>,
     // Reexported names are not associated with individual `DefId`s,
     // e.g. a glob import can introduce a lot of names, all with the same `DefId`.
     // That's why the encoded list needs to contain `ModChild` structures describing all the names

--- a/compiler/rustc_middle/src/ty/assoc.rs
+++ b/compiler/rustc_middle/src/ty/assoc.rs
@@ -31,15 +31,16 @@ impl AssocItem {
         match self.kind {
             ty::AssocKind::Type { data: AssocTypeData::Normal(name) } => Some(name),
             ty::AssocKind::Type { data: AssocTypeData::Rpitit(_) } => None,
-            ty::AssocKind::Const { name, .. } => Some(name),
+            ty::AssocKind::Const { data: AssocConstData::Named(name), .. } => Some(name),
+            ty::AssocKind::Const { data: AssocConstData::Anonymous, .. } => None,
             ty::AssocKind::Fn { name, .. } => Some(name),
         }
     }
 
-    // Gets the identifier name. Aborts if it lacks one, i.e. is an RPITIT
-    // associated type.
+    // Gets the identifier name. Aborts if it lacks one, e.g. for an RPITIT
+    // associated type or an anonymous associated const.
     pub fn name(&self) -> Symbol {
-        self.opt_name().expect("name of non-Rpitit assoc item")
+        self.opt_name().expect("name of anonymous associated item")
     }
 
     pub fn ident(&self, tcx: TyCtxt<'_>) -> Ident {
@@ -120,7 +121,11 @@ impl AssocItem {
                 tcx.fn_sig(self.def_id).instantiate_identity().skip_binder().to_string()
             }
             ty::AssocKind::Type { .. } => format!("type {};", self.name()),
-            ty::AssocKind::Const { name, .. } => {
+            ty::AssocKind::Const { data, .. } => {
+                let name = match data {
+                    AssocConstData::Named(name) => name,
+                    AssocConstData::Anonymous => rustc_span::symbol::kw::Underscore,
+                };
                 format!("const {}: {:?};", name, tcx.type_of(self.def_id).instantiate_identity())
             }
         }
@@ -154,6 +159,10 @@ impl AssocItem {
         }
     }
 
+    pub fn is_anon_const(&self) -> bool {
+        matches!(self.kind, ty::AssocKind::Const { data: AssocConstData::Anonymous, .. })
+    }
+
     pub fn is_fn(&self) -> bool {
         matches!(self.kind, ty::AssocKind::Fn { .. })
     }
@@ -185,8 +194,15 @@ pub enum AssocTypeData {
 }
 
 #[derive(Copy, Clone, PartialEq, Debug, StableHash, Eq, Hash, Encodable, Decodable)]
+pub enum AssocConstData {
+    Named(Symbol),
+    /// An associated constant named `_`, which *semantically* has no name.
+    Anonymous,
+}
+
+#[derive(Copy, Clone, PartialEq, Debug, StableHash, Eq, Hash, Encodable, Decodable)]
 pub enum AssocKind {
-    Const { name: Symbol, is_type_const: bool },
+    Const { data: AssocConstData, is_type_const: bool },
     Fn { name: Symbol, has_self: bool },
     Type { data: AssocTypeData },
 }
@@ -273,6 +289,11 @@ impl AssocItems {
     /// for a known trait, make that trait a lang item instead of indexing this array.
     pub fn in_definition_order(&self) -> impl '_ + Iterator<Item = &ty::AssocItem> {
         self.items.iter().map(|(_, v)| v)
+    }
+
+    /// Returns named associated items in definition order.
+    pub fn named_items(&self) -> impl '_ + Iterator<Item = &ty::AssocItem> {
+        self.items.iter().filter_map(|(name, v)| name.is_some().then(|| v))
     }
 
     pub fn len(&self) -> usize {

--- a/compiler/rustc_passes/src/dead.rs
+++ b/compiler/rustc_passes/src/dead.rs
@@ -841,6 +841,17 @@ fn maybe_record_as_seed<'tcx>(
             }
         }
         DefKind::AssocFn | DefKind::AssocConst { .. } | DefKind::AssocTy => {
+            // As with free constants named `_`, associated constants named `_` are always live.
+            if let hir::Node::ImplItem(impl_item) = tcx.hir_node_by_def_id(owner_id.def_id)
+                && impl_item.is_anon_const()
+            {
+                push_into_worklist(WorkItem {
+                    id: owner_id.def_id,
+                    propagated: ComesFromAllowExpect::No,
+                    own: ComesFromAllowExpect::No,
+                });
+            }
+
             if allow_dead_code.is_none() {
                 let parent = tcx.local_parent(owner_id.def_id);
                 match tcx.def_kind(parent) {

--- a/compiler/rustc_public/src/ty.rs
+++ b/compiler/rustc_public/src/ty.rs
@@ -1712,9 +1712,15 @@ pub enum AssocTypeData {
     Rpitit(ImplTraitInTraitData),
 }
 
+#[derive(Clone, PartialEq, Debug, Eq, Serialize)]
+pub enum AssocConstData {
+    Named(Symbol),
+    Anonymous,
+}
+
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub enum AssocKind {
-    Const { name: Symbol },
+    Const { data: AssocConstData },
     Fn { name: Symbol, has_self: bool },
     Type { data: AssocTypeData },
 }

--- a/compiler/rustc_public/src/ty/tys.rs
+++ b/compiler/rustc_public/src/ty/tys.rs
@@ -1365,9 +1365,15 @@ pub enum AssocTypeData {
     Rpitit(ImplTraitInTraitData),
 }
 
+#[derive(Clone, PartialEq, Debug, Eq, Serialize)]
+pub enum AssocConstData {
+    Named(Symbol),
+    Anonymous,
+}
+
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub enum AssocKind {
-    Const { name: Symbol },
+    Const { data: AssocConstData },
     Fn { name: Symbol, has_self: bool },
     Type { data: AssocTypeData },
 }

--- a/compiler/rustc_public/src/unstable/convert/stable/ty.rs
+++ b/compiler/rustc_public/src/unstable/convert/stable/ty.rs
@@ -1070,9 +1070,14 @@ impl<'tcx> Stable<'tcx> for ty::AssocKind {
         tables: &mut Tables<'cx, BridgeTys>,
         cx: &CompilerCtxt<'cx, BridgeTys>,
     ) -> Self::T {
-        use crate::ty::{AssocKind, AssocTypeData};
+        use crate::ty::{AssocConstData, AssocKind, AssocTypeData};
         match *self {
-            ty::AssocKind::Const { name, .. } => AssocKind::Const { name: name.to_string() },
+            ty::AssocKind::Const { data, .. } => AssocKind::Const {
+                data: match data {
+                    ty::AssocConstData::Named(name) => AssocConstData::Named(name.to_string()),
+                    ty::AssocConstData::Anonymous => AssocConstData::Anonymous,
+                },
+            },
             ty::AssocKind::Fn { name, has_self } => {
                 AssocKind::Fn { name: name.to_string(), has_self }
             }

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -446,6 +446,7 @@ symbols! {
         assert_zero_valid,
         asserting,
         associated_const_equality,
+        associated_const_underscore,
         associated_consts,
         associated_type_bounds,
         associated_type_defaults,

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -447,6 +447,7 @@ symbols! {
         assert_zero_valid,
         asserting,
         associated_const_equality,
+        associated_const_underscore,
         associated_consts,
         associated_type_bounds,
         associated_type_defaults,

--- a/compiler/rustc_trait_selection/src/traits/dyn_compatibility.rs
+++ b/compiler/rustc_trait_selection/src/traits/dyn_compatibility.rs
@@ -361,7 +361,8 @@ pub fn dyn_compatibility_violations_for_assoc_item(
     let span = || item.ident(tcx).span;
 
     match item.kind {
-        ty::AssocKind::Const { name, is_type_const } => {
+        ty::AssocKind::Const { is_type_const, .. } => {
+            let name = item.name();
             // We will permit type associated consts if they are explicitly mentioned in the
             // trait object type. We can't check this here, as here we only check if it is
             // guaranteed to not be possible.

--- a/compiler/rustc_trait_selection/src/traits/dyn_compatibility.rs
+++ b/compiler/rustc_trait_selection/src/traits/dyn_compatibility.rs
@@ -360,7 +360,8 @@ pub fn dyn_compatibility_violations_for_assoc_item(
     let span = || item.ident(tcx).span;
 
     match item.kind {
-        ty::AssocKind::Const { name, is_type_const } => {
+        ty::AssocKind::Const { is_type_const, .. } => {
+            let name = item.name();
             // We will permit type associated consts if they are explicitly mentioned in the
             // trait object type. We can't check this here, as here we only check if it is
             // guaranteed to not be possible.

--- a/compiler/rustc_ty_utils/src/assoc.rs
+++ b/compiler/rustc_ty_utils/src/assoc.rs
@@ -88,9 +88,10 @@ fn associated_item_from_trait_item(
     let owner_id = trait_item.owner_id;
     let name = trait_item.ident.name;
     let kind = match trait_item.kind {
-        hir::TraitItemKind::Const(_, _) => {
-            ty::AssocKind::Const { name, is_type_const: tcx.is_type_const(owner_id.def_id) }
-        }
+        hir::TraitItemKind::Const(_, _) => ty::AssocKind::Const {
+            data: ty::AssocConstData::Named(name),
+            is_type_const: tcx.is_type_const(owner_id.def_id),
+        },
         hir::TraitItemKind::Fn { .. } => {
             ty::AssocKind::Fn { name, has_self: fn_has_self_parameter(tcx, owner_id) }
         }
@@ -107,7 +108,12 @@ fn associated_item_from_impl_item(tcx: TyCtxt<'_>, impl_item: &hir::ImplItem<'_>
     let name = impl_item.ident.name;
     let kind = match impl_item.kind {
         hir::ImplItemKind::Const(_, rhs) => {
-            ty::AssocKind::Const { name, is_type_const: matches!(rhs, ConstItemRhs::TypeConst(_)) }
+            let data = if impl_item.is_anon_const() {
+                ty::AssocConstData::Anonymous
+            } else {
+                ty::AssocConstData::Named(name)
+            };
+            ty::AssocKind::Const { data, is_type_const: matches!(rhs, ConstItemRhs::TypeConst(_)) }
         }
         hir::ImplItemKind::Fn { .. } => {
             ty::AssocKind::Fn { name, has_self: fn_has_self_parameter(tcx, owner_id) }

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -523,6 +523,7 @@ pub(crate) fn build_impl(
                 .items
                 .iter()
                 .map(|&item| tcx.hir_impl_item(item))
+                .filter(|item| !item.is_anon_const())
                 .filter(|item| {
                     // Filter out impl items whose corresponding trait item has `doc(hidden)`
                     // not to document such impl items.

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -3047,7 +3047,9 @@ fn clean_impl<'tcx>(
     let items = impl_
         .items
         .iter()
-        .map(|&ii| clean_impl_item(tcx.hir_impl_item(ii), cx))
+        .map(|&ii| tcx.hir_impl_item(ii))
+        .filter(|item| !item.is_anon_const())
+        .map(|item| clean_impl_item(item, cx))
         .collect::<Vec<_>>();
 
     // If this impl block is a positive implementation of the Deref trait, then we

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -3040,7 +3040,9 @@ fn clean_impl<'tcx>(
     let items = impl_
         .items
         .iter()
-        .map(|&ii| clean_impl_item(tcx.hir_impl_item(ii), cx))
+        .map(|&ii| tcx.hir_impl_item(ii))
+        .filter(|item| !item.is_anon_const())
+        .map(|item| clean_impl_item(item, cx))
         .collect::<Vec<_>>();
 
     // If this impl block is a positive implementation of the Deref trait, then we

--- a/src/tools/clippy/clippy_lints/src/assigning_clones.rs
+++ b/src/tools/clippy/clippy_lints/src/assigning_clones.rs
@@ -109,7 +109,7 @@ impl<'tcx> LateLintPass<'tcx> for AssigningClones {
             })
             && let resolved_assoc_items = cx.tcx.associated_items(resolved_impl)
             // Only suggest if `clone_from`/`clone_into` is explicitly implemented
-            && resolved_assoc_items.in_definition_order().any(|assoc|
+            && resolved_assoc_items.named_items().any(|assoc|
                 match which_trait {
                     CloneTrait::Clone => assoc.name() == sym::clone_from,
                     CloneTrait::ToOwned => assoc.name() == sym::clone_into,

--- a/tests/rustdoc-html/associated-const-underscore.rs
+++ b/tests/rustdoc-html/associated-const-underscore.rs
@@ -1,0 +1,11 @@
+#![feature(associated_const_underscore)]
+
+pub struct Struct;
+
+impl Struct {
+    //@ has associated_const_underscore/struct.Struct.html '//*[@id="associatedconstant.NAMED"]' ''
+    pub const NAMED: () = ();
+
+    //@ !has associated_const_underscore/struct.Struct.html '//*[@id="associatedconstant._"]' ''
+    pub const _: () = ();
+}

--- a/tests/rustdoc-json/associated-const-underscore.rs
+++ b/tests/rustdoc-json/associated-const-underscore.rs
@@ -1,0 +1,11 @@
+#![feature(associated_const_underscore)]
+
+pub struct Struct;
+
+impl Struct {
+    //@ has "$..index[?(@.name=='NAMED')].inner.assoc_const"
+    pub const NAMED: () = ();
+
+    //@ !has "$..index[?(@.name=='_')]"
+    pub const _: () = ();
+}

--- a/tests/ui/associated-consts/associated-const-underscore-dead-code.rs
+++ b/tests/ui/associated-consts/associated-const-underscore-dead-code.rs
@@ -1,0 +1,13 @@
+#![feature(associated_const_underscore)]
+#![deny(dead_code)]
+
+fn main() {}
+
+struct Struct {}
+
+impl Struct {
+    const _: () = {
+        struct Unused;
+        //~^ ERROR: struct `Unused` is never constructed [dead_code]
+    };
+}

--- a/tests/ui/associated-consts/associated-const-underscore-dead-code.stderr
+++ b/tests/ui/associated-consts/associated-const-underscore-dead-code.stderr
@@ -1,0 +1,14 @@
+error: struct `Unused` is never constructed
+  --> $DIR/associated-const-underscore-dead-code.rs:10:16
+   |
+LL |         struct Unused;
+   |                ^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/associated-const-underscore-dead-code.rs:2:9
+   |
+LL | #![deny(dead_code)]
+   |         ^^^^^^^^^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/associated-consts/associated-const-underscore-fail.rs
+++ b/tests/ui/associated-consts/associated-const-underscore-fail.rs
@@ -1,0 +1,41 @@
+#![feature(associated_const_underscore)]
+
+fn main() {}
+
+pub struct Struct;
+
+impl Struct {
+    const _: () = {
+        let _ = Struct;
+    };
+    // typeck
+    const _: u32 = "not a number";
+    //~^ ERROR mismatched types
+}
+
+trait InvalidTrait {
+    const _: ();
+    //~^ ERROR `const` items in this context need a name
+}
+
+trait Trait {}
+
+struct Type;
+
+impl Trait for Type {
+    const _: () = ();
+    //~^ ERROR `const` items in this context need a name
+    //~| ERROR const `_` is not a member of trait `Trait`
+}
+
+struct Local;
+
+impl std::thread::Thread {
+    //~^ ERROR cannot define inherent `impl` for a type outside of the crate where the type is defined
+    const _: () = ();
+}
+
+impl &Local {
+    //~^ ERROR cannot define inherent `impl` for primitive types
+    const _: () = ();
+}

--- a/tests/ui/associated-consts/associated-const-underscore-fail.stderr
+++ b/tests/ui/associated-consts/associated-const-underscore-fail.stderr
@@ -1,0 +1,48 @@
+error: `const` items in this context need a name
+  --> $DIR/associated-const-underscore-fail.rs:17:11
+   |
+LL |     const _: ();
+   |           ^ `_` is not a valid name for this `const` item
+
+error: `const` items in this context need a name
+  --> $DIR/associated-const-underscore-fail.rs:26:11
+   |
+LL |     const _: () = ();
+   |           ^ `_` is not a valid name for this `const` item
+
+error[E0438]: const `_` is not a member of trait `Trait`
+  --> $DIR/associated-const-underscore-fail.rs:26:5
+   |
+LL |     const _: () = ();
+   |     ^^^^^^^^^^^^^^^^^ not a member of trait `Trait`
+
+error[E0116]: cannot define inherent `impl` for a type outside of the crate where the type is defined
+  --> $DIR/associated-const-underscore-fail.rs:33:1
+   |
+LL | impl std::thread::Thread {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^ impl for type defined outside of crate
+   |
+   = help: consider defining a trait and implementing it for the type or using a newtype wrapper like `struct MyType(ExternalType);` and implement it
+   = note: for more details about the orphan rules, see <https://doc.rust-lang.org/reference/items/implementations.html?highlight=orphan#orphan-rules>
+
+error[E0390]: cannot define inherent `impl` for primitive types
+  --> $DIR/associated-const-underscore-fail.rs:38:1
+   |
+LL | impl &Local {
+   | ^^^^^^^^^^^
+   |
+   = help: consider using an extension trait instead
+   = note: you could also try moving the reference to uses of `Local` (such as `self`) within the implementation
+
+error[E0308]: mismatched types
+  --> $DIR/associated-const-underscore-fail.rs:12:20
+   |
+LL |     const _: u32 = "not a number";
+   |              ---   ^^^^^^^^^^^^^^ expected `u32`, found `&str`
+   |              |
+   |              expected because of the type of the associated constant
+
+error: aborting due to 6 previous errors
+
+Some errors have detailed explanations: E0116, E0308, E0390, E0438.
+For more information about an error, try `rustc --explain E0116`.

--- a/tests/ui/associated-consts/associated-const-underscore-visibility.rs
+++ b/tests/ui/associated-consts/associated-const-underscore-visibility.rs
@@ -1,0 +1,20 @@
+#![feature(associated_const_underscore)]
+#![deny(private_interfaces)]
+fn main() {}
+
+pub struct Public;
+struct Private;
+
+impl Public {
+    pub const _: Private = Private;
+    //~^ ERROR: type `Private` is more private than the item `Public::_` [private_interfaces]
+}
+
+impl Public {
+    const _: Private = Private;
+}
+
+impl Private {
+    pub const _: Private = Private;
+    pub const _: () = {};
+}

--- a/tests/ui/associated-consts/associated-const-underscore-visibility.stderr
+++ b/tests/ui/associated-consts/associated-const-underscore-visibility.stderr
@@ -1,0 +1,19 @@
+error: type `Private` is more private than the item `Public::_`
+  --> $DIR/associated-const-underscore-visibility.rs:9:5
+   |
+LL |     pub const _: Private = Private;
+   |     ^^^^^^^^^^^^^^^^^^^^ associated constant `Public::_` is reachable at visibility `pub`
+   |
+note: but type `Private` is only usable at visibility `pub(crate)`
+  --> $DIR/associated-const-underscore-visibility.rs:6:1
+   |
+LL | struct Private;
+   | ^^^^^^^^^^^^^^
+note: the lint level is defined here
+  --> $DIR/associated-const-underscore-visibility.rs:2:9
+   |
+LL | #![deny(private_interfaces)]
+   |         ^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/associated-consts/associated-const-underscore.rs
+++ b/tests/ui/associated-consts/associated-const-underscore.rs
@@ -1,0 +1,75 @@
+//@ check-pass
+
+#![feature(associated_const_underscore)]
+
+use std::mem;
+
+struct Struct<T>(T);
+
+impl<T> Struct<T> {
+    const _: () = {
+        let _: Option<Self>;
+    };
+
+    const _: i16 = 0;
+}
+
+impl Struct<i16> {
+    const _: () = ();
+}
+
+type Field<'a, T> = &'a mut T;
+
+struct Thing<'a, T> {
+    field: Field<'a, T>,
+}
+
+impl<'a, T: Eq> Thing<'a, T> {
+    const _: () = {
+        fn require_outlives<'a, T: 'a>() {}
+        let _ = require_outlives::<'a, T>;
+        let _: Option<Self>;
+    };
+}
+
+struct Unit;
+
+impl Unit {
+    // An associated const named `_` is not evaluated unless it is accessed.
+    // However, associated consts named `_` cannot be accessed, so this should pass.
+    const _: () = panic!();
+    const _: () = assert!(false);
+    const _: [(); {
+        {
+            assert!(std::mem::size_of::<Self>() == 0)
+        };
+        0
+    }] = [];
+    const _: [(); {
+        {
+            assert!(true)
+        };
+        0
+    }] = [];
+}
+
+struct Generic<T>(T);
+
+impl<T> Generic<T> {
+    const _: () = assert!(mem::size_of::<T>() % 2 == 0);
+}
+
+fn main() {
+    let _ = Unit;
+    let _ = Generic([0u8; 3]);
+}
+
+trait CfgTrait {
+    #[cfg(any())]
+    const _: () = ();
+}
+
+impl CfgTrait for Unit {
+    #[cfg(any())]
+    const _: () = ();
+}

--- a/tests/ui/feature-gates/feature-gate-associated-const-underscore.rs
+++ b/tests/ui/feature-gates/feature-gate-associated-const-underscore.rs
@@ -1,0 +1,10 @@
+struct Thing {}
+
+impl Thing {
+    const _: () = {};
+    //~^ ERROR: naming associated constants with `_` is unstable [E0658]
+}
+
+fn main() {
+    let _ = Thing {};
+}

--- a/tests/ui/feature-gates/feature-gate-associated-const-underscore.stderr
+++ b/tests/ui/feature-gates/feature-gate-associated-const-underscore.stderr
@@ -1,0 +1,13 @@
+error[E0658]: naming associated constants with `_` is unstable
+  --> $DIR/feature-gate-associated-const-underscore.rs:4:11
+   |
+LL |     const _: () = {};
+   |           ^
+   |
+   = note: see issue #158944 <https://github.com/rust-lang/rust/issues/158944> for more information
+   = help: add `#![feature(associated_const_underscore)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/parser/assoc/assoc-const-underscore-semantic-fail.rs
+++ b/tests/ui/parser/assoc/assoc-const-underscore-semantic-fail.rs
@@ -1,5 +1,4 @@
-// Semantically, an associated constant cannot use `_` as a name.
-
+// Semantically, a trait/trait impl associated constant cannot use _ as a name.
 fn main() {}
 
 const _: () = {
@@ -9,9 +8,5 @@ const _: () = {
     impl A for () {
         const _: () = (); //~ ERROR `const` items in this context need a name
         //~^ ERROR const `_` is not a member of trait `A`
-    }
-    struct B;
-    impl B {
-        const _: () = (); //~ ERROR `const` items in this context need a name
     }
 };

--- a/tests/ui/parser/assoc/assoc-const-underscore-semantic-fail.stderr
+++ b/tests/ui/parser/assoc/assoc-const-underscore-semantic-fail.stderr
@@ -1,27 +1,21 @@
 error: `const` items in this context need a name
-  --> $DIR/assoc-const-underscore-semantic-fail.rs:7:15
+  --> $DIR/assoc-const-underscore-semantic-fail.rs:6:15
    |
 LL |         const _: () = ();
    |               ^ `_` is not a valid name for this `const` item
 
 error: `const` items in this context need a name
-  --> $DIR/assoc-const-underscore-semantic-fail.rs:10:15
-   |
-LL |         const _: () = ();
-   |               ^ `_` is not a valid name for this `const` item
-
-error: `const` items in this context need a name
-  --> $DIR/assoc-const-underscore-semantic-fail.rs:15:15
+  --> $DIR/assoc-const-underscore-semantic-fail.rs:9:15
    |
 LL |         const _: () = ();
    |               ^ `_` is not a valid name for this `const` item
 
 error[E0438]: const `_` is not a member of trait `A`
-  --> $DIR/assoc-const-underscore-semantic-fail.rs:10:9
+  --> $DIR/assoc-const-underscore-semantic-fail.rs:9:9
    |
 LL |         const _: () = ();
    |         ^^^^^^^^^^^^^^^^^ not a member of trait `A`
 
-error: aborting due to 4 previous errors
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0438`.


### PR DESCRIPTION
This PR doesn't change the current behavior of the `dead_code` lint for unused associated consts with underscore-prefixed names and treats associated consts named `_` consistently.

There might still be some places that should've been changed to use `named_items()` instead of `in_definition_order()`, though I'm not quite sure.

Unresolved questions:
- Whether to lint `impl Private { pub const _: Private = Private; }`, where the visibility qualifier here has no effect. It seems like there wasn't any disagreement on linting this, though what's proposed in the RFC currently diverges from that: [RFC: Associated const underscore](https://github.com/dtolnay/rfcs/blob/assocunderscore/text/0000-associated-const-underscore.md#reference-level-explanation).

Tracking:
- https://github.com/rust-lang/rust/issues/158944