### PR TITLE
[crater experiment] lint against `Struct { .. }` when `Struct` has all private fields

### DIFF
--- a/compiler/rustc_attr_parsing/src/attributes/stability.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/stability.rs
@@ -1,6 +1,5 @@
 use std::num::NonZero;
 
-use rustc_errors::ErrorGuaranteed;
 use rustc_feature::{ACCEPTED_LANG_FEATURES, AttributeStability};
 use rustc_hir::attrs::UnstableRemovedFeature;
 use rustc_hir::target::GenericParamKind;
@@ -348,7 +347,7 @@ pub(crate) fn parse_stability(
             let level = StabilityLevel::Stable { since, allowed_through_unstable_modules: None };
             Some((feature, level))
         }
-        Err(ErrorGuaranteed { .. }) => None,
+        Err(_) => None,
     }
 }
 
@@ -452,7 +451,7 @@ pub(crate) fn parse_unstability(
             };
             Some((feature, level))
         }
-        (Err(ErrorGuaranteed { .. }), _) | (_, Err(ErrorGuaranteed { .. })) => None,
+        (Err(_), _) | (_, Err(_)) => None,
     }
 }
 

--- a/compiler/rustc_borrowck/src/type_check/liveness/trace.rs
+++ b/compiler/rustc_borrowck/src/type_check/liveness/trace.rs
@@ -10,7 +10,7 @@ use rustc_mir_dataflow::impls::MaybeInitializedPlaces;
 use rustc_mir_dataflow::move_paths::{HasMoveData, MoveData, MovePathIndex};
 use rustc_mir_dataflow::points::{DenseLocationMap, PointIndex};
 use rustc_mir_dataflow::{Analysis, ResultsCursor};
-use rustc_span::{DUMMY_SP, ErrorGuaranteed, Span};
+use rustc_span::{DUMMY_SP, Span};
 use rustc_trait_selection::error_reporting::InferCtxtErrorExt;
 use rustc_trait_selection::traits::ObligationCtxt;
 use rustc_trait_selection::traits::outlives_for_liveness::FreeRegionsVisitor;
@@ -644,7 +644,7 @@ impl<'tcx> LivenessContext<'_, '_, 'tcx> {
             Ok(TypeOpOutput { output, constraints, .. }) => {
                 DropData { dropck_result: output, region_constraint_data: constraints }
             }
-            Err(ErrorGuaranteed { .. }) => {
+            Err(_) => {
                 // We don't run dropck on HIR, and dropck looks inside fields of
                 // types, so there's no guarantee that it succeeds. We also
                 // can't rely on the `ErrorGuaranteed` from `fully_perform` here

--- a/compiler/rustc_hir_analysis/src/check/check.rs
+++ b/compiler/rustc_hir_analysis/src/check/check.rs
@@ -1303,7 +1303,7 @@ fn check_impl_items_against_trait<'tcx>(
         let ty_impl_item = tcx.associated_item(impl_item);
         let ty_trait_item = match ty_impl_item.expect_trait_impl() {
             Ok(trait_item_id) => tcx.associated_item(trait_item_id),
-            Err(ErrorGuaranteed { .. }) => continue,
+            Err(_) => continue,
         };
 
         let res = tcx.ensure_result().compare_impl_item(impl_item.expect_local());

--- a/compiler/rustc_hir_analysis/src/check/wfcheck.rs
+++ b/compiler/rustc_hir_analysis/src/check/wfcheck.rs
@@ -2069,7 +2069,7 @@ pub(super) fn check_variances_for_type_defn<'tcx>(tcx: TyCtxt<'tcx>, def_id: Loc
         }
 
         // Look for `ErrorGuaranteed` deeply within this type.
-        if let ControlFlow::Break(ErrorGuaranteed { .. }) = tcx
+        if let ControlFlow::Break(_) = tcx
             .type_of(def_id)
             .instantiate_identity()
             .skip_norm_wip()

--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -3258,10 +3258,19 @@ impl<'tcx> LateLintPass<'tcx> for RestPatternMatchOnStructWithAllPrivateFields {
             };
 
             if all_private {
+                let def_did = adt_def.did();
+                let decorator = if let Some(def_span) = tcx.hir_span_if_local(def_did) {
+                    RestPatternUsedOnStructWithAllPrivateFields::Local(def_span)
+                } else {
+                    RestPatternUsedOnStructWithAllPrivateFields::Foreign(
+                        tcx.crate_name(def_did.krate),
+                    )
+                };
+
                 cx.emit_span_lint(
                     REST_PATTERN_MATCH_ON_STRUCT_WITH_ALL_PRIVATE_FIELDS,
                     pat.span,
-                    RestPatternUsedOnStructWithAllPrivateFields,
+                    decorator,
                 );
             }
         }

--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -33,7 +33,7 @@ use rustc_middle::bug;
 use rustc_middle::ty::layout::LayoutOf;
 use rustc_middle::ty::print::with_no_trimmed_paths;
 use rustc_middle::ty::{
-    self, AssocContainer, Ty, TyCtxt, TypeVisitableExt, Unnormalized, Upcast, VariantDef,
+    self, AdtFlags, AssocContainer, Ty, TyCtxt, TypeVisitableExt, Unnormalized, Upcast, VariantDef,
 };
 // hardwired lints from rustc_lint_defs
 pub use rustc_session::lint::builtin::*;
@@ -59,6 +59,7 @@ use crate::lints::{
     BuiltinUngatedAsyncFnTrackCaller, BuiltinUnpermittedTypeInit, BuiltinUnpermittedTypeInitSub,
     BuiltinUnreachablePub, BuiltinUnsafe, BuiltinUnstableFeatures, BuiltinUnusedDocComment,
     BuiltinUnusedDocCommentSub, BuiltinWhileTrue, EqInternalMethodImplemented, InvalidAsmLabel,
+    RestPatternUsedOnStructWithAllPrivateFields,
 };
 use crate::{EarlyContext, EarlyLintPass, LateContext, LateLintPass, LintContext};
 
@@ -3189,6 +3190,80 @@ impl<'tcx> LateLintPass<'tcx> for InternalEqTraitMethodImpls {
                 item.span,
                 EqInternalMethodImplemented,
             );
+        }
+    }
+}
+
+declare_lint! {
+    /// WIP for crater
+    ///
+    /// ### Example
+    ///
+    /// ```rust
+    /// mod inner {
+    ///     pub struct Foo {
+    ///         cant_see_me: i32,
+    ///     }
+    /// }
+    ///
+    /// use inner::Foo;
+    ///
+    /// fn test(foo: Foo) {
+    ///     match foo {
+    ///         Foo { .. } => (),
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// {{produces}}
+    ///
+    /// ### Recommended fix
+    ///
+    /// WIP
+    ///
+    /// ### Explanation
+    ///
+    /// WIP
+    pub REST_PATTERN_MATCH_ON_STRUCT_WITH_ALL_PRIVATE_FIELDS,
+    Deny,
+    "WIP for CRATER",
+}
+
+declare_lint_pass!(RestPatternMatchOnStructWithAllPrivateFields => [REST_PATTERN_MATCH_ON_STRUCT_WITH_ALL_PRIVATE_FIELDS]);
+
+impl<'tcx> LateLintPass<'tcx> for RestPatternMatchOnStructWithAllPrivateFields {
+    fn check_pat(&mut self, cx: &LateContext<'tcx>, pat: &'tcx rustc_hir::Pat<'tcx>) {
+        let tcx = cx.tcx;
+        if let PatKind::Struct(ref qpath, [], Some(_)) = pat.kind
+            && cx.typeck_results().tainted_by_errors.is_none()
+        {
+            let adt_def = cx
+                .typeck_results()
+                .pat_ty(pat)
+                .ty_adt_def()
+                .expect("struct pattern type is not an ADT");
+
+            if adt_def.flags().contains(AdtFlags::IS_ENUM) {
+                return;
+            }
+
+            let variant = adt_def.variant_of_res(cx.qpath_res(qpath, pat.hir_id));
+
+            let all_private = if variant.fields.is_empty() {
+                variant.field_list_has_applicable_non_exhaustive()
+            } else {
+                variant.fields.iter().all(|field| {
+                    !field.vis.is_accessible_from(tcx.parent_module(pat.hir_id).to_def_id(), tcx)
+                })
+            };
+
+            if all_private {
+                cx.emit_span_lint(
+                    REST_PATTERN_MATCH_ON_STRUCT_WITH_ALL_PRIVATE_FIELDS,
+                    pat.span,
+                    RestPatternUsedOnStructWithAllPrivateFields,
+                );
+            }
         }
     }
 }

--- a/compiler/rustc_lint/src/lib.rs
+++ b/compiler/rustc_lint/src/lib.rs
@@ -273,6 +273,7 @@ late_lint_methods!(
             InternalEqTraitMethodImpls: InternalEqTraitMethodImpls,
             ImplicitProvenanceCasts: ImplicitProvenanceCasts,
             CVoidReturns: CVoidReturns,
+            RestPatternMatchOnStructWithAllPrivateFields: RestPatternMatchOnStructWithAllPrivateFields,
         ]
     ]
 );

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -3038,6 +3038,20 @@ pub(crate) enum Ptr2IntSuggestion<'tcx> {
     },
 }
 
-#[derive(Diagnostic)]
-#[diag("crater fail!!!!")]
-pub(crate) struct RestPatternUsedOnStructWithAllPrivateFields;
+pub(crate) enum RestPatternUsedOnStructWithAllPrivateFields {
+    Local(Span),
+    Foreign(Symbol),
+}
+
+impl<'a> Diagnostic<'a, ()> for RestPatternUsedOnStructWithAllPrivateFields {
+    fn into_diag(self, dcx: DiagCtxtHandle<'a>, level: Level) -> Diag<'a, ()> {
+        let mut diag =
+            Diag::new(dcx, level, msg!("crater fail !! problematic pattern detected !!"));
+        match self {
+            Self::Local(span) => diag.span_note(span, msg!("the type is defined here")),
+            Self::Foreign(symbol) => diag.note(format!("the type is defined in crate `{symbol}`")),
+        };
+
+        diag
+    }
+}

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -3037,3 +3037,7 @@ pub(crate) enum Ptr2IntSuggestion<'tcx> {
         cast_span: Span,
     },
 }
+
+#[derive(Diagnostic)]
+#[diag("crater fail!!!!")]
+pub(crate) struct RestPatternUsedOnStructWithAllPrivateFields;

--- a/compiler/rustc_trait_selection/src/traits/project.rs
+++ b/compiler/rustc_trait_selection/src/traits/project.rs
@@ -1016,7 +1016,7 @@ fn assemble_candidates_from_impls<'cx, 'tcx>(
                     // Always project `ErrorGuaranteed`, since this will just help
                     // us propagate `TyKind::Error` around which suppresses ICEs
                     // and spurious, unrelated inference errors.
-                    Err(ErrorGuaranteed { .. }) => true,
+                    Err(_) => true,
                 }
             }
             ImplSource::Builtin(BuiltinImplSource::Misc | BuiltinImplSource::Trivial, _) => {


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/159356)*
<!-- homu-ignore:end -->

Draft as this is just a Crater experiment, and should not be merged.

Deny-by-default lint on `Struct { .. }` patterns where `Struct` has only fields not visible from the location of the pattern (if it has no fields, it must be from a foreign crate and `#[non_exhaustive]`). This is to gather data to inform https://github.com/rust-lang/rfcs/pull/3753.

@rustbot label A-patterns T-lang
@rustbot ready
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
r? compiler