### PR TITLE
Cap socket send length to c_int::MAX on Apple targets

### DIFF
--- a/library/std/src/net/tcp/tests.rs
+++ b/library/std/src/net/tcp/tests.rs
@@ -956,3 +956,34 @@ fn connect_timeout_valid() {
     let addr = listener.local_addr().unwrap();
     TcpStream::connect_timeout(&addr, Duration::from_secs(2)).unwrap();
 }
+
+// #115325: writing a buffer larger than `c_int::MAX` bytes used to fail on
+// macOS with `EINVAL`; `write_all` should now transfer it via short sends.
+#[test]
+#[cfg(target_pointer_width = "64")]
+#[ignore = "requires ~2 GiB of memory"]
+fn write_buffer_larger_than_c_int_max() {
+    const LEN: usize = crate::ffi::c_int::MAX as usize + 1;
+
+    let listener = t!(TcpListener::bind("127.0.0.1:0"));
+    let addr = t!(listener.local_addr());
+    let reader = thread::spawn(move || {
+        let (mut sock, _) = t!(listener.accept());
+        let mut received = 0usize;
+        let mut buf = vec![0u8; 1 << 20];
+        loop {
+            match sock.read(&mut buf) {
+                Ok(0) => break,
+                Ok(n) => received += n,
+                Err(e) => panic!("read error: {e}"),
+            }
+        }
+        received
+    });
+
+    let mut stream = t!(TcpStream::connect(addr));
+    let data = vec![0u8; LEN];
+    t!(stream.write_all(&data));
+    drop(stream); // signal EOF so the reader loop terminates
+    assert_eq!(reader.join().unwrap(), LEN);
+}

--- a/library/std/src/net/tcp/tests.rs
+++ b/library/std/src/net/tcp/tests.rs
@@ -964,22 +964,10 @@ fn connect_timeout_valid() {
 fn write_buffer_larger_than_c_int_max() {
     const LEN: usize = crate::ffi::c_int::MAX as usize + 1;
 
-    // Back the source buffer with a read-only anonymous mmap rather than a 2 GiB
-    // `Vec`. The pages are demand-zero and never written, so they stay mapped to
-    // the shared zero page and the test doesn't actually consume ~2 GiB of
-    // physical memory while `write_all` reads through the buffer.
-    let data = unsafe {
-        let ptr = libc::mmap(
-            crate::ptr::null_mut(),
-            LEN,
-            libc::PROT_READ,
-            libc::MAP_PRIVATE | libc::MAP_ANON,
-            -1,
-            0,
-        );
-        assert_ne!(ptr, libc::MAP_FAILED, "mmap failed: {}", crate::io::Error::last_os_error());
-        crate::slice::from_raw_parts(ptr as *const u8, LEN)
-    };
+    // Back the source buffer with a read-only anonymous mapping rather than a
+    // 2 GiB `Vec`, so the test doesn't actually consume ~2 GiB of physical
+    // memory while `write_all` reads through the buffer.
+    let data = crate::net::tests::ZeroedMmap::new(LEN);
 
     let listener = t!(TcpListener::bind("127.0.0.1:0"));
     let addr = t!(listener.local_addr());
@@ -998,11 +986,7 @@ fn write_buffer_larger_than_c_int_max() {
     });
 
     let mut stream = t!(TcpStream::connect(addr));
-    t!(stream.write_all(data));
+    t!(stream.write_all(&data));
     drop(stream); // signal EOF so the reader loop terminates
     assert_eq!(reader.join().unwrap(), LEN);
-
-    unsafe {
-        assert_eq!(libc::munmap(data.as_ptr() as *mut libc::c_void, LEN), 0);
-    }
 }

--- a/library/std/src/net/tcp/tests.rs
+++ b/library/std/src/net/tcp/tests.rs
@@ -960,10 +960,26 @@ fn connect_timeout_valid() {
 // #115325: writing a buffer larger than `c_int::MAX` bytes used to fail on
 // macOS with `EINVAL`; `write_all` should now transfer it via short sends.
 #[test]
-#[cfg(target_pointer_width = "64")]
-#[ignore = "requires ~2 GiB of memory"]
+#[cfg(all(target_pointer_width = "64", unix))]
 fn write_buffer_larger_than_c_int_max() {
     const LEN: usize = crate::ffi::c_int::MAX as usize + 1;
+
+    // Back the source buffer with a read-only anonymous mmap rather than a 2 GiB
+    // `Vec`. The pages are demand-zero and never written, so they stay mapped to
+    // the shared zero page and the test doesn't actually consume ~2 GiB of
+    // physical memory while `write_all` reads through the buffer.
+    let data = unsafe {
+        let ptr = libc::mmap(
+            crate::ptr::null_mut(),
+            LEN,
+            libc::PROT_READ,
+            libc::MAP_PRIVATE | libc::MAP_ANON,
+            -1,
+            0,
+        );
+        assert_ne!(ptr, libc::MAP_FAILED, "mmap failed: {}", crate::io::Error::last_os_error());
+        crate::slice::from_raw_parts(ptr as *const u8, LEN)
+    };
 
     let listener = t!(TcpListener::bind("127.0.0.1:0"));
     let addr = t!(listener.local_addr());
@@ -982,8 +998,11 @@ fn write_buffer_larger_than_c_int_max() {
     });
 
     let mut stream = t!(TcpStream::connect(addr));
-    let data = vec![0u8; LEN];
-    t!(stream.write_all(&data));
+    t!(stream.write_all(data));
     drop(stream); // signal EOF so the reader loop terminates
     assert_eq!(reader.join().unwrap(), LEN);
+
+    unsafe {
+        assert_eq!(libc::munmap(data.as_ptr() as *mut libc::c_void, LEN), 0);
+    }
 }

--- a/library/std/src/net/tests.rs
+++ b/library/std/src/net/tests.rs
@@ -37,6 +37,56 @@ pub fn compare_ignore_zoneid(a: &SocketAddr, b: &SocketAddr) -> bool {
     }
 }
 
+/// A read-only anonymous mapping of `len` zero bytes.
+///
+/// The tests that need a buffer larger than `c_int::MAX` use this instead of a
+/// `Vec`: the pages are demand-zero and never written, so they stay mapped to
+/// the shared zero page and the mapping doesn't actually consume `len` bytes of
+/// physical memory.
+#[cfg(all(target_pointer_width = "64", unix))]
+pub struct ZeroedMmap {
+    ptr: *mut libc::c_void,
+    len: usize,
+}
+
+#[cfg(all(target_pointer_width = "64", unix))]
+impl ZeroedMmap {
+    pub fn new(len: usize) -> ZeroedMmap {
+        let ptr = unsafe {
+            libc::mmap(
+                crate::ptr::null_mut(),
+                len,
+                libc::PROT_READ,
+                libc::MAP_PRIVATE | libc::MAP_ANON,
+                -1,
+                0,
+            )
+        };
+        assert_ne!(ptr, libc::MAP_FAILED, "mmap failed: {}", crate::io::Error::last_os_error());
+        ZeroedMmap { ptr, len }
+    }
+}
+
+#[cfg(all(target_pointer_width = "64", unix))]
+impl crate::ops::Deref for ZeroedMmap {
+    type Target = [u8];
+
+    fn deref(&self) -> &[u8] {
+        // SAFETY: the mapping is live for `self.len` readable bytes until `Drop`.
+        unsafe { crate::slice::from_raw_parts(self.ptr as *const u8, self.len) }
+    }
+}
+
+#[cfg(all(target_pointer_width = "64", unix))]
+impl Drop for ZeroedMmap {
+    fn drop(&mut self) {
+        // SAFETY: `ptr`/`len` come from the `mmap` call above and are unmapped once.
+        unsafe {
+            libc::munmap(self.ptr, self.len);
+        }
+    }
+}
+
 #[test]
 fn hostname_smoketest() {
     // Just a smoke test to ensure it can be called.

--- a/library/std/src/net/udp/tests.rs
+++ b/library/std/src/net/udp/tests.rs
@@ -374,3 +374,17 @@ fn set_nonblocking() {
         }
     })
 }
+
+// #115325: a datagram larger than `c_int::MAX` bytes can't be sent atomically
+// and must be rejected rather than truncated.
+#[test]
+#[cfg(target_pointer_width = "64")]
+#[ignore = "requires ~2 GiB of memory"]
+fn send_datagram_larger_than_c_int_max() {
+    let socket = t!(UdpSocket::bind("127.0.0.1:0"));
+    let addr = t!(socket.local_addr());
+    let data = vec![0u8; crate::ffi::c_int::MAX as usize + 1];
+    assert!(socket.send_to(&data, addr).is_err());
+    t!(socket.connect(addr));
+    assert!(socket.send(&data).is_err());
+}

--- a/library/std/src/net/udp/tests.rs
+++ b/library/std/src/net/udp/tests.rs
@@ -378,12 +378,30 @@ fn set_nonblocking() {
 // #115325: a datagram larger than `c_int::MAX` bytes can't be sent atomically
 // and must be rejected rather than truncated.
 #[test]
-#[cfg(target_pointer_width = "64")]
-#[ignore = "requires ~2 GiB of memory"]
+#[cfg(all(target_pointer_width = "64", unix))]
 fn send_datagram_larger_than_c_int_max() {
+    // A read-only anonymous mapping rather than a 2 GiB `Vec`: the datagram is
+    // rejected before the kernel ever reads the pages, so this costs no
+    // physical memory.
+    let data = crate::net::tests::ZeroedMmap::new(crate::ffi::c_int::MAX as usize + 1);
+
     let socket = t!(UdpSocket::bind("127.0.0.1:0"));
     let addr = t!(socket.local_addr());
+    assert!(socket.send_to(&data, addr).is_err());
+    t!(socket.connect(addr));
+    assert!(socket.send(&data).is_err());
+}
+
+// Same as above, for the platforms where the `mmap` trick isn't available and
+// the buffer really has to be allocated.
+#[test]
+#[cfg(all(target_pointer_width = "64", not(unix)))]
+#[ignore = "requires ~2 GiB of memory"]
+fn send_datagram_larger_than_c_int_max() {
     let data = vec![0u8; crate::ffi::c_int::MAX as usize + 1];
+
+    let socket = t!(UdpSocket::bind("127.0.0.1:0"));
+    let addr = t!(socket.local_addr());
     assert!(socket.send_to(&data, addr).is_err());
     t!(socket.connect(addr));
     assert!(socket.send(&data).is_err());

--- a/library/std/src/sys/net/connection/socket/mod.rs
+++ b/library/std/src/sys/net/connection/socket/mod.rs
@@ -709,14 +709,18 @@ impl UdpSocket {
         self.inner.peek_from(buf)
     }
 
+    // `MAX_SEND_LEN` is `usize::MAX` off Apple/Windows, where the guard is a no-op.
+    #[allow(clippy::absurd_extreme_comparisons)]
     pub fn send_to(&self, buf: &[u8], dst: &SocketAddr) -> io::Result<usize> {
-        let len = cmp::min(buf.len(), MAX_SEND_LEN) as wrlen_t;
+        if buf.len() > MAX_SEND_LEN {
+            return Err(io::Error::from_raw_os_error(c::EMSGSIZE));
+        }
         let (dst, dstlen) = socket_addr_to_c(dst);
         let ret = cvt(unsafe {
             c::sendto(
                 self.inner.as_raw(),
                 buf.as_ptr() as *const c_void,
-                len,
+                buf.len() as wrlen_t,
                 MSG_NOSIGNAL,
                 dst.as_ptr(),
                 dstlen,
@@ -862,10 +866,19 @@ impl UdpSocket {
         self.inner.peek(buf)
     }
 
+    // `MAX_SEND_LEN` is `usize::MAX` off Apple/Windows, where the guard is a no-op.
+    #[allow(clippy::absurd_extreme_comparisons)]
     pub fn send(&self, buf: &[u8]) -> io::Result<usize> {
-        let len = cmp::min(buf.len(), MAX_SEND_LEN) as wrlen_t;
+        if buf.len() > MAX_SEND_LEN {
+            return Err(io::Error::from_raw_os_error(c::EMSGSIZE));
+        }
         let ret = cvt(unsafe {
-            c::send(self.inner.as_raw(), buf.as_ptr() as *const c_void, len, MSG_NOSIGNAL)
+            c::send(
+                self.inner.as_raw(),
+                buf.as_ptr() as *const c_void,
+                buf.len() as wrlen_t,
+                MSG_NOSIGNAL,
+            )
         })?;
         Ok(ret as usize)
     }

--- a/library/std/src/sys/net/connection/socket/mod.rs
+++ b/library/std/src/sys/net/connection/socket/mod.rs
@@ -35,6 +35,9 @@ cfg_select! {
 
 use netc as c;
 
+const MAX_SEND_LEN: usize =
+    if cfg!(target_vendor = "apple") { c_int::MAX as usize } else { <wrlen_t>::MAX as usize };
+
 cfg_select! {
     any(
         target_os = "dragonfly",
@@ -430,7 +433,7 @@ impl TcpStream {
     }
 
     pub fn write(&self, buf: &[u8]) -> io::Result<usize> {
-        let len = cmp::min(buf.len(), <wrlen_t>::MAX as usize) as wrlen_t;
+        let len = cmp::min(buf.len(), MAX_SEND_LEN) as wrlen_t;
         let ret = cvt(unsafe {
             c::send(self.inner.as_raw(), buf.as_ptr() as *const c_void, len, MSG_NOSIGNAL)
         })?;
@@ -707,7 +710,7 @@ impl UdpSocket {
     }
 
     pub fn send_to(&self, buf: &[u8], dst: &SocketAddr) -> io::Result<usize> {
-        let len = cmp::min(buf.len(), <wrlen_t>::MAX as usize) as wrlen_t;
+        let len = cmp::min(buf.len(), MAX_SEND_LEN) as wrlen_t;
         let (dst, dstlen) = socket_addr_to_c(dst);
         let ret = cvt(unsafe {
             c::sendto(
@@ -860,7 +863,7 @@ impl UdpSocket {
     }
 
     pub fn send(&self, buf: &[u8]) -> io::Result<usize> {
-        let len = cmp::min(buf.len(), <wrlen_t>::MAX as usize) as wrlen_t;
+        let len = cmp::min(buf.len(), MAX_SEND_LEN) as wrlen_t;
         let ret = cvt(unsafe {
             c::send(self.inner.as_raw(), buf.as_ptr() as *const c_void, len, MSG_NOSIGNAL)
         })?;

--- a/library/std/src/sys/net/connection/socket/tests.rs
+++ b/library/std/src/sys/net/connection/socket/tests.rs
@@ -17,3 +17,15 @@ fn no_lookup_host_duplicates() {
         "There should be no duplicate localhost entries"
     );
 }
+
+// #115325: on Apple, `send` rejects a length > `c_int::MAX` with `EINVAL`, so
+// the clamp must not regress to the unbounded `wrlen_t::MAX`.
+#[test]
+fn max_send_len_within_platform_limit() {
+    if cfg!(target_vendor = "apple") {
+        assert_eq!(MAX_SEND_LEN, c_int::MAX as usize);
+    } else {
+        assert_eq!(MAX_SEND_LEN, <wrlen_t>::MAX as usize);
+    }
+    assert_eq!(crate::cmp::min(MAX_SEND_LEN.saturating_add(1), MAX_SEND_LEN), MAX_SEND_LEN);
+}

--- a/library/std/src/sys/net/connection/socket/tests.rs
+++ b/library/std/src/sys/net/connection/socket/tests.rs
@@ -27,5 +27,4 @@ fn max_send_len_within_platform_limit() {
     } else {
         assert_eq!(MAX_SEND_LEN, <wrlen_t>::MAX as usize);
     }
-    assert_eq!(crate::cmp::min(MAX_SEND_LEN.saturating_add(1), MAX_SEND_LEN), MAX_SEND_LEN);
 }

--- a/library/std/src/sys/net/connection/socket/unix.rs
+++ b/library/std/src/sys/net/connection/socket/unix.rs
@@ -279,7 +279,7 @@ impl Socket {
 
     #[cfg(not(target_os = "wasi"))]
     pub fn send_with_flags(&self, buf: &[u8], flags: c_int) -> io::Result<usize> {
-        let len = cmp::min(buf.len(), <wrlen_t>::MAX as usize) as wrlen_t;
+        let len = cmp::min(buf.len(), super::MAX_SEND_LEN) as wrlen_t;
         let ret = cvt(unsafe {
             libc::send(self.as_raw_fd(), buf.as_ptr() as *const c_void, len, flags)
         })?;

--- a/library/std/src/sys/net/connection/socket/windows.rs
+++ b/library/std/src/sys/net/connection/socket/windows.rs
@@ -31,8 +31,8 @@ pub(super) mod netc {
         IP_DROP_MEMBERSHIP, IP_MULTICAST_LOOP, IP_MULTICAST_TTL, IP_TTL, IPPROTO_IP, IPPROTO_IPV6,
         IPV6_ADD_MEMBERSHIP, IPV6_DROP_MEMBERSHIP, IPV6_MULTICAST_LOOP, IPV6_V6ONLY, SO_BROADCAST,
         SO_RCVTIMEO, SO_SNDTIMEO, SOCK_DGRAM, SOCK_STREAM, SOCKADDR as sockaddr,
-        SOCKADDR_STORAGE as sockaddr_storage, SOL_SOCKET, bind, connect, freeaddrinfo, getpeername,
-        getsockname, getsockopt, listen, setsockopt,
+        SOCKADDR_STORAGE as sockaddr_storage, SOL_SOCKET, WSAEMSGSIZE as EMSGSIZE, bind, connect,
+        freeaddrinfo, getpeername, getsockname, getsockopt, listen, setsockopt,
     };
 
     #[allow(non_camel_case_types)]


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/159530)*
<!-- homu-ignore:end -->

On Apple, `send`/`sendto` reject a length larger than `c_int::MAX` with `EINVAL` instead of doing a short send. The send length was only clamped to `wrlen_t::MAX` (a no-op on 64-bit unix), so writing more than `c_int::MAX` bytes to a socket failed on macOS.

Add a `MAX_SEND_LEN` cap (`c_int::MAX` on Apple, `wrlen_t::MAX` elsewhere), used in `write`, `send`, `send_to`, and `send_with_flags`.

Fixes rust-lang/rust#115325