### PR TITLE
Fix typo in usize::overflowing_add docs

### DIFF
--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -2938,7 +2938,7 @@ macro_rules! uint_impl {
         /// # Examples
         ///
         /// ```
-        #[doc = concat!("assert_eq!(5", stringify!($SelfT), ".overflowing_add(2), (7, false));")]
+        #[doc = concat!("assert_eq!(5_", stringify!($SelfT), ".overflowing_add(2), (7, false));")]
         #[doc = concat!("assert_eq!(", stringify!($SelfT), "::MAX.overflowing_add(1), (0, true));")]
         /// ```
         #[stable(feature = "wrapping", since = "1.7.0")]


### PR DESCRIPTION
<!-- homu-ignore:start -->
Fixes a minor formatting inconsistency in the documentation examples for `overflowing_add`.

Specifically, this adds an underscore separator to the numeric literal suffix to match the established idiomatic styling used throughout other macro-generated primitive documentation examples (for instance, the `wrapping_shr` examples which consistently use `128_usize`, `42_usize`, etc.).
<!-- homu-ignore:end -->
