### PR TITLE
std: clarify available_parallelism docs for Windows 11 processor groups

### DIFF
--- a/library/std/src/thread/functions.rs
+++ b/library/std/src/thread/functions.rs
@@ -640,10 +640,13 @@ pub fn park_timeout(dur: Duration) {
 ///
 /// On Windows:
 /// - It may undercount the amount of parallelism available on systems with more
-///   than 64 logical CPUs. However, programs typically need specific support to
-///   take advantage of more than 64 logical CPUs, and in the absence of such
-///   support, the number returned by this function accurately reflects the
-///   number of logical CPUs the program can use by default.
+///   than 64 logical CPUs, because it reports only the logical CPUs in one
+///   processor group. Before Windows 11 and Windows Server 2022, a process was by
+///   default confined to a single processor group, so this count reflected the CPUs
+///   it could use without explicitly opting into other groups. Starting with Windows
+///   11 and Windows Server 2022, a process and its threads have affinities that by
+///   default span all processor groups, so on systems with more than 64 logical CPUs
+///   this may report fewer CPUs than are available to the program.
 /// - It may overcount the amount of parallelism available on systems limited by
 ///   process-wide affinity masks, or job object limitations.
 ///


### PR DESCRIPTION
On Windows, `available_parallelism`'s docs say the "more than 64 logical CPUs" undercount is harmless because a program needs special support to use more than 64 anyway. That stopped being true in Windows 11 and Windows Server 2022: processes now [span all processor groups by default](https://learn.microsoft.com/en-us/windows/win32/procthread/processor-groups#behavior-starting-with-windows-11-and-windows-server-2022), so a program can use more than 64 without any special handling, while `GetSystemInfo` still counts only one group.

Updates the note to describe the before and after. Docs only.

Addresses rust-lang/rust#152389

r? @ChrisDenton

