### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,15 +1,13 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended",
+    // Use https://github.com/rust-lang/renovate/blob/main/actions.json
+    "github>rust-lang/renovate:actions",
     // Open a PR to migrate the config when Renovate deprecates syntax
     ":configMigration",
     // Refresh lock files on the first day of each month
     // (still gated by dashboard approval for now)
     ":maintainLockFilesMonthly",
-    // Pin GitHub Actions to their commit SHA digests, resolving floating tags
-    // (e.g. `v4`) to the full SemVer version (e.g. `v4.1.2`)
-    "helpers:pinGitHubActionDigestsToSemver"
   ],
   // Require manual approval from the Dependency Dashboard before opening PRs
   "dependencyDashboardApproval": true,

--- a/compiler/rustc_resolve/src/diagnostics/impls.rs
+++ b/compiler/rustc_resolve/src/diagnostics/impls.rs
@@ -334,9 +334,9 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         self.tcx.dcx()
     }
 
-    pub(crate) fn report_errors(&mut self, krate: &Crate) {
+    pub(crate) fn report_errors(&mut self, krate: &Crate, use_injections: Vec<UseError<'tcx>>) {
         self.report_delayed_vis_resolution_errors();
-        self.report_with_use_injections(krate);
+        self.report_with_use_injections(krate, use_injections);
 
         for &(span_use, span_def) in &self.macro_expanded_macro_export_errors {
             self.lint_buffer.buffer_lint(
@@ -390,9 +390,9 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         }
     }
 
-    fn report_with_use_injections(&mut self, krate: &Crate) {
+    fn report_with_use_injections(&mut self, krate: &Crate, use_injections: Vec<UseError<'tcx>>) {
         for UseError { mut err, candidates, node_id, instead, suggestion, path, is_call } in
-            mem::take(&mut self.use_injections)
+            use_injections
         {
             let (span, found_use) = if node_id != DUMMY_NODE_ID {
                 UsePlacementFinder::check(krate, node_id)

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -849,6 +849,9 @@ struct LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
 
     /// Count the number of places a lifetime is used.
     lifetime_uses: FxHashMap<LocalDefId, LifetimeUseSet>,
+
+    /// `use` injections are delayed for better placement and deduplication.
+    use_injections: Vec<UseError<'tcx>>,
 }
 
 impl<'ra, 'tcx> AsRef<Resolver<'ra, 'tcx>> for LateResolutionVisitor<'_, '_, 'ra, 'tcx> {
@@ -1544,6 +1547,7 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
             // errors at module scope should always be reported
             in_func_body: false,
             lifetime_uses: Default::default(),
+            use_injections: Vec::new(),
         }
     }
 
@@ -4624,7 +4628,7 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
                     is_call: source.is_call(),
                 };
 
-                this.r.use_injections.push(ue);
+                this.use_injections.push(ue);
             }
 
             PartialRes::new(Res::Err)
@@ -4728,7 +4732,7 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
                         }
                     } else {
                         // If there are suggested imports, the error reporting is delayed
-                        this.r.use_injections.push(UseError {
+                        this.use_injections.push(UseError {
                             err,
                             candidates,
                             node_id,
@@ -5701,7 +5705,10 @@ impl<'ast> Visitor<'ast> for ItemInfoCollector<'_, 'ast, '_, '_> {
 
 impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
     /// Returns the `use` and `extern crate` items of the crate, for use by `check_unused`.
-    pub(crate) fn late_resolve_crate<'ast>(&mut self, krate: &'ast Crate) -> Vec<&'ast Item> {
+    pub(crate) fn late_resolve_crate<'ast>(
+        &mut self,
+        krate: &'ast Crate,
+    ) -> (Vec<&'ast Item>, Vec<UseError<'tcx>>) {
         with_owner(self, CRATE_NODE_ID, |this| {
             let mut info_collector = ItemInfoCollector { r: this, use_items: Vec::new() };
             visit::walk_crate(&mut info_collector, krate);
@@ -5710,7 +5717,9 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             late_resolution_visitor
                 .resolve_doc_links(&krate.attrs, MaybeExported::Ok(CRATE_NODE_ID));
             visit::walk_crate(&mut late_resolution_visitor, krate);
-            for (id, span) in late_resolution_visitor.diag_metadata.unused_labels.iter() {
+            let LateResolutionVisitor { use_injections, diag_metadata, .. } =
+                late_resolution_visitor;
+            for (id, span) in diag_metadata.unused_labels.iter() {
                 this.lint_buffer.buffer_lint(
                     lint::builtin::UNUSED_LABELS,
                     *id,
@@ -5718,7 +5727,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                     crate::diagnostics::UnusedLabel,
                 );
             }
-            use_items
+            (use_items, use_injections)
         })
     }
 }

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -1381,8 +1381,6 @@ pub struct Resolver<'ra, 'tcx> {
     /// Ambiguity errors are delayed for deduplication.
     ambiguity_errors: Vec<AmbiguityError<'ra>> = Vec::new(),
     issue_145575_hack_applied: bool = false,
-    /// `use` injections are delayed for better placement and deduplication.
-    use_injections: Vec<UseError<'tcx>> = Vec::new(),
     /// Visibility path resolution failures are delayed until all modules are collected.
     delayed_vis_resolution_errors: Vec<DelayedVisResolutionError<'ra>> = Vec::new(),
     /// Crate-local macro expanded `macro_export` referred to by a module-relative path.
@@ -2051,11 +2049,13 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             self.tcx
                 .sess
                 .time("finalize_macro_resolutions", || self.finalize_macro_resolutions(krate));
-            let use_items =
+            let (use_items, use_injections) =
                 self.tcx.sess.time("late_resolve_crate", || self.late_resolve_crate(krate));
             self.tcx.sess.time("resolve_main", || self.resolve_main());
             self.tcx.sess.time("resolve_check_unused", || self.check_unused(use_items));
-            self.tcx.sess.time("resolve_report_errors", || self.report_errors(krate));
+            self.tcx
+                .sess
+                .time("resolve_report_errors", || self.report_errors(krate, use_injections));
             self.tcx
                 .sess
                 .time("resolve_postprocess", || self.cstore_mut().postprocess(self.tcx, krate));

--- a/compiler/rustc_target/src/spec/targets/aarch64_unknown_fuchsia.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_unknown_fuchsia.rs
@@ -10,6 +10,7 @@ pub(crate) fn target() -> Target {
     base.stack_probes = StackProbeType::Inline;
     base.supported_sanitizers = SanitizerSet::ADDRESS
         | SanitizerSet::CFI
+        | SanitizerSet::HWADDRESS
         | SanitizerSet::LEAK
         | SanitizerSet::SHADOWCALLSTACK;
     base.default_sanitizers = SanitizerSet::SHADOWCALLSTACK;

--- a/compiler/rustc_target/src/spec/targets/riscv64gc_unknown_fuchsia.rs
+++ b/compiler/rustc_target/src/spec/targets/riscv64gc_unknown_fuchsia.rs
@@ -10,7 +10,10 @@ pub(crate) fn target() -> Target {
     base.llvm_abiname = LlvmAbi::Lp64d;
     base.max_atomic_width = Some(64);
     base.stack_probes = StackProbeType::Inline;
-    base.supported_sanitizers = SanitizerSet::ADDRESS | SanitizerSet::SHADOWCALLSTACK;
+    base.supported_sanitizers = SanitizerSet::ADDRESS
+        | SanitizerSet::CFI
+        | SanitizerSet::LEAK
+        | SanitizerSet::SHADOWCALLSTACK;
     base.default_sanitizers = SanitizerSet::SHADOWCALLSTACK;
     base.supports_xray = true;
 


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#159028 (fuchsia: Ensure all existing ported sanitizers for Fuchsia are supported)
 - rust-lang/rust#159339 (Resolver: extract `use_injections` out of main `Resolver`)
 - rust-lang/rust#159342 (renovate: group github actions updates)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=159028,159339,159342)
<!-- homu-ignore:end -->

