### PR TITLE
Implement `Debug` helpers via `Cell`

### DIFF
--- a/library/core/src/fmt/builders.rs
+++ b/library/core/src/fmt/builders.rs
@@ -1,5 +1,6 @@
 #![allow(unused_imports)]
 
+use crate::cell::Cell;
 use crate::fmt::{self, Debug, Formatter};
 
 struct PadAdapter<'buf, 'state> {
@@ -47,6 +48,29 @@ impl fmt::Write for PadAdapter<'_, '_> {
         }
         self.state.on_newline = c == '\n';
         self.buf.write_char(c)
+    }
+}
+
+/// Wraps an `FnOnce` formatting closure in a type that implements [`fmt::Debug`] by calling the
+/// closure, allowing the `*_with` builder methods to forward to their `&dyn fmt::Debug`
+/// counterparts.
+///
+/// By doing this, the builder logic is monomorphized only once and not for every closure type
+/// (see #149745).
+///
+/// Formatting a `DebugOnce` consumes the closure, so attempting to format it more than once
+/// panics. This never happens because the debug builders format each value exactly once.
+struct DebugOnce<F>(Cell<Option<F>>);
+
+impl<F> fmt::Debug for DebugOnce<F>
+where
+    F: FnOnce(&mut fmt::Formatter<'_>) -> fmt::Result,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.0.take() {
+            Some(value_fmt) => value_fmt(f),
+            None => panic!("formatting closure called more than once"),
+        }
     }
 }
 
@@ -130,7 +154,29 @@ impl<'a, 'b: 'a> DebugStruct<'a, 'b> {
     /// ```
     #[stable(feature = "debug_builders", since = "1.2.0")]
     pub fn field(&mut self, name: &str, value: &dyn fmt::Debug) -> &mut Self {
-        self.field_with(name, |f| value.fmt(f))
+        self.result = self.result.and_then(|_| {
+            if self.is_pretty() {
+                if !self.has_fields {
+                    self.fmt.write_str(" {\n")?;
+                }
+                let mut slot = None;
+                let mut state = Default::default();
+                let mut writer = PadAdapter::wrap(self.fmt, &mut slot, &mut state);
+                writer.write_str(name)?;
+                writer.write_str(": ")?;
+                value.fmt(&mut writer)?;
+                writer.write_str(",\n")
+            } else {
+                let prefix = if self.has_fields { ", " } else { " { " };
+                self.fmt.write_str(prefix)?;
+                self.fmt.write_str(name)?;
+                self.fmt.write_str(": ")?;
+                value.fmt(self.fmt)
+            }
+        });
+
+        self.has_fields = true;
+        self
     }
 
     /// Adds a new field to the generated struct output.
@@ -142,29 +188,7 @@ impl<'a, 'b: 'a> DebugStruct<'a, 'b> {
     where
         F: FnOnce(&mut fmt::Formatter<'_>) -> fmt::Result,
     {
-        self.result = self.result.and_then(|_| {
-            if self.is_pretty() {
-                if !self.has_fields {
-                    self.fmt.write_str(" {\n")?;
-                }
-                let mut slot = None;
-                let mut state = Default::default();
-                let mut writer = PadAdapter::wrap(self.fmt, &mut slot, &mut state);
-                writer.write_str(name)?;
-                writer.write_str(": ")?;
-                value_fmt(&mut writer)?;
-                writer.write_str(",\n")
-            } else {
-                let prefix = if self.has_fields { ", " } else { " { " };
-                self.fmt.write_str(prefix)?;
-                self.fmt.write_str(name)?;
-                self.fmt.write_str(": ")?;
-                value_fmt(self.fmt)
-            }
-        });
-
-        self.has_fields = true;
-        self
+        self.field(name, &DebugOnce(Cell::new(Some(value_fmt))))
     }
 
     /// Marks the struct as non-exhaustive, indicating to the reader that there are some other
@@ -327,7 +351,25 @@ impl<'a, 'b: 'a> DebugTuple<'a, 'b> {
     /// ```
     #[stable(feature = "debug_builders", since = "1.2.0")]
     pub fn field(&mut self, value: &dyn fmt::Debug) -> &mut Self {
-        self.field_with(|f| value.fmt(f))
+        self.result = self.result.and_then(|_| {
+            if self.is_pretty() {
+                if self.fields == 0 {
+                    self.fmt.write_str("(\n")?;
+                }
+                let mut slot = None;
+                let mut state = Default::default();
+                let mut writer = PadAdapter::wrap(self.fmt, &mut slot, &mut state);
+                value.fmt(&mut writer)?;
+                writer.write_str(",\n")
+            } else {
+                let prefix = if self.fields == 0 { "(" } else { ", " };
+                self.fmt.write_str(prefix)?;
+                value.fmt(self.fmt)
+            }
+        });
+
+        self.fields += 1;
+        self
     }
 
     /// Adds a new field to the generated tuple struct output.
@@ -339,25 +381,7 @@ impl<'a, 'b: 'a> DebugTuple<'a, 'b> {
     where
         F: FnOnce(&mut fmt::Formatter<'_>) -> fmt::Result,
     {
-        self.result = self.result.and_then(|_| {
-            if self.is_pretty() {
-                if self.fields == 0 {
-                    self.fmt.write_str("(\n")?;
-                }
-                let mut slot = None;
-                let mut state = Default::default();
-                let mut writer = PadAdapter::wrap(self.fmt, &mut slot, &mut state);
-                value_fmt(&mut writer)?;
-                writer.write_str(",\n")
-            } else {
-                let prefix = if self.fields == 0 { "(" } else { ", " };
-                self.fmt.write_str(prefix)?;
-                value_fmt(self.fmt)
-            }
-        });
-
-        self.fields += 1;
-        self
+        self.field(&DebugOnce(Cell::new(Some(value_fmt))))
     }
 
     /// Marks the tuple struct as non-exhaustive, indicating to the reader that there are some
@@ -453,10 +477,7 @@ struct DebugInner<'a, 'b: 'a> {
 }
 
 impl<'a, 'b: 'a> DebugInner<'a, 'b> {
-    fn entry_with<F>(&mut self, entry_fmt: F)
-    where
-        F: FnOnce(&mut fmt::Formatter<'_>) -> fmt::Result,
-    {
+    fn entry(&mut self, entry: &dyn fmt::Debug) {
         self.result = self.result.and_then(|_| {
             if self.is_pretty() {
                 if !self.has_fields {
@@ -465,17 +486,24 @@ impl<'a, 'b: 'a> DebugInner<'a, 'b> {
                 let mut slot = None;
                 let mut state = Default::default();
                 let mut writer = PadAdapter::wrap(self.fmt, &mut slot, &mut state);
-                entry_fmt(&mut writer)?;
+                entry.fmt(&mut writer)?;
                 writer.write_str(",\n")
             } else {
                 if self.has_fields {
                     self.fmt.write_str(", ")?
                 }
-                entry_fmt(self.fmt)
+                entry.fmt(self.fmt)
             }
         });
 
         self.has_fields = true;
+    }
+
+    fn entry_with<F>(&mut self, entry_fmt: F)
+    where
+        F: FnOnce(&mut fmt::Formatter<'_>) -> fmt::Result,
+    {
+        self.entry(&DebugOnce(Cell::new(Some(entry_fmt))));
     }
 
     fn is_pretty(&self) -> bool {
@@ -546,7 +574,7 @@ impl<'a, 'b: 'a> DebugSet<'a, 'b> {
     /// ```
     #[stable(feature = "debug_builders", since = "1.2.0")]
     pub fn entry(&mut self, entry: &dyn fmt::Debug) -> &mut Self {
-        self.inner.entry_with(|f| entry.fmt(f));
+        self.inner.entry(entry);
         self
     }
 
@@ -738,7 +766,7 @@ impl<'a, 'b: 'a> DebugList<'a, 'b> {
     /// ```
     #[stable(feature = "debug_builders", since = "1.2.0")]
     pub fn entry(&mut self, entry: &dyn fmt::Debug) -> &mut Self {
-        self.inner.entry_with(|f| entry.fmt(f));
+        self.inner.entry(entry);
         self
     }
 
@@ -969,18 +997,6 @@ impl<'a, 'b: 'a> DebugMap<'a, 'b> {
     /// ```
     #[stable(feature = "debug_map_key_value", since = "1.42.0")]
     pub fn key(&mut self, key: &dyn fmt::Debug) -> &mut Self {
-        self.key_with(|f| key.fmt(f))
-    }
-
-    /// Adds the key part of a new entry to the map output.
-    ///
-    /// This method is equivalent to [`DebugMap::key`], but formats the
-    /// key using a provided closure rather than by calling [`Debug::fmt`].
-    #[unstable(feature = "debug_closure_helpers", issue = "117729")]
-    pub fn key_with<F>(&mut self, key_fmt: F) -> &mut Self
-    where
-        F: FnOnce(&mut fmt::Formatter<'_>) -> fmt::Result,
-    {
         self.result = self.result.and_then(|_| {
             assert!(
                 !self.has_key,
@@ -995,13 +1011,13 @@ impl<'a, 'b: 'a> DebugMap<'a, 'b> {
                 let mut slot = None;
                 self.state = Default::default();
                 let mut writer = PadAdapter::wrap(self.fmt, &mut slot, &mut self.state);
-                key_fmt(&mut writer)?;
+                key.fmt(&mut writer)?;
                 writer.write_str(": ")?;
             } else {
                 if self.has_fields {
                     self.fmt.write_str(", ")?
                 }
-                key_fmt(self.fmt)?;
+                key.fmt(self.fmt)?;
                 self.fmt.write_str(": ")?;
             }
 
@@ -1010,6 +1026,18 @@ impl<'a, 'b: 'a> DebugMap<'a, 'b> {
         });
 
         self
+    }
+
+    /// Adds the key part of a new entry to the map output.
+    ///
+    /// This method is equivalent to [`DebugMap::key`], but formats the
+    /// key using a provided closure rather than by calling [`Debug::fmt`].
+    #[unstable(feature = "debug_closure_helpers", issue = "117729")]
+    pub fn key_with<F>(&mut self, key_fmt: F) -> &mut Self
+    where
+        F: FnOnce(&mut fmt::Formatter<'_>) -> fmt::Result,
+    {
+        self.key(&DebugOnce(Cell::new(Some(key_fmt))))
     }
 
     /// Adds the value part of a new entry to the map output.
@@ -1045,7 +1073,24 @@ impl<'a, 'b: 'a> DebugMap<'a, 'b> {
     /// ```
     #[stable(feature = "debug_map_key_value", since = "1.42.0")]
     pub fn value(&mut self, value: &dyn fmt::Debug) -> &mut Self {
-        self.value_with(|f| value.fmt(f))
+        self.result = self.result.and_then(|_| {
+            assert!(self.has_key, "attempted to format a map value before its key");
+
+            if self.is_pretty() {
+                let mut slot = None;
+                let mut writer = PadAdapter::wrap(self.fmt, &mut slot, &mut self.state);
+                value.fmt(&mut writer)?;
+                writer.write_str(",\n")?;
+            } else {
+                value.fmt(self.fmt)?;
+            }
+
+            self.has_key = false;
+            Ok(())
+        });
+
+        self.has_fields = true;
+        self
     }
 
     /// Adds the value part of a new entry to the map output.
@@ -1057,24 +1102,7 @@ impl<'a, 'b: 'a> DebugMap<'a, 'b> {
     where
         F: FnOnce(&mut fmt::Formatter<'_>) -> fmt::Result,
     {
-        self.result = self.result.and_then(|_| {
-            assert!(self.has_key, "attempted to format a map value before its key");
-
-            if self.is_pretty() {
-                let mut slot = None;
-                let mut writer = PadAdapter::wrap(self.fmt, &mut slot, &mut self.state);
-                value_fmt(&mut writer)?;
-                writer.write_str(",\n")?;
-            } else {
-                value_fmt(self.fmt)?;
-            }
-
-            self.has_key = false;
-            Ok(())
-        });
-
-        self.has_fields = true;
-        self
+        self.value(&DebugOnce(Cell::new(Some(value_fmt))))
     }
 
     /// Adds the contents of an iterator of entries to the map output.


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/159302)*
<!-- homu-ignore:end -->

Related to rust-lang/rust#149745, but does not fix it (yet).

Following @jmillikin's [suggestion](https://github.com/rust-lang/rust/pull/159302#issuecomment-4977482957), the builder logic now lives in the pre-existing non-generic methods taking `&dyn fmt::Debug` (where it used to exist), and each `*_with` method wraps its closure in a private `DebugOnce` struct that implements `Debug` by calling the closure, so the body is compiled once.

Just for context: A `dyn FnOnce` [can't be called behind a reference](https://github.com/rust-lang/rust/issues/149745#issuecomment-3625834423), hence the `Cell<Option<..>>` stuff in `DebugOnce`.

###### repro.rs

```rust
#![feature(debug_closure_helpers)]
#![crate_type = "lib"]

use core::fmt;

pub struct Point {
    pub x: u32,
    pub y: u32,
}

impl fmt::Debug for Point {
    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
        f.debug_struct("Point")
            .field_with("x", |f| self.x.fmt(f))
            .field_with("y", |f| self.y.fmt(f))
            .finish()
    }
}
```

```bash
rustc +nightly --edition=2024 --emit=llvm-ir -Copt-level=0 -o before.ll repro.rs
rustc +stage1  --edition=2024 --emit=llvm-ir -Copt-level=0 -o after.ll  repro.rs
```

On the repro above, I saw the LLVM IR drop from 739 to 268 lines (an earlier version of this PR using `&mut dyn FnMut` measured 372). Since the stable `&dyn fmt::Debug` methods no longer go through any closure indirection, this should also avoid the potential runtime regression in the `derive(Debug)` microbenchmark.

This was the only remaining [blocker](https://github.com/rust-lang/rust/issues/117729#issuecomment-3715580040) for stabilizing `debug_closure_helpers`, so it should unblock rust-lang/rust#146099.
