### PR TITLE
Support creating float constants in rustc_public mir

### DIFF
--- a/compiler/rustc_public/src/compiler_interface.rs
+++ b/compiler/rustc_public/src/compiler_interface.rs
@@ -18,7 +18,7 @@ use crate::mir::{BinOp, Body, Place, UnOp};
 use crate::target::{MachineInfo, MachineSize};
 use crate::ty::{
     AdtDef, AdtKind, Allocation, AssocItem, Asyncness, ClosureDef, ClosureKind, Constness,
-    CoroutineDef, Discr, FieldDef, FnDef, ForeignDef, ForeignItemKind, ForeignModule,
+    CoroutineDef, Discr, FieldDef, FloatTy, FnDef, ForeignDef, ForeignItemKind, ForeignModule,
     ForeignModuleDef, GenericArgs, GenericPredicates, Generics, ImplDef, ImplTrait, IntrinsicDef,
     LineInfo, MirConst, PolyFnSig, RigidTy, Span, TraitDecl, TraitDef, TraitRef, Ty, TyConst,
     TyConstId, TyKind, UintTy, VariantDef, VariantIdx, VtblEntry,
@@ -514,7 +514,7 @@ impl<'tcx> CompilerInterface<'tcx> {
         self.with_cx(|tables, cx| cx.new_const_bool(value).stable(tables, cx))
     }
 
-    /// Create a new constant that represents the given value.
+    /// Create a new integer constant that represents the given value.
     pub(crate) fn try_new_const_uint(
         &self,
         value: u128,
@@ -524,6 +524,22 @@ impl<'tcx> CompilerInterface<'tcx> {
             let ty = cx.ty_new_uint(uint_ty.internal(tables, cx.tcx));
             cx.try_new_const_uint(value, ty).map(|cnst| cnst.stable(tables, cx))
         })
+    }
+
+    /// Create a new float constant that represents the given value.
+    /// The value is the binary representation of the float constant.
+    /// Example: `try_new_const_float(2.5_f32.to_bits() as u128, FloatTy::F32)`.
+    pub(crate) fn try_new_const_float(
+        &self,
+        value: u128,
+        float_ty: FloatTy,
+    ) -> Result<MirConst, Error> {
+        let mut tables = self.tables.borrow_mut();
+        let cx = &*self.cx.borrow();
+        let ty = cx.new_rigid_ty(RigidTy::Float(float_ty).internal(&mut *tables, cx.tcx));
+        // We use `try_new_const_uint` here since it is capable of constructing all scalars in the mir
+        // that are not pointer.
+        cx.try_new_const_uint(value, ty).map(|cnst| cnst.stable(&mut *tables, cx))
     }
 
     pub(crate) fn try_new_ty_const_uint(

--- a/compiler/rustc_public/src/ty.rs
+++ b/compiler/rustc_public/src/ty.rs
@@ -212,6 +212,13 @@ impl MirConst {
     pub fn try_from_uint(value: u128, uint_ty: UintTy) -> Result<MirConst, Error> {
         with(|cx| cx.try_new_const_uint(value, uint_ty))
     }
+
+    /// Build a new constant that represents the given floating point number.
+    /// The value is the binary representation of the float constant.
+    /// Example: `try_from_float(2.5_f32.to_bits() as u128, FloatTy::F32)`.
+    pub fn try_from_float(value: u128, float_ty: FloatTy) -> Result<MirConst, Error> {
+        with(|cx| cx.try_new_const_float(value, float_ty))
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]


### PR DESCRIPTION
This PR adds a `try_from_float` similar to `try_from_uint` to the `rustc_public::ty::MirConst`.

It takes `u128` and users need a `.to_bits() as u128` to call this function. I did this because `f64` couldn't capture a `f128` const completely, and `f128` needs to cast and a branch on the input types, making the code complex. Another alternative is adding 4 functions `try_from_f16` to `try_from_f128`, which I don't like, but that's also an option.