### PR TITLE
tests: prefer max-llvm-major-version over open LLVM ranges

### DIFF
--- a/tests/assembly-llvm/simd-bitmask.rs
+++ b/tests/assembly-llvm/simd-bitmask.rs
@@ -11,7 +11,7 @@
 //@ [aarch64] min-llvm-version: 23
 //@ [aarch64] compile-flags: --target=aarch64-unknown-linux-gnu
 //@ [aarch64] needs-llvm-components: aarch64
-//@ [aarch64-llvm-pre-23] ignore-llvm-version: 23 - 99
+//@ [aarch64-llvm-pre-23] max-llvm-major-version: 22
 //@ [aarch64-llvm-pre-23] compile-flags: --target=aarch64-unknown-linux-gnu
 //@ [aarch64-llvm-pre-23] needs-llvm-components: aarch64
 //@ assembly-output: emit-asm

--- a/tests/codegen-llvm/array-equality.rs
+++ b/tests/codegen-llvm/array-equality.rs
@@ -1,5 +1,5 @@
 //@ revisions: llvm-current llvm-next
-//@[llvm-current] ignore-llvm-version: 23 - 99
+//@[llvm-current] max-llvm-major-version: 22
 //@[llvm-next] min-llvm-version: 23
 //@ compile-flags: -Copt-level=3 -Z merge-functions=disabled
 //@ only-x86_64

--- a/tests/ui/explicit-tail-calls/support/bystack.rs
+++ b/tests/ui/explicit-tail-calls/support/bystack.rs
@@ -36,11 +36,11 @@
 //@ revisions: loongarch32
 //@[loongarch32] compile-flags: --target loongarch32-unknown-none
 //@[loongarch32] needs-llvm-components: loongarch
-//@[loongarch32] ignore-llvm-version: 22 - 23
+//@[loongarch32] max-llvm-major-version: 21
 //@ revisions: loongarch64
 //@[loongarch64] compile-flags: --target loongarch64-unknown-linux-gnu
 //@[loongarch64] needs-llvm-components: loongarch
-//@[loongarch64] ignore-llvm-version: 22 - 23
+//@[loongarch64] max-llvm-major-version: 21
 //@ revisions: bpf
 //@[bpf] compile-flags: --target bpfeb-unknown-none
 //@[bpf] needs-llvm-components: bpf

--- a/tests/ui/explicit-tail-calls/support/byval.rs
+++ b/tests/ui/explicit-tail-calls/support/byval.rs
@@ -36,11 +36,11 @@
 //@ revisions: loongarch32
 //@[loongarch32] compile-flags: --target loongarch32-unknown-none
 //@[loongarch32] needs-llvm-components: loongarch
-//@[loongarch32] ignore-llvm-version: 22 - 23
+//@[loongarch32] max-llvm-major-version: 21
 //@ revisions: loongarch64
 //@[loongarch64] compile-flags: --target loongarch64-unknown-linux-gnu
 //@[loongarch64] needs-llvm-components: loongarch
-//@[loongarch64] ignore-llvm-version: 22 - 23
+//@[loongarch64] max-llvm-major-version: 21
 //@ revisions: bpf
 //@[bpf] compile-flags: --target bpfeb-unknown-none
 //@[bpf] needs-llvm-components: bpf


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Per review, take option 3: replace open `ignore-llvm-version` ranges with `max-llvm-major-version`. Left gdb `X - 99.0` ranges alone so CI's older gdb still runs those tests.

Fixes rust-lang/rust#159338.