### PR TITLE
Convert `ParseNtResult` into `TokenStream` earlier

### DIFF
--- a/compiler/rustc_expand/src/lib.rs
+++ b/compiler/rustc_expand/src/lib.rs
@@ -7,6 +7,7 @@
 #![feature(proc_macro_internals)]
 #![feature(try_blocks)]
 #![feature(yeet_expr)]
+#![recursion_limit = "256"]
 // tidy-alphabetical-end
 
 mod build;

--- a/compiler/rustc_expand/src/mbe/transcribe.rs
+++ b/compiler/rustc_expand/src/mbe/transcribe.rs
@@ -1,10 +1,9 @@
 use std::mem;
 
 use rustc_ast::token::{
-    self, Delimiter, IdentIsRaw, InvisibleOrigin, Lit, LitKind, MetaVarKind, Token, TokenKind,
+    self, Delimiter, IdentIsRaw, InvisibleOrigin, Lit, LitKind, Token, TokenKind,
 };
 use rustc_ast::tokenstream::{DelimSpacing, DelimSpan, Spacing, TokenStream, TokenTree};
-use rustc_ast::{ExprKind, StmtKind, TyKind, UnOp};
 use rustc_data_structures::fx::FxHashMap;
 use rustc_errors::{Diag, DiagCtxtHandle, PResult, listify, pluralize};
 use rustc_parse::lexer::nfc_normalize;
@@ -12,8 +11,7 @@ use rustc_parse::parser::ParseNtResult;
 use rustc_session::parse::ParseSess;
 use rustc_span::hygiene::{LocalExpnId, Transparency};
 use rustc_span::{
-    BytePos, Ident, MacroRulesNormalizedIdent, Span, Symbol, SyntaxContext, kw, sym,
-    with_metavar_spans,
+    Ident, MacroRulesNormalizedIdent, Span, Symbol, SyntaxContext, sym, with_metavar_spans,
 };
 use smallvec::{SmallVec, smallvec};
 
@@ -481,8 +479,9 @@ fn transcribe_pnr<'tx>(
         )
     };
 
-    let tt = match pnr {
-        ParseNtResult::Tt(tt) => {
+    let metavar_kind = pnr.metavar_kind();
+    let tt = match *pnr {
+        ParseNtResult::Tt(ref tt) => {
             // `tt`s are emitted into the output stream directly as "raw tokens",
             // without wrapping them into groups. Other variables are emitted into
             // the output stream as groups with `Delimiter::Invisible` to maintain
@@ -492,92 +491,33 @@ fn transcribe_pnr<'tx>(
         ParseNtResult::Ident(ident, is_raw) => {
             tscx.marker.mark_span(&mut sp);
             with_metavar_spans(|mspans| mspans.insert(ident.span, sp));
-            let kind = token::NtIdent(*ident, *is_raw);
+            let kind = token::NtIdent(ident, is_raw);
             TokenTree::token_alone(kind, sp)
         }
         ParseNtResult::Lifetime(ident, is_raw) => {
             tscx.marker.mark_span(&mut sp);
             with_metavar_spans(|mspans| mspans.insert(ident.span, sp));
-            let kind = token::NtLifetime(*ident, *is_raw);
+            let kind = token::NtLifetime(ident, is_raw);
             TokenTree::token_alone(kind, sp)
         }
-        ParseNtResult::Item(item) => {
-            mk_delimited(item.span, MetaVarKind::Item, TokenStream::from_ast(item))
-        }
-        ParseNtResult::Block(block) => {
-            mk_delimited(block.node.span, MetaVarKind::Block, TokenStream::from_ast(block))
-        }
-        ParseNtResult::Stmt(stmt) => {
-            let stream = if let StmtKind::Empty = stmt.kind {
-                // FIXME: Properly collect tokens for empty statements.
-                TokenStream::token_alone(token::Semi, stmt.span)
-            } else {
-                TokenStream::from_ast(stmt)
-            };
-            mk_delimited(stmt.span, MetaVarKind::Stmt, stream)
-        }
-        ParseNtResult::Pat(pat, pat_kind) => {
-            mk_delimited(pat.node.span, MetaVarKind::Pat(*pat_kind), TokenStream::from_ast(pat))
-        }
-        ParseNtResult::Expr(expr, kind) => {
-            let (can_begin_literal_maybe_minus, can_begin_string_literal) = match &expr.kind {
-                ExprKind::Lit(_) => (true, true),
-                ExprKind::Unary(UnOp::Neg, e) if matches!(&e.kind, ExprKind::Lit(_)) => {
-                    (true, false)
-                }
-                _ => (false, false),
-            };
-            mk_delimited(
-                expr.span,
-                MetaVarKind::Expr {
-                    kind: *kind,
-                    can_begin_literal_maybe_minus,
-                    can_begin_string_literal,
-                },
-                TokenStream::from_ast(expr),
-            )
-        }
-        ParseNtResult::Literal(lit) => {
-            mk_delimited(lit.span, MetaVarKind::Literal, TokenStream::from_ast(lit))
-        }
-        ParseNtResult::Ty(ty) => {
-            let is_path = matches!(&ty.node.kind, TyKind::Path(None, _path));
-            mk_delimited(ty.node.span, MetaVarKind::Ty { is_path }, TokenStream::from_ast(ty))
-        }
-        ParseNtResult::Meta(attr_item) => {
-            let has_meta_form = attr_item.node.meta_kind().is_some();
-            mk_delimited(
-                attr_item.node.span(),
-                MetaVarKind::Meta { has_meta_form },
-                TokenStream::from_ast(attr_item),
-            )
-        }
-        ParseNtResult::Path(path) => {
-            mk_delimited(path.node.span, MetaVarKind::Path, TokenStream::from_ast(path))
-        }
-        ParseNtResult::Vis(vis) => {
-            mk_delimited(vis.node.span, MetaVarKind::Vis, TokenStream::from_ast(vis))
-        }
-        ParseNtResult::Guard(guard) => {
-            // FIXME(macro_guard_matcher):
-            // Perhaps it would be better to treat the leading `if` as part of `ast::Guard` during parsing?
-            // Currently they are separate, but in macros we match and emit the leading `if` for `:guard` matchers, which creates some inconsistency.
-
-            let leading_if_span =
-                guard.span_with_leading_if.with_hi(guard.span_with_leading_if.lo() + BytePos(2));
-            let mut ts =
-                TokenStream::token_alone(token::Ident(kw::If, IdentIsRaw::No), leading_if_span);
-            ts.push_stream(TokenStream::from_ast(&guard.cond));
-
-            mk_delimited(guard.span_with_leading_if, MetaVarKind::Guard, ts)
-        }
+        ParseNtResult::Item(span, ref ts)
+        | ParseNtResult::Block(span, ref ts)
+        | ParseNtResult::Stmt(span, ref ts)
+        | ParseNtResult::Pat(span, ref ts, _)
+        | ParseNtResult::Expr { span, tokens: ref ts, .. }
+        | ParseNtResult::Literal(span, ref ts)
+        | ParseNtResult::Ty { span, tokens: ref ts, .. }
+        | ParseNtResult::Meta { span, tokens: ref ts, .. }
+        | ParseNtResult::Path(span, ref ts)
+        | ParseNtResult::Vis(span, ref ts)
+        | ParseNtResult::Guard(span, ref ts) => mk_delimited(span, metavar_kind, ts.clone()),
     };
 
     tscx.result.push(tt);
     Ok(())
 }
 
-/// Turn `${expr(...)}` metavariable expressionss into tokens.
+/// Turn `${expr(...)}` metavariable expressions into tokens.
 fn transcribe_metavar_expr<'tx>(
     tscx: &mut TranscrCtx<'tx, '_>,
     dspan: DelimSpan,
@@ -991,6 +931,17 @@ fn extract_symbol_from_pnr<'a>(
     pnr: &ParseNtResult,
     span_err: Span,
 ) -> PResult<'a, Symbol> {
+    // FIXME(bal-e): traverse delimiters?
+    fn as_single_tok_kind(ts: &TokenStream) -> Option<&TokenKind> {
+        if ts.len() == 1
+            && let Some(TokenTree::Token(t, _)) = ts.get(0)
+        {
+            Some(&t.kind)
+        } else {
+            None
+        }
+    }
+
     match pnr {
         ParseNtResult::Ident(nt_ident, is_raw) => {
             if let IdentIsRaw::Yes = is_raw {
@@ -1016,14 +967,16 @@ fn extract_symbol_from_pnr<'a>(
             },
             _,
         )) => Ok(*symbol),
-        ParseNtResult::Literal(expr)
-            if let ExprKind::Lit(Lit { kind: LitKind::Str, symbol, suffix: None }) = &expr.kind =>
+        ParseNtResult::Literal(_, ts)
+            if let Some(TokenKind::Literal(Lit { kind: LitKind::Str, symbol, suffix: None })) =
+                as_single_tok_kind(ts) =>
         {
             Ok(*symbol)
         }
-        ParseNtResult::Literal(expr)
-            if let ExprKind::Lit(lit @ Lit { kind: LitKind::Integer, symbol, suffix }) =
-                &expr.kind =>
+        ParseNtResult::Literal(_, ts)
+            if let Some(TokenKind::Literal(
+                lit @ Lit { kind: LitKind::Integer, symbol, suffix },
+            )) = as_single_tok_kind(ts) =>
         {
             if lit.is_semantic_float() {
                 Err(dcx

--- a/compiler/rustc_parse/src/parser/mod.rs
+++ b/compiler/rustc_parse/src/parser/mod.rs
@@ -30,7 +30,6 @@ use rustc_ast::token::{
 };
 use rustc_ast::tokenstream::{
     ParserRange, ParserReplacement, Spacing, TokenCursor, TokenStream, TokenTree, TokenTreeCursor,
-    WithTokens,
 };
 use rustc_ast::util::case::Case;
 use rustc_ast::util::classify;
@@ -1817,26 +1816,64 @@ impl<'a> Parser<'a> {
     }
 }
 
-// Metavar captures of various kinds. The more complex node kinds (e.g. `Item`, `Expr`) store
-// tokens in the node itself because those tokens are needed for non-terminal parsing and for other
-// reasons (e.g. cfg expansion). Simpler node kinds (e.g. `Block`, `Path`) only need tokens for
-// non-terminal parsing so here they store the tokens next to the node, keeping the node size
-// smaller.
+// Extra data stored here to help re-parse the token streams later.
 #[derive(Clone, Debug)]
 pub enum ParseNtResult {
     Tt(TokenTree),
     Ident(Ident, IdentIsRaw),
     Lifetime(Ident, IdentIsRaw),
-    Item(Box<ast::Item>),
-    Block(WithTokens<Box<ast::Block>>),
-    Stmt(Box<ast::Stmt>),
-    Pat(WithTokens<Box<ast::Pat>>, NtPatKind),
-    Expr(Box<ast::Expr>, NtExprKind),
-    Literal(Box<ast::Expr>),
-    Ty(WithTokens<Box<ast::Ty>>),
-    // These tokens are for the attr item, e.g. just the `foo` within `#[foo]` or `#![foo]`.
-    Meta(WithTokens<Box<ast::AttrItem>>),
-    Path(WithTokens<Box<ast::Path>>),
-    Vis(WithTokens<Box<ast::Visibility>>),
-    Guard(Box<ast::Guard>),
+    Item(Span, TokenStream),
+    Block(Span, TokenStream),
+    Stmt(Span, TokenStream),
+    Pat(Span, TokenStream, NtPatKind),
+    Expr {
+        span: Span,
+        tokens: TokenStream,
+        kind: NtExprKind,
+        can_begin_literal_maybe_minus: bool,
+        can_begin_string_literal: bool,
+    },
+    Literal(Span, TokenStream),
+    Ty {
+        span: Span,
+        tokens: TokenStream,
+        is_path: bool,
+    },
+    Meta {
+        span: Span,
+        // These tokens are for the attr item, e.g. just the `foo` within `#[foo]` or `#![foo]`.
+        tokens: TokenStream,
+        has_meta_form: bool,
+    },
+    Path(Span, TokenStream),
+    Vis(Span, TokenStream),
+    Guard(Span, TokenStream),
+}
+
+impl ParseNtResult {
+    pub fn metavar_kind(&self) -> MetaVarKind {
+        match self {
+            ParseNtResult::Tt(..) => MetaVarKind::TT,
+            ParseNtResult::Ident(..) => MetaVarKind::Ident,
+            ParseNtResult::Lifetime(..) => MetaVarKind::Lifetime,
+            ParseNtResult::Item(..) => MetaVarKind::Item,
+            ParseNtResult::Block(..) => MetaVarKind::Block,
+            ParseNtResult::Stmt(..) => MetaVarKind::Stmt,
+            &ParseNtResult::Pat(.., pat_kind) => MetaVarKind::Pat(pat_kind),
+            &ParseNtResult::Expr {
+                kind,
+                can_begin_literal_maybe_minus,
+                can_begin_string_literal,
+                ..
+            } => {
+                MetaVarKind::Expr { kind, can_begin_literal_maybe_minus, can_begin_string_literal }
+            }
+            ParseNtResult::Literal(..) => MetaVarKind::Literal,
+            &ParseNtResult::Ty { is_path, .. } => MetaVarKind::Ty { is_path },
+            &ParseNtResult::Meta { has_meta_form, .. } => MetaVarKind::Meta { has_meta_form },
+            ParseNtResult::Path(..) => MetaVarKind::Path,
+            ParseNtResult::Vis(..) => MetaVarKind::Vis,
+            ParseNtResult::Guard(..) => MetaVarKind::Guard,
+        }
+    }
 }

--- a/compiler/rustc_parse/src/parser/nonterminal.rs
+++ b/compiler/rustc_parse/src/parser/nonterminal.rs
@@ -1,10 +1,11 @@
 use rustc_ast::token::NtExprKind::*;
 use rustc_ast::token::NtPatKind::*;
-use rustc_ast::token::{self, InvisibleOrigin, MetaVarKind, NonterminalKind, Token};
-use rustc_ast::tokenstream::WithTokens;
+use rustc_ast::token::{self, IdentIsRaw, InvisibleOrigin, MetaVarKind, NonterminalKind, Token};
+use rustc_ast::tokenstream::{TokenStream, WithTokens};
+use rustc_ast::{ExprKind, StmtKind, TyKind, UnOp};
 use rustc_ast_pretty::pprust;
 use rustc_errors::PResult;
-use rustc_span::{Ident, kw};
+use rustc_span::{BytePos, Ident, kw};
 
 use crate::diagnostics::UnexpectedNonterminal;
 use crate::parser::pat::{CommaRecoveryMode, RecoverColon, RecoverComma};
@@ -119,34 +120,41 @@ impl<'a> Parser<'a> {
     /// site.
     #[inline]
     pub fn parse_nonterminal(&mut self, kind: NonterminalKind) -> PResult<'a, ParseNtResult> {
-        // A `macro_rules!` invocation may pass a captured item/expr to a proc-macro,
-        // which requires having captured tokens available. Since we cannot determine
-        // in advance whether or not a proc-macro will be (transitively) invoked,
-        // we always capture tokens for any nonterminal that needs them.
+        // Extra information is collected to help re-parse the meta-variable later.
+        // FIXME: Don't build a real AST; we just need a token stream.
         match kind {
             // Note that TT is treated differently to all the others.
             NonterminalKind::TT => Ok(ParseNtResult::Tt(self.parse_token_tree())),
             NonterminalKind::Item => match self
                 .parse_item(ForceCollect::Yes, AllowConstBlockItems::Yes)?
             {
-                Some(item) => Ok(ParseNtResult::Item(item)),
+                Some(item) => Ok(ParseNtResult::Item(item.span, TokenStream::from_ast(&item))),
                 None => Err(self.dcx().create_err(UnexpectedNonterminal::Item(self.token.span))),
             },
             NonterminalKind::Block => {
                 // While a block *expression* may have attributes (e.g. `#[my_attr] { ... }`),
                 // the ':block' matcher does not support them
-                Ok(ParseNtResult::Block(self.collect_tokens_no_attrs(|this| {
+                let block = self.collect_tokens_no_attrs(|this| {
                     this.parse_block().map(|block| WithTokens::new(block))
-                })?))
+                })?;
+                Ok(ParseNtResult::Block(block.node.span, TokenStream::from_ast(&block)))
             }
             NonterminalKind::Stmt => match self.parse_stmt(ForceCollect::Yes)? {
-                Some(stmt) => Ok(ParseNtResult::Stmt(Box::new(stmt))),
+                Some(stmt) => {
+                    let stream = if let StmtKind::Empty = stmt.kind {
+                        // FIXME: Properly collect tokens for empty statements.
+                        TokenStream::token_alone(token::Semi, stmt.span)
+                    } else {
+                        TokenStream::from_ast(&stmt)
+                    };
+                    Ok(ParseNtResult::Stmt(stmt.span, stream))
+                }
                 None => {
                     Err(self.dcx().create_err(UnexpectedNonterminal::Statement(self.token.span)))
                 }
             },
-            NonterminalKind::Pat(pat_kind) => Ok(ParseNtResult::Pat(
-                self.collect_tokens_no_attrs(|this| {
+            NonterminalKind::Pat(pat_kind) => {
+                let pat = self.collect_tokens_no_attrs(|this| {
                     match pat_kind {
                         PatParam { .. } => this.parse_pat_no_top_alt(None, None),
                         PatWithOr => this.parse_pat_no_top_guard(
@@ -157,21 +165,43 @@ impl<'a> Parser<'a> {
                         ),
                     }
                     .map(|pat| WithTokens::new(Box::new(pat)))
-                })?,
-                pat_kind,
-            )),
+                })?;
+                Ok(ParseNtResult::Pat(pat.node.span, TokenStream::from_ast(&pat), pat_kind))
+            }
             NonterminalKind::Expr(expr_kind) => {
-                Ok(ParseNtResult::Expr(self.parse_expr_force_collect()?, expr_kind))
+                let expr = self.parse_expr_force_collect()?;
+                let (can_begin_literal_maybe_minus, can_begin_string_literal) = match &expr.kind {
+                    ExprKind::Lit(_) => (true, true),
+                    ExprKind::Unary(UnOp::Neg, e) if matches!(&e.kind, ExprKind::Lit(_)) => {
+                        (true, false)
+                    }
+                    _ => (false, false),
+                };
+
+                Ok(ParseNtResult::Expr {
+                    span: expr.span,
+                    tokens: TokenStream::from_ast(&expr),
+                    kind: expr_kind,
+                    can_begin_literal_maybe_minus,
+                    can_begin_string_literal,
+                })
             }
             NonterminalKind::Literal => {
                 // The `:literal` matcher does not support attributes.
-                Ok(ParseNtResult::Literal(
-                    self.collect_tokens_no_attrs(|this| this.parse_literal_maybe_minus())?,
-                ))
+                let lit = self.collect_tokens_no_attrs(|this| this.parse_literal_maybe_minus())?;
+                Ok(ParseNtResult::Literal(lit.span, TokenStream::from_ast(&lit)))
             }
-            NonterminalKind::Ty => Ok(ParseNtResult::Ty(self.collect_tokens_no_attrs(|this| {
-                this.parse_ty_no_question_mark_recover().map(|ty| WithTokens::new(ty))
-            })?)),
+            NonterminalKind::Ty => {
+                let ty = self.collect_tokens_no_attrs(|this| {
+                    this.parse_ty_no_question_mark_recover().map(|ty| WithTokens::new(ty))
+                })?;
+                let is_path = matches!(&ty.node.kind, TyKind::Path(None, _path));
+                Ok(ParseNtResult::Ty {
+                    span: ty.node.span,
+                    tokens: TokenStream::from_ast(&ty),
+                    is_path,
+                })
+            }
             // This could be handled like a token, since it is one.
             NonterminalKind::Ident => {
                 if let Some((ident, is_raw)) = get_macro_ident(&self.token) {
@@ -185,18 +215,26 @@ impl<'a> Parser<'a> {
                 }
             }
             NonterminalKind::Path => {
-                Ok(ParseNtResult::Path(self.collect_tokens_no_attrs(|this| {
+                let path = self.collect_tokens_no_attrs(|this| {
                     this.parse_path(PathStyle::Type).map(|path| WithTokens::new(Box::new(path)))
-                })?))
+                })?;
+                Ok(ParseNtResult::Path(path.node.span, TokenStream::from_ast(&path)))
             }
-            NonterminalKind::Meta => Ok(ParseNtResult::Meta(
-                self.parse_attr_item(ForceCollect::Yes)?.map(|item| Box::new(item)),
-            )),
+            NonterminalKind::Meta => {
+                let attr_item = self.parse_attr_item(ForceCollect::Yes)?.map(|item| Box::new(item));
+                let has_meta_form = attr_item.node.meta_kind().is_some();
+                Ok(ParseNtResult::Meta {
+                    span: attr_item.node.span(),
+                    tokens: TokenStream::from_ast(&attr_item),
+                    has_meta_form,
+                })
+            }
             NonterminalKind::Vis => {
-                Ok(ParseNtResult::Vis(self.collect_tokens_no_attrs(|this| {
+                let vis = self.collect_tokens_no_attrs(|this| {
                     this.parse_visibility(FollowedByType::Yes)
                         .map(|vis| WithTokens::new(Box::new(vis)))
-                })?))
+                })?;
+                Ok(ParseNtResult::Vis(vis.node.span, TokenStream::from_ast(&vis)))
             }
             NonterminalKind::Lifetime => {
                 // We want to keep `'keyword` parsing, just like `keyword` is still
@@ -212,7 +250,20 @@ impl<'a> Parser<'a> {
                 }
             }
             NonterminalKind::Guard => {
-                Ok(ParseNtResult::Guard(self.expect_match_arm_guard(ForceCollect::Yes)?))
+                let guard = self.expect_match_arm_guard(ForceCollect::Yes)?;
+
+                // FIXME(macro_guard_matcher):
+                // Perhaps it would be better to treat the leading `if` as part of `ast::Guard` during parsing?
+                // Currently they are separate, but in macros we match and emit the leading `if` for `:guard` matchers, which creates some inconsistency.
+
+                let leading_if_span = guard
+                    .span_with_leading_if
+                    .with_hi(guard.span_with_leading_if.lo() + BytePos(2));
+                let mut ts =
+                    TokenStream::token_alone(token::Ident(kw::If, IdentIsRaw::No), leading_if_span);
+                ts.push_stream(TokenStream::from_ast(&guard.cond));
+
+                Ok(ParseNtResult::Guard(guard.span_with_leading_if, ts))
             }
         }
     }

--- a/compiler/rustc_parse/src/parser/nonterminal.rs
+++ b/compiler/rustc_parse/src/parser/nonterminal.rs
@@ -125,34 +125,32 @@ impl<'a> Parser<'a> {
         match kind {
             // Note that TT is treated differently to all the others.
             NonterminalKind::TT => Ok(ParseNtResult::Tt(self.parse_token_tree())),
-            NonterminalKind::Item => match self
-                .parse_item(ForceCollect::Yes, AllowConstBlockItems::Yes)?
-            {
-                Some(item) => Ok(ParseNtResult::Item(item.span, TokenStream::from_ast(&item))),
-                None => Err(self.dcx().create_err(UnexpectedNonterminal::Item(self.token.span))),
-            },
+            NonterminalKind::Item => {
+                let item =
+                    self.parse_item(ForceCollect::Yes, AllowConstBlockItems::Yes)?.ok_or_else(
+                        || self.dcx().create_err(UnexpectedNonterminal::Item(self.token.span)),
+                    )?;
+                Ok(ParseNtResult::Item(item.span, TokenStream::from_ast(&item)))
+            }
             NonterminalKind::Block => {
                 // While a block *expression* may have attributes (e.g. `#[my_attr] { ... }`),
                 // the ':block' matcher does not support them
-                let block = self.collect_tokens_no_attrs(|this| {
-                    this.parse_block().map(|block| WithTokens::new(block))
-                })?;
+                let block =
+                    self.collect_tokens_no_attrs(|this| this.parse_block().map(WithTokens::new))?;
                 Ok(ParseNtResult::Block(block.node.span, TokenStream::from_ast(&block)))
             }
-            NonterminalKind::Stmt => match self.parse_stmt(ForceCollect::Yes)? {
-                Some(stmt) => {
-                    let stream = if let StmtKind::Empty = stmt.kind {
-                        // FIXME: Properly collect tokens for empty statements.
-                        TokenStream::token_alone(token::Semi, stmt.span)
-                    } else {
-                        TokenStream::from_ast(&stmt)
-                    };
-                    Ok(ParseNtResult::Stmt(stmt.span, stream))
-                }
-                None => {
-                    Err(self.dcx().create_err(UnexpectedNonterminal::Statement(self.token.span)))
-                }
-            },
+            NonterminalKind::Stmt => {
+                let stmt = self.parse_stmt(ForceCollect::Yes)?.ok_or_else(|| {
+                    self.dcx().create_err(UnexpectedNonterminal::Statement(self.token.span))
+                })?;
+                let stream = if let StmtKind::Empty = stmt.kind {
+                    // FIXME: Properly collect tokens for empty statements.
+                    TokenStream::token_alone(token::Semi, stmt.span)
+                } else {
+                    TokenStream::from_ast(&stmt)
+                };
+                Ok(ParseNtResult::Stmt(stmt.span, stream))
+            }
             NonterminalKind::Pat(pat_kind) => {
                 let pat = self.collect_tokens_no_attrs(|this| {
                     match pat_kind {
@@ -193,7 +191,7 @@ impl<'a> Parser<'a> {
             }
             NonterminalKind::Ty => {
                 let ty = self.collect_tokens_no_attrs(|this| {
-                    this.parse_ty_no_question_mark_recover().map(|ty| WithTokens::new(ty))
+                    this.parse_ty_no_question_mark_recover().map(WithTokens::new)
                 })?;
                 let is_path = matches!(&ty.node.kind, TyKind::Path(None, _path));
                 Ok(ParseNtResult::Ty {
@@ -216,12 +214,12 @@ impl<'a> Parser<'a> {
             }
             NonterminalKind::Path => {
                 let path = self.collect_tokens_no_attrs(|this| {
-                    this.parse_path(PathStyle::Type).map(|path| WithTokens::new(Box::new(path)))
+                    this.parse_path(PathStyle::Type).map(WithTokens::new)
                 })?;
                 Ok(ParseNtResult::Path(path.node.span, TokenStream::from_ast(&path)))
             }
             NonterminalKind::Meta => {
-                let attr_item = self.parse_attr_item(ForceCollect::Yes)?.map(|item| Box::new(item));
+                let attr_item = self.parse_attr_item(ForceCollect::Yes)?;
                 let has_meta_form = attr_item.node.meta_kind().is_some();
                 Ok(ParseNtResult::Meta {
                     span: attr_item.node.span(),
@@ -231,8 +229,7 @@ impl<'a> Parser<'a> {
             }
             NonterminalKind::Vis => {
                 let vis = self.collect_tokens_no_attrs(|this| {
-                    this.parse_visibility(FollowedByType::Yes)
-                        .map(|vis| WithTokens::new(Box::new(vis)))
+                    this.parse_visibility(FollowedByType::Yes).map(|vis| WithTokens::new(vis))
                 })?;
                 Ok(ParseNtResult::Vis(vis.node.span, TokenStream::from_ast(&vis)))
             }


### PR DESCRIPTION
`ParseNtResult` holds AST items, which is unnecessary since its only use is to be serialized back into a `TokenStream`. This PR reduces the usage of `ParseNtResult` by converting it to a `TokenStream` earlier (right after `Parser::parse_nonterminal()`), hopefully making it easier to inline more away in the future. It does so by introducing a new `ParsedNtTokens` type which stores `TokenStream`s + metadata for macro transcribing; now `NamedMatch` (which is how the macro parser communicates with the macro transcriber) holds this type instead of `ParseNtResult`.

Local benchmarking suggests this may bring improvements and regressions. Previously, the conversion to `TokenStream` was done every time a meta-variable was transcribed, and now it is done when the meta-variable is parsed. Benchmarks where meta-variables are transcribed zero times should regress while benchmarks where meta-variables are transcribed two or more times should improve. But I think this PR is worthwhile anyway, it is a useful step to avoid building those ASTs in the first place.

Most of the work is in a single commit, let me know if it needs splitting.

r? @nnethercote