### PR TITLE
compiler: redescribe llvmlike_vector_align as rust_vector_align

### DIFF
--- a/compiler/rustc_abi/src/callconv/reg.rs
+++ b/compiler/rustc_abi/src/callconv/reg.rs
@@ -69,7 +69,7 @@ impl Reg {
                 128 => dl.f128_align,
                 _ => panic!("unsupported float: {self:?}"),
             },
-            RegKind::Vector { .. } => dl.llvmlike_vector_align(self.size),
+            RegKind::Vector { .. } => dl.rust_vector_align(self.size),
         }
     }
 }

--- a/compiler/rustc_abi/src/layout.rs
+++ b/compiler/rustc_abi/src/layout.rs
@@ -1514,7 +1514,7 @@ where
             BackendRepr::SimdScalableVector { element, count, number_of_vectors },
             size.checked_mul(number_of_vectors.0 as u64, dl)
                 .ok_or_else(|| LayoutCalculatorError::SizeOverflow)?,
-            dl.llvmlike_vector_align(size),
+            dl.rust_vector_align(size),
         ),
         // Non-power-of-two vectors have padding up to the next power-of-two.
         // If we're a packed repr, remove the padding while keeping the alignment as close
@@ -1523,7 +1523,7 @@ where
             (BackendRepr::Memory { sized: true }, size, Align::max_aligned_factor(size))
         }
         SimdVectorKind::PackedFixed | SimdVectorKind::Fixed => {
-            (BackendRepr::SimdVector { element, count }, size, dl.llvmlike_vector_align(size))
+            (BackendRepr::SimdVector { element, count }, size, dl.rust_vector_align(size))
         }
     };
     let size = size.align_to(align);

--- a/compiler/rustc_abi/src/lib.rs
+++ b/compiler/rustc_abi/src/lib.rs
@@ -658,17 +658,25 @@ impl TargetDataLayout {
 
     /// psABI-mandated alignment for a vector type, if any
     #[inline]
-    fn cabi_vector_align(&self, vec_size: Size) -> Option<Align> {
+    fn c_vector_align(&self, vec_size: Size) -> Option<Align> {
         self.vector_align
             .iter()
             .find(|(size, _align)| *size == vec_size)
             .map(|(_size, align)| *align)
     }
 
-    /// an alignment resembling the one LLVM would pick for a vector
+    /// Rust-assigned alignment of any vector type
+    ///
+    /// When the shape of a vector matches that in a C psABI, we *must* agree when performing FFI.
+    /// This currently answers correctly for C compatibility purposes as it is a useful default.
+    /// Otherwise this choice is arbitrary, as vector types do not necessarily match hardware so
+    /// this can conjure "imaginary" answers that just happen to be convenient for us.
+    ///
+    /// Importantly, Rust vector alignment is not required to be monotonic between vector sizes,
+    /// even though it currently is.
     #[inline]
-    pub fn llvmlike_vector_align(&self, vec_size: Size) -> Align {
-        self.cabi_vector_align(vec_size)
+    pub fn rust_vector_align(&self, vec_size: Size) -> Align {
+        self.c_vector_align(vec_size)
             .unwrap_or(Align::from_bytes(vec_size.bytes().next_power_of_two()).unwrap())
     }
 


### PR DESCRIPTION
This is mostly a cosmetic change. The current form of this function tends to mislead people to assume it is implicitly "correct" in various ways by invoking LLVM as an authority.

It is only sort-of correct. More specifically, LLVM mostly doesn't care, and neither do we, except when it comes to FFI.

So, we have an arbitrary algorithm that works usefully in most cases. It is not inherently more correct than other arbitrary algorithms, so spell this out and weaken its contract.

<!-- homu-ignore:start -->
r? @scottmcm

I have various mostly-written PRs I was considering stuffing this commit in, including one that actually changes the algorithm as this suggests, but I figured I'd make this change first so that I stop having psychic lock contention.
<!-- homu-ignore:end -->
