### PR TITLE
Document Rc and Arc downcasting from Any

### DIFF
--- a/library/core/src/any.rs
+++ b/library/core/src/any.rs
@@ -38,6 +38,12 @@
 //! assert_eq!(boxed_id, TypeId::of::<Box<dyn Any>>());
 //! ```
 //!
+//! To downcast an `Rc<dyn Any>` or `Arc<dyn Any>`, use [`Rc::downcast`] or
+//! [`Arc::downcast`], respectively.
+//!
+//! [`Rc::downcast`]: ../../std/rc/struct.Rc.html#method.downcast
+//! [`Arc::downcast`]: ../../std/sync/struct.Arc.html#method.downcast
+//!
 //! ## Examples
 //!
 //! Consider a situation where we want to log a value passed to a function.


### PR DESCRIPTION
Closes rust-lang/rust#147651.

The `std::any` module explains the smart-pointer `type_id` behavior, but it only points readers to the `Box` API. Add direct links to `Rc::downcast` and `Arc::downcast` so users can discover the owning downcast APIs for those pointer types.

Validation:

- `git diff --check`
- Confirmed both target methods exist in `library/alloc/src/rc.rs` and `library/alloc/src/sync.rs`
- Confirmed the links follow the existing cross-crate relative-link style used for `Box`

A full rustdoc build was not run because this is a sparse checkout without the bootstrap toolchain.