### PR TITLE
experiment: shrink LitKind to 16 bytes

### DIFF
--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -19,16 +19,17 @@
 //! - [`UnOp`], [`BinOp`], and [`BinOpKind`]: Unary and binary operators.
 
 use std::borrow::{Borrow, Cow};
+use std::cmp::Ordering;
 use std::{cmp, fmt};
 
 pub use GenericArgs::*;
 pub use UnsafeSource::*;
 pub use rustc_ast_ir::{FloatTy, IntTy, Movability, Mutability, Pinnedness, UintTy};
-use rustc_data_structures::packed::Pu128;
 use rustc_data_structures::stable_hash::{StableHash, StableHashCtxt, StableHasher};
 use rustc_data_structures::stack::ensure_sufficient_stack;
 use rustc_data_structures::tagged_ptr::Tag;
 use rustc_macros::{Decodable, Encodable, StableHash, Walkable};
+use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
 pub use rustc_span::AttrId;
 use rustc_span::def_id::LocalDefId;
 use rustc_span::{
@@ -2242,6 +2243,78 @@ pub enum LitFloatType {
     Unsuffixed,
 }
 
+#[derive(Clone, Copy, Debug, Hash, Eq, PartialEq, StableHash)]
+pub struct IntVal(pub &'static u128);
+
+impl IntVal {
+    const ZERO: IntVal = IntVal(&0);
+    const ONE: IntVal = IntVal(&1);
+
+    pub fn new(val: u128) -> Self {
+        match val {
+            // assuming these literals are the most common
+            // we can avoid allocating for them
+            0 => Self::ZERO,
+            1 => Self::ONE,
+            // FIXME(panstromek) avoid leak (this is just an experiment)
+            v => Self(Box::leak(Box::new(v))),
+        }
+    }
+
+    pub fn get(&self) -> u128 {
+        *self.0
+    }
+}
+
+impl<S: Encoder> Encodable<S> for IntVal {
+    #[inline]
+    fn encode(&self, s: &mut S) {
+        { self.0 }.encode(s);
+    }
+}
+
+impl<D: Decoder> Decodable<D> for IntVal {
+    #[inline]
+    fn decode(d: &mut D) -> Self {
+        u128::decode(d).into()
+    }
+}
+
+impl fmt::Display for IntVal {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl From<IntVal> for u128 {
+    #[inline]
+    fn from(value: IntVal) -> Self {
+        value.get()
+    }
+}
+
+impl From<u128> for IntVal {
+    #[inline]
+    fn from(value: u128) -> Self {
+        Self::new(value)
+    }
+}
+
+impl PartialEq<u128> for IntVal {
+    #[inline]
+    fn eq(&self, other: &u128) -> bool {
+        *self.0 == *other
+    }
+}
+
+impl PartialOrd<u128> for IntVal {
+    #[inline]
+    fn partial_cmp(&self, other: &u128) -> Option<Ordering> {
+        self.0.partial_cmp(other)
+    }
+}
+
 /// This type is used within both `ast::MetaItemLit` and `hir::Lit`.
 ///
 /// Note that the entire literal (including the suffix) is considered when
@@ -2265,7 +2338,7 @@ pub enum LitKind {
     /// A character literal (`'a'`).
     Char(char),
     /// An integer literal (`1`).
-    Int(Pu128, LitIntType),
+    Int(IntVal, LitIntType),
     /// A float literal (`1.0`, `1f64` or `1E10f64`). The pre-suffix part is
     /// stored as a symbol rather than `f64` so that `LitKind` can impl `Eq`
     /// and `Hash`.
@@ -4413,11 +4486,11 @@ mod size_asserts {
     static_assert_size!(Item, 152);
     static_assert_size!(ItemKind, 88);
     static_assert_size!(Lifetime, 16);
-    static_assert_size!(LitKind, 24);
+    static_assert_size!(LitKind, 16);
     static_assert_size!(Local, 96);
-    static_assert_size!(MetaItem, 88);
-    static_assert_size!(MetaItemKind, 40);
-    static_assert_size!(MetaItemLit, 40);
+    static_assert_size!(MetaItem, 80);
+    static_assert_size!(MetaItemKind, 32);
+    static_assert_size!(MetaItemLit, 32);
     static_assert_size!(Param, 40);
     static_assert_size!(Pat, 80);
     static_assert_size!(PatKind, 56);

--- a/compiler/rustc_attr_parsing/src/attributes/autodiff.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/autodiff.rs
@@ -68,7 +68,7 @@ impl SingleAttributeParser for RustcAutodiffParser {
         let width = if let Some(width) = items.peek()
             && let MetaItemOrLitParser::Lit(width) = width
             && let LitKind::Int(width, _) = width.kind
-            && let Ok(width) = width.0.try_into()
+            && let Ok(width) = width.get().try_into()
         {
             _ = items.next();
             width

--- a/compiler/rustc_attr_parsing/src/attributes/rustc_internal.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/rustc_internal.rs
@@ -126,7 +126,7 @@ impl SingleAttributeParser for RustcLegacyConstGenericsParser {
                 ..
             }) = possible_index
             {
-                parsed_indexes.push((index.0 as usize, possible_index.span()));
+                parsed_indexes.push((*index.0 as usize, possible_index.span()));
             } else {
                 cx.adcx().expected_integer_literal(possible_index.span());
                 errored = true;

--- a/compiler/rustc_attr_parsing/src/attributes/util.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/util.rs
@@ -49,7 +49,7 @@ pub(crate) fn parse_single_integer(
         cx.adcx().expected_integer_literal(single.span());
         return None;
     };
-    Some(num.0)
+    Some(*num.0)
 }
 
 impl AcceptContext<'_, '_> {

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -5507,6 +5507,7 @@ mod size_asserts {
     static_assert_size!(ImplItemKind<'_>, 40);
     static_assert_size!(Item<'_>, 88);
     static_assert_size!(ItemKind<'_>, 64);
+    static_assert_size!(Lit, 24);
     static_assert_size!(LetStmt<'_>, 64);
     static_assert_size!(Param<'_>, 32);
     static_assert_size!(Pat<'_>, 80);

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
@@ -4,7 +4,6 @@ use core::iter;
 
 use hir::def_id::LocalDefId;
 use rustc_ast::util::parser::ExprPrecedence;
-use rustc_data_structures::packed::Pu128;
 use rustc_errors::{Applicability, Diag, MultiSpan, listify, msg};
 use rustc_hir::def::{CtorKind, CtorOf, DefKind, Res};
 use rustc_hir::intravisit::Visitor;
@@ -1880,7 +1879,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         };
 
         // Provided expression needs to be a literal `0`.
-        let ExprKind::Lit(Spanned { node: rustc_ast::LitKind::Int(Pu128(0), _), span }) = expr.kind
+        let ExprKind::Lit(Spanned { node: rustc_ast::LitKind::Int(rustc_ast::IntVal(0), _), span }) =
+            expr.kind
         else {
             return false;
         };

--- a/compiler/rustc_hir_typeck/src/op.rs
+++ b/compiler/rustc_hir_typeck/src/op.rs
@@ -1,7 +1,6 @@
 //! Code related to processing overloaded binary and unary operators.
 
 use rustc_ast::{self as ast, AssignOp, BinOp};
-use rustc_data_structures::packed::Pu128;
 use rustc_errors::codes::*;
 use rustc_errors::{Applicability, Diag, struct_span_code_err};
 use rustc_hir::def_id::DefId;
@@ -1027,7 +1026,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                     Expr {
                                         kind:
                                             ExprKind::Lit(Spanned {
-                                                node: ast::LitKind::Int(Pu128(1), _),
+                                                node: ast::LitKind::Int(ast::IntVal(1), _),
                                                 ..
                                             }),
                                         ..


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

This is a bad way to do it but I want to see the impact.

This seems like an obvious thing to do (all LitKind variants are 8 bytes, only the `Int` one is 24),  but I haven't found previous attempt to try this.

Not sure if I need to fix clippy to run try build.