### PR TITLE
renovate: don't update PRs in the merge queue

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -13,6 +13,8 @@
   ],
   // Require manual approval from the Dependency Dashboard before opening PRs
   "dependencyDashboardApproval": true,
+  // Renovate shouldn't update a PR if it is in the bors merge queue.
+  "stopUpdatingLabel": "S-waiting-on-bors",
   "packageRules": [
     {
       // No dashboard approval necessary for GitHub Actions updates


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
For context, see [#t-infra > renovate for rust-lang/rust](https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/renovate.20for.20rust-lang.2Frust/with/610601736).
<!-- homu-ignore:end -->
r? @Kobzol