### PR TITLE
tests/assembly-llvm: pin frame pointer in issue-141649 aarch64 test

### DIFF
--- a/tests/assembly-llvm/issue-141649.rs
+++ b/tests/assembly-llvm/issue-141649.rs
@@ -2,6 +2,7 @@
 //@ compile-flags: -Copt-level=3
 
 //@ revisions: aarch64
+//@ [aarch64] compile-flags: -Cforce-frame-pointers=yes
 //@ [aarch64] only-aarch64
 
 //@ revisions: linux-x86_64


### PR DESCRIPTION
The `scoped_two_small_structs` test expects `sub sp, sp, #48` on
aarch64, which assumes the frame pointer (x29) is saved. Custom targets
that don't set `frame-pointer: non-leaf` (e.g., OpenEmbedded/Yocto's
`aarch64-poky-linux-gnu`) omit x29, producing `sub sp, sp, #32` instead.

Add `-Cforce-frame-pointers=yes` to the aarch64 revision so the test
produces consistent codegen regardless of the target's default frame
pointer policy.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
