### PR TITLE
resolve: Inherit eager invocation parents

### DIFF
--- a/compiler/rustc_resolve/src/macros.rs
+++ b/compiler/rustc_resolve/src/macros.rs
@@ -248,19 +248,30 @@ impl<'ra, 'tcx> ResolverExpand for Resolver<'ra, 'tcx> {
         force: bool,
     ) -> Result<Arc<SyntaxExtension>, Indeterminate> {
         let invoc_id = invoc.expansion_data.id;
-        let parent_scope = match self.invocation_parent_scopes.get(&invoc_id) {
-            Some(parent_scope) => *parent_scope,
-            None => {
-                // If there's no entry in the table, then we are resolving an eagerly expanded
-                // macro, which should inherit its parent scope from its eager expansion root -
+        let (parent_scope, invocation_parent) = match (
+            self.invocation_parent_scopes.get(&invoc_id),
+            self.invocation_parents.get(&invoc_id),
+        ) {
+            (Some(parent_scope), Some(invocation_parent)) => (*parent_scope, *invocation_parent),
+            (None, None) => {
+                // Eager macro invocations are not collected into the reduced graph, so they
+                // inherit their parent scope and invocation parent from the eager expansion root -
                 // the macro that requested this eager expansion.
                 let parent_scope = *self
                     .invocation_parent_scopes
                     .get(&eager_expansion_root)
                     .expect("non-eager expansion without a parent scope");
+                let invocation_parent = *self
+                    .invocation_parents
+                    .get(&eager_expansion_root)
+                    .expect("non-eager expansion without an invocation parent");
                 self.invocation_parent_scopes.insert(invoc_id, parent_scope);
-                parent_scope
+                self.invocation_parents.insert(invoc_id, invocation_parent);
+                (parent_scope, invocation_parent)
             }
+            _ => unreachable!(
+                "invocation parent tables must both contain or both miss an invocation"
+            ),
         };
 
         let (mut derives, mut inner_attr, mut deleg_impl) = (&[][..], false, None);
@@ -275,7 +286,7 @@ impl<'ra, 'tcx> ResolverExpand for Resolver<'ra, 'tcx> {
             InvocationKind::GlobDelegation { ref item, .. } => {
                 let ast::AssocItemKind::DelegationMac(deleg) = &item.kind else { unreachable!() };
                 let DelegationSuffixes::Glob(star_span) = deleg.suffixes else { unreachable!() };
-                deleg_impl = Some((self.invocation_parent(invoc_id), star_span));
+                deleg_impl = Some((invocation_parent.parent_def, star_span));
                 // It is sufficient to consider glob delegation a bang macro for now.
                 (&deleg.prefix, MacroKind::Bang)
             }
@@ -286,16 +297,13 @@ impl<'ra, 'tcx> ResolverExpand for Resolver<'ra, 'tcx> {
         let supports_macro_expansion = invoc.fragment_kind.supports_macro_expansion();
         let node_id = invoc.expansion_data.lint_node_id;
         // This is a heuristic, but it's good enough for the lint.
-        let looks_like_invoc_in_mod_inert_attr = self
-            .invocation_parents
-            .get(&invoc_id)
-            .or_else(|| self.invocation_parents.get(&eager_expansion_root))
-            .filter(|&&InvocationParent { parent_def: mod_def_id, in_attr, .. }| {
+        let looks_like_invoc_in_mod_inert_attr = Some(invocation_parent)
+            .filter(|&InvocationParent { parent_def: mod_def_id, in_attr, .. }| {
                 in_attr
                     && invoc.fragment_kind == AstFragmentKind::Expr
                     && self.tcx.def_kind(mod_def_id) == DefKind::Mod
             })
-            .map(|&InvocationParent { parent_def: mod_def_id, .. }| mod_def_id);
+            .map(|InvocationParent { parent_def: mod_def_id, .. }| mod_def_id);
         let sugg_span = match &invoc.kind {
             InvocationKind::Attr { item: Annotatable::Item(item), .. }
                 if !item.span.from_expansion() =>

--- a/tests/ui/delegation/eager-format-glob-delegation-ice-159233.rs
+++ b/tests/ui/delegation/eager-format-glob-delegation-ice-159233.rs
@@ -1,0 +1,10 @@
+//@ edition: 2024
+
+#![feature(fn_delegation)]
+
+static REGEX: () = format!(|| { reuse impl Trait for S; });
+//~^ ERROR format argument must be a string literal
+//~| ERROR cannot find type `Trait` in this scope
+//~| ERROR mismatched types
+
+fn main() {}

--- a/tests/ui/delegation/eager-format-glob-delegation-ice-159233.stderr
+++ b/tests/ui/delegation/eager-format-glob-delegation-ice-159233.stderr
@@ -1,0 +1,27 @@
+error: format argument must be a string literal
+  --> $DIR/eager-format-glob-delegation-ice-159233.rs:5:28
+   |
+LL | static REGEX: () = format!(|| { reuse impl Trait for S; });
+   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: you might be missing a string literal to format with
+   |
+LL | static REGEX: () = format!("{}", || { reuse impl Trait for S; });
+   |                            +++++
+
+error[E0433]: cannot find type `Trait` in this scope
+  --> $DIR/eager-format-glob-delegation-ice-159233.rs:5:44
+   |
+LL | static REGEX: () = format!(|| { reuse impl Trait for S; });
+   |                                            ^^^^^ use of undeclared type `Trait`
+
+error[E0308]: mismatched types
+  --> $DIR/eager-format-glob-delegation-ice-159233.rs:5:20
+   |
+LL | static REGEX: () = format!(|| { reuse impl Trait for S; });
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found `String`
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0308, E0433.
+For more information about an error, try `rustc --explain E0308`.


### PR DESCRIPTION
Fixes rust-lang/rust#159233

`format!` eagerly expands its first arg. In this case that path ran into a glob delegation from `fn_delegation`, and resolver tried to read `invocation_parents[invoc_id]` for an eager invocation that never went through reduced-graph collection. So a bad input got an ICE instead of normal errors.

This makes eager invocations copy `InvocationParent` from the eager expansion root, matching the parent-scope fallback already there. imo this is the right place to fix it: idk of a cleaner split where the scope and parent def do not drift apart. fyi the UI regression is the reported case, btw, and it still emits the expected user-facing errors without the panic.