### PR TITLE
[compiler] Implement `PartialOrd` via `Ord` for `Span` and newtype_indexes

### DIFF
--- a/compiler/rustc_index_macros/src/newtype.rs
+++ b/compiler/rustc_index_macros/src/newtype.rs
@@ -138,13 +138,15 @@ impl Parse for Newtype {
                     }
                 }
                 impl ::std::cmp::Ord for #name {
+                    #[inline]
                     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
                         self.as_u32().cmp(&other.as_u32())
                     }
                 }
                 impl ::std::cmp::PartialOrd for #name {
+                    #[inline]
                     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-                        self.as_u32().partial_cmp(&other.as_u32())
+                        Some(self.cmp(other))
                     }
                 }
             }

--- a/compiler/rustc_span/src/lib.rs
+++ b/compiler/rustc_span/src/lib.rs
@@ -738,7 +738,7 @@ impl Default for SpanData {
 
 impl PartialOrd for Span {
     fn partial_cmp(&self, rhs: &Self) -> Option<Ordering> {
-        PartialOrd::partial_cmp(&self.data(), &rhs.data())
+        Some(self.cmp(rhs))
     }
 }
 impl Ord for Span {


### PR DESCRIPTION
For something unconditionally `Ord`, this is better than using `partial_cmp` on fields.

I couldn't find any other cases in the compiler codebase of this, but it's entirely possible I missed some.  Let me know if you can think of any.
