### PR TITLE
std: upgrade `addr2line`, `object`, `miniz_oxide`

### DIFF
--- a/library/Cargo.lock
+++ b/library/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "addr2line"
-version = "0.25.1"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+checksum = "efe1709241908a54ef1925c6018f41d3f523d0cfe174719761eb39e7b7bf086a"
 dependencies = [
  "gimli",
  "rustc-std-workspace-alloc",
@@ -115,9 +115,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.32.3"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+checksum = "1033caf0b349c518623b5396bfb2cf0bddf44f0306d543a250e5743297aafd10"
 dependencies = [
  "rustc-std-workspace-alloc",
  "rustc-std-workspace-core",
@@ -164,9 +164,9 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.9"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+checksum = "b63fbc4a50860e98e7b2aa7804ded1db5cbc3aff9193adaff57a6931bf7c4b4c"
 dependencies = [
  "adler2",
  "rustc-std-workspace-alloc",
@@ -185,9 +185,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.37.3"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+checksum = "2e5a6c098c7a3b6547378093f5cc30bc54fd361ce711e05293a5cc589562739b"
 dependencies = [
  "memchr",
  "rustc-std-workspace-alloc",
@@ -390,9 +390,9 @@ dependencies = [
 
 [[package]]
 name = "unwinding"
-version = "0.2.8"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60612c845ef41699f39dc8c5391f252942c0a88b7d15da672eff0d14101bbd6d"
+checksum = "4b134ada16dda9e435abe2a6d76a01d497bc60707357845a15f9b0ed42dc88ce"
 dependencies = [
  "gimli",
  "rustc-std-workspace-core",

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -29,8 +29,8 @@ std_detect = { path = "../std_detect", public = true }
 rustc-demangle = { version = "0.1.28", features = ['rustc-dep-of-std'] }
 
 [target.'cfg(not(all(windows, target_env = "msvc", not(target_vendor = "uwp"))))'.dependencies]
-miniz_oxide = { version = "0.8.0", optional = true, default-features = false }
-addr2line = { version = "0.25.0", optional = true, default-features = false }
+miniz_oxide = { version = "0.9.0", optional = true, default-features = false }
+addr2line = { version = "0.27.0", optional = true, default-features = false }
 
 [target.'cfg(not(all(windows, target_env = "msvc")))'.dependencies]
 libc = { version = "0.2.185", default-features = false, features = [
@@ -38,7 +38,7 @@ libc = { version = "0.2.185", default-features = false, features = [
 ], public = true }
 
 [target.'cfg(all(not(target_os = "aix"), not(all(windows, target_env = "msvc", not(target_vendor = "uwp")))))'.dependencies]
-object = { version = "0.37.1", default-features = false, optional = true, features = [
+object = { version = "0.39", default-features = false, optional = true, features = [
     'read_core',
     'elf',
     'macho',
@@ -48,7 +48,7 @@ object = { version = "0.37.1", default-features = false, optional = true, featur
 ] }
 
 [target.'cfg(target_os = "aix")'.dependencies]
-object = { version = "0.37.1", default-features = false, optional = true, features = [
+object = { version = "0.39", default-features = false, optional = true, features = [
     'read_core',
     'xcoff',
     'unaligned',


### PR DESCRIPTION
The `addr2line` upgrade also upgrades `gimli`, and we need a new
`unwinding` to align on that. No code changes are required.

See also rust-lang/backtrace-rs#765, but since `std` uses that as a
`#[path] mod backtrace_rs`, we don't need to wait for the crate update.
