### PR TITLE
doc: clarify attr parser APIs

### DIFF
--- a/compiler/rustc_attr_parsing/src/parser.rs
+++ b/compiler/rustc_attr_parsing/src/parser.rs
@@ -301,11 +301,13 @@ impl MetaItemOrLitParser {
     }
 }
 
-// FIXME(scrabsha): once #155696 is merged, update this and mention the higher-level APIs.
 /// Utility that deconstructs a MetaItem into usable parts.
 ///
 /// MetaItems are syntactically extremely flexible, but specific attributes want to parse
-/// them in custom, more restricted ways. This can be done using this struct.
+/// them in custom, more restricted ways. For common argument shapes, prefer the higher-level
+/// [`AcceptContext::expect_list`](crate::context::AcceptContext::expect_list) and
+/// [`AcceptContext::expect_single`](crate::context::AcceptContext::expect_single) helpers.
+/// Use this struct when parsing a custom restricted syntax.
 ///
 /// MetaItems consist of some path, and some args. The args could be empty. In other words:
 ///


### PR DESCRIPTION
Follow up on rust-lang/rust#155696 by documenting the higher-level `AcceptContext` helpers for common argument shapes.

`MetaItemParser` remains the lower-level tool for attributes with custom restricted syntax. Remove the stale FIXME now that the helpers are available.