### PR TITLE
fix some edition annotations in UI tests

### DIFF
--- a/tests/ui/delegation/hir-crate-items-before-lowering-ices.ice_155125.stderr
+++ b/tests/ui/delegation/hir-crate-items-before-lowering-ices.ice_155125.stderr
@@ -1,5 +1,5 @@
 error[E0428]: the name `foo` is defined multiple times
-  --> $DIR/hir-crate-items-before-lowering-ices.rs:12:17
+  --> $DIR/hir-crate-items-before-lowering-ices.rs:13:17
    |
 LL |                 fn foo() {}
    |                 -------- previous definition of the value `foo` here
@@ -9,7 +9,7 @@ LL |                 reuse foo;
    = note: `foo` must be defined only once in the value namespace of this block
 
 error: complex const arguments must be placed inside of a `const` block
-  --> $DIR/hir-crate-items-before-lowering-ices.rs:10:37
+  --> $DIR/hir-crate-items-before-lowering-ices.rs:11:37
    |
 LL |               core::direct_const_arg!({
    |  _____________________________________^

--- a/tests/ui/delegation/hir-crate-items-before-lowering-ices.ice_155127.stderr
+++ b/tests/ui/delegation/hir-crate-items-before-lowering-ices.ice_155127.stderr
@@ -1,5 +1,5 @@
 error: `#[deprecated]` attribute cannot be used on delegations
-  --> $DIR/hir-crate-items-before-lowering-ices.rs:26:9
+  --> $DIR/hir-crate-items-before-lowering-ices.rs:27:9
    |
 LL |         #[deprecated]
    |         ^^^^^^^^^^^^^

--- a/tests/ui/delegation/hir-crate-items-before-lowering-ices.ice_155128.stderr
+++ b/tests/ui/delegation/hir-crate-items-before-lowering-ices.ice_155128.stderr
@@ -1,5 +1,5 @@
 error: delegation's target expression is specified for function with no params
-  --> $DIR/hir-crate-items-before-lowering-ices.rs:36:18
+  --> $DIR/hir-crate-items-before-lowering-ices.rs:37:18
    |
 LL |       reuse a as b {
    |  __________________^
@@ -10,7 +10,7 @@ LL | |     }
    | |_____^
 
 error[E0061]: this function takes 0 arguments but 1 argument was supplied
-  --> $DIR/hir-crate-items-before-lowering-ices.rs:36:11
+  --> $DIR/hir-crate-items-before-lowering-ices.rs:37:11
    |
 LL |       reuse a as b {
    |  ___________^______-
@@ -21,7 +21,7 @@ LL | |     }
    | |_____- unexpected argument of type `fn() {foo::<_>}`
    |
 note: function defined here
-  --> $DIR/hir-crate-items-before-lowering-ices.rs:34:8
+  --> $DIR/hir-crate-items-before-lowering-ices.rs:35:8
    |
 LL |     fn a() {}
    |        ^

--- a/tests/ui/delegation/hir-crate-items-before-lowering-ices.ice_155164.stderr
+++ b/tests/ui/delegation/hir-crate-items-before-lowering-ices.ice_155164.stderr
@@ -1,5 +1,5 @@
 error: complex const arguments must be placed inside of a `const` block
-  --> $DIR/hir-crate-items-before-lowering-ices.rs:47:37
+  --> $DIR/hir-crate-items-before-lowering-ices.rs:48:37
    |
 LL |               core::direct_const_arg!({
    |  _____________________________________^

--- a/tests/ui/delegation/hir-crate-items-before-lowering-ices.ice_155202.stderr
+++ b/tests/ui/delegation/hir-crate-items-before-lowering-ices.ice_155202.stderr
@@ -1,16 +1,18 @@
-error[E0425]: cannot find value `async` in this scope
-  --> $DIR/hir-crate-items-before-lowering-ices.rs:66:13
+error: function cannot return without recursing
+  --> $DIR/hir-crate-items-before-lowering-ices.rs:67:22
    |
-LL |             async || {};
-   |             ^^^^^ not found in this scope
-
-error[E0308]: mismatched types
-  --> $DIR/hir-crate-items-before-lowering-ices.rs:66:22
+LL |         reuse Trait::bar {
+   |                      ^^^
+   |                      |
+   |                      cannot return without recursing
+   |                      recursive call site
    |
-LL |             async || {};
-   |                      ^^ expected `bool`, found `()`
+   = help: a `loop` may express intention better if this is on purpose
+note: the lint level is defined here
+  --> $DIR/hir-crate-items-before-lowering-ices.rs:61:8
+   |
+LL | #[deny(unconditional_recursion)]
+   |        ^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 
-Some errors have detailed explanations: E0308, E0425.
-For more information about an error, try `rustc --explain E0308`.

--- a/tests/ui/delegation/hir-crate-items-before-lowering-ices.rs
+++ b/tests/ui/delegation/hir-crate-items-before-lowering-ices.rs
@@ -1,4 +1,5 @@
 //@ revisions: ice_155125 ice_155127 ice_155128 ice_155164 ice_155202
+//@[ice_155202] edition: 2024
 
 #![feature(min_generic_const_args, fn_delegation)]
 
@@ -57,14 +58,14 @@ mod ice_155164 {
 }
 
 #[cfg(ice_155202)]
+#[deny(unconditional_recursion)]
 mod ice_155202 {
     trait Trait {
         fn bar(self);
     }
     impl Trait for () {
-        reuse Trait::bar {
-            async || {}; //[ice_155202]~ ERROR: mismatched types
-            //[ice_155202]~^ ERROR: cannot find value `async` in this scope
+        reuse Trait::bar { //[ice_155202]~ ERROR: cannot return without recursing
+            async || {};
         }
     }
 }

--- a/tests/ui/type-alias-impl-trait/tait-normalize.rs
+++ b/tests/ui/type-alias-impl-trait/tait-normalize.rs
@@ -2,6 +2,9 @@
 //@ [next] compile-flags: -Znext-solver
 //@ check-pass
 
+// this fails in edition 2021; see tests/crashes/119786-1.rs
+//@ edition: 2015..2018
+
 #![feature(type_alias_impl_trait)]
 
 fn enum_upvar() {

--- a/tests/ui/use/use-self-at-end.e2015.stderr
+++ b/tests/ui/use/use-self-at-end.e2015.stderr
@@ -1,5 +1,5 @@
 error: imports need to be explicitly named
-  --> $DIR/use-self-at-end.rs:14:24
+  --> $DIR/use-self-at-end.rs:15:24
    |
 LL |         pub use crate::self;
    |                        ^^^^
@@ -10,7 +10,7 @@ LL |         pub use crate::self as name;
    |                             +++++++
 
 error: imports need to be explicitly named
-  --> $DIR/use-self-at-end.rs:16:25
+  --> $DIR/use-self-at-end.rs:17:25
    |
 LL |         pub use crate::{self};
    |                         ^^^^
@@ -21,7 +21,7 @@ LL |         pub use crate::{self as name};
    |                              +++++++
 
 error: imports need to be explicitly named
-  --> $DIR/use-self-at-end.rs:20:17
+  --> $DIR/use-self-at-end.rs:21:17
    |
 LL |         pub use self;
    |                 ^^^^
@@ -32,7 +32,7 @@ LL |         pub use self as name;
    |                      +++++++
 
 error: imports need to be explicitly named
-  --> $DIR/use-self-at-end.rs:22:18
+  --> $DIR/use-self-at-end.rs:23:18
    |
 LL |         pub use {self};
    |                  ^^^^
@@ -43,7 +43,7 @@ LL |         pub use {self as name};
    |                       +++++++
 
 error: imports need to be explicitly named
-  --> $DIR/use-self-at-end.rs:26:23
+  --> $DIR/use-self-at-end.rs:27:23
    |
 LL |         pub use self::self;
    |                       ^^^^
@@ -54,7 +54,7 @@ LL |         pub use self::self as name;
    |                            +++++++
 
 error: imports need to be explicitly named
-  --> $DIR/use-self-at-end.rs:29:24
+  --> $DIR/use-self-at-end.rs:30:24
    |
 LL |         pub use self::{self};
    |                        ^^^^
@@ -65,7 +65,7 @@ LL |         pub use self::{self as name};
    |                             +++++++
 
 error: imports need to be explicitly named
-  --> $DIR/use-self-at-end.rs:33:24
+  --> $DIR/use-self-at-end.rs:34:24
    |
 LL |         pub use super::self;
    |                        ^^^^
@@ -76,7 +76,7 @@ LL |         pub use super::self as name;
    |                             +++++++
 
 error: imports need to be explicitly named
-  --> $DIR/use-self-at-end.rs:36:25
+  --> $DIR/use-self-at-end.rs:37:25
    |
 LL |         pub use super::{self};
    |                         ^^^^
@@ -87,7 +87,7 @@ LL |         pub use super::{self as name};
    |                              +++++++
 
 error: imports need to be explicitly named
-  --> $DIR/use-self-at-end.rs:48:19
+  --> $DIR/use-self-at-end.rs:50:19
    |
 LL |         pub use ::self;
    |                   ^^^^
@@ -98,7 +98,7 @@ LL |         pub use ::self as name;
    |                        +++++++
 
 error: imports need to be explicitly named
-  --> $DIR/use-self-at-end.rs:52:20
+  --> $DIR/use-self-at-end.rs:56:20
    |
 LL |         pub use ::{self};
    |                    ^^^^
@@ -109,31 +109,31 @@ LL |         pub use ::{self as name};
    |                         +++++++
 
 error: `self` in paths can only be used in start position or last position
-  --> $DIR/use-self-at-end.rs:57:20
+  --> $DIR/use-self-at-end.rs:63:20
    |
 LL |         pub use z::self::self;
    |                    ^^^^
 
 error: `self` in paths can only be used in start position or last position
-  --> $DIR/use-self-at-end.rs:58:20
+  --> $DIR/use-self-at-end.rs:64:20
    |
 LL |         pub use z::self::self as z1;
    |                    ^^^^
 
 error: `self` in paths can only be used in start position or last position
-  --> $DIR/use-self-at-end.rs:59:21
+  --> $DIR/use-self-at-end.rs:65:21
    |
 LL |         pub use z::{self::{self}};
    |                     ^^^^
 
 error: `self` in paths can only be used in start position or last position
-  --> $DIR/use-self-at-end.rs:60:21
+  --> $DIR/use-self-at-end.rs:66:21
    |
 LL |         pub use z::{self::{self as z2}};
    |                     ^^^^
 
 error[E0252]: the name `x` is defined multiple times
-  --> $DIR/use-self-at-end.rs:42:28
+  --> $DIR/use-self-at-end.rs:43:28
    |
 LL |         pub use crate::x::self;
    |                 -------------- previous import of the module `x` here
@@ -147,7 +147,7 @@ LL |         pub use crate::x::{self};
    = note: `x` must be defined only once in the type namespace of this module
 
 error[E0252]: the name `Enum` is defined multiple times
-  --> $DIR/use-self-at-end.rs:71:31
+  --> $DIR/use-self-at-end.rs:77:31
    |
 LL |         pub use super::Enum::self;
    |                 ----------------- previous import of the type `Enum` here
@@ -161,7 +161,7 @@ LL |         pub use super::Enum::{self};
    = note: `Enum` must be defined only once in the type namespace of this module
 
 error[E0252]: the name `Trait` is defined multiple times
-  --> $DIR/use-self-at-end.rs:79:32
+  --> $DIR/use-self-at-end.rs:88:32
    |
 LL |         pub use super::Trait::self;
    |                 ------------------ previous import of the trait `Trait` here
@@ -175,103 +175,103 @@ LL |         pub use super::Trait::{self};
    = note: `Trait` must be defined only once in the type namespace of this module
 
 error[E0432]: unresolved import `super::Struct`
-  --> $DIR/use-self-at-end.rs:63:24
+  --> $DIR/use-self-at-end.rs:69:24
    |
 LL |         pub use super::Struct::self;
    |                        ^^^^^^ `Struct` is a struct, not a module
 
 error[E0432]: unresolved import `super::Struct`
-  --> $DIR/use-self-at-end.rs:64:24
+  --> $DIR/use-self-at-end.rs:70:24
    |
 LL |         pub use super::Struct::self as Struct1;
    |                        ^^^^^^ `Struct` is a struct, not a module
 
 error[E0432]: unresolved import `super::Struct`
-  --> $DIR/use-self-at-end.rs:65:24
+  --> $DIR/use-self-at-end.rs:71:24
    |
 LL |         pub use super::Struct::{self};
    |                        ^^^^^^ `Struct` is a struct, not a module
 
 error[E0433]: `self` in paths can only be used in start position or last position
-  --> $DIR/use-self-at-end.rs:83:24
+  --> $DIR/use-self-at-end.rs:92:24
    |
 LL |         pub use super::self::y::z;
    |                        ^^^^ can only be used in path start position or last position
 
 error[E0433]: `self` in paths can only be used in start position or last position
-  --> $DIR/use-self-at-end.rs:84:24
+  --> $DIR/use-self-at-end.rs:93:24
    |
 LL |         pub use super::self::y::z as z3;
    |                        ^^^^ can only be used in path start position or last position
 
 error[E0433]: `self` in paths can only be used in start position or last position
-  --> $DIR/use-self-at-end.rs:85:24
+  --> $DIR/use-self-at-end.rs:94:24
    |
 LL |         pub use super::self::y::{z};
    |                        ^^^^ can only be used in path start position or last position
 
 error[E0433]: `self` in paths can only be used in start position or last position
-  --> $DIR/use-self-at-end.rs:86:24
+  --> $DIR/use-self-at-end.rs:95:24
    |
 LL |         pub use super::self::y::{z as z4};
    |                        ^^^^ can only be used in path start position or last position
 
 error[E0432]: unresolved import `super::Struct`
-  --> $DIR/use-self-at-end.rs:66:24
+  --> $DIR/use-self-at-end.rs:72:24
    |
 LL |         pub use super::Struct::{self as Struct2};
    |                        ^^^^^^ `Struct` is a struct, not a module
 
 error[E0433]: `self` in paths can only be used in start position or last position
-  --> $DIR/use-self-at-end.rs:56:21
+  --> $DIR/use-self-at-end.rs:62:21
    |
 LL |         type G = z::self::self;
    |                     ^^^^ can only be used in path start position or last position
 
 error[E0433]: `self` in paths can only be used in start position or last position
-  --> $DIR/use-self-at-end.rs:82:25
+  --> $DIR/use-self-at-end.rs:91:25
    |
 LL |         type K = super::self::y::z;
    |                         ^^^^ can only be used in path start position or last position
 
 error[E0573]: expected type, found module `crate::self`
-  --> $DIR/use-self-at-end.rs:13:18
+  --> $DIR/use-self-at-end.rs:14:18
    |
 LL |         type A = crate::self;
    |                  ^^^^^^^^^^^ not a type
 
 error[E0573]: expected type, found module `self`
-  --> $DIR/use-self-at-end.rs:19:18
+  --> $DIR/use-self-at-end.rs:20:18
    |
 LL |         type B = self;
    |                  ^^^^ not a type
 
 error[E0573]: expected type, found module `self::self`
-  --> $DIR/use-self-at-end.rs:25:18
+  --> $DIR/use-self-at-end.rs:26:18
    |
 LL |         type C = self::self;
    |                  ^^^^^^^^^^ not a type
 
 error[E0573]: expected type, found module `super::self`
-  --> $DIR/use-self-at-end.rs:32:18
+  --> $DIR/use-self-at-end.rs:33:18
    |
 LL |         type D = super::self;
    |                  ^^^^^^^^^^^ not a type
 
 error[E0573]: expected type, found module `crate::x::self`
-  --> $DIR/use-self-at-end.rs:39:18
+  --> $DIR/use-self-at-end.rs:40:18
    |
 LL |         type E = crate::x::self;
    |                  ^^^^^^^^^^^^^^ not a type
 
 error[E0573]: expected type, found module `::self`
-  --> $DIR/use-self-at-end.rs:45:18
+  --> $DIR/use-self-at-end.rs:46:18
    |
 LL |         type F = ::self;
    |                  ^^^^^^ not a type
 
 error[E0223]: ambiguous associated type
-  --> $DIR/use-self-at-end.rs:62:18
+  --> $DIR/use-self-at-end.rs:68:18
    |
 LL |         type H = super::Struct::self;
    |                  ^^^^^^^^^^^^^^^^^^^
@@ -283,7 +283,7 @@ LL +         type H = <x::Struct as Example>::self;
    |
 
 warning: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/use-self-at-end.rs:74:18
+  --> $DIR/use-self-at-end.rs:80:18
    |
 LL |         type J = super::Trait::self;
    |                  ^^^^^^^^^^^^^^^^^^

--- a/tests/ui/use/use-self-at-end.e2021.stderr
+++ b/tests/ui/use/use-self-at-end.e2021.stderr
@@ -284,21 +284,18 @@ LL -         type H = super::Struct::self;
 LL +         type H = <x::Struct as Example>::self;
    |
 
-warning: trait objects without an explicit `dyn` are deprecated
+error[E0782]: expected a type, found a trait
   --> $DIR/use-self-at-end.rs:80:18
    |
 LL |         type J = super::Trait::self;
    |                  ^^^^^^^^^^^^^^^^^^
    |
-   = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
-   = note: `#[warn(bare_trait_objects)]` (part of `#[warn(rust_2021_compatibility)]`) on by default
-help: if this is a dyn-compatible trait, use `dyn`
+help: you can add the `dyn` keyword if you want a trait object
    |
 LL |         type J = dyn super::Trait::self;
    |                  +++
 
-error: aborting due to 36 previous errors; 1 warning emitted
+error: aborting due to 37 previous errors
 
-Some errors have detailed explanations: E0223, E0252, E0425, E0432, E0433, E0573.
+Some errors have detailed explanations: E0223, E0252, E0425, E0432, E0433, E0573, E0782.
 For more information about an error, try `rustc --explain E0223`.

--- a/tests/ui/use/use-self-at-end.rs
+++ b/tests/ui/use/use-self-at-end.rs
@@ -1,6 +1,7 @@
-//@ revisions: e2015 e2018
+//@ revisions: e2015 e2018 e2021
 //@ [e2015] edition: 2015
-//@ [e2018] edition: 2018..
+//@ [e2018] edition: 2018
+//@ [e2021] edition: 2021..
 
 pub mod x {
     pub struct Struct;
@@ -45,13 +46,18 @@ pub mod x {
         type F = ::self;
         //[e2015]~^ ERROR expected type, found module `::self`
         //[e2018]~^^ ERROR cannot find crate `self` in the list of imported crates
+        //[e2021]~^^^ ERROR cannot find crate `self` in the list of imported crates
         pub use ::self;
         //[e2015]~^ ERROR imports need to be explicitly named
         //[e2018]~^^ ERROR extern prelude cannot be imported
+        //[e2021]~^^^ ERROR extern prelude cannot be imported
         pub use ::self as crate4; //[e2018]~ ERROR extern prelude cannot be imported
+        //[e2021]~^ ERROR extern prelude cannot be imported
         pub use ::{self}; //[e2018]~ ERROR extern prelude cannot be imported
         //[e2015]~^ ERROR imports need to be explicitly named
+        //[e2021]~^^ ERROR extern prelude cannot be imported
         pub use ::{self as crate5}; //[e2018]~ ERROR extern prelude cannot be imported
+        //[e2021]~^ ERROR extern prelude cannot be imported
 
         type G = z::self::self; //~ ERROR `self` in paths can only be used in start position
         pub use z::self::self; //~ ERROR `self` in paths can only be used in start position or last position
@@ -72,8 +78,11 @@ pub mod x {
         pub use super::Enum::{self as Enum2};
 
         type J = super::Trait::self;
-        //~^ WARN trait objects without an explicit `dyn` are deprecated
-        //~^^ WARN this is accepted in the current edition
+        //[e2015]~^ WARN trait objects without an explicit `dyn` are deprecated
+        //[e2015]~^^ WARN this is accepted in the current edition
+        //[e2018]~^^^ WARN trait objects without an explicit `dyn` are deprecated
+        //[e2018]~^^^^ WARN this is accepted in the current edition
+        //[e2021]~^^^^^ ERROR expected a type, found a trait
         pub use super::Trait::self;
         pub use super::Trait::self as Trait1;
         pub use super::Trait::{self}; //~ ERROR the name `Trait` is defined multiple times


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

- 155202 used an async closure with the default 2015 edition, so it never
tested anything useful
- tait-normalize is already known to crash with edition 2021 (https://github.com/rust-lang/rust/issues/119786)
- use-self-at-end legitimately has different behavior in 2021 edition