### PR TITLE
inline Once wait and wait_force

### DIFF
--- a/library/std/src/sync/once.rs
+++ b/library/std/src/sync/once.rs
@@ -296,6 +296,7 @@ impl Once {
     /// If this [`Once`] has been poisoned because an initialization closure has
     /// panicked, this method will also panic. Use [`wait_force`](Self::wait_force)
     /// if this behavior is not desired.
+    #[inline]
     #[stable(feature = "once_wait", since = "1.86.0")]
     #[rustc_should_not_be_called_on_const_items]
     pub fn wait(&self) {
@@ -309,6 +310,7 @@ impl Once {
     ///
     /// If this [`Once`] has been poisoned, this function blocks until it
     /// becomes completed, unlike [`Once::wait()`], which panics in this case.
+    #[inline]
     #[stable(feature = "once_wait", since = "1.86.0")]
     #[rustc_should_not_be_called_on_const_items]
     pub fn wait_force(&self) {


### PR DESCRIPTION
I expected `OnceLock::wait` to generate an inline state check and a conditional call to `sys::Once::wait`, but a call to `Once::wait_force` is generated instead. This is because these methods are missing the `#[inline]` attribute.