### PR TITLE
Add regression test for too-big by-value ABI args

### DIFF
--- a/tests/ui/abi/too-big-byval-abi-issue-148853.rs
+++ b/tests/ui/abi/too-big-byval-abi-issue-148853.rs
@@ -1,0 +1,12 @@
+//@ only-64bit
+//@ edition: 2024
+//@ build-fail
+
+#![crate_type = "lib"]
+
+#[repr(C)]
+pub struct Big([u8; 1 << 63]);
+
+#[unsafe(no_mangle)]
+pub extern "C" fn foo(_x: Big) {}
+//~^ ERROR values of the type `[u8; 9223372036854775808]` are too big for the target architecture

--- a/tests/ui/abi/too-big-byval-abi-issue-148853.stderr
+++ b/tests/ui/abi/too-big-byval-abi-issue-148853.stderr
@@ -1,0 +1,8 @@
+error: values of the type `[u8; 9223372036854775808]` are too big for the target architecture
+  --> $DIR/too-big-byval-abi-issue-148853.rs:11:1
+   |
+LL | pub extern "C" fn foo(_x: Big) {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Fixes rust-lang/rust#148853

Adds a regression test for a huge `extern "C"` by-value argument that used to ICE while computing the exported symbol ABI. Current rustc reports the expected `too big for the target architecture` layout error instead