### PR TITLE
bootstrap: honor suite skips for coverage modes

### DIFF
--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -46,6 +46,8 @@ use crate::{CLang, CodegenBackendKind, GitRepo, Mode, PathSet, TestTarget, envif
 
 mod compiletest;
 pub mod failed_tests;
+#[cfg(test)]
+mod tests;
 
 /// Runs `cargo test` on various internal tools used by bootstrap.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -1958,6 +1960,11 @@ impl Coverage {
     const SUITE: &'static str = "coverage";
     const ALL_MODES: &[CompiletestMode] =
         &[CompiletestMode::CoverageMap, CompiletestMode::CoverageRun];
+
+    fn skips_all_modes(skip: &[PathBuf]) -> bool {
+        let path = Path::new(Self::PATH);
+        skip.iter().any(|skip| path.starts_with(skip) || path.ends_with(skip))
+    }
 }
 
 impl Step for Coverage {
@@ -1983,6 +1990,10 @@ impl Step for Coverage {
     }
 
     fn make_run(run: RunConfig<'_>) {
+        if Self::skips_all_modes(&run.builder.config.skip) {
+            return;
+        }
+
         let compiler = run.builder.compiler(run.builder.top_stage, run.build_triple());
         let target = run.target;
 
@@ -2015,13 +2026,6 @@ impl Step for Coverage {
         modes.retain(|mode| {
             !run.builder.config.skip.iter().any(|skip| skip == Path::new(mode.as_str()))
         });
-
-        // FIXME(Zalathar): Make these commands skip all coverage tests, as expected:
-        // - `./x test --skip=tests`
-        // - `./x test --skip=tests/coverage`
-        // - `./x test --skip=coverage`
-        // Skip handling currently doesn't have a way to know that skipping the coverage
-        // suite should also skip the `coverage-map` and `coverage-run` aliases.
 
         for mode in modes {
             run.builder.ensure(Coverage { compiler, target, mode });

--- a/src/bootstrap/src/core/build_steps/test/tests.rs
+++ b/src/bootstrap/src/core/build_steps/test/tests.rs
@@ -1,0 +1,23 @@
+use std::path::PathBuf;
+
+use super::Coverage;
+
+#[test]
+fn coverage_skip_matches_suite_paths() {
+    for path in ["tests", "tests/coverage", "coverage"] {
+        assert!(
+            Coverage::skips_all_modes(&[PathBuf::from(path)]),
+            "{path} should skip all coverage tests"
+        );
+    }
+}
+
+#[test]
+fn coverage_skip_preserves_other_modes() {
+    for path in ["coverage-map", "coverage-run"] {
+        assert!(
+            !Coverage::skips_all_modes(&[PathBuf::from(path)]),
+            "{path} should only skip its corresponding coverage mode"
+        );
+    }
+}


### PR DESCRIPTION
The `Coverage` step registers both the `tests/coverage` suite path and the
`coverage-map` / `coverage-run` mode aliases.

During default test selection, central skip handling removes the suite path,
but leaves the mode aliases selected. As a result, these commands can still run
coverage tests:

- `./x test --skip=tests`
- `./x test --skip=tests/coverage`
- `./x test --skip=coverage`

This change checks whether the coverage suite itself was skipped before
processing the selected coverage modes. Mode-specific skips such as
`--skip=coverage-map` and `--skip=coverage-run` retain their existing behavior.

Regression tests cover both suite-level and mode-specific skip paths.

Tested with:

```text
python x.py test bootstrap --set build.submodules=false \
--test-args core::build_steps::test::tests::coverage_skip