### PR TITLE
Bump rustc-demangle to 0.1.28

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3570,9 +3570,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
 
 [[package]]
 name = "rustc-hash"

--- a/compiler/rustc_codegen_llvm/Cargo.toml
+++ b/compiler/rustc_codegen_llvm/Cargo.toml
@@ -17,7 +17,7 @@ libc = "0.2"
 libloading = { version = "0.9.0" }
 measureme = "12.0.1"
 object = { version = "0.37.0", default-features = false, features = ["std", "read"] }
-rustc-demangle = "0.1.21"
+rustc-demangle = "0.1.28"
 rustc_abi = { path = "../rustc_abi" }
 rustc_ast = { path = "../rustc_ast" }
 rustc_codegen_ssa = { path = "../rustc_codegen_ssa" }

--- a/compiler/rustc_symbol_mangling/Cargo.toml
+++ b/compiler/rustc_symbol_mangling/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 [dependencies]
 # tidy-alphabetical-start
 punycode = "0.4.0"
-rustc-demangle = "0.1.27"
+rustc-demangle = "0.1.28"
 rustc_abi = { path = "../rustc_abi" }
 rustc_data_structures = { path = "../rustc_data_structures" }
 rustc_hashes = { path = "../rustc_hashes" }

--- a/library/Cargo.lock
+++ b/library/Cargo.lock
@@ -274,9 +274,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
 dependencies = [
  "rustc-std-workspace-core",
 ]

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -26,7 +26,7 @@ hashbrown = { version = "0.17.1", default-features = false, features = [
 std_detect = { path = "../std_detect", public = true }
 
 # Dependencies of the `backtrace` crate
-rustc-demangle = { version = "0.1.27", features = ['rustc-dep-of-std'] }
+rustc-demangle = { version = "0.1.28", features = ['rustc-dep-of-std'] }
 
 [target.'cfg(not(all(windows, target_env = "msvc", not(target_vendor = "uwp"))))'.dependencies]
 miniz_oxide = { version = "0.8.0", optional = true, default-features = false }

--- a/library/stdarch/Cargo.lock
+++ b/library/stdarch/Cargo.lock
@@ -678,9 +678,9 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
 
 [[package]]
 name = "rustix"

--- a/library/stdarch/crates/stdarch-test/Cargo.toml
+++ b/library/stdarch/crates/stdarch-test/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2024"
 [dependencies]
 assert-instr-macro = { path = "../assert-instr-macro" }
 simd-test-macro = { path = "../simd-test-macro" }
-rustc-demangle = "0.1.8"
+rustc-demangle = "0.1.28"
 
 [target.'cfg(windows)'.dependencies]
 cc = "1.0"

--- a/src/tools/clippy/lintcheck/ci_crates.toml
+++ b/src/tools/clippy/lintcheck/ci_crates.toml
@@ -163,7 +163,7 @@ zerocopy = { name = 'zerocopy', version = '0.7.35' }
 rustversion = { name = 'rustversion', version = '1.0.17' }
 env_logger = { name = 'env_logger', version = '0.11.3' }
 webpki-roots = { name = 'webpki-roots', version = '0.26.3' }
-rustc-demangle = { name = 'rustc-demangle', version = '0.1.24' }
+rustc-demangle = { name = 'rustc-demangle', version = '0.1.28' }
 mime = { name = 'mime', version = '0.3.17' }
 termcolor = { name = 'termcolor', version = '1.4.1' }
 subtle = { name = 'subtle', version = '2.6.1' }

--- a/src/tools/coverage-dump/Cargo.toml
+++ b/src/tools/coverage-dump/Cargo.toml
@@ -12,4 +12,4 @@ leb128 = "0.2.5"
 md5 = { package = "md-5" , version = "0.10.5" }
 miniz_oxide = "0.8.8"
 regex = "1.8.4"
-rustc-demangle = "0.1.23"
+rustc-demangle = "0.1.28"


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

This PR is part of the splat lang experiment: rust-lang/rust#153629 

It brings in the changes from https://github.com/rust-lang/rustc-demangle/pull/90, which encode splatted types with a `w` prefix in type mangling. This is required to fix the symbol clashes in rust-lang/rust#158644.

We need to upgrade the compiler and standard library to avoid "can't demangle" panics or errors. Some tools might work without the upgrade, but we might as well do it there as well.

@rustbot label +C-enhancement +F-splat +T-compiler +A-name-mangling