### PR TITLE
impl_trait_overcaptures: Set MSRV to 1.82

### DIFF
--- a/compiler/rustc_lint/src/impl_trait_overcaptures.rs
+++ b/compiler/rustc_lint/src/impl_trait_overcaptures.rs
@@ -73,6 +73,7 @@ declare_lint! {
     @future_incompatible = FutureIncompatibleInfo {
         reason: fcw!(EditionSemanticsChange 2024 "rpit-lifetime-capture"),
     };
+    @msrv = "1.82";
 }
 
 declare_lint! {


### PR DESCRIPTION
`+ use<'a>` syntax was stabilized in Rust 1.82:
https://github.com/rust-lang/rust/pull/127672
