### PR TITLE
Skip no-op landing pads after monomorphization

### DIFF
--- a/compiler/rustc_codegen_ssa/src/mir/analyze.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/analyze.rs
@@ -7,6 +7,7 @@ use rustc_index::bit_set::DenseBitSet;
 use rustc_index::{IndexSlice, IndexVec};
 use rustc_middle::mir::visit::{MutatingUseContext, NonMutatingUseContext, PlaceContext, Visitor};
 use rustc_middle::mir::{self, DefLocation, Location, TerminatorKind, traversal};
+use rustc_middle::ty::TyCtxt;
 use rustc_middle::ty::layout::{HasTyCtxt, LayoutOf};
 use rustc_middle::{bug, span_bug, ty};
 use tracing::debug;
@@ -271,6 +272,79 @@ impl<'a, 'b, 'tcx, Bx: BuilderMethods<'b, 'tcx>> Visitor<'tcx> for LocalAnalyzer
     fn visit_statement_debuginfo(&mut self, _: &mir::StmtDebugInfo<'tcx>, _: Location) {
         // Debuginfo does not generate actual code.
     }
+}
+
+/// Finds cleanup blocks that turn out to be no-op landing pads after
+/// monomorphization: on the unwind path they do nothing except (transitively)
+/// "drop" types that don't actually need dropping, before resuming unwinding.
+///
+/// Unwind edges to such blocks are replaced with `UnwindAction::Continue`
+/// during codegen, so no useless `invoke` + landing pad is emitted for them.
+/// This is the monomorphization-aware counterpart of the
+/// `RemoveNoopLandingPads` MIR pass, which runs on generic MIR and so has to
+/// conservatively treat drops of generic types as needing drop.
+pub(crate) fn nop_landing_pads<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    instance: ty::Instance<'tcx>,
+    mir: &mir::Body<'tcx>,
+) -> DenseBitSet<mir::BasicBlock> {
+    let mut nop_landing_pads = DenseBitSet::new_empty(mir.basic_blocks.len());
+    if !mir.basic_blocks.iter().any(|bb| bb.is_cleanup) {
+        return nop_landing_pads;
+    }
+
+    let typing_env = ty::TypingEnv::fully_monomorphized();
+    // Postorder, so that a block's successors are visited before the block.
+    for (bb, data) in traversal::postorder(mir) {
+        if !data.is_cleanup {
+            continue;
+        }
+
+        let nop_statements = data.statements.iter().all(|stmt| match &stmt.kind {
+            mir::StatementKind::StorageLive(_)
+            | mir::StatementKind::StorageDead(_)
+            | mir::StatementKind::Coverage(..)
+            | mir::StatementKind::ConstEvalCounter
+            | mir::StatementKind::BackwardIncompatibleDropHint { .. }
+            | mir::StatementKind::Nop => true,
+
+            // Writing to a local (e.g., a drop flag) cannot be observed once
+            // the landing pad is skipped.
+            mir::StatementKind::Assign(assign) => {
+                matches!(assign.1, mir::Rvalue::Use(..) | mir::Rvalue::Discriminant(_))
+                    && assign.0.as_local().is_some()
+            }
+
+            _ => false,
+        });
+        if !nop_statements {
+            continue;
+        }
+
+        let terminator = data.terminator();
+        let nop_terminator = match terminator.kind {
+            TerminatorKind::Goto { .. }
+            | TerminatorKind::UnwindResume
+            | TerminatorKind::SwitchInt { .. } => {
+                terminator.successors().all(|succ| nop_landing_pads.contains(succ))
+            }
+            // A drop of a type without drop glue is a no-op. Its unwind
+            // successor doesn't matter as the drop is never actually called.
+            TerminatorKind::Drop { place, target, .. } => {
+                let ty = instance.instantiate_mir_and_normalize_erasing_regions(
+                    tcx,
+                    typing_env,
+                    ty::EarlyBinder::bind(tcx, place.ty(mir, tcx).ty),
+                );
+                !ty.needs_drop(tcx, typing_env) && nop_landing_pads.contains(target)
+            }
+            _ => false,
+        };
+        if nop_terminator {
+            nop_landing_pads.insert(bb);
+        }
+    }
+    nop_landing_pads
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]

--- a/compiler/rustc_codegen_ssa/src/mir/block.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/block.rs
@@ -215,6 +215,17 @@ impl<'a, 'tcx> TerminatorCodegenHelper<'tcx> {
             unwind = mir::UnwindAction::Unreachable;
         }
 
+        // After monomorphization, a landing pad may turn out to be a no-op
+        // (e.g. when the only thing it would drop is a type that doesn't
+        // actually need dropping); skip it and let unwinding continue past
+        // this frame instead. This is the monomorphization-aware counterpart
+        // of what `RemoveNoopLandingPads` does on generic MIR.
+        if let mir::UnwindAction::Cleanup(cleanup) = unwind
+            && fx.nop_landing_pads.contains(cleanup)
+        {
+            unwind = mir::UnwindAction::Continue;
+        }
+
         let unwind_block = match unwind {
             mir::UnwindAction::Cleanup(cleanup) => Some(self.llbb_with_cleanup(fx, cleanup)),
             mir::UnwindAction::Continue => None,
@@ -319,10 +330,15 @@ impl<'a, 'tcx> TerminatorCodegenHelper<'tcx> {
         mergeable_succ: bool,
     ) -> MergingSucc {
         let unwind_target = match unwind {
-            mir::UnwindAction::Cleanup(cleanup) => Some(self.llbb_with_cleanup(fx, cleanup)),
+            // As in `do_call`, skip landing pads that are no-ops after
+            // monomorphization.
+            mir::UnwindAction::Cleanup(cleanup) if !fx.nop_landing_pads.contains(cleanup) => {
+                Some(self.llbb_with_cleanup(fx, cleanup))
+            }
             mir::UnwindAction::Terminate(reason) => Some(fx.terminate_block(reason, None)),
-            mir::UnwindAction::Continue => None,
-            mir::UnwindAction::Unreachable => None,
+            mir::UnwindAction::Cleanup(_)
+            | mir::UnwindAction::Continue
+            | mir::UnwindAction::Unreachable => None,
         };
 
         if operands.iter().any(|x| matches!(x, InlineAsmOperandRef::Label { .. })) {

--- a/compiler/rustc_codegen_ssa/src/mir/mod.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/mod.rs
@@ -80,6 +80,11 @@ pub struct FunctionCx<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> {
     /// The funclet status of each basic block
     cleanup_kinds: Option<IndexVec<mir::BasicBlock, analyze::CleanupKind>>,
 
+    /// Cleanup blocks that turned out to be no-op landing pads after
+    /// monomorphization; unwind edges to them are replaced with
+    /// `UnwindAction::Continue` (see [`analyze::nop_landing_pads`]).
+    nop_landing_pads: DenseBitSet<mir::BasicBlock>,
+
     /// When targeting MSVC, this stores the cleanup info for each funclet BB.
     /// This is initialized at the same time as the `landing_pads` entry for the
     /// funclets' head block, i.e. when needed by an unwind / `cleanup_ret` edge.
@@ -227,8 +232,41 @@ pub fn codegen_mir<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
     let start_llbb = Bx::append_block(cx, llfn, "start");
     let mut start_bx = Bx::build(cx, start_llbb);
 
-    if mir.basic_blocks.iter().any(|bb| {
-        bb.is_cleanup || matches!(bb.terminator().unwind(), Some(mir::UnwindAction::Terminate(_)))
+    let nop_landing_pads = analyze::nop_landing_pads(tcx, instance, mir);
+
+    let mut traversal_order = traversal::mono_reachable_reverse_postorder(mir, tcx, instance);
+    if !nop_landing_pads.is_empty() {
+        // Skipping the unwind edges to no-op landing pads can make (parts of)
+        // the cleanup path unreachable; don't codegen unreachable blocks.
+        let mut reachable = DenseBitSet::new_empty(mir.basic_blocks.len());
+        reachable.insert(mir::START_BLOCK);
+        let mut stack = vec![mir::START_BLOCK];
+        while let Some(bb) = stack.pop() {
+            let data = &mir.basic_blocks[bb];
+            let skipped_unwind = match data.terminator().unwind() {
+                Some(&mir::UnwindAction::Cleanup(cleanup))
+                    if nop_landing_pads.contains(cleanup) =>
+                {
+                    Some(cleanup)
+                }
+                _ => None,
+            };
+            for succ in data.mono_successors(tcx, instance) {
+                if Some(succ) != skipped_unwind && reachable.insert(succ) {
+                    stack.push(succ);
+                }
+            }
+        }
+        traversal_order.retain(|bb| reachable.contains(*bb));
+    }
+
+    // The personality function is only needed if some codegenned block is a
+    // landing pad (all cleanup blocks are potential landing pads, and contain
+    // `resume`s) or calls the terminate block upon unwinding.
+    if traversal_order.iter().any(|&bb| {
+        let data = &mir.basic_blocks[bb];
+        data.is_cleanup
+            || matches!(data.terminator().unwind(), Some(mir::UnwindAction::Terminate(_)))
     }) {
         start_bx.set_personality_fn(cx.eh_personality());
     }
@@ -255,6 +293,7 @@ pub fn codegen_mir<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
         unreachable_block: None,
         terminate_blocks: IndexVec::from_elem(None, &mir.basic_blocks),
         cleanup_kinds,
+        nop_landing_pads,
         landing_pads: IndexVec::from_elem(None, &mir.basic_blocks),
         funclets: IndexVec::from_fn_n(|_| None, mir.basic_blocks.len()),
         cold_blocks: find_cold_blocks(tcx, mir),
@@ -275,7 +314,6 @@ pub fn codegen_mir<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
         fx.compute_per_local_var_debug_info(&mut start_bx).unzip();
     fx.per_local_var_debug_info = per_local_var_debug_info;
 
-    let traversal_order = traversal::mono_reachable_reverse_postorder(mir, tcx, instance);
     let memory_locals = analyze::non_ssa_locals(&fx, &traversal_order);
 
     // Allocate variable and temp allocas

--- a/tests/codegen-llvm/noop-landing-pad-mono.rs
+++ b/tests/codegen-llvm/noop-landing-pad-mono.rs
@@ -1,0 +1,29 @@
+//@ compile-flags: -Copt-level=0 -Ccodegen-units=1 -Cno-prepopulate-passes
+//@ needs-unwind
+
+// Regression test for <https://github.com/rust-lang/rust/issues/159399>.
+//
+// `RemoveNoopLandingPads` can't remove the landing pad of `generic_wrapper`
+// because it runs on generic MIR, where `T` conservatively needs drop. When
+// monomorphizing with a no-drop type like `u32`, codegen must notice that the
+// landing pad does nothing and skip it, instead of emitting an `invoke` whose
+// landing pad just resumes.
+
+#![crate_type = "lib"]
+
+#[inline(never)]
+fn inner(_: &dyn Sync) {}
+
+// CHECK-LABEL: define{{.*}}generic_wrapper
+// CHECK-NOT: personality
+// CHECK-NOT: invoke
+// CHECK-NOT: landingpad
+// CHECK-NOT: resume
+// CHECK-LABEL: {{^[}]}}
+fn generic_wrapper<T: Sync>(val: T) {
+    inner(&val);
+}
+
+pub fn caller() {
+    generic_wrapper(1u32);
+}


### PR DESCRIPTION
This PR introduces a monomorphization-aware analysis to identify and skip cleanup blocks that are effectively no-ops (e.g., when they only drop types that do not need dropping). 

Previously, rustc would emit unnecessary cleanup blocks and `invoke` instructions for generic functions instantiated with no-drop types, resulting in dead code in the final assembly. This analysis acts as the monomorphization counterpart to the `RemoveNoopLandingPads` MIR pass, which runs on generic MIR and must conservatively assume drops are needed. During codegen, unwind edges to these no-op landing pads are replaced with `UnwindAction::Continue`, preventing the emission of useless landing pads.

Closes rust-lang/rust#159399