### PR TITLE
clippy: avoid invalid `ref_as_ptr` suggestions in const/static initializers

### DIFF
--- a/src/tools/clippy/clippy_lints/src/casts/ref_as_ptr.rs
+++ b/src/tools/clippy/clippy_lints/src/casts/ref_as_ptr.rs
@@ -1,7 +1,9 @@
 use clippy_utils::diagnostics::span_lint_and_sugg;
 use clippy_utils::source::snippet_with_applicability;
 use clippy_utils::sugg::Sugg;
-use clippy_utils::{ExprUseNode, get_expr_use_site, is_expr_temporary_value, std_or_core};
+use clippy_utils::{
+    ExprUseNode, get_expr_use_site, is_expr_temporary_value, is_inside_always_const_context, std_or_core,
+};
 use rustc_errors::Applicability;
 use rustc_hir::{Expr, ExprKind, Mutability, Ty, TyKind};
 use rustc_lint::LateContext;
@@ -26,10 +28,10 @@ pub(super) fn check<'tcx>(
     {
         if let ExprKind::AddrOf(_, _, addr_inner) = cast_expr.kind
             && is_expr_temporary_value(cx, addr_inner)
-            && matches!(
+            && (matches!(
                 get_expr_use_site(cx.tcx, cx.typeck_results(), expr.span.ctxt(), expr).use_node(cx),
                 ExprUseNode::LetStmt(_) | ExprUseNode::ConstStatic(_)
-            )
+            ) || is_inside_always_const_context(cx.tcx, expr.hir_id))
         {
             return;
         }

--- a/src/tools/clippy/tests/ui/ref_as_ptr.fixed
+++ b/src/tools/clippy/tests/ui/ref_as_ptr.fixed
@@ -99,6 +99,11 @@ fn main() {
     let _ = &String::new() as *const _;
     let _ = &mut String::new() as *mut _;
     const FOO: *const String = &String::new() as *const _;
+
+    // Regression test for #13910.
+    // This should not lint because the suggested replacement fails during
+    // const evaluation.
+    static mut REGRESSION: *mut i32 = &mut [42] as *mut [i32] as *mut i32;
 }
 
 #[clippy::msrv = "1.75"]

--- a/src/tools/clippy/tests/ui/ref_as_ptr.rs
+++ b/src/tools/clippy/tests/ui/ref_as_ptr.rs
@@ -99,6 +99,11 @@ fn main() {
     let _ = &String::new() as *const _;
     let _ = &mut String::new() as *mut _;
     const FOO: *const String = &String::new() as *const _;
+
+    // Regression test for #13910.
+    // This should not lint because the suggested replacement fails during
+    // const evaluation.
+    static mut REGRESSION: *mut i32 = &mut [42] as *mut [i32] as *mut i32;
 }
 
 #[clippy::msrv = "1.75"]

--- a/src/tools/clippy/tests/ui/ref_as_ptr.stderr
+++ b/src/tools/clippy/tests/ui/ref_as_ptr.stderr
@@ -218,46 +218,40 @@ LL |     let _ = &*x as *const _;
    |             ^^^^^^^^^^^^^^^ help: try: `std::ptr::from_ref(&*x)`
 
 error: reference as raw pointer
-  --> tests/ui/ref_as_ptr.rs:119:7
+  --> tests/ui/ref_as_ptr.rs:124:7
    |
 LL |     f(val as *const i32);
    |       ^^^^^^^^^^^^^^^^^ help: try: `std::ptr::from_ref::<i32>(val)`
 
 error: reference as raw pointer
-  --> tests/ui/ref_as_ptr.rs:121:7
+  --> tests/ui/ref_as_ptr.rs:126:7
    |
 LL |     f(mut_val as *mut i32);
    |       ^^^^^^^^^^^^^^^^^^^ help: try: `std::ptr::from_mut::<i32>(mut_val)`
 
 error: reference as raw pointer
-  --> tests/ui/ref_as_ptr.rs:126:7
+  --> tests/ui/ref_as_ptr.rs:131:7
    |
 LL |     f(val as *const _);
    |       ^^^^^^^^^^^^^^^ help: try: `std::ptr::from_ref(val)`
 
 error: reference as raw pointer
-  --> tests/ui/ref_as_ptr.rs:128:7
+  --> tests/ui/ref_as_ptr.rs:133:7
    |
 LL |     f(val as *const [u8]);
    |       ^^^^^^^^^^^^^^^^^^ help: try: `std::ptr::from_ref::<[u8]>(val)`
 
 error: reference as raw pointer
-  --> tests/ui/ref_as_ptr.rs:133:7
+  --> tests/ui/ref_as_ptr.rs:138:7
    |
 LL |     f(val as *mut _);
    |       ^^^^^^^^^^^^^ help: try: `std::ptr::from_mut(val)`
 
 error: reference as raw pointer
-  --> tests/ui/ref_as_ptr.rs:135:7
+  --> tests/ui/ref_as_ptr.rs:140:7
    |
 LL |     f(val as *mut str);
    |       ^^^^^^^^^^^^^^^ help: try: `std::ptr::from_mut::<str>(val)`
-
-error: reference as raw pointer
-  --> tests/ui/ref_as_ptr.rs:143:9
-   |
-LL |         self.0 as *const _ as *const _
-   |         ^^^^^^^^^^^^^^^^^^ help: try: `std::ptr::from_ref(self.0)`
 
 error: reference as raw pointer
   --> tests/ui/ref_as_ptr.rs:148:9
@@ -266,7 +260,7 @@ LL |         self.0 as *const _ as *const _
    |         ^^^^^^^^^^^^^^^^^^ help: try: `std::ptr::from_ref(self.0)`
 
 error: reference as raw pointer
-  --> tests/ui/ref_as_ptr.rs:157:9
+  --> tests/ui/ref_as_ptr.rs:153:9
    |
 LL |         self.0 as *const _ as *const _
    |         ^^^^^^^^^^^^^^^^^^ help: try: `std::ptr::from_ref(self.0)`
@@ -279,6 +273,12 @@ LL |         self.0 as *const _ as *const _
 
 error: reference as raw pointer
   --> tests/ui/ref_as_ptr.rs:167:9
+   |
+LL |         self.0 as *const _ as *const _
+   |         ^^^^^^^^^^^^^^^^^^ help: try: `std::ptr::from_ref(self.0)`
+
+error: reference as raw pointer
+  --> tests/ui/ref_as_ptr.rs:172:9
    |
 LL |         self.0 as *mut _ as *mut _
    |         ^^^^^^^^^^^^^^^^ help: try: `std::ptr::from_mut(self.0)`


### PR DESCRIPTION
Fixes rust-lang/rust#13910.

`ref_as_ptr` can suggest `std::ptr::from_ref`/`std::ptr::from_mut` for nested reference-to-raw-pointer casts inside `const` and `static` initializers. The suggested replacement then fails during const evaluation.

The existing guard only checks the immediate expression use site, which misses nested cast expressions. Extend it to also check whether the expression is inside an always-const context using `is_inside_always_const_context`.

### Testing

- Added a regression test reproducing the reported nested `static mut` case.
- Ran the `ref_as_ptr` UI tests.