### PR TITLE
Fix safety doc in intrinsics::simd

### DIFF
--- a/library/core/src/intrinsics/simd/mod.rs
+++ b/library/core/src/intrinsics/simd/mod.rs
@@ -371,8 +371,8 @@ pub const unsafe fn simd_shuffle<T, U, V>(x: T, y: T, idx: U) -> V;
 /// `val`.
 ///
 /// # Safety
-/// Unmasked values in `T` must be readable as if by `<ptr>::read` (e.g. aligned to the element
-/// type).
+/// Each pointer in `ptr` whose corresponding value in `mask` is `!0` must be readable as if by
+/// [`ptr::read`][crate::ptr::read] (e.g. aligned to the element type).
 ///
 /// `mask` must only contain `0` or `!0` values.
 #[rustc_intrinsic]
@@ -395,8 +395,8 @@ pub const unsafe fn simd_gather<T, U, V>(val: T, ptr: U, mask: V) -> T;
 /// (This is relevant in case two of the stores overlap.)
 ///
 /// # Safety
-/// Unmasked values in `T` must be writeable as if by `<ptr>::write` (e.g. aligned to the element
-/// type).
+/// Each pointer in `ptr` whose corresponding value in `mask` is `!0` must be writable as if by
+/// [`ptr::write`][crate::ptr::write] (e.g. aligned to the element type).
 ///
 /// `mask` must only contain `0` or `!0` values.
 #[rustc_intrinsic]


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

The Safety documentation for `simd_gather` and `simd_scatter` incorrectly described unmasked values in `T` as requiring readable or writable memory.

The memory access is performed through the corresponding enabled pointer lane in `ptr`, so this updates the documentation to state that requirement explicitly. 