### PR TITLE
fix process-panic-after-fork on some Linux

### DIFF
--- a/tests/ui/process/process-panic-after-fork.rs
+++ b/tests/ui/process/process-panic-after-fork.rs
@@ -15,6 +15,7 @@
 extern crate libc;
 
 use std::alloc::{GlobalAlloc, Layout};
+use std::assert_matches;
 use std::ffi::c_int;
 use std::fmt;
 use std::panic::{self, panic_any};
@@ -193,5 +194,5 @@ fn main() {
 
     let status = run(&|| panic!("allocating to display... {}", DisplayWithHeap));
     dbg!(status);
-    assert_eq!(status.signal(), Some(libc::SIGUSR1));
+    assert_matches!(status.signal(), Some(libc::SIGUSR1 | libc::SIGIOT));
 }


### PR DESCRIPTION
On an old voidlinux system I tested, the final `status.signal()` is `Some(libc::SIGIOT)`, which fails the test. So I just extend the assertion to cover this case.