### PR TITLE
Gate `tests/debuginfo/function-call.rs` on min GDB 15.1

### DIFF
--- a/tests/debuginfo/function-call.rs
+++ b/tests/debuginfo/function-call.rs
@@ -1,5 +1,9 @@
 // This test does not passed with gdb < 8.0. See #53497.
-//@ min-gdb-version: 10.1
+//
+// This test seems to have become very flaky with "Couldn't write extended state status: Bad
+// address." since around June 2026, where CI typically uses GDB 12.1 on Ubuntu 22.04. I tried
+// running this locally with GDB 15.1 and could not reproduce the flakiness. See #159073.
+//@ min-gdb-version: 15.1
 
 //@ compile-flags:-g
 //@ ignore-backends: gcc


### PR DESCRIPTION
## Summary

See rust-lang/rust#159073, this test has been flaky with

```
/checkout/obj/build/x86_64-unknown-linux-gnu/test/debuginfo/function-call.gdb/function-call.debugger.script:11: Error in sourced command file:
Couldn't write extended state status: Bad address.
```

on linux CI jobs under various environments and hosts/targets. I tried running this under GDB 15.1 locally (WSL, `x86_64-unknown-linux-gnu`) but could not reproduce. CI typically uses GDB 12.1 with Ubuntu 22.04. So gate this test with min GDB 15.1 which prevents it from running in CI to workaround the flakiness but still allow running it locally under GDB >= 15.1.

It's *possible* there's a genuine problem here, but this looks like a deep debugging rabbit hole so let's not run this test in CI for now to not have the frequent flakiness. Revert this PR if we figure out where the problem lies.

## Additional context

Also asked in [#t-compiler > &#96;tests/debuginfo/function-call.rs&#96; + gdb recently flaky](https://rust-lang.zulipchat.com/#narrow/channel/131828-t-compiler/topic/.60tests.2Fdebuginfo.2Ffunction-call.2Ers.60.20.2B.20gdb.20recently.20flaky/with/611111005).