### PR TITLE
Update cargo submodule

### DIFF
--- a/src/bootstrap/src/core/build_steps/dist.rs
+++ b/src/bootstrap/src/core/build_steps/dist.rs
@@ -1445,7 +1445,7 @@ impl Step for Cargo {
 
         let cargo = builder.ensure(tool::Cargo::from_build_compiler(build_compiler, target));
         let src = builder.src.join("src/tools/cargo");
-        let etc = src.join("src/etc");
+        let etc = src.join("etc");
 
         // Prepare the image directory
         let mut tarball = Tarball::new(builder, "cargo", &target.triple);

--- a/src/bootstrap/src/core/build_steps/doc.rs
+++ b/src/bootstrap/src/core/build_steps/doc.rs
@@ -70,7 +70,7 @@ macro_rules! book {
 // adding a build step in `src/bootstrap/code/builder/mod.rs`!
 // NOTE: Make sure to add the corresponding submodule when adding a new book.
 book!(
-    CargoBook, "src/tools/cargo/src/doc", "cargo", &[];
+    CargoBook, "src/tools/cargo/doc/book", "cargo", &[];
     ClippyBook, "src/tools/clippy/book", "clippy", &[];
     EditionGuide, "src/doc/edition-guide", "edition-guide", &[];
     EmbeddedBook, "src/doc/embedded-book", "embedded-book", &[];

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_doc.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_doc.snap
@@ -50,7 +50,7 @@ expression: doc
     - Set({doc::src/doc/rustc})
 [Doc] doc::CargoBook
     targets: [aarch64-unknown-linux-gnu]
-    - Set({doc::src/tools/cargo/src/doc})
+    - Set({doc::src/tools/cargo/doc/book})
 [Doc] doc::ClippyBook
     targets: [aarch64-unknown-linux-gnu]
     - Set({doc::src/tools/clippy/book})


### PR DESCRIPTION
29 commits in 59800466c5c41c444d264b1010b4d57e85a7117f..3efb1f477e99b42974b982d939fd100303cdf7db
2026-07-07 15:52:22 +0000 to 2026-07-17 23:53:19 +0000
- refactor(context): normalize in `homedir` instead (rust-lang/cargo#17222)
- chore(ci): reflect doc folder move in book deployment (rust-lang/cargo#17235)
- refactor(ops): Have cargo-metadata's ops match the command name (rust-lang/cargo#17233)
- chore: Flatten src (rust-lang/cargo#17231)
- chore: Flatten `src` (rust-lang/cargo#17230)
- chore(ci): remove stale libsecret packages (rust-lang/cargo#17229)
- perf: Lazily initialize git2 fetch transports  (rust-lang/cargo#17226)
- test(trim-paths): re-enable lldb debugger tests  (rust-lang/cargo#17223)
- Include SBOM outputs in fingerprints (rust-lang/cargo#17216)
- Update cfg_aliases to 0.2.2 (rust-lang/cargo#17225)
- test(trim-paths): exercise GDB on windows-gnu (rust-lang/cargo#17221)
- feat(profile): Disable incremental compilation under CI by default (rust-lang/cargo#17220)
- Remove myself from review rotation (rust-lang/cargo#17219)
- Fix typo in comment in sync (rust-lang/cargo#17217)
- docs(ref): Improve handing of built-in profiles (rust-lang/cargo#17213)
- fix: dont apply host-config gating to stable behavior (rust-lang/cargo#17198)
- chore(deps): update msrv (rust-lang/cargo#17192)
- test: fix race in cargo_compile_with_invalid_code_in_deps (rust-lang/cargo#17203)
- Rename `-Zno-embed-metadata` to `-Zembed-metadata=no` (rust-lang/cargo#17149)
- fix(source): incorrect duplicate package warning (rust-lang/cargo#17204)
- Fix manifest schema generation: `TomlDebugInfo` enum-variants doesn't renamed (rust-lang/cargo#17202)
- Reduce library search path length in new build dir layout (rust-lang/cargo#17191)
- fix(install): Move --debug to Compilation options (rust-lang/cargo#17199)
- chore(ci): dogfood `build.warnings` (rust-lang/cargo#17195)
- docs(lints): Better match clippy in lint section titles (rust-lang/cargo#17190)
- chore: bump to 0.100.0; update changelog (rust-lang/cargo#17189)
- docs(ref): Clarify MSRV for lints (rust-lang/cargo#17184)
- docs(report): add missing entry for `cargo report future-incompatibilities` (rust-lang/cargo#17188)
- Reduce rustc `-L` args used in the new `build-dir` layout (rust-lang/cargo#17168)
