### PR TITLE
Add codegen test for constant returns after local use

### DIFF
--- a/tests/codegen-llvm/issues/issue-91010.rs
+++ b/tests/codegen-llvm/issues/issue-91010.rs
@@ -1,0 +1,28 @@
+// Regression test for preserving constant return values after a use of the
+// same local through `black_box` or formatting.
+
+//@ compile-flags: -Copt-level=3
+
+#![crate_type = "lib"]
+
+use std::hint::black_box;
+
+// CHECK-LABEL: @black_box_ref_constant
+#[no_mangle]
+pub fn black_box_ref_constant() -> i32 {
+    let x = 1;
+    black_box(&x);
+
+    // CHECK: ret i32 1
+    x
+}
+
+// CHECK-LABEL: @format_ref_constant
+#[no_mangle]
+pub fn format_ref_constant() -> i32 {
+    let x = 1;
+    println!("{}", x);
+
+    // CHECK: ret i32 1
+    x
+}


### PR DESCRIPTION
Closes rust-lang/rust#91010