### PR TITLE
Fix the reporting of layout normalization failures in transmute checks

### DIFF
--- a/compiler/rustc_hir_typeck/src/intrinsicck.rs
+++ b/compiler/rustc_hir_typeck/src/intrinsicck.rs
@@ -75,20 +75,20 @@ fn check_transmute<'tcx>(
     hir_id: HirId,
 ) -> Result<(), ErrorGuaranteed> {
     let span = tcx.hir_span(hir_id);
-    let normalize = |ty| {
-        if let Ok(ty) = tcx.try_normalize_erasing_regions(typing_env, ty) {
-            ty
-        } else {
-            Ty::new_error_with_message(
-                tcx,
-                span,
-                format!("tried to normalize non-wf type {ty:#?} in check_transmute"),
-            )
-        }
+    let normalize = |ty: Unnormalized<'tcx, Ty<'tcx>>| -> Result<Ty<'tcx>, ErrorGuaranteed> {
+        let unnormalized_ty = ty.skip_normalization();
+        tcx.try_normalize_erasing_regions(typing_env, ty).map_err(|err| {
+            tcx.dcx()
+                .struct_span_err(
+                    span,
+                    LayoutError::NormalizationFailure(unnormalized_ty, err).to_string(),
+                )
+                .emit()
+        })
     };
 
-    let from = normalize(from);
-    let to = normalize(to);
+    let from = normalize(from)?;
+    let to = normalize(to)?;
     trace!(?from, ?to);
 
     // Transmutes that are only changing lifetimes are always ok.

--- a/compiler/rustc_hir_typeck/src/intrinsicck.rs
+++ b/compiler/rustc_hir_typeck/src/intrinsicck.rs
@@ -75,20 +75,15 @@ fn check_transmute<'tcx>(
     hir_id: HirId,
 ) -> Result<(), ErrorGuaranteed> {
     let span = tcx.hir_span(hir_id);
-    let normalize = |ty| {
-        if let Ok(ty) = tcx.try_normalize_erasing_regions(typing_env, ty) {
-            ty
-        } else {
-            Ty::new_error_with_message(
-                tcx,
-                span,
-                format!("tried to normalize non-wf type {ty:#?} in check_transmute"),
-            )
-        }
+    let normalize = |ty: Unnormalized<'tcx, Ty<'tcx>>| -> Result<Ty<'tcx>, ErrorGuaranteed> {
+        tcx.try_normalize_erasing_regions(typing_env, ty).map_err(|err| {
+            let err = LayoutError::NormalizationFailure(ty.skip_normalization(), err);
+            tcx.dcx().struct_span_err(span, err.to_string()).emit()
+        })
     };
 
-    let from = normalize(from);
-    let to = normalize(to);
+    let from = normalize(from)?;
+    let to = normalize(to)?;
     trace!(?from, ?to);
 
     // Transmutes that are only changing lifetimes are always ok.

--- a/tests/ui/layout/normalization-failure.rs
+++ b/tests/ui/layout/normalization-failure.rs
@@ -48,9 +48,7 @@ fn opaque<T>() -> impl Project2 {
 fn check<T: Project1>() {
     unsafe {
         std::mem::transmute::<_, ()>(opaque::<T>().get());
-        //~^ ERROR: cannot transmute
-        //~| NOTE: source type: `{type error}` (the type has an unknown layout)
-        //~| NOTE: target type: `()` (0 bits)
+        //~^ ERROR: unable to determine layout
     }
 }
 

--- a/tests/ui/layout/normalization-failure.stderr
+++ b/tests/ui/layout/normalization-failure.stderr
@@ -1,12 +1,8 @@
-error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+error: unable to determine layout for `<impl Project2 as Project2>::Assoc2` because `<impl Project2 as Project2>::Assoc2` cannot be normalized
   --> $DIR/normalization-failure.rs:50:9
    |
 LL |         std::mem::transmute::<_, ()>(opaque::<T>().get());
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: source type: `{type error}` (the type has an unknown layout)
-   = note: target type: `()` (0 bits)
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0512`.


### PR DESCRIPTION
Fixes rust-lang/rust#149588.

"check_transmute" normalized the source and target types before computing their size skeletons. When that normalization failed, it created a {type error} placeholder and continued into the generic transmute-size diagnostic. This hid the actual layout failure and produced an unhelpful E0512 message.

This changes transmute checking to report the layout normalization failure directly and return early. The diagnostic now explains that rustc cannot determine the layout because the associated type cannot be normalized, instead of showing `{type error}` as the source type.

I also updated the existing ./tests/ui/layout/normalization-failure.rs test to cover the corrected diagnostic.