### PR TITLE
Fix PR number in bootstrap's change tracker

### DIFF
--- a/src/bootstrap/src/utils/change_tracker.rs
+++ b/src/bootstrap/src/utils/change_tracker.rs
@@ -637,7 +637,7 @@ pub const CONFIG_CHANGE_HISTORY: &[ChangeInfo] = &[
         summary: "New option `rust.compress-debuginfo` allows configuring whether Rust and C/C++ debuginfo should be compressed.",
     },
     ChangeInfo {
-        change_id: 999999,
+        change_id: 158912,
         severity: ChangeSeverity::Info,
         summary: "New config section `pgo` was introduced, to configure PGO profiling options. The `--rust-profile-use`/`--rust-profile-generate`/`--llvm-profile-use`/`--llvm-profile-generate` flags and the `rust.profile-use`/`rust.profile-generate` config options have been deprecated.",
     },


### PR DESCRIPTION
Missed this in https://github.com/rust-lang/rust/pull/158912 :facepalm:
