### PR TITLE
rerun in original typing mode if we meet any opaques in post analysis

### DIFF
--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
@@ -870,7 +870,7 @@ where
             (
                 RerunCondition::OpaqueInStorageOrAnyOpaqueHasInferAsHidden(_),
                 TypingMode::PostAnalysis | TypingMode::Codegen,
-            ) => RerunDecision::No,
+            ) => RerunDecision::Yes,
             (
                 RerunCondition::OpaqueInStorageOrAnyOpaqueHasInferAsHidden(defids),
                 TypingMode::Typeck { defining_opaque_types_and_generators: opaques },

--- a/tests/ui/traits/next-solver/rerun-if-any-opaque-or-has-infer-as-hidden-in-codegen.rs
+++ b/tests/ui/traits/next-solver/rerun-if-any-opaque-or-has-infer-as-hidden-in-codegen.rs
@@ -1,0 +1,34 @@
+//@ compile-flags: -Znext-solver
+//@ check-pass
+
+fn mk_vec() -> Vec<Vec<&'static str>> {
+    loop {}
+}
+
+fn parse_feature(feature: &str) -> impl Iterator<Item = &str> {
+    std::iter::once(feature)
+}
+
+fn main() {
+    // In `codegen_select_candidate`, we try to find an impl for `FlatMap::into_iter`
+    // We try to prove `FlatMap<...>: IntoIterator`.
+    // The blanket impl requires `FlatMap<...>: Iterator`.
+    // The `Iterator` impl of `FlatMap` has nested goals:
+    // `Projection(Fn::Output<parse_feature, (?assoc,)>, iter::Once`.
+    // We normalize this goal and set rerun condition to `AnyOpaqueHasInferAsHidden`
+    // with reason `SelfTyInfer` because we instantiated impls with infers when
+    // assembling candidates for intermediate goals.
+    // Then we evaluate the normalized goal:
+    // `Projection(Fn::Output<parse_feature, (&str,)>, iter::Once`.
+    // The alias term is normalized to rigid alias `impl Iterator<Item = &str>` as
+    // we're in `TypingMode::ErasedNotCoherence`.
+    // But the expected term is revealed `iter::Once` thus relating failed.
+    // The goal fails with rerun condition `OpaqueInStorage(parse_feature::opaque)`.
+    // This goal should be rerun in `TypingMode::Codegen` mode, but
+    // `AnyOpaqueHasInferAsHidden + OpaqueInStorage = OpaqueInStorageOrAnyOpaqueHasInferAsHidden`
+    // which didn't trigger rerun in `TypingMode::Codegen` mode previously.
+    mk_vec()
+        .into_iter()
+        .flatten()
+        .flat_map(parse_feature).into_iter();
+}


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

When the rerun condition is `OpaqueInStorage` and typing mode is `PostAnalysis/Codegen`, we do rerun the evaluation in original typing mode.
It's strange that we don't do the same when the rerun condition is `OpaqueInStorageOrAnyOpaqueHasInferAsHidden`.

This fixes an ICE when building `cargo` with the next solver.

r? @jdonszelmann 
cc @lcnr