### PR TITLE
windows-gnu: enable native TLS

### DIFF
--- a/compiler/rustc_target/src/spec/base/windows_gnu.rs
+++ b/compiler/rustc_target/src/spec/base/windows_gnu.rs
@@ -101,6 +101,7 @@ pub(crate) fn opts() -> TargetOptions {
         emit_debug_gdb_scripts: false,
         requires_uwtable: true,
         eh_frame_header: false,
+        has_thread_local: true,
         debuginfo_kind: DebuginfoKind::Dwarf,
         // FIXME(davidtwco): Support Split DWARF on Windows GNU - may require LLVM changes to
         // output DWO, despite using DWARF, doesn't use ELF..


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
Since Rust 1.98 we have declared minimal supported versions for the tools like the linker. That means native TLS is supposed to work now as seen in try builds in: https://github.com/rust-lang/rust/pull/156819
Therefore, this change is very likely to cause issues if somebody still doesn't adhere to the requirements. As such I don't know what form of approval will be required.

Fixes rust-lang/rust#91659
Fixes rust-lang/rust#135719