### PR TITLE
Remove SIZE generic param from DisplayBuffer in core::net

### DIFF
--- a/library/core/src/net/display_buffer.rs
+++ b/library/core/src/net/display_buffer.rs
@@ -2,15 +2,20 @@ use crate::mem::MaybeUninit;
 use crate::{fmt, str};
 
 /// Used for slow path in `Display` implementations when alignment is required.
-pub(super) struct DisplayBuffer<const SIZE: usize> {
-    buf: [MaybeUninit<u8>; SIZE],
+pub(super) struct DisplayBuffer<'a> {
+    buf: &'a mut [MaybeUninit<u8>],
     len: usize,
 }
 
-impl<const SIZE: usize> DisplayBuffer<SIZE> {
+impl<'a> DisplayBuffer<'a> {
     #[inline]
-    pub(super) const fn new() -> Self {
-        Self { buf: [MaybeUninit::uninit(); SIZE], len: 0 }
+    pub(super) const fn new(buf: &'a mut [MaybeUninit<u8>]) -> Self {
+        Self { buf, len: 0 }
+    }
+
+    #[inline]
+    pub(super) const fn buffer<const SIZE: usize>() -> [MaybeUninit<u8>; SIZE] {
+        [MaybeUninit::uninit(); SIZE]
     }
 
     #[inline]
@@ -24,7 +29,7 @@ impl<const SIZE: usize> DisplayBuffer<SIZE> {
     }
 }
 
-impl<const SIZE: usize> fmt::Write for DisplayBuffer<SIZE> {
+impl fmt::Write for DisplayBuffer<'_> {
     fn write_str(&mut self, s: &str) -> fmt::Result {
         let bytes = s.as_bytes();
 

--- a/library/core/src/net/ip_addr.rs
+++ b/library/core/src/net/ip_addr.rs
@@ -1192,7 +1192,8 @@ impl fmt::Display for Ipv4Addr {
         } else {
             const LONGEST_IPV4_ADDR: &str = "255.255.255.255";
 
-            let mut buf = DisplayBuffer::<{ LONGEST_IPV4_ADDR.len() }>::new();
+            let mut buf = DisplayBuffer::buffer::<{ LONGEST_IPV4_ADDR.len() }>();
+            let mut buf = DisplayBuffer::new(&mut buf);
             // Buffer is long enough for the longest possible IPv4 address, so this should never fail.
             write!(buf, "{}.{}.{}.{}", octets[0], octets[1], octets[2], octets[3]).unwrap();
 
@@ -2197,7 +2198,8 @@ impl fmt::Display for Ipv6Addr {
         } else {
             const LONGEST_IPV6_ADDR: &str = "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff";
 
-            let mut buf = DisplayBuffer::<{ LONGEST_IPV6_ADDR.len() }>::new();
+            let mut buf = DisplayBuffer::buffer::<{ LONGEST_IPV6_ADDR.len() }>();
+            let mut buf = DisplayBuffer::new(&mut buf);
             // Buffer is long enough for the longest possible IPv6 address, so this should never fail.
             write!(buf, "{}", self).unwrap();
 

--- a/library/core/src/net/socket_addr.rs
+++ b/library/core/src/net/socket_addr.rs
@@ -652,7 +652,8 @@ impl fmt::Display for SocketAddrV4 {
         } else {
             const LONGEST_IPV4_SOCKET_ADDR: &str = "255.255.255.255:65535";
 
-            let mut buf = DisplayBuffer::<{ LONGEST_IPV4_SOCKET_ADDR.len() }>::new();
+            let mut buf = DisplayBuffer::buffer::<{ LONGEST_IPV4_SOCKET_ADDR.len() }>();
+            let mut buf = DisplayBuffer::new(&mut buf);
             // Buffer is long enough for the longest possible IPv4 socket address, so this should never fail.
             write!(buf, "{}:{}", self.ip(), self.port()).unwrap();
 
@@ -682,7 +683,8 @@ impl fmt::Display for SocketAddrV6 {
             const LONGEST_IPV6_SOCKET_ADDR: &str =
                 "[ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff%4294967295]:65535";
 
-            let mut buf = DisplayBuffer::<{ LONGEST_IPV6_SOCKET_ADDR.len() }>::new();
+            let mut buf = DisplayBuffer::buffer::<{ LONGEST_IPV6_SOCKET_ADDR.len() }>();
+            let mut buf = DisplayBuffer::new(&mut buf);
             match self.scope_id() {
                 0 => write!(buf, "[{}]:{}", self.ip(), self.port()),
                 scope_id => write!(buf, "[{}%{}]:{}", self.ip(), scope_id, self.port()),


### PR DESCRIPTION
These symbols were observed on the surface of `core.o`:
```
<core::net::display_buffer::DisplayBuffer<15> as core::fmt::Write>::write_char
<core::net::display_buffer::DisplayBuffer<15> as core::fmt::Write>::write_fmt
<core::net::display_buffer::DisplayBuffer<15> as core::fmt::Write>::write_str
<core::net::display_buffer::DisplayBuffer<21> as core::fmt::Write>::write_char
<core::net::display_buffer::DisplayBuffer<21> as core::fmt::Write>::write_fmt
<core::net::display_buffer::DisplayBuffer<21> as core::fmt::Write>::write_str
<core::net::display_buffer::DisplayBuffer<39> as core::fmt::Write>::write_char
<core::net::display_buffer::DisplayBuffer<39> as core::fmt::Write>::write_fmt
<core::net::display_buffer::DisplayBuffer<39> as core::fmt::Write>::write_str
<core::net::display_buffer::DisplayBuffer<58> as core::fmt::Write>::write_char
<core::net::display_buffer::DisplayBuffer<58> as core::fmt::Write>::write_fmt
<core::net::display_buffer::DisplayBuffer<58> as core::fmt::Write>::write_str
```
There's no reason to instantiate four different copies of this super simple logic, so remove the size parameter allowing each case to call into the same shared machine code.

It's not possible to inline these symbols into the `{SocketAddrV*,Ipv*Addr}::fmt` methods because `core::fmt::write` constructs a `&mut dyn fmt::Write` to the `DisplayBuffer`.