### PR TITLE
add rustc_no_writable to mem::forget and structs it uses

### DIFF
--- a/library/core/src/mem/manually_drop.rs
+++ b/library/core/src/mem/manually_drop.rs
@@ -178,6 +178,7 @@ impl<T> ManuallyDrop<T> {
     #[stable(feature = "manually_drop", since = "1.20.0")]
     #[rustc_const_stable(feature = "const_manually_drop", since = "1.32.0")]
     #[inline(always)]
+    #[rustc_no_writable]
     pub const fn new(value: T) -> ManuallyDrop<T> {
         ManuallyDrop { value: MaybeDangling::new(value) }
     }

--- a/library/core/src/mem/maybe_dangling.rs
+++ b/library/core/src/mem/maybe_dangling.rs
@@ -74,6 +74,7 @@ pub struct MaybeDangling<P: ?Sized>(P);
 
 impl<P: ?Sized> MaybeDangling<P> {
     /// Wraps a value in a `MaybeDangling`, allowing it to dangle.
+    #[rustc_no_writable]
     pub const fn new(x: P) -> Self
     where
         P: Sized,

--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -186,6 +186,7 @@ pub mod type_info;
 #[rustc_const_stable(feature = "const_forget", since = "1.46.0")]
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_diagnostic_item = "mem_forget"]
+#[rustc_no_writable]
 pub const fn forget<T>(t: T) {
     let _ = ManuallyDrop::new(t);
 }
@@ -1170,6 +1171,7 @@ pub const unsafe fn transmute_copy<Src, Dst>(src: &Src) -> Dst {
 /// let _: std::mem::MaybeUninit<u16> = unsafe { transmute_prefix(123_u8) };
 /// ```
 #[unstable(feature = "transmute_prefix", issue = "155079")]
+#[rustc_no_writable]
 pub const unsafe fn transmute_prefix<Src, Dst>(src: Src) -> Dst {
     #[repr(C)]
     union Transmute<A, B> {
@@ -1219,6 +1221,7 @@ pub const unsafe fn transmute_prefix<Src, Dst>(src: Src) -> Dst {
 #[unstable(feature = "transmute_neo", issue = "155079")]
 #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
 #[inline]
+#[rustc_no_writable]
 pub const unsafe fn transmute_neo<Src, Dst>(src: Src) -> Dst {
     const { assert!(Src::SIZE == Dst::SIZE) };
 

--- a/src/tools/miri/tests/pass/tree_borrows/mem_forget-implicit_writes.rs
+++ b/src/tools/miri/tests/pass/tree_borrows/mem_forget-implicit_writes.rs
@@ -1,0 +1,20 @@
+// Regression test. This failed before applying `#[rustc_no_writable]` to `mem::forget`, `ManuallyDrop::new`, and `MaybeDangling::new`.
+//@compile-flags: -Zmiri-tree-borrows -Zmiri-tree-borrows-implicit-writes
+
+use std::mem;
+
+// This function is taken from the crate `derive_more`, from the file `into.rs`
+unsafe fn transmute<From, To>(from: From) -> To {
+    let to = unsafe { mem::transmute_copy(&from) };
+    mem::forget(from);
+    to
+}
+
+fn main() {
+    let mut val = 10u32;
+    let r: &mut u32 = &mut val;
+
+    let to: &mut i32 = unsafe { transmute(r) };
+
+    assert_eq!(*to, 10);
+}


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/159181)*
<!-- homu-ignore:end -->

This builds upon https://github.com/rust-lang/rust/pull/155207 and is similar to https://github.com/rust-lang/rust/pull/157202. It adds the `#[rustc_no_writable]` attribute to `mem::forget` and the `MaybeDangling` and `ManuallyDrop`. This makes Miri with Tree Borrows and implicit writes no longer report UB for a test in `derive_more`.
As the pattern itself is quite unclean, and I have not seen `mem::forget` to cause trouble before with implicit writes, I'm not sure how much sense it makes to add it to `mem::forget`. The test works unter Tree Borrows, but fails already for Stacked Borrows. Thus I would be happy for some guidance if the attribute makes sense here @RalfJung  @JoJoDeveloping.