### PR TITLE
Fix --document-private-items not documenting private re-exports of hi…

### DIFF
--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1683,10 +1683,8 @@ fn first_non_private<'tcx>(
                         }
                         if (cx.document_hidden() ||
                             !cx.tcx.is_doc_hidden(use_def_id)) &&
-                            // We never check for "cx.document_private()"
-                            // because if a re-export is not fully public, it's never
-                            // documented.
-                            cx.tcx.local_visibility(local_use_def_id).is_public()
+                            (cx.tcx.local_visibility(local_use_def_id).is_public()
+                                || cx.document_private())
                         {
                             break 'reexps;
                         }
@@ -3108,7 +3106,7 @@ fn clean_extern_crate<'tcx>(
     let crate_def_id = cnum.as_def_id();
     let attrs = cx.tcx.hir_attrs(krate.hir_id());
     let ty_vis = cx.tcx.visibility(krate.owner_id);
-    let please_inline = ty_vis.is_public()
+    let please_inline = (ty_vis.is_public() || cx.document_private())
         && attrs.iter().any(|a| {
             matches!(
             a,
@@ -3196,7 +3194,8 @@ fn clean_use_statement_inner<'tcx>(
     // module, there isn't really a parent module, which makes the results
     // meaningless. In this case, we make sure the answer is `false`.
     let is_visible_from_parent_mod =
-        visibility.is_accessible_from(parent_mod, cx.tcx) && !current_mod.is_top_level_module();
+        visibility.is_accessible_from(parent_mod, cx.tcx)
+            && (!current_mod.is_top_level_module() || !import.vis_span.is_empty());
 
     if pub_underscore && let Some((_, inline_span)) = inline_attr {
         struct_span_code_err!(
@@ -3225,6 +3224,9 @@ fn clean_use_statement_inner<'tcx>(
     // Also check whether imports were asked to be inlined, in case we're trying to re-export a
     // crate in Rust 2018+
     let path = clean_path(path, cx);
+    let should_be_displayed = visibility.is_public()
+        || (cx.document_private() && !import.vis_span.is_empty());
+
     let inner = if kind == hir::UseKind::Glob {
         if !denied {
             let mut visited = DefIdSet::default();
@@ -3239,7 +3241,7 @@ fn clean_use_statement_inner<'tcx>(
                 return items;
             }
         }
-        Import::new_glob(resolve_use_source(cx, path), true)
+        Import::new_glob(resolve_use_source(cx, path), should_be_displayed)
     } else {
         let name = name.unwrap();
         if inline_attr.is_none()
@@ -3268,7 +3270,7 @@ fn clean_use_statement_inner<'tcx>(
             ));
             return items;
         }
-        Import::new_simple(name, resolve_use_source(cx, path), true)
+        Import::new_simple(name, resolve_use_source(cx, path), should_be_displayed)
     };
 
     vec![Item::from_def_id_and_parts(import_def_id.to_def_id(), None, ImportItem(inner), cx.tcx)]

--- a/src/librustdoc/passes/strip_priv_imports.rs
+++ b/src/librustdoc/passes/strip_priv_imports.rs
@@ -14,6 +14,11 @@ pub(crate) const STRIP_PRIV_IMPORTS: Pass = Pass {
 
 pub(crate) fn strip_priv_imports(krate: clean::Crate, cx: &mut DocContext<'_>) -> clean::Crate {
     let is_json_output = cx.is_json_output();
-    ImportStripper { tcx: cx.tcx, is_json_output, document_hidden: cx.document_hidden() }
-        .fold_crate(krate)
+    ImportStripper {
+        tcx: cx.tcx,
+        document_private: cx.document_private(),
+        is_json_output,
+        document_hidden: cx.document_hidden(),
+    }
+    .fold_crate(krate)
 }

--- a/src/librustdoc/passes/strip_private.rs
+++ b/src/librustdoc/passes/strip_private.rs
@@ -30,8 +30,13 @@ pub(crate) fn strip_private(mut krate: clean::Crate, cx: &mut DocContext<'_>) ->
             tcx: cx.tcx,
         };
         krate =
-            ImportStripper { tcx: cx.tcx, is_json_output, document_hidden: cx.document_hidden() }
-                .fold_crate(stripper.fold_crate(krate));
+            ImportStripper {
+                tcx: cx.tcx,
+                document_private: cx.document_private(),
+                is_json_output,
+                document_hidden: cx.document_hidden(),
+            }
+            .fold_crate(stripper.fold_crate(krate));
     }
 
     // strip all impls referencing private items

--- a/src/librustdoc/passes/stripper.rs
+++ b/src/librustdoc/passes/stripper.rs
@@ -266,6 +266,7 @@ impl DocFolder for ImplStripper<'_, '_> {
 /// This stripper discards all private import statements (`use`, `extern crate`)
 pub(crate) struct ImportStripper<'tcx> {
     pub(crate) tcx: TyCtxt<'tcx>,
+    pub(crate) document_private: bool,
     pub(crate) is_json_output: bool,
     pub(crate) document_hidden: bool,
 }
@@ -289,6 +290,14 @@ impl DocFolder for ImportStripper<'_> {
             {
                 debug!("ImportStripper: stripping {:?}", i.name);
                 None
+            }
+            clean::ImportItem(imp) if self.document_private => {
+                if !imp.should_be_displayed {
+                    debug!("ImportStripper: stripping {:?}", i.name);
+                    None
+                } else {
+                    Some(self.fold_item_recur(i))
+                }
             }
             // clean::ImportItem(_) if !self.document_hidden && i.is_doc_hidden() => None,
             clean::ExternCrateItem { .. } | clean::ImportItem(..)

--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -206,7 +206,8 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
         debug!("Going through module {m:?}");
         // Keep track of if there were any private modules in the path.
         let orig_inside_public_path = self.inside_public_path;
-        self.inside_public_path &= self.cx.tcx.local_visibility(def_id).is_public();
+        self.inside_public_path &= self.cx.tcx.local_visibility(def_id).is_public()
+            || self.cx.document_private();
 
         // Reimplementation of `walk_mod` because we need to do it in two passes (explanations in
         // the second loop):
@@ -470,7 +471,7 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
         let tcx = self.cx.tcx;
 
         let def_id = item.owner_id.to_def_id();
-        let is_pub = tcx.visibility(def_id).is_public();
+        let is_pub = tcx.visibility(def_id).is_public() || self.cx.document_private();
 
         if is_pub {
             self.store_path(item.owner_id.to_def_id());
@@ -592,7 +593,10 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
         import_id: Option<LocalDefId>,
     ) {
         // If inlining we only want to include public functions.
-        if !self.inlining || self.cx.tcx.visibility(item.owner_id).is_public() {
+        if !self.inlining
+            || self.cx.tcx.visibility(item.owner_id).is_public()
+            || self.cx.document_private()
+        {
             self.modules.last_mut().unwrap().foreigns.push(Foreign { item, renamed, import_id });
         }
     }

--- a/tests/rustdoc-html/document-private-items-reexports.rs
+++ b/tests/rustdoc-html/document-private-items-reexports.rs
@@ -1,0 +1,16 @@
+//@ compile-flags: --document-private-items
+
+#![crate_name = "document_private_items_reexports"]
+
+// @has document_private_items_reexports/index.html
+// @hasraw - 'ABC'
+// @hasraw - 'foo bar'
+// @has document_private_items_reexports/struct.ABC.html
+// @hasraw - 'pub(crate) struct ABC'
+
+#[doc(hidden)]
+pub(crate) struct __ABC;
+
+/// foo bar
+#[doc(inline)]
+pub(crate) use __ABC as ABC;


### PR DESCRIPTION
Fixes rust-lang/rust#159109

Under `--document-private-items`, `rustdoc` is expected to document private items and private re-exports. However, when a private re-export (e.g. `pub(crate) use`) with `#[doc(inline)]` points to a private/hidden item, it was not being documented.

### Root Cause
1. In `src/librustdoc/visit_ast.rs`, the AST is traversed to find items to document. `RustdocVisitor` determines if an item/module is public (`is_pub` and `inside_public_path`) based on whether its visibility is public.
2. Since private re-exports are not public, `is_pub` was computed as `false`, and local inlining (`maybe_inline_local`) was skipped.
3. Because the item was not locally inlined, it remained an `ImportItem` in the clean representation and was subsequently stripped by the `strip-hidden` pass because the target item was marked `#[doc(hidden)]`.

### Fix
1. Updated `RustdocVisitor` in `src/librustdoc/visit_ast.rs` to treat private items, parent modules, and foreign items as public (making them eligible for local inlining) when `document_private` is active.
2. Updated `clean_extern_crate` in `src/librustdoc/clean/mod.rs` to allow inlining of private `extern crate` statements if `document_private` is active.
3. Added a regression test case `tests/rustdoc-html/document-private-items-reexports.rs` that validates private re-exports are correctly documented.
