### PR TITLE
[perf] Allow cross-crate inlining through explicitly inline trait calls

### DIFF
--- a/compiler/rustc_mir_transform/src/cross_crate_inline.rs
+++ b/compiler/rustc_mir_transform/src/cross_crate_inline.rs
@@ -1,12 +1,12 @@
 use rustc_hir::attrs::InlineAttr;
 use rustc_hir::def::DefKind;
-use rustc_hir::def_id::LocalDefId;
+use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_hir::{self as hir, find_attr};
 use rustc_middle::bug;
 use rustc_middle::mir::visit::Visitor;
 use rustc_middle::mir::*;
 use rustc_middle::query::Providers;
-use rustc_middle::ty::TyCtxt;
+use rustc_middle::ty::{self, GenericArgsRef, InstanceKind, TyCtxt};
 use rustc_session::config::{InliningThreshold, OptLevel};
 
 use crate::{inline, pass_manager as pm};
@@ -100,13 +100,19 @@ fn cross_crate_inlinable(tcx: TyCtxt<'_>, def_id: LocalDefId) -> bool {
     };
 
     let mir = tcx.optimized_mir(def_id);
-    let mut checker =
-        CostChecker { tcx, callee_body: mir, calls: 0, statements: 0, landing_pads: 0, resumes: 0 };
+    let mut checker = CostChecker {
+        tcx,
+        typing_env: None,
+        callee_body: mir,
+        calls: 0,
+        statements: 0,
+        landing_pads: 0,
+        resumes: 0,
+        statements_threshold: threshold,
+    };
     checker.visit_body(mir);
-    checker.calls == 0
-        && checker.resumes == 0
-        && checker.landing_pads == 0
-        && checker.statements <= threshold
+
+    checker.cost_allows_cross_crate_inlining()
 }
 
 // The threshold that CostChecker computes is balancing the desire to make more things
@@ -120,11 +126,64 @@ fn cross_crate_inlinable(tcx: TyCtxt<'_>, def_id: LocalDefId) -> bool {
 
 struct CostChecker<'b, 'tcx> {
     tcx: TyCtxt<'tcx>,
+    /// Computed only if the body contains a trait call that needs instance resolution.
+    typing_env: Option<ty::TypingEnv<'tcx>>,
     callee_body: &'b Body<'tcx>,
     calls: usize,
     statements: usize,
     landing_pads: usize,
     resumes: usize,
+    statements_threshold: usize,
+}
+
+impl<'tcx> CostChecker<'_, 'tcx> {
+    fn cost_allows_cross_crate_inlining(&self) -> bool {
+        self.calls == 0
+            && self.landing_pads == 0
+            && self.resumes == 0
+            && self.statements <= self.statements_threshold
+    }
+
+    fn typing_env(&mut self) -> ty::TypingEnv<'tcx> {
+        *self.typing_env.get_or_insert_with(|| self.callee_body.typing_env(self.tcx))
+    }
+
+    /// Whether the call to the given item can be ignored for call-counting purposes
+    /// in cross-crate inlining cost analysis.
+    fn is_trait_call_ignorable_for_cross_crate_inlining(
+        &mut self,
+        def_id: DefId,
+        args: GenericArgsRef<'tcx>,
+    ) -> bool {
+        let tcx = self.tcx;
+
+        if tcx.trait_of_assoc(def_id).is_none() {
+            return false;
+        }
+
+        let typing_env = self.typing_env();
+        let Some((instance, _)) =
+            inline::try_resolve_call_instance(tcx, typing_env, def_id, ty::Binder::dummy(args))
+        else {
+            return false;
+        };
+
+        let InstanceKind::Item(_) = instance.def else {
+            return false;
+        };
+
+        // `#[inline]` is ignored on externally exported functions.
+        let codegen_fn_attrs = tcx.codegen_instance_attrs(instance.def);
+        if codegen_fn_attrs.contains_extern_indicator() {
+            return false;
+        }
+
+        match codegen_fn_attrs.inline {
+            InlineAttr::Always | InlineAttr::Force { .. } => true,
+            InlineAttr::Hint => !matches!(tcx.sess.opts.optimize, OptLevel::No),
+            InlineAttr::None | InlineAttr::Never => false,
+        }
+    }
 }
 
 impl<'tcx> Visitor<'tcx> for CostChecker<'_, 'tcx> {
@@ -155,10 +214,24 @@ impl<'tcx> Visitor<'tcx> for CostChecker<'_, 'tcx> {
                 // But there are a handful of intrinsics such as raw_eq that should not block
                 // cross-crate-inlining. Adding a broad exception for all intrinsics benchmarks well
                 // and seems more sustainable than an ever-growing list of intrinsics to ignore.
-                if let Some((fn_def_id, _)) = func.const_fn_def()
-                    && find_attr!(tcx, fn_def_id, RustcIntrinsic)
-                {
-                    return;
+                //
+                // Another exception is statically dispatched trait calls whose selected
+                // implementations are explicitly `#[inline]`. Resolving them here
+                // prevents such calls from disqualifying an otherwise-small enclosing function.
+                if let Some((fn_def_id, args)) = func.const_fn_def() {
+                    if find_attr!(tcx, fn_def_id, RustcIntrinsic) {
+                        return;
+                    }
+
+                    // Only perform the potentially-expensive resolution
+                    // if we haven't already given up (or are about to give up)
+                    // on cross-crate inlining due to other disqualifying findings.
+                    if self.cost_allows_cross_crate_inlining()
+                        && !matches!(unwind, UnwindAction::Cleanup(_))
+                        && self.is_trait_call_ignorable_for_cross_crate_inlining(fn_def_id, args)
+                    {
+                        return;
+                    }
                 }
                 self.calls += 1;
                 if let UnwindAction::Cleanup(_) = unwind {

--- a/compiler/rustc_mir_transform/src/inline.rs
+++ b/compiler/rustc_mir_transform/src/inline.rs
@@ -526,6 +526,23 @@ fn process_blocks<'tcx, I: Inliner<'tcx>>(
     }
 }
 
+pub(super) fn try_resolve_call_instance<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    typing_env: ty::TypingEnv<'tcx>,
+    def_id: DefId,
+    args: ty::Binder<'tcx, ty::GenericArgsRef<'tcx>>,
+) -> Option<(Instance<'tcx>, ty::GenericArgsRef<'tcx>)> {
+    // To resolve an instance its args have to be fully normalized.
+    let normalized_args = tcx
+        .try_normalize_erasing_regions(typing_env, Unnormalized::new_wip(args))
+        .ok()?
+        .no_bound_vars()
+        .unwrap();
+    let instance =
+        Instance::try_resolve(tcx, typing_env, def_id, normalized_args).ok().flatten()?;
+    Some((instance, normalized_args))
+}
+
 fn resolve_callsite<'tcx, I: Inliner<'tcx>>(
     inliner: &I,
     caller_body: &Body<'tcx>,
@@ -545,14 +562,8 @@ fn resolve_callsite<'tcx, I: Inliner<'tcx>>(
                 return None;
             }
 
-            // To resolve an instance its args have to be fully normalized.
-            let args = tcx
-                .try_normalize_erasing_regions(inliner.typing_env(), Unnormalized::new_wip(args))
-                .ok()?
-                .no_bound_vars()
-                .unwrap();
-            let mut callee =
-                Instance::try_resolve(tcx, inliner.typing_env(), def_id, args).ok().flatten()?;
+            let (mut callee, args) =
+                try_resolve_call_instance(tcx, inliner.typing_env(), def_id, args)?;
 
             if let InstanceKind::Virtual(..) = callee.def {
                 return None;

--- a/tests/codegen-llvm/cross-crate-inlining/auxiliary/leaf.rs
+++ b/tests/codegen-llvm/cross-crate-inlining/auxiliary/leaf.rs
@@ -28,3 +28,105 @@ pub fn leaf_with_intrinsic(a: &[u64; 2], b: &[u64; 2]) -> bool {
 pub fn leaf_with_assert(a: i32, b: i32) -> i32 {
     a / b
 }
+
+pub trait FindToken<T> {
+    fn find_token(&self, token: T) -> bool;
+}
+
+// This function's optimized MIR contains only statically dispatched trait calls.
+// Their selected implementations are marked inline.
+impl FindToken<char> for &str {
+    fn find_token(&self, token: char) -> bool {
+        self.chars().any(|character| character == token)
+    }
+}
+
+pub fn free_find_token(input: &str, token: char) -> bool {
+    input.chars().any(|character| character == token)
+}
+
+// This function's optimized MIR contains multiple statically dispatched trait calls.
+// Their selected implementations are marked inline.
+pub fn multiple_inline_trait_calls(input: &str, first: char, second: char) -> bool {
+    input.chars().any(|character| character == first)
+        && input.chars().any(|character| character == second)
+}
+
+pub struct InherentFindToken;
+
+impl InherentFindToken {
+    pub fn find_token(input: &str, token: char) -> bool {
+        // Keep this distinct from `free_find_token` so LLVM cannot alias their definitions.
+        !input.chars().any(|character| character == token)
+    }
+}
+
+pub struct NonInlineTraitCall;
+
+pub trait NonInlineTrait {
+    fn call(&self, value: u32) -> u32;
+}
+
+impl NonInlineTrait for NonInlineTraitCall {
+    #[inline(never)]
+    fn call(&self, value: u32) -> u32 {
+        value + 1
+    }
+}
+
+pub fn stem_with_non_inline_trait_call(value: u32) -> u32 {
+    <NonInlineTraitCall as NonInlineTrait>::call(&NonInlineTraitCall, value)
+}
+
+pub struct ExportedInlineTraitCall;
+
+pub trait ExportedInlineTrait {
+    fn exported_call(&self, value: u32) -> u32;
+}
+
+impl ExportedInlineTrait for ExportedInlineTraitCall {
+    #[expect(unused_attributes)]
+    #[inline]
+    #[no_mangle]
+    fn exported_call(&self, value: u32) -> u32 {
+        value + 2
+    }
+}
+
+pub fn stem_with_exported_inline_trait_call(value: u32) -> u32 {
+    <ExportedInlineTraitCall as ExportedInlineTrait>::exported_call(&ExportedInlineTraitCall, value)
+}
+
+pub trait Factory<T> {
+    type Item;
+}
+
+pub struct IntFactory;
+
+impl<T> Factory<T> for IntFactory {
+    type Item = usize;
+}
+
+pub trait InlineProjectionCall<T> {
+    fn inline_call(value: T) -> T;
+}
+
+impl<T> InlineProjectionCall<T> for () {
+    #[inline]
+    fn inline_call(value: T) -> T {
+        value
+    }
+}
+
+// This is a compile-only regression test.
+// The trivial bound makes normalization of the projected call argument fail
+// while `cross_crate_inlinable` examines this generic function.
+// The query must handle that failure without causing an ICE.
+pub fn caller_with_trivial_bound<T>(
+    value: <IntFactory as Factory<T>>::Item,
+) -> <IntFactory as Factory<T>>::Item
+where
+    IntFactory: Factory<T>,
+{
+    <() as InlineProjectionCall<<IntFactory as Factory<T>>::Item>>::inline_call(value)
+}

--- a/tests/codegen-llvm/cross-crate-inlining/auxiliary/trait_call_eligibility.rs
+++ b/tests/codegen-llvm/cross-crate-inlining/auxiliary/trait_call_eligibility.rs
@@ -1,0 +1,74 @@
+//@ compile-flags: -Copt-level=3 -Zinline-mir=no -Zcross-crate-inline-threshold=100
+
+#![crate_type = "lib"]
+#![crate_name = "trait_call_eligibility_aux"]
+
+// MIR inlining is disabled only in this auxiliary crate
+// so every call under classification remains in optimized MIR.
+// The downstream test crate uses normal O3 MIR inlining.
+
+pub struct ExplicitlyInline;
+
+pub trait ExplicitInlineCall {
+    fn call(value: u32) -> u32;
+}
+
+impl ExplicitInlineCall for ExplicitlyInline {
+    #[inline]
+    fn call(value: u32) -> u32 {
+        value.wrapping_add(10)
+    }
+}
+
+pub fn encloses_explicit_inline_trait_call(value: u32) -> u32 {
+    <ExplicitlyInline as ExplicitInlineCall>::call(value)
+}
+
+pub struct NotInline;
+
+pub trait NoInlineCall {
+    fn call(value: u32) -> u32;
+}
+
+impl NoInlineCall for NotInline {
+    fn call(value: u32) -> u32 {
+        value.wrapping_add(20)
+    }
+}
+
+pub fn encloses_no_inline_trait_call(value: u32) -> u32 {
+    <NotInline as NoInlineCall>::call(value)
+}
+
+#[inline]
+fn direct_inline_call(value: u32) -> u32 {
+    value.wrapping_add(30)
+}
+
+pub fn encloses_direct_inline_call(value: u32) -> u32 {
+    direct_inline_call(value)
+}
+
+pub trait InlineVirtualCall {
+    #[inline]
+    fn call(&self, value: u32) -> u32 {
+        value.wrapping_add(40)
+    }
+}
+
+// Resolution produces an `InstanceKind::Virtual`, which must not be treated
+// like the statically selected item above even though the provided trait method
+// is explicitly inline.
+pub fn encloses_inline_virtual_call(callee: &dyn InlineVirtualCall, value: u32) -> u32 {
+    <dyn InlineVirtualCall as InlineVirtualCall>::call(callee, value)
+}
+
+pub trait UnresolvedCall {
+    fn call(&self) -> u32;
+}
+
+// This is a compile-only regression test. Normalization succeeds, but instance selection cannot
+// choose an implementation for `T`; cross-crate classification must conservatively reject the call.
+pub fn caller_with_unresolved_selection<T: UnresolvedCall>(value: &T) -> u32 {
+    <T as UnresolvedCall>::call(value)
+}

--- a/tests/codegen-llvm/cross-crate-inlining/leaf-inlining.rs
+++ b/tests/codegen-llvm/cross-crate-inlining/leaf-inlining.rs
@@ -6,6 +6,7 @@
 extern crate leaf;
 
 // Check that we inline a leaf cross-crate call
+// CHECK-LABEL: @leaf_outer(
 #[no_mangle]
 pub fn leaf_outer() -> String {
     // CHECK-NOT: call {{.*}}leaf_fn
@@ -13,6 +14,7 @@ pub fn leaf_outer() -> String {
 }
 
 // Check that we do not inline a non-leaf cross-crate call
+// CHECK-LABEL: @stem_outer(
 #[no_mangle]
 pub fn stem_outer() -> String {
     // CHECK: call {{.*}}stem_fn
@@ -20,6 +22,7 @@ pub fn stem_outer() -> String {
 }
 
 // Check that we inline functions that call intrinsics
+// CHECK-LABEL: @leaf_with_intrinsic_outer(
 #[no_mangle]
 pub fn leaf_with_intrinsic_outer(a: &[u64; 2], b: &[u64; 2]) -> bool {
     // CHECK-NOT: call {{.*}}leaf_with_intrinsic
@@ -27,10 +30,64 @@ pub fn leaf_with_intrinsic_outer(a: &[u64; 2], b: &[u64; 2]) -> bool {
 }
 
 // Check that we inline functions with assert terminators
+// CHECK-LABEL: @leaf_with_assert(
 #[no_mangle]
 pub fn leaf_with_assert(a: i32, b: i32) -> i32 {
     // CHECK-NOT: call {{.*}}leaf_with_assert
     // CHECK: sdiv i32 %a, %b
     // CHECK-NOT: call {{.*}}leaf_with_assert
     leaf::leaf_with_assert(a, b)
+}
+
+// Check that we inline functions with only statically dispatched trait calls.
+// The selected implementations are inline.
+// CHECK-LABEL: @leaf_with_inline_trait_calls(
+#[no_mangle]
+pub fn leaf_with_inline_trait_calls(input: &str, token: char) -> bool {
+    // CHECK-NOT: call {{.*}}find_token
+    <&str as leaf::FindToken<char>>::find_token(&input, token)
+}
+
+// Check that a free function containing qualifying trait calls
+// can be inferred cross-crate-inlinable.
+// CHECK-LABEL: @free_fn_with_inline_trait_calls(
+#[no_mangle]
+pub fn free_fn_with_inline_trait_calls(input: &str, token: char) -> bool {
+    // CHECK-NOT: call {{.*}}free_find_token
+    leaf::free_find_token(input, token)
+}
+
+// Check that multiple qualifying trait calls do not prevent cross-crate inlining.
+// CHECK-LABEL: @multiple_inline_trait_calls(
+#[no_mangle]
+pub fn multiple_inline_trait_calls(input: &str, first: char, second: char) -> bool {
+    // CHECK-NOT: call {{.*}}multiple_inline_trait_calls
+    leaf::multiple_inline_trait_calls(input, first, second)
+}
+
+// Check that an inherent associated function containing qualifying trait calls
+// can be inferred cross-crate-inlinable.
+// CHECK-LABEL: @inherent_assoc_fn_with_inline_trait_calls(
+#[no_mangle]
+pub fn inherent_assoc_fn_with_inline_trait_calls(input: &str, token: char) -> bool {
+    // CHECK-NOT: call {{.*}}InherentFindToken.*find_token
+    leaf::InherentFindToken::find_token(input, token)
+}
+
+// Check that we do not inline functions with statically dispatched trait calls
+// when the selected implementations are not inline.
+// CHECK-LABEL: @stem_with_non_inline_trait_call(
+#[no_mangle]
+pub fn stem_with_non_inline_trait_call(value: u32) -> u32 {
+    // CHECK: call {{.*}}stem_with_non_inline_trait_call
+    leaf::stem_with_non_inline_trait_call(value)
+}
+
+// Check that we do not inline functions with statically dispatched trait calls
+// when the selected implementations are exported and therefore globally shared.
+// CHECK-LABEL: @stem_with_exported_inline_trait_call(
+#[no_mangle]
+pub fn stem_with_exported_inline_trait_call(value: u32) -> u32 {
+    // CHECK: call {{.*}}stem_with_exported_inline_trait_call
+    leaf::stem_with_exported_inline_trait_call(value)
 }

--- a/tests/codegen-llvm/cross-crate-inlining/trait-call-eligibility.rs
+++ b/tests/codegen-llvm/cross-crate-inlining/trait-call-eligibility.rs
@@ -1,0 +1,42 @@
+//@ compile-flags: -Copt-level=3 -Zcross-crate-inline-threshold=100
+//@ aux-build:trait_call_eligibility.rs
+
+#![crate_type = "lib"]
+
+extern crate trait_call_eligibility_aux as eligibility;
+
+// A statically selected, explicitly inline trait implementation
+// does not disqualify the enclosing body from inferred cross-crate inlining.
+// CHECK-LABEL: @explicit_inline_trait_call_outer(
+#[no_mangle]
+pub fn explicit_inline_trait_call_outer(value: u32) -> u32 {
+    // CHECK-NOT: call {{.*}}encloses_explicit_inline_trait_call
+    // CHECK: add i32 %value, 10
+    // CHECK-NOT: call {{.*}}encloses_explicit_inline_trait_call
+    eligibility::encloses_explicit_inline_trait_call(value)
+}
+
+// A selected implementation without an inline attribute remains disqualifying.
+// CHECK-LABEL: @no_inline_trait_call_outer(
+#[no_mangle]
+pub fn no_inline_trait_call_outer(value: u32) -> u32 {
+    // CHECK: call {{.*}}encloses_no_inline_trait_call
+    eligibility::encloses_no_inline_trait_call(value)
+}
+
+// A remaining direct call to an explicitly inline non-trait function
+// still prevents inferred cross-crate inlining.
+// CHECK-LABEL: @direct_inline_call_outer(
+#[no_mangle]
+pub fn direct_inline_call_outer(value: u32) -> u32 {
+    // CHECK: call {{.*}}encloses_direct_inline_call
+    eligibility::encloses_direct_inline_call(value)
+}
+
+// A virtual selection is not a statically selected item and is disqualifying.
+// CHECK-LABEL: @inline_virtual_call_outer(
+#[no_mangle]
+pub fn inline_virtual_call_outer(callee: &dyn eligibility::InlineVirtualCall, value: u32) -> u32 {
+    // CHECK: call {{.*}}encloses_inline_virtual_call
+    eligibility::encloses_inline_virtual_call(callee, value)
+}


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/159119)*
<!-- homu-ignore:end -->

Inferred cross-crate inlining currently makes an otherwise-unannotated function available to downstream crates only when its optimized MIR is small and contains no ordinary calls, with intrinsic calls exempted.

This misses small functions whose remaining calls are statically dispatched trait calls to implementations explicitly marked `#[inline]`, since the MIR call identifies the trait item but the relevant inline attribute belongs to the implementation selected for that call.

This PR addresses that edge case by resolving the selected implementation during cross-crate inlining cost analysis. When resolution produces a statically selected, explicitly inline item that is not externally exported, the call no longer disqualifies the enclosing function.

## Motivation

The `nom-json` runtime benchmark uses nom 7.1.3, and its hot path includes an unannotated implementation equivalent to:

```rust
impl FindToken<char> for &str {
    fn find_token(&self, token: char) -> bool {
        self.chars().any(|character| character == token)
    }
}
```

The iterator operations here are marked `#[inline]`, but prior to this PR that wasn't sufficient — `find_token()` was not made available for downstream cross-crate inlining.

The benchmarked function uses the JSON parser and repeatedly uses `find_token()` to look for `"`. Making `find_token()` available for downstream inlining allows constant propagation to replace the general-case search with a direct comparison, which is much more efficient.

The same optimization already happens in LTO-enabled builds. However, LTO is much more expensive than regular `cargo build --release`. This PR recovers that optimization for regular `cargo build --release` builds.

The same optimization can also be recovered by marking `find_token()` with the `#[inline]` attribute. While that's still probably a reasonable idea, I still think it's a good idea to offer better out-of-the-box performance for default (non-LTO) release builds even when users haven't realized that their small cross-crate trait function implementation is a good `#[inline]` candidate.

r? oli-obk

**AI disclosure:** The optimization opportunity here was discovered as part of a systematic probe for missed optimizations using a combination of both traditional and AI tools. The code here was initially prototyped and vetted by AI tools, followed by additional manual work. I secured approval in advance from the reviewer I pinged. I stand behind the quality of the code I'm submitting, and I vouch it's as good or better compared to if I had written every line by my own hand.