### PR TITLE
unsafe_attr_outside_unsafe: Set MSRV to 1.82

### DIFF
--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -4992,6 +4992,7 @@ declare_lint! {
     @future_incompatible = FutureIncompatibleInfo {
         reason: fcw!(EditionError 2024 "unsafe-attributes"),
     };
+    @msrv = "1.82";
 }
 
 declare_lint! {


### PR DESCRIPTION
`unsafe(attr)` syntax was stabilized in Rust 1.82:
https://github.com/rust-lang/rust/pull/128771
