### PR TITLE
assert only opaques with sub unified hidden infer are non-rigid

### DIFF
--- a/compiler/rustc_next_trait_solver/src/solve/assembly/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/assembly/mod.rs
@@ -1095,8 +1095,8 @@ where
                     if let ty::Alias(is_rigid, alias_ty) = ty.kind()
                         && let Some(opaque_ty) = alias_ty.try_to_opaque()
                     {
-                        debug_assert_eq!(is_rigid, ty::IsRigid::No);
                         if opaque_ty == self.opaque_ty {
+                            debug_assert_eq!(is_rigid, ty::IsRigid::No);
                             return self.self_ty;
                         }
                     }

--- a/tests/ui/traits/next-solver/opaques/dont-ice-replacing-non-rigid-opaque.rs
+++ b/tests/ui/traits/next-solver/opaques/dont-ice-replacing-non-rigid-opaque.rs
@@ -1,0 +1,25 @@
+//@ compile-flags: -Znext-solver
+//@ check-pass
+
+// Regression test for #158784
+//
+// We should assert that only opaque types that is to be replaced
+// are non-rigid. We can have rigid opaque types elsewhere.
+
+#![feature(type_alias_impl_trait)]
+type Rigid = impl Sized;
+#[define_opaque(Rigid)]
+fn define_rigid() -> Rigid {}
+
+type MyIter<T> = impl Iterator<Item = T>;
+
+#[define_opaque(MyIter)]
+fn define_my_iter<T>(a: T) -> MyIter<T> {
+    if false {
+        // `Rigid` being rigid is totally fine here.
+        let _: MyIter<Rigid> = std::iter::once(define_rigid());
+    }
+    std::iter::once(a)
+}
+
+fn main() {}


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
Fixes rust-lang/rust#158784

r? lcnr