### PR TITLE
Add Arc/Rc::strong_count_from_raw

### DIFF
--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -1606,6 +1606,49 @@ impl<T: ?Sized> Rc<T> {
     pub unsafe fn decrement_strong_count(ptr: *const T) {
         unsafe { Self::decrement_strong_count_in(ptr, Global) }
     }
+
+    /// Gets the number of strong (`Rc`) pointers to the allocation behind the given raw pointer.
+    ///
+    /// This method does not consume or drop the `Rc` behind this pointer. To avoid a memory
+    /// leak, the pointer must be converted back to an `Rc` using [`Rc::from_raw`] or the
+    /// allocation must be released using [`Rc::decrement_strong_count`].
+    ///
+    /// # Safety
+    ///
+    /// The pointer must have been obtained through `Rc::into_raw` and must satisfy the
+    /// same layout requirements specified in [`Rc::from_raw_in`][from_raw_in].
+    /// The associated `Rc` instance must be valid (i.e. the strong count must be at
+    /// least 1) for the duration of this method, and `ptr` must point to a block of memory
+    /// allocated by the global allocator.
+    ///
+    /// [from_raw_in]: Rc::from_raw_in
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(arc_raw_get_strong)]
+    /// use std::rc::Rc;
+    ///
+    /// let five = Rc::new(5);
+    /// let _also_five = Rc::clone(&five);
+    /// let ptr = Rc::into_raw(five);
+    ///
+    /// unsafe {
+    ///     assert_eq!(2, Rc::strong_count_from_raw(ptr));
+    ///
+    ///     // Convert back to an `Rc` to avoid leaking memory.
+    ///     let five = Rc::from_raw(ptr);
+    ///     assert_eq!(2, Rc::strong_count(&five));
+    /// }
+    /// ```
+    #[inline]
+    #[unstable(feature = "arc_raw_get_strong", issue = "157021")]
+    pub unsafe fn strong_count_from_raw(ptr: *const T) -> usize {
+        let offset = unsafe { data_offset(ptr) };
+        // Reverse the offset to find the original RcInner.
+        let rc_ptr = unsafe { ptr.byte_sub(offset) as *mut RcInner<T> };
+        unsafe { (*rc_ptr).strong.get() }
+    }
 }
 
 impl<T: ?Sized, A: Allocator> Rc<T, A> {

--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -1606,6 +1606,46 @@ impl<T: ?Sized> Rc<T> {
     pub unsafe fn decrement_strong_count(ptr: *const T) {
         unsafe { Self::decrement_strong_count_in(ptr, Global) }
     }
+
+    /// Gets the number of strong (`Rc`) pointers to the allocation behind the given raw pointer.
+    ///
+    /// This method does not consume or drop the `Rc` behind this pointer.
+    ///
+    /// # Safety
+    ///
+    /// The pointer must point to (and have valid metadata for) the value inside a live `Rc`
+    /// allocation, such as a pointer returned by [`Rc::into_raw`],
+    /// [`Rc::into_raw_with_allocator`], or [`Rc::as_ptr`].
+    /// `T` must have the same alignment as that value.
+    /// The associated `Rc` instance must be valid (i.e. the strong count must be at
+    /// least 1) for the duration of this method.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(arc_raw_get_strong)]
+    /// use std::rc::Rc;
+    ///
+    /// let five = Rc::new(5);
+    /// let _also_five = Rc::clone(&five);
+    /// let ptr = Rc::into_raw(five);
+    ///
+    /// unsafe {
+    ///     assert_eq!(2, Rc::strong_count_from_raw(ptr));
+    ///
+    ///     // Convert back to an `Rc` to avoid leaking memory.
+    ///     let five = Rc::from_raw(ptr);
+    ///     assert_eq!(2, Rc::strong_count(&five));
+    /// }
+    /// ```
+    #[inline]
+    #[unstable(feature = "arc_raw_get_strong", issue = "157021")]
+    pub unsafe fn strong_count_from_raw(ptr: *const T) -> usize {
+        let offset = unsafe { data_offset(ptr) };
+        // Reverse the offset to find the original RcInner.
+        let rc_ptr = unsafe { ptr.byte_sub(offset) as *mut RcInner<T> };
+        unsafe { (*rc_ptr).strong.get() }
+    }
 }
 
 impl<T: ?Sized, A: Allocator> Rc<T, A> {

--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -1618,8 +1618,7 @@ impl<T: ?Sized> Rc<T> {
     /// The pointer must have been obtained through `Rc::into_raw` and must satisfy the
     /// same layout requirements specified in [`Rc::from_raw_in`][from_raw_in].
     /// The associated `Rc` instance must be valid (i.e. the strong count must be at
-    /// least 1) for the duration of this method, and `ptr` must point to a block of memory
-    /// allocated by the global allocator.
+    /// least 1) for the duration of this method.
     ///
     /// [from_raw_in]: Rc::from_raw_in
     ///

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -1766,6 +1766,57 @@ impl<T: ?Sized> Arc<T> {
     pub unsafe fn decrement_strong_count(ptr: *const T) {
         unsafe { Arc::decrement_strong_count_in(ptr, Global) }
     }
+
+    /// Gets the number of strong (`Arc`) pointers to the allocation behind the given raw
+    /// pointer.
+    ///
+    /// This method does not consume or drop the `Arc` behind this pointer. To avoid a memory
+    /// leak, the pointer must be converted back to an `Arc` using [`Arc::from_raw`] or the
+    /// allocation must be released using [`Arc::decrement_strong_count`].
+    ///
+    /// # Safety
+    ///
+    /// The pointer must have been obtained through `Arc::into_raw` and must satisfy the
+    /// same layout requirements specified in [`Arc::from_raw_in`][from_raw_in].
+    /// The associated `Arc` instance must be valid (i.e. the strong count must be at
+    /// least 1) for the duration of this method, and `ptr` must point to a block of memory
+    /// allocated by the global allocator.
+    ///
+    /// Using this method correctly also requires extra care: another thread can change the
+    /// strong count at any time, including between calling this method and acting on the
+    /// result.
+    ///
+    /// [from_raw_in]: Arc::from_raw_in
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(arc_raw_get_strong)]
+    /// use std::sync::Arc;
+    ///
+    /// let five = Arc::new(5);
+    /// let _also_five = Arc::clone(&five);
+    /// let ptr = Arc::into_raw(five);
+    ///
+    /// unsafe {
+    ///     // This assertion is deterministic because we haven't shared
+    ///     // the `Arc` between threads.
+    ///     assert_eq!(2, Arc::strong_count_from_raw(ptr));
+    ///
+    ///     // Convert back to an `Arc` to avoid leaking memory.
+    ///     let five = Arc::from_raw(ptr);
+    ///     assert_eq!(2, Arc::strong_count(&five));
+    /// }
+    /// ```
+    #[inline]
+    #[must_use]
+    #[unstable(feature = "arc_raw_get_strong", issue = "157021")]
+    pub unsafe fn strong_count_from_raw(ptr: *const T) -> usize {
+        let offset = unsafe { data_offset(ptr) };
+        // Reverse the offset to find the original ArcInner.
+        let arc_ptr = unsafe { ptr.byte_sub(offset) as *mut ArcInner<T> };
+        unsafe { (*arc_ptr).strong.load(Relaxed) }
+    }
 }
 
 impl<T: ?Sized, A: Allocator> Arc<T, A> {

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -1771,6 +1771,54 @@ impl<T: ?Sized> Arc<T> {
     pub unsafe fn decrement_strong_count(ptr: *const T) {
         unsafe { Arc::decrement_strong_count_in(ptr, Global) }
     }
+
+    /// Gets the number of strong (`Arc`) pointers to the allocation behind the given raw
+    /// pointer.
+    ///
+    /// This method does not consume or drop the `Arc` behind this pointer.
+    ///
+    /// # Safety
+    ///
+    /// The pointer must point to (and have valid metadata for) the value inside a live `Arc`
+    /// allocation, such as a pointer returned by [`Arc::into_raw`],
+    /// [`Arc::into_raw_with_allocator`], or [`Arc::as_ptr`].
+    /// `T` must have the same alignment as that value.
+    /// The associated `Arc` instance must be valid (i.e. the strong count must be at
+    /// least 1) for the duration of this method.
+    ///
+    /// Using this method correctly also requires extra care: another thread can change the
+    /// strong count at any time, including between calling this method and acting on the
+    /// result.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(arc_raw_get_strong)]
+    /// use std::sync::Arc;
+    ///
+    /// let five = Arc::new(5);
+    /// let _also_five = Arc::clone(&five);
+    /// let ptr = Arc::into_raw(five);
+    ///
+    /// unsafe {
+    ///     // This assertion is deterministic because we haven't shared
+    ///     // the `Arc` between threads.
+    ///     assert_eq!(2, Arc::strong_count_from_raw(ptr));
+    ///
+    ///     // Convert back to an `Arc` to avoid leaking memory.
+    ///     let five = Arc::from_raw(ptr);
+    ///     assert_eq!(2, Arc::strong_count(&five));
+    /// }
+    /// ```
+    #[inline]
+    #[must_use]
+    #[unstable(feature = "arc_raw_get_strong", issue = "157021")]
+    pub unsafe fn strong_count_from_raw(ptr: *const T) -> usize {
+        let offset = unsafe { data_offset(ptr) };
+        // Reverse the offset to find the original ArcInner.
+        let arc_ptr = unsafe { ptr.byte_sub(offset) as *mut ArcInner<T> };
+        unsafe { (*arc_ptr).strong.load(Relaxed) }
+    }
 }
 
 impl<T: ?Sized, A: Allocator> Arc<T, A> {

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -1779,8 +1779,7 @@ impl<T: ?Sized> Arc<T> {
     /// The pointer must have been obtained through `Arc::into_raw` and must satisfy the
     /// same layout requirements specified in [`Arc::from_raw_in`][from_raw_in].
     /// The associated `Arc` instance must be valid (i.e. the strong count must be at
-    /// least 1) for the duration of this method, and `ptr` must point to a block of memory
-    /// allocated by the global allocator.
+    /// least 1) for the duration of this method.
     ///
     /// Using this method correctly also requires extra care: another thread can change the
     /// strong count at any time, including between calling this method and acting on the


### PR DESCRIPTION
Tracking issue: rust-lang/rust#157021
Accepted ACP: rust-lang/libs-team#792

Adds `strong_count_from_raw` to `Arc` and `Rc`: read the strong count directly from a raw pointer, without reconstructing the smart pointer. The existing workaround is `ManuallyDrop::new(Arc::from_raw(ptr))` + `strong_count`, which takes ownership of a reference the caller doesn't own and could cause a double free if not using it properly, the detailed motivation of this in the ACP.

This PR implements strong count only, libs-api deferred weak count until there's a concrete use case.

The body reads the counter by walking back `data_offset` the way `from_raw_in` does, instead of materializing a temporary `Arc`/`Rc`, the call can't accidentally take ownership, and the `Relaxed` load matches `strong_count`. Lives next to `increment_strong_count`/`decrement_strong_count`.

Safety doc: pointer to the value of a live allocation with valid metadata (feeds `data_offset`),  such as pointer returned by `into_raw`, `into_raw_with_allocator`, `as_ptr`.  `T` aligned like that value, strong count ≥ 1 for the duration of the call.
