### PR TITLE
doc: document wasm import symbol mangling

### DIFF
--- a/src/doc/rustc/src/symbol-mangling/index.md
+++ b/src/doc/rustc/src/symbol-mangling/index.md
@@ -17,13 +17,18 @@ The [`#[export_name]`attribute][reference-export_name] can be used to specify th
 Items listed in an [`extern` block][reference-extern-block] use the identifier of the item without mangling to refer to the item.
 The [`#[link_name]` attribute][reference-link_name] can be used to change that name.
 
-<!--
-FIXME: This is incomplete for wasm, per https://github.com/rust-lang/rust/blob/d4c364347ce65cf083d4419195b8232440928d4d/compiler/rustc_symbol_mangling/src/lib.rs#L191-L210
--->
+### WebAssembly import modules
+
+On WebAssembly targets, foreign items in an `extern` block using
+[`#[link(wasm_import_module = "...")]`][reference-link-attribute] are mangled even if
+`#[no_mangle]` or `#[link_name]` is used. This distinguishes imports with the same name from
+different WebAssembly modules. The requested module and import name are emitted separately in
+the WebAssembly import metadata.
 
 [reference-no_mangle]: ../../reference/abi.html#the-no_mangle-attribute
 [reference-export_name]: ../../reference/abi.html#the-export_name-attribute
 [reference-link_name]: ../../reference/items/external-blocks.html#the-link_name-attribute
+[reference-link-attribute]: ../../reference/items/external-blocks.html#the-link-attribute
 [reference-extern-block]: ../../reference/items/external-blocks.html
 
 ## Decoding

--- a/src/doc/rustc/src/symbol-mangling/index.md
+++ b/src/doc/rustc/src/symbol-mangling/index.md
@@ -19,14 +19,9 @@ The [`#[link_name]` attribute][reference-link_name] can be used to change that n
 
 ### WebAssembly import modules
 
-On WebAssembly targets, rustc currently mangles foreign items in an `extern` block using
-[`#[link(wasm_import_module = "...")]`][reference-link-attribute], even if `#[no_mangle]` or
-`#[link_name]` is used.
-
-This is an implementation detail of the current WebAssembly code generation and linking setup,
-and may change. It avoids current linker and code generation behavior that can conflate
-same-named imports from different WebAssembly modules. The requested module and import name are
-emitted as the `wasm-import-module` and `wasm-import-name` LLVM attributes.
+On WebAssembly targets, foreign items in `extern` blocks can use the same import name without
+conflicting when they use different [`#[link(wasm_import_module = "...")]`][reference-link-attribute]
+values.
 
 [reference-no_mangle]: ../../reference/abi.html#the-no_mangle-attribute
 [reference-export_name]: ../../reference/abi.html#the-export_name-attribute

--- a/src/doc/rustc/src/symbol-mangling/index.md
+++ b/src/doc/rustc/src/symbol-mangling/index.md
@@ -19,11 +19,14 @@ The [`#[link_name]` attribute][reference-link_name] can be used to change that n
 
 ### WebAssembly import modules
 
-On WebAssembly targets, foreign items in an `extern` block using
-[`#[link(wasm_import_module = "...")]`][reference-link-attribute] are mangled even if
-`#[no_mangle]` or `#[link_name]` is used. This distinguishes imports with the same name from
-different WebAssembly modules. The requested module and import name are emitted separately in
-the WebAssembly import metadata.
+On WebAssembly targets, rustc currently mangles foreign items in an `extern` block using
+[`#[link(wasm_import_module = "...")]`][reference-link-attribute], even if `#[no_mangle]` or
+`#[link_name]` is used.
+
+This is an implementation detail of the current WebAssembly code generation and linking setup,
+and may change. It avoids current linker and code generation behavior that can conflate
+same-named imports from different WebAssembly modules. The requested module and import name are
+emitted as the `wasm-import-module` and `wasm-import-name` LLVM attributes.
 
 [reference-no_mangle]: ../../reference/abi.html#the-no_mangle-attribute
 [reference-export_name]: ../../reference/abi.html#the-export_name-attribute


### PR DESCRIPTION
Document that foreign items from wasm_import_module extern blocks are mangled even with #[no_mangle] or #[link_name], so same-named imports from different WebAssembly modules remain distinct.