### PR TITLE
missing_unsafe_on_extern: Set MSRV to 1.82

### DIFF
--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -4952,6 +4952,7 @@ declare_lint! {
     @future_incompatible = FutureIncompatibleInfo {
         reason: fcw!(EditionError 2024 "unsafe-extern"),
     };
+    @msrv = "1.82";
 }
 
 declare_lint! {


### PR DESCRIPTION
`unsafe extern` blocks were stabilized in 1.82:
https://github.com/rust-lang/rust/pull/127921
