### PR TITLE
make rustdoc::bare_urls strip trailing periods from url

### DIFF
--- a/src/librustdoc/passes/lint/bare_urls.rs
+++ b/src/librustdoc/passes/lint/bare_urls.rs
@@ -111,6 +111,14 @@ fn find_raw_urls(
             url_range.start -= 1;
             url_range.end += 1;
             without_brackets = Some(match_.as_str());
+        } else {
+            // Periods are valid in URLs, but very uncommon as the last character of one, while
+            // being very common as sentence punctuation right after one. Leave any trailing
+            // period out of the link, so that `Visit https://example.com/docs.` is linkified as
+            // `Visit <https://example.com/docs>.`.
+            let trailing_periods =
+                match_.as_str().len() - match_.as_str().trim_end_matches('.').len();
+            url_range.end -= trailing_periods;
         }
         f(cx, "this URL is not a hyperlink", url_range, without_brackets);
     }

--- a/tests/rustdoc-ui/lints/bare-urls.fixed
+++ b/tests/rustdoc-ui/lints/bare-urls.fixed
@@ -69,6 +69,16 @@ pub mod foo {
     pub fn bar() {}
 }
 
+/// Visit <https://example.com/docs>.
+//~^ ERROR this URL is not a hyperlink
+/// Two sentences. <https://example.com>. And more text.
+//~^ ERROR this URL is not a hyperlink
+/// Trailing ellipsis <https://example.com/docs>...
+//~^ ERROR this URL is not a hyperlink
+/// A period in the middle of <https://example.com/a.b> is part of the URL.
+//~^ ERROR this URL is not a hyperlink
+pub fn trailing_period() {}
+
 /// <https://bloob.blob>
 //~^ ERROR this URL is not a hyperlink
 /// [ <https://bloob.blob> ]

--- a/tests/rustdoc-ui/lints/bare-urls.rs
+++ b/tests/rustdoc-ui/lints/bare-urls.rs
@@ -69,6 +69,16 @@ pub mod foo {
     pub fn bar() {}
 }
 
+/// Visit https://example.com/docs.
+//~^ ERROR this URL is not a hyperlink
+/// Two sentences. https://example.com. And more text.
+//~^ ERROR this URL is not a hyperlink
+/// Trailing ellipsis https://example.com/docs...
+//~^ ERROR this URL is not a hyperlink
+/// A period in the middle of https://example.com/a.b is part of the URL.
+//~^ ERROR this URL is not a hyperlink
+pub fn trailing_period() {}
+
 /// [https://bloob.blob]
 //~^ ERROR this URL is not a hyperlink
 /// [ https://bloob.blob ]

--- a/tests/rustdoc-ui/lints/bare-urls.stderr
+++ b/tests/rustdoc-ui/lints/bare-urls.stderr
@@ -244,7 +244,55 @@ LL | #[doc = "<https://example.com/raw>"]
    |          +                       +
 
 error: this URL is not a hyperlink
-  --> $DIR/bare-urls.rs:72:5
+  --> $DIR/bare-urls.rs:72:11
+   |
+LL | /// Visit https://example.com/docs.
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: bare URLs are not automatically turned into clickable links
+help: use an automatic link instead
+   |
+LL | /// Visit <https://example.com/docs>.
+   |           +                        +
+
+error: this URL is not a hyperlink
+  --> $DIR/bare-urls.rs:74:20
+   |
+LL | /// Two sentences. https://example.com. And more text.
+   |                    ^^^^^^^^^^^^^^^^^^^
+   |
+   = note: bare URLs are not automatically turned into clickable links
+help: use an automatic link instead
+   |
+LL | /// Two sentences. <https://example.com>. And more text.
+   |                    +                   +
+
+error: this URL is not a hyperlink
+  --> $DIR/bare-urls.rs:76:23
+   |
+LL | /// Trailing ellipsis https://example.com/docs...
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: bare URLs are not automatically turned into clickable links
+help: use an automatic link instead
+   |
+LL | /// Trailing ellipsis <https://example.com/docs>...
+   |                       +                        +
+
+error: this URL is not a hyperlink
+  --> $DIR/bare-urls.rs:78:31
+   |
+LL | /// A period in the middle of https://example.com/a.b is part of the URL.
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: bare URLs are not automatically turned into clickable links
+help: use an automatic link instead
+   |
+LL | /// A period in the middle of <https://example.com/a.b> is part of the URL.
+   |                               +                       +
+
+error: this URL is not a hyperlink
+  --> $DIR/bare-urls.rs:82:5
    |
 LL | /// [https://bloob.blob]
    |     ^^^^^^^^^^^^^^^^^^^^
@@ -257,7 +305,7 @@ LL + /// <https://bloob.blob>
    |
 
 error: this URL is not a hyperlink
-  --> $DIR/bare-urls.rs:74:7
+  --> $DIR/bare-urls.rs:84:7
    |
 LL | /// [ https://bloob.blob ]
    |       ^^^^^^^^^^^^^^^^^^
@@ -269,7 +317,7 @@ LL | /// [ <https://bloob.blob> ]
    |       +                  +
 
 error: this URL is not a hyperlink
-  --> $DIR/bare-urls.rs:76:7
+  --> $DIR/bare-urls.rs:86:7
    |
 LL | /// [ https://bloob.blob]
    |       ^^^^^^^^^^^^^^^^^^
@@ -281,7 +329,7 @@ LL | /// [ <https://bloob.blob>]
    |       +                  +
 
 error: this URL is not a hyperlink
-  --> $DIR/bare-urls.rs:78:6
+  --> $DIR/bare-urls.rs:88:6
    |
 LL | /// [https://bloob.blob ]
    |      ^^^^^^^^^^^^^^^^^^
@@ -293,7 +341,7 @@ LL | /// [<https://bloob.blob> ]
    |      +                  +
 
 error: this URL is not a hyperlink
-  --> $DIR/bare-urls.rs:80:6
+  --> $DIR/bare-urls.rs:90:6
    |
 LL | /// [https://bloob.blob
    |      ^^^^^^^^^^^^^^^^^^
@@ -305,7 +353,7 @@ LL | /// [<https://bloob.blob>
    |      +                  +
 
 error: this URL is not a hyperlink
-  --> $DIR/bare-urls.rs:82:5
+  --> $DIR/bare-urls.rs:92:5
    |
 LL | /// https://bloob.blob]
    |     ^^^^^^^^^^^^^^^^^^
@@ -316,5 +364,5 @@ help: use an automatic link instead
 LL | /// <https://bloob.blob>]
    |     +                  +
 
-error: aborting due to 26 previous errors
+error: aborting due to 30 previous errors
 


### PR DESCRIPTION
Fixes rust-lang/rust#159480 