### PR TITLE
a bit optimize four-digit chunks in integer formatting

### DIFF
--- a/library/core/src/fmt/num.rs
+++ b/library/core/src/fmt/num.rs
@@ -847,7 +847,8 @@ unsafe fn write_quad(buf: &mut [MaybeUninit<u8>], offset: usize, quad: u64) {
 /// Encodes the 16 least-significant decimals of n into `buf[OFFSET .. OFFSET +
 /// 16 ]`.
 fn enc_16lsd<const OFFSET: usize>(buf: &mut [MaybeUninit<u8>], n: u64) {
-    // Callers pass a remainder modulo 10^16 and reserve sixteen output bytes.
+    // SAFETY: Every caller passes a remainder produced by division by 10^16,
+    // and every used `OFFSET` specialization reserves sixteen bytes in `buf`.
     unsafe {
         core::hint::assert_unchecked(n < 10_000_000_000_000_000);
         core::hint::assert_unchecked(OFFSET <= buf.len() - 16);

--- a/library/core/src/fmt/num.rs
+++ b/library/core/src/fmt/num.rs
@@ -690,15 +690,11 @@ impl u128 {
             unsafe { core::hint::assert_unchecked(offset <= buf.len()) }
             offset -= 4;
 
-            // pull two pairs
             let quad = remain % 1_00_00;
             remain /= 1_00_00;
-            let pair1 = (quad / 100) as usize;
-            let pair2 = (quad % 100) as usize;
-            buf[offset + 0].write(DECIMAL_PAIRS[pair1 * 2 + 0]);
-            buf[offset + 1].write(DECIMAL_PAIRS[pair1 * 2 + 1]);
-            buf[offset + 2].write(DECIMAL_PAIRS[pair2 * 2 + 0]);
-            buf[offset + 3].write(DECIMAL_PAIRS[pair2 * 2 + 1]);
+            // SAFETY: quad is a remainder modulo 10_000. The offset checks
+            // above reserve exactly four bytes in buf.
+            unsafe { write_quad(buf, offset, quad) };
         }
 
         // Format per two digits from the lookup table.
@@ -814,32 +810,64 @@ impl i128 {
     }
 }
 
+/// Writes `quad` as exactly four digits (for example: `42` becomes `"0042"`).
+///
+/// # Safety
+///
+/// `quad` must be below 10_000 and `buf[offset..offset + 4]` must be in bounds.
+#[inline(always)]
+unsafe fn write_quad(buf: &mut [MaybeUninit<u8>], offset: usize, quad: u64) {
+    // SAFETY: These are this function's caller-provided invariants.
+    unsafe {
+        core::hint::assert_unchecked(quad < 10_000);
+        core::hint::assert_unchecked(offset <= buf.len() - 4);
+    }
+
+    // For the documented range, ceil(2^19 / 100) gives an exact quotiet.
+    const DIV100_SHIFT: u32 = 19;
+    const DIV100_RECIPROCAL: u32 = (1 << DIV100_SHIFT) / 100 + 1;
+
+    let quad = quad as u32;
+    let high = (quad * DIV100_RECIPROCAL) >> DIV100_SHIFT;
+    let low = quad - high * 100;
+    let high = high as usize;
+    let low = low as usize;
+
+    // SAFETY: `high` and `low` are below 100 because quad is below 10_000. The
+    // destination has four bytes by the precondition, and the two source pairs
+    // are disjoint from it because `DECIMAL_PAIRS` is static RO storage.
+    unsafe {
+        let pairs = DECIMAL_PAIRS.as_ptr();
+        let dst = buf.as_mut_ptr().add(offset).cast::<u8>();
+        core::ptr::copy_nonoverlapping(pairs.add(high * 2), dst, 2);
+        core::ptr::copy_nonoverlapping(pairs.add(low * 2), dst.add(2), 2);
+    }
+}
+
 /// Encodes the 16 least-significant decimals of n into `buf[OFFSET .. OFFSET +
 /// 16 ]`.
 fn enc_16lsd<const OFFSET: usize>(buf: &mut [MaybeUninit<u8>], n: u64) {
-    // Consume the least-significant decimals from a working copy.
+    // Callers pass a remainder modulo 10^16 and reserve sixteen output bytes.
+    unsafe {
+        core::hint::assert_unchecked(n < 10_000_000_000_000_000);
+        core::hint::assert_unchecked(OFFSET <= buf.len() - 16);
+    }
+
+    // Peel four digits at a time from right to left (12345678 -> 1234 | 5678).
+    // Since 10_000 is constant, LLVM replaces each division with multiply or shift.
     let mut remain = n;
 
-    // Format per four digits from the lookup table.
     for quad_index in (1..4).rev() {
         // pull two pairs
         let quad = remain % 1_00_00;
         remain /= 1_00_00;
-        let pair1 = (quad / 100) as usize;
-        let pair2 = (quad % 100) as usize;
-        buf[quad_index * 4 + OFFSET + 0].write(DECIMAL_PAIRS[pair1 * 2 + 0]);
-        buf[quad_index * 4 + OFFSET + 1].write(DECIMAL_PAIRS[pair1 * 2 + 1]);
-        buf[quad_index * 4 + OFFSET + 2].write(DECIMAL_PAIRS[pair2 * 2 + 0]);
-        buf[quad_index * 4 + OFFSET + 3].write(DECIMAL_PAIRS[pair2 * 2 + 1]);
+        // SAFETY: modulo bounds quad; OFFSET and quad_index select one of the
+        // four non-overlapping four-byte regions proven in bounds above.
+        unsafe { write_quad(buf, quad_index * 4 + OFFSET, quad) };
     }
 
-    // final two pairs
-    let pair1 = (remain / 100) as usize;
-    let pair2 = (remain % 100) as usize;
-    buf[OFFSET + 0].write(DECIMAL_PAIRS[pair1 * 2 + 0]);
-    buf[OFFSET + 1].write(DECIMAL_PAIRS[pair1 * 2 + 1]);
-    buf[OFFSET + 2].write(DECIMAL_PAIRS[pair2 * 2 + 0]);
-    buf[OFFSET + 3].write(DECIMAL_PAIRS[pair2 * 2 + 1]);
+    // SAFETY: OFFSET starts the first four-byte region proven in bounds above.
+    unsafe { write_quad(buf, OFFSET, remain) };
 }
 
 /// Euclidean division plus remainder with constant 1E16 basically consumes 16

--- a/library/core/src/fmt/num.rs
+++ b/library/core/src/fmt/num.rs
@@ -823,12 +823,9 @@ unsafe fn write_quad(buf: &mut [MaybeUninit<u8>], offset: usize, quad: u64) {
         core::hint::assert_unchecked(offset + 4 <= buf.len());
     }
 
-    // For the documented range, ceil(2^19 / 100) gives an exact quotiet.
-    const DIV100_SHIFT: u32 = 19;
-    const DIV100_RECIPROCAL: u32 = (1 << DIV100_SHIFT) / 100 + 1;
-
     let quad = quad as u32;
-    let high = (quad * DIV100_RECIPROCAL) >> DIV100_SHIFT;
+    // Note: this is equivalent to `quad / 100`, but contains no division instructions
+    let high = (quad * const { (1 << 19) / 100 + 1 }) >> 19;
     let low = quad - high * 100;
     let high = high as usize;
     let low = low as usize;

--- a/library/core/src/fmt/num.rs
+++ b/library/core/src/fmt/num.rs
@@ -867,9 +867,7 @@ fn enc_16lsd<const OFFSET: usize>(buf: &mut [MaybeUninit<u8>], n: u64) {
         // non-overlapping four-byte regions proven in bounds above.
         unsafe {
             write_quad(
-                buf.get_unchecked_mut(
-                    OFFSET + quad_index * 4..OFFSET + (quad_index + 1) * 4,
-                ),
+                buf.get_unchecked_mut(OFFSET + quad_index * 4..OFFSET + (quad_index + 1) * 4),
                 quad,
             );
         }

--- a/library/core/src/fmt/num.rs
+++ b/library/core/src/fmt/num.rs
@@ -820,7 +820,7 @@ unsafe fn write_quad(buf: &mut [MaybeUninit<u8>], offset: usize, quad: u64) {
     // SAFETY: These are this function's caller-provided invariants.
     unsafe {
         core::hint::assert_unchecked(quad < 10_000);
-        core::hint::assert_unchecked(offset <= buf.len() - 4);
+        core::hint::assert_unchecked(offset + 4 <= buf.len());
     }
 
     // For the documented range, ceil(2^19 / 100) gives an exact quotiet.
@@ -851,7 +851,7 @@ fn enc_16lsd<const OFFSET: usize>(buf: &mut [MaybeUninit<u8>], n: u64) {
     // and every used `OFFSET` specialization reserves sixteen bytes in `buf`.
     unsafe {
         core::hint::assert_unchecked(n < 10_000_000_000_000_000);
-        core::hint::assert_unchecked(OFFSET <= buf.len() - 16);
+        core::hint::assert_unchecked(OFFSET + 16 <= buf.len());
     }
 
     // Peel four digits at a time from right to left (12345678 -> 1234 | 5678).

--- a/library/core/src/fmt/num.rs
+++ b/library/core/src/fmt/num.rs
@@ -693,11 +693,11 @@ impl u128 {
             let quad = remain % 1_00_00;
             remain /= 1_00_00;
 
-            write_quad(
-                // SAFETY: `offset >= 4` was asserted above.
-                unsafe { buf.get_unchecked_mut(offset..offset + 4) },
-                quad,
-            );
+            // SAFETY: quad is a remainder modulo 10_000. The offset checks
+            // above reserve exactly four bytes in buf.
+            unsafe {
+                write_quad(buf.get_unchecked_mut(offset..offset + 4), quad);
+            }
         }
 
         // Format per two digits from the lookup table.
@@ -814,8 +814,12 @@ impl i128 {
 }
 
 /// Writes `quad` as exactly four digits (for example: `42` becomes `"0042"`).
+///
+/// # Safety
+///
+/// `quad` must be below 10_000 and `buf` must contain exactly four bytes.
 #[inline(always)]
-fn write_quad(buf: &mut [MaybeUninit<u8>], quad: u64) {
+unsafe fn write_quad(buf: &mut [MaybeUninit<u8>], quad: u64) {
     // SAFETY: These are this function's caller-provided invariants.
     unsafe {
         core::hint::assert_unchecked(quad < 10_000);
@@ -855,20 +859,20 @@ fn enc_16lsd<const OFFSET: usize>(buf: &mut [MaybeUninit<u8>], n: u64) {
         let quad = remain % 1_00_00;
         remain /= 1_00_00;
 
-        write_quad(
-            // SAFETY: `OFFSET + 16 <= buf.len()` and `quad_index < 4`, so this range is within `buf`.
-            unsafe {
-                buf.get_unchecked_mut(OFFSET + quad_index * 4..OFFSET + (quad_index + 1) * 4)
-            },
-            quad,
-        );
+        // SAFETY: `OFFSET + quad_index * 4` starts one of the four
+        // non-overlapping four-byte regions proven in bounds above.
+        unsafe {
+            write_quad(
+                buf.get_unchecked_mut(OFFSET + quad_index * 4..OFFSET + (quad_index + 1) * 4),
+                quad,
+            );
+        }
     }
 
-    write_quad(
-        // SAFETY: `OFFSET + 16 <= buf.len()` was asserted above.
-        unsafe { buf.get_unchecked_mut(OFFSET..OFFSET + 4) },
-        remain,
-    );
+    // SAFETY: OFFSET starts the first four-byte region proven in bounds above.
+    unsafe {
+        write_quad(buf.get_unchecked_mut(OFFSET..OFFSET + 4), remain);
+    }
 }
 
 /// Euclidean division plus remainder with constant 1E16 basically consumes 16

--- a/library/core/src/fmt/num.rs
+++ b/library/core/src/fmt/num.rs
@@ -838,7 +838,7 @@ unsafe fn write_quad(buf: &mut [MaybeUninit<u8>], quad: u64) {
     // pairs are disjoint from it because `DECIMAL_PAIRS` is static RO storage.
     unsafe {
         let pairs = DECIMAL_PAIRS.as_ptr();
-        let dst = buf.as_mut_ptr().cast::<u8>();
+        let dst = buf.as_mut_ptr().cast_init();
 
         core::ptr::copy_nonoverlapping(pairs.add(high * 2), dst, 2);
         core::ptr::copy_nonoverlapping(pairs.add(low * 2), dst.add(2), 2);

--- a/library/core/src/fmt/num.rs
+++ b/library/core/src/fmt/num.rs
@@ -694,7 +694,9 @@ impl u128 {
             remain /= 1_00_00;
             // SAFETY: quad is a remainder modulo 10_000. The offset checks
             // above reserve exactly four bytes in buf.
-            unsafe { write_quad(buf, offset, quad) };
+            unsafe {
+                write_quad(buf.get_unchecked_mut(offset..offset + 4), quad);
+            }
         }
 
         // Format per two digits from the lookup table.
@@ -814,28 +816,30 @@ impl i128 {
 ///
 /// # Safety
 ///
-/// `quad` must be below 10_000 and `buf[offset..offset + 4]` must be in bounds.
+/// `quad` must be below 10_000 and `buf` must contain exactly four bytes.
 #[inline(always)]
-unsafe fn write_quad(buf: &mut [MaybeUninit<u8>], offset: usize, quad: u64) {
+unsafe fn write_quad(buf: &mut [MaybeUninit<u8>], quad: u64) {
     // SAFETY: These are this function's caller-provided invariants.
     unsafe {
         core::hint::assert_unchecked(quad < 10_000);
-        core::hint::assert_unchecked(offset + 4 <= buf.len());
+        core::hint::assert_unchecked(buf.len() == 4);
     }
 
     let quad = quad as u32;
-    // Note: this is equivalent to `quad / 100`, but contains no division instructions
+
+    // Note: this is equivalent to `quad / 100`, but contains no division instructions.
     let high = (quad * const { (1 << 19) / 100 + 1 }) >> 19;
     let low = quad - high * 100;
     let high = high as usize;
     let low = low as usize;
 
-    // SAFETY: `high` and `low` are below 100 because quad is below 10_000. The
-    // destination has four bytes by the precondition, and the two source pairs
-    // are disjoint from it because `DECIMAL_PAIRS` is static RO storage.
+    // SAFETY: `high` and `low` are below 100 because `quad` is below 10_000.
+    // The destination has four bytes by the precondition, and the two source
+    // pairs are disjoint from it because `DECIMAL_PAIRS` is static RO storage.
     unsafe {
         let pairs = DECIMAL_PAIRS.as_ptr();
-        let dst = buf.as_mut_ptr().add(offset).cast::<u8>();
+        let dst = buf.as_mut_ptr().cast::<u8>();
+
         core::ptr::copy_nonoverlapping(pairs.add(high * 2), dst, 2);
         core::ptr::copy_nonoverlapping(pairs.add(low * 2), dst.add(2), 2);
     }
@@ -856,16 +860,25 @@ fn enc_16lsd<const OFFSET: usize>(buf: &mut [MaybeUninit<u8>], n: u64) {
     let mut remain = n;
 
     for quad_index in (1..4).rev() {
-        // pull two pairs
         let quad = remain % 1_00_00;
         remain /= 1_00_00;
-        // SAFETY: modulo bounds quad; OFFSET and quad_index select one of the
-        // four non-overlapping four-byte regions proven in bounds above.
-        unsafe { write_quad(buf, quad_index * 4 + OFFSET, quad) };
+
+        // SAFETY: `OFFSET + quad_index * 4` starts one of the four
+        // non-overlapping four-byte regions proven in bounds above.
+        unsafe {
+            write_quad(
+                buf.get_unchecked_mut(
+                    OFFSET + quad_index * 4..OFFSET + (quad_index + 1) * 4,
+                ),
+                quad,
+            );
+        }
     }
 
     // SAFETY: OFFSET starts the first four-byte region proven in bounds above.
-    unsafe { write_quad(buf, OFFSET, remain) };
+    unsafe {
+        write_quad(buf.get_unchecked_mut(OFFSET..OFFSET + 4), remain);
+    }
 }
 
 /// Euclidean division plus remainder with constant 1E16 basically consumes 16

--- a/library/core/src/fmt/num.rs
+++ b/library/core/src/fmt/num.rs
@@ -666,7 +666,9 @@ impl u128 {
             (mod_1e16, U128_MAX_DEC_N)
         } else {
             // Write digits at buf[23..39].
-            enc_16lsd::<{ U128_MAX_DEC_N - 16 }>(buf, mod_1e16);
+            //
+            // SAFETY: `mod_1e16 < 1e16` (remainder), and `U128_MAX_DEC_N - 16 + 16 == buf.len()`.
+            unsafe { enc_16lsd::<{ U128_MAX_DEC_N - 16 }>(buf, mod_1e16) };
 
             // Take another 16 decimals.
             let (quot2, mod2) = div_rem_1e16(quot_1e16);
@@ -674,7 +676,10 @@ impl u128 {
                 (mod2, U128_MAX_DEC_N - 16)
             } else {
                 // Write digits at buf[7..23].
-                enc_16lsd::<{ U128_MAX_DEC_N - 32 }>(buf, mod2);
+                //
+                // SAFETY: `mod2 < 1e16` (remainder), and `U128_MAX_DEC_N - 32 + 16 <= buf.len()`.
+                unsafe { enc_16lsd::<{ U128_MAX_DEC_N - 32 }>(buf, mod2) };
+
                 // Quot2 has at most 7 decimals remaining after two 1e16 divisions.
                 (quot2 as u64, U128_MAX_DEC_N - 32)
             }
@@ -843,7 +848,7 @@ unsafe fn write_quad(buf: &mut [MaybeUninit<u8>], quad: u64) {
 
 /// Encodes the 16 least-significant decimals of n into `buf[OFFSET .. OFFSET +
 /// 16 ]`.
-fn enc_16lsd<const OFFSET: usize>(buf: &mut [MaybeUninit<u8>], n: u64) {
+unsafe fn enc_16lsd<const OFFSET: usize>(buf: &mut [MaybeUninit<u8>], n: u64) {
     // SAFETY: Every caller passes a remainder produced by division by 10^16,
     // and every used `OFFSET` specialization reserves sixteen bytes in `buf`.
     unsafe {

--- a/library/core/src/fmt/num.rs
+++ b/library/core/src/fmt/num.rs
@@ -692,11 +692,12 @@ impl u128 {
 
             let quad = remain % 1_00_00;
             remain /= 1_00_00;
-            // SAFETY: quad is a remainder modulo 10_000. The offset checks
-            // above reserve exactly four bytes in buf.
-            unsafe {
-                write_quad(buf.get_unchecked_mut(offset..offset + 4), quad);
-            }
+
+            write_quad(
+                // SAFETY: `offset >= 4` was asserted above.
+                unsafe { buf.get_unchecked_mut(offset..offset + 4) },
+                quad,
+            );
         }
 
         // Format per two digits from the lookup table.
@@ -813,12 +814,8 @@ impl i128 {
 }
 
 /// Writes `quad` as exactly four digits (for example: `42` becomes `"0042"`).
-///
-/// # Safety
-///
-/// `quad` must be below 10_000 and `buf` must contain exactly four bytes.
 #[inline(always)]
-unsafe fn write_quad(buf: &mut [MaybeUninit<u8>], quad: u64) {
+fn write_quad(buf: &mut [MaybeUninit<u8>], quad: u64) {
     // SAFETY: These are this function's caller-provided invariants.
     unsafe {
         core::hint::assert_unchecked(quad < 10_000);
@@ -834,15 +831,10 @@ unsafe fn write_quad(buf: &mut [MaybeUninit<u8>], quad: u64) {
     let low = low as usize;
 
     // SAFETY: `high` and `low` are below 100 because `quad` is below 10_000.
-    // The destination has four bytes by the precondition, and the two source
-    // pairs are disjoint from it because `DECIMAL_PAIRS` is static RO storage.
-    unsafe {
-        let pairs = DECIMAL_PAIRS.as_ptr();
-        let dst = buf.as_mut_ptr().cast_init();
+    unsafe { core::hint::assert_unchecked(high < 100 && low < 100) }
 
-        core::ptr::copy_nonoverlapping(pairs.add(high * 2), dst, 2);
-        core::ptr::copy_nonoverlapping(pairs.add(low * 2), dst.add(2), 2);
-    }
+    buf[0..2].write_copy_of_slice(&DECIMAL_PAIRS[high * 2..high * 2 + 2]);
+    buf[2..4].write_copy_of_slice(&DECIMAL_PAIRS[low * 2..low * 2 + 2]);
 }
 
 /// Encodes the 16 least-significant decimals of n into `buf[OFFSET .. OFFSET +
@@ -863,20 +855,20 @@ fn enc_16lsd<const OFFSET: usize>(buf: &mut [MaybeUninit<u8>], n: u64) {
         let quad = remain % 1_00_00;
         remain /= 1_00_00;
 
-        // SAFETY: `OFFSET + quad_index * 4` starts one of the four
-        // non-overlapping four-byte regions proven in bounds above.
-        unsafe {
-            write_quad(
-                buf.get_unchecked_mut(OFFSET + quad_index * 4..OFFSET + (quad_index + 1) * 4),
-                quad,
-            );
-        }
+        write_quad(
+            // SAFETY: `OFFSET + 16 <= buf.len()` and `quad_index < 4`, so this range is within `buf`.
+            unsafe {
+                buf.get_unchecked_mut(OFFSET + quad_index * 4..OFFSET + (quad_index + 1) * 4)
+            },
+            quad,
+        );
     }
 
-    // SAFETY: OFFSET starts the first four-byte region proven in bounds above.
-    unsafe {
-        write_quad(buf.get_unchecked_mut(OFFSET..OFFSET + 4), remain);
-    }
+    write_quad(
+        // SAFETY: `OFFSET + 16 <= buf.len()` was asserted above.
+        unsafe { buf.get_unchecked_mut(OFFSET..OFFSET + 4) },
+        remain,
+    );
 }
 
 /// Euclidean division plus remainder with constant 1E16 basically consumes 16

--- a/library/core/src/fmt/num.rs
+++ b/library/core/src/fmt/num.rs
@@ -848,6 +848,10 @@ unsafe fn write_quad(buf: &mut [MaybeUninit<u8>], quad: u64) {
 
 /// Encodes the 16 least-significant decimals of n into `buf[OFFSET .. OFFSET +
 /// 16 ]`.
+///
+/// # Safety
+///
+/// `n` must be below 1e16, and `buf` must be at least `OFFSET + 16` bytes long.
 unsafe fn enc_16lsd<const OFFSET: usize>(buf: &mut [MaybeUninit<u8>], n: u64) {
     // SAFETY: Every caller passes a remainder produced by division by 10^16,
     // and every used `OFFSET` specialization reserves sixteen bytes in `buf`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/159130)*
<!-- homu-ignore:end -->

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

<p>
  <img
    src="https://thesvg.org/icons/compiler-explorer/default.svg"
    alt="Compiler Explorer"
    height="16"
    valign="middle"
  />
  <a href="https://godbolt.org/z/aTr54hTvT">GodBolt</a>
</p>

Number of asm instructions has decreased (78 -> 59)

The current upstream version contains:

```asm
movabs  rax, 9999999999999999
cmp     rsi, rax
ja      .LBB0_2
```

(if `n > 9_999_999_999_999_999` -> go to panic)

But this function isn't part of the public API, so _I suppose_ we can use `assert_unchecked(n < 10_000_000_000_000_000);`

Similarly, `write_quad` has been moved to a separate fn to reduce duplication slightly