### PR TITLE
Skip trivial cast lint for trait object upcasts

### DIFF
--- a/compiler/rustc_hir_typeck/src/cast.rs
+++ b/compiler/rustc_hir_typeck/src/cast.rs
@@ -724,6 +724,10 @@ impl<'a, 'tcx> CastCheck<'tcx> {
     }
 
     fn trivial_cast_lint(&self, fcx: &FnCtxt<'a, 'tcx>) {
+        if self.is_non_trivial_ref_trait_object_upcast(fcx) {
+            return;
+        }
+
         let (numeric, lint) = if self.cast_ty.is_numeric() && self.expr_ty.is_numeric() {
             (true, lint::builtin::TRIVIAL_NUMERIC_CASTS)
         } else {
@@ -737,6 +741,35 @@ impl<'a, 'tcx> CastCheck<'tcx> {
             self.span,
             diagnostics::TrivialCast { numeric, expr_ty, cast_ty },
         );
+    }
+
+    // A trait-object upcast from a method receiver, such as
+    // `(other as &dyn Any).downcast_ref::<u32>()`,
+    // is not trivial, because it may change the method resolution, we want to skip the lint in this case.
+    // see issue #148219
+    fn is_non_trivial_ref_trait_object_upcast(&self, fcx: &FnCtxt<'a, 'tcx>) -> bool {
+        if !matches!(
+            (self.expr_ty.kind(), self.cast_ty.kind()),
+            (ty::Ref(_, from_ty, _), ty::Ref(_, to_ty, _))
+                if matches!(
+                    (from_ty.kind(), to_ty.kind()),
+                    (ty::Dynamic(from_data, _), ty::Dynamic(to_data, _)) if from_data != to_data
+                )
+        ) {
+            return false;
+        }
+
+        let hir::Node::Expr(cast_expr) = fcx.tcx.parent_hir_node(self.expr.hir_id) else {
+            return false;
+        };
+        let hir::Node::Expr(parent) = fcx.tcx.parent_hir_node(cast_expr.hir_id) else {
+            return false;
+        };
+
+        matches!(
+            parent.kind,
+            hir::ExprKind::MethodCall(_, receiver, ..) if receiver.hir_id == cast_expr.hir_id
+        )
     }
 
     fn expr_span_for_type_resolution(&self, fcx: &FnCtxt<'a, 'tcx>) -> Span {

--- a/tests/ui/lint/trivial-casts-dyn-any-issue-148219.rs
+++ b/tests/ui/lint/trivial-casts-dyn-any-issue-148219.rs
@@ -1,0 +1,27 @@
+//! Trait-object upcasts used as method receivers can affect method lookup.
+
+//@ check-pass
+
+#![warn(trivial_casts)]
+
+use std::any::Any;
+
+trait DynKey: Any {}
+
+impl<T: Any> DynKey for T {}
+
+fn method_receiver(other: &dyn DynKey) {
+    let _ = (other as &dyn Any).downcast_ref::<u32>();
+}
+
+fn plain_binding(other: &dyn DynKey) {
+    // This cast is trivial, but it is not used as a method receiver,
+    // so it should be linted.
+    let _ = other as &dyn Any;
+    //~^ WARN trivial cast
+}
+
+fn main() {
+    method_receiver(&0u32);
+    plain_binding(&0u32);
+}

--- a/tests/ui/lint/trivial-casts-dyn-any-issue-148219.stderr
+++ b/tests/ui/lint/trivial-casts-dyn-any-issue-148219.stderr
@@ -1,0 +1,15 @@
+warning: trivial cast: `&(dyn DynKey + 'static)` as `&(dyn Any + 'static)`
+  --> $DIR/trivial-casts-dyn-any-issue-148219.rs:20:13
+   |
+LL |     let _ = other as &dyn Any;
+   |             ^^^^^^^^^^^^^^^^^
+   |
+   = help: cast can be replaced by coercion; this might require a temporary variable
+note: the lint level is defined here
+  --> $DIR/trivial-casts-dyn-any-issue-148219.rs:5:9
+   |
+LL | #![warn(trivial_casts)]
+   |         ^^^^^^^^^^^^^
+
+warning: 1 warning emitted
+


### PR DESCRIPTION
Fixes rust-lang/rust#148219  

In the case like `(other as &dyn Any).downcast_ref::<T>()`, removing the cast can change method lookup, so the cast is not always trivial, so skip lint on it.

