### PR TITLE
Add nan2008 target feature for MIPS

### DIFF
--- a/compiler/rustc_target/src/target_features.rs
+++ b/compiler/rustc_target/src/target_features.rs
@@ -606,6 +606,7 @@ const MIPS_FEATURES: &[(&str, Stability, ImpliedFeatures)] = &[
     // tidy-alphabetical-start
     ("fp64", Unstable(sym::mips_target_feature), &[]),
     ("msa", Unstable(sym::mips_target_feature), &[]),
+    ("nan2008", Unstable(sym::mips_target_feature), &[]),
     ("virt", Unstable(sym::mips_target_feature), &[]),
     // tidy-alphabetical-end
 ];

--- a/tests/ui/check-cfg/target_feature.stderr
+++ b/tests/ui/check-cfg/target_feature.stderr
@@ -225,6 +225,7 @@ LL |     cfg!(target_feature = "_UNEXPECTED_VALUE");
 `mutable-globals`
 `mve`
 `mve.fp`
+`nan2008`
 `neon`
 `nnp-assist`
 `nontrapping-fptoint`


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/159526)*
<!-- homu-ignore:end -->

Adds `nan2008` to the allowed target features for MIPS, gated behind theexisting unstable `mips_target_feature` gate (tracking issue rust-lang/rust#150253), matching LLVM's `nan2008` subtarget feature (IEEE 754-2008 NaN encoding).

Previously, `-Ctarget-feature=+nan2008` produced `warning: unknown feature specified for '-Ctarget-feature': 'nan2008'` and the feature was silently ignored. Since the prebuilt `std` for MIPS targets is compiled with legacy NaN encoding, linking against libraries built with GCC's `-mnan=2008` failed with `ld: failed to merge target specific data` (mixing `-mnan=legacy` and `-mnan=2008` objects).

With this change, users can enable the feature (together with `-Zbuild-std` to rebuild `std` with matching NaN encoding) to link such libraries.

The feature name matches LLVM's directly, so no `to_llvm_features` mapping is needed. The `tests/ui/check-cfg/target_feature.rs` expected output was re-blessed.

Fixes rust-lang/rust#98999