### PR TITLE
Rollup of 17 pull requests

### DIFF
--- a/compiler/rustc_ast/src/ast_traits.rs
+++ b/compiler/rustc_ast/src/ast_traits.rs
@@ -62,7 +62,7 @@ impl<T: HasNodeId> HasNodeId for Box<T> {
 }
 
 /// A trait for AST nodes having (or not having) collected tokens.
-pub trait HasTokens {
+pub trait HasTokens: HasAttrs {
     fn tokens(&self) -> Option<&LazyAttrTokenStream>;
     fn tokens_mut(&mut self) -> Option<&mut Option<LazyAttrTokenStream>>;
 }
@@ -109,7 +109,7 @@ impl_has_tokens_none!(
     WherePredicate
 );
 
-impl<T> HasTokens for WithTokens<T> {
+impl<T: HasAttrs> HasTokens for WithTokens<T> {
     fn tokens(&self) -> Option<&LazyAttrTokenStream> {
         self.tokens.as_ref()
     }

--- a/compiler/rustc_ast/src/attr/mod.rs
+++ b/compiler/rustc_ast/src/attr/mod.rs
@@ -7,7 +7,7 @@ use std::fmt::Debug;
 use std::sync::atomic::{AtomicU32, Ordering};
 
 use rustc_index::bit_set::GrowableBitSet;
-use rustc_span::{Ident, Span, Symbol, sym};
+use rustc_span::{Ident, Span, Symbol, kw, sym};
 use smallvec::{SmallVec, smallvec};
 use thin_vec::{ThinVec, thin_vec};
 
@@ -21,7 +21,8 @@ use crate::token::{
     self, CommentKind, Delimiter, DocFragmentKind, InvisibleOrigin, MetaVarKind, Token,
 };
 use crate::tokenstream::{
-    DelimSpan, LazyAttrTokenStream, Spacing, TokenStream, TokenStreamIter, TokenTree,
+    AttrTokenStream, AttrTokenTree, DelimSpacing, DelimSpan, LazyAttrTokenStream, Spacing,
+    TokenStream, TokenStreamIter, TokenTree,
 };
 use crate::util::comments;
 use crate::util::literal::escape_string_symbol;
@@ -737,23 +738,6 @@ pub fn mk_doc_comment(
     Attribute { kind: AttrKind::DocComment(comment_kind, data), id: g.mk_attr_id(), style, span }
 }
 
-fn mk_attr(
-    g: &AttrIdGenerator,
-    style: AttrStyle,
-    unsafety: Safety,
-    path: Path,
-    args: AttrArgs,
-    span: Span,
-) -> Attribute {
-    mk_attr_from_item(
-        g,
-        AttrItem { unsafety, path, args: AttrItemKind::Unparsed(args) },
-        None,
-        style,
-        span,
-    )
-}
-
 pub fn mk_attr_from_item(
     g: &AttrIdGenerator,
     item: AttrItem,
@@ -769,6 +753,50 @@ pub fn mk_attr_from_item(
     }
 }
 
+fn mk_attr_tokens(
+    style: AttrStyle,
+    unsafety: Safety,
+    item_tokens: AttrTokenStream,
+    span: Span,
+) -> LazyAttrTokenStream {
+    let safety_kw = match unsafety {
+        Safety::Default => None,
+        Safety::Unsafe(span) => Some((kw::Unsafe, span)),
+        Safety::Safe(span) => Some((kw::Safe, span)),
+    };
+    let item_tokens = if let Some((kw, kw_span)) = safety_kw {
+        AttrTokenStream::new(vec![
+            AttrTokenTree::Token(Token::from_ast_ident(Ident::new(kw, kw_span)), Spacing::Alone),
+            AttrTokenTree::Delimited(
+                DelimSpan::from_single(span),
+                DelimSpacing::new(Spacing::JointHidden, Spacing::Alone),
+                Delimiter::Parenthesis,
+                item_tokens,
+            ),
+        ])
+    } else {
+        item_tokens
+    };
+
+    let mut tokens = match style {
+        AttrStyle::Outer => {
+            vec![AttrTokenTree::Token(Token::new(token::Pound, span), Spacing::JointHidden)]
+        }
+        AttrStyle::Inner => vec![
+            AttrTokenTree::Token(Token::new(token::Pound, span), Spacing::Joint),
+            AttrTokenTree::Token(Token::new(token::Bang, span), Spacing::JointHidden),
+        ],
+    };
+    tokens.push(AttrTokenTree::Delimited(
+        DelimSpan::from_single(span),
+        DelimSpacing::new(Spacing::JointHidden, Spacing::Alone),
+        Delimiter::Bracket,
+        item_tokens,
+    ));
+
+    LazyAttrTokenStream::new_direct(AttrTokenStream::new(tokens))
+}
+
 pub fn mk_attr_word(
     g: &AttrIdGenerator,
     style: AttrStyle,
@@ -778,7 +806,24 @@ pub fn mk_attr_word(
 ) -> Attribute {
     let path = Path::from_ident(Ident::new(name, span));
     let args = AttrArgs::Empty;
-    mk_attr(g, style, unsafety, path, args, span)
+
+    let tokens = Some(mk_attr_tokens(
+        style,
+        unsafety,
+        AttrTokenStream::new(vec![AttrTokenTree::Token(
+            Token::from_ast_ident(Ident::new(name, span)),
+            Spacing::Alone,
+        )]),
+        span,
+    ));
+
+    mk_attr_from_item(
+        g,
+        AttrItem { unsafety, path, args: AttrItemKind::Unparsed(args) },
+        tokens,
+        style,
+        span,
+    )
 }
 
 pub fn mk_attr_nested_word(
@@ -800,7 +845,32 @@ pub fn mk_attr_nested_word(
         delim: Delimiter::Parenthesis,
         tokens: inner_tokens,
     });
-    mk_attr(g, style, unsafety, path, attr_args, span)
+
+    let tokens = Some(mk_attr_tokens(
+        style,
+        unsafety,
+        AttrTokenStream::new(vec![
+            AttrTokenTree::Token(Token::from_ast_ident(Ident::new(outer, span)), Spacing::Alone),
+            AttrTokenTree::Delimited(
+                DelimSpan::from_single(span),
+                DelimSpacing::new(Spacing::JointHidden, Spacing::Alone),
+                Delimiter::Parenthesis,
+                AttrTokenStream::new(vec![AttrTokenTree::Token(
+                    Token::from_ast_ident(Ident::new(inner, span)),
+                    Spacing::Alone,
+                )]),
+            ),
+        ]),
+        span,
+    ));
+
+    mk_attr_from_item(
+        g,
+        AttrItem { unsafety, path, args: AttrItemKind::Unparsed(attr_args) },
+        tokens,
+        style,
+        span,
+    )
 }
 
 pub fn mk_attr_name_value_str(
@@ -821,7 +891,28 @@ pub fn mk_attr_name_value_str(
     });
     let path = Path::from_ident(Ident::new(name, span));
     let args = AttrArgs::Eq { eq_span: span, expr };
-    mk_attr(g, style, unsafety, path, args, span)
+
+    let tokens = Some(mk_attr_tokens(
+        style,
+        unsafety,
+        AttrTokenStream::new(vec![
+            AttrTokenTree::Token(Token::from_ast_ident(Ident::new(name, span)), Spacing::Alone),
+            AttrTokenTree::Token(Token::new(token::Eq, span), Spacing::Alone),
+            AttrTokenTree::Token(
+                Token::new(token::TokenKind::lit(lit.kind, lit.symbol, lit.suffix), span),
+                Spacing::Alone,
+            ),
+        ]),
+        span,
+    ));
+
+    mk_attr_from_item(
+        g,
+        AttrItem { unsafety, path, args: AttrItemKind::Unparsed(args) },
+        tokens,
+        style,
+        span,
+    )
 }
 
 pub fn filter_by_name(attrs: &[Attribute], name: Symbol) -> impl Iterator<Item = &Attribute> {

--- a/compiler/rustc_ast/src/tokenstream.rs
+++ b/compiler/rustc_ast/src/tokenstream.rs
@@ -18,7 +18,7 @@ use rustc_span::{DUMMY_SP, Span, SpanDecoder, SpanEncoder, Symbol, sym};
 use thin_vec::ThinVec;
 
 use crate::ast::AttrStyle;
-use crate::ast_traits::{HasAttrs, HasTokens};
+use crate::ast_traits::HasTokens;
 use crate::token::{self, Delimiter, Token, TokenKind};
 use crate::{AttrVec, Attribute};
 
@@ -653,7 +653,7 @@ impl TokenStream {
         TokenStream::new(vec![TokenTree::token_alone(kind, span)])
     }
 
-    pub fn from_ast(node: &(impl HasAttrs + HasTokens + fmt::Debug)) -> TokenStream {
+    pub fn from_ast(node: &(impl HasTokens + fmt::Debug)) -> TokenStream {
         let tokens = node.tokens().unwrap_or_else(|| panic!("missing tokens for node: {:?}", node));
         let mut tts = vec![];
         attrs_and_tokens_to_token_trees(node.attrs(), tokens, &mut tts);

--- a/compiler/rustc_ast_lowering/src/expr/closure.rs
+++ b/compiler/rustc_ast_lowering/src/expr/closure.rs
@@ -38,6 +38,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                     &closure.body,
                     closure.fn_decl_span,
                     closure.fn_arg_span,
+                    attrs,
                 ),
                 span: self.lower_span(e.span),
             },
@@ -240,7 +241,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
             fn_decl_span: self.lower_span(fn_decl_span),
             fn_arg_span: Some(self.lower_span(fn_arg_span)),
             kind: closure_kind,
-            constness: self.lower_constness(constness),
+            constness: self.lower_constness(attrs, constness),
             explicit_captures,
         });
 
@@ -308,6 +309,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
         body: &Expr,
         fn_decl_span: Span,
         fn_arg_span: Span,
+        attrs: &[hir::Attribute],
     ) -> hir::ExprKind<'hir> {
         let closure_def_id = self.local_def_id(closure_id);
         let (binder_clause, generic_params) = self.lower_closure_binder(binder);
@@ -369,7 +371,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
             // knows that a `FnDecl` output type like `-> &str` actually means
             // "coroutine that returns &str", rather than directly returning a `&str`.
             kind: hir::ClosureKind::CoroutineClosure(coroutine_desugaring),
-            constness: self.lower_constness(constness),
+            constness: self.lower_constness(attrs, constness),
             explicit_captures: &[],
         });
         hir::ExprKind::Closure(c)

--- a/compiler/rustc_ast_lowering/src/item.rs
+++ b/compiler/rustc_ast_lowering/src/item.rs
@@ -479,7 +479,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                     .arena
                     .alloc_from_iter(impl_items.iter().map(|item| self.lower_impl_item_ref(item)));
 
-                let constness = self.lower_constness(*constness);
+                let constness = self.lower_constness(attrs, *constness);
 
                 hir::ItemKind::Impl(hir::Impl {
                     generics,
@@ -499,7 +499,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 bounds,
                 items,
             }) => {
-                let constness = self.lower_constness(*constness);
+                let constness = self.lower_constness(attrs, *constness);
                 let impl_restriction = self.lower_impl_restriction(impl_restriction);
                 let ident = self.lower_ident(*ident);
                 let (generics, (safety, items, bounds)) = self.lower_generics(
@@ -530,7 +530,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 }
             }
             ItemKind::TraitAlias(TraitAlias { constness, ident, generics, bounds }) => {
-                let constness = self.lower_constness(*constness);
+                let constness = self.lower_constness(attrs, *constness);
                 let ident = self.lower_ident(*ident);
                 let (generics, bounds) = self.lower_generics(
                     generics,
@@ -1702,21 +1702,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
             safety.into()
         };
 
-        let mut constness = self.lower_constness(h.constness);
-        if let Some(&attr_span) = find_attr!(attrs, RustcComptime(span) => span) {
-            match std::mem::replace(&mut constness, rustc_hir::Constness::Const { always: true }) {
-                rustc_hir::Constness::Const { always: true } => {
-                    unreachable!("lower_constness cannot produce comptime")
-                }
-                // A function can't be `const` and `comptime` at the same time
-                rustc_hir::Constness::Const { always: false } => {
-                    let Const::Yes(span) = h.constness else { unreachable!() };
-                    self.dcx().emit_err(ConstComptimeFn { span, attr_span });
-                }
-                // Good
-                rustc_hir::Constness::NotConst => {}
-            }
-        }
+        let constness = self.lower_constness(attrs, h.constness);
 
         hir::FnHeader { safety, asyncness, constness, abi: self.lower_extern(h.ext) }
     }
@@ -1778,11 +1764,30 @@ impl<'hir> LoweringContext<'_, 'hir> {
         });
     }
 
-    pub(super) fn lower_constness(&mut self, c: Const) -> hir::Constness {
-        match c {
+    /// Lowers constness or comptime attribute.
+    /// Whether `const` is allowed here is checked by ast validation.
+    /// Whether `comptime` is allowed here is checked by the `comptime` attribute parser.
+    pub(super) fn lower_constness(&mut self, attrs: &[hir::Attribute], c: Const) -> hir::Constness {
+        let mut constness = match c {
             Const::Yes(_) => hir::Constness::Const { always: false },
             Const::No => hir::Constness::NotConst,
+        };
+
+        if let Some(&attr_span) = find_attr!(attrs, RustcComptime(span) => span) {
+            match std::mem::replace(&mut constness, hir::Constness::Const { always: true }) {
+                hir::Constness::Const { always: true } => {
+                    unreachable!("lower_constness cannot produce comptime")
+                }
+                // A function can't be `const` and `comptime` at the same time
+                hir::Constness::Const { always: false } => {
+                    let Const::Yes(span) = c else { unreachable!() };
+                    self.dcx().emit_err(ConstComptimeFn { span, attr_span });
+                }
+                // Good
+                hir::Constness::NotConst => {}
+            }
         }
+        constness
     }
 
     pub(super) fn lower_safety(&self, s: Safety, default: hir::Safety) -> hir::Safety {

--- a/compiler/rustc_attr_parsing/src/attributes/semantics.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/semantics.rs
@@ -23,6 +23,7 @@ impl NoArgsAttributeParser for ComptimeParser {
     const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[
         Allow(Target::Method(MethodKind::Inherent)),
         Allow(Target::Fn),
+        Allow(Target::Impl { of_trait: false }),
     ]);
     const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const CREATE: fn(Span) -> AttributeKind = AttributeKind::RustcComptime;

--- a/compiler/rustc_builtin_macros/src/cfg_eval.rs
+++ b/compiler/rustc_builtin_macros/src/cfg_eval.rs
@@ -3,7 +3,7 @@ use core::ops::ControlFlow;
 use rustc_ast as ast;
 use rustc_ast::mut_visit::MutVisitor;
 use rustc_ast::visit::{AssocCtxt, Visitor};
-use rustc_ast::{Attribute, HasAttrs, HasTokens, NodeId, mut_visit, visit};
+use rustc_ast::{Attribute, HasTokens, NodeId, mut_visit, visit};
 use rustc_errors::PResult;
 use rustc_expand::base::{Annotatable, ExtCtxt};
 use rustc_expand::config::StripUnconfigured;
@@ -67,7 +67,7 @@ fn has_cfg_or_cfg_attr(annotatable: &Annotatable) -> bool {
 }
 
 impl CfgEval<'_> {
-    fn configure<T: HasAttrs + HasTokens>(&mut self, node: T) -> Option<T> {
+    fn configure<T: HasTokens>(&mut self, node: T) -> Option<T> {
         self.0.configure(node)
     }
 

--- a/compiler/rustc_codegen_cranelift/src/abi/mod.rs
+++ b/compiler/rustc_codegen_cranelift/src/abi/mod.rs
@@ -440,18 +440,6 @@ pub(crate) fn codegen_terminator_call<'tcx>(
             }
         }
 
-        if fx.tcx.symbol_name(instance).name.starts_with("llvm.") {
-            crate::intrinsics::codegen_llvm_intrinsic_call(
-                fx,
-                fx.tcx.symbol_name(instance).name,
-                args,
-                ret_place,
-                target,
-                source_info.span,
-            );
-            return;
-        }
-
         match instance.def {
             InstanceKind::Intrinsic(_) => {
                 match crate::intrinsics::codegen_intrinsic_call(
@@ -465,6 +453,17 @@ pub(crate) fn codegen_terminator_call<'tcx>(
                     Ok(()) => return,
                     Err(instance) => Some(instance),
                 }
+            }
+            InstanceKind::LlvmIntrinsic(_) => {
+                crate::intrinsics::codegen_llvm_intrinsic_call(
+                    fx,
+                    fx.tcx.symbol_name(instance).name,
+                    args,
+                    ret_place,
+                    target,
+                    source_info.span,
+                );
+                return;
             }
             // We don't need AsyncDropGlueCtorShim here because it is not `noop func`,
             // it is `func returning noop future`

--- a/compiler/rustc_codegen_ssa/src/base.rs
+++ b/compiler/rustc_codegen_ssa/src/base.rs
@@ -892,12 +892,8 @@ pub fn is_call_from_compiler_builtins_to_upstream_monomorphization<'tcx>(
     tcx: TyCtxt<'tcx>,
     instance: Instance<'tcx>,
 ) -> bool {
-    fn is_llvm_intrinsic(tcx: TyCtxt<'_>, def_id: DefId) -> bool {
-        if let Some(name) = tcx.codegen_fn_attrs(def_id).symbol_name {
-            name.as_str().starts_with("llvm.")
-        } else {
-            false
-        }
+    if let ty::InstanceKind::LlvmIntrinsic(_) = instance.def {
+        return false;
     }
 
     fn is_extern_call_to_local_crate<'tcx>(tcx: TyCtxt<'tcx>, instance: Instance<'tcx>) -> bool {
@@ -910,7 +906,6 @@ pub fn is_call_from_compiler_builtins_to_upstream_monomorphization<'tcx>(
     let def_id = instance.def_id();
     !def_id.is_local()
         && tcx.is_compiler_builtins(LOCAL_CRATE)
-        && !is_llvm_intrinsic(tcx, def_id)
         && !tcx.should_codegen_locally(instance)
         && !is_extern_call_to_local_crate(tcx, instance)
 }

--- a/compiler/rustc_codegen_ssa/src/mir/block.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/block.rs
@@ -1112,8 +1112,8 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
         };
 
         if let Some(instance) = instance
+            && let ty::InstanceKind::LlvmIntrinsic(_) = instance.def
             && let Some(name) = bx.tcx().codegen_fn_attrs(instance.def_id()).symbol_name
-            && name.as_str().starts_with("llvm.")
             // This is the only LLVM intrinsic we use that unwinds
             // FIXME either add unwind support to codegen_llvm_intrinsic_call or replace usage of
             // this intrinsic with something else

--- a/compiler/rustc_const_eval/src/check_consts/ops.rs
+++ b/compiler/rustc_const_eval/src/check_consts/ops.rs
@@ -614,7 +614,10 @@ impl<'tcx> NonConstOp<'tcx> for LiveDrop<'tcx> {
         };
 
         // If the dropped type is a type parameter, suggest adding a `[const] Destruct` bound.
-        if let Param(param_ty) = self.dropped_ty.kind() {
+        // The suggestion is only offered on nightly, since `[const]` bounds are unstable.
+        if let Param(param_ty) = self.dropped_ty.kind()
+            && ccx.tcx.sess.is_nightly_build()
+        {
             let tcx = ccx.tcx;
             let caller = ccx.def_id();
             if let Some(generics) = tcx.hir_node_by_def_id(caller).generics() {

--- a/compiler/rustc_const_eval/src/check_consts/ops.rs
+++ b/compiler/rustc_const_eval/src/check_consts/ops.rs
@@ -594,7 +594,7 @@ impl<'tcx> NonConstOp<'tcx> for LiveDrop<'tcx> {
     }
 
     fn build_error(&self, ccx: &ConstCx<'_, 'tcx>, span: Span) -> Diag<'tcx> {
-        if self.needs_non_const_drop {
+        let mut err = if self.needs_non_const_drop {
             ccx.dcx().create_err(diagnostics::LiveDrop {
                 span,
                 dropped_ty: self.dropped_ty,
@@ -611,7 +611,27 @@ impl<'tcx> NonConstOp<'tcx> for LiveDrop<'tcx> {
                 },
                 sym::const_destruct,
             )
+        };
+
+        // If the dropped type is a type parameter, suggest adding a `[const] Destruct` bound.
+        if let Param(param_ty) = self.dropped_ty.kind() {
+            let tcx = ccx.tcx;
+            let caller = ccx.def_id();
+            if let Some(generics) = tcx.hir_node_by_def_id(caller).generics() {
+                let destruct_def_id = tcx.lang_items().destruct_trait();
+                suggest_constraining_type_param(
+                    tcx,
+                    generics,
+                    &mut err,
+                    param_ty.name.as_str(),
+                    "[const] Destruct",
+                    destruct_def_id,
+                    None,
+                );
+            }
         }
+
+        err
     }
 }
 

--- a/compiler/rustc_const_eval/src/const_eval/dummy_machine.rs
+++ b/compiler/rustc_const_eval/src/const_eval/dummy_machine.rs
@@ -105,6 +105,17 @@ impl<'tcx> interpret::Machine<'tcx> for DummyMachine {
         unimplemented!()
     }
 
+    fn call_llvm_intrinsic(
+        _ecx: &mut InterpCx<'tcx, Self>,
+        _instance: ty::Instance<'tcx>,
+        _args: &[interpret::OpTy<'tcx, Self::Provenance>],
+        _destination: &interpret::PlaceTy<'tcx, Self::Provenance>,
+        _target: Option<BasicBlock>,
+        _unwind: UnwindAction,
+    ) -> interpret::InterpResult<'tcx> {
+        unimplemented!()
+    }
+
     fn assert_panic(
         _ecx: &mut InterpCx<'tcx, Self>,
         _msg: &rustc_middle::mir::AssertMessage<'tcx>,

--- a/compiler/rustc_const_eval/src/const_eval/dummy_machine.rs
+++ b/compiler/rustc_const_eval/src/const_eval/dummy_machine.rs
@@ -111,7 +111,6 @@ impl<'tcx> interpret::Machine<'tcx> for DummyMachine {
         _args: &[interpret::OpTy<'tcx, Self::Provenance>],
         _destination: &interpret::PlaceTy<'tcx, Self::Provenance>,
         _target: Option<BasicBlock>,
-        _unwind: UnwindAction,
     ) -> interpret::InterpResult<'tcx> {
         unimplemented!()
     }

--- a/compiler/rustc_const_eval/src/const_eval/machine.rs
+++ b/compiler/rustc_const_eval/src/const_eval/machine.rs
@@ -751,7 +751,6 @@ impl<'tcx> interpret::Machine<'tcx> for CompileTimeMachine<'tcx> {
         _args: &[OpTy<'tcx>],
         _dest: &PlaceTy<'tcx, Self::Provenance>,
         _target: Option<mir::BasicBlock>,
-        _unwind: mir::UnwindAction,
     ) -> InterpResult<'tcx> {
         let intrinsic_name = ecx.tcx.codegen_fn_attrs(instance.def_id()).symbol_name.unwrap();
 

--- a/compiler/rustc_const_eval/src/const_eval/machine.rs
+++ b/compiler/rustc_const_eval/src/const_eval/machine.rs
@@ -745,6 +745,19 @@ impl<'tcx> interpret::Machine<'tcx> for CompileTimeMachine<'tcx> {
         interp_ok(None)
     }
 
+    fn call_llvm_intrinsic(
+        ecx: &mut InterpCx<'tcx, Self>,
+        instance: ty::Instance<'tcx>,
+        _args: &[OpTy<'tcx>],
+        _dest: &PlaceTy<'tcx, Self::Provenance>,
+        _target: Option<mir::BasicBlock>,
+        _unwind: mir::UnwindAction,
+    ) -> InterpResult<'tcx> {
+        let intrinsic_name = ecx.tcx.codegen_fn_attrs(instance.def_id()).symbol_name.unwrap();
+
+        throw_unsup_format!("LLVM intrinsic `{intrinsic_name}` is not supported at compile-time");
+    }
+
     fn assert_panic(
         ecx: &mut InterpCx<'tcx, Self>,
         msg: &AssertMessage<'tcx>,

--- a/compiler/rustc_const_eval/src/interpret/call.rs
+++ b/compiler/rustc_const_eval/src/interpret/call.rs
@@ -652,6 +652,17 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                     interp_ok(())
                 }
             }
+            ty::InstanceKind::LlvmIntrinsic(_) => {
+                // FIXME: Should `InPlace` arguments be reset to uninit?
+                M::call_llvm_intrinsic(
+                    self,
+                    instance,
+                    &Self::copy_fn_args(args),
+                    destination,
+                    target,
+                    unwind,
+                )
+            }
             ty::InstanceKind::Shim(ty::ShimKind::VTable(..))
             | ty::InstanceKind::Shim(ty::ShimKind::Reify(..))
             | ty::InstanceKind::Shim(ty::ShimKind::ClosureOnce { .. })

--- a/compiler/rustc_const_eval/src/interpret/call.rs
+++ b/compiler/rustc_const_eval/src/interpret/call.rs
@@ -660,7 +660,6 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                     &Self::copy_fn_args(args),
                     destination,
                     target,
-                    unwind,
                 )
             }
             ty::InstanceKind::Shim(ty::ShimKind::VTable(..))

--- a/compiler/rustc_const_eval/src/interpret/machine.rs
+++ b/compiler/rustc_const_eval/src/interpret/machine.rs
@@ -255,7 +255,6 @@ pub trait Machine<'tcx>: Sized {
         args: &[OpTy<'tcx, Self::Provenance>],
         destination: &PlaceTy<'tcx, Self::Provenance>,
         target: Option<mir::BasicBlock>,
-        unwind: mir::UnwindAction,
     ) -> InterpResult<'tcx>;
 
     /// Check whether the given function may be executed on the current machine, in terms of the

--- a/compiler/rustc_const_eval/src/interpret/machine.rs
+++ b/compiler/rustc_const_eval/src/interpret/machine.rs
@@ -247,6 +247,17 @@ pub trait Machine<'tcx>: Sized {
         unwind: mir::UnwindAction,
     ) -> InterpResult<'tcx, Option<ty::Instance<'tcx>>>;
 
+    /// Directly process an LLVM intrinsic without pushing a stack frame. It is the hook's
+    /// responsibility to advance the instruction pointer as appropriate.
+    fn call_llvm_intrinsic(
+        ecx: &mut InterpCx<'tcx, Self>,
+        instance: ty::Instance<'tcx>,
+        args: &[OpTy<'tcx, Self::Provenance>],
+        destination: &PlaceTy<'tcx, Self::Provenance>,
+        target: Option<mir::BasicBlock>,
+        unwind: mir::UnwindAction,
+    ) -> InterpResult<'tcx>;
+
     /// Check whether the given function may be executed on the current machine, in terms of the
     /// target features is requires.
     fn check_fn_target_features(

--- a/compiler/rustc_expand/src/config.rs
+++ b/compiler/rustc_expand/src/config.rs
@@ -167,7 +167,7 @@ macro_rules! configure {
 }
 
 impl<'a> StripUnconfigured<'a> {
-    pub fn configure<T: HasAttrs + HasTokens>(&self, mut node: T) -> Option<T> {
+    pub fn configure<T: HasTokens>(&self, mut node: T) -> Option<T> {
         self.process_cfg_attrs(&mut node);
         self.in_cfg(node.attrs()).then(|| {
             self.try_configure_tokens(&mut node);

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -601,8 +601,6 @@ pub(crate) struct BuiltinDerefNullptr {
     pub label: Span,
 }
 
-// FIXME: migrate fluent::lint::builtin_asm_labels
-
 #[derive(Diagnostic)]
 pub(crate) enum BuiltinSpecialModuleNameUsed {
     #[diag("found module declaration for lib.rs")]

--- a/compiler/rustc_middle/src/mir/visit.rs
+++ b/compiler/rustc_middle/src/mir/visit.rs
@@ -347,6 +347,7 @@ macro_rules! make_mir_visitor {
                         ty::InstanceKind::Item(_def_id) => {}
 
                         ty::InstanceKind::Intrinsic(_def_id)
+                        | ty::InstanceKind::LlvmIntrinsic(_def_id)
                         | ty::InstanceKind::Shim(ty::ShimKind::VTable(_def_id))
                         | ty::InstanceKind::Shim(ty::ShimKind::Reify(_def_id, _))
                         | ty::InstanceKind::Virtual(_def_id, _)

--- a/compiler/rustc_middle/src/mono.rs
+++ b/compiler/rustc_middle/src/mono.rs
@@ -524,6 +524,7 @@ impl<'tcx> CodegenUnit<'tcx> {
                 MonoItem::Fn(ref instance) => match instance.def {
                     InstanceKind::Item(def) => def.as_local().map(|_| def),
                     InstanceKind::Intrinsic(..)
+                    | InstanceKind::LlvmIntrinsic(..)
                     | InstanceKind::Virtual(..)
                     | InstanceKind::Shim(ShimKind::VTable(..))
                     | InstanceKind::Shim(ShimKind::Reify(..))

--- a/compiler/rustc_middle/src/ty/instance.rs
+++ b/compiler/rustc_middle/src/ty/instance.rs
@@ -70,10 +70,17 @@ pub enum InstanceKind<'tcx> {
 
     /// An intrinsic `fn` item (with`#[rustc_intrinsic]`).
     ///
-    /// Alongside `Virtual`, this is the only `InstanceKind` that does not have its own callable MIR.
-    /// Instead, codegen and const eval "magically" evaluate calls to intrinsics purely in the
-    /// caller.
+    /// Alongside `LlvmIntrinsic` and `Virtual`, this is the only `InstanceKind`
+    /// that does not have its own callable MIR. Instead, codegen and const eval
+    /// "magically" evaluate calls to intrinsics purely in the caller.
     Intrinsic(DefId),
+
+    /// An LLVM intrinsic `fn` item (with `extern "unadjusted"`).
+    ///
+    /// Alongside `Intrinsic` and `Virtual`, this is the only `InstanceKind`
+    /// that does not have its own callable MIR. Instead, codegen and const eval
+    /// "magically" evaluate calls to LLVM intrinsics purely in the caller.
+    LlvmIntrinsic(DefId),
 
     /// Dynamic dispatch to `<dyn Trait as Trait>::fn`.
     ///
@@ -253,7 +260,8 @@ impl<'tcx> InstanceKind<'tcx> {
         match self {
             InstanceKind::Item(def_id)
             | InstanceKind::Virtual(def_id, _)
-            | InstanceKind::Intrinsic(def_id) => def_id,
+            | InstanceKind::Intrinsic(def_id)
+            | InstanceKind::LlvmIntrinsic(def_id) => def_id,
             InstanceKind::Shim(shim) => shim.def_id(),
         }
     }
@@ -262,7 +270,9 @@ impl<'tcx> InstanceKind<'tcx> {
     pub fn def_id_if_not_guaranteed_local_codegen(self) -> Option<DefId> {
         match self {
             InstanceKind::Item(def) => Some(def),
-            InstanceKind::Virtual(..) | InstanceKind::Intrinsic(..) => None,
+            InstanceKind::Virtual(..)
+            | InstanceKind::Intrinsic(..)
+            | InstanceKind::LlvmIntrinsic(..) => None,
             InstanceKind::Shim(shim) => shim.def_id_if_not_guaranteed_local_codegen(),
         }
     }
@@ -280,7 +290,9 @@ impl<'tcx> InstanceKind<'tcx> {
                 DefPathData::Ctor | DefPathData::Closure
             ),
             InstanceKind::Shim(shim) => shim.requires_inline(),
-            InstanceKind::Virtual(..) | InstanceKind::Intrinsic(..) => true,
+            InstanceKind::Virtual(..)
+            | InstanceKind::Intrinsic(..)
+            | InstanceKind::LlvmIntrinsic(..) => true,
         }
     }
 
@@ -308,7 +320,10 @@ impl<'tcx> InstanceKind<'tcx> {
     /// body should perform necessary instantiations.
     pub fn has_polymorphic_mir_body(&self) -> bool {
         match *self {
-            InstanceKind::Item(_) | InstanceKind::Intrinsic(..) | InstanceKind::Virtual(..) => true,
+            InstanceKind::Item(_)
+            | InstanceKind::Intrinsic(..)
+            | InstanceKind::LlvmIntrinsic(..)
+            | InstanceKind::Virtual(..) => true,
             InstanceKind::Shim(shim) => shim.has_polymorphic_mir_body(),
         }
     }

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -1833,7 +1833,9 @@ impl<'tcx> TyCtxt<'tcx> {
                     _ => self.optimized_mir(def),
                 }
             }
-            ty::InstanceKind::Intrinsic(..) => bug!("intrinsics have no instance MIR"),
+            ty::InstanceKind::Intrinsic(..) | ty::InstanceKind::LlvmIntrinsic(..) => {
+                bug!("intrinsics have no instance MIR")
+            }
             ty::InstanceKind::Virtual(..) => bug!("virtual dispatches have no instance MIR"),
             ty::InstanceKind::Shim(shim) => self.mir_shims(shim),
         };

--- a/compiler/rustc_middle/src/ty/print/mod.rs
+++ b/compiler/rustc_middle/src/ty/print/mod.rs
@@ -368,6 +368,7 @@ impl<'tcx, P: Printer<'tcx> + std::fmt::Write> Print<P> for ty::Instance<'tcx> {
         match self.def {
             ty::InstanceKind::Item(_) => {}
             ty::InstanceKind::Intrinsic(_) => cx.write_str(" - intrinsic")?,
+            ty::InstanceKind::LlvmIntrinsic(_) => cx.write_str(" - LLVM intrinsic")?,
             ty::InstanceKind::Virtual(_, num) => cx.write_str(&format!(" - virtual#{num}"))?,
             ty::InstanceKind::Shim(shim) => {
                 cx.write_str(" - ")?;

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -2357,7 +2357,7 @@ impl<'tcx> Printer<'tcx> for FmtPrinter<'_, 'tcx> {
             {
                 // We only truncate types that we know are likely to be much longer than 3 chars.
                 // There's no point in replacing `i32` or `!`.
-                write!(self, "...")?;
+                write!(self, "_")?;
                 Ok(())
             }
             _ => {

--- a/compiler/rustc_mir_transform/src/inline.rs
+++ b/compiler/rustc_mir_transform/src/inline.rs
@@ -730,7 +730,7 @@ fn check_mir_is_available<'tcx, I: Inliner<'tcx>>(
             }
         }
         // These have no own callable MIR.
-        InstanceKind::Intrinsic(_) | InstanceKind::Virtual(..) => {
+        InstanceKind::Intrinsic(_) | InstanceKind::LlvmIntrinsic(_) | InstanceKind::Virtual(..) => {
             debug!("instance without MIR (intrinsic / virtual)");
             return Err("implementation limitation -- cannot inline intrinsic");
         }

--- a/compiler/rustc_mir_transform/src/inline/cycle.rs
+++ b/compiler/rustc_mir_transform/src/inline/cycle.rs
@@ -21,7 +21,9 @@ fn should_recurse<'tcx>(tcx: TyCtxt<'tcx>, callee: ty::Instance<'tcx>) -> bool {
         }
 
         // These have no own callable MIR.
-        InstanceKind::Intrinsic(_) | InstanceKind::Virtual(..) => return false,
+        InstanceKind::Intrinsic(_) | InstanceKind::LlvmIntrinsic(_) | InstanceKind::Virtual(..) => {
+            return false;
+        }
 
         // These have MIR and if that MIR is inlined, instantiated and then inlining is run
         // again, a function item can end up getting inlined. Thus we'll be able to cause

--- a/compiler/rustc_monomorphize/src/collector.rs
+++ b/compiler/rustc_monomorphize/src/collector.rs
@@ -1018,7 +1018,9 @@ fn visit_instance_use<'tcx>(
     }
 
     match instance.def {
-        ty::InstanceKind::Virtual(..) | ty::InstanceKind::Intrinsic(_) => {
+        ty::InstanceKind::Virtual(..)
+        | ty::InstanceKind::Intrinsic(_)
+        | ty::InstanceKind::LlvmIntrinsic(_) => {
             if !is_direct_call {
                 bug!("{:?} being reified", instance);
             }

--- a/compiler/rustc_monomorphize/src/partitioning.rs
+++ b/compiler/rustc_monomorphize/src/partitioning.rs
@@ -631,6 +631,7 @@ fn characteristic_def_id_of_mono_item<'tcx>(
             let def_id = match instance.def {
                 ty::InstanceKind::Item(def) => def,
                 ty::InstanceKind::Intrinsic(..)
+                | ty::InstanceKind::LlvmIntrinsic(..)
                 | ty::InstanceKind::Virtual(..)
                 | ty::InstanceKind::Shim(ty::ShimKind::VTable(..))
                 | ty::InstanceKind::Shim(ty::ShimKind::Reify(..))
@@ -810,6 +811,7 @@ fn mono_item_visibility<'tcx>(
         | InstanceKind::Shim(ShimKind::FnPtr(..))
         | InstanceKind::Virtual(..)
         | InstanceKind::Intrinsic(..)
+        | InstanceKind::LlvmIntrinsic(..)
         | InstanceKind::Shim(ShimKind::ClosureOnce { .. })
         | InstanceKind::Shim(ShimKind::ConstructCoroutineInClosure { .. })
         | InstanceKind::Shim(ShimKind::DropGlue(..))

--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
@@ -870,7 +870,7 @@ where
             (
                 RerunCondition::OpaqueInStorageOrAnyOpaqueHasInferAsHidden(_),
                 TypingMode::PostAnalysis | TypingMode::Codegen,
-            ) => RerunDecision::No,
+            ) => RerunDecision::Yes,
             (
                 RerunCondition::OpaqueInStorageOrAnyOpaqueHasInferAsHidden(defids),
                 TypingMode::Typeck { defining_opaque_types_and_generators: opaques },

--- a/compiler/rustc_parse/src/parser/attr_wrapper.rs
+++ b/compiler/rustc_parse/src/parser/attr_wrapper.rs
@@ -5,7 +5,7 @@ use rustc_ast::token::Token;
 use rustc_ast::tokenstream::{
     AttrsTarget, LazyAttrTokenStream, NodeRange, ParserRange, Spacing, TokenCursor,
 };
-use rustc_ast::{self as ast, AttrVec, Attribute, HasAttrs, HasTokens};
+use rustc_ast::{self as ast, AttrVec, Attribute, HasTokens};
 use rustc_data_structures::fx::FxHashSet;
 use rustc_errors::PResult;
 use rustc_session::parse::ParseSess;
@@ -137,7 +137,7 @@ impl<'a> Parser<'a> {
     ///     }                               //  32..33
     /// }                                   //  33..34
     /// ```
-    pub(super) fn collect_tokens<R: HasAttrs + HasTokens>(
+    pub(super) fn collect_tokens<R: HasTokens>(
         &mut self,
         pre_attr_pos: Option<CollectPos>,
         attrs: AttrWrapper,

--- a/compiler/rustc_parse/src/parser/mod.rs
+++ b/compiler/rustc_parse/src/parser/mod.rs
@@ -36,9 +36,8 @@ use rustc_ast::util::case::Case;
 use rustc_ast::util::classify;
 use rustc_ast::{
     self as ast, AnonConst, AttrArgs, AttrId, BinOpKind, ByRef, Const, CoroutineKind,
-    DUMMY_NODE_ID, DelimArgs, Expr, ExprKind, Extern, HasAttrs, HasTokens, ImplRestriction,
-    MutRestriction, Mutability, Recovered, RestrictionKind, Safety, StrLit, Visibility,
-    VisibilityKind,
+    DUMMY_NODE_ID, DelimArgs, Expr, ExprKind, Extern, HasTokens, ImplRestriction, MutRestriction,
+    Mutability, Recovered, RestrictionKind, Safety, StrLit, Visibility, VisibilityKind,
 };
 use rustc_ast_pretty::pprust;
 use rustc_data_structures::fx::FxHashMap;
@@ -1662,7 +1661,7 @@ impl<'a> Parser<'a> {
         }
     }
 
-    fn collect_tokens_no_attrs<R: HasAttrs + HasTokens>(
+    fn collect_tokens_no_attrs<R: HasTokens>(
         &mut self,
         f: impl FnOnce(&mut Self) -> PResult<'a, R>,
     ) -> PResult<'a, R> {

--- a/compiler/rustc_public/src/mir/mono.rs
+++ b/compiler/rustc_public/src/mir/mono.rs
@@ -32,6 +32,8 @@ pub enum InstanceKind {
     Item,
     /// A compiler intrinsic function.
     Intrinsic,
+    /// An LLVM intrinsic function.
+    LlvmIntrinsic,
     /// A virtual function definition stored in a VTable.
     /// The `idx` field indicates the position in the VTable for this instance.
     Virtual { idx: usize },
@@ -113,7 +115,10 @@ impl Instance {
             InstanceKind::Intrinsic => {
                 Some(with(|context| context.intrinsic(self.def.def_id()).unwrap().fn_name()))
             }
-            InstanceKind::Item | InstanceKind::Virtual { .. } | InstanceKind::Shim => None,
+            InstanceKind::LlvmIntrinsic
+            | InstanceKind::Item
+            | InstanceKind::Virtual { .. }
+            | InstanceKind::Shim => None,
         }
     }
 

--- a/compiler/rustc_public/src/unstable/convert/stable/ty.rs
+++ b/compiler/rustc_public/src/unstable/convert/stable/ty.rs
@@ -970,6 +970,7 @@ impl<'tcx> Stable<'tcx> for ty::Instance<'tcx> {
         let kind = match self.def {
             ty::InstanceKind::Item(..) => crate::mir::mono::InstanceKind::Item,
             ty::InstanceKind::Intrinsic(..) => crate::mir::mono::InstanceKind::Intrinsic,
+            ty::InstanceKind::LlvmIntrinsic(..) => crate::mir::mono::InstanceKind::LlvmIntrinsic,
             ty::InstanceKind::Virtual(_def_id, idx) => {
                 crate::mir::mono::InstanceKind::Virtual { idx }
             }

--- a/compiler/rustc_trait_selection/src/traits/effects.rs
+++ b/compiler/rustc_trait_selection/src/traits/effects.rs
@@ -601,7 +601,8 @@ fn evaluate_host_effect_from_selection_candidate<'tcx>(
                     match tcx.impl_trait_header(impl_.impl_def_id).constness {
                         rustc_hir::Constness::Const { always } => {
                             if always {
-                                unimplemented!()
+                                // FIXME(comptime): just bailing for now to avoid an ICE in a test.
+                                return Err(EvaluationFailure::NoSolution);
                             }
                         }
                         rustc_hir::Constness::NotConst => {

--- a/compiler/rustc_ty_utils/src/instance.rs
+++ b/compiler/rustc_ty_utils/src/instance.rs
@@ -1,5 +1,6 @@
 use rustc_errors::ErrorGuaranteed;
 use rustc_hir::LangItem;
+use rustc_hir::def::DefKind;
 use rustc_hir::def_id::DefId;
 use rustc_infer::infer::TyCtxtInferExt;
 use rustc_middle::bug;
@@ -91,6 +92,12 @@ fn resolve_instance_raw<'tcx>(
         } else if tcx.is_async_drop_in_place_coroutine(def_id) {
             let ty = args.type_at(0);
             ty::InstanceKind::Shim(ty::ShimKind::AsyncDropGlue(def_id, ty))
+        } else if tcx.def_kind(def_id) == DefKind::Fn
+            && let Some(name) = tcx.codegen_fn_attrs(def_id).symbol_name
+            && name.as_str().starts_with("llvm.")
+        {
+            debug!(" => LLVM intrinsic");
+            ty::InstanceKind::LlvmIntrinsic(def_id)
         } else {
             debug!(" => free item");
             ty::InstanceKind::Item(def_id)

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -906,16 +906,12 @@ impl<T> [T] {
     #[inline]
     #[track_caller]
     pub const fn swap(&mut self, a: usize, b: usize) {
-        // FIXME: use swap_unchecked here (https://github.com/rust-lang/rust/pull/88540#issuecomment-944344343)
-        // Can't take two mutable loans from one vector, so instead use raw pointers.
-        let pa = &raw mut self[a];
-        let pb = &raw mut self[b];
-        // SAFETY: `pa` and `pb` have been created from safe mutable references and refer
-        // to elements in the slice and therefore are guaranteed to be valid and aligned.
-        // Note that accessing the elements behind `a` and `b` is checked and will
-        // panic when out of bounds.
+        // Bounds checks that panic exactly like indexing would.
+        let _ = &self[a];
+        let _ = &self[b];
+        // SAFETY: `a` and `b` were checked to be in bounds above.
         unsafe {
-            ptr::swap(pa, pb);
+            self.swap_unchecked(a, b);
         }
     }
 

--- a/library/std/src/sync/once.rs
+++ b/library/std/src/sync/once.rs
@@ -296,6 +296,7 @@ impl Once {
     /// If this [`Once`] has been poisoned because an initialization closure has
     /// panicked, this method will also panic. Use [`wait_force`](Self::wait_force)
     /// if this behavior is not desired.
+    #[inline]
     #[stable(feature = "once_wait", since = "1.86.0")]
     #[rustc_should_not_be_called_on_const_items]
     pub fn wait(&self) {
@@ -309,6 +310,7 @@ impl Once {
     ///
     /// If this [`Once`] has been poisoned, this function blocks until it
     /// becomes completed, unlike [`Once::wait()`], which panics in this case.
+    #[inline]
     #[stable(feature = "once_wait", since = "1.86.0")]
     #[rustc_should_not_be_called_on_const_items]
     pub fn wait_force(&self) {

--- a/src/bootstrap/src/core/build_steps/check.rs
+++ b/src/bootstrap/src/core/build_steps/check.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 
 use crate::core::build_steps::compile::{
     ArtifactKeepMode, add_to_sysroot, run_cargo, rustc_cargo, rustc_cargo_env, std_cargo,
-    std_crates_for_run_make,
+    std_crates_for_make_run,
 };
 use crate::core::build_steps::tool;
 use crate::core::build_steps::tool::{
@@ -68,7 +68,7 @@ impl Step for Std {
         // Explicitly pass -p for all dependencies crates -- this will force cargo
         // to also check the tests/benches/examples for these crates, rather
         // than just the leaf crate.
-        let crates = std_crates_for_run_make(&run);
+        let crates = std_crates_for_make_run(&run);
         run.builder.ensure(Std {
             build_compiler: prepare_compiler_for_check(run.builder, run.target, Mode::Std)
                 .build_compiler(),

--- a/src/bootstrap/src/core/build_steps/clippy.rs
+++ b/src/bootstrap/src/core/build_steps/clippy.rs
@@ -13,11 +13,12 @@
 //! to pass a prebuilt Clippy from the outside when running `cargo clippy`, but that would be
 //! (as usual) a massive undertaking/refactoring.
 
-use super::compile::{ArtifactKeepMode, run_cargo, rustc_cargo, std_cargo};
 use super::tool::{SourceType, prepare_tool_cargo};
 use crate::builder::{Builder, ShouldRun};
 use crate::core::build_steps::check::{CompilerForCheck, prepare_compiler_for_check};
-use crate::core::build_steps::compile::std_crates_for_run_make;
+use crate::core::build_steps::compile::{
+    ArtifactKeepMode, run_cargo, rustc_cargo, std_cargo, std_crates_for_make_run,
+};
 use crate::core::builder;
 use crate::core::builder::{Alias, Kind, RunConfig, Step, StepMetadata, crate_description};
 use crate::utils::build_stamp::{self, BuildStamp};
@@ -178,7 +179,7 @@ impl Step for Std {
     }
 
     fn make_run(run: RunConfig<'_>) {
-        let crates = std_crates_for_run_make(&run);
+        let crates = std_crates_for_make_run(&run);
         let config = LintConfig::new(run.builder);
         run.builder.ensure(Std::new(run.builder, run.target, config, crates));
     }

--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -122,7 +122,7 @@ impl Step for Std {
     }
 
     fn make_run(run: RunConfig<'_>) {
-        let crates = std_crates_for_run_make(&run);
+        let crates = std_crates_for_make_run(&run);
         let builder = run.builder;
 
         // Force compilation of the standard library from source if the `library` is modified. This allows
@@ -479,9 +479,9 @@ fn copy_self_contained_objects(
     target_deps
 }
 
-/// Resolves standard library crates for `Std::run_make` for any build kind (like check, doc,
+/// Resolves standard library crates for [`Std::make_run`] for any build kind (like check, doc,
 /// build, clippy, etc.).
-pub fn std_crates_for_run_make(run: &RunConfig<'_>) -> Vec<String> {
+pub fn std_crates_for_make_run(run: &RunConfig<'_>) -> Vec<String> {
     let mut crates = run.make_run_crates(builder::Alias::Library);
 
     // For no_std targets, we only want to check core and alloc

--- a/src/bootstrap/src/core/build_steps/doc.rs
+++ b/src/bootstrap/src/core/build_steps/doc.rs
@@ -667,7 +667,7 @@ impl Step for Std {
     }
 
     fn make_run(run: RunConfig<'_>) {
-        let crates = compile::std_crates_for_run_make(&run);
+        let crates = compile::std_crates_for_make_run(&run);
         let target_is_no_std = run.builder.no_std(run.target).unwrap_or(false);
         if crates.is_empty() && target_is_no_std {
             return;

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -1085,10 +1085,12 @@ impl Step for IntrinsicTest {
         cmd.env("CFLAGS", cflags);
         // intrinsic-test shells out to `cargo` and `rustfmt` make bootstrap's
         // managed binaries findable by prepending their dirs to PATH.
-        let rustfmt_path = builder.config.initial_rustfmt.clone().unwrap_or_else(|| {
-            eprintln!("intrinsic-test: rustfmt is required but not available on this channel");
-            crate::exit!(1);
-        });
+        let Some(rustfmt_path) = builder.config.initial_rustfmt.clone() else {
+            eprintln!(
+                "WARNING: intrinsic-test skipped because rustfmt is required but not available on this channel"
+            );
+            return;
+        };
 
         let mut path_dirs: Vec<PathBuf> = Vec::new();
         if let Some(cargo_dir) = builder.initial_cargo.parent() {

--- a/src/tools/miri/src/intrinsics/mod.rs
+++ b/src/tools/miri/src/intrinsics/mod.rs
@@ -10,7 +10,7 @@ pub use self::atomic::AtomicRmwOp;
 use rand::RngExt;
 use rustc_abi::Size;
 use rustc_middle::{mir, ty};
-use rustc_span::Symbol;
+use rustc_span::{Symbol, sym};
 
 use self::atomic::EvalContextExt as _;
 use self::math::EvalContextExt as _;

--- a/src/tools/miri/src/machine.rs
+++ b/src/tools/miri/src/machine.rs
@@ -1301,6 +1301,18 @@ impl<'tcx> Machine<'tcx> for MiriMachine<'tcx> {
     }
 
     #[inline(always)]
+    fn call_llvm_intrinsic(
+        ecx: &mut MiriInterpCx<'tcx>,
+        instance: ty::Instance<'tcx>,
+        args: &[OpTy<'tcx>],
+        dest: &PlaceTy<'tcx>,
+        ret: Option<mir::BasicBlock>,
+        unwind: mir::UnwindAction,
+    ) -> InterpResult<'tcx, ()> {
+        ecx.call_llvm_intrinsic(instance, args, dest, ret, unwind)
+    }
+
+    #[inline(always)]
     fn assert_panic(
         ecx: &mut MiriInterpCx<'tcx>,
         msg: &mir::AssertMessage<'tcx>,

--- a/src/tools/miri/src/machine.rs
+++ b/src/tools/miri/src/machine.rs
@@ -1307,9 +1307,8 @@ impl<'tcx> Machine<'tcx> for MiriMachine<'tcx> {
         args: &[OpTy<'tcx>],
         dest: &PlaceTy<'tcx>,
         ret: Option<mir::BasicBlock>,
-        unwind: mir::UnwindAction,
     ) -> InterpResult<'tcx, ()> {
-        ecx.call_llvm_intrinsic(instance, args, dest, ret, unwind)
+        ecx.call_llvm_intrinsic(instance, args, dest, ret)
     }
 
     #[inline(always)]

--- a/src/tools/miri/src/shims/aarch64.rs
+++ b/src/tools/miri/src/shims/aarch64.rs
@@ -13,7 +13,7 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         link_name: Symbol,
         args: &[OpTy<'tcx>],
         dest: &MPlaceTy<'tcx>,
-    ) -> InterpResult<'tcx, EmulateItemResult> {
+    ) -> InterpResult<'tcx, bool> {
         let this = self.eval_context_mut();
         // Prefix should have already been checked.
         let unprefixed_name = link_name.as_str().strip_prefix("llvm.aarch64.").unwrap();
@@ -273,8 +273,8 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 this.write_scalar(Scalar::from_u128(result), &dest)?;
             }
 
-            _ => return interp_ok(EmulateItemResult::NotSupported),
+            _ => return interp_ok(false),
         }
-        interp_ok(EmulateItemResult::NeedsReturn)
+        interp_ok(true)
     }
 }

--- a/src/tools/miri/src/shims/foreign_items.rs
+++ b/src/tools/miri/src/shims/foreign_items.rs
@@ -249,7 +249,6 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         args: &[OpTy<'tcx>],
         dest: &PlaceTy<'tcx>,
         ret: Option<mir::BasicBlock>,
-        unwind: mir::UnwindAction,
     ) -> InterpResult<'tcx> {
         let this = self.eval_context_mut();
 
@@ -258,7 +257,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         // FIXME: avoid allocating memory
         let dest = this.force_allocation(dest)?;
 
-        let res = match link_name.as_str() {
+        let handled = match link_name.as_str() {
             // LLVM intrinsics
             "llvm.prefetch.p0" => {
                 let [p, rw, loc, ty] = this.check_shim_sig_unadjusted(link_name, args)?;
@@ -285,7 +284,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                     throw_unsup_format!("unsupported `llvm.prefetch` type argument: {}", ty);
                 }
 
-                EmulateItemResult::NeedsReturn
+                true
             }
             // Used to implement the x86 `_mm{,256,512}_popcnt_epi{8,16,32,64}` and wasm
             // `{i,u}8x16_popcnt` functions.
@@ -311,7 +310,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                     )?;
                 }
 
-                EmulateItemResult::NeedsReturn
+                true
             }
 
             // Target-specific shims
@@ -331,26 +330,18 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 shims::loongarch::EvalContextExt::emulate_loongarch_intrinsic(
                     this, link_name, args, &dest,
                 )?,
-            _ => EmulateItemResult::NotSupported,
+            _ => false,
         };
 
         // The rest either implements the logic, or falls back to `lookup_exported_symbol`.
-        match res {
-            EmulateItemResult::NeedsReturn => {
-                trace!("{:?}", this.dump_place(&dest.clone().into()));
-                this.return_to_block(ret)
-            }
-            EmulateItemResult::NeedsUnwind => {
-                // Jump to the unwind block to begin unwinding.
-                this.unwind_to_block(unwind)
-            }
-            EmulateItemResult::AlreadyJumped => interp_ok(()),
-            EmulateItemResult::NotSupported => {
-                throw_machine_stop!(TerminationInfo::UnsupportedForeignItem(format!(
-                    "can't call LLVM intrinsic `{link_name}` on architecture `{arch}`",
-                    arch = this.tcx.sess.target.arch,
-                )));
-            }
+        if handled {
+            trace!("{:?}", this.dump_place(&dest.clone().into()));
+            this.return_to_block(ret)
+        } else {
+            throw_machine_stop!(TerminationInfo::UnsupportedForeignItem(format!(
+                "can't call LLVM intrinsic `{link_name}` on architecture `{arch}`",
+                arch = this.tcx.sess.target.arch,
+            )));
         }
     }
 }

--- a/src/tools/miri/src/shims/foreign_items.rs
+++ b/src/tools/miri/src/shims/foreign_items.rs
@@ -241,6 +241,118 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             Some(instance) => interp_ok(Some((this.load_mir(instance.def, None)?, instance))),
         }
     }
+
+    // FIXME move this and the LLVM intrinsic impls to the intrinsics module
+    fn call_llvm_intrinsic(
+        &mut self,
+        instance: ty::Instance<'tcx>,
+        args: &[OpTy<'tcx>],
+        dest: &PlaceTy<'tcx>,
+        ret: Option<mir::BasicBlock>,
+        unwind: mir::UnwindAction,
+    ) -> InterpResult<'tcx> {
+        let this = self.eval_context_mut();
+
+        let link_name = this.tcx.codegen_fn_attrs(instance.def_id()).symbol_name.unwrap();
+
+        // FIXME: avoid allocating memory
+        let dest = this.force_allocation(dest)?;
+
+        let res = match link_name.as_str() {
+            // LLVM intrinsics
+            "llvm.prefetch.p0" => {
+                let [p, rw, loc, ty] = this.check_shim_sig_unadjusted(link_name, args)?;
+
+                let _ = this.read_pointer(p)?;
+                let rw = this.read_scalar(rw)?.to_i32()?;
+                let loc = this.read_scalar(loc)?.to_i32()?;
+                let ty = this.read_scalar(ty)?.to_i32()?;
+
+                if ty == 1 {
+                    // Data cache prefetch.
+                    // Notably, we do not have to check the pointer, this operation is never UB!
+
+                    if !matches!(rw, 0 | 1) {
+                        throw_unsup_format!("invalid `rw` value passed to `llvm.prefetch`: {}", rw);
+                    }
+                    if !matches!(loc, 0..=3) {
+                        throw_unsup_format!(
+                            "invalid `loc` value passed to `llvm.prefetch`: {}",
+                            loc
+                        );
+                    }
+                } else {
+                    throw_unsup_format!("unsupported `llvm.prefetch` type argument: {}", ty);
+                }
+
+                EmulateItemResult::NeedsReturn
+            }
+            // Used to implement the x86 `_mm{,256,512}_popcnt_epi{8,16,32,64}` and wasm
+            // `{i,u}8x16_popcnt` functions.
+            name if name.starts_with("llvm.ctpop.v")
+                && this.tcx.sess.target.endian == Endian::Little =>
+            {
+                let [op] = this.check_shim_sig_unadjusted(link_name, args)?;
+
+                let (op, op_len) = this.project_to_simd(op)?;
+                let (dest, dest_len) = this.project_to_simd(&dest)?;
+
+                assert_eq!(dest_len, op_len);
+
+                for i in 0..dest_len {
+                    let op = this.read_immediate(&this.project_index(&op, i)?)?;
+                    // Use `to_uint` to get a zero-extended `u128`. Those
+                    // extra zeros will not affect `count_ones`.
+                    let res = op.to_scalar().to_uint(op.layout.size)?.count_ones();
+
+                    this.write_scalar(
+                        Scalar::from_uint(res, op.layout.size),
+                        &this.project_index(&dest, i)?,
+                    )?;
+                }
+
+                EmulateItemResult::NeedsReturn
+            }
+
+            // Target-specific shims
+            name if name.starts_with("llvm.x86.")
+                && matches!(this.tcx.sess.target.arch, Arch::X86 | Arch::X86_64)
+                && this.tcx.sess.target.endian == Endian::Little =>
+                shims::x86::EvalContextExt::emulate_x86_intrinsic(this, link_name, args, &dest)?,
+            name if name.starts_with("llvm.aarch64.")
+                && this.tcx.sess.target.arch == Arch::AArch64
+                && this.tcx.sess.target.endian == Endian::Little =>
+                shims::aarch64::EvalContextExt::emulate_aarch64_intrinsic(
+                    this, link_name, args, &dest,
+                )?,
+            name if name.starts_with("llvm.loongarch.")
+                && matches!(this.tcx.sess.target.arch, Arch::LoongArch32 | Arch::LoongArch64)
+                && this.tcx.sess.target.endian == Endian::Little =>
+                shims::loongarch::EvalContextExt::emulate_loongarch_intrinsic(
+                    this, link_name, args, &dest,
+                )?,
+            _ => EmulateItemResult::NotSupported,
+        };
+
+        // The rest either implements the logic, or falls back to `lookup_exported_symbol`.
+        match res {
+            EmulateItemResult::NeedsReturn => {
+                trace!("{:?}", this.dump_place(&dest.clone().into()));
+                this.return_to_block(ret)
+            }
+            EmulateItemResult::NeedsUnwind => {
+                // Jump to the unwind block to begin unwinding.
+                this.unwind_to_block(unwind)
+            }
+            EmulateItemResult::AlreadyJumped => interp_ok(()),
+            EmulateItemResult::NotSupported => {
+                throw_machine_stop!(TerminationInfo::UnsupportedForeignItem(format!(
+                    "can't call LLVM intrinsic `{link_name}` on architecture `{arch}`",
+                    arch = this.tcx.sess.target.arch,
+                )));
+            }
+        }
+    }
 }
 
 impl<'tcx> EvalContextExtPriv<'tcx> for crate::MiriInterpCx<'tcx> {}
@@ -801,83 +913,6 @@ trait EvalContextExtPriv<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 let bytes = std::iter::repeat_n(val, n.try_into().unwrap());
                 this.write_bytes_ptr(ptr_dest, bytes)?;
                 this.write_pointer(ptr_dest, dest)?;
-            }
-
-            // LLVM intrinsics
-            "llvm.prefetch.p0" => {
-                let [p, rw, loc, ty] = this.check_shim_sig_unadjusted(link_name, args)?;
-
-                let _ = this.read_pointer(p)?;
-                let rw = this.read_scalar(rw)?.to_i32()?;
-                let loc = this.read_scalar(loc)?.to_i32()?;
-                let ty = this.read_scalar(ty)?.to_i32()?;
-
-                if ty == 1 {
-                    // Data cache prefetch.
-                    // Notably, we do not have to check the pointer, this operation is never UB!
-
-                    if !matches!(rw, 0 | 1) {
-                        throw_unsup_format!("invalid `rw` value passed to `llvm.prefetch`: {}", rw);
-                    }
-                    if !matches!(loc, 0..=3) {
-                        throw_unsup_format!(
-                            "invalid `loc` value passed to `llvm.prefetch`: {}",
-                            loc
-                        );
-                    }
-                } else {
-                    throw_unsup_format!("unsupported `llvm.prefetch` type argument: {}", ty);
-                }
-            }
-            // Used to implement the x86 `_mm{,256,512}_popcnt_epi{8,16,32,64}` and wasm
-            // `{i,u}8x16_popcnt` functions.
-            name if name.starts_with("llvm.ctpop.v")
-                && this.tcx.sess.target.endian == Endian::Little =>
-            {
-                let [op] = this.check_shim_sig_unadjusted(link_name, args)?;
-
-                let (op, op_len) = this.project_to_simd(op)?;
-                let (dest, dest_len) = this.project_to_simd(dest)?;
-
-                assert_eq!(dest_len, op_len);
-
-                for i in 0..dest_len {
-                    let op = this.read_immediate(&this.project_index(&op, i)?)?;
-                    // Use `to_uint` to get a zero-extended `u128`. Those
-                    // extra zeros will not affect `count_ones`.
-                    let res = op.to_scalar().to_uint(op.layout.size)?.count_ones();
-
-                    this.write_scalar(
-                        Scalar::from_uint(res, op.layout.size),
-                        &this.project_index(&dest, i)?,
-                    )?;
-                }
-            }
-
-            // Target-specific shims
-            name if name.starts_with("llvm.x86.")
-                && matches!(this.tcx.sess.target.arch, Arch::X86 | Arch::X86_64)
-                && this.tcx.sess.target.endian == Endian::Little =>
-            {
-                return shims::x86::EvalContextExt::emulate_x86_intrinsic(
-                    this, link_name, args, dest,
-                );
-            }
-            name if name.starts_with("llvm.aarch64.")
-                && this.tcx.sess.target.arch == Arch::AArch64
-                && this.tcx.sess.target.endian == Endian::Little =>
-            {
-                return shims::aarch64::EvalContextExt::emulate_aarch64_intrinsic(
-                    this, link_name, args, dest,
-                );
-            }
-            name if name.starts_with("llvm.loongarch.")
-                && matches!(this.tcx.sess.target.arch, Arch::LoongArch32 | Arch::LoongArch64)
-                && this.tcx.sess.target.endian == Endian::Little =>
-            {
-                return shims::loongarch::EvalContextExt::emulate_loongarch_intrinsic(
-                    this, link_name, args, dest,
-                );
             }
 
             // Fallback to shims in submodules.

--- a/src/tools/miri/src/shims/loongarch.rs
+++ b/src/tools/miri/src/shims/loongarch.rs
@@ -11,7 +11,7 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         link_name: Symbol,
         args: &[OpTy<'tcx>],
         dest: &MPlaceTy<'tcx>,
-    ) -> InterpResult<'tcx, EmulateItemResult> {
+    ) -> InterpResult<'tcx, bool> {
         let this = self.eval_context_mut();
         // Prefix should have already been checked.
         let unprefixed_name = link_name.as_str().strip_prefix("llvm.loongarch.").unwrap();
@@ -67,8 +67,8 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 let result = compute_crc32(crc, data, bit_size, polynomial);
                 this.write_scalar(Scalar::from_u32(result), dest)?;
             }
-            _ => return interp_ok(EmulateItemResult::NotSupported),
+            _ => return interp_ok(false),
         }
-        interp_ok(EmulateItemResult::NeedsReturn)
+        interp_ok(true)
     }
 }

--- a/src/tools/miri/src/shims/x86/aesni.rs
+++ b/src/tools/miri/src/shims/x86/aesni.rs
@@ -10,7 +10,7 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         link_name: Symbol,
         args: &[OpTy<'tcx>],
         dest: &MPlaceTy<'tcx>,
-    ) -> InterpResult<'tcx, EmulateItemResult> {
+    ) -> InterpResult<'tcx, bool> {
         let this = self.eval_context_mut();
         this.expect_target_feature_for_intrinsic(link_name, "aes")?;
         // Prefix should have already been checked.
@@ -112,9 +112,9 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             }
             // TODO: Implement the `llvm.x86.aesni.aeskeygenassist` when possible
             // with an external crate.
-            _ => return interp_ok(EmulateItemResult::NotSupported),
+            _ => return interp_ok(false),
         }
-        interp_ok(EmulateItemResult::NeedsReturn)
+        interp_ok(true)
     }
 }
 

--- a/src/tools/miri/src/shims/x86/avx.rs
+++ b/src/tools/miri/src/shims/x86/avx.rs
@@ -14,7 +14,7 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         link_name: Symbol,
         args: &[OpTy<'tcx>],
         dest: &MPlaceTy<'tcx>,
-    ) -> InterpResult<'tcx, EmulateItemResult> {
+    ) -> InterpResult<'tcx, bool> {
         let this = self.eval_context_mut();
         this.expect_target_feature_for_intrinsic(link_name, "avx")?;
         // Prefix should have already been checked.
@@ -243,8 +243,8 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // The only thing that needs to be ensured is the correct calling convention.
                 let [] = this.check_shim_sig_unadjusted(link_name, args)?;
             }
-            _ => return interp_ok(EmulateItemResult::NotSupported),
+            _ => return interp_ok(false),
         }
-        interp_ok(EmulateItemResult::NeedsReturn)
+        interp_ok(true)
     }
 }

--- a/src/tools/miri/src/shims/x86/avx2.rs
+++ b/src/tools/miri/src/shims/x86/avx2.rs
@@ -14,7 +14,7 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         link_name: Symbol,
         args: &[OpTy<'tcx>],
         dest: &MPlaceTy<'tcx>,
-    ) -> InterpResult<'tcx, EmulateItemResult> {
+    ) -> InterpResult<'tcx, bool> {
         let this = self.eval_context_mut();
         this.expect_target_feature_for_intrinsic(link_name, "avx2")?;
         // Prefix should have already been checked.
@@ -216,8 +216,8 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
                 pmaddwd(this, left, right, dest)?;
             }
-            _ => return interp_ok(EmulateItemResult::NotSupported),
+            _ => return interp_ok(false),
         }
-        interp_ok(EmulateItemResult::NeedsReturn)
+        interp_ok(true)
     }
 }

--- a/src/tools/miri/src/shims/x86/avx512.rs
+++ b/src/tools/miri/src/shims/x86/avx512.rs
@@ -12,7 +12,7 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         link_name: Symbol,
         args: &[OpTy<'tcx>],
         dest: &MPlaceTy<'tcx>,
-    ) -> InterpResult<'tcx, EmulateItemResult> {
+    ) -> InterpResult<'tcx, bool> {
         let this = self.eval_context_mut();
         // Prefix should have already been checked.
         let unprefixed_name = link_name.as_str().strip_prefix("llvm.x86.avx512.").unwrap();
@@ -178,9 +178,9 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
                 packusdw(this, a, b, dest)?;
             }
-            _ => return interp_ok(EmulateItemResult::NotSupported),
+            _ => return interp_ok(false),
         }
-        interp_ok(EmulateItemResult::NeedsReturn)
+        interp_ok(true)
     }
 }
 

--- a/src/tools/miri/src/shims/x86/bmi.rs
+++ b/src/tools/miri/src/shims/x86/bmi.rs
@@ -10,7 +10,7 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         link_name: Symbol,
         args: &[OpTy<'tcx>],
         dest: &MPlaceTy<'tcx>,
-    ) -> InterpResult<'tcx, EmulateItemResult> {
+    ) -> InterpResult<'tcx, bool> {
         let this = self.eval_context_mut();
 
         // Prefix should have already been checked.
@@ -29,7 +29,7 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         this.expect_target_feature_for_intrinsic(link_name, target_feature)?;
 
         if is_64_bit && this.tcx.sess.target.arch != Arch::X86_64 {
-            return interp_ok(EmulateItemResult::NotSupported);
+            return interp_ok(false);
         }
 
         let [left, right] = this.check_shim_sig_unadjusted(link_name, args)?;
@@ -92,7 +92,7 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 }
                 result
             }
-            _ => return interp_ok(EmulateItemResult::NotSupported),
+            _ => return interp_ok(false),
         };
 
         let result = if is_64_bit {
@@ -102,6 +102,6 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         };
         this.write_scalar(result, dest)?;
 
-        interp_ok(EmulateItemResult::NeedsReturn)
+        interp_ok(true)
     }
 }

--- a/src/tools/miri/src/shims/x86/gfni.rs
+++ b/src/tools/miri/src/shims/x86/gfni.rs
@@ -9,7 +9,7 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         link_name: Symbol,
         args: &[OpTy<'tcx>],
         dest: &MPlaceTy<'tcx>,
-    ) -> InterpResult<'tcx, EmulateItemResult> {
+    ) -> InterpResult<'tcx, bool> {
         let this = self.eval_context_mut();
 
         // Prefix should have already been checked.
@@ -58,9 +58,9 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                     this.write_scalar(Scalar::from_u8(gf2p8_mul(left, right)), &dest)?;
                 }
             }
-            _ => return interp_ok(EmulateItemResult::NotSupported),
+            _ => return interp_ok(false),
         }
-        interp_ok(EmulateItemResult::NeedsReturn)
+        interp_ok(true)
     }
 }
 

--- a/src/tools/miri/src/shims/x86/mod.rs
+++ b/src/tools/miri/src/shims/x86/mod.rs
@@ -30,7 +30,7 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         link_name: Symbol,
         args: &[OpTy<'tcx>],
         dest: &MPlaceTy<'tcx>,
-    ) -> InterpResult<'tcx, EmulateItemResult> {
+    ) -> InterpResult<'tcx, bool> {
         let this = self.eval_context_mut();
         // Prefix should have already been checked.
         let unprefixed_name = link_name.as_str().strip_prefix("llvm.x86.").unwrap();
@@ -42,7 +42,7 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             // https://www.intel.com/content/www/us/en/docs/cpp-compiler/developer-guide-reference/2021-8/subborrow-u32-subborrow-u64.html
             "addcarry.32" | "addcarry.64" | "subborrow.32" | "subborrow.64" => {
                 if unprefixed_name.ends_with("64") && this.tcx.sess.target.arch != Arch::X86_64 {
-                    return interp_ok(EmulateItemResult::NotSupported);
+                    return interp_ok(false);
                 }
 
                 let [cb_in, a, b] = this.check_shim_sig_unadjusted(link_name, args)?;
@@ -147,9 +147,9 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 );
             }
 
-            _ => return interp_ok(EmulateItemResult::NotSupported),
+            _ => return interp_ok(false),
         }
-        interp_ok(EmulateItemResult::NeedsReturn)
+        interp_ok(true)
     }
 }
 

--- a/src/tools/miri/src/shims/x86/sha.rs
+++ b/src/tools/miri/src/shims/x86/sha.rs
@@ -15,7 +15,7 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         link_name: Symbol,
         args: &[OpTy<'tcx>],
         dest: &MPlaceTy<'tcx>,
-    ) -> InterpResult<'tcx, EmulateItemResult> {
+    ) -> InterpResult<'tcx, bool> {
         let this = self.eval_context_mut();
         this.expect_target_feature_for_intrinsic(link_name, "sha")?;
         // Prefix should have already been checked.
@@ -104,9 +104,9 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 let result = sha256msg2(a, b);
                 write(this, &dest, result)?;
             }
-            _ => return interp_ok(EmulateItemResult::NotSupported),
+            _ => return interp_ok(false),
         }
-        interp_ok(EmulateItemResult::NeedsReturn)
+        interp_ok(true)
     }
 }
 

--- a/src/tools/miri/src/shims/x86/sse.rs
+++ b/src/tools/miri/src/shims/x86/sse.rs
@@ -14,7 +14,7 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         link_name: Symbol,
         args: &[OpTy<'tcx>],
         dest: &MPlaceTy<'tcx>,
-    ) -> InterpResult<'tcx, EmulateItemResult> {
+    ) -> InterpResult<'tcx, bool> {
         let this = self.eval_context_mut();
         this.expect_target_feature_for_intrinsic(link_name, "sse")?;
         // Prefix should have already been checked.
@@ -171,8 +171,8 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
                 this.write_immediate(*res, dest)?;
             }
-            _ => return interp_ok(EmulateItemResult::NotSupported),
+            _ => return interp_ok(false),
         }
-        interp_ok(EmulateItemResult::NeedsReturn)
+        interp_ok(true)
     }
 }

--- a/src/tools/miri/src/shims/x86/sse2.rs
+++ b/src/tools/miri/src/shims/x86/sse2.rs
@@ -14,7 +14,7 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         link_name: Symbol,
         args: &[OpTy<'tcx>],
         dest: &MPlaceTy<'tcx>,
-    ) -> InterpResult<'tcx, EmulateItemResult> {
+    ) -> InterpResult<'tcx, bool> {
         let this = self.eval_context_mut();
         this.expect_target_feature_for_intrinsic(link_name, "sse2")?;
         // Prefix should have already been checked.
@@ -272,8 +272,8 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
                 pmaddwd(this, left, right, dest)?;
             }
-            _ => return interp_ok(EmulateItemResult::NotSupported),
+            _ => return interp_ok(false),
         }
-        interp_ok(EmulateItemResult::NeedsReturn)
+        interp_ok(true)
     }
 }

--- a/src/tools/miri/src/shims/x86/sse3.rs
+++ b/src/tools/miri/src/shims/x86/sse3.rs
@@ -9,7 +9,7 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         link_name: Symbol,
         args: &[OpTy<'tcx>],
         dest: &MPlaceTy<'tcx>,
-    ) -> InterpResult<'tcx, EmulateItemResult> {
+    ) -> InterpResult<'tcx, bool> {
         let this = self.eval_context_mut();
         this.expect_target_feature_for_intrinsic(link_name, "sse3")?;
         // Prefix should have already been checked.
@@ -28,8 +28,8 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
                 this.mem_copy(src_ptr, dest.ptr(), dest.layout.size, /*nonoverlapping*/ true)?;
             }
-            _ => return interp_ok(EmulateItemResult::NotSupported),
+            _ => return interp_ok(false),
         }
-        interp_ok(EmulateItemResult::NeedsReturn)
+        interp_ok(true)
     }
 }

--- a/src/tools/miri/src/shims/x86/sse41.rs
+++ b/src/tools/miri/src/shims/x86/sse41.rs
@@ -10,7 +10,7 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         link_name: Symbol,
         args: &[OpTy<'tcx>],
         dest: &MPlaceTy<'tcx>,
-    ) -> InterpResult<'tcx, EmulateItemResult> {
+    ) -> InterpResult<'tcx, bool> {
         let this = self.eval_context_mut();
         this.expect_target_feature_for_intrinsic(link_name, "sse4.1")?;
         // Prefix should have already been checked.
@@ -155,8 +155,8 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
                 this.write_scalar(Scalar::from_i32(res.into()), dest)?;
             }
-            _ => return interp_ok(EmulateItemResult::NotSupported),
+            _ => return interp_ok(false),
         }
-        interp_ok(EmulateItemResult::NeedsReturn)
+        interp_ok(true)
     }
 }

--- a/src/tools/miri/src/shims/x86/sse42.rs
+++ b/src/tools/miri/src/shims/x86/sse42.rs
@@ -279,7 +279,7 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         link_name: Symbol,
         args: &[OpTy<'tcx>],
         dest: &MPlaceTy<'tcx>,
-    ) -> InterpResult<'tcx, EmulateItemResult> {
+    ) -> InterpResult<'tcx, bool> {
         let this = self.eval_context_mut();
         this.expect_target_feature_for_intrinsic(link_name, "sse4.2")?;
         // Prefix should have already been checked.
@@ -428,7 +428,7 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 };
 
                 if bit_size == 64 && this.tcx.sess.target.arch != Arch::X86_64 {
-                    return interp_ok(EmulateItemResult::NotSupported);
+                    return interp_ok(false);
                 }
 
                 let [left, right] = this.check_shim_sig_unadjusted(link_name, args)?;
@@ -460,8 +460,8 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
                 this.write_scalar(result, dest)?;
             }
-            _ => return interp_ok(EmulateItemResult::NotSupported),
+            _ => return interp_ok(false),
         }
-        interp_ok(EmulateItemResult::NeedsReturn)
+        interp_ok(true)
     }
 }

--- a/src/tools/miri/src/shims/x86/ssse3.rs
+++ b/src/tools/miri/src/shims/x86/ssse3.rs
@@ -11,7 +11,7 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         link_name: Symbol,
         args: &[OpTy<'tcx>],
         dest: &MPlaceTy<'tcx>,
-    ) -> InterpResult<'tcx, EmulateItemResult> {
+    ) -> InterpResult<'tcx, bool> {
         let this = self.eval_context_mut();
         this.expect_target_feature_for_intrinsic(link_name, "ssse3")?;
         // Prefix should have already been checked.
@@ -67,8 +67,8 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
                 psign(this, left, right, dest)?;
             }
-            _ => return interp_ok(EmulateItemResult::NotSupported),
+            _ => return interp_ok(false),
         }
-        interp_ok(EmulateItemResult::NeedsReturn)
+        interp_ok(true)
     }
 }

--- a/src/tools/tidy/src/deps.rs
+++ b/src/tools/tidy/src/deps.rs
@@ -242,11 +242,17 @@ const EXCEPTIONS_RUST_ANALYZER: ExceptionList = &[
 
 const EXCEPTIONS_RUSTC_PERF: ExceptionList = &[
     // tidy-alphabetical-start
+    ("aws-lc-rs", "ISC AND (Apache-2.0 OR ISC)"),
+    (
+        "aws-lc-sys",
+        "ISC AND (Apache-2.0 OR ISC) AND Apache-2.0 AND MIT AND BSD-3-Clause AND (Apache-2.0 OR ISC OR MIT) AND (Apache-2.0 OR ISC OR MIT-0)",
+    ),
+    ("brotli", "BSD-3-Clause AND MIT"),
+    ("fast-srgb8", "MIT OR Apache-2.0 OR CC0-1.0"),
     ("inferno", "CDDL-1.0"),
     ("option-ext", "MPL-2.0"),
-    ("terminfo", "WTFPL"),
     ("wasite", "Apache-2.0 OR BSL-1.0 OR MIT"),
-    ("wezterm-bidi", "MIT AND Unicode-DFS-2016"),
+    ("webpki-root-certs", "CDLA-Permissive-2.0"),
     ("whoami", "Apache-2.0 OR BSL-1.0 OR MIT"),
     // tidy-alphabetical-end
 ];

--- a/src/tools/tidy/src/extdeps.rs
+++ b/src/tools/tidy/src/extdeps.rs
@@ -10,7 +10,7 @@ use crate::diagnostics::TidyCtx;
 const ALLOWED_SOURCES: &[&str] = &[
     r#""registry+https://github.com/rust-lang/crates.io-index""#,
     // This is `rust_team_data` used by `site` in src/tools/rustc-perf,
-    r#""git+https://github.com/rust-lang/team#a5260e76d3aa894c64c56e6ddc8545b9a98043ec""#,
+    r#""git+https://github.com/rust-lang/team#db2c1ed9fbc0216e533db954cd249045c01c7406""#,
 ];
 
 /// Checks for external package sources. `root` is the path to the directory that contains the

--- a/tests/codegen-llvm/issues/rem-match-unreachable.rs
+++ b/tests/codegen-llvm/issues/rem-match-unreachable.rs
@@ -1,0 +1,32 @@
+// Matching every possible result of `x % 5` should not keep unreachable
+// fallback panic code.
+
+//@ compile-flags: -Copt-level=3
+//@ only-64bit
+
+#![crate_type = "lib"]
+
+unsafe extern "C" {
+    fn rem_arm0(x: usize) -> usize;
+    fn rem_arm1(x: usize) -> usize;
+    fn rem_arm2(x: usize) -> usize;
+    fn rem_arm3(x: usize) -> usize;
+    fn rem_arm4(x: usize) -> usize;
+}
+
+// CHECK-LABEL: @rem_match_unreachable
+// CHECK-NOT: core::panicking::panic
+// CHECK-NOT: entered unreachable code
+#[no_mangle]
+pub fn rem_match_unreachable(x: usize) -> usize {
+    unsafe {
+        match x % 5 {
+            0 => rem_arm0(x),
+            1 => rem_arm1(x),
+            2 => rem_arm2(x),
+            3 => rem_arm3(x),
+            4 => rem_arm4(x),
+            _ => unreachable!(),
+        }
+    }
+}

--- a/tests/codegen-llvm/range-len-try-from.rs
+++ b/tests/codegen-llvm/range-len-try-from.rs
@@ -4,6 +4,7 @@
 
 //@ compile-flags: -Copt-level=3
 //@ only-64bit
+//@ ignore-s390x OPT missing on s390x https://github.com/llvm/llvm-project/issues/208712
 
 #![crate_type = "lib"]
 

--- a/tests/run-make/const-destruct-stable-toolchain/const-drop-nightly.stderr
+++ b/tests/run-make/const-destruct-stable-toolchain/const-drop-nightly.stderr
@@ -1,0 +1,16 @@
+error[E0493]: destructor of `T` cannot be evaluated at compile-time
+  --> const-drop.rs:1:24
+   |
+LL | const fn const_drop<T>(_: T) {}
+   |                        ^      - value is dropped here
+   |                        |
+   |                        the destructor for this type cannot be evaluated in constant functions
+   |
+help: consider restricting type parameter `T` with unstable trait `Destruct`
+   |
+LL | const fn const_drop<T: [const] Destruct>(_: T) {}
+   |                      ++++++++++++++++++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0493`.

--- a/tests/run-make/const-destruct-stable-toolchain/const-drop-stable.stderr
+++ b/tests/run-make/const-destruct-stable-toolchain/const-drop-stable.stderr
@@ -1,0 +1,11 @@
+error[E0493]: destructor of `T` cannot be evaluated at compile-time
+ --> const-drop.rs:1:24
+  |
+1 | const fn const_drop<T>(_: T) {}
+  |                        ^      - value is dropped here
+  |                        |
+  |                        the destructor for this type cannot be evaluated in constant functions
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0493`.

--- a/tests/run-make/const-destruct-stable-toolchain/const-drop.rs
+++ b/tests/run-make/const-destruct-stable-toolchain/const-drop.rs
@@ -1,0 +1,3 @@
+const fn const_drop<T>(_: T) {}
+
+fn main() {}

--- a/tests/run-make/const-destruct-stable-toolchain/rmake.rs
+++ b/tests/run-make/const-destruct-stable-toolchain/rmake.rs
@@ -1,0 +1,26 @@
+//@ needs-target-std
+//
+// Test that the suggestion to constrain a type parameter that is dropped in a const
+// function with a `[const] Destruct` bound is only offered on nightly, since the bound
+// requires an unstable feature.
+
+use run_make_support::{diff, rustc};
+
+fn main() {
+    let out = rustc()
+        .input("const-drop.rs")
+        .env("RUSTC_BOOTSTRAP", "-1")
+        .run_fail()
+        .assert_stderr_not_contains("consider restricting type parameter `T`")
+        .stderr_utf8();
+    diff().expected_file("const-drop-stable.stderr").actual_text("(rustc)", &out).run();
+    let out = rustc()
+        .input("const-drop.rs")
+        .ui_testing()
+        .run_fail()
+        .assert_stderr_contains(
+            "consider restricting type parameter `T` with unstable trait `Destruct`",
+        )
+        .stderr_utf8();
+    diff().expected_file("const-drop-nightly.stderr").actual_text("(rustc)", &out).run();
+}

--- a/tests/ui/codegen/overflow-during-mono.stderr
+++ b/tests/ui/codegen/overflow-during-mono.stderr
@@ -3,8 +3,8 @@ error[E0275]: overflow evaluating the requirement `for<'a> {closure@$DIR/overflo
    = help: consider increasing the recursion limit by adding a `#![recursion_limit = "64"]` attribute to your crate (`overflow_during_mono`)
    = note: required for `Filter<IntoIter<i32, 11>, {closure@overflow-during-mono.rs:14:41}>` to implement `Iterator`
    = note: 31 redundant requirements hidden
-   = note: required for `Filter<Filter<Filter<Filter<Filter<..., ...>, ...>, ...>, ...>, ...>` to implement `Iterator`
-   = note: required for `Filter<Filter<Filter<Filter<Filter<..., ...>, ...>, ...>, ...>, ...>` to implement `IntoIterator`
+   = note: required for `Filter<Filter<Filter<Filter<Filter<Filter<_, _>, _>, _>, _>, _>, _>` to implement `Iterator`
+   = note: required for `Filter<Filter<Filter<Filter<Filter<Filter<_, _>, _>, _>, _>, _>, _>` to implement `IntoIterator`
    = note: the full name for the type has been written to '$TEST_BUILD_DIR/overflow-during-mono.long-type-$LONG_TYPE_HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
 

--- a/tests/ui/coercion/hr_alias_normalization_leaking_vars.stderr
+++ b/tests/ui/coercion/hr_alias_normalization_leaking_vars.stderr
@@ -16,7 +16,7 @@ error[E0308]: mismatched types
   --> $DIR/hr_alias_normalization_leaking_vars.rs:34:36
    |
 LL |     LendingIterator::for_each(&(), f);
-   |     -------------------------      ^ expected `Box<fn(...)>`, found fn item
+   |     -------------------------      ^ expected `Box<fn(_)>`, found fn item
    |     |
    |     arguments to this function are incorrect
    |

--- a/tests/ui/comptime/comptime_closure.rs
+++ b/tests/ui/comptime/comptime_closure.rs
@@ -1,0 +1,13 @@
+#![feature(rustc_attrs, stmt_expr_attributes)]
+
+const _: () = {
+    let f = #[rustc_comptime]
+    //~^ ERROR: `#[rustc_comptime]` attribute cannot be used on closures
+    || ();
+
+    // FIXME(comptime): closures should work, too.
+    f();
+    //~^ ERROR: cannot call non-const closure in constants
+};
+
+fn main() {}

--- a/tests/ui/comptime/comptime_closure.stderr
+++ b/tests/ui/comptime/comptime_closure.stderr
@@ -1,0 +1,20 @@
+error: `#[rustc_comptime]` attribute cannot be used on closures
+  --> $DIR/comptime_closure.rs:4:13
+   |
+LL |     let f = #[rustc_comptime]
+   |             ^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[rustc_comptime]` can be applied to functions, inherent impl blocks, and inherent methods
+
+error[E0015]: cannot call non-const closure in constants
+  --> $DIR/comptime_closure.rs:9:5
+   |
+LL |     f();
+   |     ^^^
+   |
+   = note: closures need an RFC before allowed to be called in constants
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0015`.

--- a/tests/ui/comptime/comptime_impl.rs
+++ b/tests/ui/comptime/comptime_impl.rs
@@ -1,0 +1,37 @@
+#![feature(rustc_attrs, const_trait_impl)]
+
+const trait Foo {
+    fn foo(&self);
+
+    fn bar(&self) {}
+}
+
+struct Bar;
+
+#[rustc_comptime]
+//~^ ERROR: cannot be used on inherent impl
+impl Bar {
+    fn boo(&self) {}
+}
+
+#[rustc_comptime]
+//~^ ERROR: cannot be used on trait impl
+impl Foo for Bar {
+    fn foo(&self) {
+        comptime_fn();
+        //~^ ERROR: comptime fns can only be called at compile time
+    }
+}
+
+#[rustc_comptime]
+fn comptime_fn() {}
+
+const _: () = {
+    Bar.boo();
+    Bar.foo();
+    //~^ ERROR: `Bar: const Foo` is not satisfied
+    Bar.bar();
+    //~^ ERROR: `Bar: const Foo` is not satisfied
+};
+
+fn main() {}

--- a/tests/ui/comptime/comptime_impl.rs
+++ b/tests/ui/comptime/comptime_impl.rs
@@ -9,7 +9,6 @@ const trait Foo {
 struct Bar;
 
 #[rustc_comptime]
-//~^ ERROR: cannot be used on inherent impl
 impl Bar {
     fn boo(&self) {}
 }
@@ -19,7 +18,6 @@ impl Bar {
 impl Foo for Bar {
     fn foo(&self) {
         comptime_fn();
-        //~^ ERROR: comptime fns can only be called at compile time
     }
 }
 

--- a/tests/ui/comptime/comptime_impl.stderr
+++ b/tests/ui/comptime/comptime_impl.stderr
@@ -1,27 +1,13 @@
-error: `#[rustc_comptime]` attribute cannot be used on inherent impl blocks
-  --> $DIR/comptime_impl.rs:11:1
-   |
-LL | #[rustc_comptime]
-   | ^^^^^^^^^^^^^^^^^
-   |
-   = help: `#[rustc_comptime]` can only be applied to functions
-
 error: `#[rustc_comptime]` attribute cannot be used on trait impl blocks
-  --> $DIR/comptime_impl.rs:17:1
+  --> $DIR/comptime_impl.rs:16:1
    |
 LL | #[rustc_comptime]
    | ^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_comptime]` can only be applied to functions
-
-error: comptime fns can only be called at compile time
-  --> $DIR/comptime_impl.rs:21:9
-   |
-LL |         comptime_fn();
-   |         ^^^^^^^^^^^^^
+   = help: `#[rustc_comptime]` can be applied to functions and inherent impl blocks
 
 error[E0277]: the trait bound `Bar: const Foo` is not satisfied
-  --> $DIR/comptime_impl.rs:31:9
+  --> $DIR/comptime_impl.rs:29:9
    |
 LL |     Bar.foo();
    |         ^^^
@@ -32,7 +18,7 @@ LL | impl const Foo for Bar {
    |      +++++
 
 error[E0277]: the trait bound `Bar: const Foo` is not satisfied
-  --> $DIR/comptime_impl.rs:33:9
+  --> $DIR/comptime_impl.rs:31:9
    |
 LL |     Bar.bar();
    |         ^^^
@@ -42,6 +28,6 @@ help: make the `impl` of trait `Foo` `const`
 LL | impl const Foo for Bar {
    |      +++++
 
-error: aborting due to 5 previous errors
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/comptime/comptime_impl.stderr
+++ b/tests/ui/comptime/comptime_impl.stderr
@@ -1,0 +1,47 @@
+error: `#[rustc_comptime]` attribute cannot be used on inherent impl blocks
+  --> $DIR/comptime_impl.rs:11:1
+   |
+LL | #[rustc_comptime]
+   | ^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[rustc_comptime]` can only be applied to functions
+
+error: `#[rustc_comptime]` attribute cannot be used on trait impl blocks
+  --> $DIR/comptime_impl.rs:17:1
+   |
+LL | #[rustc_comptime]
+   | ^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[rustc_comptime]` can only be applied to functions
+
+error: comptime fns can only be called at compile time
+  --> $DIR/comptime_impl.rs:21:9
+   |
+LL |         comptime_fn();
+   |         ^^^^^^^^^^^^^
+
+error[E0277]: the trait bound `Bar: const Foo` is not satisfied
+  --> $DIR/comptime_impl.rs:31:9
+   |
+LL |     Bar.foo();
+   |         ^^^
+   |
+help: make the `impl` of trait `Foo` `const`
+   |
+LL | impl const Foo for Bar {
+   |      +++++
+
+error[E0277]: the trait bound `Bar: const Foo` is not satisfied
+  --> $DIR/comptime_impl.rs:33:9
+   |
+LL |     Bar.bar();
+   |         ^^^
+   |
+help: make the `impl` of trait `Foo` `const`
+   |
+LL | impl const Foo for Bar {
+   |      +++++
+
+error: aborting due to 5 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/comptime/comptime_method.rs
+++ b/tests/ui/comptime/comptime_method.rs
@@ -3,14 +3,15 @@
 struct Bar;
 
 #[rustc_comptime]
-//~^ ERROR: cannot be used on inherent impl
 impl Bar {
     fn boo(&self) {}
 }
 
 const _: () = {
     Bar.boo();
-    //~^ ERROR: cannot call non-const method `Bar::boo` in constants
 };
 
-fn main() {}
+fn main() {
+    Bar.boo();
+    //~^ ERROR: comptime fns can only be called at compile time
+}

--- a/tests/ui/comptime/comptime_method.rs
+++ b/tests/ui/comptime/comptime_method.rs
@@ -1,0 +1,16 @@
+#![feature(rustc_attrs)]
+
+struct Bar;
+
+#[rustc_comptime]
+//~^ ERROR: cannot be used on inherent impl
+impl Bar {
+    fn boo(&self) {}
+}
+
+const _: () = {
+    Bar.boo();
+    //~^ ERROR: cannot call non-const method `Bar::boo` in constants
+};
+
+fn main() {}

--- a/tests/ui/comptime/comptime_method.stderr
+++ b/tests/ui/comptime/comptime_method.stderr
@@ -1,0 +1,19 @@
+error: `#[rustc_comptime]` attribute cannot be used on inherent impl blocks
+  --> $DIR/comptime_method.rs:5:1
+   |
+LL | #[rustc_comptime]
+   | ^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[rustc_comptime]` can only be applied to functions
+
+error[E0015]: cannot call non-const method `Bar::boo` in constants
+  --> $DIR/comptime_method.rs:12:9
+   |
+LL |     Bar.boo();
+   |         ^^^^^
+   |
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0015`.

--- a/tests/ui/comptime/comptime_method.stderr
+++ b/tests/ui/comptime/comptime_method.stderr
@@ -1,19 +1,8 @@
-error: `#[rustc_comptime]` attribute cannot be used on inherent impl blocks
-  --> $DIR/comptime_method.rs:5:1
-   |
-LL | #[rustc_comptime]
-   | ^^^^^^^^^^^^^^^^^
-   |
-   = help: `#[rustc_comptime]` can only be applied to functions
-
-error[E0015]: cannot call non-const method `Bar::boo` in constants
-  --> $DIR/comptime_method.rs:12:9
+error: comptime fns can only be called at compile time
+  --> $DIR/comptime_method.rs:15:5
    |
 LL |     Bar.boo();
-   |         ^^^^^
-   |
-   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
+   |     ^^^^^^^^^
 
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0015`.

--- a/tests/ui/comptime/comptime_method_bounds.rs
+++ b/tests/ui/comptime/comptime_method_bounds.rs
@@ -1,0 +1,24 @@
+//@check-pass
+
+#![feature(rustc_attrs, const_trait_impl)]
+
+struct Bar<T>(T);
+
+const trait Trait {
+    fn method(&self) {}
+}
+
+#[rustc_comptime]
+impl<T: const Trait> Bar<T> {
+    fn boo(&self) {
+        self.0.method()
+    }
+}
+
+const impl Trait for () {}
+
+const _: () = {
+    Bar(()).boo();
+};
+
+fn main() {}

--- a/tests/ui/comptime/comptime_trait.rs
+++ b/tests/ui/comptime/comptime_trait.rs
@@ -1,0 +1,32 @@
+#![feature(rustc_attrs, const_trait_impl, trait_alias)]
+
+#[rustc_comptime]
+//~^ ERROR: `#[rustc_comptime]` attribute cannot be used on traits
+trait Trait {
+    fn method(&self) {}
+}
+
+const impl Trait for () {}
+
+#[rustc_comptime]
+//~^ ERROR: `#[rustc_comptime]` attribute cannot be used on trait impl
+impl Trait for u32 {
+    fn method(&self) {
+        comptime_fn();
+    }
+}
+
+#[rustc_comptime]
+fn comptime_fn() {}
+
+#[rustc_comptime]
+//~^ ERROR: `#[rustc_comptime]` attribute cannot be used on trait aliases
+trait TraitAlias = const Trait;
+
+#[rustc_comptime]
+fn func<T: const TraitAlias>(t: &T) {
+    t.method()
+    //~^ ERROR: cannot call non-const method `<T as Trait>::method` in constants
+}
+
+fn main() {}

--- a/tests/ui/comptime/comptime_trait.stderr
+++ b/tests/ui/comptime/comptime_trait.stderr
@@ -1,0 +1,35 @@
+error: `#[rustc_comptime]` attribute cannot be used on traits
+  --> $DIR/comptime_trait.rs:3:1
+   |
+LL | #[rustc_comptime]
+   | ^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[rustc_comptime]` can be applied to functions and inherent impl blocks
+
+error: `#[rustc_comptime]` attribute cannot be used on trait impl blocks
+  --> $DIR/comptime_trait.rs:11:1
+   |
+LL | #[rustc_comptime]
+   | ^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[rustc_comptime]` can be applied to functions and inherent impl blocks
+
+error: `#[rustc_comptime]` attribute cannot be used on trait aliases
+  --> $DIR/comptime_trait.rs:22:1
+   |
+LL | #[rustc_comptime]
+   | ^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[rustc_comptime]` can be applied to functions and inherent impl blocks
+
+error[E0015]: cannot call non-const method `<T as Trait>::method` in constants
+  --> $DIR/comptime_trait.rs:28:7
+   |
+LL |     t.method()
+   |       ^^^^^^^^
+   |
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0015`.

--- a/tests/ui/comptime/trait_comptime.stderr
+++ b/tests/ui/comptime/trait_comptime.stderr
@@ -4,7 +4,7 @@ error: `#[rustc_comptime]` attribute cannot be used on required trait methods
 LL |     #[rustc_comptime]
    |     ^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_comptime]` can only be applied to functions with a body
+   = help: `#[rustc_comptime]` can be applied to functions with a body and inherent impl blocks
 
 error: `#[rustc_comptime]` attribute cannot be used on provided trait methods
   --> $DIR/trait_comptime.rs:8:5
@@ -12,7 +12,7 @@ error: `#[rustc_comptime]` attribute cannot be used on provided trait methods
 LL |     #[rustc_comptime]
    |     ^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_comptime]` can be applied to functions and inherent methods
+   = help: `#[rustc_comptime]` can be applied to functions, inherent impl blocks, and inherent methods
 
 error: `#[rustc_comptime]` attribute cannot be used on trait methods in impl blocks
   --> $DIR/trait_comptime.rs:21:5
@@ -20,7 +20,7 @@ error: `#[rustc_comptime]` attribute cannot be used on trait methods in impl blo
 LL |     #[rustc_comptime]
    |     ^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_comptime]` can be applied to functions and inherent methods
+   = help: `#[rustc_comptime]` can be applied to functions, inherent impl blocks, and inherent methods
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/consts/min_const_fn/min_const_fn.stderr
+++ b/tests/ui/consts/min_const_fn/min_const_fn.stderr
@@ -73,6 +73,11 @@ LL | const fn no_apit(_x: impl std::fmt::Debug) {}
    |                  ^^                         - value is dropped here
    |                  |
    |                  the destructor for this type cannot be evaluated in constant functions
+   |
+help: consider restricting opaque type `impl std::fmt::Debug` with unstable trait `Destruct`
+   |
+LL | const fn no_apit(_x: impl std::fmt::Debug + [const] Destruct) {}
+   |                                           ++++++++++++++++++
 
 error: aborting due to 9 previous errors
 

--- a/tests/ui/consts/unstable-const-fn-in-libcore.stderr
+++ b/tests/ui/consts/unstable-const-fn-in-libcore.stderr
@@ -6,6 +6,11 @@ LL |     const fn unwrap_or_else<F: [const] FnOnce() -> T>(self, f: F) -> T {
 ...
 LL |     }
    |     - value is dropped here
+   |
+help: consider further restricting type parameter `F` with unstable trait `Destruct`
+   |
+LL |     const fn unwrap_or_else<F: [const] FnOnce() -> T + [const] Destruct>(self, f: F) -> T {
+   |                                                      ++++++++++++++++++
 
 error[E0493]: destructor of `Opt<T>` cannot be evaluated at compile-time
   --> $DIR/unstable-const-fn-in-libcore.rs:19:55

--- a/tests/ui/diagnostic-width/E0271.ascii.stderr
+++ b/tests/ui/diagnostic-width/E0271.ascii.stderr
@@ -1,4 +1,4 @@
-error[E0271]: type mismatch resolving `<Result<..., ()> as Future>::Error == Foo`
+error[E0271]: type mismatch resolving `<Result<_, ()> as Future>::Error == Foo`
   --> $DIR/E0271.rs:19:5
    |
 LL | /     Box::new(
@@ -7,14 +7,14 @@ LL | |             Err::<(), _>(
 LL | |                 Ok::<_, ()>(
 ...  |
 LL | |     )
-   | |_____^ type mismatch resolving `<Result<..., ()> as Future>::Error == Foo`
+   | |_____^ type mismatch resolving `<Result<_, ()> as Future>::Error == Foo`
    |
 note: expected this to be `Foo`
   --> $DIR/E0271.rs:9:18
    |
 LL |     type Error = E;
    |                  ^
-   = note: required for the cast from `Box<Result<..., ()>>` to `Box<...>`
+   = note: required for the cast from `Box<Result<_, ()>>` to `Box<_>`
    = note: the full name for the type has been written to '$TEST_BUILD_DIR/E0271.long-type-$LONG_TYPE_HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
 

--- a/tests/ui/diagnostic-width/E0271.unicode.stderr
+++ b/tests/ui/diagnostic-width/E0271.unicode.stderr
@@ -1,4 +1,4 @@
-error[E0271]: type mismatch resolving `<Result<..., ()> as Future>::Error == Foo`
+error[E0271]: type mismatch resolving `<Result<_, ()> as Future>::Error == Foo`
    ╭▸ $DIR/E0271.rs:19:5
    │
 LL │ ┏     Box::new(
@@ -7,14 +7,14 @@ LL │ ┃             Err::<(), _>(
 LL │ ┃                 Ok::<_, ()>(
    ‡ ┃
 LL │ ┃     )
-   │ ┗━━━━━┛ type mismatch resolving `<Result<..., ()> as Future>::Error == Foo`
+   │ ┗━━━━━┛ type mismatch resolving `<Result<_, ()> as Future>::Error == Foo`
    ╰╴
 note: expected this to be `Foo`
    ╭▸ $DIR/E0271.rs:9:18
    │
 LL │     type Error = E;
    │                  ━
-   ├ note: required for the cast from `Box<Result<..., ()>>` to `Box<...>`
+   ├ note: required for the cast from `Box<Result<_, ()>>` to `Box<_>`
    ├ note: the full name for the type has been written to '$TEST_BUILD_DIR/E0271.long-type-$LONG_TYPE_HASH.txt'
    ╰ note: consider using `--verbose` to print the full type name to the console
 

--- a/tests/ui/diagnostic-width/binop.rs
+++ b/tests/ui/diagnostic-width/binop.rs
@@ -5,11 +5,11 @@ type C = (B, B, B, B);
 type D = (C, C, C, C);
 
 fn foo(x: D) {
-    x + x; //~ ERROR cannot add `(...
+    x + x; //~ ERROR cannot add `((_
 }
 
 fn bar(x: D) {
-    !x; //~ ERROR cannot apply unary operator `!` to type `(...
+    !x; //~ ERROR cannot apply unary operator `!` to type `((_
 }
 
 fn main() {}

--- a/tests/ui/diagnostic-width/binop.stderr
+++ b/tests/ui/diagnostic-width/binop.stderr
@@ -1,15 +1,15 @@
-error[E0369]: cannot add `(..., ..., ..., ...)` to `(..., ..., ..., ...)`
+error[E0369]: cannot add `((_, _, _, _), _, _, _)` to `((_, _, _, _), _, _, _)`
   --> $DIR/binop.rs:8:7
    |
 LL |     x + x;
-   |     - ^ - (..., ..., ..., ...)
+   |     - ^ - ((_, _, _, _), _, _, _)
    |     |
-   |     (..., ..., ..., ...)
+   |     ((_, _, _, _), _, _, _)
    |
    = note: the full name for the type has been written to '$TEST_BUILD_DIR/binop.long-type-$LONG_TYPE_HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
 
-error[E0600]: cannot apply unary operator `!` to type `(..., ..., ..., ...)`
+error[E0600]: cannot apply unary operator `!` to type `((_, _, _, _), _, _, _)`
   --> $DIR/binop.rs:12:5
    |
 LL |     !x;

--- a/tests/ui/diagnostic-width/long-E0308.ascii.stderr
+++ b/tests/ui/diagnostic-width/long-E0308.ascii.stderr
@@ -16,10 +16,10 @@ LL |  |         Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok...
 LL |  |             Ok("")
 LL |  |         ))))))))))))))))))))))))))))))
 LL |  |     ))))))))))))))))))))))))))))));
-   |  |__________________________________^ expected `Atype<Btype<Ctype<..., i32>, i32>, i32>`, found `Result<Result<Result<..., _>, _>, _>`
+   |  |__________________________________^ expected `Atype<Btype<Ctype<_, i32>, i32>, i32>`, found `Result<Result<Result<_, _>, _>, _>`
    |
-   = note: expected struct `Atype<Btype<..., i32>, i32>`
-                found enum `Result<Result<..., _>, _>`
+   = note: expected struct `Atype<Btype<_, i32>, i32>`
+                found enum `Result<Result<_, _>, _>`
    = note: the full name for the type has been written to '$TEST_BUILD_DIR/long-E0308.long-type-$LONG_TYPE_HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
 
@@ -32,10 +32,10 @@ LL | |         Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(...
 LL | |             Ok(Ok(Ok(Ok(Ok(Ok(Ok("")))))))
 LL | |         ))))))))))))))))))))))))))))))
 LL | |     ))))))))))))))))))))))));
-   | |____________________________^ expected `Option<Result<Option<Option<...>>, _>>`, found `Result<Result<Result<..., _>, _>, _>`
+   | |____________________________^ expected `Option<Result<Option<Option<_>>, _>>`, found `Result<Result<Result<_, _>, _>, _>`
    |
-   = note: expected enum `Option<Result<Option<...>, _>>`
-              found enum `Result<Result<..., _>, _>`
+   = note: expected enum `Option<Result<Option<_>, _>>`
+              found enum `Result<Result<_, _>, _>`
    = note: the full name for the type has been written to '$TEST_BUILD_DIR/long-E0308.long-type-$LONG_TYPE_HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
 
@@ -50,11 +50,11 @@ LL | |           Atype<
 ...  |
 LL | |       i32
 LL | |     > = ();
-   | |     -   ^^ expected `Atype<Btype<Ctype<..., i32>, i32>, i32>`, found `()`
+   | |     -   ^^ expected `Atype<Btype<Ctype<_, i32>, i32>, i32>`, found `()`
    | |_____|
    |       expected due to this
    |
-   = note: expected struct `Atype<Btype<..., i32>, i32>`
+   = note: expected struct `Atype<Btype<_, i32>, i32>`
            found unit type `()`
    = note: the full name for the type has been written to '$TEST_BUILD_DIR/long-E0308.long-type-$LONG_TYPE_HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
@@ -70,10 +70,10 @@ LL | |         Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(...
 LL | |             Ok(Ok(Ok(Ok(Ok(Ok(Ok("")))))))
 LL | |         ))))))))))))))))))))))))))))))
 LL | |     ))))))))))))))))))))))));
-   | |____________________________^ expected `()`, found `Result<Result<Result<..., _>, _>, _>`
+   | |____________________________^ expected `()`, found `Result<Result<Result<_, _>, _>, _>`
    |
    = note: expected unit type `()`
-                   found enum `Result<Result<..., _>, _>`
+                   found enum `Result<Result<_, _>, _>`
    = note: the full name for the type has been written to '$TEST_BUILD_DIR/long-E0308.long-type-$LONG_TYPE_HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
 

--- a/tests/ui/diagnostic-width/long-E0308.unicode.stderr
+++ b/tests/ui/diagnostic-width/long-E0308.unicode.stderr
@@ -16,10 +16,10 @@ LL │  ┃         Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(O…
 LL │  ┃             Ok("")
 LL │  ┃         ))))))))))))))))))))))))))))))
 LL │  ┃     ))))))))))))))))))))))))))))));
-   │  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛ expected `Atype<Btype<Ctype<..., i32>, i32>, i32>`, found `Result<Result<Result<..., _>, _>, _>`
+   │  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛ expected `Atype<Btype<Ctype<_, i32>, i32>, i32>`, found `Result<Result<Result<_, _>, _>, _>`
    │
-   ├ note: expected struct `Atype<Btype<..., i32>, i32>`
-   │            found enum `Result<Result<..., _>, _>`
+   ├ note: expected struct `Atype<Btype<_, i32>, i32>`
+   │            found enum `Result<Result<_, _>, _>`
    ├ note: the full name for the type has been written to '$TEST_BUILD_DIR/long-E0308.long-type-$LONG_TYPE_HASH.txt'
    ╰ note: consider using `--verbose` to print the full type name to the console
 
@@ -32,10 +32,10 @@ LL │ ┃         Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok…
 LL │ ┃             Ok(Ok(Ok(Ok(Ok(Ok(Ok("")))))))
 LL │ ┃         ))))))))))))))))))))))))))))))
 LL │ ┃     ))))))))))))))))))))))));
-   │ ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛ expected `Option<Result<Option<Option<...>>, _>>`, found `Result<Result<Result<..., _>, _>, _>`
+   │ ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛ expected `Option<Result<Option<Option<_>>, _>>`, found `Result<Result<Result<_, _>, _>, _>`
    │
-   ├ note: expected enum `Option<Result<Option<...>, _>>`
-   │          found enum `Result<Result<..., _>, _>`
+   ├ note: expected enum `Option<Result<Option<_>, _>>`
+   │          found enum `Result<Result<_, _>, _>`
    ├ note: the full name for the type has been written to '$TEST_BUILD_DIR/long-E0308.long-type-$LONG_TYPE_HASH.txt'
    ╰ note: consider using `--verbose` to print the full type name to the console
 
@@ -50,11 +50,11 @@ LL │ │           Atype<
    ‡ │
 LL │ │       i32
 LL │ │     > = ();
-   │ │     │   ━━ expected `Atype<Btype<Ctype<..., i32>, i32>, i32>`, found `()`
+   │ │     │   ━━ expected `Atype<Btype<Ctype<_, i32>, i32>, i32>`, found `()`
    │ └─────┤
    │       expected due to this
    │
-   ├ note: expected struct `Atype<Btype<..., i32>, i32>`
+   ├ note: expected struct `Atype<Btype<_, i32>, i32>`
    │       found unit type `()`
    ├ note: the full name for the type has been written to '$TEST_BUILD_DIR/long-E0308.long-type-$LONG_TYPE_HASH.txt'
    ╰ note: consider using `--verbose` to print the full type name to the console
@@ -70,10 +70,10 @@ LL │ ┃         Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok(Ok…
 LL │ ┃             Ok(Ok(Ok(Ok(Ok(Ok(Ok("")))))))
 LL │ ┃         ))))))))))))))))))))))))))))))
 LL │ ┃     ))))))))))))))))))))))));
-   │ ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛ expected `()`, found `Result<Result<Result<..., _>, _>, _>`
+   │ ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛ expected `()`, found `Result<Result<Result<_, _>, _>, _>`
    │
    ├ note: expected unit type `()`
-   │               found enum `Result<Result<..., _>, _>`
+   │               found enum `Result<Result<_, _>, _>`
    ├ note: the full name for the type has been written to '$TEST_BUILD_DIR/long-E0308.long-type-$LONG_TYPE_HASH.txt'
    ╰ note: consider using `--verbose` to print the full type name to the console
 

--- a/tests/ui/diagnostic-width/long-E0529.rs
+++ b/tests/ui/diagnostic-width/long-E0529.rs
@@ -7,8 +7,8 @@ type C = (B, B, B, B);
 type D = (C, C, C, C);
 
 fn foo(x: D) {
-    let [] = x; //~ ERROR expected an array or slice, found `(...
-    //~^ NOTE pattern cannot match with input type `(...
+    let [] = x; //~ ERROR expected an array or slice, found `((_
+    //~^ NOTE pattern cannot match with input type `((_
 }
 
 fn main() {}

--- a/tests/ui/diagnostic-width/long-E0529.stderr
+++ b/tests/ui/diagnostic-width/long-E0529.stderr
@@ -1,8 +1,8 @@
-error[E0529]: expected an array or slice, found `(..., ..., ..., ...)`
+error[E0529]: expected an array or slice, found `((_, _, _, _), _, _, _)`
   --> $DIR/long-E0529.rs:10:9
    |
 LL |     let [] = x;
-   |         ^^ pattern cannot match with input type `(..., ..., ..., ...)`
+   |         ^^ pattern cannot match with input type `((_, _, _, _), _, _, _)`
    |
    = note: the full name for the type has been written to '$TEST_BUILD_DIR/long-E0529.long-type-$LONG_TYPE_HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console

--- a/tests/ui/diagnostic-width/long-E0609.rs
+++ b/tests/ui/diagnostic-width/long-E0609.rs
@@ -6,7 +6,7 @@ type C = (B, B, B, B);
 type D = (C, C, C, C);
 
 fn foo(x: D) {
-    x.field; //~ ERROR no field `field` on type `(...
+    x.field; //~ ERROR no field `field` on type `((_
 }
 
 fn main() {}

--- a/tests/ui/diagnostic-width/long-E0609.stderr
+++ b/tests/ui/diagnostic-width/long-E0609.stderr
@@ -1,4 +1,4 @@
-error[E0609]: no field `field` on type `(..., ..., ..., ...)`
+error[E0609]: no field `field` on type `((_, _, _, _), _, _, _)`
   --> $DIR/long-E0609.rs:9:7
    |
 LL |     x.field;

--- a/tests/ui/diagnostic-width/long-E0614.rs
+++ b/tests/ui/diagnostic-width/long-E0614.rs
@@ -6,7 +6,7 @@ type C = (B, B, B, B);
 type D = (C, C, C, C);
 
 fn foo(x: D) {
-    *x; //~ ERROR type `(...
+    *x; //~ ERROR type `((_
 }
 
 fn main() {}

--- a/tests/ui/diagnostic-width/long-E0614.stderr
+++ b/tests/ui/diagnostic-width/long-E0614.stderr
@@ -1,4 +1,4 @@
-error[E0614]: type `(..., ..., ..., ...)` cannot be dereferenced
+error[E0614]: type `((_, _, _, _), _, _, _)` cannot be dereferenced
   --> $DIR/long-E0614.rs:9:5
    |
 LL |     *x;

--- a/tests/ui/diagnostic-width/long-E0618.rs
+++ b/tests/ui/diagnostic-width/long-E0618.rs
@@ -6,8 +6,8 @@ type B = (A, A, A, A);
 type C = (B, B, B, B);
 type D = (C, C, C, C);
 
-fn foo(x: D) { //~ NOTE `x` has type `(...
-    x(); //~ ERROR expected function, found `(...
+fn foo(x: D) { //~ NOTE `x` has type `((_
+    x(); //~ ERROR expected function, found `((_
 }
 
 fn main() {}

--- a/tests/ui/diagnostic-width/long-E0618.stderr
+++ b/tests/ui/diagnostic-width/long-E0618.stderr
@@ -1,8 +1,8 @@
-error[E0618]: expected function, found `(..., ..., ..., ...)`
+error[E0618]: expected function, found `((_, _, _, _), _, _, _)`
   --> $DIR/long-E0618.rs:10:5
    |
 LL | fn foo(x: D) {
-   |        - `x` has type `(..., ..., ..., ...)`
+   |        - `x` has type `((_, _, _, _), _, _, _)`
 LL |     x();
    |     ^--
    |     |

--- a/tests/ui/diagnostic-width/long-e0277.rs
+++ b/tests/ui/diagnostic-width/long-e0277.rs
@@ -9,5 +9,5 @@ trait Trait {}
 fn require_trait<T: Trait>() {}
 
 fn main() {
-    require_trait::<D>(); //~ ERROR the trait bound `(...
+    require_trait::<D>(); //~ ERROR the trait bound `((_
 }

--- a/tests/ui/diagnostic-width/long-e0277.stderr
+++ b/tests/ui/diagnostic-width/long-e0277.stderr
@@ -1,10 +1,10 @@
-error[E0277]: the trait bound `(..., ..., ..., ...): Trait` is not satisfied
+error[E0277]: the trait bound `((_, _, _, _), _, _, _): Trait` is not satisfied
   --> $DIR/long-e0277.rs:12:21
    |
 LL |     require_trait::<D>();
    |                     ^ unsatisfied trait bound
    |
-   = help: the trait `Trait` is not implemented for `(..., ..., ..., ...)`
+   = help: the trait `Trait` is not implemented for `((_, _, _, _), _, _, _)`
 help: this trait has no implementations, consider adding one
   --> $DIR/long-e0277.rs:7:1
    |

--- a/tests/ui/diagnostic-width/non-copy-type-moved.stderr
+++ b/tests/ui/diagnostic-width/non-copy-type-moved.stderr
@@ -2,7 +2,7 @@ error[E0382]: use of moved value: `x`
   --> $DIR/non-copy-type-moved.rs:14:14
    |
 LL | fn foo(x: D) {
-   |        - move occurs because `x` has type `(..., ..., ..., ...)`, which does not implement the `Copy` trait
+   |        - move occurs because `x` has type `((_, _, _, _), _, _, _)`, which does not implement the `Copy` trait
 LL |     let _a = x;
    |              - value moved here
 LL |     let _b = x;

--- a/tests/ui/diagnostic-width/secondary-label-with-long-type.rs
+++ b/tests/ui/diagnostic-width/secondary-label-with-long-type.rs
@@ -7,8 +7,8 @@ type D = (C, C, C, C);
 
 fn foo(x: D) {
     let () = x; //~ ERROR mismatched types
-    //~^ NOTE this expression has type `((...,
-    //~| NOTE expected `((...,
+    //~^ NOTE this expression has type `(((_,
+    //~| NOTE expected `(((_,
     //~| NOTE expected tuple
     //~| NOTE the full name for the type has been written to
     //~| NOTE consider using `--verbose` to print the full type name to the console

--- a/tests/ui/diagnostic-width/secondary-label-with-long-type.stderr
+++ b/tests/ui/diagnostic-width/secondary-label-with-long-type.stderr
@@ -2,11 +2,11 @@ error[E0308]: mismatched types
   --> $DIR/secondary-label-with-long-type.rs:9:9
    |
 LL |     let () = x;
-   |         ^^   - this expression has type `((..., ..., ..., ...), ..., ..., ...)`
+   |         ^^   - this expression has type `(((_, _, _, _), _, _, _), _, _, _)`
    |         |
-   |         expected `((..., ..., ..., ...), ..., ..., ...)`, found `()`
+   |         expected `(((_, _, _, _), _, _, _), _, _, _)`, found `()`
    |
-   = note:  expected tuple `((..., ..., ..., ...), ..., ..., ...)`
+   = note:  expected tuple `(((_, _, _, _), _, _, _), _, _, _)`
            found unit type `()`
    = note: the full name for the type has been written to '$TEST_BUILD_DIR/secondary-label-with-long-type.long-type-$LONG_TYPE_HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console

--- a/tests/ui/dropck/dropck_no_diverge_on_nonregular_1.stderr
+++ b/tests/ui/dropck/dropck_no_diverge_on_nonregular_1.stderr
@@ -4,7 +4,7 @@ error[E0320]: overflow while adding drop-check rules for `FingerTree<i32>`
 LL |     let ft =
    |         ^^
    |
-   = note: overflowed on `FingerTree<Node<Node<Node<Node<Node<Node<Node<Node<Node<...>>>>>>>>>>`
+   = note: overflowed on `FingerTree<Node<Node<Node<Node<Node<Node<Node<Node<Node<_>>>>>>>>>>`
    = note: the full name for the type has been written to '$TEST_BUILD_DIR/dropck_no_diverge_on_nonregular_1.long-type-$LONG_TYPE_HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
 

--- a/tests/ui/error-codes/E0275.stderr
+++ b/tests/ui/error-codes/E0275.stderr
@@ -1,11 +1,11 @@
-error[E0275]: overflow evaluating the requirement `Bar<Bar<Bar<Bar<Bar<Bar<Bar<...>>>>>>>: Foo`
+error[E0275]: overflow evaluating the requirement `Bar<Bar<Bar<Bar<Bar<Bar<Bar<_>>>>>>>: Foo`
   --> $DIR/E0275.rs:6:33
    |
 LL | impl<T> Foo for T where Bar<T>: Foo {}
    |                                 ^^^
    |
    = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`E0275`)
-note: required for `Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<...>>>>>>>>>>>>>` to implement `Foo`
+note: required for `Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<_>>>>>>>>>>>>>` to implement `Foo`
   --> $DIR/E0275.rs:6:9
    |
 LL | impl<T> Foo for T where Bar<T>: Foo {}

--- a/tests/ui/higher-ranked/relate-bound-region-ice-144033.rs
+++ b/tests/ui/higher-ranked/relate-bound-region-ice-144033.rs
@@ -1,0 +1,33 @@
+// Regression test for <https://github.com/rust-lang/rust/issues/144033>.
+// A delegating impl whose method drops the trait's HRTB where-clause used to
+// ICE with "cannot relate bound region" instead of emitting normal errors.
+
+trait FooMut {
+    type Baz: 'static;
+    fn bar<'a, I>(self, iterator: &'a I)
+    where
+        for<'b> &'b I: IntoIterator<Item = &'b &'a Self::Baz>;
+}
+struct DelegatingFooMut<T> {}
+//~^ ERROR type parameter `T` is never used
+
+impl<T> FooMut for DelegatingFooMut<T>
+where
+    T: FooMut,
+{
+    type Baz = DelegatingBaz<T::Baz>;
+    fn bar<'a, I>(self, collection: &'a I)
+    //~^ ERROR lifetime parameters do not match the trait definition
+    where
+        for<'b> &'b I: IntoIterator,
+    {
+        let collection = collection.into_iter().map(|b| &b);
+        self.bar(collection)
+        //~^ ERROR type mismatch resolving
+        //~| ERROR mismatched types
+    }
+}
+struct DelegatingBaz<T>;
+//~^ ERROR type parameter `T` is never used
+
+fn main() {}

--- a/tests/ui/higher-ranked/relate-bound-region-ice-144033.rs
+++ b/tests/ui/higher-ranked/relate-bound-region-ice-144033.rs
@@ -1,33 +1,23 @@
 // Regression test for <https://github.com/rust-lang/rust/issues/144033>.
-// A delegating impl whose method drops the trait's HRTB where-clause used to
-// ICE with "cannot relate bound region" instead of emitting normal errors.
+// This used to ICE with "cannot relate bound region" instead of emitting
+// normal errors.
 
 trait FooMut {
-    type Baz: 'static;
-    fn bar<'a, I>(self, iterator: &'a I)
+    fn bar<I>(self, _: I)
     where
-        for<'b> &'b I: IntoIterator<Item = &'b &'a Self::Baz>;
+        for<'b> &'b I: Iterator<Item = &'b ()>;
 }
-struct DelegatingFooMut<T> {}
-//~^ ERROR type parameter `T` is never used
 
-impl<T> FooMut for DelegatingFooMut<T>
-where
-    T: FooMut,
-{
-    type Baz = DelegatingBaz<T::Baz>;
-    fn bar<'a, I>(self, collection: &'a I)
-    //~^ ERROR lifetime parameters do not match the trait definition
+impl FooMut for () {
+    fn bar<I>(self, _: I)
     where
-        for<'b> &'b I: IntoIterator,
+        for<'b> &'b I: Iterator,
     {
-        let collection = collection.into_iter().map(|b| &b);
+        let collection = std::iter::empty::<()>().map(|_| &());
         self.bar(collection)
-        //~^ ERROR type mismatch resolving
+        //~^ ERROR expected `&I` to be an iterator that yields `&()`
         //~| ERROR mismatched types
     }
 }
-struct DelegatingBaz<T>;
-//~^ ERROR type parameter `T` is never used
 
 fn main() {}

--- a/tests/ui/higher-ranked/relate-bound-region-ice-144033.stderr
+++ b/tests/ui/higher-ranked/relate-bound-region-ice-144033.stderr
@@ -1,0 +1,98 @@
+error[E0392]: type parameter `T` is never used
+  --> $DIR/relate-bound-region-ice-144033.rs:11:25
+   |
+LL | struct DelegatingFooMut<T> {}
+   |                         ^ unused type parameter
+   |
+   = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
+   = help: if you intended `T` to be a const parameter, use `const T: /* Type */` instead
+
+error[E0195]: lifetime parameters do not match the trait definition
+  --> $DIR/relate-bound-region-ice-144033.rs:19:12
+   |
+LL |     fn bar<'a, I>(self, collection: &'a I)
+   |            ^^
+   |
+   = note: lifetime parameters differ in whether they are early- or late-bound
+note: `'a` differs between the trait and impl
+  --> $DIR/relate-bound-region-ice-144033.rs:7:12
+   |
+LL |   trait FooMut {
+   |   ------------ in this trait...
+LL |       type Baz: 'static;
+LL |       fn bar<'a, I>(self, iterator: &'a I)
+   |              ^^ `'a` is early-bound
+LL |       where
+LL |           for<'b> &'b I: IntoIterator<Item = &'b &'a Self::Baz>;
+   |                                       ------------------------ this lifetime bound makes `'a` early-bound
+...
+LL | / impl<T> FooMut for DelegatingFooMut<T>
+LL | | where
+LL | |     T: FooMut,
+   | |______________- in this impl...
+...
+LL |       fn bar<'a, I>(self, collection: &'a I)
+   |              ^^ `'a` is late-bound
+
+error[E0392]: type parameter `T` is never used
+  --> $DIR/relate-bound-region-ice-144033.rs:30:22
+   |
+LL | struct DelegatingBaz<T>;
+   |                      ^ unused type parameter
+   |
+   = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
+   = help: if you intended `T` to be a const parameter, use `const T: /* Type */` instead
+
+error[E0271]: type mismatch resolving `<&I as IntoIterator>::Item == &&DelegatingBaz<<T as FooMut>::Baz>`
+  --> $DIR/relate-bound-region-ice-144033.rs:25:18
+   |
+LL |         self.bar(collection)
+   |              --- ^^^^^^^^^^ expected `&&DelegatingBaz<<T as FooMut>::Baz>`, found associated type
+   |              |
+   |              required by a bound introduced by this call
+   |
+   = note:    expected reference `&&DelegatingBaz<<T as FooMut>::Baz>`
+           found associated type `<&I as IntoIterator>::Item`
+   = help: consider constraining the associated type `<&I as IntoIterator>::Item` to `&&DelegatingBaz<<T as FooMut>::Baz>`
+   = note: for more information, visit https://doc.rust-lang.org/book/ch19-03-advanced-traits.html
+note: the method call chain might not have had the expected associated types
+  --> $DIR/relate-bound-region-ice-144033.rs:19:37
+   |
+LL |     fn bar<'a, I>(self, collection: &'a I)
+   |                                     ^^^^^ `IntoIterator::Item` is `<&I as IntoIterator>::Item` here
+...
+LL |         let collection = collection.into_iter().map(|b| &b);
+   |                                     ----------- ----------- `IntoIterator::Item` changed to `&<&I as IntoIterator>::Item` here
+   |                                     |
+   |                                     `IntoIterator::Item` remains `<&I as IntoIterator>::Item` here
+note: required by a bound in `FooMut::bar`
+  --> $DIR/relate-bound-region-ice-144033.rs:9:37
+   |
+LL |     fn bar<'a, I>(self, iterator: &'a I)
+   |        --- required by a bound in this associated function
+LL |     where
+LL |         for<'b> &'b I: IntoIterator<Item = &'b &'a Self::Baz>;
+   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `FooMut::bar`
+
+error[E0308]: mismatched types
+  --> $DIR/relate-bound-region-ice-144033.rs:25:18
+   |
+LL |         let collection = collection.into_iter().map(|b| &b);
+   |                                                     --- the found closure
+LL |         self.bar(collection)
+   |              --- ^^^^^^^^^^ expected `&I`, found `Map<<&I as IntoIterator>::IntoIter, ...>`
+   |              |
+   |              arguments to this method are incorrect
+   |
+   = note: expected reference `&I`
+                 found struct `Map<<&I as IntoIterator>::IntoIter, {closure@$DIR/relate-bound-region-ice-144033.rs:24:53: 24:56}>`
+note: method defined here
+  --> $DIR/relate-bound-region-ice-144033.rs:7:8
+   |
+LL |     fn bar<'a, I>(self, iterator: &'a I)
+   |        ^^^              --------
+
+error: aborting due to 5 previous errors
+
+Some errors have detailed explanations: E0195, E0271, E0308, E0392.
+For more information about an error, try `rustc --explain E0195`.

--- a/tests/ui/higher-ranked/relate-bound-region-ice-144033.stderr
+++ b/tests/ui/higher-ranked/relate-bound-region-ice-144033.stderr
@@ -1,98 +1,53 @@
-error[E0392]: type parameter `T` is never used
-  --> $DIR/relate-bound-region-ice-144033.rs:11:25
-   |
-LL | struct DelegatingFooMut<T> {}
-   |                         ^ unused type parameter
-   |
-   = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
-   = help: if you intended `T` to be a const parameter, use `const T: /* Type */` instead
-
-error[E0195]: lifetime parameters do not match the trait definition
-  --> $DIR/relate-bound-region-ice-144033.rs:19:12
-   |
-LL |     fn bar<'a, I>(self, collection: &'a I)
-   |            ^^
-   |
-   = note: lifetime parameters differ in whether they are early- or late-bound
-note: `'a` differs between the trait and impl
-  --> $DIR/relate-bound-region-ice-144033.rs:7:12
-   |
-LL |   trait FooMut {
-   |   ------------ in this trait...
-LL |       type Baz: 'static;
-LL |       fn bar<'a, I>(self, iterator: &'a I)
-   |              ^^ `'a` is early-bound
-LL |       where
-LL |           for<'b> &'b I: IntoIterator<Item = &'b &'a Self::Baz>;
-   |                                       ------------------------ this lifetime bound makes `'a` early-bound
-...
-LL | / impl<T> FooMut for DelegatingFooMut<T>
-LL | | where
-LL | |     T: FooMut,
-   | |______________- in this impl...
-...
-LL |       fn bar<'a, I>(self, collection: &'a I)
-   |              ^^ `'a` is late-bound
-
-error[E0392]: type parameter `T` is never used
-  --> $DIR/relate-bound-region-ice-144033.rs:30:22
-   |
-LL | struct DelegatingBaz<T>;
-   |                      ^ unused type parameter
-   |
-   = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
-   = help: if you intended `T` to be a const parameter, use `const T: /* Type */` instead
-
-error[E0271]: type mismatch resolving `<&I as IntoIterator>::Item == &&DelegatingBaz<<T as FooMut>::Baz>`
-  --> $DIR/relate-bound-region-ice-144033.rs:25:18
+error[E0271]: expected `&I` to be an iterator that yields `&()`, but it yields `<&I as Iterator>::Item`
+  --> $DIR/relate-bound-region-ice-144033.rs:17:18
    |
 LL |         self.bar(collection)
-   |              --- ^^^^^^^^^^ expected `&&DelegatingBaz<<T as FooMut>::Baz>`, found associated type
+   |              --- ^^^^^^^^^^ expected `&()`, found associated type
    |              |
    |              required by a bound introduced by this call
    |
-   = note:    expected reference `&&DelegatingBaz<<T as FooMut>::Baz>`
-           found associated type `<&I as IntoIterator>::Item`
-   = help: consider constraining the associated type `<&I as IntoIterator>::Item` to `&&DelegatingBaz<<T as FooMut>::Baz>`
+   = note:    expected reference `&()`
+           found associated type `<&I as Iterator>::Item`
+   = help: consider constraining the associated type `<&I as Iterator>::Item` to `&()`
    = note: for more information, visit https://doc.rust-lang.org/book/ch19-03-advanced-traits.html
 note: the method call chain might not have had the expected associated types
-  --> $DIR/relate-bound-region-ice-144033.rs:19:37
+  --> $DIR/relate-bound-region-ice-144033.rs:16:51
    |
-LL |     fn bar<'a, I>(self, collection: &'a I)
-   |                                     ^^^^^ `IntoIterator::Item` is `<&I as IntoIterator>::Item` here
-...
-LL |         let collection = collection.into_iter().map(|b| &b);
-   |                                     ----------- ----------- `IntoIterator::Item` changed to `&<&I as IntoIterator>::Item` here
-   |                                     |
-   |                                     `IntoIterator::Item` remains `<&I as IntoIterator>::Item` here
+LL |         let collection = std::iter::empty::<()>().map(|_| &());
+   |                          ------------------------ ^^^^^^^^^^^^ `Iterator::Item` is `&()` here
+   |                          |
+   |                          this expression has type `Empty<()>`
 note: required by a bound in `FooMut::bar`
-  --> $DIR/relate-bound-region-ice-144033.rs:9:37
+  --> $DIR/relate-bound-region-ice-144033.rs:8:33
    |
-LL |     fn bar<'a, I>(self, iterator: &'a I)
+LL |     fn bar<I>(self, _: I)
    |        --- required by a bound in this associated function
 LL |     where
-LL |         for<'b> &'b I: IntoIterator<Item = &'b &'a Self::Baz>;
-   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `FooMut::bar`
+LL |         for<'b> &'b I: Iterator<Item = &'b ()>;
+   |                                 ^^^^^^^^^^^^^ required by this bound in `FooMut::bar`
 
 error[E0308]: mismatched types
-  --> $DIR/relate-bound-region-ice-144033.rs:25:18
+  --> $DIR/relate-bound-region-ice-144033.rs:17:18
    |
-LL |         let collection = collection.into_iter().map(|b| &b);
-   |                                                     --- the found closure
+LL |     fn bar<I>(self, _: I)
+   |            - expected this type parameter
+...
+LL |         let collection = std::iter::empty::<()>().map(|_| &());
+   |                                                       --- the found closure
 LL |         self.bar(collection)
-   |              --- ^^^^^^^^^^ expected `&I`, found `Map<<&I as IntoIterator>::IntoIter, ...>`
+   |              --- ^^^^^^^^^^ expected type parameter `I`, found `Map<Empty<()>, {closure@...}>`
    |              |
    |              arguments to this method are incorrect
    |
-   = note: expected reference `&I`
-                 found struct `Map<<&I as IntoIterator>::IntoIter, {closure@$DIR/relate-bound-region-ice-144033.rs:24:53: 24:56}>`
+   = note: expected type parameter `I`
+                      found struct `Map<std::iter::Empty<()>, {closure@$DIR/relate-bound-region-ice-144033.rs:16:55: 16:58}>`
 note: method defined here
-  --> $DIR/relate-bound-region-ice-144033.rs:7:8
+  --> $DIR/relate-bound-region-ice-144033.rs:6:8
    |
-LL |     fn bar<'a, I>(self, iterator: &'a I)
-   |        ^^^              --------
+LL |     fn bar<I>(self, _: I)
+   |        ^^^          -
 
-error: aborting due to 5 previous errors
+error: aborting due to 2 previous errors
 
-Some errors have detailed explanations: E0195, E0271, E0308, E0392.
-For more information about an error, try `rustc --explain E0195`.
+Some errors have detailed explanations: E0271, E0308.
+For more information about an error, try `rustc --explain E0271`.

--- a/tests/ui/higher-ranked/trait-bounds/hang-on-deeply-nested-dyn.stderr
+++ b/tests/ui/higher-ranked/trait-bounds/hang-on-deeply-nested-dyn.stderr
@@ -11,7 +11,7 @@ LL | |     ),
 LL | | ) {
    | |_- expected `&dyn for<'a> Fn(&'a (dyn for<'a> Fn(&'a (dyn for<'a> Fn(&'a (dyn for<'a> Fn(&'a (dyn for<'a> Fn(&'a (dyn for<'a> Fn(&'a (dyn for<'a> Fn(&'a (dyn for<'a> Fn(&'a (dyn for<'a> Fn(&'a (dyn for<'a> Fn(&'a (dyn for<'a> Fn(&'a (dyn Fn(u32) + 'a)) + 'a)) + 'a)) + 'a)) + 'a)) + 'a)) + 'a)) + 'a)) + 'a)) + 'a)) + 'a))` because of return type
 LL |       f
-   |       ^ expected `&dyn Fn(&dyn Fn(&dyn Fn(&dyn Fn(&...))))`, found `&dyn Fn(u32)`
+   |       ^ expected `&dyn Fn(&dyn Fn(&dyn Fn(&dyn Fn(&_))))`, found `&dyn Fn(u32)`
    |
    = note: expected reference `&dyn for<'a> Fn(&'a (dyn for<'a> Fn(&'a (dyn for<'a> Fn(&'a (dyn for<'a> Fn(&'a (dyn for<'a> Fn(&'a (dyn for<'a> Fn(&'a (dyn for<'a> Fn(&'a (dyn for<'a> Fn(&'a (dyn for<'a> Fn(&'a (dyn for<'a> Fn(&'a (dyn for<'a> Fn(&'a (dyn Fn(u32) + 'a)) + 'a)) + 'a)) + 'a)) + 'a)) + 'a)) + 'a)) + 'a)) + 'a)) + 'a)) + 'a))`
               found reference `&dyn Fn(u32)`

--- a/tests/ui/inference/really-long-type-in-let-binding-without-sufficient-type-info.stderr
+++ b/tests/ui/inference/really-long-type-in-let-binding-without-sufficient-type-info.stderr
@@ -1,4 +1,4 @@
-error[E0282]: type annotations needed for `Result<_, (((..., ..., ..., ...), ..., ..., ...), ..., ..., ...)>`
+error[E0282]: type annotations needed for `Result<_, ((((i32, i32, i32, i32), _, _, _), _, _, _), _, _, _)>`
   --> $DIR/really-long-type-in-let-binding-without-sufficient-type-info.rs:8:9
    |
 LL |     let y = Err(x);

--- a/tests/ui/infinite/infinite-instantiation-struct-tail-ice-114484.rs
+++ b/tests/ui/infinite/infinite-instantiation-struct-tail-ice-114484.rs
@@ -10,7 +10,7 @@
 //~| ERROR reached the recursion limit finding the struct tail for `VirtualWrapper<SomeData<256>, 0>`
 //~| ERROR reached the recursion limit finding the struct tail for `VirtualWrapper<SomeData<256>, 0>`
 //~| ERROR reached the recursion limit finding the struct tail for `VirtualWrapper<SomeData<256>, 0>`
-//~| ERROR reached the recursion limit while instantiating `<VirtualWrapper<..., 1> as MyTrait>::virtualize`
+//~| ERROR reached the recursion limit while instantiating `<VirtualWrapper<_, 1> as MyTrait>::virtualize`
 
 //@ build-fail
 //@ compile-flags: --diagnostic-width=100 -Zwrite-long-types-to-disk=yes

--- a/tests/ui/infinite/infinite-instantiation-struct-tail-ice-114484.stderr
+++ b/tests/ui/infinite/infinite-instantiation-struct-tail-ice-114484.stderr
@@ -17,7 +17,7 @@ error: reached the recursion limit finding the struct tail for `[u8; 256]`
    = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]`
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-note: the above error was encountered while instantiating `fn virtualize_my_trait::<VirtualWrapper<..., 1>>`
+note: the above error was encountered while instantiating `fn virtualize_my_trait::<VirtualWrapper<_, 1>>`
   --> $DIR/infinite-instantiation-struct-tail-ice-114484.rs:38:18
    |
 LL |         unsafe { virtualize_my_trait(L, self) }
@@ -45,7 +45,7 @@ error: reached the recursion limit finding the struct tail for `SomeData<256>`
    = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]`
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-note: the above error was encountered while instantiating `fn virtualize_my_trait::<VirtualWrapper<..., 1>>`
+note: the above error was encountered while instantiating `fn virtualize_my_trait::<VirtualWrapper<_, 1>>`
   --> $DIR/infinite-instantiation-struct-tail-ice-114484.rs:38:18
    |
 LL |         unsafe { virtualize_my_trait(L, self) }
@@ -73,7 +73,7 @@ error: reached the recursion limit finding the struct tail for `VirtualWrapper<S
    = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]`
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-note: the above error was encountered while instantiating `fn virtualize_my_trait::<VirtualWrapper<..., 1>>`
+note: the above error was encountered while instantiating `fn virtualize_my_trait::<VirtualWrapper<_, 1>>`
   --> $DIR/infinite-instantiation-struct-tail-ice-114484.rs:38:18
    |
 LL |         unsafe { virtualize_my_trait(L, self) }
@@ -82,7 +82,7 @@ LL |         unsafe { virtualize_my_trait(L, self) }
    = note: the full name for the type has been written to '$TEST_BUILD_DIR/infinite-instantiation-struct-tail-ice-114484.long-type-$LONG_TYPE_HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
 
-error: reached the recursion limit while instantiating `<VirtualWrapper<..., 1> as MyTrait>::virtualize`
+error: reached the recursion limit while instantiating `<VirtualWrapper<_, 1> as MyTrait>::virtualize`
    |
 note: `<VirtualWrapper<T, L> as MyTrait>::virtualize` defined here
   --> $DIR/infinite-instantiation-struct-tail-ice-114484.rs:37:5

--- a/tests/ui/infinite/infinite-instantiation.stderr
+++ b/tests/ui/infinite/infinite-instantiation.stderr
@@ -1,4 +1,4 @@
-error: reached the recursion limit while instantiating `function::<Option<Option<Option<Option<...>>>>>`
+error: reached the recursion limit while instantiating `function::<Option<Option<Option<Option<_>>>>>`
   --> $DIR/infinite-instantiation.rs:22:9
    |
 LL |         function(counter - 1, t.to_option());

--- a/tests/ui/issues/issue-37311-type-length-limit/issue-37311.stderr
+++ b/tests/ui/issues/issue-37311-type-length-limit/issue-37311.stderr
@@ -1,4 +1,4 @@
-error: reached the recursion limit while instantiating `<(&(&(&..., ...), ...), ...) as Foo>::recurse`
+error: reached the recursion limit while instantiating `<(&(&(&(&(&_, _), _), _), _), _) as Foo>::recurse`
   --> $DIR/issue-37311.rs:17:9
    |
 LL |         (self, self).recurse();

--- a/tests/ui/lazy-type-alias/inherent-impls-overflow.current.stderr
+++ b/tests/ui/lazy-type-alias/inherent-impls-overflow.current.stderr
@@ -14,7 +14,7 @@ LL | impl Loop {}
    |
    = note: in case this is a recursive type alias, consider using a struct, enum, or union instead
 
-error[E0275]: overflow normalizing the type alias `Poly0<(((((((...,),),),),),),)>`
+error[E0275]: overflow normalizing the type alias `Poly0<(((((((_,),),),),),),)>`
   --> $DIR/inherent-impls-overflow.rs:17:1
    |
 LL | type Poly0<T> = Poly1<(T,)>;
@@ -22,7 +22,7 @@ LL | type Poly0<T> = Poly1<(T,)>;
    |
    = note: in case this is a recursive type alias, consider using a struct, enum, or union instead
 
-error[E0275]: overflow normalizing the type alias `Poly1<(((((((...,),),),),),),)>`
+error[E0275]: overflow normalizing the type alias `Poly1<(((((((_,),),),),),),)>`
   --> $DIR/inherent-impls-overflow.rs:20:1
    |
 LL | type Poly1<T> = Poly0<(T,)>;
@@ -30,7 +30,7 @@ LL | type Poly1<T> = Poly0<(T,)>;
    |
    = note: in case this is a recursive type alias, consider using a struct, enum, or union instead
 
-error[E0275]: overflow normalizing the type alias `Poly1<(((((((...,),),),),),),)>`
+error[E0275]: overflow normalizing the type alias `Poly1<(((((((_,),),),),),),)>`
   --> $DIR/inherent-impls-overflow.rs:24:1
    |
 LL | impl Poly0<()> {}

--- a/tests/ui/lazy-type-alias/inherent-impls-overflow.rs
+++ b/tests/ui/lazy-type-alias/inherent-impls-overflow.rs
@@ -15,14 +15,14 @@ impl Loop {}
 //[next]~| ERROR overflow evaluating the requirement `Loop == _`
 
 type Poly0<T> = Poly1<(T,)>;
-//[current]~^ ERROR overflow normalizing the type alias `Poly0<(((((((...,),),),),),),)>`
+//[current]~^ ERROR overflow normalizing the type alias `Poly0<(((((((_,),),),),),),)>`
 //[next]~^^ ERROR overflow evaluating the requirement
 type Poly1<T> = Poly0<(T,)>;
-//[current]~^ ERROR  overflow normalizing the type alias `Poly1<(((((((...,),),),),),),)>`
+//[current]~^ ERROR  overflow normalizing the type alias `Poly1<(((((((_,),),),),),),)>`
 //[next]~^^ ERROR overflow evaluating the requirement
 
 impl Poly0<()> {}
-//[current]~^ ERROR overflow normalizing the type alias `Poly1<(((((((...,),),),),),),)>`
+//[current]~^ ERROR overflow normalizing the type alias `Poly1<(((((((_,),),),),),),)>`
 //[next]~^^ ERROR overflow evaluating the requirement `Poly0<()> == _`
 //[next]~| ERROR overflow evaluating the requirement
 

--- a/tests/ui/limits/type-length-limit-enforcement.stderr
+++ b/tests/ui/limits/type-length-limit-enforcement.stderr
@@ -1,4 +1,4 @@
-error: reached the type-length limit while instantiating `drop::<Option<((..., ..., ...), ..., ...)>>`
+error: reached the type-length limit while instantiating `drop::<Option<((((_, _, _), _, _), _, _), _, _)>>`
   --> $DIR/type-length-limit-enforcement.rs:34:5
    |
 LL |     drop::<Option<A>>(None);

--- a/tests/ui/methods/inherent-bound-in-probe.stderr
+++ b/tests/ui/methods/inherent-bound-in-probe.stderr
@@ -28,7 +28,7 @@ LL | where
 LL |     &'a T: IntoIterator<Item = &'a u8>,
    |                         ------------- unsatisfied trait bound introduced here
    = note: 126 redundant requirements hidden
-   = note: required for `&BitReaderWrapper<BitReaderWrapper<BitReaderWrapper<...>>>` to implement `IntoIterator`
+   = note: required for `&BitReaderWrapper<BitReaderWrapper<BitReaderWrapper<_>>>` to implement `IntoIterator`
 note: required by a bound in `Helper`
   --> $DIR/inherent-bound-in-probe.rs:17:12
    |

--- a/tests/ui/methods/probe-error-on-infinite-deref.stderr
+++ b/tests/ui/methods/probe-error-on-infinite-deref.stderr
@@ -1,4 +1,4 @@
-error[E0055]: reached the recursion limit while auto-dereferencing `Wrap<Wrap<Wrap<Wrap<Wrap<Wrap<Wrap<Wrap<Wrap<Wrap<Wrap<...>>>>>>>>>>>`
+error[E0055]: reached the recursion limit while auto-dereferencing `Wrap<Wrap<Wrap<Wrap<Wrap<Wrap<Wrap<Wrap<Wrap<Wrap<Wrap<_>>>>>>>>>>>`
   --> $DIR/probe-error-on-infinite-deref.rs:14:13
    |
 LL |     Wrap(1).lmao();

--- a/tests/ui/mismatched_types/mismatch-sugg-for-shorthand-field.stderr
+++ b/tests/ui/mismatched_types/mismatch-sugg-for-shorthand-field.stderr
@@ -55,7 +55,7 @@ LL |     let a = async { 42 };
    |             ----- the found `async` block
 ...
 LL |     let s = Demo { a };
-   |                    ^ expected `Pin<Box<...>>`, found `async` block
+   |                    ^ expected `Pin<Box<_>>`, found `async` block
    |
    = note:     expected struct `Pin<Box<(dyn Future<Output = i32> + Send + 'static)>>`
            found `async` block `{async block@$DIR/mismatch-sugg-for-shorthand-field.rs:53:13: 53:18}`

--- a/tests/ui/parallel-rustc/dyn-trait-ice-153366.stderr
+++ b/tests/ui/parallel-rustc/dyn-trait-ice-153366.stderr
@@ -52,7 +52,7 @@ LL | fn iso<A>(a: Fn) -> Option<_>
    |                     --------- expected `Option<_>` because of return type
 ...
 LL |     Box::new(iso_un_option)
-   |     ^^^^^^^^^^^^^^^^^^^^^^^ expected `Option<_>`, found `Box<fn() -> ... {iso_un_option::<_>}>`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^ expected `Option<_>`, found `Box<fn() -> _ {iso_un_option::<_>}>`
    |
    = note: expected enum `Option<_>`
             found struct `Box<fn() -> {type error} {iso_un_option::<_>}>`

--- a/tests/ui/proc-macro/test-followed-by-attr-macros.rs
+++ b/tests/ui/proc-macro/test-followed-by-attr-macros.rs
@@ -1,0 +1,26 @@
+//@ check-pass
+//@ compile-flags: --test
+//@ proc-macro: test-macros.rs
+//@ edition: 2024
+
+#![feature(macro_attr)]
+
+extern crate test_macros;
+
+fn main() {}
+
+mod proc_macro_attr {
+    #[test]
+    #[test_macros::identity_attr]
+    fn test() {}
+}
+
+mod macro_rules_attr {
+    macro_rules! repro {
+        attr() { $($tt:tt)* } => { $($tt)* }
+    }
+
+    #[test]
+    #[repro]
+    fn test() {}
+}

--- a/tests/ui/recursion/infinite-function-recursion-error-8727.stderr
+++ b/tests/ui/recursion/infinite-function-recursion-error-8727.stderr
@@ -9,7 +9,7 @@ LL |     generic::<Option<T>>();
    = help: a `loop` may express intention better if this is on purpose
    = note: `#[warn(unconditional_recursion)]` on by default
 
-error: reached the recursion limit while instantiating `generic::<Option<Option<Option<Option<...>>>>>`
+error: reached the recursion limit while instantiating `generic::<Option<Option<Option<Option<_>>>>>`
   --> $DIR/infinite-function-recursion-error-8727.rs:9:5
    |
 LL |     generic::<Option<T>>();

--- a/tests/ui/recursion/issue-23122-2.stderr
+++ b/tests/ui/recursion/issue-23122-2.stderr
@@ -1,11 +1,11 @@
-error[E0275]: overflow evaluating the requirement `<<<<<<<... as Next>::Next as Next>::Next as Next>::Next as Next>::Next as Next>::Next as Next>::Next as Next>::Next: Sized`
+error[E0275]: overflow evaluating the requirement `<<<<<<<_ as Next>::Next as Next>::Next as Next>::Next as Next>::Next as Next>::Next as Next>::Next as Next>::Next: Sized`
   --> $DIR/issue-23122-2.rs:11:17
    |
 LL |     type Next = <GetNext<T::Next> as Next>::Next;
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`issue_23122_2`)
-note: required for `GetNext<<<<... as Next>::Next as Next>::Next as Next>::Next>` to implement `Next`
+note: required for `GetNext<<<<_ as Next>::Next as Next>::Next as Next>::Next>` to implement `Next`
   --> $DIR/issue-23122-2.rs:10:15
    |
 LL | impl<T: Next> Next for GetNext<T> {

--- a/tests/ui/recursion/issue-38591-non-regular-dropck-recursion.stderr
+++ b/tests/ui/recursion/issue-38591-non-regular-dropck-recursion.stderr
@@ -4,7 +4,7 @@ error[E0320]: overflow while adding drop-check rules for `S<u32>`
 LL | fn f(x: S<u32>) {}
    |      ^
    |
-   = note: overflowed on `S<fn(fn(fn(fn(fn(fn(fn(fn(fn(fn(fn(fn(fn(fn(fn(fn(...))))))))))))))))>`
+   = note: overflowed on `S<fn(fn(fn(fn(fn(fn(fn(fn(fn(fn(fn(fn(fn(fn(fn(fn(_))))))))))))))))>`
    = note: the full name for the type has been written to '$TEST_BUILD_DIR/issue-38591-non-regular-dropck-recursion.long-type-$LONG_TYPE_HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
 

--- a/tests/ui/recursion/issue-83150.stderr
+++ b/tests/ui/recursion/issue-83150.stderr
@@ -15,7 +15,7 @@ error[E0275]: overflow evaluating the requirement `Map<&mut std::ops::Range<u8>,
    = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`issue_83150`)
    = note: required for `&mut Map<&mut Range<u8>, {closure@issue-83150.rs:12:24}>` to implement `Iterator`
    = note: 65 redundant requirements hidden
-   = note: required for `&mut Map<&mut Map<&mut Map<&mut Map<&mut ..., ...>, ...>, ...>, ...>` to implement `Iterator`
+   = note: required for `&mut Map<&mut Map<&mut Map<&mut Map<&mut Map<_, _>, _>, _>, _>, _>` to implement `Iterator`
    = note: the full name for the type has been written to '$TEST_BUILD_DIR/issue-83150.long-type-$LONG_TYPE_HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
 

--- a/tests/ui/recursion/recursion.stderr
+++ b/tests/ui/recursion/recursion.stderr
@@ -1,4 +1,4 @@
-error: reached the recursion limit while instantiating `test::<Cons<Cons<Cons<Cons<Cons<Cons<...>>>>>>>`
+error: reached the recursion limit while instantiating `test::<Cons<Cons<Cons<Cons<Cons<Cons<_>>>>>>>`
   --> $DIR/recursion.rs:17:11
    |
 LL |     _ => {test (n-1, i+1, Cons {head:2*i+1, tail:first}, Cons{head:i*i, tail:second})}

--- a/tests/ui/recursion/recursive-impl-trait-iterator-by-ref-67552.stderr
+++ b/tests/ui/recursion/recursive-impl-trait-iterator-by-ref-67552.stderr
@@ -1,4 +1,4 @@
-error: reached the recursion limit while instantiating `rec::<&mut &mut &mut &mut &mut &mut &mut &mut ...>`
+error: reached the recursion limit while instantiating `rec::<&mut &mut &mut &mut &mut &mut &mut &mut _>`
   --> $DIR/recursive-impl-trait-iterator-by-ref-67552.rs:28:9
    |
 LL |         rec(identity(&mut it))

--- a/tests/ui/self/arbitrary-self-from-method-substs-ice.stderr
+++ b/tests/ui/self/arbitrary-self-from-method-substs-ice.stderr
@@ -15,6 +15,11 @@ LL |     const fn get<R: Deref<Target = Self>>(self: R) -> u32 {
 ...
 LL |     }
    |     - value is dropped here
+   |
+help: consider further restricting type parameter `R` with unstable trait `Destruct`
+   |
+LL |     const fn get<R: Deref<Target = Self> + [const] Destruct>(self: R) -> u32 {
+   |                                          ++++++++++++++++++
 
 error[E0801]: invalid generic `self` parameter type: `R`
   --> $DIR/arbitrary-self-from-method-substs-ice.rs:10:49

--- a/tests/ui/static/static-drop-scope.stderr
+++ b/tests/ui/static/static-drop-scope.stderr
@@ -37,6 +37,11 @@ LL | const fn const_drop<T>(_: T) {}
    |                        ^      - value is dropped here
    |                        |
    |                        the destructor for this type cannot be evaluated in constant functions
+   |
+help: consider restricting type parameter `T` with unstable trait `Destruct`
+   |
+LL | const fn const_drop<T: [const] Destruct>(_: T) {}
+   |                      ++++++++++++++++++
 
 error[E0493]: destructor of `(T, ())` cannot be evaluated at compile-time
   --> $DIR/static-drop-scope.rs:17:5

--- a/tests/ui/suggestions/box-future-wrong-output.stderr
+++ b/tests/ui/suggestions/box-future-wrong-output.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/box-future-wrong-output.rs:20:39
    |
 LL |     let _: BoxFuture<'static, bool> = async {}.boxed();
-   |            ------------------------   ^^^^^^^^^^^^^^^^ expected `Pin<Box<...>>`, found `Pin<Box<dyn Future<Output = ()> + Send>>`
+   |            ------------------------   ^^^^^^^^^^^^^^^^ expected `Pin<Box<_>>`, found `Pin<Box<dyn Future<Output = ()> + Send>>`
    |            |
    |            expected due to this
    |

--- a/tests/ui/suggestions/expected-boxed-future-isnt-pinned.stderr
+++ b/tests/ui/suggestions/expected-boxed-future-isnt-pinned.stderr
@@ -5,7 +5,7 @@ LL | fn foo<F: Future<Output=i32> + Send + 'static>(x: F) -> BoxFuture<'static, 
    |        - found this type parameter                      ----------------------- expected `Pin<Box<(dyn Future<Output = i32> + Send + 'static)>>` because of return type
 LL |     // We could instead use an `async` block, but this way we have no std spans.
 LL |     x
-   |     ^ expected `Pin<Box<...>>`, found type parameter `F`
+   |     ^ expected `Pin<Box<_>>`, found type parameter `F`
    |
    = note:      expected struct `Pin<Box<(dyn Future<Output = i32> + Send + 'static)>>`
            found type parameter `F`
@@ -20,7 +20,7 @@ error[E0308]: mismatched types
 LL | fn bar<F: Future<Output=i32> + Send + 'static>(x: F) -> BoxFuture<'static, i32> {
    |                                                         ----------------------- expected `Pin<Box<(dyn Future<Output = i32> + Send + 'static)>>` because of return type
 LL |     Box::new(x)
-   |     ^^^^^^^^^^^ expected `Pin<Box<...>>`, found `Box<F>`
+   |     ^^^^^^^^^^^ expected `Pin<Box<_>>`, found `Box<F>`
    |
    = note: expected struct `Pin<Box<(dyn Future<Output = i32> + Send + 'static)>>`
               found struct `Box<F>`
@@ -76,7 +76,7 @@ LL |   fn zap() -> BoxFuture<'static, i32> {
 LL | /     async {
 LL | |         42
 LL | |     }
-   | |_____^ expected `Pin<Box<...>>`, found `async` block
+   | |_____^ expected `Pin<Box<_>>`, found `async` block
    |
    = note:     expected struct `Pin<Box<(dyn Future<Output = i32> + Send + 'static)>>`
            found `async` block `{async block@$DIR/expected-boxed-future-isnt-pinned.rs:28:5: 28:10}`

--- a/tests/ui/suggestions/issue-107860.stderr
+++ b/tests/ui/suggestions/issue-107860.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/issue-107860.rs:3:36
    |
 LL | async fn str<T>(T: &str) -> &str { &str }
-   |                                    ^^^^ expected `&str`, found `&fn(&str) -> ... {str::<_>}`
+   |                                    ^^^^ expected `&str`, found `&fn(&str) -> _ {str::<_>}`
    |
    = note: expected reference `&str`
               found reference `&for<'a> fn(&'a str) -> impl Future<Output = &'a str> {str::<_>}`

--- a/tests/ui/trait-bounds/associated-error-bound-issue-145586.stderr
+++ b/tests/ui/trait-bounds/associated-error-bound-issue-145586.stderr
@@ -8,7 +8,7 @@ LL |     fn deserialize_ignored_any<V>(self, visitor: V) -> Result<V::Value, Sel
    |                                                        ----------------------------- expected `Result<<V as Visitor<'de>>::Value, E>` because of return type
 ...
 LL |             Ok(deserializer) => deserializer.deserialize_ignored_any(visitor),
-   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Result<<V as Visitor<'_>>::Value, E>`, found `Result<<V as Visitor<'_>>::Value, ...>`
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Result<<V as Visitor<'_>>::Value, E>`, found `Result<<V as Visitor<'_>>::Value, _>`
    |
    = note: expected enum `Result<_, E>`
               found enum `Result<_, <T as Deserializer<'de>>::Error>`

--- a/tests/ui/traits/const-traits/minicore-drop-fail.stderr
+++ b/tests/ui/traits/const-traits/minicore-drop-fail.stderr
@@ -30,6 +30,11 @@ LL | const fn drop_arbitrary<T>(_: T) {
 LL |
 LL | }
    | - value is dropped here
+   |
+help: consider restricting type parameter `T` with trait `Destruct`
+   |
+LL | const fn drop_arbitrary<T: [const] Destruct>(_: T) {
+   |                          ++++++++++++++++++
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/traits/issue-68295.stderr
+++ b/tests/ui/traits/issue-68295.stderr
@@ -5,7 +5,7 @@ LL | fn crash<R, C>(input: Matrix<R, C, ()>) -> Matrix<R, C, u32>
    |                                            ----------------- expected `Matrix<R, C, u32>` because of return type
 ...
 LL |     input.into_owned()
-   |     ^^^^^^^^^^^^^^^^^^ expected `Matrix<R, C, u32>`, found `Matrix<R, C, ...>`
+   |     ^^^^^^^^^^^^^^^^^^ expected `Matrix<R, C, u32>`, found `Matrix<R, C, _>`
    |
    = note: expected struct `Matrix<_, _, u32>`
               found struct `Matrix<_, _, <() as Allocator<R, C>>::Buffer>`

--- a/tests/ui/traits/issue-91949-hangs-on-recursion.stderr
+++ b/tests/ui/traits/issue-91949-hangs-on-recursion.stderr
@@ -24,7 +24,7 @@ LL | impl<T, I: Iterator<Item = T>> Iterator for IteratorOfWrapped<T, I> {
    |                     |
    |                     unsatisfied trait bound introduced here
    = note: 256 redundant requirements hidden
-   = note: required for `IteratorOfWrapped<(), Map<IteratorOfWrapped<(), Map<..., ...>>, ...>>` to implement `Iterator`
+   = note: required for `IteratorOfWrapped<(), Map<IteratorOfWrapped<(), Map<_, _>>, _>>` to implement `Iterator`
    = note: the full name for the type has been written to '$TEST_BUILD_DIR/issue-91949-hangs-on-recursion.long-type-$LONG_TYPE_HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
 

--- a/tests/ui/traits/next-solver/overflow/global-cache.stderr
+++ b/tests/ui/traits/next-solver/overflow/global-cache.stderr
@@ -1,4 +1,4 @@
-error[E0275]: overflow evaluating the requirement `Inc<Inc<Inc<Inc<Inc<Inc<Inc<...>>>>>>>: Trait`
+error[E0275]: overflow evaluating the requirement `Inc<Inc<Inc<Inc<Inc<Inc<Inc<_>>>>>>>: Trait`
   --> $DIR/global-cache.rs:21:19
    |
 LL |     impls_trait::<Four<Four<Four<Four<()>>>>>();

--- a/tests/ui/traits/next-solver/rerun-if-any-opaque-or-has-infer-as-hidden-in-codegen.rs
+++ b/tests/ui/traits/next-solver/rerun-if-any-opaque-or-has-infer-as-hidden-in-codegen.rs
@@ -1,0 +1,34 @@
+//@ compile-flags: -Znext-solver
+//@ check-pass
+
+fn mk_vec() -> Vec<Vec<&'static str>> {
+    loop {}
+}
+
+fn parse_feature(feature: &str) -> impl Iterator<Item = &str> {
+    std::iter::once(feature)
+}
+
+fn main() {
+    // In `codegen_select_candidate`, we try to find an impl for `FlatMap::into_iter`
+    // We try to prove `FlatMap<...>: IntoIterator`.
+    // The blanket impl requires `FlatMap<...>: Iterator`.
+    // The `Iterator` impl of `FlatMap` has nested goals:
+    // `Projection(Fn::Output<parse_feature, (?assoc,)>, iter::Once`.
+    // We normalize this goal and set rerun condition to `AnyOpaqueHasInferAsHidden`
+    // with reason `SelfTyInfer` because we instantiated impls with infers when
+    // assembling candidates for intermediate goals.
+    // Then we evaluate the normalized goal:
+    // `Projection(Fn::Output<parse_feature, (&str,)>, iter::Once`.
+    // The alias term is normalized to rigid alias `impl Iterator<Item = &str>` as
+    // we're in `TypingMode::ErasedNotCoherence`.
+    // But the expected term is revealed `iter::Once` thus relating failed.
+    // The goal fails with rerun condition `OpaqueInStorage(parse_feature::opaque)`.
+    // This goal should be rerun in `TypingMode::Codegen` mode, but
+    // `AnyOpaqueHasInferAsHidden + OpaqueInStorage = OpaqueInStorageOrAnyOpaqueHasInferAsHidden`
+    // which didn't trigger rerun in `TypingMode::Codegen` mode previously.
+    mk_vec()
+        .into_iter()
+        .flatten()
+        .flat_map(parse_feature).into_iter();
+}

--- a/tests/ui/traits/on_unimplemented_long_types.stderr
+++ b/tests/ui/traits/on_unimplemented_long_types.stderr
@@ -1,4 +1,4 @@
-error[E0277]: `Option<Option<Option<...>>>` doesn't implement `std::fmt::Display`
+error[E0277]: `Option<Option<Option<_>>>` doesn't implement `std::fmt::Display`
   --> $DIR/on_unimplemented_long_types.rs:3:17
    |
 LL |   pub fn foo() -> impl std::fmt::Display {
@@ -11,9 +11,9 @@ LL | |                 Some(Some(Some(Some(Some(Some(Some...
 ...  |
 LL | |         ))))))))))),
 LL | |     )))))))))))
-   | |_______________- return type was inferred to be `Option<Option<Option<...>>>` here
+   | |_______________- return type was inferred to be `Option<Option<Option<_>>>` here
    |
-   = help: the trait `std::fmt::Display` is not implemented for `Option<Option<Option<...>>>`
+   = help: the trait `std::fmt::Display` is not implemented for `Option<Option<Option<_>>>`
    = note: the full name for the type has been written to '$TEST_BUILD_DIR/on_unimplemented_long_types.long-type-$LONG_TYPE_HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
 

--- a/tests/ui/traits/trait-impl-overflow-with-where-clause-20413.stderr
+++ b/tests/ui/traits/trait-impl-overflow-with-where-clause-20413.stderr
@@ -7,7 +7,7 @@ LL | struct NoData<T>;
    = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
    = help: if you intended `T` to be a const parameter, use `const T: /* Type */` instead
 
-error[E0275]: overflow evaluating the requirement `NoData<NoData<NoData<NoData<NoData<NoData<NoData<...>>>>>>>: Foo`
+error[E0275]: overflow evaluating the requirement `NoData<NoData<NoData<NoData<NoData<NoData<NoData<_>>>>>>>: Foo`
   --> $DIR/trait-impl-overflow-with-where-clause-20413.rs:9:36
    |
 LL | impl<T> Foo for T where NoData<T>: Foo {
@@ -22,7 +22,7 @@ LL | impl<T> Foo for T where NoData<T>: Foo {
    = note: 126 redundant requirements hidden
    = note: required for `NoData<T>` to implement `Foo`
 
-error[E0275]: overflow evaluating the requirement `AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<...>>>>>>>: Bar`
+error[E0275]: overflow evaluating the requirement `AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<_>>>>>>>: Bar`
   --> $DIR/trait-impl-overflow-with-where-clause-20413.rs:28:42
    |
 LL | impl<T> Bar for T where EvenLessData<T>: Baz {
@@ -42,7 +42,7 @@ LL | impl<T> Bar for T where EvenLessData<T>: Baz {
    = note: 125 redundant requirements hidden
    = note: required for `EvenLessData<T>` to implement `Baz`
 
-error[E0275]: overflow evaluating the requirement `EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<...>>>>>>>: Baz`
+error[E0275]: overflow evaluating the requirement `EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<AlmostNoData<EvenLessData<_>>>>>>>: Baz`
   --> $DIR/trait-impl-overflow-with-where-clause-20413.rs:35:42
    |
 LL | impl<T> Baz for T where AlmostNoData<T>: Bar {

--- a/tests/ui/trimmed-paths/doc-hidden.rs
+++ b/tests/ui/trimmed-paths/doc-hidden.rs
@@ -44,7 +44,7 @@ fn uses_local() {
         DocHiddenInHiddenMod,
     ) = 3u32;
     //~^ ERROR mismatched types [E0308]
-    //~| NOTE expected `(ActuallyPub, ..., ..., ..., ..., ...)`, found `u32`
+    //~| NOTE expected `(ActuallyPub, DocHidden, _, _, _, _)`, found `u32`
     //~| NOTE expected tuple `(local::ActuallyPub, DocHidden, local::pub_mod::ActuallyPubInPubMod, DocHiddenInPubMod, ActuallyPubInHiddenMod, DocHiddenInHiddenMod)`
 }
 
@@ -63,6 +63,6 @@ fn uses_helper() {
         DocHiddenInHiddenMod,
     ) = 3u32;
     //~^ ERROR mismatched types [E0308]
-    //~| NOTE expected `(ActuallyPub, ..., ..., ..., ..., ...)`, found `u32`
+    //~| NOTE expected `(ActuallyPub, DocHidden, _, _, _, _)`, found `u32`
     //~| NOTE expected tuple `(doc_hidden_helper::ActuallyPub, doc_hidden_helper::DocHidden, doc_hidden_helper::pub_mod::ActuallyPubInPubMod, doc_hidden_helper::pub_mod::DocHiddenInPubMod, doc_hidden_helper::hidden_mod::ActuallyPubInHiddenMod, doc_hidden_helper::hidden_mod::DocHiddenInHiddenMod)`
 }

--- a/tests/ui/trimmed-paths/doc-hidden.stderr
+++ b/tests/ui/trimmed-paths/doc-hidden.stderr
@@ -9,7 +9,7 @@ LL | |         DocHidden,
 ...  |
 LL | |         DocHiddenInHiddenMod,
 LL | |     ) = 3u32;
-   | |     -   ^^^^ expected `(ActuallyPub, ..., ..., ..., ..., ...)`, found `u32`
+   | |     -   ^^^^ expected `(ActuallyPub, DocHidden, _, _, _, _)`, found `u32`
    | |_____|
    |       expected due to this
    |
@@ -27,7 +27,7 @@ LL | |         DocHidden,
 ...  |
 LL | |         DocHiddenInHiddenMod,
 LL | |     ) = 3u32;
-   | |     -   ^^^^ expected `(ActuallyPub, ..., ..., ..., ..., ...)`, found `u32`
+   | |     -   ^^^^ expected `(ActuallyPub, DocHidden, _, _, _, _)`, found `u32`
    | |_____|
    |       expected due to this
    |

--- a/tests/ui/type-alias-impl-trait/send-bound-nested-async-95719.rs
+++ b/tests/ui/type-alias-impl-trait/send-bound-nested-async-95719.rs
@@ -1,0 +1,53 @@
+// Regression test for <https://github.com/rust-lang/rust/issues/95719>.
+// The `Send` bound of a GAT `impl Future` was lost when the future was
+// wrapped in another `async fn`, failing with "the parameter type `G` may
+// not live long enough".
+//@ check-pass
+//@ edition: 2021
+
+#![feature(impl_trait_in_assoc_type)]
+
+use std::future::Future;
+
+pub trait Get: Send + Sync {
+    type Ret<'a>: Future<Output = usize> + Send + 'a
+    where
+        Self: 'a;
+    fn get<'a>(&'a self) -> Self::Ret<'a>
+    where
+        Self: 'a;
+}
+
+impl Get for usize {
+    type Ret<'a>
+        = impl Future<Output = usize> + Send + 'a
+    where
+        Self: 'a;
+
+    fn get<'a>(&'a self) -> Self::Ret<'a>
+    where
+        Self: 'a,
+    {
+        async move { *self }
+    }
+}
+
+fn is_send<R, F: Future<Output = R> + Send>(_f: &F) -> bool {
+    true
+}
+
+async fn wrap<G: Get>(g: &G) -> usize {
+    let fut = g.get();
+    assert!(is_send(&fut));
+    fut.await
+}
+
+async fn wrap_wrap<G: Get>(g: &G) -> usize {
+    let fut = wrap(g);
+    assert!(is_send(&fut));
+    fut.await
+}
+
+fn main() {
+    let _ = wrap_wrap(&0usize);
+}

--- a/tests/ui/typeck/issue-107775.stderr
+++ b/tests/ui/typeck/issue-107775.stderr
@@ -6,7 +6,7 @@ LL |         map.insert(1, Struct::do_something);
    |         |
    |         ... which causes `map` to have type `HashMap<{integer}, fn(u8) -> Pin<Box<dyn Future<Output = ()> + Send>> {<Struct as Trait>::do_something::<'_>}>`
 LL |         Self { map }
-   |                ^^^ expected `HashMap<u16, fn(u8) -> Pin<Box<...>>>`, found `HashMap<{integer}, ...>`
+   |                ^^^ expected `HashMap<u16, fn(u8) -> Pin<Box<_>>>`, found `HashMap<{integer}, _>`
    |
    = note: expected struct `HashMap<u16, fn(_) -> Pin<Box<(dyn Future<Output = ()> + Send + 'static)>>>`
               found struct `HashMap<{integer}, fn(_) -> Pin<Box<dyn Future<Output = ()> + Send>> {<Struct as Trait>::do_something::<'_>}>`


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#157824 (Comptime inherent impls)
 - rust-lang/rust#158993 (rerun in original typing mode if we meet any opaques in post analysis)
 - rust-lang/rust#159160 (Make `HasTokens` a sub-trait of `HasAttrs`.)
 - rust-lang/rust#159183 (Introduce InstanceKind::LlvmIntrinsic)
 - rust-lang/rust#159251 (Bump rustc-perf submodule)
 - rust-lang/rust#155013 (Suggest the `[const] Destruct` bound for type parameters in const functions when missing)
 - rust-lang/rust#159235 (Add regression test for rust-lang/rust#95719)
 - rust-lang/rust#159239 (Add codegen test for remainder match)
 - rust-lang/rust#159243 (inline Once wait and wait_force)
 - rust-lang/rust#159255 (Replace shortened type with `_` instead of `...` as placeholder)
 - rust-lang/rust#159259 (Add regression test for rust-lang/rust#144033)
 - rust-lang/rust#159265 (bootstrap: skip intrinsic-test when rustfmt is unavailable)
 - rust-lang/rust#159269 (disable range-len-try-from.rs on s390x)
 - rust-lang/rust#159272 (slice: make swap delegate to swap_unchecked)
 - rust-lang/rust#159274 (bootstrap: Rename `std_crates_for_run_make` to `std_crates_for_make_run`)
 - rust-lang/rust#159275 (remove obsolete comment)
 - rust-lang/rust#159277 (Construct `tokens` for attrs made by `mk_attr_word` and other variants)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=157824,158993,159160,159183,159251,155013,159235,159239,159243,159255,159259,159265,159269,159272,159274,159275,159277)
<!-- homu-ignore:end -->

