### PR TITLE
ast_lowering: Reject invalid direct_const_arg owners

### DIFF
--- a/compiler/rustc_ast_lowering/src/expr.rs
+++ b/compiler/rustc_ast_lowering/src/expr.rs
@@ -499,15 +499,8 @@ impl<'hir> LoweringContext<'_, 'hir> {
 
                 ExprKind::MacCall(_) => panic!("{:?} shouldn't exist here", e.span),
 
-                ExprKind::DirectConstArg(_) => {
-                    let e = self
-                        .tcx
-                        .dcx()
-                        .struct_span_err(
-                            e.span,
-                            "expected expression, found `direct_const_arg!()` constant",
-                        )
-                        .emit();
+                ExprKind::DirectConstArg(expr) => {
+                    let e = self.emit_bad_direct_const_arg(e.span, expr, "expression");
                     hir::ExprKind::Err(e)
                 }
             };

--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -53,7 +53,7 @@ use rustc_data_structures::steal::Steal;
 use rustc_data_structures::tagged_ptr::TaggedRef;
 use rustc_data_structures::unord::ExtendUnord;
 use rustc_errors::codes::*;
-use rustc_errors::{DiagArgFromDisplay, DiagCtxtHandle};
+use rustc_errors::{DiagArgFromDisplay, DiagCtxtHandle, ErrorGuaranteed};
 use rustc_hir::def::{DefKind, LifetimeRes, Namespace, PartialRes, PerNS, Res};
 use rustc_hir::def_id::{DefId, LOCAL_CRATE, LocalDefId, LocalDefIdMap};
 use rustc_hir::definitions::PerParentDisambiguatorState;
@@ -1760,18 +1760,30 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 let fields = self.arena.alloc_slice(fields);
                 hir::TyKind::View(ty, fields)
             }
-            TyKind::DirectConstArg(_) => {
-                let e = self
-                    .tcx
-                    .dcx()
-                    .struct_span_err(t.span, "expected type, found `direct_const_arg!()` constant")
-                    .emit();
+            TyKind::DirectConstArg(expr) => {
+                let e = self.emit_bad_direct_const_arg(t.span, expr, "type");
                 hir::TyKind::Err(e)
             }
             TyKind::Dummy => panic!("`TyKind::Dummy` should never be lowered"),
         };
 
         hir::Ty { kind, span: self.lower_span(t.span), hir_id: self.lower_node_id(t.id) }
+    }
+
+    pub(crate) fn emit_bad_direct_const_arg(
+        &mut self,
+        span: Span,
+        expr: &Expr,
+        expected: &'static str,
+    ) -> ErrorGuaranteed {
+        let msg = format!("expected {expected}, found `direct_const_arg!()` constant");
+        if expr::WillCreateDefIdsVisitor.visit_expr(expr).is_break() {
+            // FIXME(mgca): make this non-fatal once we have a better way to handle
+            // nested items in invalid `direct_const_arg!()` arguments.
+            self.dcx().struct_span_fatal(span, msg).emit()
+        } else {
+            self.dcx().struct_span_err(span, msg).emit()
+        }
     }
 
     fn lower_ty_direct_lifetime(

--- a/tests/ui/const-generics/mgca/invalid-direct-const-arg-owner-issue-159172.expr.stderr
+++ b/tests/ui/const-generics/mgca/invalid-direct-const-arg-owner-issue-159172.expr.stderr
@@ -1,0 +1,13 @@
+error: expected expression, found `direct_const_arg!()` constant
+  --> $DIR/invalid-direct-const-arg-owner-issue-159172.rs:21:13
+   |
+LL |       let _ = core::direct_const_arg!(|| {
+   |  _____________^
+LL | |
+LL | |         use std::io::*;
+LL | |         write!(_, "")
+LL | |     });
+   | |______^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/const-generics/mgca/invalid-direct-const-arg-owner-issue-159172.rs
+++ b/tests/ui/const-generics/mgca/invalid-direct-const-arg-owner-issue-159172.rs
@@ -1,0 +1,26 @@
+//@ revisions: ty expr
+#![feature(min_generic_const_args)]
+
+#[cfg(ty)]
+trait Iter<
+    const C: core::direct_const_arg!(|| {
+        //[ty]~^ ERROR expected type, found `direct_const_arg!()` constant
+        use std::io::*;
+        let mut buffer = std::fs::File::create("foo.txt")?;
+        write!(buffer, "oh no")?;
+    }),
+>
+{
+}
+
+#[cfg(ty)]
+fn main() {}
+
+#[cfg(expr)]
+fn main() {
+    let _ = core::direct_const_arg!(|| {
+        //[expr]~^ ERROR expected expression, found `direct_const_arg!()` constant
+        use std::io::*;
+        write!(_, "")
+    });
+}

--- a/tests/ui/const-generics/mgca/invalid-direct-const-arg-owner-issue-159172.ty.stderr
+++ b/tests/ui/const-generics/mgca/invalid-direct-const-arg-owner-issue-159172.ty.stderr
@@ -1,0 +1,14 @@
+error: expected type, found `direct_const_arg!()` constant
+  --> $DIR/invalid-direct-const-arg-owner-issue-159172.rs:6:14
+   |
+LL |       const C: core::direct_const_arg!(|| {
+   |  ______________^
+LL | |
+LL | |         use std::io::*;
+LL | |         let mut buffer = std::fs::File::create("foo.txt")?;
+LL | |         write!(buffer, "oh no")?;
+LL | |     }),
+   | |______^
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Fixes rust-lang/rust#159172

Invalid direct_const_arg! nodes in type/expression positions can still wrap closures, so later unused-import checking can ask for a HIR owner that lowering never created. btw this only hits already-invalid code, but an ICE there still feels too sharp.

Handle those invalid cases with the same fatal path used for unrepresentable mGCA args when the wrapped expr would create nested DefIds, and keep the ordinary diagnostic otherwise. imo this is the least invasive fix here since rust-lang/rust#158617's valid const-arg fallback path stays alone.