### PR TITLE
Rollup of 15 pull requests

### DIFF
--- a/compiler/rustc_ast/src/ast_traits.rs
+++ b/compiler/rustc_ast/src/ast_traits.rs
@@ -62,7 +62,7 @@ impl<T: HasNodeId> HasNodeId for Box<T> {
 }
 
 /// A trait for AST nodes having (or not having) collected tokens.
-pub trait HasTokens {
+pub trait HasTokens: HasAttrs {
     fn tokens(&self) -> Option<&LazyAttrTokenStream>;
     fn tokens_mut(&mut self) -> Option<&mut Option<LazyAttrTokenStream>>;
 }
@@ -109,7 +109,7 @@ impl_has_tokens_none!(
     WherePredicate
 );
 
-impl<T> HasTokens for WithTokens<T> {
+impl<T: HasAttrs> HasTokens for WithTokens<T> {
     fn tokens(&self) -> Option<&LazyAttrTokenStream> {
         self.tokens.as_ref()
     }

--- a/compiler/rustc_ast/src/tokenstream.rs
+++ b/compiler/rustc_ast/src/tokenstream.rs
@@ -18,7 +18,7 @@ use rustc_span::{DUMMY_SP, Span, SpanDecoder, SpanEncoder, Symbol, sym};
 use thin_vec::ThinVec;
 
 use crate::ast::AttrStyle;
-use crate::ast_traits::{HasAttrs, HasTokens};
+use crate::ast_traits::HasTokens;
 use crate::token::{self, Delimiter, Token, TokenKind};
 use crate::{AttrVec, Attribute};
 
@@ -653,7 +653,7 @@ impl TokenStream {
         TokenStream::new(vec![TokenTree::token_alone(kind, span)])
     }
 
-    pub fn from_ast(node: &(impl HasAttrs + HasTokens + fmt::Debug)) -> TokenStream {
+    pub fn from_ast(node: &(impl HasTokens + fmt::Debug)) -> TokenStream {
         let tokens = node.tokens().unwrap_or_else(|| panic!("missing tokens for node: {:?}", node));
         let mut tts = vec![];
         attrs_and_tokens_to_token_trees(node.attrs(), tokens, &mut tts);

--- a/compiler/rustc_ast_lowering/src/expr/closure.rs
+++ b/compiler/rustc_ast_lowering/src/expr/closure.rs
@@ -38,6 +38,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                     &closure.body,
                     closure.fn_decl_span,
                     closure.fn_arg_span,
+                    attrs,
                 ),
                 span: self.lower_span(e.span),
             },
@@ -240,7 +241,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
             fn_decl_span: self.lower_span(fn_decl_span),
             fn_arg_span: Some(self.lower_span(fn_arg_span)),
             kind: closure_kind,
-            constness: self.lower_constness(constness),
+            constness: self.lower_constness(attrs, constness),
             explicit_captures,
         });
 
@@ -308,6 +309,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
         body: &Expr,
         fn_decl_span: Span,
         fn_arg_span: Span,
+        attrs: &[hir::Attribute],
     ) -> hir::ExprKind<'hir> {
         let closure_def_id = self.local_def_id(closure_id);
         let (binder_clause, generic_params) = self.lower_closure_binder(binder);
@@ -369,7 +371,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
             // knows that a `FnDecl` output type like `-> &str` actually means
             // "coroutine that returns &str", rather than directly returning a `&str`.
             kind: hir::ClosureKind::CoroutineClosure(coroutine_desugaring),
-            constness: self.lower_constness(constness),
+            constness: self.lower_constness(attrs, constness),
             explicit_captures: &[],
         });
         hir::ExprKind::Closure(c)

--- a/compiler/rustc_ast_lowering/src/item.rs
+++ b/compiler/rustc_ast_lowering/src/item.rs
@@ -479,7 +479,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                     .arena
                     .alloc_from_iter(impl_items.iter().map(|item| self.lower_impl_item_ref(item)));
 
-                let constness = self.lower_constness(*constness);
+                let constness = self.lower_constness(attrs, *constness);
 
                 hir::ItemKind::Impl(hir::Impl {
                     generics,
@@ -499,7 +499,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 bounds,
                 items,
             }) => {
-                let constness = self.lower_constness(*constness);
+                let constness = self.lower_constness(attrs, *constness);
                 let impl_restriction = self.lower_impl_restriction(impl_restriction);
                 let ident = self.lower_ident(*ident);
                 let (generics, (safety, items, bounds)) = self.lower_generics(
@@ -530,7 +530,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 }
             }
             ItemKind::TraitAlias(TraitAlias { constness, ident, generics, bounds }) => {
-                let constness = self.lower_constness(*constness);
+                let constness = self.lower_constness(attrs, *constness);
                 let ident = self.lower_ident(*ident);
                 let (generics, bounds) = self.lower_generics(
                     generics,
@@ -1702,21 +1702,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
             safety.into()
         };
 
-        let mut constness = self.lower_constness(h.constness);
-        if let Some(&attr_span) = find_attr!(attrs, RustcComptime(span) => span) {
-            match std::mem::replace(&mut constness, rustc_hir::Constness::Const { always: true }) {
-                rustc_hir::Constness::Const { always: true } => {
-                    unreachable!("lower_constness cannot produce comptime")
-                }
-                // A function can't be `const` and `comptime` at the same time
-                rustc_hir::Constness::Const { always: false } => {
-                    let Const::Yes(span) = h.constness else { unreachable!() };
-                    self.dcx().emit_err(ConstComptimeFn { span, attr_span });
-                }
-                // Good
-                rustc_hir::Constness::NotConst => {}
-            }
-        }
+        let constness = self.lower_constness(attrs, h.constness);
 
         hir::FnHeader { safety, asyncness, constness, abi: self.lower_extern(h.ext) }
     }
@@ -1778,11 +1764,30 @@ impl<'hir> LoweringContext<'_, 'hir> {
         });
     }
 
-    pub(super) fn lower_constness(&mut self, c: Const) -> hir::Constness {
-        match c {
+    /// Lowers constness or comptime attribute.
+    /// Whether `const` is allowed here is checked by ast validation.
+    /// Whether `comptime` is allowed here is checked by the `comptime` attribute parser.
+    pub(super) fn lower_constness(&mut self, attrs: &[hir::Attribute], c: Const) -> hir::Constness {
+        let mut constness = match c {
             Const::Yes(_) => hir::Constness::Const { always: false },
             Const::No => hir::Constness::NotConst,
+        };
+
+        if let Some(&attr_span) = find_attr!(attrs, RustcComptime(span) => span) {
+            match std::mem::replace(&mut constness, hir::Constness::Const { always: true }) {
+                hir::Constness::Const { always: true } => {
+                    unreachable!("lower_constness cannot produce comptime")
+                }
+                // A function can't be `const` and `comptime` at the same time
+                hir::Constness::Const { always: false } => {
+                    let Const::Yes(span) = c else { unreachable!() };
+                    self.dcx().emit_err(ConstComptimeFn { span, attr_span });
+                }
+                // Good
+                hir::Constness::NotConst => {}
+            }
         }
+        constness
     }
 
     pub(super) fn lower_safety(&self, s: Safety, default: hir::Safety) -> hir::Safety {

--- a/compiler/rustc_attr_parsing/src/attributes/semantics.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/semantics.rs
@@ -23,6 +23,7 @@ impl NoArgsAttributeParser for ComptimeParser {
     const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[
         Allow(Target::Method(MethodKind::Inherent)),
         Allow(Target::Fn),
+        Allow(Target::Impl { of_trait: false }),
     ]);
     const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const CREATE: fn(Span) -> AttributeKind = AttributeKind::RustcComptime;

--- a/compiler/rustc_builtin_macros/src/cfg_eval.rs
+++ b/compiler/rustc_builtin_macros/src/cfg_eval.rs
@@ -3,7 +3,7 @@ use core::ops::ControlFlow;
 use rustc_ast as ast;
 use rustc_ast::mut_visit::MutVisitor;
 use rustc_ast::visit::{AssocCtxt, Visitor};
-use rustc_ast::{Attribute, HasAttrs, HasTokens, NodeId, mut_visit, visit};
+use rustc_ast::{Attribute, HasTokens, NodeId, mut_visit, visit};
 use rustc_errors::PResult;
 use rustc_expand::base::{Annotatable, ExtCtxt};
 use rustc_expand::config::StripUnconfigured;
@@ -67,7 +67,7 @@ fn has_cfg_or_cfg_attr(annotatable: &Annotatable) -> bool {
 }
 
 impl CfgEval<'_> {
-    fn configure<T: HasAttrs + HasTokens>(&mut self, node: T) -> Option<T> {
+    fn configure<T: HasTokens>(&mut self, node: T) -> Option<T> {
         self.0.configure(node)
     }
 

--- a/compiler/rustc_codegen_cranelift/src/abi/mod.rs
+++ b/compiler/rustc_codegen_cranelift/src/abi/mod.rs
@@ -440,18 +440,6 @@ pub(crate) fn codegen_terminator_call<'tcx>(
             }
         }
 
-        if fx.tcx.symbol_name(instance).name.starts_with("llvm.") {
-            crate::intrinsics::codegen_llvm_intrinsic_call(
-                fx,
-                fx.tcx.symbol_name(instance).name,
-                args,
-                ret_place,
-                target,
-                source_info.span,
-            );
-            return;
-        }
-
         match instance.def {
             InstanceKind::Intrinsic(_) => {
                 match crate::intrinsics::codegen_intrinsic_call(
@@ -465,6 +453,17 @@ pub(crate) fn codegen_terminator_call<'tcx>(
                     Ok(()) => return,
                     Err(instance) => Some(instance),
                 }
+            }
+            InstanceKind::LlvmIntrinsic(_) => {
+                crate::intrinsics::codegen_llvm_intrinsic_call(
+                    fx,
+                    fx.tcx.symbol_name(instance).name,
+                    args,
+                    ret_place,
+                    target,
+                    source_info.span,
+                );
+                return;
             }
             // We don't need AsyncDropGlueCtorShim here because it is not `noop func`,
             // it is `func returning noop future`

--- a/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
@@ -1044,7 +1044,7 @@ fn visibility_di_flags<'ll, 'tcx>(
     match visibility {
         Visibility::Public => DIFlags::FlagPublic,
         // Private fields have a restricted visibility of the module containing the type.
-        Visibility::Restricted(did) if did == parent_did => DIFlags::FlagPrivate,
+        Visibility::Restricted(did) if did.to_def_id() == parent_did => DIFlags::FlagPrivate,
         // `pub(crate)`/`pub(super)` visibilities are any other restricted visibility.
         Visibility::Restricted(..) => DIFlags::FlagProtected,
     }

--- a/compiler/rustc_codegen_ssa/src/base.rs
+++ b/compiler/rustc_codegen_ssa/src/base.rs
@@ -892,12 +892,8 @@ pub fn is_call_from_compiler_builtins_to_upstream_monomorphization<'tcx>(
     tcx: TyCtxt<'tcx>,
     instance: Instance<'tcx>,
 ) -> bool {
-    fn is_llvm_intrinsic(tcx: TyCtxt<'_>, def_id: DefId) -> bool {
-        if let Some(name) = tcx.codegen_fn_attrs(def_id).symbol_name {
-            name.as_str().starts_with("llvm.")
-        } else {
-            false
-        }
+    if let ty::InstanceKind::LlvmIntrinsic(_) = instance.def {
+        return false;
     }
 
     fn is_extern_call_to_local_crate<'tcx>(tcx: TyCtxt<'tcx>, instance: Instance<'tcx>) -> bool {
@@ -910,7 +906,6 @@ pub fn is_call_from_compiler_builtins_to_upstream_monomorphization<'tcx>(
     let def_id = instance.def_id();
     !def_id.is_local()
         && tcx.is_compiler_builtins(LOCAL_CRATE)
-        && !is_llvm_intrinsic(tcx, def_id)
         && !tcx.should_codegen_locally(instance)
         && !is_extern_call_to_local_crate(tcx, instance)
 }

--- a/compiler/rustc_codegen_ssa/src/mir/block.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/block.rs
@@ -1112,8 +1112,8 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
         };
 
         if let Some(instance) = instance
+            && let ty::InstanceKind::LlvmIntrinsic(_) = instance.def
             && let Some(name) = bx.tcx().codegen_fn_attrs(instance.def_id()).symbol_name
-            && name.as_str().starts_with("llvm.")
             // This is the only LLVM intrinsic we use that unwinds
             // FIXME either add unwind support to codegen_llvm_intrinsic_call or replace usage of
             // this intrinsic with something else

--- a/compiler/rustc_const_eval/src/const_eval/dummy_machine.rs
+++ b/compiler/rustc_const_eval/src/const_eval/dummy_machine.rs
@@ -105,6 +105,17 @@ impl<'tcx> interpret::Machine<'tcx> for DummyMachine {
         unimplemented!()
     }
 
+    fn call_llvm_intrinsic(
+        _ecx: &mut InterpCx<'tcx, Self>,
+        _instance: ty::Instance<'tcx>,
+        _args: &[interpret::OpTy<'tcx, Self::Provenance>],
+        _destination: &interpret::PlaceTy<'tcx, Self::Provenance>,
+        _target: Option<BasicBlock>,
+        _unwind: UnwindAction,
+    ) -> interpret::InterpResult<'tcx> {
+        unimplemented!()
+    }
+
     fn assert_panic(
         _ecx: &mut InterpCx<'tcx, Self>,
         _msg: &rustc_middle::mir::AssertMessage<'tcx>,

--- a/compiler/rustc_const_eval/src/const_eval/dummy_machine.rs
+++ b/compiler/rustc_const_eval/src/const_eval/dummy_machine.rs
@@ -111,7 +111,6 @@ impl<'tcx> interpret::Machine<'tcx> for DummyMachine {
         _args: &[interpret::OpTy<'tcx, Self::Provenance>],
         _destination: &interpret::PlaceTy<'tcx, Self::Provenance>,
         _target: Option<BasicBlock>,
-        _unwind: UnwindAction,
     ) -> interpret::InterpResult<'tcx> {
         unimplemented!()
     }

--- a/compiler/rustc_const_eval/src/const_eval/machine.rs
+++ b/compiler/rustc_const_eval/src/const_eval/machine.rs
@@ -751,7 +751,6 @@ impl<'tcx> interpret::Machine<'tcx> for CompileTimeMachine<'tcx> {
         _args: &[OpTy<'tcx>],
         _dest: &PlaceTy<'tcx, Self::Provenance>,
         _target: Option<mir::BasicBlock>,
-        _unwind: mir::UnwindAction,
     ) -> InterpResult<'tcx> {
         let intrinsic_name = ecx.tcx.codegen_fn_attrs(instance.def_id()).symbol_name.unwrap();
 

--- a/compiler/rustc_const_eval/src/const_eval/machine.rs
+++ b/compiler/rustc_const_eval/src/const_eval/machine.rs
@@ -745,6 +745,19 @@ impl<'tcx> interpret::Machine<'tcx> for CompileTimeMachine<'tcx> {
         interp_ok(None)
     }
 
+    fn call_llvm_intrinsic(
+        ecx: &mut InterpCx<'tcx, Self>,
+        instance: ty::Instance<'tcx>,
+        _args: &[OpTy<'tcx>],
+        _dest: &PlaceTy<'tcx, Self::Provenance>,
+        _target: Option<mir::BasicBlock>,
+        _unwind: mir::UnwindAction,
+    ) -> InterpResult<'tcx> {
+        let intrinsic_name = ecx.tcx.codegen_fn_attrs(instance.def_id()).symbol_name.unwrap();
+
+        throw_unsup_format!("LLVM intrinsic `{intrinsic_name}` is not supported at compile-time");
+    }
+
     fn assert_panic(
         ecx: &mut InterpCx<'tcx, Self>,
         msg: &AssertMessage<'tcx>,

--- a/compiler/rustc_const_eval/src/interpret/call.rs
+++ b/compiler/rustc_const_eval/src/interpret/call.rs
@@ -652,6 +652,17 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                     interp_ok(())
                 }
             }
+            ty::InstanceKind::LlvmIntrinsic(_) => {
+                // FIXME: Should `InPlace` arguments be reset to uninit?
+                M::call_llvm_intrinsic(
+                    self,
+                    instance,
+                    &Self::copy_fn_args(args),
+                    destination,
+                    target,
+                    unwind,
+                )
+            }
             ty::InstanceKind::Shim(ty::ShimKind::VTable(..))
             | ty::InstanceKind::Shim(ty::ShimKind::Reify(..))
             | ty::InstanceKind::Shim(ty::ShimKind::ClosureOnce { .. })

--- a/compiler/rustc_const_eval/src/interpret/call.rs
+++ b/compiler/rustc_const_eval/src/interpret/call.rs
@@ -660,7 +660,6 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                     &Self::copy_fn_args(args),
                     destination,
                     target,
-                    unwind,
                 )
             }
             ty::InstanceKind::Shim(ty::ShimKind::VTable(..))

--- a/compiler/rustc_const_eval/src/interpret/machine.rs
+++ b/compiler/rustc_const_eval/src/interpret/machine.rs
@@ -255,7 +255,6 @@ pub trait Machine<'tcx>: Sized {
         args: &[OpTy<'tcx, Self::Provenance>],
         destination: &PlaceTy<'tcx, Self::Provenance>,
         target: Option<mir::BasicBlock>,
-        unwind: mir::UnwindAction,
     ) -> InterpResult<'tcx>;
 
     /// Check whether the given function may be executed on the current machine, in terms of the

--- a/compiler/rustc_const_eval/src/interpret/machine.rs
+++ b/compiler/rustc_const_eval/src/interpret/machine.rs
@@ -247,6 +247,17 @@ pub trait Machine<'tcx>: Sized {
         unwind: mir::UnwindAction,
     ) -> InterpResult<'tcx, Option<ty::Instance<'tcx>>>;
 
+    /// Directly process an LLVM intrinsic without pushing a stack frame. It is the hook's
+    /// responsibility to advance the instruction pointer as appropriate.
+    fn call_llvm_intrinsic(
+        ecx: &mut InterpCx<'tcx, Self>,
+        instance: ty::Instance<'tcx>,
+        args: &[OpTy<'tcx, Self::Provenance>],
+        destination: &PlaceTy<'tcx, Self::Provenance>,
+        target: Option<mir::BasicBlock>,
+        unwind: mir::UnwindAction,
+    ) -> InterpResult<'tcx>;
+
     /// Check whether the given function may be executed on the current machine, in terms of the
     /// target features is requires.
     fn check_fn_target_features(

--- a/compiler/rustc_expand/src/base.rs
+++ b/compiler/rustc_expand/src/base.rs
@@ -24,7 +24,7 @@ use rustc_parse::MACRO_ARGUMENTS;
 use rustc_parse::parser::Parser;
 use rustc_session::Session;
 use rustc_session::parse::ParseSess;
-use rustc_span::def_id::{CrateNum, DefId, LocalDefId};
+use rustc_span::def_id::{CrateNum, DefId, LocalDefId, ModId};
 use rustc_span::edition::Edition;
 use rustc_span::hygiene::{AstPass, ExpnData, ExpnKind, LocalExpnId, MacroKind};
 use rustc_span::source_map::SourceMap;
@@ -1003,7 +1003,7 @@ impl SyntaxExtension {
         descr: Symbol,
         kind: MacroKind,
         macro_def_id: Option<DefId>,
-        parent_module: Option<DefId>,
+        parent_module: Option<ModId>,
     ) -> ExpnData {
         ExpnData::new(
             ExpnKind::Macro(kind, descr),

--- a/compiler/rustc_expand/src/config.rs
+++ b/compiler/rustc_expand/src/config.rs
@@ -167,7 +167,7 @@ macro_rules! configure {
 }
 
 impl<'a> StripUnconfigured<'a> {
-    pub fn configure<T: HasAttrs + HasTokens>(&self, mut node: T) -> Option<T> {
+    pub fn configure<T: HasTokens>(&self, mut node: T) -> Option<T> {
         self.process_cfg_attrs(&mut node);
         self.in_cfg(node.attrs()).then(|| {
             self.try_configure_tokens(&mut node);

--- a/compiler/rustc_hir_analysis/src/check/compare_impl_item/refine.rs
+++ b/compiler/rustc_hir_analysis/src/check/compare_impl_item/refine.rs
@@ -12,6 +12,7 @@ use rustc_middle::ty::{
     TypeVisitableExt, TypeVisitor, TypingMode, Unnormalized,
 };
 use rustc_span::Span;
+use rustc_span::def_id::ModId;
 use rustc_trait_selection::regions::InferCtxtRegionExt;
 use rustc_trait_selection::traits::{ObligationCtxt, elaborate, normalize_param_env_or_error};
 
@@ -380,7 +381,7 @@ fn report_mismatched_rpitit_signature<'tcx>(
     );
 }
 
-fn type_visibility<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> Option<ty::Visibility<DefId>> {
+fn type_visibility<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> Option<ty::Visibility<ModId>> {
     match *ty.kind() {
         ty::Ref(_, ty, _) => type_visibility(tcx, ty),
         ty::Adt(def, args) => {

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
@@ -45,6 +45,7 @@ use rustc_middle::ty::{
 use rustc_middle::{bug, span_bug};
 use rustc_session::errors::feature_err;
 use rustc_session::lint::builtin::AMBIGUOUS_ASSOCIATED_ITEMS;
+use rustc_span::def_id::ModId;
 use rustc_span::{DUMMY_SP, Ident, Span, kw, sym};
 use rustc_trait_selection::infer::InferCtxtExt;
 use rustc_trait_selection::traits::{self, FulfillmentError};
@@ -116,7 +117,7 @@ pub enum RegionInferReason<'a> {
 pub struct InherentAssocCandidate {
     pub impl_: DefId,
     pub assoc_item: DefId,
-    pub scope: DefId,
+    pub scope: ModId,
 }
 
 pub struct ResolvedStructPath<'tcx> {
@@ -1806,7 +1807,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
         ident: Ident,
         assoc_tag: ty::AssocTag,
         scope: DefId,
-    ) -> Option<(ty::AssocItem, /*scope*/ DefId)> {
+    ) -> Option<(ty::AssocItem, /*scope*/ ModId)> {
         let tcx = self.tcx();
 
         let (ident, def_scope) = tcx.adjust_ident_and_get_scope(ident, scope, self.item_def_id());
@@ -1826,7 +1827,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
         &self,
         item_def_id: DefId,
         ident: Ident,
-        scope: DefId,
+        scope: ModId,
         block: HirId,
         span: Span,
     ) {

--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -1192,7 +1192,7 @@ impl UnreachablePub {
                 && let parent_parent = cx
                     .tcx
                     .parent_module_from_def_id(cx.tcx.parent_module_from_def_id(def_id).into())
-                && *restricted_did == parent_parent.to_local_def_id()
+                && *restricted_did == parent_parent
                 && !restricted_did.to_def_id().is_crate_root()
             {
                 "pub(super)"

--- a/compiler/rustc_lint/src/late.rs
+++ b/compiler/rustc_lint/src/late.rs
@@ -8,7 +8,7 @@ use std::cell::Cell;
 
 use rustc_data_structures::stack::ensure_sufficient_stack;
 use rustc_data_structures::sync::par_join;
-use rustc_hir::def_id::{LocalDefId, LocalModDefId};
+use rustc_hir::def_id::{LocalDefId, LocalModId};
 use rustc_hir::{self as hir, AmbigArg, HirId, intravisit as hir_visit};
 use rustc_middle::hir::nested_filter;
 use rustc_middle::ty::{self, TyCtxt};
@@ -335,7 +335,7 @@ crate::late_lint_methods!(impl_late_lint_pass, []);
 
 pub fn late_lint_mod<'tcx, T: LateLintPass<'tcx> + 'tcx>(
     tcx: TyCtxt<'tcx>,
-    module_def_id: LocalModDefId,
+    mod_id: LocalModId,
     builtin_lints: T,
 ) {
     let context = LateContext {
@@ -344,7 +344,7 @@ pub fn late_lint_mod<'tcx, T: LateLintPass<'tcx> + 'tcx>(
         cached_typeck_results: Cell::new(None),
         param_env: ty::ParamEnv::empty(),
         effective_visibilities: tcx.effective_visibilities(()),
-        last_node_with_lint_attrs: tcx.local_def_id_to_hir_id(module_def_id),
+        last_node_with_lint_attrs: tcx.local_def_id_to_hir_id(mod_id),
         generics: None,
         only_module: true,
     };
@@ -363,26 +363,26 @@ pub fn late_lint_mod<'tcx, T: LateLintPass<'tcx> + 'tcx>(
     let builtin_lints_must_run = is_lint_pass_required(skippable_lints, &builtin_lints.get_lints());
     if passes.is_empty() {
         if builtin_lints_must_run {
-            late_lint_mod_inner(tcx, module_def_id, context, builtin_lints);
+            late_lint_mod_inner(tcx, mod_id, context, builtin_lints);
         }
     } else {
         if builtin_lints_must_run {
             passes.push(Box::new(builtin_lints) as Box<dyn LateLintPass<'tcx>>);
         }
         let pass = RuntimeCombinedLateLintPass { passes };
-        late_lint_mod_inner(tcx, module_def_id, context, pass);
+        late_lint_mod_inner(tcx, mod_id, context, pass);
     }
 }
 
 fn late_lint_mod_inner<'tcx, T: LateLintPass<'tcx>>(
     tcx: TyCtxt<'tcx>,
-    module_def_id: LocalModDefId,
+    mod_id: LocalModId,
     context: LateContext<'tcx>,
     pass: T,
 ) {
     let mut cx = LateContextAndPass { context, pass };
 
-    let (module, _span, hir_id) = tcx.hir_get_module(module_def_id);
+    let (module, _span, hir_id) = tcx.hir_get_module(mod_id);
 
     cx.with_lint_attrs(hir_id, |cx| {
         // There is no module lint that will have the crate itself as an item, so check it here.

--- a/compiler/rustc_lint/src/lib.rs
+++ b/compiler/rustc_lint/src/lib.rs
@@ -121,7 +121,7 @@ use redundant_semicolon::*;
 use reference_casting::*;
 use runtime_symbols::*;
 use rustc_data_structures::unord::UnordSet;
-use rustc_hir::def_id::LocalModDefId;
+use rustc_hir::def_id::LocalModId;
 use rustc_middle::query::Providers;
 use rustc_middle::ty::TyCtxt;
 use shadowed_into_iter::ShadowedIntoIter;
@@ -154,8 +154,8 @@ pub fn provide(providers: &mut Providers) {
     *providers = Providers { lint_mod, ..*providers };
 }
 
-fn lint_mod(tcx: TyCtxt<'_>, module_def_id: LocalModDefId) {
-    late_lint_mod(tcx, module_def_id, BuiltinCombinedLateLintModPass::new());
+fn lint_mod(tcx: TyCtxt<'_>, mod_id: LocalModId) {
+    late_lint_mod(tcx, mod_id, BuiltinCombinedLateLintModPass::new());
 }
 
 early_lint_methods!(

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -601,8 +601,6 @@ pub(crate) struct BuiltinDerefNullptr {
     pub label: Span,
 }
 
-// FIXME: migrate fluent::lint::builtin_asm_labels
-
 #[derive(Diagnostic)]
 pub(crate) enum BuiltinSpecialModuleNameUsed {
     #[diag("found module declaration for lib.rs")]

--- a/compiler/rustc_lint/src/unused/must_use.rs
+++ b/compiler/rustc_lint/src/unused/must_use.rs
@@ -143,7 +143,7 @@ pub fn is_ty_must_use<'tcx>(
         return IsTyMustUse::Trivial;
     }
 
-    let parent_mod_did = cx.tcx.parent_module(expr.hir_id).to_def_id();
+    let parent_mod_did = cx.tcx.parent_module(expr.hir_id);
     let is_uninhabited =
         |t: Ty<'tcx>| !t.is_inhabited_from(cx.tcx, parent_mod_did, cx.typing_env());
 

--- a/compiler/rustc_metadata/src/rmeta/decoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder.rs
@@ -32,6 +32,7 @@ use rustc_serialize::{Decodable, Decoder};
 use rustc_session::config::TargetModifier;
 use rustc_session::config::mitigation_coverage::DeniedPartialMitigation;
 use rustc_session::cstore::{CrateSource, ExternCrate};
+use rustc_span::def_id::ModId;
 use rustc_span::hygiene::HygieneDecodeContext;
 use rustc_span::{
     BlobDecoder, BytePos, ByteSymbol, DUMMY_SP, Pos, RemapPathScopeComponents, SpanData,
@@ -1173,14 +1174,14 @@ impl CrateMetadata {
         )
     }
 
-    fn get_visibility(&self, tcx: TyCtxt<'_>, id: DefIndex) -> Visibility<DefId> {
+    fn get_visibility(&self, tcx: TyCtxt<'_>, id: DefIndex) -> Visibility<ModId> {
         self.root
             .tables
             .visibility
             .get(self, id)
             .unwrap_or_else(|| self.missing("visibility", id))
             .decode((self, tcx))
-            .map_id(|index| self.local_def_id(index))
+            .map_id(|index| ModId::new_unchecked(self.local_def_id(index)))
     }
 
     fn get_safety(&self, id: DefIndex) -> Safety {

--- a/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
@@ -19,6 +19,7 @@ use rustc_middle::util::Providers;
 use rustc_serialize::Decoder;
 use rustc_session::StableCrateId;
 use rustc_session::cstore::{CrateStore, ExternCrate};
+use rustc_span::def_id::ModId;
 use rustc_span::hygiene::ExpnId;
 use rustc_span::{Span, Symbol, kw};
 
@@ -188,6 +189,13 @@ impl IntoArgs for DefId {
     type Other = ();
     fn into_args(self) -> (DefId, ()) {
         (self, ())
+    }
+}
+
+impl IntoArgs for ModId {
+    type Other = ();
+    fn into_args(self) -> (DefId, ()) {
+        (self.to_def_id(), ())
     }
 }
 

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -28,6 +28,7 @@ use rustc_middle::{bug, span_bug};
 use rustc_serialize::{Decodable, Decoder, Encodable, Encoder, opaque};
 use rustc_session::config::mitigation_coverage::DeniedPartialMitigation;
 use rustc_session::config::{CrateType, OptLevel, TargetModifier};
+use rustc_span::def_id::CRATE_MOD_ID;
 use rustc_span::hygiene::HygieneEncodeContext;
 use rustc_span::{
     ByteSymbol, ExternalSource, FileName, SourceFile, SpanData, SpanEncoder, StableSourceFileId,
@@ -1455,8 +1456,10 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
                 record!(self.tables.codegen_fn_attrs[def_id] <- self.tcx.codegen_fn_attrs(def_id));
             }
             if should_encode_visibility(def_kind) {
-                let vis =
-                    self.tcx.local_visibility(local_id).map_id(|def_id| def_id.local_def_index);
+                let vis = self
+                    .tcx
+                    .local_visibility(local_id)
+                    .map_id(|mod_id| mod_id.to_local_def_id().local_def_index);
                 record!(self.tables.visibility[def_id] <- vis);
             }
             if should_encode_stability(def_kind) {
@@ -1979,16 +1982,18 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
             self.tables.def_kind.set_some(LOCAL_CRATE.as_def_id().index, DefKind::Mod);
             record!(self.tables.def_span[LOCAL_CRATE.as_def_id()] <- tcx.def_span(LOCAL_CRATE.as_def_id()));
             self.encode_attrs(LOCAL_CRATE.as_def_id().expect_local());
-            let vis = tcx.local_visibility(CRATE_DEF_ID).map_id(|def_id| def_id.local_def_index);
+            let vis = tcx
+                .local_visibility(CRATE_DEF_ID)
+                .map_id(|mod_id| mod_id.to_local_def_id().local_def_index);
             record!(self.tables.visibility[LOCAL_CRATE.as_def_id()] <- vis);
             if let Some(stability) = stability {
                 record!(self.tables.lookup_stability[LOCAL_CRATE.as_def_id()] <- stability);
             }
             self.encode_deprecation(LOCAL_CRATE.as_def_id());
-            if let Some(res_map) = tcx.resolutions(()).doc_link_resolutions.get(&CRATE_DEF_ID) {
+            if let Some(res_map) = tcx.resolutions(()).doc_link_resolutions.get(&CRATE_MOD_ID) {
                 record!(self.tables.doc_link_resolutions[LOCAL_CRATE.as_def_id()] <- res_map);
             }
-            if let Some(traits) = tcx.resolutions(()).doc_link_traits_in_scope.get(&CRATE_DEF_ID) {
+            if let Some(traits) = tcx.resolutions(()).doc_link_traits_in_scope.get(&CRATE_MOD_ID) {
                 record_array!(self.tables.doc_link_traits_in_scope[LOCAL_CRATE.as_def_id()] <- traits);
             }
 

--- a/compiler/rustc_middle/src/dep_graph/dep_node_key.rs
+++ b/compiler/rustc_middle/src/dep_graph/dep_node_key.rs
@@ -2,7 +2,7 @@ use std::fmt::Debug;
 
 use rustc_data_structures::fingerprint::Fingerprint;
 use rustc_data_structures::stable_hash::{StableHash, StableHasher};
-use rustc_hir::def_id::{CrateNum, DefId, LOCAL_CRATE, LocalDefId, LocalModDefId, ModDefId};
+use rustc_hir::def_id::{CrateNum, DefId, LOCAL_CRATE, LocalDefId, LocalModId, ModId};
 use rustc_hir::definitions::DefPathHash;
 use rustc_hir::{HirId, ItemLocalId, OwnerId};
 
@@ -194,7 +194,7 @@ impl<'tcx> DepNodeKey<'tcx> for HirId {
     }
 }
 
-impl<'tcx> DepNodeKey<'tcx> for ModDefId {
+impl<'tcx> DepNodeKey<'tcx> for ModId {
     #[inline(always)]
     fn key_fingerprint_style() -> KeyFingerprintStyle {
         KeyFingerprintStyle::DefPathHash
@@ -207,11 +207,11 @@ impl<'tcx> DepNodeKey<'tcx> for ModDefId {
 
     #[inline(always)]
     fn try_recover_key(tcx: TyCtxt<'tcx>, dep_node: &DepNode) -> Option<Self> {
-        DefId::try_recover_key(tcx, dep_node).map(ModDefId::new_unchecked)
+        DefId::try_recover_key(tcx, dep_node).map(ModId::new_unchecked)
     }
 }
 
-impl<'tcx> DepNodeKey<'tcx> for LocalModDefId {
+impl<'tcx> DepNodeKey<'tcx> for LocalModId {
     #[inline(always)]
     fn key_fingerprint_style() -> KeyFingerprintStyle {
         KeyFingerprintStyle::DefPathHash
@@ -224,6 +224,6 @@ impl<'tcx> DepNodeKey<'tcx> for LocalModDefId {
 
     #[inline(always)]
     fn try_recover_key(tcx: TyCtxt<'tcx>, dep_node: &DepNode) -> Option<Self> {
-        LocalDefId::try_recover_key(tcx, dep_node).map(LocalModDefId::new_unchecked)
+        LocalDefId::try_recover_key(tcx, dep_node).map(LocalModId::new_unchecked)
     }
 }

--- a/compiler/rustc_middle/src/hir/map.rs
+++ b/compiler/rustc_middle/src/hir/map.rs
@@ -499,17 +499,15 @@ impl<'tcx> TyCtxt<'tcx> {
 
     pub fn hir_for_each_module(self, mut f: impl FnMut(LocalModId)) {
         let crate_items = self.hir_crate_items(());
-        for module in crate_items.submodules.iter() {
-            f(LocalModId::new_unchecked(module.def_id))
+        for &module in crate_items.submodules.iter() {
+            f(module)
         }
     }
 
     #[inline]
     pub fn par_hir_for_each_module(self, f: impl Fn(LocalModId) + DynSend + DynSync) {
         let crate_items = self.hir_crate_items(());
-        par_for_each_in(&crate_items.submodules[..], |module| {
-            f(LocalModId::new_unchecked(module.def_id))
-        })
+        par_for_each_in(&crate_items.submodules[..], |&&module| f(module));
     }
 
     #[inline]
@@ -518,9 +516,7 @@ impl<'tcx> TyCtxt<'tcx> {
         f: impl Fn(LocalModId) -> Result<(), ErrorGuaranteed> + DynSend + DynSync,
     ) -> Result<(), ErrorGuaranteed> {
         let crate_items = self.hir_crate_items(());
-        try_par_for_each_in(&crate_items.submodules[..], |module| {
-            f(LocalModId::new_unchecked(module.def_id))
-        })
+        try_par_for_each_in(&crate_items.submodules[..], |&&module| f(module))
     }
 
     /// Returns an iterator for the nodes in the ancestor tree of the `current_id`
@@ -1298,7 +1294,7 @@ pub(crate) fn hir_crate_items(tcx: TyCtxt<'_>, _: ()) -> ModuleItems {
     // A "crate collector" and "module collector" start at a
     // module item (the former starts at the crate root) but only
     // the former needs to collect it. ItemCollector does not do this for us.
-    collector.submodules.push(CRATE_OWNER_ID);
+    collector.submodules.push(CRATE_MOD_ID);
     tcx.hir_walk_toplevel_module(&mut collector);
 
     let ItemCollector {
@@ -1337,7 +1333,7 @@ struct ItemCollector<'tcx> {
     // (see <https://github.com/rust-lang/rust/pull/158119#issuecomment-4751513679>).
     crate_collector: bool,
     tcx: TyCtxt<'tcx>,
-    submodules: Vec<OwnerId> = vec![],
+    submodules: Vec<LocalModId> = vec![],
     items: Vec<ItemId> = vec![],
     trait_items: Vec<TraitItemId> = vec![],
     impl_items: Vec<ImplItemId> = vec![],
@@ -1386,7 +1382,7 @@ impl<'hir> Visitor<'hir> for ItemCollector<'hir> {
 
         // Items that are modules are handled here instead of in visit_mod.
         if let ItemKind::Mod(_, module) = &item.kind {
-            self.submodules.push(item.owner_id);
+            self.submodules.push(LocalModId::new_unchecked(item.owner_id.def_id));
             // A module collector does not recurse inside nested modules.
             if self.crate_collector {
                 intravisit::walk_mod(self, module);

--- a/compiler/rustc_middle/src/hir/map.rs
+++ b/compiler/rustc_middle/src/hir/map.rs
@@ -10,13 +10,13 @@ use rustc_data_structures::steal::Steal;
 use rustc_data_structures::svh::Svh;
 use rustc_data_structures::sync::{DynSend, DynSync, par_for_each_in, try_par_for_each_in};
 use rustc_hir::def::{DefKind, Res};
-use rustc_hir::def_id::{DefId, LOCAL_CRATE, LocalDefId, LocalModDefId};
+use rustc_hir::def_id::{DefId, LOCAL_CRATE, LocalDefId, LocalModId};
 use rustc_hir::definitions::{DefKey, DefPath, DefPathHash};
 use rustc_hir::intravisit::Visitor;
 use rustc_hir::lints::DelayedLints;
 use rustc_hir::*;
 use rustc_hir_pretty as pprust_hir;
-use rustc_span::def_id::StableCrateId;
+use rustc_span::def_id::{CRATE_MOD_ID, StableCrateId};
 use rustc_span::{ErrorGuaranteed, Ident, Span, Symbol, kw, with_metavar_spans};
 
 use crate::hir::{ModuleItems, ProjectedMaybeOwner, nested_filter};
@@ -207,7 +207,7 @@ impl<'tcx> TyCtxt<'tcx> {
     }
 
     #[inline]
-    pub fn hir_module_free_items(self, module: LocalModDefId) -> impl Iterator<Item = ItemId> {
+    pub fn hir_module_free_items(self, module: LocalModId) -> impl Iterator<Item = ItemId> {
         self.hir_module_items(module).free_items()
     }
 
@@ -412,7 +412,7 @@ impl<'tcx> TyCtxt<'tcx> {
         find_attr!(self.hir_krate_attrs(), RustcCoherenceIsCore)
     }
 
-    pub fn hir_get_module(self, module: LocalModDefId) -> (&'tcx Mod<'tcx>, Span, HirId) {
+    pub fn hir_get_module(self, module: LocalModId) -> (&'tcx Mod<'tcx>, Span, HirId) {
         let hir_id = HirId::make_owner(module.to_local_def_id());
         match self.hir_owner_node(hir_id.owner) {
             OwnerNode::Item(&Item { span, kind: ItemKind::Mod(_, m), .. }) => (m, span, hir_id),
@@ -426,7 +426,7 @@ impl<'tcx> TyCtxt<'tcx> {
     where
         V: Visitor<'tcx>,
     {
-        let (top_mod, span, hir_id) = self.hir_get_module(LocalModDefId::CRATE_DEF_ID);
+        let (top_mod, span, hir_id) = self.hir_get_module(CRATE_MOD_ID);
         visitor.visit_mod(top_mod, span, hir_id)
     }
 
@@ -477,11 +477,7 @@ impl<'tcx> TyCtxt<'tcx> {
 
     /// This method is the equivalent of `visit_all_item_likes_in_crate` but restricted to
     /// item-likes in a single module.
-    pub fn hir_visit_item_likes_in_module<V>(
-        self,
-        module: LocalModDefId,
-        visitor: &mut V,
-    ) -> V::Result
+    pub fn hir_visit_item_likes_in_module<V>(self, module: LocalModId, visitor: &mut V) -> V::Result
     where
         V: Visitor<'tcx>,
     {
@@ -501,29 +497,29 @@ impl<'tcx> TyCtxt<'tcx> {
         V::Result::output()
     }
 
-    pub fn hir_for_each_module(self, mut f: impl FnMut(LocalModDefId)) {
+    pub fn hir_for_each_module(self, mut f: impl FnMut(LocalModId)) {
         let crate_items = self.hir_crate_items(());
         for module in crate_items.submodules.iter() {
-            f(LocalModDefId::new_unchecked(module.def_id))
+            f(LocalModId::new_unchecked(module.def_id))
         }
     }
 
     #[inline]
-    pub fn par_hir_for_each_module(self, f: impl Fn(LocalModDefId) + DynSend + DynSync) {
+    pub fn par_hir_for_each_module(self, f: impl Fn(LocalModId) + DynSend + DynSync) {
         let crate_items = self.hir_crate_items(());
         par_for_each_in(&crate_items.submodules[..], |module| {
-            f(LocalModDefId::new_unchecked(module.def_id))
+            f(LocalModId::new_unchecked(module.def_id))
         })
     }
 
     #[inline]
     pub fn try_par_hir_for_each_module(
         self,
-        f: impl Fn(LocalModDefId) -> Result<(), ErrorGuaranteed> + DynSend + DynSync,
+        f: impl Fn(LocalModId) -> Result<(), ErrorGuaranteed> + DynSend + DynSync,
     ) -> Result<(), ErrorGuaranteed> {
         let crate_items = self.hir_crate_items(());
         try_par_for_each_in(&crate_items.submodules[..], |module| {
-            f(LocalModDefId::new_unchecked(module.def_id))
+            f(LocalModId::new_unchecked(module.def_id))
         })
     }
 
@@ -1261,7 +1257,7 @@ fn upstream_crates(tcx: TyCtxt<'_>) -> Vec<(StableCrateId, Svh)> {
     upstream_crates
 }
 
-pub(super) fn hir_module_items(tcx: TyCtxt<'_>, module_id: LocalModDefId) -> ModuleItems {
+pub(super) fn hir_module_items(tcx: TyCtxt<'_>, module_id: LocalModId) -> ModuleItems {
     let mut collector = ItemCollector::new(tcx, false);
 
     let (hir_mod, span, hir_id) = tcx.hir_get_module(module_id);

--- a/compiler/rustc_middle/src/hir/mod.rs
+++ b/compiler/rustc_middle/src/hir/mod.rs
@@ -28,7 +28,7 @@ pub struct ModuleItems {
     /// Whether this represents the whole crate, in which case we need to add `CRATE_OWNER_ID` to
     /// the iterators if we want to account for the crate root.
     add_root: bool,
-    submodules: Box<[OwnerId]>,
+    submodules: Box<[LocalModId]>,
     free_items: Box<[ItemId]>,
     trait_items: Box<[TraitItemId]>,
     impl_items: Box<[ImplItemId]>,

--- a/compiler/rustc_middle/src/hir/mod.rs
+++ b/compiler/rustc_middle/src/hir/mod.rs
@@ -12,7 +12,7 @@ use rustc_data_structures::stable_hash::{StableHash, StableHasher};
 use rustc_data_structures::steal::Steal;
 use rustc_data_structures::sync::{DynSend, DynSync, try_par_for_each_in};
 use rustc_hir::def::{DefKind, Res};
-use rustc_hir::def_id::{DefId, LocalDefId, LocalDefIdMap, LocalModDefId};
+use rustc_hir::def_id::{DefId, LocalDefId, LocalDefIdMap, LocalModId};
 use rustc_hir::lints::DelayedLints;
 use rustc_hir::*;
 use rustc_macros::{Decodable, Encodable, StableHash};
@@ -146,22 +146,22 @@ impl ModuleItems {
 }
 
 impl<'tcx> TyCtxt<'tcx> {
-    pub fn parent_module(self, id: HirId) -> LocalModDefId {
+    pub fn parent_module(self, id: HirId) -> LocalModId {
         if !id.is_owner() && self.def_kind(id.owner) == DefKind::Mod {
-            LocalModDefId::new_unchecked(id.owner.def_id)
+            LocalModId::new_unchecked(id.owner.def_id)
         } else {
             self.parent_module_from_def_id(id.owner.def_id)
         }
     }
 
-    pub fn parent_module_from_def_id(self, mut id: LocalDefId) -> LocalModDefId {
+    pub fn parent_module_from_def_id(self, mut id: LocalDefId) -> LocalModId {
         while let Some(parent) = self.opt_local_parent(id) {
             id = parent;
             if self.def_kind(id) == DefKind::Mod {
                 break;
             }
         }
-        LocalModDefId::new_unchecked(id)
+        LocalModId::new_unchecked(id)
     }
 
     /// Returns `true` if this is a foreign item (i.e., linked via `extern { ... }`).

--- a/compiler/rustc_middle/src/metadata.rs
+++ b/compiler/rustc_middle/src/metadata.rs
@@ -1,7 +1,7 @@
 use rustc_hir::def::Res;
 use rustc_macros::{StableHash, TyDecodable, TyEncodable};
 use rustc_span::Ident;
-use rustc_span::def_id::DefId;
+use rustc_span::def_id::{DefId, ModId};
 use smallvec::SmallVec;
 
 use crate::ty;
@@ -39,7 +39,7 @@ pub struct ModChild {
     /// Local variables cannot be exported, so this `Res` doesn't need the ID parameter.
     pub res: Res<!>,
     /// Visibility of the item.
-    pub vis: ty::Visibility<DefId>,
+    pub vis: ty::Visibility<ModId>,
     /// Reexport chain linking this module child to its original reexported item.
     /// Empty if the module child is a proper item.
     pub reexport_chain: SmallVec<[Reexport; 2]>,

--- a/compiler/rustc_middle/src/mir/visit.rs
+++ b/compiler/rustc_middle/src/mir/visit.rs
@@ -347,6 +347,7 @@ macro_rules! make_mir_visitor {
                         ty::InstanceKind::Item(_def_id) => {}
 
                         ty::InstanceKind::Intrinsic(_def_id)
+                        | ty::InstanceKind::LlvmIntrinsic(_def_id)
                         | ty::InstanceKind::Shim(ty::ShimKind::VTable(_def_id))
                         | ty::InstanceKind::Shim(ty::ShimKind::Reify(_def_id, _))
                         | ty::InstanceKind::Virtual(_def_id, _)

--- a/compiler/rustc_middle/src/mono.rs
+++ b/compiler/rustc_middle/src/mono.rs
@@ -524,6 +524,7 @@ impl<'tcx> CodegenUnit<'tcx> {
                 MonoItem::Fn(ref instance) => match instance.def {
                     InstanceKind::Item(def) => def.as_local().map(|_| def),
                     InstanceKind::Intrinsic(..)
+                    | InstanceKind::LlvmIntrinsic(..)
                     | InstanceKind::Virtual(..)
                     | InstanceKind::Shim(ShimKind::VTable(..))
                     | InstanceKind::Shim(ShimKind::Reify(..))

--- a/compiler/rustc_middle/src/queries.rs
+++ b/compiler/rustc_middle/src/queries.rs
@@ -64,7 +64,7 @@ use rustc_errors::{ErrorGuaranteed, catch_fatal_errors};
 use rustc_hir as hir;
 use rustc_hir::attrs::{EiiDecl, EiiImpl, StrippedCfgItem};
 use rustc_hir::def::{DefKind, DocLinkResMap};
-use rustc_hir::def_id::{CrateNum, DefId, DefIdMap, LocalDefId, LocalDefIdSet, LocalModDefId};
+use rustc_hir::def_id::{CrateNum, DefId, DefIdMap, LocalDefId, LocalDefIdSet, LocalModId};
 use rustc_hir::lang_items::{LangItem, LanguageItems};
 use rustc_hir::{ItemLocalId, PreciseCapturingArgKind};
 use rustc_index::IndexVec;
@@ -236,7 +236,7 @@ rustc_queries! {
     ///
     /// This can be conveniently accessed by `tcx.hir_visit_item_likes_in_module`.
     /// Avoid calling this query directly.
-    query hir_module_items(key: LocalModDefId) -> &'tcx rustc_middle::hir::ModuleItems {
+    query hir_module_items(key: LocalModId) -> &'tcx rustc_middle::hir::ModuleItems {
         arena_cache
         desc { "getting HIR module items in `{}`", tcx.def_path_str(key) }
         cache_on_disk
@@ -1156,7 +1156,7 @@ rustc_queries! {
     }
 
     /// Performs lint checking for the module.
-    query lint_mod(key: LocalModDefId) {
+    query lint_mod(key: LocalModId) {
         desc { "linting {}", describe_as_module(key, tcx) }
     }
 
@@ -1165,16 +1165,16 @@ rustc_queries! {
     }
 
     /// Checks the attributes in the module.
-    query check_mod_attrs(key: LocalModDefId) {
+    query check_mod_attrs(key: LocalModId) {
         desc { "checking attributes in {}", describe_as_module(key, tcx) }
     }
 
     /// Checks for uses of unstable APIs in the module.
-    query check_mod_unstable_api_usage(key: LocalModDefId) {
+    query check_mod_unstable_api_usage(key: LocalModId) {
         desc { "checking for unstable API usage in {}", describe_as_module(key, tcx) }
     }
 
-    query check_mod_privacy(key: LocalModDefId) {
+    query check_mod_privacy(key: LocalModId) {
         desc { "checking privacy in {}", describe_as_module(key.to_local_def_id(), tcx) }
     }
 
@@ -1189,7 +1189,7 @@ rustc_queries! {
         desc { "finding live symbols in crate" }
     }
 
-    query check_mod_deathness(key: LocalModDefId) {
+    query check_mod_deathness(key: LocalModId) {
         desc { "checking deathness of variables in {}", describe_as_module(key, tcx) }
     }
 
@@ -1380,7 +1380,7 @@ rustc_queries! {
         eval_always
         desc { "checking effective visibilities" }
     }
-    query check_private_in_public(module_def_id: LocalModDefId) {
+    query check_private_in_public(module_def_id: LocalModId) {
         desc {
             "checking for private elements in public interfaces for {}",
             describe_as_module(module_def_id, tcx)

--- a/compiler/rustc_middle/src/queries.rs
+++ b/compiler/rustc_middle/src/queries.rs
@@ -76,7 +76,7 @@ use rustc_session::cstore::{
     CrateDepKind, CrateSource, ExternCrate, ForeignModule, LinkagePreference, NativeLib,
 };
 use rustc_session::lint::StableLintExpectationId;
-use rustc_span::def_id::LOCAL_CRATE;
+use rustc_span::def_id::{LOCAL_CRATE, ModId};
 use rustc_span::{DUMMY_SP, LocalExpnId, Span, Spanned, Symbol};
 use rustc_target::spec::PanicStrategy;
 
@@ -2164,7 +2164,7 @@ rustc_queries! {
     /// ```
     ///
     /// In here, if you call `visibility` on `T`, it'll panic.
-    query visibility(def_id: DefId) -> ty::Visibility<DefId> {
+    query visibility(def_id: DefId) -> ty::Visibility<ModId> {
         desc { "computing visibility of `{}`", tcx.def_path_str(def_id) }
         separate_provide_extern
         feedable
@@ -2692,13 +2692,13 @@ rustc_queries! {
         separate_provide_extern
     }
 
-    query doc_link_resolutions(def_id: DefId) -> &'tcx DocLinkResMap {
+    query doc_link_resolutions(def_id: ModId) -> &'tcx DocLinkResMap {
         eval_always
         desc { "resolutions for documentation links for a module" }
         separate_provide_extern
     }
 
-    query doc_link_traits_in_scope(def_id: DefId) -> &'tcx [DefId] {
+    query doc_link_traits_in_scope(def_id: ModId) -> &'tcx [DefId] {
         eval_always
         desc { "traits in scope for documentation links for a module" }
         separate_provide_extern

--- a/compiler/rustc_middle/src/query/erase.rs
+++ b/compiler/rustc_middle/src/query/erase.rs
@@ -13,6 +13,7 @@ use std::mem::MaybeUninit;
 use rustc_ast::tokenstream::TokenStream;
 use rustc_data_structures::steal::Steal;
 use rustc_data_structures::sync::{DynSend, DynSync};
+use rustc_span::def_id::ModId;
 use rustc_span::{ErrorGuaranteed, Spanned};
 
 use crate::mono::{MonoItem, NormalizationErrorInMono};
@@ -246,7 +247,7 @@ impl_erasable_for_types_with_no_type_params! {
     rustc_middle::ty::ParamEnv<'_>,
     rustc_middle::ty::SymbolName<'_>,
     rustc_middle::ty::TypingEnv<'_>,
-    rustc_middle::ty::Visibility<rustc_span::def_id::DefId>,
+    rustc_middle::ty::Visibility<ModId>,
     rustc_middle::ty::inhabitedness::InhabitedPredicate<'_>,
     rustc_session::Limits,
     rustc_session::config::OptLevel,

--- a/compiler/rustc_middle/src/query/into_query_key.rs
+++ b/compiler/rustc_middle/src/query/into_query_key.rs
@@ -1,5 +1,5 @@
 use rustc_hir::OwnerId;
-use rustc_hir::def_id::{DefId, LocalDefId, LocalModDefId, ModDefId};
+use rustc_hir::def_id::{DefId, LocalDefId, LocalModId, ModId};
 
 /// Argument-conversion trait used by some queries and other `TyCtxt` methods.
 ///
@@ -48,21 +48,21 @@ impl IntoQueryKey<DefId> for OwnerId {
     }
 }
 
-impl IntoQueryKey<DefId> for ModDefId {
+impl IntoQueryKey<DefId> for ModId {
     #[inline(always)]
     fn into_query_key(self) -> DefId {
         self.to_def_id()
     }
 }
 
-impl IntoQueryKey<DefId> for LocalModDefId {
+impl IntoQueryKey<DefId> for LocalModId {
     #[inline(always)]
     fn into_query_key(self) -> DefId {
         self.to_def_id()
     }
 }
 
-impl IntoQueryKey<LocalDefId> for LocalModDefId {
+impl IntoQueryKey<LocalDefId> for LocalModId {
     #[inline(always)]
     fn into_query_key(self) -> LocalDefId {
         self.into()

--- a/compiler/rustc_middle/src/query/keys.rs
+++ b/compiler/rustc_middle/src/query/keys.rs
@@ -7,7 +7,7 @@ use std::hash::Hash;
 use rustc_ast::tokenstream::TokenStream;
 use rustc_data_structures::sso::SsoHashSet;
 use rustc_data_structures::stable_hash::StableHash;
-use rustc_hir::def_id::{CrateNum, DefId, LOCAL_CRATE, LocalDefId, LocalModDefId};
+use rustc_hir::def_id::{CrateNum, DefId, LOCAL_CRATE, LocalDefId, LocalModId};
 use rustc_hir::hir_id::OwnerId;
 use rustc_span::{DUMMY_SP, Ident, LocalExpnId, Span, Symbol};
 
@@ -157,7 +157,7 @@ impl QueryKey for DefId {
     }
 }
 
-impl QueryKey for LocalModDefId {
+impl QueryKey for LocalModId {
     fn default_span(&self, tcx: TyCtxt<'_>) -> Span {
         tcx.def_span(*self)
     }

--- a/compiler/rustc_middle/src/query/keys.rs
+++ b/compiler/rustc_middle/src/query/keys.rs
@@ -9,6 +9,7 @@ use rustc_data_structures::sso::SsoHashSet;
 use rustc_data_structures::stable_hash::StableHash;
 use rustc_hir::def_id::{CrateNum, DefId, LOCAL_CRATE, LocalDefId, LocalModId};
 use rustc_hir::hir_id::OwnerId;
+use rustc_span::def_id::ModId;
 use rustc_span::{DUMMY_SP, Ident, LocalExpnId, Span, Symbol};
 
 use crate::dep_graph::DepNodeIndex;
@@ -154,6 +155,19 @@ impl QueryKey for DefId {
     #[inline(always)]
     fn as_local_key(&self) -> Option<Self::LocalQueryKey> {
         self.as_local()
+    }
+}
+
+impl QueryKey for ModId {
+    type LocalQueryKey = LocalModId;
+
+    fn default_span(&self, tcx: TyCtxt<'_>) -> Span {
+        tcx.def_span(self.to_def_id())
+    }
+
+    #[inline(always)]
+    fn key_as_def_id(&self) -> Option<DefId> {
+        Some(self.to_def_id())
     }
 }
 

--- a/compiler/rustc_middle/src/ty/assoc.rs
+++ b/compiler/rustc_middle/src/ty/assoc.rs
@@ -3,6 +3,7 @@ use rustc_hir as hir;
 use rustc_hir::def::{DefKind, Namespace};
 use rustc_hir::def_id::DefId;
 use rustc_macros::{Decodable, Encodable, StableHash};
+use rustc_span::def_id::ModId;
 use rustc_span::{ErrorGuaranteed, Ident, Symbol};
 
 use super::{TyCtxt, Visibility};
@@ -82,7 +83,7 @@ impl AssocItem {
     }
 
     #[inline]
-    pub fn visibility(&self, tcx: TyCtxt<'_>) -> Visibility<DefId> {
+    pub fn visibility(&self, tcx: TyCtxt<'_>) -> Visibility<ModId> {
         tcx.visibility(self.def_id)
     }
 

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -620,7 +620,7 @@ impl<'tcx> TyCtxt<'tcx> {
                 other => bug!("{key:?} is not an assoc item of a trait impl: {other:?}"),
             }
         }
-        TyCtxtFeed { tcx: self, key }.visibility(vis.to_def_id())
+        TyCtxtFeed { tcx: self, key }.visibility(vis.to_mod_id())
     }
 }
 
@@ -1324,8 +1324,8 @@ impl<'tcx> TyCtxt<'tcx> {
         // Visibilities for opaque types are meaningless, but still provided
         // so that all items have visibilities.
         if matches!(def_kind, DefKind::Closure | DefKind::OpaqueTy) {
-            let parent_mod = self.parent_module_from_def_id(def_id).to_def_id();
-            feed.visibility(ty::Visibility::Restricted(parent_mod));
+            let parent_mod = self.parent_module_from_def_id(def_id);
+            feed.visibility(ty::Visibility::Restricted(parent_mod.to_mod_id()));
         }
 
         feed

--- a/compiler/rustc_middle/src/ty/inhabitedness/inhabited_predicate.rs
+++ b/compiler/rustc_middle/src/ty/inhabitedness/inhabited_predicate.rs
@@ -1,8 +1,9 @@
 use rustc_macros::StableHash;
+use rustc_span::def_id::{LocalModId, ModId};
 use smallvec::SmallVec;
 use tracing::instrument;
 
-use crate::ty::{self, DefId, OpaqueTypeKey, Ty, TyCtxt, TypingEnv, Unnormalized};
+use crate::ty::{self, OpaqueTypeKey, Ty, TyCtxt, TypingEnv, Unnormalized};
 
 /// Represents whether some type is inhabited in a given context.
 /// Examples of uninhabited types are `!`, `enum Void {}`, or a struct
@@ -20,7 +21,7 @@ pub enum InhabitedPredicate<'tcx> {
     ConstIsZero(ty::Const<'tcx>),
     /// Uninhabited if within a certain module. This occurs when an uninhabited
     /// type has restricted visibility.
-    NotInModule(DefId),
+    NotInModule(ModId),
     /// Inhabited if some generic type is inhabited.
     /// These are replaced by calling [`Self::instantiate`].
     GenericType(Ty<'tcx>),
@@ -38,7 +39,7 @@ impl<'tcx> InhabitedPredicate<'tcx> {
         self,
         tcx: TyCtxt<'tcx>,
         typing_env: TypingEnv<'tcx>,
-        module_def_id: DefId,
+        module_def_id: LocalModId,
     ) -> bool {
         self.apply_revealing_opaque(tcx, typing_env, module_def_id, &|_| None)
     }
@@ -49,7 +50,7 @@ impl<'tcx> InhabitedPredicate<'tcx> {
         self,
         tcx: TyCtxt<'tcx>,
         typing_env: TypingEnv<'tcx>,
-        module_def_id: DefId,
+        module_def_id: LocalModId,
         reveal_opaque: &impl Fn(OpaqueTypeKey<'tcx>) -> Option<Ty<'tcx>>,
     ) -> bool {
         let Ok(result) = self.apply_inner::<!>(
@@ -83,7 +84,7 @@ impl<'tcx> InhabitedPredicate<'tcx> {
         tcx: TyCtxt<'tcx>,
         typing_env: TypingEnv<'tcx>,
         eval_stack: &mut SmallVec<[Ty<'tcx>; 1]>, // for cycle detection
-        in_module: &impl Fn(DefId) -> Result<bool, E>,
+        in_module: &impl Fn(ModId) -> Result<bool, E>,
         reveal_opaque: &impl Fn(OpaqueTypeKey<'tcx>) -> Option<Ty<'tcx>>,
     ) -> Result<bool, E> {
         match self {

--- a/compiler/rustc_middle/src/ty/inhabitedness/mod.rs
+++ b/compiler/rustc_middle/src/ty/inhabitedness/mod.rs
@@ -43,6 +43,7 @@
 //! This code should only compile in modules where the uninhabitedness of `Foo`
 //! is visible.
 
+use rustc_span::def_id::LocalModId;
 use rustc_type_ir::TyKind::*;
 use tracing::instrument;
 
@@ -184,7 +185,7 @@ impl<'tcx> Ty<'tcx> {
     pub fn is_inhabited_from(
         self,
         tcx: TyCtxt<'tcx>,
-        module: DefId,
+        module: LocalModId,
         typing_env: ty::TypingEnv<'tcx>,
     ) -> bool {
         self.inhabited_predicate(tcx).apply(tcx, typing_env, module)

--- a/compiler/rustc_middle/src/ty/instance.rs
+++ b/compiler/rustc_middle/src/ty/instance.rs
@@ -70,10 +70,17 @@ pub enum InstanceKind<'tcx> {
 
     /// An intrinsic `fn` item (with`#[rustc_intrinsic]`).
     ///
-    /// Alongside `Virtual`, this is the only `InstanceKind` that does not have its own callable MIR.
-    /// Instead, codegen and const eval "magically" evaluate calls to intrinsics purely in the
-    /// caller.
+    /// Alongside `LlvmIntrinsic` and `Virtual`, this is the only `InstanceKind`
+    /// that does not have its own callable MIR. Instead, codegen and const eval
+    /// "magically" evaluate calls to intrinsics purely in the caller.
     Intrinsic(DefId),
+
+    /// An LLVM intrinsic `fn` item (with `extern "unadjusted"`).
+    ///
+    /// Alongside `Intrinsic` and `Virtual`, this is the only `InstanceKind`
+    /// that does not have its own callable MIR. Instead, codegen and const eval
+    /// "magically" evaluate calls to LLVM intrinsics purely in the caller.
+    LlvmIntrinsic(DefId),
 
     /// Dynamic dispatch to `<dyn Trait as Trait>::fn`.
     ///
@@ -253,7 +260,8 @@ impl<'tcx> InstanceKind<'tcx> {
         match self {
             InstanceKind::Item(def_id)
             | InstanceKind::Virtual(def_id, _)
-            | InstanceKind::Intrinsic(def_id) => def_id,
+            | InstanceKind::Intrinsic(def_id)
+            | InstanceKind::LlvmIntrinsic(def_id) => def_id,
             InstanceKind::Shim(shim) => shim.def_id(),
         }
     }
@@ -262,7 +270,9 @@ impl<'tcx> InstanceKind<'tcx> {
     pub fn def_id_if_not_guaranteed_local_codegen(self) -> Option<DefId> {
         match self {
             InstanceKind::Item(def) => Some(def),
-            InstanceKind::Virtual(..) | InstanceKind::Intrinsic(..) => None,
+            InstanceKind::Virtual(..)
+            | InstanceKind::Intrinsic(..)
+            | InstanceKind::LlvmIntrinsic(..) => None,
             InstanceKind::Shim(shim) => shim.def_id_if_not_guaranteed_local_codegen(),
         }
     }
@@ -280,7 +290,9 @@ impl<'tcx> InstanceKind<'tcx> {
                 DefPathData::Ctor | DefPathData::Closure
             ),
             InstanceKind::Shim(shim) => shim.requires_inline(),
-            InstanceKind::Virtual(..) | InstanceKind::Intrinsic(..) => true,
+            InstanceKind::Virtual(..)
+            | InstanceKind::Intrinsic(..)
+            | InstanceKind::LlvmIntrinsic(..) => true,
         }
     }
 
@@ -308,7 +320,10 @@ impl<'tcx> InstanceKind<'tcx> {
     /// body should perform necessary instantiations.
     pub fn has_polymorphic_mir_body(&self) -> bool {
         match *self {
-            InstanceKind::Item(_) | InstanceKind::Intrinsic(..) | InstanceKind::Virtual(..) => true,
+            InstanceKind::Item(_)
+            | InstanceKind::Intrinsic(..)
+            | InstanceKind::LlvmIntrinsic(..)
+            | InstanceKind::Virtual(..) => true,
             InstanceKind::Shim(shim) => shim.has_polymorphic_mir_body(),
         }
     }

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -50,6 +50,7 @@ use rustc_macros::{
 use rustc_serialize::{Decodable, Encodable};
 use rustc_session::config::OptLevel;
 pub use rustc_session::lint::RegisteredTools;
+use rustc_span::def_id::{LocalModId, ModId};
 use rustc_span::hygiene::MacroKind;
 use rustc_span::{DUMMY_SP, ExpnId, ExpnKind, Ident, Span, Symbol};
 use rustc_target::callconv::FnAbi;
@@ -199,8 +200,8 @@ pub struct ResolverGlobalCtxt {
     /// Mapping from ident span to path span for paths that don't exist as written, but that
     /// exist under `std`. For example, wrote `str::from_utf8` instead of `std::str::from_utf8`.
     pub confused_type_with_std_module: FxIndexMap<Span, Span>,
-    pub doc_link_resolutions: FxIndexMap<LocalDefId, DocLinkResMap>,
-    pub doc_link_traits_in_scope: FxIndexMap<LocalDefId, Vec<DefId>>,
+    pub doc_link_resolutions: FxIndexMap<LocalModId, DocLinkResMap>,
+    pub doc_link_traits_in_scope: FxIndexMap<LocalModId, Vec<DefId>>,
     pub all_macro_rules: UnordSet<Symbol>,
     pub stripped_cfg_items: Vec<StrippedCfgItem>,
     // Information about delegations which is used when handling recursive delegations
@@ -311,7 +312,7 @@ impl Asyncness {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Copy, Hash, Encodable, BlobDecodable, StableHash)]
-pub enum Visibility<Id = LocalDefId> {
+pub enum Visibility<Id = LocalModId> {
     /// Visible everywhere (including in other crates).
     Public,
     /// Visible only in the given crate-local module.
@@ -324,7 +325,7 @@ impl Visibility {
             ty::Visibility::Restricted(restricted_id) => {
                 if restricted_id.is_top_level_module() {
                     "pub(crate)".to_string()
-                } else if restricted_id == tcx.parent_module_from_def_id(def_id).to_local_def_id() {
+                } else if restricted_id == tcx.parent_module_from_def_id(def_id) {
                     "pub(self)".to_string()
                 } else {
                     format!(
@@ -428,11 +429,13 @@ impl<Id> Visibility<Id> {
     }
 }
 
-impl<Id: Into<DefId>> Visibility<Id> {
-    pub fn to_def_id(self) -> Visibility<DefId> {
-        self.map_id(Into::into)
+impl Visibility<LocalModId> {
+    pub fn to_mod_id(self) -> Visibility<ModId> {
+        self.map_id(LocalModId::to_mod_id)
     }
+}
 
+impl<Id: Into<DefId>> Visibility<Id> {
     /// Returns `true` if an item with this visibility is accessible from the given module.
     pub fn is_accessible_from(self, module: impl Into<DefId>, tcx: TyCtxt<'_>) -> bool {
         match self {
@@ -477,7 +480,7 @@ impl<Id: Into<DefId> + Debug + Copy> Visibility<Id> {
     }
 }
 
-impl Visibility<DefId> {
+impl Visibility<ModId> {
     pub fn expect_local(self) -> Visibility {
         self.map_id(|id| id.expect_local())
     }
@@ -486,7 +489,7 @@ impl Visibility<DefId> {
     pub fn is_visible_locally(self) -> bool {
         match self {
             Visibility::Public => true,
-            Visibility::Restricted(def_id) => def_id.is_local(),
+            Visibility::Restricted(mod_id) => mod_id.is_local(),
         }
     }
 }
@@ -1468,7 +1471,7 @@ pub enum VariantDiscr {
 pub struct FieldDef {
     pub did: DefId,
     pub name: Symbol,
-    pub vis: Visibility<DefId>,
+    pub vis: Visibility<ModId>,
     pub safety: hir::Safety,
     pub value: Option<DefId>,
 }
@@ -2162,12 +2165,12 @@ impl<'tcx> TyCtxt<'tcx> {
         mut ident: Ident,
         scope: DefId,
         item_id: LocalDefId,
-    ) -> (Ident, DefId) {
+    ) -> (Ident, ModId) {
         let scope = ident
             .span
             .normalize_to_macros_2_0_and_adjust(self.expn_that_defined(scope))
             .and_then(|actual_expansion| actual_expansion.expn_data().parent_module)
-            .unwrap_or_else(|| self.parent_module_from_def_id(item_id).to_def_id());
+            .unwrap_or_else(|| self.parent_module_from_def_id(item_id).to_mod_id());
         (ident, scope)
     }
 

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -1833,7 +1833,9 @@ impl<'tcx> TyCtxt<'tcx> {
                     _ => self.optimized_mir(def),
                 }
             }
-            ty::InstanceKind::Intrinsic(..) => bug!("intrinsics have no instance MIR"),
+            ty::InstanceKind::Intrinsic(..) | ty::InstanceKind::LlvmIntrinsic(..) => {
+                bug!("intrinsics have no instance MIR")
+            }
             ty::InstanceKind::Virtual(..) => bug!("virtual dispatches have no instance MIR"),
             ty::InstanceKind::Shim(shim) => self.mir_shims(shim),
         };

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -403,9 +403,13 @@ impl TyCtxt<'_> {
         }
     }
 
-    pub fn is_descendant_of(self, descendant: DefId, ancestor: DefId) -> bool {
+    pub fn is_descendant_of(
+        self,
+        descendant: impl Into<DefId>,
+        ancestor: impl Into<DefId>,
+    ) -> bool {
         matches!(
-            self.def_id_partial_cmp(descendant, ancestor),
+            self.def_id_partial_cmp(descendant.into(), ancestor.into()),
             Some(Ordering::Less | Ordering::Equal)
         )
     }
@@ -434,7 +438,7 @@ impl<Id: Into<DefId>> Visibility<Id> {
         match self {
             // Public items are visible everywhere.
             Visibility::Public => true,
-            Visibility::Restricted(id) => tcx.is_descendant_of(module.into(), id.into()),
+            Visibility::Restricted(id) => tcx.is_descendant_of(module, id),
         }
     }
 

--- a/compiler/rustc_middle/src/ty/print/mod.rs
+++ b/compiler/rustc_middle/src/ty/print/mod.rs
@@ -368,6 +368,7 @@ impl<'tcx, P: Printer<'tcx> + std::fmt::Write> Print<P> for ty::Instance<'tcx> {
         match self.def {
             ty::InstanceKind::Item(_) => {}
             ty::InstanceKind::Intrinsic(_) => cx.write_str(" - intrinsic")?,
+            ty::InstanceKind::LlvmIntrinsic(_) => cx.write_str(" - LLVM intrinsic")?,
             ty::InstanceKind::Virtual(_, num) => cx.write_str(&format!(" - virtual#{num}"))?,
             ty::InstanceKind::Shim(shim) => {
                 cx.write_str(" - ")?;

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -2357,7 +2357,7 @@ impl<'tcx> Printer<'tcx> for FmtPrinter<'_, 'tcx> {
             {
                 // We only truncate types that we know are likely to be much longer than 3 chars.
                 // There's no point in replacing `i32` or `!`.
-                write!(self, "...")?;
+                write!(self, "_")?;
                 Ok(())
             }
             _ => {

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -385,7 +385,6 @@ pub trait PrettyPrinter<'tcx>: Printer<'tcx> + fmt::Write {
                 && Some(*visible_parent) != actual_parent
             {
                 this.tcx()
-                    // FIXME(typed_def_id): Further propagate ModId
                     .module_children(ModId::new_unchecked(*visible_parent))
                     .iter()
                     .filter(|child| child.res.opt_def_id() == Some(def_id))
@@ -612,7 +611,6 @@ pub trait PrettyPrinter<'tcx>: Printer<'tcx> + fmt::Write {
                 // that's public and whose identifier isn't `_`.
                 let reexport = self
                     .tcx()
-                    // FIXME(typed_def_id): Further propagate ModId
                     .module_children(ModId::new_unchecked(visible_parent))
                     .iter()
                     .filter(|child| child.res.opt_def_id() == Some(def_id))

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -11,7 +11,7 @@ use rustc_data_structures::unord::UnordMap;
 use rustc_hir as hir;
 use rustc_hir::LangItem;
 use rustc_hir::def::{self, CtorKind, DefKind, Namespace};
-use rustc_hir::def_id::{DefIdMap, DefIdSet, LOCAL_CRATE, ModDefId};
+use rustc_hir::def_id::{DefIdMap, DefIdSet, LOCAL_CRATE, ModId};
 use rustc_hir::definitions::{DefKey, DefPathDataName};
 use rustc_hir::limit::Limit;
 use rustc_macros::{Lift, extension};
@@ -385,8 +385,8 @@ pub trait PrettyPrinter<'tcx>: Printer<'tcx> + fmt::Write {
                 && Some(*visible_parent) != actual_parent
             {
                 this.tcx()
-                    // FIXME(typed_def_id): Further propagate ModDefId
-                    .module_children(ModDefId::new_unchecked(*visible_parent))
+                    // FIXME(typed_def_id): Further propagate ModId
+                    .module_children(ModId::new_unchecked(*visible_parent))
                     .iter()
                     .filter(|child| child.res.opt_def_id() == Some(def_id))
                     .find(|child| child.vis.is_public() && child.ident.name != kw::Underscore)
@@ -612,8 +612,8 @@ pub trait PrettyPrinter<'tcx>: Printer<'tcx> + fmt::Write {
                 // that's public and whose identifier isn't `_`.
                 let reexport = self
                     .tcx()
-                    // FIXME(typed_def_id): Further propagate ModDefId
-                    .module_children(ModDefId::new_unchecked(visible_parent))
+                    // FIXME(typed_def_id): Further propagate ModId
+                    .module_children(ModId::new_unchecked(visible_parent))
                     .iter()
                     .filter(|child| child.res.opt_def_id() == Some(def_id))
                     .find(|child| child.vis.is_public() && child.ident.name != kw::Underscore)

--- a/compiler/rustc_middle/src/ty/structural_impls.rs
+++ b/compiler/rustc_middle/src/ty/structural_impls.rs
@@ -250,6 +250,7 @@ TrivialTypeTraversalImpls! {
     rustc_span::Ident,
     rustc_span::Span,
     rustc_span::Symbol,
+    rustc_span::def_id::ModId,
     rustc_target::asm::InlineAsmRegOrRegClass,
     // tidy-alphabetical-end
 }

--- a/compiler/rustc_middle/src/ty/trait_def.rs
+++ b/compiler/rustc_middle/src/ty/trait_def.rs
@@ -140,7 +140,7 @@ impl ImplRestrictionKind {
                 if restricted_to.krate == rustc_hir::def_id::LOCAL_CRATE {
                     with_crate_prefix!(with_no_trimmed_paths!(tcx.def_path_str(restricted_to)))
                 } else {
-                    tcx.def_path_str(restricted_to.krate.as_mod_def_id())
+                    tcx.def_path_str(restricted_to.krate.as_mod_id())
                 }
             }
         }

--- a/compiler/rustc_mir_build/src/builder/scope.rs
+++ b/compiler/rustc_mir_build/src/builder/scope.rs
@@ -967,7 +967,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         let cx = RustcPatCtxt {
             tcx: self.tcx,
             typeck_results,
-            module: self.tcx.parent_module(self.hir_id).to_def_id(),
+            module: self.tcx.parent_module(self.hir_id),
             typing_env: ty::TypingEnv::post_typeck_until_borrowck_for_mir_build(
                 self.tcx,
                 self.def_id,

--- a/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
@@ -385,7 +385,7 @@ impl<'p, 'tcx> MatchVisitor<'p, 'tcx> {
             tcx: self.tcx,
             typeck_results: self.typeck_results,
             typing_env: self.typing_env,
-            module: self.tcx.parent_module(self.hir_source).to_def_id(),
+            module: self.tcx.parent_module(self.hir_source),
             dropless_arena: self.dropless_arena,
             match_lint_level: self.hir_source,
             whole_match_span,

--- a/compiler/rustc_mir_transform/src/inline.rs
+++ b/compiler/rustc_mir_transform/src/inline.rs
@@ -730,7 +730,7 @@ fn check_mir_is_available<'tcx, I: Inliner<'tcx>>(
             }
         }
         // These have no own callable MIR.
-        InstanceKind::Intrinsic(_) | InstanceKind::Virtual(..) => {
+        InstanceKind::Intrinsic(_) | InstanceKind::LlvmIntrinsic(_) | InstanceKind::Virtual(..) => {
             debug!("instance without MIR (intrinsic / virtual)");
             return Err("implementation limitation -- cannot inline intrinsic");
         }

--- a/compiler/rustc_mir_transform/src/inline/cycle.rs
+++ b/compiler/rustc_mir_transform/src/inline/cycle.rs
@@ -21,7 +21,9 @@ fn should_recurse<'tcx>(tcx: TyCtxt<'tcx>, callee: ty::Instance<'tcx>) -> bool {
         }
 
         // These have no own callable MIR.
-        InstanceKind::Intrinsic(_) | InstanceKind::Virtual(..) => return false,
+        InstanceKind::Intrinsic(_) | InstanceKind::LlvmIntrinsic(_) | InstanceKind::Virtual(..) => {
+            return false;
+        }
 
         // These have MIR and if that MIR is inlined, instantiated and then inlining is run
         // again, a function item can end up getting inlined. Thus we'll be able to cause

--- a/compiler/rustc_mir_transform/src/lint_and_remove_uninhabited.rs
+++ b/compiler/rustc_mir_transform/src/lint_and_remove_uninhabited.rs
@@ -14,7 +14,7 @@ impl<'tcx> crate::MirPass<'tcx> for LintAndRemoveUninhabited {
     fn run_pass(&self, tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
         let def_id = body.source.def_id().expect_local();
         tracing::debug!(?def_id);
-        let parent_module = tcx.parent_module_from_def_id(def_id).to_def_id();
+        let parent_module = tcx.parent_module_from_def_id(def_id);
         let typing_env = body.typing_env(tcx);
 
         // check if the function's return type is inhabited

--- a/compiler/rustc_monomorphize/src/collector.rs
+++ b/compiler/rustc_monomorphize/src/collector.rs
@@ -1018,7 +1018,9 @@ fn visit_instance_use<'tcx>(
     }
 
     match instance.def {
-        ty::InstanceKind::Virtual(..) | ty::InstanceKind::Intrinsic(_) => {
+        ty::InstanceKind::Virtual(..)
+        | ty::InstanceKind::Intrinsic(_)
+        | ty::InstanceKind::LlvmIntrinsic(_) => {
             if !is_direct_call {
                 bug!("{:?} being reified", instance);
             }

--- a/compiler/rustc_monomorphize/src/partitioning.rs
+++ b/compiler/rustc_monomorphize/src/partitioning.rs
@@ -631,6 +631,7 @@ fn characteristic_def_id_of_mono_item<'tcx>(
             let def_id = match instance.def {
                 ty::InstanceKind::Item(def) => def,
                 ty::InstanceKind::Intrinsic(..)
+                | ty::InstanceKind::LlvmIntrinsic(..)
                 | ty::InstanceKind::Virtual(..)
                 | ty::InstanceKind::Shim(ty::ShimKind::VTable(..))
                 | ty::InstanceKind::Shim(ty::ShimKind::Reify(..))
@@ -810,6 +811,7 @@ fn mono_item_visibility<'tcx>(
         | InstanceKind::Shim(ShimKind::FnPtr(..))
         | InstanceKind::Virtual(..)
         | InstanceKind::Intrinsic(..)
+        | InstanceKind::LlvmIntrinsic(..)
         | InstanceKind::Shim(ShimKind::ClosureOnce { .. })
         | InstanceKind::Shim(ShimKind::ConstructCoroutineInClosure { .. })
         | InstanceKind::Shim(ShimKind::DropGlue(..))

--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
@@ -870,7 +870,7 @@ where
             (
                 RerunCondition::OpaqueInStorageOrAnyOpaqueHasInferAsHidden(_),
                 TypingMode::PostAnalysis | TypingMode::Codegen,
-            ) => RerunDecision::No,
+            ) => RerunDecision::Yes,
             (
                 RerunCondition::OpaqueInStorageOrAnyOpaqueHasInferAsHidden(defids),
                 TypingMode::Typeck { defining_opaque_types_and_generators: opaques },

--- a/compiler/rustc_parse/src/parser/attr_wrapper.rs
+++ b/compiler/rustc_parse/src/parser/attr_wrapper.rs
@@ -5,7 +5,7 @@ use rustc_ast::token::Token;
 use rustc_ast::tokenstream::{
     AttrsTarget, LazyAttrTokenStream, NodeRange, ParserRange, Spacing, TokenCursor,
 };
-use rustc_ast::{self as ast, AttrVec, Attribute, HasAttrs, HasTokens};
+use rustc_ast::{self as ast, AttrVec, Attribute, HasTokens};
 use rustc_data_structures::fx::FxHashSet;
 use rustc_errors::PResult;
 use rustc_session::parse::ParseSess;
@@ -137,7 +137,7 @@ impl<'a> Parser<'a> {
     ///     }                               //  32..33
     /// }                                   //  33..34
     /// ```
-    pub(super) fn collect_tokens<R: HasAttrs + HasTokens>(
+    pub(super) fn collect_tokens<R: HasTokens>(
         &mut self,
         pre_attr_pos: Option<CollectPos>,
         attrs: AttrWrapper,

--- a/compiler/rustc_parse/src/parser/mod.rs
+++ b/compiler/rustc_parse/src/parser/mod.rs
@@ -36,9 +36,8 @@ use rustc_ast::util::case::Case;
 use rustc_ast::util::classify;
 use rustc_ast::{
     self as ast, AnonConst, AttrArgs, AttrId, BinOpKind, ByRef, Const, CoroutineKind,
-    DUMMY_NODE_ID, DelimArgs, Expr, ExprKind, Extern, HasAttrs, HasTokens, ImplRestriction,
-    MutRestriction, Mutability, Recovered, RestrictionKind, Safety, StrLit, Visibility,
-    VisibilityKind,
+    DUMMY_NODE_ID, DelimArgs, Expr, ExprKind, Extern, HasTokens, ImplRestriction, MutRestriction,
+    Mutability, Recovered, RestrictionKind, Safety, StrLit, Visibility, VisibilityKind,
 };
 use rustc_ast_pretty::pprust;
 use rustc_data_structures::fx::FxHashMap;
@@ -1662,7 +1661,7 @@ impl<'a> Parser<'a> {
         }
     }
 
-    fn collect_tokens_no_attrs<R: HasAttrs + HasTokens>(
+    fn collect_tokens_no_attrs<R: HasTokens>(
         &mut self,
         f: impl FnOnce(&mut Self) -> PResult<'a, R>,
     ) -> PResult<'a, R> {

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -21,7 +21,7 @@ use rustc_hir::attrs::{
     OptimizeAttr, ReprAttr,
 };
 use rustc_hir::def::DefKind;
-use rustc_hir::def_id::LocalModDefId;
+use rustc_hir::def_id::LocalModId;
 use rustc_hir::intravisit::{self, Visitor};
 use rustc_hir::{
     self as hir, Attribute, CRATE_HIR_ID, Constness, FnSig, ForeignItem, GenericParam,
@@ -1783,7 +1783,7 @@ fn check_non_exported_macro_for_invalid_attrs(tcx: TyCtxt<'_>, item: &Item<'_>) 
     }
 }
 
-fn check_mod_attrs(tcx: TyCtxt<'_>, module_def_id: LocalModDefId) {
+fn check_mod_attrs(tcx: TyCtxt<'_>, module_def_id: LocalModId) {
     let check_attr_visitor = &mut CheckAttrVisitor { tcx, abort: Cell::new(false) };
     tcx.hir_visit_item_likes_in_module(module_def_id, check_attr_visitor);
     if module_def_id.to_local_def_id().is_top_level_module() {

--- a/compiler/rustc_passes/src/check_export.rs
+++ b/compiler/rustc_passes/src/check_export.rs
@@ -56,7 +56,7 @@ impl<'tcx> ExportableItemCollector<'tcx> {
         if has_attr && !is_pub {
             let vis = visibilities.effective_vis(def_id).cloned().unwrap_or_else(|| {
                 EffectiveVisibility::from_vis(Visibility::Restricted(
-                    self.tcx.parent_module_from_def_id(def_id).to_local_def_id(),
+                    self.tcx.parent_module_from_def_id(def_id),
                 ))
             });
             let vis = vis.at_level(Level::Direct);

--- a/compiler/rustc_passes/src/dead.rs
+++ b/compiler/rustc_passes/src/dead.rs
@@ -12,7 +12,7 @@ use rustc_abi::FieldIdx;
 use rustc_data_structures::fx::{FxHashSet, FxIndexSet};
 use rustc_errors::{ErrorGuaranteed, MultiSpan};
 use rustc_hir::def::{CtorOf, DefKind, Res};
-use rustc_hir::def_id::{DefId, LocalDefId, LocalModDefId};
+use rustc_hir::def_id::{DefId, LocalDefId, LocalModId};
 use rustc_hir::intravisit::{self, Visitor};
 use rustc_hir::{self as hir, ForeignItemId, ItemId, Node, PatKind, QPath, find_attr};
 use rustc_middle::middle::codegen_fn_attrs::CodegenFnAttrFlags;
@@ -1325,7 +1325,7 @@ impl<'tcx> DeadVisitor<'tcx> {
     }
 }
 
-fn check_mod_deathness(tcx: TyCtxt<'_>, module: LocalModDefId) {
+fn check_mod_deathness(tcx: TyCtxt<'_>, module: LocalModId) {
     let Ok(DeadCodeLivenessSummary { pre_deferred_seeding, final_result }) =
         tcx.live_symbols_and_ignored_derived_traits(()).as_ref()
     else {
@@ -1367,7 +1367,7 @@ fn check_mod_deathness(tcx: TyCtxt<'_>, module: LocalModDefId) {
 fn lint_dead_codes<'tcx>(
     tcx: TyCtxt<'tcx>,
     target_lint: &'static Lint,
-    module: LocalModDefId,
+    module: LocalModId,
     live_symbols: &'tcx LocalDefIdSet,
     ignored_derived_traits: &'tcx LocalDefIdMap<FxIndexSet<DefId>>,
     free_items: impl Iterator<Item = ItemId>,

--- a/compiler/rustc_passes/src/stability.rs
+++ b/compiler/rustc_passes/src/stability.rs
@@ -9,7 +9,7 @@ use rustc_data_structures::unord::{ExtendUnord, UnordMap, UnordSet};
 use rustc_feature::{EnabledLangFeature, EnabledLibFeature, UNSTABLE_LANG_FEATURES};
 use rustc_hir::attrs::{AttributeKind, DeprecatedSince};
 use rustc_hir::def::{DefKind, Res};
-use rustc_hir::def_id::{CRATE_DEF_ID, LOCAL_CRATE, LocalDefId, LocalModDefId};
+use rustc_hir::def_id::{CRATE_DEF_ID, LOCAL_CRATE, LocalDefId, LocalModId};
 use rustc_hir::intravisit::{self, Visitor, VisitorExt};
 use rustc_hir::{
     self as hir, AmbigArg, ConstStability, Constness, DefaultBodyStability, FieldDef, HirId, Item,
@@ -520,21 +520,21 @@ impl<'tcx> Visitor<'tcx> for MissingStabilityAnnotations<'tcx> {
 
 /// Cross-references the feature names of unstable APIs with enabled
 /// features and possibly prints errors.
-fn check_mod_unstable_api_usage(tcx: TyCtxt<'_>, module_def_id: LocalModDefId) {
-    tcx.hir_visit_item_likes_in_module(module_def_id, &mut Checker { tcx });
+fn check_mod_unstable_api_usage(tcx: TyCtxt<'_>, mod_id: LocalModId) {
+    tcx.hir_visit_item_likes_in_module(mod_id, &mut Checker { tcx });
 
     let is_staged_api =
         tcx.sess.opts.unstable_opts.force_unstable_if_unmarked || tcx.features().staged_api();
     if is_staged_api {
         let effective_visibilities = &tcx.effective_visibilities(());
         let mut missing = MissingStabilityAnnotations { tcx, effective_visibilities };
-        if module_def_id.is_top_level_module() {
+        if mod_id.is_top_level_module() {
             missing.check_missing_stability(CRATE_DEF_ID);
         }
-        tcx.hir_visit_item_likes_in_module(module_def_id, &mut missing);
+        tcx.hir_visit_item_likes_in_module(mod_id, &mut missing);
     }
 
-    if module_def_id.is_top_level_module() {
+    if mod_id.is_top_level_module() {
         check_unused_or_stable_features(tcx)
     }
 }

--- a/compiler/rustc_pattern_analysis/src/rustc.rs
+++ b/compiler/rustc_pattern_analysis/src/rustc.rs
@@ -5,7 +5,6 @@ use std::iter::once;
 use rustc_abi::{FIRST_VARIANT, FieldIdx, Integer, VariantIdx};
 use rustc_arena::DroplessArena;
 use rustc_hir::HirId;
-use rustc_hir::def_id::DefId;
 use rustc_index::{Idx, IndexVec};
 use rustc_middle::middle::stability::EvalResult;
 use rustc_middle::thir::{self, Pat, PatKind, PatRange, PatRangeBoundary};
@@ -15,6 +14,7 @@ use rustc_middle::ty::{
 };
 use rustc_middle::{bug, span_bug};
 use rustc_session::lint;
+use rustc_span::def_id::LocalModId;
 use rustc_span::{DUMMY_SP, ErrorGuaranteed, Span};
 
 use crate::constructor::Constructor::*;
@@ -84,7 +84,7 @@ pub struct RustcPatCtxt<'p, 'tcx: 'p> {
     /// inhabited can depend on whether it was defined in the current module or
     /// not. E.g., `struct Foo { _private: ! }` cannot be seen to be empty
     /// outside its module and should not be matchable with an empty match statement.
-    pub module: DefId,
+    pub module: LocalModId,
     pub typing_env: ty::TypingEnv<'tcx>,
     /// To allocate the result of `self.ctor_sub_tys()`
     pub dropless_arena: &'p DroplessArena,

--- a/compiler/rustc_privacy/src/lib.rs
+++ b/compiler/rustc_privacy/src/lib.rs
@@ -405,9 +405,8 @@ impl VisibilityLike for EffectiveVisibility {
     ) -> Self {
         let effective_vis =
             find.effective_visibilities.effective_vis(def_id).copied().unwrap_or_else(|| {
-                let private_vis = ty::Visibility::Restricted(
-                    find.tcx.parent_module_from_def_id(def_id).to_local_def_id(),
-                );
+                let private_vis =
+                    ty::Visibility::Restricted(find.tcx.parent_module_from_def_id(def_id));
                 EffectiveVisibility::from_vis(private_vis)
             });
 
@@ -517,7 +516,6 @@ impl<'tcx> EmbargoVisitor<'tcx> {
         max_vis: Option<ty::Visibility>,
         level: Level,
     ) -> bool {
-        // FIXME(typed_def_id): Make `Visibility::Restricted` use a `LocalModId` by default.
         let private_vis =
             ty::Visibility::Restricted(self.tcx.parent_module_from_def_id(def_id).into());
         if max_vis != Some(private_vis) {
@@ -1434,12 +1432,10 @@ impl SearchInterfaceForPrivateItemsVisitor<'_> {
         if self.hard_error && self.required_visibility.greater_than(vis, self.tcx) {
             let vis_descr = match vis {
                 ty::Visibility::Public => "public",
-                ty::Visibility::Restricted(vis_def_id) => {
-                    if vis_def_id
-                        == self.tcx.parent_module_from_def_id(local_def_id).to_local_def_id()
-                    {
+                ty::Visibility::Restricted(vis_mod_id) => {
+                    if vis_mod_id == self.tcx.parent_module_from_def_id(local_def_id) {
                         "private"
-                    } else if vis_def_id.is_top_level_module() {
+                    } else if vis_mod_id.is_top_level_module() {
                         "crate-private"
                     } else {
                         "restricted"

--- a/compiler/rustc_privacy/src/lib.rs
+++ b/compiler/rustc_privacy/src/lib.rs
@@ -21,7 +21,7 @@ use rustc_data_structures::indexmap::IndexSet;
 use rustc_data_structures::intern::Interned;
 use rustc_errors::{MultiSpan, listify};
 use rustc_hir::def::{CtorOf, DefKind, Res};
-use rustc_hir::def_id::{DefId, LocalDefId, LocalModDefId};
+use rustc_hir::def_id::{DefId, LocalDefId, LocalModId};
 use rustc_hir::intravisit::{self, InferKind, Visitor};
 use rustc_hir::{self as hir, AmbigArg, ForeignItemId, ItemId, OwnerId, PatKind, find_attr};
 use rustc_middle::middle::privacy::{EffectiveVisibilities, EffectiveVisibility, Level};
@@ -517,7 +517,7 @@ impl<'tcx> EmbargoVisitor<'tcx> {
         max_vis: Option<ty::Visibility>,
         level: Level,
     ) -> bool {
-        // FIXME(typed_def_id): Make `Visibility::Restricted` use a `LocalModDefId` by default.
+        // FIXME(typed_def_id): Make `Visibility::Restricted` use a `LocalModId` by default.
         let private_vis =
             ty::Visibility::Restricted(self.tcx.parent_module_from_def_id(def_id).into());
         if max_vis != Some(private_vis) {
@@ -1128,14 +1128,14 @@ impl<'tcx> Visitor<'tcx> for NamePrivacyVisitor<'tcx> {
 /// Checks are performed on "semantic" types regardless of names and their hygiene.
 struct TypePrivacyVisitor<'tcx> {
     tcx: TyCtxt<'tcx>,
-    module_def_id: LocalModDefId,
+    mod_id: LocalModId,
     maybe_typeck_results: Option<&'tcx ty::TypeckResults<'tcx>>,
     span: Span,
 }
 
 impl<'tcx> TypePrivacyVisitor<'tcx> {
     fn item_is_accessible(&self, did: DefId) -> bool {
-        self.tcx.visibility(did).is_accessible_from(self.module_def_id, self.tcx)
+        self.tcx.visibility(did).is_accessible_from(self.mod_id, self.tcx)
     }
 
     // Take node-id of an expression or pattern and check its type for privacy.
@@ -1746,17 +1746,17 @@ pub fn provide(providers: &mut Providers) {
     };
 }
 
-fn check_mod_privacy(tcx: TyCtxt<'_>, module_def_id: LocalModDefId) {
+fn check_mod_privacy(tcx: TyCtxt<'_>, mod_id: LocalModId) {
     // Check privacy of names not checked in previous compilation stages.
     let mut visitor = NamePrivacyVisitor { tcx, maybe_typeck_results: None };
-    tcx.hir_visit_item_likes_in_module(module_def_id, &mut visitor);
+    tcx.hir_visit_item_likes_in_module(mod_id, &mut visitor);
 
     // Check privacy of explicitly written types and traits as well as
     // inferred types of expressions and patterns.
-    let span = tcx.def_span(module_def_id);
-    let mut visitor = TypePrivacyVisitor { tcx, module_def_id, maybe_typeck_results: None, span };
+    let span = tcx.def_span(mod_id);
+    let mut visitor = TypePrivacyVisitor { tcx, mod_id, maybe_typeck_results: None, span };
 
-    let module = tcx.hir_module_items(module_def_id);
+    let module = tcx.hir_module_items(mod_id);
     for def_id in module.definitions() {
         let _ = rustc_ty_utils::sig_types::walk_types(tcx, def_id, &mut visitor);
 
@@ -1881,12 +1881,12 @@ fn effective_visibilities(tcx: TyCtxt<'_>, (): ()) -> &EffectiveVisibilities {
     tcx.arena.alloc(visitor.effective_visibilities)
 }
 
-fn check_private_in_public(tcx: TyCtxt<'_>, module_def_id: LocalModDefId) {
+fn check_private_in_public(tcx: TyCtxt<'_>, mod_id: LocalModId) {
     let effective_visibilities = tcx.effective_visibilities(());
     // Check for private types in public interfaces.
     let checker = PrivateItemsInPublicInterfacesChecker { tcx, effective_visibilities };
 
-    let crate_items = tcx.hir_module_items(module_def_id);
+    let crate_items = tcx.hir_module_items(mod_id);
     let _ = crate_items.par_items(|id| Ok(checker.check_item(id)));
     let _ = crate_items.par_foreign_items(|id| Ok(checker.check_foreign_item(id)));
 }

--- a/compiler/rustc_public/src/mir/mono.rs
+++ b/compiler/rustc_public/src/mir/mono.rs
@@ -32,6 +32,8 @@ pub enum InstanceKind {
     Item,
     /// A compiler intrinsic function.
     Intrinsic,
+    /// An LLVM intrinsic function.
+    LlvmIntrinsic,
     /// A virtual function definition stored in a VTable.
     /// The `idx` field indicates the position in the VTable for this instance.
     Virtual { idx: usize },
@@ -113,7 +115,10 @@ impl Instance {
             InstanceKind::Intrinsic => {
                 Some(with(|context| context.intrinsic(self.def.def_id()).unwrap().fn_name()))
             }
-            InstanceKind::Item | InstanceKind::Virtual { .. } | InstanceKind::Shim => None,
+            InstanceKind::LlvmIntrinsic
+            | InstanceKind::Item
+            | InstanceKind::Virtual { .. }
+            | InstanceKind::Shim => None,
         }
     }
 

--- a/compiler/rustc_public/src/unstable/convert/stable/ty.rs
+++ b/compiler/rustc_public/src/unstable/convert/stable/ty.rs
@@ -970,6 +970,7 @@ impl<'tcx> Stable<'tcx> for ty::Instance<'tcx> {
         let kind = match self.def {
             ty::InstanceKind::Item(..) => crate::mir::mono::InstanceKind::Item,
             ty::InstanceKind::Intrinsic(..) => crate::mir::mono::InstanceKind::Intrinsic,
+            ty::InstanceKind::LlvmIntrinsic(..) => crate::mir::mono::InstanceKind::LlvmIntrinsic,
             ty::InstanceKind::Virtual(_def_id, idx) => {
                 crate::mir::mono::InstanceKind::Virtual { idx }
             }

--- a/compiler/rustc_resolve/src/build_reduced_graph.rs
+++ b/compiler/rustc_resolve/src/build_reduced_graph.rs
@@ -19,12 +19,13 @@ use rustc_expand::base::{ResolverExpand, SyntaxExtension, SyntaxExtensionKind};
 use rustc_hir::Attribute;
 use rustc_hir::attrs::{AttributeKind, MacroUseArgs};
 use rustc_hir::def::{self, *};
-use rustc_hir::def_id::{CRATE_DEF_ID, DefId, LocalDefId};
+use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_index::bit_set::DenseBitSet;
 use rustc_metadata::creader::LoadedMacro;
 use rustc_middle::metadata::{ModChild, Reexport};
 use rustc_middle::ty::{TyCtxtFeed, Visibility};
 use rustc_middle::{bug, span_bug};
+use rustc_span::def_id::{CRATE_MOD_ID, ModId};
 use rustc_span::hygiene::{ExpnId, LocalExpnId, MacroKind};
 use rustc_span::{Ident, Span, Symbol, kw, sym};
 use thin_vec::ThinVec;
@@ -71,7 +72,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         expn_id: LocalExpnId,
     ) {
         let decl =
-            self.arenas.new_def_decl(res, vis.to_def_id(), span, expn_id, Some(parent.to_module()));
+            self.arenas.new_def_decl(res, vis.to_mod_id(), span, expn_id, Some(parent.to_module()));
         let ident = IdentKey::new(orig_ident);
         self.plant_decl_into_local_module(ident, orig_ident.span, ns, decl);
     }
@@ -274,7 +275,8 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                                     Ok(Visibility::Public)
                                 }
                                 _ => {
-                                    let vis = Visibility::Restricted(res.def_id());
+                                    let vis =
+                                        Visibility::Restricted(ModId::new_unchecked(res.def_id()));
                                     if self.is_accessible_from(vis, parent_scope.module) {
                                         if finalize {
                                             self.record_partial_res(id, PartialRes::new(res));
@@ -904,7 +906,7 @@ impl<'a, 'ra, 'tcx> DefCollector<'a, 'ra, 'tcx> {
                     let mut ctor_vis = if vis.is_public()
                         && ast::attr::contains_name(&item.attrs, sym::non_exhaustive)
                     {
-                        Visibility::Restricted(CRATE_DEF_ID)
+                        Visibility::Restricted(CRATE_MOD_ID)
                     } else {
                         vis
                     };
@@ -922,7 +924,7 @@ impl<'a, 'ra, 'tcx> DefCollector<'a, 'ra, 'tcx> {
                         if ctor_vis.greater_than(field_vis, self.r.tcx) {
                             ctor_vis = field_vis;
                         }
-                        field_visibilities.push(field_vis.to_def_id());
+                        field_visibilities.push(field_vis.to_mod_id());
                     }
                     // If this is a unit or tuple-like struct, register the constructor.
                     let feed = self.create_def(
@@ -940,7 +942,7 @@ impl<'a, 'ra, 'tcx> DefCollector<'a, 'ra, 'tcx> {
                     self.insert_field_visibilities_local(ctor_def_id.to_def_id(), vdata.fields());
 
                     let ctor =
-                        StructCtor { res: ctor_res, vis: ctor_vis.to_def_id(), field_visibilities };
+                        StructCtor { res: ctor_res, vis: ctor_vis.to_mod_id(), field_visibilities };
                     self.r.struct_ctors.insert(local_def_id, ctor);
                 }
                 self.r.struct_generics.insert(local_def_id, generics.clone());
@@ -1154,7 +1156,7 @@ impl<'a, 'ra, 'tcx> DefCollector<'a, 'ra, 'tcx> {
                 root_span: span,
                 span,
                 module_path: Vec::new(),
-                vis: Visibility::Restricted(CRATE_DEF_ID),
+                vis: Visibility::Restricted(CRATE_MOD_ID),
                 vis_span: item.vis.span,
                 on_unknown_attr: OnUnknownData::from_attrs(this.r, &item.attrs),
             })
@@ -1310,11 +1312,11 @@ impl<'a, 'ra, 'tcx> DefCollector<'a, 'ra, 'tcx> {
             let vis = if is_macro_export {
                 Visibility::Public
             } else {
-                Visibility::Restricted(CRATE_DEF_ID)
+                Visibility::Restricted(CRATE_MOD_ID)
             };
             let decl = self.r.arenas.new_def_decl(
                 res,
-                vis.to_def_id(),
+                vis.to_mod_id(),
                 span,
                 expansion,
                 Some(parent_scope.module),
@@ -1516,7 +1518,7 @@ impl<'a, 'ra, 'tcx> DefCollector<'a, 'ra, 'tcx> {
         // If the variant is marked as non_exhaustive then lower the visibility to within the crate.
         let ctor_vis =
             if vis.is_public() && ast::attr::contains_name(&variant.attrs, sym::non_exhaustive) {
-                Visibility::Restricted(CRATE_DEF_ID)
+                Visibility::Restricted(CRATE_MOD_ID)
             } else {
                 vis
             };

--- a/compiler/rustc_resolve/src/diagnostics/impls.rs
+++ b/compiler/rustc_resolve/src/diagnostics/impls.rs
@@ -32,6 +32,7 @@ use rustc_session::lint::builtin::{
     AMBIGUOUS_PANIC_IMPORTS, MACRO_EXPANDED_MACRO_EXPORTS_ACCESSED_BY_ABSOLUTE_PATHS,
 };
 use rustc_session::utils::was_invoked_from_cargo;
+use rustc_span::def_id::ModId;
 use rustc_span::edit_distance::find_best_match_for_name;
 use rustc_span::edition::Edition;
 use rustc_span::hygiene::MacroKind;
@@ -68,8 +69,8 @@ pub(crate) type LabelSuggestion = (Ident, bool);
 #[derive(Clone)]
 pub(crate) struct StructCtor {
     pub res: Res,
-    pub vis: Visibility<DefId>,
-    pub field_visibilities: Vec<Visibility<DefId>>,
+    pub vis: Visibility<ModId>,
+    pub field_visibilities: Vec<Visibility<ModId>>,
 }
 
 impl StructCtor {
@@ -1991,7 +1992,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 }
                 return;
             }
-            if Some(parent_nearest) == scope.opt_def_id() {
+            if Some(parent_nearest.to_def_id()) == scope.opt_def_id() {
                 err.subdiagnostic(MacroDefinedLater { span: unused_ident.span });
                 err.subdiagnostic(MacroSuggMovePosition { span: ident.span, ident });
                 return;

--- a/compiler/rustc_resolve/src/effective_visibilities.rs
+++ b/compiler/rustc_resolve/src/effective_visibilities.rs
@@ -7,6 +7,7 @@ use rustc_hir::def::{DefKind, Res};
 use rustc_hir::def_id::{CRATE_DEF_ID, LocalDefId};
 use rustc_middle::middle::privacy::{EffectiveVisibilities, EffectiveVisibility, Level};
 use rustc_middle::ty::Visibility;
+use rustc_span::def_id::{CRATE_MOD_ID, LocalModId};
 use rustc_span::sym;
 use tracing::info;
 
@@ -55,7 +56,7 @@ pub(crate) struct EffectiveVisibilitiesVisitor<'a, 'ra, 'tcx> {
 impl Resolver<'_, '_> {
     fn private_vis_decl(&self, decl: Decl<'_>) -> Visibility {
         Visibility::Restricted(
-            decl.parent_module.map_or(CRATE_DEF_ID, |m| m.nearest_parent_mod().expect_local()),
+            decl.parent_module.map_or(CRATE_MOD_ID, |m| m.nearest_parent_mod().expect_local()),
         )
     }
 
@@ -65,8 +66,8 @@ impl Resolver<'_, '_> {
             .get_nearest_non_block_module(def_id.to_def_id())
             .nearest_parent_mod()
             .expect_local();
-        if normal_mod_id == def_id {
-            Visibility::Restricted(self.tcx.local_parent(def_id))
+        if normal_mod_id.to_local_def_id() == def_id {
+            Visibility::Restricted(LocalModId::new_unchecked(self.tcx.local_parent(def_id)))
         } else {
             Visibility::Restricted(normal_mod_id)
         }
@@ -85,7 +86,7 @@ impl<'a, 'ra, 'tcx> EffectiveVisibilitiesVisitor<'a, 'ra, 'tcx> {
             r,
             def_effective_visibilities: Default::default(),
             import_effective_visibilities: Default::default(),
-            current_private_vis: Visibility::Restricted(CRATE_DEF_ID),
+            current_private_vis: Visibility::Restricted(CRATE_MOD_ID),
             macro_reachable: Default::default(),
             changed: true,
         };
@@ -230,7 +231,7 @@ impl<'a, 'ra, 'tcx> EffectiveVisibilitiesVisitor<'a, 'ra, 'tcx> {
     fn update_macro(&mut self, def_id: LocalDefId, inherited_effective_vis: EffectiveVisibility) {
         let max_vis = Some(self.r.tcx.local_visibility(def_id));
         let priv_vis = if def_id == CRATE_DEF_ID {
-            Visibility::Restricted(CRATE_DEF_ID)
+            Visibility::Restricted(CRATE_MOD_ID)
         } else {
             self.r.private_vis_def(def_id)
         };
@@ -352,8 +353,10 @@ impl<'a, 'ra, 'tcx> Visitor<'a> for EffectiveVisibilitiesVisitor<'a, 'ra, 'tcx> 
             ),
 
             ast::ItemKind::Mod(..) => {
-                let prev_private_vis =
-                    mem::replace(&mut self.current_private_vis, Visibility::Restricted(def_id));
+                let prev_private_vis = mem::replace(
+                    &mut self.current_private_vis,
+                    Visibility::Restricted(LocalModId::new_unchecked(def_id)),
+                );
                 self.set_bindings_effective_visibilities(def_id);
                 visit::walk_item(self, item);
                 self.current_private_vis = prev_private_vis;

--- a/compiler/rustc_resolve/src/ident.rs
+++ b/compiler/rustc_resolve/src/ident.rs
@@ -1831,7 +1831,9 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
     ) -> PathResult<'ra> {
         let mut module = None;
         let mut module_had_parse_errors = !self.mods_with_parse_errors.is_empty()
-            && self.mods_with_parse_errors.contains(&parent_scope.module.nearest_parent_mod());
+            && self
+                .mods_with_parse_errors
+                .contains(&parent_scope.module.nearest_parent_mod().to_def_id());
         let mut allow_super = true;
         let mut second_binding = None;
 

--- a/compiler/rustc_resolve/src/imports.rs
+++ b/compiler/rustc_resolve/src/imports.rs
@@ -473,7 +473,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             kind: DeclKind::Import { source_decl: decl, import },
             ambiguity: CmCell::new(None),
             span: import.span,
-            initial_vis: vis.to_def_id(),
+            initial_vis: vis.to_mod_id(),
             ambiguity_vis_max: CmCell::new(None),
             ambiguity_vis_min: CmCell::new(None),
             expansion: import.parent_scope.expansion,
@@ -1646,7 +1646,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         ns: Namespace,
     ) -> Option<BufferedEarlyLint> {
         let crate_private_reexport = match decl.vis() {
-            Visibility::Restricted(def_id) if def_id.is_top_level_module() => true,
+            Visibility::Restricted(mod_id) if mod_id.is_top_level_module() => true,
             _ => false,
         };
 

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -71,6 +71,7 @@ use rustc_middle::ty::{
 use rustc_middle::{bug, span_bug};
 use rustc_session::config::CrateType;
 use rustc_session::lint::builtin::PRIVATE_MACRO_USE;
+use rustc_span::def_id::{LocalModId, ModId};
 use rustc_span::hygiene::{ExpnId, LocalExpnId, MacroKind, SyntaxContext, Transparency};
 use rustc_span::{DUMMY_SP, Ident, Span, Symbol, kw, sym};
 use smallvec::{SmallVec, smallvec};
@@ -706,7 +707,7 @@ impl<'ra> ModuleData<'ra> {
         expansion: ExpnId,
         span: Span,
         no_implicit_prelude: bool,
-        vis: Visibility<DefId>,
+        vis: Visibility<ModId>,
         arenas: &'ra ResolverArenas<'ra>,
     ) -> Self {
         let is_foreign = !kind.is_local();
@@ -840,11 +841,11 @@ impl<'ra> Module<'ra> {
         }
     }
 
-    /// The [`DefId`] of the nearest `mod` item ancestor (which may be this module).
+    /// The [`ModId`] of the nearest `mod` item ancestor (which may be this module).
     /// This may be the crate root.
-    fn nearest_parent_mod(self) -> DefId {
+    fn nearest_parent_mod(self) -> ModId {
         match self.kind {
-            ModuleKind::Def(DefKind::Mod, def_id, _, _) => def_id,
+            ModuleKind::Def(DefKind::Mod, def_id, _, _) => ModId::new_unchecked(def_id),
             _ => self.parent.expect("non-root module without parent").nearest_parent_mod(),
         }
     }
@@ -894,7 +895,7 @@ impl<'ra> LocalModule<'ra> {
     fn new(
         parent: Option<LocalModule<'ra>>,
         kind: ModuleKind,
-        vis: Visibility<DefId>,
+        vis: Visibility<ModId>,
         expn_id: ExpnId,
         span: Span,
         no_implicit_prelude: bool,
@@ -916,7 +917,7 @@ impl<'ra> ExternModule<'ra> {
     fn new(
         parent: Option<ExternModule<'ra>>,
         kind: ModuleKind,
-        vis: Visibility<DefId>,
+        vis: Visibility<ModId>,
         expn_id: ExpnId,
         span: Span,
         no_implicit_prelude: bool,
@@ -980,7 +981,7 @@ struct DeclData<'ra> {
     ambiguity: CmCell<Option<(Decl<'ra>, bool /*warning*/)>>,
     expansion: LocalExpnId,
     span: Span,
-    initial_vis: Visibility<DefId>,
+    initial_vis: Visibility<ModId>,
     /// If the declaration refers to an ambiguous glob set, then this is the most visible
     /// declaration from the set, if its visibility is different from `initial_vis`.
     ambiguity_vis_max: CmCell<Option<Decl<'ra>>>,
@@ -1099,12 +1100,12 @@ struct AmbiguityError<'ra> {
 }
 
 impl<'ra> DeclData<'ra> {
-    fn vis(&self) -> Visibility<DefId> {
+    fn vis(&self) -> Visibility<ModId> {
         // Select the maximum visibility if there are multiple ambiguous glob imports.
         self.ambiguity_vis_max.get().map(|d| d.vis()).unwrap_or_else(|| self.initial_vis)
     }
 
-    fn min_vis(&self) -> Visibility<DefId> {
+    fn min_vis(&self) -> Visibility<ModId> {
         // Select the minimum visibility if there are multiple ambiguous glob imports.
         self.ambiguity_vis_min.get().map(|d| d.vis()).unwrap_or_else(|| self.initial_vis)
     }
@@ -1490,8 +1491,8 @@ pub struct Resolver<'ra, 'tcx> {
     effective_visibilities: EffectiveVisibilities,
     macro_reachable_adts: FxIndexMap<LocalDefId, FxIndexSet<LocalDefId>>,
 
-    doc_link_resolutions: FxIndexMap<LocalDefId, DocLinkResMap>,
-    doc_link_traits_in_scope: FxIndexMap<LocalDefId, Vec<DefId>>,
+    doc_link_resolutions: FxIndexMap<LocalModId, DocLinkResMap>,
+    doc_link_traits_in_scope: FxIndexMap<LocalModId, Vec<DefId>>,
     all_macro_rules: UnordSet<Symbol> = Default::default(),
 
     /// Invocation ids of all glob delegations.
@@ -1539,7 +1540,7 @@ impl<'ra> ResolverArenas<'ra> {
     fn new_def_decl(
         &'ra self,
         res: Res,
-        vis: Visibility<DefId>,
+        vis: Visibility<ModId>,
         span: Span,
         expansion: LocalExpnId,
         parent_module: Option<Module<'ra>>,
@@ -1924,7 +1925,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
     }
 
     fn feed_visibility(&mut self, feed: TyCtxtFeed<'tcx, LocalDefId>, vis: Visibility) {
-        feed.visibility(vis.to_def_id());
+        feed.visibility(vis.to_mod_id());
         self.visibilities_for_hashing.push((feed.def_id(), vis));
     }
 
@@ -2359,10 +2360,10 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
     }
 
     fn resolve_self(&self, ctxt: &mut SyntaxContext, module: Module<'ra>) -> Module<'ra> {
-        let mut module = self.expect_module(module.nearest_parent_mod());
+        let mut module = self.expect_module(module.nearest_parent_mod().to_def_id());
         while module.span.ctxt().normalize_to_macros_2_0() != *ctxt {
             let parent = module.parent.unwrap_or_else(|| self.expn_def_scope(ctxt.remove_mark()));
-            module = self.expect_module(parent.nearest_parent_mod());
+            module = self.expect_module(parent.nearest_parent_mod().to_def_id());
         }
         module
     }
@@ -2749,7 +2750,7 @@ enum Stage {
 #[derive(Copy, Clone, Debug)]
 struct ImportSummary {
     vis: Visibility,
-    nearest_parent_mod: LocalDefId,
+    nearest_parent_mod: LocalModId,
     is_single: bool,
     priv_macro_use: bool,
     span: Span,

--- a/compiler/rustc_resolve/src/macros.rs
+++ b/compiler/rustc_resolve/src/macros.rs
@@ -1170,7 +1170,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             && kinds.contains(MacroKinds::BANG)
             // And the `macro_rules` is defined inside the attribute's module,
             // so it cannot be in scope unless imported.
-            && self.tcx.is_descendant_of(def_id, mod_def_id.to_def_id())
+            && self.tcx.is_descendant_of(def_id, mod_def_id)
         {
             // Try to resolve our ident ignoring `macro_rules` scopes.
             // If such resolution is successful and gives the same result

--- a/compiler/rustc_resolve/src/macros.rs
+++ b/compiler/rustc_resolve/src/macros.rs
@@ -28,6 +28,7 @@ use rustc_session::lint::builtin::{
     LEGACY_DERIVE_HELPERS, OUT_OF_SCOPE_MACRO_CALLS, UNKNOWN_DIAGNOSTIC_ATTRIBUTES,
     UNUSED_MACRO_RULES, UNUSED_MACROS,
 };
+use rustc_span::def_id::ModId;
 use rustc_span::edit_distance::find_best_match_for_name;
 use rustc_span::edition::Edition;
 use rustc_span::hygiene::{self, AstPass, ExpnData, ExpnKind, LocalExpnId, MacroKind};
@@ -214,8 +215,8 @@ impl<'ra, 'tcx> ResolverExpand for Resolver<'ra, 'tcx> {
         features: &[Symbol],
         parent_module_id: Option<NodeId>,
     ) -> LocalExpnId {
-        let parent_module =
-            parent_module_id.map(|module_id| self.owner_def_id(module_id).to_def_id());
+        let parent_module = parent_module_id
+            .map(|module_id| ModId::new_unchecked(self.owner_def_id(module_id).to_def_id()));
         let expn_id = self.tcx.with_stable_hashing_context(|hcx| {
             LocalExpnId::fresh(
                 ExpnData::allow_unstable(
@@ -230,8 +231,9 @@ impl<'ra, 'tcx> ResolverExpand for Resolver<'ra, 'tcx> {
             )
         });
 
-        let parent_scope = parent_module
-            .map_or(self.empty_module, |def_id| self.expect_module(def_id).expect_local());
+        let parent_scope = parent_module.map_or(self.empty_module, |def_id| {
+            self.expect_module(def_id.to_def_id()).expect_local()
+        });
         self.ast_transform_scopes.insert(expn_id, parent_scope);
 
         expn_id

--- a/compiler/rustc_span/src/def_id.rs
+++ b/compiler/rustc_span/src/def_id.rs
@@ -465,102 +465,88 @@ impl ToStableHashKey for LocalDefId {
     }
 }
 
-macro_rules! typed_def_id {
-    ($Name:ident, $LocalName:ident) => {
-        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Encodable, Decodable, StableHash)]
-        pub struct $Name(DefId);
-
-        impl $Name {
-            #[inline]
-            pub const fn new_unchecked(def_id: DefId) -> Self {
-                Self(def_id)
-            }
-
-            #[inline]
-            pub fn to_def_id(self) -> DefId {
-                self.into()
-            }
-
-            #[inline]
-            pub fn is_local(self) -> bool {
-                self.0.is_local()
-            }
-
-            #[inline]
-            pub fn as_local(self) -> Option<$LocalName> {
-                self.0.as_local().map($LocalName::new_unchecked)
-            }
-        }
-
-        impl From<$LocalName> for $Name {
-            #[inline]
-            fn from(local: $LocalName) -> Self {
-                Self(local.0.to_def_id())
-            }
-        }
-
-        impl From<$Name> for DefId {
-            #[inline]
-            fn from(typed: $Name) -> Self {
-                typed.0
-            }
-        }
-
-        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Encodable, Decodable, StableHash)]
-        pub struct $LocalName(LocalDefId);
-
-        impl !Ord for $LocalName {}
-        impl !PartialOrd for $LocalName {}
-
-        impl $LocalName {
-            #[inline]
-            pub const fn new_unchecked(def_id: LocalDefId) -> Self {
-                Self(def_id)
-            }
-
-            #[inline]
-            pub fn to_def_id(self) -> DefId {
-                self.0.into()
-            }
-
-            #[inline]
-            pub fn to_local_def_id(self) -> LocalDefId {
-                self.0
-            }
-        }
-
-        impl From<$LocalName> for LocalDefId {
-            #[inline]
-            fn from(typed: $LocalName) -> Self {
-                typed.0
-            }
-        }
-
-        impl From<$LocalName> for DefId {
-            #[inline]
-            fn from(typed: $LocalName) -> Self {
-                typed.0.into()
-            }
-        }
-    };
-}
-
-// N.B.: when adding new typed `DefId`s update the corresponding trait impls in
-// `rustc_middle::dep_graph::dep_node_key` for `DepNodeKey`.
-typed_def_id! { ModDefId, LocalModDefId }
-
-impl LocalModDefId {
-    pub const CRATE_DEF_ID: Self = Self::new_unchecked(CRATE_DEF_ID);
-}
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Encodable, Decodable, StableHash)]
+pub struct ModDefId(DefId);
 
 impl ModDefId {
+    #[inline]
+    pub const fn new_unchecked(def_id: DefId) -> Self {
+        Self(def_id)
+    }
+
+    #[inline]
+    pub fn to_def_id(self) -> DefId {
+        self.into()
+    }
+
+    #[inline]
+    pub fn is_local(self) -> bool {
+        self.0.is_local()
+    }
+
+    #[inline]
+    pub fn as_local(self) -> Option<LocalModDefId> {
+        self.0.as_local().map(LocalModDefId::new_unchecked)
+    }
+
     pub fn is_top_level_module(self) -> bool {
         self.0.is_top_level_module()
     }
 }
 
+impl From<LocalModDefId> for ModDefId {
+    #[inline]
+    fn from(local: LocalModDefId) -> Self {
+        Self(local.0.to_def_id())
+    }
+}
+
+impl From<ModDefId> for DefId {
+    #[inline]
+    fn from(typed: ModDefId) -> Self {
+        typed.0
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Encodable, Decodable, StableHash)]
+pub struct LocalModDefId(LocalDefId);
+
+impl !Ord for LocalModDefId {}
+impl !PartialOrd for LocalModDefId {}
+
 impl LocalModDefId {
+    pub const CRATE_DEF_ID: Self = Self::new_unchecked(CRATE_DEF_ID);
+
+    #[inline]
+    pub const fn new_unchecked(def_id: LocalDefId) -> Self {
+        Self(def_id)
+    }
+
     pub fn is_top_level_module(self) -> bool {
         self.0.is_top_level_module()
+    }
+
+    #[inline]
+    pub fn to_def_id(self) -> DefId {
+        self.0.into()
+    }
+
+    #[inline]
+    pub fn to_local_def_id(self) -> LocalDefId {
+        self.0
+    }
+}
+
+impl From<LocalModDefId> for LocalDefId {
+    #[inline]
+    fn from(typed: LocalModDefId) -> Self {
+        typed.0
+    }
+}
+
+impl From<LocalModDefId> for DefId {
+    #[inline]
+    fn from(typed: LocalModDefId) -> Self {
+        typed.0.into()
     }
 }

--- a/compiler/rustc_span/src/def_id.rs
+++ b/compiler/rustc_span/src/def_id.rs
@@ -40,8 +40,8 @@ impl CrateNum {
     }
 
     #[inline]
-    pub fn as_mod_def_id(self) -> ModDefId {
-        ModDefId::new_unchecked(DefId { krate: self, index: CRATE_DEF_INDEX })
+    pub fn as_mod_id(self) -> ModId {
+        ModId::new_unchecked(DefId { krate: self, index: CRATE_DEF_INDEX })
     }
 }
 
@@ -377,6 +377,7 @@ impl !Ord for LocalDefId {}
 impl !PartialOrd for LocalDefId {}
 
 pub const CRATE_DEF_ID: LocalDefId = LocalDefId { local_def_index: CRATE_DEF_INDEX };
+pub const CRATE_MOD_ID: LocalModId = LocalModId::new_unchecked(CRATE_DEF_ID);
 
 impl Idx for LocalDefId {
     #[inline]
@@ -466,9 +467,9 @@ impl ToStableHashKey for LocalDefId {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Encodable, Decodable, StableHash)]
-pub struct ModDefId(DefId);
+pub struct ModId(DefId);
 
-impl ModDefId {
+impl ModId {
     #[inline]
     pub const fn new_unchecked(def_id: DefId) -> Self {
         Self(def_id)
@@ -485,8 +486,8 @@ impl ModDefId {
     }
 
     #[inline]
-    pub fn as_local(self) -> Option<LocalModDefId> {
-        self.0.as_local().map(LocalModDefId::new_unchecked)
+    pub fn as_local(self) -> Option<LocalModId> {
+        self.0.as_local().map(LocalModId::new_unchecked)
     }
 
     pub fn is_top_level_module(self) -> bool {
@@ -494,29 +495,27 @@ impl ModDefId {
     }
 }
 
-impl From<LocalModDefId> for ModDefId {
+impl From<LocalModId> for ModId {
     #[inline]
-    fn from(local: LocalModDefId) -> Self {
+    fn from(local: LocalModId) -> Self {
         Self(local.0.to_def_id())
     }
 }
 
-impl From<ModDefId> for DefId {
+impl From<ModId> for DefId {
     #[inline]
-    fn from(typed: ModDefId) -> Self {
+    fn from(typed: ModId) -> Self {
         typed.0
     }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Encodable, Decodable, StableHash)]
-pub struct LocalModDefId(LocalDefId);
+pub struct LocalModId(LocalDefId);
 
-impl !Ord for LocalModDefId {}
-impl !PartialOrd for LocalModDefId {}
+impl !Ord for LocalModId {}
+impl !PartialOrd for LocalModId {}
 
-impl LocalModDefId {
-    pub const CRATE_DEF_ID: Self = Self::new_unchecked(CRATE_DEF_ID);
-
+impl LocalModId {
     #[inline]
     pub const fn new_unchecked(def_id: LocalDefId) -> Self {
         Self(def_id)
@@ -537,16 +536,16 @@ impl LocalModDefId {
     }
 }
 
-impl From<LocalModDefId> for LocalDefId {
+impl From<LocalModId> for LocalDefId {
     #[inline]
-    fn from(typed: LocalModDefId) -> Self {
+    fn from(typed: LocalModId) -> Self {
         typed.0
     }
 }
 
-impl From<LocalModDefId> for DefId {
+impl From<LocalModId> for DefId {
     #[inline]
-    fn from(typed: LocalModDefId) -> Self {
+    fn from(typed: LocalModId) -> Self {
         typed.0.into()
     }
 }

--- a/compiler/rustc_span/src/def_id.rs
+++ b/compiler/rustc_span/src/def_id.rs
@@ -494,6 +494,10 @@ impl ModId {
         LocalModId::new_unchecked(self.0.expect_local())
     }
 
+    pub fn is_crate_root(self) -> bool {
+        self.0.is_crate_root()
+    }
+
     pub fn is_top_level_module(self) -> bool {
         self.0.is_top_level_module()
     }

--- a/compiler/rustc_span/src/def_id.rs
+++ b/compiler/rustc_span/src/def_id.rs
@@ -490,6 +490,10 @@ impl ModId {
         self.0.as_local().map(LocalModId::new_unchecked)
     }
 
+    pub fn expect_local(self) -> LocalModId {
+        LocalModId::new_unchecked(self.0.expect_local())
+    }
+
     pub fn is_top_level_module(self) -> bool {
         self.0.is_top_level_module()
     }
@@ -528,6 +532,10 @@ impl LocalModId {
     #[inline]
     pub fn to_def_id(self) -> DefId {
         self.0.into()
+    }
+
+    pub fn to_mod_id(self) -> ModId {
+        ModId::new_unchecked(self.0.to_def_id())
     }
 
     #[inline]

--- a/compiler/rustc_span/src/hygiene.rs
+++ b/compiler/rustc_span/src/hygiene.rs
@@ -41,7 +41,7 @@ use rustc_macros::{Decodable, Encodable, StableHash};
 use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
 use tracing::{debug, trace};
 
-use crate::def_id::{CRATE_DEF_ID, CrateNum, DefId, LOCAL_CRATE, StableCrateId};
+use crate::def_id::{CRATE_DEF_ID, CrateNum, DefId, LOCAL_CRATE, ModId, StableCrateId};
 use crate::edition::Edition;
 use crate::source_map::SourceMap;
 use crate::symbol::{Symbol, kw, sym};
@@ -1012,7 +1012,7 @@ pub struct ExpnData {
     /// if this `ExpnData` corresponds to a macro invocation
     pub macro_def_id: Option<DefId>,
     /// The normal module (`mod`) in which the expanded macro was defined.
-    pub parent_module: Option<DefId>,
+    pub parent_module: Option<ModId>,
     /// Suppresses the `unsafe_code` lint for code produced by this macro.
     pub(crate) allow_internal_unsafe: bool,
     /// Enables the macro helper hack (`ident!(...)` -> `$crate::ident!(...)`) for this macro.
@@ -1036,7 +1036,7 @@ impl ExpnData {
         allow_internal_unstable: Option<Arc<[Symbol]>>,
         edition: Edition,
         macro_def_id: Option<DefId>,
-        parent_module: Option<DefId>,
+        parent_module: Option<ModId>,
         allow_internal_unsafe: bool,
         local_inner_macros: bool,
         collapse_debuginfo: bool,
@@ -1065,7 +1065,7 @@ impl ExpnData {
         call_site: Span,
         edition: Edition,
         macro_def_id: Option<DefId>,
-        parent_module: Option<DefId>,
+        parent_module: Option<ModId>,
     ) -> ExpnData {
         ExpnData {
             kind,
@@ -1090,7 +1090,7 @@ impl ExpnData {
         edition: Edition,
         allow_internal_unstable: Arc<[Symbol]>,
         macro_def_id: Option<DefId>,
-        parent_module: Option<DefId>,
+        parent_module: Option<ModId>,
     ) -> ExpnData {
         ExpnData {
             allow_internal_unstable: Some(allow_internal_unstable),

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/region.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/region.rs
@@ -833,7 +833,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                         None => generic_param_scope,
                     },
                 };
-                match self.tcx.is_descendant_of(type_scope.into(), lifetime_scope.into()) {
+                match self.tcx.is_descendant_of(type_scope, lifetime_scope) {
                     true => type_scope,
                     false => lifetime_scope,
                 }

--- a/compiler/rustc_trait_selection/src/traits/effects.rs
+++ b/compiler/rustc_trait_selection/src/traits/effects.rs
@@ -601,7 +601,8 @@ fn evaluate_host_effect_from_selection_candidate<'tcx>(
                     match tcx.impl_trait_header(impl_.impl_def_id).constness {
                         rustc_hir::Constness::Const { always } => {
                             if always {
-                                unimplemented!()
+                                // FIXME(comptime): just bailing for now to avoid an ICE in a test.
+                                return Err(EvaluationFailure::NoSolution);
                             }
                         }
                         rustc_hir::Constness::NotConst => {

--- a/compiler/rustc_ty_utils/src/instance.rs
+++ b/compiler/rustc_ty_utils/src/instance.rs
@@ -1,5 +1,6 @@
 use rustc_errors::ErrorGuaranteed;
 use rustc_hir::LangItem;
+use rustc_hir::def::DefKind;
 use rustc_hir::def_id::DefId;
 use rustc_infer::infer::TyCtxtInferExt;
 use rustc_middle::bug;
@@ -91,6 +92,12 @@ fn resolve_instance_raw<'tcx>(
         } else if tcx.is_async_drop_in_place_coroutine(def_id) {
             let ty = args.type_at(0);
             ty::InstanceKind::Shim(ty::ShimKind::AsyncDropGlue(def_id, ty))
+        } else if tcx.def_kind(def_id) == DefKind::Fn
+            && let Some(name) = tcx.codegen_fn_attrs(def_id).symbol_name
+            && name.as_str().starts_with("llvm.")
+        {
+            debug!(" => LLVM intrinsic");
+            ty::InstanceKind::LlvmIntrinsic(def_id)
         } else {
             debug!(" => free item");
             ty::InstanceKind::Item(def_id)

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -906,16 +906,12 @@ impl<T> [T] {
     #[inline]
     #[track_caller]
     pub const fn swap(&mut self, a: usize, b: usize) {
-        // FIXME: use swap_unchecked here (https://github.com/rust-lang/rust/pull/88540#issuecomment-944344343)
-        // Can't take two mutable loans from one vector, so instead use raw pointers.
-        let pa = &raw mut self[a];
-        let pb = &raw mut self[b];
-        // SAFETY: `pa` and `pb` have been created from safe mutable references and refer
-        // to elements in the slice and therefore are guaranteed to be valid and aligned.
-        // Note that accessing the elements behind `a` and `b` is checked and will
-        // panic when out of bounds.
+        // Bounds checks that panic exactly like indexing would.
+        let _ = &self[a];
+        let _ = &self[b];
+        // SAFETY: `a` and `b` were checked to be in bounds above.
         unsafe {
-            ptr::swap(pa, pb);
+            self.swap_unchecked(a, b);
         }
     }
 

--- a/library/std/src/sync/once.rs
+++ b/library/std/src/sync/once.rs
@@ -296,6 +296,7 @@ impl Once {
     /// If this [`Once`] has been poisoned because an initialization closure has
     /// panicked, this method will also panic. Use [`wait_force`](Self::wait_force)
     /// if this behavior is not desired.
+    #[inline]
     #[stable(feature = "once_wait", since = "1.86.0")]
     #[rustc_should_not_be_called_on_const_items]
     pub fn wait(&self) {
@@ -309,6 +310,7 @@ impl Once {
     ///
     /// If this [`Once`] has been poisoned, this function blocks until it
     /// becomes completed, unlike [`Once::wait()`], which panics in this case.
+    #[inline]
     #[stable(feature = "once_wait", since = "1.86.0")]
     #[rustc_should_not_be_called_on_const_items]
     pub fn wait_force(&self) {

--- a/src/bootstrap/src/core/build_steps/check.rs
+++ b/src/bootstrap/src/core/build_steps/check.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 
 use crate::core::build_steps::compile::{
     ArtifactKeepMode, add_to_sysroot, run_cargo, rustc_cargo, rustc_cargo_env, std_cargo,
-    std_crates_for_run_make,
+    std_crates_for_make_run,
 };
 use crate::core::build_steps::tool;
 use crate::core::build_steps::tool::{
@@ -68,7 +68,7 @@ impl Step for Std {
         // Explicitly pass -p for all dependencies crates -- this will force cargo
         // to also check the tests/benches/examples for these crates, rather
         // than just the leaf crate.
-        let crates = std_crates_for_run_make(&run);
+        let crates = std_crates_for_make_run(&run);
         run.builder.ensure(Std {
             build_compiler: prepare_compiler_for_check(run.builder, run.target, Mode::Std)
                 .build_compiler(),

--- a/src/bootstrap/src/core/build_steps/clippy.rs
+++ b/src/bootstrap/src/core/build_steps/clippy.rs
@@ -13,11 +13,12 @@
 //! to pass a prebuilt Clippy from the outside when running `cargo clippy`, but that would be
 //! (as usual) a massive undertaking/refactoring.
 
-use super::compile::{ArtifactKeepMode, run_cargo, rustc_cargo, std_cargo};
 use super::tool::{SourceType, prepare_tool_cargo};
 use crate::builder::{Builder, ShouldRun};
 use crate::core::build_steps::check::{CompilerForCheck, prepare_compiler_for_check};
-use crate::core::build_steps::compile::std_crates_for_run_make;
+use crate::core::build_steps::compile::{
+    ArtifactKeepMode, run_cargo, rustc_cargo, std_cargo, std_crates_for_make_run,
+};
 use crate::core::builder;
 use crate::core::builder::{Alias, Kind, RunConfig, Step, StepMetadata, crate_description};
 use crate::utils::build_stamp::{self, BuildStamp};
@@ -178,7 +179,7 @@ impl Step for Std {
     }
 
     fn make_run(run: RunConfig<'_>) {
-        let crates = std_crates_for_run_make(&run);
+        let crates = std_crates_for_make_run(&run);
         let config = LintConfig::new(run.builder);
         run.builder.ensure(Std::new(run.builder, run.target, config, crates));
     }

--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -122,7 +122,7 @@ impl Step for Std {
     }
 
     fn make_run(run: RunConfig<'_>) {
-        let crates = std_crates_for_run_make(&run);
+        let crates = std_crates_for_make_run(&run);
         let builder = run.builder;
 
         // Force compilation of the standard library from source if the `library` is modified. This allows
@@ -479,9 +479,9 @@ fn copy_self_contained_objects(
     target_deps
 }
 
-/// Resolves standard library crates for `Std::run_make` for any build kind (like check, doc,
+/// Resolves standard library crates for [`Std::make_run`] for any build kind (like check, doc,
 /// build, clippy, etc.).
-pub fn std_crates_for_run_make(run: &RunConfig<'_>) -> Vec<String> {
+pub fn std_crates_for_make_run(run: &RunConfig<'_>) -> Vec<String> {
     let mut crates = run.make_run_crates(builder::Alias::Library);
 
     // For no_std targets, we only want to check core and alloc

--- a/src/bootstrap/src/core/build_steps/doc.rs
+++ b/src/bootstrap/src/core/build_steps/doc.rs
@@ -667,7 +667,7 @@ impl Step for Std {
     }
 
     fn make_run(run: RunConfig<'_>) {
-        let crates = compile::std_crates_for_run_make(&run);
+        let crates = compile::std_crates_for_make_run(&run);
         let target_is_no_std = run.builder.no_std(run.target).unwrap_or(false);
         if crates.is_empty() && target_is_no_std {
             return;

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -1085,10 +1085,12 @@ impl Step for IntrinsicTest {
         cmd.env("CFLAGS", cflags);
         // intrinsic-test shells out to `cargo` and `rustfmt` make bootstrap's
         // managed binaries findable by prepending their dirs to PATH.
-        let rustfmt_path = builder.config.initial_rustfmt.clone().unwrap_or_else(|| {
-            eprintln!("intrinsic-test: rustfmt is required but not available on this channel");
-            crate::exit!(1);
-        });
+        let Some(rustfmt_path) = builder.config.initial_rustfmt.clone() else {
+            eprintln!(
+                "WARNING: intrinsic-test skipped because rustfmt is required but not available on this channel"
+            );
+            return;
+        };
 
         let mut path_dirs: Vec<PathBuf> = Vec::new();
         if let Some(cargo_dir) = builder.initial_cargo.parent() {

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use rustc_data_structures::fx::FxHashSet;
 use rustc_data_structures::thin_vec::{ThinVec, thin_vec};
 use rustc_hir::def::{DefKind, MacroKinds, Res};
-use rustc_hir::def_id::{DefId, DefIdSet, LocalDefId, LocalModDefId};
+use rustc_hir::def_id::{DefId, DefIdSet, LocalDefId, LocalModId};
 use rustc_hir::{self as hir, Mutability, find_attr};
 use rustc_metadata::creader::{CStore, LoadedMacro};
 use rustc_middle::ty::fast_reject::SimplifiedType;
@@ -181,7 +181,7 @@ pub(crate) fn try_inline(
 pub(crate) fn try_inline_glob(
     cx: &mut DocContext<'_>,
     res: Res,
-    current_mod: LocalModDefId,
+    current_mod: LocalModId,
     visited: &mut DefIdSet,
     inlined_names: &mut FxHashSet<(ItemType, Symbol)>,
     import: &hir::Item<'_>,

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -25,7 +25,7 @@ use rustc_resolve::rustdoc::{
     DocFragment, add_doc_fragment, attrs_to_doc_fragments, inner_docs, span_of_fragments,
 };
 use rustc_session::Session;
-use rustc_span::def_id::CRATE_DEF_ID;
+use rustc_span::def_id::{CRATE_DEF_ID, ModId};
 use rustc_span::hygiene::MacroKind;
 use rustc_span::symbol::{Symbol, kw, sym};
 use rustc_span::{DUMMY_SP, FileName, Ident, Loc, RemapPathScopeComponents};
@@ -871,7 +871,7 @@ impl Item {
 
     /// Returns the visibility of the current item. If the visibility is "inherited", then `None`
     /// is returned.
-    pub(crate) fn visibility(&self, tcx: TyCtxt<'_>) -> Option<Visibility<DefId>> {
+    pub(crate) fn visibility(&self, tcx: TyCtxt<'_>) -> Option<Visibility<ModId>> {
         let def_id = match self.item_id {
             // Anything but DefId *shouldn't* matter, but return a reasonable value anyway.
             ItemId::Auto { .. } | ItemId::Blanket { .. } => return None,

--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -16,6 +16,7 @@ use rustc_hir::find_attr;
 use rustc_metadata::rendered_const;
 use rustc_middle::mir;
 use rustc_middle::ty::{self, GenericArgKind, GenericArgsRef, TyCtxt, TypeVisitableExt};
+use rustc_span::def_id::ModId;
 use rustc_span::symbol::{Symbol, kw, sym};
 use tracing::{debug, warn};
 
@@ -556,17 +557,17 @@ where
 }
 
 /// Find the nearest parent module of a [`DefId`].
-pub(crate) fn find_nearest_parent_module(tcx: TyCtxt<'_>, def_id: DefId) -> Option<DefId> {
+pub(crate) fn find_nearest_parent_module(tcx: TyCtxt<'_>, def_id: DefId) -> Option<ModId> {
     if def_id.is_top_level_module() {
         // The crate root has no parent. Use it as the root instead.
-        Some(def_id)
+        Some(ModId::new_unchecked(def_id))
     } else {
         let mut current = def_id;
         // The immediate parent might not always be a module.
         // Find the first parent which is.
         while let Some(parent) = tcx.opt_parent(current) {
             if tcx.def_kind(parent) == DefKind::Mod {
-                return Some(parent);
+                return Some(ModId::new_unchecked(parent));
             }
             current = parent;
         }

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -1421,29 +1421,29 @@ pub(crate) fn visibility_print_with_space(item: &clean::Item, cx: &Context<'_>) 
 
         match vis {
             ty::Visibility::Public => f.write_str("pub ")?,
-            ty::Visibility::Restricted(vis_did) => {
+            ty::Visibility::Restricted(vis_mod_id) => {
                 // FIXME(camelid): This may not work correctly if `item_did` is a module.
                 //                 However, rustdoc currently never displays a module's
                 //                 visibility, so it shouldn't matter.
                 let parent_module =
                     find_nearest_parent_module(cx.tcx(), item.item_id.expect_def_id());
 
-                if vis_did.is_crate_root() {
+                if vis_mod_id.is_crate_root() {
                     f.write_str("pub(crate) ")?;
-                } else if parent_module == Some(vis_did) {
+                } else if parent_module == Some(vis_mod_id) {
                     // `pub(in foo)` where `foo` is the parent module
                     // is the same as no visibility modifier; do nothing
                 } else if parent_module
-                    .and_then(|parent| find_nearest_parent_module(cx.tcx(), parent))
-                    == Some(vis_did)
+                    .and_then(|parent| find_nearest_parent_module(cx.tcx(), parent.to_def_id()))
+                    == Some(vis_mod_id)
                 {
                     f.write_str("pub(super) ")?;
                 } else {
-                    let path = cx.tcx().def_path(vis_did);
+                    let path = cx.tcx().def_path(vis_mod_id.to_def_id());
                     debug!("path={path:?}");
                     // modified from `resolved_path()` to work with `DefPathData`
                     let last_name = path.data.last().unwrap().data.get_opt_name().unwrap();
-                    let anchor = print_anchor(vis_did, last_name, cx);
+                    let anchor = print_anchor(vis_mod_id.to_def_id(), last_name, cx);
 
                     f.write_str("pub(in ")?;
                     for seg in &path.data[..path.data.len() - 1] {

--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -16,6 +16,7 @@ use rustc_hir::{HeaderSafety, Safety, find_attr};
 use rustc_metadata::rendered_const;
 use rustc_middle::ty::TyCtxt;
 use rustc_middle::{bug, ty};
+use rustc_span::def_id::ModId;
 use rustc_span::{Pos, Symbol, kw, sym};
 use rustdoc_json_types::*;
 
@@ -207,15 +208,15 @@ impl FromClean<clean::Span> for Option<Span> {
     }
 }
 
-impl FromClean<Option<ty::Visibility<DefId>>> for Visibility {
-    fn from_clean(v: &Option<ty::Visibility<DefId>>, renderer: &JsonRenderer<'_>) -> Self {
-        match v {
+impl FromClean<Option<ty::Visibility<ModId>>> for Visibility {
+    fn from_clean(v: &Option<ty::Visibility<ModId>>, renderer: &JsonRenderer<'_>) -> Self {
+        match *v {
             None => Visibility::Default,
             Some(ty::Visibility::Public) => Visibility::Public,
-            Some(ty::Visibility::Restricted(did)) if did.is_crate_root() => Visibility::Crate,
-            Some(ty::Visibility::Restricted(did)) => Visibility::Restricted {
-                parent: renderer.id_from_item_default((*did).into()),
-                path: renderer.tcx.def_path(*did).to_string_no_crate_verbose(),
+            Some(ty::Visibility::Restricted(mod_id)) if mod_id.is_crate_root() => Visibility::Crate,
+            Some(ty::Visibility::Restricted(mod_id)) => Visibility::Restricted {
+                parent: renderer.id_from_item_default(ItemId::DefId(mod_id.to_def_id())),
+                path: renderer.tcx.def_path(mod_id.to_def_id()).to_string_no_crate_verbose(),
             },
         }
     }

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -26,6 +26,7 @@ use rustc_resolve::rustdoc::{
 use rustc_session::config::CrateType;
 use rustc_session::lint::Lint;
 use rustc_span::BytePos;
+use rustc_span::def_id::ModId;
 use rustc_span::symbol::{Ident, Symbol, sym};
 use smallvec::{SmallVec, smallvec};
 use tracing::{debug, info, instrument, trace};
@@ -170,7 +171,7 @@ struct UnresolvedPath<'a> {
     /// Item on which the link is resolved, used for resolving `Self`.
     item_id: DefId,
     /// The scope the link was resolved in.
-    module_id: DefId,
+    module_id: ModId,
     /// If part of the link resolved, this has the `Res`.
     ///
     /// In `[std::io::Error::x]`, `std::io::Error` would be a partial resolution.
@@ -208,7 +209,7 @@ pub(crate) enum UrlFragment {
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub(crate) struct ResolutionInfo {
     item_id: DefId,
-    module_id: DefId,
+    module_id: ModId,
     dis: Option<Disambiguator>,
     path_str: Box<str>,
     extra_fragment: Option<String>,
@@ -286,7 +287,7 @@ impl<'tcx> LinkCollector<'_, 'tcx> {
         &self,
         path_str: &'path str,
         item_id: DefId,
-        module_id: DefId,
+        module_id: ModId,
     ) -> Result<(Res, DefId), UnresolvedPath<'path>> {
         let tcx = self.cx.tcx;
         let no_res = || UnresolvedPath {
@@ -355,7 +356,7 @@ impl<'tcx> LinkCollector<'_, 'tcx> {
         path_str: &str,
         ns: Namespace,
         item_id: DefId,
-        module_id: DefId,
+        module_id: ModId,
     ) -> Option<Res> {
         if let res @ Some(..) = resolve_self_ty(self.cx.tcx, path_str, ns, item_id) {
             return res;
@@ -392,7 +393,7 @@ impl<'tcx> LinkCollector<'_, 'tcx> {
         ns: Namespace,
         disambiguator: Option<Disambiguator>,
         item_id: DefId,
-        module_id: DefId,
+        module_id: ModId,
     ) -> Result<Vec<(Res, Option<DefId>)>, UnresolvedPath<'path>> {
         let tcx = self.cx.tcx;
 
@@ -604,7 +605,7 @@ fn resolve_associated_item<'tcx>(
     item_name: Symbol,
     ns: Namespace,
     disambiguator: Option<Disambiguator>,
-    module_id: DefId,
+    module_id: ModId,
 ) -> Vec<(Res, DefId)> {
     let item_ident = Ident::with_dummy_span(item_name);
 
@@ -665,7 +666,7 @@ fn resolve_assoc_on_primitive<'tcx>(
     prim: PrimitiveType,
     ns: Namespace,
     item_ident: Ident,
-    module_id: DefId,
+    module_id: ModId,
 ) -> Vec<(Res, DefId)> {
     let root_res = Res::Primitive(prim);
     let items = resolve_primitive_inherent_assoc_item(tcx, prim, ns, item_ident);
@@ -690,7 +691,7 @@ fn resolve_assoc_on_adt<'tcx>(
     item_ident: Ident,
     ns: Namespace,
     disambiguator: Option<Disambiguator>,
-    module_id: DefId,
+    module_id: ModId,
 ) -> Vec<(Res, DefId)> {
     debug!("looking for associated item named {item_ident} for item {adt_def_id:?}");
     let root_res = Res::from_def_id(tcx, adt_def_id);
@@ -735,7 +736,7 @@ fn resolve_assoc_on_simple_type<'tcx>(
     ty_def_id: DefId,
     item_ident: Ident,
     ns: Namespace,
-    module_id: DefId,
+    module_id: ModId,
 ) -> Vec<(Res, DefId)> {
     let root_res = Res::from_def_id(tcx, ty_def_id);
     // Checks if item_name belongs to `impl SomeItem`
@@ -781,7 +782,7 @@ fn resolve_structfield<'tcx>(adt_def: ty::AdtDef<'tcx>, item_name: Symbol) -> Op
 /// `<io::Error as error::Error>::source`.
 fn resolve_associated_trait_item<'tcx>(
     ty: Ty<'tcx>,
-    module: DefId,
+    module: ModId,
     item_ident: Ident,
     ns: Namespace,
     tcx: TyCtxt<'tcx>,
@@ -841,7 +842,7 @@ fn trait_assoc_to_impl_assoc_item<'tcx>(
 fn trait_impls_for<'tcx>(
     tcx: TyCtxt<'tcx>,
     ty: Ty<'tcx>,
-    module: DefId,
+    module: ModId,
 ) -> FxIndexSet<(DefId, DefId)> {
     let mut impls = FxIndexSet::default();
 
@@ -1097,7 +1098,7 @@ impl LinkCollector<'_, '_> {
                 return;
             }
             let module_id = match tcx.def_kind(item_id) {
-                DefKind::Mod if item.inner_docs(tcx) => item_id,
+                DefKind::Mod if item.inner_docs(tcx) => ModId::new_unchecked(item_id),
                 _ => find_nearest_parent_module(tcx, item_id).unwrap(),
             };
             for md_link in preprocessed_markdown_links(&doc) {
@@ -1180,7 +1181,7 @@ impl LinkCollector<'_, '_> {
         dox: &str,
         item: &Item,
         item_id: DefId,
-        module_id: DefId,
+        module_id: ModId,
         PreprocessedMarkdownLink(pp_link, ori_link): &PreprocessedMarkdownLink,
     ) -> Option<ItemLink> {
         trace!("considering link '{}'", ori_link.link);
@@ -2112,7 +2113,7 @@ fn resolution_failure(
                     }
 
                     let last_found_module = match *partial_res {
-                        Some(Res::Def(DefKind::Mod, id)) => Some(id),
+                        Some(Res::Def(DefKind::Mod, id)) => Some(ModId::new_unchecked(id)),
                         None => Some(module_id),
                         _ => None,
                     };

--- a/src/librustdoc/passes/lint/redundant_explicit_links.rs
+++ b/src/librustdoc/passes/lint/redundant_explicit_links.rs
@@ -9,7 +9,7 @@ use rustc_resolve::rustdoc::pulldown_cmark::{
     BrokenLink, BrokenLinkCallback, CowStr, Event, LinkType, OffsetIter, Parser, Tag,
 };
 use rustc_resolve::rustdoc::{prepare_to_doc_link_resolution, source_span_for_markdown_range};
-use rustc_span::def_id::DefId;
+use rustc_span::def_id::{DefId, ModId};
 use rustc_span::{Span, Symbol};
 
 use crate::clean::Item;
@@ -58,7 +58,7 @@ fn check_redundant_explicit_link_for_did(
     }
 
     let module_id = match cx.tcx.def_kind(did) {
-        DefKind::Mod if item.inner_docs(cx.tcx) => did,
+        DefKind::Mod if item.inner_docs(cx.tcx) => ModId::new_unchecked(did),
         _ => find_nearest_parent_module(cx.tcx, did).unwrap(),
     };
 

--- a/src/tools/clippy/clippy_lints/src/error_impl_error.rs
+++ b/src/tools/clippy/clippy_lints/src/error_impl_error.rs
@@ -81,7 +81,7 @@ impl<'tcx> LateLintPass<'tcx> for ErrorImplError {
 /// which aren't reexported
 fn is_visible_outside_module(cx: &LateContext<'_>, def_id: LocalDefId) -> bool {
     !matches!(
-        cx.tcx.visibility(def_id),
-        Visibility::Restricted(mod_def_id) if cx.tcx.parent_module_from_def_id(def_id).to_def_id() == mod_def_id
+        cx.tcx.local_visibility(def_id),
+        Visibility::Restricted(mod_def_id) if cx.tcx.parent_module_from_def_id(def_id) == mod_def_id
     )
 }

--- a/src/tools/clippy/clippy_lints/src/infallible_try_from.rs
+++ b/src/tools/clippy/clippy_lints/src/infallible_try_from.rs
@@ -59,7 +59,7 @@ impl<'tcx> LateLintPass<'tcx> for InfallibleTryFrom {
             .filter_by_name_unhygienic_and_kind(sym::Error, AssocTag::Type)
         {
             let ii_ty = cx.tcx.type_of(ii.def_id).instantiate_identity().skip_norm_wip();
-            if !ii_ty.is_inhabited_from(cx.tcx, ii.def_id, cx.typing_env()) {
+            if !ii_ty.is_inhabited_from(cx.tcx, cx.tcx.parent_module_from_def_id(ii.def_id.expect_local()), cx.typing_env()) {
                 let mut span = MultiSpan::from_span(cx.tcx.def_span(item.owner_id.to_def_id()));
                 let ii_ty_span = cx
                     .tcx

--- a/src/tools/clippy/clippy_lints/src/inherent_impl.rs
+++ b/src/tools/clippy/clippy_lints/src/inherent_impl.rs
@@ -3,7 +3,7 @@ use clippy_config::types::InherentImplLintScope;
 use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::{fulfill_or_allowed, is_cfg_test, is_in_cfg_test};
 use rustc_data_structures::fx::FxHashMap;
-use rustc_hir::def_id::{LocalDefId, LocalModDefId};
+use rustc_hir::def_id::{LocalDefId, LocalModId};
 use rustc_hir::{Item, ItemKind, Node};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_session::impl_lint_pass;
@@ -63,7 +63,7 @@ impl MultipleInherentImpl {
 
 #[derive(Hash, Eq, PartialEq, Clone)]
 enum Criterion {
-    Module(LocalModDefId),
+    Module(LocalModId),
     File(FileName),
     Crate,
 }

--- a/src/tools/clippy/clippy_lints/src/redundant_pub_crate.rs
+++ b/src/tools/clippy/clippy_lints/src/redundant_pub_crate.rs
@@ -5,7 +5,7 @@ use rustc_hir::{Item, ItemKind, UseKind};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty;
 use rustc_session::impl_lint_pass;
-use rustc_span::def_id::CRATE_DEF_ID;
+use rustc_span::def_id::CRATE_MOD_ID;
 
 declare_clippy_lint! {
     /// ### What it does
@@ -44,7 +44,7 @@ pub struct RedundantPubCrate {
 
 impl<'tcx> LateLintPass<'tcx> for RedundantPubCrate {
     fn check_item(&mut self, cx: &LateContext<'tcx>, item: &'tcx Item<'tcx>) {
-        if cx.tcx.visibility(item.owner_id.def_id) == ty::Visibility::Restricted(CRATE_DEF_ID.to_def_id())
+        if cx.tcx.local_visibility(item.owner_id.def_id) == ty::Visibility::Restricted(CRATE_MOD_ID)
             && !cx.effective_visibilities.is_exported(item.owner_id.def_id)
             && self.is_exported.last() == Some(&false)
             && !is_ignorable_export(item)

--- a/src/tools/clippy/clippy_lints/src/unused_trait_names.rs
+++ b/src/tools/clippy/clippy_lints/src/unused_trait_names.rs
@@ -68,7 +68,7 @@ impl<'tcx> LateLintPass<'tcx> for UnusedTraitNames {
             && cx.tcx.resolutions(()).maybe_unused_trait_imports.contains(&item.owner_id.def_id)
             // Only check this import if it is visible to its module only (no pub, pub(crate), ...)
             && let module = cx.tcx.parent_module_from_def_id(item.owner_id.def_id)
-            && cx.tcx.visibility(item.owner_id.def_id) == Visibility::Restricted(module.to_def_id())
+            && cx.tcx.local_visibility(item.owner_id.def_id) == Visibility::Restricted(module)
             && let Some(last_segment) = path.segments.last()
             && let Some(snip) = snippet_opt(cx, last_segment.ident.span)
             && self.msrv.meets(cx, msrvs::UNDERSCORE_IMPORTS)

--- a/src/tools/clippy/clippy_lints/src/wildcard_imports.rs
+++ b/src/tools/clippy/clippy_lints/src/wildcard_imports.rs
@@ -123,7 +123,7 @@ impl LateLintPass<'_> for WildcardImports {
         }
 
         let module = cx.tcx.parent_module_from_def_id(item.owner_id.def_id);
-        if cx.tcx.visibility(item.owner_id.def_id) != ty::Visibility::Restricted(module.to_def_id())
+        if cx.tcx.local_visibility(item.owner_id.def_id) != ty::Visibility::Restricted(module)
             && !self.warn_on_all
         {
             return;

--- a/src/tools/clippy/clippy_utils/src/lib.rs
+++ b/src/tools/clippy/clippy_utils/src/lib.rs
@@ -88,7 +88,7 @@ use rustc_data_structures::unhash::UnindexMap;
 use rustc_hir::LangItem::{OptionNone, OptionSome, ResultErr, ResultOk};
 use rustc_hir::attrs::CfgEntry;
 use rustc_hir::def::{DefKind, Res};
-use rustc_hir::def_id::{DefId, LocalDefId, LocalModDefId};
+use rustc_hir::def_id::{DefId, LocalDefId, LocalModId};
 use rustc_hir::definitions::{DefPath, DefPathData};
 use rustc_hir::hir_id::{HirIdMap, HirIdSet};
 use rustc_hir::intravisit::{Visitor, walk_expr};
@@ -2348,11 +2348,11 @@ pub fn is_hir_ty_cfg_dependant(cx: &LateContext<'_>, ty: &hir::Ty<'_>) -> bool {
     false
 }
 
-static TEST_ITEM_NAMES_CACHE: OnceLock<Mutex<FxHashMap<LocalModDefId, Vec<Symbol>>>> = OnceLock::new();
+static TEST_ITEM_NAMES_CACHE: OnceLock<Mutex<FxHashMap<LocalModId, Vec<Symbol>>>> = OnceLock::new();
 
 /// Returns the names of the test items in the given module.
 /// The names are sorted using the default `Symbol` ordering.
-fn test_item_names(tcx: TyCtxt<'_>, module: LocalModDefId) -> Vec<Symbol> {
+fn test_item_names(tcx: TyCtxt<'_>, module: LocalModId) -> Vec<Symbol> {
     let cache = TEST_ITEM_NAMES_CACHE.get_or_init(|| Mutex::new(FxHashMap::default()));
     let mut map = cache.lock().unwrap();
     match map.entry(module) {

--- a/src/tools/miri/src/intrinsics/mod.rs
+++ b/src/tools/miri/src/intrinsics/mod.rs
@@ -10,7 +10,7 @@ pub use self::atomic::AtomicRmwOp;
 use rand::RngExt;
 use rustc_abi::Size;
 use rustc_middle::{mir, ty};
-use rustc_span::Symbol;
+use rustc_span::{Symbol, sym};
 
 use self::atomic::EvalContextExt as _;
 use self::math::EvalContextExt as _;

--- a/src/tools/miri/src/machine.rs
+++ b/src/tools/miri/src/machine.rs
@@ -1301,6 +1301,18 @@ impl<'tcx> Machine<'tcx> for MiriMachine<'tcx> {
     }
 
     #[inline(always)]
+    fn call_llvm_intrinsic(
+        ecx: &mut MiriInterpCx<'tcx>,
+        instance: ty::Instance<'tcx>,
+        args: &[OpTy<'tcx>],
+        dest: &PlaceTy<'tcx>,
+        ret: Option<mir::BasicBlock>,
+        unwind: mir::UnwindAction,
+    ) -> InterpResult<'tcx, ()> {
+        ecx.call_llvm_intrinsic(instance, args, dest, ret, unwind)
+    }
+
+    #[inline(always)]
     fn assert_panic(
         ecx: &mut MiriInterpCx<'tcx>,
         msg: &mir::AssertMessage<'tcx>,

--- a/src/tools/miri/src/machine.rs
+++ b/src/tools/miri/src/machine.rs
@@ -1307,9 +1307,8 @@ impl<'tcx> Machine<'tcx> for MiriMachine<'tcx> {
         args: &[OpTy<'tcx>],
         dest: &PlaceTy<'tcx>,
         ret: Option<mir::BasicBlock>,
-        unwind: mir::UnwindAction,
     ) -> InterpResult<'tcx, ()> {
-        ecx.call_llvm_intrinsic(instance, args, dest, ret, unwind)
+        ecx.call_llvm_intrinsic(instance, args, dest, ret)
     }
 
     #[inline(always)]

--- a/src/tools/miri/src/shims/aarch64.rs
+++ b/src/tools/miri/src/shims/aarch64.rs
@@ -13,7 +13,7 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         link_name: Symbol,
         args: &[OpTy<'tcx>],
         dest: &MPlaceTy<'tcx>,
-    ) -> InterpResult<'tcx, EmulateItemResult> {
+    ) -> InterpResult<'tcx, bool> {
         let this = self.eval_context_mut();
         // Prefix should have already been checked.
         let unprefixed_name = link_name.as_str().strip_prefix("llvm.aarch64.").unwrap();
@@ -273,8 +273,8 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 this.write_scalar(Scalar::from_u128(result), &dest)?;
             }
 
-            _ => return interp_ok(EmulateItemResult::NotSupported),
+            _ => return interp_ok(false),
         }
-        interp_ok(EmulateItemResult::NeedsReturn)
+        interp_ok(true)
     }
 }

--- a/src/tools/miri/src/shims/foreign_items.rs
+++ b/src/tools/miri/src/shims/foreign_items.rs
@@ -249,7 +249,6 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         args: &[OpTy<'tcx>],
         dest: &PlaceTy<'tcx>,
         ret: Option<mir::BasicBlock>,
-        unwind: mir::UnwindAction,
     ) -> InterpResult<'tcx> {
         let this = self.eval_context_mut();
 
@@ -258,7 +257,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         // FIXME: avoid allocating memory
         let dest = this.force_allocation(dest)?;
 
-        let res = match link_name.as_str() {
+        let handled = match link_name.as_str() {
             // LLVM intrinsics
             "llvm.prefetch.p0" => {
                 let [p, rw, loc, ty] = this.check_shim_sig_unadjusted(link_name, args)?;
@@ -285,7 +284,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                     throw_unsup_format!("unsupported `llvm.prefetch` type argument: {}", ty);
                 }
 
-                EmulateItemResult::NeedsReturn
+                true
             }
             // Used to implement the x86 `_mm{,256,512}_popcnt_epi{8,16,32,64}` and wasm
             // `{i,u}8x16_popcnt` functions.
@@ -311,7 +310,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                     )?;
                 }
 
-                EmulateItemResult::NeedsReturn
+                true
             }
 
             // Target-specific shims
@@ -331,26 +330,18 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 shims::loongarch::EvalContextExt::emulate_loongarch_intrinsic(
                     this, link_name, args, &dest,
                 )?,
-            _ => EmulateItemResult::NotSupported,
+            _ => false,
         };
 
         // The rest either implements the logic, or falls back to `lookup_exported_symbol`.
-        match res {
-            EmulateItemResult::NeedsReturn => {
-                trace!("{:?}", this.dump_place(&dest.clone().into()));
-                this.return_to_block(ret)
-            }
-            EmulateItemResult::NeedsUnwind => {
-                // Jump to the unwind block to begin unwinding.
-                this.unwind_to_block(unwind)
-            }
-            EmulateItemResult::AlreadyJumped => interp_ok(()),
-            EmulateItemResult::NotSupported => {
-                throw_machine_stop!(TerminationInfo::UnsupportedForeignItem(format!(
-                    "can't call LLVM intrinsic `{link_name}` on architecture `{arch}`",
-                    arch = this.tcx.sess.target.arch,
-                )));
-            }
+        if handled {
+            trace!("{:?}", this.dump_place(&dest.clone().into()));
+            this.return_to_block(ret)
+        } else {
+            throw_machine_stop!(TerminationInfo::UnsupportedForeignItem(format!(
+                "can't call LLVM intrinsic `{link_name}` on architecture `{arch}`",
+                arch = this.tcx.sess.target.arch,
+            )));
         }
     }
 }

--- a/src/tools/miri/src/shims/foreign_items.rs
+++ b/src/tools/miri/src/shims/foreign_items.rs
@@ -241,6 +241,118 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             Some(instance) => interp_ok(Some((this.load_mir(instance.def, None)?, instance))),
         }
     }
+
+    // FIXME move this and the LLVM intrinsic impls to the intrinsics module
+    fn call_llvm_intrinsic(
+        &mut self,
+        instance: ty::Instance<'tcx>,
+        args: &[OpTy<'tcx>],
+        dest: &PlaceTy<'tcx>,
+        ret: Option<mir::BasicBlock>,
+        unwind: mir::UnwindAction,
+    ) -> InterpResult<'tcx> {
+        let this = self.eval_context_mut();
+
+        let link_name = this.tcx.codegen_fn_attrs(instance.def_id()).symbol_name.unwrap();
+
+        // FIXME: avoid allocating memory
+        let dest = this.force_allocation(dest)?;
+
+        let res = match link_name.as_str() {
+            // LLVM intrinsics
+            "llvm.prefetch.p0" => {
+                let [p, rw, loc, ty] = this.check_shim_sig_unadjusted(link_name, args)?;
+
+                let _ = this.read_pointer(p)?;
+                let rw = this.read_scalar(rw)?.to_i32()?;
+                let loc = this.read_scalar(loc)?.to_i32()?;
+                let ty = this.read_scalar(ty)?.to_i32()?;
+
+                if ty == 1 {
+                    // Data cache prefetch.
+                    // Notably, we do not have to check the pointer, this operation is never UB!
+
+                    if !matches!(rw, 0 | 1) {
+                        throw_unsup_format!("invalid `rw` value passed to `llvm.prefetch`: {}", rw);
+                    }
+                    if !matches!(loc, 0..=3) {
+                        throw_unsup_format!(
+                            "invalid `loc` value passed to `llvm.prefetch`: {}",
+                            loc
+                        );
+                    }
+                } else {
+                    throw_unsup_format!("unsupported `llvm.prefetch` type argument: {}", ty);
+                }
+
+                EmulateItemResult::NeedsReturn
+            }
+            // Used to implement the x86 `_mm{,256,512}_popcnt_epi{8,16,32,64}` and wasm
+            // `{i,u}8x16_popcnt` functions.
+            name if name.starts_with("llvm.ctpop.v")
+                && this.tcx.sess.target.endian == Endian::Little =>
+            {
+                let [op] = this.check_shim_sig_unadjusted(link_name, args)?;
+
+                let (op, op_len) = this.project_to_simd(op)?;
+                let (dest, dest_len) = this.project_to_simd(&dest)?;
+
+                assert_eq!(dest_len, op_len);
+
+                for i in 0..dest_len {
+                    let op = this.read_immediate(&this.project_index(&op, i)?)?;
+                    // Use `to_uint` to get a zero-extended `u128`. Those
+                    // extra zeros will not affect `count_ones`.
+                    let res = op.to_scalar().to_uint(op.layout.size)?.count_ones();
+
+                    this.write_scalar(
+                        Scalar::from_uint(res, op.layout.size),
+                        &this.project_index(&dest, i)?,
+                    )?;
+                }
+
+                EmulateItemResult::NeedsReturn
+            }
+
+            // Target-specific shims
+            name if name.starts_with("llvm.x86.")
+                && matches!(this.tcx.sess.target.arch, Arch::X86 | Arch::X86_64)
+                && this.tcx.sess.target.endian == Endian::Little =>
+                shims::x86::EvalContextExt::emulate_x86_intrinsic(this, link_name, args, &dest)?,
+            name if name.starts_with("llvm.aarch64.")
+                && this.tcx.sess.target.arch == Arch::AArch64
+                && this.tcx.sess.target.endian == Endian::Little =>
+                shims::aarch64::EvalContextExt::emulate_aarch64_intrinsic(
+                    this, link_name, args, &dest,
+                )?,
+            name if name.starts_with("llvm.loongarch.")
+                && matches!(this.tcx.sess.target.arch, Arch::LoongArch32 | Arch::LoongArch64)
+                && this.tcx.sess.target.endian == Endian::Little =>
+                shims::loongarch::EvalContextExt::emulate_loongarch_intrinsic(
+                    this, link_name, args, &dest,
+                )?,
+            _ => EmulateItemResult::NotSupported,
+        };
+
+        // The rest either implements the logic, or falls back to `lookup_exported_symbol`.
+        match res {
+            EmulateItemResult::NeedsReturn => {
+                trace!("{:?}", this.dump_place(&dest.clone().into()));
+                this.return_to_block(ret)
+            }
+            EmulateItemResult::NeedsUnwind => {
+                // Jump to the unwind block to begin unwinding.
+                this.unwind_to_block(unwind)
+            }
+            EmulateItemResult::AlreadyJumped => interp_ok(()),
+            EmulateItemResult::NotSupported => {
+                throw_machine_stop!(TerminationInfo::UnsupportedForeignItem(format!(
+                    "can't call LLVM intrinsic `{link_name}` on architecture `{arch}`",
+                    arch = this.tcx.sess.target.arch,
+                )));
+            }
+        }
+    }
 }
 
 impl<'tcx> EvalContextExtPriv<'tcx> for crate::MiriInterpCx<'tcx> {}
@@ -801,83 +913,6 @@ trait EvalContextExtPriv<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 let bytes = std::iter::repeat_n(val, n.try_into().unwrap());
                 this.write_bytes_ptr(ptr_dest, bytes)?;
                 this.write_pointer(ptr_dest, dest)?;
-            }
-
-            // LLVM intrinsics
-            "llvm.prefetch.p0" => {
-                let [p, rw, loc, ty] = this.check_shim_sig_unadjusted(link_name, args)?;
-
-                let _ = this.read_pointer(p)?;
-                let rw = this.read_scalar(rw)?.to_i32()?;
-                let loc = this.read_scalar(loc)?.to_i32()?;
-                let ty = this.read_scalar(ty)?.to_i32()?;
-
-                if ty == 1 {
-                    // Data cache prefetch.
-                    // Notably, we do not have to check the pointer, this operation is never UB!
-
-                    if !matches!(rw, 0 | 1) {
-                        throw_unsup_format!("invalid `rw` value passed to `llvm.prefetch`: {}", rw);
-                    }
-                    if !matches!(loc, 0..=3) {
-                        throw_unsup_format!(
-                            "invalid `loc` value passed to `llvm.prefetch`: {}",
-                            loc
-                        );
-                    }
-                } else {
-                    throw_unsup_format!("unsupported `llvm.prefetch` type argument: {}", ty);
-                }
-            }
-            // Used to implement the x86 `_mm{,256,512}_popcnt_epi{8,16,32,64}` and wasm
-            // `{i,u}8x16_popcnt` functions.
-            name if name.starts_with("llvm.ctpop.v")
-                && this.tcx.sess.target.endian == Endian::Little =>
-            {
-                let [op] = this.check_shim_sig_unadjusted(link_name, args)?;
-
-                let (op, op_len) = this.project_to_simd(op)?;
-                let (dest, dest_len) = this.project_to_simd(dest)?;
-
-                assert_eq!(dest_len, op_len);
-
-                for i in 0..dest_len {
-                    let op = this.read_immediate(&this.project_index(&op, i)?)?;
-                    // Use `to_uint` to get a zero-extended `u128`. Those
-                    // extra zeros will not affect `count_ones`.
-                    let res = op.to_scalar().to_uint(op.layout.size)?.count_ones();
-
-                    this.write_scalar(
-                        Scalar::from_uint(res, op.layout.size),
-                        &this.project_index(&dest, i)?,
-                    )?;
-                }
-            }
-
-            // Target-specific shims
-            name if name.starts_with("llvm.x86.")
-                && matches!(this.tcx.sess.target.arch, Arch::X86 | Arch::X86_64)
-                && this.tcx.sess.target.endian == Endian::Little =>
-            {
-                return shims::x86::EvalContextExt::emulate_x86_intrinsic(
-                    this, link_name, args, dest,
-                );
-            }
-            name if name.starts_with("llvm.aarch64.")
-                && this.tcx.sess.target.arch == Arch::AArch64
-                && this.tcx.sess.target.endian == Endian::Little =>
-            {
-                return shims::aarch64::EvalContextExt::emulate_aarch64_intrinsic(
-                    this, link_name, args, dest,
-                );
-            }
-            name if name.starts_with("llvm.loongarch.")
-                && matches!(this.tcx.sess.target.arch, Arch::LoongArch32 | Arch::LoongArch64)
-                && this.tcx.sess.target.endian == Endian::Little =>
-            {
-                return shims::loongarch::EvalContextExt::emulate_loongarch_intrinsic(
-                    this, link_name, args, dest,
-                );
             }
 
             // Fallback to shims in submodules.

--- a/src/tools/miri/src/shims/loongarch.rs
+++ b/src/tools/miri/src/shims/loongarch.rs
@@ -11,7 +11,7 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         link_name: Symbol,
         args: &[OpTy<'tcx>],
         dest: &MPlaceTy<'tcx>,
-    ) -> InterpResult<'tcx, EmulateItemResult> {
+    ) -> InterpResult<'tcx, bool> {
         let this = self.eval_context_mut();
         // Prefix should have already been checked.
         let unprefixed_name = link_name.as_str().strip_prefix("llvm.loongarch.").unwrap();
@@ -67,8 +67,8 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 let result = compute_crc32(crc, data, bit_size, polynomial);
                 this.write_scalar(Scalar::from_u32(result), dest)?;
             }
-            _ => return interp_ok(EmulateItemResult::NotSupported),
+            _ => return interp_ok(false),
         }
-        interp_ok(EmulateItemResult::NeedsReturn)
+        interp_ok(true)
     }
 }

--- a/src/tools/miri/src/shims/x86/aesni.rs
+++ b/src/tools/miri/src/shims/x86/aesni.rs
@@ -10,7 +10,7 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         link_name: Symbol,
         args: &[OpTy<'tcx>],
         dest: &MPlaceTy<'tcx>,
-    ) -> InterpResult<'tcx, EmulateItemResult> {
+    ) -> InterpResult<'tcx, bool> {
         let this = self.eval_context_mut();
         this.expect_target_feature_for_intrinsic(link_name, "aes")?;
         // Prefix should have already been checked.
@@ -112,9 +112,9 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             }
             // TODO: Implement the `llvm.x86.aesni.aeskeygenassist` when possible
             // with an external crate.
-            _ => return interp_ok(EmulateItemResult::NotSupported),
+            _ => return interp_ok(false),
         }
-        interp_ok(EmulateItemResult::NeedsReturn)
+        interp_ok(true)
     }
 }
 

--- a/src/tools/miri/src/shims/x86/avx.rs
+++ b/src/tools/miri/src/shims/x86/avx.rs
@@ -14,7 +14,7 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         link_name: Symbol,
         args: &[OpTy<'tcx>],
         dest: &MPlaceTy<'tcx>,
-    ) -> InterpResult<'tcx, EmulateItemResult> {
+    ) -> InterpResult<'tcx, bool> {
         let this = self.eval_context_mut();
         this.expect_target_feature_for_intrinsic(link_name, "avx")?;
         // Prefix should have already been checked.
@@ -243,8 +243,8 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // The only thing that needs to be ensured is the correct calling convention.
                 let [] = this.check_shim_sig_unadjusted(link_name, args)?;
             }
-            _ => return interp_ok(EmulateItemResult::NotSupported),
+            _ => return interp_ok(false),
         }
-        interp_ok(EmulateItemResult::NeedsReturn)
+        interp_ok(true)
     }
 }

--- a/src/tools/miri/src/shims/x86/avx2.rs
+++ b/src/tools/miri/src/shims/x86/avx2.rs
@@ -14,7 +14,7 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         link_name: Symbol,
         args: &[OpTy<'tcx>],
         dest: &MPlaceTy<'tcx>,
-    ) -> InterpResult<'tcx, EmulateItemResult> {
+    ) -> InterpResult<'tcx, bool> {
         let this = self.eval_context_mut();
         this.expect_target_feature_for_intrinsic(link_name, "avx2")?;
         // Prefix should have already been checked.
@@ -216,8 +216,8 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
                 pmaddwd(this, left, right, dest)?;
             }
-            _ => return interp_ok(EmulateItemResult::NotSupported),
+            _ => return interp_ok(false),
         }
-        interp_ok(EmulateItemResult::NeedsReturn)
+        interp_ok(true)
     }
 }

--- a/src/tools/miri/src/shims/x86/avx512.rs
+++ b/src/tools/miri/src/shims/x86/avx512.rs
@@ -12,7 +12,7 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         link_name: Symbol,
         args: &[OpTy<'tcx>],
         dest: &MPlaceTy<'tcx>,
-    ) -> InterpResult<'tcx, EmulateItemResult> {
+    ) -> InterpResult<'tcx, bool> {
         let this = self.eval_context_mut();
         // Prefix should have already been checked.
         let unprefixed_name = link_name.as_str().strip_prefix("llvm.x86.avx512.").unwrap();
@@ -178,9 +178,9 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
                 packusdw(this, a, b, dest)?;
             }
-            _ => return interp_ok(EmulateItemResult::NotSupported),
+            _ => return interp_ok(false),
         }
-        interp_ok(EmulateItemResult::NeedsReturn)
+        interp_ok(true)
     }
 }
 

--- a/src/tools/miri/src/shims/x86/bmi.rs
+++ b/src/tools/miri/src/shims/x86/bmi.rs
@@ -10,7 +10,7 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         link_name: Symbol,
         args: &[OpTy<'tcx>],
         dest: &MPlaceTy<'tcx>,
-    ) -> InterpResult<'tcx, EmulateItemResult> {
+    ) -> InterpResult<'tcx, bool> {
         let this = self.eval_context_mut();
 
         // Prefix should have already been checked.
@@ -29,7 +29,7 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         this.expect_target_feature_for_intrinsic(link_name, target_feature)?;
 
         if is_64_bit && this.tcx.sess.target.arch != Arch::X86_64 {
-            return interp_ok(EmulateItemResult::NotSupported);
+            return interp_ok(false);
         }
 
         let [left, right] = this.check_shim_sig_unadjusted(link_name, args)?;
@@ -92,7 +92,7 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 }
                 result
             }
-            _ => return interp_ok(EmulateItemResult::NotSupported),
+            _ => return interp_ok(false),
         };
 
         let result = if is_64_bit {
@@ -102,6 +102,6 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         };
         this.write_scalar(result, dest)?;
 
-        interp_ok(EmulateItemResult::NeedsReturn)
+        interp_ok(true)
     }
 }

--- a/src/tools/miri/src/shims/x86/gfni.rs
+++ b/src/tools/miri/src/shims/x86/gfni.rs
@@ -9,7 +9,7 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         link_name: Symbol,
         args: &[OpTy<'tcx>],
         dest: &MPlaceTy<'tcx>,
-    ) -> InterpResult<'tcx, EmulateItemResult> {
+    ) -> InterpResult<'tcx, bool> {
         let this = self.eval_context_mut();
 
         // Prefix should have already been checked.
@@ -58,9 +58,9 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                     this.write_scalar(Scalar::from_u8(gf2p8_mul(left, right)), &dest)?;
                 }
             }
-            _ => return interp_ok(EmulateItemResult::NotSupported),
+            _ => return interp_ok(false),
         }
-        interp_ok(EmulateItemResult::NeedsReturn)
+        interp_ok(true)
     }
 }
 

--- a/src/tools/miri/src/shims/x86/mod.rs
+++ b/src/tools/miri/src/shims/x86/mod.rs
@@ -30,7 +30,7 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         link_name: Symbol,
         args: &[OpTy<'tcx>],
         dest: &MPlaceTy<'tcx>,
-    ) -> InterpResult<'tcx, EmulateItemResult> {
+    ) -> InterpResult<'tcx, bool> {
         let this = self.eval_context_mut();
         // Prefix should have already been checked.
         let unprefixed_name = link_name.as_str().strip_prefix("llvm.x86.").unwrap();
@@ -42,7 +42,7 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             // https://www.intel.com/content/www/us/en/docs/cpp-compiler/developer-guide-reference/2021-8/subborrow-u32-subborrow-u64.html
             "addcarry.32" | "addcarry.64" | "subborrow.32" | "subborrow.64" => {
                 if unprefixed_name.ends_with("64") && this.tcx.sess.target.arch != Arch::X86_64 {
-                    return interp_ok(EmulateItemResult::NotSupported);
+                    return interp_ok(false);
                 }
 
                 let [cb_in, a, b] = this.check_shim_sig_unadjusted(link_name, args)?;
@@ -147,9 +147,9 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 );
             }
 
-            _ => return interp_ok(EmulateItemResult::NotSupported),
+            _ => return interp_ok(false),
         }
-        interp_ok(EmulateItemResult::NeedsReturn)
+        interp_ok(true)
     }
 }
 

--- a/src/tools/miri/src/shims/x86/sha.rs
+++ b/src/tools/miri/src/shims/x86/sha.rs
@@ -15,7 +15,7 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         link_name: Symbol,
         args: &[OpTy<'tcx>],
         dest: &MPlaceTy<'tcx>,
-    ) -> InterpResult<'tcx, EmulateItemResult> {
+    ) -> InterpResult<'tcx, bool> {
         let this = self.eval_context_mut();
         this.expect_target_feature_for_intrinsic(link_name, "sha")?;
         // Prefix should have already been checked.
@@ -104,9 +104,9 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 let result = sha256msg2(a, b);
                 write(this, &dest, result)?;
             }
-            _ => return interp_ok(EmulateItemResult::NotSupported),
+            _ => return interp_ok(false),
         }
-        interp_ok(EmulateItemResult::NeedsReturn)
+        interp_ok(true)
     }
 }
 

--- a/src/tools/miri/src/shims/x86/sse.rs
+++ b/src/tools/miri/src/shims/x86/sse.rs
@@ -14,7 +14,7 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         link_name: Symbol,
         args: &[OpTy<'tcx>],
         dest: &MPlaceTy<'tcx>,
-    ) -> InterpResult<'tcx, EmulateItemResult> {
+    ) -> InterpResult<'tcx, bool> {
         let this = self.eval_context_mut();
         this.expect_target_feature_for_intrinsic(link_name, "sse")?;
         // Prefix should have already been checked.
@@ -171,8 +171,8 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
                 this.write_immediate(*res, dest)?;
             }
-            _ => return interp_ok(EmulateItemResult::NotSupported),
+            _ => return interp_ok(false),
         }
-        interp_ok(EmulateItemResult::NeedsReturn)
+        interp_ok(true)
     }
 }

--- a/src/tools/miri/src/shims/x86/sse2.rs
+++ b/src/tools/miri/src/shims/x86/sse2.rs
@@ -14,7 +14,7 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         link_name: Symbol,
         args: &[OpTy<'tcx>],
         dest: &MPlaceTy<'tcx>,
-    ) -> InterpResult<'tcx, EmulateItemResult> {
+    ) -> InterpResult<'tcx, bool> {
         let this = self.eval_context_mut();
         this.expect_target_feature_for_intrinsic(link_name, "sse2")?;
         // Prefix should have already been checked.
@@ -272,8 +272,8 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
                 pmaddwd(this, left, right, dest)?;
             }
-            _ => return interp_ok(EmulateItemResult::NotSupported),
+            _ => return interp_ok(false),
         }
-        interp_ok(EmulateItemResult::NeedsReturn)
+        interp_ok(true)
     }
 }

--- a/src/tools/miri/src/shims/x86/sse3.rs
+++ b/src/tools/miri/src/shims/x86/sse3.rs
@@ -9,7 +9,7 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         link_name: Symbol,
         args: &[OpTy<'tcx>],
         dest: &MPlaceTy<'tcx>,
-    ) -> InterpResult<'tcx, EmulateItemResult> {
+    ) -> InterpResult<'tcx, bool> {
         let this = self.eval_context_mut();
         this.expect_target_feature_for_intrinsic(link_name, "sse3")?;
         // Prefix should have already been checked.
@@ -28,8 +28,8 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
                 this.mem_copy(src_ptr, dest.ptr(), dest.layout.size, /*nonoverlapping*/ true)?;
             }
-            _ => return interp_ok(EmulateItemResult::NotSupported),
+            _ => return interp_ok(false),
         }
-        interp_ok(EmulateItemResult::NeedsReturn)
+        interp_ok(true)
     }
 }

--- a/src/tools/miri/src/shims/x86/sse41.rs
+++ b/src/tools/miri/src/shims/x86/sse41.rs
@@ -10,7 +10,7 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         link_name: Symbol,
         args: &[OpTy<'tcx>],
         dest: &MPlaceTy<'tcx>,
-    ) -> InterpResult<'tcx, EmulateItemResult> {
+    ) -> InterpResult<'tcx, bool> {
         let this = self.eval_context_mut();
         this.expect_target_feature_for_intrinsic(link_name, "sse4.1")?;
         // Prefix should have already been checked.
@@ -155,8 +155,8 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
                 this.write_scalar(Scalar::from_i32(res.into()), dest)?;
             }
-            _ => return interp_ok(EmulateItemResult::NotSupported),
+            _ => return interp_ok(false),
         }
-        interp_ok(EmulateItemResult::NeedsReturn)
+        interp_ok(true)
     }
 }

--- a/src/tools/miri/src/shims/x86/sse42.rs
+++ b/src/tools/miri/src/shims/x86/sse42.rs
@@ -279,7 +279,7 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         link_name: Symbol,
         args: &[OpTy<'tcx>],
         dest: &MPlaceTy<'tcx>,
-    ) -> InterpResult<'tcx, EmulateItemResult> {
+    ) -> InterpResult<'tcx, bool> {
         let this = self.eval_context_mut();
         this.expect_target_feature_for_intrinsic(link_name, "sse4.2")?;
         // Prefix should have already been checked.
@@ -428,7 +428,7 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 };
 
                 if bit_size == 64 && this.tcx.sess.target.arch != Arch::X86_64 {
-                    return interp_ok(EmulateItemResult::NotSupported);
+                    return interp_ok(false);
                 }
 
                 let [left, right] = this.check_shim_sig_unadjusted(link_name, args)?;
@@ -460,8 +460,8 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
                 this.write_scalar(result, dest)?;
             }
-            _ => return interp_ok(EmulateItemResult::NotSupported),
+            _ => return interp_ok(false),
         }
-        interp_ok(EmulateItemResult::NeedsReturn)
+        interp_ok(true)
     }
 }

--- a/src/tools/miri/src/shims/x86/ssse3.rs
+++ b/src/tools/miri/src/shims/x86/ssse3.rs
@@ -11,7 +11,7 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         link_name: Symbol,
         args: &[OpTy<'tcx>],
         dest: &MPlaceTy<'tcx>,
-    ) -> InterpResult<'tcx, EmulateItemResult> {
+    ) -> InterpResult<'tcx, bool> {
         let this = self.eval_context_mut();
         this.expect_target_feature_for_intrinsic(link_name, "ssse3")?;
         // Prefix should have already been checked.
@@ -67,8 +67,8 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
                 psign(this, left, right, dest)?;
             }
-            _ => return interp_ok(EmulateItemResult::NotSupported),
+            _ => return interp_ok(false),
         }
-        interp_ok(EmulateItemResult::NeedsReturn)
+        interp_ok(true)
     }
 }

--- a/src/tools/tidy/src/deps.rs
+++ b/src/tools/tidy/src/deps.rs
@@ -242,11 +242,17 @@ const EXCEPTIONS_RUST_ANALYZER: ExceptionList = &[
 
 const EXCEPTIONS_RUSTC_PERF: ExceptionList = &[
     // tidy-alphabetical-start
+    ("aws-lc-rs", "ISC AND (Apache-2.0 OR ISC)"),
+    (
+        "aws-lc-sys",
+        "ISC AND (Apache-2.0 OR ISC) AND Apache-2.0 AND MIT AND BSD-3-Clause AND (Apache-2.0 OR ISC OR MIT) AND (Apache-2.0 OR ISC OR MIT-0)",
+    ),
+    ("brotli", "BSD-3-Clause AND MIT"),
+    ("fast-srgb8", "MIT OR Apache-2.0 OR CC0-1.0"),
     ("inferno", "CDDL-1.0"),
     ("option-ext", "MPL-2.0"),
-    ("terminfo", "WTFPL"),
     ("wasite", "Apache-2.0 OR BSL-1.0 OR MIT"),
-    ("wezterm-bidi", "MIT AND Unicode-DFS-2016"),
+    ("webpki-root-certs", "CDLA-Permissive-2.0"),
     ("whoami", "Apache-2.0 OR BSL-1.0 OR MIT"),
     // tidy-alphabetical-end
 ];

--- a/src/tools/tidy/src/extdeps.rs
+++ b/src/tools/tidy/src/extdeps.rs
@@ -10,7 +10,7 @@ use crate::diagnostics::TidyCtx;
 const ALLOWED_SOURCES: &[&str] = &[
     r#""registry+https://github.com/rust-lang/crates.io-index""#,
     // This is `rust_team_data` used by `site` in src/tools/rustc-perf,
-    r#""git+https://github.com/rust-lang/team#a5260e76d3aa894c64c56e6ddc8545b9a98043ec""#,
+    r#""git+https://github.com/rust-lang/team#db2c1ed9fbc0216e533db954cd249045c01c7406""#,
 ];
 
 /// Checks for external package sources. `root` is the path to the directory that contains the

--- a/tests/codegen-llvm/range-len-try-from.rs
+++ b/tests/codegen-llvm/range-len-try-from.rs
@@ -4,6 +4,7 @@
 
 //@ compile-flags: -Copt-level=3
 //@ only-64bit
+//@ ignore-s390x OPT missing on s390x https://github.com/llvm/llvm-project/issues/208712
 
 #![crate_type = "lib"]
 

--- a/tests/ui/codegen/overflow-during-mono.stderr
+++ b/tests/ui/codegen/overflow-during-mono.stderr
@@ -3,8 +3,8 @@ error[E0275]: overflow evaluating the requirement `for<'a> {closure@$DIR/overflo
    = help: consider increasing the recursion limit by adding a `#![recursion_limit = "64"]` attribute to your crate (`overflow_during_mono`)
    = note: required for `Filter<IntoIter<i32, 11>, {closure@overflow-during-mono.rs:14:41}>` to implement `Iterator`
    = note: 31 redundant requirements hidden
-   = note: required for `Filter<Filter<Filter<Filter<Filter<..., ...>, ...>, ...>, ...>, ...>` to implement `Iterator`
-   = note: required for `Filter<Filter<Filter<Filter<Filter<..., ...>, ...>, ...>, ...>, ...>` to implement `IntoIterator`
+   = note: required for `Filter<Filter<Filter<Filter<Filter<Filter<_, _>, _>, _>, _>, _>, _>` to implement `Iterator`
+   = note: required for `Filter<Filter<Filter<Filter<Filter<Filter<_, _>, _>, _>, _>, _>, _>` to implement `IntoIterator`
    = note: the full name for the type has been written to '$TEST_BUILD_DIR/overflow-during-mono.long-type-$LONG_TYPE_HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
 

--- a/tests/ui/coercion/hr_alias_normalization_leaking_vars.stderr
+++ b/tests/ui/coercion/hr_alias_normalization_leaking_vars.stderr
@@ -16,7 +16,7 @@ error[E0308]: mismatched types
   --> $DIR/hr_alias_normalization_leaking_vars.rs:34:36
    |
 LL |     LendingIterator::for_each(&(), f);
-   |     -------------------------      ^ expected `Box<fn(...)>`, found fn item
+   |     -------------------------      ^ expected `Box<fn(_)>`, found fn item
    |     |
    |     arguments to this function are incorrect
    |

--- a/tests/ui/comptime/comptime_closure.rs
+++ b/tests/ui/comptime/comptime_closure.rs
@@ -1,0 +1,13 @@
+#![feature(rustc_attrs, stmt_expr_attributes)]
+
+const _: () = {
+    let f = #[rustc_comptime]
+    //~^ ERROR: `#[rustc_comptime]` attribute cannot be used on closures
+    || ();
+
+    // FIXME(comptime): closures should work, too.
+    f();
+    //~^ ERROR: cannot call non-const closure in constants
+};
+
+fn main() {}

--- a/tests/ui/comptime/comptime_closure.stderr
+++ b/tests/ui/comptime/comptime_closure.stderr
@@ -1,0 +1,20 @@
+error: `#[rustc_comptime]` attribute cannot be used on closures
+  --> $DIR/comptime_closure.rs:4:13
+   |
+LL |     let f = #[rustc_comptime]
+   |             ^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[rustc_comptime]` can be applied to functions, inherent impl blocks, and inherent methods
+
+error[E0015]: cannot call non-const closure in constants
+  --> $DIR/comptime_closure.rs:9:5
+   |
+LL |     f();
+   |     ^^^
+   |
+   = note: closures need an RFC before allowed to be called in constants
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0015`.

--- a/tests/ui/comptime/comptime_impl.rs
+++ b/tests/ui/comptime/comptime_impl.rs
@@ -1,0 +1,37 @@
+#![feature(rustc_attrs, const_trait_impl)]
+
+const trait Foo {
+    fn foo(&self);
+
+    fn bar(&self) {}
+}
+
+struct Bar;
+
+#[rustc_comptime]
+//~^ ERROR: cannot be used on inherent impl
+impl Bar {
+    fn boo(&self) {}
+}
+
+#[rustc_comptime]
+//~^ ERROR: cannot be used on trait impl
+impl Foo for Bar {
+    fn foo(&self) {
+        comptime_fn();
+        //~^ ERROR: comptime fns can only be called at compile time
+    }
+}
+
+#[rustc_comptime]
+fn comptime_fn() {}
+
+const _: () = {
+    Bar.boo();
+    Bar.foo();
+    //~^ ERROR: `Bar: const Foo` is not satisfied
+    Bar.bar();
+    //~^ ERROR: `Bar: const Foo` is not satisfied
+};
+
+fn main() {}

--- a/tests/ui/comptime/comptime_impl.rs
+++ b/tests/ui/comptime/comptime_impl.rs
@@ -9,7 +9,6 @@ const trait Foo {
 struct Bar;
 
 #[rustc_comptime]
-//~^ ERROR: cannot be used on inherent impl
 impl Bar {
     fn boo(&self) {}
 }
@@ -19,7 +18,6 @@ impl Bar {
 impl Foo for Bar {
     fn foo(&self) {
         comptime_fn();
-        //~^ ERROR: comptime fns can only be called at compile time
     }
 }
 

--- a/tests/ui/comptime/comptime_impl.stderr
+++ b/tests/ui/comptime/comptime_impl.stderr
@@ -1,27 +1,13 @@
-error: `#[rustc_comptime]` attribute cannot be used on inherent impl blocks
-  --> $DIR/comptime_impl.rs:11:1
-   |
-LL | #[rustc_comptime]
-   | ^^^^^^^^^^^^^^^^^
-   |
-   = help: `#[rustc_comptime]` can only be applied to functions
-
 error: `#[rustc_comptime]` attribute cannot be used on trait impl blocks
-  --> $DIR/comptime_impl.rs:17:1
+  --> $DIR/comptime_impl.rs:16:1
    |
 LL | #[rustc_comptime]
    | ^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_comptime]` can only be applied to functions
-
-error: comptime fns can only be called at compile time
-  --> $DIR/comptime_impl.rs:21:9
-   |
-LL |         comptime_fn();
-   |         ^^^^^^^^^^^^^
+   = help: `#[rustc_comptime]` can be applied to functions and inherent impl blocks
 
 error[E0277]: the trait bound `Bar: const Foo` is not satisfied
-  --> $DIR/comptime_impl.rs:31:9
+  --> $DIR/comptime_impl.rs:29:9
    |
 LL |     Bar.foo();
    |         ^^^
@@ -32,7 +18,7 @@ LL | impl const Foo for Bar {
    |      +++++
 
 error[E0277]: the trait bound `Bar: const Foo` is not satisfied
-  --> $DIR/comptime_impl.rs:33:9
+  --> $DIR/comptime_impl.rs:31:9
    |
 LL |     Bar.bar();
    |         ^^^
@@ -42,6 +28,6 @@ help: make the `impl` of trait `Foo` `const`
 LL | impl const Foo for Bar {
    |      +++++
 
-error: aborting due to 5 previous errors
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/comptime/comptime_impl.stderr
+++ b/tests/ui/comptime/comptime_impl.stderr
@@ -1,0 +1,47 @@
+error: `#[rustc_comptime]` attribute cannot be used on inherent impl blocks
+  --> $DIR/comptime_impl.rs:11:1
+   |
+LL | #[rustc_comptime]
+   | ^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[rustc_comptime]` can only be applied to functions
+
+error: `#[rustc_comptime]` attribute cannot be used on trait impl blocks
+  --> $DIR/comptime_impl.rs:17:1
+   |
+LL | #[rustc_comptime]
+   | ^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[rustc_comptime]` can only be applied to functions
+
+error: comptime fns can only be called at compile time
+  --> $DIR/comptime_impl.rs:21:9
+   |
+LL |         comptime_fn();
+   |         ^^^^^^^^^^^^^
+
+error[E0277]: the trait bound `Bar: const Foo` is not satisfied
+  --> $DIR/comptime_impl.rs:31:9
+   |
+LL |     Bar.foo();
+   |         ^^^
+   |
+help: make the `impl` of trait `Foo` `const`
+   |
+LL | impl const Foo for Bar {
+   |      +++++
+
+error[E0277]: the trait bound `Bar: const Foo` is not satisfied
+  --> $DIR/comptime_impl.rs:33:9
+   |
+LL |     Bar.bar();
+   |         ^^^
+   |
+help: make the `impl` of trait `Foo` `const`
+   |
+LL | impl const Foo for Bar {
+   |      +++++
+
+error: aborting due to 5 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/comptime/comptime_method.rs
+++ b/tests/ui/comptime/comptime_method.rs
@@ -3,14 +3,15 @@
 struct Bar;
 
 #[rustc_comptime]
-//~^ ERROR: cannot be used on inherent impl
 impl Bar {
     fn boo(&self) {}
 }
 
 const _: () = {
     Bar.boo();
-    //~^ ERROR: cannot call non-const method `Bar::boo` in constants
 };
 
-fn main() {}
+fn main() {
+    Bar.boo();
+    //~^ ERROR: comptime fns can only be called at compile time
+}

--- a/tests/ui/comptime/comptime_method.rs
+++ b/tests/ui/comptime/comptime_method.rs
@@ -1,0 +1,16 @@
+#![feature(rustc_attrs)]
+
+struct Bar;
+
+#[rustc_comptime]
+//~^ ERROR: cannot be used on inherent impl
+impl Bar {
+    fn boo(&self) {}
+}
+
+const _: () = {
+    Bar.boo();
+    //~^ ERROR: cannot call non-const method `Bar::boo` in constants
+};
+
+fn main() {}

--- a/tests/ui/comptime/comptime_method.stderr
+++ b/tests/ui/comptime/comptime_method.stderr
@@ -1,0 +1,19 @@
+error: `#[rustc_comptime]` attribute cannot be used on inherent impl blocks
+  --> $DIR/comptime_method.rs:5:1
+   |
+LL | #[rustc_comptime]
+   | ^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[rustc_comptime]` can only be applied to functions
+
+error[E0015]: cannot call non-const method `Bar::boo` in constants
+  --> $DIR/comptime_method.rs:12:9
+   |
+LL |     Bar.boo();
+   |         ^^^^^
+   |
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0015`.

--- a/tests/ui/comptime/comptime_method.stderr
+++ b/tests/ui/comptime/comptime_method.stderr
@@ -1,19 +1,8 @@
-error: `#[rustc_comptime]` attribute cannot be used on inherent impl blocks
-  --> $DIR/comptime_method.rs:5:1
-   |
-LL | #[rustc_comptime]
-   | ^^^^^^^^^^^^^^^^^
-   |
-   = help: `#[rustc_comptime]` can only be applied to functions
-
-error[E0015]: cannot call non-const method `Bar::boo` in constants
-  --> $DIR/comptime_method.rs:12:9
+error: comptime fns can only be called at compile time
+  --> $DIR/comptime_method.rs:15:5
    |
 LL |     Bar.boo();
-   |         ^^^^^
-   |
-   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
+   |     ^^^^^^^^^
 
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0015`.

--- a/tests/ui/comptime/comptime_method_bounds.rs
+++ b/tests/ui/comptime/comptime_method_bounds.rs
@@ -1,0 +1,24 @@
+//@check-pass
+
+#![feature(rustc_attrs, const_trait_impl)]
+
+struct Bar<T>(T);
+
+const trait Trait {
+    fn method(&self) {}
+}
+
+#[rustc_comptime]
+impl<T: const Trait> Bar<T> {
+    fn boo(&self) {
+        self.0.method()
+    }
+}
+
+const impl Trait for () {}
+
+const _: () = {
+    Bar(()).boo();
+};
+
+fn main() {}

--- a/tests/ui/comptime/comptime_trait.rs
+++ b/tests/ui/comptime/comptime_trait.rs
@@ -1,0 +1,32 @@
+#![feature(rustc_attrs, const_trait_impl, trait_alias)]
+
+#[rustc_comptime]
+//~^ ERROR: `#[rustc_comptime]` attribute cannot be used on traits
+trait Trait {
+    fn method(&self) {}
+}
+
+const impl Trait for () {}
+
+#[rustc_comptime]
+//~^ ERROR: `#[rustc_comptime]` attribute cannot be used on trait impl
+impl Trait for u32 {
+    fn method(&self) {
+        comptime_fn();
+    }
+}
+
+#[rustc_comptime]
+fn comptime_fn() {}
+
+#[rustc_comptime]
+//~^ ERROR: `#[rustc_comptime]` attribute cannot be used on trait aliases
+trait TraitAlias = const Trait;
+
+#[rustc_comptime]
+fn func<T: const TraitAlias>(t: &T) {
+    t.method()
+    //~^ ERROR: cannot call non-const method `<T as Trait>::method` in constants
+}
+
+fn main() {}

--- a/tests/ui/comptime/comptime_trait.stderr
+++ b/tests/ui/comptime/comptime_trait.stderr
@@ -1,0 +1,35 @@
+error: `#[rustc_comptime]` attribute cannot be used on traits
+  --> $DIR/comptime_trait.rs:3:1
+   |
+LL | #[rustc_comptime]
+   | ^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[rustc_comptime]` can be applied to functions and inherent impl blocks
+
+error: `#[rustc_comptime]` attribute cannot be used on trait impl blocks
+  --> $DIR/comptime_trait.rs:11:1
+   |
+LL | #[rustc_comptime]
+   | ^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[rustc_comptime]` can be applied to functions and inherent impl blocks
+
+error: `#[rustc_comptime]` attribute cannot be used on trait aliases
+  --> $DIR/comptime_trait.rs:22:1
+   |
+LL | #[rustc_comptime]
+   | ^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[rustc_comptime]` can be applied to functions and inherent impl blocks
+
+error[E0015]: cannot call non-const method `<T as Trait>::method` in constants
+  --> $DIR/comptime_trait.rs:28:7
+   |
+LL |     t.method()
+   |       ^^^^^^^^
+   |
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0015`.

--- a/tests/ui/comptime/trait_comptime.stderr
+++ b/tests/ui/comptime/trait_comptime.stderr
@@ -4,7 +4,7 @@ error: `#[rustc_comptime]` attribute cannot be used on required trait methods
 LL |     #[rustc_comptime]
    |     ^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_comptime]` can only be applied to functions with a body
+   = help: `#[rustc_comptime]` can be applied to functions with a body and inherent impl blocks
 
 error: `#[rustc_comptime]` attribute cannot be used on provided trait methods
   --> $DIR/trait_comptime.rs:8:5
@@ -12,7 +12,7 @@ error: `#[rustc_comptime]` attribute cannot be used on provided trait methods
 LL |     #[rustc_comptime]
    |     ^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_comptime]` can be applied to functions and inherent methods
+   = help: `#[rustc_comptime]` can be applied to functions, inherent impl blocks, and inherent methods
 
 error: `#[rustc_comptime]` attribute cannot be used on trait methods in impl blocks
   --> $DIR/trait_comptime.rs:21:5
@@ -20,7 +20,7 @@ error: `#[rustc_comptime]` attribute cannot be used on trait methods in impl blo
 LL |     #[rustc_comptime]
    |     ^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_comptime]` can be applied to functions and inherent methods
+   = help: `#[rustc_comptime]` can be applied to functions, inherent impl blocks, and inherent methods
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/diagnostic-width/E0271.ascii.stderr
+++ b/tests/ui/diagnostic-width/E0271.ascii.stderr
@@ -1,4 +1,4 @@
-error[E0271]: type mismatch resolving `<Result<..., ()> as Future>::Error == Foo`
+error[E0271]: type mismatch resolving `<Result<_, ()> as Future>::Error == Foo`
   --> $DIR/E0271.rs:19:5
    |
 LL | /     Box::new(
@@ -7,14 +7,14 @@ LL | |             Err::<(), _>(
 LL | |                 Ok::<_, ()>(
 ...  |
 LL | |     )
-   | |_____^ type mismatch resolving `<Result<..., ()> as Future>::Error == Foo`
+   | |_____^ type mismatch resolving `<Result<_, ()> as Future>::Error == Foo`
    |
 note: expected this to be `Foo`
   --> $DIR/E0271.rs:9:18
    |
 LL |     type Error = E;
    |                  ^
-   = note: required for the cast from `Box<Result<..., ()>>` to `Box<...>`
+   = note: required for the cast from `Box<Result<_, ()>>` to `Box<_>`
    = note: the full name for the type has been written to '$TEST_BUILD_DIR/E0271.long-type-$LONG_TYPE_HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
 

--- a/tests/ui/diagnostic-width/E0271.unicode.stderr
+++ b/tests/ui/diagnostic-width/E0271.unicode.stderr
@@ -1,4 +1,4 @@
-error[E0271]: type mismatch resolving `<Result<..., ()> as Future>::Error == Foo`
+error[E0271]: type mismatch resolving `<Result<_, ()> as Future>::Error == Foo`
    ╭▸ $DIR/E0271.rs:19:5
    │
 LL │ ┏     Box::new(
@@ -7,14 +7,14 @@ LL │ ┃             Err::<(), _>(
 LL │ ┃                 Ok::<_, ()>(
    ‡ ┃
 LL │ ┃     )
-   │ ┗━━━━━┛ type mismatch resolving `<Result<..., ()> as Future>::Error == Foo`
+   │ ┗━━━━━┛ type mismatch resolving `<Result<_, ()> as Future>::Error == Foo`
    ╰╴
 note: expected this to be `Foo`
    ╭▸ $DIR/E0271.rs:9:18
    │
 LL │     type Error = E;
    │                  ━
-   ├ note: required for the cast from `Box<Result<..., ()>>` to `Box<...>`
+   ├ note: required for the cast from `Box<Result<_, ()>>` to `Box<_>`
    ├ note: the full name for the type has been written to '$TEST_BUILD_DIR/E0271.long-type-$LONG_TYPE_HASH.txt'
    ╰ note: consider using `--verbose` to print the full type name to the console
 

--- a/tests/ui/diagnostic-width/binop.rs
+++ b/tests/ui/diagnostic-width/binop.rs
@@ -5,11 +5,11 @@ type C = (B, B, B, B);
 type D = (C, C, C, C);
 
 fn foo(x: D) {
-    x + x; //~ ERROR cannot add `(...
+    x + x; //~ ERROR cannot add `((_
 }
 
 fn bar(x: D) {
-    !x; //~ ERROR cannot apply unary operator `!` to type `(...
+    !x; //~ ERROR cannot apply unary operator `!` to type `((_
 }
 
 fn main() {}

--- a/tests/ui/diagnostic-width/binop.stderr
+++ b/tests/ui/diagnostic-width/binop.stderr
@@ -1,15 +1,15 @@
-error[E0369]: cannot add `(..., ..., ..., ...)` to `(..., ..., ..., ...)`
+error[E0369]: cannot add `((_, _, _, _), _, _, _)` to `((_, _, _, _), _, _, _)`
   --> $DIR/binop.rs:8:7
    |
 LL |     x + x;
-   |     - ^ - (..., ..., ..., ...)
+   |     - ^ - ((_, _, _, _), _, _, _)
    |     |
-   |     (..., ..., ..., ...)
+   |     ((_, _, _, _), _, _, _)
    |
    = note: the full name for the type has been written to '$TEST_BUILD_DIR/binop.long-type-$LONG_TYPE_HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
 
-error[E0600]: cannot apply unary operator `!` to type `(..., ..., ..., ...)`
+error[E0600]: cannot apply unary operator `!` to type `((_, _, _, _), _, _, _)`
   --> $DIR/binop.rs:12:5
    |
 LL |     !x;

--- a/tests/ui/diagnostic-width/long-E0308.ascii.stderr
+++ b/tests/ui/diagnostic-width/long-E0308.ascii.stderr
@@ -16,10 +16,10 @@ LL |  |         Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok...
 LL |  |             Ok("")
 LL |  |         ))))))))))))))))))))))))))))))
 LL |  |     ))))))))))))))))))))))))))))));
-   |  |__________________________________^ expected `Atype<Btype<Ctype<..., i32>, i32>, i32>`, found `Result<Result<Result<..., _>, _>, _>`
+   |  |__________________________________^ expected `Atype<Btype<Ctype<_, i32>, i32>, i32>`, found `Result<Result<Result<_, _>, _>, _>`
    |
-   = note: expected struct `Atype<Btype<..., i32>, i32>`
-                found enum `Result<Result<..., _>, _>`
+   = note: expected struct `Atype<Btype<_, i32>, i32>`
+                found enum `Result<Result<_, _>, _>`
    = note: the full name for the type has been written to '$TEST_BUILD_DIR/long-E0308.long-type-$LONG_TYPE_HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
 
@@ -32,10 +32,10 @@ LL | |         Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(...
 LL | |             Ok(Ok(Ok(Ok(Ok(Ok(Ok("")))))))
 LL | |         ))))))))))))))))))))))))))))))
 LL | |     ))))))))))))))))))))))));
-   | |____________________________^ expected `Option<Result<Option<Option<...>>, _>>`, found `Result<Result<Result<..., _>, _>, _>`
+   | |____________________________^ expected `Option<Result<Option<Option<_>>, _>>`, found `Result<Result<Result<_, _>, _>, _>`
    |
-   = note: expected enum `Option<Result<Option<...>, _>>`
-              found enum `Result<Result<..., _>, _>`
+   = note: expected enum `Option<Result<Option<_>, _>>`
+              found enum `Result<Result<_, _>, _>`
    = note: the full name for the type has been written to '$TEST_BUILD_DIR/long-E0308.long-type-$LONG_TYPE_HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
 
@@ -50,11 +50,11 @@ LL | |           Atype<
 ...  |
 LL | |       i32
 LL | |     > = ();
-   | |     -   ^^ expected `Atype<Btype<Ctype<..., i32>, i32>, i32>`, found `()`
+   | |     -   ^^ expected `Atype<Btype<Ctype<_, i32>, i32>, i32>`, found `()`
    | |_____|
    |       expected due to this
    |
-   = note: expected struct `Atype<Btype<..., i32>, i32>`
+   = note: expected struct `Atype<Btype<_, i32>, i32>`
            found unit type `()`
    = note: the full name for the type has been written to '$TEST_BUILD_DIR/long-E0308.long-type-$LONG_TYPE_HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
@@ -70,10 +70,10 @@ LL | |         Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(...
 LL | |             Ok(Ok(Ok(Ok(Ok(Ok(Ok("")))))))
 LL | |         ))))))))))))))))))))))))))))))
 LL | |     ))))))))))))))))))))))));
-   | |____________________________^ expected `()`, found `Result<Result<Result<..., _>, _>, _>`
+   | |____________________________^ expected `()`, found `Result<Result<Result<_, _>, _>, _>`
    |
    = note: expected unit type `()`
-                   found enum `Result<Result<..., _>, _>`
+                   found enum `Result<Result<_, _>, _>`
    = note: the full name for the type has been written to '$TEST_BUILD_DIR/long-E0308.long-type-$LONG_TYPE_HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
 

--- a/tests/ui/diagnostic-width/long-E0308.unicode.stderr
+++ b/tests/ui/diagnostic-width/long-E0308.unicode.stderr
@@ -16,10 +16,10 @@ LL │  ┃         Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(O…
 LL │  ┃             Ok("")
 LL │  ┃         ))))))))))))))))))))))))))))))
 LL │  ┃     ))))))))))))))))))))))))))))));
-   │  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛ expected `Atype<Btype<Ctype<..., i32>, i32>, i32>`, found `Result<Result<Result<..., _>, _>, _>`
+   │  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛ expected `Atype<Btype<Ctype<_, i32>, i32>, i32>`, found `Result<Result<Result<_, _>, _>, _>`
    │
-   ├ note: expected struct `Atype<Btype<..., i32>, i32>`
-   │            found enum `Result<Result<..., _>, _>`
+   ├ note: expected struct `Atype<Btype<_, i32>, i32>`
+   │            found enum `Result<Result<_, _>, _>`
    ├ note: the full name for the type has been written to '$TEST_BUILD_DIR/long-E0308.long-type-$LONG_TYPE_HASH.txt'
    ╰ note: consider using `--verbose` to print the full type name to the console
 
@@ -32,10 +32,10 @@ LL │ ┃         Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok…
 LL │ ┃             Ok(Ok(Ok(Ok(Ok(Ok(Ok("")))))))
 LL │ ┃         ))))))))))))))))))))))))))))))
 LL │ ┃     ))))))))))))))))))))))));
-   │ ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛ expected `Option<Result<Option<Option<...>>, _>>`, found `Result<Result<Result<..., _>, _>, _>`
+   │ ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛ expected `Option<Result<Option<Option<_>>, _>>`, found `Result<Result<Result<_, _>, _>, _>`
    │
-   ├ note: expected enum `Option<Result<Option<...>, _>>`
-   │          found enum `Result<Result<..., _>, _>`
+   ├ note: expected enum `Option<Result<Option<_>, _>>`
+   │          found enum `Result<Result<_, _>, _>`
    ├ note: the full name for the type has been written to '$TEST_BUILD_DIR/long-E0308.long-type-$LONG_TYPE_HASH.txt'
    ╰ note: consider using `--verbose` to print the full type name to the console
 
@@ -50,11 +50,11 @@ LL │ │           Atype<
    ‡ │
 LL │ │       i32
 LL │ │     > = ();
-   │ │     │   ━━ expected `Atype<Btype<Ctype<..., i32>, i32>, i32>`, found `()`
+   │ │     │   ━━ expected `Atype<Btype<Ctype<_, i32>, i32>, i32>`, found `()`
    │ └─────┤
    │       expected due to this
    │
-   ├ note: expected struct `Atype<Btype<..., i32>, i32>`
+   ├ note: expected struct `Atype<Btype<_, i32>, i32>`
    │       found unit type `()`
    ├ note: the full name for the type has been written to '$TEST_BUILD_DIR/long-E0308.long-type-$LONG_TYPE_HASH.txt'
    ╰ note: consider using `--verbose` to print the full type name to the console
@@ -70,10 +70,10 @@ LL │ ┃         Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok…
 LL │ ┃             Ok(Ok(Ok(Ok(Ok(Ok(Ok("")))))))
 LL │ ┃         ))))))))))))))))))))))))))))))
 LL │ ┃     ))))))))))))))))))))))));
-   │ ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛ expected `()`, found `Result<Result<Result<..., _>, _>, _>`
+   │ ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛ expected `()`, found `Result<Result<Result<_, _>, _>, _>`
    │
    ├ note: expected unit type `()`
-   │               found enum `Result<Result<..., _>, _>`
+   │               found enum `Result<Result<_, _>, _>`
    ├ note: the full name for the type has been written to '$TEST_BUILD_DIR/long-E0308.long-type-$LONG_TYPE_HASH.txt'
    ╰ note: consider using `--verbose` to print the full type name to the console
 

--- a/tests/ui/diagnostic-width/long-E0529.rs
+++ b/tests/ui/diagnostic-width/long-E0529.rs
@@ -7,8 +7,8 @@ type C = (B, B, B, B);
 type D = (C, C, C, C);
 
 fn foo(x: D) {
-    let [] = x; //~ ERROR expected an array or slice, found `(...
-    //~^ NOTE pattern cannot match with input type `(...
+    let [] = x; //~ ERROR expected an array or slice, found `((_
+    //~^ NOTE pattern cannot match with input type `((_
 }
 
 fn main() {}

--- a/tests/ui/diagnostic-width/long-E0529.stderr
+++ b/tests/ui/diagnostic-width/long-E0529.stderr
@@ -1,8 +1,8 @@
-error[E0529]: expected an array or slice, found `(..., ..., ..., ...)`
+error[E0529]: expected an array or slice, found `((_, _, _, _), _, _, _)`
   --> $DIR/long-E0529.rs:10:9
    |
 LL |     let [] = x;
-   |         ^^ pattern cannot match with input type `(..., ..., ..., ...)`
+   |         ^^ pattern cannot match with input type `((_, _, _, _), _, _, _)`
    |
    = note: the full name for the type has been written to '$TEST_BUILD_DIR/long-E0529.long-type-$LONG_TYPE_HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console

--- a/tests/ui/diagnostic-width/long-E0609.rs
+++ b/tests/ui/diagnostic-width/long-E0609.rs
@@ -6,7 +6,7 @@ type C = (B, B, B, B);
 type D = (C, C, C, C);
 
 fn foo(x: D) {
-    x.field; //~ ERROR no field `field` on type `(...
+    x.field; //~ ERROR no field `field` on type `((_
 }
 
 fn main() {}

--- a/tests/ui/diagnostic-width/long-E0609.stderr
+++ b/tests/ui/diagnostic-width/long-E0609.stderr
@@ -1,4 +1,4 @@
-error[E0609]: no field `field` on type `(..., ..., ..., ...)`
+error[E0609]: no field `field` on type `((_, _, _, _), _, _, _)`
   --> $DIR/long-E0609.rs:9:7
    |
 LL |     x.field;

--- a/tests/ui/diagnostic-width/long-E0614.rs
+++ b/tests/ui/diagnostic-width/long-E0614.rs
@@ -6,7 +6,7 @@ type C = (B, B, B, B);
 type D = (C, C, C, C);
 
 fn foo(x: D) {
-    *x; //~ ERROR type `(...
+    *x; //~ ERROR type `((_
 }
 
 fn main() {}

--- a/tests/ui/diagnostic-width/long-E0614.stderr
+++ b/tests/ui/diagnostic-width/long-E0614.stderr
@@ -1,4 +1,4 @@
-error[E0614]: type `(..., ..., ..., ...)` cannot be dereferenced
+error[E0614]: type `((_, _, _, _), _, _, _)` cannot be dereferenced
   --> $DIR/long-E0614.rs:9:5
    |
 LL |     *x;

--- a/tests/ui/diagnostic-width/long-E0618.rs
+++ b/tests/ui/diagnostic-width/long-E0618.rs
@@ -6,8 +6,8 @@ type B = (A, A, A, A);
 type C = (B, B, B, B);
 type D = (C, C, C, C);
 
-fn foo(x: D) { //~ NOTE `x` has type `(...
-    x(); //~ ERROR expected function, found `(...
+fn foo(x: D) { //~ NOTE `x` has type `((_
+    x(); //~ ERROR expected function, found `((_
 }
 
 fn main() {}

--- a/tests/ui/diagnostic-width/long-E0618.stderr
+++ b/tests/ui/diagnostic-width/long-E0618.stderr
@@ -1,8 +1,8 @@
-error[E0618]: expected function, found `(..., ..., ..., ...)`
+error[E0618]: expected function, found `((_, _, _, _), _, _, _)`
   --> $DIR/long-E0618.rs:10:5
    |
 LL | fn foo(x: D) {
-   |        - `x` has type `(..., ..., ..., ...)`
+   |        - `x` has type `((_, _, _, _), _, _, _)`
 LL |     x();
    |     ^--
    |     |

--- a/tests/ui/diagnostic-width/long-e0277.rs
+++ b/tests/ui/diagnostic-width/long-e0277.rs
@@ -9,5 +9,5 @@ trait Trait {}
 fn require_trait<T: Trait>() {}
 
 fn main() {
-    require_trait::<D>(); //~ ERROR the trait bound `(...
+    require_trait::<D>(); //~ ERROR the trait bound `((_
 }

--- a/tests/ui/diagnostic-width/long-e0277.stderr
+++ b/tests/ui/diagnostic-width/long-e0277.stderr
@@ -1,10 +1,10 @@
-error[E0277]: the trait bound `(..., ..., ..., ...): Trait` is not satisfied
+error[E0277]: the trait bound `((_, _, _, _), _, _, _): Trait` is not satisfied
   --> $DIR/long-e0277.rs:12:21
    |
 LL |     require_trait::<D>();
    |                     ^ unsatisfied trait bound
    |
-   = help: the trait `Trait` is not implemented for `(..., ..., ..., ...)`
+   = help: the trait `Trait` is not implemented for `((_, _, _, _), _, _, _)`
 help: this trait has no implementations, consider adding one
   --> $DIR/long-e0277.rs:7:1
    |

--- a/tests/ui/diagnostic-width/non-copy-type-moved.stderr
+++ b/tests/ui/diagnostic-width/non-copy-type-moved.stderr
@@ -2,7 +2,7 @@ error[E0382]: use of moved value: `x`
   --> $DIR/non-copy-type-moved.rs:14:14
    |
 LL | fn foo(x: D) {
-   |        - move occurs because `x` has type `(..., ..., ..., ...)`, which does not implement the `Copy` trait
+   |        - move occurs because `x` has type `((_, _, _, _), _, _, _)`, which does not implement the `Copy` trait
 LL |     let _a = x;
    |              - value moved here
 LL |     let _b = x;

--- a/tests/ui/diagnostic-width/secondary-label-with-long-type.rs
+++ b/tests/ui/diagnostic-width/secondary-label-with-long-type.rs
@@ -7,8 +7,8 @@ type D = (C, C, C, C);
 
 fn foo(x: D) {
     let () = x; //~ ERROR mismatched types
-    //~^ NOTE this expression has type `((...,
-    //~| NOTE expected `((...,
+    //~^ NOTE this expression has type `(((_,
+    //~| NOTE expected `(((_,
     //~| NOTE expected tuple
     //~| NOTE the full name for the type has been written to
     //~| NOTE consider using `--verbose` to print the full type name to the console

--- a/tests/ui/diagnostic-width/secondary-label-with-long-type.stderr
+++ b/tests/ui/diagnostic-width/secondary-label-with-long-type.stderr
@@ -2,11 +2,11 @@ error[E0308]: mismatched types
   --> $DIR/secondary-label-with-long-type.rs:9:9
    |
 LL |     let () = x;
-   |         ^^   - this expression has type `((..., ..., ..., ...), ..., ..., ...)`
+   |         ^^   - this expression has type `(((_, _, _, _), _, _, _), _, _, _)`
    |         |
-   |         expected `((..., ..., ..., ...), ..., ..., ...)`, found `()`
+   |         expected `(((_, _, _, _), _, _, _), _, _, _)`, found `()`
    |
-   = note:  expected tuple `((..., ..., ..., ...), ..., ..., ...)`
+   = note:  expected tuple `(((_, _, _, _), _, _, _), _, _, _)`
            found unit type `()`
    = note: the full name for the type has been written to '$TEST_BUILD_DIR/secondary-label-with-long-type.long-type-$LONG_TYPE_HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console

--- a/tests/ui/dropck/dropck_no_diverge_on_nonregular_1.stderr
+++ b/tests/ui/dropck/dropck_no_diverge_on_nonregular_1.stderr
@@ -4,7 +4,7 @@ error[E0320]: overflow while adding drop-check rules for `FingerTree<i32>`
 LL |     let ft =
    |         ^^
    |
-   = note: overflowed on `FingerTree<Node<Node<Node<Node<Node<Node<Node<Node<Node<...>>>>>>>>>>`
+   = note: overflowed on `FingerTree<Node<Node<Node<Node<Node<Node<Node<Node<Node<_>>>>>>>>>>`
    = note: the full name for the type has been written to '$TEST_BUILD_DIR/dropck_no_diverge_on_nonregular_1.long-type-$LONG_TYPE_HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
 

--- a/tests/ui/error-codes/E0275.stderr
+++ b/tests/ui/error-codes/E0275.stderr
@@ -1,11 +1,11 @@
-error[E0275]: overflow evaluating the requirement `Bar<Bar<Bar<Bar<Bar<Bar<Bar<...>>>>>>>: Foo`
+error[E0275]: overflow evaluating the requirement `Bar<Bar<Bar<Bar<Bar<Bar<Bar<_>>>>>>>: Foo`
   --> $DIR/E0275.rs:6:33
    |
 LL | impl<T> Foo for T where Bar<T>: Foo {}
    |                                 ^^^
    |
    = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`E0275`)
-note: required for `Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<...>>>>>>>>>>>>>` to implement `Foo`
+note: required for `Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<_>>>>>>>>>>>>>` to implement `Foo`
   --> $DIR/E0275.rs:6:9
    |
 LL | impl<T> Foo for T where Bar<T>: Foo {}

--- a/tests/ui/higher-ranked/relate-bound-region-ice-144033.rs
+++ b/tests/ui/higher-ranked/relate-bound-region-ice-144033.rs
@@ -1,0 +1,33 @@
+// Regression test for <https://github.com/rust-lang/rust/issues/144033>.
+// A delegating impl whose method drops the trait's HRTB where-clause used to
+// ICE with "cannot relate bound region" instead of emitting normal errors.
+
+trait FooMut {
+    type Baz: 'static;
+    fn bar<'a, I>(self, iterator: &'a I)
+    where
+        for<'b> &'b I: IntoIterator<Item = &'b &'a Self::Baz>;
+}
+struct DelegatingFooMut<T> {}
+//~^ ERROR type parameter `T` is never used
+
+impl<T> FooMut for DelegatingFooMut<T>
+where
+    T: FooMut,
+{
+    type Baz = DelegatingBaz<T::Baz>;
+    fn bar<'a, I>(self, collection: &'a I)
+    //~^ ERROR lifetime parameters do not match the trait definition
+    where
+        for<'b> &'b I: IntoIterator,
+    {
+        let collection = collection.into_iter().map(|b| &b);
+        self.bar(collection)
+        //~^ ERROR type mismatch resolving
+        //~| ERROR mismatched types
+    }
+}
+struct DelegatingBaz<T>;
+//~^ ERROR type parameter `T` is never used
+
+fn main() {}

--- a/tests/ui/higher-ranked/relate-bound-region-ice-144033.rs
+++ b/tests/ui/higher-ranked/relate-bound-region-ice-144033.rs
@@ -1,33 +1,23 @@
 // Regression test for <https://github.com/rust-lang/rust/issues/144033>.
-// A delegating impl whose method drops the trait's HRTB where-clause used to
-// ICE with "cannot relate bound region" instead of emitting normal errors.
+// This used to ICE with "cannot relate bound region" instead of emitting
+// normal errors.
 
 trait FooMut {
-    type Baz: 'static;
-    fn bar<'a, I>(self, iterator: &'a I)
+    fn bar<I>(self, _: I)
     where
-        for<'b> &'b I: IntoIterator<Item = &'b &'a Self::Baz>;
+        for<'b> &'b I: Iterator<Item = &'b ()>;
 }
-struct DelegatingFooMut<T> {}
-//~^ ERROR type parameter `T` is never used
 
-impl<T> FooMut for DelegatingFooMut<T>
-where
-    T: FooMut,
-{
-    type Baz = DelegatingBaz<T::Baz>;
-    fn bar<'a, I>(self, collection: &'a I)
-    //~^ ERROR lifetime parameters do not match the trait definition
+impl FooMut for () {
+    fn bar<I>(self, _: I)
     where
-        for<'b> &'b I: IntoIterator,
+        for<'b> &'b I: Iterator,
     {
-        let collection = collection.into_iter().map(|b| &b);
+        let collection = std::iter::empty::<()>().map(|_| &());
         self.bar(collection)
-        //~^ ERROR type mismatch resolving
+        //~^ ERROR expected `&I` to be an iterator that yields `&()`
         //~| ERROR mismatched types
     }
 }
-struct DelegatingBaz<T>;
-//~^ ERROR type parameter `T` is never used
 
 fn main() {}

--- a/tests/ui/higher-ranked/relate-bound-region-ice-144033.stderr
+++ b/tests/ui/higher-ranked/relate-bound-region-ice-144033.stderr
@@ -1,0 +1,98 @@
+error[E0392]: type parameter `T` is never used
+  --> $DIR/relate-bound-region-ice-144033.rs:11:25
+   |
+LL | struct DelegatingFooMut<T> {}
+   |                         ^ unused type parameter
+   |
+   = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
+   = help: if you intended `T` to be a const parameter, use `const T: /* Type */` instead
+
+error[E0195]: lifetime parameters do not match the trait definition
+  --> $DIR/relate-bound-region-ice-144033.rs:19:12
+   |
+LL |     fn bar<'a, I>(self, collection: &'a I)
+   |            ^^
+   |
+   = note: lifetime parameters differ in whether they are early- or late-bound
+note: `'a` differs between the trait and impl
+  --> $DIR/relate-bound-region-ice-144033.rs:7:12
+   |
+LL |   trait FooMut {
+   |   ------------ in this trait...
+LL |       type Baz: 'static;
+LL |       fn bar<'a, I>(self, iterator: &'a I)
+   |              ^^ `'a` is early-bound
+LL |       where
+LL |           for<'b> &'b I: IntoIterator<Item = &'b &'a Self::Baz>;
+   |                                       ------------------------ this lifetime bound makes `'a` early-bound
+...
+LL | / impl<T> FooMut for DelegatingFooMut<T>
+LL | | where
+LL | |     T: FooMut,
+   | |______________- in this impl...
+...
+LL |       fn bar<'a, I>(self, collection: &'a I)
+   |              ^^ `'a` is late-bound
+
+error[E0392]: type parameter `T` is never used
+  --> $DIR/relate-bound-region-ice-144033.rs:30:22
+   |
+LL | struct DelegatingBaz<T>;
+   |                      ^ unused type parameter
+   |
+   = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
+   = help: if you intended `T` to be a const parameter, use `const T: /* Type */` instead
+
+error[E0271]: type mismatch resolving `<&I as IntoIterator>::Item == &&DelegatingBaz<<T as FooMut>::Baz>`
+  --> $DIR/relate-bound-region-ice-144033.rs:25:18
+   |
+LL |         self.bar(collection)
+   |              --- ^^^^^^^^^^ expected `&&DelegatingBaz<<T as FooMut>::Baz>`, found associated type
+   |              |
+   |              required by a bound introduced by this call
+   |
+   = note:    expected reference `&&DelegatingBaz<<T as FooMut>::Baz>`
+           found associated type `<&I as IntoIterator>::Item`
+   = help: consider constraining the associated type `<&I as IntoIterator>::Item` to `&&DelegatingBaz<<T as FooMut>::Baz>`
+   = note: for more information, visit https://doc.rust-lang.org/book/ch19-03-advanced-traits.html
+note: the method call chain might not have had the expected associated types
+  --> $DIR/relate-bound-region-ice-144033.rs:19:37
+   |
+LL |     fn bar<'a, I>(self, collection: &'a I)
+   |                                     ^^^^^ `IntoIterator::Item` is `<&I as IntoIterator>::Item` here
+...
+LL |         let collection = collection.into_iter().map(|b| &b);
+   |                                     ----------- ----------- `IntoIterator::Item` changed to `&<&I as IntoIterator>::Item` here
+   |                                     |
+   |                                     `IntoIterator::Item` remains `<&I as IntoIterator>::Item` here
+note: required by a bound in `FooMut::bar`
+  --> $DIR/relate-bound-region-ice-144033.rs:9:37
+   |
+LL |     fn bar<'a, I>(self, iterator: &'a I)
+   |        --- required by a bound in this associated function
+LL |     where
+LL |         for<'b> &'b I: IntoIterator<Item = &'b &'a Self::Baz>;
+   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `FooMut::bar`
+
+error[E0308]: mismatched types
+  --> $DIR/relate-bound-region-ice-144033.rs:25:18
+   |
+LL |         let collection = collection.into_iter().map(|b| &b);
+   |                                                     --- the found closure
+LL |         self.bar(collection)
+   |              --- ^^^^^^^^^^ expected `&I`, found `Map<<&I as IntoIterator>::IntoIter, ...>`
+   |              |
+   |              arguments to this method are incorrect
+   |
+   = note: expected reference `&I`
+                 found struct `Map<<&I as IntoIterator>::IntoIter, {closure@$DIR/relate-bound-region-ice-144033.rs:24:53: 24:56}>`
+note: method defined here
+  --> $DIR/relate-bound-region-ice-144033.rs:7:8
+   |
+LL |     fn bar<'a, I>(self, iterator: &'a I)
+   |        ^^^              --------
+
+error: aborting due to 5 previous errors
+
+Some errors have detailed explanations: E0195, E0271, E0308, E0392.
+For more information about an error, try `rustc --explain E0195`.

--- a/tests/ui/higher-ranked/relate-bound-region-ice-144033.stderr
+++ b/tests/ui/higher-ranked/relate-bound-region-ice-144033.stderr
@@ -1,98 +1,53 @@
-error[E0392]: type parameter `T` is never used
-  --> $DIR/relate-bound-region-ice-144033.rs:11:25
-   |
-LL | struct DelegatingFooMut<T> {}
-   |                         ^ unused type parameter
-   |
-   = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
-   = help: if you intended `T` to be a const parameter, use `const T: /* Type */` instead
-
-error[E0195]: lifetime parameters do not match the trait definition
-  --> $DIR/relate-bound-region-ice-144033.rs:19:12
-   |
-LL |     fn bar<'a, I>(self, collection: &'a I)
-   |            ^^
-   |
-   = note: lifetime parameters differ in whether they are early- or late-bound
-note: `'a` differs between the trait and impl
-  --> $DIR/relate-bound-region-ice-144033.rs:7:12
-   |
-LL |   trait FooMut {
-   |   ------------ in this trait...
-LL |       type Baz: 'static;
-LL |       fn bar<'a, I>(self, iterator: &'a I)
-   |              ^^ `'a` is early-bound
-LL |       where
-LL |           for<'b> &'b I: IntoIterator<Item = &'b &'a Self::Baz>;
-   |                                       ------------------------ this lifetime bound makes `'a` early-bound
-...
-LL | / impl<T> FooMut for DelegatingFooMut<T>
-LL | | where
-LL | |     T: FooMut,
-   | |______________- in this impl...
-...
-LL |       fn bar<'a, I>(self, collection: &'a I)
-   |              ^^ `'a` is late-bound
-
-error[E0392]: type parameter `T` is never used
-  --> $DIR/relate-bound-region-ice-144033.rs:30:22
-   |
-LL | struct DelegatingBaz<T>;
-   |                      ^ unused type parameter
-   |
-   = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
-   = help: if you intended `T` to be a const parameter, use `const T: /* Type */` instead
-
-error[E0271]: type mismatch resolving `<&I as IntoIterator>::Item == &&DelegatingBaz<<T as FooMut>::Baz>`
-  --> $DIR/relate-bound-region-ice-144033.rs:25:18
+error[E0271]: expected `&I` to be an iterator that yields `&()`, but it yields `<&I as Iterator>::Item`
+  --> $DIR/relate-bound-region-ice-144033.rs:17:18
    |
 LL |         self.bar(collection)
-   |              --- ^^^^^^^^^^ expected `&&DelegatingBaz<<T as FooMut>::Baz>`, found associated type
+   |              --- ^^^^^^^^^^ expected `&()`, found associated type
    |              |
    |              required by a bound introduced by this call
    |
-   = note:    expected reference `&&DelegatingBaz<<T as FooMut>::Baz>`
-           found associated type `<&I as IntoIterator>::Item`
-   = help: consider constraining the associated type `<&I as IntoIterator>::Item` to `&&DelegatingBaz<<T as FooMut>::Baz>`
+   = note:    expected reference `&()`
+           found associated type `<&I as Iterator>::Item`
+   = help: consider constraining the associated type `<&I as Iterator>::Item` to `&()`
    = note: for more information, visit https://doc.rust-lang.org/book/ch19-03-advanced-traits.html
 note: the method call chain might not have had the expected associated types
-  --> $DIR/relate-bound-region-ice-144033.rs:19:37
+  --> $DIR/relate-bound-region-ice-144033.rs:16:51
    |
-LL |     fn bar<'a, I>(self, collection: &'a I)
-   |                                     ^^^^^ `IntoIterator::Item` is `<&I as IntoIterator>::Item` here
-...
-LL |         let collection = collection.into_iter().map(|b| &b);
-   |                                     ----------- ----------- `IntoIterator::Item` changed to `&<&I as IntoIterator>::Item` here
-   |                                     |
-   |                                     `IntoIterator::Item` remains `<&I as IntoIterator>::Item` here
+LL |         let collection = std::iter::empty::<()>().map(|_| &());
+   |                          ------------------------ ^^^^^^^^^^^^ `Iterator::Item` is `&()` here
+   |                          |
+   |                          this expression has type `Empty<()>`
 note: required by a bound in `FooMut::bar`
-  --> $DIR/relate-bound-region-ice-144033.rs:9:37
+  --> $DIR/relate-bound-region-ice-144033.rs:8:33
    |
-LL |     fn bar<'a, I>(self, iterator: &'a I)
+LL |     fn bar<I>(self, _: I)
    |        --- required by a bound in this associated function
 LL |     where
-LL |         for<'b> &'b I: IntoIterator<Item = &'b &'a Self::Baz>;
-   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `FooMut::bar`
+LL |         for<'b> &'b I: Iterator<Item = &'b ()>;
+   |                                 ^^^^^^^^^^^^^ required by this bound in `FooMut::bar`
 
 error[E0308]: mismatched types
-  --> $DIR/relate-bound-region-ice-144033.rs:25:18
+  --> $DIR/relate-bound-region-ice-144033.rs:17:18
    |
-LL |         let collection = collection.into_iter().map(|b| &b);
-   |                                                     --- the found closure
+LL |     fn bar<I>(self, _: I)
+   |            - expected this type parameter
+...
+LL |         let collection = std::iter::empty::<()>().map(|_| &());
+   |                                                       --- the found closure
 LL |         self.bar(collection)
-   |              --- ^^^^^^^^^^ expected `&I`, found `Map<<&I as IntoIterator>::IntoIter, ...>`
+   |              --- ^^^^^^^^^^ expected type parameter `I`, found `Map<Empty<()>, {closure@...}>`
    |              |
    |              arguments to this method are incorrect
    |
-   = note: expected reference `&I`
-                 found struct `Map<<&I as IntoIterator>::IntoIter, {closure@$DIR/relate-bound-region-ice-144033.rs:24:53: 24:56}>`
+   = note: expected type parameter `I`
+                      found struct `Map<std::iter::Empty<()>, {closure@$DIR/relate-bound-region-ice-144033.rs:16:55: 16:58}>`
 note: method defined here
-  --> $DIR/relate-bound-region-ice-144033.rs:7:8
+  --> $DIR/relate-bound-region-ice-144033.rs:6:8
    |
-LL |     fn bar<'a, I>(self, iterator: &'a I)
-   |        ^^^              --------
+LL |     fn bar<I>(self, _: I)
+   |        ^^^          -
 
-error: aborting due to 5 previous errors
+error: aborting due to 2 previous errors
 
-Some errors have detailed explanations: E0195, E0271, E0308, E0392.
-For more information about an error, try `rustc --explain E0195`.
+Some errors have detailed explanations: E0271, E0308.
+For more information about an error, try `rustc --explain E0271`.

--- a/tests/ui/higher-ranked/trait-bounds/hang-on-deeply-nested-dyn.stderr
+++ b/tests/ui/higher-ranked/trait-bounds/hang-on-deeply-nested-dyn.stderr
@@ -11,7 +11,7 @@ LL | |     ),
 LL | | ) {
    | |_- expected `&dyn for<'a> Fn(&'a (dyn for<'a> Fn(&'a (dyn for<'a> Fn(&'a (dyn for<'a> Fn(&'a (dyn for<'a> Fn(&'a (dyn for<'a> Fn(&'a (dyn for<'a> Fn(&'a (dyn for<'a> Fn(&'a (dyn for<'a> Fn(&'a (dyn for<'a> Fn(&'a (dyn for<'a> Fn(&'a (dyn Fn(u32) + 'a)) + 'a)) + 'a)) + 'a)) + 'a)) + 'a)) + 'a)) + 'a)) + 'a)) + 'a)) + 'a))` because of return type
 LL |       f
-   |       ^ expected `&dyn Fn(&dyn Fn(&dyn Fn(&dyn Fn(&...))))`, found `&dyn Fn(u32)`
+   |       ^ expected `&dyn Fn(&dyn Fn(&dyn Fn(&dyn Fn(&_))))`, found `&dyn Fn(u32)`
    |
    = note: expected reference `&dyn for<'a> Fn(&'a (dyn for<'a> Fn(&'a (dyn for<'a> Fn(&'a (dyn for<'a> Fn(&'a (dyn for<'a> Fn(&'a (dyn for<'a> Fn(&'a (dyn for<'a> Fn(&'a (dyn for<'a> Fn(&'a (dyn for<'a> Fn(&'a (dyn for<'a> Fn(&'a (dyn for<'a> Fn(&'a (dyn Fn(u32) + 'a)) + 'a)) + 'a)) + 'a)) + 'a)) + 'a)) + 'a)) + 'a)) + 'a)) + 'a)) + 'a))`
               found reference `&dyn Fn(u32)`

--- a/tests/ui/inference/really-long-type-in-let-binding-without-sufficient-type-info.stderr
+++ b/tests/ui/inference/really-long-type-in-let-binding-without-sufficient-type-info.stderr
@@ -1,4 +1,4 @@
-error[E0282]: type annotations needed for `Result<_, (((..., ..., ..., ...), ..., ..., ...), ..., ..., ...)>`
+error[E0282]: type annotations needed for `Result<_, ((((i32, i32, i32, i32), _, _, _), _, _, _), _, _, _)>`
   --> $DIR/really-long-type-in-let-binding-without-sufficient-type-info.rs:8:9
    |
 LL |     let y = Err(x);

--- a/tests/ui/infinite/infinite-instantiation-struct-tail-ice-114484.rs
+++ b/tests/ui/infinite/infinite-instantiation-struct-tail-ice-114484.rs
@@ -10,7 +10,7 @@
 //~| ERROR reached the recursion limit finding the struct tail for `VirtualWrapper<SomeData<256>, 0>`
 //~| ERROR reached the recursion limit finding the struct tail for `VirtualWrapper<SomeData<256>, 0>`
 //~| ERROR reached the recursion limit finding the struct tail for `VirtualWrapper<SomeData<256>, 0>`
-//~| ERROR reached the recursion limit while instantiating `<VirtualWrapper<..., 1> as MyTrait>::virtualize`
+//~| ERROR reached the recursion limit while instantiating `<VirtualWrapper<_, 1> as MyTrait>::virtualize`
 
 //@ build-fail
 //@ compile-flags: --diagnostic-width=100 -Zwrite-long-types-to-disk=yes

--- a/tests/ui/infinite/infinite-instantiation-struct-tail-ice-114484.stderr
+++ b/tests/ui/infinite/infinite-instantiation-struct-tail-ice-114484.stderr
@@ -17,7 +17,7 @@ error: reached the recursion limit finding the struct tail for `[u8; 256]`
    = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]`
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-note: the above error was encountered while instantiating `fn virtualize_my_trait::<VirtualWrapper<..., 1>>`
+note: the above error was encountered while instantiating `fn virtualize_my_trait::<VirtualWrapper<_, 1>>`
   --> $DIR/infinite-instantiation-struct-tail-ice-114484.rs:38:18
    |
 LL |         unsafe { virtualize_my_trait(L, self) }
@@ -45,7 +45,7 @@ error: reached the recursion limit finding the struct tail for `SomeData<256>`
    = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]`
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-note: the above error was encountered while instantiating `fn virtualize_my_trait::<VirtualWrapper<..., 1>>`
+note: the above error was encountered while instantiating `fn virtualize_my_trait::<VirtualWrapper<_, 1>>`
   --> $DIR/infinite-instantiation-struct-tail-ice-114484.rs:38:18
    |
 LL |         unsafe { virtualize_my_trait(L, self) }
@@ -73,7 +73,7 @@ error: reached the recursion limit finding the struct tail for `VirtualWrapper<S
    = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]`
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-note: the above error was encountered while instantiating `fn virtualize_my_trait::<VirtualWrapper<..., 1>>`
+note: the above error was encountered while instantiating `fn virtualize_my_trait::<VirtualWrapper<_, 1>>`
   --> $DIR/infinite-instantiation-struct-tail-ice-114484.rs:38:18
    |
 LL |         unsafe { virtualize_my_trait(L, self) }
@@ -82,7 +82,7 @@ LL |         unsafe { virtualize_my_trait(L, self) }
    = note: the full name for the type has been written to '$TEST_BUILD_DIR/infinite-instantiation-struct-tail-ice-114484.long-type-$LONG_TYPE_HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
 
-error: reached the recursion limit while instantiating `<VirtualWrapper<..., 1> as MyTrait>::virtualize`
+error: reached the recursion limit while instantiating `<VirtualWrapper<_, 1> as MyTrait>::virtualize`
    |
 note: `<VirtualWrapper<T, L> as MyTrait>::virtualize` defined here
   --> $DIR/infinite-instantiation-struct-tail-ice-114484.rs:37:5

--- a/tests/ui/infinite/infinite-instantiation.stderr
+++ b/tests/ui/infinite/infinite-instantiation.stderr
@@ -1,4 +1,4 @@
-error: reached the recursion limit while instantiating `function::<Option<Option<Option<Option<...>>>>>`
+error: reached the recursion limit while instantiating `function::<Option<Option<Option<Option<_>>>>>`
   --> $DIR/infinite-instantiation.rs:22:9
    |
 LL |         function(counter - 1, t.to_option());

--- a/tests/ui/issues/issue-37311-type-length-limit/issue-37311.stderr
+++ b/tests/ui/issues/issue-37311-type-length-limit/issue-37311.stderr
@@ -1,4 +1,4 @@
-error: reached the recursion limit while instantiating `<(&(&(&..., ...), ...), ...) as Foo>::recurse`
+error: reached the recursion limit while instantiating `<(&(&(&(&(&_, _), _), _), _), _) as Foo>::recurse`
   --> $DIR/issue-37311.rs:17:9
    |
 LL |         (self, self).recurse();

--- a/tests/ui/lazy-type-alias/inherent-impls-overflow.current.stderr
+++ b/tests/ui/lazy-type-alias/inherent-impls-overflow.current.stderr
@@ -14,7 +14,7 @@ LL | impl Loop {}
    |
    = note: in case this is a recursive type alias, consider using a struct, enum, or union instead
 
-error[E0275]: overflow normalizing the type alias `Poly0<(((((((...,),),),),),),)>`
+error[E0275]: overflow normalizing the type alias `Poly0<(((((((_,),),),),),),)>`
   --> $DIR/inherent-impls-overflow.rs:17:1
    |
 LL | type Poly0<T> = Poly1<(T,)>;
@@ -22,7 +22,7 @@ LL | type Poly0<T> = Poly1<(T,)>;
    |
    = note: in case this is a recursive type alias, consider using a struct, enum, or union instead
 
-error[E0275]: overflow normalizing the type alias `Poly1<(((((((...,),),),),),),)>`
+error[E0275]: overflow normalizing the type alias `Poly1<(((((((_,),),),),),),)>`
   --> $DIR/inherent-impls-overflow.rs:20:1
    |
 LL | type Poly1<T> = Poly0<(T,)>;
@@ -30,7 +30,7 @@ LL | type Poly1<T> = Poly0<(T,)>;
    |
    = note: in case this is a recursive type alias, consider using a struct, enum, or union instead
 
-error[E0275]: overflow normalizing the type alias `Poly1<(((((((...,),),),),),),)>`
+error[E0275]: overflow normalizing the type alias `Poly1<(((((((_,),),),),),),)>`
   --> $DIR/inherent-impls-overflow.rs:24:1
    |
 LL | impl Poly0<()> {}

--- a/tests/ui/lazy-type-alias/inherent-impls-overflow.rs
+++ b/tests/ui/lazy-type-alias/inherent-impls-overflow.rs
@@ -15,14 +15,14 @@ impl Loop {}
 //[next]~| ERROR overflow evaluating the requirement `Loop == _`
 
 type Poly0<T> = Poly1<(T,)>;
-//[current]~^ ERROR overflow normalizing the type alias `Poly0<(((((((...,),),),),),),)>`
+//[current]~^ ERROR overflow normalizing the type alias `Poly0<(((((((_,),),),),),),)>`
 //[next]~^^ ERROR overflow evaluating the requirement
 type Poly1<T> = Poly0<(T,)>;
-//[current]~^ ERROR  overflow normalizing the type alias `Poly1<(((((((...,),),),),),),)>`
+//[current]~^ ERROR  overflow normalizing the type alias `Poly1<(((((((_,),),),),),),)>`
 //[next]~^^ ERROR overflow evaluating the requirement
 
 impl Poly0<()> {}
-//[current]~^ ERROR overflow normalizing the type alias `Poly1<(((((((...,),),),),),),)>`
+//[current]~^ ERROR overflow normalizing the type alias `Poly1<(((((((_,),),),),),),)>`
 //[next]~^^ ERROR overflow evaluating the requirement `Poly0<()> == _`
 //[next]~| ERROR overflow evaluating the requirement
 

--- a/tests/ui/limits/type-length-limit-enforcement.stderr
+++ b/tests/ui/limits/type-length-limit-enforcement.stderr
@@ -1,4 +1,4 @@
-error: reached the type-length limit while instantiating `drop::<Option<((..., ..., ...), ..., ...)>>`
+error: reached the type-length limit while instantiating `drop::<Option<((((_, _, _), _, _), _, _), _, _)>>`
   --> $DIR/type-length-limit-enforcement.rs:34:5
    |
 LL |     drop::<Option<A>>(None);

--- a/tests/ui/methods/inherent-bound-in-probe.stderr
+++ b/tests/ui/methods/inherent-bound-in-probe.stderr
@@ -28,7 +28,7 @@ LL | where
 LL |     &'a T: IntoIterator<Item = &'a u8>,
    |                         ------------- unsatisfied trait bound introduced here
    = note: 126 redundant requirements hidden
-   = note: required for `&BitReaderWrapper<BitReaderWrapper<BitReaderWrapper<...>>>` to implement `IntoIterator`
+   = note: required for `&BitReaderWrapper<BitReaderWrapper<BitReaderWrapper<_>>>` to implement `IntoIterator`
 note: required by a bound in `Helper`
   --> $DIR/inherent-bound-in-probe.rs:17:12
    |

--- a/tests/ui/methods/probe-error-on-infinite-deref.stderr
+++ b/tests/ui/methods/probe-error-on-infinite-deref.stderr
@@ -1,4 +1,4 @@
-error[E0055]: reached the recursion limit while auto-dereferencing `Wrap<Wrap<Wrap<Wrap<Wrap<Wrap<Wrap<Wrap<Wrap<Wrap<Wrap<...>>>>>>>>>>>`
+error[E0055]: reached the recursion limit while auto-dereferencing `Wrap<Wrap<Wrap<Wrap<Wrap<Wrap<Wrap<Wrap<Wrap<Wrap<Wrap<_>>>>>>>>>>>`
   --> $DIR/probe-error-on-infinite-deref.rs:14:13
    |
 LL |     Wrap(1).lmao();

--- a/tests/ui/mismatched_types/mismatch-sugg-for-shorthand-field.stderr
+++ b/tests/ui/mismatched_types/mismatch-sugg-for-shorthand-field.stderr
@@ -55,7 +55,7 @@ LL |     let a = async { 42 };
    |             ----- the found `async` block
 ...
 LL |     let s = Demo { a };
-   |                    ^ expected `Pin<Box<...>>`, found `async` block
+   |                    ^ expected `Pin<Box<_>>`, found `async` block
    |
    = note:     expected struct `Pin<Box<(dyn Future<Output = i32> + Send + 'static)>>`
            found `async` block `{async block@$DIR/mismatch-sugg-for-shorthand-field.rs:53:13: 53:18}`

--- a/tests/ui/parallel-rustc/dyn-trait-ice-153366.stderr
+++ b/tests/ui/parallel-rustc/dyn-trait-ice-153366.stderr
@@ -52,7 +52,7 @@ LL | fn iso<A>(a: Fn) -> Option<_>
    |                     --------- expected `Option<_>` because of return type
 ...
 LL |     Box::new(iso_un_option)
-   |     ^^^^^^^^^^^^^^^^^^^^^^^ expected `Option<_>`, found `Box<fn() -> ... {iso_un_option::<_>}>`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^ expected `Option<_>`, found `Box<fn() -> _ {iso_un_option::<_>}>`
    |
    = note: expected enum `Option<_>`
             found struct `Box<fn() -> {type error} {iso_un_option::<_>}>`

--- a/tests/ui/recursion/infinite-function-recursion-error-8727.stderr
+++ b/tests/ui/recursion/infinite-function-recursion-error-8727.stderr
@@ -9,7 +9,7 @@ LL |     generic::<Option<T>>();
    = help: a `loop` may express intention better if this is on purpose
    = note: `#[warn(unconditional_recursion)]` on by default
 
-error: reached the recursion limit while instantiating `generic::<Option<Option<Option<Option<...>>>>>`
+error: reached the recursion limit while instantiating `generic::<Option<Option<Option<Option<_>>>>>`
   --> $DIR/infinite-function-recursion-error-8727.rs:9:5
    |
 LL |     generic::<Option<T>>();

--- a/tests/ui/recursion/issue-23122-2.stderr
+++ b/tests/ui/recursion/issue-23122-2.stderr
@@ -1,11 +1,11 @@
-error[E0275]: overflow evaluating the requirement `<<<<<<<... as Next>::Next as Next>::Next as Next>::Next as Next>::Next as Next>::Next as Next>::Next as Next>::Next: Sized`
+error[E0275]: overflow evaluating the requirement `<<<<<<<_ as Next>::Next as Next>::Next as Next>::Next as Next>::Next as Next>::Next as Next>::Next as Next>::Next: Sized`
   --> $DIR/issue-23122-2.rs:11:17
    |
 LL |     type Next = <GetNext<T::Next> as Next>::Next;
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`issue_23122_2`)
-note: required for `GetNext<<<<... as Next>::Next as Next>::Next as Next>::Next>` to implement `Next`
+note: required for `GetNext<<<<_ as Next>::Next as Next>::Next as Next>::Next>` to implement `Next`
   --> $DIR/issue-23122-2.rs:10:15
    |
 LL | impl<T: Next> Next for GetNext<T> {

--- a/tests/ui/recursion/issue-38591-non-regular-dropck-recursion.stderr
+++ b/tests/ui/recursion/issue-38591-non-regular-dropck-recursion.stderr
@@ -4,7 +4,7 @@ error[E0320]: overflow while adding drop-check rules for `S<u32>`
 LL | fn f(x: S<u32>) {}
    |      ^
    |
-   = note: overflowed on `S<fn(fn(fn(fn(fn(fn(fn(fn(fn(fn(fn(fn(fn(fn(fn(fn(...))))))))))))))))>`
+   = note: overflowed on `S<fn(fn(fn(fn(fn(fn(fn(fn(fn(fn(fn(fn(fn(fn(fn(fn(_))))))))))))))))>`
    = note: the full name for the type has been written to '$TEST_BUILD_DIR/issue-38591-non-regular-dropck-recursion.long-type-$LONG_TYPE_HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
 

--- a/tests/ui/recursion/issue-83150.stderr
+++ b/tests/ui/recursion/issue-83150.stderr
@@ -15,7 +15,7 @@ error[E0275]: overflow evaluating the requirement `Map<&mut std::ops::Range<u8>,
    = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`issue_83150`)
    = note: required for `&mut Map<&mut Range<u8>, {closure@issue-83150.rs:12:24}>` to implement `Iterator`
    = note: 65 redundant requirements hidden
-   = note: required for `&mut Map<&mut Map<&mut Map<&mut Map<&mut ..., ...>, ...>, ...>, ...>` to implement `Iterator`
+   = note: required for `&mut Map<&mut Map<&mut Map<&mut Map<&mut Map<_, _>, _>, _>, _>, _>` to implement `Iterator`
    = note: the full name for the type has been written to '$TEST_BUILD_DIR/issue-83150.long-type-$LONG_TYPE_HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
 

--- a/tests/ui/recursion/recursion.stderr
+++ b/tests/ui/recursion/recursion.stderr
@@ -1,4 +1,4 @@
-error: reached the recursion limit while instantiating `test::<Cons<Cons<Cons<Cons<Cons<Cons<...>>>>>>>`
+error: reached the recursion limit while instantiating `test::<Cons<Cons<Cons<Cons<Cons<Cons<_>>>>>>>`
   --> $DIR/recursion.rs:17:11
    |
 LL |     _ => {test (n-1, i+1, Cons {head:2*i+1, tail:first}, Cons{head:i*i, tail:second})}

--- a/tests/ui/recursion/recursive-impl-trait-iterator-by-ref-67552.stderr
+++ b/tests/ui/recursion/recursive-impl-trait-iterator-by-ref-67552.stderr
@@ -1,4 +1,4 @@
-error: reached the recursion limit while instantiating `rec::<&mut &mut &mut &mut &mut &mut &mut &mut ...>`
+error: reached the recursion limit while instantiating `rec::<&mut &mut &mut &mut &mut &mut &mut &mut _>`
   --> $DIR/recursive-impl-trait-iterator-by-ref-67552.rs:28:9
    |
 LL |         rec(identity(&mut it))

--- a/tests/ui/suggestions/box-future-wrong-output.stderr
+++ b/tests/ui/suggestions/box-future-wrong-output.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/box-future-wrong-output.rs:20:39
    |
 LL |     let _: BoxFuture<'static, bool> = async {}.boxed();
-   |            ------------------------   ^^^^^^^^^^^^^^^^ expected `Pin<Box<...>>`, found `Pin<Box<dyn Future<Output = ()> + Send>>`
+   |            ------------------------   ^^^^^^^^^^^^^^^^ expected `Pin<Box<_>>`, found `Pin<Box<dyn Future<Output = ()> + Send>>`
    |            |
    |            expected due to this
    |

--- a/tests/ui/suggestions/expected-boxed-future-isnt-pinned.stderr
+++ b/tests/ui/suggestions/expected-boxed-future-isnt-pinned.stderr
@@ -5,7 +5,7 @@ LL | fn foo<F: Future<Output=i32> + Send + 'static>(x: F) -> BoxFuture<'static, 
    |        - found this type parameter                      ----------------------- expected `Pin<Box<(dyn Future<Output = i32> + Send + 'static)>>` because of return type
 LL |     // We could instead use an `async` block, but this way we have no std spans.
 LL |     x
-   |     ^ expected `Pin<Box<...>>`, found type parameter `F`
+   |     ^ expected `Pin<Box<_>>`, found type parameter `F`
    |
    = note:      expected struct `Pin<Box<(dyn Future<Output = i32> + Send + 'static)>>`
            found type parameter `F`
@@ -20,7 +20,7 @@ error[E0308]: mismatched types
 LL | fn bar<F: Future<Output=i32> + Send + 'static>(x: F) -> BoxFuture<'static, i32> {
    |                                                         ----------------------- expected `Pin<Box<(dyn Future<Output = i32> + Send + 'static)>>` because of return type
 LL |     Box::new(x)
-   |     ^^^^^^^^^^^ expected `Pin<Box<...>>`, found `Box<F>`
+   |     ^^^^^^^^^^^ expected `Pin<Box<_>>`, found `Box<F>`
    |
    = note: expected struct `Pin<Box<(dyn Future<Output = i32> + Send + 'static)>>`
               found struct `Box<F>`
@@ -76,7 +76,7 @@ LL |   fn zap() -> BoxFuture<'static, i32> {
 LL | /     async {
 LL | |         42
 LL | |     }
-   | |_____^ expected `Pin<Box<...>>`, found `async` block
+   | |_____^ expected `Pin<Box<_>>`, found `async` block
    |
    = note:     expected struct `Pin<Box<(dyn Future<Output = i32> + Send + 'static)>>`
            found `async` block `{async block@$DIR/expected-boxed-future-isnt-pinned.rs:28:5: 28:10}`

--- a/tests/ui/suggestions/issue-107860.stderr
+++ b/tests/ui/suggestions/issue-107860.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/issue-107860.rs:3:36
    |
 LL | async fn str<T>(T: &str) -> &str { &str }
-   |                                    ^^^^ expected `&str`, found `&fn(&str) -> ... {str::<_>}`
+   |                                    ^^^^ expected `&str`, found `&fn(&str) -> _ {str::<_>}`
    |
    = note: expected reference `&str`
               found reference `&for<'a> fn(&'a str) -> impl Future<Output = &'a str> {str::<_>}`

--- a/tests/ui/trait-bounds/associated-error-bound-issue-145586.stderr
+++ b/tests/ui/trait-bounds/associated-error-bound-issue-145586.stderr
@@ -8,7 +8,7 @@ LL |     fn deserialize_ignored_any<V>(self, visitor: V) -> Result<V::Value, Sel
    |                                                        ----------------------------- expected `Result<<V as Visitor<'de>>::Value, E>` because of return type
 ...
 LL |             Ok(deserializer) => deserializer.deserialize_ignored_any(visitor),
-   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Result<<V as Visitor<'_>>::Value, E>`, found `Result<<V as Visitor<'_>>::Value, ...>`
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Result<<V as Visitor<'_>>::Value, E>`, found `Result<<V as Visitor<'_>>::Value, _>`
    |
    = note: expected enum `Result<_, E>`
               found enum `Result<_, <T as Deserializer<'de>>::Error>`

--- a/tests/ui/traits/issue-68295.stderr
+++ b/tests/ui/traits/issue-68295.stderr
@@ -5,7 +5,7 @@ LL | fn crash<R, C>(input: Matrix<R, C, ()>) -> Matrix<R, C, u32>
    |                                            ----------------- expected `Matrix<R, C, u32>` because of return type
 ...
 LL |     input.into_owned()
-   |     ^^^^^^^^^^^^^^^^^^ expected `Matrix<R, C, u32>`, found `Matrix<R, C, ...>`
+   |     ^^^^^^^^^^^^^^^^^^ expected `Matrix<R, C, u32>`, found `Matrix<R, C, _>`
    |
    = note: expected struct `Matrix<_, _, u32>`
               found struct `Matrix<_, _, <() as Allocator<R, C>>::Buffer>`

--- a/tests/ui/traits/issue-91949-hangs-on-recursion.stderr
+++ b/tests/ui/traits/issue-91949-hangs-on-recursion.stderr
@@ -24,7 +24,7 @@ LL | impl<T, I: Iterator<Item = T>> Iterator for IteratorOfWrapped<T, I> {
    |                     |
    |                     unsatisfied trait bound introduced here
    = note: 256 redundant requirements hidden
-   = note: required for `IteratorOfWrapped<(), Map<IteratorOfWrapped<(), Map<..., ...>>, ...>>` to implement `Iterator`
+   = note: required for `IteratorOfWrapped<(), Map<IteratorOfWrapped<(), Map<_, _>>, _>>` to implement `Iterator`
    = note: the full name for the type has been written to '$TEST_BUILD_DIR/issue-91949-hangs-on-recursion.long-type-$LONG_TYPE_HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
 

--- a/tests/ui/traits/next-solver/overflow/global-cache.stderr
+++ b/tests/ui/traits/next-solver/overflow/global-cache.stderr
@@ -1,4 +1,4 @@
-error[E0275]: overflow evaluating the requirement `Inc<Inc<Inc<Inc<Inc<Inc<Inc<...>>>>>>>: Trait`
+error[E0275]: overflow evaluating the requirement `Inc<Inc<Inc<Inc<Inc<Inc<Inc<_>>>>>>>: Trait`
   --> $DIR/global-cache.rs:21:19
    |
 LL |     impls_trait::<Four<Four<Four<Four<()>>>>>();

--- a/tests/ui/traits/next-solver/rerun-if-any-opaque-or-has-infer-as-hidden-in-codegen.rs
+++ b/tests/ui/traits/next-solver/rerun-if-any-opaque-or-has-infer-as-hidden-in-codegen.rs
@@ -1,0 +1,34 @@
+//@ compile-flags: -Znext-solver
+//@ check-pass
+
+fn mk_vec() -> Vec<Vec<&'static str>> {
+    loop {}
+}
+
+fn parse_feature(feature: &str) -> impl Iterator<Item = &str> {
+    std::iter::once(feature)
+}
+
+fn main() {
+    // In `codegen_select_candidate`, we try to find an impl for `FlatMap::into_iter`
+    // We try to prove `FlatMap<...>: IntoIterator`.
+    // The blanket impl requires `FlatMap<...>: Iterator`.
+    // The `Iterator` impl of `FlatMap` has nested goals:
+    // `Projection(Fn::Output<parse_feature, (?assoc,)>, iter::Once`.
+    // We normalize this goal and set rerun condition to `AnyOpaqueHasInferAsHidden`
+    // with reason `SelfTyInfer` because we instantiated impls with infers when
+    // assembling candidates for intermediate goals.
+    // Then we evaluate the normalized goal:
+    // `Projection(Fn::Output<parse_feature, (&str,)>, iter::Once`.
+    // The alias term is normalized to rigid alias `impl Iterator<Item = &str>` as
+    // we're in `TypingMode::ErasedNotCoherence`.
+    // But the expected term is revealed `iter::Once` thus relating failed.
+    // The goal fails with rerun condition `OpaqueInStorage(parse_feature::opaque)`.
+    // This goal should be rerun in `TypingMode::Codegen` mode, but
+    // `AnyOpaqueHasInferAsHidden + OpaqueInStorage = OpaqueInStorageOrAnyOpaqueHasInferAsHidden`
+    // which didn't trigger rerun in `TypingMode::Codegen` mode previously.
+    mk_vec()
+        .into_iter()
+        .flatten()
+        .flat_map(parse_feature).into_iter();
+}

--- a/tests/ui/traits/on_unimplemented_long_types.stderr
+++ b/tests/ui/traits/on_unimplemented_long_types.stderr
@@ -1,4 +1,4 @@
-error[E0277]: `Option<Option<Option<...>>>` doesn't implement `std::fmt::Display`
+error[E0277]: `Option<Option<Option<_>>>` doesn't implement `std::fmt::Display`
   --> $DIR/on_unimplemented_long_types.rs:3:17
    |
 LL |   pub fn foo() -> impl std::fmt::Display {
@@ -11,9 +11,9 @@ LL | |                 Some(Some(Some(Some(Some(Some(Some...
 ...  |
 LL | |         ))))))))))),
 LL | |     )))))))))))
-   | |_______________- return type was inferred to be `Option<Option<Option<...>>>` here
+   | |_______________- return type was inferred to be `Option<Option<Option<_>>>` here
    |
-   = help: the trait `std::fmt::Display` is not implemented for `Option<Option<Option<...>>>`
+   = help: the trait `std::fmt::Display` is not implemented for `Option<Option<Option<_>>>`
    = note: the full name for the type has been written to '$TEST_BUILD_DIR/on_unimplemented_long_types.long-type-$LONG_TYPE_HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
 

--- a/tests/ui/traits/trait-impl-overflow-with-where-clause-20413.stderr
+++ b/tests/ui/traits/trait-impl-overflow-with-where-clause-20413.stderr
@@ -7,7 +7,7 @@ LL | struct NoData<T>;
    = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
    = help: if you intended `T` to be a const parameter, use `const T: /* Type */` instead
 
-error[E0275]: overflow evaluating the requirement `NoData<NoData<NoData<NoData<NoData<NoData<NoData<...>>>>>>>: Foo`
+error[E0275]: overflow evaluating the requirement `NoData<NoData<NoData<NoData<NoData<NoData<NoData<_>>>>>>>: Foo`
   --> $DIR/trait-impl-overflow-with-where-clause-20413.rs:9:36
    |
 LL | impl<T> Foo for T where NoData<T>: Foo {
@@ -22,7 +22,7 @@ LL | impl<T> Foo for T where NoData<T>: Foo {
    = note: 126 redundant requirements hidden
    = note: required for `NoData<T>` to implement `Foo`
 
-error[E0275]: overflow evaluating the requirement `AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<...>>>>>>>: Bar`
+error[E0275]: overflow evaluating the requirement `AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<_>>>>>>>: Bar`
   --> $DIR/trait-impl-overflow-with-where-clause-20413.rs:28:42
    |
 LL | impl<T> Bar for T where EvenLessData<T>: Baz {
@@ -42,7 +42,7 @@ LL | impl<T> Bar for T where EvenLessData<T>: Baz {
    = note: 125 redundant requirements hidden
    = note: required for `EvenLessData<T>` to implement `Baz`
 
-error[E0275]: overflow evaluating the requirement `EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<...>>>>>>>: Baz`
+error[E0275]: overflow evaluating the requirement `EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<_>>>>>>>: Baz`
   --> $DIR/trait-impl-overflow-with-where-clause-20413.rs:35:42
    |
 LL | impl<T> Baz for T where AlmostNoData<T>: Bar {

--- a/tests/ui/trimmed-paths/doc-hidden.rs
+++ b/tests/ui/trimmed-paths/doc-hidden.rs
@@ -44,7 +44,7 @@ fn uses_local() {
         DocHiddenInHiddenMod,
     ) = 3u32;
     //~^ ERROR mismatched types [E0308]
-    //~| NOTE expected `(ActuallyPub, ..., ..., ..., ..., ...)`, found `u32`
+    //~| NOTE expected `(ActuallyPub, DocHidden, _, _, _, _)`, found `u32`
     //~| NOTE expected tuple `(local::ActuallyPub, DocHidden, local::pub_mod::ActuallyPubInPubMod, DocHiddenInPubMod, ActuallyPubInHiddenMod, DocHiddenInHiddenMod)`
 }
 
@@ -63,6 +63,6 @@ fn uses_helper() {
         DocHiddenInHiddenMod,
     ) = 3u32;
     //~^ ERROR mismatched types [E0308]
-    //~| NOTE expected `(ActuallyPub, ..., ..., ..., ..., ...)`, found `u32`
+    //~| NOTE expected `(ActuallyPub, DocHidden, _, _, _, _)`, found `u32`
     //~| NOTE expected tuple `(doc_hidden_helper::ActuallyPub, doc_hidden_helper::DocHidden, doc_hidden_helper::pub_mod::ActuallyPubInPubMod, doc_hidden_helper::pub_mod::DocHiddenInPubMod, doc_hidden_helper::hidden_mod::ActuallyPubInHiddenMod, doc_hidden_helper::hidden_mod::DocHiddenInHiddenMod)`
 }

--- a/tests/ui/trimmed-paths/doc-hidden.stderr
+++ b/tests/ui/trimmed-paths/doc-hidden.stderr
@@ -9,7 +9,7 @@ LL | |         DocHidden,
 ...  |
 LL | |         DocHiddenInHiddenMod,
 LL | |     ) = 3u32;
-   | |     -   ^^^^ expected `(ActuallyPub, ..., ..., ..., ..., ...)`, found `u32`
+   | |     -   ^^^^ expected `(ActuallyPub, DocHidden, _, _, _, _)`, found `u32`
    | |_____|
    |       expected due to this
    |
@@ -27,7 +27,7 @@ LL | |         DocHidden,
 ...  |
 LL | |         DocHiddenInHiddenMod,
 LL | |     ) = 3u32;
-   | |     -   ^^^^ expected `(ActuallyPub, ..., ..., ..., ..., ...)`, found `u32`
+   | |     -   ^^^^ expected `(ActuallyPub, DocHidden, _, _, _, _)`, found `u32`
    | |_____|
    |       expected due to this
    |

--- a/tests/ui/type-alias-impl-trait/send-bound-nested-async-95719.rs
+++ b/tests/ui/type-alias-impl-trait/send-bound-nested-async-95719.rs
@@ -1,0 +1,53 @@
+// Regression test for <https://github.com/rust-lang/rust/issues/95719>.
+// The `Send` bound of a GAT `impl Future` was lost when the future was
+// wrapped in another `async fn`, failing with "the parameter type `G` may
+// not live long enough".
+//@ check-pass
+//@ edition: 2021
+
+#![feature(impl_trait_in_assoc_type)]
+
+use std::future::Future;
+
+pub trait Get: Send + Sync {
+    type Ret<'a>: Future<Output = usize> + Send + 'a
+    where
+        Self: 'a;
+    fn get<'a>(&'a self) -> Self::Ret<'a>
+    where
+        Self: 'a;
+}
+
+impl Get for usize {
+    type Ret<'a>
+        = impl Future<Output = usize> + Send + 'a
+    where
+        Self: 'a;
+
+    fn get<'a>(&'a self) -> Self::Ret<'a>
+    where
+        Self: 'a,
+    {
+        async move { *self }
+    }
+}
+
+fn is_send<R, F: Future<Output = R> + Send>(_f: &F) -> bool {
+    true
+}
+
+async fn wrap<G: Get>(g: &G) -> usize {
+    let fut = g.get();
+    assert!(is_send(&fut));
+    fut.await
+}
+
+async fn wrap_wrap<G: Get>(g: &G) -> usize {
+    let fut = wrap(g);
+    assert!(is_send(&fut));
+    fut.await
+}
+
+fn main() {
+    let _ = wrap_wrap(&0usize);
+}

--- a/tests/ui/typeck/issue-107775.stderr
+++ b/tests/ui/typeck/issue-107775.stderr
@@ -6,7 +6,7 @@ LL |         map.insert(1, Struct::do_something);
    |         |
    |         ... which causes `map` to have type `HashMap<{integer}, fn(u8) -> Pin<Box<dyn Future<Output = ()> + Send>> {<Struct as Trait>::do_something::<'_>}>`
 LL |         Self { map }
-   |                ^^^ expected `HashMap<u16, fn(u8) -> Pin<Box<...>>>`, found `HashMap<{integer}, ...>`
+   |                ^^^ expected `HashMap<u16, fn(u8) -> Pin<Box<_>>>`, found `HashMap<{integer}, _>`
    |
    = note: expected struct `HashMap<u16, fn(_) -> Pin<Box<(dyn Future<Output = ()> + Send + 'static)>>>`
               found struct `HashMap<{integer}, fn(_) -> Pin<Box<dyn Future<Output = ()> + Send>> {<Struct as Trait>::do_something::<'_>}>`


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#157824 (Comptime inherent impls)
 - rust-lang/rust#158993 (rerun in original typing mode if we meet any opaques in post analysis)
 - rust-lang/rust#159160 (Make `HasTokens` a sub-trait of `HasAttrs`.)
 - rust-lang/rust#159183 (Introduce InstanceKind::LlvmIntrinsic)
 - rust-lang/rust#159197 (Rename ModDefId to ModId and use more)
 - rust-lang/rust#159251 (Bump rustc-perf submodule)
 - rust-lang/rust#159235 (Add regression test for rust-lang/rust#95719)
 - rust-lang/rust#159243 (inline Once wait and wait_force)
 - rust-lang/rust#159255 (Replace shortened type with `_` instead of `...` as placeholder)
 - rust-lang/rust#159259 (Add regression test for rust-lang/rust#144033)
 - rust-lang/rust#159265 (bootstrap: skip intrinsic-test when rustfmt is unavailable)
 - rust-lang/rust#159269 (disable range-len-try-from.rs on s390x)
 - rust-lang/rust#159272 (slice: make swap delegate to swap_unchecked)
 - rust-lang/rust#159274 (bootstrap: Rename `std_crates_for_run_make` to `std_crates_for_make_run`)
 - rust-lang/rust#159275 (remove obsolete comment)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=157824,158993,159160,159183,159197,159251,159235,159243,159255,159259,159265,159269,159272,159274,159275)
<!-- homu-ignore:end -->

