### PR TITLE
Fix(lib/fs/win): Fall back on Win32 delete for `Dir::remove_file`

### DIFF
--- a/library/std/src/sys/fs/windows/dir.rs
+++ b/library/std/src/sys/fs/windows/dir.rs
@@ -6,7 +6,7 @@ use crate::os::windows::io::{
     OwnedHandle, RawHandle,
 };
 use crate::path::Path;
-use crate::sys::api::{self, SetFileInformation, UnicodeStrRef, WinError};
+use crate::sys::api::{UnicodeStrRef, WinError};
 use crate::sys::fs::windows::debug_path_handle;
 use crate::sys::fs::{File, FileAttr, OpenOptions};
 use crate::sys::handle::Handle;
@@ -127,16 +127,7 @@ impl Dir {
         let mut opts = OpenOptions::new();
         opts.access_mode(c::DELETE);
         let handle = self.open_file_native(path, &opts, dir)?;
-        let info = c::FILE_DISPOSITION_INFO_EX { Flags: c::FILE_DISPOSITION_FLAG_DELETE };
-        let result = unsafe {
-            c::SetFileInformationByHandle(
-                handle.as_raw_handle(),
-                c::FileDispositionInfoEx,
-                (&info).as_ptr(),
-                size_of::<c::FILE_DISPOSITION_INFO_EX>() as _,
-            )
-        };
-        if result == 0 { Err(api::get_last_error()).io_result() } else { Ok(()) }
+        File::from_inner(handle).delete().io_result()
     }
 
     fn rename_native(&self, from: &[u16], to_dir: &Self, to: &[u16], dir: bool) -> io::Result<()> {


### PR DESCRIPTION
The `test_dir_remove_file` test currently fails under Windows 7 on:

```
thread 'fs::tests::test_dir_remove_file' (2028) panicked at library/std/src/fs/tests.rs:2590:5:
dir.remove_file("foo.txt") failed with: The parameter is incorrect. (os error 87)
```

Looking into it, this is because the `FILE_DISPOSITION_INFO_EX` variant of the `SetFileInformationByHandle` API is used while it is only available starting from Windows 10 1607. However, `FILE_DISPOSITION_INFO` is still available since Vista.

This is therefore fixed by introducing a fallback to the latter API if the former fails. This is achieved by re-using some logic that is already available through `File::delete` and that does exactly this.

cc rust-lang/rust#120426 @roblabla @the8472 @ChrisDenton @RalfJung

@rustbot label A-io T-libs O-Windows-7