### PR TITLE
emit `(lldb)` prefix to make commands more distinct

### DIFF
--- a/src/etc/lldb_batchmode/runner.py
+++ b/src/etc/lldb_batchmode/runner.py
@@ -74,7 +74,7 @@ def execute_command(command_interpreter, command):
     global registered_breakpoints
 
     res = lldb.SBCommandReturnObject()
-    print(command)
+    print(f"(lldb) {command}")
     command_interpreter.HandleCommand(command, res)
 
     if res.Succeeded():


### PR DESCRIPTION
As discussed in https://github.com/rust-lang/rust/pull/158298

r? @Kobzol, @jieyouxu 