### PR TITLE
Add explicit `Iterator::count` impl for `str::EncodeUtf16`

### DIFF
--- a/library/alloctests/tests/str.rs
+++ b/library/alloctests/tests/str.rs
@@ -1786,6 +1786,21 @@ fn test_utf16_size_hint() {
 }
 
 #[test]
+fn test_utf16_count() {
+    assert_eq!("".encode_utf16().count(), 0);
+    assert_eq!("a".encode_utf16().count(), 1);
+    assert_eq!("é".encode_utf16().count(), 1);
+    assert_eq!("字".encode_utf16().count(), 1);
+    assert_eq!("\u{1F4A9}".encode_utf16().count(), 2);
+    let mut iter = "\u{1F4A9}字éa".encode_utf16();
+    assert_eq!(iter.clone().count(), 5);
+    iter.next();
+    assert_eq!(iter.clone().count(), 4); // counting half of the surrogate pair
+    iter.next();
+    assert_eq!(iter.count(), 3);
+}
+
+#[test]
 fn starts_with_in_unicode() {
     assert!(!"├── Cargo.toml".starts_with("# "));
 }

--- a/library/core/src/str/iter.rs
+++ b/library/core/src/str/iter.rs
@@ -1533,6 +1533,43 @@ impl<'a> Iterator for EncodeUtf16<'a> {
             (len.div_ceil(3) + 1, Some(len + 1))
         }
     }
+
+    #[inline]
+    fn count(self) -> usize {
+        let extra = if self.extra == 0 { 0 } else { 1 };
+        // Find UTF-8 non-continuation bytes and map:
+        //
+        // len_utf8() | len_utf16()
+        // -----------|------------
+        // 1          | 1
+        // 2          | 1
+        // 3          | 1
+        // 4          | 2
+        //
+        // Because we never map to larger values the result is never larger than
+        // `self.chars.as_str().len()` so the sum can never overflow
+        self.chars.as_str().as_bytes().iter().fold(extra, |acc, &byte| {
+            acc.wrapping_add({
+                if byte < 0b1000_0000 {
+                    // 0b0xxx_xxxx: ASCII-compatible U+0000 to U+007F
+                    1
+                } else if byte < 0b1100_0000 {
+                    // 0b10xx_xxxx: UTF-8 continuation byte, skip
+                    0
+                } else if byte < 0b1111_0000 {
+                    // 0b110x_xxxx: start of a 2-byte UTF-8 sequence for U+0080 to U+07FF
+                    // 0b1110_xxxx: start of a 3-byte UTF-8 sequence for U+0800 to U+FFFF
+                    1
+                } else {
+                    // 0b1111_0xxx: start of a 4-byte UTF-8 sequence for U+010000 to U+10FFFF
+                    // This is exactly the range encoded as a surrogate pair in UTF-16
+                    //
+                    // 0b1111_1xxx: would fall here but never occurs in valid UTF-8
+                    2
+                }
+            })
+        })
+    }
 }
 
 #[stable(feature = "fused", since = "1.26.0")]


### PR DESCRIPTION
In the early days of Unicode, many systems adopted it by storing in-memory strings in (roughly) `Vec<u16>`, encoded as UCS-2 / UTF-16 / WTF-16. The “natural” way to index such strings or measure their length is counting UTF-16 code units. In some cases, such lengths or offsets found their way in protocols or APIs, such that even a Rust implementation that uses `&str` internally needs to count 16-bit code units for compatibility. For example this comes up in Servo’s implementation of some DOM APIs.

One way to convert from an `&str` index (counted 8-bit code units) is:

```rust
let index_16bit = string[..i].encode_utf16().count();
```

Before this PR, the default `Iterator::count` relies on `Iterator::next` which decodes UTF-8 and encodes to UTF-16, doing more work than needed. Instead, this PR matches on bit patterns in the underlying UTF-8 string.

For comparison, `str::Chars` already has a sophisticated impl for `Iterator::count` in `library/core/src/str/count.rs`.