### PR TITLE
Consider `()` as suspicious only when expecting `!` for runtime symbols

### DIFF
--- a/compiler/rustc_lint/src/runtime_symbols.rs
+++ b/compiler/rustc_lint/src/runtime_symbols.rs
@@ -227,11 +227,16 @@ fn check<'tcx>(
         let expected = Ty::new_fn_ptr(cx.tcx, lang_sig);
         let actual = Ty::new_fn_ptr(cx.tcx, user_sig);
 
+        // ! is ABI compatible with ()
+        // https://github.com/rust-lang/rust/issues/159446
+        let lang_ret_incompatible_with_unit = !lang_sig.output().skip_binder().is_unit()
+            && !lang_sig.output().skip_binder().is_never();
+        let user_sig_ret_is_unit = user_sig.output().skip_binder().is_unit();
+
         if lang_sig.abi() != user_sig.abi()
             || lang_sig.c_variadic() != user_sig.c_variadic()
             || lang_sig.inputs().skip_binder().len() != user_sig.inputs().skip_binder().len()
-            || (!lang_sig.output().skip_binder().is_unit()
-                && user_sig.output().skip_binder().is_unit())
+            || (lang_ret_incompatible_with_unit && user_sig_ret_is_unit)
         {
             cx.emit_span_lint(
                 INVALID_RUNTIME_SYMBOL_DEFINITIONS,

--- a/tests/ui/lint/runtime-symbols-unix.rs
+++ b/tests/ui/lint/runtime-symbols-unix.rs
@@ -57,6 +57,18 @@ fn suspicious() {
         pub static exit2: Option<unsafe extern "C" fn(f32) -> !>;
         //~^ WARN suspicious definition of the runtime `exit` symbol
     }
+
+    extern "C" {
+        #[link_name = "exit"]
+        pub fn exit3(code: i32) -> i32;
+        //~^ WARN suspicious definition of the runtime `exit` symbol
+
+        // ! is ABI compatible with ()
+        // https://github.com/rust-lang/rust/issues/159446
+        #[link_name = "exit"]
+        pub fn exit4(code: i32);
+        //~^ WARN suspicious definition of the runtime `exit` symbol
+    }
 }
 
 fn main() {}

--- a/tests/ui/lint/runtime-symbols-unix.stderr
+++ b/tests/ui/lint/runtime-symbols-unix.stderr
@@ -124,5 +124,27 @@ LL |         pub static exit2: Option<unsafe extern "C" fn(f32) -> !>;
    = help: either fix the signature or remove any attributes like `#[unsafe(no_mangle)]`, `#[unsafe(export_name = "exit")]`, or `#[link_name = "exit"]`
    = help: allow this lint if the signature is compatible
 
-error: aborting due to 8 previous errors; 4 warnings emitted
+warning: suspicious definition of the runtime `exit` symbol used by the standard library
+  --> $DIR/runtime-symbols-unix.rs:63:9
+   |
+LL |         pub fn exit3(code: i32) -> i32;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: expected `unsafe extern "C" fn(i32) -> !`
+           found    `unsafe extern "C" fn(i32) -> i32`
+   = help: either fix the signature or remove any attributes like `#[unsafe(no_mangle)]`, `#[unsafe(export_name = "exit")]`, or `#[link_name = "exit"]`
+   = help: allow this lint if the signature is compatible
+
+warning: suspicious definition of the runtime `exit` symbol used by the standard library
+  --> $DIR/runtime-symbols-unix.rs:69:9
+   |
+LL |         pub fn exit4(code: i32);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: expected `unsafe extern "C" fn(i32) -> !`
+           found    `unsafe extern "C" fn(i32)`
+   = help: either fix the signature or remove any attributes like `#[unsafe(no_mangle)]`, `#[unsafe(export_name = "exit")]`, or `#[link_name = "exit"]`
+   = help: allow this lint if the signature is compatible
+
+error: aborting due to 8 previous errors; 6 warnings emitted
 


### PR DESCRIPTION
Consider `()` as suspicious only when expecting `!` for runtime symbols, as `!` is considered ABI compatible in Rust with `()` (https://github.com/rust-lang/rust/issues/159446#issuecomment-5007167464).

Fixes rust-lang/rust#159446