### PR TITLE
Fix `dead_code_pub_in_binary` false positive on library crates

### DIFF
--- a/compiler/rustc_passes/src/dead.rs
+++ b/compiler/rustc_passes/src/dead.rs
@@ -1334,7 +1334,18 @@ fn check_mod_deathness(tcx: TyCtxt<'_>, module: LocalModDefId) {
 
     let module_items = tcx.hir_module_items(module);
 
-    if tcx.crate_types().contains(&CrateType::Executable) {
+    // A library crate compiled with `--test` would be considered as `CrateType::Executable`,
+    // but the public items in it should not be warned as dead code.
+    #[allow(rustc::bad_opt_access)]
+    if tcx.crate_types().contains(&CrateType::Executable)
+        && !(tcx.sess.opts.test
+            && tcx.sess.opts.crate_types.iter().any(|ty| {
+                *ty == CrateType::StaticLib
+                    || *ty == CrateType::Dylib
+                    || *ty == CrateType::Rlib
+                    || *ty == CrateType::ProcMacro
+            }))
+    {
         let is_unused_pub = |def_id: LocalDefId| {
             tcx.effective_visibilities(()).is_public_at_level(def_id, Level::Reachable)
                 && !pre_deferred_seeding.live_symbols.contains(&def_id)

--- a/tests/ui/lint/dead-code-pub-in-binary/test-bin.rs
+++ b/tests/ui/lint/dead-code-pub-in-binary/test-bin.rs
@@ -1,0 +1,9 @@
+//@ compile-flags: --test
+// A normal crate compiled with `--test`.
+
+#![deny(dead_code)]
+#![deny(dead_code_pub_in_binary)]
+
+pub fn unused_pub_fn() {} //~ ERROR function `unused_pub_fn` is never used
+
+fn unused_priv_fn() {} //~ ERROR function `unused_priv_fn` is never used

--- a/tests/ui/lint/dead-code-pub-in-binary/test-bin.stderr
+++ b/tests/ui/lint/dead-code-pub-in-binary/test-bin.stderr
@@ -1,0 +1,27 @@
+error: function `unused_pub_fn` is never used
+  --> $DIR/test-bin.rs:7:8
+   |
+LL | pub fn unused_pub_fn() {}
+   |        ^^^^^^^^^^^^^
+   |
+   = note: in libraries, `pub` items can be used by dependent crates; in binaries, they cannot, so this `pub` item is unused
+note: the lint level is defined here
+  --> $DIR/test-bin.rs:5:9
+   |
+LL | #![deny(dead_code_pub_in_binary)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^
+
+error: function `unused_priv_fn` is never used
+  --> $DIR/test-bin.rs:9:4
+   |
+LL | fn unused_priv_fn() {}
+   |    ^^^^^^^^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/test-bin.rs:4:9
+   |
+LL | #![deny(dead_code)]
+   |         ^^^^^^^^^
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/lint/dead-code-pub-in-binary/test-lib.rs
+++ b/tests/ui/lint/dead-code-pub-in-binary/test-lib.rs
@@ -1,0 +1,9 @@
+//@ compile-flags: --test --crate-type=lib,bin
+// A library crate compiled with `--test`.
+
+#![deny(dead_code)]
+#![deny(dead_code_pub_in_binary)]
+
+pub fn unused_pub_fn() {} // Should NOT error because this is a library compiled for testing
+
+fn unused_priv_fn() {} //~ ERROR function `unused_priv_fn` is never used

--- a/tests/ui/lint/dead-code-pub-in-binary/test-lib.stderr
+++ b/tests/ui/lint/dead-code-pub-in-binary/test-lib.stderr
@@ -1,0 +1,14 @@
+error: function `unused_priv_fn` is never used
+  --> $DIR/test-lib.rs:9:4
+   |
+LL | fn unused_priv_fn() {}
+   |    ^^^^^^^^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/test-lib.rs:4:9
+   |
+LL | #![deny(dead_code)]
+   |         ^^^^^^^^^
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Fixes rust-lang/rust#159078 

Fix `dead_code_pub_in_binary` false positive on public items when compiling library crates with `--all-targets` flag
