### PR TITLE
core: implement `Rng` for references

### DIFF
--- a/library/core/src/random.rs
+++ b/library/core/src/random.rs
@@ -14,6 +14,15 @@ pub trait Rng {
     fn fill_bytes(&mut self, bytes: &mut [u8]);
 }
 
+/// Implements `Rng` for mutable references to random number generators by
+/// forwarding all methods to the referenced generator.
+#[unstable(feature = "random", issue = "130703")]
+impl<'a, R: Rng + ?Sized> Rng for &'a mut R {
+    fn fill_bytes(&mut self, bytes: &mut [u8]) {
+        R::fill_bytes(self, bytes);
+    }
+}
+
 /// A trait representing a distribution of random values for a type.
 #[unstable(feature = "random", issue = "130703")]
 pub trait Distribution<T> {


### PR DESCRIPTION
Tracking issue: rust-lang/rust#130703 

Just like `Iterator` `Rng` should be implemented for references to RNGs. Aside from the functionality this adds, it also prevents inconsistent implementations.

I've not added a `by_ref` method here since such a method can easily be added later and arguably should be `final`.

r? libs-api