### PR TITLE
Add #[inline] to core::io methods with simple logic or forwarding

### DIFF
--- a/library/core/src/io/error.rs
+++ b/library/core/src/io/error.rs
@@ -605,6 +605,7 @@ impl fmt::Debug for Custom {
 
 #[unstable(feature = "core_io_internals", reason = "exposed only for libstd", issue = "none")]
 impl Drop for Custom {
+    #[inline]
     fn drop(&mut self) {
         // SAFETY: `Custom::from_raw` ensures this call is safe.
         unsafe {
@@ -631,12 +632,14 @@ impl Custom {
     }
 
     #[unstable(feature = "core_io_internals", reason = "exposed only for libstd", issue = "none")]
+    #[inline]
     pub fn into_raw(self) -> crate::ptr::NonNull<dyn error::Error + Send + Sync> {
         let ptr = self.error;
         core::mem::forget(self);
         ptr
     }
 
+    #[inline]
     fn error_ref(&self) -> &(dyn error::Error + Send + Sync + 'static) {
         // SAFETY:
         // `from_raw` ensures `error` is a valid pointer up to a static lifetime
@@ -644,6 +647,7 @@ impl Custom {
         unsafe { self.error.as_ref() }
     }
 
+    #[inline]
     fn error_mut(&mut self) -> &mut (dyn error::Error + Send + Sync + 'static) {
         // SAFETY:
         // `from_raw` ensures `error` is a valid pointer up to a static lifetime
@@ -668,6 +672,7 @@ unsafe impl Sync for CustomOwner {}
 
 #[unstable(feature = "core_io_internals", reason = "exposed only for libstd", issue = "none")]
 impl Drop for CustomOwner {
+    #[inline]
     fn drop(&mut self) {
         // SAFETY: `CustomOwner::from_raw` ensures this call is safe.
         unsafe {
@@ -687,6 +692,7 @@ impl CustomOwner {
     }
 
     #[unstable(feature = "core_io_internals", reason = "exposed only for libstd", issue = "none")]
+    #[inline]
     pub fn into_raw(self) -> crate::ptr::NonNull<Custom> {
         let ptr = self.0;
         core::mem::forget(self);

--- a/library/core/src/io/error/os_functions_atomic.rs
+++ b/library/core/src/io/error/os_functions_atomic.rs
@@ -15,6 +15,7 @@ use crate::sync::atomic;
 static OS_FUNCTIONS: atomic::AtomicPtr<OsFunctions> =
     atomic::AtomicPtr::new(OsFunctions::DEFAULT as *const _ as *mut _);
 
+#[inline]
 fn get_os_functions() -> &'static OsFunctions {
     // SAFETY:
     //  * `OS_FUNCTIONS` is initially a pointer to `OsFunctions::DEFAULT`, which is valid for a static lifetime.

--- a/library/core/src/io/error/repr_bitpacked.rs
+++ b/library/core/src/io/error/repr_bitpacked.rs
@@ -133,6 +133,7 @@ unsafe impl Send for Repr {}
 unsafe impl Sync for Repr {}
 
 impl Repr {
+    #[cfg_attr(not(debug_assertions), inline)]
     pub(super) fn new_custom(b: CustomOwner) -> Self {
         let p = b.into_raw().as_ptr().cast::<u8>();
         // Should only be possible if an allocator handed out a pointer with

--- a/library/core/src/io/io_slice.rs
+++ b/library/core/src/io/io_slice.rs
@@ -155,6 +155,7 @@ impl<'a> IoSliceMut<'a> {
     /// assert_eq!(&data, b"Abcdef");
     /// ```
     #[unstable(feature = "io_slice_as_bytes", issue = "132818")]
+    #[inline]
     pub const fn into_slice(self) -> &'a mut [u8] {
         self.0.into_slice()
     }
@@ -323,6 +324,7 @@ impl<'a> IoSlice<'a> {
     /// assert_eq!(io_slice.as_slice(), b"def");
     /// ```
     #[unstable(feature = "io_slice_as_bytes", issue = "132818")]
+    #[inline]
     pub const fn as_slice(self) -> &'a [u8] {
         self.0.as_slice()
     }

--- a/library/core/src/net/ip_addr.rs
+++ b/library/core/src/net/ip_addr.rs
@@ -2482,6 +2482,7 @@ macro_rules! bitop_impls {
 
             $(#[$attr])*
             const impl $BitOpAssign<&'_ $ty> for $ty {
+                #[inline]
                 fn $bitop_assign(&mut self, rhs: &'_ $ty) {
                     self.$bitop_assign(*rhs);
                 }


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/159369)*
<!-- homu-ignore:end -->

These methods are super trivial, but they were observed as exported functions on the `core.o` object file in RfL. They are super trivial methods that just perform either a trivial operation or forward to another method call, so it makes much more sense for these to be inlined into their caller.