### PR TITLE
Look for the cdb architecture that corresponds to the target triple

### DIFF
--- a/src/bootstrap/src/core/debuggers/cdb.rs
+++ b/src/bootstrap/src/core/debuggers/cdb.rs
@@ -1,4 +1,3 @@
-use std::env;
 use std::path::PathBuf;
 
 use crate::core::config::TargetSelection;
@@ -8,18 +7,19 @@ pub(crate) struct Cdb {
 }
 
 /// We consult the registry to find the installed cdb.exe and try "Program Files" if that fails.
+#[cfg(windows)]
 pub(crate) fn discover_cdb(target: TargetSelection) -> Option<Cdb> {
-    if !cfg!(windows) || !target.ends_with("-pc-windows-msvc") {
+    if !target.ends_with("-pc-windows-msvc") {
         return None;
     }
 
-    let cdb_arch = if cfg!(target_arch = "x86") {
+    let cdb_arch = if target.starts_with("i686") {
         "x86"
-    } else if cfg!(target_arch = "x86_64") {
+    } else if target.starts_with("x86_64") {
         "x64"
-    } else if cfg!(target_arch = "aarch64") {
+    } else if target.starts_with("aarch64") || target.starts_with("arm64") {
         "arm64"
-    } else if cfg!(target_arch = "arm") {
+    } else if target.starts_with("arm") || target.starts_with("thumb") {
         "arm"
     } else {
         return None; // No compatible CDB.exe in the Windows 10 SDK
@@ -27,6 +27,11 @@ pub(crate) fn discover_cdb(target: TargetSelection) -> Option<Cdb> {
 
     let path = discover_cdb_registry(cdb_arch).or_else(|| discover_cdb_program_files(cdb_arch))?;
     Some(Cdb { cdb: path })
+}
+
+#[cfg(not(windows))]
+pub(crate) fn discover_cdb(_target: TargetSelection) -> Option<Cdb> {
+    None
 }
 
 #[cfg(windows)]
@@ -39,14 +44,11 @@ fn discover_cdb_registry(cdb_arch: &'static str) -> Option<PathBuf> {
     path.exists().then_some(path)
 }
 
-#[cfg(not(windows))]
-fn discover_cdb_registry(_cdb_arch: &'static str) -> Option<PathBuf> {
-    None
-}
-
+#[cfg(windows)]
 fn discover_cdb_program_files(cdb_arch: &'static str) -> Option<PathBuf> {
-    let mut path =
-        PathBuf::from(env::var_os("ProgramFiles(x86)").or_else(|| env::var_os("ProgramFiles"))?);
+    let mut path = PathBuf::from(
+        std::env::var_os("ProgramFiles(x86)").or_else(|| std::env::var_os("ProgramFiles"))?,
+    );
     path.extend([r"Windows Kits\10\Debuggers", cdb_arch, r"cdb.exe"]);
     path.exists().then_some(path)
 }


### PR DESCRIPTION
instead of the build triple

Debugging other architectures with the build target CDB is neither a common nor a good user experience - for example, when targeting i686 from a x86_64 build target, you get all the internal WOW64 events, which also break debuginfo tests. (See rust-lang/rust#159032)

Use the cdb.exe that corresponds to the target's architecture instead.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
