### PR TITLE
Apply `#[diagnostic::opaque]` to macros expanding to built-in syntax

### DIFF
--- a/library/core/src/field.rs
+++ b/library/core/src/field.rs
@@ -128,6 +128,7 @@ impl<T: ?Sized, const VARIANT: u32, const FIELD: u32> Ord
 #[diagnostic::on_unmatched_args(
     note = "this macro expects a container type and a field path, like `field_of!(Type, field)` or `field_of!(Enum, Variant.field)`"
 )]
+#[diagnostic::opaque]
 // NOTE: when stabilizing this macro, we can never add new trait impls for `FieldRepresentingType`,
 // since it is `#[fundamental]` and thus could break users of this macro, since the compiler expands
 // it to `FieldRepresentingType<...>`. Thus stabilizing this requires careful thought about the

--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -1913,7 +1913,7 @@ pub(crate) mod builtin {
         issue = "23416",
         reason = "placeholder syntax for type ascription"
     )]
-    #[rustfmt::skip]
+    #[diagnostic::opaque]
     pub macro type_ascribe($expr:expr, $ty:ty) {
         builtin # type_ascribe($expr, $ty)
     }
@@ -1925,6 +1925,7 @@ pub(crate) mod builtin {
         issue = "87121",
         reason = "placeholder syntax for deref patterns"
     )]
+    #[diagnostic::opaque]
     pub macro deref($pat:pat) {
         builtin # deref($pat)
     }

--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -1651,9 +1651,9 @@ impl<T> SizedTypeProperties for T {}
 )]
 #[doc(alias = "memoffset")]
 #[allow_internal_unstable(builtin_syntax, core_intrinsics)]
+#[diagnostic::opaque]
 pub macro offset_of($Container:ty, $($fields:expr)+ $(,)?) {
-    // The `{}` is for better error messages
-    const {builtin # offset_of($Container, $($fields)+)}
+    const { builtin # offset_of($Container, $($fields)+) }
 }
 
 /// Create a fresh instance of the inhabited ZST type `T`.

--- a/library/core/src/unsafe_binder.rs
+++ b/library/core/src/unsafe_binder.rs
@@ -3,6 +3,7 @@
 /// Unwrap an unsafe binder into its underlying type.
 #[allow_internal_unstable(builtin_syntax)]
 #[unstable(feature = "unsafe_binders", issue = "130516")]
+#[diagnostic::opaque]
 pub macro unwrap_binder {
     ($expr:expr) => {
         builtin # unwrap_binder ( $expr )
@@ -15,6 +16,7 @@ pub macro unwrap_binder {
 /// Wrap a type into an unsafe binder.
 #[allow_internal_unstable(builtin_syntax)]
 #[unstable(feature = "unsafe_binders", issue = "130516")]
+#[diagnostic::opaque]
 pub macro wrap_binder {
     ($expr:expr) => {
         builtin # wrap_binder ( $expr )

--- a/tests/ui/feature-gates/feature-gate-offset-of-slice.stderr
+++ b/tests/ui/feature-gates/feature-gate-offset-of-slice.stderr
@@ -5,7 +5,6 @@ LL |     offset_of!(S, c);
    |     ^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[i32]`
-   = note: this error originates in the macro `offset_of` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[i32]` cannot be known at compilation time
   --> $DIR/feature-gate-offset-of-slice.rs:21:5
@@ -19,7 +18,6 @@ note: required because it appears within the type `S`
    |
 LL | struct S {
    |        ^
-   = note: this error originates in the macro `offset_of` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[i32]` cannot be known at compilation time
   --> $DIR/feature-gate-offset-of-slice.rs:25:5
@@ -28,7 +26,6 @@ LL |     offset_of!(Tup, 1);
    |     ^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[i32]`
-   = note: this error originates in the macro `offset_of` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/field_representing_types/invalid.next.stderr
+++ b/tests/ui/field_representing_types/invalid.next.stderr
@@ -41,8 +41,6 @@ LL |     let _: field_of!(Enum, Variant..field);
    |            |
    |            in this macro invocation
    |            this macro call doesn't expand to a type
-   |
-   = note: this error originates in the macro `field_of` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: offset_of expects dot-separated field and variant names
   --> $DIR/invalid.rs:29:30
@@ -58,8 +56,6 @@ LL |     let _: field_of!(Struct, [42]);
    |            |
    |            in this macro invocation
    |            this macro call doesn't expand to a type
-   |
-   = note: this error originates in the macro `field_of` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `field_of!` only supports a single field or a variant with a field
   --> $DIR/invalid.rs:31:30

--- a/tests/ui/field_representing_types/invalid.old.stderr
+++ b/tests/ui/field_representing_types/invalid.old.stderr
@@ -41,8 +41,6 @@ LL |     let _: field_of!(Enum, Variant..field);
    |            |
    |            in this macro invocation
    |            this macro call doesn't expand to a type
-   |
-   = note: this error originates in the macro `field_of` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: offset_of expects dot-separated field and variant names
   --> $DIR/invalid.rs:29:30
@@ -58,8 +56,6 @@ LL |     let _: field_of!(Struct, [42]);
    |            |
    |            in this macro invocation
    |            this macro call doesn't expand to a type
-   |
-   = note: this error originates in the macro `field_of` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `field_of!` only supports a single field or a variant with a field
   --> $DIR/invalid.rs:31:30

--- a/tests/ui/field_representing_types/weird-impls.next.stderr
+++ b/tests/ui/field_representing_types/weird-impls.next.stderr
@@ -3,8 +3,6 @@ error[E0120]: the `Drop` trait may only be implemented for local structs, enums,
    |
 LL | impl Drop for field_of!(MyStruct, 0) {
    |               ^^^^^^^^^^^^^^^^^^^^^^ must be a struct, enum, or union in the current crate
-   |
-   = note: this error originates in the macro `field_of` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0321]: cross-crate traits with a default impl, like `Send`, can only be implemented for a struct/enum type defined in the current crate
   --> $DIR/weird-impls.rs:15:1

--- a/tests/ui/field_representing_types/weird-impls.old.stderr
+++ b/tests/ui/field_representing_types/weird-impls.old.stderr
@@ -3,8 +3,6 @@ error[E0120]: the `Drop` trait may only be implemented for local structs, enums,
    |
 LL | impl Drop for field_of!(MyStruct, 0) {
    |               ^^^^^^^^^^^^^^^^^^^^^^ must be a struct, enum, or union in the current crate
-   |
-   = note: this error originates in the macro `field_of` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0321]: cross-crate traits with a default impl, like `Send`, can only be implemented for a struct/enum type defined in the current crate
   --> $DIR/weird-impls.rs:15:1

--- a/tests/ui/offset-of/inside-array-length.stderr
+++ b/tests/ui/offset-of/inside-array-length.stderr
@@ -6,7 +6,6 @@ LL | fn foo<'a, T: 'a>(_: [(); std::mem::offset_of!((T,), 0)]) {}
    |
    = help: consider moving this anonymous constant into a `const` function
    = note: this operation may be supported in the future
-   = note: this error originates in the macro `std::mem::offset_of` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0392]: type parameter `T` is never used
   --> $DIR/inside-array-length.rs:13:15
@@ -25,7 +24,6 @@ LL |     [(); std::mem::offset_of!((T,), 0)]:,
    |
    = help: consider moving this anonymous constant into a `const` function
    = note: this operation may be supported in the future
-   = note: this error originates in the macro `std::mem::offset_of` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0391]: cycle detected when evaluating type-level constant
   --> $DIR/inside-array-length.rs:9:27
@@ -41,7 +39,6 @@ LL | fn foo<'a, T: 'a>(_: [(); std::mem::offset_of!((T,), 0)]) {}
    = note: ...which again requires evaluating type-level constant, completing the cycle
    = note: cycle used when normalizing `inside_array_length::::foo::{constant#0}`
    = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
-   = note: this error originates in the macro `std::mem::offset_of` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `dyn Trait` cannot be known at compilation time
   --> $DIR/inside-array-length.rs:21:14

--- a/tests/ui/offset-of/offset-of-dst-field.stderr
+++ b/tests/ui/offset-of/offset-of-dst-field.stderr
@@ -5,7 +5,6 @@ LL |     offset_of!(Alpha, z);
    |     ^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-   = note: this error originates in the macro `offset_of` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `(dyn Trait + 'static)` cannot be known at compilation time
   --> $DIR/offset-of-dst-field.rs:38:5
@@ -14,7 +13,6 @@ LL |     offset_of!(Beta, z);
    |     ^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `(dyn Trait + 'static)`
-   = note: this error originates in the macro `offset_of` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `Extern` cannot be known at compilation time
   --> $DIR/offset-of-dst-field.rs:39:5
@@ -23,7 +21,6 @@ LL |     offset_of!(Gamma, z);
    |     ^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `Extern`
-   = note: this error originates in the macro `offset_of` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `dyn Trait` cannot be known at compilation time
   --> $DIR/offset-of-dst-field.rs:41:5
@@ -32,7 +29,6 @@ LL |     offset_of!((u8, dyn Trait), 1);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `dyn Trait`
-   = note: this error originates in the macro `offset_of` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `Extern` cannot be known at compilation time
   --> $DIR/offset-of-dst-field.rs:46:5
@@ -41,7 +37,6 @@ LL |     offset_of!(Delta<Extern>, z);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `Extern`
-   = note: this error originates in the macro `offset_of` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `dyn Trait` cannot be known at compilation time
   --> $DIR/offset-of-dst-field.rs:47:5
@@ -50,7 +45,6 @@ LL |     offset_of!(Delta<dyn Trait>, z);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `dyn Trait`
-   = note: this error originates in the macro `offset_of` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> $DIR/offset-of-dst-field.rs:45:5
@@ -64,7 +58,6 @@ note: required because it appears within the type `Alpha`
    |
 LL | struct Alpha {
    |        ^^^^^
-   = note: this error originates in the macro `offset_of` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `T` cannot be known at compilation time
   --> $DIR/offset-of-dst-field.rs:51:5
@@ -74,7 +67,6 @@ LL | fn generic_with_maybe_sized<T: ?Sized>() -> usize {
 LL |     offset_of!(Delta<T>, z)
    |     ^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = note: this error originates in the macro `offset_of` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - fn generic_with_maybe_sized<T: ?Sized>() -> usize {

--- a/tests/ui/offset-of/offset-of-must-use.stderr
+++ b/tests/ui/offset-of/offset-of-must-use.stderr
@@ -10,7 +10,6 @@ note: the lint level is defined here
 LL | #![warn(unused)]
    |         ^^^^^^
    = note: `#[warn(unused_must_use)]` implied by `#[warn(unused)]`
-   = note: this warning originates in the macro `core::mem::offset_of` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: 1 warning emitted
 

--- a/tests/ui/offset-of/offset-of-output-type.stderr
+++ b/tests/ui/offset-of/offset-of-output-type.stderr
@@ -3,48 +3,36 @@ error[E0308]: mismatched types
    |
 LL |     let _: u8 = offset_of!(S, v);
    |                 ^^^^^^^^^^^^^^^^ expected `u8`, found `usize`
-   |
-   = note: this error originates in the macro `offset_of` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types
   --> $DIR/offset-of-output-type.rs:11:18
    |
 LL |     let _: u16 = offset_of!(S, v);
    |                  ^^^^^^^^^^^^^^^^ expected `u16`, found `usize`
-   |
-   = note: this error originates in the macro `offset_of` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types
   --> $DIR/offset-of-output-type.rs:12:18
    |
 LL |     let _: u32 = offset_of!(S, v);
    |                  ^^^^^^^^^^^^^^^^ expected `u32`, found `usize`
-   |
-   = note: this error originates in the macro `offset_of` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types
   --> $DIR/offset-of-output-type.rs:13:18
    |
 LL |     let _: u64 = offset_of!(S, v);
    |                  ^^^^^^^^^^^^^^^^ expected `u64`, found `usize`
-   |
-   = note: this error originates in the macro `offset_of` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types
   --> $DIR/offset-of-output-type.rs:14:20
    |
 LL |     let _: isize = offset_of!(S, v);
    |                    ^^^^^^^^^^^^^^^^ expected `isize`, found `usize`
-   |
-   = note: this error originates in the macro `offset_of` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types
   --> $DIR/offset-of-output-type.rs:17:5
    |
 LL |     offset_of!(S, v)
    |     ^^^^^^^^^^^^^^^^ expected `()`, found `usize`
-   |
-   = note: this error originates in the macro `offset_of` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/offset-of/offset-of-unstable.stderr
+++ b/tests/ui/offset-of/offset-of-unstable.stderr
@@ -37,7 +37,6 @@ LL | |     );
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-   = note: this error originates in the macro `offset_of` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/offset-of-unstable.rs:16:5
@@ -47,7 +46,6 @@ LL |     offset_of!(StableWithUnstableField, unstable);
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-   = note: this error originates in the macro `offset_of` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/offset-of-unstable.rs:18:5
@@ -57,7 +55,6 @@ LL |     offset_of!(StableWithUnstableFieldType, stable.unstable);
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-   = note: this error originates in the macro `offset_of` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/offset-of-unstable.rs:19:5
@@ -71,7 +68,6 @@ LL | |     );
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-   = note: this error originates in the macro `offset_of` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/offset-of-unstable.rs:24:5
@@ -85,7 +81,6 @@ LL | |     );
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-   = note: this error originates in the macro `offset_of` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/pattern/deref-patterns/ref-mut.stderr
+++ b/tests/ui/pattern/deref-patterns/ref-mut.stderr
@@ -3,8 +3,6 @@ error[E0277]: the trait bound `Rc<{integer}>: DerefMut` is not satisfied
    |
 LL |         deref!(x) => {}
    |         ^^^^^^^^^ the trait `DerefMut` is not implemented for `Rc<{integer}>`
-   |
-   = note: this error originates in the macro `deref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Rc<({integer},)>: DerefMut` is not satisfied
   --> $DIR/ref-mut.rs:21:9

--- a/tests/ui/raw-ref-op/raw-ref-temp.stderr
+++ b/tests/ui/raw-ref-op/raw-ref-temp.stderr
@@ -75,32 +75,24 @@ error[E0745]: cannot take address of a temporary
    |
 LL |     let ref_ascribe = &raw const type_ascribe!(2, i32);
    |                                  ^^^^^^^^^^^^^^^^^^^^^ temporary value
-   |
-   = note: this error originates in the macro `type_ascribe` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0745]: cannot take address of a temporary
   --> $DIR/raw-ref-temp.rs:27:36
    |
 LL |     let mut_ref_ascribe = &raw mut type_ascribe!(3, i32);
    |                                    ^^^^^^^^^^^^^^^^^^^^^ temporary value
-   |
-   = note: this error originates in the macro `type_ascribe` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0745]: cannot take address of a temporary
   --> $DIR/raw-ref-temp.rs:29:40
    |
 LL |     let ascribe_field_ref = &raw const type_ascribe!(PAIR.0, i32);
    |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^ temporary value
-   |
-   = note: this error originates in the macro `type_ascribe` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0745]: cannot take address of a temporary
   --> $DIR/raw-ref-temp.rs:30:38
    |
 LL |     let ascribe_index_ref = &raw mut type_ascribe!(ARRAY[0], i32);
    |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ temporary value
-   |
-   = note: this error originates in the macro `type_ascribe` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 16 previous errors
 

--- a/tests/ui/reachable/expr_type.stderr
+++ b/tests/ui/reachable/expr_type.stderr
@@ -12,7 +12,6 @@ note: the lint level is defined here
    |
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
-   = note: this error originates in the macro `type_ascribe` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/typeck/issue-91267.stderr
+++ b/tests/ui/typeck/issue-91267.stderr
@@ -17,8 +17,6 @@ LL | fn main() {
    |          - expected `()` because of default return type
 LL |     type_ascribe!(0, u8<e<5>=e>)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found `u8`
-   |
-   = note: this error originates in the macro `type_ascribe` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/unsafe-binders/mismatch.stderr
+++ b/tests/ui/unsafe-binders/mismatch.stderr
@@ -14,7 +14,6 @@ LL |     let _: i32 = wrap_binder!(&());
    |                  ^^^^^^^^^^^^^^^^^
    |
    = note: unsafe binders are the only valid output of wrap
-   = note: this error originates in the macro `wrap_binder` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: expected unsafe binder, found integer as input of `unwrap_binder!()`
   --> $DIR/mismatch.rs:17:20

--- a/tests/ui/unsafe-binders/moves.stderr
+++ b/tests/ui/unsafe-binders/moves.stderr
@@ -26,7 +26,6 @@ LL |         drop(unwrap_binder!(binder));
    |              ^^^^^^^^^^^^^^^^^^^^^^ value used here after move
    |
    = note: move occurs because `binder` has type `ManuallyDrop<NotCopyInner>`, which does not implement the `Copy` trait
-   = note: this error originates in the macro `unwrap_binder` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0382]: use of moved value: `binder.0`
   --> $DIR/moves.rs:35:14


### PR DESCRIPTION
For context, thin wrapper macros expanding to built-in syntax `builtin # SYNTAX(…)` (internal feature `builtin_syntax`) is an alternative to built-in macros (`#[rustc_builtin_macro]`) for introducing new syntax constructs that takes slightly less code to implement in the compiler (since one doesn't need to write boiler-plate expanders, see RUST-122806 for example).

However, one disadvantage of that approach is the fact that the thin wrapper macro is a normal macro and is thus considered "interesting" wrt. macro backtraces. The fact that it expands to `builtin # SYNTAX(…)` should be considered an implementation detail and thus these macros should be considered opaque.

I've applied `#[diagnostic::opaque]` (rust-lang/rust#158608) to all of these macros which successfully suppresses diagnostic notes of the form `` this error originates in the macro `SYNTAX` (…) ``. Well, it doesn't actually omit the expansion from the macro backtrace when `-Zmacro-backtrace` is passed which was surprising but seems intentional looking at the linked PR. Still, this is better than nothing.

r? @mejrs