### PR TITLE
add a FCW for overflow errors with the next solver

### DIFF
--- a/compiler/rustc_hir_analysis/src/coherence/orphan.rs
+++ b/compiler/rustc_hir_analysis/src/coherence/orphan.rs
@@ -319,7 +319,8 @@ fn orphan_check<'tcx>(
     }
 
     // (1)  Instantiate all generic params with fresh inference vars.
-    let infcx = tcx.infer_ctxt().build(TypingMode::Coherence);
+    let infcx =
+        tcx.infer_ctxt().enable_next_solver_overflow_fcw(false).build(TypingMode::Coherence);
     let cause = traits::ObligationCause::dummy();
     let args = infcx.fresh_args_for_item(cause.span, impl_def_id.to_def_id());
     let trait_ref = trait_ref.instantiate(tcx, args).skip_norm_wip();

--- a/compiler/rustc_infer/src/infer/at.rs
+++ b/compiler/rustc_infer/src/infer/at.rs
@@ -85,6 +85,7 @@ impl<'tcx> InferCtxt<'tcx> {
                 .placeholder_assumptions_for_next_solver
                 .clone(),
             next_trait_solver: self.next_trait_solver,
+            enable_next_solver_overflow_fcw: self.enable_next_solver_overflow_fcw,
             obligation_inspector: self.obligation_inspector.clone(),
         }
     }
@@ -113,6 +114,7 @@ impl<'tcx> InferCtxt<'tcx> {
                 .placeholder_assumptions_for_next_solver
                 .clone(),
             next_trait_solver: self.next_trait_solver,
+            enable_next_solver_overflow_fcw: self.enable_next_solver_overflow_fcw,
             obligation_inspector: self.obligation_inspector.clone(),
         };
         forked.inner.borrow_mut().projection_cache().clear();

--- a/compiler/rustc_infer/src/infer/context.rs
+++ b/compiler/rustc_infer/src/infer/context.rs
@@ -326,6 +326,10 @@ impl<'tcx> rustc_type_ir::InferCtxtLike for InferCtxt<'tcx> {
         self.probe(|_| probe())
     }
 
+    fn commit_if_ok<T, E>(&self, f: impl FnOnce() -> Result<T, E>) -> Result<T, E> {
+        self.commit_if_ok(|_| f())
+    }
+
     fn sub_regions(
         &self,
         sub: ty::Region<'tcx>,

--- a/compiler/rustc_infer/src/infer/context.rs
+++ b/compiler/rustc_infer/src/infer/context.rs
@@ -25,6 +25,10 @@ impl<'tcx> rustc_type_ir::InferCtxtLike for InferCtxt<'tcx> {
         self.next_trait_solver
     }
 
+    fn enable_next_solver_overflow_fcw(&self) -> bool {
+        self.enable_next_solver_overflow_fcw
+    }
+
     fn disable_trait_solver_fast_paths(&self) -> bool {
         self.disable_trait_solver_fast_paths()
     }

--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -338,6 +338,13 @@ pub struct InferCtxt<'tcx> {
 
     next_trait_solver: bool,
 
+    /// We have a `recursion_depth_exceeding_limit` FCW to mitigate breakages
+    /// caused by enabling the next solver globally. But the next solver is
+    /// already used by default in some places so we know they won't have
+    /// additional breakages. We also don't want spurious result in coherence
+    /// checking so we disable the FCW there as well.
+    enable_next_solver_overflow_fcw: bool,
+
     pub obligation_inspector: Cell<Option<ObligationInspector<'tcx>>>,
 }
 
@@ -578,6 +585,7 @@ pub struct InferCtxtBuilder<'tcx> {
     /// Whether we should use the new trait solver in the local inference context,
     /// which affects things like which solver is used in `predicate_may_hold`.
     next_trait_solver: bool,
+    enable_next_solver_overflow_fcw: bool,
 }
 
 #[extension(pub trait TyCtxtInferExt<'tcx>)]
@@ -589,6 +597,7 @@ impl<'tcx> TyCtxt<'tcx> {
             in_hir_typeck: false,
             skip_leak_check: false,
             next_trait_solver: self.next_trait_solver_globally(),
+            enable_next_solver_overflow_fcw: true,
         }
     }
 }
@@ -596,6 +605,14 @@ impl<'tcx> TyCtxt<'tcx> {
 impl<'tcx> InferCtxtBuilder<'tcx> {
     pub fn with_next_trait_solver(mut self, next_trait_solver: bool) -> Self {
         self.next_trait_solver = next_trait_solver;
+        self
+    }
+
+    pub fn enable_next_solver_overflow_fcw(
+        mut self,
+        enable_next_solver_overflow_fcw: bool,
+    ) -> Self {
+        self.enable_next_solver_overflow_fcw = enable_next_solver_overflow_fcw;
         self
     }
 
@@ -648,6 +665,7 @@ impl<'tcx> InferCtxtBuilder<'tcx> {
             in_hir_typeck,
             skip_leak_check,
             next_trait_solver,
+            enable_next_solver_overflow_fcw,
         } = *self;
         InferCtxt {
             tcx,
@@ -665,6 +683,7 @@ impl<'tcx> InferCtxtBuilder<'tcx> {
             universe: Cell::new(ty::UniverseIndex::ROOT),
             placeholder_assumptions_for_next_solver: RefCell::new(Default::default()),
             next_trait_solver,
+            enable_next_solver_overflow_fcw,
             obligation_inspector: Cell::new(None),
         }
     }

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -78,7 +78,6 @@ pub mod hardwired {
             MUST_NOT_SUSPEND,
             NAMED_ARGUMENTS_USED_POSITIONALLY,
             NEVER_TYPE_FALLBACK_FLOWING_INTO_UNSAFE,
-            NEXT_TRAIT_SOLVER_OVERFLOW,
             NON_CONTIGUOUS_RANGE_ENDPOINTS,
             NON_EXHAUSTIVE_OMITTED_PATTERNS,
             OUT_OF_SCOPE_MACRO_CALLS,
@@ -88,6 +87,7 @@ pub mod hardwired {
             PRIVATE_INTERFACES,
             PROC_MACRO_DERIVE_RESOLUTION_FALLBACK,
             PUB_USE_OF_PRIVATE_EXTERN_CRATE,
+            RECURSION_DEPTH_EXCEEDING_LIMIT,
             REDUNDANT_IMPORTS,
             REDUNDANT_LIFETIMES,
             REFINING_IMPL_TRAIT_INTERNAL,
@@ -5582,8 +5582,8 @@ declare_lint! {
 }
 
 declare_lint! {
-    /// The `next_trait_solver_overflow` lint detects situations where the obligation evaluation
-    /// overflows with the next solver but not with the old solver.
+    /// The `recursion_depth_exceeding_limit` lint detects cases where the compiler does not
+    /// correctly track the recursion depth in obligation evaluation.
     ///
     /// ### Example
     /// ```text
@@ -5620,21 +5620,16 @@ declare_lint! {
     ///
     /// ### Explanation
     ///
-    /// The trait solvers use a recursion limit to avoid hangs from deeply nested obligations.
-    /// They also use caches to avoid redundant computation. This is a performance optimization and
-    /// shouldn't affect the final evaluation result.
+    /// The compiler uses a recursion limit in obligation evaluation to avoid hangs.
     ///
-    /// However, the old solver doesn't validate depth requirement when looking up cache. This means
-    /// evaluation results depend on whether cache entries exists which in turn depends on cache
-    /// insertion order.
-    ///
-    /// The next solver correctly records and validates recursion depth requirements when using
-    /// the cache. This makes it more prone to overflow compared to the old solver.
+    /// However, the old trait solver sometimes ignores the recursion depth, whereas
+    /// the new solver correctly tracks it. This reveals cases where overflow should
+    /// have occurred previously.
     ///
     /// This is a [future-incompatible] lint to transition this to a hard error in the future.
     ///
     /// [future-incompatible]: ../index.md#future-incompatible-lints
-    pub NEXT_TRAIT_SOLVER_OVERFLOW,
+    pub RECURSION_DEPTH_EXCEEDING_LIMIT,
     Warn,
     "detects trait solving overflow that only happens with the next solver",
     @future_incompatible = FutureIncompatibleInfo {

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -78,6 +78,7 @@ pub mod hardwired {
             MUST_NOT_SUSPEND,
             NAMED_ARGUMENTS_USED_POSITIONALLY,
             NEVER_TYPE_FALLBACK_FLOWING_INTO_UNSAFE,
+            NEXT_TRAIT_SOLVER_OVERFLOW,
             NON_CONTIGUOUS_RANGE_ENDPOINTS,
             NON_EXHAUSTIVE_OMITTED_PATTERNS,
             OUT_OF_SCOPE_MACRO_CALLS,
@@ -5577,5 +5578,67 @@ declare_lint! {
     @future_incompatible = FutureIncompatibleInfo {
         reason: fcw!(FutureReleaseError #156047),
         report_in_deps: true,
+    };
+}
+
+declare_lint! {
+    /// The `next_trait_solver_overflow` lint detects situations where the obligation evaluation
+    /// overflows with the next solver but not with the old solver.
+    ///
+    /// ### Example
+    /// ```text
+    /// rustc -Znext-solver example.rs
+    /// ```
+    ///
+    /// ```rust,ignore (requires next solver)
+    /// #![recursion_limit = "8"]
+    /// struct Foo<T> {
+    ///    t: T,
+    ///    opt_t: Option<T>,
+    /// }
+    /// fn require_sync<T: Sync>() {}
+    /// fn main() {
+    ///     require_sync::<Foo<Foo<Foo<Foo<Foo<Foo<()>>>>>>>();
+    /// }
+    /// ```
+    ///
+    /// This will produces:
+    /// ```text
+    /// error[E0275]: overflow evaluating the requirement `Foo<Foo<Foo<Foo<Foo<Foo<()>>>>>>: Sync`
+    ///  --> example.rs:12:20
+    ///   |
+    ///   |     require_sync::<Foo<Foo<Foo<Foo<Foo<Foo<()>>>>>>>();
+    ///   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    ///   |
+    ///   = help: consider increasing the recursion limit by adding a `#![recursion_limit = "16"]` attribute to your crate
+    /// note: required by a bound in `require_sync`
+    ///  --> example.rs:9:20
+    ///   |
+    ///   | fn require_sync<T: Sync>() {}
+    ///   |                    ^^^^ required by this bound in `require_sync`
+    /// ```
+    ///
+    /// ### Explanation
+    ///
+    /// The trait solvers use a recursion limit to avoid hangs from deeply nested obligations.
+    /// They also use caches to avoid redundant computation. This is a performance optimization and
+    /// shouldn't affect the final evaluation result.
+    ///
+    /// However, the old solver doesn't validate depth requirement when looking up cache. This means
+    /// evaluation results depend on whether cache entries exists which in turn depends on cache
+    /// insertion order.
+    ///
+    /// The next solver correctly records and validates recursion depth requirements when using
+    /// the cache. This makes it more prone to overflow compared to the old solver.
+    ///
+    /// This is a [future-incompatible] lint to transition this to a hard error in the future.
+    ///
+    /// [future-incompatible]: ../index.md#future-incompatible-lints
+    pub NEXT_TRAIT_SOLVER_OVERFLOW,
+    Warn,
+    "detects trait solving overflow that only happens with the next solver",
+    @future_incompatible = FutureIncompatibleInfo {
+        reason: fcw!(FutureReleaseError #159228),
+        report_in_deps: false,
     };
 }

--- a/compiler/rustc_middle/src/queries.rs
+++ b/compiler/rustc_middle/src/queries.rs
@@ -2617,10 +2617,10 @@ rustc_queries! {
 
     /// Used by `-Znext-solver` to compute proof trees.
     query evaluate_root_goal_for_proof_tree_raw(
-        goal: solve::CanonicalInput<'tcx>,
+        key: (solve::CanonicalInput<'tcx>, usize)
     ) -> (solve::QueryResult<'tcx>, &'tcx solve::inspect::Probe<TyCtxt<'tcx>>) {
         no_hash
-        desc { "computing proof tree for `{}`", goal.canonical.value.goal.predicate }
+        desc { "computing proof tree for `{}` with depth `{}`", key.0.canonical.value.goal.predicate, key.1 }
     }
 
     /// Returns the Rust target features for the current target. These are not always the same as LLVM target features!

--- a/compiler/rustc_middle/src/query/keys.rs
+++ b/compiler/rustc_middle/src/query/keys.rs
@@ -340,6 +340,12 @@ impl<'tcx, T: QueryKeyBounds> QueryKey for (CanonicalQueryInput<'tcx, T>, bool) 
     }
 }
 
+impl<'tcx, T: QueryKeyBounds> QueryKey for (CanonicalQueryInput<'tcx, T>, usize) {
+    fn default_span(&self, _tcx: TyCtxt<'_>) -> Span {
+        DUMMY_SP
+    }
+}
+
 impl<'tcx> QueryKey for (Ty<'tcx>, rustc_abi::VariantIdx) {
     fn default_span(&self, _tcx: TyCtxt<'_>) -> Span {
         DUMMY_SP

--- a/compiler/rustc_middle/src/ty/context/impl_interner.rs
+++ b/compiler/rustc_middle/src/ty/context/impl_interner.rs
@@ -796,7 +796,7 @@ impl<'tcx> Interner for TyCtxt<'tcx> {
 
     fn emit_next_solver_overflow_fcw(self, predicate: ty::Predicate<'tcx>, span: Span) {
         self.emit_node_span_lint(
-            rustc_session::lint::builtin::NEXT_TRAIT_SOLVER_OVERFLOW,
+            rustc_session::lint::builtin::RECURSION_DEPTH_EXCEEDING_LIMIT,
             CRATE_HIR_ID,
             span,
             rustc_errors::DiagDecorator(|diag| {

--- a/compiler/rustc_middle/src/ty/context/impl_interner.rs
+++ b/compiler/rustc_middle/src/ty/context/impl_interner.rs
@@ -3,12 +3,13 @@
 use std::ops::ControlFlow;
 use std::{debug_assert_matches, fmt};
 
+use rustc_data_structures::Limit;
 use rustc_data_structures::intern::Interned;
 use rustc_errors::ErrorGuaranteed;
 use rustc_hir as hir;
-use rustc_hir::def::{CtorKind, DefKind};
-use rustc_hir::def_id::{DefId, LocalDefId};
-use rustc_hir::lang_items::LangItem;
+use rustc_hir::def::{CtorKind, DefKind, Namespace};
+use rustc_hir::def_id::{DefId, LOCAL_CRATE, LocalDefId};
+use rustc_hir::{CRATE_HIR_ID, LangItem};
 use rustc_span::{DUMMY_SP, Span, Symbol};
 use rustc_type_ir::lang_items::{SolverAdtLangItem, SolverProjectionLangItem, SolverTraitLangItem};
 use rustc_type_ir::{
@@ -22,6 +23,7 @@ use crate::traits::cache::WithDepNode;
 use crate::traits::solve::{
     self, CanonicalInput, ExternalConstraints, ExternalConstraintsData, QueryResult, inspect,
 };
+use crate::ty::print::{FmtPrinter, Print};
 use crate::ty::{
     self, BoundRegion, Clause, Const, List, ParamTy, Pattern, PolyExistentialPredicate, Predicate,
     Region, RegionKind, Ty, TyCtxt,
@@ -787,8 +789,44 @@ impl<'tcx> Interner for TyCtxt<'tcx> {
     fn evaluate_root_goal_for_proof_tree_raw(
         self,
         canonical_goal: CanonicalInput<'tcx>,
+        root_depth: usize,
     ) -> (QueryResult<'tcx>, &'tcx inspect::Probe<TyCtxt<'tcx>>) {
-        self.evaluate_root_goal_for_proof_tree_raw(canonical_goal)
+        self.evaluate_root_goal_for_proof_tree_raw((canonical_goal, root_depth))
+    }
+
+    fn emit_next_solver_overflow_fcw(self, predicate: ty::Predicate<'tcx>, span: Span) {
+        self.emit_node_span_lint(
+            rustc_session::lint::builtin::NEXT_TRAIT_SOLVER_OVERFLOW,
+            CRATE_HIR_ID,
+            span,
+            rustc_errors::DiagDecorator(|diag| {
+                // FIXME: share this with overflow error in fulfillment instead of duplicating.
+                let pred_str = {
+                    let s = predicate.to_string();
+                    if s.len() > 50 {
+                        let mut p: FmtPrinter<'_, '_> =
+                            FmtPrinter::new_with_limit(self, Namespace::TypeNS, Limit(6));
+                        predicate.print(&mut p).unwrap();
+                        p.into_buffer()
+                    } else {
+                        s
+                    }
+                };
+                diag.primary_message(format!(
+                    "overflow evaluating the requirement `{pred_str}`",
+                ));
+                diag.help(format!(
+                    "consider increasing the recursion limit by adding a \
+                     `#![recursion_limit = \"{}\"]` attribute to your crate (`{}`)",
+                    self.recursion_limit() * 2,
+                    self.crate_name(LOCAL_CRATE),
+                ));
+                diag.help(
+                    "or consider adding a manual `impl` of auto traits like `Send` for intermediate types, if auto traits are involved",
+                );
+                diag.note("this lint is attached to the whole crate and can't be disabled on a per-function basis");
+            }),
+        )
     }
 
     fn item_name(self, id: DefId) -> Symbol {

--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
@@ -318,7 +318,7 @@ where
 /// does so. Thus the next solver is more prone to overflow.
 /// To mitigate breakages, we re-evaluate the overflowed goal with doubled recursion limit
 /// and emit a FCW if it succeeds.
-/// See the doc comment on `NEXT_TRAIT_SOLVER_OVERFLOW` and #159228 for more details.
+/// See the doc comment on `RECURSION_DEPTH_EXCEEDING_LIMIT` and #159228 for more details.
 fn maybe_evaluate_root_goal_with_higher_recursion_limit<D, I>(
     delegate: &D,
     goal: Goal<I, I::Predicate>,
@@ -328,7 +328,7 @@ fn maybe_evaluate_root_goal_with_higher_recursion_limit<D, I>(
     D: SolverDelegate<Interner = I>,
     I: Interner,
 {
-    if delegate.typing_mode_raw().is_coherence() {
+    if !delegate.enable_next_solver_overflow_fcw() {
         return;
     }
 
@@ -351,21 +351,21 @@ fn maybe_evaluate_root_goal_with_higher_recursion_limit<D, I>(
     }
 
     let rerun_result = delegate.commit_if_ok(|| {
-        let new_result =
+        let rerun_result =
             EvalCtxt::enter_root(delegate, delegate.cx().recursion_limit() * 2, span, |ecx| {
                 ecx.evaluate_goal_no_fast_paths(GoalSource::Misc, goal)
             });
-        if let Ok(goal_evaluation) = &new_result
+        if let Ok(goal_evaluation) = &rerun_result
             && goal_evaluation.certainty.is_yes()
         {
-            Ok(new_result)
+            Ok(rerun_result)
         } else {
             Err(())
         }
     });
-    if let Ok(new_result) = rerun_result {
+    if let Ok(rerun_result) = rerun_result {
         delegate.cx().emit_next_solver_overflow_fcw(predicate, span);
-        *initial_result = new_result;
+        *initial_result = rerun_result;
     }
 }
 
@@ -373,7 +373,7 @@ fn maybe_evaluate_root_goal_with_higher_recursion_limit<D, I>(
 /// does so. Thus the next solver is more prone to overflow.
 /// To mitigate breakages, we re-evaluate the overflowed goal with doubled recursion limit
 /// and emit a FCW if it succeeds.
-/// See the doc comment on `NEXT_TRAIT_SOLVER_OVERFLOW` and #159228 for more details.
+/// See the doc comment on `RECURSION_DEPTH_EXCEEDING_LIMIT` and #159228 for more details.
 fn maybe_evaluate_root_goal_for_proof_tree_with_higher_recursion_limit<D, I>(
     delegate: &D,
     goal: Goal<I, I::Predicate>,
@@ -386,7 +386,7 @@ fn maybe_evaluate_root_goal_for_proof_tree_with_higher_recursion_limit<D, I>(
     D: SolverDelegate<Interner = I>,
     I: Interner,
 {
-    if delegate.typing_mode_raw().is_coherence() {
+    if !delegate.enable_next_solver_overflow_fcw() {
         return;
     }
 
@@ -425,9 +425,9 @@ fn maybe_evaluate_root_goal_for_proof_tree_with_higher_recursion_limit<D, I>(
             Err(())
         }
     });
-    if let Ok(new_result_pair) = rerun_result {
+    if let Ok(rerun_result) = rerun_result {
         delegate.cx().emit_next_solver_overflow_fcw(predicate, span);
-        *initial_result = new_result_pair;
+        *initial_result = rerun_result;
     }
 }
 

--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
@@ -246,10 +246,10 @@ where
             return Ok(res);
         }
 
-        let result = EvalCtxt::enter_root(self, self.cx().recursion_limit(), span, |ecx| {
-            // Fast paths handled above
+        let mut result = EvalCtxt::enter_root(self, self.cx().recursion_limit(), span, |ecx| {
             ecx.evaluate_goal_no_fast_paths(GoalSource::Misc, goal)
         });
+        maybe_evaluate_root_goal_with_higher_recursion_limit(self, goal, span, &mut result);
 
         match result {
             Ok(i) => Ok(i),
@@ -302,7 +302,132 @@ where
         goal: Goal<I, I::Predicate>,
         span: I::Span,
     ) -> (Result<NestedNormalizationGoals<I>, NoSolution>, inspect::GoalEvaluation<I>) {
-        evaluate_root_goal_for_proof_tree(self, goal, span)
+        let mut result =
+            evaluate_root_goal_for_proof_tree(self, goal, span, self.cx().recursion_limit());
+        maybe_evaluate_root_goal_for_proof_tree_with_higher_recursion_limit(
+            self,
+            goal,
+            span,
+            &mut result,
+        );
+        result
+    }
+}
+
+/// The old solver doesn't check depth requirement when looking up cache while the next solver
+/// does so. Thus the next solver is more prone to overflow.
+/// To mitigate breakages, we re-evaluate the overflowed goal with doubled recursion limit
+/// and emit a FCW if it succeeds.
+/// See the doc comment on `NEXT_TRAIT_SOLVER_OVERFLOW` and #159228 for more details.
+fn maybe_evaluate_root_goal_with_higher_recursion_limit<D, I>(
+    delegate: &D,
+    goal: Goal<I, I::Predicate>,
+    span: I::Span,
+    initial_result: &mut Result<GoalEvaluation<I>, NoSolutionOrRerunNonErased>,
+) where
+    D: SolverDelegate<Interner = I>,
+    I: Interner,
+{
+    if delegate.typing_mode_raw().is_coherence() {
+        return;
+    }
+
+    let predicate = match initial_result {
+        Err(_) => return,
+        Ok(goal_evaluation) if !goal_evaluation.certainty.is_overflow() => return,
+        Ok(goal_evaluation) => goal_evaluation.goal.predicate,
+    };
+
+    // Some goals no longer overflow after the stalled infers are resolved.
+    // Thus we don't have to rerun eagerly here.
+    let has_stalled_infers = match predicate.kind().skip_binder() {
+        ty::PredicateKind::Clause(ty::ClauseKind::Projection(projection)) => {
+            projection.projection_term.has_non_region_infer()
+        }
+        _ => predicate.has_non_region_infer(),
+    };
+    if has_stalled_infers {
+        return;
+    }
+
+    let rerun_result = delegate.commit_if_ok(|| {
+        let new_result =
+            EvalCtxt::enter_root(delegate, delegate.cx().recursion_limit() * 2, span, |ecx| {
+                ecx.evaluate_goal_no_fast_paths(GoalSource::Misc, goal)
+            });
+        if let Ok(goal_evaluation) = &new_result
+            && goal_evaluation.certainty.is_yes()
+        {
+            Ok(new_result)
+        } else {
+            Err(())
+        }
+    });
+    if let Ok(new_result) = rerun_result {
+        delegate.cx().emit_next_solver_overflow_fcw(predicate, span);
+        *initial_result = new_result;
+    }
+}
+
+/// The old solver doesn't check depth requirement when looking up cache while the next solver
+/// does so. Thus the next solver is more prone to overflow.
+/// To mitigate breakages, we re-evaluate the overflowed goal with doubled recursion limit
+/// and emit a FCW if it succeeds.
+/// See the doc comment on `NEXT_TRAIT_SOLVER_OVERFLOW` and #159228 for more details.
+fn maybe_evaluate_root_goal_for_proof_tree_with_higher_recursion_limit<D, I>(
+    delegate: &D,
+    goal: Goal<I, I::Predicate>,
+    span: I::Span,
+    initial_result: &mut (
+        Result<NestedNormalizationGoals<I>, NoSolution>,
+        inspect::GoalEvaluation<I>,
+    ),
+) where
+    D: SolverDelegate<Interner = I>,
+    I: Interner,
+{
+    if delegate.typing_mode_raw().is_coherence() {
+        return;
+    }
+
+    let goal_evaluation = &initial_result.1;
+    match goal_evaluation.result {
+        Err(_) => return,
+        Ok(response) if !response.value.certainty.is_overflow() => return,
+        Ok(_) => {}
+    }
+
+    // Some goals no longer overflow after the stalled infers are resolved.
+    // Thus we don't have to rerun eagerly here.
+    let predicate: I::Predicate = goal_evaluation.uncanonicalized_goal.predicate;
+    let has_stalled_infers = match predicate.kind().skip_binder() {
+        ty::PredicateKind::Clause(ty::ClauseKind::Projection(projection)) => {
+            projection.projection_term.has_non_region_infer()
+        }
+        _ => predicate.has_non_region_infer(),
+    };
+    if has_stalled_infers {
+        return;
+    }
+
+    let rerun_result = delegate.commit_if_ok(|| {
+        let (new_result, new_goal_evaluation) = evaluate_root_goal_for_proof_tree(
+            delegate,
+            goal,
+            span,
+            delegate.cx().recursion_limit() * 2,
+        );
+        if let Ok(response) = &new_goal_evaluation.result
+            && response.value.certainty.is_yes()
+        {
+            Ok((new_result, new_goal_evaluation))
+        } else {
+            Err(())
+        }
+    });
+    if let Ok(new_result_pair) = rerun_result {
+        delegate.cx().emit_next_solver_overflow_fcw(predicate, span);
+        *initial_result = new_result_pair;
     }
 }
 
@@ -1701,11 +1826,12 @@ pub fn evaluate_root_goal_for_proof_tree_raw_provider<
 >(
     cx: I,
     canonical_goal: CanonicalInput<I>,
+    root_depth: usize,
 ) -> (QueryResult<I>, I::Probe) {
     let mut inspect = inspect::ProofTreeBuilder::new();
     let (canonical_result, accessed_opaques) = SearchGraph::<D>::evaluate_root_goal_for_proof_tree(
         cx,
-        cx.recursion_limit(),
+        root_depth,
         canonical_goal,
         &mut inspect,
     );
@@ -1723,6 +1849,7 @@ pub(super) fn evaluate_root_goal_for_proof_tree<D: SolverDelegate<Interner = I>,
     delegate: &D,
     goal: Goal<I, I::Predicate>,
     origin_span: I::Span,
+    root_depth: usize,
 ) -> (Result<NestedNormalizationGoals<I>, NoSolution>, inspect::GoalEvaluation<I>) {
     let opaque_types = delegate.clone_opaque_types_lookup_table();
     let (goal, opaque_types) = eager_resolve_vars(&**delegate, (goal, opaque_types));
@@ -1732,7 +1859,7 @@ pub(super) fn evaluate_root_goal_for_proof_tree<D: SolverDelegate<Interner = I>,
         canonicalize_goal(delegate, goal, &opaque_types, typing_mode.into());
 
     let (canonical_result, final_revision) =
-        delegate.cx().evaluate_root_goal_for_proof_tree_raw(canonical_goal);
+        delegate.cx().evaluate_root_goal_for_proof_tree_raw(canonical_goal, root_depth);
 
     let proof_tree = inspect::GoalEvaluation {
         uncanonicalized_goal: goal,

--- a/compiler/rustc_trait_selection/src/solve.rs
+++ b/compiler/rustc_trait_selection/src/solve.rs
@@ -19,11 +19,10 @@ pub use select::InferCtxtSelectExt;
 
 fn evaluate_root_goal_for_proof_tree_raw<'tcx>(
     tcx: TyCtxt<'tcx>,
-    canonical_input: CanonicalInput<TyCtxt<'tcx>>,
+    key: (CanonicalInput<TyCtxt<'tcx>>, usize),
 ) -> (QueryResult<TyCtxt<'tcx>>, &'tcx inspect::Probe<TyCtxt<'tcx>>) {
     evaluate_root_goal_for_proof_tree_raw_provider::<SolverDelegate<'tcx>, TyCtxt<'tcx>>(
-        tcx,
-        canonical_input,
+        tcx, key.0, key.1,
     )
 }
 

--- a/compiler/rustc_trait_selection/src/traits/coherence.rs
+++ b/compiler/rustc_trait_selection/src/traits/coherence.rs
@@ -263,6 +263,7 @@ fn overlap<'tcx>(
         .infer_ctxt()
         .skip_leak_check(skip_leak_check.is_yes())
         .with_next_trait_solver(tcx.next_trait_solver_in_coherence())
+        .enable_next_solver_overflow_fcw(false)
         .build(TypingMode::Coherence);
     let selcx = &mut SelectionContext::new(&infcx);
     if track_ambiguity_causes.is_yes() {
@@ -504,7 +505,11 @@ fn impl_intersection_has_negative_obligation(
 
     // N.B. We need to unify impl headers *with* `TypingMode::Coherence`,
     // even if proving negative predicates doesn't need `TypingMode::Coherence`.
-    let ref infcx = tcx.infer_ctxt().with_next_trait_solver(true).build(TypingMode::Coherence);
+    let ref infcx = tcx
+        .infer_ctxt()
+        .with_next_trait_solver(true)
+        .enable_next_solver_overflow_fcw(false)
+        .build(TypingMode::Coherence);
     let root_universe = infcx.universe();
     assert_eq!(root_universe, ty::UniverseIndex::ROOT);
 

--- a/compiler/rustc_trait_selection/src/traits/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/mod.rs
@@ -789,6 +789,7 @@ pub fn impossible_predicates<'tcx>(tcx: TyCtxt<'tcx>, predicates: Vec<ty::Clause
     let (infcx, param_env) = tcx
         .infer_ctxt()
         .with_next_trait_solver(true)
+        .enable_next_solver_overflow_fcw(false)
         .build_with_typing_env(ty::TypingEnv::fully_monomorphized());
 
     let ocx = ObligationCtxt::new(&infcx);
@@ -897,6 +898,7 @@ fn is_impossible_associated_item(
         .infer_ctxt()
         .ignoring_regions()
         .with_next_trait_solver(true)
+        .enable_next_solver_overflow_fcw(false)
         .build(TypingMode::Coherence);
     let param_env = ty::ParamEnv::empty();
     let fresh_args = infcx.fresh_args_for_item(tcx.def_span(impl_def_id), impl_def_id);

--- a/compiler/rustc_type_ir/src/infer_ctxt.rs
+++ b/compiler/rustc_type_ir/src/infer_ctxt.rs
@@ -465,6 +465,8 @@ pub trait InferCtxtLike: Sized {
 
     fn probe<T>(&self, probe: impl FnOnce() -> T) -> T;
 
+    fn commit_if_ok<T, E>(&self, f: impl FnOnce() -> Result<T, E>) -> Result<T, E>;
+
     fn sub_regions(
         &self,
         sub: Region<Self::Interner>,

--- a/compiler/rustc_type_ir/src/infer_ctxt.rs
+++ b/compiler/rustc_type_ir/src/infer_ctxt.rs
@@ -344,6 +344,8 @@ pub trait InferCtxtLike: Sized {
         true
     }
 
+    fn enable_next_solver_overflow_fcw(&self) -> bool;
+
     fn disable_trait_solver_fast_paths(&self) -> bool;
 
     fn typing_mode_raw(&self) -> TypingMode<Self::Interner>;

--- a/compiler/rustc_type_ir/src/interner.rs
+++ b/compiler/rustc_type_ir/src/interner.rs
@@ -465,7 +465,10 @@ pub trait Interner:
     fn evaluate_root_goal_for_proof_tree_raw(
         self,
         canonical_goal: CanonicalInput<Self>,
+        root_depth: usize,
     ) -> (QueryResult<Self>, Self::Probe);
+
+    fn emit_next_solver_overflow_fcw(self, predicate: Self::Predicate, span: Self::Span);
 
     fn item_name(self, item_index: Self::DefId) -> Self::Symbol;
 

--- a/compiler/rustc_type_ir/src/solve/mod.rs
+++ b/compiler/rustc_type_ir/src/solve/mod.rs
@@ -848,6 +848,20 @@ impl Certainty {
             stalled_on_coroutines: StalledOnCoroutines::No,
         })
     }
+
+    pub fn is_yes(&self) -> bool {
+        match self {
+            Certainty::Yes => true,
+            Certainty::Maybe(_) => false,
+        }
+    }
+
+    pub fn is_overflow(&self) -> bool {
+        match self {
+            Certainty::Maybe(MaybeInfo { cause: MaybeCause::Overflow { .. }, .. }) => true,
+            _ => false,
+        }
+    }
 }
 
 /// Why we failed to evaluate a goal.

--- a/tests/ui/infinite/infinite-instantiation-struct-tail-ice-114484.rs
+++ b/tests/ui/infinite/infinite-instantiation-struct-tail-ice-114484.rs
@@ -13,7 +13,7 @@
 //~| ERROR reached the recursion limit while instantiating `<VirtualWrapper<_, 1> as MyTrait>::virtualize`
 
 //@ build-fail
-//@ compile-flags: --diagnostic-width=100 -Zwrite-long-types-to-disk=yes
+//@ compile-flags: --diagnostic-width=100 -Zwrite-long-types-to-disk=yes -Awarnings
 
 // Regression test for #114484: This used to ICE during monomorphization, because we treated
 // `<VirtualWrapper<...> as Pointee>::Metadata` as a rigid projection after reaching the recursion

--- a/tests/ui/traits/next-solver/overflow/fcw-on-auto-trait.next.stderr
+++ b/tests/ui/traits/next-solver/overflow/fcw-on-auto-trait.next.stderr
@@ -1,0 +1,28 @@
+warning: overflow evaluating the requirement `Foo<Foo<Foo<Foo<Foo<Foo<()>>>>>>: Sync`
+  --> $DIR/fcw-on-auto-trait.rs:22:5
+   |
+LL |     require_sync::<Foo<Foo<Foo<Foo<Foo<Foo<()>>>>>>>();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider increasing the recursion limit by adding a `#![recursion_limit = "16"]` attribute to your crate (`fcw_on_auto_trait`)
+   = help: or consider adding a manual `impl` of auto traits like `Send` for intermediate types, if auto traits are involved
+   = note: this lint is attached to the whole crate and can't be disabled on a per-function basis
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #159228 <https://github.com/rust-lang/rust/issues/159228>
+   = note: `#[warn(next_trait_solver_overflow)]` (part of `#[warn(future_incompatible)]`) on by default
+
+warning: overflow evaluating the requirement `Foo<Foo<Foo<Foo<Foo<Foo<()>>>>>>: Sync`
+  --> $DIR/fcw-on-auto-trait.rs:22:5
+   |
+LL |     require_sync::<Foo<Foo<Foo<Foo<Foo<Foo<()>>>>>>>();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider increasing the recursion limit by adding a `#![recursion_limit = "16"]` attribute to your crate (`fcw_on_auto_trait`)
+   = help: or consider adding a manual `impl` of auto traits like `Send` for intermediate types, if auto traits are involved
+   = note: this lint is attached to the whole crate and can't be disabled on a per-function basis
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #159228 <https://github.com/rust-lang/rust/issues/159228>
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+warning: 2 warnings emitted
+

--- a/tests/ui/traits/next-solver/overflow/fcw-on-auto-trait.next.stderr
+++ b/tests/ui/traits/next-solver/overflow/fcw-on-auto-trait.next.stderr
@@ -9,7 +9,7 @@ LL |     require_sync::<Foo<Foo<Foo<Foo<Foo<Foo<()>>>>>>>();
    = note: this lint is attached to the whole crate and can't be disabled on a per-function basis
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #159228 <https://github.com/rust-lang/rust/issues/159228>
-   = note: `#[warn(next_trait_solver_overflow)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[warn(recursion_depth_exceeding_limit)]` (part of `#[warn(future_incompatible)]`) on by default
 
 warning: overflow evaluating the requirement `Foo<Foo<Foo<Foo<Foo<Foo<()>>>>>>: Sync`
   --> $DIR/fcw-on-auto-trait.rs:22:5

--- a/tests/ui/traits/next-solver/overflow/fcw-on-auto-trait.rs
+++ b/tests/ui/traits/next-solver/overflow/fcw-on-auto-trait.rs
@@ -20,9 +20,8 @@ fn require_sync<T: Sync>() {}
 
 fn main() {
     require_sync::<Foo<Foo<Foo<Foo<Foo<Foo<()>>>>>>>();
-    //[next]~^ WARN: overflow evaluating the requirement `Foo<Foo<Foo<Foo<Foo<Foo<()>>>>>>: Sync` [next_trait_solver_overflow]
+    //[next]~^ WARN: overflow evaluating the requirement `Foo<Foo<Foo<Foo<Foo<Foo<()>>>>>>: Sync` [recursion_depth_exceeding_limit]
     //[next]~| WARN: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-    //[next]~| WARN: overflow evaluating the requirement `Foo<Foo<Foo<Foo<Foo<Foo<()>>>>>>: Sync` [next_trait_solver_overflow]
+    //[next]~| WARN: overflow evaluating the requirement `Foo<Foo<Foo<Foo<Foo<Foo<()>>>>>>: Sync` [recursion_depth_exceeding_limit]
     //[next]~| WARN: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-
 }

--- a/tests/ui/traits/next-solver/overflow/fcw-on-auto-trait.rs
+++ b/tests/ui/traits/next-solver/overflow/fcw-on-auto-trait.rs
@@ -1,0 +1,28 @@
+//@ revisions: old next
+//@[next] compile-flags: -Znext-solver
+//@ check-pass
+
+// The old solver doesn't verify depth when looking up cache.
+// To avoid breakage, we evaluate with higher recursion limit in the next solver
+// and emit an FCW for this.
+// See the `NEXT_TRAIT_SOLVER_OVERFLOW` FCW.
+
+#![recursion_limit = "8"]
+
+// The field order matters 😂
+#[allow(dead_code)]
+struct Foo<T> {
+    t: T,
+    opt_t: Option<T>,
+}
+
+fn require_sync<T: Sync>() {}
+
+fn main() {
+    require_sync::<Foo<Foo<Foo<Foo<Foo<Foo<()>>>>>>>();
+    //[next]~^ WARN: overflow evaluating the requirement `Foo<Foo<Foo<Foo<Foo<Foo<()>>>>>>: Sync` [next_trait_solver_overflow]
+    //[next]~| WARN: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+    //[next]~| WARN: overflow evaluating the requirement `Foo<Foo<Foo<Foo<Foo<Foo<()>>>>>>: Sync` [next_trait_solver_overflow]
+    //[next]~| WARN: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+
+}

--- a/tests/ui/traits/next-solver/overflow/fcw-on-normalization.next.stderr
+++ b/tests/ui/traits/next-solver/overflow/fcw-on-normalization.next.stderr
@@ -9,7 +9,7 @@ LL |     let b: <W<W<W<W<W<W<W<W<W<W<()>>>>>>>>>> as HasAssoc>::Assoc = loop {};
    = note: this lint is attached to the whole crate and can't be disabled on a per-function basis
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #159228 <https://github.com/rust-lang/rust/issues/159228>
-   = note: `#[warn(next_trait_solver_overflow)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[warn(recursion_depth_exceeding_limit)]` (part of `#[warn(future_incompatible)]`) on by default
 
 warning: overflow evaluating the requirement `<W<W<W<W<W<W<W<_>>>>>>> as HasAssoc>::Assoc == _`
   --> $DIR/fcw-on-normalization.rs:40:12

--- a/tests/ui/traits/next-solver/overflow/fcw-on-normalization.next.stderr
+++ b/tests/ui/traits/next-solver/overflow/fcw-on-normalization.next.stderr
@@ -1,0 +1,104 @@
+warning: overflow evaluating the requirement `<W<W<W<W<W<W<W<_>>>>>>> as HasAssoc>::Assoc == _`
+  --> $DIR/fcw-on-normalization.rs:40:12
+   |
+LL |     let b: <W<W<W<W<W<W<W<W<W<W<()>>>>>>>>>> as HasAssoc>::Assoc = loop {};
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider increasing the recursion limit by adding a `#![recursion_limit = "16"]` attribute to your crate (`fcw_on_normalization`)
+   = help: or consider adding a manual `impl` of auto traits like `Send` for intermediate types, if auto traits are involved
+   = note: this lint is attached to the whole crate and can't be disabled on a per-function basis
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #159228 <https://github.com/rust-lang/rust/issues/159228>
+   = note: `#[warn(next_trait_solver_overflow)]` (part of `#[warn(future_incompatible)]`) on by default
+
+warning: overflow evaluating the requirement `<W<W<W<W<W<W<W<_>>>>>>> as HasAssoc>::Assoc == _`
+  --> $DIR/fcw-on-normalization.rs:40:12
+   |
+LL |     let b: <W<W<W<W<W<W<W<W<W<W<()>>>>>>>>>> as HasAssoc>::Assoc = loop {};
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider increasing the recursion limit by adding a `#![recursion_limit = "16"]` attribute to your crate (`fcw_on_normalization`)
+   = help: or consider adding a manual `impl` of auto traits like `Send` for intermediate types, if auto traits are involved
+   = note: this lint is attached to the whole crate and can't be disabled on a per-function basis
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #159228 <https://github.com/rust-lang/rust/issues/159228>
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+warning: overflow evaluating the requirement `W<W<W<W<W<W<W<W<W<W<()>>>>>>>>>>: HasAssoc`
+  --> $DIR/fcw-on-normalization.rs:40:12
+   |
+LL |     let b: <W<W<W<W<W<W<W<W<W<W<()>>>>>>>>>> as HasAssoc>::Assoc = loop {};
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider increasing the recursion limit by adding a `#![recursion_limit = "16"]` attribute to your crate (`fcw_on_normalization`)
+   = help: or consider adding a manual `impl` of auto traits like `Send` for intermediate types, if auto traits are involved
+   = note: this lint is attached to the whole crate and can't be disabled on a per-function basis
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #159228 <https://github.com/rust-lang/rust/issues/159228>
+
+warning: overflow evaluating the requirement `<W<W<W<W<W<W<_>>>>>> as HasAssoc>::Assoc well-formed`
+  --> $DIR/fcw-on-normalization.rs:40:12
+   |
+LL |     let b: <W<W<W<W<W<W<W<W<W<W<()>>>>>>>>>> as HasAssoc>::Assoc = loop {};
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider increasing the recursion limit by adding a `#![recursion_limit = "16"]` attribute to your crate (`fcw_on_normalization`)
+   = help: or consider adding a manual `impl` of auto traits like `Send` for intermediate types, if auto traits are involved
+   = note: this lint is attached to the whole crate and can't be disabled on a per-function basis
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #159228 <https://github.com/rust-lang/rust/issues/159228>
+
+warning: overflow evaluating the requirement `<W<W<W<W<W<W<W<_>>>>>>> as HasAssoc>::Assoc == _`
+  --> $DIR/fcw-on-normalization.rs:40:12
+   |
+LL |     let b: <W<W<W<W<W<W<W<W<W<W<()>>>>>>>>>> as HasAssoc>::Assoc = loop {};
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider increasing the recursion limit by adding a `#![recursion_limit = "16"]` attribute to your crate (`fcw_on_normalization`)
+   = help: or consider adding a manual `impl` of auto traits like `Send` for intermediate types, if auto traits are involved
+   = note: this lint is attached to the whole crate and can't be disabled on a per-function basis
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #159228 <https://github.com/rust-lang/rust/issues/159228>
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+warning: overflow evaluating the requirement `<W<W<W<W<W<W<_>>>>>> as HasAssoc>::Assoc well-formed`
+  --> $DIR/fcw-on-normalization.rs:40:12
+   |
+LL |     let b: <W<W<W<W<W<W<W<W<W<W<()>>>>>>>>>> as HasAssoc>::Assoc = loop {};
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider increasing the recursion limit by adding a `#![recursion_limit = "16"]` attribute to your crate (`fcw_on_normalization`)
+   = help: or consider adding a manual `impl` of auto traits like `Send` for intermediate types, if auto traits are involved
+   = note: this lint is attached to the whole crate and can't be disabled on a per-function basis
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #159228 <https://github.com/rust-lang/rust/issues/159228>
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+warning: overflow evaluating the requirement `<W<W<W<W<W<W<W<_>>>>>>> as HasAssoc>::Assoc == _`
+  --> $DIR/fcw-on-normalization.rs:40:12
+   |
+LL |     let b: <W<W<W<W<W<W<W<W<W<W<()>>>>>>>>>> as HasAssoc>::Assoc = loop {};
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider increasing the recursion limit by adding a `#![recursion_limit = "16"]` attribute to your crate (`fcw_on_normalization`)
+   = help: or consider adding a manual `impl` of auto traits like `Send` for intermediate types, if auto traits are involved
+   = note: this lint is attached to the whole crate and can't be disabled on a per-function basis
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #159228 <https://github.com/rust-lang/rust/issues/159228>
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+warning: overflow evaluating the requirement `<W<W<W<W<W<W<_>>>>>> as HasAssoc>::Assoc well-formed`
+  --> $DIR/fcw-on-normalization.rs:40:12
+   |
+LL |     let b: <W<W<W<W<W<W<W<W<W<W<()>>>>>>>>>> as HasAssoc>::Assoc = loop {};
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider increasing the recursion limit by adding a `#![recursion_limit = "16"]` attribute to your crate (`fcw_on_normalization`)
+   = help: or consider adding a manual `impl` of auto traits like `Send` for intermediate types, if auto traits are involved
+   = note: this lint is attached to the whole crate and can't be disabled on a per-function basis
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #159228 <https://github.com/rust-lang/rust/issues/159228>
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+warning: 8 warnings emitted
+

--- a/tests/ui/traits/next-solver/overflow/fcw-on-normalization.rs
+++ b/tests/ui/traits/next-solver/overflow/fcw-on-normalization.rs
@@ -1,0 +1,62 @@
+//@ revisions: old next
+//@[next] compile-flags: -Znext-solver
+//@ check-pass
+
+// The old solver doesn't verify depth when looking up cache.
+// To avoid breakage, we evaluate with higher recursion limit in the next solver
+// and emit an FCW for this.
+// See the `NEXT_TRAIT_SOLVER_OVERFLOW` FCW.
+
+#![recursion_limit = "8"]
+
+trait Trait {
+    fn anyone_can_call(&self);
+}
+
+trait HasAssoc {
+    type Assoc;
+}
+
+struct W<T>(T);
+
+impl<T: HasAssoc> HasAssoc for W<T> {
+    type Assoc = T::Assoc;
+}
+
+impl HasAssoc for () {
+    type Assoc = ();
+}
+
+impl Trait for () {
+    fn anyone_can_call(&self) {}
+}
+
+fn foo() {
+    // Insert a cache entry for the old solver. Without this, the old solver
+    // also overflows.
+    let a: <W<W<W<W<W<W<W<()>>>>>>> as HasAssoc>::Assoc = loop {};
+    a.anyone_can_call();
+
+    let b: <W<W<W<W<W<W<W<W<W<W<()>>>>>>>>>> as HasAssoc>::Assoc = loop {};
+    //[next]~^ WARN: overflow evaluating the requirement `<W<W<W<W<W<W<W<_>>>>>>> as HasAssoc>::Assoc == _` [next_trait_solver_overflow]
+    //[next]~| WARN: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+    //[next]~| WARN: overflow evaluating the requirement `<W<W<W<W<W<W<W<_>>>>>>> as HasAssoc>::Assoc == _` [next_trait_solver_overflow]
+    //[next]~| WARN: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+    //[next]~| WARN: overflow evaluating the requirement `W<W<W<W<W<W<W<W<W<W<()>>>>>>>>>>: HasAssoc` [next_trait_solver_overflow]
+    //[next]~| WARN: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+    //[next]~| WARN: overflow evaluating the requirement `<W<W<W<W<W<W<_>>>>>> as HasAssoc>::Assoc well-formed` [next_trait_solver_overflow]
+    //[next]~| WARN: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+    //[next]~| WARN: overflow evaluating the requirement `<W<W<W<W<W<W<W<_>>>>>>> as HasAssoc>::Assoc == _` [next_trait_solver_overflow]
+    //[next]~| WARN: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+    //[next]~| WARN: overflow evaluating the requirement `<W<W<W<W<W<W<_>>>>>> as HasAssoc>::Assoc well-formed` [next_trait_solver_overflow]
+    //[next]~| WARN: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+    //[next]~| WARN: overflow evaluating the requirement `<W<W<W<W<W<W<W<_>>>>>>> as HasAssoc>::Assoc == _` [next_trait_solver_overflow]
+    //[next]~| WARN: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+    //[next]~| WARN: overflow evaluating the requirement `<W<W<W<W<W<W<_>>>>>> as HasAssoc>::Assoc well-formed` [next_trait_solver_overflow]
+    //[next]~| WARN: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+
+    // Force normalization when looking up methods and the self_ty is normalized to infer.
+    b.anyone_can_call();
+}
+
+fn main() {}

--- a/tests/ui/traits/next-solver/overflow/fcw-on-normalization.rs
+++ b/tests/ui/traits/next-solver/overflow/fcw-on-normalization.rs
@@ -5,7 +5,7 @@
 // The old solver doesn't verify depth when looking up cache.
 // To avoid breakage, we evaluate with higher recursion limit in the next solver
 // and emit an FCW for this.
-// See the `NEXT_TRAIT_SOLVER_OVERFLOW` FCW.
+// See the `recursion_depth_exceeding_limit` FCW.
 
 #![recursion_limit = "8"]
 
@@ -38,21 +38,21 @@ fn foo() {
     a.anyone_can_call();
 
     let b: <W<W<W<W<W<W<W<W<W<W<()>>>>>>>>>> as HasAssoc>::Assoc = loop {};
-    //[next]~^ WARN: overflow evaluating the requirement `<W<W<W<W<W<W<W<_>>>>>>> as HasAssoc>::Assoc == _` [next_trait_solver_overflow]
+    //[next]~^ WARN: overflow evaluating the requirement `<W<W<W<W<W<W<W<_>>>>>>> as HasAssoc>::Assoc == _` [recursion_depth_exceeding_limit]
     //[next]~| WARN: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-    //[next]~| WARN: overflow evaluating the requirement `<W<W<W<W<W<W<W<_>>>>>>> as HasAssoc>::Assoc == _` [next_trait_solver_overflow]
+    //[next]~| WARN: overflow evaluating the requirement `<W<W<W<W<W<W<W<_>>>>>>> as HasAssoc>::Assoc == _` [recursion_depth_exceeding_limit]
     //[next]~| WARN: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-    //[next]~| WARN: overflow evaluating the requirement `W<W<W<W<W<W<W<W<W<W<()>>>>>>>>>>: HasAssoc` [next_trait_solver_overflow]
+    //[next]~| WARN: overflow evaluating the requirement `W<W<W<W<W<W<W<W<W<W<()>>>>>>>>>>: HasAssoc` [recursion_depth_exceeding_limit]
     //[next]~| WARN: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-    //[next]~| WARN: overflow evaluating the requirement `<W<W<W<W<W<W<_>>>>>> as HasAssoc>::Assoc well-formed` [next_trait_solver_overflow]
+    //[next]~| WARN: overflow evaluating the requirement `<W<W<W<W<W<W<_>>>>>> as HasAssoc>::Assoc well-formed` [recursion_depth_exceeding_limit]
     //[next]~| WARN: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-    //[next]~| WARN: overflow evaluating the requirement `<W<W<W<W<W<W<W<_>>>>>>> as HasAssoc>::Assoc == _` [next_trait_solver_overflow]
+    //[next]~| WARN: overflow evaluating the requirement `<W<W<W<W<W<W<W<_>>>>>>> as HasAssoc>::Assoc == _` [recursion_depth_exceeding_limit]
     //[next]~| WARN: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-    //[next]~| WARN: overflow evaluating the requirement `<W<W<W<W<W<W<_>>>>>> as HasAssoc>::Assoc well-formed` [next_trait_solver_overflow]
+    //[next]~| WARN: overflow evaluating the requirement `<W<W<W<W<W<W<_>>>>>> as HasAssoc>::Assoc well-formed` [recursion_depth_exceeding_limit]
     //[next]~| WARN: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-    //[next]~| WARN: overflow evaluating the requirement `<W<W<W<W<W<W<W<_>>>>>>> as HasAssoc>::Assoc == _` [next_trait_solver_overflow]
+    //[next]~| WARN: overflow evaluating the requirement `<W<W<W<W<W<W<W<_>>>>>>> as HasAssoc>::Assoc == _` [recursion_depth_exceeding_limit]
     //[next]~| WARN: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-    //[next]~| WARN: overflow evaluating the requirement `<W<W<W<W<W<W<_>>>>>> as HasAssoc>::Assoc well-formed` [next_trait_solver_overflow]
+    //[next]~| WARN: overflow evaluating the requirement `<W<W<W<W<W<W<_>>>>>> as HasAssoc>::Assoc well-formed` [recursion_depth_exceeding_limit]
     //[next]~| WARN: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
     // Force normalization when looking up methods and the self_ty is normalized to infer.

--- a/tests/ui/traits/next-solver/overflow/global-cache.rs
+++ b/tests/ui/traits/next-solver/overflow/global-cache.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: -Znext-solver
+//@ compile-flags: -Znext-solver -Awarnings
 
 // Check that we consider the reached depth of global cache
 // entries when detecting overflow. We would otherwise be unstable
@@ -19,5 +19,6 @@ type Four<T> = Inc<Inc<Inc<Inc<T>>>>;
 fn main() {
     impls_trait::<Four<Four<()>>>();
     impls_trait::<Four<Four<Four<Four<()>>>>>();
+    impls_trait::<Four<Four<Four<Four<Four<Four<()>>>>>>>();
     //~^ ERROR overflow evaluating the requirement
 }

--- a/tests/ui/traits/next-solver/overflow/global-cache.stderr
+++ b/tests/ui/traits/next-solver/overflow/global-cache.stderr
@@ -1,8 +1,8 @@
 error[E0275]: overflow evaluating the requirement `Inc<Inc<Inc<Inc<Inc<Inc<Inc<_>>>>>>>: Trait`
-  --> $DIR/global-cache.rs:21:19
+  --> $DIR/global-cache.rs:22:19
    |
-LL |     impls_trait::<Four<Four<Four<Four<()>>>>>();
-   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     impls_trait::<Four<Four<Four<Four<Four<Four<()>>>>>>>();
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: consider increasing the recursion limit by adding a `#![recursion_limit = "18"]` attribute to your crate (`global_cache`)
 note: required by a bound in `impls_trait`

--- a/tests/ui/traits/next-solver/unsize-overflow.rs
+++ b/tests/ui/traits/next-solver/unsize-overflow.rs
@@ -1,7 +1,7 @@
-//@ compile-flags: -Znext-solver
-#![recursion_limit = "8"]
+//@ compile-flags: -Znext-solver -Awarnings
+#![recursion_limit = "6"]
 
 fn main() {
-    let _: Box<dyn Send> = Box::new(&&&&&&&1);
-    //~^ ERROR overflow evaluating the requirement `Box<&&&&&&&i32>: CoerceUnsized<Box<dyn Send>>
+    let _: Box<dyn Send> = Box::new(&&&&&&&&&&&&1);
+    //~^ ERROR overflow evaluating the requirement `Box<&&&&&&&&&&&&i32>: CoerceUnsized<Box<dyn Send>>
 }

--- a/tests/ui/traits/next-solver/unsize-overflow.stderr
+++ b/tests/ui/traits/next-solver/unsize-overflow.stderr
@@ -1,11 +1,11 @@
-error[E0275]: overflow evaluating the requirement `Box<&&&&&&&i32>: CoerceUnsized<Box<dyn Send>>`
+error[E0275]: overflow evaluating the requirement `Box<&&&&&&&&&&&&i32>: CoerceUnsized<Box<dyn Send>>`
   --> $DIR/unsize-overflow.rs:5:28
    |
-LL |     let _: Box<dyn Send> = Box::new(&&&&&&&1);
-   |                            ^^^^^^^^^^^^^^^^^^
+LL |     let _: Box<dyn Send> = Box::new(&&&&&&&&&&&&1);
+   |                            ^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: consider increasing the recursion limit by adding a `#![recursion_limit = "16"]` attribute to your crate (`unsize_overflow`)
-   = note: required for the cast from `Box<&&&&&&&i32>` to `Box<dyn Send>`
+   = help: consider increasing the recursion limit by adding a `#![recursion_limit = "12"]` attribute to your crate (`unsize_overflow`)
+   = note: required for the cast from `Box<&&&&&&&&&&&&i32>` to `Box<dyn Send>`
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/159224)*
<!-- homu-ignore:end -->

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

The old solver doesn't check cache entry's depth requirement when looking up cache while the next solver correctly does so. It's necessary to behave correctly with respect to incremental compilation.
As a result, the next solver is more likely to run into overflow errors.

We try to catch such breakages by rerun the evaluation with doubled recursion limit and if that succeeds we emit a FCW.

This PR is being discussed on [zulip](https://rust-lang.zulipchat.com/#narrow/channel/364551-t-types.2Ftrait-system-refactor/topic/The.20old.20solver.20don.27t.20record.20required.20depth.20on.20cache/with/604756008) 

The lint issue is rust-lang/rust#159228

r? @lcnr