### PR TITLE
Fix ignore-llvm-version directive in codegen-llvm/array-equality.rs

### DIFF
--- a/tests/codegen-llvm/array-equality.rs
+++ b/tests/codegen-llvm/array-equality.rs
@@ -1,5 +1,5 @@
 //@ revisions: llvm-current llvm-next
-//@[llvm-current] ignore-llvm-version: 23-99
+//@[llvm-current] ignore-llvm-version: 23 - 99
 //@[llvm-next] min-llvm-version: 23
 //@ compile-flags: -Copt-level=3 -Z merge-functions=disabled
 //@ only-x86_64


### PR DESCRIPTION
There needs to be spaces around the dash, otherwise it doesn't work as a range (which matters now that LLVM trunk is 24).