### PR TITLE
Clarify safety requirements for SIMD shl/shr and masked load/store

### DIFF
--- a/library/core/src/intrinsics/simd/mod.rs
+++ b/library/core/src/intrinsics/simd/mod.rs
@@ -109,13 +109,13 @@ pub const unsafe fn simd_rem<T>(lhs: T, rhs: T) -> T;
 
 /// Shifts vector left elementwise, with UB on overflow.
 ///
-/// Shifts `lhs` left by `rhs`, shifting in sign bits for signed types.
+/// Shifts `lhs` left by `rhs`, shifting in zeros.
 ///
 /// `T` must be a vector of integers.
 ///
 /// # Safety
 ///
-/// Each element of `rhs` must be less than `<int>::BITS`.
+/// Each element of `rhs` must be in `0..<int>::BITS`.
 #[rustc_intrinsic]
 #[rustc_nounwind]
 pub const unsafe fn simd_shl<T>(lhs: T, rhs: T) -> T;
@@ -128,7 +128,7 @@ pub const unsafe fn simd_shl<T>(lhs: T, rhs: T) -> T;
 ///
 /// # Safety
 ///
-/// Each element of `rhs` must be less than `<int>::BITS`.
+/// Each element of `rhs` must be in `0..<int>::BITS`.
 #[rustc_intrinsic]
 #[rustc_nounwind]
 pub const unsafe fn simd_shr<T>(lhs: T, rhs: T) -> T;
@@ -145,7 +145,7 @@ pub const unsafe fn simd_shr<T>(lhs: T, rhs: T) -> T;
 ///
 /// # Safety
 ///
-/// Each element of `shift` must be less than `<int>::BITS`.
+/// Each element of `shift` must be in `0..<int>::BITS`.
 #[rustc_intrinsic]
 #[rustc_nounwind]
 pub const unsafe fn simd_funnel_shl<T>(a: T, b: T, shift: T) -> T;
@@ -162,7 +162,7 @@ pub const unsafe fn simd_funnel_shl<T>(a: T, b: T, shift: T) -> T;
 ///
 /// # Safety
 ///
-/// Each element of `shift` must be less than `<int>::BITS`.
+/// Each element of `shift` must be in `0..<int>::BITS`.
 #[rustc_intrinsic]
 #[rustc_nounwind]
 pub const unsafe fn simd_funnel_shr<T>(a: T, b: T, shift: T) -> T;
@@ -433,6 +433,9 @@ pub enum SimdAlign {
 /// # Safety
 /// `ptr` must be aligned according to the `ALIGN` parameter, see [`SimdAlign`] for details.
 ///
+/// Each pointer offset from `ptr` whose corresponding value in `mask` is `!0` must be readable as if
+/// by [`ptr::read`][crate::ptr::read].
+///
 /// `mask` must only contain `0` or `!0` values.
 #[rustc_intrinsic]
 #[rustc_nounwind]
@@ -454,6 +457,9 @@ pub const unsafe fn simd_masked_load<V, U, T, const ALIGN: SimdAlign>(mask: V, p
 ///
 /// # Safety
 /// `ptr` must be aligned according to the `ALIGN` parameter, see [`SimdAlign`] for details.
+///
+/// Each pointer offset from `ptr` whose corresponding value in `mask` is `!0` must be writable as if
+/// by [`ptr::write`][crate::ptr::write].
 ///
 /// `mask` must only contain `0` or `!0` values.
 #[rustc_intrinsic]


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->


This PR fixes some safety documentation of SIMD functions. These functions are talked in Zulip topic: [Maybe some safety doc need fixs in intrinsics::simd](https://rust-lang.zulipchat.com/#narrow/channel/131828-t-compiler/topic/Maybe.20some.20safety.20doc.20need.20fixs.20in.20intrinsics.3A.3Asimd/with/609693756).

Brief explanation: `simd_shl` and `simd_shr` may accept a `rhs` of negative value, but that value will be interpreted as unsigned and thus violate the requirement that `rhs` is less than `<int>::BITS`. So it's better to add a supplement that `rhs` must be in 0..`<int>::BITS`. Also, the `simd_shl` refer that `shifting in sign bits for signed types`, but left shift always shifts in zero bits.

And `simd_masked_load` and `simd_masked_store` need to explicitly state that the corresponding `ptr` must be readable/writable as if by `ptr::read/write`, refering to [portable-simd::core_simd::load_select_ptr](https://doc.rust-lang.org/src/core/portable-simd/crates/core_simd/src/vector.rs.html#451) and [portable-simd::core_simd::store_select_ptr](https://doc.rust-lang.org/src/core/portable-simd/crates/core_simd/src/vector.rs.html#710)