### PR TITLE
Move `std::time::Instant` to `core`

### DIFF
--- a/library/core/src/time.rs
+++ b/library/core/src/time.rs
@@ -19,6 +19,11 @@
 //! assert_eq!(total, Duration::new(10, 7));
 //! ```
 
+mod instant;
+
+#[unstable(feature = "core_time_instant", issue = "none")]
+pub use instant::Instant;
+
 use crate::fmt;
 use crate::iter::Sum;
 use crate::num::niche_types::Nanoseconds;

--- a/library/core/src/time/instant.rs
+++ b/library/core/src/time/instant.rs
@@ -68,6 +68,7 @@ use crate::time::Duration;
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[rustc_has_incoherent_inherent_impls]
 #[repr(transparent)]
+#[rustc_pub_transparent]
 #[stable(feature = "time2", since = "1.8.0")]
 #[cfg_attr(not(test), rustc_diagnostic_item = "Instant")]
 pub struct Instant(Duration);

--- a/library/core/src/time/instant.rs
+++ b/library/core/src/time/instant.rs
@@ -1,0 +1,231 @@
+use crate::fmt;
+use crate::ops::{Add, AddAssign, Sub, SubAssign};
+use crate::time::Duration;
+
+/// A measurement of a monotonically nondecreasing clock.
+/// Opaque and useful only with [`Duration`].
+///
+/// Instants are always guaranteed, barring [platform bugs], to be no less than any previously
+/// measured instant when created, and are often useful for tasks such as measuring
+/// benchmarks or timing how long an operation takes.
+///
+/// Note, however, that instants are **not** guaranteed to be **steady**. In other
+/// words, each tick of the underlying clock might not be the same length (e.g.
+/// some seconds may be longer than others). An instant may jump forwards or
+/// experience time dilation (slow down or speed up), but it will never go
+/// backwards.
+/// As part of this non-guarantee it is also not specified whether system suspends count as
+/// elapsed time or not. The behavior varies across platforms and Rust versions.
+///
+/// Instants are opaque types that can only be compared to one another. There is
+/// no method to get "the number of seconds" from an instant. Instead, it only
+/// allows measuring the duration between two instants (or comparing two
+/// instants).
+///
+/// Example:
+///
+/// ```no_run
+/// use std::time::{Duration, Instant};
+/// use std::thread::sleep;
+///
+/// fn main() {
+///    let now = Instant::now();
+///
+///    // we sleep for 2 seconds
+///    sleep(Duration::new(2, 0));
+///    // it prints '2'
+///    println!("{}", now.elapsed().as_secs());
+/// }
+/// ```
+///
+/// [platform bugs]: Instant#monotonicity
+///
+/// > Note: mathematical operations like [`add`] may panic if the underlying
+/// > structure cannot represent the new point in time.
+///
+/// [`add`]: Instant::add
+///
+/// ## Monotonicity
+///
+/// On all platforms `Instant` will try to use an OS API that guarantees monotonic behavior
+/// if available, which is the case for all [tier 1] platforms.
+/// In practice such guarantees are – under rare circumstances – broken by hardware, virtualization
+/// or operating system bugs. To work around these bugs and platforms not offering monotonic clocks
+/// [`duration_since`], [`elapsed`] and [`sub`](#impl-Sub-for-Instant) saturate to zero. In older
+/// Rust versions this lead to a panic instead. [`checked_duration_since`] can be used to detect and
+/// handle situations where monotonicity is violated, or `Instant`s are subtracted in the wrong order.
+///
+/// This workaround obscures programming errors where earlier and later instants are accidentally
+/// swapped. For this reason future Rust versions may reintroduce panics.
+///
+/// [tier 1]: https://doc.rust-lang.org/rustc/platform-support.html
+/// [`duration_since`]: Instant::duration_since
+// FIXME(#74481): Hard-links required to link from `core` to `std` for incoherent method
+/// [`elapsed`]: ../../std/time/struct.Instant.html#method.elapsed
+/// [`sub`]: Instant::sub
+/// [`checked_duration_since`]: Instant::checked_duration_since
+///
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[rustc_has_incoherent_inherent_impls]
+#[repr(transparent)]
+#[stable(feature = "time2", since = "1.8.0")]
+#[cfg_attr(not(test), rustc_diagnostic_item = "Instant")]
+pub struct Instant(Duration);
+
+impl Instant {
+    /// Returns the amount of time elapsed from another instant to this one,
+    /// or zero duration if that instant is later than this one.
+    ///
+    /// # Panics
+    ///
+    /// Previous Rust versions panicked when `earlier` was later than `self`. Currently this
+    /// method saturates. Future versions may reintroduce the panic in some circumstances.
+    /// See [Monotonicity].
+    ///
+    /// [Monotonicity]: Instant#monotonicity
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use std::time::{Duration, Instant};
+    /// use std::thread::sleep;
+    ///
+    /// let now = Instant::now();
+    /// sleep(Duration::new(1, 0));
+    /// let new_now = Instant::now();
+    /// println!("{:?}", new_now.duration_since(now));
+    /// println!("{:?}", now.duration_since(new_now)); // 0ns
+    /// ```
+    #[must_use]
+    #[stable(feature = "time2", since = "1.8.0")]
+    pub fn duration_since(&self, earlier: Instant) -> Duration {
+        self.checked_duration_since(earlier).unwrap_or_default()
+    }
+
+    /// Returns the amount of time elapsed from another instant to this one,
+    /// or None if that instant is later than this one.
+    ///
+    /// Due to [monotonicity bugs], even under correct logical ordering of the passed `Instant`s,
+    /// this method can return `None`.
+    ///
+    /// [monotonicity bugs]: Instant#monotonicity
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use std::time::{Duration, Instant};
+    /// use std::thread::sleep;
+    ///
+    /// let now = Instant::now();
+    /// sleep(Duration::new(1, 0));
+    /// let new_now = Instant::now();
+    /// println!("{:?}", new_now.checked_duration_since(now));
+    /// println!("{:?}", now.checked_duration_since(new_now)); // None
+    /// ```
+    #[must_use]
+    #[stable(feature = "checked_duration_since", since = "1.39.0")]
+    pub fn checked_duration_since(&self, earlier: Instant) -> Option<Duration> {
+        self.0.checked_sub(earlier.0)
+    }
+
+    /// Returns the amount of time elapsed from another instant to this one,
+    /// or zero duration if that instant is later than this one.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use std::time::{Duration, Instant};
+    /// use std::thread::sleep;
+    ///
+    /// let now = Instant::now();
+    /// sleep(Duration::new(1, 0));
+    /// let new_now = Instant::now();
+    /// println!("{:?}", new_now.saturating_duration_since(now));
+    /// println!("{:?}", now.saturating_duration_since(new_now)); // 0ns
+    /// ```
+    #[must_use]
+    #[stable(feature = "checked_duration_since", since = "1.39.0")]
+    pub fn saturating_duration_since(&self, earlier: Instant) -> Duration {
+        self.checked_duration_since(earlier).unwrap_or_default()
+    }
+
+    /// Returns `Some(t)` where `t` is the time `self + duration` if `t` can be represented as
+    /// `Instant` (which means it's inside the bounds of the underlying data structure), `None`
+    /// otherwise.
+    #[stable(feature = "time_checked_add", since = "1.34.0")]
+    pub fn checked_add(&self, duration: Duration) -> Option<Instant> {
+        self.0.checked_add(duration).map(Instant)
+    }
+
+    /// Returns `Some(t)` where `t` is the time `self - duration` if `t` can be represented as
+    /// `Instant` (which means it's inside the bounds of the underlying data structure), `None`
+    /// otherwise.
+    #[stable(feature = "time_checked_add", since = "1.34.0")]
+    pub fn checked_sub(&self, duration: Duration) -> Option<Instant> {
+        self.0.checked_sub(duration).map(Instant)
+    }
+}
+
+#[stable(feature = "time2", since = "1.8.0")]
+impl Add<Duration> for Instant {
+    type Output = Instant;
+
+    /// # Panics
+    ///
+    /// This function may panic if the resulting point in time cannot be represented by the
+    /// underlying data structure. See [`Instant::checked_add`] for a version without panic.
+    #[track_caller]
+    fn add(self, other: Duration) -> Instant {
+        self.checked_add(other).expect("overflow when adding duration to instant")
+    }
+}
+
+#[stable(feature = "time_augmented_assignment", since = "1.9.0")]
+impl AddAssign<Duration> for Instant {
+    fn add_assign(&mut self, other: Duration) {
+        *self = *self + other;
+    }
+}
+
+#[stable(feature = "time2", since = "1.8.0")]
+impl Sub<Duration> for Instant {
+    type Output = Instant;
+
+    #[track_caller]
+    fn sub(self, other: Duration) -> Instant {
+        self.checked_sub(other).expect("overflow when subtracting duration from instant")
+    }
+}
+
+#[stable(feature = "time_augmented_assignment", since = "1.9.0")]
+impl SubAssign<Duration> for Instant {
+    fn sub_assign(&mut self, other: Duration) {
+        *self = *self - other;
+    }
+}
+
+#[stable(feature = "time2", since = "1.8.0")]
+impl Sub<Instant> for Instant {
+    type Output = Duration;
+
+    /// Returns the amount of time elapsed from another instant to this one,
+    /// or zero duration if that instant is later than this one.
+    ///
+    /// # Panics
+    ///
+    /// Previous Rust versions panicked when `other` was later than `self`. Currently this
+    /// method saturates. Future versions may reintroduce the panic in some circumstances.
+    /// See [Monotonicity].
+    ///
+    /// [Monotonicity]: Instant#monotonicity
+    fn sub(self, other: Instant) -> Duration {
+        self.duration_since(other)
+    }
+}
+
+#[stable(feature = "time2", since = "1.8.0")]
+impl fmt::Debug for Instant {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -334,6 +334,7 @@
 #![feature(core_io)]
 #![feature(core_io_borrowed_buf)]
 #![feature(core_io_internals)]
+#![feature(core_time_instant)]
 #![feature(cstr_display)]
 #![feature(cursor_split)]
 #![feature(drop_guard)]

--- a/library/std/src/sys/thread/motor.rs
+++ b/library/std/src/sys/thread/motor.rs
@@ -64,5 +64,5 @@ pub fn sleep(dur: Duration) {
 }
 
 pub fn sleep_until(deadline: Instant) {
-    moto_rt::thread::sleep_until(deadline.into_inner())
+    moto_rt::thread::sleep_until(crate::time::instant_into_inner(deadline))
 }

--- a/library/std/src/sys/thread/unix.rs
+++ b/library/std/src/sys/thread/unix.rs
@@ -672,7 +672,7 @@ pub fn sleep_until(deadline: crate::time::Instant) {
         }
 
         if let Some(clock_nanosleep) = __clock_nanosleep_time64.get() {
-            let ts = deadline.into_inner().into_timespec().to_timespec64();
+            let ts = crate::time::instant_into_inner(deadline).into_timespec().to_timespec64();
             loop {
                 let r = unsafe {
                     clock_nanosleep(
@@ -700,7 +700,7 @@ pub fn sleep_until(deadline: crate::time::Instant) {
         }
     }
 
-    let Some(ts) = deadline.into_inner().into_timespec().to_timespec() else {
+    let Some(ts) = crate::time::instant_into_inner(deadline).into_timespec().to_timespec() else {
         // The deadline is further in the future then can be passed to
         // clock_nanosleep. We have to use Self::sleep instead. This might
         // happen on 32 bit platforms, especially closer to 2038.
@@ -750,7 +750,8 @@ pub fn sleep_until(deadline: crate::time::Instant) {
 
     // Make sure to round up to ensure that we definitely sleep until after
     // the deadline has elapsed.
-    let Some(deadline) = deadline.into_inner().into_mach_absolute_time_ceil() else {
+    let Some(deadline) = crate::time::instant_into_inner(deadline).into_mach_absolute_time_ceil()
+    else {
         // Since the deadline is before the system boot time, it has already
         // passed, so we can return immediately.
         return;

--- a/library/std/src/sys/time/hermit.rs
+++ b/library/std/src/sys/time/hermit.rs
@@ -19,16 +19,13 @@ impl Instant {
         Instant(clock_gettime(CLOCK_MONOTONIC))
     }
 
-    pub fn checked_sub_instant(&self, other: &Instant) -> Option<Duration> {
-        self.0.sub_timespec(&other.0).ok()
+    pub fn from_duration(duration: Duration) -> Instant {
+        let spec = Timespec::MIN.checked_add_duration(&duration).unwrap();
+        Instant(spec)
     }
 
-    pub fn checked_add_duration(&self, other: &Duration) -> Option<Instant> {
-        Some(Instant(self.0.checked_add_duration(other)?))
-    }
-
-    pub fn checked_sub_duration(&self, other: &Duration) -> Option<Instant> {
-        Some(Instant(self.0.checked_sub_duration(other)?))
+    pub fn into_duration(self) -> Duration {
+        self.0.sub_timespec(&Timespec::MIN).unwrap()
     }
 }
 

--- a/library/std/src/sys/time/sgx.rs
+++ b/library/std/src/sys/time/sgx.rs
@@ -14,16 +14,12 @@ impl Instant {
         Instant(usercalls::insecure_time())
     }
 
-    pub fn checked_sub_instant(&self, other: &Instant) -> Option<Duration> {
-        self.0.checked_sub(other.0)
+    pub fn from_duration(duration: Duration) -> Instant {
+        Instant(duration)
     }
 
-    pub fn checked_add_duration(&self, other: &Duration) -> Option<Instant> {
-        Some(Instant(self.0.checked_add(*other)?))
-    }
-
-    pub fn checked_sub_duration(&self, other: &Duration) -> Option<Instant> {
-        Some(Instant(self.0.checked_sub(*other)?))
+    pub fn into_duration(self) -> Duration {
+        self.0
     }
 }
 

--- a/library/std/src/sys/time/solid.rs
+++ b/library/std/src/sys/time/solid.rs
@@ -11,25 +11,14 @@ impl Instant {
         Instant(itron::time::get_tim())
     }
 
-    pub fn checked_sub_instant(&self, other: &Instant) -> Option<Duration> {
-        self.0.checked_sub(other.0).map(|ticks| {
-            // `SYSTIM` is measured in microseconds
-            Duration::from_micros(ticks)
-        })
+    pub fn from_duration(duration: Duration) -> Instant {
+        // `SYSTIM` is measured in microseconds
+        Instant(duration.as_micros().try_into().unwrap())
     }
 
-    pub fn checked_add_duration(&self, other: &Duration) -> Option<Instant> {
+    pub fn into_duration(self) -> Duration {
         // `SYSTIM` is measured in microseconds
-        let ticks = other.as_micros();
-
-        Some(Instant(self.0.checked_add(ticks.try_into().ok()?)?))
-    }
-
-    pub fn checked_sub_duration(&self, other: &Duration) -> Option<Instant> {
-        // `SYSTIM` is measured in microseconds
-        let ticks = other.as_micros();
-
-        Some(Instant(self.0.checked_sub(ticks.try_into().ok()?)?))
+        Duration::from_micros(self.0)
     }
 }
 

--- a/library/std/src/sys/time/uefi.rs
+++ b/library/std/src/sys/time/uefi.rs
@@ -55,16 +55,12 @@ impl Instant {
         panic!("time not implemented on this platform")
     }
 
-    pub fn checked_sub_instant(&self, other: &Instant) -> Option<Duration> {
-        self.0.checked_sub(other.0)
+    pub fn from_duration(duration: Duration) -> Instant {
+        Instant(duration)
     }
 
-    pub fn checked_add_duration(&self, other: &Duration) -> Option<Instant> {
-        Some(Instant(self.0.checked_add(*other)?))
-    }
-
-    pub fn checked_sub_duration(&self, other: &Duration) -> Option<Instant> {
-        Some(Instant(self.0.checked_sub(*other)?))
+    pub fn into_duration(self) -> Duration {
+        self.0
     }
 }
 

--- a/library/std/src/sys/time/unix.rs
+++ b/library/std/src/sys/time/unix.rs
@@ -74,18 +74,6 @@ impl Instant {
         Instant { t: Timespec::now(Self::CLOCK_ID) }
     }
 
-    pub fn checked_sub_instant(&self, other: &Instant) -> Option<Duration> {
-        self.t.sub_timespec(&other.t).ok()
-    }
-
-    pub fn checked_add_duration(&self, other: &Duration) -> Option<Instant> {
-        Some(Instant { t: self.t.checked_add_duration(other)? })
-    }
-
-    pub fn checked_sub_duration(&self, other: &Duration) -> Option<Instant> {
-        Some(Instant { t: self.t.checked_sub_duration(other)? })
-    }
-
     #[cfg_attr(
         not(target_os = "linux"),
         allow(unused, reason = "needed by the `sleep_until` on some unix platforms")
@@ -122,6 +110,15 @@ impl Instant {
         // number by a 32-bit number yields a number that needs at most
         // 126 bits.
         Some((nanos * u128::from(timebase.denom)).div_ceil(u128::from(timebase.numer)))
+    }
+
+    pub fn from_duration(duration: Duration) -> Instant {
+        let spec = Timespec::MIN.checked_add_duration(&duration).unwrap();
+        Instant { t: spec }
+    }
+
+    pub fn into_duration(self) -> Duration {
+        self.t.sub_timespec(&Timespec::MIN).unwrap()
     }
 }
 

--- a/library/std/src/sys/time/unsupported.rs
+++ b/library/std/src/sys/time/unsupported.rs
@@ -13,16 +13,12 @@ impl Instant {
         panic!("time not implemented on this platform")
     }
 
-    pub fn checked_sub_instant(&self, other: &Instant) -> Option<Duration> {
-        self.0.checked_sub(other.0)
+    pub fn from_duration(duration: Duration) -> Instant {
+        Instant(duration)
     }
 
-    pub fn checked_add_duration(&self, other: &Duration) -> Option<Instant> {
-        Some(Instant(self.0.checked_add(*other)?))
-    }
-
-    pub fn checked_sub_duration(&self, other: &Duration) -> Option<Instant> {
-        Some(Instant(self.0.checked_sub(*other)?))
+    pub fn into_duration(self) -> Duration {
+        self.0
     }
 }
 

--- a/library/std/src/sys/time/vexos.rs
+++ b/library/std/src/sys/time/vexos.rs
@@ -9,15 +9,11 @@ impl Instant {
         Self(Duration::from_micros(micros))
     }
 
-    pub fn checked_sub_instant(&self, other: &Instant) -> Option<Duration> {
-        self.0.checked_sub(other.0)
+    pub fn from_duration(duration: Duration) -> Instant {
+        Instant(duration)
     }
 
-    pub fn checked_add_duration(&self, other: &Duration) -> Option<Instant> {
-        Some(Instant(self.0.checked_add(*other)?))
-    }
-
-    pub fn checked_sub_duration(&self, other: &Duration) -> Option<Instant> {
-        Some(Instant(self.0.checked_sub(*other)?))
+    pub fn into_duration(self) -> Duration {
+        self.0
     }
 }

--- a/library/std/src/sys/time/windows.rs
+++ b/library/std/src/sys/time/windows.rs
@@ -43,27 +43,20 @@ impl Instant {
         // see <https://github.com/rust-lang/rust/issues/156142>.
         let instant_nsec = instant_nsec + (u64::MAX / 4);
 
-        Self { t: Duration::from_nanos(instant_nsec) }
-    }
-
-    pub fn checked_sub_instant(&self, other: &Instant) -> Option<Duration> {
         // On windows there's a threshold below which we consider two timestamps
         // equivalent due to measurement error. For more details + doc link,
         // check the docs on epsilon.
-        let epsilon = perf_counter::epsilon();
-        if other.t > self.t && other.t - self.t <= epsilon {
-            Some(Duration::new(0, 0))
-        } else {
-            self.t.checked_sub(other.t)
-        }
+        let instant_nsec = instant_nsec.next_multiple_of(perf_counter::epsilon().as_nanos() as u64);
+
+        Self { t: Duration::from_nanos(instant_nsec) }
     }
 
-    pub fn checked_add_duration(&self, other: &Duration) -> Option<Instant> {
-        Some(Instant { t: self.t.checked_add(*other)? })
+    pub fn from_duration(duration: Duration) -> Instant {
+        Instant { t: duration }
     }
 
-    pub fn checked_sub_duration(&self, other: &Duration) -> Option<Instant> {
-        Some(Instant { t: self.t.checked_sub(*other)? })
+    pub fn into_duration(self) -> Duration {
+        self.t
     }
 }
 

--- a/library/std/src/sys/time/xous.rs
+++ b/library/std/src/sys/time/xous.rs
@@ -21,16 +21,12 @@ impl Instant {
         Instant { 0: Duration::from_millis(lower as u64 | (upper as u64) << 32) }
     }
 
-    pub fn checked_sub_instant(&self, other: &Instant) -> Option<Duration> {
-        self.0.checked_sub(other.0)
+    pub fn from_duration(duration: Duration) -> Instant {
+        Instant(duration)
     }
 
-    pub fn checked_add_duration(&self, other: &Duration) -> Option<Instant> {
-        self.0.checked_add(*other).map(Instant)
-    }
-
-    pub fn checked_sub_duration(&self, other: &Duration) -> Option<Instant> {
-        self.0.checked_sub(*other).map(Instant)
+    pub fn into_duration(self) -> Duration {
+        self.0
     }
 }
 

--- a/library/std/src/time.rs
+++ b/library/std/src/time.rs
@@ -33,6 +33,8 @@
 
 #[stable(feature = "time", since = "1.3.0")]
 pub use core::time::Duration;
+#[stable(feature = "time2", since = "1.8.0")]
+pub use core::time::Instant;
 #[stable(feature = "duration_checked_float", since = "1.66.0")]
 pub use core::time::TryFromFloatSecsError;
 
@@ -40,120 +42,6 @@ use crate::error::Error;
 use crate::fmt;
 use crate::ops::{Add, AddAssign, Sub, SubAssign};
 use crate::sys::{FromInner, IntoInner, time};
-
-/// A measurement of a monotonically nondecreasing clock.
-/// Opaque and useful only with [`Duration`].
-///
-/// Instants are always guaranteed, barring [platform bugs], to be no less than any previously
-/// measured instant when created, and are often useful for tasks such as measuring
-/// benchmarks or timing how long an operation takes.
-///
-/// Note, however, that instants are **not** guaranteed to be **steady**. In other
-/// words, each tick of the underlying clock might not be the same length (e.g.
-/// some seconds may be longer than others). An instant may jump forwards or
-/// experience time dilation (slow down or speed up), but it will never go
-/// backwards.
-/// As part of this non-guarantee it is also not specified whether system suspends count as
-/// elapsed time or not. The behavior varies across platforms and Rust versions.
-///
-/// Instants are opaque types that can only be compared to one another. There is
-/// no method to get "the number of seconds" from an instant. Instead, it only
-/// allows measuring the duration between two instants (or comparing two
-/// instants).
-///
-/// The size of an `Instant` struct may vary depending on the target operating
-/// system.
-///
-/// Example:
-///
-/// ```no_run
-/// use std::time::{Duration, Instant};
-/// use std::thread::sleep;
-///
-/// fn main() {
-///    let now = Instant::now();
-///
-///    // we sleep for 2 seconds
-///    sleep(Duration::new(2, 0));
-///    // it prints '2'
-///    println!("{}", now.elapsed().as_secs());
-/// }
-/// ```
-///
-/// [platform bugs]: Instant#monotonicity
-///
-/// # OS-specific behaviors
-///
-/// An `Instant` is a wrapper around system-specific types and it may behave
-/// differently depending on the underlying operating system. For example,
-/// the following snippet is fine on Linux but panics on macOS:
-///
-/// ```no_run
-/// use std::time::{Instant, Duration};
-///
-/// let now = Instant::now();
-/// let days_per_10_millennia = 365_2425;
-/// let solar_seconds_per_day = 60 * 60 * 24;
-/// let millennium_in_solar_seconds = 31_556_952_000;
-/// assert_eq!(millennium_in_solar_seconds, days_per_10_millennia * solar_seconds_per_day / 10);
-///
-/// let duration = Duration::new(millennium_in_solar_seconds, 0);
-/// println!("{:?}", now + duration);
-/// ```
-///
-/// For cross-platform code, you can comfortably use durations of up to around one hundred years.
-///
-/// # Underlying System calls
-///
-/// The following system calls are [currently] being used by `now()` to find out
-/// the current time:
-///
-/// |  Platform |               System call                                            |
-/// |-----------|----------------------------------------------------------------------|
-/// | SGX       | [`insecure_time` usercall]. More information on [timekeeping in SGX] |
-/// | UNIX      | [clock_gettime] with `CLOCK_MONOTONIC`                               |
-/// | WASI      | [clock_gettime] with `CLOCK_MONOTONIC`                               |
-/// | Darwin    | [clock_gettime] with `CLOCK_UPTIME_RAW`                              |
-/// | VXWorks   | [clock_gettime] with `CLOCK_MONOTONIC`                               |
-/// | SOLID     | `get_tim`                                                            |
-/// | Windows   | [QueryPerformanceCounter]                                            |
-///
-/// [currently]: crate::io#platform-specific-behavior
-/// [QueryPerformanceCounter]: https://docs.microsoft.com/en-us/windows/win32/api/profileapi/nf-profileapi-queryperformancecounter
-/// [`insecure_time` usercall]: https://edp.fortanix.com/docs/api/fortanix_sgx_abi/struct.Usercalls.html#method.insecure_time
-/// [timekeeping in SGX]: https://edp.fortanix.com/docs/concepts/rust-std/#codestdtimecode
-/// [clock_gettime]: https://pubs.opengroup.org/onlinepubs/9799919799/functions/clock_getres.html
-///
-/// **Disclaimer:** These system calls might change over time.
-///
-/// > Note: mathematical operations like [`add`] may panic if the underlying
-/// > structure cannot represent the new point in time.
-///
-/// [`add`]: Instant::add
-///
-/// ## Monotonicity
-///
-/// On all platforms `Instant` will try to use an OS API that guarantees monotonic behavior
-/// if available, which is the case for all [tier 1] platforms.
-/// In practice such guarantees are – under rare circumstances – broken by hardware, virtualization
-/// or operating system bugs. To work around these bugs and platforms not offering monotonic clocks
-/// [`duration_since`], [`elapsed`] and [`sub`](#impl-Sub-for-Instant) saturate to zero. In older
-/// Rust versions this lead to a panic instead. [`checked_duration_since`] can be used to detect and
-/// handle situations where monotonicity is violated, or `Instant`s are subtracted in the wrong order.
-///
-/// This workaround obscures programming errors where earlier and later instants are accidentally
-/// swapped. For this reason future Rust versions may reintroduce panics.
-///
-/// [tier 1]: https://doc.rust-lang.org/rustc/platform-support.html
-/// [`duration_since`]: Instant::duration_since
-/// [`elapsed`]: Instant::elapsed
-/// [`sub`]: Instant::sub
-/// [`checked_duration_since`]: Instant::checked_duration_since
-///
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[stable(feature = "time2", since = "1.8.0")]
-#[cfg_attr(not(test), rustc_diagnostic_item = "Instant")]
-pub struct Instant(time::Instant);
 
 /// A measurement of the system clock, useful for talking to
 /// external entities like the file system or other processes.
@@ -269,6 +157,7 @@ pub struct SystemTime(time::SystemTime);
 #[stable(feature = "time2", since = "1.8.0")]
 pub struct SystemTimeError(Duration);
 
+#[cfg(not(test))]
 impl Instant {
     /// Returns an instant corresponding to "now".
     ///
@@ -279,87 +168,43 @@ impl Instant {
     ///
     /// let now = Instant::now();
     /// ```
+    ///
+    /// # Underlying System calls
+    ///
+    /// The following system calls are [currently] being used by `now()` to find out
+    /// the current time:
+    ///
+    /// |  Platform |               System call                                            |
+    /// |-----------|----------------------------------------------------------------------|
+    /// | SGX       | [`insecure_time` usercall]. More information on [timekeeping in SGX] |
+    /// | UNIX      | [clock_gettime] with `CLOCK_MONOTONIC`                               |
+    /// | WASI      | [clock_gettime] with `CLOCK_MONOTONIC`                               |
+    /// | Darwin    | [clock_gettime] with `CLOCK_UPTIME_RAW`                              |
+    /// | VXWorks   | [clock_gettime] with `CLOCK_MONOTONIC`                               |
+    /// | SOLID     | `get_tim`                                                            |
+    /// | Windows   | [QueryPerformanceCounter]                                            |
+    ///
+    /// [currently]: crate::io#platform-specific-behavior
+    /// [QueryPerformanceCounter]: https://docs.microsoft.com/en-us/windows/win32/api/profileapi/nf-profileapi-queryperformancecounter
+    /// [`insecure_time` usercall]: https://edp.fortanix.com/docs/api/fortanix_sgx_abi/struct.Usercalls.html#method.insecure_time
+    /// [timekeeping in SGX]: https://edp.fortanix.com/docs/concepts/rust-std/#codestdtimecode
+    /// [clock_gettime]: https://pubs.opengroup.org/onlinepubs/9799919799/functions/clock_getres.html
+    ///
+    /// **Disclaimer:** These system calls might change over time.
+    ///
+    /// [tier 1]: https://doc.rust-lang.org/rustc/platform-support.html
+    /// [`duration_since`]: Instant::duration_since
+    // FIXME(#74481): Hard-links required to link from `core` to `std` for incoherent method
+    /// [`elapsed`]: struct.Instant.html#method.elapsed
+    /// [`sub`]: Instant::sub
+    /// [`checked_duration_since`]: Instant::checked_duration_since
+    ///
+    #[rustc_allow_incoherent_impl]
     #[must_use]
     #[stable(feature = "time2", since = "1.8.0")]
     #[cfg_attr(not(test), rustc_diagnostic_item = "instant_now")]
     pub fn now() -> Instant {
-        Instant(time::Instant::now())
-    }
-
-    /// Returns the amount of time elapsed from another instant to this one,
-    /// or zero duration if that instant is later than this one.
-    ///
-    /// # Panics
-    ///
-    /// Previous Rust versions panicked when `earlier` was later than `self`. Currently this
-    /// method saturates. Future versions may reintroduce the panic in some circumstances.
-    /// See [Monotonicity].
-    ///
-    /// [Monotonicity]: Instant#monotonicity
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// use std::time::{Duration, Instant};
-    /// use std::thread::sleep;
-    ///
-    /// let now = Instant::now();
-    /// sleep(Duration::new(1, 0));
-    /// let new_now = Instant::now();
-    /// println!("{:?}", new_now.duration_since(now));
-    /// println!("{:?}", now.duration_since(new_now)); // 0ns
-    /// ```
-    #[must_use]
-    #[stable(feature = "time2", since = "1.8.0")]
-    pub fn duration_since(&self, earlier: Instant) -> Duration {
-        self.checked_duration_since(earlier).unwrap_or_default()
-    }
-
-    /// Returns the amount of time elapsed from another instant to this one,
-    /// or None if that instant is later than this one.
-    ///
-    /// Due to [monotonicity bugs], even under correct logical ordering of the passed `Instant`s,
-    /// this method can return `None`.
-    ///
-    /// [monotonicity bugs]: Instant#monotonicity
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// use std::time::{Duration, Instant};
-    /// use std::thread::sleep;
-    ///
-    /// let now = Instant::now();
-    /// sleep(Duration::new(1, 0));
-    /// let new_now = Instant::now();
-    /// println!("{:?}", new_now.checked_duration_since(now));
-    /// println!("{:?}", now.checked_duration_since(new_now)); // None
-    /// ```
-    #[must_use]
-    #[stable(feature = "checked_duration_since", since = "1.39.0")]
-    pub fn checked_duration_since(&self, earlier: Instant) -> Option<Duration> {
-        self.0.checked_sub_instant(&earlier.0)
-    }
-
-    /// Returns the amount of time elapsed from another instant to this one,
-    /// or zero duration if that instant is later than this one.
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// use std::time::{Duration, Instant};
-    /// use std::thread::sleep;
-    ///
-    /// let now = Instant::now();
-    /// sleep(Duration::new(1, 0));
-    /// let new_now = Instant::now();
-    /// println!("{:?}", new_now.saturating_duration_since(now));
-    /// println!("{:?}", now.saturating_duration_since(new_now)); // 0ns
-    /// ```
-    #[must_use]
-    #[stable(feature = "checked_duration_since", since = "1.39.0")]
-    pub fn saturating_duration_since(&self, earlier: Instant) -> Duration {
-        self.checked_duration_since(earlier).unwrap_or_default()
+        instant_now()
     }
 
     /// Returns the amount of time elapsed since this instant.
@@ -383,100 +228,32 @@ impl Instant {
     /// sleep(three_secs);
     /// assert!(instant.elapsed() >= three_secs);
     /// ```
+    #[rustc_allow_incoherent_impl]
     #[must_use]
     #[stable(feature = "time2", since = "1.8.0")]
     pub fn elapsed(&self) -> Duration {
         Instant::now() - *self
     }
-
-    /// Returns `Some(t)` where `t` is the time `self + duration` if `t` can be represented as
-    /// `Instant` (which means it's inside the bounds of the underlying data structure), `None`
-    /// otherwise.
-    #[stable(feature = "time_checked_add", since = "1.34.0")]
-    pub fn checked_add(&self, duration: Duration) -> Option<Instant> {
-        self.0.checked_add_duration(&duration).map(Instant)
-    }
-
-    /// Returns `Some(t)` where `t` is the time `self - duration` if `t` can be represented as
-    /// `Instant` (which means it's inside the bounds of the underlying data structure), `None`
-    /// otherwise.
-    #[stable(feature = "time_checked_add", since = "1.34.0")]
-    pub fn checked_sub(&self, duration: Duration) -> Option<Instant> {
-        self.0.checked_sub_duration(&duration).map(Instant)
-    }
-
-    // Used by platform specific `sleep_until` implementations such as the one used on Linux.
-    #[cfg_attr(
-        not(target_os = "linux"),
-        allow(unused, reason = "not every platform has a specific `sleep_until`")
-    )]
-    pub(crate) fn into_inner(self) -> time::Instant {
-        self.0
-    }
 }
 
-#[stable(feature = "time2", since = "1.8.0")]
-impl Add<Duration> for Instant {
-    type Output = Instant;
-
-    /// # Panics
-    ///
-    /// This function may panic if the resulting point in time cannot be represented by the
-    /// underlying data structure. See [`Instant::checked_add`] for a version without panic.
-    #[track_caller]
-    fn add(self, other: Duration) -> Instant {
-        self.checked_add(other).expect("overflow when adding duration to instant")
-    }
+#[cfg_attr(test, expect(unused, reason = "incoherence workaround"))]
+fn instant_now() -> Instant {
+    // SAFETY:
+    // * Instant is a transparent wrapper around Duration.
+    // * time::Instant::now() produces a monotonically increasing value suitable
+    //   for Instant.
+    unsafe { crate::mem::transmute(time::Instant::now().into_duration()) }
 }
 
-#[stable(feature = "time_augmented_assignment", since = "1.9.0")]
-impl AddAssign<Duration> for Instant {
-    fn add_assign(&mut self, other: Duration) {
-        *self = *self + other;
-    }
-}
-
-#[stable(feature = "time2", since = "1.8.0")]
-impl Sub<Duration> for Instant {
-    type Output = Instant;
-
-    #[track_caller]
-    fn sub(self, other: Duration) -> Instant {
-        self.checked_sub(other).expect("overflow when subtracting duration from instant")
-    }
-}
-
-#[stable(feature = "time_augmented_assignment", since = "1.9.0")]
-impl SubAssign<Duration> for Instant {
-    fn sub_assign(&mut self, other: Duration) {
-        *self = *self - other;
-    }
-}
-
-#[stable(feature = "time2", since = "1.8.0")]
-impl Sub<Instant> for Instant {
-    type Output = Duration;
-
-    /// Returns the amount of time elapsed from another instant to this one,
-    /// or zero duration if that instant is later than this one.
-    ///
-    /// # Panics
-    ///
-    /// Previous Rust versions panicked when `other` was later than `self`. Currently this
-    /// method saturates. Future versions may reintroduce the panic in some circumstances.
-    /// See [Monotonicity].
-    ///
-    /// [Monotonicity]: Instant#monotonicity
-    fn sub(self, other: Instant) -> Duration {
-        self.duration_since(other)
-    }
-}
-
-#[stable(feature = "time2", since = "1.8.0")]
-impl fmt::Debug for Instant {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.0.fmt(f)
-    }
+// Used by platform specific `sleep_until` implementations such as the one used on Linux.
+#[cfg_attr(
+    not(target_os = "linux"),
+    allow(unused, reason = "not every platform has a specific `sleep_until`")
+)]
+pub(crate) fn instant_into_inner(this: Instant) -> time::Instant {
+    // SAFETY:
+    // * Instant is a transparent wrapper around Duration.
+    unsafe { time::Instant::from_duration(crate::mem::transmute(this)) }
 }
 
 impl SystemTime {


### PR DESCRIPTION
ACP: None (happy to create one if requested!)
Tracking Issue: None
Feature Gate: `core_time_instant`

# Background

`Instant` is currently provided by `std` as it has a platform specific internal representation. However, this representation is currently unavailable to users. That is, there is no method to convert to an from a system-specific value. As such, users do not actually benefit from this platform dependent representation. Further, since the type is defined in `std` and entirely opaque, libraries such as [`web-time`](https://crates.io/crates/web-time) must recreate the `Instant` API to act as a polyfill. Even though `wasm32-unknown-unknown` has access to `std`, its `now()` implementation is a panic-stub, so this library is virtually required when writing Rust for the browser.

This reliance on a 3rd party polyfill is frustrating for end users. As an example, `wasm32v1-none` is currently incompatible with the polyfill due to its lack of `no_std` support.

## Solution

Instead, I propose standardising on `Duration` as the canonical internal representation of an `Instant`. As is already the case, the meaning of the internal value is undefined. Users do not have safe access to this value and are provided no guarantees around its reference point.

With a standard representation, `Instant` can then be moved to `core::time`, allowing `no_std` libraries access to the type. Creating a value of type `Instant` is still restricted to `std` in safe Rust. This is done by leaving `now()` and `elapsed()` in `std` as incoherent methods.

To allow 3rd party libraries such as `web-time` to be substantially simplified, I am also proposing `Instant` be a `repr(transparent)` type, which will allow using `transmute` to convert between a `Duration` and `Instant` without causing UB. This will allow polyfills for `Instant` to simply provide `now()` and `elapsed()` as trait extension methods on the `core` type. In the future, these could be brought into `core` as well using EII.

## Platform Specific Changes

* On Windows, `Instant` would consider anything within an `epsilon()` to be equivalent. Instead of checking against epsilon at comparison, I round the internal `Duration` to the next multiple of epsilon at creation. I believe this should give the same effect in mitigating measurement noise.
* For Unix, Hermit, and Solid, `Instant` now has an layout equivalent to `Duration`. All other platforms were already a wrapper around `Duration`.

---

## Notes

- No AI tooling of any kind was used during the creation of this PR.
- Creating based on my own personal frustrations with working on time for crates like Bevy and Wgpu. Would love feedback from the Libs team to see if this is something that could be generally supported!
- I have not (yet) created an ACP or RFC as a PR is simple enough for this change that I thought it would be more useful to just review the change directly. Happy to create one if requested!
- The ability to create an `Instant` through transmutation would likely resolve rust-lang/rust#40910, and be substantially helpful for libraries such as [`mock_instant`](https://crates.io/crates/mock_instant). This isn't the reason for my effort, but it is worth noting.