### PR TITLE
Allow `Foo { .. }` patterns to match non-struct types

### DIFF
--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -1814,13 +1814,16 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         base_expr: &'tcx hir::StructTailExpr<'tcx>,
     ) -> Ty<'tcx> {
         // Find the relevant variant
-        let (variant, adt_ty) = match self.check_struct_path(qpath, expr.hir_id) {
+        let (variant, adt_ty) = match self.check_struct_path(qpath, expr.hir_id, false) {
             Ok(data) => data,
             Err(guar) => {
                 self.check_struct_fields_on_error(fields, base_expr);
                 return Ty::new_error(self.tcx, guar);
             }
         };
+        // This is safe because we passed `allow_any_type: false`
+        // to `check_struct_path()` above
+        let variant = variant.unwrap();
 
         // Prohibit struct expressions when non-exhaustive flag is set.
         let adt = adt_ty.ty_adt_def().expect("`check_struct_path` returned non-ADT type");

--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -1824,13 +1824,16 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         base_expr: &'tcx hir::StructTailExpr<'tcx>,
     ) -> Ty<'tcx> {
         // Find the relevant variant
-        let (variant, adt_ty) = match self.check_struct_path(qpath, expr.hir_id) {
+        let (variant, adt_ty) = match self.check_struct_path(qpath, expr.hir_id, false) {
             Ok(data) => data,
             Err(guar) => {
                 self.check_struct_fields_on_error(fields, base_expr);
                 return Ty::new_error(self.tcx, guar);
             }
         };
+        // This is safe because we passed `allow_any_type: false`
+        // to `check_struct_path()` above
+        let variant = variant.unwrap();
 
         // Prohibit struct expressions when non-exhaustive flag is set.
         let adt = adt_ty.ty_adt_def().expect("`check_struct_path` returned non-ADT type");

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
@@ -1035,11 +1035,16 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         }
     }
 
+    /// `allow_any_type` is `true` for `Path { .. }` patterns (with only a `..` rest).
+    /// If it's not set to `true`, then the only valid `qpath`s point
+    /// a struct, union, or enum variant, and the returned `Option<&'tcx ty::VariantDef>`
+    /// will be `Some`.
     pub(crate) fn check_struct_path(
         &self,
         qpath: &QPath<'tcx>,
         hir_id: HirId,
-    ) -> Result<(&'tcx ty::VariantDef, Ty<'tcx>), ErrorGuaranteed> {
+        allow_any_type: bool,
+    ) -> Result<(Option<&'tcx ty::VariantDef>, Ty<'tcx>), ErrorGuaranteed> {
         let path_span = qpath.span();
         let (def, ty) = self.finish_resolving_struct_path(qpath, path_span, hir_id);
         let variant = match def {
@@ -1063,6 +1068,15 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 }
                 _ => None,
             },
+            Res::Def(
+                DefKind::Enum
+                | DefKind::Trait
+                | DefKind::TraitAlias
+                | DefKind::TyParam
+                | DefKind::ForeignTy,
+                _,
+            )
+            | Res::PrimTy(..) => None,
             _ => bug!("unexpected definition: {:?}", def),
         };
 
@@ -1075,7 +1089,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             // Check bounds on type arguments used in the path.
             self.add_required_obligations_for_hir(path_span, did, args, hir_id);
 
-            Ok((variant, ty.normalized))
+            Ok((Some(variant), ty.normalized))
+        } else if allow_any_type {
+            Ok((None, ty.normalized))
         } else {
             Err(match *ty.normalized.kind() {
                 ty::Error(guar) => {

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
@@ -1067,11 +1067,16 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         }
     }
 
+    /// `allow_any_type` is `true` for `Path { .. }` patterns (with only a `..` rest).
+    /// If it's not set to `true`, then the only valid `qpath`s point
+    /// a struct, union, or enum variant, and the returned `Option<&'tcx ty::VariantDef>`
+    /// will be `Some`.
     pub(crate) fn check_struct_path(
         &self,
         qpath: &QPath<'tcx>,
         hir_id: HirId,
-    ) -> Result<(&'tcx ty::VariantDef, Ty<'tcx>), ErrorGuaranteed> {
+        allow_any_type: bool,
+    ) -> Result<(Option<&'tcx ty::VariantDef>, Ty<'tcx>), ErrorGuaranteed> {
         let path_span = qpath.span();
         let (def, ty) = self.finish_resolving_struct_path(qpath, path_span, hir_id);
         let variant = match def {
@@ -1095,6 +1100,15 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 }
                 _ => None,
             },
+            Res::Def(
+                DefKind::Enum
+                | DefKind::Trait
+                | DefKind::TraitAlias
+                | DefKind::TyParam
+                | DefKind::ForeignTy,
+                _,
+            )
+            | Res::PrimTy(..) => None,
             _ => bug!("unexpected definition: {:?}", def),
         };
 
@@ -1107,7 +1121,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             // Check bounds on type arguments used in the path.
             self.add_required_obligations_for_hir(path_span, did, args, hir_id);
 
-            Ok((variant, ty.normalized))
+            Ok((Some(variant), ty.normalized))
+        } else if allow_any_type {
+            Ok((None, ty.normalized))
         } else {
             Err(match *ty.normalized.kind() {
                 ty::Error(guar) => {

--- a/compiler/rustc_hir_typeck/src/pat.rs
+++ b/compiler/rustc_hir_typeck/src/pat.rs
@@ -304,9 +304,21 @@ struct ResolvedPat<'tcx> {
 
 #[derive(Clone, Copy, Debug)]
 enum ResolvedPatKind<'tcx> {
-    Path { res: Res, pat_res: Res, segments: &'tcx [hir::PathSegment<'tcx>] },
-    Struct { variant: &'tcx VariantDef },
-    TupleStruct { res: Res, variant: &'tcx VariantDef },
+    Path {
+        res: Res,
+        pat_res: Res,
+        segments: &'tcx [hir::PathSegment<'tcx>],
+    },
+    Struct {
+        variant: &'tcx VariantDef,
+    },
+    TupleStruct {
+        res: Res,
+        variant: &'tcx VariantDef,
+    },
+    /// A `Type { .. }` pattern, where `Type` is not an ADT variant.
+    /// Lowers to a wildcard pattern in THIR.
+    TypedWild,
 }
 
 impl<'tcx> ResolvedPat<'tcx> {
@@ -410,7 +422,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             PatKind::Expr(PatExpr { kind: PatExprKind::Path(qpath), hir_id, span }) => {
                 Some(self.resolve_pat_path(*hir_id, *span, qpath))
             }
-            PatKind::Struct(ref qpath, ..) => Some(self.resolve_pat_struct(pat, qpath)),
+            PatKind::Struct(ref qpath, fields, rest) => {
+                Some(self.resolve_pat_struct(pat, qpath, fields.is_empty() && rest.is_some()))
+            }
             PatKind::TupleStruct(ref qpath, ..) => Some(self.resolve_pat_tuple_struct(pat, qpath)),
             _ => None,
         };
@@ -630,6 +644,14 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         expected,
                         pat_info,
                     ),
+                Ok(ResolvedPat { ty, kind: ResolvedPatKind::TypedWild }) => {
+                    debug_assert!(fields.is_empty());
+                    debug_assert!(has_rest_pat.is_some());
+                    match self.demand_eqtype_pat(pat.span, expected, ty, &pat_info.top_info) {
+                        Ok(()) => ty,
+                        Err(guar) => Ty::new_error(self.tcx, guar),
+                    }
+                }
                 Err(guar) => {
                     let ty_err = Ty::new_error(self.tcx, guar);
                     for field in fields {
@@ -1502,10 +1524,16 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         &self,
         pat: &'tcx Pat<'tcx>,
         qpath: &hir::QPath<'tcx>,
+        allow_any_type: bool,
     ) -> Result<ResolvedPat<'tcx>, ErrorGuaranteed> {
         // Resolve the path and check the definition for errors.
-        let (variant, pat_ty) = self.check_struct_path(qpath, pat.hir_id)?;
-        Ok(ResolvedPat { ty: pat_ty, kind: ResolvedPatKind::Struct { variant } })
+        let (variant, pat_ty) = self.check_struct_path(qpath, pat.hir_id, allow_any_type)?;
+        let kind = if let Some(variant) = variant {
+            ResolvedPatKind::Struct { variant }
+        } else {
+            ResolvedPatKind::TypedWild
+        };
+        Ok(ResolvedPat { ty: pat_ty, kind })
     }
 
     /// Reject pin-projection through a type that isn't structurally pinnable.

--- a/compiler/rustc_hir_typeck/src/pat.rs
+++ b/compiler/rustc_hir_typeck/src/pat.rs
@@ -304,9 +304,21 @@ struct ResolvedPat<'tcx> {
 
 #[derive(Clone, Copy, Debug)]
 enum ResolvedPatKind<'tcx> {
-    Path { res: Res, pat_res: Res, segments: &'tcx [hir::PathSegment<'tcx>] },
-    Struct { variant: &'tcx VariantDef },
-    TupleStruct { res: Res, variant: &'tcx VariantDef },
+    Path {
+        res: Res,
+        pat_res: Res,
+        segments: &'tcx [hir::PathSegment<'tcx>],
+    },
+    Struct {
+        variant: &'tcx VariantDef,
+    },
+    TupleStruct {
+        res: Res,
+        variant: &'tcx VariantDef,
+    },
+    /// A `Type { .. }` pattern, where `Type` is not an ADT variant.
+    /// Lowers to a wildcard pattern in THIR.
+    TypedWild,
 }
 
 impl<'tcx> ResolvedPat<'tcx> {
@@ -410,7 +422,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             PatKind::Expr(PatExpr { kind: PatExprKind::Path(qpath), hir_id, span }) => {
                 Some(self.resolve_pat_path(*hir_id, *span, qpath))
             }
-            PatKind::Struct(ref qpath, ..) => Some(self.resolve_pat_struct(pat, qpath)),
+            PatKind::Struct(ref qpath, fields, rest) => {
+                Some(self.resolve_pat_struct(pat, qpath, fields.is_empty() && rest.is_some()))
+            }
             PatKind::TupleStruct(ref qpath, ..) => Some(self.resolve_pat_tuple_struct(pat, qpath)),
             _ => None,
         };
@@ -630,6 +644,14 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         expected,
                         pat_info,
                     ),
+                Ok(ResolvedPat { ty, kind: ResolvedPatKind::TypedWild }) => {
+                    debug_assert!(fields.is_empty());
+                    debug_assert!(has_rest_pat.is_some());
+                    match self.demand_eqtype_pat(pat.span, expected, ty, &pat_info.top_info) {
+                        Ok(()) => ty,
+                        Err(guar) => Ty::new_error(self.tcx, guar),
+                    }
+                }
                 Err(guar) => {
                     let ty_err = Ty::new_error(self.tcx, guar);
                     for field in fields {
@@ -1498,10 +1520,16 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         &self,
         pat: &'tcx Pat<'tcx>,
         qpath: &hir::QPath<'tcx>,
+        allow_any_type: bool,
     ) -> Result<ResolvedPat<'tcx>, ErrorGuaranteed> {
         // Resolve the path and check the definition for errors.
-        let (variant, pat_ty) = self.check_struct_path(qpath, pat.hir_id)?;
-        Ok(ResolvedPat { ty: pat_ty, kind: ResolvedPatKind::Struct { variant } })
+        let (variant, pat_ty) = self.check_struct_path(qpath, pat.hir_id, allow_any_type)?;
+        let kind = if let Some(variant) = variant {
+            ResolvedPatKind::Struct { variant }
+        } else {
+            ResolvedPatKind::TypedWild
+        };
+        Ok(ResolvedPat { ty: pat_ty, kind })
     }
 
     /// Reject pin-projection through a type that isn't structurally pinnable.

--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -152,6 +152,7 @@ impl<'tcx> LateLintPass<'tcx> for NonShorthandFieldPatterns {
         // The result shouldn't be tainted, otherwise it will cause ICE.
         if let PatKind::Struct(ref qpath, field_pats, _) = pat.kind
             && cx.typeck_results().tainted_by_errors.is_none()
+            && !field_pats.is_empty()
         {
             let variant = cx
                 .typeck_results()

--- a/compiler/rustc_mir_build/src/thir/pattern/mod.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/mod.rs
@@ -425,10 +425,10 @@ impl<'tcx, 'ptcx> PatCtxt<'tcx, 'ptcx> {
                 };
                 let variant_def = adt_def.variant_of_res(res);
                 let subpatterns = self.lower_tuple_subpats(pats, variant_def.fields.len(), ddpos);
-                return self.lower_variant_or_leaf(pat, None, res, subpatterns);
+                return self.lower_variant_or_leaf(pat, None, res, subpatterns, false);
             }
 
-            hir::PatKind::Struct(ref qpath, fields, _) => {
+            hir::PatKind::Struct(ref qpath, fields, rest) => {
                 let res = self.typeck_results.qpath_res(qpath, pat.hir_id);
                 let subpatterns = fields
                     .iter()
@@ -442,7 +442,7 @@ impl<'tcx, 'ptcx> PatCtxt<'tcx, 'ptcx> {
                     })
                     .collect();
 
-                return self.lower_variant_or_leaf(pat, None, res, subpatterns);
+                return self.lower_variant_or_leaf(pat, None, res, subpatterns, rest.is_some());
             }
 
             hir::PatKind::Or(pats) => PatKind::Or { pats: self.lower_patterns(pats) },
@@ -512,12 +512,15 @@ impl<'tcx, 'ptcx> PatCtxt<'tcx, 'ptcx> {
         Box::new(Pat { ty, span, kind, extra: None })
     }
 
+    /// If `has_braced_rest` is `true`, `res` is not an enum variant, and there are no `subpatterns`,
+    /// this lowers to [`PatKind::Wild`].
     fn lower_variant_or_leaf(
         &mut self,
         pat: &'tcx hir::Pat<'tcx>,
         expr: Option<&'tcx hir::PatExpr<'tcx>>,
         res: Res,
         subpatterns: Vec<FieldPat<'tcx>>,
+        has_braced_rest: bool,
     ) -> Box<Pat<'tcx>> {
         // Check whether the caller should have provided an `expr` for this pattern kind.
         assert_matches!(
@@ -570,6 +573,8 @@ impl<'tcx, 'ptcx> PatCtxt<'tcx, 'ptcx> {
                     PatKind::Leaf { subpatterns }
                 }
             }
+
+            _ if subpatterns.is_empty() && has_braced_rest => PatKind::Wild,
 
             Res::Def(
                 DefKind::Struct
@@ -649,7 +654,7 @@ impl<'tcx, 'ptcx> PatCtxt<'tcx, 'ptcx> {
             _ => {
                 // The path isn't the name of a constant, so it must actually
                 // be a unit struct or unit variant (e.g. `Option::None`).
-                return self.lower_variant_or_leaf(pat, Some(expr), res, vec![]);
+                return self.lower_variant_or_leaf(pat, Some(expr), res, vec![], false);
             }
         };
 

--- a/compiler/rustc_mir_build/src/thir/pattern/mod.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/mod.rs
@@ -420,10 +420,10 @@ impl<'tcx, 'ptcx> PatCtxt<'tcx, 'ptcx> {
                 };
                 let variant_def = adt_def.variant_of_res(res);
                 let subpatterns = self.lower_tuple_subpats(pats, variant_def.fields.len(), ddpos);
-                return self.lower_variant_or_leaf(pat, None, res, subpatterns);
+                return self.lower_variant_or_leaf(pat, None, res, subpatterns, false);
             }
 
-            hir::PatKind::Struct(ref qpath, fields, _) => {
+            hir::PatKind::Struct(ref qpath, fields, rest) => {
                 let res = self.typeck_results.qpath_res(qpath, pat.hir_id);
                 let subpatterns = fields
                     .iter()
@@ -437,7 +437,7 @@ impl<'tcx, 'ptcx> PatCtxt<'tcx, 'ptcx> {
                     })
                     .collect();
 
-                return self.lower_variant_or_leaf(pat, None, res, subpatterns);
+                return self.lower_variant_or_leaf(pat, None, res, subpatterns, rest.is_some());
             }
 
             hir::PatKind::Or(pats) => PatKind::Or { pats: self.lower_patterns(pats) },
@@ -507,12 +507,15 @@ impl<'tcx, 'ptcx> PatCtxt<'tcx, 'ptcx> {
         Box::new(Pat { ty, span, kind, extra: None })
     }
 
+    /// If `has_braced_rest` is `true`, `res` is not an enum variant, and there are no `subpatterns`,
+    /// this lowers to [`PatKind::Wild`].
     fn lower_variant_or_leaf(
         &mut self,
         pat: &'tcx hir::Pat<'tcx>,
         expr: Option<&'tcx hir::PatExpr<'tcx>>,
         res: Res,
         subpatterns: Vec<FieldPat<'tcx>>,
+        has_braced_rest: bool,
     ) -> Box<Pat<'tcx>> {
         // Check whether the caller should have provided an `expr` for this pattern kind.
         assert_matches!(
@@ -566,6 +569,8 @@ impl<'tcx, 'ptcx> PatCtxt<'tcx, 'ptcx> {
                     PatKind::Leaf { subpatterns }
                 }
             }
+
+            _ if subpatterns.is_empty() && has_braced_rest => PatKind::Wild,
 
             Res::Def(
                 DefKind::Struct
@@ -645,7 +650,7 @@ impl<'tcx, 'ptcx> PatCtxt<'tcx, 'ptcx> {
             _ => {
                 // The path isn't the name of a constant, so it must actually
                 // be a unit struct or unit variant (e.g. `Option::None`).
-                return self.lower_variant_or_leaf(pat, Some(expr), res, vec![]);
+                return self.lower_variant_or_leaf(pat, Some(expr), res, vec![], false);
             }
         };
 

--- a/compiler/rustc_passes/src/dead.rs
+++ b/compiler/rustc_passes/src/dead.rs
@@ -313,8 +313,13 @@ impl<'tcx> MarkSymbolVisitor<'tcx> {
                 // we will lose the liveness info of `T` cause we cannot mark it live when visiting `foo`.
                 // Related issue: https://github.com/rust-lang/rust/issues/120770
                 self.check_def_id(adt.did());
+
+                if pats.is_empty() {
+                    return;
+                }
                 adt.variant_of_res(res)
             }
+            _ if pats.is_empty() => return,
             _ => span_bug!(lhs.span, "non-ADT in struct pattern"),
         };
         for pat in pats {

--- a/compiler/rustc_privacy/src/lib.rs
+++ b/compiler/rustc_privacy/src/lib.rs
@@ -1103,7 +1103,9 @@ impl<'tcx> Visitor<'tcx> for NamePrivacyVisitor<'tcx> {
     }
 
     fn visit_pat(&mut self, pat: &'tcx hir::Pat<'tcx>) {
-        if let PatKind::Struct(ref qpath, fields, _) = pat.kind {
+        if let PatKind::Struct(ref qpath, fields, _) = pat.kind
+            && !fields.is_empty()
+        {
             let res = self.typeck_results().qpath_res(qpath, pat.hir_id);
             let adt = self.typeck_results().pat_ty(pat).ty_adt_def().unwrap();
             let variant = adt.variant_of_res(res);

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -455,6 +455,8 @@ pub(crate) enum PathSource<'a, 'ast, 'ra> {
     Pat,
     /// Paths in struct expressions and patterns `Path { .. }`.
     Struct(Option<&'a Expr>),
+    /// Paths in patterns matching `Path { .. }` exactly (no fields, with rest pattern).
+    TypeOrEnumVariant,
     /// Paths in tuple struct patterns `Path(..)`.
     TupleStruct(Span, &'ra [Span]),
     /// `m::A::B` in `<T as m::A>::B::C`.
@@ -484,6 +486,7 @@ impl PathSource<'_, '_, '_> {
             PathSource::Type
             | PathSource::Trait(_)
             | PathSource::Struct(_)
+            | PathSource::TypeOrEnumVariant
             | PathSource::DefineOpaques
             | PathSource::Module => TypeNS,
             PathSource::Expr(..)
@@ -504,6 +507,7 @@ impl PathSource<'_, '_, '_> {
             | PathSource::Expr(..)
             | PathSource::Pat
             | PathSource::Struct(_)
+            | PathSource::TypeOrEnumVariant
             | PathSource::TupleStruct(..)
             | PathSource::ReturnTypeNotation => true,
             PathSource::Trait(_)
@@ -524,6 +528,7 @@ impl PathSource<'_, '_, '_> {
             PathSource::Trait(_) => "trait",
             PathSource::Pat => "unit struct, unit variant or constant",
             PathSource::Struct(_) => "struct, variant or union type",
+            PathSource::TypeOrEnumVariant => "type or enum variant",
             PathSource::TraitItem(ValueNS, PathSource::TupleStruct(..))
             | PathSource::TupleStruct(..) => "tuple struct or tuple variant",
             PathSource::TraitItem(ns, _) => match ns {
@@ -636,6 +641,24 @@ impl PathSource<'_, '_, '_> {
                 ) | Res::SelfTyParam { .. }
                     | Res::SelfTyAlias { .. }
             ),
+            PathSource::TypeOrEnumVariant => matches!(
+                res,
+                Res::Def(
+                    DefKind::Struct
+                        | DefKind::Union
+                        | DefKind::Enum
+                        | DefKind::Variant
+                        | DefKind::Trait
+                        | DefKind::TraitAlias
+                        | DefKind::TyAlias
+                        | DefKind::AssocTy
+                        | DefKind::TyParam
+                        | DefKind::ForeignTy,
+                    _,
+                ) | Res::PrimTy(..)
+                    | Res::SelfTyParam { .. }
+                    | Res::SelfTyAlias { .. }
+            ),
             PathSource::TraitItem(ns, _) => match res {
                 Res::Def(DefKind::AssocConst { .. } | DefKind::AssocFn, _) if ns == ValueNS => true,
                 Res::Def(DefKind::AssocTy, _) if ns == TypeNS => true,
@@ -673,8 +696,14 @@ impl PathSource<'_, '_, '_> {
         match (self, has_unexpected_resolution) {
             (PathSource::Trait(_), true) => E0404,
             (PathSource::Trait(_), false) => E0405,
-            (PathSource::Type | PathSource::DefineOpaques, true) => E0573,
-            (PathSource::Type | PathSource::DefineOpaques, false) => E0425,
+            (
+                PathSource::Type | PathSource::DefineOpaques | PathSource::TypeOrEnumVariant,
+                true,
+            ) => E0573,
+            (
+                PathSource::Type | PathSource::DefineOpaques | PathSource::TypeOrEnumVariant,
+                false,
+            ) => E0425,
             (PathSource::Struct(_), true) => E0574,
             (PathSource::Struct(_), false) => E0422,
             (PathSource::Expr(..), true)
@@ -2246,6 +2275,7 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
                 PathSource::Expr(..)
                 | PathSource::Pat
                 | PathSource::Struct(_)
+                | PathSource::TypeOrEnumVariant
                 | PathSource::TupleStruct(..)
                 | PathSource::DefineOpaques
                 | PathSource::Delegation
@@ -4260,8 +4290,14 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
                 PatKind::Path(ref qself, ref path) => {
                     self.smart_resolve_path(pat.id, qself, path, PathSource::Pat);
                 }
-                PatKind::Struct(ref qself, ref path, ref _fields, ref rest) => {
-                    self.smart_resolve_path(pat.id, qself, path, PathSource::Struct(None));
+                PatKind::Struct(ref qself, ref path, ref fields, ref rest) => {
+                    let path_source = if fields.is_empty() && matches!(rest, PatFieldsRest::Rest(_))
+                    {
+                        PathSource::TypeOrEnumVariant
+                    } else {
+                        PathSource::Struct(None)
+                    };
+                    self.smart_resolve_path(pat.id, qself, path, path_source);
                     self.record_patterns_with_skipped_bindings(pat, rest);
                 }
                 PatKind::Or(ref ps) => {

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -439,6 +439,8 @@ pub(crate) enum PathSource<'a, 'ast, 'ra> {
     Pat,
     /// Paths in struct expressions and patterns `Path { .. }`.
     Struct(Option<&'a Expr>),
+    /// Paths in patterns matching `Path { .. }` exactly (no fields, with rest pattern).
+    TypeOrEnumVariant,
     /// Paths in tuple struct patterns `Path(..)`.
     TupleStruct(Span, &'ra [Span]),
     /// `m::A::B` in `<T as m::A>::B::C`.
@@ -468,6 +470,7 @@ impl PathSource<'_, '_, '_> {
             PathSource::Type
             | PathSource::Trait(_)
             | PathSource::Struct(_)
+            | PathSource::TypeOrEnumVariant
             | PathSource::DefineOpaques
             | PathSource::Module => TypeNS,
             PathSource::Expr(..)
@@ -488,6 +491,7 @@ impl PathSource<'_, '_, '_> {
             | PathSource::Expr(..)
             | PathSource::Pat
             | PathSource::Struct(_)
+            | PathSource::TypeOrEnumVariant
             | PathSource::TupleStruct(..)
             | PathSource::ReturnTypeNotation => true,
             PathSource::Trait(_)
@@ -508,6 +512,7 @@ impl PathSource<'_, '_, '_> {
             PathSource::Trait(_) => "trait",
             PathSource::Pat => "unit struct, unit variant or constant",
             PathSource::Struct(_) => "struct, variant or union type",
+            PathSource::TypeOrEnumVariant => "type or enum variant",
             PathSource::TraitItem(ValueNS, PathSource::TupleStruct(..))
             | PathSource::TupleStruct(..) => "tuple struct or tuple variant",
             PathSource::TraitItem(ns, _) => match ns {
@@ -620,6 +625,24 @@ impl PathSource<'_, '_, '_> {
                 ) | Res::SelfTyParam { .. }
                     | Res::SelfTyAlias { .. }
             ),
+            PathSource::TypeOrEnumVariant => matches!(
+                res,
+                Res::Def(
+                    DefKind::Struct
+                        | DefKind::Union
+                        | DefKind::Enum
+                        | DefKind::Variant
+                        | DefKind::Trait
+                        | DefKind::TraitAlias
+                        | DefKind::TyAlias
+                        | DefKind::AssocTy
+                        | DefKind::TyParam
+                        | DefKind::ForeignTy,
+                    _,
+                ) | Res::PrimTy(..)
+                    | Res::SelfTyParam { .. }
+                    | Res::SelfTyAlias { .. }
+            ),
             PathSource::TraitItem(ns, _) => match res {
                 Res::Def(DefKind::AssocConst { .. } | DefKind::AssocFn, _) if ns == ValueNS => true,
                 Res::Def(DefKind::AssocTy, _) if ns == TypeNS => true,
@@ -657,8 +680,14 @@ impl PathSource<'_, '_, '_> {
         match (self, has_unexpected_resolution) {
             (PathSource::Trait(_), true) => E0404,
             (PathSource::Trait(_), false) => E0405,
-            (PathSource::Type | PathSource::DefineOpaques, true) => E0573,
-            (PathSource::Type | PathSource::DefineOpaques, false) => E0425,
+            (
+                PathSource::Type | PathSource::DefineOpaques | PathSource::TypeOrEnumVariant,
+                true,
+            ) => E0573,
+            (
+                PathSource::Type | PathSource::DefineOpaques | PathSource::TypeOrEnumVariant,
+                false,
+            ) => E0425,
             (PathSource::Struct(_), true) => E0574,
             (PathSource::Struct(_), false) => E0422,
             (PathSource::Expr(..), true)
@@ -2219,6 +2248,7 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
                 PathSource::Expr(..)
                 | PathSource::Pat
                 | PathSource::Struct(_)
+                | PathSource::TypeOrEnumVariant
                 | PathSource::TupleStruct(..)
                 | PathSource::DefineOpaques
                 | PathSource::Delegation
@@ -4230,8 +4260,14 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
                 PatKind::Path(ref qself, ref path) => {
                     self.smart_resolve_path(pat.id, qself, path, PathSource::Pat);
                 }
-                PatKind::Struct(ref qself, ref path, ref _fields, ref rest) => {
-                    self.smart_resolve_path(pat.id, qself, path, PathSource::Struct(None));
+                PatKind::Struct(ref qself, ref path, ref fields, ref rest) => {
+                    let path_source = if fields.is_empty() && matches!(rest, PatFieldsRest::Rest(_))
+                    {
+                        PathSource::TypeOrEnumVariant
+                    } else {
+                        PathSource::Struct(None)
+                    };
+                    self.smart_resolve_path(pat.id, qself, path, path_source);
                     self.record_patterns_with_skipped_bindings(pat, rest);
                 }
                 PatKind::Or(ref ps) => {

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -437,9 +437,9 @@ pub(crate) enum PathSource<'a, 'ast, 'ra> {
     Expr(Option<&'ast Expr>),
     /// Paths in path patterns `Path`.
     Pat,
-    /// Paths in struct expressions and patterns `Path { .. }`.
+    /// Paths in struct expressions `Path { .. }`.
     Struct(Option<&'a Expr>),
-    /// Paths in patterns matching `Path { .. }` exactly (no fields, with rest pattern).
+    /// Paths in struct patterns `Path { .. }`.
     TypeOrEnumVariant,
     /// Paths in tuple struct patterns `Path(..)`.
     TupleStruct(Span, &'ra [Span]),
@@ -632,8 +632,6 @@ impl PathSource<'_, '_, '_> {
                         | DefKind::Union
                         | DefKind::Enum
                         | DefKind::Variant
-                        | DefKind::Trait
-                        | DefKind::TraitAlias
                         | DefKind::TyAlias
                         | DefKind::AssocTy
                         | DefKind::TyParam
@@ -4260,13 +4258,8 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
                 PatKind::Path(ref qself, ref path) => {
                     self.smart_resolve_path(pat.id, qself, path, PathSource::Pat);
                 }
-                PatKind::Struct(ref qself, ref path, ref fields, ref rest) => {
-                    let path_source = if fields.is_empty() && matches!(rest, PatFieldsRest::Rest(_))
-                    {
-                        PathSource::TypeOrEnumVariant
-                    } else {
-                        PathSource::Struct(None)
-                    };
+                PatKind::Struct(ref qself, ref path, _, ref rest) => {
+                    let path_source = PathSource::TypeOrEnumVariant;
                     self.smart_resolve_path(pat.id, qself, path, path_source);
                     self.record_patterns_with_skipped_bindings(pat, rest);
                 }

--- a/tests/ui/pattern/box-pattern-constructor-mismatch.rs
+++ b/tests/ui/pattern/box-pattern-constructor-mismatch.rs
@@ -1,11 +1,16 @@
-//! Test that `box _` patterns and `Box { .. }` patterns can't be used to match on the same place.
-//! This is required for the current implementation of exhaustiveness analysis for deref patterns.
+//! `Type { .. }` patterns get translated into wildcards,
+//! so restrictions on mixing deref and non-deref patterns
+//! don't apply to them.
+//! (And you can't name fields of `Box` outside `alloc`.)
+
+//@ run-pass
 
 #![feature(box_patterns)]
 
 fn main() {
     match Box::new(0) {
-        box _ => {} //~ ERROR mix of deref patterns and normal constructors
+        box _ => {}
         Box { .. } => {}
+        //~^ WARN unreachable pattern
     }
 }

--- a/tests/ui/pattern/box-pattern-constructor-mismatch.stderr
+++ b/tests/ui/pattern/box-pattern-constructor-mismatch.stderr
@@ -1,10 +1,12 @@
-error: mix of deref patterns and normal constructors
-  --> $DIR/box-pattern-constructor-mismatch.rs:8:9
+warning: unreachable pattern
+  --> $DIR/box-pattern-constructor-mismatch.rs:13:9
    |
 LL |         box _ => {}
-   |         ^^^^^ matches on the result of dereferencing `Box<i32>`
+   |         ----- matches all the relevant values
 LL |         Box { .. } => {}
-   |         ^^^^^^^^^^ matches directly on `Box<i32>`
+   |         ^^^^^^^^^^ no value can reach this
+   |
+   = note: `#[warn(unreachable_patterns)]` (part of `#[warn(unused)]`) on by default
 
-error: aborting due to 1 previous error
+warning: 1 warning emitted
 

--- a/tests/ui/pattern/deref-pattern-box-constructor-mismatch.rs
+++ b/tests/ui/pattern/deref-pattern-box-constructor-mismatch.rs
@@ -1,12 +1,11 @@
-//! Test that `deref!(_)` patterns and `Box { .. }` patterns can't be used
-//! to match on the same place.
-//! This is required for the current implementation of exhaustiveness analysis for deref patterns.
+//@ run-pass
+//! Test that `Box { .. }` is treated like a wildcard.
 
 #![feature(deref_patterns)]
 
 fn main() {
     match Box::new(0) {
-        deref!(_) => {} //~ ERROR mix of deref patterns and normal constructors
-        Box { .. } => {}
+        deref!(_) => {}
+        Box { .. } => {} //~ WARN unreachable pattern
     }
 }

--- a/tests/ui/pattern/deref-pattern-box-constructor-mismatch.stderr
+++ b/tests/ui/pattern/deref-pattern-box-constructor-mismatch.stderr
@@ -1,10 +1,12 @@
-error: mix of deref patterns and normal constructors
+warning: unreachable pattern
   --> $DIR/deref-pattern-box-constructor-mismatch.rs:9:9
    |
 LL |         deref!(_) => {}
-   |         ^^^^^^^^^ matches on the result of dereferencing `Box<i32>`
+   |         --------- matches all the relevant values
 LL |         Box { .. } => {}
-   |         ^^^^^^^^^^ matches directly on `Box<i32>`
+   |         ^^^^^^^^^^ no value can reach this
+   |
+   = note: `#[warn(unreachable_patterns)]` (part of `#[warn(unused)]`) on by default
 
-error: aborting due to 1 previous error
+warning: 1 warning emitted
 

--- a/tests/ui/pattern/non-struct-struct-patterns-err.rs
+++ b/tests/ui/pattern/non-struct-struct-patterns-err.rs
@@ -1,0 +1,70 @@
+//@ edition: 2024
+
+fn main() {
+    let mut x = 0;
+
+    match 3_i32 {
+        u64 { .. } => x += 1,
+        //~^ ERROR mismatched types
+    }
+
+    match "hello world" {
+        char { .. } => x += 1,
+        //~^ ERROR mismatched types
+    }
+
+    type Unit = ();
+
+    match (false,) {
+        Unit { .. } => x += 1,
+        //~^ ERROR mismatched types
+    }
+
+    match &3_i32 {
+        &&&&i32 { .. } => x += 1,
+        //~^ ERROR mismatched types
+    }
+
+    match Some(false) {
+        Result { .. } => x += 1,
+        //~^ ERROR mismatched types
+    }
+
+    fn foo<T, U>(input: T, input_2: U, x: &mut usize) {
+        match input {
+            U { .. } => *x += 1,
+            //~^ ERROR mismatched types
+        }
+
+        match input_2 {
+            T { .. } => *x += 1,
+            //~^ ERROR mismatched types
+        }
+    }
+
+    foo(&&(18, 32, false, "abcdefg"), true, &mut x);
+
+    trait Trait {
+        type Assoc;
+
+        fn method(&self, assoc: Self::Assoc, x: &mut usize) {
+            match self {
+                Self::Assoc { .. } => *x += 1,
+                //~^ ERROR mismatched types
+            }
+
+            match assoc {
+                Self { .. } => *x += 1,
+                //~^ ERROR mismatched types
+            }
+        }
+    }
+
+    impl Trait for (u64,) {
+        type Assoc = [f32; 17];
+    }
+
+    (73_u64,).method([4.2; 17], &mut x);
+
+    assert_eq!(x, 10);
+}

--- a/tests/ui/pattern/non-struct-struct-patterns-err.stderr
+++ b/tests/ui/pattern/non-struct-struct-patterns-err.stderr
@@ -1,0 +1,117 @@
+error[E0308]: mismatched types
+  --> $DIR/non-struct-struct-patterns-err.rs:7:9
+   |
+LL |     match 3_i32 {
+   |           ----- this expression has type `i32`
+LL |         u64 { .. } => x += 1,
+   |         ^^^^^^^^^^ expected `i32`, found `u64`
+
+error[E0308]: mismatched types
+  --> $DIR/non-struct-struct-patterns-err.rs:12:9
+   |
+LL |     match "hello world" {
+   |           ------------- this expression has type `&str`
+LL |         char { .. } => x += 1,
+   |         ^^^^^^^^^^^ expected `str`, found `char`
+
+error[E0308]: mismatched types
+  --> $DIR/non-struct-struct-patterns-err.rs:19:9
+   |
+LL |     match (false,) {
+   |           -------- this expression has type `(bool,)`
+LL |         Unit { .. } => x += 1,
+   |         ^^^^^^^^^^^ expected `(bool,)`, found `()`
+   |
+   = note:  expected tuple `(bool,)`
+           found unit type `()`
+
+error[E0308]: mismatched types
+  --> $DIR/non-struct-struct-patterns-err.rs:24:10
+   |
+LL |     match &3_i32 {
+   |           ------ this expression has type `&i32`
+LL |         &&&&i32 { .. } => x += 1,
+   |          ^^^^^^^^^^^^^ expected `i32`, found `&_`
+   |
+   = note:   expected type `i32`
+           found reference `&_`
+
+error[E0308]: mismatched types
+  --> $DIR/non-struct-struct-patterns-err.rs:29:9
+   |
+LL |     match Some(false) {
+   |           ----------- this expression has type `Option<bool>`
+LL |         Result { .. } => x += 1,
+   |         ^^^^^^^^^^^^^ expected `Option<bool>`, found `Result<_, _>`
+   |
+   = note: expected enum `Option<bool>`
+              found enum `Result<_, _>`
+
+error[E0308]: mismatched types
+  --> $DIR/non-struct-struct-patterns-err.rs:35:13
+   |
+LL |     fn foo<T, U>(input: T, input_2: U, x: &mut usize) {
+   |            -  - found type parameter
+   |            |
+   |            expected type parameter
+LL |         match input {
+   |               ----- this expression has type `T`
+LL |             U { .. } => *x += 1,
+   |             ^^^^^^^^ expected type parameter `T`, found type parameter `U`
+   |
+   = note: expected type parameter `T`
+              found type parameter `U`
+   = note: a type parameter was expected, but a different one was found; you might be missing a type parameter or trait bound
+   = note: for more information, visit https://doc.rust-lang.org/book/ch10-02-traits.html#traits-as-parameters
+
+error[E0308]: mismatched types
+  --> $DIR/non-struct-struct-patterns-err.rs:40:13
+   |
+LL |     fn foo<T, U>(input: T, input_2: U, x: &mut usize) {
+   |            -  - expected type parameter
+   |            |
+   |            found type parameter
+...
+LL |         match input_2 {
+   |               ------- this expression has type `U`
+LL |             T { .. } => *x += 1,
+   |             ^^^^^^^^ expected type parameter `U`, found type parameter `T`
+   |
+   = note: expected type parameter `U`
+              found type parameter `T`
+   = note: a type parameter was expected, but a different one was found; you might be missing a type parameter or trait bound
+   = note: for more information, visit https://doc.rust-lang.org/book/ch10-02-traits.html#traits-as-parameters
+
+error[E0308]: mismatched types
+  --> $DIR/non-struct-struct-patterns-err.rs:52:17
+   |
+LL |     trait Trait {
+   |     ----------- expected this type parameter
+...
+LL |             match self {
+   |                   ---- this expression has type `&Self`
+LL |                 Self::Assoc { .. } => *x += 1,
+   |                 ^^^^^^^^^^^^^^^^^^ expected type parameter `Self`, found associated type
+   |
+   = note: expected type parameter `Self`
+             found associated type `<Self as main::Trait>::Assoc`
+   = note: you might be missing a type parameter or trait bound
+
+error[E0308]: mismatched types
+  --> $DIR/non-struct-struct-patterns-err.rs:57:17
+   |
+LL |     trait Trait {
+   |     ----------- found this type parameter
+...
+LL |             match assoc {
+   |                   ----- this expression has type `<Self as main::Trait>::Assoc`
+LL |                 Self { .. } => *x += 1,
+   |                 ^^^^^^^^^^^ expected associated type, found type parameter `Self`
+   |
+   = note: expected associated type `<Self as main::Trait>::Assoc`
+               found type parameter `Self`
+   = note: you might be missing a type parameter or trait bound
+
+error: aborting due to 9 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/pattern/non-struct-struct-patterns.rs
+++ b/tests/ui/pattern/non-struct-struct-patterns.rs
@@ -1,0 +1,68 @@
+//@ run-pass
+//@ edition: 2024
+
+fn main() {
+    let mut x = 0;
+
+    match 3_i32 {
+        i32 { .. } => x += 1,
+    }
+
+    match "hello world" {
+        str { .. } => x += 1,
+    }
+
+    type Unit = ();
+
+    match () {
+        Unit { .. } => x += 1,
+    }
+
+    match &3_i32 {
+        &i32 { .. } => x += 1,
+    }
+
+    match &3_i32 {
+        i32 { .. } => x += 1,
+    }
+
+    type Foo = dyn Send;
+    let a: &Foo = &3_i32;
+    match a {
+        &Foo { .. } => x += 1,
+    }
+
+    match Some(false) {
+        Option { .. } => x += 1,
+    }
+
+    fn foo<T>(input: T, x: &mut usize) {
+        match input {
+            T { .. } => *x += 1,
+        }
+    }
+
+    foo(&&(18, 32, false, "abcdefg"), &mut x);
+
+    trait Trait {
+        type Assoc;
+
+        fn method(&self, assoc: Self::Assoc, x: &mut usize) {
+            match self {
+                Self { .. } => *x += 1,
+            }
+
+            match assoc {
+                Self::Assoc { .. } => *x += 1,
+            }
+        }
+    }
+
+    impl Trait for (u64,) {
+        type Assoc = [f32; 17];
+    }
+
+    (73_u64,).method([4.2; 17], &mut x);
+
+    assert_eq!(x, 10);
+}

--- a/tests/ui/pattern/non-struct-struct-patterns.rs
+++ b/tests/ui/pattern/non-struct-struct-patterns.rs
@@ -36,6 +36,25 @@ fn main() {
         Option { .. } => x += 1,
     }
 
+    match Some(false) {
+        Option::<bool> { .. } => x += 1,
+    }
+
+    match Some(false) {
+        Option::Some { .. } => x += 1,
+        _ => panic!(),
+    }
+
+    match Some(false) {
+        Option::<bool>::Some { .. } => x += 1,
+        _ => panic!(),
+    }
+
+    match Some(false) {
+        Option::Some::<bool> { .. } => x += 1,
+        _ => panic!(),
+    }
+
     fn foo<T>(input: T, x: &mut usize) {
         match input {
             T { .. } => *x += 1,
@@ -64,5 +83,5 @@ fn main() {
 
     (73_u64,).method([4.2; 17], &mut x);
 
-    assert_eq!(x, 10);
+    assert_eq!(x, 14);
 }

--- a/tests/ui/pattern/self-ctor-133272.rs
+++ b/tests/ui/pattern/self-ctor-133272.rs
@@ -16,6 +16,6 @@ impl Foo {
     fn fun() {
         let S { ref Self } = todo!();
         //~^ ERROR expected identifier, found keyword `Self`
-        //~| ERROR cannot find struct, variant or union type `S` in this scope
+        //~| ERROR cannot find type or enum variant `S` in this scope
     }
 }

--- a/tests/ui/pattern/self-ctor-133272.stderr
+++ b/tests/ui/pattern/self-ctor-133272.stderr
@@ -6,7 +6,7 @@ LL |         let S { ref Self } = todo!();
    |             |
    |             while parsing the fields for this pattern
 
-error[E0422]: cannot find struct, variant or union type `S` in this scope
+error[E0425]: cannot find type or enum variant `S` in this scope
   --> $DIR/self-ctor-133272.rs:17:13
    |
 LL |         let S { ref Self } = todo!();
@@ -14,4 +14,4 @@ LL |         let S { ref Self } = todo!();
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0422`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/pattern/struct-pattern-on-non-struct-resolve-error.rs
+++ b/tests/ui/pattern/struct-pattern-on-non-struct-resolve-error.rs
@@ -3,7 +3,6 @@
 fn main() {
     if let <Vec<()> as Iterator>::Item { .. } = 1 {
         //~^ ERROR E0658
-        //~| ERROR E0071
         //~| ERROR E0277
         x //~ ERROR E0425
     }

--- a/tests/ui/pattern/struct-pattern-on-non-struct-resolve-error.stderr
+++ b/tests/ui/pattern/struct-pattern-on-non-struct-resolve-error.stderr
@@ -1,5 +1,5 @@
 error[E0425]: cannot find value `x` in this scope
-  --> $DIR/struct-pattern-on-non-struct-resolve-error.rs:8:9
+  --> $DIR/struct-pattern-on-non-struct-resolve-error.rs:7:9
    |
 LL |         x
    |         ^ not found in this scope
@@ -14,12 +14,6 @@ LL |     if let <Vec<()> as Iterator>::Item { .. } = 1 {
    = help: add `#![feature(more_qualified_paths)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0071]: expected struct, variant or union type, found inferred type
-  --> $DIR/struct-pattern-on-non-struct-resolve-error.rs:4:12
-   |
-LL |     if let <Vec<()> as Iterator>::Item { .. } = 1 {
-   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^ not a struct
-
 error[E0277]: `Vec<()>` is not an iterator
   --> $DIR/struct-pattern-on-non-struct-resolve-error.rs:4:12
    |
@@ -28,7 +22,7 @@ LL |     if let <Vec<()> as Iterator>::Item { .. } = 1 {
    |
    = help: the trait `Iterator` is not implemented for `Vec<()>`
 
-error: aborting due to 4 previous errors
+error: aborting due to 3 previous errors
 
-Some errors have detailed explanations: E0071, E0277, E0425, E0658.
-For more information about an error, try `rustc --explain E0071`.
+Some errors have detailed explanations: E0277, E0425, E0658.
+For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/pattern/struct_pattern_on_tuple_enum.rs
+++ b/tests/ui/pattern/struct_pattern_on_tuple_enum.rs
@@ -5,6 +5,6 @@ enum Foo {
 
 fn main() {
     match Foo::Bar(1) {
-        Foo { i } => () //~ ERROR expected struct, variant or union type, found enum `Foo`
+        Foo { i } => () //~ ERROR expected struct, variant or union type, found `Foo`
     }
 }

--- a/tests/ui/pattern/struct_pattern_on_tuple_enum.stderr
+++ b/tests/ui/pattern/struct_pattern_on_tuple_enum.stderr
@@ -1,9 +1,9 @@
-error[E0574]: expected struct, variant or union type, found enum `Foo`
+error[E0071]: expected struct, variant or union type, found `Foo`
   --> $DIR/struct_pattern_on_tuple_enum.rs:8:9
    |
 LL |         Foo { i } => ()
-   |         ^^^ not a struct, variant or union type
+   |         ^^^ not a struct
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0574`.
+For more information about this error, try `rustc --explain E0071`.

--- a/tests/ui/pin-ergonomics/pattern-matching-mix-deref-pattern.both.stderr
+++ b/tests/ui/pin-ergonomics/pattern-matching-mix-deref-pattern.both.stderr
@@ -1,11 +1,11 @@
 error: cannot project on type that is not `#[pin_v2]`
-  --> $DIR/pattern-matching-mix-deref-pattern.rs:121:9
+  --> $DIR/pattern-matching-mix-deref-pattern.rs:108:9
    |
 LL |     let NonPinProject { x } = foo;
    |         ^^^^^^^^^^^^^^^^^^^
    |
 note: type defined here
-  --> $DIR/pattern-matching-mix-deref-pattern.rs:28:1
+  --> $DIR/pattern-matching-mix-deref-pattern.rs:27:1
    |
 LL | struct NonPinProject<T> {
    | ^^^^^^^^^^^^^^^^^^^^^^^
@@ -16,13 +16,13 @@ LL | struct NonPinProject<T> {
    |
 
 error: cannot project on type that is not `#[pin_v2]`
-  --> $DIR/pattern-matching-mix-deref-pattern.rs:125:9
+  --> $DIR/pattern-matching-mix-deref-pattern.rs:113:9
    |
 LL |     let NonPinProject { x } = bar;
    |         ^^^^^^^^^^^^^^^^^^^
    |
 note: type defined here
-  --> $DIR/pattern-matching-mix-deref-pattern.rs:28:1
+  --> $DIR/pattern-matching-mix-deref-pattern.rs:27:1
    |
 LL | struct NonPinProject<T> {
    | ^^^^^^^^^^^^^^^^^^^^^^^
@@ -33,13 +33,13 @@ LL | struct NonPinProject<T> {
    |
 
 error: cannot project on type that is not `#[pin_v2]`
-  --> $DIR/pattern-matching-mix-deref-pattern.rs:131:9
+  --> $DIR/pattern-matching-mix-deref-pattern.rs:121:9
    |
 LL |         NonPinProject { x } => {}
    |         ^^^^^^^^^^^^^^^^^^^
    |
 note: type defined here
-  --> $DIR/pattern-matching-mix-deref-pattern.rs:28:1
+  --> $DIR/pattern-matching-mix-deref-pattern.rs:27:1
    |
 LL | struct NonPinProject<T> {
    | ^^^^^^^^^^^^^^^^^^^^^^^
@@ -50,13 +50,13 @@ LL | struct NonPinProject<T> {
    |
 
 error: cannot project on type that is not `#[pin_v2]`
-  --> $DIR/pattern-matching-mix-deref-pattern.rs:139:9
+  --> $DIR/pattern-matching-mix-deref-pattern.rs:129:9
    |
 LL |         NonPinProject { x } => {}
    |         ^^^^^^^^^^^^^^^^^^^
    |
 note: type defined here
-  --> $DIR/pattern-matching-mix-deref-pattern.rs:28:1
+  --> $DIR/pattern-matching-mix-deref-pattern.rs:27:1
    |
 LL | struct NonPinProject<T> {
    | ^^^^^^^^^^^^^^^^^^^^^^^
@@ -66,77 +66,5 @@ LL + #[pin_v2]
 LL | struct NonPinProject<T> {
    |
 
-error: mix of deref patterns and normal constructors
-  --> $DIR/pattern-matching-mix-deref-pattern.rs:37:9
-   |
-LL |         Foo { x, y } => {}
-   |         ^^^^^^^^^^^^ matches on the result of dereferencing `Pin<&mut Foo<T, U>>`
-...
-LL |         Pin { .. } => {}
-   |         ^^^^^^^^^^ matches directly on `Pin<&mut Foo<T, U>>`
-
-error: mix of deref patterns and normal constructors
-  --> $DIR/pattern-matching-mix-deref-pattern.rs:45:9
-   |
-LL |         Foo { x, y } => {}
-   |         ^^^^^^^^^^^^ matches on the result of dereferencing `Pin<&mut Foo<T, U>>`
-...
-LL |         Pin { .. } => {}
-   |         ^^^^^^^^^^ matches directly on `Pin<&mut Foo<T, U>>`
-
-error: mix of deref patterns and normal constructors
-  --> $DIR/pattern-matching-mix-deref-pattern.rs:59:9
-   |
-LL |         Foo { x, y } => {}
-   |         ^^^^^^^^^^^^ matches on the result of dereferencing `Pin<&Foo<T, U>>`
-...
-LL |         Pin { .. } => {}
-   |         ^^^^^^^^^^ matches directly on `Pin<&Foo<T, U>>`
-
-error: mix of deref patterns and normal constructors
-  --> $DIR/pattern-matching-mix-deref-pattern.rs:67:9
-   |
-LL |         Foo { x, y } => {}
-   |         ^^^^^^^^^^^^ matches on the result of dereferencing `Pin<&Foo<T, U>>`
-...
-LL |         Pin { .. } => {}
-   |         ^^^^^^^^^^ matches directly on `Pin<&Foo<T, U>>`
-
-error: mix of deref patterns and normal constructors
-  --> $DIR/pattern-matching-mix-deref-pattern.rs:81:9
-   |
-LL |         Bar(x, y) => {}
-   |         ^^^^^^^^^ matches on the result of dereferencing `Pin<&mut Bar<T, U>>`
-...
-LL |         Pin { .. } => {}
-   |         ^^^^^^^^^^ matches directly on `Pin<&mut Bar<T, U>>`
-
-error: mix of deref patterns and normal constructors
-  --> $DIR/pattern-matching-mix-deref-pattern.rs:89:9
-   |
-LL |         Bar(x, y) => {}
-   |         ^^^^^^^^^ matches on the result of dereferencing `Pin<&mut Bar<T, U>>`
-...
-LL |         Pin { .. } => {}
-   |         ^^^^^^^^^^ matches directly on `Pin<&mut Bar<T, U>>`
-
-error: mix of deref patterns and normal constructors
-  --> $DIR/pattern-matching-mix-deref-pattern.rs:103:9
-   |
-LL |         Bar(x, y) => {}
-   |         ^^^^^^^^^ matches on the result of dereferencing `Pin<&Bar<T, U>>`
-...
-LL |         Pin { .. } => {}
-   |         ^^^^^^^^^^ matches directly on `Pin<&Bar<T, U>>`
-
-error: mix of deref patterns and normal constructors
-  --> $DIR/pattern-matching-mix-deref-pattern.rs:111:9
-   |
-LL |         Bar(x, y) => {}
-   |         ^^^^^^^^^ matches on the result of dereferencing `Pin<&Bar<T, U>>`
-...
-LL |         Pin { .. } => {}
-   |         ^^^^^^^^^^ matches directly on `Pin<&Bar<T, U>>`
-
-error: aborting due to 12 previous errors
+error: aborting due to 4 previous errors
 

--- a/tests/ui/pin-ergonomics/pattern-matching-mix-deref-pattern.deref_patterns.stderr
+++ b/tests/ui/pin-ergonomics/pattern-matching-mix-deref-pattern.deref_patterns.stderr
@@ -1,92 +1,293 @@
-error: mix of deref patterns and normal constructors
-  --> $DIR/pattern-matching-mix-deref-pattern.rs:37:9
+error[E0507]: cannot move out of a shared reference
+  --> $DIR/pattern-matching-mix-deref-pattern.rs:42:22
    |
+LL |     let _ = || match foo.as_mut() {
+   |                      ^^^^^^^^^^^^
+LL |
 LL |         Foo { x, y } => {}
-   |         ^^^^^^^^^^^^ matches on the result of dereferencing `Pin<&mut Foo<T, U>>`
-...
-LL |         Pin { .. } => {}
-   |         ^^^^^^^^^^ matches directly on `Pin<&mut Foo<T, U>>`
-
-error: mix of deref patterns and normal constructors
-  --> $DIR/pattern-matching-mix-deref-pattern.rs:45:9
+   |               -  - ...and here
+   |               |
+   |               data moved here
    |
+   = note: move occurs because these variables have types that don't implement the `Copy` trait
+help: consider borrowing the pattern binding
+   |
+LL |         Foo { ref x, y } => {}
+   |               +++
+help: consider borrowing the pattern binding
+   |
+LL |         Foo { x, ref y } => {}
+   |                  +++
+
+error[E0507]: cannot move out of a shared reference
+  --> $DIR/pattern-matching-mix-deref-pattern.rs:32:24
+   |
+LL |     let Foo { x, y } = foo.as_mut();
+   |               -  -     ^^^^^^^^^^^^
+   |               |  |
+   |               |  ...and here
+   |               data moved here
+   |
+   = note: move occurs because these variables have types that don't implement the `Copy` trait
+help: consider borrowing the pattern binding
+   |
+LL |     let Foo { ref x, y } = foo.as_mut();
+   |               +++
+help: consider borrowing the pattern binding
+   |
+LL |     let Foo { x, ref y } = foo.as_mut();
+   |                  +++
+
+error[E0507]: cannot move out of a shared reference
+  --> $DIR/pattern-matching-mix-deref-pattern.rs:36:11
+   |
+LL |     match foo.as_mut() {
+   |           ^^^^^^^^^^^^
+LL |
 LL |         Foo { x, y } => {}
-   |         ^^^^^^^^^^^^ matches on the result of dereferencing `Pin<&mut Foo<T, U>>`
-...
-LL |         Pin { .. } => {}
-   |         ^^^^^^^^^^ matches directly on `Pin<&mut Foo<T, U>>`
-
-error: mix of deref patterns and normal constructors
-  --> $DIR/pattern-matching-mix-deref-pattern.rs:59:9
+   |               -  - ...and here
+   |               |
+   |               data moved here
    |
+   = note: move occurs because these variables have types that don't implement the `Copy` trait
+help: consider borrowing the pattern binding
+   |
+LL |         Foo { ref x, y } => {}
+   |               +++
+help: consider borrowing the pattern binding
+   |
+LL |         Foo { x, ref y } => {}
+   |                  +++
+
+error[E0507]: cannot move out of a shared reference
+  --> $DIR/pattern-matching-mix-deref-pattern.rs:61:22
+   |
+LL |     let _ = || match foo {
+   |                      ^^^
+LL |
 LL |         Foo { x, y } => {}
-   |         ^^^^^^^^^^^^ matches on the result of dereferencing `Pin<&Foo<T, U>>`
-...
-LL |         Pin { .. } => {}
-   |         ^^^^^^^^^^ matches directly on `Pin<&Foo<T, U>>`
-
-error: mix of deref patterns and normal constructors
-  --> $DIR/pattern-matching-mix-deref-pattern.rs:67:9
+   |               -  - ...and here
+   |               |
+   |               data moved here
    |
+   = note: move occurs because these variables have types that don't implement the `Copy` trait
+help: consider borrowing here
+   |
+LL |     let _ = || match &foo {
+   |                      +
+
+error[E0507]: cannot move out of a shared reference
+  --> $DIR/pattern-matching-mix-deref-pattern.rs:51:24
+   |
+LL |     let Foo { x, y } = foo;
+   |               -  -     ^^^
+   |               |  |
+   |               |  ...and here
+   |               data moved here
+   |
+   = note: move occurs because these variables have types that don't implement the `Copy` trait
+help: consider borrowing the pattern binding
+   |
+LL |     let Foo { ref x, y } = foo;
+   |               +++
+help: consider borrowing the pattern binding
+   |
+LL |     let Foo { x, ref y } = foo;
+   |                  +++
+
+error[E0507]: cannot move out of a shared reference
+  --> $DIR/pattern-matching-mix-deref-pattern.rs:55:11
+   |
+LL |     match foo {
+   |           ^^^
+LL |
 LL |         Foo { x, y } => {}
-   |         ^^^^^^^^^^^^ matches on the result of dereferencing `Pin<&Foo<T, U>>`
-...
-LL |         Pin { .. } => {}
-   |         ^^^^^^^^^^ matches directly on `Pin<&Foo<T, U>>`
-
-error: mix of deref patterns and normal constructors
-  --> $DIR/pattern-matching-mix-deref-pattern.rs:81:9
+   |               -  - ...and here
+   |               |
+   |               data moved here
    |
+   = note: move occurs because these variables have types that don't implement the `Copy` trait
+help: consider borrowing the pattern binding
+   |
+LL |         Foo { ref x, y } => {}
+   |               +++
+help: consider borrowing the pattern binding
+   |
+LL |         Foo { x, ref y } => {}
+   |                  +++
+
+error[E0507]: cannot move out of a shared reference
+  --> $DIR/pattern-matching-mix-deref-pattern.rs:80:22
+   |
+LL |     let _ = || match bar.as_mut() {
+   |                      ^^^^^^^^^^^^
+LL |
 LL |         Bar(x, y) => {}
-   |         ^^^^^^^^^ matches on the result of dereferencing `Pin<&mut Bar<T, U>>`
-...
-LL |         Pin { .. } => {}
-   |         ^^^^^^^^^^ matches directly on `Pin<&mut Bar<T, U>>`
-
-error: mix of deref patterns and normal constructors
-  --> $DIR/pattern-matching-mix-deref-pattern.rs:89:9
+   |             -  - ...and here
+   |             |
+   |             data moved here
    |
+   = note: move occurs because these variables have types that don't implement the `Copy` trait
+help: consider borrowing the pattern binding
+   |
+LL |         Bar(ref x, y) => {}
+   |             +++
+help: consider borrowing the pattern binding
+   |
+LL |         Bar(x, ref y) => {}
+   |                +++
+
+error[E0507]: cannot move out of a shared reference
+  --> $DIR/pattern-matching-mix-deref-pattern.rs:70:21
+   |
+LL |     let Bar(x, y) = bar.as_mut();
+   |             -  -    ^^^^^^^^^^^^
+   |             |  |
+   |             |  ...and here
+   |             data moved here
+   |
+   = note: move occurs because these variables have types that don't implement the `Copy` trait
+help: consider borrowing the pattern binding
+   |
+LL |     let Bar(ref x, y) = bar.as_mut();
+   |             +++
+help: consider borrowing the pattern binding
+   |
+LL |     let Bar(x, ref y) = bar.as_mut();
+   |                +++
+
+error[E0507]: cannot move out of a shared reference
+  --> $DIR/pattern-matching-mix-deref-pattern.rs:74:11
+   |
+LL |     match bar.as_mut() {
+   |           ^^^^^^^^^^^^
+LL |
 LL |         Bar(x, y) => {}
-   |         ^^^^^^^^^ matches on the result of dereferencing `Pin<&mut Bar<T, U>>`
-...
-LL |         Pin { .. } => {}
-   |         ^^^^^^^^^^ matches directly on `Pin<&mut Bar<T, U>>`
-
-error: mix of deref patterns and normal constructors
-  --> $DIR/pattern-matching-mix-deref-pattern.rs:103:9
+   |             -  - ...and here
+   |             |
+   |             data moved here
    |
+   = note: move occurs because these variables have types that don't implement the `Copy` trait
+help: consider borrowing the pattern binding
+   |
+LL |         Bar(ref x, y) => {}
+   |             +++
+help: consider borrowing the pattern binding
+   |
+LL |         Bar(x, ref y) => {}
+   |                +++
+
+error[E0507]: cannot move out of a shared reference
+  --> $DIR/pattern-matching-mix-deref-pattern.rs:99:22
+   |
+LL |     let _ = || match bar {
+   |                      ^^^
+LL |
 LL |         Bar(x, y) => {}
-   |         ^^^^^^^^^ matches on the result of dereferencing `Pin<&Bar<T, U>>`
-...
-LL |         Pin { .. } => {}
-   |         ^^^^^^^^^^ matches directly on `Pin<&Bar<T, U>>`
-
-error: mix of deref patterns and normal constructors
-  --> $DIR/pattern-matching-mix-deref-pattern.rs:111:9
+   |             -  - ...and here
+   |             |
+   |             data moved here
    |
+   = note: move occurs because these variables have types that don't implement the `Copy` trait
+help: consider borrowing here
+   |
+LL |     let _ = || match &bar {
+   |                      +
+
+error[E0507]: cannot move out of a shared reference
+  --> $DIR/pattern-matching-mix-deref-pattern.rs:89:21
+   |
+LL |     let Bar(x, y) = bar;
+   |             -  -    ^^^
+   |             |  |
+   |             |  ...and here
+   |             data moved here
+   |
+   = note: move occurs because these variables have types that don't implement the `Copy` trait
+help: consider borrowing the pattern binding
+   |
+LL |     let Bar(ref x, y) = bar;
+   |             +++
+help: consider borrowing the pattern binding
+   |
+LL |     let Bar(x, ref y) = bar;
+   |                +++
+
+error[E0507]: cannot move out of a shared reference
+  --> $DIR/pattern-matching-mix-deref-pattern.rs:93:11
+   |
+LL |     match bar {
+   |           ^^^
+LL |
 LL |         Bar(x, y) => {}
-   |         ^^^^^^^^^ matches on the result of dereferencing `Pin<&Bar<T, U>>`
-...
-LL |         Pin { .. } => {}
-   |         ^^^^^^^^^^ matches directly on `Pin<&Bar<T, U>>`
-
-error: mix of deref patterns and normal constructors
-  --> $DIR/pattern-matching-mix-deref-pattern.rs:131:9
+   |             -  - ...and here
+   |             |
+   |             data moved here
    |
+   = note: move occurs because these variables have types that don't implement the `Copy` trait
+help: consider borrowing the pattern binding
+   |
+LL |         Bar(ref x, y) => {}
+   |             +++
+help: consider borrowing the pattern binding
+   |
+LL |         Bar(x, ref y) => {}
+   |                +++
+
+error[E0507]: cannot move out of a shared reference
+  --> $DIR/pattern-matching-mix-deref-pattern.rs:108:31
+   |
+LL |     let NonPinProject { x } = foo;
+   |                         -     ^^^
+   |                         |
+   |                         data moved here because `x` has type `T`, which does not implement the `Copy` trait
+   |
+help: consider borrowing the pattern binding
+   |
+LL |     let NonPinProject { ref x } = foo;
+   |                         +++
+
+error[E0507]: cannot move out of a shared reference
+  --> $DIR/pattern-matching-mix-deref-pattern.rs:113:31
+   |
+LL |     let NonPinProject { x } = bar;
+   |                         -     ^^^
+   |                         |
+   |                         data moved here because `x` has type `U`, which does not implement the `Copy` trait
+   |
+help: consider borrowing the pattern binding
+   |
+LL |     let NonPinProject { ref x } = bar;
+   |                         +++
+
+error[E0507]: cannot move out of a shared reference
+  --> $DIR/pattern-matching-mix-deref-pattern.rs:119:11
+   |
+LL |     match foo {
+   |           ^^^
+LL |
 LL |         NonPinProject { x } => {}
-   |         ^^^^^^^^^^^^^^^^^^^ matches on the result of dereferencing `Pin<&mut NonPinProject<T>>`
-...
-LL |         Pin { .. } => {}
-   |         ^^^^^^^^^^ matches directly on `Pin<&mut NonPinProject<T>>`
-
-error: mix of deref patterns and normal constructors
-  --> $DIR/pattern-matching-mix-deref-pattern.rs:139:9
+   |                         - data moved here because `x` has type `T`, which does not implement the `Copy` trait
    |
+help: consider borrowing the pattern binding
+   |
+LL |         NonPinProject { ref x } => {}
+   |                         +++
+
+error[E0507]: cannot move out of a shared reference
+  --> $DIR/pattern-matching-mix-deref-pattern.rs:127:11
+   |
+LL |     match bar {
+   |           ^^^
+LL |
 LL |         NonPinProject { x } => {}
-   |         ^^^^^^^^^^^^^^^^^^^ matches on the result of dereferencing `Pin<&NonPinProject<U>>`
-...
-LL |         Pin { .. } => {}
-   |         ^^^^^^^^^^ matches directly on `Pin<&NonPinProject<U>>`
+   |                         - data moved here because `x` has type `U`, which does not implement the `Copy` trait
+   |
+help: consider borrowing the pattern binding
+   |
+LL |         NonPinProject { ref x } => {}
+   |                         +++
 
-error: aborting due to 10 previous errors
+error: aborting due to 16 previous errors
 
+For more information about this error, try `rustc --explain E0507`.

--- a/tests/ui/pin-ergonomics/pattern-matching-mix-deref-pattern.deref_patterns.stderr
+++ b/tests/ui/pin-ergonomics/pattern-matching-mix-deref-pattern.deref_patterns.stderr
@@ -1,25 +1,4 @@
 error[E0507]: cannot move out of a shared reference
-  --> $DIR/pattern-matching-mix-deref-pattern.rs:42:22
-   |
-LL |     let _ = || match foo.as_mut() {
-   |                      ^^^^^^^^^^^^
-LL |
-LL |         Foo { x, y } => {}
-   |               -  - ...and here
-   |               |
-   |               data moved here
-   |
-   = note: move occurs because these variables have types that don't implement the `Copy` trait
-help: consider borrowing the pattern binding
-   |
-LL |         Foo { ref x, y } => {}
-   |               +++
-help: consider borrowing the pattern binding
-   |
-LL |         Foo { x, ref y } => {}
-   |                  +++
-
-error[E0507]: cannot move out of a shared reference
   --> $DIR/pattern-matching-mix-deref-pattern.rs:32:24
    |
 LL |     let Foo { x, y } = foo.as_mut();
@@ -60,10 +39,10 @@ LL |         Foo { x, ref y } => {}
    |                  +++
 
 error[E0507]: cannot move out of a shared reference
-  --> $DIR/pattern-matching-mix-deref-pattern.rs:61:22
+  --> $DIR/pattern-matching-mix-deref-pattern.rs:42:22
    |
-LL |     let _ = || match foo {
-   |                      ^^^
+LL |     let _ = || match foo.as_mut() {
+   |                      ^^^^^^^^^^^^
 LL |
 LL |         Foo { x, y } => {}
    |               -  - ...and here
@@ -71,10 +50,14 @@ LL |         Foo { x, y } => {}
    |               data moved here
    |
    = note: move occurs because these variables have types that don't implement the `Copy` trait
-help: consider borrowing here
+help: consider borrowing the pattern binding
    |
-LL |     let _ = || match &foo {
-   |                      +
+LL |         Foo { ref x, y } => {}
+   |               +++
+help: consider borrowing the pattern binding
+   |
+LL |         Foo { x, ref y } => {}
+   |                  +++
 
 error[E0507]: cannot move out of a shared reference
   --> $DIR/pattern-matching-mix-deref-pattern.rs:51:24
@@ -117,25 +100,21 @@ LL |         Foo { x, ref y } => {}
    |                  +++
 
 error[E0507]: cannot move out of a shared reference
-  --> $DIR/pattern-matching-mix-deref-pattern.rs:80:22
+  --> $DIR/pattern-matching-mix-deref-pattern.rs:61:22
    |
-LL |     let _ = || match bar.as_mut() {
-   |                      ^^^^^^^^^^^^
+LL |     let _ = || match foo {
+   |                      ^^^
 LL |
-LL |         Bar(x, y) => {}
-   |             -  - ...and here
-   |             |
-   |             data moved here
+LL |         Foo { x, y } => {}
+   |               -  - ...and here
+   |               |
+   |               data moved here
    |
    = note: move occurs because these variables have types that don't implement the `Copy` trait
-help: consider borrowing the pattern binding
+help: consider borrowing here
    |
-LL |         Bar(ref x, y) => {}
-   |             +++
-help: consider borrowing the pattern binding
-   |
-LL |         Bar(x, ref y) => {}
-   |                +++
+LL |     let _ = || match &foo {
+   |                      +
 
 error[E0507]: cannot move out of a shared reference
   --> $DIR/pattern-matching-mix-deref-pattern.rs:70:21
@@ -178,10 +157,10 @@ LL |         Bar(x, ref y) => {}
    |                +++
 
 error[E0507]: cannot move out of a shared reference
-  --> $DIR/pattern-matching-mix-deref-pattern.rs:99:22
+  --> $DIR/pattern-matching-mix-deref-pattern.rs:80:22
    |
-LL |     let _ = || match bar {
-   |                      ^^^
+LL |     let _ = || match bar.as_mut() {
+   |                      ^^^^^^^^^^^^
 LL |
 LL |         Bar(x, y) => {}
    |             -  - ...and here
@@ -189,10 +168,14 @@ LL |         Bar(x, y) => {}
    |             data moved here
    |
    = note: move occurs because these variables have types that don't implement the `Copy` trait
-help: consider borrowing here
+help: consider borrowing the pattern binding
    |
-LL |     let _ = || match &bar {
-   |                      +
+LL |         Bar(ref x, y) => {}
+   |             +++
+help: consider borrowing the pattern binding
+   |
+LL |         Bar(x, ref y) => {}
+   |                +++
 
 error[E0507]: cannot move out of a shared reference
   --> $DIR/pattern-matching-mix-deref-pattern.rs:89:21
@@ -233,6 +216,23 @@ help: consider borrowing the pattern binding
    |
 LL |         Bar(x, ref y) => {}
    |                +++
+
+error[E0507]: cannot move out of a shared reference
+  --> $DIR/pattern-matching-mix-deref-pattern.rs:99:22
+   |
+LL |     let _ = || match bar {
+   |                      ^^^
+LL |
+LL |         Bar(x, y) => {}
+   |             -  - ...and here
+   |             |
+   |             data moved here
+   |
+   = note: move occurs because these variables have types that don't implement the `Copy` trait
+help: consider borrowing here
+   |
+LL |     let _ = || match &bar {
+   |                      +
 
 error[E0507]: cannot move out of a shared reference
   --> $DIR/pattern-matching-mix-deref-pattern.rs:108:31

--- a/tests/ui/pin-ergonomics/pattern-matching-mix-deref-pattern.normal.stderr
+++ b/tests/ui/pin-ergonomics/pattern-matching-mix-deref-pattern.normal.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/pattern-matching-mix-deref-pattern.rs:33:9
+  --> $DIR/pattern-matching-mix-deref-pattern.rs:32:9
    |
 LL |     let Foo { x, y } = foo.as_mut();
    |         ^^^^^^^^^^^^   ------------ this expression has type `Pin<&mut Foo<T, U>>`
@@ -14,10 +14,11 @@ LL |     let Foo { x, y } = *foo.as_mut();
    |                        +
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-matching-mix-deref-pattern.rs:37:9
+  --> $DIR/pattern-matching-mix-deref-pattern.rs:38:9
    |
 LL |     match foo.as_mut() {
    |           ------------ this expression has type `Pin<&mut Foo<T, U>>`
+LL |
 LL |         Foo { x, y } => {}
    |         ^^^^^^^^^^^^ expected `Pin<&mut Foo<T, U>>`, found `Foo<_, _>`
    |
@@ -29,10 +30,11 @@ LL |     match *foo.as_mut() {
    |           +
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-matching-mix-deref-pattern.rs:45:9
+  --> $DIR/pattern-matching-mix-deref-pattern.rs:44:9
    |
 LL |     let _ = || match foo.as_mut() {
    |                      ------------ this expression has type `Pin<&mut Foo<T, U>>`
+LL |
 LL |         Foo { x, y } => {}
    |         ^^^^^^^^^^^^ expected `Pin<&mut Foo<T, U>>`, found `Foo<_, _>`
    |
@@ -44,7 +46,7 @@ LL |     let _ = || match *foo.as_mut() {
    |                      +
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-matching-mix-deref-pattern.rs:55:9
+  --> $DIR/pattern-matching-mix-deref-pattern.rs:51:9
    |
 LL |     let Foo { x, y } = foo;
    |         ^^^^^^^^^^^^   --- this expression has type `Pin<&Foo<T, U>>`
@@ -59,10 +61,11 @@ LL |     let Foo { x, y } = *foo;
    |                        +
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-matching-mix-deref-pattern.rs:59:9
+  --> $DIR/pattern-matching-mix-deref-pattern.rs:57:9
    |
 LL |     match foo {
    |           --- this expression has type `Pin<&Foo<T, U>>`
+LL |
 LL |         Foo { x, y } => {}
    |         ^^^^^^^^^^^^ expected `Pin<&Foo<T, U>>`, found `Foo<_, _>`
    |
@@ -74,10 +77,11 @@ LL |     match *foo {
    |           +
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-matching-mix-deref-pattern.rs:67:9
+  --> $DIR/pattern-matching-mix-deref-pattern.rs:63:9
    |
 LL |     let _ = || match foo {
    |                      --- this expression has type `Pin<&Foo<T, U>>`
+LL |
 LL |         Foo { x, y } => {}
    |         ^^^^^^^^^^^^ expected `Pin<&Foo<T, U>>`, found `Foo<_, _>`
    |
@@ -89,7 +93,7 @@ LL |     let _ = || match *foo {
    |                      +
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-matching-mix-deref-pattern.rs:77:9
+  --> $DIR/pattern-matching-mix-deref-pattern.rs:70:9
    |
 LL |     let Bar(x, y) = bar.as_mut();
    |         ^^^^^^^^^   ------------ this expression has type `Pin<&mut Bar<T, U>>`
@@ -104,10 +108,11 @@ LL |     let Bar(x, y) = *bar.as_mut();
    |                     +
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-matching-mix-deref-pattern.rs:81:9
+  --> $DIR/pattern-matching-mix-deref-pattern.rs:76:9
    |
 LL |     match bar.as_mut() {
    |           ------------ this expression has type `Pin<&mut Bar<T, U>>`
+LL |
 LL |         Bar(x, y) => {}
    |         ^^^^^^^^^ expected `Pin<&mut Bar<T, U>>`, found `Bar<_, _>`
    |
@@ -119,10 +124,11 @@ LL |     match *bar.as_mut() {
    |           +
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-matching-mix-deref-pattern.rs:89:9
+  --> $DIR/pattern-matching-mix-deref-pattern.rs:82:9
    |
 LL |     let _ = || match bar.as_mut() {
    |                      ------------ this expression has type `Pin<&mut Bar<T, U>>`
+LL |
 LL |         Bar(x, y) => {}
    |         ^^^^^^^^^ expected `Pin<&mut Bar<T, U>>`, found `Bar<_, _>`
    |
@@ -134,7 +140,7 @@ LL |     let _ = || match *bar.as_mut() {
    |                      +
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-matching-mix-deref-pattern.rs:99:9
+  --> $DIR/pattern-matching-mix-deref-pattern.rs:89:9
    |
 LL |     let Bar(x, y) = bar;
    |         ^^^^^^^^^   --- this expression has type `Pin<&Bar<T, U>>`
@@ -149,10 +155,11 @@ LL |     let Bar(x, y) = *bar;
    |                     +
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-matching-mix-deref-pattern.rs:103:9
+  --> $DIR/pattern-matching-mix-deref-pattern.rs:95:9
    |
 LL |     match bar {
    |           --- this expression has type `Pin<&Bar<T, U>>`
+LL |
 LL |         Bar(x, y) => {}
    |         ^^^^^^^^^ expected `Pin<&Bar<T, U>>`, found `Bar<_, _>`
    |
@@ -164,10 +171,11 @@ LL |     match *bar {
    |           +
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-matching-mix-deref-pattern.rs:111:9
+  --> $DIR/pattern-matching-mix-deref-pattern.rs:101:9
    |
 LL |     let _ = || match bar {
    |                      --- this expression has type `Pin<&Bar<T, U>>`
+LL |
 LL |         Bar(x, y) => {}
    |         ^^^^^^^^^ expected `Pin<&Bar<T, U>>`, found `Bar<_, _>`
    |
@@ -179,7 +187,7 @@ LL |     let _ = || match *bar {
    |                      +
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-matching-mix-deref-pattern.rs:121:9
+  --> $DIR/pattern-matching-mix-deref-pattern.rs:108:9
    |
 LL |     let NonPinProject { x } = foo;
    |         ^^^^^^^^^^^^^^^^^^^   --- this expression has type `Pin<&mut NonPinProject<T>>`
@@ -194,7 +202,7 @@ LL |     let NonPinProject { x } = *foo;
    |                               +
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-matching-mix-deref-pattern.rs:125:9
+  --> $DIR/pattern-matching-mix-deref-pattern.rs:113:9
    |
 LL |     let NonPinProject { x } = bar;
    |         ^^^^^^^^^^^^^^^^^^^   --- this expression has type `Pin<&NonPinProject<U>>`
@@ -209,10 +217,11 @@ LL |     let NonPinProject { x } = *bar;
    |                               +
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-matching-mix-deref-pattern.rs:131:9
+  --> $DIR/pattern-matching-mix-deref-pattern.rs:121:9
    |
 LL |     match foo {
    |           --- this expression has type `Pin<&mut NonPinProject<T>>`
+LL |
 LL |         NonPinProject { x } => {}
    |         ^^^^^^^^^^^^^^^^^^^ expected `Pin<&mut NonPinProject<T>>`, found `NonPinProject<_>`
    |
@@ -224,10 +233,11 @@ LL |     match *foo {
    |           +
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-matching-mix-deref-pattern.rs:139:9
+  --> $DIR/pattern-matching-mix-deref-pattern.rs:129:9
    |
 LL |     match bar {
    |           --- this expression has type `Pin<&NonPinProject<U>>`
+LL |
 LL |         NonPinProject { x } => {}
    |         ^^^^^^^^^^^^^^^^^^^ expected `Pin<&NonPinProject<U>>`, found `NonPinProject<_>`
    |

--- a/tests/ui/pin-ergonomics/pattern-matching-mix-deref-pattern.pin_ergonomics.stderr
+++ b/tests/ui/pin-ergonomics/pattern-matching-mix-deref-pattern.pin_ergonomics.stderr
@@ -1,11 +1,11 @@
 error: cannot project on type that is not `#[pin_v2]`
-  --> $DIR/pattern-matching-mix-deref-pattern.rs:121:9
+  --> $DIR/pattern-matching-mix-deref-pattern.rs:108:9
    |
 LL |     let NonPinProject { x } = foo;
    |         ^^^^^^^^^^^^^^^^^^^
    |
 note: type defined here
-  --> $DIR/pattern-matching-mix-deref-pattern.rs:28:1
+  --> $DIR/pattern-matching-mix-deref-pattern.rs:27:1
    |
 LL | struct NonPinProject<T> {
    | ^^^^^^^^^^^^^^^^^^^^^^^
@@ -16,13 +16,13 @@ LL | struct NonPinProject<T> {
    |
 
 error: cannot project on type that is not `#[pin_v2]`
-  --> $DIR/pattern-matching-mix-deref-pattern.rs:125:9
+  --> $DIR/pattern-matching-mix-deref-pattern.rs:113:9
    |
 LL |     let NonPinProject { x } = bar;
    |         ^^^^^^^^^^^^^^^^^^^
    |
 note: type defined here
-  --> $DIR/pattern-matching-mix-deref-pattern.rs:28:1
+  --> $DIR/pattern-matching-mix-deref-pattern.rs:27:1
    |
 LL | struct NonPinProject<T> {
    | ^^^^^^^^^^^^^^^^^^^^^^^
@@ -33,13 +33,13 @@ LL | struct NonPinProject<T> {
    |
 
 error: cannot project on type that is not `#[pin_v2]`
-  --> $DIR/pattern-matching-mix-deref-pattern.rs:131:9
+  --> $DIR/pattern-matching-mix-deref-pattern.rs:121:9
    |
 LL |         NonPinProject { x } => {}
    |         ^^^^^^^^^^^^^^^^^^^
    |
 note: type defined here
-  --> $DIR/pattern-matching-mix-deref-pattern.rs:28:1
+  --> $DIR/pattern-matching-mix-deref-pattern.rs:27:1
    |
 LL | struct NonPinProject<T> {
    | ^^^^^^^^^^^^^^^^^^^^^^^
@@ -50,13 +50,13 @@ LL | struct NonPinProject<T> {
    |
 
 error: cannot project on type that is not `#[pin_v2]`
-  --> $DIR/pattern-matching-mix-deref-pattern.rs:139:9
+  --> $DIR/pattern-matching-mix-deref-pattern.rs:129:9
    |
 LL |         NonPinProject { x } => {}
    |         ^^^^^^^^^^^^^^^^^^^
    |
 note: type defined here
-  --> $DIR/pattern-matching-mix-deref-pattern.rs:28:1
+  --> $DIR/pattern-matching-mix-deref-pattern.rs:27:1
    |
 LL | struct NonPinProject<T> {
    | ^^^^^^^^^^^^^^^^^^^^^^^
@@ -66,77 +66,5 @@ LL + #[pin_v2]
 LL | struct NonPinProject<T> {
    |
 
-error: mix of deref patterns and normal constructors
-  --> $DIR/pattern-matching-mix-deref-pattern.rs:37:9
-   |
-LL |         Foo { x, y } => {}
-   |         ^^^^^^^^^^^^ matches on the result of dereferencing `Pin<&mut Foo<T, U>>`
-...
-LL |         Pin { .. } => {}
-   |         ^^^^^^^^^^ matches directly on `Pin<&mut Foo<T, U>>`
-
-error: mix of deref patterns and normal constructors
-  --> $DIR/pattern-matching-mix-deref-pattern.rs:45:9
-   |
-LL |         Foo { x, y } => {}
-   |         ^^^^^^^^^^^^ matches on the result of dereferencing `Pin<&mut Foo<T, U>>`
-...
-LL |         Pin { .. } => {}
-   |         ^^^^^^^^^^ matches directly on `Pin<&mut Foo<T, U>>`
-
-error: mix of deref patterns and normal constructors
-  --> $DIR/pattern-matching-mix-deref-pattern.rs:59:9
-   |
-LL |         Foo { x, y } => {}
-   |         ^^^^^^^^^^^^ matches on the result of dereferencing `Pin<&Foo<T, U>>`
-...
-LL |         Pin { .. } => {}
-   |         ^^^^^^^^^^ matches directly on `Pin<&Foo<T, U>>`
-
-error: mix of deref patterns and normal constructors
-  --> $DIR/pattern-matching-mix-deref-pattern.rs:67:9
-   |
-LL |         Foo { x, y } => {}
-   |         ^^^^^^^^^^^^ matches on the result of dereferencing `Pin<&Foo<T, U>>`
-...
-LL |         Pin { .. } => {}
-   |         ^^^^^^^^^^ matches directly on `Pin<&Foo<T, U>>`
-
-error: mix of deref patterns and normal constructors
-  --> $DIR/pattern-matching-mix-deref-pattern.rs:81:9
-   |
-LL |         Bar(x, y) => {}
-   |         ^^^^^^^^^ matches on the result of dereferencing `Pin<&mut Bar<T, U>>`
-...
-LL |         Pin { .. } => {}
-   |         ^^^^^^^^^^ matches directly on `Pin<&mut Bar<T, U>>`
-
-error: mix of deref patterns and normal constructors
-  --> $DIR/pattern-matching-mix-deref-pattern.rs:89:9
-   |
-LL |         Bar(x, y) => {}
-   |         ^^^^^^^^^ matches on the result of dereferencing `Pin<&mut Bar<T, U>>`
-...
-LL |         Pin { .. } => {}
-   |         ^^^^^^^^^^ matches directly on `Pin<&mut Bar<T, U>>`
-
-error: mix of deref patterns and normal constructors
-  --> $DIR/pattern-matching-mix-deref-pattern.rs:103:9
-   |
-LL |         Bar(x, y) => {}
-   |         ^^^^^^^^^ matches on the result of dereferencing `Pin<&Bar<T, U>>`
-...
-LL |         Pin { .. } => {}
-   |         ^^^^^^^^^^ matches directly on `Pin<&Bar<T, U>>`
-
-error: mix of deref patterns and normal constructors
-  --> $DIR/pattern-matching-mix-deref-pattern.rs:111:9
-   |
-LL |         Bar(x, y) => {}
-   |         ^^^^^^^^^ matches on the result of dereferencing `Pin<&Bar<T, U>>`
-...
-LL |         Pin { .. } => {}
-   |         ^^^^^^^^^^ matches directly on `Pin<&Bar<T, U>>`
-
-error: aborting due to 12 previous errors
+error: aborting due to 4 previous errors
 

--- a/tests/ui/pin-ergonomics/pattern-matching-mix-deref-pattern.rs
+++ b/tests/ui/pin-ergonomics/pattern-matching-mix-deref-pattern.rs
@@ -4,9 +4,8 @@
 #![cfg_attr(any(deref_patterns, both), feature(deref_patterns))]
 #![allow(incomplete_features)]
 
-// This test verifies that the `pin_ergonomics` feature works well
-// together with the `deref_patterns` feature under the error:
-// "mix of deref patterns and normal constructors".
+//! This test used to verify that the `pin_ergonomics` feature works well
+//! together with the `deref_patterns` feature.
 
 use std::pin::Pin;
 
@@ -32,21 +31,18 @@ struct NonPinProject<T> {
 fn foo_mut<T: Unpin, U: Unpin>(mut foo: Pin<&mut Foo<T, U>>) {
     let Foo { x, y } = foo.as_mut();
     //[normal]~^ ERROR mismatched types
+    //[deref_patterns]~^^ ERROR E0507
 
     match foo.as_mut() {
+        //[deref_patterns]~^ ERROR E0507
         Foo { x, y } => {}
         //[normal]~^ ERROR mismatched types
-        //[deref_patterns]~^^ ERROR mix of deref patterns and normal constructors
-        //[pin_ergonomics]~^^^ ERROR mix of deref patterns and normal constructors
-        //[both]~^^^^ ERROR mix of deref patterns and normal constructors
         Pin { .. } => {}
     }
     let _ = || match foo.as_mut() {
+        //[deref_patterns]~^ ERROR E0507
         Foo { x, y } => {}
         //[normal]~^ ERROR mismatched types
-        //[deref_patterns]~^^ ERROR mix of deref patterns and normal constructors
-        //[pin_ergonomics]~^^^ ERROR mix of deref patterns and normal constructors
-        //[both]~^^^^ ERROR mix of deref patterns and normal constructors
         Pin { .. } => {}
     };
 }
@@ -54,43 +50,37 @@ fn foo_mut<T: Unpin, U: Unpin>(mut foo: Pin<&mut Foo<T, U>>) {
 fn foo_const<T: Unpin, U: Unpin>(foo: Pin<&Foo<T, U>>) {
     let Foo { x, y } = foo;
     //[normal]~^ ERROR mismatched types
+    //[deref_patterns]~^^ ERROR E0507
 
     match foo {
+        //[deref_patterns]~^ ERROR E0507
         Foo { x, y } => {}
         //[normal]~^ ERROR mismatched types
-        //[deref_patterns]~^^ ERROR mix of deref patterns and normal constructors
-        //[pin_ergonomics]~^^^ ERROR mix of deref patterns and normal constructors
-        //[both]~^^^^ ERROR mix of deref patterns and normal constructors
         Pin { .. } => {}
     }
     let _ = || match foo {
+        //[deref_patterns]~^ ERROR E0507
         Foo { x, y } => {}
         //[normal]~^ ERROR mismatched types
-        //[deref_patterns]~^^ ERROR mix of deref patterns and normal constructors
-        //[pin_ergonomics]~^^^ ERROR mix of deref patterns and normal constructors
-        //[both]~^^^^ ERROR mix of deref patterns and normal constructors
         Pin { .. } => {}
     };
 }
 
-fn bar_mut<T: Unpin, U: Unpin>(bar: Pin<&mut Bar<T, U>>) {
+fn bar_mut<T: Unpin, U: Unpin>(mut bar: Pin<&mut Bar<T, U>>) {
     let Bar(x, y) = bar.as_mut();
     //[normal]~^ ERROR mismatched types
+    //[deref_patterns]~^^ ERROR E0507
 
     match bar.as_mut() {
+        //[deref_patterns]~^ ERROR E0507
         Bar(x, y) => {}
         //[normal]~^ ERROR mismatched types
-        //[deref_patterns]~^^ ERROR mix of deref patterns and normal constructors
-        //[pin_ergonomics]~^^^ ERROR mix of deref patterns and normal constructors
-        //[both]~^^^^ ERROR mix of deref patterns and normal constructors
         Pin { .. } => {}
     }
     let _ = || match bar.as_mut() {
+        //[deref_patterns]~^ ERROR E0507
         Bar(x, y) => {}
         //[normal]~^ ERROR mismatched types
-        //[deref_patterns]~^^ ERROR mix of deref patterns and normal constructors
-        //[pin_ergonomics]~^^^ ERROR mix of deref patterns and normal constructors
-        //[both]~^^^^ ERROR mix of deref patterns and normal constructors
         Pin { .. } => {}
     };
 }
@@ -98,21 +88,18 @@ fn bar_mut<T: Unpin, U: Unpin>(bar: Pin<&mut Bar<T, U>>) {
 fn bar_const<T: Unpin, U: Unpin>(bar: Pin<&Bar<T, U>>) {
     let Bar(x, y) = bar;
     //[normal]~^ ERROR mismatched types
+    //[deref_patterns]~^^ ERROR E0507
 
     match bar {
+        //[deref_patterns]~^ ERROR E0507
         Bar(x, y) => {}
         //[normal]~^ ERROR mismatched types
-        //[deref_patterns]~^^ ERROR mix of deref patterns and normal constructors
-        //[pin_ergonomics]~^^^ ERROR mix of deref patterns and normal constructors
-        //[both]~^^^^ ERROR mix of deref patterns and normal constructors
         Pin { .. } => {}
     }
     let _ = || match bar {
+        //[deref_patterns]~^ ERROR E0507
         Bar(x, y) => {}
         //[normal]~^ ERROR mismatched types
-        //[deref_patterns]~^^ ERROR mix of deref patterns and normal constructors
-        //[pin_ergonomics]~^^^ ERROR mix of deref patterns and normal constructors
-        //[both]~^^^^ ERROR mix of deref patterns and normal constructors
         Pin { .. } => {}
     };
 }
@@ -120,27 +107,29 @@ fn bar_const<T: Unpin, U: Unpin>(bar: Pin<&Bar<T, U>>) {
 fn non_pin_project<T, U: Unpin>(foo: Pin<&mut NonPinProject<T>>, bar: Pin<&NonPinProject<U>>) {
     let NonPinProject { x } = foo;
     //[normal]~^ ERROR mismatched types
-    //[pin_ergonomics]~^^ ERROR cannot project on type that is not `#[pin_v2]`
-    //[both]~^^^ ERROR cannot project on type that is not `#[pin_v2]`
+    //[deref_patterns]~^^ ERROR E0507
+    //[pin_ergonomics]~^^^ ERROR cannot project on type that is not `#[pin_v2]`
+    //[both]~^^^^ ERROR cannot project on type that is not `#[pin_v2]`
     let NonPinProject { x } = bar;
     //[normal]~^ ERROR mismatched types
-    //[pin_ergonomics]~^^ ERROR cannot project on type that is not `#[pin_v2]`
-    //[both]~^^^ ERROR cannot project on type that is not `#[pin_v2]`
+    //[deref_patterns]~^^ ERROR E0507
+    //[pin_ergonomics]~^^^ ERROR cannot project on type that is not `#[pin_v2]`
+    //[both]~^^^^ ERROR cannot project on type that is not `#[pin_v2]`
 
     match foo {
+        //[deref_patterns]~^ ERROR E0507
         NonPinProject { x } => {}
         //[normal]~^ ERROR mismatched types
-        //[deref_patterns]~^^ ERROR mix of deref patterns and normal constructors
-        //[pin_ergonomics]~^^^ ERROR cannot project on type that is not `#[pin_v2]`
-        //[both]~^^^^ ERROR cannot project on type that is not `#[pin_v2]`
+        //[pin_ergonomics]~^^ ERROR cannot project on type that is not `#[pin_v2]`
+        //[both]~^^^ ERROR cannot project on type that is not `#[pin_v2]`
         Pin { .. } => {}
     }
     match bar {
+        //[deref_patterns]~^ ERROR E0507
         NonPinProject { x } => {}
         //[normal]~^ ERROR mismatched types
-        //[deref_patterns]~^^ ERROR mix of deref patterns and normal constructors
-        //[pin_ergonomics]~^^^ ERROR cannot project on type that is not `#[pin_v2]`
-        //[both]~^^^^ ERROR cannot project on type that is not `#[pin_v2]`
+        //[pin_ergonomics]~^^ ERROR cannot project on type that is not `#[pin_v2]`
+        //[both]~^^^ ERROR cannot project on type that is not `#[pin_v2]`
         Pin { .. } => {}
     }
 }

--- a/tests/ui/resolve/point-at-type-parameter-shadowing-another-type.stderr
+++ b/tests/ui/resolve/point-at-type-parameter-shadowing-another-type.stderr
@@ -1,15 +1,9 @@
-error[E0574]: expected struct, variant or union type, found type parameter `Baz`
+error[E0071]: expected struct, variant or union type, found type parameter `Baz`
   --> $DIR/point-at-type-parameter-shadowing-another-type.rs:16:13
    |
-LL | struct Baz {
-   |        --- you might have meant to refer to this struct
-...
-LL | impl<Baz> Foo<Baz> for Bar {
-   |      --- found this type parameter
-...
 LL |             Baz { num } => num,
-   |             ^^^ not a struct, variant or union type
+   |             ^^^ not a struct
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0574`.
+For more information about this error, try `rustc --explain E0071`.

--- a/tests/ui/structs/non-struct-in-struct-position.rs
+++ b/tests/ui/structs/non-struct-in-struct-position.rs
@@ -8,8 +8,8 @@ fn main() {
     let v = u32 { x: 1 }; //~ ERROR expected struct, variant or union type, found builtin type `u32`
     match () {
         A { x: 1 } => {}
-        //~^ ERROR expected struct, variant or union type, found module `A`
+        //~^ ERROR expected type or enum variant, found module `A`
         u32 { x: 1 } => {}
-        //~^ ERROR expected struct, variant or union type, found builtin type `u32`
+        //~^ ERROR expected struct, variant or union type, found `u32`
     }
 }

--- a/tests/ui/structs/non-struct-in-struct-position.stderr
+++ b/tests/ui/structs/non-struct-in-struct-position.stderr
@@ -10,18 +10,19 @@ error[E0574]: expected struct, variant or union type, found builtin type `u32`
 LL |     let v = u32 { x: 1 };
    |             ^^^ not a struct, variant or union type
 
-error[E0574]: expected struct, variant or union type, found module `A`
+error[E0573]: expected type or enum variant, found module `A`
   --> $DIR/non-struct-in-struct-position.rs:10:9
    |
 LL |         A { x: 1 } => {}
-   |         ^ not a struct, variant or union type
+   |         ^ not a type or enum variant
 
-error[E0574]: expected struct, variant or union type, found builtin type `u32`
+error[E0071]: expected struct, variant or union type, found `u32`
   --> $DIR/non-struct-in-struct-position.rs:12:9
    |
 LL |         u32 { x: 1 } => {}
-   |         ^^^ not a struct, variant or union type
+   |         ^^^ not a struct
 
 error: aborting due to 4 previous errors
 
-For more information about this error, try `rustc --explain E0574`.
+Some errors have detailed explanations: E0071, E0573, E0574.
+For more information about an error, try `rustc --explain E0071`.

--- a/tests/ui/structs/struct-path-self.rs
+++ b/tests/ui/structs/struct-path-self.rs
@@ -8,8 +8,7 @@ trait Tr {
         //~^ ERROR expected struct, variant or union type, found type parameter
         //~| ERROR type arguments are not allowed on self type
         match s {
-            Self { .. } => {}
-            //~^ ERROR expected struct, variant or union type, found type parameter
+            Self { .. } => {} // OK
         }
     }
 }

--- a/tests/ui/structs/struct-path-self.stderr
+++ b/tests/ui/structs/struct-path-self.stderr
@@ -24,14 +24,8 @@ error[E0071]: expected struct, variant or union type, found type parameter `Self
 LL |         let z = Self::<u8> {};
    |                 ^^^^^^^^^^ not a struct
 
-error[E0071]: expected struct, variant or union type, found type parameter `Self`
-  --> $DIR/struct-path-self.rs:11:13
-   |
-LL |             Self { .. } => {}
-   |             ^^^^ not a struct
-
 error[E0109]: type arguments are not allowed on self type
-  --> $DIR/struct-path-self.rs:20:24
+  --> $DIR/struct-path-self.rs:19:24
    |
 LL |         let z = Self::<u8> {};
    |                 ----   ^^ type argument not allowed
@@ -53,7 +47,7 @@ LL +         let z = Self {};
    |
 
 error[E0109]: type arguments are not allowed on self type
-  --> $DIR/struct-path-self.rs:30:24
+  --> $DIR/struct-path-self.rs:29:24
    |
 LL |         let z = Self::<u8> {};
    |                 ----   ^^ type argument not allowed
@@ -74,7 +68,7 @@ LL -         let z = Self::<u8> {};
 LL +         let z = Self {};
    |
 
-error: aborting due to 6 previous errors
+error: aborting due to 5 previous errors
 
 Some errors have detailed explanations: E0071, E0109.
 For more information about an error, try `rustc --explain E0071`.

--- a/tests/ui/union/union.rs
+++ b/tests/ui/union/union.rs
@@ -37,13 +37,16 @@ pub fn main() {
     match foo {
         Foo { zst: () } => {} //~ ERROR access to union field is unsafe
     }
-    match foo {
-        Foo { pizza: Pizza { .. } } => {} //~ ERROR access to union field is unsafe
-    }
+
 
     // binding to wildcard is okay
     match foo {
         Foo { bar: _ } => {},
     }
     let Foo { bar: _ } = foo;
+
+    match foo {
+        // OK, `Type { .. }` is equivalent to wildcard
+        Foo { pizza: Pizza { .. } } => {}
+    }
 }

--- a/tests/ui/union/union.stderr
+++ b/tests/ui/union/union.stderr
@@ -25,14 +25,6 @@ LL |         Foo { zst: () } => {}
    |
    = note: the field may not be properly initialized: using uninitialized data will cause undefined behavior
 
-error[E0133]: access to union field is unsafe and requires unsafe function or block
-  --> $DIR/union.rs:41:22
-   |
-LL |         Foo { pizza: Pizza { .. } } => {}
-   |                      ^^^^^^^^^^^^ access to union field
-   |
-   = note: the field may not be properly initialized: using uninitialized data will cause undefined behavior
-
-error: aborting due to 4 previous errors
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0133`.

--- a/tests/ui/union/union_destructure.rs
+++ b/tests/ui/union/union_destructure.rs
@@ -31,11 +31,10 @@ fn main() {
     };
 
     let u = Foo { bar: 9 };
-    unsafe {
-        match u {
-            Foo { baz: Pie { .. } } => {}
-        };
-    }
+    match u {
+        Foo { baz: Pie { .. } } => {}
+    };
+
     let u = Foo { bar: 10 };
     unsafe {
         match u {

--- a/tests/ui/union/union_destructure.rs
+++ b/tests/ui/union/union_destructure.rs
@@ -32,11 +32,10 @@ fn main() {
     };
 
     let u = Foo { bar: 9 };
-    unsafe {
-        match u {
-            Foo { baz: Pie { .. } } => {}
-        };
-    }
+    match u {
+        Foo { baz: Pie { .. } } => {}
+    };
+
     let u = Foo { bar: 10 };
     unsafe {
         match u {

--- a/tests/ui/use/issue-18986.rs
+++ b/tests/ui/use/issue-18986.rs
@@ -5,6 +5,6 @@ pub use use_from_trait_xc::Trait;
 
 fn main() {
     match () {
-        Trait { x: 42 } => () //~ ERROR expected struct, variant or union type, found trait `Trait`
+        Trait { x: 42 } => (), //~ ERROR expected type or enum variant, found trait `Trait`
     }
 }

--- a/tests/ui/use/issue-18986.stderr
+++ b/tests/ui/use/issue-18986.stderr
@@ -1,8 +1,8 @@
-error[E0574]: expected struct, variant or union type, found trait `Trait`
+error[E0573]: expected type or enum variant, found trait `Trait`
   --> $DIR/issue-18986.rs:8:9
    |
-LL |         Trait { x: 42 } => ()
-   |         ^^^^^ not a struct, variant or union type
+LL |         Trait { x: 42 } => (),
+   |         ^^^^^ not a type or enum variant
    |
 help: consider importing this struct instead
    |
@@ -11,4 +11,4 @@ LL + use std::mem::type_info::Trait;
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0574`.
+For more information about this error, try `rustc --explain E0573`.


### PR DESCRIPTION
Implements https://github.com/rust-lang/rfcs/pull/3753.

r? @ghost

@rustbot label T-lang A-patterns
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
