### PR TITLE
Explicitly materialize debuginfo tests for all debuggers

### DIFF
--- a/src/tools/compiletest/src/debuggers.rs
+++ b/src/tools/compiletest/src/debuggers.rs
@@ -1,58 +1,6 @@
-use std::env;
 use std::process::Command;
-use std::sync::Arc;
 
 use camino::Utf8Path;
-
-use crate::common::{Config, Debugger};
-
-pub(crate) fn configure_cdb(config: &Config) -> Option<Arc<Config>> {
-    config.cdb.as_ref()?;
-
-    Some(Arc::new(Config { debugger: Some(Debugger::Cdb), ..config.clone() }))
-}
-
-pub(crate) fn configure_gdb(config: &Config) -> Option<Arc<Config>> {
-    config.gdb_version?;
-
-    if config.matches_env("msvc") {
-        return None;
-    }
-
-    if config.remote_test_client.is_some() && !config.target.contains("android") {
-        println!(
-            "WARNING: debuginfo tests are not available when \
-             testing with remote"
-        );
-        return None;
-    }
-
-    if config.target.contains("android") {
-        println!(
-            "{} debug-info test uses tcp 5039 port.\
-             please reserve it",
-            config.target
-        );
-
-        // android debug-info test uses remote debugger so, we test 1 thread
-        // at once as they're all sharing the same TCP port to communicate
-        // over.
-        //
-        // we should figure out how to lift this restriction! (run them all
-        // on different ports allocated dynamically).
-        //
-        // SAFETY: at this point we are still single-threaded.
-        unsafe { env::set_var("RUST_TEST_THREADS", "1") };
-    }
-
-    Some(Arc::new(Config { debugger: Some(Debugger::Gdb), ..config.clone() }))
-}
-
-pub(crate) fn configure_lldb(config: &Config) -> Option<Arc<Config>> {
-    config.lldb.as_ref()?;
-
-    Some(Arc::new(Config { debugger: Some(Debugger::Lldb), ..config.clone() }))
-}
 
 pub(crate) fn query_cdb_version(cdb: &Utf8Path) -> Option<[u16; 4]> {
     let mut version = None;

--- a/src/tools/compiletest/src/directives.rs
+++ b/src/tools/compiletest/src/directives.rs
@@ -899,52 +899,82 @@ pub(crate) fn make_test_description(
     let mut ignore_message: Option<Cow<'static, str>> = None;
     let mut should_fail = false;
 
-    // Scan through the test file to handle `ignore-*`, `only-*`, and `needs-*` directives.
-    iter_directives(config, file_directives, &mut |ln @ &DirectiveLine { line_number, .. }| {
-        if !ln.applies_to_test_revision(test_revision) {
-            return;
-        }
-
-        // Parse `aux-*` directives, for use by up-to-date checks.
-        parse_and_update_aux(config, ln, aux_props);
-
-        macro_rules! decision {
-            ($e:expr) => {
-                match $e {
-                    IgnoreDecision::Ignore { reason } => {
-                        ignore_message = Some(reason.into());
-                    }
-                    IgnoreDecision::Error { message } => {
-                        error!("{path}:{line_number}: {message}");
-                        *poisoned = true;
-                        return;
-                    }
-                    IgnoreDecision::Continue => {}
+    // Perform a per-file (rather than per-line) ignore decision to skip running debuginfo tests
+    // if we don't have a debugger for them available.
+    // This is needed because we duplicate the Config once for each debugger.
+    if config.mode == TestMode::DebugInfo {
+        match &config.debugger {
+            Some(Debugger::Cdb) => {
+                if let Some(msg) = check_cdb_support(config) {
+                    ignore_message = Some(Cow::Owned(msg));
                 }
-            };
+            }
+            Some(Debugger::Gdb) => {
+                if let Some(msg) = check_gdb_support(config) {
+                    ignore_message = Some(Cow::Owned(msg));
+                }
+            }
+            Some(Debugger::Lldb) => {
+                if let Some(msg) = check_lldb_support(config) {
+                    ignore_message = Some(Cow::Owned(msg));
+                }
+            }
+            None => {}
         }
+    }
 
-        decision!(cfg::handle_ignore(&cache.cfg_conditions, ln));
-        decision!(cfg::handle_only(&cache.cfg_conditions, ln));
-        decision!(needs::handle_needs(&cache.needs, config, ln));
-        decision!(ignore_llvm(config, ln));
-        decision!(ignore_backends(config, ln));
-        decision!(needs_backends(config, ln));
-        decision!(ignore_cdb(config, ln));
-        decision!(ignore_gdb(config, ln));
-        decision!(ignore_lldb(config, ln));
-        decision!(ignore_parallel_frontend(config, ln));
+    if ignore_message.is_none() {
+        // Scan through the test file to handle `ignore-*`, `only-*`, and `needs-*` directives.
+        iter_directives(
+            config,
+            file_directives,
+            &mut |ln @ &DirectiveLine { line_number, .. }| {
+                if !ln.applies_to_test_revision(test_revision) {
+                    return;
+                }
 
-        if config.target == "wasm32-unknown-unknown"
-            && config.parse_name_directive(ln, directives::CHECK_RUN_RESULTS)
-        {
-            decision!(IgnoreDecision::Ignore {
-                reason: "ignored on WASM as the run results cannot be checked there".into(),
-            });
-        }
+                // Parse `aux-*` directives, for use by up-to-date checks.
+                parse_and_update_aux(config, ln, aux_props);
 
-        should_fail |= config.parse_name_directive(ln, "should-fail");
-    });
+                macro_rules! decision {
+                    ($e:expr) => {
+                        match $e {
+                            IgnoreDecision::Ignore { reason } => {
+                                ignore_message = Some(reason.into());
+                            }
+                            IgnoreDecision::Error { message } => {
+                                error!("{path}:{line_number}: {message}");
+                                *poisoned = true;
+                                return;
+                            }
+                            IgnoreDecision::Continue => {}
+                        }
+                    };
+                }
+
+                decision!(cfg::handle_ignore(&cache.cfg_conditions, ln));
+                decision!(cfg::handle_only(&cache.cfg_conditions, ln));
+                decision!(needs::handle_needs(&cache.needs, config, ln));
+                decision!(ignore_llvm(config, ln));
+                decision!(ignore_backends(config, ln));
+                decision!(needs_backends(config, ln));
+                decision!(ignore_cdb(config, ln));
+                decision!(ignore_gdb(config, ln));
+                decision!(ignore_lldb(config, ln));
+                decision!(ignore_parallel_frontend(config, ln));
+
+                if config.target == "wasm32-unknown-unknown"
+                    && config.parse_name_directive(ln, directives::CHECK_RUN_RESULTS)
+                {
+                    decision!(IgnoreDecision::Ignore {
+                        reason: "ignored on WASM as the run results cannot be checked there".into(),
+                    });
+                }
+
+                should_fail |= config.parse_name_directive(ln, "should-fail");
+            },
+        );
+    }
 
     // The `should-fail` annotation doesn't apply to pretty tests,
     // since we run the pretty printer across all tests by default.
@@ -961,6 +991,32 @@ pub(crate) fn make_test_description(
         ignore_message,
         should_fail,
     }
+}
+
+/// Returns `None` if CDB is available, otherwise returns an ignore message.
+fn check_cdb_support(config: &Config) -> Option<String> {
+    if config.cdb.is_none() { Some("cdb is not available".to_string()) } else { None }
+}
+
+/// Returns `None` if GDB is available, otherwise returns an ignore message.
+fn check_gdb_support(config: &Config) -> Option<String> {
+    if config.gdb_version.is_none() {
+        return Some("gdb is not available".to_string());
+    }
+
+    if config.matches_env("msvc") {
+        return Some("gdb tests do not run on msvc".to_string());
+    }
+
+    if config.remote_test_client.is_some() && !config.target.contains("android") {
+        return Some("gdb tests are not available when testing with remote".to_string());
+    }
+    None
+}
+
+/// Returns `None` if LLDB is available, otherwise returns an ignore message.
+fn check_lldb_support(config: &Config) -> Option<String> {
+    if config.lldb.is_none() { Some("lldb is not available".to_string()) } else { None }
 }
 
 fn ignore_cdb(config: &Config, line: &DirectiveLine<'_>) -> IgnoreDecision {

--- a/src/tools/compiletest/src/directives.rs
+++ b/src/tools/compiletest/src/directives.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::collections::HashSet;
 use std::process::Command;
 use std::{env, fs};
@@ -895,8 +896,7 @@ pub(crate) fn make_test_description(
     poisoned: &mut bool,
     aux_props: &mut AuxProps,
 ) -> CollectedTestDesc {
-    let mut ignore = false;
-    let mut ignore_message = None;
+    let mut ignore_message: Option<Cow<'static, str>> = None;
     let mut should_fail = false;
 
     // Scan through the test file to handle `ignore-*`, `only-*`, and `needs-*` directives.
@@ -912,7 +912,6 @@ pub(crate) fn make_test_description(
             ($e:expr) => {
                 match $e {
                     IgnoreDecision::Ignore { reason } => {
-                        ignore = true;
                         ignore_message = Some(reason.into());
                     }
                     IgnoreDecision::Error { message } => {
@@ -959,7 +958,6 @@ pub(crate) fn make_test_description(
     CollectedTestDesc {
         name,
         filterable_path: filterable_path.to_owned(),
-        ignore,
         ignore_message,
         should_fail,
     }

--- a/src/tools/compiletest/src/directives/tests.rs
+++ b/src/tools/compiletest/src/directives/tests.rs
@@ -284,7 +284,7 @@ fn check_ignore(config: &Config, contents: &str) -> bool {
     let tn = String::new();
     let p = Utf8Path::new("a.rs");
     let d = make_test_description(&config, tn, p, p, contents, None);
-    d.ignore
+    d.is_ignored()
 }
 
 #[test]

--- a/src/tools/compiletest/src/executor.rs
+++ b/src/tools/compiletest/src/executor.rs
@@ -100,7 +100,7 @@ fn spawn_test_thread(
     test: &CollectedTest,
     completion_sender: mpsc::Sender<TestCompletion>,
 ) -> Option<thread::JoinHandle<()>> {
-    if test.desc.ignore && !test.config.run_ignored {
+    if test.desc.is_ignored() && !test.config.run_ignored {
         completion_sender
             .send(TestCompletion { id, outcome: TestOutcome::Ignored, stdout: None })
             .unwrap();
@@ -336,9 +336,14 @@ pub(crate) struct CollectedTest {
 pub(crate) struct CollectedTestDesc {
     pub(crate) name: String,
     pub(crate) filterable_path: Utf8PathBuf,
-    pub(crate) ignore: bool,
     pub(crate) ignore_message: Option<Cow<'static, str>>,
     pub(crate) should_fail: ShouldFail,
+}
+
+impl CollectedTestDesc {
+    pub(crate) fn is_ignored(&self) -> bool {
+        self.ignore_message.is_some()
+    }
 }
 
 /// Tests with `//@ should-fail` are tests of compiletest itself, and should

--- a/src/tools/compiletest/src/lib.rs
+++ b/src/tools/compiletest/src/lib.rs
@@ -946,11 +946,10 @@ fn make_test(cx: &TestCollectorCx, collector: &mut TestCollector, testpaths: &Te
 
         // If a test's inputs haven't changed since the last time it ran,
         // mark it as ignored so that the executor will skip it.
-        if !desc.ignore
+        if !desc.is_ignored()
             && !cx.config.force_rerun
             && is_up_to_date(cx, testpaths, &aux_props, revision)
         {
-            desc.ignore = true;
             // Keep this in sync with the "up-to-date" message detected by bootstrap.
             // FIXME(Zalathar): Now that we are no longer tied to libtest, we could
             // find a less fragile way to communicate this status to bootstrap.

--- a/src/tools/compiletest/src/lib.rs
+++ b/src/tools/compiletest/src/lib.rs
@@ -561,19 +561,28 @@ fn run_tests(config: Arc<Config>) {
     if let TestMode::DebugInfo = config.mode {
         // Debugging emscripten code doesn't make sense today
         if !config.target.contains("emscripten") {
-            match config.debugger {
-                Some(Debugger::Cdb) => configs.extend(debuggers::configure_cdb(&config)),
-                Some(Debugger::Gdb) => configs.extend(debuggers::configure_gdb(&config)),
-                Some(Debugger::Lldb) => configs.extend(debuggers::configure_lldb(&config)),
-                // FIXME: the *implicit* debugger discovery makes it really difficult to control
-                // which {`cdb`, `gdb`, `lldb`} are used. These should **not** be implicitly
-                // discovered by `compiletest`; these should be explicit `bootstrap` configuration
-                // options that are passed to `compiletest`!
-                None => {
-                    configs.extend(debuggers::configure_cdb(&config));
-                    configs.extend(debuggers::configure_gdb(&config));
-                    configs.extend(debuggers::configure_lldb(&config));
-                }
+            // FIXME: ideally, we would just have one config, and then have some mechanism of
+            // generating multiple variants of a test, one for each debugger (something like
+            // debuginfo revisions). But for now, we just create three configs.
+            configs.extend([
+                Arc::new(Config { debugger: Some(Debugger::Cdb), ..config.as_ref().clone() }),
+                Arc::new(Config { debugger: Some(Debugger::Gdb), ..config.as_ref().clone() }),
+                Arc::new(Config { debugger: Some(Debugger::Lldb), ..config.as_ref().clone() }),
+            ]);
+
+            // FIXME: this should ideally happen somewhere else..
+            if config.target.contains("android") {
+                println!("{} debug-info test uses tcp 5039 port. please reserve it", config.target);
+
+                // android debug-info test uses remote debugger so, we test 1 thread
+                // at once as they're all sharing the same TCP port to communicate
+                // over.
+                //
+                // we should figure out how to lift this restriction! (run them all
+                // on different ports allocated dynamically).
+                //
+                // SAFETY: at this point we are still single-threaded.
+                unsafe { env::set_var("RUST_TEST_THREADS", "1") };
             }
         }
     } else {


### PR DESCRIPTION
When testing https://github.com/rust-lang/rust/pull/158298, I realized that when you don't have a given debugger (CDB, GDB, LLDB) available, compiletest will silently skip generating "variants" of debuginfo tests for a given debugger. So if you run a single debuginfo test, it will run 0/1/2/3 tests, based on what debuggers you have available. So it will show `running 1/2/3 tests` without telling you that it is actually three separate tests, but some of them were automatically ignored.

This is made even worse by the fact that bootstrap/compiletest currently automatically discovers debuggers, so there is a lot of implicit behavior stacked on top of each other.

This PR changes that, so that compiletest *always* creates all three variants of the tests, but if you don't have a debugger X available, then the X variant will be ignored, so you can see clearly in the output that it was ignored and why, which is much better than the test simply disappearing.

So after running a given debuginfo test, you will see e.g. this:
```
running 3 tests
test [debuginfo-cdb] tests/debuginfo/basic-types.rs ... ignored, cdb is not available
test [debuginfo-gdb] tests/debuginfo/basic-types.rs ... ok
test [debuginfo-lldb] tests/debuginfo/basic-types.rs ... ok
```

Which makes it more more obvious that there are in fact three separate tests, but some of them are ignored (and why).

The way this is achieved is a bit hacky, but that is caused by the previous way compiletest did things. To simulate the three variants of each debuginfo test, compiletest currently generates a separate instance (!) of the `Config` for each debugger, in the `run_tests` function. That's quite hacky, to say the least, and it requires storing a `debugger` field in the `Config`, which specifies for which variant we are currently running the debuginfo test.

I wanted to try using a single config, and encoding the CDB/GDB/LLDB variants as revisions instead. However, I found out that some debuginfo tests actually do use revisions for.. actual revisions, which caught me by surprise. So we would either need to expand the set of used revisions, so that if the test has e.g. `revision=lto`, `revision=no-lto`, we would then turn that into:
- `revision=lto-cdb`
- `revision=lto-gdb`
- `revision=no-lto-cdb`
- `revision=no-lto-gdb`
- `revision=no-lto-lldb`

That's maybe not such a bad solution, and it would allow us to use a single `Config` instance, but it would also require either encoding the debugger inside the revision string and then parsing it out (ugh), or turning revisions into a struct that would contain multiple information (such as the debugger used and then the revision name).

Or we could introduce a separate mechanism for "multiplying" tests, but we already have revisions, and it seems overkill to introduce something like this only for debuggers (unless it is also needed at other places...).

So what I did in this PR instead is to keep the three separate configs, but rather than not generating the Config when a debugger is missing, we *always* generate a separate config for each debugger, but then we ignore tests that do not match the "active" debugger in the Config. Because this ignore logic is not per directive line, but per test, so I had to introduce a new block of code that does that, but that seems fine to me, when compared to the mountain of hacks already present in this part of the codebase xD

This is implemented in the second commit, the first commit is just a small simplification refactoring.

r? @jieyouxu

Fixes: https://github.com/rust-lang/rust/issues/126628