### PR TITLE
Always generate private and hidden items in JSON docs of the stdlib

### DIFF
--- a/library/std_detect/src/detect/os/linux/aarch64.rs
+++ b/library/std_detect/src/detect/os/linux/aarch64.rs
@@ -258,7 +258,7 @@ impl AtHwcap {
     /// Initializes the cache from the feature -bits.
     ///
     /// The feature dependencies here come directly from LLVM's feature definitions:
-    /// https://github.com/llvm/llvm-project/blob/main/llvm/lib/Target/AArch64/AArch64.td
+    /// <https://github.com/llvm/llvm-project/blob/main/llvm/lib/Target/AArch64/AArch64.td>
     fn cache(self, is_exynos9810: bool) -> cache::Initializer {
         let mut value = cache::Initializer::default();
         {

--- a/src/bootstrap/src/core/build_steps/doc.rs
+++ b/src/bootstrap/src/core/build_steps/doc.rs
@@ -831,7 +831,9 @@ fn doc_std(
         cargo.rustdocflag(arg);
     }
 
-    if builder.config.library_docs_private_items {
+    // This is needed for cargo-semver-checks and potentially other downstream tools that consume
+    // the JSON data.
+    if format == DocumentationFormat::Json || builder.config.library_docs_private_items {
         cargo.rustdocflag("--document-private-items").rustdocflag("--document-hidden-items");
     }
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/159188)*
<!-- homu-ignore:end -->

This data is needed for downstream tools, e.g. cargo-semver-checks, to analyse the whole stdlib.

For the HTML output it is configurable using `build.library-docs-private-items`, but to avoid adding a separate config for just the JSON format, I think that we can just enable it unconditionally.

An alternative would be to change the flag from a bool to something like
```rust
enum StdDocsPrivateItems {
    No,
    Yes,
    Html,
    Json
}
```