### PR TITLE
Fix ICE on TypeTestError during speculative NLL solve

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/region_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/region_errors.rs
@@ -71,31 +71,43 @@ impl<'tcx> ConstraintDescription for ConstraintCategory<'tcx> {
 ///
 /// Usually we expect this to either be empty or contain a small number of items, so we can avoid
 /// allocation most of the time.
-pub(crate) struct RegionErrors<'tcx>(Vec<(RegionErrorKind<'tcx>, ErrorGuaranteed)>, TyCtxt<'tcx>);
+pub(crate) struct RegionErrors<'tcx> {
+    errors: Vec<(RegionErrorKind<'tcx>, ErrorGuaranteed)>,
+    tcx: TyCtxt<'tcx>,
+    speculative: bool,
+}
 
 impl<'tcx> RegionErrors<'tcx> {
     pub(crate) fn new(tcx: TyCtxt<'tcx>) -> Self {
-        Self(vec![], tcx)
+        Self { errors: vec![], tcx, speculative: false }
+    }
+    pub(crate) fn new_speculative(tcx: TyCtxt<'tcx>) -> Self {
+        Self { errors: vec![], tcx, speculative: true }
     }
     #[track_caller]
     pub(crate) fn push(&mut self, val: impl Into<RegionErrorKind<'tcx>>) {
         let val = val.into();
-        let guar = self.1.sess.dcx().delayed_bug(format!("{val:?}"));
-        self.0.push((val, guar));
+        let guar = if self.speculative {
+            #[allow(deprecated)]
+            ErrorGuaranteed::unchecked_error_guaranteed()
+        } else {
+            self.tcx.sess.dcx().delayed_bug(format!("{val:?}"))
+        };
+        self.errors.push((val, guar));
     }
     pub(crate) fn is_empty(&self) -> bool {
-        self.0.is_empty()
+        self.errors.is_empty()
     }
     pub(crate) fn into_iter(
         self,
     ) -> impl Iterator<Item = (RegionErrorKind<'tcx>, ErrorGuaranteed)> {
-        self.0.into_iter()
+        self.errors.into_iter()
     }
 }
 
 impl std::fmt::Debug for RegionErrors<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_tuple("RegionErrors").field(&self.0).finish()
+        f.debug_tuple("RegionErrors").field(&self.errors).finish()
     }
 }
 
@@ -320,13 +332,17 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
                         );
                         let origin =
                             SubregionOrigin::RelateParamBound(type_test_span, generic_ty, None);
-                        self.buffer_error(self.infcx.err_ctxt().construct_generic_bound_failure(
-                            self.body.source.def_id().expect_local(),
-                            type_test_span,
-                            Some(origin),
-                            self.name_regions(self.infcx.tcx, type_test.generic_kind),
-                            lower_bound_region,
-                        ));
+                        self.buffer_error(
+                            self.infcx.err_ctxt().construct_generic_bound_failure(
+                                self.infcx.tcx.typeck_root_def_id_local(
+                                    self.body.source.def_id().expect_local(),
+                                ),
+                                type_test_span,
+                                Some(origin),
+                                self.name_regions(self.infcx.tcx, type_test.generic_kind),
+                                lower_bound_region,
+                            ),
+                        );
                     } else {
                         // FIXME. We should handle this case better. It
                         // indicates that we have e.g., some region variable

--- a/compiler/rustc_borrowck/src/nll.rs
+++ b/compiler/rustc_borrowck/src/nll.rs
@@ -103,7 +103,7 @@ pub(crate) fn compute_closure_requirements_modulo_opaques<'tcx>(
         location_map,
     );
 
-    let (closure_region_requirements, _nll_errors) = regioncx.solve(infcx, body, None);
+    let (closure_region_requirements, _nll_errors) = regioncx.solve(infcx, body, None, true);
     closure_region_requirements
 }
 
@@ -180,7 +180,7 @@ pub(crate) fn compute_regions<'tcx>(
 
     // Solve the region constraints.
     let (closure_region_requirements, nll_errors) =
-        regioncx.solve(infcx, body, polonius_output.clone());
+        regioncx.solve(infcx, body, polonius_output.clone(), false);
 
     NllOutput {
         regioncx,

--- a/compiler/rustc_borrowck/src/region_infer/mod.rs
+++ b/compiler/rustc_borrowck/src/region_infer/mod.rs
@@ -485,11 +485,16 @@ impl<'tcx> RegionInferenceContext<'tcx> {
         infcx: &InferCtxt<'tcx>,
         body: &Body<'tcx>,
         polonius_output: Option<Box<PoloniusOutput>>,
+        speculative: bool,
     ) -> (Option<ClosureRegionRequirements<'tcx>>, RegionErrors<'tcx>) {
         let mir_def_id = body.source.def_id();
         self.propagate_constraints();
 
-        let mut errors_buffer = RegionErrors::new(infcx.tcx);
+        let mut errors_buffer = if speculative {
+            RegionErrors::new_speculative(infcx.tcx)
+        } else {
+            RegionErrors::new(infcx.tcx)
+        };
 
         // If this is a nested body, we propagate unsatisfied
         // outlives constraints to the parent body instead of

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/region.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/region.rs
@@ -786,42 +786,49 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             let (type_scope, type_param_sugg_span) = match bound_kind {
                 GenericKind::Param(param) => {
                     let generics = self.tcx.generics_of(generic_param_scope);
-                    let type_param = generics.type_param(param, self.tcx);
-                    let def_id = type_param.def_id.expect_local();
-                    let scope = self.tcx.local_def_id_to_hir_id(def_id).owner.def_id;
-                    // Get the `hir::Param` to verify whether it already has any bounds.
-                    // We do this to avoid suggesting code that ends up as `T: 'a'b`,
-                    // instead we suggest `T: 'a + 'b` in that case.
-                    let hir_generics = self.tcx.hir_get_generics(scope).unwrap();
-                    let sugg_span = match hir_generics.bounds_span_for_suggestions(def_id) {
-                        Some((span, open_paren_sp)) => {
-                            Some((span, LifetimeSuggestion::NeedsPlus(open_paren_sp)))
-                        }
-                        // If `param` corresponds to `Self`, no usable suggestion span.
-                        None if generics.has_self && param.index == 0 => None,
-                        None => {
-                            let mut colon_flag = false;
-                            let span = if let Some(param) =
-                                hir_generics.params.iter().find(|param| param.def_id == def_id)
-                                && let ParamName::Plain(ident) = param.name
-                            {
-                                if let Some(sp) = param.colon_span {
-                                    colon_flag = true;
-                                    sp.shrink_to_hi()
-                                } else {
-                                    ident.span.shrink_to_hi()
-                                }
-                            } else {
-                                let span = self.tcx.def_span(def_id);
-                                span.shrink_to_hi()
-                            };
-                            match colon_flag {
-                                true => Some((span, LifetimeSuggestion::HasColon)),
-                                false => Some((span, LifetimeSuggestion::NeedsColon)),
+                    if (param.index as usize) < generics.count()
+                        && let param_def = generics.param_at(param.index as usize, self.tcx)
+                        && matches!(param_def.kind, ty::GenericParamDefKind::Type { .. })
+                    {
+                        let type_param = generics.type_param(param, self.tcx);
+                        let def_id = type_param.def_id.expect_local();
+                        let scope = self.tcx.local_def_id_to_hir_id(def_id).owner.def_id;
+                        // Get the `hir::Param` to verify whether it already has any bounds.
+                        // We do this to avoid suggesting code that ends up as `T: 'a'b`,
+                        // instead we suggest `T: 'a + 'b` in that case.
+                        let hir_generics = self.tcx.hir_get_generics(scope).unwrap();
+                        let sugg_span = match hir_generics.bounds_span_for_suggestions(def_id) {
+                            Some((span, open_paren_sp)) => {
+                                Some((span, LifetimeSuggestion::NeedsPlus(open_paren_sp)))
                             }
-                        }
-                    };
-                    (scope, sugg_span)
+                            // If `param` corresponds to `Self`, no usable suggestion span.
+                            None if generics.has_self && param.index == 0 => None,
+                            None => {
+                                let mut colon_flag = false;
+                                let span = if let Some(param) =
+                                    hir_generics.params.iter().find(|param| param.def_id == def_id)
+                                    && let ParamName::Plain(ident) = param.name
+                                {
+                                    if let Some(sp) = param.colon_span {
+                                        colon_flag = true;
+                                        sp.shrink_to_hi()
+                                    } else {
+                                        ident.span.shrink_to_hi()
+                                    }
+                                } else {
+                                    let span = self.tcx.def_span(def_id);
+                                    span.shrink_to_hi()
+                                };
+                                match colon_flag {
+                                    true => Some((span, LifetimeSuggestion::HasColon)),
+                                    false => Some((span, LifetimeSuggestion::NeedsColon)),
+                                }
+                            }
+                        };
+                        (scope, sugg_span)
+                    } else {
+                        (generic_param_scope, None)
+                    }
                 }
                 _ => (generic_param_scope, None),
             };

--- a/tests/ui/borrowck/ice-speculative-type-test-issue-159100.rs
+++ b/tests/ui/borrowck/ice-speculative-type-test-issue-159100.rs
@@ -1,0 +1,9 @@
+//@ check-pass
+//@ edition: 2021
+
+#![feature(generic_const_exprs)]
+//~^ WARNING the feature `generic_const_exprs` is incomplete
+
+fn main() {
+    async { std::any::TypeId::of::<[u8; 1 << 3]> };
+}


### PR DESCRIPTION
This PR prevents registering a delayed bug during speculative NLL solve runs.

When solving NLL regions in helper/speculative contexts (e.g. compute_closure_requirements_modulo_opaques), any error generated is ignored and not emitted to the user. Registering a delayed bug for these ignored errors causes the compiler to panic/ICE at the end of compilation when no error has been emitted. This PR adds a speculative flag to prevent registering delayed bugs in such scenarios.