### PR TITLE
Disallow AsyncDrop on unions

### DIFF
--- a/compiler/rustc_hir_analysis/src/check/wfcheck.rs
+++ b/compiler/rustc_hir_analysis/src/check/wfcheck.rs
@@ -1317,6 +1317,7 @@ fn check_impl<'tcx>(
                 // therefore don't need to be WF (the trait's `Self: Trait` predicate
                 // won't hold).
                 let trait_ref = tcx.impl_trait_ref(item.owner_id).instantiate_identity();
+                check_async_drop_not_on_union(tcx, trait_ref, impl_.self_ty.span)?;
                 // Avoid bogus "type annotations needed `Foo: Bar`" errors on `impl Bar for Foo` in
                 // case other `Foo` impls are incoherent.
                 tcx.ensure_result().coherent_trait(trait_ref.skip_normalization().def_id)?;
@@ -1397,6 +1398,23 @@ fn check_impl<'tcx>(
         check_where_clauses(wfcx, item.owner_id.def_id);
         Ok(())
     })
+}
+
+/// `AsyncDrop` must not be implemented for `Union`s
+/// Droping in synchronous context would silently skip
+/// the cleanup, use `Drop` instead
+fn check_async_drop_not_on_union<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    trait_ref: Unnormalized<'tcx, ty::TraitRef<'tcx>>,
+    self_ty_span: Span,
+) -> Result<(), ErrorGuaranteed> {
+    if Some(trait_ref.skip_normalization().def_id) == tcx.lang_items().async_drop_trait()
+        && let ty::Adt(def, _) = trait_ref.skip_normalization().self_ty().kind()
+        && def.is_union()
+    {
+        return Err(tcx.dcx().emit_err(errors::AsyncDropUnion { span: self_ty_span }));
+    }
+    Ok(())
 }
 
 /// Checks where-clauses and inline bounds that are declared on `def_id`.

--- a/compiler/rustc_hir_analysis/src/check/wfcheck.rs
+++ b/compiler/rustc_hir_analysis/src/check/wfcheck.rs
@@ -1401,7 +1401,7 @@ fn check_impl<'tcx>(
 }
 
 /// `AsyncDrop` must not be implemented for `Union`s
-/// Droping in synchronous context would silently skip
+/// Dropping in synchronous context would silently skip
 /// the cleanup, use `Drop` instead
 fn check_async_drop_not_on_union<'tcx>(
     tcx: TyCtxt<'tcx>,

--- a/compiler/rustc_hir_analysis/src/check/wfcheck.rs
+++ b/compiler/rustc_hir_analysis/src/check/wfcheck.rs
@@ -1412,7 +1412,7 @@ fn check_async_drop_not_on_union<'tcx>(
         && let ty::Adt(def, _) = trait_ref.skip_normalization().self_ty().kind()
         && def.is_union()
     {
-        return Err(tcx.dcx().emit_err(errors::AsyncDropUnion { span: self_ty_span }));
+        return Err(tcx.dcx().emit_err(diagnostics::AsyncDropUnion { span: self_ty_span }));
     }
     Ok(())
 }

--- a/compiler/rustc_hir_analysis/src/diagnostics.rs
+++ b/compiler/rustc_hir_analysis/src/diagnostics.rs
@@ -1844,6 +1844,17 @@ pub(crate) struct AsyncDropWithoutSyncDrop {
 }
 
 #[derive(Diagnostic)]
+#[diag("`AsyncDrop` impl for `Union`")]
+#[help(
+    "cancellation for union should be synchronous using `Drop` trait since cleanup silently skipped in async"
+)]
+pub(crate) struct AsyncDropUnion {
+    #[primary_span]
+    #[label("union implementing `AsyncDrop`")]
+    pub span: Span,
+}
+
+#[derive(Diagnostic)]
 #[diag("lifetime parameters or bounds of `{$ident}` do not match the declaration")]
 pub(crate) struct LifetimesOrBoundsMismatchOnEii {
     #[primary_span]

--- a/src/tools/miri/tests/pass/async-drop.rs
+++ b/src/tools/miri/tests/pass/async-drop.rs
@@ -82,8 +82,6 @@ fn main() {
             foo
         })
         .await;
-
-        test_async_drop(AsyncUnion { signed: 21 }).await;
     });
     let res = fut.poll(&mut cx);
     assert_eq!(res, Poll::Ready(()));
@@ -190,24 +188,5 @@ impl AsyncDrop for AsyncEnum {
             }
         };
         mem::forget(mem::replace(&mut *self, new_self));
-    }
-}
-
-// FIXME(zetanumbers): Disallow types with `AsyncDrop` in unions
-union AsyncUnion {
-    signed: i32,
-    unsigned: u32,
-}
-
-impl Drop for AsyncUnion {
-    fn drop(&mut self) {
-        println!("AsyncUnion::drop: {}, {}", unsafe { self.signed }, unsafe { self.unsigned },);
-    }
-}
-impl AsyncDrop for AsyncUnion {
-    async fn drop(self: Pin<&mut Self>) {
-        println!("AsyncUnion::async_drop: {}, {}", unsafe { self.signed }, unsafe {
-            self.unsigned
-        });
     }
 }

--- a/src/tools/miri/tests/pass/async-drop.stack.stdout
+++ b/src/tools/miri/tests/pass/async-drop.stack.stdout
@@ -19,5 +19,4 @@ SyncInt::drop: 17
 AsyncInt::async_drop: 18
 AsyncInt::async_drop: 19
 AsyncInt::async_drop: 20
-AsyncUnion::async_drop: 21, 21
 AsyncInt::async_drop: 10

--- a/src/tools/miri/tests/pass/async-drop.tree.stdout
+++ b/src/tools/miri/tests/pass/async-drop.tree.stdout
@@ -19,5 +19,4 @@ SyncInt::drop: 17
 AsyncInt::async_drop: 18
 AsyncInt::async_drop: 19
 AsyncInt::async_drop: 20
-AsyncUnion::async_drop: 21, 21
 AsyncInt::async_drop: 10

--- a/src/tools/miri/tests/pass/async-drop.tree_implicit_writes.stdout
+++ b/src/tools/miri/tests/pass/async-drop.tree_implicit_writes.stdout
@@ -19,5 +19,4 @@ SyncInt::drop: 17
 AsyncInt::async_drop: 18
 AsyncInt::async_drop: 19
 AsyncInt::async_drop: 20
-AsyncUnion::async_drop: 21, 21
 AsyncInt::async_drop: 10

--- a/tests/ui/async-await/async-drop/async-drop-initial.rs
+++ b/tests/ui/async-await/async-drop/async-drop-initial.rs
@@ -107,8 +107,6 @@ fn main() {
             48,
         )
         .await;
-
-        test_async_drop(AsyncUnion { signed: 21 }, 32).await;
     });
     let res = fut.poll(&mut cx);
     assert_eq!(res, Poll::Ready(()));
@@ -217,30 +215,5 @@ impl AsyncDrop for AsyncEnum {
             }
         };
         mem::forget(mem::replace(&mut *self, new_self));
-    }
-}
-
-// FIXME(zetanumbers): Disallow types with `AsyncDrop` in unions
-union AsyncUnion {
-    signed: i32,
-    unsigned: u32,
-}
-
-impl Drop for AsyncUnion {
-    fn drop(&mut self) {
-        println!(
-            "AsyncUnion::drop: {}, {}",
-            unsafe { self.signed },
-            unsafe { self.unsigned },
-        );
-    }
-}
-impl AsyncDrop for AsyncUnion {
-    async fn drop(self: Pin<&mut Self>) {
-        println!(
-            "AsyncUnion::Dropper::poll: {}, {}",
-            unsafe { self.signed },
-            unsafe { self.unsigned },
-        );
     }
 }

--- a/tests/ui/async-await/async-drop/async-drop-initial.run.stdout
+++ b/tests/ui/async-await/async-drop/async-drop-initial.run.stdout
@@ -19,4 +19,3 @@ SyncInt::drop: 17
 AsyncInt::Dropper::poll: 18
 AsyncInt::Dropper::poll: 19
 AsyncInt::Dropper::poll: 20
-AsyncUnion::Dropper::poll: 21, 21

--- a/tests/ui/async-await/async-drop/union.rs
+++ b/tests/ui/async-await/async-drop/union.rs
@@ -1,0 +1,33 @@
+//@ edition: 2018
+
+// `AsyncDrop` may not be implemented for unions: a union has no async drop glue,
+// so dropping it in a synchronous context would silently skip the async cleanup.
+// Synchronous `Drop` on a union remains allowed.
+//
+// This resolves the `FIXME(zetanumbers): Disallow types with AsyncDrop in unions`
+// and implements the "union types rejecting non-trivially async destructible
+// fields" item from the async drop tracking issue (rust-lang/rust#126482).
+
+#![feature(async_drop)]
+#![allow(incomplete_features)]
+
+use std::future::AsyncDrop;
+use std::pin::Pin;
+
+union U {
+    a: i32,
+    b: u32,
+}
+
+// Allowed: a union may still implement the synchronous `Drop` trait.
+impl Drop for U {
+    fn drop(&mut self) {}
+}
+
+// Rejected: a union may not implement `AsyncDrop`.
+impl AsyncDrop for U {
+    //~^ ERROR `AsyncDrop` impl for `Union`
+    async fn drop(self: Pin<&mut Self>) {}
+}
+
+fn main() {}

--- a/tests/ui/async-await/async-drop/union.stderr
+++ b/tests/ui/async-await/async-drop/union.stderr
@@ -1,0 +1,10 @@
+error: `AsyncDrop` impl for `Union`
+  --> $DIR/union.rs:28:20
+   |
+LL | impl AsyncDrop for U {
+   |                    ^ union implementing `AsyncDrop`
+   |
+   = help: cancellation for union should be synchronous using `Drop` trait since cleanup silently skipped in async
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Creates a warning when attempting to impl AsyncDrop on a Union.

tracking issue https://github.com/rust-lang/rust/issues/126482 for AsyncDrop 

Investigated the field-level mention in the tracking issue and found that implementing AsyncDrop requires implementing Drop, and implementing Drop will cause E0740, rejecting with "A union cannot have fields with destructors."

Basically, I was looking at the code trying to understand `AsyncDrop` and ran into the FIXME and wanted to fix it.

Disclosure: my first attempt at solving this https://github.com/AndyGauge/rust/pull/4 used claude code to propose a solution, then I used https://github.com/andygauge/rust-reviewer to propose moving from compiler/rustc_hir_analysis/src/coherence/builtin.rs to compiler/rustc_hir_analysis/src/check/wfcheck.rs. All code and descriptions have been rewritten by hand and only using Zed's tab-completion powered by rust-analyzer, rejecting the LLM's documentation, inlining method, and rustdoc.