### PR TITLE
Update tests for LLVM 23

### DIFF
--- a/tests/assembly-llvm/simd-intrinsic-mask-reduce.rs
+++ b/tests/assembly-llvm/simd-intrinsic-mask-reduce.rs
@@ -1,12 +1,16 @@
 // verify that simd mask reductions do not introduce additional bit shift operations
 //@ add-minicore
-//@ revisions: x86 aarch64
+//@ revisions: x86 aarch64-llvm22 aarch64
 //@ [x86] compile-flags: --target=x86_64-unknown-linux-gnu -C llvm-args=-x86-asm-syntax=intel
 // Set the base cpu explicitly, in case the default has been changed.
 //@ [x86] compile-flags: -C target-cpu=x86-64
 //@ [x86] needs-llvm-components: x86
+//@ [aarch64-llvm22] compile-flags: --target=aarch64-unknown-linux-gnu
+//@ [aarch64-llvm22] needs-llvm-components: aarch64
+//@ [aarch64-llvm22] max-llvm-major-version: 22
 //@ [aarch64] compile-flags: --target=aarch64-unknown-linux-gnu
 //@ [aarch64] needs-llvm-components: aarch64
+//@ [aarch64] min-llvm-version: 23
 //@ assembly-output: emit-asm
 //@ compile-flags: --crate-type=lib -Copt-level=3 -C panic=abort
 
@@ -33,12 +37,19 @@ pub unsafe extern "C" fn mask_reduce_all(m: mask8x16) -> bool {
     // x86-NEXT: {{cmp ax, -1|cmp eax, 65535|xor eax, 65535}}
     // x86-NEXT: sete al
     //
+    // aarch64-llvm22-NOT: shl
+    // aarch64-llvm22: cmge v0.16b, v0.16b, #0
+    // aarch64-llvm22-DAG: mov [[REG1:[a-z0-9]+]], #1
+    // aarch64-llvm22-DAG: umaxv b0, v0.16b
+    // aarch64-llvm22-NEXT: fmov [[REG2:[a-z0-9]+]], s0
+    // aarch64-llvm22-NEXT: bic w0, [[REG1]], [[REG2]]
+    //
     // aarch64-NOT: shl
     // aarch64: cmge v0.16b, v0.16b, #0
-    // aarch64-DAG: mov [[REG1:[a-z0-9]+]], #1
-    // aarch64-DAG: umaxv b0, v0.16b
-    // aarch64-NEXT: fmov [[REG2:[a-z0-9]+]], s0
-    // aarch64-NEXT: bic w0, [[REG1]], [[REG2]]
+    // aarch64-NEXT: addp [[REG1:d[0-9]+]], v0.2d
+    // aarch64-NEXT: fmov [[REG2:x[0-9]+]], [[REG1]]
+    // aarch64-NEXT: cmp [[REG2]], #0
+    // aarch64-NEXT: cset w0, eq
     simd_reduce_all(m)
 }
 
@@ -50,10 +61,17 @@ pub unsafe extern "C" fn mask_reduce_any(m: mask8x16) -> bool {
     // x86-NEXT: test eax, eax
     // x86-NEXT: setne al
     //
+    // aarch64-llvm22-NOT: shl
+    // aarch64-llvm22: cmlt v0.16b, v0.16b, #0
+    // aarch64-llvm22-NEXT: umaxv b0, v0.16b
+    // aarch64-llvm22-NEXT: fmov [[REG:[a-z0-9]+]], s0
+    // aarch64-llvm22-NEXT: and w0, [[REG]], #0x1
+    //
     // aarch64-NOT: shl
     // aarch64: cmlt v0.16b, v0.16b, #0
-    // aarch64-NEXT: umaxv b0, v0.16b
-    // aarch64-NEXT: fmov [[REG:[a-z0-9]+]], s0
-    // aarch64-NEXT: and w0, [[REG]], #0x1
+    // aarch64-NEXT: addp [[REG1:d[0-9]+]], v0.2d
+    // aarch64-NEXT: fmov [[REG2:x[0-9]+]], [[REG1]]
+    // aarch64-NEXT: cmp [[REG2]], #0
+    // aarch64-NEXT: cset w0, ne
     simd_reduce_any(m)
 }

--- a/tests/assembly-llvm/slice-is_ascii.rs
+++ b/tests/assembly-llvm/slice-is_ascii.rs
@@ -6,6 +6,11 @@
 //@ only-x86_64
 //@ ignore-sgx
 
+// No longer optimizes as desired, tracked at:
+// https://github.com/rust-lang/rust/issues/154141
+// https://github.com/llvm/llvm-project/issues/209216
+//@ max-llvm-major-version: 22
+
 #![feature(str_internals)]
 
 // CHECK-LABEL: is_ascii_simple_demo:

--- a/tests/codegen-llvm/asm/global_asm.rs
+++ b/tests/codegen-llvm/asm/global_asm.rs
@@ -7,10 +7,10 @@
 
 use std::arch::global_asm;
 
-// CHECK-LABEL: foo
 // CHECK: module asm
+// CHECK-LABEL: foo
 // this regex will capture the correct unconditional branch inst.
-// CHECK: module asm "{{[[:space:]]+}}jmp baz"
+// CHECK: "{{[[:space:]]+}}jmp baz"
 global_asm!(
     r#"
     .global foo

--- a/tests/codegen-llvm/asm/global_asm_include.rs
+++ b/tests/codegen-llvm/asm/global_asm_include.rs
@@ -7,9 +7,9 @@
 
 use std::arch::global_asm;
 
-// CHECK-LABEL: foo
 // CHECK: module asm
-// CHECK: module asm "{{[[:space:]]+}}jmp baz"
+// CHECK-LABEL: foo
+// CHECK: "{{[[:space:]]+}}jmp baz"
 global_asm!(include_str!("foo.s"));
 
 extern "C" {

--- a/tests/codegen-llvm/asm/global_asm_x2.rs
+++ b/tests/codegen-llvm/asm/global_asm_x2.rs
@@ -8,12 +8,12 @@
 
 use core::arch::global_asm;
 
-// CHECK-LABEL: foo
 // CHECK: module asm
-// CHECK: module asm "{{[[:space:]]+}}jmp baz"
+// CHECK-LABEL: foo
+// CHECK: "{{[[:space:]]+}}jmp baz"
 // any other global_asm will be appended to this first block, so:
 // CHECK-LABEL: bar
-// CHECK: module asm "{{[[:space:]]+}}jmp quux"
+// CHECK: "{{[[:space:]]+}}jmp quux"
 global_asm!(
     r#"
     .global foo

--- a/tests/codegen-llvm/issues/issue-107681-unwrap_unchecked.rs
+++ b/tests/codegen-llvm/issues/issue-107681-unwrap_unchecked.rs
@@ -14,7 +14,6 @@ pub unsafe fn foo(x: &mut Copied<Iter<'_, u32>>) -> u32 {
     // CHECK-NOT: br {{.*}}
     // CHECK-NOT: select
     // CHECK: [[RET:%.*]] = load i32, ptr
-    // CHECK-NEXT: assume
-    // CHECK-NEXT: ret i32 [[RET]]
+    // CHECK: ret i32 [[RET]]
     x.next().unwrap_unchecked()
 }

--- a/tests/run-make/pgo-branch-weights/filecheck-patterns.txt
+++ b/tests/run-make/pgo-branch-weights/filecheck-patterns.txt
@@ -2,16 +2,16 @@
 # First, establish that certain !prof labels are attached to the expected
 # functions and branching instructions.
 
-CHECK: define void @function_called_twice(i32 {{.*}} !prof [[function_called_twice_id:![0-9]+]] {
+CHECK: define void @function_called_twice(i32 {{.*}} !prof [[function_called_twice_id:![0-9]+]]
 CHECK: br i1 {{.*}}, label {{.*}}, label {{.*}}, !prof [[branch_weights0:![0-9]+]]
 
-CHECK: define void @function_called_42_times(i32{{.*}} %c) {{.*}} !prof [[function_called_42_times_id:![0-9]+]] {
+CHECK: define void @function_called_42_times(i32{{.*}} %c) {{.*}} !prof [[function_called_42_times_id:![0-9]+]]
 CHECK:      switch i32 %c, label {{.*}} [
 CHECK-NEXT:     i32 97, label {{.*}}
 CHECK-NEXT:     i32 98, label {{.*}}
 CHECK-NEXT: ], !prof [[branch_weights1:![0-9]+]]
 
-CHECK: define void @function_called_never(i32 {{.*}} !prof [[function_called_never_id:![0-9]+]] {
+CHECK: define void @function_called_never(i32 {{.*}} !prof [[function_called_never_id:![0-9]+]]
 
 
 

--- a/tests/run-make/pgo-embed-bc-lto/interesting.rs
+++ b/tests/run-make/pgo-embed-bc-lto/interesting.rs
@@ -10,7 +10,7 @@ pub fn function_called_once() {
 }
 
 // CHECK-LABEL: @function_called_once
-// CHECK-SAME: !prof [[function_called_once_id:![0-9]+]] {
+// CHECK-SAME: !prof [[function_called_once_id:![0-9]+]]
 // CHECK: "CG Profile"
 // CHECK-NOT: "CG Profile"
 // CHECK-DAG: [[function_called_once_id]] = !{!"function_entry_count", i64 1}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/158880.
Fixes https://github.com/rust-lang/rust/issues/158572.
Fixes https://github.com/rust-lang/rust/issues/156050.

One test is disabled on LLVM 23, because it's no longer optimized as expected. Tracked in https://github.com/rust-lang/rust/issues/154141 and https://github.com/llvm/llvm-project/issues/209216.