### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -2357,7 +2357,7 @@ impl<'tcx> Printer<'tcx> for FmtPrinter<'_, 'tcx> {
             {
                 // We only truncate types that we know are likely to be much longer than 3 chars.
                 // There's no point in replacing `i32` or `!`.
-                write!(self, "...")?;
+                write!(self, "_")?;
                 Ok(())
             }
             _ => {

--- a/library/std/src/sync/once.rs
+++ b/library/std/src/sync/once.rs
@@ -296,6 +296,7 @@ impl Once {
     /// If this [`Once`] has been poisoned because an initialization closure has
     /// panicked, this method will also panic. Use [`wait_force`](Self::wait_force)
     /// if this behavior is not desired.
+    #[inline]
     #[stable(feature = "once_wait", since = "1.86.0")]
     #[rustc_should_not_be_called_on_const_items]
     pub fn wait(&self) {
@@ -309,6 +310,7 @@ impl Once {
     ///
     /// If this [`Once`] has been poisoned, this function blocks until it
     /// becomes completed, unlike [`Once::wait()`], which panics in this case.
+    #[inline]
     #[stable(feature = "once_wait", since = "1.86.0")]
     #[rustc_should_not_be_called_on_const_items]
     pub fn wait_force(&self) {

--- a/src/bootstrap/src/core/build_steps/check.rs
+++ b/src/bootstrap/src/core/build_steps/check.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 
 use crate::core::build_steps::compile::{
     ArtifactKeepMode, add_to_sysroot, run_cargo, rustc_cargo, rustc_cargo_env, std_cargo,
-    std_crates_for_run_make,
+    std_crates_for_make_run,
 };
 use crate::core::build_steps::tool;
 use crate::core::build_steps::tool::{
@@ -68,7 +68,7 @@ impl Step for Std {
         // Explicitly pass -p for all dependencies crates -- this will force cargo
         // to also check the tests/benches/examples for these crates, rather
         // than just the leaf crate.
-        let crates = std_crates_for_run_make(&run);
+        let crates = std_crates_for_make_run(&run);
         run.builder.ensure(Std {
             build_compiler: prepare_compiler_for_check(run.builder, run.target, Mode::Std)
                 .build_compiler(),

--- a/src/bootstrap/src/core/build_steps/clippy.rs
+++ b/src/bootstrap/src/core/build_steps/clippy.rs
@@ -13,11 +13,12 @@
 //! to pass a prebuilt Clippy from the outside when running `cargo clippy`, but that would be
 //! (as usual) a massive undertaking/refactoring.
 
-use super::compile::{ArtifactKeepMode, run_cargo, rustc_cargo, std_cargo};
 use super::tool::{SourceType, prepare_tool_cargo};
 use crate::builder::{Builder, ShouldRun};
 use crate::core::build_steps::check::{CompilerForCheck, prepare_compiler_for_check};
-use crate::core::build_steps::compile::std_crates_for_run_make;
+use crate::core::build_steps::compile::{
+    ArtifactKeepMode, run_cargo, rustc_cargo, std_cargo, std_crates_for_make_run,
+};
 use crate::core::builder;
 use crate::core::builder::{Alias, Kind, RunConfig, Step, StepMetadata, crate_description};
 use crate::utils::build_stamp::{self, BuildStamp};
@@ -178,7 +179,7 @@ impl Step for Std {
     }
 
     fn make_run(run: RunConfig<'_>) {
-        let crates = std_crates_for_run_make(&run);
+        let crates = std_crates_for_make_run(&run);
         let config = LintConfig::new(run.builder);
         run.builder.ensure(Std::new(run.builder, run.target, config, crates));
     }

--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -122,7 +122,7 @@ impl Step for Std {
     }
 
     fn make_run(run: RunConfig<'_>) {
-        let crates = std_crates_for_run_make(&run);
+        let crates = std_crates_for_make_run(&run);
         let builder = run.builder;
 
         // Force compilation of the standard library from source if the `library` is modified. This allows
@@ -479,9 +479,9 @@ fn copy_self_contained_objects(
     target_deps
 }
 
-/// Resolves standard library crates for `Std::run_make` for any build kind (like check, doc,
+/// Resolves standard library crates for [`Std::make_run`] for any build kind (like check, doc,
 /// build, clippy, etc.).
-pub fn std_crates_for_run_make(run: &RunConfig<'_>) -> Vec<String> {
+pub fn std_crates_for_make_run(run: &RunConfig<'_>) -> Vec<String> {
     let mut crates = run.make_run_crates(builder::Alias::Library);
 
     // For no_std targets, we only want to check core and alloc

--- a/src/bootstrap/src/core/build_steps/doc.rs
+++ b/src/bootstrap/src/core/build_steps/doc.rs
@@ -667,7 +667,7 @@ impl Step for Std {
     }
 
     fn make_run(run: RunConfig<'_>) {
-        let crates = compile::std_crates_for_run_make(&run);
+        let crates = compile::std_crates_for_make_run(&run);
         let target_is_no_std = run.builder.no_std(run.target).unwrap_or(false);
         if crates.is_empty() && target_is_no_std {
             return;

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -1085,10 +1085,12 @@ impl Step for IntrinsicTest {
         cmd.env("CFLAGS", cflags);
         // intrinsic-test shells out to `cargo` and `rustfmt` make bootstrap's
         // managed binaries findable by prepending their dirs to PATH.
-        let rustfmt_path = builder.config.initial_rustfmt.clone().unwrap_or_else(|| {
-            eprintln!("intrinsic-test: rustfmt is required but not available on this channel");
-            crate::exit!(1);
-        });
+        let Some(rustfmt_path) = builder.config.initial_rustfmt.clone() else {
+            eprintln!(
+                "WARNING: intrinsic-test skipped because rustfmt is required but not available on this channel"
+            );
+            return;
+        };
 
         let mut path_dirs: Vec<PathBuf> = Vec::new();
         if let Some(cargo_dir) = builder.initial_cargo.parent() {

--- a/src/tools/tidy/src/deps.rs
+++ b/src/tools/tidy/src/deps.rs
@@ -242,11 +242,17 @@ const EXCEPTIONS_RUST_ANALYZER: ExceptionList = &[
 
 const EXCEPTIONS_RUSTC_PERF: ExceptionList = &[
     // tidy-alphabetical-start
+    ("aws-lc-rs", "ISC AND (Apache-2.0 OR ISC)"),
+    (
+        "aws-lc-sys",
+        "ISC AND (Apache-2.0 OR ISC) AND Apache-2.0 AND MIT AND BSD-3-Clause AND (Apache-2.0 OR ISC OR MIT) AND (Apache-2.0 OR ISC OR MIT-0)",
+    ),
+    ("brotli", "BSD-3-Clause AND MIT"),
+    ("fast-srgb8", "MIT OR Apache-2.0 OR CC0-1.0"),
     ("inferno", "CDDL-1.0"),
     ("option-ext", "MPL-2.0"),
-    ("terminfo", "WTFPL"),
     ("wasite", "Apache-2.0 OR BSL-1.0 OR MIT"),
-    ("wezterm-bidi", "MIT AND Unicode-DFS-2016"),
+    ("webpki-root-certs", "CDLA-Permissive-2.0"),
     ("whoami", "Apache-2.0 OR BSL-1.0 OR MIT"),
     // tidy-alphabetical-end
 ];

--- a/src/tools/tidy/src/extdeps.rs
+++ b/src/tools/tidy/src/extdeps.rs
@@ -10,7 +10,7 @@ use crate::diagnostics::TidyCtx;
 const ALLOWED_SOURCES: &[&str] = &[
     r#""registry+https://github.com/rust-lang/crates.io-index""#,
     // This is `rust_team_data` used by `site` in src/tools/rustc-perf,
-    r#""git+https://github.com/rust-lang/team#a5260e76d3aa894c64c56e6ddc8545b9a98043ec""#,
+    r#""git+https://github.com/rust-lang/team#db2c1ed9fbc0216e533db954cd249045c01c7406""#,
 ];
 
 /// Checks for external package sources. `root` is the path to the directory that contains the

--- a/tests/ui/codegen/overflow-during-mono.stderr
+++ b/tests/ui/codegen/overflow-during-mono.stderr
@@ -3,8 +3,8 @@ error[E0275]: overflow evaluating the requirement `for<'a> {closure@$DIR/overflo
    = help: consider increasing the recursion limit by adding a `#![recursion_limit = "64"]` attribute to your crate (`overflow_during_mono`)
    = note: required for `Filter<IntoIter<i32, 11>, {closure@overflow-during-mono.rs:14:41}>` to implement `Iterator`
    = note: 31 redundant requirements hidden
-   = note: required for `Filter<Filter<Filter<Filter<Filter<..., ...>, ...>, ...>, ...>, ...>` to implement `Iterator`
-   = note: required for `Filter<Filter<Filter<Filter<Filter<..., ...>, ...>, ...>, ...>, ...>` to implement `IntoIterator`
+   = note: required for `Filter<Filter<Filter<Filter<Filter<Filter<_, _>, _>, _>, _>, _>, _>` to implement `Iterator`
+   = note: required for `Filter<Filter<Filter<Filter<Filter<Filter<_, _>, _>, _>, _>, _>, _>` to implement `IntoIterator`
    = note: the full name for the type has been written to '$TEST_BUILD_DIR/overflow-during-mono.long-type-$LONG_TYPE_HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
 

--- a/tests/ui/coercion/hr_alias_normalization_leaking_vars.stderr
+++ b/tests/ui/coercion/hr_alias_normalization_leaking_vars.stderr
@@ -16,7 +16,7 @@ error[E0308]: mismatched types
   --> $DIR/hr_alias_normalization_leaking_vars.rs:34:36
    |
 LL |     LendingIterator::for_each(&(), f);
-   |     -------------------------      ^ expected `Box<fn(...)>`, found fn item
+   |     -------------------------      ^ expected `Box<fn(_)>`, found fn item
    |     |
    |     arguments to this function are incorrect
    |

--- a/tests/ui/diagnostic-width/E0271.ascii.stderr
+++ b/tests/ui/diagnostic-width/E0271.ascii.stderr
@@ -1,4 +1,4 @@
-error[E0271]: type mismatch resolving `<Result<..., ()> as Future>::Error == Foo`
+error[E0271]: type mismatch resolving `<Result<_, ()> as Future>::Error == Foo`
   --> $DIR/E0271.rs:19:5
    |
 LL | /     Box::new(
@@ -7,14 +7,14 @@ LL | |             Err::<(), _>(
 LL | |                 Ok::<_, ()>(
 ...  |
 LL | |     )
-   | |_____^ type mismatch resolving `<Result<..., ()> as Future>::Error == Foo`
+   | |_____^ type mismatch resolving `<Result<_, ()> as Future>::Error == Foo`
    |
 note: expected this to be `Foo`
   --> $DIR/E0271.rs:9:18
    |
 LL |     type Error = E;
    |                  ^
-   = note: required for the cast from `Box<Result<..., ()>>` to `Box<...>`
+   = note: required for the cast from `Box<Result<_, ()>>` to `Box<_>`
    = note: the full name for the type has been written to '$TEST_BUILD_DIR/E0271.long-type-$LONG_TYPE_HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
 

--- a/tests/ui/diagnostic-width/E0271.unicode.stderr
+++ b/tests/ui/diagnostic-width/E0271.unicode.stderr
@@ -1,4 +1,4 @@
-error[E0271]: type mismatch resolving `<Result<..., ()> as Future>::Error == Foo`
+error[E0271]: type mismatch resolving `<Result<_, ()> as Future>::Error == Foo`
    ╭▸ $DIR/E0271.rs:19:5
    │
 LL │ ┏     Box::new(
@@ -7,14 +7,14 @@ LL │ ┃             Err::<(), _>(
 LL │ ┃                 Ok::<_, ()>(
    ‡ ┃
 LL │ ┃     )
-   │ ┗━━━━━┛ type mismatch resolving `<Result<..., ()> as Future>::Error == Foo`
+   │ ┗━━━━━┛ type mismatch resolving `<Result<_, ()> as Future>::Error == Foo`
    ╰╴
 note: expected this to be `Foo`
    ╭▸ $DIR/E0271.rs:9:18
    │
 LL │     type Error = E;
    │                  ━
-   ├ note: required for the cast from `Box<Result<..., ()>>` to `Box<...>`
+   ├ note: required for the cast from `Box<Result<_, ()>>` to `Box<_>`
    ├ note: the full name for the type has been written to '$TEST_BUILD_DIR/E0271.long-type-$LONG_TYPE_HASH.txt'
    ╰ note: consider using `--verbose` to print the full type name to the console
 

--- a/tests/ui/diagnostic-width/binop.rs
+++ b/tests/ui/diagnostic-width/binop.rs
@@ -5,11 +5,11 @@ type C = (B, B, B, B);
 type D = (C, C, C, C);
 
 fn foo(x: D) {
-    x + x; //~ ERROR cannot add `(...
+    x + x; //~ ERROR cannot add `((_
 }
 
 fn bar(x: D) {
-    !x; //~ ERROR cannot apply unary operator `!` to type `(...
+    !x; //~ ERROR cannot apply unary operator `!` to type `((_
 }
 
 fn main() {}

--- a/tests/ui/diagnostic-width/binop.stderr
+++ b/tests/ui/diagnostic-width/binop.stderr
@@ -1,15 +1,15 @@
-error[E0369]: cannot add `(..., ..., ..., ...)` to `(..., ..., ..., ...)`
+error[E0369]: cannot add `((_, _, _, _), _, _, _)` to `((_, _, _, _), _, _, _)`
   --> $DIR/binop.rs:8:7
    |
 LL |     x + x;
-   |     - ^ - (..., ..., ..., ...)
+   |     - ^ - ((_, _, _, _), _, _, _)
    |     |
-   |     (..., ..., ..., ...)
+   |     ((_, _, _, _), _, _, _)
    |
    = note: the full name for the type has been written to '$TEST_BUILD_DIR/binop.long-type-$LONG_TYPE_HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
 
-error[E0600]: cannot apply unary operator `!` to type `(..., ..., ..., ...)`
+error[E0600]: cannot apply unary operator `!` to type `((_, _, _, _), _, _, _)`
   --> $DIR/binop.rs:12:5
    |
 LL |     !x;

--- a/tests/ui/diagnostic-width/long-E0308.ascii.stderr
+++ b/tests/ui/diagnostic-width/long-E0308.ascii.stderr
@@ -16,10 +16,10 @@ LL |  |         Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok...
 LL |  |             Ok("")
 LL |  |         ))))))))))))))))))))))))))))))
 LL |  |     ))))))))))))))))))))))))))))));
-   |  |__________________________________^ expected `Atype<Btype<Ctype<..., i32>, i32>, i32>`, found `Result<Result<Result<..., _>, _>, _>`
+   |  |__________________________________^ expected `Atype<Btype<Ctype<_, i32>, i32>, i32>`, found `Result<Result<Result<_, _>, _>, _>`
    |
-   = note: expected struct `Atype<Btype<..., i32>, i32>`
-                found enum `Result<Result<..., _>, _>`
+   = note: expected struct `Atype<Btype<_, i32>, i32>`
+                found enum `Result<Result<_, _>, _>`
    = note: the full name for the type has been written to '$TEST_BUILD_DIR/long-E0308.long-type-$LONG_TYPE_HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
 
@@ -32,10 +32,10 @@ LL | |         Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(...
 LL | |             Ok(Ok(Ok(Ok(Ok(Ok(Ok("")))))))
 LL | |         ))))))))))))))))))))))))))))))
 LL | |     ))))))))))))))))))))))));
-   | |____________________________^ expected `Option<Result<Option<Option<...>>, _>>`, found `Result<Result<Result<..., _>, _>, _>`
+   | |____________________________^ expected `Option<Result<Option<Option<_>>, _>>`, found `Result<Result<Result<_, _>, _>, _>`
    |
-   = note: expected enum `Option<Result<Option<...>, _>>`
-              found enum `Result<Result<..., _>, _>`
+   = note: expected enum `Option<Result<Option<_>, _>>`
+              found enum `Result<Result<_, _>, _>`
    = note: the full name for the type has been written to '$TEST_BUILD_DIR/long-E0308.long-type-$LONG_TYPE_HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
 
@@ -50,11 +50,11 @@ LL | |           Atype<
 ...  |
 LL | |       i32
 LL | |     > = ();
-   | |     -   ^^ expected `Atype<Btype<Ctype<..., i32>, i32>, i32>`, found `()`
+   | |     -   ^^ expected `Atype<Btype<Ctype<_, i32>, i32>, i32>`, found `()`
    | |_____|
    |       expected due to this
    |
-   = note: expected struct `Atype<Btype<..., i32>, i32>`
+   = note: expected struct `Atype<Btype<_, i32>, i32>`
            found unit type `()`
    = note: the full name for the type has been written to '$TEST_BUILD_DIR/long-E0308.long-type-$LONG_TYPE_HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
@@ -70,10 +70,10 @@ LL | |         Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(...
 LL | |             Ok(Ok(Ok(Ok(Ok(Ok(Ok("")))))))
 LL | |         ))))))))))))))))))))))))))))))
 LL | |     ))))))))))))))))))))))));
-   | |____________________________^ expected `()`, found `Result<Result<Result<..., _>, _>, _>`
+   | |____________________________^ expected `()`, found `Result<Result<Result<_, _>, _>, _>`
    |
    = note: expected unit type `()`
-                   found enum `Result<Result<..., _>, _>`
+                   found enum `Result<Result<_, _>, _>`
    = note: the full name for the type has been written to '$TEST_BUILD_DIR/long-E0308.long-type-$LONG_TYPE_HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
 

--- a/tests/ui/diagnostic-width/long-E0308.unicode.stderr
+++ b/tests/ui/diagnostic-width/long-E0308.unicode.stderr
@@ -16,10 +16,10 @@ LL │  ┃         Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(O…
 LL │  ┃             Ok("")
 LL │  ┃         ))))))))))))))))))))))))))))))
 LL │  ┃     ))))))))))))))))))))))))))))));
-   │  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛ expected `Atype<Btype<Ctype<..., i32>, i32>, i32>`, found `Result<Result<Result<..., _>, _>, _>`
+   │  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛ expected `Atype<Btype<Ctype<_, i32>, i32>, i32>`, found `Result<Result<Result<_, _>, _>, _>`
    │
-   ├ note: expected struct `Atype<Btype<..., i32>, i32>`
-   │            found enum `Result<Result<..., _>, _>`
+   ├ note: expected struct `Atype<Btype<_, i32>, i32>`
+   │            found enum `Result<Result<_, _>, _>`
    ├ note: the full name for the type has been written to '$TEST_BUILD_DIR/long-E0308.long-type-$LONG_TYPE_HASH.txt'
    ╰ note: consider using `--verbose` to print the full type name to the console
 
@@ -32,10 +32,10 @@ LL │ ┃         Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok…
 LL │ ┃             Ok(Ok(Ok(Ok(Ok(Ok(Ok("")))))))
 LL │ ┃         ))))))))))))))))))))))))))))))
 LL │ ┃     ))))))))))))))))))))))));
-   │ ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛ expected `Option<Result<Option<Option<...>>, _>>`, found `Result<Result<Result<..., _>, _>, _>`
+   │ ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛ expected `Option<Result<Option<Option<_>>, _>>`, found `Result<Result<Result<_, _>, _>, _>`
    │
-   ├ note: expected enum `Option<Result<Option<...>, _>>`
-   │          found enum `Result<Result<..., _>, _>`
+   ├ note: expected enum `Option<Result<Option<_>, _>>`
+   │          found enum `Result<Result<_, _>, _>`
    ├ note: the full name for the type has been written to '$TEST_BUILD_DIR/long-E0308.long-type-$LONG_TYPE_HASH.txt'
    ╰ note: consider using `--verbose` to print the full type name to the console
 
@@ -50,11 +50,11 @@ LL │ │           Atype<
    ‡ │
 LL │ │       i32
 LL │ │     > = ();
-   │ │     │   ━━ expected `Atype<Btype<Ctype<..., i32>, i32>, i32>`, found `()`
+   │ │     │   ━━ expected `Atype<Btype<Ctype<_, i32>, i32>, i32>`, found `()`
    │ └─────┤
    │       expected due to this
    │
-   ├ note: expected struct `Atype<Btype<..., i32>, i32>`
+   ├ note: expected struct `Atype<Btype<_, i32>, i32>`
    │       found unit type `()`
    ├ note: the full name for the type has been written to '$TEST_BUILD_DIR/long-E0308.long-type-$LONG_TYPE_HASH.txt'
    ╰ note: consider using `--verbose` to print the full type name to the console
@@ -70,10 +70,10 @@ LL │ ┃         Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok…
 LL │ ┃             Ok(Ok(Ok(Ok(Ok(Ok(Ok("")))))))
 LL │ ┃         ))))))))))))))))))))))))))))))
 LL │ ┃     ))))))))))))))))))))))));
-   │ ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛ expected `()`, found `Result<Result<Result<..., _>, _>, _>`
+   │ ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛ expected `()`, found `Result<Result<Result<_, _>, _>, _>`
    │
    ├ note: expected unit type `()`
-   │               found enum `Result<Result<..., _>, _>`
+   │               found enum `Result<Result<_, _>, _>`
    ├ note: the full name for the type has been written to '$TEST_BUILD_DIR/long-E0308.long-type-$LONG_TYPE_HASH.txt'
    ╰ note: consider using `--verbose` to print the full type name to the console
 

--- a/tests/ui/diagnostic-width/long-E0529.rs
+++ b/tests/ui/diagnostic-width/long-E0529.rs
@@ -7,8 +7,8 @@ type C = (B, B, B, B);
 type D = (C, C, C, C);
 
 fn foo(x: D) {
-    let [] = x; //~ ERROR expected an array or slice, found `(...
-    //~^ NOTE pattern cannot match with input type `(...
+    let [] = x; //~ ERROR expected an array or slice, found `((_
+    //~^ NOTE pattern cannot match with input type `((_
 }
 
 fn main() {}

--- a/tests/ui/diagnostic-width/long-E0529.stderr
+++ b/tests/ui/diagnostic-width/long-E0529.stderr
@@ -1,8 +1,8 @@
-error[E0529]: expected an array or slice, found `(..., ..., ..., ...)`
+error[E0529]: expected an array or slice, found `((_, _, _, _), _, _, _)`
   --> $DIR/long-E0529.rs:10:9
    |
 LL |     let [] = x;
-   |         ^^ pattern cannot match with input type `(..., ..., ..., ...)`
+   |         ^^ pattern cannot match with input type `((_, _, _, _), _, _, _)`
    |
    = note: the full name for the type has been written to '$TEST_BUILD_DIR/long-E0529.long-type-$LONG_TYPE_HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console

--- a/tests/ui/diagnostic-width/long-E0609.rs
+++ b/tests/ui/diagnostic-width/long-E0609.rs
@@ -6,7 +6,7 @@ type C = (B, B, B, B);
 type D = (C, C, C, C);
 
 fn foo(x: D) {
-    x.field; //~ ERROR no field `field` on type `(...
+    x.field; //~ ERROR no field `field` on type `((_
 }
 
 fn main() {}

--- a/tests/ui/diagnostic-width/long-E0609.stderr
+++ b/tests/ui/diagnostic-width/long-E0609.stderr
@@ -1,4 +1,4 @@
-error[E0609]: no field `field` on type `(..., ..., ..., ...)`
+error[E0609]: no field `field` on type `((_, _, _, _), _, _, _)`
   --> $DIR/long-E0609.rs:9:7
    |
 LL |     x.field;

--- a/tests/ui/diagnostic-width/long-E0614.rs
+++ b/tests/ui/diagnostic-width/long-E0614.rs
@@ -6,7 +6,7 @@ type C = (B, B, B, B);
 type D = (C, C, C, C);
 
 fn foo(x: D) {
-    *x; //~ ERROR type `(...
+    *x; //~ ERROR type `((_
 }
 
 fn main() {}

--- a/tests/ui/diagnostic-width/long-E0614.stderr
+++ b/tests/ui/diagnostic-width/long-E0614.stderr
@@ -1,4 +1,4 @@
-error[E0614]: type `(..., ..., ..., ...)` cannot be dereferenced
+error[E0614]: type `((_, _, _, _), _, _, _)` cannot be dereferenced
   --> $DIR/long-E0614.rs:9:5
    |
 LL |     *x;

--- a/tests/ui/diagnostic-width/long-E0618.rs
+++ b/tests/ui/diagnostic-width/long-E0618.rs
@@ -6,8 +6,8 @@ type B = (A, A, A, A);
 type C = (B, B, B, B);
 type D = (C, C, C, C);
 
-fn foo(x: D) { //~ NOTE `x` has type `(...
-    x(); //~ ERROR expected function, found `(...
+fn foo(x: D) { //~ NOTE `x` has type `((_
+    x(); //~ ERROR expected function, found `((_
 }
 
 fn main() {}

--- a/tests/ui/diagnostic-width/long-E0618.stderr
+++ b/tests/ui/diagnostic-width/long-E0618.stderr
@@ -1,8 +1,8 @@
-error[E0618]: expected function, found `(..., ..., ..., ...)`
+error[E0618]: expected function, found `((_, _, _, _), _, _, _)`
   --> $DIR/long-E0618.rs:10:5
    |
 LL | fn foo(x: D) {
-   |        - `x` has type `(..., ..., ..., ...)`
+   |        - `x` has type `((_, _, _, _), _, _, _)`
 LL |     x();
    |     ^--
    |     |

--- a/tests/ui/diagnostic-width/long-e0277.rs
+++ b/tests/ui/diagnostic-width/long-e0277.rs
@@ -9,5 +9,5 @@ trait Trait {}
 fn require_trait<T: Trait>() {}
 
 fn main() {
-    require_trait::<D>(); //~ ERROR the trait bound `(...
+    require_trait::<D>(); //~ ERROR the trait bound `((_
 }

--- a/tests/ui/diagnostic-width/long-e0277.stderr
+++ b/tests/ui/diagnostic-width/long-e0277.stderr
@@ -1,10 +1,10 @@
-error[E0277]: the trait bound `(..., ..., ..., ...): Trait` is not satisfied
+error[E0277]: the trait bound `((_, _, _, _), _, _, _): Trait` is not satisfied
   --> $DIR/long-e0277.rs:12:21
    |
 LL |     require_trait::<D>();
    |                     ^ unsatisfied trait bound
    |
-   = help: the trait `Trait` is not implemented for `(..., ..., ..., ...)`
+   = help: the trait `Trait` is not implemented for `((_, _, _, _), _, _, _)`
 help: this trait has no implementations, consider adding one
   --> $DIR/long-e0277.rs:7:1
    |

--- a/tests/ui/diagnostic-width/non-copy-type-moved.stderr
+++ b/tests/ui/diagnostic-width/non-copy-type-moved.stderr
@@ -2,7 +2,7 @@ error[E0382]: use of moved value: `x`
   --> $DIR/non-copy-type-moved.rs:14:14
    |
 LL | fn foo(x: D) {
-   |        - move occurs because `x` has type `(..., ..., ..., ...)`, which does not implement the `Copy` trait
+   |        - move occurs because `x` has type `((_, _, _, _), _, _, _)`, which does not implement the `Copy` trait
 LL |     let _a = x;
    |              - value moved here
 LL |     let _b = x;

--- a/tests/ui/diagnostic-width/secondary-label-with-long-type.rs
+++ b/tests/ui/diagnostic-width/secondary-label-with-long-type.rs
@@ -7,8 +7,8 @@ type D = (C, C, C, C);
 
 fn foo(x: D) {
     let () = x; //~ ERROR mismatched types
-    //~^ NOTE this expression has type `((...,
-    //~| NOTE expected `((...,
+    //~^ NOTE this expression has type `(((_,
+    //~| NOTE expected `(((_,
     //~| NOTE expected tuple
     //~| NOTE the full name for the type has been written to
     //~| NOTE consider using `--verbose` to print the full type name to the console

--- a/tests/ui/diagnostic-width/secondary-label-with-long-type.stderr
+++ b/tests/ui/diagnostic-width/secondary-label-with-long-type.stderr
@@ -2,11 +2,11 @@ error[E0308]: mismatched types
   --> $DIR/secondary-label-with-long-type.rs:9:9
    |
 LL |     let () = x;
-   |         ^^   - this expression has type `((..., ..., ..., ...), ..., ..., ...)`
+   |         ^^   - this expression has type `(((_, _, _, _), _, _, _), _, _, _)`
    |         |
-   |         expected `((..., ..., ..., ...), ..., ..., ...)`, found `()`
+   |         expected `(((_, _, _, _), _, _, _), _, _, _)`, found `()`
    |
-   = note:  expected tuple `((..., ..., ..., ...), ..., ..., ...)`
+   = note:  expected tuple `(((_, _, _, _), _, _, _), _, _, _)`
            found unit type `()`
    = note: the full name for the type has been written to '$TEST_BUILD_DIR/secondary-label-with-long-type.long-type-$LONG_TYPE_HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console

--- a/tests/ui/dropck/dropck_no_diverge_on_nonregular_1.stderr
+++ b/tests/ui/dropck/dropck_no_diverge_on_nonregular_1.stderr
@@ -4,7 +4,7 @@ error[E0320]: overflow while adding drop-check rules for `FingerTree<i32>`
 LL |     let ft =
    |         ^^
    |
-   = note: overflowed on `FingerTree<Node<Node<Node<Node<Node<Node<Node<Node<Node<...>>>>>>>>>>`
+   = note: overflowed on `FingerTree<Node<Node<Node<Node<Node<Node<Node<Node<Node<_>>>>>>>>>>`
    = note: the full name for the type has been written to '$TEST_BUILD_DIR/dropck_no_diverge_on_nonregular_1.long-type-$LONG_TYPE_HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
 

--- a/tests/ui/error-codes/E0275.stderr
+++ b/tests/ui/error-codes/E0275.stderr
@@ -1,11 +1,11 @@
-error[E0275]: overflow evaluating the requirement `Bar<Bar<Bar<Bar<Bar<Bar<Bar<...>>>>>>>: Foo`
+error[E0275]: overflow evaluating the requirement `Bar<Bar<Bar<Bar<Bar<Bar<Bar<_>>>>>>>: Foo`
   --> $DIR/E0275.rs:6:33
    |
 LL | impl<T> Foo for T where Bar<T>: Foo {}
    |                                 ^^^
    |
    = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`E0275`)
-note: required for `Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<...>>>>>>>>>>>>>` to implement `Foo`
+note: required for `Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<_>>>>>>>>>>>>>` to implement `Foo`
   --> $DIR/E0275.rs:6:9
    |
 LL | impl<T> Foo for T where Bar<T>: Foo {}

--- a/tests/ui/higher-ranked/relate-bound-region-ice-144033.rs
+++ b/tests/ui/higher-ranked/relate-bound-region-ice-144033.rs
@@ -1,0 +1,33 @@
+// Regression test for <https://github.com/rust-lang/rust/issues/144033>.
+// A delegating impl whose method drops the trait's HRTB where-clause used to
+// ICE with "cannot relate bound region" instead of emitting normal errors.
+
+trait FooMut {
+    type Baz: 'static;
+    fn bar<'a, I>(self, iterator: &'a I)
+    where
+        for<'b> &'b I: IntoIterator<Item = &'b &'a Self::Baz>;
+}
+struct DelegatingFooMut<T> {}
+//~^ ERROR type parameter `T` is never used
+
+impl<T> FooMut for DelegatingFooMut<T>
+where
+    T: FooMut,
+{
+    type Baz = DelegatingBaz<T::Baz>;
+    fn bar<'a, I>(self, collection: &'a I)
+    //~^ ERROR lifetime parameters do not match the trait definition
+    where
+        for<'b> &'b I: IntoIterator,
+    {
+        let collection = collection.into_iter().map(|b| &b);
+        self.bar(collection)
+        //~^ ERROR type mismatch resolving
+        //~| ERROR mismatched types
+    }
+}
+struct DelegatingBaz<T>;
+//~^ ERROR type parameter `T` is never used
+
+fn main() {}

--- a/tests/ui/higher-ranked/relate-bound-region-ice-144033.rs
+++ b/tests/ui/higher-ranked/relate-bound-region-ice-144033.rs
@@ -1,33 +1,23 @@
 // Regression test for <https://github.com/rust-lang/rust/issues/144033>.
-// A delegating impl whose method drops the trait's HRTB where-clause used to
-// ICE with "cannot relate bound region" instead of emitting normal errors.
+// This used to ICE with "cannot relate bound region" instead of emitting
+// normal errors.
 
 trait FooMut {
-    type Baz: 'static;
-    fn bar<'a, I>(self, iterator: &'a I)
+    fn bar<I>(self, _: I)
     where
-        for<'b> &'b I: IntoIterator<Item = &'b &'a Self::Baz>;
+        for<'b> &'b I: Iterator<Item = &'b ()>;
 }
-struct DelegatingFooMut<T> {}
-//~^ ERROR type parameter `T` is never used
 
-impl<T> FooMut for DelegatingFooMut<T>
-where
-    T: FooMut,
-{
-    type Baz = DelegatingBaz<T::Baz>;
-    fn bar<'a, I>(self, collection: &'a I)
-    //~^ ERROR lifetime parameters do not match the trait definition
+impl FooMut for () {
+    fn bar<I>(self, _: I)
     where
-        for<'b> &'b I: IntoIterator,
+        for<'b> &'b I: Iterator,
     {
-        let collection = collection.into_iter().map(|b| &b);
+        let collection = std::iter::empty::<()>().map(|_| &());
         self.bar(collection)
-        //~^ ERROR type mismatch resolving
+        //~^ ERROR expected `&I` to be an iterator that yields `&()`
         //~| ERROR mismatched types
     }
 }
-struct DelegatingBaz<T>;
-//~^ ERROR type parameter `T` is never used
 
 fn main() {}

--- a/tests/ui/higher-ranked/relate-bound-region-ice-144033.stderr
+++ b/tests/ui/higher-ranked/relate-bound-region-ice-144033.stderr
@@ -1,0 +1,98 @@
+error[E0392]: type parameter `T` is never used
+  --> $DIR/relate-bound-region-ice-144033.rs:11:25
+   |
+LL | struct DelegatingFooMut<T> {}
+   |                         ^ unused type parameter
+   |
+   = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
+   = help: if you intended `T` to be a const parameter, use `const T: /* Type */` instead
+
+error[E0195]: lifetime parameters do not match the trait definition
+  --> $DIR/relate-bound-region-ice-144033.rs:19:12
+   |
+LL |     fn bar<'a, I>(self, collection: &'a I)
+   |            ^^
+   |
+   = note: lifetime parameters differ in whether they are early- or late-bound
+note: `'a` differs between the trait and impl
+  --> $DIR/relate-bound-region-ice-144033.rs:7:12
+   |
+LL |   trait FooMut {
+   |   ------------ in this trait...
+LL |       type Baz: 'static;
+LL |       fn bar<'a, I>(self, iterator: &'a I)
+   |              ^^ `'a` is early-bound
+LL |       where
+LL |           for<'b> &'b I: IntoIterator<Item = &'b &'a Self::Baz>;
+   |                                       ------------------------ this lifetime bound makes `'a` early-bound
+...
+LL | / impl<T> FooMut for DelegatingFooMut<T>
+LL | | where
+LL | |     T: FooMut,
+   | |______________- in this impl...
+...
+LL |       fn bar<'a, I>(self, collection: &'a I)
+   |              ^^ `'a` is late-bound
+
+error[E0392]: type parameter `T` is never used
+  --> $DIR/relate-bound-region-ice-144033.rs:30:22
+   |
+LL | struct DelegatingBaz<T>;
+   |                      ^ unused type parameter
+   |
+   = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
+   = help: if you intended `T` to be a const parameter, use `const T: /* Type */` instead
+
+error[E0271]: type mismatch resolving `<&I as IntoIterator>::Item == &&DelegatingBaz<<T as FooMut>::Baz>`
+  --> $DIR/relate-bound-region-ice-144033.rs:25:18
+   |
+LL |         self.bar(collection)
+   |              --- ^^^^^^^^^^ expected `&&DelegatingBaz<<T as FooMut>::Baz>`, found associated type
+   |              |
+   |              required by a bound introduced by this call
+   |
+   = note:    expected reference `&&DelegatingBaz<<T as FooMut>::Baz>`
+           found associated type `<&I as IntoIterator>::Item`
+   = help: consider constraining the associated type `<&I as IntoIterator>::Item` to `&&DelegatingBaz<<T as FooMut>::Baz>`
+   = note: for more information, visit https://doc.rust-lang.org/book/ch19-03-advanced-traits.html
+note: the method call chain might not have had the expected associated types
+  --> $DIR/relate-bound-region-ice-144033.rs:19:37
+   |
+LL |     fn bar<'a, I>(self, collection: &'a I)
+   |                                     ^^^^^ `IntoIterator::Item` is `<&I as IntoIterator>::Item` here
+...
+LL |         let collection = collection.into_iter().map(|b| &b);
+   |                                     ----------- ----------- `IntoIterator::Item` changed to `&<&I as IntoIterator>::Item` here
+   |                                     |
+   |                                     `IntoIterator::Item` remains `<&I as IntoIterator>::Item` here
+note: required by a bound in `FooMut::bar`
+  --> $DIR/relate-bound-region-ice-144033.rs:9:37
+   |
+LL |     fn bar<'a, I>(self, iterator: &'a I)
+   |        --- required by a bound in this associated function
+LL |     where
+LL |         for<'b> &'b I: IntoIterator<Item = &'b &'a Self::Baz>;
+   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `FooMut::bar`
+
+error[E0308]: mismatched types
+  --> $DIR/relate-bound-region-ice-144033.rs:25:18
+   |
+LL |         let collection = collection.into_iter().map(|b| &b);
+   |                                                     --- the found closure
+LL |         self.bar(collection)
+   |              --- ^^^^^^^^^^ expected `&I`, found `Map<<&I as IntoIterator>::IntoIter, ...>`
+   |              |
+   |              arguments to this method are incorrect
+   |
+   = note: expected reference `&I`
+                 found struct `Map<<&I as IntoIterator>::IntoIter, {closure@$DIR/relate-bound-region-ice-144033.rs:24:53: 24:56}>`
+note: method defined here
+  --> $DIR/relate-bound-region-ice-144033.rs:7:8
+   |
+LL |     fn bar<'a, I>(self, iterator: &'a I)
+   |        ^^^              --------
+
+error: aborting due to 5 previous errors
+
+Some errors have detailed explanations: E0195, E0271, E0308, E0392.
+For more information about an error, try `rustc --explain E0195`.

--- a/tests/ui/higher-ranked/relate-bound-region-ice-144033.stderr
+++ b/tests/ui/higher-ranked/relate-bound-region-ice-144033.stderr
@@ -1,98 +1,53 @@
-error[E0392]: type parameter `T` is never used
-  --> $DIR/relate-bound-region-ice-144033.rs:11:25
-   |
-LL | struct DelegatingFooMut<T> {}
-   |                         ^ unused type parameter
-   |
-   = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
-   = help: if you intended `T` to be a const parameter, use `const T: /* Type */` instead
-
-error[E0195]: lifetime parameters do not match the trait definition
-  --> $DIR/relate-bound-region-ice-144033.rs:19:12
-   |
-LL |     fn bar<'a, I>(self, collection: &'a I)
-   |            ^^
-   |
-   = note: lifetime parameters differ in whether they are early- or late-bound
-note: `'a` differs between the trait and impl
-  --> $DIR/relate-bound-region-ice-144033.rs:7:12
-   |
-LL |   trait FooMut {
-   |   ------------ in this trait...
-LL |       type Baz: 'static;
-LL |       fn bar<'a, I>(self, iterator: &'a I)
-   |              ^^ `'a` is early-bound
-LL |       where
-LL |           for<'b> &'b I: IntoIterator<Item = &'b &'a Self::Baz>;
-   |                                       ------------------------ this lifetime bound makes `'a` early-bound
-...
-LL | / impl<T> FooMut for DelegatingFooMut<T>
-LL | | where
-LL | |     T: FooMut,
-   | |______________- in this impl...
-...
-LL |       fn bar<'a, I>(self, collection: &'a I)
-   |              ^^ `'a` is late-bound
-
-error[E0392]: type parameter `T` is never used
-  --> $DIR/relate-bound-region-ice-144033.rs:30:22
-   |
-LL | struct DelegatingBaz<T>;
-   |                      ^ unused type parameter
-   |
-   = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
-   = help: if you intended `T` to be a const parameter, use `const T: /* Type */` instead
-
-error[E0271]: type mismatch resolving `<&I as IntoIterator>::Item == &&DelegatingBaz<<T as FooMut>::Baz>`
-  --> $DIR/relate-bound-region-ice-144033.rs:25:18
+error[E0271]: expected `&I` to be an iterator that yields `&()`, but it yields `<&I as Iterator>::Item`
+  --> $DIR/relate-bound-region-ice-144033.rs:17:18
    |
 LL |         self.bar(collection)
-   |              --- ^^^^^^^^^^ expected `&&DelegatingBaz<<T as FooMut>::Baz>`, found associated type
+   |              --- ^^^^^^^^^^ expected `&()`, found associated type
    |              |
    |              required by a bound introduced by this call
    |
-   = note:    expected reference `&&DelegatingBaz<<T as FooMut>::Baz>`
-           found associated type `<&I as IntoIterator>::Item`
-   = help: consider constraining the associated type `<&I as IntoIterator>::Item` to `&&DelegatingBaz<<T as FooMut>::Baz>`
+   = note:    expected reference `&()`
+           found associated type `<&I as Iterator>::Item`
+   = help: consider constraining the associated type `<&I as Iterator>::Item` to `&()`
    = note: for more information, visit https://doc.rust-lang.org/book/ch19-03-advanced-traits.html
 note: the method call chain might not have had the expected associated types
-  --> $DIR/relate-bound-region-ice-144033.rs:19:37
+  --> $DIR/relate-bound-region-ice-144033.rs:16:51
    |
-LL |     fn bar<'a, I>(self, collection: &'a I)
-   |                                     ^^^^^ `IntoIterator::Item` is `<&I as IntoIterator>::Item` here
-...
-LL |         let collection = collection.into_iter().map(|b| &b);
-   |                                     ----------- ----------- `IntoIterator::Item` changed to `&<&I as IntoIterator>::Item` here
-   |                                     |
-   |                                     `IntoIterator::Item` remains `<&I as IntoIterator>::Item` here
+LL |         let collection = std::iter::empty::<()>().map(|_| &());
+   |                          ------------------------ ^^^^^^^^^^^^ `Iterator::Item` is `&()` here
+   |                          |
+   |                          this expression has type `Empty<()>`
 note: required by a bound in `FooMut::bar`
-  --> $DIR/relate-bound-region-ice-144033.rs:9:37
+  --> $DIR/relate-bound-region-ice-144033.rs:8:33
    |
-LL |     fn bar<'a, I>(self, iterator: &'a I)
+LL |     fn bar<I>(self, _: I)
    |        --- required by a bound in this associated function
 LL |     where
-LL |         for<'b> &'b I: IntoIterator<Item = &'b &'a Self::Baz>;
-   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `FooMut::bar`
+LL |         for<'b> &'b I: Iterator<Item = &'b ()>;
+   |                                 ^^^^^^^^^^^^^ required by this bound in `FooMut::bar`
 
 error[E0308]: mismatched types
-  --> $DIR/relate-bound-region-ice-144033.rs:25:18
+  --> $DIR/relate-bound-region-ice-144033.rs:17:18
    |
-LL |         let collection = collection.into_iter().map(|b| &b);
-   |                                                     --- the found closure
+LL |     fn bar<I>(self, _: I)
+   |            - expected this type parameter
+...
+LL |         let collection = std::iter::empty::<()>().map(|_| &());
+   |                                                       --- the found closure
 LL |         self.bar(collection)
-   |              --- ^^^^^^^^^^ expected `&I`, found `Map<<&I as IntoIterator>::IntoIter, ...>`
+   |              --- ^^^^^^^^^^ expected type parameter `I`, found `Map<Empty<()>, {closure@...}>`
    |              |
    |              arguments to this method are incorrect
    |
-   = note: expected reference `&I`
-                 found struct `Map<<&I as IntoIterator>::IntoIter, {closure@$DIR/relate-bound-region-ice-144033.rs:24:53: 24:56}>`
+   = note: expected type parameter `I`
+                      found struct `Map<std::iter::Empty<()>, {closure@$DIR/relate-bound-region-ice-144033.rs:16:55: 16:58}>`
 note: method defined here
-  --> $DIR/relate-bound-region-ice-144033.rs:7:8
+  --> $DIR/relate-bound-region-ice-144033.rs:6:8
    |
-LL |     fn bar<'a, I>(self, iterator: &'a I)
-   |        ^^^              --------
+LL |     fn bar<I>(self, _: I)
+   |        ^^^          -
 
-error: aborting due to 5 previous errors
+error: aborting due to 2 previous errors
 
-Some errors have detailed explanations: E0195, E0271, E0308, E0392.
-For more information about an error, try `rustc --explain E0195`.
+Some errors have detailed explanations: E0271, E0308.
+For more information about an error, try `rustc --explain E0271`.

--- a/tests/ui/higher-ranked/trait-bounds/hang-on-deeply-nested-dyn.stderr
+++ b/tests/ui/higher-ranked/trait-bounds/hang-on-deeply-nested-dyn.stderr
@@ -11,7 +11,7 @@ LL | |     ),
 LL | | ) {
    | |_- expected `&dyn for<'a> Fn(&'a (dyn for<'a> Fn(&'a (dyn for<'a> Fn(&'a (dyn for<'a> Fn(&'a (dyn for<'a> Fn(&'a (dyn for<'a> Fn(&'a (dyn for<'a> Fn(&'a (dyn for<'a> Fn(&'a (dyn for<'a> Fn(&'a (dyn for<'a> Fn(&'a (dyn for<'a> Fn(&'a (dyn Fn(u32) + 'a)) + 'a)) + 'a)) + 'a)) + 'a)) + 'a)) + 'a)) + 'a)) + 'a)) + 'a)) + 'a))` because of return type
 LL |       f
-   |       ^ expected `&dyn Fn(&dyn Fn(&dyn Fn(&dyn Fn(&...))))`, found `&dyn Fn(u32)`
+   |       ^ expected `&dyn Fn(&dyn Fn(&dyn Fn(&dyn Fn(&_))))`, found `&dyn Fn(u32)`
    |
    = note: expected reference `&dyn for<'a> Fn(&'a (dyn for<'a> Fn(&'a (dyn for<'a> Fn(&'a (dyn for<'a> Fn(&'a (dyn for<'a> Fn(&'a (dyn for<'a> Fn(&'a (dyn for<'a> Fn(&'a (dyn for<'a> Fn(&'a (dyn for<'a> Fn(&'a (dyn for<'a> Fn(&'a (dyn for<'a> Fn(&'a (dyn Fn(u32) + 'a)) + 'a)) + 'a)) + 'a)) + 'a)) + 'a)) + 'a)) + 'a)) + 'a)) + 'a)) + 'a))`
               found reference `&dyn Fn(u32)`

--- a/tests/ui/inference/really-long-type-in-let-binding-without-sufficient-type-info.stderr
+++ b/tests/ui/inference/really-long-type-in-let-binding-without-sufficient-type-info.stderr
@@ -1,4 +1,4 @@
-error[E0282]: type annotations needed for `Result<_, (((..., ..., ..., ...), ..., ..., ...), ..., ..., ...)>`
+error[E0282]: type annotations needed for `Result<_, ((((i32, i32, i32, i32), _, _, _), _, _, _), _, _, _)>`
   --> $DIR/really-long-type-in-let-binding-without-sufficient-type-info.rs:8:9
    |
 LL |     let y = Err(x);

--- a/tests/ui/infinite/infinite-instantiation-struct-tail-ice-114484.rs
+++ b/tests/ui/infinite/infinite-instantiation-struct-tail-ice-114484.rs
@@ -10,7 +10,7 @@
 //~| ERROR reached the recursion limit finding the struct tail for `VirtualWrapper<SomeData<256>, 0>`
 //~| ERROR reached the recursion limit finding the struct tail for `VirtualWrapper<SomeData<256>, 0>`
 //~| ERROR reached the recursion limit finding the struct tail for `VirtualWrapper<SomeData<256>, 0>`
-//~| ERROR reached the recursion limit while instantiating `<VirtualWrapper<..., 1> as MyTrait>::virtualize`
+//~| ERROR reached the recursion limit while instantiating `<VirtualWrapper<_, 1> as MyTrait>::virtualize`
 
 //@ build-fail
 //@ compile-flags: --diagnostic-width=100 -Zwrite-long-types-to-disk=yes

--- a/tests/ui/infinite/infinite-instantiation-struct-tail-ice-114484.stderr
+++ b/tests/ui/infinite/infinite-instantiation-struct-tail-ice-114484.stderr
@@ -17,7 +17,7 @@ error: reached the recursion limit finding the struct tail for `[u8; 256]`
    = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]`
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-note: the above error was encountered while instantiating `fn virtualize_my_trait::<VirtualWrapper<..., 1>>`
+note: the above error was encountered while instantiating `fn virtualize_my_trait::<VirtualWrapper<_, 1>>`
   --> $DIR/infinite-instantiation-struct-tail-ice-114484.rs:38:18
    |
 LL |         unsafe { virtualize_my_trait(L, self) }
@@ -45,7 +45,7 @@ error: reached the recursion limit finding the struct tail for `SomeData<256>`
    = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]`
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-note: the above error was encountered while instantiating `fn virtualize_my_trait::<VirtualWrapper<..., 1>>`
+note: the above error was encountered while instantiating `fn virtualize_my_trait::<VirtualWrapper<_, 1>>`
   --> $DIR/infinite-instantiation-struct-tail-ice-114484.rs:38:18
    |
 LL |         unsafe { virtualize_my_trait(L, self) }
@@ -73,7 +73,7 @@ error: reached the recursion limit finding the struct tail for `VirtualWrapper<S
    = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]`
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-note: the above error was encountered while instantiating `fn virtualize_my_trait::<VirtualWrapper<..., 1>>`
+note: the above error was encountered while instantiating `fn virtualize_my_trait::<VirtualWrapper<_, 1>>`
   --> $DIR/infinite-instantiation-struct-tail-ice-114484.rs:38:18
    |
 LL |         unsafe { virtualize_my_trait(L, self) }
@@ -82,7 +82,7 @@ LL |         unsafe { virtualize_my_trait(L, self) }
    = note: the full name for the type has been written to '$TEST_BUILD_DIR/infinite-instantiation-struct-tail-ice-114484.long-type-$LONG_TYPE_HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
 
-error: reached the recursion limit while instantiating `<VirtualWrapper<..., 1> as MyTrait>::virtualize`
+error: reached the recursion limit while instantiating `<VirtualWrapper<_, 1> as MyTrait>::virtualize`
    |
 note: `<VirtualWrapper<T, L> as MyTrait>::virtualize` defined here
   --> $DIR/infinite-instantiation-struct-tail-ice-114484.rs:37:5

--- a/tests/ui/infinite/infinite-instantiation.stderr
+++ b/tests/ui/infinite/infinite-instantiation.stderr
@@ -1,4 +1,4 @@
-error: reached the recursion limit while instantiating `function::<Option<Option<Option<Option<...>>>>>`
+error: reached the recursion limit while instantiating `function::<Option<Option<Option<Option<_>>>>>`
   --> $DIR/infinite-instantiation.rs:22:9
    |
 LL |         function(counter - 1, t.to_option());

--- a/tests/ui/issues/issue-37311-type-length-limit/issue-37311.stderr
+++ b/tests/ui/issues/issue-37311-type-length-limit/issue-37311.stderr
@@ -1,4 +1,4 @@
-error: reached the recursion limit while instantiating `<(&(&(&..., ...), ...), ...) as Foo>::recurse`
+error: reached the recursion limit while instantiating `<(&(&(&(&(&_, _), _), _), _), _) as Foo>::recurse`
   --> $DIR/issue-37311.rs:17:9
    |
 LL |         (self, self).recurse();

--- a/tests/ui/lazy-type-alias/inherent-impls-overflow.current.stderr
+++ b/tests/ui/lazy-type-alias/inherent-impls-overflow.current.stderr
@@ -14,7 +14,7 @@ LL | impl Loop {}
    |
    = note: in case this is a recursive type alias, consider using a struct, enum, or union instead
 
-error[E0275]: overflow normalizing the type alias `Poly0<(((((((...,),),),),),),)>`
+error[E0275]: overflow normalizing the type alias `Poly0<(((((((_,),),),),),),)>`
   --> $DIR/inherent-impls-overflow.rs:17:1
    |
 LL | type Poly0<T> = Poly1<(T,)>;
@@ -22,7 +22,7 @@ LL | type Poly0<T> = Poly1<(T,)>;
    |
    = note: in case this is a recursive type alias, consider using a struct, enum, or union instead
 
-error[E0275]: overflow normalizing the type alias `Poly1<(((((((...,),),),),),),)>`
+error[E0275]: overflow normalizing the type alias `Poly1<(((((((_,),),),),),),)>`
   --> $DIR/inherent-impls-overflow.rs:20:1
    |
 LL | type Poly1<T> = Poly0<(T,)>;
@@ -30,7 +30,7 @@ LL | type Poly1<T> = Poly0<(T,)>;
    |
    = note: in case this is a recursive type alias, consider using a struct, enum, or union instead
 
-error[E0275]: overflow normalizing the type alias `Poly1<(((((((...,),),),),),),)>`
+error[E0275]: overflow normalizing the type alias `Poly1<(((((((_,),),),),),),)>`
   --> $DIR/inherent-impls-overflow.rs:24:1
    |
 LL | impl Poly0<()> {}

--- a/tests/ui/lazy-type-alias/inherent-impls-overflow.rs
+++ b/tests/ui/lazy-type-alias/inherent-impls-overflow.rs
@@ -15,14 +15,14 @@ impl Loop {}
 //[next]~| ERROR overflow evaluating the requirement `Loop == _`
 
 type Poly0<T> = Poly1<(T,)>;
-//[current]~^ ERROR overflow normalizing the type alias `Poly0<(((((((...,),),),),),),)>`
+//[current]~^ ERROR overflow normalizing the type alias `Poly0<(((((((_,),),),),),),)>`
 //[next]~^^ ERROR overflow evaluating the requirement
 type Poly1<T> = Poly0<(T,)>;
-//[current]~^ ERROR  overflow normalizing the type alias `Poly1<(((((((...,),),),),),),)>`
+//[current]~^ ERROR  overflow normalizing the type alias `Poly1<(((((((_,),),),),),),)>`
 //[next]~^^ ERROR overflow evaluating the requirement
 
 impl Poly0<()> {}
-//[current]~^ ERROR overflow normalizing the type alias `Poly1<(((((((...,),),),),),),)>`
+//[current]~^ ERROR overflow normalizing the type alias `Poly1<(((((((_,),),),),),),)>`
 //[next]~^^ ERROR overflow evaluating the requirement `Poly0<()> == _`
 //[next]~| ERROR overflow evaluating the requirement
 

--- a/tests/ui/limits/type-length-limit-enforcement.stderr
+++ b/tests/ui/limits/type-length-limit-enforcement.stderr
@@ -1,4 +1,4 @@
-error: reached the type-length limit while instantiating `drop::<Option<((..., ..., ...), ..., ...)>>`
+error: reached the type-length limit while instantiating `drop::<Option<((((_, _, _), _, _), _, _), _, _)>>`
   --> $DIR/type-length-limit-enforcement.rs:34:5
    |
 LL |     drop::<Option<A>>(None);

--- a/tests/ui/methods/inherent-bound-in-probe.stderr
+++ b/tests/ui/methods/inherent-bound-in-probe.stderr
@@ -28,7 +28,7 @@ LL | where
 LL |     &'a T: IntoIterator<Item = &'a u8>,
    |                         ------------- unsatisfied trait bound introduced here
    = note: 126 redundant requirements hidden
-   = note: required for `&BitReaderWrapper<BitReaderWrapper<BitReaderWrapper<...>>>` to implement `IntoIterator`
+   = note: required for `&BitReaderWrapper<BitReaderWrapper<BitReaderWrapper<_>>>` to implement `IntoIterator`
 note: required by a bound in `Helper`
   --> $DIR/inherent-bound-in-probe.rs:17:12
    |

--- a/tests/ui/methods/probe-error-on-infinite-deref.stderr
+++ b/tests/ui/methods/probe-error-on-infinite-deref.stderr
@@ -1,4 +1,4 @@
-error[E0055]: reached the recursion limit while auto-dereferencing `Wrap<Wrap<Wrap<Wrap<Wrap<Wrap<Wrap<Wrap<Wrap<Wrap<Wrap<...>>>>>>>>>>>`
+error[E0055]: reached the recursion limit while auto-dereferencing `Wrap<Wrap<Wrap<Wrap<Wrap<Wrap<Wrap<Wrap<Wrap<Wrap<Wrap<_>>>>>>>>>>>`
   --> $DIR/probe-error-on-infinite-deref.rs:14:13
    |
 LL |     Wrap(1).lmao();

--- a/tests/ui/mismatched_types/mismatch-sugg-for-shorthand-field.stderr
+++ b/tests/ui/mismatched_types/mismatch-sugg-for-shorthand-field.stderr
@@ -55,7 +55,7 @@ LL |     let a = async { 42 };
    |             ----- the found `async` block
 ...
 LL |     let s = Demo { a };
-   |                    ^ expected `Pin<Box<...>>`, found `async` block
+   |                    ^ expected `Pin<Box<_>>`, found `async` block
    |
    = note:     expected struct `Pin<Box<(dyn Future<Output = i32> + Send + 'static)>>`
            found `async` block `{async block@$DIR/mismatch-sugg-for-shorthand-field.rs:53:13: 53:18}`

--- a/tests/ui/parallel-rustc/dyn-trait-ice-153366.stderr
+++ b/tests/ui/parallel-rustc/dyn-trait-ice-153366.stderr
@@ -52,7 +52,7 @@ LL | fn iso<A>(a: Fn) -> Option<_>
    |                     --------- expected `Option<_>` because of return type
 ...
 LL |     Box::new(iso_un_option)
-   |     ^^^^^^^^^^^^^^^^^^^^^^^ expected `Option<_>`, found `Box<fn() -> ... {iso_un_option::<_>}>`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^ expected `Option<_>`, found `Box<fn() -> _ {iso_un_option::<_>}>`
    |
    = note: expected enum `Option<_>`
             found struct `Box<fn() -> {type error} {iso_un_option::<_>}>`

--- a/tests/ui/recursion/infinite-function-recursion-error-8727.stderr
+++ b/tests/ui/recursion/infinite-function-recursion-error-8727.stderr
@@ -9,7 +9,7 @@ LL |     generic::<Option<T>>();
    = help: a `loop` may express intention better if this is on purpose
    = note: `#[warn(unconditional_recursion)]` on by default
 
-error: reached the recursion limit while instantiating `generic::<Option<Option<Option<Option<...>>>>>`
+error: reached the recursion limit while instantiating `generic::<Option<Option<Option<Option<_>>>>>`
   --> $DIR/infinite-function-recursion-error-8727.rs:9:5
    |
 LL |     generic::<Option<T>>();

--- a/tests/ui/recursion/issue-23122-2.stderr
+++ b/tests/ui/recursion/issue-23122-2.stderr
@@ -1,11 +1,11 @@
-error[E0275]: overflow evaluating the requirement `<<<<<<<... as Next>::Next as Next>::Next as Next>::Next as Next>::Next as Next>::Next as Next>::Next as Next>::Next: Sized`
+error[E0275]: overflow evaluating the requirement `<<<<<<<_ as Next>::Next as Next>::Next as Next>::Next as Next>::Next as Next>::Next as Next>::Next as Next>::Next: Sized`
   --> $DIR/issue-23122-2.rs:11:17
    |
 LL |     type Next = <GetNext<T::Next> as Next>::Next;
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`issue_23122_2`)
-note: required for `GetNext<<<<... as Next>::Next as Next>::Next as Next>::Next>` to implement `Next`
+note: required for `GetNext<<<<_ as Next>::Next as Next>::Next as Next>::Next>` to implement `Next`
   --> $DIR/issue-23122-2.rs:10:15
    |
 LL | impl<T: Next> Next for GetNext<T> {

--- a/tests/ui/recursion/issue-38591-non-regular-dropck-recursion.stderr
+++ b/tests/ui/recursion/issue-38591-non-regular-dropck-recursion.stderr
@@ -4,7 +4,7 @@ error[E0320]: overflow while adding drop-check rules for `S<u32>`
 LL | fn f(x: S<u32>) {}
    |      ^
    |
-   = note: overflowed on `S<fn(fn(fn(fn(fn(fn(fn(fn(fn(fn(fn(fn(fn(fn(fn(fn(...))))))))))))))))>`
+   = note: overflowed on `S<fn(fn(fn(fn(fn(fn(fn(fn(fn(fn(fn(fn(fn(fn(fn(fn(_))))))))))))))))>`
    = note: the full name for the type has been written to '$TEST_BUILD_DIR/issue-38591-non-regular-dropck-recursion.long-type-$LONG_TYPE_HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
 

--- a/tests/ui/recursion/issue-83150.stderr
+++ b/tests/ui/recursion/issue-83150.stderr
@@ -15,7 +15,7 @@ error[E0275]: overflow evaluating the requirement `Map<&mut std::ops::Range<u8>,
    = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`issue_83150`)
    = note: required for `&mut Map<&mut Range<u8>, {closure@issue-83150.rs:12:24}>` to implement `Iterator`
    = note: 65 redundant requirements hidden
-   = note: required for `&mut Map<&mut Map<&mut Map<&mut Map<&mut ..., ...>, ...>, ...>, ...>` to implement `Iterator`
+   = note: required for `&mut Map<&mut Map<&mut Map<&mut Map<&mut Map<_, _>, _>, _>, _>, _>` to implement `Iterator`
    = note: the full name for the type has been written to '$TEST_BUILD_DIR/issue-83150.long-type-$LONG_TYPE_HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
 

--- a/tests/ui/recursion/recursion.stderr
+++ b/tests/ui/recursion/recursion.stderr
@@ -1,4 +1,4 @@
-error: reached the recursion limit while instantiating `test::<Cons<Cons<Cons<Cons<Cons<Cons<...>>>>>>>`
+error: reached the recursion limit while instantiating `test::<Cons<Cons<Cons<Cons<Cons<Cons<_>>>>>>>`
   --> $DIR/recursion.rs:17:11
    |
 LL |     _ => {test (n-1, i+1, Cons {head:2*i+1, tail:first}, Cons{head:i*i, tail:second})}

--- a/tests/ui/recursion/recursive-impl-trait-iterator-by-ref-67552.stderr
+++ b/tests/ui/recursion/recursive-impl-trait-iterator-by-ref-67552.stderr
@@ -1,4 +1,4 @@
-error: reached the recursion limit while instantiating `rec::<&mut &mut &mut &mut &mut &mut &mut &mut ...>`
+error: reached the recursion limit while instantiating `rec::<&mut &mut &mut &mut &mut &mut &mut &mut _>`
   --> $DIR/recursive-impl-trait-iterator-by-ref-67552.rs:28:9
    |
 LL |         rec(identity(&mut it))

--- a/tests/ui/suggestions/box-future-wrong-output.stderr
+++ b/tests/ui/suggestions/box-future-wrong-output.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/box-future-wrong-output.rs:20:39
    |
 LL |     let _: BoxFuture<'static, bool> = async {}.boxed();
-   |            ------------------------   ^^^^^^^^^^^^^^^^ expected `Pin<Box<...>>`, found `Pin<Box<dyn Future<Output = ()> + Send>>`
+   |            ------------------------   ^^^^^^^^^^^^^^^^ expected `Pin<Box<_>>`, found `Pin<Box<dyn Future<Output = ()> + Send>>`
    |            |
    |            expected due to this
    |

--- a/tests/ui/suggestions/expected-boxed-future-isnt-pinned.stderr
+++ b/tests/ui/suggestions/expected-boxed-future-isnt-pinned.stderr
@@ -5,7 +5,7 @@ LL | fn foo<F: Future<Output=i32> + Send + 'static>(x: F) -> BoxFuture<'static, 
    |        - found this type parameter                      ----------------------- expected `Pin<Box<(dyn Future<Output = i32> + Send + 'static)>>` because of return type
 LL |     // We could instead use an `async` block, but this way we have no std spans.
 LL |     x
-   |     ^ expected `Pin<Box<...>>`, found type parameter `F`
+   |     ^ expected `Pin<Box<_>>`, found type parameter `F`
    |
    = note:      expected struct `Pin<Box<(dyn Future<Output = i32> + Send + 'static)>>`
            found type parameter `F`
@@ -20,7 +20,7 @@ error[E0308]: mismatched types
 LL | fn bar<F: Future<Output=i32> + Send + 'static>(x: F) -> BoxFuture<'static, i32> {
    |                                                         ----------------------- expected `Pin<Box<(dyn Future<Output = i32> + Send + 'static)>>` because of return type
 LL |     Box::new(x)
-   |     ^^^^^^^^^^^ expected `Pin<Box<...>>`, found `Box<F>`
+   |     ^^^^^^^^^^^ expected `Pin<Box<_>>`, found `Box<F>`
    |
    = note: expected struct `Pin<Box<(dyn Future<Output = i32> + Send + 'static)>>`
               found struct `Box<F>`
@@ -76,7 +76,7 @@ LL |   fn zap() -> BoxFuture<'static, i32> {
 LL | /     async {
 LL | |         42
 LL | |     }
-   | |_____^ expected `Pin<Box<...>>`, found `async` block
+   | |_____^ expected `Pin<Box<_>>`, found `async` block
    |
    = note:     expected struct `Pin<Box<(dyn Future<Output = i32> + Send + 'static)>>`
            found `async` block `{async block@$DIR/expected-boxed-future-isnt-pinned.rs:28:5: 28:10}`

--- a/tests/ui/suggestions/issue-107860.stderr
+++ b/tests/ui/suggestions/issue-107860.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/issue-107860.rs:3:36
    |
 LL | async fn str<T>(T: &str) -> &str { &str }
-   |                                    ^^^^ expected `&str`, found `&fn(&str) -> ... {str::<_>}`
+   |                                    ^^^^ expected `&str`, found `&fn(&str) -> _ {str::<_>}`
    |
    = note: expected reference `&str`
               found reference `&for<'a> fn(&'a str) -> impl Future<Output = &'a str> {str::<_>}`

--- a/tests/ui/trait-bounds/associated-error-bound-issue-145586.stderr
+++ b/tests/ui/trait-bounds/associated-error-bound-issue-145586.stderr
@@ -8,7 +8,7 @@ LL |     fn deserialize_ignored_any<V>(self, visitor: V) -> Result<V::Value, Sel
    |                                                        ----------------------------- expected `Result<<V as Visitor<'de>>::Value, E>` because of return type
 ...
 LL |             Ok(deserializer) => deserializer.deserialize_ignored_any(visitor),
-   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Result<<V as Visitor<'_>>::Value, E>`, found `Result<<V as Visitor<'_>>::Value, ...>`
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Result<<V as Visitor<'_>>::Value, E>`, found `Result<<V as Visitor<'_>>::Value, _>`
    |
    = note: expected enum `Result<_, E>`
               found enum `Result<_, <T as Deserializer<'de>>::Error>`

--- a/tests/ui/traits/issue-68295.stderr
+++ b/tests/ui/traits/issue-68295.stderr
@@ -5,7 +5,7 @@ LL | fn crash<R, C>(input: Matrix<R, C, ()>) -> Matrix<R, C, u32>
    |                                            ----------------- expected `Matrix<R, C, u32>` because of return type
 ...
 LL |     input.into_owned()
-   |     ^^^^^^^^^^^^^^^^^^ expected `Matrix<R, C, u32>`, found `Matrix<R, C, ...>`
+   |     ^^^^^^^^^^^^^^^^^^ expected `Matrix<R, C, u32>`, found `Matrix<R, C, _>`
    |
    = note: expected struct `Matrix<_, _, u32>`
               found struct `Matrix<_, _, <() as Allocator<R, C>>::Buffer>`

--- a/tests/ui/traits/issue-91949-hangs-on-recursion.stderr
+++ b/tests/ui/traits/issue-91949-hangs-on-recursion.stderr
@@ -24,7 +24,7 @@ LL | impl<T, I: Iterator<Item = T>> Iterator for IteratorOfWrapped<T, I> {
    |                     |
    |                     unsatisfied trait bound introduced here
    = note: 256 redundant requirements hidden
-   = note: required for `IteratorOfWrapped<(), Map<IteratorOfWrapped<(), Map<..., ...>>, ...>>` to implement `Iterator`
+   = note: required for `IteratorOfWrapped<(), Map<IteratorOfWrapped<(), Map<_, _>>, _>>` to implement `Iterator`
    = note: the full name for the type has been written to '$TEST_BUILD_DIR/issue-91949-hangs-on-recursion.long-type-$LONG_TYPE_HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
 

--- a/tests/ui/traits/next-solver/overflow/global-cache.stderr
+++ b/tests/ui/traits/next-solver/overflow/global-cache.stderr
@@ -1,4 +1,4 @@
-error[E0275]: overflow evaluating the requirement `Inc<Inc<Inc<Inc<Inc<Inc<Inc<...>>>>>>>: Trait`
+error[E0275]: overflow evaluating the requirement `Inc<Inc<Inc<Inc<Inc<Inc<Inc<_>>>>>>>: Trait`
   --> $DIR/global-cache.rs:21:19
    |
 LL |     impls_trait::<Four<Four<Four<Four<()>>>>>();

--- a/tests/ui/traits/on_unimplemented_long_types.stderr
+++ b/tests/ui/traits/on_unimplemented_long_types.stderr
@@ -1,4 +1,4 @@
-error[E0277]: `Option<Option<Option<...>>>` doesn't implement `std::fmt::Display`
+error[E0277]: `Option<Option<Option<_>>>` doesn't implement `std::fmt::Display`
   --> $DIR/on_unimplemented_long_types.rs:3:17
    |
 LL |   pub fn foo() -> impl std::fmt::Display {
@@ -11,9 +11,9 @@ LL | |                 Some(Some(Some(Some(Some(Some(Some...
 ...  |
 LL | |         ))))))))))),
 LL | |     )))))))))))
-   | |_______________- return type was inferred to be `Option<Option<Option<...>>>` here
+   | |_______________- return type was inferred to be `Option<Option<Option<_>>>` here
    |
-   = help: the trait `std::fmt::Display` is not implemented for `Option<Option<Option<...>>>`
+   = help: the trait `std::fmt::Display` is not implemented for `Option<Option<Option<_>>>`
    = note: the full name for the type has been written to '$TEST_BUILD_DIR/on_unimplemented_long_types.long-type-$LONG_TYPE_HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
 

--- a/tests/ui/traits/trait-impl-overflow-with-where-clause-20413.stderr
+++ b/tests/ui/traits/trait-impl-overflow-with-where-clause-20413.stderr
@@ -7,7 +7,7 @@ LL | struct NoData<T>;
    = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
    = help: if you intended `T` to be a const parameter, use `const T: /* Type */` instead
 
-error[E0275]: overflow evaluating the requirement `NoData<NoData<NoData<NoData<NoData<NoData<NoData<...>>>>>>>: Foo`
+error[E0275]: overflow evaluating the requirement `NoData<NoData<NoData<NoData<NoData<NoData<NoData<_>>>>>>>: Foo`
   --> $DIR/trait-impl-overflow-with-where-clause-20413.rs:9:36
    |
 LL | impl<T> Foo for T where NoData<T>: Foo {
@@ -22,7 +22,7 @@ LL | impl<T> Foo for T where NoData<T>: Foo {
    = note: 126 redundant requirements hidden
    = note: required for `NoData<T>` to implement `Foo`
 
-error[E0275]: overflow evaluating the requirement `AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<...>>>>>>>: Bar`
+error[E0275]: overflow evaluating the requirement `AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<_>>>>>>>: Bar`
   --> $DIR/trait-impl-overflow-with-where-clause-20413.rs:28:42
    |
 LL | impl<T> Bar for T where EvenLessData<T>: Baz {
@@ -42,7 +42,7 @@ LL | impl<T> Bar for T where EvenLessData<T>: Baz {
    = note: 125 redundant requirements hidden
    = note: required for `EvenLessData<T>` to implement `Baz`
 
-error[E0275]: overflow evaluating the requirement `EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<...>>>>>>>: Baz`
+error[E0275]: overflow evaluating the requirement `EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<_>>>>>>>: Baz`
   --> $DIR/trait-impl-overflow-with-where-clause-20413.rs:35:42
    |
 LL | impl<T> Baz for T where AlmostNoData<T>: Bar {

--- a/tests/ui/trimmed-paths/doc-hidden.rs
+++ b/tests/ui/trimmed-paths/doc-hidden.rs
@@ -44,7 +44,7 @@ fn uses_local() {
         DocHiddenInHiddenMod,
     ) = 3u32;
     //~^ ERROR mismatched types [E0308]
-    //~| NOTE expected `(ActuallyPub, ..., ..., ..., ..., ...)`, found `u32`
+    //~| NOTE expected `(ActuallyPub, DocHidden, _, _, _, _)`, found `u32`
     //~| NOTE expected tuple `(local::ActuallyPub, DocHidden, local::pub_mod::ActuallyPubInPubMod, DocHiddenInPubMod, ActuallyPubInHiddenMod, DocHiddenInHiddenMod)`
 }
 
@@ -63,6 +63,6 @@ fn uses_helper() {
         DocHiddenInHiddenMod,
     ) = 3u32;
     //~^ ERROR mismatched types [E0308]
-    //~| NOTE expected `(ActuallyPub, ..., ..., ..., ..., ...)`, found `u32`
+    //~| NOTE expected `(ActuallyPub, DocHidden, _, _, _, _)`, found `u32`
     //~| NOTE expected tuple `(doc_hidden_helper::ActuallyPub, doc_hidden_helper::DocHidden, doc_hidden_helper::pub_mod::ActuallyPubInPubMod, doc_hidden_helper::pub_mod::DocHiddenInPubMod, doc_hidden_helper::hidden_mod::ActuallyPubInHiddenMod, doc_hidden_helper::hidden_mod::DocHiddenInHiddenMod)`
 }

--- a/tests/ui/trimmed-paths/doc-hidden.stderr
+++ b/tests/ui/trimmed-paths/doc-hidden.stderr
@@ -9,7 +9,7 @@ LL | |         DocHidden,
 ...  |
 LL | |         DocHiddenInHiddenMod,
 LL | |     ) = 3u32;
-   | |     -   ^^^^ expected `(ActuallyPub, ..., ..., ..., ..., ...)`, found `u32`
+   | |     -   ^^^^ expected `(ActuallyPub, DocHidden, _, _, _, _)`, found `u32`
    | |_____|
    |       expected due to this
    |
@@ -27,7 +27,7 @@ LL | |         DocHidden,
 ...  |
 LL | |         DocHiddenInHiddenMod,
 LL | |     ) = 3u32;
-   | |     -   ^^^^ expected `(ActuallyPub, ..., ..., ..., ..., ...)`, found `u32`
+   | |     -   ^^^^ expected `(ActuallyPub, DocHidden, _, _, _, _)`, found `u32`
    | |_____|
    |       expected due to this
    |

--- a/tests/ui/typeck/issue-107775.stderr
+++ b/tests/ui/typeck/issue-107775.stderr
@@ -6,7 +6,7 @@ LL |         map.insert(1, Struct::do_something);
    |         |
    |         ... which causes `map` to have type `HashMap<{integer}, fn(u8) -> Pin<Box<dyn Future<Output = ()> + Send>> {<Struct as Trait>::do_something::<'_>}>`
 LL |         Self { map }
-   |                ^^^ expected `HashMap<u16, fn(u8) -> Pin<Box<...>>>`, found `HashMap<{integer}, ...>`
+   |                ^^^ expected `HashMap<u16, fn(u8) -> Pin<Box<_>>>`, found `HashMap<{integer}, _>`
    |
    = note: expected struct `HashMap<u16, fn(_) -> Pin<Box<(dyn Future<Output = ()> + Send + 'static)>>>`
               found struct `HashMap<{integer}, fn(_) -> Pin<Box<dyn Future<Output = ()> + Send>> {<Struct as Trait>::do_something::<'_>}>`


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#159251 (Bump rustc-perf submodule)
 - rust-lang/rust#159243 (inline Once wait and wait_force)
 - rust-lang/rust#159255 (Replace shortened type with `_` instead of `...` as placeholder)
 - rust-lang/rust#159259 (Add regression test for rust-lang/rust#144033)
 - rust-lang/rust#159265 (bootstrap: skip intrinsic-test when rustfmt is unavailable)
 - rust-lang/rust#159274 (bootstrap: Rename `std_crates_for_run_make` to `std_crates_for_make_run`)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=159251,159243,159255,159259,159265,159274)
<!-- homu-ignore:end -->

