### PR TITLE
Update documentation for `-Zdump-dep-graph`

### DIFF
--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -2358,7 +2358,7 @@ options! {
     dual_proc_macros: bool = (false, parse_bool, [TRACKED],
         "load proc macros for both target and host, but only link to the target (default: no)"),
     dump_dep_graph: bool = (false, parse_bool, [UNTRACKED],
-        "dump the dependency graph to $RUST_DEP_GRAPH (default: /tmp/dep_graph.gv) \
+        "dump the dependency graph to `$RUST_DEP_GRAPH` as both a text file and a GraphViz dot file (default: ./dep_graph.{dot, txt}) \
         (default: no)"),
     dump_mir: Option<String> = (None, parse_opt_string, [UNTRACKED],
         "dump MIR state to file.


### PR DESCRIPTION
The supposed output path was incorrect. Using `-Zdump-dep-graph` does NOT emit to `/tmp/dep_graph.gv`, but to 2 files, one being `dep_graph.txt` and the other `dep_graph.dot` in the current directory

r? @jackh726 :: Because kinda related to Incremental Systems Rethought.