### PR TITLE
make a couple codegen-llvm tests compatible with 2021 edition

### DIFF
--- a/tests/codegen-llvm/fatptr.rs
+++ b/tests/codegen-llvm/fatptr.rs
@@ -6,7 +6,7 @@ pub trait T {}
 
 // CHECK-LABEL: @copy_fat_ptr
 #[no_mangle]
-pub fn copy_fat_ptr(x: &T) {
+pub fn copy_fat_ptr(x: &dyn T) {
     // CHECK-NOT: extractvalue
     let x2 = x;
 }

--- a/tests/codegen-llvm/reg-struct-return.rs
+++ b/tests/codegen-llvm/reg-struct-return.rs
@@ -90,17 +90,7 @@ pub struct FooFloat3 {
 }
 
 pub mod tests {
-    use Foo;
-    use Foo1;
-    use Foo2;
-    use Foo3;
-    use Foo4;
-    use Foo5;
-    use FooFloat1;
-    use FooFloat2;
-    use FooFloat3;
-    use FooOversize1;
-    use FooOversize2;
+    use super::*;
 
     // ENABLED: i64 @f1()
     // DISABLED: void @f1(ptr {{.*}}sret


### PR DESCRIPTION
previously they failed for simple syntax reasons.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
