### PR TITLE
fix: suggest removing a trailing semicolon when a closure argument fails a trait bound

### DIFF
--- a/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
@@ -2549,7 +2549,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         {
             // A function body has a single return type, so keeping the value can't break any
             // other use of it.
-            self.suggest_removing_semicolon(
+            self.emit_semicolon_removal_suggestion(
                 err,
                 trait_pred,
                 candidate,
@@ -2566,7 +2566,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         &self,
         block: &hir::Block<'tcx>,
         obligation: &PredicateObligation<'tcx>,
-        trait_pred: ty::PolyTraitPredicate<'tcx>,
+        trait_pred: ty::PolyTraitClause<'tcx>,
     ) -> Option<(&'tcx hir::Stmt<'tcx>, &'tcx hir::Expr<'tcx>, Ty<'tcx>)> {
         if block.expr.is_none()
             && let Some(stmt) = block.stmts.last()
@@ -2587,10 +2587,10 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         }
     }
 
-    fn suggest_removing_semicolon(
+    fn emit_semicolon_removal_suggestion(
         &self,
         err: &mut Diag<'_>,
-        trait_pred: ty::PolyTraitPredicate<'tcx>,
+        trait_pred: ty::PolyTraitClause<'tcx>,
         (stmt, expr, ty): (&hir::Stmt<'_>, &hir::Expr<'_>, Ty<'tcx>),
         applicability: Applicability,
     ) {
@@ -2622,13 +2622,18 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         &self,
         obligation: &PredicateObligation<'tcx>,
         err: &mut Diag<'_>,
-        trait_pred: ty::PolyTraitPredicate<'tcx>,
+        trait_pred: ty::PolyTraitClause<'tcx>,
     ) -> bool {
         let &ObligationCauseCode::WhereClauseInExpr(callee_def_id, _, hir_id, idx) =
             obligation.cause.code().peel_derives()
         else {
             return false;
         };
+        // This cause code is used for the clauses of any item named in an expression, like an
+        // associated const or a type alias, and `fn_sig` is only defined for functions.
+        if !matches!(self.tcx.def_kind(callee_def_id), DefKind::Fn | DefKind::AssocFn) {
+            return false;
+        }
         let hir::Node::Expr(expr) = self.tcx.hir_node(hir_id) else {
             return false;
         };
@@ -2707,7 +2712,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         {
             // The same closure can be passed to somewhere else that expects it to return `()`,
             // where keeping the value would introduce a new error.
-            self.suggest_removing_semicolon(
+            self.emit_semicolon_removal_suggestion(
                 err,
                 trait_pred,
                 candidate,

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
@@ -2536,38 +2536,78 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         span: Span,
         trait_pred: ty::PolyTraitClause<'tcx>,
     ) -> bool {
+        if !trait_pred.self_ty().skip_binder().is_unit() {
+            return false;
+        }
         let node = self.tcx.hir_node_by_def_id(obligation.cause.body_def_id);
-        if let hir::Node::Item(hir::Item { kind: hir::ItemKind::Fn {sig, body: body_id, .. }, .. }) = node
+        if let hir::Node::Item(hir::Item {
+            kind: hir::ItemKind::Fn { sig, body: body_id, .. }, ..
+        }) = node
             && let hir::ExprKind::Block(blk, _) = &self.tcx.hir_body(*body_id).value.kind
             && sig.decl.output.span().overlaps(span)
-            && blk.expr.is_none()
-            && trait_pred.self_ty().skip_binder().is_unit()
-            && let Some(stmt) = blk.stmts.last()
-            && let hir::StmtKind::Semi(expr) = stmt.kind
-            // Only suggest this if the expression behind the semicolon implements the predicate
-            && let Some(typeck_results) = &self.typeck_results
-            && let Some(ty) = typeck_results.expr_ty_opt(expr)
-            && self.predicate_may_hold(&self.mk_trait_obligation_with_new_self_ty(
-                obligation.param_env, trait_pred.map_bound(|trait_pred| (trait_pred, ty))
-            ))
+            && let Some(candidate) = self.removable_trailing_semicolon(blk, obligation, trait_pred)
         {
-            err.span_label(
-                expr.span,
-                format!(
-                    "this expression has type `{}`, which implements `{}`",
-                    ty,
-                    trait_pred.print_modifiers_and_trait_path()
-                ),
-            );
-            err.span_suggestion(
-                self.tcx.sess.source_map().end_point(stmt.span),
-                "remove this semicolon",
-                "",
+            // A function body has a single return type, so keeping the value can't break any
+            // other use of it.
+            self.suggest_removing_semicolon(
+                err,
+                trait_pred,
+                candidate,
                 Applicability::MachineApplicable,
             );
             return true;
         }
         self.suggest_semicolon_removal_in_closure_arg(obligation, err, trait_pred)
+    }
+
+    /// If the value of `block` is discarded by a trailing semicolon and keeping it would satisfy
+    /// `trait_pred`, return that statement, its expression and the type of that expression.
+    fn removable_trailing_semicolon(
+        &self,
+        block: &hir::Block<'tcx>,
+        obligation: &PredicateObligation<'tcx>,
+        trait_pred: ty::PolyTraitPredicate<'tcx>,
+    ) -> Option<(&'tcx hir::Stmt<'tcx>, &'tcx hir::Expr<'tcx>, Ty<'tcx>)> {
+        if block.expr.is_none()
+            && let Some(stmt) = block.stmts.last()
+            && let hir::StmtKind::Semi(expr) = stmt.kind
+            && !stmt.span.from_expansion()
+            && !matches!(expr.kind, hir::ExprKind::Err(_))
+            // Only suggest this if the expression behind the semicolon implements the predicate
+            && let Some(typeck_results) = &self.typeck_results
+            && let Some(ty) =
+                typeck_results.expr_ty_opt(expr).map(|ty| self.resolve_vars_if_possible(ty))
+            && self.predicate_may_hold(&self.mk_trait_obligation_with_new_self_ty(
+                obligation.param_env, trait_pred.map_bound(|trait_pred| (trait_pred, ty))
+            ))
+        {
+            Some((stmt, expr, ty))
+        } else {
+            None
+        }
+    }
+
+    fn suggest_removing_semicolon(
+        &self,
+        err: &mut Diag<'_>,
+        trait_pred: ty::PolyTraitPredicate<'tcx>,
+        (stmt, expr, ty): (&hir::Stmt<'_>, &hir::Expr<'_>, Ty<'tcx>),
+        applicability: Applicability,
+    ) {
+        err.span_label(
+            expr.span,
+            format!(
+                "this expression has type `{}`, which implements `{}`",
+                ty,
+                trait_pred.print_modifiers_and_trait_path()
+            ),
+        );
+        err.span_suggestion(
+            self.tcx.sess.source_map().end_point(stmt.span),
+            "remove this semicolon",
+            "",
+            applicability,
+        );
     }
 
     /// Detect when a closure argument returns `()` because of a trailing semicolon and that makes
@@ -2584,10 +2624,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         err: &mut Diag<'_>,
         trait_pred: ty::PolyTraitPredicate<'tcx>,
     ) -> bool {
-        if !trait_pred.self_ty().skip_binder().is_unit() {
-            return false;
-        }
-        let &ObligationCauseCode::WhereClauseInExpr(_, _, hir_id, _) =
+        let &ObligationCauseCode::WhereClauseInExpr(callee_def_id, _, hir_id, idx) =
             obligation.cause.code().peel_derives()
         else {
             return false;
@@ -2612,15 +2649,42 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     _ => return false,
                 },
             };
-        let mut candidates = args.into_iter().filter_map(|arg| {
+        // Work with the callee's own clauses and signature, where the failing bound is still
+        // written in terms of the generic param it was declared on.
+        let clauses = self.tcx.clauses_of(callee_def_id).instantiate_identity(self.tcx);
+        let Some(ty::ClauseKind::Trait(failed)) = clauses
+            .clauses
+            .get(idx)
+            .map(|clause| clause.as_ref().skip_norm_wip().kind().skip_binder())
+        else {
+            return false;
+        };
+        let sig =
+            self.tcx.fn_sig(callee_def_id).instantiate_identity().skip_norm_wip().skip_binder();
+        let mut candidates = args.into_iter().enumerate().filter_map(|(i, arg)| {
+            // The bound has to be on what the closure returns. A bound on an unrelated param that
+            // also happened to be inferred as `()` would not be satisfied by removing a semicolon.
+            let declared = sig.inputs().get(i)?.peel_refs();
+            if !clauses.clauses.iter().any(|clause| {
+                matches!(
+                    clause.as_ref().skip_norm_wip().kind().skip_binder(),
+                    ty::ClauseKind::Projection(proj)
+                        if self.tcx.is_lang_item(proj.def_id(), LangItem::FnOnceOutput)
+                            && proj.projection_term.self_ty() == declared
+                            && proj.term.as_type() == Some(failed.self_ty())
+                )
+            }) {
+                return None;
+            }
             // The error can be reported while the closure argument is still being checked, before
             // its own type is recorded, so identify closures syntactically and only fall back to
             // the argument's type (e.g. for a closure bound to a variable and passed by path).
             let closure_def_id = match arg.kind {
                 hir::ExprKind::Closure(closure) => closure.def_id,
-                _ => match typeck_results.expr_ty_adjusted_opt(arg).map(|ty| {
-                    *self.resolve_vars_if_possible(ty).peel_refs().kind()
-                }) {
+                _ => match typeck_results
+                    .expr_ty_adjusted_opt(arg)
+                    .map(|ty| *self.resolve_vars_if_possible(ty).peel_refs().kind())
+                {
                     Some(ty::Closure(def_id, _)) => def_id.as_local()?,
                     _ => return None,
                 },
@@ -2630,48 +2694,24 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             else {
                 return None;
             };
-            let body_value = self.tcx.hir_body(closure.body).value;
-            if let hir::ExprKind::Block(block @ hir::Block { expr: None, .. }, None) =
-                body_value.kind
-                && let [.., stmt] = block.stmts
-                && !stmt.span.from_expansion()
-                && let hir::StmtKind::Semi(tail_expr) = stmt.kind
-                && !matches!(tail_expr.kind, hir::ExprKind::Err(_))
-                // Tie the failing `(): Trait` predicate to this closure through its return type.
-                // The already-checked body is in the typeck results even when the closure isn't.
-                && let Some(ret_ty) = typeck_results.expr_ty_opt(body_value)
-                && self.resolve_vars_if_possible(ret_ty).is_unit()
-                // Only suggest this if the expression behind the semicolon implements the predicate
-                && let Some(ty) =
-                    typeck_results.expr_ty_opt(tail_expr).map(|ty| self.resolve_vars_if_possible(ty))
-                && self.predicate_may_hold(&self.mk_trait_obligation_with_new_self_ty(
-                    obligation.param_env,
-                    trait_pred.map_bound(|trait_pred| (trait_pred, ty)),
-                ))
-            {
-                Some((stmt, tail_expr, ty))
-            } else {
-                None
-            }
+            let hir::ExprKind::Block(block, None) = self.tcx.hir_body(closure.body).value.kind
+            else {
+                return None;
+            };
+            self.removable_trailing_semicolon(block, obligation, trait_pred)
         });
         // Only emit the suggestion when a single closure argument matches, to avoid pointing at
         // an unrelated closure.
-        if let Some((stmt, tail_expr, ty)) = candidates.next()
+        if let Some(candidate) = candidates.next()
             && candidates.next().is_none()
         {
-            err.span_label(
-                tail_expr.span,
-                format!(
-                    "this expression has type `{}`, which implements `{}`",
-                    ty,
-                    trait_pred.print_modifiers_and_trait_path()
-                ),
-            );
-            err.span_suggestion(
-                self.tcx.sess.source_map().end_point(stmt.span),
-                "remove this semicolon",
-                "",
-                Applicability::MachineApplicable,
+            // The same closure can be passed to somewhere else that expects it to return `()`,
+            // where keeping the value would introduce a new error.
+            self.suggest_removing_semicolon(
+                err,
+                trait_pred,
+                candidate,
+                Applicability::MaybeIncorrect,
             );
             return true;
         }

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
@@ -2567,6 +2567,114 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             );
             return true;
         }
+        self.suggest_semicolon_removal_in_closure_arg(obligation, err, trait_pred)
+    }
+
+    /// Detect when a closure argument returns `()` because of a trailing semicolon and that makes
+    /// a trait bound on the function's generic param fail, and suggest removing the semicolon:
+    ///
+    /// ```text
+    /// fn bar<R: Bar>(_: impl Fn() -> R) {}
+    /// bar(|| { 5u8; })
+    /// //          - help: remove this semicolon
+    /// ```
+    fn suggest_semicolon_removal_in_closure_arg(
+        &self,
+        obligation: &PredicateObligation<'tcx>,
+        err: &mut Diag<'_>,
+        trait_pred: ty::PolyTraitPredicate<'tcx>,
+    ) -> bool {
+        if !trait_pred.self_ty().skip_binder().is_unit() {
+            return false;
+        }
+        let &ObligationCauseCode::WhereClauseInExpr(_, _, hir_id, _) =
+            obligation.cause.code().peel_derives()
+        else {
+            return false;
+        };
+        let hir::Node::Expr(expr) = self.tcx.hir_node(hir_id) else {
+            return false;
+        };
+        let Some(typeck_results) = &self.typeck_results else {
+            return false;
+        };
+        let args: Vec<&hir::Expr<'_>> =
+            match expr.kind {
+                hir::ExprKind::MethodCall(_, receiver, args, _) => {
+                    iter::once(receiver).chain(args).collect()
+                }
+                // For a call like `bar(..)` the obligation is attached to the callee path expression,
+                // so the arguments live in its parent.
+                _ => match self.tcx.parent_hir_node(expr.hir_id) {
+                    hir::Node::Expr(hir::Expr {
+                        kind: hir::ExprKind::Call(callee, args), ..
+                    }) if callee.hir_id == expr.hir_id => args.iter().collect(),
+                    _ => return false,
+                },
+            };
+        let mut candidates = args.into_iter().filter_map(|arg| {
+            // The error can be reported while the closure argument is still being checked, before
+            // its own type is recorded, so identify closures syntactically and only fall back to
+            // the argument's type (e.g. for a closure bound to a variable and passed by path).
+            let closure_def_id = match arg.kind {
+                hir::ExprKind::Closure(closure) => closure.def_id,
+                _ => match typeck_results.expr_ty_adjusted_opt(arg).map(|ty| {
+                    *self.resolve_vars_if_possible(ty).peel_refs().kind()
+                }) {
+                    Some(ty::Closure(def_id, _)) => def_id.as_local()?,
+                    _ => return None,
+                },
+            };
+            let hir::Node::Expr(hir::Expr { kind: hir::ExprKind::Closure(closure), .. }) =
+                self.tcx.hir_node_by_def_id(closure_def_id)
+            else {
+                return None;
+            };
+            let body_value = self.tcx.hir_body(closure.body).value;
+            if let hir::ExprKind::Block(block @ hir::Block { expr: None, .. }, None) =
+                body_value.kind
+                && let [.., stmt] = block.stmts
+                && !stmt.span.from_expansion()
+                && let hir::StmtKind::Semi(tail_expr) = stmt.kind
+                && !matches!(tail_expr.kind, hir::ExprKind::Err(_))
+                // Tie the failing `(): Trait` predicate to this closure through its return type.
+                // The already-checked body is in the typeck results even when the closure isn't.
+                && let Some(ret_ty) = typeck_results.expr_ty_opt(body_value)
+                && self.resolve_vars_if_possible(ret_ty).is_unit()
+                // Only suggest this if the expression behind the semicolon implements the predicate
+                && let Some(ty) =
+                    typeck_results.expr_ty_opt(tail_expr).map(|ty| self.resolve_vars_if_possible(ty))
+                && self.predicate_may_hold(&self.mk_trait_obligation_with_new_self_ty(
+                    obligation.param_env,
+                    trait_pred.map_bound(|trait_pred| (trait_pred, ty)),
+                ))
+            {
+                Some((stmt, tail_expr, ty))
+            } else {
+                None
+            }
+        });
+        // Only emit the suggestion when a single closure argument matches, to avoid pointing at
+        // an unrelated closure.
+        if let Some((stmt, tail_expr, ty)) = candidates.next()
+            && candidates.next().is_none()
+        {
+            err.span_label(
+                tail_expr.span,
+                format!(
+                    "this expression has type `{}`, which implements `{}`",
+                    ty,
+                    trait_pred.print_modifiers_and_trait_path()
+                ),
+            );
+            err.span_suggestion(
+                self.tcx.sess.source_map().end_point(stmt.span),
+                "remove this semicolon",
+                "",
+                Applicability::MachineApplicable,
+            );
+            return true;
+        }
         false
     }
 

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
@@ -2568,6 +2568,114 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             );
             return true;
         }
+        self.suggest_semicolon_removal_in_closure_arg(obligation, err, trait_pred)
+    }
+
+    /// Detect when a closure argument returns `()` because of a trailing semicolon and that makes
+    /// a trait bound on the function's generic param fail, and suggest removing the semicolon:
+    ///
+    /// ```text
+    /// fn bar<R: Bar>(_: impl Fn() -> R) {}
+    /// bar(|| { 5u8; })
+    /// //          - help: remove this semicolon
+    /// ```
+    fn suggest_semicolon_removal_in_closure_arg(
+        &self,
+        obligation: &PredicateObligation<'tcx>,
+        err: &mut Diag<'_>,
+        trait_pred: ty::PolyTraitPredicate<'tcx>,
+    ) -> bool {
+        if !trait_pred.self_ty().skip_binder().is_unit() {
+            return false;
+        }
+        let &ObligationCauseCode::WhereClauseInExpr(_, _, hir_id, _) =
+            obligation.cause.code().peel_derives()
+        else {
+            return false;
+        };
+        let hir::Node::Expr(expr) = self.tcx.hir_node(hir_id) else {
+            return false;
+        };
+        let Some(typeck_results) = &self.typeck_results else {
+            return false;
+        };
+        let args: Vec<&hir::Expr<'_>> =
+            match expr.kind {
+                hir::ExprKind::MethodCall(_, receiver, args, _) => {
+                    iter::once(receiver).chain(args).collect()
+                }
+                // For a call like `bar(..)` the obligation is attached to the callee path expression,
+                // so the arguments live in its parent.
+                _ => match self.tcx.parent_hir_node(expr.hir_id) {
+                    hir::Node::Expr(hir::Expr {
+                        kind: hir::ExprKind::Call(callee, args), ..
+                    }) if callee.hir_id == expr.hir_id => args.iter().collect(),
+                    _ => return false,
+                },
+            };
+        let mut candidates = args.into_iter().filter_map(|arg| {
+            // The error can be reported while the closure argument is still being checked, before
+            // its own type is recorded, so identify closures syntactically and only fall back to
+            // the argument's type (e.g. for a closure bound to a variable and passed by path).
+            let closure_def_id = match arg.kind {
+                hir::ExprKind::Closure(closure) => closure.def_id,
+                _ => match typeck_results.expr_ty_adjusted_opt(arg).map(|ty| {
+                    *self.resolve_vars_if_possible(ty).peel_refs().kind()
+                }) {
+                    Some(ty::Closure(def_id, _)) => def_id.as_local()?,
+                    _ => return None,
+                },
+            };
+            let hir::Node::Expr(hir::Expr { kind: hir::ExprKind::Closure(closure), .. }) =
+                self.tcx.hir_node_by_def_id(closure_def_id)
+            else {
+                return None;
+            };
+            let body_value = self.tcx.hir_body(closure.body).value;
+            if let hir::ExprKind::Block(block @ hir::Block { expr: None, .. }, None) =
+                body_value.kind
+                && let [.., stmt] = block.stmts
+                && !stmt.span.from_expansion()
+                && let hir::StmtKind::Semi(tail_expr) = stmt.kind
+                && !matches!(tail_expr.kind, hir::ExprKind::Err(_))
+                // Tie the failing `(): Trait` predicate to this closure through its return type.
+                // The already-checked body is in the typeck results even when the closure isn't.
+                && let Some(ret_ty) = typeck_results.expr_ty_opt(body_value)
+                && self.resolve_vars_if_possible(ret_ty).is_unit()
+                // Only suggest this if the expression behind the semicolon implements the predicate
+                && let Some(ty) =
+                    typeck_results.expr_ty_opt(tail_expr).map(|ty| self.resolve_vars_if_possible(ty))
+                && self.predicate_may_hold(&self.mk_trait_obligation_with_new_self_ty(
+                    obligation.param_env,
+                    trait_pred.map_bound(|trait_pred| (trait_pred, ty)),
+                ))
+            {
+                Some((stmt, tail_expr, ty))
+            } else {
+                None
+            }
+        });
+        // Only emit the suggestion when a single closure argument matches, to avoid pointing at
+        // an unrelated closure.
+        if let Some((stmt, tail_expr, ty)) = candidates.next()
+            && candidates.next().is_none()
+        {
+            err.span_label(
+                tail_expr.span,
+                format!(
+                    "this expression has type `{}`, which implements `{}`",
+                    ty,
+                    trait_pred.print_modifiers_and_trait_path()
+                ),
+            );
+            err.span_suggestion(
+                self.tcx.sess.source_map().end_point(stmt.span),
+                "remove this semicolon",
+                "",
+                Applicability::MachineApplicable,
+            );
+            return true;
+        }
         false
     }
 

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
@@ -2537,38 +2537,78 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         span: Span,
         trait_pred: ty::PolyTraitPredicate<'tcx>,
     ) -> bool {
+        if !trait_pred.self_ty().skip_binder().is_unit() {
+            return false;
+        }
         let node = self.tcx.hir_node_by_def_id(obligation.cause.body_def_id);
-        if let hir::Node::Item(hir::Item { kind: hir::ItemKind::Fn {sig, body: body_id, .. }, .. }) = node
+        if let hir::Node::Item(hir::Item {
+            kind: hir::ItemKind::Fn { sig, body: body_id, .. }, ..
+        }) = node
             && let hir::ExprKind::Block(blk, _) = &self.tcx.hir_body(*body_id).value.kind
             && sig.decl.output.span().overlaps(span)
-            && blk.expr.is_none()
-            && trait_pred.self_ty().skip_binder().is_unit()
-            && let Some(stmt) = blk.stmts.last()
-            && let hir::StmtKind::Semi(expr) = stmt.kind
-            // Only suggest this if the expression behind the semicolon implements the predicate
-            && let Some(typeck_results) = &self.typeck_results
-            && let Some(ty) = typeck_results.expr_ty_opt(expr)
-            && self.predicate_may_hold(&self.mk_trait_obligation_with_new_self_ty(
-                obligation.param_env, trait_pred.map_bound(|trait_pred| (trait_pred, ty))
-            ))
+            && let Some(candidate) = self.removable_trailing_semicolon(blk, obligation, trait_pred)
         {
-            err.span_label(
-                expr.span,
-                format!(
-                    "this expression has type `{}`, which implements `{}`",
-                    ty,
-                    trait_pred.print_modifiers_and_trait_path()
-                ),
-            );
-            err.span_suggestion(
-                self.tcx.sess.source_map().end_point(stmt.span),
-                "remove this semicolon",
-                "",
+            // A function body has a single return type, so keeping the value can't break any
+            // other use of it.
+            self.suggest_removing_semicolon(
+                err,
+                trait_pred,
+                candidate,
                 Applicability::MachineApplicable,
             );
             return true;
         }
         self.suggest_semicolon_removal_in_closure_arg(obligation, err, trait_pred)
+    }
+
+    /// If the value of `block` is discarded by a trailing semicolon and keeping it would satisfy
+    /// `trait_pred`, return that statement, its expression and the type of that expression.
+    fn removable_trailing_semicolon(
+        &self,
+        block: &hir::Block<'tcx>,
+        obligation: &PredicateObligation<'tcx>,
+        trait_pred: ty::PolyTraitPredicate<'tcx>,
+    ) -> Option<(&'tcx hir::Stmt<'tcx>, &'tcx hir::Expr<'tcx>, Ty<'tcx>)> {
+        if block.expr.is_none()
+            && let Some(stmt) = block.stmts.last()
+            && let hir::StmtKind::Semi(expr) = stmt.kind
+            && !stmt.span.from_expansion()
+            && !matches!(expr.kind, hir::ExprKind::Err(_))
+            // Only suggest this if the expression behind the semicolon implements the predicate
+            && let Some(typeck_results) = &self.typeck_results
+            && let Some(ty) =
+                typeck_results.expr_ty_opt(expr).map(|ty| self.resolve_vars_if_possible(ty))
+            && self.predicate_may_hold(&self.mk_trait_obligation_with_new_self_ty(
+                obligation.param_env, trait_pred.map_bound(|trait_pred| (trait_pred, ty))
+            ))
+        {
+            Some((stmt, expr, ty))
+        } else {
+            None
+        }
+    }
+
+    fn suggest_removing_semicolon(
+        &self,
+        err: &mut Diag<'_>,
+        trait_pred: ty::PolyTraitPredicate<'tcx>,
+        (stmt, expr, ty): (&hir::Stmt<'_>, &hir::Expr<'_>, Ty<'tcx>),
+        applicability: Applicability,
+    ) {
+        err.span_label(
+            expr.span,
+            format!(
+                "this expression has type `{}`, which implements `{}`",
+                ty,
+                trait_pred.print_modifiers_and_trait_path()
+            ),
+        );
+        err.span_suggestion(
+            self.tcx.sess.source_map().end_point(stmt.span),
+            "remove this semicolon",
+            "",
+            applicability,
+        );
     }
 
     /// Detect when a closure argument returns `()` because of a trailing semicolon and that makes
@@ -2585,10 +2625,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         err: &mut Diag<'_>,
         trait_pred: ty::PolyTraitPredicate<'tcx>,
     ) -> bool {
-        if !trait_pred.self_ty().skip_binder().is_unit() {
-            return false;
-        }
-        let &ObligationCauseCode::WhereClauseInExpr(_, _, hir_id, _) =
+        let &ObligationCauseCode::WhereClauseInExpr(callee_def_id, _, hir_id, idx) =
             obligation.cause.code().peel_derives()
         else {
             return false;
@@ -2613,15 +2650,42 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     _ => return false,
                 },
             };
-        let mut candidates = args.into_iter().filter_map(|arg| {
+        // Work with the callee's own clauses and signature, where the failing bound is still
+        // written in terms of the generic param it was declared on.
+        let clauses = self.tcx.clauses_of(callee_def_id).instantiate_identity(self.tcx);
+        let Some(ty::ClauseKind::Trait(failed)) = clauses
+            .clauses
+            .get(idx)
+            .map(|clause| clause.as_ref().skip_norm_wip().kind().skip_binder())
+        else {
+            return false;
+        };
+        let sig =
+            self.tcx.fn_sig(callee_def_id).instantiate_identity().skip_norm_wip().skip_binder();
+        let mut candidates = args.into_iter().enumerate().filter_map(|(i, arg)| {
+            // The bound has to be on what the closure returns. A bound on an unrelated param that
+            // also happened to be inferred as `()` would not be satisfied by removing a semicolon.
+            let declared = sig.inputs().get(i)?.peel_refs();
+            if !clauses.clauses.iter().any(|clause| {
+                matches!(
+                    clause.as_ref().skip_norm_wip().kind().skip_binder(),
+                    ty::ClauseKind::Projection(proj)
+                        if self.tcx.is_lang_item(proj.def_id(), LangItem::FnOnceOutput)
+                            && proj.projection_term.self_ty() == declared
+                            && proj.term.as_type() == Some(failed.self_ty())
+                )
+            }) {
+                return None;
+            }
             // The error can be reported while the closure argument is still being checked, before
             // its own type is recorded, so identify closures syntactically and only fall back to
             // the argument's type (e.g. for a closure bound to a variable and passed by path).
             let closure_def_id = match arg.kind {
                 hir::ExprKind::Closure(closure) => closure.def_id,
-                _ => match typeck_results.expr_ty_adjusted_opt(arg).map(|ty| {
-                    *self.resolve_vars_if_possible(ty).peel_refs().kind()
-                }) {
+                _ => match typeck_results
+                    .expr_ty_adjusted_opt(arg)
+                    .map(|ty| *self.resolve_vars_if_possible(ty).peel_refs().kind())
+                {
                     Some(ty::Closure(def_id, _)) => def_id.as_local()?,
                     _ => return None,
                 },
@@ -2631,48 +2695,24 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             else {
                 return None;
             };
-            let body_value = self.tcx.hir_body(closure.body).value;
-            if let hir::ExprKind::Block(block @ hir::Block { expr: None, .. }, None) =
-                body_value.kind
-                && let [.., stmt] = block.stmts
-                && !stmt.span.from_expansion()
-                && let hir::StmtKind::Semi(tail_expr) = stmt.kind
-                && !matches!(tail_expr.kind, hir::ExprKind::Err(_))
-                // Tie the failing `(): Trait` predicate to this closure through its return type.
-                // The already-checked body is in the typeck results even when the closure isn't.
-                && let Some(ret_ty) = typeck_results.expr_ty_opt(body_value)
-                && self.resolve_vars_if_possible(ret_ty).is_unit()
-                // Only suggest this if the expression behind the semicolon implements the predicate
-                && let Some(ty) =
-                    typeck_results.expr_ty_opt(tail_expr).map(|ty| self.resolve_vars_if_possible(ty))
-                && self.predicate_may_hold(&self.mk_trait_obligation_with_new_self_ty(
-                    obligation.param_env,
-                    trait_pred.map_bound(|trait_pred| (trait_pred, ty)),
-                ))
-            {
-                Some((stmt, tail_expr, ty))
-            } else {
-                None
-            }
+            let hir::ExprKind::Block(block, None) = self.tcx.hir_body(closure.body).value.kind
+            else {
+                return None;
+            };
+            self.removable_trailing_semicolon(block, obligation, trait_pred)
         });
         // Only emit the suggestion when a single closure argument matches, to avoid pointing at
         // an unrelated closure.
-        if let Some((stmt, tail_expr, ty)) = candidates.next()
+        if let Some(candidate) = candidates.next()
             && candidates.next().is_none()
         {
-            err.span_label(
-                tail_expr.span,
-                format!(
-                    "this expression has type `{}`, which implements `{}`",
-                    ty,
-                    trait_pred.print_modifiers_and_trait_path()
-                ),
-            );
-            err.span_suggestion(
-                self.tcx.sess.source_map().end_point(stmt.span),
-                "remove this semicolon",
-                "",
-                Applicability::MachineApplicable,
+            // The same closure can be passed to somewhere else that expects it to return `()`,
+            // where keeping the value would introduce a new error.
+            self.suggest_removing_semicolon(
+                err,
+                trait_pred,
+                candidate,
+                Applicability::MaybeIncorrect,
             );
             return true;
         }

--- a/tests/ui/suggestions/closure-arg-trailing-semicolon.rs
+++ b/tests/ui/suggestions/closure-arg-trailing-semicolon.rs
@@ -1,0 +1,45 @@
+//! Check that a trailing semicolon in a closure body that makes the closure return `()` and fail
+//! a trait bound on the function's generic param gets a "remove this semicolon" suggestion, like
+//! `-> impl Trait` function bodies already do.
+//!
+//! Issue: <https://github.com/rust-lang/rust/issues/54771> (closure case).
+
+trait Bar {}
+impl Bar for u8 {}
+//~^ HELP the trait `Bar` is implemented for `u8`
+//~| HELP the trait `Bar` is implemented for `u8`
+//~| HELP the trait `Bar` is implemented for `u8`
+
+fn bar<R: Bar>(_: impl Fn() -> R) {}
+
+struct S;
+impl S {
+    fn run<R: Bar>(&self, _: impl Fn() -> R) {}
+}
+
+fn main() {
+    bar(|| { 5u8; });
+    //~^ ERROR the trait bound `(): Bar` is not satisfied
+    //~| HELP remove this semicolon
+
+    S.run(|| { 5u8; });
+    //~^ ERROR the trait bound `(): Bar` is not satisfied
+    //~| HELP remove this semicolon
+
+    let c = || { 5u8; };
+    //~^ HELP remove this semicolon
+    bar(c);
+    //~^ ERROR the trait bound `(): Bar` is not satisfied
+
+    // No suggestion: the last statement isn't an expression with a semicolon.
+    bar(|| { fn why() {} });
+    //~^ ERROR the trait bound `(): Bar` is not satisfied
+
+    // No suggestion: the tail expression's type doesn't implement `Bar`.
+    bar(|| { "x"; });
+    //~^ ERROR the trait bound `(): Bar` is not satisfied
+
+    // No suggestion: the closure body is empty.
+    bar(|| {});
+    //~^ ERROR the trait bound `(): Bar` is not satisfied
+}

--- a/tests/ui/suggestions/closure-arg-trailing-semicolon.rs
+++ b/tests/ui/suggestions/closure-arg-trailing-semicolon.rs
@@ -10,6 +10,7 @@ impl Bar for u8 {}
 //~| HELP the trait `Bar` is implemented for `u8`
 //~| HELP the trait `Bar` is implemented for `u8`
 //~| HELP the trait `Bar` is implemented for `u8`
+//~| HELP the trait `Bar` is implemented for `u8`
 
 fn bar<R: Bar>(_: impl Fn() -> R) {}
 
@@ -22,6 +23,14 @@ fn unrelated<R: Bar>(_: impl Fn() -> ()) -> R {
 struct S;
 impl S {
     fn run<R: Bar>(&self, _: impl Fn() -> R) {}
+}
+
+trait Callable<T: Bar> {
+    const CALL: fn();
+}
+
+impl<T: Bar> Callable<T> for () {
+    const CALL: fn() = || {};
 }
 
 fn main() {
@@ -58,5 +67,10 @@ fn main() {
     // No suggestion: `R` is the return type of `unrelated` and is inferred as `()` from the
     // expected type, so keeping the closure's value would not satisfy the bound.
     let _: () = unrelated(|| { 5u8; });
+    //~^ ERROR the trait bound `(): Bar` is not satisfied
+
+    // No suggestion: the failing clause belongs to an associated const, which has no signature to
+    // match a closure argument against.
+    <() as Callable<()>>::CALL();
     //~^ ERROR the trait bound `(): Bar` is not satisfied
 }

--- a/tests/ui/suggestions/closure-arg-trailing-semicolon.rs
+++ b/tests/ui/suggestions/closure-arg-trailing-semicolon.rs
@@ -9,8 +9,15 @@ impl Bar for u8 {}
 //~^ HELP the trait `Bar` is implemented for `u8`
 //~| HELP the trait `Bar` is implemented for `u8`
 //~| HELP the trait `Bar` is implemented for `u8`
+//~| HELP the trait `Bar` is implemented for `u8`
 
 fn bar<R: Bar>(_: impl Fn() -> R) {}
+
+fn two<R: Bar>(_: impl Fn() -> (), _: impl Fn() -> R) {}
+
+fn unrelated<R: Bar>(_: impl Fn() -> ()) -> R {
+    loop {}
+}
 
 struct S;
 impl S {
@@ -41,5 +48,15 @@ fn main() {
 
     // No suggestion: the closure body is empty.
     bar(|| {});
+    //~^ ERROR the trait bound `(): Bar` is not satisfied
+
+    // Only the second closure returns the type the failing bound is on.
+    two(|| { 5u8; }, || { 7u8; });
+    //~^ ERROR the trait bound `(): Bar` is not satisfied
+    //~| HELP remove this semicolon
+
+    // No suggestion: `R` is the return type of `unrelated` and is inferred as `()` from the
+    // expected type, so keeping the closure's value would not satisfy the bound.
+    let _: () = unrelated(|| { 5u8; });
     //~^ ERROR the trait bound `(): Bar` is not satisfied
 }

--- a/tests/ui/suggestions/closure-arg-trailing-semicolon.stderr
+++ b/tests/ui/suggestions/closure-arg-trailing-semicolon.stderr
@@ -1,0 +1,102 @@
+error[E0277]: the trait bound `(): Bar` is not satisfied
+  --> $DIR/closure-arg-trailing-semicolon.rs:21:5
+   |
+LL |     bar(|| { 5u8; });
+   |     ^^^^^^^^^----^^^
+   |     |        |  |
+   |     |        |  help: remove this semicolon
+   |     |        this expression has type `u8`, which implements `Bar`
+   |     the trait `Bar` is not implemented for `()`
+   |
+note: required by a bound in `bar`
+  --> $DIR/closure-arg-trailing-semicolon.rs:13:11
+   |
+LL | fn bar<R: Bar>(_: impl Fn() -> R) {}
+   |           ^^^ required by this bound in `bar`
+
+error[E0277]: the trait bound `(): Bar` is not satisfied
+  --> $DIR/closure-arg-trailing-semicolon.rs:25:7
+   |
+LL |     S.run(|| { 5u8; });
+   |       ^^^      ---- help: remove this semicolon
+   |       |        |
+   |       |        this expression has type `u8`, which implements `Bar`
+   |       the trait `Bar` is not implemented for `()`
+   |
+note: required by a bound in `S::run`
+  --> $DIR/closure-arg-trailing-semicolon.rs:17:15
+   |
+LL |     fn run<R: Bar>(&self, _: impl Fn() -> R) {}
+   |               ^^^ required by this bound in `S::run`
+
+error[E0277]: the trait bound `(): Bar` is not satisfied
+  --> $DIR/closure-arg-trailing-semicolon.rs:31:5
+   |
+LL |     let c = || { 5u8; };
+   |                  ---- help: remove this semicolon
+   |                  |
+   |                  this expression has type `u8`, which implements `Bar`
+LL |
+LL |     bar(c);
+   |     ^^^^^^ the trait `Bar` is not implemented for `()`
+   |
+note: required by a bound in `bar`
+  --> $DIR/closure-arg-trailing-semicolon.rs:13:11
+   |
+LL | fn bar<R: Bar>(_: impl Fn() -> R) {}
+   |           ^^^ required by this bound in `bar`
+
+error[E0277]: the trait bound `(): Bar` is not satisfied
+  --> $DIR/closure-arg-trailing-semicolon.rs:35:5
+   |
+LL |     bar(|| { fn why() {} });
+   |     ^^^^^^^^^^^^^^^^^^^^^^^ the trait `Bar` is not implemented for `()`
+   |
+help: the trait `Bar` is implemented for `u8`
+  --> $DIR/closure-arg-trailing-semicolon.rs:8:1
+   |
+LL | impl Bar for u8 {}
+   | ^^^^^^^^^^^^^^^
+note: required by a bound in `bar`
+  --> $DIR/closure-arg-trailing-semicolon.rs:13:11
+   |
+LL | fn bar<R: Bar>(_: impl Fn() -> R) {}
+   |           ^^^ required by this bound in `bar`
+
+error[E0277]: the trait bound `(): Bar` is not satisfied
+  --> $DIR/closure-arg-trailing-semicolon.rs:39:5
+   |
+LL |     bar(|| { "x"; });
+   |     ^^^^^^^^^^^^^^^^ the trait `Bar` is not implemented for `()`
+   |
+help: the trait `Bar` is implemented for `u8`
+  --> $DIR/closure-arg-trailing-semicolon.rs:8:1
+   |
+LL | impl Bar for u8 {}
+   | ^^^^^^^^^^^^^^^
+note: required by a bound in `bar`
+  --> $DIR/closure-arg-trailing-semicolon.rs:13:11
+   |
+LL | fn bar<R: Bar>(_: impl Fn() -> R) {}
+   |           ^^^ required by this bound in `bar`
+
+error[E0277]: the trait bound `(): Bar` is not satisfied
+  --> $DIR/closure-arg-trailing-semicolon.rs:43:5
+   |
+LL |     bar(|| {});
+   |     ^^^^^^^^^^ the trait `Bar` is not implemented for `()`
+   |
+help: the trait `Bar` is implemented for `u8`
+  --> $DIR/closure-arg-trailing-semicolon.rs:8:1
+   |
+LL | impl Bar for u8 {}
+   | ^^^^^^^^^^^^^^^
+note: required by a bound in `bar`
+  --> $DIR/closure-arg-trailing-semicolon.rs:13:11
+   |
+LL | fn bar<R: Bar>(_: impl Fn() -> R) {}
+   |           ^^^ required by this bound in `bar`
+
+error: aborting due to 6 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/suggestions/closure-arg-trailing-semicolon.stderr
+++ b/tests/ui/suggestions/closure-arg-trailing-semicolon.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the trait bound `(): Bar` is not satisfied
-  --> $DIR/closure-arg-trailing-semicolon.rs:28:5
+  --> $DIR/closure-arg-trailing-semicolon.rs:37:5
    |
 LL |     bar(|| { 5u8; });
    |     ^^^^^^^^^----^^^
@@ -9,13 +9,13 @@ LL |     bar(|| { 5u8; });
    |     the trait `Bar` is not implemented for `()`
    |
 note: required by a bound in `bar`
-  --> $DIR/closure-arg-trailing-semicolon.rs:14:11
+  --> $DIR/closure-arg-trailing-semicolon.rs:15:11
    |
 LL | fn bar<R: Bar>(_: impl Fn() -> R) {}
    |           ^^^ required by this bound in `bar`
 
 error[E0277]: the trait bound `(): Bar` is not satisfied
-  --> $DIR/closure-arg-trailing-semicolon.rs:32:7
+  --> $DIR/closure-arg-trailing-semicolon.rs:41:7
    |
 LL |     S.run(|| { 5u8; });
    |       ^^^      ---- help: remove this semicolon
@@ -24,13 +24,13 @@ LL |     S.run(|| { 5u8; });
    |       the trait `Bar` is not implemented for `()`
    |
 note: required by a bound in `S::run`
-  --> $DIR/closure-arg-trailing-semicolon.rs:24:15
+  --> $DIR/closure-arg-trailing-semicolon.rs:25:15
    |
 LL |     fn run<R: Bar>(&self, _: impl Fn() -> R) {}
    |               ^^^ required by this bound in `S::run`
 
 error[E0277]: the trait bound `(): Bar` is not satisfied
-  --> $DIR/closure-arg-trailing-semicolon.rs:38:5
+  --> $DIR/closure-arg-trailing-semicolon.rs:47:5
    |
 LL |     let c = || { 5u8; };
    |                  ---- help: remove this semicolon
@@ -41,13 +41,13 @@ LL |     bar(c);
    |     ^^^^^^ the trait `Bar` is not implemented for `()`
    |
 note: required by a bound in `bar`
-  --> $DIR/closure-arg-trailing-semicolon.rs:14:11
+  --> $DIR/closure-arg-trailing-semicolon.rs:15:11
    |
 LL | fn bar<R: Bar>(_: impl Fn() -> R) {}
    |           ^^^ required by this bound in `bar`
 
 error[E0277]: the trait bound `(): Bar` is not satisfied
-  --> $DIR/closure-arg-trailing-semicolon.rs:42:5
+  --> $DIR/closure-arg-trailing-semicolon.rs:51:5
    |
 LL |     bar(|| { fn why() {} });
    |     ^^^^^^^^^^^^^^^^^^^^^^^ the trait `Bar` is not implemented for `()`
@@ -58,13 +58,13 @@ help: the trait `Bar` is implemented for `u8`
 LL | impl Bar for u8 {}
    | ^^^^^^^^^^^^^^^
 note: required by a bound in `bar`
-  --> $DIR/closure-arg-trailing-semicolon.rs:14:11
+  --> $DIR/closure-arg-trailing-semicolon.rs:15:11
    |
 LL | fn bar<R: Bar>(_: impl Fn() -> R) {}
    |           ^^^ required by this bound in `bar`
 
 error[E0277]: the trait bound `(): Bar` is not satisfied
-  --> $DIR/closure-arg-trailing-semicolon.rs:46:5
+  --> $DIR/closure-arg-trailing-semicolon.rs:55:5
    |
 LL |     bar(|| { "x"; });
    |     ^^^^^^^^^^^^^^^^ the trait `Bar` is not implemented for `()`
@@ -75,13 +75,13 @@ help: the trait `Bar` is implemented for `u8`
 LL | impl Bar for u8 {}
    | ^^^^^^^^^^^^^^^
 note: required by a bound in `bar`
-  --> $DIR/closure-arg-trailing-semicolon.rs:14:11
+  --> $DIR/closure-arg-trailing-semicolon.rs:15:11
    |
 LL | fn bar<R: Bar>(_: impl Fn() -> R) {}
    |           ^^^ required by this bound in `bar`
 
 error[E0277]: the trait bound `(): Bar` is not satisfied
-  --> $DIR/closure-arg-trailing-semicolon.rs:50:5
+  --> $DIR/closure-arg-trailing-semicolon.rs:59:5
    |
 LL |     bar(|| {});
    |     ^^^^^^^^^^ the trait `Bar` is not implemented for `()`
@@ -92,13 +92,13 @@ help: the trait `Bar` is implemented for `u8`
 LL | impl Bar for u8 {}
    | ^^^^^^^^^^^^^^^
 note: required by a bound in `bar`
-  --> $DIR/closure-arg-trailing-semicolon.rs:14:11
+  --> $DIR/closure-arg-trailing-semicolon.rs:15:11
    |
 LL | fn bar<R: Bar>(_: impl Fn() -> R) {}
    |           ^^^ required by this bound in `bar`
 
 error[E0277]: the trait bound `(): Bar` is not satisfied
-  --> $DIR/closure-arg-trailing-semicolon.rs:54:5
+  --> $DIR/closure-arg-trailing-semicolon.rs:63:5
    |
 LL |     two(|| { 5u8; }, || { 7u8; });
    |     ^^^^^^^^^^^^^^^^^^^^^^----^^^
@@ -108,13 +108,13 @@ LL |     two(|| { 5u8; }, || { 7u8; });
    |     the trait `Bar` is not implemented for `()`
    |
 note: required by a bound in `two`
-  --> $DIR/closure-arg-trailing-semicolon.rs:16:11
+  --> $DIR/closure-arg-trailing-semicolon.rs:17:11
    |
 LL | fn two<R: Bar>(_: impl Fn() -> (), _: impl Fn() -> R) {}
    |           ^^^ required by this bound in `two`
 
 error[E0277]: the trait bound `(): Bar` is not satisfied
-  --> $DIR/closure-arg-trailing-semicolon.rs:60:17
+  --> $DIR/closure-arg-trailing-semicolon.rs:69:17
    |
 LL |     let _: () = unrelated(|| { 5u8; });
    |                 ^^^^^^^^^^^^^^^^^^^^^^ the trait `Bar` is not implemented for `()`
@@ -125,11 +125,30 @@ help: the trait `Bar` is implemented for `u8`
 LL | impl Bar for u8 {}
    | ^^^^^^^^^^^^^^^
 note: required by a bound in `unrelated`
-  --> $DIR/closure-arg-trailing-semicolon.rs:18:17
+  --> $DIR/closure-arg-trailing-semicolon.rs:19:17
    |
 LL | fn unrelated<R: Bar>(_: impl Fn() -> ()) -> R {
    |                 ^^^ required by this bound in `unrelated`
 
-error: aborting due to 8 previous errors
+error[E0277]: the trait bound `(): Bar` is not satisfied
+  --> $DIR/closure-arg-trailing-semicolon.rs:74:21
+   |
+LL |     <() as Callable<()>>::CALL();
+   |                     ^^ the trait `Bar` is not implemented for `()`
+   |
+help: the trait `Bar` is implemented for `u8`
+  --> $DIR/closure-arg-trailing-semicolon.rs:8:1
+   |
+LL | impl Bar for u8 {}
+   | ^^^^^^^^^^^^^^^
+note: required by a bound in `Callable::CALL`
+  --> $DIR/closure-arg-trailing-semicolon.rs:28:19
+   |
+LL | trait Callable<T: Bar> {
+   |                   ^^^ required by this bound in `Callable::CALL`
+LL |     const CALL: fn();
+   |           ---- required by a bound in this associated constant
+
+error: aborting due to 9 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/suggestions/closure-arg-trailing-semicolon.stderr
+++ b/tests/ui/suggestions/closure-arg-trailing-semicolon.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the trait bound `(): Bar` is not satisfied
-  --> $DIR/closure-arg-trailing-semicolon.rs:21:5
+  --> $DIR/closure-arg-trailing-semicolon.rs:28:5
    |
 LL |     bar(|| { 5u8; });
    |     ^^^^^^^^^----^^^
@@ -9,13 +9,13 @@ LL |     bar(|| { 5u8; });
    |     the trait `Bar` is not implemented for `()`
    |
 note: required by a bound in `bar`
-  --> $DIR/closure-arg-trailing-semicolon.rs:13:11
+  --> $DIR/closure-arg-trailing-semicolon.rs:14:11
    |
 LL | fn bar<R: Bar>(_: impl Fn() -> R) {}
    |           ^^^ required by this bound in `bar`
 
 error[E0277]: the trait bound `(): Bar` is not satisfied
-  --> $DIR/closure-arg-trailing-semicolon.rs:25:7
+  --> $DIR/closure-arg-trailing-semicolon.rs:32:7
    |
 LL |     S.run(|| { 5u8; });
    |       ^^^      ---- help: remove this semicolon
@@ -24,13 +24,13 @@ LL |     S.run(|| { 5u8; });
    |       the trait `Bar` is not implemented for `()`
    |
 note: required by a bound in `S::run`
-  --> $DIR/closure-arg-trailing-semicolon.rs:17:15
+  --> $DIR/closure-arg-trailing-semicolon.rs:24:15
    |
 LL |     fn run<R: Bar>(&self, _: impl Fn() -> R) {}
    |               ^^^ required by this bound in `S::run`
 
 error[E0277]: the trait bound `(): Bar` is not satisfied
-  --> $DIR/closure-arg-trailing-semicolon.rs:31:5
+  --> $DIR/closure-arg-trailing-semicolon.rs:38:5
    |
 LL |     let c = || { 5u8; };
    |                  ---- help: remove this semicolon
@@ -41,13 +41,13 @@ LL |     bar(c);
    |     ^^^^^^ the trait `Bar` is not implemented for `()`
    |
 note: required by a bound in `bar`
-  --> $DIR/closure-arg-trailing-semicolon.rs:13:11
+  --> $DIR/closure-arg-trailing-semicolon.rs:14:11
    |
 LL | fn bar<R: Bar>(_: impl Fn() -> R) {}
    |           ^^^ required by this bound in `bar`
 
 error[E0277]: the trait bound `(): Bar` is not satisfied
-  --> $DIR/closure-arg-trailing-semicolon.rs:35:5
+  --> $DIR/closure-arg-trailing-semicolon.rs:42:5
    |
 LL |     bar(|| { fn why() {} });
    |     ^^^^^^^^^^^^^^^^^^^^^^^ the trait `Bar` is not implemented for `()`
@@ -58,13 +58,13 @@ help: the trait `Bar` is implemented for `u8`
 LL | impl Bar for u8 {}
    | ^^^^^^^^^^^^^^^
 note: required by a bound in `bar`
-  --> $DIR/closure-arg-trailing-semicolon.rs:13:11
+  --> $DIR/closure-arg-trailing-semicolon.rs:14:11
    |
 LL | fn bar<R: Bar>(_: impl Fn() -> R) {}
    |           ^^^ required by this bound in `bar`
 
 error[E0277]: the trait bound `(): Bar` is not satisfied
-  --> $DIR/closure-arg-trailing-semicolon.rs:39:5
+  --> $DIR/closure-arg-trailing-semicolon.rs:46:5
    |
 LL |     bar(|| { "x"; });
    |     ^^^^^^^^^^^^^^^^ the trait `Bar` is not implemented for `()`
@@ -75,13 +75,13 @@ help: the trait `Bar` is implemented for `u8`
 LL | impl Bar for u8 {}
    | ^^^^^^^^^^^^^^^
 note: required by a bound in `bar`
-  --> $DIR/closure-arg-trailing-semicolon.rs:13:11
+  --> $DIR/closure-arg-trailing-semicolon.rs:14:11
    |
 LL | fn bar<R: Bar>(_: impl Fn() -> R) {}
    |           ^^^ required by this bound in `bar`
 
 error[E0277]: the trait bound `(): Bar` is not satisfied
-  --> $DIR/closure-arg-trailing-semicolon.rs:43:5
+  --> $DIR/closure-arg-trailing-semicolon.rs:50:5
    |
 LL |     bar(|| {});
    |     ^^^^^^^^^^ the trait `Bar` is not implemented for `()`
@@ -92,11 +92,44 @@ help: the trait `Bar` is implemented for `u8`
 LL | impl Bar for u8 {}
    | ^^^^^^^^^^^^^^^
 note: required by a bound in `bar`
-  --> $DIR/closure-arg-trailing-semicolon.rs:13:11
+  --> $DIR/closure-arg-trailing-semicolon.rs:14:11
    |
 LL | fn bar<R: Bar>(_: impl Fn() -> R) {}
    |           ^^^ required by this bound in `bar`
 
-error: aborting due to 6 previous errors
+error[E0277]: the trait bound `(): Bar` is not satisfied
+  --> $DIR/closure-arg-trailing-semicolon.rs:54:5
+   |
+LL |     two(|| { 5u8; }, || { 7u8; });
+   |     ^^^^^^^^^^^^^^^^^^^^^^----^^^
+   |     |                     |  |
+   |     |                     |  help: remove this semicolon
+   |     |                     this expression has type `u8`, which implements `Bar`
+   |     the trait `Bar` is not implemented for `()`
+   |
+note: required by a bound in `two`
+  --> $DIR/closure-arg-trailing-semicolon.rs:16:11
+   |
+LL | fn two<R: Bar>(_: impl Fn() -> (), _: impl Fn() -> R) {}
+   |           ^^^ required by this bound in `two`
+
+error[E0277]: the trait bound `(): Bar` is not satisfied
+  --> $DIR/closure-arg-trailing-semicolon.rs:60:17
+   |
+LL |     let _: () = unrelated(|| { 5u8; });
+   |                 ^^^^^^^^^^^^^^^^^^^^^^ the trait `Bar` is not implemented for `()`
+   |
+help: the trait `Bar` is implemented for `u8`
+  --> $DIR/closure-arg-trailing-semicolon.rs:8:1
+   |
+LL | impl Bar for u8 {}
+   | ^^^^^^^^^^^^^^^
+note: required by a bound in `unrelated`
+  --> $DIR/closure-arg-trailing-semicolon.rs:18:17
+   |
+LL | fn unrelated<R: Bar>(_: impl Fn() -> ()) -> R {
+   |                 ^^^ required by this bound in `unrelated`
+
+error: aborting due to 8 previous errors
 
 For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/159434)*
<!-- homu-ignore:end -->

extends the remove-this-semicolon suggestion for `-> impl Trait` bodies (https://github.com/rust-lang/rust/pull/81407, https://github.com/rust-lang/rust/pull/95758) to closure arguments. only fires when the type behind the semicolon satisfies the failed bound, never when several closure arguments qualify.

before:
```
error[E0277]: the trait bound (): Bar is not satisfied
6 |     bar(|| { 5u8; })
  |     ^^^^^^^^^^^^^^^^ the trait Bar is not implemented for ()
```
after:
```
error[E0277]: the trait bound (): Bar is not satisfied
6 |     bar(|| { 5u8; })
  |     ^^^^^^^^^----^^^
  |     |        |  |
  |     |        |  help: remove this semicolon
  |     |        this expression has type u8, which implements Bar
  |     the trait Bar is not implemented for ()
```
fixes https://github.com/rust-lang/rust/issues/54771