### PR TITLE
Fix `attr_on_non_tail_expr` typo

### DIFF
--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -873,7 +873,7 @@ impl<'a> Parser<'a> {
                 && let ast::AttrKind::Normal(next_attr_kind) = next_attr.kind
                 && let Some(next_attr_args_span) = next_attr_kind.item.args.span()
                 && let [next_segment] = &next_attr_kind.item.path.segments[..]
-                && segment.ident.name == sym::cfg
+                && next_segment.ident.name == sym::cfg
             {
                 let next_expr = match snapshot.parse_expr() {
                     Ok(next_expr) => next_expr,

--- a/tests/ui/parser/attribute/multiple-tail-expr-behind-cfg.rs
+++ b/tests/ui/parser/attribute/multiple-tail-expr-behind-cfg.rs
@@ -14,6 +14,13 @@ fn bar() -> String {
     String::new()
 }
 
+fn baz() -> String {
+    #[cfg(false)]
+    [1, 2, 3].iter().map(|c| c.to_string()).collect::<String>() //~ ERROR expected `;`, found `#`
+    #[allow(unused)]
+    String::new()
+}
+
 fn main() {
     println!("{}", foo());
 }

--- a/tests/ui/parser/attribute/multiple-tail-expr-behind-cfg.stderr
+++ b/tests/ui/parser/attribute/multiple-tail-expr-behind-cfg.stderr
@@ -44,11 +44,38 @@ help: alternatively, consider surrounding the expression with a block
 LL |     { [1, 2, 3].iter().map(|c| c.to_string()).collect::<String>() }
    |     +                                                             +
 
+error: expected `;`, found `#`
+  --> $DIR/multiple-tail-expr-behind-cfg.rs:19:64
+   |
+LL |     #[cfg(false)]
+   |     ------------- only `;` terminated statements or tail expressions are allowed after this attribute
+LL |     [1, 2, 3].iter().map(|c| c.to_string()).collect::<String>()
+   |                                                                ^ expected `;` here
+LL |     #[allow(unused)]
+   |     - unexpected token
+   |
+help: add `;` here
+   |
+LL |     [1, 2, 3].iter().map(|c| c.to_string()).collect::<String>();
+   |                                                                +
+help: alternatively, consider surrounding the expression with a block
+   |
+LL |     { [1, 2, 3].iter().map(|c| c.to_string()).collect::<String>() }
+   |     +                                                             +
+help: it seems like you are trying to provide different expressions depending on `cfg`, consider using `if cfg!(..)`
+   |
+LL ~     if cfg!(false) {
+LL ~         [1, 2, 3].iter().map(|c| c.to_string()).collect::<String>()
+LL ~     } else if cfg!(unused) {
+LL ~         String::new()
+LL +     }
+   |
+
 error: cannot find attribute `attr` in this scope
   --> $DIR/multiple-tail-expr-behind-cfg.rs:13:7
    |
 LL |     #[attr]
    |       ^^^^
 
-error: aborting due to 3 previous errors
+error: aborting due to 4 previous errors
 

--- a/tests/ui/parser/attribute/multiple-tail-expr-behind-cfg.stderr
+++ b/tests/ui/parser/attribute/multiple-tail-expr-behind-cfg.stderr
@@ -62,14 +62,6 @@ help: alternatively, consider surrounding the expression with a block
    |
 LL |     { [1, 2, 3].iter().map(|c| c.to_string()).collect::<String>() }
    |     +                                                             +
-help: it seems like you are trying to provide different expressions depending on `cfg`, consider using `if cfg!(..)`
-   |
-LL ~     if cfg!(false) {
-LL ~         [1, 2, 3].iter().map(|c| c.to_string()).collect::<String>()
-LL ~     } else if cfg!(unused) {
-LL ~         String::new()
-LL +     }
-   |
 
 error: cannot find attribute `attr` in this scope
   --> $DIR/multiple-tail-expr-behind-cfg.rs:13:7


### PR DESCRIPTION
This PR fixes a minor diagnostics bug from rust-lang/rust#117988. Details in individual commits.

r? @estebank 