### PR TITLE
Stabilize String::from_utf8_lossy_owned

### DIFF
--- a/compiler/rustc_codegen_ssa/src/lib.rs
+++ b/compiler/rustc_codegen_ssa/src/lib.rs
@@ -3,11 +3,11 @@
 #![feature(file_buffered)]
 #![feature(negative_impls)]
 #![feature(option_into_flat_iter)]
-#![feature(string_from_utf8_lossy_owned)]
 #![feature(trait_alias)]
 #![feature(try_blocks)]
 #![recursion_limit = "256"]
 // tidy-alphabetical-end
+#![cfg_attr(bootstrap, feature(string_from_utf8_lossy_owned))]
 
 //! This crate contains codegen code that is used by all codegen backends (LLVM and others).
 //! The backend-agnostic functions of this crate use functions defined in various traits that

--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -668,7 +668,6 @@ impl String {
     /// Basic usage:
     ///
     /// ```
-    /// #![feature(string_from_utf8_lossy_owned)]
     /// // some bytes, in a vector
     /// let sparkle_heart = vec![240, 159, 146, 150];
     ///
@@ -680,7 +679,6 @@ impl String {
     /// Incorrect bytes:
     ///
     /// ```
-    /// #![feature(string_from_utf8_lossy_owned)]
     /// // some invalid bytes
     /// let input: Vec<u8> = b"Hello \xF0\x90\x80World".into();
     /// let output = String::from_utf8_lossy_owned(input);
@@ -689,7 +687,7 @@ impl String {
     /// ```
     #[must_use]
     #[cfg(not(no_global_oom_handling))]
-    #[unstable(feature = "string_from_utf8_lossy_owned", issue = "129436")]
+    #[stable(feature = "string_from_utf8_lossy_owned", since = "CURRENT_RUSTC_VERSION")]
     pub fn from_utf8_lossy_owned(v: Vec<u8>) -> String {
         if let Cow::Owned(string) = String::from_utf8_lossy(&v) {
             string
@@ -2252,7 +2250,6 @@ impl FromUtf8Error {
     /// # Examples
     ///
     /// ```
-    /// #![feature(string_from_utf8_lossy_owned)]
     /// // some invalid bytes
     /// let input: Vec<u8> = b"Hello \xF0\x90\x80World".into();
     ///
@@ -2269,7 +2266,7 @@ impl FromUtf8Error {
     /// ```
     #[must_use]
     #[cfg(not(no_global_oom_handling))]
-    #[unstable(feature = "string_from_utf8_lossy_owned", issue = "129436")]
+    #[stable(feature = "string_from_utf8_lossy_owned", since = "CURRENT_RUSTC_VERSION")]
     pub fn into_utf8_lossy(self) -> String {
         const REPLACEMENT: &str = "\u{FFFD}";
 

--- a/library/alloctests/tests/lib.rs
+++ b/library/alloctests/tests/lib.rs
@@ -25,7 +25,6 @@
 #![feature(iter_advance_by)]
 #![feature(iter_next_chunk)]
 #![feature(slice_partition_dedup)]
-#![feature(string_from_utf8_lossy_owned)]
 #![feature(string_remove_matches)]
 #![feature(const_btree_len)]
 #![feature(const_trait_impl)]


### PR DESCRIPTION
Passed FCP in rust-lang/rust#129436. Closes rust-lang/rust#129436.

r? libs