### PR TITLE
Fix debuginfo argument when invoking LLBC linker

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/linker.rs
+++ b/compiler/rustc_codegen_ssa/src/back/linker.rs
@@ -1944,8 +1944,13 @@ impl<'a> Linker for LlbcLinker<'a> {
         self.link_or_cc_arg(path);
     }
 
-    fn debuginfo(&mut self, _strip: Strip, _: &[PathBuf]) {
-        self.link_arg("--debug");
+    fn debuginfo(&mut self, strip: Strip, _: &[PathBuf]) {
+        match strip {
+            Strip::None => {
+                self.link_arg("--debug");
+            }
+            Strip::Debuginfo | Strip::Symbols => {}
+        }
     }
 
     fn optimize(&mut self) {


### PR DESCRIPTION
Previously LLBC's Linker implementation unconditionally added `--debug` to the linker invocation. This just became visible when 062ecd6 made LLBC no longer strip debug information unconditionally.

It is also common to use `cargo build --release` together with `-Zbuild-std=core` when targeting NVPTX. In this case the release profile will prevent all crates from embedding debug information in the first place. This additionally made the bug less visible.

This PR adds the proper logic to LLBC's linker implementation to only invoke LLBC with `--debug` when debug-information should not be stripped.

I did not add a regression test yet, since this would require to actually invoke the linker in `assembly-llvm`. As soon as https://github.com/rust-lang/rust/pull/157512 is merged and we have `assembly-output: linker-asm` available, I want to follow up on that.

cc: @kjetilkjeka 
@rustbot label +O-NVPTX