### PR TITLE
Preparatory changes for macro parsing BFS->DFS

### DIFF
--- a/compiler/rustc_ast/src/token.rs
+++ b/compiler/rustc_ast/src/token.rs
@@ -699,7 +699,7 @@ impl Token {
 
     /// Returns `true` if the token can appear at the start of a pattern.
     ///
-    /// Shamelessly borrowed from `can_begin_expr`, only used for diagnostics right now.
+    /// Shamelessly borrowed from `can_begin_expr`.
     pub fn can_begin_pattern(&self, pat_kind: NtPatKind) -> bool {
         match &self.uninterpolate().kind {
             // box, ref, mut, and other identifiers (can stricten)

--- a/compiler/rustc_expand/src/mbe/diagnostics.rs
+++ b/compiler/rustc_expand/src/mbe/diagnostics.rs
@@ -148,6 +148,12 @@ pub(super) fn failed_to_match_macro(
 struct CollectTrackerAndEmitter<'dcx, 'matcher> {
     macro_name: Ident,
     dcx: DiagCtxtHandle<'dcx>,
+
+    /// The matcher currently being parsed.
+    //
+    // FIXME: Factor out a per-arm `Tracker` so that the `Option` is unnecessary.
+    current: Option<WhichMatcher>,
+
     remaining_matcher: Option<&'matcher MatcherLoc>,
     /// Which arm's failure should we report? (the one furthest along)
     best_failure: Option<BestFailure>,
@@ -179,6 +185,14 @@ impl BestFailure {
 impl<'dcx, 'matcher> Tracker<'matcher> for CollectTrackerAndEmitter<'dcx, 'matcher> {
     type Failure = (Token, u32, &'static str);
 
+    fn prepare(&mut self, which_matcher: WhichMatcher) {
+        if self.current.is_some() {
+            bug!("`Self::after_arm()` was not called to clean up context");
+        }
+
+        self.current = Some(which_matcher);
+    }
+
     fn build_failure(tok: Token, position: u32, msg: &'static str) -> Self::Failure {
         (tok, position, msg)
     }
@@ -191,7 +205,11 @@ impl<'dcx, 'matcher> Tracker<'matcher> for CollectTrackerAndEmitter<'dcx, 'match
         }
     }
 
-    fn after_arm(&mut self, which_matcher: WhichMatcher, result: &NamedParseResult<Self::Failure>) {
+    fn after_arm(&mut self, result: &NamedParseResult<Self::Failure>) {
+        let Some(which_matcher) = self.current else {
+            bug!("`Self::prepare()` was not called to initialize context");
+        };
+
         match *result {
             Success(_) => {
                 // Nonterminal parser recovery might turn failed matches into successful ones,
@@ -226,6 +244,8 @@ impl<'dcx, 'matcher> Tracker<'matcher> for CollectTrackerAndEmitter<'dcx, 'match
             }
             ErrorReported(guar) => self.result = Some((self.root_span, guar)),
         }
+
+        self.current = None;
     }
 
     fn ambiguity(
@@ -281,6 +301,7 @@ impl<'dcx> CollectTrackerAndEmitter<'dcx, '_> {
         Self {
             macro_name,
             dcx,
+            current: None,
             remaining_matcher: None,
             best_failure: None,
             root_span,

--- a/compiler/rustc_expand/src/mbe/diagnostics.rs
+++ b/compiler/rustc_expand/src/mbe/diagnostics.rs
@@ -221,7 +221,7 @@ impl<'dcx, 'matcher> Tracker<'matcher> for CollectTrackerAndEmitter<'dcx, 'match
             }
             Ambiguity => {
                 if self.result.is_none() {
-                    bug!("`Error(..)` is only constructed through `Self::ambiguity()`");
+                    bug!("An ambiguity error occurred but `Self::ambiguity()` was not called");
                 }
             }
             ErrorReported(guar) => self.result = Some((self.root_span, guar)),

--- a/compiler/rustc_expand/src/mbe/diagnostics.rs
+++ b/compiler/rustc_expand/src/mbe/diagnostics.rs
@@ -183,8 +183,6 @@ impl BestFailure {
 }
 
 impl<'dcx, 'matcher> Tracker<'matcher> for CollectTrackerAndEmitter<'dcx, 'matcher> {
-    type Failure = (Token, u32, &'static str);
-
     fn prepare(&mut self, which_matcher: WhichMatcher) {
         if self.current.is_some() {
             bug!("`Self::after_arm()` was not called to clean up context");
@@ -201,7 +199,7 @@ impl<'dcx, 'matcher> Tracker<'matcher> for CollectTrackerAndEmitter<'dcx, 'match
         }
     }
 
-    fn after_arm(&mut self, result: &NamedParseResult<Self::Failure>) {
+    fn after_arm(&mut self, result: &NamedParseResult) {
         match *result {
             Success(_) => {
                 // Nonterminal parser recovery might turn failed matches into successful ones,
@@ -211,7 +209,7 @@ impl<'dcx, 'matcher> Tracker<'matcher> for CollectTrackerAndEmitter<'dcx, 'match
                     "should not collect detailed info for successful macro match",
                 );
             }
-            Failure(_) => {
+            Failure => {
                 if self.best_failure.is_none() {
                     bug!("A matching failure occurred but `Self::failure()` was not called");
                 }
@@ -227,7 +225,7 @@ impl<'dcx, 'matcher> Tracker<'matcher> for CollectTrackerAndEmitter<'dcx, 'match
         self.current = None;
     }
 
-    fn failure(&mut self, token: Token, approx_position: u32, msg: &'static str) -> Self::Failure {
+    fn failure(&mut self, token: Token, approx_position: u32, msg: &'static str) {
         let Some(which_matcher) = self.current else {
             bug!("`Self::prepare()` was not called to initialize context");
         };
@@ -250,8 +248,6 @@ impl<'dcx, 'matcher> Tracker<'matcher> for CollectTrackerAndEmitter<'dcx, 'match
                     .clone(),
             })
         }
-
-        (token, approx_position, msg)
     }
 
     fn ambiguity(

--- a/compiler/rustc_expand/src/mbe/diagnostics.rs
+++ b/compiler/rustc_expand/src/mbe/diagnostics.rs
@@ -193,10 +193,6 @@ impl<'dcx, 'matcher> Tracker<'matcher> for CollectTrackerAndEmitter<'dcx, 'match
         self.current = Some(which_matcher);
     }
 
-    fn build_failure(tok: Token, position: u32, msg: &'static str) -> Self::Failure {
-        (tok, position, msg)
-    }
-
     fn before_match_loc(&mut self, parser: &TtParser, matcher: &'matcher MatcherLoc) {
         if self.remaining_matcher.is_none()
             || (parser.has_no_remaining_items_for_step() && *matcher != MatcherLoc::Eof)
@@ -206,10 +202,6 @@ impl<'dcx, 'matcher> Tracker<'matcher> for CollectTrackerAndEmitter<'dcx, 'match
     }
 
     fn after_arm(&mut self, result: &NamedParseResult<Self::Failure>) {
-        let Some(which_matcher) = self.current else {
-            bug!("`Self::prepare()` was not called to initialize context");
-        };
-
         match *result {
             Success(_) => {
                 // Nonterminal parser recovery might turn failed matches into successful ones,
@@ -219,22 +211,9 @@ impl<'dcx, 'matcher> Tracker<'matcher> for CollectTrackerAndEmitter<'dcx, 'match
                     "should not collect detailed info for successful macro match",
                 );
             }
-            Failure((token, approx_position, msg)) => {
-                debug!(?token, ?msg, "a new failure of an arm");
-
-                if self.best_failure.as_ref().is_none_or(|failure| {
-                    failure.is_better_position(which_matcher, approx_position)
-                }) {
-                    self.best_failure = Some(BestFailure {
-                        token,
-                        matcher: which_matcher,
-                        position: approx_position,
-                        msg,
-                        remaining_matcher: self
-                            .remaining_matcher
-                            .expect("must have collected matcher already")
-                            .clone(),
-                    })
+            Failure(_) => {
+                if self.best_failure.is_none() {
+                    bug!("A matching failure occurred but `Self::failure()` was not called");
                 }
             }
             Ambiguity => {
@@ -246,6 +225,33 @@ impl<'dcx, 'matcher> Tracker<'matcher> for CollectTrackerAndEmitter<'dcx, 'match
         }
 
         self.current = None;
+    }
+
+    fn failure(&mut self, token: Token, approx_position: u32, msg: &'static str) -> Self::Failure {
+        let Some(which_matcher) = self.current else {
+            bug!("`Self::prepare()` was not called to initialize context");
+        };
+
+        debug!(?token, ?msg, "a new failure of an arm");
+
+        if self
+            .best_failure
+            .as_ref()
+            .is_none_or(|failure| failure.is_better_position(which_matcher, approx_position))
+        {
+            self.best_failure = Some(BestFailure {
+                token,
+                matcher: which_matcher,
+                position: approx_position,
+                msg,
+                remaining_matcher: self
+                    .remaining_matcher
+                    .expect("must have collected matcher already")
+                    .clone(),
+            })
+        }
+
+        (token, approx_position, msg)
     }
 
     fn ambiguity(

--- a/compiler/rustc_expand/src/mbe/diagnostics.rs
+++ b/compiler/rustc_expand/src/mbe/diagnostics.rs
@@ -230,18 +230,16 @@ impl<'dcx, 'matcher> Tracker<'matcher> for CollectTrackerAndEmitter<'dcx, 'match
             bug!("`Self::prepare()` was not called to initialize context");
         };
 
-        let token = &parser.token;
-        let (token, approx_position, msg) = if *token == token::Eof {
-            (
-                Token::new(
-                    token::Eof,
-                    if token.span.is_dummy() { token.span } else { token.span.shrink_to_hi() },
-                ),
-                parser.approx_token_stream_pos(),
-                "missing tokens in macro arguments",
-            )
+        let mut token = parser.token;
+        let approx_position = parser.approx_token_stream_pos();
+        let msg = if token.kind == token::Eof {
+            // FIXME: Can this be factored out of the EOF case?
+            if !token.span.is_dummy() {
+                token.span = token.span.shrink_to_hi();
+            }
+            "missing tokens in macro arguments"
         } else {
-            (*token, parser.approx_token_stream_pos(), "no rules expected this token in macro call")
+            "no rules expected this token in macro call"
         };
 
         debug!(?token, ?msg, "a new failure of an arm");

--- a/compiler/rustc_expand/src/mbe/diagnostics.rs
+++ b/compiler/rustc_expand/src/mbe/diagnostics.rs
@@ -225,9 +225,23 @@ impl<'dcx, 'matcher> Tracker<'matcher> for CollectTrackerAndEmitter<'dcx, 'match
         self.current = None;
     }
 
-    fn failure(&mut self, token: Token, approx_position: u32, msg: &'static str) {
+    fn failure(&mut self, parser: &Parser<'_>) {
         let Some(which_matcher) = self.current else {
             bug!("`Self::prepare()` was not called to initialize context");
+        };
+
+        let token = &parser.token;
+        let (token, approx_position, msg) = if *token == token::Eof {
+            (
+                Token::new(
+                    token::Eof,
+                    if token.span.is_dummy() { token.span } else { token.span.shrink_to_hi() },
+                ),
+                parser.approx_token_stream_pos(),
+                "missing tokens in macro arguments",
+            )
+        } else {
+            (*token, parser.approx_token_stream_pos(), "no rules expected this token in macro call")
         };
 
         debug!(?token, ?msg, "a new failure of an arm");

--- a/compiler/rustc_expand/src/mbe/macro_parser.rs
+++ b/compiler/rustc_expand/src/mbe/macro_parser.rs
@@ -470,119 +470,15 @@ impl TtParser {
     ) -> Option<NamedParseResult> {
         // Matcher positions that would be valid if the macro invocation was over now. Only
         // modified if `token == Eof`.
-        let token = &parser.token;
         let mut eof_mps = SmallVec::<[MatcherPos; 1]>::new();
 
-        while let Some(mut mp) = self.cur_mps.pop() {
-            let matcher_loc = &matcher[mp.idx];
-            track.before_match_loc(self, matcher_loc);
-
-            match matcher_loc {
-                MatcherLoc::Token { token: t } => {
-                    // If it's a doc comment, we just ignore it and move on to the next tt in the
-                    // matcher. This is a bug, but #95267 showed that existing programs rely on
-                    // this behaviour, and changing it would require some care and a transition
-                    // period.
-                    //
-                    // If the token matches, we can just advance the parser.
-                    //
-                    // Otherwise, this match has failed, there is nothing to do, and hopefully
-                    // another mp in `cur_mps` will match.
-                    if matches!(t, Token { kind: DocComment(..), .. }) {
-                        mp.idx += 1;
-                        self.cur_mps.push(mp);
-                    } else if token_name_eq(t, token) {
-                        mp.idx += 1;
-                        self.next_mps.push(mp);
-                    }
-                }
-                MatcherLoc::Delimited => {
-                    // Entering the delimiter is trivial.
-                    mp.idx += 1;
-                    self.cur_mps.push(mp);
-                }
-                &MatcherLoc::Sequence {
-                    op,
-                    num_metavar_decls,
-                    idx_first_after,
-                    next_metavar,
-                    seq_depth,
-                } => {
-                    // Install an empty vec for each metavar within the sequence.
-                    for metavar_idx in next_metavar..next_metavar + num_metavar_decls {
-                        mp.push_match(metavar_idx, seq_depth, MatchedSeq(vec![]));
-                    }
-
-                    if matches!(op, KleeneOp::ZeroOrMore | KleeneOp::ZeroOrOne) {
-                        // Try zero matches of this sequence, by skipping over it.
-                        self.cur_mps.push(MatcherPos {
-                            idx: idx_first_after,
-                            matches: Rc::clone(&mp.matches),
-                        });
-                    }
-
-                    // Try one or more matches of this sequence, by entering it.
-                    mp.idx += 1;
-                    self.cur_mps.push(mp);
-                }
-                &MatcherLoc::SequenceKleeneOpNoSep { op, idx_first } => {
-                    // We are past the end of a sequence with no separator. Try ending the
-                    // sequence. If that's not possible, `ending_mp` will fail quietly when it is
-                    // processed next time around the loop.
-                    let ending_mp = MatcherPos {
-                        idx: mp.idx + 1, // +1 skips the Kleene op
-                        matches: Rc::clone(&mp.matches),
-                    };
-                    self.cur_mps.push(ending_mp);
-
-                    if op != KleeneOp::ZeroOrOne {
-                        // Try another repetition.
-                        mp.idx = idx_first;
-                        self.cur_mps.push(mp);
-                    }
-                }
-                MatcherLoc::SequenceSep { separator } => {
-                    // We are past the end of a sequence with a separator but we haven't seen the
-                    // separator yet. Try ending the sequence. If that's not possible, `ending_mp`
-                    // will fail quietly when it is processed next time around the loop.
-                    let ending_mp = MatcherPos {
-                        idx: mp.idx + 2, // +2 skips the separator and the Kleene op
-                        matches: Rc::clone(&mp.matches),
-                    };
-                    self.cur_mps.push(ending_mp);
-
-                    if token_name_eq(token, separator) {
-                        // The separator matches the current token. Advance past it.
-                        mp.idx += 1;
-                        self.next_mps.push(mp);
-                    }
-                }
-                &MatcherLoc::SequenceKleeneOpAfterSep { idx_first } => {
-                    // We are past the sequence separator. This can't be a `?` Kleene op, because
-                    // they don't permit separators. Try another repetition.
-                    mp.idx = idx_first;
-                    self.cur_mps.push(mp);
-                }
-                &MatcherLoc::MetaVarDecl { kind, .. } => {
-                    // Built-in nonterminals never start with these tokens, so we can eliminate
-                    // them from consideration. We use the span of the metavariable declaration
-                    // to determine any edition-specific matching behavior for non-terminals.
-                    if Parser::nonterminal_may_begin_with(kind, token) {
-                        self.bb_mps.push(mp);
-                    }
-                }
-                MatcherLoc::Eof => {
-                    // We are past the matcher's end, and not in a sequence. Try to end things.
-                    debug_assert_eq!(mp.idx, matcher.len() - 1);
-                    if *token == token::Eof {
-                        eof_mps.push(mp);
-                    }
-                }
-            }
+        while let Some(mp) = self.cur_mps.pop() {
+            self.match_one(parser, matcher, mp, track, &mut eof_mps);
         }
 
         // If we reached the end of input, check that there is EXACTLY ONE possible matcher.
         // Otherwise, either the parse is ambiguous (which is an error) or there is a syntax error.
+        let token = &parser.token;
         if *token == token::Eof {
             assert!(self.next_mps.is_empty());
             assert!(self.bb_mps.is_empty());
@@ -601,6 +497,121 @@ impl TtParser {
             })
         } else {
             None
+        }
+    }
+
+    /// Match a single [`MatcherPos`].
+    #[inline(always)] // must be inlined in `parse_tt_inner()`
+    fn match_one<'matcher, T: Tracker<'matcher>>(
+        &mut self,
+        parser: &Parser<'_>,
+        matcher: &'matcher [MatcherLoc],
+        mut mp: MatcherPos,
+        track: &mut T,
+        eof_mps: &mut SmallVec<[MatcherPos; 1]>,
+    ) {
+        let matcher_loc = &matcher[mp.idx];
+        track.before_match_loc(self, matcher_loc);
+        let token = &parser.token;
+
+        match matcher_loc {
+            MatcherLoc::Token { token: t } => {
+                // If it's a doc comment, we just ignore it and move on to the next tt in the
+                // matcher. This is a bug, but #95267 showed that existing programs rely on this
+                // behaviour, and changing it would require some care and a transition period.
+                //
+                // If the token matches, we can just advance the parser.
+                //
+                // Otherwise, this match has failed, there is nothing to do, and hopefully another
+                // mp in `cur_mps` will match.
+                if matches!(t, Token { kind: DocComment(..), .. }) {
+                    mp.idx += 1;
+                    self.cur_mps.push(mp);
+                } else if token_name_eq(t, token) {
+                    mp.idx += 1;
+                    self.next_mps.push(mp);
+                }
+            }
+            MatcherLoc::Delimited => {
+                // Entering the delimiter is trivial.
+                mp.idx += 1;
+                self.cur_mps.push(mp);
+            }
+            &MatcherLoc::Sequence {
+                op,
+                num_metavar_decls,
+                idx_first_after,
+                next_metavar,
+                seq_depth,
+            } => {
+                // Install an empty vec for each metavar within the sequence.
+                for metavar_idx in next_metavar..next_metavar + num_metavar_decls {
+                    mp.push_match(metavar_idx, seq_depth, MatchedSeq(vec![]));
+                }
+
+                if matches!(op, KleeneOp::ZeroOrMore | KleeneOp::ZeroOrOne) {
+                    // Try zero matches of this sequence, by skipping over it.
+                    self.cur_mps
+                        .push(MatcherPos { idx: idx_first_after, matches: Rc::clone(&mp.matches) });
+                }
+
+                // Try one or more matches of this sequence, by entering it.
+                mp.idx += 1;
+                self.cur_mps.push(mp);
+            }
+            &MatcherLoc::SequenceKleeneOpNoSep { op, idx_first } => {
+                // We are past the end of a sequence with no separator. Try ending the sequence. If
+                // that's not possible, `ending_mp` will fail quietly when it is processed next time
+                // around the loop.
+                let ending_mp = MatcherPos {
+                    idx: mp.idx + 1, // +1 skips the Kleene op
+                    matches: Rc::clone(&mp.matches),
+                };
+                self.cur_mps.push(ending_mp);
+
+                if op != KleeneOp::ZeroOrOne {
+                    // Try another repetition.
+                    mp.idx = idx_first;
+                    self.cur_mps.push(mp);
+                }
+            }
+            MatcherLoc::SequenceSep { separator } => {
+                // We are past the end of a sequence with a separator but we haven't seen the
+                // separator yet. Try ending the sequence. If that's not possible, `ending_mp` will
+                // fail quietly when it is processed next time around the loop.
+                let ending_mp = MatcherPos {
+                    idx: mp.idx + 2, // +2 skips the separator and the Kleene op
+                    matches: Rc::clone(&mp.matches),
+                };
+                self.cur_mps.push(ending_mp);
+
+                if token_name_eq(token, separator) {
+                    // The separator matches the current token. Advance past it.
+                    mp.idx += 1;
+                    self.next_mps.push(mp);
+                }
+            }
+            &MatcherLoc::SequenceKleeneOpAfterSep { idx_first } => {
+                // We are past the sequence separator. This can't be a `?` Kleene op, because they
+                // don't permit separators. Try another repetition.
+                mp.idx = idx_first;
+                self.cur_mps.push(mp);
+            }
+            &MatcherLoc::MetaVarDecl { kind, .. } => {
+                // Built-in nonterminals never start with these tokens, so we can eliminate them
+                // from consideration. We use the span of the metavariable declaration to determine
+                // any edition-specific matching behavior for non-terminals.
+                if Parser::nonterminal_may_begin_with(kind, token) {
+                    self.bb_mps.push(mp);
+                }
+            }
+            MatcherLoc::Eof => {
+                // We are past the matcher's end, and not in a sequence. Try to end things.
+                debug_assert_eq!(mp.idx, matcher.len() - 1);
+                if *token == token::Eof {
+                    eof_mps.push(mp);
+                }
+            }
         }
     }
 

--- a/compiler/rustc_expand/src/mbe/macro_parser.rs
+++ b/compiler/rustc_expand/src/mbe/macro_parser.rs
@@ -302,6 +302,8 @@ pub(crate) enum ParseResult<T, F> {
     /// The usize is the approximate position of the token in the input token stream.
     Failure(F),
     /// The input could be parsed in multiple distinct ways.
+    ///
+    /// [`Tracker::ambiguity()`] will be called beforehand.
     Ambiguity,
     ErrorReported(ErrorGuaranteed),
 }

--- a/compiler/rustc_expand/src/mbe/macro_parser.rs
+++ b/compiler/rustc_expand/src/mbe/macro_parser.rs
@@ -589,10 +589,8 @@ impl TtParser {
 
             Some(match *eof_mps {
                 [_] => {
-                    let mut eof_mp = eof_mps.pop().unwrap();
-                    // Need to take ownership of the matches from within the `Rc`.
-                    Rc::make_mut(&mut eof_mp.matches);
-                    let matches = Rc::try_unwrap(eof_mp.matches).unwrap().into_iter();
+                    let eof_mp = eof_mps.pop().unwrap();
+                    let matches = Rc::unwrap_or_clone(eof_mp.matches).into_iter();
                     Success(self.nameize(matcher, matches))
                 }
                 [] => {

--- a/compiler/rustc_expand/src/mbe/macro_parser.rs
+++ b/compiler/rustc_expand/src/mbe/macro_parser.rs
@@ -592,7 +592,7 @@ impl TtParser {
                     let matches = Rc::try_unwrap(eof_mp.matches).unwrap().into_iter();
                     Success(self.nameize(matcher, matches))
                 }
-                [] => Failure(T::build_failure(
+                [] => Failure(track.failure(
                     Token::new(
                         token::Eof,
                         if token.span.is_dummy() { token.span } else { token.span.shrink_to_hi() },
@@ -642,7 +642,7 @@ impl TtParser {
                 (0, 0) => {
                     // There are no possible next positions AND we aren't waiting for the black-box
                     // parser: syntax error.
-                    return Failure(T::build_failure(
+                    return Failure(track.failure(
                         parser.token,
                         parser.approx_token_stream_pos(),
                         "no rules expected this token in macro call",

--- a/compiler/rustc_expand/src/mbe/macro_parser.rs
+++ b/compiler/rustc_expand/src/mbe/macro_parser.rs
@@ -593,18 +593,7 @@ impl TtParser {
                     Success(self.nameize(matcher, matches))
                 }
                 [] => {
-                    track.failure(
-                        Token::new(
-                            token::Eof,
-                            if token.span.is_dummy() {
-                                token.span
-                            } else {
-                                token.span.shrink_to_hi()
-                            },
-                        ),
-                        parser.approx_token_stream_pos(),
-                        "missing tokens in macro arguments",
-                    );
+                    track.failure(parser);
                     Failure
                 }
                 _ => self.ambiguity_error(parser, matcher, track),
@@ -649,11 +638,7 @@ impl TtParser {
                 (0, 0) => {
                     // There are no possible next positions AND we aren't waiting for the black-box
                     // parser: syntax error.
-                    track.failure(
-                        parser.token,
-                        parser.approx_token_stream_pos(),
-                        "no rules expected this token in macro call",
-                    );
+                    track.failure(parser);
                     return Failure;
                 }
 

--- a/compiler/rustc_expand/src/mbe/macro_parser.rs
+++ b/compiler/rustc_expand/src/mbe/macro_parser.rs
@@ -294,13 +294,13 @@ impl MatcherPos {
 
 /// Represents the possible results of an attempted parse.
 #[derive(Debug)]
-pub(crate) enum ParseResult<T, F> {
+pub(crate) enum ParseResult<T> {
     /// Parsed successfully.
     Success(T),
-    /// Arm failed to match. If the second parameter is `token::Eof`, it indicates an unexpected
-    /// end of macro invocation. Otherwise, it indicates that no rules expected the given token.
-    /// The usize is the approximate position of the token in the input token stream.
-    Failure(F),
+    /// Arm failed to match.
+    ///
+    /// [`Tracker::failure()`] will be called beforehand.
+    Failure,
     /// The input could be parsed in multiple distinct ways.
     ///
     /// [`Tracker::ambiguity()`] will be called beforehand.
@@ -311,7 +311,7 @@ pub(crate) enum ParseResult<T, F> {
 /// A `ParseResult` where the `Success` variant contains a mapping of
 /// `MacroRulesNormalizedIdent`s to `NamedMatch`es. This represents the mapping
 /// of metavars to the token trees they bind to.
-pub(crate) type NamedParseResult<F> = ParseResult<NamedMatches, F>;
+pub(crate) type NamedParseResult = ParseResult<NamedMatches>;
 
 /// Contains a mapping of `MacroRulesNormalizedIdent`s to `NamedMatch`es.
 /// This represents the mapping of metavars to the token trees they bind to.
@@ -467,7 +467,7 @@ impl TtParser {
         parser: &Parser<'_>,
         matcher: &'matcher [MatcherLoc],
         track: &mut T,
-    ) -> Option<NamedParseResult<T::Failure>> {
+    ) -> Option<NamedParseResult> {
         // Matcher positions that would be valid if the macro invocation was over now. Only
         // modified if `token == Eof`.
         let token = &parser.token;
@@ -592,14 +592,21 @@ impl TtParser {
                     let matches = Rc::try_unwrap(eof_mp.matches).unwrap().into_iter();
                     Success(self.nameize(matcher, matches))
                 }
-                [] => Failure(track.failure(
-                    Token::new(
-                        token::Eof,
-                        if token.span.is_dummy() { token.span } else { token.span.shrink_to_hi() },
-                    ),
-                    parser.approx_token_stream_pos(),
-                    "missing tokens in macro arguments",
-                )),
+                [] => {
+                    track.failure(
+                        Token::new(
+                            token::Eof,
+                            if token.span.is_dummy() {
+                                token.span
+                            } else {
+                                token.span.shrink_to_hi()
+                            },
+                        ),
+                        parser.approx_token_stream_pos(),
+                        "missing tokens in macro arguments",
+                    );
+                    Failure
+                }
                 _ => self.ambiguity_error(parser, matcher, track),
             })
         } else {
@@ -613,7 +620,7 @@ impl TtParser {
         parser: &mut Cow<'_, Parser<'_>>,
         matcher: &'matcher [MatcherLoc],
         track: &mut T,
-    ) -> NamedParseResult<T::Failure> {
+    ) -> NamedParseResult {
         // A queue of possible matcher positions. We initialize it with the matcher position in
         // which the "dot" is before the first token of the first token tree in `matcher`.
         // `parse_tt_inner` then processes all of these possible matcher positions and produces
@@ -642,11 +649,12 @@ impl TtParser {
                 (0, 0) => {
                     // There are no possible next positions AND we aren't waiting for the black-box
                     // parser: syntax error.
-                    return Failure(track.failure(
+                    track.failure(
                         parser.token,
                         parser.approx_token_stream_pos(),
                         "no rules expected this token in macro call",
-                    ));
+                    );
+                    return Failure;
                 }
 
                 (_, 0) => {
@@ -686,7 +694,7 @@ impl TtParser {
         }
     }
 
-    fn nt_parsing_error<F>(&self, loc: &MatcherLoc, err: Diag<'_>) -> NamedParseResult<F> {
+    fn nt_parsing_error(&self, loc: &MatcherLoc, err: Diag<'_>) -> NamedParseResult {
         let &MatcherLoc::MetaVarDecl { span, kind, .. } = loc else { unreachable!() };
         let guarantee = err
             .with_span_label(
@@ -702,7 +710,7 @@ impl TtParser {
         parser: &Parser<'_>,
         matcher: &'matcher [MatcherLoc],
         track: &mut T,
-    ) -> NamedParseResult<T::Failure> {
+    ) -> NamedParseResult {
         // Use a reasonable and deterministic ordering for data in the error message.
         self.bb_mps.sort_unstable_by_key(|mp| mp.idx);
         self.next_mps.sort_unstable_by_key(|mp| mp.idx);

--- a/compiler/rustc_expand/src/mbe/macro_parser.rs
+++ b/compiler/rustc_expand/src/mbe/macro_parser.rs
@@ -584,6 +584,9 @@ impl TtParser {
         // If we reached the end of input, check that there is EXACTLY ONE possible matcher.
         // Otherwise, either the parse is ambiguous (which is an error) or there is a syntax error.
         if *token == token::Eof {
+            assert!(self.next_mps.is_empty());
+            assert!(self.bb_mps.is_empty());
+
             Some(match *eof_mps {
                 [_] => {
                     let mut eof_mp = eof_mps.pop().unwrap();

--- a/compiler/rustc_expand/src/mbe/macro_rules.rs
+++ b/compiler/rustc_expand/src/mbe/macro_rules.rs
@@ -376,7 +376,7 @@ pub(super) trait Tracker<'matcher> {
     /// indicates that no rules in the arm expected the given token.
     ///
     /// The parser will return [`NamedParseResult::Failure`] after calling this.
-    fn failure(&mut self, token: Token, approx_position: u32, msg: &'static str);
+    fn failure(&mut self, parser: &Parser<'_>);
 
     /// An ambiguity error occurred.
     ///
@@ -413,7 +413,7 @@ impl<'matcher> Tracker<'matcher> for NoopTracker {
 
     fn after_arm(&mut self, _result: &NamedParseResult) {}
 
-    fn failure(&mut self, _token: Token, _approx_position: u32, _msg: &'static str) {}
+    fn failure(&mut self, _parser: &Parser<'_>) {}
 
     fn description() -> &'static str {
         "none"

--- a/compiler/rustc_expand/src/mbe/macro_rules.rs
+++ b/compiler/rustc_expand/src/mbe/macro_rules.rs
@@ -359,9 +359,6 @@ fn trace_macros_note(cx_expansions: &mut FxIndexMap<Span, Vec<String>>, sp: Span
 }
 
 pub(super) trait Tracker<'matcher> {
-    /// The contents of `ParseResult::Failure`.
-    type Failure;
-
     /// Provide context on the arm that's about to be matched.
     fn prepare(&mut self, which_matcher: WhichMatcher);
 
@@ -370,7 +367,7 @@ pub(super) trait Tracker<'matcher> {
 
     /// This is called after an arm has been parsed, either successfully or unsuccessfully. When
     /// this is called, `before_match_loc` was called at least once (with a `MatcherLoc::Eof`).
-    fn after_arm(&mut self, result: &NamedParseResult<Self::Failure>);
+    fn after_arm(&mut self, result: &NamedParseResult);
 
     /// The arm could not be matched successfully.
     ///
@@ -379,7 +376,7 @@ pub(super) trait Tracker<'matcher> {
     /// indicates that no rules in the arm expected the given token.
     ///
     /// The parser will return [`NamedParseResult::Failure`] after calling this.
-    fn failure(&mut self, token: Token, approx_position: u32, msg: &'static str) -> Self::Failure;
+    fn failure(&mut self, token: Token, approx_position: u32, msg: &'static str);
 
     /// An ambiguity error occurred.
     ///
@@ -402,8 +399,6 @@ pub(super) trait Tracker<'matcher> {
 pub(super) struct NoopTracker;
 
 impl<'matcher> Tracker<'matcher> for NoopTracker {
-    type Failure = ();
-
     fn prepare(&mut self, _which_matcher: WhichMatcher) {}
 
     fn before_match_loc(&mut self, _parser: &TtParser, _matcher: &'matcher MatcherLoc) {}
@@ -416,15 +411,9 @@ impl<'matcher> Tracker<'matcher> for NoopTracker {
     ) {
     }
 
-    fn after_arm(&mut self, _result: &NamedParseResult<Self::Failure>) {}
+    fn after_arm(&mut self, _result: &NamedParseResult) {}
 
-    fn failure(
-        &mut self,
-        _token: Token,
-        _approx_position: u32,
-        _msg: &'static str,
-    ) -> Self::Failure {
-    }
+    fn failure(&mut self, _token: Token, _approx_position: u32, _msg: &'static str) {}
 
     fn description() -> &'static str {
         "none"
@@ -661,7 +650,7 @@ pub(super) fn try_match_macro<'matcher, T: Tracker<'matcher>>(
 
                 return Ok((i, rule, named_matches));
             }
-            Failure(_) => {
+            Failure => {
                 trace!("Failed to match arm, trying the next one");
                 // Try the next arm.
             }
@@ -712,7 +701,7 @@ pub(super) fn try_match_macro_attr<'matcher, T: Tracker<'matcher>>(
 
         let mut named_matches = match result {
             Success(named_matches) => named_matches,
-            Failure(_) => {
+            Failure => {
                 mem::swap(&mut gated_spans_snapshot, &mut psess.gated_spans.spans.borrow_mut());
                 continue;
             }
@@ -731,7 +720,7 @@ pub(super) fn try_match_macro_attr<'matcher, T: Tracker<'matcher>>(
                 named_matches.extend(body_named_matches);
                 return Ok((i, rule, named_matches));
             }
-            Failure(_) => {
+            Failure => {
                 mem::swap(&mut gated_spans_snapshot, &mut psess.gated_spans.spans.borrow_mut())
             }
             Ambiguity => return Err(CanRetry::Yes),
@@ -770,7 +759,7 @@ pub(super) fn try_match_macro_derive<'matcher, T: Tracker<'matcher>>(
                 psess.gated_spans.merge(gated_spans_snapshot);
                 return Ok((i, rule, named_matches));
             }
-            Failure(_) => {
+            Failure => {
                 mem::swap(&mut gated_spans_snapshot, &mut psess.gated_spans.spans.borrow_mut())
             }
             Ambiguity => return Err(CanRetry::Yes),

--- a/compiler/rustc_expand/src/mbe/macro_rules.rs
+++ b/compiler/rustc_expand/src/mbe/macro_rules.rs
@@ -365,17 +365,21 @@ pub(super) trait Tracker<'matcher> {
     /// Provide context on the arm that's about to be matched.
     fn prepare(&mut self, which_matcher: WhichMatcher);
 
-    /// Arm failed to match. If the token is `token::Eof`, it indicates an unexpected
-    /// end of macro invocation. Otherwise, it indicates that no rules expected the given token.
-    /// The usize is the approximate position of the token in the input token stream.
-    fn build_failure(tok: Token, position: u32, msg: &'static str) -> Self::Failure;
-
     /// This is called before trying to match next MatcherLoc on the current token.
     fn before_match_loc(&mut self, parser: &TtParser, matcher: &'matcher MatcherLoc);
 
     /// This is called after an arm has been parsed, either successfully or unsuccessfully. When
     /// this is called, `before_match_loc` was called at least once (with a `MatcherLoc::Eof`).
     fn after_arm(&mut self, result: &NamedParseResult<Self::Failure>);
+
+    /// The arm could not be matched successfully.
+    ///
+    /// If the parser is located at [`token::Eof`], it indicates an unexpected end of macro
+    /// invocation. Otherwise, the parser is located at a token in the middle of the input, and it
+    /// indicates that no rules in the arm expected the given token.
+    ///
+    /// The parser will return [`NamedParseResult::Failure`] after calling this.
+    fn failure(&mut self, token: Token, approx_position: u32, msg: &'static str) -> Self::Failure;
 
     /// An ambiguity error occurred.
     ///
@@ -402,8 +406,6 @@ impl<'matcher> Tracker<'matcher> for NoopTracker {
 
     fn prepare(&mut self, _which_matcher: WhichMatcher) {}
 
-    fn build_failure(_tok: Token, _position: u32, _msg: &'static str) -> Self::Failure {}
-
     fn before_match_loc(&mut self, _parser: &TtParser, _matcher: &'matcher MatcherLoc) {}
 
     fn ambiguity(
@@ -415,6 +417,14 @@ impl<'matcher> Tracker<'matcher> for NoopTracker {
     }
 
     fn after_arm(&mut self, _result: &NamedParseResult<Self::Failure>) {}
+
+    fn failure(
+        &mut self,
+        _token: Token,
+        _approx_position: u32,
+        _msg: &'static str,
+    ) -> Self::Failure {
+    }
 
     fn description() -> &'static str {
         "none"

--- a/compiler/rustc_expand/src/mbe/macro_rules.rs
+++ b/compiler/rustc_expand/src/mbe/macro_rules.rs
@@ -374,6 +374,9 @@ pub(super) trait Tracker<'matcher> {
     /// this is called, `before_match_loc` was called at least once (with a `MatcherLoc::Eof`).
     fn after_arm(&mut self, which_matcher: WhichMatcher, result: &NamedParseResult<Self::Failure>);
 
+    /// An ambiguity error occurred.
+    ///
+    /// The parser will return [`NamedParseResult::Ambiguity`] after calling this.
     fn ambiguity(
         &mut self,
         parser: &Parser<'_>,

--- a/compiler/rustc_expand/src/mbe/macro_rules.rs
+++ b/compiler/rustc_expand/src/mbe/macro_rules.rs
@@ -362,6 +362,9 @@ pub(super) trait Tracker<'matcher> {
     /// The contents of `ParseResult::Failure`.
     type Failure;
 
+    /// Provide context on the arm that's about to be matched.
+    fn prepare(&mut self, which_matcher: WhichMatcher);
+
     /// Arm failed to match. If the token is `token::Eof`, it indicates an unexpected
     /// end of macro invocation. Otherwise, it indicates that no rules expected the given token.
     /// The usize is the approximate position of the token in the input token stream.
@@ -372,7 +375,7 @@ pub(super) trait Tracker<'matcher> {
 
     /// This is called after an arm has been parsed, either successfully or unsuccessfully. When
     /// this is called, `before_match_loc` was called at least once (with a `MatcherLoc::Eof`).
-    fn after_arm(&mut self, which_matcher: WhichMatcher, result: &NamedParseResult<Self::Failure>);
+    fn after_arm(&mut self, result: &NamedParseResult<Self::Failure>);
 
     /// An ambiguity error occurred.
     ///
@@ -397,6 +400,8 @@ pub(super) struct NoopTracker;
 impl<'matcher> Tracker<'matcher> for NoopTracker {
     type Failure = ();
 
+    fn prepare(&mut self, _which_matcher: WhichMatcher) {}
+
     fn build_failure(_tok: Token, _position: u32, _msg: &'static str) -> Self::Failure {}
 
     fn before_match_loc(&mut self, _parser: &TtParser, _matcher: &'matcher MatcherLoc) {}
@@ -409,12 +414,7 @@ impl<'matcher> Tracker<'matcher> for NoopTracker {
     ) {
     }
 
-    fn after_arm(
-        &mut self,
-        _which_matcher: WhichMatcher,
-        _result: &NamedParseResult<Self::Failure>,
-    ) {
-    }
+    fn after_arm(&mut self, _result: &NamedParseResult<Self::Failure>) {}
 
     fn description() -> &'static str {
         "none"
@@ -638,9 +638,9 @@ pub(super) fn try_match_macro<'matcher, T: Tracker<'matcher>>(
         // are not recorded. On the first `Success(..)`ful matcher, the spans are merged.
         let mut gated_spans_snapshot = mem::take(&mut *psess.gated_spans.spans.borrow_mut());
 
+        track.prepare(WhichMatcher::FOR_FUNC);
         let result = tt_parser.parse_tt(&mut Cow::Borrowed(&parser), lhs, track);
-
-        track.after_arm(WhichMatcher::FOR_FUNC, &result);
+        track.after_arm(&result);
 
         match result {
             Success(named_matches) => {
@@ -696,8 +696,9 @@ pub(super) fn try_match_macro_attr<'matcher, T: Tracker<'matcher>>(
 
         let mut gated_spans_snapshot = mem::take(&mut *psess.gated_spans.spans.borrow_mut());
 
+        track.prepare(WhichMatcher::Args);
         let result = tt_parser.parse_tt(&mut Cow::Borrowed(&args_parser), args, track);
-        track.after_arm(WhichMatcher::Args, &result);
+        track.after_arm(&result);
 
         let mut named_matches = match result {
             Success(named_matches) => named_matches,
@@ -709,8 +710,9 @@ pub(super) fn try_match_macro_attr<'matcher, T: Tracker<'matcher>>(
             ErrorReported(guar) => return Err(CanRetry::No(guar)),
         };
 
+        track.prepare(WhichMatcher::Body);
         let result = tt_parser.parse_tt(&mut Cow::Borrowed(&body_parser), body, track);
-        track.after_arm(WhichMatcher::Body, &result);
+        track.after_arm(&result);
 
         match result {
             Success(body_named_matches) => {
@@ -749,8 +751,9 @@ pub(super) fn try_match_macro_derive<'matcher, T: Tracker<'matcher>>(
 
         let mut gated_spans_snapshot = mem::take(&mut *psess.gated_spans.spans.borrow_mut());
 
+        track.prepare(WhichMatcher::FOR_DERIVE);
         let result = tt_parser.parse_tt(&mut Cow::Borrowed(&body_parser), body, track);
-        track.after_arm(WhichMatcher::FOR_DERIVE, &result);
+        track.after_arm(&result);
 
         match result {
             Success(named_matches) => {

--- a/compiler/rustc_parse/src/parser/nonterminal.rs
+++ b/compiler/rustc_parse/src/parser/nonterminal.rs
@@ -109,7 +109,7 @@ impl<'a> Parser<'a> {
                 _ => token.is_keyword(kw::If),
             },
             NonterminalKind::TT | NonterminalKind::Item | NonterminalKind::Stmt => {
-                token.kind.close_delim().is_none()
+                token.kind != token::Eof && token.kind.close_delim().is_none()
             }
         }
     }

--- a/tests/ui/macros/metavar-at-eof.rs
+++ b/tests/ui/macros/metavar-at-eof.rs
@@ -1,0 +1,40 @@
+// Test the errors resulting from meta-variables hitting EOF.
+
+#![crate_type = "lib"]
+#![feature(macro_guard_matcher)]
+
+macro_rules! unambig {
+    (item      $x:item      ) => {};
+    (block     $x:block     ) => {};
+    (stmt      $x:stmt      ) => {};
+    (pat       $x:pat       ) => {};
+    (pat_param $x:pat_param ) => {};
+    (expr      $x:expr      ) => {};
+    (expr_2021 $x:expr_2021 ) => {};
+    (ty        $x:ty        ) => {};
+    (ident     $x:ident     ) => {};
+    (lifetime  $x:lifetime  ) => {};
+    (literal   $x:literal   ) => {};
+    (meta      $x:meta      ) => {};
+    (path      $x:path      ) => {};
+    (vis       $x:vis       ) => {};
+    (guard     $x:guard     ) => {};
+    (tt        $x:tt        ) => {};
+}
+
+unambig!(item /* eof */); //~ ERROR unexpected end of macro invocation
+unambig!(block /* eof */); //~ ERROR unexpected end of macro invocation
+unambig!(stmt /* eof */); //~ ERROR unexpected end of macro invocation
+unambig!(pat /* eof */); //~ ERROR unexpected end of macro invocation
+unambig!(pat_param /* eof */); //~ ERROR unexpected end of macro invocation
+unambig!(expr /* eof */); //~ ERROR unexpected end of macro invocation
+unambig!(expr_2021 /* eof */); //~ ERROR unexpected end of macro invocation
+unambig!(ty /* eof */); //~ ERROR unexpected end of macro invocation
+unambig!(ident /* eof */); //~ ERROR unexpected end of macro invocation
+unambig!(lifetime /* eof */); //~ ERROR unexpected end of macro invocation
+unambig!(literal /* eof */); //~ ERROR unexpected end of macro invocation
+unambig!(meta /* eof */); //~ ERROR unexpected end of macro invocation
+unambig!(path /* eof */); //~ ERROR unexpected end of macro invocation
+unambig!(vis /* eof */); //~ ERROR unexpected end of macro invocation
+unambig!(guard /* eof */); //~ ERROR unexpected end of macro invocation
+unambig!(tt /* eof */); //~ ERROR unexpected end of macro invocation

--- a/tests/ui/macros/metavar-at-eof.stderr
+++ b/tests/ui/macros/metavar-at-eof.stderr
@@ -1,0 +1,242 @@
+error: unexpected end of macro invocation
+  --> $DIR/metavar-at-eof.rs:25:14
+   |
+LL | macro_rules! unambig {
+   | -------------------- when calling this macro
+...
+LL | unambig!(item /* eof */);
+   |              ^ missing tokens in macro arguments
+   |
+note: while trying to match meta-variable `$x:item`
+  --> $DIR/metavar-at-eof.rs:7:16
+   |
+LL |     (item      $x:item      ) => {};
+   |                ^^^^^^^
+
+error: unexpected end of macro invocation
+  --> $DIR/metavar-at-eof.rs:26:15
+   |
+LL | macro_rules! unambig {
+   | -------------------- when calling this macro
+...
+LL | unambig!(block /* eof */);
+   |               ^ missing tokens in macro arguments
+   |
+note: while trying to match meta-variable `$x:block`
+  --> $DIR/metavar-at-eof.rs:8:16
+   |
+LL |     (block     $x:block     ) => {};
+   |                ^^^^^^^^
+
+error: unexpected end of macro invocation
+  --> $DIR/metavar-at-eof.rs:27:14
+   |
+LL | macro_rules! unambig {
+   | -------------------- when calling this macro
+...
+LL | unambig!(stmt /* eof */);
+   |              ^ missing tokens in macro arguments
+   |
+note: while trying to match meta-variable `$x:stmt`
+  --> $DIR/metavar-at-eof.rs:9:16
+   |
+LL |     (stmt      $x:stmt      ) => {};
+   |                ^^^^^^^
+
+error: unexpected end of macro invocation
+  --> $DIR/metavar-at-eof.rs:28:13
+   |
+LL | macro_rules! unambig {
+   | -------------------- when calling this macro
+...
+LL | unambig!(pat /* eof */);
+   |             ^ missing tokens in macro arguments
+   |
+note: while trying to match meta-variable `$x:pat`
+  --> $DIR/metavar-at-eof.rs:10:16
+   |
+LL |     (pat       $x:pat       ) => {};
+   |                ^^^^^^
+
+error: unexpected end of macro invocation
+  --> $DIR/metavar-at-eof.rs:29:19
+   |
+LL | macro_rules! unambig {
+   | -------------------- when calling this macro
+...
+LL | unambig!(pat_param /* eof */);
+   |                   ^ missing tokens in macro arguments
+   |
+note: while trying to match meta-variable `$x:pat_param`
+  --> $DIR/metavar-at-eof.rs:11:16
+   |
+LL |     (pat_param $x:pat_param ) => {};
+   |                ^^^^^^^^^^^^
+
+error: unexpected end of macro invocation
+  --> $DIR/metavar-at-eof.rs:30:14
+   |
+LL | macro_rules! unambig {
+   | -------------------- when calling this macro
+...
+LL | unambig!(expr /* eof */);
+   |              ^ missing tokens in macro arguments
+   |
+note: while trying to match meta-variable `$x:expr`
+  --> $DIR/metavar-at-eof.rs:12:16
+   |
+LL |     (expr      $x:expr      ) => {};
+   |                ^^^^^^^
+
+error: unexpected end of macro invocation
+  --> $DIR/metavar-at-eof.rs:31:19
+   |
+LL | macro_rules! unambig {
+   | -------------------- when calling this macro
+...
+LL | unambig!(expr_2021 /* eof */);
+   |                   ^ missing tokens in macro arguments
+   |
+note: while trying to match meta-variable `$x:expr_2021`
+  --> $DIR/metavar-at-eof.rs:13:16
+   |
+LL |     (expr_2021 $x:expr_2021 ) => {};
+   |                ^^^^^^^^^^^^
+
+error: unexpected end of macro invocation
+  --> $DIR/metavar-at-eof.rs:32:12
+   |
+LL | macro_rules! unambig {
+   | -------------------- when calling this macro
+...
+LL | unambig!(ty /* eof */);
+   |            ^ missing tokens in macro arguments
+   |
+note: while trying to match meta-variable `$x:ty`
+  --> $DIR/metavar-at-eof.rs:14:16
+   |
+LL |     (ty        $x:ty        ) => {};
+   |                ^^^^^
+
+error: unexpected end of macro invocation
+  --> $DIR/metavar-at-eof.rs:33:15
+   |
+LL | macro_rules! unambig {
+   | -------------------- when calling this macro
+...
+LL | unambig!(ident /* eof */);
+   |               ^ missing tokens in macro arguments
+   |
+note: while trying to match meta-variable `$x:ident`
+  --> $DIR/metavar-at-eof.rs:15:16
+   |
+LL |     (ident     $x:ident     ) => {};
+   |                ^^^^^^^^
+
+error: unexpected end of macro invocation
+  --> $DIR/metavar-at-eof.rs:34:18
+   |
+LL | macro_rules! unambig {
+   | -------------------- when calling this macro
+...
+LL | unambig!(lifetime /* eof */);
+   |                  ^ missing tokens in macro arguments
+   |
+note: while trying to match meta-variable `$x:lifetime`
+  --> $DIR/metavar-at-eof.rs:16:16
+   |
+LL |     (lifetime  $x:lifetime  ) => {};
+   |                ^^^^^^^^^^^
+
+error: unexpected end of macro invocation
+  --> $DIR/metavar-at-eof.rs:35:17
+   |
+LL | macro_rules! unambig {
+   | -------------------- when calling this macro
+...
+LL | unambig!(literal /* eof */);
+   |                 ^ missing tokens in macro arguments
+   |
+note: while trying to match meta-variable `$x:literal`
+  --> $DIR/metavar-at-eof.rs:17:16
+   |
+LL |     (literal   $x:literal   ) => {};
+   |                ^^^^^^^^^^
+
+error: unexpected end of macro invocation
+  --> $DIR/metavar-at-eof.rs:36:14
+   |
+LL | macro_rules! unambig {
+   | -------------------- when calling this macro
+...
+LL | unambig!(meta /* eof */);
+   |              ^ missing tokens in macro arguments
+   |
+note: while trying to match meta-variable `$x:meta`
+  --> $DIR/metavar-at-eof.rs:18:16
+   |
+LL |     (meta      $x:meta      ) => {};
+   |                ^^^^^^^
+
+error: unexpected end of macro invocation
+  --> $DIR/metavar-at-eof.rs:37:14
+   |
+LL | macro_rules! unambig {
+   | -------------------- when calling this macro
+...
+LL | unambig!(path /* eof */);
+   |              ^ missing tokens in macro arguments
+   |
+note: while trying to match meta-variable `$x:path`
+  --> $DIR/metavar-at-eof.rs:19:16
+   |
+LL |     (path      $x:path      ) => {};
+   |                ^^^^^^^
+
+error: unexpected end of macro invocation
+  --> $DIR/metavar-at-eof.rs:38:13
+   |
+LL | macro_rules! unambig {
+   | -------------------- when calling this macro
+...
+LL | unambig!(vis /* eof */);
+   |             ^ missing tokens in macro arguments
+   |
+note: while trying to match meta-variable `$x:vis`
+  --> $DIR/metavar-at-eof.rs:20:16
+   |
+LL |     (vis       $x:vis       ) => {};
+   |                ^^^^^^
+
+error: unexpected end of macro invocation
+  --> $DIR/metavar-at-eof.rs:39:15
+   |
+LL | macro_rules! unambig {
+   | -------------------- when calling this macro
+...
+LL | unambig!(guard /* eof */);
+   |               ^ missing tokens in macro arguments
+   |
+note: while trying to match meta-variable `$x:guard`
+  --> $DIR/metavar-at-eof.rs:21:16
+   |
+LL |     (guard     $x:guard     ) => {};
+   |                ^^^^^^^^
+
+error: unexpected end of macro invocation
+  --> $DIR/metavar-at-eof.rs:40:12
+   |
+LL | macro_rules! unambig {
+   | -------------------- when calling this macro
+...
+LL | unambig!(tt /* eof */);
+   |            ^ missing tokens in macro arguments
+   |
+note: while trying to match meta-variable `$x:tt`
+  --> $DIR/metavar-at-eof.rs:22:16
+   |
+LL |     (tt        $x:tt        ) => {};
+   |                ^^^^^
+
+error: aborting due to 16 previous errors
+


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/158974)*
<!-- homu-ignore:end -->

This PR contains some miscellaneous commits I accumulated while working on the BFS->DFS change. Their goal is to simplify the code and clarifying existing behavior. It is a conceptual follow-up to rust-lang/rust#158577. High-level overview:

- Adds context about the current match arm to `Tracker` through the new `Tracker::prepare()`, so that the `WhichMatcher` parameter is available implicitly. In a later PR, this will be used to reference `MatcherLoc`s by index.

- Reformulates matching failures to work more like ambiguity errors wrt. `Tracker`; `Tracker::build_failure()` (which would build a failure consumed by `Tracker::after_arm()`) becomes `Tracker::failure()` which eagerly processes the error. This removes the need for `ParseResult::Failure` to store any data at all. This relies on the match arm context provided by `Tracker::prepare()`.

- There is a subtle edge case involving `token::Eof` and non-terminal parsing; `Parser::nonterminal_may_begin_with()` would sometimes return `true` for `token::Eof`, even though the non-terminal parse would never be attempted. `TtParser` did not check `bb_mps` when handling `token::Eof`, so non-terminal parses at EOF were being silently dropped. I changed `Parser::nonterminal_may_begin_with()` to always return `false` for `token::Eof`, making this behavior much more visible. I added a test case to make sure meta-variables return the same error uniformly when parsed against EOF.

Contains rust-lang/rust#158894, which should be merged soon (after which I'll rebase onto `main`).

Best reviewed commit-by-commit.

r? @nnethercote