### PR TITLE
Windows: add context when opening NUL for child stdio fails

### DIFF
--- a/library/std/src/sys/process/windows.rs
+++ b/library/std/src/sys/process/windows.rs
@@ -644,10 +644,13 @@ impl Stdio {
                     |e| {
                         // A raw `NotFound` here is easily mistaken for the program
                         // being missing, so say what actually failed to open.
+                        // `spawn` only passes the three standard ids, but print
+                        // anything else as a number rather than mislabeling it.
                         let stream = match stdio_id {
-                            c::STD_INPUT_HANDLE => "stdin",
-                            c::STD_OUTPUT_HANDLE => "stdout",
-                            _ => "stderr",
+                            c::STD_INPUT_HANDLE => "stdin".to_string(),
+                            c::STD_OUTPUT_HANDLE => "stdout".to_string(),
+                            c::STD_ERROR_HANDLE => "stderr".to_string(),
+                            id => format!("stdio handle {id}"),
                         };
                         Error::new(
                             e.kind(),

--- a/library/std/src/sys/process/windows.rs
+++ b/library/std/src/sys/process/windows.rs
@@ -640,7 +640,21 @@ impl Stdio {
                 opts.read(stdio_id == c::STD_INPUT_HANDLE);
                 opts.write(stdio_id != c::STD_INPUT_HANDLE);
                 opts.inherit_handle(true);
-                File::open(Path::new(r"\\.\NUL"), &opts).map(|file| file.into_inner())
+                File::open(Path::new(r"\\.\NUL"), &opts).map(|file| file.into_inner()).map_err(
+                    |e| {
+                        // A raw `NotFound` here is easily mistaken for the program
+                        // being missing, so say what actually failed to open.
+                        let stream = match stdio_id {
+                            c::STD_INPUT_HANDLE => "stdin",
+                            c::STD_OUTPUT_HANDLE => "stdout",
+                            _ => "stderr",
+                        };
+                        Error::new(
+                            e.kind(),
+                            format!("failed to open NUL device for child {stream}: {e}"),
+                        )
+                    },
+                )
             }
         }
     }


### PR DESCRIPTION
Opening `\\.\NUL` for `Stdio::Null` can fail in some environments, and `Command::spawn`/`output()` passes the raw OS error through. In the reported case that was `NotFound`, which looks exactly like the program itself being missing. Add context saying what failed to open and for which stream:

```
failed to open NUL device for child stdin: The system cannot find the file specified. (os error 2)
```

The `ErrorKind` is kept. `raw_os_error()` on this path becomes `None` since the payload is now a message string. I don't see a way to make opening NUL fail in CI, so no test; verified by hand in a local build by pointing the open at a bogus device name and checking the error out of `Command::output()`.

Fixes rust-lang/rust#157049
