### PR TITLE
bootstrap: Allow path-based skipping of the coverage test suite

### DIFF
--- a/src/bootstrap/mk/Makefile.in
+++ b/src/bootstrap/mk/Makefile.in
@@ -106,7 +106,7 @@ prepare:
 SKIP_COMPILER := --skip=compiler
 SKIP_SRC := --skip=src
 TEST_SET1 := $(SKIP_COMPILER) $(SKIP_SRC)
-TEST_SET2 := --skip=tests --skip=coverage-map --skip=coverage-run --skip=library --skip=tidyselftest
+TEST_SET2 := --skip=tests --skip=library --skip=tidyselftest
 
 ## MSVC native builders
 

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -1975,6 +1975,12 @@ impl Step for Coverage {
         for mode in Self::ALL_MODES {
             run = run.alias(mode.as_str());
         }
+
+        // Allow `./x test --skip=tests` to properly skip the coverage tests,
+        // by not treating the `coverage-map` and `coverage-run` aliases as
+        // implied command-line arguments.
+        run = run.default_to_suites_only();
+
         run
     }
 
@@ -2015,13 +2021,6 @@ impl Step for Coverage {
         modes.retain(|mode| {
             !run.builder.config.skip.iter().any(|skip| skip == Path::new(mode.as_str()))
         });
-
-        // FIXME(Zalathar): Make these commands skip all coverage tests, as expected:
-        // - `./x test --skip=tests`
-        // - `./x test --skip=tests/coverage`
-        // - `./x test --skip=coverage`
-        // Skip handling currently doesn't have a way to know that skipping the coverage
-        // suite should also skip the `coverage-map` and `coverage-run` aliases.
 
         for mode in modes {
             run.builder.ensure(Coverage { compiler, target, mode });

--- a/src/bootstrap/src/core/builder/cli_paths.rs
+++ b/src/bootstrap/src/core/builder/cli_paths.rs
@@ -138,7 +138,8 @@ pub(crate) fn match_paths_to_steps_and_run(
     if paths.is_empty() || builder.config.include_default_paths {
         for StepExtra { desc, should_run } in &steps {
             if (desc.is_default_step_fn)(builder) {
-                desc.maybe_run(builder, should_run.paths.iter().cloned().collect());
+                let default_pathsets = should_run.default_pathsets();
+                desc.maybe_run(builder, default_pathsets);
             }
         }
     }

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test.snap
@@ -13,8 +13,6 @@ expression: test
     - Suite(test::tests/crashes)
 [Test] test::Coverage
     targets: [aarch64-unknown-linux-gnu]
-    - Set({test::coverage-map})
-    - Set({test::coverage-run})
     - Suite(test::tests/coverage)
 [Test] test::MirOpt
     targets: [aarch64-unknown-linux-gnu]

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_skip_coverage.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_skip_coverage.snap
@@ -11,10 +11,6 @@ expression: test --skip=coverage
 [Test] test::Crashes
     targets: [aarch64-unknown-linux-gnu]
     - Suite(test::tests/crashes)
-[Test] test::Coverage
-    targets: [aarch64-unknown-linux-gnu]
-    - Set({test::coverage-map})
-    - Set({test::coverage-run})
 [Test] test::MirOpt
     targets: [aarch64-unknown-linux-gnu]
     - Suite(test::tests/mir-opt)

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_skip_coverage_map.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_skip_coverage_map.snap
@@ -1,0 +1,215 @@
+---
+source: src/bootstrap/src/core/builder/cli_paths/tests.rs
+expression: test --skip=coverage-map
+---
+[Test] test::Tidy
+    targets: [x86_64-unknown-linux-gnu]
+    - Set({test::src/tools/tidy})
+[Test] test::Ui
+    targets: [aarch64-unknown-linux-gnu]
+    - Suite(test::tests/ui)
+[Test] test::Crashes
+    targets: [aarch64-unknown-linux-gnu]
+    - Suite(test::tests/crashes)
+[Test] test::Coverage
+    targets: [aarch64-unknown-linux-gnu]
+    - Set({test::coverage-run})
+    - Suite(test::tests/coverage)
+[Test] test::MirOpt
+    targets: [aarch64-unknown-linux-gnu]
+    - Suite(test::tests/mir-opt)
+[Test] test::CodegenLlvm
+    targets: [aarch64-unknown-linux-gnu]
+    - Suite(test::tests/codegen-llvm)
+[Test] test::CodegenUnits
+    targets: [aarch64-unknown-linux-gnu]
+    - Suite(test::tests/codegen-units)
+[Test] test::AssemblyLlvm
+    targets: [aarch64-unknown-linux-gnu]
+    - Suite(test::tests/assembly-llvm)
+[Test] test::Incremental
+    targets: [aarch64-unknown-linux-gnu]
+    - Suite(test::tests/incremental)
+[Test] test::Debuginfo
+    targets: [aarch64-unknown-linux-gnu]
+    - Suite(test::tests/debuginfo)
+[Test] test::UiFullDeps
+    targets: [x86_64-unknown-linux-gnu]
+    - Suite(test::tests/ui-fulldeps)
+[Test] test::RustdocHtml
+    targets: [x86_64-unknown-linux-gnu]
+    - Suite(test::tests/rustdoc-html)
+[Test] test::CoverageRunRustdoc
+    targets: [x86_64-unknown-linux-gnu]
+    - Suite(test::tests/coverage-run-rustdoc)
+[Test] test::Pretty
+    targets: [x86_64-unknown-linux-gnu]
+    - Suite(test::tests/pretty)
+[Test] test::CodegenCranelift
+    targets: [x86_64-unknown-linux-gnu]
+    - Set({test::compiler/rustc_codegen_cranelift})
+[Test] test::CodegenGCC
+    targets: [x86_64-unknown-linux-gnu]
+    - Set({test::compiler/rustc_codegen_gcc})
+[Test] test::Crate
+    targets: [aarch64-unknown-linux-gnu]
+    - Set({test::library/alloc})
+    - Set({test::library/alloctests})
+    - Set({test::library/compiler-builtins/compiler-builtins})
+    - Set({test::library/core})
+    - Set({test::library/coretests})
+    - Set({test::library/panic_abort})
+    - Set({test::library/panic_unwind})
+    - Set({test::library/proc_macro})
+    - Set({test::library/rustc-std-workspace-core})
+    - Set({test::library/std})
+    - Set({test::library/std_detect})
+    - Set({test::library/sysroot})
+    - Set({test::library/test})
+    - Set({test::library/unwind})
+[Test] test::CrateLibrustc
+    targets: [x86_64-unknown-linux-gnu]
+    - Set({test::compiler})
+    - Set({test::compiler/rustc})
+    - Set({test::compiler/rustc_abi})
+    - Set({test::compiler/rustc_arena})
+    - Set({test::compiler/rustc_ast})
+    - Set({test::compiler/rustc_ast_ir})
+    - Set({test::compiler/rustc_ast_lowering})
+    - Set({test::compiler/rustc_ast_passes})
+    - Set({test::compiler/rustc_ast_pretty})
+    - Set({test::compiler/rustc_attr_parsing})
+    - Set({test::compiler/rustc_baked_icu_data})
+    - Set({test::compiler/rustc_borrowck})
+    - Set({test::compiler/rustc_builtin_macros})
+    - Set({test::compiler/rustc_codegen_llvm})
+    - Set({test::compiler/rustc_codegen_ssa})
+    - Set({test::compiler/rustc_const_eval})
+    - Set({test::compiler/rustc_data_structures})
+    - Set({test::compiler/rustc_driver})
+    - Set({test::compiler/rustc_driver_impl})
+    - Set({test::compiler/rustc_error_codes})
+    - Set({test::compiler/rustc_error_messages})
+    - Set({test::compiler/rustc_errors})
+    - Set({test::compiler/rustc_expand})
+    - Set({test::compiler/rustc_feature})
+    - Set({test::compiler/rustc_fs_util})
+    - Set({test::compiler/rustc_graphviz})
+    - Set({test::compiler/rustc_hashes})
+    - Set({test::compiler/rustc_hir})
+    - Set({test::compiler/rustc_hir_analysis})
+    - Set({test::compiler/rustc_hir_id})
+    - Set({test::compiler/rustc_hir_pretty})
+    - Set({test::compiler/rustc_hir_typeck})
+    - Set({test::compiler/rustc_incremental})
+    - Set({test::compiler/rustc_index})
+    - Set({test::compiler/rustc_index_macros})
+    - Set({test::compiler/rustc_infer})
+    - Set({test::compiler/rustc_interface})
+    - Set({test::compiler/rustc_lexer})
+    - Set({test::compiler/rustc_lint})
+    - Set({test::compiler/rustc_lint_defs})
+    - Set({test::compiler/rustc_llvm})
+    - Set({test::compiler/rustc_log})
+    - Set({test::compiler/rustc_macros})
+    - Set({test::compiler/rustc_metadata})
+    - Set({test::compiler/rustc_middle})
+    - Set({test::compiler/rustc_mir_build})
+    - Set({test::compiler/rustc_mir_dataflow})
+    - Set({test::compiler/rustc_mir_transform})
+    - Set({test::compiler/rustc_monomorphize})
+    - Set({test::compiler/rustc_next_trait_solver})
+    - Set({test::compiler/rustc_parse})
+    - Set({test::compiler/rustc_parse_format})
+    - Set({test::compiler/rustc_passes})
+    - Set({test::compiler/rustc_pattern_analysis})
+    - Set({test::compiler/rustc_privacy})
+    - Set({test::compiler/rustc_proc_macro})
+    - Set({test::compiler/rustc_public})
+    - Set({test::compiler/rustc_public_bridge})
+    - Set({test::compiler/rustc_query_impl})
+    - Set({test::compiler/rustc_resolve})
+    - Set({test::compiler/rustc_sanitizers})
+    - Set({test::compiler/rustc_serialize})
+    - Set({test::compiler/rustc_session})
+    - Set({test::compiler/rustc_span})
+    - Set({test::compiler/rustc_symbol_mangling})
+    - Set({test::compiler/rustc_target})
+    - Set({test::compiler/rustc_thread_pool})
+    - Set({test::compiler/rustc_trait_selection})
+    - Set({test::compiler/rustc_traits})
+    - Set({test::compiler/rustc_transmute})
+    - Set({test::compiler/rustc_ty_utils})
+    - Set({test::compiler/rustc_type_ir})
+    - Set({test::compiler/rustc_type_ir_macros})
+    - Set({test::compiler/rustc_windows_rc})
+[Test] test::CrateRustdoc
+    targets: [x86_64-unknown-linux-gnu]
+    - Set({test::src/librustdoc, test::src/tools/rustdoc})
+[Test] test::CrateRustdocJsonTypes
+    targets: [x86_64-unknown-linux-gnu]
+    - Set({test::src/rustdoc-json-types})
+[Test] test::CrateBootstrap
+    targets: [x86_64-unknown-linux-gnu]
+    - Set({test::src/tools/coverage-dump})
+    - Set({test::src/tools/jsondoclint})
+    - Set({test::src/tools/replace-version-placeholder})
+    - Set({test::tidyselftest})
+[Test] test::RemoteTestClientTests
+    targets: [x86_64-unknown-linux-gnu]
+    - Set({test::src/tools/remote-test-client})
+[Test] test::Linkcheck
+    targets: [x86_64-unknown-linux-gnu]
+    - Set({test::src/tools/linkchecker})
+[Test] test::TierCheck
+    targets: [x86_64-unknown-linux-gnu]
+    - Set({test::src/tools/tier-check})
+[Test] test::RustAnalyzer
+    targets: [x86_64-unknown-linux-gnu]
+    - Set({test::src/tools/rust-analyzer})
+[Test] test::ErrorIndex
+    targets: [x86_64-unknown-linux-gnu]
+    - Set({test::error-index})
+    - Set({test::src/tools/error_index_generator})
+[Test] test::RustdocBook
+    targets: [x86_64-unknown-linux-gnu]
+    - Set({test::src/doc/rustdoc})
+[Test] test::UnstableBook
+    targets: [x86_64-unknown-linux-gnu]
+    - Set({test::src/doc/unstable-book})
+[Test] test::RustcBook
+    targets: [x86_64-unknown-linux-gnu]
+    - Set({test::src/doc/rustc})
+[Test] test::StdarchVerify
+    targets: [x86_64-unknown-linux-gnu]
+    - Set({test::library/stdarch/crates/stdarch-verify})
+[Test] test::RustdocJSStd
+    targets: [x86_64-unknown-linux-gnu]
+    - Suite(test::tests/rustdoc-js-std)
+[Test] test::RustdocJSNotStd
+    targets: [x86_64-unknown-linux-gnu]
+    - Suite(test::tests/rustdoc-js)
+[Test] test::RustdocTheme
+    targets: [x86_64-unknown-linux-gnu]
+    - Set({test::src/tools/rustdoc-themes})
+[Test] test::RustdocUi
+    targets: [x86_64-unknown-linux-gnu]
+    - Suite(test::tests/rustdoc-ui)
+[Test] test::RustdocJson
+    targets: [x86_64-unknown-linux-gnu]
+    - Suite(test::tests/rustdoc-json)
+[Test] test::HtmlCheck
+    targets: [x86_64-unknown-linux-gnu]
+    - Set({test::src/tools/html-checker})
+[Test] test::RustInstaller
+    targets: [x86_64-unknown-linux-gnu]
+    - Set({test::src/tools/rust-installer})
+[Test] test::TestFloatParse
+    targets: [x86_64-unknown-linux-gnu]
+    - Set({test::src/tools/test-float-parse})
+[Test] test::RunMake
+    targets: [aarch64-unknown-linux-gnu]
+    - Suite(test::tests/run-make)
+[Test] test::RunMakeCargo
+    targets: [aarch64-unknown-linux-gnu]
+    - Suite(test::tests/run-make-cargo)

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_skip_coverage_map.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_skip_coverage_map.snap
@@ -13,7 +13,6 @@ expression: test --skip=coverage-map
     - Suite(test::tests/crashes)
 [Test] test::Coverage
     targets: [aarch64-unknown-linux-gnu]
-    - Set({test::coverage-run})
     - Suite(test::tests/coverage)
 [Test] test::MirOpt
     targets: [aarch64-unknown-linux-gnu]

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_skip_coverage_run.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_skip_coverage_run.snap
@@ -1,0 +1,215 @@
+---
+source: src/bootstrap/src/core/builder/cli_paths/tests.rs
+expression: test --skip=coverage-run
+---
+[Test] test::Tidy
+    targets: [x86_64-unknown-linux-gnu]
+    - Set({test::src/tools/tidy})
+[Test] test::Ui
+    targets: [aarch64-unknown-linux-gnu]
+    - Suite(test::tests/ui)
+[Test] test::Crashes
+    targets: [aarch64-unknown-linux-gnu]
+    - Suite(test::tests/crashes)
+[Test] test::Coverage
+    targets: [aarch64-unknown-linux-gnu]
+    - Set({test::coverage-map})
+    - Suite(test::tests/coverage)
+[Test] test::MirOpt
+    targets: [aarch64-unknown-linux-gnu]
+    - Suite(test::tests/mir-opt)
+[Test] test::CodegenLlvm
+    targets: [aarch64-unknown-linux-gnu]
+    - Suite(test::tests/codegen-llvm)
+[Test] test::CodegenUnits
+    targets: [aarch64-unknown-linux-gnu]
+    - Suite(test::tests/codegen-units)
+[Test] test::AssemblyLlvm
+    targets: [aarch64-unknown-linux-gnu]
+    - Suite(test::tests/assembly-llvm)
+[Test] test::Incremental
+    targets: [aarch64-unknown-linux-gnu]
+    - Suite(test::tests/incremental)
+[Test] test::Debuginfo
+    targets: [aarch64-unknown-linux-gnu]
+    - Suite(test::tests/debuginfo)
+[Test] test::UiFullDeps
+    targets: [x86_64-unknown-linux-gnu]
+    - Suite(test::tests/ui-fulldeps)
+[Test] test::RustdocHtml
+    targets: [x86_64-unknown-linux-gnu]
+    - Suite(test::tests/rustdoc-html)
+[Test] test::CoverageRunRustdoc
+    targets: [x86_64-unknown-linux-gnu]
+    - Suite(test::tests/coverage-run-rustdoc)
+[Test] test::Pretty
+    targets: [x86_64-unknown-linux-gnu]
+    - Suite(test::tests/pretty)
+[Test] test::CodegenCranelift
+    targets: [x86_64-unknown-linux-gnu]
+    - Set({test::compiler/rustc_codegen_cranelift})
+[Test] test::CodegenGCC
+    targets: [x86_64-unknown-linux-gnu]
+    - Set({test::compiler/rustc_codegen_gcc})
+[Test] test::Crate
+    targets: [aarch64-unknown-linux-gnu]
+    - Set({test::library/alloc})
+    - Set({test::library/alloctests})
+    - Set({test::library/compiler-builtins/compiler-builtins})
+    - Set({test::library/core})
+    - Set({test::library/coretests})
+    - Set({test::library/panic_abort})
+    - Set({test::library/panic_unwind})
+    - Set({test::library/proc_macro})
+    - Set({test::library/rustc-std-workspace-core})
+    - Set({test::library/std})
+    - Set({test::library/std_detect})
+    - Set({test::library/sysroot})
+    - Set({test::library/test})
+    - Set({test::library/unwind})
+[Test] test::CrateLibrustc
+    targets: [x86_64-unknown-linux-gnu]
+    - Set({test::compiler})
+    - Set({test::compiler/rustc})
+    - Set({test::compiler/rustc_abi})
+    - Set({test::compiler/rustc_arena})
+    - Set({test::compiler/rustc_ast})
+    - Set({test::compiler/rustc_ast_ir})
+    - Set({test::compiler/rustc_ast_lowering})
+    - Set({test::compiler/rustc_ast_passes})
+    - Set({test::compiler/rustc_ast_pretty})
+    - Set({test::compiler/rustc_attr_parsing})
+    - Set({test::compiler/rustc_baked_icu_data})
+    - Set({test::compiler/rustc_borrowck})
+    - Set({test::compiler/rustc_builtin_macros})
+    - Set({test::compiler/rustc_codegen_llvm})
+    - Set({test::compiler/rustc_codegen_ssa})
+    - Set({test::compiler/rustc_const_eval})
+    - Set({test::compiler/rustc_data_structures})
+    - Set({test::compiler/rustc_driver})
+    - Set({test::compiler/rustc_driver_impl})
+    - Set({test::compiler/rustc_error_codes})
+    - Set({test::compiler/rustc_error_messages})
+    - Set({test::compiler/rustc_errors})
+    - Set({test::compiler/rustc_expand})
+    - Set({test::compiler/rustc_feature})
+    - Set({test::compiler/rustc_fs_util})
+    - Set({test::compiler/rustc_graphviz})
+    - Set({test::compiler/rustc_hashes})
+    - Set({test::compiler/rustc_hir})
+    - Set({test::compiler/rustc_hir_analysis})
+    - Set({test::compiler/rustc_hir_id})
+    - Set({test::compiler/rustc_hir_pretty})
+    - Set({test::compiler/rustc_hir_typeck})
+    - Set({test::compiler/rustc_incremental})
+    - Set({test::compiler/rustc_index})
+    - Set({test::compiler/rustc_index_macros})
+    - Set({test::compiler/rustc_infer})
+    - Set({test::compiler/rustc_interface})
+    - Set({test::compiler/rustc_lexer})
+    - Set({test::compiler/rustc_lint})
+    - Set({test::compiler/rustc_lint_defs})
+    - Set({test::compiler/rustc_llvm})
+    - Set({test::compiler/rustc_log})
+    - Set({test::compiler/rustc_macros})
+    - Set({test::compiler/rustc_metadata})
+    - Set({test::compiler/rustc_middle})
+    - Set({test::compiler/rustc_mir_build})
+    - Set({test::compiler/rustc_mir_dataflow})
+    - Set({test::compiler/rustc_mir_transform})
+    - Set({test::compiler/rustc_monomorphize})
+    - Set({test::compiler/rustc_next_trait_solver})
+    - Set({test::compiler/rustc_parse})
+    - Set({test::compiler/rustc_parse_format})
+    - Set({test::compiler/rustc_passes})
+    - Set({test::compiler/rustc_pattern_analysis})
+    - Set({test::compiler/rustc_privacy})
+    - Set({test::compiler/rustc_proc_macro})
+    - Set({test::compiler/rustc_public})
+    - Set({test::compiler/rustc_public_bridge})
+    - Set({test::compiler/rustc_query_impl})
+    - Set({test::compiler/rustc_resolve})
+    - Set({test::compiler/rustc_sanitizers})
+    - Set({test::compiler/rustc_serialize})
+    - Set({test::compiler/rustc_session})
+    - Set({test::compiler/rustc_span})
+    - Set({test::compiler/rustc_symbol_mangling})
+    - Set({test::compiler/rustc_target})
+    - Set({test::compiler/rustc_thread_pool})
+    - Set({test::compiler/rustc_trait_selection})
+    - Set({test::compiler/rustc_traits})
+    - Set({test::compiler/rustc_transmute})
+    - Set({test::compiler/rustc_ty_utils})
+    - Set({test::compiler/rustc_type_ir})
+    - Set({test::compiler/rustc_type_ir_macros})
+    - Set({test::compiler/rustc_windows_rc})
+[Test] test::CrateRustdoc
+    targets: [x86_64-unknown-linux-gnu]
+    - Set({test::src/librustdoc, test::src/tools/rustdoc})
+[Test] test::CrateRustdocJsonTypes
+    targets: [x86_64-unknown-linux-gnu]
+    - Set({test::src/rustdoc-json-types})
+[Test] test::CrateBootstrap
+    targets: [x86_64-unknown-linux-gnu]
+    - Set({test::src/tools/coverage-dump})
+    - Set({test::src/tools/jsondoclint})
+    - Set({test::src/tools/replace-version-placeholder})
+    - Set({test::tidyselftest})
+[Test] test::RemoteTestClientTests
+    targets: [x86_64-unknown-linux-gnu]
+    - Set({test::src/tools/remote-test-client})
+[Test] test::Linkcheck
+    targets: [x86_64-unknown-linux-gnu]
+    - Set({test::src/tools/linkchecker})
+[Test] test::TierCheck
+    targets: [x86_64-unknown-linux-gnu]
+    - Set({test::src/tools/tier-check})
+[Test] test::RustAnalyzer
+    targets: [x86_64-unknown-linux-gnu]
+    - Set({test::src/tools/rust-analyzer})
+[Test] test::ErrorIndex
+    targets: [x86_64-unknown-linux-gnu]
+    - Set({test::error-index})
+    - Set({test::src/tools/error_index_generator})
+[Test] test::RustdocBook
+    targets: [x86_64-unknown-linux-gnu]
+    - Set({test::src/doc/rustdoc})
+[Test] test::UnstableBook
+    targets: [x86_64-unknown-linux-gnu]
+    - Set({test::src/doc/unstable-book})
+[Test] test::RustcBook
+    targets: [x86_64-unknown-linux-gnu]
+    - Set({test::src/doc/rustc})
+[Test] test::StdarchVerify
+    targets: [x86_64-unknown-linux-gnu]
+    - Set({test::library/stdarch/crates/stdarch-verify})
+[Test] test::RustdocJSStd
+    targets: [x86_64-unknown-linux-gnu]
+    - Suite(test::tests/rustdoc-js-std)
+[Test] test::RustdocJSNotStd
+    targets: [x86_64-unknown-linux-gnu]
+    - Suite(test::tests/rustdoc-js)
+[Test] test::RustdocTheme
+    targets: [x86_64-unknown-linux-gnu]
+    - Set({test::src/tools/rustdoc-themes})
+[Test] test::RustdocUi
+    targets: [x86_64-unknown-linux-gnu]
+    - Suite(test::tests/rustdoc-ui)
+[Test] test::RustdocJson
+    targets: [x86_64-unknown-linux-gnu]
+    - Suite(test::tests/rustdoc-json)
+[Test] test::HtmlCheck
+    targets: [x86_64-unknown-linux-gnu]
+    - Set({test::src/tools/html-checker})
+[Test] test::RustInstaller
+    targets: [x86_64-unknown-linux-gnu]
+    - Set({test::src/tools/rust-installer})
+[Test] test::TestFloatParse
+    targets: [x86_64-unknown-linux-gnu]
+    - Set({test::src/tools/test-float-parse})
+[Test] test::RunMake
+    targets: [aarch64-unknown-linux-gnu]
+    - Suite(test::tests/run-make)
+[Test] test::RunMakeCargo
+    targets: [aarch64-unknown-linux-gnu]
+    - Suite(test::tests/run-make-cargo)

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_skip_coverage_run.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_skip_coverage_run.snap
@@ -13,7 +13,6 @@ expression: test --skip=coverage-run
     - Suite(test::tests/crashes)
 [Test] test::Coverage
     targets: [aarch64-unknown-linux-gnu]
-    - Set({test::coverage-map})
     - Suite(test::tests/coverage)
 [Test] test::MirOpt
     targets: [aarch64-unknown-linux-gnu]

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_skip_tests.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_skip_tests.snap
@@ -5,10 +5,6 @@ expression: test --skip=tests
 [Test] test::Tidy
     targets: [x86_64-unknown-linux-gnu]
     - Set({test::src/tools/tidy})
-[Test] test::Coverage
-    targets: [aarch64-unknown-linux-gnu]
-    - Set({test::coverage-map})
-    - Set({test::coverage-run})
 [Test] test::CodegenCranelift
     targets: [x86_64-unknown-linux-gnu]
     - Set({test::compiler/rustc_codegen_cranelift})

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_skip_tests_coverage.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_skip_tests_coverage.snap
@@ -11,10 +11,6 @@ expression: test --skip=tests/coverage
 [Test] test::Crashes
     targets: [aarch64-unknown-linux-gnu]
     - Suite(test::tests/crashes)
-[Test] test::Coverage
-    targets: [aarch64-unknown-linux-gnu]
-    - Set({test::coverage-map})
-    - Set({test::coverage-run})
 [Test] test::MirOpt
     targets: [aarch64-unknown-linux-gnu]
     - Suite(test::tests/mir-opt)

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_skip_tests_coverage.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_skip_tests_coverage.snap
@@ -1,0 +1,215 @@
+---
+source: src/bootstrap/src/core/builder/cli_paths/tests.rs
+expression: test --skip=tests/coverage
+---
+[Test] test::Tidy
+    targets: [x86_64-unknown-linux-gnu]
+    - Set({test::src/tools/tidy})
+[Test] test::Ui
+    targets: [aarch64-unknown-linux-gnu]
+    - Suite(test::tests/ui)
+[Test] test::Crashes
+    targets: [aarch64-unknown-linux-gnu]
+    - Suite(test::tests/crashes)
+[Test] test::Coverage
+    targets: [aarch64-unknown-linux-gnu]
+    - Set({test::coverage-map})
+    - Set({test::coverage-run})
+[Test] test::MirOpt
+    targets: [aarch64-unknown-linux-gnu]
+    - Suite(test::tests/mir-opt)
+[Test] test::CodegenLlvm
+    targets: [aarch64-unknown-linux-gnu]
+    - Suite(test::tests/codegen-llvm)
+[Test] test::CodegenUnits
+    targets: [aarch64-unknown-linux-gnu]
+    - Suite(test::tests/codegen-units)
+[Test] test::AssemblyLlvm
+    targets: [aarch64-unknown-linux-gnu]
+    - Suite(test::tests/assembly-llvm)
+[Test] test::Incremental
+    targets: [aarch64-unknown-linux-gnu]
+    - Suite(test::tests/incremental)
+[Test] test::Debuginfo
+    targets: [aarch64-unknown-linux-gnu]
+    - Suite(test::tests/debuginfo)
+[Test] test::UiFullDeps
+    targets: [x86_64-unknown-linux-gnu]
+    - Suite(test::tests/ui-fulldeps)
+[Test] test::RustdocHtml
+    targets: [x86_64-unknown-linux-gnu]
+    - Suite(test::tests/rustdoc-html)
+[Test] test::CoverageRunRustdoc
+    targets: [x86_64-unknown-linux-gnu]
+    - Suite(test::tests/coverage-run-rustdoc)
+[Test] test::Pretty
+    targets: [x86_64-unknown-linux-gnu]
+    - Suite(test::tests/pretty)
+[Test] test::CodegenCranelift
+    targets: [x86_64-unknown-linux-gnu]
+    - Set({test::compiler/rustc_codegen_cranelift})
+[Test] test::CodegenGCC
+    targets: [x86_64-unknown-linux-gnu]
+    - Set({test::compiler/rustc_codegen_gcc})
+[Test] test::Crate
+    targets: [aarch64-unknown-linux-gnu]
+    - Set({test::library/alloc})
+    - Set({test::library/alloctests})
+    - Set({test::library/compiler-builtins/compiler-builtins})
+    - Set({test::library/core})
+    - Set({test::library/coretests})
+    - Set({test::library/panic_abort})
+    - Set({test::library/panic_unwind})
+    - Set({test::library/proc_macro})
+    - Set({test::library/rustc-std-workspace-core})
+    - Set({test::library/std})
+    - Set({test::library/std_detect})
+    - Set({test::library/sysroot})
+    - Set({test::library/test})
+    - Set({test::library/unwind})
+[Test] test::CrateLibrustc
+    targets: [x86_64-unknown-linux-gnu]
+    - Set({test::compiler})
+    - Set({test::compiler/rustc})
+    - Set({test::compiler/rustc_abi})
+    - Set({test::compiler/rustc_arena})
+    - Set({test::compiler/rustc_ast})
+    - Set({test::compiler/rustc_ast_ir})
+    - Set({test::compiler/rustc_ast_lowering})
+    - Set({test::compiler/rustc_ast_passes})
+    - Set({test::compiler/rustc_ast_pretty})
+    - Set({test::compiler/rustc_attr_parsing})
+    - Set({test::compiler/rustc_baked_icu_data})
+    - Set({test::compiler/rustc_borrowck})
+    - Set({test::compiler/rustc_builtin_macros})
+    - Set({test::compiler/rustc_codegen_llvm})
+    - Set({test::compiler/rustc_codegen_ssa})
+    - Set({test::compiler/rustc_const_eval})
+    - Set({test::compiler/rustc_data_structures})
+    - Set({test::compiler/rustc_driver})
+    - Set({test::compiler/rustc_driver_impl})
+    - Set({test::compiler/rustc_error_codes})
+    - Set({test::compiler/rustc_error_messages})
+    - Set({test::compiler/rustc_errors})
+    - Set({test::compiler/rustc_expand})
+    - Set({test::compiler/rustc_feature})
+    - Set({test::compiler/rustc_fs_util})
+    - Set({test::compiler/rustc_graphviz})
+    - Set({test::compiler/rustc_hashes})
+    - Set({test::compiler/rustc_hir})
+    - Set({test::compiler/rustc_hir_analysis})
+    - Set({test::compiler/rustc_hir_id})
+    - Set({test::compiler/rustc_hir_pretty})
+    - Set({test::compiler/rustc_hir_typeck})
+    - Set({test::compiler/rustc_incremental})
+    - Set({test::compiler/rustc_index})
+    - Set({test::compiler/rustc_index_macros})
+    - Set({test::compiler/rustc_infer})
+    - Set({test::compiler/rustc_interface})
+    - Set({test::compiler/rustc_lexer})
+    - Set({test::compiler/rustc_lint})
+    - Set({test::compiler/rustc_lint_defs})
+    - Set({test::compiler/rustc_llvm})
+    - Set({test::compiler/rustc_log})
+    - Set({test::compiler/rustc_macros})
+    - Set({test::compiler/rustc_metadata})
+    - Set({test::compiler/rustc_middle})
+    - Set({test::compiler/rustc_mir_build})
+    - Set({test::compiler/rustc_mir_dataflow})
+    - Set({test::compiler/rustc_mir_transform})
+    - Set({test::compiler/rustc_monomorphize})
+    - Set({test::compiler/rustc_next_trait_solver})
+    - Set({test::compiler/rustc_parse})
+    - Set({test::compiler/rustc_parse_format})
+    - Set({test::compiler/rustc_passes})
+    - Set({test::compiler/rustc_pattern_analysis})
+    - Set({test::compiler/rustc_privacy})
+    - Set({test::compiler/rustc_proc_macro})
+    - Set({test::compiler/rustc_public})
+    - Set({test::compiler/rustc_public_bridge})
+    - Set({test::compiler/rustc_query_impl})
+    - Set({test::compiler/rustc_resolve})
+    - Set({test::compiler/rustc_sanitizers})
+    - Set({test::compiler/rustc_serialize})
+    - Set({test::compiler/rustc_session})
+    - Set({test::compiler/rustc_span})
+    - Set({test::compiler/rustc_symbol_mangling})
+    - Set({test::compiler/rustc_target})
+    - Set({test::compiler/rustc_thread_pool})
+    - Set({test::compiler/rustc_trait_selection})
+    - Set({test::compiler/rustc_traits})
+    - Set({test::compiler/rustc_transmute})
+    - Set({test::compiler/rustc_ty_utils})
+    - Set({test::compiler/rustc_type_ir})
+    - Set({test::compiler/rustc_type_ir_macros})
+    - Set({test::compiler/rustc_windows_rc})
+[Test] test::CrateRustdoc
+    targets: [x86_64-unknown-linux-gnu]
+    - Set({test::src/librustdoc, test::src/tools/rustdoc})
+[Test] test::CrateRustdocJsonTypes
+    targets: [x86_64-unknown-linux-gnu]
+    - Set({test::src/rustdoc-json-types})
+[Test] test::CrateBootstrap
+    targets: [x86_64-unknown-linux-gnu]
+    - Set({test::src/tools/coverage-dump})
+    - Set({test::src/tools/jsondoclint})
+    - Set({test::src/tools/replace-version-placeholder})
+    - Set({test::tidyselftest})
+[Test] test::RemoteTestClientTests
+    targets: [x86_64-unknown-linux-gnu]
+    - Set({test::src/tools/remote-test-client})
+[Test] test::Linkcheck
+    targets: [x86_64-unknown-linux-gnu]
+    - Set({test::src/tools/linkchecker})
+[Test] test::TierCheck
+    targets: [x86_64-unknown-linux-gnu]
+    - Set({test::src/tools/tier-check})
+[Test] test::RustAnalyzer
+    targets: [x86_64-unknown-linux-gnu]
+    - Set({test::src/tools/rust-analyzer})
+[Test] test::ErrorIndex
+    targets: [x86_64-unknown-linux-gnu]
+    - Set({test::error-index})
+    - Set({test::src/tools/error_index_generator})
+[Test] test::RustdocBook
+    targets: [x86_64-unknown-linux-gnu]
+    - Set({test::src/doc/rustdoc})
+[Test] test::UnstableBook
+    targets: [x86_64-unknown-linux-gnu]
+    - Set({test::src/doc/unstable-book})
+[Test] test::RustcBook
+    targets: [x86_64-unknown-linux-gnu]
+    - Set({test::src/doc/rustc})
+[Test] test::StdarchVerify
+    targets: [x86_64-unknown-linux-gnu]
+    - Set({test::library/stdarch/crates/stdarch-verify})
+[Test] test::RustdocJSStd
+    targets: [x86_64-unknown-linux-gnu]
+    - Suite(test::tests/rustdoc-js-std)
+[Test] test::RustdocJSNotStd
+    targets: [x86_64-unknown-linux-gnu]
+    - Suite(test::tests/rustdoc-js)
+[Test] test::RustdocTheme
+    targets: [x86_64-unknown-linux-gnu]
+    - Set({test::src/tools/rustdoc-themes})
+[Test] test::RustdocUi
+    targets: [x86_64-unknown-linux-gnu]
+    - Suite(test::tests/rustdoc-ui)
+[Test] test::RustdocJson
+    targets: [x86_64-unknown-linux-gnu]
+    - Suite(test::tests/rustdoc-json)
+[Test] test::HtmlCheck
+    targets: [x86_64-unknown-linux-gnu]
+    - Set({test::src/tools/html-checker})
+[Test] test::RustInstaller
+    targets: [x86_64-unknown-linux-gnu]
+    - Set({test::src/tools/rust-installer})
+[Test] test::TestFloatParse
+    targets: [x86_64-unknown-linux-gnu]
+    - Set({test::src/tools/test-float-parse})
+[Test] test::RunMake
+    targets: [aarch64-unknown-linux-gnu]
+    - Suite(test::tests/run-make)
+[Test] test::RunMakeCargo
+    targets: [aarch64-unknown-linux-gnu]
+    - Suite(test::tests/run-make-cargo)

--- a/src/bootstrap/src/core/builder/cli_paths/tests.rs
+++ b/src/bootstrap/src/core/builder/cli_paths/tests.rs
@@ -178,10 +178,7 @@ declare_tests!(
     (x_test_skip_tests, "test --skip=tests"),
     (x_test_skip_tests_coverage, "test --skip=tests/coverage"),
     // From `src/ci/docker/scripts/stage_2_test_set2.sh`.
-    (
-        x_test_skip_tests_etc,
-        "test --skip=tests --skip=coverage-map --skip=coverage-run --skip=library --skip=tidyselftest"
-    ),
+    (x_test_skip_tests_etc, "test --skip=tests --skip=library --skip=tidyselftest"),
     (x_test_tests, "test tests"),
     (x_test_tests_skip_coverage, "test tests --skip=coverage"),
     (x_test_tests_ui, "test tests/ui"),

--- a/src/bootstrap/src/core/builder/cli_paths/tests.rs
+++ b/src/bootstrap/src/core/builder/cli_paths/tests.rs
@@ -173,8 +173,11 @@ declare_tests!(
     (x_test_rustdoc, "test rustdoc"),
     (x_test_rustdoc_html, "test rustdoc-html"),
     (x_test_skip_coverage, "test --skip=coverage"),
+    (x_test_skip_coverage_map, "test --skip=coverage-map"),
+    (x_test_skip_coverage_run, "test --skip=coverage-run"),
     // FIXME(Zalathar): This doesn't skip the coverage-map or coverage-run tests.
     (x_test_skip_tests, "test --skip=tests"),
+    (x_test_skip_tests_coverage, "test --skip=tests/coverage"),
     // From `src/ci/docker/scripts/stage_2_test_set2.sh`.
     (
         x_test_skip_tests_etc,

--- a/src/bootstrap/src/core/builder/cli_paths/tests.rs
+++ b/src/bootstrap/src/core/builder/cli_paths/tests.rs
@@ -175,7 +175,6 @@ declare_tests!(
     (x_test_skip_coverage, "test --skip=coverage"),
     (x_test_skip_coverage_map, "test --skip=coverage-map"),
     (x_test_skip_coverage_run, "test --skip=coverage-run"),
-    // FIXME(Zalathar): This doesn't skip the coverage-map or coverage-run tests.
     (x_test_skip_tests, "test --skip=tests"),
     (x_test_skip_tests_coverage, "test --skip=tests/coverage"),
     // From `src/ci/docker/scripts/stage_2_test_set2.sh`.

--- a/src/bootstrap/src/core/builder/mod.rs
+++ b/src/bootstrap/src/core/builder/mod.rs
@@ -515,11 +515,13 @@ pub struct ShouldRun<'a> {
 
     // use a BTreeSet to maintain sort order
     paths: BTreeSet<PathSet>,
+
+    default_to_suites_only: bool,
 }
 
 impl<'a> ShouldRun<'a> {
     fn new(builder: &'a Builder<'_>, kind: Kind) -> ShouldRun<'a> {
-        ShouldRun { builder, kind, paths: BTreeSet::new() }
+        ShouldRun { builder, kind, paths: BTreeSet::new(), default_to_suites_only: false }
     }
 
     /// Indicates it should run if the command-line selects the given crate or
@@ -635,6 +637,28 @@ impl<'a> ShouldRun<'a> {
             }
         }
         sets
+    }
+
+    /// When generating pathsets for a step that is being run "by default"
+    /// (i.e. when running bootstrap without an explicit command-line path),
+    /// discard any paths that were not registered as test suites.
+    ///
+    /// This is basically a hack to make path-based skipping work properly for
+    /// coverage tests, since otherwise the `coverage-map` and `coverage-run`
+    /// aliases would prevent `./x test --skip=tests` from skipping them.
+    pub(crate) fn default_to_suites_only(mut self) -> Self {
+        self.default_to_suites_only = true;
+        self
+    }
+
+    /// When the corresponding step is run "by default" (without explicit command-line paths),
+    /// act as though the user had explicitly specified these paths.
+    fn default_pathsets(&self) -> Vec<PathSet> {
+        let mut default_pathsets = self.paths.iter().cloned().collect::<Vec<_>>();
+        if self.default_to_suites_only {
+            default_pathsets.retain(|p| matches!(p, PathSet::Suite(_)));
+        }
+        default_pathsets
     }
 }
 

--- a/src/ci/docker/scripts/stage_2_test_set2.sh
+++ b/src/ci/docker/scripts/stage_2_test_set2.sh
@@ -25,7 +25,5 @@ fi
   ${SKIP_TIDY:+$SKIP_TIDY} \
   ${SKIP_RUST_ANALYZER:+$SKIP_RUST_ANALYZER} \
   --skip tests \
-  --skip coverage-map \
-  --skip coverage-run \
   --skip library \
   --skip tidyselftest


### PR DESCRIPTION
- Alternative to https://github.com/rust-lang/rust/pull/159079
---

When bootstrap runs a step by default, without explicit paths, it will normally act as though the user had explicitly requested all of the paths and aliases that the step registered through `ShouldRun`.

For the coverage test suite, that gives the wrong outcome. Running a command like `./x test --skip=tests` or `./x test --skip=coverage` should skip the coverage tests, but instead the coverage tests would run anyway, due to the `coverage-map` and `coverage-run` aliases being treated as implied command-line arguments.

This PR fixes that problem by adding a special flag to `ShouldRun`. When creating pathsets for a step that is being run by default, if the step has set the `default_to_suites_only` flag, all non-suite pathsets are discarded. That gives the desired behaviour for skipping coverage tests, without affecting other steps, since other steps don't set the flag.

The end result is that `./x test --skip=tests` should now skip the coverage tests, as intended. This lets us remove some `--skip` arguments from CI scripts, which were only required by the previous incorrect behaviour.

---

The `default_to_suites_only` flag is a bit of a hack, but to me it seems like the cleanest way to resolve this problem without having to completely overhaul how CLI paths work, which is a much bigger task. And I think being able to remove the weird extra `--skip` arguments from CI scripts makes this a net positive.

r? jieyouxu