### PR TITLE
Only force backtraces when a panic occurs in bootstrap

### DIFF
--- a/src/bootstrap/src/bin/main.rs
+++ b/src/bootstrap/src/bin/main.rs
@@ -9,6 +9,7 @@ use std::fs::{self, OpenOptions, TryLockError};
 use std::io::{self, BufRead, BufReader, IsTerminal, Read, Write};
 use std::path::Path;
 use std::str::FromStr;
+use std::sync::Once;
 use std::time::Instant;
 use std::{env, process};
 
@@ -27,16 +28,23 @@ fn main() {
 
     let _start_time = Instant::now();
 
-    // Always print backtraces to provide richer errors, to help debug hard-to-reproduce panics
-    // when the user didn't specify RUST_BACKTRACE
-    if std::env::var("RUST_BACKTRACE").is_err() {
-        unsafe {
-            std::env::set_var("RUST_BACKTRACE", "1");
-        }
-    }
-
     let default_panic_hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |info| {
+        static BACKTRACE_LOCK: Once = Once::new();
+
+        // Always print backtraces to provide richer errors, to help debug hard-to-reproduce panics
+        // when the user didn't specify RUST_BACKTRACE
+        // Note that we only override this variable in the panic handler, because bootstrap might
+        // manually capture backtraces when a command is executed, and in that case we do not want
+        // to always force backtraces.
+        BACKTRACE_LOCK.call_once(|| {
+            if std::env::var("RUST_BACKTRACE").is_err() {
+                unsafe {
+                    std::env::set_var("RUST_BACKTRACE", "1");
+                }
+            }
+        });
+
         default_panic_hook(info);
         StepStack::with_current(|stack| {
             eprintln!("\nBootstrap has panicked, currently active steps:");


### PR DESCRIPTION
In https://github.com/rust-lang/rust/pull/159040, I forced a backtrace to be printed in bootstrap when a panic happens. However, since bootstrap also captures backtraces manually during command execution, this meant that backtraces started to be printed during "normal" bootstrap failures (e.g. if tidy returned a failure), which is annoying.

This PR changes it so that the override only happens ona actual panics.

Note: bootstrap still uses a lot of panics for "normal" error conditions during a build, rather than for actual bugs or weird bootstrap situations. Those should ideally be replaced with `exit!(1)`.