### PR TITLE
renovate: group github actions updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,15 +1,13 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended",
+    // Use https://github.com/rust-lang/renovate/blob/main/actions.json
+    "github>rust-lang/renovate:actions",
     // Open a PR to migrate the config when Renovate deprecates syntax
     ":configMigration",
     // Refresh lock files on the first day of each month
     // (still gated by dashboard approval for now)
     ":maintainLockFilesMonthly",
-    // Pin GitHub Actions to their commit SHA digests, resolving floating tags
-    // (e.g. `v4`) to the full SemVer version (e.g. `v4.1.2`)
-    "helpers:pinGitHubActionDigestsToSemver"
   ],
   // Require manual approval from the Dependency Dashboard before opening PRs
   "dependencyDashboardApproval": true,


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
Group GitHub Actions updates together to minimize the number of PRs opened, using our plugin: https://github.com/rust-lang/renovate/blob/main/actions.json

As discussed in https://github.com/rust-lang/rust/pull/158113#issuecomment-4982056085
<!-- homu-ignore:end -->
r? @Kobzol