### PR TITLE
triagebot: cc miri on any special-casing of miri in the standard library

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1466,6 +1466,14 @@ cc = ["@jieyouxu"]
 
 # Content-based mentions
 
+[mentions."miri"]
+type = "content"
+trigger_files = ["library"]
+message = """
+Any special-casing of Miri in the standard library requires review.
+"""
+cc = ["@rust-lang/miri"]
+
 [mentions."#[miri::intrinsic_fallback_is_spec]"]
 type = "content"
 message = """


### PR DESCRIPTION

---

Blocked until https://github.com/rust-lang/triagebot/pull/2462 is merged and deployed.
