### PR TITLE
Use all the available inline capacity in SwitchTargets

### DIFF
--- a/compiler/rustc_middle/src/mir/syntax.rs
+++ b/compiler/rustc_middle/src/mir/syntax.rs
@@ -999,7 +999,7 @@ pub struct SwitchTargets {
     // causes problems because multiple different concrete iterator types would
     // be involved and we would need a boxed trait object, which requires an
     // allocation, which is expensive if done frequently.
-    pub(super) targets: SmallVec<[BasicBlock; 2]>,
+    pub(super) targets: SmallVec<[BasicBlock; 4]>,
 }
 
 /// Action to be taken when a stack unwind happens.


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

SmallVec always has at least 16 bytes of inline capacity available on 64bit platforms, so there's no reason to not use it if we can.
