### PR TITLE
Enable polonius alpha on nightly

### DIFF
--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -3426,10 +3426,9 @@ impl PatchableFunctionEntry {
 
 /// `-Zpolonius` values, enabling the borrow checker polonius analysis, and which version: legacy,
 /// or future prototype.
-#[derive(Clone, Copy, PartialEq, Hash, Debug, Default)]
+#[derive(Clone, Copy, PartialEq, Hash, Debug)]
 pub enum Polonius {
     /// Polonius is disabled, only use NLL.
-    #[default]
     Off,
 
     /// Legacy version, using datalog and the `polonius-engine` crate. Historical value for `-Zpolonius`.
@@ -3437,6 +3436,12 @@ pub enum Polonius {
 
     /// In-tree prototype, extending the NLL infrastructure.
     Next,
+}
+
+impl Default for Polonius {
+    fn default() -> Self {
+        if option_env!("CFG_DEFAULT_POLONIUS_NEXT").is_some() { Self::Next } else { Self::Off }
+    }
 }
 
 impl Polonius {

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -3428,7 +3428,7 @@ impl PatchableFunctionEntry {
 /// or future prototype.
 #[derive(Clone, Copy, PartialEq, Hash, Debug, Default)]
 pub enum Polonius {
-    /// The default value: disabled.
+    /// Polonius is disabled, only use NLL.
     #[default]
     Off,
 

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -894,7 +894,8 @@ mod desc {
         components: `crto`, `libc`, `unwind`, `linker`, `sanitizers`, `mingw`";
     pub(crate) const parse_linker_features: &str =
         "a list of enabled (`+` prefix) and disabled (`-` prefix) features: `lld`";
-    pub(crate) const parse_polonius: &str = "either no value or `legacy` (the default), or `next`";
+    pub(crate) const parse_polonius: &str =
+        "either no value or one of `legacy` (the default), `off`, or `next`";
     pub(crate) const parse_annotate_moves: &str =
         "either a boolean (`yes`, `no`, `on`, `off`, etc.), or a size limit in bytes";
     pub(crate) const parse_stack_protector: &str =
@@ -987,6 +988,10 @@ pub mod parse {
             }
             Some("next") => {
                 *slot = Polonius::Next;
+                true
+            }
+            Some("off") | Some("no") => {
+                *slot = Polonius::Off;
                 true
             }
             _ => false,

--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -1365,6 +1365,12 @@ pub fn rustc_cargo_env(builder: &Builder<'_>, cargo: &mut Cargo, target: TargetS
         cargo.env("RUSTC_VERIFY_LLVM_IR", "1");
     }
 
+    let nightly = builder.config.channel == "nightly" || builder.config.channel == "dev";
+    if nightly {
+        // We want to enable Polonius Alpha by default on nighty
+        cargo.env("CFG_DEFAULT_POLONIUS_NEXT", "1");
+    }
+
     // These conditionals represent a tension between three forces:
     // - For non-check builds, we need to define some LLVM-related environment
     //   variables, requiring LLVM to have been built.

--- a/tests/ui/borrowck/alias-liveness/gat-hide-lifetime-for-swap.edition2015.stderr
+++ b/tests/ui/borrowck/alias-liveness/gat-hide-lifetime-for-swap.edition2015.stderr
@@ -1,5 +1,5 @@
 error[E0515]: cannot return value referencing local variable `x`
-  --> $DIR/gat-hide-lifetime-for-swap.rs:33:5
+  --> $DIR/gat-hide-lifetime-for-swap.rs:35:5
    |
 LL |     h.hide_ref(&mut res).swap(h.hide_ref(&mut &x));
    |                                               -- `x` is borrowed here

--- a/tests/ui/borrowck/alias-liveness/gat-hide-lifetime-for-swap.edition2024.stderr
+++ b/tests/ui/borrowck/alias-liveness/gat-hide-lifetime-for-swap.edition2024.stderr
@@ -1,5 +1,5 @@
 error[E0515]: cannot return value referencing local variable `x`
-  --> $DIR/gat-hide-lifetime-for-swap.rs:33:5
+  --> $DIR/gat-hide-lifetime-for-swap.rs:35:5
    |
 LL |     h.hide_ref(&mut res).swap(h.hide_ref(&mut &x));
    |                                               -- `x` is borrowed here

--- a/tests/ui/borrowck/alias-liveness/gat-hide-lifetime-for-swap.polonius_alpha.stderr
+++ b/tests/ui/borrowck/alias-liveness/gat-hide-lifetime-for-swap.polonius_alpha.stderr
@@ -1,5 +1,5 @@
 error[E0515]: cannot return value referencing local variable `x`
-  --> $DIR/gat-hide-lifetime-for-swap.rs:33:5
+  --> $DIR/gat-hide-lifetime-for-swap.rs:35:5
    |
 LL |     h.hide_ref(&mut res).swap(h.hide_ref(&mut &x));
    |                                               -- `x` is borrowed here

--- a/tests/ui/borrowck/alias-liveness/gat-hide-lifetime-for-swap.rs
+++ b/tests/ui/borrowck/alias-liveness/gat-hide-lifetime-for-swap.rs
@@ -2,6 +2,8 @@
 //@ ignore-compare-mode-polonius (explicit revisions)
 //@ [edition2015] edition: 2015
 //@ [edition2024] edition: 2024
+//@ [edition2015] compile-flags: -Zpolonius=off
+//@ [edition2024] compile-flags: -Zpolonius=off
 //@ [polonius_alpha] edition: 2024
 //@ [polonius_alpha] compile-flags: -Zpolonius=next
 

--- a/tests/ui/borrowck/alias-liveness/gat-hide-lifetime-in-type-arg-for-swap.edition2015.stderr
+++ b/tests/ui/borrowck/alias-liveness/gat-hide-lifetime-in-type-arg-for-swap.edition2015.stderr
@@ -1,5 +1,5 @@
 error[E0515]: cannot return value referencing local variable `x`
-  --> $DIR/gat-hide-lifetime-in-type-arg-for-swap.rs:33:5
+  --> $DIR/gat-hide-lifetime-in-type-arg-for-swap.rs:35:5
    |
 LL |     h.hide(&mut res).swap(h.hide(&mut &x));
    |                                       -- `x` is borrowed here

--- a/tests/ui/borrowck/alias-liveness/gat-hide-lifetime-in-type-arg-for-swap.edition2024.stderr
+++ b/tests/ui/borrowck/alias-liveness/gat-hide-lifetime-in-type-arg-for-swap.edition2024.stderr
@@ -1,5 +1,5 @@
 error[E0515]: cannot return value referencing local variable `x`
-  --> $DIR/gat-hide-lifetime-in-type-arg-for-swap.rs:33:5
+  --> $DIR/gat-hide-lifetime-in-type-arg-for-swap.rs:35:5
    |
 LL |     h.hide(&mut res).swap(h.hide(&mut &x));
    |                                       -- `x` is borrowed here

--- a/tests/ui/borrowck/alias-liveness/gat-hide-lifetime-in-type-arg-for-swap.polonius_alpha.stderr
+++ b/tests/ui/borrowck/alias-liveness/gat-hide-lifetime-in-type-arg-for-swap.polonius_alpha.stderr
@@ -1,5 +1,5 @@
 error[E0515]: cannot return value referencing local variable `x`
-  --> $DIR/gat-hide-lifetime-in-type-arg-for-swap.rs:33:5
+  --> $DIR/gat-hide-lifetime-in-type-arg-for-swap.rs:35:5
    |
 LL |     h.hide(&mut res).swap(h.hide(&mut &x));
    |                                       -- `x` is borrowed here

--- a/tests/ui/borrowck/alias-liveness/gat-hide-lifetime-in-type-arg-for-swap.rs
+++ b/tests/ui/borrowck/alias-liveness/gat-hide-lifetime-in-type-arg-for-swap.rs
@@ -2,6 +2,8 @@
 //@ ignore-compare-mode-polonius (explicit revisions)
 //@ [edition2015] edition: 2015
 //@ [edition2024] edition: 2024
+//@ [edition2015] compile-flags: -Zpolonius=off
+//@ [edition2024] compile-flags: -Zpolonius=off
 //@ [polonius_alpha] edition: 2024
 //@ [polonius_alpha] compile-flags: -Zpolonius=next
 

--- a/tests/ui/borrowck/alias-liveness/gat-outlives-env.edition2015.stderr
+++ b/tests/ui/borrowck/alias-liveness/gat-outlives-env.edition2015.stderr
@@ -1,5 +1,5 @@
 error[E0499]: cannot borrow `t` as mutable more than once at a time
-  --> $DIR/gat-outlives-env.rs:49:13
+  --> $DIR/gat-outlives-env.rs:51:13
    |
 LL |     let a = t.changes(static_unit);
    |             - first mutable borrow occurs here

--- a/tests/ui/borrowck/alias-liveness/gat-outlives-env.edition2024.stderr
+++ b/tests/ui/borrowck/alias-liveness/gat-outlives-env.edition2024.stderr
@@ -1,5 +1,5 @@
 error[E0499]: cannot borrow `t` as mutable more than once at a time
-  --> $DIR/gat-outlives-env.rs:49:13
+  --> $DIR/gat-outlives-env.rs:51:13
    |
 LL |     let a = t.changes(static_unit);
    |             - first mutable borrow occurs here

--- a/tests/ui/borrowck/alias-liveness/gat-outlives-env.polonius_alpha.stderr
+++ b/tests/ui/borrowck/alias-liveness/gat-outlives-env.polonius_alpha.stderr
@@ -1,5 +1,5 @@
 error[E0499]: cannot borrow `t` as mutable more than once at a time
-  --> $DIR/gat-outlives-env.rs:49:13
+  --> $DIR/gat-outlives-env.rs:51:13
    |
 LL |     let a = t.changes(static_unit);
    |             - first mutable borrow occurs here

--- a/tests/ui/borrowck/alias-liveness/gat-outlives-env.rs
+++ b/tests/ui/borrowck/alias-liveness/gat-outlives-env.rs
@@ -2,6 +2,8 @@
 //@ ignore-compare-mode-polonius (explicit revisions)
 //@ [edition2015] edition: 2015
 //@ [edition2024] edition: 2024
+//@ [edition2015] compile-flags: -Zpolonius=off
+//@ [edition2024] compile-flags: -Zpolonius=off
 //@ [polonius_alpha] edition: 2024
 //@ [polonius_alpha] compile-flags: -Zpolonius=next
 

--- a/tests/ui/borrowck/alias-liveness/gat-outlives-implied.edition2024.stderr
+++ b/tests/ui/borrowck/alias-liveness/gat-outlives-implied.edition2024.stderr
@@ -1,5 +1,5 @@
 error[E0506]: cannot assign to `cluster` because it is borrowed
-  --> $DIR/gat-outlives-implied.rs:19:9
+  --> $DIR/gat-outlives-implied.rs:20:9
    |
 LL |         let changes = self.changes(&cluster);
    |                                    -------- `cluster` is borrowed here

--- a/tests/ui/borrowck/alias-liveness/gat-outlives-implied.polonius_alpha.stderr
+++ b/tests/ui/borrowck/alias-liveness/gat-outlives-implied.polonius_alpha.stderr
@@ -1,5 +1,5 @@
 error[E0506]: cannot assign to `cluster` because it is borrowed
-  --> $DIR/gat-outlives-implied.rs:19:9
+  --> $DIR/gat-outlives-implied.rs:20:9
    |
 LL |         let changes = self.changes(&cluster);
    |                                    -------- `cluster` is borrowed here

--- a/tests/ui/borrowck/alias-liveness/gat-outlives-implied.rs
+++ b/tests/ui/borrowck/alias-liveness/gat-outlives-implied.rs
@@ -1,6 +1,7 @@
 //@ revisions: edition2024 polonius_alpha
 //@ ignore-compare-mode-polonius (explicit revisions)
 //@ edition: 2024
+//@ [edition2024] compile-flags: -Zpolonius=off
 //@ [polonius_alpha] compile-flags: -Zpolonius=next
 
 // Tests that liveness for regions in associated types considers outlives

--- a/tests/ui/borrowck/alias-liveness/rpit-hide-lifetime-for-swap.edition2015.stderr
+++ b/tests/ui/borrowck/alias-liveness/rpit-hide-lifetime-for-swap.edition2015.stderr
@@ -1,5 +1,5 @@
 error[E0700]: hidden type for `impl Swap + 'a` captures lifetime that does not appear in bounds
-  --> $DIR/rpit-hide-lifetime-for-swap.rs:36:5
+  --> $DIR/rpit-hide-lifetime-for-swap.rs:38:5
    |
 LL | fn hide_ref<'a, 'b, T: 'static>(x: &'a mut &'b T) -> impl Swap + 'a {
    |                 --                                   -------------- opaque type defined here
@@ -14,7 +14,7 @@ LL | fn hide_ref<'a, 'b, T: 'static>(x: &'a mut &'b T) -> impl Swap + 'a + use<'
    |                                                                     ++++++++++++++++
 
 error[E0700]: hidden type for `impl Swap + 'a` captures lifetime that does not appear in bounds
-  --> $DIR/rpit-hide-lifetime-for-swap.rs:53:5
+  --> $DIR/rpit-hide-lifetime-for-swap.rs:55:5
    |
 LL | fn hide_rc_refcell<'a, 'b: 'a, T: 'static>(x: Rc<RefCell<&'b T>>) -> impl Swap + 'a {
    |                        --                                            -------------- opaque type defined here

--- a/tests/ui/borrowck/alias-liveness/rpit-hide-lifetime-for-swap.edition2024.stderr
+++ b/tests/ui/borrowck/alias-liveness/rpit-hide-lifetime-for-swap.edition2024.stderr
@@ -1,5 +1,5 @@
 error[E0515]: cannot return value referencing local variable `x`
-  --> $DIR/rpit-hide-lifetime-for-swap.rs:44:5
+  --> $DIR/rpit-hide-lifetime-for-swap.rs:46:5
    |
 LL |     hide_ref(&mut res).swap(hide_ref(&mut &x));
    |                                           -- `x` is borrowed here
@@ -7,7 +7,7 @@ LL |     res
    |     ^^^ returns a value referencing data owned by the current function
 
 error[E0597]: `x` does not live long enough
-  --> $DIR/rpit-hide-lifetime-for-swap.rs:60:38
+  --> $DIR/rpit-hide-lifetime-for-swap.rs:62:38
    |
 LL |     let x = [1, 2, 3];
    |         - binding `x` declared here

--- a/tests/ui/borrowck/alias-liveness/rpit-hide-lifetime-for-swap.polonius_alpha.stderr
+++ b/tests/ui/borrowck/alias-liveness/rpit-hide-lifetime-for-swap.polonius_alpha.stderr
@@ -1,5 +1,5 @@
 error[E0515]: cannot return value referencing local variable `x`
-  --> $DIR/rpit-hide-lifetime-for-swap.rs:44:5
+  --> $DIR/rpit-hide-lifetime-for-swap.rs:46:5
    |
 LL |     hide_ref(&mut res).swap(hide_ref(&mut &x));
    |                                           -- `x` is borrowed here
@@ -7,7 +7,7 @@ LL |     res
    |     ^^^ returns a value referencing data owned by the current function
 
 error[E0597]: `x` does not live long enough
-  --> $DIR/rpit-hide-lifetime-for-swap.rs:60:38
+  --> $DIR/rpit-hide-lifetime-for-swap.rs:62:38
    |
 LL |     let x = [1, 2, 3];
    |         - binding `x` declared here

--- a/tests/ui/borrowck/alias-liveness/rpit-hide-lifetime-for-swap.rs
+++ b/tests/ui/borrowck/alias-liveness/rpit-hide-lifetime-for-swap.rs
@@ -2,6 +2,8 @@
 //@ ignore-compare-mode-polonius (explicit revisions)
 //@ [edition2015] edition: 2015
 //@ [edition2024] edition: 2024
+//@ [edition2015] compile-flags: -Zpolonius=off
+//@ [edition2024] compile-flags: -Zpolonius=off
 //@ [polonius_alpha] edition: 2024
 //@ [polonius_alpha] compile-flags: -Zpolonius=next
 

--- a/tests/ui/borrowck/alias-liveness/rpit-hide-lifetime-in-type-arg-for-swap.edition2015.stderr
+++ b/tests/ui/borrowck/alias-liveness/rpit-hide-lifetime-in-type-arg-for-swap.edition2015.stderr
@@ -1,5 +1,5 @@
 error[E0515]: cannot return value referencing local variable `x`
-  --> $DIR/rpit-hide-lifetime-in-type-arg-for-swap.rs:33:5
+  --> $DIR/rpit-hide-lifetime-in-type-arg-for-swap.rs:35:5
    |
 LL |     hide(&lock, &mut res).swap(hide(&lock, &mut &x));
    |                                                 -- `x` is borrowed here

--- a/tests/ui/borrowck/alias-liveness/rpit-hide-lifetime-in-type-arg-for-swap.edition2024.stderr
+++ b/tests/ui/borrowck/alias-liveness/rpit-hide-lifetime-in-type-arg-for-swap.edition2024.stderr
@@ -1,5 +1,5 @@
 error[E0515]: cannot return value referencing local variable `x`
-  --> $DIR/rpit-hide-lifetime-in-type-arg-for-swap.rs:33:5
+  --> $DIR/rpit-hide-lifetime-in-type-arg-for-swap.rs:35:5
    |
 LL |     hide(&lock, &mut res).swap(hide(&lock, &mut &x));
    |                                                 -- `x` is borrowed here

--- a/tests/ui/borrowck/alias-liveness/rpit-hide-lifetime-in-type-arg-for-swap.polonius_alpha.stderr
+++ b/tests/ui/borrowck/alias-liveness/rpit-hide-lifetime-in-type-arg-for-swap.polonius_alpha.stderr
@@ -1,5 +1,5 @@
 error[E0515]: cannot return value referencing local variable `x`
-  --> $DIR/rpit-hide-lifetime-in-type-arg-for-swap.rs:33:5
+  --> $DIR/rpit-hide-lifetime-in-type-arg-for-swap.rs:35:5
    |
 LL |     hide(&lock, &mut res).swap(hide(&lock, &mut &x));
    |                                                 -- `x` is borrowed here

--- a/tests/ui/borrowck/alias-liveness/rpit-hide-lifetime-in-type-arg-for-swap.rs
+++ b/tests/ui/borrowck/alias-liveness/rpit-hide-lifetime-in-type-arg-for-swap.rs
@@ -2,6 +2,8 @@
 //@ ignore-compare-mode-polonius (explicit revisions)
 //@ [edition2015] edition: 2015
 //@ [edition2024] edition: 2024
+//@ [edition2015] compile-flags: -Zpolonius=off
+//@ [edition2024] compile-flags: -Zpolonius=off
 //@ [polonius_alpha] edition: 2024
 //@ [polonius_alpha] compile-flags: -Zpolonius=next
 

--- a/tests/ui/borrowck/alias-liveness/rpitit-hide-lifetime-for-swap.edition2015.stderr
+++ b/tests/ui/borrowck/alias-liveness/rpitit-hide-lifetime-for-swap.edition2015.stderr
@@ -1,5 +1,5 @@
 error[E0515]: cannot return value referencing local variable `x`
-  --> $DIR/rpitit-hide-lifetime-for-swap.rs:31:5
+  --> $DIR/rpitit-hide-lifetime-for-swap.rs:33:5
    |
 LL |     h.hide_ref(&mut res).swap(h.hide_ref(&mut &x));
    |                                               -- `x` is borrowed here

--- a/tests/ui/borrowck/alias-liveness/rpitit-hide-lifetime-for-swap.edition2024.stderr
+++ b/tests/ui/borrowck/alias-liveness/rpitit-hide-lifetime-for-swap.edition2024.stderr
@@ -1,5 +1,5 @@
 error[E0515]: cannot return value referencing local variable `x`
-  --> $DIR/rpitit-hide-lifetime-for-swap.rs:31:5
+  --> $DIR/rpitit-hide-lifetime-for-swap.rs:33:5
    |
 LL |     h.hide_ref(&mut res).swap(h.hide_ref(&mut &x));
    |                                               -- `x` is borrowed here

--- a/tests/ui/borrowck/alias-liveness/rpitit-hide-lifetime-for-swap.polonius_alpha.stderr
+++ b/tests/ui/borrowck/alias-liveness/rpitit-hide-lifetime-for-swap.polonius_alpha.stderr
@@ -1,5 +1,5 @@
 error[E0515]: cannot return value referencing local variable `x`
-  --> $DIR/rpitit-hide-lifetime-for-swap.rs:31:5
+  --> $DIR/rpitit-hide-lifetime-for-swap.rs:33:5
    |
 LL |     h.hide_ref(&mut res).swap(h.hide_ref(&mut &x));
    |                                               -- `x` is borrowed here

--- a/tests/ui/borrowck/alias-liveness/rpitit-hide-lifetime-for-swap.rs
+++ b/tests/ui/borrowck/alias-liveness/rpitit-hide-lifetime-for-swap.rs
@@ -2,6 +2,8 @@
 //@ ignore-compare-mode-polonius (explicit revisions)
 //@ [edition2015] edition: 2015
 //@ [edition2024] edition: 2024
+//@ [edition2015] compile-flags: -Zpolonius=off
+//@ [edition2024] compile-flags: -Zpolonius=off
 //@ [polonius_alpha] edition: 2024
 //@ [polonius_alpha] compile-flags: -Zpolonius=next
 

--- a/tests/ui/drop/dropck-normalize-errors.nll.stderr
+++ b/tests/ui/drop/dropck-normalize-errors.nll.stderr
@@ -1,54 +1,54 @@
 error[E0277]: the trait bound `NonImplementedStruct: NonImplementedTrait` is not satisfied in `ADecoder<'a>`
-  --> $DIR/dropck-normalize-errors.rs:19:28
+  --> $DIR/dropck-normalize-errors.rs:20:28
    |
 LL | fn make_a_decoder<'a>() -> ADecoder<'a> {
    |                            ^^^^^^^^^^^^ unsatisfied trait bound
    |
 help: within `ADecoder<'a>`, the trait `NonImplementedTrait` is not implemented for `NonImplementedStruct`
-  --> $DIR/dropck-normalize-errors.rs:14:1
+  --> $DIR/dropck-normalize-errors.rs:15:1
    |
 LL | struct NonImplementedStruct;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: this trait has no implementations, consider adding one
-  --> $DIR/dropck-normalize-errors.rs:11:1
+  --> $DIR/dropck-normalize-errors.rs:12:1
    |
 LL | trait NonImplementedTrait {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required because it appears within the type `BDecoder`
-  --> $DIR/dropck-normalize-errors.rs:30:12
+  --> $DIR/dropck-normalize-errors.rs:31:12
    |
 LL | pub struct BDecoder {
    |            ^^^^^^^^
 note: required because it appears within the type `ADecoder<'a>`
-  --> $DIR/dropck-normalize-errors.rs:16:12
+  --> $DIR/dropck-normalize-errors.rs:17:12
    |
 LL | pub struct ADecoder<'a> {
    |            ^^^^^^^^
    = note: the return type of a function must have a statically known size
 
 error[E0277]: the trait bound `NonImplementedStruct: NonImplementedTrait` is not satisfied in `BDecoder`
-  --> $DIR/dropck-normalize-errors.rs:27:20
+  --> $DIR/dropck-normalize-errors.rs:28:20
    |
 LL |     type Decoder = BDecoder;
    |                    ^^^^^^^^ unsatisfied trait bound
    |
 help: within `BDecoder`, the trait `NonImplementedTrait` is not implemented for `NonImplementedStruct`
-  --> $DIR/dropck-normalize-errors.rs:14:1
+  --> $DIR/dropck-normalize-errors.rs:15:1
    |
 LL | struct NonImplementedStruct;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: this trait has no implementations, consider adding one
-  --> $DIR/dropck-normalize-errors.rs:11:1
+  --> $DIR/dropck-normalize-errors.rs:12:1
    |
 LL | trait NonImplementedTrait {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required because it appears within the type `BDecoder`
-  --> $DIR/dropck-normalize-errors.rs:30:12
+  --> $DIR/dropck-normalize-errors.rs:31:12
    |
 LL | pub struct BDecoder {
    |            ^^^^^^^^
 note: required by a bound in `Decode::Decoder`
-  --> $DIR/dropck-normalize-errors.rs:8:5
+  --> $DIR/dropck-normalize-errors.rs:9:5
    |
 LL |     type Decoder;
    |     ^^^^^^^^^^^^^ required by this bound in `Decode::Decoder`
@@ -58,35 +58,35 @@ LL |     type Decoder: ?Sized;
    |                 ++++++++
 
 error[E0277]: the trait bound `NonImplementedStruct: NonImplementedTrait` is not satisfied
-  --> $DIR/dropck-normalize-errors.rs:31:22
+  --> $DIR/dropck-normalize-errors.rs:32:22
    |
 LL |     non_implemented: <NonImplementedStruct as NonImplementedTrait>::Assoc,
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
    |
 help: the trait `NonImplementedTrait` is not implemented for `NonImplementedStruct`
-  --> $DIR/dropck-normalize-errors.rs:14:1
+  --> $DIR/dropck-normalize-errors.rs:15:1
    |
 LL | struct NonImplementedStruct;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: this trait has no implementations, consider adding one
-  --> $DIR/dropck-normalize-errors.rs:11:1
+  --> $DIR/dropck-normalize-errors.rs:12:1
    |
 LL | trait NonImplementedTrait {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `NonImplementedStruct: NonImplementedTrait` is not satisfied
-  --> $DIR/dropck-normalize-errors.rs:19:28
+  --> $DIR/dropck-normalize-errors.rs:20:28
    |
 LL | fn make_a_decoder<'a>() -> ADecoder<'a> {
    |                            ^^^^^^^^^^^^ unsatisfied trait bound
    |
 help: the trait `NonImplementedTrait` is not implemented for `NonImplementedStruct`
-  --> $DIR/dropck-normalize-errors.rs:14:1
+  --> $DIR/dropck-normalize-errors.rs:15:1
    |
 LL | struct NonImplementedStruct;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: this trait has no implementations, consider adding one
-  --> $DIR/dropck-normalize-errors.rs:11:1
+  --> $DIR/dropck-normalize-errors.rs:12:1
    |
 LL | trait NonImplementedTrait {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/drop/dropck-normalize-errors.polonius.stderr
+++ b/tests/ui/drop/dropck-normalize-errors.polonius.stderr
@@ -1,54 +1,54 @@
 error[E0277]: the trait bound `NonImplementedStruct: NonImplementedTrait` is not satisfied in `ADecoder<'a>`
-  --> $DIR/dropck-normalize-errors.rs:19:28
+  --> $DIR/dropck-normalize-errors.rs:20:28
    |
 LL | fn make_a_decoder<'a>() -> ADecoder<'a> {
    |                            ^^^^^^^^^^^^ unsatisfied trait bound
    |
 help: within `ADecoder<'a>`, the trait `NonImplementedTrait` is not implemented for `NonImplementedStruct`
-  --> $DIR/dropck-normalize-errors.rs:14:1
+  --> $DIR/dropck-normalize-errors.rs:15:1
    |
 LL | struct NonImplementedStruct;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: this trait has no implementations, consider adding one
-  --> $DIR/dropck-normalize-errors.rs:11:1
+  --> $DIR/dropck-normalize-errors.rs:12:1
    |
 LL | trait NonImplementedTrait {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required because it appears within the type `BDecoder`
-  --> $DIR/dropck-normalize-errors.rs:30:12
+  --> $DIR/dropck-normalize-errors.rs:31:12
    |
 LL | pub struct BDecoder {
    |            ^^^^^^^^
 note: required because it appears within the type `ADecoder<'a>`
-  --> $DIR/dropck-normalize-errors.rs:16:12
+  --> $DIR/dropck-normalize-errors.rs:17:12
    |
 LL | pub struct ADecoder<'a> {
    |            ^^^^^^^^
    = note: the return type of a function must have a statically known size
 
 error[E0277]: the trait bound `NonImplementedStruct: NonImplementedTrait` is not satisfied in `BDecoder`
-  --> $DIR/dropck-normalize-errors.rs:27:20
+  --> $DIR/dropck-normalize-errors.rs:28:20
    |
 LL |     type Decoder = BDecoder;
    |                    ^^^^^^^^ unsatisfied trait bound
    |
 help: within `BDecoder`, the trait `NonImplementedTrait` is not implemented for `NonImplementedStruct`
-  --> $DIR/dropck-normalize-errors.rs:14:1
+  --> $DIR/dropck-normalize-errors.rs:15:1
    |
 LL | struct NonImplementedStruct;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: this trait has no implementations, consider adding one
-  --> $DIR/dropck-normalize-errors.rs:11:1
+  --> $DIR/dropck-normalize-errors.rs:12:1
    |
 LL | trait NonImplementedTrait {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required because it appears within the type `BDecoder`
-  --> $DIR/dropck-normalize-errors.rs:30:12
+  --> $DIR/dropck-normalize-errors.rs:31:12
    |
 LL | pub struct BDecoder {
    |            ^^^^^^^^
 note: required by a bound in `Decode::Decoder`
-  --> $DIR/dropck-normalize-errors.rs:8:5
+  --> $DIR/dropck-normalize-errors.rs:9:5
    |
 LL |     type Decoder;
    |     ^^^^^^^^^^^^^ required by this bound in `Decode::Decoder`
@@ -58,18 +58,18 @@ LL |     type Decoder: ?Sized;
    |                 ++++++++
 
 error[E0277]: the trait bound `NonImplementedStruct: NonImplementedTrait` is not satisfied
-  --> $DIR/dropck-normalize-errors.rs:31:22
+  --> $DIR/dropck-normalize-errors.rs:32:22
    |
 LL |     non_implemented: <NonImplementedStruct as NonImplementedTrait>::Assoc,
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
    |
 help: the trait `NonImplementedTrait` is not implemented for `NonImplementedStruct`
-  --> $DIR/dropck-normalize-errors.rs:14:1
+  --> $DIR/dropck-normalize-errors.rs:15:1
    |
 LL | struct NonImplementedStruct;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: this trait has no implementations, consider adding one
-  --> $DIR/dropck-normalize-errors.rs:11:1
+  --> $DIR/dropck-normalize-errors.rs:12:1
    |
 LL | trait NonImplementedTrait {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/drop/dropck-normalize-errors.rs
+++ b/tests/ui/drop/dropck-normalize-errors.rs
@@ -2,6 +2,7 @@
 
 //@ ignore-compare-mode-polonius (explicit revisions)
 //@ revisions: nll polonius
+//@ [nll] compile-flags: -Zpolonius=off
 //@ [polonius] compile-flags: -Zpolonius=next
 
 trait Decode<'a> {

--- a/tests/ui/nll/get_default.legacy.stderr
+++ b/tests/ui/nll/get_default.legacy.stderr
@@ -1,5 +1,5 @@
 error[E0502]: cannot borrow `*map` as mutable because it is also borrowed as immutable
-  --> $DIR/get_default.rs:35:17
+  --> $DIR/get_default.rs:36:17
    |
 LL | fn err(map: &mut Map) -> &String {
    |             - let's call the lifetime of this reference `'1`

--- a/tests/ui/nll/get_default.nll.stderr
+++ b/tests/ui/nll/get_default.nll.stderr
@@ -1,5 +1,5 @@
 error[E0502]: cannot borrow `*map` as mutable because it is also borrowed as immutable
-  --> $DIR/get_default.rs:24:17
+  --> $DIR/get_default.rs:25:17
    |
 LL | fn ok(map: &mut Map) -> &String {
    |            - let's call the lifetime of this reference `'1`
@@ -14,7 +14,7 @@ LL |                 map.set(String::new()); // Ideally, this would not error.
    |                 ^^^^^^^^^^^^^^^^^^^^^^ mutable borrow occurs here
 
 error[E0502]: cannot borrow `*map` as mutable because it is also borrowed as immutable
-  --> $DIR/get_default.rs:35:17
+  --> $DIR/get_default.rs:36:17
    |
 LL | fn err(map: &mut Map) -> &String {
    |             - let's call the lifetime of this reference `'1`
@@ -29,7 +29,7 @@ LL |                 return v;
    |                        - returning this value requires that `*map` is borrowed for `'1`
 
 error[E0502]: cannot borrow `*map` as mutable because it is also borrowed as immutable
-  --> $DIR/get_default.rs:40:17
+  --> $DIR/get_default.rs:41:17
    |
 LL | fn err(map: &mut Map) -> &String {
    |             - let's call the lifetime of this reference `'1`

--- a/tests/ui/nll/get_default.polonius.stderr
+++ b/tests/ui/nll/get_default.polonius.stderr
@@ -1,5 +1,5 @@
 error[E0502]: cannot borrow `*map` as mutable because it is also borrowed as immutable
-  --> $DIR/get_default.rs:35:17
+  --> $DIR/get_default.rs:36:17
    |
 LL | fn err(map: &mut Map) -> &String {
    |             - let's call the lifetime of this reference `'1`

--- a/tests/ui/nll/get_default.rs
+++ b/tests/ui/nll/get_default.rs
@@ -3,6 +3,7 @@
 
 //@ ignore-compare-mode-polonius (explicit revisions)
 //@ revisions: nll polonius legacy
+//@ [nll] compile-flags: -Zpolonius=off
 //@ [polonius] compile-flags: -Z polonius=next
 //@ [legacy] compile-flags: -Z polonius=legacy
 

--- a/tests/ui/nll/issue-46589.nll.stderr
+++ b/tests/ui/nll/issue-46589.nll.stderr
@@ -1,5 +1,5 @@
 error[E0499]: cannot borrow `**other` as mutable more than once at a time
-  --> $DIR/issue-46589.rs:25:21
+  --> $DIR/issue-46589.rs:26:21
    |
 LL |         *other = match (*other).get_self() {
    |                        -------- first mutable borrow occurs here

--- a/tests/ui/nll/issue-46589.polonius.stderr
+++ b/tests/ui/nll/issue-46589.polonius.stderr
@@ -1,5 +1,5 @@
 error[E0499]: cannot borrow `**other` as mutable more than once at a time
-  --> $DIR/issue-46589.rs:25:21
+  --> $DIR/issue-46589.rs:26:21
    |
 LL |         *other = match (*other).get_self() {
    |                        -------- first mutable borrow occurs here

--- a/tests/ui/nll/issue-46589.rs
+++ b/tests/ui/nll/issue-46589.rs
@@ -1,6 +1,7 @@
 //@ ignore-compare-mode-polonius (explicit revisions)
 //@ revisions: nll polonius legacy
 //@ [nll] known-bug: #46589
+//@ [nll] compile-flags: -Zpolonius=off
 //@ [polonius] known-bug: #46589
 //@ [polonius] compile-flags: -Zpolonius=next
 //@ [legacy] check-pass

--- a/tests/ui/nll/polonius/filtering-lending-iterator-issue-92985.nll.stderr
+++ b/tests/ui/nll/polonius/filtering-lending-iterator-issue-92985.nll.stderr
@@ -1,5 +1,5 @@
 error[E0499]: cannot borrow `self.iter` as mutable more than once at a time
-  --> $DIR/filtering-lending-iterator-issue-92985.rs:49:32
+  --> $DIR/filtering-lending-iterator-issue-92985.rs:50:32
    |
 LL |     fn next(&mut self) -> Option<I::Item<'_>> {
    |             - let's call the lifetime of this reference `'1`

--- a/tests/ui/nll/polonius/filtering-lending-iterator-issue-92985.rs
+++ b/tests/ui/nll/polonius/filtering-lending-iterator-issue-92985.rs
@@ -12,6 +12,7 @@
 //@ ignore-compare-mode-polonius (explicit revisions)
 //@ revisions: nll polonius legacy
 //@ [nll] known-bug: #92985
+//@ [nll] compile-flags: -Z polonius=off
 //@ [polonius] check-pass
 //@ [polonius] compile-flags: -Z polonius=next
 //@ [legacy] check-pass

--- a/tests/ui/nll/polonius/iterating-updating-cursor-issue-108704.nll.stderr
+++ b/tests/ui/nll/polonius/iterating-updating-cursor-issue-108704.nll.stderr
@@ -1,5 +1,5 @@
 error[E0499]: cannot borrow `*elements` as mutable more than once at a time
-  --> $DIR/iterating-updating-cursor-issue-108704.rs:41:26
+  --> $DIR/iterating-updating-cursor-issue-108704.rs:42:26
    |
 LL |         for (idx, el) in elements.iter_mut().enumerate() {
    |                          ^^^^^^^^

--- a/tests/ui/nll/polonius/iterating-updating-cursor-issue-108704.polonius.stderr
+++ b/tests/ui/nll/polonius/iterating-updating-cursor-issue-108704.polonius.stderr
@@ -1,5 +1,5 @@
 error[E0499]: cannot borrow `*elements` as mutable more than once at a time
-  --> $DIR/iterating-updating-cursor-issue-108704.rs:41:26
+  --> $DIR/iterating-updating-cursor-issue-108704.rs:42:26
    |
 LL |         for (idx, el) in elements.iter_mut().enumerate() {
    |                          ^^^^^^^^

--- a/tests/ui/nll/polonius/iterating-updating-cursor-issue-108704.rs
+++ b/tests/ui/nll/polonius/iterating-updating-cursor-issue-108704.rs
@@ -6,6 +6,7 @@
 //@ ignore-compare-mode-polonius (explicit revisions)
 //@ revisions: nll polonius legacy
 //@ [nll] known-bug: #108704
+//@ [nll] compile-flags: -Z polonius=off
 //@ [polonius] known-bug: #108704
 //@ [polonius] compile-flags: -Z polonius=next
 //@ [legacy] check-pass

--- a/tests/ui/nll/polonius/iterating-updating-cursor-issue-57165.nll.stderr
+++ b/tests/ui/nll/polonius/iterating-updating-cursor-issue-57165.nll.stderr
@@ -1,5 +1,5 @@
 error[E0499]: cannot borrow `p.0` as mutable more than once at a time
-  --> $DIR/iterating-updating-cursor-issue-57165.rs:30:20
+  --> $DIR/iterating-updating-cursor-issue-57165.rs:31:20
    |
 LL |     while let Some(now) = p {
    |                    ^^^    - first borrow used here, in later iteration of loop
@@ -7,7 +7,7 @@ LL |     while let Some(now) = p {
    |                    `p.0` was mutably borrowed here in the previous iteration of the loop
 
 error[E0503]: cannot use `*p` because it was mutably borrowed
-  --> $DIR/iterating-updating-cursor-issue-57165.rs:30:27
+  --> $DIR/iterating-updating-cursor-issue-57165.rs:31:27
    |
 LL |     while let Some(now) = p {
    |                    ---    ^

--- a/tests/ui/nll/polonius/iterating-updating-cursor-issue-57165.polonius.stderr
+++ b/tests/ui/nll/polonius/iterating-updating-cursor-issue-57165.polonius.stderr
@@ -1,5 +1,5 @@
 error[E0499]: cannot borrow `p.0` as mutable more than once at a time
-  --> $DIR/iterating-updating-cursor-issue-57165.rs:30:20
+  --> $DIR/iterating-updating-cursor-issue-57165.rs:31:20
    |
 LL |     while let Some(now) = p {
    |                    ^^^    - first borrow used here, in later iteration of loop
@@ -7,7 +7,7 @@ LL |     while let Some(now) = p {
    |                    `p.0` was mutably borrowed here in the previous iteration of the loop
 
 error[E0503]: cannot use `*p` because it was mutably borrowed
-  --> $DIR/iterating-updating-cursor-issue-57165.rs:30:27
+  --> $DIR/iterating-updating-cursor-issue-57165.rs:31:27
    |
 LL |     while let Some(now) = p {
    |                    ---    ^

--- a/tests/ui/nll/polonius/iterating-updating-cursor-issue-57165.rs
+++ b/tests/ui/nll/polonius/iterating-updating-cursor-issue-57165.rs
@@ -6,6 +6,7 @@
 //@ ignore-compare-mode-polonius (explicit revisions)
 //@ revisions: nll polonius legacy
 //@ [nll] known-bug: #57165
+//@ [nll] compile-flags: -Z polonius=off
 //@ [polonius] known-bug: #57165
 //@ [polonius] compile-flags: -Z polonius=next
 //@ [legacy] check-pass

--- a/tests/ui/nll/polonius/iterating-updating-cursor-issue-63908.nll.stderr
+++ b/tests/ui/nll/polonius/iterating-updating-cursor-issue-63908.nll.stderr
@@ -1,5 +1,5 @@
 error[E0506]: cannot assign to `*node_ref` because it is borrowed
-  --> $DIR/iterating-updating-cursor-issue-63908.rs:43:5
+  --> $DIR/iterating-updating-cursor-issue-63908.rs:44:5
    |
 LL | fn remove_last_node_iterative<T>(mut node_ref: &mut List<T>) {
    |                                                - let's call the lifetime of this reference `'1`

--- a/tests/ui/nll/polonius/iterating-updating-cursor-issue-63908.polonius.stderr
+++ b/tests/ui/nll/polonius/iterating-updating-cursor-issue-63908.polonius.stderr
@@ -1,5 +1,5 @@
 error[E0506]: cannot assign to `*node_ref` because it is borrowed
-  --> $DIR/iterating-updating-cursor-issue-63908.rs:43:5
+  --> $DIR/iterating-updating-cursor-issue-63908.rs:44:5
    |
 LL | fn remove_last_node_iterative<T>(mut node_ref: &mut List<T>) {
    |                                                - let's call the lifetime of this reference `'1`

--- a/tests/ui/nll/polonius/iterating-updating-cursor-issue-63908.rs
+++ b/tests/ui/nll/polonius/iterating-updating-cursor-issue-63908.rs
@@ -6,6 +6,7 @@
 //@ ignore-compare-mode-polonius (explicit revisions)
 //@ revisions: nll polonius legacy
 //@ [nll] known-bug: #63908
+//@ [nll] compile-flags: -Z polonius=off
 //@ [polonius] known-bug: #63908
 //@ [polonius] compile-flags: -Z polonius=next
 //@ [legacy] check-pass

--- a/tests/ui/nll/polonius/iterating-updating-mutref.nll.stderr
+++ b/tests/ui/nll/polonius/iterating-updating-mutref.nll.stderr
@@ -1,5 +1,5 @@
 error[E0499]: cannot borrow `self.buf_read` as mutable more than once at a time
-  --> $DIR/iterating-updating-mutref.rs:76:23
+  --> $DIR/iterating-updating-mutref.rs:77:23
    |
 LL |     pub fn next<'a>(&'a mut self) -> &'a str {
    |                 -- lifetime `'a` defined here

--- a/tests/ui/nll/polonius/iterating-updating-mutref.rs
+++ b/tests/ui/nll/polonius/iterating-updating-mutref.rs
@@ -10,6 +10,7 @@
 //@ ignore-compare-mode-polonius (explicit revisions)
 //@ revisions: nll polonius legacy
 //@ [nll] known-bug: #46859
+//@ [nll] compile-flags: -Z polonius=off
 //@ [polonius] check-pass
 //@ [polonius] compile-flags: -Z polonius=next
 //@ [legacy] check-pass

--- a/tests/ui/nll/polonius/location-insensitive-constraints-issue-70044.nll.stderr
+++ b/tests/ui/nll/polonius/location-insensitive-constraints-issue-70044.nll.stderr
@@ -1,5 +1,5 @@
 error[E0502]: cannot borrow `one` as immutable because it is also borrowed as mutable
-  --> $DIR/location-insensitive-constraints-issue-70044.rs:22:20
+  --> $DIR/location-insensitive-constraints-issue-70044.rs:23:20
    |
 LL |         let mut y = &mut one;
    |                     -------- mutable borrow occurs here

--- a/tests/ui/nll/polonius/location-insensitive-constraints-issue-70044.rs
+++ b/tests/ui/nll/polonius/location-insensitive-constraints-issue-70044.rs
@@ -4,6 +4,7 @@
 
 //@ ignore-compare-mode-polonius (explicit revisions)
 //@ revisions: nll polonius legacy
+//@ [nll] compile-flags: -Z polonius=off
 //@ [polonius] check-pass
 //@ [polonius] compile-flags: -Z polonius=next
 //@ [legacy] check-pass

--- a/tests/ui/nll/polonius/location-insensitive-scopes-issue-116657.nll.stderr
+++ b/tests/ui/nll/polonius/location-insensitive-scopes-issue-116657.nll.stderr
@@ -1,5 +1,5 @@
 error[E0046]: not all trait items implemented, missing: `call`
-  --> $DIR/location-insensitive-scopes-issue-116657.rs:18:1
+  --> $DIR/location-insensitive-scopes-issue-116657.rs:19:1
    |
 LL |     fn call(x: Self) -> Self::Output;
    |     --------------------------------- `call` from trait
@@ -8,7 +8,7 @@ LL | impl<T: PlusOne> Callable for T {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `call` in implementation
 
 error: unconstrained opaque type
-  --> $DIR/location-insensitive-scopes-issue-116657.rs:22:19
+  --> $DIR/location-insensitive-scopes-issue-116657.rs:23:19
    |
 LL |     type Output = impl PlusOne;
    |                   ^^^^^^^^^^^^
@@ -16,7 +16,7 @@ LL |     type Output = impl PlusOne;
    = note: `Output` must be used in combination with a concrete type within the same impl
 
 error[E0700]: hidden type for `impl PlusOne` captures lifetime that does not appear in bounds
-  --> $DIR/location-insensitive-scopes-issue-116657.rs:28:5
+  --> $DIR/location-insensitive-scopes-issue-116657.rs:29:5
    |
 LL | fn test<'a>(y: &'a mut i32) -> impl PlusOne {
    |         --                     ------------ opaque type defined here

--- a/tests/ui/nll/polonius/location-insensitive-scopes-issue-116657.polonius.stderr
+++ b/tests/ui/nll/polonius/location-insensitive-scopes-issue-116657.polonius.stderr
@@ -1,5 +1,5 @@
 error[E0046]: not all trait items implemented, missing: `call`
-  --> $DIR/location-insensitive-scopes-issue-116657.rs:18:1
+  --> $DIR/location-insensitive-scopes-issue-116657.rs:19:1
    |
 LL |     fn call(x: Self) -> Self::Output;
    |     --------------------------------- `call` from trait
@@ -8,7 +8,7 @@ LL | impl<T: PlusOne> Callable for T {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `call` in implementation
 
 error: unconstrained opaque type
-  --> $DIR/location-insensitive-scopes-issue-116657.rs:22:19
+  --> $DIR/location-insensitive-scopes-issue-116657.rs:23:19
    |
 LL |     type Output = impl PlusOne;
    |                   ^^^^^^^^^^^^
@@ -16,7 +16,7 @@ LL |     type Output = impl PlusOne;
    = note: `Output` must be used in combination with a concrete type within the same impl
 
 error[E0700]: hidden type for `impl PlusOne` captures lifetime that does not appear in bounds
-  --> $DIR/location-insensitive-scopes-issue-116657.rs:28:5
+  --> $DIR/location-insensitive-scopes-issue-116657.rs:29:5
    |
 LL | fn test<'a>(y: &'a mut i32) -> impl PlusOne {
    |         --                     ------------ opaque type defined here

--- a/tests/ui/nll/polonius/location-insensitive-scopes-issue-116657.rs
+++ b/tests/ui/nll/polonius/location-insensitive-scopes-issue-116657.rs
@@ -2,6 +2,7 @@
 // different loan scopes when a member constraint was not ultimately applied.
 
 //@ revisions: nll polonius
+//@ [nll] compile-flags: -Zpolonius=off
 //@ [polonius] compile-flags: -Zpolonius=next
 
 #![feature(impl_trait_in_assoc_type)]

--- a/tests/ui/nll/polonius/location-insensitive-scopes-issue-117146.nll.stderr
+++ b/tests/ui/nll/polonius/location-insensitive-scopes-issue-117146.nll.stderr
@@ -1,5 +1,5 @@
 error[E0597]: `a` does not live long enough
-  --> $DIR/location-insensitive-scopes-issue-117146.rs:10:18
+  --> $DIR/location-insensitive-scopes-issue-117146.rs:11:18
    |
 LL |     let a = ();
    |         - binding `a` declared here
@@ -14,18 +14,18 @@ LL | }
    | - `a` dropped here while still borrowed
    |
 note: due to a current limitation of the type system, this implies a `'static` lifetime
-  --> $DIR/location-insensitive-scopes-issue-117146.rs:20:11
+  --> $DIR/location-insensitive-scopes-issue-117146.rs:21:11
    |
 LL | fn bad<F: Fn(&()) -> &()>(_: F) {}
    |           ^^^^^^^^^^^^^^
 note: requirement that the value outlives `'static` introduced here
-  --> $DIR/location-insensitive-scopes-issue-117146.rs:20:22
+  --> $DIR/location-insensitive-scopes-issue-117146.rs:21:22
    |
 LL | fn bad<F: Fn(&()) -> &()>(_: F) {}
    |                      ^^^
 
 error: implementation of `Fn` is not general enough
-  --> $DIR/location-insensitive-scopes-issue-117146.rs:13:5
+  --> $DIR/location-insensitive-scopes-issue-117146.rs:14:5
    |
 LL |     bad(&b);
    |     ^^^^^^^ implementation of `Fn` is not general enough
@@ -38,7 +38,7 @@ LL |     let b = |_: &()| &a;
    |               +++++
 
 error: implementation of `FnOnce` is not general enough
-  --> $DIR/location-insensitive-scopes-issue-117146.rs:13:5
+  --> $DIR/location-insensitive-scopes-issue-117146.rs:14:5
    |
 LL |     bad(&b);
    |     ^^^^^^^ implementation of `FnOnce` is not general enough

--- a/tests/ui/nll/polonius/location-insensitive-scopes-issue-117146.polonius.stderr
+++ b/tests/ui/nll/polonius/location-insensitive-scopes-issue-117146.polonius.stderr
@@ -1,5 +1,5 @@
 error[E0597]: `a` does not live long enough
-  --> $DIR/location-insensitive-scopes-issue-117146.rs:10:18
+  --> $DIR/location-insensitive-scopes-issue-117146.rs:11:18
    |
 LL |     let a = ();
    |         - binding `a` declared here
@@ -14,18 +14,18 @@ LL | }
    | - `a` dropped here while still borrowed
    |
 note: due to a current limitation of the type system, this implies a `'static` lifetime
-  --> $DIR/location-insensitive-scopes-issue-117146.rs:20:11
+  --> $DIR/location-insensitive-scopes-issue-117146.rs:21:11
    |
 LL | fn bad<F: Fn(&()) -> &()>(_: F) {}
    |           ^^^^^^^^^^^^^^
 note: requirement that the value outlives `'static` introduced here
-  --> $DIR/location-insensitive-scopes-issue-117146.rs:20:22
+  --> $DIR/location-insensitive-scopes-issue-117146.rs:21:22
    |
 LL | fn bad<F: Fn(&()) -> &()>(_: F) {}
    |                      ^^^
 
 error: implementation of `Fn` is not general enough
-  --> $DIR/location-insensitive-scopes-issue-117146.rs:13:5
+  --> $DIR/location-insensitive-scopes-issue-117146.rs:14:5
    |
 LL |     bad(&b);
    |     ^^^^^^^ implementation of `Fn` is not general enough
@@ -38,7 +38,7 @@ LL |     let b = |_: &()| &a;
    |               +++++
 
 error: implementation of `FnOnce` is not general enough
-  --> $DIR/location-insensitive-scopes-issue-117146.rs:13:5
+  --> $DIR/location-insensitive-scopes-issue-117146.rs:14:5
    |
 LL |     bad(&b);
    |     ^^^^^^^ implementation of `FnOnce` is not general enough

--- a/tests/ui/nll/polonius/location-insensitive-scopes-issue-117146.rs
+++ b/tests/ui/nll/polonius/location-insensitive-scopes-issue-117146.rs
@@ -3,6 +3,7 @@
 // region.
 
 //@ revisions: nll polonius
+//@ [nll] compile-flags: -Zpolonius=off
 //@ [polonius] compile-flags: -Zpolonius=next
 
 fn main() {

--- a/tests/ui/nll/polonius/location-insensitive-scopes-liveness.rs
+++ b/tests/ui/nll/polonius/location-insensitive-scopes-liveness.rs
@@ -6,10 +6,11 @@
 // regions were marked live later, and live loans were not recomputed at this point.
 
 //@ ignore-compare-mode-polonius (explicit revisions)
-//@ revisions: polonius_next polonius
+//@ revisions: nll polonius_next polonius
 //@ check-pass
+//@ [nll] compile-flags: -Zpolonius=off
 //@ [polonius_next] compile-flags: -Z polonius=next
-//@ [polonius] compile-flags: -Z polonius
+//@ [polonius] compile-flags: -Z polonius=legacy
 
 // minimized from wavefc-cli-3.0.0
 fn repro1() {

--- a/tests/ui/nll/polonius/nll-problem-case-2-issue-92038.nll.stderr
+++ b/tests/ui/nll/polonius/nll-problem-case-2-issue-92038.nll.stderr
@@ -1,5 +1,5 @@
 error[E0499]: cannot borrow `*a` as mutable more than once at a time
-  --> $DIR/nll-problem-case-2-issue-92038.rs:16:26
+  --> $DIR/nll-problem-case-2-issue-92038.rs:17:26
    |
 LL | fn reborrow(a: &mut u8) -> &mut u8 {
    |                - let's call the lifetime of this reference `'1`

--- a/tests/ui/nll/polonius/nll-problem-case-2-issue-92038.rs
+++ b/tests/ui/nll/polonius/nll-problem-case-2-issue-92038.rs
@@ -6,6 +6,7 @@
 
 //@ ignore-compare-mode-polonius (explicit revisions)
 //@ revisions: nll polonius legacy
+//@ [nll] compile-flags: -Z polonius=off
 //@ [polonius] check-pass
 //@ [polonius] compile-flags: -Z polonius=next
 //@ [legacy] check-pass

--- a/tests/ui/nll/polonius/nll-problem-case-3-issue-112087.nll.stderr
+++ b/tests/ui/nll/polonius/nll-problem-case-3-issue-112087.nll.stderr
@@ -1,5 +1,5 @@
 error[E0506]: cannot assign to `*opt` because it is borrowed
-  --> $DIR/nll-problem-case-3-issue-112087.rs:23:5
+  --> $DIR/nll-problem-case-3-issue-112087.rs:24:5
    |
 LL | fn issue_112087<'a>(opt: &'a mut Option<i32>, b: bool) -> Result<&'a mut Option<i32>, &'a mut i32> {
    |                 -- lifetime `'a` defined here

--- a/tests/ui/nll/polonius/nll-problem-case-3-issue-112087.rs
+++ b/tests/ui/nll/polonius/nll-problem-case-3-issue-112087.rs
@@ -8,6 +8,7 @@
 //@ ignore-compare-mode-polonius (explicit revisions)
 //@ revisions: nll polonius legacy
 //@ [nll] known-bug: #112087
+//@ [nll] compile-flags: -Z polonius=off
 //@ [polonius] check-pass
 //@ [polonius] compile-flags: -Z polonius=next
 //@ [legacy] check-pass

--- a/tests/ui/nll/polonius/nll-problem-case-3-issue-123839.nll.stderr
+++ b/tests/ui/nll/polonius/nll-problem-case-3-issue-123839.nll.stderr
@@ -1,5 +1,5 @@
 error[E0506]: cannot assign to `self.status` because it is borrowed
-  --> $DIR/nll-problem-case-3-issue-123839.rs:37:9
+  --> $DIR/nll-problem-case-3-issue-123839.rs:38:9
    |
 LL |     fn foo(self: &mut Self) -> Result<(), &str> {
    |                  - let's call the lifetime of this reference `'1`

--- a/tests/ui/nll/polonius/nll-problem-case-3-issue-123839.rs
+++ b/tests/ui/nll/polonius/nll-problem-case-3-issue-123839.rs
@@ -8,6 +8,7 @@
 //@ ignore-compare-mode-polonius (explicit revisions)
 //@ revisions: nll polonius legacy
 //@ [nll] known-bug: #123839
+//@ [nll] compile-flags: -Z polonius=off
 //@ [polonius] check-pass
 //@ [polonius] compile-flags: -Z polonius=next
 //@ [legacy] check-pass

--- a/tests/ui/nll/polonius/nll-problem-case-3-issue-124070.nll.stderr
+++ b/tests/ui/nll/polonius/nll-problem-case-3-issue-124070.nll.stderr
@@ -1,5 +1,5 @@
 error[E0502]: cannot borrow `self.field` as immutable because it is also borrowed as mutable
-  --> $DIR/nll-problem-case-3-issue-124070.rs:28:16
+  --> $DIR/nll-problem-case-3-issue-124070.rs:29:16
    |
 LL |     fn f(&mut self) -> &str {
    |          - let's call the lifetime of this reference `'1`

--- a/tests/ui/nll/polonius/nll-problem-case-3-issue-124070.rs
+++ b/tests/ui/nll/polonius/nll-problem-case-3-issue-124070.rs
@@ -8,6 +8,7 @@
 //@ ignore-compare-mode-polonius (explicit revisions)
 //@ revisions: nll polonius legacy
 //@ [nll] known-bug: #124070
+//@ [nll] compile-flags: -Z polonius=off
 //@ [polonius] check-pass
 //@ [polonius] compile-flags: -Z polonius=next
 //@ [legacy] check-pass

--- a/tests/ui/nll/polonius/nll-problem-case-3-issue-124254.nll.stderr
+++ b/tests/ui/nll/polonius/nll-problem-case-3-issue-124254.nll.stderr
@@ -1,5 +1,5 @@
 error[E0499]: cannot borrow `list[_]` as mutable more than once at a time
-  --> $DIR/nll-problem-case-3-issue-124254.rs:30:5
+  --> $DIR/nll-problem-case-3-issue-124254.rs:31:5
    |
 LL | fn find_lowest_or_first_empty_pos(list: &mut [Option<u8>]) -> &mut Option<u8> {
    |                                         - let's call the lifetime of this reference `'1`
@@ -14,7 +14,7 @@ LL |     &mut list[lowest_idx]
    |     ^^^^^^^^^^^^^^^^^^^^^ second mutable borrow occurs here
 
 error[E0503]: cannot use `*list` because it was mutably borrowed
-  --> $DIR/nll-problem-case-3-issue-124254.rs:30:10
+  --> $DIR/nll-problem-case-3-issue-124254.rs:31:10
    |
 LL | fn find_lowest_or_first_empty_pos(list: &mut [Option<u8>]) -> &mut Option<u8> {
    |                                         - let's call the lifetime of this reference `'1`

--- a/tests/ui/nll/polonius/nll-problem-case-3-issue-124254.rs
+++ b/tests/ui/nll/polonius/nll-problem-case-3-issue-124254.rs
@@ -6,6 +6,7 @@
 //@ ignore-compare-mode-polonius (explicit revisions)
 //@ revisions: nll polonius legacy
 //@ [nll] known-bug: #124254
+//@ [nll] compile-flags: -Z polonius=off
 //@ [polonius] check-pass
 //@ [polonius] compile-flags: -Z polonius=next
 //@ [legacy] check-pass

--- a/tests/ui/nll/polonius/nll-problem-case-3-issue-21906.nll.stderr
+++ b/tests/ui/nll/polonius/nll-problem-case-3-issue-21906.nll.stderr
@@ -1,5 +1,5 @@
 error[E0499]: cannot borrow `*map` as mutable more than once at a time
-  --> $DIR/nll-problem-case-3-issue-21906.rs:26:13
+  --> $DIR/nll-problem-case-3-issue-21906.rs:27:13
    |
 LL |   fn from_the_rfc<'r, K: Hash + Eq + Copy, V: Default>(
    |                   -- lifetime `'r` defined here
@@ -17,7 +17,7 @@ LL | |     }
    | |_____- returning this value requires that `*map` is borrowed for `'r`
 
 error[E0499]: cannot borrow `*map` as mutable more than once at a time
-  --> $DIR/nll-problem-case-3-issue-21906.rs:27:13
+  --> $DIR/nll-problem-case-3-issue-21906.rs:28:13
    |
 LL |   fn from_the_rfc<'r, K: Hash + Eq + Copy, V: Default>(
    |                   -- lifetime `'r` defined here
@@ -36,7 +36,7 @@ LL | |     }
    | |_____- returning this value requires that `*map` is borrowed for `'r`
 
 error[E0499]: cannot borrow `*map` as mutable more than once at a time
-  --> $DIR/nll-problem-case-3-issue-21906.rs:45:41
+  --> $DIR/nll-problem-case-3-issue-21906.rs:46:41
    |
 LL | fn get_priority_mut_entry<'a, K, V>(
    |                           -- lifetime `'a` defined here
@@ -49,7 +49,7 @@ LL |         Entry::Vacant(_vacant) => match map.entry(key2) {
    |                                         ^^^ second mutable borrow occurs here
 
 error[E0499]: cannot borrow `*self` as mutable more than once at a time
-  --> $DIR/nll-problem-case-3-issue-21906.rs:64:21
+  --> $DIR/nll-problem-case-3-issue-21906.rs:65:21
    |
 LL |     fn two(&mut self) -> &i32 {
    |            - let's call the lifetime of this reference `'1`
@@ -61,7 +61,7 @@ LL |                 return k;
    |                        - returning this value requires that `*self` is borrowed for `'1`
 
 error[E0502]: cannot borrow `x.data` as immutable because it is also borrowed as mutable
-  --> $DIR/nll-problem-case-3-issue-21906.rs:82:22
+  --> $DIR/nll-problem-case-3-issue-21906.rs:83:22
    |
 LL | fn foo(x: &mut Foo) -> Option<&mut i32> {
    |           - let's call the lifetime of this reference `'1`
@@ -74,7 +74,7 @@ LL |     println!("{:?}", x.data);
    |                      ^^^^^^ immutable borrow occurs here
 
 error[E0499]: cannot borrow `*vec` as mutable more than once at a time
-  --> $DIR/nll-problem-case-3-issue-21906.rs:97:9
+  --> $DIR/nll-problem-case-3-issue-21906.rs:98:9
    |
 LL | fn f(vec: &mut Vec<u8>) -> &u8 {
    |           - let's call the lifetime of this reference `'1`
@@ -88,7 +88,7 @@ LL |         vec.push(10);
    |         ^^^ second mutable borrow occurs here
 
 error[E0502]: cannot borrow `*vec` as immutable because it is also borrowed as mutable
-  --> $DIR/nll-problem-case-3-issue-21906.rs:98:9
+  --> $DIR/nll-problem-case-3-issue-21906.rs:99:9
    |
 LL | fn f(vec: &mut Vec<u8>) -> &u8 {
    |           - let's call the lifetime of this reference `'1`

--- a/tests/ui/nll/polonius/nll-problem-case-3-issue-21906.rs
+++ b/tests/ui/nll/polonius/nll-problem-case-3-issue-21906.rs
@@ -8,6 +8,7 @@
 //@ ignore-compare-mode-polonius (explicit revisions)
 //@ revisions: nll polonius legacy
 //@ [nll] known-bug: #21906
+//@ [nll] compile-flags: -Z polonius=off
 //@ [polonius] check-pass
 //@ [polonius] compile-flags: -Z polonius=next
 //@ [legacy] check-pass

--- a/tests/ui/nll/polonius/nll-problem-case-3-issue-51526.nll.stderr
+++ b/tests/ui/nll/polonius/nll-problem-case-3-issue-51526.nll.stderr
@@ -1,5 +1,5 @@
 error[E0502]: cannot borrow `*queue` as mutable because it is also borrowed as immutable
-  --> $DIR/nll-problem-case-3-issue-51526.rs:26:9
+  --> $DIR/nll-problem-case-3-issue-51526.rs:27:9
    |
 LL | fn next(queue: &mut VecDeque<u32>, above: u32) -> Option<&u32> {
    |                - let's call the lifetime of this reference `'1`

--- a/tests/ui/nll/polonius/nll-problem-case-3-issue-51526.rs
+++ b/tests/ui/nll/polonius/nll-problem-case-3-issue-51526.rs
@@ -8,6 +8,7 @@
 //@ ignore-compare-mode-polonius (explicit revisions)
 //@ revisions: nll polonius legacy
 //@ [nll] known-bug: #51526
+//@ [nll] compile-flags: -Z polonius=off
 //@ [polonius] check-pass
 //@ [polonius] compile-flags: -Z polonius=next
 //@ [legacy] check-pass

--- a/tests/ui/nll/polonius/nll-problem-case-3-issue-51545.nll.stderr
+++ b/tests/ui/nll/polonius/nll-problem-case-3-issue-51545.nll.stderr
@@ -1,5 +1,5 @@
 error[E0499]: cannot borrow `*o` as mutable more than once at a time
-  --> $DIR/nll-problem-case-3-issue-51545.rs:17:17
+  --> $DIR/nll-problem-case-3-issue-51545.rs:18:17
    |
 LL | fn borrow(o: &mut Option<i32>) -> Option<&mut i32> {
    |              - let's call the lifetime of this reference `'1`

--- a/tests/ui/nll/polonius/nll-problem-case-3-issue-51545.rs
+++ b/tests/ui/nll/polonius/nll-problem-case-3-issue-51545.rs
@@ -6,6 +6,7 @@
 //@ ignore-compare-mode-polonius (explicit revisions)
 //@ revisions: nll polonius legacy
 //@ [nll] known-bug: #51545
+//@ [nll] compile-flags: -Z polonius=off
 //@ [polonius] check-pass
 //@ [polonius] compile-flags: -Z polonius=next
 //@ [legacy] check-pass

--- a/tests/ui/nll/polonius/nll-problem-case-3-issue-54663.nll.stderr
+++ b/tests/ui/nll/polonius/nll-problem-case-3-issue-54663.nll.stderr
@@ -1,5 +1,5 @@
 error[E0499]: cannot borrow `*x` as mutable more than once at a time
-  --> $DIR/nll-problem-case-3-issue-54663.rs:20:9
+  --> $DIR/nll-problem-case-3-issue-54663.rs:21:9
    |
 LL | fn foo(x: &mut u8) -> Option<&u8> {
    |           - let's call the lifetime of this reference `'1`

--- a/tests/ui/nll/polonius/nll-problem-case-3-issue-54663.rs
+++ b/tests/ui/nll/polonius/nll-problem-case-3-issue-54663.rs
@@ -8,6 +8,7 @@
 //@ ignore-compare-mode-polonius (explicit revisions)
 //@ revisions: nll polonius legacy
 //@ [nll] known-bug: #54663
+//@ [nll] compile-flags: -Z polonius=off
 //@ [polonius] check-pass
 //@ [polonius] compile-flags: -Z polonius=next
 //@ [legacy] check-pass

--- a/tests/ui/nll/polonius/nll-problem-case-3-issue-58787.nll.stderr
+++ b/tests/ui/nll/polonius/nll-problem-case-3-issue-58787.nll.stderr
@@ -1,5 +1,5 @@
 error[E0503]: cannot use `list.0` because it was mutably borrowed
-  --> $DIR/nll-problem-case-3-issue-58787.rs:34:11
+  --> $DIR/nll-problem-case-3-issue-58787.rs:35:11
    |
 LL |         Some(ref mut d) => {
    |              --------- `list.0.0` is borrowed here
@@ -11,7 +11,7 @@ LL |     match list.0 {
    |           borrow later used here
 
 error[E0499]: cannot borrow `list.0.0` as mutable more than once at a time
-  --> $DIR/nll-problem-case-3-issue-58787.rs:35:14
+  --> $DIR/nll-problem-case-3-issue-58787.rs:36:14
    |
 LL |         Some(ref mut d) => {
    |              --------- first mutable borrow occurs here
@@ -23,7 +23,7 @@ LL |         Some(ref mut d) => {
    |              first borrow later used here
 
 error[E0503]: cannot use `list.0` because it was mutably borrowed
-  --> $DIR/nll-problem-case-3-issue-58787.rs:41:11
+  --> $DIR/nll-problem-case-3-issue-58787.rs:42:11
    |
 LL |         Some(ref mut d) => {
    |              --------- `list.0.0` is borrowed here
@@ -35,7 +35,7 @@ LL |     match list {
    |           borrow later used here
 
 error[E0499]: cannot borrow `list.0.0` as mutable more than once at a time
-  --> $DIR/nll-problem-case-3-issue-58787.rs:42:19
+  --> $DIR/nll-problem-case-3-issue-58787.rs:43:19
    |
 LL |         Some(ref mut d) => {
    |              --------- first mutable borrow occurs here
@@ -47,7 +47,7 @@ LL |         List(Some(d)) => {
    |                   first borrow later used here
 
 error[E0503]: cannot use `list.0` because it was mutably borrowed
-  --> $DIR/nll-problem-case-3-issue-58787.rs:50:11
+  --> $DIR/nll-problem-case-3-issue-58787.rs:51:11
    |
 LL |         List(Some(d)) => {
    |                   - `list.0.0` is borrowed here
@@ -59,7 +59,7 @@ LL |     match list {
    |           borrow later used here
 
 error[E0499]: cannot borrow `list.0.0` as mutable more than once at a time
-  --> $DIR/nll-problem-case-3-issue-58787.rs:51:19
+  --> $DIR/nll-problem-case-3-issue-58787.rs:52:19
    |
 LL |         List(Some(d)) => {
    |                   - first mutable borrow occurs here
@@ -71,7 +71,7 @@ LL |         List(Some(d)) => {
    |                   first borrow later used here
 
 error[E0499]: cannot borrow `list.0` as mutable more than once at a time
-  --> $DIR/nll-problem-case-3-issue-58787.rs:57:11
+  --> $DIR/nll-problem-case-3-issue-58787.rs:58:11
    |
 LL |         List(Some(d)) => {
    |                   - first mutable borrow occurs here
@@ -83,7 +83,7 @@ LL |     match &mut list.0 {
    |           first borrow later used here
 
 error[E0499]: cannot borrow `list.0` as mutable more than once at a time
-  --> $DIR/nll-problem-case-3-issue-58787.rs:66:11
+  --> $DIR/nll-problem-case-3-issue-58787.rs:67:11
    |
 LL |     match &mut list.0 {
    |           ----------- first mutable borrow occurs here
@@ -95,7 +95,7 @@ LL |     match &mut list.0 {
    |           first borrow later used here
 
 error[E0506]: cannot assign to `list.0` because it is borrowed
-  --> $DIR/nll-problem-case-3-issue-58787.rs:73:5
+  --> $DIR/nll-problem-case-3-issue-58787.rs:74:5
    |
 LL |     match &mut list.0 {
    |           ----------- `list.0` is borrowed here

--- a/tests/ui/nll/polonius/nll-problem-case-3-issue-58787.rs
+++ b/tests/ui/nll/polonius/nll-problem-case-3-issue-58787.rs
@@ -8,6 +8,7 @@
 //@ ignore-compare-mode-polonius (explicit revisions)
 //@ revisions: nll polonius legacy
 //@ [nll] known-bug: #58787
+//@ [nll] compile-flags: -Z polonius=off
 //@ [polonius] check-pass
 //@ [polonius] compile-flags: -Z polonius=next
 //@ [legacy] check-pass

--- a/tests/ui/nll/polonius/nll-problem-case-3-issue-68934.nll.stderr
+++ b/tests/ui/nll/polonius/nll-problem-case-3-issue-68934.nll.stderr
@@ -1,5 +1,5 @@
 error[E0505]: cannot move out of value because it is borrowed
-  --> $DIR/nll-problem-case-3-issue-68934.rs:35:14
+  --> $DIR/nll-problem-case-3-issue-68934.rs:36:14
    |
 LL |     fn deep_fetch(&mut self, value: Either<A, B>) -> Result<&mut Self, (&mut Self, Either<A, B>)> {
    |                   - let's call the lifetime of this reference `'1`

--- a/tests/ui/nll/polonius/nll-problem-case-3-issue-68934.rs
+++ b/tests/ui/nll/polonius/nll-problem-case-3-issue-68934.rs
@@ -8,6 +8,7 @@
 //@ ignore-compare-mode-polonius (explicit revisions)
 //@ revisions: nll polonius legacy
 //@ [nll] known-bug: #68934
+//@ [nll] compile-flags: -Z polonius=off
 //@ [polonius] check-pass
 //@ [polonius] compile-flags: -Z polonius=next
 //@ [legacy] check-pass

--- a/tests/ui/wf/hir-wf-check-erase-regions.nll.stderr
+++ b/tests/ui/wf/hir-wf-check-erase-regions.nll.stderr
@@ -1,5 +1,5 @@
 error[E0277]: `&'a T` is not an iterator
-  --> $DIR/hir-wf-check-erase-regions.rs:11:21
+  --> $DIR/hir-wf-check-erase-regions.rs:12:21
    |
 LL |     type IntoIter = std::iter::Flatten<std::slice::Iter<'a, T>>;
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `&'a T` is not an iterator
@@ -12,7 +12,7 @@ note: required by a bound in `std::iter::IntoIterator::IntoIter`
   --> $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
 
 error[E0277]: `&'a T` is not an iterator
-  --> $DIR/hir-wf-check-erase-regions.rs:11:5
+  --> $DIR/hir-wf-check-erase-regions.rs:12:5
    |
 LL |     type IntoIter = std::iter::Flatten<std::slice::Iter<'a, T>>;
    |     ^^^^^^^^^^^^^ `&'a T` is not an iterator
@@ -25,7 +25,7 @@ note: required by a bound in `Flatten`
   --> $SRC_DIR/core/src/iter/adapters/flatten.rs:LL:COL
 
 error[E0277]: `&'a T` is not an iterator
-  --> $DIR/hir-wf-check-erase-regions.rs:15:27
+  --> $DIR/hir-wf-check-erase-regions.rs:16:27
    |
 LL |     fn into_iter(self) -> Self::IntoIter {
    |                           ^^^^^^^^^^^^^^ `&'a T` is not an iterator
@@ -38,7 +38,7 @@ note: required by a bound in `Flatten`
   --> $SRC_DIR/core/src/iter/adapters/flatten.rs:LL:COL
 
 error[E0277]: `&T` is not an iterator
-  --> $DIR/hir-wf-check-erase-regions.rs:15:27
+  --> $DIR/hir-wf-check-erase-regions.rs:16:27
    |
 LL |     fn into_iter(self) -> Self::IntoIter {
    |                           ^^^^^^^^^^^^^^ `&T` is not an iterator

--- a/tests/ui/wf/hir-wf-check-erase-regions.polonius.stderr
+++ b/tests/ui/wf/hir-wf-check-erase-regions.polonius.stderr
@@ -1,5 +1,5 @@
 error[E0277]: `&'a T` is not an iterator
-  --> $DIR/hir-wf-check-erase-regions.rs:11:21
+  --> $DIR/hir-wf-check-erase-regions.rs:12:21
    |
 LL |     type IntoIter = std::iter::Flatten<std::slice::Iter<'a, T>>;
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `&'a T` is not an iterator
@@ -12,7 +12,7 @@ note: required by a bound in `std::iter::IntoIterator::IntoIter`
   --> $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
 
 error[E0277]: `&'a T` is not an iterator
-  --> $DIR/hir-wf-check-erase-regions.rs:11:5
+  --> $DIR/hir-wf-check-erase-regions.rs:12:5
    |
 LL |     type IntoIter = std::iter::Flatten<std::slice::Iter<'a, T>>;
    |     ^^^^^^^^^^^^^ `&'a T` is not an iterator
@@ -25,7 +25,7 @@ note: required by a bound in `Flatten`
   --> $SRC_DIR/core/src/iter/adapters/flatten.rs:LL:COL
 
 error[E0277]: `&'a T` is not an iterator
-  --> $DIR/hir-wf-check-erase-regions.rs:15:27
+  --> $DIR/hir-wf-check-erase-regions.rs:16:27
    |
 LL |     fn into_iter(self) -> Self::IntoIter {
    |                           ^^^^^^^^^^^^^^ `&'a T` is not an iterator

--- a/tests/ui/wf/hir-wf-check-erase-regions.rs
+++ b/tests/ui/wf/hir-wf-check-erase-regions.rs
@@ -3,6 +3,7 @@
 
 //@ ignore-compare-mode-polonius (explicit revisions)
 //@ revisions: nll polonius
+//@ [nll] compile-flags: -Zpolonius=off
 //@ [polonius] compile-flags: -Zpolonius=next
 
 pub struct Table<T, const N: usize>([Option<T>; N]);


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/159343)*
<!-- homu-ignore:end -->

 See [rust-lang/compiler-team#](https://github.com/rust-lang/compiler-team/issues/1015)

The first commit here adds an `-Zpolonius=nll` argument for tests and so people can disable alpha on nightly.