### PR TITLE
Add regression tests for two fixed issues

### DIFF
--- a/tests/ui/associated-consts/assoc-const-equality-region-var-hash-ice.rs
+++ b/tests/ui/associated-consts/assoc-const-equality-region-var-hash-ice.rs
@@ -1,0 +1,17 @@
+//! Regression test for <https://github.com/rust-lang/rust/issues/148620>.
+
+trait Trait<'a> {
+    const K: &'a ();
+}
+
+fn foo() -> dyn Trait<'r, K = {}> {
+    //~^ ERROR use of undeclared lifetime name `'r`
+    //~| ERROR associated const equality is incomplete
+    {
+        6
+        //~^ ERROR mismatched types
+    }
+    5
+}
+
+fn main() {}

--- a/tests/ui/associated-consts/assoc-const-equality-region-var-hash-ice.stderr
+++ b/tests/ui/associated-consts/assoc-const-equality-region-var-hash-ice.stderr
@@ -1,0 +1,41 @@
+error[E0261]: use of undeclared lifetime name `'r`
+  --> $DIR/assoc-const-equality-region-var-hash-ice.rs:7:23
+   |
+LL | fn foo() -> dyn Trait<'r, K = {}> {
+   |                       ^^ undeclared lifetime
+   |
+   = note: for more information on higher-ranked polymorphism, visit https://doc.rust-lang.org/nomicon/hrtb.html
+help: consider making the bound lifetime-generic with a new `'r` lifetime
+   |
+LL | fn foo() -> dyn for<'r> Trait<'r, K = {}> {
+   |                 +++++++
+help: consider introducing lifetime `'r` here
+   |
+LL | fn foo<'r>() -> dyn Trait<'r, K = {}> {
+   |       ++++
+
+error[E0658]: associated const equality is incomplete
+  --> $DIR/assoc-const-equality-region-var-hash-ice.rs:7:27
+   |
+LL | fn foo() -> dyn Trait<'r, K = {}> {
+   |                           ^^^^^^
+   |
+   = note: see issue #132980 <https://github.com/rust-lang/rust/issues/132980> for more information
+   = help: add `#![feature(min_generic_const_args)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0308]: mismatched types
+  --> $DIR/assoc-const-equality-region-var-hash-ice.rs:11:9
+   |
+LL |         6
+   |         ^ expected `()`, found integer
+   |
+help: you might have meant to return this value
+   |
+LL |         return 6;
+   |         ++++++  +
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0261, E0308, E0658.
+For more information about an error, try `rustc --explain E0261`.

--- a/tests/ui/const-generics/defaults/const-param-default-body-param-env-ice.rs
+++ b/tests/ui/const-generics/defaults/const-param-default-body-param-env-ice.rs
@@ -1,0 +1,15 @@
+//! Regression test for <https://github.com/rust-lang/rust/issues/148096>.
+
+impl<const N: usize = { || [0; X] }, X> dyn PartialEq<X> {}
+//~^ ERROR generic parameters with a default must be trailing
+//~| ERROR generic parameter defaults cannot reference parameters before they are declared
+//~| ERROR defaults for generic parameters are not allowed here
+//~| ERROR the const parameter `N` is not constrained by the impl trait, self type, or predicates
+//~| ERROR cannot define inherent `impl` for a type outside of the crate where the type is defined
+
+fn foo() {}
+
+pub struct S<const N: usize = { const { [1; foo] } }>;
+//~^ ERROR mismatched types
+
+fn main() {}

--- a/tests/ui/const-generics/defaults/const-param-default-body-param-env-ice.stderr
+++ b/tests/ui/const-generics/defaults/const-param-default-body-param-env-ice.stderr
@@ -1,0 +1,50 @@
+error: generic parameters with a default must be trailing
+  --> $DIR/const-param-default-body-param-env-ice.rs:3:12
+   |
+LL | impl<const N: usize = { || [0; X] }, X> dyn PartialEq<X> {}
+   |            ^
+
+error[E0128]: generic parameter defaults cannot reference parameters before they are declared
+  --> $DIR/const-param-default-body-param-env-ice.rs:3:32
+   |
+LL | impl<const N: usize = { || [0; X] }, X> dyn PartialEq<X> {}
+   |                                ^ cannot reference `X` before it is declared
+
+error: defaults for generic parameters are not allowed here
+  --> $DIR/const-param-default-body-param-env-ice.rs:3:6
+   |
+LL | impl<const N: usize = { || [0; X] }, X> dyn PartialEq<X> {}
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0207]: the const parameter `N` is not constrained by the impl trait, self type, or predicates
+  --> $DIR/const-param-default-body-param-env-ice.rs:3:6
+   |
+LL | impl<const N: usize = { || [0; X] }, X> dyn PartialEq<X> {}
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unconstrained const parameter
+   |
+   = note: expressions using a const parameter must map each value to a distinct output value
+   = note: proving the result of expressions other than the parameter are unique is not supported
+
+error[E0308]: mismatched types
+  --> $DIR/const-param-default-body-param-env-ice.rs:12:45
+   |
+LL | pub struct S<const N: usize = { const { [1; foo] } }>;
+   |                                             ^^^ expected `usize`, found fn item
+   |
+   = note: expected type `usize`
+           found fn item `fn() {foo}`
+   = note: array length can only be `usize`
+
+error[E0116]: cannot define inherent `impl` for a type outside of the crate where the type is defined
+  --> $DIR/const-param-default-body-param-env-ice.rs:3:1
+   |
+LL | impl<const N: usize = { || [0; X] }, X> dyn PartialEq<X> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl for type defined outside of crate
+   |
+   = help: consider defining a trait and implementing it for the type or using a newtype wrapper like `struct MyType(ExternalType);` and implement it
+   = note: for more details about the orphan rules, see <https://doc.rust-lang.org/reference/items/implementations.html?highlight=orphan#orphan-rules>
+
+error: aborting due to 6 previous errors
+
+Some errors have detailed explanations: E0116, E0128, E0207, E0308.
+For more information about an error, try `rustc --explain E0116`.


### PR DESCRIPTION
This PR adds two regression tests for two ICE issues that have been identified as fixed and marked with E-needs-test.

Closes rust-lang/rust#148096.
Closes rust-lang/rust#148620.