### PR TITLE
Print a loud error if the configured LLDB cannot be found

### DIFF
--- a/src/bootstrap/src/core/debuggers/lldb.rs
+++ b/src/bootstrap/src/core/debuggers/lldb.rs
@@ -14,12 +14,16 @@ pub(crate) fn discover_lldb(builder: &Builder<'_>) -> Option<Lldb> {
     // explicit opt-in or configuration.
     let lldb_exe = builder.config.lldb.clone().unwrap_or_else(|| PathBuf::from("lldb"));
 
-    let lldb_version = command(&lldb_exe)
-        .allow_failure()
-        .arg("--version")
-        .run_capture(builder)
-        .stdout_if_ok()
-        .filter(|v| !v.trim().is_empty())?;
+    let mut cmd = command(&lldb_exe);
+    cmd.arg("--version");
+
+    // If a path to a LLDB binary was provided, it has to exist and return some version, to avoid
+    // silent failures.
+    let explicitly_set_lldb = builder.config.lldb.is_some();
+    if !explicitly_set_lldb {
+        cmd = cmd.allow_failure();
+    }
+    let lldb_version = cmd.run_capture(builder).stdout_if_ok().filter(|v| !v.trim().is_empty())?;
 
     Some(Lldb { lldb_exe, lldb_version })
 }


### PR DESCRIPTION
Found in https://github.com/rust-lang/rust/pull/158298.

r? @jieyouxu
