### PR TITLE
Fix the stale metrics directory warning

### DIFF
--- a/compiler/rustc_driver_impl/src/lib.rs
+++ b/compiler/rustc_driver_impl/src/lib.rs
@@ -1423,7 +1423,7 @@ fn ice_path_with_config(config: Option<&UnstableOptions>) -> &'static Option<Pat
                     return None;
                 }
                 if let Some(unstable_opts) = config && unstable_opts.metrics_dir.is_some() {
-                    tracing::warn!("ignoring -Zerror-metrics in favor of RUSTC_ICE for destination of ICE report files");
+                    tracing::warn!("ignoring -Zmetrics-dir in favor of RUSTC_ICE for destination of ICE report files");
                 }
                 PathBuf::from(s)
             }

--- a/tests/run-make/dump-ice-to-disk/rmake.rs
+++ b/tests/run-make/dump-ice-to-disk/rmake.rs
@@ -195,7 +195,10 @@ fn test_flag_and_env(baseline: &IceDump) {
             .env("RUSTC_ICE", &real_dir)
             .arg("-Ztreat-err-as-bug=1")
             .arg(metrics_arg)
-            .run_fail();
+            .run_fail()
+            .assert_stderr_contains(
+                "ignoring -Zmetrics-dir in favor of RUSTC_ICE for destination of ICE report files",
+            );
 
         let cwd_ice_files = find_ice_dumps_in_dir(cwd());
         assert!(cwd_ice_files.is_empty(), "RUSTC_ICE should override -Zmetrics-dir");


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

The warning emitted when RUSTC_ICE overrides -Zmetrics-dir referenced
the nonexistent -Zerror-metrics option. Use the actual option name and
cover the warning text in the existing run-make test.
