### PR TITLE
fs::hard_link: use linkat on Android

### DIFF
--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -2872,7 +2872,7 @@ pub fn copy<P: AsRef<Path>, Q: AsRef<Path>>(from: P, to: Q) -> io::Result<u64> {
 ///
 /// This function currently corresponds to the `CreateHardLink` function on Windows.
 /// On most Unix systems, it corresponds to the `linkat` function with no flags.
-/// On Android, VxWorks, and Redox, it instead corresponds to the `link` function.
+/// On VxWorks and Redox, it instead corresponds to the `link` function.
 /// On MacOS, it uses the `linkat` function if it is available, but on very old
 /// systems where `linkat` is not available, `link` is selected at runtime instead.
 /// Note that, this [may change in the future][changes].

--- a/library/std/src/sys/fs/unix.rs
+++ b/library/std/src/sys/fs/unix.rs
@@ -2057,9 +2057,6 @@ pub fn link(original: &CStr, link: &CStr) -> io::Result<()> {
             target_os = "vxworks",
             target_os = "redox",
             target_os = "espidf",
-            // Android has `linkat` on newer versions, but we happen to know
-            // `link` always has the correct behavior, so it's here as well.
-            target_os = "android",
             // Other misc platforms
             target_os = "horizon",
             target_os = "vita",

--- a/src/tools/miri/tests/pass/shims/fs.rs
+++ b/src/tools/miri/tests/pass/shims/fs.rs
@@ -49,9 +49,8 @@ fn main() {
     if cfg!(not(windows)) {
         test_directory();
         test_canonicalize();
-        #[cfg(not(target_os = "solaris"))]
+        #[cfg(not(target_os = "solaris"))] // does not have flock
         test_flock();
-        #[cfg(not(target_os = "android"))]
         test_hard_link();
 
         test_readv_writev();
@@ -559,8 +558,6 @@ fn test_preadv_pwritev() {
     assert_eq!(written_bytes.as_slice(), &write_buffer[0..bytes_written]);
 }
 
-// std uses `libc::link` on Android which we do not support.
-#[cfg(not(target_os = "android"))]
 fn test_hard_link() {
     let source = utils::prepare_with_content("miri_test_fs_hard_link_source.txt", b"hello");
     let link = utils::prepare("miri_test_fs_hard_link_link.txt");


### PR DESCRIPTION
According to https://github.com/rust-lang/rust/commit/6249cda78f0cd32b60fb11702b7ffef3e3bab0b2, `linkat` needs API level 21. That is ancient (2014, Android 5). Our [target page](https://doc.rust-lang.org/rustc/platform-support/android.html) does not say which minimum Android version or API level we support, it just says:

> Rust will support the most recent Long Term Support (LTS) Android Native Development Kit (NDK). By default Rust will support all API levels supported by the NDK, but a higher minimum API level may be required if deemed necessary.

That's pretty useless as I have no idea how I'd figure out what the "API levels support by the NDK" are.
Cc @chriswailes @jfgoog @maurer @pirama-arumuga-nainar 

Fixes https://github.com/rust-lang/miri/issues/5080