### PR TITLE
bootstrap: expand '@argfile' arguments to rustc shim

### DIFF
--- a/src/bootstrap/src/bin/rustc.rs
+++ b/src/bootstrap/src/bin/rustc.rs
@@ -22,8 +22,8 @@ use std::time::Instant;
 
 use arg_file_command::ArgFileCommand;
 use shared_helpers::{
-    dylib_path, dylib_path_var, exe, maybe_dump, parse_rustc_stage, parse_rustc_verbose,
-    parse_value_from_args,
+    collect_args, dylib_path, dylib_path_var, exe, maybe_dump, parse_rustc_stage,
+    parse_rustc_verbose, parse_value_from_args,
 };
 
 #[path = "../utils/shared_helpers.rs"]
@@ -36,7 +36,7 @@ mod arg_file_command;
 mod proc_macro_deps;
 
 fn main() {
-    let orig_args = env::args_os().skip(1).collect::<Vec<_>>();
+    let orig_args = collect_args();
     let mut args = orig_args.clone();
 
     let stage = parse_rustc_stage();

--- a/src/bootstrap/src/bin/rustdoc.rs
+++ b/src/bootstrap/src/bin/rustdoc.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 
 use arg_file_command::ArgFileCommand;
 use shared_helpers::{
-    dylib_path, dylib_path_var, maybe_dump, parse_rustc_stage, parse_rustc_verbose,
+    collect_args, dylib_path, dylib_path_var, maybe_dump, parse_rustc_stage, parse_rustc_verbose,
     parse_value_from_args,
 };
 
@@ -18,7 +18,7 @@ mod shared_helpers;
 mod arg_file_command;
 
 fn main() {
-    let args = env::args_os().skip(1).collect::<Vec<_>>();
+    let args = collect_args();
 
     let stage = parse_rustc_stage();
     let verbose = parse_rustc_verbose();

--- a/src/bootstrap/src/utils/shared_helpers.rs
+++ b/src/bootstrap/src/utils/shared_helpers.rs
@@ -16,7 +16,8 @@
 use std::env;
 use std::ffi::OsString;
 use std::fs::OpenOptions;
-use std::io::Write;
+use std::io::{BufRead, Write};
+use std::path::Path;
 use std::process::Command;
 use std::str::FromStr;
 
@@ -125,4 +126,31 @@ pub fn parse_value_from_args<'a>(args: &'a [OsString], key: &str) -> Option<&'a 
     }
 
     None
+}
+
+/// Collect all the command line arguments, including the arguments from any `@argfile`
+pub fn collect_args() -> Vec<OsString> {
+    let mut args = Vec::with_capacity(env::args_os().len());
+    for arg in env::args_os().skip(1) {
+        if let Some(s) = arg.to_str()
+            && let Some(path) = s.strip_prefix('@')
+        {
+            args.extend(args_from_argfile(Path::new(path)));
+        } else {
+            args.push(arg)
+        }
+    }
+    args
+}
+
+/// Reads all the arguments from argfile given by `path`.
+/// Each argument should be on a line by itself
+fn args_from_argfile(path: &Path) -> Vec<OsString> {
+    fn collect_lines(path: &Path) -> Result<Vec<OsString>, std::io::Error> {
+        let file = std::fs::File::open(path)?;
+        let lines: Result<Vec<OsString>, std::io::Error> =
+            std::io::BufReader::new(file).lines().map(|r| r.map(OsString::from)).collect();
+        lines
+    }
+    collect_lines(path).expect("read args from argfile {path:?}")
 }


### PR DESCRIPTION
When cargo invokes `rustc`, if the command line exceeds some system defined limit, `cargo` will try again and pass the arguments in an argfile.

When the bootstrap rustc shim tries to detect `--target`, it does not account for `@argfile` arguments.  As a result, the shim doesn't find `--target` and incorrectly sets `is_build_script` to true, as well as passing the `RUSTC_HOST_FLAGS` to the underlying compiler

This PR makes the shim read all the arguments from every `@argfile`.

Previous work rust-lang/rust#155439 already updated the shim to use `ArgFileCommand` to pass arguments down to the underlying `rustc`.

r? kobzol