### PR TITLE
pretty-print: use inline asm's actual macro name

### DIFF
--- a/compiler/rustc_ast_pretty/src/pprust/state/expr.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state/expr.rs
@@ -778,7 +778,7 @@ impl<'a> State<'a> {
             }
             ast::ExprKind::InlineAsm(a) => {
                 // FIXME: Print `builtin # asm` once macro `asm` uses `builtin_syntax`.
-                self.word("asm!");
+                self.word(format!("{}!", a.asm_macro.macro_name()));
                 self.print_inline_asm(a);
             }
             ast::ExprKind::FormatArgs(fmt) => {

--- a/compiler/rustc_hir_pretty/src/lib.rs
+++ b/compiler/rustc_hir_pretty/src/lib.rs
@@ -1740,7 +1740,7 @@ impl<'a> State<'a> {
                 self.print_expr_cond_paren(result, self.precedence(result) < ExprPrecedence::Jump);
             }
             hir::ExprKind::InlineAsm(asm) => {
-                self.word("asm!");
+                self.word(format!("{}!", asm.asm_macro.macro_name()));
                 self.print_inline_asm(asm);
             }
             hir::ExprKind::OffsetOf(container, fields) => {

--- a/tests/ui/unpretty/exhaustive-asm.expanded.stdout
+++ b/tests/ui/unpretty/exhaustive-asm.expanded.stdout
@@ -22,6 +22,10 @@ mod expressions {
             out(reg)
             _);
     }
+
+    /// ExprKind::InlineAsm, with the `naked_asm!` macro
+    #[unsafe(naked)]
+    extern "C" fn expr_naked_asm() { naked_asm!("ret"); }
 }
 
 mod items {

--- a/tests/ui/unpretty/exhaustive-asm.hir.stdout
+++ b/tests/ui/unpretty/exhaustive-asm.hir.stdout
@@ -21,6 +21,10 @@ mod expressions {
             out(reg)
             _);
     }
+
+    /// ExprKind::InlineAsm, with the `naked_asm!` macro
+    #[attr = Naked]
+    extern "C" fn expr_naked_asm() { naked_asm!("ret"); }
 }
 
 mod items {

--- a/tests/ui/unpretty/exhaustive-asm.rs
+++ b/tests/ui/unpretty/exhaustive-asm.rs
@@ -21,6 +21,12 @@ mod expressions {
             tmp = out(reg) _,
         );
     }
+
+    /// ExprKind::InlineAsm, with the `naked_asm!` macro
+    #[unsafe(naked)]
+    extern "C" fn expr_naked_asm() {
+        core::arch::naked_asm!("ret");
+    }
 }
 
 mod items {


### PR DESCRIPTION
`ExprKind::InlineAsm` was always printed as `asm!`, so `naked_asm!` was printed as `asm!` too. Use `asm_macro.macro_name()` in the AST and HIR pretty-printers to print the correct name.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
