### PR TITLE
Mark `PrivateItems` with `std_internals` unstable feature.

### DIFF
--- a/library/core/src/marker/variance.rs
+++ b/library/core/src/marker/variance.rs
@@ -234,6 +234,7 @@ phantom_type! {
 }
 
 mod private_items {
+    #[unstable(feature = "std_internals", issue = "none")]
     pub trait PrivateItems {
         const VALUE: Self;
     }


### PR DESCRIPTION
Fixes rust-lang/rust#158654 as discussed in https://github.com/rust-lang/rust/issues/158654#issuecomment-4906226368

r? @joshtriplett

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
