### PR TITLE
Account for async closures when pointing at lifetime in return type

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/region_name.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/region_name.rs
@@ -791,10 +791,16 @@ impl<'tcx> MirBorrowckCtxt<'_, '_, 'tcx> {
     fn give_name_if_anonymous_region_appears_in_output(&self, fr: RegionVid) -> Option<RegionName> {
         let tcx = self.infcx.tcx;
 
-        let return_ty = self.regioncx.universal_regions().unnormalized_output_ty;
+        let mut return_ty = self.regioncx.universal_regions().unnormalized_output_ty;
         debug!("give_name_if_anonymous_region_appears_in_output: return_ty = {:?}", return_ty);
         if !tcx.any_free_region_meets(&return_ty, |r| r.as_var() == fr) {
             return None;
+        }
+
+        if let ty::Coroutine(_, args) = return_ty.kind() {
+            // When the return type is identified to be `{async closure body}`, we instead care
+            // about the actual return type of that coroutine.
+            return_ty = args.as_coroutine().return_ty();
         }
 
         let mir_hir_id = self.mir_hir_id();

--- a/tests/ui/async-await/async-closures/higher-ranked-return.stderr
+++ b/tests/ui/async-await/async-closures/higher-ranked-return.stderr
@@ -2,9 +2,9 @@ error: lifetime may not live long enough
   --> $DIR/higher-ranked-return.rs:11:46
    |
 LL |           let x = async move |x: &str| -> &str {
-   |  ________________________________-________----_^
+   |  ________________________________-________-____^
    | |                                |        |
-   | |                                |        return type of async closure `{async closure body@$DIR/higher-ranked-return.rs:11:46: 13:10}` contains a lifetime `'2`
+   | |                                |        let's call the lifetime of this reference `'2`
    | |                                let's call the lifetime of this reference `'1`
 LL | |             x
 LL | |         };

--- a/tests/ui/async-await/async-closures/not-lending.stderr
+++ b/tests/ui/async-await/async-closures/not-lending.stderr
@@ -4,7 +4,7 @@ error: lifetime may not live long enough
 LL |         let x = async move || -> &String { &s };
    |                 ------------------------ ^^^^^^ returning this value requires that `'1` must outlive `'2`
    |                 |                |
-   |                 |                return type of async closure `{async closure body@$DIR/not-lending.rs:12:42: 12:48}` contains a lifetime `'2`
+   |                 |                let's call the lifetime of this reference `'2`
    |                 lifetime `'1` represents this closure's body
    |
    = note: closure implements `AsyncFn`, so references to captured variables can't escape the closure
@@ -15,7 +15,7 @@ error: lifetime may not live long enough
 LL |         let x = async move || { &s };
    |                 ------------- ^^^^^^ returning this value requires that `'1` must outlive `'2`
    |                 |           |
-   |                 |           return type of async closure `{async closure body@$DIR/not-lending.rs:16:31: 16:37}` contains a lifetime `'2`
+   |                 |           return type of async closure is &'2 String
    |                 lifetime `'1` represents this closure's body
    |
    = note: closure implements `AsyncFn`, so references to captured variables can't escape the closure

--- a/tests/ui/async-await/issue-74072-lifetime-name-annotations.stderr
+++ b/tests/ui/async-await/issue-74072-lifetime-name-annotations.stderr
@@ -29,7 +29,7 @@ error: lifetime may not live long enough
 LL |       (async move || {
    |  ______-------------_^
    | |      |           |
-   | |      |           return type of async closure `{async closure body@$DIR/issue-74072-lifetime-name-annotations.rs:13:20: 19:6}` contains a lifetime `'2`
+   | |      |           return type of async closure is &'2 i32
    | |      lifetime `'1` represents this closure's body
 LL | |
 LL | |
@@ -78,7 +78,7 @@ error: lifetime may not live long enough
 LL |       (async move || -> &i32 {
    |  ______---------------------_^
    | |      |                |
-   | |      |                return type of async closure `{async closure body@$DIR/issue-74072-lifetime-name-annotations.rs:23:28: 29:6}` contains a lifetime `'2`
+   | |      |                let's call the lifetime of this reference `'2`
    | |      lifetime `'1` represents this closure's body
 LL | |
 LL | |


### PR DESCRIPTION
```
error: lifetime may not live long enough
  --> $DIR/higher-ranked-return.rs:11:46
   |
LL |           let x = async move |x: &str| -> &str {
   |  ________________________________-________-____^
   | |                                |        |
   | |                                |        let's call the lifetime of this reference `'2`
   | |                                let's call the lifetime of this reference `'1`
LL | |             x
LL | |         };
   | |_________^ returning this value requires that `'1` must outlive `'2`
```

instead of

```
error: lifetime may not live long enough
  --> $DIR/higher-ranked-return.rs:11:46
   |
LL |           let x = async move |x: &str| -> &str {
   |  ________________________________-________----_^
   | |                                |        |
   | |                                |        return type of async closure `{async closure body@$DIR/higher-ranked-return.rs:11:46: 13:10}` contains a lifetime `'2`
   | |                                let's call the lifetime of this reference `'1`
LL | |             x
LL | |         };
   | |_________^ returning this value requires that `'1` must outlive `'2`
```

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
