### PR TITLE
Add new variant to iterating-updating-mutref borrowck test

### DIFF
--- a/tests/ui/nll/polonius/iterating-updating-mutref.nll.stderr
+++ b/tests/ui/nll/polonius/iterating-updating-mutref.nll.stderr
@@ -1,5 +1,5 @@
 error[E0499]: cannot borrow `self.buf_read` as mutable more than once at a time
-  --> $DIR/iterating-updating-mutref.rs:61:23
+  --> $DIR/iterating-updating-mutref.rs:76:23
    |
 LL |     pub fn next<'a>(&'a mut self) -> &'a str {
    |                 -- lifetime `'a` defined here

--- a/tests/ui/nll/polonius/iterating-updating-mutref.rs
+++ b/tests/ui/nll/polonius/iterating-updating-mutref.rs
@@ -49,6 +49,21 @@ fn to_refs2<T>(mut list: &mut List<T>) -> Vec<&mut T> {
     result
 }
 
+// In a-mir-formality, the local `cursor` was (incorrectly) considered live
+// on a second borrowck pass, resulting in an incorrect error.
+fn to_refs3<'a, T>(list: &'a mut List<T>) -> &'a mut T {
+    let mut result: &'a mut T;
+    let mut cursor: &'a mut List<T> = &mut *list;
+    loop {
+        result = &mut cursor.value;
+        if let Some(n) = cursor.next.as_mut() {
+            cursor = n;
+        } else {
+            return result;
+        }
+    }
+}
+
 // Another MCVE from the same issue, but was rejected by NLLs.
 pub struct Decoder {
     buf_read: BufRead,


### PR DESCRIPTION
This is a useful variant to consider when porting to a-mir-formality.

r? lqd