### PR TITLE
Add regression test for imperfect derive diagnostics

### DIFF
--- a/tests/ui/derives/debug/imperfect-derive-debug-diagnostic.rs
+++ b/tests/ui/derives/debug/imperfect-derive-debug-diagnostic.rs
@@ -1,0 +1,17 @@
+// Regression test for #52560: point at an imperfect derive when its generated
+// bound is unsatisfied.
+
+use std::fmt::Debug;
+
+#[derive(Debug)]
+struct Foo<B: Bar>(B::Item);
+
+trait Bar {
+    type Item: Debug;
+}
+
+fn print<B: Bar>(value: Foo<B>) {
+    println!("{value:?}"); //~ ERROR `B` doesn't implement `Debug`
+}
+
+fn main() {}

--- a/tests/ui/derives/debug/imperfect-derive-debug-diagnostic.stderr
+++ b/tests/ui/derives/debug/imperfect-derive-debug-diagnostic.stderr
@@ -1,0 +1,22 @@
+error[E0277]: `B` doesn't implement `Debug`
+  --> $DIR/imperfect-derive-debug-diagnostic.rs:14:15
+   |
+LL |     println!("{value:?}");
+   |               ^^^^^^^^^ `B` cannot be formatted using `{:?}` because it doesn't implement `Debug`
+   |
+note: required for `Foo<B>` to implement `Debug`
+  --> $DIR/imperfect-derive-debug-diagnostic.rs:7:8
+   |
+LL | #[derive(Debug)]
+   |          ----- in this derive macro expansion
+LL | struct Foo<B: Bar>(B::Item);
+   |        ^^^ - type parameter would need to implement `Debug`
+   = help: consider manually implementing `Debug` to avoid undesired bounds
+help: consider further restricting type parameter `B` with trait `Debug`
+   |
+LL | fn print<B: Bar + std::fmt::Debug>(value: Foo<B>) {
+   |                 +++++++++++++++++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Adds a UI regression test for the improved diagnostic emitted when a derived
`Debug` implementation introduces an undesired generic bound.

This specifically exercises the associated-type case from rust-lang/rust#52560, where
`Foo<B>` stores `B::Item`, while the error is emitted in a generic function body.

The test pins the note pointing to the derived type parameter and the help
suggesting a manual `Debug` implementation.

The expected stderr output was generated with `./x test --bless`, and the test
passes without blessing. `./x test tidy` also passes.

Issue rust-lang/rust#52560 also covers the follow-up diagnostic after applying the suggested
`B: Debug` bound; that remaining case is outside the scope of this PR.

CC rust-lang/rust#52560
