### PR TITLE
Fix diagnostic format parsing after escaped Unicode

### DIFF
--- a/compiler/rustc_parse_format/src/lib.rs
+++ b/compiler/rustc_parse_format/src/lib.rs
@@ -759,7 +759,7 @@ impl<'input> Parser<'input> {
             return spec;
         };
 
-        spec.ty = self.string(self.input_vec_index);
+        spec.ty = self.string(self.input_vec_index2pos(self.input_vec_index));
         spec.ty_span = {
             let end = self.input_vec_index2range(self.input_vec_index).start;
             Some(start..end)

--- a/compiler/rustc_parse_format/src/tests.rs
+++ b/compiler/rustc_parse_format/src/tests.rs
@@ -576,6 +576,21 @@ fn diagnostic_format_flags() {
 }
 
 #[test]
+fn diagnostic_format_flags_after_escaped_unicode() {
+    let lit = "넣{thing:blah}";
+    let snippet = r#""\u{b123}{thing:blah}""#.into();
+    let mut parser = Parser::new(lit, None, Some(snippet), false, ParseMode::Diagnostic);
+    assert!(parser.is_source_literal);
+
+    let [Lit("넣"), NextArgument(arg)] = &*parser.by_ref().collect::<Vec<Piece<'static>>>() else {
+        panic!()
+    };
+
+    assert_eq!(arg.format.ty, "blah");
+    assert!(parser.errors.is_empty());
+}
+
+#[test]
 fn diagnostic_format_mod() {
     let lit = "{thing:+}";
     let mut parser = Parser::new(lit, None, None, false, ParseMode::Diagnostic);


### PR DESCRIPTION
Fixes rust-lang/rust#159252.

`Parser::diagnostic` passed an `input_vec` character index to `Parser::string`, which expects a byte offset into the unescaped input. Escapes or multibyte characters before a diagnostic format specifier can make those coordinate systems diverge, producing an incorrect specifier or panicking on a non-character boundary.

Convert the current vector index with `input_vec_index2pos`, and add a regression test combining an escaped Unicode source literal with a diagnostic format specifier.

## Verification

- `cargo test --manifest-path compiler/rustc_parse_format/Cargo.toml` (29 passed)
- `cargo fmt --manifest-path compiler/rustc_parse_format/Cargo.toml --check`
- `git diff --check`
