### PR TITLE
Add regression test for #101363

### DIFF
--- a/tests/ui/consts/promoted-const-tuple-variant-101363.rs
+++ b/tests/ui/consts/promoted-const-tuple-variant-101363.rs
@@ -1,0 +1,19 @@
+//! Regression test for <https://github.com/rust-lang/rust/issues/101363>.
+//! Borrowing the result of a block expression inside a tuple variant
+//! constructor in a `const` used to fail with E0716; it is now promoted.
+
+//@ check-pass
+
+const OPTIONAL_SLICE_V1: Option<&'static [u8]> = Some(&{
+    let array = [1, 2, 3];
+    array
+});
+
+const OPTIONAL_SLICE_V2: Option<&'static [u8]> = Some {
+    0: &{
+        let array = [1, 2, 3];
+        array
+    },
+};
+
+fn main() {}


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
Adds a regression test for rust-lang/rust#101363: borrowing a block expression inside
a tuple variant constructor in a `const` now compiles. Test passes locally.

Closes rust-lang/rust#101363
