### PR TITLE
rustc_llvm: Emit module summaries when using -Clto=fat

### DIFF
--- a/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
@@ -603,6 +603,27 @@ struct LLVMRustSanitizerOptions {
 extern "C" typedef void (*registerEnzymeAndPassPipelineFn)(
     llvm::PassBuilder &PB, bool augment);
 
+/// Forces the bitcode writer to emit full LTO summary instead of thin LTO
+/// summary for embedded bitcode under Fat LTO.
+///
+/// Note the bitcode writer will only emit the full LTO block ID if the
+/// "ThinLTO" metadata is defined and explicitly set to zero. Otherwise, the
+/// thin LTO block ID will be emitted.
+static void forceFullLTOSummary(Module *M) {
+  // This function may be called twice, such as if you call it with `-C lto=fat
+  // --emit=llvm-bc`, so exit early if if we've already set up the module to
+  // emit full LTO summaries.
+  if (auto *Existing = M->getModuleFlag("ThinLTO")) {
+    auto *Const = mdconst::extract<ConstantInt>(Existing);
+    assert(Const->getZExtValue() == 0 &&
+           "ThinLTO flag already set to non-zero");
+    return;
+  }
+
+  auto *Zero = ConstantInt::get(Type::getInt32Ty(M->getContext()), 0);
+  M->addModuleFlag(Module::Error, "ThinLTO", Zero);
+}
+
 extern "C" LLVMRustResult LLVMRustOptimize(
     LLVMModuleRef ModuleRef, LLVMTargetMachineRef TMRef,
     LLVMRustPassBuilderOptLevel OptLevelRust, LLVMRustOptStage OptStage,
@@ -943,14 +964,17 @@ extern "C" LLVMRustResult LLVMRustOptimize(
     }
     // For `-Copt-level=0`, and the pre-link fat/thin LTO stages.
     if (ThinLTOBufferRef && *ThinLTOBufferRef == nullptr) {
-      // thin lto summaries prevent fat lto, so do not emit them if fat
-      // lto is requested. See PR #136840 for background information.
+      // thin lto summaries prevent fat lto, so emit a full summary instead if
+      // fat lto is requested. See PR #136840 for background information.
       if (OptStage != LLVMRustOptStage::PreLinkFatLTO) {
         MPM.addPass(ThinLTOBitcodeWriterPass(
             ThinLTODataOS,
             ThinLTOSummaryBufferRef ? &ThinLinkDataOS : nullptr));
       } else {
-        MPM.addPass(BitcodeWriterPass(ThinLTODataOS));
+        forceFullLTOSummary(TheModule);
+        MPM.addPass(BitcodeWriterPass(ThinLTODataOS,
+                                      /*ShouldPreserveUseListOrder=*/false,
+                                      /*EmitSummaryIndex=*/true));
       }
       *ThinLTOBufferRef = ThinLTOBuffer.release();
       if (ThinLTOSummaryBufferRef) {
@@ -1469,26 +1493,30 @@ extern "C" LLVMRustBuffer *LLVMRustModuleSerialize(LLVMModuleRef M,
   {
     auto OS = raw_string_ostream(Ret->data);
     {
-      if (is_thin) {
-        PassBuilder PB;
-        LoopAnalysisManager LAM;
-        FunctionAnalysisManager FAM;
-        CGSCCAnalysisManager CGAM;
-        ModuleAnalysisManager MAM;
-        PB.registerModuleAnalyses(MAM);
-        PB.registerCGSCCAnalyses(CGAM);
-        PB.registerFunctionAnalyses(FAM);
-        PB.registerLoopAnalyses(LAM);
-        PB.crossRegisterProxies(LAM, FAM, CGAM, MAM);
-        ModulePassManager MPM;
+      PassBuilder PB;
+      LoopAnalysisManager LAM;
+      FunctionAnalysisManager FAM;
+      CGSCCAnalysisManager CGAM;
+      ModuleAnalysisManager MAM;
+      PB.registerModuleAnalyses(MAM);
+      PB.registerCGSCCAnalyses(CGAM);
+      PB.registerFunctionAnalyses(FAM);
+      PB.registerLoopAnalyses(LAM);
+      PB.crossRegisterProxies(LAM, FAM, CGAM, MAM);
+
+      ModulePassManager MPM;
 #if LLVM_VERSION_GE(23, 0)
-        MPM.addPass(AssignGUIDPass());
+      MPM.addPass(AssignGUIDPass());
 #endif
+
+      if (is_thin) {
         MPM.addPass(ThinLTOBitcodeWriterPass(OS, nullptr));
-        MPM.run(*unwrap(M), MAM);
       } else {
-        WriteBitcodeToFile(*unwrap(M), OS);
+        forceFullLTOSummary(unwrap(M));
+        MPM.addPass(BitcodeWriterPass(OS, /*ShouldPreserveUseListOrder=*/false,
+                                      /*EmitSummaryIndex=*/true));
       }
+      MPM.run(*unwrap(M), MAM);
     }
   }
   return Ret.release();

--- a/compiler/rustc_metadata/src/fs.rs
+++ b/compiler/rustc_metadata/src/fs.rs
@@ -96,7 +96,7 @@ pub fn encode_and_write_metadata(tcx: TyCtxt<'_>) -> EncodedMetadata {
         if tcx.sess.opts.json_artifact_notifications {
             tcx.dcx().emit_artifact_notification(out_filename.as_path(), "metadata");
         }
-        (filename, None)
+        (filename, Some(metadata_tmpdir))
     } else {
         (metadata_filename, Some(metadata_tmpdir))
     };

--- a/tests/run-make/fat-lto-module-summary/foo.rs
+++ b/tests/run-make/fat-lto-module-summary/foo.rs
@@ -1,0 +1,3 @@
+#![no_std]
+
+pub fn foo() {}

--- a/tests/run-make/fat-lto-module-summary/rmake.rs
+++ b/tests/run-make/fat-lto-module-summary/rmake.rs
@@ -1,0 +1,10 @@
+use run_make_support::{llvm_bcanalyzer, rustc};
+
+fn main() {
+    rustc().input("foo.rs").crate_type("lib").arg("-Clto=fat").arg("--emit=llvm-bc").run();
+
+    llvm_bcanalyzer()
+        .input("foo.bc")
+        .run()
+        .assert_stdout_contains("FULL_LTO_GLOBALVAL_SUMMARY_BLOCK");
+}


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/159029)*
<!-- homu-ignore:end -->

Currently, module summaries are only emitted with thin lto. If we would link full/fat lto'd rust code against lto'd c++ code built with CFI (or WPD), those passes would fail during the link step because the participating rust modules are missing module summaries. Rust code does not know at compile-time if it would be participating in some special link which may require module summaries, so this PR ensures module summaries are unconditionally emitted for full/fat lto, just like with thin lto.

The WriteBitcodeToFile function just invokes the normal BitcodeWriterPass under the hood, but doesn't provide a way to set the argument for emitting module summaries. So this patch just adds the pass directly and sets that argument.

This is a rebase of @PiJoules's https://github.com/rust-lang/rust/pull/158099, which also should fix up the tests with the gcc tools.