### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/compiler/rustc_ast_pretty/src/pprust/state/expr.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state/expr.rs
@@ -778,7 +778,7 @@ impl<'a> State<'a> {
             }
             ast::ExprKind::InlineAsm(a) => {
                 // FIXME: Print `builtin # asm` once macro `asm` uses `builtin_syntax`.
-                self.word("asm!");
+                self.word(format!("{}!", a.asm_macro.macro_name()));
                 self.print_inline_asm(a);
             }
             ast::ExprKind::FormatArgs(fmt) => {

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
@@ -431,13 +431,16 @@ impl<'tcx> ForbidParamUsesFolder<'tcx> {
                 diag.span_note(impl_.self_ty.span, "not a concrete type");
             }
         }
-        if matches!(self.context, ForbidParamContext::ConstArgument)
-            && self.tcx.features().min_generic_const_args()
-        {
-            if !self.tcx.features().generic_const_args() {
-                diag.help("add `#![feature(generic_const_args)]` to allow generic expressions as the RHS of const items");
-            } else {
+        if matches!(self.context, ForbidParamContext::ConstArgument) {
+            if self.tcx.features().generic_const_args() {
                 diag.help("consider factoring the expression into a `type const` item and use it as the const argument instead");
+            } else if self.tcx.features().min_generic_const_args() {
+                diag.help("add `#![feature(generic_const_args)]` and extract the expression into a `type const` item");
+            } else if self.tcx.sess.is_nightly_build() {
+                diag.help(
+                    "add `#![feature(generic_const_exprs)]` to allow generic const expressions",
+                );
+                diag.help("alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item");
             }
         }
         diag.emit()

--- a/compiler/rustc_hir_pretty/src/lib.rs
+++ b/compiler/rustc_hir_pretty/src/lib.rs
@@ -1740,7 +1740,7 @@ impl<'a> State<'a> {
                 self.print_expr_cond_paren(result, self.precedence(result) < ExprPrecedence::Jump);
             }
             hir::ExprKind::InlineAsm(asm) => {
-                self.word("asm!");
+                self.word(format!("{}!", asm.asm_macro.macro_name()));
                 self.print_inline_asm(asm);
             }
             hir::ExprKind::OffsetOf(container, fields) => {

--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -1730,10 +1730,10 @@ mod size_asserts {
 
     use super::*;
     // tidy-alphabetical-start
-    static_assert_size!(BasicBlockData<'_>, 160);
+    static_assert_size!(BasicBlockData<'_>, 144);
     static_assert_size!(LocalDecl<'_>, 40);
     static_assert_size!(SourceScopeData<'_>, 64);
-    static_assert_size!(Statement<'_>, 56);
+    static_assert_size!(Statement<'_>, 40);
     static_assert_size!(Terminator<'_>, 104);
     static_assert_size!(VarDebugInfo<'_>, 88);
     // tidy-alphabetical-end

--- a/compiler/rustc_middle/src/mir/statement.rs
+++ b/compiler/rustc_middle/src/mir/statement.rs
@@ -2,6 +2,7 @@
 
 use std::ops;
 
+use rustc_data_structures::outline;
 use tracing::{debug, instrument};
 
 use super::interpret::GlobalAlloc;
@@ -1034,66 +1035,107 @@ impl RawPtrKind {
     }
 }
 
+// FIXME(panstromek)
+//  I'd like to use real ThinVec here, but it fails to borrow check,
+//  probably because ThinVec doesn't have #[may_dangle] on Drop impl?
+type ThinVec<T> = Option<Box<Vec<T>>>;
+
+// This collection is almost always empty, so we
+// use thin representation and optimize all methods
+// for that by inlining the empty check
+// and outlining the rest.
 #[derive(Default, Debug, Clone, TyEncodable, TyDecodable, StableHash, TypeFoldable, TypeVisitable)]
-pub struct StmtDebugInfos<'tcx>(Vec<StmtDebugInfo<'tcx>>);
+pub struct StmtDebugInfos<'tcx>(ThinVec<StmtDebugInfo<'tcx>>);
 
 impl<'tcx> StmtDebugInfos<'tcx> {
     pub fn push(&mut self, debuginfo: StmtDebugInfo<'tcx>) {
-        self.0.push(debuginfo);
+        self.0.get_or_insert_default().push(debuginfo);
     }
-
+    #[inline]
     pub fn drop_debuginfo(&mut self) {
-        self.0.clear();
+        match &mut self.0 {
+            None => (),
+            Some(v) => outline(move || v.clear()),
+        }
     }
 
+    #[inline]
     pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
+        match &self.0 {
+            None => true,
+            Some(v) => outline(move || v.is_empty()),
+        }
     }
-
+    #[inline]
     pub fn prepend(&mut self, debuginfos: &mut Self) {
         if debuginfos.is_empty() {
             return;
         };
-        debuginfos.0.append(self);
-        std::mem::swap(debuginfos, self);
+        outline(move || {
+            debuginfos.append(self);
+            std::mem::swap(debuginfos, self);
+        })
     }
-
+    #[inline]
     pub fn append(&mut self, debuginfos: &mut Self) {
         if debuginfos.is_empty() {
             return;
         };
-        self.0.append(debuginfos);
+        outline(move || {
+            self.0.get_or_insert_default().append(debuginfos.0.as_mut().unwrap().as_mut())
+        });
     }
-
+    #[inline]
     pub fn extend(&mut self, debuginfos: &Self) {
         if debuginfos.is_empty() {
             return;
         };
-        self.0.extend_from_slice(debuginfos);
+        outline(move || self.0.get_or_insert_default().extend_from_slice(debuginfos.as_slice()))
     }
 
+    #[inline]
+    pub fn as_slice(&self) -> &[StmtDebugInfo<'tcx>] {
+        match &self.0 {
+            None => &[],
+            Some(items) => outline(move || items.as_slice()),
+        }
+    }
+
+    #[inline]
+    pub fn as_mut_slice(&mut self) -> &mut [StmtDebugInfo<'tcx>] {
+        match &mut self.0 {
+            None => &mut [],
+            Some(items) => outline(move || items.as_mut_slice()),
+        }
+    }
+    #[inline]
     pub fn retain_locals(&mut self, locals: &DenseBitSet<Local>) {
-        self.retain(|debuginfo| match debuginfo {
-            StmtDebugInfo::AssignRef(local, _) | StmtDebugInfo::InvalidAssign(local) => {
-                locals.contains(*local)
-            }
-        });
+        match &mut self.0 {
+            None => (),
+            Some(items) => outline(move || {
+                items.retain(|debuginfo| match debuginfo {
+                    StmtDebugInfo::AssignRef(local, _) | StmtDebugInfo::InvalidAssign(local) => {
+                        locals.contains(*local)
+                    }
+                })
+            }),
+        }
     }
 }
 
 impl<'tcx> ops::Deref for StmtDebugInfos<'tcx> {
-    type Target = Vec<StmtDebugInfo<'tcx>>;
+    type Target = [StmtDebugInfo<'tcx>];
 
     #[inline]
-    fn deref(&self) -> &Vec<StmtDebugInfo<'tcx>> {
-        &self.0
+    fn deref(&self) -> &Self::Target {
+        self.as_slice()
     }
 }
 
 impl<'tcx> ops::DerefMut for StmtDebugInfos<'tcx> {
     #[inline]
-    fn deref_mut(&mut self) -> &mut Vec<StmtDebugInfo<'tcx>> {
-        &mut self.0
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.as_mut_slice()
     }
 }
 

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -407,6 +407,10 @@ pub(crate) struct ParamInNonTrivialAnonConst {
         "consider factoring the expression into a `type const` item and use it as the const argument instead"
     )]
     pub(crate) help_gca: bool,
+    #[help(
+        "alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item"
+    )]
+    pub(crate) help_suggest_gca: bool,
 }
 
 #[derive(Debug)]

--- a/compiler/rustc_resolve/src/error_helper.rs
+++ b/compiler/rustc_resolve/src/error_helper.rs
@@ -1288,9 +1288,11 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                     span,
                     name,
                     param_kind: is_type,
-                    help: self.tcx.sess.is_nightly_build(),
+                    help: self.tcx.sess.is_nightly_build()
+                        && !self.tcx.features().min_generic_const_args(),
                     is_gca,
                     help_gca: is_gca,
+                    help_suggest_gca: self.tcx.sess.is_nightly_build() && !is_gca,
                 })
             }
             ResolutionError::ParamInEnumDiscriminant { name, param_kind: is_type } => {

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -3983,9 +3983,12 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
                         span: lifetime_ref.ident.span,
                         name: lifetime_ref.ident.name,
                         param_kind: diagnostics::ParamKindInNonTrivialAnonConst::Lifetime,
-                        help: self.r.tcx.sess.is_nightly_build(),
+                        help: self.r.tcx.sess.is_nightly_build()
+                            && !self.r.features.min_generic_const_args(),
                         is_gca: self.r.features.generic_const_args(),
                         help_gca: self.r.features.generic_const_args(),
+                        help_suggest_gca: self.r.tcx.sess.is_nightly_build()
+                            && !self.r.features.generic_const_args(),
                     })
                     .emit()
             }

--- a/library/std/src/sys/args/sgx.rs
+++ b/library/std/src/sys/args/sgx.rs
@@ -1,9 +1,7 @@
-#![allow(implicit_provenance_casts)] // FIXME: this module systematically confuses pointers and integers
-
 use crate::ffi::OsString;
 use crate::num::NonZero;
 use crate::ops::Try;
-use crate::sync::atomic::{Atomic, AtomicUsize, Ordering};
+use crate::sync::OnceLock;
 use crate::sys::FromInner;
 use crate::sys::os_str::Buf;
 use crate::sys::pal::abi::usercalls::alloc;
@@ -13,8 +11,7 @@ use crate::{fmt, slice};
 // Specifying linkage/symbol name is solely to ensure a single instance between this crate and its unit tests
 #[cfg_attr(test, linkage = "available_externally")]
 #[unsafe(export_name = "_ZN16__rust_internals3std3sys3sgx4args4ARGSE")]
-static ARGS: Atomic<usize> = AtomicUsize::new(0);
-type ArgsStore = Vec<OsString>;
+static ARGS: OnceLock<Vec<OsString>> = OnceLock::new();
 
 #[cfg_attr(test, allow(dead_code))]
 pub unsafe fn init(argc: isize, argv: *const *const u8) {
@@ -23,15 +20,16 @@ pub unsafe fn init(argc: isize, argv: *const *const u8) {
         let args = args
             .iter()
             .map(|a| OsString::from_inner(Buf { inner: a.copy_user_buffer() }))
-            .collect::<ArgsStore>();
-        ARGS.store(Box::into_raw(Box::new(args)) as _, Ordering::Relaxed);
+            .collect::<Vec<_>>();
+
+        if let Err(_) = ARGS.set(args) {
+            rtabort!("init called twice");
+        }
     }
 }
 
 pub fn args() -> Args {
-    let args = unsafe { (ARGS.load(Ordering::Relaxed) as *const ArgsStore).as_ref() };
-    let slice = args.map(|args| args.as_slice()).unwrap_or(&[]);
-    Args { iter: slice.iter() }
+    Args { iter: ARGS.get().map_or_default(|args| args.iter()) }
 }
 
 pub struct Args {

--- a/src/bootstrap/src/core/debuggers/cdb.rs
+++ b/src/bootstrap/src/core/debuggers/cdb.rs
@@ -1,4 +1,3 @@
-use std::env;
 use std::path::PathBuf;
 
 use crate::core::config::TargetSelection;
@@ -8,18 +7,19 @@ pub(crate) struct Cdb {
 }
 
 /// We consult the registry to find the installed cdb.exe and try "Program Files" if that fails.
+#[cfg(windows)]
 pub(crate) fn discover_cdb(target: TargetSelection) -> Option<Cdb> {
-    if !cfg!(windows) || !target.ends_with("-pc-windows-msvc") {
+    if !target.ends_with("-pc-windows-msvc") {
         return None;
     }
 
-    let cdb_arch = if cfg!(target_arch = "x86") {
+    let cdb_arch = if target.starts_with("i686") {
         "x86"
-    } else if cfg!(target_arch = "x86_64") {
+    } else if target.starts_with("x86_64") {
         "x64"
-    } else if cfg!(target_arch = "aarch64") {
+    } else if target.starts_with("aarch64") || target.starts_with("arm64") {
         "arm64"
-    } else if cfg!(target_arch = "arm") {
+    } else if target.starts_with("arm") || target.starts_with("thumb") {
         "arm"
     } else {
         return None; // No compatible CDB.exe in the Windows 10 SDK
@@ -27,6 +27,11 @@ pub(crate) fn discover_cdb(target: TargetSelection) -> Option<Cdb> {
 
     let path = discover_cdb_registry(cdb_arch).or_else(|| discover_cdb_program_files(cdb_arch))?;
     Some(Cdb { cdb: path })
+}
+
+#[cfg(not(windows))]
+pub(crate) fn discover_cdb(_target: TargetSelection) -> Option<Cdb> {
+    None
 }
 
 #[cfg(windows)]
@@ -39,14 +44,11 @@ fn discover_cdb_registry(cdb_arch: &'static str) -> Option<PathBuf> {
     path.exists().then_some(path)
 }
 
-#[cfg(not(windows))]
-fn discover_cdb_registry(_cdb_arch: &'static str) -> Option<PathBuf> {
-    None
-}
-
+#[cfg(windows)]
 fn discover_cdb_program_files(cdb_arch: &'static str) -> Option<PathBuf> {
-    let mut path =
-        PathBuf::from(env::var_os("ProgramFiles(x86)").or_else(|| env::var_os("ProgramFiles"))?);
+    let mut path = PathBuf::from(
+        std::env::var_os("ProgramFiles(x86)").or_else(|| std::env::var_os("ProgramFiles"))?,
+    );
     path.extend([r"Windows Kits\10\Debuggers", cdb_arch, r"cdb.exe"]);
     path.exists().then_some(path)
 }

--- a/src/bootstrap/src/utils/change_tracker.rs
+++ b/src/bootstrap/src/utils/change_tracker.rs
@@ -637,7 +637,7 @@ pub const CONFIG_CHANGE_HISTORY: &[ChangeInfo] = &[
         summary: "New option `rust.compress-debuginfo` allows configuring whether Rust and C/C++ debuginfo should be compressed.",
     },
     ChangeInfo {
-        change_id: 999999,
+        change_id: 158912,
         severity: ChangeSeverity::Info,
         summary: "New config section `pgo` was introduced, to configure PGO profiling options. The `--rust-profile-use`/`--rust-profile-generate`/`--llvm-profile-use`/`--llvm-profile-generate` flags and the `rust.profile-use`/`rust.profile-generate` config options have been deprecated.",
     },

--- a/tests/assembly-llvm/c-variadic/riscv.rs
+++ b/tests/assembly-llvm/c-variadic/riscv.rs
@@ -64,18 +64,16 @@ unsafe extern "C" fn read_i32(ap: &mut VaList<'_>) -> i32 {
     // CHECK-LABEL: read_i32
     //
     // RISCV32: lw a2, 0(a0)
-    // RISCV32-NEXT: lw a1, 0(a2)
+    // RISCV32-NEXT: lw [[VAL:a[0-1]]], 0(a2)
     // RISCV32-NEXT: addi a2, a2, 4
-    // RISCV32-NEXT: sw a2, 0(a0)
-    // RISCV32-NEXT: mv a0, a1
-    // RISCV32-NEXT: ret
+    // RISCV32-NEXT: sw a2, 0([[PTR:a[0-1]]])
+    // RISCV32: ret
     //
     // RISCV64: ld a2, 0(a0)
-    // RISCV64-NEXT: lw a1, 0(a2)
+    // RISCV64-NEXT: lw [[VAL:a[0-1]]], 0(a2)
     // RISCV64-NEXT: addi a2, a2, 8
-    // RISCV64-NEXT: sd a2, 0(a0)
-    // RISCV64-NEXT: mv a0, a1
-    // RISCV64-NEXT: ret
+    // RISCV64-NEXT: sd a2, 0([[PTR:a[0-1]]])
+    // RISCV64: ret
     va_arg(ap)
 }
 
@@ -83,22 +81,20 @@ unsafe extern "C" fn read_i32(ap: &mut VaList<'_>) -> i32 {
 unsafe extern "C" fn read_i64(ap: &mut VaList<'_>) -> i64 {
     // CHECK-LABEL: read_i64
     //
-    // RISCV32: lw a1, 0(a0)
-    // RISCV32-NEXT: addi a1, a1, 7
-    // RISCV32-NEXT: andi a3, a1, -8
-    // RISCV32-NEXT: lw a2, 0(a3)
+    // RISCV32: lw [[PTR:a[0-1]]], 0(a0)
+    // RISCV32-NEXT: addi [[PTR]], [[PTR]], 7
+    // RISCV32-NEXT: andi a3, [[PTR]], -8
+    // RISCV32-NEXT: lw [[LOW:a[02]]], 0(a3)
     // RISCV32-NEXT: lw a1, 4(a3)
     // RISCV32-NEXT: addi a3, a3, 8
-    // RISCV32-NEXT: sw a3, 0(a0)
-    // RISCV32-NEXT: mv a0, a2
-    // RISCV32-NEXT: ret
+    // RISCV32-NEXT: sw a3, 0([[LIST:a[02]]])
+    // RISCV32: ret
     //
     // RISCV64: ld a2, 0(a0)
-    // RISCV64-NEXT: ld a1, 0(a2)
+    // RISCV64-NEXT: ld [[VAL:a[0-1]]], 0(a2)
     // RISCV64-NEXT: addi a2, a2, 8
-    // RISCV64-NEXT: sd a2, 0(a0)
-    // RISCV64-NEXT: mv a0, a1
-    // RISCV64-NEXT: ret
+    // RISCV64-NEXT: sd a2, 0([[PTR:a[0-1]]])
+    // RISCV64: ret
     va_arg(ap)
 }
 
@@ -107,15 +103,14 @@ unsafe extern "C" fn read_i64(ap: &mut VaList<'_>) -> i64 {
 unsafe extern "C" fn read_i128(ap: &mut VaList<'_>) -> i128 {
     // RISCV64-LABEL: read_i128
     //
-    // RISCV64: ld a1, 0(a0)
-    // RISCV64-NEXT: addi a1, a1, 15
-    // RISCV64-NEXT: andi a3, a1, -16
-    // RISCV64-NEXT: ld a2, 0(a3)
+    // RISCV64: ld [[PTR:a[0-1]]], 0(a0)
+    // RISCV64-NEXT: addi [[PTR]], [[PTR]], 15
+    // RISCV64-NEXT: andi a3, [[PTR]], -16
+    // RISCV64-NEXT: ld [[LOW:a[02]]], 0(a3)
     // RISCV64-NEXT: ld a1, 8(a3)
     // RISCV64-NEXT: addi a3, a3, 16
-    // RISCV64-NEXT: sd a3, 0(a0)
-    // RISCV64-NEXT: mv a0, a2
-    // RISCV64-NEXT: ret
+    // RISCV64-NEXT: sd a3, 0([[LIST:a[02]]])
+    // RISCV64: ret
     va_arg(ap)
 }
 

--- a/tests/ui/associated-consts/associated-const-type-parameter-arrays.stderr
+++ b/tests/ui/associated-consts/associated-const-type-parameter-arrays.stderr
@@ -6,6 +6,7 @@ LL |     let _array: [u32; <A as Foo>::Y];
    |
    = note: type parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/associated-consts/issue-47814.stderr
+++ b/tests/ui/associated-consts/issue-47814.stderr
@@ -9,6 +9,8 @@ note: not a concrete type
    |
 LL | impl<'a> ArpIPv4<'a> {
    |          ^^^^^^^^^^^
+   = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/associated-item/associated-item-duplicate-bounds.stderr
+++ b/tests/ui/associated-item/associated-item-duplicate-bounds.stderr
@@ -6,6 +6,7 @@ LL |     links: [u32; A::LINKS], // Shouldn't suggest bounds already there.
    |
    = note: type parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/adt_const_params/index-oob-ice-83993.stderr
+++ b/tests/ui/const-generics/adt_const_params/index-oob-ice-83993.stderr
@@ -6,6 +6,7 @@ LL |         let x: &'b ();
    |
    = note: lifetime parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/index-oob-ice-83993.rs:18:17
@@ -15,6 +16,7 @@ LL |         let _: &'b ();
    |
    = note: lifetime parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/const-arg-in-const-arg.min.stderr
+++ b/tests/ui/const-generics/const-arg-in-const-arg.min.stderr
@@ -6,6 +6,7 @@ LL |     let _: [u8; foo::<T>()];
    |
    = note: type parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/const-arg-in-const-arg.rs:16:23
@@ -15,6 +16,7 @@ LL |     let _: [u8; bar::<N>()];
    |
    = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/const-arg-in-const-arg.rs:18:23
@@ -24,6 +26,7 @@ LL |     let _: [u8; faz::<'a>(&())];
    |
    = note: lifetime parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/const-arg-in-const-arg.rs:20:23
@@ -33,6 +36,7 @@ LL |     let _: [u8; baz::<'a>(&())];
    |
    = note: lifetime parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/const-arg-in-const-arg.rs:21:23
@@ -42,6 +46,7 @@ LL |     let _: [u8; faz::<'b>(&())];
    |
    = note: lifetime parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/const-arg-in-const-arg.rs:23:23
@@ -51,6 +56,7 @@ LL |     let _: [u8; baz::<'b>(&())];
    |
    = note: lifetime parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/const-arg-in-const-arg.rs:27:23
@@ -60,6 +66,7 @@ LL |     let _ = [0; bar::<N>()];
    |
    = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/const-arg-in-const-arg.rs:29:23
@@ -69,6 +76,7 @@ LL |     let _ = [0; faz::<'a>(&())];
    |
    = note: lifetime parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/const-arg-in-const-arg.rs:31:23
@@ -78,6 +86,7 @@ LL |     let _ = [0; baz::<'a>(&())];
    |
    = note: lifetime parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/const-arg-in-const-arg.rs:32:23
@@ -87,6 +96,7 @@ LL |     let _ = [0; faz::<'b>(&())];
    |
    = note: lifetime parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/const-arg-in-const-arg.rs:34:23
@@ -96,6 +106,7 @@ LL |     let _ = [0; baz::<'b>(&())];
    |
    = note: lifetime parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/const-arg-in-const-arg.rs:35:24
@@ -105,6 +116,7 @@ LL |     let _: Foo<{ foo::<T>() }>;
    |
    = note: type parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/const-arg-in-const-arg.rs:36:24
@@ -114,6 +126,7 @@ LL |     let _: Foo<{ bar::<N>() }>;
    |
    = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/const-arg-in-const-arg.rs:38:24
@@ -123,6 +136,7 @@ LL |     let _: Foo<{ faz::<'a>(&()) }>;
    |
    = note: lifetime parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/const-arg-in-const-arg.rs:40:24
@@ -132,6 +146,7 @@ LL |     let _: Foo<{ baz::<'a>(&()) }>;
    |
    = note: lifetime parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/const-arg-in-const-arg.rs:41:24
@@ -141,6 +156,7 @@ LL |     let _: Foo<{ faz::<'b>(&()) }>;
    |
    = note: lifetime parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/const-arg-in-const-arg.rs:43:24
@@ -150,6 +166,7 @@ LL |     let _: Foo<{ baz::<'b>(&()) }>;
    |
    = note: lifetime parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/const-arg-in-const-arg.rs:44:27
@@ -159,6 +176,7 @@ LL |     let _ = Foo::<{ foo::<T>() }>;
    |
    = note: type parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/const-arg-in-const-arg.rs:45:27
@@ -168,6 +186,7 @@ LL |     let _ = Foo::<{ bar::<N>() }>;
    |
    = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/const-arg-in-const-arg.rs:47:27
@@ -177,6 +196,7 @@ LL |     let _ = Foo::<{ faz::<'a>(&()) }>;
    |
    = note: lifetime parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/const-arg-in-const-arg.rs:49:27
@@ -186,6 +206,7 @@ LL |     let _ = Foo::<{ baz::<'a>(&()) }>;
    |
    = note: lifetime parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/const-arg-in-const-arg.rs:50:27
@@ -195,6 +216,7 @@ LL |     let _ = Foo::<{ faz::<'b>(&()) }>;
    |
    = note: lifetime parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/const-arg-in-const-arg.rs:52:27
@@ -204,6 +226,7 @@ LL |     let _ = Foo::<{ baz::<'b>(&()) }>;
    |
    = note: lifetime parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error[E0747]: unresolved item provided when a constant was expected
   --> $DIR/const-arg-in-const-arg.rs:16:23

--- a/tests/ui/const-generics/const-argument-if-length.min.stderr
+++ b/tests/ui/const-generics/const-argument-if-length.min.stderr
@@ -6,6 +6,7 @@ LL |     pad: [u8; is_zst::<T>()],
    |
    = note: type parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error[E0277]: the size for values of type `T` cannot be known at compilation time
   --> $DIR/const-argument-if-length.rs:16:12

--- a/tests/ui/const-generics/const-argument-non-static-lifetime.min.stderr
+++ b/tests/ui/const-generics/const-argument-non-static-lifetime.min.stderr
@@ -6,6 +6,7 @@ LL |         let _: &'a ();
    |
    = note: lifetime parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/defaults/complex-generic-default-expr.min.stderr
+++ b/tests/ui/const-generics/defaults/complex-generic-default-expr.min.stderr
@@ -6,6 +6,7 @@ LL | struct Foo<const N: usize, const M: usize = { N + 1 }>;
    |
    = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/complex-generic-default-expr.rs:9:62
@@ -15,6 +16,7 @@ LL | struct Bar<T, const TYPE_SIZE: usize = { std::mem::size_of::<T>() }>(T);
    |
    = note: type parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/early/const_arg_trivial_macro_expansion-4.stderr
+++ b/tests/ui/const-generics/early/const_arg_trivial_macro_expansion-4.stderr
@@ -9,6 +9,7 @@ LL | fn foo<const N: usize>() -> Foo<{ arg!{} arg!{} }> { loop {} }
    |
    = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
    = note: this error originates in the macro `arg` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: generic parameters may not be used in const operations
@@ -22,6 +23,7 @@ LL | fn foo<const N: usize>() -> Foo<{ arg!{} arg!{} }> { loop {} }
    |
    = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
    = note: this error originates in the macro `arg` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: generic parameters may not be used in const operations
@@ -32,6 +34,7 @@ LL | fn bar<const N: usize>() -> [(); { empty!{}; N }] { loop {} }
    |
    = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/const-generics/early/macro_rules-braces.stderr
+++ b/tests/ui/const-generics/early/macro_rules-braces.stderr
@@ -28,6 +28,7 @@ LL |     let _: foo!({{ N }});
    |
    = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/macro_rules-braces.rs:36:19
@@ -37,6 +38,7 @@ LL |     let _: bar!({ N });
    |
    = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/macro_rules-braces.rs:41:20
@@ -46,6 +48,7 @@ LL |     let _: baz!({{ N }});
    |
    = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/macro_rules-braces.rs:46:19
@@ -55,6 +58,7 @@ LL |     let _: biz!({ N });
    |
    = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/const-generics/early/trivial-const-arg-macro-nested-braces-2.stderr
+++ b/tests/ui/const-generics/early/trivial-const-arg-macro-nested-braces-2.stderr
@@ -9,6 +9,7 @@ LL | fn foo<const N: usize>() -> A<{{ y!() }}> {
    |
    = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
    = note: this error originates in the macro `y` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error

--- a/tests/ui/const-generics/early/trivial-const-arg-macro-nested-braces.stderr
+++ b/tests/ui/const-generics/early/trivial-const-arg-macro-nested-braces.stderr
@@ -9,6 +9,7 @@ LL | fn foo<const N: usize>() -> A<{ y!() }> {
    |
    = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
    = note: this error originates in the macro `y` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error

--- a/tests/ui/const-generics/early/trivial-const-arg-nested-braces.stderr
+++ b/tests/ui/const-generics/early/trivial-const-arg-nested-braces.stderr
@@ -6,6 +6,7 @@ LL | fn foo<const N: usize>() -> A<{ { N } }> {
    |
    = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/gca/suggest-const-item-for-generic-expr.rs
+++ b/tests/ui/const-generics/gca/suggest-const-item-for-generic-expr.rs
@@ -1,0 +1,26 @@
+// Regression test for https://github.com/rust-lang/rust/issues/156729
+//
+// When a generic parameter is used in a const operation, the diagnostic should
+// suggest creating a `type const` item as an alternative to `generic_const_exprs`.
+
+use std::mem::size_of;
+
+// Exact case from the issue: `Self` in a trait method.
+pub unsafe trait TrivialType: Copy {
+    fn as_bytes(&self) -> &[u8; size_of::<Self>()] {
+        //~^ ERROR generic parameters may not be used in const operations
+        todo!()
+    }
+}
+
+fn foo<T>() -> [u8; size_of::<T>()] {
+    //~^ ERROR generic parameters may not be used in const operations
+    todo!()
+}
+
+fn bar<const N: usize>() -> [u8; N + 1] {
+    //~^ ERROR generic parameters may not be used in const operations
+    todo!()
+}
+
+fn main() {}

--- a/tests/ui/const-generics/gca/suggest-const-item-for-generic-expr.stderr
+++ b/tests/ui/const-generics/gca/suggest-const-item-for-generic-expr.stderr
@@ -1,0 +1,32 @@
+error: generic parameters may not be used in const operations
+  --> $DIR/suggest-const-item-for-generic-expr.rs:10:43
+   |
+LL |     fn as_bytes(&self) -> &[u8; size_of::<Self>()] {
+   |                                           ^^^^ cannot perform const operation using `Self`
+   |
+   = note: type parameters may not be used in const expressions
+   = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
+
+error: generic parameters may not be used in const operations
+  --> $DIR/suggest-const-item-for-generic-expr.rs:16:31
+   |
+LL | fn foo<T>() -> [u8; size_of::<T>()] {
+   |                               ^ cannot perform const operation using `T`
+   |
+   = note: type parameters may not be used in const expressions
+   = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
+
+error: generic parameters may not be used in const operations
+  --> $DIR/suggest-const-item-for-generic-expr.rs:21:34
+   |
+LL | fn bar<const N: usize>() -> [u8; N + 1] {
+   |                                  ^ cannot perform const operation using `N`
+   |
+   = help: const parameters may only be used as standalone arguments here, i.e. `N`
+   = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
+
+error: aborting due to 3 previous errors
+

--- a/tests/ui/const-generics/generic_const_exprs/array-size-in-generic-struct-param.min.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/array-size-in-generic-struct-param.min.stderr
@@ -6,6 +6,7 @@ LL | struct ArithArrayLen<const N: usize>([u32; 0 + N]);
    |
    = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/array-size-in-generic-struct-param.rs:23:15
@@ -15,6 +16,7 @@ LL |     arr: [u8; CFG.arr_size],
    |
    = help: const parameters may only be used as standalone arguments here, i.e. `CFG`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: `Config` is forbidden as the type of a const generic parameter
   --> $DIR/array-size-in-generic-struct-param.rs:21:21

--- a/tests/ui/const-generics/generic_const_exprs/bad-multiply.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/bad-multiply.stderr
@@ -6,6 +6,7 @@ LL |     SmallVec<{ D * 2 }>:,
    |
    = help: const parameters may only be used as standalone arguments here, i.e. `D`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error[E0747]: constant provided when a type was expected
   --> $DIR/bad-multiply.rs:7:14

--- a/tests/ui/const-generics/generic_const_exprs/dependence_lint.full.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/dependence_lint.full.stderr
@@ -6,6 +6,7 @@ LL |     let _: [u8; size_of::<*mut T>()]; // error on stable, error with gce
    |
    = note: type parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/dependence_lint.rs:22:37
@@ -15,6 +16,7 @@ LL |     let _: [u8; if true { size_of::<T>() } else { 3 }]; // error on stable,
    |
    = note: type parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 warning: cannot use constants which depend on generic parameters in types
   --> $DIR/dependence_lint.rs:10:9

--- a/tests/ui/const-generics/generic_const_exprs/feature-attribute-missing-in-dependent-crate-ice.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/feature-attribute-missing-in-dependent-crate-ice.stderr
@@ -9,6 +9,8 @@ note: not a concrete type
    |
 LL | impl<const F: usize> aux::FromSlice for Wrapper<F> {
    |                                         ^^^^^^^^^^
+   = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/generic_const_exprs/feature-gate-generic_const_exprs.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/feature-gate-generic_const_exprs.stderr
@@ -6,6 +6,7 @@ LL | type Arr<const N: usize> = [u8; N - 1];
    |
    = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/generic_const_exprs/issue-72787.min.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/issue-72787.min.stderr
@@ -6,6 +6,7 @@ LL |     Condition<{ LHS <= RHS }>: True
    |
    = help: const parameters may only be used as standalone arguments here, i.e. `LHS`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/issue-72787.rs:11:24
@@ -15,6 +16,7 @@ LL |     Condition<{ LHS <= RHS }>: True
    |
    = help: const parameters may only be used as standalone arguments here, i.e. `RHS`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/issue-72787.rs:23:25
@@ -24,6 +26,7 @@ LL |     IsLessOrEqual<{ 8 - I }, { 8 - J }>: True,
    |
    = help: const parameters may only be used as standalone arguments here, i.e. `I`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/issue-72787.rs:23:36
@@ -33,6 +36,7 @@ LL |     IsLessOrEqual<{ 8 - I }, { 8 - J }>: True,
    |
    = help: const parameters may only be used as standalone arguments here, i.e. `J`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/const-generics/generic_const_exprs/issue-72819-generic-in-const-eval.min.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/issue-72819-generic-in-const-eval.min.stderr
@@ -6,6 +6,7 @@ LL | where Assert::<{N < usize::MAX / 2}>: IsTrue,
    |
    = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/generic_const_exprs/issue-74713.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/issue-74713.stderr
@@ -6,6 +6,7 @@ LL |         let _: &'a ();
    |
    = note: lifetime parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error[E0308]: mismatched types
   --> $DIR/issue-74713.rs:3:10

--- a/tests/ui/const-generics/generic_const_exprs/trivial-anon-const-use-cases.min.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/trivial-anon-const-use-cases.min.stderr
@@ -6,6 +6,7 @@ LL |     stuff: [u8; { S + 1 }], // `S + 1` is NOT a valid const expression in t
    |
    = help: const parameters may only be used as standalone arguments here, i.e. `S`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/ice-68875.stderr
+++ b/tests/ui/const-generics/ice-68875.stderr
@@ -3,6 +3,9 @@ error: generic `Self` types are currently not permitted in anonymous constants
    |
 LL |     data: &'a [u8; Self::SIZE],
    |                    ^^^^
+   |
+   = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/intrinsics-type_name-as-const-argument.min.stderr
+++ b/tests/ui/const-generics/intrinsics-type_name-as-const-argument.min.stderr
@@ -6,6 +6,7 @@ LL |     T: Trait<{ std::intrinsics::type_name::<T>() }>,
    |
    = note: type parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: `&'static str` is forbidden as the type of a const generic parameter
   --> $DIR/intrinsics-type_name-as-const-argument.rs:9:22

--- a/tests/ui/const-generics/issue-46511.stderr
+++ b/tests/ui/const-generics/issue-46511.stderr
@@ -6,6 +6,7 @@ LL |     _a: [u8; std::mem::size_of::<&'a mut u8>()]
    |
    = note: lifetime parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error[E0392]: lifetime parameter `'a` is never used
   --> $DIR/issue-46511.rs:3:12

--- a/tests/ui/const-generics/issues/issue-56445-2.stderr
+++ b/tests/ui/const-generics/issues/issue-56445-2.stderr
@@ -9,6 +9,8 @@ note: not a concrete type
    |
 LL | impl<'a> OnDiskDirEntry<'a> {
    |          ^^^^^^^^^^^^^^^^^^
+   = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/issues/issue-56445-3.stderr
+++ b/tests/ui/const-generics/issues/issue-56445-3.stderr
@@ -3,6 +3,9 @@ error: generic `Self` types are currently not permitted in anonymous constants
    |
 LL |     ram: [u8; Self::SIZE],
    |               ^^^^
+   |
+   = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/issues/issue-67375.min.stderr
+++ b/tests/ui/const-generics/issues/issue-67375.min.stderr
@@ -6,6 +6,7 @@ LL |     inner: [(); { [|_: &T| {}; 0].len() }],
    |
    = note: type parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error[E0392]: type parameter `T` is never used
   --> $DIR/issue-67375.rs:5:12

--- a/tests/ui/const-generics/issues/issue-67945-1.min.stderr
+++ b/tests/ui/const-generics/issues/issue-67945-1.min.stderr
@@ -6,6 +6,7 @@ LL |         let x: S = MaybeUninit::uninit();
    |
    = note: type parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/issue-67945-1.rs:13:45
@@ -15,6 +16,7 @@ LL |         let b = &*(&x as *const _ as *const S);
    |
    = note: type parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error[E0392]: type parameter `S` is never used
   --> $DIR/issue-67945-1.rs:7:12

--- a/tests/ui/const-generics/issues/issue-67945-2.min.stderr
+++ b/tests/ui/const-generics/issues/issue-67945-2.min.stderr
@@ -3,6 +3,9 @@ error: generic `Self` types are currently not permitted in anonymous constants
    |
 LL |         let x: Option<Box<Self>> = None;
    |                           ^^^^
+   |
+   = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/issues/issue-67945-3.min.stderr
+++ b/tests/ui/const-generics/issues/issue-67945-3.min.stderr
@@ -6,6 +6,7 @@ LL |         let x: Option<S> = None;
    |
    = note: type parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error[E0392]: type parameter `S` is never used
   --> $DIR/issue-67945-3.rs:9:12

--- a/tests/ui/const-generics/issues/issue-67945-4.min.stderr
+++ b/tests/ui/const-generics/issues/issue-67945-4.min.stderr
@@ -6,6 +6,7 @@ LL |         let x: Option<Box<S>> = None;
    |
    = note: type parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error[E0392]: type parameter `S` is never used
   --> $DIR/issue-67945-4.rs:8:12

--- a/tests/ui/const-generics/issues/issue-68366.min.stderr
+++ b/tests/ui/const-generics/issues/issue-68366.min.stderr
@@ -6,6 +6,7 @@ LL | impl <const N: usize> Collatz<{Some(N)}> {}
    |
    = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: `Option<usize>` is forbidden as the type of a const generic parameter
   --> $DIR/issue-68366.rs:9:25

--- a/tests/ui/const-generics/issues/issue-76701-ty-param-in-const.stderr
+++ b/tests/ui/const-generics/issues/issue-76701-ty-param-in-const.stderr
@@ -6,6 +6,7 @@ LL | fn ty_param<T>() -> [u8; std::mem::size_of::<T>()] {
    |
    = note: type parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/issue-76701-ty-param-in-const.rs:6:42
@@ -15,6 +16,7 @@ LL | fn const_param<const N: usize>() -> [u8; N + 1] {
    |
    = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/issues/issue-80062.stderr
+++ b/tests/ui/const-generics/issues/issue-80062.stderr
@@ -6,6 +6,7 @@ LL |     let _: [u8; sof::<T>()];
    |
    = note: type parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/issues/issue-80375.stderr
+++ b/tests/ui/const-generics/issues/issue-80375.stderr
@@ -6,6 +6,7 @@ LL | struct MyArray<const COUNT: usize>([u8; COUNT + 1]);
    |
    = help: const parameters may only be used as standalone arguments here, i.e. `COUNT`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/legacy-const-generics-bad.stderr
+++ b/tests/ui/const-generics/legacy-const-generics-bad.stderr
@@ -18,6 +18,7 @@ LL |     legacy_const_generics::foo(0, N + 1, 2);
    |
    = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/mgca/adt_expr_arg_simple.stderr
+++ b/tests/ui/const-generics/mgca/adt_expr_arg_simple.stderr
@@ -10,7 +10,7 @@ error: generic parameters may not be used in const operations
 LL |     foo::<{ Some::<u32> { 0: const { N + 1 } } }>();
    |                                      ^
    |
-   = help: add `#![feature(generic_const_args)]` to allow generic expressions as the RHS of const items
+   = help: add `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/mgca/direct-const-arg-feature-gate.stderr
+++ b/tests/ui/const-generics/mgca/direct-const-arg-feature-gate.stderr
@@ -16,6 +16,7 @@ LL | fn foo<const N: usize>(_: [(); core::direct_const_arg!(N)]) {}
    |
    = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: expected expression, found `direct_const_arg!()` constant
   --> $DIR/direct-const-arg-feature-gate.rs:1:32

--- a/tests/ui/const-generics/mgca/double-inline-const.stderr
+++ b/tests/ui/const-generics/mgca/double-inline-const.stderr
@@ -9,7 +9,7 @@ note: not a concrete type
    |
 LL | impl<const N: usize> S<N> {
    |                      ^^^^
-   = help: add `#![feature(generic_const_args)]` to allow generic expressions as the RHS of const items
+   = help: add `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/mgca/double-wrapped-path-not-accidentally-stabilized.stderr
+++ b/tests/ui/const-generics/mgca/double-wrapped-path-not-accidentally-stabilized.stderr
@@ -6,6 +6,7 @@ LL |     f::<{ { N } }>();
    |
    = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/mgca/early-bound-param-lt-bad.stderr
+++ b/tests/ui/const-generics/mgca/early-bound-param-lt-bad.stderr
@@ -4,7 +4,7 @@ error: generic parameters may not be used in const operations
 LL |     T: Trait<const { let a: &'a (); 1 }>
    |                              ^^
    |
-   = help: add `#![feature(generic_const_args)]` to allow generic expressions as the RHS of const items
+   = help: add `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/mgca/explicit_anon_consts.stderr
+++ b/tests/ui/const-generics/mgca/explicit_anon_consts.stderr
@@ -40,7 +40,7 @@ error: generic parameters may not be used in const operations
 LL | type const ITEM3<const N: usize>: usize = const { N };
    |                                                   ^
    |
-   = help: add `#![feature(generic_const_args)]` to allow generic expressions as the RHS of const items
+   = help: add `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/explicit_anon_consts.rs:60:31
@@ -48,7 +48,7 @@ error: generic parameters may not be used in const operations
 LL |     T3: Trait<ASSOC = const { N }>,
    |                               ^
    |
-   = help: add `#![feature(generic_const_args)]` to allow generic expressions as the RHS of const items
+   = help: add `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/explicit_anon_consts.rs:69:58
@@ -56,7 +56,7 @@ error: generic parameters may not be used in const operations
 LL | struct Default3<const N: usize, const M: usize = const { N }>;
    |                                                          ^
    |
-   = help: add `#![feature(generic_const_args)]` to allow generic expressions as the RHS of const items
+   = help: add `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/explicit_anon_consts.rs:28:27
@@ -64,7 +64,7 @@ error: generic parameters may not be used in const operations
 LL |     let _3 = [(); const { N }];
    |                           ^
    |
-   = help: add `#![feature(generic_const_args)]` to allow generic expressions as the RHS of const items
+   = help: add `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/explicit_anon_consts.rs:33:26
@@ -72,7 +72,7 @@ error: generic parameters may not be used in const operations
 LL |     let _6: [(); const { N }] = todo!();
    |                          ^
    |
-   = help: add `#![feature(generic_const_args)]` to allow generic expressions as the RHS of const items
+   = help: add `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/explicit_anon_consts.rs:11:41
@@ -80,7 +80,7 @@ error: generic parameters may not be used in const operations
 LL | type Adt3<const N: usize> = Foo<const { N }>;
    |                                         ^
    |
-   = help: add `#![feature(generic_const_args)]` to allow generic expressions as the RHS of const items
+   = help: add `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/explicit_anon_consts.rs:19:42
@@ -88,7 +88,7 @@ error: generic parameters may not be used in const operations
 LL | type Arr3<const N: usize> = [(); const { N }];
    |                                          ^
    |
-   = help: add `#![feature(generic_const_args)]` to allow generic expressions as the RHS of const items
+   = help: add `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 13 previous errors
 

--- a/tests/ui/const-generics/mgca/mixed-direct-anon-expression-diagnostics.stderr
+++ b/tests/ui/const-generics/mgca/mixed-direct-anon-expression-diagnostics.stderr
@@ -10,7 +10,7 @@ error: generic parameters may not be used in const operations
 LL |     f::<{ (N, 1 + 1) }>();
    |            ^
    |
-   = help: add `#![feature(generic_const_args)]` to allow generic expressions as the RHS of const items
+   = help: add `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/mgca/selftyalias-containing-param.stderr
+++ b/tests/ui/const-generics/mgca/selftyalias-containing-param.stderr
@@ -9,7 +9,7 @@ note: not a concrete type
    |
 LL | impl<const N: usize> S<N> {
    |                      ^^^^
-   = help: add `#![feature(generic_const_args)]` to allow generic expressions as the RHS of const items
+   = help: add `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/mgca/selftyparam.stderr
+++ b/tests/ui/const-generics/mgca/selftyparam.stderr
@@ -4,7 +4,7 @@ error: generic parameters may not be used in const operations
 LL |     fn foo() -> [(); const { let _: Self; 1 }];
    |                                     ^^^^
    |
-   = help: add `#![feature(generic_const_args)]` to allow generic expressions as the RHS of const items
+   = help: add `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/mgca/size-of-generic-ptr-in-array-len.stderr
+++ b/tests/ui/const-generics/mgca/size-of-generic-ptr-in-array-len.stderr
@@ -10,7 +10,7 @@ error: generic parameters may not be used in const operations
 LL |     [0; const { size_of::<*mut T>() }];
    |                                ^
    |
-   = help: add `#![feature(generic_const_args)]` to allow generic expressions as the RHS of const items
+   = help: add `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/mgca/tuple_ctor_complex_args.stderr
+++ b/tests/ui/const-generics/mgca/tuple_ctor_complex_args.stderr
@@ -10,7 +10,7 @@ error: generic parameters may not be used in const operations
 LL |     with_point::<{ Point(const { N + 1 }, N) }>();
    |                                  ^
    |
-   = help: add `#![feature(generic_const_args)]` to allow generic expressions as the RHS of const items
+   = help: add `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/mgca/tuple_expr_arg_complex.stderr
+++ b/tests/ui/const-generics/mgca/tuple_expr_arg_complex.stderr
@@ -22,7 +22,7 @@ error: generic parameters may not be used in const operations
 LL |     takes_nested_tuple::<{ core::direct_const_arg!((N, (N, const { N + 1 }))) }>();
    |                                                                    ^
    |
-   = help: add `#![feature(generic_const_args)]` to allow generic expressions as the RHS of const items
+   = help: add `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/const-generics/mgca/type_const-on-generic-expr.stderr
+++ b/tests/ui/const-generics/mgca/type_const-on-generic-expr.stderr
@@ -4,7 +4,7 @@ error: generic parameters may not be used in const operations
 LL | type const FREE1<T>: usize = const { std::mem::size_of::<T>() };
    |                                                          ^
    |
-   = help: add `#![feature(generic_const_args)]` to allow generic expressions as the RHS of const items
+   = help: add `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/type_const-on-generic-expr.rs:8:51
@@ -12,7 +12,7 @@ error: generic parameters may not be used in const operations
 LL | type const FREE2<const I: usize>: usize = const { I + 1 };
    |                                                   ^
    |
-   = help: add `#![feature(generic_const_args)]` to allow generic expressions as the RHS of const items
+   = help: add `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/mgca/type_const-on-generic_expr-2.stderr
+++ b/tests/ui/const-generics/mgca/type_const-on-generic_expr-2.stderr
@@ -4,7 +4,7 @@ error: generic parameters may not be used in const operations
 LL |     type const N1<T>: usize = const { std::mem::size_of::<T>() };
    |                                                           ^
    |
-   = help: add `#![feature(generic_const_args)]` to allow generic expressions as the RHS of const items
+   = help: add `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/type_const-on-generic_expr-2.rs:15:52
@@ -12,7 +12,7 @@ error: generic parameters may not be used in const operations
 LL |     type const N2<const I: usize>: usize = const { I + 1 };
    |                                                    ^
    |
-   = help: add `#![feature(generic_const_args)]` to allow generic expressions as the RHS of const items
+   = help: add `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/type_const-on-generic_expr-2.rs:17:40
@@ -20,7 +20,7 @@ error: generic parameters may not be used in const operations
 LL |     type const N3: usize = const { 2 & X };
    |                                        ^
    |
-   = help: add `#![feature(generic_const_args)]` to allow generic expressions as the RHS of const items
+   = help: add `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/const-generics/min_const_generics/complex-expression.stderr
+++ b/tests/ui/const-generics/min_const_generics/complex-expression.stderr
@@ -6,6 +6,7 @@ LL | struct Break0<const N: usize>([u8; { N + 1 }]);
    |
    = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/complex-expression.rs:13:40
@@ -15,6 +16,7 @@ LL | struct Break1<const N: usize>([u8; { { N } }]);
    |
    = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/complex-expression.rs:17:17
@@ -24,6 +26,7 @@ LL |     let _: [u8; N + 1];
    |
    = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/complex-expression.rs:22:17
@@ -33,6 +36,7 @@ LL |     let _ = [0; N + 1];
    |
    = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/complex-expression.rs:26:45
@@ -42,6 +46,7 @@ LL | struct BreakTy0<T>(T, [u8; { size_of::<*mut T>() }]);
    |
    = note: type parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/complex-expression.rs:29:47
@@ -51,6 +56,7 @@ LL | struct BreakTy1<T>(T, [u8; { { size_of::<*mut T>() } }]);
    |
    = note: type parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/complex-expression.rs:33:32
@@ -60,6 +66,7 @@ LL |     let _: [u8; size_of::<*mut T>() + 1];
    |
    = note: type parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 warning: cannot use constants which depend on generic parameters in types
   --> $DIR/complex-expression.rs:38:17

--- a/tests/ui/const-generics/min_const_generics/forbid-non-static-lifetimes.stderr
+++ b/tests/ui/const-generics/min_const_generics/forbid-non-static-lifetimes.stderr
@@ -6,6 +6,7 @@ LL |     test::<{ let _: &'a (); 3 },>();
    |
    = note: lifetime parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/forbid-non-static-lifetimes.rs:21:16
@@ -15,6 +16,7 @@ LL |     [(); (|_: &'a u8| (), 0).1];
    |
    = note: lifetime parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/min_const_generics/forbid-self-no-normalize.stderr
+++ b/tests/ui/const-generics/min_const_generics/forbid-self-no-normalize.stderr
@@ -9,6 +9,8 @@ note: not a concrete type
    |
 LL | impl<T> BindsParam<T> for <T as AlwaysApplicable>::Assoc {
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/min_const_generics/self-ty-in-const-1.stderr
+++ b/tests/ui/const-generics/min_const_generics/self-ty-in-const-1.stderr
@@ -6,6 +6,7 @@ LL |     fn t1() -> [u8; std::mem::size_of::<Self>()];
    |
    = note: type parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic `Self` types are currently not permitted in anonymous constants
   --> $DIR/self-ty-in-const-1.rs:12:41
@@ -18,6 +19,8 @@ note: not a concrete type
    |
 LL | impl<T> Bar<T> {
    |         ^^^^^^
+   = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/min_const_generics/self-ty-in-const-2.stderr
+++ b/tests/ui/const-generics/min_const_generics/self-ty-in-const-2.stderr
@@ -9,6 +9,8 @@ note: not a concrete type
    |
 LL | impl<T> Baz for Bar<T> {
    |                 ^^^^^^
+   = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/outer-lifetime-in-const-generic-default.stderr
+++ b/tests/ui/const-generics/outer-lifetime-in-const-generic-default.stderr
@@ -6,6 +6,7 @@ LL |         let x: &'a ();
    |
    = note: lifetime parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/params-in-ct-in-ty-param-lazy-norm.min.stderr
+++ b/tests/ui/const-generics/params-in-ct-in-ty-param-lazy-norm.min.stderr
@@ -12,6 +12,7 @@ LL | struct Foo<T, U = [u8; std::mem::size_of::<T>()]>(T, U);
    |
    = note: type parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error[E0128]: generic parameter defaults cannot reference parameters before they are declared
   --> $DIR/params-in-ct-in-ty-param-lazy-norm.rs:8:21

--- a/tests/ui/const-generics/repeat_expr_hack_gives_right_generics.stderr
+++ b/tests/ui/const-generics/repeat_expr_hack_gives_right_generics.stderr
@@ -6,6 +6,7 @@ LL |     bar::<{ [1; N] }>();
    |
    = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/repeat_expr_hack_gives_right_generics.rs:22:19
@@ -15,6 +16,7 @@ LL |     bar::<{ [1; { N + 1 }] }>();
    |
    = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/type-relative-path-144547.min.stderr
+++ b/tests/ui/const-generics/type-relative-path-144547.min.stderr
@@ -3,6 +3,9 @@ error: generic parameters may not be used in const operations
    |
 LL |     type SupportedArray<T> = [T; <Self::InfoType as LevelInfo>::SUPPORTED_SLOTS];
    |                                   ^^^^^^^^^^^^^^
+   |
+   = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/const-eval/size-of-t.stderr
+++ b/tests/ui/consts/const-eval/size-of-t.stderr
@@ -6,6 +6,7 @@ LL |     let _arr: [u8; size_of::<T>()];
    |
    = note: type parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-generic-const-args.stderr
+++ b/tests/ui/feature-gates/feature-gate-generic-const-args.stderr
@@ -4,7 +4,7 @@ error: generic parameters may not be used in const operations
 LL | type const INC<const N: usize>: usize = const { N + 1 };
    |                                                 ^
    |
-   = help: add `#![feature(generic_const_args)]` to allow generic expressions as the RHS of const items
+   = help: add `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-min-generic-const-args.stderr
+++ b/tests/ui/feature-gates/feature-gate-min-generic-const-args.stderr
@@ -6,6 +6,7 @@ LL | fn foo<T: Trait>() -> [u8; <T as Trait>::ASSOC] {
    |
    = note: type parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error[E0658]: `type const` syntax is experimental
   --> $DIR/feature-gate-min-generic-const-args.rs:2:5

--- a/tests/ui/generics/param-in-ct-in-ty-param-default.stderr
+++ b/tests/ui/generics/param-in-ct-in-ty-param-default.stderr
@@ -6,6 +6,7 @@ LL | struct Foo<T, U = [u8; std::mem::size_of::<T>()]>(T, U);
    |
    = note: type parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/lifetimes/issue-64173-unused-lifetimes.stderr
+++ b/tests/ui/lifetimes/issue-64173-unused-lifetimes.stderr
@@ -6,6 +6,7 @@ LL |     beta: [(); foo::<&'a ()>()],
    |
    = note: lifetime parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error[E0392]: lifetime parameter `'s` is never used
   --> $DIR/issue-64173-unused-lifetimes.rs:3:12
@@ -20,6 +21,9 @@ error: generic `Self` types are currently not permitted in anonymous constants
    |
 LL |     array: [(); size_of::<&Self>()],
    |                            ^^^^
+   |
+   = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error[E0392]: lifetime parameter `'a` is never used
   --> $DIR/issue-64173-unused-lifetimes.rs:15:12

--- a/tests/ui/macros/macro-missing-fragment.rs
+++ b/tests/ui/macros/macro-missing-fragment.rs
@@ -17,6 +17,10 @@ macro_rules! accidental_dollar_prefix {
     ( $test:$tt ) => {}; //~ ERROR missing fragment
 }
 
+macro_rules! accidental_dollar_prefix_in_repetition {
+    ( $($test:$tt),* ) => {}; //~ ERROR missing fragment
+}
+
 fn main() {
     used_arm!();
     used_macro_unused_arm!();

--- a/tests/ui/macros/macro-missing-fragment.stderr
+++ b/tests/ui/macros/macro-missing-fragment.stderr
@@ -51,5 +51,19 @@ LL -     ( $test:$tt ) => {};
 LL +     ( $test:tt ) => {};
    |
 
-error: aborting due to 4 previous errors
+error: missing fragment specifier
+  --> $DIR/macro-missing-fragment.rs:21:15
+   |
+LL |     ( $($test:$tt),* ) => {};
+   |               ^
+   |
+   = note: fragment specifiers must be provided
+   = help: valid fragment specifiers are `ident`, `block`, `stmt`, `expr`, `pat`, `ty`, `lifetime`, `literal`, `path`, `meta`, `tt`, `item` and `vis`, along with `expr_2021` and `pat_param` for edition compatibility
+help: fragment specifiers should not be prefixed with `$`
+   |
+LL -     ( $($test:$tt),* ) => {};
+LL +     ( $($test:tt),* ) => {};
+   |
+
+error: aborting due to 5 previous errors
 

--- a/tests/ui/resolve/issue-39559.stderr
+++ b/tests/ui/resolve/issue-39559.stderr
@@ -6,6 +6,7 @@ LL |     entries: [T; D::dim()],
    |
    = note: type parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/type/pattern_types/assoc_const.default.stderr
+++ b/tests/ui/type/pattern_types/assoc_const.default.stderr
@@ -6,6 +6,7 @@ LL | fn foo<T: Foo>(_: pattern_type!(u32 is <T as Foo>::START..=<T as Foo>::END)
    |
    = note: type parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/assoc_const.rs:17:61
@@ -15,6 +16,7 @@ LL | fn foo<T: Foo>(_: pattern_type!(u32 is <T as Foo>::START..=<T as Foo>::END)
    |
    = note: type parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/assoc_const.rs:20:40
@@ -24,6 +26,7 @@ LL | fn bar<T: Foo>(_: pattern_type!(u32 is T::START..=T::END)) {}
    |
    = note: type parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/assoc_const.rs:20:51
@@ -33,6 +36,7 @@ LL | fn bar<T: Foo>(_: pattern_type!(u32 is T::START..=T::END)) {}
    |
    = note: type parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/unpretty/exhaustive-asm.expanded.stdout
+++ b/tests/ui/unpretty/exhaustive-asm.expanded.stdout
@@ -22,6 +22,10 @@ mod expressions {
             out(reg)
             _);
     }
+
+    /// ExprKind::InlineAsm, with the `naked_asm!` macro
+    #[unsafe(naked)]
+    extern "C" fn expr_naked_asm() { naked_asm!("ret"); }
 }
 
 mod items {

--- a/tests/ui/unpretty/exhaustive-asm.hir.stdout
+++ b/tests/ui/unpretty/exhaustive-asm.hir.stdout
@@ -21,6 +21,10 @@ mod expressions {
             out(reg)
             _);
     }
+
+    /// ExprKind::InlineAsm, with the `naked_asm!` macro
+    #[attr = Naked]
+    extern "C" fn expr_naked_asm() { naked_asm!("ret"); }
 }
 
 mod items {

--- a/tests/ui/unpretty/exhaustive-asm.rs
+++ b/tests/ui/unpretty/exhaustive-asm.rs
@@ -21,6 +21,12 @@ mod expressions {
             tmp = out(reg) _,
         );
     }
+
+    /// ExprKind::InlineAsm, with the `naked_asm!` macro
+    #[unsafe(naked)]
+    extern "C" fn expr_naked_asm() {
+        core::arch::naked_asm!("ret");
+    }
 }
 
 mod items {


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#159126 (Fix PR number in bootstrap's change tracker)
 - rust-lang/rust#156968 (diagnostics: suggest generic_const_args for const ops)
 - rust-lang/rust#159012 (Shrink mir::Statement to 40 bytes)
 - rust-lang/rust#158182 (std: use `OnceLock` for SGX argument storage)
 - rust-lang/rust#159114 (Add regression test for $-prefixed fragment specifier in repetition)
 - rust-lang/rust#159060 (Look for the cdb architecture that corresponds to the target triple)
 - rust-lang/rust#159089 (riscv: update c-variadic test for LLVM changes)
 - rust-lang/rust#159093 (pretty-print: use inline asm's actual macro name)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=159126,156968,159012,158182,159114,159060,159089,159093)
<!-- homu-ignore:end -->

