### PR TITLE
rustdoc: Fix auto trait normalization env

### DIFF
--- a/src/librustdoc/clean/auto_trait.rs
+++ b/src/librustdoc/clean/auto_trait.rs
@@ -172,34 +172,36 @@ fn clean_param_env<'tcx>(
 
     // FIXME(#111101): Incorporate the explicit predicates of the item here...
     let item_clauses: FxIndexSet<_> = tcx.param_env(item_def_id).caller_bounds().iter().collect();
-    let where_predicates = param_env
-        .caller_bounds()
-        .iter()
-        // FIXME: ...which hopefully allows us to simplify this:
-        .filter(|clause| {
-            !item_clauses.contains(clause)
-                || clause
-                    .as_trait_clause()
-                    .is_some_and(|clause| tcx.lang_items().sized_trait() == Some(clause.def_id()))
-        })
-        .map(|clause| {
-            fold_regions(tcx, clause, |r, _| match r.kind() {
-                // FIXME: Don't `unwrap_or`, I think we should panic if we encounter an infer var that
-                // we can't map to a concrete region. However, `AutoTraitFinder` *does* leak those kinds
-                // of `ReVar`s for some reason at the time of writing. See `rustdoc-ui/` tests.
-                // This is in dire need of an investigation into `AutoTraitFinder`.
-                ty::ReVar(vid) => vid_to_region.get(&vid).copied().unwrap_or(r),
-                ty::ReEarlyParam(_) | ty::ReStatic | ty::ReBound(..) | ty::ReError(_) => r,
-                // FIXME(#120606): `AutoTraitFinder` can actually leak placeholder regions which feels
-                // incorrect. Needs investigation.
-                ty::ReLateParam(_) | ty::RePlaceholder(_) | ty::ReErased => {
-                    bug!("unexpected region kind: {r:?}")
-                }
+    let where_predicates = cx.with_exact_param_env(param_env, |cx| {
+        param_env
+            .caller_bounds()
+            .iter()
+            // FIXME: ...which hopefully allows us to simplify this:
+            .filter(|clause| {
+                !item_clauses.contains(clause)
+                    || clause.as_trait_clause().is_some_and(|clause| {
+                        tcx.lang_items().sized_trait() == Some(clause.def_id())
+                    })
             })
-        })
-        .flat_map(|clause| clean_predicate(clause, cx))
-        .chain(clean_region_outlives_constraints(&region_data, generics))
-        .collect();
+            .map(|clause| {
+                fold_regions(tcx, clause, |r, _| match r.kind() {
+                    // FIXME: Don't `unwrap_or`, I think we should panic if we encounter an infer var that
+                    // we can't map to a concrete region. However, `AutoTraitFinder` *does* leak those kinds
+                    // of `ReVar`s for some reason at the time of writing. See `rustdoc-ui/` tests.
+                    // This is in dire need of an investigation into `AutoTraitFinder`.
+                    ty::ReVar(vid) => vid_to_region.get(&vid).copied().unwrap_or(r),
+                    ty::ReEarlyParam(_) | ty::ReStatic | ty::ReBound(..) | ty::ReError(_) => r,
+                    // FIXME(#120606): `AutoTraitFinder` can actually leak placeholder regions which feels
+                    // incorrect. Needs investigation.
+                    ty::ReLateParam(_) | ty::RePlaceholder(_) | ty::ReErased => {
+                        bug!("unexpected region kind: {r:?}")
+                    }
+                })
+            })
+            .flat_map(|clause| clean_predicate(clause, cx))
+            .chain(clean_region_outlives_constraints(&region_data, generics))
+            .collect()
+    });
 
     let mut generics = clean::Generics { params, where_predicates };
     simplify::sizedness_bounds(cx, &mut generics);

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -87,7 +87,15 @@ impl<'tcx> DocContext<'tcx> {
         def_id: DefId,
         f: F,
     ) -> T {
-        let old_param_env = mem::replace(&mut self.param_env, self.tcx.param_env(def_id));
+        self.with_exact_param_env(self.tcx.param_env(def_id), f)
+    }
+
+    pub(crate) fn with_exact_param_env<T, F: FnOnce(&mut Self) -> T>(
+        &mut self,
+        param_env: ParamEnv<'tcx>,
+        f: F,
+    ) -> T {
+        let old_param_env = mem::replace(&mut self.param_env, param_env);
         let ret = f(self);
         self.param_env = old_param_env;
         ret

--- a/tests/rustdoc-html/synthetic_auto/issue-159065.rs
+++ b/tests/rustdoc-html/synthetic_auto/issue-159065.rs
@@ -1,0 +1,6 @@
+//@ compile-flags: -Znext-solver=globally -Znormalize-docs
+
+#![crate_name = "foo"]
+
+#[doc(inline)]
+pub use std as other;


### PR DESCRIPTION
Fixes rust-lang/rust#159065

rustdoc ICEs on #[doc(inline)] pub use std as other; with -Znext-solver=globally -Znormalize-docs. The synthetic auto-trait code builds a ParamEnv for the generated where-clauses, but nested type normalization still reads cx.param_env (via `clean_predicate` -> `clean_middle_ty` -> `normalize`). In the inline std case that env can be empty, so the solver later idk's the type of the placeholder const.

Use that synthetic auto-trait ParamEnv while cleaning the generated where-clauses. imo this is the least weird place to do it: the clauses came from that env, so their normalization should use it too. btw, the added rustdoc-html test is just the reduced issue case, fyi.