### PR TITLE
Don't list escaping bound regions in nested `for<...>` binders of E0308 notes

### DIFF
--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -2692,7 +2692,13 @@ impl<'tcx> FmtPrinter<'_, 'tcx> {
 struct RegionFolder<'a, 'tcx> {
     tcx: TyCtxt<'tcx>,
     current_index: ty::DebruijnIndex,
-    region_map: UnordMap<ty::BoundRegion<'tcx>, ty::Region<'tcx>>,
+    /// Regions that have already been named, keyed by the number of binders
+    /// between the binder being named and the region's binder: `0` for regions
+    /// bound by the binder being named (and placeholders), `n > 0` for regions
+    /// escaping through it into the `n`th enclosing binder. Escaping regions
+    /// are recorded only so that repeated occurrences are named consistently;
+    /// they don't belong in this binder's `for<...>` list (#134410).
+    region_map: UnordMap<(u32, ty::BoundRegion<'tcx>), ty::Region<'tcx>>,
     name: &'a mut (
                 dyn FnMut(
         Option<ty::DebruijnIndex>, // Debruijn index of the folded late-bound region
@@ -2732,7 +2738,11 @@ impl<'a, 'tcx> ty::TypeFolder<TyCtxt<'tcx>> for RegionFolder<'a, 'tcx> {
         let name = &mut self.name;
         let region = match r.kind() {
             ty::ReBound(ty::BoundVarIndexKind::Bound(db), br) if db >= self.current_index => {
-                *self.region_map.entry(br).or_insert_with(|| name(Some(db), self.current_index, br))
+                let binder_offset = db.as_u32() - self.current_index.as_u32();
+                *self
+                    .region_map
+                    .entry((binder_offset, br))
+                    .or_insert_with(|| name(Some(db), self.current_index, br))
             }
             ty::RePlaceholder(ty::PlaceholderRegion {
                 bound: ty::BoundRegion { kind, .. },
@@ -2747,7 +2757,7 @@ impl<'a, 'tcx> ty::TypeFolder<TyCtxt<'tcx>> for RegionFolder<'a, 'tcx> {
                         let br = ty::BoundRegion { var: ty::BoundVar::ZERO, kind };
                         *self
                             .region_map
-                            .entry(br)
+                            .entry((0, br))
                             .or_insert_with(|| name(None, self.current_index, br))
                     }
                 }
@@ -2901,6 +2911,17 @@ impl<'tcx> FmtPrinter<'_, 'tcx> {
                 start_or_continue(self, mode.start_str(), "");
             }
             start_or_continue(self, "", "> ");
+
+            // Only return the regions that are actually bound by `value`'s binder
+            // (binder offset 0). Regions merely escaping through it are bound by
+            // an enclosing binder and must not show up in the `for<...>` list the
+            // caller builds from this map (#134410, #111365).
+            let region_map = region_map
+                .into_items()
+                .filter_map(|((binder_offset, br), region)| {
+                    (binder_offset == 0).then_some((br, region))
+                })
+                .collect();
 
             (new_value, region_map)
         };

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -2692,15 +2692,10 @@ impl<'tcx> FmtPrinter<'_, 'tcx> {
 struct RegionFolder<'a, 'tcx> {
     tcx: TyCtxt<'tcx>,
     current_index: ty::DebruijnIndex,
+    /// Regions bound by the binder being named (and placeholders) that have
+    /// already been named.
     region_map: UnordMap<ty::BoundRegion<'tcx>, ty::Region<'tcx>>,
-    name: &'a mut (
-                dyn FnMut(
-        Option<ty::DebruijnIndex>, // Debruijn index of the folded late-bound region
-        ty::DebruijnIndex,         // Index corresponding to binder level
-        ty::BoundRegion<'tcx>,
-    ) -> ty::Region<'tcx>
-                    + 'a
-            ),
+    name: &'a mut (dyn FnMut(ty::BoundRegion<'tcx>) -> ty::Region<'tcx> + 'a),
 }
 
 impl<'a, 'tcx> ty::TypeFolder<TyCtxt<'tcx>> for RegionFolder<'a, 'tcx> {
@@ -2731,8 +2726,13 @@ impl<'a, 'tcx> ty::TypeFolder<TyCtxt<'tcx>> for RegionFolder<'a, 'tcx> {
     fn fold_region(&mut self, r: ty::Region<'tcx>) -> ty::Region<'tcx> {
         let name = &mut self.name;
         let region = match r.kind() {
-            ty::ReBound(ty::BoundVarIndexKind::Bound(db), br) if db >= self.current_index => {
-                *self.region_map.entry(br).or_insert_with(|| name(Some(db), self.current_index, br))
+            // Only name regions bound by the binder being named. Regions bound by an
+            // enclosing binder that merely escape through this one keep their name
+            // (they were named when that binder was folded) and their index, and must
+            // not end up in `region_map`, which callers use to build `for<...>` lists
+            // (#102392, #134410).
+            ty::ReBound(ty::BoundVarIndexKind::Bound(db), br) if db == self.current_index => {
+                *self.region_map.entry(br).or_insert_with(|| name(br))
             }
             ty::RePlaceholder(ty::PlaceholderRegion {
                 bound: ty::BoundRegion { kind, .. },
@@ -2745,10 +2745,7 @@ impl<'a, 'tcx> ty::TypeFolder<TyCtxt<'tcx>> for RegionFolder<'a, 'tcx> {
                     _ => {
                         // Index doesn't matter, since this is just for naming and these never get bound
                         let br = ty::BoundRegion { var: ty::BoundVar::ZERO, kind };
-                        *self
-                            .region_map
-                            .entry(br)
-                            .or_insert_with(|| name(None, self.current_index, br))
+                        *self.region_map.entry(br).or_insert_with(|| name(br))
                     }
                 }
             }
@@ -2857,29 +2854,14 @@ impl<'tcx> FmtPrinter<'_, 'tcx> {
 
             let trim_path = with_forced_trimmed_paths();
             // Closure used in `RegionFolder` to create names for anonymous late-bound
-            // regions. We use two `DebruijnIndex`es (one for the currently folded
-            // late-bound region and the other for the binder level) to determine
-            // whether a name has already been created for the currently folded region,
-            // see issue #102392.
-            let mut name = |lifetime_idx: Option<ty::DebruijnIndex>,
-                            binder_level_idx: ty::DebruijnIndex,
-                            br: ty::BoundRegion<'tcx>| {
+            // regions.
+            let mut name = |br: ty::BoundRegion<'tcx>| {
                 let (name, kind) = if let Some(name) = br.kind.get_name(tcx) {
                     (name, br.kind)
                 } else {
                     let name = next_name(self);
                     (name, ty::BoundRegionKind::NamedForPrinting(name))
                 };
-
-                if let Some(lt_idx) = lifetime_idx {
-                    if lt_idx > binder_level_idx {
-                        return ty::Region::new_bound(
-                            tcx,
-                            ty::INNERMOST,
-                            ty::BoundRegion { var: br.var, kind },
-                        );
-                    }
-                }
 
                 // Unconditionally render `unsafe<>`.
                 if !trim_path || mode == WrapBinderMode::Unsafe {

--- a/tests/ui/higher-ranked/nested-binder-cmp-fn-sig-print.rs
+++ b/tests/ui/higher-ranked/nested-binder-cmp-fn-sig-print.rs
@@ -1,0 +1,26 @@
+//! Regression test for <https://github.com/rust-lang/rust/issues/134410> and
+//! <https://github.com/rust-lang/rust/issues/111365>.
+//!
+//! The expected/found notes of "one type is more general than the other" errors
+//! used to leak lifetimes bound by outer binders into nested `for<...>` lists,
+//! printing invalid types such as `&mut for<'a> fn(for<'a> fn(&'a ()))` or
+//! `for<'o> fn(for<'a, 'o> fn(&'a (), &'o ()))`.
+
+type F1 = fn(fn(&'static ()));
+type F2 = for<'a> fn(fn(&'a ()));
+
+fn issue_134410(a: &mut F1) {
+    let _: &mut F2 = a; //~ ERROR mismatched types
+}
+
+type One = fn(HelperOne);
+type HelperOne = for<'a> fn(&'a (), &'a ());
+
+type Two = for<'o> fn(HelperTwo<'o>);
+type HelperTwo<'x> = for<'a> fn(&'a (), &'x ());
+
+fn issue_111365(x: One) -> Two {
+    x //~ ERROR mismatched types
+}
+
+fn main() {}

--- a/tests/ui/higher-ranked/nested-binder-cmp-fn-sig-print.stderr
+++ b/tests/ui/higher-ranked/nested-binder-cmp-fn-sig-print.stderr
@@ -1,0 +1,23 @@
+error[E0308]: mismatched types
+  --> $DIR/nested-binder-cmp-fn-sig-print.rs:23:5
+   |
+LL | fn issue_111365(x: One) -> Two {
+   |                            --- expected `for<'o> fn(for<'a> fn(&'a (), &'o ()))` because of return type
+LL |     x
+   |     ^ one type is more general than the other
+   |
+   = note: expected fn pointer `for<'o> fn(for<'a> fn(&'a (), &'o ()))`
+              found fn pointer `fn(for<'a> fn(&'a (), &'a ()))`
+
+error[E0308]: mismatched types
+  --> $DIR/nested-binder-cmp-fn-sig-print.rs:13:22
+   |
+LL |     let _: &mut F2 = a;
+   |                      ^ one type is more general than the other
+   |
+   = note: expected mutable reference `&mut for<'a> fn(fn(&'a ()))`
+              found mutable reference `&mut fn(fn(&()))`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/nll/relate_tys/placeholder-outlives-existential.stderr
+++ b/tests/ui/nll/relate_tys/placeholder-outlives-existential.stderr
@@ -5,7 +5,7 @@ LL |     x
    |     ^ one type is more general than the other
    |
    = note: expected fn pointer `fn(fn(fn(for<'unify> fn(Contra<'unify>, Co<'unify>))))`
-              found fn pointer `for<'e> fn(for<'e, 'p> fn(for<'e, 'p> fn(for<'e, 'p> fn(Contra<'e>, Co<'p>))))`
+              found fn pointer `for<'e> fn(for<'p> fn(fn(fn(Contra<'e>, Co<'p>))))`
 
 error: lifetime may not live long enough
   --> $DIR/placeholder-outlives-existential.rs:28:5


### PR DESCRIPTION
The expected/found notes of "one type is more general than the other" errors could print types that are not even valid syntax, repeating lifetimes from an outer binder inside nested `for<...>` lists:

```
= note: expected mutable reference `&mut for<'a> fn(for<'a> fn(&'a ()))`
           found mutable reference `&mut fn(fn(&()))`
```

The expected type here is actually `&mut for<'a> fn(fn(&'a ()))`, the inner fn pointer binds nothing. In the example from rust-lang/rust#111365 the note printed `for<'o> fn(for<'a, 'o> fn(&'a (), &'o ()))` even though the inner binder only binds `'a`.

The cause is in how `cmp_fn_sig` builds its `for<...>` prefixes. It calls `name_all_regions` and joins every region of the returned map into the list. But `RegionFolder` folded every region at or above the depth of the binder being printed (`db >= self.current_index`), so regions that are bound by an enclosing binder and merely escape through the current one also ended up in the map. The pretty printer's own text output already skipped those regions via a special case in the naming closure (which is why the labels of these diagnostics were correct, see rust-lang/rust#102392), but the returned map kept them, and `cmp_fn_sig` recurses through nested fn pointers one binder at a time, so every nested `for<...>` list picked up all the outer lifetimes. That special case also rebound the escaping region to `self.current_index`, i.e. shifted its De Bruijn index down so that it looked like it was bound by the current binder.

This PR makes `RegionFolder` only fold regions bound by the binder being named (`db == self.current_index`). Escaping regions are left untouched: they keep their index, and they already carry a name because the enclosing binder named them when it was folded (`cmp_fn_sig` recurses on the folded value). This makes the rust-lang/rust#102392 special case in the naming closure dead, so it is removed along with the two `DebruijnIndex` parameters it needed.

With this change, the two examples above print:

```
= note: expected mutable reference `&mut for<'a> fn(fn(&'a ()))`
           found mutable reference `&mut fn(fn(&()))`
```

```
= note: expected fn pointer `for<'o> fn(for<'a> fn(&'a (), &'o ()))`
           found fn pointer `fn(for<'a> fn(&'a (), &'a ()))`
```

The `found` line of `tests/ui/nll/relate_tys/placeholder-outlives-existential.rs` also loses its leaked binders and now matches the type written in the test's source.

Fixes rust-lang/rust#134410

This also fixes the leaked outer lifetimes reported in rust-lang/rust#111365, but I left that issue open since it additionally asks for renaming of shadowed lifetimes (`for<'a> fn(for<'a> ...)` for two distinct lifetimes both named `'a` in the source), which is a separate problem.
