### PR TITLE
Include self-contained -L in native-static-libs

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -1786,39 +1786,68 @@ fn print_native_static_libs(
     all_native_libs: &[NativeLib],
     all_rust_dylibs: &[&Path],
 ) {
-    let mut lib_args: Vec<_> = all_native_libs
-        .iter()
-        .filter(|l| relevant_lib(sess, l))
-        .filter_map(|lib| {
-            let name = lib.name;
-            match lib.kind {
-                NativeLibKind::Static { bundle: Some(false), .. }
-                | NativeLibKind::Dylib { .. }
-                | NativeLibKind::Unspecified => {
-                    let verbatim = lib.verbatim;
-                    if sess.target.is_like_msvc {
-                        let (prefix, suffix) = sess.staticlib_components(verbatim);
-                        Some(format!("{prefix}{name}{suffix}"))
-                    } else if sess.target.linker_flavor.is_gnu() {
-                        Some(format!("-l{}{}", if verbatim { ":" } else { "" }, name))
-                    } else {
-                        Some(format!("-l{name}"))
+    let (linker_path, _) = linker_and_flavor(sess);
+    let self_contained_components =
+        self_contained_components(sess, CrateType::StaticLib, &linker_path);
+
+    let mut lib_args = Vec::new();
+
+    if self_contained_components.intersects(
+        LinkSelfContainedComponents::LIBC
+            | LinkSelfContainedComponents::UNWIND
+            | LinkSelfContainedComponents::MINGW,
+    ) {
+        let self_contained_dir = sess
+            .target_tlib_path
+            .dir
+            .join("self-contained")
+            .into_os_string()
+            .into_string()
+            .expect("non-utf8 component in path");
+
+        if sess.target.is_like_msvc {
+            lib_args.push(format!("/LIBPATH:{self_contained_dir}"));
+        } else {
+            lib_args.push("-L".to_string());
+            lib_args.push(self_contained_dir);
+        }
+    }
+
+    lib_args.extend(
+        all_native_libs
+            .iter()
+            .filter(|l| relevant_lib(sess, l))
+            .filter_map(|lib| {
+                let name = lib.name;
+                match lib.kind {
+                    NativeLibKind::Static { bundle: Some(false), .. }
+                    | NativeLibKind::Dylib { .. }
+                    | NativeLibKind::Unspecified => {
+                        let verbatim = lib.verbatim;
+                        if sess.target.is_like_msvc {
+                            let (prefix, suffix) = sess.staticlib_components(verbatim);
+                            Some(format!("{prefix}{name}{suffix}"))
+                        } else if sess.target.linker_flavor.is_gnu() {
+                            Some(format!("-l{}{}", if verbatim { ":" } else { "" }, name))
+                        } else {
+                            Some(format!("-l{name}"))
+                        }
                     }
+                    NativeLibKind::Framework { .. } => {
+                        // ld-only syntax, since there are no frameworks in MSVC
+                        Some(format!("-framework {name}"))
+                    }
+                    // These are included, no need to print them
+                    NativeLibKind::Static { bundle: None | Some(true), .. }
+                    | NativeLibKind::LinkArg
+                    | NativeLibKind::WasmImportModule
+                    | NativeLibKind::RawDylib { .. } => None,
                 }
-                NativeLibKind::Framework { .. } => {
-                    // ld-only syntax, since there are no frameworks in MSVC
-                    Some(format!("-framework {name}"))
-                }
-                // These are included, no need to print them
-                NativeLibKind::Static { bundle: None | Some(true), .. }
-                | NativeLibKind::LinkArg
-                | NativeLibKind::WasmImportModule
-                | NativeLibKind::RawDylib { .. } => None,
-            }
-        })
-        // deduplication of consecutive repeated libraries, see rust-lang/rust#113209
-        .dedup()
-        .collect();
+            })
+            // deduplication of consecutive repeated libraries, see rust-lang/rust#113209
+            .dedup(),
+    );
+
     for path in all_rust_dylibs {
         // FIXME deduplicate with add_dynamic_crate
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/159145)*
<!-- homu-ignore:end -->

_(I suggest reviewing with whitespace ignored.)_

rustc uses heuristics to determine whether the self-contained path should be on the linker search path.  It's important to get these right, because if self-contained is improperly missing from the search path, linking will fail (as seen [here][1]), but if it's improperly present, a broken executable can be produced due to e.g. linking two different libcs (as seen [here][2] and [here][3]).  All of this works reasonably well when rustc is doing the linking, but when linking is done externally, there's a problem: there's no way for a build tool to know whether rustc would include the self-contained path or not.  Without a way to find this out from rustc, the only way for a build tool to correctly link with a staticlib produced by rustc is to exactly reimplement rustc's heuristics.  Not ideal.

The existing `rustc --print native-static-libs` option exists to enable build tools to find out what linker flags should be used when linking a rustc-produced staticlib.  Without including the argument to add the self-contained directory to the search path when necessary, though, it doesn't meet its intended purpose — build tools relying on `native-static-libs` will still sometimes do the wrong thing.  Fixing this will make it possible for build tools to link the correct self-contained libraries when necessary, without each build tool having to match rustc's heuristics itself.  This will enable fixing real problems encountered with Meson, where either self-contained libraries were not found, or self-contained libraries were incorrectly linked.

[1]: https://github.com/mesonbuild/meson/pull/15216
[2]: https://bugs.gentoo.org/970166
[3]: https://bugs.gentoo.org/967728

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
