### PR TITLE
std: fix FreeBSD environ() null deref under crt-static

### DIFF
--- a/library/std/src/sys/env/unix.rs
+++ b/library/std/src/sys/env/unix.rs
@@ -49,7 +49,19 @@ pub unsafe fn environ() -> *mut *const *const c_char {
 
     static ENVIRON: LazyLock<Environ> = LazyLock::new(|| {
         Environ(unsafe {
-            libc::dlsym(libc::RTLD_DEFAULT, c"environ".as_ptr()) as *mut *const *const c_char
+            let dynamic =
+                libc::dlsym(libc::RTLD_DEFAULT, c"environ".as_ptr()) as *mut *const *const c_char;
+            if !dynamic.is_null() {
+                dynamic
+            } else {
+                // Reading an `extern_weak` static yields the symbol's address
+                // (null if unresolved), not its contents.
+                unsafe extern "C" {
+                    #[linkage = "extern_weak"]
+                    static environ: *mut *const *const c_char;
+                }
+                environ
+            }
         })
     });
     ENVIRON.0


### PR DESCRIPTION
### The bug

On FreeBSD, `environ()` resolves the symbol with `dlsym(RTLD_DEFAULT, "environ")`, which needs a dynamic symbol table. A `-C target-feature=+crt-static` executable has none, so `dlsym` returns null, and every caller that walks the environment array dereferences that return before the null check further down, which only guards the array contents rather than the pointer itself. So `std::env::vars`/`vars_os` and `Command::spawn` segfault on a statically linked FreeBSD binary. `std::env::var` is unaffected, since it goes through `getenv`.

The `dlsym` accessor was added in rust-lang/rust#153718 to make `environ` resolve in cdylibs linked with `-Wl,--no-undefined`. That fixed the shared-library case but regressed the static-executable one, which is the only build of the two that lacks the dynamic symbol table `dlsym` depends on.

### The fix

When `dlsym` returns null, fall back to a weakly linked reference to `environ`. rustc lowers an `extern_weak` static to an indirection global that holds the symbol's address, so reading the static yields the address of `environ`, or null if nothing defines it. This is the same mechanism the `weak!` macro in `sys/pal/unix/weak` uses for function symbols.

The fallback covers both cases the accessor has to satisfy: in a static executable it resolves because `crt1.o` defines `environ`, and a weak undefined reference still links cleanly under `-Wl,--no-undefined`, the constraint `dlsym` was introduced for.

### Testing

No test. `x86_64-unknown-freebsd` is Tier 2, and its only CI job is a Linux-hosted cross-compile `dist` build, so FreeBSD binaries never execute in CI regardless of what ships. rust-lang/rust#151132 and rust-lang/rust#153718 (the PR this repairs) both landed FreeBSD `sys` fixes without one.

Fixes rust-lang/rust#158939

r? libs
