### PR TITLE
rustdoc: remove old `--emit` types

### DIFF
--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -336,9 +336,6 @@ impl FromStr for EmitType {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            // old nightly-only choices that are going away soon
-            "toolchain-shared-resources" => Ok(Self::HtmlStaticFiles),
-            "invocation-specific" => Ok(Self::HtmlNonStaticFiles),
             // modern choices
             "html-static-files" => Ok(Self::HtmlStaticFiles),
             "html-non-static-files" => Ok(Self::HtmlNonStaticFiles),

--- a/src/librustdoc/html/render/write_shared.rs
+++ b/src/librustdoc/html/render/write_shared.rs
@@ -11,7 +11,7 @@
 //!    contents, so they do not include a hash in their filename and are not safe to
 //!    cache with `Cache-Control: immutable`. They include the contents of the
 //!    --resource-suffix flag and are emitted when --emit-type is empty (default)
-//!    or contains "invocation-specific".
+//!    or contains "html-non-static-files".
 
 use std::cell::RefCell;
 use std::ffi::{OsStr, OsString};

--- a/tests/run-make/emit-shared-files/rmake.rs
+++ b/tests/run-make/emit-shared-files/rmake.rs
@@ -12,7 +12,7 @@ use run_make_support::{has_extension, has_prefix, path, rustdoc, shallow_find_fi
 fn main() {
     rustdoc()
         .arg("-Zunstable-options")
-        .arg("--emit=invocation-specific")
+        .arg("--emit=html-non-static-files")
         .out_dir("invocation-only")
         .arg("--resource-suffix=-xxx")
         .args(&["--theme", "y.css"])

--- a/tests/run-make/rustdoc-scrape-examples-dep-info/rmake.rs
+++ b/tests/run-make/rustdoc-scrape-examples-dep-info/rmake.rs
@@ -9,7 +9,7 @@ fn main() {
 
     scrape::scrape(
         &["--scrape-tests", "--emit=dep-info"],
-        &["--emit=dep-info,invocation-specific"],
+        &["--emit=dep-info,html-non-static-files"],
     );
 
     let content = rfs::read_to_string("rustdoc/foobar.d").replace(r"\", "/");


### PR DESCRIPTION
We deprecated these awhile ago, and now all the usages are changed.
