### PR TITLE
std: fix panic in Windows Stdin::read_vectored with pending surrogate

### DIFF
--- a/library/std/src/sys/stdio/windows.rs
+++ b/library/std/src/sys/stdio/windows.rs
@@ -278,7 +278,7 @@ impl io::Read for Stdin {
             Ok(bytes_copied)
         } else if buf.len() - bytes_copied < 4 {
             // Not enough space to get a UTF-8 byte. We will use the incomplete UTF8.
-            let mut utf16_buf = [MaybeUninit::new(0); 1];
+            let mut utf16_buf = [MaybeUninit::new(0); 2];
             // Read one u16 character.
             let read = read_u16s_fixup_surrogates(handle, &mut utf16_buf, 1, &mut self.surrogate)?;
             // Read bytes, using the (now-empty) self.incomplete_utf8 as extra space.


### PR DESCRIPTION
Fixes rust-lang/rust#158096.

The small-buffer path in `Stdin::read_vectored` allocates a one-element UTF-16 scratch buffer before calling `read_u16s_fixup_surrogates`.

When a pending surrogate exists, `read_u16s_fixup_surrogates` needs temporary storage for both the buffered surrogate and one newly read UTF-16 code unit. The one-element buffer causes an out-of-bounds slice before `ReadConsoleW` is called.

Increase the scratch buffer to two UTF-16 code units, matching the  function's requirements while leaving the normal read path unchanged.