### PR TITLE
fix(lld): route version mismatch warnings to linker_info on macOS

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -864,9 +864,9 @@ fn is_msvc_link_exe(sess: &Session) -> bool {
         && linker_path.to_str() == Some("link.exe")
 }
 
-fn is_macos_ld(sess: &Session) -> bool {
+fn is_macos_linker(sess: &Session) -> bool {
     let (_, flavor) = linker_and_flavor(sess);
-    sess.target.is_like_darwin && matches!(flavor, LinkerFlavor::Darwin(_, Lld::No))
+    sess.target.is_like_darwin && matches!(flavor, LinkerFlavor::Darwin(..))
 }
 
 fn is_windows_gnu_ld(sess: &Session) -> bool {
@@ -933,8 +933,8 @@ fn report_linker_output(
                 *output += "\r\n"
             }
         });
-    } else if is_macos_ld(sess) {
-        info!("inferred macOS LD");
+    } else if is_macos_linker(sess) {
+        info!("inferred macOS linker");
 
         // FIXME: Tracked by https://github.com/rust-lang/rust/issues/136113
         let deployment_mismatch = |line: &str| {
@@ -947,6 +947,8 @@ fn report_linker_output(
                 && line.contains("building for")
                 && line.contains("but linking with")
                 && line.contains("which was built for newer version"))
+            // lld (ld64.lld / rust-lld):
+            || line.contains("which is newer than target minimum of")
         };
         // FIXME: This is a real warning we would like to show, but it hits too many crates
         // to want to turn it on immediately.

--- a/tests/run-make/macos-lld-version-warning/fake-linker.rs
+++ b/tests/run-make/macos-lld-version-warning/fake-linker.rs
@@ -1,0 +1,6 @@
+fn main() {
+    eprintln!(
+        "ld64.lld: warning: /path/to/lib.rlib(lib.o) has version 26.4.1, \
+         which is newer than target minimum of 11.0.0"
+    );
+}

--- a/tests/run-make/macos-lld-version-warning/main.rs
+++ b/tests/run-make/macos-lld-version-warning/main.rs
@@ -1,0 +1,3 @@
+#![warn(linker_info, linker_messages)]
+
+fn main() {}

--- a/tests/run-make/macos-lld-version-warning/rmake.rs
+++ b/tests/run-make/macos-lld-version-warning/rmake.rs
@@ -21,8 +21,5 @@ fn main() {
         .stderr_utf8();
 
     // The lld version warning should appear under linker_info, not linker_messages.
-    diff()
-        .expected_file("warnings.txt")
-        .actual_text("(lld version warning)", &warnings)
-        .run();
+    diff().expected_file("warnings.txt").actual_text("(lld version warning)", &warnings).run();
 }

--- a/tests/run-make/macos-lld-version-warning/rmake.rs
+++ b/tests/run-make/macos-lld-version-warning/rmake.rs
@@ -1,0 +1,28 @@
+//! Tests that lld-format version mismatch warnings on macOS are routed to `linker_info`
+//! (not `linker_messages`), matching the treatment of ld64/ld_prime deployment warnings.
+//! See <https://github.com/rust-lang/rust/issues/159227>
+
+//@ only-macos
+//@ ignore-cross-compile (need to run fake linker)
+
+use run_make_support::{diff, rustc};
+
+fn main() {
+    rustc().arg("fake-linker.rs").output("fake-linker").run();
+
+    // Use darwin-lld-cc flavor to exercise the Darwin(_, Lld::Yes) path.
+    let warnings = rustc()
+        .input("main.rs")
+        .arg("-Clink-self-contained=-linker")
+        .arg("-Zunstable-options")
+        .arg("-Clinker-flavor=darwin-lld-cc")
+        .linker("./fake-linker")
+        .run()
+        .stderr_utf8();
+
+    // The lld version warning should appear under linker_info, not linker_messages.
+    diff()
+        .expected_file("warnings.txt")
+        .actual_text("(lld version warning)", &warnings)
+        .run();
+}

--- a/tests/run-make/macos-lld-version-warning/warnings.txt
+++ b/tests/run-make/macos-lld-version-warning/warnings.txt
@@ -1,0 +1,11 @@
+warning: ld64.lld: warning: /path/to/lib.rlib(lib.o) has version 26.4.1, which is newer than target minimum of 11.0.0
+         
+  |
+note: the lint level is defined here
+ --> main.rs:1:9
+  |
+1 | #![warn(linker_info, linker_messages)]
+  |         ^^^^^^^^^^^
+
+warning: 1 warning emitted
+


### PR DESCRIPTION
## Summary

Fixes rust-lang/rust#159227

When using `lld` on macOS, benign version mismatch warnings surface to users:
```
warning: linker stderr: rust-lld: /path/file.rlib(file.o) has version 26.4.1, which is newer than target minimum of 11.0.0
```

These are the same class of harmless deployment-target warnings already suppressed for Apple's native `ld64`. The root cause: `is_macos_ld` required `LinkerFlavor::Darwin(_, Lld::No)`, so when lld was used (`Lld::Yes`), the entire filtering chain was skipped.

### Changes

- **Broaden `is_macos_ld` → `is_macos_linker`**: match `Darwin(..)` instead of `Darwin(_, Lld::No)` so filtering runs for both ld and lld
- **Add lld pattern to `deployment_mismatch`**: `line.contains("which is newer than target minimum of")` — the distinctive lld phrasing for version mismatch
- **Add test**: `tests/run-make/macos-lld-version-warning/` with a fake linker emitting lld-format warnings, using `-Clinker-flavor=darwin-lld-cc` to exercise the `Darwin(_, Lld::Yes)` code path

Warnings are downgraded to `linker_info` (default `Allow`), not silenced — users who opt into `-W linker-info` still see them.

## Test plan

- [x] `./x test tests/run-make/macos-lld-version-warning` — new test passes
- [x] `./x test tests/run-make/linker-warning` — no regressions
- [x] `./x test tests/run-make/macos-deployment-target-warning` — no regressions
- [x] `./x test tidy` — passes
- [x] Manual verification with stage1 compiler (see below)

## Manual verification

<details>
<summary>Click to expand manual test session</summary>

```
~/G/rust | fix-llvm-lld..err-warnings !1 ?1  ./x build compiler
Building bootstrap
    Finished [`dev` profile [unoptimized]](https://doc.rust-lang.org/cargo/reference/profiles.html#default-profiles) target(s) in 0.11s
WARNING: you have not made a `bootstrap.toml`
HELP: consider running `./x.py setup` or copying `bootstrap.example.toml` by running `cp bootstrap.example.toml bootstrap.toml`
/Users/ianmiller/GitHub/rust/build/aarch64-apple-darwin/ci-llvm/bin/llvm-strip does not exist; skipping copy
Building stage1 compiler artifacts (stage0 -> stage1, aarch64-apple-darwin)
    Finished [`release` profile [optimized]](https://doc.rust-lang.org/cargo/reference/profiles.html#default-profiles) target(s) in 0.33s
Creating a sysroot for stage1 compiler (use `rustup toolchain link 'name' build/host/stage1`)
WARNING: you have not made a `bootstrap.toml`
HELP: consider running `./x.py setup` or copying `bootstrap.example.toml` by running `cp bootstrap.example.toml bootstrap.toml`
NOTE: this message was printed twice to make it more likely to be seen
Build completed successfully in 0:00:04

~/G/rust | fix-llvm-lld..err-warnings !1 ?1  ./x build library
Building bootstrap
    Finished `dev` profile [unoptimized] target(s) in 0.07s
Building stage1 compiler artifacts (stage0 -> stage1, aarch64-apple-darwin)
    Finished `release` profile [optimized] target(s) in 0.38s
Creating a sysroot for stage1 compiler (use `rustup toolchain link 'name' build/host/stage1`)
Building stage1 library artifacts (stage1 -> stage1, aarch64-apple-darwin)
    Finished `dist` profile [optimized] target(s) in 0.04s
Build completed successfully in 0:00:07

~/G/rust | fix-llvm-lld..err-warnings !1 ?1  DYLD_LIBRARY_PATH="build/aarch64-apple-darwin/stage1/lib" \
    build/aarch64-apple-darwin/stage1/bin/rustc \
    tests/run-make/macos-lld-version-warning/fake-linker.rs \
    -o /tmp/fake-linker

~/G/rust | fix-llvm-lld..err-warnings !1 ?1  echo 'fn main() {}' > /tmp/test.rs

# WITHOUT -Wlinker-info: silent (fix works)
~/G/rust | fix-llvm-lld..err-warnings !1 ?1  DYLD_LIBRARY_PATH="build/aarch64-apple-darwin/stage1/lib" \
    build/aarch64-apple-darwin/stage1/bin/rustc /tmp/test.rs \
    -o /tmp/test \
    -Clinker-flavor=darwin-lld-cc \
    -Clink-self-contained=-linker \
    -Zunstable-options \
    -Clinker=/tmp/fake-linker

# WITH -Wlinker-info: warning visible under linker_info lint (opt-in works)
~/G/rust | fix-llvm-lld..err-warnings !1 ?1  DYLD_LIBRARY_PATH="build/aarch64-apple-darwin/stage1/lib" \
    build/aarch64-apple-darwin/stage1/bin/rustc /tmp/test.rs \
    -o /tmp/test \
    -Clinker-flavor=darwin-lld-cc \
    -Clink-self-contained=-linker \
    -Zunstable-options \
    -Clinker=/tmp/fake-linker \
    -Wlinker-info
warning: ld64.lld: warning: /path/to/lib.rlib(lib.o) has version 26.4.1, which is newer than target minimum of 11.0.0

  |
  = note: requested on the command line with `-W linker-info`

warning: 1 warning emitted
```

</details>