### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
@@ -4258,9 +4258,11 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                         err.span_note(spans, msg);
                         if derived && trait_name != "Copy" {
                             err.help(format!(
-                                "consider manually implementing `{trait_name}` to avoid undesired \
-                                 bounds",
+                                "consider manually implementing `{trait_name}` to avoid undesired bounds caused by \"imperfect derives\"",
                             ));
+                            err.note(
+                                "to learn more, visit <https://github.com/rust-lang/rust/issues/26925>",
+                            );
                         }
                         point_at_assoc_type_restriction(
                             tcx,

--- a/library/Cargo.lock
+++ b/library/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "addr2line"
-version = "0.25.1"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+checksum = "efe1709241908a54ef1925c6018f41d3f523d0cfe174719761eb39e7b7bf086a"
 dependencies = [
  "gimli",
  "rustc-std-workspace-alloc",
@@ -115,9 +115,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.32.3"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+checksum = "1033caf0b349c518623b5396bfb2cf0bddf44f0306d543a250e5743297aafd10"
 dependencies = [
  "rustc-std-workspace-alloc",
  "rustc-std-workspace-core",
@@ -164,9 +164,9 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.9"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+checksum = "b63fbc4a50860e98e7b2aa7804ded1db5cbc3aff9193adaff57a6931bf7c4b4c"
 dependencies = [
  "adler2",
  "rustc-std-workspace-alloc",
@@ -185,9 +185,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.37.3"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+checksum = "2e5a6c098c7a3b6547378093f5cc30bc54fd361ce711e05293a5cc589562739b"
 dependencies = [
  "memchr",
  "rustc-std-workspace-alloc",
@@ -390,9 +390,9 @@ dependencies = [
 
 [[package]]
 name = "unwinding"
-version = "0.2.8"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60612c845ef41699f39dc8c5391f252942c0a88b7d15da672eff0d14101bbd6d"
+checksum = "4b134ada16dda9e435abe2a6d76a01d497bc60707357845a15f9b0ed42dc88ce"
 dependencies = [
  "gimli",
  "rustc-std-workspace-core",

--- a/library/core/src/attribute_docs.rs
+++ b/library/core/src/attribute_docs.rs
@@ -445,3 +445,52 @@ mod no_std_attribute {}
 ///
 /// [the `inline` attribute]: ../reference/attributes/codegen.html#the-inline-attribute
 mod inline_attribute {}
+
+#[doc(attribute = "proc_macro")]
+//
+/// Defines a function-like procedural macro.
+///
+/// Applied to a `pub` function at the root of a proc-macro crate, `proc_macro` makes that function usable as a macro invoked as
+/// `foo!(...)` in other crates. The function receives the tokens written inside the invocation as a [`TokenStream`] and returns
+/// the [`TokenStream`] that replaces the invocation:
+///
+/// ```rust, ignore (requires depending on the proc-macro crate)
+/// # extern crate proc_macro;
+/// use proc_macro::TokenStream;
+///
+/// #[proc_macro]
+/// pub fn foo(input: TokenStream) -> TokenStream {
+///    "fn answer() -> u32 { 67 }".parse().unwrap()
+/// }
+/// ```
+///
+/// The macro can only be invoked from other crates, not from the crate where it is defined:
+///
+/// ```rust,ignore (requires depending on the proc-macro crate)
+/// use my_macro_crate::foo;
+///
+/// // Expands to `fn answer() -> u32 { 67 }`.
+/// foo!();
+///
+/// fn main() {
+///    println!("{}", answer()); // Prints 67
+/// }
+/// ```
+///
+/// The attribute is only usable with crates of the `proc-macro` crate type, which is set in the crate's `Cargo.toml`
+/// with `proc-macro = true` in the `[lib]` section. Using it anywhere else is a compilation error:
+///
+/// ```text
+///error: the `#[proc_macro]` attribute is only usable with crates of the `proc-macro` crate type
+/// --> src/lib.rs:4:1
+///  |
+/// 4| #[proc_macro]
+///  | ^^^^^^^^^^^^
+/// ```
+///
+/// For more information, see the Reference on [function-like procedural macros] and the [`proc_macro`] crate documentation.
+///
+/// [`TokenStream`]: ../proc_macro/struct.TokenStream.html
+/// [function-like procedural macros]: ../reference/procedural-macros.html#the-proc_macro-attribute
+/// [`proc_macro`]: ../proc_macro/index.html
+mod proc_macro_attribute {}

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -29,8 +29,8 @@ std_detect = { path = "../std_detect", public = true }
 rustc-demangle = { version = "0.1.28", features = ['rustc-dep-of-std'] }
 
 [target.'cfg(not(all(windows, target_env = "msvc", not(target_vendor = "uwp"))))'.dependencies]
-miniz_oxide = { version = "0.8.0", optional = true, default-features = false }
-addr2line = { version = "0.25.0", optional = true, default-features = false }
+miniz_oxide = { version = "0.9.0", optional = true, default-features = false }
+addr2line = { version = "0.27.0", optional = true, default-features = false }
 
 [target.'cfg(not(all(windows, target_env = "msvc")))'.dependencies]
 libc = { version = "0.2.185", default-features = false, features = [
@@ -38,7 +38,7 @@ libc = { version = "0.2.185", default-features = false, features = [
 ], public = true }
 
 [target.'cfg(all(not(target_os = "aix"), not(all(windows, target_env = "msvc", not(target_vendor = "uwp")))))'.dependencies]
-object = { version = "0.37.1", default-features = false, optional = true, features = [
+object = { version = "0.39", default-features = false, optional = true, features = [
     'read_core',
     'elf',
     'macho',
@@ -48,7 +48,7 @@ object = { version = "0.37.1", default-features = false, optional = true, featur
 ] }
 
 [target.'cfg(target_os = "aix")'.dependencies]
-object = { version = "0.37.1", default-features = false, optional = true, features = [
+object = { version = "0.39", default-features = false, optional = true, features = [
     'read_core',
     'xcoff',
     'unaligned',

--- a/tests/ui/associated-types/issue-38821.stderr
+++ b/tests/ui/associated-types/issue-38821.stderr
@@ -108,7 +108,8 @@ LL | pub enum ColumnInsertValue<Col, Expr> where
 ...
 LL |     Expr: Expression<SqlType=<Col::SqlType as IntoNullable>::Nullable>,
    |                      ------------------------------------------------ unsatisfied trait bound
-   = help: consider manually implementing `Debug` to avoid undesired bounds
+   = help: consider manually implementing `Debug` to avoid undesired bounds caused by "imperfect derives"
+   = note: to learn more, visit <https://github.com/rust-lang/rust/issues/26925>
 help: consider further restricting the associated type
    |
 LL |     Expr: Expression<SqlType=<Col::SqlType as IntoNullable>::Nullable>, <Col as Expression>::SqlType: NotNull,
@@ -238,7 +239,8 @@ LL | pub enum ColumnInsertValue<Col, Expr> where
 ...
 LL |     Expr: Expression<SqlType=<Col::SqlType as IntoNullable>::Nullable>,
    |                      ------------------------------------------------ unsatisfied trait bound
-   = help: consider manually implementing `Clone` to avoid undesired bounds
+   = help: consider manually implementing `Clone` to avoid undesired bounds caused by "imperfect derives"
+   = note: to learn more, visit <https://github.com/rust-lang/rust/issues/26925>
 help: consider further restricting the associated type
    |
 LL |     Expr: Expression<SqlType=<Col::SqlType as IntoNullable>::Nullable>, <Col as Expression>::SqlType: NotNull,

--- a/tests/ui/const-generics/adt_const_params/unsizing-wfcheck-issue-126272.stderr
+++ b/tests/ui/const-generics/adt_const_params/unsizing-wfcheck-issue-126272.stderr
@@ -67,7 +67,8 @@ LL | #[derive(Debug, PartialEq, Eq, ConstParamTy)]
    |          ----- in this derive macro expansion
 LL | struct Bar<T>(T);
    |        ^^^ - unsatisfied trait bound
-   = help: consider manually implementing `Debug` to avoid undesired bounds
+   = help: consider manually implementing `Debug` to avoid undesired bounds caused by "imperfect derives"
+   = note: to learn more, visit <https://github.com/rust-lang/rust/issues/26925>
    = note: 2 redundant requirements hidden
    = note: required for `&&'static Bar<(dyn Debug + 'static)>` to implement `Debug`
    = note: required for the cast from `&&&'static Bar<(dyn Debug + 'static)>` to `&dyn Debug`
@@ -102,7 +103,8 @@ LL | #[derive(Debug, PartialEq, Eq, ConstParamTy)]
    |                            -- in this derive macro expansion
 LL | struct Bar<T>(T);
    |        ^^^ - type parameter would need to implement `Eq`
-   = help: consider manually implementing `Eq` to avoid undesired bounds
+   = help: consider manually implementing `Eq` to avoid undesired bounds caused by "imperfect derives"
+   = note: to learn more, visit <https://github.com/rust-lang/rust/issues/26925>
    = note: 1 redundant requirement hidden
    = note: required for `&'static Bar<dyn Debug>` to implement `Eq`
 note: required by a bound in `std::cmp::AssertParamIsEq`

--- a/tests/ui/derives/clone-copy/deriving-copyclone.stderr
+++ b/tests/ui/derives/clone-copy/deriving-copyclone.stderr
@@ -38,7 +38,8 @@ LL | #[derive(Copy, Clone)]
    |                ----- in this derive macro expansion
 LL | struct B<T> {
    |        ^ - type parameter would need to implement `Clone`
-   = help: consider manually implementing `Clone` to avoid undesired bounds
+   = help: consider manually implementing `Clone` to avoid undesired bounds caused by "imperfect derives"
+   = note: to learn more, visit <https://github.com/rust-lang/rust/issues/26925>
 note: required by a bound in `is_clone`
   --> $DIR/deriving-copyclone.rs:19:16
    |

--- a/tests/ui/derives/redundant-derive-note-on-unimplemented.stderr
+++ b/tests/ui/derives/redundant-derive-note-on-unimplemented.stderr
@@ -21,7 +21,8 @@ LL | #[derive(Debug)]
    |          ----- in this derive macro expansion
 LL | struct S<T>(T);
    |        ^ - type parameter would need to implement `Debug`
-   = help: consider manually implementing `Debug` to avoid undesired bounds
+   = help: consider manually implementing `Debug` to avoid undesired bounds caused by "imperfect derives"
+   = note: to learn more, visit <https://github.com/rust-lang/rust/issues/26925>
 help: consider annotating `X` with `#[derive(Debug)]`
    |
 LL + #[derive(Debug)]

--- a/tests/ui/proc-macro/issue-104884-trait-impl-sugg-err.stderr
+++ b/tests/ui/proc-macro/issue-104884-trait-impl-sugg-err.stderr
@@ -44,7 +44,8 @@ LL | #[derive(PartialOrd, AddImpl)]
 ...
 LL | struct PriorityQueue<T>(BinaryHeap<PriorityQueueEntry<T>>);
    |        ^^^^^^^^^^^^^ - type parameter would need to implement `PartialOrd`
-   = help: consider manually implementing `PartialOrd` to avoid undesired bounds
+   = help: consider manually implementing `PartialOrd` to avoid undesired bounds caused by "imperfect derives"
+   = note: to learn more, visit <https://github.com/rust-lang/rust/issues/26925>
 note: required by a bound in `Ord`
   --> $SRC_DIR/core/src/cmp.rs:LL:COL
 

--- a/tests/ui/suggestions/missing-bound-in-derive-copy-impl-2.stderr
+++ b/tests/ui/suggestions/missing-bound-in-derive-copy-impl-2.stderr
@@ -30,7 +30,8 @@ LL | #[derive(Debug, Copy, Clone)]
    |          ----- in this derive macro expansion
 LL | pub struct Vector2<T: Debug + Copy + Clone> {
    |            ^^^^^^^            ---- unsatisfied trait bound
-   = help: consider manually implementing `Debug` to avoid undesired bounds
+   = help: consider manually implementing `Debug` to avoid undesired bounds caused by "imperfect derives"
+   = note: to learn more, visit <https://github.com/rust-lang/rust/issues/26925>
    = note: required for the cast from `&Vector2<K>` to `&dyn Debug`
 help: consider further restricting type parameter `K` with trait `Copy`
    |
@@ -72,7 +73,8 @@ LL | #[derive(Debug, Copy, Clone)]
    |                       ----- in this derive macro expansion
 LL | pub struct Vector2<T: Debug + Copy + Clone> {
    |            ^^^^^^^            ---- unsatisfied trait bound
-   = help: consider manually implementing `Clone` to avoid undesired bounds
+   = help: consider manually implementing `Clone` to avoid undesired bounds caused by "imperfect derives"
+   = note: to learn more, visit <https://github.com/rust-lang/rust/issues/26925>
 help: consider further restricting type parameter `K` with trait `Copy`
    |
 LL | pub struct AABB<K: Debug + std::marker::Copy> {

--- a/tests/ui/suggestions/missing-bound-in-derive-copy-impl.stderr
+++ b/tests/ui/suggestions/missing-bound-in-derive-copy-impl.stderr
@@ -66,7 +66,8 @@ LL | #[derive(Debug, Copy, Clone)]
    |          ----- in this derive macro expansion
 LL | pub struct Vector2<T: Debug + Copy + Clone> {
    |            ^^^^^^^            ---- unsatisfied trait bound
-   = help: consider manually implementing `Debug` to avoid undesired bounds
+   = help: consider manually implementing `Debug` to avoid undesired bounds caused by "imperfect derives"
+   = note: to learn more, visit <https://github.com/rust-lang/rust/issues/26925>
    = note: required for the cast from `&Vector2<K>` to `&dyn Debug`
 help: consider restricting type parameter `K` with trait `Copy`
    |
@@ -136,7 +137,8 @@ LL | #[derive(Debug, Copy, Clone)]
    |                       ----- in this derive macro expansion
 LL | pub struct Vector2<T: Debug + Copy + Clone> {
    |            ^^^^^^^            ---- unsatisfied trait bound
-   = help: consider manually implementing `Clone` to avoid undesired bounds
+   = help: consider manually implementing `Clone` to avoid undesired bounds caused by "imperfect derives"
+   = note: to learn more, visit <https://github.com/rust-lang/rust/issues/26925>
 help: consider restricting type parameter `K` with trait `Copy`
    |
 LL | pub struct AABB<K: std::marker::Copy> {

--- a/tests/ui/traits/derive-implicit-bound.stderr
+++ b/tests/ui/traits/derive-implicit-bound.stderr
@@ -14,7 +14,8 @@ LL | #[derive(PartialEq, Eq)]
    |          --------- in this derive macro expansion
 LL | pub struct Id<T>(PhantomData<T>);
    |            ^^ - type parameter would need to implement `PartialEq`
-   = help: consider manually implementing `PartialEq` to avoid undesired bounds
+   = help: consider manually implementing `PartialEq` to avoid undesired bounds caused by "imperfect derives"
+   = note: to learn more, visit <https://github.com/rust-lang/rust/issues/26925>
 note: required by a bound in `accept_eq`
   --> $DIR/derive-implicit-bound.rs:17:23
    |


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#158764 (Improve E0277 for imperfect derives)
 - rust-lang/rust#159345 (std: upgrade `addr2line`, `object`, `miniz_oxide`)
 - rust-lang/rust#158962 (Add `proc_macro` attribute documentation)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=158764,159345,158962)
<!-- homu-ignore:end -->

