### PR TITLE
Suggest `Vec<T>` instead of `[T]`

### DIFF
--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -4317,7 +4317,7 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
                             "instead, you are more likely to want"
                         };
                         let mut owned_sugg = lt.kind == MissingLifetimeKind::Ampersand;
-                        let mut sugg_is_str_to_string = false;
+                        let mut sugg_slice_to_vec_or_string = false;
                         let mut sugg = vec![(lt.span, String::new())];
                         if let Some((kind, _span)) = self.diag_metadata.current_function
                             && let FnKind::Fn(_, _, ast::Fn { sig, .. }) = kind
@@ -4362,7 +4362,7 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
                                                         lt.span.with_hi(ty.span.hi()),
                                                         "String".to_string(),
                                                     )];
-                                                    sugg_is_str_to_string = true;
+                                                    sugg_slice_to_vec_or_string = true;
                                                 }
                                                 Some(Res::PrimTy(..)) => {}
                                                 Some(Res::Def(
@@ -4389,7 +4389,7 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
                                                         lt.span.with_hi(ty.span.hi()),
                                                         "String".to_string(),
                                                     )];
-                                                    sugg_is_str_to_string = true;
+                                                    sugg_slice_to_vec_or_string = true;
                                                 }
                                                 Res::PrimTy(..) => {}
                                                 Res::Def(
@@ -4420,13 +4420,15 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
                                         (lt.span.with_hi(inner_ty.span.lo()), "Vec<".to_string()),
                                         (ty.span.with_lo(inner_ty.span.hi()), ">".to_string()),
                                     ];
+                                    sugg_slice_to_vec_or_string = true;
                                 }
                             }
                         }
                         if owned_sugg {
+                            // Suggest to remove the ref prefix (usually an &) from the return type.
                             if let Some(span) =
                                 self.find_ref_prefix_span_for_owned_suggestion(lt.span)
-                                && !sugg_is_str_to_string
+                                && !sugg_slice_to_vec_or_string
                             {
                                 sugg = vec![(span, String::new())];
                             }

--- a/tests/ui/resolve/suggestions/suggest-vec-not-slice.rs
+++ b/tests/ui/resolve/suggestions/suggest-vec-not-slice.rs
@@ -1,0 +1,9 @@
+// Suggest `Vec<T>`, not `[T]` (#159491).
+fn values() -> &[i32] {
+    //~^ ERROR [E0106]
+    //~| SUGGESTION Vec<
+    //~| SUGGESTION 'static
+    let values = vec![1, 2];
+    &values
+}
+fn main(){}

--- a/tests/ui/resolve/suggestions/suggest-vec-not-slice.stderr
+++ b/tests/ui/resolve/suggestions/suggest-vec-not-slice.stderr
@@ -1,0 +1,20 @@
+error[E0106]: missing lifetime specifier
+  --> $DIR/suggest-vec-not-slice.rs:2:16
+   |
+LL | fn values() -> &[i32] {
+   |                ^ expected named lifetime parameter
+   |
+   = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
+help: consider using the `'static` lifetime, but this is uncommon unless you're returning a borrowed value from a `const` or a `static`
+   |
+LL | fn values() -> &'static [i32] {
+   |                 +++++++
+help: instead, you are more likely to want to return an owned value
+   |
+LL - fn values() -> &[i32] {
+LL + fn values() -> Vec<i32> {
+   |
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0106`.


### PR DESCRIPTION
Fixes rust-lang/rust#159491

Looks like a regression introduced by:rust-lang/rust#151530