### PR TITLE
Prevent compiletest from overwriting the linker for cross-built tests

### DIFF
--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -1899,7 +1899,7 @@ impl<'test> TestCx<'test> {
             {
                 compiler.arg(format!("-Clinker={linker}"));
             }
-        } else {
+        } else if !custom_target {
             self.maybe_add_external_args(&mut compiler, &self.config.target_rustcflags);
             if compiler_kind == CompilerKind::Rustc
                 && let Some(ref linker) = self.config.target_linker


### PR DESCRIPTION
Compiletest already avoids passing its default `--target` when a test provides one explicitly through compile-flags. However, it would still pass the globally configured target linker via `-Clinker`.

This is problematic for cross-built tests, where the effective compilation target can differ from compiletest's configured target. For example, when compiletest is running with `x86_64-unknown-linux-musl` as its configured target, a test that explicitly compiles for `nvptx64-nvidia-cuda` can incorrectly inherit the musl linker [(reference)](https://triage.rust-lang.org/gha-logs/rust-lang/rust/85506420007).

With this patch the configured target linker is only passed, when the test does not contain a custom `--target`. 

In terms of testing compiletest, a direct unit test would be ideal here. However, `make_compile_args` is currently difficult to exercise in isolation because it depends on a fully constructed `TestCx`. Adding such a test would require either non-trivial test setup or a refactor to make the argument construction testable. Therefore, I did _not_ add a test here.
