### PR TITLE
SROA: bound fixpoint iterations for self-referential types

### DIFF
--- a/compiler/rustc_mir_transform/src/sroa.rs
+++ b/compiler/rustc_mir_transform/src/sroa.rs
@@ -12,6 +12,9 @@ use tracing::{debug, instrument};
 
 use crate::patch::MirPatch;
 
+// Bound fixpoint iterations to avoid non-termination on self-referential types.
+const SROA_ITERATION_LIMIT: usize = 10;
+
 pub(super) struct ScalarReplacementOfAggregates;
 
 impl<'tcx> crate::MirPass<'tcx> for ScalarReplacementOfAggregates {
@@ -30,7 +33,7 @@ impl<'tcx> crate::MirPass<'tcx> for ScalarReplacementOfAggregates {
 
         let mut excluded = excluded_locals(body);
         let typing_env = body.typing_env(tcx);
-        loop {
+        for _ in 0..SROA_ITERATION_LIMIT {
             debug!(?excluded);
             let escaping = escaping_locals(tcx, &excluded, body);
             debug!(?escaping);

--- a/tests/ui/mir/sroa-self-referential-hang.rs
+++ b/tests/ui/mir/sroa-self-referential-hang.rs
@@ -1,0 +1,23 @@
+//@ check-pass
+//@ compile-flags: -Zmir-opt-level=0 -Zmir-enable-passes=+ScalarReplacementOfAggregates
+
+// Regression test for #153205.
+// Tests that SROA does not loop forever on self-referential types.
+
+trait Apply {
+    type Output<T>;
+}
+struct Identity;
+impl Apply for Identity {
+    type Output<T> = T;
+}
+
+struct Thing<A: Apply>(A::Output<Self>);
+
+fn foo<A: Apply>() {
+    let _x: Thing<A>;
+}
+
+fn main() {
+    foo::<Identity>();
+}


### PR DESCRIPTION
## Description

Fixes rust-lang/rust#153205.

Self-referential aggregate types can cause SROA to repeatedly introduce equivalent locals, preventing the fixpoint loop from converging.

Bound the number of SROA fixpoint iterations. Since SROA is an optimization pass, stopping early is still correct and simply leaves some aggregates unflattened.

## Testing

- Added a regression test for the reported reproducer.
- Verified the reproducer hangs without the fix and completes with it.
- Ran the relevant MIR optimization tests.