### PR TITLE
implement #![feature(macroless_generic_const_args)]

### DIFF
--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -1465,12 +1465,23 @@ impl<'hir> LoweringContext<'_, 'hir> {
                     TyKind::DirectConstArg(expr)
                         if self.tcx.features().min_generic_const_args() =>
                     {
-                        let ct = match self.can_lower_expr_to_const_arg_direct(expr) {
+                        let ct = match self.can_lower_expr_to_const_arg_direct(
+                            expr,
+                            DirectConstArgContext::MacrolessMinGenericConstArgs,
+                        ) {
                             Ok(()) => self.lower_expr_to_const_arg_direct(expr, None),
                             Err(e) => e.emit(self),
                         };
                         let ct = self.arena.alloc(ct);
-                        return GenericArg::Const(ct.try_as_ambig_ct().unwrap());
+                        // note: this allows direct_const_arg!(_) to be inferred to a type. a little
+                        // wonky.
+                        return match ct.try_as_ambig_ct() {
+                            Some(ct) => GenericArg::Const(ct),
+                            None => GenericArg::Infer(hir::InferArg {
+                                hir_id: ct.hir_id,
+                                span: ct.span,
+                            }),
+                        };
                     }
                     _ => {}
                 }
@@ -2608,7 +2619,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
 
         let is_trivial_path = path.is_potential_trivial_const_arg()
             && matches!(res, Res::Def(DefKind::ConstParam, _));
-        let ct_kind = if is_trivial_path || tcx.features().min_generic_const_args() {
+        let ct_kind = if is_trivial_path || tcx.features().macroless_generic_const_args() {
             let qpath = self.lower_qpath(
                 ty_id,
                 &None,
@@ -2671,7 +2682,15 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 hir::ConstItemRhs::Body(self.lower_const_body(span, None))
             }
             ConstItemRhsKind::TypeConst { rhs: Some(anon) } => {
-                hir::ConstItemRhs::TypeConst(self.lower_anon_const_to_const_arg_and_alloc(anon))
+                hir::ConstItemRhs::TypeConst(self.arena.alloc(
+                    match self.can_lower_expr_to_const_arg_direct(
+                        &anon.value,
+                        DirectConstArgContext::MacrolessMinGenericConstArgs,
+                    ) {
+                        Ok(()) => self.lower_expr_to_const_arg_direct(&anon.value, Some(anon.id)),
+                        Err(err) => err.emit(self),
+                    },
+                ))
             }
             ConstItemRhsKind::TypeConst { rhs: None } => {
                 let const_arg = ConstArg {
@@ -2690,63 +2709,67 @@ impl<'hir> LoweringContext<'_, 'hir> {
     fn can_lower_expr_to_const_arg_direct(
         &mut self,
         expr: &Expr,
+        context: DirectConstArgContext,
     ) -> Result<(), UnrepresentableConstArgError> {
-        let is_mgca = self.tcx.features().min_generic_const_args();
-        // Note the only stable case is currently ExprKind::Path. All others have an is_mgca guard.
-        match &expr.kind {
-            ExprKind::Call(func, args)
-                if is_mgca && let ExprKind::Path(_qself, _path) = &func.kind =>
-            {
+        use DirectConstArgContext::*;
+        // Note the only stable case is currently ExprKind::Path
+        match (&expr.kind, context) {
+            (
+                ExprKind::Call(Expr { kind: ExprKind::Path(_, _), .. }, args),
+                MacrolessMinGenericConstArgs,
+            ) => {
                 for arg in args {
-                    self.can_lower_expr_to_const_arg_direct(arg)?;
+                    self.can_lower_expr_to_const_arg_direct(arg, context)?;
                 }
                 Ok(())
             }
-            ExprKind::Tup(exprs) if is_mgca => {
+            (ExprKind::Tup(exprs), MacrolessMinGenericConstArgs) => {
                 for expr in exprs {
-                    self.can_lower_expr_to_const_arg_direct(expr)?;
+                    self.can_lower_expr_to_const_arg_direct(expr, context)?;
                 }
                 Ok(())
             }
-            ExprKind::Path(qself, path)
-                if is_mgca
-                    || path.is_potential_trivial_const_arg()
-                        && matches!(
-                            self.get_partial_res(expr.id)
-                                .and_then(|partial_res| partial_res.full_res()),
-                            Some(Res::Def(DefKind::ConstParam, _))
-                        ) =>
-            {
-                Ok(())
+            (ExprKind::Path(_, _), MacrolessMinGenericConstArgs) => Ok(()),
+            (ExprKind::Path(_, path), _) => {
+                if path.is_potential_trivial_const_arg()
+                    && matches!(
+                        self.get_partial_res(expr.id)
+                            .and_then(|partial_res| partial_res.full_res()),
+                        Some(Res::Def(DefKind::ConstParam, _))
+                    )
+                {
+                    Ok(())
+                } else {
+                    Err(UnrepresentableConstArgError::new(expr))
+                }
             }
-            ExprKind::Struct(se) if is_mgca => {
+            (ExprKind::Struct(se), MacrolessMinGenericConstArgs) => {
                 for f in &se.fields {
-                    self.can_lower_expr_to_const_arg_direct(&f.expr)?;
+                    self.can_lower_expr_to_const_arg_direct(&f.expr, context)?;
                 }
                 Ok(())
             }
-            ExprKind::Array(elements) if is_mgca => {
+            (ExprKind::Array(elements), MacrolessMinGenericConstArgs) => {
                 for element in elements {
-                    self.can_lower_expr_to_const_arg_direct(element)?;
+                    self.can_lower_expr_to_const_arg_direct(element, context)?;
                 }
                 Ok(())
             }
-            ExprKind::Underscore if is_mgca => Ok(()),
-            ExprKind::Block(block, _)
-                if is_mgca
-                    && let [stmt] = block.stmts.as_slice()
+            (ExprKind::Underscore, MacrolessMinGenericConstArgs) => Ok(()),
+            (ExprKind::Block(block, _), MacrolessMinGenericConstArgs)
+                if let [stmt] = block.stmts.as_slice()
                     && let StmtKind::Expr(expr) = &stmt.kind =>
             {
-                self.can_lower_expr_to_const_arg_direct(expr)
+                self.can_lower_expr_to_const_arg_direct(expr, context)
             }
-            ExprKind::Lit(literal) if is_mgca => Ok(()),
-            ExprKind::Unary(UnOp::Neg, inner_expr)
-                if is_mgca && let ExprKind::Lit(_) = &inner_expr.kind =>
+            (ExprKind::Lit(_), MacrolessMinGenericConstArgs) => Ok(()),
+            (ExprKind::Unary(UnOp::Neg, inner_expr), MacrolessMinGenericConstArgs)
+                if let ExprKind::Lit(_) = &inner_expr.kind =>
             {
                 Ok(())
             }
-            ExprKind::ConstBlock(anon) if is_mgca => Ok(()),
-            ExprKind::DirectConstArg(expr) if is_mgca => {
+            (ExprKind::ConstBlock(_), MacrolessMinGenericConstArgs) => Ok(()),
+            (ExprKind::DirectConstArg(_), MacrolessMinGenericConstArgs | MinGenericConstArgs) => {
                 // Always report this as able to be represented directly. If it turns out not to be,
                 // `lower_expr_to_const_arg_direct` will report an error.
                 Ok(())
@@ -2763,8 +2786,6 @@ impl<'hir> LoweringContext<'_, 'hir> {
         expr: &Expr,
         id_override: Option<NodeId>,
     ) -> hir::ConstArg<'hir> {
-        debug_assert!(self.can_lower_expr_to_const_arg_direct(expr).is_ok());
-
         let span = self.lower_span(expr.span);
         let node_id = id_override.unwrap_or(expr.id);
         match &expr.kind {
@@ -2925,7 +2946,12 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 // ExprKind::DirectConstArg, which effectively forces the expression to be lowered
                 // as a direct arg. If it actually turns out to not be possible, emit an error
                 // instead.
-                match self.can_lower_expr_to_const_arg_direct(expr) {
+                // Always use MacrolessMinGenericConstArgs, even if we're under regular GCA, because
+                // that's what the macro means: to enter a context that is like macroless GCA.
+                match self.can_lower_expr_to_const_arg_direct(
+                    expr,
+                    DirectConstArgContext::MacrolessMinGenericConstArgs,
+                ) {
                     Ok(()) => self.lower_expr_to_const_arg_direct(expr, id_override),
                     Err(err) => err.emit(self),
                 }
@@ -2947,24 +2973,28 @@ impl<'hir> LoweringContext<'_, 'hir> {
         &mut self,
         anon: &AnonConst,
     ) -> &'hir hir::ConstArg<'hir> {
-        self.arena.alloc(self.lower_anon_const_to_const_arg(anon, anon.value.span))
+        self.arena.alloc(self.lower_anon_const_to_const_arg(anon))
     }
 
     #[instrument(level = "debug", skip(self))]
-    fn lower_anon_const_to_const_arg(
-        &mut self,
-        anon: &AnonConst,
-        span: Span,
-    ) -> hir::ConstArg<'hir> {
+    fn lower_anon_const_to_const_arg(&mut self, anon: &AnonConst) -> hir::ConstArg<'hir> {
         // Stable only allows one nesting of blocks for directly represented paths. mGCA allows
         // arbitrarily many, and are handled inside lower_expr_to_const_arg_direct for consistency.
-        let expr = if self.tcx.features().min_generic_const_args() {
+        let expr = if self.tcx.features().macroless_generic_const_args() {
             &anon.value
         } else {
             anon.value.maybe_unwrap_block()
         };
 
-        if self.can_lower_expr_to_const_arg_direct(expr).is_ok() {
+        let context = if self.tcx.features().macroless_generic_const_args() {
+            DirectConstArgContext::MacrolessMinGenericConstArgs
+        } else if self.tcx.features().min_generic_const_args() {
+            DirectConstArgContext::MinGenericConstArgs
+        } else {
+            DirectConstArgContext::Stable
+        };
+
+        if self.can_lower_expr_to_const_arg_direct(expr, context).is_ok() {
             return self.lower_expr_to_const_arg_direct(expr, Some(anon.id));
         }
 
@@ -3267,6 +3297,21 @@ impl<'hir> GenericArgsCtor<'hir> {
         };
         this.arena.alloc(ga)
     }
+}
+
+#[derive(Copy, Clone, Debug)]
+enum DirectConstArgContext {
+    /// The only allowed direct const arg representation is simple paths that nameres to generic
+    /// const parameters.
+    Stable,
+    /// The allowed representations are what is allowed on stable, plus the `direct_const_arg!` macro.
+    MinGenericConstArgs,
+    /// Expressions attempt to be lowered directly, and if that fails, the expression falls back to
+    /// being represented as an anon const.
+    ///
+    /// This context is also used under MinGenericConstArgs inside a `direct_const_arg!` macro, for
+    /// simplicity, as they allow the same code.
+    MacrolessMinGenericConstArgs,
 }
 
 #[derive(Debug)]

--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -632,6 +632,8 @@ declare_features! (
     (unstable, macro_metavar_expr, "1.61.0", Some(83527)),
     /// Provides a way to concatenate identifiers using metavariable expressions.
     (unstable, macro_metavar_expr_concat, "1.81.0", Some(124225)),
+    /// Allows directly represented generic_const_args without the `direct_const_arg!` macro.
+    (incomplete, macroless_generic_const_args, "CURRENT_RUSTC_VERSION", Some(159006)),
     /// Allows `#[marker]` on certain traits allowing overlapping implementations.
     (unstable, marker_trait_attr, "1.30.0", Some(29864)),
     /// Enable mgca `type const` syntax before expansion.
@@ -877,5 +879,6 @@ pub const INCOMPATIBLE_FEATURES: &[(Symbol, Symbol)] = &[
 /// Some features require one or more other features to be enabled.
 pub const DEPENDENT_FEATURES: &[(Symbol, &[Symbol])] = &[
     (sym::generic_const_args, &[sym::min_generic_const_args]),
+    (sym::macroless_generic_const_args, &[sym::min_generic_const_args]),
     (sym::unsized_const_params, &[sym::adt_const_params]),
 ];

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1254,6 +1254,7 @@ symbols! {
         macro_reexport,
         macro_use,
         macro_vis_matcher,
+        macroless_generic_const_args,
         macros_in_extern,
         main,
         malloc_fn,

--- a/src/doc/unstable-book/src/language-features/macroless-generic-const-args.md
+++ b/src/doc/unstable-book/src/language-features/macroless-generic-const-args.md
@@ -1,0 +1,68 @@
+# macroless_generic_const_args
+
+Enables using `#![feature(min_generic_const_args)]` without the `direct_const_arg!` macro.
+
+The tracking issue for this feature is: [#159006]
+
+[#159006]: https://github.com/rust-lang/rust/issues/159006
+
+------------------------
+
+Warning: This feature is incomplete; its design and syntax may change.
+
+Related features: [min_generic_const_args]. See that doc for what the `direct_const_arg!` is. This feature enables
+support for directly represented const arguments without the macro.
+
+[min_generic_const_args]: min-generic-const-args.md
+
+## Examples
+
+Here is an example from [min_generic_const_args]:
+
+[min_generic_const_args]: min-generic-const-args.md
+
+```rust
+#![allow(incomplete_features)]
+#![feature(min_generic_const_args)]
+
+trait Bar {
+    type const VAL: usize;
+    type const VAL2: usize;
+}
+
+struct Baz;
+
+impl Bar for Baz {
+    type const VAL: usize = 2;
+    type const VAL2: usize = const { Self::VAL * 2 };
+}
+
+struct Foo<B: Bar> {
+    arr1: [usize; core::direct_const_arg!(B::VAL)],
+    arr2: [usize; core::direct_const_arg!(B::VAL2)],
+}
+```
+
+Using `#![feature(macroless_generic_const_args)]` enables you to write the above without the macro:
+
+```rust
+#![allow(incomplete_features)]
+#![feature(min_generic_const_args, macroless_generic_const_args)]
+
+trait Bar {
+    type const VAL: usize;
+    type const VAL2: usize;
+}
+
+struct Baz;
+
+impl Bar for Baz {
+    type const VAL: usize = 2;
+    type const VAL2: usize = const { Self::VAL * 2 };
+}
+
+struct Foo<B: Bar> {
+    arr1: [usize; B::VAL],
+    arr2: [usize; B::VAL2],
+}
+```

--- a/src/doc/unstable-book/src/language-features/min-generic-const-args.md
+++ b/src/doc/unstable-book/src/language-features/min-generic-const-args.md
@@ -15,12 +15,28 @@ and uses a different approach for implementation. It is intentionally more restr
 cases that make the `generic_const_exprs` hard to implement properly. See [Feature background][feature_background]
 for more details.
 
-Related features: [generic_const_args], [generic_const_items].
+Related features: [macroless_generic_const_args], [generic_const_args], [generic_const_items].
 
 [feature_background]: https://github.com/rust-lang/project-const-generics/blob/main/documents/min_const_generics_plan.md
 [generic_const_exprs]: generic-const-exprs.md
+[macroless_generic_const_args]: macroless-generic-const-args.md
 [generic_const_args]: generic-const-args.md
 [generic_const_items]: generic-const-items.md
+
+## `direct_const_arg!` macro
+
+This feature introduces a new macro: `direct_const_arg!`.
+
+When an expression is used as a generic argument, it is typically lowered as an "anon const", which is an expression
+that is opaque to the type system and cannot contain generics. Using `direct_const_arg!` instead represents the
+expression "directly", i.e. without an anon const, in a way that is visible to the type system.
+
+(Note that plain paths to generic parameters are always represented directly, without `direct_const_arg!`, as this
+already works on stable)
+
+See [macroless_generic_const_args] as a feature to disable the requirement of writing `direct_const_arg!`.
+
+[macroless_generic_const_args]: macroless-generic-const-args.md
 
 ## `type const` syntax
 
@@ -35,8 +51,8 @@ type const X: usize = 1;
 const Y: usize = 1;
 
 struct Foo {
-    good_arr: [(); X], // Allowed
-    bad_arr: [(); Y], // Will not compile, `Y` must be `type const`.
+    good_arr: [(); core::direct_const_arg!(X)], // Allowed
+    bad_arr: [(); core::direct_const_arg!(Y)], // Will not compile, `Y` must be `type const`.
 }
 ```
 
@@ -59,8 +75,8 @@ impl Bar for Baz {
 }
 
 struct Foo<B: Bar> {
-    arr1: [usize; B::VAL],
-    arr2: [usize; B::VAL2],
+    arr1: [usize; core::direct_const_arg!(B::VAL)],
+    arr2: [usize; core::direct_const_arg!(B::VAL2)],
 }
 ```
 

--- a/tests/crashes/138009.rs
+++ b/tests/crashes/138009.rs
@@ -1,6 +1,6 @@
 //@ known-bug: #138009
 #![feature(min_generic_const_args)]
 #[repr(simd)]
-struct T([isize; N]);
+struct T([isize; core::direct_const_arg!(N)]);
 
 static X: T = T();

--- a/tests/crashes/138088.rs
+++ b/tests/crashes/138088.rs
@@ -1,5 +1,5 @@
 //@ known-bug: #138088
 #![feature(min_generic_const_args)]
 trait Bar {
-    fn x(&self) -> [i32; Bar::x];
+    fn x(&self) -> [i32; core::direct_const_arg!(Bar::x)];
 }

--- a/tests/crashes/149809.rs
+++ b/tests/crashes/149809.rs
@@ -6,7 +6,7 @@ struct Qux<'a> {
 }
 impl<'a> Qux<'a> {
     type const LEN: usize = 4;
-    fn foo(_: [u8; Qux::LEN]) {}
+    fn foo(_: [u8; core::direct_const_arg!(Qux::LEN)]) {}
 }
 
 fn main() {}

--- a/tests/crashes/150049.rs
+++ b/tests/crashes/150049.rs
@@ -6,7 +6,9 @@ struct Foo<'a> {
 }
 
 impl<'a> Foo<'a> {
-    fn foo(_: [u8; Foo::X]) { std::mem::transmute([4]) }
+    fn foo(_: [u8; core::direct_const_arg!(Foo::X)]) {
+        std::mem::transmute([4])
+    }
 }
 
 fn main() {}

--- a/tests/crashes/150749.rs
+++ b/tests/crashes/150749.rs
@@ -6,7 +6,7 @@ trait CollectArray {
 }
 impl CollectArray for () {
     fn inner_array() {
-        let temp_ptr: [(); Self];
+        let temp_ptr: [(); core::direct_const_arg!(Self)];
     }
 }
 fn main() {}

--- a/tests/crashes/150969.rs
+++ b/tests/crashes/150969.rs
@@ -3,5 +3,5 @@
 #![feature(min_generic_const_args)]
 
 fn pass_enum<const N : usize, const M : usize = const {N}> {
-  pass_enum::<{None}>
+  pass_enum::<{core::direct_const_arg!(None)}>
 }

--- a/tests/rustdoc-html/type-const-associated-const-no-body.rs
+++ b/tests/rustdoc-html/type-const-associated-const-no-body.rs
@@ -2,7 +2,7 @@
 //! and <https://github.com/rust-lang/rust/issues/158155>
 
 #![crate_name = "foo"]
-#![feature(min_generic_const_args)]
+#![feature(min_generic_const_args, macroless_generic_const_args)]
 #![expect(incomplete_features)]
 
 pub trait Tr {

--- a/tests/rustdoc-html/type-const-free-in-array.rs
+++ b/tests/rustdoc-html/type-const-free-in-array.rs
@@ -1,5 +1,5 @@
 #![crate_name = "foo"]
-#![feature(min_generic_const_args)]
+#![feature(min_generic_const_args, macroless_generic_const_args)]
 #![expect(incomplete_features)]
 
 type const N: usize = 2;

--- a/tests/rustdoc-html/type-const-inherent-with-body.rs
+++ b/tests/rustdoc-html/type-const-inherent-with-body.rs
@@ -1,5 +1,5 @@
 #![crate_name = "foo"]
-#![feature(min_generic_const_args, inherent_associated_types)]
+#![feature(min_generic_const_args, macroless_generic_const_args, inherent_associated_types)]
 #![expect(incomplete_features)]
 
 pub struct Foo;

--- a/tests/ui/associated-consts/type-const-in-array-len-wrong-type.rs
+++ b/tests/ui/associated-consts/type-const-in-array-len-wrong-type.rs
@@ -1,6 +1,9 @@
-#![feature(generic_const_exprs)]
-#![feature(min_generic_const_args)]
-#![feature(inherent_associated_types)]
+#![feature(
+    generic_const_exprs,
+    min_generic_const_args,
+    macroless_generic_const_args,
+    inherent_associated_types
+)]
 
 struct OnDiskDirEntry<'a>(&'a ());
 

--- a/tests/ui/associated-consts/type-const-in-array-len-wrong-type.stderr
+++ b/tests/ui/associated-consts/type-const-in-array-len-wrong-type.stderr
@@ -1,5 +1,5 @@
 error: the constant `2` is not of type `usize`
-  --> $DIR/type-const-in-array-len-wrong-type.rs:10:26
+  --> $DIR/type-const-in-array-len-wrong-type.rs:13:26
    |
 LL |     fn lfn_contents() -> [char; Self::LFN_FRAGMENT_LEN] {
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `usize`, found `i64`

--- a/tests/ui/associated-consts/type-const-in-array-len.rs
+++ b/tests/ui/associated-consts/type-const-in-array-len.rs
@@ -1,7 +1,6 @@
 //@ check-pass
 
-#![feature(min_generic_const_args)]
-#![feature(inherent_associated_types)]
+#![feature(min_generic_const_args, macroless_generic_const_args, inherent_associated_types)]
 
 // Test case from #138226: generic impl with multiple type parameters
 struct Foo<A, B>(A, B);

--- a/tests/ui/const-generics/associated-const-bindings/dyn-compat-const-param-default-mentions-self.rs
+++ b/tests/ui/const-generics/associated-const-bindings/dyn-compat-const-param-default-mentions-self.rs
@@ -1,7 +1,7 @@
 // Test that we force users to explicitly specify const arguments for const parameters that
 // have defaults if the default mentions the `Self` type parameter.
 
-#![feature(min_generic_const_args)]
+#![feature(min_generic_const_args, macroless_generic_const_args)]
 #![expect(incomplete_features)]
 
 trait X<const N: usize = { <Self as Y>::N }> {}

--- a/tests/ui/const-generics/associated-const-bindings/dyn-compat-const-projection-behind-trait-alias-mentions-self.rs
+++ b/tests/ui/const-generics/associated-const-bindings/dyn-compat-const-projection-behind-trait-alias-mentions-self.rs
@@ -5,7 +5,7 @@
 // The author of the trait object type can't fix this unlike the supertrait bound
 // equivalent where they just need to explicitly specify the assoc const.
 
-#![feature(min_generic_const_args, trait_alias)]
+#![feature(min_generic_const_args, macroless_generic_const_args, trait_alias)]
 #![expect(incomplete_features)]
 
 trait Trait {

--- a/tests/ui/const-generics/associated-const-bindings/dyn-compat-const-projection-from-supertrait-mentions-self.rs
+++ b/tests/ui/const-generics/associated-const-bindings/dyn-compat-const-projection-from-supertrait-mentions-self.rs
@@ -1,7 +1,7 @@
 // Test that we force users to explicitly specify associated constants (via bindings)
 // which reference the `Self` type parameter.
 
-#![feature(min_generic_const_args)]
+#![feature(min_generic_const_args, macroless_generic_const_args)]
 #![expect(incomplete_features)]
 
 trait X: Y<K = { Self::Q }> {

--- a/tests/ui/const-generics/associated-const-bindings/dyn-compat-self-const-projections-in-assoc-const-ty.rs
+++ b/tests/ui/const-generics/associated-const-bindings/dyn-compat-self-const-projections-in-assoc-const-ty.rs
@@ -7,6 +7,7 @@
 #![feature(
     adt_const_params,
     min_generic_const_args,
+    macroless_generic_const_args,
     const_param_ty_trait,
     generic_const_parameter_types
 )]

--- a/tests/ui/const-generics/associated-const-bindings/dyn-compat-self-const-projections-in-assoc-const-ty.stderr
+++ b/tests/ui/const-generics/associated-const-bindings/dyn-compat-self-const-projections-in-assoc-const-ty.stderr
@@ -1,11 +1,11 @@
 error: type annotations needed for the literal
-  --> $DIR/dyn-compat-self-const-projections-in-assoc-const-ty.rs:32:33
+  --> $DIR/dyn-compat-self-const-projections-in-assoc-const-ty.rs:33:33
    |
 LL |     let _: dyn A<Ty = i32, CT = 0>;
    |                                 ^
 
 error: type annotations needed for the literal
-  --> $DIR/dyn-compat-self-const-projections-in-assoc-const-ty.rs:34:34
+  --> $DIR/dyn-compat-self-const-projections-in-assoc-const-ty.rs:35:34
    |
 LL |     let _: &dyn A<Ty = i32, CT = 0> = &();
    |                                  ^

--- a/tests/ui/const-generics/associated-const-bindings/dyn-compat-self-const-projections-in-methods.rs
+++ b/tests/ui/const-generics/associated-const-bindings/dyn-compat-self-const-projections-in-methods.rs
@@ -11,7 +11,7 @@
 // correct values from the type assoc consts).
 //@ run-pass
 
-#![feature(min_generic_const_args)]
+#![feature(min_generic_const_args, macroless_generic_const_args)]
 #![expect(incomplete_features)]
 
 trait Trait {

--- a/tests/ui/const-generics/associated-const-bindings/dyn-compat-self-const-projections-in-supertrait-bounds.rs
+++ b/tests/ui/const-generics/associated-const-bindings/dyn-compat-self-const-projections-in-supertrait-bounds.rs
@@ -4,7 +4,7 @@
 
 //@ dont-require-annotations: NOTE
 
-#![feature(min_generic_const_args)]
+#![feature(min_generic_const_args, macroless_generic_const_args)]
 #![expect(incomplete_features)]
 
 trait Trait: SuperTrait<{ Self::N }> {

--- a/tests/ui/const-generics/associated-const-bindings/normalization-via-param-env.rs
+++ b/tests/ui/const-generics/associated-const-bindings/normalization-via-param-env.rs
@@ -1,5 +1,5 @@
 //@ check-pass
-#![feature(min_generic_const_args)]
+#![feature(min_generic_const_args, macroless_generic_const_args)]
 #![allow(incomplete_features)]
 
 // Regression test for normalizing const projections

--- a/tests/ui/const-generics/associated-const-bindings/wf-mismatch-3.rs
+++ b/tests/ui/const-generics/associated-const-bindings/wf-mismatch-3.rs
@@ -1,7 +1,7 @@
 //! Check that we correctly handle associated const bindings
 //! where the RHS is a normalizable const projection (#151642).
 
-#![feature(min_generic_const_args)]
+#![feature(min_generic_const_args, macroless_generic_const_args)]
 #![expect(incomplete_features)]
 
 trait Trait { type const CT: bool; }

--- a/tests/ui/const-generics/fn-item-as-const-arg-137084.rs
+++ b/tests/ui/const-generics/fn-item-as-const-arg-137084.rs
@@ -1,7 +1,7 @@
 // Regression test for https://github.com/rust-lang/rust/issues/137084
 // Previously caused ICE when using function item as const generic argument
 
-#![feature(min_generic_const_args)]
+#![feature(min_generic_const_args, macroless_generic_const_args)]
 #![allow(incomplete_features)]
 
 fn a<const b: i32>() {}

--- a/tests/ui/const-generics/gca/ambiguous-on-failed-eval-with-vars-fail.next.stderr
+++ b/tests/ui/const-generics/gca/ambiguous-on-failed-eval-with-vars-fail.next.stderr
@@ -1,11 +1,11 @@
 error[E0284]: type annotations needed for `([(); _], [(); 10])`
-  --> $DIR/ambiguous-on-failed-eval-with-vars-fail.rs:29:9
+  --> $DIR/ambiguous-on-failed-eval-with-vars-fail.rs:32:9
    |
 LL |     let (mut arr, mut arr_with_weird_len) = free();
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ------ type must be known at this point
    |
 note: required by a const generic parameter in `free`
-  --> $DIR/ambiguous-on-failed-eval-with-vars-fail.rs:24:9
+  --> $DIR/ambiguous-on-failed-eval-with-vars-fail.rs:27:9
    |
 LL | fn free<const N: usize>() -> ([(); N], [(); FREE::<N>]) {
    |         ^^^^^^^^^^^^^^ required by this const generic parameter in `free`
@@ -15,7 +15,7 @@ LL |     let (mut arr, mut arr_with_weird_len): ([_; N], _) = free();
    |                                          +++++++++++++
 
 error[E0271]: type mismatch resolving `FREE<10> == 2`
-  --> $DIR/ambiguous-on-failed-eval-with-vars-fail.rs:35:45
+  --> $DIR/ambiguous-on-failed-eval-with-vars-fail.rs:38:45
    |
 LL |     let (mut arr, mut arr_with_weird_len) = free();
    |                                             ^^^^^^ expected `2`, found `10`
@@ -24,13 +24,13 @@ LL |     let (mut arr, mut arr_with_weird_len) = free();
               found constant `10`
 
 error[E0284]: type annotations needed for `([(); _], [(); 10])`
-  --> $DIR/ambiguous-on-failed-eval-with-vars-fail.rs:46:9
+  --> $DIR/ambiguous-on-failed-eval-with-vars-fail.rs:49:9
    |
 LL |     let (mut arr, mut arr_with_weird_len) = proj();
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ------ type must be known at this point
    |
 note: required by a const generic parameter in `proj`
-  --> $DIR/ambiguous-on-failed-eval-with-vars-fail.rs:41:9
+  --> $DIR/ambiguous-on-failed-eval-with-vars-fail.rs:44:9
    |
 LL | fn proj<const N: usize>() -> ([(); N], [(); <S as Trait>::PROJ::<N>]) {
    |         ^^^^^^^^^^^^^^ required by this const generic parameter in `proj`
@@ -40,7 +40,7 @@ LL |     let (mut arr, mut arr_with_weird_len): ([_; N], _) = proj();
    |                                          +++++++++++++
 
 error[E0271]: type mismatch resolving `<S as Trait>::PROJ<10> == 2`
-  --> $DIR/ambiguous-on-failed-eval-with-vars-fail.rs:52:45
+  --> $DIR/ambiguous-on-failed-eval-with-vars-fail.rs:55:45
    |
 LL |     let (mut arr, mut arr_with_weird_len) = proj();
    |                                             ^^^^^^ expected `2`, found `10`

--- a/tests/ui/const-generics/gca/ambiguous-on-failed-eval-with-vars-fail.old.stderr
+++ b/tests/ui/const-generics/gca/ambiguous-on-failed-eval-with-vars-fail.old.stderr
@@ -1,8 +1,8 @@
 error: `generic_const_args` requires -Znext-solver=globally to be enabled
-  --> $DIR/ambiguous-on-failed-eval-with-vars-fail.rs:9:12
+  --> $DIR/ambiguous-on-failed-eval-with-vars-fail.rs:10:5
    |
-LL | #![feature(generic_const_args)]
-   |            ^^^^^^^^^^^^^^^^^^
+LL |     generic_const_args,
+   |     ^^^^^^^^^^^^^^^^^^
    |
    = help: enable all of these features
 

--- a/tests/ui/const-generics/gca/ambiguous-on-failed-eval-with-vars-fail.rs
+++ b/tests/ui/const-generics/gca/ambiguous-on-failed-eval-with-vars-fail.rs
@@ -4,10 +4,13 @@
 // runs on the old solver, just in case someone attempts to implement GCA for the old solver and
 // removes the restriction that -Znext-solver must be enabled)
 
-#![feature(generic_const_items)]
-#![feature(min_generic_const_args)]
-#![feature(generic_const_args)]
+#![feature(
+    min_generic_const_args,
+    macroless_generic_const_args,
+    generic_const_args,
 //[old]~^ ERROR next-solver
+    generic_const_items
+)]
 #![expect(incomplete_features)]
 
 const FREE<const A: usize>: usize = 10;

--- a/tests/ui/const-generics/gca/ambiguous-on-failed-eval-with-vars.rs
+++ b/tests/ui/const-generics/gca/ambiguous-on-failed-eval-with-vars.rs
@@ -1,9 +1,12 @@
 //@ check-pass
 //@ compile-flags: -Znext-solver
 
-#![feature(generic_const_items)]
-#![feature(min_generic_const_args)]
-#![feature(generic_const_args)]
+#![feature(
+    min_generic_const_args,
+    macroless_generic_const_args,
+    generic_const_args,
+    generic_const_items
+)]
 #![expect(incomplete_features)]
 
 const FREE<const A: usize>: usize = 10;

--- a/tests/ui/const-generics/gca/generic-free-const.rs
+++ b/tests/ui/const-generics/gca/generic-free-const.rs
@@ -1,9 +1,12 @@
 //@ check-pass
 //@ compile-flags: -Znext-solver
 
-#![feature(min_generic_const_args)]
-#![feature(generic_const_args)]
-#![feature(generic_const_items)]
+#![feature(
+    min_generic_const_args,
+    macroless_generic_const_args,
+    generic_const_args,
+    generic_const_items
+)]
 #![expect(incomplete_features)]
 
 const ADD1<const N: usize>: usize = N + 1;

--- a/tests/ui/const-generics/gca/non-type-equality-fail.rs
+++ b/tests/ui/const-generics/gca/non-type-equality-fail.rs
@@ -1,7 +1,6 @@
 //@ compile-flags: -Znext-solver
 
-#![feature(min_generic_const_args)]
-#![feature(generic_const_args)]
+#![feature(min_generic_const_args, macroless_generic_const_args, generic_const_args)]
 #![expect(incomplete_features)]
 
 trait Trait {

--- a/tests/ui/const-generics/gca/non-type-equality-fail.stderr
+++ b/tests/ui/const-generics/gca/non-type-equality-fail.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/non-type-equality-fail.rs:32:9
+  --> $DIR/non-type-equality-fail.rs:31:9
    |
 LL |     let _: Struct<{ <GenericStructImpl<N> as Trait>::PROJECTED_A }> =
    |            -------------------------------------------------------- expected due to this
@@ -10,7 +10,7 @@ LL |         Struct::<{ <GenericStructImpl<N> as Trait>::PROJECTED_B }>;
               found struct `Struct<<GenericStructImpl<N> as Trait>::PROJECTED_B>`
 
 error[E0308]: mismatched types
-  --> $DIR/non-type-equality-fail.rs:37:41
+  --> $DIR/non-type-equality-fail.rs:36:41
    |
 LL |     let _: Struct<{ T::PROJECTED_A }> = Struct::<{ T::PROJECTED_B }>;
    |            --------------------------   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `<T as Trait>::PROJECTED_A`, found `<T as Trait>::PROJECTED_B`

--- a/tests/ui/const-generics/gca/non-type-equality-ok.rs
+++ b/tests/ui/const-generics/gca/non-type-equality-ok.rs
@@ -1,9 +1,12 @@
 //@ check-pass
 //@ compile-flags: -Znext-solver
 
-#![feature(min_generic_const_args)]
-#![feature(generic_const_args)]
-#![feature(generic_const_items)]
+#![feature(
+    min_generic_const_args,
+    macroless_generic_const_args,
+    generic_const_args,
+    generic_const_items
+)]
 #![expect(incomplete_features)]
 
 trait Trait {

--- a/tests/ui/const-generics/gca/path-to-non-type-const.rs
+++ b/tests/ui/const-generics/gca/path-to-non-type-const.rs
@@ -1,8 +1,7 @@
 //@ check-pass
 //@ compile-flags: -Znext-solver
 
-#![feature(min_generic_const_args)]
-#![feature(generic_const_args)]
+#![feature(min_generic_const_args, macroless_generic_const_args, generic_const_args)]
 #![expect(incomplete_features)]
 
 trait Trait {

--- a/tests/ui/const-generics/gca/path-to-non-type-inherent-associated-const.rs
+++ b/tests/ui/const-generics/gca/path-to-non-type-inherent-associated-const.rs
@@ -2,9 +2,12 @@
 //! off on implementing paths to IACs until a refactoring of how IAC generics are represented.
 //@ compile-flags: -Znext-solver
 
-#![feature(min_generic_const_args)]
-#![feature(generic_const_args)]
-#![feature(inherent_associated_types)]
+#![feature(
+    inherent_associated_types,
+    min_generic_const_args,
+    generic_const_args,
+    macroless_generic_const_args
+)]
 #![expect(incomplete_features)]
 
 struct StructImpl;

--- a/tests/ui/const-generics/gca/path-to-non-type-inherent-associated-const.stderr
+++ b/tests/ui/const-generics/gca/path-to-non-type-inherent-associated-const.stderr
@@ -1,5 +1,5 @@
 error: use of `const` in the type system not defined as `type const`
-  --> $DIR/path-to-non-type-inherent-associated-const.rs:24:24
+  --> $DIR/path-to-non-type-inherent-associated-const.rs:27:24
    |
 LL |     let _ = Struct::<{ StructImpl::INHERENT }>;
    |                        ^^^^^^^^^^^^^^^^^^^^
@@ -10,7 +10,7 @@ LL |     type const INHERENT: usize = 1;
    |     ++++
 
 error: use of `const` in the type system not defined as `type const`
-  --> $DIR/path-to-non-type-inherent-associated-const.rs:26:24
+  --> $DIR/path-to-non-type-inherent-associated-const.rs:29:24
    |
 LL |     let _ = Struct::<{ GenericStructImpl::<2>::INHERENT }>;
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/const-generics/generic_const_exprs/non-local-const.rs
+++ b/tests/ui/const-generics/generic_const_exprs/non-local-const.rs
@@ -1,8 +1,7 @@
 // regression test for #133808.
 //@ aux-build:non_local_type_const.rs
 
-#![feature(generic_const_exprs)]
-#![feature(min_generic_const_args)]
+#![feature(min_generic_const_args, macroless_generic_const_args, generic_const_exprs)]
 #![allow(incomplete_features)]
 #![crate_type = "lib"]
 extern crate non_local_type_const;

--- a/tests/ui/const-generics/generic_const_exprs/non-local-const.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/non-local-const.stderr
@@ -1,5 +1,5 @@
 error: the constant `'a'` is not of type `usize`
-  --> $DIR/non-local-const.rs:11:14
+  --> $DIR/non-local-const.rs:10:14
    |
 LL | impl Foo for [u8; non_local_type_const::NON_LOCAL_CONST] {}
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `usize`, found `char`

--- a/tests/ui/const-generics/ice-151186-fn-ptr-in-where-clause.rs
+++ b/tests/ui/const-generics/ice-151186-fn-ptr-in-where-clause.rs
@@ -1,6 +1,6 @@
 // Regression test for https://github.com/rust-lang/rust/issues/151186
 
-#![feature(min_generic_const_args)]
+#![feature(min_generic_const_args, macroless_generic_const_args)]
 #![allow(incomplete_features)]
 
 trait Maybe<T> {}

--- a/tests/ui/const-generics/mgca/adt_expr_arg_simple.rs
+++ b/tests/ui/const-generics/mgca/adt_expr_arg_simple.rs
@@ -1,4 +1,4 @@
-#![feature(min_generic_const_args, adt_const_params)]
+#![feature(min_generic_const_args, macroless_generic_const_args, adt_const_params)]
 #![expect(incomplete_features)]
 
 #[derive(Eq, PartialEq, std::marker::ConstParamTy)]

--- a/tests/ui/const-generics/mgca/adt_expr_arg_tuple_expr_fail.stderr
+++ b/tests/ui/const-generics/mgca/adt_expr_arg_tuple_expr_fail.stderr
@@ -1,35 +1,35 @@
 error: the constant `N` is not of type `u32`
-  --> $DIR/adt_expr_arg_tuple_expr_fail.rs:13:21
+  --> $DIR/adt_expr_arg_tuple_expr_fail.rs:17:21
    |
 LL |     takes_tuple::<{ (N, N2) }>();
    |                     ^^^^^^^ expected `u32`, found `usize`
 
 error: the constant `N` is not of type `u32`
-  --> $DIR/adt_expr_arg_tuple_expr_fail.rs:15:21
+  --> $DIR/adt_expr_arg_tuple_expr_fail.rs:19:21
    |
 LL |     takes_tuple::<{ (N, T::ASSOC) }>();
    |                     ^^^^^^^^^^^^^ expected `u32`, found `usize`
 
 error: the constant `<T as Trait>::ASSOC` is not of type `u32`
-  --> $DIR/adt_expr_arg_tuple_expr_fail.rs:15:21
+  --> $DIR/adt_expr_arg_tuple_expr_fail.rs:19:21
    |
 LL |     takes_tuple::<{ (N, T::ASSOC) }>();
    |                     ^^^^^^^^^^^^^ expected `u32`, found `usize`
 
 error: the constant `N` is not of type `u32`
-  --> $DIR/adt_expr_arg_tuple_expr_fail.rs:19:28
+  --> $DIR/adt_expr_arg_tuple_expr_fail.rs:23:28
    |
 LL |     takes_nested_tuple::<{ (N, (N, N2)) }>();
    |                            ^^^^^^^^^^^^ expected `u32`, found `usize`
 
 error: the constant `N` is not of type `u32`
-  --> $DIR/adt_expr_arg_tuple_expr_fail.rs:21:28
+  --> $DIR/adt_expr_arg_tuple_expr_fail.rs:25:28
    |
 LL |     takes_nested_tuple::<{ (N, (N, T::ASSOC)) }>();
    |                            ^^^^^^^^^^^^^^^^^^ expected `u32`, found `usize`
 
 error: the constant `<T as Trait>::ASSOC` is not of type `u32`
-  --> $DIR/adt_expr_arg_tuple_expr_fail.rs:21:28
+  --> $DIR/adt_expr_arg_tuple_expr_fail.rs:25:28
    |
 LL |     takes_nested_tuple::<{ (N, (N, T::ASSOC)) }>();
    |                            ^^^^^^^^^^^^^^^^^^ expected `u32`, found `usize`

--- a/tests/ui/const-generics/mgca/adt_expr_erroneuous_inits.rs
+++ b/tests/ui/const-generics/mgca/adt_expr_erroneuous_inits.rs
@@ -1,4 +1,4 @@
-#![feature(min_generic_const_args, adt_const_params)]
+#![feature(min_generic_const_args, macroless_generic_const_args, adt_const_params)]
 #![expect(incomplete_features)]
 #![crate_type = "lib"]
 

--- a/tests/ui/const-generics/mgca/adt_expr_fields_type_check.rs
+++ b/tests/ui/const-generics/mgca/adt_expr_fields_type_check.rs
@@ -1,4 +1,4 @@
-#![feature(min_generic_const_args, adt_const_params)]
+#![feature(min_generic_const_args, macroless_generic_const_args, adt_const_params)]
 #![expect(incomplete_features)]
 
 #[derive(Eq, PartialEq, std::marker::ConstParamTy)]

--- a/tests/ui/const-generics/mgca/adt_expr_infers_from_value.rs
+++ b/tests/ui/const-generics/mgca/adt_expr_infers_from_value.rs
@@ -3,13 +3,14 @@
 #![feature(
     generic_const_items,
     min_generic_const_args,
+    macroless_generic_const_args,
     adt_const_params,
     generic_const_parameter_types,
-    const_param_ty_trait,
+    const_param_ty_trait
 )]
 #![expect(incomplete_features)]
 
-use std::marker::{PhantomData, ConstParamTy, ConstParamTy_};
+use std::marker::{ConstParamTy, ConstParamTy_, PhantomData};
 
 #[derive(PartialEq, Eq, ConstParamTy)]
 struct Foo<T> {
@@ -34,11 +35,12 @@ fn main() {
     // This tests that we are able to infer `?x=3` even though the first `ty::Const`
     // may be a fully evaluated constant, and the latter is not fully evaluatable due
     // to inference variables.
-    let _: PC<_, { WRAP::<u8, const { 1 + 1 }> }>
-        =  PC::<_, { Foo::<u8> { field: _ }}>;
+    let _: PC<_, { WRAP::<u8, const { 1 + 1 }> }> = PC::<_, { Foo::<u8> { field: _ } }>;
 }
 
 // "PhantomConst" helper equivalent to "PhantomData" used for testing equalities
 // of arbitrarily typed const arguments.
-struct PC<T: ConstParamTy_, const N: T> { _0: PhantomData<T> }
+struct PC<T: ConstParamTy_, const N: T> {
+    _0: PhantomData<T>,
+}
 const PC<T: ConstParamTy_, const N: T>: PC<T, N> = PC { _0: PhantomData::<T> };

--- a/tests/ui/const-generics/mgca/adt_expr_unit_enum_extra_field.rs
+++ b/tests/ui/const-generics/mgca/adt_expr_unit_enum_extra_field.rs
@@ -1,4 +1,4 @@
-#![feature(min_generic_const_args, adt_const_params)]
+#![feature(min_generic_const_args, macroless_generic_const_args, adt_const_params)]
 
 #[derive(Eq, PartialEq, std::marker::ConstParamTy)]
 enum E {

--- a/tests/ui/const-generics/mgca/adt_expr_unit_struct_extra_field.rs
+++ b/tests/ui/const-generics/mgca/adt_expr_unit_struct_extra_field.rs
@@ -1,4 +1,4 @@
-#![feature(min_generic_const_args, adt_const_params)]
+#![feature(min_generic_const_args, macroless_generic_const_args, adt_const_params)]
 
 #[derive(Eq, PartialEq, std::marker::ConstParamTy)]
 struct Foo;

--- a/tests/ui/const-generics/mgca/ambiguous-assoc-const.rs
+++ b/tests/ui/const-generics/mgca/ambiguous-assoc-const.rs
@@ -1,4 +1,4 @@
-#![feature(min_generic_const_args)]
+#![feature(min_generic_const_args, macroless_generic_const_args)]
 #![expect(incomplete_features)]
 
 trait Tr {

--- a/tests/ui/const-generics/mgca/array-const-arg-type-mismatch.rs
+++ b/tests/ui/const-generics/mgca/array-const-arg-type-mismatch.rs
@@ -1,5 +1,5 @@
 #![expect(incomplete_features)]
-#![feature(adt_const_params, min_generic_const_args)]
+#![feature(adt_const_params, min_generic_const_args, macroless_generic_const_args)]
 use std::marker::ConstParamTy;
 
 #[derive(Eq, PartialEq, ConstParamTy)]

--- a/tests/ui/const-generics/mgca/array-expr-simple.rs
+++ b/tests/ui/const-generics/mgca/array-expr-simple.rs
@@ -1,6 +1,6 @@
 //@ run-pass
 #![expect(incomplete_features)]
-#![feature(min_generic_const_args, adt_const_params)]
+#![feature(min_generic_const_args, macroless_generic_const_args, adt_const_params)]
 #![allow(dead_code)]
 
 fn takes_array_u32<const A: [u32; 3]>() {}

--- a/tests/ui/const-generics/mgca/array-expr-type-mismatch-in-where-bound.rs
+++ b/tests/ui/const-generics/mgca/array-expr-type-mismatch-in-where-bound.rs
@@ -1,5 +1,5 @@
 //! regression test for <https://github.com/rust-lang/rust/issues/151024>
-#![feature(min_generic_const_args)]
+#![feature(min_generic_const_args, macroless_generic_const_args)]
 #![feature(adt_const_params)]
 #![expect(incomplete_features)]
 

--- a/tests/ui/const-generics/mgca/array-expr-with-assoc-const.rs
+++ b/tests/ui/const-generics/mgca/array-expr-with-assoc-const.rs
@@ -1,6 +1,6 @@
 //@ run-pass
 #![expect(incomplete_features)]
-#![feature(min_generic_const_args, adt_const_params)]
+#![feature(min_generic_const_args, macroless_generic_const_args, adt_const_params)]
 #![allow(dead_code)]
 
 fn takes_array<const A: [u32; 3]>() {}

--- a/tests/ui/const-generics/mgca/array-expr-with-macro.rs
+++ b/tests/ui/const-generics/mgca/array-expr-with-macro.rs
@@ -1,6 +1,6 @@
 //@ run-pass
 #![expect(incomplete_features)]
-#![feature(min_generic_const_args, adt_const_params)]
+#![feature(min_generic_const_args, macroless_generic_const_args, adt_const_params)]
 #![allow(dead_code)]
 
 macro_rules! make_array {

--- a/tests/ui/const-generics/mgca/array-expr-with-struct.rs
+++ b/tests/ui/const-generics/mgca/array-expr-with-struct.rs
@@ -1,5 +1,5 @@
 //@ run-pass
-#![feature(min_generic_const_args, adt_const_params)]
+#![feature(min_generic_const_args, macroless_generic_const_args, adt_const_params)]
 #![expect(incomplete_features)]
 #![allow(dead_code)]
 

--- a/tests/ui/const-generics/mgca/array-expr-with-tuple.rs
+++ b/tests/ui/const-generics/mgca/array-expr-with-tuple.rs
@@ -1,5 +1,10 @@
 //@ run-pass
-#![feature(min_generic_const_args, adt_const_params, unsized_const_params)]
+#![feature(
+    min_generic_const_args,
+    macroless_generic_const_args,
+    adt_const_params,
+    unsized_const_params
+)]
 #![expect(incomplete_features)]
 #![allow(dead_code)]
 

--- a/tests/ui/const-generics/mgca/array-with-wrong-tuple-type.rs
+++ b/tests/ui/const-generics/mgca/array-with-wrong-tuple-type.rs
@@ -1,4 +1,9 @@
-#![feature(adt_const_params, min_generic_const_args, unsized_const_params)]
+#![feature(
+    adt_const_params,
+    min_generic_const_args,
+    macroless_generic_const_args,
+    unsized_const_params
+)]
 #![allow(incomplete_features)]
 
 use std::marker::ConstParamTy;
@@ -8,7 +13,6 @@ struct A;
 
 fn takes_tuple<const N: [(u32, u32); 1]>() {}
 fn takes_nested_tuple<const N: [(u32, (u32, u32)); 1]>() {}
-
 
 fn main() {
     takes_tuple::<{ [A] }>();

--- a/tests/ui/const-generics/mgca/array-with-wrong-tuple-type.stderr
+++ b/tests/ui/const-generics/mgca/array-with-wrong-tuple-type.stderr
@@ -1,11 +1,11 @@
 error: the constant `A` is not of type `(u32, u32)`
-  --> $DIR/array-with-wrong-tuple-type.rs:14:21
+  --> $DIR/array-with-wrong-tuple-type.rs:18:21
    |
 LL |     takes_tuple::<{ [A] }>();
    |                     ^^^ expected `(u32, u32)`, found `A`
 
 error: the constant `A` is not of type `(u32, (u32, u32))`
-  --> $DIR/array-with-wrong-tuple-type.rs:16:28
+  --> $DIR/array-with-wrong-tuple-type.rs:20:28
    |
 LL |     takes_nested_tuple::<{ [A] }>();
    |                            ^^^ expected `(u32, (u32, u32))`, found `A`

--- a/tests/ui/const-generics/mgca/array_elem_type_mismatch.rs
+++ b/tests/ui/const-generics/mgca/array_elem_type_mismatch.rs
@@ -1,6 +1,11 @@
 //! Regression test for <https://github.com/rust-lang/rust/issues/152683>
 #![expect(incomplete_features)]
-#![feature(adt_const_params, generic_const_parameter_types, min_generic_const_args)]
+#![feature(
+    adt_const_params,
+    generic_const_parameter_types,
+    min_generic_const_args,
+    macroless_generic_const_args
+)]
 fn foo<const N: usize, const A: [u8; N]>() {}
 
 fn main() {

--- a/tests/ui/const-generics/mgca/array_elem_type_mismatch.stderr
+++ b/tests/ui/const-generics/mgca/array_elem_type_mismatch.stderr
@@ -1,11 +1,11 @@
 error: the constant `2` is not of type `u8`
-  --> $DIR/array_elem_type_mismatch.rs:7:16
+  --> $DIR/array_elem_type_mismatch.rs:12:16
    |
 LL |     foo::<_, { [0, 1u8, 2u32, 8u64] }>();
    |                ^^^^^^^^^^^^^^^^^^^^ expected `u8`, found `u32`
 
 error: the constant `8` is not of type `u8`
-  --> $DIR/array_elem_type_mismatch.rs:7:16
+  --> $DIR/array_elem_type_mismatch.rs:12:16
    |
 LL |     foo::<_, { [0, 1u8, 2u32, 8u64] }>();
    |                ^^^^^^^^^^^^^^^^^^^^ expected `u8`, found `u64`

--- a/tests/ui/const-generics/mgca/assoc-const-projection-in-bound.rs
+++ b/tests/ui/const-generics/mgca/assoc-const-projection-in-bound.rs
@@ -1,7 +1,7 @@
 //! regression test for <https://github.com/rust-lang/rust/issues/141014>
 //@ run-pass
 #![expect(incomplete_features)]
-#![feature(min_generic_const_args)]
+#![feature(min_generic_const_args, macroless_generic_const_args)]
 #![allow(dead_code)]
 
 trait Abc {}

--- a/tests/ui/const-generics/mgca/assoc-const-without-type_const.rs
+++ b/tests/ui/const-generics/mgca/assoc-const-without-type_const.rs
@@ -1,4 +1,4 @@
-#![feature(min_generic_const_args)]
+#![feature(min_generic_const_args, macroless_generic_const_args)]
 #![allow(incomplete_features)]
 
 pub trait Tr {

--- a/tests/ui/const-generics/mgca/assoc-const.rs
+++ b/tests/ui/const-generics/mgca/assoc-const.rs
@@ -1,6 +1,6 @@
 //@ check-pass
 
-#![feature(min_generic_const_args)]
+#![feature(min_generic_const_args, macroless_generic_const_args)]
 #![allow(incomplete_features)]
 
 pub trait Tr<X> {

--- a/tests/ui/const-generics/mgca/bad-impl-trait-with-apit.rs
+++ b/tests/ui/const-generics/mgca/bad-impl-trait-with-apit.rs
@@ -1,7 +1,7 @@
 // Regression test for issue #155834
 
 #![expect(incomplete_features)]
-#![feature(min_generic_const_args)]
+#![feature(min_generic_const_args, macroless_generic_const_args)]
 
 trait Trait {}
 

--- a/tests/ui/const-generics/mgca/braced-const-infer.rs
+++ b/tests/ui/const-generics/mgca/braced-const-infer.rs
@@ -1,5 +1,5 @@
 //! Regression test for https://github.com/rust-lang/rust/issues/153198
-#![feature(min_generic_const_args)]
+#![feature(min_generic_const_args, macroless_generic_const_args)]
 #![allow(incomplete_features, rust_2021_compatibility)]
 
 trait Trait<T> {}

--- a/tests/ui/const-generics/mgca/const-ctor-overflow-eval.rs
+++ b/tests/ui/const-generics/mgca/const-ctor-overflow-eval.rs
@@ -1,4 +1,4 @@
-#![feature(min_generic_const_args, adt_const_params)]
+#![feature(min_generic_const_args, macroless_generic_const_args, adt_const_params)]
 #![expect(incomplete_features)]
 use std::marker::ConstParamTy;
 

--- a/tests/ui/const-generics/mgca/const-ctor-with-error.rs
+++ b/tests/ui/const-generics/mgca/const-ctor-with-error.rs
@@ -1,6 +1,6 @@
 // to ensure it does not ices like before
 
-#![feature(min_generic_const_args, adt_const_params)]
+#![feature(min_generic_const_args, macroless_generic_const_args, adt_const_params)]
 #![expect(incomplete_features)]
 use std::marker::ConstParamTy;
 

--- a/tests/ui/const-generics/mgca/const-ctor.rs
+++ b/tests/ui/const-generics/mgca/const-ctor.rs
@@ -6,6 +6,7 @@
 
 #![feature(
     min_generic_const_args,
+    macroless_generic_const_args,
     adt_const_params,
     generic_const_parameter_types,
     const_param_ty_trait

--- a/tests/ui/const-generics/mgca/infer-vars-in-const-args-conflicting.rs
+++ b/tests/ui/const-generics/mgca/infer-vars-in-const-args-conflicting.rs
@@ -4,7 +4,12 @@
 //! See https://github.com/rust-lang/rust/pull/153557
 
 #![allow(incomplete_features)]
-#![feature(adt_const_params, min_generic_const_args, generic_const_parameter_types)]
+#![feature(
+    adt_const_params,
+    min_generic_const_args,
+    macroless_generic_const_args,
+    generic_const_parameter_types
+)]
 
 fn main() {
     foo::<_, { 2 }>();
@@ -14,7 +19,7 @@ fn main() {
 }
 
 struct PC<T, const N: T> {
-//~^ ERROR: `T` can't be used as a const parameter type [E0741]
+    //~^ ERROR: `T` can't be used as a const parameter type [E0741]
     a: T,
 }
 

--- a/tests/ui/const-generics/mgca/infer-vars-in-const-args-conflicting.stderr
+++ b/tests/ui/const-generics/mgca/infer-vars-in-const-args-conflicting.stderr
@@ -1,17 +1,17 @@
 error[E0741]: `T` can't be used as a const parameter type
-  --> $DIR/infer-vars-in-const-args-conflicting.rs:16:23
+  --> $DIR/infer-vars-in-const-args-conflicting.rs:21:23
    |
 LL | struct PC<T, const N: T> {
    |                       ^
 
 error: type annotations needed for the literal
-  --> $DIR/infer-vars-in-const-args-conflicting.rs:10:16
+  --> $DIR/infer-vars-in-const-args-conflicting.rs:15:16
    |
 LL |     foo::<_, { 2 }>();
    |                ^
 
 error: type annotations needed for the literal
-  --> $DIR/infer-vars-in-const-args-conflicting.rs:12:20
+  --> $DIR/infer-vars-in-const-args-conflicting.rs:17:20
    |
 LL |     let _: PC<_, { 42 }> = PC { a: 1, b: 1 };
    |                    ^^

--- a/tests/ui/const-generics/mgca/infer-vars-in-const-args-correct.rs
+++ b/tests/ui/const-generics/mgca/infer-vars-in-const-args-correct.rs
@@ -7,8 +7,10 @@
 //@check-pass
 
 #![allow(incomplete_features)]
-#![feature(adt_const_params,
+#![feature(
+    adt_const_params,
     min_generic_const_args,
+    macroless_generic_const_args,
     generic_const_parameter_types,
     unsized_const_params
 )]

--- a/tests/ui/const-generics/mgca/inherent-const-gating.rs
+++ b/tests/ui/const-generics/mgca/inherent-const-gating.rs
@@ -1,4 +1,4 @@
-#![feature(min_generic_const_args)]
+#![feature(min_generic_const_args, macroless_generic_const_args)]
 #![allow(incomplete_features)]
 
 struct S;

--- a/tests/ui/const-generics/mgca/invalid-array-in-tuple.rs
+++ b/tests/ui/const-generics/mgca/invalid-array-in-tuple.rs
@@ -1,4 +1,9 @@
-#![feature(adt_const_params, min_generic_const_args, unsized_const_params)]
+#![feature(
+    adt_const_params,
+    min_generic_const_args,
+    macroless_generic_const_args,
+    unsized_const_params
+)]
 #![allow(incomplete_features)]
 
 use std::marker::ConstParamTy;

--- a/tests/ui/const-generics/mgca/invalid-array-in-tuple.stderr
+++ b/tests/ui/const-generics/mgca/invalid-array-in-tuple.stderr
@@ -1,5 +1,5 @@
 error: the constant `Bar` is not of type `Foo`
-  --> $DIR/invalid-array-in-tuple.rs:14:32
+  --> $DIR/invalid-array-in-tuple.rs:19:32
    |
 LL |     takes_tuple_with_array::<{ ([Bar], 1) }>();
    |                                ^^^^^^^^^^ expected `Foo`, found `Bar`

--- a/tests/ui/const-generics/mgca/macro-const-arg-infer.rs
+++ b/tests/ui/const-generics/mgca/macro-const-arg-infer.rs
@@ -1,5 +1,5 @@
 //! Regression test for https://github.com/rust-lang/rust/issues/153198
-#![feature(min_generic_const_args)]
+#![feature(min_generic_const_args, macroless_generic_const_args)]
 #![allow(incomplete_features)]
 macro_rules! y {
     ( $($matcher:tt)*) => {

--- a/tests/ui/const-generics/mgca/missing_generic_params.rs
+++ b/tests/ui/const-generics/mgca/missing_generic_params.rs
@@ -7,7 +7,7 @@
 // is only possible within bodies. So a delayed
 // bug was generated with no error ever reported.
 
-#![feature(min_generic_const_args)]
+#![feature(min_generic_const_args, macroless_generic_const_args)]
 #![allow(incomplete_features)]
 trait Trait {}
 impl Trait for [(); N] {}

--- a/tests/ui/const-generics/mgca/multi_braced_direct_const_args.rs
+++ b/tests/ui/const-generics/mgca/multi_braced_direct_const_args.rs
@@ -1,6 +1,6 @@
 //@ check-pass
 
-#![feature(min_generic_const_args)]
+#![feature(min_generic_const_args, macroless_generic_const_args)]
 #![expect(incomplete_features)]
 
 struct Foo<const N: usize>;

--- a/tests/ui/const-generics/mgca/non-local-const-without-type_const.rs
+++ b/tests/ui/const-generics/mgca/non-local-const-without-type_const.rs
@@ -1,6 +1,6 @@
 // Just a test of the error message (it's different for non-local consts)
 //@ aux-build:non_local_const.rs
-#![feature(min_generic_const_args)]
+#![feature(min_generic_const_args, macroless_generic_const_args)]
 #![allow(incomplete_features)]
 extern crate non_local_const;
 fn main() {

--- a/tests/ui/const-generics/mgca/nonsensical-negated-literal.rs
+++ b/tests/ui/const-generics/mgca/nonsensical-negated-literal.rs
@@ -1,11 +1,16 @@
-#![feature(adt_const_params, min_generic_const_args, unsized_const_params)]
+#![feature(
+    adt_const_params,
+    min_generic_const_args,
+    macroless_generic_const_args,
+    unsized_const_params
+)]
 #![expect(incomplete_features)]
 
 use std::marker::ConstParamTy;
 
 #[derive(Eq, PartialEq, ConstParamTy)]
 struct Foo {
-    field: isize
+    field: isize,
 }
 
 fn foo<const F: Foo>() {}

--- a/tests/ui/const-generics/mgca/nonsensical-negated-literal.stderr
+++ b/tests/ui/const-generics/mgca/nonsensical-negated-literal.stderr
@@ -1,41 +1,41 @@
 error: negated literal must be an integer
-  --> $DIR/nonsensical-negated-literal.rs:20:26
+  --> $DIR/nonsensical-negated-literal.rs:25:26
    |
 LL |     foo::<{ Foo { field: -true } }>();
    |                          ^^^^^
 
 error: negated literal must be an integer
-  --> $DIR/nonsensical-negated-literal.rs:22:28
+  --> $DIR/nonsensical-negated-literal.rs:27:28
    |
 LL |     foo::<{ Foo { field: { -true } } }>();
    |                            ^^^^^
 
 error: negated literal must be an integer
-  --> $DIR/nonsensical-negated-literal.rs:24:26
+  --> $DIR/nonsensical-negated-literal.rs:29:26
    |
 LL |     foo::<{ Foo { field: -"<3" } }>();
    |                          ^^^^^
 
 error: negated literal must be an integer
-  --> $DIR/nonsensical-negated-literal.rs:26:28
+  --> $DIR/nonsensical-negated-literal.rs:31:28
    |
 LL |     foo::<{ Foo { field: { -"<3" } } }>();
    |                            ^^^^^
 
 error: negated literal must be an integer
-  --> $DIR/nonsensical-negated-literal.rs:29:13
+  --> $DIR/nonsensical-negated-literal.rs:34:13
    |
 LL |     bar::<{ -"hi" }>();
    |             ^^^^^
 
 error: type annotations needed for the literal
-  --> $DIR/nonsensical-negated-literal.rs:16:26
+  --> $DIR/nonsensical-negated-literal.rs:21:26
    |
 LL |     foo::<{ Foo { field: -1_usize } }>();
    |                          ^^^^^^^^
 
 error: type annotations needed for the literal
-  --> $DIR/nonsensical-negated-literal.rs:18:28
+  --> $DIR/nonsensical-negated-literal.rs:23:28
    |
 LL |     foo::<{ Foo { field: { -1_usize } } }>();
    |                            ^^^^^^^^

--- a/tests/ui/const-generics/mgca/printing_valtrees_supports_non_values.rs
+++ b/tests/ui/const-generics/mgca/printing_valtrees_supports_non_values.rs
@@ -2,7 +2,7 @@
 //@ edition: 2024
 
 #![allow(incomplete_features)]
-#![feature(min_generic_const_args, adt_const_params)]
+#![feature(min_generic_const_args, macroless_generic_const_args, adt_const_params)]
 
 #[derive(Eq, PartialEq, core::marker::ConstParamTy)]
 struct Foo;

--- a/tests/ui/const-generics/mgca/resolution-with-inherent-associated-types.rs
+++ b/tests/ui/const-generics/mgca/resolution-with-inherent-associated-types.rs
@@ -4,7 +4,7 @@
 
 //@compile-flags: --crate-type=lib
 #![expect(incomplete_features)]
-#![feature(inherent_associated_types, min_generic_const_args)]
+#![feature(inherent_associated_types, min_generic_const_args, macroless_generic_const_args)]
 trait Trait {}
 
 struct Struct<const N: usize>;

--- a/tests/ui/const-generics/mgca/size-of-generic-ptr-in-array-len.rs
+++ b/tests/ui/const-generics/mgca/size-of-generic-ptr-in-array-len.rs
@@ -1,6 +1,6 @@
 //! regression test for <https://github.com/rust-lang/rust/issues/147415>
 #![expect(incomplete_features)]
-#![feature(min_generic_const_args)]
+#![feature(min_generic_const_args, macroless_generic_const_args)]
 
 fn foo<T>() {
     [0; size_of::<*mut T>()];

--- a/tests/ui/const-generics/mgca/struct-ctor-in-array-len.rs
+++ b/tests/ui/const-generics/mgca/struct-ctor-in-array-len.rs
@@ -5,7 +5,7 @@
 // for const alias to resolve to: Ctor(Struct, Const)".
 // It should now produce a proper type error.
 
-#![feature(min_generic_const_args)]
+#![feature(min_generic_const_args, macroless_generic_const_args)]
 
 struct S;
 

--- a/tests/ui/const-generics/mgca/suggest-pub-type_const.fixed
+++ b/tests/ui/const-generics/mgca/suggest-pub-type_const.fixed
@@ -1,7 +1,7 @@
 //! Regression test for <https://github.com/rust-lang/rust/issues/157368>
 //! Tests suggesting `pub type const` instead of `type pub const`.
 //@ run-rustfix
-#![feature(min_generic_const_args, inherent_associated_types)]
+#![feature(min_generic_const_args, macroless_generic_const_args, inherent_associated_types)]
 #![allow(dead_code)]
 
 mod impl_item {

--- a/tests/ui/const-generics/mgca/suggest-pub-type_const.rs
+++ b/tests/ui/const-generics/mgca/suggest-pub-type_const.rs
@@ -1,7 +1,7 @@
 //! Regression test for <https://github.com/rust-lang/rust/issues/157368>
 //! Tests suggesting `pub type const` instead of `type pub const`.
 //@ run-rustfix
-#![feature(min_generic_const_args, inherent_associated_types)]
+#![feature(min_generic_const_args, macroless_generic_const_args, inherent_associated_types)]
 #![allow(dead_code)]
 
 mod impl_item {

--- a/tests/ui/const-generics/mgca/synth-gen-arg-ice-158152.rs
+++ b/tests/ui/const-generics/mgca/synth-gen-arg-ice-158152.rs
@@ -1,4 +1,4 @@
-#![feature(min_generic_const_args)]
+#![feature(min_generic_const_args, macroless_generic_const_args)]
 
 trait A<T> {}
 trait Trait<const N: usize> {}

--- a/tests/ui/const-generics/mgca/tuple_ctor_arg_simple.rs
+++ b/tests/ui/const-generics/mgca/tuple_ctor_arg_simple.rs
@@ -1,5 +1,5 @@
 //@ run-pass
-#![feature(min_generic_const_args, adt_const_params)]
+#![feature(min_generic_const_args, macroless_generic_const_args, adt_const_params)]
 #![expect(incomplete_features)]
 #![allow(dead_code)]
 

--- a/tests/ui/const-generics/mgca/tuple_ctor_complex_args.rs
+++ b/tests/ui/const-generics/mgca/tuple_ctor_complex_args.rs
@@ -1,4 +1,4 @@
-#![feature(min_generic_const_args, adt_const_params)]
+#![feature(min_generic_const_args, macroless_generic_const_args, adt_const_params)]
 #![expect(incomplete_features)]
 
 use std::marker::ConstParamTy;

--- a/tests/ui/const-generics/mgca/tuple_ctor_erroneous.rs
+++ b/tests/ui/const-generics/mgca/tuple_ctor_erroneous.rs
@@ -1,4 +1,4 @@
-#![feature(min_generic_const_args, adt_const_params)]
+#![feature(min_generic_const_args, macroless_generic_const_args, adt_const_params)]
 #![expect(incomplete_features)]
 
 use std::marker::ConstParamTy;

--- a/tests/ui/const-generics/mgca/tuple_ctor_in_array_len.rs
+++ b/tests/ui/const-generics/mgca/tuple_ctor_in_array_len.rs
@@ -1,6 +1,6 @@
 //! Regression test for <https://github.com/rust-lang/rust/issues/136379>
 
-#![feature(min_generic_const_args)]
+#![feature(min_generic_const_args, macroless_generic_const_args)]
 #![expect(incomplete_features)]
 
 pub struct S();

--- a/tests/ui/const-generics/mgca/tuple_ctor_nested.rs
+++ b/tests/ui/const-generics/mgca/tuple_ctor_nested.rs
@@ -1,5 +1,5 @@
 //@ run-pass
-#![feature(min_generic_const_args, adt_const_params)]
+#![feature(min_generic_const_args, macroless_generic_const_args, adt_const_params)]
 #![expect(incomplete_features)]
 
 use std::marker::ConstParamTy;

--- a/tests/ui/const-generics/mgca/tuple_ctor_type_relative.rs
+++ b/tests/ui/const-generics/mgca/tuple_ctor_type_relative.rs
@@ -1,5 +1,5 @@
 //@ run-pass
-#![feature(min_generic_const_args, adt_const_params)]
+#![feature(min_generic_const_args, macroless_generic_const_args, adt_const_params)]
 #![expect(incomplete_features)]
 
 use std::marker::ConstParamTy;

--- a/tests/ui/const-generics/mgca/tuple_expr_arg_bad-issue-151048.rs
+++ b/tests/ui/const-generics/mgca/tuple_expr_arg_bad-issue-151048.rs
@@ -1,4 +1,4 @@
-#![feature(min_generic_const_args)]
+#![feature(min_generic_const_args, macroless_generic_const_args)]
 #![expect(incomplete_features)]
 
 struct Y {

--- a/tests/ui/const-generics/mgca/tuple_expr_arg_macroless.rs
+++ b/tests/ui/const-generics/mgca/tuple_expr_arg_macroless.rs
@@ -1,3 +1,5 @@
+//@ check-pass
+
 #![feature(
     min_generic_const_args,
     macroless_generic_const_args,
@@ -7,24 +9,18 @@
 #![expect(incomplete_features)]
 
 trait Trait {
-    type const ASSOC: usize;
+    type const ASSOC: u32;
 }
 
 fn takes_tuple<const A: (u32, u32)>() {}
 fn takes_nested_tuple<const A: (u32, (u32, u32))>() {}
 
-fn generic_caller<T: Trait, const N: usize, const N2: u32>() {
+fn generic_caller<T: Trait, const N: u32, const N2: u32>() {
     takes_tuple::<{ (N, N2) }>();
-    //~^ ERROR the constant `N` is not of type `u32`
     takes_tuple::<{ (N, T::ASSOC) }>();
-    //~^ ERROR the constant `N` is not of type `u32`
-    //~| ERROR the constant `<T as Trait>::ASSOC` is not of type `u32`
 
     takes_nested_tuple::<{ (N, (N, N2)) }>();
-    //~^ ERROR the constant `N` is not of type `u32`
     takes_nested_tuple::<{ (N, (N, T::ASSOC)) }>();
-    //~^ ERROR the constant `N` is not of type `u32`
-    //~| ERROR the constant `<T as Trait>::ASSOC` is not of type `u32`
 }
 
 fn main() {}

--- a/tests/ui/const-generics/mgca/tuple_expr_arg_mismatch_type.rs
+++ b/tests/ui/const-generics/mgca/tuple_expr_arg_mismatch_type.rs
@@ -1,4 +1,4 @@
-#![feature(min_generic_const_args)]
+#![feature(min_generic_const_args, macroless_generic_const_args)]
 #![expect(incomplete_features)]
 
 pub fn takes_nested_tuple<const N: u32>() {

--- a/tests/ui/const-generics/mgca/tuple_expr_arg_simple.rs
+++ b/tests/ui/const-generics/mgca/tuple_expr_arg_simple.rs
@@ -11,11 +11,11 @@ fn takes_tuple<const A: (u32, u32)>() {}
 fn takes_nested_tuple<const A: (u32, (u32, u32))>() {}
 
 fn generic_caller<T: Trait, const N: u32, const N2: u32>() {
-    takes_tuple::<{ (N, N2) }>();
-    takes_tuple::<{ (N, T::ASSOC) }>();
+    takes_tuple::<{ core::direct_const_arg!((N, N2)) }>();
+    takes_tuple::<{ core::direct_const_arg!((N, T::ASSOC)) }>();
 
-    takes_nested_tuple::<{ (N, (N, N2)) }>();
-    takes_nested_tuple::<{ (N, (N, T::ASSOC)) }>();
+    takes_nested_tuple::<{ core::direct_const_arg!((N, (N, N2))) }>();
+    takes_nested_tuple::<{ core::direct_const_arg!((N, (N, T::ASSOC))) }>();
 }
 
 fn main() {}

--- a/tests/ui/const-generics/mgca/tuple_expr_arg_unbounded_assoc_const.rs
+++ b/tests/ui/const-generics/mgca/tuple_expr_arg_unbounded_assoc_const.rs
@@ -1,4 +1,4 @@
-#![feature(min_generic_const_args, adt_const_params)]
+#![feature(min_generic_const_args, macroless_generic_const_args, adt_const_params)]
 
 // Regression test for an ICE in privacy checking while walking the `T` qself
 // of `T::ASSOC` inside a tuple const argument.

--- a/tests/ui/const-generics/mgca/tuple_expr_type_mismatch.rs
+++ b/tests/ui/const-generics/mgca/tuple_expr_type_mismatch.rs
@@ -3,6 +3,7 @@
 #![feature(
     adt_const_params,
     min_generic_const_args,
+    macroless_generic_const_args,
     unsized_const_params
 )]
 fn foo<const X: (bool, i32)>() {}

--- a/tests/ui/const-generics/mgca/tuple_expr_type_mismatch.stderr
+++ b/tests/ui/const-generics/mgca/tuple_expr_type_mismatch.stderr
@@ -1,23 +1,23 @@
 error: type annotations needed for the literal
-  --> $DIR/tuple_expr_type_mismatch.rs:13:14
+  --> $DIR/tuple_expr_type_mismatch.rs:14:14
    |
 LL |     foo::<{ (1, true) }>();
    |              ^
 
 error: expected `i32`, found const array
-  --> $DIR/tuple_expr_type_mismatch.rs:15:21
+  --> $DIR/tuple_expr_type_mismatch.rs:16:21
    |
 LL |     bar::<{ (1_u32, [1, 2]) }>();
    |                     ^^^^^^
 
 error: the constant `1` is not of type `char`
-  --> $DIR/tuple_expr_type_mismatch.rs:17:13
+  --> $DIR/tuple_expr_type_mismatch.rs:18:13
    |
 LL |     qux::<{ (1i32, 'a') }>();
    |             ^^^^^^^^^^^ expected `char`, found `i32`
 
 error: the constant `'a'` is not of type `i32`
-  --> $DIR/tuple_expr_type_mismatch.rs:17:13
+  --> $DIR/tuple_expr_type_mismatch.rs:18:13
    |
 LL |     qux::<{ (1i32, 'a') }>();
    |             ^^^^^^^^^^^ expected `i32`, found `char`

--- a/tests/ui/const-generics/mgca/type-const-free-value-type-mismatch.next.stderr
+++ b/tests/ui/const-generics/mgca/type-const-free-value-type-mismatch.next.stderr
@@ -10,7 +10,7 @@ error[E0284]: type annotations needed
 LL | fn f() -> [u8; const { N }] {}
    |           ^^^^^^^^^^^^^^^^^ cannot infer the value of the constant `_`
    |
-   = note: cannot satisfy `f::{constant#0}::{constant#0} == _`
+   = note: cannot satisfy `f::{constant#0} == _`
 
 error[E0308]: mismatched types
   --> $DIR/type-const-free-value-type-mismatch.rs:11:11

--- a/tests/ui/const-generics/mgca/type-const-inherent-value-type-mismatch.next.stderr
+++ b/tests/ui/const-generics/mgca/type-const-inherent-value-type-mismatch.next.stderr
@@ -4,7 +4,7 @@ error[E0284]: type annotations needed
 LL | fn f() -> [u8; const { Struct::N }] {}
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer the value of the constant `_`
    |
-   = note: cannot satisfy `f::{constant#0}::{constant#0} == _`
+   = note: cannot satisfy `f::{constant#0} == _`
 
 error: the constant `"this isn't a usize"` is not of type `usize`
   --> $DIR/type-const-inherent-value-type-mismatch.rs:13:5

--- a/tests/ui/const-generics/mgca/type-const-value-type-mismatch.rs
+++ b/tests/ui/const-generics/mgca/type-const-value-type-mismatch.rs
@@ -5,7 +5,7 @@
 //@[next] compile-flags: -Znext-solver
 //@ compile-flags: -Zvalidate-mir
 
-#![feature(min_generic_const_args)]
+#![feature(min_generic_const_args, macroless_generic_const_args)]
 
 pub struct A;
 

--- a/tests/ui/const-generics/mgca/type_as_const_in_array_len.rs
+++ b/tests/ui/const-generics/mgca/type_as_const_in_array_len.rs
@@ -1,6 +1,6 @@
 //! Regression test for <https://github.com/rust-lang/rust/issues/138132>
 
-#![feature(min_generic_const_args)]
+#![feature(min_generic_const_args, macroless_generic_const_args)]
 #![expect(incomplete_features)]
 
 struct B(Box<[u8; C]>);

--- a/tests/ui/const-generics/mgca/type_const-array-return.rs
+++ b/tests/ui/const-generics/mgca/type_const-array-return.rs
@@ -1,7 +1,7 @@
 //@ check-pass
 // This test should compile without an ICE.
 #![expect(incomplete_features)]
-#![feature(min_generic_const_args)]
+#![feature(min_generic_const_args, macroless_generic_const_args)]
 
 pub struct A;
 

--- a/tests/ui/const-generics/mgca/unexpected-fn-item-in-array.rs
+++ b/tests/ui/const-generics/mgca/unexpected-fn-item-in-array.rs
@@ -1,6 +1,6 @@
 // Make sure we don't ICE when encountering an fn item during lowering in mGCA.
 
-#![feature(min_generic_const_args)]
+#![feature(min_generic_const_args, macroless_generic_const_args)]
 
 trait A<T> {}
 

--- a/tests/ui/const-generics/mgca/unmarked-free-const.rs
+++ b/tests/ui/const-generics/mgca/unmarked-free-const.rs
@@ -1,6 +1,6 @@
 // regression test, used to ICE
 
-#![feature(min_generic_const_args)]
+#![feature(min_generic_const_args, macroless_generic_const_args)]
 #![allow(incomplete_features)]
 
 const N: usize = 4;

--- a/tests/ui/const-generics/mgca/wrapped_array_elem_type_mismatch.rs
+++ b/tests/ui/const-generics/mgca/wrapped_array_elem_type_mismatch.rs
@@ -1,5 +1,5 @@
 #![expect(incomplete_features)]
-#![feature(adt_const_params, min_generic_const_args)]
+#![feature(adt_const_params, min_generic_const_args, macroless_generic_const_args)]
 
 struct ArrWrap<const N: [u8; 1]>;
 

--- a/tests/ui/const-generics/mgca/wrong_type_const_arr_diag.rs
+++ b/tests/ui/const-generics/mgca/wrong_type_const_arr_diag.rs
@@ -1,6 +1,6 @@
 // This test causes ERROR: mismatched types [E0308]
 // and makes rustc to print array from const arguments
-#![feature(min_generic_const_args, adt_const_params)]
+#![feature(min_generic_const_args, macroless_generic_const_args, adt_const_params)]
 #![allow(incomplete_features)]
 
 struct TakesArr<const N: [u8; 1]>;

--- a/tests/ui/const-generics/mgca/wrong_type_const_arr_diag_trait.rs
+++ b/tests/ui/const-generics/mgca/wrong_type_const_arr_diag_trait.rs
@@ -1,6 +1,6 @@
 // This test causes ERROR: mismatched types [E0308]
 // and makes rustc to print array from const arguments
-#![feature(min_generic_const_args, adt_const_params, trivial_bounds)]
+#![feature(min_generic_const_args, macroless_generic_const_args, adt_const_params, trivial_bounds)]
 #![allow(incomplete_features)]
 
 trait Trait {

--- a/tests/ui/const-generics/min_adt_const_params/tuple_with_infer_arg.rs
+++ b/tests/ui/const-generics/min_adt_const_params/tuple_with_infer_arg.rs
@@ -1,7 +1,6 @@
 //@ check-pass
 
-#![feature(min_adt_const_params)]
-#![feature(min_generic_const_args)]
+#![feature(min_adt_const_params, min_generic_const_args, macroless_generic_const_args)]
 
 struct S<const X: (u32, u32)>;
 

--- a/tests/ui/const-generics/type-relative-path-144547.rs
+++ b/tests/ui/const-generics/type-relative-path-144547.rs
@@ -4,7 +4,7 @@
 //@[mgca] check-pass
 #![allow(incomplete_features)]
 #![feature(mgca_type_const_syntax)]
-#![cfg_attr(mgca, feature(min_generic_const_args))]
+#![cfg_attr(mgca, feature(min_generic_const_args, macroless_generic_const_args))]
 // FIXME(mgca) syntax is it's own feature flag before
 // expansion and is also an incomplete feature.
 //#![cfg_attr(mgca, expect(incomplete_features))]

--- a/tests/ui/feature-gates/feature-gate-macroless-generic-const-args.rs
+++ b/tests/ui/feature-gates/feature-gate-macroless-generic-const-args.rs
@@ -5,10 +5,8 @@ trait Trait {
 }
 
 // FIXME(mgca): add suggestion for mgca to this error
-fn foo<T: Trait>() -> [u8; core::direct_const_arg!(<T as Trait>::ASSOC)] {
+fn foo<T: Trait>() -> [u8; <T as Trait>::ASSOC] {
     //~^ ERROR generic parameters may not be used in const operations
-    //~| ERROR use of unstable library feature `min_generic_const_args` [E0658]
-    //~| ERROR expected expression, found `direct_const_arg!()` constant
     loop {}
 }
 

--- a/tests/ui/feature-gates/feature-gate-macroless-generic-const-args.stderr
+++ b/tests/ui/feature-gates/feature-gate-macroless-generic-const-args.stderr
@@ -1,25 +1,15 @@
-error[E0658]: use of unstable library feature `min_generic_const_args`
-  --> $DIR/feature-gate-min-generic-const-args.rs:8:28
-   |
-LL | fn foo<T: Trait>() -> [u8; core::direct_const_arg!(<T as Trait>::ASSOC)] {
-   |                            ^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #132980 <https://github.com/rust-lang/rust/issues/132980> for more information
-   = help: add `#![feature(min_generic_const_args)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
 error: generic parameters may not be used in const operations
-  --> $DIR/feature-gate-min-generic-const-args.rs:8:53
+  --> $DIR/feature-gate-macroless-generic-const-args.rs:8:29
    |
-LL | fn foo<T: Trait>() -> [u8; core::direct_const_arg!(<T as Trait>::ASSOC)] {
-   |                                                     ^ cannot perform const operation using `T`
+LL | fn foo<T: Trait>() -> [u8; <T as Trait>::ASSOC] {
+   |                             ^ cannot perform const operation using `T`
    |
    = note: type parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
    = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error[E0658]: `type const` syntax is experimental
-  --> $DIR/feature-gate-min-generic-const-args.rs:2:5
+  --> $DIR/feature-gate-macroless-generic-const-args.rs:2:5
    |
 LL |     type const ASSOC: usize;
    |     ^^^^^^^^^^
@@ -29,7 +19,7 @@ LL |     type const ASSOC: usize;
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: associated `type const` are unstable
-  --> $DIR/feature-gate-min-generic-const-args.rs:2:5
+  --> $DIR/feature-gate-macroless-generic-const-args.rs:2:5
    |
 LL |     type const ASSOC: usize;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -38,12 +28,6 @@ LL |     type const ASSOC: usize;
    = help: add `#![feature(min_generic_const_args)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error: expected expression, found `direct_const_arg!()` constant
-  --> $DIR/feature-gate-min-generic-const-args.rs:8:28
-   |
-LL | fn foo<T: Trait>() -> [u8; core::direct_const_arg!(<T as Trait>::ASSOC)] {
-   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: aborting due to 5 previous errors
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/object-lifetime/object-lifetime-default-inherent-gac.rs
+++ b/tests/ui/object-lifetime/object-lifetime-default-inherent-gac.rs
@@ -4,7 +4,12 @@
 
 // FIXME: Ideally, this test would be check-pass. See below for details.
 
-#![feature(min_generic_const_args, inherent_associated_types, generic_const_items)]
+#![feature(
+    min_generic_const_args,
+    macroless_generic_const_args,
+    inherent_associated_types,
+    generic_const_items
+)]
 #![expect(incomplete_features)]
 
 mod own { // the lifetime comes from the own generics

--- a/tests/ui/object-lifetime/object-lifetime-default-inherent-gac.stderr
+++ b/tests/ui/object-lifetime/object-lifetime-default-inherent-gac.stderr
@@ -1,5 +1,5 @@
 error[E0228]: cannot deduce the lifetime bound for this trait object type from context
-  --> $DIR/object-lifetime-default-inherent-gac.rs:19:48
+  --> $DIR/object-lifetime-default-inherent-gac.rs:24:48
    |
 LL |     fn check<'r>() where [(); Parent::CT::<'r, dyn super::Trait>]: {}
    |                                                ^^^^^^^^^^^^^^^^
@@ -10,7 +10,7 @@ LL |     fn check<'r>() where [(); Parent::CT::<'r, dyn super::Trait + /* 'a */>
    |                                                                 ++++++++++
 
 error[E0228]: cannot deduce the lifetime bound for this trait object type from context
-  --> $DIR/object-lifetime-default-inherent-gac.rs:32:50
+  --> $DIR/object-lifetime-default-inherent-gac.rs:37:50
    |
 LL |     fn check<'r>() where [(); Parent::<'r>::CT::<dyn super::Trait>]: {}
    |                                                  ^^^^^^^^^^^^^^^^

--- a/tests/ui/sanitizer/cfi/assoc-const-projection-issue-151878.rs
+++ b/tests/ui/sanitizer/cfi/assoc-const-projection-issue-151878.rs
@@ -4,7 +4,7 @@
 //@ build-pass
 //@ no-prefer-dynamic
 
-#![feature(min_generic_const_args, associated_type_defaults)]
+#![feature(min_generic_const_args, macroless_generic_const_args, associated_type_defaults)]
 #![expect(incomplete_features)]
 
 trait Trait {

--- a/tests/ui/transmutability/non_scalar_alignment_value.rs
+++ b/tests/ui/transmutability/non_scalar_alignment_value.rs
@@ -1,6 +1,4 @@
-#![feature(min_generic_const_args)]
-
-#![feature(transmutability)]
+#![feature(min_generic_const_args, macroless_generic_const_args, transmutability)]
 
 mod assert {
     use std::mem::{Assume, TransmuteFrom};

--- a/tests/ui/transmutability/non_scalar_alignment_value.stderr
+++ b/tests/ui/transmutability/non_scalar_alignment_value.stderr
@@ -1,23 +1,23 @@
 error: struct expression with missing field initialiser for `alignment`
-  --> $DIR/non_scalar_alignment_value.rs:14:32
+  --> $DIR/non_scalar_alignment_value.rs:12:32
    |
 LL |                     alignment: Assume {},
    |                                ^^^^^^^^^
 
 error: struct expression with missing field initialiser for `lifetimes`
-  --> $DIR/non_scalar_alignment_value.rs:14:32
+  --> $DIR/non_scalar_alignment_value.rs:12:32
    |
 LL |                     alignment: Assume {},
    |                                ^^^^^^^^^
 
 error: struct expression with missing field initialiser for `safety`
-  --> $DIR/non_scalar_alignment_value.rs:14:32
+  --> $DIR/non_scalar_alignment_value.rs:12:32
    |
 LL |                     alignment: Assume {},
    |                                ^^^^^^^^^
 
 error: struct expression with missing field initialiser for `validity`
-  --> $DIR/non_scalar_alignment_value.rs:14:32
+  --> $DIR/non_scalar_alignment_value.rs:12:32
    |
 LL |                     alignment: Assume {},
    |                                ^^^^^^^^^

--- a/tests/ui/type-alias/recursive-lazy-type-alias-ice-152633.rs
+++ b/tests/ui/type-alias/recursive-lazy-type-alias-ice-152633.rs
@@ -3,8 +3,7 @@
 //!
 //! Regression test for <https://github.com/rust-lang/rust/issues/152633>.
 
-#![feature(checked_type_aliases)]
-#![feature(min_generic_const_args)]
+#![feature(checked_type_aliases, min_generic_const_args, macroless_generic_const_args)]
 
 trait Trait {
     type const ASSOC: ();

--- a/tests/ui/type-alias/recursive-lazy-type-alias-ice-152633.stderr
+++ b/tests/ui/type-alias/recursive-lazy-type-alias-ice-152633.stderr
@@ -1,5 +1,5 @@
 error[E0275]: overflow normalizing the type alias `Arr2`
-  --> $DIR/recursive-lazy-type-alias-ice-152633.rs:12:1
+  --> $DIR/recursive-lazy-type-alias-ice-152633.rs:11:1
    |
 LL | type Arr2 = [usize; <Arr2 as Trait>::ASSOC];
    | ^^^^^^^^^

--- a/tests/ui/unpretty/struct-exprs-tuple-call-pretty-printing.rs
+++ b/tests/ui/unpretty/struct-exprs-tuple-call-pretty-printing.rs
@@ -1,7 +1,7 @@
 //@ compile-flags: -Zunpretty=hir
 //@ check-pass
 
-#![feature(min_generic_const_args, adt_const_params)]
+#![feature(min_generic_const_args, macroless_generic_const_args, adt_const_params)]
 #![expect(incomplete_features)]
 #![allow(dead_code)]
 

--- a/tests/ui/unpretty/struct-exprs-tuple-call-pretty-printing.stdout
+++ b/tests/ui/unpretty/struct-exprs-tuple-call-pretty-printing.stdout
@@ -3,7 +3,8 @@
 
 #![expect(incomplete_features)]
 #![allow(dead_code)]
-#![attr = Feature([min_generic_const_args#0, adt_const_params#0])]
+#![attr = Feature([min_generic_const_args#0, macroless_generic_const_args#0,
+adt_const_params#0])]
 extern crate std;
 #[attr = PreludeImport]
 use ::std::prelude::rust_2015::*;

--- a/tests/ui/use/import_trait_associated_item_bad.rs
+++ b/tests/ui/use/import_trait_associated_item_bad.rs
@@ -1,5 +1,4 @@
-#![feature(import_trait_associated_functions)]
-#![feature(min_generic_const_args)]
+#![feature(import_trait_associated_functions, min_generic_const_args, macroless_generic_const_args)]
 #![allow(incomplete_features)]
 
 trait Trait {

--- a/tests/ui/use/import_trait_associated_item_bad.stderr
+++ b/tests/ui/use/import_trait_associated_item_bad.stderr
@@ -1,5 +1,5 @@
 error[E0223]: ambiguous associated type
-  --> $DIR/import_trait_associated_item_bad.rs:11:15
+  --> $DIR/import_trait_associated_item_bad.rs:10:15
    |
 LL | type Alias1 = AssocTy;
    |               ^^^^^^^
@@ -10,7 +10,7 @@ LL | type Alias1 = <Example as Trait>::AssocTy;
    |               ++++++++++++++++++++
 
 error[E0223]: ambiguous associated type
-  --> $DIR/import_trait_associated_item_bad.rs:12:15
+  --> $DIR/import_trait_associated_item_bad.rs:11:15
    |
 LL | type Alias2 = self::AssocTy;
    |               ^^^^^^^^^^^^^
@@ -22,7 +22,7 @@ LL + type Alias2 = <Example as Trait>::AssocTy;
    |
 
 error[E0223]: ambiguous associated constant
-  --> $DIR/import_trait_associated_item_bad.rs:15:20
+  --> $DIR/import_trait_associated_item_bad.rs:14:20
    |
 LL | type Alias3 = [u8; CONST];
    |                    ^^^^^
@@ -33,7 +33,7 @@ LL | type Alias3 = [u8; <Example as Trait>::CONST];
    |                    ++++++++++++++++++++
 
 error[E0223]: ambiguous associated constant
-  --> $DIR/import_trait_associated_item_bad.rs:16:20
+  --> $DIR/import_trait_associated_item_bad.rs:15:20
    |
 LL | type Alias4 = [u8; self::CONST];
    |                    ^^^^^^^^^^^


### PR DESCRIPTION
tracking issue: https://github.com/rust-lang/rust/issues/159006

lots of description of what is happening here in the tracking issue, not gonna copypaste it into here :)

the test situation is that after discussion with boxy of whether our mgca tests should be:

- keep them under only `min_generic_const_args`, and add `direct_const_arg!()` where it's needed
- keep the code contents as-is, and add `#![feature(macroless_generic_const_args)]` where it's needed

the second seems more desirable, so that's what I did. There are still quite a few tests that only have `min_generic_const_args` without `macroless_generic_const_args` (140 of them, to be exact - `rg --files-without-match macroless_generic_const_args $(rg -g '*.rs' --files-with-matches min_generic_const_args tests) | wc -l`, and now 90 with `macroless_generic_const_args`)

r? @BoxyUwU 