### PR TITLE
Revert extension of `-1` for `None`-like tags

### DIFF
--- a/compiler/rustc_abi/src/lib.rs
+++ b/compiler/rustc_abi/src/lib.rs
@@ -2103,8 +2103,7 @@ impl Niche {
         let distance_end_zero = max_value - v.end;
         // FIXME: this ought to work for `bool` too, but that seems to be hitting a miscompilation
         // <https://github.com/rust-lang/rust/pull/155473#issuecomment-4302036343>
-        let is_bool = size.bytes() == 1 && v == WrappingRange { start: 0, end: 1 };
-        if count == 1 && !is_bool {
+        if count == 1 && v != (WrappingRange { start: 0, end: 1 }) {
             // We only need one, so just pick the one closest to zero.
             // Not only does that obviously use zero if it's possible, but it also
             // simplifies testing things like `Option<char>`, since looking for `-1`

--- a/tests/codegen-llvm/function-arguments.rs
+++ b/tests/codegen-llvm/function-arguments.rs
@@ -265,7 +265,7 @@ pub fn return_slice(x: &[u16]) -> &[u16] {
     x
 }
 
-// CHECK: { i16, i16 } @enum_id_1(i16 noundef{{( range\(i16 -1, 2\))?}} %x.0, i16 %x.1)
+// CHECK: { i16, i16 } @enum_id_1(i16 noundef{{( range\(i16 0, 3\))?}} %x.0, i16 %x.1)
 #[no_mangle]
 pub fn enum_id_1(x: Option<Result<u16, u16>>) -> Option<Result<u16, u16>> {
     x

--- a/tests/ui/codegen/dont-miscompile-enums.rs
+++ b/tests/ui/codegen/dont-miscompile-enums.rs
@@ -1,0 +1,43 @@
+//@ run-pass
+
+// Bad regression test for https://github.com/rust-lang/rust/issues/159035
+// This should probably be replaced with a codegen test, though that might need to be in LLVM,
+// as it seems that the miscompilation may occur on correct IR misoptimized by SimplifyCFG.
+
+#![allow(dead_code)]
+
+enum Inner {
+    A(u32),
+    B(u32),
+}
+struct Big {
+    _pad: u64,
+    inner: Inner,
+}
+struct Small {
+    a: u16,
+    b: u16,
+    _f: fn(),
+}
+enum Checksum {
+    X(Big),
+    Y(Small),
+}
+impl Checksum {
+    fn finalize(self) -> u32 {
+        match self {
+            Checksum::X(h) => match h.inner {
+                Inner::A(s) => s,
+                Inner::B(s) => s,
+            },
+            Checksum::Y(s) => (u32::from(s.b) << 16) | u32::from(s.a),
+        }
+    }
+}
+#[inline(never)]
+fn run(c: Option<Checksum>) -> Option<u32> {
+    c.map(|c| c.finalize())
+}
+fn main() {
+    println!("{:?}", run(std::hint::black_box(None)));
+}


### PR DESCRIPTION
Note that I am not marking this as resolving the inciting issue in question as it addresses the symptom without curing the disease.

This reverts https://github.com/rust-lang/rust/pull/155850

<!-- homu-ignore:start -->
r? @scottmcm
<!-- homu-ignore:end -->


Said issue in question: https://github.com/rust-lang/rust/issues/159035