### PR TITLE
Bring runtime symbols statics on par with foreign functions

### DIFF
--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -846,7 +846,7 @@ pub(crate) enum RedefiningRuntimeSymbolsDiag<'tcx> {
     #[help(
         "either fix the signature or remove any attributes like `#[unsafe(no_mangle)]`, `#[unsafe(export_name = \"{$symbol_name}\")]`, or `#[link_name = \"{$symbol_name}\"]`"
     )]
-    FnDefInvalid { symbol_name: String, expected_fn_sig: Ty<'tcx>, found_fn_sig: Ty<'tcx> },
+    Invalid { symbol_name: String, expected_fn_sig: Ty<'tcx>, found_fn_sig: Ty<'tcx> },
     #[diag(
         "suspicious definition of the runtime `{$symbol_name}` symbol used by the standard library"
     )]
@@ -858,18 +858,7 @@ pub(crate) enum RedefiningRuntimeSymbolsDiag<'tcx> {
         "either fix the signature or remove any attributes like `#[unsafe(no_mangle)]`, `#[unsafe(export_name = \"{$symbol_name}\")]`, or `#[link_name = \"{$symbol_name}\"]`"
     )]
     #[help("allow this lint if the signature is compatible")]
-    FnDefSuspicious { symbol_name: String, expected_fn_sig: Ty<'tcx>, found_fn_sig: Ty<'tcx> },
-    #[diag(
-        "invalid definition of the runtime `{$symbol_name}` symbol used by the standard library"
-    )]
-    #[note(
-        "expected `{$expected_fn_sig}`
-    found    `{$static_ty}`"
-    )]
-    #[help(
-        "either fix the signature or remove any attributes `#[unsafe(no_mangle)]` or `#[unsafe(export_name = \"{$symbol_name}\")]`"
-    )]
-    Static { symbol_name: String, static_ty: Ty<'tcx>, expected_fn_sig: Ty<'tcx> },
+    Suspicious { symbol_name: String, expected_fn_sig: Ty<'tcx>, found_fn_sig: Ty<'tcx> },
 }
 
 // drop_forget_useless.rs

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -864,7 +864,7 @@ pub(crate) enum RedefiningRuntimeSymbolsDiag<'tcx> {
     )]
     #[note(
         "expected `{$expected_fn_sig}`
-    found    `static {$symbol_name}: {$static_ty}`"
+    found    `{$static_ty}`"
     )]
     #[help(
         "either fix the signature or remove any attributes `#[unsafe(no_mangle)]` or `#[unsafe(export_name = \"{$symbol_name}\")]`"

--- a/compiler/rustc_lint/src/runtime_symbols.rs
+++ b/compiler/rustc_lint/src/runtime_symbols.rs
@@ -125,7 +125,10 @@ impl<'tcx> LateLintPass<'tcx> for RuntimeSymbols {
                             check_fn(cx, &symbol_name.name, fn_sig, did);
                         }
                         ForeignItemKind::Static(..) => {
-                            check_static(cx, &symbol_name.name, did, item.span);
+                            // We only check static with #[linkage = "..."] attribute (see std weak! macro)
+                            if cx.tcx.codegen_fn_attrs(did).import_linkage.is_some() {
+                                check_static(cx, &symbol_name.name, did, item.span);
+                            }
                         }
                         ForeignItemKind::Type => return,
                     }

--- a/compiler/rustc_lint/src/runtime_symbols.rs
+++ b/compiler/rustc_lint/src/runtime_symbols.rs
@@ -1,7 +1,7 @@
 use rustc_hir::def_id::LocalDefId;
 use rustc_hir::{self as hir, CanonicalSymbol, FnSig, ForeignItemKind};
 use rustc_infer::infer::DefineOpaqueTypes;
-use rustc_middle::ty::{self, Instance, Ty};
+use rustc_middle::ty::{self, Instance, PolyFnSig, Ty};
 use rustc_session::{declare_lint, declare_lint_pass};
 use rustc_span::{Span, Symbol};
 use rustc_trait_selection::infer::TyCtxtInferExt;
@@ -154,44 +154,7 @@ fn check_fn(cx: &LateContext<'_>, symbol_name: &str, sig: FnSig<'_>, did: LocalD
         .tcx
         .normalize_erasing_regions(cx.typing_env(), cx.tcx.fn_sig(did).instantiate_identity());
 
-    // Compare the two signatures with an inference context
-    let infcx = cx.tcx.infer_ctxt().build(cx.typing_mode());
-    let cause = rustc_middle::traits::ObligationCause::misc(sig.span, did);
-    let result = infcx.at(&cause, cx.param_env).eq(DefineOpaqueTypes::No, lang_sig, user_sig);
-
-    // If they don't match, emit our own mismatch signatures
-    if let Err(_terr) = result {
-        // Create fn pointers for diagnostics purpose
-        let expected = Ty::new_fn_ptr(cx.tcx, lang_sig);
-        let actual = Ty::new_fn_ptr(cx.tcx, user_sig);
-
-        if lang_sig.abi() != user_sig.abi()
-            || lang_sig.c_variadic() != user_sig.c_variadic()
-            || lang_sig.inputs().skip_binder().len() != user_sig.inputs().skip_binder().len()
-            || (!lang_sig.output().skip_binder().is_unit()
-                && user_sig.output().skip_binder().is_unit())
-        {
-            cx.emit_span_lint(
-                INVALID_RUNTIME_SYMBOL_DEFINITIONS,
-                sig.span,
-                RedefiningRuntimeSymbolsDiag::Invalid {
-                    symbol_name: symbol_name.to_string(),
-                    found_fn_sig: actual,
-                    expected_fn_sig: expected,
-                },
-            );
-        } else {
-            cx.emit_span_lint(
-                SUSPICIOUS_RUNTIME_SYMBOL_DEFINITIONS,
-                sig.span,
-                RedefiningRuntimeSymbolsDiag::Suspicious {
-                    symbol_name: symbol_name.to_string(),
-                    found_fn_sig: actual,
-                    expected_fn_sig: expected,
-                },
-            );
-        };
-    }
+    check(cx, symbol_name, did, sig.span, lang_sig, user_sig);
 }
 
 fn check_static<'tcx>(cx: &LateContext<'tcx>, symbol_name: &str, did: LocalDefId, sp: Span) {
@@ -238,24 +201,54 @@ fn check_static<'tcx>(cx: &LateContext<'tcx>, symbol_name: &str, did: LocalDefId
         return;
     };
 
+    // Compare the signatures and report a warning/error depending on the mismatch
+    check(cx, symbol_name, did, sp, lang_sig, user_sig);
+}
+
+fn check<'tcx>(
+    cx: &LateContext<'tcx>,
+    symbol_name: &str,
+    did: LocalDefId,
+    sp: Span,
+    lang_sig: PolyFnSig<'tcx>,
+    user_sig: PolyFnSig<'tcx>,
+) {
     // Compare the two signatures with an inference context
     let infcx = cx.tcx.infer_ctxt().build(cx.typing_mode());
     let cause = rustc_middle::traits::ObligationCause::misc(sp, did);
     let result = infcx.at(&cause, cx.param_env).eq(DefineOpaqueTypes::No, lang_sig, user_sig);
 
-    // Compare the expected function signature with the static type, report an error if they don't match
+    // If they don't match, emit our own mismatch signatures
     if result.is_err() {
-        let user_sig = Ty::new_fn_ptr(cx.tcx, user_sig);
-        let lang_sig = Ty::new_fn_ptr(cx.tcx, lang_sig);
+        // Create fn pointers for diagnostics purpose
+        let expected = Ty::new_fn_ptr(cx.tcx, lang_sig);
+        let actual = Ty::new_fn_ptr(cx.tcx, user_sig);
 
-        cx.emit_span_lint(
-            INVALID_RUNTIME_SYMBOL_DEFINITIONS,
-            sp,
-            RedefiningRuntimeSymbolsDiag::Invalid {
-                symbol_name: symbol_name.to_string(),
-                found_fn_sig: user_sig,
-                expected_fn_sig: lang_sig,
-            },
-        );
+        if lang_sig.abi() != user_sig.abi()
+            || lang_sig.c_variadic() != user_sig.c_variadic()
+            || lang_sig.inputs().skip_binder().len() != user_sig.inputs().skip_binder().len()
+            || (!lang_sig.output().skip_binder().is_unit()
+                && user_sig.output().skip_binder().is_unit())
+        {
+            cx.emit_span_lint(
+                INVALID_RUNTIME_SYMBOL_DEFINITIONS,
+                sp,
+                RedefiningRuntimeSymbolsDiag::Invalid {
+                    symbol_name: symbol_name.to_string(),
+                    found_fn_sig: actual,
+                    expected_fn_sig: expected,
+                },
+            );
+        } else {
+            cx.emit_span_lint(
+                SUSPICIOUS_RUNTIME_SYMBOL_DEFINITIONS,
+                sp,
+                RedefiningRuntimeSymbolsDiag::Suspicious {
+                    symbol_name: symbol_name.to_string(),
+                    found_fn_sig: actual,
+                    expected_fn_sig: expected,
+                },
+            );
+        };
     }
 }

--- a/compiler/rustc_lint/src/runtime_symbols.rs
+++ b/compiler/rustc_lint/src/runtime_symbols.rs
@@ -174,7 +174,7 @@ fn check_fn(cx: &LateContext<'_>, symbol_name: &str, sig: FnSig<'_>, did: LocalD
             cx.emit_span_lint(
                 INVALID_RUNTIME_SYMBOL_DEFINITIONS,
                 sig.span,
-                RedefiningRuntimeSymbolsDiag::FnDefInvalid {
+                RedefiningRuntimeSymbolsDiag::Invalid {
                     symbol_name: symbol_name.to_string(),
                     found_fn_sig: actual,
                     expected_fn_sig: expected,
@@ -184,7 +184,7 @@ fn check_fn(cx: &LateContext<'_>, symbol_name: &str, sig: FnSig<'_>, did: LocalD
             cx.emit_span_lint(
                 SUSPICIOUS_RUNTIME_SYMBOL_DEFINITIONS,
                 sig.span,
-                RedefiningRuntimeSymbolsDiag::FnDefSuspicious {
+                RedefiningRuntimeSymbolsDiag::Suspicious {
                     symbol_name: symbol_name.to_string(),
                     found_fn_sig: actual,
                     expected_fn_sig: expected,
@@ -229,9 +229,9 @@ fn check_static<'tcx>(cx: &LateContext<'tcx>, symbol_name: &str, did: LocalDefId
         cx.emit_span_lint(
             INVALID_RUNTIME_SYMBOL_DEFINITIONS,
             sp,
-            RedefiningRuntimeSymbolsDiag::Static {
-                static_ty: user_sig,
+            RedefiningRuntimeSymbolsDiag::Invalid {
                 symbol_name: symbol_name.to_string(),
+                found_fn_sig: user_sig,
                 expected_fn_sig: lang_sig,
             },
         );
@@ -251,9 +251,9 @@ fn check_static<'tcx>(cx: &LateContext<'tcx>, symbol_name: &str, did: LocalDefId
         cx.emit_span_lint(
             INVALID_RUNTIME_SYMBOL_DEFINITIONS,
             sp,
-            RedefiningRuntimeSymbolsDiag::Static {
-                static_ty: user_sig,
+            RedefiningRuntimeSymbolsDiag::Invalid {
                 symbol_name: symbol_name.to_string(),
+                found_fn_sig: user_sig,
                 expected_fn_sig: lang_sig,
             },
         );

--- a/compiler/rustc_lint/src/runtime_symbols.rs
+++ b/compiler/rustc_lint/src/runtime_symbols.rs
@@ -203,34 +203,58 @@ fn check_static<'tcx>(cx: &LateContext<'tcx>, symbol_name: &str, did: LocalDefId
         return;
     };
 
-    // Get the static type
-    let static_ty = cx.tcx.type_of(did).instantiate_identity().skip_norm_wip();
-
-    // Peel Option<...> and get the inner type (see std weak! macro with #[linkage = "extern_weak"])
-    let inner_static_ty: Ty<'_> = match static_ty.kind() {
-        ty::Adt(def, args) if Some(def.did()) == cx.tcx.lang_items().option_type() => {
-            args.type_at(0)
-        }
-        _ => static_ty,
-    };
-
     // Get the expected symbol function signature
     let lang_sig = cx.tcx.normalize_erasing_regions(
         cx.typing_env(),
         cx.tcx.fn_sig(expected_def_id).instantiate_identity(),
     );
 
-    let expected = Ty::new_fn_ptr(cx.tcx, lang_sig);
+    // Get the static type
+    let outer_user_sig = cx.tcx.type_of(did).instantiate_identity().skip_norm_wip();
 
-    // Compare the expected function signature with the static type, report an error if they don't match
-    if expected != inner_static_ty {
+    // Peel Option<...> and get the inner type (see std weak! macro with #[linkage = "extern_weak"])
+    let user_sig: Ty<'_> = match outer_user_sig.kind() {
+        ty::Adt(def, args) if Some(def.did()) == cx.tcx.lang_items().option_type() => {
+            args.type_at(0)
+        }
+        _ => outer_user_sig,
+    };
+
+    let user_sig = if let ty::FnPtr(sig_tys, hdr) = user_sig.kind() {
+        sig_tys.with(*hdr)
+    } else {
+        // not a function pointer, report an error
+
+        let lang_sig = Ty::new_fn_ptr(cx.tcx, lang_sig);
         cx.emit_span_lint(
             INVALID_RUNTIME_SYMBOL_DEFINITIONS,
             sp,
             RedefiningRuntimeSymbolsDiag::Static {
-                static_ty,
+                static_ty: user_sig,
                 symbol_name: symbol_name.to_string(),
-                expected_fn_sig: expected,
+                expected_fn_sig: lang_sig,
+            },
+        );
+        return;
+    };
+
+    // Compare the two signatures with an inference context
+    let infcx = cx.tcx.infer_ctxt().build(cx.typing_mode());
+    let cause = rustc_middle::traits::ObligationCause::misc(sp, did);
+    let result = infcx.at(&cause, cx.param_env).eq(DefineOpaqueTypes::No, lang_sig, user_sig);
+
+    // Compare the expected function signature with the static type, report an error if they don't match
+    if result.is_err() {
+        let user_sig = Ty::new_fn_ptr(cx.tcx, user_sig);
+        let lang_sig = Ty::new_fn_ptr(cx.tcx, lang_sig);
+
+        cx.emit_span_lint(
+            INVALID_RUNTIME_SYMBOL_DEFINITIONS,
+            sp,
+            RedefiningRuntimeSymbolsDiag::Static {
+                static_ty: user_sig,
+                symbol_name: symbol_name.to_string(),
+                expected_fn_sig: lang_sig,
             },
         );
     }

--- a/tests/ui/lint/runtime-symbols-unix.rs
+++ b/tests/ui/lint/runtime-symbols-unix.rs
@@ -51,6 +51,14 @@ fn suspicious() {
 
         pub fn exit(code: f32) -> !;
         //~^ WARN suspicious definition of the runtime `exit` symbol
+
+        #[link_name = "exit"]
+        pub static exit2: Option<unsafe extern "C" fn(f32) -> !>;
+        //~^ WARN suspicious definition of the runtime `exit` symbol
+
+        #[link_name = "exit"]
+        pub static exit3: unsafe extern "C" fn(f32) -> !;
+        //~^ WARN suspicious definition of the runtime `exit` symbol
     }
 }
 

--- a/tests/ui/lint/runtime-symbols-unix.rs
+++ b/tests/ui/lint/runtime-symbols-unix.rs
@@ -4,6 +4,7 @@
 //@ edition: 2021
 //@ normalize-stderr: "\*const [iu]8" -> "*const U8"
 
+#![feature(linkage)]
 #![feature(c_variadic)]
 #![allow(clashing_extern_declarations)] // we are voluntarily testing different definitions
 
@@ -53,11 +54,8 @@ fn suspicious() {
         //~^ WARN suspicious definition of the runtime `exit` symbol
 
         #[link_name = "exit"]
+        #[linkage = "weak"]
         pub static exit2: Option<unsafe extern "C" fn(f32) -> !>;
-        //~^ WARN suspicious definition of the runtime `exit` symbol
-
-        #[link_name = "exit"]
-        pub static exit3: unsafe extern "C" fn(f32) -> !;
         //~^ WARN suspicious definition of the runtime `exit` symbol
     }
 }

--- a/tests/ui/lint/runtime-symbols-unix.stderr
+++ b/tests/ui/lint/runtime-symbols-unix.stderr
@@ -113,5 +113,27 @@ LL |         pub fn exit(code: f32) -> !;
    = help: either fix the signature or remove any attributes like `#[unsafe(no_mangle)]`, `#[unsafe(export_name = "exit")]`, or `#[link_name = "exit"]`
    = help: allow this lint if the signature is compatible
 
-error: aborting due to 8 previous errors; 3 warnings emitted
+warning: suspicious definition of the runtime `exit` symbol used by the standard library
+  --> $DIR/runtime-symbols-unix.rs:56:9
+   |
+LL |         pub static exit2: Option<unsafe extern "C" fn(f32) -> !>;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: expected `unsafe extern "C" fn(i32) -> !`
+           found    `unsafe extern "C" fn(f32) -> !`
+   = help: either fix the signature or remove any attributes like `#[unsafe(no_mangle)]`, `#[unsafe(export_name = "exit")]`, or `#[link_name = "exit"]`
+   = help: allow this lint if the signature is compatible
+
+warning: suspicious definition of the runtime `exit` symbol used by the standard library
+  --> $DIR/runtime-symbols-unix.rs:60:9
+   |
+LL |         pub static exit3: unsafe extern "C" fn(f32) -> !;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: expected `unsafe extern "C" fn(i32) -> !`
+           found    `unsafe extern "C" fn(f32) -> !`
+   = help: either fix the signature or remove any attributes like `#[unsafe(no_mangle)]`, `#[unsafe(export_name = "exit")]`, or `#[link_name = "exit"]`
+   = help: allow this lint if the signature is compatible
+
+error: aborting due to 8 previous errors; 5 warnings emitted
 

--- a/tests/ui/lint/runtime-symbols-unix.stderr
+++ b/tests/ui/lint/runtime-symbols-unix.stderr
@@ -36,7 +36,7 @@ LL |     pub static close: () = ();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: expected `unsafe extern "C" fn(i32) -> i32`
-           found    `static close: ()`
+           found    `()`
    = help: either fix the signature or remove any attributes `#[unsafe(no_mangle)]` or `#[unsafe(export_name = "close")]`
 
 error: invalid definition of the runtime `malloc` symbol used by the standard library

--- a/tests/ui/lint/runtime-symbols-unix.stderr
+++ b/tests/ui/lint/runtime-symbols-unix.stderr
@@ -1,5 +1,5 @@
 error: invalid definition of the runtime `open` symbol used by the standard library
-  --> $DIR/runtime-symbols-unix.rs:14:5
+  --> $DIR/runtime-symbols-unix.rs:15:5
    |
 LL |     pub fn open() {}
    |     ^^^^^^^^^^^^^
@@ -10,7 +10,7 @@ LL |     pub fn open() {}
    = note: `#[deny(invalid_runtime_symbol_definitions)]` on by default
 
 error: invalid definition of the runtime `read` symbol used by the standard library
-  --> $DIR/runtime-symbols-unix.rs:18:9
+  --> $DIR/runtime-symbols-unix.rs:19:9
    |
 LL |         pub fn read();
    |         ^^^^^^^^^^^^^^
@@ -20,7 +20,7 @@ LL |         pub fn read();
    = help: either fix the signature or remove any attributes like `#[unsafe(no_mangle)]`, `#[unsafe(export_name = "read")]`, or `#[link_name = "read"]`
 
 error: invalid definition of the runtime `write` symbol used by the standard library
-  --> $DIR/runtime-symbols-unix.rs:21:9
+  --> $DIR/runtime-symbols-unix.rs:22:9
    |
 LL |         pub fn write();
    |         ^^^^^^^^^^^^^^^
@@ -30,7 +30,7 @@ LL |         pub fn write();
    = help: either fix the signature or remove any attributes like `#[unsafe(no_mangle)]`, `#[unsafe(export_name = "write")]`, or `#[link_name = "write"]`
 
 error: invalid definition of the runtime `close` symbol used by the standard library
-  --> $DIR/runtime-symbols-unix.rs:26:5
+  --> $DIR/runtime-symbols-unix.rs:27:5
    |
 LL |     pub static close: () = ();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -40,7 +40,7 @@ LL |     pub static close: () = ();
    = help: either fix the signature or remove any attributes like `#[unsafe(no_mangle)]`, `#[unsafe(export_name = "close")]`, or `#[link_name = "close"]`
 
 error: invalid definition of the runtime `malloc` symbol used by the standard library
-  --> $DIR/runtime-symbols-unix.rs:30:9
+  --> $DIR/runtime-symbols-unix.rs:31:9
    |
 LL |         pub fn malloc();
    |         ^^^^^^^^^^^^^^^^
@@ -50,7 +50,7 @@ LL |         pub fn malloc();
    = help: either fix the signature or remove any attributes like `#[unsafe(no_mangle)]`, `#[unsafe(export_name = "malloc")]`, or `#[link_name = "malloc"]`
 
 error: invalid definition of the runtime `realloc` symbol used by the standard library
-  --> $DIR/runtime-symbols-unix.rs:33:9
+  --> $DIR/runtime-symbols-unix.rs:34:9
    |
 LL |         pub fn realloc();
    |         ^^^^^^^^^^^^^^^^^
@@ -60,7 +60,7 @@ LL |         pub fn realloc();
    = help: either fix the signature or remove any attributes like `#[unsafe(no_mangle)]`, `#[unsafe(export_name = "realloc")]`, or `#[link_name = "realloc"]`
 
 error: invalid definition of the runtime `free` symbol used by the standard library
-  --> $DIR/runtime-symbols-unix.rs:36:9
+  --> $DIR/runtime-symbols-unix.rs:37:9
    |
 LL |         pub fn free();
    |         ^^^^^^^^^^^^^^
@@ -70,7 +70,7 @@ LL |         pub fn free();
    = help: either fix the signature or remove any attributes like `#[unsafe(no_mangle)]`, `#[unsafe(export_name = "free")]`, or `#[link_name = "free"]`
 
 error: invalid definition of the runtime `exit` symbol used by the standard library
-  --> $DIR/runtime-symbols-unix.rs:39:9
+  --> $DIR/runtime-symbols-unix.rs:40:9
    |
 LL |         pub fn exit();
    |         ^^^^^^^^^^^^^^
@@ -80,7 +80,7 @@ LL |         pub fn exit();
    = help: either fix the signature or remove any attributes like `#[unsafe(no_mangle)]`, `#[unsafe(export_name = "exit")]`, or `#[link_name = "exit"]`
 
 warning: suspicious definition of the runtime `open` symbol used by the standard library
-  --> $DIR/runtime-symbols-unix.rs:46:9
+  --> $DIR/runtime-symbols-unix.rs:47:9
    |
 LL |         pub fn open(path: *const U8, oflag: usize, ...) -> c_int;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -92,7 +92,7 @@ LL |         pub fn open(path: *const U8, oflag: usize, ...) -> c_int;
    = note: `#[warn(suspicious_runtime_symbol_definitions)]` on by default
 
 warning: suspicious definition of the runtime `free` symbol used by the standard library
-  --> $DIR/runtime-symbols-unix.rs:49:9
+  --> $DIR/runtime-symbols-unix.rs:50:9
    |
 LL |         pub fn free(ptr: *const U8);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -103,7 +103,7 @@ LL |         pub fn free(ptr: *const U8);
    = help: allow this lint if the signature is compatible
 
 warning: suspicious definition of the runtime `exit` symbol used by the standard library
-  --> $DIR/runtime-symbols-unix.rs:52:9
+  --> $DIR/runtime-symbols-unix.rs:53:9
    |
 LL |         pub fn exit(code: f32) -> !;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -114,7 +114,7 @@ LL |         pub fn exit(code: f32) -> !;
    = help: allow this lint if the signature is compatible
 
 warning: suspicious definition of the runtime `exit` symbol used by the standard library
-  --> $DIR/runtime-symbols-unix.rs:56:9
+  --> $DIR/runtime-symbols-unix.rs:58:9
    |
 LL |         pub static exit2: Option<unsafe extern "C" fn(f32) -> !>;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -124,16 +124,5 @@ LL |         pub static exit2: Option<unsafe extern "C" fn(f32) -> !>;
    = help: either fix the signature or remove any attributes like `#[unsafe(no_mangle)]`, `#[unsafe(export_name = "exit")]`, or `#[link_name = "exit"]`
    = help: allow this lint if the signature is compatible
 
-warning: suspicious definition of the runtime `exit` symbol used by the standard library
-  --> $DIR/runtime-symbols-unix.rs:60:9
-   |
-LL |         pub static exit3: unsafe extern "C" fn(f32) -> !;
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: expected `unsafe extern "C" fn(i32) -> !`
-           found    `unsafe extern "C" fn(f32) -> !`
-   = help: either fix the signature or remove any attributes like `#[unsafe(no_mangle)]`, `#[unsafe(export_name = "exit")]`, or `#[link_name = "exit"]`
-   = help: allow this lint if the signature is compatible
-
-error: aborting due to 8 previous errors; 5 warnings emitted
+error: aborting due to 8 previous errors; 4 warnings emitted
 

--- a/tests/ui/lint/runtime-symbols-unix.stderr
+++ b/tests/ui/lint/runtime-symbols-unix.stderr
@@ -37,7 +37,7 @@ LL |     pub static close: () = ();
    |
    = note: expected `unsafe extern "C" fn(i32) -> i32`
            found    `()`
-   = help: either fix the signature or remove any attributes `#[unsafe(no_mangle)]` or `#[unsafe(export_name = "close")]`
+   = help: either fix the signature or remove any attributes like `#[unsafe(no_mangle)]`, `#[unsafe(export_name = "close")]`, or `#[link_name = "close"]`
 
 error: invalid definition of the runtime `malloc` symbol used by the standard library
   --> $DIR/runtime-symbols-unix.rs:30:9

--- a/tests/ui/lint/runtime-symbols.rs
+++ b/tests/ui/lint/runtime-symbols.rs
@@ -25,6 +25,12 @@ fn invalid() {
     pub static strlen: () = ();
     //~^ ERROR invalid definition of the runtime `strlen` symbol
 
+    extern "C" {
+        #[link_name = "strlen"]
+        static strlen2: Option<unsafe extern "C" fn(s: *const c_char)>;
+        //~^ ERROR invalid definition of the runtime `strlen` symbol
+    }
+
     // ABI mismatch: Rust ABI instead of C ABI
     #[no_mangle]
     pub fn memcpy(dest: *mut c_void, src: *const c_void, n: usize) -> *mut c_void {

--- a/tests/ui/lint/runtime-symbols.rs
+++ b/tests/ui/lint/runtime-symbols.rs
@@ -3,6 +3,7 @@
 //@ edition: 2021
 //@ normalize-stderr: "\*const [iu]8" -> "*const U8"
 
+#![feature(linkage)]
 #![feature(c_variadic)]
 #![allow(clashing_extern_declarations)] // we are voluntarily testing different definitions
 
@@ -27,6 +28,7 @@ fn invalid() {
 
     extern "C" {
         #[link_name = "strlen"]
+        #[linkage = "weak"]
         static strlen2: Option<unsafe extern "C" fn(s: *const c_char)>;
         //~^ ERROR invalid definition of the runtime `strlen` symbol
     }
@@ -94,6 +96,7 @@ fn valid() {
 
         fn bcmp(s1: *const c_void, s2: *const c_void, n: usize) -> c_int;
 
+        #[linkage = "linkonce"]
         static strlen: Option<unsafe extern "C" fn(s: *const c_char) -> usize>;
     }
 }

--- a/tests/ui/lint/runtime-symbols.stderr
+++ b/tests/ui/lint/runtime-symbols.stderr
@@ -36,11 +36,21 @@ LL |     pub static strlen: () = ();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: expected `unsafe extern "C" fn(*const U8) -> usize`
-           found    `static strlen: ()`
+           found    `()`
+   = help: either fix the signature or remove any attributes `#[unsafe(no_mangle)]` or `#[unsafe(export_name = "strlen")]`
+
+error: invalid definition of the runtime `strlen` symbol used by the standard library
+  --> $DIR/runtime-symbols.rs:30:9
+   |
+LL |         static strlen2: Option<unsafe extern "C" fn(s: *const c_char)>;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: expected `unsafe extern "C" fn(*const U8) -> usize`
+           found    `unsafe extern "C" fn(*const U8)`
    = help: either fix the signature or remove any attributes `#[unsafe(no_mangle)]` or `#[unsafe(export_name = "strlen")]`
 
 error: invalid definition of the runtime `memcpy` symbol used by the standard library
-  --> $DIR/runtime-symbols.rs:30:5
+  --> $DIR/runtime-symbols.rs:36:5
    |
 LL |     pub fn memcpy(dest: *mut c_void, src: *const c_void, n: usize) -> *mut c_void {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -50,7 +60,7 @@ LL |     pub fn memcpy(dest: *mut c_void, src: *const c_void, n: usize) -> *mut 
    = help: either fix the signature or remove any attributes like `#[unsafe(no_mangle)]`, `#[unsafe(export_name = "memcpy")]`, or `#[link_name = "memcpy"]`
 
 error: invalid definition of the runtime `bcmp` symbol used by the standard library
-  --> $DIR/runtime-symbols.rs:37:5
+  --> $DIR/runtime-symbols.rs:43:5
    |
 LL |     pub unsafe extern "C" fn bcmp(s1: *const c_void, s2: *const c_void, n: usize, _: ...) -> c_int {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -60,7 +70,7 @@ LL |     pub unsafe extern "C" fn bcmp(s1: *const c_void, s2: *const c_void, n: 
    = help: either fix the signature or remove any attributes like `#[unsafe(no_mangle)]`, `#[unsafe(export_name = "bcmp")]`, or `#[link_name = "bcmp"]`
 
 error: invalid definition of the runtime `bcmp` symbol used by the standard library
-  --> $DIR/runtime-symbols.rs:44:5
+  --> $DIR/runtime-symbols.rs:50:5
    |
 LL |     pub extern "C" fn bcmp_(s1: *const c_void, s2: *const c_void, n: usize) {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -70,7 +80,7 @@ LL |     pub extern "C" fn bcmp_(s1: *const c_void, s2: *const c_void, n: usize)
    = help: either fix the signature or remove any attributes like `#[unsafe(no_mangle)]`, `#[unsafe(export_name = "bcmp")]`, or `#[link_name = "bcmp"]`
 
 warning: suspicious definition of the runtime `memcpy` symbol used by the standard library
-  --> $DIR/runtime-symbols.rs:50:5
+  --> $DIR/runtime-symbols.rs:56:5
    |
 LL |     pub extern "C" fn memcpy(dest: *mut c_void, src: *const c_void, n: i64) -> *mut c_void {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -82,7 +92,7 @@ LL |     pub extern "C" fn memcpy(dest: *mut c_void, src: *const c_void, n: i64)
    = note: `#[warn(suspicious_runtime_symbol_definitions)]` on by default
 
 warning: suspicious definition of the runtime `memmove` symbol used by the standard library
-  --> $DIR/runtime-symbols.rs:56:5
+  --> $DIR/runtime-symbols.rs:62:5
    |
 LL |     pub extern "C" fn memmove(dest: *mut c_void, src: *const c_void, n: i64) -> *mut c_void {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -93,7 +103,7 @@ LL |     pub extern "C" fn memmove(dest: *mut c_void, src: *const c_void, n: i64
    = help: allow this lint if the signature is compatible
 
 warning: suspicious definition of the runtime `memset` symbol used by the standard library
-  --> $DIR/runtime-symbols.rs:62:9
+  --> $DIR/runtime-symbols.rs:68:9
    |
 LL |         fn memset(s: *mut c_void, c: c_int, n: usize) -> f64;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -104,7 +114,7 @@ LL |         fn memset(s: *mut c_void, c: c_int, n: usize) -> f64;
    = help: allow this lint if the signature is compatible
 
 warning: suspicious definition of the runtime `bcmp` symbol used by the standard library
-  --> $DIR/runtime-symbols.rs:67:5
+  --> $DIR/runtime-symbols.rs:73:5
    |
 LL |     pub extern "C" fn bcmp_(s1: *const U8, s2: *const U8, n: usize) -> c_int {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -115,7 +125,7 @@ LL |     pub extern "C" fn bcmp_(s1: *const U8, s2: *const U8, n: usize) -> c_in
    = help: allow this lint if the signature is compatible
 
 warning: suspicious definition of the runtime `strlen` symbol used by the standard library
-  --> $DIR/runtime-symbols.rs:73:5
+  --> $DIR/runtime-symbols.rs:79:5
    |
 LL |     pub extern "C" fn strlen(s: *const u64) -> usize {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -125,5 +135,5 @@ LL |     pub extern "C" fn strlen(s: *const u64) -> usize {
    = help: either fix the signature or remove any attributes like `#[unsafe(no_mangle)]`, `#[unsafe(export_name = "strlen")]`, or `#[link_name = "strlen"]`
    = help: allow this lint if the signature is compatible
 
-error: aborting due to 7 previous errors; 5 warnings emitted
+error: aborting due to 8 previous errors; 5 warnings emitted
 

--- a/tests/ui/lint/runtime-symbols.stderr
+++ b/tests/ui/lint/runtime-symbols.stderr
@@ -1,5 +1,5 @@
 error: invalid definition of the runtime `memmove` symbol used by the standard library
-  --> $DIR/runtime-symbols.rs:13:5
+  --> $DIR/runtime-symbols.rs:14:5
    |
 LL |     pub fn memmove() {}
    |     ^^^^^^^^^^^^^^^^
@@ -10,7 +10,7 @@ LL |     pub fn memmove() {}
    = note: `#[deny(invalid_runtime_symbol_definitions)]` on by default
 
 error: invalid definition of the runtime `memset` symbol used by the standard library
-  --> $DIR/runtime-symbols.rs:17:9
+  --> $DIR/runtime-symbols.rs:18:9
    |
 LL |         pub fn memset();
    |         ^^^^^^^^^^^^^^^^
@@ -20,7 +20,7 @@ LL |         pub fn memset();
    = help: either fix the signature or remove any attributes like `#[unsafe(no_mangle)]`, `#[unsafe(export_name = "memset")]`, or `#[link_name = "memset"]`
 
 error: invalid definition of the runtime `memcmp` symbol used by the standard library
-  --> $DIR/runtime-symbols.rs:20:9
+  --> $DIR/runtime-symbols.rs:21:9
    |
 LL |         pub fn memcmp();
    |         ^^^^^^^^^^^^^^^^
@@ -30,7 +30,7 @@ LL |         pub fn memcmp();
    = help: either fix the signature or remove any attributes like `#[unsafe(no_mangle)]`, `#[unsafe(export_name = "memcmp")]`, or `#[link_name = "memcmp"]`
 
 error: invalid definition of the runtime `strlen` symbol used by the standard library
-  --> $DIR/runtime-symbols.rs:25:5
+  --> $DIR/runtime-symbols.rs:26:5
    |
 LL |     pub static strlen: () = ();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -40,7 +40,7 @@ LL |     pub static strlen: () = ();
    = help: either fix the signature or remove any attributes like `#[unsafe(no_mangle)]`, `#[unsafe(export_name = "strlen")]`, or `#[link_name = "strlen"]`
 
 error: invalid definition of the runtime `strlen` symbol used by the standard library
-  --> $DIR/runtime-symbols.rs:30:9
+  --> $DIR/runtime-symbols.rs:32:9
    |
 LL |         static strlen2: Option<unsafe extern "C" fn(s: *const c_char)>;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -50,7 +50,7 @@ LL |         static strlen2: Option<unsafe extern "C" fn(s: *const c_char)>;
    = help: either fix the signature or remove any attributes like `#[unsafe(no_mangle)]`, `#[unsafe(export_name = "strlen")]`, or `#[link_name = "strlen"]`
 
 error: invalid definition of the runtime `memcpy` symbol used by the standard library
-  --> $DIR/runtime-symbols.rs:36:5
+  --> $DIR/runtime-symbols.rs:38:5
    |
 LL |     pub fn memcpy(dest: *mut c_void, src: *const c_void, n: usize) -> *mut c_void {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -60,7 +60,7 @@ LL |     pub fn memcpy(dest: *mut c_void, src: *const c_void, n: usize) -> *mut 
    = help: either fix the signature or remove any attributes like `#[unsafe(no_mangle)]`, `#[unsafe(export_name = "memcpy")]`, or `#[link_name = "memcpy"]`
 
 error: invalid definition of the runtime `bcmp` symbol used by the standard library
-  --> $DIR/runtime-symbols.rs:43:5
+  --> $DIR/runtime-symbols.rs:45:5
    |
 LL |     pub unsafe extern "C" fn bcmp(s1: *const c_void, s2: *const c_void, n: usize, _: ...) -> c_int {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -70,7 +70,7 @@ LL |     pub unsafe extern "C" fn bcmp(s1: *const c_void, s2: *const c_void, n: 
    = help: either fix the signature or remove any attributes like `#[unsafe(no_mangle)]`, `#[unsafe(export_name = "bcmp")]`, or `#[link_name = "bcmp"]`
 
 error: invalid definition of the runtime `bcmp` symbol used by the standard library
-  --> $DIR/runtime-symbols.rs:50:5
+  --> $DIR/runtime-symbols.rs:52:5
    |
 LL |     pub extern "C" fn bcmp_(s1: *const c_void, s2: *const c_void, n: usize) {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -80,7 +80,7 @@ LL |     pub extern "C" fn bcmp_(s1: *const c_void, s2: *const c_void, n: usize)
    = help: either fix the signature or remove any attributes like `#[unsafe(no_mangle)]`, `#[unsafe(export_name = "bcmp")]`, or `#[link_name = "bcmp"]`
 
 warning: suspicious definition of the runtime `memcpy` symbol used by the standard library
-  --> $DIR/runtime-symbols.rs:56:5
+  --> $DIR/runtime-symbols.rs:58:5
    |
 LL |     pub extern "C" fn memcpy(dest: *mut c_void, src: *const c_void, n: i64) -> *mut c_void {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -92,7 +92,7 @@ LL |     pub extern "C" fn memcpy(dest: *mut c_void, src: *const c_void, n: i64)
    = note: `#[warn(suspicious_runtime_symbol_definitions)]` on by default
 
 warning: suspicious definition of the runtime `memmove` symbol used by the standard library
-  --> $DIR/runtime-symbols.rs:62:5
+  --> $DIR/runtime-symbols.rs:64:5
    |
 LL |     pub extern "C" fn memmove(dest: *mut c_void, src: *const c_void, n: i64) -> *mut c_void {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -103,7 +103,7 @@ LL |     pub extern "C" fn memmove(dest: *mut c_void, src: *const c_void, n: i64
    = help: allow this lint if the signature is compatible
 
 warning: suspicious definition of the runtime `memset` symbol used by the standard library
-  --> $DIR/runtime-symbols.rs:68:9
+  --> $DIR/runtime-symbols.rs:70:9
    |
 LL |         fn memset(s: *mut c_void, c: c_int, n: usize) -> f64;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -114,7 +114,7 @@ LL |         fn memset(s: *mut c_void, c: c_int, n: usize) -> f64;
    = help: allow this lint if the signature is compatible
 
 warning: suspicious definition of the runtime `bcmp` symbol used by the standard library
-  --> $DIR/runtime-symbols.rs:73:5
+  --> $DIR/runtime-symbols.rs:75:5
    |
 LL |     pub extern "C" fn bcmp_(s1: *const U8, s2: *const U8, n: usize) -> c_int {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -125,7 +125,7 @@ LL |     pub extern "C" fn bcmp_(s1: *const U8, s2: *const U8, n: usize) -> c_in
    = help: allow this lint if the signature is compatible
 
 warning: suspicious definition of the runtime `strlen` symbol used by the standard library
-  --> $DIR/runtime-symbols.rs:79:5
+  --> $DIR/runtime-symbols.rs:81:5
    |
 LL |     pub extern "C" fn strlen(s: *const u64) -> usize {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/lint/runtime-symbols.stderr
+++ b/tests/ui/lint/runtime-symbols.stderr
@@ -37,7 +37,7 @@ LL |     pub static strlen: () = ();
    |
    = note: expected `unsafe extern "C" fn(*const U8) -> usize`
            found    `()`
-   = help: either fix the signature or remove any attributes `#[unsafe(no_mangle)]` or `#[unsafe(export_name = "strlen")]`
+   = help: either fix the signature or remove any attributes like `#[unsafe(no_mangle)]`, `#[unsafe(export_name = "strlen")]`, or `#[link_name = "strlen"]`
 
 error: invalid definition of the runtime `strlen` symbol used by the standard library
   --> $DIR/runtime-symbols.rs:30:9
@@ -47,7 +47,7 @@ LL |         static strlen2: Option<unsafe extern "C" fn(s: *const c_char)>;
    |
    = note: expected `unsafe extern "C" fn(*const U8) -> usize`
            found    `unsafe extern "C" fn(*const U8)`
-   = help: either fix the signature or remove any attributes `#[unsafe(no_mangle)]` or `#[unsafe(export_name = "strlen")]`
+   = help: either fix the signature or remove any attributes like `#[unsafe(no_mangle)]`, `#[unsafe(export_name = "strlen")]`, or `#[link_name = "strlen"]`
 
 error: invalid definition of the runtime `memcpy` symbol used by the standard library
   --> $DIR/runtime-symbols.rs:36:5


### PR DESCRIPTION
This PR cleanups the `static` items path when checking the runtime symbols, and brings it on par with the foreign functions check.

It also fixes a bug where static only reported the invalid lint and never the suspicious lint.

Best reviewed commit by commit.

<!-- homu-ignore:start -->
r? @GuillaumeGomez
<!-- homu-ignore:end -->
