### PR TITLE
rustc_target: Add acquire-release to implied features of v8

### DIFF
--- a/compiler/rustc_target/src/target_features.rs
+++ b/compiler/rustc_target/src/target_features.rs
@@ -194,7 +194,7 @@ static ARM_FEATURES: &[(&str, Stability, ImpliedFeatures)] = &[
     ("v6m", Unstable(sym::arm_target_feature), &["v6"]),
     ("v6t2", Unstable(sym::arm_target_feature), &["v6k", "v8m", "thumb2"]),
     ("v7", Unstable(sym::arm_target_feature), &["v6t2"]),
-    ("v8", Unstable(sym::arm_target_feature), &["v7"]),
+    ("v8", Unstable(sym::arm_target_feature), &["v7", "acquire-release"]),
     ("v8.1m.main", Unstable(sym::arm_target_feature), &["v8m.main"]),
     ("v8m", Unstable(sym::arm_target_feature), &["v6m"]),
     ("v8m.main", Unstable(sym::arm_target_feature), &["v7"]),


### PR DESCRIPTION


<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

`acquire-release` target feature has been added in https://github.com/rust-lang/rust/pull/158405, but I missed that existing `v8` target feature [implies it in LLVM](https://github.com/llvm/llvm-project/blob/llvmorg-22.1.8/llvm/lib/Target/ARM/ARMFeatures.td#L645).

r? @davidtwco


@rustbot label +O-arm +A-target-feature