### PR TITLE
Generate `valid_range`s for enums sign-agnostically

### DIFF
--- a/compiler/rustc_abi/src/layout.rs
+++ b/compiler/rustc_abi/src/layout.rs
@@ -350,7 +350,7 @@ impl<Cx: HasDataLayout> LayoutCalculator<Cx> {
         is_enum: bool,
         is_special_no_niche: bool,
         discr_range_of_repr: impl Fn(i128, i128) -> (Integer, bool),
-        discriminants: impl Iterator<Item = (VariantIdx, i128)>,
+        discriminants: impl Iterator<Item = (VariantIdx, u128)>,
         always_sized: bool,
     ) -> LayoutCalculatorResult<FieldIdx, VariantIdx, F> {
         let (present_first, present_second) = {
@@ -583,7 +583,7 @@ impl<Cx: HasDataLayout> LayoutCalculator<Cx> {
         repr: &ReprOptions,
         variants: &IndexSlice<VariantIdx, IndexVec<FieldIdx, F>>,
         discr_range_of_repr: impl Fn(i128, i128) -> (Integer, bool),
-        discriminants: impl Iterator<Item = (VariantIdx, i128)>,
+        discriminants: impl Iterator<Item = (VariantIdx, u128)>,
     ) -> LayoutCalculatorResult<FieldIdx, VariantIdx, F> {
         let dl = self.cx.data_layout();
         // bail if the enum has an incoherent repr that cannot be computed
@@ -767,9 +767,9 @@ impl<Cx: HasDataLayout> LayoutCalculator<Cx> {
                 if discr_type.is_signed() {
                     // sign extend the raw representation to be an i128
                     // FIXME: do this at the discriminant iterator creation sites
-                    discr_int.size().sign_extend(val as u128)
+                    discr_int.size().sign_extend(val)
                 } else {
-                    val
+                    val as i128
                 }
             })
             .collect();

--- a/compiler/rustc_abi/src/layout.rs
+++ b/compiler/rustc_abi/src/layout.rs
@@ -1,7 +1,6 @@
-use std::collections::BTreeSet;
 use std::fmt::{self, Write};
 use std::ops::Deref;
-use std::range::RangeInclusive;
+use std::range::{RangeFrom, RangeInclusive, RangeToInclusive};
 use std::{cmp, iter};
 
 use rustc_hashes::Hash64;
@@ -349,7 +348,7 @@ impl<Cx: HasDataLayout> LayoutCalculator<Cx> {
         variants: &IndexSlice<VariantIdx, IndexVec<FieldIdx, F>>,
         is_enum: bool,
         is_special_no_niche: bool,
-        discr_range_of_repr: impl Fn(i128, i128) -> (Integer, bool),
+        discr_range_of_repr: impl Fn(RangeFrom<i128>, RangeToInclusive<u128>) -> (Integer, bool),
         discriminants: impl Iterator<Item = (VariantIdx, u128)>,
         always_sized: bool,
     ) -> LayoutCalculatorResult<FieldIdx, VariantIdx, F> {
@@ -582,7 +581,7 @@ impl<Cx: HasDataLayout> LayoutCalculator<Cx> {
         &self,
         repr: &ReprOptions,
         variants: &IndexSlice<VariantIdx, IndexVec<FieldIdx, F>>,
-        discr_range_of_repr: impl Fn(i128, i128) -> (Integer, bool),
+        discr_range_of_repr: impl Fn(RangeFrom<i128>, RangeToInclusive<u128>) -> (Integer, bool),
         discriminants: impl Iterator<Item = (VariantIdx, u128)>,
     ) -> LayoutCalculatorResult<FieldIdx, VariantIdx, F> {
         let dl = self.cx.data_layout();
@@ -755,63 +754,36 @@ impl<Cx: HasDataLayout> LayoutCalculator<Cx> {
         let niche_filling_layout = calculate_niche_filling_layout();
 
         let discr_type = repr.discr_type();
-        let discr_int = Integer::from_attr(dl, discr_type);
-        // Because we can only represent one range of valid values, we'll look for the
-        // largest range of invalid values and pick everything else as the range of valid
-        // values.
+        let discr_size = Integer::from_attr(dl, discr_type).size();
 
-        // First we need to sort the possible discriminant values so that we can look for the largest gap:
-        let valid_discriminants: BTreeSet<i128> = discriminants
+        let necessary_discriminants: Vec<u128> = discriminants
             .filter(|&(i, _)| repr.c() || variants[i].iter().all(|f| !f.is_uninhabited()))
-            .map(|(_, val)| {
-                if discr_type.is_signed() {
-                    // sign extend the raw representation to be an i128
-                    // FIXME: do this at the discriminant iterator creation sites
-                    discr_int.size().sign_extend(val)
-                } else {
-                    val as i128
-                }
-            })
+            .map(|(_, val)| val)
             .collect();
-        trace!(?valid_discriminants);
-        let discriminants = valid_discriminants.iter().copied();
-        //let next_discriminants = discriminants.clone().cycle().skip(1);
-        let next_discriminants =
-            discriminants.clone().chain(valid_discriminants.first().copied()).skip(1);
-        // Iterate over pairs of each discriminant together with the next one.
-        // Since they were sorted, we can now compute the niche sizes and pick the largest.
-        let discriminants = discriminants.zip(next_discriminants);
-        let largest_niche = discriminants.max_by_key(|&(start, end)| {
-            trace!(?start, ?end);
-            // If this is a wraparound range, the niche size is `MAX - abs(diff)`, as the diff between
-            // the two end points is actually the size of the valid discriminants.
-            let dist = if start > end {
-                // Overflow can happen for 128 bit discriminants if `end` is negative.
-                // But in that case casting to `u128` still gets us the right value,
-                // as the distance must be positive if the lhs of the subtraction is larger than the rhs.
-                let dist = start.wrapping_sub(end);
-                if discr_type.is_signed() {
-                    discr_int.signed_max().wrapping_sub(dist) as u128
-                } else {
-                    discr_int.size().unsigned_int_max() - dist as u128
-                }
-            } else {
-                // Overflow can happen for 128 bit discriminants if `start` is negative.
-                // But in that case casting to `u128` still gets us the right value,
-                // as the distance must be positive if the lhs of the subtraction is larger than the rhs.
-                end.wrapping_sub(start) as u128
-            };
-            trace!(?dist);
-            dist
-        });
-        trace!(?largest_niche);
 
-        // `max` is the last valid discriminant before the largest niche
-        // `min` is the first valid discriminant after the largest niche
-        let (max, min) = largest_niche
+        // When picking the integer to use, we respect how the discriminants were written
+        // in the original rust code, rather than looking only at the bit pattern.
+        let (min_negative, max_positive): (i128, u128) = if discr_type.is_signed() {
+            necessary_discriminants.iter().copied().map(|val| discr_size.sign_extend(val)).fold(
+                (0_i128, 0_u128),
+                |(min, max), val| {
+                    if let Ok(val) = u128::try_from(val) {
+                        (min, max.max(val))
+                    } else {
+                        (min.min(val), max)
+                    }
+                },
+            )
+        } else {
             // We might have no inhabited variants, so pretend there's at least one.
-            .unwrap_or((0, 0));
-        let (min_ity, signed) = discr_range_of_repr(min, max); //Integer::discr_range_of_repr(tcx, ty, &repr, min, max);
+            (0, necessary_discriminants.iter().copied().max().unwrap_or(0))
+        };
+        trace!(?min_negative, ?max_positive);
+
+        let (min_ity, signed) = discr_range_of_repr(
+            RangeFrom { start: min_negative },
+            RangeToInclusive { last: max_positive },
+        ); //Integer::discr_range_of_repr(tcx, ty, &repr, min, max);
 
         let mut align = dl.aggregate_align;
         let mut max_repr_align = repr.align;
@@ -929,13 +901,16 @@ impl<Cx: HasDataLayout> LayoutCalculator<Cx> {
             }
         }
 
-        let tag_mask = ity.size().unsigned_int_max();
+        let tag_valid_range = {
+            let tag_size = ity.size();
+            let tags = necessary_discriminants.into_iter().map(|d| tag_size.truncate(d));
+            WrappingRange::smallest_range_containing(tags, tag_size)
+                // We might have no inhabited variants, so pretend there's at least one.
+                .unwrap_or(WrappingRange { start: 0, end: 0 })
+        };
         let tag = Scalar::Initialized {
             value: Primitive::Int(ity, signed),
-            valid_range: WrappingRange {
-                start: (min as u128 & tag_mask),
-                end: (max as u128 & tag_mask),
-            },
+            valid_range: tag_valid_range,
         };
         let mut abi = BackendRepr::Memory { sized: true };
 

--- a/compiler/rustc_abi/src/lib.rs
+++ b/compiler/rustc_abi/src/lib.rs
@@ -41,7 +41,7 @@ use std::fmt;
 #[cfg(feature = "nightly")]
 use std::iter::Step;
 use std::num::{NonZeroUsize, ParseIntError};
-use std::ops::{Add, AddAssign, Deref, Mul, RangeFull, Sub};
+use std::ops::{Add, AddAssign, Deref, Mul, Sub};
 use std::range::RangeInclusive;
 use std::str::FromStr;
 
@@ -65,6 +65,7 @@ mod extern_abi;
 mod layout;
 #[cfg(test)]
 mod tests;
+mod wrapping_range;
 
 pub use callconv::{Heterogeneous, HomogeneousAggregate, Reg, RegKind};
 pub use canon_abi::{ArmCall, CanonAbi, InterruptKind, X86Call};
@@ -74,6 +75,7 @@ pub use extern_abi::{ExternAbi, all_names};
 pub use layout::{FIRST_VARIANT, FieldIdx, LayoutCalculator, LayoutCalculatorError, VariantIdx};
 #[cfg(feature = "nightly")]
 pub use layout::{Layout, TyAbiInterface, TyAndLayout};
+pub use wrapping_range::WrappingRange;
 
 #[derive(Clone, Copy, PartialEq, Eq, Default)]
 #[cfg_attr(feature = "nightly", derive(Encodable_NoContext, Decodable_NoContext, StableHash))]
@@ -1468,152 +1470,6 @@ impl Primitive {
             Float(f) => f.align(dl),
             Pointer(a) => dl.pointer_align_in(a),
         }
-    }
-}
-
-/// Inclusive wrap-around range of valid values, that is, if
-/// start > end, it represents `start..=MAX`, followed by `0..=end`.
-///
-/// That is, for an i8 primitive, a range of `254..=2` means following
-/// sequence:
-///
-///    254 (-2), 255 (-1), 0, 1, 2
-///
-/// This is intended specifically to mirror LLVM’s `!range` metadata semantics.
-#[derive(Clone, Copy, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "nightly", derive(StableHash))]
-pub struct WrappingRange {
-    pub start: u128,
-    pub end: u128,
-}
-
-impl WrappingRange {
-    fn debug_as(&self, size: Size, is_signed: bool) -> impl fmt::Debug {
-        let range = *self;
-        fmt::from_fn(move |f| {
-            if range == WrappingRange::full(size) {
-                // This is intentionally not using `is_full_for` so that we ensure
-                // different values always debug-print differently.
-                // We don't need the full details when it's the canonical full range,
-                // but if one is looking at the debug output it might be that seeing
-                // `u8 is (..=0) | (1..)` instead of `u8 is ..` is the information
-                // you needed because the problem is that despite being *a* full
-                // range it's not *the* canonical one you expected it was.
-                f.write_str("..")
-            } else if is_signed {
-                let start = size.sign_extend(range.start);
-                let end = size.sign_extend(range.end);
-                if start > end {
-                    write!(f, "(..={}) | ({}..)", end, start)
-                } else {
-                    write!(f, "{}..={}", start, end)
-                }
-            } else {
-                write!(f, "{:?}", range)
-            }
-        })
-    }
-
-    pub fn full(size: Size) -> Self {
-        Self { start: 0, end: size.unsigned_int_max() }
-    }
-
-    /// Returns `true` if `v` is contained in the range.
-    #[inline(always)]
-    pub fn contains(&self, v: u128) -> bool {
-        if self.start <= self.end {
-            self.start <= v && v <= self.end
-        } else {
-            self.start <= v || v <= self.end
-        }
-    }
-
-    /// Returns `true` if all the values in `other` are contained in this range,
-    /// when the values are considered as having width `size`.
-    #[inline(always)]
-    pub fn contains_range(&self, other: Self, size: Size) -> bool {
-        if self.is_full_for(size) {
-            true
-        } else {
-            let trunc = |x| size.truncate(x);
-
-            let delta = self.start;
-            let max = trunc(self.end.wrapping_sub(delta));
-
-            let other_start = trunc(other.start.wrapping_sub(delta));
-            let other_end = trunc(other.end.wrapping_sub(delta));
-
-            // Having shifted both input ranges by `delta`, now we only need to check
-            // whether `0..=max` contains `other_start..=other_end`, which can only
-            // happen if the other doesn't wrap since `self` isn't everything.
-            (other_start <= other_end) && (other_end <= max)
-        }
-    }
-
-    /// Returns `self` with replaced `start`
-    #[inline(always)]
-    fn with_start(mut self, start: u128) -> Self {
-        self.start = start;
-        self
-    }
-
-    /// Returns `self` with replaced `end`
-    #[inline(always)]
-    fn with_end(mut self, end: u128) -> Self {
-        self.end = end;
-        self
-    }
-
-    /// Returns `true` if `size` completely fills the range.
-    ///
-    /// Note that this is *not* the same as `self == WrappingRange::full(size)`.
-    /// Niche calculations can produce full ranges which are not the canonical one;
-    /// for example `Option<NonZero<u16>>` gets `valid_range: (..=0) | (1..)`.
-    #[inline]
-    fn is_full_for(&self, size: Size) -> bool {
-        let max_value = size.unsigned_int_max();
-        debug_assert!(self.start <= max_value && self.end <= max_value);
-        self.start == (self.end.wrapping_add(1) & max_value)
-    }
-
-    /// Checks whether this range is considered non-wrapping when the values are
-    /// interpreted as *unsigned* numbers of width `size`.
-    ///
-    /// Returns `Ok(true)` if there's no wrap-around, `Ok(false)` if there is,
-    /// and `Err(..)` if the range is full so it depends how you think about it.
-    #[inline]
-    pub fn no_unsigned_wraparound(&self, size: Size) -> Result<bool, RangeFull> {
-        if self.is_full_for(size) { Err(..) } else { Ok(self.start <= self.end) }
-    }
-
-    /// Checks whether this range is considered non-wrapping when the values are
-    /// interpreted as *signed* numbers of width `size`.
-    ///
-    /// This is heavily dependent on the `size`, as `100..=200` does wrap when
-    /// interpreted as `i8`, but doesn't when interpreted as `i16`.
-    ///
-    /// Returns `Ok(true)` if there's no wrap-around, `Ok(false)` if there is,
-    /// and `Err(..)` if the range is full so it depends how you think about it.
-    #[inline]
-    pub fn no_signed_wraparound(&self, size: Size) -> Result<bool, RangeFull> {
-        if self.is_full_for(size) {
-            Err(..)
-        } else {
-            let start: i128 = size.sign_extend(self.start);
-            let end: i128 = size.sign_extend(self.end);
-            Ok(start <= end)
-        }
-    }
-}
-
-impl fmt::Debug for WrappingRange {
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if self.start > self.end {
-            write!(fmt, "(..={}) | ({}..)", self.end, self.start)?;
-        } else {
-            write!(fmt, "{}..={}", self.start, self.end)?;
-        }
-        Ok(())
     }
 }
 

--- a/compiler/rustc_abi/src/wrapping_range.rs
+++ b/compiler/rustc_abi/src/wrapping_range.rs
@@ -1,0 +1,152 @@
+use std::fmt;
+use std::ops::RangeFull;
+
+use crate::Size;
+#[cfg(feature = "nightly")]
+use crate::StableHash;
+
+/// Inclusive wrap-around range of valid values, that is, if
+/// start > end, it represents `start..=MAX`, followed by `0..=end`.
+///
+/// That is, for an i8 primitive, a range of `254..=2` means following
+/// sequence:
+///
+///    254 (-2), 255 (-1), 0, 1, 2
+///
+/// This is intended specifically to mirror LLVM’s `!range` metadata semantics.
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "nightly", derive(StableHash))]
+pub struct WrappingRange {
+    pub start: u128,
+    pub end: u128,
+}
+
+impl WrappingRange {
+    pub(crate) fn debug_as(&self, size: Size, is_signed: bool) -> impl fmt::Debug {
+        let range = *self;
+        fmt::from_fn(move |f| {
+            if range == WrappingRange::full(size) {
+                // This is intentionally not using `is_full_for` so that we ensure
+                // different values always debug-print differently.
+                // We don't need the full details when it's the canonical full range,
+                // but if one is looking at the debug output it might be that seeing
+                // `u8 is (..=0) | (1..)` instead of `u8 is ..` is the information
+                // you needed because the problem is that despite being *a* full
+                // range it's not *the* canonical one you expected it was.
+                f.write_str("..")
+            } else if is_signed {
+                let start = size.sign_extend(range.start);
+                let end = size.sign_extend(range.end);
+                if start > end {
+                    write!(f, "(..={}) | ({}..)", end, start)
+                } else {
+                    write!(f, "{}..={}", start, end)
+                }
+            } else {
+                write!(f, "{:?}", range)
+            }
+        })
+    }
+
+    pub fn full(size: Size) -> Self {
+        Self { start: 0, end: size.unsigned_int_max() }
+    }
+
+    /// Returns `true` if `v` is contained in the range.
+    #[inline(always)]
+    pub fn contains(&self, v: u128) -> bool {
+        if self.start <= self.end {
+            self.start <= v && v <= self.end
+        } else {
+            self.start <= v || v <= self.end
+        }
+    }
+
+    /// Returns `true` if all the values in `other` are contained in this range,
+    /// when the values are considered as having width `size`.
+    #[inline(always)]
+    pub fn contains_range(&self, other: Self, size: Size) -> bool {
+        if self.is_full_for(size) {
+            true
+        } else {
+            let trunc = |x| size.truncate(x);
+
+            let delta = self.start;
+            let max = trunc(self.end.wrapping_sub(delta));
+
+            let other_start = trunc(other.start.wrapping_sub(delta));
+            let other_end = trunc(other.end.wrapping_sub(delta));
+
+            // Having shifted both input ranges by `delta`, now we only need to check
+            // whether `0..=max` contains `other_start..=other_end`, which can only
+            // happen if the other doesn't wrap since `self` isn't everything.
+            (other_start <= other_end) && (other_end <= max)
+        }
+    }
+
+    /// Returns `self` with replaced `start`
+    #[inline(always)]
+    pub(crate) fn with_start(mut self, start: u128) -> Self {
+        self.start = start;
+        self
+    }
+
+    /// Returns `self` with replaced `end`
+    #[inline(always)]
+    pub(crate) fn with_end(mut self, end: u128) -> Self {
+        self.end = end;
+        self
+    }
+
+    /// Returns `true` if `size` completely fills the range.
+    ///
+    /// Note that this is *not* the same as `self == WrappingRange::full(size)`.
+    /// Niche calculations can produce full ranges which are not the canonical one;
+    /// for example `Option<NonZero<u16>>` gets `valid_range: (..=0) | (1..)`.
+    #[inline]
+    pub fn is_full_for(&self, size: Size) -> bool {
+        let max_value = size.unsigned_int_max();
+        debug_assert!(self.start <= max_value && self.end <= max_value);
+        self.start == (self.end.wrapping_add(1) & max_value)
+    }
+
+    /// Checks whether this range is considered non-wrapping when the values are
+    /// interpreted as *unsigned* numbers of width `size`.
+    ///
+    /// Returns `Ok(true)` if there's no wrap-around, `Ok(false)` if there is,
+    /// and `Err(..)` if the range is full so it depends how you think about it.
+    #[inline]
+    pub fn no_unsigned_wraparound(&self, size: Size) -> Result<bool, RangeFull> {
+        if self.is_full_for(size) { Err(..) } else { Ok(self.start <= self.end) }
+    }
+
+    /// Checks whether this range is considered non-wrapping when the values are
+    /// interpreted as *signed* numbers of width `size`.
+    ///
+    /// This is heavily dependent on the `size`, as `100..=200` does wrap when
+    /// interpreted as `i8`, but doesn't when interpreted as `i16`.
+    ///
+    /// Returns `Ok(true)` if there's no wrap-around, `Ok(false)` if there is,
+    /// and `Err(..)` if the range is full so it depends how you think about it.
+    #[inline]
+    pub fn no_signed_wraparound(&self, size: Size) -> Result<bool, RangeFull> {
+        if self.is_full_for(size) {
+            Err(..)
+        } else {
+            let start: i128 = size.sign_extend(self.start);
+            let end: i128 = size.sign_extend(self.end);
+            Ok(start <= end)
+        }
+    }
+}
+
+impl fmt::Debug for WrappingRange {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.start > self.end {
+            write!(fmt, "(..={}) | ({}..)", self.end, self.start)?;
+        } else {
+            write!(fmt, "{}..={}", self.start, self.end)?;
+        }
+        Ok(())
+    }
+}

--- a/compiler/rustc_abi/src/wrapping_range.rs
+++ b/compiler/rustc_abi/src/wrapping_range.rs
@@ -98,6 +98,11 @@ impl WrappingRange {
         self
     }
 
+    /// The wrapping distance from `self.start` to `self.end`.
+    fn width(&self, size: Size) -> u128 {
+        size.truncate(u128::wrapping_sub(self.end, self.start))
+    }
+
     /// Returns `true` if `size` completely fills the range.
     ///
     /// Note that this is *not* the same as `self == WrappingRange::full(size)`.
@@ -137,6 +142,58 @@ impl WrappingRange {
             let end: i128 = size.sign_extend(self.end);
             Ok(start <= end)
         }
+    }
+
+    /// Returns a `WrappingRange` that contains all of the values from the iterator,
+    /// when they're treated as values `size` wide.
+    ///
+    /// # Examples
+    ///
+    ///
+    /// ```
+    /// use rustc_abi::{Size, WrappingRange};
+    ///
+    /// let range = WrappingRange::smallest_range_containing([2, 6, 12, 4], Size::from_bytes(2));
+    /// assert_eq!(range.unwrap(), WrappingRange { start: 2, end: 12 });
+    ///
+    /// let range = WrappingRange::smallest_range_containing(0..=127, Size::from_bytes(1));
+    /// assert_eq!(range.unwrap(), WrappingRange { start: 0, end: 127 });
+    /// let range = WrappingRange::smallest_range_containing([129, 128, 127], Size::from_bytes(1));
+    /// assert_eq!(range.unwrap(), WrappingRange { start: 127, end: 129 });
+    ///
+    /// // The size matters because it changes where the wrapping can happen:
+    /// let range = WrappingRange::smallest_range_containing([1, 254], Size::from_bytes(1));
+    /// assert_eq!(range.unwrap(), WrappingRange { start: 254, end: 1 });
+    /// let range = WrappingRange::smallest_range_containing([1, 254], Size::from_bytes(4));
+    /// assert_eq!(range.unwrap(), WrappingRange { start: 1, end: 254 });
+    ///
+    /// // Both `100..=228` and `..=228 | 100..` are the same size, but we pick the one without zero.
+    /// let range = WrappingRange::smallest_range_containing([100, 228], Size::from_bytes(1));
+    /// assert_eq!(range.unwrap(), WrappingRange { start: 100, end: 228 });
+    /// // These 4 values are evenly spaced so all 4 candidate ranges have length 193:
+    /// // `(..=32) | (96..)`, `(..=96) | (160..)`, `(..=160) | (224..)`, and `32..=224`.
+    /// // We pick the last one as the only one that doesn't contain zero.
+    /// let range = WrappingRange::smallest_range_containing([0xA0, 0xE0, 0x20, 0x60], Size::from_bytes(1));
+    /// assert_eq!(range.unwrap(), WrappingRange { start: 0x20, end: 0xE0 });
+    /// ```
+    pub fn smallest_range_containing(
+        values: impl IntoIterator<Item = u128>,
+        size: Size,
+    ) -> Option<Self> {
+        let mut values: Vec<_> = values.into_iter().collect();
+        let umax = size.unsigned_int_max();
+        for value in &values {
+            debug_assert!(*value <= umax, "Value {value:?} is too big for {size:?}");
+        }
+        values.sort_unstable();
+
+        // Having sorted all the values, every element is a possible start point for the
+        // range of values, up to the previous element (wrapping around the end of the vec).
+        // Look at all those candidates and pick the one that's as narrow as possible.
+        let pairs = std::iter::zip(values.iter().copied(), values.iter().copied().cycle().skip(1));
+        let ranges = pairs.map(|(end, start)| WrappingRange { start, end });
+        let smallest_range = ranges.min_by_key(|r| (r.width(size), r.start));
+        smallest_range
     }
 }
 

--- a/compiler/rustc_attr_parsing/src/attributes/rustc_dump.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/rustc_dump.rs
@@ -123,8 +123,7 @@ impl CombineAttributeParser for RustcDumpLayoutParser {
         Allow(Target::TyAlias),
     ]);
 
-    const TEMPLATE: AttributeTemplate =
-        template!(List: &["abi", "align", "size", "homogenous_aggregate", "debug"]);
+    const TEMPLATE: AttributeTemplate = template!(List: &["abi", "align", "size", "homogenous_aggregate", "largest_niche", "debug"]);
     const STABILITY: AttributeStability = unstable!(rustc_attrs);
 
     fn extend(
@@ -150,6 +149,7 @@ impl CombineAttributeParser for RustcDumpLayoutParser {
                 sym::backend_repr => RustcDumpLayoutKind::BackendRepr,
                 sym::debug => RustcDumpLayoutKind::Debug,
                 sym::homogeneous_aggregate => RustcDumpLayoutKind::HomogenousAggregate,
+                sym::largest_niche => RustcDumpLayoutKind::LargestNiche,
                 sym::size => RustcDumpLayoutKind::Size,
                 _ => {
                     cx.adcx().expected_specific_argument(

--- a/compiler/rustc_hir/src/attrs/data_structures.rs
+++ b/compiler/rustc_hir/src/attrs/data_structures.rs
@@ -809,6 +809,7 @@ pub enum RustcDumpLayoutKind {
     BackendRepr,
     Debug,
     HomogenousAggregate,
+    LargestNiche,
     Size,
 }
 

--- a/compiler/rustc_middle/src/ty/layout.rs
+++ b/compiler/rustc_middle/src/ty/layout.rs
@@ -68,9 +68,11 @@ impl abi::Integer {
     }
 
     /// Finds the appropriate Integer type and signedness for the given
-    /// signed discriminant range and `#[repr]` attribute.
-    /// N.B.: `u128` values above `i128::MAX` will be treated as signed, but
-    /// that shouldn't affect anything, other than maybe debuginfo.
+    /// discriminant range and `#[repr]` attribute.
+    ///
+    /// To represent the way the values were written in the rust source, min and max
+    /// are in different types. It's thus possible to pass in an unrepresentable range,
+    /// and the method will panic in those cases.
     ///
     /// This is the basis for computing the type of the *tag* of an enum (which can be smaller than
     /// the type of the *discriminant*, which is determined by [`ReprOptions::discr_type`]).
@@ -78,15 +80,24 @@ impl abi::Integer {
         tcx: TyCtxt<'tcx>,
         ty: Ty<'tcx>,
         repr: &ReprOptions,
-        min: i128,
-        max: i128,
+        min_negative: i128,
+        max_positive: u128,
     ) -> (abi::Integer, bool) {
+        assert!(
+            min_negative >= 0 || max_positive <= i128::MAX.cast_unsigned(),
+            "No type can represent the full range of {min_negative}..={max_positive}",
+        );
+
         // Theoretically, negative values could be larger in unsigned representation
         // than the unsigned representation of the signed minimum. However, if there
         // are any negative values, the only valid unsigned representation is u128
         // which can fit all i128 values, so the result remains unaffected.
-        let unsigned_fit = abi::Integer::fit_unsigned(cmp::max(min as u128, max as u128));
-        let signed_fit = cmp::max(abi::Integer::fit_signed(min), abi::Integer::fit_signed(max));
+        let unsigned_fit =
+            abi::Integer::fit_unsigned(cmp::max(min_negative.cast_unsigned(), max_positive));
+        let signed_fit = cmp::max(
+            abi::Integer::fit_signed(min_negative),
+            abi::Integer::fit_signed(max_positive.cast_signed()),
+        );
 
         if let Some(ity) = repr.int {
             let discr = abi::Integer::from_attr(&tcx, ity);

--- a/compiler/rustc_passes/src/layout_test.rs
+++ b/compiler/rustc_passes/src/layout_test.rs
@@ -85,6 +85,9 @@ fn dump_layout_of(tcx: TyCtxt<'_>, item_def_id: LocalDefId, kinds: &[RustcDumpLa
                             ty_layout.homogeneous_aggregate(&UnwrapLayoutCx { tcx, typing_env });
                         format!("homogeneous_aggregate: {data:?}")
                     }
+                    RustcDumpLayoutKind::LargestNiche => {
+                        format!("largest_niche: {:?}", ty_layout.largest_niche)
+                    }
                     RustcDumpLayoutKind::Size => format!("size: {:?}", ty_layout.size),
                 };
                 tcx.dcx().span_err(span, message);

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1174,6 +1174,7 @@ symbols! {
         lang,
         lang_items,
         large_assignments,
+        largest_niche,
         last,
         lasx,
         late_bound_turbofishing,

--- a/compiler/rustc_ty_utils/src/layout.rs
+++ b/compiler/rustc_ty_utils/src/layout.rs
@@ -718,7 +718,7 @@ fn layout_of_uncached<'tcx>(
 
             let discriminants_iter = || {
                 def.is_enum()
-                    .then(|| def.discriminants(tcx).map(|(v, d)| (v, d.val as i128)))
+                    .then(|| def.discriminants(tcx).map(|(v, d)| (v, d.val)))
                     .into_flat_iter()
             };
 

--- a/compiler/rustc_ty_utils/src/layout.rs
+++ b/compiler/rustc_ty_utils/src/layout.rs
@@ -1,3 +1,5 @@
+use std::range::{RangeFrom, RangeToInclusive};
+
 use hir::def_id::DefId;
 use rustc_abi as abi;
 use rustc_abi::Integer::{I8, I32};
@@ -713,8 +715,9 @@ fn layout_of_uncached<'tcx>(
             // UnsafeCell and UnsafePinned both disable niche optimizations
             let is_special_no_niche = def.is_unsafe_cell() || def.is_unsafe_pinned();
 
-            let discr_range_of_repr =
-                |min, max| abi::Integer::discr_range_of_repr(tcx, ty, &def.repr(), min, max);
+            let discr_range_of_repr = |min: RangeFrom<i128>, max: RangeToInclusive<u128>| {
+                abi::Integer::discr_range_of_repr(tcx, ty, &def.repr(), min.start, max.last)
+            };
 
             let discriminants_iter = || {
                 def.is_enum()

--- a/tests/ui/layout/enum-signedness.rs
+++ b/tests/ui/layout/enum-signedness.rs
@@ -44,7 +44,7 @@ enum PositiveByteC {
 #[rustc_dump_layout(largest_niche)]
 #[repr(Rust)]
 enum Negative32BitRust {
-    //~^ ERROR: value: i32, valid_range: (..=0) | (2147483648..)
+    //~^ ERROR: value: i32, valid_range: 0..=2147483648
     A = 0,
     B = i32::MIN as isize,
 }
@@ -52,7 +52,7 @@ enum Negative32BitRust {
 #[rustc_dump_layout(largest_niche)]
 #[repr(C)]
 enum Negative32BitC {
-    //~^ ERROR: value: i32, valid_range: (..=0) | (2147483648..)
+    //~^ ERROR: value: i32, valid_range: 0..=2147483648
     A = 0,
     B = i32::MIN as isize,
 }

--- a/tests/ui/layout/enum-signedness.rs
+++ b/tests/ui/layout/enum-signedness.rs
@@ -1,0 +1,114 @@
+//@ only-64bit
+#![feature(rustc_attrs)]
+#![feature(never_type)]
+#![crate_type = "lib"]
+
+// When picking a representation for things that don't force a particular discriminant type,
+// we look at how the value was actually written, which means that "equivalent" things
+// actually need to come out different.
+
+// The tests run only on 64-bit because we have to give things as `isize` in these cases.
+
+#[rustc_dump_layout(largest_niche)]
+#[repr(Rust)]
+enum NegativeByteRust {
+    //~^ ERROR: value: i8, valid_range: 155..=156
+    A = -100,
+    B = -101,
+}
+
+#[rustc_dump_layout(largest_niche)]
+#[repr(C)]
+enum NegativeByteC {
+    //~^ ERROR: value: i32, valid_range: 4294967195..=4294967196
+    A = -100,
+    B = -101,
+}
+
+#[rustc_dump_layout(largest_niche)]
+#[repr(Rust)]
+enum PositiveByteRust {
+    //~^ ERROR: value: u8, valid_range: 155..=156
+    A = 256 - 100,
+    B = 256 - 101,
+}
+
+#[rustc_dump_layout(largest_niche)]
+#[repr(C)]
+enum PositiveByteC {
+    //~^ ERROR: value: u32, valid_range: 155..=156
+    A = 256 - 100,
+    B = 256 - 101,
+}
+
+#[rustc_dump_layout(largest_niche)]
+#[repr(Rust)]
+enum Negative32BitRust {
+    //~^ ERROR: value: i32, valid_range: (..=0) | (2147483648..)
+    A = 0,
+    B = i32::MIN as isize,
+}
+
+#[rustc_dump_layout(largest_niche)]
+#[repr(C)]
+enum Negative32BitC {
+    //~^ ERROR: value: i32, valid_range: (..=0) | (2147483648..)
+    A = 0,
+    B = i32::MIN as isize,
+}
+
+#[rustc_dump_layout(largest_niche)]
+#[repr(Rust)]
+enum Positive32BitRust {
+    //~^ ERROR: value: u32, valid_range: 0..=2147483648
+    A = 0,
+    B = i32::MIN.cast_unsigned() as isize,
+}
+
+#[rustc_dump_layout(largest_niche)]
+#[repr(C)]
+enum Positive32BitC {
+    //~^ ERROR: value: u32, valid_range: 0..=2147483648
+    A = 0,
+    B = i32::MIN.cast_unsigned() as isize,
+}
+
+#[rustc_dump_layout(largest_niche)]
+#[repr(Rust)]
+enum Negative64BitRust {
+    //~^ ERROR: value: i64, valid_range: 9223372036854775808..=9223372036854775809
+    A = i64::MIN as isize,
+    B = i64::MIN as isize + 1,
+}
+
+#[rustc_dump_layout(largest_niche)]
+#[repr(C)]
+enum Negative64BitC {
+    //~^ ERROR: value: i64, valid_range: 9223372036854775808..=9223372036854775809
+    A = i64::MIN as isize,
+    //~^ WARN: enum discriminant does not fit into C
+    //~| WARN: previously accepted
+    B = i64::MIN as isize + 1,
+    //~^ WARN: enum discriminant does not fit into C
+    //~| WARN: previously accepted
+}
+
+#[rustc_dump_layout(largest_niche)]
+#[repr(Rust)]
+enum Positive64BitRust {
+    //~^ ERROR: value: u64, valid_range: 9223372036854775806..=9223372036854775807
+    A = i64::MAX as isize - 1,
+    B = i64::MAX as isize,
+}
+
+#[rustc_dump_layout(largest_niche)]
+#[repr(C)]
+enum Positive64BitC {
+    //~^ ERROR: value: u64, valid_range: 9223372036854775806..=9223372036854775807
+    A = i64::MAX as isize - 1,
+    //~^ WARN: enum discriminant does not fit into C
+    //~| WARN: previously accepted
+    B = i64::MAX as isize,
+    //~^ WARN: enum discriminant does not fit into C
+    //~| WARN: previously accepted
+}

--- a/tests/ui/layout/enum-signedness.stderr
+++ b/tests/ui/layout/enum-signedness.stderr
@@ -67,13 +67,13 @@ error: largest_niche: Some(Niche { offset: Size(0 bytes), value: u32, valid_rang
 LL | enum PositiveByteC {
    | ^^^^^^^^^^^^^^^^^^
 
-error: largest_niche: Some(Niche { offset: Size(0 bytes), value: i32, valid_range: (..=0) | (2147483648..) })
+error: largest_niche: Some(Niche { offset: Size(0 bytes), value: i32, valid_range: 0..=2147483648 })
   --> $DIR/enum-signedness.rs:46:1
    |
 LL | enum Negative32BitRust {
    | ^^^^^^^^^^^^^^^^^^^^^^
 
-error: largest_niche: Some(Niche { offset: Size(0 bytes), value: i32, valid_range: (..=0) | (2147483648..) })
+error: largest_niche: Some(Niche { offset: Size(0 bytes), value: i32, valid_range: 0..=2147483648 })
   --> $DIR/enum-signedness.rs:54:1
    |
 LL | enum Negative32BitC {

--- a/tests/ui/layout/enum-signedness.stderr
+++ b/tests/ui/layout/enum-signedness.stderr
@@ -1,0 +1,119 @@
+warning: `repr(C)` enum discriminant does not fit into C `int` nor into C `unsigned int`
+  --> $DIR/enum-signedness.rs:88:5
+   |
+LL |     A = i64::MIN as isize,
+   |     ^
+   |
+   = note: `repr(C)` enums with big discriminants are non-portable, and their size in Rust might not match their size in C
+   = help: use `repr($int_ty)` instead to explicitly set the size of this enum
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #124403 <https://github.com/rust-lang/rust/issues/124403>
+   = note: `#[warn(repr_c_enums_larger_than_int)]` (part of `#[warn(future_incompatible)]`) on by default
+
+warning: `repr(C)` enum discriminant does not fit into C `int` nor into C `unsigned int`
+  --> $DIR/enum-signedness.rs:91:5
+   |
+LL |     B = i64::MIN as isize + 1,
+   |     ^
+   |
+   = note: `repr(C)` enums with big discriminants are non-portable, and their size in Rust might not match their size in C
+   = help: use `repr($int_ty)` instead to explicitly set the size of this enum
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #124403 <https://github.com/rust-lang/rust/issues/124403>
+
+warning: `repr(C)` enum discriminant does not fit into C `int` nor into C `unsigned int`
+  --> $DIR/enum-signedness.rs:108:5
+   |
+LL |     A = i64::MAX as isize - 1,
+   |     ^
+   |
+   = note: `repr(C)` enums with big discriminants are non-portable, and their size in Rust might not match their size in C
+   = help: use `repr($int_ty)` instead to explicitly set the size of this enum
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #124403 <https://github.com/rust-lang/rust/issues/124403>
+
+warning: `repr(C)` enum discriminant does not fit into C `int` nor into C `unsigned int`
+  --> $DIR/enum-signedness.rs:111:5
+   |
+LL |     B = i64::MAX as isize,
+   |     ^
+   |
+   = note: `repr(C)` enums with big discriminants are non-portable, and their size in Rust might not match their size in C
+   = help: use `repr($int_ty)` instead to explicitly set the size of this enum
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #124403 <https://github.com/rust-lang/rust/issues/124403>
+
+error: largest_niche: Some(Niche { offset: Size(0 bytes), value: i8, valid_range: 155..=156 })
+  --> $DIR/enum-signedness.rs:14:1
+   |
+LL | enum NegativeByteRust {
+   | ^^^^^^^^^^^^^^^^^^^^^
+
+error: largest_niche: Some(Niche { offset: Size(0 bytes), value: i32, valid_range: 4294967195..=4294967196 })
+  --> $DIR/enum-signedness.rs:22:1
+   |
+LL | enum NegativeByteC {
+   | ^^^^^^^^^^^^^^^^^^
+
+error: largest_niche: Some(Niche { offset: Size(0 bytes), value: u8, valid_range: 155..=156 })
+  --> $DIR/enum-signedness.rs:30:1
+   |
+LL | enum PositiveByteRust {
+   | ^^^^^^^^^^^^^^^^^^^^^
+
+error: largest_niche: Some(Niche { offset: Size(0 bytes), value: u32, valid_range: 155..=156 })
+  --> $DIR/enum-signedness.rs:38:1
+   |
+LL | enum PositiveByteC {
+   | ^^^^^^^^^^^^^^^^^^
+
+error: largest_niche: Some(Niche { offset: Size(0 bytes), value: i32, valid_range: (..=0) | (2147483648..) })
+  --> $DIR/enum-signedness.rs:46:1
+   |
+LL | enum Negative32BitRust {
+   | ^^^^^^^^^^^^^^^^^^^^^^
+
+error: largest_niche: Some(Niche { offset: Size(0 bytes), value: i32, valid_range: (..=0) | (2147483648..) })
+  --> $DIR/enum-signedness.rs:54:1
+   |
+LL | enum Negative32BitC {
+   | ^^^^^^^^^^^^^^^^^^^
+
+error: largest_niche: Some(Niche { offset: Size(0 bytes), value: u32, valid_range: 0..=2147483648 })
+  --> $DIR/enum-signedness.rs:62:1
+   |
+LL | enum Positive32BitRust {
+   | ^^^^^^^^^^^^^^^^^^^^^^
+
+error: largest_niche: Some(Niche { offset: Size(0 bytes), value: u32, valid_range: 0..=2147483648 })
+  --> $DIR/enum-signedness.rs:70:1
+   |
+LL | enum Positive32BitC {
+   | ^^^^^^^^^^^^^^^^^^^
+
+error: largest_niche: Some(Niche { offset: Size(0 bytes), value: i64, valid_range: 9223372036854775808..=9223372036854775809 })
+  --> $DIR/enum-signedness.rs:78:1
+   |
+LL | enum Negative64BitRust {
+   | ^^^^^^^^^^^^^^^^^^^^^^
+
+error: largest_niche: Some(Niche { offset: Size(0 bytes), value: i64, valid_range: 9223372036854775808..=9223372036854775809 })
+  --> $DIR/enum-signedness.rs:86:1
+   |
+LL | enum Negative64BitC {
+   | ^^^^^^^^^^^^^^^^^^^
+
+error: largest_niche: Some(Niche { offset: Size(0 bytes), value: u64, valid_range: 9223372036854775806..=9223372036854775807 })
+  --> $DIR/enum-signedness.rs:98:1
+   |
+LL | enum Positive64BitRust {
+   | ^^^^^^^^^^^^^^^^^^^^^^
+
+error: largest_niche: Some(Niche { offset: Size(0 bytes), value: u64, valid_range: 9223372036854775806..=9223372036854775807 })
+  --> $DIR/enum-signedness.rs:106:1
+   |
+LL | enum Positive64BitC {
+   | ^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 12 previous errors; 4 warnings emitted
+

--- a/tests/ui/layout/enum-unusual-variants.rs
+++ b/tests/ui/layout/enum-unusual-variants.rs
@@ -1,0 +1,78 @@
+#![feature(rustc_attrs)]
+#![feature(never_type)]
+#![crate_type = "lib"]
+
+// Regression test for https://github.com/rust-lang/rust/issues/159438
+// where with `i8` it was getting an unnecessarily-broad `valid_range`
+
+#[rustc_dump_layout(largest_niche)]
+enum With128Variants {
+    //~^ ERROR: value: u8, valid_range: 0..=127
+    _0 = 0,
+    _1 = 1,
+    _2 = 2,
+    // layout doesn't actually care if we elide a bunch here
+    _125 = 125,
+    _126 = 126,
+    _127 = 127,
+}
+
+#[rustc_dump_layout(largest_niche)]
+#[repr(i8)]
+enum With128VariantsI8 {
+    //~^ ERROR: value: i8, valid_range: (..=2) | (125..)
+    _0 = 0,
+    _1 = 1,
+    _2 = 2,
+    // layout doesn't actually care if we elide a bunch here
+    _125 = 125,
+    _126 = 126,
+    _127 = 127,
+}
+
+#[rustc_dump_layout(largest_niche)]
+#[repr(u8)]
+enum With128VariantsU8 {
+    //~^ ERROR: value: u8, valid_range: 0..=127
+    _0 = 0,
+    _1 = 1,
+    _2 = 2,
+    // layout doesn't actually care if we elide a bunch here
+    _125 = 125,
+    _126 = 126,
+    _127 = 127,
+}
+
+// For these either the wrapping or the non-wrapping `valid_range` have the same size,
+// but it would be nice to consistently pick the one that leaves `0` unclaimed
+// so that it can be used for `None` later.
+
+#[rustc_dump_layout(largest_niche)]
+enum Symmetric {
+    //~^ ERROR: value: u8, valid_range: 1..=129
+    A = 1,
+    B = 129,
+}
+
+#[rustc_dump_layout(largest_niche)]
+#[repr(u8)]
+enum SymmetricU8 {
+    //~^ ERROR: value: u8, valid_range: (..=1) | (129..)
+    A = 1,
+    B = 129,
+}
+
+#[rustc_dump_layout(largest_niche)]
+enum SymmetricSigned {
+    //~^ ERROR: value: i8, valid_range: (..=1) | (129..)
+    A = -127,
+    B = 1,
+}
+
+#[rustc_dump_layout(largest_niche)]
+#[repr(i8)]
+enum SymmetricSignedI8 {
+    //~^ ERROR: value: i8, valid_range: (..=1) | (129..)
+    A = -127,
+    B = 1,
+}

--- a/tests/ui/layout/enum-unusual-variants.rs
+++ b/tests/ui/layout/enum-unusual-variants.rs
@@ -20,7 +20,7 @@ enum With128Variants {
 #[rustc_dump_layout(largest_niche)]
 #[repr(i8)]
 enum With128VariantsI8 {
-    //~^ ERROR: value: i8, valid_range: (..=2) | (125..)
+    //~^ ERROR: value: i8, valid_range: 0..=127
     _0 = 0,
     _1 = 1,
     _2 = 2,
@@ -57,14 +57,17 @@ enum Symmetric {
 #[rustc_dump_layout(largest_niche)]
 #[repr(u8)]
 enum SymmetricU8 {
-    //~^ ERROR: value: u8, valid_range: (..=1) | (129..)
+    //~^ ERROR: value: u8, valid_range: 1..=129
     A = 1,
     B = 129,
 }
 
+// Note that to get this one to work it's essential that the `valid_range` is
+// calculated on the *tag* values, because if calculated on the *discriminants*
+// the best range is different because of the wider range of `isize`.
 #[rustc_dump_layout(largest_niche)]
 enum SymmetricSigned {
-    //~^ ERROR: value: i8, valid_range: (..=1) | (129..)
+    //~^ ERROR: value: i8, valid_range: 1..=129
     A = -127,
     B = 1,
 }
@@ -72,7 +75,7 @@ enum SymmetricSigned {
 #[rustc_dump_layout(largest_niche)]
 #[repr(i8)]
 enum SymmetricSignedI8 {
-    //~^ ERROR: value: i8, valid_range: (..=1) | (129..)
+    //~^ ERROR: value: i8, valid_range: 1..=129
     A = -127,
     B = 1,
 }

--- a/tests/ui/layout/enum-unusual-variants.stderr
+++ b/tests/ui/layout/enum-unusual-variants.stderr
@@ -4,7 +4,7 @@ error: largest_niche: Some(Niche { offset: Size(0 bytes), value: u8, valid_range
 LL | enum With128Variants {
    | ^^^^^^^^^^^^^^^^^^^^
 
-error: largest_niche: Some(Niche { offset: Size(0 bytes), value: i8, valid_range: (..=2) | (125..) })
+error: largest_niche: Some(Niche { offset: Size(0 bytes), value: i8, valid_range: 0..=127 })
   --> $DIR/enum-unusual-variants.rs:22:1
    |
 LL | enum With128VariantsI8 {
@@ -22,20 +22,20 @@ error: largest_niche: Some(Niche { offset: Size(0 bytes), value: u8, valid_range
 LL | enum Symmetric {
    | ^^^^^^^^^^^^^^
 
-error: largest_niche: Some(Niche { offset: Size(0 bytes), value: u8, valid_range: (..=1) | (129..) })
+error: largest_niche: Some(Niche { offset: Size(0 bytes), value: u8, valid_range: 1..=129 })
   --> $DIR/enum-unusual-variants.rs:59:1
    |
 LL | enum SymmetricU8 {
    | ^^^^^^^^^^^^^^^^
 
-error: largest_niche: Some(Niche { offset: Size(0 bytes), value: i8, valid_range: (..=1) | (129..) })
-  --> $DIR/enum-unusual-variants.rs:66:1
+error: largest_niche: Some(Niche { offset: Size(0 bytes), value: i8, valid_range: 1..=129 })
+  --> $DIR/enum-unusual-variants.rs:69:1
    |
 LL | enum SymmetricSigned {
    | ^^^^^^^^^^^^^^^^^^^^
 
-error: largest_niche: Some(Niche { offset: Size(0 bytes), value: i8, valid_range: (..=1) | (129..) })
-  --> $DIR/enum-unusual-variants.rs:74:1
+error: largest_niche: Some(Niche { offset: Size(0 bytes), value: i8, valid_range: 1..=129 })
+  --> $DIR/enum-unusual-variants.rs:77:1
    |
 LL | enum SymmetricSignedI8 {
    | ^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/layout/enum-unusual-variants.stderr
+++ b/tests/ui/layout/enum-unusual-variants.stderr
@@ -1,0 +1,44 @@
+error: largest_niche: Some(Niche { offset: Size(0 bytes), value: u8, valid_range: 0..=127 })
+  --> $DIR/enum-unusual-variants.rs:9:1
+   |
+LL | enum With128Variants {
+   | ^^^^^^^^^^^^^^^^^^^^
+
+error: largest_niche: Some(Niche { offset: Size(0 bytes), value: i8, valid_range: (..=2) | (125..) })
+  --> $DIR/enum-unusual-variants.rs:22:1
+   |
+LL | enum With128VariantsI8 {
+   | ^^^^^^^^^^^^^^^^^^^^^^
+
+error: largest_niche: Some(Niche { offset: Size(0 bytes), value: u8, valid_range: 0..=127 })
+  --> $DIR/enum-unusual-variants.rs:35:1
+   |
+LL | enum With128VariantsU8 {
+   | ^^^^^^^^^^^^^^^^^^^^^^
+
+error: largest_niche: Some(Niche { offset: Size(0 bytes), value: u8, valid_range: 1..=129 })
+  --> $DIR/enum-unusual-variants.rs:51:1
+   |
+LL | enum Symmetric {
+   | ^^^^^^^^^^^^^^
+
+error: largest_niche: Some(Niche { offset: Size(0 bytes), value: u8, valid_range: (..=1) | (129..) })
+  --> $DIR/enum-unusual-variants.rs:59:1
+   |
+LL | enum SymmetricU8 {
+   | ^^^^^^^^^^^^^^^^
+
+error: largest_niche: Some(Niche { offset: Size(0 bytes), value: i8, valid_range: (..=1) | (129..) })
+  --> $DIR/enum-unusual-variants.rs:66:1
+   |
+LL | enum SymmetricSigned {
+   | ^^^^^^^^^^^^^^^^^^^^
+
+error: largest_niche: Some(Niche { offset: Size(0 bytes), value: i8, valid_range: (..=1) | (129..) })
+  --> $DIR/enum-unusual-variants.rs:74:1
+   |
+LL | enum SymmetricSignedI8 {
+   | ^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 7 previous errors
+


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/159509)*
<!-- homu-ignore:end -->

Prompted by https://github.com/rust-lang/rust/issues/159438#issuecomment-5007170897, this reworks the generation of the tag layout information for enums.

Having gone down the wrong path at first here, I think the core trouble this is having is that the current calculation is trying to serve two incompatible desires:
- When picking the `value: Primitive`, we need to respect the signedness of the original *discriminant* numbers as typed in Rust.
- When picking the `valid_range: WrappingRange`, we want to *ignore* the signedness (and size!) of the discriminants and look only at the bit values (and size) of the *tags* themselves.

This thus splits the handling in `layout_of_enum` into those two parts, handled differently.
- When looking at *discriminants* (to eventually call [`discr_range_of_repr`](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/ty/layout/trait.IntegerExt.html#tymethod.discr_range_of_repr)), we obey the signedness of the inputs to find the smallest negative discriminant and largest positive discriminant -- notably *without* any wraparound logic.
- Then after having used the discriminants to pick a *tag* size, then we run a wrapping-aware check to pick the best `WrappingRange` to represent those tags (which can be a different range than we'd have picked on the discriminants, especially for `repr(Rust)` where the discriminants are `isize`).

With apologies for sending this when you'd said you'd look at it, but I got inspired 😅 
r? @oli-obk 

Fixes rust-lang/rust#159438

---

I have a bunch of commits in here; it's probably best reviewed one at a time.

1. Just moving `WrappingRange` to its own file, since the `lib.rs` is over 2000 lines already so if I was going to add stuff I figured some reorganizing could help.
2. Adding a new constructor to `WrappingRange` that takes an iterator of values and returns a range containing those values.  Dealing just in `u128` + `Size`, like `WrappingRange` does in other places, it doesn't even *have* signedness information so structurally is prevented from having any "why are `repr(u8)` and `repr(i8) picking different ranges?" issues.  I found it helpful to have this split out from the layout code, for example that it let me put some examples on the doc-comment.  Nothing actually *uses* the new function in this commit though.
3. Stop giving layout discriminants as `i128` since <https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/ty/util/struct.Discr.html#structfield.val> points out that they're generated as `u128` in the same way that `WrappingRange` uses already -- even with the field doc that `-1_i8` is generated as `255_u128`, so the `as i128`ing was probably just making everything more confusing here than it needed to be.
4. Adding some tests looking at the generated `Primitive` and `valid_range`, along with rustc support for `#[rustc_dump_layout(largest_niche)]` to help have these tests include specific ERROR annotations rather than just the stderr.  The tests pass at this point, so the next commit can update them to show the change.
5. This one actually updates layout code, including using the `WrappingRange` constructor added earlier.
