### PR TITLE
Avoid ICE in From/TryFrom cast suggestion when encountering HRTBs

### DIFF
--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -285,27 +285,21 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                             || self.tcx.is_diagnostic_item(sym::TryFrom, trait_def_id))
                             && (self.tcx.is_diagnostic_item(sym::From, leaf_trait_def_id)
                                 || self.tcx.is_diagnostic_item(sym::TryFrom, leaf_trait_def_id))
-                        {
-                            let trait_ref = leaf_trait_predicate.skip_binder().trait_ref;
-
-                            if let Some(found_ty) =
+                            && let Some(trait_ref) =
+                                leaf_trait_predicate.no_bound_vars().map(|pred| pred.trait_ref)
+                            && let Some(found_ty) =
                                 trait_ref.args.get(1).and_then(|arg| arg.as_type())
-                            {
-                                let ty = main_trait_predicate.skip_binder().self_ty();
+                            && let Some(ty) =
+                                main_trait_predicate.no_bound_vars().map(|pred| pred.self_ty())
+                            && let Some(cast_ty) =
+                                self.find_explicit_cast_type(obligation.param_env, found_ty, ty)
+                        {
+                            let found_ty_str = self.tcx.short_string(found_ty, &mut long_ty_file);
+                            let cast_ty_str = self.tcx.short_string(cast_ty, &mut long_ty_file);
 
-                                if let Some(cast_ty) =
-                                    self.find_explicit_cast_type(obligation.param_env, found_ty, ty)
-                                {
-                                    let found_ty_str =
-                                        self.tcx.short_string(found_ty, &mut long_ty_file);
-                                    let cast_ty_str =
-                                        self.tcx.short_string(cast_ty, &mut long_ty_file);
-
-                                    err.help(format!(
-                                        "consider casting the `{found_ty_str}` value to `{cast_ty_str}`",
-                                    ));
-                                }
-                            }
+                            err.help(format!(
+                                "consider casting the `{found_ty_str}` value to `{cast_ty_str}`",
+                            ));
                         }
 
                         *err.long_ty_path() = long_ty_file;

--- a/tests/ui/traits/explicit-reference-cast-hrtb.rs
+++ b/tests/ui/traits/explicit-reference-cast-hrtb.rs
@@ -1,0 +1,14 @@
+//! Regression test for #158967
+
+struct Foo;
+
+fn f()
+where
+    for<'a> Foo: From<&'a String>,
+{
+}
+
+fn main() {
+    f();
+    //~^ ERROR the trait bound `for<'a> Foo: From<&'a String>` is not satisfied [E0277]
+}

--- a/tests/ui/traits/explicit-reference-cast-hrtb.stderr
+++ b/tests/ui/traits/explicit-reference-cast-hrtb.stderr
@@ -1,0 +1,23 @@
+error[E0277]: the trait bound `for<'a> Foo: From<&'a String>` is not satisfied
+  --> $DIR/explicit-reference-cast-hrtb.rs:12:5
+   |
+LL |     f();
+   |     ^^^ unsatisfied trait bound
+   |
+help: the trait `for<'a> From<&'a String>` is not implemented for `Foo`
+  --> $DIR/explicit-reference-cast-hrtb.rs:3:1
+   |
+LL | struct Foo;
+   | ^^^^^^^^^^
+note: required by a bound in `f`
+  --> $DIR/explicit-reference-cast-hrtb.rs:7:18
+   |
+LL | fn f()
+   |    - required by a bound in this function
+LL | where
+LL |     for<'a> Foo: From<&'a String>,
+   |                  ^^^^^^^^^^^^^^^^ required by this bound in `f`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

When the cast suggestion sees a `where for<'a> Foo: From<&'a String>` pred where `Foo` doesn't `impl From<&'a String>`, it calls `skip_binder()` on the main and leaf preds, giving us a type like `&'a String`. When we try to look for impls of `From<<&'a String as Deref>::Target>` for the suggestion, we see the escaping `'a` and ICE.

This PR changes the `skip_binder()`s to `no_bound_vars()`. As a consequence, we skip creating the help line when the `From`/`TryFrom` bound is higher-ranked.

fixes rust-lang/rust#158967 