### PR TITLE
[perf] Avoid checking for alternate `Debug` on every struct field.

### DIFF
--- a/library/core/src/fmt/builders.rs
+++ b/library/core/src/fmt/builders.rs
@@ -99,6 +99,21 @@ pub(super) fn debug_struct_new<'a, 'b>(
     DebugStruct { fmt, result, has_fields: false }
 }
 
+fn debug_struct_field_non_pretty<F>(
+    fmt: &mut fmt::Formatter<'_>,
+    prefix: &str,
+    name: &str,
+    value_fmt: F,
+) -> fmt::Result
+where
+    F: FnOnce(&mut fmt::Formatter<'_>) -> fmt::Result,
+{
+    fmt.write_str(prefix)?;
+    fmt.write_str(name)?;
+    fmt.write_str(": ")?;
+    value_fmt(fmt)
+}
+
 impl<'a, 'b: 'a> DebugStruct<'a, 'b> {
     /// Adds a new field to the generated struct output.
     ///
@@ -156,11 +171,23 @@ impl<'a, 'b: 'a> DebugStruct<'a, 'b> {
                 writer.write_str(",\n")
             } else {
                 let prefix = if self.has_fields { ", " } else { " { " };
-                self.fmt.write_str(prefix)?;
-                self.fmt.write_str(name)?;
-                self.fmt.write_str(": ")?;
-                value_fmt(self.fmt)
+                debug_struct_field_non_pretty(self.fmt, prefix, name, value_fmt)
             }
+        });
+
+        self.has_fields = true;
+        self
+    }
+
+    /// Adds a new field to the generated struct output in non-pretty mode.
+    ///
+    /// Fast path version of [`Self::field`] that allows skipping the pretty mode check.
+    /// It's the caller's responsibility to verify non-pretty mode is configured
+    /// prior to calling this function.
+    pub(super) fn field_non_pretty(&mut self, name: &str, value: &dyn fmt::Debug) -> &mut Self {
+        self.result = self.result.and_then(|_| {
+            let prefix = if self.has_fields { ", " } else { " { " };
+            debug_struct_field_non_pretty(self.fmt, prefix, name, |f| value.fmt(f))
         });
 
         self.has_fields = true;
@@ -246,6 +273,18 @@ impl<'a, 'b: 'a> DebugStruct<'a, 'b> {
             self.result = self.result.and_then(|_| {
                 if self.is_pretty() { self.fmt.write_str("}") } else { self.fmt.write_str(" }") }
             });
+        }
+        self.result
+    }
+
+    /// Finishes output in non-pretty mode and returns any error encountered.
+    ///
+    /// Fast path version of [`Self::finish`] that allows skipping the pretty mode check.
+    /// It's the caller's responsibility to verify non-pretty mode is configured
+    /// prior to calling this function.
+    pub(super) fn finish_non_pretty(&mut self) -> fmt::Result {
+        if self.has_fields {
+            self.result = self.result.and_then(|_| self.fmt.write_str(" }"));
         }
         self.result
     }

--- a/library/core/src/fmt/mod.rs
+++ b/library/core/src/fmt/mod.rs
@@ -564,6 +564,27 @@ pub struct Formatter<'a> {
     buf: &'a mut (dyn Write + 'a),
 }
 
+// The fixed-arity derive helpers check `$formatter.alternate()` ("pretty mode") once
+// so that in the common case (non-alternate mode) we can use the fast path
+// that does not require re-checking it once for every field.
+macro_rules! debug_struct_fixed_fields {
+    (
+        $formatter:ident,
+        $name:expr,
+        $(($field_name:expr, $value:expr)),+ $(,)?
+    ) => {{
+        if $formatter.alternate() {
+            let mut builder = builders::debug_struct_new($formatter, $name);
+            $(builder.field($field_name, $value);)+
+            builder.finish()
+        } else {
+            let mut builder = builders::debug_struct_new($formatter, $name);
+            $(builder.field_non_pretty($field_name, $value);)+
+            builder.finish_non_pretty()
+        }
+    }};
+}
+
 impl<'a> Formatter<'a> {
     /// Creates a new formatter with given [`FormattingOptions`].
     ///
@@ -2460,9 +2481,7 @@ impl<'a> Formatter<'a> {
         name1: &str,
         value1: &dyn Debug,
     ) -> Result {
-        let mut builder = builders::debug_struct_new(self, name);
-        builder.field(name1, value1);
-        builder.finish()
+        debug_struct_fixed_fields!(self, name, (name1, value1))
     }
 
     /// Shrinks `derive(Debug)` code, for faster compilation and smaller
@@ -2478,10 +2497,7 @@ impl<'a> Formatter<'a> {
         name2: &str,
         value2: &dyn Debug,
     ) -> Result {
-        let mut builder = builders::debug_struct_new(self, name);
-        builder.field(name1, value1);
-        builder.field(name2, value2);
-        builder.finish()
+        debug_struct_fixed_fields!(self, name, (name1, value1), (name2, value2))
     }
 
     /// Shrinks `derive(Debug)` code, for faster compilation and smaller
@@ -2499,11 +2515,7 @@ impl<'a> Formatter<'a> {
         name3: &str,
         value3: &dyn Debug,
     ) -> Result {
-        let mut builder = builders::debug_struct_new(self, name);
-        builder.field(name1, value1);
-        builder.field(name2, value2);
-        builder.field(name3, value3);
-        builder.finish()
+        debug_struct_fixed_fields!(self, name, (name1, value1), (name2, value2), (name3, value3))
     }
 
     /// Shrinks `derive(Debug)` code, for faster compilation and smaller
@@ -2523,12 +2535,14 @@ impl<'a> Formatter<'a> {
         name4: &str,
         value4: &dyn Debug,
     ) -> Result {
-        let mut builder = builders::debug_struct_new(self, name);
-        builder.field(name1, value1);
-        builder.field(name2, value2);
-        builder.field(name3, value3);
-        builder.field(name4, value4);
-        builder.finish()
+        debug_struct_fixed_fields!(
+            self,
+            name,
+            (name1, value1),
+            (name2, value2),
+            (name3, value3),
+            (name4, value4),
+        )
     }
 
     /// Shrinks `derive(Debug)` code, for faster compilation and smaller
@@ -2550,13 +2564,15 @@ impl<'a> Formatter<'a> {
         name5: &str,
         value5: &dyn Debug,
     ) -> Result {
-        let mut builder = builders::debug_struct_new(self, name);
-        builder.field(name1, value1);
-        builder.field(name2, value2);
-        builder.field(name3, value3);
-        builder.field(name4, value4);
-        builder.field(name5, value5);
-        builder.finish()
+        debug_struct_fixed_fields!(
+            self,
+            name,
+            (name1, value1),
+            (name2, value2),
+            (name3, value3),
+            (name4, value4),
+            (name5, value5),
+        )
     }
 
     /// Shrinks `derive(Debug)` code, for faster compilation and smaller binaries.

--- a/library/coretests/tests/fmt/builders.rs
+++ b/library/coretests/tests/fmt/builders.rs
@@ -188,6 +188,42 @@ mod debug_struct {
 
         assert_eq!("Foo {\n    bar: true,\n    baz: false,\n}", format!("{Foo:#?}"))
     }
+
+    #[test]
+    fn test_derived_helpers_match_builder() {
+        fn assert_matches_builder(builder: &dyn fmt::Debug, derived: &dyn fmt::Debug) {
+            assert_eq!(format!("{builder:?}"), format!("{derived:?}"));
+            assert_eq!(format!("{builder:#?}"), format!("{derived:#?}"));
+        }
+
+        macro_rules! check_arity {
+            ($name:ident { $($field:ident: $value:expr),+ $(,)? }) => {{
+                #[derive(Debug)]
+                struct $name {
+                    $($field: u8),+
+                }
+
+                struct ViaBuilder<'a>(&'a $name);
+
+                impl fmt::Debug for ViaBuilder<'_> {
+                    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                        f.debug_struct(stringify!($name))
+                            $(.field(stringify!($field), &self.0.$field))+
+                            .finish()
+                    }
+                }
+
+                let value = $name { $($field: $value),+ };
+                assert_matches_builder(&ViaBuilder(&value), &value);
+            }};
+        }
+
+        check_arity!(One { a: 1 });
+        check_arity!(Two { a: 1, b: 2 });
+        check_arity!(Three { a: 1, b: 2, c: 3 });
+        check_arity!(Four { a: 1, b: 2, c: 3, d: 4 });
+        check_arity!(Five { a: 1, b: 2, c: 3, d: 4, e: 5 });
+    }
 }
 
 mod debug_tuple {


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/159120)*
<!-- homu-ignore:end -->

The `fmt-debug-derive` benchmark shows there's [a -6.78% instruction win](https://perf.rust-lang.org/compare.html?start=48e8ec6f05057f942a97187dde770a118e05f42c&end=ebaa02e6d9bfb6b35b6e45eaccab8b7ebb9c6461&stat=instructions%3Au&tab=runtime) to be had by not checking for alternate ("pretty") formatting for every field in the pre-written 1-5 arity cases of derived `Debug` struct representations.

Since non-alternate mode is the default, add a fast path that supports only checking for alternate mode once total per formatting invocation, rather than once per field per invocation.

It's likely that the analogous methods for tuple structs would benefit from a similar change, but the `fmt-debug-derive` benchmark doesn't include this case. If the reviewers are amenable to it, I'd be happy to add both a new benchmark and, if perf-positive, make the analogous tuple struct optimization.

r? @kobzol

**AI disclosure:** The optimization opportunity here was discovered as part of a systematic probe for missed optimizations utilizing both traditional and AI tools. The code here was initially prototyped and vetted by AI tools, followed by additional manual work. I secured approval in advance from the reviewer I pinged. I stand behind the quality of the code I'm submitting, and I vouch it's as good or better compared to if I had written every line by my own hand.