### PR TITLE
c-variadic: Update cfg for 128-bit integers to fix build error on AArch64 ILP32

### DIFF
--- a/library/core/src/ffi/va_list.rs
+++ b/library/core/src/ffi/va_list.rs
@@ -371,25 +371,28 @@ unsafe impl VaArgSafe for usize {}
 // does provide `__int128` on 64-bit `*-pc-windows-msvc`, and we follow suit.
 cfg_select! {
     any(
-        target_arch = "aarch64",
-        target_arch = "amdgpu",
-        target_arch = "arm64ec",
-        target_arch = "bpf",
-        target_arch = "loongarch64",
-        target_arch = "mips64",
-        target_arch = "mips64r6",
-        target_arch = "nvptx64",
-        target_arch = "powerpc64",
-        target_arch = "riscv64",
-        target_arch = "s390x",
-        target_arch = "sparc64",
         target_arch = "wasm32",
-        target_arch = "wasm64",
-        target_arch = "x86_64",
+        all(target_arch = "x86_64", target_abi = "x32"),
+        all(
+            target_pointer_width = "64",
+            any(
+                target_arch = "aarch64",
+                target_arch = "amdgpu",
+                target_arch = "arm64ec",
+                target_arch = "bpf",
+                target_arch = "loongarch64",
+                target_arch = "mips64",
+                target_arch = "mips64r6",
+                target_arch = "nvptx64",
+                target_arch = "powerpc64",
+                target_arch = "riscv64",
+                target_arch = "s390x",
+                target_arch = "sparc64",
+                target_arch = "wasm64",
+                target_arch = "x86_64",
+            ),
+        ),
     ) => {
-        #[cfg(not(any(target_arch = "wasm32", target_abi = "x32", target_pointer_width = "64")))]
-        compile_error!("unexpected target architecture for 128-bit c-variadic");
-
         #[unstable_feature_bound(c_variadic_int128)]
         #[unstable(feature = "c_variadic_int128", issue = "155752")]
         unsafe impl VaArgSafe for i128 {}


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

This fixes build error on AArch64 ILP32 targets (aarch64-unknown-linux-gnu_ilp32, aarch64_be-unknown-linux-gnu_ilp32, arm64_32-apple-watchos) introduced in https://github.com/rust-lang/rust/pull/155429. See https://github.com/rust-lang/rust/pull/155429#discussion_r3563374982 for details.

The approach used in this PR (use exact cfgs instead of using a rough cfgs with checking unexpected case by `compile_error!`) is also based on what was proposed in that comment. The set of allowed cases should not be changed in this PR.

cc @folkertdev


@rustbot label +O-aarch64 +F-c_variadic