### PR TITLE
borrowck: Make `ConstraintCategory::CallArgument` diagnostics pinpoint specific args

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
@@ -19,10 +19,10 @@ use rustc_index::bit_set::DenseBitSet;
 use rustc_middle::bug;
 use rustc_middle::hir::nested_filter::OnlyBodies;
 use rustc_middle::mir::{
-    self, AggregateKind, BindingForm, BorrowKind, ClearCrossCrate, ConstraintCategory,
-    FakeBorrowKind, FakeReadCause, LocalDecl, LocalInfo, LocalKind, Location, MutBorrowKind,
-    Operand, Place, PlaceRef, PlaceTy, ProjectionElem, Rvalue, Statement, StatementKind,
-    Terminator, TerminatorKind, VarBindingForm, VarDebugInfoContents,
+    self, AggregateKind, BindingForm, BorrowKind, CallArgumentKind, ClearCrossCrate,
+    ConstraintCategory, FakeBorrowKind, FakeReadCause, LocalDecl, LocalInfo, LocalKind, Location,
+    MutBorrowKind, Operand, Place, PlaceRef, PlaceTy, ProjectionElem, Rvalue, Statement,
+    StatementKind, Terminator, TerminatorKind, VarBindingForm, VarDebugInfoContents,
 };
 use rustc_middle::ty::print::PrintTraitRefExt as _;
 use rustc_middle::ty::{
@@ -3070,7 +3070,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
                         name: self.synthesize_region_name(),
                         source: RegionNameSource::Static,
                     },
-                    ConstraintCategory::CallArgument(None),
+                    ConstraintCategory::CallArgument(None, CallArgumentKind::Normal),
                     var_or_use_span,
                     &format!("`{name}`"),
                     "block",
@@ -3081,7 +3081,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
             ) if let OutlivesConstraint {
                 category:
                     category @ (ConstraintCategory::Return(_)
-                    | ConstraintCategory::CallArgument(_)
+                    | ConstraintCategory::CallArgument(_, _)
                     | ConstraintCategory::OpaqueType),
                 from_closure: false,
                 span,
@@ -3719,7 +3719,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
                 let msg = format!("{kind} is returned here");
                 err.span_note(constraint_span, msg);
             }
-            ConstraintCategory::CallArgument(_) => {
+            ConstraintCategory::CallArgument(_, _) => {
                 fr_name.highlight_region_name(&mut err);
                 if matches!(
                     use_span.coroutine_kind(),

--- a/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
@@ -19,10 +19,10 @@ use rustc_infer::traits::TraitErrors;
 use rustc_middle::bug;
 use rustc_middle::hir::nested_filter::OnlyBodies;
 use rustc_middle::mir::{
-    self, AggregateKind, BindingForm, BorrowKind, ClearCrossCrate, ConstraintCategory,
-    FakeBorrowKind, FakeReadCause, LocalDecl, LocalInfo, LocalKind, Location, MutBorrowKind,
-    Operand, Place, PlaceRef, PlaceTy, ProjectionElem, Rvalue, Statement, StatementKind,
-    Terminator, TerminatorKind, VarBindingForm, VarDebugInfoContents,
+    self, AggregateKind, BindingForm, BorrowKind, CallArgumentKind, ClearCrossCrate,
+    ConstraintCategory, FakeBorrowKind, FakeReadCause, LocalDecl, LocalInfo, LocalKind, Location,
+    MutBorrowKind, Operand, Place, PlaceRef, PlaceTy, ProjectionElem, Rvalue, Statement,
+    StatementKind, Terminator, TerminatorKind, VarBindingForm, VarDebugInfoContents,
 };
 use rustc_middle::ty::print::PrintTraitRefExt as _;
 use rustc_middle::ty::{
@@ -3130,7 +3130,7 @@ impl<'diag, 'tcx> MirBorrowckCtxt<'_, 'diag, 'tcx> {
                         name: self.synthesize_region_name(),
                         source: RegionNameSource::Static,
                     },
-                    ConstraintCategory::CallArgument(None),
+                    ConstraintCategory::CallArgument(None, CallArgumentKind::Normal),
                     var_or_use_span,
                     &format!("`{name}`"),
                     "block",
@@ -3141,7 +3141,7 @@ impl<'diag, 'tcx> MirBorrowckCtxt<'_, 'diag, 'tcx> {
             ) if let OutlivesConstraint {
                 category:
                     category @ (ConstraintCategory::Return(_)
-                    | ConstraintCategory::CallArgument(_)
+                    | ConstraintCategory::CallArgument(_, _)
                     | ConstraintCategory::OpaqueType),
                 from_closure: false,
                 span,
@@ -3779,7 +3779,7 @@ impl<'diag, 'tcx> MirBorrowckCtxt<'_, 'diag, 'tcx> {
                 let msg = format!("{kind} is returned here");
                 err.span_note(constraint_span, msg);
             }
-            ConstraintCategory::CallArgument(_) => {
+            ConstraintCategory::CallArgument(_, _) => {
                 fr_name.highlight_region_name(&mut err);
                 if matches!(
                     use_span.coroutine_kind(),

--- a/compiler/rustc_borrowck/src/diagnostics/opaque_types.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/opaque_types.rs
@@ -244,7 +244,7 @@ impl<'tcx> TypeVisitor<TyCtxt<'tcx>> for FindOpaqueRegion<'_, 'tcx> {
                 {
                     for constraint in path {
                         // If we find a call in this path, then check if it defines the opaque.
-                        if let ConstraintCategory::CallArgument(Some(call_ty)) = constraint.category
+                        if let ConstraintCategory::CallArgument(Some(call_ty), _) = constraint.category
                             && let ty::FnDef(call_def_id, _) = *call_ty.kind()
                             // This function defines the opaque :D
                             && call_def_id == parent

--- a/compiler/rustc_borrowck/src/diagnostics/region_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/region_errors.rs
@@ -13,7 +13,7 @@ use rustc_hir::{PolyTraitRef, TyKind, WhereBoundPredicate};
 use rustc_infer::infer::{NllRegionVariableOrigin, SubregionOrigin};
 use rustc_middle::bug;
 use rustc_middle::hir::place::PlaceBase;
-use rustc_middle::mir::{AnnotationSource, ConstraintCategory, ReturnConstraint};
+use rustc_middle::mir::{AnnotationSource, CallArgumentKind, ConstraintCategory, ReturnConstraint};
 use rustc_middle::ty::{
     self, GenericArgs, Region, RegionVid, Ty, TyCtxt, TypeFoldable, TypeVisitor, fold_regions,
 };
@@ -49,7 +49,11 @@ impl<'tcx> ConstraintDescription for ConstraintCategory<'tcx> {
             ConstraintCategory::UseAsStatic => "using this value as a static ",
             ConstraintCategory::Cast { is_implicit_coercion: false, .. } => "cast ",
             ConstraintCategory::Cast { is_implicit_coercion: true, .. } => "coercion ",
-            ConstraintCategory::CallArgument(_) => "argument ",
+            ConstraintCategory::CallArgument(_, kind) => match kind {
+                CallArgumentKind::Normal => "argument ",
+                CallArgumentKind::Receiver => "receiver ",
+                CallArgumentKind::Closure => "closure ",
+            },
             ConstraintCategory::TypeAnnotation(AnnotationSource::GenericArg) => "generic argument ",
             ConstraintCategory::TypeAnnotation(_) => "type annotation ",
             ConstraintCategory::SizedBound => "proving this value is `Sized` ",
@@ -491,7 +495,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
                 self.report_fnmut_error(&errci, kind)
             }
             (ConstraintCategory::Assignment, true, false)
-            | (ConstraintCategory::CallArgument(_), true, false) => {
+            | (ConstraintCategory::CallArgument(_, _), true, false) => {
                 let mut db = self.report_escaping_data_error(&errci);
 
                 outlives_suggestion.intermediate_suggestion(self, &errci, &mut db);
@@ -945,7 +949,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
 
         let tcx = self.infcx.tcx;
 
-        let ConstraintCategory::CallArgument(Some(func_ty)) = category else { return };
+        let ConstraintCategory::CallArgument(Some(func_ty), _) = category else { return };
         let ty::FnDef(fn_did, args) = *func_ty.kind() else { return };
         debug!(?fn_did, ?args);
 

--- a/compiler/rustc_borrowck/src/diagnostics/region_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/region_errors.rs
@@ -13,7 +13,7 @@ use rustc_hir::{PolyTraitRef, TyKind, WhereBoundPredicate};
 use rustc_infer::infer::{NllRegionVariableOrigin, SubregionOrigin};
 use rustc_middle::bug;
 use rustc_middle::hir::place::PlaceBase;
-use rustc_middle::mir::{AnnotationSource, ConstraintCategory, ReturnConstraint};
+use rustc_middle::mir::{AnnotationSource, CallArgumentKind, ConstraintCategory, ReturnConstraint};
 use rustc_middle::ty::{
     self, GenericArgs, Region, RegionExt, RegionVid, Ty, TyCtxt, TypeFoldable, TypeVisitor,
     fold_regions,
@@ -50,7 +50,11 @@ impl<'tcx> ConstraintDescription for ConstraintCategory<'tcx> {
             ConstraintCategory::UseAsStatic => "using this value as a static ",
             ConstraintCategory::Cast { is_implicit_coercion: false, .. } => "cast ",
             ConstraintCategory::Cast { is_implicit_coercion: true, .. } => "coercion ",
-            ConstraintCategory::CallArgument(_) => "argument ",
+            ConstraintCategory::CallArgument(_, kind) => match kind {
+                CallArgumentKind::Normal => "argument ",
+                CallArgumentKind::Receiver => "receiver ",
+                CallArgumentKind::Closure => "closure ",
+            },
             ConstraintCategory::TypeAnnotation(AnnotationSource::GenericArg) => "generic argument ",
             ConstraintCategory::TypeAnnotation(_) => "type annotation ",
             ConstraintCategory::SizedBound => "proving this value is `Sized` ",
@@ -492,7 +496,7 @@ impl<'diag, 'tcx> MirBorrowckCtxt<'_, 'diag, 'tcx> {
                 self.report_fnmut_error(&errci, kind)
             }
             (ConstraintCategory::Assignment, true, false)
-            | (ConstraintCategory::CallArgument(_), true, false) => {
+            | (ConstraintCategory::CallArgument(_, _), true, false) => {
                 let mut db = self.report_escaping_data_error(&errci);
 
                 outlives_suggestion.intermediate_suggestion(self, &errci, &mut db);
@@ -946,7 +950,7 @@ impl<'diag, 'tcx> MirBorrowckCtxt<'_, 'diag, 'tcx> {
 
         let tcx = self.infcx.tcx;
 
-        let ConstraintCategory::CallArgument(Some(func_ty)) = category else { return };
+        let ConstraintCategory::CallArgument(Some(func_ty), _) = category else { return };
         let ty::FnDef(fn_did, args) = *func_ty.kind() else { return };
         debug!(?fn_did, ?args);
 

--- a/compiler/rustc_borrowck/src/lib.rs
+++ b/compiler/rustc_borrowck/src/lib.rs
@@ -228,10 +228,6 @@ pub struct ClosureOutlivesRequirement<'tcx> {
     pub category: ConstraintCategory<'tcx>,
 }
 
-// Make sure this enum doesn't unintentionally grow
-#[cfg(target_pointer_width = "64")]
-rustc_data_structures::static_assert_size!(ConstraintCategory<'_>, 16);
-
 /// The subject of a `ClosureOutlivesRequirement` -- that is, the thing
 /// that must outlive some region.
 #[derive(Copy, Clone, Debug)]

--- a/compiler/rustc_borrowck/src/lib.rs
+++ b/compiler/rustc_borrowck/src/lib.rs
@@ -231,10 +231,6 @@ pub struct ClosureOutlivesRequirement<'tcx> {
     pub category: ConstraintCategory<'tcx>,
 }
 
-// Make sure this enum doesn't unintentionally grow
-#[cfg(target_pointer_width = "64")]
-rustc_data_structures::static_assert_size!(ConstraintCategory<'_>, 16);
-
 /// The subject of a `ClosureOutlivesRequirement` -- that is, the thing
 /// that must outlive some region.
 #[derive(Copy, Clone, Debug)]

--- a/compiler/rustc_borrowck/src/region_infer/mod.rs
+++ b/compiler/rustc_borrowck/src/region_infer/mod.rs
@@ -1754,7 +1754,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
                     | AnnotationSource::OpaqueCast,
                 )
                 | ConstraintCategory::Cast { .. }
-                | ConstraintCategory::CallArgument(_)
+                | ConstraintCategory::CallArgument(_, _)
                 | ConstraintCategory::CopyBound
                 | ConstraintCategory::SizedBound
                 | ConstraintCategory::Assignment

--- a/compiler/rustc_borrowck/src/region_infer/mod.rs
+++ b/compiler/rustc_borrowck/src/region_infer/mod.rs
@@ -1756,7 +1756,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
                     | AnnotationSource::OpaqueCast,
                 )
                 | ConstraintCategory::Cast { .. }
-                | ConstraintCategory::CallArgument(_)
+                | ConstraintCategory::CallArgument(_, _)
                 | ConstraintCategory::CopyBound
                 | ConstraintCategory::SizedBound
                 | ConstraintCategory::Assignment

--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -10,7 +10,7 @@ use rustc_errors::ErrorGuaranteed;
 use rustc_hir as hir;
 use rustc_hir::def::DefKind;
 use rustc_hir::def_id::LocalDefId;
-use rustc_hir::lang_items::LangItem;
+use rustc_hir::lang_items::{FN_TRAITS, LangItem};
 use rustc_index::{IndexSlice, IndexVec};
 use rustc_infer::infer::canonical::QueryRegionConstraints;
 use rustc_infer::infer::outlives::env::RegionBoundPairs;
@@ -1630,7 +1630,7 @@ impl<'a, 'tcx> Visitor<'tcx> for TypeChecker<'a, 'tcx> {
                             ty_left,
                             common_ty,
                             location.to_locations(),
-                            ConstraintCategory::CallArgument(None),
+                            ConstraintCategory::CallArgument(None, CallArgumentKind::Normal),
                         )
                         .unwrap_or_else(|err| {
                             bug!("Could not equate type variable with {:?}: {:?}", ty_left, err)
@@ -1639,7 +1639,7 @@ impl<'a, 'tcx> Visitor<'tcx> for TypeChecker<'a, 'tcx> {
                             ty_right,
                             common_ty,
                             location.to_locations(),
-                            ConstraintCategory::CallArgument(None),
+                            ConstraintCategory::CallArgument(None, CallArgumentKind::Normal),
                         ) {
                             span_mirbug!(
                                 self,
@@ -2047,10 +2047,27 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
             let op_arg_ty = op_arg.node.ty(self.body, self.tcx());
 
             let op_arg_ty = self.normalize(ty::Unnormalized::new_wip(op_arg_ty), term_location);
+            let is_closure = n == 0
+                && matches!(func_ty.kind(), ty::FnDef(def_id, _) if {
+                    let tcx = self.tcx();
+                    let trait_id = tcx.trait_item_of(*def_id).unwrap_or(*def_id);
+                    tcx.trait_of_assoc(trait_id).is_some_and(|trait_id| {
+                        FN_TRAITS.iter().any(|&lang_item| tcx.is_lang_item(trait_id, lang_item))
+                    })
+                });
+            let is_receiver = n == 0
+                && matches!(&term.kind, TerminatorKind::Call { fn_span, .. } if term.source_info.span != *fn_span);
             let category = if call_source.from_hir_call() {
-                ConstraintCategory::CallArgument(Some(
-                    self.infcx.tcx.erase_and_anonymize_regions(func_ty),
-                ))
+                ConstraintCategory::CallArgument(
+                    Some(self.infcx.tcx.erase_and_anonymize_regions(func_ty)),
+                    if is_closure {
+                        CallArgumentKind::Closure
+                    } else if is_receiver {
+                        CallArgumentKind::Receiver
+                    } else {
+                        CallArgumentKind::Normal
+                    },
+                )
             } else {
                 ConstraintCategory::Boring
             };

--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -438,6 +438,19 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
         self.relate_types(sup, ty::Contravariant, sub, locations, category)
     }
 
+    fn sub_types_spanned(
+        &mut self,
+        sub: Ty<'tcx>,
+        sup: Ty<'tcx>,
+        locations: Locations,
+        span: Option<Span>,
+        category: ConstraintCategory<'tcx>,
+    ) -> Result<(), NoSolution> {
+        // Use this order of parameters because the sup type is usually the
+        // "expected" type in diagnostics.
+        self.relate_types_spanned(sup, ty::Contravariant, sub, locations, span, category)
+    }
+
     #[instrument(skip(self, category), level = "debug")]
     fn eq_types(
         &mut self,
@@ -2057,23 +2070,30 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
                 });
             let is_receiver = n == 0
                 && matches!(&term.kind, TerminatorKind::Call { fn_span, .. } if term.source_info.span != *fn_span);
-            let category = if call_source.from_hir_call() {
-                ConstraintCategory::CallArgument(
-                    Some(self.infcx.tcx.erase_and_anonymize_regions(func_ty)),
-                    if is_closure {
-                        CallArgumentKind::Closure
-                    } else if is_receiver {
-                        CallArgumentKind::Receiver
-                    } else {
-                        CallArgumentKind::Normal
-                    },
+            let (category, span) = if call_source.from_hir_call() {
+                (
+                    ConstraintCategory::CallArgument(
+                        Some(self.infcx.tcx.erase_and_anonymize_regions(func_ty)),
+                        if is_closure {
+                            CallArgumentKind::Closure
+                        } else if is_receiver {
+                            CallArgumentKind::Receiver
+                        } else {
+                            CallArgumentKind::Normal
+                        },
+                    ),
+                    Some(op_arg.span),
                 )
             } else {
-                ConstraintCategory::Boring
+                (ConstraintCategory::Boring, None)
             };
-            if let Err(terr) =
-                self.sub_types(op_arg_ty, *fn_arg, term_location.to_locations(), category)
-            {
+            if let Err(terr) = self.sub_types_spanned(
+                op_arg_ty,
+                *fn_arg,
+                term_location.to_locations(),
+                span,
+                category,
+            ) {
                 span_mirbug!(
                     self,
                     term,

--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -8,7 +8,7 @@ use rustc_data_structures::frozen::Frozen;
 use rustc_data_structures::fx::{FxIndexMap, FxIndexSet};
 use rustc_errors::ErrorGuaranteed;
 use rustc_hir as hir;
-use rustc_hir::attrs::lang_items::LangItem;
+use rustc_hir::attrs::lang_items::{FN_TRAITS, LangItem};
 use rustc_hir::def::DefKind;
 use rustc_hir::def_id::LocalDefId;
 use rustc_index::{IndexSlice, IndexVec};
@@ -1640,7 +1640,7 @@ impl<'a, 'tcx> Visitor<'tcx> for TypeChecker<'a, 'tcx> {
                             ty_left,
                             common_ty,
                             location.to_locations(),
-                            ConstraintCategory::CallArgument(None),
+                            ConstraintCategory::CallArgument(None, CallArgumentKind::Normal),
                         )
                         .unwrap_or_else(|err| {
                             bug!("Could not equate type variable with {:?}: {:?}", ty_left, err)
@@ -1649,7 +1649,7 @@ impl<'a, 'tcx> Visitor<'tcx> for TypeChecker<'a, 'tcx> {
                             ty_right,
                             common_ty,
                             location.to_locations(),
-                            ConstraintCategory::CallArgument(None),
+                            ConstraintCategory::CallArgument(None, CallArgumentKind::Normal),
                         ) {
                             span_mirbug!(
                                 self,
@@ -2057,10 +2057,27 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
             let op_arg_ty = op_arg.node.ty(self.body, self.tcx());
 
             let op_arg_ty = self.normalize(ty::Unnormalized::new_wip(op_arg_ty), term_location);
+            let is_closure = n == 0
+                && matches!(func_ty.kind(), ty::FnDef(def_id, _) if {
+                    let tcx = self.tcx();
+                    let trait_id = tcx.trait_item_of(*def_id).unwrap_or(*def_id);
+                    tcx.trait_of_assoc(trait_id).is_some_and(|trait_id| {
+                        FN_TRAITS.iter().any(|&lang_item| tcx.is_lang_item(trait_id, lang_item))
+                    })
+                });
+            let is_receiver = n == 0
+                && matches!(&term.kind, TerminatorKind::Call { fn_span, .. } if term.source_info.span != *fn_span);
             let category = if call_source.from_hir_call() {
-                ConstraintCategory::CallArgument(Some(
-                    self.infcx.tcx.erase_and_anonymize_regions(func_ty),
-                ))
+                ConstraintCategory::CallArgument(
+                    Some(self.infcx.tcx.erase_and_anonymize_regions(func_ty)),
+                    if is_closure {
+                        CallArgumentKind::Closure
+                    } else if is_receiver {
+                        CallArgumentKind::Receiver
+                    } else {
+                        CallArgumentKind::Normal
+                    },
+                )
             } else {
                 ConstraintCategory::Boring
             };

--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -438,6 +438,19 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
         self.relate_types(sup, ty::Contravariant, sub, locations, category)
     }
 
+    fn sub_types_spanned(
+        &mut self,
+        sub: Ty<'tcx>,
+        sup: Ty<'tcx>,
+        locations: Locations,
+        span: Option<Span>,
+        category: ConstraintCategory<'tcx>,
+    ) -> Result<(), NoSolution> {
+        // Use this order of parameters because the sup type is usually the
+        // "expected" type in diagnostics.
+        self.relate_types_spanned(sup, ty::Contravariant, sub, locations, span, category)
+    }
+
     #[instrument(skip(self, category), level = "debug")]
     fn eq_types(
         &mut self,
@@ -2067,23 +2080,30 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
                 });
             let is_receiver = n == 0
                 && matches!(&term.kind, TerminatorKind::Call { fn_span, .. } if term.source_info.span != *fn_span);
-            let category = if call_source.from_hir_call() {
-                ConstraintCategory::CallArgument(
-                    Some(self.infcx.tcx.erase_and_anonymize_regions(func_ty)),
-                    if is_closure {
-                        CallArgumentKind::Closure
-                    } else if is_receiver {
-                        CallArgumentKind::Receiver
-                    } else {
-                        CallArgumentKind::Normal
-                    },
+            let (category, span) = if call_source.from_hir_call() {
+                (
+                    ConstraintCategory::CallArgument(
+                        Some(self.infcx.tcx.erase_and_anonymize_regions(func_ty)),
+                        if is_closure {
+                            CallArgumentKind::Closure
+                        } else if is_receiver {
+                            CallArgumentKind::Receiver
+                        } else {
+                            CallArgumentKind::Normal
+                        },
+                    ),
+                    Some(op_arg.span),
                 )
             } else {
-                ConstraintCategory::Boring
+                (ConstraintCategory::Boring, None)
             };
-            if let Err(terr) =
-                self.sub_types(op_arg_ty, *fn_arg, term_location.to_locations(), category)
-            {
+            if let Err(terr) = self.sub_types_spanned(
+                op_arg_ty,
+                *fn_arg,
+                term_location.to_locations(),
+                span,
+                category,
+            ) {
                 span_mirbug!(
                     self,
                     term,

--- a/compiler/rustc_borrowck/src/type_check/relate_tys.rs
+++ b/compiler/rustc_borrowck/src/type_check/relate_tys.rs
@@ -23,15 +23,6 @@ use crate::renumber::RegionCtxt;
 use crate::type_check::{InstantiateOpaqueType, Locations, TypeChecker};
 
 impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
-    /// Adds sufficient constraints to ensure that `a R b` where `R` depends on `v`:
-    ///
-    /// - "Covariant" `a <: b`
-    /// - "Invariant" `a == b`
-    /// - "Contravariant" `a :> b`
-    ///
-    /// N.B., the type `a` is permitted to have unresolved inference
-    /// variables, but not the type `b`.
-    #[instrument(skip(self), level = "debug")]
     pub(super) fn relate_types(
         &mut self,
         a: Ty<'tcx>,
@@ -40,7 +31,30 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
         locations: Locations,
         category: ConstraintCategory<'tcx>,
     ) -> Result<(), NoSolution> {
-        NllTypeRelating::new(self, locations, category, UniverseInfo::relate(a, b), v)
+        self.relate_types_spanned(a, v, b, locations, None, category)
+    }
+
+    /// Adds sufficient constraints to ensure that `a R b` where `R` depends on `v`:
+    ///
+    /// - "Covariant" `a <: b`
+    /// - "Invariant" `a == b`
+    /// - "Contravariant" `a :> b`
+    ///
+    /// N.B., the type `a` is permitted to have unresolved inference
+    /// variables, but not the type `b`.
+    ///
+    /// FIXME: Explain `span`
+    #[instrument(skip(self), level = "debug")]
+    pub(super) fn relate_types_spanned(
+        &mut self,
+        a: Ty<'tcx>,
+        v: ty::Variance,
+        b: Ty<'tcx>,
+        locations: Locations,
+        span: Option<Span>,
+        category: ConstraintCategory<'tcx>,
+    ) -> Result<(), NoSolution> {
+        NllTypeRelating::new(self, locations, span, category, UniverseInfo::relate(a, b), v)
             .relate(a, b)?;
         Ok(())
     }
@@ -53,7 +67,7 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
         locations: Locations,
         category: ConstraintCategory<'tcx>,
     ) -> Result<(), NoSolution> {
-        NllTypeRelating::new(self, locations, category, UniverseInfo::other(), ty::Invariant)
+        NllTypeRelating::new(self, locations, None, category, UniverseInfo::other(), ty::Invariant)
             .relate(a, b)?;
         Ok(())
     }
@@ -64,6 +78,10 @@ struct NllTypeRelating<'a, 'b, 'tcx> {
 
     /// Where (and why) is this relation taking place?
     locations: Locations,
+
+    /// An optional Span in case we want to be more specific than `locations` in
+    /// diagnostics.
+    span: Option<Span>,
 
     /// What category do we assign the resulting `'a: 'b` relationships?
     category: ConstraintCategory<'tcx>,
@@ -87,6 +105,7 @@ impl<'a, 'b, 'tcx> NllTypeRelating<'a, 'b, 'tcx> {
     fn new(
         type_checker: &'a mut TypeChecker<'b, 'tcx>,
         locations: Locations,
+        span: Option<Span>,
         category: ConstraintCategory<'tcx>,
         universe_info: UniverseInfo<'tcx>,
         ambient_variance: ty::Variance,
@@ -97,6 +116,7 @@ impl<'a, 'b, 'tcx> NllTypeRelating<'a, 'b, 'tcx> {
             category,
             universe_info,
             ambient_variance,
+            span,
             ambient_variance_info: ty::VarianceDiagInfo::default(),
         }
     }
@@ -299,7 +319,7 @@ impl<'a, 'b, 'tcx> NllTypeRelating<'a, 'b, 'tcx> {
             sup,
             sub,
             locations: self.locations,
-            span: self.locations.span(self.type_checker.body),
+            span: self.span.unwrap_or_else(|| self.locations.span(self.type_checker.body)),
             category: self.category,
             variance_info: info,
             from_closure: false,

--- a/compiler/rustc_borrowck/src/type_check/relate_tys.rs
+++ b/compiler/rustc_borrowck/src/type_check/relate_tys.rs
@@ -21,15 +21,6 @@ use crate::renumber::RegionCtxt;
 use crate::type_check::{InstantiateOpaqueType, Locations, TypeChecker};
 
 impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
-    /// Adds sufficient constraints to ensure that `a R b` where `R` depends on `v`:
-    ///
-    /// - "Covariant" `a <: b`
-    /// - "Invariant" `a == b`
-    /// - "Contravariant" `a :> b`
-    ///
-    /// N.B., the type `a` is permitted to have unresolved inference
-    /// variables, but not the type `b`.
-    #[instrument(skip(self), level = "debug")]
     pub(super) fn relate_types(
         &mut self,
         a: Ty<'tcx>,
@@ -38,7 +29,30 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
         locations: Locations,
         category: ConstraintCategory<'tcx>,
     ) -> Result<(), NoSolution> {
-        NllTypeRelating::new(self, locations, category, UniverseInfo::relate(a, b), v)
+        self.relate_types_spanned(a, v, b, locations, None, category)
+    }
+
+    /// Adds sufficient constraints to ensure that `a R b` where `R` depends on `v`:
+    ///
+    /// - "Covariant" `a <: b`
+    /// - "Invariant" `a == b`
+    /// - "Contravariant" `a :> b`
+    ///
+    /// N.B., the type `a` is permitted to have unresolved inference
+    /// variables, but not the type `b`.
+    ///
+    /// FIXME: Explain `span`
+    #[instrument(skip(self), level = "debug")]
+    pub(super) fn relate_types_spanned(
+        &mut self,
+        a: Ty<'tcx>,
+        v: ty::Variance,
+        b: Ty<'tcx>,
+        locations: Locations,
+        span: Option<Span>,
+        category: ConstraintCategory<'tcx>,
+    ) -> Result<(), NoSolution> {
+        NllTypeRelating::new(self, locations, span, category, UniverseInfo::relate(a, b), v)
             .relate(a, b)?;
         Ok(())
     }
@@ -51,7 +65,7 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
         locations: Locations,
         category: ConstraintCategory<'tcx>,
     ) -> Result<(), NoSolution> {
-        NllTypeRelating::new(self, locations, category, UniverseInfo::other(), ty::Invariant)
+        NllTypeRelating::new(self, locations, None, category, UniverseInfo::other(), ty::Invariant)
             .relate(a, b)?;
         Ok(())
     }
@@ -62,6 +76,10 @@ struct NllTypeRelating<'a, 'b, 'tcx> {
 
     /// Where (and why) is this relation taking place?
     locations: Locations,
+
+    /// An optional Span in case we want to be more specific than `locations` in
+    /// diagnostics.
+    span: Option<Span>,
 
     /// What category do we assign the resulting `'a: 'b` relationships?
     category: ConstraintCategory<'tcx>,
@@ -85,6 +103,7 @@ impl<'a, 'b, 'tcx> NllTypeRelating<'a, 'b, 'tcx> {
     fn new(
         type_checker: &'a mut TypeChecker<'b, 'tcx>,
         locations: Locations,
+        span: Option<Span>,
         category: ConstraintCategory<'tcx>,
         universe_info: UniverseInfo<'tcx>,
         ambient_variance: ty::Variance,
@@ -95,6 +114,7 @@ impl<'a, 'b, 'tcx> NllTypeRelating<'a, 'b, 'tcx> {
             category,
             universe_info,
             ambient_variance,
+            span,
             ambient_variance_info: ty::VarianceDiagInfo::default(),
         }
     }
@@ -321,7 +341,7 @@ impl<'a, 'b, 'tcx> NllTypeRelating<'a, 'b, 'tcx> {
             sup,
             sub,
             locations: self.locations,
-            span: self.locations.span(self.type_checker.body),
+            span: self.span.unwrap_or_else(|| self.locations.span(self.type_checker.body)),
             category: self.category,
             variance_info: info,
             from_closure: false,

--- a/compiler/rustc_middle/src/mir/query.rs
+++ b/compiler/rustc_middle/src/mir/query.rs
@@ -93,6 +93,19 @@ pub struct ConstQualifs {
     pub needs_non_const_drop: bool,
     pub tainted_by_errors: Option<ErrorGuaranteed>,
 }
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+#[derive(TyEncodable, TyDecodable, StableHash, TypeVisitable, TypeFoldable)]
+pub enum CallArgumentKind {
+    Normal,
+    Receiver,
+    Closure,
+}
+
+// Make sure this enum doesn't unintentionally grow
+#[cfg(target_pointer_width = "64")]
+rustc_data_structures::static_assert_size!(ConstraintCategory<'_>, 16);
+
 /// Outlives-constraints can be categorized to determine whether and why they
 /// are interesting (for error reporting). Order of variants indicates sort
 /// order of the category, thereby influencing diagnostic output.
@@ -116,7 +129,7 @@ pub enum ConstraintCategory<'tcx> {
     },
 
     /// Contains the function type if available.
-    CallArgument(Option<Ty<'tcx>>),
+    CallArgument(Option<Ty<'tcx>>, CallArgumentKind), // to save binary size for static_assert_size!
     CopyBound,
     SizedBound,
     Assignment,

--- a/src/tools/clippy/tests/ui/crashes/ice-6256.stderr
+++ b/src/tools/clippy/tests/ui/crashes/ice-6256.stderr
@@ -2,10 +2,10 @@ error[E0521]: borrowed data escapes outside of closure
   --> tests/ui/crashes/ice-6256.rs:13:26
    |
 LL |     let f = |x: &dyn TT| x.func();
-   |              -  -        ^^^^^^^^
+   |              -  -        ^
    |              |  |        |
    |              |  |        `x` escapes the closure body here
-   |              |  |        argument requires that `'1` must outlive `'static`
+   |              |  |        receiver requires that `'1` must outlive `'static`
    |              |  let's call the lifetime of this reference `'1`
    |              `x` is a reference that is only valid in the closure body
 

--- a/tests/ui/any/any_static.next.stderr
+++ b/tests/ui/any/any_static.next.stderr
@@ -1,15 +1,15 @@
 error[E0521]: borrowed data escapes outside of function
-  --> $DIR/any_static.rs:18:35
+  --> $DIR/any_static.rs:18:77
    |
 LL | fn extend(a: &Payload) -> &'static Payload {
    |           -  - let's call the lifetime of this reference `'1`
    |           |
    |           `a` is a reference that is only valid in the function body
 LL |     let b: &(dyn Any + 'static) = try_as_dyn::<&Payload, dyn Any + 'static>(&a).unwrap();
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |                                   |
-   |                                   `a` escapes the function body here
-   |                                   argument requires that `'1` must outlive `'static`
+   |                                                                             ^^
+   |                                                                             |
+   |                                                                             `a` escapes the function body here
+   |                                                                             argument requires that `'1` must outlive `'static`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/any/any_static.old.stderr
+++ b/tests/ui/any/any_static.old.stderr
@@ -1,15 +1,15 @@
 error[E0521]: borrowed data escapes outside of function
-  --> $DIR/any_static.rs:18:35
+  --> $DIR/any_static.rs:18:77
    |
 LL | fn extend(a: &Payload) -> &'static Payload {
    |           -  - let's call the lifetime of this reference `'1`
    |           |
    |           `a` is a reference that is only valid in the function body
 LL |     let b: &(dyn Any + 'static) = try_as_dyn::<&Payload, dyn Any + 'static>(&a).unwrap();
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |                                   |
-   |                                   `a` escapes the function body here
-   |                                   argument requires that `'1` must outlive `'static`
+   |                                                                             ^^
+   |                                                                             |
+   |                                                                             `a` escapes the function body here
+   |                                                                             argument requires that `'1` must outlive `'static`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/any/static_method_bound.stderr
+++ b/tests/ui/any/static_method_bound.stderr
@@ -1,15 +1,15 @@
 error[E0521]: borrowed data escapes outside of function
-  --> $DIR/static_method_bound.rs:30:37
+  --> $DIR/static_method_bound.rs:30:81
    |
 LL | fn extend(a: &Payload) -> &'static Payload {
    |           -  - let's call the lifetime of this reference `'1`
    |           |
    |           `a` is a reference that is only valid in the function body
 LL |     let b: &(dyn Trait + 'static) = try_as_dyn::<&Payload, dyn Trait + 'static>(&a).unwrap();
-   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |                                     |
-   |                                     `a` escapes the function body here
-   |                                     argument requires that `'1` must outlive `'static`
+   |                                                                                 ^^
+   |                                                                                 |
+   |                                                                                 `a` escapes the function body here
+   |                                                                                 argument requires that `'1` must outlive `'static`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/associated-types/cache/project-fn-ret-invariant.oneuse.stderr
+++ b/tests/ui/associated-types/cache/project-fn-ret-invariant.oneuse.stderr
@@ -1,5 +1,5 @@
 error: lifetime may not live long enough
-  --> $DIR/project-fn-ret-invariant.rs:40:13
+  --> $DIR/project-fn-ret-invariant.rs:40:20
    |
 LL | fn baz<'a, 'b>(x: Type<'a>, y: Type<'b>) -> (Type<'a>, Type<'b>) {
    |        --  -- lifetime `'b` defined here
@@ -7,7 +7,7 @@ LL | fn baz<'a, 'b>(x: Type<'a>, y: Type<'b>) -> (Type<'a>, Type<'b>) {
    |        lifetime `'a` defined here
 LL |     let f = foo; // <-- No consistent type can be inferred for `f` here.
 LL |     let a = bar(f, x);
-   |             ^^^^^^^^^ argument requires that `'b` must outlive `'a`
+   |                    ^ argument requires that `'b` must outlive `'a`
    |
    = help: consider adding the following bound: `'b: 'a`
    = note: requirement occurs because of the type `Type<'_>`, which makes the generic argument `'_` invariant
@@ -15,7 +15,7 @@ LL |     let a = bar(f, x);
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
 error: lifetime may not live long enough
-  --> $DIR/project-fn-ret-invariant.rs:42:13
+  --> $DIR/project-fn-ret-invariant.rs:42:20
    |
 LL | fn baz<'a, 'b>(x: Type<'a>, y: Type<'b>) -> (Type<'a>, Type<'b>) {
    |        --  -- lifetime `'b` defined here
@@ -23,7 +23,7 @@ LL | fn baz<'a, 'b>(x: Type<'a>, y: Type<'b>) -> (Type<'a>, Type<'b>) {
    |        lifetime `'a` defined here
 ...
 LL |     let b = bar(f, y);
-   |             ^^^^^^^^^ argument requires that `'a` must outlive `'b`
+   |                    ^ argument requires that `'a` must outlive `'b`
    |
    = help: consider adding the following bound: `'a: 'b`
    = note: requirement occurs because of the type `Type<'_>`, which makes the generic argument `'_` invariant

--- a/tests/ui/async-await/async-closures/without-precise-captures-we-are-powerless.stderr
+++ b/tests/ui/async-await/async-closures/without-precise-captures-we-are-powerless.stderr
@@ -7,7 +7,7 @@ LL |     let c = async || { println!("{}", *x); };
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ borrowed value does not live long enough
 LL |     outlives::<'a>(c());
 LL |     outlives::<'a>(call_once(c));
-   |     ---------------------------- argument requires that `x` is borrowed for `'a`
+   |                    ------------ argument requires that `x` is borrowed for `'a`
 ...
 LL | }
    |  - `x` dropped here while still borrowed
@@ -21,10 +21,10 @@ LL | fn simple<'a>(x: &'a i32) {
 LL |     let c = async move || { println!("{}", *x); };
    |         - binding `c` declared here
 LL |     outlives::<'a>(c());
-   |     ---------------^---
-   |     |              |
-   |     |              borrowed value does not live long enough
-   |     argument requires that `c` is borrowed for `'a`
+   |                    ^--
+   |                    |
+   |                    borrowed value does not live long enough
+   |                    argument requires that `c` is borrowed for `'a`
 LL |     outlives::<'a>(call_once(c));
 LL | }
    | - `c` dropped here while still borrowed
@@ -44,7 +44,7 @@ LL |     let c = async || { println!("{}", *x.0); };
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ borrowed value does not live long enough
 LL |     outlives::<'a>(c());
 LL |     outlives::<'a>(call_once(c));
-   |     ---------------------------- argument requires that `x` is borrowed for `'a`
+   |                    ------------ argument requires that `x` is borrowed for `'a`
 ...
 LL | }
    |  - `x` dropped here while still borrowed
@@ -58,7 +58,7 @@ LL |     let c = async || { println!("{}", *x.0); };
    |             ---------------------------------- borrow of `x` occurs here
 LL |     outlives::<'a>(c());
 LL |     outlives::<'a>(call_once(c));
-   |     ---------------------------- argument requires that `x` is borrowed for `'a`
+   |                    ------------ argument requires that `x` is borrowed for `'a`
 LL |
 LL |     let c = async move || { println!("{}", *x.0); };
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ move out of `x` occurs here
@@ -72,10 +72,10 @@ LL | fn through_field<'a>(x: S<'a>) {
 LL |     let c = async move || { println!("{}", *x.0); };
    |         - binding `c` declared here
 LL |     outlives::<'a>(c());
-   |     ---------------^---
-   |     |              |
-   |     |              borrowed value does not live long enough
-   |     argument requires that `c` is borrowed for `'a`
+   |                    ^--
+   |                    |
+   |                    borrowed value does not live long enough
+   |                    argument requires that `c` is borrowed for `'a`
 LL |     outlives::<'a>(call_once(c));
 LL | }
    | - `c` dropped here while still borrowed
@@ -95,10 +95,10 @@ LL | fn through_field<'a>(x: S<'a>) {
 LL |     let c = async move || { println!("{}", *x.0); };
    |         - binding `c` declared here
 LL |     outlives::<'a>(c());
-   |     -------------------
-   |     |              |
-   |     |              borrow of `c` occurs here
-   |     argument requires that `c` is borrowed for `'a`
+   |                    ---
+   |                    |
+   |                    borrow of `c` occurs here
+   |                    argument requires that `c` is borrowed for `'a`
 LL |     outlives::<'a>(call_once(c));
    |                              ^ move out of `c` occurs here
    |
@@ -117,15 +117,15 @@ LL |     let c = async || { println!("{}", *x.0); };
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ borrowed value does not live long enough
 LL |     outlives::<'a>(c());
 LL |     outlives::<'a>(call_once(c));
-   |     ---------------------------- argument requires that `x` is borrowed for `'a`
+   |                    ------------ argument requires that `x` is borrowed for `'a`
 LL | }
    |  - `x` dropped here while still borrowed
 
 error[E0621]: explicit lifetime required in the type of `x`
-  --> $DIR/without-precise-captures-we-are-powerless.rs:38:5
+  --> $DIR/without-precise-captures-we-are-powerless.rs:38:20
    |
 LL |     outlives::<'a>(call_once(c));
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ lifetime `'a` required
+   |                    ^^^^^^^^^^^^ lifetime `'a` required
    |
 help: add explicit lifetime `'a` to the type of `x`
    |
@@ -140,10 +140,10 @@ LL | fn through_field_and_ref_move<'a>(x: &S<'a>) {
 LL |     let c = async move || { println!("{}", *x.0); };
    |         - binding `c` declared here
 LL |     outlives::<'a>(c());
-   |     ---------------^---
-   |     |              |
-   |     |              borrowed value does not live long enough
-   |     argument requires that `c` is borrowed for `'a`
+   |                    ^--
+   |                    |
+   |                    borrowed value does not live long enough
+   |                    argument requires that `c` is borrowed for `'a`
 LL |     outlives::<'a>(call_once(c));
 LL | }
    | - `c` dropped here while still borrowed
@@ -155,10 +155,10 @@ LL | fn outlives<'a>(_: impl Sized + 'a) {}
    |                                 ^^
 
 error[E0621]: explicit lifetime required in the type of `x`
-  --> $DIR/without-precise-captures-we-are-powerless.rs:44:5
+  --> $DIR/without-precise-captures-we-are-powerless.rs:44:20
    |
 LL |     outlives::<'a>(call_once(c));
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ lifetime `'a` required
+   |                    ^^^^^^^^^^^^ lifetime `'a` required
    |
 help: add explicit lifetime `'a` to the type of `x`
    |
@@ -174,7 +174,7 @@ LL |     let c = async || { println!("{}", *x); };
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ borrowed value does not live long enough
 LL |     T.outlives::<'a>(c());
 LL |     T.outlives::<'a>(call_once(c));
-   |     ------------------------------ argument requires that `x` is borrowed for `'a`
+   |                      ------------ argument requires that `x` is borrowed for `'a`
 ...
 LL | }
    |  - `x` dropped here while still borrowed
@@ -188,10 +188,10 @@ LL | fn through_method<'a>(x: &'a i32) {
 LL |     let c = async move || { println!("{}", *x); };
    |         - binding `c` declared here
 LL |     T.outlives::<'a>(c());
-   |     -----------------^---
-   |     |                |
-   |     |                borrowed value does not live long enough
-   |     argument requires that `c` is borrowed for `'a`
+   |                      ^--
+   |                      |
+   |                      borrowed value does not live long enough
+   |                      argument requires that `c` is borrowed for `'a`
 LL |     T.outlives::<'a>(call_once(c));
 LL | }
    | - `c` dropped here while still borrowed

--- a/tests/ui/async-await/issue-74072-lifetime-name-annotations.stderr
+++ b/tests/ui/async-await/issue-74072-lifetime-name-annotations.stderr
@@ -44,20 +44,21 @@ LL | |     })()
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/issue-74072-lifetime-name-annotations.rs:13:5
    |
-LL |    pub fn async_closure(x: &mut i32) -> impl Future<Output=&i32> {
-   |                            - let's call the lifetime of this reference `'1`
-LL | //     (async move || {
-LL | ||
-LL | ||
-LL | ||         let y = &*x;
-LL | ||         *x += 1;
-LL | ||         y
-LL | ||     })()
-   | ||______^_- argument requires that borrow lasts for `'1`
-   | |_______|
-   |         creates a temporary value which is freed while still in use
-LL |    }
-   |    - temporary value is freed at the end of this statement
+LL |   pub fn async_closure(x: &mut i32) -> impl Future<Output=&i32> {
+   |                           - let's call the lifetime of this reference `'1`
+LL | /     (async move || {
+LL | |
+LL | |
+LL | |         let y = &*x;
+LL | |         *x += 1;
+LL | |         y
+LL | |     })()
+   | |      ^
+   | |      |
+   | |______creates a temporary value which is freed while still in use
+   |        argument requires that borrow lasts for `'1`
+LL |   }
+   |   - temporary value is freed at the end of this statement
 
 error[E0506]: cannot assign to `*x` because it is borrowed
   --> $DIR/issue-74072-lifetime-name-annotations.rs:27:9
@@ -93,20 +94,21 @@ LL | |     })()
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/issue-74072-lifetime-name-annotations.rs:23:5
    |
-LL |    pub fn async_closure_explicit_return_type(x: &mut i32) -> impl Future<Output=&i32> {
-   |                                                 - let's call the lifetime of this reference `'1`
-LL | //     (async move || -> &i32 {
-LL | ||
-LL | ||
-LL | ||         let y = &*x;
-LL | ||         *x += 1;
-LL | ||         y
-LL | ||     })()
-   | ||______^_- argument requires that borrow lasts for `'1`
-   | |_______|
-   |         creates a temporary value which is freed while still in use
-LL |    }
-   |    - temporary value is freed at the end of this statement
+LL |   pub fn async_closure_explicit_return_type(x: &mut i32) -> impl Future<Output=&i32> {
+   |                                                - let's call the lifetime of this reference `'1`
+LL | /     (async move || -> &i32 {
+LL | |
+LL | |
+LL | |         let y = &*x;
+LL | |         *x += 1;
+LL | |         y
+LL | |     })()
+   | |      ^
+   | |      |
+   | |______creates a temporary value which is freed while still in use
+   |        argument requires that borrow lasts for `'1`
+LL |   }
+   |   - temporary value is freed at the end of this statement
 
 error[E0506]: cannot assign to `*x` because it is borrowed
   --> $DIR/issue-74072-lifetime-name-annotations.rs:35:9

--- a/tests/ui/async-await/issue-74072-lifetime-name-annotations.stderr
+++ b/tests/ui/async-await/issue-74072-lifetime-name-annotations.stderr
@@ -13,20 +13,21 @@ LL |     y
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/issue-74072-lifetime-name-annotations.rs:13:5
    |
-LL |    pub fn async_closure(x: &mut i32) -> impl Future<Output=&i32> {
-   |                            - let's call the lifetime of this reference `'1`
-LL | //     (async move || {
-LL | ||
-LL | ||
-LL | ||         let y = &*x;
-LL | ||         *x += 1;
-LL | ||         y
-LL | ||     })()
-   | ||______^_- argument requires that borrow lasts for `'1`
-   | |_______|
-   |         creates a temporary value which is freed while still in use
-LL |    }
-   |    - temporary value is freed at the end of this statement
+LL |   pub fn async_closure(x: &mut i32) -> impl Future<Output=&i32> {
+   |                           - let's call the lifetime of this reference `'1`
+LL | /     (async move || {
+LL | |
+LL | |
+LL | |         let y = &*x;
+LL | |         *x += 1;
+LL | |         y
+LL | |     })()
+   | |      ^
+   | |      |
+   | |______creates a temporary value which is freed while still in use
+   |        argument requires that borrow lasts for `'1`
+LL |   }
+   |   - temporary value is freed at the end of this statement
 
 error: lifetime may not live long enough
   --> $DIR/issue-74072-lifetime-name-annotations.rs:13:20
@@ -62,20 +63,21 @@ LL |         y
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/issue-74072-lifetime-name-annotations.rs:23:5
    |
-LL |    pub fn async_closure_explicit_return_type(x: &mut i32) -> impl Future<Output=&i32> {
-   |                                                 - let's call the lifetime of this reference `'1`
-LL | //     (async move || -> &i32 {
-LL | ||
-LL | ||
-LL | ||         let y = &*x;
-LL | ||         *x += 1;
-LL | ||         y
-LL | ||     })()
-   | ||______^_- argument requires that borrow lasts for `'1`
-   | |_______|
-   |         creates a temporary value which is freed while still in use
-LL |    }
-   |    - temporary value is freed at the end of this statement
+LL |   pub fn async_closure_explicit_return_type(x: &mut i32) -> impl Future<Output=&i32> {
+   |                                                - let's call the lifetime of this reference `'1`
+LL | /     (async move || -> &i32 {
+LL | |
+LL | |
+LL | |         let y = &*x;
+LL | |         *x += 1;
+LL | |         y
+LL | |     })()
+   | |      ^
+   | |      |
+   | |______creates a temporary value which is freed while still in use
+   |        argument requires that borrow lasts for `'1`
+LL |   }
+   |   - temporary value is freed at the end of this statement
 
 error: lifetime may not live long enough
   --> $DIR/issue-74072-lifetime-name-annotations.rs:23:28

--- a/tests/ui/async-await/issues/issue-62097.stderr
+++ b/tests/ui/async-await/issues/issue-62097.stderr
@@ -7,17 +7,17 @@ LL |         foo(|| self.bar()).await;
    |             may outlive borrowed value `self`
    |
 note: function requires argument type to outlive `'static`
-  --> $DIR/issue-62097.rs:13:9
+  --> $DIR/issue-62097.rs:13:13
    |
 LL |         foo(|| self.bar()).await;
-   |         ^^^^^^^^^^^^^^^^^^
+   |             ^^^^^^^^^^^^^
 help: to force the closure to take ownership of `self` (and any other referenced variables), use the `move` keyword
    |
 LL |         foo(move || self.bar()).await;
    |             ++++
 
 error[E0521]: borrowed data escapes outside of method
-  --> $DIR/issue-62097.rs:13:9
+  --> $DIR/issue-62097.rs:13:13
    |
 LL |     pub async fn run_dummy_fn(&self) {
    |                               -----
@@ -25,10 +25,10 @@ LL |     pub async fn run_dummy_fn(&self) {
    |                               `self` is a reference that is only valid in the method body
    |                               let's call the lifetime of this reference `'1`
 LL |         foo(|| self.bar()).await;
-   |         ^^^^^^^^^^^^^^^^^^
-   |         |
-   |         `self` escapes the method body here
-   |         argument requires that `'1` must outlive `'static`
+   |             ^^^^^^^^^^^^^
+   |             |
+   |             `self` escapes the method body here
+   |             argument requires that `'1` must outlive `'static`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/async-await/issues/issue-62097.stderr
+++ b/tests/ui/async-await/issues/issue-62097.stderr
@@ -1,17 +1,3 @@
-error[E0521]: borrowed data escapes outside of method
-  --> $DIR/issue-62097.rs:13:9
-   |
-LL |     pub async fn run_dummy_fn(&self) {
-   |                               -----
-   |                               |
-   |                               `self` is a reference that is only valid in the method body
-   |                               let's call the lifetime of this reference `'1`
-LL |         foo(|| self.bar()).await;
-   |         ^^^^^^^^^^^^^^^^^^
-   |         |
-   |         `self` escapes the method body here
-   |         argument requires that `'1` must outlive `'static`
-
 error[E0373]: closure may outlive the current function, but it borrows `self`, which is owned by the current function
   --> $DIR/issue-62097.rs:13:13
    |
@@ -21,14 +7,28 @@ LL |         foo(|| self.bar()).await;
    |             may outlive borrowed value `self`
    |
 note: function requires argument type to outlive `'static`
-  --> $DIR/issue-62097.rs:13:9
+  --> $DIR/issue-62097.rs:13:13
    |
 LL |         foo(|| self.bar()).await;
-   |         ^^^^^^^^^^^^^^^^^^
+   |             ^^^^^^^^^^^^^
 help: to force the closure to take ownership of `self` (and any other referenced variables), use the `move` keyword
    |
 LL |         foo(move || self.bar()).await;
    |             ++++
+
+error[E0521]: borrowed data escapes outside of method
+  --> $DIR/issue-62097.rs:13:13
+   |
+LL |     pub async fn run_dummy_fn(&self) {
+   |                               -----
+   |                               |
+   |                               `self` is a reference that is only valid in the method body
+   |                               let's call the lifetime of this reference `'1`
+LL |         foo(|| self.bar()).await;
+   |             ^^^^^^^^^^^^^
+   |             |
+   |             `self` escapes the method body here
+   |             argument requires that `'1` must outlive `'static`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/async-await/issues/issue-72312.stderr
+++ b/tests/ui/async-await/issues/issue-72312.stderr
@@ -1,5 +1,5 @@
 error[E0521]: borrowed data escapes outside of method
-  --> $DIR/issue-72312.rs:12:9
+  --> $DIR/issue-72312.rs:12:24
    |
 LL |       pub async fn start(&self) {
    |                          -----
@@ -7,13 +7,14 @@ LL |       pub async fn start(&self) {
    |                          `self` is a reference that is only valid in the method body
    |                          let's call the lifetime of this reference `'1`
 ...
-LL | /         require_static(async move {
+LL |           require_static(async move {
+   |  ________________________^
 ...  |
 LL | |         });
-   | |          ^
-   | |          |
-   | |__________`self` escapes the method body here
-   |            argument requires that `'1` must outlive `'static`
+   | |         ^
+   | |         |
+   | |_________`self` escapes the method body here
+   |           argument requires that `'1` must outlive `'static`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/borrowck/alias-liveness/higher-ranked-outlives-for-capture.stderr
+++ b/tests/ui/borrowck/alias-liveness/higher-ranked-outlives-for-capture.stderr
@@ -2,10 +2,10 @@ error[E0716]: temporary value dropped while borrowed
   --> $DIR/higher-ranked-outlives-for-capture.rs:13:11
    |
 LL |     test(&vec![])
-   |     ------^^^^^^-
-   |     |     |
-   |     |     creates a temporary value which is freed while still in use
-   |     argument requires that borrow lasts for `'static`
+   |          -^^^^^^
+   |          ||
+   |          |creates a temporary value which is freed while still in use
+   |          argument requires that borrow lasts for `'static`
 LL | }
    | - temporary value is freed at the end of this statement
 

--- a/tests/ui/borrowck/anonymous-region-in-apit.stderr
+++ b/tests/ui/borrowck/anonymous-region-in-apit.stderr
@@ -1,13 +1,13 @@
 error[E0521]: borrowed data escapes outside of closure
-  --> $DIR/anonymous-region-in-apit.rs:8:17
+  --> $DIR/anonymous-region-in-apit.rs:8:25
    |
 LL | fn qux(foo: impl Foo<&str>) {
    |        --- lifetime `'2` appears in the type of `foo`
 LL |     |baz: &str| foo.bar(baz);
-   |      ---  -     ^^^^^^^^^^^^
-   |      |    |     |
-   |      |    |     `baz` escapes the closure body here
-   |      |    |     argument requires that `'1` must outlive `'2`
+   |      ---  -             ^^^
+   |      |    |             |
+   |      |    |             `baz` escapes the closure body here
+   |      |    |             argument requires that `'1` must outlive `'2`
    |      |    let's call the lifetime of this reference `'1`
    |      `baz` is a reference that is only valid in the closure body
 

--- a/tests/ui/borrowck/borrowck-escaping-closure-error-1.stderr
+++ b/tests/ui/borrowck/borrowck-escaping-closure-error-1.stderr
@@ -7,10 +7,10 @@ LL |     spawn(|| books.push(4));
    |           may outlive borrowed value `books`
    |
 note: function requires argument type to outlive `'static`
-  --> $DIR/borrowck-escaping-closure-error-1.rs:13:5
+  --> $DIR/borrowck-escaping-closure-error-1.rs:13:11
    |
 LL |     spawn(|| books.push(4));
-   |     ^^^^^^^^^^^^^^^^^^^^^^^
+   |           ^^^^^^^^^^^^^^^^
 help: to force the closure to take ownership of `books` (and any other referenced variables), use the `move` keyword
    |
 LL |     spawn(move || books.push(4));

--- a/tests/ui/borrowck/closure-upvar-named-lifetime.stderr
+++ b/tests/ui/borrowck/closure-upvar-named-lifetime.stderr
@@ -11,7 +11,7 @@ LL |         let value = map.borrow_mut().entry("foo".to_string());
    |                     ^^^ borrowed value does not live long enough
 ...
 LL |         f(wrapped_value);
-   |         ---------------- closure requires that `map` is borrowed for `'a`
+   |         - closure requires that `map` is borrowed for `'a`
 LL |     }
    |     - `map` dropped here while still borrowed
    |
@@ -30,7 +30,7 @@ LL |         let value = map.borrow_mut().entry("foo".to_string());
    |                     creates a temporary value which is freed while still in use
 ...
 LL |         f(wrapped_value);
-   |         ---------------- closure requires that borrow lasts for `'a`
+   |         - closure requires that borrow lasts for `'a`
    |
 note: requirement that the value outlives `'a` introduced here
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
@@ -70,7 +70,7 @@ LL |         let value = map.borrow_mut().entry("foo".to_string());
    |                     ^^^ borrowed value does not live long enough
 ...
 LL |         f(value);
-   |         -------- closure requires that `map` is borrowed for `'a`
+   |         - closure requires that `map` is borrowed for `'a`
 LL |     }
    |     - `map` dropped here while still borrowed
 
@@ -86,7 +86,7 @@ LL |         let value = map.borrow_mut().entry("foo".to_string());
    |                     creates a temporary value which is freed while still in use
 ...
 LL |         f(value);
-   |         -------- closure requires that borrow lasts for `'a`
+   |         - closure requires that borrow lasts for `'a`
 
 error[E0700]: hidden type for `impl Fn(RefCell<HashMap<String, String>>)` captures lifetime that does not appear in bounds
   --> $DIR/closure-upvar-named-lifetime.rs:32:5

--- a/tests/ui/borrowck/closure-upvar-named-lifetime.stderr
+++ b/tests/ui/borrowck/closure-upvar-named-lifetime.stderr
@@ -11,7 +11,7 @@ LL |         let value = map.borrow_mut().entry("foo".to_string());
    |                     ^^^ borrowed value does not live long enough
 ...
 LL |         f(wrapped_value);
-   |         ---------------- argument requires that `map` is borrowed for `'a`
+   |         ---------------- closure requires that `map` is borrowed for `'a`
 LL |     }
    |     - `map` dropped here while still borrowed
    |
@@ -30,7 +30,7 @@ LL |         let value = map.borrow_mut().entry("foo".to_string());
    |                     creates a temporary value which is freed while still in use
 ...
 LL |         f(wrapped_value);
-   |         ---------------- argument requires that borrow lasts for `'a`
+   |         ---------------- closure requires that borrow lasts for `'a`
    |
 note: requirement that the value outlives `'a` introduced here
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
@@ -70,7 +70,7 @@ LL |         let value = map.borrow_mut().entry("foo".to_string());
    |                     ^^^ borrowed value does not live long enough
 ...
 LL |         f(value);
-   |         -------- argument requires that `map` is borrowed for `'a`
+   |         -------- closure requires that `map` is borrowed for `'a`
 LL |     }
    |     - `map` dropped here while still borrowed
 
@@ -86,7 +86,7 @@ LL |         let value = map.borrow_mut().entry("foo".to_string());
    |                     creates a temporary value which is freed while still in use
 ...
 LL |         f(value);
-   |         -------- argument requires that borrow lasts for `'a`
+   |         -------- closure requires that borrow lasts for `'a`
 
 error[E0700]: hidden type for `impl Fn(RefCell<HashMap<String, String>>)` captures lifetime that does not appear in bounds
   --> $DIR/closure-upvar-named-lifetime.rs:32:5

--- a/tests/ui/borrowck/closure-upvar-named-lifetime.stderr
+++ b/tests/ui/borrowck/closure-upvar-named-lifetime.stderr
@@ -33,7 +33,7 @@ LL |         let value = map.borrow_mut().entry("foo".to_string());
    |                     ^^^ borrowed value does not live long enough
 ...
 LL |         f(wrapped_value);
-   |         ---------------- argument requires that `map` is borrowed for `'a`
+   |         ---------------- closure requires that `map` is borrowed for `'a`
 LL |     }
    |     - `map` dropped here while still borrowed
    |
@@ -52,7 +52,7 @@ LL |         let value = map.borrow_mut().entry("foo".to_string());
    |                     creates a temporary value which is freed while still in use
 ...
 LL |         f(wrapped_value);
-   |         ---------------- argument requires that borrow lasts for `'a`
+   |         ---------------- closure requires that borrow lasts for `'a`
    |
 note: requirement that the value outlives `'a` introduced here
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
@@ -92,7 +92,7 @@ LL |         let value = map.borrow_mut().entry("foo".to_string());
    |                     ^^^ borrowed value does not live long enough
 ...
 LL |         f(value);
-   |         -------- argument requires that `map` is borrowed for `'a`
+   |         -------- closure requires that `map` is borrowed for `'a`
 LL |     }
    |     - `map` dropped here while still borrowed
 
@@ -108,7 +108,7 @@ LL |         let value = map.borrow_mut().entry("foo".to_string());
    |                     creates a temporary value which is freed while still in use
 ...
 LL |         f(value);
-   |         -------- argument requires that borrow lasts for `'a`
+   |         -------- closure requires that borrow lasts for `'a`
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/borrowck/closure-upvar-named-lifetime.stderr
+++ b/tests/ui/borrowck/closure-upvar-named-lifetime.stderr
@@ -33,7 +33,7 @@ LL |         let value = map.borrow_mut().entry("foo".to_string());
    |                     ^^^ borrowed value does not live long enough
 ...
 LL |         f(wrapped_value);
-   |         ---------------- closure requires that `map` is borrowed for `'a`
+   |         - closure requires that `map` is borrowed for `'a`
 LL |     }
    |     - `map` dropped here while still borrowed
    |
@@ -52,7 +52,7 @@ LL |         let value = map.borrow_mut().entry("foo".to_string());
    |                     creates a temporary value which is freed while still in use
 ...
 LL |         f(wrapped_value);
-   |         ---------------- closure requires that borrow lasts for `'a`
+   |         - closure requires that borrow lasts for `'a`
    |
 note: requirement that the value outlives `'a` introduced here
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
@@ -92,7 +92,7 @@ LL |         let value = map.borrow_mut().entry("foo".to_string());
    |                     ^^^ borrowed value does not live long enough
 ...
 LL |         f(value);
-   |         -------- closure requires that `map` is borrowed for `'a`
+   |         - closure requires that `map` is borrowed for `'a`
 LL |     }
    |     - `map` dropped here while still borrowed
 
@@ -108,7 +108,7 @@ LL |         let value = map.borrow_mut().entry("foo".to_string());
    |                     creates a temporary value which is freed while still in use
 ...
 LL |         f(value);
-   |         -------- closure requires that borrow lasts for `'a`
+   |         - closure requires that borrow lasts for `'a`
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/borrowck/fn-item-check-trait-ref.stderr
+++ b/tests/ui/borrowck/fn-item-check-trait-ref.stderr
@@ -2,7 +2,7 @@ error[E0716]: temporary value dropped while borrowed
   --> $DIR/fn-item-check-trait-ref.rs:13:7
    |
 LL |     (&String::new()).assert_static();
-   |     --^^^^^^^^^^^^^------------------ temporary value is freed at the end of this statement
+   |     --^^^^^^^^^^^^^-                - temporary value is freed at the end of this statement
    |     | |
    |     | creates a temporary value which is freed while still in use
    |     receiver requires that borrow lasts for `'static`

--- a/tests/ui/borrowck/fn-item-check-trait-ref.stderr
+++ b/tests/ui/borrowck/fn-item-check-trait-ref.stderr
@@ -5,7 +5,7 @@ LL |     (&String::new()).assert_static();
    |     --^^^^^^^^^^^^^------------------ temporary value is freed at the end of this statement
    |     | |
    |     | creates a temporary value which is freed while still in use
-   |     argument requires that borrow lasts for `'static`
+   |     receiver requires that borrow lasts for `'static`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/borrowck/fn-item-check-type-params.stderr
+++ b/tests/ui/borrowck/fn-item-check-type-params.stderr
@@ -1,15 +1,15 @@
 error[E0521]: borrowed data escapes outside of function
-  --> $DIR/fn-item-check-type-params.rs:31:5
+  --> $DIR/fn-item-check-type-params.rs:31:15
    |
 LL | pub fn test_call<'a>(val: &'a str) {
    |                  --  --- `val` is a reference that is only valid in the function body
    |                  |
    |                  lifetime `'a` defined here
 LL |     extend_lt(val);
-   |     ^^^^^^^^^^^^^^
-   |     |
-   |     `val` escapes the function body here
-   |     argument requires that `'a` must outlive `'static`
+   |               ^^^
+   |               |
+   |               `val` escapes the function body here
+   |               argument requires that `'a` must outlive `'static`
 
 error: lifetime may not live long enough
   --> $DIR/fn-item-check-type-params.rs:39:31
@@ -23,10 +23,10 @@ error[E0716]: temporary value dropped while borrowed
   --> $DIR/fn-item-check-type-params.rs:48:11
    |
 LL |     want(&String::new(), extend_lt);
-   |     ------^^^^^^^^^^^^^------------- temporary value is freed at the end of this statement
-   |     |     |
-   |     |     creates a temporary value which is freed while still in use
-   |     argument requires that borrow lasts for `'static`
+   |          -^^^^^^^^^^^^^            - temporary value is freed at the end of this statement
+   |          ||
+   |          |creates a temporary value which is freed while still in use
+   |          argument requires that borrow lasts for `'static`
    |
 note: requirement that the value outlives `'static` introduced here
   --> $DIR/fn-item-check-type-params.rs:47:33
@@ -38,10 +38,10 @@ error[E0716]: temporary value dropped while borrowed
   --> $DIR/fn-item-check-type-params.rs:54:26
    |
 LL |     let val = extend_lt(&String::from("blah blah blah"));
-   |               -----------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-- temporary value is freed at the end of this statement
-   |               |          |
-   |               |          creates a temporary value which is freed while still in use
-   |               argument requires that borrow lasts for `'static`
+   |                         -^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - temporary value is freed at the end of this statement
+   |                         ||
+   |                         |creates a temporary value which is freed while still in use
+   |                         argument requires that borrow lasts for `'static`
    |
 note: requirement that the value outlives `'static` introduced here
   --> $DIR/fn-item-check-type-params.rs:22:21

--- a/tests/ui/borrowck/ice-on-non-ref-sig-ty.stderr
+++ b/tests/ui/borrowck/ice-on-non-ref-sig-ty.stderr
@@ -1,18 +1,3 @@
-error[E0521]: borrowed data escapes outside of method
-  --> $DIR/ice-on-non-ref-sig-ty.rs:13:9
-   |
-LL | impl<'a> W<'a> for &'static () {
-   |      -- lifetime `'a` defined here
-LL |     fn g<T>(self, x: &'a T) -> &'static T {
-   |             ----  - `x` is a reference that is only valid in the method body
-   |             |
-   |             `self` declared here, outside of the method body
-LL |         f(&self, x)
-   |         ^^^^^^^^^^^
-   |         |
-   |         `x` escapes the method body here
-   |         argument requires that `'a` must outlive `'static`
-
 error[E0597]: `self` does not live long enough
   --> $DIR/ice-on-non-ref-sig-ty.rs:13:11
    |
@@ -29,6 +14,21 @@ LL |     }
    = help: use data from the highlighted arguments which match the `'static` lifetime of the return type
    = note: functions cannot return a borrow to data owned within the function's scope, functions can only return borrows to data passed as arguments
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch04-02-references-and-borrowing.html#dangling-references>
+
+error[E0521]: borrowed data escapes outside of method
+  --> $DIR/ice-on-non-ref-sig-ty.rs:13:18
+   |
+LL | impl<'a> W<'a> for &'static () {
+   |      -- lifetime `'a` defined here
+LL |     fn g<T>(self, x: &'a T) -> &'static T {
+   |             ----  - `x` is a reference that is only valid in the method body
+   |             |
+   |             `self` declared here, outside of the method body
+LL |         f(&self, x)
+   |                  ^
+   |                  |
+   |                  `x` escapes the method body here
+   |                  argument requires that `'a` must outlive `'static`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/borrowck/implementation-not-general-enough-ice-133252.stderr
+++ b/tests/ui/borrowck/implementation-not-general-enough-ice-133252.stderr
@@ -1,8 +1,8 @@
 error: implementation of `LoadQuery` is not general enough
-  --> $DIR/implementation-not-general-enough-ice-133252.rs:9:9
+  --> $DIR/implementation-not-general-enough-ice-133252.rs:9:20
    |
 LL |         force_send(async_load(&not_static));
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ implementation of `LoadQuery` is not general enough
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^ implementation of `LoadQuery` is not general enough
    |
    = note: `LoadQuery<'0>` would have to be implemented for the type `&u8`, for any lifetime `'0`...
    = note: ...but `LoadQuery<'1>` is actually implemented for the type `&'1 u8`, for some specific lifetime `'1`
@@ -15,10 +15,10 @@ LL |     async {
 LL |         let not_static = 0;
    |             ---------- binding `not_static` declared here
 LL |         force_send(async_load(&not_static));
-   |         ----------------------^^^^^^^^^^^--
-   |         |                     |
-   |         |                     borrowed value does not live long enough
-   |         argument requires that `not_static` is borrowed for `'1`
+   |                    -----------^^^^^^^^^^^-
+   |                    |          |
+   |                    |          borrowed value does not live long enough
+   |                    argument requires that `not_static` is borrowed for `'1`
 ...
 LL |     }
    |     - `not_static` dropped here while still borrowed

--- a/tests/ui/borrowck/issue-103624.stderr
+++ b/tests/ui/borrowck/issue-103624.stderr
@@ -28,7 +28,7 @@ LL | struct StructB {}
    | ^^^^^^^^^^^^^^ consider implementing `Clone` for this type
 
 error[E0521]: borrowed data escapes outside of method
-  --> $DIR/issue-103624.rs:14:9
+  --> $DIR/issue-103624.rs:14:24
    |
 LL |       async fn foo(&self) {
    |                    -----
@@ -36,15 +36,16 @@ LL |       async fn foo(&self) {
    |                    `self` is a reference that is only valid in the method body
    |                    let's call the lifetime of this reference `'1`
 LL |           let bar = self.b.bar().await;
-LL | /         spawn_blocking(move || {
+LL |           spawn_blocking(move || {
+   |  ________________________^
 LL | |
 LL | |             self.b;
 LL | |
 LL | |         })
-   | |          ^
-   | |          |
-   | |__________`self` escapes the method body here
-   |            argument requires that `'1` must outlive `'static`
+   | |         ^
+   | |         |
+   | |_________`self` escapes the method body here
+   |           argument requires that `'1` must outlive `'static`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/borrowck/issue-103624.stderr
+++ b/tests/ui/borrowck/issue-103624.stderr
@@ -1,5 +1,5 @@
 error[E0521]: borrowed data escapes outside of method
-  --> $DIR/issue-103624.rs:14:9
+  --> $DIR/issue-103624.rs:14:24
    |
 LL |       async fn foo(&self) {
    |                    -----
@@ -7,15 +7,16 @@ LL |       async fn foo(&self) {
    |                    `self` is a reference that is only valid in the method body
    |                    let's call the lifetime of this reference `'1`
 LL |           let bar = self.b.bar().await;
-LL | /         spawn_blocking(move || {
+LL |           spawn_blocking(move || {
+   |  ________________________^
 LL | |
 LL | |             self.b;
 LL | |
 LL | |         })
-   | |          ^
-   | |          |
-   | |__________`self` escapes the method body here
-   |            argument requires that `'1` must outlive `'static`
+   | |         ^
+   | |         |
+   | |_________`self` escapes the method body here
+   |           argument requires that `'1` must outlive `'static`
 
 error[E0507]: cannot move out of `self.b`, as `self` is a captured variable in an `Fn` closure
   --> $DIR/issue-103624.rs:16:13

--- a/tests/ui/borrowck/issue-17545.stderr
+++ b/tests/ui/borrowck/issue-17545.stderr
@@ -3,13 +3,14 @@ error[E0716]: temporary value dropped while borrowed
    |
 LL |   pub fn foo<'a, F: Fn(&'a ())>(bar: F) {
    |              -- lifetime `'a` defined here
-LL | /     bar.call((
+LL |       bar.call((
+   |  ______________-
 LL | |         &id(()),
    | |          ^^^^^^ creates a temporary value which is freed while still in use
 LL | |     ));
-   | |      -- temporary value is freed at the end of this statement
-   | |______|
-   |        argument requires that borrow lasts for `'a`
+   | |     - - temporary value is freed at the end of this statement
+   | |_____|
+   |       argument requires that borrow lasts for `'a`
    |
 note: requirement that the value outlives `'a` introduced here
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL

--- a/tests/ui/borrowck/issue-7573.stderr
+++ b/tests/ui/borrowck/issue-7573.stderr
@@ -8,7 +8,7 @@ LL |     let push_id = |installed_id: &CrateId| {
    |                    ------------ `installed_id` is a reference that is only valid in the closure body
 LL |
 LL |         lines_to_use.push(installed_id);
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `installed_id` escapes the closure body here
+   |         ^^^^^^^^^^^^ `installed_id` escapes the closure body here
    |
    = note: requirement occurs because of a mutable reference to `Vec<&CrateId>`
    = note: mutable references are invariant over their type parameter

--- a/tests/ui/borrowck/mut-borrow-in-loop.stderr
+++ b/tests/ui/borrowck/mut-borrow-in-loop.stderr
@@ -13,10 +13,10 @@ LL | impl<'a, T : 'a> FuncWrapper<'a, T> {
    |      -- lifetime `'a` defined here
 ...
 LL |             (self.func)(arg)
-   |             ------------^^^-
-   |             |           |
-   |             |           `*arg` was mutably borrowed here in the previous iteration of the loop
-   |             argument requires that `*arg` is borrowed for `'a`
+   |                         ^^^
+   |                         |
+   |                         `*arg` was mutably borrowed here in the previous iteration of the loop
+   |                         argument requires that `*arg` is borrowed for `'a`
 
 error[E0499]: cannot borrow `*arg` as mutable more than once at a time
   --> $DIR/mut-borrow-in-loop.rs:16:25
@@ -25,10 +25,10 @@ LL | impl<'a, T : 'a> FuncWrapper<'a, T> {
    |      -- lifetime `'a` defined here
 ...
 LL |             (self.func)(arg)
-   |             ------------^^^-
-   |             |           |
-   |             |           `*arg` was mutably borrowed here in the previous iteration of the loop
-   |             argument requires that `*arg` is borrowed for `'a`
+   |                         ^^^
+   |                         |
+   |                         `*arg` was mutably borrowed here in the previous iteration of the loop
+   |                         argument requires that `*arg` is borrowed for `'a`
 
 error[E0499]: cannot borrow `*arg` as mutable more than once at a time
   --> $DIR/mut-borrow-in-loop.rs:23:25
@@ -37,10 +37,10 @@ LL | impl<'a, T : 'a> FuncWrapper<'a, T> {
    |      -- lifetime `'a` defined here
 ...
 LL |             (self.func)(arg)
-   |             ------------^^^-
-   |             |           |
-   |             |           `*arg` was mutably borrowed here in the previous iteration of the loop
-   |             argument requires that `*arg` is borrowed for `'a`
+   |                         ^^^
+   |                         |
+   |                         `*arg` was mutably borrowed here in the previous iteration of the loop
+   |                         argument requires that `*arg` is borrowed for `'a`
 
 error: aborting due to 3 previous errors; 1 warning emitted
 

--- a/tests/ui/borrowck/non-promotable-static-ref.stderr
+++ b/tests/ui/borrowck/non-promotable-static-ref.stderr
@@ -2,10 +2,10 @@ error[E0716]: temporary value dropped while borrowed
   --> $DIR/non-promotable-static-ref.rs:8:10
    |
 LL |     foo(&unpromotable(5u32));
-   |     -----^^^^^^^^^^^^^^^^^^-- temporary value is freed at the end of this statement
-   |     |    |
-   |     |    creates a temporary value which is freed while still in use
-   |     argument requires that borrow lasts for `'static`
+   |         -^^^^^^^^^^^^^^^^^^ - temporary value is freed at the end of this statement
+   |         ||
+   |         |creates a temporary value which is freed while still in use
+   |         argument requires that borrow lasts for `'static`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/borrowck/var-matching-lifetime-but-unused-not-mentioned.stderr
+++ b/tests/ui/borrowck/var-matching-lifetime-but-unused-not-mentioned.stderr
@@ -1,5 +1,5 @@
 error[E0521]: borrowed data escapes outside of function
-  --> $DIR/var-matching-lifetime-but-unused-not-mentioned.rs:14:5
+  --> $DIR/var-matching-lifetime-but-unused-not-mentioned.rs:14:13
    |
 LL | fn foo<'a>(
    |        -- lifetime `'a` defined here
@@ -7,10 +7,10 @@ LL |     used_arg: &'a u8,
    |     -------- `used_arg` is a reference that is only valid in the function body
 ...
 LL |     consume(c);
-   |     ^^^^^^^^^^
-   |     |
-   |     `used_arg` escapes the function body here
-   |     argument requires that `'a` must outlive `'static`
+   |             ^
+   |             |
+   |             `used_arg` escapes the function body here
+   |             argument requires that `'a` must outlive `'static`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/cast/ptr-to-trait-obj-different-regions-misc.stderr
+++ b/tests/ui/cast/ptr-to-trait-obj-different-regions-misc.stderr
@@ -211,7 +211,7 @@ help: `'b` and `'a` must be the same: replace one with the other
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0521]: borrowed data escapes outside of function
-  --> $DIR/ptr-to-trait-obj-different-regions-misc.rs:46:5
+  --> $DIR/ptr-to-trait-obj-different-regions-misc.rs:46:20
    |
 LL | fn extend_to_static<'a>(ptr: *const dyn Trait<'a>) {
    |                     --  ---
@@ -220,10 +220,10 @@ LL | fn extend_to_static<'a>(ptr: *const dyn Trait<'a>) {
    |                     |   `ptr` is a reference that is only valid in the function body
    |                     lifetime `'a` defined here
 LL |     require_static(ptr as _)
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^
-   |     |
-   |     `ptr` escapes the function body here
-   |     argument requires that `'a` must outlive `'static`
+   |                    ^^^^^^^^
+   |                    |
+   |                    `ptr` escapes the function body here
+   |                    argument requires that `'a` must outlive `'static`
    |
 note: raw pointer casts of trait objects cannot extend lifetimes
   --> $DIR/ptr-to-trait-obj-different-regions-misc.rs:46:20

--- a/tests/ui/closures/closure-bounds-static-cant-capture-borrowed.stderr
+++ b/tests/ui/closures/closure-bounds-static-cant-capture-borrowed.stderr
@@ -1,20 +1,3 @@
-error[E0521]: borrowed data escapes outside of function
-  --> $DIR/closure-bounds-static-cant-capture-borrowed.rs:6:5
-   |
-LL |   fn foo(x: &()) {
-   |          -  - let's call the lifetime of this reference `'1`
-   |          |
-   |          `x` is a reference that is only valid in the function body
-LL | /     bar(|| {
-LL | |
-LL | |
-LL | |         let _ = x;
-LL | |     })
-   | |      ^
-   | |      |
-   | |______`x` escapes the function body here
-   |        argument requires that `'1` must outlive `'static`
-
 error[E0373]: closure may outlive the current function, but it borrows `x`, which is owned by the current function
   --> $DIR/closure-bounds-static-cant-capture-borrowed.rs:6:9
    |
@@ -25,18 +8,37 @@ LL |         let _ = x;
    |                 - `x` is borrowed here
    |
 note: function requires argument type to outlive `'static`
-  --> $DIR/closure-bounds-static-cant-capture-borrowed.rs:6:5
+  --> $DIR/closure-bounds-static-cant-capture-borrowed.rs:6:9
    |
-LL | /     bar(|| {
+LL |       bar(|| {
+   |  _________^
 LL | |
 LL | |
 LL | |         let _ = x;
 LL | |     })
-   | |______^
+   | |_____^
 help: to force the closure to take ownership of `x` (and any other referenced variables), use the `move` keyword
    |
 LL |     bar(move || {
    |         ++++
+
+error[E0521]: borrowed data escapes outside of function
+  --> $DIR/closure-bounds-static-cant-capture-borrowed.rs:6:9
+   |
+LL |   fn foo(x: &()) {
+   |          -  - let's call the lifetime of this reference `'1`
+   |          |
+   |          `x` is a reference that is only valid in the function body
+LL |       bar(|| {
+   |  _________^
+LL | |
+LL | |
+LL | |         let _ = x;
+LL | |     })
+   | |     ^
+   | |     |
+   | |_____`x` escapes the function body here
+   |       argument requires that `'1` must outlive `'static`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/closures/deduce-signature/obligation-with-leaking-placeholders.current.stderr
+++ b/tests/ui/closures/deduce-signature/obligation-with-leaking-placeholders.current.stderr
@@ -1,12 +1,13 @@
 error: implementation of `Foo` is not general enough
-  --> $DIR/obligation-with-leaking-placeholders.rs:18:5
+  --> $DIR/obligation-with-leaking-placeholders.rs:18:15
    |
-LL | /     needs_foo(|x| {
+LL |       needs_foo(|x| {
+   |  _______________^
 LL | |
 LL | |
 LL | |         x.to_string();
 LL | |     });
-   | |______^ implementation of `Foo` is not general enough
+   | |_____^ implementation of `Foo` is not general enough
    |
    = note: `Wrap<{closure@...}>` must implement `Foo<'0>`, for any lifetime `'0`...
    = note: ...but it actually implements `Foo<'1>`, for some specific lifetime `'1`

--- a/tests/ui/closures/deduce-signature/obligation-with-leaking-placeholders.current.stderr
+++ b/tests/ui/closures/deduce-signature/obligation-with-leaking-placeholders.current.stderr
@@ -1,12 +1,13 @@
 error: implementation of `Foo` is not general enough
-  --> $DIR/obligation-with-leaking-placeholders.rs:18:5
+  --> $DIR/obligation-with-leaking-placeholders.rs:18:15
    |
-LL | /     needs_foo(|x| {
+LL |       needs_foo(|x| {
+   |  _______________^
 LL | |
 LL | |
 LL | |         x.to_string();
 LL | |     });
-   | |______^ implementation of `Foo` is not general enough
+   | |_____^ implementation of `Foo` is not general enough
    |
    = note: `Wrap<{closure@$DIR/obligation-with-leaking-placeholders.rs:18:15: 18:18}>` must implement `Foo<'0>`, for any lifetime `'0`...
    = note: ...but it actually implements `Foo<'1>`, for some specific lifetime `'1`

--- a/tests/ui/consts/promoted_const_call5.stderr
+++ b/tests/ui/consts/promoted_const_call5.stderr
@@ -36,10 +36,10 @@ error[E0716]: temporary value dropped while borrowed
   --> $DIR/promoted_const_call5.rs:36:30
    |
 LL |     let _: &'static _ = &id(&new_string());
-   |                          ----^^^^^^^^^^^^-- temporary value is freed at the end of this statement
-   |                          |   |
-   |                          |   creates a temporary value which is freed while still in use
-   |                          argument requires that borrow lasts for `'static`
+   |                             -^^^^^^^^^^^^ - temporary value is freed at the end of this statement
+   |                             ||
+   |                             |creates a temporary value which is freed while still in use
+   |                             argument requires that borrow lasts for `'static`
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promoted_const_call5.rs:40:26

--- a/tests/ui/coroutine/resume-arg-late-bound.stderr
+++ b/tests/ui/coroutine/resume-arg-late-bound.stderr
@@ -1,8 +1,8 @@
 error: implementation of `Coroutine` is not general enough
-  --> $DIR/resume-arg-late-bound.rs:15:5
+  --> $DIR/resume-arg-late-bound.rs:15:10
    |
 LL |     test(gen);
-   |     ^^^^^^^^^ implementation of `Coroutine` is not general enough
+   |          ^^^ implementation of `Coroutine` is not general enough
    |
    = note: `{coroutine@$DIR/resume-arg-late-bound.rs:11:28: 11:44}` must implement `Coroutine<&'1 mut bool>`, for any lifetime `'1`...
    = note: ...but it actually implements `Coroutine<&'2 mut bool>`, for some specific lifetime `'2`

--- a/tests/ui/coroutine/resume-arg-late-bound.stderr
+++ b/tests/ui/coroutine/resume-arg-late-bound.stderr
@@ -1,8 +1,8 @@
 error: implementation of `Coroutine` is not general enough
-  --> $DIR/resume-arg-late-bound.rs:15:5
+  --> $DIR/resume-arg-late-bound.rs:15:10
    |
 LL |     test(gen);
-   |     ^^^^^^^^^ implementation of `Coroutine` is not general enough
+   |          ^^^ implementation of `Coroutine` is not general enough
    |
    = note: `{coroutine@...}` must implement `Coroutine<&'1 mut bool>`, for any lifetime `'1`...
    = note: ...but it actually implements `Coroutine<&'2 mut bool>`, for some specific lifetime `'2`

--- a/tests/ui/coroutine/resume-arg-outlives-2.stderr
+++ b/tests/ui/coroutine/resume-arg-outlives-2.stderr
@@ -1,20 +1,21 @@
 error[E0521]: borrowed data escapes outside of function
-  --> $DIR/resume-arg-outlives-2.rs:21:5
+  --> $DIR/resume-arg-outlives-2.rs:21:19
    |
 LL |   fn demo<'not_static>(s: &'not_static str) -> thread::JoinHandle<()> {
    |           -----------  - `s` is a reference that is only valid in the function body
    |           |
    |           lifetime `'not_static` defined here
 ...
-LL | /     thread::spawn(move || {
+LL |       thread::spawn(move || {
+   |  ___________________^
 LL | |
 LL | |         thread::sleep(time::Duration::from_millis(200));
 LL | |         generator.as_mut().resume(""); // <- resumes from the last `yield`, running `dbg!(ctx)`.
 LL | |     })
-   | |      ^
-   | |      |
-   | |______`s` escapes the function body here
-   |        argument requires that `'not_static` must outlive `'static`
+   | |     ^
+   | |     |
+   | |_____`s` escapes the function body here
+   |       argument requires that `'not_static` must outlive `'static`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/field_representing_types/invariant.next.stderr
+++ b/tests/ui/field_representing_types/invariant.next.stderr
@@ -1,29 +1,29 @@
 error: lifetime may not live long enough
-  --> $DIR/invariant.rs:15:5
+  --> $DIR/invariant.rs:15:13
    |
 LL | fn assert_invariant<'a, 'b>(x: field_of!(Struct<'a>, field), y: field_of!(Struct<'b>, field)) {
    |                     --  -- lifetime `'b` defined here
    |                     |
    |                     lifetime `'a` defined here
 LL |     consume(x, y);
-   |     ^^^^^^^^^^^^^ argument requires that `'a` must outlive `'b`
+   |             ^ argument requires that `'b` must outlive `'a`
    |
-   = help: consider adding the following bound: `'a: 'b`
+   = help: consider adding the following bound: `'b: 'a`
    = note: requirement occurs because of the type `field_of!(Struct<'_>, field)`, which makes the generic argument `Struct<'_>` invariant
    = note: the struct `FieldRepresentingType<T, VARIANT, FIELD>` is invariant over the parameter `T`
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
 error: lifetime may not live long enough
-  --> $DIR/invariant.rs:15:5
+  --> $DIR/invariant.rs:15:16
    |
 LL | fn assert_invariant<'a, 'b>(x: field_of!(Struct<'a>, field), y: field_of!(Struct<'b>, field)) {
    |                     --  -- lifetime `'b` defined here
    |                     |
    |                     lifetime `'a` defined here
 LL |     consume(x, y);
-   |     ^^^^^^^^^^^^^ argument requires that `'b` must outlive `'a`
+   |                ^ argument requires that `'a` must outlive `'b`
    |
-   = help: consider adding the following bound: `'b: 'a`
+   = help: consider adding the following bound: `'a: 'b`
    = note: requirement occurs because of the type `field_of!(Struct<'_>, field)`, which makes the generic argument `Struct<'_>` invariant
    = note: the struct `FieldRepresentingType<T, VARIANT, FIELD>` is invariant over the parameter `T`
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance

--- a/tests/ui/field_representing_types/invariant.old.stderr
+++ b/tests/ui/field_representing_types/invariant.old.stderr
@@ -1,29 +1,29 @@
 error: lifetime may not live long enough
-  --> $DIR/invariant.rs:15:5
+  --> $DIR/invariant.rs:15:13
    |
 LL | fn assert_invariant<'a, 'b>(x: field_of!(Struct<'a>, field), y: field_of!(Struct<'b>, field)) {
    |                     --  -- lifetime `'b` defined here
    |                     |
    |                     lifetime `'a` defined here
 LL |     consume(x, y);
-   |     ^^^^^^^^^^^^^ argument requires that `'a` must outlive `'b`
+   |             ^ argument requires that `'b` must outlive `'a`
    |
-   = help: consider adding the following bound: `'a: 'b`
+   = help: consider adding the following bound: `'b: 'a`
    = note: requirement occurs because of the type `field_of!(Struct<'_>, field)`, which makes the generic argument `Struct<'_>` invariant
    = note: the struct `FieldRepresentingType<T, VARIANT, FIELD>` is invariant over the parameter `T`
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
 error: lifetime may not live long enough
-  --> $DIR/invariant.rs:15:5
+  --> $DIR/invariant.rs:15:16
    |
 LL | fn assert_invariant<'a, 'b>(x: field_of!(Struct<'a>, field), y: field_of!(Struct<'b>, field)) {
    |                     --  -- lifetime `'b` defined here
    |                     |
    |                     lifetime `'a` defined here
 LL |     consume(x, y);
-   |     ^^^^^^^^^^^^^ argument requires that `'b` must outlive `'a`
+   |                ^ argument requires that `'a` must outlive `'b`
    |
-   = help: consider adding the following bound: `'b: 'a`
+   = help: consider adding the following bound: `'a: 'b`
    = note: requirement occurs because of the type `field_of!(Struct<'_>, field)`, which makes the generic argument `Struct<'_>` invariant
    = note: the struct `FieldRepresentingType<T, VARIANT, FIELD>` is invariant over the parameter `T`
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance

--- a/tests/ui/generic-associated-types/bugs/hrtb-implied-1.stderr
+++ b/tests/ui/generic-associated-types/bugs/hrtb-implied-1.stderr
@@ -5,7 +5,7 @@ LL |     let slice = &mut ();
    |                      ^^ creates a temporary value which is freed while still in use
 LL |     let windows = WindowsMut { slice };
 LL |     print_items::<WindowsMut<'_>>(windows);
-   |     -------------------------------------- argument requires that borrow lasts for `'static`
+   |                                   ------- argument requires that borrow lasts for `'static`
 LL | }
    | - temporary value is freed at the end of this statement
    |

--- a/tests/ui/generic-associated-types/bugs/hrtb-implied-2.stderr
+++ b/tests/ui/generic-associated-types/bugs/hrtb-implied-2.stderr
@@ -10,7 +10,7 @@ LL |     let _next = iter2.next();
    |                 ^^^^^^^^^^^^
    |                 |
    |                 `iter` escapes the function body here
-   |                 argument requires that `'1` must outlive `'static`
+   |                 receiver requires that `'1` must outlive `'static`
    |
    = note: requirement occurs because of a mutable reference to `Eat<&mut I, F>`
    = note: mutable references are invariant over their type parameter

--- a/tests/ui/generic-associated-types/bugs/hrtb-implied-2.stderr
+++ b/tests/ui/generic-associated-types/bugs/hrtb-implied-2.stderr
@@ -7,7 +7,7 @@ LL | fn fails<I: LendingIterator, F>(iter: &mut I, f: F) -> bool
    |                                 `iter` is a reference that is only valid in the function body
 ...
 LL |     let _next = iter2.next();
-   |                 ^^^^^^^^^^^^
+   |                 ^^^^^
    |                 |
    |                 `iter` escapes the function body here
    |                 receiver requires that `'1` must outlive `'static`

--- a/tests/ui/generic-associated-types/bugs/hrtb-implied-3.stderr
+++ b/tests/ui/generic-associated-types/bugs/hrtb-implied-3.stderr
@@ -1,15 +1,15 @@
 error[E0521]: borrowed data escapes outside of function
-  --> $DIR/hrtb-implied-3.rs:19:5
+  --> $DIR/hrtb-implied-3.rs:19:19
    |
 LL | fn fails(iter: &str) {
    |          ----  - let's call the lifetime of this reference `'1`
    |          |
    |          `iter` is a reference that is only valid in the function body
 LL |     trivial_bound(iter);
-   |     ^^^^^^^^^^^^^^^^^^^
-   |     |
-   |     `iter` escapes the function body here
-   |     argument requires that `'1` must outlive `'static`
+   |                   ^^^^
+   |                   |
+   |                   `iter` escapes the function body here
+   |                   argument requires that `'1` must outlive `'static`
    |
 note: due to a current limitation of the type system, this implies a `'static` lifetime
   --> $DIR/hrtb-implied-3.rs:14:5

--- a/tests/ui/generic-associated-types/issue-74684-1.stderr
+++ b/tests/ui/generic-associated-types/issue-74684-1.stderr
@@ -6,10 +6,10 @@ LL | fn bug<'a, T: ?Sized + Fun<F<'a> = [u8]>>(_ : Box<T>) -> &'static T::F<'a> 
 LL |     let a = [0; 1];
    |         - binding `a` declared here
 LL |     let _x = T::identity(&a);
-   |              ------------^^-
-   |              |           |
-   |              |           borrowed value does not live long enough
-   |              argument requires that `a` is borrowed for `'a`
+   |                          ^^
+   |                          |
+   |                          borrowed value does not live long enough
+   |                          argument requires that `a` is borrowed for `'a`
 ...
 LL | }
    | - `a` dropped here while still borrowed

--- a/tests/ui/generic-associated-types/issue-74684-2.stderr
+++ b/tests/ui/generic-associated-types/issue-74684-2.stderr
@@ -25,10 +25,10 @@ LL | fn bug<'a, T: ?Sized + Fun<F<'a> = [u8]>>(t: Box<T>) -> &'static T::F<'a> {
 LL |     let a = [0; 1];
    |         - binding `a` declared here
 LL |     let x = T::identity(&a);
-   |             ------------^^-
-   |             |           |
-   |             |           borrowed value does not live long enough
-   |             argument requires that `a` is borrowed for `'a`
+   |                         ^^
+   |                         |
+   |                         borrowed value does not live long enough
+   |                         argument requires that `a` is borrowed for `'a`
 LL |     todo!()
 LL | }
    | - `a` dropped here while still borrowed

--- a/tests/ui/higher-ranked/hrtb-associated-type-leak-check-55731.stderr
+++ b/tests/ui/higher-ranked/hrtb-associated-type-leak-check-55731.stderr
@@ -1,11 +1,12 @@
 error: implementation of `DistributedIteratorMulti` is not general enough
-  --> $DIR/hrtb-associated-type-leak-check-55731.rs:49:5
+  --> $DIR/hrtb-associated-type-leak-check-55731.rs:49:11
    |
-LL | /     multi(Map {
+LL |       multi(Map {
+   |  ___________^
 LL | |         i: Cloned(PhantomData),
 LL | |         f: X,
 LL | |     });
-   | |______^ implementation of `DistributedIteratorMulti` is not general enough
+   | |_____^ implementation of `DistributedIteratorMulti` is not general enough
    |
    = note: `DistributedIteratorMulti<&'0 ()>` would have to be implemented for the type `Cloned<&()>`, for any lifetime `'0`...
    = note: ...but `DistributedIteratorMulti<&'1 ()>` is actually implemented for the type `Cloned<&'1 ()>`, for some specific lifetime `'1`

--- a/tests/ui/higher-ranked/subtype/hr-subtype.bound_a_b_ret_a_vs_bound_a_ret_a.stderr
+++ b/tests/ui/higher-ranked/subtype/hr-subtype.bound_a_b_ret_a_vs_bound_a_ret_a.stderr
@@ -1,8 +1,8 @@
 error[E0308]: mismatched types
-  --> $DIR/hr-subtype.rs:54:13
+  --> $DIR/hr-subtype.rs:54:26
    |
 LL |               gimme::<$t1>(None::<$t2>);
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^ one type is more general than the other
+   |                            ^^^^^^^^^^^ one type is more general than the other
 ...
 LL | / check! { bound_a_b_ret_a_vs_bound_a_ret_a: (for<'a,'b> fn(&'a u32, &'b u32) -> &'a u32,
 LL | | for<'a>    fn(&'a u32, &'a u32) -> &'a u32) }

--- a/tests/ui/higher-ranked/subtype/hr-subtype.bound_a_vs_free_x.stderr
+++ b/tests/ui/higher-ranked/subtype/hr-subtype.bound_a_vs_free_x.stderr
@@ -1,8 +1,8 @@
 error[E0308]: mismatched types
-  --> $DIR/hr-subtype.rs:54:13
+  --> $DIR/hr-subtype.rs:54:26
    |
 LL |               gimme::<$t1>(None::<$t2>);
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^ one type is more general than the other
+   |                            ^^^^^^^^^^^ one type is more general than the other
 ...
 LL | / check! { bound_a_vs_free_x: (for<'a> fn(&'a u32),
 LL | | fn(&'x u32)) }

--- a/tests/ui/higher-ranked/subtype/hr-subtype.bound_inv_a_b_vs_bound_inv_a.stderr
+++ b/tests/ui/higher-ranked/subtype/hr-subtype.bound_inv_a_b_vs_bound_inv_a.stderr
@@ -1,8 +1,8 @@
 error[E0308]: mismatched types
-  --> $DIR/hr-subtype.rs:54:13
+  --> $DIR/hr-subtype.rs:54:26
    |
 LL |               gimme::<$t1>(None::<$t2>);
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^ one type is more general than the other
+   |                            ^^^^^^^^^^^ one type is more general than the other
 ...
 LL | / check! { bound_inv_a_b_vs_bound_inv_a: (for<'a,'b> fn(Inv<'a>, Inv<'b>),
 LL | | for<'a>    fn(Inv<'a>, Inv<'a>)) }
@@ -13,10 +13,10 @@ LL | | for<'a>    fn(Inv<'a>, Inv<'a>)) }
    = note: this error originates in the macro `check` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types
-  --> $DIR/hr-subtype.rs:54:13
+  --> $DIR/hr-subtype.rs:54:26
    |
 LL |               gimme::<$t1>(None::<$t2>);
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^ one type is more general than the other
+   |                            ^^^^^^^^^^^ one type is more general than the other
 ...
 LL | / check! { bound_inv_a_b_vs_bound_inv_a: (for<'a,'b> fn(Inv<'a>, Inv<'b>),
 LL | | for<'a>    fn(Inv<'a>, Inv<'a>)) }

--- a/tests/ui/higher-ranked/subtype/hr-subtype.free_inv_x_vs_free_inv_y.stderr
+++ b/tests/ui/higher-ranked/subtype/hr-subtype.free_inv_x_vs_free_inv_y.stderr
@@ -1,12 +1,12 @@
 error: lifetime may not live long enough
-  --> $DIR/hr-subtype.rs:48:13
+  --> $DIR/hr-subtype.rs:48:26
    |
 LL |           fn subtype<'x, 'y: 'x, 'z: 'y>() {
    |                      --  -- lifetime `'y` defined here
    |                      |
    |                      lifetime `'x` defined here
 LL |               gimme::<$t2>(None::<$t1>);
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^ argument requires that `'x` must outlive `'y`
+   |                            ^^^^^^^^^^^ argument requires that `'x` must outlive `'y`
 ...
 LL | / check! { free_inv_x_vs_free_inv_y: (fn(Inv<'x>),
 LL | | fn(Inv<'y>)) }
@@ -19,14 +19,14 @@ LL | | fn(Inv<'y>)) }
    = note: this error originates in the macro `check` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: lifetime may not live long enough
-  --> $DIR/hr-subtype.rs:54:13
+  --> $DIR/hr-subtype.rs:54:26
    |
 LL |           fn supertype<'x, 'y: 'x, 'z: 'y>() {
    |                        --  -- lifetime `'y` defined here
    |                        |
    |                        lifetime `'x` defined here
 LL |               gimme::<$t1>(None::<$t2>);
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^ argument requires that `'x` must outlive `'y`
+   |                            ^^^^^^^^^^^ argument requires that `'x` must outlive `'y`
 ...
 LL | / check! { free_inv_x_vs_free_inv_y: (fn(Inv<'x>),
 LL | | fn(Inv<'y>)) }

--- a/tests/ui/higher-ranked/subtype/hr-subtype.free_x_vs_free_y.stderr
+++ b/tests/ui/higher-ranked/subtype/hr-subtype.free_x_vs_free_y.stderr
@@ -1,12 +1,12 @@
 error: lifetime may not live long enough
-  --> $DIR/hr-subtype.rs:54:13
+  --> $DIR/hr-subtype.rs:54:26
    |
 LL |           fn supertype<'x, 'y: 'x, 'z: 'y>() {
    |                        --  -- lifetime `'y` defined here
    |                        |
    |                        lifetime `'x` defined here
 LL |               gimme::<$t1>(None::<$t2>);
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^ argument requires that `'x` must outlive `'y`
+   |                            ^^^^^^^^^^^ argument requires that `'x` must outlive `'y`
 ...
 LL | / check! { free_x_vs_free_y: (fn(&'x u32),
 LL | | fn(&'y u32)) }

--- a/tests/ui/impl-header-lifetime-elision/dyn-trait.stderr
+++ b/tests/ui/impl-header-lifetime-elision/dyn-trait.stderr
@@ -1,15 +1,15 @@
 error[E0521]: borrowed data escapes outside of function
-  --> $DIR/dyn-trait.rs:24:5
+  --> $DIR/dyn-trait.rs:24:16
    |
 LL | fn with_dyn_debug_static<'a>(x: Box<dyn Debug + 'a>) {
    |                          --  - `x` is a reference that is only valid in the function body
    |                          |
    |                          lifetime `'a` defined here
 LL |     static_val(x);
-   |     ^^^^^^^^^^^^^
-   |     |
-   |     `x` escapes the function body here
-   |     argument requires that `'a` must outlive `'static`
+   |                ^
+   |                |
+   |                `x` escapes the function body here
+   |                argument requires that `'a` must outlive `'static`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/impl-trait/does-not-live-long-enough.stderr
+++ b/tests/ui/impl-trait/does-not-live-long-enough.stderr
@@ -12,7 +12,7 @@ note: function requires argument type to outlive `'a`
   --> $DIR/does-not-live-long-enough.rs:6:9
    |
 LL |         self.data.iter().filter(|s| s.starts_with(prefix)).map(|s| s.as_ref())
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: to force the closure to take ownership of `prefix` (and any other referenced variables), use the `move` keyword
    |
 LL |         self.data.iter().filter(move |s| s.starts_with(prefix)).map(|s| s.as_ref())

--- a/tests/ui/impl-trait/precise-capturing/migration-note.stderr
+++ b/tests/ui/impl-trait/precise-capturing/migration-note.stderr
@@ -5,10 +5,10 @@ LL |     let x = vec![0];
    |         - binding `x` declared here
 LL |
 LL |     display_len(&x)
-   |     ------------^^-
-   |     |           |
-   |     |           borrowed value does not live long enough
-   |     argument requires that `x` is borrowed for `'static`
+   |                 ^^
+   |                 |
+   |                 borrowed value does not live long enough
+   |                 argument requires that `x` is borrowed for `'static`
 ...
 LL | }
    | - `x` dropped here while still borrowed
@@ -45,7 +45,7 @@ LL |     let a = display_len(&x);
    |                         ^^ borrowed value does not live long enough
 ...
 LL |     needs_static(a);
-   |     --------------- argument requires that `x` is borrowed for `'static`
+   |                  - argument requires that `x` is borrowed for `'static`
 LL |
 LL | }
    | - `x` dropped here while still borrowed
@@ -126,7 +126,7 @@ LL |     let a = display_len_mut(&mut x);
    |                             ^^^^^^ borrowed value does not live long enough
 ...
 LL |     needs_static(a);
-   |     --------------- argument requires that `x` is borrowed for `'static`
+   |                  - argument requires that `x` is borrowed for `'static`
 LL |
 LL | }
    | - `x` dropped here while still borrowed

--- a/tests/ui/impl-trait/precise-capturing/rpitit.rs
+++ b/tests/ui/impl-trait/precise-capturing/rpitit.rs
@@ -11,9 +11,9 @@ trait TraitLt<'a: 'a> {
 }
 fn trait_lt<'a, 'b, T: for<'r> TraitLt<'r>> () {
     eq_types(
-        //~^ ERROR lifetime may not live long enough
-        //~| ERROR lifetime may not live long enough
+        //~v ERROR lifetime may not live long enough
         <T as TraitLt<'a>>::hello(),
+        //~v ERROR lifetime may not live long enough
         <T as TraitLt<'b>>::hello(),
     );
 }

--- a/tests/ui/impl-trait/precise-capturing/rpitit.stderr
+++ b/tests/ui/impl-trait/precise-capturing/rpitit.stderr
@@ -7,38 +7,30 @@ LL |     fn hello() -> impl Sized + use<Self>;
    |                   ^^^^^^^^^^^^^^^^^^^^^^
 
 error: lifetime may not live long enough
-  --> $DIR/rpitit.rs:13:5
+  --> $DIR/rpitit.rs:15:9
    |
-LL |   fn trait_lt<'a, 'b, T: for<'r> TraitLt<'r>> () {
-   |               --  -- lifetime `'b` defined here
-   |               |
-   |               lifetime `'a` defined here
-LL | /     eq_types(
-LL | |
-LL | |
-LL | |         <T as TraitLt<'a>>::hello(),
-LL | |         <T as TraitLt<'b>>::hello(),
-LL | |     );
-   | |_____^ argument requires that `'a` must outlive `'b`
-   |
-   = help: consider adding the following bound: `'a: 'b`
-
-error: lifetime may not live long enough
-  --> $DIR/rpitit.rs:13:5
-   |
-LL |   fn trait_lt<'a, 'b, T: for<'r> TraitLt<'r>> () {
-   |               --  -- lifetime `'b` defined here
-   |               |
-   |               lifetime `'a` defined here
-LL | /     eq_types(
-LL | |
-LL | |
-LL | |         <T as TraitLt<'a>>::hello(),
-LL | |         <T as TraitLt<'b>>::hello(),
-LL | |     );
-   | |_____^ argument requires that `'b` must outlive `'a`
+LL | fn trait_lt<'a, 'b, T: for<'r> TraitLt<'r>> () {
+   |             --  -- lifetime `'b` defined here
+   |             |
+   |             lifetime `'a` defined here
+...
+LL |         <T as TraitLt<'a>>::hello(),
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ argument requires that `'b` must outlive `'a`
    |
    = help: consider adding the following bound: `'b: 'a`
+
+error: lifetime may not live long enough
+  --> $DIR/rpitit.rs:17:9
+   |
+LL | fn trait_lt<'a, 'b, T: for<'r> TraitLt<'r>> () {
+   |             --  -- lifetime `'b` defined here
+   |             |
+   |             lifetime `'a` defined here
+...
+LL |         <T as TraitLt<'b>>::hello(),
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ argument requires that `'a` must outlive `'b`
+   |
+   = help: consider adding the following bound: `'a: 'b`
 
 help: `'a` and `'b` must be the same: replace one with the other
 

--- a/tests/ui/implied-bounds/assoc-ty-wf-used-to-get-assoc-ty.stderr
+++ b/tests/ui/implied-bounds/assoc-ty-wf-used-to-get-assoc-ty.stderr
@@ -4,10 +4,10 @@ error[E0597]: `x` does not live long enough
 LL |     let x: u8 = 3;
    |         - binding `x` declared here
 LL |     let _: &'static u8 = test(&x, &&3);
-   |                          -----^^------
-   |                          |    |
-   |                          |    borrowed value does not live long enough
-   |                          argument requires that `x` is borrowed for `'static`
+   |                               ^^
+   |                               |
+   |                               borrowed value does not live long enough
+   |                               argument requires that `x` is borrowed for `'static`
 ...
 LL | }
    | - `x` dropped here while still borrowed

--- a/tests/ui/lifetimes/apit-not-targeted-by-lifetime-suggestion.stderr
+++ b/tests/ui/lifetimes/apit-not-targeted-by-lifetime-suggestion.stderr
@@ -6,7 +6,7 @@ LL | fn push_apit(vec: &mut Vec<&str>, s: &str, _fun: impl Clone) {
    |                            |
    |                            let's call the lifetime of this reference `'2`
 LL |     vec.push(s);
-   |     ^^^^^^^^^^^ argument requires that `'1` must outlive `'2`
+   |     ^^^ receiver requires that `'1` must outlive `'2`
    |
    = note: requirement occurs because of a mutable reference to `Vec<&str>`
    = note: mutable references are invariant over their type parameter
@@ -24,7 +24,7 @@ LL | fn push_ref_apit(vec: &mut Vec<&str>, s: &str, _fun: &impl Clone) {
    |                                |
    |                                let's call the lifetime of this reference `'2`
 LL |     vec.push(s);
-   |     ^^^^^^^^^^^ argument requires that `'1` must outlive `'2`
+   |     ^^^ receiver requires that `'1` must outlive `'2`
    |
    = note: requirement occurs because of a mutable reference to `Vec<&str>`
    = note: mutable references are invariant over their type parameter
@@ -42,7 +42,7 @@ LL | fn push_real_generic<T>(vec: &mut Vec<&str>, s: &str, _fun: T) {
    |                                       |
    |                                       let's call the lifetime of this reference `'2`
 LL |     vec.push(s);
-   |     ^^^^^^^^^^^ argument requires that `'1` must outlive `'2`
+   |     ^^^ receiver requires that `'1` must outlive `'2`
    |
    = note: requirement occurs because of a mutable reference to `Vec<&str>`
    = note: mutable references are invariant over their type parameter

--- a/tests/ui/lifetimes/elided-self-lifetime-in-trait-fn.stderr
+++ b/tests/ui/lifetimes/elided-self-lifetime-in-trait-fn.stderr
@@ -7,7 +7,7 @@ LL |     fn a(&'a self) -> &'a bool;
 LL |     fn b(&self) {
    |          - let's call the lifetime of this reference `'1`
 LL |         self.a();
-   |         ^^^^^^^^ receiver requires that `'1` must outlive `'a`
+   |         ^^^^ receiver requires that `'1` must outlive `'a`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/lifetimes/elided-self-lifetime-in-trait-fn.stderr
+++ b/tests/ui/lifetimes/elided-self-lifetime-in-trait-fn.stderr
@@ -7,7 +7,7 @@ LL |     fn a(&'a self) -> &'a bool;
 LL |     fn b(&self) {
    |          - let's call the lifetime of this reference `'1`
 LL |         self.a();
-   |         ^^^^^^^^ argument requires that `'1` must outlive `'a`
+   |         ^^^^^^^^ receiver requires that `'1` must outlive `'a`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/lifetimes/issue-79187-2.stderr
+++ b/tests/ui/lifetimes/issue-79187-2.stderr
@@ -43,10 +43,10 @@ LL |     take_foo(|a: &i32| a);
    |                ++++++
 
 error[E0308]: mismatched types
-  --> $DIR/issue-79187-2.rs:11:5
+  --> $DIR/issue-79187-2.rs:11:14
    |
 LL |     take_foo(|a: &i32| a);
-   |     ^^^^^^^^^^^^^^^^^^^^^ one type is more general than the other
+   |              ^^^^^^^^^^^ one type is more general than the other
    |
    = note: expected reference `&_`
               found reference `&_`
@@ -57,10 +57,10 @@ LL | fn take_foo(_: impl Foo) {}
    |                     ^^^
 
 error[E0308]: mismatched types
-  --> $DIR/issue-79187-2.rs:14:5
+  --> $DIR/issue-79187-2.rs:14:14
    |
 LL |     take_foo(|a: &i32| -> &i32 { a });
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ one type is more general than the other
+   |              ^^^^^^^^^^^^^^^^^^^^^^^ one type is more general than the other
    |
    = note: expected reference `&_`
               found reference `&_`

--- a/tests/ui/lifetimes/issue-79187-2.stderr
+++ b/tests/ui/lifetimes/issue-79187-2.stderr
@@ -25,10 +25,10 @@ LL |     take_foo(|a: &i32| a);
    |                ++++++
 
 error[E0308]: mismatched types
-  --> $DIR/issue-79187-2.rs:11:5
+  --> $DIR/issue-79187-2.rs:11:14
    |
 LL |     take_foo(|a: &i32| a);
-   |     ^^^^^^^^^^^^^^^^^^^^^ one type is more general than the other
+   |              ^^^^^^^^^^^ one type is more general than the other
    |
    = note: expected reference `&_`
               found reference `&_`
@@ -48,10 +48,10 @@ LL |     take_foo(|a: &i32| a);
    |                  let's call the lifetime of this reference `'1`
 
 error[E0308]: mismatched types
-  --> $DIR/issue-79187-2.rs:14:5
+  --> $DIR/issue-79187-2.rs:14:14
    |
 LL |     take_foo(|a: &i32| -> &i32 { a });
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ one type is more general than the other
+   |              ^^^^^^^^^^^^^^^^^^^^^^^ one type is more general than the other
    |
    = note: expected reference `&_`
               found reference `&_`

--- a/tests/ui/lifetimes/issue-90170-elision-mismatch.stderr
+++ b/tests/ui/lifetimes/issue-90170-elision-mismatch.stderr
@@ -2,7 +2,7 @@ error: lifetime may not live long enough
   --> $DIR/issue-90170-elision-mismatch.rs:3:40
    |
 LL | pub fn foo(x: &mut Vec<&u8>, y: &u8) { x.push(y); }
-   |                        -        -      ^^^^^^^^^ receiver requires that `'1` must outlive `'2`
+   |                        -        -      ^ receiver requires that `'1` must outlive `'2`
    |                        |        |
    |                        |        let's call the lifetime of this reference `'1`
    |                        let's call the lifetime of this reference `'2`
@@ -19,7 +19,7 @@ error: lifetime may not live long enough
   --> $DIR/issue-90170-elision-mismatch.rs:5:44
    |
 LL | pub fn foo2(x: &mut Vec<&'_ u8>, y: &u8) { x.push(y); }
-   |                         -           -      ^^^^^^^^^ receiver requires that `'1` must outlive `'2`
+   |                         -           -      ^ receiver requires that `'1` must outlive `'2`
    |                         |           |
    |                         |           let's call the lifetime of this reference `'1`
    |                         let's call the lifetime of this reference `'2`
@@ -37,7 +37,7 @@ error: lifetime may not live long enough
   --> $DIR/issue-90170-elision-mismatch.rs:7:63
    |
 LL | pub fn foo3<'a>(_other: &'a [u8], x: &mut Vec<&u8>, y: &u8) { x.push(y); }
-   |                                               -        -      ^^^^^^^^^ receiver requires that `'1` must outlive `'2`
+   |                                               -        -      ^ receiver requires that `'1` must outlive `'2`
    |                                               |        |
    |                                               |        let's call the lifetime of this reference `'1`
    |                                               let's call the lifetime of this reference `'2`

--- a/tests/ui/lifetimes/issue-90170-elision-mismatch.stderr
+++ b/tests/ui/lifetimes/issue-90170-elision-mismatch.stderr
@@ -2,7 +2,7 @@ error: lifetime may not live long enough
   --> $DIR/issue-90170-elision-mismatch.rs:3:40
    |
 LL | pub fn foo(x: &mut Vec<&u8>, y: &u8) { x.push(y); }
-   |                        -        -      ^^^^^^^^^ argument requires that `'1` must outlive `'2`
+   |                        -        -      ^^^^^^^^^ receiver requires that `'1` must outlive `'2`
    |                        |        |
    |                        |        let's call the lifetime of this reference `'1`
    |                        let's call the lifetime of this reference `'2`
@@ -19,7 +19,7 @@ error: lifetime may not live long enough
   --> $DIR/issue-90170-elision-mismatch.rs:5:44
    |
 LL | pub fn foo2(x: &mut Vec<&'_ u8>, y: &u8) { x.push(y); }
-   |                         -           -      ^^^^^^^^^ argument requires that `'1` must outlive `'2`
+   |                         -           -      ^^^^^^^^^ receiver requires that `'1` must outlive `'2`
    |                         |           |
    |                         |           let's call the lifetime of this reference `'1`
    |                         let's call the lifetime of this reference `'2`
@@ -37,7 +37,7 @@ error: lifetime may not live long enough
   --> $DIR/issue-90170-elision-mismatch.rs:7:63
    |
 LL | pub fn foo3<'a>(_other: &'a [u8], x: &mut Vec<&u8>, y: &u8) { x.push(y); }
-   |                                               -        -      ^^^^^^^^^ argument requires that `'1` must outlive `'2`
+   |                                               -        -      ^^^^^^^^^ receiver requires that `'1` must outlive `'2`
    |                                               |        |
    |                                               |        let's call the lifetime of this reference `'1`
    |                                               let's call the lifetime of this reference `'2`

--- a/tests/ui/lifetimes/issue-90600-expected-return-static-indirect.stderr
+++ b/tests/ui/lifetimes/issue-90600-expected-return-static-indirect.stderr
@@ -7,13 +7,13 @@ LL |     let refcell = RefCell::new(&mut foo);
    |                                ^^^^^^^^ borrowed value does not live long enough
 ...
 LL |     read_thing(read);
-   |     ---------------- argument requires that `foo` is borrowed for `'static`
+   |                ---- argument requires that `foo` is borrowed for `'static`
 LL |
 LL | }
    |  - `foo` dropped here while still borrowed
 
 error[E0521]: borrowed data escapes outside of function
-  --> $DIR/issue-90600-expected-return-static-indirect.rs:11:5
+  --> $DIR/issue-90600-expected-return-static-indirect.rs:11:16
    |
 LL | fn inner(mut foo: &[u8]) {
    |          -------  - let's call the lifetime of this reference `'1`
@@ -21,10 +21,10 @@ LL | fn inner(mut foo: &[u8]) {
    |          `foo` is a reference that is only valid in the function body
 ...
 LL |     read_thing(read);
-   |     ^^^^^^^^^^^^^^^^
-   |     |
-   |     `foo` escapes the function body here
-   |     argument requires that `'1` must outlive `'static`
+   |                ^^^^
+   |                |
+   |                `foo` escapes the function body here
+   |                argument requires that `'1` must outlive `'static`
    |
    = note: requirement occurs because of the type `RefCell<(dyn std::io::Read + 'static)>`, which makes the generic argument `(dyn std::io::Read + 'static)` invariant
    = note: the struct `RefCell<T>` is invariant over the parameter `T`

--- a/tests/ui/lifetimes/iterator-trait-lifetime-error-13058.stderr
+++ b/tests/ui/lifetimes/iterator-trait-lifetime-error-13058.stderr
@@ -2,7 +2,7 @@ error[E0621]: explicit lifetime required in the type of `cont`
   --> $DIR/iterator-trait-lifetime-error-13058.rs:16:21
    |
 LL |     let cont_iter = cont.iter();
-   |                     ^^^^^^^^^^^ lifetime `'r` required
+   |                     ^^^^ lifetime `'r` required
    |
 help: add explicit lifetime `'r` to the type of `cont`
    |

--- a/tests/ui/lifetimes/lifetime-bound-will-change-warning.stderr
+++ b/tests/ui/lifetimes/lifetime-bound-will-change-warning.stderr
@@ -1,5 +1,5 @@
 error[E0521]: borrowed data escapes outside of function
-  --> $DIR/lifetime-bound-will-change-warning.rs:34:5
+  --> $DIR/lifetime-bound-will-change-warning.rs:34:13
    |
 LL | fn test2<'a>(x: &'a Box<dyn Fn() + 'a>) {
    |          --  - `x` is a reference that is only valid in the function body
@@ -7,13 +7,13 @@ LL | fn test2<'a>(x: &'a Box<dyn Fn() + 'a>) {
    |          lifetime `'a` defined here
 LL |     // but ref_obj will not, so warn.
 LL |     ref_obj(x)
-   |     ^^^^^^^^^^
-   |     |
-   |     `x` escapes the function body here
-   |     argument requires that `'a` must outlive `'static`
+   |             ^
+   |             |
+   |             `x` escapes the function body here
+   |             argument requires that `'a` must outlive `'static`
 
 error[E0521]: borrowed data escapes outside of function
-  --> $DIR/lifetime-bound-will-change-warning.rs:40:5
+  --> $DIR/lifetime-bound-will-change-warning.rs:40:18
    |
 LL | fn test2cc<'a>(x: &'a Box<dyn Fn() + 'a>) {
    |            --  - `x` is a reference that is only valid in the function body
@@ -21,10 +21,10 @@ LL | fn test2cc<'a>(x: &'a Box<dyn Fn() + 'a>) {
    |            lifetime `'a` defined here
 LL |     // same as test2, but cross crate
 LL |     lib::ref_obj(x)
-   |     ^^^^^^^^^^^^^^^
-   |     |
-   |     `x` escapes the function body here
-   |     argument requires that `'a` must outlive `'static`
+   |                  ^
+   |                  |
+   |                  `x` escapes the function body here
+   |                  argument requires that `'a` must outlive `'static`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/lifetimes/lifetime-errors/e0621-mut-ref-aliases-pointee-lifetime-distinct.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/e0621-mut-ref-aliases-pointee-lifetime-distinct.stderr
@@ -2,7 +2,7 @@ error[E0621]: explicit lifetime required in the type of `y`
   --> $DIR/e0621-mut-ref-aliases-pointee-lifetime-distinct.rs:6:5
    |
 LL |     x.push(y);
-   |     ^^^^^^^^^ lifetime `'a` required
+   |     ^ lifetime `'a` required
    |
 help: add explicit lifetime `'a` to the type of `y`
    |

--- a/tests/ui/lifetimes/lifetime-errors/ex2a-push-one-existing-name-2.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/ex2a-push-one-existing-name-2.stderr
@@ -2,7 +2,7 @@ error[E0621]: explicit lifetime required in the type of `x`
   --> $DIR/ex2a-push-one-existing-name-2.rs:6:5
    |
 LL |     y.push(x);
-   |     ^^^^^^^^^ lifetime `'a` required
+   |     ^ lifetime `'a` required
    |
 help: add explicit lifetime `'a` to the type of `x`
    |

--- a/tests/ui/lifetimes/lifetime-errors/ex2a-push-one-existing-name-early-bound.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/ex2a-push-one-existing-name-early-bound.stderr
@@ -2,7 +2,7 @@ error[E0621]: explicit lifetime required in the type of `y`
   --> $DIR/ex2a-push-one-existing-name-early-bound.rs:8:5
    |
 LL |     x.push(y);
-   |     ^^^^^^^^^ lifetime `'a` required
+   |     ^ lifetime `'a` required
    |
 help: add explicit lifetime `'a` to the type of `y`
    |

--- a/tests/ui/lifetimes/lifetime-errors/ex2a-push-one-existing-name.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/ex2a-push-one-existing-name.stderr
@@ -2,7 +2,7 @@ error[E0621]: explicit lifetime required in the type of `y`
   --> $DIR/ex2a-push-one-existing-name.rs:6:5
    |
 LL |     x.push(y);
-   |     ^^^^^^^^^ lifetime `'a` required
+   |     ^ lifetime `'a` required
    |
 help: add explicit lifetime `'a` to the type of `y`
    |

--- a/tests/ui/lifetimes/lifetime-errors/ex2b-push-no-existing-names.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/ex2b-push-no-existing-names.stderr
@@ -6,7 +6,7 @@ LL | fn foo(x: &mut Vec<Ref<i32>>, y: Ref<i32>) {
    |        |
    |        has type `&mut Vec<Ref<'2, i32>>`
 LL |     x.push(y);
-   |     ^^^^^^^^^ receiver requires that `'1` must outlive `'2`
+   |     ^ receiver requires that `'1` must outlive `'2`
    |
    = note: requirement occurs because of a mutable reference to `Vec<Ref<'_, i32>>`
    = note: mutable references are invariant over their type parameter

--- a/tests/ui/lifetimes/lifetime-errors/ex2b-push-no-existing-names.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/ex2b-push-no-existing-names.stderr
@@ -6,7 +6,7 @@ LL | fn foo(x: &mut Vec<Ref<i32>>, y: Ref<i32>) {
    |        |
    |        has type `&mut Vec<Ref<'2, i32>>`
 LL |     x.push(y);
-   |     ^^^^^^^^^ argument requires that `'1` must outlive `'2`
+   |     ^^^^^^^^^ receiver requires that `'1` must outlive `'2`
    |
    = note: requirement occurs because of a mutable reference to `Vec<Ref<'_, i32>>`
    = note: mutable references are invariant over their type parameter

--- a/tests/ui/lifetimes/lifetime-errors/ex2c-push-inference-variable.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/ex2c-push-inference-variable.stderr
@@ -7,7 +7,7 @@ LL | fn foo<'a, 'b, 'c>(x: &'a mut Vec<Ref<'b, i32>>, y: Ref<'c, i32>) {
    |            lifetime `'b` defined here
 LL |     let z = Ref { data: y.data };
 LL |     x.push(z);
-   |     ^^^^^^^^^ receiver requires that `'c` must outlive `'b`
+   |     ^ receiver requires that `'c` must outlive `'b`
    |
    = help: consider adding the following bound: `'c: 'b`
    = note: requirement occurs because of a mutable reference to `Vec<Ref<'_, i32>>`

--- a/tests/ui/lifetimes/lifetime-errors/ex2c-push-inference-variable.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/ex2c-push-inference-variable.stderr
@@ -7,7 +7,7 @@ LL | fn foo<'a, 'b, 'c>(x: &'a mut Vec<Ref<'b, i32>>, y: Ref<'c, i32>) {
    |            lifetime `'b` defined here
 LL |     let z = Ref { data: y.data };
 LL |     x.push(z);
-   |     ^^^^^^^^^ argument requires that `'c` must outlive `'b`
+   |     ^^^^^^^^^ receiver requires that `'c` must outlive `'b`
    |
    = help: consider adding the following bound: `'c: 'b`
    = note: requirement occurs because of a mutable reference to `Vec<Ref<'_, i32>>`

--- a/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-3.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-3.stderr
@@ -6,7 +6,7 @@ LL | fn foo(z: &mut Vec<(&u8,&u8)>, (x, y): (&u8, &u8)) {
    |                     |
    |                     let's call the lifetime of this reference `'2`
 LL |     z.push((x,y));
-   |     ^^^^^^^^^^^^^ receiver requires that `'1` must outlive `'2`
+   |     ^ receiver requires that `'1` must outlive `'2`
    |
    = note: requirement occurs because of a mutable reference to `Vec<(&u8, &u8)>`
    = note: mutable references are invariant over their type parameter
@@ -24,7 +24,7 @@ LL | fn foo(z: &mut Vec<(&u8,&u8)>, (x, y): (&u8, &u8)) {
    |                         |
    |                         let's call the lifetime of this reference `'4`
 LL |     z.push((x,y));
-   |     ^^^^^^^^^^^^^ receiver requires that `'3` must outlive `'4`
+   |     ^ receiver requires that `'3` must outlive `'4`
    |
    = note: requirement occurs because of a mutable reference to `Vec<(&u8, &u8)>`
    = note: mutable references are invariant over their type parameter

--- a/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-3.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-3.stderr
@@ -6,7 +6,7 @@ LL | fn foo(z: &mut Vec<(&u8,&u8)>, (x, y): (&u8, &u8)) {
    |                     |
    |                     let's call the lifetime of this reference `'2`
 LL |     z.push((x,y));
-   |     ^^^^^^^^^^^^^ argument requires that `'1` must outlive `'2`
+   |     ^^^^^^^^^^^^^ receiver requires that `'1` must outlive `'2`
    |
    = note: requirement occurs because of a mutable reference to `Vec<(&u8, &u8)>`
    = note: mutable references are invariant over their type parameter
@@ -24,7 +24,7 @@ LL | fn foo(z: &mut Vec<(&u8,&u8)>, (x, y): (&u8, &u8)) {
    |                         |
    |                         let's call the lifetime of this reference `'4`
 LL |     z.push((x,y));
-   |     ^^^^^^^^^^^^^ argument requires that `'3` must outlive `'4`
+   |     ^^^^^^^^^^^^^ receiver requires that `'3` must outlive `'4`
    |
    = note: requirement occurs because of a mutable reference to `Vec<(&u8, &u8)>`
    = note: mutable references are invariant over their type parameter

--- a/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-both-are-structs-earlybound-regions.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-both-are-structs-earlybound-regions.stderr
@@ -7,7 +7,7 @@ LL | fn foo<'a, 'b>(mut x: Vec<Ref<'a>>, y: Ref<'b>)
    |        lifetime `'a` defined here
 ...
 LL |     x.push(y);
-   |     ^^^^^^^^^ argument requires that `'b` must outlive `'a`
+   |     ^^^^^^^^^ receiver requires that `'b` must outlive `'a`
    |
    = help: consider adding the following bound: `'b: 'a`
    = note: requirement occurs because of a mutable reference to `Vec<Ref<'_>>`

--- a/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-both-are-structs-earlybound-regions.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-both-are-structs-earlybound-regions.stderr
@@ -7,7 +7,7 @@ LL | fn foo<'a, 'b>(mut x: Vec<Ref<'a>>, y: Ref<'b>)
    |        lifetime `'a` defined here
 ...
 LL |     x.push(y);
-   |     ^^^^^^^^^ receiver requires that `'b` must outlive `'a`
+   |     ^ receiver requires that `'b` must outlive `'a`
    |
    = help: consider adding the following bound: `'b: 'a`
    = note: requirement occurs because of a mutable reference to `Vec<Ref<'_>>`

--- a/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-both-are-structs-latebound-regions.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-both-are-structs-latebound-regions.stderr
@@ -6,7 +6,7 @@ LL | fn foo<'a, 'b>(mut x: Vec<Ref<'a>>, y: Ref<'b>) {
    |        |
    |        lifetime `'a` defined here
 LL |     x.push(y);
-   |     ^^^^^^^^^ receiver requires that `'b` must outlive `'a`
+   |     ^ receiver requires that `'b` must outlive `'a`
    |
    = help: consider adding the following bound: `'b: 'a`
    = note: requirement occurs because of a mutable reference to `Vec<Ref<'_>>`

--- a/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-both-are-structs-latebound-regions.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-both-are-structs-latebound-regions.stderr
@@ -6,7 +6,7 @@ LL | fn foo<'a, 'b>(mut x: Vec<Ref<'a>>, y: Ref<'b>) {
    |        |
    |        lifetime `'a` defined here
 LL |     x.push(y);
-   |     ^^^^^^^^^ argument requires that `'b` must outlive `'a`
+   |     ^^^^^^^^^ receiver requires that `'b` must outlive `'a`
    |
    = help: consider adding the following bound: `'b: 'a`
    = note: requirement occurs because of a mutable reference to `Vec<Ref<'_>>`

--- a/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-both-are-structs.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-both-are-structs.stderr
@@ -6,7 +6,7 @@ LL | fn foo(mut x: Vec<Ref>, y: Ref) {
    |        |
    |        has type `Vec<Ref<'2>>`
 LL |     x.push(y);
-   |     ^^^^^^^^^ argument requires that `'1` must outlive `'2`
+   |     ^^^^^^^^^ receiver requires that `'1` must outlive `'2`
    |
    = note: requirement occurs because of a mutable reference to `Vec<Ref<'_>>`
    = note: mutable references are invariant over their type parameter

--- a/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-both-are-structs.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-both-are-structs.stderr
@@ -6,7 +6,7 @@ LL | fn foo(mut x: Vec<Ref>, y: Ref) {
    |        |
    |        has type `Vec<Ref<'2>>`
 LL |     x.push(y);
-   |     ^^^^^^^^^ receiver requires that `'1` must outlive `'2`
+   |     ^ receiver requires that `'1` must outlive `'2`
    |
    = note: requirement occurs because of a mutable reference to `Vec<Ref<'_>>`
    = note: mutable references are invariant over their type parameter

--- a/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-latebound-regions.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-latebound-regions.stderr
@@ -6,7 +6,7 @@ LL | fn foo<'a,'b>(x: &mut Vec<&'a u8>, y: &'b u8) {
    |        |
    |        lifetime `'a` defined here
 LL |     x.push(y);
-   |     ^^^^^^^^^ argument requires that `'b` must outlive `'a`
+   |     ^^^^^^^^^ receiver requires that `'b` must outlive `'a`
    |
    = help: consider adding the following bound: `'b: 'a`
    = note: requirement occurs because of a mutable reference to `Vec<&u8>`

--- a/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-latebound-regions.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-latebound-regions.stderr
@@ -6,7 +6,7 @@ LL | fn foo<'a,'b>(x: &mut Vec<&'a u8>, y: &'b u8) {
    |        |
    |        lifetime `'a` defined here
 LL |     x.push(y);
-   |     ^^^^^^^^^ receiver requires that `'b` must outlive `'a`
+   |     ^ receiver requires that `'b` must outlive `'a`
    |
    = help: consider adding the following bound: `'b: 'a`
    = note: requirement occurs because of a mutable reference to `Vec<&u8>`

--- a/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-one-is-struct-5.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-one-is-struct-5.stderr
@@ -6,7 +6,7 @@ LL | fn bar(foo: &mut Foo) {
    |        |
    |        has type `&mut Foo<'2>`
 LL |     foo.modify();
-   |     ^^^^^^^^^^^^ argument requires that `'1` must outlive `'2`
+   |     ^^^^^^^^^^^^ receiver requires that `'1` must outlive `'2`
    |
    = note: requirement occurs because of a mutable reference to `Foo<'_>`
    = note: mutable references are invariant over their type parameter

--- a/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-one-is-struct-5.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-one-is-struct-5.stderr
@@ -6,7 +6,7 @@ LL | fn bar(foo: &mut Foo) {
    |        |
    |        has type `&mut Foo<'2>`
 LL |     foo.modify();
-   |     ^^^^^^^^^^^^ receiver requires that `'1` must outlive `'2`
+   |     ^^^ receiver requires that `'1` must outlive `'2`
    |
    = note: requirement occurs because of a mutable reference to `Foo<'_>`
    = note: mutable references are invariant over their type parameter

--- a/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-using-fn-items.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-using-fn-items.stderr
@@ -1,3 +1,21 @@
+error: lifetime may not live long enough
+  --> $DIR/ex3-both-anon-regions-using-fn-items.rs:2:3
+   |
+LL | fn foo(x:fn(&u8, &u8), y: Vec<&u8>, z: &u8) {
+   |                               -        - let's call the lifetime of this reference `'1`
+   |                               |
+   |                               let's call the lifetime of this reference `'2`
+LL |   y.push(z);
+   |   ^ receiver requires that `'1` must outlive `'2`
+   |
+   = note: requirement occurs because of a mutable reference to `Vec<&u8>`
+   = note: mutable references are invariant over their type parameter
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
+help: consider introducing a named lifetime parameter
+   |
+LL | fn foo<'a>(x:fn(&u8, &u8), y: Vec<&'a u8>, z: &'a u8) {
+   |       ++++                         ++          ++
+
 error[E0596]: cannot borrow `y` as mutable, as it is not declared as mutable
   --> $DIR/ex3-both-anon-regions-using-fn-items.rs:2:3
    |
@@ -8,24 +26,6 @@ help: consider changing this to be mutable
    |
 LL | fn foo(x:fn(&u8, &u8), mut y: Vec<&u8>, z: &u8) {
    |                        +++
-
-error: lifetime may not live long enough
-  --> $DIR/ex3-both-anon-regions-using-fn-items.rs:2:3
-   |
-LL | fn foo(x:fn(&u8, &u8), y: Vec<&u8>, z: &u8) {
-   |                               -        - let's call the lifetime of this reference `'1`
-   |                               |
-   |                               let's call the lifetime of this reference `'2`
-LL |   y.push(z);
-   |   ^^^^^^^^^ receiver requires that `'1` must outlive `'2`
-   |
-   = note: requirement occurs because of a mutable reference to `Vec<&u8>`
-   = note: mutable references are invariant over their type parameter
-   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
-help: consider introducing a named lifetime parameter
-   |
-LL | fn foo<'a>(x:fn(&u8, &u8), y: Vec<&'a u8>, z: &'a u8) {
-   |       ++++                         ++          ++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-using-fn-items.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-using-fn-items.stderr
@@ -17,7 +17,7 @@ LL | fn foo(x:fn(&u8, &u8), y: Vec<&u8>, z: &u8) {
    |                               |
    |                               let's call the lifetime of this reference `'2`
 LL |   y.push(z);
-   |   ^^^^^^^^^ argument requires that `'1` must outlive `'2`
+   |   ^^^^^^^^^ receiver requires that `'1` must outlive `'2`
    |
    = note: requirement occurs because of a mutable reference to `Vec<&u8>`
    = note: mutable references are invariant over their type parameter

--- a/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-using-impl-items.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-using-impl-items.stderr
@@ -6,7 +6,7 @@ LL |     fn foo(x: &mut Vec<&u8>, y: &u8) {
    |                        |
    |                        let's call the lifetime of this reference `'2`
 LL |         x.push(y);
-   |         ^^^^^^^^^ argument requires that `'1` must outlive `'2`
+   |         ^^^^^^^^^ receiver requires that `'1` must outlive `'2`
    |
    = note: requirement occurs because of a mutable reference to `Vec<&u8>`
    = note: mutable references are invariant over their type parameter

--- a/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-using-impl-items.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-using-impl-items.stderr
@@ -6,7 +6,7 @@ LL |     fn foo(x: &mut Vec<&u8>, y: &u8) {
    |                        |
    |                        let's call the lifetime of this reference `'2`
 LL |         x.push(y);
-   |         ^^^^^^^^^ receiver requires that `'1` must outlive `'2`
+   |         ^ receiver requires that `'1` must outlive `'2`
    |
    = note: requirement occurs because of a mutable reference to `Vec<&u8>`
    = note: mutable references are invariant over their type parameter

--- a/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-using-trait-objects.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-using-trait-objects.stderr
@@ -1,3 +1,21 @@
+error: lifetime may not live long enough
+  --> $DIR/ex3-both-anon-regions-using-trait-objects.rs:2:3
+   |
+LL | fn foo(x:Box<dyn Fn(&u8, &u8)> , y: Vec<&u8>, z: &u8) {
+   |                                         -        - let's call the lifetime of this reference `'1`
+   |                                         |
+   |                                         let's call the lifetime of this reference `'2`
+LL |   y.push(z);
+   |   ^ receiver requires that `'1` must outlive `'2`
+   |
+   = note: requirement occurs because of a mutable reference to `Vec<&u8>`
+   = note: mutable references are invariant over their type parameter
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
+help: consider introducing a named lifetime parameter
+   |
+LL | fn foo<'a>(x:Box<dyn Fn(&u8, &u8)> , y: Vec<&'a u8>, z: &'a u8) {
+   |       ++++                                   ++          ++
+
 error[E0596]: cannot borrow `y` as mutable, as it is not declared as mutable
   --> $DIR/ex3-both-anon-regions-using-trait-objects.rs:2:3
    |
@@ -8,24 +26,6 @@ help: consider changing this to be mutable
    |
 LL | fn foo(x:Box<dyn Fn(&u8, &u8)> , mut y: Vec<&u8>, z: &u8) {
    |                                  +++
-
-error: lifetime may not live long enough
-  --> $DIR/ex3-both-anon-regions-using-trait-objects.rs:2:3
-   |
-LL | fn foo(x:Box<dyn Fn(&u8, &u8)> , y: Vec<&u8>, z: &u8) {
-   |                                         -        - let's call the lifetime of this reference `'1`
-   |                                         |
-   |                                         let's call the lifetime of this reference `'2`
-LL |   y.push(z);
-   |   ^^^^^^^^^ receiver requires that `'1` must outlive `'2`
-   |
-   = note: requirement occurs because of a mutable reference to `Vec<&u8>`
-   = note: mutable references are invariant over their type parameter
-   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
-help: consider introducing a named lifetime parameter
-   |
-LL | fn foo<'a>(x:Box<dyn Fn(&u8, &u8)> , y: Vec<&'a u8>, z: &'a u8) {
-   |       ++++                                   ++          ++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-using-trait-objects.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-using-trait-objects.stderr
@@ -17,7 +17,7 @@ LL | fn foo(x:Box<dyn Fn(&u8, &u8)> , y: Vec<&u8>, z: &u8) {
    |                                         |
    |                                         let's call the lifetime of this reference `'2`
 LL |   y.push(z);
-   |   ^^^^^^^^^ argument requires that `'1` must outlive `'2`
+   |   ^^^^^^^^^ receiver requires that `'1` must outlive `'2`
    |
    = note: requirement occurs because of a mutable reference to `Vec<&u8>`
    = note: mutable references are invariant over their type parameter

--- a/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions.stderr
@@ -6,7 +6,7 @@ LL | fn foo(x: &mut Vec<&u8>, y: &u8) {
    |                    |
    |                    let's call the lifetime of this reference `'2`
 LL |     x.push(y);
-   |     ^^^^^^^^^ argument requires that `'1` must outlive `'2`
+   |     ^^^^^^^^^ receiver requires that `'1` must outlive `'2`
    |
    = note: requirement occurs because of a mutable reference to `Vec<&u8>`
    = note: mutable references are invariant over their type parameter

--- a/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions.stderr
@@ -6,7 +6,7 @@ LL | fn foo(x: &mut Vec<&u8>, y: &u8) {
    |                    |
    |                    let's call the lifetime of this reference `'2`
 LL |     x.push(y);
-   |     ^^^^^^^^^ receiver requires that `'1` must outlive `'2`
+   |     ^ receiver requires that `'1` must outlive `'2`
    |
    = note: requirement occurs because of a mutable reference to `Vec<&u8>`
    = note: mutable references are invariant over their type parameter

--- a/tests/ui/lifetimes/trait-method-lifetime-suggestion.stderr
+++ b/tests/ui/lifetimes/trait-method-lifetime-suggestion.stderr
@@ -7,7 +7,7 @@ LL |     fn foo(&'a self);
 LL |     fn bar(&self) {
    |            - let's call the lifetime of this reference `'1`
 LL |         self.foo();
-   |         ^^^^^^^^^^ receiver requires that `'1` must outlive `'a`
+   |         ^^^^ receiver requires that `'1` must outlive `'a`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/lifetimes/trait-method-lifetime-suggestion.stderr
+++ b/tests/ui/lifetimes/trait-method-lifetime-suggestion.stderr
@@ -7,7 +7,7 @@ LL |     fn foo(&'a self);
 LL |     fn bar(&self) {
    |            - let's call the lifetime of this reference `'1`
 LL |         self.foo();
-   |         ^^^^^^^^^^ argument requires that `'1` must outlive `'a`
+   |         ^^^^^^^^^^ receiver requires that `'1` must outlive `'a`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/mismatched_types/closure-arg-type-mismatch.stderr
+++ b/tests/ui/mismatched_types/closure-arg-type-mismatch.stderr
@@ -42,17 +42,17 @@ note: required by a bound in `map`
   --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
 
 error[E0521]: borrowed data escapes outside of function
-  --> $DIR/closure-arg-type-mismatch.rs:10:5
+  --> $DIR/closure-arg-type-mismatch.rs:10:9
    |
 LL | fn _test<'a>(f: fn(*mut &'a u32)) {
    |          --  - `f` is a reference that is only valid in the function body
    |          |
    |          lifetime `'a` defined here
 LL |     baz(f);
-   |     ^^^^^^
-   |     |
-   |     `f` escapes the function body here
-   |     argument requires that `'a` must outlive `'static`
+   |         ^
+   |         |
+   |         `f` escapes the function body here
+   |         argument requires that `'a` must outlive `'static`
    |
    = note: requirement occurs because of a mutable pointer to `&u32`
    = note: mutable pointers are invariant over their type parameter
@@ -64,19 +64,19 @@ LL | fn baz<F: Fn(*mut &u32)>(_: F) {}
    |           ^^^^^^^^^^^^^
 
 error: implementation of `Fn` is not general enough
-  --> $DIR/closure-arg-type-mismatch.rs:10:5
+  --> $DIR/closure-arg-type-mismatch.rs:10:9
    |
 LL |     baz(f);
-   |     ^^^^^^ implementation of `Fn` is not general enough
+   |         ^ implementation of `Fn` is not general enough
    |
    = note: `fn(*mut &'2 u32)` must implement `Fn<(*mut &'1 u32,)>`, for any lifetime `'1`...
    = note: ...but it actually implements `Fn<(*mut &'2 u32,)>`, for some specific lifetime `'2`
 
 error: implementation of `FnOnce` is not general enough
-  --> $DIR/closure-arg-type-mismatch.rs:10:5
+  --> $DIR/closure-arg-type-mismatch.rs:10:9
    |
 LL |     baz(f);
-   |     ^^^^^^ implementation of `FnOnce` is not general enough
+   |         ^ implementation of `FnOnce` is not general enough
    |
    = note: `fn(*mut &'2 u32)` must implement `FnOnce<(*mut &'1 u32,)>`, for any lifetime `'1`...
    = note: ...but it actually implements `FnOnce<(*mut &'2 u32,)>`, for some specific lifetime `'2`

--- a/tests/ui/nll/closure-requirements/propagate-approximated-both-lower-bounds.rs
+++ b/tests/ui/nll/closure-requirements/propagate-approximated-both-lower-bounds.rs
@@ -34,11 +34,11 @@ fn demand_y<'x, 'y>(_cell_x: Cell<&'x u32>, _cell_y: Cell<&'y u32>, _y: &'y u32)
 
 #[rustc_regions]
 fn supply<'a, 'b, 'c>(cell_a: Cell<&'a u32>, cell_b: Cell<&'b u32>, cell_c: Cell<&'c u32>) {
-    //~vv ERROR lifetime may not live long enough
-    //~v ERROR lifetime may not live long enough
     establish_relationships(
         cell_a,
         cell_b,
+        //~vv ERROR lifetime may not live long enough
+        //~v ERROR lifetime may not live long enough
         cell_c,
         |_outlives1, _outlives2, _outlives3, x, y| {
             // Only works if 'x: 'y:

--- a/tests/ui/nll/closure-requirements/propagate-approximated-both-lower-bounds.stderr
+++ b/tests/ui/nll/closure-requirements/propagate-approximated-both-lower-bounds.stderr
@@ -27,21 +27,15 @@ LL | fn supply<'a, 'b, 'c>(cell_a: Cell<&'a u32>, cell_b: Cell<&'b u32>, cell_c:
    = note: defining type: supply
 
 error: lifetime may not live long enough
-  --> $DIR/propagate-approximated-both-lower-bounds.rs:39:5
+  --> $DIR/propagate-approximated-both-lower-bounds.rs:42:9
    |
-LL |   fn supply<'a, 'b, 'c>(cell_a: Cell<&'a u32>, cell_b: Cell<&'b u32>, cell_c: Cell<&'c u32>) {
-   |             --      -- lifetime `'c` defined here
-   |             |
-   |             lifetime `'a` defined here
+LL | fn supply<'a, 'b, 'c>(cell_a: Cell<&'a u32>, cell_b: Cell<&'b u32>, cell_c: Cell<&'c u32>) {
+   |           --      -- lifetime `'c` defined here
+   |           |
+   |           lifetime `'a` defined here
 ...
-LL | /     establish_relationships(
-LL | |         cell_a,
-LL | |         cell_b,
-LL | |         cell_c,
-...  |
-LL | |         },
-LL | |     );
-   | |_____^ argument requires that `'a` must outlive `'c`
+LL |         cell_c,
+   |         ^^^^^^ argument requires that `'a` must outlive `'c`
    |
    = help: consider adding the following bound: `'a: 'c`
    = note: requirement occurs because of the type `Cell<&'?10 u32>`, which makes the generic argument `&'?10 u32` invariant
@@ -49,21 +43,15 @@ LL | |     );
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
 error: lifetime may not live long enough
-  --> $DIR/propagate-approximated-both-lower-bounds.rs:39:5
+  --> $DIR/propagate-approximated-both-lower-bounds.rs:42:9
    |
-LL |   fn supply<'a, 'b, 'c>(cell_a: Cell<&'a u32>, cell_b: Cell<&'b u32>, cell_c: Cell<&'c u32>) {
-   |                 --  -- lifetime `'c` defined here
-   |                 |
-   |                 lifetime `'b` defined here
+LL | fn supply<'a, 'b, 'c>(cell_a: Cell<&'a u32>, cell_b: Cell<&'b u32>, cell_c: Cell<&'c u32>) {
+   |               --  -- lifetime `'c` defined here
+   |               |
+   |               lifetime `'b` defined here
 ...
-LL | /     establish_relationships(
-LL | |         cell_a,
-LL | |         cell_b,
-LL | |         cell_c,
-...  |
-LL | |         },
-LL | |     );
-   | |_____^ argument requires that `'b` must outlive `'c`
+LL |         cell_c,
+   |         ^^^^^^ argument requires that `'b` must outlive `'c`
    |
    = help: consider adding the following bound: `'b: 'c`
    = note: requirement occurs because of the type `Cell<&'?10 u32>`, which makes the generic argument `&'?10 u32` invariant

--- a/tests/ui/nll/closure-requirements/propagate-approximated-ref.stderr
+++ b/tests/ui/nll/closure-requirements/propagate-approximated-ref.stderr
@@ -29,16 +29,14 @@ LL | fn supply<'a, 'b>(cell_a: Cell<&'a u32>, cell_b: Cell<&'b u32>) {
    = note: defining type: supply
 
 error: lifetime may not live long enough
-  --> $DIR/propagate-approximated-ref.rs:43:5
+  --> $DIR/propagate-approximated-ref.rs:43:38
    |
-LL |   fn supply<'a, 'b>(cell_a: Cell<&'a u32>, cell_b: Cell<&'b u32>) {
-   |             --  -- lifetime `'b` defined here
-   |             |
-   |             lifetime `'a` defined here
-LL | /     establish_relationships(&cell_a, &cell_b, |_outlives1, _outlives2, x, y| {
-...  |
-LL | |     });
-   | |______^ argument requires that `'a` must outlive `'b`
+LL | fn supply<'a, 'b>(cell_a: Cell<&'a u32>, cell_b: Cell<&'b u32>) {
+   |           --  -- lifetime `'b` defined here
+   |           |
+   |           lifetime `'a` defined here
+LL |     establish_relationships(&cell_a, &cell_b, |_outlives1, _outlives2, x, y| {
+   |                                      ^^^^^^^ argument requires that `'a` must outlive `'b`
    |
    = help: consider adding the following bound: `'a: 'b`
    = note: requirement occurs because of the type `Cell<&'?11 u32>`, which makes the generic argument `&'?11 u32` invariant

--- a/tests/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-comparing-against-free.stderr
+++ b/tests/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-comparing-against-free.stderr
@@ -65,7 +65,7 @@ LL |     let cell = Cell::new(&a);
    |                          ^^ borrowed value does not live long enough
 ...
 LL |         cell_x.set(cell_a.get()); // forces 'a: 'x, implies 'a = 'static -> borrow error
-   |         ------------------------ argument requires that `a` is borrowed for `'static`
+   |         ------------------------ receiver requires that `a` is borrowed for `'static`
 LL |     })
 LL | }
    | - `a` dropped here while still borrowed

--- a/tests/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-comparing-against-free.stderr
+++ b/tests/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-comparing-against-free.stderr
@@ -19,7 +19,7 @@ LL |     foo(cell, |cell_a, cell_x| {
    |                |
    |                `cell_a` declared here, outside of the closure body
 LL |         cell_a.set(cell_x.get()); // forces 'x: 'a, error in closure
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^ `cell_x` escapes the closure body here
+   |         ^^^^^^ `cell_x` escapes the closure body here
    |
    = note: requirement occurs because of the type `Cell<&'?9 u32>`, which makes the generic argument `&'?9 u32` invariant
    = note: the struct `Cell<T>` is invariant over the parameter `T`
@@ -65,7 +65,7 @@ LL |     let cell = Cell::new(&a);
    |                          ^^ borrowed value does not live long enough
 ...
 LL |         cell_x.set(cell_a.get()); // forces 'a: 'x, implies 'a = 'static -> borrow error
-   |         ------------------------ receiver requires that `a` is borrowed for `'static`
+   |         ------ receiver requires that `a` is borrowed for `'static`
 LL |     })
 LL | }
    | - `a` dropped here while still borrowed

--- a/tests/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-comparing-against-free.stderr
+++ b/tests/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-comparing-against-free.stderr
@@ -27,7 +27,7 @@ LL |     foo(cell, |cell_a, cell_x| {
    |                |
    |                `cell_a` declared here, outside of the closure body
 LL |         cell_a.set(cell_x.get()); // forces 'x: 'a, error in closure
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^ `cell_x` escapes the closure body here
+   |         ^^^^^^ `cell_x` escapes the closure body here
    |
    = note: requirement occurs because of the type `Cell<&'?9 u32>`, which makes the generic argument `&'?9 u32` invariant
    = note: the struct `Cell<T>` is invariant over the parameter `T`
@@ -65,7 +65,7 @@ LL |     let cell = Cell::new(&a);
    |                          ^^ borrowed value does not live long enough
 ...
 LL |         cell_x.set(cell_a.get()); // forces 'a: 'x, implies 'a = 'static -> borrow error
-   |         ------------------------ receiver requires that `a` is borrowed for `'static`
+   |         ------ receiver requires that `a` is borrowed for `'static`
 LL |     })
 LL | }
    | - `a` dropped here while still borrowed

--- a/tests/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-no-bound.stderr
+++ b/tests/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-no-bound.stderr
@@ -28,7 +28,7 @@ LL | fn supply<'a, 'b>(cell_a: Cell<&'a u32>, cell_b: Cell<&'b u32>) {
    = note: defining type: supply
 
 error[E0521]: borrowed data escapes outside of function
-  --> $DIR/propagate-approximated-shorter-to-static-no-bound.rs:34:9
+  --> $DIR/propagate-approximated-shorter-to-static-no-bound.rs:34:21
    |
 LL | fn supply<'a, 'b>(cell_a: Cell<&'a u32>, cell_b: Cell<&'b u32>) {
    |           --      ------ `cell_a` is a reference that is only valid in the function body
@@ -36,10 +36,10 @@ LL | fn supply<'a, 'b>(cell_a: Cell<&'a u32>, cell_b: Cell<&'b u32>) {
    |           lifetime `'a` defined here
 ...
 LL |         demand_y(x, y, x.get())
-   |         ^^^^^^^^^^^^^^^^^^^^^^^
-   |         |
-   |         `cell_a` escapes the function body here
-   |         argument requires that `'a` must outlive `'static`
+   |                     ^
+   |                     |
+   |                     `cell_a` escapes the function body here
+   |                     argument requires that `'a` must outlive `'static`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-wrong-bound.stderr
+++ b/tests/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-wrong-bound.stderr
@@ -29,7 +29,7 @@ LL | fn supply<'a, 'b>(cell_a: Cell<&'a u32>, cell_b: Cell<&'b u32>) {
    = note: defining type: supply
 
 error[E0521]: borrowed data escapes outside of function
-  --> $DIR/propagate-approximated-shorter-to-static-wrong-bound.rs:37:9
+  --> $DIR/propagate-approximated-shorter-to-static-wrong-bound.rs:37:21
    |
 LL | fn supply<'a, 'b>(cell_a: Cell<&'a u32>, cell_b: Cell<&'b u32>) {
    |           --      ------ `cell_a` is a reference that is only valid in the function body
@@ -37,10 +37,10 @@ LL | fn supply<'a, 'b>(cell_a: Cell<&'a u32>, cell_b: Cell<&'b u32>) {
    |           lifetime `'a` defined here
 ...
 LL |         demand_y(x, y, x.get())
-   |         ^^^^^^^^^^^^^^^^^^^^^^^
-   |         |
-   |         `cell_a` escapes the function body here
-   |         argument requires that `'a` must outlive `'static`
+   |                     ^
+   |                     |
+   |                     `cell_a` escapes the function body here
+   |                     argument requires that `'a` must outlive `'static`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/nll/closure-requirements/propagate-approximated-val.stderr
+++ b/tests/ui/nll/closure-requirements/propagate-approximated-val.stderr
@@ -25,16 +25,14 @@ LL | fn test<'a, 'b>(cell_a: Cell<&'a u32>, cell_b: Cell<&'b u32>) {
    = note: defining type: test
 
 error: lifetime may not live long enough
-  --> $DIR/propagate-approximated-val.rs:36:5
+  --> $DIR/propagate-approximated-val.rs:36:37
    |
-LL |   fn test<'a, 'b>(cell_a: Cell<&'a u32>, cell_b: Cell<&'b u32>) {
-   |           --  -- lifetime `'b` defined here
-   |           |
-   |           lifetime `'a` defined here
-LL | /     establish_relationships(cell_a, cell_b, |outlives1, outlives2, x, y| {
-...  |
-LL | |     });
-   | |______^ argument requires that `'a` must outlive `'b`
+LL | fn test<'a, 'b>(cell_a: Cell<&'a u32>, cell_b: Cell<&'b u32>) {
+   |         --  -- lifetime `'b` defined here
+   |         |
+   |         lifetime `'a` defined here
+LL |     establish_relationships(cell_a, cell_b, |outlives1, outlives2, x, y| {
+   |                                     ^^^^^^ argument requires that `'a` must outlive `'b`
    |
    = help: consider adding the following bound: `'a: 'b`
    = note: requirement occurs because of the type `Cell<&'?7 u32>`, which makes the generic argument `&'?7 u32` invariant

--- a/tests/ui/nll/closure-requirements/propagate-fail-to-approximate-longer-no-bounds.stderr
+++ b/tests/ui/nll/closure-requirements/propagate-fail-to-approximate-longer-no-bounds.stderr
@@ -18,7 +18,7 @@ LL |     establish_relationships(&cell_a, &cell_b, |_outlives, x, y| {
    = note: late-bound region is '?3
 
 error: lifetime may not live long enough
-  --> $DIR/propagate-fail-to-approximate-longer-no-bounds.rs:37:9
+  --> $DIR/propagate-fail-to-approximate-longer-no-bounds.rs:37:21
    |
 LL |     establish_relationships(&cell_a, &cell_b, |_outlives, x, y| {
    |                                                ---------  - has type `&'?6 Cell<&'1 u32>`
@@ -26,7 +26,7 @@ LL |     establish_relationships(&cell_a, &cell_b, |_outlives, x, y| {
    |                                                has type `&'?4 Cell<&'2 &'?1 u32>`
 LL |         // Only works if 'x: 'y:
 LL |         demand_y(x, y, x.get())
-   |         ^^^^^^^^^^^^^^^^^^^^^^^ argument requires that `'1` must outlive `'2`
+   |                     ^ argument requires that `'1` must outlive `'2`
    |
    = note: requirement occurs because of the type `Cell<&'?37 u32>`, which makes the generic argument `&'?37 u32` invariant
    = note: the struct `Cell<T>` is invariant over the parameter `T`

--- a/tests/ui/nll/closure-requirements/propagate-fail-to-approximate-longer-no-bounds.stderr
+++ b/tests/ui/nll/closure-requirements/propagate-fail-to-approximate-longer-no-bounds.stderr
@@ -26,7 +26,7 @@ LL | fn supply<'a, 'b>(cell_a: Cell<&'a u32>, cell_b: Cell<&'b u32>) {
    = note: defining type: supply
 
 error: lifetime may not live long enough
-  --> $DIR/propagate-fail-to-approximate-longer-no-bounds.rs:37:9
+  --> $DIR/propagate-fail-to-approximate-longer-no-bounds.rs:37:21
    |
 LL |     establish_relationships(&cell_a, &cell_b, |_outlives, x, y| {
    |                                                ---------  - has type `&'?6 Cell<&'1 u32>`
@@ -34,7 +34,7 @@ LL |     establish_relationships(&cell_a, &cell_b, |_outlives, x, y| {
    |                                                has type `&'?4 Cell<&'2 &'?1 u32>`
 LL |         // Only works if 'x: 'y:
 LL |         demand_y(x, y, x.get())
-   |         ^^^^^^^^^^^^^^^^^^^^^^^ argument requires that `'1` must outlive `'2`
+   |                     ^ argument requires that `'1` must outlive `'2`
    |
    = note: requirement occurs because of the type `Cell<&'?37 u32>`, which makes the generic argument `&'?37 u32` invariant
    = note: the struct `Cell<T>` is invariant over the parameter `T`

--- a/tests/ui/nll/closure-requirements/propagate-fail-to-approximate-longer-wrong-bounds.stderr
+++ b/tests/ui/nll/closure-requirements/propagate-fail-to-approximate-longer-wrong-bounds.stderr
@@ -19,7 +19,7 @@ LL |     establish_relationships(&cell_a, &cell_b, |_outlives1, _outlives2, x, y
    = note: late-bound region is '?4
 
 error: lifetime may not live long enough
-  --> $DIR/propagate-fail-to-approximate-longer-wrong-bounds.rs:41:9
+  --> $DIR/propagate-fail-to-approximate-longer-wrong-bounds.rs:41:21
    |
 LL |     establish_relationships(&cell_a, &cell_b, |_outlives1, _outlives2, x, y| {
    |                                                ----------  ---------- has type `&'?7 Cell<&'2 &'?2 u32>`
@@ -27,7 +27,7 @@ LL |     establish_relationships(&cell_a, &cell_b, |_outlives1, _outlives2, x, y
    |                                                has type `&'?5 Cell<&'1 &'?1 u32>`
 LL |         // Only works if 'x: 'y:
 LL |         demand_y(x, y, x.get())
-   |         ^^^^^^^^^^^^^^^^^^^^^^^ argument requires that `'1` must outlive `'2`
+   |                     ^ argument requires that `'1` must outlive `'2`
    |
    = note: requirement occurs because of the type `Cell<&'?43 u32>`, which makes the generic argument `&'?43 u32` invariant
    = note: the struct `Cell<T>` is invariant over the parameter `T`

--- a/tests/ui/nll/closure-requirements/propagate-fail-to-approximate-longer-wrong-bounds.stderr
+++ b/tests/ui/nll/closure-requirements/propagate-fail-to-approximate-longer-wrong-bounds.stderr
@@ -27,7 +27,7 @@ LL | fn supply<'a, 'b>(cell_a: Cell<&'a u32>, cell_b: Cell<&'b u32>) {
    = note: defining type: supply
 
 error: lifetime may not live long enough
-  --> $DIR/propagate-fail-to-approximate-longer-wrong-bounds.rs:41:9
+  --> $DIR/propagate-fail-to-approximate-longer-wrong-bounds.rs:41:21
    |
 LL |     establish_relationships(&cell_a, &cell_b, |_outlives1, _outlives2, x, y| {
    |                                                ----------  ---------- has type `&'?7 Cell<&'2 &'?2 u32>`
@@ -35,7 +35,7 @@ LL |     establish_relationships(&cell_a, &cell_b, |_outlives1, _outlives2, x, y
    |                                                has type `&'?5 Cell<&'1 &'?1 u32>`
 LL |         // Only works if 'x: 'y:
 LL |         demand_y(x, y, x.get())
-   |         ^^^^^^^^^^^^^^^^^^^^^^^ argument requires that `'1` must outlive `'2`
+   |                     ^ argument requires that `'1` must outlive `'2`
    |
    = note: requirement occurs because of the type `Cell<&'?43 u32>`, which makes the generic argument `&'?43 u32` invariant
    = note: the struct `Cell<T>` is invariant over the parameter `T`

--- a/tests/ui/nll/issue-42574-diagnostic-in-nested-closure.stderr
+++ b/tests/ui/nll/issue-42574-diagnostic-in-nested-closure.stderr
@@ -1,8 +1,8 @@
 error: lifetime may not live long enough
-  --> $DIR/issue-42574-diagnostic-in-nested-closure.rs:7:8
+  --> $DIR/issue-42574-diagnostic-in-nested-closure.rs:7:13
    |
 LL |     || doit(data);
-   |     -- ^^^^^^^^^^ argument requires that `'1` must outlive `'static`
+   |     --      ^^^^ argument requires that `'1` must outlive `'static`
    |     |
    |     lifetime `'1` represents this closure's body
    |
@@ -14,10 +14,10 @@ error[E0597]: `data` does not live long enough
 LL | fn doit(data: &'static mut ()) {
    |         ---- binding `data` declared here
 LL |     || doit(data);
-   |     -- -----^^^^-
-   |     |  |    |
-   |     |  |    borrowed value does not live long enough
-   |     |  argument requires that `data` is borrowed for `'static`
+   |     --      ^^^^
+   |     |       |
+   |     |       borrowed value does not live long enough
+   |     |       argument requires that `data` is borrowed for `'static`
    |     value captured here
 ...
 LL | }

--- a/tests/ui/nll/issue-52113.stderr
+++ b/tests/ui/nll/issue-52113.stderr
@@ -7,7 +7,7 @@ LL | fn produce_err<'a, 'b: 'a>(data: &'b mut Vec<&'b u32>, value: &'a u32) -> i
    |                lifetime `'a` defined here
 ...
 LL |         data.push(value);
-   |         ^^^^^^^^^^^^^^^^ receiver requires that `'a` must outlive `'b`
+   |         ^^^^ receiver requires that `'a` must outlive `'b`
    |
    = help: consider adding the following bound: `'a: 'b`
 

--- a/tests/ui/nll/issue-52113.stderr
+++ b/tests/ui/nll/issue-52113.stderr
@@ -7,7 +7,7 @@ LL | fn produce_err<'a, 'b: 'a>(data: &'b mut Vec<&'b u32>, value: &'a u32) -> i
    |                lifetime `'a` defined here
 ...
 LL |         data.push(value);
-   |         ^^^^^^^^^^^^^^^^ argument requires that `'a` must outlive `'b`
+   |         ^^^^^^^^^^^^^^^^ receiver requires that `'a` must outlive `'b`
    |
    = help: consider adding the following bound: `'a: 'b`
 

--- a/tests/ui/nll/issue-54779-anon-static-lifetime.stderr
+++ b/tests/ui/nll/issue-54779-anon-static-lifetime.stderr
@@ -1,5 +1,5 @@
 error[E0521]: borrowed data escapes outside of method
-  --> $DIR/issue-54779-anon-static-lifetime.rs:32:9
+  --> $DIR/issue-54779-anon-static-lifetime.rs:32:24
    |
 LL |         cx: &dyn DebugContext,
    |         --  - let's call the lifetime of this reference `'1`
@@ -7,10 +7,10 @@ LL |         cx: &dyn DebugContext,
    |         `cx` is a reference that is only valid in the method body
 ...
 LL |         bar.debug_with(cx);
-   |         ^^^^^^^^^^^^^^^^^^
-   |         |
-   |         `cx` escapes the method body here
-   |         argument requires that `'1` must outlive `'static`
+   |                        ^^
+   |                        |
+   |                        `cx` escapes the method body here
+   |                        argument requires that `'1` must outlive `'static`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/nll/issue-57265-return-type-wf-check.stderr
+++ b/tests/ui/nll/issue-57265-return-type-wf-check.stderr
@@ -2,10 +2,10 @@ error[E0716]: temporary value dropped while borrowed
   --> $DIR/issue-57265-return-type-wf-check.rs:20:23
    |
 LL |     let (_, z) = foo(&"hello".to_string());
-   |                  -----^^^^^^^^^^^^^^^^^^^-- temporary value is freed at the end of this statement
-   |                  |    |
-   |                  |    creates a temporary value which is freed while still in use
-   |                  argument requires that borrow lasts for `'static`
+   |                      -^^^^^^^^^^^^^^^^^^^ - temporary value is freed at the end of this statement
+   |                      ||
+   |                      |creates a temporary value which is freed while still in use
+   |                      argument requires that borrow lasts for `'static`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/nll/issue-67007-escaping-data.stderr
+++ b/tests/ui/nll/issue-67007-escaping-data.stderr
@@ -7,7 +7,7 @@ LL |     fn bad_method<'a>(&self, fcx: &FnCtxt<'a, 'tcx>) {
    |                   -- lifetime `'a` defined here
 LL |         let other = self.use_fcx(fcx);
 LL |         fcx.use_it(other);
-   |         ^^^^^^^^^^^^^^^^^ argument requires that `'a` must outlive `'tcx`
+   |         ^^^^^^^^^^^^^^^^^ receiver requires that `'a` must outlive `'tcx`
    |
    = help: consider adding the following bound: `'a: 'tcx`
    = note: requirement occurs because of the type `FnCtxt<'_, '_>`, which makes the generic argument `'_` invariant

--- a/tests/ui/nll/issue-67007-escaping-data.stderr
+++ b/tests/ui/nll/issue-67007-escaping-data.stderr
@@ -7,7 +7,7 @@ LL |     fn bad_method<'a>(&self, fcx: &FnCtxt<'a, 'tcx>) {
    |                   -- lifetime `'a` defined here
 LL |         let other = self.use_fcx(fcx);
 LL |         fcx.use_it(other);
-   |         ^^^^^^^^^^^^^^^^^ receiver requires that `'a` must outlive `'tcx`
+   |         ^^^ receiver requires that `'a` must outlive `'tcx`
    |
    = help: consider adding the following bound: `'a: 'tcx`
    = note: requirement occurs because of the type `FnCtxt<'_, '_>`, which makes the generic argument `'_` invariant

--- a/tests/ui/nll/issue-69114-static-ty.stderr
+++ b/tests/ui/nll/issue-69114-static-ty.stderr
@@ -4,9 +4,8 @@ error[E0597]: `n` does not live long enough
 LL |     let n = 42;
    |         - binding `n` declared here
 LL |     FOO(&n);
-   |     ----^^-
-   |     |   |
-   |     |   borrowed value does not live long enough
+   |     --- ^^ borrowed value does not live long enough
+   |     |
    |     closure requires that `n` is borrowed for `'static`
 LL |
 LL | }

--- a/tests/ui/nll/issue-69114-static-ty.stderr
+++ b/tests/ui/nll/issue-69114-static-ty.stderr
@@ -7,7 +7,7 @@ LL |     FOO(&n);
    |     ----^^-
    |     |   |
    |     |   borrowed value does not live long enough
-   |     argument requires that `n` is borrowed for `'static`
+   |     closure requires that `n` is borrowed for `'static`
 LL |
 LL | }
    | - `n` dropped here while still borrowed

--- a/tests/ui/nll/issue-95272.stderr
+++ b/tests/ui/nll/issue-95272.stderr
@@ -1,5 +1,5 @@
 error: lifetime may not live long enough
-  --> $DIR/issue-95272.rs:11:5
+  --> $DIR/issue-95272.rs:11:10
    |
 LL | fn test<'a, 'b>(x: Cell<&'a ()>, y: Cell<&'b ()>) {
    |         --  -- lifetime `'b` defined here
@@ -7,7 +7,7 @@ LL | fn test<'a, 'b>(x: Cell<&'a ()>, y: Cell<&'b ()>) {
    |         lifetime `'a` defined here
 LL |     let f = check;
 LL |     f(x, y);
-   |     ^^^^^^^ argument requires that `'a` must outlive `'b`
+   |          ^ argument requires that `'a` must outlive `'b`
    |
    = help: consider adding the following bound: `'a: 'b`
    = note: requirement occurs because of the type `Cell<&()>`, which makes the generic argument `&()` invariant

--- a/tests/ui/nll/local-outlives-static-via-hrtb.stderr
+++ b/tests/ui/nll/local-outlives-static-via-hrtb.stderr
@@ -4,10 +4,10 @@ error[E0597]: `local` does not live long enough
 LL |     let local = 0;
    |         ----- binding `local` declared here
 LL |     assert_static_via_hrtb(&local);
-   |     -----------------------^^^^^^-
-   |     |                      |
-   |     |                      borrowed value does not live long enough
-   |     argument requires that `local` is borrowed for `'static`
+   |                            ^^^^^^
+   |                            |
+   |                            borrowed value does not live long enough
+   |                            argument requires that `local` is borrowed for `'static`
 LL |     assert_static_via_hrtb_with_assoc_type(&&local);
 LL | }
    | - `local` dropped here while still borrowed
@@ -30,10 +30,10 @@ LL |     let local = 0;
    |         ----- binding `local` declared here
 LL |     assert_static_via_hrtb(&local);
 LL |     assert_static_via_hrtb_with_assoc_type(&&local);
-   |     ----------------------------------------^^^^^^-
-   |     |                                       |
-   |     |                                       borrowed value does not live long enough
-   |     argument requires that `local` is borrowed for `'static`
+   |                                            -^^^^^^
+   |                                            ||
+   |                                            |borrowed value does not live long enough
+   |                                            argument requires that `local` is borrowed for `'static`
 LL | }
    | - `local` dropped here while still borrowed
    |

--- a/tests/ui/nll/outlives-suggestion-simple.stderr
+++ b/tests/ui/nll/outlives-suggestion-simple.stderr
@@ -90,7 +90,7 @@ LL |         self.x
    = help: consider adding the following bound: `'b: 'a`
 
 error: lifetime may not live long enough
-  --> $DIR/outlives-suggestion-simple.rs:71:9
+  --> $DIR/outlives-suggestion-simple.rs:71:19
    |
 LL | impl<'a> Foo2<'a> {
    |      -- lifetime `'a` defined here
@@ -98,7 +98,7 @@ LL |     // should not produce outlives suggestions to name 'self
 LL |     fn get_bar(&self) -> Bar2 {
    |                - let's call the lifetime of this reference `'1`
 LL |         Bar2::new(&self)
-   |         ^^^^^^^^^^^^^^^^ argument requires that `'1` must outlive `'a`
+   |                   ^^^^^ argument requires that `'1` must outlive `'a`
    |
    = note: requirement occurs because of the type `Foo2<'_>`, which makes the generic argument `'_` invariant
    = note: the struct `Foo2<'a>` is invariant over the parameter `'a`

--- a/tests/ui/nll/ty-outlives/projection-one-region-closure.stderr
+++ b/tests/ui/nll/ty-outlives/projection-one-region-closure.stderr
@@ -25,7 +25,7 @@ LL | |     T: Anything<'b>,
    = note: defining type: no_relationships_late::<'?1, T>
 
 error: lifetime may not live long enough
-  --> $DIR/projection-one-region-closure.rs:45:5
+  --> $DIR/projection-one-region-closure.rs:45:20
    |
 LL | fn no_relationships_late<'a, 'b, T>(cell: Cell<&'a ()>, t: T)
    |                          --  -- lifetime `'b` defined here
@@ -33,7 +33,7 @@ LL | fn no_relationships_late<'a, 'b, T>(cell: Cell<&'a ()>, t: T)
    |                          lifetime `'a` defined here
 ...
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ argument requires that `'b` must outlive `'a`
+   |                    ^^^^ argument requires that `'b` must outlive `'a`
    |
    = help: consider adding the following bound: `'b: 'a`
    = note: requirement occurs because of the type `Cell<&'?6 ()>`, which makes the generic argument `&'?6 ()` invariant
@@ -81,7 +81,7 @@ LL | |     'a: 'a,
    = note: defining type: no_relationships_early::<'?1, '?2, T>
 
 error: lifetime may not live long enough
-  --> $DIR/projection-one-region-closure.rs:56:5
+  --> $DIR/projection-one-region-closure.rs:56:20
    |
 LL | fn no_relationships_early<'a, 'b, T>(cell: Cell<&'a ()>, t: T)
    |                           --  -- lifetime `'b` defined here
@@ -89,7 +89,7 @@ LL | fn no_relationships_early<'a, 'b, T>(cell: Cell<&'a ()>, t: T)
    |                           lifetime `'a` defined here
 ...
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ argument requires that `'b` must outlive `'a`
+   |                    ^^^^ argument requires that `'b` must outlive `'a`
    |
    = help: consider adding the following bound: `'b: 'a`
    = note: requirement occurs because of the type `Cell<&'?7 ()>`, which makes the generic argument `&'?7 ()` invariant

--- a/tests/ui/nll/ty-outlives/projection-one-region-trait-bound-closure.stderr
+++ b/tests/ui/nll/ty-outlives/projection-one-region-trait-bound-closure.stderr
@@ -24,7 +24,7 @@ LL | |     T: Anything<'b>,
    = note: defining type: no_relationships_late::<'?1, T>
 
 error: lifetime may not live long enough
-  --> $DIR/projection-one-region-trait-bound-closure.rs:37:5
+  --> $DIR/projection-one-region-trait-bound-closure.rs:37:20
    |
 LL | fn no_relationships_late<'a, 'b, T>(cell: Cell<&'a ()>, t: T)
    |                          --  -- lifetime `'b` defined here
@@ -32,7 +32,7 @@ LL | fn no_relationships_late<'a, 'b, T>(cell: Cell<&'a ()>, t: T)
    |                          lifetime `'a` defined here
 ...
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ argument requires that `'b` must outlive `'a`
+   |                    ^^^^ argument requires that `'b` must outlive `'a`
    |
    = help: consider adding the following bound: `'b: 'a`
    = note: requirement occurs because of the type `Cell<&'?6 ()>`, which makes the generic argument `&'?6 ()` invariant
@@ -65,7 +65,7 @@ LL | |     'a: 'a,
    = note: defining type: no_relationships_early::<'?1, '?2, T>
 
 error: lifetime may not live long enough
-  --> $DIR/projection-one-region-trait-bound-closure.rs:47:5
+  --> $DIR/projection-one-region-trait-bound-closure.rs:47:20
    |
 LL | fn no_relationships_early<'a, 'b, T>(cell: Cell<&'a ()>, t: T)
    |                           --  -- lifetime `'b` defined here
@@ -73,7 +73,7 @@ LL | fn no_relationships_early<'a, 'b, T>(cell: Cell<&'a ()>, t: T)
    |                           lifetime `'a` defined here
 ...
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ argument requires that `'b` must outlive `'a`
+   |                    ^^^^ argument requires that `'b` must outlive `'a`
    |
    = help: consider adding the following bound: `'b: 'a`
    = note: requirement occurs because of the type `Cell<&'?7 ()>`, which makes the generic argument `&'?7 ()` invariant

--- a/tests/ui/nll/ty-outlives/projection-two-region-trait-bound-closure.stderr
+++ b/tests/ui/nll/ty-outlives/projection-two-region-trait-bound-closure.stderr
@@ -177,7 +177,7 @@ LL | |     T: Anything<'b, 'b>,
    = note: defining type: two_regions::<'?1, T>
 
 error: lifetime may not live long enough
-  --> $DIR/projection-two-region-trait-bound-closure.rs:87:5
+  --> $DIR/projection-two-region-trait-bound-closure.rs:87:20
    |
 LL | fn two_regions<'a, 'b, T>(cell: Cell<&'a ()>, t: T)
    |                --  -- lifetime `'b` defined here
@@ -185,7 +185,7 @@ LL | fn two_regions<'a, 'b, T>(cell: Cell<&'a ()>, t: T)
    |                lifetime `'a` defined here
 ...
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ argument requires that `'b` must outlive `'a`
+   |                    ^^^^ argument requires that `'b` must outlive `'a`
    |
    = help: consider adding the following bound: `'b: 'a`
    = note: requirement occurs because of the type `Cell<&'?6 ()>`, which makes the generic argument `&'?6 ()` invariant

--- a/tests/ui/nll/user-annotations/adt-nullary-enums.stderr
+++ b/tests/ui/nll/user-annotations/adt-nullary-enums.stderr
@@ -1,49 +1,49 @@
 error[E0597]: `c` does not live long enough
   --> $DIR/adt-nullary-enums.rs:33:41
    |
-LL |       let c = 66;
-   |           - binding `c` declared here
-LL | /     combine(
-LL | |         SomeEnum::SomeVariant(Cell::new(&c)),
-   | |                                         ^^ borrowed value does not live long enough
-LL | |         SomeEnum::SomeOtherVariant::<Cell<&'static u32>>,
-LL | |     );
-   | |_____- argument requires that `c` is borrowed for `'static`
-LL |   }
-   |   - `c` dropped here while still borrowed
+LL |     let c = 66;
+   |         - binding `c` declared here
+LL |     combine(
+LL |         SomeEnum::SomeVariant(Cell::new(&c)),
+   |                                         ^^ borrowed value does not live long enough
+LL |         SomeEnum::SomeOtherVariant::<Cell<&'static u32>>,
+   |         ------------------------------------------------ argument requires that `c` is borrowed for `'static`
+LL |     );
+LL | }
+   | - `c` dropped here while still borrowed
 
 error[E0597]: `c` does not live long enough
   --> $DIR/adt-nullary-enums.rs:41:41
    |
-LL |   fn annot_reference_named_lifetime<'a>(_d: &'a u32) {
-   |                                     -- lifetime `'a` defined here
-LL |       let c = 66;
-   |           - binding `c` declared here
-LL | /     combine(
-LL | |         SomeEnum::SomeVariant(Cell::new(&c)),
-   | |                                         ^^ borrowed value does not live long enough
-LL | |         SomeEnum::SomeOtherVariant::<Cell<&'a u32>>,
-LL | |     );
-   | |_____- argument requires that `c` is borrowed for `'a`
-LL |   }
-   |   - `c` dropped here while still borrowed
+LL | fn annot_reference_named_lifetime<'a>(_d: &'a u32) {
+   |                                   -- lifetime `'a` defined here
+LL |     let c = 66;
+   |         - binding `c` declared here
+LL |     combine(
+LL |         SomeEnum::SomeVariant(Cell::new(&c)),
+   |                                         ^^ borrowed value does not live long enough
+LL |         SomeEnum::SomeOtherVariant::<Cell<&'a u32>>,
+   |         ------------------------------------------- argument requires that `c` is borrowed for `'a`
+LL |     );
+LL | }
+   | - `c` dropped here while still borrowed
 
 error[E0597]: `c` does not live long enough
   --> $DIR/adt-nullary-enums.rs:54:45
    |
-LL |   fn annot_reference_named_lifetime_in_closure<'a>(_: &'a u32) {
-   |                                                -- lifetime `'a` defined here
-LL |       let _closure = || {
-LL |           let c = 66;
-   |               - binding `c` declared here
-LL | /         combine(
-LL | |             SomeEnum::SomeVariant(Cell::new(&c)),
-   | |                                             ^^ borrowed value does not live long enough
-LL | |             SomeEnum::SomeOtherVariant::<Cell<&'a u32>>,
-LL | |         );
-   | |_________- argument requires that `c` is borrowed for `'a`
-LL |       };
-   |       - `c` dropped here while still borrowed
+LL | fn annot_reference_named_lifetime_in_closure<'a>(_: &'a u32) {
+   |                                              -- lifetime `'a` defined here
+LL |     let _closure = || {
+LL |         let c = 66;
+   |             - binding `c` declared here
+LL |         combine(
+LL |             SomeEnum::SomeVariant(Cell::new(&c)),
+   |                                             ^^ borrowed value does not live long enough
+LL |             SomeEnum::SomeOtherVariant::<Cell<&'a u32>>,
+   |             ------------------------------------------- argument requires that `c` is borrowed for `'a`
+LL |         );
+LL |     };
+   |     - `c` dropped here while still borrowed
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/nll/user-annotations/adt-tuple-struct-calls.stderr
+++ b/tests/ui/nll/user-annotations/adt-tuple-struct-calls.stderr
@@ -48,10 +48,10 @@ LL |     let _closure = || {
 LL |         let c = 66;
    |             - binding `c` declared here
 LL |         f(&c);
-   |         --^^-
-   |         | |
-   |         | borrowed value does not live long enough
-   |         argument requires that `c` is borrowed for `'1`
+   |           ^^
+   |           |
+   |           borrowed value does not live long enough
+   |           argument requires that `c` is borrowed for `'1`
 LL |     };
    |     - `c` dropped here while still borrowed
 

--- a/tests/ui/nll/user-annotations/closure-substs.stderr
+++ b/tests/ui/nll/user-annotations/closure-substs.stderr
@@ -16,26 +16,26 @@ LL |         return x;
    |                ^ returning this value requires that `'1` must outlive `'static`
 
 error: lifetime may not live long enough
-  --> $DIR/closure-substs.rs:20:9
+  --> $DIR/closure-substs.rs:20:11
    |
 LL | fn bar<'a>() {
    |        -- lifetime `'a` defined here
 ...
 LL |         b(x);
-   |         ^^^^ argument requires that `'a` must outlive `'static`
+   |           ^ argument requires that `'a` must outlive `'static`
 
 error[E0521]: borrowed data escapes outside of closure
-  --> $DIR/closure-substs.rs:27:9
+  --> $DIR/closure-substs.rs:27:11
    |
 LL |     |x: &i32, b: fn(&'static i32)| {
    |      -  - let's call the lifetime of this reference `'1`
    |      |
    |      `x` is a reference that is only valid in the closure body
 LL |         b(x);
-   |         ^^^^
-   |         |
-   |         `x` escapes the closure body here
-   |         argument requires that `'1` must outlive `'static`
+   |           ^
+   |           |
+   |           `x` escapes the closure body here
+   |           argument requires that `'1` must outlive `'static`
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/nll/user-annotations/constant-in-expr-inherent-2.stderr
+++ b/tests/ui/nll/user-annotations/constant-in-expr-inherent-2.stderr
@@ -4,10 +4,10 @@ error[E0597]: `x` does not live long enough
 LL |     let x = ();
    |         - binding `x` declared here
 LL |     FUN(&x);
-   |     ----^^-
-   |     |   |
-   |     |   borrowed value does not live long enough
-   |     argument requires that `x` is borrowed for `'static`
+   |         ^^
+   |         |
+   |         borrowed value does not live long enough
+   |         argument requires that `x` is borrowed for `'static`
 ...
 LL | }
    | - `x` dropped here while still borrowed
@@ -19,10 +19,10 @@ LL |     let x = ();
    |         - binding `x` declared here
 LL |     FUN(&x);
 LL |     A::ASSOCIATED_FUN(&x);
-   |     ------------------^^-
-   |     |                 |
-   |     |                 borrowed value does not live long enough
-   |     argument requires that `x` is borrowed for `'static`
+   |                       ^^
+   |                       |
+   |                       borrowed value does not live long enough
+   |                       argument requires that `x` is borrowed for `'static`
 ...
 LL | }
    | - `x` dropped here while still borrowed
@@ -34,10 +34,10 @@ LL |     let x = ();
    |         - binding `x` declared here
 ...
 LL |     B::ALSO_ASSOCIATED_FUN(&x);
-   |     -----------------------^^-
-   |     |                      |
-   |     |                      borrowed value does not live long enough
-   |     argument requires that `x` is borrowed for `'static`
+   |                            ^^
+   |                            |
+   |                            borrowed value does not live long enough
+   |                            argument requires that `x` is borrowed for `'static`
 LL |     <_>::TRAIT_ASSOCIATED_FUN(&x);
 LL | }
    | - `x` dropped here while still borrowed
@@ -49,10 +49,10 @@ LL |     let x = ();
    |         - binding `x` declared here
 ...
 LL |     <_>::TRAIT_ASSOCIATED_FUN(&x);
-   |     --------------------------^^-
-   |     |                         |
-   |     |                         borrowed value does not live long enough
-   |     argument requires that `x` is borrowed for `'static`
+   |                               ^^
+   |                               |
+   |                               borrowed value does not live long enough
+   |                               argument requires that `x` is borrowed for `'static`
 LL | }
    | - `x` dropped here while still borrowed
 

--- a/tests/ui/nll/user-annotations/fns.stderr
+++ b/tests/ui/nll/user-annotations/fns.stderr
@@ -4,10 +4,10 @@ error[E0597]: `c` does not live long enough
 LL |     let c = 66;
    |         - binding `c` declared here
 LL |     some_fn::<&'static u32>(&c);
-   |     ------------------------^^-
-   |     |                       |
-   |     |                       borrowed value does not live long enough
-   |     argument requires that `c` is borrowed for `'static`
+   |                             ^^
+   |                             |
+   |                             borrowed value does not live long enough
+   |                             argument requires that `c` is borrowed for `'static`
 LL | }
    | - `c` dropped here while still borrowed
 
@@ -19,10 +19,10 @@ LL | fn annot_reference_named_lifetime<'a>(_d: &'a u32) {
 LL |     let c = 66;
    |         - binding `c` declared here
 LL |     some_fn::<&'a u32>(&c);
-   |     -------------------^^-
-   |     |                  |
-   |     |                  borrowed value does not live long enough
-   |     argument requires that `c` is borrowed for `'a`
+   |                        ^^
+   |                        |
+   |                        borrowed value does not live long enough
+   |                        argument requires that `c` is borrowed for `'a`
 LL | }
    | - `c` dropped here while still borrowed
 
@@ -35,10 +35,10 @@ LL |     let _closure = || {
 LL |         let c = 66;
    |             - binding `c` declared here
 LL |         some_fn::<&'a u32>(&c);
-   |         -------------------^^-
-   |         |                  |
-   |         |                  borrowed value does not live long enough
-   |         argument requires that `c` is borrowed for `'a`
+   |                            ^^
+   |                            |
+   |                            borrowed value does not live long enough
+   |                            argument requires that `c` is borrowed for `'a`
 LL |     };
    |     - `c` dropped here while still borrowed
 

--- a/tests/ui/nll/user-annotations/method-call.stderr
+++ b/tests/ui/nll/user-annotations/method-call.stderr
@@ -4,10 +4,10 @@ error[E0597]: `c` does not live long enough
 LL |     let c = 66;
    |         - binding `c` declared here
 LL |     a.method::<&'static u32>(b,  &c);
-   |     -----------------------------^^-
-   |     |                            |
-   |     |                            borrowed value does not live long enough
-   |     argument requires that `c` is borrowed for `'static`
+   |                                  ^^
+   |                                  |
+   |                                  borrowed value does not live long enough
+   |                                  argument requires that `c` is borrowed for `'static`
 LL | }
    | - `c` dropped here while still borrowed
 
@@ -20,10 +20,10 @@ LL | fn annot_reference_named_lifetime<'a>(_d: &'a u32) {
 LL |     let c = 66;
    |         - binding `c` declared here
 LL |     a.method::<&'a u32>(b,  &c);
-   |     ------------------------^^-
-   |     |                       |
-   |     |                       borrowed value does not live long enough
-   |     argument requires that `c` is borrowed for `'a`
+   |                             ^^
+   |                             |
+   |                             borrowed value does not live long enough
+   |                             argument requires that `c` is borrowed for `'a`
 LL | }
    | - `c` dropped here while still borrowed
 
@@ -36,10 +36,10 @@ LL | fn annot_reference_named_lifetime_in_closure<'a>(_: &'a u32) {
 LL |         let c = 66;
    |             - binding `c` declared here
 LL |         a.method::<&'a u32>(b,  &c);
-   |         ------------------------^^-
-   |         |                       |
-   |         |                       borrowed value does not live long enough
-   |         argument requires that `c` is borrowed for `'a`
+   |                                 ^^
+   |                                 |
+   |                                 borrowed value does not live long enough
+   |                                 argument requires that `c` is borrowed for `'a`
 LL |     };
    |     - `c` dropped here while still borrowed
 

--- a/tests/ui/nll/user-annotations/method-ufcs-1.stderr
+++ b/tests/ui/nll/user-annotations/method-ufcs-1.stderr
@@ -20,10 +20,10 @@ LL |     let a = 22;
    |         - binding `a` declared here
 ...
 LL |     <&'a u32 as Bazoom<_>>::method(&a, b, c);
-   |     -------------------------------^^-------
-   |     |                              |
-   |     |                              borrowed value does not live long enough
-   |     argument requires that `a` is borrowed for `'a`
+   |                                    ^^
+   |                                    |
+   |                                    borrowed value does not live long enough
+   |                                    argument requires that `a` is borrowed for `'a`
 LL | }
    | - `a` dropped here while still borrowed
 
@@ -39,10 +39,10 @@ LL |     let _closure = || {
    |                    -- value captured here
 LL |         let c = 66;
 LL |         <&'a u32 as Bazoom<_>>::method(&a, b, c);
-   |         --------------------------------^-------
-   |         |                               |
-   |         |                               borrowed value does not live long enough
-   |         argument requires that `a` is borrowed for `'a`
+   |                                        -^
+   |                                        ||
+   |                                        |borrowed value does not live long enough
+   |                                        argument requires that `a` is borrowed for `'a`
 LL |     };
 LL | }
    | - `a` dropped here while still borrowed

--- a/tests/ui/nll/user-annotations/method-ufcs-2.stderr
+++ b/tests/ui/nll/user-annotations/method-ufcs-2.stderr
@@ -21,10 +21,10 @@ LL |     let b = 44;
    |         - binding `b` declared here
 LL |     let c = 66;
 LL |     <_ as Bazoom<&'a u32>>::method(a, &b, c);
-   |     ----------------------------------^^----
-   |     |                                 |
-   |     |                                 borrowed value does not live long enough
-   |     argument requires that `b` is borrowed for `'a`
+   |                                       ^^
+   |                                       |
+   |                                       borrowed value does not live long enough
+   |                                       argument requires that `b` is borrowed for `'a`
 LL | }
    | - `b` dropped here while still borrowed
 
@@ -40,10 +40,10 @@ LL |     let _closure = || {
    |                    -- value captured here
 LL |         let c = 66;
 LL |         <_ as Bazoom<&'a u32>>::method(a, &b, c);
-   |         -----------------------------------^----
-   |         |                                  |
-   |         |                                  borrowed value does not live long enough
-   |         argument requires that `b` is borrowed for `'a`
+   |                                           -^
+   |                                           ||
+   |                                           |borrowed value does not live long enough
+   |                                           argument requires that `b` is borrowed for `'a`
 LL |     };
 LL | }
    | - `b` dropped here while still borrowed

--- a/tests/ui/nll/user-annotations/method-ufcs-3.stderr
+++ b/tests/ui/nll/user-annotations/method-ufcs-3.stderr
@@ -4,10 +4,10 @@ error[E0597]: `c` does not live long enough
 LL |     let c = 66;
    |         - binding `c` declared here
 LL |     <_ as Bazoom<_>>::method::<&'static u32>(&a, b, &c);
-   |     ------------------------------------------------^^-
-   |     |                                               |
-   |     |                                               borrowed value does not live long enough
-   |     argument requires that `c` is borrowed for `'static`
+   |                                                     ^^
+   |                                                     |
+   |                                                     borrowed value does not live long enough
+   |                                                     argument requires that `c` is borrowed for `'static`
 LL | }
    | - `c` dropped here while still borrowed
 
@@ -20,10 +20,10 @@ LL | fn annot_reference_named_lifetime<'a>(_d: &'a u32) {
 LL |     let c = 66;
    |         - binding `c` declared here
 LL |     <_ as Bazoom<_>>::method::<&'a u32>(&a, b, &c);
-   |     -------------------------------------------^^-
-   |     |                                          |
-   |     |                                          borrowed value does not live long enough
-   |     argument requires that `c` is borrowed for `'a`
+   |                                                ^^
+   |                                                |
+   |                                                borrowed value does not live long enough
+   |                                                argument requires that `c` is borrowed for `'a`
 LL | }
    | - `c` dropped here while still borrowed
 
@@ -36,10 +36,10 @@ LL | fn annot_reference_named_lifetime_in_closure<'a>(_: &'a u32) {
 LL |         let c = 66;
    |             - binding `c` declared here
 LL |         <_ as Bazoom<_>>::method::<&'a u32>(&a, b, &c);
-   |         -------------------------------------------^^-
-   |         |                                          |
-   |         |                                          borrowed value does not live long enough
-   |         argument requires that `c` is borrowed for `'a`
+   |                                                    ^^
+   |                                                    |
+   |                                                    borrowed value does not live long enough
+   |                                                    argument requires that `c` is borrowed for `'a`
 LL |     };
    |     - `c` dropped here while still borrowed
 

--- a/tests/ui/nll/user-annotations/method-ufcs-inherent-1.stderr
+++ b/tests/ui/nll/user-annotations/method-ufcs-inherent-1.stderr
@@ -6,10 +6,10 @@ LL | fn foo<'a>() {
 LL |     let v = 22;
    |         - binding `v` declared here
 LL |     let x = A::<'a>::new(&v, 22);
-   |             -------------^^-----
-   |             |            |
-   |             |            borrowed value does not live long enough
-   |             argument requires that `v` is borrowed for `'a`
+   |                          ^^
+   |                          |
+   |                          borrowed value does not live long enough
+   |                          argument requires that `v` is borrowed for `'a`
 LL |
 LL | }
    | - `v` dropped here while still borrowed

--- a/tests/ui/nll/user-annotations/method-ufcs-inherent-2.stderr
+++ b/tests/ui/nll/user-annotations/method-ufcs-inherent-2.stderr
@@ -6,10 +6,10 @@ LL | fn foo<'a>() {
 LL |     let v = 22;
    |         - binding `v` declared here
 LL |     let x = A::<'a>::new::<&'a u32>(&v, &v);
-   |             ------------------------^^-----
-   |             |                       |
-   |             |                       borrowed value does not live long enough
-   |             argument requires that `v` is borrowed for `'a`
+   |                                     ^^
+   |                                     |
+   |                                     borrowed value does not live long enough
+   |                                     argument requires that `v` is borrowed for `'a`
 ...
 LL | }
    | - `v` dropped here while still borrowed
@@ -22,10 +22,10 @@ LL | fn foo<'a>() {
 LL |     let v = 22;
    |         - binding `v` declared here
 LL |     let x = A::<'a>::new::<&'a u32>(&v, &v);
-   |             ----------------------------^^-
-   |             |                           |
-   |             |                           borrowed value does not live long enough
-   |             argument requires that `v` is borrowed for `'a`
+   |                                         ^^
+   |                                         |
+   |                                         borrowed value does not live long enough
+   |                                         argument requires that `v` is borrowed for `'a`
 ...
 LL | }
    | - `v` dropped here while still borrowed

--- a/tests/ui/nll/user-annotations/method-ufcs-inherent-3.stderr
+++ b/tests/ui/nll/user-annotations/method-ufcs-inherent-3.stderr
@@ -6,10 +6,10 @@ LL | fn foo<'a>() {
 LL |     let v = 22;
    |         - binding `v` declared here
 LL |     let x = <A<'a>>::new(&v, 22);
-   |             -------------^^-----
-   |             |            |
-   |             |            borrowed value does not live long enough
-   |             argument requires that `v` is borrowed for `'a`
+   |                          ^^
+   |                          |
+   |                          borrowed value does not live long enough
+   |                          argument requires that `v` is borrowed for `'a`
 LL |
 LL | }
    | - `v` dropped here while still borrowed

--- a/tests/ui/nll/user-annotations/method-ufcs-inherent-4.stderr
+++ b/tests/ui/nll/user-annotations/method-ufcs-inherent-4.stderr
@@ -6,10 +6,10 @@ LL | fn foo<'a>() {
 LL |     let v = 22;
    |         - binding `v` declared here
 LL |     let x = <A<'a>>::new::<&'a u32>(&v, &v);
-   |             ------------------------^^-----
-   |             |                       |
-   |             |                       borrowed value does not live long enough
-   |             argument requires that `v` is borrowed for `'a`
+   |                                     ^^
+   |                                     |
+   |                                     borrowed value does not live long enough
+   |                                     argument requires that `v` is borrowed for `'a`
 ...
 LL | }
    | - `v` dropped here while still borrowed
@@ -22,10 +22,10 @@ LL | fn foo<'a>() {
 LL |     let v = 22;
    |         - binding `v` declared here
 LL |     let x = <A<'a>>::new::<&'a u32>(&v, &v);
-   |             ----------------------------^^-
-   |             |                           |
-   |             |                           borrowed value does not live long enough
-   |             argument requires that `v` is borrowed for `'a`
+   |                                         ^^
+   |                                         |
+   |                                         borrowed value does not live long enough
+   |                                         argument requires that `v` is borrowed for `'a`
 ...
 LL | }
    | - `v` dropped here while still borrowed

--- a/tests/ui/object-lifetime/object-lifetime-default-mybox.stderr
+++ b/tests/ui/object-lifetime/object-lifetime-default-mybox.stderr
@@ -12,17 +12,17 @@ LL |     a
    = help: consider adding the following bound: `'a: 'b`
 
 error[E0521]: borrowed data escapes outside of function
-  --> $DIR/object-lifetime-default-mybox.rs:32:5
+  --> $DIR/object-lifetime-default-mybox.rs:32:11
    |
 LL | fn load2<'a>(ss: &MyBox<dyn SomeTrait + 'a>) -> MyBox<dyn SomeTrait + 'a> {
    |          --  -- `ss` is a reference that is only valid in the function body
    |          |
    |          lifetime `'a` defined here
 LL |     load0(ss)
-   |     ^^^^^^^^^
-   |     |
-   |     `ss` escapes the function body here
-   |     argument requires that `'a` must outlive `'static`
+   |           ^^
+   |           |
+   |           `ss` escapes the function body here
+   |           argument requires that `'a` must outlive `'static`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/reborrow/coerce-shared-lifetime-mismatch.stderr
+++ b/tests/ui/reborrow/coerce-shared-lifetime-mismatch.stderr
@@ -4,10 +4,10 @@ error[E0597]: `a` does not live long enough
 LL |     let a = CustomMarker(PhantomData);
    |         - binding `a` declared here
 LL |     method(a);
-   |     -------^-
-   |     |      |
-   |     |      borrowed value does not live long enough
-   |     argument requires that `a` is borrowed for `'static`
+   |            ^
+   |            |
+   |            borrowed value does not live long enough
+   |            argument requires that `a` is borrowed for `'static`
 LL |
 LL | }
    | - `a` dropped here while still borrowed

--- a/tests/ui/reborrow/coerce-shared-lifetime-mismatch.stderr
+++ b/tests/ui/reborrow/coerce-shared-lifetime-mismatch.stderr
@@ -12,10 +12,10 @@ error[E0597]: `a` does not live long enough
 LL |     let a = CustomMarker(PhantomData);
    |         - binding `a` declared here
 LL |     method(a);
-   |     -------^-
-   |     |      |
-   |     |      borrowed value does not live long enough
-   |     argument requires that `a` is borrowed for `'static`
+   |            ^
+   |            |
+   |            borrowed value does not live long enough
+   |            argument requires that `a` is borrowed for `'static`
 LL |
 LL | }
    | - `a` dropped here while still borrowed

--- a/tests/ui/regions/issue-78262.base.stderr
+++ b/tests/ui/regions/issue-78262.base.stderr
@@ -5,7 +5,7 @@ LL |     let f = |x: &dyn TT| x.func();
    |              -  -        ^^^^^^^^
    |              |  |        |
    |              |  |        `x` escapes the closure body here
-   |              |  |        argument requires that `'1` must outlive `'static`
+   |              |  |        receiver requires that `'1` must outlive `'static`
    |              |  let's call the lifetime of this reference `'1`
    |              `x` is a reference that is only valid in the closure body
 

--- a/tests/ui/regions/issue-78262.base.stderr
+++ b/tests/ui/regions/issue-78262.base.stderr
@@ -2,7 +2,7 @@ error[E0521]: borrowed data escapes outside of closure
   --> $DIR/issue-78262.rs:12:26
    |
 LL |     let f = |x: &dyn TT| x.func();
-   |              -  -        ^^^^^^^^
+   |              -  -        ^
    |              |  |        |
    |              |  |        `x` escapes the closure body here
    |              |  |        receiver requires that `'1` must outlive `'static`

--- a/tests/ui/regions/issue-78262.polonius.stderr
+++ b/tests/ui/regions/issue-78262.polonius.stderr
@@ -5,7 +5,7 @@ LL |     let f = |x: &dyn TT| x.func();
    |              -  -        ^^^^^^^^
    |              |  |        |
    |              |  |        `x` escapes the closure body here
-   |              |  |        argument requires that `'1` must outlive `'static`
+   |              |  |        receiver requires that `'1` must outlive `'static`
    |              |  let's call the lifetime of this reference `'1`
    |              `x` is a reference that is only valid in the closure body
 

--- a/tests/ui/regions/issue-78262.polonius.stderr
+++ b/tests/ui/regions/issue-78262.polonius.stderr
@@ -2,7 +2,7 @@ error[E0521]: borrowed data escapes outside of closure
   --> $DIR/issue-78262.rs:12:26
    |
 LL |     let f = |x: &dyn TT| x.func();
-   |              -  -        ^^^^^^^^
+   |              -  -        ^
    |              |  |        |
    |              |  |        `x` escapes the closure body here
    |              |  |        receiver requires that `'1` must outlive `'static`

--- a/tests/ui/regions/lifetime-not-long-enough-suggestion-regression-test-124563.stderr
+++ b/tests/ui/regions/lifetime-not-long-enough-suggestion-regression-test-124563.stderr
@@ -41,7 +41,7 @@ LL |   impl<'a, 'b, T> Foo for FooImpl<'a, 'b, T>
 LL | /         self.enter_scope(|ctx| {
 LL | |             BarImpl(ctx);
 LL | |         });
-   | |__________^ argument requires that `'a` must outlive `'b`
+   | |__________^ receiver requires that `'a` must outlive `'b`
    |
    = help: consider adding the following bound: `'a: 'b`
    = note: requirement occurs because of a mutable reference to `FooImpl<'_, '_, T>`

--- a/tests/ui/regions/lifetime-not-long-enough-suggestion-regression-test-124563.stderr
+++ b/tests/ui/regions/lifetime-not-long-enough-suggestion-regression-test-124563.stderr
@@ -33,15 +33,13 @@ LL |             BarImpl(ctx);
 error: lifetime may not live long enough
   --> $DIR/lifetime-not-long-enough-suggestion-regression-test-124563.rs:22:9
    |
-LL |   impl<'a, 'b, T> Foo for FooImpl<'a, 'b, T>
-   |        --  -- lifetime `'b` defined here
-   |        |
-   |        lifetime `'a` defined here
+LL | impl<'a, 'b, T> Foo for FooImpl<'a, 'b, T>
+   |      --  -- lifetime `'b` defined here
+   |      |
+   |      lifetime `'a` defined here
 ...
-LL | /         self.enter_scope(|ctx| {
-LL | |             BarImpl(ctx);
-LL | |         });
-   | |__________^ receiver requires that `'a` must outlive `'b`
+LL |         self.enter_scope(|ctx| {
+   |         ^^^^ receiver requires that `'a` must outlive `'b`
    |
    = help: consider adding the following bound: `'a: 'b`
    = note: requirement occurs because of a mutable reference to `FooImpl<'_, '_, T>`

--- a/tests/ui/regions/lifetime-not-long-enough-suggestion-regression-test-124563.stderr
+++ b/tests/ui/regions/lifetime-not-long-enough-suggestion-regression-test-124563.stderr
@@ -26,7 +26,7 @@ LL |   impl<'a, 'b, T> Foo for FooImpl<'a, 'b, T>
 LL | /         self.enter_scope(|ctx| {
 LL | |             BarImpl(ctx);
 LL | |         });
-   | |__________^ argument requires that `'a` must outlive `'b`
+   | |__________^ receiver requires that `'a` must outlive `'b`
    |
    = help: consider adding the following bound: `'a: 'b`
    = note: requirement occurs because of a mutable reference to `FooImpl<'_, '_, T>`

--- a/tests/ui/regions/lifetime-not-long-enough-suggestion-regression-test-124563.stderr
+++ b/tests/ui/regions/lifetime-not-long-enough-suggestion-regression-test-124563.stderr
@@ -18,15 +18,13 @@ LL | impl<'a, 'b, T> Foo for FooImpl<'a, 'b, T>
 error: lifetime may not live long enough
   --> $DIR/lifetime-not-long-enough-suggestion-regression-test-124563.rs:22:9
    |
-LL |   impl<'a, 'b, T> Foo for FooImpl<'a, 'b, T>
-   |        --  -- lifetime `'b` defined here
-   |        |
-   |        lifetime `'a` defined here
+LL | impl<'a, 'b, T> Foo for FooImpl<'a, 'b, T>
+   |      --  -- lifetime `'b` defined here
+   |      |
+   |      lifetime `'a` defined here
 ...
-LL | /         self.enter_scope(|ctx| {
-LL | |             BarImpl(ctx);
-LL | |         });
-   | |__________^ receiver requires that `'a` must outlive `'b`
+LL |         self.enter_scope(|ctx| {
+   |         ^^^^ receiver requires that `'a` must outlive `'b`
    |
    = help: consider adding the following bound: `'a: 'b`
    = note: requirement occurs because of a mutable reference to `FooImpl<'_, '_, T>`

--- a/tests/ui/regions/multiple-sources-for-outlives-requirement.stderr
+++ b/tests/ui/regions/multiple-sources-for-outlives-requirement.stderr
@@ -4,10 +4,10 @@ error[E0716]: temporary value dropped while borrowed
 LL | fn foo<'b>() {
    |        -- lifetime `'b` defined here
 LL |     outlives_indir::<'_, 'b, _>(&mut 1u32);
-   |     ---------------------------------^^^^-- temporary value is freed at the end of this statement
-   |     |                                |
-   |     |                                creates a temporary value which is freed while still in use
-   |     argument requires that borrow lasts for `'b`
+   |                                 -----^^^^ - temporary value is freed at the end of this statement
+   |                                 |    |
+   |                                 |    creates a temporary value which is freed while still in use
+   |                                 argument requires that borrow lasts for `'b`
    |
 note: requirements that the value outlives `'b` introduced here
   --> $DIR/multiple-sources-for-outlives-requirement.rs:1:23

--- a/tests/ui/regions/region-lifetime-bounds-on-fns-where-clause.stderr
+++ b/tests/ui/regions/region-lifetime-bounds-on-fns-where-clause.stderr
@@ -23,7 +23,7 @@ LL |     *x = *y;
    = help: consider adding the following bound: `'b: 'a`
 
 error: lifetime may not live long enough
-  --> $DIR/region-lifetime-bounds-on-fns-where-clause.rs:14:5
+  --> $DIR/region-lifetime-bounds-on-fns-where-clause.rs:14:7
    |
 LL | fn c<'a,'b>(x: &mut &'a isize, y: &mut &'b isize) {
    |      -- -- lifetime `'b` defined here
@@ -31,7 +31,7 @@ LL | fn c<'a,'b>(x: &mut &'a isize, y: &mut &'b isize) {
    |      lifetime `'a` defined here
 ...
 LL |     a(x, y);
-   |     ^^^^^^^ argument requires that `'b` must outlive `'a`
+   |       ^ argument requires that `'b` must outlive `'a`
    |
    = help: consider adding the following bound: `'b: 'a`
    = note: requirement occurs because of a mutable reference to `&isize`

--- a/tests/ui/regions/region-multiple-lifetime-bounds-on-fns-where-clause.stderr
+++ b/tests/ui/regions/region-multiple-lifetime-bounds-on-fns-where-clause.stderr
@@ -23,7 +23,7 @@ LL |     *x = *y;
    = help: consider adding the following bound: `'b: 'a`
 
 error: lifetime may not live long enough
-  --> $DIR/region-multiple-lifetime-bounds-on-fns-where-clause.rs:16:5
+  --> $DIR/region-multiple-lifetime-bounds-on-fns-where-clause.rs:16:7
    |
 LL | fn c<'a,'b, 'c>(x: &mut &'a isize, y: &mut &'b isize, z: &mut &'c isize) {
    |      -- -- lifetime `'b` defined here
@@ -31,7 +31,7 @@ LL | fn c<'a,'b, 'c>(x: &mut &'a isize, y: &mut &'b isize, z: &mut &'c isize) {
    |      lifetime `'a` defined here
 ...
 LL |     a(x, y, z);
-   |     ^^^^^^^^^^ argument requires that `'b` must outlive `'a`
+   |       ^ argument requires that `'b` must outlive `'a`
    |
    = help: consider adding the following bound: `'b: 'a`
    = note: requirement occurs because of a mutable reference to `&isize`

--- a/tests/ui/regions/regions-bounded-method-type-parameters-cross-crate.stderr
+++ b/tests/ui/regions/regions-bounded-method-type-parameters-cross-crate.stderr
@@ -7,7 +7,7 @@ LL | fn call_bigger_region<'x, 'y>(a: Inv<'x>, b: Inv<'y>) {
    |                       lifetime `'x` defined here
 LL |     // Here the value provided for 'y is 'y, and hence 'y:'x does not hold.
 LL |     a.bigger_region(b)
-   |     ^^^^^^^^^^^^^^^^^^ receiver requires that `'y` must outlive `'x`
+   |     ^ receiver requires that `'y` must outlive `'x`
    |
    = help: consider adding the following bound: `'y: 'x`
    = note: requirement occurs because of the type `Inv<'_>`, which makes the generic argument `'_` invariant

--- a/tests/ui/regions/regions-bounded-method-type-parameters-cross-crate.stderr
+++ b/tests/ui/regions/regions-bounded-method-type-parameters-cross-crate.stderr
@@ -7,7 +7,7 @@ LL | fn call_bigger_region<'x, 'y>(a: Inv<'x>, b: Inv<'y>) {
    |                       lifetime `'x` defined here
 LL |     // Here the value provided for 'y is 'y, and hence 'y:'x does not hold.
 LL |     a.bigger_region(b)
-   |     ^^^^^^^^^^^^^^^^^^ argument requires that `'y` must outlive `'x`
+   |     ^^^^^^^^^^^^^^^^^^ receiver requires that `'y` must outlive `'x`
    |
    = help: consider adding the following bound: `'y: 'x`
    = note: requirement occurs because of the type `Inv<'_>`, which makes the generic argument `'_` invariant

--- a/tests/ui/regions/regions-bounded-method-type-parameters-trait-bound.stderr
+++ b/tests/ui/regions/regions-bounded-method-type-parameters-trait-bound.stderr
@@ -1,5 +1,5 @@
 error: lifetime may not live long enough
-  --> $DIR/regions-bounded-method-type-parameters-trait-bound.rs:20:5
+  --> $DIR/regions-bounded-method-type-parameters-trait-bound.rs:20:14
    |
 LL | fn caller2<'a,'b,F:Foo<'a>>(a: Inv<'a>, b: Inv<'b>, f: F) {
    |            -- -- lifetime `'b` defined here
@@ -7,7 +7,7 @@ LL | fn caller2<'a,'b,F:Foo<'a>>(a: Inv<'a>, b: Inv<'b>, f: F) {
    |            lifetime `'a` defined here
 LL |     // Here the value provided for 'y is 'b, and hence 'b:'a does not hold.
 LL |     f.method(b);
-   |     ^^^^^^^^^^^ argument requires that `'b` must outlive `'a`
+   |              ^ argument requires that `'b` must outlive `'a`
    |
    = help: consider adding the following bound: `'b: 'a`
    = note: requirement occurs because of the type `Inv<'_>`, which makes the generic argument `'_` invariant

--- a/tests/ui/regions/regions-infer-proc-static-upvar.stderr
+++ b/tests/ui/regions/regions-infer-proc-static-upvar.stderr
@@ -5,10 +5,11 @@ LL |       let x = 3;
    |           - binding `x` declared here
 LL |       let y = &x;
    |               ^^ borrowed value does not live long enough
-LL | /     foo(move|| {
+LL |       foo(move|| {
+   |  _________-
 LL | |         let _a = *y;
 LL | |     });
-   | |______- argument requires that `x` is borrowed for `'static`
+   | |_____- argument requires that `x` is borrowed for `'static`
 LL |   }
    |   - `x` dropped here while still borrowed
    |

--- a/tests/ui/regions/regions-lifetime-bounds-on-fns.stderr
+++ b/tests/ui/regions/regions-lifetime-bounds-on-fns.stderr
@@ -23,7 +23,7 @@ LL |     *x = *y;
    = help: consider adding the following bound: `'b: 'a`
 
 error: lifetime may not live long enough
-  --> $DIR/regions-lifetime-bounds-on-fns.rs:14:5
+  --> $DIR/regions-lifetime-bounds-on-fns.rs:14:7
    |
 LL | fn c<'a,'b>(x: &mut &'a isize, y: &mut &'b isize) {
    |      -- -- lifetime `'b` defined here
@@ -31,7 +31,7 @@ LL | fn c<'a,'b>(x: &mut &'a isize, y: &mut &'b isize) {
    |      lifetime `'a` defined here
 ...
 LL |     a(x, y);
-   |     ^^^^^^^ argument requires that `'b` must outlive `'a`
+   |       ^ argument requires that `'b` must outlive `'a`
    |
    = help: consider adding the following bound: `'b: 'a`
    = note: requirement occurs because of a mutable reference to `&isize`

--- a/tests/ui/regions/regions-pattern-typing-issue-19552.stderr
+++ b/tests/ui/regions/regions-pattern-typing-issue-19552.stderr
@@ -6,7 +6,7 @@ LL |     let line = String::new();
 LL |     match [&*line] {
    |              ^^^^ borrowed value does not live long enough
 LL |         [ word ] => { assert_static(word); }
-   |                       ------------------- argument requires that `line` is borrowed for `'static`
+   |                                     ---- argument requires that `line` is borrowed for `'static`
 LL |     }
 LL | }
    | - `line` dropped here while still borrowed

--- a/tests/ui/regions/regions-static-bound.stderr
+++ b/tests/ui/regions/regions-static-bound.stderr
@@ -50,20 +50,20 @@ LL |     t
    |     ^ returning this value requires that `'a` must outlive `'static`
 
 error[E0521]: borrowed data escapes outside of function
-  --> $DIR/regions-static-bound.rs:18:5
+  --> $DIR/regions-static-bound.rs:18:15
    |
 LL | fn error(u: &(), v: &()) {
    |          -  - let's call the lifetime of this reference `'1`
    |          |
    |          `u` is a reference that is only valid in the function body
 LL |     static_id(&u);
-   |     ^^^^^^^^^^^^^
-   |     |
-   |     `u` escapes the function body here
-   |     argument requires that `'1` must outlive `'static`
+   |               ^^
+   |               |
+   |               `u` escapes the function body here
+   |               argument requires that `'1` must outlive `'static`
 
 error[E0521]: borrowed data escapes outside of function
-  --> $DIR/regions-static-bound.rs:20:5
+  --> $DIR/regions-static-bound.rs:20:24
    |
 LL | fn error(u: &(), v: &()) {
    |                  -  - let's call the lifetime of this reference `'2`
@@ -71,10 +71,10 @@ LL | fn error(u: &(), v: &()) {
    |                  `v` is a reference that is only valid in the function body
 ...
 LL |     static_id_indirect(&v);
-   |     ^^^^^^^^^^^^^^^^^^^^^^
-   |     |
-   |     `v` escapes the function body here
-   |     argument requires that `'2` must outlive `'static`
+   |                        ^^
+   |                        |
+   |                        `v` escapes the function body here
+   |                        argument requires that `'2` must outlive `'static`
 
 error: aborting due to 3 previous errors; 4 warnings emitted
 

--- a/tests/ui/static/static-lifetime-bound.stderr
+++ b/tests/ui/static/static-lifetime-bound.stderr
@@ -4,10 +4,10 @@ error[E0597]: `x` does not live long enough
 LL |     let x = 0;
    |         - binding `x` declared here
 LL |     f(&x);
-   |     --^^-
-   |     | |
-   |     | borrowed value does not live long enough
-   |     argument requires that `x` is borrowed for `'static`
+   |       ^^
+   |       |
+   |       borrowed value does not live long enough
+   |       argument requires that `x` is borrowed for `'static`
 LL | }
    | - `x` dropped here while still borrowed
    |

--- a/tests/ui/static/static-region-bound.stderr
+++ b/tests/ui/static/static-region-bound.stderr
@@ -4,7 +4,7 @@ error[E0716]: temporary value dropped while borrowed
 LL |     let x = &id(3);
    |              ^^^^^ creates a temporary value which is freed while still in use
 LL |     f(x);
-   |     ---- argument requires that borrow lasts for `'static`
+   |       - argument requires that borrow lasts for `'static`
 LL | }
    | - temporary value is freed at the end of this statement
    |

--- a/tests/ui/suggestions/impl-on-dyn-trait-with-implicit-static-bound-needing-more-suggestions.stderr
+++ b/tests/ui/suggestions/impl-on-dyn-trait-with-implicit-static-bound-needing-more-suggestions.stderr
@@ -36,7 +36,7 @@ LL |         val.use_self()
    |         ^^^^^^^^^^^^^^
    |         |
    |         `val` escapes the function body here
-   |         argument requires that `'a` must outlive `'static`
+   |         receiver requires that `'a` must outlive `'static`
    |
 note: the used `impl` has a `'static` requirement
   --> $DIR/impl-on-dyn-trait-with-implicit-static-bound-needing-more-suggestions.rs:60:30

--- a/tests/ui/suggestions/impl-on-dyn-trait-with-implicit-static-bound-needing-more-suggestions.stderr
+++ b/tests/ui/suggestions/impl-on-dyn-trait-with-implicit-static-bound-needing-more-suggestions.stderr
@@ -33,7 +33,7 @@ LL |     fn use_it<'a>(val: Box<dyn ObjectTrait<Assoc = i32> + 'a>) -> &'a () {
    |               |
    |               lifetime `'a` defined here
 LL |         val.use_self()
-   |         ^^^^^^^^^^^^^^
+   |         ^^^
    |         |
    |         `val` escapes the function body here
    |         receiver requires that `'a` must outlive `'static`

--- a/tests/ui/suggestions/impl-on-dyn-trait-with-implicit-static-bound.stderr
+++ b/tests/ui/suggestions/impl-on-dyn-trait-with-implicit-static-bound.stderr
@@ -9,7 +9,7 @@ LL |         val.use_self::<T>()
    |         ^^^^^^^^^^^^^^^^^^^
    |         |
    |         `val` escapes the function body here
-   |         argument requires that `'a` must outlive `'static`
+   |         receiver requires that `'a` must outlive `'static`
    |
 note: the used `impl` has a `'static` requirement
   --> $DIR/impl-on-dyn-trait-with-implicit-static-bound.rs:15:32
@@ -34,7 +34,7 @@ LL |         val.use_self()
    |         ^^^^^^^^^^^^^^
    |         |
    |         `val` escapes the function body here
-   |         argument requires that `'a` must outlive `'static`
+   |         receiver requires that `'a` must outlive `'static`
    |
 note: the used `impl` has a `'static` requirement
   --> $DIR/impl-on-dyn-trait-with-implicit-static-bound.rs:67:14
@@ -59,7 +59,7 @@ LL |         val.use_self()
    |         ^^^^^^^^^^^^^^
    |         |
    |         `val` escapes the function body here
-   |         argument requires that `'a` must outlive `'static`
+   |         receiver requires that `'a` must outlive `'static`
    |
 note: the used `impl` has a `'static` requirement
   --> $DIR/impl-on-dyn-trait-with-implicit-static-bound.rs:89:26
@@ -111,7 +111,7 @@ LL |         val.use_self()
    |         ^^^^^^^^^^^^^^
    |         |
    |         `val` escapes the function body here
-   |         argument requires that `'a` must outlive `'static`
+   |         receiver requires that `'a` must outlive `'static`
    |
 note: the used `impl` has a `'static` requirement
   --> $DIR/impl-on-dyn-trait-with-implicit-static-bound.rs:32:26
@@ -136,7 +136,7 @@ LL |         val.use_self()
    |         ^^^^^^^^^^^^^^
    |         |
    |         `val` escapes the function body here
-   |         argument requires that `'a` must outlive `'static`
+   |         receiver requires that `'a` must outlive `'static`
    |
 note: the used `impl` has a `'static` requirement
   --> $DIR/impl-on-dyn-trait-with-implicit-static-bound.rs:50:30

--- a/tests/ui/suggestions/impl-on-dyn-trait-with-implicit-static-bound.stderr
+++ b/tests/ui/suggestions/impl-on-dyn-trait-with-implicit-static-bound.stderr
@@ -6,7 +6,7 @@ LL |     fn use_it<'a, T>(val: &'a dyn ObjectTrait<T>) -> impl OtherTrait<'a> + 
    |               |
    |               lifetime `'a` defined here
 LL |         val.use_self::<T>()
-   |         ^^^^^^^^^^^^^^^^^^^
+   |         ^^^
    |         |
    |         `val` escapes the function body here
    |         receiver requires that `'a` must outlive `'static`
@@ -31,7 +31,7 @@ LL |     fn use_it<'a>(val: &'a dyn ObjectTrait) -> impl OtherTrait<'a> + 'a {
    |               |
    |               lifetime `'a` defined here
 LL |         val.use_self()
-   |         ^^^^^^^^^^^^^^
+   |         ^^^
    |         |
    |         `val` escapes the function body here
    |         receiver requires that `'a` must outlive `'static`
@@ -56,7 +56,7 @@ LL |     fn use_it<'a>(val: &'a dyn ObjectTrait) -> impl OtherTrait<'a> {
    |               |
    |               lifetime `'a` defined here
 LL |         val.use_self()
-   |         ^^^^^^^^^^^^^^
+   |         ^^^
    |         |
    |         `val` escapes the function body here
    |         receiver requires that `'a` must outlive `'static`
@@ -75,17 +75,17 @@ LL |     impl MyTrait for dyn ObjectTrait + '_ {}
    |                                      ++++
 
 error[E0521]: borrowed data escapes outside of function
-  --> $DIR/impl-on-dyn-trait-with-implicit-static-bound.rs:112:9
+  --> $DIR/impl-on-dyn-trait-with-implicit-static-bound.rs:112:27
    |
 LL |     fn use_it<'a>(val: &'a dyn ObjectTrait) -> impl OtherTrait<'a> + 'a {
    |               --  --- `val` is a reference that is only valid in the function body
    |               |
    |               lifetime `'a` defined here
 LL |         MyTrait::use_self(val)
-   |         ^^^^^^^^^^^^^^^^^^^^^^
-   |         |
-   |         `val` escapes the function body here
-   |         argument requires that `'a` must outlive `'static`
+   |                           ^^^
+   |                           |
+   |                           `val` escapes the function body here
+   |                           argument requires that `'a` must outlive `'static`
    |
 note: the used `impl` has a `'static` requirement
   --> $DIR/impl-on-dyn-trait-with-implicit-static-bound.rs:108:26
@@ -108,7 +108,7 @@ LL |     fn use_it<'a>(val: &'a dyn ObjectTrait) -> &'a () {
    |               |
    |               lifetime `'a` defined here
 LL |         val.use_self()
-   |         ^^^^^^^^^^^^^^
+   |         ^^^
    |         |
    |         `val` escapes the function body here
    |         receiver requires that `'a` must outlive `'static`
@@ -133,7 +133,7 @@ LL |     fn use_it<'a>(val: &'a Box<dyn ObjectTrait + 'a>) -> &'a () {
    |               |
    |               lifetime `'a` defined here
 LL |         val.use_self()
-   |         ^^^^^^^^^^^^^^
+   |         ^^^
    |         |
    |         `val` escapes the function body here
    |         receiver requires that `'a` must outlive `'static`

--- a/tests/ui/traits/associated_type_bound/check-trait-object-bounds-3.stderr
+++ b/tests/ui/traits/associated_type_bound/check-trait-object-bounds-3.stderr
@@ -4,10 +4,10 @@ error[E0597]: `s` does not live long enough
 LL |         let s = String::from("abcdef");
    |             - binding `s` declared here
 LL |         z = f::<dyn X<Y = &str>>(&s);
-   |             ---------------------^^-
-   |             |                    |
-   |             |                    borrowed value does not live long enough
-   |             argument requires that `s` is borrowed for `'static`
+   |                                  ^^
+   |                                  |
+   |                                  borrowed value does not live long enough
+   |                                  argument requires that `s` is borrowed for `'static`
 LL |
 LL |     }
    |     - `s` dropped here while still borrowed

--- a/tests/ui/traits/object/issue-44454-2.stderr
+++ b/tests/ui/traits/object/issue-44454-2.stderr
@@ -1,5 +1,5 @@
 error[E0521]: borrowed data escapes outside of function
-  --> $DIR/issue-44454-2.rs:16:5
+  --> $DIR/issue-44454-2.rs:16:23
    |
 LL | fn extend_lt<'a>(x: &'a str) -> Box<dyn AsRef<str> + 'static> {
    |              --  - `x` is a reference that is only valid in the function body
@@ -7,10 +7,10 @@ LL | fn extend_lt<'a>(x: &'a str) -> Box<dyn AsRef<str> + 'static> {
    |              lifetime `'a` defined here
 LL |     type DynTrait = dyn for<'a> Trait<&'a str, Assoc = &'a str>;
 LL |     hr::<DynTrait, _>(x)
-   |     ^^^^^^^^^^^^^^^^^^^^
-   |     |
-   |     `x` escapes the function body here
-   |     argument requires that `'a` must outlive `'static`
+   |                       ^
+   |                       |
+   |                       `x` escapes the function body here
+   |                       argument requires that `'a` must outlive `'static`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/transmutability/references/reject_lifetime_extension.stderr
+++ b/tests/ui/transmutability/references/reject_lifetime_extension.stderr
@@ -55,17 +55,17 @@ LL |         unsafe { transmute(src) }
    |                  ^^^^^^^^^^^^^^ returning this value requires that `'a` must outlive `'static`
 
 error[E0521]: borrowed data escapes outside of function
-  --> $DIR/reject_lifetime_extension.rs:80:18
+  --> $DIR/reject_lifetime_extension.rs:80:30
    |
 LL |     fn call_extend_hrtb<'a>(src: &'a u8) -> &'static u8 {
    |                         --  --- `src` is a reference that is only valid in the function body
    |                         |
    |                         lifetime `'a` defined here
 LL |         unsafe { extend_hrtb(src) }
-   |                  ^^^^^^^^^^^^^^^^
-   |                  |
-   |                  `src` escapes the function body here
-   |                  argument requires that `'a` must outlive `'static`
+   |                              ^^^
+   |                              |
+   |                              `src` escapes the function body here
+   |                              argument requires that `'a` must outlive `'static`
    |
 note: due to a current limitation of the type system, this implies a `'static` lifetime
   --> $DIR/reject_lifetime_extension.rs:85:9

--- a/tests/ui/unboxed-closures/issue-30906.stderr
+++ b/tests/ui/unboxed-closures/issue-30906.stderr
@@ -1,8 +1,8 @@
 error: implementation of `FnOnce` is not general enough
-  --> $DIR/issue-30906.rs:18:5
+  --> $DIR/issue-30906.rs:18:10
    |
 LL |     test(Compose(f, |_| {}));
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^ implementation of `FnOnce` is not general enough
+   |          ^^^^^^^^^^^^^^^^^^ implementation of `FnOnce` is not general enough
    |
    = note: `fn(&'2 str) -> T` must implement `FnOnce<(&'1 str,)>`, for any lifetime `'1`...
    = note: ...but it actually implements `FnOnce<(&'2 str,)>`, for some specific lifetime `'2`

--- a/tests/ui/unboxed-closures/unboxed-closures-infer-argument-types-two-region-pointers.stderr
+++ b/tests/ui/unboxed-closures/unboxed-closures-infer-argument-types-two-region-pointers.stderr
@@ -6,7 +6,7 @@ LL |     doit(0, &|x, y| {
    |               |
    |               has type `&Cell<&'2 i32>`
 LL |         x.set(y);
-   |         ^^^^^^^^ receiver requires that `'1` must outlive `'2`
+   |         ^ receiver requires that `'1` must outlive `'2`
    |
    = note: requirement occurs because of the type `Cell<&i32>`, which makes the generic argument `&i32` invariant
    = note: the struct `Cell<T>` is invariant over the parameter `T`

--- a/tests/ui/unboxed-closures/unboxed-closures-infer-argument-types-two-region-pointers.stderr
+++ b/tests/ui/unboxed-closures/unboxed-closures-infer-argument-types-two-region-pointers.stderr
@@ -6,7 +6,7 @@ LL |     doit(0, &|x, y| {
    |               |
    |               has type `&Cell<&'2 i32>`
 LL |         x.set(y);
-   |         ^^^^^^^^ argument requires that `'1` must outlive `'2`
+   |         ^^^^^^^^ receiver requires that `'1` must outlive `'2`
    |
    = note: requirement occurs because of the type `Cell<&i32>`, which makes the generic argument `&i32` invariant
    = note: the struct `Cell<T>` is invariant over the parameter `T`

--- a/tests/ui/underscore-lifetime/underscore-lifetime-elison-mismatch.stderr
+++ b/tests/ui/underscore-lifetime/underscore-lifetime-elison-mismatch.stderr
@@ -2,7 +2,7 @@ error: lifetime may not live long enough
   --> $DIR/underscore-lifetime-elison-mismatch.rs:1:42
    |
 LL | fn foo(x: &mut Vec<&'_ u8>, y: &'_ u8) { x.push(y); }
-   |                    -           -         ^^^^^^^^^ argument requires that `'1` must outlive `'2`
+   |                    -           -         ^^^^^^^^^ receiver requires that `'1` must outlive `'2`
    |                    |           |
    |                    |           let's call the lifetime of this reference `'1`
    |                    let's call the lifetime of this reference `'2`

--- a/tests/ui/underscore-lifetime/underscore-lifetime-elison-mismatch.stderr
+++ b/tests/ui/underscore-lifetime/underscore-lifetime-elison-mismatch.stderr
@@ -2,7 +2,7 @@ error: lifetime may not live long enough
   --> $DIR/underscore-lifetime-elison-mismatch.rs:1:42
    |
 LL | fn foo(x: &mut Vec<&'_ u8>, y: &'_ u8) { x.push(y); }
-   |                    -           -         ^^^^^^^^^ receiver requires that `'1` must outlive `'2`
+   |                    -           -         ^ receiver requires that `'1` must outlive `'2`
    |                    |           |
    |                    |           let's call the lifetime of this reference `'1`
    |                    let's call the lifetime of this reference `'2`

--- a/tests/ui/variance/variance-trait-matching.stderr
+++ b/tests/ui/variance/variance-trait-matching.stderr
@@ -1,8 +1,8 @@
 error[E0621]: explicit lifetime required in the type of `get`
-  --> $DIR/variance-trait-matching.rs:24:5
+  --> $DIR/variance-trait-matching.rs:24:10
    |
 LL |     pick(get, &22)
-   |     ^^^^^^^^^^^^^^ lifetime `'a` required
+   |          ^^^ lifetime `'a` required
    |
 help: add explicit lifetime `'a` to the type of `get`
    |

--- a/tests/ui/wf/wf-in-where-clause-static.current.stderr
+++ b/tests/ui/wf/wf-in-where-clause-static.current.stderr
@@ -2,10 +2,10 @@ error[E0716]: temporary value dropped while borrowed
   --> $DIR/wf-in-where-clause-static.rs:18:18
    |
 LL |     let s = foo(&String::from("blah blah blah"));
-   |             -----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-- temporary value is freed at the end of this statement
-   |             |    |
-   |             |    creates a temporary value which is freed while still in use
-   |             argument requires that borrow lasts for `'static`
+   |                 -^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - temporary value is freed at the end of this statement
+   |                 ||
+   |                 |creates a temporary value which is freed while still in use
+   |                 argument requires that borrow lasts for `'static`
    |
 note: requirement that the value outlives `'static` introduced here
   --> $DIR/wf-in-where-clause-static.rs:12:17

--- a/tests/ui/wf/wf-in-where-clause-static.next.stderr
+++ b/tests/ui/wf/wf-in-where-clause-static.next.stderr
@@ -2,10 +2,10 @@ error[E0716]: temporary value dropped while borrowed
   --> $DIR/wf-in-where-clause-static.rs:18:18
    |
 LL |     let s = foo(&String::from("blah blah blah"));
-   |             -----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-- temporary value is freed at the end of this statement
-   |             |    |
-   |             |    creates a temporary value which is freed while still in use
-   |             argument requires that borrow lasts for `'static`
+   |                 -^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - temporary value is freed at the end of this statement
+   |                 ||
+   |                 |creates a temporary value which is freed while still in use
+   |                 argument requires that borrow lasts for `'static`
    |
 note: requirement that the value outlives `'static` introduced here
   --> $DIR/wf-in-where-clause-static.rs:12:17


### PR DESCRIPTION
Before this commit, `ConstraintCategory::CallArgument` diagnostics would point to the entire call expression:

    LL |     let b = bar(f, y);
       |             ^^^^^^^^^ argument requires that `'a` must outlive `'b`

This commit changes the diagnostics to point to the specific argument that is causing the lifetime issue:

    LL |     let b = bar(f, y);
       |                    ^ argument requires that `'a` must outlive `'b`


# Draft

This is just a draft and not ready for review. (Although if someone says "this will never work because of ..." I would like to hear that, of course)

I am currently primarily interested in running perf on this, to get a sense for is this can be made to work. If not, there are hopefully other ways to achieve the same end result.
