### PR TITLE
Fix offset used to read the second part of scalar pairs from a `const`

### DIFF
--- a/compiler/rustc_codegen_ssa/src/mir/operand.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/operand.rs
@@ -227,10 +227,11 @@ impl<'a, 'tcx, V: CodegenObject> OperandRef<'tcx, V> {
             BackendRepr::ScalarPair {
                 a: a @ abi::Scalar::Initialized { .. },
                 b: b @ abi::Scalar::Initialized { .. },
-                b_offset,
+                b_offset: local_b_offset,
             } => {
                 let (a_size, b_size) = (a.size(bx), b.size(bx));
-                assert!(b_offset.bytes() > 0);
+                let alloc_b_offset = offset + local_b_offset;
+                assert!(alloc_b_offset.bytes() > 0);
                 let a_val = read_scalar(
                     offset,
                     a_size,
@@ -238,7 +239,7 @@ impl<'a, 'tcx, V: CodegenObject> OperandRef<'tcx, V> {
                     bx.scalar_pair_element_backend_type(layout, 0, true),
                 );
                 let b_val = read_scalar(
-                    b_offset,
+                    alloc_b_offset,
                     b_size,
                     b,
                     bx.scalar_pair_element_backend_type(layout, 1, true),

--- a/tests/codegen-llvm/const-array-of-pairs.rs
+++ b/tests/codegen-llvm/const-array-of-pairs.rs
@@ -1,0 +1,19 @@
+//@ compile-flags: -C no-prepopulate-passes
+
+#![crate_type = "lib"]
+
+// Regression test for https://github.com/rust-lang/rust/issues/159116
+// where a change had started reading at the wrong offset into a const
+// when the sub-object had BackendRepr::ScalarPair
+
+const PAIRS: [(u64, u64); 3] = [(1, 2), (3, 4), (5, 6)];
+
+// CHECK-LABEL: @read_not_first_pair
+#[no_mangle]
+pub fn read_not_first_pair() -> (u64, u64) {
+    // FIXME: This is clearly wrong
+
+    // CHECK: start:
+    // CHECK-NEXT: ret { i64, i64 } { i64 3, i64 2 }
+    PAIRS[1]
+}

--- a/tests/codegen-llvm/const-array-of-pairs.rs
+++ b/tests/codegen-llvm/const-array-of-pairs.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: -C no-prepopulate-passes
+//@ compile-flags: -O -C no-prepopulate-passes
 
 #![crate_type = "lib"]
 
@@ -6,12 +6,12 @@
 // where a change had started reading at the wrong offset into a const
 // when the sub-object had BackendRepr::ScalarPair
 
-const PAIRS: [(u64, u64); 3] = [(1, 2), (3, 4), (5, 6)];
+const PAIRS: [(u16, u16); 3] = [(1, 2), (3, 4), (5, 6)];
 
 // CHECK-LABEL: @read_not_first_pair
 #[no_mangle]
-pub fn read_not_first_pair() -> (u64, u64) {
+pub fn read_not_first_pair() -> (u16, u16) {
     // CHECK: start:
-    // CHECK-NEXT: ret { i64, i64 } { i64 3, i64 4 }
+    // CHECK-NEXT: ret { i16, i16 } { i16 3, i16 4 }
     PAIRS[1]
 }

--- a/tests/codegen-llvm/const-array-of-pairs.rs
+++ b/tests/codegen-llvm/const-array-of-pairs.rs
@@ -11,9 +11,7 @@ const PAIRS: [(u64, u64); 3] = [(1, 2), (3, 4), (5, 6)];
 // CHECK-LABEL: @read_not_first_pair
 #[no_mangle]
 pub fn read_not_first_pair() -> (u64, u64) {
-    // FIXME: This is clearly wrong
-
     // CHECK: start:
-    // CHECK-NEXT: ret { i64, i64 } { i64 3, i64 2 }
+    // CHECK-NEXT: ret { i64, i64 } { i64 3, i64 4 }
     PAIRS[1]
 }


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/159148)*
<!-- homu-ignore:end -->

Fixes https://github.com/rust-lang/rust/issues/159116

r? @workingjubilee 