### PR TITLE
rustc_incremental: avoid ICE when dumping dep graph fails

### DIFF
--- a/compiler/rustc_incremental/src/assert_dep_graph.rs
+++ b/compiler/rustc_incremental/src/assert_dep_graph.rs
@@ -35,7 +35,8 @@
 
 use std::env;
 use std::fs::{self, File};
-use std::io::Write;
+use std::io::{self, Write};
+use std::path::PathBuf;
 
 use rustc_data_structures::fx::FxIndexSet;
 use rustc_data_structures::graph::linked_graph::{Direction, INCOMING, NodeIndex, OUTGOING};
@@ -63,7 +64,13 @@ pub(crate) fn assert_dep_graph(tcx: TyCtxt<'_>) {
 
         if tcx.sess.opts.unstable_opts.dump_dep_graph {
             if let Some(graph) = &retained_dep_graph {
-                dump_graph(graph);
+                if let Err((path, err)) = dump_graph(graph) {
+                    tcx.dcx().emit_fatal(diagnostics::WriteNew {
+                        name: "dependency graph",
+                        path,
+                        err,
+                    });
+                }
             }
         }
 
@@ -208,7 +215,7 @@ fn check_paths<'tcx>(
     }
 }
 
-fn dump_graph(graph: &RetainedDepGraph) {
+fn dump_graph(graph: &RetainedDepGraph) -> Result<(), (PathBuf, io::Error)> {
     let path: String = env::var("RUST_DEP_GRAPH").unwrap_or_else(|_| "dep_graph".to_string());
 
     let nodes = match env::var("RUST_DEP_GRAPH_FILTER") {
@@ -226,20 +233,23 @@ fn dump_graph(graph: &RetainedDepGraph) {
 
     {
         // dump a .txt file with just the edges:
-        let txt_path = format!("{path}.txt");
-        let mut file = File::create_buffered(&txt_path).unwrap();
+        let txt_path = PathBuf::from(format!("{path}.txt"));
+        let mut file = File::create_buffered(&txt_path).map_err(|err| (txt_path.clone(), err))?;
         for (source, target) in &edges {
-            write!(file, "{source:?} -> {target:?}\n").unwrap();
+            write!(file, "{source:?} -> {target:?}\n").map_err(|err| (txt_path.clone(), err))?;
         }
     }
 
     {
         // dump a .dot file in graphviz format:
-        let dot_path = format!("{path}.dot");
+        let dot_path = PathBuf::from(format!("{path}.dot"));
         let mut v = Vec::new();
-        dot::render(&GraphvizDepGraph(nodes, edges), &mut v).unwrap();
-        fs::write(dot_path, v).unwrap();
+        dot::render(&GraphvizDepGraph(nodes, edges), &mut v)
+            .expect("writing the dependency graph to a byte buffer cannot fail");
+        fs::write(&dot_path, v).map_err(|err| (dot_path, err))?;
     }
+
+    Ok(())
 }
 
 #[allow(missing_docs)]

--- a/tests/run-make/dep-graph/rmake.rs
+++ b/tests/run-make/dep-graph/rmake.rs
@@ -15,4 +15,14 @@ fn main() {
 
     assert!(path("dep-graph.txt").is_file());
     assert!(path("dep-graph.dot").is_file());
+
+    rustc()
+        .input("foo.rs")
+        .incremental(path("incr-fail"))
+        .arg("-Zquery-dep-graph")
+        .arg("-Zdump-dep-graph")
+        .env("RUST_DEP_GRAPH", path("does-not-exist/dep-graph"))
+        .run_fail()
+        .assert_stderr_contains("failed to write dependency graph")
+        .assert_not_ice();
 }


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->


`-Zdump-dep-graph` used `unwrap()` when creating or writing the dependency graph output files. As a result, setting `RUST_DEP_GRAPH` to a path whose parent directory does not exist, or to another unwritable location, caused rustc to ICE.

This changes `dump_graph` to propagate filesystem errors and emit the existing structured file-writing diagnostic at the caller.

The run-make test now covers an invalid output directory and verifies that rustc reports a normal error without ICEing.

Tests:

- `./x test tests/run-make/dep-graph`
- `./x fmt --check`
- `./x test tidy`
