### PR TITLE
std: count all processor groups in available_parallelism on Windows

### DIFF
--- a/library/std/src/sys/pal/windows/c/bindings.txt
+++ b/library/std/src/sys/pal/windows/c/bindings.txt
@@ -2188,6 +2188,7 @@ GetModuleHandleW
 GetOverlappedResult
 getpeername
 GetProcAddress
+GetProcessGroupAffinity
 GetProcessId
 getsockname
 getsockopt

--- a/library/std/src/sys/pal/windows/c/windows_sys.rs
+++ b/library/std/src/sys/pal/windows/c/windows_sys.rs
@@ -60,6 +60,7 @@ windows_link::link!("kernel32.dll" "system" fn GetModuleHandleExW(dwflags : u32,
 windows_link::link!("kernel32.dll" "system" fn GetModuleHandleW(lpmodulename : PCWSTR) -> HMODULE);
 windows_link::link!("kernel32.dll" "system" fn GetOverlappedResult(hfile : HANDLE, lpoverlapped : *const OVERLAPPED, lpnumberofbytestransferred : *mut u32, bwait : BOOL) -> BOOL);
 windows_link::link!("kernel32.dll" "system" fn GetProcAddress(hmodule : HMODULE, lpprocname : PCSTR) -> FARPROC);
+windows_link::link!("kernel32.dll" "system" fn GetProcessGroupAffinity(hprocess : HANDLE, groupcount : *mut u16, grouparray : *mut u16) -> BOOL);
 windows_link::link!("kernel32.dll" "system" fn GetProcessId(process : HANDLE) -> u32);
 windows_link::link!("kernel32.dll" "system" fn GetStdHandle(nstdhandle : STD_HANDLE) -> HANDLE);
 windows_link::link!("kernel32.dll" "system" fn GetSystemDirectoryW(lpbuffer : PWSTR, usize : u32) -> u32);

--- a/library/std/src/sys/thread/windows.rs
+++ b/library/std/src/sys/thread/windows.rs
@@ -78,9 +78,25 @@ impl Thread {
 
 pub fn available_parallelism() -> io::Result<NonZero<usize>> {
     let res = unsafe {
-        let mut sysinfo: c::SYSTEM_INFO = crate::mem::zeroed();
-        c::GetSystemInfo(&mut sysinfo);
-        sysinfo.dwNumberOfProcessors as usize
+        // Before Windows 11 / Server 2022 a process is confined to a single processor
+        // group by default; since then it spans every group. The number of groups the
+        // process is assigned to tells the two apart without an OS-version check.
+        let mut group_count: u16 = 1;
+        let mut group: u16 = 0;
+        // A process in more than one group fails this call with ERROR_INSUFFICIENT_BUFFER
+        // and writes the real group count into `group_count`; every other case leaves the
+        // initial `1`, so the return value can be ignored.
+        c::GetProcessGroupAffinity(c::GetCurrentProcess(), &mut group_count, &mut group);
+
+        if group_count > 1 {
+            // The process spans every group, so count the active CPUs across all of them.
+            c::GetActiveProcessorCount(c::ALL_PROCESSOR_GROUPS) as usize
+        } else {
+            // A single group holds every CPU the process can use by default.
+            let mut sysinfo: c::SYSTEM_INFO = crate::mem::zeroed();
+            c::GetSystemInfo(&mut sysinfo);
+            sysinfo.dwNumberOfProcessors as usize
+        }
     };
     match res {
         0 => Err(io::Error::UNKNOWN_THREAD_COUNT),

--- a/src/tools/miri/src/shims/windows/foreign_items.rs
+++ b/src/tools/miri/src/shims/windows/foreign_items.rs
@@ -635,35 +635,6 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                     &system_info,
                 )?;
             }
-            // this is only callable from std, which always asks for `ALL_PROCESSOR_GROUPS`
-            "GetActiveProcessorCount" if this.frame_in_std() => {
-                // FIXME: This does not have a direct test (#3179).
-                let [_group_number] = this.check_shim_sig(
-                    shim_sig!(extern "system" fn(u16) -> u32),
-                    link_name,
-                    abi,
-                    args,
-                )?;
-                // Miri does not model processor groups, so report every CPU.
-                this.write_scalar(Scalar::from_u32(this.machine.num_cpus), dest)?;
-            }
-            // this is only callable from std, which ignores the group array and the return value
-            "GetProcessGroupAffinity" if this.frame_in_std() => {
-                // FIXME: This does not have a direct test (#3179).
-                let [_handle, group_count, _group_array] = this.check_shim_sig(
-                    shim_sig!(extern "system" fn(winapi::HANDLE, *mut _, *mut _) -> winapi::BOOL),
-                    link_name,
-                    abi,
-                    args,
-                )?;
-                // Report more than one group so `available_parallelism` takes the
-                // `GetActiveProcessorCount(ALL_PROCESSOR_GROUPS)` path; a single-group
-                // affinity mask cannot hold the up-to-1024 CPUs the num-cpus test uses.
-                let group_count = this.deref_pointer_as(group_count, this.machine.layouts.u16)?;
-                this.write_scalar(Scalar::from_u16(2), &group_count)?;
-                this.write_scalar(Scalar::from_i32(1), dest)?; // TRUE
-            }
-
             // Thread-local storage
             "TlsAlloc" => {
                 // FIXME: This does not have a direct test (#3179).
@@ -1436,6 +1407,41 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
                 // FIXME: this should return a nonzero value if this call does result in switching to another thread.
                 this.write_null(dest)?;
+            }
+
+            // this is only callable from std, which always asks for `ALL_PROCESSOR_GROUPS`
+            "GetActiveProcessorCount" if this.frame_in_std() => {
+                // FIXME: This does not have a direct test (#3179).
+                let [group_number] = this.check_shim_sig(
+                    shim_sig!(extern "system" fn(u16) -> u32),
+                    link_name,
+                    abi,
+                    args,
+                )?;
+                const ALL_PROCESSOR_GROUPS: u16 = 0xffff;
+                if this.read_scalar(group_number)?.to_u16()? != ALL_PROCESSOR_GROUPS {
+                    throw_unsup_format!(
+                        "GetActiveProcessorCount: only ALL_PROCESSOR_GROUPS is supported"
+                    );
+                }
+                // Miri does not model processor groups, so report every CPU.
+                this.write_scalar(Scalar::from_u32(this.machine.num_cpus), dest)?;
+            }
+            // this is only callable from std, which ignores the group array and the return value
+            "GetProcessGroupAffinity" if this.frame_in_std() => {
+                // FIXME: This does not have a direct test (#3179).
+                let [_handle, group_count, _group_array] = this.check_shim_sig(
+                    shim_sig!(extern "system" fn(winapi::HANDLE, *mut _, *mut _) -> winapi::BOOL),
+                    link_name,
+                    abi,
+                    args,
+                )?;
+                // Report more than one group so `available_parallelism` takes the
+                // `GetActiveProcessorCount(ALL_PROCESSOR_GROUPS)` path, giving Miri
+                // coverage of the multi-group branch.
+                let group_count = this.deref_pointer_as(group_count, this.machine.layouts.u16)?;
+                this.write_scalar(Scalar::from_u16(2), &group_count)?;
+                this.write_scalar(Scalar::from_i32(1), dest)?; // TRUE
             }
 
             _ => return interp_ok(EmulateItemResult::NotSupported),

--- a/src/tools/miri/src/shims/windows/foreign_items.rs
+++ b/src/tools/miri/src/shims/windows/foreign_items.rs
@@ -635,7 +635,8 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                     &system_info,
                 )?;
             }
-            "GetActiveProcessorCount" => {
+            // this is only callable from std, which always asks for `ALL_PROCESSOR_GROUPS`
+            "GetActiveProcessorCount" if this.frame_in_std() => {
                 // FIXME: This does not have a direct test (#3179).
                 let [_group_number] = this.check_shim_sig(
                     shim_sig!(extern "system" fn(u16) -> u32),
@@ -646,7 +647,8 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // Miri does not model processor groups, so report every CPU.
                 this.write_scalar(Scalar::from_u32(this.machine.num_cpus), dest)?;
             }
-            "GetProcessGroupAffinity" => {
+            // this is only callable from std, which ignores the group array and the return value
+            "GetProcessGroupAffinity" if this.frame_in_std() => {
                 // FIXME: This does not have a direct test (#3179).
                 let [_handle, group_count, _group_array] = this.check_shim_sig(
                     shim_sig!(extern "system" fn(winapi::HANDLE, *mut _, *mut _) -> winapi::BOOL),

--- a/src/tools/miri/src/shims/windows/foreign_items.rs
+++ b/src/tools/miri/src/shims/windows/foreign_items.rs
@@ -635,6 +635,32 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                     &system_info,
                 )?;
             }
+            "GetActiveProcessorCount" => {
+                // FIXME: This does not have a direct test (#3179).
+                let [_group_number] = this.check_shim_sig(
+                    shim_sig!(extern "system" fn(u16) -> u32),
+                    link_name,
+                    abi,
+                    args,
+                )?;
+                // Miri does not model processor groups, so report every CPU.
+                this.write_scalar(Scalar::from_u32(this.machine.num_cpus), dest)?;
+            }
+            "GetProcessGroupAffinity" => {
+                // FIXME: This does not have a direct test (#3179).
+                let [_handle, group_count, _group_array] = this.check_shim_sig(
+                    shim_sig!(extern "system" fn(winapi::HANDLE, *mut _, *mut _) -> winapi::BOOL),
+                    link_name,
+                    abi,
+                    args,
+                )?;
+                // Report more than one group so `available_parallelism` takes the
+                // `GetActiveProcessorCount(ALL_PROCESSOR_GROUPS)` path; a single-group
+                // affinity mask cannot hold the up-to-1024 CPUs the num-cpus test uses.
+                let group_count = this.deref_pointer_as(group_count, this.machine.layouts.u16)?;
+                this.write_scalar(Scalar::from_u16(2), &group_count)?;
+                this.write_scalar(Scalar::from_i32(1), dest)?; // TRUE
+            }
 
             // Thread-local storage
             "TlsAlloc" => {


### PR DESCRIPTION
`available_parallelism` calls `GetSystemInfo`, which only reports the process's primary processor group, so a 128-CPU Windows machine looks like 64.

[Since Windows 11 and Server 2022](https://learn.microsoft.com/en-us/windows/win32/procthread/processor-groups) a process can run on every group by default, but before that it could only use one, so always calling `GetActiveProcessorCount(ALL_PROCESSOR_GROUPS)` would overcount there.

[`GetProcessGroupAffinity`](https://learn.microsoft.com/en-us/windows/win32/api/processtopologyapi/nf-processtopologyapi-getprocessgroupaffinity) tells the two apart with no version check, and exists since Windows 7. If the process is in more than one group, count all of them; otherwise keep `GetSystemInfo`, which stays correct on Windows 10. rust-lang/rust#114856 proposed the same call without the gate.

On a machine with three or more groups, a process that runs on some but not all of them now gets the system total, an overcount, where before it was an undercount. Counting only the CPUs a process is allowed to use is rust-lang/rust#143709.

Miri doesn't model processor groups, so both calls get std-only shims: `GetProcessGroupAffinity` reports two groups, `GetActiveProcessorCount` returns `num_cpus`. The `-Zmiri-num-cpus=1024` test then hits the multi-group branch. The >64-CPU path needs real hardware, so nothing covers it here.

Two things I'm unsure about:

- I use `ALL_PROCESSOR_GROUPS` instead of adding up `GetActiveProcessorCount` for each group the process is in. That would avoid the overcount above, at the cost of a buffer and a loop, and it still wouldn't handle affinity inside a group. Happy to do it that way if you prefer.
- I ignore the return value, assuming any failure other than `ERROR_INSUFFICIENT_BUFFER` leaves `group_count` at 1. Docs don't say what happens to it when the call fails for any other reason, so I'm not sure that's safe?

Fixes rust-lang/rust#152389





