### PR TITLE
Clarify mid is a byte offset in str::split_at family docs

### DIFF
--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -829,7 +829,9 @@ impl str {
     /// string. It must also be on the boundary of a UTF-8 code point.
     ///
     /// The two slices returned go from the start of the string slice to `mid`,
-    /// and from `mid` to the end of the string slice.
+    /// and from `mid` to the end of the string slice. The `mid` byte is the
+    /// first byte of the second slice: the first slice covers `0..mid` and the
+    /// second slice covers `mid..self.len()`.
     ///
     /// To get mutable string slices instead, see the [`split_at_mut`]
     /// method.
@@ -869,7 +871,9 @@ impl str {
     /// string. It must also be on the boundary of a UTF-8 code point.
     ///
     /// The two slices returned go from the start of the string slice to `mid`,
-    /// and from `mid` to the end of the string slice.
+    /// and from `mid` to the end of the string slice. The `mid` byte is the
+    /// first byte of the second slice: the first slice covers `0..mid` and the
+    /// second slice covers `mid..self.len()`.
     ///
     /// To get immutable string slices instead, see the [`split_at`] method.
     ///
@@ -914,7 +918,9 @@ impl str {
     /// method returns `None` if that’s not the case.
     ///
     /// The two slices returned go from the start of the string slice to `mid`,
-    /// and from `mid` to the end of the string slice.
+    /// and from `mid` to the end of the string slice. The `mid` byte is the
+    /// first byte of the second slice: the first slice covers `0..mid` and the
+    /// second slice covers `mid..self.len()`.
     ///
     /// To get mutable string slices instead, see the [`split_at_mut_checked`]
     /// method.
@@ -954,7 +960,9 @@ impl str {
     /// method returns `None` if that’s not the case.
     ///
     /// The two slices returned go from the start of the string slice to `mid`,
-    /// and from `mid` to the end of the string slice.
+    /// and from `mid` to the end of the string slice. The `mid` byte is the
+    /// first byte of the second slice: the first slice covers `0..mid` and the
+    /// second slice covers `mid..self.len()`.
     ///
     /// To get immutable string slices instead, see the [`split_at_checked`] method.
     ///


### PR DESCRIPTION
The documentation for `split_at`, `split_at_mut`, `split_at_checked`, and `split_at_mut_checked` said the two slices go "from the start ... to `mid`, and from `mid` to the end", which did not state which slice the `mid` byte belongs to. Clarify that `mid` is the first byte of the second slice: the first slice covers `0..mid` and the second covers `mid..self.len()`.


<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
