### PR TITLE
Remove redundant Xous network error checks

### DIFF
--- a/library/std/src/sys/net/connection/xous/tcplistener.rs
+++ b/library/std/src/sys/net/connection/xous/tcplistener.rs
@@ -135,8 +135,6 @@ impl TcpListener {
                     return Err(io::const_error!(io::ErrorKind::TimedOut, "accept timed out"));
                 } else if receive_request.raw[4] == NetError::WouldBlock as u8 {
                     return Err(io::const_error!(io::ErrorKind::WouldBlock, "accept would block"));
-                } else if receive_request.raw[4] == NetError::LibraryError as u8 {
-                    return Err(io::const_error!(io::ErrorKind::Other, "library error"));
                 } else {
                     return Err(io::const_error!(io::ErrorKind::Other, "library error"));
                 }

--- a/library/std/src/sys/net/connection/xous/udp.rs
+++ b/library/std/src/sys/net/connection/xous/udp.rs
@@ -151,8 +151,6 @@ impl UdpSocket {
                     return Err(io::const_error!(io::ErrorKind::TimedOut, "recv timed out"));
                 } else if receive_request.raw[4] == NetError::WouldBlock as u8 {
                     return Err(io::const_error!(io::ErrorKind::WouldBlock, "recv would block"));
-                } else if receive_request.raw[4] == NetError::LibraryError as u8 {
-                    return Err(io::const_error!(io::ErrorKind::Other, "library error"));
                 } else {
                     return Err(io::const_error!(io::ErrorKind::Other, "library error"));
                 }


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

The Xous UDP receive path and TCP listener accept path explicitly checked
`NetError::LibraryError`, but the matching branch and catch-all branch both
returned `io::ErrorKind::Other` with `"library error"`.

Remove the duplicated checks and let `LibraryError` use the existing catch-all
branch. Timeout and would-block handling remain unchanged, and every error code
still produces the same error kind and message as before. This makes the control
flow clearer while preserving existing behavior.