### PR TITLE
[rustdoc] Do not take `doc(cfg())` into account when filtering doctests

### DIFF
--- a/library/core/src/os/darwin/objc.rs
+++ b/library/core/src/os/darwin/objc.rs
@@ -67,7 +67,8 @@ pub type SEL = *mut objc_selector;
 ///
 /// # Example
 ///
-/// ```no_run
+#[cfg_attr(target_os = "macos", doc = "```no_run")]
+#[cfg_attr(not(target_os = "macos"), doc = "```ignore (needs macos)")]
 /// #![feature(darwin_objc)]
 /// use core::os::darwin::objc;
 ///
@@ -93,7 +94,8 @@ pub macro class($classname:expr) {{
 ///
 /// # Examples
 ///
-/// ```no_run
+#[cfg_attr(target_os = "macos", doc = "```no_run")]
+#[cfg_attr(not(target_os = "macos"), doc = "```ignore (needs macos)")]
 /// #![feature(darwin_objc)]
 /// use core::os::darwin::objc;
 ///

--- a/library/std/src/os/aix/fs.rs
+++ b/library/std/src/os/aix/fs.rs
@@ -16,7 +16,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "aix", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "aix"), doc = "```ignore (needs aix)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::aix::fs::MetadataExt;
@@ -33,7 +34,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "aix", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "aix"), doc = "```ignore (needs aix)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::aix::fs::MetadataExt;
@@ -50,7 +52,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "aix", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "aix"), doc = "```ignore (needs aix)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::aix::fs::MetadataExt;
@@ -67,7 +70,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "aix", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "aix"), doc = "```ignore (needs aix)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::aix::fs::MetadataExt;
@@ -84,7 +88,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "aix", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "aix"), doc = "```ignore (needs aix)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::aix::fs::MetadataExt;
@@ -101,7 +106,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "aix", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "aix"), doc = "```ignore (needs aix)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::aix::fs::MetadataExt;
@@ -118,7 +124,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "aix", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "aix"), doc = "```ignore (needs aix)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::aix::fs::MetadataExt;
@@ -138,7 +145,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "aix", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "aix"), doc = "```ignore (needs aix)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::aix::fs::MetadataExt;
@@ -155,7 +163,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "aix", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "aix"), doc = "```ignore (needs aix)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::aix::fs::MetadataExt;
@@ -174,7 +183,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "aix", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "aix"), doc = "```ignore (needs aix)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::aix::fs::MetadataExt;
@@ -191,7 +201,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "aix", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "aix"), doc = "```ignore (needs aix)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::aix::fs::MetadataExt;
@@ -210,7 +221,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "aix", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "aix"), doc = "```ignore (needs aix)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::aix::fs::MetadataExt;
@@ -227,7 +239,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "aix", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "aix"), doc = "```ignore (needs aix)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::aix::fs::MetadataExt;
@@ -246,7 +259,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "aix", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "aix"), doc = "```ignore (needs aix)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::aix::fs::MetadataExt;
@@ -263,7 +277,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "aix", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "aix"), doc = "```ignore (needs aix)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::aix::fs::MetadataExt;
@@ -280,7 +295,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "aix", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "aix"), doc = "```ignore (needs aix)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::aix::fs::MetadataExt;

--- a/library/std/src/os/fortanix_sgx/ffi.rs
+++ b/library/std/src/os/fortanix_sgx/ffi.rs
@@ -2,7 +2,11 @@
 //!
 //! # Examples
 //!
-//! ```
+#![cfg_attr(all(target_vendor = "fortanix", target_env = "sgx"), doc = "```")]
+#![cfg_attr(
+    not(all(target_vendor = "fortanix", target_env = "sgx")),
+    doc = "```ignore (needs aix)"
+)]
 //! use std::ffi::OsString;
 //! use std::os::fortanix_sgx::ffi::OsStringExt;
 //!
@@ -17,7 +21,11 @@
 //! assert_eq!(bytes, b"foo");
 //! ```
 //!
-//! ```
+#![cfg_attr(all(target_vendor = "fortanix", target_env = "sgx"), doc = "```")]
+#![cfg_attr(
+    not(all(target_vendor = "fortanix", target_env = "sgx")),
+    doc = "```ignore (needs aix)"
+)]
 //! use std::ffi::OsStr;
 //! use std::os::fortanix_sgx::ffi::OsStrExt;
 //!

--- a/library/std/src/os/freebsd/net.rs
+++ b/library/std/src/os/freebsd/net.rs
@@ -27,7 +27,8 @@ pub impl(self) trait UnixSocketExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "freebsd", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "freebsd"), doc = "```ignore (needs freebsd)")]
     /// #![feature(unix_socket_ancillary_data)]
     /// use std::os::freebsd::net::UnixSocketExt;
     /// use std::os::unix::net::UnixDatagram;

--- a/library/std/src/os/hermit/ffi.rs
+++ b/library/std/src/os/hermit/ffi.rs
@@ -2,7 +2,8 @@
 //!
 //! # Examples
 //!
-//! ```
+#![cfg_attr(target_os = "hermit", doc = "```")]
+#![cfg_attr(not(target_os = "hermit"), doc = "```ignore (needs hermit)")]
 //! use std::ffi::OsString;
 //! use std::os::hermit::ffi::OsStringExt;
 //!
@@ -17,7 +18,8 @@
 //! assert_eq!(bytes, b"foo");
 //! ```
 //!
-//! ```
+#![cfg_attr(target_os = "hermit", doc = "```")]
+#![cfg_attr(not(target_os = "hermit"), doc = "```ignore (needs hermit)")]
 //! use std::ffi::OsStr;
 //! use std::os::hermit::ffi::OsStrExt;
 //!

--- a/library/std/src/os/hurd/fs.rs
+++ b/library/std/src/os/hurd/fs.rs
@@ -16,7 +16,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "hurd", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "hurd"), doc = "```ignore (needs hurd)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::hurd::fs::MetadataExt;
@@ -33,7 +34,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "hurd", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "hurd"), doc = "```ignore (needs hurd)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::hurd::fs::MetadataExt;
@@ -50,7 +52,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "hurd", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "hurd"), doc = "```ignore (needs hurd)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::hurd::fs::MetadataExt;
@@ -67,7 +70,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "hurd", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "hurd"), doc = "```ignore (needs hurd)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::hurd::fs::MetadataExt;
@@ -84,7 +88,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "hurd", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "hurd"), doc = "```ignore (needs hurd)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::hurd::fs::MetadataExt;
@@ -101,7 +106,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "hurd", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "hurd"), doc = "```ignore (needs hurd)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::hurd::fs::MetadataExt;
@@ -118,7 +124,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "hurd", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "hurd"), doc = "```ignore (needs hurd)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::hurd::fs::MetadataExt;
@@ -138,7 +145,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "hurd", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "hurd"), doc = "```ignore (needs hurd)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::hurd::fs::MetadataExt;
@@ -155,7 +163,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "hurd", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "hurd"), doc = "```ignore (needs hurd)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::hurd::fs::MetadataExt;
@@ -174,7 +183,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "hurd", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "hurd"), doc = "```ignore (needs hurd)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::hurd::fs::MetadataExt;
@@ -191,7 +201,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "hurd", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "hurd"), doc = "```ignore (needs hurd)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::hurd::fs::MetadataExt;
@@ -210,7 +221,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "hurd", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "hurd"), doc = "```ignore (needs hurd)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::hurd::fs::MetadataExt;
@@ -227,7 +239,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "hurd", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "hurd"), doc = "```ignore (needs hurd)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::hurd::fs::MetadataExt;
@@ -246,7 +259,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "hurd", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "hurd"), doc = "```ignore (needs hurd)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::hurd::fs::MetadataExt;
@@ -263,7 +277,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "hurd", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "hurd"), doc = "```ignore (needs hurd)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::hurd::fs::MetadataExt;
@@ -280,7 +295,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "hurd", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "hurd"), doc = "```ignore (needs hurd)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::hurd::fs::MetadataExt;

--- a/library/std/src/os/l4re/fs.rs
+++ b/library/std/src/os/l4re/fs.rs
@@ -25,7 +25,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "l4re", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "l4re"), doc = "```ignore (needs l4re)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::linux::fs::MetadataExt;
@@ -45,7 +46,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "l4re", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "l4re"), doc = "```ignore (needs l4re)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::linux::fs::MetadataExt;
@@ -62,7 +64,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "l4re", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "l4re"), doc = "```ignore (needs l4re)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::linux::fs::MetadataExt;
@@ -79,7 +82,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "l4re", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "l4re"), doc = "```ignore (needs l4re)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::linux::fs::MetadataExt;
@@ -96,7 +100,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "l4re", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "l4re"), doc = "```ignore (needs l4re)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::linux::fs::MetadataExt;
@@ -113,7 +118,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "l4re", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "l4re"), doc = "```ignore (needs l4re)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::linux::fs::MetadataExt;
@@ -130,7 +136,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "l4re", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "l4re"), doc = "```ignore (needs l4re)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::linux::fs::MetadataExt;
@@ -147,7 +154,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "l4re", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "l4re"), doc = "```ignore (needs l4re)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::linux::fs::MetadataExt;
@@ -167,7 +175,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "l4re", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "l4re"), doc = "```ignore (needs l4re)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::linux::fs::MetadataExt;
@@ -184,7 +193,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "l4re", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "l4re"), doc = "```ignore (needs l4re)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::linux::fs::MetadataExt;
@@ -203,7 +213,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "l4re", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "l4re"), doc = "```ignore (needs l4re)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::linux::fs::MetadataExt;
@@ -220,7 +231,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "l4re", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "l4re"), doc = "```ignore (needs l4re)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::linux::fs::MetadataExt;
@@ -239,7 +251,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "l4re", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "l4re"), doc = "```ignore (needs l4re)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::linux::fs::MetadataExt;
@@ -256,7 +269,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "l4re", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "l4re"), doc = "```ignore (needs l4re)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::linux::fs::MetadataExt;
@@ -275,7 +289,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "l4re", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "l4re"), doc = "```ignore (needs l4re)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::linux::fs::MetadataExt;
@@ -292,7 +307,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "l4re", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "l4re"), doc = "```ignore (needs l4re)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::linux::fs::MetadataExt;
@@ -309,7 +325,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "l4re", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "l4re"), doc = "```ignore (needs l4re)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::linux::fs::MetadataExt;

--- a/library/std/src/os/linux/fs.rs
+++ b/library/std/src/os/linux/fs.rs
@@ -25,7 +25,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "linux", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "linux"), doc = "```ignore (needs linux)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::linux::fs::MetadataExt;
@@ -45,7 +46,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "linux", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "linux"), doc = "```ignore (needs linux)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::linux::fs::MetadataExt;
@@ -62,7 +64,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "linux", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "linux"), doc = "```ignore (needs linux)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::linux::fs::MetadataExt;
@@ -79,7 +82,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "linux", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "linux"), doc = "```ignore (needs linux)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::linux::fs::MetadataExt;
@@ -96,7 +100,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "linux", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "linux"), doc = "```ignore (needs linux)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::linux::fs::MetadataExt;
@@ -113,7 +118,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "linux", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "linux"), doc = "```ignore (needs linux)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::linux::fs::MetadataExt;
@@ -130,7 +136,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "linux", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "linux"), doc = "```ignore (needs linux)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::linux::fs::MetadataExt;
@@ -147,7 +154,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "linux", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "linux"), doc = "```ignore (needs linux)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::linux::fs::MetadataExt;
@@ -167,7 +175,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "linux", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "linux"), doc = "```ignore (needs linux)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::linux::fs::MetadataExt;
@@ -184,7 +193,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "linux", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "linux"), doc = "```ignore (needs linux)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::linux::fs::MetadataExt;
@@ -203,7 +213,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "linux", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "linux"), doc = "```ignore (needs linux)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::linux::fs::MetadataExt;
@@ -220,7 +231,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "linux", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "linux"), doc = "```ignore (needs linux)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::linux::fs::MetadataExt;
@@ -239,7 +251,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "linux", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "linux"), doc = "```ignore (needs linux)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::linux::fs::MetadataExt;
@@ -256,7 +269,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "linux", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "linux"), doc = "```ignore (needs linux)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::linux::fs::MetadataExt;
@@ -275,7 +289,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "linux", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "linux"), doc = "```ignore (needs linux)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::linux::fs::MetadataExt;
@@ -292,7 +307,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "linux", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "linux"), doc = "```ignore (needs linux)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::linux::fs::MetadataExt;
@@ -309,7 +325,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "linux", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "linux"), doc = "```ignore (needs linux)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::linux::fs::MetadataExt;

--- a/library/std/src/os/linux/process.rs
+++ b/library/std/src/os/linux/process.rs
@@ -20,8 +20,10 @@ struct InnerPidFd;
 /// with [`create_pidfd`]. Subsequently, the created pidfd can be retrieved
 /// from the [`Child`] by calling [`pidfd`] or [`into_pidfd`].
 ///
-/// Example:
-/// ```no_run
+/// # Examples
+///
+#[cfg_attr(target_os = "linux", doc = "```no_run")]
+#[cfg_attr(not(target_os = "linux"), doc = "```ignore (needs linux)")]
 /// #![feature(linux_pidfd)]
 /// use std::os::linux::process::{CommandExt, ChildExt};
 /// use std::process::Command;

--- a/library/std/src/os/net/linux_ext/addr.rs
+++ b/library/std/src/os/net/linux_ext/addr.rs
@@ -20,7 +20,14 @@ pub impl(in crate::os) trait SocketAddrExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(
+        any(target_os = "linux", target_os = "android", target_os = "cygwin"),
+        doc = "```no_run"
+    )]
+    #[cfg_attr(
+        not(any(target_os = "linux", target_os = "android", target_os = "cygwin")),
+        doc = "```ignore (needs linux)"
+    )]
     /// use std::os::unix::net::{UnixListener, SocketAddr};
     /// #[cfg(target_os = "linux")]
     /// use std::os::linux::net::SocketAddrExt;
@@ -48,7 +55,14 @@ pub impl(in crate::os) trait SocketAddrExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(
+        any(target_os = "linux", target_os = "android", target_os = "cygwin"),
+        doc = "```no_run"
+    )]
+    #[cfg_attr(
+        not(any(target_os = "linux", target_os = "android", target_os = "cygwin")),
+        doc = "```ignore (needs linux)"
+    )]
     /// use std::os::unix::net::{UnixListener, SocketAddr};
     /// #[cfg(target_os = "linux")]
     /// use std::os::linux::net::SocketAddrExt;

--- a/library/std/src/os/net/linux_ext/socket.rs
+++ b/library/std/src/os/net/linux_ext/socket.rs
@@ -24,7 +24,14 @@ pub impl(self) trait UnixSocketExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(
+        any(target_os = "linux", target_os = "android", target_os = "cygwin"),
+        doc = "```no_run"
+    )]
+    #[cfg_attr(
+        not(any(target_os = "linux", target_os = "android", target_os = "cygwin")),
+        doc = "```ignore (needs linux)"
+    )]
     /// #![feature(unix_socket_ancillary_data)]
     /// #[cfg(target_os = "linux")]
     /// use std::os::linux::net::UnixSocketExt;

--- a/library/std/src/os/net/linux_ext/tcp.rs
+++ b/library/std/src/os/net/linux_ext/tcp.rs
@@ -23,7 +23,14 @@ pub impl(self) trait TcpStreamExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(
+        any(target_os = "linux", target_os = "android", target_os = "cygwin"),
+        doc = "```no_run"
+    )]
+    #[cfg_attr(
+        not(any(target_os = "linux", target_os = "android", target_os = "cygwin")),
+        doc = "```ignore (needs linux)"
+    )]
     /// use std::net::TcpStream;
     /// #[cfg(target_os = "linux")]
     /// use std::os::linux::net::TcpStreamExt;
@@ -43,7 +50,14 @@ pub impl(self) trait TcpStreamExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(
+        any(target_os = "linux", target_os = "android", target_os = "cygwin"),
+        doc = "```no_run"
+    )]
+    #[cfg_attr(
+        not(any(target_os = "linux", target_os = "android", target_os = "cygwin")),
+        doc = "```ignore (needs linux)"
+    )]
     /// use std::net::TcpStream;
     /// #[cfg(target_os = "linux")]
     /// use std::os::linux::net::TcpStreamExt;
@@ -92,7 +106,14 @@ pub impl(self) trait TcpStreamExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(
+        any(target_os = "linux", target_os = "android", target_os = "cygwin"),
+        doc = "```no_run"
+    )]
+    #[cfg_attr(
+        not(any(target_os = "linux", target_os = "android", target_os = "cygwin")),
+        doc = "```ignore (needs linux)"
+    )]
     /// #![feature(tcp_deferaccept)]
     /// use std::net::TcpStream;
     /// use std::os::linux::net::TcpStreamExt;

--- a/library/std/src/os/netbsd/net.rs
+++ b/library/std/src/os/netbsd/net.rs
@@ -27,7 +27,8 @@ pub impl(self) trait UnixSocketExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "netbsd", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "netbsd"), doc = "```ignore (needs netbsd)")]
     /// #![feature(unix_socket_ancillary_data)]
     /// use std::os::netbsd::net::UnixSocketExt;
     /// use std::os::unix::net::UnixDatagram;

--- a/library/std/src/os/redox/fs.rs
+++ b/library/std/src/os/redox/fs.rs
@@ -21,7 +21,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "redox", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "redox"), doc = "```ignore (needs redox)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::redox::fs::MetadataExt;
@@ -45,7 +46,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "redox", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "redox"), doc = "```ignore (needs redox)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::redox::fs::MetadataExt;
@@ -62,7 +64,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "redox", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "redox"), doc = "```ignore (needs redox)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::redox::fs::MetadataExt;
@@ -79,7 +82,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "redox", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "redox"), doc = "```ignore (needs redox)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::redox::fs::MetadataExt;
@@ -96,7 +100,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "redox", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "redox"), doc = "```ignore (needs redox)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::redox::fs::MetadataExt;
@@ -113,7 +118,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "redox", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "redox"), doc = "```ignore (needs redox)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::redox::fs::MetadataExt;
@@ -130,7 +136,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "redox", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "redox"), doc = "```ignore (needs redox)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::redox::fs::MetadataExt;
@@ -147,7 +154,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "redox", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "redox"), doc = "```ignore (needs redox)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::redox::fs::MetadataExt;
@@ -167,7 +175,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "redox", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "redox"), doc = "```ignore (needs redox)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::redox::fs::MetadataExt;
@@ -184,7 +193,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "redox", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "redox"), doc = "```ignore (needs redox)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::redox::fs::MetadataExt;
@@ -203,7 +213,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "redox", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "redox"), doc = "```ignore (needs redox)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::redox::fs::MetadataExt;
@@ -220,7 +231,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "redox", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "redox"), doc = "```ignore (needs redox)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::redox::fs::MetadataExt;
@@ -239,7 +251,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "redox", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "redox"), doc = "```ignore (needs redox)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::redox::fs::MetadataExt;
@@ -256,7 +269,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "redox", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "redox"), doc = "```ignore (needs redox)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::redox::fs::MetadataExt;
@@ -275,7 +289,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "redox", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "redox"), doc = "```ignore (needs redox)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::redox::fs::MetadataExt;
@@ -292,7 +307,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "redox", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "redox"), doc = "```ignore (needs redox)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::redox::fs::MetadataExt;
@@ -309,7 +325,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "redox", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "redox"), doc = "```ignore (needs redox)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::redox::fs::MetadataExt;

--- a/library/std/src/os/rtems/fs.rs
+++ b/library/std/src/os/rtems/fs.rs
@@ -12,7 +12,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "rtems", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "rtems"), doc = "```ignore (needs rtems)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::rtems::fs::MetadataExt;
@@ -30,7 +31,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "rtems", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "rtems"), doc = "```ignore (needs rtems)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::rtems::fs::MetadataExt;
@@ -48,7 +50,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "rtems", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "rtems"), doc = "```ignore (needs rtems)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::rtems::fs::MetadataExt;
@@ -66,7 +69,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "rtems", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "rtems"), doc = "```ignore (needs rtems)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::rtems::fs::MetadataExt;
@@ -84,7 +88,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "rtems", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "rtems"), doc = "```ignore (needs rtems)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::rtems::fs::MetadataExt;
@@ -102,7 +107,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "rtems", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "rtems"), doc = "```ignore (needs rtems)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::rtems::fs::MetadataExt;
@@ -120,7 +126,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "rtems", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "rtems"), doc = "```ignore (needs rtems)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::rtems::fs::MetadataExt;
@@ -141,7 +148,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "rtems", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "rtems"), doc = "```ignore (needs rtems)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::rtems::fs::MetadataExt;
@@ -159,7 +167,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "rtems", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "rtems"), doc = "```ignore (needs rtems)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::rtems::fs::MetadataExt;
@@ -179,7 +188,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "rtems", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "rtems"), doc = "```ignore (needs rtems)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::rtems::fs::MetadataExt;
@@ -197,7 +207,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "rtems", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "rtems"), doc = "```ignore (needs rtems)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::rtems::fs::MetadataExt;
@@ -217,7 +228,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "rtems", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "rtems"), doc = "```ignore (needs rtems)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::rtems::fs::MetadataExt;
@@ -235,7 +247,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "rtems", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "rtems"), doc = "```ignore (needs rtems)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::rtems::fs::MetadataExt;
@@ -255,7 +268,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "rtems", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "rtems"), doc = "```ignore (needs rtems)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::rtems::fs::MetadataExt;
@@ -273,7 +287,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "rtems", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "rtems"), doc = "```ignore (needs rtems)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::rtems::fs::MetadataExt;
@@ -291,7 +306,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_os = "rtems", doc = "```no_run")]
+    #[cfg_attr(not(target_os = "rtems"), doc = "```ignore (needs rtems)")]
     /// use std::fs;
     /// use std::io;
     /// use std::os::rtems::fs::MetadataExt;

--- a/library/std/src/os/solid/ffi.rs
+++ b/library/std/src/os/solid/ffi.rs
@@ -2,7 +2,8 @@
 //!
 //! # Examples
 //!
-//! ```
+#![cfg_attr(target_os = "solid", doc = "```")]
+#![cfg_attr(not(target_os = "solid"), doc = "```ignore (needs solid)")]
 //! use std::ffi::OsString;
 //! use std::os::solid::ffi::OsStringExt;
 //!
@@ -17,7 +18,8 @@
 //! assert_eq!(bytes, b"foo");
 //! ```
 //!
-//! ```
+#![cfg_attr(target_os = "solid", doc = "```")]
+#![cfg_attr(not(target_os = "solid"), doc = "```ignore (needs solid)")]
 //! use std::ffi::OsStr;
 //! use std::os::solid::ffi::OsStrExt;
 //!

--- a/library/std/src/os/solid/io.rs
+++ b/library/std/src/os/solid/io.rs
@@ -257,7 +257,8 @@ macro_rules! impl_owned_fd_traits {
 impl_owned_fd_traits! { TcpStream TcpListener UdpSocket }
 
 /// This impl allows implementing traits that require `AsFd` on Arc.
-/// ```
+#[cfg_attr(target_os = "solid", doc = "```")]
+#[cfg_attr(not(target_os = "solid"), doc = "```ignore (needs solid)")]
 /// # #[cfg(target_os = "solid_asp3")] mod group_cfg {
 /// # use std::os::solid::io::AsFd;
 /// use std::net::UdpSocket;

--- a/library/std/src/os/unix/ffi/mod.rs
+++ b/library/std/src/os/unix/ffi/mod.rs
@@ -2,7 +2,8 @@
 //!
 //! # Examples
 //!
-//! ```
+#![cfg_attr(target_family = "unix", doc = "```")]
+#![cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
 //! use std::ffi::OsString;
 //! use std::os::unix::ffi::OsStringExt;
 //!
@@ -17,7 +18,8 @@
 //! assert_eq!(bytes, b"foo");
 //! ```
 //!
-//! ```
+#![cfg_attr(target_family = "unix", doc = "```")]
+#![cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
 //! use std::ffi::OsStr;
 //! use std::os::unix::ffi::OsStrExt;
 //!

--- a/library/std/src/os/unix/fs.rs
+++ b/library/std/src/os/unix/fs.rs
@@ -40,7 +40,8 @@ pub trait FileExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// use std::io;
     /// use std::fs::File;
     /// use std::os::unix::prelude::FileExt;
@@ -98,7 +99,8 @@ pub trait FileExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// use std::io;
     /// use std::fs::File;
     /// use std::os::unix::prelude::FileExt;
@@ -138,7 +140,8 @@ pub trait FileExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// #![feature(core_io_borrowed_buf)]
     /// #![feature(read_buf_at)]
     ///
@@ -174,7 +177,8 @@ pub trait FileExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// #![feature(core_io_borrowed_buf)]
     /// #![feature(read_buf_at)]
     ///
@@ -245,7 +249,8 @@ pub trait FileExt {
     /// Therefore, it is important to be vigilant while changing options to mitigate
     /// unexpected behavior.
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// use std::fs::File;
     /// use std::io;
     /// use std::os::unix::prelude::FileExt;
@@ -268,7 +273,8 @@ pub trait FileExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// use std::fs::File;
     /// use std::io;
     /// use std::os::unix::prelude::FileExt;
@@ -317,7 +323,8 @@ pub trait FileExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// use std::fs::File;
     /// use std::io;
     /// use std::os::unix::prelude::FileExt;
@@ -372,7 +379,8 @@ impl FileExt for fs::File {
 ///
 /// # Examples
 ///
-/// ```no_run
+#[cfg_attr(target_family = "unix", doc = "```no_run")]
+#[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
 /// use std::fs::{File, Permissions};
 /// use std::io::{ErrorKind, Result as IoResult};
 /// use std::os::unix::fs::PermissionsExt;
@@ -427,7 +435,8 @@ impl FileExt for fs::File {
 /// }
 /// ```
 ///
-/// ```no_run
+#[cfg_attr(target_family = "unix", doc = "```no_run")]
+#[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
 /// use std::fs::Permissions;
 /// use std::os::unix::fs::PermissionsExt;
 ///
@@ -485,7 +494,8 @@ pub trait OpenOptionsExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// use std::fs::OpenOptions;
     /// use std::os::unix::fs::OpenOptionsExt;
     ///
@@ -508,7 +518,8 @@ pub trait OpenOptionsExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// # mod libc { pub const O_NOFOLLOW: i32 = 0; }
     /// use std::fs::OpenOptions;
     /// use std::os::unix::fs::OpenOptionsExt;
@@ -544,7 +555,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// use std::io;
     /// use std::fs;
     /// use std::os::unix::fs::MetadataExt;
@@ -561,7 +573,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// use std::fs;
     /// use std::os::unix::fs::MetadataExt;
     /// use std::io;
@@ -578,7 +591,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// use std::fs;
     /// use std::os::unix::fs::MetadataExt;
     /// use std::io;
@@ -599,7 +613,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// use std::fs;
     /// use std::os::unix::fs::MetadataExt;
     /// use std::io;
@@ -616,7 +631,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// use std::fs;
     /// use std::os::unix::fs::MetadataExt;
     /// use std::io;
@@ -633,7 +649,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// use std::fs;
     /// use std::os::unix::fs::MetadataExt;
     /// use std::io;
@@ -650,7 +667,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// use std::fs;
     /// use std::os::unix::fs::MetadataExt;
     /// use std::io;
@@ -667,7 +685,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// use std::fs;
     /// use std::os::unix::fs::MetadataExt;
     /// use std::io;
@@ -684,7 +703,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// use std::fs;
     /// use std::os::unix::fs::MetadataExt;
     /// use std::io;
@@ -703,7 +723,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// use std::fs;
     /// use std::os::unix::fs::MetadataExt;
     /// use std::io;
@@ -720,7 +741,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// use std::fs;
     /// use std::os::unix::fs::MetadataExt;
     /// use std::io;
@@ -739,7 +761,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// use std::fs;
     /// use std::os::unix::fs::MetadataExt;
     /// use std::io;
@@ -756,7 +779,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// use std::fs;
     /// use std::os::unix::fs::MetadataExt;
     /// use std::io;
@@ -775,7 +799,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// use std::fs;
     /// use std::os::unix::fs::MetadataExt;
     /// use std::io;
@@ -792,7 +817,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// use std::fs;
     /// use std::os::unix::fs::MetadataExt;
     /// use std::io;
@@ -811,7 +837,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// use std::fs;
     /// use std::os::unix::fs::MetadataExt;
     /// use std::io;
@@ -895,7 +922,8 @@ pub trait FileTypeExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// use std::fs;
     /// use std::os::unix::fs::FileTypeExt;
     /// use std::io;
@@ -913,7 +941,8 @@ pub trait FileTypeExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// use std::fs;
     /// use std::os::unix::fs::FileTypeExt;
     /// use std::io;
@@ -931,7 +960,8 @@ pub trait FileTypeExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// use std::fs;
     /// use std::os::unix::fs::FileTypeExt;
     /// use std::io;
@@ -949,7 +979,8 @@ pub trait FileTypeExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// use std::fs;
     /// use std::os::unix::fs::FileTypeExt;
     /// use std::io;
@@ -989,7 +1020,8 @@ pub trait DirEntryExt {
     ///
     /// # Examples
     ///
-    /// ```
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// use std::fs;
     /// use std::os::unix::fs::DirEntryExt;
     ///
@@ -1020,7 +1052,8 @@ pub impl(self) trait DirEntryExt2 {
     ///
     /// # Examples
     ///
-    /// ```
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// #![feature(dir_entry_ext2)]
     /// use std::os::unix::fs::DirEntryExt2;
     /// use std::{fs, io};
@@ -1052,7 +1085,8 @@ impl DirEntryExt2 for fs::DirEntry {
 ///
 /// # Examples
 ///
-/// ```no_run
+#[cfg_attr(target_family = "unix", doc = "```no_run")]
+#[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
 /// use std::os::unix::fs;
 ///
 /// fn main() -> std::io::Result<()> {
@@ -1073,7 +1107,8 @@ pub trait DirBuilderExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// use std::fs::DirBuilder;
     /// use std::os::unix::fs::DirBuilderExt;
     ///
@@ -1110,7 +1145,8 @@ impl DirBuilderExt for fs::DirBuilder {
 ///
 /// # Examples
 ///
-/// ```no_run
+#[cfg_attr(target_family = "unix", doc = "```no_run")]
+#[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
 /// use std::os::unix::fs;
 ///
 /// fn main() -> std::io::Result<()> {
@@ -1129,7 +1165,8 @@ pub fn chown<P: AsRef<Path>>(dir: P, uid: Option<u32>, gid: Option<u32>) -> io::
 ///
 /// # Examples
 ///
-/// ```no_run
+#[cfg_attr(target_family = "unix", doc = "```no_run")]
+#[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
 /// use std::os::unix::fs;
 ///
 /// fn main() -> std::io::Result<()> {
@@ -1150,7 +1187,8 @@ pub fn fchown<F: AsFd>(fd: F, uid: Option<u32>, gid: Option<u32>) -> io::Result<
 ///
 /// # Examples
 ///
-/// ```no_run
+#[cfg_attr(target_family = "unix", doc = "```no_run")]
+#[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
 /// use std::os::unix::fs;
 ///
 /// fn main() -> std::io::Result<()> {
@@ -1172,7 +1210,8 @@ pub fn lchown<P: AsRef<Path>>(dir: P, uid: Option<u32>, gid: Option<u32>) -> io:
 ///
 /// # Examples
 ///
-/// ```no_run
+#[cfg_attr(target_family = "unix", doc = "```no_run")]
+#[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
 /// use std::os::unix::fs;
 ///
 /// fn main() -> std::io::Result<()> {
@@ -1192,7 +1231,8 @@ pub fn chroot<P: AsRef<Path>>(dir: P) -> io::Result<()> {
 ///
 /// # Examples
 ///
-/// ```no_run
+#[cfg_attr(target_family = "unix", doc = "```no_run")]
+#[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
 /// # #![feature(unix_mkfifo)]
 /// # #[cfg(not(unix))]
 /// # fn main() {}

--- a/library/std/src/os/unix/io/mod.rs
+++ b/library/std/src/os/unix/io/mod.rs
@@ -119,7 +119,8 @@ pub impl(self) trait StdioExt {
     ///
     /// [currently]: crate::io#platform-specific-behavior
     ///
-    /// ```
+    #[cfg_attr(target_family = "unix", doc = "```")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// #![feature(stdio_swap)]
     /// use std::io::{self, Read, Write};
     /// use std::os::unix::io::StdioExt;

--- a/library/std/src/os/unix/mod.rs
+++ b/library/std/src/os/unix/mod.rs
@@ -11,7 +11,8 @@
 //!
 //! # Examples
 //!
-//! ```no_run
+#![cfg_attr(target_family = "unix", doc = "```no_run")]
+#![cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
 //! use std::fs::File;
 //! use std::os::unix::prelude::*;
 //!

--- a/library/std/src/os/unix/net/addr.rs
+++ b/library/std/src/os/unix/net/addr.rs
@@ -76,7 +76,8 @@ enum AddressKind<'a> {
 ///
 /// # Examples
 ///
-/// ```
+#[cfg_attr(target_family = "unix", doc = "```")]
+#[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
 /// use std::os::unix::net::UnixListener;
 ///
 /// let socket = match UnixListener::bind("/tmp/sock") {
@@ -145,7 +146,8 @@ impl SocketAddr {
     ///
     /// # Examples
     ///
-    /// ```
+    #[cfg_attr(target_family = "unix", doc = "```")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// use std::os::unix::net::SocketAddr;
     /// use std::path::Path;
     ///
@@ -158,7 +160,8 @@ impl SocketAddr {
     ///
     /// Creating a `SocketAddr` with a NULL byte results in an error.
     ///
-    /// ```
+    #[cfg_attr(target_family = "unix", doc = "```")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// use std::os::unix::net::SocketAddr;
     ///
     /// assert!(SocketAddr::from_pathname("/path/with/\0/bytes").is_err());
@@ -177,7 +180,8 @@ impl SocketAddr {
     ///
     /// A named address:
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// use std::os::unix::net::UnixListener;
     ///
     /// fn main() -> std::io::Result<()> {
@@ -190,7 +194,8 @@ impl SocketAddr {
     ///
     /// An unnamed address:
     ///
-    /// ```
+    #[cfg_attr(target_family = "unix", doc = "```")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// use std::os::unix::net::UnixDatagram;
     ///
     /// fn main() -> std::io::Result<()> {
@@ -212,7 +217,8 @@ impl SocketAddr {
     ///
     /// With a pathname:
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// use std::os::unix::net::UnixListener;
     /// use std::path::Path;
     ///
@@ -226,7 +232,8 @@ impl SocketAddr {
     ///
     /// Without a pathname:
     ///
-    /// ```
+    #[cfg_attr(target_family = "unix", doc = "```")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// use std::os::unix::net::UnixDatagram;
     ///
     /// fn main() -> std::io::Result<()> {

--- a/library/std/src/os/unix/net/ancillary.rs
+++ b/library/std/src/os/unix/net/ancillary.rs
@@ -577,8 +577,14 @@ impl<'a> Iterator for Messages<'a> {
 ///
 /// # Example
 ///
-#[cfg_attr(target_family = "unix", doc = "```no_run")]
-#[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
+#[cfg_attr(
+    any(target_os = "android", target_os = "linux", target_os = "cygwin"),
+    doc = "```no_run"
+)]
+#[cfg_attr(
+    not(any(target_os = "android", target_os = "linux", target_os = "cygwin")),
+    doc = "```ignore (needs unix)"
+)]
 /// #![feature(unix_socket_ancillary_data)]
 /// use std::os::unix::net::{UnixStream, SocketAncillary, AncillaryData};
 /// use std::io::IoSliceMut;
@@ -617,8 +623,14 @@ impl<'a> SocketAncillary<'a> {
     ///
     /// # Example
     ///
-    #[cfg_attr(target_family = "unix", doc = "```no_run")]
-    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
+    #[cfg_attr(
+        any(target_os = "android", target_os = "linux", target_os = "cygwin"),
+        doc = "```no_run"
+    )]
+    #[cfg_attr(
+        not(any(target_os = "android", target_os = "linux", target_os = "cygwin")),
+        doc = "```ignore (needs unix)"
+    )]
     /// # #![allow(unused_mut)]
     /// #![feature(unix_socket_ancillary_data)]
     /// use std::os::unix::net::SocketAncillary;
@@ -661,8 +673,14 @@ impl<'a> SocketAncillary<'a> {
     ///
     /// # Example
     ///
-    #[cfg_attr(target_family = "unix", doc = "```no_run")]
-    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
+    #[cfg_attr(
+        any(target_os = "android", target_os = "linux", target_os = "cygwin"),
+        doc = "```no_run"
+    )]
+    #[cfg_attr(
+        not(any(target_os = "android", target_os = "linux", target_os = "cygwin")),
+        doc = "```ignore (needs unix)"
+    )]
     /// #![feature(unix_socket_ancillary_data)]
     /// use std::os::unix::net::{UnixStream, SocketAncillary};
     /// use std::io::IoSliceMut;
@@ -696,8 +714,14 @@ impl<'a> SocketAncillary<'a> {
     ///
     /// # Example
     ///
-    #[cfg_attr(target_family = "unix", doc = "```no_run")]
-    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
+    #[cfg_attr(
+        any(target_os = "android", target_os = "linux", target_os = "cygwin"),
+        doc = "```no_run"
+    )]
+    #[cfg_attr(
+        not(any(target_os = "android", target_os = "linux", target_os = "cygwin")),
+        doc = "```ignore (needs unix)"
+    )]
     /// #![feature(unix_socket_ancillary_data)]
     /// use std::os::unix::net::{UnixStream, SocketAncillary};
     /// use std::os::unix::io::AsRawFd;
@@ -764,8 +788,14 @@ impl<'a> SocketAncillary<'a> {
     ///
     /// # Example
     ///
-    #[cfg_attr(target_family = "unix", doc = "```no_run")]
-    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
+    #[cfg_attr(
+        any(target_os = "android", target_os = "linux", target_os = "cygwin"),
+        doc = "```no_run"
+    )]
+    #[cfg_attr(
+        not(any(target_os = "android", target_os = "linux", target_os = "cygwin")),
+        doc = "```ignore (needs unix)"
+    )]
     /// #![feature(unix_socket_ancillary_data)]
     /// use std::os::unix::net::{UnixStream, SocketAncillary, AncillaryData};
     /// use std::io::IoSliceMut;

--- a/library/std/src/os/unix/net/ancillary.rs
+++ b/library/std/src/os/unix/net/ancillary.rs
@@ -576,7 +576,9 @@ impl<'a> Iterator for Messages<'a> {
 /// A Unix socket Ancillary data struct.
 ///
 /// # Example
-/// ```no_run
+///
+#[cfg_attr(target_family = "unix", doc = "```no_run")]
+#[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
 /// #![feature(unix_socket_ancillary_data)]
 /// use std::os::unix::net::{UnixStream, SocketAncillary, AncillaryData};
 /// use std::io::IoSliceMut;
@@ -615,7 +617,8 @@ impl<'a> SocketAncillary<'a> {
     ///
     /// # Example
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// # #![allow(unused_mut)]
     /// #![feature(unix_socket_ancillary_data)]
     /// use std::os::unix::net::SocketAncillary;
@@ -658,7 +661,8 @@ impl<'a> SocketAncillary<'a> {
     ///
     /// # Example
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// #![feature(unix_socket_ancillary_data)]
     /// use std::os::unix::net::{UnixStream, SocketAncillary};
     /// use std::io::IoSliceMut;
@@ -692,7 +696,8 @@ impl<'a> SocketAncillary<'a> {
     ///
     /// # Example
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// #![feature(unix_socket_ancillary_data)]
     /// use std::os::unix::net::{UnixStream, SocketAncillary};
     /// use std::os::unix::io::AsRawFd;
@@ -759,7 +764,8 @@ impl<'a> SocketAncillary<'a> {
     ///
     /// # Example
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// #![feature(unix_socket_ancillary_data)]
     /// use std::os::unix::net::{UnixStream, SocketAncillary, AncillaryData};
     /// use std::io::IoSliceMut;

--- a/library/std/src/os/unix/net/datagram.rs
+++ b/library/std/src/os/unix/net/datagram.rs
@@ -46,7 +46,8 @@ const MSG_NOSIGNAL: core::ffi::c_int = 0x0;
 ///
 /// # Examples
 ///
-/// ```no_run
+#[cfg_attr(target_family = "unix", doc = "```no_run")]
+#[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
 /// use std::os::unix::net::UnixDatagram;
 ///
 /// fn main() -> std::io::Result<()> {
@@ -81,7 +82,8 @@ impl UnixDatagram {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// use std::os::unix::net::UnixDatagram;
     ///
     /// let sock = match UnixDatagram::bind("/path/to/the/socket") {
@@ -108,7 +110,8 @@ impl UnixDatagram {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// use std::os::unix::net::{UnixDatagram};
     ///
     /// fn main() -> std::io::Result<()> {
@@ -142,7 +145,8 @@ impl UnixDatagram {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// use std::os::unix::net::UnixDatagram;
     ///
     /// let sock = match UnixDatagram::unbound() {
@@ -165,7 +169,8 @@ impl UnixDatagram {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// use std::os::unix::net::UnixDatagram;
     ///
     /// let (sock1, sock2) = match UnixDatagram::pair() {
@@ -193,7 +198,8 @@ impl UnixDatagram {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// use std::os::unix::net::UnixDatagram;
     ///
     /// fn main() -> std::io::Result<()> {
@@ -222,7 +228,8 @@ impl UnixDatagram {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// use std::os::unix::net::{UnixDatagram};
     ///
     /// fn main() -> std::io::Result<()> {
@@ -260,7 +267,8 @@ impl UnixDatagram {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// use std::os::unix::net::UnixDatagram;
     ///
     /// fn main() -> std::io::Result<()> {
@@ -278,7 +286,8 @@ impl UnixDatagram {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// use std::os::unix::net::UnixDatagram;
     ///
     /// fn main() -> std::io::Result<()> {
@@ -300,7 +309,8 @@ impl UnixDatagram {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// use std::os::unix::net::UnixDatagram;
     ///
     /// fn main() -> std::io::Result<()> {
@@ -350,7 +360,8 @@ impl UnixDatagram {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// use std::os::unix::net::UnixDatagram;
     ///
     /// fn main() -> std::io::Result<()> {
@@ -372,7 +383,8 @@ impl UnixDatagram {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// use std::os::unix::net::UnixDatagram;
     ///
     /// fn main() -> std::io::Result<()> {
@@ -505,7 +517,8 @@ impl UnixDatagram {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// use std::os::unix::net::UnixDatagram;
     ///
     /// fn main() -> std::io::Result<()> {
@@ -539,7 +552,8 @@ impl UnixDatagram {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// use std::os::unix::net::{UnixDatagram};
     ///
     /// fn main() -> std::io::Result<()> {
@@ -575,7 +589,8 @@ impl UnixDatagram {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// use std::os::unix::net::UnixDatagram;
     ///
     /// fn main() -> std::io::Result<()> {
@@ -696,7 +711,8 @@ impl UnixDatagram {
     ///
     /// # Examples
     ///
-    /// ```
+    #[cfg_attr(target_family = "unix", doc = "```")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// use std::os::unix::net::UnixDatagram;
     /// use std::time::Duration;
     ///
@@ -711,7 +727,8 @@ impl UnixDatagram {
     /// An [`Err`] is returned if the zero [`Duration`] is passed to this
     /// method:
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// use std::io;
     /// use std::os::unix::net::UnixDatagram;
     /// use std::time::Duration;
@@ -740,7 +757,8 @@ impl UnixDatagram {
     ///
     /// # Examples
     ///
-    /// ```
+    #[cfg_attr(target_family = "unix", doc = "```")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// use std::os::unix::net::UnixDatagram;
     /// use std::time::Duration;
     ///
@@ -755,7 +773,8 @@ impl UnixDatagram {
     /// An [`Err`] is returned if the zero [`Duration`] is passed to this
     /// method:
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// use std::io;
     /// use std::os::unix::net::UnixDatagram;
     /// use std::time::Duration;
@@ -777,7 +796,8 @@ impl UnixDatagram {
     ///
     /// # Examples
     ///
-    /// ```
+    #[cfg_attr(target_family = "unix", doc = "```")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// use std::os::unix::net::UnixDatagram;
     /// use std::time::Duration;
     ///
@@ -798,7 +818,8 @@ impl UnixDatagram {
     ///
     /// # Examples
     ///
-    /// ```
+    #[cfg_attr(target_family = "unix", doc = "```")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// use std::os::unix::net::UnixDatagram;
     /// use std::time::Duration;
     ///
@@ -819,7 +840,8 @@ impl UnixDatagram {
     ///
     /// # Examples
     ///
-    /// ```
+    #[cfg_attr(target_family = "unix", doc = "```")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// use std::os::unix::net::UnixDatagram;
     ///
     /// fn main() -> std::io::Result<()> {
@@ -862,7 +884,8 @@ impl UnixDatagram {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// use std::os::unix::net::UnixDatagram;
     ///
     /// fn main() -> std::io::Result<()> {
@@ -884,7 +907,8 @@ impl UnixDatagram {
     /// specified portions to immediately return with an appropriate value
     /// (see the documentation of [`Shutdown`]).
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// use std::os::unix::net::UnixDatagram;
     /// use std::net::Shutdown;
     ///
@@ -908,7 +932,8 @@ impl UnixDatagram {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// #![feature(unix_socket_peek)]
     ///
     /// use std::os::unix::net::UnixDatagram;
@@ -940,7 +965,8 @@ impl UnixDatagram {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// #![feature(unix_socket_peek)]
     ///
     /// use std::os::unix::net::UnixDatagram;

--- a/library/std/src/os/unix/net/listener.rs
+++ b/library/std/src/os/unix/net/listener.rs
@@ -9,7 +9,8 @@ use crate::{fmt, io, mem};
 ///
 /// # Examples
 ///
-/// ```no_run
+#[cfg_attr(target_family = "unix", doc = "```no_run")]
+#[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
 /// use std::thread;
 /// use std::os::unix::net::{UnixStream, UnixListener};
 ///
@@ -56,7 +57,8 @@ impl UnixListener {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// use std::os::unix::net::UnixListener;
     ///
     /// let listener = match UnixListener::bind("/path/to/the/socket") {
@@ -115,7 +117,8 @@ impl UnixListener {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// use std::os::unix::net::{UnixListener};
     ///
     /// fn main() -> std::io::Result<()> {
@@ -160,7 +163,8 @@ impl UnixListener {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// use std::os::unix::net::UnixListener;
     ///
     /// fn main() -> std::io::Result<()> {
@@ -190,7 +194,8 @@ impl UnixListener {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// use std::os::unix::net::UnixListener;
     ///
     /// fn main() -> std::io::Result<()> {
@@ -208,7 +213,8 @@ impl UnixListener {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// use std::os::unix::net::UnixListener;
     ///
     /// fn main() -> std::io::Result<()> {
@@ -232,7 +238,8 @@ impl UnixListener {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// use std::os::unix::net::UnixListener;
     ///
     /// fn main() -> std::io::Result<()> {
@@ -250,7 +257,8 @@ impl UnixListener {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// use std::os::unix::net::UnixListener;
     ///
     /// fn main() -> std::io::Result<()> {
@@ -277,7 +285,8 @@ impl UnixListener {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// use std::thread;
     /// use std::os::unix::net::{UnixStream, UnixListener};
     ///
@@ -372,7 +381,8 @@ impl<'a> IntoIterator for &'a UnixListener {
 ///
 /// # Examples
 ///
-/// ```no_run
+#[cfg_attr(target_family = "unix", doc = "```no_run")]
+#[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
 /// use std::thread;
 /// use std::os::unix::net::{UnixStream, UnixListener};
 ///

--- a/library/std/src/os/unix/net/stream.rs
+++ b/library/std/src/os/unix/net/stream.rs
@@ -44,7 +44,8 @@ use crate::time::Duration;
 ///
 /// # Examples
 ///
-/// ```no_run
+#[cfg_attr(target_family = "unix", doc = "```no_run")]
+#[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
 /// use std::os::unix::net::UnixStream;
 /// use std::io::prelude::*;
 ///
@@ -93,7 +94,8 @@ impl UnixStream {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// use std::os::unix::net::UnixStream;
     ///
     /// let socket = match UnixStream::connect("/tmp/sock") {
@@ -121,7 +123,8 @@ impl UnixStream {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// use std::os::unix::net::{UnixListener, UnixStream};
     ///
     /// fn main() -> std::io::Result<()> {
@@ -137,7 +140,7 @@ impl UnixStream {
     ///     };
     ///     Ok(())
     /// }
-    /// ````
+    /// ```
     #[stable(feature = "unix_socket_abstract", since = "1.70.0")]
     pub fn connect_addr(socket_addr: &SocketAddr) -> io::Result<UnixStream> {
         unsafe {
@@ -157,7 +160,8 @@ impl UnixStream {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// use std::os::unix::net::UnixStream;
     ///
     /// let (sock1, sock2) = match UnixStream::pair() {
@@ -183,7 +187,8 @@ impl UnixStream {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// use std::os::unix::net::UnixStream;
     ///
     /// fn main() -> std::io::Result<()> {
@@ -201,7 +206,8 @@ impl UnixStream {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// use std::os::unix::net::UnixStream;
     ///
     /// fn main() -> std::io::Result<()> {
@@ -219,7 +225,8 @@ impl UnixStream {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// use std::os::unix::net::UnixStream;
     ///
     /// fn main() -> std::io::Result<()> {
@@ -237,7 +244,8 @@ impl UnixStream {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// #![feature(peer_credentials_unix_socket)]
     /// use std::os::unix::net::UnixStream;
     ///
@@ -274,7 +282,8 @@ impl UnixStream {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// use std::os::unix::net::UnixStream;
     /// use std::time::Duration;
     ///
@@ -288,7 +297,8 @@ impl UnixStream {
     /// An [`Err`] is returned if the zero [`Duration`] is passed to this
     /// method:
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// use std::io;
     /// use std::os::unix::net::UnixStream;
     /// use std::time::Duration;
@@ -316,7 +326,8 @@ impl UnixStream {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// use std::os::unix::net::UnixStream;
     /// use std::time::Duration;
     ///
@@ -331,7 +342,8 @@ impl UnixStream {
     /// An [`Err`] is returned if the zero [`Duration`] is passed to this
     /// method:
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// use std::io;
     /// use std::os::unix::net::UnixStream;
     /// use std::time::Duration;
@@ -353,7 +365,8 @@ impl UnixStream {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// use std::os::unix::net::UnixStream;
     /// use std::time::Duration;
     ///
@@ -373,7 +386,8 @@ impl UnixStream {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// use std::os::unix::net::UnixStream;
     /// use std::time::Duration;
     ///
@@ -394,7 +408,8 @@ impl UnixStream {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// use std::os::unix::net::UnixStream;
     ///
     /// fn main() -> std::io::Result<()> {
@@ -437,7 +452,8 @@ impl UnixStream {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// use std::os::unix::net::UnixStream;
     ///
     /// fn main() -> std::io::Result<()> {
@@ -464,7 +480,8 @@ impl UnixStream {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// use std::os::unix::net::UnixStream;
     /// use std::net::Shutdown;
     ///
@@ -488,7 +505,8 @@ impl UnixStream {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// #![feature(unix_socket_peek)]
     ///
     /// use std::os::unix::net::UnixStream;

--- a/library/std/src/os/unix/process.rs
+++ b/library/std/src/os/unix/process.rs
@@ -188,7 +188,8 @@ pub impl(self) trait CommandExt {
     ///
     /// A process group ID of 0 will use the process ID as the PGID.
     ///
-    /// ```no_run
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// use std::process::Command;
     /// use std::os::unix::process::CommandExt;
     ///
@@ -303,7 +304,8 @@ pub impl(self) trait ExitStatusExt {
     /// status. The following example relies on that convention and is therefore not guaranteed to
     /// hold on every target:
     ///
-    /// ```
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// # if cfg!(target_os = "fuchsia") { return; }
     /// use std::os::unix::process::ExitStatusExt;
     /// use std::process::ExitStatus;
@@ -324,7 +326,8 @@ pub impl(self) trait ExitStatusExt {
     /// 8-bit exit code in bits 8..16, so a status built with `(code & 0xff) << 8` will usually
     /// round-trip back to the original exit code:
     ///
-    /// ```
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// # if cfg!(target_os = "fuchsia") { return; }
     /// use std::os::unix::process::ExitStatusExt;
     /// use std::process::ExitStatus;
@@ -350,7 +353,8 @@ pub impl(self) trait ExitStatusExt {
     /// In other words, if [`WIFSIGNALED`][`wait`], this returns [`WTERMSIG`][`wait`]. For such a status,
     /// [`ExitStatus::code`] returns `None`:
     ///
-    /// ```
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// # if cfg!(target_os = "fuchsia") { return; }
     /// use std::os::unix::process::ExitStatusExt;
     /// use std::process::ExitStatus;
@@ -475,7 +479,8 @@ pub impl(self) trait ChildExt {
     ///
     /// # Examples
     ///
-    /// ```rust
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// #![feature(unix_send_signal)]
     ///
     /// use std::{io, os::unix::process::ChildExt, process::{Command, Stdio}};
@@ -503,7 +508,8 @@ pub impl(self) trait ChildExt {
     ///
     /// # Examples
     ///
-    /// ```rust
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// #![feature(unix_send_signal)]
     ///
     /// use std::{io, os::unix::process::{ChildExt, CommandExt}, process::{Command, Stdio}};
@@ -535,7 +541,8 @@ pub impl(self) trait ChildExt {
     ///
     /// # Examples
     ///
-    /// ```rust
+    #[cfg_attr(target_family = "unix", doc = "```no_run")]
+    #[cfg_attr(not(target_family = "unix"), doc = "```ignore (needs unix)")]
     /// #![feature(unix_kill_process_group)]
     ///
     /// use std::{os::unix::process::{ChildExt, CommandExt}, process::{Command, Stdio}};

--- a/library/std/src/os/wasi/mod.rs
+++ b/library/std/src/os/wasi/mod.rs
@@ -11,7 +11,8 @@
 //!
 //! # Examples
 //!
-//! ```no_run
+#![cfg_attr(target_os = "wasi", doc = "```no_run")]
+#![cfg_attr(not(target_os = "wasi"), doc = "```ignore (needs wasi)")]
 //! use std::fs::File;
 //! use std::os::wasi::prelude::*;
 //!

--- a/library/std/src/os/windows/ffi.rs
+++ b/library/std/src/os/windows/ffi.rs
@@ -72,7 +72,8 @@ pub impl(self) trait OsStringExt {
     ///
     /// # Examples
     ///
-    /// ```
+    #[cfg_attr(windows, doc = "```no_run")]
+    #[cfg_attr(not(windows), doc = "```ignore (needs windows)")]
     /// use std::ffi::OsString;
     /// use std::os::windows::prelude::*;
     ///
@@ -104,7 +105,8 @@ pub impl(self) trait OsStrExt {
     ///
     /// # Examples
     ///
-    /// ```
+    #[cfg_attr(windows, doc = "```no_run")]
+    #[cfg_attr(not(windows), doc = "```ignore (needs windows)")]
     /// use std::ffi::OsString;
     /// use std::os::windows::prelude::*;
     ///

--- a/library/std/src/os/windows/fs.rs
+++ b/library/std/src/os/windows/fs.rs
@@ -31,7 +31,8 @@ pub trait FileExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(windows, doc = "```no_run")]
+    #[cfg_attr(not(windows), doc = "```ignore (needs windows)")]
     /// use std::io;
     /// use std::fs::File;
     /// use std::os::windows::prelude::*;
@@ -59,7 +60,8 @@ pub trait FileExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(windows, doc = "```no_run")]
+    #[cfg_attr(not(windows), doc = "```ignore (needs windows)")]
     /// #![feature(core_io_borrowed_buf)]
     /// #![feature(read_buf_at)]
     ///
@@ -104,7 +106,8 @@ pub trait FileExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(windows, doc = "```no_run")]
+    #[cfg_attr(not(windows), doc = "```ignore (needs windows)")]
     /// use std::fs::File;
     /// use std::os::windows::prelude::*;
     ///
@@ -151,7 +154,8 @@ pub trait OpenOptionsExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(windows, doc = "```no_run")]
+    #[cfg_attr(not(windows), doc = "```ignore (needs windows)")]
     /// use std::fs::OpenOptions;
     /// use std::os::windows::prelude::*;
     ///
@@ -176,7 +180,8 @@ pub trait OpenOptionsExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(windows, doc = "```no_run")]
+    #[cfg_attr(not(windows), doc = "```ignore (needs windows)")]
     /// use std::fs::OpenOptions;
     /// use std::os::windows::prelude::*;
     ///
@@ -202,7 +207,8 @@ pub trait OpenOptionsExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(windows, doc = "```no_run")]
+    #[cfg_attr(not(windows), doc = "```ignore (needs windows)")]
     /// # #![allow(unexpected_cfgs)]
     /// # #[cfg(for_demonstration_only)]
     /// extern crate winapi;
@@ -240,7 +246,8 @@ pub trait OpenOptionsExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(windows, doc = "```no_run")]
+    #[cfg_attr(not(windows), doc = "```ignore (needs windows)")]
     /// # #![allow(unexpected_cfgs)]
     /// # #[cfg(for_demonstration_only)]
     /// extern crate winapi;
@@ -282,7 +289,8 @@ pub trait OpenOptionsExt {
 
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(windows, doc = "```no_run")]
+    #[cfg_attr(not(windows), doc = "```ignore (needs windows)")]
     /// # #![allow(unexpected_cfgs)]
     /// # #[cfg(for_demonstration_only)]
     /// extern crate winapi;
@@ -377,7 +385,8 @@ impl OpenOptionsExt2 for OpenOptions {
 ///
 /// # Example
 ///
-/// ```no_run
+#[cfg_attr(windows, doc = "```no_run")]
+#[cfg_attr(not(windows), doc = "```ignore (needs windows)")]
 /// #![feature(windows_permissions_ext)]
 /// use std::fs::Permissions;
 /// use std::os::windows::fs::PermissionsExt;
@@ -440,7 +449,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(windows, doc = "```no_run")]
+    #[cfg_attr(not(windows), doc = "```ignore (needs windows)")]
     /// use std::io;
     /// use std::fs;
     /// use std::os::windows::prelude::*;
@@ -470,7 +480,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(windows, doc = "```no_run")]
+    #[cfg_attr(not(windows), doc = "```ignore (needs windows)")]
     /// use std::io;
     /// use std::fs;
     /// use std::os::windows::prelude::*;
@@ -505,7 +516,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(windows, doc = "```no_run")]
+    #[cfg_attr(not(windows), doc = "```ignore (needs windows)")]
     /// use std::io;
     /// use std::fs;
     /// use std::os::windows::prelude::*;
@@ -538,7 +550,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(windows, doc = "```no_run")]
+    #[cfg_attr(not(windows), doc = "```ignore (needs windows)")]
     /// use std::io;
     /// use std::fs;
     /// use std::os::windows::prelude::*;
@@ -561,7 +574,8 @@ pub trait MetadataExt {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(windows, doc = "```no_run")]
+    #[cfg_attr(not(windows), doc = "```ignore (needs windows)")]
     /// use std::io;
     /// use std::fs;
     /// use std::os::windows::prelude::*;
@@ -700,7 +714,8 @@ impl FileTimesExt for fs::FileTimes {
 ///
 /// # Examples
 ///
-/// ```no_run
+#[cfg_attr(windows, doc = "```no_run")]
+#[cfg_attr(not(windows), doc = "```ignore (needs windows)")]
 /// use std::os::windows::fs;
 ///
 /// fn main() -> std::io::Result<()> {
@@ -739,7 +754,8 @@ pub fn symlink_file<P: AsRef<Path>, Q: AsRef<Path>>(original: P, link: Q) -> io:
 ///
 /// # Examples
 ///
-/// ```no_run
+#[cfg_attr(windows, doc = "```no_run")]
+#[cfg_attr(not(windows), doc = "```ignore (needs windows)")]
 /// use std::os::windows::fs;
 ///
 /// fn main() -> std::io::Result<()> {

--- a/library/std/src/os/windows/io/handle.rs
+++ b/library/std/src/os/windows/io/handle.rs
@@ -424,7 +424,8 @@ pub trait AsHandle {
     ///
     /// # Example
     ///
-    /// ```rust,no_run
+    #[cfg_attr(windows, doc = "```no_run")]
+    #[cfg_attr(not(windows), doc = "```ignore (needs windows)")]
     /// use std::fs::File;
     /// # use std::io;
     /// use std::os::windows::io::{AsHandle, BorrowedHandle};

--- a/library/std/src/os/windows/io/mod.rs
+++ b/library/std/src/os/windows/io/mod.rs
@@ -83,7 +83,8 @@ pub impl(self) trait StdioExt {
     /// (e.g. C stdio) or libraries that acquire a clone of the file handle
     /// will not be aware of this change.
     ///
-    /// ```
+    #[cfg_attr(windows, doc = "```no_run")]
+    #[cfg_attr(not(windows), doc = "```ignore (needs windows)")]
     /// #![feature(stdio_swap)]
     /// use std::io::{self, Read, Write};
     /// use std::os::windows::io::StdioExt;

--- a/library/std/src/os/windows/mod.rs
+++ b/library/std/src/os/windows/mod.rs
@@ -8,7 +8,8 @@
 //!
 //! # Examples
 //!
-//! ```no_run
+#![cfg_attr(windows, doc = "```no_run")]
+#![cfg_attr(not(windows), doc = "```ignore (needs windows)")]
 //! use std::fs::File;
 //! use std::os::windows::prelude::*;
 //!

--- a/library/std/src/os/windows/net/addr.rs
+++ b/library/std/src/os/windows/net/addr.rs
@@ -79,7 +79,8 @@ impl SocketAddr {
     ///
     /// With a pathname:
     ///
-    /// ```no_run
+    #[cfg_attr(windows, doc = "```no_run")]
+    #[cfg_attr(not(windows), doc = "```ignore (needs windows)")]
     /// #![feature(windows_unix_domain_sockets)]
     /// use std::os::windows::net::UnixListener;
     /// use std::path::Path;
@@ -104,7 +105,8 @@ impl SocketAddr {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(windows, doc = "```no_run")]
+    #[cfg_attr(not(windows), doc = "```ignore (needs windows)")]
     /// #![feature(windows_unix_domain_sockets)]
     /// use std::os::windows::net::SocketAddr;
     /// use std::path::Path;
@@ -118,7 +120,8 @@ impl SocketAddr {
     ///
     /// Creating a `SocketAddr` with a NULL byte results in an error.
     ///
-    /// ```no_run
+    #[cfg_attr(windows, doc = "```no_run")]
+    #[cfg_attr(not(windows), doc = "```ignore (needs windows)")]
     /// #![feature(windows_unix_domain_sockets)]
     /// use std::os::windows::net::SocketAddr;
     ///
@@ -151,7 +154,8 @@ impl SocketAddr {
     ///
     /// A named address:
     ///
-    /// ```no_run
+    #[cfg_attr(windows, doc = "```no_run")]
+    #[cfg_attr(not(windows), doc = "```ignore (needs windows)")]
     /// #![feature(windows_unix_domain_sockets)]
     /// use std::os::windows::net::UnixListener;
     ///

--- a/library/std/src/os/windows/net/listener.rs
+++ b/library/std/src/os/windows/net/listener.rs
@@ -16,7 +16,8 @@ use crate::{fmt, io};
 ///
 /// # Examples
 ///
-/// ```no_run
+#[cfg_attr(windows, doc = "```no_run")]
+#[cfg_attr(not(windows), doc = "```ignore (needs windows)")]
 /// #![feature(windows_unix_domain_sockets)]
 /// use std::thread;
 /// use std::os::windows::net::{UnixStream, UnixListener};
@@ -61,7 +62,8 @@ impl UnixListener {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(windows, doc = "```no_run")]
+    #[cfg_attr(not(windows), doc = "```ignore (needs windows)")]
     /// #![feature(windows_unix_domain_sockets)]
     /// use std::os::windows::net::UnixListener;
     ///
@@ -84,7 +86,8 @@ impl UnixListener {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(windows, doc = "```no_run")]
+    #[cfg_attr(not(windows), doc = "```ignore (needs windows)")]
     /// #![feature(windows_unix_domain_sockets)]
     /// use std::os::windows::net::{UnixListener};
     ///
@@ -122,7 +125,8 @@ impl UnixListener {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(windows, doc = "```no_run")]
+    #[cfg_attr(not(windows), doc = "```ignore (needs windows)")]
     /// #![feature(windows_unix_domain_sockets)]
     /// use std::os::windows::net::UnixListener;
     ///
@@ -148,7 +152,8 @@ impl UnixListener {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(windows, doc = "```no_run")]
+    #[cfg_attr(not(windows), doc = "```ignore (needs windows)")]
     /// #![feature(windows_unix_domain_sockets)]
     /// use std::os::windows::net::UnixListener;
     ///
@@ -170,7 +175,8 @@ impl UnixListener {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(windows, doc = "```no_run")]
+    #[cfg_attr(not(windows), doc = "```ignore (needs windows)")]
     /// #![feature(windows_unix_domain_sockets)]
     /// use std::os::windows::net::UnixListener;
     ///
@@ -194,7 +200,8 @@ impl UnixListener {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(windows, doc = "```no_run")]
+    #[cfg_attr(not(windows), doc = "```ignore (needs windows)")]
     /// #![feature(windows_unix_domain_sockets)]
     /// use std::os::windows::net::UnixListener;
     ///
@@ -212,7 +219,8 @@ impl UnixListener {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(windows, doc = "```no_run")]
+    #[cfg_attr(not(windows), doc = "```ignore (needs windows)")]
     /// #![feature(windows_unix_domain_sockets)]
     /// use std::os::windows::net::UnixListener;
     ///
@@ -236,7 +244,8 @@ impl UnixListener {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(windows, doc = "```no_run")]
+    #[cfg_attr(not(windows), doc = "```ignore (needs windows)")]
     /// #![feature(windows_unix_domain_sockets)]
     /// use std::thread;
     /// use std::os::windows::net::{UnixStream, UnixListener};
@@ -272,7 +281,8 @@ impl UnixListener {
 ///
 /// # Examples
 ///
-/// ```no_run
+#[cfg_attr(windows, doc = "```no_run")]
+#[cfg_attr(not(windows), doc = "```ignore (needs windows)")]
 /// #![feature(windows_unix_domain_sockets)]
 /// use std::thread;
 /// use std::os::windows::net::{UnixStream, UnixListener};

--- a/library/std/src/os/windows/net/stream.rs
+++ b/library/std/src/os/windows/net/stream.rs
@@ -21,7 +21,8 @@ use crate::{fmt, io};
 ///
 /// # Examples
 ///
-/// ```no_run
+#[cfg_attr(windows, doc = "```no_run")]
+#[cfg_attr(not(windows), doc = "```ignore (needs windows)")]
 /// #![feature(windows_unix_domain_sockets)]
 /// use std::os::windows::net::UnixStream;
 /// use std::io::prelude::*;
@@ -54,7 +55,8 @@ impl UnixStream {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(windows, doc = "```no_run")]
+    #[cfg_attr(not(windows), doc = "```ignore (needs windows)")]
     /// #![feature(windows_unix_domain_sockets)]
     /// use std::os::windows::net::UnixStream;
     ///
@@ -77,7 +79,8 @@ impl UnixStream {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(windows, doc = "```no_run")]
+    #[cfg_attr(not(windows), doc = "```ignore (needs windows)")]
     /// #![feature(windows_unix_domain_sockets)]
     /// use std::os::windows::net::{UnixListener, UnixStream};
     ///
@@ -112,7 +115,8 @@ impl UnixStream {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(windows, doc = "```no_run")]
+    #[cfg_attr(not(windows), doc = "```ignore (needs windows)")]
     /// #![feature(windows_unix_domain_sockets)]
     /// use std::os::windows::net::UnixStream;
     ///
@@ -130,7 +134,8 @@ impl UnixStream {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(windows, doc = "```no_run")]
+    #[cfg_attr(not(windows), doc = "```ignore (needs windows)")]
     /// #![feature(windows_unix_domain_sockets)]
     /// use std::os::windows::net::UnixStream;
     ///
@@ -148,7 +153,8 @@ impl UnixStream {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(windows, doc = "```no_run")]
+    #[cfg_attr(not(windows), doc = "```ignore (needs windows)")]
     /// #![feature(windows_unix_domain_sockets)]
     /// use std::os::windows::net::UnixStream;
     /// use std::time::Duration;
@@ -168,7 +174,8 @@ impl UnixStream {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(windows, doc = "```no_run")]
+    #[cfg_attr(not(windows), doc = "```ignore (needs windows)")]
     /// #![feature(windows_unix_domain_sockets)]
     /// use std::os::windows::net::UnixStream;
     ///
@@ -192,7 +199,8 @@ impl UnixStream {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(windows, doc = "```no_run")]
+    #[cfg_attr(not(windows), doc = "```ignore (needs windows)")]
     /// #![feature(windows_unix_domain_sockets)]
     /// use std::os::windows::net::UnixStream;
     /// use std::time::Duration;
@@ -207,7 +215,8 @@ impl UnixStream {
     /// An [`Err`] is returned if the zero [`Duration`] is passed to this
     /// method:
     ///
-    /// ```no_run
+    #[cfg_attr(windows, doc = "```no_run")]
+    #[cfg_attr(not(windows), doc = "```ignore (needs windows)")]
     /// #![feature(windows_unix_domain_sockets)]
     /// use std::io;
     /// use std::os::windows::net::UnixStream;
@@ -235,7 +244,8 @@ impl UnixStream {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(windows, doc = "```no_run")]
+    #[cfg_attr(not(windows), doc = "```ignore (needs windows)")]
     /// #![feature(windows_unix_domain_sockets)]
     /// use std::os::windows::net::UnixStream;
     /// use std::time::Duration;
@@ -251,7 +261,8 @@ impl UnixStream {
     /// An [`Err`] is returned if the zero [`Duration`] is passed to this
     /// method:
     ///
-    /// ```no_run
+    #[cfg_attr(windows, doc = "```no_run")]
+    #[cfg_attr(not(windows), doc = "```ignore (needs windows)")]
     /// #![feature(windows_unix_domain_sockets)]
     /// use std::io;
     /// use std::os::windows::net::UnixStream;
@@ -277,7 +288,8 @@ impl UnixStream {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(windows, doc = "```no_run")]
+    #[cfg_attr(not(windows), doc = "```ignore (needs windows)")]
     /// #![feature(windows_unix_domain_sockets)]
     /// use std::os::windows::net::UnixStream;
     /// use std::net::Shutdown;
@@ -296,7 +308,8 @@ impl UnixStream {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(windows, doc = "```no_run")]
+    #[cfg_attr(not(windows), doc = "```ignore (needs windows)")]
     /// #![feature(windows_unix_domain_sockets)]
     /// use std::os::windows::net::UnixStream;
     ///
@@ -321,7 +334,8 @@ impl UnixStream {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(windows, doc = "```no_run")]
+    #[cfg_attr(not(windows), doc = "```ignore (needs windows)")]
     /// #![feature(windows_unix_domain_sockets)]
     /// use std::os::windows::net::UnixStream;
     ///
@@ -339,7 +353,8 @@ impl UnixStream {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    #[cfg_attr(windows, doc = "```no_run")]
+    #[cfg_attr(not(windows), doc = "```ignore (needs windows)")]
     /// #![feature(windows_unix_domain_sockets)]
     /// use std::os::windows::net::UnixStream;
     /// use std::time::Duration;

--- a/library/std/src/os/windows/process.rs
+++ b/library/std/src/os/windows/process.rs
@@ -273,7 +273,8 @@ pub impl(self) trait CommandExt {
     ///
     /// # Example
     ///
-    /// ```
+    #[cfg_attr(windows, doc = "```")]
+    #[cfg_attr(not(windows), doc = "```ignore (needs windows)")]
     /// #![feature(windows_process_extensions_async_pipes)]
     /// use std::os::windows::process::CommandExt;
     /// use std::process::{Command, Stdio};
@@ -304,7 +305,8 @@ pub impl(self) trait CommandExt {
     ///
     /// # Example
     ///
-    /// ```
+    #[cfg_attr(windows, doc = "```")]
+    #[cfg_attr(not(windows), doc = "```ignore (needs windows)")]
     /// #![feature(windows_process_extensions_raw_attribute)]
     /// use std::os::windows::io::AsRawHandle;
     /// use std::os::windows::process::{CommandExt, ProcThreadAttributeList};
@@ -563,8 +565,9 @@ impl<'a> ProcThreadAttributeListBuilder<'a> {
     ///
     /// # Example
     ///
-    #[cfg_attr(target_vendor = "win7", doc = "```no_run")]
-    #[cfg_attr(not(target_vendor = "win7"), doc = "```")]
+    #[cfg_attr(not(windows), doc = "```ignore (needs windows)")]
+    #[cfg_attr(all(windows, target_vendor = "win7"), doc = "```no_run")]
+    #[cfg_attr(all(windows, not(target_vendor = "win7")), doc = "```")]
     /// #![feature(windows_process_extensions_raw_attribute)]
     /// use std::ffi::c_void;
     /// use std::os::windows::process::{CommandExt, ProcThreadAttributeList};

--- a/library/stdarch/crates/core_arch/src/amdgpu/mod.rs
+++ b/library/stdarch/crates/core_arch/src/amdgpu/mod.rs
@@ -351,13 +351,13 @@ pub unsafe fn sched_barrier<const MASK: u32>() {
 /// Combining multiple `sched_group_barrier` intrinsics enables an ordering of specific instruction types during instruction scheduling.
 /// For example, the following enforces a sequence of 1 VMEM read, followed by 1 VALU instruction, followed by 5 MFMA instructions.
 ///
-/// ```rust
+/// ```ignore (only available on AMD)
 /// // 1 VMEM read
-/// sched_group_barrier::<32, 1, 0>()
+/// sched_group_barrier::<32, 1, 0>();
 /// // 1 VALU
-/// sched_group_barrier::<2, 1, 0>()
+/// sched_group_barrier::<2, 1, 0>();
 /// // 5 MFMA
-/// sched_group_barrier::<8, 5, 0>()
+/// sched_group_barrier::<8, 5, 0>();
 /// ```
 ///
 #[doc = include_str!("intrinsic_is_convergent.md")]

--- a/library/stdarch/crates/core_arch/src/nvptx/mod.rs
+++ b/library/stdarch/crates/core_arch/src/nvptx/mod.rs
@@ -157,10 +157,13 @@ unsafe extern "C" {
     /// * `format`: A pointer to the format specifier input (uses common `printf` format).
     /// * `valist`: A pointer to the valist input.
     ///
-    /// ```
+    /// ```ignore (available only for nvptx)
+    /// # use std::mem::transmute;
     /// #[repr(C)]
     /// struct PrintArgs(f32, f32, f32, i32);
     ///
+    /// let a = 0.1f32;
+    /// let b = 0.2f32;
     /// vprintf(
     ///     "int(%f + %f) = int(%f) = %d\n".as_ptr(),
     ///     transmute(&PrintArgs(a, b, a + b, (a + b) as i32)),

--- a/library/stdarch/crates/core_arch/src/x86/mod.rs
+++ b/library/stdarch/crates/core_arch/src/x86/mod.rs
@@ -39,7 +39,11 @@ types! {
     ///
     /// # Examples
     ///
-    /// ```
+    #[cfg_attr(any(target_arch = "x86", target_arch = "x86_64"), doc = "```")]
+    #[cfg_attr(
+        not(any(target_arch = "x86", target_arch = "x86_64")),
+        doc = "```ignore (only works on x86 targets)",
+    )]
     /// #[cfg(target_arch = "x86")]
     /// use std::arch::x86::*;
     /// #[cfg(target_arch = "x86_64")]
@@ -82,7 +86,11 @@ types! {
     ///
     /// # Examples
     ///
-    /// ```
+    #[cfg_attr(any(target_arch = "x86", target_arch = "x86_64"), doc = "```")]
+    #[cfg_attr(
+        not(any(target_arch = "x86", target_arch = "x86_64")),
+        doc = "```ignore (only works on x86 targets)",
+    )]
     /// #[cfg(target_arch = "x86")]
     /// use std::arch::x86::*;
     /// #[cfg(target_arch = "x86_64")]
@@ -125,7 +133,11 @@ types! {
     ///
     /// # Examples
     ///
-    /// ```
+    #[cfg_attr(any(target_arch = "x86", target_arch = "x86_64"), doc = "```")]
+    #[cfg_attr(
+        not(any(target_arch = "x86", target_arch = "x86_64")),
+        doc = "```ignore (only works on x86 targets)",
+    )]
     /// #[cfg(target_arch = "x86")]
     /// use std::arch::x86::*;
     /// #[cfg(target_arch = "x86_64")]
@@ -172,7 +184,11 @@ types! {
     ///
     /// # Examples
     ///
-    /// ```
+    #[cfg_attr(any(target_arch = "x86", target_arch = "x86_64"), doc = "```")]
+    #[cfg_attr(
+        not(any(target_arch = "x86", target_arch = "x86_64")),
+        doc = "```ignore (only works on x86 targets)",
+    )]
     /// #[cfg(target_arch = "x86")]
     /// use std::arch::x86::*;
     /// #[cfg(target_arch = "x86_64")]
@@ -215,7 +231,11 @@ types! {
     ///
     /// # Examples
     ///
-    /// ```
+    #[cfg_attr(any(target_arch = "x86", target_arch = "x86_64"), doc = "```")]
+    #[cfg_attr(
+        not(any(target_arch = "x86", target_arch = "x86_64")),
+        doc = "```ignore (only works on x86 targets)",
+    )]
     /// #[cfg(target_arch = "x86")]
     /// use std::arch::x86::*;
     /// #[cfg(target_arch = "x86_64")]
@@ -258,7 +278,11 @@ types! {
     ///
     /// # Examples
     ///
-    /// ```
+    #[cfg_attr(any(target_arch = "x86", target_arch = "x86_64"), doc = "```")]
+    #[cfg_attr(
+        not(any(target_arch = "x86", target_arch = "x86_64")),
+        doc = "```ignore (only works on x86 targets)",
+    )]
     /// #[cfg(target_arch = "x86")]
     /// use std::arch::x86::*;
     /// #[cfg(target_arch = "x86_64")]

--- a/src/librustdoc/clean/cfg.rs
+++ b/src/librustdoc/clean/cfg.rs
@@ -30,7 +30,7 @@ mod tests;
 // Because `CfgEntry` includes `Span`, we must NEVER use `==`/`!=` operators on `Cfg` and instead
 // use `is_equivalent_to`.
 #[cfg_attr(test, derive(PartialEq))]
-pub(crate) struct Cfg(CfgEntry);
+pub(crate) struct Cfg(pub(crate) CfgEntry);
 
 // Similar to `hir::DocCfgHideShow` but allows to handle both `show` and `hide` as with the `except`
 // field in `Any` variant.
@@ -744,7 +744,7 @@ pub(crate) struct CfgInfo {
     hidden_cfg: FxHashMap<Symbol, DocCfgHide>,
     /// Current computed `cfg`. Each time we enter a new item, this field is updated as well while
     /// taking into account the `hidden_cfg` information.
-    current_cfg: Cfg,
+    pub(crate) current_cfg: Cfg,
     /// Whether the `doc(auto_cfg())` feature is enabled or not at this point.
     auto_cfg_active: bool,
     /// If the parent item used `doc(cfg(...))`, then we don't want to overwrite `current_cfg`,

--- a/src/librustdoc/doctest/rust.rs
+++ b/src/librustdoc/doctest/rust.rs
@@ -6,17 +6,18 @@ use std::sync::Arc;
 
 use proc_macro2::{TokenStream, TokenTree};
 use rustc_attr_parsing::eval_config_entry;
-use rustc_hir::attrs::AttributeKind;
+use rustc_hir::attrs::{AttributeKind, CfgEntry};
 use rustc_hir::def_id::{CRATE_DEF_ID, LocalDefId};
-use rustc_hir::{self as hir, Attribute, CRATE_HIR_ID, intravisit};
+use rustc_hir::{self as hir, CRATE_HIR_ID, intravisit};
 use rustc_middle::hir::nested_filter;
 use rustc_middle::ty::TyCtxt;
 use rustc_resolve::rustdoc::span_of_fragments;
 use rustc_span::source_map::SourceMap;
-use rustc_span::{BytePos, DUMMY_SP, FileName, Pos, Span};
+use rustc_span::{BytePos, DUMMY_SP, FileName, Pos, Span, sym};
 
 use super::{DocTestVisitor, ScrapedDocTest};
-use crate::clean::{Attributes, CfgInfo, extract_cfg_from_attrs};
+use crate::clean::cfg::Cfg;
+use crate::clean::{Attributes, CfgInfo};
 use crate::html::markdown::{self, CodeLineMapping, ErrorCodes, LangString, MdRelLine};
 
 struct RustCollector {
@@ -118,64 +119,87 @@ impl HirCollector<'_> {
         sp: Span,
         nested: F,
     ) {
-        let ast_attrs = self.tcx.hir_attrs(self.tcx.local_def_id_to_hir_id(def_id));
-        if let Some(ref cfg) =
-            extract_cfg_from_attrs(ast_attrs.iter(), self.tcx, &mut CfgInfo::default())
-            && !eval_config_entry(&self.tcx.sess, cfg.inner()).as_bool()
-        {
-            return;
-        }
+        let hir_attrs = self.tcx.hir_attrs(self.tcx.local_def_id_to_hir_id(def_id));
+
+        let mut cfg_info = CfgInfo::default();
+        let mut found_features = 0;
 
         let source_map = self.tcx.sess.source_map();
-        // Try collecting `#[doc(test(attr(...)))]`
         let old_global_crate_attrs_len = self.collector.global_crate_attrs.len();
-        for attr in ast_attrs {
-            let Attribute::Parsed(AttributeKind::Doc(d)) = attr else { continue };
-            for attr_span in &d.test_attrs {
-                // FIXME: This is ugly, remove when `test_attrs` has been ported to new attribute API.
-                if let Ok(snippet) = source_map.span_to_snippet(*attr_span)
-                    && let Ok(stream) = TokenStream::from_str(&snippet)
-                {
-                    let mut iter = stream.into_iter().peekable();
-                    while let Some(token) = iter.next() {
-                        if let TokenTree::Ident(i) = token {
-                            let i = i.to_string();
-                            let peek = iter.peek();
-                            // From this ident, we can have things like:
-                            //
-                            // * Group: `allow(...)`
-                            // * Name/value: `crate_name = "..."`
-                            // * Tokens: `html_no_url`
-                            //
-                            // So we peek next element to know what case we are in.
-                            match peek {
-                                Some(TokenTree::Group(g)) => {
-                                    let g = g.to_string();
-                                    iter.next();
-                                    // Add the additional attributes to the global_crate_attrs vector
-                                    self.collector.global_crate_attrs.push(format!("{i}{g}"));
-                                }
-                                // If next item is `=`, it means it's a name value so we will need
-                                // to get the value as well.
-                                Some(TokenTree::Punct(p)) if p.as_char() == '=' => {
-                                    let p = p.to_string();
-                                    iter.next();
-                                    if let Some(last) = iter.next() {
-                                        // Add the additional attributes to the global_crate_attrs vector
-                                        self.collector
-                                            .global_crate_attrs
-                                            .push(format!("{i}{p}{last}"));
+        // This loop does two things:
+        //
+        // 1. Collect `#[target_feature(...)]`.
+        // 2. Collect `#[doc(test(attr(...)))]`.
+        for attr in hir_attrs.iter() {
+            let hir::Attribute::Parsed(attr) = attr else { continue };
+            if let AttributeKind::TargetFeature { features, .. } = attr {
+                for (feature, _) in features {
+                    found_features += 1;
+                    cfg_info.current_cfg &= Cfg(CfgEntry::NameValue {
+                        name: sym::target_feature,
+                        value: Some(*feature),
+                        span: DUMMY_SP,
+                    });
+                }
+            } else if let AttributeKind::Doc(d) = attr {
+                for attr_span in &d.test_attrs {
+                    // FIXME: This is ugly, remove when `test_attrs` has been ported to new
+                    // attribute API.
+                    if let Ok(snippet) = source_map.span_to_snippet(*attr_span)
+                        && let Ok(stream) = TokenStream::from_str(&snippet)
+                    {
+                        let mut iter = stream.into_iter().peekable();
+                        while let Some(token) = iter.next() {
+                            if let TokenTree::Ident(i) = token {
+                                let i = i.to_string();
+                                let peek = iter.peek();
+                                // From this ident, we can have things like:
+                                //
+                                // * Group: `allow(...)`
+                                // * Name/value: `crate_name = "..."`
+                                // * Tokens: `html_no_url`
+                                //
+                                // So we peek next element to know what case we are in.
+                                match peek {
+                                    Some(TokenTree::Group(g)) => {
+                                        let g = g.to_string();
+                                        iter.next();
+                                        // Add the additional attributes to the `global_crate_attrs`
+                                        // vector
+                                        self.collector.global_crate_attrs.push(format!("{i}{g}"));
                                     }
-                                }
-                                _ => {
-                                    // Add the additional attributes to the global_crate_attrs vector
-                                    self.collector.global_crate_attrs.push(i.to_string());
+                                    // If next item is `=`, it means it's a name value so we will
+                                    // need to get the value as well.
+                                    Some(TokenTree::Punct(p)) if p.as_char() == '=' => {
+                                        let p = p.to_string();
+                                        iter.next();
+                                        if let Some(last) = iter.next() {
+                                            // Add the additional attributes to the
+                                            // `global_crate_attrs` vector.
+                                            self.collector
+                                                .global_crate_attrs
+                                                .push(format!("{i}{p}{last}"));
+                                        }
+                                    }
+                                    _ => {
+                                        // Add the additional attributes to the `global_crate_attrs`
+                                        // vector.
+                                        self.collector.global_crate_attrs.push(i.to_string());
+                                    }
                                 }
                             }
                         }
                     }
                 }
             }
+        }
+
+        // We only look at the `target_feature` attributes as the `cfg` attributes have already been
+        // applied at this point, so no need to take them into account again.
+        if found_features != 0
+            && !eval_config_entry(&self.tcx.sess, &cfg_info.current_cfg.inner()).as_bool()
+        {
+            return;
         }
 
         let mut has_name = false;
@@ -186,7 +210,7 @@ impl HirCollector<'_> {
 
         // The collapse-docs pass won't combine sugared/raw doc attributes, or included files with
         // anything else, this will combine them for us.
-        let attrs = Attributes::from_hir(ast_attrs);
+        let attrs = Attributes::from_hir(hir_attrs);
         if let Some(doc) = attrs.opt_doc_value() {
             let span = span_of_fragments(&attrs.doc_strings).unwrap_or(sp);
             self.collector.position = if span.edition().at_least_rust_2024() {
@@ -194,7 +218,7 @@ impl HirCollector<'_> {
             } else {
                 // this span affects filesystem path resolution,
                 // so we need to keep it the same as it was previously
-                ast_attrs
+                hir_attrs
                     .iter()
                     .find(|attr| attr.doc_str().is_some())
                     .map(|attr| {

--- a/tests/run-make/rustdoc-filter-doc_cfg-doctest/foo.rs
+++ b/tests/run-make/rustdoc-filter-doc_cfg-doctest/foo.rs
@@ -1,0 +1,15 @@
+#![feature(doc_cfg)]
+
+/// ```
+/// assert!(true);
+/// ```
+#[doc(cfg(spec))]
+fn f() {}
+
+#[doc(cfg(false))]
+mod dummy {
+    /// ```
+    /// assert!(true);
+    /// ```
+    fn f2() {}
+}

--- a/tests/run-make/rustdoc-filter-doc_cfg-doctest/rmake.rs
+++ b/tests/run-make/rustdoc-filter-doc_cfg-doctest/rmake.rs
@@ -1,0 +1,30 @@
+//! Regression test to ensure that `doc(cfg())` has no impact on the filtered-out doctests.
+//!
+//! Regression test for <https://github.com/rust-lang/rust/issues/147033>.
+
+//@ ignore-cross-compile
+
+use run_make_support::rustdoc;
+
+fn check_rustdoc_test_output(edition: &str) {
+    let out = rustdoc().input("foo.rs").edition(edition).arg("--test").run().stdout_utf8();
+
+    // There should be two tests run.
+    assert!(out.contains("running 2 test"), "Failed with edition {edition}");
+    // They should be in `foo.rs`.
+    assert!(out.contains("test foo.rs - f (line 3) ... ok"), "Failed with edition {edition}");
+    assert!(
+        out.contains("test foo.rs - dummy::f2 (line 11) ... ok"),
+        "Failed with edition {edition}"
+    );
+    // We double-check that the test was run (successfully).
+    assert!(
+        out.contains("test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out;"),
+        "Failed with edition {edition}",
+    );
+}
+
+fn main() {
+    check_rustdoc_test_output("2015");
+    check_rustdoc_test_output("2024");
+}


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/159014)*
<!-- homu-ignore:end -->

Part of rust-lang/rust#147033.

Because it was using the `extract_cfg_from_attrs` common function, it was taking into account the `doc(cfg())` attributes the same as if they were a `cfg`.

I didn't mark this PR as "fix" because I didn't handle the case of the doctest not being marked as ignored because I'm not sure if we should revisit the fact that we ignore these doctests or if we should just mark them as ignored (because of `target_feature(enable = "...")`).

Setting @fmease as reviewer as they are likely the only one with context about this issue. :laughing: 

r? @fmease 