### PR TITLE
Avoid using probe self_ty for delegation arguments

### DIFF
--- a/compiler/rustc_hir_typeck/src/callee.rs
+++ b/compiler/rustc_hir_typeck/src/callee.rs
@@ -696,7 +696,11 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 scope,
             );
 
-            let Ok(pick) = pick else { return do_check() };
+            let Ok(ref pick) = pick else { return do_check() };
+
+            let mut ctx = ConfirmContext::new(self, arg.span, arg, arg);
+            let (adjusted_arg_type, method_adjustments) =
+                ctx.create_ty_adjustments_from_pick(arg_type, pick);
 
             if is_first_arg && args_to_map.len() > 1 {
                 // We successfully found a pick and adjustments for first argument,
@@ -706,7 +710,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 let cause = self.cause(call_expr.span, ObligationCauseCode::Misc);
                 if self
                     .at(&cause, self.param_env)
-                    .sup(DefineOpaqueTypes::Yes, formal_input_tys[0], pick.self_ty)
+                    .sup(DefineOpaqueTypes::Yes, formal_input_tys[0], adjusted_arg_type)
                     .is_err()
                 {
                     return do_check();
@@ -723,9 +727,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     self.typeck_results
                         .borrow_mut()
                         .node_types_mut()
-                        .insert(arg.hir_id, pick.self_ty)
+                        .insert(arg.hir_id, adjusted_arg_type)
                         .expect("must be set"),
-                    pick,
+                    method_adjustments,
                 ),
             );
         }
@@ -736,13 +740,12 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             let mut results = self.typeck_results.borrow_mut();
             let mut adjustments = results.adjustments_mut();
 
-            let (prev_type, pick) = prev_types.remove(&arg.hir_id).expect("must be in a map");
+            let (prev_type, method_adjustments) =
+                prev_types.remove(&arg.hir_id).expect("must be in a map");
 
             // Remove any added adjustments for arg expression during `do_check` and replace them with ours.
             let adjustments = adjustments.entry(arg.hir_id).or_default();
-
-            let mut ctx = ConfirmContext::new(self, arg.span, arg, arg);
-            *adjustments = ctx.create_ty_adjustments_from_pick(prev_type, &pick).1;
+            *adjustments = method_adjustments;
 
             // Restore original first provided arg type.
             results.node_types_mut().insert(arg.hir_id, prev_type);

--- a/tests/ui/delegation/method-probe-self-ty-infer-var.rs
+++ b/tests/ui/delegation/method-probe-self-ty-infer-var.rs
@@ -1,7 +1,6 @@
 // Regression test for https://github.com/rust-lang/rust/issues/159128.
 
 #![feature(fn_delegation)]
-#![allow(incomplete_features)]
 
 trait Trait {
     fn method(self);

--- a/tests/ui/delegation/method-probe-self-ty-infer-var.rs
+++ b/tests/ui/delegation/method-probe-self-ty-infer-var.rs
@@ -1,0 +1,18 @@
+// Regression test for https://github.com/rust-lang/rust/issues/159128.
+
+#![feature(fn_delegation)]
+#![allow(incomplete_features)]
+
+trait Trait {
+    fn method(self);
+}
+
+struct S<S>;
+//~^ ERROR type parameter `S` is never used
+
+impl<T> Trait for S<T> {
+    reuse Trait::method { S }
+    //~^ ERROR type annotations needed
+}
+
+fn main() {}

--- a/tests/ui/delegation/method-probe-self-ty-infer-var.stderr
+++ b/tests/ui/delegation/method-probe-self-ty-infer-var.stderr
@@ -1,5 +1,5 @@
 error[E0392]: type parameter `S` is never used
-  --> $DIR/method-probe-self-ty-infer-var.rs:10:10
+  --> $DIR/method-probe-self-ty-infer-var.rs:9:10
    |
 LL | struct S<S>;
    |          ^ unused type parameter
@@ -8,7 +8,7 @@ LL | struct S<S>;
    = help: if you intended `S` to be a const parameter, use `const S: /* Type */` instead
 
 error[E0282]: type annotations needed
-  --> $DIR/method-probe-self-ty-infer-var.rs:14:27
+  --> $DIR/method-probe-self-ty-infer-var.rs:13:27
    |
 LL |     reuse Trait::method { S }
    |                           ^ cannot infer type of the type parameter `S` declared on the struct `S`

--- a/tests/ui/delegation/method-probe-self-ty-infer-var.stderr
+++ b/tests/ui/delegation/method-probe-self-ty-infer-var.stderr
@@ -1,0 +1,24 @@
+error[E0392]: type parameter `S` is never used
+  --> $DIR/method-probe-self-ty-infer-var.rs:10:10
+   |
+LL | struct S<S>;
+   |          ^ unused type parameter
+   |
+   = help: consider removing `S`, referring to it in a field, or using a marker such as `PhantomData`
+   = help: if you intended `S` to be a const parameter, use `const S: /* Type */` instead
+
+error[E0282]: type annotations needed
+  --> $DIR/method-probe-self-ty-infer-var.rs:14:27
+   |
+LL |     reuse Trait::method { S }
+   |                           ^ cannot infer type of the type parameter `S` declared on the struct `S`
+   |
+help: consider specifying a concrete type for the type parameter `S`
+   |
+LL |     reuse Trait::method { S::</* Type */> }
+   |                            ++++++++++++++
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0282, E0392.
+For more information about an error, try `rustc --explain E0282`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Fixes rust-lang/rust#159128

The old code temporarily wrote `pick.self_ty` into the first argument's node type before normal argument checking.

That `self_ty` can contain inference variables created inside the method-probe transaction, so resolving it later in the real function checking context could cause the ICE in `ena`.