### PR TITLE
cmse: clear variant-dependent padding in `enum`s

### DIFF
--- a/compiler/rustc_abi/src/layout/ty.rs
+++ b/compiler/rustc_abi/src/layout/ty.rs
@@ -284,6 +284,27 @@ impl<'a, Ty> TyAndLayout<'a, Ty> {
         found
     }
 
+    /// Whether this type/layout has any padding that is dependent on a variant, i.e. has bytes that
+    /// are padding for some, but not all, valid values of this type.
+    pub fn has_variant_dependent_padding<C>(&self, cx: &C) -> bool
+    where
+        Ty: TyAbiInterface<'a, C> + Copy,
+    {
+        match self.variants {
+            Variants::Multiple { .. } => true,
+            Variants::Empty => false,
+            Variants::Single { .. } => match &self.fields {
+                FieldsShape::Primitive | FieldsShape::Union(_) => false,
+                FieldsShape::Array { count, .. } => {
+                    *count > 0 && self.field(cx, 0).has_variant_dependent_padding(cx)
+                }
+                FieldsShape::Arbitrary { offsets, .. } => {
+                    (0..offsets.len()).any(|i| self.field(cx, i).has_variant_dependent_padding(cx))
+                }
+            },
+        }
+    }
+
     /// The ranges of bytes that are always ignored by the representation relation of this type.
     ///
     /// In other words, for any sequence of bytes, if we reset the these padding bytes to uninit,
@@ -316,6 +337,45 @@ impl<'a, Ty> TyAndLayout<'a, Ty> {
         uninit_ranges
     }
 
+    /// The ranges of bytes that are ignored by the representation relation of this variant.
+    ///
+    /// The result does not include variant-independent padding.
+    pub fn variant_dependent_padding_ranges<C>(
+        &self,
+        cx: &C,
+        variant_index: VariantIdx,
+    ) -> Vec<Range<Size>>
+    where
+        Ty: TyAbiInterface<'a, C> + Copy,
+    {
+        let Variants::Multiple { .. } = self.variants else {
+            return Vec::new();
+        };
+
+        // Bytes that are data in some variant.
+        let mut any = RangeSet::new();
+        self.add_data_ranges(cx, Size::ZERO, &mut any);
+
+        // Bytes that are data in this variant.
+        let mut this = RangeSet::new();
+
+        // The variants do not contain e.g. the discriminant or coroutine upvars.
+        let FieldsShape::Arbitrary { offsets, in_memory_order: _ } = &self.fields else {
+            unreachable!("a multi-variant layout should have `Arbitrary` fields")
+        };
+
+        // So add them explicitly.
+        for (field, &offset) in offsets.iter_enumerated() {
+            let field = self.field(cx, field.as_usize());
+            field.add_data_ranges(cx, offset, &mut this);
+        }
+
+        self.for_variant(cx, variant_index).add_data_ranges(cx, Size::ZERO, &mut this);
+
+        // Padding specific to this variant: data in some variant, but not in this one.
+        any.difference(&this).0.iter().map(|&(offset, size)| offset..offset + size).collect()
+    }
+
     /// Extend `out` with all ranges of bytes that *may* carry relevant data for values of this type.
     /// For enums and unions there are offsets that are initialized for some
     /// variants but not for others; those offset *will* get added to `out`.
@@ -327,51 +387,43 @@ impl<'a, Ty> TyAndLayout<'a, Ty> {
             return;
         }
 
-        match &self.variants {
-            Variants::Empty => { /* done */ }
-            Variants::Single { index: _ } => match &self.fields {
-                FieldsShape::Primitive => {
-                    out.add_range(base_offset, self.size);
+        // Visit the fields of this value. For enum values the fields include the discriminant.
+        match &self.fields {
+            FieldsShape::Primitive => {
+                out.add_range(base_offset, self.size);
+            }
+            &FieldsShape::Union(field_count) => {
+                for field in 0..field_count.get() {
+                    let field = self.field(cx, field);
+                    field.add_data_ranges(cx, base_offset, out);
                 }
-                &FieldsShape::Union(field_count) => {
-                    for field in 0..field_count.get() {
-                        let field = self.field(cx, field);
-                        field.add_data_ranges(cx, base_offset, out);
-                    }
-                }
-                &FieldsShape::Array { stride, count } => {
-                    let elem = self.field(cx, 0);
+            }
+            &FieldsShape::Array { stride, count } => {
+                let elem = self.field(cx, 0);
 
-                    // For scalars we know there is no padding between the elements,
-                    // so the entire array is a single big data range.
-                    if elem.backend_repr.is_scalar() {
-                        out.add_range(base_offset, elem.size * count);
-                    } else {
-                        // FIXME: this is really inefficient for large arrays.
-                        for idx in 0..count {
-                            elem.add_data_ranges(cx, base_offset + idx * stride, out);
-                        }
+                // For scalars we know there is no padding between the elements,
+                // so the entire array is a single big data range.
+                if elem.backend_repr.is_scalar() {
+                    out.add_range(base_offset, elem.size * count);
+                } else {
+                    // FIXME: this is really inefficient for large arrays.
+                    for idx in 0..count {
+                        elem.add_data_ranges(cx, base_offset + idx * stride, out);
                     }
                 }
-                FieldsShape::Arbitrary { offsets, in_memory_order: _ } => {
-                    for (field, &offset) in offsets.iter_enumerated() {
-                        let field = self.field(cx, field.as_usize());
-                        field.add_data_ranges(cx, base_offset + offset, out);
-                    }
-                }
-            },
-            Variants::Multiple { variants, .. } => {
-                // The variants do not contain e.g. the discriminant or coroutine upvars.
-                let FieldsShape::Arbitrary { offsets, in_memory_order: _ } = &self.fields else {
-                    unreachable!("a multi-variant layout should have `Arbitrary` fields")
-                };
-
-                // So add them explicitly.
+            }
+            FieldsShape::Arbitrary { offsets, in_memory_order: _ } => {
                 for (field, &offset) in offsets.iter_enumerated() {
                     let field = self.field(cx, field.as_usize());
                     field.add_data_ranges(cx, base_offset + offset, out);
                 }
+            }
+        }
 
+        // Visit the fields of each variant.
+        match &self.variants {
+            Variants::Empty | Variants::Single { index: _ } => { /* done */ }
+            Variants::Multiple { variants, .. } => {
                 for variant in variants.indices() {
                     let variant = self.for_variant(cx, variant);
                     variant.add_data_ranges(cx, base_offset, out);

--- a/compiler/rustc_abi/src/layout/ty.rs
+++ b/compiler/rustc_abi/src/layout/ty.rs
@@ -361,6 +361,17 @@ impl<'a, Ty> TyAndLayout<'a, Ty> {
                 }
             },
             Variants::Multiple { variants, .. } => {
+                // The variants do not contain e.g. the discriminant or coroutine upvars.
+                let FieldsShape::Arbitrary { offsets, in_memory_order: _ } = &self.fields else {
+                    unreachable!("a multi-variant layout should have `Arbitrary` fields")
+                };
+
+                // So add them explicitly.
+                for (field, &offset) in offsets.iter_enumerated() {
+                    let field = self.field(cx, field.as_usize());
+                    field.add_data_ranges(cx, base_offset + offset, out);
+                }
+
                 for variant in variants.indices() {
                     let variant = self.for_variant(cx, variant);
                     variant.add_data_ranges(cx, base_offset, out);

--- a/compiler/rustc_abi/src/layout/ty.rs
+++ b/compiler/rustc_abi/src/layout/ty.rs
@@ -291,7 +291,7 @@ impl<'a, Ty> TyAndLayout<'a, Ty> {
     /// This is the "guaranteed" padding. There may be more bytes that are padding for some
     /// but not all variants of this type; those are not included.
     /// (E.g. `Option<i8>` has no guaranteed padding so the empty range set is returned, but its `None` value still has padding).
-    pub fn padding_ranges<C>(&self, cx: &C) -> Vec<Range<Size>>
+    pub fn variant_independent_padding_ranges<C>(&self, cx: &C) -> Vec<Range<Size>>
     where
         Ty: TyAbiInterface<'a, C> + Copy,
     {

--- a/compiler/rustc_codegen_ssa/src/mir/block.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/block.rs
@@ -2,7 +2,8 @@ use std::cmp;
 use std::ops::Range;
 
 use rustc_abi::{
-    Align, ArmCall, BackendRepr, CanonAbi, ExternAbi, HasDataLayout, Reg, Size, WrappingRange,
+    Align, ArmCall, BackendRepr, CanonAbi, ExternAbi, FieldsShape, HasDataLayout, Reg, Size,
+    VariantIdx, Variants, WrappingRange,
 };
 use rustc_ast as ast;
 use rustc_ast::{InlineAsmOptions, InlineAsmTemplatePiece};
@@ -603,14 +604,9 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
 
                 if self.fn_abi.conv == CanonAbi::Arm(ArmCall::CCmseNonSecureEntry) {
                     // The return value of an `extern "cmse-nonsecure-entry"` function crosses the
-                    // secure boundary. Zero padding bytes so information does not leak.
-                    //
-                    // This only zeroes "guaranteed" padding. There may be more bytes that are
-                    // padding for some but not all variants of this type; those are not zeroed.
-                    //
-                    // Returning a value with value-dependent padding will instead trigger a lint.
+                    // secure boundary. Clear any padding bytes so information does not leak.
                     let ret_layout = self.fn_abi.ret.layout;
-                    self.clear_cmse_padding(bx, llslot, ret_layout.size, ret_layout);
+                    self.clear_padding_cmse(bx, llslot, ret_layout.size, ret_layout);
                 }
 
                 load_cast(bx, cast_ty, llslot, self.fn_abi.ret.layout.align.abi)
@@ -1729,7 +1725,21 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
         }
     }
 
-    fn clear_cmse_padding(
+    /// When using CMSE, values that cross the secure boundary from secure to non-secure mode can
+    /// contain stale secure data in their padding bytes. This function clears that data. This is
+    /// required when a value is:
+    ///
+    /// - passed to an `extern "cmse-nonsecure-call"` function
+    /// - returned from an `extern "cmse-nonsecure-entry"` function
+    ///
+    /// This function clears both:
+    ///
+    /// - variant-independent padding, bytes that are padding for all valid values of the type
+    /// - variant-dependent padding, bytes that are padding for some but not all values of the type
+    ///
+    /// Clearing variant-dependent padding requires looking at the data at runtime to determine what
+    /// bytes to clear.
+    fn clear_padding_cmse(
         &mut self,
         bx: &mut Bx,
         base_ptr: Bx::Value,
@@ -1738,25 +1748,143 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
     ) {
         // First clear variant-independent padding, a series of memsets.
         let variant_independent = layout.variant_independent_padding_ranges(self.cx);
-        self.zero_byte_ranges(bx, base_ptr, limit, &variant_independent);
+        self.zero_byte_ranges(bx, base_ptr, Size::ZERO, limit, &variant_independent);
+
+        // Then clear the extra padding of the active variant of any (nested) enum.
+        self.clear_variant_dependent_padding(bx, base_ptr, Size::ZERO, limit, layout);
+    }
+
+    fn clear_variant_dependent_padding(
+        &mut self,
+        bx: &mut Bx,
+        base_ptr: Bx::Value,
+        base_offset: Size,
+        limit: Size,
+        layout: TyAndLayout<'tcx>,
+    ) {
+        let cx = self.cx;
+
+        if !layout.has_variant_dependent_padding(cx) {
+            return;
+        }
+
+        // Recurse into aggregate fields/elements to reach any nested enums.
+        match layout.fields {
+            FieldsShape::Array { stride, count } => {
+                let elem = layout.field(cx, 0);
+                if elem.has_variant_dependent_padding(cx) {
+                    for idx in 0..count {
+                        let off = base_offset + idx * stride;
+                        self.clear_variant_dependent_padding(bx, base_ptr, off, limit, elem);
+                    }
+                }
+            }
+            FieldsShape::Arbitrary { .. } => {
+                for i in 0..layout.fields.count() {
+                    let field = layout.field(cx, i);
+                    if field.has_variant_dependent_padding(cx) {
+                        let off = base_offset + layout.fields.offset(i);
+                        self.clear_variant_dependent_padding(bx, base_ptr, off, limit, field);
+                    }
+                }
+            }
+            FieldsShape::Primitive | FieldsShape::Union(_) => { /* nothing to visit */ }
+        }
+
+        // If this is not a multi-variant enum, we're done.
+        let Variants::Multiple { ref variants, .. } = layout.variants else {
+            return;
+        };
+
+        // Collect variants that will need padding cleared.
+        let mut work = Vec::with_capacity(variants.len());
+        for i in 0..variants.len() {
+            let idx = VariantIdx::from_usize(i);
+            let variant = layout.for_variant(cx, idx);
+
+            // Don't consider uninhabited variants.
+            if variant.is_uninhabited() {
+                continue;
+            }
+
+            let variant_dependent = layout.variant_dependent_padding_ranges(cx, idx);
+            let has_nested_variant_dependent = (0..variant.fields.count())
+                .any(|i| variant.field(cx, i).has_variant_dependent_padding(cx));
+
+            if !variant_dependent.is_empty() || has_nested_variant_dependent {
+                work.push((idx, variant, variant_dependent));
+            }
+        }
+
+        if work.is_empty() {
+            return;
+        }
+
+        // Build the switch and clear the appropriate padding for each variant.
+        let root_block = bx.llbb();
+        let join_block = bx.append_sibling_block("cmse_pad_join");
+        let mut cases = Vec::with_capacity(work.len());
+
+        for (idx, variant, variant_dependent) in work.into_iter() {
+            let Some(discr) = layout.ty.discriminant_for_variant(bx.tcx(), idx) else {
+                bug!("multi-variant layout on a type without discriminants");
+            };
+
+            let variant_block = bx.append_sibling_block("cmse_pad_variant");
+            bx.switch_to_block(variant_block);
+
+            // Clear the padding of this variant.
+            self.zero_byte_ranges(bx, base_ptr, base_offset, limit, &variant_dependent);
+
+            // Recurse into the fields.
+            for i in 0..variant.fields.count() {
+                let field = variant.field(cx, i);
+                let off = base_offset + variant.fields.offset(i);
+                self.clear_variant_dependent_padding(bx, base_ptr, off, limit, field);
+            }
+
+            bx.br(join_block);
+            cases.push((discr.val, variant_block));
+        }
+
+        // Construct the dispatch.
+        bx.switch_to_block(root_block);
+
+        let discr_ty = layout.ty.discriminant_ty(bx.tcx());
+        let enum_ptr = bx.inbounds_ptradd(base_ptr, bx.const_usize(base_offset.bytes()));
+        let operand = OperandRef {
+            val: OperandValue::Ref(PlaceValue::new_sized(enum_ptr, layout.align.abi)),
+            layout,
+            move_annotation: None,
+        };
+        let discr = operand.codegen_get_discr(self, bx, discr_ty);
+
+        // Default to the join block (for variants without variant-dependent padding).
+        bx.switch(discr, join_block, cases.into_iter());
+
+        bx.switch_to_block(join_block);
     }
 
     fn zero_byte_ranges(
         &mut self,
         bx: &mut Bx,
         ptr: Bx::Value,
+        offset: Size,
         limit: Size,
         ranges: &[Range<Size>],
     ) {
         let zero = bx.const_u8(0);
 
         for range in ranges {
-            let end = cmp::min(range.end, limit);
+            let start = range.start + offset;
+            let end = range.end + offset;
+
+            let end = cmp::min(end, limit);
             if range.start >= end {
                 continue;
             }
-            let offset = bx.const_usize(range.start.bytes());
-            let len = bx.const_usize((end - range.start).bytes());
+            let offset = bx.const_usize(start.bytes());
+            let len = bx.const_usize((end - start).bytes());
             let ptr = bx.inbounds_ptradd(ptr, offset);
             bx.memset(ptr, zero, len, Align::ONE, MemFlags::empty());
         }
@@ -1891,14 +2019,9 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                 );
 
                 // The arguments of an `extern "cmse-nonsecure-call"` function cross the secure
-                // boundary. Zero padding bytes so information does not leak.
-                //
-                // This only zeroes "guaranteed" padding. There may be more bytes that are
-                // padding for some but not all variants of this type; those are not zeroed.
-                //
-                // Passing an argument with value-dependent padding will instead trigger a lint.
+                // boundary. Clear any padding bytes so information does not leak.
                 if conv == CanonAbi::Arm(ArmCall::CCmseNonSecureCall) {
-                    self.clear_cmse_padding(
+                    self.clear_padding_cmse(
                         bx,
                         llscratch,
                         Size::from_bytes(copy_bytes),

--- a/compiler/rustc_codegen_ssa/src/mir/block.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/block.rs
@@ -11,7 +11,7 @@ use rustc_hir::attrs::AttributeKind;
 use rustc_hir::lang_items::LangItem;
 use rustc_lint_defs::builtin::TAIL_CALL_TRACK_CALLER;
 use rustc_middle::mir::{self, AssertKind, InlineAsmMacro, SwitchTargets, UnwindTerminateReason};
-use rustc_middle::ty::layout::{HasTyCtxt, LayoutOf, ValidityRequirement};
+use rustc_middle::ty::layout::{HasTyCtxt, LayoutOf, TyAndLayout, ValidityRequirement};
 use rustc_middle::ty::print::{with_no_trimmed_paths, with_no_visible_paths};
 use rustc_middle::ty::{self, Instance, Ty, TypeVisitableExt};
 use rustc_middle::{bug, span_bug};
@@ -610,8 +610,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                     //
                     // Returning a value with value-dependent padding will instead trigger a lint.
                     let ret_layout = self.fn_abi.ret.layout;
-                    let uninit_ranges = ret_layout.padding_ranges(bx.cx());
-                    self.zero_byte_ranges(bx, llslot, ret_layout.size, &uninit_ranges);
+                    self.clear_cmse_padding(bx, llslot, ret_layout.size, ret_layout);
                 }
 
                 load_cast(bx, cast_ty, llslot, self.fn_abi.ret.layout.align.abi)
@@ -1730,6 +1729,18 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
         }
     }
 
+    fn clear_cmse_padding(
+        &mut self,
+        bx: &mut Bx,
+        base_ptr: Bx::Value,
+        limit: Size,
+        layout: TyAndLayout<'tcx>,
+    ) {
+        // First clear variant-independent padding, a series of memsets.
+        let variant_independent = layout.variant_independent_padding_ranges(self.cx);
+        self.zero_byte_ranges(bx, base_ptr, limit, &variant_independent);
+    }
+
     fn zero_byte_ranges(
         &mut self,
         bx: &mut Bx,
@@ -1887,11 +1898,11 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                 //
                 // Passing an argument with value-dependent padding will instead trigger a lint.
                 if conv == CanonAbi::Arm(ArmCall::CCmseNonSecureCall) {
-                    self.zero_byte_ranges(
+                    self.clear_cmse_padding(
                         bx,
                         llscratch,
                         Size::from_bytes(copy_bytes),
-                        &arg.layout.padding_ranges(bx.cx()),
+                        arg.layout,
                     );
                 }
 

--- a/compiler/rustc_data_structures/src/range_set.rs
+++ b/compiler/rustc_data_structures/src/range_set.rs
@@ -56,4 +56,44 @@ where
             v.insert(idx, (offset, size));
         }
     }
+
+    /// The ranges from `self` with any intersection with `other` removed.
+    pub fn difference(&self, other: &Self) -> Self {
+        let (a, b) = (self, other);
+        let mut out = Vec::new();
+
+        let mut j = 0;
+        for &(a_offset, a_size) in a.0.iter() {
+            let mut cursor = a_offset;
+            let a_end = a_offset + a_size;
+
+            // Skip ranges of `b` that end before this range of `a` begins.
+            // both sequences are sorted they cannot overlap any later range of `a` either.
+            while let Some(&(b_offset, b_size)) = b.0.get(j)
+                && b_offset + b_size <= cursor
+            {
+                j += 1;
+            }
+
+            // Carve out each range of `b` that overlaps this range of `a`. A range of `b` may extend
+            // past `a_end` and overlap the next range of `a`, so leave `j` pointing at it.
+            let mut k = j;
+            while let Some(&(b_offset, b_size)) = b.0.get(k)
+                && b_offset < a_end
+            {
+                if b_offset > cursor {
+                    out.push((cursor, b_offset));
+                }
+                cursor = Ord::max(cursor, b_offset + b_size);
+                k += 1;
+            }
+
+            // Keep the remainder of the `a`'s range.
+            if cursor < a_end {
+                out.push((cursor, a_end));
+            }
+        }
+
+        Self(out)
+    }
 }

--- a/tests/assembly-llvm/cmse-clear-padding.rs
+++ b/tests/assembly-llvm/cmse-clear-padding.rs
@@ -221,8 +221,9 @@ impl Copy for VariantsSameSize {}
 
 // CHECK-LABEL: variants_same_size:
 // CHECK: mov r7, sp
-// CHECK-NEXT: ldrh r0, [r0, #2]
-// CHECK-NEXT: lsls r0, r0, #16
+// CHECK-NEXT: ldrh r1, [r0, #2]
+// CHECK-NEXT: ldrb r0, [r0]
+// CHECK-NEXT: orr.w r0, r0, r1, lsl #16
 #[no_mangle]
 extern "cmse-nonsecure-entry" fn variants_same_size(v: &VariantsSameSize) -> VariantsSameSize {
     *v
@@ -238,8 +239,8 @@ impl Copy for VariantsDifferentSize {}
 
 // CHECK-LABEL: variants_different_size:
 // CHECK: mov r7, sp
-// CHECK-NEXT: ldrh r0, [r0, #2]
-// CHECK-NEXT: lsls r0, r0, #16
+// CHECK-NEXT: ldr r0, [r0]
+// CHECK-NEXT: bic r0, r0, #65280
 #[no_mangle]
 extern "cmse-nonsecure-entry" fn variants_different_size(
     v: &VariantsDifferentSize,
@@ -259,8 +260,9 @@ impl Copy for UninhabitedVariant {}
 
 // CHECK-LABEL: uninhabited_variant:
 // CHECK: mov r7, sp
-// CHECK-NEXT: ldrh r0, [r0, #2]
-// CHECK-NEXT: lsls r0, r0, #16
+// CHECK-NEXT: ldrh r1, [r0, #2]
+// CHECK-NEXT: ldrb r0, [r0]
+// CHECK-NEXT: orr.w r0, r0, r1, lsl #16
 #[no_mangle]
 extern "cmse-nonsecure-entry" fn uninhabited_variant(v: &UninhabitedVariant) -> UninhabitedVariant {
     *v
@@ -268,8 +270,8 @@ extern "cmse-nonsecure-entry" fn uninhabited_variant(v: &UninhabitedVariant) -> 
 
 // CHECK-LABEL: variants_same_size_array:
 // CHECK: mov r7, sp
-// CHECK-NEXT: ldrh r0, [r0, #2]
-// CHECK-NEXT: lsls r0, r0, #16
+// CHECK-NEXT: ldr r0, [r0]
+// CHECK-NEXT: bic r0, r0, #65280
 #[no_mangle]
 #[expect(improper_ctypes_definitions)]
 extern "cmse-nonsecure-entry" fn variants_same_size_array(
@@ -280,8 +282,8 @@ extern "cmse-nonsecure-entry" fn variants_same_size_array(
 
 // CHECK-LABEL: variants_different_size_array:
 // CHECK: mov r7, sp
-// CHECK-NEXT: ldrh r0, [r0, #2]
-// CHECK-NEXT: lsls r0, r0, #16
+// CHECK-NEXT: ldr r0, [r0]
+// CHECK-NEXT: bic r0, r0, #65280
 #[no_mangle]
 #[expect(improper_ctypes_definitions)]
 extern "cmse-nonsecure-entry" fn variants_different_size_array(
@@ -292,8 +294,9 @@ extern "cmse-nonsecure-entry" fn variants_different_size_array(
 
 // CHECK-LABEL: variants_same_size_tuple:
 // CHECK: mov r7, sp
-// CHECK-NEXT: ldrh r0, [r0, #2]
-// CHECK-NEXT: lsls r0, r0, #16
+// CHECK-NEXT: ldrh r1, [r0, #2]
+// CHECK-NEXT: ldrb r0, [r0]
+// CHECK-NEXT: orr.w r0, r0, r1, lsl #16
 #[no_mangle]
 #[expect(improper_ctypes_definitions)]
 extern "cmse-nonsecure-entry" fn variants_same_size_tuple(
@@ -304,8 +307,8 @@ extern "cmse-nonsecure-entry" fn variants_same_size_tuple(
 
 // CHECK-LABEL: variants_different_size_tuple:
 // CHECK: mov r7, sp
-// CHECK-NEXT: ldrh r0, [r0, #2]
-// CHECK-NEXT: lsls r0, r0, #16
+// CHECK-NEXT: ldr r0, [r0]
+// CHECK-NEXT: bic r0, r0, #65280
 #[no_mangle]
 #[expect(improper_ctypes_definitions)]
 extern "cmse-nonsecure-entry" fn variants_different_size_tuple(
@@ -324,9 +327,9 @@ enum ThreeVariants {
 
 // CHECK-LABEL: cmse_call_three_variants:
 // CHECK: mov r7, sp
+// CHECK-NEXT: mov r3, r0
+// CHECK-NEXT: uxtb r0, r1
 // CHECK-NEXT: mov r1, r2
-// CHECK-NEXT: mov r2, r0
-// CHECK-NEXT: movs r0, #0
 #[no_mangle]
 #[expect(improper_ctypes_definitions)]
 extern "C" fn cmse_call_three_variants(

--- a/tests/assembly-llvm/cmse-clear-padding.rs
+++ b/tests/assembly-llvm/cmse-clear-padding.rs
@@ -237,10 +237,16 @@ enum VariantsDifferentSize {
 }
 impl Copy for VariantsDifferentSize {}
 
+// A uxtbeq conditionally clears the padding only for variant A.
+//
 // CHECK-LABEL: variants_different_size:
 // CHECK: mov r7, sp
-// CHECK-NEXT: ldr r0, [r0]
-// CHECK-NEXT: bic r0, r0, #65280
+// CHECK-NEXT: ldrh r1, [r0, #2]
+// CHECK-NEXT: ldrb r0, [r0]
+// CHECK-NEXT: lsls r2, r0, #31
+// CHECK-NEXT: it eq
+// CHECK-NEXT: uxtbeq r1, r1
+// CHECK-NEXT: orr.w r0, r0, r1, lsl #16
 #[no_mangle]
 extern "cmse-nonsecure-entry" fn variants_different_size(
     v: &VariantsDifferentSize,
@@ -258,6 +264,8 @@ enum UninhabitedVariant {
 }
 impl Copy for UninhabitedVariant {}
 
+// Only `B` is inhabited, so reading the tag is not needed.
+//
 // CHECK-LABEL: uninhabited_variant:
 // CHECK: mov r7, sp
 // CHECK-NEXT: ldrh r1, [r0, #2]
@@ -268,6 +276,7 @@ extern "cmse-nonsecure-entry" fn uninhabited_variant(v: &UninhabitedVariant) -> 
     *v
 }
 
+// The single guaranteed-padding byte is cleared with a `bic` mask over the whole loaded word.
 // CHECK-LABEL: variants_same_size_array:
 // CHECK: mov r7, sp
 // CHECK-NEXT: ldr r0, [r0]
@@ -282,8 +291,12 @@ extern "cmse-nonsecure-entry" fn variants_same_size_array(
 
 // CHECK-LABEL: variants_different_size_array:
 // CHECK: mov r7, sp
-// CHECK-NEXT: ldr r0, [r0]
-// CHECK-NEXT: bic r0, r0, #65280
+// CHECK-NEXT: ldrh r1, [r0, #2]
+// CHECK-NEXT: ldrb r0, [r0]
+// CHECK-NEXT: lsls r2, r0, #31
+// CHECK-NEXT: it eq
+// CHECK-NEXT: uxtbeq r1, r1
+// CHECK-NEXT: orr.w r0, r0, r1, lsl #16
 #[no_mangle]
 #[expect(improper_ctypes_definitions)]
 extern "cmse-nonsecure-entry" fn variants_different_size_array(
@@ -307,8 +320,12 @@ extern "cmse-nonsecure-entry" fn variants_same_size_tuple(
 
 // CHECK-LABEL: variants_different_size_tuple:
 // CHECK: mov r7, sp
-// CHECK-NEXT: ldr r0, [r0]
-// CHECK-NEXT: bic r0, r0, #65280
+// CHECK-NEXT: ldrh r1, [r0, #2]
+// CHECK-NEXT: ldrb r0, [r0]
+// CHECK-NEXT: lsls r2, r0, #31
+// CHECK-NEXT: it eq
+// CHECK-NEXT: uxtbeq r1, r1
+// CHECK-NEXT: orr.w r0, r0, r1, lsl #16
 #[no_mangle]
 #[expect(improper_ctypes_definitions)]
 extern "cmse-nonsecure-entry" fn variants_different_size_tuple(
@@ -326,15 +343,71 @@ enum ThreeVariants {
 }
 
 // CHECK-LABEL: cmse_call_three_variants:
-// CHECK: mov r7, sp
-// CHECK-NEXT: mov r3, r0
+// CHECK: mov r3, r0
+//
+// Clears padding in the extend the discriminant.
 // CHECK-NEXT: uxtb r0, r1
-// CHECK-NEXT: mov r1, r2
+//
+// Uses uxtb for the A variant, uxtheq for the B variant,
+// and nothing for the C variant.
+//
+// CHECK-NEXT: cbz r0, .LBB{{[0-9_]+}}
+// CHECK-NEXT: cmp r0, #1
+// CHECK-NEXT: it eq
+// CHECK-NEXT: uxtheq r2, r2
+// CHECK-NEXT: b .LBB{{[0-9_]+}}
+// CHECK-NEXT: .LBB{{[0-9_]+}}:
+// CHECK-NEXT: uxtb r2, r2
 #[no_mangle]
 #[expect(improper_ctypes_definitions)]
 extern "C" fn cmse_call_three_variants(
     f: unsafe extern "cmse-nonsecure-call" fn(ThreeVariants),
     x: ThreeVariants,
+) {
+    unsafe { f(x) }
+}
+
+/// Three variants of different sizes, with a nested enum.
+#[repr(C)]
+enum ThreeVariantsNested {
+    A(u8),
+    B(Option<u8>),
+    C(u32),
+}
+
+// CHECK-LABEL: cmse_call_three_variants_nested:
+// CHECK: mov r3, r0
+//
+// Clears padding in the extend the discriminant.
+// CHECK-NEXT: uxtb r0, r1
+//
+// Match on the discriminant, jump to A block
+//
+// CHECK-NEXT: cbz r0, .LBB{{[0-9_]+}}
+//
+// Match on the discriminant, do nothing for C.
+//
+// CHECK-NEXT: cmp r0, #1
+// CHECK-NEXT: bne .LBB{{[0-9_]+}}
+//
+// The B variant conditionally clears the Option payload.
+//
+// CHECK-NEXT: lsls r1, r2, #31
+// CHECK-NEXT: movw r1, #65535
+// CHECK-NEXT: it eq
+// CHECK-NEXT: moveq r1, #254
+// CHECK-NEXT: ands r2, r1
+// CHECK-NEXT: b .LBB{{[0-9_]+}}
+//
+// The A variant uses uxtb.
+//
+// CHECK-NEXT: .LBB{{[0-9_]+}}:
+// CHECK-NEXT: uxtb r2, r2
+#[no_mangle]
+#[expect(improper_ctypes_definitions)]
+extern "C" fn cmse_call_three_variants_nested(
+    f: unsafe extern "cmse-nonsecure-call" fn(ThreeVariantsNested),
+    x: ThreeVariantsNested,
 ) {
     unsafe { f(x) }
 }
@@ -346,11 +419,17 @@ struct BoolU32 {
     val: u32,
 }
 
+// Bit 0b0010 is used to encode the tag, so `r0 - 2 == 0` checks the tag value.
+// Zero-extension clears padding in the tag 32-bit word, the `val` is either 0
+// (stored in r1) when None or the actual value r2 when Some.
+//
 // CHECK-LABEL: cmse_call_niche:
 // CHECK: mov r7, sp
 // CHECK-NEXT: mov r3, r0
 // CHECK-NEXT: uxtb r0, r1
-// CHECK-NEXT: mov r1, r2
+// CHECK-NEXT: subs r1, r0, #2
+// CHECK-NEXT: it ne
+// CHECK-NEXT: movne r1, r2
 #[no_mangle]
 #[expect(improper_ctypes_definitions)]
 extern "C" fn cmse_call_niche(

--- a/tests/assembly-llvm/cmse-clear-padding.rs
+++ b/tests/assembly-llvm/cmse-clear-padding.rs
@@ -221,9 +221,8 @@ impl Copy for VariantsSameSize {}
 
 // CHECK-LABEL: variants_same_size:
 // CHECK: mov r7, sp
-// CHECK-NEXT: ldrh r1, [r0, #2]
-// CHECK-NEXT: ldrb r0, [r0]
-// CHECK-NEXT: orr.w r0, r0, r1, lsl #16
+// CHECK-NEXT: ldrh r0, [r0, #2]
+// CHECK-NEXT: lsls r0, r0, #16
 #[no_mangle]
 extern "cmse-nonsecure-entry" fn variants_same_size(v: &VariantsSameSize) -> VariantsSameSize {
     *v
@@ -237,6 +236,10 @@ enum VariantsDifferentSize {
 }
 impl Copy for VariantsDifferentSize {}
 
+// CHECK-LABEL: variants_different_size:
+// CHECK: mov r7, sp
+// CHECK-NEXT: ldrh r0, [r0, #2]
+// CHECK-NEXT: lsls r0, r0, #16
 #[no_mangle]
 extern "cmse-nonsecure-entry" fn variants_different_size(
     v: &VariantsDifferentSize,
@@ -254,11 +257,19 @@ enum UninhabitedVariant {
 }
 impl Copy for UninhabitedVariant {}
 
+// CHECK-LABEL: uninhabited_variant:
+// CHECK: mov r7, sp
+// CHECK-NEXT: ldrh r0, [r0, #2]
+// CHECK-NEXT: lsls r0, r0, #16
 #[no_mangle]
 extern "cmse-nonsecure-entry" fn uninhabited_variant(v: &UninhabitedVariant) -> UninhabitedVariant {
     *v
 }
 
+// CHECK-LABEL: variants_same_size_array:
+// CHECK: mov r7, sp
+// CHECK-NEXT: ldrh r0, [r0, #2]
+// CHECK-NEXT: lsls r0, r0, #16
 #[no_mangle]
 #[expect(improper_ctypes_definitions)]
 extern "cmse-nonsecure-entry" fn variants_same_size_array(
@@ -267,6 +278,10 @@ extern "cmse-nonsecure-entry" fn variants_same_size_array(
     *v
 }
 
+// CHECK-LABEL: variants_different_size_array:
+// CHECK: mov r7, sp
+// CHECK-NEXT: ldrh r0, [r0, #2]
+// CHECK-NEXT: lsls r0, r0, #16
 #[no_mangle]
 #[expect(improper_ctypes_definitions)]
 extern "cmse-nonsecure-entry" fn variants_different_size_array(
@@ -275,6 +290,10 @@ extern "cmse-nonsecure-entry" fn variants_different_size_array(
     *v
 }
 
+// CHECK-LABEL: variants_same_size_tuple:
+// CHECK: mov r7, sp
+// CHECK-NEXT: ldrh r0, [r0, #2]
+// CHECK-NEXT: lsls r0, r0, #16
 #[no_mangle]
 #[expect(improper_ctypes_definitions)]
 extern "cmse-nonsecure-entry" fn variants_same_size_tuple(
@@ -283,6 +302,10 @@ extern "cmse-nonsecure-entry" fn variants_same_size_tuple(
     *v
 }
 
+// CHECK-LABEL: variants_different_size_tuple:
+// CHECK: mov r7, sp
+// CHECK-NEXT: ldrh r0, [r0, #2]
+// CHECK-NEXT: lsls r0, r0, #16
 #[no_mangle]
 #[expect(improper_ctypes_definitions)]
 extern "cmse-nonsecure-entry" fn variants_different_size_tuple(
@@ -299,6 +322,11 @@ enum ThreeVariants {
     C(u32),
 }
 
+// CHECK-LABEL: cmse_call_three_variants:
+// CHECK: mov r7, sp
+// CHECK-NEXT: mov r1, r2
+// CHECK-NEXT: mov r2, r0
+// CHECK-NEXT: movs r0, #0
 #[no_mangle]
 #[expect(improper_ctypes_definitions)]
 extern "C" fn cmse_call_three_variants(
@@ -315,6 +343,11 @@ struct BoolU32 {
     val: u32,
 }
 
+// CHECK-LABEL: cmse_call_niche:
+// CHECK: mov r7, sp
+// CHECK-NEXT: mov r3, r0
+// CHECK-NEXT: uxtb r0, r1
+// CHECK-NEXT: mov r1, r2
 #[no_mangle]
 #[expect(improper_ctypes_definitions)]
 extern "C" fn cmse_call_niche(

--- a/tests/assembly-llvm/cmse-clear-padding.rs
+++ b/tests/assembly-llvm/cmse-clear-padding.rs
@@ -123,6 +123,8 @@ struct WideU8 {
     a: u8,
 }
 
+// `extern "C"` does not clear the padding.
+//
 // CHECK-LABEL: c_ret_with_wide_u8:
 // CHECK: mov r7, sp
 // CHECK-NEXT: orr.w r0, r0, r1, lsl #16
@@ -131,6 +133,8 @@ extern "C" fn c_ret_with_wide_u8(a: u8, b: u8) -> [WideU8; 2] {
     [WideU8 { a }, WideU8 { a: b }]
 }
 
+// Upper bits are cleared by uxtb.
+//
 // CHECK-LABEL: cmse_ret_with_wide_u8:
 // CHECK: mov r7, sp
 // CHECK-NEXT: uxtb r1, r1
@@ -139,6 +143,36 @@ extern "C" fn c_ret_with_wide_u8(a: u8, b: u8) -> [WideU8; 2] {
 #[no_mangle]
 extern "cmse-nonsecure-entry" fn cmse_ret_with_wide_u8(a: u8, b: u8) -> [WideU8; 2] {
     [WideU8 { a }, WideU8 { a: b }]
+}
+
+// Same idea, the padding is recognized even through the MaybeUninit.
+//
+// CHECK-LABEL: cmse_ret_with_wide_u8_uninit:
+// CHECK: mov r7, sp
+// CHECK-NEXT: uxtb r0, r0
+// CHECK-NEXT: orr.w r0, r0, r1, lsl #16
+// CHECK-NEXT: bic r0, r0, #-16711936
+#[no_mangle]
+extern "cmse-nonsecure-entry" fn cmse_ret_with_wide_u8_uninit(
+    a: u16,
+    b: u16,
+) -> [MaybeUninit<WideU8>; 2] {
+    unsafe { [mem::transmute(a), mem::transmute(b)] }
+}
+
+// Same idea, the padding is recognized even through the MaybeUninit.
+//
+// CHECK-LABEL: cmse_ret_with_wide_u8_uninit_tuple:
+// CHECK: mov r7, sp
+// CHECK-NEXT: uxtb r0, r0
+// CHECK-NEXT: orr.w r0, r0, r1, lsl #16
+// CHECK-NEXT: bic r0, r0, #-16711936
+#[no_mangle]
+extern "cmse-nonsecure-entry" fn cmse_ret_with_wide_u8_uninit_tuple(
+    a: u16,
+    b: u16,
+) -> (MaybeUninit<WideU8>, MaybeUninit<WideU8>) {
+    unsafe { (mem::transmute(a), mem::transmute(b)) }
 }
 
 // CHECK-LABEL: c_call_with_inner_wide_u8:
@@ -177,28 +211,115 @@ extern "C" fn cmse_call_with_inner_wide_u8(
     unsafe { f(x) }
 }
 
-// CHECK-LABEL: cmse_ret_with_wide_u8_uninit:
+/// No variant-dependent padding.
+#[repr(C)]
+enum VariantsSameSize {
+    A(u16),
+    B(u16),
+}
+impl Copy for VariantsSameSize {}
+
+// CHECK-LABEL: variants_same_size:
 // CHECK: mov r7, sp
-// CHECK-NEXT: uxtb r0, r0
+// CHECK-NEXT: ldrh r1, [r0, #2]
+// CHECK-NEXT: ldrb r0, [r0]
 // CHECK-NEXT: orr.w r0, r0, r1, lsl #16
-// CHECK-NEXT: bic r0, r0, #-16711936
 #[no_mangle]
-extern "cmse-nonsecure-entry" fn cmse_ret_with_wide_u8_uninit(
-    a: u16,
-    b: u16,
-) -> [MaybeUninit<WideU8>; 2] {
-    unsafe { [mem::transmute(a), mem::transmute(b)] }
+extern "cmse-nonsecure-entry" fn variants_same_size(v: &VariantsSameSize) -> VariantsSameSize {
+    *v
 }
 
-// CHECK-LABEL: cmse_ret_with_wide_u8_uninit_tuple:
-// CHECK: mov r7, sp
-// CHECK-NEXT: uxtb r0, r0
-// CHECK-NEXT: orr.w r0, r0, r1, lsl #16
-// CHECK-NEXT: bic r0, r0, #-16711936
+/// One byte of variant-dependent padding.
+#[repr(C)]
+enum VariantsDifferentSize {
+    A(u8),
+    B(u16),
+}
+impl Copy for VariantsDifferentSize {}
+
 #[no_mangle]
-extern "cmse-nonsecure-entry" fn cmse_ret_with_wide_u8_uninit_tuple(
-    a: u16,
-    b: u16,
-) -> (MaybeUninit<WideU8>, MaybeUninit<WideU8>) {
-    unsafe { (mem::transmute(a), mem::transmute(b)) }
+extern "cmse-nonsecure-entry" fn variants_different_size(
+    v: &VariantsDifferentSize,
+) -> VariantsDifferentSize {
+    *v
+}
+
+enum Void {}
+impl Copy for Void {}
+
+#[repr(C)]
+enum UninhabitedVariant {
+    A(Void),
+    B(u16),
+}
+impl Copy for UninhabitedVariant {}
+
+#[no_mangle]
+extern "cmse-nonsecure-entry" fn uninhabited_variant(v: &UninhabitedVariant) -> UninhabitedVariant {
+    *v
+}
+
+#[no_mangle]
+#[expect(improper_ctypes_definitions)]
+extern "cmse-nonsecure-entry" fn variants_same_size_array(
+    v: &[VariantsSameSize; 1],
+) -> [VariantsSameSize; 1] {
+    *v
+}
+
+#[no_mangle]
+#[expect(improper_ctypes_definitions)]
+extern "cmse-nonsecure-entry" fn variants_different_size_array(
+    v: &[VariantsDifferentSize; 1],
+) -> [VariantsDifferentSize; 1] {
+    *v
+}
+
+#[no_mangle]
+#[expect(improper_ctypes_definitions)]
+extern "cmse-nonsecure-entry" fn variants_same_size_tuple(
+    v: &(VariantsSameSize,),
+) -> (VariantsSameSize,) {
+    *v
+}
+
+#[no_mangle]
+#[expect(improper_ctypes_definitions)]
+extern "cmse-nonsecure-entry" fn variants_different_size_tuple(
+    v: &(VariantsDifferentSize,),
+) -> (VariantsDifferentSize,) {
+    *v
+}
+
+/// Three variants of different sizes.
+#[repr(C)]
+enum ThreeVariants {
+    A(u8),
+    B(u16),
+    C(u32),
+}
+
+#[no_mangle]
+#[expect(improper_ctypes_definitions)]
+extern "C" fn cmse_call_three_variants(
+    f: unsafe extern "cmse-nonsecure-call" fn(ThreeVariants),
+    x: ThreeVariants,
+) {
+    unsafe { f(x) }
+}
+
+/// The tag is stored in the niche of the `bool`.
+#[repr(C)]
+struct BoolU32 {
+    flag: bool,
+    val: u32,
+}
+
+#[no_mangle]
+#[expect(improper_ctypes_definitions)]
+extern "C" fn cmse_call_niche(
+    f: unsafe extern "cmse-nonsecure-call" fn(Option<BoolU32>),
+    x: Option<BoolU32>,
+) {
+    unsafe { f(x) }
 }


### PR DESCRIPTION
tracking issue: https://github.com/rust-lang/rust/issues/81391
tracking issue: https://github.com/rust-lang/rust/issues/75835

Since https://github.com/rust-lang/rust/pull/157397 we clear variant-independent padding, bytes that are padding for all valid values of the type. This PR extends that idea to also clear variant-dependent padding, where we have to check what variant a (nested) enum has to determine which bytes are padding so we can clear them.

With these changes the lint from https://github.com/rust-lang/rust/pull/147697 can lint on just `union`s.

r? @davidtwco 
cc @RalfJung @Jules-Bertholet 