### PR TITLE
Cleanup `chunk_by` count method and add tests

### DIFF
--- a/library/core/src/slice/iter.rs
+++ b/library/core/src/slice/iter.rs
@@ -3052,16 +3052,11 @@ where
 
     #[inline]
     fn count(mut self) -> usize {
-        let Some((mut previous, rest)) = self.slice.split_first() else {
-            return 0;
-        };
-
-        let mut count = 1;
-        for current in rest {
-            count += usize::from(!(self.predicate)(previous, current));
-            previous = current;
+        if self.slice.is_empty() {
+            0
+        } else {
+            1 + self.slice.array_windows().filter(|&[a, b]| !(self.predicate)(a, b)).count()
         }
-        count
     }
 
     #[inline]

--- a/library/coretests/tests/slice.rs
+++ b/library/coretests/tests/slice.rs
@@ -618,6 +618,85 @@ fn test_chunks_exact_mut_zip() {
     assert_eq!(v1, [13, 14, 19, 20, 4]);
 }
 
+// every one starts a new chunk
+// every zero is part of the current chunk
+fn chunk_by_fn(_: &u8, b: &u8) -> bool {
+    *b == 0
+}
+
+// all cases of chunking up to length 4
+const CHUNKS: [&[&[u8]]; 16] = [
+    &[],
+    &[&[1]],
+    &[&[1, 0]],
+    &[&[1], &[1]],
+    &[&[1, 0, 0]],
+    &[&[1, 0], &[1]],
+    &[&[1], &[1, 0]],
+    &[&[1], &[1], &[1]],
+    &[&[1, 0, 0, 0]],
+    &[&[1, 0, 0], &[1]],
+    &[&[1, 0], &[1, 0]],
+    &[&[1, 0], &[1], &[1]],
+    &[&[1], &[1, 0, 0]],
+    &[&[1], &[1, 0], &[1]],
+    &[&[1], &[1], &[1, 0]],
+    &[&[1], &[1], &[1], &[1]],
+];
+
+#[test]
+fn test_chunk_by_count() {
+    for chunks in CHUNKS {
+        let case: Vec<_> = chunks.concat();
+        assert_eq!(
+            case.chunk_by(chunk_by_fn).map(|_| 1).sum::<usize>(),
+            case.chunk_by(chunk_by_fn).count(),
+            "not equal for {case:?}"
+        );
+    }
+}
+
+#[test]
+fn test_chunk_by_chunks() {
+    // tests next through collect
+    for chunks in CHUNKS {
+        let case: Vec<_> = chunks.concat();
+        assert_eq!(
+            chunks,
+            case.chunk_by(chunk_by_fn).collect::<Vec<_>>(),
+            "not equal for {case:?}"
+        );
+    }
+}
+
+#[test]
+fn test_chunk_by_rchunks() {
+    // tests next_back through rfold
+    for chunks in CHUNKS {
+        let case: Vec<_> = chunks.concat();
+        assert_eq!(
+            chunks.iter().rev().copied().collect::<Vec<_>>(),
+            case.chunk_by(chunk_by_fn).rfold(vec![], |mut v, e| {
+                v.push(e);
+                v
+            }),
+            "not equal for {case:?}"
+        );
+    }
+}
+
+#[test]
+fn test_chunk_by_last() {
+    for chunks in CHUNKS {
+        let case: Vec<_> = chunks.concat();
+        assert_eq!(
+            chunks.iter().copied().last(),
+            case.chunk_by(chunk_by_fn).last(),
+            "not equal for {case:?}"
+        );
+    }
+}
+
 #[test]
 fn test_array_windows_infer() {
     let v: &[i32] = &[0, 1, 0, 1];


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/159389)*
<!-- homu-ignore:end -->

Cleanup `chunk_by` count method (introduced in rust-lang/rust#158866) to use `array_windows` for improved readability.

EDIT: also added tests for `chunk_by`.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
