### PR TITLE
Add ui tests for test harness item walk and proc macro input gating

### DIFF
--- a/tests/ui/proc-macro/auxiliary/identity-attr.rs
+++ b/tests/ui/proc-macro/auxiliary/identity-attr.rs
@@ -1,0 +1,11 @@
+//@ force-host
+//@ no-prefer-dynamic
+#![crate_type = "proc-macro"]
+
+extern crate proc_macro;
+use proc_macro::TokenStream;
+
+#[proc_macro_attribute]
+pub fn id(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    item
+}

--- a/tests/ui/proc-macro/macro-def-in-attr-input.rs
+++ b/tests/ui/proc-macro/macro-def-in-attr-input.rs
@@ -2,13 +2,10 @@
 //@ edition: 2021
 //@ check-pass
 
-
 // `gate_proc_macro_input` walks attribute-macro input with the
 // `GateProcMacroInput` visitor; a `macro_rules!` definition inside the
 // annotated item makes that walk hit `visit_macro_def`, which nothing
 // else in the suite exercises.
-
-
 
 #[identity_attr::id]
 pub fn f() {

--- a/tests/ui/proc-macro/macro-def-in-attr-input.rs
+++ b/tests/ui/proc-macro/macro-def-in-attr-input.rs
@@ -1,0 +1,21 @@
+//@ proc-macro: identity-attr.rs
+//@ edition: 2021
+//@ check-pass
+
+
+// `gate_proc_macro_input` walks attribute-macro input with the
+// `GateProcMacroInput` visitor; a `macro_rules!` definition inside the
+// annotated item makes that walk hit `visit_macro_def`, which nothing
+// else in the suite exercises.
+
+
+
+#[identity_attr::id]
+pub fn f() {
+    macro_rules! m {
+        () => {};
+    }
+    m!();
+}
+
+fn main() {}

--- a/tests/ui/unpretty/exhaustive.expanded.stdout
+++ b/tests/ui/unpretty/exhaustive.expanded.stdout
@@ -8,7 +8,6 @@
 //@[harness]check-pass
 //@ edition:2024
 
-
 // Note: the HIR revision includes a `.stderr` file because there are some
 // errors that only occur once we get past the AST.
 // The `harness` revision runs test-harness expansion (`--test`) over this

--- a/tests/ui/unpretty/exhaustive.expanded.stdout
+++ b/tests/ui/unpretty/exhaustive.expanded.stdout
@@ -1,13 +1,20 @@
 #![feature(prelude_import)]
-//@ revisions: expanded hir
+//@ revisions: expanded hir harness
 //@[expanded]compile-flags: -Zunpretty=expanded
 //@[expanded]check-pass
 //@[hir]compile-flags: -Zunpretty=hir
 //@[hir]check-fail
+//@[harness]compile-flags: -Zunpretty=expanded --test
+//@[harness]check-pass
 //@ edition:2024
+
 
 // Note: the HIR revision includes a `.stderr` file because there are some
 // errors that only occur once we get past the AST.
+// The `harness` revision runs test-harness expansion (`--test`) over this
+// file, so the `InnerItemLinter` and `EntryPointCleaner` visitors in
+// rustc_builtin_macros walk the complete AST. `-Zunpretty=expanded` stops
+// before the analyses that make the `hir` revision fail.
 
 #![feature(auto_traits)]
 #![feature(box_patterns)]

--- a/tests/ui/unpretty/exhaustive.harness.stdout
+++ b/tests/ui/unpretty/exhaustive.harness.stdout
@@ -8,7 +8,6 @@
 //@[harness]check-pass
 //@ edition:2024
 
-
 // Note: the HIR revision includes a `.stderr` file because there are some
 // errors that only occur once we get past the AST.
 // The `harness` revision runs test-harness expansion (`--test`) over this

--- a/tests/ui/unpretty/exhaustive.harness.stdout
+++ b/tests/ui/unpretty/exhaustive.harness.stdout
@@ -1,3 +1,4 @@
+#![feature(prelude_import)]
 //@ revisions: expanded hir harness
 //@[expanded]compile-flags: -Zunpretty=expanded
 //@[expanded]check-pass
@@ -15,40 +16,53 @@
 // rustc_builtin_macros walk the complete AST. `-Zunpretty=expanded` stops
 // before the analyses that make the `hir` revision fail.
 
+#![feature(auto_traits)]
+#![feature(box_patterns)]
+#![feature(builtin_syntax)]
+#![feature(const_trait_impl)]
+#![feature(coroutines)]
+#![feature(decl_macro)]
+#![feature(deref_patterns)]
+#![feature(explicit_tail_calls)]
+#![feature(gen_blocks)]
+#![feature(more_qualified_paths)]
+#![feature(never_patterns)]
+#![feature(never_type)]
+#![feature(pattern_types)]
+#![feature(pattern_type_macro)]
+#![feature(prelude_import)]
+#![feature(specialization)]
+#![feature(trace_macros)]
+#![feature(trait_alias)]
+#![feature(try_blocks)]
+#![feature(try_blocks_heterogeneous)]
+#![feature(yeet_expr)]
 #![allow(incomplete_features)]
-#![attr = Feature([auto_traits#0, box_patterns#0, builtin_syntax#0,
-const_trait_impl#0, coroutines#0, decl_macro#0, deref_patterns#0,
-explicit_tail_calls#0, gen_blocks#0, more_qualified_paths#0, never_patterns#0,
-never_type#0, pattern_types#0, pattern_type_macro#0, prelude_import#0,
-specialization#0, trace_macros#0, trait_alias#0, try_blocks#0,
-try_blocks_heterogeneous#0, yeet_expr#0])]
 extern crate std;
-#[attr = PreludeImport]
+#[prelude_import]
 use std::prelude::rust_2024::*;
 
 mod prelude {
-    use std::prelude::rust_2024::*;
+    pub use std::prelude::rust_2024::*;
 
-    type T = _;
+    pub type T = _;
 
-    trait Trait {
-        const
-        CONST:
-        ();
+    pub trait Trait {
+        const CONST: ();
     }
 }
 
-#[attr = PreludeImport]
+#[prelude_import]
 use self::prelude::*;
 
-/// inner single-line doc comment
-/**
+mod attributes {
+    //! inner single-line doc comment
+    /*!
      * inner multi-line doc comment
      */
-#[doc = "inner doc attribute"]
-#[allow(dead_code, unused_variables)]
-#[attr = NoStd]
-mod attributes {
+    #![doc = "inner doc attribute"]
+    #![allow(dead_code, unused_variables)]
+    #![no_std]
 
     /// outer single-line doc comment
     /**
@@ -57,7 +71,7 @@ mod attributes {
     #[doc = "outer doc attribute"]
     #[doc = "macro"]
     #[allow()]
-    #[attr = Repr {reprs: [ReprC]}]
+    #[repr(C)]
     struct Struct;
 }
 
@@ -75,12 +89,11 @@ mod expressions {
 
     /// ExprKind::ConstBlock
     fn expr_const_block() {
-        const { };
+        const {};
         const { 1 };
-        const
-                {
-                    struct S;
-                };
+        const {
+                struct S;
+            };
     }
 
     /// ExprKind::Call
@@ -121,77 +134,49 @@ mod expressions {
     fn expr_unary() { let expr; *expr; !expr; -expr; }
 
     /// ExprKind::Lit
-    fn expr_lit() { 'x'; 1000i8; 1.00000000000000000000001; }
+    fn expr_lit() { 'x'; 1_000_i8; 1.00000000000000000000001; }
 
     /// ExprKind::Cast
     fn expr_cast() { let expr; expr as T; expr as T<u8>; }
 
     /// ExprKind::Type
-    fn expr_type() { let expr; type_ascribe!(expr, T); }
+    fn expr_type() { let expr; builtin # type_ascribe(expr, T); }
 
     /// ExprKind::Let
     fn expr_let() {
         let b;
-        if let Some(a) = b { }
-        if let _ = true && false { }
-        if let _ = (true && false) { }
+        if let Some(a) = b {}
+        if let _ = true && false {}
+        if let _ = (true && false) {}
     }
 
     /// ExprKind::If
     fn expr_if() {
-        if true { }
-        if !true { }
-        if let true = true { } else { }
-        if true { } else if false { }
-        if true { } else if false { } else { }
+        if true {}
+        if !true {}
+        if let true = true {} else {}
+        if true {} else if false {}
+        if true {} else if false {} else {}
         if true { return; } else if false { 0 } else { 0 }
     }
 
     /// ExprKind::While
     fn expr_while() {
-        loop { if false { } else { break; } }
-        'a: loop { if false { } else { break; } }
-        loop { if let true = true { } else { break; } }
+        while false {}
+        'a: while false {}
+        while let true = true {}
     }
 
     /// ExprKind::ForLoop
-    fn expr_for_loop() {
-        let x;
-        {
-            let _t =
-                match into_iter(x) {
-                    mut iter =>
-                        loop {
-                            match next(&mut iter) {
-                                None {} => break,
-                                Some {  0: _ } => { }
-                            }
-                        },
-                };
-            _t
-        };
-        {
-            let _t =
-                match into_iter(x) {
-                    mut iter =>
-                        'a: loop {
-                            match next(&mut iter) {
-                                None {} => break,
-                                Some {  0: _ } => { }
-                            }
-                        },
-                };
-            _t
-        }
-    }
+    fn expr_for_loop() { let x; for _ in x {} 'a: for _ in x {} }
 
     /// ExprKind::Loop
-    fn expr_loop() { loop { } 'a: loop { } }
+    fn expr_loop() { loop {} 'a: loop {} }
 
     /// ExprKind::Match
     fn expr_match() {
         let value;
-        match value { }
+        match value {}
         match value { ok => 1, }
         match value { ok => 1, err => 0, }
     }
@@ -199,64 +184,56 @@ mod expressions {
     /// ExprKind::Closure
     fn expr_closure() {
         let value;
-        || { };
-        |x| { };
-        |x: u8| { };
+        || {};
+        |x| {};
+        |x: u8| {};
         || ();
         move || value;
-        || |mut _task_context: ResumeTy| { { let _t = value; _t } };
-        move || |mut _task_context: ResumeTy| { { let _t = value; _t } };
-        || value;
-        move || value;
-        || |mut _task_context: ResumeTy| { { let _t = value; _t } };
-        move || |mut _task_context: ResumeTy| { { let _t = value; _t } };
+        async || value;
+        async move || value;
+        static || value;
+        static move || value;
+        (static async || value);
+        (static async move || value);
         || -> u8 { value };
-        1 + (|| { });
+        1 + || {};
     }
 
     /// ExprKind::Block
     fn expr_block() {
-        { }
-        unsafe { }
-        'a: { }
+        {}
+        unsafe {}
+        'a: {}
+
         #[allow()]
-        { }
-        #[allow()]
-        { }
+        {}
+        {
+            #![allow()]
+        }
     }
 
     /// ExprKind::Gen
     fn expr_gen() {
-        |mut _task_context: ResumeTy| { };
-        move |mut _task_context: ResumeTy| { };
-        || { };
-        move || { };
-        |mut _task_context: ResumeTy| { };
-        move |mut _task_context: ResumeTy| { };
+        async {};
+        async move {};
+        gen {};
+        gen move {};
+        async gen {};
+        async gen move {};
     }
 
     /// ExprKind::Await
     fn expr_await() {
         let fut;
-        {
-            fut;
-            (/*ERROR*/)
-        };
+        fut.await;
     }
 
     /// ExprKind::TryBlock
     fn expr_try_block() {
-        { from_output(()) }
-        { return; from_output(()) }
-        type_ascribe!({ from_output(()) }, Option<_>);
-        type_ascribe!({
-                from_output(match branch(None) {
-                        Break {  0: residual } => #[allow(unreachable_code)]
-                            break from_residual(residual),
-                        Continue {  0: val } => #[allow(unreachable_code)]
-                            val,
-                    })
-            }, Option<String>)
+        try {}
+        try { return; }
+        try bikeshed Option<_> {}
+        try bikeshed Option<String> { None? }
     }
 
     /// ExprKind::Assign
@@ -274,19 +251,19 @@ mod expressions {
     /// ExprKind::Range
     fn expr_range() {
         let (lo, hi);
-        RangeFull {  };
-        RangeTo { end: hi };
-        RangeFrom { start: lo };
-        Range { start: lo, end: hi };
-        Range { start: lo, end: hi };
-        RangeToInclusive { end: hi };
-        range_inclusive_new(lo, hi);
-        range_inclusive_new(-2, -1);
+        ..;
+        ..hi;
+        lo..;
+        lo..hi;
+        lo..hi;
+        ..=hi;
+        lo..=hi;
+        -2..=-1;
     }
 
     /// ExprKind::Underscore
     fn expr_underscore() {
-        (/*ERROR*/);
+        _;
     }
 
     /// ExprKind::Path
@@ -295,11 +272,11 @@ mod expressions {
         crate::expressions::expr_path;
         crate::expressions::expr_path::<'static>;
         <T as Default>::default;
-        <T as ::core::default::Default>::default;
-        x;
-        x::<T, T>;
-        crate::expressions::expr_path;
-        core::marker::PhantomData;
+        <T as ::core::default::Default>::default::<>;
+        x::();
+        x::(T, T) -> T;
+        crate::() -> ()::expressions::() -> ()::expr_path;
+        core::()::marker::()::PhantomData;
     }
 
     /// ExprKind::AddrOf
@@ -347,17 +324,16 @@ mod expressions {
 
 
 
-        const { offset_of!(T, field) };
+        const { builtin # offset_of(T, field) };
     }
     /// ExprKind::MacCall
     fn expr_mac_call() { "..."; "..."; "..."; }
     /// ExprKind::Struct
     fn expr_struct() {
-        struct Struct {
-        }
+        struct Struct {}
         let (x, base);
-        Struct {  };
-        <Struct as ToOwned>::Owned {  };
+        Struct {};
+        <Struct as ToOwned>::Owned {};
         Struct { .. };
         Struct { ..base };
         Struct { x };
@@ -370,21 +346,13 @@ mod expressions {
     /// ExprKind::Repeat
     fn expr_repeat() { [(); 0]; }
     /// ExprKind::Paren
-    fn expr_paren() { let expr; expr; }
+    fn expr_paren() { let expr; (expr); }
     /// ExprKind::Try
-    fn expr_try() {
-        let expr;
-        match branch(expr) {
-            Break {  0: residual } => #[allow(unreachable_code)]
-                return from_residual(residual),
-            Continue {  0: val } => #[allow(unreachable_code)]
-                val,
-        };
-    }
+    fn expr_try() { let expr; expr?; }
     /// ExprKind::Yield
-    fn expr_yield() { yield (); yield true; }
+    fn expr_yield() { yield; yield true; }
     /// ExprKind::Yeet
-    fn expr_yeet() { return from_yeet(()); return from_yeet(0); }
+    fn expr_yeet() { do yeet; do yeet 0; }
     /// ExprKind::Become
     fn expr_become() { become true; }
     /// ExprKind::IncludedBytes
@@ -394,12 +362,8 @@ mod expressions {
     /// ExprKind::FormatArgs
     fn expr_format_args() {
         let expr;
-        format_arguments::from_str("");
-        {
-            super let args = (&expr,);
-            super let args = [format_argument::new_display(args.0)];
-            unsafe { format_arguments::new(b"\xc0\x00", &args) }
-        };
+        format_args!("");
+        format_args!("{0}", expr);
     }
 }
 mod items {
@@ -407,84 +371,67 @@ mod items {
     mod item_extern_crate {
         extern crate core;
         extern crate self as unpretty;
-        extern crate core as _;
+        pub extern crate core as _;
     }
     /// ItemKind::Use
     mod item_use {
-        use ::{};
-        use crate::expressions;
-        use crate::items::item_use;
-        use core::*;
+        use crate::{expressions, items::item_use};
+        pub use core::*;
     }
     /// ItemKind::Static
     mod item_static {
-        static A: () = { };
-        static mut B: () = { };
+        pub static A: () = {};
+        static mut B: () = {};
     }
     /// ItemKind::Const
     mod item_const {
-        const A: () = { };
+        pub const A: () = {};
         trait TraitItems {
-            const
-            B:
-            ();
-            const
-            C:
-            ()
-            =
-            { };
+            const B: ();
+            const C: () = {};
         }
     }
     /// ItemKind::Fn
     mod item_fn {
-        const unsafe extern "C" fn f() { }
-        async unsafe extern "C" fn g()
-            ->
-                /*impl Trait*/ |mut _task_context: ResumeTy|
-            { { let _t = { }; _t } }
-        fn h<'a, T>() where T: 'a { }
+        pub const unsafe extern "C" fn f() {}
+        pub async unsafe extern "C" fn g() {}
+        fn h<'a, T>() where T: 'a {}
         trait TraitItems {
             unsafe extern "C" fn f();
         }
         impl TraitItems for _ {
-            unsafe extern "C" fn f() { }
+            default unsafe extern "C" fn f() {}
         }
     }
     /// ItemKind::Mod
     mod item_mod { }
     /// ItemKind::ForeignMod
     mod item_foreign_mod {
-        extern "Rust" { }
-        extern "C" { }
+        unsafe extern "C++" {}
+        unsafe extern "C" {}
     }
     /// ItemKind::GlobalAsm: see exhaustive-asm.rs
     /// ItemKind::TyAlias
     mod item_ty_alias {
-        type Type<'a> where T: 'a = T;
+        pub type Type<'a> where T: 'a = T;
     }
     /// ItemKind::Enum
     mod item_enum {
-        enum Void { }
-        enum Empty {
-            Unit,
-            Tuple(),
-            Struct {
-                },
-        }
+        pub enum Void {}
+        enum Empty { Unit, Tuple(), Struct {}, }
         enum Generic<'a, T> where T: 'a {
             Tuple(T),
             Struct {
-                    t: T,
-                },
+                t: T,
+            },
         }
     }
     /// ItemKind::Struct
     mod item_struct {
-        struct Unit;
+        pub struct Unit;
         struct Tuple();
         struct Newtype(Unit);
-        struct Struct {
-        }
+        struct Struct {}
         struct Generic<'a, T> where T: 'a {
             t: T,
         }
@@ -497,37 +444,39 @@ mod items {
     }
     /// ItemKind::Trait
     mod item_trait {
-        auto unsafe trait Send { }
-        trait Trait<'a>: Sized where Self: 'a { }
+        pub unsafe auto trait Send {}
+        trait Trait<'a>: Sized where Self: 'a {}
     }
     /// ItemKind::TraitAlias
     mod item_trait_alias {
-        trait Trait<T> = Sized where for<'a> T: 'a;
+        pub trait Trait<T> = Sized where for<'a> T: 'a;
     }
     /// ItemKind::Impl
     mod item_impl {
-        impl () { }
-        impl <T> () { }
-        impl Default for () { }
-        impl <T> const Default for () { }
+        impl () {}
+        impl<T> () {}
+        impl Default for () {}
+        const impl<T> Default for () {}
     }
     /// ItemKind::MacCall
     mod item_mac_call { }
     /// ItemKind::MacroDef
     mod item_macro_def {
         macro_rules! mac { () => {...}; }
-        macro stringify { () => {} }
+        pub macro stringify { () => {} }
     }
     /// ItemKind::Delegation
-    /** FIXME: todo */
-    mod item_delegation { }
+    mod item_delegation {
+        /*! FIXME: todo */
+    }
     /// ItemKind::DelegationMac
-    /** FIXME: todo */
-    mod item_delegation_mac { }
+    mod item_delegation_mac {
+        /*! FIXME: todo */
+    }
 }
 mod patterns {
     /// PatKind::Missing
-    fn pat_missing() { let _: for fn(u32, T, &'_ str); }
+    fn pat_missing() { let _: fn(u32, T, &str); }
     /// PatKind::Wild
     fn pat_wild() { let _; }
     /// PatKind::Ident
@@ -536,19 +485,19 @@ mod patterns {
         let ref x;
         let mut x;
         let ref mut x;
-        let ref mut x@_;
+        let ref mut x @ _;
     }
     /// PatKind::Struct
     fn pat_struct() {
         let T {};
         let T::<T> {};
         let T::<'static> {};
-        let T {  x };
-        let T {  x: _x };
+        let T { x };
+        let T { x: _x };
         let T { .. };
-        let T {  x, .. };
-        let T {  x: _x, .. };
-        let T {  0: _x, .. };
+        let T { x, .. };
+        let T { x: _x, .. };
+        let T { 0: _x, .. };
         let <T as ToOwned>::Owned {};
     }
     /// PatKind::TupleStruct
@@ -562,7 +511,7 @@ mod patterns {
         let Tuple(x, ..);
     }
     /// PatKind::Or
-    fn pat_or() { let true | false; let true; let true | false; }
+    fn pat_or() { let (true | false); let (true); let (true | false); }
     /// PatKind::Path
     fn pat_path() {
         let core::marker::PhantomData;
@@ -579,17 +528,17 @@ mod patterns {
     /// PatKind::Ref
     fn pat_ref() { let &pat; let &mut pat; }
     /// PatKind::Expr
-    fn pat_expr() { let 1000i8; let -""; }
+    fn pat_expr() { let 1_000_i8; let -""; }
     /// PatKind::Range
-    fn pat_range() { let ..1; let 0...; let 0..1; let 0...1; let -2...-1; }
+    fn pat_range() { let ..1; let 0..; let 0..1; let 0..=1; let -2..=-1; }
     /// PatKind::Slice
     fn pat_slice() { let []; let [true]; let [true]; let [true, false]; }
     /// PatKind::Rest
-    fn pat_rest() { let _; }
+    fn pat_rest() { let ..; }
     /// PatKind::Never
     fn pat_never() { let !; let Some(!); }
     /// PatKind::Paren
-    fn pat_paren() { let pat; }
+    fn pat_paren() { let (pat); }
     /// PatKind::MacCall
     fn pat_mac_call() { let ""; let ""; let ""; }
 }
@@ -603,8 +552,7 @@ mod statements {
     }
     /// StmtKind::Item
     fn stmt_item() {
-        struct Struct {
-        }
+        struct Struct {}
         struct Unit;
     }
     /// StmtKind::Expr
@@ -612,7 +560,7 @@ mod statements {
     /// StmtKind::Semi
     fn stmt_semi() { 1 + 1; }
     /// StmtKind::Empty
-    fn stmt_empty() { }
+    fn stmt_empty() { ; }
     /// StmtKind::MacCall
     fn stmt_mac_call() { "..."; "..."; "..."; }
 }
@@ -651,35 +599,37 @@ mod types {
         let _: T<'static>;
         let _: T<T>;
         let _: T<T>;
-        let _: T;
+        let _: T() -> !;
         let _: <T as ToOwned>::Owned;
     }
     /// TyKind::TraitObject
     fn ty_trait_object() {
         let _: dyn Send;
         let _: dyn Send + 'static;
-        let _: dyn Send + 'static;
+        let _: dyn 'static + Send;
         let _: dyn for<'a> Send;
     }
     /// TyKind::ImplTrait
     const fn ty_impl_trait() {
-        let _: (/*ERROR*/);
-        let _: (/*ERROR*/);
-        let _: (/*ERROR*/);
-        let _: (/*ERROR*/);
-        let _: (/*ERROR*/);
-        let _: (/*ERROR*/);
+        let _: impl Send;
+        let _: impl Send + 'static;
+        let _: impl 'static + Send;
+        let _: impl ?Sized;
+        let _: impl [const] Clone;
+        let _: impl for<'a> Send;
     }
     /// TyKind::Paren
-    fn ty_paren() { let _: T; }
+    fn ty_paren() { let _: (T); }
     /// TyKind::Typeof
-    /** unused for now */
-    fn ty_typeof() { }
+    fn ty_typeof() {
+        /*! unused for now */
+    }
     /// TyKind::Infer
     fn ty_infer() { let _: _; }
     /// TyKind::ImplicitSelf
-    /** there is no syntax for this */
-    fn ty_implicit_self() { }
+    fn ty_implicit_self() {
+        /*! there is no syntax for this */
+    }
     /// TyKind::MacCall
     fn ty_mac_call() {
         macro_rules! ty { ($ty:ty) => { $ty } }
@@ -688,26 +638,34 @@ mod types {
         let _: T;
     }
     /// TyKind::CVarArgs
-    /** FIXME: todo */
-    fn ty_c_var_args() { }
+    fn ty_c_var_args() {
+        /*! FIXME: todo */
+    }
     /// TyKind::Pat
-    fn ty_pat() { let _: u32 is 1..=RangeMax; }
+    fn ty_pat() { let _: u32 is const 1..; }
 }
 mod visibilities {
     /// VisibilityKind::Public
     mod visibility_public {
-        struct Pub;
+        pub struct Pub;
     }
     /// VisibilityKind::Restricted
     mod visibility_restricted {
-        struct PubCrate;
-        struct PubSelf;
-        struct PubSuper;
-        struct PubInCrate;
-        struct PubInSelf;
-        struct PubInSuper;
-        struct PubInCrateVisibilities;
-        struct PubInSelfSuper;
-        struct PubInSuperMod;
+        pub(crate) struct PubCrate;
+        pub(self) struct PubSelf;
+        pub(super) struct PubSuper;
+        pub(in crate) struct PubInCrate;
+        pub(in self) struct PubInSelf;
+        pub(in super) struct PubInSuper;
+        pub(in crate::visibilities) struct PubInCrateVisibilities;
+        pub(in self::super) struct PubInSelfSuper;
+        pub(in super::visibility_restricted) struct PubInSuperMod;
     }
+}
+#[rustc_main]
+#[coverage(off)]
+#[doc(hidden)]
+pub fn main() -> () {
+    extern crate test;
+    test::test_main_static(&[])
 }

--- a/tests/ui/unpretty/exhaustive.hir.stderr
+++ b/tests/ui/unpretty/exhaustive.hir.stderr
@@ -1,17 +1,17 @@
 error[E0697]: closures cannot be static
-  --> $DIR/exhaustive.rs:218:9
+  --> $DIR/exhaustive.rs:217:9
    |
 LL |         static || value;
    |         ^^^^^^^^^
 
 error[E0697]: closures cannot be static
-  --> $DIR/exhaustive.rs:219:9
+  --> $DIR/exhaustive.rs:218:9
    |
 LL |         static move || value;
    |         ^^^^^^^^^^^^^^
 
 error[E0728]: `await` is only allowed inside `async` functions and blocks
-  --> $DIR/exhaustive.rs:248:13
+  --> $DIR/exhaustive.rs:247:13
    |
 LL |     fn expr_await() {
    |     --------------- this is not `async`
@@ -20,19 +20,19 @@ LL |         fut.await;
    |             ^^^^^ only allowed inside `async` functions and blocks
 
 error: in expressions, `_` can only be used on the left-hand side of an assignment
-  --> $DIR/exhaustive.rs:299:9
+  --> $DIR/exhaustive.rs:298:9
    |
 LL |         _;
    |         ^ `_` not allowed here
 
 error[E0214]: parenthesized type parameters may only be used with a `Fn` trait
-  --> $DIR/exhaustive.rs:309:9
+  --> $DIR/exhaustive.rs:308:9
    |
 LL |         x::();
    |         ^^^^^ only `Fn` traits may use parentheses
 
 error[E0214]: parenthesized type parameters may only be used with a `Fn` trait
-  --> $DIR/exhaustive.rs:310:9
+  --> $DIR/exhaustive.rs:309:9
    |
 LL |         x::(T, T) -> T;
    |         ^^^^^^^^^^^^^^ only `Fn` traits may use parentheses
@@ -44,31 +44,31 @@ LL +         x::<T, T> -> T;
    |
 
 error[E0214]: parenthesized type parameters may only be used with a `Fn` trait
-  --> $DIR/exhaustive.rs:311:9
+  --> $DIR/exhaustive.rs:310:9
    |
 LL |         crate::() -> ()::expressions::() -> ()::expr_path;
    |         ^^^^^^^^^^^^^^^ only `Fn` traits may use parentheses
 
 error[E0214]: parenthesized type parameters may only be used with a `Fn` trait
-  --> $DIR/exhaustive.rs:311:26
+  --> $DIR/exhaustive.rs:310:26
    |
 LL |         crate::() -> ()::expressions::() -> ()::expr_path;
    |                          ^^^^^^^^^^^^^^^^^^^^^ only `Fn` traits may use parentheses
 
 error[E0214]: parenthesized type parameters may only be used with a `Fn` trait
-  --> $DIR/exhaustive.rs:314:9
+  --> $DIR/exhaustive.rs:313:9
    |
 LL |         core::()::marker::()::PhantomData;
    |         ^^^^^^^^ only `Fn` traits may use parentheses
 
 error[E0214]: parenthesized type parameters may only be used with a `Fn` trait
-  --> $DIR/exhaustive.rs:314:19
+  --> $DIR/exhaustive.rs:313:19
    |
 LL |         core::()::marker::()::PhantomData;
    |                   ^^^^^^^^^^ only `Fn` traits may use parentheses
 
 error: `yield` can only be used in `#[coroutine]` closures, or `gen` blocks
-  --> $DIR/exhaustive.rs:401:9
+  --> $DIR/exhaustive.rs:400:9
    |
 LL |         yield;
    |         ^^^^^
@@ -79,7 +79,7 @@ LL |     #[coroutine] fn expr_yield() {
    |     ++++++++++++
 
 error[E0703]: invalid ABI: found `C++`
-  --> $DIR/exhaustive.rs:481:23
+  --> $DIR/exhaustive.rs:480:23
    |
 LL |         unsafe extern "C++" {}
    |                       ^^^^^ invalid ABI
@@ -87,7 +87,7 @@ LL |         unsafe extern "C++" {}
    = note: invoke `rustc --print=calling-conventions` for a full list of supported calling conventions
 
 error: `..` patterns are not allowed here
-  --> $DIR/exhaustive.rs:688:13
+  --> $DIR/exhaustive.rs:687:13
    |
 LL |         let ..;
    |             ^^
@@ -95,13 +95,13 @@ LL |         let ..;
    = note: only allowed in tuple, tuple struct, and slice patterns
 
 error[E0214]: parenthesized type parameters may only be used with a `Fn` trait
-  --> $DIR/exhaustive.rs:803:16
+  --> $DIR/exhaustive.rs:802:16
    |
 LL |         let _: T() -> !;
    |                ^^^^^^^^ only `Fn` traits may use parentheses
 
 error[E0562]: `impl Trait` is not allowed in the type of variable bindings
-  --> $DIR/exhaustive.rs:817:16
+  --> $DIR/exhaustive.rs:816:16
    |
 LL |         let _: impl Send;
    |                ^^^^^^^^^
@@ -112,7 +112,7 @@ LL |         let _: impl Send;
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0562]: `impl Trait` is not allowed in the type of variable bindings
-  --> $DIR/exhaustive.rs:818:16
+  --> $DIR/exhaustive.rs:817:16
    |
 LL |         let _: impl Send + 'static;
    |                ^^^^^^^^^^^^^^^^^^^
@@ -123,7 +123,7 @@ LL |         let _: impl Send + 'static;
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0562]: `impl Trait` is not allowed in the type of variable bindings
-  --> $DIR/exhaustive.rs:819:16
+  --> $DIR/exhaustive.rs:818:16
    |
 LL |         let _: impl 'static + Send;
    |                ^^^^^^^^^^^^^^^^^^^
@@ -134,7 +134,7 @@ LL |         let _: impl 'static + Send;
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0562]: `impl Trait` is not allowed in the type of variable bindings
-  --> $DIR/exhaustive.rs:820:16
+  --> $DIR/exhaustive.rs:819:16
    |
 LL |         let _: impl ?Sized;
    |                ^^^^^^^^^^^
@@ -145,7 +145,7 @@ LL |         let _: impl ?Sized;
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0562]: `impl Trait` is not allowed in the type of variable bindings
-  --> $DIR/exhaustive.rs:821:16
+  --> $DIR/exhaustive.rs:820:16
    |
 LL |         let _: impl [const] Clone;
    |                ^^^^^^^^^^^^^^^^^^
@@ -156,7 +156,7 @@ LL |         let _: impl [const] Clone;
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0562]: `impl Trait` is not allowed in the type of variable bindings
-  --> $DIR/exhaustive.rs:822:16
+  --> $DIR/exhaustive.rs:821:16
    |
 LL |         let _: impl for<'a> Send;
    |                ^^^^^^^^^^^^^^^^^

--- a/tests/ui/unpretty/exhaustive.hir.stderr
+++ b/tests/ui/unpretty/exhaustive.hir.stderr
@@ -1,17 +1,17 @@
 error[E0697]: closures cannot be static
-  --> $DIR/exhaustive.rs:211:9
+  --> $DIR/exhaustive.rs:218:9
    |
 LL |         static || value;
    |         ^^^^^^^^^
 
 error[E0697]: closures cannot be static
-  --> $DIR/exhaustive.rs:212:9
+  --> $DIR/exhaustive.rs:219:9
    |
 LL |         static move || value;
    |         ^^^^^^^^^^^^^^
 
 error[E0728]: `await` is only allowed inside `async` functions and blocks
-  --> $DIR/exhaustive.rs:241:13
+  --> $DIR/exhaustive.rs:248:13
    |
 LL |     fn expr_await() {
    |     --------------- this is not `async`
@@ -20,19 +20,19 @@ LL |         fut.await;
    |             ^^^^^ only allowed inside `async` functions and blocks
 
 error: in expressions, `_` can only be used on the left-hand side of an assignment
-  --> $DIR/exhaustive.rs:292:9
+  --> $DIR/exhaustive.rs:299:9
    |
 LL |         _;
    |         ^ `_` not allowed here
 
 error[E0214]: parenthesized type parameters may only be used with a `Fn` trait
-  --> $DIR/exhaustive.rs:302:9
+  --> $DIR/exhaustive.rs:309:9
    |
 LL |         x::();
    |         ^^^^^ only `Fn` traits may use parentheses
 
 error[E0214]: parenthesized type parameters may only be used with a `Fn` trait
-  --> $DIR/exhaustive.rs:303:9
+  --> $DIR/exhaustive.rs:310:9
    |
 LL |         x::(T, T) -> T;
    |         ^^^^^^^^^^^^^^ only `Fn` traits may use parentheses
@@ -44,31 +44,31 @@ LL +         x::<T, T> -> T;
    |
 
 error[E0214]: parenthesized type parameters may only be used with a `Fn` trait
-  --> $DIR/exhaustive.rs:304:9
+  --> $DIR/exhaustive.rs:311:9
    |
 LL |         crate::() -> ()::expressions::() -> ()::expr_path;
    |         ^^^^^^^^^^^^^^^ only `Fn` traits may use parentheses
 
 error[E0214]: parenthesized type parameters may only be used with a `Fn` trait
-  --> $DIR/exhaustive.rs:304:26
+  --> $DIR/exhaustive.rs:311:26
    |
 LL |         crate::() -> ()::expressions::() -> ()::expr_path;
    |                          ^^^^^^^^^^^^^^^^^^^^^ only `Fn` traits may use parentheses
 
 error[E0214]: parenthesized type parameters may only be used with a `Fn` trait
-  --> $DIR/exhaustive.rs:307:9
+  --> $DIR/exhaustive.rs:314:9
    |
 LL |         core::()::marker::()::PhantomData;
    |         ^^^^^^^^ only `Fn` traits may use parentheses
 
 error[E0214]: parenthesized type parameters may only be used with a `Fn` trait
-  --> $DIR/exhaustive.rs:307:19
+  --> $DIR/exhaustive.rs:314:19
    |
 LL |         core::()::marker::()::PhantomData;
    |                   ^^^^^^^^^^ only `Fn` traits may use parentheses
 
 error: `yield` can only be used in `#[coroutine]` closures, or `gen` blocks
-  --> $DIR/exhaustive.rs:394:9
+  --> $DIR/exhaustive.rs:401:9
    |
 LL |         yield;
    |         ^^^^^
@@ -79,7 +79,7 @@ LL |     #[coroutine] fn expr_yield() {
    |     ++++++++++++
 
 error[E0703]: invalid ABI: found `C++`
-  --> $DIR/exhaustive.rs:474:23
+  --> $DIR/exhaustive.rs:481:23
    |
 LL |         unsafe extern "C++" {}
    |                       ^^^^^ invalid ABI
@@ -87,7 +87,7 @@ LL |         unsafe extern "C++" {}
    = note: invoke `rustc --print=calling-conventions` for a full list of supported calling conventions
 
 error: `..` patterns are not allowed here
-  --> $DIR/exhaustive.rs:681:13
+  --> $DIR/exhaustive.rs:688:13
    |
 LL |         let ..;
    |             ^^
@@ -95,13 +95,13 @@ LL |         let ..;
    = note: only allowed in tuple, tuple struct, and slice patterns
 
 error[E0214]: parenthesized type parameters may only be used with a `Fn` trait
-  --> $DIR/exhaustive.rs:796:16
+  --> $DIR/exhaustive.rs:803:16
    |
 LL |         let _: T() -> !;
    |                ^^^^^^^^ only `Fn` traits may use parentheses
 
 error[E0562]: `impl Trait` is not allowed in the type of variable bindings
-  --> $DIR/exhaustive.rs:810:16
+  --> $DIR/exhaustive.rs:817:16
    |
 LL |         let _: impl Send;
    |                ^^^^^^^^^
@@ -112,7 +112,7 @@ LL |         let _: impl Send;
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0562]: `impl Trait` is not allowed in the type of variable bindings
-  --> $DIR/exhaustive.rs:811:16
+  --> $DIR/exhaustive.rs:818:16
    |
 LL |         let _: impl Send + 'static;
    |                ^^^^^^^^^^^^^^^^^^^
@@ -123,7 +123,7 @@ LL |         let _: impl Send + 'static;
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0562]: `impl Trait` is not allowed in the type of variable bindings
-  --> $DIR/exhaustive.rs:812:16
+  --> $DIR/exhaustive.rs:819:16
    |
 LL |         let _: impl 'static + Send;
    |                ^^^^^^^^^^^^^^^^^^^
@@ -134,7 +134,7 @@ LL |         let _: impl 'static + Send;
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0562]: `impl Trait` is not allowed in the type of variable bindings
-  --> $DIR/exhaustive.rs:813:16
+  --> $DIR/exhaustive.rs:820:16
    |
 LL |         let _: impl ?Sized;
    |                ^^^^^^^^^^^
@@ -145,7 +145,7 @@ LL |         let _: impl ?Sized;
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0562]: `impl Trait` is not allowed in the type of variable bindings
-  --> $DIR/exhaustive.rs:814:16
+  --> $DIR/exhaustive.rs:821:16
    |
 LL |         let _: impl [const] Clone;
    |                ^^^^^^^^^^^^^^^^^^
@@ -156,7 +156,7 @@ LL |         let _: impl [const] Clone;
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0562]: `impl Trait` is not allowed in the type of variable bindings
-  --> $DIR/exhaustive.rs:815:16
+  --> $DIR/exhaustive.rs:822:16
    |
 LL |         let _: impl for<'a> Send;
    |                ^^^^^^^^^^^^^^^^^

--- a/tests/ui/unpretty/exhaustive.hir.stdout
+++ b/tests/ui/unpretty/exhaustive.hir.stdout
@@ -7,7 +7,6 @@
 //@[harness]check-pass
 //@ edition:2024
 
-
 // Note: the HIR revision includes a `.stderr` file because there are some
 // errors that only occur once we get past the AST.
 // The `harness` revision runs test-harness expansion (`--test`) over this

--- a/tests/ui/unpretty/exhaustive.rs
+++ b/tests/ui/unpretty/exhaustive.rs
@@ -7,7 +7,6 @@
 //@[harness]check-pass
 //@ edition:2024
 
-
 // Note: the HIR revision includes a `.stderr` file because there are some
 // errors that only occur once we get past the AST.
 // The `harness` revision runs test-harness expansion (`--test`) over this

--- a/tests/ui/unpretty/exhaustive.rs
+++ b/tests/ui/unpretty/exhaustive.rs
@@ -1,12 +1,19 @@
-//@ revisions: expanded hir
+//@ revisions: expanded hir harness
 //@[expanded]compile-flags: -Zunpretty=expanded
 //@[expanded]check-pass
 //@[hir]compile-flags: -Zunpretty=hir
 //@[hir]check-fail
+//@[harness]compile-flags: -Zunpretty=expanded --test
+//@[harness]check-pass
 //@ edition:2024
+
 
 // Note: the HIR revision includes a `.stderr` file because there are some
 // errors that only occur once we get past the AST.
+// The `harness` revision runs test-harness expansion (`--test`) over this
+// file, so the `InnerItemLinter` and `EntryPointCleaner` visitors in
+// rustc_builtin_macros walk the complete AST. `-Zunpretty=expanded` stops
+// before the analyses that make the `hir` revision fail.
 
 #![feature(auto_traits)]
 #![feature(box_patterns)]


### PR DESCRIPTION
These add coverage for two compiler paths that real crates hit constantly but the test suite never exercised. Found by diffing coverage from compiling crates.io crates against the test suite's coverage, then confirmed by putting a panic in the functions and compiling the crates.

These add coverage for two compiler paths that real crates hit constantly but the test suite never exercised. Found by diffing coverage from compiling crates.io crates against the test suite's coverage, then confirmed by putting a panic in the functions and compiling the crates.

Functions covered that the suite previously didn't hit:
- `<InnerItemLinter as Visitor>::visit_where_predicate`, `visit_where_predicate_kind`, `visit_qself`, `visit_pat_field`, `visit_anon_const`
- `<EntryPointCleaner as MutVisitor>::visit_where_predicate`, `flat_map_where_predicate`, `visit_where_predicate_kind`, `visit_qself`, `visit_pat_field`, `flat_map_pat_field`
- `<GateProcMacroInput as Visitor>::visit_macro_def`

For the test harness case this adds a `harness` revision to `tests/ui/unpretty/exhaustive.rs` that compiles it with `--test`, so the harness expansion visitors walk the complete AST instead of a hand-picked one. `-Zunpretty=expanded` stops before the analyses that make the `hir` revision fail.

The second test covers `GateProcMacroInput::visit_macro_def`, which only runs when an attribute proc macro is applied to an item containing a `macro_rules!` definition.

r? jackh726
