### PR TITLE
Add regression test for #120328

### DIFF
--- a/tests/ui/traits/next-solver/closure-capture-in-loop-120328.rs
+++ b/tests/ui/traits/next-solver/closure-capture-in-loop-120328.rs
@@ -1,0 +1,13 @@
+//@ compile-flags: -Znext-solver
+//@ edition: 2021
+//@ check-pass
+
+// Regression test for <https://github.com/rust-lang/rust/issues/120328>.
+// Closures capturing an iterated variable in edition 2021 used to ICE
+// with the next trait solver during MIR building.
+
+fn main() {
+    for item in &[1, 2, 3] {
+        let _ = || *item;
+    }
+}


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Adds a regression test for rust-lang/rust#120328: closures capturing an iterated variable
in edition 2021 used to ICE with `-Znext-solver=globally` during MIR building.
The ICE no longer reproduces. Test passes locally on x86_64-pc-windows-gnu.

Closes rust-lang/rust#120328
