### PR TITLE
Implement `rustc_datastructures::RwLock` as union over `RefCell` and `parking_lot::RwLock`.

### DIFF
--- a/compiler/rustc_data_structures/src/sync.rs
+++ b/compiler/rustc_data_structures/src/sync.rs
@@ -25,11 +25,6 @@
 use std::collections::HashMap;
 use std::hash::{BuildHasher, Hash};
 
-pub use parking_lot::{
-    MappedRwLockReadGuard as MappedReadGuard, MappedRwLockWriteGuard as MappedWriteGuard,
-    RwLockReadGuard as ReadGuard, RwLockWriteGuard as WriteGuard,
-};
-
 pub use self::atomic::AtomicU64;
 pub use self::freeze::{FreezeLock, FreezeReadGuard, FreezeWriteGuard};
 #[doc(no_inline)]
@@ -41,6 +36,7 @@ pub use self::parallel::{
     broadcast, par_fns, par_for_each_in, par_join, par_map, parallel_guard, spawn,
     try_par_for_each_in,
 };
+pub use self::rw_lock::{MappedReadGuard, MappedWriteGuard, ReadGuard, RwLock, WriteGuard};
 pub use self::vec::{AppendOnlyIndexVec, AppendOnlyVec};
 pub use self::worker_local::{Registry, WorkerLocal};
 pub use crate::marker::*;
@@ -48,6 +44,7 @@ pub use crate::marker::*;
 mod freeze;
 mod lock;
 mod parallel;
+mod rw_lock;
 mod vec;
 mod worker_local;
 
@@ -149,10 +146,6 @@ mod mode {
     }
 }
 
-/// This makes locks panic if they are already held.
-/// It is only useful when you are running in a single thread
-const ERROR_CHECKING: bool = false;
-
 #[derive(Default)]
 #[repr(align(64))]
 pub struct CacheAligned<T>(pub T);
@@ -166,60 +159,5 @@ pub trait HashMapExt<K, V> {
 impl<K: Eq + Hash, V: Eq, S: BuildHasher> HashMapExt<K, V> for HashMap<K, V, S> {
     fn insert_same(&mut self, key: K, value: V) {
         self.entry(key).and_modify(|old| assert!(*old == value)).or_insert(value);
-    }
-}
-
-#[derive(Debug, Default)]
-pub struct RwLock<T>(parking_lot::RwLock<T>);
-
-impl<T> RwLock<T> {
-    #[inline(always)]
-    pub fn new(inner: T) -> Self {
-        RwLock(parking_lot::RwLock::new(inner))
-    }
-
-    #[inline(always)]
-    pub fn into_inner(self) -> T {
-        self.0.into_inner()
-    }
-
-    #[inline(always)]
-    pub fn get_mut(&mut self) -> &mut T {
-        self.0.get_mut()
-    }
-
-    #[inline(always)]
-    pub fn read(&self) -> ReadGuard<'_, T> {
-        if ERROR_CHECKING {
-            self.0.try_read().expect("lock was already held")
-        } else {
-            self.0.read()
-        }
-    }
-
-    #[inline(always)]
-    pub fn try_write(&self) -> Result<WriteGuard<'_, T>, ()> {
-        self.0.try_write().ok_or(())
-    }
-
-    #[inline(always)]
-    pub fn write(&self) -> WriteGuard<'_, T> {
-        if ERROR_CHECKING {
-            self.0.try_write().expect("lock was already held")
-        } else {
-            self.0.write()
-        }
-    }
-
-    #[inline(always)]
-    #[track_caller]
-    pub fn borrow(&self) -> ReadGuard<'_, T> {
-        self.read()
-    }
-
-    #[inline(always)]
-    #[track_caller]
-    pub fn borrow_mut(&self) -> WriteGuard<'_, T> {
-        self.write()
     }
 }

--- a/compiler/rustc_data_structures/src/sync.rs
+++ b/compiler/rustc_data_structures/src/sync.rs
@@ -28,9 +28,9 @@ use std::hash::{BuildHasher, Hash};
 pub use self::atomic::AtomicU64;
 pub use self::freeze::{FreezeLock, FreezeReadGuard, FreezeWriteGuard};
 #[doc(no_inline)]
-pub use self::lock::{Lock, LockGuard, Mode};
+pub use self::lock::{Lock, LockGuard};
 pub use self::mode::{
-    FromDyn, check_dyn_thread_safe, is_dyn_thread_safe, set_dyn_thread_safe_mode,
+    FromDyn, Mode, check_dyn_thread_safe, is_dyn_thread_safe, set_dyn_thread_safe_mode,
 };
 pub use self::parallel::{
     broadcast, par_fns, par_for_each_in, par_join, par_map, parallel_guard, spawn,
@@ -64,6 +64,12 @@ mod mode {
     use std::sync::atomic::{AtomicU8, Ordering};
 
     use crate::sync::{DynSend, DynSync};
+
+    #[derive(Clone, Copy, PartialEq)]
+    pub enum Mode {
+        NoSync,
+        Sync,
+    }
 
     const UNINITIALIZED: u8 = 0;
     const DYN_NOT_THREAD_SAFE: u8 = 1;

--- a/compiler/rustc_data_structures/src/sync/lock.rs
+++ b/compiler/rustc_data_structures/src/sync/lock.rs
@@ -1,19 +1,13 @@
 //! This module implements a lock which only uses synchronization if `might_be_dyn_thread_safe` is true.
 //! It implements `DynSend` and `DynSync` instead of the typical `Send` and `Sync` traits.
 
-use std::{fmt, hint};
-
-#[derive(Clone, Copy, PartialEq)]
-pub enum Mode {
-    NoSync,
-    Sync,
-}
-
 use std::cell::{Cell, UnsafeCell};
 use std::marker::PhantomData;
 use std::mem::ManuallyDrop;
 use std::ops::{Deref, DerefMut};
+use std::{fmt, hint};
 
+use mode::Mode;
 use parking_lot::RawMutex;
 use parking_lot::lock_api::RawMutex as _;
 

--- a/compiler/rustc_data_structures/src/sync/rw_lock.rs
+++ b/compiler/rustc_data_structures/src/sync/rw_lock.rs
@@ -1,52 +1,359 @@
-pub use parking_lot::{
-    MappedRwLockReadGuard as MappedReadGuard, MappedRwLockWriteGuard as MappedWriteGuard,
-    RwLockReadGuard as ReadGuard, RwLockWriteGuard as WriteGuard,
-};
+use core::fmt;
+use std::cell::{Cell, UnsafeCell};
+use std::marker::PhantomData;
+use std::mem::ManuallyDrop;
+use std::ops::{Deref, DerefMut};
+use std::{hint, mem};
+
+use parking_lot::RawRwLock;
+use parking_lot::lock_api::RawRwLock as _;
+
+use crate::sync::mode::{self, Mode};
+
+// Mimic `RefCell` borrow counting
+type BorrowCounter = isize;
+const UNUSED: BorrowCounter = 0;
+
+#[inline(always)]
+const fn is_writing(x: BorrowCounter) -> bool {
+    x < UNUSED
+}
+
+#[inline(always)]
+const fn is_reading(x: BorrowCounter) -> bool {
+    x > UNUSED
+}
+
+/// A guard holding shared access to a `RwLock` which is in a read-locked state.
+#[must_use = "if unused the Lock will immediately unlock"]
+pub struct ReadGuard<'a, T> {
+    rw_lock: &'a RwLock<T>,
+    marker: PhantomData<&'a T>,
+
+    /// The synchronization mode of the lock. This is explicitly passed to let LLVM relate it
+    /// to the original lock operation.
+    mode: Mode,
+}
+
+/// # SAFETY
+///
+/// - union_access: `mode` and `mode_union` must be in the same state
+/// - unlock: `mode_union` must be in a read-locked state
+#[inline(always)]
+unsafe fn drop_read_lock(mode: Mode, mode_union: &ModeUnion) {
+    match mode {
+        Mode::NoSync => {
+            let borrow = unsafe { &mode_union.no_sync };
+            debug_assert!(is_reading(borrow.get()));
+            borrow.update(|b| b - 1);
+        }
+        Mode::Sync => unsafe { mode_union.sync.unlock_shared() },
+    }
+}
+
+impl<'a, T: 'a> Drop for ReadGuard<'a, T> {
+    fn drop(&mut self) {
+        // SAFETY (union access): We get `self.mode` from the lock operation so it is consistent
+        // with the `lock.mode` state. This means we access the right union fields.
+        // SAFETY (unlock): We know that the rwlock is read-locked as this type is a proof of that.
+        unsafe {
+            drop_read_lock(self.mode, &self.rw_lock.mode_union);
+        }
+    }
+}
+
+impl<'a, T: 'a> Deref for ReadGuard<'a, T> {
+    type Target = T;
+    #[inline]
+    fn deref(&self) -> &T {
+        // SAFETY: We have shared access to the shared access of this type,
+        // so we can give out a shared reference.
+        unsafe { &*self.rw_lock.data.get() }
+    }
+}
+
+#[must_use = "if unused the RwLock will immediately unlock"]
+pub struct MappedReadGuard<'a, T> {
+    mode_union: &'a ModeUnion,
+    data: *const T,
+    marker: PhantomData<&'a T>,
+
+    /// The synchronization mode of the lock. This is explicitly passed to let LLVM relate it
+    /// to the original lock operation.
+    mode: Mode,
+}
+
+impl<'a, T: 'a> Drop for MappedReadGuard<'a, T> {
+    fn drop(&mut self) {
+        // SAFETY (union access): We get `self.mode` from the lock operation so it is consistent
+        // with the `lock.mode` state. This means we access the right union fields.
+        // SAFETY (unlock): We know that the rwlock is read-locked as this type is a proof of that.
+        unsafe {
+            drop_read_lock(self.mode, self.mode_union);
+        }
+    }
+}
+
+impl<'a, T: 'a> Deref for MappedReadGuard<'a, T> {
+    type Target = T;
+    #[inline]
+    fn deref(&self) -> &T {
+        // SAFETY: We have shared access to the shared access of this type,
+        // so we can give out a shared reference.
+        unsafe { &*self.data }
+    }
+}
+
+impl<'a, T: 'a> ReadGuard<'a, T> {
+    pub fn map<U, F>(self, f: F) -> MappedReadGuard<'a, U>
+    where
+        F: FnOnce(&T) -> &U,
+    {
+        let mode = self.mode;
+        let mode_union = &self.rw_lock.mode_union;
+        let data = f(unsafe { &*self.rw_lock.data.get() });
+        mem::forget(self);
+        MappedReadGuard { mode_union, data, marker: PhantomData, mode }
+    }
+}
+
+/// A guard holding exclusive access to a `RwLock` which is in a write-locked state.
+#[must_use = "if unused the Lock will immediately unlock"]
+pub struct WriteGuard<'a, T> {
+    rw_lock: &'a RwLock<T>,
+    marker: PhantomData<&'a mut T>,
+
+    /// The synchronization mode of the lock. This is explicitly passed to let LLVM relate it
+    /// to the original lock operation.
+    mode: Mode,
+}
+
+/// # SAFETY
+///
+/// - union_access: `mode` and `mode_union` must be in the same state
+/// - unlock: `mode_union` must be in a write-locked state
+#[inline(always)]
+unsafe fn drop_write_lock(mode: Mode, mode_union: &ModeUnion) {
+    // SAFETY: Caller guarantees union_access.
+    match mode {
+        Mode::NoSync => {
+            let borrow = unsafe { &mode_union.no_sync };
+            debug_assert!(is_writing(borrow.get()));
+            borrow.update(|b| b + 1);
+        }
+        // SAFETY: Caller guarantees write-locked state.
+        Mode::Sync => unsafe { mode_union.sync.unlock_exclusive() },
+    }
+}
+
+impl<'a, T: 'a> Drop for WriteGuard<'a, T> {
+    fn drop(&mut self) {
+        // SAFETY (union access): We get `mode` from the lock operation so it is consistent
+        // with the `lock.mode` state. This means we access the right union fields.
+        // SAFETY (unlock): We know that the rwlock is write-locked as this type is a proof of that.
+        unsafe { drop_write_lock(self.mode, &self.rw_lock.mode_union) };
+    }
+}
+
+impl<'a, T: 'a> Deref for WriteGuard<'a, T> {
+    type Target = T;
+    #[inline]
+    fn deref(&self) -> &T {
+        // SAFETY: We have shared access to the shared access of this type,
+        // so we can give out a shared reference.
+        unsafe { &*self.rw_lock.data.get() }
+    }
+}
+
+impl<'a, T: 'a> DerefMut for WriteGuard<'a, T> {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut T {
+        // SAFETY: We have exclusive access to the exclusive access of this type,
+        // so we can give out a exclusive reference.
+        unsafe { &mut *self.rw_lock.data.get() }
+    }
+}
+
+#[must_use = "if unused the RwLock will immediately unlock"]
+pub struct MappedWriteGuard<'a, T> {
+    mode_union: &'a ModeUnion,
+    data: *mut T,
+    marker: PhantomData<&'a mut T>,
+
+    /// The synchronization mode of the lock. This is explicitly passed to let LLVM relate it
+    /// to the original lock operation.
+    mode: Mode,
+}
+
+impl<'a, T: 'a> Drop for MappedWriteGuard<'a, T> {
+    fn drop(&mut self) {
+        // SAFETY (union access): We get `self.mode` from the lock operation so it is consistent
+        // with the `lock.mode` state. This means we access the right union fields.
+        // SAFETY (unlock): We know that the rwlock is write-locked as this type is a proof of that.
+        unsafe {
+            drop_write_lock(self.mode, &self.mode_union);
+        }
+    }
+}
+
+impl<'a, T: 'a> Deref for MappedWriteGuard<'a, T> {
+    type Target = T;
+    #[inline]
+    fn deref(&self) -> &T {
+        // SAFETY: We have shared access to the exclusive access of this type,
+        // so we can give out a shared reference.
+        unsafe { &*self.data }
+    }
+}
+
+impl<'a, T: 'a> DerefMut for MappedWriteGuard<'a, T> {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut T {
+        // SAFETY: We have exclusive access to the exclusive access of this type,
+        // so we can give out a exclusive reference.
+        unsafe { &mut *self.data }
+    }
+}
+
+impl<'a, T: 'a> WriteGuard<'a, T> {
+    pub fn map<U, F>(self, f: F) -> MappedWriteGuard<'a, U>
+    where
+        F: FnOnce(&mut T) -> &mut U,
+    {
+        let mode = self.mode;
+        let mode_union = &self.rw_lock.mode_union;
+        // SAFETY: We have owned access to the exclusive access of this type,
+        // so we can give out a exclusive reference.
+        let data = f(unsafe { &mut *self.rw_lock.data.get() });
+        mem::forget(self);
+        MappedWriteGuard { mode_union, data, marker: PhantomData, mode }
+    }
+}
+
+union ModeUnion {
+    /// Mimics the borrow counting of `RefCell` that is only used if `RwLock.mode` is `NoSync`.
+    no_sync: ManuallyDrop<Cell<BorrowCounter>>,
+
+    /// A RwLock of parking_lot that is only used if `RwLock.mode` is `Sync`
+    sync: ManuallyDrop<RawRwLock>,
+}
+
+pub struct RwLock<T> {
+    mode: Mode,
+
+    mode_union: ModeUnion,
+    data: UnsafeCell<T>,
+}
 
 /// This makes locks panic if they are already held.
 /// It is only useful when you are running in a single thread
 const ERROR_CHECKING: bool = false;
 
-#[derive(Debug, Default)]
-pub struct RwLock<T>(parking_lot::RwLock<T>);
-
 impl<T> RwLock<T> {
     #[inline(always)]
     pub fn new(inner: T) -> Self {
-        RwLock(parking_lot::RwLock::new(inner))
+        let (mode, mode_union) = if mode::might_be_dyn_thread_safe() {
+            hint::cold_path();
+            // Create the lock with synchronization enabled using the `RawRwLock` type.
+            (Mode::Sync, ModeUnion { sync: ManuallyDrop::new(RawRwLock::INIT) })
+        } else {
+            // Create the lock with synchronization disabled.
+            (Mode::NoSync, ModeUnion { no_sync: ManuallyDrop::new(Cell::new(UNUSED)) })
+        };
+        RwLock { mode, mode_union, data: UnsafeCell::new(inner) }
     }
 
     #[inline(always)]
     pub fn into_inner(self) -> T {
-        self.0.into_inner()
+        self.data.into_inner()
     }
 
     #[inline(always)]
     pub fn get_mut(&mut self) -> &mut T {
-        self.0.get_mut()
+        self.data.get_mut()
     }
 
     #[inline(always)]
     pub fn read(&self) -> ReadGuard<'_, T> {
         if ERROR_CHECKING {
-            self.0.try_read().expect("lock was already held")
+            self.try_read().expect("lock was already held")
         } else {
-            self.0.read()
+            let mode = self.mode;
+
+            // SAFETY: This is safe since the union fields are used in accordance with `self.mode`.
+            match mode {
+                Mode::NoSync => {
+                    let borrow = unsafe { &self.mode_union.no_sync };
+                    if is_writing(borrow.get()) {
+                        panic!("RwLock already mutably borrowed");
+                    }
+                    borrow.update(|b| b + 1);
+                }
+                Mode::Sync => unsafe { self.mode_union.sync.lock_shared() },
+            }
+            ReadGuard { rw_lock: self, marker: PhantomData, mode }
         }
     }
 
-    #[inline(always)]
-    pub fn try_write(&self) -> Result<WriteGuard<'_, T>, ()> {
-        self.0.try_write().ok_or(())
+    pub fn try_read(&self) -> Result<ReadGuard<'_, T>, ()> {
+        let mode = self.mode;
+
+        // SAFETY: This is safe since the union fields are used in accordance with `self.mode`.
+        match mode {
+            Mode::NoSync => {
+                let borrow = unsafe { &self.mode_union.no_sync };
+                let is_reading = !is_writing(borrow.get());
+                if is_reading {
+                    borrow.update(|b| b + 1);
+                }
+                is_reading
+            }
+            Mode::Sync => unsafe { self.mode_union.sync.try_lock_shared() },
+        }
+        .then(|| ReadGuard { rw_lock: self, marker: PhantomData, mode })
+        .ok_or(())
     }
 
     #[inline(always)]
     pub fn write(&self) -> WriteGuard<'_, T> {
         if ERROR_CHECKING {
-            self.0.try_write().expect("lock was already held")
+            self.try_write().expect("lock was already held")
         } else {
-            self.0.write()
+            let mode = self.mode;
+
+            // SAFETY: This is safe since the union fields are used in accordance with `self.mode`.
+            match mode {
+                Mode::NoSync => {
+                    let borrow = unsafe { &self.mode_union.no_sync };
+                    if borrow.get() != UNUSED {
+                        panic!("lock was already held")
+                    }
+                    borrow.replace(UNUSED - 1);
+                }
+                Mode::Sync => unsafe { self.mode_union.sync.lock_exclusive() },
+            }
+            WriteGuard { rw_lock: self, marker: PhantomData, mode }
         }
+    }
+
+    #[inline(always)]
+    pub fn try_write(&self) -> Result<WriteGuard<'_, T>, ()> {
+        let mode = self.mode;
+
+        // SAFETY: This is safe since the union fields are used in accordance with `self.mode`.
+        match mode {
+            Mode::NoSync => {
+                let borrow = unsafe { &self.mode_union.no_sync };
+                let unused = borrow.get() == UNUSED;
+                if unused {
+                    borrow.replace(UNUSED - 1);
+                }
+                unused
+            }
+            Mode::Sync => unsafe { self.mode_union.sync.try_lock_exclusive() },
+        }
+        .then(|| WriteGuard { rw_lock: self, marker: PhantomData, mode })
+        .ok_or(())
     }
 
     #[inline(always)]
@@ -59,5 +366,36 @@ impl<T> RwLock<T> {
     #[track_caller]
     pub fn borrow_mut(&self) -> WriteGuard<'_, T> {
         self.write()
+    }
+}
+
+impl<T: Default> Default for RwLock<T> {
+    fn default() -> Self {
+        RwLock::new(T::default())
+    }
+}
+
+impl<T: fmt::Debug> fmt::Debug for RwLock<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut debug = f.debug_struct("RwLock");
+        match self.try_read() {
+            Ok(guard) => debug.field("data", &&*guard).finish(),
+            Err(()) => {
+                // Additional format_args! here is to remove quotes around <locked> in debug output.
+                debug.field("data", &format_args!("<locked>")).finish()
+            }
+        }
+    }
+}
+
+impl<'a, T: fmt::Debug + 'a> fmt::Debug for MappedWriteGuard<'a, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&**self, f)
+    }
+}
+
+impl<'a, T: fmt::Debug + 'a> fmt::Debug for MappedReadGuard<'a, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&**self, f)
     }
 }

--- a/compiler/rustc_data_structures/src/sync/rw_lock.rs
+++ b/compiler/rustc_data_structures/src/sync/rw_lock.rs
@@ -105,14 +105,14 @@ impl<'a, T: 'a> Deref for MappedReadGuard<'a, T> {
 }
 
 impl<'a, T: 'a> ReadGuard<'a, T> {
-    pub fn map<U, F>(self, f: F) -> MappedReadGuard<'a, U>
+    pub fn map<U, F>(s: Self, f: F) -> MappedReadGuard<'a, U>
     where
         F: FnOnce(&T) -> &U,
     {
-        let mode = self.mode;
-        let mode_union = &self.rw_lock.mode_union;
-        let data = f(unsafe { &*self.rw_lock.data.get() });
-        mem::forget(self);
+        let mode = s.mode;
+        let mode_union = &s.rw_lock.mode_union;
+        let data = f(unsafe { &*s.rw_lock.data.get() });
+        mem::forget(s);
         MappedReadGuard { mode_union, data, marker: PhantomData, mode }
     }
 }
@@ -216,16 +216,16 @@ impl<'a, T: 'a> DerefMut for MappedWriteGuard<'a, T> {
 }
 
 impl<'a, T: 'a> WriteGuard<'a, T> {
-    pub fn map<U, F>(self, f: F) -> MappedWriteGuard<'a, U>
+    pub fn map<U, F>(s: Self, f: F) -> MappedWriteGuard<'a, U>
     where
         F: FnOnce(&mut T) -> &mut U,
     {
-        let mode = self.mode;
-        let mode_union = &self.rw_lock.mode_union;
+        let mode = s.mode;
+        let mode_union = &s.rw_lock.mode_union;
         // SAFETY: We have owned access to the exclusive access of this type,
         // so we can give out a exclusive reference.
-        let data = f(unsafe { &mut *self.rw_lock.data.get() });
-        mem::forget(self);
+        let data = f(unsafe { &mut *s.rw_lock.data.get() });
+        mem::forget(s);
         MappedWriteGuard { mode_union, data, marker: PhantomData, mode }
     }
 }
@@ -295,6 +295,7 @@ impl<T> RwLock<T> {
         }
     }
 
+    #[inline(always)]
     pub fn try_read(&self) -> Result<ReadGuard<'_, T>, ()> {
         let mode = self.mode;
 

--- a/compiler/rustc_data_structures/src/sync/rw_lock.rs
+++ b/compiler/rustc_data_structures/src/sync/rw_lock.rs
@@ -273,7 +273,6 @@ impl<T> RwLock<T> {
         self.data.get_mut()
     }
 
-    #[inline(always)]
     pub fn read(&self) -> ReadGuard<'_, T> {
         if ERROR_CHECKING {
             self.try_read().expect("lock was already held")
@@ -295,7 +294,6 @@ impl<T> RwLock<T> {
         }
     }
 
-    #[inline(always)]
     pub fn try_read(&self) -> Result<ReadGuard<'_, T>, ()> {
         let mode = self.mode;
 
@@ -315,7 +313,6 @@ impl<T> RwLock<T> {
         .ok_or(())
     }
 
-    #[inline(always)]
     pub fn write(&self) -> WriteGuard<'_, T> {
         if ERROR_CHECKING {
             self.try_write().expect("lock was already held")
@@ -337,7 +334,6 @@ impl<T> RwLock<T> {
         }
     }
 
-    #[inline(always)]
     pub fn try_write(&self) -> Result<WriteGuard<'_, T>, ()> {
         let mode = self.mode;
 

--- a/compiler/rustc_data_structures/src/sync/rw_lock.rs
+++ b/compiler/rustc_data_structures/src/sync/rw_lock.rs
@@ -1,0 +1,63 @@
+pub use parking_lot::{
+    MappedRwLockReadGuard as MappedReadGuard, MappedRwLockWriteGuard as MappedWriteGuard,
+    RwLockReadGuard as ReadGuard, RwLockWriteGuard as WriteGuard,
+};
+
+/// This makes locks panic if they are already held.
+/// It is only useful when you are running in a single thread
+const ERROR_CHECKING: bool = false;
+
+#[derive(Debug, Default)]
+pub struct RwLock<T>(parking_lot::RwLock<T>);
+
+impl<T> RwLock<T> {
+    #[inline(always)]
+    pub fn new(inner: T) -> Self {
+        RwLock(parking_lot::RwLock::new(inner))
+    }
+
+    #[inline(always)]
+    pub fn into_inner(self) -> T {
+        self.0.into_inner()
+    }
+
+    #[inline(always)]
+    pub fn get_mut(&mut self) -> &mut T {
+        self.0.get_mut()
+    }
+
+    #[inline(always)]
+    pub fn read(&self) -> ReadGuard<'_, T> {
+        if ERROR_CHECKING {
+            self.0.try_read().expect("lock was already held")
+        } else {
+            self.0.read()
+        }
+    }
+
+    #[inline(always)]
+    pub fn try_write(&self) -> Result<WriteGuard<'_, T>, ()> {
+        self.0.try_write().ok_or(())
+    }
+
+    #[inline(always)]
+    pub fn write(&self) -> WriteGuard<'_, T> {
+        if ERROR_CHECKING {
+            self.0.try_write().expect("lock was already held")
+        } else {
+            self.0.write()
+        }
+    }
+
+    #[inline(always)]
+    #[track_caller]
+    pub fn borrow(&self) -> ReadGuard<'_, T> {
+        self.read()
+    }
+
+    #[inline(always)]
+    #[track_caller]
+    pub fn borrow_mut(&self) -> WriteGuard<'_, T> {
+        self.write()
+    }
+}

--- a/compiler/rustc_data_structures/src/sync/vec.rs
+++ b/compiler/rustc_data_structures/src/sync/vec.rs
@@ -2,6 +2,8 @@ use std::marker::PhantomData;
 
 use rustc_index::Idx;
 
+use crate::sync::RwLock;
+
 #[derive(Default)]
 pub struct AppendOnlyIndexVec<I: Idx, T: Copy> {
     vec: elsa::sync::LockFreeFrozenVec<T>,
@@ -26,7 +28,7 @@ impl<I: Idx, T: Copy> AppendOnlyIndexVec<I, T> {
 
 #[derive(Default)]
 pub struct AppendOnlyVec<T: Copy> {
-    vec: parking_lot::RwLock<Vec<T>>,
+    vec: RwLock<Vec<T>>,
 }
 
 impl<T: Copy> AppendOnlyVec<T> {


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/159452)*
<!-- homu-ignore:end -->

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Revive of rust-lang/rust#136772.

cc "Parallel Rustc Front-end" https://github.com/rust-lang/rust/issues/113349

Instead of explicit enums I decided to see what would happen if we would use the `ModeUnion` with `Mode`. Nothing changes API wise, but perf may or may not improve.

Second commit shows what actually changes, first commit just moves `RwLock` to a separate module.
