### PR TITLE
Honor field-level lint attributes in non_snake_case

### DIFF
--- a/compiler/rustc_lint/src/late.rs
+++ b/compiler/rustc_lint/src/late.rs
@@ -198,7 +198,6 @@ impl<'tcx, T: LateLintPass<'tcx>> hir_visit::Visitor<'tcx> for LateContextAndPas
     }
 
     fn visit_variant_data(&mut self, s: &'tcx hir::VariantData<'tcx>) {
-        lint_callback!(self, check_struct_def, s);
         hir_visit::walk_struct_def(self, s);
     }
 

--- a/compiler/rustc_lint/src/nonstandard_style.rs
+++ b/compiler/rustc_lint/src/nonstandard_style.rs
@@ -211,7 +211,7 @@ impl EarlyLintPass for NonCamelCaseTypes {
 
 declare_lint! {
     /// The `non_snake_case` lint detects variables, methods, functions,
-    /// lifetime parameters and modules that don't have snake case names.
+    /// lifetime parameters, named fields and modules that don't have snake case names.
     ///
     /// ### Example
     ///
@@ -452,10 +452,8 @@ impl<'tcx> LateLintPass<'tcx> for NonSnakeCase {
         }
     }
 
-    fn check_struct_def(&mut self, cx: &LateContext<'_>, s: &hir::VariantData<'_>) {
-        for sf in s.fields() {
-            self.check_snake_case(cx, "structure field", &sf.ident);
-        }
+    fn check_field_def(&mut self, cx: &LateContext<'_>, field: &hir::FieldDef<'_>) {
+        self.check_snake_case(cx, "structure field", &field.ident);
     }
 }
 

--- a/compiler/rustc_lint/src/passes.rs
+++ b/compiler/rustc_lint/src/passes.rs
@@ -37,7 +37,6 @@ macro_rules! late_lint_methods {
             fn check_trait_item(a: &'tcx rustc_hir::TraitItem<'tcx>);
             fn check_impl_item(a: &'tcx rustc_hir::ImplItem<'tcx>);
             fn check_impl_item_post(a: &'tcx rustc_hir::ImplItem<'tcx>);
-            fn check_struct_def(a: &'tcx rustc_hir::VariantData<'tcx>);
             fn check_field_def(a: &'tcx rustc_hir::FieldDef<'tcx>);
             fn check_variant(a: &'tcx rustc_hir::Variant<'tcx>);
             fn check_path(a: &rustc_hir::Path<'tcx>, b: rustc_hir::HirId);

--- a/tests/ui/lint/non-snake-case/field-lint-expectation-issue-159323.rs
+++ b/tests/ui/lint/non-snake-case/field-lint-expectation-issue-159323.rs
@@ -1,0 +1,33 @@
+//@ check-pass
+
+// Regression test for issue #159323
+// Field-level lint attributes must control `non_snake_case` diagnostics for that field.
+
+#![deny(non_snake_case, unfulfilled_lint_expectations)]
+
+pub struct Struct {
+    #[expect(non_snake_case)]
+    pub expected_Field: bool,
+
+    #[allow(non_snake_case)]
+    pub allowed_Field: bool,
+}
+
+#[expect(non_snake_case)]
+pub struct ParentExpectation {
+    pub expected_Field: bool,
+}
+
+pub enum Enum {
+    Variant {
+        #[expect(non_snake_case)]
+        expected_Field: bool,
+    },
+}
+
+pub union Union {
+    #[expect(non_snake_case)]
+    pub expected_Field: bool,
+}
+
+fn main() {}


### PR DESCRIPTION
Fixes rust-lang/rust#159323 

non_snake_case checked field names from the enclosing struct with `check_struct_def`, so field-level lint attributes such as `#[expect(non_snake_case)]` were not respected.

while https://github.com/rust-lang/rust/blob/e54776fbdb9c233ebbc164fbb9f97e82f879f28c/compiler/rustc_lint/src/late.rs#L206-L209 honor lint attributes.

