### PR TITLE
error on naked EII implementations

### DIFF
--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -210,7 +210,9 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
             &AttributeKind::RustcPubTransparent(attr_span) => {
                 self.check_rustc_pub_transparent(attr_span, span, attrs)
             }
-            AttributeKind::Naked(..) => self.check_naked(hir_id, target),
+            AttributeKind::Naked(naked_span) => {
+                self.check_naked(hir_id, *naked_span, attrs, target)
+            }
             AttributeKind::TrackCaller(attr_span) => {
                 self.check_track_caller(hir_id, *attr_span, attrs, target)
             }
@@ -728,7 +730,7 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
     }
 
     /// Checks if `#[naked]` is applied to a function definition.
-    fn check_naked(&self, hir_id: HirId, target: Target) {
+    fn check_naked(&self, hir_id: HirId, naked_span: Span, attrs: &[Attribute], target: Target) {
         match target {
             Target::Fn
             | Target::Method(MethodKind::Trait { body: true } | MethodKind::Inherent) => {
@@ -745,6 +747,24 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                         ),
                     )
                     .emit();
+                }
+
+                // EII forwards calls to an implementation through a shim the compiler synthesizes
+                // around its body. A naked function's body is exactly the user's `naked_asm!`, so
+                // the shim has nowhere to go. See <https://github.com/rust-lang/rust/issues/158293>.
+                if let Some(impls) = find_attr!(attrs, EiiImpls(impls) => impls) {
+                    for i in impls {
+                        let name = match i.resolution {
+                            EiiImplResolution::Macro(def_id) => self.tcx.item_name(def_id),
+                            EiiImplResolution::Known(def_id) => self.tcx.item_name(def_id),
+                            EiiImplResolution::Error(_eg) => continue,
+                        };
+                        self.dcx().emit_err(diagnostics::EiiWithNaked {
+                            naked_span,
+                            name,
+                            impl_span: i.span,
+                        });
+                    }
                 }
             }
             _ => {}

--- a/compiler/rustc_passes/src/diagnostics.rs
+++ b/compiler/rustc_passes/src/diagnostics.rs
@@ -1088,6 +1088,16 @@ pub(crate) struct EiiWithTrackCaller {
 }
 
 #[derive(Diagnostic)]
+#[diag("`#[{$name}]` is not allowed to be `#[naked]`")]
+pub(crate) struct EiiWithNaked {
+    #[primary_span]
+    pub naked_span: Span,
+    pub name: Symbol,
+    #[label("`#[{$name}]` implementation cannot be `#[naked]`")]
+    pub impl_span: Span,
+}
+
+#[derive(Diagnostic)]
 #[diag("`#[{$name}]` {$kind} required, but not found")]
 pub(crate) struct EiiWithoutImpl {
     #[primary_span]

--- a/tests/ui/eii/naked_impl_issue_158293.rs
+++ b/tests/ui/eii/naked_impl_issue_158293.rs
@@ -1,0 +1,29 @@
+// An EII implementation cannot be `#[naked]`: EII forwards calls through a shim the
+// compiler synthesizes around the body, which has nowhere to go in a naked function.
+// See <https://github.com/rust-lang/rust/issues/158293>.
+
+//@ needs-asm-support
+#![feature(extern_item_impls)]
+#![allow(dead_code)]
+
+#[eii(requires_impl)]
+unsafe extern "C" fn entry_eh(_: usize);
+
+#[crate::requires_impl]
+#[unsafe(naked)] //~ ERROR `#[requires_impl]` is not allowed to be `#[naked]`
+unsafe extern "C" fn eh(_: usize) {
+    core::arch::naked_asm!("nop");
+}
+
+#[eii(opt_impl)]
+unsafe extern "C" fn entry_default(_: usize) {
+    println!("called default")
+}
+
+#[crate::opt_impl]
+#[unsafe(naked)] //~ ERROR `#[opt_impl]` is not allowed to be `#[naked]`
+unsafe extern "C" fn eh_default(_: usize) {
+    core::arch::naked_asm!("nop");
+}
+
+fn main() {}

--- a/tests/ui/eii/naked_impl_issue_158293.stderr
+++ b/tests/ui/eii/naked_impl_issue_158293.stderr
@@ -1,0 +1,18 @@
+error: `#[requires_impl]` is not allowed to be `#[naked]`
+  --> $DIR/naked_impl_issue_158293.rs:13:1
+   |
+LL | #[crate::requires_impl]
+   | ----------------------- `#[requires_impl]` implementation cannot be `#[naked]`
+LL | #[unsafe(naked)]
+   | ^^^^^^^^^^^^^^^^
+
+error: `#[opt_impl]` is not allowed to be `#[naked]`
+  --> $DIR/naked_impl_issue_158293.rs:24:1
+   |
+LL | #[crate::opt_impl]
+   | ------------------ `#[opt_impl]` implementation cannot be `#[naked]`
+LL | #[unsafe(naked)]
+   | ^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Fix rust-lang/rust#158293.

A naked function used as an EII implementation silently breaks instead of being diagnosed. EII forwards calls to an implementation through a shim the compiler synthesizes around its body; a naked function's body is exactly the user's `naked_asm!`, so the shim has nowhere to go and the forwarding alias is dropped. Without a default impl the artifact then fails to link with an unhelpful "undefined symbol"; with one (`opt_impl`) the default is used instead of the user's body, with no diagnostic.

As discussed on the [tracking issue](https://github.com/rust-lang/rust/issues/125418), naked EII may not be supportable at all, and until that is known the combination should be rejected. This adds a check in check_naked — mirroring the existing `#[track_caller]` check — that errors when an EII impl is also `#[naked]`, covering both `requires_impl` and `opt_impl`.

r? @bjorn3 