### PR TITLE
clippy: add missing proc_macros aux-build declarations.

### DIFF
--- a/src/tools/clippy/tests/ui/non_canonical_clone_impl.fixed
+++ b/src/tools/clippy/tests/ui/non_canonical_clone_impl.fixed
@@ -1,4 +1,5 @@
 //@aux-build:proc_macro_derive.rs
+//@aux-build:proc_macros.rs
 #![expect(clippy::clone_on_copy)]
 #![allow(clippy::assigning_clones)]
 #![no_main]

--- a/src/tools/clippy/tests/ui/non_canonical_clone_impl.rs
+++ b/src/tools/clippy/tests/ui/non_canonical_clone_impl.rs
@@ -1,4 +1,5 @@
 //@aux-build:proc_macro_derive.rs
+//@aux-build:proc_macros.rs
 #![expect(clippy::clone_on_copy)]
 #![allow(clippy::assigning_clones)]
 #![no_main]

--- a/src/tools/clippy/tests/ui/non_canonical_clone_impl.stderr
+++ b/src/tools/clippy/tests/ui/non_canonical_clone_impl.stderr
@@ -1,5 +1,5 @@
 error: non-canonical implementation of `clone` on a `Copy` type
-  --> tests/ui/non_canonical_clone_impl.rs:12:29
+  --> tests/ui/non_canonical_clone_impl.rs:13:29
    |
 LL |       fn clone(&self) -> Self {
    |  _____________________________^
@@ -12,7 +12,7 @@ LL | |     }
    = help: to override `-D warnings` add `#[allow(clippy::non_canonical_clone_impl)]`
 
 error: unnecessary implementation of `clone_from` on a `Copy` type
-  --> tests/ui/non_canonical_clone_impl.rs:17:5
+  --> tests/ui/non_canonical_clone_impl.rs:18:5
    |
 LL | /     fn clone_from(&mut self, source: &Self) {
 LL | |
@@ -22,7 +22,7 @@ LL | |     }
    | |_____^ help: remove it
 
 error: non-canonical implementation of `clone` on a `Copy` type
-  --> tests/ui/non_canonical_clone_impl.rs:82:29
+  --> tests/ui/non_canonical_clone_impl.rs:83:29
    |
 LL |       fn clone(&self) -> Self {
    |  _____________________________^
@@ -32,7 +32,7 @@ LL | |     }
    | |_____^ help: change this to: `{ *self }`
 
 error: unnecessary implementation of `clone_from` on a `Copy` type
-  --> tests/ui/non_canonical_clone_impl.rs:87:5
+  --> tests/ui/non_canonical_clone_impl.rs:88:5
    |
 LL | /     fn clone_from(&mut self, source: &Self) {
 LL | |
@@ -42,7 +42,7 @@ LL | |     }
    | |_____^ help: remove it
 
 error: non-canonical implementation of `clone` on a `Copy` type
-  --> tests/ui/non_canonical_clone_impl.rs:121:37
+  --> tests/ui/non_canonical_clone_impl.rs:122:37
    |
 LL |               fn clone(&self) -> Self {
    |  _____________________________________^
@@ -54,7 +54,7 @@ LL | |             }
    = note: this error originates in the macro `__inline_mac_mod_issue12788` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: non-canonical implementation of `clone` on a `Copy` type
-  --> tests/ui/non_canonical_clone_impl.rs:160:29
+  --> tests/ui/non_canonical_clone_impl.rs:161:29
    |
 LL |       fn clone(&self) -> Self {
    |  _____________________________^
@@ -64,7 +64,7 @@ LL | |     }
    | |_____^ help: change this to: `{ *self }`
 
 error: non-canonical implementation of `clone` on a `Copy` type
-  --> tests/ui/non_canonical_clone_impl.rs:187:33
+  --> tests/ui/non_canonical_clone_impl.rs:188:33
    |
 LL |           fn clone(&self) -> Self {
    |  _________________________________^

--- a/src/tools/clippy/tests/ui/non_canonical_partial_ord_impl.fixed
+++ b/src/tools/clippy/tests/ui/non_canonical_partial_ord_impl.fixed
@@ -1,4 +1,5 @@
 //@aux-build:proc_macro_derive.rs
+//@aux-build:proc_macros.rs
 #![no_main]
 
 extern crate proc_macros;

--- a/src/tools/clippy/tests/ui/non_canonical_partial_ord_impl.rs
+++ b/src/tools/clippy/tests/ui/non_canonical_partial_ord_impl.rs
@@ -1,4 +1,5 @@
 //@aux-build:proc_macro_derive.rs
+//@aux-build:proc_macros.rs
 #![no_main]
 
 extern crate proc_macros;

--- a/src/tools/clippy/tests/ui/non_canonical_partial_ord_impl.stderr
+++ b/src/tools/clippy/tests/ui/non_canonical_partial_ord_impl.stderr
@@ -1,5 +1,5 @@
 error: non-canonical implementation of `partial_cmp` on an `Ord` type
-  --> tests/ui/non_canonical_partial_ord_impl.rs:20:1
+  --> tests/ui/non_canonical_partial_ord_impl.rs:21:1
    |
 LL | / impl PartialOrd for A {
 LL | |
@@ -20,7 +20,7 @@ LL +     fn partial_cmp(&self, other: &Self) -> Option<Ordering> { Some(self.cmp
    |
 
 error: non-canonical implementation of `partial_cmp` on an `Ord` type
-  --> tests/ui/non_canonical_partial_ord_impl.rs:55:1
+  --> tests/ui/non_canonical_partial_ord_impl.rs:56:1
    |
 LL | / impl PartialOrd for C {
 LL | |
@@ -39,7 +39,7 @@ LL +     fn partial_cmp(&self, other: &Self) -> Option<Ordering> { Some(self.cmp
    |
 
 error: non-canonical implementation of `partial_cmp` on an `Ord` type
-  --> tests/ui/non_canonical_partial_ord_impl.rs:191:9
+  --> tests/ui/non_canonical_partial_ord_impl.rs:192:9
    |
 LL | /         impl PartialOrd for A {
 LL | |
@@ -59,7 +59,7 @@ LL +             fn partial_cmp(&self, other: &Self) -> Option<Ordering> { Some(
    |
 
 error: non-canonical implementation of `partial_cmp` on an `Ord` type
-  --> tests/ui/non_canonical_partial_ord_impl.rs:271:1
+  --> tests/ui/non_canonical_partial_ord_impl.rs:272:1
    |
 LL | / impl PartialOrd for K {
 LL | |
@@ -78,7 +78,7 @@ LL +     fn partial_cmp(&self, other: &Self) -> Option<Ordering> { Some(self.cmp
    |
 
 error: non-canonical implementation of `partial_cmp` on an `Ord` type
-  --> tests/ui/non_canonical_partial_ord_impl.rs:289:1
+  --> tests/ui/non_canonical_partial_ord_impl.rs:290:1
    |
 LL | / impl PartialOrd for L {
 LL | |


### PR DESCRIPTION
Fix two Clippy UI tests that import the `proc_macros` auxiliary crate without declaring it as an aux-build dependency.

Both tests only declare:

  //@aux-build:proc_macro_derive.rs

but they also contain:

  extern crate proc_macros;
  use proc_macros::inline_macros;

Because `proc_macros.rs` is not declared, ui_test does not pass an explicit `--extern proc_macros=.../libproc_macros.so` for these tests.  The tests can still appear to work when another test has already built `proc_macros.rs`, because rustc then finds it through the shared `-L .../tests/ui/auxiliary` directory.

That fallback is racy.  During a parallel Clippy UI run, the auxiliary build can leave `libproc_macros.rmeta` visible before `libproc_macros.so` is written.  If one of these tests starts in that window, rustc loads metadata for a proc-macro crate but has no dylib in the crate source, then ICEs in `rustc_metadata::creader` with:

  no dylib for a proc-macro crate

Adding `//@aux-build:proc_macros.rs` makes the dependency explicit, forcing ui_test to build `proc_macros.rs` before running the test and to pass the proc-macro dylib through `--extern`.

Happened to me when building rust (1.94.1 specifically) on a 64 core amd epyc.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
