### PR TITLE
Add `io::ErrorKind::InputOutputError`

### DIFF
--- a/library/core/src/io/error.rs
+++ b/library/core/src/io/error.rs
@@ -951,6 +951,14 @@ pub enum ErrorKind {
     #[unstable(feature = "io_error_too_many_open_files", issue = "158319")]
     TooManyOpenFiles,
 
+    /// A low-level input/output error.
+    ///
+    /// This usually indicates a hardware or device-level failure, such as a bad
+    /// disk sector or a removed device, but the operating system may also report
+    /// it for other low-level I/O conditions.
+    #[unstable(feature = "io_error_input_output_error", issue = "159066")]
+    InputOutputError,
+
     // "Unusual" error kinds which do not correspond simply to (sets
     // of) OS error codes, should be added just above this comment.
     // `Other` and `Uncategorized` should remain at the end:
@@ -1001,6 +1009,7 @@ impl ErrorKind {
             FilesystemLoop => "filesystem loop or indirection limit (e.g. symlink loop)",
             HostUnreachable => "host unreachable",
             InProgress => "in progress",
+            InputOutputError => "input/output error",
             Interrupted => "operation interrupted",
             InvalidData => "invalid data",
             InvalidFilename => "invalid filename",
@@ -1093,6 +1102,7 @@ impl ErrorKind {
             OutOfMemory,
             InProgress,
             TooManyOpenFiles,
+            InputOutputError,
             Uncategorized,
         })
     }

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -356,6 +356,7 @@
 #![feature(hint_must_use)]
 #![feature(int_from_ascii)]
 #![feature(io_error_inprogress)]
+#![feature(io_error_input_output_error)]
 #![feature(io_error_more)]
 #![feature(io_error_too_many_open_files)]
 #![feature(io_error_uncategorized)]

--- a/library/std/src/sys/fs/vexos.rs
+++ b/library/std/src/sys/fs/vexos.rs
@@ -545,7 +545,7 @@ fn map_fresult(fresult: vex_sdk::FRESULT) -> io::Result<()> {
     match fresult {
         vex_sdk::FRESULT::FR_OK => Ok(()),
         vex_sdk::FRESULT::FR_DISK_ERR => Err(io::const_error!(
-            io::ErrorKind::Uncategorized,
+            io::ErrorKind::InputOutputError,
             "internal function reported an unrecoverable hard error",
         )),
         vex_sdk::FRESULT::FR_INT_ERR => Err(io::const_error!(

--- a/library/std/src/sys/io/error/unix.rs
+++ b/library/std/src/sys/io/error/unix.rs
@@ -177,6 +177,7 @@ pub fn decode_error_kind(errno: i32) -> io::ErrorKind {
         libc::EINPROGRESS => InProgress,
         libc::EMFILE | libc::ENFILE => TooManyOpenFiles,
         libc::EOPNOTSUPP => Unsupported,
+        libc::EIO => InputOutputError,
 
         libc::EACCES | libc::EPERM => PermissionDenied,
 

--- a/library/std/src/sys/io/error/windows.rs
+++ b/library/std/src/sys/io/error/windows.rs
@@ -64,6 +64,7 @@ pub fn decode_error_kind(errno: i32) -> io::ErrorKind {
         c::ERROR_TOO_MANY_OPEN_FILES => return TooManyOpenFiles,
         c::ERROR_FILENAME_EXCED_RANGE => return InvalidFilename,
         c::ERROR_CANT_RESOLVE_FILENAME => return FilesystemLoop,
+        c::ERROR_IO_DEVICE => return InputOutputError,
         _ => {}
     }
 


### PR DESCRIPTION
Adds an unstable `io::ErrorKind::InputOutputError` for low-level I/O failures.

`EIO` currently decodes to `ErrorKind::Uncategorized`, so stable code cannot tell that an operation failed at the low-level I/O layer without inspecting `raw_os_error()` and a platform-specific `libc`/`windows-sys` constant.

Implements the accepted ACP rust-lang/libs-team#824. The variant name is still open for bikeshedding before stabilization (see the ACP); this uses `InputOutputError` as accepted for now.

The variant maps:
- `EIO` on Unix, WASI, and teeos
- `ERROR_IO_DEVICE` on Windows
- `FR_DISK_ERR` on VEXos

I didn't add a test, since the decode tables don't have one today (same as rust-lang/rust#158326).

Tracking issue: rust-lang/rust#159066

r? libs
