### PR TITLE
Fix segfault in env access in statically linked FreeBSD binaries

### DIFF
--- a/library/std/src/sys/env/unix.rs
+++ b/library/std/src/sys/env/unix.rs
@@ -38,21 +38,19 @@ pub unsafe fn environ() -> *mut *const *const c_char {
     unsafe { libc::_NSGetEnviron() as *mut *const *const c_char }
 }
 
-// On FreeBSD, environ comes from CRT rather than libc
+// On FreeBSD, environ lives in crt1.o, not libc.so, so a shared library
+// cannot take a strong link-time reference to it (#153451), and dlsym cannot
+// find it in a statically linked executable, which has no dynamic symbol
+// table to search (#158939). A weak reference covers both: it binds at link
+// time in any executable, and in a shared library the runtime linker
+// resolves it against the environ the executable exports.
 #[cfg(target_os = "freebsd")]
 pub unsafe fn environ() -> *mut *const *const c_char {
-    use crate::sync::LazyLock;
-
-    struct Environ(*mut *const *const c_char);
-    unsafe impl Send for Environ {}
-    unsafe impl Sync for Environ {}
-
-    static ENVIRON: LazyLock<Environ> = LazyLock::new(|| {
-        Environ(unsafe {
-            libc::dlsym(libc::RTLD_DEFAULT, c"environ".as_ptr()) as *mut *const *const c_char
-        })
-    });
-    ENVIRON.0
+    unsafe extern "C" {
+        #[linkage = "extern_weak"]
+        static environ: *mut *const *const c_char;
+    }
+    unsafe { environ }
 }
 
 // Use the `environ` static which is part of POSIX.
@@ -75,14 +73,19 @@ pub fn env_read_lock() -> impl Drop {
 pub fn env() -> Env {
     unsafe {
         let _guard = env_read_lock();
-        let mut environ = *environ();
         let mut result = Vec::new();
-        if !environ.is_null() {
-            while !(*environ).is_null() {
-                if let Some(key_value) = parse(CStr::from_ptr(*environ).to_bytes()) {
-                    result.push(key_value);
+        // A null return means the platform could not locate the symbol;
+        // treat it like an empty environment.
+        let environ_ptr = environ();
+        if !environ_ptr.is_null() {
+            let mut environ = *environ_ptr;
+            if !environ.is_null() {
+                while !(*environ).is_null() {
+                    if let Some(key_value) = parse(CStr::from_ptr(*environ).to_bytes()) {
+                        result.push(key_value);
+                    }
+                    environ = environ.add(1);
                 }
-                environ = environ.add(1);
             }
         }
         return Env::new(result);


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/159112)*
<!-- homu-ignore:end -->

On FreeBSD `environ` is provided by the startup object linked into every executable (crt1.o) rather than by libc.so, so rust-lang/rust#153718 switched std to a dlsym lookup to keep shared libraries linkable with `-Wl,--no-undefined` (rust-lang/rust#153451). But dlsym needs a dynamic symbol table, which statically linked executables do not have: it returns null, and both `env::vars_os` and the `Command` spawn paths dereference it (rust-lang/rust#158939).

Resolve `environ` through a weak reference first: crt1.o defines it in every executable, statically linked ones included, and a weak undefined symbol does not break shared library links. Fall back to dlsym only when the weak reference is null, i.e. inside a shared library, where the dynamic lookup is available. Also stop dereferencing a null table pointer in `env()`, so an unresolvable `environ` degrades to an empty environment instead of a crash.

The `extern_weak` reference is the same mechanism std already uses for `__dso_handle` and `__cxa_thread_atexit_impl` in `sys/thread_local/destructors/linux_like.rs`.

## Testing

CI cannot execute FreeBSD tests (the target is cross-compiled only), so:

- `./x check library/std --target x86_64-unknown-freebsd` and a host check pass.
- The reproduction from rust-lang/rust#158939, built with `-C target-feature=+crt-static`, was executed on FreeBSD 14.4-RELEASE (amd64): built with stock 1.96.0 it segfaults on `vars_os()` (SIGSEGV, exit 139); built against std from this branch it iterates the environment, spawns a child with an inherited environment, and exits cleanly.
- Downstream, the crash was originally isolated and worked around in a production daemon whose CI runs the exact affected configuration (static, LTO) on a real FreeBSD kernel per commit; that harness stands ready to validate a nightly containing this fix.

This is a regression from stable to stable (1.95 -> 1.96) and may be worth a beta backport.

Fixes rust-lang/rust#158939
