### PR TITLE
Fix ICE for direct inline const generic defaults

### DIFF
--- a/compiler/rustc_hir_analysis/src/collect/generics_of.rs
+++ b/compiler/rustc_hir_analysis/src/collect/generics_of.rs
@@ -140,7 +140,8 @@ pub(super) fn generics_of(tcx: TyCtxt<'_>, def_id: LocalDefId) -> ty::Generics {
                     //
                     // This has some implications for how we get the clauses available to the anon const
                     // see `explicit_clauses_of` for more information on this
-                    let generics = tcx.generics_of(parent_did);
+                    let parent_def_id = tcx.local_parent(param_id);
+                    let generics = tcx.generics_of(parent_def_id);
                     let param_def_idx = generics.param_def_id_to_index[&param_id.to_def_id()];
                     // In the above example this would be .params[..N#0]
                     let own_params = generics.params_to(param_def_idx as usize, tcx).to_owned();

--- a/tests/ui/const-generics/generic_const_exprs/direct-inline-const-generic-default.rs
+++ b/tests/ui/const-generics/generic_const_exprs/direct-inline-const-generic-default.rs
@@ -1,0 +1,10 @@
+//@ check-pass
+
+// Regression test for https://github.com/rust-lang/rust/issues/159063.
+
+#![feature(generic_const_exprs)]
+#![feature(min_generic_const_args)]
+
+struct S<const N: usize = const { 0 }>;
+
+fn main() {}


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Fixes rust-lang/rust#159063

This pr is for using the defaulted const parameter's parent to find the generics containing the parameter, instead of using the queried anonymous const's parent.