### PR TITLE
Improve cross-namespace name diagnostics

### DIFF
--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -383,6 +383,7 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
         span: Span,
         source: PathSource<'_, 'ast, 'ra>,
         res: Option<Res>,
+        could_be_expr: bool,
     ) -> BaseError {
         // Make the base error.
         let mut expected = source.descr_expected();
@@ -400,28 +401,7 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
                     }
                     _ => None,
                 },
-                could_be_expr: match res {
-                    Res::Def(DefKind::Fn, _) => {
-                        // Verify whether this is a fn call or an Fn used as a type.
-                        self.r
-                            .tcx
-                            .sess
-                            .source_map()
-                            .span_to_snippet(span)
-                            .is_ok_and(|snippet| snippet.ends_with(')'))
-                    }
-                    Res::Def(
-                        DefKind::Ctor(..)
-                        | DefKind::AssocFn
-                        | DefKind::Const { .. }
-                        | DefKind::AssocConst { .. },
-                        _,
-                    )
-                    | Res::SelfCtor(_)
-                    | Res::PrimTy(_)
-                    | Res::Local(_) => true,
-                    _ => false,
-                },
+                could_be_expr,
                 suggestion: None,
                 module: None,
             }
@@ -571,10 +551,34 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
                 fallback_label,
                 span: item_span,
                 span_label,
-                could_be_expr: false,
+                could_be_expr,
                 suggestion,
                 module,
             }
+        }
+    }
+
+    fn could_be_expr(&self, res: Res, span: Span) -> bool {
+        match res {
+            // Verify whether this is a fn call or an Fn used as a type.
+            Res::Def(DefKind::Fn, _) => self
+                .r
+                .tcx
+                .sess
+                .source_map()
+                .span_to_snippet(span)
+                .is_ok_and(|snippet| snippet.ends_with(')')),
+            Res::Def(
+                DefKind::Ctor(..)
+                | DefKind::AssocFn
+                | DefKind::Const { .. }
+                | DefKind::AssocConst { .. },
+                _,
+            )
+            | Res::SelfCtor(_)
+            | Res::PrimTy(_)
+            | Res::Local(_) => true,
+            _ => false,
         }
     }
 
@@ -636,11 +640,28 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
         qself: Option<&QSelf>,
     ) -> (Diag<'tcx>, Vec<ImportSuggestion>) {
         debug!(?res, ?source);
-        let base_error = self.make_base_error(path, span, source, res);
+        let cross_namespace_res = res.filter(|res| !res.matches_ns(source.namespace()));
+        let could_be_expr = res.is_some_and(|res| self.could_be_expr(res, span));
+        let base_error = self.make_base_error(
+            path,
+            span,
+            source,
+            if cross_namespace_res.is_some() { None } else { res },
+            could_be_expr,
+        );
 
         let code = source.error_code(res.is_some());
         let mut err = self.r.dcx().struct_span_err(base_error.span, base_error.msg.clone());
         err.code(code);
+
+        if let Some(res) = cross_namespace_res {
+            err.note(format!(
+                "{} {} named `{}` exists in another namespace",
+                res.article(),
+                res.descr(),
+                Segment::names_to_string(path),
+            ));
+        }
 
         // Try to get the span of the identifier within the path's syntax context
         // (if that's different).

--- a/src/tools/miri/tests/fail/rustc-error.rs
+++ b/src/tools/miri/tests/fail/rustc-error.rs
@@ -1,4 +1,4 @@
 // Make sure we exit with non-0 status code when the program fails to build.
 fn main() {
-    println("Hello, world!"); //~ ERROR: expected function, found macro
+    println("Hello, world!"); //~ ERROR: cannot find function `println` in this scope
 }

--- a/src/tools/miri/tests/fail/rustc-error.stderr
+++ b/src/tools/miri/tests/fail/rustc-error.stderr
@@ -1,9 +1,10 @@
-error[E0423]: expected function, found macro `println`
+error[E0423]: cannot find function `println` in this scope
   --> tests/fail/rustc-error.rs:LL:CC
    |
 LL |     println("Hello, world!");
-   |     ^^^^^^^ not a function
+   |     ^^^^^^^ not found in this scope
    |
+   = note: a macro named `println` exists in another namespace
 help: use `!` to invoke the macro
    |
 LL |     println!("Hello, world!");

--- a/tests/ui/associated-consts/issue-58022.rs
+++ b/tests/ui/associated-consts/issue-58022.rs
@@ -13,7 +13,7 @@ impl Bar<[u8]> {
     fn new(slice: &[u8; Self::SIZE]) -> Self {
         //~^ ERROR: the size for values of type `[u8]` cannot be known at compilation time
         Foo(Box::new(*slice))
-        //~^ ERROR: expected function, tuple struct or tuple variant, found trait `Foo`
+        //~^ ERROR: cannot find function, tuple struct or tuple variant `Foo` in this scope
     }
 }
 

--- a/tests/ui/associated-consts/issue-58022.stderr
+++ b/tests/ui/associated-consts/issue-58022.stderr
@@ -21,11 +21,13 @@ LL |
 LL |     fn new(slice: &[u8; Foo::SIZE]) -> Self;
    |                         ^^^^^^^^^ cannot refer to the associated constant of trait
 
-error[E0423]: expected function, tuple struct or tuple variant, found trait `Foo`
+error[E0423]: cannot find function, tuple struct or tuple variant `Foo` in this scope
   --> $DIR/issue-58022.rs:15:9
    |
 LL |         Foo(Box::new(*slice))
-   |         ^^^ not a function, tuple struct or tuple variant
+   |         ^^^ not found in this scope
+   |
+   = note: a trait named `Foo` exists in another namespace
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/associated-item/missing-associated_item_or_field_def_ids.rs
+++ b/tests/ui/associated-item/missing-associated_item_or_field_def_ids.rs
@@ -1,7 +1,7 @@
 // Regression test for <https://github.com/rust-lang/rust/issues/137554>.
 
 fn main() -> dyn Iterator + ?Iterator::advance_by(usize) {
-    //~^ ERROR expected trait, found associated function `Iterator::advance_by`
+    //~^ ERROR cannot find trait `advance_by` in trait `Iterator`
     //~| ERROR relaxed bounds are not permitted in trait object types
     todo!()
 }

--- a/tests/ui/associated-item/missing-associated_item_or_field_def_ids.stderr
+++ b/tests/ui/associated-item/missing-associated_item_or_field_def_ids.stderr
@@ -1,8 +1,10 @@
-error[E0404]: expected trait, found associated function `Iterator::advance_by`
-  --> $DIR/missing-associated_item_or_field_def_ids.rs:3:30
+error[E0404]: cannot find trait `advance_by` in trait `Iterator`
+  --> $DIR/missing-associated_item_or_field_def_ids.rs:3:40
    |
 LL | fn main() -> dyn Iterator + ?Iterator::advance_by(usize) {
-   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^ not a trait
+   |                                        ^^^^^^^^^^ not found in `Iterator`
+   |
+   = note: an associated function named `Iterator::advance_by` exists in another namespace
 
 error: relaxed bounds are not permitted in trait object types
   --> $DIR/missing-associated_item_or_field_def_ids.rs:3:29

--- a/tests/ui/associated-type-bounds/return-type-notation/bad-inputs-and-output.fixed
+++ b/tests/ui/associated-type-bounds/return-type-notation/bad-inputs-and-output.fixed
@@ -29,12 +29,12 @@ fn baz_path<T: Trait>() where T::method(..): Send {}
 //~^ ERROR return type notation arguments must be elided with `..`
 
 fn foo_qualified<T: Trait>() where T::method(..): Send {}
-//~^ ERROR expected associated type
+//~^ ERROR cannot find associated type `method` in trait `Trait`
 
 fn bar_qualified<T: Trait>() where T::method(..): Send {}
-//~^ ERROR expected associated type
+//~^ ERROR cannot find associated type `method` in trait `Trait`
 
 fn baz_qualified<T: Trait>() where T::method(..): Send {}
-//~^ ERROR expected associated type
+//~^ ERROR cannot find associated type `method` in trait `Trait`
 
 fn main() {}

--- a/tests/ui/associated-type-bounds/return-type-notation/bad-inputs-and-output.rs
+++ b/tests/ui/associated-type-bounds/return-type-notation/bad-inputs-and-output.rs
@@ -29,12 +29,12 @@ fn baz_path<T: Trait>() where T::method(): Send {}
 //~^ ERROR return type notation arguments must be elided with `..`
 
 fn foo_qualified<T: Trait>() where <T as Trait>::method(i32): Send {}
-//~^ ERROR expected associated type
+//~^ ERROR cannot find associated type `method` in trait `Trait`
 
 fn bar_qualified<T: Trait>() where <T as Trait>::method() -> (): Send {}
-//~^ ERROR expected associated type
+//~^ ERROR cannot find associated type `method` in trait `Trait`
 
 fn baz_qualified<T: Trait>() where <T as Trait>::method(): Send {}
-//~^ ERROR expected associated type
+//~^ ERROR cannot find associated type `method` in trait `Trait`
 
 fn main() {}

--- a/tests/ui/associated-type-bounds/return-type-notation/bad-inputs-and-output.stderr
+++ b/tests/ui/associated-type-bounds/return-type-notation/bad-inputs-and-output.stderr
@@ -10,36 +10,39 @@ LL - fn bay_path<T: Trait>() where T::method(..) -> (): Send {}
 LL + fn bay_path<T: Trait>() where T::method(..): Send {}
    |
 
-error[E0575]: expected associated type, found associated function `Trait::method`
-  --> $DIR/bad-inputs-and-output.rs:31:36
+error[E0575]: cannot find associated type `method` in trait `Trait`
+  --> $DIR/bad-inputs-and-output.rs:31:50
    |
 LL | fn foo_qualified<T: Trait>() where <T as Trait>::method(i32): Send {}
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^ not a associated type
+   |                                                  ^^^^^^ not found in `Trait`
    |
+   = note: an associated function named `Trait::method` exists in another namespace
 help: you might have meant to use the return type notation syntax
    |
 LL - fn foo_qualified<T: Trait>() where <T as Trait>::method(i32): Send {}
 LL + fn foo_qualified<T: Trait>() where T::method(..): Send {}
    |
 
-error[E0575]: expected associated type, found associated function `Trait::method`
-  --> $DIR/bad-inputs-and-output.rs:34:36
+error[E0575]: cannot find associated type `method` in trait `Trait`
+  --> $DIR/bad-inputs-and-output.rs:34:50
    |
 LL | fn bar_qualified<T: Trait>() where <T as Trait>::method() -> (): Send {}
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not a associated type
+   |                                                  ^^^^^^ not found in `Trait`
    |
+   = note: an associated function named `Trait::method` exists in another namespace
 help: you might have meant to use the return type notation syntax
    |
 LL - fn bar_qualified<T: Trait>() where <T as Trait>::method() -> (): Send {}
 LL + fn bar_qualified<T: Trait>() where T::method(..): Send {}
    |
 
-error[E0575]: expected associated type, found associated function `Trait::method`
-  --> $DIR/bad-inputs-and-output.rs:37:36
+error[E0575]: cannot find associated type `method` in trait `Trait`
+  --> $DIR/bad-inputs-and-output.rs:37:50
    |
 LL | fn baz_qualified<T: Trait>() where <T as Trait>::method(): Send {}
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^ not a associated type
+   |                                                  ^^^^^^ not found in `Trait`
    |
+   = note: an associated function named `Trait::method` exists in another namespace
 help: you might have meant to use the return type notation syntax
    |
 LL - fn baz_qualified<T: Trait>() where <T as Trait>::method(): Send {}

--- a/tests/ui/associated-type-bounds/return-type-notation/not-a-method.rs
+++ b/tests/ui/associated-type-bounds/return-type-notation/not-a-method.rs
@@ -13,7 +13,7 @@ where
 fn not_a_method_and_typoed()
 where
     function(): Send,
-    //~^ ERROR expected type, found function `function`
+    //~^ ERROR cannot find type `function` in this scope
 {
 }
 

--- a/tests/ui/associated-type-bounds/return-type-notation/not-a-method.stderr
+++ b/tests/ui/associated-type-bounds/return-type-notation/not-a-method.stderr
@@ -4,11 +4,13 @@ error[E0575]: expected function, found function `function`
 LL |     function(..): Send,
    |     ^^^^^^^^^^^^ not a function
 
-error[E0573]: expected type, found function `function`
+error[E0573]: cannot find type `function` in this scope
   --> $DIR/not-a-method.rs:15:5
    |
 LL |     function(): Send,
-   |     ^^^^^^^^^^ not a type
+   |     ^^^^^^^^ not found in this scope
+   |
+   = note: a function named `function` exists in another namespace
 
 error[E0576]: cannot find function `method` in this scope
   --> $DIR/not-a-method.rs:27:5

--- a/tests/ui/associated-type-bounds/return-type-notation/path-missing.rs
+++ b/tests/ui/associated-type-bounds/return-type-notation/path-missing.rs
@@ -10,7 +10,7 @@ where
     <T as A>::method(..): Send,
     //~^ ERROR cannot find method or associated constant `method` in trait `A`
     <T as A>::bad(..): Send,
-    //~^ ERROR expected method or associated constant, found associated type `A::bad`
+    //~^ ERROR cannot find method or associated constant `bad` in trait `A`
 {
 }
 

--- a/tests/ui/associated-type-bounds/return-type-notation/path-missing.stderr
+++ b/tests/ui/associated-type-bounds/return-type-notation/path-missing.stderr
@@ -4,11 +4,13 @@ error[E0576]: cannot find method or associated constant `method` in trait `A`
 LL |     <T as A>::method(..): Send,
    |               ^^^^^^ not found in `A`
 
-error[E0575]: expected method or associated constant, found associated type `A::bad`
-  --> $DIR/path-missing.rs:12:5
+error[E0575]: cannot find method or associated constant `bad` in trait `A`
+  --> $DIR/path-missing.rs:12:15
    |
 LL |     <T as A>::bad(..): Send,
-   |     ^^^^^^^^^^^^^^^^^ not a method or associated constant
+   |               ^^^ not found in `A`
+   |
+   = note: an associated type named `A::bad` exists in another namespace
 
 error[E0220]: associated function `method` not found for `T`
   --> $DIR/path-missing.rs:19:8

--- a/tests/ui/associated-types/tuple-struct-expr-pat.fixed
+++ b/tests/ui/associated-types/tuple-struct-expr-pat.fixed
@@ -8,17 +8,17 @@
 
 fn main() {
     let <T<0> as Trait>::Assoc {} = <T<0> as Trait>::Assoc {};
-    //~^ error: expected method or associated constant, found associated type
-    //~| error: expected tuple struct or tuple variant, found associated type
+    //~^ error: cannot find method or associated constant `Assoc` in trait `Trait`
+    //~| error: cannot find tuple struct or tuple variant `Assoc` in trait `Trait`
     let <T<1> as Trait>::Assoc { 0: _a } = <T<1> as Trait>::Assoc { 0: 0 };
-    //~^ error: expected method or associated constant, found associated type
-    //~| error: expected tuple struct or tuple variant, found associated type
+    //~^ error: cannot find method or associated constant `Assoc` in trait `Trait`
+    //~| error: cannot find tuple struct or tuple variant `Assoc` in trait `Trait`
     let <T<2> as Trait>::Assoc { 0: _a, 1: _b } = <T<2> as Trait>::Assoc { 0: 0, 1: 1 };
-    //~^ error: expected method or associated constant, found associated type
-    //~| error: expected tuple struct or tuple variant, found associated type
+    //~^ error: cannot find method or associated constant `Assoc` in trait `Trait`
+    //~| error: cannot find tuple struct or tuple variant `Assoc` in trait `Trait`
     let <T<3> as Trait>::Assoc { 0: ref _a, 1: ref mut _b, 2: mut _c } = <T<3> as Trait>::Assoc { 0: 0, 1: 1, 2: 2 };
-    //~^ error: expected method or associated constant, found associated type
-    //~| error: expected tuple struct or tuple variant, found associated type
+    //~^ error: cannot find method or associated constant `Assoc` in trait `Trait`
+    //~| error: cannot find tuple struct or tuple variant `Assoc` in trait `Trait`
 }
 
 

--- a/tests/ui/associated-types/tuple-struct-expr-pat.rs
+++ b/tests/ui/associated-types/tuple-struct-expr-pat.rs
@@ -8,17 +8,17 @@
 
 fn main() {
     let <T<0> as Trait>::Assoc() = <T<0> as Trait>::Assoc();
-    //~^ error: expected method or associated constant, found associated type
-    //~| error: expected tuple struct or tuple variant, found associated type
+    //~^ error: cannot find method or associated constant `Assoc` in trait `Trait`
+    //~| error: cannot find tuple struct or tuple variant `Assoc` in trait `Trait`
     let <T<1> as Trait>::Assoc(_a) = <T<1> as Trait>::Assoc(0);
-    //~^ error: expected method or associated constant, found associated type
-    //~| error: expected tuple struct or tuple variant, found associated type
+    //~^ error: cannot find method or associated constant `Assoc` in trait `Trait`
+    //~| error: cannot find tuple struct or tuple variant `Assoc` in trait `Trait`
     let <T<2> as Trait>::Assoc(_a, _b) = <T<2> as Trait>::Assoc(0, 1);
-    //~^ error: expected method or associated constant, found associated type
-    //~| error: expected tuple struct or tuple variant, found associated type
+    //~^ error: cannot find method or associated constant `Assoc` in trait `Trait`
+    //~| error: cannot find tuple struct or tuple variant `Assoc` in trait `Trait`
     let <T<3> as Trait>::Assoc(ref _a, ref mut _b, mut _c) = <T<3> as Trait>::Assoc(0, 1, 2);
-    //~^ error: expected method or associated constant, found associated type
-    //~| error: expected tuple struct or tuple variant, found associated type
+    //~^ error: cannot find method or associated constant `Assoc` in trait `Trait`
+    //~| error: cannot find tuple struct or tuple variant `Assoc` in trait `Trait`
 }
 
 

--- a/tests/ui/associated-types/tuple-struct-expr-pat.stderr
+++ b/tests/ui/associated-types/tuple-struct-expr-pat.stderr
@@ -1,9 +1,10 @@
-error[E0575]: expected method or associated constant, found associated type `Trait::Assoc`
-  --> $DIR/tuple-struct-expr-pat.rs:10:36
+error[E0575]: cannot find method or associated constant `Assoc` in trait `Trait`
+  --> $DIR/tuple-struct-expr-pat.rs:10:53
    |
 LL |     let <T<0> as Trait>::Assoc() = <T<0> as Trait>::Assoc();
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^
+   |                                                     ^^^^^
    |
+   = note: an associated type named `Trait::Assoc` exists in another namespace
    = note: can't use a type alias as a constructor
 help: use struct expression instead
    |
@@ -11,12 +12,13 @@ LL -     let <T<0> as Trait>::Assoc() = <T<0> as Trait>::Assoc();
 LL +     let <T<0> as Trait>::Assoc() = <T<0> as Trait>::Assoc {};
    |
 
-error[E0575]: expected tuple struct or tuple variant, found associated type `Trait::Assoc`
-  --> $DIR/tuple-struct-expr-pat.rs:10:9
+error[E0575]: cannot find tuple struct or tuple variant `Assoc` in trait `Trait`
+  --> $DIR/tuple-struct-expr-pat.rs:10:26
    |
 LL |     let <T<0> as Trait>::Assoc() = <T<0> as Trait>::Assoc();
-   |         ^^^^^^^^^^^^^^^^^^^^^^
+   |                          ^^^^^
    |
+   = note: an associated type named `Trait::Assoc` exists in another namespace
    = note: can't use a type alias as tuple pattern
 help: use struct pattern instead
    |
@@ -24,12 +26,13 @@ LL -     let <T<0> as Trait>::Assoc() = <T<0> as Trait>::Assoc();
 LL +     let <T<0> as Trait>::Assoc {} = <T<0> as Trait>::Assoc();
    |
 
-error[E0575]: expected method or associated constant, found associated type `Trait::Assoc`
-  --> $DIR/tuple-struct-expr-pat.rs:13:38
+error[E0575]: cannot find method or associated constant `Assoc` in trait `Trait`
+  --> $DIR/tuple-struct-expr-pat.rs:13:55
    |
 LL |     let <T<1> as Trait>::Assoc(_a) = <T<1> as Trait>::Assoc(0);
-   |                                      ^^^^^^^^^^^^^^^^^^^^^^
+   |                                                       ^^^^^
    |
+   = note: an associated type named `Trait::Assoc` exists in another namespace
    = note: can't use a type alias as a constructor
 help: use struct expression instead
    |
@@ -37,12 +40,13 @@ LL -     let <T<1> as Trait>::Assoc(_a) = <T<1> as Trait>::Assoc(0);
 LL +     let <T<1> as Trait>::Assoc(_a) = <T<1> as Trait>::Assoc { 0: 0 };
    |
 
-error[E0575]: expected tuple struct or tuple variant, found associated type `Trait::Assoc`
-  --> $DIR/tuple-struct-expr-pat.rs:13:9
+error[E0575]: cannot find tuple struct or tuple variant `Assoc` in trait `Trait`
+  --> $DIR/tuple-struct-expr-pat.rs:13:26
    |
 LL |     let <T<1> as Trait>::Assoc(_a) = <T<1> as Trait>::Assoc(0);
-   |         ^^^^^^^^^^^^^^^^^^^^^^
+   |                          ^^^^^
    |
+   = note: an associated type named `Trait::Assoc` exists in another namespace
    = note: can't use a type alias as tuple pattern
 help: use struct pattern instead
    |
@@ -50,12 +54,13 @@ LL -     let <T<1> as Trait>::Assoc(_a) = <T<1> as Trait>::Assoc(0);
 LL +     let <T<1> as Trait>::Assoc { 0: _a } = <T<1> as Trait>::Assoc(0);
    |
 
-error[E0575]: expected method or associated constant, found associated type `Trait::Assoc`
-  --> $DIR/tuple-struct-expr-pat.rs:16:42
+error[E0575]: cannot find method or associated constant `Assoc` in trait `Trait`
+  --> $DIR/tuple-struct-expr-pat.rs:16:59
    |
 LL |     let <T<2> as Trait>::Assoc(_a, _b) = <T<2> as Trait>::Assoc(0, 1);
-   |                                          ^^^^^^^^^^^^^^^^^^^^^^
+   |                                                           ^^^^^
    |
+   = note: an associated type named `Trait::Assoc` exists in another namespace
    = note: can't use a type alias as a constructor
 help: use struct expression instead
    |
@@ -63,12 +68,13 @@ LL -     let <T<2> as Trait>::Assoc(_a, _b) = <T<2> as Trait>::Assoc(0, 1);
 LL +     let <T<2> as Trait>::Assoc(_a, _b) = <T<2> as Trait>::Assoc { 0: 0, 1: 1 };
    |
 
-error[E0575]: expected tuple struct or tuple variant, found associated type `Trait::Assoc`
-  --> $DIR/tuple-struct-expr-pat.rs:16:9
+error[E0575]: cannot find tuple struct or tuple variant `Assoc` in trait `Trait`
+  --> $DIR/tuple-struct-expr-pat.rs:16:26
    |
 LL |     let <T<2> as Trait>::Assoc(_a, _b) = <T<2> as Trait>::Assoc(0, 1);
-   |         ^^^^^^^^^^^^^^^^^^^^^^
+   |                          ^^^^^
    |
+   = note: an associated type named `Trait::Assoc` exists in another namespace
    = note: can't use a type alias as tuple pattern
 help: use struct pattern instead
    |
@@ -76,12 +82,13 @@ LL -     let <T<2> as Trait>::Assoc(_a, _b) = <T<2> as Trait>::Assoc(0, 1);
 LL +     let <T<2> as Trait>::Assoc { 0: _a, 1: _b } = <T<2> as Trait>::Assoc(0, 1);
    |
 
-error[E0575]: expected method or associated constant, found associated type `Trait::Assoc`
-  --> $DIR/tuple-struct-expr-pat.rs:19:62
+error[E0575]: cannot find method or associated constant `Assoc` in trait `Trait`
+  --> $DIR/tuple-struct-expr-pat.rs:19:79
    |
 LL |     let <T<3> as Trait>::Assoc(ref _a, ref mut _b, mut _c) = <T<3> as Trait>::Assoc(0, 1, 2);
-   |                                                              ^^^^^^^^^^^^^^^^^^^^^^
+   |                                                                               ^^^^^
    |
+   = note: an associated type named `Trait::Assoc` exists in another namespace
    = note: can't use a type alias as a constructor
 help: use struct expression instead
    |
@@ -89,12 +96,13 @@ LL -     let <T<3> as Trait>::Assoc(ref _a, ref mut _b, mut _c) = <T<3> as Trait
 LL +     let <T<3> as Trait>::Assoc(ref _a, ref mut _b, mut _c) = <T<3> as Trait>::Assoc { 0: 0, 1: 1, 2: 2 };
    |
 
-error[E0575]: expected tuple struct or tuple variant, found associated type `Trait::Assoc`
-  --> $DIR/tuple-struct-expr-pat.rs:19:9
+error[E0575]: cannot find tuple struct or tuple variant `Assoc` in trait `Trait`
+  --> $DIR/tuple-struct-expr-pat.rs:19:26
    |
 LL |     let <T<3> as Trait>::Assoc(ref _a, ref mut _b, mut _c) = <T<3> as Trait>::Assoc(0, 1, 2);
-   |         ^^^^^^^^^^^^^^^^^^^^^^
+   |                          ^^^^^
    |
+   = note: an associated type named `Trait::Assoc` exists in another namespace
    = note: can't use a type alias as tuple pattern
 help: use struct pattern instead
    |

--- a/tests/ui/async-await/async-drop/ex-ice1.rs
+++ b/tests/ui/async-await/async-drop/ex-ice1.rs
@@ -6,7 +6,7 @@ use core::pin::{pin, Pin};
 
 fn main() {
     let fut = pin!(async {
-        let async_drop_fut = pin!(core::future::async_drop(async {})); //~ ERROR: expected function, found module `core::future::async_drop`
+        let async_drop_fut = pin!(core::future::async_drop(async {})); //~ ERROR: cannot find function `async_drop` in module `core::future`
         //~^ ERROR: module `async_drop` is private
         (async_drop_fut).await;
     });

--- a/tests/ui/async-await/async-drop/ex-ice1.stderr
+++ b/tests/ui/async-await/async-drop/ex-ice1.stderr
@@ -1,8 +1,10 @@
-error[E0423]: expected function, found module `core::future::async_drop`
-  --> $DIR/ex-ice1.rs:9:35
+error[E0423]: cannot find function `async_drop` in module `core::future`
+  --> $DIR/ex-ice1.rs:9:49
    |
 LL | ...   let async_drop_fut = pin!(core::future::async_drop(async {}));
-   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^ not a function
+   |                                               ^^^^^^^^^^ not found in `core::future`
+   |
+   = note: a module named `core::future::async_drop` exists in another namespace
 
 error[E0603]: module `async_drop` is private
   --> $DIR/ex-ice1.rs:9:49

--- a/tests/ui/async-await/issues/issue-78654.full.stderr
+++ b/tests/ui/async-await/issues/issue-78654.full.stderr
@@ -1,8 +1,10 @@
-error[E0573]: expected type, found built-in attribute `feature`
+error[E0573]: cannot find type `feature` in this scope
   --> $DIR/issue-78654.rs:9:15
    |
 LL | impl<const H: feature> Foo {
-   |               ^^^^^^^ not a type
+   |               ^^^^^^^ not found in this scope
+   |
+   = note: a built-in attribute named `feature` exists in another namespace
 
 error[E0207]: the const parameter `H` is not constrained by the impl trait, self type, or predicates
   --> $DIR/issue-78654.rs:9:6

--- a/tests/ui/async-await/issues/issue-78654.min.stderr
+++ b/tests/ui/async-await/issues/issue-78654.min.stderr
@@ -1,8 +1,10 @@
-error[E0573]: expected type, found built-in attribute `feature`
+error[E0573]: cannot find type `feature` in this scope
   --> $DIR/issue-78654.rs:9:15
    |
 LL | impl<const H: feature> Foo {
-   |               ^^^^^^^ not a type
+   |               ^^^^^^^ not found in this scope
+   |
+   = note: a built-in attribute named `feature` exists in another namespace
 
 error[E0207]: the const parameter `H` is not constrained by the impl trait, self type, or predicates
   --> $DIR/issue-78654.rs:9:6

--- a/tests/ui/async-await/issues/issue-78654.rs
+++ b/tests/ui/async-await/issues/issue-78654.rs
@@ -7,7 +7,7 @@
 struct Foo;
 
 impl<const H: feature> Foo {
-//~^ ERROR: expected type, found built-in attribute `feature`
+//~^ ERROR: cannot find type `feature` in this scope
 //~^^ ERROR: the const parameter `H` is not constrained by the impl trait, self type, or predicates
     async fn biz() {}
 }

--- a/tests/ui/closures/local-type-mix.rs
+++ b/tests/ui/closures/local-type-mix.rs
@@ -2,14 +2,14 @@
 //@ edition:2018
 
 fn main() {
-    let _ = |x: x| x; //~ ERROR expected type
-    let _ = |x: bool| -> x { x }; //~ ERROR expected type
-    let _ = async move |x: x| x; //~ ERROR expected type
-    let _ = async move |x: bool| -> x { x }; //~ ERROR expected type
+    let _ = |x: x| x; //~ ERROR cannot find type `x` in this scope
+    let _ = |x: bool| -> x { x }; //~ ERROR cannot find type `x` in this scope
+    let _ = async move |x: x| x; //~ ERROR cannot find type `x` in this scope
+    let _ = async move |x: bool| -> x { x }; //~ ERROR cannot find type `x` in this scope
 }
 
-fn foo(x: x) {} //~ ERROR expected type
-fn foo_ret(x: bool) -> x {} //~ ERROR expected type
+fn foo(x: x) {} //~ ERROR cannot find type `x` in this scope
+fn foo_ret(x: bool) -> x {} //~ ERROR cannot find type `x` in this scope
 
-async fn async_foo(x: x) {} //~ ERROR expected type
-async fn async_foo_ret(x: bool) -> x {} //~ ERROR expected type
+async fn async_foo(x: x) {} //~ ERROR cannot find type `x` in this scope
+async fn async_foo_ret(x: bool) -> x {} //~ ERROR cannot find type `x` in this scope

--- a/tests/ui/closures/local-type-mix.stderr
+++ b/tests/ui/closures/local-type-mix.stderr
@@ -1,50 +1,66 @@
-error[E0573]: expected type, found local variable `x`
+error[E0573]: cannot find type `x` in this scope
   --> $DIR/local-type-mix.rs:5:17
    |
 LL |     let _ = |x: x| x;
-   |                 ^ not a type
+   |                 ^ not found in this scope
+   |
+   = note: a local variable named `x` exists in another namespace
 
-error[E0573]: expected type, found local variable `x`
+error[E0573]: cannot find type `x` in this scope
   --> $DIR/local-type-mix.rs:6:26
    |
 LL |     let _ = |x: bool| -> x { x };
-   |                          ^ not a type
+   |                          ^ not found in this scope
+   |
+   = note: a local variable named `x` exists in another namespace
 
-error[E0573]: expected type, found local variable `x`
+error[E0573]: cannot find type `x` in this scope
   --> $DIR/local-type-mix.rs:7:28
    |
 LL |     let _ = async move |x: x| x;
-   |                            ^ not a type
+   |                            ^ not found in this scope
+   |
+   = note: a local variable named `x` exists in another namespace
 
-error[E0573]: expected type, found local variable `x`
+error[E0573]: cannot find type `x` in this scope
   --> $DIR/local-type-mix.rs:8:37
    |
 LL |     let _ = async move |x: bool| -> x { x };
-   |                                     ^ not a type
+   |                                     ^ not found in this scope
+   |
+   = note: a local variable named `x` exists in another namespace
 
-error[E0573]: expected type, found local variable `x`
+error[E0573]: cannot find type `x` in this scope
   --> $DIR/local-type-mix.rs:11:11
    |
 LL | fn foo(x: x) {}
-   |           ^ not a type
+   |           ^ not found in this scope
+   |
+   = note: a local variable named `x` exists in another namespace
 
-error[E0573]: expected type, found local variable `x`
+error[E0573]: cannot find type `x` in this scope
   --> $DIR/local-type-mix.rs:12:24
    |
 LL | fn foo_ret(x: bool) -> x {}
-   |                        ^ not a type
+   |                        ^ not found in this scope
+   |
+   = note: a local variable named `x` exists in another namespace
 
-error[E0573]: expected type, found local variable `x`
+error[E0573]: cannot find type `x` in this scope
   --> $DIR/local-type-mix.rs:14:23
    |
 LL | async fn async_foo(x: x) {}
-   |                       ^ not a type
+   |                       ^ not found in this scope
+   |
+   = note: a local variable named `x` exists in another namespace
 
-error[E0573]: expected type, found local variable `x`
+error[E0573]: cannot find type `x` in this scope
   --> $DIR/local-type-mix.rs:15:36
    |
 LL | async fn async_foo_ret(x: bool) -> x {}
-   |                                    ^ not a type
+   |                                    ^ not found in this scope
+   |
+   = note: a local variable named `x` exists in another namespace
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/const-generics/assoc_const_as_type_argument.rs
+++ b/tests/ui/const-generics/assoc_const_as_type_argument.rs
@@ -6,7 +6,7 @@ fn bar<const N: usize>() {}
 
 fn foo<T: Trait>() {
     bar::<<T as Trait>::ASSOC>();
-    //~^ ERROR: expected associated type, found associated constant `Trait::ASSOC`
+    //~^ ERROR: cannot find associated type `ASSOC` in trait `Trait`
     //~| ERROR: unresolved item provided when a constant was expected
 }
 

--- a/tests/ui/const-generics/assoc_const_as_type_argument.stderr
+++ b/tests/ui/const-generics/assoc_const_as_type_argument.stderr
@@ -1,8 +1,10 @@
-error[E0575]: expected associated type, found associated constant `Trait::ASSOC`
-  --> $DIR/assoc_const_as_type_argument.rs:8:11
+error[E0575]: cannot find associated type `ASSOC` in trait `Trait`
+  --> $DIR/assoc_const_as_type_argument.rs:8:25
    |
 LL |     bar::<<T as Trait>::ASSOC>();
-   |           ^^^^^^^^^^^^^^^^^^^ not a associated type
+   |                         ^^^^^ not found in `Trait`
+   |
+   = note: an associated constant named `Trait::ASSOC` exists in another namespace
 
 error[E0747]: unresolved item provided when a constant was expected
   --> $DIR/assoc_const_as_type_argument.rs:8:11

--- a/tests/ui/const-generics/const-generic-function.rs
+++ b/tests/ui/const-generics/const-generic-function.rs
@@ -13,7 +13,7 @@ const fn baz() -> i32 {
 const FOO: i32 = 3;
 
 fn main() {
-    foo::<baz()>(); //~ ERROR expected type, found function `baz`
+    foo::<baz()>(); //~ ERROR cannot find type `baz` in this scope
     //~^ ERROR unresolved item provided when a constant was expected
     foo::<bar(bar(1, 1), bar(1, 1))>(); //~ ERROR expected type, found `1`
     foo::<bar(1, 1)>(); //~ ERROR expected type, found `1`

--- a/tests/ui/const-generics/const-generic-function.stderr
+++ b/tests/ui/const-generics/const-generic-function.stderr
@@ -31,11 +31,13 @@ help: expressions must be enclosed in braces to be used as const generic argumen
 LL |     foo::<{ bar(FOO, 2) }>();
    |           +             +
 
-error[E0573]: expected type, found function `baz`
+error[E0573]: cannot find type `baz` in this scope
   --> $DIR/const-generic-function.rs:16:11
    |
 LL |     foo::<baz()>();
-   |           ^^^^^ not a type
+   |           ^^^ not found in this scope
+   |
+   = note: a function named `baz` exists in another namespace
 
 error[E0747]: unresolved item provided when a constant was expected
   --> $DIR/const-generic-function.rs:16:11

--- a/tests/ui/const-generics/generic_const_exprs/issue-69654.rs
+++ b/tests/ui/const-generics/generic_const_exprs/issue-69654.rs
@@ -3,7 +3,7 @@
 
 trait Bar<T> {}
 impl<T> Bar<T> for [u8; T] {}
-//~^ ERROR expected value, found type parameter `T`
+//~^ ERROR cannot find value `T` in this scope
 
 struct Foo<const N: usize> {}
 impl<const N: usize> Foo<N>

--- a/tests/ui/const-generics/generic_const_exprs/issue-69654.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/issue-69654.stderr
@@ -1,11 +1,10 @@
-error[E0423]: expected value, found type parameter `T`
+error[E0423]: cannot find value `T` in this scope
   --> $DIR/issue-69654.rs:5:25
    |
 LL | impl<T> Bar<T> for [u8; T] {}
-   |      -                  ^ not a value
-   |      |
-   |      found this type parameter
+   |                         ^ not found in this scope
    |
+   = note: a type parameter named `T` exists in another namespace
 help: you might have meant to write a const parameter here
    |
 LL | impl<const T: /* Type */> Bar<T> for [u8; T] {}

--- a/tests/ui/const-generics/generic_const_exprs/unknown-alias-defkind-anonconst-ice-116710.rs
+++ b/tests/ui/const-generics/generic_const_exprs/unknown-alias-defkind-anonconst-ice-116710.rs
@@ -4,7 +4,7 @@
 #![allow(incomplete_features)]
 
 struct A<const N: u32 = 1, const M: u32 = u8>;
-//~^ ERROR expected value, found builtin type `u8`
+//~^ ERROR cannot find value `u8` in this scope
 
 trait Trait {}
 impl<const N: u32> Trait for A<N> {}

--- a/tests/ui/const-generics/generic_const_exprs/unknown-alias-defkind-anonconst-ice-116710.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/unknown-alias-defkind-anonconst-ice-116710.stderr
@@ -1,8 +1,10 @@
-error[E0423]: expected value, found builtin type `u8`
+error[E0423]: cannot find value `u8` in this scope
   --> $DIR/unknown-alias-defkind-anonconst-ice-116710.rs:6:43
    |
 LL | struct A<const N: u32 = 1, const M: u32 = u8>;
-   |                                           ^^ not a value
+   |                                           ^^ not found in this scope
+   |
+   = note: a builtin type named `u8` exists in another namespace
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/incorrect-const-param.rs
+++ b/tests/ui/const-generics/incorrect-const-param.rs
@@ -13,11 +13,11 @@ where
 }
 
 // Forgot const
-impl<T, N: usize> From<[T; N]> for VecWrapper<T> //~ ERROR expected value, found type parameter `N`
+impl<T, N: usize> From<[T; N]> for VecWrapper<T> //~ ERROR cannot find value `N` in this scope
 where //~^ ERROR expected trait, found builtin type `usize`
     T: Clone,
 {
-    fn from(slice: [T; N]) -> Self { //~ ERROR expected value, found type parameter `N`
+    fn from(slice: [T; N]) -> Self { //~ ERROR cannot find value `N` in this scope
         VecWrapper(slice.to_vec())
     }
 }
@@ -33,11 +33,11 @@ where
 }
 
 // Forgot const and type
-impl<T, N> From<[T; N]> for VecWrapper<T> //~ ERROR expected value, found type parameter `N`
+impl<T, N> From<[T; N]> for VecWrapper<T> //~ ERROR cannot find value `N` in this scope
 where
     T: Clone,
 {
-    fn from(slice: [T; N]) -> Self { //~ ERROR expected value, found type parameter `N`
+    fn from(slice: [T; N]) -> Self { //~ ERROR cannot find value `N` in this scope
         VecWrapper(slice.to_vec())
     }
 }

--- a/tests/ui/const-generics/incorrect-const-param.stderr
+++ b/tests/ui/const-generics/incorrect-const-param.stderr
@@ -9,13 +9,13 @@ help: you likely meant to write the type of the const parameter here
 LL | impl<T, const N: /* Type */> From<[T; N]> for VecWrapper<T>
    |                ++++++++++++
 
-error[E0423]: expected value, found type parameter `N`
+error[E0423]: cannot find value `N` in this scope
   --> $DIR/incorrect-const-param.rs:16:28
    |
 LL | impl<T, N: usize> From<[T; N]> for VecWrapper<T>
-   |         -                  ^ not a value
-   |         |
-   |         found this type parameter
+   |                            ^ not found in this scope
+   |
+   = note: a type parameter named `N` exists in another namespace
 
 error[E0404]: expected trait, found builtin type `usize`
   --> $DIR/incorrect-const-param.rs:16:12
@@ -28,37 +28,33 @@ help: you might have meant to write a const parameter here
 LL | impl<T, const N: usize> From<[T; N]> for VecWrapper<T>
    |         +++++
 
-error[E0423]: expected value, found type parameter `N`
+error[E0423]: cannot find value `N` in this scope
   --> $DIR/incorrect-const-param.rs:20:24
    |
-LL | impl<T, N: usize> From<[T; N]> for VecWrapper<T>
-   |         - found this type parameter
-...
 LL |     fn from(slice: [T; N]) -> Self {
-   |                        ^ not a value
+   |                        ^ not found in this scope
+   |
+   = note: a type parameter named `N` exists in another namespace
 
-error[E0423]: expected value, found type parameter `N`
+error[E0423]: cannot find value `N` in this scope
   --> $DIR/incorrect-const-param.rs:36:21
    |
 LL | impl<T, N> From<[T; N]> for VecWrapper<T>
-   |         -           ^ not a value
-   |         |
-   |         found this type parameter
+   |                     ^ not found in this scope
    |
+   = note: a type parameter named `N` exists in another namespace
 help: you might have meant to write a const parameter here
    |
 LL | impl<T, const N: /* Type */> From<[T; N]> for VecWrapper<T>
    |         +++++  ++++++++++++
 
-error[E0423]: expected value, found type parameter `N`
+error[E0423]: cannot find value `N` in this scope
   --> $DIR/incorrect-const-param.rs:40:24
    |
-LL | impl<T, N> From<[T; N]> for VecWrapper<T>
-   |         - found this type parameter
-...
 LL |     fn from(slice: [T; N]) -> Self {
-   |                        ^ not a value
+   |                        ^ not found in this scope
    |
+   = note: a type parameter named `N` exists in another namespace
 help: you might have meant to write a const parameter here
    |
 LL | impl<T, const N: /* Type */> From<[T; N]> for VecWrapper<T>

--- a/tests/ui/const-generics/mgca/adt_expr_erroneuous_inits.rs
+++ b/tests/ui/const-generics/mgca/adt_expr_erroneuous_inits.rs
@@ -21,6 +21,6 @@ fn bar() {
     //~^ ERROR: cannot find struct, variant or union type `Fooo` in this scope
     //~| ERROR: struct expression with invalid base path
     accepts::<{ NonStruct { }}>();
-    //~^ ERROR: expected struct, variant or union type, found function `NonStruct`
+    //~^ ERROR: cannot find struct, variant or union type `NonStruct` in this scope
     //~| ERROR: struct expression with invalid base path
 }

--- a/tests/ui/const-generics/mgca/adt_expr_erroneuous_inits.stderr
+++ b/tests/ui/const-generics/mgca/adt_expr_erroneuous_inits.stderr
@@ -13,11 +13,13 @@ LL -     accepts::<{ Fooo::<u8> { field: const { 1 } }}>();
 LL +     accepts::<{ Foo::<u8> { field: const { 1 } }}>();
    |
 
-error[E0574]: expected struct, variant or union type, found function `NonStruct`
+error[E0574]: cannot find struct, variant or union type `NonStruct` in this scope
   --> $DIR/adt_expr_erroneuous_inits.rs:23:17
    |
 LL |     accepts::<{ NonStruct { }}>();
-   |                 ^^^^^^^^^ not a struct, variant or union type
+   |                 ^^^^^^^^^ not found in this scope
+   |
+   = note: a function named `NonStruct` exists in another namespace
 
 error: struct expression with missing field initialiser for `field`
   --> $DIR/adt_expr_erroneuous_inits.rs:16:17

--- a/tests/ui/const-generics/min_const_generics/const-expression-suggest-missing-braces.rs
+++ b/tests/ui/const-generics/min_const_generics/const-expression-suggest-missing-braces.rs
@@ -9,8 +9,8 @@ fn b() {
     // FIXME(const_generics): these diagnostics are awful, because trait objects without `dyn` were
     // a terrible mistake.
     foo::<BAR + BAR>();
-    //~^ ERROR expected trait, found constant `BAR`
-    //~| ERROR expected trait, found constant `BAR`
+    //~^ ERROR cannot find trait `BAR` in this scope
+    //~| ERROR cannot find trait `BAR` in this scope
     //~| ERROR type provided when a constant was expected
 }
 fn c() {

--- a/tests/ui/const-generics/min_const_generics/const-expression-suggest-missing-braces.stderr
+++ b/tests/ui/const-generics/min_const_generics/const-expression-suggest-missing-braces.stderr
@@ -119,17 +119,21 @@ help: expressions must be enclosed in braces to be used as const generic argumen
 LL |     foo::<{ BAR - bar::<i32>() }>();
    |           +                    +
 
-error[E0404]: expected trait, found constant `BAR`
+error[E0404]: cannot find trait `BAR` in this scope
   --> $DIR/const-expression-suggest-missing-braces.rs:11:11
    |
 LL |     foo::<BAR + BAR>();
-   |           ^^^ not a trait
+   |           ^^^ not found in this scope
+   |
+   = note: a constant named `BAR` exists in another namespace
 
-error[E0404]: expected trait, found constant `BAR`
+error[E0404]: cannot find trait `BAR` in this scope
   --> $DIR/const-expression-suggest-missing-braces.rs:11:17
    |
 LL |     foo::<BAR + BAR>();
-   |                 ^^^ not a trait
+   |                 ^^^ not found in this scope
+   |
+   = note: a constant named `BAR` exists in another namespace
 
 error[E0747]: type provided when a constant was expected
   --> $DIR/const-expression-suggest-missing-braces.rs:11:11

--- a/tests/ui/const-generics/struct-with-invalid-const-param.rs
+++ b/tests/ui/const-generics/struct-with-invalid-const-param.rs
@@ -1,5 +1,5 @@
 // Checks that a const param cannot be stored in a struct.
 
-struct S<const C: u8>(C); //~ ERROR expected type, found const parameter
+struct S<const C: u8>(C); //~ ERROR cannot find type `C` in this scope
 
 fn main() {}

--- a/tests/ui/const-generics/struct-with-invalid-const-param.stderr
+++ b/tests/ui/const-generics/struct-with-invalid-const-param.stderr
@@ -1,8 +1,10 @@
-error[E0573]: expected type, found const parameter `C`
+error[E0573]: cannot find type `C` in this scope
   --> $DIR/struct-with-invalid-const-param.rs:3:23
    |
 LL | struct S<const C: u8>(C);
-   |                       ^ not a type
+   |                       ^ not found in this scope
+   |
+   = note: a const parameter named `C` exists in another namespace
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/type_not_in_scope.rs
+++ b/tests/ui/const-generics/type_not_in_scope.rs
@@ -5,7 +5,7 @@ impl X {
     }
 }
 fn getn<const N: cfg_attr>() -> [u8; N] {}
-//~^ ERROR: expected type, found built-in attribute `cfg_attr`
+//~^ ERROR: cannot find type `cfg_attr` in this scope
 //~| ERROR: mismatched types
 
 fn main() {}

--- a/tests/ui/const-generics/type_not_in_scope.stderr
+++ b/tests/ui/const-generics/type_not_in_scope.stderr
@@ -4,11 +4,13 @@ error[E0425]: cannot find type `X` in this scope
 LL | impl X {
    |      ^ not found in this scope
 
-error[E0573]: expected type, found built-in attribute `cfg_attr`
+error[E0573]: cannot find type `cfg_attr` in this scope
   --> $DIR/type_not_in_scope.rs:7:18
    |
 LL | fn getn<const N: cfg_attr>() -> [u8; N] {}
-   |                  ^^^^^^^^ not a type
+   |                  ^^^^^^^^ not found in this scope
+   |
+   = note: a built-in attribute named `cfg_attr` exists in another namespace
 
 error[E0308]: mismatched types
   --> $DIR/type_not_in_scope.rs:7:33

--- a/tests/ui/cross-crate/unit-struct.rs
+++ b/tests/ui/cross-crate/unit-struct.rs
@@ -7,8 +7,8 @@ extern crate xcrate_unit_struct;
 
 fn main() {
     let _ = xcrate_unit_struct::StructWithFields;
-    //~^ ERROR expected value, found struct `xcrate_unit_struct::StructWithFields`
+    //~^ ERROR cannot find value `StructWithFields` in crate `xcrate_unit_struct`
     let _ = xcrate_unit_struct::StructWithPrivFields;
-    //~^ ERROR expected value, found struct `xcrate_unit_struct::StructWithPrivFields`
+    //~^ ERROR cannot find value `StructWithPrivFields` in crate `xcrate_unit_struct`
     let _ = xcrate_unit_struct::Struct;
 }

--- a/tests/ui/cross-crate/unit-struct.stderr
+++ b/tests/ui/cross-crate/unit-struct.stderr
@@ -1,24 +1,30 @@
-error[E0423]: expected value, found struct `xcrate_unit_struct::StructWithFields`
-  --> $DIR/unit-struct.rs:9:13
+error[E0423]: cannot find value `StructWithFields` in crate `xcrate_unit_struct`
+  --> $DIR/unit-struct.rs:9:33
    |
 LL |     let _ = xcrate_unit_struct::StructWithFields;
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use struct literal syntax instead: `xcrate_unit_struct::StructWithFields { foo: val }`
+   |             --------------------^^^^^^^^^^^^^^^^
+   |             |
+   |             help: use struct literal syntax instead: `xcrate_unit_struct::StructWithFields { foo: val }`
    |
   ::: $DIR/auxiliary/xcrate_unit_struct.rs:20:1
    |
 LL | pub struct StructWithFields {
    | --------------------------- `xcrate_unit_struct::StructWithFields` defined here
+   |
+   = note: a struct named `xcrate_unit_struct::StructWithFields` exists in another namespace
 
-error[E0423]: expected value, found struct `xcrate_unit_struct::StructWithPrivFields`
-  --> $DIR/unit-struct.rs:11:13
+error[E0423]: cannot find value `StructWithPrivFields` in crate `xcrate_unit_struct`
+  --> $DIR/unit-struct.rs:11:33
    |
 LL |     let _ = xcrate_unit_struct::StructWithPrivFields;
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                 ^^^^^^^^^^^^^^^^^^^^
    |
   ::: $DIR/auxiliary/xcrate_unit_struct.rs:25:1
    |
 LL | pub struct StructWithPrivFields {
    | ------------------------------- `xcrate_unit_struct::StructWithPrivFields` defined here
+   |
+   = note: a struct named `xcrate_unit_struct::StructWithPrivFields` exists in another namespace
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/delegation/bad-resolve.rs
+++ b/tests/ui/delegation/bad-resolve.rs
@@ -25,7 +25,7 @@ impl Trait for S {
     //~| ERROR expected function, found associated constant `Trait::C`
     reuse <F as Trait>::Type;
     //~^ ERROR item `Type` is an associated method, which doesn't match its trait `Trait`
-    //~| ERROR expected method or associated constant, found associated type `Trait::Type`
+    //~| ERROR cannot find method or associated constant `Type` in trait `Trait`
     reuse <F as Trait>::baz;
     //~^ ERROR method `baz` is not a member of trait `Trait`
     //~| ERROR cannot find method or associated constant `baz` in trait `Trait`
@@ -42,6 +42,6 @@ impl Trait for S {
 mod prefix {}
 reuse unresolved_prefix::{a, b, c}; //~ ERROR cannot find module or crate `unresolved_prefix`
 reuse prefix::{self, super, crate}; //~ ERROR `crate` in paths can only be used in start position
-//~^ ERROR expected function, found module `prefix::self`
+//~^ ERROR cannot find function `self` in module `prefix`
 
 fn main() {}

--- a/tests/ui/delegation/bad-resolve.stderr
+++ b/tests/ui/delegation/bad-resolve.stderr
@@ -40,11 +40,13 @@ error[E0423]: expected function, found associated constant `Trait::C`
 LL |     reuse <F as Trait>::C;
    |           ^^^^^^^^^^^^^^^ not a function
 
-error[E0575]: expected method or associated constant, found associated type `Trait::Type`
-  --> $DIR/bad-resolve.rs:26:11
+error[E0575]: cannot find method or associated constant `Type` in trait `Trait`
+  --> $DIR/bad-resolve.rs:26:25
    |
 LL |     reuse <F as Trait>::Type;
-   |           ^^^^^^^^^^^^^^^^^^ not a method or associated constant
+   |                         ^^^^ not found in `Trait`
+   |
+   = note: an associated type named `Trait::Type` exists in another namespace
 
 error[E0576]: cannot find method or associated constant `baz` in trait `Trait`
   --> $DIR/bad-resolve.rs:29:25
@@ -82,11 +84,13 @@ LL -     reuse Trait::foo2 { self.0 }
 LL +     reuse Trait::foo { self.0 }
    |
 
-error[E0423]: expected function, found module `prefix::self`
-  --> $DIR/bad-resolve.rs:44:7
+error[E0423]: cannot find function `self` in module `prefix`
+  --> $DIR/bad-resolve.rs:44:16
    |
 LL | reuse prefix::{self, super, crate};
-   |       ^^^^^^ not a function
+   |                ^^^^ not found in `prefix`
+   |
+   = note: a module named `prefix::self` exists in another namespace
 
 error[E0186]: method `foo` has a `&self` declaration in the trait, but not in the impl
   --> $DIR/bad-resolve.rs:34:11

--- a/tests/ui/delegation/generics/def-path-hash-collision-ice-153410.rs
+++ b/tests/ui/delegation/generics/def-path-hash-collision-ice-153410.rs
@@ -19,7 +19,7 @@
 impl Iterator {
 //~^ ERROR: expected a type, found a trait [E0782]
     reuse< < <for<'a> fn()>::Output>::Item as Iterator>::*;
-    //~^ ERROR: expected method or associated constant, found associated type `Iterator::Item`
+    //~^ ERROR: cannot find method or associated constant `Item` in trait `Iterator`
     //~| ERROR: ambiguous associated type
 }
 

--- a/tests/ui/delegation/generics/def-path-hash-collision-ice-153410.stderr
+++ b/tests/ui/delegation/generics/def-path-hash-collision-ice-153410.stderr
@@ -1,8 +1,10 @@
-error[E0575]: expected method or associated constant, found associated type `Iterator::Item`
-  --> $DIR/def-path-hash-collision-ice-153410.rs:21:10
+error[E0575]: cannot find method or associated constant `Item` in trait `Iterator`
+  --> $DIR/def-path-hash-collision-ice-153410.rs:21:58
    |
 LL |     reuse< < <for<'a> fn()>::Output>::Item as Iterator>::*;
-   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not a method or associated constant
+   |                                                          ^ not found in `Iterator`
+   |
+   = note: an associated type named `Iterator::Item` exists in another namespace
 
 error[E0782]: expected a type, found a trait
   --> $DIR/def-path-hash-collision-ice-153410.rs:19:6

--- a/tests/ui/delegation/generics/generics-gen-args-errors.rs
+++ b/tests/ui/delegation/generics/generics-gen-args-errors.rs
@@ -11,7 +11,7 @@ mod test_1 {
         //~^ ERROR: function takes 3 generic arguments but 6 generic arguments were supplied
 
         bar::<String, String, { String }>();
-        //~^ ERROR: expected value, found struct `String` [E0423]
+        //~^ ERROR: cannot find value `String` in this scope [E0423]
 
         bar::<'static, 'static, 'static, 'static, 'static>();
         //~^ ERROR: function takes 2 lifetime arguments but 5 lifetime arguments were supplied

--- a/tests/ui/delegation/generics/generics-gen-args-errors.stderr
+++ b/tests/ui/delegation/generics/generics-gen-args-errors.stderr
@@ -59,7 +59,7 @@ help: consider introducing lifetime `'a` here
 LL |     reuse foo'a, ::<"asdasd", asd, "askdn", 'static, 'a> as bar7;
    |              +++
 
-error[E0423]: expected value, found struct `String`
+error[E0423]: cannot find value `String` in this scope
   --> $DIR/generics-gen-args-errors.rs:13:33
    |
 LL |         bar::<String, String, { String }>();
@@ -68,6 +68,8 @@ LL |         bar::<String, String, { String }>();
   --> $SRC_DIR/alloc/src/string.rs:LL:COL
    |
    = note: `String` defined here
+   |
+   = note: a struct named `String` exists in another namespace
 
 error[E0425]: cannot find type `asd` in this scope
   --> $DIR/generics-gen-args-errors.rs:27:15

--- a/tests/ui/delegation/generics/synth-params-ice-143498.rs
+++ b/tests/ui/delegation/generics/synth-params-ice-143498.rs
@@ -19,7 +19,7 @@
 impl X {
 //~^ ERROR: cannot find type `X` in this scope
     reuse< std::fmt::Debug as Iterator >::*;
-    //~^ ERROR: expected method or associated constant, found associated type `Iterator::Item`
+    //~^ ERROR: cannot find method or associated constant `Item` in trait `Iterator`
     //~| ERROR: expected a type, found a trait
 }
 

--- a/tests/ui/delegation/generics/synth-params-ice-143498.stderr
+++ b/tests/ui/delegation/generics/synth-params-ice-143498.stderr
@@ -4,11 +4,13 @@ error[E0425]: cannot find type `X` in this scope
 LL | impl X {
    |      ^ not found in this scope
 
-error[E0575]: expected method or associated constant, found associated type `Iterator::Item`
-  --> $DIR/synth-params-ice-143498.rs:21:10
+error[E0575]: cannot find method or associated constant `Item` in trait `Iterator`
+  --> $DIR/synth-params-ice-143498.rs:21:43
    |
 LL |     reuse< std::fmt::Debug as Iterator >::*;
-   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not a method or associated constant
+   |                                           ^ not found in `Iterator`
+   |
+   = note: an associated type named `Iterator::Item` exists in another namespace
 
 error[E0782]: expected a type, found a trait
   --> $DIR/synth-params-ice-143498.rs:21:12

--- a/tests/ui/delegation/glob-non-fn.rs
+++ b/tests/ui/delegation/glob-non-fn.rs
@@ -31,7 +31,7 @@ impl Trait for Bad { //~ ERROR not all trait items implemented, missing: `CONST`
     //~| ERROR item `Type` is an associated method, which doesn't match its trait `Trait`
     //~| ERROR duplicate definitions with name `method`
     //~| ERROR expected function, found associated constant `Trait::CONST`
-    //~| ERROR expected function, found associated type `Trait::Type`
+    //~| ERROR cannot find function `Type` in trait `Trait`
 }
 
 fn main() {}

--- a/tests/ui/delegation/glob-non-fn.stderr
+++ b/tests/ui/delegation/glob-non-fn.stderr
@@ -34,11 +34,13 @@ error[E0423]: expected function, found associated constant `Trait::CONST`
 LL |     reuse Trait::* { &self.0 }
    |           ^^^^^ not a function
 
-error[E0423]: expected function, found associated type `Trait::Type`
-  --> $DIR/glob-non-fn.rs:29:11
+error[E0423]: cannot find function `Type` in trait `Trait`
+  --> $DIR/glob-non-fn.rs:29:18
    |
 LL |     reuse Trait::* { &self.0 }
-   |           ^^^^^ not a function
+   |                  ^ not found in `Trait`
+   |
+   = note: an associated type named `Trait::Type` exists in another namespace
 
 error[E0046]: not all trait items implemented, missing: `CONST`, `Type`, `method`
   --> $DIR/glob-non-fn.rs:28:1

--- a/tests/ui/delegation/ice-non-fn-target-in-trait-impl.rs
+++ b/tests/ui/delegation/ice-non-fn-target-in-trait-impl.rs
@@ -11,9 +11,9 @@ trait Trait {
 
 impl Trait for () {
     reuse std::path::<> as bar;
-    //~^ ERROR expected function, found module `std::path`
+    //~^ ERROR cannot find function `path` in crate `std`
     reuse core::<> as bar2;
-    //~^ ERROR expected function, found crate `core`
+    //~^ ERROR cannot find function `core` in this scope
 }
 
 fn main() {}

--- a/tests/ui/delegation/ice-non-fn-target-in-trait-impl.stderr
+++ b/tests/ui/delegation/ice-non-fn-target-in-trait-impl.stderr
@@ -1,14 +1,18 @@
-error[E0423]: expected function, found module `std::path`
-  --> $DIR/ice-non-fn-target-in-trait-impl.rs:13:11
+error[E0423]: cannot find function `path` in crate `std`
+  --> $DIR/ice-non-fn-target-in-trait-impl.rs:13:16
    |
 LL |     reuse std::path::<> as bar;
-   |           ^^^^^^^^^^^^^ not a function
+   |                ^^^^ not found in `std`
+   |
+   = note: a module named `std::path` exists in another namespace
 
-error[E0423]: expected function, found crate `core`
+error[E0423]: cannot find function `core` in this scope
   --> $DIR/ice-non-fn-target-in-trait-impl.rs:15:11
    |
 LL |     reuse core::<> as bar2;
-   |           ^^^^^^^^ not a function
+   |           ^^^^ not found in this scope
+   |
+   = note: a crate named `core` exists in another namespace
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/delegation/impl-reuse-non-reuse-items.rs
+++ b/tests/ui/delegation/impl-reuse-non-reuse-items.rs
@@ -24,7 +24,7 @@ mod non_delegatable_items {
     //~| ERROR item `Type` is an associated method, which doesn't match its trait `Trait`
     //~| ERROR duplicate definitions with name `method`
     //~| ERROR expected function, found associated constant `Trait::CONST`
-    //~| ERROR expected function, found associated type `Trait::Type`
+    //~| ERROR cannot find function `Type` in trait `Trait`
     //~| ERROR not all trait items implemented, missing: `CONST`, `Type`, `method`
 }
 

--- a/tests/ui/delegation/impl-reuse-non-reuse-items.stderr
+++ b/tests/ui/delegation/impl-reuse-non-reuse-items.stderr
@@ -34,11 +34,13 @@ error[E0423]: expected function, found associated constant `Trait::CONST`
 LL |     reuse impl Trait for S { &self.0 }
    |                ^^^^^ not a function
 
-error[E0423]: expected function, found associated type `Trait::Type`
-  --> $DIR/impl-reuse-non-reuse-items.rs:22:16
+error[E0423]: cannot find function `Type` in trait `Trait`
+  --> $DIR/impl-reuse-non-reuse-items.rs:22:5
    |
 LL |     reuse impl Trait for S { &self.0 }
-   |                ^^^^^ not a function
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not found in `Trait`
+   |
+   = note: an associated type named `Trait::Type` exists in another namespace
 
 error[E0046]: not all trait items implemented, missing: `CONST`, `Type`, `method`
   --> $DIR/impl-reuse-non-reuse-items.rs:22:5

--- a/tests/ui/delegation/impl-reuse-self-hygiene.rs
+++ b/tests/ui/delegation/impl-reuse-self-hygiene.rs
@@ -7,21 +7,21 @@ trait Trait {
 
 struct S1(u8);
 macro_rules! one_line_reuse { ($self:ident) => { reuse impl Trait for S1 { $self.0 } } }
-//~^ ERROR expected value, found module `self`
-//~| ERROR expected value, found module `self`
 one_line_reuse!(self);
+//~^ ERROR cannot find value `self` in this scope
+//~| ERROR cannot find value `self` in this scope
 
 struct S2(u8);
 macro_rules! one_line_reuse_expr { ($x:expr) => { reuse impl Trait for S2 { $x } } }
 one_line_reuse_expr!(self.0);
-//~^ ERROR expected value, found module `self`
-//~| ERROR expected value, found module `self`
+//~^ ERROR cannot find value `self` in this scope
+//~| ERROR cannot find value `self` in this scope
 
 struct S3(u8);
 macro_rules! s3 { () => { S3 } }
 macro_rules! one_line_reuse_expr2 { ($x:expr) => { reuse impl Trait for s3!() { $x } } }
 one_line_reuse_expr2!(self.0);
-//~^ ERROR expected value, found module `self`
-//~| ERROR expected value, found module `self`
+//~^ ERROR cannot find value `self` in this scope
+//~| ERROR cannot find value `self` in this scope
 
 fn main() {}

--- a/tests/ui/delegation/impl-reuse-self-hygiene.stderr
+++ b/tests/ui/delegation/impl-reuse-self-hygiene.stderr
@@ -1,41 +1,33 @@
-error[E0424]: expected value, found module `self`
-  --> $DIR/impl-reuse-self-hygiene.rs:9:76
+error[E0424]: cannot find value `self` in this scope
+  --> $DIR/impl-reuse-self-hygiene.rs:10:17
    |
 LL | macro_rules! one_line_reuse { ($self:ident) => { reuse impl Trait for S1 { $self.0 } } }
-   |                                                  --------------------------^^^^^----
+   |                                                  -----------------------------------
    |                                                  |                         |
+   |                                                  |                         due to this macro variable
    |                                                  |                         `self` value is a keyword only available in methods with a `self` parameter
    |                                                  `self` not allowed in an implementation
-...
 LL | one_line_reuse!(self);
-   | --------------------- in this macro invocation
+   |                 ^^^^
    |
-   = note: this error originates in the macro `one_line_reuse` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: a module named `self` exists in another namespace
 
-error[E0424]: expected value, found module `self`
-  --> $DIR/impl-reuse-self-hygiene.rs:9:76
+error[E0424]: cannot find value `self` in this scope
+  --> $DIR/impl-reuse-self-hygiene.rs:10:17
    |
 LL | macro_rules! one_line_reuse { ($self:ident) => { reuse impl Trait for S1 { $self.0 } } }
-   |                                                  --------------------------^^^^^----
+   |                                                  -----------------------------------
    |                                                  |                         |
+   |                                                  |                         due to this macro variable
    |                                                  |                         `self` value is a keyword only available in methods with a `self` parameter
    |                                                  `self` not allowed in an implementation
-...
 LL | one_line_reuse!(self);
-   | --------------------- in this macro invocation
+   |                 ^^^^
    |
+   = note: a module named `self` exists in another namespace
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-   = note: this error originates in the macro `one_line_reuse` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0424]: expected value, found module `self`
-  --> $DIR/impl-reuse-self-hygiene.rs:16:22
-   |
-LL | macro_rules! one_line_reuse_expr { ($x:expr) => { reuse impl Trait for S2 { $x } } }
-   |                                                   ------------------------------ `self` not allowed in an implementation
-LL | one_line_reuse_expr!(self.0);
-   |                      ^^^^ `self` value is a keyword only available in methods with a `self` parameter
-
-error[E0424]: expected value, found module `self`
+error[E0424]: cannot find value `self` in this scope
   --> $DIR/impl-reuse-self-hygiene.rs:16:22
    |
 LL | macro_rules! one_line_reuse_expr { ($x:expr) => { reuse impl Trait for S2 { $x } } }
@@ -43,17 +35,30 @@ LL | macro_rules! one_line_reuse_expr { ($x:expr) => { reuse impl Trait for S2 {
 LL | one_line_reuse_expr!(self.0);
    |                      ^^^^ `self` value is a keyword only available in methods with a `self` parameter
    |
+   = note: a module named `self` exists in another namespace
+
+error[E0424]: cannot find value `self` in this scope
+  --> $DIR/impl-reuse-self-hygiene.rs:16:22
+   |
+LL | macro_rules! one_line_reuse_expr { ($x:expr) => { reuse impl Trait for S2 { $x } } }
+   |                                                   ------------------------------ `self` not allowed in an implementation
+LL | one_line_reuse_expr!(self.0);
+   |                      ^^^^ `self` value is a keyword only available in methods with a `self` parameter
+   |
+   = note: a module named `self` exists in another namespace
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error[E0424]: expected value, found module `self`
+error[E0424]: cannot find value `self` in this scope
   --> $DIR/impl-reuse-self-hygiene.rs:23:23
    |
 LL | macro_rules! one_line_reuse_expr2 { ($x:expr) => { reuse impl Trait for s3!() { $x } } }
    |                                                    --------------------------------- `self` not allowed in an implementation
 LL | one_line_reuse_expr2!(self.0);
    |                       ^^^^ `self` value is a keyword only available in methods with a `self` parameter
+   |
+   = note: a module named `self` exists in another namespace
 
-error[E0424]: expected value, found module `self`
+error[E0424]: cannot find value `self` in this scope
   --> $DIR/impl-reuse-self-hygiene.rs:23:23
    |
 LL | macro_rules! one_line_reuse_expr2 { ($x:expr) => { reuse impl Trait for s3!() { $x } } }
@@ -61,6 +66,7 @@ LL | macro_rules! one_line_reuse_expr2 { ($x:expr) => { reuse impl Trait for s3!
 LL | one_line_reuse_expr2!(self.0);
    |                       ^^^^ `self` value is a keyword only available in methods with a `self` parameter
    |
+   = note: a module named `self` exists in another namespace
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 6 previous errors

--- a/tests/ui/delegation/reuse-trait-path-with-empty-generics.rs
+++ b/tests/ui/delegation/reuse-trait-path-with-empty-generics.rs
@@ -7,7 +7,7 @@ trait Trait {
 
 impl Trait for () {
     reuse Trait::<> as bar4;
-    //~^ ERROR expected function, found trait `Trait`
+    //~^ ERROR cannot find function `Trait` in this scope
 }
 
 fn main() {}

--- a/tests/ui/delegation/reuse-trait-path-with-empty-generics.stderr
+++ b/tests/ui/delegation/reuse-trait-path-with-empty-generics.stderr
@@ -1,8 +1,10 @@
-error[E0423]: expected function, found trait `Trait`
+error[E0423]: cannot find function `Trait` in this scope
   --> $DIR/reuse-trait-path-with-empty-generics.rs:9:11
    |
 LL |     reuse Trait::<> as bar4;
-   |           ^^^^^^^^^ not a function
+   |           ^^^^^ not found in this scope
+   |
+   = note: a trait named `Trait` exists in another namespace
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/delegation/self-hygiene.rs
+++ b/tests/ui/delegation/self-hygiene.rs
@@ -1,8 +1,8 @@
 #![feature(fn_delegation)]
 
 macro_rules! emit_self { () => { self } }
-//~^ ERROR expected value, found module `self`
-//~| ERROR expected value, found module `self`
+//~^ ERROR cannot find value `self` in this scope
+//~| ERROR cannot find value `self` in this scope
 
 struct S;
 impl S {

--- a/tests/ui/delegation/self-hygiene.stderr
+++ b/tests/ui/delegation/self-hygiene.stderr
@@ -1,4 +1,4 @@
-error[E0424]: expected value, found module `self`
+error[E0424]: cannot find value `self` in this scope
   --> $DIR/self-hygiene.rs:3:34
    |
 LL |   macro_rules! emit_self { () => { self } }
@@ -10,9 +10,10 @@ LL | |         emit_self!();
 LL | |     }
    | |_____- this function has a `self` parameter, but a macro invocation can only access identifiers it receives from parameters
    |
+   = note: a module named `self` exists in another namespace
    = note: this error originates in the macro `emit_self` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0424]: expected value, found module `self`
+error[E0424]: cannot find value `self` in this scope
   --> $DIR/self-hygiene.rs:3:34
    |
 LL |   macro_rules! emit_self { () => { self } }
@@ -24,6 +25,7 @@ LL | |     emit_self!()
 LL | | }
    | |_- delegation supports a `self` parameter, but a macro invocation can only access identifiers it receives from parameters
    |
+   = note: a module named `self` exists in another namespace
    = note: this error originates in the macro `emit_self` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors

--- a/tests/ui/delegation/target-expr.rs
+++ b/tests/ui/delegation/target-expr.rs
@@ -31,7 +31,7 @@ fn main() {
         reuse_ptr(0)
     }
     self.0;
-    //~^ ERROR expected value, found module `self`
+    //~^ ERROR cannot find value `self` in this scope
     let z = x;
     //~^ ERROR cannot find value `x` in this scope
 }

--- a/tests/ui/delegation/target-expr.stderr
+++ b/tests/ui/delegation/target-expr.stderr
@@ -18,7 +18,7 @@ LL |         let x = y;
    |
    = help: use the `|| { ... }` closure form instead
 
-error[E0424]: expected value, found module `self`
+error[E0424]: cannot find value `self` in this scope
   --> $DIR/target-expr.rs:33:5
    |
 LL | fn main() {
@@ -26,6 +26,8 @@ LL | fn main() {
 ...
 LL |     self.0;
    |     ^^^^ `self` value is a keyword only available in methods with a `self` parameter
+   |
+   = note: a module named `self` exists in another namespace
 
 error[E0425]: cannot find value `x` in this scope
   --> $DIR/target-expr.rs:35:13

--- a/tests/ui/did_you_mean/issue-43871-enum-instead-of-variant.rs
+++ b/tests/ui/did_you_mean/issue-43871-enum-instead-of-variant.rs
@@ -16,21 +16,21 @@ enum ManyVariants {
 }
 
 fn result_test() {
-    let x = Option(1); //~ ERROR expected function, tuple struct or tuple variant, found enum
+    let x = Option(1); //~ ERROR cannot find function, tuple struct or tuple variant `Option` in this scope
 
-    if let Option(_) = x { //~ ERROR expected tuple struct or tuple variant, found enum
+    if let Option(_) = x { //~ ERROR cannot find tuple struct or tuple variant `Option` in this scope
         println!("It is OK.");
     }
 
     let y = Example::Ex(String::from("test"));
 
-    if let Example(_) = y { //~ ERROR expected tuple struct or tuple variant, found enum
+    if let Example(_) = y { //~ ERROR cannot find tuple struct or tuple variant `Example` in this scope
         println!("It is OK.");
     }
 
-    let y = Void(); //~ ERROR expected function, tuple struct or tuple variant, found enum
+    let y = Void(); //~ ERROR cannot find function, tuple struct or tuple variant `Void` in this scope
 
-    let z = ManyVariants(); //~ ERROR expected function, tuple struct or tuple variant, found enum
+    let z = ManyVariants(); //~ ERROR cannot find function, tuple struct or tuple variant `ManyVariants` in this scope
 }
 
 fn main() {}

--- a/tests/ui/did_you_mean/issue-43871-enum-instead-of-variant.stderr
+++ b/tests/ui/did_you_mean/issue-43871-enum-instead-of-variant.stderr
@@ -1,9 +1,10 @@
-error[E0532]: expected tuple struct or tuple variant, found enum `Option`
+error[E0532]: cannot find tuple struct or tuple variant `Option` in this scope
   --> $DIR/issue-43871-enum-instead-of-variant.rs:21:12
    |
 LL |     if let Option(_) = x {
    |            ^^^^^^
    |
+   = note: an enum named `Option` exists in another namespace
    = help: you might have meant to match against the enum's non-tuple variant
 help: try to match against one of the enum's variants
    |
@@ -11,12 +12,13 @@ LL -     if let Option(_) = x {
 LL +     if let std::option::Option::Some(_) = x {
    |
 
-error[E0532]: expected tuple struct or tuple variant, found enum `Example`
+error[E0532]: cannot find tuple struct or tuple variant `Example` in this scope
   --> $DIR/issue-43871-enum-instead-of-variant.rs:27:12
    |
 LL |     if let Example(_) = y {
    |            ^^^^^^^
    |
+   = note: an enum named `Example` exists in another namespace
    = help: you might have meant to match against the enum's non-tuple variant
 note: the enum is defined here
   --> $DIR/issue-43871-enum-instead-of-variant.rs:1:1
@@ -28,12 +30,13 @@ help: try to match against one of the enum's variants
 LL |     if let Example::Ex(_) = y {
    |                   ++++
 
-error[E0423]: expected function, tuple struct or tuple variant, found enum `Option`
+error[E0423]: cannot find function, tuple struct or tuple variant `Option` in this scope
   --> $DIR/issue-43871-enum-instead-of-variant.rs:19:13
    |
 LL |     let x = Option(1);
    |             ^^^^^^
    |
+   = note: an enum named `Option` exists in another namespace
    = help: you might have meant to construct the enum's non-tuple variant
 help: try to construct one of the enum's variants
    |
@@ -41,12 +44,13 @@ LL -     let x = Option(1);
 LL +     let x = std::option::Option::Some(1);
    |
 
-error[E0423]: expected function, tuple struct or tuple variant, found enum `Void`
+error[E0423]: cannot find function, tuple struct or tuple variant `Void` in this scope
   --> $DIR/issue-43871-enum-instead-of-variant.rs:31:13
    |
 LL |     let y = Void();
    |             ^^^^
    |
+   = note: an enum named `Void` exists in another namespace
    = help: the enum has no tuple variants to construct
 note: the enum is defined here
   --> $DIR/issue-43871-enum-instead-of-variant.rs:3:1
@@ -54,12 +58,13 @@ note: the enum is defined here
 LL | enum Void {}
    | ^^^^^^^^^^^^
 
-error[E0423]: expected function, tuple struct or tuple variant, found enum `ManyVariants`
+error[E0423]: cannot find function, tuple struct or tuple variant `ManyVariants` in this scope
   --> $DIR/issue-43871-enum-instead-of-variant.rs:33:13
    |
 LL |     let z = ManyVariants();
    |             ^^^^^^^^^^^^
    |
+   = note: an enum named `ManyVariants` exists in another namespace
    = help: the enum has no tuple variants to construct
    = help: you might have meant to construct one of the enum's non-tuple variants
 note: the enum is defined here

--- a/tests/ui/ergonomic-clones/async/local-type.rs
+++ b/tests/ui/ergonomic-clones/async/local-type.rs
@@ -5,6 +5,6 @@
 #![allow(incomplete_features)]
 
 fn main() {
-    let _ = async use |x: x| x; //~ ERROR expected type
-    let _ = async use |x: bool| -> x { x }; //~ ERROR expected type
+    let _ = async use |x: x| x; //~ ERROR cannot find type `x` in this scope
+    let _ = async use |x: bool| -> x { x }; //~ ERROR cannot find type `x` in this scope
 }

--- a/tests/ui/ergonomic-clones/async/local-type.stderr
+++ b/tests/ui/ergonomic-clones/async/local-type.stderr
@@ -1,14 +1,18 @@
-error[E0573]: expected type, found local variable `x`
+error[E0573]: cannot find type `x` in this scope
   --> $DIR/local-type.rs:8:27
    |
 LL |     let _ = async use |x: x| x;
-   |                           ^ not a type
+   |                           ^ not found in this scope
+   |
+   = note: a local variable named `x` exists in another namespace
 
-error[E0573]: expected type, found local variable `x`
+error[E0573]: cannot find type `x` in this scope
   --> $DIR/local-type.rs:9:36
    |
 LL |     let _ = async use |x: bool| -> x { x };
-   |                                    ^ not a type
+   |                                    ^ not found in this scope
+   |
+   = note: a local variable named `x` exists in another namespace
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/ergonomic-clones/closure/local-type.rs
+++ b/tests/ui/ergonomic-clones/closure/local-type.rs
@@ -4,6 +4,6 @@
 #![allow(incomplete_features)]
 
 fn main() {
-    let _ = use |x: x| x; //~ ERROR expected type
-    let _ = use |x: bool| -> x { x }; //~ ERROR expected type
+    let _ = use |x: x| x; //~ ERROR cannot find type `x` in this scope
+    let _ = use |x: bool| -> x { x }; //~ ERROR cannot find type `x` in this scope
 }

--- a/tests/ui/ergonomic-clones/closure/local-type.stderr
+++ b/tests/ui/ergonomic-clones/closure/local-type.stderr
@@ -1,14 +1,18 @@
-error[E0573]: expected type, found local variable `x`
+error[E0573]: cannot find type `x` in this scope
   --> $DIR/local-type.rs:7:21
    |
 LL |     let _ = use |x: x| x;
-   |                     ^ not a type
+   |                     ^ not found in this scope
+   |
+   = note: a local variable named `x` exists in another namespace
 
-error[E0573]: expected type, found local variable `x`
+error[E0573]: cannot find type `x` in this scope
   --> $DIR/local-type.rs:8:30
    |
 LL |     let _ = use |x: bool| -> x { x };
-   |                              ^ not a type
+   |                              ^ not found in this scope
+   |
+   = note: a local variable named `x` exists in another namespace
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/error-codes/E0423-struct-literal-comment.rs
+++ b/tests/ui/error-codes/E0423-struct-literal-comment.rs
@@ -8,7 +8,7 @@ fn main() {
     // Parser will report an error here
     if T { x: 10 } == T {} {}
     //~^ ERROR struct literals are not allowed here
-    //~| ERROR expected value, found struct `T`
+    //~| ERROR cannot find value `T` in this scope
 
     // Regression test for the `followed_by_brace` helper:
     // comments inside the braces should not suppress the parenthesized struct literal suggestion.

--- a/tests/ui/error-codes/E0423-struct-literal-comment.stderr
+++ b/tests/ui/error-codes/E0423-struct-literal-comment.stderr
@@ -15,23 +15,25 @@ error: expected expression, found `==`
 LL |     if U { /* keep comment here */ } == U {}
    |                                      ^^ expected expression
 
-error[E0423]: expected value, found struct `T`
+error[E0423]: cannot find value `T` in this scope
   --> $DIR/E0423-struct-literal-comment.rs:9:23
    |
 LL |     if T { x: 10 } == T {} {}
-   |                       ^ not a value
+   |                       ^ not found in this scope
    |
+   = note: a struct named `T` exists in another namespace
 help: surround the struct literal with parentheses
    |
 LL |     if T { x: 10 } == (T {}) {}
    |                       +    +
 
-error[E0423]: expected value, found struct `U`
+error[E0423]: cannot find value `U` in this scope
   --> $DIR/E0423-struct-literal-comment.rs:15:8
    |
 LL |     if U { /* keep comment here */ } == U {}
-   |        ^ not a value
+   |        ^ not found in this scope
    |
+   = note: a struct named `U` exists in another namespace
 help: surround the struct literal with parentheses
    |
 LL |     if (U { /* keep comment here */ }) == U {}

--- a/tests/ui/error-codes/E0423.stderr
+++ b/tests/ui/error-codes/E0423.stderr
@@ -26,18 +26,19 @@ help: surround the struct literal with parentheses
 LL |     for _ in (std::ops::Range { start: 0, end: 10 }) {}
    |              +                                     +
 
-error[E0423]: expected value, found struct `T`
+error[E0423]: cannot find value `T` in this scope
   --> $DIR/E0423.rs:14:8
    |
 LL |     if T {} == T {} { println!("Ok"); }
-   |        ^ not a value
+   |        ^ not found in this scope
    |
+   = note: a struct named `T` exists in another namespace
 help: surround the struct literal with parentheses
    |
 LL |     if (T {}) == T {} { println!("Ok"); }
    |        +    +
 
-error[E0423]: expected function, tuple struct or tuple variant, found struct `Foo`
+error[E0423]: cannot find function, tuple struct or tuple variant `Foo` in this scope
   --> $DIR/E0423.rs:4:13
    |
 LL |     struct Foo { a: bool };
@@ -49,6 +50,7 @@ LL |     let f = Foo();
 LL | fn foo() {
    | -------- similarly named function `foo` defined here
    |
+   = note: a struct named `Foo` exists in another namespace
 help: use struct literal syntax instead
    |
 LL -     let f = Foo();

--- a/tests/ui/error-codes/E0424.stderr
+++ b/tests/ui/error-codes/E0424.stderr
@@ -1,4 +1,4 @@
-error[E0424]: expected value, found module `self`
+error[E0424]: cannot find value `self` in this scope
   --> $DIR/E0424.rs:7:9
    |
 LL |     fn foo() {
@@ -6,12 +6,13 @@ LL |     fn foo() {
 LL |         self.bar();
    |         ^^^^ `self` value is a keyword only available in methods with a `self` parameter
    |
+   = note: a module named `self` exists in another namespace
 help: add a `self` receiver parameter to make the associated `fn` a method
    |
 LL |     fn foo(&self) {
    |            +++++
 
-error[E0424]: expected value, found module `self`
+error[E0424]: cannot find value `self` in this scope
   --> $DIR/E0424.rs:11:9
    |
 LL |     fn baz(_: i32) {
@@ -19,12 +20,13 @@ LL |     fn baz(_: i32) {
 LL |         self.bar();
    |         ^^^^ `self` value is a keyword only available in methods with a `self` parameter
    |
+   = note: a module named `self` exists in another namespace
 help: add a `self` receiver parameter to make the associated `fn` a method
    |
 LL |     fn baz(&self, _: i32) {
    |            ++++++
 
-error[E0424]: expected value, found module `self`
+error[E0424]: cannot find value `self` in this scope
   --> $DIR/E0424.rs:15:20
    |
 LL |     fn qux() {
@@ -32,16 +34,19 @@ LL |     fn qux() {
 LL |         let _ = || self.bar();
    |                    ^^^^ `self` value is a keyword only available in methods with a `self` parameter
    |
+   = note: a module named `self` exists in another namespace
 help: add a `self` receiver parameter to make the associated `fn` a method
    |
 LL |     fn qux(&self) {
    |            +++++
 
-error[E0424]: expected unit struct, unit variant or constant, found module `self`
+error[E0424]: cannot find unit struct, unit variant or constant `self` in this scope
   --> $DIR/E0424.rs:20:9
    |
 LL |     let self = "self";
    |         ^^^^ `self` value is a keyword and may not be bound to variables or shadowed
+   |
+   = note: a module named `self` exists in another namespace
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/errors/remap-path-prefix-reverse.local-self.stderr
+++ b/tests/ui/errors/remap-path-prefix-reverse.local-self.stderr
@@ -1,13 +1,17 @@
-error[E0423]: expected value, found struct `remapped_dep::SomeStruct`
-  --> $DIR/remap-path-prefix-reverse.rs:15:13
+error[E0423]: cannot find value `SomeStruct` in crate `remapped_dep`
+  --> $DIR/remap-path-prefix-reverse.rs:15:27
    |
 LL |     let _ = remapped_dep::SomeStruct;
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^ help: use struct literal syntax instead: `remapped_dep::SomeStruct {}`
+   |             --------------^^^^^^^^^^
+   |             |
+   |             help: use struct literal syntax instead: `remapped_dep::SomeStruct {}`
    |
   ::: remapped-aux/remapped_dep.rs:4:1
    |
 LL | pub struct SomeStruct {} // This line should be show as part of the error.
    | --------------------- `remapped_dep::SomeStruct` defined here
+   |
+   = note: a struct named `remapped_dep::SomeStruct` exists in another namespace
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/errors/remap-path-prefix-reverse.remapped-self.stderr
+++ b/tests/ui/errors/remap-path-prefix-reverse.remapped-self.stderr
@@ -1,13 +1,17 @@
-error[E0423]: expected value, found struct `remapped_dep::SomeStruct`
-  --> $DIR/remap-path-prefix-reverse.rs:15:13
+error[E0423]: cannot find value `SomeStruct` in crate `remapped_dep`
+  --> $DIR/remap-path-prefix-reverse.rs:15:27
    |
 LL |     let _ = remapped_dep::SomeStruct;
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^ help: use struct literal syntax instead: `remapped_dep::SomeStruct {}`
+   |             --------------^^^^^^^^^^
+   |             |
+   |             help: use struct literal syntax instead: `remapped_dep::SomeStruct {}`
    |
   ::: remapped-aux/remapped_dep.rs:4:1
    |
 LL | pub struct SomeStruct {} // This line should be show as part of the error.
    | --------------------- `remapped_dep::SomeStruct` defined here
+   |
+   = note: a struct named `remapped_dep::SomeStruct` exists in another namespace
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/errors/remap-path-prefix-reverse.rs
+++ b/tests/ui/errors/remap-path-prefix-reverse.rs
@@ -13,5 +13,5 @@ fn main() {
     // The actual error is irrelevant. The important part it that is should show
     // a snippet of the dependency's source.
     let _ = remapped_dep::SomeStruct;
-    //~^ ERROR expected value, found struct `remapped_dep::SomeStruct`
+    //~^ ERROR cannot find value `SomeStruct` in crate `remapped_dep`
 }

--- a/tests/ui/field_representing_types/nonexistent.next.stderr
+++ b/tests/ui/field_representing_types/nonexistent.next.stderr
@@ -1,8 +1,10 @@
-error[E0573]: expected type, found function `main`
+error[E0573]: cannot find type `main` in this scope
   --> $DIR/nonexistent.rs:43:22
    |
 LL |     let _: field_of!(main, field);
-   |                      ^^^^ not a type
+   |                      ^^^^ not found in this scope
+   |
+   = note: a function named `main` exists in another namespace
 
 error[E0609]: no field `other` on type `Struct`
   --> $DIR/nonexistent.rs:23:30

--- a/tests/ui/field_representing_types/nonexistent.old.stderr
+++ b/tests/ui/field_representing_types/nonexistent.old.stderr
@@ -1,8 +1,10 @@
-error[E0573]: expected type, found function `main`
+error[E0573]: cannot find type `main` in this scope
   --> $DIR/nonexistent.rs:43:22
    |
 LL |     let _: field_of!(main, field);
-   |                      ^^^^ not a type
+   |                      ^^^^ not found in this scope
+   |
+   = note: a function named `main` exists in another namespace
 
 error[E0609]: no field `other` on type `Struct`
   --> $DIR/nonexistent.rs:23:30

--- a/tests/ui/field_representing_types/nonexistent.rs
+++ b/tests/ui/field_representing_types/nonexistent.rs
@@ -40,7 +40,7 @@ fn main() {
     let _: field_of!(*const Struct, field); //~ ERROR: type `*const Struct` doesn't have fields
     let _: field_of!(fn() -> Struct, field); //~ ERROR: type `fn() -> Struct` doesn't have fields
     let _: field_of!(dyn Trait, field); //~ ERROR: type `dyn Trait` doesn't have fields
-    let _: field_of!(main, field); //~ ERROR: expected type, found function `main`
+    let _: field_of!(main, field); //~ ERROR: cannot find type `main` in this scope
     let _: field_of!(_, field); //~ ERROR: cannot use `_` in this position
 }
 

--- a/tests/ui/hygiene/missing-self-diag.rs
+++ b/tests/ui/hygiene/missing-self-diag.rs
@@ -7,7 +7,7 @@ pub struct Foo;
 
 macro_rules! call_bar {
     () => {
-        self.bar(); //~ ERROR expected value
+        self.bar(); //~ ERROR cannot find value `self` in this scope
     }
 }
 

--- a/tests/ui/hygiene/missing-self-diag.stderr
+++ b/tests/ui/hygiene/missing-self-diag.stderr
@@ -1,4 +1,4 @@
-error[E0424]: expected value, found module `self`
+error[E0424]: cannot find value `self` in this scope
   --> $DIR/missing-self-diag.rs:10:9
    |
 LL |           self.bar();
@@ -10,6 +10,7 @@ LL | |         call_bar!();
 LL | |     }
    | |_____- this function has a `self` parameter, but a macro invocation can only access identifiers it receives from parameters
    |
+   = note: a module named `self` exists in another namespace
    = note: this error originates in the macro `call_bar` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error

--- a/tests/ui/hygiene/rustc-macro-transparency.rs
+++ b/tests/ui/hygiene/rustc-macro-transparency.rs
@@ -26,6 +26,6 @@ fn main() {
     Opaque; //~ ERROR cannot find value `Opaque` in this scope
 
     transparent; // OK
-    semiopaque; //~ ERROR expected value, found macro `semiopaque`
-    opaque; //~ ERROR expected value, found macro `opaque`
+    semiopaque; //~ ERROR cannot find value `semiopaque` in this scope
+    opaque; //~ ERROR cannot find value `opaque` in this scope
 }

--- a/tests/ui/hygiene/rustc-macro-transparency.stderr
+++ b/tests/ui/hygiene/rustc-macro-transparency.stderr
@@ -4,26 +4,29 @@ error[E0425]: cannot find value `Opaque` in this scope
 LL |     Opaque;
    |     ^^^^^^ not found in this scope
 
-error[E0423]: expected value, found macro `semiopaque`
+error[E0423]: cannot find value `semiopaque` in this scope
   --> $DIR/rustc-macro-transparency.rs:29:5
    |
 LL |     struct SemiOpaque;
    |     ------------------ similarly named unit struct `SemiOpaque` defined here
 ...
 LL |     semiopaque;
-   |     ^^^^^^^^^^ not a value
+   |     ^^^^^^^^^^ not found in this scope
    |
+   = note: a macro named `semiopaque` exists in another namespace
 help: a unit struct with a similar name exists (notice the capitalization)
    |
 LL -     semiopaque;
 LL +     SemiOpaque;
    |
 
-error[E0423]: expected value, found macro `opaque`
+error[E0423]: cannot find value `opaque` in this scope
   --> $DIR/rustc-macro-transparency.rs:30:5
    |
 LL |     opaque;
-   |     ^^^^^^ not a value
+   |     ^^^^^^ not found in this scope
+   |
+   = note: a macro named `opaque` exists in another namespace
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/impl-trait/universal_wrong_bounds.rs
+++ b/tests/ui/impl-trait/universal_wrong_bounds.rs
@@ -6,8 +6,8 @@ fn foo(f: impl Display + Clone) -> String {
     wants_clone(f);
 }
 
-fn wants_debug(g: impl Debug) { } //~ ERROR expected trait, found derive macro `Debug`
-fn wants_display(g: impl Debug) { } //~ ERROR expected trait, found derive macro `Debug`
+fn wants_debug(g: impl Debug) { } //~ ERROR cannot find trait `Debug` in this scope
+fn wants_display(g: impl Debug) { } //~ ERROR cannot find trait `Debug` in this scope
 fn wants_clone(g: impl Clone) { }
 
 fn main() {}

--- a/tests/ui/impl-trait/universal_wrong_bounds.stderr
+++ b/tests/ui/impl-trait/universal_wrong_bounds.stderr
@@ -1,20 +1,22 @@
-error[E0404]: expected trait, found derive macro `Debug`
+error[E0404]: cannot find trait `Debug` in this scope
   --> $DIR/universal_wrong_bounds.rs:9:24
    |
 LL | fn wants_debug(g: impl Debug) { }
-   |                        ^^^^^ not a trait
+   |                        ^^^^^ not found in this scope
    |
+   = note: a derive macro named `Debug` exists in another namespace
 help: consider importing this trait instead
    |
 LL + use std::fmt::Debug;
    |
 
-error[E0404]: expected trait, found derive macro `Debug`
+error[E0404]: cannot find trait `Debug` in this scope
   --> $DIR/universal_wrong_bounds.rs:10:26
    |
 LL | fn wants_display(g: impl Debug) { }
-   |                          ^^^^^ not a trait
+   |                          ^^^^^ not found in this scope
    |
+   = note: a derive macro named `Debug` exists in another namespace
 help: consider importing this trait instead
    |
 LL + use std::fmt::Debug;

--- a/tests/ui/imports/glob-resolve1.rs
+++ b/tests/ui/imports/glob-resolve1.rs
@@ -26,7 +26,7 @@ fn foo<T>() {}
 fn main() {
     fpriv(); //~ ERROR cannot find function `fpriv` in this scope
     epriv(); //~ ERROR cannot find function `epriv` in this scope
-    B; //~ ERROR expected value, found enum `B`
+    B; //~ ERROR cannot find value `B` in this scope
     C; //~ ERROR cannot find value `C` in this scope
     import(); //~ ERROR: cannot find function `import` in this scope
 

--- a/tests/ui/imports/glob-resolve1.stderr
+++ b/tests/ui/imports/glob-resolve1.stderr
@@ -22,12 +22,13 @@ note: function `bar::epriv` exists but is inaccessible
 LL |         fn epriv();
    |         ^^^^^^^^^^^ not accessible
 
-error[E0423]: expected value, found enum `B`
+error[E0423]: cannot find value `B` in this scope
   --> $DIR/glob-resolve1.rs:29:5
    |
 LL |     B;
    |     ^
    |
+   = note: an enum named `B` exists in another namespace
 note: the enum is defined here
   --> $DIR/glob-resolve1.rs:15:5
    |

--- a/tests/ui/imports/issue-38293.rs
+++ b/tests/ui/imports/issue-38293.rs
@@ -13,5 +13,5 @@ mod bar {
 use bar::baz::{self};
 
 fn main() {
-    baz(); //~ ERROR expected function, found module `baz`
+    baz(); //~ ERROR cannot find function `baz` in this scope
 }

--- a/tests/ui/imports/issue-38293.stderr
+++ b/tests/ui/imports/issue-38293.stderr
@@ -4,12 +4,13 @@ error[E0432]: unresolved import `foo::f`
 LL | use foo::f::{self};
    |          ^ expected type, found function `f` in `foo`
 
-error[E0423]: expected function, found module `baz`
+error[E0423]: cannot find function `baz` in this scope
   --> $DIR/issue-38293.rs:16:5
    |
 LL |     baz();
-   |     ^^^ not a function
+   |     ^^^ not found in this scope
    |
+   = note: a module named `baz` exists in another namespace
 help: consider importing this function instead
    |
 LL + use bar::baz;

--- a/tests/ui/imports/issue-4366-2.rs
+++ b/tests/ui/imports/issue-4366-2.rs
@@ -23,5 +23,5 @@ mod m1 {
 }
 
 fn main() {
-    foo(); //~ ERROR expected function, found module `foo`
+    foo(); //~ ERROR cannot find function `foo` in this scope
 }

--- a/tests/ui/imports/issue-4366-2.stderr
+++ b/tests/ui/imports/issue-4366-2.stderr
@@ -10,12 +10,13 @@ note: type alias `a::b::Bar` exists but is inaccessible
 LL |         type Bar = isize;
    |         ^^^^^^^^^^^^^^^^^ not accessible
 
-error[E0423]: expected function, found module `foo`
+error[E0423]: cannot find function `foo` in this scope
   --> $DIR/issue-4366-2.rs:26:5
    |
 LL |     foo();
-   |     ^^^ not a function
+   |     ^^^ not found in this scope
    |
+   = note: a module named `foo` exists in another namespace
 note: function `m1::foo` exists but is inaccessible
   --> $DIR/issue-4366-2.rs:22:5
    |

--- a/tests/ui/imports/private-from-decl-macro.fail.stderr
+++ b/tests/ui/imports/private-from-decl-macro.fail.stderr
@@ -17,7 +17,7 @@ LL |     crate::m::mac_glob!();
    |     --------------------- in this macro invocation
    = note: this error originates in the macro `crate::m::mac_glob` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0423]: expected value, found struct `S`
+error[E0423]: cannot find value `S` in this scope
   --> $DIR/private-from-decl-macro.rs:28:17
    |
 LL |     pub struct S {}
@@ -26,6 +26,7 @@ LL |     pub struct S {}
 LL |         let s = S;
    |                 ^
    |
+   = note: a struct named `S` exists in another namespace
 note: constant `m::S` exists but is inaccessible
   --> $DIR/private-from-decl-macro.rs:10:5
    |

--- a/tests/ui/imports/private-from-decl-macro.rs
+++ b/tests/ui/imports/private-from-decl-macro.rs
@@ -25,7 +25,7 @@ mod single {
     fn check() {
         let s = S {};
         #[cfg(fail)]
-        let s = S; //[fail]~ ERROR expected value, found struct `S`
+        let s = S; //[fail]~ ERROR cannot find value `S` in this scope
     }
 }
 

--- a/tests/ui/imports/suggest-import-ice-issue-127302.edition2015.stderr
+++ b/tests/ui/imports/suggest-import-ice-issue-127302.edition2015.stderr
@@ -29,11 +29,13 @@ help: consider importing this function
 LL + use std::env::args;
    |
 
-error[E0532]: expected unit struct, unit variant or constant, found module `crate::config`
-  --> $DIR/suggest-import-ice-issue-127302.rs:7:9
+error[E0532]: cannot find unit struct, unit variant or constant `config` in the crate root
+  --> $DIR/suggest-import-ice-issue-127302.rs:7:16
    |
 LL |         crate::config => {}
-   |         ^^^^^^^^^^^^^ not a unit struct, unit variant or constant
+   |                ^^^^^^ not found in the crate root
+   |
+   = note: a module named `crate::config` exists in another namespace
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/imports/suggest-import-ice-issue-127302.edition2021.stderr
+++ b/tests/ui/imports/suggest-import-ice-issue-127302.edition2021.stderr
@@ -29,11 +29,13 @@ help: consider importing this function
 LL + use std::env::args;
    |
 
-error[E0532]: expected unit struct, unit variant or constant, found module `crate::config`
-  --> $DIR/suggest-import-ice-issue-127302.rs:7:9
+error[E0532]: cannot find unit struct, unit variant or constant `config` in the crate root
+  --> $DIR/suggest-import-ice-issue-127302.rs:7:16
    |
 LL |         crate::config => {}
-   |         ^^^^^^^^^^^^^ not a unit struct, unit variant or constant
+   |                ^^^^^^ not found in the crate root
+   |
+   = note: a module named `crate::config` exists in another namespace
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/imports/suggest-import-ice-issue-127302.rs
+++ b/tests/ui/imports/suggest-import-ice-issue-127302.rs
@@ -4,7 +4,7 @@ mod config; //~ ERROR file not found for module
 
 fn main() {
     match &args.cmd { //~ ERROR cannot find value `args` in this scope
-        crate::config => {} //~ ERROR expected unit struct, unit variant or constant, found module `crate::config`
+        crate::config => {} //~ ERROR cannot find unit struct, unit variant or constant `config` in the crate root
     }
 
     println!(args.ctx.compiler.display());

--- a/tests/ui/issues/issue-38412.stderr
+++ b/tests/ui/issues/issue-38412.stderr
@@ -3,6 +3,8 @@ error[E0532]: cannot match against a tuple struct which contains private fields
    |
 LL |     let Box(a) = loop { };
    |         ^^^ constructor is not visible here due to private fields
+   |
+   = note: a struct named `Box` exists in another namespace
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/lang-items/issue-83471.rs
+++ b/tests/ui/lang-items/issue-83471.rs
@@ -22,7 +22,7 @@ trait Sized: MetaSized {}
 //~| ERROR: `fn` lang item must be applied to a trait with 1 generic argument
 trait Fn {
     fn call(export_name);
-    //~^ ERROR: expected type
+    //~^ ERROR: cannot find type `export_name` in this scope
     //~| WARNING: anonymous parameters are deprecated
     //~| WARNING: this is accepted in the current edition
 }

--- a/tests/ui/lang-items/issue-83471.stderr
+++ b/tests/ui/lang-items/issue-83471.stderr
@@ -1,8 +1,10 @@
-error[E0573]: expected type, found built-in attribute `export_name`
+error[E0573]: cannot find type `export_name` in this scope
   --> $DIR/issue-83471.rs:24:13
    |
 LL |     fn call(export_name);
-   |             ^^^^^^^^^^^ not a type
+   |             ^^^^^^^^^^^ not found in this scope
+   |
+   = note: a built-in attribute named `export_name` exists in another namespace
 
 warning: anonymous parameters are deprecated and will be removed in the next edition
   --> $DIR/issue-83471.rs:24:13

--- a/tests/ui/namespace/namespace-mix.rs
+++ b/tests/ui/namespace/namespace-mix.rs
@@ -32,13 +32,13 @@ mod m2 {
 
 fn f12() {
     check(m1::S{}); //~ ERROR c::Item
-    check(m1::S); //~ ERROR expected value, found type alias `m1::S`
+    check(m1::S); //~ ERROR cannot find value `S` in module `m1`
     check(m2::S{}); //~ ERROR c::S
     check(m2::S); //~ ERROR c::Item
 }
 fn xf12() {
     check(xm1::S{}); //~ ERROR c::Item
-    check(xm1::S); //~ ERROR expected value, found type alias `xm1::S`
+    check(xm1::S); //~ ERROR cannot find value `S` in module `xm1`
     check(xm2::S{}); //~ ERROR c::S
     check(xm2::S); //~ ERROR c::Item
 }
@@ -98,13 +98,13 @@ mod m8 {
 
 fn f78() {
     check(m7::V{}); //~ ERROR c::Item
-    check(m7::V); //~ ERROR expected value, found type alias `m7::V`
+    check(m7::V); //~ ERROR cannot find value `V` in module `m7`
     check(m8::V{}); //~ ERROR c::E
     check(m8::V); //~ ERROR c::Item
 }
 fn xf78() {
     check(xm7::V{}); //~ ERROR c::Item
-    check(xm7::V); //~ ERROR expected value, found type alias `xm7::V`
+    check(xm7::V); //~ ERROR cannot find value `V` in module `xm7`
     check(xm8::V{}); //~ ERROR c::E
     check(xm8::V); //~ ERROR c::Item
 }

--- a/tests/ui/namespace/namespace-mix.stderr
+++ b/tests/ui/namespace/namespace-mix.stderr
@@ -1,12 +1,13 @@
-error[E0423]: expected value, found type alias `m1::S`
-  --> $DIR/namespace-mix.rs:35:11
+error[E0423]: cannot find value `S` in module `m1`
+  --> $DIR/namespace-mix.rs:35:15
    |
 LL |     pub struct TS();
    |     ---------------- similarly named tuple struct `TS` defined here
 ...
 LL |     check(m1::S);
-   |           ^^^^^
+   |               ^
    |
+   = note: a type alias named `m1::S` exists in another namespace
 help: a tuple struct with a similar name exists
    |
 LL |     check(m1::TS);
@@ -23,17 +24,18 @@ LL -     check(m1::S);
 LL +     check(S);
    |
 
-error[E0423]: expected value, found type alias `xm1::S`
-  --> $DIR/namespace-mix.rs:41:11
+error[E0423]: cannot find value `S` in module `xm1`
+  --> $DIR/namespace-mix.rs:41:16
    |
 LL |     check(xm1::S);
-   |           ^^^^^^
+   |                ^
    |
   ::: $DIR/auxiliary/namespace-mix.rs:5:5
    |
 LL |     pub struct TS();
    |     ------------- similarly named tuple struct `TS` defined here
    |
+   = note: a type alias named `xm1::S` exists in another namespace
 help: a tuple struct with a similar name exists
    |
 LL |     check(xm1::TS);
@@ -50,15 +52,16 @@ LL -     check(xm1::S);
 LL +     check(S);
    |
 
-error[E0423]: expected value, found type alias `m7::V`
-  --> $DIR/namespace-mix.rs:101:11
+error[E0423]: cannot find value `V` in module `m7`
+  --> $DIR/namespace-mix.rs:101:15
    |
 LL |         TV(),
    |         ---- similarly named tuple variant `TV` defined here
 ...
 LL |     check(m7::V);
-   |           ^^^^^
+   |               ^
    |
+   = note: a type alias named `m7::V` exists in another namespace
 help: a tuple variant with a similar name exists
    |
 LL |     check(m7::TV);
@@ -75,17 +78,18 @@ LL -     check(m7::V);
 LL +     check(V);
    |
 
-error[E0423]: expected value, found type alias `xm7::V`
-  --> $DIR/namespace-mix.rs:107:11
+error[E0423]: cannot find value `V` in module `xm7`
+  --> $DIR/namespace-mix.rs:107:16
    |
 LL |     check(xm7::V);
-   |           ^^^^^^
+   |                ^
    |
   ::: $DIR/auxiliary/namespace-mix.rs:9:9
    |
 LL |         TV(),
    |         -- similarly named tuple variant `TV` defined here
    |
+   = note: a type alias named `xm7::V` exists in another namespace
 help: a tuple variant with a similar name exists
    |
 LL |     check(xm7::TV);

--- a/tests/ui/parallel-rustc/recursive-impl-trait-deadlock-issue-129912.rs
+++ b/tests/ui/parallel-rustc/recursive-impl-trait-deadlock-issue-129912.rs
@@ -6,8 +6,8 @@
 
 fn option(i: i32) -> impl Sync {
     if generator_sig() < 0 { None } else { Sized((option(i - Sized), i)) }
-    //~^ ERROR expected value, found trait `Sized`
-    //~| ERROR expected function, tuple struct or tuple variant, found trait `Sized`
+    //~^ ERROR cannot find value `Sized` in this scope
+    //~| ERROR cannot find function, tuple struct or tuple variant `Sized` in this scope
 }
 
 fn tuple() -> impl Sized {
@@ -70,7 +70,7 @@ fn substs_change<T: 'static>() -> impl Sized {
 }
 
 fn generator_hold() -> impl generator_capture {
-    //~^ ERROR expected trait, found function `generator_capture`
+    //~^ ERROR cannot find trait `generator_capture` in this scope
     move || {
         let x = ();
         yield;

--- a/tests/ui/parallel-rustc/recursive-impl-trait-deadlock-issue-129912.stderr
+++ b/tests/ui/parallel-rustc/recursive-impl-trait-deadlock-issue-129912.stderr
@@ -13,11 +13,13 @@ LL | #![feature(generators)]
    = note: removed in 1.75.0; see <https://github.com/rust-lang/rust/pull/116958> for more information
    = note: renamed to `coroutines`
 
-error[E0423]: expected value, found trait `Sized`
+error[E0423]: cannot find value `Sized` in this scope
   --> $DIR/recursive-impl-trait-deadlock-issue-129912.rs:8:62
    |
 LL |     if generator_sig() < 0 { None } else { Sized((option(i - Sized), i)) }
-   |                                                              ^^^^^ not a value
+   |                                                              ^^^^^ not found in this scope
+   |
+   = note: a trait named `Sized` exists in another namespace
 
 error[E0425]: cannot find value `i` in this scope
   --> $DIR/recursive-impl-trait-deadlock-issue-129912.rs:52:8
@@ -31,11 +33,13 @@ error[E0404]: expected trait, found builtin type `i32`
 LL | fn generator_capture() -> impl i32 {
    |                                ^^^ not a trait
 
-error[E0404]: expected trait, found function `generator_capture`
+error[E0404]: cannot find trait `generator_capture` in this scope
   --> $DIR/recursive-impl-trait-deadlock-issue-129912.rs:72:29
    |
 LL | fn generator_hold() -> impl generator_capture {
-   |                             ^^^^^^^^^^^^^^^^^ not a trait
+   |                             ^^^^^^^^^^^^^^^^^ not found in this scope
+   |
+   = note: a function named `generator_capture` exists in another namespace
 
 error[E0658]: yield syntax is experimental
   --> $DIR/recursive-impl-trait-deadlock-issue-129912.rs:60:9
@@ -125,11 +129,13 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
 LL | fn closure_sig() -> _ {
    |                     ^ not allowed in type signatures
 
-error[E0423]: expected function, tuple struct or tuple variant, found trait `Sized`
+error[E0423]: cannot find function, tuple struct or tuple variant `Sized` in this scope
   --> $DIR/recursive-impl-trait-deadlock-issue-129912.rs:8:44
    |
 LL |     if generator_sig() < 0 { None } else { Sized((option(i - Sized), i)) }
-   |                                            ^^^^^ not a function, tuple struct or tuple variant
+   |                                            ^^^^^ not found in this scope
+   |
+   = note: a trait named `Sized` exists in another namespace
 
 error: aborting due to 17 previous errors
 

--- a/tests/ui/parser/issues/issue-73568-lifetime-after-mut.rs
+++ b/tests/ui/parser/issues/issue-73568-lifetime-after-mut.rs
@@ -15,6 +15,6 @@ fn y<'a>(y: &mut 'a + Send) {
     //~^ ERROR expected a path on the left-hand side of `+`
     //~| ERROR at least one trait is required for an object type
     let z = y as &mut 'a + Send;
-    //~^ ERROR expected value, found trait `Send`
+    //~^ ERROR cannot find value `Send` in this scope
     //~| ERROR at least one trait is required for an object type
 }

--- a/tests/ui/parser/issues/issue-73568-lifetime-after-mut.stderr
+++ b/tests/ui/parser/issues/issue-73568-lifetime-after-mut.stderr
@@ -37,11 +37,13 @@ LL -         fn w<$lt>(w: &mut $lt i32) {}
 LL +         fn w<$lt>(w: &$lt mut i32) {}
    |
 
-error[E0423]: expected value, found trait `Send`
+error[E0423]: cannot find value `Send` in this scope
   --> $DIR/issue-73568-lifetime-after-mut.rs:17:28
    |
 LL |     let z = y as &mut 'a + Send;
-   |                            ^^^^ not a value
+   |                            ^^^^ not found in this scope
+   |
+   = note: a trait named `Send` exists in another namespace
 
 error[E0224]: at least one trait is required for an object type
   --> $DIR/issue-73568-lifetime-after-mut.rs:14:18

--- a/tests/ui/parser/not-a-pred.rs
+++ b/tests/ui/parser/not-a-pred.rs
@@ -1,8 +1,8 @@
 fn f(a: isize, b: isize) : lt(a, b) { }
 //~^ ERROR return types are denoted using `->`
-//~| ERROR expected type, found function `lt` [E0573]
-//~| ERROR expected type, found local variable `a` [E0573]
-//~| ERROR expected type, found local variable `b` [E0573]
+//~| ERROR cannot find type `lt` in this scope [E0573]
+//~| ERROR cannot find type `a` in this scope [E0573]
+//~| ERROR cannot find type `b` in this scope [E0573]
 
 fn lt(a: isize, b: isize) { }
 

--- a/tests/ui/parser/not-a-pred.stderr
+++ b/tests/ui/parser/not-a-pred.stderr
@@ -10,23 +10,29 @@ LL - fn f(a: isize, b: isize) : lt(a, b) { }
 LL + fn f(a: isize, b: isize) -> lt(a, b) { }
    |
 
-error[E0573]: expected type, found function `lt`
+error[E0573]: cannot find type `lt` in this scope
   --> $DIR/not-a-pred.rs:1:28
    |
 LL | fn f(a: isize, b: isize) : lt(a, b) { }
-   |                            ^^^^^^^^ not a type
+   |                            ^^ not found in this scope
+   |
+   = note: a function named `lt` exists in another namespace
 
-error[E0573]: expected type, found local variable `a`
+error[E0573]: cannot find type `a` in this scope
   --> $DIR/not-a-pred.rs:1:31
    |
 LL | fn f(a: isize, b: isize) : lt(a, b) { }
-   |                               ^ not a type
+   |                               ^ not found in this scope
+   |
+   = note: a local variable named `a` exists in another namespace
 
-error[E0573]: expected type, found local variable `b`
+error[E0573]: cannot find type `b` in this scope
   --> $DIR/not-a-pred.rs:1:34
    |
 LL | fn f(a: isize, b: isize) : lt(a, b) { }
-   |                                  ^ not a type
+   |                                  ^ not found in this scope
+   |
+   = note: a local variable named `b` exists in another namespace
 
 error[E0425]: cannot find function `check` in this scope
   --> $DIR/not-a-pred.rs:12:5

--- a/tests/ui/parser/recover/array-type-no-semi.rs
+++ b/tests/ui/parser/recover/array-type-no-semi.rs
@@ -8,7 +8,7 @@ fn main() {
     //~^ ERROR expected `;` or `]`, found `,`
     let a: [i32, ];
     //~^ ERROR expected `;` or `]`, found `,`
-    //~| ERROR expected value, found builtin type `i32` [E0423]
+    //~| ERROR cannot find value `i32` in this scope [E0423]
     let c: [i32, x];
     //~^ ERROR expected `;` or `]`, found `,`
     //~| ERROR attempt to use a non-constant value in a constant [E0435]

--- a/tests/ui/parser/recover/array-type-no-semi.stderr
+++ b/tests/ui/parser/recover/array-type-no-semi.stderr
@@ -71,11 +71,13 @@ LL -     let x = 5;
 LL +     const x: /* Type */ = 5;
    |
 
-error[E0423]: expected value, found builtin type `i32`
+error[E0423]: cannot find value `i32` in this scope
   --> $DIR/array-type-no-semi.rs:9:13
    |
 LL |     let a: [i32, ];
-   |             ^^^ not a value
+   |             ^^^ not found in this scope
+   |
+   = note: a builtin type named `i32` exists in another namespace
 
 error: aborting due to 7 previous errors
 

--- a/tests/ui/parser/unicode-string-literal-syntax-error-64792.rs
+++ b/tests/ui/parser/unicode-string-literal-syntax-error-64792.rs
@@ -1,6 +1,6 @@
 // https://github.com/rust-lang/rust/issues/64792
 struct X {}
 
-const Y: X = X("ö"); //~ ERROR expected function, tuple struct or tuple variant, found struct `X`
+const Y: X = X("ö"); //~ ERROR cannot find function, tuple struct or tuple variant `X` in this scope
 
 fn main() {}

--- a/tests/ui/parser/unicode-string-literal-syntax-error-64792.stderr
+++ b/tests/ui/parser/unicode-string-literal-syntax-error-64792.stderr
@@ -1,4 +1,4 @@
-error[E0423]: expected function, tuple struct or tuple variant, found struct `X`
+error[E0423]: cannot find function, tuple struct or tuple variant `X` in this scope
   --> $DIR/unicode-string-literal-syntax-error-64792.rs:4:14
    |
 LL | struct X {}
@@ -6,6 +6,8 @@ LL | struct X {}
 LL |
 LL | const Y: X = X("ö");
    |              ^^^^^^ help: use struct literal syntax instead: `X {}`
+   |
+   = note: a struct named `X` exists in another namespace
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/pattern/issue-106862.fixed
+++ b/tests/ui/pattern/issue-106862.fixed
@@ -14,31 +14,31 @@ fn main() {
 
     match f {
         FooB { x: a, y: b } => println!("{} {}", a, b),
-        //~^ ERROR expected tuple struct or tuple variant, found variant `FooB`
+        //~^ ERROR cannot find tuple struct or tuple variant `FooB` in this scope
         _ => (),
     }
 
     match f {
         FooB { x, y } => println!("{} {}", x, y),
-        //~^ ERROR expected tuple struct or tuple variant, found variant `FooB`
+        //~^ ERROR cannot find tuple struct or tuple variant `FooB` in this scope
         _ => (),
     }
 
     match f {
         FooA { opt_x: Some(x), y } => println!("{} {}", x, y),
-        //~^ ERROR expected tuple struct or tuple variant, found variant `FooA`
+        //~^ ERROR cannot find tuple struct or tuple variant `FooA` in this scope
         _ => (),
     }
 
     match f {
         FooB { x: a, y: _ } => println!("{}", a),
-        //~^ ERROR expected tuple struct or tuple variant, found variant `FooB`
+        //~^ ERROR cannot find tuple struct or tuple variant `FooB` in this scope
         _ => (),
     }
 
     match f {
         FooB { x, y } => (),
-        //~^ ERROR expected tuple struct or tuple variant, found variant `FooB`
+        //~^ ERROR cannot find tuple struct or tuple variant `FooB` in this scope
         _ => (),
     }
 }

--- a/tests/ui/pattern/issue-106862.rs
+++ b/tests/ui/pattern/issue-106862.rs
@@ -14,31 +14,31 @@ fn main() {
 
     match f {
         FooB(a, b) => println!("{} {}", a, b),
-        //~^ ERROR expected tuple struct or tuple variant, found variant `FooB`
+        //~^ ERROR cannot find tuple struct or tuple variant `FooB` in this scope
         _ => (),
     }
 
     match f {
         FooB(x, y) => println!("{} {}", x, y),
-        //~^ ERROR expected tuple struct or tuple variant, found variant `FooB`
+        //~^ ERROR cannot find tuple struct or tuple variant `FooB` in this scope
         _ => (),
     }
 
     match f {
         FooA(Some(x), y) => println!("{} {}", x, y),
-        //~^ ERROR expected tuple struct or tuple variant, found variant `FooA`
+        //~^ ERROR cannot find tuple struct or tuple variant `FooA` in this scope
         _ => (),
     }
 
     match f {
         FooB(a, _, _) => println!("{}", a),
-        //~^ ERROR expected tuple struct or tuple variant, found variant `FooB`
+        //~^ ERROR cannot find tuple struct or tuple variant `FooB` in this scope
         _ => (),
     }
 
     match f {
         FooB() => (),
-        //~^ ERROR expected tuple struct or tuple variant, found variant `FooB`
+        //~^ ERROR cannot find tuple struct or tuple variant `FooB` in this scope
         _ => (),
     }
 }

--- a/tests/ui/pattern/issue-106862.stderr
+++ b/tests/ui/pattern/issue-106862.stderr
@@ -1,4 +1,4 @@
-error[E0532]: expected tuple struct or tuple variant, found variant `FooB`
+error[E0532]: cannot find tuple struct or tuple variant `FooB` in this scope
   --> $DIR/issue-106862.rs:16:9
    |
 LL |     FooB { x: i32, y: i32 }
@@ -6,8 +6,10 @@ LL |     FooB { x: i32, y: i32 }
 ...
 LL |         FooB(a, b) => println!("{} {}", a, b),
    |         ^^^^^^^^^^ help: use struct pattern syntax instead: `FooB { x: a, y: b }`
+   |
+   = note: a variant named `FooB` exists in another namespace
 
-error[E0532]: expected tuple struct or tuple variant, found variant `FooB`
+error[E0532]: cannot find tuple struct or tuple variant `FooB` in this scope
   --> $DIR/issue-106862.rs:22:9
    |
 LL |     FooB { x: i32, y: i32 }
@@ -15,8 +17,10 @@ LL |     FooB { x: i32, y: i32 }
 ...
 LL |         FooB(x, y) => println!("{} {}", x, y),
    |         ^^^^^^^^^^ help: use struct pattern syntax instead: `FooB { x, y }`
+   |
+   = note: a variant named `FooB` exists in another namespace
 
-error[E0532]: expected tuple struct or tuple variant, found variant `FooA`
+error[E0532]: cannot find tuple struct or tuple variant `FooA` in this scope
   --> $DIR/issue-106862.rs:28:9
    |
 LL |     FooA { opt_x: Option<i32>, y: i32 },
@@ -24,8 +28,10 @@ LL |     FooA { opt_x: Option<i32>, y: i32 },
 ...
 LL |         FooA(Some(x), y) => println!("{} {}", x, y),
    |         ^^^^^^^^^^^^^^^^ help: use struct pattern syntax instead: `FooA { opt_x: Some(x), y }`
+   |
+   = note: a variant named `FooA` exists in another namespace
 
-error[E0532]: expected tuple struct or tuple variant, found variant `FooB`
+error[E0532]: cannot find tuple struct or tuple variant `FooB` in this scope
   --> $DIR/issue-106862.rs:34:9
    |
 LL |     FooB { x: i32, y: i32 }
@@ -33,8 +39,10 @@ LL |     FooB { x: i32, y: i32 }
 ...
 LL |         FooB(a, _, _) => println!("{}", a),
    |         ^^^^^^^^^^^^^ help: use struct pattern syntax instead: `FooB { x: a, y: _ }`
+   |
+   = note: a variant named `FooB` exists in another namespace
 
-error[E0532]: expected tuple struct or tuple variant, found variant `FooB`
+error[E0532]: cannot find tuple struct or tuple variant `FooB` in this scope
   --> $DIR/issue-106862.rs:40:9
    |
 LL |     FooB { x: i32, y: i32 }
@@ -42,6 +50,8 @@ LL |     FooB { x: i32, y: i32 }
 ...
 LL |         FooB() => (),
    |         ^^^^^^ help: use struct pattern syntax instead: `FooB { x, y }`
+   |
+   = note: a variant named `FooB` exists in another namespace
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/pattern/no-match-tuple-variant-self-ctor.rs
+++ b/tests/ui/pattern/no-match-tuple-variant-self-ctor.rs
@@ -28,7 +28,7 @@ mod struct_ {
     impl S {
         fn foo() {
             let Self = S;
-            //[struct_]~^ ERROR expected value, found struct `S`
+            //[struct_]~^ ERROR cannot find value `S` in this scope
             //[struct_]~| ERROR expected unit struct, found self constructor `Self`
         }
     }

--- a/tests/ui/pattern/no-match-tuple-variant-self-ctor.struct_.stderr
+++ b/tests/ui/pattern/no-match-tuple-variant-self-ctor.struct_.stderr
@@ -1,4 +1,4 @@
-error[E0423]: expected value, found struct `S`
+error[E0423]: cannot find value `S` in this scope
   --> $DIR/no-match-tuple-variant-self-ctor.rs:30:24
    |
 LL |     struct S {}
@@ -6,6 +6,8 @@ LL |     struct S {}
 ...
 LL |             let Self = S;
    |                        ^ help: use struct literal syntax instead: `S {}`
+   |
+   = note: a struct named `S` exists in another namespace
 
 error[E0533]: expected unit struct, found self constructor `Self`
   --> $DIR/no-match-tuple-variant-self-ctor.rs:30:17

--- a/tests/ui/pattern/struct-variant-as-tuple-variant.rs
+++ b/tests/ui/pattern/struct-variant-as-tuple-variant.rs
@@ -10,6 +10,6 @@ fn main() {
     let f = FooB { x: 3, y: 4 };
     match f {
         FooB(a, b) => println!("{} {}", a, b),
-        //~^ ERROR expected tuple struct or tuple variant, found variant `FooB`
+        //~^ ERROR cannot find tuple struct or tuple variant `FooB` in this scope
     }
 }

--- a/tests/ui/pattern/struct-variant-as-tuple-variant.stderr
+++ b/tests/ui/pattern/struct-variant-as-tuple-variant.stderr
@@ -1,4 +1,4 @@
-error[E0532]: expected tuple struct or tuple variant, found variant `FooB`
+error[E0532]: cannot find tuple struct or tuple variant `FooB` in this scope
   --> $DIR/struct-variant-as-tuple-variant.rs:12:9
    |
 LL |     FooB { x: i32, y: i32 }
@@ -6,6 +6,8 @@ LL |     FooB { x: i32, y: i32 }
 ...
 LL |         FooB(a, b) => println!("{} {}", a, b),
    |         ^^^^^^^^^^ help: use struct pattern syntax instead: `FooB { x: a, y: b }`
+   |
+   = note: a variant named `FooB` exists in another namespace
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/privacy/ctor-not-accessible-due-to-inaccessible-field-in-reexport.fixed
+++ b/tests/ui/privacy/ctor-not-accessible-due-to-inaccessible-field-in-reexport.fixed
@@ -11,8 +11,10 @@ mod my_mod {
         fn my_func() {
             let crate::my_mod::Foo(x) = crate::my_mod::Foo(42);
             //~^ ERROR cannot initialize a tuple struct which contains private fields
+            //~| NOTE a struct named `crate::Foo` exists in another namespace
             //~| HELP the type can be constructed directly, because its fields are available from the current scope
             //~| ERROR cannot match against a tuple struct which contains private fields
+            //~| NOTE a struct named `crate::Foo` exists in another namespace
             //~| HELP the type can be constructed directly, because its fields are available from the current scope
         }
     }

--- a/tests/ui/privacy/ctor-not-accessible-due-to-inaccessible-field-in-reexport.rs
+++ b/tests/ui/privacy/ctor-not-accessible-due-to-inaccessible-field-in-reexport.rs
@@ -11,8 +11,10 @@ mod my_mod {
         fn my_func() {
             let crate::Foo(x) = crate::Foo(42);
             //~^ ERROR cannot initialize a tuple struct which contains private fields
+            //~| NOTE a struct named `crate::Foo` exists in another namespace
             //~| HELP the type can be constructed directly, because its fields are available from the current scope
             //~| ERROR cannot match against a tuple struct which contains private fields
+            //~| NOTE a struct named `crate::Foo` exists in another namespace
             //~| HELP the type can be constructed directly, because its fields are available from the current scope
         }
     }

--- a/tests/ui/privacy/ctor-not-accessible-due-to-inaccessible-field-in-reexport.stderr
+++ b/tests/ui/privacy/ctor-not-accessible-due-to-inaccessible-field-in-reexport.stderr
@@ -1,9 +1,10 @@
 error[E0423]: cannot initialize a tuple struct which contains private fields
-  --> $DIR/ctor-not-accessible-due-to-inaccessible-field-in-reexport.rs:12:33
+  --> $DIR/ctor-not-accessible-due-to-inaccessible-field-in-reexport.rs:12:40
    |
 LL |             let crate::Foo(x) = crate::Foo(42);
-   |                                 ^^^^^^^^^^
+   |                                        ^^^
    |
+   = note: a struct named `crate::Foo` exists in another namespace
 note: the type is accessed through this re-export, but the type's constructor is not visible in this import's scope due to private fields
   --> $DIR/ctor-not-accessible-due-to-inaccessible-field-in-reexport.rs:3:9
    |
@@ -15,11 +16,12 @@ LL |             let crate::Foo(x) = crate::my_mod::Foo(42);
    |                                        ++++++++
 
 error[E0532]: cannot match against a tuple struct which contains private fields
-  --> $DIR/ctor-not-accessible-due-to-inaccessible-field-in-reexport.rs:12:17
+  --> $DIR/ctor-not-accessible-due-to-inaccessible-field-in-reexport.rs:12:24
    |
 LL |             let crate::Foo(x) = crate::Foo(42);
-   |                 ^^^^^^^^^^
+   |                        ^^^
    |
+   = note: a struct named `crate::Foo` exists in another namespace
 note: the type is accessed through this re-export, but the type's constructor is not visible in this import's scope due to private fields
   --> $DIR/ctor-not-accessible-due-to-inaccessible-field-in-reexport.rs:3:9
    |

--- a/tests/ui/privacy/issue-75906.stderr
+++ b/tests/ui/privacy/issue-75906.stderr
@@ -4,6 +4,7 @@ error[E0423]: cannot initialize a tuple struct which contains private fields
 LL |     let y = Bar(12);
    |             ^^^
    |
+   = note: a struct named `Bar` exists in another namespace
 note: constructor is not visible here due to private fields
   --> $DIR/issue-75906.rs:4:20
    |

--- a/tests/ui/privacy/issue-75907.stderr
+++ b/tests/ui/privacy/issue-75907.stderr
@@ -4,6 +4,7 @@ error[E0532]: cannot match against a tuple struct which contains private fields
 LL |     let Bar(x, y, Foo(z)) = make_bar();
    |         ^^^
    |
+   = note: a struct named `Bar` exists in another namespace
 note: constructor is not visible here due to private fields
   --> $DIR/issue-75907.rs:15:16
    |
@@ -23,6 +24,7 @@ error[E0532]: cannot match against a tuple struct which contains private fields
 LL |     let Bar(x, y, Foo(z)) = make_bar();
    |                   ^^^
    |
+   = note: a struct named `Foo` exists in another namespace
 note: constructor is not visible here due to private fields
   --> $DIR/issue-75907.rs:15:23
    |

--- a/tests/ui/privacy/issue-75907_b.stderr
+++ b/tests/ui/privacy/issue-75907_b.stderr
@@ -4,6 +4,7 @@ error[E0532]: cannot match against a tuple struct which contains private fields
 LL |     let Bar(x, y, z) = make_bar();
    |         ^^^
    |
+   = note: a struct named `Bar` exists in another namespace
 note: constructor is not visible here due to private fields
   --> $DIR/issue-75907_b.rs:9:16
    |
@@ -18,6 +19,7 @@ error[E0532]: cannot match against a tuple struct which contains private fields
 LL |     let Foo(x, y, z) = Foo::new();
    |         ^^^
    |
+   = note: a struct named `Foo` exists in another namespace
 note: constructor is not visible here due to private fields
   --> $DIR/issue-75907_b.rs:12:13
    |

--- a/tests/ui/privacy/legacy-ctor-visibility.rs
+++ b/tests/ui/privacy/legacy-ctor-visibility.rs
@@ -7,7 +7,7 @@ mod m {
         use crate::S;
         fn f() {
             S(10);
-            //~^ ERROR expected function, tuple struct or tuple variant, found struct `S`
+            //~^ ERROR cannot find function, tuple struct or tuple variant `S` in this scope
         }
     }
 }

--- a/tests/ui/privacy/legacy-ctor-visibility.stderr
+++ b/tests/ui/privacy/legacy-ctor-visibility.stderr
@@ -1,8 +1,10 @@
-error[E0423]: expected function, tuple struct or tuple variant, found struct `S`
+error[E0423]: cannot find function, tuple struct or tuple variant `S` in this scope
   --> $DIR/legacy-ctor-visibility.rs:9:13
    |
 LL |             S(10);
    |             ^
+   |
+   = note: a struct named `S` exists in another namespace
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/privacy/privacy-ns1.rs
+++ b/tests/ui/privacy/privacy-ns1.rs
@@ -18,7 +18,7 @@ pub mod foo1 {
 fn test_glob1() {
     use foo1::*;
 
-    Bar();  //~ ERROR expected function, tuple struct or tuple variant, found trait `Bar`
+    Bar();  //~ ERROR cannot find function, tuple struct or tuple variant `Bar` in this scope
 }
 
 // private type, public value

--- a/tests/ui/privacy/privacy-ns1.stderr
+++ b/tests/ui/privacy/privacy-ns1.stderr
@@ -1,4 +1,4 @@
-error[E0423]: expected function, tuple struct or tuple variant, found trait `Bar`
+error[E0423]: cannot find function, tuple struct or tuple variant `Bar` in this scope
   --> $DIR/privacy-ns1.rs:21:5
    |
 LL |     pub struct Baz;
@@ -7,6 +7,7 @@ LL |     pub struct Baz;
 LL |     Bar();
    |     ^^^
    |
+   = note: a trait named `Bar` exists in another namespace
 note: these functions exist but are inaccessible
   --> $DIR/privacy-ns1.rs:15:5
    |

--- a/tests/ui/privacy/privacy-ns2.rs
+++ b/tests/ui/privacy/privacy-ns2.rs
@@ -18,13 +18,13 @@ pub mod foo1 {
 fn test_single1() {
     use foo1::Bar;
 
-    Bar(); //~ ERROR expected function, tuple struct or tuple variant, found trait `Bar`
+    Bar(); //~ ERROR cannot find function, tuple struct or tuple variant `Bar` in this scope
 }
 
 fn test_list1() {
     use foo1::{Bar,Baz};
 
-    Bar(); //~ ERROR expected function, tuple struct or tuple variant, found trait `Bar`
+    Bar(); //~ ERROR cannot find function, tuple struct or tuple variant `Bar` in this scope
 }
 
 // private type, public value
@@ -40,7 +40,7 @@ fn test_single2() {
     use foo2::Bar;
 
     let _x : Box<Bar>; //~ ERROR constant provided when a type was expected
-    let _x : Bar(); //~ ERROR expected type, found function `Bar`
+    let _x : Bar(); //~ ERROR cannot find type `Bar` in this scope
 }
 
 fn test_list2() {

--- a/tests/ui/privacy/privacy-ns2.stderr
+++ b/tests/ui/privacy/privacy-ns2.stderr
@@ -1,9 +1,10 @@
-error[E0423]: expected function, tuple struct or tuple variant, found trait `Bar`
+error[E0423]: cannot find function, tuple struct or tuple variant `Bar` in this scope
   --> $DIR/privacy-ns2.rs:21:5
    |
 LL |     Bar();
-   |     ^^^ not a function, tuple struct or tuple variant
+   |     ^^^ not found in this scope
    |
+   = note: a trait named `Bar` exists in another namespace
 note: these functions exist but are inaccessible
   --> $DIR/privacy-ns2.rs:15:5
    |
@@ -17,7 +18,7 @@ help: consider importing this function instead
 LL + use foo2::Bar;
    |
 
-error[E0423]: expected function, tuple struct or tuple variant, found trait `Bar`
+error[E0423]: cannot find function, tuple struct or tuple variant `Bar` in this scope
   --> $DIR/privacy-ns2.rs:27:5
    |
 LL |     pub struct Baz;
@@ -26,6 +27,7 @@ LL |     pub struct Baz;
 LL |     Bar();
    |     ^^^
    |
+   = note: a trait named `Bar` exists in another namespace
 note: these functions exist but are inaccessible
   --> $DIR/privacy-ns2.rs:15:5
    |
@@ -44,12 +46,13 @@ help: consider importing this function instead
 LL + use foo2::Bar;
    |
 
-error[E0573]: expected type, found function `Bar`
+error[E0573]: cannot find type `Bar` in this scope
   --> $DIR/privacy-ns2.rs:43:14
    |
 LL |     let _x : Bar();
-   |              ^^^^^ not a type
+   |              ^^^ not found in this scope
    |
+   = note: a function named `Bar` exists in another namespace
 note: these traits exist but are inaccessible
   --> $DIR/privacy-ns2.rs:32:5
    |

--- a/tests/ui/privacy/private-fields-diagnostic-issue-151408.stderr
+++ b/tests/ui/privacy/private-fields-diagnostic-issue-151408.stderr
@@ -16,6 +16,7 @@ error[E0423]: cannot initialize a tuple struct which contains private fields
 LL |     let _ = PublicTuple();
    |             ^^^^^^^^^^^
    |
+   = note: a struct named `PublicTuple` exists in another namespace
 note: constructor is not visible here due to private fields
   --> $DIR/auxiliary/private-fields-diagnostic-aux-issue-151408.rs:18:24
    |

--- a/tests/ui/privacy/suggest-box-new.rs
+++ b/tests/ui/privacy/suggest-box-new.rs
@@ -12,7 +12,7 @@ fn main() {
         x: ()
     };
     let _ = std::collections::HashMap();
-    //~^ ERROR expected function, tuple struct or tuple variant, found struct `std::collections::HashMap`
+    //~^ ERROR cannot find function, tuple struct or tuple variant `HashMap` in module `std::collections`
     let _ = std::collections::HashMap {};
     //~^ ERROR cannot construct `HashMap<_, _, _, _>` with struct literal syntax due to private fields
     let _ = Box {}; //~ ERROR cannot construct `Box<_, _>` with struct literal syntax due to private fields

--- a/tests/ui/privacy/suggest-box-new.stderr
+++ b/tests/ui/privacy/suggest-box-new.stderr
@@ -1,4 +1,4 @@
-error[E0423]: expected function, tuple struct or tuple variant, found struct `std::collections::HashMap`
+error[E0423]: cannot find function, tuple struct or tuple variant `HashMap` in module `std::collections`
   --> $DIR/suggest-box-new.rs:14:13
    |
 LL |     let _ = std::collections::HashMap();
@@ -8,6 +8,8 @@ LL |     let _ = std::collections::HashMap();
   ::: $SRC_DIR/std/src/collections/hash/map.rs:LL:COL
    |
    = note: `std::collections::HashMap` defined here
+   |
+   = note: a struct named `std::collections::HashMap` exists in another namespace
 help: you might have meant to use an associated function to build this type
    |
 LL |     let _ = std::collections::HashMap::new();
@@ -33,6 +35,7 @@ error[E0423]: cannot initialize a tuple struct which contains private fields
 LL |         wtf: Some(Box(U {
    |                   ^^^
    |
+   = note: a struct named `Box` exists in another namespace
 note: constructor is not visible here due to private fields
   --> $SRC_DIR/alloc/src/boxed.rs:LL:COL
    |

--- a/tests/ui/privacy/suggest-making-field-public.stderr
+++ b/tests/ui/privacy/suggest-making-field-public.stderr
@@ -24,6 +24,7 @@ error[E0423]: cannot initialize a tuple struct which contains private fields
 LL |         A("".into());
    |         ^
    |
+   = note: a struct named `A` exists in another namespace
 note: constructor is not visible here due to private fields
   --> $DIR/suggest-making-field-public.rs:3:18
    |

--- a/tests/ui/resolve/bad-expr-path2.rs
+++ b/tests/ui/resolve/bad-expr-path2.rs
@@ -6,5 +6,5 @@ fn main(arguments: Vec<String>) { //~ ERROR `main` function has wrong type
     log(debug, m1::arguments);
     //~^ ERROR cannot find function `log` in this scope
     //~| ERROR cannot find value `debug` in this scope
-    //~| ERROR expected value, found module `m1::arguments`
+    //~| ERROR cannot find value `arguments` in module `m1`
 }

--- a/tests/ui/resolve/bad-expr-path2.stderr
+++ b/tests/ui/resolve/bad-expr-path2.stderr
@@ -4,11 +4,13 @@ error[E0425]: cannot find value `debug` in this scope
 LL |     log(debug, m1::arguments);
    |         ^^^^^ not found in this scope
 
-error[E0423]: expected value, found module `m1::arguments`
-  --> $DIR/bad-expr-path2.rs:6:16
+error[E0423]: cannot find value `arguments` in module `m1`
+  --> $DIR/bad-expr-path2.rs:6:20
    |
 LL |     log(debug, m1::arguments);
-   |                ^^^^^^^^^^^^^ not a value
+   |                    ^^^^^^^^^ not found in `m1`
+   |
+   = note: a module named `m1::arguments` exists in another namespace
 
 error[E0580]: `main` function has wrong type
   --> $DIR/bad-expr-path2.rs:5:1

--- a/tests/ui/resolve/builtin-attribute-not-value.rs
+++ b/tests/ui/resolve/builtin-attribute-not-value.rs
@@ -1,0 +1,29 @@
+fn missing_value() {
+    path;
+    //~^ ERROR cannot find value `path` in this scope [E0423]
+}
+
+fn missing_function() {
+    path();
+    //~^ ERROR cannot find function `path` in this scope [E0423]
+}
+
+fn suggested_value() {
+    let pathh = ();
+    path;
+    //~^ ERROR cannot find value `path` in this scope [E0423]
+    let _ = pathh;
+}
+
+struct Wat {
+    path: (),
+}
+
+impl Wat {
+    fn new() -> Wat {
+        Wat { path }
+        //~^ ERROR cannot find value `path` in this scope [E0423]
+    }
+}
+
+fn main() {}

--- a/tests/ui/resolve/builtin-attribute-not-value.stderr
+++ b/tests/ui/resolve/builtin-attribute-not-value.stderr
@@ -1,0 +1,42 @@
+error[E0423]: cannot find value `path` in this scope
+  --> $DIR/builtin-attribute-not-value.rs:2:5
+   |
+LL |     path;
+   |     ^^^^ not found in this scope
+   |
+   = note: a built-in attribute named `path` exists in another namespace
+
+error[E0423]: cannot find value `path` in this scope
+  --> $DIR/builtin-attribute-not-value.rs:13:5
+   |
+LL |     path;
+   |     ^^^^
+   |
+   = note: a built-in attribute named `path` exists in another namespace
+help: a local variable with a similar name exists
+   |
+LL |     pathh;
+   |         +
+
+error[E0423]: cannot find value `path` in this scope
+  --> $DIR/builtin-attribute-not-value.rs:24:15
+   |
+LL |     path: (),
+   |     ---- a field by that name exists in `Self`
+...
+LL |         Wat { path }
+   |               ^^^^
+   |
+   = note: a built-in attribute named `path` exists in another namespace
+
+error[E0423]: cannot find function `path` in this scope
+  --> $DIR/builtin-attribute-not-value.rs:7:5
+   |
+LL |     path();
+   |     ^^^^ not found in this scope
+   |
+   = note: a built-in attribute named `path` exists in another namespace
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0423`.

--- a/tests/ui/resolve/change-ty-to-const-param-sugg-0.rs
+++ b/tests/ui/resolve/change-ty-to-const-param-sugg-0.rs
@@ -5,6 +5,6 @@ fn make<N: u32>() {}
 struct Array<N: usize>([bool; N]);
 //~^ ERROR expected trait, found builtin type `usize`
 //~| HELP you might have meant to write a const parameter here
-//~| ERROR expected value, found type parameter `N`
+//~| ERROR cannot find value `N` in this scope
 
 fn main() {}

--- a/tests/ui/resolve/change-ty-to-const-param-sugg-0.stderr
+++ b/tests/ui/resolve/change-ty-to-const-param-sugg-0.stderr
@@ -20,13 +20,13 @@ help: you might have meant to write a const parameter here
 LL | struct Array<const N: usize>([bool; N]);
    |              +++++
 
-error[E0423]: expected value, found type parameter `N`
+error[E0423]: cannot find value `N` in this scope
   --> $DIR/change-ty-to-const-param-sugg-0.rs:5:31
    |
 LL | struct Array<N: usize>([bool; N]);
-   |              -                ^ not a value
-   |              |
-   |              found this type parameter
+   |                               ^ not found in this scope
+   |
+   = note: a type parameter named `N` exists in another namespace
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/resolve/dot-notation-type-namespace-suggest-path-sep.rs
+++ b/tests/ui/resolve/dot-notation-type-namespace-suggest-path-sep.rs
@@ -8,54 +8,54 @@ mod foo {
 
 fn main() {
     let _ = String.new();
-    //~^ ERROR expected value, found struct `String`
+    //~^ ERROR cannot find value `String` in this scope
     //~| HELP use the path separator
 
     let _ = String.default;
-    //~^ ERROR expected value, found struct `String`
+    //~^ ERROR cannot find value `String` in this scope
     //~| HELP use the path separator
 
     let _ = Vec::<()>.with_capacity(1);
-    //~^ ERROR expected value, found struct `Vec`
+    //~^ ERROR cannot find value `Vec` in this scope
     //~| HELP use the path separator
 
     let _ = Alias.new();
-    //~^ ERROR expected value, found type alias `Alias`
+    //~^ ERROR cannot find value `Alias` in this scope
     //~| HELP use the path separator
 
     let _ = Alias.default;
-    //~^ ERROR expected value, found type alias `Alias`
+    //~^ ERROR cannot find value `Alias` in this scope
     //~| HELP use the path separator
 
     let _ = foo.bar;
-    //~^ ERROR expected value, found module `foo`
+    //~^ ERROR cannot find value `foo` in this scope
     //~| HELP use the path separator
 }
 
 macro_rules! Type {
     () => {
         ::std::cell::Cell
-        //~^ ERROR expected value, found struct `::std::cell::Cell`
-        //~| ERROR expected value, found struct `::std::cell::Cell`
-        //~| ERROR expected value, found struct `::std::cell::Cell`
+        //~^ ERROR cannot find value `Cell` in module `::std::cell`
+        //~| ERROR cannot find value `Cell` in module `::std::cell`
+        //~| ERROR cannot find value `Cell` in module `::std::cell`
     };
     (alias) => {
         Alias
-        //~^ ERROR expected value, found type alias `Alias`
-        //~| ERROR expected value, found type alias `Alias`
-        //~| ERROR expected value, found type alias `Alias`
+        //~^ ERROR cannot find value `Alias` in this scope
+        //~| ERROR cannot find value `Alias` in this scope
+        //~| ERROR cannot find value `Alias` in this scope
     };
 }
 
 macro_rules! create {
     (type method) => {
         Vec.new()
-        //~^ ERROR expected value, found struct `Vec`
+        //~^ ERROR cannot find value `Vec` in this scope
         //~| HELP use the path separator
     };
     (type field) => {
         Vec.new
-        //~^ ERROR expected value, found struct `Vec`
+        //~^ ERROR cannot find value `Vec` in this scope
         //~| HELP use the path separator
     };
     (macro method) => {
@@ -71,22 +71,20 @@ macro_rules! create {
 macro_rules! check_ty {
     ($Ty:ident) => {
         $Ty.foo
-        //~^ ERROR expected value, found type alias `Alias`
-        //~| HELP use the path separator
+        //~^ HELP use the path separator
     };
 }
 macro_rules! check_ident {
     ($Ident:ident) => {
         Alias.$Ident
-        //~^ ERROR expected value, found type alias `Alias`
+        //~^ ERROR cannot find value `Alias` in this scope
         //~| HELP use the path separator
     };
 }
 macro_rules! check_ty_ident {
     ($Ty:ident, $Ident:ident) => {
         $Ty.$Ident
-        //~^ ERROR expected value, found type alias `Alias`
-        //~| HELP use the path separator
+        //~^ HELP use the path separator
     };
 }
 
@@ -118,6 +116,8 @@ fn interaction_with_macros() {
     let _ = create!(macro method alias);
 
     let _ = check_ty!(Alias);
+    //~^ ERROR cannot find value `Alias` in this scope
     let _ = check_ident!(foo);
     let _ = check_ty_ident!(Alias, foo);
+    //~^ ERROR cannot find value `Alias` in this scope
 }

--- a/tests/ui/resolve/dot-notation-type-namespace-suggest-path-sep.stderr
+++ b/tests/ui/resolve/dot-notation-type-namespace-suggest-path-sep.stderr
@@ -1,84 +1,91 @@
-error[E0423]: expected value, found struct `String`
+error[E0423]: cannot find value `String` in this scope
   --> $DIR/dot-notation-type-namespace-suggest-path-sep.rs:10:13
    |
 LL |     let _ = String.new();
    |             ^^^^^^
    |
+   = note: a struct named `String` exists in another namespace
 help: use the path separator to refer to an item
    |
 LL -     let _ = String.new();
 LL +     let _ = String::new();
    |
 
-error[E0423]: expected value, found struct `String`
+error[E0423]: cannot find value `String` in this scope
   --> $DIR/dot-notation-type-namespace-suggest-path-sep.rs:14:13
    |
 LL |     let _ = String.default;
    |             ^^^^^^
    |
+   = note: a struct named `String` exists in another namespace
 help: use the path separator to refer to an item
    |
 LL -     let _ = String.default;
 LL +     let _ = String::default;
    |
 
-error[E0423]: expected value, found struct `Vec`
+error[E0423]: cannot find value `Vec` in this scope
   --> $DIR/dot-notation-type-namespace-suggest-path-sep.rs:18:13
    |
 LL |     let _ = Vec::<()>.with_capacity(1);
-   |             ^^^^^^^^^
+   |             ^^^
    |
+   = note: a struct named `Vec` exists in another namespace
 help: use the path separator to refer to an item
    |
 LL -     let _ = Vec::<()>.with_capacity(1);
 LL +     let _ = Vec::<()>::with_capacity(1);
    |
 
-error[E0423]: expected value, found type alias `Alias`
+error[E0423]: cannot find value `Alias` in this scope
   --> $DIR/dot-notation-type-namespace-suggest-path-sep.rs:22:13
    |
 LL |     let _ = Alias.new();
    |             ^^^^^
    |
+   = note: a type alias named `Alias` exists in another namespace
 help: use the path separator to refer to an item
    |
 LL -     let _ = Alias.new();
 LL +     let _ = Alias::new();
    |
 
-error[E0423]: expected value, found type alias `Alias`
+error[E0423]: cannot find value `Alias` in this scope
   --> $DIR/dot-notation-type-namespace-suggest-path-sep.rs:26:13
    |
 LL |     let _ = Alias.default;
    |             ^^^^^
    |
+   = note: a type alias named `Alias` exists in another namespace
 help: use the path separator to refer to an item
    |
 LL -     let _ = Alias.default;
 LL +     let _ = Alias::default;
    |
 
-error[E0423]: expected value, found module `foo`
+error[E0423]: cannot find value `foo` in this scope
   --> $DIR/dot-notation-type-namespace-suggest-path-sep.rs:30:13
    |
 LL |     let _ = foo.bar;
    |             ^^^
    |
+   = note: a module named `foo` exists in another namespace
 help: use the path separator to refer to an item
    |
 LL -     let _ = foo.bar;
 LL +     let _ = foo::bar;
    |
 
-error[E0423]: expected value, found struct `::std::cell::Cell`
-  --> $DIR/dot-notation-type-namespace-suggest-path-sep.rs:37:9
+error[E0423]: cannot find value `Cell` in module `::std::cell`
+  --> $DIR/dot-notation-type-namespace-suggest-path-sep.rs:37:22
    |
 LL |         ::std::cell::Cell
-   |         ^^^^^^^^^^^^^^^^^
+   |                      ^^^^
 ...
 LL |     Type!().get();
    |     ------- in this macro invocation
    |
+   = note: a struct named `::std::cell::Cell` exists in another namespace
    = note: this error originates in the macro `Type` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: use the path separator to refer to an item
    |
@@ -86,15 +93,16 @@ LL -     Type!().get();
 LL +     <Type!()>::get();
    |
 
-error[E0423]: expected value, found struct `::std::cell::Cell`
-  --> $DIR/dot-notation-type-namespace-suggest-path-sep.rs:37:9
+error[E0423]: cannot find value `Cell` in module `::std::cell`
+  --> $DIR/dot-notation-type-namespace-suggest-path-sep.rs:37:22
    |
 LL |         ::std::cell::Cell
-   |         ^^^^^^^^^^^^^^^^^
+   |                      ^^^^
 ...
 LL |     Type! {}.get;
    |     -------- in this macro invocation
    |
+   = note: a struct named `::std::cell::Cell` exists in another namespace
    = note: this error originates in the macro `Type` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: use the path separator to refer to an item
    |
@@ -102,7 +110,7 @@ LL -     Type! {}.get;
 LL +     <Type! {}>::get;
    |
 
-error[E0423]: expected value, found type alias `Alias`
+error[E0423]: cannot find value `Alias` in this scope
   --> $DIR/dot-notation-type-namespace-suggest-path-sep.rs:43:9
    |
 LL |         Alias
@@ -111,6 +119,7 @@ LL |         Alias
 LL |     Type!(alias).get();
    |     ------------ in this macro invocation
    |
+   = note: a type alias named `Alias` exists in another namespace
    = note: this error originates in the macro `Type` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: use the path separator to refer to an item
    |
@@ -118,7 +127,7 @@ LL -     Type!(alias).get();
 LL +     <Type!(alias)>::get();
    |
 
-error[E0423]: expected value, found type alias `Alias`
+error[E0423]: cannot find value `Alias` in this scope
   --> $DIR/dot-notation-type-namespace-suggest-path-sep.rs:43:9
    |
 LL |         Alias
@@ -127,6 +136,7 @@ LL |         Alias
 LL |     Type! {alias}.get;
    |     ------------- in this macro invocation
    |
+   = note: a type alias named `Alias` exists in another namespace
    = note: this error originates in the macro `Type` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: use the path separator to refer to an item
    |
@@ -134,7 +144,7 @@ LL -     Type! {alias}.get;
 LL +     <Type! {alias}>::get;
    |
 
-error[E0423]: expected value, found struct `Vec`
+error[E0423]: cannot find value `Vec` in this scope
   --> $DIR/dot-notation-type-namespace-suggest-path-sep.rs:52:9
    |
 LL |         Vec.new()
@@ -143,6 +153,7 @@ LL |         Vec.new()
 LL |     let _ = create!(type method);
    |             -------------------- in this macro invocation
    |
+   = note: a struct named `Vec` exists in another namespace
    = note: this error originates in the macro `create` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: use the path separator to refer to an item
    |
@@ -150,7 +161,7 @@ LL -         Vec.new()
 LL +         Vec::new()
    |
 
-error[E0423]: expected value, found struct `Vec`
+error[E0423]: cannot find value `Vec` in this scope
   --> $DIR/dot-notation-type-namespace-suggest-path-sep.rs:57:9
    |
 LL |         Vec.new
@@ -159,6 +170,7 @@ LL |         Vec.new
 LL |     let _ = create!(type field);
    |             ------------------- in this macro invocation
    |
+   = note: a struct named `Vec` exists in another namespace
    = note: this error originates in the macro `create` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: use the path separator to refer to an item
    |
@@ -166,15 +178,16 @@ LL -         Vec.new
 LL +         Vec::new
    |
 
-error[E0423]: expected value, found struct `::std::cell::Cell`
-  --> $DIR/dot-notation-type-namespace-suggest-path-sep.rs:37:9
+error[E0423]: cannot find value `Cell` in module `::std::cell`
+  --> $DIR/dot-notation-type-namespace-suggest-path-sep.rs:37:22
    |
 LL |         ::std::cell::Cell
-   |         ^^^^^^^^^^^^^^^^^
+   |                      ^^^^
 ...
 LL |     let _ = create!(macro method);
    |             --------------------- in this macro invocation
    |
+   = note: a struct named `::std::cell::Cell` exists in another namespace
    = note: this error originates in the macro `Type` which comes from the expansion of the macro `create` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: use the path separator to refer to an item
    |
@@ -182,7 +195,7 @@ LL -         Type!().new(0)
 LL +         <Type!()>::new(0)
    |
 
-error[E0423]: expected value, found type alias `Alias`
+error[E0423]: cannot find value `Alias` in this scope
   --> $DIR/dot-notation-type-namespace-suggest-path-sep.rs:43:9
    |
 LL |         Alias
@@ -191,6 +204,7 @@ LL |         Alias
 LL |     let _ = create!(macro method alias);
    |             --------------------------- in this macro invocation
    |
+   = note: a type alias named `Alias` exists in another namespace
    = note: this error originates in the macro `Type` which comes from the expansion of the macro `create` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: use the path separator to refer to an item
    |
@@ -198,24 +212,24 @@ LL -         Type!(alias).new(0)
 LL +         <Type!(alias)>::new(0)
    |
 
-error[E0423]: expected value, found type alias `Alias`
-  --> $DIR/dot-notation-type-namespace-suggest-path-sep.rs:73:9
+error[E0423]: cannot find value `Alias` in this scope
+  --> $DIR/dot-notation-type-namespace-suggest-path-sep.rs:118:23
    |
 LL |         $Ty.foo
-   |         ^^^
+   |         --- due to this macro variable
 ...
 LL |     let _ = check_ty!(Alias);
-   |             ---------------- in this macro invocation
+   |                       ^^^^^
    |
-   = note: this error originates in the macro `check_ty` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: a type alias named `Alias` exists in another namespace
 help: use the path separator to refer to an item
    |
 LL -         $Ty.foo
 LL +         $Ty::foo
    |
 
-error[E0423]: expected value, found type alias `Alias`
-  --> $DIR/dot-notation-type-namespace-suggest-path-sep.rs:80:9
+error[E0423]: cannot find value `Alias` in this scope
+  --> $DIR/dot-notation-type-namespace-suggest-path-sep.rs:79:9
    |
 LL |         Alias.$Ident
    |         ^^^^^
@@ -223,6 +237,7 @@ LL |         Alias.$Ident
 LL |     let _ = check_ident!(foo);
    |             ----------------- in this macro invocation
    |
+   = note: a type alias named `Alias` exists in another namespace
    = note: this error originates in the macro `check_ident` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: use the path separator to refer to an item
    |
@@ -230,16 +245,16 @@ LL -         Alias.$Ident
 LL +         <Alias>::$Ident
    |
 
-error[E0423]: expected value, found type alias `Alias`
-  --> $DIR/dot-notation-type-namespace-suggest-path-sep.rs:87:9
+error[E0423]: cannot find value `Alias` in this scope
+  --> $DIR/dot-notation-type-namespace-suggest-path-sep.rs:121:29
    |
 LL |         $Ty.$Ident
-   |         ^^^
+   |         --- due to this macro variable
 ...
 LL |     let _ = check_ty_ident!(Alias, foo);
-   |             --------------------------- in this macro invocation
+   |                             ^^^^^
    |
-   = note: this error originates in the macro `check_ty_ident` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: a type alias named `Alias` exists in another namespace
 help: use the path separator to refer to an item
    |
 LL -         $Ty.$Ident

--- a/tests/ui/resolve/empty-struct-braces-expr.rs
+++ b/tests/ui/resolve/empty-struct-braces-expr.rs
@@ -12,16 +12,16 @@ enum E {
 }
 
 fn main() {
-    let e1 = Empty1; //~ ERROR expected value, found struct `Empty1`
+    let e1 = Empty1; //~ ERROR cannot find value `Empty1` in this scope
     let e1 = Empty1();
-    //~^ ERROR expected function, tuple struct or tuple variant, found struct `Empty1`
+    //~^ ERROR cannot find function, tuple struct or tuple variant `Empty1` in this scope
     let e3 = E::Empty3; //~ ERROR expected value, found struct variant `E::Empty3`
     let e3 = E::Empty3();
     //~^ ERROR expected value, found struct variant `E::Empty3`
 
-    let xe1 = XEmpty1; //~ ERROR expected value, found struct `XEmpty1`
+    let xe1 = XEmpty1; //~ ERROR cannot find value `XEmpty1` in this scope
     let xe1 = XEmpty1();
-    //~^ ERROR expected function, tuple struct or tuple variant, found struct `XEmpty1`
+    //~^ ERROR cannot find function, tuple struct or tuple variant `XEmpty1` in this scope
     let xe3 = XE::Empty3; //~ ERROR no variant, associated function, or constant named `Empty3` found for enum
     let xe3 = XE::Empty3(); //~ ERROR no variant, associated function, or constant named `Empty3` found for enum
 

--- a/tests/ui/resolve/empty-struct-braces-expr.stderr
+++ b/tests/ui/resolve/empty-struct-braces-expr.stderr
@@ -1,4 +1,4 @@
-error[E0423]: expected value, found struct `Empty1`
+error[E0423]: cannot find value `Empty1` in this scope
   --> $DIR/empty-struct-braces-expr.rs:15:14
    |
 LL | struct Empty1 {}
@@ -12,6 +12,7 @@ LL |     let e1 = Empty1;
 LL | pub struct XEmpty2;
    | ------------------ similarly named unit struct `XEmpty2` defined here
    |
+   = note: a struct named `Empty1` exists in another namespace
 help: use struct literal syntax instead
    |
 LL |     let e1 = Empty1 {};
@@ -22,7 +23,7 @@ LL -     let e1 = Empty1;
 LL +     let e1 = XEmpty2;
    |
 
-error[E0423]: expected value, found struct `XEmpty1`
+error[E0423]: cannot find value `XEmpty1` in this scope
   --> $DIR/empty-struct-braces-expr.rs:22:15
    |
 LL |     let xe1 = XEmpty1;
@@ -35,6 +36,7 @@ LL | pub struct XEmpty1 {}
 LL | pub struct XEmpty2;
    | ------------------ similarly named unit struct `XEmpty2` defined here
    |
+   = note: a struct named `XEmpty1` exists in another namespace
 help: use struct literal syntax instead
    |
 LL |     let xe1 = XEmpty1 {};
@@ -45,7 +47,7 @@ LL -     let xe1 = XEmpty1;
 LL +     let xe1 = XEmpty2;
    |
 
-error[E0423]: expected function, tuple struct or tuple variant, found struct `Empty1`
+error[E0423]: cannot find function, tuple struct or tuple variant `Empty1` in this scope
   --> $DIR/empty-struct-braces-expr.rs:16:14
    |
 LL | struct Empty1 {}
@@ -59,6 +61,7 @@ LL |     let e1 = Empty1();
 LL | pub struct XEmpty2;
    | ------------------ similarly named unit struct `XEmpty2` defined here
    |
+   = note: a struct named `Empty1` exists in another namespace
 help: use struct literal syntax instead
    |
 LL -     let e1 = Empty1();
@@ -93,7 +96,7 @@ LL -     let e3 = E::Empty3();
 LL +     let e3 = E::Empty3 {};
    |
 
-error[E0423]: expected function, tuple struct or tuple variant, found struct `XEmpty1`
+error[E0423]: cannot find function, tuple struct or tuple variant `XEmpty1` in this scope
   --> $DIR/empty-struct-braces-expr.rs:23:15
    |
 LL |     let xe1 = XEmpty1();
@@ -106,6 +109,7 @@ LL | pub struct XEmpty1 {}
 LL | pub struct XEmpty2;
    | ------------------ similarly named unit struct `XEmpty2` defined here
    |
+   = note: a struct named `XEmpty1` exists in another namespace
 help: use struct literal syntax instead
    |
 LL -     let xe1 = XEmpty1();

--- a/tests/ui/resolve/empty-struct-braces-pat-2.rs
+++ b/tests/ui/resolve/empty-struct-braces-pat-2.rs
@@ -12,15 +12,15 @@ fn main() {
     let xe1 = XEmpty1 {};
 
     match e1 {
-        Empty1() => () //~ ERROR expected tuple struct or tuple variant, found struct `Empty1`
+        Empty1() => () //~ ERROR cannot find tuple struct or tuple variant `Empty1` in this scope
     }
     match xe1 {
-        XEmpty1() => () //~ ERROR expected tuple struct or tuple variant, found struct `XEmpty1`
+        XEmpty1() => () //~ ERROR cannot find tuple struct or tuple variant `XEmpty1` in this scope
     }
     match e1 {
-        Empty1(..) => () //~ ERROR expected tuple struct or tuple variant, found struct `Empty1`
+        Empty1(..) => () //~ ERROR cannot find tuple struct or tuple variant `Empty1` in this scope
     }
     match xe1 {
-        XEmpty1(..) => () //~ ERROR expected tuple struct or tuple variant, found struct `XEmpty1`
+        XEmpty1(..) => () //~ ERROR cannot find tuple struct or tuple variant `XEmpty1` in this scope
     }
 }

--- a/tests/ui/resolve/empty-struct-braces-pat-2.stderr
+++ b/tests/ui/resolve/empty-struct-braces-pat-2.stderr
@@ -1,4 +1,4 @@
-error[E0532]: expected tuple struct or tuple variant, found struct `Empty1`
+error[E0532]: cannot find tuple struct or tuple variant `Empty1` in this scope
   --> $DIR/empty-struct-braces-pat-2.rs:15:9
    |
 LL | struct Empty1 {}
@@ -12,6 +12,7 @@ LL |         Empty1() => ()
 LL | pub struct XEmpty6();
    | ------------------ similarly named tuple struct `XEmpty6` defined here
    |
+   = note: a struct named `Empty1` exists in another namespace
 help: use struct pattern syntax instead
    |
 LL -         Empty1() => ()
@@ -23,7 +24,7 @@ LL -         Empty1() => ()
 LL +         XEmpty6() => ()
    |
 
-error[E0532]: expected tuple struct or tuple variant, found struct `XEmpty1`
+error[E0532]: cannot find tuple struct or tuple variant `XEmpty1` in this scope
   --> $DIR/empty-struct-braces-pat-2.rs:18:9
    |
 LL |         XEmpty1() => ()
@@ -37,6 +38,7 @@ LL | pub struct XEmpty2;
 LL | pub struct XEmpty6();
    | ------------------ similarly named tuple struct `XEmpty6` defined here
    |
+   = note: a struct named `XEmpty1` exists in another namespace
 help: use struct pattern syntax instead
    |
 LL -         XEmpty1() => ()
@@ -48,7 +50,7 @@ LL -         XEmpty1() => ()
 LL +         XEmpty6() => ()
    |
 
-error[E0532]: expected tuple struct or tuple variant, found struct `Empty1`
+error[E0532]: cannot find tuple struct or tuple variant `Empty1` in this scope
   --> $DIR/empty-struct-braces-pat-2.rs:21:9
    |
 LL | struct Empty1 {}
@@ -62,6 +64,7 @@ LL |         Empty1(..) => ()
 LL | pub struct XEmpty6();
    | ------------------ similarly named tuple struct `XEmpty6` defined here
    |
+   = note: a struct named `Empty1` exists in another namespace
 help: use struct pattern syntax instead
    |
 LL -         Empty1(..) => ()
@@ -73,7 +76,7 @@ LL -         Empty1(..) => ()
 LL +         XEmpty6(..) => ()
    |
 
-error[E0532]: expected tuple struct or tuple variant, found struct `XEmpty1`
+error[E0532]: cannot find tuple struct or tuple variant `XEmpty1` in this scope
   --> $DIR/empty-struct-braces-pat-2.rs:24:9
    |
 LL |         XEmpty1(..) => ()
@@ -87,6 +90,7 @@ LL | pub struct XEmpty2;
 LL | pub struct XEmpty6();
    | ------------------ similarly named tuple struct `XEmpty6` defined here
    |
+   = note: a struct named `XEmpty1` exists in another namespace
 help: use struct pattern syntax instead
    |
 LL -         XEmpty1(..) => ()

--- a/tests/ui/resolve/enum-expected-value-suggest-variants.rs
+++ b/tests/ui/resolve/enum-expected-value-suggest-variants.rs
@@ -14,37 +14,37 @@ enum Bar {
 
 fn main() {
     let _: Foo = Foo(0);
-    //~^ ERROR expected function
+    //~^ ERROR cannot find function, tuple struct or tuple variant `Foo` in this scope
     //~| HELP try to construct one of the enum's variants
 
     let _: Foo = Foo.A(0);
-    //~^ ERROR expected value, found enum `Foo`
+    //~^ ERROR cannot find value `Foo` in this scope
     //~| HELP use the path separator to refer to a variant
 
     let _: Foo = Foo.Bad(0);
-    //~^ ERROR expected value, found enum `Foo`
+    //~^ ERROR cannot find value `Foo` in this scope
     //~| HELP the following enum variants are available
 
     let _: Bar = Bar(0);
-    //~^ ERROR expected function
+    //~^ ERROR cannot find function, tuple struct or tuple variant `Bar` in this scope
     //~| HELP try to construct one of the enum's variants
     //~| HELP you might have meant to construct one of the enum's non-tuple variants
 
     let _: Bar = Bar.C(0);
-    //~^ ERROR expected value, found enum `Bar`
+    //~^ ERROR cannot find value `Bar` in this scope
     //~| HELP use the path separator to refer to a variant
 
     let _: Bar = Bar.E;
-    //~^ ERROR expected value, found enum `Bar`
+    //~^ ERROR cannot find value `Bar` in this scope
     //~| HELP use the path separator to refer to a variant
 
     let _: Bar = Bar.Bad(0);
-    //~^ ERROR expected value, found enum `Bar`
+    //~^ ERROR cannot find value `Bar` in this scope
     //~| HELP you might have meant to use one of the following enum variants
     //~| HELP alternatively, the following enum variants are also available
 
     let _: Bar = Bar.Bad;
-    //~^ ERROR expected value, found enum `Bar`
+    //~^ ERROR cannot find value `Bar` in this scope
     //~| HELP you might have meant to use one of the following enum variants
     //~| HELP alternatively, the following enum variants are also available
 
@@ -52,7 +52,7 @@ fn main() {
         A(..) => {}
         //~^ ERROR cannot find tuple struct or tuple variant `A` in this scope
         Foo(..) => {}
-        //~^ ERROR expected tuple struct or tuple variant
+        //~^ ERROR cannot find tuple struct or tuple variant `Foo` in this scope
         //~| HELP try to match against one of the enum's variants
         _ => {}
     }

--- a/tests/ui/resolve/enum-expected-value-suggest-variants.stderr
+++ b/tests/ui/resolve/enum-expected-value-suggest-variants.stderr
@@ -1,9 +1,10 @@
-error[E0423]: expected value, found enum `Foo`
+error[E0423]: cannot find value `Foo` in this scope
   --> $DIR/enum-expected-value-suggest-variants.rs:20:18
    |
 LL |     let _: Foo = Foo.A(0);
    |                  ^^^
    |
+   = note: an enum named `Foo` exists in another namespace
 note: the enum is defined here
   --> $DIR/enum-expected-value-suggest-variants.rs:2:1
    |
@@ -19,12 +20,13 @@ LL -     let _: Foo = Foo.A(0);
 LL +     let _: Foo = Foo::A(0);
    |
 
-error[E0423]: expected value, found enum `Foo`
+error[E0423]: cannot find value `Foo` in this scope
   --> $DIR/enum-expected-value-suggest-variants.rs:24:18
    |
 LL |     let _: Foo = Foo.Bad(0);
    |                  ^^^
    |
+   = note: an enum named `Foo` exists in another namespace
 note: the enum is defined here
   --> $DIR/enum-expected-value-suggest-variants.rs:2:1
    |
@@ -43,12 +45,13 @@ LL -     let _: Foo = Foo.Bad(0);
 LL +     let _: Foo = (Foo::B(/* fields */)).Bad(0);
    |
 
-error[E0423]: expected value, found enum `Bar`
+error[E0423]: cannot find value `Bar` in this scope
   --> $DIR/enum-expected-value-suggest-variants.rs:33:18
    |
 LL |     let _: Bar = Bar.C(0);
    |                  ^^^
    |
+   = note: an enum named `Bar` exists in another namespace
 note: the enum is defined here
   --> $DIR/enum-expected-value-suggest-variants.rs:8:1
    |
@@ -65,12 +68,13 @@ LL -     let _: Bar = Bar.C(0);
 LL +     let _: Bar = Bar::C(0);
    |
 
-error[E0423]: expected value, found enum `Bar`
+error[E0423]: cannot find value `Bar` in this scope
   --> $DIR/enum-expected-value-suggest-variants.rs:37:18
    |
 LL |     let _: Bar = Bar.E;
    |                  ^^^
    |
+   = note: an enum named `Bar` exists in another namespace
 note: the enum is defined here
   --> $DIR/enum-expected-value-suggest-variants.rs:8:1
    |
@@ -87,12 +91,13 @@ LL -     let _: Bar = Bar.E;
 LL +     let _: Bar = Bar::E;
    |
 
-error[E0423]: expected value, found enum `Bar`
+error[E0423]: cannot find value `Bar` in this scope
   --> $DIR/enum-expected-value-suggest-variants.rs:41:18
    |
 LL |     let _: Bar = Bar.Bad(0);
    |                  ^^^
    |
+   = note: an enum named `Bar` exists in another namespace
 note: the enum is defined here
   --> $DIR/enum-expected-value-suggest-variants.rs:8:1
    |
@@ -118,12 +123,13 @@ LL -     let _: Bar = Bar.Bad(0);
 LL +     let _: Bar = (Bar::D(/* fields */)).Bad(0);
    |
 
-error[E0423]: expected value, found enum `Bar`
+error[E0423]: cannot find value `Bar` in this scope
   --> $DIR/enum-expected-value-suggest-variants.rs:46:18
    |
 LL |     let _: Bar = Bar.Bad;
    |                  ^^^
    |
+   = note: an enum named `Bar` exists in another namespace
 note: the enum is defined here
   --> $DIR/enum-expected-value-suggest-variants.rs:8:1
    |
@@ -160,12 +166,13 @@ help: consider importing this tuple variant
 LL + use Foo::A;
    |
 
-error[E0532]: expected tuple struct or tuple variant, found enum `Foo`
+error[E0532]: cannot find tuple struct or tuple variant `Foo` in this scope
   --> $DIR/enum-expected-value-suggest-variants.rs:54:9
    |
 LL |         Foo(..) => {}
    |         ^^^
    |
+   = note: an enum named `Foo` exists in another namespace
 note: the enum is defined here
   --> $DIR/enum-expected-value-suggest-variants.rs:2:1
    |
@@ -182,12 +189,13 @@ LL |         Foo::A(..) => {}
 LL |         Foo::B(..) => {}
    |            +++
 
-error[E0423]: expected function, tuple struct or tuple variant, found enum `Foo`
+error[E0423]: cannot find function, tuple struct or tuple variant `Foo` in this scope
   --> $DIR/enum-expected-value-suggest-variants.rs:16:18
    |
 LL |     let _: Foo = Foo(0);
    |                  ^^^
    |
+   = note: an enum named `Foo` exists in another namespace
 note: the enum is defined here
   --> $DIR/enum-expected-value-suggest-variants.rs:2:1
    |
@@ -204,12 +212,13 @@ LL |     let _: Foo = Foo::A(0);
 LL |     let _: Foo = Foo::B(0);
    |                     +++
 
-error[E0423]: expected function, tuple struct or tuple variant, found enum `Bar`
+error[E0423]: cannot find function, tuple struct or tuple variant `Bar` in this scope
   --> $DIR/enum-expected-value-suggest-variants.rs:28:18
    |
 LL |     let _: Bar = Bar(0);
    |                  ^^^
    |
+   = note: an enum named `Bar` exists in another namespace
    = help: you might have meant to construct one of the enum's non-tuple variants
 note: the enum is defined here
   --> $DIR/enum-expected-value-suggest-variants.rs:8:1

--- a/tests/ui/resolve/impl-on-non-type.rs
+++ b/tests/ui/resolve/impl-on-non-type.rs
@@ -4,10 +4,10 @@ static Y: u8 = 1;
 fn foo() {}
 
 impl X {}
-//~^ ERROR expected type, found constant `X`
+//~^ ERROR cannot find type `X` in this scope
 impl Y {}
-//~^ ERROR expected type, found static `Y`
+//~^ ERROR cannot find type `Y` in this scope
 impl foo {}
-//~^ ERROR expected type, found function `foo`
+//~^ ERROR cannot find type `foo` in this scope
 
 fn main() {}

--- a/tests/ui/resolve/impl-on-non-type.stderr
+++ b/tests/ui/resolve/impl-on-non-type.stderr
@@ -1,20 +1,26 @@
-error[E0573]: expected type, found constant `X`
+error[E0573]: cannot find type `X` in this scope
   --> $DIR/impl-on-non-type.rs:6:6
    |
 LL | impl X {}
-   |      ^ not a type
+   |      ^ not found in this scope
+   |
+   = note: a constant named `X` exists in another namespace
 
-error[E0573]: expected type, found static `Y`
+error[E0573]: cannot find type `Y` in this scope
   --> $DIR/impl-on-non-type.rs:8:6
    |
 LL | impl Y {}
-   |      ^ not a type
+   |      ^ not found in this scope
+   |
+   = note: a static named `Y` exists in another namespace
 
-error[E0573]: expected type, found function `foo`
+error[E0573]: cannot find type `foo` in this scope
   --> $DIR/impl-on-non-type.rs:10:6
    |
 LL | impl foo {}
-   |      ^^^ not a type
+   |      ^^^ not found in this scope
+   |
+   = note: a function named `foo` exists in another namespace
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/resolve/issue-100365.rs
+++ b/tests/ui/resolve/issue-100365.rs
@@ -1,29 +1,29 @@
 fn main() {
     let addr = Into::<std::net::IpAddr>.into([127, 0, 0, 1]);
-    //~^ ERROR expected value, found trait `Into`
+    //~^ ERROR cannot find value `Into` in this scope
     //~| HELP use the path separator
 
     let _ = Into.into(());
-    //~^ ERROR expected value, found trait `Into`
+    //~^ ERROR cannot find value `Into` in this scope
     //~| HELP use the path separator
 
     let _ = Into::<()>.into;
-    //~^ ERROR expected value, found trait `Into`
+    //~^ ERROR cannot find value `Into` in this scope
     //~| HELP use the path separator
 }
 
 macro_rules! Trait {
     () => {
         ::std::iter::Iterator
-        //~^ ERROR expected value, found trait `::std::iter::Iterator`
-        //~| ERROR expected value, found trait `::std::iter::Iterator`
+        //~^ ERROR cannot find value `Iterator` in module `::std::iter`
+        //~| ERROR cannot find value `Iterator` in module `::std::iter`
     };
 }
 
 macro_rules! create {
     () => {
         Into::<String>.into("")
-        //~^ ERROR expected value, found trait `Into`
+        //~^ ERROR cannot find value `Into` in this scope
         //~| HELP use the path separator
     };
 }

--- a/tests/ui/resolve/issue-100365.stderr
+++ b/tests/ui/resolve/issue-100365.stderr
@@ -1,70 +1,76 @@
-error[E0423]: expected value, found trait `Into`
+error[E0423]: cannot find value `Into` in this scope
   --> $DIR/issue-100365.rs:2:16
    |
 LL |     let addr = Into::<std::net::IpAddr>.into([127, 0, 0, 1]);
-   |                ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                ^^^^
    |
+   = note: a trait named `Into` exists in another namespace
 help: use the path separator to refer to an item
    |
 LL -     let addr = Into::<std::net::IpAddr>.into([127, 0, 0, 1]);
 LL +     let addr = Into::<std::net::IpAddr>::into([127, 0, 0, 1]);
    |
 
-error[E0423]: expected value, found trait `Into`
+error[E0423]: cannot find value `Into` in this scope
   --> $DIR/issue-100365.rs:6:13
    |
 LL |     let _ = Into.into(());
    |             ^^^^
    |
+   = note: a trait named `Into` exists in another namespace
 help: use the path separator to refer to an item
    |
 LL -     let _ = Into.into(());
 LL +     let _ = Into::into(());
    |
 
-error[E0423]: expected value, found trait `Into`
+error[E0423]: cannot find value `Into` in this scope
   --> $DIR/issue-100365.rs:10:13
    |
 LL |     let _ = Into::<()>.into;
-   |             ^^^^^^^^^^
+   |             ^^^^
    |
+   = note: a trait named `Into` exists in another namespace
 help: use the path separator to refer to an item
    |
 LL -     let _ = Into::<()>.into;
 LL +     let _ = Into::<()>::into;
    |
 
-error[E0423]: expected value, found trait `::std::iter::Iterator`
-  --> $DIR/issue-100365.rs:17:9
+error[E0423]: cannot find value `Iterator` in module `::std::iter`
+  --> $DIR/issue-100365.rs:17:22
    |
 LL |         ::std::iter::Iterator
-   |         ^^^^^^^^^^^^^^^^^^^^^ not a value
+   |                      ^^^^^^^^ not found in `::std::iter`
 ...
 LL |     Trait!().map(std::convert::identity); // no `help` here!
    |     -------- in this macro invocation
    |
+   = note: a trait named `::std::iter::Iterator` exists in another namespace
    = note: this error originates in the macro `Trait` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0423]: expected value, found trait `::std::iter::Iterator`
-  --> $DIR/issue-100365.rs:17:9
+error[E0423]: cannot find value `Iterator` in module `::std::iter`
+  --> $DIR/issue-100365.rs:17:22
    |
 LL |         ::std::iter::Iterator
-   |         ^^^^^^^^^^^^^^^^^^^^^ not a value
+   |                      ^^^^^^^^ not found in `::std::iter`
 ...
 LL |     Trait!().map; // no `help` here!
    |     -------- in this macro invocation
    |
+   = note: a trait named `::std::iter::Iterator` exists in another namespace
    = note: this error originates in the macro `Trait` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0423]: expected value, found trait `Into`
+error[E0423]: cannot find value `Into` in this scope
   --> $DIR/issue-100365.rs:25:9
    |
 LL |         Into::<String>.into("")
-   |         ^^^^^^^^^^^^^^
+   |         ^^^^
 ...
 LL |     let _ = create!();
    |             --------- in this macro invocation
    |
+   = note: a trait named `Into` exists in another namespace
    = note: this error originates in the macro `create` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: use the path separator to refer to an item
    |

--- a/tests/ui/resolve/issue-2356.rs
+++ b/tests/ui/resolve/issue-2356.rs
@@ -63,7 +63,7 @@ impl Cat {
 impl Cat {
   fn meow() {
     if self.whiskers > 3 {
-        //~^ ERROR expected value, found module `self`
+        //~^ ERROR cannot find value `self` in this scope
         println!("MEOW");
     }
   }
@@ -90,5 +90,5 @@ impl Cat {
 
 fn main() {
     self += 1;
-    //~^ ERROR expected value, found module `self`
+    //~^ ERROR cannot find value `self` in this scope
 }

--- a/tests/ui/resolve/issue-2356.stderr
+++ b/tests/ui/resolve/issue-2356.stderr
@@ -7,7 +7,7 @@ LL |   whiskers: isize,
 LL |     whiskers -= other;
    |     ^^^^^^^^
 
-error[E0424]: expected value, found module `self`
+error[E0424]: cannot find value `self` in this scope
   --> $DIR/issue-2356.rs:65:8
    |
 LL |   fn meow() {
@@ -15,6 +15,7 @@ LL |   fn meow() {
 LL |     if self.whiskers > 3 {
    |        ^^^^ `self` value is a keyword only available in methods with a `self` parameter
    |
+   = note: a module named `self` exists in another namespace
 help: add a `self` receiver parameter to make the associated `fn` a method
    |
 LL |   fn meow(&self) {
@@ -40,13 +41,15 @@ LL |   whiskers: isize,
 LL |     whiskers = 4;
    |     ^^^^^^^^
 
-error[E0424]: expected value, found module `self`
+error[E0424]: cannot find value `self` in this scope
   --> $DIR/issue-2356.rs:92:5
    |
 LL | fn main() {
    |    ---- this function can't have a `self` parameter
 LL |     self += 1;
    |     ^^^^ `self` value is a keyword only available in methods with a `self` parameter
+   |
+   = note: a module named `self` exists in another namespace
 
 error[E0425]: cannot find function `shave` in this scope
   --> $DIR/issue-2356.rs:17:5

--- a/tests/ui/resolve/issue-33876.rs
+++ b/tests/ui/resolve/issue-33876.rs
@@ -7,6 +7,6 @@ trait Bar {}
 impl Bar for Foo {}
 
 fn main() {
-    let any: &dyn Any = &Bar; //~ ERROR expected value, found trait `Bar`
+    let any: &dyn Any = &Bar; //~ ERROR cannot find value `Bar` in this scope
     if any.is::<u32>() { println!("u32"); }
 }

--- a/tests/ui/resolve/issue-33876.stderr
+++ b/tests/ui/resolve/issue-33876.stderr
@@ -1,8 +1,10 @@
-error[E0423]: expected value, found trait `Bar`
+error[E0423]: cannot find value `Bar` in this scope
   --> $DIR/issue-33876.rs:10:26
    |
 LL |     let any: &dyn Any = &Bar;
-   |                          ^^^ not a value
+   |                          ^^^ not found in this scope
+   |
+   = note: a trait named `Bar` exists in another namespace
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/resolve/issue-39226.rs
+++ b/tests/ui/resolve/issue-39226.rs
@@ -9,6 +9,6 @@ fn main() {
 
     let s: Something = Something {
         handle: Handle
-        //~^ ERROR expected value, found struct `Handle`
+        //~^ ERROR cannot find value `Handle` in this scope
     };
 }

--- a/tests/ui/resolve/issue-39226.stderr
+++ b/tests/ui/resolve/issue-39226.stderr
@@ -1,4 +1,4 @@
-error[E0423]: expected value, found struct `Handle`
+error[E0423]: cannot find value `Handle` in this scope
   --> $DIR/issue-39226.rs:11:17
    |
 LL | struct Handle {}
@@ -7,6 +7,7 @@ LL | struct Handle {}
 LL |         handle: Handle
    |                 ^^^^^^
    |
+   = note: a struct named `Handle` exists in another namespace
 help: use struct literal syntax instead
    |
 LL |         handle: Handle {}

--- a/tests/ui/resolve/issue-42944.stderr
+++ b/tests/ui/resolve/issue-42944.stderr
@@ -16,6 +16,7 @@ error[E0423]: cannot initialize a tuple struct which contains private fields
 LL |         Bx(());
    |         ^^
    |
+   = note: a struct named `Bx` exists in another namespace
 note: constructor is not visible here due to private fields
   --> $DIR/issue-42944.rs:3:19
    |

--- a/tests/ui/resolve/issue-6702.rs
+++ b/tests/ui/resolve/issue-6702.rs
@@ -5,5 +5,5 @@ struct Monster {
 
 fn main() {
     let _m = Monster();
-    //~^ ERROR expected function, tuple struct or tuple variant, found struct `Monster`
+    //~^ ERROR cannot find function, tuple struct or tuple variant `Monster` in this scope
 }

--- a/tests/ui/resolve/issue-6702.stderr
+++ b/tests/ui/resolve/issue-6702.stderr
@@ -1,4 +1,4 @@
-error[E0423]: expected function, tuple struct or tuple variant, found struct `Monster`
+error[E0423]: cannot find function, tuple struct or tuple variant `Monster` in this scope
   --> $DIR/issue-6702.rs:7:14
    |
 LL | / struct Monster {
@@ -8,6 +8,8 @@ LL | | }
 ...
 LL |       let _m = Monster();
    |                ^^^^^^^^^ help: use struct literal syntax instead: `Monster { damage: val }`
+   |
+   = note: a struct named `Monster` exists in another namespace
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/resolve/issue-73427.rs
+++ b/tests/ui/resolve/issue-73427.rs
@@ -31,20 +31,20 @@ fn main() {
     // is used rather than a variant.
 
     A.foo();
-    //~^ ERROR expected value, found enum `A`
+    //~^ ERROR cannot find value `A` in this scope
     B.foo();
-    //~^ ERROR expected value, found enum `B`
+    //~^ ERROR cannot find value `B` in this scope
     C.foo();
-    //~^ ERROR expected value, found enum `C`
+    //~^ ERROR cannot find value `C` in this scope
     D.foo();
-    //~^ ERROR expected value, found enum `D`
+    //~^ ERROR cannot find value `D` in this scope
     E.foo();
-    //~^ ERROR expected value, found enum `E`
+    //~^ ERROR cannot find value `E` in this scope
 
     // Only tuple variants are suggested in calls or tuple struct pattern matching.
 
     let x = A(3);
-    //~^ ERROR expected function, tuple struct or tuple variant, found enum `A`
+    //~^ ERROR cannot find function, tuple struct or tuple variant `A` in this scope
     if let A(3) = x { }
-    //~^ ERROR expected tuple struct or tuple variant, found enum `A`
+    //~^ ERROR cannot find tuple struct or tuple variant `A` in this scope
 }

--- a/tests/ui/resolve/issue-73427.stderr
+++ b/tests/ui/resolve/issue-73427.stderr
@@ -1,9 +1,10 @@
-error[E0423]: expected value, found enum `A`
+error[E0423]: cannot find value `A` in this scope
   --> $DIR/issue-73427.rs:33:5
    |
 LL |     A.foo();
    |     ^
    |
+   = note: an enum named `A` exists in another namespace
 note: the enum is defined here
   --> $DIR/issue-73427.rs:1:1
    |
@@ -28,12 +29,13 @@ LL -     A.foo();
 LL +     (A::TupleWithFields(/* fields */)).foo();
    |
 
-error[E0423]: expected value, found enum `B`
+error[E0423]: cannot find value `B` in this scope
   --> $DIR/issue-73427.rs:35:5
    |
 LL |     B.foo();
    |     ^
    |
+   = note: an enum named `B` exists in another namespace
 note: the enum is defined here
   --> $DIR/issue-73427.rs:9:1
    |
@@ -48,12 +50,13 @@ LL -     B.foo();
 LL +     (B::TupleWithFields(/* fields */)).foo();
    |
 
-error[E0423]: expected value, found enum `C`
+error[E0423]: cannot find value `C` in this scope
   --> $DIR/issue-73427.rs:37:5
    |
 LL |     C.foo();
    |     ^
    |
+   = note: an enum named `C` exists in another namespace
 note: the enum is defined here
   --> $DIR/issue-73427.rs:14:1
    |
@@ -73,12 +76,13 @@ LL -     C.foo();
 LL +     (C::TupleWithFields(/* fields */)).foo();
    |
 
-error[E0423]: expected value, found enum `D`
+error[E0423]: cannot find value `D` in this scope
   --> $DIR/issue-73427.rs:39:5
    |
 LL |     D.foo();
    |     ^
    |
+   = note: an enum named `D` exists in another namespace
 note: the enum is defined here
   --> $DIR/issue-73427.rs:20:1
    |
@@ -97,12 +101,13 @@ LL -     D.foo();
 LL +     (D::TupleWithFields(/* fields */)).foo();
    |
 
-error[E0423]: expected value, found enum `E`
+error[E0423]: cannot find value `E` in this scope
   --> $DIR/issue-73427.rs:41:5
    |
 LL |     E.foo();
    |     ^
    |
+   = note: an enum named `E` exists in another namespace
 note: the enum is defined here
   --> $DIR/issue-73427.rs:25:1
    |
@@ -126,12 +131,13 @@ LL + use std::f32::consts::E;
 LL + use std::f64::consts::E;
    |
 
-error[E0532]: expected tuple struct or tuple variant, found enum `A`
+error[E0532]: cannot find tuple struct or tuple variant `A` in this scope
   --> $DIR/issue-73427.rs:48:12
    |
 LL |     if let A(3) = x { }
    |            ^
    |
+   = note: an enum named `A` exists in another namespace
    = help: you might have meant to match against the enum's non-tuple variant
 note: the enum is defined here
   --> $DIR/issue-73427.rs:1:1
@@ -151,12 +157,13 @@ LL |     if let A::Tuple(3) = x { }
 LL |     if let A::TupleWithFields(3) = x { }
    |             +++++++++++++++++
 
-error[E0423]: expected function, tuple struct or tuple variant, found enum `A`
+error[E0423]: cannot find function, tuple struct or tuple variant `A` in this scope
   --> $DIR/issue-73427.rs:46:13
    |
 LL |     let x = A(3);
    |             ^
    |
+   = note: an enum named `A` exists in another namespace
    = help: you might have meant to construct the enum's non-tuple variant
 note: the enum is defined here
   --> $DIR/issue-73427.rs:1:1

--- a/tests/ui/resolve/no-implicit-prelude-nested.rs
+++ b/tests/ui/resolve/no-implicit-prelude-nested.rs
@@ -9,7 +9,7 @@ mod foo {
     mod baz {
         struct Test;
         impl Add for Test {} //~ ERROR cannot find trait `Add` in this scope
-        impl Clone for Test {} //~ ERROR expected trait, found derive macro `Clone`
+        impl Clone for Test {} //~ ERROR cannot find trait `Clone` in this scope
         impl Iterator for Test {} //~ ERROR cannot find trait `Iterator` in this scope
         impl ToString for Test {} //~ ERROR cannot find trait `ToString` in this scope
         impl Writer for Test {} //~ ERROR cannot find trait `Writer` in this scope
@@ -21,7 +21,7 @@ mod foo {
 
     struct Test;
     impl Add for Test {} //~ ERROR cannot find trait `Add` in this scope
-    impl Clone for Test {} //~ ERROR expected trait, found derive macro `Clone`
+    impl Clone for Test {} //~ ERROR cannot find trait `Clone` in this scope
     impl Iterator for Test {} //~ ERROR cannot find trait `Iterator` in this scope
     impl ToString for Test {} //~ ERROR cannot find trait `ToString` in this scope
     impl Writer for Test {} //~ ERROR cannot find trait `Writer` in this scope
@@ -36,7 +36,7 @@ fn qux() {
     mod qux_inner {
         struct Test;
         impl Add for Test {} //~ ERROR cannot find trait `Add` in this scope
-        impl Clone for Test {} //~ ERROR expected trait, found derive macro `Clone`
+        impl Clone for Test {} //~ ERROR cannot find trait `Clone` in this scope
         impl Iterator for Test {} //~ ERROR cannot find trait `Iterator` in this scope
         impl ToString for Test {} //~ ERROR cannot find trait `ToString` in this scope
         impl Writer for Test {} //~ ERROR cannot find trait `Writer` in this scope

--- a/tests/ui/resolve/no-implicit-prelude-nested.stderr
+++ b/tests/ui/resolve/no-implicit-prelude-nested.stderr
@@ -9,12 +9,13 @@ help: consider importing this trait
 LL +         use std::ops::Add;
    |
 
-error[E0404]: expected trait, found derive macro `Clone`
+error[E0404]: cannot find trait `Clone` in this scope
   --> $DIR/no-implicit-prelude-nested.rs:12:14
    |
 LL |         impl Clone for Test {}
-   |              ^^^^^ not a trait
+   |              ^^^^^ not found in this scope
    |
+   = note: a derive macro named `Clone` exists in another namespace
 help: consider importing this trait instead
    |
 LL +         use std::clone::Clone;
@@ -70,12 +71,13 @@ help: consider importing this trait
 LL +     use std::ops::Add;
    |
 
-error[E0404]: expected trait, found derive macro `Clone`
+error[E0404]: cannot find trait `Clone` in this scope
   --> $DIR/no-implicit-prelude-nested.rs:24:10
    |
 LL |     impl Clone for Test {}
-   |          ^^^^^ not a trait
+   |          ^^^^^ not found in this scope
    |
+   = note: a derive macro named `Clone` exists in another namespace
 help: consider importing this trait instead
    |
 LL +     use std::clone::Clone;
@@ -131,12 +133,13 @@ help: consider importing this trait
 LL +         use std::ops::Add;
    |
 
-error[E0404]: expected trait, found derive macro `Clone`
+error[E0404]: cannot find trait `Clone` in this scope
   --> $DIR/no-implicit-prelude-nested.rs:39:14
    |
 LL |         impl Clone for Test {}
-   |              ^^^^^ not a trait
+   |              ^^^^^ not found in this scope
    |
+   = note: a derive macro named `Clone` exists in another namespace
 help: consider importing this trait instead
    |
 LL +         use std::clone::Clone;

--- a/tests/ui/resolve/no-implicit-prelude.rs
+++ b/tests/ui/resolve/no-implicit-prelude.rs
@@ -8,7 +8,7 @@
 
 struct Test;
 impl Add for Test {} //~ ERROR cannot find trait `Add` in this scope
-impl Clone for Test {} //~ ERROR expected trait, found derive macro `Clone`
+impl Clone for Test {} //~ ERROR cannot find trait `Clone` in this scope
 impl Iterator for Test {} //~ ERROR cannot find trait `Iterator` in this scope
 impl ToString for Test {} //~ ERROR cannot find trait `ToString` in this scope
 impl Writer for Test {} //~ ERROR cannot find trait `Writer` in this scope

--- a/tests/ui/resolve/no-implicit-prelude.stderr
+++ b/tests/ui/resolve/no-implicit-prelude.stderr
@@ -9,12 +9,13 @@ help: consider importing this trait
 LL + use std::ops::Add;
    |
 
-error[E0404]: expected trait, found derive macro `Clone`
+error[E0404]: cannot find trait `Clone` in this scope
   --> $DIR/no-implicit-prelude.rs:11:6
    |
 LL | impl Clone for Test {}
-   |      ^^^^^ not a trait
+   |      ^^^^^ not found in this scope
    |
+   = note: a derive macro named `Clone` exists in another namespace
 help: consider importing this trait instead
    |
 LL + use std::clone::Clone;

--- a/tests/ui/resolve/privacy-enum-ctor.rs
+++ b/tests/ui/resolve/privacy-enum-ctor.rs
@@ -22,9 +22,9 @@ mod m {
 
     fn f() {
         n::Z;
-        //~^ ERROR expected value, found enum `n::Z`
+        //~^ ERROR cannot find value `Z` in module `n`
         Z;
-        //~^ ERROR expected value, found enum `Z`
+        //~^ ERROR cannot find value `Z` in this scope
         let _: Z = Z::Fn;
         //~^ ERROR mismatched types
         let _: Z = Z::Struct;
@@ -40,7 +40,7 @@ use m::E; // OK, only the type is imported
 
 fn main() {
     let _: E = m::E;
-    //~^ ERROR expected value, found enum `m::E`
+    //~^ ERROR cannot find value `E` in module `m`
     let _: E = m::E::Fn;
     //~^ ERROR mismatched types
     let _: E = m::E::Struct;
@@ -48,7 +48,7 @@ fn main() {
     let _: E = m::E::Unit();
     //~^ ERROR expected function, found enum variant `m::E::Unit`
     let _: E = E;
-    //~^ ERROR expected value, found enum `E`
+    //~^ ERROR cannot find value `E` in this scope
     let _: E = E::Fn;
     //~^ ERROR mismatched types
     let _: E = E::Struct;
@@ -57,7 +57,7 @@ fn main() {
     //~^ ERROR expected function, found enum variant `E::Unit`
     let _: Z = m::n::Z;
     //~^ ERROR cannot find type `Z` in this scope
-    //~| ERROR expected value, found enum `m::n::Z`
+    //~| ERROR cannot find value `Z` in module `m::n`
     //~| ERROR enum `Z` is private
     let _: Z = m::n::Z::Fn;
     //~^ ERROR cannot find type `Z` in this scope

--- a/tests/ui/resolve/privacy-enum-ctor.stderr
+++ b/tests/ui/resolve/privacy-enum-ctor.stderr
@@ -1,9 +1,10 @@
-error[E0423]: expected value, found enum `n::Z`
-  --> $DIR/privacy-enum-ctor.rs:24:9
+error[E0423]: cannot find value `Z` in module `n`
+  --> $DIR/privacy-enum-ctor.rs:24:12
    |
 LL |         n::Z;
-   |         ^^^^
+   |            ^
    |
+   = note: an enum named `n::Z` exists in another namespace
 note: the enum is defined here
   --> $DIR/privacy-enum-ctor.rs:12:9
    |
@@ -26,12 +27,13 @@ LL -         n::Z;
 LL +         (m::Z::Fn(/* fields */));
    |
 
-error[E0423]: expected value, found enum `Z`
+error[E0423]: cannot find value `Z` in this scope
   --> $DIR/privacy-enum-ctor.rs:26:9
    |
 LL |         Z;
    |         ^
    |
+   = note: an enum named `Z` exists in another namespace
 note: the enum is defined here
   --> $DIR/privacy-enum-ctor.rs:12:9
    |
@@ -54,15 +56,16 @@ LL -         Z;
 LL +         (m::Z::Fn(/* fields */));
    |
 
-error[E0423]: expected value, found enum `m::E`
-  --> $DIR/privacy-enum-ctor.rs:42:16
+error[E0423]: cannot find value `E` in module `m`
+  --> $DIR/privacy-enum-ctor.rs:42:19
    |
 LL |     fn f() {
    |     ------ similarly named function `f` defined here
 ...
 LL |     let _: E = m::E;
-   |                ^^^^
+   |                   ^
    |
+   = note: an enum named `m::E` exists in another namespace
 note: the enum is defined here
   --> $DIR/privacy-enum-ctor.rs:3:5
    |
@@ -105,12 +108,13 @@ LL -     let _: E = m::E;
 LL +     let _: E = E;
    |
 
-error[E0423]: expected value, found enum `E`
+error[E0423]: cannot find value `E` in this scope
   --> $DIR/privacy-enum-ctor.rs:50:16
    |
 LL |     let _: E = E;
    |                ^
    |
+   = note: an enum named `E` exists in another namespace
 note: the enum is defined here
   --> $DIR/privacy-enum-ctor.rs:3:5
    |
@@ -162,12 +166,13 @@ LL -     let _: Z = m::n::Z;
 LL +     let _: E = m::n::Z;
    |
 
-error[E0423]: expected value, found enum `m::n::Z`
-  --> $DIR/privacy-enum-ctor.rs:58:16
+error[E0423]: cannot find value `Z` in module `m::n`
+  --> $DIR/privacy-enum-ctor.rs:58:22
    |
 LL |     let _: Z = m::n::Z;
-   |                ^^^^^^^
+   |                      ^
    |
+   = note: an enum named `m::n::Z` exists in another namespace
 note: the enum is defined here
   --> $DIR/privacy-enum-ctor.rs:12:9
    |

--- a/tests/ui/resolve/privacy-struct-ctor.rs
+++ b/tests/ui/resolve/privacy-struct-ctor.rs
@@ -19,7 +19,7 @@ mod m {
         n::Z;
         //~^ ERROR tuple struct constructor `Z` is private
         Z;
-        //~^ ERROR expected value, found struct `Z`
+        //~^ ERROR cannot find value `Z` in this scope
     }
 }
 
@@ -32,17 +32,17 @@ fn main() {
     let _: S = m::S(2);
     //~^ ERROR tuple struct constructor `S` is private
     S;
-    //~^ ERROR expected value, found struct `S`
+    //~^ ERROR cannot find value `S` in this scope
     m::n::Z;
     //~^ ERROR tuple struct constructor `Z` is private
 
     S2;
-    //~^ ERROR expected value, found struct `S2`
+    //~^ ERROR cannot find value `S2` in this scope
 
     xcrate::m::S;
     //~^ ERROR tuple struct constructor `S` is private
     xcrate::S;
-    //~^ ERROR expected value, found struct `xcrate::S`
+    //~^ ERROR cannot find value `S` in crate `xcrate`
     xcrate::m::n::Z;
     //~^ ERROR tuple struct constructor `Z` is private
 }

--- a/tests/ui/resolve/privacy-struct-ctor.stderr
+++ b/tests/ui/resolve/privacy-struct-ctor.stderr
@@ -1,4 +1,4 @@
-error[E0423]: expected value, found struct `Z`
+error[E0423]: cannot find value `Z` in this scope
   --> $DIR/privacy-struct-ctor.rs:21:9
    |
 LL |     pub struct S(u8);
@@ -7,19 +7,22 @@ LL |     pub struct S(u8);
 LL |         Z;
    |         ^ constructor is not visible here due to private fields
    |
+   = note: a struct named `Z` exists in another namespace
 help: a tuple struct with a similar name exists
    |
 LL -         Z;
 LL +         S;
    |
 
-error[E0423]: expected value, found struct `S`
+error[E0423]: cannot find value `S` in this scope
   --> $DIR/privacy-struct-ctor.rs:34:5
    |
 LL |     S;
    |     ^ constructor is not visible here due to private fields
+   |
+   = note: a struct named `S` exists in another namespace
 
-error[E0423]: expected value, found struct `S2`
+error[E0423]: cannot find value `S2` in this scope
   --> $DIR/privacy-struct-ctor.rs:39:5
    |
 LL | /     pub struct S2 {
@@ -29,13 +32,18 @@ LL | |     }
 ...
 LL |       S2;
    |       ^^ help: use struct literal syntax instead: `S2 { s: val }`
+   |
+   = note: a struct named `S2` exists in another namespace
 
-error[E0423]: expected value, found struct `xcrate::S`
-  --> $DIR/privacy-struct-ctor.rs:44:5
+error[E0423]: cannot find value `S` in crate `xcrate`
+  --> $DIR/privacy-struct-ctor.rs:44:13
    |
 LL |     xcrate::S;
-   |     ^^^^^^^^^ constructor is not visible here due to private fields
+   |     --------^
+   |     |
+   |     constructor is not visible here due to private fields
    |
+   = note: a struct named `xcrate::S` exists in another namespace
 note: tuple struct `m::S` exists but is inaccessible
   --> $DIR/privacy-struct-ctor.rs:7:5
    |

--- a/tests/ui/resolve/private-constructor-self-issue-147343.stderr
+++ b/tests/ui/resolve/private-constructor-self-issue-147343.stderr
@@ -4,6 +4,7 @@ error[E0423]: cannot initialize a tuple struct which contains private fields
 LL |         S(self);
    |         ^
    |
+   = note: a struct named `S` exists in another namespace
    = note: constructor is not visible here due to private fields
 
 error: aborting due to 1 previous error

--- a/tests/ui/resolve/regression-struct-called-as-function-148919.rs
+++ b/tests/ui/resolve/regression-struct-called-as-function-148919.rs
@@ -3,7 +3,7 @@ struct Bar {}
 impl Bar {
     fn into_self(self) -> Bar {
         Bar(self)
-        //~^ ERROR expected function, tuple struct or tuple variant, found struct `Bar` [E0423]
+        //~^ ERROR cannot find function, tuple struct or tuple variant `Bar` in this scope [E0423]
     }
 }
 

--- a/tests/ui/resolve/regression-struct-called-as-function-148919.stderr
+++ b/tests/ui/resolve/regression-struct-called-as-function-148919.stderr
@@ -1,8 +1,10 @@
-error[E0423]: expected function, tuple struct or tuple variant, found struct `Bar`
+error[E0423]: cannot find function, tuple struct or tuple variant `Bar` in this scope
   --> $DIR/regression-struct-called-as-function-148919.rs:5:9
    |
 LL |         Bar(self)
    |         ^^^
+   |
+   = note: a struct named `Bar` exists in another namespace
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/resolve/resolve-dont-hint-macro.rs
+++ b/tests/ui/resolve/resolve-dont-hint-macro.rs
@@ -1,4 +1,4 @@
 fn main() {
     let zero = assert_eq::<()>();
-    //~^ ERROR expected function, found macro `assert_eq`
+    //~^ ERROR cannot find function `assert_eq` in this scope
 }

--- a/tests/ui/resolve/resolve-dont-hint-macro.stderr
+++ b/tests/ui/resolve/resolve-dont-hint-macro.stderr
@@ -1,8 +1,12 @@
-error[E0423]: expected function, found macro `assert_eq`
+error[E0423]: cannot find function `assert_eq` in this scope
   --> $DIR/resolve-dont-hint-macro.rs:2:16
    |
 LL |     let zero = assert_eq::<()>();
-   |                ^^^^^^^^^^^^^^^ not a function
+   |                ^^^^^^^^^------
+   |                |
+   |                not found in this scope
+   |
+   = note: a macro named `assert_eq` exists in another namespace
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/resolve/resolve-hint-macro.fixed
+++ b/tests/ui/resolve/resolve-hint-macro.fixed
@@ -1,11 +1,11 @@
 //@ run-rustfix
 fn main() {
     assert_eq!(1, 1);
-    //~^ ERROR expected function, found macro `assert_eq`
+    //~^ ERROR cannot find function `assert_eq` in this scope
     assert_eq! { 1, 1 };
-    //~^ ERROR expected struct, variant or union type, found macro `assert_eq`
+    //~^ ERROR cannot find struct, variant or union type `assert_eq` in this scope
     //~| ERROR expected identifier, found `1`
     //~| ERROR expected identifier, found `1`
     assert![true];
-    //~^ ERROR expected value, found macro `assert`
+    //~^ ERROR cannot find value `assert` in this scope
 }

--- a/tests/ui/resolve/resolve-hint-macro.rs
+++ b/tests/ui/resolve/resolve-hint-macro.rs
@@ -1,11 +1,11 @@
 //@ run-rustfix
 fn main() {
     assert_eq(1, 1);
-    //~^ ERROR expected function, found macro `assert_eq`
+    //~^ ERROR cannot find function `assert_eq` in this scope
     assert_eq { 1, 1 };
-    //~^ ERROR expected struct, variant or union type, found macro `assert_eq`
+    //~^ ERROR cannot find struct, variant or union type `assert_eq` in this scope
     //~| ERROR expected identifier, found `1`
     //~| ERROR expected identifier, found `1`
     assert[true];
-    //~^ ERROR expected value, found macro `assert`
+    //~^ ERROR cannot find value `assert` in this scope
 }

--- a/tests/ui/resolve/resolve-hint-macro.stderr
+++ b/tests/ui/resolve/resolve-hint-macro.stderr
@@ -14,34 +14,37 @@ LL |     assert_eq { 1, 1 };
    |     |
    |     while parsing this struct
 
-error[E0574]: expected struct, variant or union type, found macro `assert_eq`
+error[E0574]: cannot find struct, variant or union type `assert_eq` in this scope
   --> $DIR/resolve-hint-macro.rs:5:5
    |
 LL |     assert_eq { 1, 1 };
-   |     ^^^^^^^^^ not a struct, variant or union type
+   |     ^^^^^^^^^ not found in this scope
    |
+   = note: a macro named `assert_eq` exists in another namespace
 help: use `!` to invoke the macro
    |
 LL |     assert_eq! { 1, 1 };
    |              +
 
-error[E0423]: expected value, found macro `assert`
+error[E0423]: cannot find value `assert` in this scope
   --> $DIR/resolve-hint-macro.rs:9:5
    |
 LL |     assert[true];
-   |     ^^^^^^ not a value
+   |     ^^^^^^ not found in this scope
    |
+   = note: a macro named `assert` exists in another namespace
 help: use `!` to invoke the macro
    |
 LL |     assert![true];
    |           +
 
-error[E0423]: expected function, found macro `assert_eq`
+error[E0423]: cannot find function `assert_eq` in this scope
   --> $DIR/resolve-hint-macro.rs:3:5
    |
 LL |     assert_eq(1, 1);
-   |     ^^^^^^^^^ not a function
+   |     ^^^^^^^^^ not found in this scope
    |
+   = note: a macro named `assert_eq` exists in another namespace
 help: use `!` to invoke the macro
    |
 LL |     assert_eq!(1, 1);

--- a/tests/ui/resolve/resolve-primitive-fallback.rs
+++ b/tests/ui/resolve/resolve-primitive-fallback.rs
@@ -2,7 +2,7 @@
 fn main() {
     // Make sure primitive type fallback doesn't work in value namespace
     std::mem::size_of(u16);
-    //~^ ERROR expected value, found builtin type `u16`
+    //~^ ERROR cannot find value `u16` in this scope
     //~| ERROR function takes 0 arguments but 1 argument was supplied
 
     // Make sure primitive type fallback doesn't work with global paths

--- a/tests/ui/resolve/resolve-primitive-fallback.stderr
+++ b/tests/ui/resolve/resolve-primitive-fallback.stderr
@@ -1,8 +1,10 @@
-error[E0423]: expected value, found builtin type `u16`
+error[E0423]: cannot find value `u16` in this scope
   --> $DIR/resolve-primitive-fallback.rs:4:23
    |
 LL |     std::mem::size_of(u16);
-   |                       ^^^ not a value
+   |                       ^^^ not found in this scope
+   |
+   = note: a builtin type named `u16` exists in another namespace
 
 error[E0425]: cannot find type `u8` in the crate root
   --> $DIR/resolve-primitive-fallback.rs:9:14

--- a/tests/ui/resolve/suggestions/suggest-constructor-cycle-error.stderr
+++ b/tests/ui/resolve/suggestions/suggest-constructor-cycle-error.stderr
@@ -1,9 +1,10 @@
 error[E0423]: cannot initialize a tuple struct which contains private fields
-  --> $DIR/suggest-constructor-cycle-error.rs:7:29
+  --> $DIR/suggest-constructor-cycle-error.rs:7:32
    |
 LL | const CONST_NAME: a::Uuid = a::Uuid(());
-   |                             ^^^^^^^
+   |                                ^^^^
    |
+   = note: a struct named `a::Uuid` exists in another namespace
 note: constructor is not visible here due to private fields
   --> $DIR/auxiliary/suggest-constructor-cycle-error.rs:2:21
    |

--- a/tests/ui/resolve/suggestions/suggest-path-for-tuple-struct.rs
+++ b/tests/ui/resolve/suggestions/suggest-path-for-tuple-struct.rs
@@ -20,7 +20,7 @@ use module::{SomeTupleStruct, SomeRegularStruct};
 
 fn main() {
     let _ = SomeTupleStruct.new();
-    //~^ ERROR expected value, found struct `SomeTupleStruct`
+    //~^ ERROR cannot find value `SomeTupleStruct` in this scope
     let _ = SomeRegularStruct.new();
-    //~^ ERROR expected value, found struct `SomeRegularStruct`
+    //~^ ERROR cannot find value `SomeRegularStruct` in this scope
 }

--- a/tests/ui/resolve/suggestions/suggest-path-for-tuple-struct.stderr
+++ b/tests/ui/resolve/suggestions/suggest-path-for-tuple-struct.stderr
@@ -1,21 +1,23 @@
-error[E0423]: expected value, found struct `SomeTupleStruct`
+error[E0423]: cannot find value `SomeTupleStruct` in this scope
   --> $DIR/suggest-path-for-tuple-struct.rs:22:13
    |
 LL |     let _ = SomeTupleStruct.new();
    |             ^^^^^^^^^^^^^^^
    |
+   = note: a struct named `SomeTupleStruct` exists in another namespace
 help: use the path separator to refer to an item
    |
 LL -     let _ = SomeTupleStruct.new();
 LL +     let _ = SomeTupleStruct::new();
    |
 
-error[E0423]: expected value, found struct `SomeRegularStruct`
+error[E0423]: cannot find value `SomeRegularStruct` in this scope
   --> $DIR/suggest-path-for-tuple-struct.rs:24:13
    |
 LL |     let _ = SomeRegularStruct.new();
    |             ^^^^^^^^^^^^^^^^^
    |
+   = note: a struct named `SomeRegularStruct` exists in another namespace
 help: use the path separator to refer to an item
    |
 LL -     let _ = SomeRegularStruct.new();

--- a/tests/ui/resolve/suggestions/suggest-path-instead-of-mod-dot-item.rs
+++ b/tests/ui/resolve/suggestions/suggest-path-instead-of-mod-dot-item.rs
@@ -15,75 +15,75 @@ pub mod a {
 
 fn h1() -> i32 {
     a.I
-    //~^ ERROR expected value, found module `a`
+    //~^ ERROR cannot find value `a` in this scope
     //~| HELP use the path separator
 }
 
 fn h2() -> i32 {
     a.g()
-    //~^ ERROR expected value, found module `a`
+    //~^ ERROR cannot find value `a` in this scope
     //~| HELP use the path separator
 }
 
 fn h3() -> i32 {
     a.b.J
-    //~^ ERROR expected value, found module `a`
+    //~^ ERROR cannot find value `a` in this scope
     //~| HELP use the path separator
 }
 
 fn h4() -> i32 {
     a::b.J
-    //~^ ERROR expected value, found module `a::b`
+    //~^ ERROR cannot find value `b` in module `a`
     //~| HELP a constant with a similar name exists
     //~| HELP use the path separator
 }
 
 fn h5() {
     a.b.f();
-    //~^ ERROR expected value, found module `a`
+    //~^ ERROR cannot find value `a` in this scope
     //~| HELP use the path separator
     let v = Vec::new();
     v.push(a::b);
-    //~^ ERROR expected value, found module `a::b`
+    //~^ ERROR cannot find value `b` in module `a`
     //~| HELP a constant with a similar name exists
 }
 
 fn h6() -> i32 {
     a::b.f()
-    //~^ ERROR expected value, found module `a::b`
+    //~^ ERROR cannot find value `b` in module `a`
     //~| HELP a constant with a similar name exists
     //~| HELP use the path separator
 }
 
 fn h7() {
     a::b
-    //~^ ERROR expected value, found module `a::b`
+    //~^ ERROR cannot find value `b` in module `a`
     //~| HELP a constant with a similar name exists
 }
 
 fn h8() -> i32 {
     a::b()
-    //~^ ERROR expected function, found module `a::b`
+    //~^ ERROR cannot find function `b` in module `a`
     //~| HELP a constant with a similar name exists
 }
 
 macro_rules! module {
     () => {
         a
-        //~^ ERROR expected value, found module `a`
-        //~| ERROR expected value, found module `a`
+        //~^ ERROR cannot find value `a` in this scope
+        //~| ERROR cannot find value `a` in this scope
     };
 }
 
 macro_rules! create {
     (method) => {
         a.f()
-        //~^ ERROR expected value, found module `a`
+        //~^ ERROR cannot find value `a` in this scope
         //~| HELP use the path separator
     };
     (field) => {
         a.f
-        //~^ ERROR expected value, found module `a`
+        //~^ ERROR cannot find value `a` in this scope
         //~| HELP use the path separator
     };
 }

--- a/tests/ui/resolve/suggestions/suggest-path-instead-of-mod-dot-item.stderr
+++ b/tests/ui/resolve/suggestions/suggest-path-instead-of-mod-dot-item.stderr
@@ -1,48 +1,52 @@
-error[E0423]: expected value, found module `a`
+error[E0423]: cannot find value `a` in this scope
   --> $DIR/suggest-path-instead-of-mod-dot-item.rs:17:5
    |
 LL |     a.I
    |     ^
    |
+   = note: a module named `a` exists in another namespace
 help: use the path separator to refer to an item
    |
 LL -     a.I
 LL +     a::I
    |
 
-error[E0423]: expected value, found module `a`
+error[E0423]: cannot find value `a` in this scope
   --> $DIR/suggest-path-instead-of-mod-dot-item.rs:23:5
    |
 LL |     a.g()
    |     ^
    |
+   = note: a module named `a` exists in another namespace
 help: use the path separator to refer to an item
    |
 LL -     a.g()
 LL +     a::g()
    |
 
-error[E0423]: expected value, found module `a`
+error[E0423]: cannot find value `a` in this scope
   --> $DIR/suggest-path-instead-of-mod-dot-item.rs:29:5
    |
 LL |     a.b.J
    |     ^
    |
+   = note: a module named `a` exists in another namespace
 help: use the path separator to refer to an item
    |
 LL -     a.b.J
 LL +     a::b.J
    |
 
-error[E0423]: expected value, found module `a::b`
-  --> $DIR/suggest-path-instead-of-mod-dot-item.rs:35:5
+error[E0423]: cannot find value `b` in module `a`
+  --> $DIR/suggest-path-instead-of-mod-dot-item.rs:35:8
    |
 LL |     pub const I: i32 = 1;
    |     --------------------- similarly named constant `I` defined here
 ...
 LL |     a::b.J
-   |     ^^^^
+   |        ^
    |
+   = note: a module named `a::b` exists in another namespace
 help: use the path separator to refer to an item
    |
 LL -     a::b.J
@@ -54,42 +58,45 @@ LL -     a::b.J
 LL +     a::I.J
    |
 
-error[E0423]: expected value, found module `a`
+error[E0423]: cannot find value `a` in this scope
   --> $DIR/suggest-path-instead-of-mod-dot-item.rs:42:5
    |
 LL |     a.b.f();
    |     ^
    |
+   = note: a module named `a` exists in another namespace
 help: use the path separator to refer to an item
    |
 LL -     a.b.f();
 LL +     a::b.f();
    |
 
-error[E0423]: expected value, found module `a::b`
-  --> $DIR/suggest-path-instead-of-mod-dot-item.rs:46:12
+error[E0423]: cannot find value `b` in module `a`
+  --> $DIR/suggest-path-instead-of-mod-dot-item.rs:46:15
    |
 LL |     pub const I: i32 = 1;
    |     --------------------- similarly named constant `I` defined here
 ...
 LL |     v.push(a::b);
-   |            ^^^^
+   |               ^
    |
+   = note: a module named `a::b` exists in another namespace
 help: a constant with a similar name exists
    |
 LL -     v.push(a::b);
 LL +     v.push(a::I);
    |
 
-error[E0423]: expected value, found module `a::b`
-  --> $DIR/suggest-path-instead-of-mod-dot-item.rs:52:5
+error[E0423]: cannot find value `b` in module `a`
+  --> $DIR/suggest-path-instead-of-mod-dot-item.rs:52:8
    |
 LL |     pub const I: i32 = 1;
    |     --------------------- similarly named constant `I` defined here
 ...
 LL |     a::b.f()
-   |     ^^^^
+   |        ^
    |
+   = note: a module named `a::b` exists in another namespace
 help: use the path separator to refer to an item
    |
 LL -     a::b.f()
@@ -101,59 +108,63 @@ LL -     a::b.f()
 LL +     a::I.f()
    |
 
-error[E0423]: expected value, found module `a::b`
-  --> $DIR/suggest-path-instead-of-mod-dot-item.rs:59:5
+error[E0423]: cannot find value `b` in module `a`
+  --> $DIR/suggest-path-instead-of-mod-dot-item.rs:59:8
    |
 LL |     pub const I: i32 = 1;
    |     --------------------- similarly named constant `I` defined here
 ...
 LL |     a::b
-   |     ^^^^
+   |        ^
    |
+   = note: a module named `a::b` exists in another namespace
 help: a constant with a similar name exists
    |
 LL -     a::b
 LL +     a::I
    |
 
-error[E0423]: expected function, found module `a::b`
-  --> $DIR/suggest-path-instead-of-mod-dot-item.rs:65:5
+error[E0423]: cannot find function `b` in module `a`
+  --> $DIR/suggest-path-instead-of-mod-dot-item.rs:65:8
    |
 LL |     pub const I: i32 = 1;
    |     --------------------- similarly named constant `I` defined here
 ...
 LL |     a::b()
-   |     ^^^^
+   |        ^
    |
+   = note: a module named `a::b` exists in another namespace
 help: a constant with a similar name exists
    |
 LL -     a::b()
 LL +     a::I()
    |
 
-error[E0423]: expected value, found module `a`
+error[E0423]: cannot find value `a` in this scope
   --> $DIR/suggest-path-instead-of-mod-dot-item.rs:72:9
    |
 LL |         a
-   |         ^ not a value
+   |         ^ not found in this scope
 ...
 LL |     module!().g::<()>(); // no `help` here!
    |     --------- in this macro invocation
    |
+   = note: a module named `a` exists in another namespace
    = note: this error originates in the macro `module` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0423]: expected value, found module `a`
+error[E0423]: cannot find value `a` in this scope
   --> $DIR/suggest-path-instead-of-mod-dot-item.rs:72:9
    |
 LL |         a
-   |         ^ not a value
+   |         ^ not found in this scope
 ...
 LL |     module!().g; // no `help` here!
    |     --------- in this macro invocation
    |
+   = note: a module named `a` exists in another namespace
    = note: this error originates in the macro `module` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0423]: expected value, found module `a`
+error[E0423]: cannot find value `a` in this scope
   --> $DIR/suggest-path-instead-of-mod-dot-item.rs:80:9
    |
 LL |         a.f()
@@ -162,6 +173,7 @@ LL |         a.f()
 LL |     let _ = create!(method);
    |             --------------- in this macro invocation
    |
+   = note: a module named `a` exists in another namespace
    = note: this error originates in the macro `create` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: use the path separator to refer to an item
    |
@@ -169,7 +181,7 @@ LL -         a.f()
 LL +         a::f()
    |
 
-error[E0423]: expected value, found module `a`
+error[E0423]: cannot find value `a` in this scope
   --> $DIR/suggest-path-instead-of-mod-dot-item.rs:85:9
    |
 LL |         a.f
@@ -178,6 +190,7 @@ LL |         a.f
 LL |     let _ = create!(field);
    |             -------------- in this macro invocation
    |
+   = note: a module named `a` exists in another namespace
    = note: this error originates in the macro `create` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: use the path separator to refer to an item
    |

--- a/tests/ui/resolve/tuple-struct-alias.rs
+++ b/tests/ui/resolve/tuple-struct-alias.rs
@@ -2,8 +2,8 @@ struct S(u8, u16);
 type A = S;
 
 fn main() {
-    let s = A(0, 1); //~ ERROR expected function
+    let s = A(0, 1); //~ ERROR cannot find function, tuple struct or tuple variant `A` in this scope
     match s {
-        A(..) => {} //~ ERROR expected tuple struct or tuple variant
+        A(..) => {} //~ ERROR cannot find tuple struct or tuple variant `A` in this scope
     }
 }

--- a/tests/ui/resolve/tuple-struct-alias.stderr
+++ b/tests/ui/resolve/tuple-struct-alias.stderr
@@ -1,4 +1,4 @@
-error[E0532]: expected tuple struct or tuple variant, found type alias `A`
+error[E0532]: cannot find tuple struct or tuple variant `A` in this scope
   --> $DIR/tuple-struct-alias.rs:7:9
    |
 LL | struct S(u8, u16);
@@ -7,13 +7,14 @@ LL | struct S(u8, u16);
 LL |         A(..) => {}
    |         ^
    |
+   = note: a type alias named `A` exists in another namespace
 help: a tuple struct with a similar name exists
    |
 LL -         A(..) => {}
 LL +         S(..) => {}
    |
 
-error[E0423]: expected function, tuple struct or tuple variant, found type alias `A`
+error[E0423]: cannot find function, tuple struct or tuple variant `A` in this scope
   --> $DIR/tuple-struct-alias.rs:5:13
    |
 LL | struct S(u8, u16);
@@ -22,6 +23,7 @@ LL | struct S(u8, u16);
 LL |     let s = A(0, 1);
    |             ^
    |
+   = note: a type alias named `A` exists in another namespace
 help: a tuple struct with a similar name exists
    |
 LL -     let s = A(0, 1);

--- a/tests/ui/rfcs/rfc-2008-non-exhaustive/struct.rs
+++ b/tests/ui/rfcs/rfc-2008-non-exhaustive/struct.rs
@@ -27,7 +27,7 @@ fn main() {
     //~^ ERROR `..` required with struct marked as non-exhaustive
 
     let us = UnitStruct;
-    //~^ ERROR expected value, found struct `UnitStruct` [E0423]
+    //~^ ERROR cannot find value `UnitStruct` in this scope [E0423]
 
     let us_explicit = structs::UnitStruct;
     //~^ ERROR unit struct `UnitStruct` is private [E0603]

--- a/tests/ui/rfcs/rfc-2008-non-exhaustive/struct.stderr
+++ b/tests/ui/rfcs/rfc-2008-non-exhaustive/struct.stderr
@@ -1,8 +1,10 @@
-error[E0423]: expected value, found struct `UnitStruct`
+error[E0423]: cannot find value `UnitStruct` in this scope
   --> $DIR/struct.rs:29:14
    |
 LL |     let us = UnitStruct;
    |              ^^^^^^^^^^ constructor is not visible here due to private fields
+   |
+   = note: a struct named `UnitStruct` exists in another namespace
 
 error[E0603]: tuple struct constructor `TupleStruct` is private
   --> $DIR/struct.rs:23:32
@@ -66,6 +68,8 @@ error[E0423]: cannot initialize a tuple struct which contains private fields
    |
 LL |     let ts = TupleStruct(640, 480);
    |              ^^^^^^^^^^^
+   |
+   = note: a struct named `TupleStruct` exists in another namespace
 
 error[E0638]: `..` required with struct marked as non-exhaustive
   --> $DIR/struct.rs:26:9

--- a/tests/ui/rfcs/rfc-2126-crate-paths/keyword-crate-as-identifier.rs
+++ b/tests/ui/rfcs/rfc-2126-crate-paths/keyword-crate-as-identifier.rs
@@ -1,4 +1,4 @@
 fn main() {
     let crate = 0;
-    //~^ ERROR expected unit struct, unit variant or constant, found module `crate`
+    //~^ ERROR cannot find unit struct, unit variant or constant `crate` in this scope
 }

--- a/tests/ui/rfcs/rfc-2126-crate-paths/keyword-crate-as-identifier.stderr
+++ b/tests/ui/rfcs/rfc-2126-crate-paths/keyword-crate-as-identifier.stderr
@@ -1,8 +1,10 @@
-error[E0532]: expected unit struct, unit variant or constant, found module `crate`
+error[E0532]: cannot find unit struct, unit variant or constant `crate` in this scope
   --> $DIR/keyword-crate-as-identifier.rs:2:9
    |
 LL |     let crate = 0;
-   |         ^^^^^ not a unit struct, unit variant or constant
+   |         ^^^^^ not found in this scope
+   |
+   = note: a module named `crate` exists in another namespace
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/rfcs/rfc-2126-extern-absolute-paths/single-segment.rs
+++ b/tests/ui/rfcs/rfc-2126-extern-absolute-paths/single-segment.rs
@@ -6,6 +6,7 @@ use crate; //~ ERROR imports need to be explicitly named
 use *; //~ ERROR cannot glob-import all possible crates
 
 fn main() {
-    let s = ::xcrate; //~ ERROR expected value, found crate `::xcrate`
-                      //~^ NOTE not a value
+    let s = ::xcrate; //~ ERROR cannot find crate `xcrate` in the list of imported crates
+                      //~^ NOTE not found in the list of imported crates
+                      //~| NOTE a crate named `::xcrate` exists in another namespace
 }

--- a/tests/ui/rfcs/rfc-2126-extern-absolute-paths/single-segment.stderr
+++ b/tests/ui/rfcs/rfc-2126-extern-absolute-paths/single-segment.stderr
@@ -15,11 +15,13 @@ error: cannot glob-import all possible crates
 LL | use *;
    |     ^
 
-error[E0423]: expected value, found crate `::xcrate`
-  --> $DIR/single-segment.rs:9:13
+error[E0423]: cannot find crate `xcrate` in the list of imported crates
+  --> $DIR/single-segment.rs:9:15
    |
 LL |     let s = ::xcrate;
-   |             ^^^^^^^^ not a value
+   |               ^^^^^^ not found in the list of imported crates
+   |
+   = note: a crate named `::xcrate` exists in another namespace
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/sized/relaxing-default-bound-error-37534.rs
+++ b/tests/ui/sized/relaxing-default-bound-error-37534.rs
@@ -1,5 +1,5 @@
 // issue: <https://github.com/rust-lang/rust/issues/37534>
 
-struct Foo<T: ?Hash> {} //~ ERROR expected trait, found derive macro `Hash`
+struct Foo<T: ?Hash> {} //~ ERROR cannot find trait `Hash` in this scope
 
 fn main() {}

--- a/tests/ui/sized/relaxing-default-bound-error-37534.stderr
+++ b/tests/ui/sized/relaxing-default-bound-error-37534.stderr
@@ -1,9 +1,10 @@
-error[E0404]: expected trait, found derive macro `Hash`
+error[E0404]: cannot find trait `Hash` in this scope
   --> $DIR/relaxing-default-bound-error-37534.rs:3:16
    |
 LL | struct Foo<T: ?Hash> {}
-   |                ^^^^ not a trait
+   |                ^^^^ not found in this scope
    |
+   = note: a derive macro named `Hash` exists in another namespace
 help: consider importing this trait instead
    |
 LL + use std::hash::Hash;

--- a/tests/ui/structs/ice-line-bounds-issue-148684.rs
+++ b/tests/ui/structs/ice-line-bounds-issue-148684.rs
@@ -5,5 +5,5 @@ struct A {
 
 fn main() {
     A(2, vec![])
-    //~^ ERROR expected function, tuple struct or tuple variant, found struct `A`
+    //~^ ERROR cannot find function, tuple struct or tuple variant `A` in this scope
 }

--- a/tests/ui/structs/ice-line-bounds-issue-148684.stderr
+++ b/tests/ui/structs/ice-line-bounds-issue-148684.stderr
@@ -1,4 +1,4 @@
-error[E0423]: expected function, tuple struct or tuple variant, found struct `A`
+error[E0423]: cannot find function, tuple struct or tuple variant `A` in this scope
   --> $DIR/ice-line-bounds-issue-148684.rs:7:5
    |
 LL | / struct A {
@@ -9,6 +9,8 @@ LL | | }
 ...
 LL |       A(2, vec![])
    |       ^^^^^^^^^^^^
+   |
+   = note: a struct named `A` exists in another namespace
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/structs/struct-construct-with-call-issue-138931.rs
+++ b/tests/ui/structs/struct-construct-with-call-issue-138931.rs
@@ -12,14 +12,14 @@ struct PersonWithAge {
 
 fn main() {
     let wilfred = PersonOnlyName("Name1".to_owned());
-    //~^ ERROR expected function, tuple struct or tuple variant, found struct `PersonOnlyName` [E0423]
+    //~^ ERROR cannot find function, tuple struct or tuple variant `PersonOnlyName` in this scope [E0423]
 
-    let bill = PersonWithAge( //~ ERROR expected function, tuple struct or tuple variant, found struct `PersonWithAge` [E0423]
+    let bill = PersonWithAge( //~ ERROR cannot find function, tuple struct or tuple variant `PersonWithAge` in this scope [E0423]
         "Name2".to_owned(),
         20,
         180,
     );
 
     let person = PersonWithAge("Name3".to_owned());
-    //~^ ERROR expected function, tuple struct or tuple variant, found struct `PersonWithAge` [E0423]
+    //~^ ERROR cannot find function, tuple struct or tuple variant `PersonWithAge` in this scope [E0423]
 }

--- a/tests/ui/structs/struct-construct-with-call-issue-138931.stderr
+++ b/tests/ui/structs/struct-construct-with-call-issue-138931.stderr
@@ -1,4 +1,4 @@
-error[E0423]: expected function, tuple struct or tuple variant, found struct `PersonOnlyName`
+error[E0423]: cannot find function, tuple struct or tuple variant `PersonOnlyName` in this scope
   --> $DIR/struct-construct-with-call-issue-138931.rs:14:19
    |
 LL | / struct PersonOnlyName {
@@ -9,13 +9,14 @@ LL | | }
 LL |       let wilfred = PersonOnlyName("Name1".to_owned());
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
+   = note: a struct named `PersonOnlyName` exists in another namespace
 help: use struct literal syntax instead of calling
    |
 LL -     let wilfred = PersonOnlyName("Name1".to_owned());
 LL +     let wilfred = PersonOnlyName{name: "Name1".to_owned()};
    |
 
-error[E0423]: expected function, tuple struct or tuple variant, found struct `PersonWithAge`
+error[E0423]: cannot find function, tuple struct or tuple variant `PersonWithAge` in this scope
   --> $DIR/struct-construct-with-call-issue-138931.rs:17:16
    |
 LL | / struct PersonWithAge {
@@ -33,6 +34,7 @@ LL | |         180,
 LL | |     );
    | |_____^
    |
+   = note: a struct named `PersonWithAge` exists in another namespace
 help: use struct literal syntax instead of calling
    |
 LL ~     let bill = PersonWithAge{name: "Name2".to_owned(),
@@ -40,7 +42,7 @@ LL ~         age: 20,
 LL ~         height: 180};
    |
 
-error[E0423]: expected function, tuple struct or tuple variant, found struct `PersonWithAge`
+error[E0423]: cannot find function, tuple struct or tuple variant `PersonWithAge` in this scope
   --> $DIR/struct-construct-with-call-issue-138931.rs:23:18
    |
 LL | / struct PersonWithAge {
@@ -52,6 +54,8 @@ LL | | }
 ...
 LL |       let person = PersonWithAge("Name3".to_owned());
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use struct literal syntax instead: `PersonWithAge { name: val, age: val, height: val }`
+   |
+   = note: a struct named `PersonWithAge` exists in another namespace
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/suggestions/assoc-const-as-field.rs
+++ b/tests/ui/suggestions/assoc-const-as-field.rs
@@ -9,5 +9,5 @@ fn foo(_: usize) {}
 
 fn main() {
     foo(Mod::Foo.Bar);
-    //~^ ERROR expected value, found
+    //~^ ERROR cannot find value `Foo` in module `Mod`
 }

--- a/tests/ui/suggestions/assoc-const-as-field.stderr
+++ b/tests/ui/suggestions/assoc-const-as-field.stderr
@@ -1,9 +1,10 @@
-error[E0423]: expected value, found struct `Mod::Foo`
-  --> $DIR/assoc-const-as-field.rs:11:9
+error[E0423]: cannot find value `Foo` in module `Mod`
+  --> $DIR/assoc-const-as-field.rs:11:14
    |
 LL |     foo(Mod::Foo.Bar);
-   |         ^^^^^^^^
+   |              ^^^
    |
+   = note: a struct named `Mod::Foo` exists in another namespace
 help: use the path separator to refer to an item
    |
 LL -     foo(Mod::Foo.Bar);

--- a/tests/ui/suggestions/issue-109396.rs
+++ b/tests/ui/suggestions/issue-109396.rs
@@ -3,7 +3,7 @@ fn main() {
         let mut mutex = std::mem::zeroed(
             //~^ ERROR this function takes 0 arguments but 4 arguments were supplied
             file.as_raw_fd(),
-            //~^ ERROR expected value, found macro `file`
+            //~^ ERROR cannot find value `file` in this scope
             0,
             0,
             0,

--- a/tests/ui/suggestions/issue-109396.stderr
+++ b/tests/ui/suggestions/issue-109396.stderr
@@ -1,8 +1,10 @@
-error[E0423]: expected value, found macro `file`
+error[E0423]: cannot find value `file` in this scope
   --> $DIR/issue-109396.rs:5:13
    |
 LL |             file.as_raw_fd(),
-   |             ^^^^ not a value
+   |             ^^^^ not found in this scope
+   |
+   = note: a macro named `file` exists in another namespace
 
 error[E0061]: this function takes 0 arguments but 4 arguments were supplied
   --> $DIR/issue-109396.rs:3:25

--- a/tests/ui/suggestions/issue-61226.fixed
+++ b/tests/ui/suggestions/issue-61226.fixed
@@ -2,5 +2,5 @@
 struct X {}
 fn main() {
     let _ = vec![X {}]; //…
-    //~^ ERROR expected value, found struct `X`
+    //~^ ERROR cannot find value `X` in this scope
 }

--- a/tests/ui/suggestions/issue-61226.rs
+++ b/tests/ui/suggestions/issue-61226.rs
@@ -2,5 +2,5 @@
 struct X {}
 fn main() {
     let _ = vec![X]; //…
-    //~^ ERROR expected value, found struct `X`
+    //~^ ERROR cannot find value `X` in this scope
 }

--- a/tests/ui/suggestions/issue-61226.stderr
+++ b/tests/ui/suggestions/issue-61226.stderr
@@ -1,4 +1,4 @@
-error[E0423]: expected value, found struct `X`
+error[E0423]: cannot find value `X` in this scope
   --> $DIR/issue-61226.rs:4:18
    |
 LL | struct X {}
@@ -6,6 +6,8 @@ LL | struct X {}
 LL | fn main() {
 LL |     let _ = vec![X]; //…
    |                  ^ help: use struct literal syntax instead: `X {}`
+   |
+   = note: a struct named `X` exists in another namespace
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/suggestions/let-binding-init-expr-as-ty.rs
+++ b/tests/ui/suggestions/let-binding-init-expr-as-ty.rs
@@ -1,7 +1,7 @@
 fn foo(num: i32) -> i32 {
     // FIXME: This case doesn't really check that `from_be` is a valid function in `i32`.
     let foo: i32::from_be(num);
-    //~^ ERROR expected type, found local variable `num`
+    //~^ ERROR cannot find type `num` in this scope
     //~| ERROR expected type, found associated function call
     foo
 }
@@ -33,9 +33,9 @@ fn main() {
     let x: ""; //~ ERROR expected type, found `""`
 
     // Functions
-    let x: bar(); //~ ERROR expected type, found function `bar`
-    let x: bar; //~ ERROR expected type, found function `bar`
+    let x: bar(); //~ ERROR cannot find type `bar` in this scope
+    let x: bar; //~ ERROR cannot find type `bar` in this scope
 
     // Locals
-    let x: x; //~ ERROR expected type, found local variable `x`
+    let x: x; //~ ERROR cannot find type `x` in this scope
 }

--- a/tests/ui/suggestions/let-binding-init-expr-as-ty.stderr
+++ b/tests/ui/suggestions/let-binding-init-expr-as-ty.stderr
@@ -26,37 +26,41 @@ LL -     let x: "";
 LL +     let x = "";
    |
 
-error[E0573]: expected type, found local variable `num`
+error[E0573]: cannot find type `num` in this scope
   --> $DIR/let-binding-init-expr-as-ty.rs:3:27
    |
 LL |     let foo: i32::from_be(num);
-   |                           ^^^ not a type
+   |                           ^^^ not found in this scope
    |
+   = note: a local variable named `num` exists in another namespace
 help: use `=` if you meant to assign
    |
 LL -     let foo: i32::from_be(num);
 LL +     let foo = i32::from_be(num);
    |
 
-error[E0573]: expected type, found function `bar`
+error[E0573]: cannot find type `bar` in this scope
   --> $DIR/let-binding-init-expr-as-ty.rs:36:12
    |
 LL |     let x: bar();
-   |            ^^^^^ not a type
+   |            ^^^ not found in this scope
    |
+   = note: a function named `bar` exists in another namespace
 help: use `=` if you meant to assign
    |
 LL -     let x: bar();
 LL +     let x = bar();
    |
 
-error[E0573]: expected type, found function `bar`
+error[E0573]: cannot find type `bar` in this scope
   --> $DIR/let-binding-init-expr-as-ty.rs:37:12
    |
 LL |     let x: bar;
-   |            ^^^ not a type
+   |            ^^^ not found in this scope
+   |
+   = note: a function named `bar` exists in another namespace
 
-error[E0573]: expected type, found local variable `x`
+error[E0573]: cannot find type `x` in this scope
   --> $DIR/let-binding-init-expr-as-ty.rs:40:12
    |
 LL | struct K(S::new(()));
@@ -65,6 +69,7 @@ LL | struct K(S::new(()));
 LL |     let x: x;
    |            ^
    |
+   = note: a local variable named `x` exists in another namespace
 help: a struct with a similar name exists
    |
 LL -     let x: x;

--- a/tests/ui/suggestions/let-binding-suggest-issue-133713.fixed
+++ b/tests/ui/suggestions/let-binding-suggest-issue-133713.fixed
@@ -2,11 +2,11 @@
 #![allow(dead_code)]
 
 fn demo1() {
-    let _last: u64 = 0; //~ ERROR expected value, found builtin type `u64`
+    let _last: u64 = 0; //~ ERROR cannot find value `u64` in this scope
 }
 
 fn demo2() {
-    let _val: u64; //~ ERROR expected value, found builtin type `u64`
+    let _val: u64; //~ ERROR cannot find value `u64` in this scope
 }
 
 fn main() {}

--- a/tests/ui/suggestions/let-binding-suggest-issue-133713.rs
+++ b/tests/ui/suggestions/let-binding-suggest-issue-133713.rs
@@ -2,11 +2,11 @@
 #![allow(dead_code)]
 
 fn demo1() {
-    let _last = u64 = 0; //~ ERROR expected value, found builtin type `u64`
+    let _last = u64 = 0; //~ ERROR cannot find value `u64` in this scope
 }
 
 fn demo2() {
-    let _val = u64; //~ ERROR expected value, found builtin type `u64`
+    let _val = u64; //~ ERROR cannot find value `u64` in this scope
 }
 
 fn main() {}

--- a/tests/ui/suggestions/let-binding-suggest-issue-133713.stderr
+++ b/tests/ui/suggestions/let-binding-suggest-issue-133713.stderr
@@ -1,21 +1,23 @@
-error[E0423]: expected value, found builtin type `u64`
+error[E0423]: cannot find value `u64` in this scope
   --> $DIR/let-binding-suggest-issue-133713.rs:5:17
    |
 LL |     let _last = u64 = 0;
    |                 ^^^
    |
+   = note: a builtin type named `u64` exists in another namespace
 help: you might have meant to use `:` for type annotation
    |
 LL -     let _last = u64 = 0;
 LL +     let _last: u64 = 0;
    |
 
-error[E0423]: expected value, found builtin type `u64`
+error[E0423]: cannot find value `u64` in this scope
   --> $DIR/let-binding-suggest-issue-133713.rs:9:16
    |
 LL |     let _val = u64;
    |                ^^^
    |
+   = note: a builtin type named `u64` exists in another namespace
 help: you might have meant to use `:` for type annotation
    |
 LL -     let _val = u64;

--- a/tests/ui/suggestions/multi-suggestion.ascii.stderr
+++ b/tests/ui/suggestions/multi-suggestion.ascii.stderr
@@ -1,4 +1,4 @@
-error[E0423]: expected function, tuple struct or tuple variant, found struct `std::collections::HashMap`
+error[E0423]: cannot find function, tuple struct or tuple variant `HashMap` in module `std::collections`
   --> $DIR/multi-suggestion.rs:17:13
    |
 LL |     let _ = std::collections::HashMap();
@@ -8,6 +8,8 @@ LL |     let _ = std::collections::HashMap();
   ::: $SRC_DIR/std/src/collections/hash/map.rs:LL:COL
    |
    = note: `std::collections::HashMap` defined here
+   |
+   = note: a struct named `std::collections::HashMap` exists in another namespace
 help: you might have meant to use an associated function to build this type
    |
 LL |     let _ = std::collections::HashMap::new();
@@ -33,6 +35,7 @@ error[E0423]: cannot initialize a tuple struct which contains private fields
 LL |         wtf: Some(Box(U {
    |                   ^^^
    |
+   = note: a struct named `Box` exists in another namespace
 note: constructor is not visible here due to private fields
   --> $SRC_DIR/alloc/src/boxed.rs:LL:COL
    |

--- a/tests/ui/suggestions/multi-suggestion.rs
+++ b/tests/ui/suggestions/multi-suggestion.rs
@@ -15,7 +15,7 @@ fn main() {
         x: ()
     };
     let _ = std::collections::HashMap();
-    //[ascii]~^ ERROR expected function, tuple struct or tuple variant, found struct `std::collections::HashMap`
+    //[ascii]~^ ERROR cannot find function, tuple struct or tuple variant `HashMap` in module `std::collections`
     let _ = std::collections::HashMap {};
     //[ascii]~^ ERROR cannot construct `HashMap<_, _, _, _>` with struct literal syntax due to private fields
     let _ = Box {}; //[ascii]~ ERROR cannot construct `Box<_, _>` with struct literal syntax due to private fields

--- a/tests/ui/suggestions/multi-suggestion.unicode.stderr
+++ b/tests/ui/suggestions/multi-suggestion.unicode.stderr
@@ -1,4 +1,4 @@
-error[E0423]: expected function, tuple struct or tuple variant, found struct `std::collections::HashMap`
+error[E0423]: cannot find function, tuple struct or tuple variant `HashMap` in module `std::collections`
    ╭▸ $DIR/multi-suggestion.rs:17:13
    │
 LL │     let _ = std::collections::HashMap();
@@ -7,7 +7,9 @@ LL │     let _ = std::collections::HashMap();
    ╭▸ $SRC_DIR/std/src/collections/hash/map.rs:LL:COL
    ⸬  $SRC_DIR/std/src/collections/hash/map.rs:LL:COL
    │
-   ╰ note: `std::collections::HashMap` defined here
+   ├ note: `std::collections::HashMap` defined here
+   │
+   ╰ note: a struct named `std::collections::HashMap` exists in another namespace
 help: you might have meant to use an associated function to build this type
    ╭╴
 LL │     let _ = std::collections::HashMap::new();
@@ -32,7 +34,8 @@ error[E0423]: cannot initialize a tuple struct which contains private fields
    │
 LL │         wtf: Some(Box(U {
    │                   ━━━
-   ╰╴
+   │
+   ╰ note: a struct named `Box` exists in another namespace
 note: constructor is not visible here due to private fields
    ╭▸ $SRC_DIR/alloc/src/boxed.rs:LL:COL
    │

--- a/tests/ui/suggestions/suggest-add-self-issue-128042.rs
+++ b/tests/ui/suggestions/suggest-add-self-issue-128042.rs
@@ -5,7 +5,7 @@ struct Thing {
 impl Thing {
     fn oof(*mut Self) { //~ ERROR expected parameter name, found `*`
         self.state = 1;
-        //~^ ERROR expected value, found module `self`
+        //~^ ERROR cannot find value `self` in this scope
     }
 }
 

--- a/tests/ui/suggestions/suggest-add-self-issue-128042.stderr
+++ b/tests/ui/suggestions/suggest-add-self-issue-128042.stderr
@@ -4,7 +4,7 @@ error: expected parameter name, found `*`
 LL |     fn oof(*mut Self) {
    |            ^ expected parameter name
 
-error[E0424]: expected value, found module `self`
+error[E0424]: cannot find value `self` in this scope
   --> $DIR/suggest-add-self-issue-128042.rs:7:9
    |
 LL |     fn oof(*mut Self) {
@@ -12,6 +12,7 @@ LL |     fn oof(*mut Self) {
 LL |         self.state = 1;
    |         ^^^^ `self` value is a keyword only available in methods with a `self` parameter
    |
+   = note: a module named `self` exists in another namespace
 help: add a `self` receiver parameter to make the associated `fn` a method
    |
 LL |     fn oof(&self, *mut Self) {

--- a/tests/ui/suggestions/suggest-add-self-issue-131084.rs
+++ b/tests/ui/suggestions/suggest-add-self-issue-131084.rs
@@ -9,19 +9,19 @@ impl SomeStruct {
     fn some_fn(&some_name) {
         //~^ ERROR expected one of `:`, `@`, or `|`, found `)`
         self
-        //~^ ERROR expected value, found module `self`
+        //~^ ERROR cannot find value `self` in this scope
     }
 
     fn mut_param(mut some_name) {
         //~^ ERROR expected one of `:`, `@`, or `|`, found `)`
         self
-        //~^ ERROR expected value, found module `self`
+        //~^ ERROR cannot find value `self` in this scope
     }
 
     fn type_before_name(String s) {
         //~^ ERROR expected one of `:`, `@`, or `|`, found `s`
         self
-        //~^ ERROR expected value, found module `self`
+        //~^ ERROR cannot find value `self` in this scope
     }
 }
 

--- a/tests/ui/suggestions/suggest-add-self-issue-131084.stderr
+++ b/tests/ui/suggestions/suggest-add-self-issue-131084.stderr
@@ -46,7 +46,7 @@ LL |     fn type_before_name(String s) {
    |                         |      expected one of `:`, `@`, or `|`
    |                         help: declare the type after the parameter binding: `<identifier>: <type>`
 
-error[E0424]: expected value, found module `self`
+error[E0424]: cannot find value `self` in this scope
   --> $DIR/suggest-add-self-issue-131084.rs:11:9
    |
 LL |     fn some_fn(&some_name) {
@@ -55,12 +55,13 @@ LL |
 LL |         self
    |         ^^^^ `self` value is a keyword only available in methods with a `self` parameter
    |
+   = note: a module named `self` exists in another namespace
 help: add a `self` receiver parameter to make the associated `fn` a method
    |
 LL |     fn some_fn(&self, &some_name) {
    |                ++++++
 
-error[E0424]: expected value, found module `self`
+error[E0424]: cannot find value `self` in this scope
   --> $DIR/suggest-add-self-issue-131084.rs:17:9
    |
 LL |     fn mut_param(mut some_name) {
@@ -69,12 +70,13 @@ LL |
 LL |         self
    |         ^^^^ `self` value is a keyword only available in methods with a `self` parameter
    |
+   = note: a module named `self` exists in another namespace
 help: add a `self` receiver parameter to make the associated `fn` a method
    |
 LL |     fn mut_param(&self, mut some_name) {
    |                  ++++++
 
-error[E0424]: expected value, found module `self`
+error[E0424]: cannot find value `self` in this scope
   --> $DIR/suggest-add-self-issue-131084.rs:23:9
    |
 LL |     fn type_before_name(String s) {
@@ -83,6 +85,7 @@ LL |
 LL |         self
    |         ^^^^ `self` value is a keyword only available in methods with a `self` parameter
    |
+   = note: a module named `self` exists in another namespace
 help: add a `self` receiver parameter to make the associated `fn` a method
    |
 LL |     fn type_before_name(&self, String s) {

--- a/tests/ui/suggestions/suggest-add-self.rs
+++ b/tests/ui/suggestions/suggest-add-self.rs
@@ -3,12 +3,12 @@ struct X(i32);
 impl X {
     pub(crate) fn f() {
         self.0
-        //~^ ERROR expected value, found module `self`
+        //~^ ERROR cannot find value `self` in this scope
     }
 
     pub fn g() {
         self.0
-        //~^ ERROR expected value, found module `self`
+        //~^ ERROR cannot find value `self` in this scope
     }
 }
 

--- a/tests/ui/suggestions/suggest-add-self.stderr
+++ b/tests/ui/suggestions/suggest-add-self.stderr
@@ -1,4 +1,4 @@
-error[E0424]: expected value, found module `self`
+error[E0424]: cannot find value `self` in this scope
   --> $DIR/suggest-add-self.rs:5:9
    |
 LL |     pub(crate) fn f() {
@@ -6,12 +6,13 @@ LL |     pub(crate) fn f() {
 LL |         self.0
    |         ^^^^ `self` value is a keyword only available in methods with a `self` parameter
    |
+   = note: a module named `self` exists in another namespace
 help: add a `self` receiver parameter to make the associated `fn` a method
    |
 LL |     pub(crate) fn f(&self) {
    |                     +++++
 
-error[E0424]: expected value, found module `self`
+error[E0424]: cannot find value `self` in this scope
   --> $DIR/suggest-add-self.rs:10:9
    |
 LL |     pub fn g() {
@@ -19,6 +20,7 @@ LL |     pub fn g() {
 LL |         self.0
    |         ^^^^ `self` value is a keyword only available in methods with a `self` parameter
    |
+   = note: a module named `self` exists in another namespace
 help: add a `self` receiver parameter to make the associated `fn` a method
    |
 LL |     pub fn g(&self) {

--- a/tests/ui/suggestions/use-placement-resolve.fixed
+++ b/tests/ui/suggestions/use-placement-resolve.fixed
@@ -10,4 +10,4 @@ use std::fmt::Debug;
 
 fn main() {}
 
-fn foobar<T: Debug>(x: T) {} //~ ERROR expected trait, found derive macro
+fn foobar<T: Debug>(x: T) {} //~ ERROR cannot find trait `Debug` in this scope

--- a/tests/ui/suggestions/use-placement-resolve.rs
+++ b/tests/ui/suggestions/use-placement-resolve.rs
@@ -8,4 +8,4 @@
 
 fn main() {}
 
-fn foobar<T: Debug>(x: T) {} //~ ERROR expected trait, found derive macro
+fn foobar<T: Debug>(x: T) {} //~ ERROR cannot find trait `Debug` in this scope

--- a/tests/ui/suggestions/use-placement-resolve.stderr
+++ b/tests/ui/suggestions/use-placement-resolve.stderr
@@ -1,9 +1,10 @@
-error[E0404]: expected trait, found derive macro `Debug`
+error[E0404]: cannot find trait `Debug` in this scope
   --> $DIR/use-placement-resolve.rs:11:14
    |
 LL | fn foobar<T: Debug>(x: T) {}
-   |              ^^^^^ not a trait
+   |              ^^^^^ not found in this scope
    |
+   = note: a derive macro named `Debug` exists in another namespace
 help: consider importing this trait instead
    |
 LL + use std::fmt::Debug;

--- a/tests/ui/tool-attributes/tool-attributes-misplaced-1.rs
+++ b/tests/ui/tool-attributes/tool-attributes-misplaced-1.rs
@@ -1,5 +1,5 @@
 type A = rustfmt; //~ ERROR expected type, found tool module `rustfmt`
-type B = rustfmt::skip; //~ ERROR expected type, found tool attribute `rustfmt::skip`
+type B = rustfmt::skip; //~ ERROR cannot find type `skip` in `rustfmt`
 
 #[derive(rustfmt)] //~ ERROR cannot find derive macro `rustfmt` in this scope
                    //~| ERROR cannot find derive macro `rustfmt` in this scope
@@ -11,8 +11,8 @@ fn check() {}
 
 #[rustfmt::skip] // OK
 fn main() {
-    rustfmt; //~ ERROR expected value, found tool module `rustfmt`
+    rustfmt; //~ ERROR cannot find value `rustfmt` in this scope
     rustfmt!(); //~ ERROR cannot find macro `rustfmt` in this scope
 
-    rustfmt::skip; //~ ERROR expected value, found tool attribute `rustfmt::skip`
+    rustfmt::skip; //~ ERROR cannot find value `skip` in `rustfmt`
 }

--- a/tests/ui/tool-attributes/tool-attributes-misplaced-1.stderr
+++ b/tests/ui/tool-attributes/tool-attributes-misplaced-1.stderr
@@ -30,23 +30,29 @@ error[E0573]: expected type, found tool module `rustfmt`
 LL | type A = rustfmt;
    |          ^^^^^^^ not a type
 
-error[E0573]: expected type, found tool attribute `rustfmt::skip`
-  --> $DIR/tool-attributes-misplaced-1.rs:2:10
+error[E0573]: cannot find type `skip` in `rustfmt`
+  --> $DIR/tool-attributes-misplaced-1.rs:2:19
    |
 LL | type B = rustfmt::skip;
-   |          ^^^^^^^^^^^^^ not a type
+   |                   ^^^^ not found in `rustfmt`
+   |
+   = note: a tool attribute named `rustfmt::skip` exists in another namespace
 
-error[E0423]: expected value, found tool module `rustfmt`
+error[E0423]: cannot find value `rustfmt` in this scope
   --> $DIR/tool-attributes-misplaced-1.rs:14:5
    |
 LL |     rustfmt;
-   |     ^^^^^^^ not a value
+   |     ^^^^^^^ not found in this scope
+   |
+   = note: a tool module named `rustfmt` exists in another namespace
 
-error[E0423]: expected value, found tool attribute `rustfmt::skip`
-  --> $DIR/tool-attributes-misplaced-1.rs:17:5
+error[E0423]: cannot find value `skip` in `rustfmt`
+  --> $DIR/tool-attributes-misplaced-1.rs:17:14
    |
 LL |     rustfmt::skip;
-   |     ^^^^^^^^^^^^^ not a value
+   |              ^^^^ not found in `rustfmt`
+   |
+   = note: a tool attribute named `rustfmt::skip` exists in another namespace
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/track-diagnostics/track3.rs
+++ b/tests/ui/track-diagnostics/track3.rs
@@ -10,6 +10,6 @@ fn main() {
     let _unimported = Blah { field: u8 };
     //~^ ERROR cannot find struct, variant or union type `Blah` in this scope
     //~| NOTE created at
-    //~| ERROR expected value, found builtin type `u8`
+    //~| ERROR cannot find value `u8` in this scope
     //~| NOTE created at
 }

--- a/tests/ui/track-diagnostics/track3.stderr
+++ b/tests/ui/track-diagnostics/track3.stderr
@@ -6,13 +6,14 @@ LL |     let _unimported = Blah { field: u8 };
    |
    = note: -Ztrack-diagnostics: created at compiler/rustc_resolve/src/late/diagnostics.rs:LL:CC
 
-error[E0423]: expected value, found builtin type `u8`
+error[E0423]: cannot find value `u8` in this scope
   --> $DIR/track3.rs:LL:CC
    |
 LL |     let _unimported = Blah { field: u8 };
-   |                                     ^^ not a value
+   |                                     ^^ not found in this scope
    |
    = note: -Ztrack-diagnostics: created at compiler/rustc_resolve/src/late/diagnostics.rs:LL:CC
+   = note: a builtin type named `u8` exists in another namespace
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/traits/associated_type_bound/assoc-type-maybe-trait-147356.rs
+++ b/tests/ui/traits/associated_type_bound/assoc-type-maybe-trait-147356.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 fn foo<T: FromStr>() -> T
 where
-    <T as FromStr>::Err: Debug, //~ ERROR expected trait
+    <T as FromStr>::Err: Debug, //~ ERROR cannot find trait `Debug` in this scope
 {
     "".parse().unwrap()
 }

--- a/tests/ui/traits/associated_type_bound/assoc-type-maybe-trait-147356.stderr
+++ b/tests/ui/traits/associated_type_bound/assoc-type-maybe-trait-147356.stderr
@@ -1,9 +1,10 @@
-error[E0404]: expected trait, found derive macro `Debug`
+error[E0404]: cannot find trait `Debug` in this scope
   --> $DIR/assoc-type-maybe-trait-147356.rs:4:26
    |
 LL |     <T as FromStr>::Err: Debug,
-   |                          ^^^^^ not a trait
+   |                          ^^^^^ not found in this scope
    |
+   = note: a derive macro named `Debug` exists in another namespace
 help: consider importing this trait instead
    |
 LL + use std::fmt::Debug;

--- a/tests/ui/try-block/try-block-in-edition2015.rs
+++ b/tests/ui/try-block/try-block-in-edition2015.rs
@@ -2,7 +2,7 @@
 
 pub fn main() {
     let try_result: Option<_> = try {
-    //~^ ERROR expected struct, variant or union type, found macro `try`
+    //~^ ERROR cannot find struct, variant or union type `try` in this scope
         let x = 5; //~ ERROR expected identifier, found keyword
         x
     };

--- a/tests/ui/try-block/try-block-in-edition2015.stderr
+++ b/tests/ui/try-block/try-block-in-edition2015.stderr
@@ -7,12 +7,13 @@ LL |
 LL |         let x = 5;
    |         ^^^ expected identifier, found keyword
 
-error[E0574]: expected struct, variant or union type, found macro `try`
+error[E0574]: cannot find struct, variant or union type `try` in this scope
   --> $DIR/try-block-in-edition2015.rs:4:33
    |
 LL |     let try_result: Option<_> = try {
-   |                                 ^^^ not a struct, variant or union type
+   |                                 ^^^ not found in this scope
    |
+   = note: a macro named `try` exists in another namespace
    = note: if you want the `try` keyword, you need Rust 2018 or later
 help: use `!` to invoke the macro
    |

--- a/tests/ui/type-alias-impl-trait/define_opaques_attr/non_type.rs
+++ b/tests/ui/type-alias-impl-trait/define_opaques_attr/non_type.rs
@@ -3,5 +3,5 @@
 fn foo() {}
 
 #[define_opaque(foo)]
-//~^ ERROR: expected type alias or associated type with opaqaue types
+//~^ ERROR: cannot find type alias or associated type with opaqaue types `foo` in this scope
 fn main() {}

--- a/tests/ui/type-alias-impl-trait/define_opaques_attr/non_type.stderr
+++ b/tests/ui/type-alias-impl-trait/define_opaques_attr/non_type.stderr
@@ -1,8 +1,10 @@
-error[E0573]: expected type alias or associated type with opaqaue types, found function `foo`
+error[E0573]: cannot find type alias or associated type with opaqaue types `foo` in this scope
   --> $DIR/non_type.rs:5:17
    |
 LL | #[define_opaque(foo)]
-   |                 ^^^ not a type alias or associated type with opaqaue types
+   |                 ^^^ not found in this scope
+   |
+   = note: a function named `foo` exists in another namespace
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/typeck/issue-84831.rs
+++ b/tests/ui/typeck/issue-84831.rs
@@ -1,8 +1,8 @@
 fn f() {
-    std::<0>; //~ ERROR expected value
+    std::<0>; //~ ERROR cannot find value `std` in this scope
 }
 fn j() {
-    std::<_ as _>; //~ ERROR expected value
+    std::<_ as _>; //~ ERROR cannot find value `std` in this scope
     //~^ ERROR expected one of `,` or `>`, found keyword `as`
 }
 

--- a/tests/ui/typeck/issue-84831.stderr
+++ b/tests/ui/typeck/issue-84831.stderr
@@ -9,17 +9,21 @@ help: expressions must be enclosed in braces to be used as const generic argumen
 LL |     std::<{ _ as _ }>;
    |           +        +
 
-error[E0423]: expected value, found crate `std`
+error[E0423]: cannot find value `std` in this scope
   --> $DIR/issue-84831.rs:2:5
    |
 LL |     std::<0>;
-   |     ^^^^^^^^ not a value
+   |     ^^^ not found in this scope
+   |
+   = note: a crate named `std` exists in another namespace
 
-error[E0423]: expected value, found crate `std`
+error[E0423]: cannot find value `std` in this scope
   --> $DIR/issue-84831.rs:5:5
    |
 LL |     std::<_ as _>;
-   |     ^^^^^^^^^^^^^ not a value
+   |     ^^^ not found in this scope
+   |
+   = note: a crate named `std` exists in another namespace
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/ufcs/ufcs-partially-resolved.rs
+++ b/tests/ui/ufcs/ufcs-partially-resolved.rs
@@ -49,8 +49,8 @@ fn main() {
     <u8 as Tr::Y>::NN; //~ ERROR expected trait, found associated type `Tr::Y`
     <u8 as E::Y>::NN; //~ ERROR expected trait, found variant `E::Y`
 
-    let _: <u8 as Dr>::Z; //~ ERROR expected associated type, found associated function `Dr::Z`
-    <u8 as Dr>::X; //~ ERROR expected method or associated constant, found associated type `Dr::X`
-    let _: <u8 as Dr>::Z::N; //~ ERROR expected associated type, found associated function `Dr::Z`
+    let _: <u8 as Dr>::Z; //~ ERROR cannot find associated type `Z` in trait `Dr`
+    <u8 as Dr>::X; //~ ERROR cannot find method or associated constant `X` in trait `Dr`
+    let _: <u8 as Dr>::Z::N; //~ ERROR cannot find associated type `Z` in trait `Dr`
     <u8 as Dr>::X::N; //~ ERROR no associated function or constant named `N` found for type `u16`
 }

--- a/tests/ui/ufcs/ufcs-partially-resolved.stderr
+++ b/tests/ui/ufcs/ufcs-partially-resolved.stderr
@@ -278,45 +278,48 @@ error[E0404]: expected trait, found variant `E::Y`
 LL |     <u8 as E::Y>::NN;
    |            ^^^^ not a trait
 
-error[E0575]: expected associated type, found associated function `Dr::Z`
-  --> $DIR/ufcs-partially-resolved.rs:52:12
+error[E0575]: cannot find associated type `Z` in trait `Dr`
+  --> $DIR/ufcs-partially-resolved.rs:52:24
    |
 LL |     type X = u16;
    |     ------------- similarly named associated type `X` defined here
 ...
 LL |     let _: <u8 as Dr>::Z;
-   |            ^^^^^^^^^^^^^
+   |                        ^
    |
+   = note: an associated function named `Dr::Z` exists in another namespace
 help: an associated type with a similar name exists
    |
 LL -     let _: <u8 as Dr>::Z;
 LL +     let _: <u8 as Dr>::X;
    |
 
-error[E0575]: expected method or associated constant, found associated type `Dr::X`
-  --> $DIR/ufcs-partially-resolved.rs:53:5
+error[E0575]: cannot find method or associated constant `X` in trait `Dr`
+  --> $DIR/ufcs-partially-resolved.rs:53:17
    |
 LL |     fn Z() {}
    |     ------ similarly named associated function `Z` defined here
 ...
 LL |     <u8 as Dr>::X;
-   |     ^^^^^^^^^^^^^
+   |                 ^
    |
+   = note: an associated type named `Dr::X` exists in another namespace
 help: an associated function with a similar name exists
    |
 LL -     <u8 as Dr>::X;
 LL +     <u8 as Dr>::Z;
    |
 
-error[E0575]: expected associated type, found associated function `Dr::Z`
-  --> $DIR/ufcs-partially-resolved.rs:54:12
+error[E0575]: cannot find associated type `Z` in trait `Dr`
+  --> $DIR/ufcs-partially-resolved.rs:54:24
    |
 LL |     type X = u16;
    |     ------------- similarly named associated type `X` defined here
 ...
 LL |     let _: <u8 as Dr>::Z::N;
-   |            ^^^^^^^^^^^^^^^^
+   |                        ^
    |
+   = note: an associated function named `Dr::Z` exists in another namespace
 help: an associated type with a similar name exists
    |
 LL -     let _: <u8 as Dr>::Z::N;

--- a/tests/ui/unboxed-closures/unboxed-closures-type-mismatch-closure-from-another-scope.stderr
+++ b/tests/ui/unboxed-closures/unboxed-closures-type-mismatch-closure-from-another-scope.stderr
@@ -32,12 +32,13 @@ note: closure parameter defined here
 LL |         let mut closure = expect_sig(|p, y| *p = y);
    |                                       ^
 
-error[E0423]: expected function, found macro `deref`
+error[E0423]: cannot find function `deref` in this scope
   --> $DIR/unboxed-closures-type-mismatch-closure-from-another-scope.rs:13:5
    |
 LL |     deref(p);
-   |     ^^^^^ not a function
+   |     ^^^^^ not found in this scope
    |
+   = note: a macro named `deref` exists in another namespace
 help: use the `.` operator to call the method `Deref::deref` on `&&()`
    |
 LL -     deref(p);

--- a/tests/ui/wf/ice-hir-wf-check-anon-const-issue-122199.rs
+++ b/tests/ui/wf/ice-hir-wf-check-anon-const-issue-122199.rs
@@ -3,7 +3,7 @@ trait Trait<const N: dyn Trait = bar> {
     //~| ERROR cycle detected when computing type of `Trait::N`
     fn fnc<const N: dyn Trait = u32>(&self) -> dyn Trait {
         //~^ ERROR the name `N` is already used for a generic parameter in this item's generic parameters
-        //~| ERROR expected value, found builtin type `u32`
+        //~| ERROR cannot find value `u32` in this scope
         bar
         //~^ ERROR cannot find value `bar` in this scope
     }

--- a/tests/ui/wf/ice-hir-wf-check-anon-const-issue-122199.stderr
+++ b/tests/ui/wf/ice-hir-wf-check-anon-const-issue-122199.stderr
@@ -13,11 +13,13 @@ error[E0425]: cannot find value `bar` in this scope
 LL | trait Trait<const N: dyn Trait = bar> {
    |                                  ^^^ not found in this scope
 
-error[E0423]: expected value, found builtin type `u32`
+error[E0423]: cannot find value `u32` in this scope
   --> $DIR/ice-hir-wf-check-anon-const-issue-122199.rs:4:33
    |
 LL |     fn fnc<const N: dyn Trait = u32>(&self) -> dyn Trait {
-   |                                 ^^^ not a value
+   |                                 ^^^ not found in this scope
+   |
+   = note: a builtin type named `u32` exists in another namespace
 
 error[E0425]: cannot find value `bar` in this scope
   --> $DIR/ice-hir-wf-check-anon-const-issue-122199.rs:7:9


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Close rust-lang/rust#86290

Cross-namespace name matches now use the ordinary missing-name diagnostic while preserving its error code and suggestions. The diagnostic adds a note identifying the item found in another namespace, while same-namespace wrong-kind diagnostics remain unchanged.

The UI expectations cover cross-namespace combinations across the resolver suite, including preservation of existing suggestions.
