### PR TITLE
[aarch64][win] Pass oversized c-variadic args indirectly on Arm64EC

### DIFF
--- a/compiler/rustc_target/src/callconv/aarch64.rs
+++ b/compiler/rustc_target/src/callconv/aarch64.rs
@@ -3,7 +3,7 @@ use std::iter;
 use rustc_abi::{BackendRepr, HasDataLayout, Primitive, TyAbiInterface};
 
 use crate::callconv::{ArgAbi, FnAbi, Reg, RegKind, Uniform};
-use crate::spec::{HasTargetSpec, RustcAbi, Target};
+use crate::spec::{Arch, HasTargetSpec, RustcAbi, Target};
 
 /// Indicates the variant of the AArch64 ABI we are compiling for.
 /// Used to accommodate Apple and Microsoft's deviations from the usual AAPCS ABI.
@@ -166,10 +166,26 @@ where
         classify_ret(cx, &mut fn_abi.ret, kind);
     }
 
-    for arg in fn_abi.args.iter_mut() {
+    // On Arm64EC the variadic portion of a c-variadic call follows the MS x64 ABI:
+    // "Any argument that doesn't fit in 8 bytes, or is not 1, 2, 4, or 8 bytes, must
+    // be passed by reference".
+    let c_variadic = fn_abi.c_variadic;
+    let fixed_count = fn_abi.fixed_count as usize;
+    let is_arm64ec = cx.target_spec().arch == Arch::Arm64EC;
+
+    for (idx, arg) in fn_abi.args.iter_mut().enumerate() {
         if arg.is_ignore() {
             continue;
         }
+
+        if is_arm64ec && c_variadic && idx >= fixed_count {
+            let size = arg.layout.size.bytes();
+            if size > 8 || !size.is_power_of_two() {
+                arg.make_indirect();
+                continue;
+            }
+        }
+
         classify_arg(cx, arg, kind);
     }
 }

--- a/tests/codegen-llvm/arm64ec-c-variadic-i128.rs
+++ b/tests/codegen-llvm/arm64ec-c-variadic-i128.rs
@@ -1,0 +1,39 @@
+//! Verify the arm64ec calling convention for `i128` passed through the variadic
+//! portion of a C-variadic call.
+//!
+//! On arm64ec the variadic tail follows the MS x64 ABI: any argument that does not
+//! fit in 8 bytes, or is not 1/2/4/8 bytes, is passed by reference. So a variadic
+//! `i128`/`u128` is passed indirectly (as a pointer), which must stay in sync with
+//! how `va_arg` reads it back. A *fixed* `i128` argument is still passed by value.
+
+//@ add-minicore
+//@ compile-flags: -Copt-level=3 --target arm64ec-pc-windows-msvc
+//@ needs-llvm-components: aarch64
+
+#![crate_type = "lib"]
+#![no_std]
+#![no_core]
+#![feature(no_core)]
+
+extern crate minicore;
+
+extern "C" {
+    fn variadic(fixed: u32, ...);
+    fn fixed(arg: i128);
+}
+
+// A variadic `i128` argument is passed by reference (as a pointer).
+#[no_mangle]
+pub unsafe extern "C" fn pass_variadic_i128(x: i128) {
+    // CHECK-LABEL: @pass_variadic_i128(
+    // CHECK: call void (i32, ...) @variadic(i32 {{.*}}, ptr {{.*}})
+    variadic(0, x);
+}
+
+// A fixed `i128` argument is still passed by value.
+#[no_mangle]
+pub unsafe extern "C" fn pass_fixed_i128(x: i128) {
+    // CHECK-LABEL: @pass_fixed_i128(
+    // CHECK: call void @fixed(i128
+    fixed(x);
+}


### PR DESCRIPTION
On Arm64EC the variadic portion of a c-variadic call must follow the MS x64 ABI: any argument that does not fit in 8 bytes, or whose size is not 1, 2, 4, or 8 bytes, is passed by reference. rustc's `va_arg` implementation already reads such arguments indirectly, but the caller side in `aarch64::compute_abi_info` passed a scalar `i128` by value (it is not an aggregate, so it bypassed `classify_arg`). The callee then dereferenced the inline value as a pointer, causing an access violation (0xC0000005) at runtime.

Mark variadic-tail arguments larger than 8 bytes, or whose size is not a power of two, as indirect on Arm64EC so the caller and the `va_arg` reader agree. Fixed arguments are unaffected: a fixed `i128` is still passed by value, matching MSVC and Clang.

Add a codegen test verifying that a variadic `i128` is passed as a pointer while a fixed `i128` is passed by value.