### PR TITLE
Add regression test for $-prefixed fragment specifier in repetition

### DIFF
--- a/tests/ui/macros/macro-missing-fragment.rs
+++ b/tests/ui/macros/macro-missing-fragment.rs
@@ -17,6 +17,10 @@ macro_rules! accidental_dollar_prefix {
     ( $test:$tt ) => {}; //~ ERROR missing fragment
 }
 
+macro_rules! accidental_dollar_prefix_in_repetition {
+    ( $($test:$tt),* ) => {}; //~ ERROR missing fragment
+}
+
 fn main() {
     used_arm!();
     used_macro_unused_arm!();

--- a/tests/ui/macros/macro-missing-fragment.stderr
+++ b/tests/ui/macros/macro-missing-fragment.stderr
@@ -51,5 +51,19 @@ LL -     ( $test:$tt ) => {};
 LL +     ( $test:tt ) => {};
    |
 
-error: aborting due to 4 previous errors
+error: missing fragment specifier
+  --> $DIR/macro-missing-fragment.rs:21:15
+   |
+LL |     ( $($test:$tt),* ) => {};
+   |               ^
+   |
+   = note: fragment specifiers must be provided
+   = help: valid fragment specifiers are `ident`, `block`, `stmt`, `expr`, `pat`, `ty`, `lifetime`, `literal`, `path`, `meta`, `tt`, `item` and `vis`, along with `expr_2021` and `pat_param` for edition compatibility
+help: fragment specifiers should not be prefixed with `$`
+   |
+LL -     ( $($test:$tt),* ) => {};
+LL +     ( $($test:tt),* ) => {};
+   |
+
+error: aborting due to 5 previous errors
 


### PR DESCRIPTION
Fixes rust-lang/rust#157157.

The diagnostic was fixed in rust-lang/rust#155643, but the existing test only covers an accidental `$` before a fragment specifier at the top level of a matcher. 
This adds the equivalent case inside a repetition.

The new case reuses `$test:$tt` from the adjacent test so that repetition nesting is the only difference between the two cases.

Tested with:
- `./x test tests/ui/macros/macro-missing-fragment.rs`

This is my first contribution to this repository, so please let me know if I have missed any conventions or required steps or should make any additional changes.