### PR TITLE
When both expected and found are the same type, use only name instead of full path

### DIFF
--- a/compiler/rustc_trait_selection/src/error_reporting/infer/mod.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/mod.rs
@@ -1078,8 +1078,8 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     //         ---  ^ type argument elided
                     //         |
                     //         highlighted in output
-                    values.0.push_normal(path1);
-                    values.1.push_normal(path2);
+                    values.0.push_normal(self.tcx.item_name(did1).to_string());
+                    values.1.push_normal(self.tcx.item_name(did2).to_string());
 
                     // Avoid printing out default generic parameters that are common to both
                     // types.

--- a/tests/ui/higher-ranked/higher-ranked-lifetime-equality.stderr
+++ b/tests/ui/higher-ranked/higher-ranked-lifetime-equality.stderr
@@ -4,8 +4,8 @@ error[E0308]: mismatched types
 LL |     let foo: Foo<Two> = foo;
    |                         ^^^ one type is more general than the other
    |
-   = note: expected struct `my_api::Foo<for<'a, 'b> fn(&'a (), &'b ())>`
-              found struct `my_api::Foo<for<'a> fn(&'a (), &'a ())>`
+   = note: expected struct `Foo<for<'a, 'b> fn(&'a (), &'b ())>`
+              found struct `Foo<for<'a> fn(&'a (), &'a ())>`
 
 error[E0308]: mismatched types
   --> $DIR/higher-ranked-lifetime-equality.rs:34:25
@@ -13,8 +13,8 @@ error[E0308]: mismatched types
 LL |     let foo: Foo<Two> = foo;
    |                         ^^^ one type is more general than the other
    |
-   = note: expected struct `my_api::Foo<for<'a, 'b> fn(&'a (), &'b ())>`
-              found struct `my_api::Foo<for<'a> fn(&'a (), &'a ())>`
+   = note: expected struct `Foo<for<'a, 'b> fn(&'a (), &'b ())>`
+              found struct `Foo<for<'a> fn(&'a (), &'a ())>`
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 2 previous errors

--- a/tests/ui/impl-trait/recursive-type-alias-impl-trait-declaration-too-subtle.stderr
+++ b/tests/ui/impl-trait/recursive-type-alias-impl-trait-declaration-too-subtle.stderr
@@ -7,8 +7,8 @@ LL |     type Foo = impl PartialEq<(Foo, i32)>;
 LL |         fn eq(&self, _other: &(Foo, i32)) -> bool {
    |                              ^^^^^^^^^^^ expected `a::Bar`, found opaque type
    |
-   = note: expected signature `fn(&a::Bar, &(a::Bar, _)) -> _`
-              found signature `fn(&a::Bar, &(a::Foo, _)) -> _`
+   = note: expected signature `fn(&Bar, &(a::Bar, _)) -> _`
+              found signature `fn(&Bar, &(a::Foo, _)) -> _`
 help: change the parameter type to match the trait
    |
 LL -         fn eq(&self, _other: &(Foo, i32)) -> bool {
@@ -24,8 +24,8 @@ LL |     type Foo = impl PartialEq<(Foo, i32)>;
 LL |         fn eq(&self, _other: &(Bar, i32)) -> bool {
    |                              ^^^^^^^^^^^ expected opaque type, found `b::Bar`
    |
-   = note: expected signature `fn(&b::Bar, &(b::Foo, _)) -> _`
-              found signature `fn(&b::Bar, &(b::Bar, _)) -> _`
+   = note: expected signature `fn(&Bar, &(b::Foo, _)) -> _`
+              found signature `fn(&Bar, &(b::Bar, _)) -> _`
 note: this item must have a `#[define_opaque(b::Foo)]` attribute to be able to define hidden types
   --> $DIR/recursive-type-alias-impl-trait-declaration-too-subtle.rs:25:12
    |

--- a/tests/ui/inference/question-mark-type-inference-in-chain.stderr
+++ b/tests/ui/inference/question-mark-type-inference-in-chain.stderr
@@ -42,8 +42,8 @@ LL |         .collect::<Result<Vec<Version>>>()?;
    |          |
    |          required by a bound introduced by this call
    |
-help: the trait `FromIterator<std::result::Result<_, Error>>` is not implemented for `std::result::Result<Vec<Version>, AnotherError>`
-      but trait `FromIterator<std::result::Result<_, AnotherError>>` is implemented for it
+help: the trait `FromIterator<Result<_, Error>>` is not implemented for `std::result::Result<Vec<Version>, AnotherError>`
+      but trait `FromIterator<Result<_, AnotherError>>` is implemented for it
   --> $SRC_DIR/core/src/result.rs:LL:COL
    = help: for that trait implementation, expected `AnotherError`, found `Error`
 note: the method call chain might not have had the expected associated types

--- a/tests/ui/range/issue-73553-misinterp-range-literal.stderr
+++ b/tests/ui/range/issue-73553-misinterp-range-literal.stderr
@@ -6,8 +6,8 @@ LL |     demo(tell(1)..tell(10));
    |     |
    |     arguments to this function are incorrect
    |
-   = note: expected reference `&std::ops::Range<_>`
-                 found struct `std::ops::Range<_>`
+   = note: expected reference `&Range<_>`
+                 found struct `Range<_>`
 note: function defined here
   --> $DIR/issue-73553-misinterp-range-literal.rs:3:4
    |
@@ -26,8 +26,8 @@ LL |     demo(1..10);
    |     |
    |     arguments to this function are incorrect
    |
-   = note: expected reference `&std::ops::Range<usize>`
-                 found struct `std::ops::Range<{integer}>`
+   = note: expected reference `&Range<usize>`
+                 found struct `Range<{integer}>`
 note: function defined here
   --> $DIR/issue-73553-misinterp-range-literal.rs:3:4
    |

--- a/tests/ui/regions/resolve-re-error-ice.stderr
+++ b/tests/ui/regions/resolve-re-error-ice.stderr
@@ -14,8 +14,8 @@ note: ...so that the method type is compatible with trait
    |
 LL |     fn key_set(&self) -> Subject<'a, Keys<K, V>, (), R> {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: expected `fn(&Subject<'_, _, _, _>) -> Subject<'_, std::collections::hash_map::Keys<'_, _, _>, _, _>`
-              found `fn(&Subject<'_, _, _, _>) -> Subject<'a, std::collections::hash_map::Keys<'_, _, _>, _, _>`
+   = note: expected `fn(&Subject<'_, _, _, _>) -> Subject<'_, Keys<'_, _, _>, _, _>`
+              found `fn(&Subject<'_, _, _, _>) -> Subject<'a, Keys<'_, _, _>, _, _>`
 note: but, the lifetime must be valid for the lifetime `'a` as defined here...
   --> $DIR/resolve-re-error-ice.rs:10:6
    |


### PR DESCRIPTION
This makes the output marginally shorter, and further visually differentiates part of the types that are different by deemphasazing those that are the same.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
