### PR TITLE
Always use a `DropTree` to build drops

### DIFF
--- a/compiler/rustc_mir_build/src/builder/block.rs
+++ b/compiler/rustc_mir_build/src/builder/block.rs
@@ -272,16 +272,18 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                             .into_block();
                     } else {
                         let scope = (*init_scope, source_info);
-                        let _: BlockAnd<()> = this.in_scope(scope, lint_level, |this| {
-                            this.declare_bindings(
-                                visibility_scope,
-                                remainder_span,
-                                pattern,
-                                None,
-                                None,
-                            );
-                            block.unit()
-                        });
+                        block = this
+                            .in_scope(scope, lint_level, |this| {
+                                this.declare_bindings(
+                                    visibility_scope,
+                                    remainder_span,
+                                    pattern,
+                                    None,
+                                    None,
+                                );
+                                block.unit()
+                            })
+                            .into_block();
 
                         debug!("ast_block_stmts: pattern={:?}", pattern);
                         this.visit_primary_bindings(pattern, &mut |this, node, span| {

--- a/compiler/rustc_mir_build/src/builder/expr/as_rvalue.rs
+++ b/compiler/rustc_mir_build/src/builder/expr/as_rvalue.rs
@@ -11,7 +11,7 @@ use rustc_middle::ty::adjustment::PointerCoercion;
 use rustc_middle::ty::cast::{CastTy, mir_cast_kind};
 use rustc_middle::ty::util::IntTypeExt;
 use rustc_middle::ty::{self, Ty, UpvarArgs};
-use rustc_span::{DUMMY_SP, Span, Spanned};
+use rustc_span::Span;
 use tracing::debug;
 
 use crate::builder::expr::as_place::PlaceBase;
@@ -74,6 +74,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                             NeedsTemporary::No
                         )
                     );
+                    this.record_operand_moved(&value_operand);
                     block.and(Rvalue::Repeat(value_operand, count))
                 }
             }
@@ -219,6 +220,9 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     })
                     .collect();
 
+                for operand in fields.iter() {
+                    this.record_operand_moved(operand);
+                }
                 block.and(Rvalue::Aggregate(Box::new(AggregateKind::Array(el_ty)), fields))
             }
             ExprKind::Tuple { ref fields } => {
@@ -240,6 +244,9 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     })
                     .collect();
 
+                for operand in fields.iter() {
+                    this.record_operand_moved(operand);
+                }
                 block.and(Rvalue::Aggregate(Box::new(AggregateKind::Tuple), fields))
             }
             ExprKind::Closure(ClosureExpr {
@@ -342,6 +349,9 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                         Box::new(AggregateKind::CoroutineClosure(closure_id.to_def_id(), args))
                     }
                 };
+                for operand in operands.iter() {
+                    this.record_operand_moved(operand);
+                }
                 block.and(Rvalue::Aggregate(result, operands))
             }
             ExprKind::Assign { .. } | ExprKind::AssignOp { .. } => {
@@ -424,6 +434,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                         NeedsTemporary::No,
                     )
                 );
+                this.record_operand_moved(&operand);
                 block.and(Rvalue::Use(operand, WithRetag::Yes))
             }
 
@@ -647,7 +658,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 this.diverge_from(block);
                 block = success;
             }
-            this.record_operands_moved(&[Spanned { node: value_operand, span: DUMMY_SP }]);
+            this.record_operand_moved(&value_operand);
         }
         block.and(Rvalue::Aggregate(Box::new(AggregateKind::Array(elem_ty)), IndexVec::new()))
     }

--- a/compiler/rustc_mir_build/src/builder/expr/into.rs
+++ b/compiler/rustc_mir_build/src/builder/expr/into.rs
@@ -6,6 +6,7 @@ use rustc_data_structures::fx::FxHashMap;
 use rustc_data_structures::stack::ensure_sufficient_stack;
 use rustc_hir as hir;
 use rustc_hir::lang_items::LangItem;
+use rustc_index::IndexVec;
 use rustc_middle::mir::*;
 use rustc_middle::span_bug;
 use rustc_middle::thir::*;
@@ -491,7 +492,9 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
 
                 let success = this.cfg.start_new_block();
 
-                this.record_operands_moved(&args);
+                for operand in args.iter() {
+                    this.record_operand_moved(&operand.node);
+                }
 
                 debug!("expr_into_dest: fn_span={:?}", fn_span);
 
@@ -636,7 +639,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 let variant = adt_def.variant(variant_index);
                 let field_names = variant.fields.indices();
 
-                let fields = match base {
+                let fields: IndexVec<_, _> = match base {
                     AdtExprBase::None => {
                         field_names.filter_map(|n| fields_map.get(&n).cloned()).collect()
                     }
@@ -701,6 +704,9 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     user_ty,
                     active_field_index,
                 ));
+                for operand in fields.iter() {
+                    this.record_operand_moved(operand);
+                }
                 this.cfg.push_assign(
                     block,
                     source_info,
@@ -849,7 +855,9 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 debug_assert!(Category::of(&expr.kind) == Some(Category::Place));
 
                 let place = unpack!(block = this.as_place(block, expr_id));
-                let rvalue = Rvalue::Use(this.consume_by_copy_or_move(place), WithRetag::Yes);
+                let operand = this.consume_by_copy_or_move(place);
+                this.record_operand_moved(&operand);
+                let rvalue = Rvalue::Use(operand, WithRetag::Yes);
                 this.cfg.push_assign(block, source_info, destination, rvalue);
                 block.unit()
             }
@@ -875,6 +883,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     block =
                         this.as_operand(block, scope, value, LocalInfo::Boring, NeedsTemporary::No)
                 );
+                this.record_operand_moved(&value);
                 let resume = this.cfg.start_new_block();
                 this.cfg.terminate(
                     block,

--- a/compiler/rustc_mir_build/src/builder/expr/stmt.rs
+++ b/compiler/rustc_mir_build/src/builder/expr/stmt.rs
@@ -126,7 +126,9 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                         })
                         .collect();
 
-                    this.record_operands_moved(&args);
+                    for operand in args.iter() {
+                        this.record_operand_moved(&operand.node);
+                    }
 
                     debug!("expr_into_dest: fn_span={:?}", fn_span);
 

--- a/compiler/rustc_mir_build/src/builder/mod.rs
+++ b/compiler/rustc_mir_build/src/builder/mod.rs
@@ -532,22 +532,21 @@ fn construct_fn<'tcx>(
         region::Scope { local_id: body.id().hir_id.local_id, data: region::ScopeData::Arguments };
     let source_info = builder.source_info(span);
     let call_site_s = (call_site_scope, source_info);
-    let _: BlockAnd<()> = builder.in_scope(call_site_s, LintLevel::Inherited, |builder| {
-        let arg_scope_s = (arg_scope, source_info);
-        // Attribute epilogue to function's closing brace
-        let fn_end = span_with_body.shrink_to_hi();
-        let return_block = builder
-            .in_breakable_scope(None, Place::return_place(), fn_end, |builder| {
+    // Attribute epilogue to function's closing brace
+    let fn_end = span_with_body.shrink_to_hi();
+    let return_block = builder
+        .in_scope(call_site_s, LintLevel::Inherited, |builder| {
+            let arg_scope_s = (arg_scope, source_info);
+            builder.in_breakable_scope(None, Place::return_place(), fn_end, |builder| {
                 Some(builder.in_scope(arg_scope_s, LintLevel::Inherited, |builder| {
                     builder.args_and_body(START_BLOCK, arguments, arg_scope, expr)
                 }))
             })
-            .into_block();
-        let source_info = builder.source_info(fn_end);
-        builder.cfg.terminate(return_block, source_info, TerminatorKind::Return);
-        builder.build_drop_trees();
-        return_block.unit()
-    });
+        })
+        .into_block();
+    let source_info = builder.source_info(fn_end);
+    builder.cfg.terminate(return_block, source_info, TerminatorKind::Return);
+    builder.build_drop_trees();
 
     let mut body = builder.finish();
 

--- a/compiler/rustc_mir_build/src/builder/scope.rs
+++ b/compiler/rustc_mir_build/src/builder/scope.rs
@@ -255,24 +255,6 @@ struct DropNodeKey {
 }
 
 impl Scope {
-    /// Whether there's anything to do for the cleanup path, that is,
-    /// when unwinding through this scope. This includes destructors,
-    /// but not StorageDead statements, which don't get emitted at all
-    /// for unwinding, for several reasons:
-    ///  * clang doesn't emit llvm.lifetime.end for C++ unwinding
-    ///  * LLVM's memory dependency analysis can't handle it atm
-    ///  * polluting the cleanup MIR with StorageDead creates
-    ///    landing pads even though there's no actual destructors
-    ///  * freeing up stack space has no effect during unwinding
-    /// Note that for coroutines we do emit StorageDeads, for the
-    /// use of optimizations in the MIR coroutine transform.
-    fn needs_cleanup(&self) -> bool {
-        self.drops.iter().any(|drop| match drop.kind {
-            DropKind::Value | DropKind::ForLint => true,
-            DropKind::Storage => false,
-        })
-    }
-
     fn invalidate_cache(&mut self) {
         self.cached_unwind_block = None;
         self.cached_coroutine_drop_block = None;
@@ -324,6 +306,20 @@ impl DropTree {
     fn add_entry_point(&mut self, from: BasicBlock, to: DropIdx) {
         debug_assert!(to < self.drop_nodes.next_index());
         self.entry_points.push((to, from));
+    }
+
+    /// Helper to add all drops from the given scope to the drop tree.
+    fn add_scope_drops(&mut self, scope: &Scope, mut next: DropIdx) -> DropIdx {
+        for drop in &scope.drops {
+            let should_emit = match drop.kind {
+                DropKind::Value | DropKind::ForLint => !scope.moved_locals.contains(drop.local),
+                DropKind::Storage => true,
+            };
+            if should_emit {
+                next = self.add_drop(*drop, next);
+            }
+        }
+        next
     }
 
     /// Builds the MIR for a given drop tree.
@@ -1219,31 +1215,35 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
     }
 
     fn leave_top_scope(&mut self, block: BasicBlock) -> BasicBlock {
-        // If we are emitting a `drop` statement, we need to have the cached
-        // diverge cleanup pads ready in case that drop panics.
-        let needs_cleanup = self.scopes.scopes.last().is_some_and(|scope| scope.needs_cleanup());
-        let is_coroutine = self.coroutine.is_some();
-        let unwind_to = if needs_cleanup { self.diverge_cleanup() } else { DropIdx::MAX };
+        let scope = self.scopes.scopes.last().expect("leave_top_scope called with no scopes");
 
-        let scope = self.scopes.scopes.last().expect("leave_top_scope called with no scopes");
-        let has_async_drops = is_coroutine
-            && scope.drops.iter().any(|v| v.kind == DropKind::Value && self.is_async_drop(v.local));
-        let dropline_to = if has_async_drops { Some(self.diverge_dropline()) } else { None };
-        let scope = self.scopes.scopes.last().expect("leave_top_scope called with no scopes");
-        let typing_env = self.typing_env();
-        build_scope_drops(
-            &mut self.cfg,
-            &mut self.scopes.unwind_drops,
-            &mut self.scopes.coroutine_drops,
-            scope,
-            block,
-            unwind_to,
-            dropline_to,
-            is_coroutine && needs_cleanup,
-            self.arg_count,
-            |v: Local| Self::is_async_drop_impl(self.tcx, &self.local_decls, typing_env, v),
-        )
-        .into_block()
+        let mut drops = DropTree::new();
+        let drop_idx = drops.add_scope_drops(&scope, ROOT_NODE);
+
+        // We registered no drop, do not clutter the generated MIR with silly goto blocks.
+        if drop_idx == ROOT_NODE {
+            return block;
+        }
+
+        drops.add_entry_point(block, drop_idx);
+
+        let outer_scope = self
+            .scopes
+            .scopes
+            .iter()
+            .rev()
+            .nth(1)
+            .map_or_else(|| self.scopes.scopes[0].region_scope, |scope| scope.region_scope);
+
+        // `build_exit_tree` doesn't have access to our source_info, so we
+        // create a dummy terminator now. `TerminatorKind::UnwindResume` is used
+        // because MIR type checking will panic if it hasn't been overwritten.
+        // (See `<ExitScopes as DropTreeBuilder>::link_entry_point`.)
+        let source_info = scope.drops[0].source_info;
+        self.cfg.terminate(block, source_info, TerminatorKind::UnwindResume);
+
+        self.build_exit_tree(drops, outer_scope, DUMMY_SP, None)
+            .map_or_else(|| self.cfg.start_new_block(), |block| block.into_block())
     }
 
     /// Possibly creates a new source scope if `current_root` and `parent_root`
@@ -1784,184 +1784,6 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         guard_scope.drops.clear();
         guard_scope.invalidate_cache();
     }
-}
-
-/// Builds drops for `pop_scope` and `leave_top_scope`.
-///
-/// # Parameters
-///
-/// * `unwind_drops`, the drop tree data structure storing what needs to be cleaned up if unwind occurs
-/// * `scope`, describes the drops that will occur on exiting the scope in regular execution
-/// * `block`, the block to branch to once drops are complete (assuming no unwind occurs)
-/// * `unwind_to`, describes the drops that would occur at this point in the code if a
-///   panic occurred (a subset of the drops in `scope`, since we sometimes elide StorageDead and other
-///   instructions on unwinding)
-/// * `dropline_to`, describes the drops that would occur at this point in the code if a
-///    coroutine drop occurred.
-/// * `storage_dead_on_unwind`, if true, then we should emit `StorageDead` even when unwinding
-/// * `arg_count`, number of MIR local variables corresponding to fn arguments (used to assert that we don't drop those)
-fn build_scope_drops<'tcx, F>(
-    cfg: &mut CFG<'tcx>,
-    unwind_drops: &mut DropTree,
-    coroutine_drops: &mut DropTree,
-    scope: &Scope,
-    block: BasicBlock,
-    unwind_to: DropIdx,
-    dropline_to: Option<DropIdx>,
-    storage_dead_on_unwind: bool,
-    arg_count: usize,
-    is_async_drop: F,
-) -> BlockAnd<()>
-where
-    F: Fn(Local) -> bool,
-{
-    debug!("build_scope_drops({:?} -> {:?}), dropline_to={:?}", block, scope, dropline_to);
-
-    // Build up the drops in evaluation order. The end result will
-    // look like:
-    //
-    // [SDs, drops[n]] --..> [SDs, drop[1]] -> [SDs, drop[0]] -> [[SDs]]
-    //               |                    |                 |
-    //               :                    |                 |
-    //                                    V                 V
-    // [drop[n]] -...-> [drop[1]] ------> [drop[0]] ------> [last_unwind_to]
-    //
-    // The horizontal arrows represent the execution path when the drops return
-    // successfully. The downwards arrows represent the execution path when the
-    // drops panic (panicking while unwinding will abort, so there's no need for
-    // another set of arrows).
-    //
-    // For coroutines, we unwind from a drop on a local to its StorageDead
-    // statement. For other functions we don't worry about StorageDead. The
-    // drops for the unwind path should have already been generated by
-    // `diverge_cleanup_gen`.
-
-    // `unwind_to` indicates what needs to be dropped should unwinding occur.
-    // This is a subset of what needs to be dropped when exiting the scope.
-    // As we unwind the scope, we will also move `unwind_to` backwards to match,
-    // so that we can use it should a destructor panic.
-    let mut unwind_to = unwind_to;
-
-    // The block that we should jump to after drops complete. We start by building the final drop (`drops[n]`
-    // in the diagram above) and then build the drops (e.g., `drop[1]`, `drop[0]`) that come before it.
-    // block begins as the successor of `drops[n]` and then becomes `drops[n]` so that `drops[n-1]`
-    // will branch to `drops[n]`.
-    let mut block = block;
-
-    // `dropline_to` indicates what needs to be dropped should coroutine drop occur.
-    let mut dropline_to = dropline_to;
-
-    for drop_data in scope.drops.iter().rev() {
-        let source_info = drop_data.source_info;
-        let local = drop_data.local;
-
-        match drop_data.kind {
-            DropKind::Value => {
-                // `unwind_to` should drop the value that we're about to
-                // schedule. If dropping this value panics, then we continue
-                // with the *next* value on the unwind path.
-                //
-                // We adjust this BEFORE we create the drop (e.g., `drops[n]`)
-                // because `drops[n]` should unwind to `drops[n-1]`.
-                debug_assert_eq!(unwind_drops.drop_nodes[unwind_to].data.local, drop_data.local);
-                debug_assert_eq!(unwind_drops.drop_nodes[unwind_to].data.kind, drop_data.kind);
-                unwind_to = unwind_drops.drop_nodes[unwind_to].next;
-
-                if let Some(idx) = dropline_to {
-                    debug_assert_eq!(coroutine_drops.drop_nodes[idx].data.local, drop_data.local);
-                    debug_assert_eq!(coroutine_drops.drop_nodes[idx].data.kind, drop_data.kind);
-                    dropline_to = Some(coroutine_drops.drop_nodes[idx].next);
-                }
-
-                // If the operand has been moved, and we are not on an unwind
-                // path, then don't generate the drop. (We only take this into
-                // account for non-unwind paths so as not to disturb the
-                // caching mechanism.)
-                if scope.moved_locals.contains(local) {
-                    continue;
-                }
-
-                unwind_drops.add_entry_point(block, unwind_to);
-                if let Some(to) = dropline_to
-                    && is_async_drop(local)
-                {
-                    coroutine_drops.add_entry_point(block, to);
-                }
-
-                let next = cfg.start_new_block();
-                cfg.terminate(
-                    block,
-                    source_info,
-                    TerminatorKind::Drop {
-                        place: local.into(),
-                        target: next,
-                        unwind: UnwindAction::Continue,
-                        replace: false,
-                        drop: None,
-                    },
-                );
-                block = next;
-            }
-            DropKind::ForLint => {
-                // As in the `DropKind::Storage` case below:
-                // normally lint-related drops are not emitted for unwind,
-                // so we can just leave `unwind_to` unmodified, but in some
-                // cases we emit things ALSO on the unwind path, so we need to adjust
-                // `unwind_to` in that case.
-                if storage_dead_on_unwind {
-                    debug_assert_eq!(
-                        unwind_drops.drop_nodes[unwind_to].data.local,
-                        drop_data.local
-                    );
-                    debug_assert_eq!(unwind_drops.drop_nodes[unwind_to].data.kind, drop_data.kind);
-                    unwind_to = unwind_drops.drop_nodes[unwind_to].next;
-                }
-
-                // If the operand has been moved, and we are not on an unwind
-                // path, then don't generate the drop. (We only take this into
-                // account for non-unwind paths so as not to disturb the
-                // caching mechanism.)
-                if scope.moved_locals.contains(local) {
-                    continue;
-                }
-
-                cfg.push(
-                    block,
-                    Statement::new(
-                        source_info,
-                        StatementKind::BackwardIncompatibleDropHint {
-                            place: Box::new(local.into()),
-                            reason: BackwardIncompatibleDropReason::Edition2024,
-                        },
-                    ),
-                );
-            }
-            DropKind::Storage => {
-                // Ordinarily, storage-dead nodes are not emitted on unwind, so we don't
-                // need to adjust `unwind_to` on this path. However, in some specific cases
-                // we *do* emit storage-dead nodes on the unwind path, and in that case now that
-                // the storage-dead has completed, we need to adjust the `unwind_to` pointer
-                // so that any future drops we emit will not register storage-dead.
-                if storage_dead_on_unwind {
-                    debug_assert_eq!(
-                        unwind_drops.drop_nodes[unwind_to].data.local,
-                        drop_data.local
-                    );
-                    debug_assert_eq!(unwind_drops.drop_nodes[unwind_to].data.kind, drop_data.kind);
-                    unwind_to = unwind_drops.drop_nodes[unwind_to].next;
-                }
-                if let Some(idx) = dropline_to {
-                    debug_assert_eq!(coroutine_drops.drop_nodes[idx].data.local, drop_data.local);
-                    debug_assert_eq!(coroutine_drops.drop_nodes[idx].data.kind, drop_data.kind);
-                    dropline_to = Some(coroutine_drops.drop_nodes[idx].next);
-                }
-                // Only temps and vars need their storage dead.
-                assert!(local.index() > arg_count);
-                cfg.push(block, Statement::new(source_info, StatementKind::StorageDead(local)));
-            }
-        }
-    }
-    block.unit()
 }
 
 impl<'a, 'tcx: 'a> Builder<'a, 'tcx> {

--- a/compiler/rustc_mir_build/src/builder/scope.rs
+++ b/compiler/rustc_mir_build/src/builder/scope.rs
@@ -821,9 +821,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
 
         let mut drop_idx = ROOT_NODE;
         for scope in &self.scopes.scopes[stack_index + 1..] {
-            for drop in &scope.drops {
-                drop_idx = drops.add_drop(*drop, drop_idx);
-            }
+            drop_idx = drops.add_scope_drops(scope, drop_idx);
         }
         drops.add_entry_point(block, drop_idx);
 
@@ -1022,11 +1020,10 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
 
         let drops = &mut scope.const_continue_drops;
 
-        let drop_idx = self.scopes.scopes[stack_index + 1..]
-            .iter()
-            .flat_map(|scope| &scope.drops)
-            .fold(ROOT_NODE, |drop_idx, &drop| drops.add_drop(drop, drop_idx));
-
+        let mut drop_idx = ROOT_NODE;
+        for scope in &self.scopes.scopes[stack_index + 1..] {
+            drop_idx = drops.add_scope_drops(scope, drop_idx);
+        }
         drops.add_entry_point(imaginary_target, drop_idx);
 
         self.cfg.terminate(imaginary_target, source_info, TerminatorKind::UnwindResume);
@@ -1035,11 +1032,10 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         let stack_index = self.scopes.stack_index(region_scope, span);
         let mut drops = DropTree::new();
 
-        let drop_idx = self.scopes.scopes[stack_index + 1..]
-            .iter()
-            .flat_map(|scope| &scope.drops)
-            .fold(ROOT_NODE, |drop_idx, &drop| drops.add_drop(drop, drop_idx));
-
+        let mut drop_idx = ROOT_NODE;
+        for scope in &self.scopes.scopes[stack_index + 1..] {
+            drop_idx = drops.add_scope_drops(scope, drop_idx);
+        }
         drops.add_entry_point(drop_and_continue_block, drop_idx);
 
         // `build_drop_trees` doesn't have access to our source_info, so we
@@ -1071,12 +1067,10 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         // Upgrade `if_then_scope` to `&mut`.
         let if_then_scope = self.scopes.if_then_scope.as_mut().expect("upgrading & to &mut");
 
-        let mut drop_idx = ROOT_NODE;
         let drops = &mut if_then_scope.else_drops;
+        let mut drop_idx = ROOT_NODE;
         for scope in &self.scopes.scopes[stack_index + 1..] {
-            for drop in &scope.drops {
-                drop_idx = drops.add_drop(*drop, drop_idx);
-            }
+            drop_idx = drops.add_scope_drops(scope, drop_idx);
         }
         drops.add_entry_point(block, drop_idx);
 
@@ -1569,7 +1563,11 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         let is_coroutine = self.coroutine.is_some();
         for scope in &mut self.scopes.scopes[uncached_scope..=target] {
             for drop in &scope.drops {
-                if is_coroutine || drop.kind == DropKind::Value {
+                let emit = match drop.kind {
+                    DropKind::Storage => is_coroutine,
+                    DropKind::Value | DropKind::ForLint => !scope.moved_locals.contains(drop.local),
+                };
+                if emit {
                     cached_drop = self.scopes.unwind_drops.add_drop(*drop, cached_drop);
                 }
             }
@@ -1630,9 +1628,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         }
 
         for scope in &mut self.scopes.scopes[uncached_scope..=target] {
-            for drop in &scope.drops {
-                cached_drop = self.scopes.coroutine_drops.add_drop(*drop, cached_drop);
-            }
+            cached_drop = self.scopes.coroutine_drops.add_scope_drops(scope, cached_drop);
             scope.cached_coroutine_drop_block = Some(cached_drop);
         }
 

--- a/compiler/rustc_mir_build/src/builder/scope.rs
+++ b/compiler/rustc_mir_build/src/builder/scope.rs
@@ -553,9 +553,9 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         let breakable_scope = self.scopes.breakable_scopes.pop().unwrap();
         assert!(breakable_scope.region_scope == region_scope);
         let break_block =
-            self.build_exit_tree(breakable_scope.break_drops, region_scope, span, None);
+            self.build_exit_tree(breakable_scope.break_drops, region_scope, span, None, &[]);
         if let Some(drops) = breakable_scope.continue_drops {
-            self.build_exit_tree(drops, region_scope, span, loop_block);
+            self.build_exit_tree(drops, region_scope, span, loop_block, &[]);
         }
         match (normal_exit_block, break_block) {
             (Some(block), None) | (None, Some(block)) => block,
@@ -609,6 +609,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             region_scope,
             span,
             None,
+            &[],
         );
 
         match (normal_exit_block, break_block) {
@@ -664,8 +665,9 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         let if_then_scope = mem::replace(&mut self.scopes.if_then_scope, previous_scope).unwrap();
         assert!(if_then_scope.region_scope == region_scope);
 
-        let else_block =
-            self.build_exit_tree(if_then_scope.else_drops, region_scope, span, None).map_or_else(
+        let else_block = self
+            .build_exit_tree(if_then_scope.else_drops, region_scope, span, None, &[])
+            .map_or_else(
                 || self.cfg.start_new_block(),
                 |else_block_and| else_block_and.into_block(),
             );
@@ -1046,7 +1048,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         // (See `<ExitScopes as DropTreeBuilder>::link_entry_point`.)
         self.cfg.terminate(drop_and_continue_block, source_info, TerminatorKind::UnwindResume);
 
-        self.build_exit_tree(drops, region_scope, span, Some(real_target));
+        self.build_exit_tree(drops, region_scope, span, Some(real_target), &[]);
 
         return self.cfg.start_new_block().unit();
     }
@@ -1091,7 +1093,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
     /// Instead, all scheduled drops are immediately added to the CFG.
     pub(crate) fn break_for_tail_call(
         &mut self,
-        mut block: BasicBlock,
+        block: BasicBlock,
         args: &[Spanned<Operand<'tcx>>],
         source_info: SourceInfo,
     ) -> BlockAnd<()> {
@@ -1114,88 +1116,42 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             })
             .collect();
 
-        let mut unwind_to = self.diverge_cleanup_target(
-            self.scopes.scopes.iter().rev().nth(1).unwrap().region_scope,
-            DUMMY_SP,
-        );
-        let typing_env = self.typing_env();
-        let unwind_drops = &mut self.scopes.unwind_drops;
+        let end_span = self.tcx.sess.source_map().end_point(source_info.span);
 
+        let mut drops = DropTree::new();
+        let mut drop_idx = ROOT_NODE;
         // the innermost scope contains only the destructors for the tail call arguments
         // we only want to drop these in case of a panic, so we skip it
-        for scope in self.scopes.scopes[1..].iter().rev().skip(1) {
-            // FIXME(explicit_tail_calls) code duplication with `build_scope_drops`
-            for drop_data in scope.drops.iter().rev() {
-                let source_info = drop_data.source_info;
-                let local = drop_data.local;
-
-                if !self.local_decls[local].ty.needs_drop(self.tcx, typing_env) {
-                    continue;
-                }
-
-                match drop_data.kind {
-                    DropKind::Value => {
-                        // `unwind_to` should drop the value that we're about to
-                        // schedule. If dropping this value panics, then we continue
-                        // with the *next* value on the unwind path.
-                        debug_assert_eq!(
-                            unwind_drops.drop_nodes[unwind_to].data.local,
-                            drop_data.local
-                        );
-                        debug_assert_eq!(
-                            unwind_drops.drop_nodes[unwind_to].data.kind,
-                            drop_data.kind
-                        );
-                        unwind_to = unwind_drops.drop_nodes[unwind_to].next;
-
-                        let mut unwind_entry_point = unwind_to;
-
-                        // the tail call arguments must be dropped if any of these drops panic
-                        for drop in arg_drops.iter().copied() {
-                            unwind_entry_point = unwind_drops.add_drop(drop, unwind_entry_point);
-                        }
-
-                        unwind_drops.add_entry_point(block, unwind_entry_point);
-
-                        let next = self.cfg.start_new_block();
-                        self.cfg.terminate(
-                            block,
-                            source_info,
-                            TerminatorKind::Drop {
-                                place: local.into(),
-                                target: next,
-                                unwind: UnwindAction::Continue,
-                                replace: false,
-                                drop: None,
-                            },
-                        );
-                        block = next;
-                    }
-                    DropKind::ForLint => {
-                        self.cfg.push(
-                            block,
-                            Statement::new(
-                                source_info,
-                                StatementKind::BackwardIncompatibleDropHint {
-                                    place: Box::new(local.into()),
-                                    reason: BackwardIncompatibleDropReason::Edition2024,
-                                },
-                            ),
-                        );
-                    }
-                    DropKind::Storage => {
-                        // Only temps and vars need their storage dead.
-                        assert!(local.index() > self.arg_count);
-                        self.cfg.push(
-                            block,
-                            Statement::new(source_info, StatementKind::StorageDead(local)),
-                        );
-                    }
+        for scope in &self.scopes.scopes[1..self.scopes.scopes.len() - 1] {
+            for drop in &scope.drops {
+                let should_emit = match drop.kind {
+                    DropKind::Value | DropKind::ForLint => !scope.moved_locals.contains(drop.local),
+                    DropKind::Storage => true,
+                };
+                if should_emit {
+                    let mut drop = *drop;
+                    drop.source_info.span = end_span;
+                    drop_idx = drops.add_drop(drop, drop_idx);
                 }
             }
         }
 
-        block.unit()
+        // We registered no drop, do not clutter the generated MIR with silly goto blocks.
+        if drop_idx == ROOT_NODE {
+            return block.unit();
+        }
+
+        drops.add_entry_point(block, drop_idx);
+
+        // `build_exit_tree` doesn't have access to our source_info, so we
+        // create a dummy terminator now. `TerminatorKind::UnwindResume` is used
+        // because MIR type checking will panic if it hasn't been overwritten.
+        // (See `<ExitScopes as DropTreeBuilder>::link_entry_point`.)
+        self.cfg.terminate(block, source_info, TerminatorKind::UnwindResume);
+
+        let outer_scope = self.scopes.scopes[0].region_scope;
+        self.build_exit_tree(drops, outer_scope, DUMMY_SP, None, &arg_drops)
+            .unwrap_or_else(|| self.cfg.start_new_block().unit())
     }
 
     fn is_async_drop_impl(
@@ -1242,7 +1198,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         let source_info = scope.drops[0].source_info;
         self.cfg.terminate(block, source_info, TerminatorKind::UnwindResume);
 
-        self.build_exit_tree(drops, outer_scope, DUMMY_SP, None)
+        self.build_exit_tree(drops, outer_scope, DUMMY_SP, None, &[])
             .map_or_else(|| self.cfg.start_new_block(), |block| block.into_block())
     }
 
@@ -1797,6 +1753,7 @@ impl<'a, 'tcx: 'a> Builder<'a, 'tcx> {
         else_scope: region::Scope,
         span: Span,
         continue_block: Option<BasicBlock>,
+        extra_unwind_drops: &[DropData],
     ) -> Option<BlockAnd<()>> {
         let blocks = drops.build_mir::<ExitScopes>(&mut self.cfg, continue_block);
         let is_coroutine = self.coroutine.is_some();
@@ -1823,10 +1780,13 @@ impl<'a, 'tcx: 'a> Builder<'a, 'tcx> {
                             .scopes
                             .unwind_drops
                             .add_drop(drop_node.data, unwind_indices[drop_node.next]);
-                        self.scopes.unwind_drops.add_entry_point(
-                            blocks[drop_idx].unwrap(),
-                            unwind_indices[drop_node.next],
-                        );
+                        let mut unwind_to = unwind_indices[drop_node.next];
+                        for extra_drop in extra_unwind_drops {
+                            unwind_to = self.scopes.unwind_drops.add_drop(*extra_drop, unwind_to);
+                        }
+                        self.scopes
+                            .unwind_drops
+                            .add_entry_point(blocks[drop_idx].unwrap(), unwind_to);
                         unwind_indices.push(unwind_drop);
                     }
                 }

--- a/compiler/rustc_mir_build/src/builder/scope.rs
+++ b/compiler/rustc_mir_build/src/builder/scope.rs
@@ -86,6 +86,7 @@ use std::mem;
 use interpret::ErrorHandled;
 use rustc_data_structures::fx::FxHashMap;
 use rustc_hir::HirId;
+use rustc_index::bit_set::GrowableBitSet;
 use rustc_index::{IndexSlice, IndexVec};
 use rustc_middle::middle::region;
 use rustc_middle::mir::{self, *};
@@ -137,7 +138,7 @@ struct Scope {
     /// end of the vector (top of the stack) first.
     drops: Vec<DropData>,
 
-    moved_locals: Vec<Local>,
+    moved_locals: GrowableBitSet<Local>,
 
     /// The drop index that will drop everything in and below this scope on an
     /// unwind path.
@@ -494,7 +495,7 @@ impl<'tcx> Scopes<'tcx> {
             source_scope: vis_scope,
             region_scope,
             drops: vec![],
-            moved_locals: vec![],
+            moved_locals: GrowableBitSet::new_empty(),
             cached_unwind_block: None,
             cached_coroutine_drop_block: None,
         });
@@ -1575,9 +1576,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             // -- add it to the list of moved operands. Note that this
             // local might not have been an operand created for this
             // call, it could come from other places too.
-            if scope.drops.iter().any(|drop| drop.local == local && drop.kind == DropKind::Value) {
-                scope.moved_locals.push(local);
-            }
+            scope.moved_locals.insert(local);
         }
     }
 
@@ -1878,7 +1877,7 @@ where
                 // path, then don't generate the drop. (We only take this into
                 // account for non-unwind paths so as not to disturb the
                 // caching mechanism.)
-                if scope.moved_locals.contains(&local) {
+                if scope.moved_locals.contains(local) {
                     continue;
                 }
 
@@ -1922,7 +1921,7 @@ where
                 // path, then don't generate the drop. (We only take this into
                 // account for non-unwind paths so as not to disturb the
                 // caching mechanism.)
-                if scope.moved_locals.contains(&local) {
+                if scope.moved_locals.contains(local) {
                     continue;
                 }
 

--- a/compiler/rustc_mir_build/src/builder/scope.rs
+++ b/compiler/rustc_mir_build/src/builder/scope.rs
@@ -1522,7 +1522,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         self.schedule_drop(span, region_scope, local, DropKind::ForLint);
     }
 
-    /// Indicates that the "local operand" stored in `local` is
+    /// Indicates that the "local operand" stored in `operand` is
     /// *moved* at some point during execution (see `local_scope` for
     /// more information about what a "local operand" is -- in short,
     /// it's an intermediate operand created as part of preparing some
@@ -1558,19 +1558,19 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
     /// spurious borrow-check errors -- the problem, ironically, is
     /// not the `DROP(_X)` itself, but the (spurious) unwind pathways
     /// that it creates. See #64391 for an example.
-    pub(crate) fn record_operands_moved(&mut self, operands: &[Spanned<Operand<'tcx>>]) {
+    #[instrument(level = "debug", skip(self))]
+    pub(crate) fn record_operand_moved(&mut self, operand: &Operand<'tcx>) {
         let local_scope = self.local_scope();
         let scope = self.scopes.scopes.last_mut().unwrap();
-
-        assert_eq!(scope.region_scope, local_scope, "local scope is not the topmost scope!",);
+        assert_eq!(scope.region_scope, local_scope, "local scope is not the topmost scope!");
 
         // look for moves of a local variable, like `MOVE(_X)`
-        let locals_moved = operands.iter().flat_map(|operand| match operand.node {
+        let local_moved = match operand {
             Operand::Copy(_) | Operand::Constant(_) | Operand::RuntimeChecks(_) => None,
             Operand::Move(place) => place.as_local(),
-        });
+        };
 
-        for local in locals_moved {
+        if let Some(local) = local_moved {
             // check if we have a Drop for this operand and -- if so
             // -- add it to the list of moved operands. Note that this
             // local might not have been an operand created for this

--- a/tests/mir-opt/box_conditional_drop_allocator.main.ElaborateDrops.diff
+++ b/tests/mir-opt/box_conditional_drop_allocator.main.ElaborateDrops.diff
@@ -31,11 +31,11 @@
           _2 = HasDrop;
           StorageLive(_3);
           _3 = DropAllocator;
-          _1 = Box::<HasDrop, DropAllocator>::new_in(move _2, move _3) -> [return: bb1, unwind: bb11];
++         _9 = const true;
+          _1 = Box::<HasDrop, DropAllocator>::new_in(move _2, move _3) -> [return: bb1, unwind continue];
       }
   
       bb1: {
-+         _9 = const true;
           StorageDead(_3);
           StorageDead(_2);
           StorageLive(_4);
@@ -47,7 +47,7 @@
           StorageLive(_5);
           StorageLive(_6);
           _6 = move (*_1);
-          _5 = std::mem::drop::<HasDrop>(move _6) -> [return: bb3, unwind: bb9];
+          _5 = std::mem::drop::<HasDrop>(move _6) -> [return: bb3, unwind: bb8];
       }
   
       bb3: {
@@ -75,7 +75,7 @@
       bb6: {
           StorageDead(_4);
 -         drop(_1) -> [return: bb7, unwind continue];
-+         goto -> bb23;
++         goto -> bb19;
       }
   
       bb7: {
@@ -85,102 +85,82 @@
       }
   
       bb8 (cleanup): {
--         drop(_8) -> [return: bb10, unwind terminate(cleanup)];
-+         goto -> bb10;
+-         drop(_1) -> [return: bb9, unwind terminate(cleanup)];
++         goto -> bb25;
       }
   
       bb9 (cleanup): {
--         drop(_6) -> [return: bb10, unwind terminate(cleanup)];
-+         goto -> bb10;
-      }
-  
-      bb10 (cleanup): {
--         drop(_1) -> [return: bb13, unwind terminate(cleanup)];
-+         goto -> bb29;
-      }
-  
-      bb11 (cleanup): {
--         drop(_3) -> [return: bb12, unwind terminate(cleanup)];
-+         goto -> bb12;
-      }
-  
-      bb12 (cleanup): {
--         drop(_2) -> [return: bb13, unwind terminate(cleanup)];
-+         goto -> bb13;
-      }
-  
-      bb13 (cleanup): {
           resume;
 +     }
 + 
-+     bb14: {
++     bb10: {
 +         _9 = const false;
 +         goto -> bb7;
 +     }
 + 
-+     bb15 (cleanup): {
-+         drop((_1.1: DropAllocator)) -> [return: bb13, unwind terminate(cleanup)];
++     bb11 (cleanup): {
++         drop((_1.1: DropAllocator)) -> [return: bb9, unwind terminate(cleanup)];
++     }
++ 
++     bb12 (cleanup): {
++         switchInt(copy _9) -> [0: bb9, otherwise: bb11];
++     }
++ 
++     bb13: {
++         drop((_1.1: DropAllocator)) -> [return: bb10, unwind: bb9];
++     }
++ 
++     bb14: {
++         switchInt(copy _9) -> [0: bb10, otherwise: bb13];
++     }
++ 
++     bb15: {
++         _10 = &mut _1;
++         _11 = <Box<HasDrop, DropAllocator> as Drop>::drop(move _10) -> [return: bb14, unwind: bb12];
 +     }
 + 
 +     bb16 (cleanup): {
-+         switchInt(copy _9) -> [0: bb13, otherwise: bb15];
++         _12 = &mut _1;
++         _13 = <Box<HasDrop, DropAllocator> as Drop>::drop(move _12) -> [return: bb12, unwind terminate(cleanup)];
 +     }
 + 
 +     bb17: {
-+         drop((_1.1: DropAllocator)) -> [return: bb14, unwind: bb13];
++         goto -> bb15;
 +     }
 + 
 +     bb18: {
-+         switchInt(copy _9) -> [0: bb14, otherwise: bb17];
++         _14 = copy ((_1.0: std::ptr::Unique<HasDrop>).0: std::ptr::NonNull<HasDrop>) as *const HasDrop (Transmute);
++         goto -> bb17;
 +     }
 + 
 +     bb19: {
-+         _10 = &mut _1;
-+         _11 = <Box<HasDrop, DropAllocator> as Drop>::drop(move _10) -> [return: bb18, unwind: bb16];
++         switchInt(copy _9) -> [0: bb14, otherwise: bb18];
 +     }
 + 
 +     bb20 (cleanup): {
-+         _12 = &mut _1;
-+         _13 = <Box<HasDrop, DropAllocator> as Drop>::drop(move _12) -> [return: bb16, unwind terminate(cleanup)];
++         drop((_1.1: DropAllocator)) -> [return: bb9, unwind terminate(cleanup)];
 +     }
 + 
-+     bb21: {
-+         goto -> bb19;
++     bb21 (cleanup): {
++         switchInt(copy _9) -> [0: bb9, otherwise: bb20];
 +     }
 + 
-+     bb22: {
-+         _14 = copy ((_1.0: std::ptr::Unique<HasDrop>).0: std::ptr::NonNull<HasDrop>) as *const HasDrop (Transmute);
-+         goto -> bb21;
++     bb22 (cleanup): {
++         _15 = &mut _1;
++         _16 = <Box<HasDrop, DropAllocator> as Drop>::drop(move _15) -> [return: bb21, unwind terminate(cleanup)];
 +     }
 + 
-+     bb23: {
-+         switchInt(copy _9) -> [0: bb18, otherwise: bb22];
++     bb23 (cleanup): {
++         goto -> bb22;
 +     }
 + 
 +     bb24 (cleanup): {
-+         drop((_1.1: DropAllocator)) -> [return: bb13, unwind terminate(cleanup)];
++         _17 = copy ((_1.0: std::ptr::Unique<HasDrop>).0: std::ptr::NonNull<HasDrop>) as *const HasDrop (Transmute);
++         goto -> bb23;
 +     }
 + 
 +     bb25 (cleanup): {
-+         switchInt(copy _9) -> [0: bb13, otherwise: bb24];
-+     }
-+ 
-+     bb26 (cleanup): {
-+         _15 = &mut _1;
-+         _16 = <Box<HasDrop, DropAllocator> as Drop>::drop(move _15) -> [return: bb25, unwind terminate(cleanup)];
-+     }
-+ 
-+     bb27 (cleanup): {
-+         goto -> bb26;
-+     }
-+ 
-+     bb28 (cleanup): {
-+         _17 = copy ((_1.0: std::ptr::Unique<HasDrop>).0: std::ptr::NonNull<HasDrop>) as *const HasDrop (Transmute);
-+         goto -> bb27;
-+     }
-+ 
-+     bb29 (cleanup): {
-+         switchInt(copy _9) -> [0: bb25, otherwise: bb28];
++         switchInt(copy _9) -> [0: bb21, otherwise: bb24];
       }
   }
   

--- a/tests/mir-opt/box_partial_move.maybe_move.ElaborateDrops.diff
+++ b/tests/mir-opt/box_partial_move.maybe_move.ElaborateDrops.diff
@@ -19,7 +19,7 @@
 +         _5 = const true;
           StorageLive(_3);
           _3 = copy _1;
-          switchInt(move _3) -> [0: bb3, otherwise: bb1];
+          switchInt(move _3) -> [0: bb2, otherwise: bb1];
       }
   
       bb1: {
@@ -27,68 +27,58 @@
 +         _5 = const false;
           _4 = move (*_2);
           _0 = Option::<String>::Some(move _4);
--         drop(_4) -> [return: bb2, unwind: bb6];
-+         goto -> bb2;
+          StorageDead(_4);
+          goto -> bb3;
       }
   
       bb2: {
-          StorageDead(_4);
-          goto -> bb4;
+          _0 = Option::<String>::None;
+          goto -> bb3;
       }
   
       bb3: {
-          _0 = Option::<String>::None;
-          goto -> bb4;
+          StorageDead(_3);
+-         drop(_2) -> [return: bb4, unwind continue];
++         goto -> bb12;
       }
   
       bb4: {
-          StorageDead(_3);
--         drop(_2) -> [return: bb5, unwind continue];
-+         goto -> bb14;
-      }
-  
-      bb5: {
           return;
-      }
-  
-      bb6 (cleanup): {
--         drop(_2) -> [return: bb7, unwind terminate(cleanup)];
-+         goto -> bb7;
-      }
-  
-      bb7 (cleanup): {
-          resume;
 +     }
 + 
-+     bb8: {
-+         goto -> bb5;
++     bb5 (cleanup): {
++         resume;
++     }
++ 
++     bb6: {
++         goto -> bb4;
++     }
++ 
++     bb7: {
++         _6 = &mut _2;
++         _7 = <Box<String> as Drop>::drop(move _6) -> [return: bb6, unwind: bb5];
++     }
++ 
++     bb8 (cleanup): {
++         _8 = &mut _2;
++         _9 = <Box<String> as Drop>::drop(move _8) -> [return: bb5, unwind terminate(cleanup)];
 +     }
 + 
 +     bb9: {
-+         _6 = &mut _2;
-+         _7 = <Box<String> as Drop>::drop(move _6) -> [return: bb8, unwind: bb7];
++         goto -> bb11;
 +     }
 + 
-+     bb10 (cleanup): {
-+         _8 = &mut _2;
-+         _9 = <Box<String> as Drop>::drop(move _8) -> [return: bb7, unwind terminate(cleanup)];
++     bb10: {
++         drop((*_10)) -> [return: bb7, unwind: bb8];
 +     }
 + 
 +     bb11: {
-+         goto -> bb13;
++         switchInt(copy _5) -> [0: bb7, otherwise: bb10];
 +     }
 + 
 +     bb12: {
-+         drop((*_10)) -> [return: bb9, unwind: bb10];
-+     }
-+ 
-+     bb13: {
-+         switchInt(copy _5) -> [0: bb9, otherwise: bb12];
-+     }
-+ 
-+     bb14: {
 +         _10 = copy ((_2.0: std::ptr::Unique<std::string::String>).0: std::ptr::NonNull<std::string::String>) as *const std::string::String (Transmute);
-+         goto -> bb11;
++         goto -> bb9;
       }
   }
   

--- a/tests/mir-opt/build_correct_coerce.main.built.after.mir
+++ b/tests/mir-opt/build_correct_coerce.main.built.after.mir
@@ -12,6 +12,10 @@ fn main() -> () {
         _1 = foo as for<'a> fn(&'a (), &'a ()) (PointerCoercion(ReifyFnPointer(Safe), AsCast));
         FakeRead(ForLet(None), _1);
         _0 = const ();
+        goto -> bb1;
+    }
+
+    bb1: {
         StorageDead(_1);
         return;
     }

--- a/tests/mir-opt/building/enum_cast.bar.built.after.mir
+++ b/tests/mir-opt/building/enum_cast.bar.built.after.mir
@@ -11,6 +11,10 @@ fn bar(_1: Bar) -> usize {
         _2 = move _1;
         _3 = discriminant(_2);
         _0 = move _3 as usize (IntToInt);
+        goto -> bb1;
+    }
+
+    bb1: {
         StorageDead(_2);
         return;
     }

--- a/tests/mir-opt/building/enum_cast.boo.built.after.mir
+++ b/tests/mir-opt/building/enum_cast.boo.built.after.mir
@@ -11,6 +11,10 @@ fn boo(_1: Boo) -> usize {
         _2 = move _1;
         _3 = discriminant(_2);
         _0 = move _3 as usize (IntToInt);
+        goto -> bb1;
+    }
+
+    bb1: {
         StorageDead(_2);
         return;
     }

--- a/tests/mir-opt/building/enum_cast.far.built.after.mir
+++ b/tests/mir-opt/building/enum_cast.far.built.after.mir
@@ -11,6 +11,10 @@ fn far(_1: Far) -> isize {
         _2 = move _1;
         _3 = discriminant(_2);
         _0 = move _3 as isize (IntToInt);
+        goto -> bb1;
+    }
+
+    bb1: {
         StorageDead(_2);
         return;
     }

--- a/tests/mir-opt/building/enum_cast.foo.built.after.mir
+++ b/tests/mir-opt/building/enum_cast.foo.built.after.mir
@@ -11,6 +11,10 @@ fn foo(_1: Foo) -> usize {
         _2 = move _1;
         _3 = discriminant(_2);
         _0 = move _3 as usize (IntToInt);
+        goto -> bb1;
+    }
+
+    bb1: {
         StorageDead(_2);
         return;
     }

--- a/tests/mir-opt/building/enum_cast.offsetty.built.after.mir
+++ b/tests/mir-opt/building/enum_cast.offsetty.built.after.mir
@@ -11,6 +11,10 @@ fn offsetty(_1: NotStartingAtZero) -> u32 {
         _2 = move _1;
         _3 = discriminant(_2);
         _0 = move _3 as u32 (IntToInt);
+        goto -> bb1;
+    }
+
+    bb1: {
         StorageDead(_2);
         return;
     }

--- a/tests/mir-opt/building/enum_cast.signy.built.after.mir
+++ b/tests/mir-opt/building/enum_cast.signy.built.after.mir
@@ -11,6 +11,10 @@ fn signy(_1: SignedAroundZero) -> i16 {
         _2 = move _1;
         _3 = discriminant(_2);
         _0 = move _3 as i16 (IntToInt);
+        goto -> bb1;
+    }
+
+    bb1: {
         StorageDead(_2);
         return;
     }

--- a/tests/mir-opt/building/enum_cast.unsigny.built.after.mir
+++ b/tests/mir-opt/building/enum_cast.unsigny.built.after.mir
@@ -11,6 +11,10 @@ fn unsigny(_1: UnsignedAroundZero) -> u16 {
         _2 = move _1;
         _3 = discriminant(_2);
         _0 = move _3 as u16 (IntToInt);
+        goto -> bb1;
+    }
+
+    bb1: {
         StorageDead(_2);
         return;
     }

--- a/tests/mir-opt/building/eq_never_type._f.built.after.mir
+++ b/tests/mir-opt/building/eq_never_type._f.built.after.mir
@@ -21,6 +21,10 @@ fn _f(_1: !, _2: !) -> () {
     }
 
     bb1: {
+        goto -> bb2;
+    }
+
+    bb2: {
         StorageDead(_6);
         StorageLive(_7);
         StorageLive(_8);
@@ -29,25 +33,37 @@ fn _f(_1: !, _2: !) -> () {
         unreachable;
     }
 
-    bb2: {
+    bb3: {
         _7 = &_8;
-        StorageDead(_9);
-        _4 = <() as PartialEq>::eq(move _5, move _7) -> [return: bb3, unwind: bb5];
+        goto -> bb4;
     }
 
-    bb3: {
+    bb4: {
+        StorageDead(_9);
+        _4 = <() as PartialEq>::eq(move _5, move _7) -> [return: bb5, unwind: bb9];
+    }
+
+    bb5: {
+        goto -> bb6;
+    }
+
+    bb6: {
         StorageDead(_7);
         StorageDead(_5);
+        goto -> bb7;
+    }
+
+    bb7: {
         StorageDead(_8);
         StorageDead(_4);
         unreachable;
     }
 
-    bb4: {
+    bb8: {
         return;
     }
 
-    bb5 (cleanup): {
+    bb9 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/building/fallible_struct_drop.build.ElaborateDrops.diff
+++ b/tests/mir-opt/building/fallible_struct_drop.build.ElaborateDrops.diff
@@ -129,7 +129,7 @@
   
       bb1: {
           StorageDead(_6);
-          _4 = <Result<String, ()> as Try>::branch(move _5) -> [return: bb2, unwind: bb91];
+          _4 = <Result<String, ()> as Try>::branch(move _5) -> [return: bb2, unwind: bb80];
       }
   
       bb2: {
@@ -148,7 +148,7 @@
           StorageLive(_12);
           _12 = move ((_4 as Continue).0: std::string::String);
           _3 = move _12;
--         drop(_12) -> [return: bb7, unwind: bb90];
+-         drop(_12) -> [return: bb7, unwind: bb79];
 +         goto -> bb7;
       }
   
@@ -157,7 +157,7 @@
           _9 = copy ((_4 as Break).0: std::result::Result<std::convert::Infallible, ()>);
           StorageLive(_11);
           _11 = copy _9;
-          _0 = <Result<Big, ()> as FromResidual<Result<Infallible, ()>>>::from_residual(move _11) -> [return: bb6, unwind: bb90];
+          _0 = <Result<Big, ()> as FromResidual<Result<Infallible, ()>>>::from_residual(move _11) -> [return: bb6, unwind: bb79];
       }
   
       bb6: {
@@ -165,7 +165,7 @@
           StorageDead(_9);
           StorageDead(_3);
           StorageDead(_2);
-          goto -> bb60;
+          goto -> bb54;
       }
   
       bb7: {
@@ -178,12 +178,12 @@
           _17 = copy _1;
           _16 = BitXor(move _17, const 1_u64);
           StorageDead(_17);
-          _15 = make_one(move _16) -> [return: bb8, unwind: bb89];
+          _15 = make_one(move _16) -> [return: bb8, unwind: bb78];
       }
   
       bb8: {
           StorageDead(_16);
-          _14 = <Result<String, ()> as Try>::branch(move _15) -> [return: bb9, unwind: bb88];
+          _14 = <Result<String, ()> as Try>::branch(move _15) -> [return: bb9, unwind: bb77];
       }
   
       bb9: {
@@ -198,7 +198,7 @@
           StorageLive(_22);
           _22 = move ((_14 as Continue).0: std::string::String);
           _13 = move _22;
--         drop(_22) -> [return: bb13, unwind: bb86];
+-         drop(_22) -> [return: bb13, unwind: bb75];
 +         goto -> bb13;
       }
   
@@ -207,14 +207,14 @@
           _19 = copy ((_14 as Break).0: std::result::Result<std::convert::Infallible, ()>);
           StorageLive(_21);
           _21 = copy _19;
-          _0 = <Result<Big, ()> as FromResidual<Result<Infallible, ()>>>::from_residual(move _21) -> [return: bb12, unwind: bb86];
+          _0 = <Result<Big, ()> as FromResidual<Result<Infallible, ()>>>::from_residual(move _21) -> [return: bb12, unwind: bb75];
       }
   
       bb12: {
           StorageDead(_21);
           StorageDead(_19);
           StorageDead(_13);
-          drop(_3) -> [return: bb57, unwind: bb87];
+          drop(_3) -> [return: bb51, unwind: bb76];
       }
   
       bb13: {
@@ -227,12 +227,12 @@
           _27 = copy _1;
           _26 = BitXor(move _27, const 2_u64);
           StorageDead(_27);
-          _25 = make_one(move _26) -> [return: bb14, unwind: bb85];
+          _25 = make_one(move _26) -> [return: bb14, unwind: bb74];
       }
   
       bb14: {
           StorageDead(_26);
-          _24 = <Result<String, ()> as Try>::branch(move _25) -> [return: bb15, unwind: bb84];
+          _24 = <Result<String, ()> as Try>::branch(move _25) -> [return: bb15, unwind: bb73];
       }
   
       bb15: {
@@ -247,7 +247,7 @@
           StorageLive(_32);
           _32 = move ((_24 as Continue).0: std::string::String);
           _23 = move _32;
--         drop(_32) -> [return: bb19, unwind: bb81];
+-         drop(_32) -> [return: bb19, unwind: bb70];
 +         goto -> bb19;
       }
   
@@ -256,14 +256,14 @@
           _29 = copy ((_24 as Break).0: std::result::Result<std::convert::Infallible, ()>);
           StorageLive(_31);
           _31 = copy _29;
-          _0 = <Result<Big, ()> as FromResidual<Result<Infallible, ()>>>::from_residual(move _31) -> [return: bb18, unwind: bb81];
+          _0 = <Result<Big, ()> as FromResidual<Result<Infallible, ()>>>::from_residual(move _31) -> [return: bb18, unwind: bb70];
       }
   
       bb18: {
           StorageDead(_31);
           StorageDead(_29);
           StorageDead(_23);
-          drop(_13) -> [return: bb53, unwind: bb82];
+          drop(_13) -> [return: bb47, unwind: bb71];
       }
   
       bb19: {
@@ -276,12 +276,12 @@
           _37 = copy _1;
           _36 = BitXor(move _37, const 3_u64);
           StorageDead(_37);
-          _35 = make_one(move _36) -> [return: bb20, unwind: bb80];
+          _35 = make_one(move _36) -> [return: bb20, unwind: bb69];
       }
   
       bb20: {
           StorageDead(_36);
-          _34 = <Result<String, ()> as Try>::branch(move _35) -> [return: bb21, unwind: bb79];
+          _34 = <Result<String, ()> as Try>::branch(move _35) -> [return: bb21, unwind: bb68];
       }
   
       bb21: {
@@ -296,7 +296,7 @@
           StorageLive(_42);
           _42 = move ((_34 as Continue).0: std::string::String);
           _33 = move _42;
--         drop(_42) -> [return: bb25, unwind: bb75];
+-         drop(_42) -> [return: bb25, unwind: bb64];
 +         goto -> bb25;
       }
   
@@ -305,14 +305,14 @@
           _39 = copy ((_34 as Break).0: std::result::Result<std::convert::Infallible, ()>);
           StorageLive(_41);
           _41 = copy _39;
-          _0 = <Result<Big, ()> as FromResidual<Result<Infallible, ()>>>::from_residual(move _41) -> [return: bb24, unwind: bb75];
+          _0 = <Result<Big, ()> as FromResidual<Result<Infallible, ()>>>::from_residual(move _41) -> [return: bb24, unwind: bb64];
       }
   
       bb24: {
           StorageDead(_41);
           StorageDead(_39);
           StorageDead(_33);
-          drop(_23) -> [return: bb48, unwind: bb76];
+          drop(_23) -> [return: bb42, unwind: bb65];
       }
   
       bb25: {
@@ -325,12 +325,12 @@
           _47 = copy _1;
           _46 = BitXor(move _47, const 4_u64);
           StorageDead(_47);
-          _45 = make_one(move _46) -> [return: bb26, unwind: bb74];
+          _45 = make_one(move _46) -> [return: bb26, unwind: bb63];
       }
   
       bb26: {
           StorageDead(_46);
-          _44 = <Result<String, ()> as Try>::branch(move _45) -> [return: bb27, unwind: bb73];
+          _44 = <Result<String, ()> as Try>::branch(move _45) -> [return: bb27, unwind: bb62];
       }
   
       bb27: {
@@ -344,7 +344,7 @@
           StorageLive(_52);
           _52 = move ((_44 as Continue).0: std::string::String);
           _43 = move _52;
--         drop(_52) -> [return: bb31, unwind: bb68];
+-         drop(_52) -> [return: bb31, unwind: bb57];
 +         goto -> bb31;
       }
   
@@ -353,228 +353,221 @@
           _49 = copy ((_44 as Break).0: std::result::Result<std::convert::Infallible, ()>);
           StorageLive(_51);
           _51 = copy _49;
-          _0 = <Result<Big, ()> as FromResidual<Result<Infallible, ()>>>::from_residual(move _51) -> [return: bb30, unwind: bb68];
+          _0 = <Result<Big, ()> as FromResidual<Result<Infallible, ()>>>::from_residual(move _51) -> [return: bb30, unwind: bb57];
       }
   
       bb30: {
           StorageDead(_51);
           StorageDead(_49);
           StorageDead(_43);
-          drop(_33) -> [return: bb43, unwind: bb69];
+          drop(_33) -> [return: bb37, unwind: bb58];
       }
   
       bb31: {
           StorageDead(_52);
           _2 = Big { f0: move _3, f1: move _13, f2: move _23, f3: move _33, f4: move _43 };
--         drop(_43) -> [return: bb32, unwind: bb63];
-+         goto -> bb32;
+          StorageDead(_43);
+          StorageDead(_33);
+          StorageDead(_23);
+          StorageDead(_13);
+          StorageDead(_3);
+          _0 = Result::<Big, ()>::Ok(move _2);
+          StorageDead(_2);
+-         drop(_44) -> [return: bb32, unwind: bb67];
++         goto -> bb82;
       }
   
       bb32: {
-          StorageDead(_43);
--         drop(_33) -> [return: bb33, unwind: bb64];
-+         goto -> bb33;
+          StorageDead(_44);
+-         drop(_34) -> [return: bb33, unwind: bb72];
++         goto -> bb83;
       }
   
       bb33: {
-          StorageDead(_33);
--         drop(_23) -> [return: bb34, unwind: bb65];
-+         goto -> bb34;
++         _53 = const false;
+          StorageDead(_34);
+-         drop(_24) -> [return: bb34, unwind: bb76];
++         goto -> bb84;
       }
   
       bb34: {
-          StorageDead(_23);
--         drop(_13) -> [return: bb35, unwind: bb66];
-+         goto -> bb35;
++         _54 = const false;
+          StorageDead(_24);
+-         drop(_14) -> [return: bb35, unwind: bb79];
++         goto -> bb85;
       }
   
       bb35: {
-          StorageDead(_13);
--         drop(_3) -> [return: bb36, unwind: bb67];
-+         goto -> bb36;
++         _55 = const false;
+          StorageDead(_14);
+-         drop(_4) -> [return: bb36, unwind continue];
++         goto -> bb86;
       }
   
       bb36: {
-          StorageDead(_3);
-          _0 = Result::<Big, ()>::Ok(move _2);
--         drop(_2) -> [return: bb37, unwind: bb72];
-+         goto -> bb37;
++         _56 = const false;
+          StorageDead(_4);
+          goto -> bb56;
       }
   
       bb37: {
-          StorageDead(_2);
--         drop(_44) -> [return: bb38, unwind: bb78];
-+         goto -> bb93;
+          StorageDead(_33);
+          drop(_23) -> [return: bb38, unwind: bb59];
       }
   
       bb38: {
-          StorageDead(_44);
--         drop(_34) -> [return: bb39, unwind: bb83];
-+         goto -> bb94;
+          StorageDead(_23);
+          drop(_13) -> [return: bb39, unwind: bb60];
       }
   
       bb39: {
-+         _53 = const false;
-          StorageDead(_34);
--         drop(_24) -> [return: bb40, unwind: bb87];
-+         goto -> bb95;
+          StorageDead(_13);
+          drop(_3) -> [return: bb40, unwind: bb61];
       }
   
       bb40: {
-+         _54 = const false;
-          StorageDead(_24);
--         drop(_14) -> [return: bb41, unwind: bb90];
-+         goto -> bb96;
+          StorageDead(_3);
+          StorageDead(_2);
+-         drop(_44) -> [return: bb41, unwind: bb67];
++         goto -> bb87;
       }
   
       bb41: {
-+         _55 = const false;
-          StorageDead(_14);
--         drop(_4) -> [return: bb42, unwind continue];
-+         goto -> bb97;
+          StorageDead(_44);
+          goto -> bb45;
       }
   
       bb42: {
-+         _56 = const false;
-          StorageDead(_4);
-          goto -> bb62;
+          StorageDead(_23);
+          drop(_13) -> [return: bb43, unwind: bb66];
       }
   
       bb43: {
-          StorageDead(_33);
-          drop(_23) -> [return: bb44, unwind: bb70];
+          StorageDead(_13);
+          drop(_3) -> [return: bb44, unwind: bb67];
       }
   
       bb44: {
-          StorageDead(_23);
-          drop(_13) -> [return: bb45, unwind: bb71];
+          StorageDead(_3);
+          StorageDead(_2);
+          goto -> bb45;
       }
   
       bb45: {
-          StorageDead(_13);
-          drop(_3) -> [return: bb46, unwind: bb72];
+-         drop(_34) -> [return: bb46, unwind: bb72];
++         goto -> bb88;
       }
   
       bb46: {
-          StorageDead(_3);
-          StorageDead(_2);
--         drop(_44) -> [return: bb47, unwind: bb78];
-+         goto -> bb98;
++         _53 = const false;
+          StorageDead(_34);
+          goto -> bb49;
       }
   
       bb47: {
-          StorageDead(_44);
-          goto -> bb51;
+          StorageDead(_13);
+          drop(_3) -> [return: bb48, unwind: bb72];
       }
   
       bb48: {
-          StorageDead(_23);
-          drop(_13) -> [return: bb49, unwind: bb77];
+          StorageDead(_3);
+          StorageDead(_2);
+          goto -> bb49;
       }
   
       bb49: {
-          StorageDead(_13);
-          drop(_3) -> [return: bb50, unwind: bb78];
+-         drop(_24) -> [return: bb50, unwind: bb76];
++         goto -> bb89;
       }
   
       bb50: {
-          StorageDead(_3);
-          StorageDead(_2);
-          goto -> bb51;
++         _54 = const false;
+          StorageDead(_24);
+          goto -> bb52;
       }
   
       bb51: {
--         drop(_34) -> [return: bb52, unwind: bb83];
-+         goto -> bb99;
+          StorageDead(_3);
+          StorageDead(_2);
+          goto -> bb52;
       }
   
       bb52: {
-+         _53 = const false;
-          StorageDead(_34);
-          goto -> bb55;
+-         drop(_14) -> [return: bb53, unwind: bb79];
++         goto -> bb90;
       }
   
       bb53: {
-          StorageDead(_13);
-          drop(_3) -> [return: bb54, unwind: bb83];
++         _55 = const false;
+          StorageDead(_14);
+          goto -> bb54;
       }
   
       bb54: {
-          StorageDead(_3);
-          StorageDead(_2);
-          goto -> bb55;
+-         drop(_4) -> [return: bb55, unwind continue];
++         goto -> bb91;
       }
   
       bb55: {
--         drop(_24) -> [return: bb56, unwind: bb87];
-+         goto -> bb100;
++         _56 = const false;
+          StorageDead(_4);
+          goto -> bb56;
       }
   
       bb56: {
-+         _54 = const false;
-          StorageDead(_24);
-          goto -> bb58;
-      }
-  
-      bb57: {
-          StorageDead(_3);
-          StorageDead(_2);
-          goto -> bb58;
-      }
-  
-      bb58: {
--         drop(_14) -> [return: bb59, unwind: bb90];
-+         goto -> bb101;
-      }
-  
-      bb59: {
-+         _55 = const false;
-          StorageDead(_14);
-          goto -> bb60;
-      }
-  
-      bb60: {
--         drop(_4) -> [return: bb61, unwind continue];
-+         goto -> bb102;
-      }
-  
-      bb61: {
-+         _56 = const false;
-          StorageDead(_4);
-          goto -> bb62;
-      }
-  
-      bb62: {
           return;
       }
   
-      bb63 (cleanup): {
--         drop(_33) -> [return: bb64, unwind terminate(cleanup)];
-+         goto -> bb64;
+      bb57 (cleanup): {
+          drop(_33) -> [return: bb58, unwind terminate(cleanup)];
       }
   
-      bb64 (cleanup): {
--         drop(_23) -> [return: bb65, unwind terminate(cleanup)];
-+         goto -> bb65;
+      bb58 (cleanup): {
+          drop(_23) -> [return: bb59, unwind terminate(cleanup)];
       }
   
-      bb65 (cleanup): {
--         drop(_13) -> [return: bb66, unwind terminate(cleanup)];
-+         goto -> bb66;
+      bb59 (cleanup): {
+          drop(_13) -> [return: bb60, unwind terminate(cleanup)];
       }
   
-      bb66 (cleanup): {
--         drop(_3) -> [return: bb67, unwind terminate(cleanup)];
+      bb60 (cleanup): {
+          drop(_3) -> [return: bb61, unwind terminate(cleanup)];
+      }
+  
+      bb61 (cleanup): {
+-         drop(_44) -> [return: bb67, unwind terminate(cleanup)];
 +         goto -> bb67;
       }
   
+      bb62 (cleanup): {
+-         drop(_45) -> [return: bb63, unwind terminate(cleanup)];
++         goto -> bb63;
+      }
+  
+      bb63 (cleanup): {
+          drop(_33) -> [return: bb64, unwind terminate(cleanup)];
+      }
+  
+      bb64 (cleanup): {
+          drop(_23) -> [return: bb65, unwind terminate(cleanup)];
+      }
+  
+      bb65 (cleanup): {
+          drop(_13) -> [return: bb66, unwind terminate(cleanup)];
+      }
+  
+      bb66 (cleanup): {
+          drop(_3) -> [return: bb67, unwind terminate(cleanup)];
+      }
+  
       bb67 (cleanup): {
--         drop(_2) -> [return: bb72, unwind terminate(cleanup)];
+-         drop(_34) -> [return: bb72, unwind terminate(cleanup)];
 +         goto -> bb72;
       }
   
       bb68 (cleanup): {
-          drop(_33) -> [return: bb69, unwind terminate(cleanup)];
+-         drop(_35) -> [return: bb69, unwind terminate(cleanup)];
++         goto -> bb69;
       }
   
       bb69 (cleanup): {
@@ -590,137 +583,89 @@
       }
   
       bb72 (cleanup): {
--         drop(_44) -> [return: bb78, unwind terminate(cleanup)];
-+         goto -> bb78;
+-         drop(_24) -> [return: bb76, unwind terminate(cleanup)];
++         goto -> bb76;
       }
   
       bb73 (cleanup): {
--         drop(_45) -> [return: bb74, unwind terminate(cleanup)];
+-         drop(_25) -> [return: bb74, unwind terminate(cleanup)];
 +         goto -> bb74;
       }
   
       bb74 (cleanup): {
-          drop(_33) -> [return: bb75, unwind terminate(cleanup)];
+          drop(_13) -> [return: bb75, unwind terminate(cleanup)];
       }
   
       bb75 (cleanup): {
-          drop(_23) -> [return: bb76, unwind terminate(cleanup)];
+          drop(_3) -> [return: bb76, unwind terminate(cleanup)];
       }
   
       bb76 (cleanup): {
-          drop(_13) -> [return: bb77, unwind terminate(cleanup)];
+-         drop(_14) -> [return: bb79, unwind terminate(cleanup)];
++         goto -> bb79;
       }
   
       bb77 (cleanup): {
-          drop(_3) -> [return: bb78, unwind terminate(cleanup)];
+-         drop(_15) -> [return: bb78, unwind terminate(cleanup)];
++         goto -> bb78;
       }
   
       bb78 (cleanup): {
--         drop(_34) -> [return: bb83, unwind terminate(cleanup)];
-+         goto -> bb83;
+          drop(_3) -> [return: bb79, unwind terminate(cleanup)];
       }
   
       bb79 (cleanup): {
--         drop(_35) -> [return: bb80, unwind terminate(cleanup)];
-+         goto -> bb80;
+-         drop(_4) -> [return: bb81, unwind terminate(cleanup)];
++         goto -> bb81;
       }
   
       bb80 (cleanup): {
-          drop(_23) -> [return: bb81, unwind terminate(cleanup)];
+-         drop(_5) -> [return: bb81, unwind terminate(cleanup)];
++         goto -> bb81;
       }
   
       bb81 (cleanup): {
-          drop(_13) -> [return: bb82, unwind terminate(cleanup)];
-      }
-  
-      bb82 (cleanup): {
-          drop(_3) -> [return: bb83, unwind terminate(cleanup)];
-      }
-  
-      bb83 (cleanup): {
--         drop(_24) -> [return: bb87, unwind terminate(cleanup)];
-+         goto -> bb87;
-      }
-  
-      bb84 (cleanup): {
--         drop(_25) -> [return: bb85, unwind terminate(cleanup)];
-+         goto -> bb85;
-      }
-  
-      bb85 (cleanup): {
-          drop(_13) -> [return: bb86, unwind terminate(cleanup)];
-      }
-  
-      bb86 (cleanup): {
-          drop(_3) -> [return: bb87, unwind terminate(cleanup)];
-      }
-  
-      bb87 (cleanup): {
--         drop(_14) -> [return: bb90, unwind terminate(cleanup)];
-+         goto -> bb90;
-      }
-  
-      bb88 (cleanup): {
--         drop(_15) -> [return: bb89, unwind terminate(cleanup)];
-+         goto -> bb89;
-      }
-  
-      bb89 (cleanup): {
-          drop(_3) -> [return: bb90, unwind terminate(cleanup)];
-      }
-  
-      bb90 (cleanup): {
--         drop(_4) -> [return: bb92, unwind terminate(cleanup)];
-+         goto -> bb92;
-      }
-  
-      bb91 (cleanup): {
--         drop(_5) -> [return: bb92, unwind terminate(cleanup)];
-+         goto -> bb92;
-      }
-  
-      bb92 (cleanup): {
           resume;
 +     }
 + 
-+     bb93: {
-+         goto -> bb38;
++     bb82: {
++         goto -> bb32;
 +     }
 + 
-+     bb94: {
-+         goto -> bb39;
++     bb83: {
++         goto -> bb33;
 +     }
 + 
-+     bb95: {
-+         goto -> bb40;
++     bb84: {
++         goto -> bb34;
 +     }
 + 
-+     bb96: {
++     bb85: {
++         goto -> bb35;
++     }
++ 
++     bb86: {
++         goto -> bb36;
++     }
++ 
++     bb87: {
 +         goto -> bb41;
 +     }
 + 
-+     bb97: {
-+         goto -> bb42;
++     bb88: {
++         goto -> bb46;
 +     }
 + 
-+     bb98: {
-+         goto -> bb47;
++     bb89: {
++         goto -> bb50;
 +     }
 + 
-+     bb99: {
-+         goto -> bb52;
++     bb90: {
++         goto -> bb53;
 +     }
 + 
-+     bb100: {
-+         goto -> bb56;
-+     }
-+ 
-+     bb101: {
-+         goto -> bb59;
-+     }
-+ 
-+     bb102: {
-+         goto -> bb61;
++     bb91: {
++         goto -> bb55;
       }
   }
   

--- a/tests/mir-opt/building/fallible_struct_drop.build.ElaborateDrops.diff
+++ b/tests/mir-opt/building/fallible_struct_drop.build.ElaborateDrops.diff
@@ -129,11 +129,11 @@
   
       bb1: {
           StorageDead(_6);
-          _4 = <Result<String, ()> as Try>::branch(move _5) -> [return: bb2, unwind: bb80];
++         _56 = const true;
+          _4 = <Result<String, ()> as Try>::branch(move _5) -> [return: bb2, unwind continue];
       }
   
       bb2: {
-+         _56 = const true;
           StorageDead(_5);
           PlaceMention(_4);
           _8 = discriminant(_4);
@@ -148,7 +148,7 @@
           StorageLive(_12);
           _12 = move ((_4 as Continue).0: std::string::String);
           _3 = move _12;
--         drop(_12) -> [return: bb7, unwind: bb79];
+-         drop(_12) -> [return: bb7, unwind: bb75];
 +         goto -> bb7;
       }
   
@@ -157,7 +157,7 @@
           _9 = copy ((_4 as Break).0: std::result::Result<std::convert::Infallible, ()>);
           StorageLive(_11);
           _11 = copy _9;
-          _0 = <Result<Big, ()> as FromResidual<Result<Infallible, ()>>>::from_residual(move _11) -> [return: bb6, unwind: bb79];
+          _0 = <Result<Big, ()> as FromResidual<Result<Infallible, ()>>>::from_residual(move _11) -> [return: bb6, unwind: bb75];
       }
   
       bb6: {
@@ -178,12 +178,12 @@
           _17 = copy _1;
           _16 = BitXor(move _17, const 1_u64);
           StorageDead(_17);
-          _15 = make_one(move _16) -> [return: bb8, unwind: bb78];
+          _15 = make_one(move _16) -> [return: bb8, unwind: bb74];
       }
   
       bb8: {
           StorageDead(_16);
-          _14 = <Result<String, ()> as Try>::branch(move _15) -> [return: bb9, unwind: bb77];
+          _14 = <Result<String, ()> as Try>::branch(move _15) -> [return: bb9, unwind: bb74];
       }
   
       bb9: {
@@ -198,7 +198,7 @@
           StorageLive(_22);
           _22 = move ((_14 as Continue).0: std::string::String);
           _13 = move _22;
--         drop(_22) -> [return: bb13, unwind: bb75];
+-         drop(_22) -> [return: bb13, unwind: bb72];
 +         goto -> bb13;
       }
   
@@ -207,14 +207,14 @@
           _19 = copy ((_14 as Break).0: std::result::Result<std::convert::Infallible, ()>);
           StorageLive(_21);
           _21 = copy _19;
-          _0 = <Result<Big, ()> as FromResidual<Result<Infallible, ()>>>::from_residual(move _21) -> [return: bb12, unwind: bb75];
+          _0 = <Result<Big, ()> as FromResidual<Result<Infallible, ()>>>::from_residual(move _21) -> [return: bb12, unwind: bb72];
       }
   
       bb12: {
           StorageDead(_21);
           StorageDead(_19);
           StorageDead(_13);
-          drop(_3) -> [return: bb51, unwind: bb76];
+          drop(_3) -> [return: bb51, unwind: bb73];
       }
   
       bb13: {
@@ -227,12 +227,12 @@
           _27 = copy _1;
           _26 = BitXor(move _27, const 2_u64);
           StorageDead(_27);
-          _25 = make_one(move _26) -> [return: bb14, unwind: bb74];
+          _25 = make_one(move _26) -> [return: bb14, unwind: bb71];
       }
   
       bb14: {
           StorageDead(_26);
-          _24 = <Result<String, ()> as Try>::branch(move _25) -> [return: bb15, unwind: bb73];
+          _24 = <Result<String, ()> as Try>::branch(move _25) -> [return: bb15, unwind: bb71];
       }
   
       bb15: {
@@ -247,7 +247,7 @@
           StorageLive(_32);
           _32 = move ((_24 as Continue).0: std::string::String);
           _23 = move _32;
--         drop(_32) -> [return: bb19, unwind: bb70];
+-         drop(_32) -> [return: bb19, unwind: bb68];
 +         goto -> bb19;
       }
   
@@ -256,14 +256,14 @@
           _29 = copy ((_24 as Break).0: std::result::Result<std::convert::Infallible, ()>);
           StorageLive(_31);
           _31 = copy _29;
-          _0 = <Result<Big, ()> as FromResidual<Result<Infallible, ()>>>::from_residual(move _31) -> [return: bb18, unwind: bb70];
+          _0 = <Result<Big, ()> as FromResidual<Result<Infallible, ()>>>::from_residual(move _31) -> [return: bb18, unwind: bb68];
       }
   
       bb18: {
           StorageDead(_31);
           StorageDead(_29);
           StorageDead(_23);
-          drop(_13) -> [return: bb47, unwind: bb71];
+          drop(_13) -> [return: bb47, unwind: bb69];
       }
   
       bb19: {
@@ -276,12 +276,12 @@
           _37 = copy _1;
           _36 = BitXor(move _37, const 3_u64);
           StorageDead(_37);
-          _35 = make_one(move _36) -> [return: bb20, unwind: bb69];
+          _35 = make_one(move _36) -> [return: bb20, unwind: bb67];
       }
   
       bb20: {
           StorageDead(_36);
-          _34 = <Result<String, ()> as Try>::branch(move _35) -> [return: bb21, unwind: bb68];
+          _34 = <Result<String, ()> as Try>::branch(move _35) -> [return: bb21, unwind: bb67];
       }
   
       bb21: {
@@ -296,7 +296,7 @@
           StorageLive(_42);
           _42 = move ((_34 as Continue).0: std::string::String);
           _33 = move _42;
--         drop(_42) -> [return: bb25, unwind: bb64];
+-         drop(_42) -> [return: bb25, unwind: bb63];
 +         goto -> bb25;
       }
   
@@ -305,14 +305,14 @@
           _39 = copy ((_34 as Break).0: std::result::Result<std::convert::Infallible, ()>);
           StorageLive(_41);
           _41 = copy _39;
-          _0 = <Result<Big, ()> as FromResidual<Result<Infallible, ()>>>::from_residual(move _41) -> [return: bb24, unwind: bb64];
+          _0 = <Result<Big, ()> as FromResidual<Result<Infallible, ()>>>::from_residual(move _41) -> [return: bb24, unwind: bb63];
       }
   
       bb24: {
           StorageDead(_41);
           StorageDead(_39);
           StorageDead(_33);
-          drop(_23) -> [return: bb42, unwind: bb65];
+          drop(_23) -> [return: bb42, unwind: bb64];
       }
   
       bb25: {
@@ -325,7 +325,7 @@
           _47 = copy _1;
           _46 = BitXor(move _47, const 4_u64);
           StorageDead(_47);
-          _45 = make_one(move _46) -> [return: bb26, unwind: bb63];
+          _45 = make_one(move _46) -> [return: bb26, unwind: bb62];
       }
   
       bb26: {
@@ -373,35 +373,35 @@
           StorageDead(_3);
           _0 = Result::<Big, ()>::Ok(move _2);
           StorageDead(_2);
--         drop(_44) -> [return: bb32, unwind: bb67];
-+         goto -> bb82;
+-         drop(_44) -> [return: bb32, unwind: bb66];
++         goto -> bb77;
       }
   
       bb32: {
           StorageDead(_44);
--         drop(_34) -> [return: bb33, unwind: bb72];
-+         goto -> bb83;
+-         drop(_34) -> [return: bb33, unwind: bb70];
++         goto -> bb78;
       }
   
       bb33: {
 +         _53 = const false;
           StorageDead(_34);
--         drop(_24) -> [return: bb34, unwind: bb76];
-+         goto -> bb84;
+-         drop(_24) -> [return: bb34, unwind: bb73];
++         goto -> bb79;
       }
   
       bb34: {
 +         _54 = const false;
           StorageDead(_24);
--         drop(_14) -> [return: bb35, unwind: bb79];
-+         goto -> bb85;
+-         drop(_14) -> [return: bb35, unwind: bb75];
++         goto -> bb80;
       }
   
       bb35: {
 +         _55 = const false;
           StorageDead(_14);
 -         drop(_4) -> [return: bb36, unwind continue];
-+         goto -> bb86;
++         goto -> bb81;
       }
   
       bb36: {
@@ -428,8 +428,8 @@
       bb40: {
           StorageDead(_3);
           StorageDead(_2);
--         drop(_44) -> [return: bb41, unwind: bb67];
-+         goto -> bb87;
+-         drop(_44) -> [return: bb41, unwind: bb66];
++         goto -> bb82;
       }
   
       bb41: {
@@ -439,12 +439,12 @@
   
       bb42: {
           StorageDead(_23);
-          drop(_13) -> [return: bb43, unwind: bb66];
+          drop(_13) -> [return: bb43, unwind: bb65];
       }
   
       bb43: {
           StorageDead(_13);
-          drop(_3) -> [return: bb44, unwind: bb67];
+          drop(_3) -> [return: bb44, unwind: bb66];
       }
   
       bb44: {
@@ -454,8 +454,8 @@
       }
   
       bb45: {
--         drop(_34) -> [return: bb46, unwind: bb72];
-+         goto -> bb88;
+-         drop(_34) -> [return: bb46, unwind: bb70];
++         goto -> bb83;
       }
   
       bb46: {
@@ -466,7 +466,7 @@
   
       bb47: {
           StorageDead(_13);
-          drop(_3) -> [return: bb48, unwind: bb72];
+          drop(_3) -> [return: bb48, unwind: bb70];
       }
   
       bb48: {
@@ -476,8 +476,8 @@
       }
   
       bb49: {
--         drop(_24) -> [return: bb50, unwind: bb76];
-+         goto -> bb89;
+-         drop(_24) -> [return: bb50, unwind: bb73];
++         goto -> bb84;
       }
   
       bb50: {
@@ -493,8 +493,8 @@
       }
   
       bb52: {
--         drop(_14) -> [return: bb53, unwind: bb79];
-+         goto -> bb90;
+-         drop(_14) -> [return: bb53, unwind: bb75];
++         goto -> bb85;
       }
   
       bb53: {
@@ -505,7 +505,7 @@
   
       bb54: {
 -         drop(_4) -> [return: bb55, unwind continue];
-+         goto -> bb91;
++         goto -> bb86;
       }
   
       bb55: {
@@ -535,136 +535,111 @@
       }
   
       bb61 (cleanup): {
--         drop(_44) -> [return: bb67, unwind terminate(cleanup)];
-+         goto -> bb67;
+-         drop(_44) -> [return: bb66, unwind terminate(cleanup)];
++         goto -> bb66;
       }
   
       bb62 (cleanup): {
--         drop(_45) -> [return: bb63, unwind terminate(cleanup)];
-+         goto -> bb63;
+          drop(_33) -> [return: bb63, unwind terminate(cleanup)];
       }
   
       bb63 (cleanup): {
-          drop(_33) -> [return: bb64, unwind terminate(cleanup)];
+          drop(_23) -> [return: bb64, unwind terminate(cleanup)];
       }
   
       bb64 (cleanup): {
-          drop(_23) -> [return: bb65, unwind terminate(cleanup)];
+          drop(_13) -> [return: bb65, unwind terminate(cleanup)];
       }
   
       bb65 (cleanup): {
-          drop(_13) -> [return: bb66, unwind terminate(cleanup)];
+          drop(_3) -> [return: bb66, unwind terminate(cleanup)];
       }
   
       bb66 (cleanup): {
-          drop(_3) -> [return: bb67, unwind terminate(cleanup)];
+-         drop(_34) -> [return: bb70, unwind terminate(cleanup)];
++         goto -> bb70;
       }
   
       bb67 (cleanup): {
--         drop(_34) -> [return: bb72, unwind terminate(cleanup)];
-+         goto -> bb72;
+          drop(_23) -> [return: bb68, unwind terminate(cleanup)];
       }
   
       bb68 (cleanup): {
--         drop(_35) -> [return: bb69, unwind terminate(cleanup)];
-+         goto -> bb69;
+          drop(_13) -> [return: bb69, unwind terminate(cleanup)];
       }
   
       bb69 (cleanup): {
-          drop(_23) -> [return: bb70, unwind terminate(cleanup)];
+          drop(_3) -> [return: bb70, unwind terminate(cleanup)];
       }
   
       bb70 (cleanup): {
-          drop(_13) -> [return: bb71, unwind terminate(cleanup)];
+-         drop(_24) -> [return: bb73, unwind terminate(cleanup)];
++         goto -> bb73;
       }
   
       bb71 (cleanup): {
-          drop(_3) -> [return: bb72, unwind terminate(cleanup)];
+          drop(_13) -> [return: bb72, unwind terminate(cleanup)];
       }
   
       bb72 (cleanup): {
--         drop(_24) -> [return: bb76, unwind terminate(cleanup)];
-+         goto -> bb76;
+          drop(_3) -> [return: bb73, unwind terminate(cleanup)];
       }
   
       bb73 (cleanup): {
--         drop(_25) -> [return: bb74, unwind terminate(cleanup)];
-+         goto -> bb74;
+-         drop(_14) -> [return: bb75, unwind terminate(cleanup)];
++         goto -> bb75;
       }
   
       bb74 (cleanup): {
-          drop(_13) -> [return: bb75, unwind terminate(cleanup)];
+          drop(_3) -> [return: bb75, unwind terminate(cleanup)];
       }
   
       bb75 (cleanup): {
-          drop(_3) -> [return: bb76, unwind terminate(cleanup)];
+-         drop(_4) -> [return: bb76, unwind terminate(cleanup)];
++         goto -> bb76;
       }
   
       bb76 (cleanup): {
--         drop(_14) -> [return: bb79, unwind terminate(cleanup)];
-+         goto -> bb79;
-      }
-  
-      bb77 (cleanup): {
--         drop(_15) -> [return: bb78, unwind terminate(cleanup)];
-+         goto -> bb78;
-      }
-  
-      bb78 (cleanup): {
-          drop(_3) -> [return: bb79, unwind terminate(cleanup)];
-      }
-  
-      bb79 (cleanup): {
--         drop(_4) -> [return: bb81, unwind terminate(cleanup)];
-+         goto -> bb81;
-      }
-  
-      bb80 (cleanup): {
--         drop(_5) -> [return: bb81, unwind terminate(cleanup)];
-+         goto -> bb81;
-      }
-  
-      bb81 (cleanup): {
           resume;
 +     }
 + 
-+     bb82: {
++     bb77: {
 +         goto -> bb32;
 +     }
 + 
-+     bb83: {
++     bb78: {
 +         goto -> bb33;
 +     }
 + 
-+     bb84: {
++     bb79: {
 +         goto -> bb34;
 +     }
 + 
-+     bb85: {
++     bb80: {
 +         goto -> bb35;
 +     }
 + 
-+     bb86: {
++     bb81: {
 +         goto -> bb36;
 +     }
 + 
-+     bb87: {
++     bb82: {
 +         goto -> bb41;
 +     }
 + 
-+     bb88: {
++     bb83: {
 +         goto -> bb46;
 +     }
 + 
-+     bb89: {
++     bb84: {
 +         goto -> bb50;
 +     }
 + 
-+     bb90: {
++     bb85: {
 +         goto -> bb53;
 +     }
 + 
-+     bb91: {
++     bb86: {
 +         goto -> bb55;
       }
   }

--- a/tests/mir-opt/building/index_array_and_slice.index_array.built.after.mir
+++ b/tests/mir-opt/building/index_array_and_slice.index_array.built.after.mir
@@ -14,18 +14,22 @@ fn index_array(_1: &[i32; 7], _2: usize) -> &i32 {
         _4 = copy _2;
         FakeRead(ForIndex, (*_1));
         _5 = Lt(copy _4, const 7_usize);
-        assert(move _5, "index out of bounds: the length is {} but the index is {}", const 7_usize, copy _4) -> [success: bb1, unwind: bb2];
+        assert(move _5, "index out of bounds: the length is {} but the index is {}", const 7_usize, copy _4) -> [success: bb1, unwind: bb3];
     }
 
     bb1: {
         _3 = &(*_1)[_4];
         _0 = &(*_3);
+        goto -> bb2;
+    }
+
+    bb2: {
         StorageDead(_4);
         StorageDead(_3);
         return;
     }
 
-    bb2 (cleanup): {
+    bb3 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/building/index_array_and_slice.index_const_generic_array.built.after.mir
+++ b/tests/mir-opt/building/index_array_and_slice.index_const_generic_array.built.after.mir
@@ -14,18 +14,22 @@ fn index_const_generic_array(_1: &[i32; N], _2: usize) -> &i32 {
         _4 = copy _2;
         FakeRead(ForIndex, (*_1));
         _5 = Lt(copy _4, const N);
-        assert(move _5, "index out of bounds: the length is {} but the index is {}", const N, copy _4) -> [success: bb1, unwind: bb2];
+        assert(move _5, "index out of bounds: the length is {} but the index is {}", const N, copy _4) -> [success: bb1, unwind: bb3];
     }
 
     bb1: {
         _3 = &(*_1)[_4];
         _0 = &(*_3);
+        goto -> bb2;
+    }
+
+    bb2: {
         StorageDead(_4);
         StorageDead(_3);
         return;
     }
 
-    bb2 (cleanup): {
+    bb3 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/building/index_array_and_slice.index_custom.built.after.mir
+++ b/tests/mir-opt/building/index_array_and_slice.index_custom.built.after.mir
@@ -17,18 +17,22 @@ fn index_custom(_1: &WithSliceTail, _2: usize) -> &i32 {
         _5 = &raw const (fake) ((*_1).1: [i32]);
         _6 = PtrMetadata(move _5);
         _7 = Lt(copy _4, copy _6);
-        assert(move _7, "index out of bounds: the length is {} but the index is {}", move _6, copy _4) -> [success: bb1, unwind: bb2];
+        assert(move _7, "index out of bounds: the length is {} but the index is {}", move _6, copy _4) -> [success: bb1, unwind: bb3];
     }
 
     bb1: {
         _3 = &((*_1).1: [i32])[_4];
         _0 = &(*_3);
+        goto -> bb2;
+    }
+
+    bb2: {
         StorageDead(_4);
         StorageDead(_3);
         return;
     }
 
-    bb2 (cleanup): {
+    bb3 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/building/index_array_and_slice.index_mut_slice.built.after.mir
+++ b/tests/mir-opt/building/index_array_and_slice.index_mut_slice.built.after.mir
@@ -17,18 +17,22 @@ fn index_mut_slice(_1: &mut [i32], _2: usize) -> &i32 {
         _5 = &raw const (fake) (*_1);
         _6 = PtrMetadata(move _5);
         _7 = Lt(copy _4, copy _6);
-        assert(move _7, "index out of bounds: the length is {} but the index is {}", move _6, copy _4) -> [success: bb1, unwind: bb2];
+        assert(move _7, "index out of bounds: the length is {} but the index is {}", move _6, copy _4) -> [success: bb1, unwind: bb3];
     }
 
     bb1: {
         _3 = &(*_1)[_4];
         _0 = &(*_3);
+        goto -> bb2;
+    }
+
+    bb2: {
         StorageDead(_4);
         StorageDead(_3);
         return;
     }
 
-    bb2 (cleanup): {
+    bb3 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/building/index_array_and_slice.index_slice.built.after.mir
+++ b/tests/mir-opt/building/index_array_and_slice.index_slice.built.after.mir
@@ -15,18 +15,22 @@ fn index_slice(_1: &[i32], _2: usize) -> &i32 {
         _4 = copy _2;
         _5 = PtrMetadata(copy _1);
         _6 = Lt(copy _4, copy _5);
-        assert(move _6, "index out of bounds: the length is {} but the index is {}", move _5, copy _4) -> [success: bb1, unwind: bb2];
+        assert(move _6, "index out of bounds: the length is {} but the index is {}", move _5, copy _4) -> [success: bb1, unwind: bb3];
     }
 
     bb1: {
         _3 = &(*_1)[_4];
         _0 = &(*_3);
+        goto -> bb2;
+    }
+
+    bb2: {
         StorageDead(_4);
         StorageDead(_3);
         return;
     }
 
-    bb2 (cleanup): {
+    bb3 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/building/issue_101867.main.built.after.mir
+++ b/tests/mir-opt/building/issue_101867.main.built.after.mir
@@ -26,47 +26,63 @@ fn main() -> () {
         AscribeUserType(_1, o, UserTypeProjection { base: UserType(1), projs: [] });
         PlaceMention(_1);
         _6 = discriminant(_1);
-        switchInt(move _6) -> [1: bb4, otherwise: bb3];
+        switchInt(move _6) -> [1: bb6, otherwise: bb5];
     }
 
     bb1: {
         StorageLive(_3);
         StorageLive(_4);
-        _4 = std::rt::begin_panic::<&str>(const "explicit panic") -> [return: bb2, unwind: bb8];
+        _4 = std::rt::begin_panic::<&str>(const "explicit panic") -> [return: bb2, unwind: bb12];
     }
 
     bb2: {
+        goto -> bb3;
+    }
+
+    bb3: {
         StorageDead(_4);
+        goto -> bb4;
+    }
+
+    bb4: {
         StorageDead(_3);
         unreachable;
     }
 
-    bb3: {
-        goto -> bb7;
-    }
-
-    bb4: {
-        falseEdge -> [real: bb6, imaginary: bb3];
-    }
-
     bb5: {
-        goto -> bb3;
+        goto -> bb9;
     }
 
     bb6: {
+        falseEdge -> [real: bb8, imaginary: bb5];
+    }
+
+    bb7: {
+        goto -> bb5;
+    }
+
+    bb8: {
         StorageLive(_5);
         _5 = copy ((_1 as Some).0: u8);
         _0 = const ();
+        goto -> bb10;
+    }
+
+    bb9: {
+        goto -> bb1;
+    }
+
+    bb10: {
         StorageDead(_5);
+        goto -> bb11;
+    }
+
+    bb11: {
         StorageDead(_1);
         return;
     }
 
-    bb7: {
-        goto -> bb1;
-    }
-
-    bb8 (cleanup): {
+    bb12 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/building/issue_110508.{impl#0}-BAR.built.after.mir
+++ b/tests/mir-opt/building/issue_110508.{impl#0}-BAR.built.after.mir
@@ -8,6 +8,10 @@ const <impl at $DIR/issue_110508.rs:10:1: 10:9>::BAR: Foo = {
         StorageLive(_1);
         _1 = ();
         _0 = Foo::Bar(move _1);
+        goto -> bb1;
+    }
+
+    bb1: {
         StorageDead(_1);
         return;
     }

--- a/tests/mir-opt/building/issue_110508.{impl#0}-SELF_BAR.built.after.mir
+++ b/tests/mir-opt/building/issue_110508.{impl#0}-SELF_BAR.built.after.mir
@@ -8,6 +8,10 @@ const <impl at $DIR/issue_110508.rs:10:1: 10:9>::SELF_BAR: Foo = {
         StorageLive(_1);
         _1 = ();
         _0 = Foo::Bar(move _1);
+        goto -> bb1;
+    }
+
+    bb1: {
         StorageDead(_1);
         return;
     }

--- a/tests/mir-opt/building/issue_49232.main.built.after.mir
+++ b/tests/mir-opt/building/issue_49232.main.built.after.mir
@@ -17,7 +17,7 @@ fn main() -> () {
     }
 
     bb1: {
-        falseUnwind -> [real: bb2, unwind: bb14];
+        falseUnwind -> [real: bb2, unwind: bb18];
     }
 
     bb2: {
@@ -43,7 +43,7 @@ fn main() -> () {
 
     bb6: {
         _0 = const ();
-        goto -> bb13;
+        goto -> bb17;
     }
 
     bb7: {
@@ -65,28 +65,44 @@ fn main() -> () {
 
     bb11: {
         FakeRead(ForLet(None), _2);
+        goto -> bb12;
+    }
+
+    bb12: {
         StorageDead(_3);
         StorageLive(_5);
         StorageLive(_6);
         _6 = &_2;
-        _5 = std::mem::drop::<&i32>(move _6) -> [return: bb12, unwind: bb14];
+        _5 = std::mem::drop::<&i32>(move _6) -> [return: bb13, unwind: bb18];
     }
 
-    bb12: {
+    bb13: {
+        goto -> bb14;
+    }
+
+    bb14: {
         StorageDead(_6);
+        goto -> bb15;
+    }
+
+    bb15: {
         StorageDead(_5);
         _1 = const ();
+        goto -> bb16;
+    }
+
+    bb16: {
         StorageDead(_2);
         goto -> bb1;
     }
 
-    bb13: {
+    bb17: {
         StorageDead(_3);
         StorageDead(_2);
         return;
     }
 
-    bb14 (cleanup): {
+    bb18 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/building/logical_or_in_conditional.test_complex.built.after.mir
+++ b/tests/mir-opt/building/logical_or_in_conditional.test_complex.built.after.mir
@@ -19,7 +19,7 @@ fn test_complex() -> () {
     bb0: {
         StorageLive(_1);
         StorageLive(_2);
-        _2 = E::f() -> [return: bb1, unwind: bb35];
+        _2 = E::f() -> [return: bb1, unwind: bb42];
     }
 
     bb1: {
@@ -29,7 +29,7 @@ fn test_complex() -> () {
     }
 
     bb2: {
-        goto -> bb21;
+        goto -> bb23;
     }
 
     bb3: {
@@ -42,7 +42,7 @@ fn test_complex() -> () {
 
     bb5: {
         StorageLive(_4);
-        _4 = always_true() -> [return: bb6, unwind: bb35];
+        _4 = always_true() -> [return: bb6, unwind: bb42];
     }
 
     bb6: {
@@ -60,94 +60,89 @@ fn test_complex() -> () {
     }
 
     bb8: {
-        goto -> bb14;
+        goto -> bb15;
     }
 
     bb9: {
-        drop(_7) -> [return: bb11, unwind: bb35];
+        goto -> bb11;
     }
 
     bb10: {
-        goto -> bb12;
+        goto -> bb13;
     }
 
     bb11: {
-        StorageDead(_7);
-        StorageDead(_6);
-        goto -> bb18;
+        drop(_7) -> [return: bb12, unwind: bb42];
     }
 
     bb12: {
-        drop(_7) -> [return: bb13, unwind: bb35];
+        StorageDead(_7);
+        StorageDead(_6);
+        goto -> bb20;
     }
 
     bb13: {
-        StorageDead(_7);
-        StorageDead(_6);
-        goto -> bb14;
+        drop(_7) -> [return: bb14, unwind: bb42];
     }
 
     bb14: {
+        StorageDead(_7);
+        StorageDead(_6);
+        goto -> bb15;
+    }
+
+    bb15: {
         StorageLive(_8);
         StorageLive(_9);
         StorageLive(_10);
         _10 = Droppy(const 1_u8);
         _9 = copy (_10.0: u8);
         _8 = Gt(move _9, const 1_u8);
-        switchInt(move _8) -> [0: bb16, otherwise: bb15];
-    }
-
-    bb15: {
-        drop(_10) -> [return: bb17, unwind: bb35];
+        switchInt(move _8) -> [0: bb17, otherwise: bb16];
     }
 
     bb16: {
-        goto -> bb19;
-    }
-
-    bb17: {
-        StorageDead(_10);
-        StorageDead(_9);
         goto -> bb18;
     }
 
-    bb18: {
-        _1 = const ();
-        StorageDead(_2);
-        goto -> bb22;
-    }
-
-    bb19: {
-        drop(_10) -> [return: bb20, unwind: bb35];
-    }
-
-    bb20: {
-        StorageDead(_10);
-        StorageDead(_9);
+    bb17: {
         goto -> bb21;
     }
 
-    bb21: {
-        StorageDead(_2);
+    bb18: {
+        drop(_10) -> [return: bb19, unwind: bb42];
+    }
+
+    bb19: {
+        StorageDead(_10);
+        StorageDead(_9);
+        goto -> bb20;
+    }
+
+    bb20: {
         _1 = const ();
-        goto -> bb22;
+        goto -> bb24;
+    }
+
+    bb21: {
+        drop(_10) -> [return: bb22, unwind: bb42];
     }
 
     bb22: {
-        StorageDead(_8);
-        StorageDead(_5);
-        StorageDead(_4);
-        StorageDead(_1);
-        StorageLive(_11);
-        _11 = always_true() -> [return: bb23, unwind: bb35];
+        StorageDead(_10);
+        StorageDead(_9);
+        goto -> bb23;
     }
 
     bb23: {
-        switchInt(move _11) -> [0: bb25, otherwise: bb24];
+        StorageDead(_2);
+        _1 = const ();
+        goto -> bb25;
     }
 
     bb24: {
-        goto -> bb33;
+        StorageDead(_2);
+        goto -> bb25;
     }
 
     bb25: {
@@ -155,50 +150,83 @@ fn test_complex() -> () {
     }
 
     bb26: {
-        StorageLive(_12);
-        _12 = E::f() -> [return: bb27, unwind: bb35];
+        StorageDead(_8);
+        StorageDead(_5);
+        StorageDead(_4);
+        goto -> bb27;
     }
 
     bb27: {
-        PlaceMention(_12);
-        _13 = discriminant(_12);
-        switchInt(move _13) -> [1: bb29, otherwise: bb28];
+        StorageDead(_1);
+        StorageLive(_11);
+        _11 = always_true() -> [return: bb28, unwind: bb42];
     }
 
     bb28: {
-        goto -> bb32;
+        switchInt(move _11) -> [0: bb30, otherwise: bb29];
     }
 
     bb29: {
-        falseEdge -> [real: bb31, imaginary: bb28];
+        goto -> bb38;
     }
 
     bb30: {
-        goto -> bb28;
+        goto -> bb31;
     }
 
     bb31: {
-        _0 = const ();
-        StorageDead(_12);
-        goto -> bb34;
+        StorageLive(_12);
+        _12 = E::f() -> [return: bb32, unwind: bb42];
     }
 
     bb32: {
-        StorageDead(_12);
-        goto -> bb33;
+        PlaceMention(_12);
+        _13 = discriminant(_12);
+        switchInt(move _13) -> [1: bb34, otherwise: bb33];
     }
 
     bb33: {
-        _0 = const ();
-        goto -> bb34;
+        goto -> bb37;
     }
 
     bb34: {
+        falseEdge -> [real: bb36, imaginary: bb33];
+    }
+
+    bb35: {
+        goto -> bb33;
+    }
+
+    bb36: {
+        _0 = const ();
+        goto -> bb39;
+    }
+
+    bb37: {
+        StorageDead(_12);
+        goto -> bb38;
+    }
+
+    bb38: {
+        _0 = const ();
+        goto -> bb40;
+    }
+
+    bb39: {
+        StorageDead(_12);
+        goto -> bb40;
+    }
+
+    bb40: {
+        goto -> bb41;
+    }
+
+    bb41: {
         StorageDead(_11);
         return;
     }
 
-    bb35 (cleanup): {
+    bb42 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/building/logical_or_in_conditional.test_or.built.after.mir
+++ b/tests/mir-opt/building/logical_or_in_conditional.test_or.built.after.mir
@@ -20,24 +20,28 @@ fn test_or() -> () {
     }
 
     bb1: {
-        drop(_3) -> [return: bb3, unwind: bb13];
+        goto -> bb3;
     }
 
     bb2: {
-        goto -> bb4;
+        goto -> bb5;
     }
 
     bb3: {
-        StorageDead(_3);
-        StorageDead(_2);
-        goto -> bb9;
+        drop(_3) -> [return: bb4, unwind: bb16];
     }
 
     bb4: {
-        drop(_3) -> [return: bb5, unwind: bb13];
+        StorageDead(_3);
+        StorageDead(_2);
+        goto -> bb11;
     }
 
     bb5: {
+        drop(_3) -> [return: bb6, unwind: bb16];
+    }
+
+    bb6: {
         StorageDead(_3);
         StorageDead(_2);
         StorageLive(_4);
@@ -46,46 +50,54 @@ fn test_or() -> () {
         _6 = Droppy(const 1_u8);
         _5 = copy (_6.0: u8);
         _4 = Gt(move _5, const 1_u8);
-        switchInt(move _4) -> [0: bb7, otherwise: bb6];
-    }
-
-    bb6: {
-        drop(_6) -> [return: bb8, unwind: bb13];
+        switchInt(move _4) -> [0: bb8, otherwise: bb7];
     }
 
     bb7: {
-        goto -> bb10;
-    }
-
-    bb8: {
-        StorageDead(_6);
-        StorageDead(_5);
         goto -> bb9;
     }
 
-    bb9: {
-        _0 = const ();
+    bb8: {
         goto -> bb12;
+    }
+
+    bb9: {
+        drop(_6) -> [return: bb10, unwind: bb16];
     }
 
     bb10: {
-        drop(_6) -> [return: bb11, unwind: bb13];
+        StorageDead(_6);
+        StorageDead(_5);
+        goto -> bb11;
     }
 
     bb11: {
-        StorageDead(_6);
-        StorageDead(_5);
         _0 = const ();
-        goto -> bb12;
+        goto -> bb14;
     }
 
     bb12: {
+        drop(_6) -> [return: bb13, unwind: bb16];
+    }
+
+    bb13: {
+        StorageDead(_6);
+        StorageDead(_5);
+        _0 = const ();
+        goto -> bb14;
+    }
+
+    bb14: {
+        goto -> bb15;
+    }
+
+    bb15: {
         StorageDead(_4);
         StorageDead(_1);
         return;
     }
 
-    bb13 (cleanup): {
+    bb16 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/building/loop_match_diverges.break_to_block_unit.built.after.mir
+++ b/tests/mir-opt/building/loop_match_diverges.break_to_block_unit.built.after.mir
@@ -18,7 +18,7 @@ fn break_to_block_unit() -> u8 {
     }
 
     bb1: {
-        falseUnwind -> [real: bb2, unwind: bb10];
+        falseUnwind -> [real: bb2, unwind: bb12];
     }
 
     bb2: {
@@ -54,12 +54,20 @@ fn break_to_block_unit() -> u8 {
     }
 
     bb9: {
+        goto -> bb10;
+    }
+
+    bb10: {
         StorageDead(_2);
+        goto -> bb11;
+    }
+
+    bb11: {
         StorageDead(_1);
         return;
     }
 
-    bb10 (cleanup): {
+    bb12 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/building/loop_match_diverges.infinite_a.built.after.mir
+++ b/tests/mir-opt/building/loop_match_diverges.infinite_a.built.after.mir
@@ -16,7 +16,7 @@ fn infinite_a(_1: u8) -> () {
     }
 
     bb1: {
-        falseUnwind -> [real: bb2, unwind: bb7];
+        falseUnwind -> [real: bb2, unwind: bb9];
     }
 
     bb2: {
@@ -24,7 +24,6 @@ fn infinite_a(_1: u8) -> () {
         StorageLive(_4);
         _4 = copy _1;
         _3 = copy _4;
-        StorageDead(_4);
         goto -> bb4;
     }
 
@@ -34,20 +33,29 @@ fn infinite_a(_1: u8) -> () {
     }
 
     bb4: {
+        StorageDead(_4);
+        goto -> bb5;
+    }
+
+    bb5: {
         _1 = copy _3;
         goto -> bb1;
     }
 
-    bb5: {
+    bb6: {
         unreachable;
     }
 
-    bb6: {
+    bb7: {
+        goto -> bb8;
+    }
+
+    bb8: {
         StorageDead(_2);
         return;
     }
 
-    bb7 (cleanup): {
+    bb9 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/building/loop_match_diverges.simple.built.after.mir
+++ b/tests/mir-opt/building/loop_match_diverges.simple.built.after.mir
@@ -21,7 +21,7 @@ fn simple(_1: State) -> State {
     }
 
     bb1: {
-        falseUnwind -> [real: bb2, unwind: bb37];
+        falseUnwind -> [real: bb2, unwind: bb39];
     }
 
     bb2: {
@@ -53,7 +53,7 @@ fn simple(_1: State) -> State {
 
     bb8: {
         _2 = const ();
-        goto -> bb36;
+        goto -> bb37;
     }
 
     bb9: {
@@ -77,7 +77,7 @@ fn simple(_1: State) -> State {
     }
 
     bb13: {
-        goto -> bb34;
+        goto -> bb35;
     }
 
     bb14: {
@@ -85,7 +85,7 @@ fn simple(_1: State) -> State {
     }
 
     bb15: {
-        goto -> bb32;
+        goto -> bb33;
     }
 
     bb16: {
@@ -103,7 +103,7 @@ fn simple(_1: State) -> State {
     }
 
     bb19: {
-        goto -> bb33;
+        goto -> bb34;
     }
 
     bb20: {
@@ -130,7 +130,7 @@ fn simple(_1: State) -> State {
     }
 
     bb25: {
-        goto -> bb33;
+        goto -> bb34;
     }
 
     bb26: {
@@ -147,43 +147,51 @@ fn simple(_1: State) -> State {
     }
 
     bb29: {
-        StorageDead(_7);
-        goto -> bb32;
+        goto -> bb30;
     }
 
     bb30: {
-        unreachable;
+        StorageDead(_7);
+        goto -> bb33;
     }
 
     bb31: {
-        goto -> bb32;
+        unreachable;
     }
 
     bb32: {
-        _1 = move _4;
-        goto -> bb35;
+        goto -> bb33;
     }
 
     bb33: {
-        StorageDead(_7);
-        goto -> bb34;
+        _1 = move _4;
+        goto -> bb36;
     }
 
     bb34: {
+        StorageDead(_7);
         goto -> bb35;
     }
 
     bb35: {
-        goto -> bb1;
+        goto -> bb36;
     }
 
     bb36: {
+        goto -> bb1;
+    }
+
+    bb37: {
+        goto -> bb38;
+    }
+
+    bb38: {
         StorageDead(_2);
         _0 = move _1;
         return;
     }
 
-    bb37 (cleanup): {
+    bb39 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/building/loop_match_no_self_assign.helper.built.after.mir
+++ b/tests/mir-opt/building/loop_match_no_self_assign.helper.built.after.mir
@@ -19,7 +19,7 @@ fn helper() -> u8 {
     }
 
     bb1: {
-        falseUnwind -> [real: bb2, unwind: bb11];
+        falseUnwind -> [real: bb2, unwind: bb13];
     }
 
     bb2: {
@@ -59,12 +59,20 @@ fn helper() -> u8 {
     }
 
     bb10: {
+        goto -> bb11;
+    }
+
+    bb11: {
         StorageDead(_2);
+        goto -> bb12;
+    }
+
+    bb12: {
         StorageDead(_1);
         return;
     }
 
-    bb11 (cleanup): {
+    bb13 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/building/match/array_len.const_array_len.built.after.panic-abort.mir
+++ b/tests/mir-opt/building/match/array_len.const_array_len.built.after.panic-abort.mir
@@ -43,7 +43,7 @@ fn const_array_len(_1: [T; 5]) -> () {
         StorageLive(_6);
         StorageLive(_7);
         _7 = move _2;
-        _6 = opaque::<T>(move _7) -> [return: bb3, unwind: bb27];
+        _6 = opaque::<T>(move _7) -> [return: bb3, unwind: bb24];
     }
 
     bb3: {
@@ -60,7 +60,7 @@ fn const_array_len(_1: [T; 5]) -> () {
         StorageLive(_8);
         StorageLive(_9);
         _9 = move _3;
-        _8 = opaque::<T>(move _9) -> [return: bb6, unwind: bb26];
+        _8 = opaque::<T>(move _9) -> [return: bb6, unwind: bb24];
     }
 
     bb6: {
@@ -77,7 +77,7 @@ fn const_array_len(_1: [T; 5]) -> () {
         StorageLive(_10);
         StorageLive(_11);
         _11 = move _4;
-        _10 = opaque::<[T; 2]>(move _11) -> [return: bb9, unwind: bb25];
+        _10 = opaque::<[T; 2]>(move _11) -> [return: bb9, unwind: bb24];
     }
 
     bb9: {
@@ -118,22 +118,22 @@ fn const_array_len(_1: [T; 5]) -> () {
     }
 
     bb16: {
-        drop(_5) -> [return: bb17, unwind: bb29];
+        drop(_5) -> [return: bb17, unwind: bb25];
     }
 
     bb17: {
         StorageDead(_5);
-        drop(_4) -> [return: bb18, unwind: bb30];
+        drop(_4) -> [return: bb18, unwind: bb26];
     }
 
     bb18: {
         StorageDead(_4);
-        drop(_3) -> [return: bb19, unwind: bb31];
+        drop(_3) -> [return: bb19, unwind: bb27];
     }
 
     bb19: {
         StorageDead(_3);
-        drop(_2) -> [return: bb20, unwind: bb32];
+        drop(_2) -> [return: bb20, unwind: bb28];
     }
 
     bb20: {
@@ -146,7 +146,7 @@ fn const_array_len(_1: [T; 5]) -> () {
     }
 
     bb22: {
-        drop(_1) -> [return: bb23, unwind: bb33];
+        drop(_1) -> [return: bb23, unwind: bb29];
     }
 
     bb23: {
@@ -154,42 +154,26 @@ fn const_array_len(_1: [T; 5]) -> () {
     }
 
     bb24 (cleanup): {
-        drop(_13) -> [return: bb28, unwind terminate(cleanup)];
+        drop(_5) -> [return: bb25, unwind terminate(cleanup)];
     }
 
     bb25 (cleanup): {
-        drop(_11) -> [return: bb28, unwind terminate(cleanup)];
+        drop(_4) -> [return: bb26, unwind terminate(cleanup)];
     }
 
     bb26 (cleanup): {
-        drop(_9) -> [return: bb28, unwind terminate(cleanup)];
+        drop(_3) -> [return: bb27, unwind terminate(cleanup)];
     }
 
     bb27 (cleanup): {
-        drop(_7) -> [return: bb28, unwind terminate(cleanup)];
+        drop(_2) -> [return: bb28, unwind terminate(cleanup)];
     }
 
     bb28 (cleanup): {
-        drop(_5) -> [return: bb29, unwind terminate(cleanup)];
+        drop(_1) -> [return: bb29, unwind terminate(cleanup)];
     }
 
     bb29 (cleanup): {
-        drop(_4) -> [return: bb30, unwind terminate(cleanup)];
-    }
-
-    bb30 (cleanup): {
-        drop(_3) -> [return: bb31, unwind terminate(cleanup)];
-    }
-
-    bb31 (cleanup): {
-        drop(_2) -> [return: bb32, unwind terminate(cleanup)];
-    }
-
-    bb32 (cleanup): {
-        drop(_1) -> [return: bb33, unwind terminate(cleanup)];
-    }
-
-    bb33 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/building/match/array_len.const_array_len.built.after.panic-abort.mir
+++ b/tests/mir-opt/building/match/array_len.const_array_len.built.after.panic-abort.mir
@@ -28,7 +28,7 @@ fn const_array_len(_1: [T; 5]) -> () {
     }
 
     bb1: {
-        goto -> bb7;
+        goto -> bb15;
     }
 
     bb2: {
@@ -43,113 +43,153 @@ fn const_array_len(_1: [T; 5]) -> () {
         StorageLive(_6);
         StorageLive(_7);
         _7 = move _2;
-        _6 = opaque::<T>(move _7) -> [return: bb3, unwind: bb17];
+        _6 = opaque::<T>(move _7) -> [return: bb3, unwind: bb27];
     }
 
     bb3: {
+        goto -> bb4;
+    }
+
+    bb4: {
         StorageDead(_7);
+        goto -> bb5;
+    }
+
+    bb5: {
         StorageDead(_6);
         StorageLive(_8);
         StorageLive(_9);
         _9 = move _3;
-        _8 = opaque::<T>(move _9) -> [return: bb4, unwind: bb16];
+        _8 = opaque::<T>(move _9) -> [return: bb6, unwind: bb26];
     }
 
-    bb4: {
+    bb6: {
+        goto -> bb7;
+    }
+
+    bb7: {
         StorageDead(_9);
+        goto -> bb8;
+    }
+
+    bb8: {
         StorageDead(_8);
         StorageLive(_10);
         StorageLive(_11);
         _11 = move _4;
-        _10 = opaque::<[T; 2]>(move _11) -> [return: bb5, unwind: bb15];
+        _10 = opaque::<[T; 2]>(move _11) -> [return: bb9, unwind: bb25];
     }
 
-    bb5: {
+    bb9: {
+        goto -> bb10;
+    }
+
+    bb10: {
         StorageDead(_11);
+        goto -> bb11;
+    }
+
+    bb11: {
         StorageDead(_10);
         StorageLive(_12);
         StorageLive(_13);
         _13 = move _5;
-        _12 = opaque::<T>(move _13) -> [return: bb6, unwind: bb14];
-    }
-
-    bb6: {
-        StorageDead(_13);
-        StorageDead(_12);
-        _0 = const ();
-        drop(_5) -> [return: bb8, unwind: bb19];
-    }
-
-    bb7: {
-        _0 = const ();
-        goto -> bb12;
-    }
-
-    bb8: {
-        StorageDead(_5);
-        drop(_4) -> [return: bb9, unwind: bb20];
-    }
-
-    bb9: {
-        StorageDead(_4);
-        drop(_3) -> [return: bb10, unwind: bb21];
-    }
-
-    bb10: {
-        StorageDead(_3);
-        drop(_2) -> [return: bb11, unwind: bb22];
-    }
-
-    bb11: {
-        StorageDead(_2);
-        goto -> bb12;
+        _12 = opaque::<T>(move _13) -> [return: bb12, unwind: bb24];
     }
 
     bb12: {
-        drop(_1) -> [return: bb13, unwind: bb23];
+        goto -> bb13;
     }
 
     bb13: {
+        StorageDead(_13);
+        goto -> bb14;
+    }
+
+    bb14: {
+        StorageDead(_12);
+        _0 = const ();
+        goto -> bb16;
+    }
+
+    bb15: {
+        _0 = const ();
+        goto -> bb21;
+    }
+
+    bb16: {
+        drop(_5) -> [return: bb17, unwind: bb29];
+    }
+
+    bb17: {
+        StorageDead(_5);
+        drop(_4) -> [return: bb18, unwind: bb30];
+    }
+
+    bb18: {
+        StorageDead(_4);
+        drop(_3) -> [return: bb19, unwind: bb31];
+    }
+
+    bb19: {
+        StorageDead(_3);
+        drop(_2) -> [return: bb20, unwind: bb32];
+    }
+
+    bb20: {
+        StorageDead(_2);
+        goto -> bb21;
+    }
+
+    bb21: {
+        goto -> bb22;
+    }
+
+    bb22: {
+        drop(_1) -> [return: bb23, unwind: bb33];
+    }
+
+    bb23: {
         return;
     }
 
-    bb14 (cleanup): {
-        drop(_13) -> [return: bb18, unwind terminate(cleanup)];
+    bb24 (cleanup): {
+        drop(_13) -> [return: bb28, unwind terminate(cleanup)];
     }
 
-    bb15 (cleanup): {
-        drop(_11) -> [return: bb18, unwind terminate(cleanup)];
+    bb25 (cleanup): {
+        drop(_11) -> [return: bb28, unwind terminate(cleanup)];
     }
 
-    bb16 (cleanup): {
-        drop(_9) -> [return: bb18, unwind terminate(cleanup)];
+    bb26 (cleanup): {
+        drop(_9) -> [return: bb28, unwind terminate(cleanup)];
     }
 
-    bb17 (cleanup): {
-        drop(_7) -> [return: bb18, unwind terminate(cleanup)];
+    bb27 (cleanup): {
+        drop(_7) -> [return: bb28, unwind terminate(cleanup)];
     }
 
-    bb18 (cleanup): {
-        drop(_5) -> [return: bb19, unwind terminate(cleanup)];
+    bb28 (cleanup): {
+        drop(_5) -> [return: bb29, unwind terminate(cleanup)];
     }
 
-    bb19 (cleanup): {
-        drop(_4) -> [return: bb20, unwind terminate(cleanup)];
+    bb29 (cleanup): {
+        drop(_4) -> [return: bb30, unwind terminate(cleanup)];
     }
 
-    bb20 (cleanup): {
-        drop(_3) -> [return: bb21, unwind terminate(cleanup)];
+    bb30 (cleanup): {
+        drop(_3) -> [return: bb31, unwind terminate(cleanup)];
     }
 
-    bb21 (cleanup): {
-        drop(_2) -> [return: bb22, unwind terminate(cleanup)];
+    bb31 (cleanup): {
+        drop(_2) -> [return: bb32, unwind terminate(cleanup)];
     }
 
-    bb22 (cleanup): {
-        drop(_1) -> [return: bb23, unwind terminate(cleanup)];
+    bb32 (cleanup): {
+        drop(_1) -> [return: bb33, unwind terminate(cleanup)];
     }
 
-    bb23 (cleanup): {
+    bb33 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/building/match/array_len.const_array_len.built.after.panic-unwind.mir
+++ b/tests/mir-opt/building/match/array_len.const_array_len.built.after.panic-unwind.mir
@@ -43,7 +43,7 @@ fn const_array_len(_1: [T; 5]) -> () {
         StorageLive(_6);
         StorageLive(_7);
         _7 = move _2;
-        _6 = opaque::<T>(move _7) -> [return: bb3, unwind: bb27];
+        _6 = opaque::<T>(move _7) -> [return: bb3, unwind: bb24];
     }
 
     bb3: {
@@ -60,7 +60,7 @@ fn const_array_len(_1: [T; 5]) -> () {
         StorageLive(_8);
         StorageLive(_9);
         _9 = move _3;
-        _8 = opaque::<T>(move _9) -> [return: bb6, unwind: bb26];
+        _8 = opaque::<T>(move _9) -> [return: bb6, unwind: bb24];
     }
 
     bb6: {
@@ -77,7 +77,7 @@ fn const_array_len(_1: [T; 5]) -> () {
         StorageLive(_10);
         StorageLive(_11);
         _11 = move _4;
-        _10 = opaque::<[T; 2]>(move _11) -> [return: bb9, unwind: bb25];
+        _10 = opaque::<[T; 2]>(move _11) -> [return: bb9, unwind: bb24];
     }
 
     bb9: {
@@ -118,22 +118,22 @@ fn const_array_len(_1: [T; 5]) -> () {
     }
 
     bb16: {
-        drop(_5) -> [return: bb17, unwind: bb29];
+        drop(_5) -> [return: bb17, unwind: bb25];
     }
 
     bb17: {
         StorageDead(_5);
-        drop(_4) -> [return: bb18, unwind: bb30];
+        drop(_4) -> [return: bb18, unwind: bb26];
     }
 
     bb18: {
         StorageDead(_4);
-        drop(_3) -> [return: bb19, unwind: bb31];
+        drop(_3) -> [return: bb19, unwind: bb27];
     }
 
     bb19: {
         StorageDead(_3);
-        drop(_2) -> [return: bb20, unwind: bb32];
+        drop(_2) -> [return: bb20, unwind: bb28];
     }
 
     bb20: {
@@ -146,7 +146,7 @@ fn const_array_len(_1: [T; 5]) -> () {
     }
 
     bb22: {
-        drop(_1) -> [return: bb23, unwind: bb33];
+        drop(_1) -> [return: bb23, unwind: bb29];
     }
 
     bb23: {
@@ -154,42 +154,26 @@ fn const_array_len(_1: [T; 5]) -> () {
     }
 
     bb24 (cleanup): {
-        drop(_13) -> [return: bb28, unwind terminate(cleanup)];
+        drop(_5) -> [return: bb25, unwind terminate(cleanup)];
     }
 
     bb25 (cleanup): {
-        drop(_11) -> [return: bb28, unwind terminate(cleanup)];
+        drop(_4) -> [return: bb26, unwind terminate(cleanup)];
     }
 
     bb26 (cleanup): {
-        drop(_9) -> [return: bb28, unwind terminate(cleanup)];
+        drop(_3) -> [return: bb27, unwind terminate(cleanup)];
     }
 
     bb27 (cleanup): {
-        drop(_7) -> [return: bb28, unwind terminate(cleanup)];
+        drop(_2) -> [return: bb28, unwind terminate(cleanup)];
     }
 
     bb28 (cleanup): {
-        drop(_5) -> [return: bb29, unwind terminate(cleanup)];
+        drop(_1) -> [return: bb29, unwind terminate(cleanup)];
     }
 
     bb29 (cleanup): {
-        drop(_4) -> [return: bb30, unwind terminate(cleanup)];
-    }
-
-    bb30 (cleanup): {
-        drop(_3) -> [return: bb31, unwind terminate(cleanup)];
-    }
-
-    bb31 (cleanup): {
-        drop(_2) -> [return: bb32, unwind terminate(cleanup)];
-    }
-
-    bb32 (cleanup): {
-        drop(_1) -> [return: bb33, unwind terminate(cleanup)];
-    }
-
-    bb33 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/building/match/array_len.const_array_len.built.after.panic-unwind.mir
+++ b/tests/mir-opt/building/match/array_len.const_array_len.built.after.panic-unwind.mir
@@ -28,7 +28,7 @@ fn const_array_len(_1: [T; 5]) -> () {
     }
 
     bb1: {
-        goto -> bb7;
+        goto -> bb15;
     }
 
     bb2: {
@@ -43,113 +43,153 @@ fn const_array_len(_1: [T; 5]) -> () {
         StorageLive(_6);
         StorageLive(_7);
         _7 = move _2;
-        _6 = opaque::<T>(move _7) -> [return: bb3, unwind: bb17];
+        _6 = opaque::<T>(move _7) -> [return: bb3, unwind: bb27];
     }
 
     bb3: {
+        goto -> bb4;
+    }
+
+    bb4: {
         StorageDead(_7);
+        goto -> bb5;
+    }
+
+    bb5: {
         StorageDead(_6);
         StorageLive(_8);
         StorageLive(_9);
         _9 = move _3;
-        _8 = opaque::<T>(move _9) -> [return: bb4, unwind: bb16];
+        _8 = opaque::<T>(move _9) -> [return: bb6, unwind: bb26];
     }
 
-    bb4: {
+    bb6: {
+        goto -> bb7;
+    }
+
+    bb7: {
         StorageDead(_9);
+        goto -> bb8;
+    }
+
+    bb8: {
         StorageDead(_8);
         StorageLive(_10);
         StorageLive(_11);
         _11 = move _4;
-        _10 = opaque::<[T; 2]>(move _11) -> [return: bb5, unwind: bb15];
+        _10 = opaque::<[T; 2]>(move _11) -> [return: bb9, unwind: bb25];
     }
 
-    bb5: {
+    bb9: {
+        goto -> bb10;
+    }
+
+    bb10: {
         StorageDead(_11);
+        goto -> bb11;
+    }
+
+    bb11: {
         StorageDead(_10);
         StorageLive(_12);
         StorageLive(_13);
         _13 = move _5;
-        _12 = opaque::<T>(move _13) -> [return: bb6, unwind: bb14];
-    }
-
-    bb6: {
-        StorageDead(_13);
-        StorageDead(_12);
-        _0 = const ();
-        drop(_5) -> [return: bb8, unwind: bb19];
-    }
-
-    bb7: {
-        _0 = const ();
-        goto -> bb12;
-    }
-
-    bb8: {
-        StorageDead(_5);
-        drop(_4) -> [return: bb9, unwind: bb20];
-    }
-
-    bb9: {
-        StorageDead(_4);
-        drop(_3) -> [return: bb10, unwind: bb21];
-    }
-
-    bb10: {
-        StorageDead(_3);
-        drop(_2) -> [return: bb11, unwind: bb22];
-    }
-
-    bb11: {
-        StorageDead(_2);
-        goto -> bb12;
+        _12 = opaque::<T>(move _13) -> [return: bb12, unwind: bb24];
     }
 
     bb12: {
-        drop(_1) -> [return: bb13, unwind: bb23];
+        goto -> bb13;
     }
 
     bb13: {
+        StorageDead(_13);
+        goto -> bb14;
+    }
+
+    bb14: {
+        StorageDead(_12);
+        _0 = const ();
+        goto -> bb16;
+    }
+
+    bb15: {
+        _0 = const ();
+        goto -> bb21;
+    }
+
+    bb16: {
+        drop(_5) -> [return: bb17, unwind: bb29];
+    }
+
+    bb17: {
+        StorageDead(_5);
+        drop(_4) -> [return: bb18, unwind: bb30];
+    }
+
+    bb18: {
+        StorageDead(_4);
+        drop(_3) -> [return: bb19, unwind: bb31];
+    }
+
+    bb19: {
+        StorageDead(_3);
+        drop(_2) -> [return: bb20, unwind: bb32];
+    }
+
+    bb20: {
+        StorageDead(_2);
+        goto -> bb21;
+    }
+
+    bb21: {
+        goto -> bb22;
+    }
+
+    bb22: {
+        drop(_1) -> [return: bb23, unwind: bb33];
+    }
+
+    bb23: {
         return;
     }
 
-    bb14 (cleanup): {
-        drop(_13) -> [return: bb18, unwind terminate(cleanup)];
+    bb24 (cleanup): {
+        drop(_13) -> [return: bb28, unwind terminate(cleanup)];
     }
 
-    bb15 (cleanup): {
-        drop(_11) -> [return: bb18, unwind terminate(cleanup)];
+    bb25 (cleanup): {
+        drop(_11) -> [return: bb28, unwind terminate(cleanup)];
     }
 
-    bb16 (cleanup): {
-        drop(_9) -> [return: bb18, unwind terminate(cleanup)];
+    bb26 (cleanup): {
+        drop(_9) -> [return: bb28, unwind terminate(cleanup)];
     }
 
-    bb17 (cleanup): {
-        drop(_7) -> [return: bb18, unwind terminate(cleanup)];
+    bb27 (cleanup): {
+        drop(_7) -> [return: bb28, unwind terminate(cleanup)];
     }
 
-    bb18 (cleanup): {
-        drop(_5) -> [return: bb19, unwind terminate(cleanup)];
+    bb28 (cleanup): {
+        drop(_5) -> [return: bb29, unwind terminate(cleanup)];
     }
 
-    bb19 (cleanup): {
-        drop(_4) -> [return: bb20, unwind terminate(cleanup)];
+    bb29 (cleanup): {
+        drop(_4) -> [return: bb30, unwind terminate(cleanup)];
     }
 
-    bb20 (cleanup): {
-        drop(_3) -> [return: bb21, unwind terminate(cleanup)];
+    bb30 (cleanup): {
+        drop(_3) -> [return: bb31, unwind terminate(cleanup)];
     }
 
-    bb21 (cleanup): {
-        drop(_2) -> [return: bb22, unwind terminate(cleanup)];
+    bb31 (cleanup): {
+        drop(_2) -> [return: bb32, unwind terminate(cleanup)];
     }
 
-    bb22 (cleanup): {
-        drop(_1) -> [return: bb23, unwind terminate(cleanup)];
+    bb32 (cleanup): {
+        drop(_1) -> [return: bb33, unwind terminate(cleanup)];
     }
 
-    bb23 (cleanup): {
+    bb33 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/building/match/array_len.slice_len.built.after.panic-abort.mir
+++ b/tests/mir-opt/building/match/array_len.slice_len.built.after.panic-abort.mir
@@ -36,7 +36,7 @@ fn slice_len(_1: &[T]) -> () {
     }
 
     bb1: {
-        goto -> bb9;
+        goto -> bb17;
     }
 
     bb2: {
@@ -59,57 +59,93 @@ fn slice_len(_1: &[T]) -> () {
         StorageLive(_10);
         StorageLive(_11);
         _11 = copy _6;
-        _10 = opaque::<&T>(move _11) -> [return: bb5, unwind: bb11];
+        _10 = opaque::<&T>(move _11) -> [return: bb5, unwind: bb20];
     }
 
     bb5: {
+        goto -> bb6;
+    }
+
+    bb6: {
         StorageDead(_11);
+        goto -> bb7;
+    }
+
+    bb7: {
         StorageDead(_10);
         StorageLive(_12);
         StorageLive(_13);
         _13 = copy _7;
-        _12 = opaque::<&T>(move _13) -> [return: bb6, unwind: bb11];
-    }
-
-    bb6: {
-        StorageDead(_13);
-        StorageDead(_12);
-        StorageLive(_14);
-        StorageLive(_15);
-        _15 = copy _8;
-        _14 = opaque::<&[T]>(move _15) -> [return: bb7, unwind: bb11];
-    }
-
-    bb7: {
-        StorageDead(_15);
-        StorageDead(_14);
-        StorageLive(_16);
-        StorageLive(_17);
-        _17 = copy _9;
-        _16 = opaque::<&T>(move _17) -> [return: bb8, unwind: bb11];
+        _12 = opaque::<&T>(move _13) -> [return: bb8, unwind: bb20];
     }
 
     bb8: {
-        StorageDead(_17);
-        StorageDead(_16);
-        _0 = const ();
-        StorageDead(_9);
-        StorageDead(_8);
-        StorageDead(_7);
-        StorageDead(_6);
-        goto -> bb10;
+        goto -> bb9;
     }
 
     bb9: {
-        _0 = const ();
+        StorageDead(_13);
         goto -> bb10;
     }
 
     bb10: {
+        StorageDead(_12);
+        StorageLive(_14);
+        StorageLive(_15);
+        _15 = copy _8;
+        _14 = opaque::<&[T]>(move _15) -> [return: bb11, unwind: bb20];
+    }
+
+    bb11: {
+        goto -> bb12;
+    }
+
+    bb12: {
+        StorageDead(_15);
+        goto -> bb13;
+    }
+
+    bb13: {
+        StorageDead(_14);
+        StorageLive(_16);
+        StorageLive(_17);
+        _17 = copy _9;
+        _16 = opaque::<&T>(move _17) -> [return: bb14, unwind: bb20];
+    }
+
+    bb14: {
+        goto -> bb15;
+    }
+
+    bb15: {
+        StorageDead(_17);
+        goto -> bb16;
+    }
+
+    bb16: {
+        StorageDead(_16);
+        _0 = const ();
+        goto -> bb18;
+    }
+
+    bb17: {
+        _0 = const ();
+        goto -> bb19;
+    }
+
+    bb18: {
+        StorageDead(_9);
+        StorageDead(_8);
+        StorageDead(_7);
+        StorageDead(_6);
+        goto -> bb19;
+    }
+
+    bb19: {
         return;
     }
 
-    bb11 (cleanup): {
+    bb20 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/building/match/array_len.slice_len.built.after.panic-unwind.mir
+++ b/tests/mir-opt/building/match/array_len.slice_len.built.after.panic-unwind.mir
@@ -36,7 +36,7 @@ fn slice_len(_1: &[T]) -> () {
     }
 
     bb1: {
-        goto -> bb9;
+        goto -> bb17;
     }
 
     bb2: {
@@ -59,57 +59,93 @@ fn slice_len(_1: &[T]) -> () {
         StorageLive(_10);
         StorageLive(_11);
         _11 = copy _6;
-        _10 = opaque::<&T>(move _11) -> [return: bb5, unwind: bb11];
+        _10 = opaque::<&T>(move _11) -> [return: bb5, unwind: bb20];
     }
 
     bb5: {
+        goto -> bb6;
+    }
+
+    bb6: {
         StorageDead(_11);
+        goto -> bb7;
+    }
+
+    bb7: {
         StorageDead(_10);
         StorageLive(_12);
         StorageLive(_13);
         _13 = copy _7;
-        _12 = opaque::<&T>(move _13) -> [return: bb6, unwind: bb11];
-    }
-
-    bb6: {
-        StorageDead(_13);
-        StorageDead(_12);
-        StorageLive(_14);
-        StorageLive(_15);
-        _15 = copy _8;
-        _14 = opaque::<&[T]>(move _15) -> [return: bb7, unwind: bb11];
-    }
-
-    bb7: {
-        StorageDead(_15);
-        StorageDead(_14);
-        StorageLive(_16);
-        StorageLive(_17);
-        _17 = copy _9;
-        _16 = opaque::<&T>(move _17) -> [return: bb8, unwind: bb11];
+        _12 = opaque::<&T>(move _13) -> [return: bb8, unwind: bb20];
     }
 
     bb8: {
-        StorageDead(_17);
-        StorageDead(_16);
-        _0 = const ();
-        StorageDead(_9);
-        StorageDead(_8);
-        StorageDead(_7);
-        StorageDead(_6);
-        goto -> bb10;
+        goto -> bb9;
     }
 
     bb9: {
-        _0 = const ();
+        StorageDead(_13);
         goto -> bb10;
     }
 
     bb10: {
+        StorageDead(_12);
+        StorageLive(_14);
+        StorageLive(_15);
+        _15 = copy _8;
+        _14 = opaque::<&[T]>(move _15) -> [return: bb11, unwind: bb20];
+    }
+
+    bb11: {
+        goto -> bb12;
+    }
+
+    bb12: {
+        StorageDead(_15);
+        goto -> bb13;
+    }
+
+    bb13: {
+        StorageDead(_14);
+        StorageLive(_16);
+        StorageLive(_17);
+        _17 = copy _9;
+        _16 = opaque::<&T>(move _17) -> [return: bb14, unwind: bb20];
+    }
+
+    bb14: {
+        goto -> bb15;
+    }
+
+    bb15: {
+        StorageDead(_17);
+        goto -> bb16;
+    }
+
+    bb16: {
+        StorageDead(_16);
+        _0 = const ();
+        goto -> bb18;
+    }
+
+    bb17: {
+        _0 = const ();
+        goto -> bb19;
+    }
+
+    bb18: {
+        StorageDead(_9);
+        StorageDead(_8);
+        StorageDead(_7);
+        StorageDead(_6);
+        goto -> bb19;
+    }
+
+    bb19: {
         return;
     }
 
-    bb11 (cleanup): {
+    bb20 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/building/match/match_false_edges.full_tested_match.built.after.mir
+++ b/tests/mir-opt/building/match/match_false_edges.full_tested_match.built.after.mir
@@ -50,7 +50,7 @@ fn full_tested_match() -> () {
 
     bb5: {
         _1 = (const 3_i32, const 3_i32);
-        goto -> bb14;
+        goto -> bb19;
     }
 
     bb6: {
@@ -63,9 +63,7 @@ fn full_tested_match() -> () {
         StorageLive(_10);
         _10 = copy _9;
         _1 = (const 2_i32, move _10);
-        StorageDead(_10);
-        StorageDead(_9);
-        goto -> bb14;
+        goto -> bb17;
     }
 
     bb8: {
@@ -73,7 +71,7 @@ fn full_tested_match() -> () {
         _6 = &((_2 as Some).0: i32);
         _3 = &fake shallow _2;
         StorageLive(_7);
-        _7 = guard() -> [return: bb10, unwind: bb16];
+        _7 = guard() -> [return: bb10, unwind: bb22];
     }
 
     bb9: {
@@ -85,6 +83,14 @@ fn full_tested_match() -> () {
     }
 
     bb11: {
+        goto -> bb13;
+    }
+
+    bb12: {
+        goto -> bb14;
+    }
+
+    bb13: {
         StorageDead(_7);
         FakeRead(ForMatchGuard, _3);
         FakeRead(ForGuardBinding, _6);
@@ -93,36 +99,54 @@ fn full_tested_match() -> () {
         StorageLive(_8);
         _8 = copy _5;
         _1 = (const 1_i32, move _8);
-        StorageDead(_8);
-        StorageDead(_5);
-        StorageDead(_6);
-        goto -> bb14;
+        goto -> bb15;
     }
 
-    bb12: {
-        goto -> bb13;
-    }
-
-    bb13: {
+    bb14: {
         StorageDead(_7);
         StorageDead(_6);
         goto -> bb9;
     }
 
-    bb14: {
+    bb15: {
+        StorageDead(_8);
+        goto -> bb16;
+    }
+
+    bb16: {
+        StorageDead(_5);
+        StorageDead(_6);
+        goto -> bb19;
+    }
+
+    bb17: {
+        StorageDead(_10);
+        goto -> bb18;
+    }
+
+    bb18: {
+        StorageDead(_9);
+        goto -> bb19;
+    }
+
+    bb19: {
         PlaceMention(_1);
+        goto -> bb21;
+    }
+
+    bb20: {
+        FakeRead(ForMatchedPlace(None), _1);
+        unreachable;
+    }
+
+    bb21: {
         StorageDead(_2);
         StorageDead(_1);
         _0 = const ();
         return;
     }
 
-    bb15: {
-        FakeRead(ForMatchedPlace(None), _1);
-        unreachable;
-    }
-
-    bb16 (cleanup): {
+    bb22 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/building/match/match_false_edges.full_tested_match2.built.after.mir
+++ b/tests/mir-opt/building/match/match_false_edges.full_tested_match2.built.after.mir
@@ -46,9 +46,7 @@ fn full_tested_match2() -> () {
         StorageLive(_10);
         _10 = copy _9;
         _1 = (const 2_i32, move _10);
-        StorageDead(_10);
-        StorageDead(_9);
-        goto -> bb14;
+        goto -> bb17;
     }
 
     bb4: {
@@ -65,7 +63,7 @@ fn full_tested_match2() -> () {
 
     bb7: {
         _1 = (const 3_i32, const 3_i32);
-        goto -> bb14;
+        goto -> bb19;
     }
 
     bb8: {
@@ -73,7 +71,7 @@ fn full_tested_match2() -> () {
         _6 = &((_2 as Some).0: i32);
         _3 = &fake shallow _2;
         StorageLive(_7);
-        _7 = guard() -> [return: bb10, unwind: bb16];
+        _7 = guard() -> [return: bb10, unwind: bb22];
     }
 
     bb9: {
@@ -85,6 +83,14 @@ fn full_tested_match2() -> () {
     }
 
     bb11: {
+        goto -> bb13;
+    }
+
+    bb12: {
+        goto -> bb14;
+    }
+
+    bb13: {
         StorageDead(_7);
         FakeRead(ForMatchGuard, _3);
         FakeRead(ForGuardBinding, _6);
@@ -93,36 +99,54 @@ fn full_tested_match2() -> () {
         StorageLive(_8);
         _8 = copy _5;
         _1 = (const 1_i32, move _8);
-        StorageDead(_8);
-        StorageDead(_5);
-        StorageDead(_6);
-        goto -> bb14;
+        goto -> bb15;
     }
 
-    bb12: {
-        goto -> bb13;
-    }
-
-    bb13: {
+    bb14: {
         StorageDead(_7);
         StorageDead(_6);
         goto -> bb9;
     }
 
-    bb14: {
+    bb15: {
+        StorageDead(_8);
+        goto -> bb16;
+    }
+
+    bb16: {
+        StorageDead(_5);
+        StorageDead(_6);
+        goto -> bb19;
+    }
+
+    bb17: {
+        StorageDead(_10);
+        goto -> bb18;
+    }
+
+    bb18: {
+        StorageDead(_9);
+        goto -> bb19;
+    }
+
+    bb19: {
         PlaceMention(_1);
+        goto -> bb21;
+    }
+
+    bb20: {
+        FakeRead(ForMatchedPlace(None), _1);
+        unreachable;
+    }
+
+    bb21: {
         StorageDead(_2);
         StorageDead(_1);
         _0 = const ();
         return;
     }
 
-    bb15: {
-        FakeRead(ForMatchedPlace(None), _1);
-        unreachable;
-    }
-
-    bb16 (cleanup): {
+    bb22 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/building/match/match_false_edges.main.built.after.mir
+++ b/tests/mir-opt/building/match/match_false_edges.main.built.after.mir
@@ -63,8 +63,7 @@ fn main() -> () {
         StorageLive(_14);
         _14 = copy _2;
         _1 = const 4_i32;
-        StorageDead(_14);
-        goto -> bb22;
+        goto -> bb27;
     }
 
     bb6: {
@@ -87,7 +86,7 @@ fn main() -> () {
         StorageLive(_12);
         StorageLive(_13);
         _13 = copy (*_11);
-        _12 = guard2(move _13) -> [return: bb18, unwind: bb24];
+        _12 = guard2(move _13) -> [return: bb21, unwind: bb31];
     }
 
     bb10: {
@@ -98,8 +97,7 @@ fn main() -> () {
         StorageLive(_9);
         _9 = copy _2;
         _1 = const 2_i32;
-        StorageDead(_9);
-        goto -> bb22;
+        goto -> bb20;
     }
 
     bb12: {
@@ -107,7 +105,7 @@ fn main() -> () {
         _7 = &((_2 as Some).0: i32);
         _3 = &fake shallow _2;
         StorageLive(_8);
-        _8 = guard() -> [return: bb14, unwind: bb24];
+        _8 = guard() -> [return: bb14, unwind: bb31];
     }
 
     bb13: {
@@ -119,32 +117,53 @@ fn main() -> () {
     }
 
     bb15: {
+        goto -> bb17;
+    }
+
+    bb16: {
+        goto -> bb18;
+    }
+
+    bb17: {
         StorageDead(_8);
         FakeRead(ForMatchGuard, _3);
         FakeRead(ForGuardBinding, _7);
         StorageLive(_6);
         _6 = copy ((_2 as Some).0: i32);
         _1 = const 1_i32;
-        StorageDead(_6);
-        StorageDead(_7);
-        goto -> bb22;
+        goto -> bb19;
     }
 
-    bb16: {
-        goto -> bb17;
-    }
-
-    bb17: {
+    bb18: {
         StorageDead(_8);
         StorageDead(_7);
         goto -> bb13;
     }
 
-    bb18: {
-        switchInt(move _12) -> [0: bb20, otherwise: bb19];
+    bb19: {
+        StorageDead(_6);
+        StorageDead(_7);
+        goto -> bb28;
     }
 
-    bb19: {
+    bb20: {
+        StorageDead(_9);
+        goto -> bb28;
+    }
+
+    bb21: {
+        switchInt(move _12) -> [0: bb23, otherwise: bb22];
+    }
+
+    bb22: {
+        goto -> bb24;
+    }
+
+    bb23: {
+        goto -> bb25;
+    }
+
+    bb24: {
         StorageDead(_13);
         StorageDead(_12);
         FakeRead(ForMatchGuard, _3);
@@ -152,36 +171,45 @@ fn main() -> () {
         StorageLive(_10);
         _10 = copy ((_2 as Some).0: i32);
         _1 = const 3_i32;
-        StorageDead(_10);
-        StorageDead(_11);
-        goto -> bb22;
+        goto -> bb26;
     }
 
-    bb20: {
-        goto -> bb21;
-    }
-
-    bb21: {
+    bb25: {
         StorageDead(_13);
         StorageDead(_12);
         StorageDead(_11);
         goto -> bb10;
     }
 
-    bb22: {
+    bb26: {
+        StorageDead(_10);
+        StorageDead(_11);
+        goto -> bb28;
+    }
+
+    bb27: {
+        StorageDead(_14);
+        goto -> bb28;
+    }
+
+    bb28: {
         PlaceMention(_1);
+        goto -> bb30;
+    }
+
+    bb29: {
+        FakeRead(ForMatchedPlace(None), _1);
+        unreachable;
+    }
+
+    bb30: {
         StorageDead(_2);
         StorageDead(_1);
         _0 = const ();
         return;
     }
 
-    bb23: {
-        FakeRead(ForMatchedPlace(None), _1);
-        unreachable;
-    }
-
-    bb24 (cleanup): {
+    bb31 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/building/receiver_ptr_mutability.main.built.after.mir
+++ b/tests/mir-opt/building/receiver_ptr_mutability.main.built.after.mir
@@ -29,7 +29,7 @@ fn main() -> () {
 
     bb0: {
         StorageLive(_1);
-        _1 = null_mut::<Test>() -> [return: bb1, unwind: bb4];
+        _1 = null_mut::<Test>() -> [return: bb1, unwind: bb13];
     }
 
     bb1: {
@@ -40,12 +40,24 @@ fn main() -> () {
         StorageLive(_4);
         _4 = copy _1;
         _3 = move _4 as *const Test (PointerCoercion(MutToConstPointer, Implicit));
-        StorageDead(_4);
-        _2 = Test::x(move _3) -> [return: bb2, unwind: bb4];
+        goto -> bb2;
     }
 
     bb2: {
+        StorageDead(_4);
+        _2 = Test::x(move _3) -> [return: bb3, unwind: bb13];
+    }
+
+    bb3: {
+        goto -> bb4;
+    }
+
+    bb4: {
         StorageDead(_3);
+        goto -> bb5;
+    }
+
+    bb5: {
         StorageDead(_2);
         StorageLive(_5);
         StorageLive(_6);
@@ -59,29 +71,53 @@ fn main() -> () {
         _5 = &(*_6);
         FakeRead(ForLet(None), _5);
         AscribeUserType(_5, o, UserTypeProjection { base: UserType(3), projs: [] });
+        goto -> bb6;
+    }
+
+    bb6: {
         StorageDead(_6);
         StorageLive(_10);
         StorageLive(_11);
         StorageLive(_12);
         _12 = copy (*(*(*(*_5))));
         _11 = move _12 as *const Test (PointerCoercion(MutToConstPointer, Implicit));
-        StorageDead(_12);
-        _10 = Test::x(move _11) -> [return: bb3, unwind: bb4];
+        goto -> bb7;
     }
 
-    bb3: {
+    bb7: {
+        StorageDead(_12);
+        _10 = Test::x(move _11) -> [return: bb8, unwind: bb13];
+    }
+
+    bb8: {
+        goto -> bb9;
+    }
+
+    bb9: {
         StorageDead(_11);
+        goto -> bb10;
+    }
+
+    bb10: {
         StorageDead(_10);
         _0 = const ();
+        goto -> bb11;
+    }
+
+    bb11: {
         StorageDead(_9);
         StorageDead(_8);
         StorageDead(_7);
         StorageDead(_5);
+        goto -> bb12;
+    }
+
+    bb12: {
         StorageDead(_1);
         return;
     }
 
-    bb4 (cleanup): {
+    bb13 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/building/shifts.shift_signed.built.after.mir
+++ b/tests/mir-opt/building/shifts.shift_signed.built.after.mir
@@ -49,11 +49,15 @@ fn shift_signed(_1: i8, _2: u128, _3: i8, _4: i32, _5: i128) -> ([i8; 3], [u128;
         _9 = copy _3;
         _10 = copy _9 as u8 (IntToInt);
         _11 = Lt(move _10, const 8_u8);
-        assert(move _11, "attempt to shift right by `{}`, which would overflow", copy _9) -> [success: bb1, unwind: bb7];
+        assert(move _11, "attempt to shift right by `{}`, which would overflow", copy _9) -> [success: bb1, unwind: bb16];
     }
 
     bb1: {
         _7 = Shr(move _8, move _9);
+        goto -> bb2;
+    }
+
+    bb2: {
         StorageDead(_9);
         StorageDead(_8);
         StorageLive(_12);
@@ -63,11 +67,15 @@ fn shift_signed(_1: i8, _2: u128, _3: i8, _4: i32, _5: i128) -> ([i8; 3], [u128;
         _14 = copy _4;
         _15 = copy _14 as u32 (IntToInt);
         _16 = Lt(move _15, const 8_u32);
-        assert(move _16, "attempt to shift right by `{}`, which would overflow", copy _14) -> [success: bb2, unwind: bb7];
+        assert(move _16, "attempt to shift right by `{}`, which would overflow", copy _14) -> [success: bb3, unwind: bb16];
     }
 
-    bb2: {
+    bb3: {
         _12 = Shr(move _13, move _14);
+        goto -> bb4;
+    }
+
+    bb4: {
         StorageDead(_14);
         StorageDead(_13);
         StorageLive(_17);
@@ -77,14 +85,22 @@ fn shift_signed(_1: i8, _2: u128, _3: i8, _4: i32, _5: i128) -> ([i8; 3], [u128;
         _19 = copy _5;
         _20 = copy _19 as u128 (IntToInt);
         _21 = Lt(move _20, const 8_u128);
-        assert(move _21, "attempt to shift right by `{}`, which would overflow", copy _19) -> [success: bb3, unwind: bb7];
+        assert(move _21, "attempt to shift right by `{}`, which would overflow", copy _19) -> [success: bb5, unwind: bb16];
     }
 
-    bb3: {
+    bb5: {
         _17 = Shr(move _18, move _19);
+        goto -> bb6;
+    }
+
+    bb6: {
         StorageDead(_19);
         StorageDead(_18);
         _6 = [move _7, move _12, move _17];
+        goto -> bb7;
+    }
+
+    bb7: {
         StorageDead(_17);
         StorageDead(_12);
         StorageDead(_7);
@@ -96,11 +112,15 @@ fn shift_signed(_1: i8, _2: u128, _3: i8, _4: i32, _5: i128) -> ([i8; 3], [u128;
         _25 = copy _3;
         _26 = copy _25 as u8 (IntToInt);
         _27 = Lt(move _26, const 128_u8);
-        assert(move _27, "attempt to shift left by `{}`, which would overflow", copy _25) -> [success: bb4, unwind: bb7];
+        assert(move _27, "attempt to shift left by `{}`, which would overflow", copy _25) -> [success: bb8, unwind: bb16];
     }
 
-    bb4: {
+    bb8: {
         _23 = Shl(move _24, move _25);
+        goto -> bb9;
+    }
+
+    bb9: {
         StorageDead(_25);
         StorageDead(_24);
         StorageLive(_28);
@@ -110,11 +130,15 @@ fn shift_signed(_1: i8, _2: u128, _3: i8, _4: i32, _5: i128) -> ([i8; 3], [u128;
         _30 = copy _4;
         _31 = copy _30 as u32 (IntToInt);
         _32 = Lt(move _31, const 128_u32);
-        assert(move _32, "attempt to shift left by `{}`, which would overflow", copy _30) -> [success: bb5, unwind: bb7];
+        assert(move _32, "attempt to shift left by `{}`, which would overflow", copy _30) -> [success: bb10, unwind: bb16];
     }
 
-    bb5: {
+    bb10: {
         _28 = Shl(move _29, move _30);
+        goto -> bb11;
+    }
+
+    bb11: {
         StorageDead(_30);
         StorageDead(_29);
         StorageLive(_33);
@@ -124,24 +148,36 @@ fn shift_signed(_1: i8, _2: u128, _3: i8, _4: i32, _5: i128) -> ([i8; 3], [u128;
         _35 = copy _5;
         _36 = copy _35 as u128 (IntToInt);
         _37 = Lt(move _36, const 128_u128);
-        assert(move _37, "attempt to shift left by `{}`, which would overflow", copy _35) -> [success: bb6, unwind: bb7];
+        assert(move _37, "attempt to shift left by `{}`, which would overflow", copy _35) -> [success: bb12, unwind: bb16];
     }
 
-    bb6: {
+    bb12: {
         _33 = Shl(move _34, move _35);
+        goto -> bb13;
+    }
+
+    bb13: {
         StorageDead(_35);
         StorageDead(_34);
         _22 = [move _23, move _28, move _33];
+        goto -> bb14;
+    }
+
+    bb14: {
         StorageDead(_33);
         StorageDead(_28);
         StorageDead(_23);
         _0 = (move _6, move _22);
+        goto -> bb15;
+    }
+
+    bb15: {
         StorageDead(_22);
         StorageDead(_6);
         return;
     }
 
-    bb7 (cleanup): {
+    bb16 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/building/shifts.shift_unsigned.built.after.mir
+++ b/tests/mir-opt/building/shifts.shift_unsigned.built.after.mir
@@ -42,11 +42,15 @@ fn shift_unsigned(_1: u8, _2: i128, _3: u8, _4: u32, _5: u128) -> ([u8; 3], [i12
         StorageLive(_9);
         _9 = copy _3;
         _10 = Lt(copy _9, const 8_u8);
-        assert(move _10, "attempt to shift right by `{}`, which would overflow", copy _9) -> [success: bb1, unwind: bb7];
+        assert(move _10, "attempt to shift right by `{}`, which would overflow", copy _9) -> [success: bb1, unwind: bb16];
     }
 
     bb1: {
         _7 = Shr(move _8, move _9);
+        goto -> bb2;
+    }
+
+    bb2: {
         StorageDead(_9);
         StorageDead(_8);
         StorageLive(_11);
@@ -55,11 +59,15 @@ fn shift_unsigned(_1: u8, _2: i128, _3: u8, _4: u32, _5: u128) -> ([u8; 3], [i12
         StorageLive(_13);
         _13 = copy _4;
         _14 = Lt(copy _13, const 8_u32);
-        assert(move _14, "attempt to shift right by `{}`, which would overflow", copy _13) -> [success: bb2, unwind: bb7];
+        assert(move _14, "attempt to shift right by `{}`, which would overflow", copy _13) -> [success: bb3, unwind: bb16];
     }
 
-    bb2: {
+    bb3: {
         _11 = Shr(move _12, move _13);
+        goto -> bb4;
+    }
+
+    bb4: {
         StorageDead(_13);
         StorageDead(_12);
         StorageLive(_15);
@@ -68,14 +76,22 @@ fn shift_unsigned(_1: u8, _2: i128, _3: u8, _4: u32, _5: u128) -> ([u8; 3], [i12
         StorageLive(_17);
         _17 = copy _5;
         _18 = Lt(copy _17, const 8_u128);
-        assert(move _18, "attempt to shift right by `{}`, which would overflow", copy _17) -> [success: bb3, unwind: bb7];
+        assert(move _18, "attempt to shift right by `{}`, which would overflow", copy _17) -> [success: bb5, unwind: bb16];
     }
 
-    bb3: {
+    bb5: {
         _15 = Shr(move _16, move _17);
+        goto -> bb6;
+    }
+
+    bb6: {
         StorageDead(_17);
         StorageDead(_16);
         _6 = [move _7, move _11, move _15];
+        goto -> bb7;
+    }
+
+    bb7: {
         StorageDead(_15);
         StorageDead(_11);
         StorageDead(_7);
@@ -86,11 +102,15 @@ fn shift_unsigned(_1: u8, _2: i128, _3: u8, _4: u32, _5: u128) -> ([u8; 3], [i12
         StorageLive(_22);
         _22 = copy _3;
         _23 = Lt(copy _22, const 128_u8);
-        assert(move _23, "attempt to shift left by `{}`, which would overflow", copy _22) -> [success: bb4, unwind: bb7];
+        assert(move _23, "attempt to shift left by `{}`, which would overflow", copy _22) -> [success: bb8, unwind: bb16];
     }
 
-    bb4: {
+    bb8: {
         _20 = Shl(move _21, move _22);
+        goto -> bb9;
+    }
+
+    bb9: {
         StorageDead(_22);
         StorageDead(_21);
         StorageLive(_24);
@@ -99,11 +119,15 @@ fn shift_unsigned(_1: u8, _2: i128, _3: u8, _4: u32, _5: u128) -> ([u8; 3], [i12
         StorageLive(_26);
         _26 = copy _4;
         _27 = Lt(copy _26, const 128_u32);
-        assert(move _27, "attempt to shift left by `{}`, which would overflow", copy _26) -> [success: bb5, unwind: bb7];
+        assert(move _27, "attempt to shift left by `{}`, which would overflow", copy _26) -> [success: bb10, unwind: bb16];
     }
 
-    bb5: {
+    bb10: {
         _24 = Shl(move _25, move _26);
+        goto -> bb11;
+    }
+
+    bb11: {
         StorageDead(_26);
         StorageDead(_25);
         StorageLive(_28);
@@ -112,24 +136,36 @@ fn shift_unsigned(_1: u8, _2: i128, _3: u8, _4: u32, _5: u128) -> ([u8; 3], [i12
         StorageLive(_30);
         _30 = copy _5;
         _31 = Lt(copy _30, const 128_u128);
-        assert(move _31, "attempt to shift left by `{}`, which would overflow", copy _30) -> [success: bb6, unwind: bb7];
+        assert(move _31, "attempt to shift left by `{}`, which would overflow", copy _30) -> [success: bb12, unwind: bb16];
     }
 
-    bb6: {
+    bb12: {
         _28 = Shl(move _29, move _30);
+        goto -> bb13;
+    }
+
+    bb13: {
         StorageDead(_30);
         StorageDead(_29);
         _19 = [move _20, move _24, move _28];
+        goto -> bb14;
+    }
+
+    bb14: {
         StorageDead(_28);
         StorageDead(_24);
         StorageDead(_20);
         _0 = (move _6, move _19);
+        goto -> bb15;
+    }
+
+    bb15: {
         StorageDead(_19);
         StorageDead(_6);
         return;
     }
 
-    bb7 (cleanup): {
+    bb16 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/building/storage_live_dead_in_statics.XXX.built.after.mir
+++ b/tests/mir-opt/building/storage_live_dead_in_statics.XXX.built.after.mir
@@ -143,6 +143,10 @@ static XXX: &Foo = {
         StorageLive(_48);
         _48 = (const 0_u32, const 3_u32);
         _6 = [move _7, move _8, move _9, move _10, move _11, move _12, move _13, move _14, move _15, move _16, move _17, move _18, move _19, move _20, move _21, move _22, move _23, move _24, move _25, move _26, move _27, move _28, move _29, move _30, move _31, move _32, move _33, move _34, move _35, move _36, move _37, move _38, move _39, move _40, move _41, move _42, move _43, move _44, move _45, move _46, move _47, move _48];
+        goto -> bb1;
+    }
+
+    bb1: {
         StorageDead(_48);
         StorageDead(_47);
         StorageDead(_46);
@@ -188,11 +192,23 @@ static XXX: &Foo = {
         _5 = &_6;
         _4 = &(*_5);
         _3 = move _4 as &[(u32, u32)] (PointerCoercion(Unsize, Implicit));
+        goto -> bb2;
+    }
+
+    bb2: {
         StorageDead(_4);
         _2 = Foo { tup: const "hi", data: move _3 };
+        goto -> bb3;
+    }
+
+    bb3: {
         StorageDead(_3);
         _1 = &_2;
         _0 = &(*_1);
+        goto -> bb4;
+    }
+
+    bb4: {
         StorageDead(_5);
         StorageDead(_1);
         return;

--- a/tests/mir-opt/building/uniform_array_move_out.move_out_by_subslice.CleanupPostBorrowck.after.mir
+++ b/tests/mir-opt/building/uniform_array_move_out.move_out_by_subslice.CleanupPostBorrowck.after.mir
@@ -16,53 +16,45 @@ fn move_out_by_subslice() -> () {
     bb0: {
         StorageLive(_1);
         StorageLive(_2);
-        _2 = Box::<i32>::new(const 1_i32) -> [return: bb1, unwind: bb9];
+        _2 = Box::<i32>::new(const 1_i32) -> [return: bb1, unwind: bb7];
     }
 
     bb1: {
         StorageLive(_3);
-        _3 = Box::<i32>::new(const 2_i32) -> [return: bb2, unwind: bb8];
+        _3 = Box::<i32>::new(const 2_i32) -> [return: bb2, unwind: bb6];
     }
 
     bb2: {
         _1 = [move _2, move _3];
-        drop(_3) -> [return: bb3, unwind: bb8];
-    }
-
-    bb3: {
         StorageDead(_3);
-        drop(_2) -> [return: bb4, unwind: bb9];
-    }
-
-    bb4: {
         StorageDead(_2);
         nop;
         PlaceMention(_1);
         StorageLive(_4);
         _4 = move _1[0..2];
         _0 = const ();
-        drop(_4) -> [return: bb5, unwind: bb7];
+        drop(_4) -> [return: bb3, unwind: bb5];
     }
 
-    bb5: {
+    bb3: {
         StorageDead(_4);
-        drop(_1) -> [return: bb6, unwind: bb9];
+        drop(_1) -> [return: bb4, unwind: bb7];
     }
 
-    bb6: {
+    bb4: {
         StorageDead(_1);
         return;
     }
 
+    bb5 (cleanup): {
+        drop(_1) -> [return: bb7, unwind terminate(cleanup)];
+    }
+
+    bb6 (cleanup): {
+        drop(_2) -> [return: bb7, unwind terminate(cleanup)];
+    }
+
     bb7 (cleanup): {
-        drop(_1) -> [return: bb9, unwind terminate(cleanup)];
-    }
-
-    bb8 (cleanup): {
-        drop(_2) -> [return: bb9, unwind terminate(cleanup)];
-    }
-
-    bb9 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/building/uniform_array_move_out.move_out_from_end.CleanupPostBorrowck.after.mir
+++ b/tests/mir-opt/building/uniform_array_move_out.move_out_from_end.CleanupPostBorrowck.after.mir
@@ -16,53 +16,45 @@ fn move_out_from_end() -> () {
     bb0: {
         StorageLive(_1);
         StorageLive(_2);
-        _2 = Box::<i32>::new(const 1_i32) -> [return: bb1, unwind: bb9];
+        _2 = Box::<i32>::new(const 1_i32) -> [return: bb1, unwind: bb7];
     }
 
     bb1: {
         StorageLive(_3);
-        _3 = Box::<i32>::new(const 2_i32) -> [return: bb2, unwind: bb8];
+        _3 = Box::<i32>::new(const 2_i32) -> [return: bb2, unwind: bb6];
     }
 
     bb2: {
         _1 = [move _2, move _3];
-        drop(_3) -> [return: bb3, unwind: bb8];
-    }
-
-    bb3: {
         StorageDead(_3);
-        drop(_2) -> [return: bb4, unwind: bb9];
-    }
-
-    bb4: {
         StorageDead(_2);
         nop;
         PlaceMention(_1);
         StorageLive(_4);
         _4 = move _1[1 of 2];
         _0 = const ();
-        drop(_4) -> [return: bb5, unwind: bb7];
+        drop(_4) -> [return: bb3, unwind: bb5];
     }
 
-    bb5: {
+    bb3: {
         StorageDead(_4);
-        drop(_1) -> [return: bb6, unwind: bb9];
+        drop(_1) -> [return: bb4, unwind: bb7];
     }
 
-    bb6: {
+    bb4: {
         StorageDead(_1);
         return;
     }
 
+    bb5 (cleanup): {
+        drop(_1) -> [return: bb7, unwind terminate(cleanup)];
+    }
+
+    bb6 (cleanup): {
+        drop(_2) -> [return: bb7, unwind terminate(cleanup)];
+    }
+
     bb7 (cleanup): {
-        drop(_1) -> [return: bb9, unwind terminate(cleanup)];
-    }
-
-    bb8 (cleanup): {
-        drop(_2) -> [return: bb9, unwind terminate(cleanup)];
-    }
-
-    bb9 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/building/user_type_annotations.let_else.built.after.mir
+++ b/tests/mir-opt/building/user_type_annotations.let_else.built.after.mir
@@ -29,13 +29,11 @@ fn let_else() -> () {
         _7 = &_8;
         _6 = &(*_7);
         _5 = (const 7_u32, const 12_u64, move _6);
-        StorageDead(_6);
-        PlaceMention(_5);
-        falseEdge -> [real: bb4, imaginary: bb3];
+        goto -> bb3;
     }
 
     bb1: {
-        _1 = core::panicking::panic(const "internal error: entered unreachable code") -> [return: bb2, unwind: bb6];
+        _1 = core::panicking::panic(const "internal error: entered unreachable code") -> [return: bb2, unwind: bb9];
     }
 
     bb2: {
@@ -43,10 +41,16 @@ fn let_else() -> () {
     }
 
     bb3: {
-        goto -> bb5;
+        StorageDead(_6);
+        PlaceMention(_5);
+        falseEdge -> [real: bb5, imaginary: bb4];
     }
 
     bb4: {
+        goto -> bb6;
+    }
+
+    bb5: {
         AscribeUserType(_5, +, UserTypeProjection { base: UserType(1), projs: [] });
         StorageLive(_2);
         _2 = copy (_5.0: u32);
@@ -54,9 +58,24 @@ fn let_else() -> () {
         _3 = copy (_5.1: u64);
         StorageLive(_4);
         _4 = copy (_5.2: &char);
+        goto -> bb7;
+    }
+
+    bb6: {
+        StorageDead(_7);
+        StorageDead(_5);
+        StorageDead(_8);
+        goto -> bb1;
+    }
+
+    bb7: {
         StorageDead(_7);
         StorageDead(_5);
         _0 = const ();
+        goto -> bb8;
+    }
+
+    bb8: {
         StorageDead(_4);
         StorageDead(_3);
         StorageDead(_2);
@@ -64,14 +83,7 @@ fn let_else() -> () {
         return;
     }
 
-    bb5: {
-        StorageDead(_7);
-        StorageDead(_5);
-        StorageDead(_8);
-        goto -> bb1;
-    }
-
-    bb6 (cleanup): {
+    bb9 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/building/user_type_annotations.let_else_bindless.built.after.mir
+++ b/tests/mir-opt/building/user_type_annotations.let_else_bindless.built.after.mir
@@ -23,13 +23,11 @@ fn let_else_bindless() -> () {
         _4 = &_5;
         _3 = &(*_4);
         _2 = (const 7_u32, const 12_u64, move _3);
-        StorageDead(_3);
-        PlaceMention(_2);
-        falseEdge -> [real: bb4, imaginary: bb3];
+        goto -> bb3;
     }
 
     bb1: {
-        _1 = core::panicking::panic(const "internal error: entered unreachable code") -> [return: bb2, unwind: bb6];
+        _1 = core::panicking::panic(const "internal error: entered unreachable code") -> [return: bb2, unwind: bb9];
     }
 
     bb2: {
@@ -37,26 +35,40 @@ fn let_else_bindless() -> () {
     }
 
     bb3: {
-        goto -> bb5;
+        StorageDead(_3);
+        PlaceMention(_2);
+        falseEdge -> [real: bb5, imaginary: bb4];
     }
 
     bb4: {
-        AscribeUserType(_2, +, UserTypeProjection { base: UserType(1), projs: [] });
-        StorageDead(_4);
-        StorageDead(_2);
-        _0 = const ();
-        StorageDead(_5);
-        return;
+        goto -> bb6;
     }
 
     bb5: {
+        AscribeUserType(_2, +, UserTypeProjection { base: UserType(1), projs: [] });
+        goto -> bb7;
+    }
+
+    bb6: {
         StorageDead(_4);
         StorageDead(_2);
         StorageDead(_5);
         goto -> bb1;
     }
 
-    bb6 (cleanup): {
+    bb7: {
+        StorageDead(_4);
+        StorageDead(_2);
+        _0 = const ();
+        goto -> bb8;
+    }
+
+    bb8: {
+        StorageDead(_5);
+        return;
+    }
+
+    bb9 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/building/user_type_annotations.let_init.built.after.mir
+++ b/tests/mir-opt/building/user_type_annotations.let_init.built.after.mir
@@ -28,6 +28,10 @@ fn let_init() -> () {
         _6 = &_7;
         _5 = &(*_6);
         _4 = (const 7_u32, const 12_u64, move _5);
+        goto -> bb1;
+    }
+
+    bb1: {
         StorageDead(_5);
         PlaceMention(_4);
         AscribeUserType(_4, +, UserTypeProjection { base: UserType(1), projs: [] });
@@ -37,18 +41,26 @@ fn let_init() -> () {
         _2 = copy (_4.1: u64);
         StorageLive(_3);
         _3 = copy (_4.2: &char);
+        goto -> bb3;
+    }
+
+    bb2: {
+        FakeRead(ForMatchedPlace(None), _4);
+        unreachable;
+    }
+
+    bb3: {
         StorageDead(_6);
         StorageDead(_4);
         _0 = const ();
+        goto -> bb4;
+    }
+
+    bb4: {
         StorageDead(_3);
         StorageDead(_2);
         StorageDead(_1);
         StorageDead(_7);
         return;
-    }
-
-    bb1: {
-        FakeRead(ForMatchedPlace(None), _4);
-        unreachable;
     }
 }

--- a/tests/mir-opt/building/user_type_annotations.let_init_bindless.built.after.mir
+++ b/tests/mir-opt/building/user_type_annotations.let_init_bindless.built.after.mir
@@ -22,18 +22,30 @@ fn let_init_bindless() -> () {
         _3 = &_4;
         _2 = &(*_3);
         _1 = (const 7_u32, const 12_u64, move _2);
-        StorageDead(_2);
-        PlaceMention(_1);
-        AscribeUserType(_1, +, UserTypeProjection { base: UserType(1), projs: [] });
-        StorageDead(_3);
-        StorageDead(_1);
-        _0 = const ();
-        StorageDead(_4);
-        return;
+        goto -> bb1;
     }
 
     bb1: {
+        StorageDead(_2);
+        PlaceMention(_1);
+        AscribeUserType(_1, +, UserTypeProjection { base: UserType(1), projs: [] });
+        goto -> bb3;
+    }
+
+    bb2: {
         FakeRead(ForMatchedPlace(None), _1);
         unreachable;
+    }
+
+    bb3: {
+        StorageDead(_3);
+        StorageDead(_1);
+        _0 = const ();
+        goto -> bb4;
+    }
+
+    bb4: {
+        StorageDead(_4);
+        return;
     }
 }

--- a/tests/mir-opt/building/user_type_annotations.let_uninit.built.after.mir
+++ b/tests/mir-opt/building/user_type_annotations.let_uninit.built.after.mir
@@ -19,6 +19,10 @@ fn let_uninit() -> () {
         StorageLive(_2);
         StorageLive(_3);
         _0 = const ();
+        goto -> bb1;
+    }
+
+    bb1: {
         StorageDead(_3);
         StorageDead(_2);
         StorageDead(_1);

--- a/tests/mir-opt/building/user_type_annotations.match_assoc_const.built.after.mir
+++ b/tests/mir-opt/building/user_type_annotations.match_assoc_const.built.after.mir
@@ -40,6 +40,10 @@ fn match_assoc_const() -> () {
     }
 
     bb6: {
+        goto -> bb7;
+    }
+
+    bb7: {
         StorageDead(_1);
         return;
     }

--- a/tests/mir-opt/building/user_type_annotations.match_assoc_const_range.built.after.mir
+++ b/tests/mir-opt/building/user_type_annotations.match_assoc_const_range.built.after.mir
@@ -68,6 +68,10 @@ fn match_assoc_const_range() -> () {
     }
 
     bb11: {
+        goto -> bb12;
+    }
+
+    bb12: {
         StorageDead(_1);
         return;
     }

--- a/tests/mir-opt/building/write_via_move.box_new.CleanupPostBorrowck.after.mir
+++ b/tests/mir-opt/building/write_via_move.box_new.CleanupPostBorrowck.after.mir
@@ -20,7 +20,7 @@ fn box_new(_1: T) -> Box<[T; 1024]> {
 
     bb0: {
         StorageLive(_2);
-        _2 = Box::<[T; 1024]>::new_uninit() -> [return: bb1, unwind: bb7];
+        _2 = Box::<[T; 1024]>::new_uninit() -> [return: bb1, unwind: bb6];
     }
 
     bb1: {
@@ -30,7 +30,7 @@ fn box_new(_1: T) -> Box<[T; 1024]> {
         StorageLive(_5);
         _5 = &mut (*_2);
         _4 = &mut (*_5);
-        _3 = MaybeUninit::<[T; 1024]>::as_mut_ptr(move _4) -> [return: bb2, unwind: bb6];
+        _3 = MaybeUninit::<[T; 1024]>::as_mut_ptr(move _4) -> [return: bb2, unwind: bb5];
     }
 
     bb2: {
@@ -54,7 +54,7 @@ fn box_new(_1: T) -> Box<[T; 1024]> {
     bb3: {
         StorageDead(_9);
         StorageDead(_3);
-        drop(_2) -> [return: bb4, unwind: bb7];
+        drop(_2) -> [return: bb4, unwind: bb6];
     }
 
     bb4: {
@@ -63,14 +63,10 @@ fn box_new(_1: T) -> Box<[T; 1024]> {
     }
 
     bb5 (cleanup): {
-        drop(_9) -> [return: bb6, unwind terminate(cleanup)];
+        drop(_2) -> [return: bb6, unwind terminate(cleanup)];
     }
 
     bb6 (cleanup): {
-        drop(_2) -> [return: bb7, unwind terminate(cleanup)];
-    }
-
-    bb7 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/const_promotion_extern_static.BOP.built.after.mir
+++ b/tests/mir-opt/const_promotion_extern_static.BOP.built.after.mir
@@ -11,6 +11,10 @@ static BOP: &i32 = {
         _2 = const 13_i32;
         _1 = &_2;
         _0 = &(*_1);
+        goto -> bb1;
+    }
+
+    bb1: {
         StorageDead(_1);
         return;
     }

--- a/tests/mir-opt/coroutine/async_await.b-{closure#0}.StateTransform.diff
+++ b/tests/mir-opt/coroutine/async_await.b-{closure#0}.StateTransform.diff
@@ -81,17 +81,17 @@
 -         StorageLive(_3);
 -         StorageLive(_4);
 -         StorageLive(_5);
--         _5 = a() -> [return: bb1, unwind: bb47];
+-         _5 = a() -> [return: bb1, unwind: bb45];
 +         _41 = move _2 as std::ptr::NonNull<std::task::Context<'_>> (Transmute);
 +         _40 = std::future::ResumeTy(move _41);
 +         _39 = copy (_1.0: &mut {async fn body of b()});
 +         _38 = discriminant((*_39));
-+         switchInt(move _38) -> [0: bb47, 1: bb46, 2: bb45, 3: bb43, 4: bb44, otherwise: bb7];
++         switchInt(move _38) -> [0: bb45, 1: bb44, 2: bb43, 3: bb41, 4: bb42, otherwise: bb7];
       }
   
       bb1: {
--         _4 = <{async fn body of a()} as IntoFuture>::into_future(move _5) -> [return: bb2, unwind: bb46];
-+         _4 = <{async fn body of a()} as IntoFuture>::into_future(move _5) -> [return: bb2, unwind: bb36];
+-         _4 = <{async fn body of a()} as IntoFuture>::into_future(move _5) -> [return: bb2, unwind: bb45];
++         _4 = <{async fn body of a()} as IntoFuture>::into_future(move _5) -> [return: bb2, unwind: bb35];
       }
   
       bb2: {
@@ -113,8 +113,8 @@
 -         _12 = &mut _6;
 +         _12 = &mut (((*_39) as variant#3).0: {async fn body of a()});
           _11 = &mut (*_12);
--         _10 = Pin::<&mut {async fn body of a()}>::new_unchecked(move _11) -> [return: bb4, unwind: bb43];
-+         _10 = Pin::<&mut {async fn body of a()}>::new_unchecked(move _11) -> [return: bb4, unwind: bb33];
+-         _10 = Pin::<&mut {async fn body of a()}>::new_unchecked(move _11) -> [return: bb4, unwind: bb42];
++         _10 = Pin::<&mut {async fn body of a()}>::new_unchecked(move _11) -> [return: bb4, unwind: bb32];
       }
   
       bb4: {
@@ -123,7 +123,7 @@
           StorageLive(_14);
           StorageLive(_15);
 -         _15 = copy _2;
--         _14 = std::future::get_context::<'_, '_>(move _15) -> [return: bb5, unwind: bb41];
+-         _14 = std::future::get_context::<'_, '_>(move _15) -> [return: bb5, unwind: bb40];
 +         _15 = copy _40;
 +         _14 = copy (_15.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
 +         goto -> bb5;
@@ -132,8 +132,8 @@
       bb5: {
           _13 = &mut (*_14);
           StorageDead(_15);
--         _9 = <{async fn body of a()} as Future>::poll(move _10, move _13) -> [return: bb6, unwind: bb42];
-+         _9 = <{async fn body of a()} as Future>::poll(move _10, move _13) -> [return: bb6, unwind: bb32];
+-         _9 = <{async fn body of a()} as Future>::poll(move _10, move _13) -> [return: bb6, unwind: bb41];
++         _9 = <{async fn body of a()} as Future>::poll(move _10, move _13) -> [return: bb6, unwind: bb31];
       }
   
       bb6: {
@@ -176,8 +176,8 @@
           StorageDead(_12);
           StorageDead(_9);
           StorageDead(_8);
--         drop(_6) -> [return: bb11, unwind: bb45];
-+         drop((((*_39) as variant#3).0: {async fn body of a()})) -> [return: bb11, unwind: bb35];
+-         drop(_6) -> [return: bb11, unwind: bb44];
++         drop((((*_39) as variant#3).0: {async fn body of a()})) -> [return: bb11, unwind: bb34];
       }
   
       bb10: {
@@ -200,8 +200,8 @@
           StorageDead(_3);
           StorageLive(_21);
           StorageLive(_22);
--         _22 = a() -> [return: bb13, unwind: bb39];
-+         _22 = a() -> [return: bb13, unwind: bb30];
+-         _22 = a() -> [return: bb13, unwind: bb38];
++         _22 = a() -> [return: bb13, unwind: bb29];
       }
   
       bb13: {
@@ -308,8 +308,8 @@
   
       bb23: {
           StorageDead(_21);
--         drop(_1) -> [return: bb24, unwind: bb50];
-+         goto -> bb41;
+-         drop(_1) -> [return: bb24, unwind: bb48];
++         goto -> bb39;
       }
   
       bb24: {
@@ -321,7 +321,7 @@
 -     bb25: {
 -         StorageDead(_36);
 -         StorageDead(_35);
--         drop(_23) -> [return: bb26, unwind: bb51];
+-         drop(_23) -> [return: bb26, unwind: bb49];
 -     }
 - 
 -     bb26: {
@@ -337,7 +337,7 @@
 -     bb28: {
 -         StorageDead(_20);
 -         StorageDead(_19);
--         drop(_6) -> [return: bb29, unwind: bb53];
+-         drop(_6) -> [return: bb29, unwind: bb51];
 -     }
 - 
 -     bb29: {
@@ -352,7 +352,7 @@
 -     }
 - 
 -     bb31: {
--         drop(_1) -> [return: bb32, unwind: bb50];
+-         drop(_1) -> [return: bb32, unwind: bb48];
 -     }
 - 
 -     bb32: {
@@ -392,116 +392,104 @@
   
 -     bb37 (cleanup): {
 -         StorageDead(_23);
--         goto -> bb40;
+-         goto -> bb39;
 +     bb28 (cleanup): {
 +         nop;
-+         goto -> bb31;
++         goto -> bb30;
       }
   
 -     bb38 (cleanup): {
--         goto -> bb39;
 +     bb29 (cleanup): {
+          StorageDead(_22);
+-         goto -> bb39;
 +         goto -> bb30;
       }
   
 -     bb39 (cleanup): {
 +     bb30 (cleanup): {
-          StorageDead(_22);
--         goto -> bb40;
-+         goto -> bb31;
+          StorageDead(_21);
+-         goto -> bb47;
++         goto -> bb37;
       }
   
 -     bb40 (cleanup): {
-+     bb31 (cleanup): {
-          StorageDead(_21);
--         goto -> bb49;
-+         goto -> bb39;
-      }
-  
--     bb41 (cleanup): {
 -         StorageDead(_15);
--         goto -> bb42;
+-         goto -> bb41;
 -     }
 - 
--     bb42 (cleanup): {
-+     bb32 (cleanup): {
+-     bb41 (cleanup): {
++     bb31 (cleanup): {
           StorageDead(_13);
           StorageDead(_10);
           StorageDead(_14);
--         goto -> bb44;
-+         goto -> bb34;
+-         goto -> bb43;
++         goto -> bb33;
+      }
+  
+-     bb42 (cleanup): {
++     bb32 (cleanup): {
+          StorageDead(_11);
+          StorageDead(_10);
+-         goto -> bb43;
++         goto -> bb33;
       }
   
 -     bb43 (cleanup): {
 +     bb33 (cleanup): {
-          StorageDead(_11);
-          StorageDead(_10);
--         goto -> bb44;
-+         goto -> bb34;
-      }
-  
--     bb44 (cleanup): {
-+     bb34 (cleanup): {
           StorageDead(_12);
           StorageDead(_9);
           StorageDead(_8);
--         drop(_6) -> [return: bb45, unwind terminate(cleanup)];
-+         drop((((*_39) as variant#3).0: {async fn body of a()})) -> [return: bb35, unwind terminate(cleanup)];
+-         drop(_6) -> [return: bb44, unwind terminate(cleanup)];
++         drop((((*_39) as variant#3).0: {async fn body of a()})) -> [return: bb34, unwind terminate(cleanup)];
+      }
+  
+-     bb44 (cleanup): {
+-         StorageDead(_6);
+-         goto -> bb46;
++     bb34 (cleanup): {
++         nop;
++         goto -> bb36;
       }
   
 -     bb45 (cleanup): {
--         StorageDead(_6);
--         goto -> bb48;
 +     bb35 (cleanup): {
-+         nop;
-+         goto -> bb38;
+          StorageDead(_5);
+-         goto -> bb46;
++         goto -> bb36;
       }
   
 -     bb46 (cleanup): {
--         goto -> bb47;
 +     bb36 (cleanup): {
+          StorageDead(_4);
+          StorageDead(_3);
+-         goto -> bb47;
 +         goto -> bb37;
       }
   
 -     bb47 (cleanup): {
+-         drop(_1) -> [return: bb48, unwind terminate(cleanup)];
 +     bb37 (cleanup): {
-          StorageDead(_5);
--         goto -> bb48;
 +         goto -> bb38;
       }
   
 -     bb48 (cleanup): {
 +     bb38 (cleanup): {
-          StorageDead(_4);
-          StorageDead(_3);
--         goto -> bb49;
-+         goto -> bb39;
-      }
-  
--     bb49 (cleanup): {
--         drop(_1) -> [return: bb50, unwind terminate(cleanup)];
-+     bb39 (cleanup): {
 +         goto -> bb40;
-      }
-  
--     bb50 (cleanup): {
-+     bb40 (cleanup): {
-+         goto -> bb42;
 +     }
 + 
-+     bb41: {
++     bb39: {
 +         goto -> bb24;
 +     }
 + 
-+     bb42 (cleanup): {
++     bb40 (cleanup): {
 +         discriminant((*_39)) = 2;
           resume;
       }
   
--     bb51 (cleanup): {
+-     bb49 (cleanup): {
 -         StorageDead(_23);
--         goto -> bb52;
-+     bb43: {
+-         goto -> bb50;
++     bb41: {
 +         StorageLive(_3);
 +         StorageLive(_4);
 +         StorageLive(_19);
@@ -510,10 +498,10 @@
 +         goto -> bb10;
       }
   
--     bb52 (cleanup): {
+-     bb50 (cleanup): {
 -         StorageDead(_21);
--         goto -> bb55;
-+     bb44: {
+-         goto -> bb53;
++     bb42: {
 +         StorageLive(_21);
 +         StorageLive(_35);
 +         StorageLive(_36);
@@ -521,28 +509,28 @@
 +         goto -> bb21;
       }
   
--     bb53 (cleanup): {
+-     bb51 (cleanup): {
 -         StorageDead(_6);
--         goto -> bb54;
-+     bb45: {
-+         assert(const false, "`async fn` resumed after panicking") -> [success: bb45, unwind continue];
+-         goto -> bb52;
++     bb43: {
++         assert(const false, "`async fn` resumed after panicking") -> [success: bb43, unwind continue];
       }
   
--     bb54 (cleanup): {
+-     bb52 (cleanup): {
 -         StorageDead(_4);
 -         StorageDead(_3);
--         goto -> bb55;
-+     bb46: {
-+         assert(const false, "`async fn` resumed after completion") -> [success: bb46, unwind continue];
+-         goto -> bb53;
++     bb44: {
++         assert(const false, "`async fn` resumed after completion") -> [success: bb44, unwind continue];
       }
   
--     bb55 (cleanup): {
--         drop(_1) -> [return: bb50, unwind terminate(cleanup)];
-+     bb47: {
+-     bb53 (cleanup): {
+-         drop(_1) -> [return: bb48, unwind terminate(cleanup)];
++     bb45: {
 +         StorageLive(_3);
 +         StorageLive(_4);
 +         StorageLive(_5);
-+         _5 = a() -> [return: bb1, unwind: bb37];
++         _5 = a() -> [return: bb1, unwind: bb35];
       }
   }
   

--- a/tests/mir-opt/coroutine/async_closure_fake_read_for_by_move.foo-{closure#0}-{closure#0}.built.after.mir
+++ b/tests/mir-opt/coroutine/async_closure_fake_read_for_by_move.foo-{closure#0}-{closure#0}.built.after.mir
@@ -18,7 +18,7 @@ yields ()
 
     bb1: {
         _0 = const ();
-        goto -> bb10;
+        goto -> bb11;
     }
 
     bb2: {
@@ -46,35 +46,43 @@ yields ()
     }
 
     bb7: {
-        StorageDead(_6);
-        FakeRead(ForMatchGuard, _3);
-        FakeRead(ForMatchGuard, _4);
-        _0 = const ();
-        goto -> bb10;
+        goto -> bb9;
     }
 
     bb8: {
-        goto -> bb9;
+        goto -> bb10;
     }
 
     bb9: {
         StorageDead(_6);
-        goto -> bb6;
+        FakeRead(ForMatchGuard, _3);
+        FakeRead(ForMatchGuard, _4);
+        _0 = const ();
+        goto -> bb11;
     }
 
     bb10: {
-        drop(_1) -> [return: bb11, unwind: bb13, drop: bb12];
+        StorageDead(_6);
+        goto -> bb6;
     }
 
     bb11: {
-        return;
+        goto -> bb12;
     }
 
     bb12: {
+        drop(_1) -> [return: bb13, unwind: bb15, drop: bb14];
+    }
+
+    bb13: {
+        return;
+    }
+
+    bb14: {
         coroutine_drop;
     }
 
-    bb13 (cleanup): {
+    bb15 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/coroutine/async_closure_shims.main-{closure#0}-{closure#0}-{closure#0}.built.after.mir
+++ b/tests/mir-opt/coroutine/async_closure_shims.main-{closure#0}-{closure#0}-{closure#0}.built.after.mir
@@ -31,21 +31,37 @@ yields ()
         _5 = &(*(_1.1: &i32));
         FakeRead(ForLet(None), _5);
         _0 = const ();
-        StorageDead(_5);
-        StorageDead(_4);
-        StorageDead(_3);
-        drop(_1) -> [return: bb1, unwind: bb3, drop: bb2];
+        goto -> bb1;
     }
 
     bb1: {
-        return;
+        StorageDead(_5);
+        goto -> bb2;
     }
 
     bb2: {
+        StorageDead(_4);
+        goto -> bb3;
+    }
+
+    bb3: {
+        StorageDead(_3);
+        goto -> bb4;
+    }
+
+    bb4: {
+        drop(_1) -> [return: bb5, unwind: bb7, drop: bb6];
+    }
+
+    bb5: {
+        return;
+    }
+
+    bb6: {
         coroutine_drop;
     }
 
-    bb3 (cleanup): {
+    bb7 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/coroutine/async_closure_shims.main-{closure#0}-{closure#1}-{closure#0}.built.after.mir
+++ b/tests/mir-opt/coroutine/async_closure_shims.main-{closure#0}-{closure#1}-{closure#0}.built.after.mir
@@ -31,21 +31,37 @@ yields ()
         _5 = &(*(_1.1: &i32));
         FakeRead(ForLet(None), _5);
         _0 = const ();
-        StorageDead(_5);
-        StorageDead(_4);
-        StorageDead(_3);
-        drop(_1) -> [return: bb1, unwind: bb3, drop: bb2];
+        goto -> bb1;
     }
 
     bb1: {
-        return;
+        StorageDead(_5);
+        goto -> bb2;
     }
 
     bb2: {
+        StorageDead(_4);
+        goto -> bb3;
+    }
+
+    bb3: {
+        StorageDead(_3);
+        goto -> bb4;
+    }
+
+    bb4: {
+        drop(_1) -> [return: bb5, unwind: bb7, drop: bb6];
+    }
+
+    bb5: {
+        return;
+    }
+
+    bb6: {
         coroutine_drop;
     }
 
-    bb3 (cleanup): {
+    bb7 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/coroutine/async_drop.array-{closure#0}.ElaborateDrops.diff
+++ b/tests/mir-opt/coroutine/async_drop.array-{closure#0}.ElaborateDrops.diff
@@ -37,184 +37,145 @@
           StorageLive(_5);
           _5 = AsyncInt(const 2_i32);
           _3 = [move _4, move _5];
--         drop(_5) -> [return: bb1, unwind: bb9, drop: bb5];
-+         goto -> bb1;
+          StorageDead(_5);
+          StorageDead(_4);
+          _0 = const ();
+-         drop(_3) -> [return: bb1, unwind: bb5, drop: bb3];
++         goto -> bb27;
       }
   
       bb1: {
-          StorageDead(_5);
--         drop(_4) -> [return: bb2, unwind: bb10, drop: bb6];
-+         goto -> bb2;
+          StorageDead(_3);
+-         drop(_1) -> [return: bb2, drop: bb4, unwind continue];
++         drop(_1) -> [return: bb2, unwind: bb6];
       }
   
       bb2: {
-          StorageDead(_4);
-          _0 = const ();
--         drop(_3) -> [return: bb3, unwind: bb11, drop: bb7];
-+         goto -> bb34;
+          return;
       }
   
       bb3: {
           StorageDead(_3);
--         drop(_1) -> [return: bb4, drop: bb8, unwind continue];
-+         drop(_1) -> [return: bb4, unwind: bb12];
+-         drop(_1) -> [return: bb4, unwind continue];
++         goto -> bb4;
       }
   
       bb4: {
-          return;
-      }
-  
-      bb5: {
-          StorageDead(_5);
--         drop(_4) -> [return: bb6, unwind: bb13];
-+         goto -> bb6;
-      }
-  
-      bb6: {
-          StorageDead(_4);
-          goto -> bb7;
-      }
-  
-      bb7: {
-          StorageDead(_3);
--         drop(_1) -> [return: bb8, unwind continue];
-+         goto -> bb8;
-      }
-  
-      bb8: {
           coroutine_drop;
       }
   
-      bb9 (cleanup): {
-          StorageDead(_5);
--         drop(_4) -> [return: bb10, unwind terminate(cleanup)];
-+         goto -> bb10;
-      }
-  
-      bb10 (cleanup): {
-          StorageDead(_4);
-          goto -> bb11;
-      }
-  
-      bb11 (cleanup): {
+      bb5 (cleanup): {
           StorageDead(_3);
-          drop(_1) -> [return: bb12, unwind terminate(cleanup)];
+          drop(_1) -> [return: bb6, unwind terminate(cleanup)];
       }
   
-      bb12 (cleanup): {
+      bb6 (cleanup): {
           resume;
-      }
-  
-      bb13 (cleanup): {
-          StorageDead(_4);
-          StorageDead(_3);
--         drop(_1) -> [return: bb12, unwind terminate(cleanup)];
-+         goto -> bb12;
 +     }
 + 
-+     bb14: {
++     bb7: {
++         StorageDead(_6);
++         goto -> bb1;
++     }
++ 
++     bb8: {
 +         StorageDead(_6);
 +         goto -> bb3;
 +     }
 + 
-+     bb15: {
++     bb9 (cleanup): {
 +         StorageDead(_6);
-+         goto -> bb7;
++         goto -> bb5;
 +     }
 + 
-+     bb16 (cleanup): {
-+         StorageDead(_6);
-+         goto -> bb11;
++     bb10: {
++         assert(const false, "`async fn` resumed after async drop") -> [success: bb10, unwind: bb9];
++     }
++ 
++     bb11: {
++         _2 = move _7;
++         StorageDead(_7);
++         goto -> bb10;
++     }
++ 
++     bb12: {
++         _2 = move _7;
++         StorageDead(_7);
++         goto -> bb18;
++     }
++ 
++     bb13: {
++         StorageLive(_7);
++         _7 = yield(const ()) -> [resume: bb11, drop: bb12];
++     }
++ 
++     bb14: {
++         unreachable;
++     }
++ 
++     bb15: {
++         _9 = discriminant(_8);
++         switchInt(move _9) -> [0: bb8, 1: bb13, otherwise: bb14];
++     }
++ 
++     bb16: {
++         _8 = <impl Future<Output = ()> as Future>::poll(move _10, move _11) -> [return: bb15, unwind: bb9];
 +     }
 + 
 +     bb17: {
-+         assert(const false, "`async fn` resumed after async drop") -> [success: bb17, unwind: bb16];
++         _12 = move _2;
++         _11 = std::future::get_context::<'_, '_>(move _12) -> [return: bb16, unwind: bb9];
 +     }
 + 
 +     bb18: {
-+         _2 = move _7;
-+         StorageDead(_7);
-+         goto -> bb17;
++         _13 = &mut _6;
++         _10 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _13) -> [return: bb17, unwind: bb9];
 +     }
 + 
 +     bb19: {
-+         _2 = move _7;
-+         StorageDead(_7);
++         _2 = move _14;
++         StorageDead(_14);
 +         goto -> bb25;
 +     }
 + 
 +     bb20: {
-+         StorageLive(_7);
-+         _7 = yield(const ()) -> [resume: bb18, drop: bb19];
++         _2 = move _14;
++         StorageDead(_14);
++         goto -> bb18;
 +     }
 + 
 +     bb21: {
-+         unreachable;
++         StorageLive(_14);
++         _14 = yield(const ()) -> [resume: bb19, drop: bb20];
 +     }
 + 
 +     bb22: {
-+         _9 = discriminant(_8);
-+         switchInt(move _9) -> [0: bb15, 1: bb20, otherwise: bb21];
++         _16 = discriminant(_15);
++         switchInt(move _16) -> [0: bb7, 1: bb21, otherwise: bb14];
 +     }
 + 
 +     bb23: {
-+         _8 = <impl Future<Output = ()> as Future>::poll(move _10, move _11) -> [return: bb22, unwind: bb16];
++         _15 = <impl Future<Output = ()> as Future>::poll(move _17, move _18) -> [return: bb22, unwind: bb9];
 +     }
 + 
 +     bb24: {
-+         _12 = move _2;
-+         _11 = std::future::get_context::<'_, '_>(move _12) -> [return: bb23, unwind: bb16];
++         _19 = move _2;
++         _18 = std::future::get_context::<'_, '_>(move _19) -> [return: bb23, unwind: bb9];
 +     }
 + 
 +     bb25: {
-+         _13 = &mut _6;
-+         _10 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _13) -> [return: bb24, unwind: bb16];
++         _20 = &mut _6;
++         _17 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _20) -> [return: bb24, unwind: bb9];
 +     }
 + 
 +     bb26: {
-+         _2 = move _14;
-+         StorageDead(_14);
-+         goto -> bb32;
++         StorageLive(_6);
++         _6 = async_drop_in_place::<[AsyncInt; 2]>(copy (_21.0: &mut [AsyncInt; 2])) -> [return: bb25, unwind: bb9];
 +     }
 + 
 +     bb27: {
-+         _2 = move _14;
-+         StorageDead(_14);
-+         goto -> bb25;
-+     }
-+ 
-+     bb28: {
-+         StorageLive(_14);
-+         _14 = yield(const ()) -> [resume: bb26, drop: bb27];
-+     }
-+ 
-+     bb29: {
-+         _16 = discriminant(_15);
-+         switchInt(move _16) -> [0: bb14, 1: bb28, otherwise: bb21];
-+     }
-+ 
-+     bb30: {
-+         _15 = <impl Future<Output = ()> as Future>::poll(move _17, move _18) -> [return: bb29, unwind: bb16];
-+     }
-+ 
-+     bb31: {
-+         _19 = move _2;
-+         _18 = std::future::get_context::<'_, '_>(move _19) -> [return: bb30, unwind: bb16];
-+     }
-+ 
-+     bb32: {
-+         _20 = &mut _6;
-+         _17 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _20) -> [return: bb31, unwind: bb16];
-+     }
-+ 
-+     bb33: {
-+         StorageLive(_6);
-+         _6 = async_drop_in_place::<[AsyncInt; 2]>(copy (_21.0: &mut [AsyncInt; 2])) -> [return: bb32, unwind: bb16];
-+     }
-+ 
-+     bb34: {
 +         _22 = &mut _3;
-+         _21 = Pin::<&mut [AsyncInt; 2]>::new_unchecked(move _22) -> [return: bb33, unwind: bb11];
++         _21 = Pin::<&mut [AsyncInt; 2]>::new_unchecked(move _22) -> [return: bb26, unwind: bb5];
       }
   }
   

--- a/tests/mir-opt/coroutine/async_drop.array-{closure#0}.StateTransform.diff
+++ b/tests/mir-opt/coroutine/async_drop.array-{closure#0}.StateTransform.diff
@@ -60,99 +60,89 @@
 -         StorageLive(_5);
 -         _5 = AsyncInt(const 2_i32);
 -         _3 = [move _4, move _5];
--         goto -> bb1;
+-         StorageDead(_5);
+-         StorageDead(_4);
+-         _0 = const ();
+-         goto -> bb27;
 +         _27 = move _2 as std::ptr::NonNull<std::task::Context<'_>> (Transmute);
 +         _26 = std::future::ResumeTy(move _27);
 +         _25 = copy (_1.0: &mut {async fn body of array()});
 +         _24 = discriminant((*_25));
-+         switchInt(move _24) -> [0: bb26, 1: bb25, 2: bb24, 3: bb22, 4: bb23, otherwise: bb11];
++         switchInt(move _24) -> [0: bb24, 1: bb23, 2: bb22, 3: bb20, 4: bb21, otherwise: bb9];
       }
   
       bb1: {
-          StorageDead(_5);
-          goto -> bb2;
+-         StorageDead(_3);
+-         drop(_1) -> [return: bb2, unwind: bb6];
++         nop;
++         goto -> bb18;
       }
   
       bb2: {
-          StorageDead(_4);
--         _0 = const ();
--         goto -> bb29;
-+         (((*_25) as variant#4).0: ()) = const ();
-+         goto -> bb19;
-      }
-  
-      bb3: {
--         StorageDead(_3);
--         drop(_1) -> [return: bb4, unwind: bb8];
-+         nop;
-+         goto -> bb20;
-      }
-  
-      bb4: {
 +         _0 = Poll::<()>::Ready(move (((*_25) as variant#4).0: ()));
 +         discriminant((*_25)) = 1;
           return;
       }
   
--     bb5: {
+-     bb3: {
 -         StorageDead(_3);
-+     bb5 (cleanup): {
++     bb3 (cleanup): {
 +         nop;
-          goto -> bb6;
+          goto -> bb4;
       }
   
--     bb6: {
+-     bb4: {
 -         coroutine_drop;
-+     bb6 (cleanup): {
-+         goto -> bb21;
++     bb4 (cleanup): {
++         goto -> bb19;
       }
   
--     bb7 (cleanup): {
+-     bb5 (cleanup): {
 -         StorageDead(_3);
--         drop(_1) -> [return: bb8, unwind terminate(cleanup)];
-+     bb7: {
+-         drop(_1) -> [return: bb6, unwind terminate(cleanup)];
++     bb5: {
++         nop;
++         goto -> bb1;
+      }
+  
+      bb6 (cleanup): {
+-         resume;
 +         nop;
 +         goto -> bb3;
       }
   
-      bb8 (cleanup): {
--         resume;
-+         nop;
-+         goto -> bb5;
+      bb7: {
+-         StorageDead(_6);
+-         goto -> bb1;
++         assert(const false, "`async fn` resumed after async drop") -> [success: bb7, unwind: bb6];
       }
   
-      bb9: {
+      bb8: {
 -         StorageDead(_6);
 -         goto -> bb3;
-+         assert(const false, "`async fn` resumed after async drop") -> [success: bb9, unwind: bb8];
-      }
-  
-      bb10: {
--         StorageDead(_6);
--         goto -> bb5;
 +         _26 = move _7;
 +         StorageDead(_7);
-+         goto -> bb9;
++         goto -> bb7;
       }
   
--     bb11 (cleanup): {
+-     bb9 (cleanup): {
 -         StorageDead(_6);
--         goto -> bb7;
-+     bb11: {
+-         goto -> bb5;
++     bb9: {
 +         unreachable;
       }
   
-      bb12: {
--         assert(const false, "`async fn` resumed after async drop") -> [success: bb12, unwind: bb11];
+      bb10: {
+-         assert(const false, "`async fn` resumed after async drop") -> [success: bb10, unwind: bb9];
 +         _26 = move _14;
 +         StorageDead(_14);
-+         goto -> bb17;
++         goto -> bb15;
       }
   
-      bb13: {
+      bb11: {
 -         _2 = move _7;
 -         StorageDead(_7);
--         goto -> bb12;
+-         goto -> bb10;
 +         StorageLive(_14);
 +         _0 = Poll::<()>::Pending;
 +         StorageDead(_14);
@@ -160,114 +150,117 @@
 +         return;
       }
   
-      bb14: {
+      bb12: {
 -         _2 = move _7;
 -         StorageDead(_7);
--         goto -> bb20;
+-         goto -> bb18;
 +         _16 = discriminant(_15);
-+         switchInt(move _16) -> [0: bb7, 1: bb13, otherwise: bb11];
++         switchInt(move _16) -> [0: bb5, 1: bb11, otherwise: bb9];
       }
   
-      bb15: {
+      bb13: {
 -         StorageLive(_7);
--         _7 = yield(const ()) -> [resume: bb13, drop: bb14];
-+         _15 = <impl Future<Output = ()> as Future>::poll(move _17, move _18) -> [return: bb14, unwind: bb8];
+-         _7 = yield(const ()) -> [resume: bb11, drop: bb12];
++         _15 = <impl Future<Output = ()> as Future>::poll(move _17, move _18) -> [return: bb12, unwind: bb6];
       }
   
-      bb16: {
+      bb14: {
 -         unreachable;
 +         _19 = move _26;
 +         _18 = copy (_19.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
-+         goto -> bb15;
++         goto -> bb13;
+      }
+  
+      bb15: {
+-         _9 = discriminant(_8);
+-         switchInt(move _9) -> [0: bb8, 1: bb13, otherwise: bb14];
++         _20 = &mut (((*_25) as variant#4).2: impl std::future::Future<Output = ()>);
++         _17 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _20) -> [return: bb14, unwind: bb6];
+      }
+  
+      bb16: {
+-         _8 = <impl Future<Output = ()> as Future>::poll(move _10, move _11) -> [return: bb15, unwind: bb9];
++         nop;
++         (((*_25) as variant#4).2: impl std::future::Future<Output = ()>) = async_drop_in_place::<[AsyncInt; 2]>(copy (_21.0: &mut [AsyncInt; 2])) -> [return: bb15, unwind: bb6];
       }
   
       bb17: {
--         _9 = discriminant(_8);
--         switchInt(move _9) -> [0: bb10, 1: bb15, otherwise: bb16];
-+         _20 = &mut (((*_25) as variant#4).2: impl std::future::Future<Output = ()>);
-+         _17 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _20) -> [return: bb16, unwind: bb8];
+-         _12 = move _2;
+-         _11 = std::future::get_context::<'_, '_>(move _12) -> [return: bb16, unwind: bb9];
++         _22 = &mut (((*_25) as variant#4).1: [AsyncInt; 2]);
++         _21 = Pin::<&mut [AsyncInt; 2]>::new_unchecked(move _22) -> [return: bb16, unwind: bb3];
       }
   
       bb18: {
--         _8 = <impl Future<Output = ()> as Future>::poll(move _10, move _11) -> [return: bb17, unwind: bb11];
-+         nop;
-+         (((*_25) as variant#4).2: impl std::future::Future<Output = ()>) = async_drop_in_place::<[AsyncInt; 2]>(copy (_21.0: &mut [AsyncInt; 2])) -> [return: bb17, unwind: bb8];
-      }
-  
-      bb19: {
--         _12 = move _2;
--         _11 = std::future::get_context::<'_, '_>(move _12) -> [return: bb18, unwind: bb11];
-+         _22 = &mut (((*_25) as variant#4).1: [AsyncInt; 2]);
-+         _21 = Pin::<&mut [AsyncInt; 2]>::new_unchecked(move _22) -> [return: bb18, unwind: bb5];
-      }
-  
-      bb20: {
 -         _13 = &mut _6;
--         _10 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _13) -> [return: bb19, unwind: bb11];
-+         goto -> bb4;
+-         _10 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _13) -> [return: bb17, unwind: bb9];
++         goto -> bb2;
       }
   
--     bb21: {
+-     bb19: {
 -         _2 = move _14;
 -         StorageDead(_14);
--         goto -> bb27;
-+     bb21 (cleanup): {
+-         goto -> bb25;
++     bb19 (cleanup): {
 +         discriminant((*_25)) = 2;
 +         resume;
       }
   
-      bb22: {
+      bb20: {
 -         _2 = move _14;
 -         StorageDead(_14);
--         goto -> bb20;
+-         goto -> bb18;
 +         StorageLive(_7);
 +         _7 = move _26;
++         goto -> bb8;
+      }
+  
+      bb21: {
+          StorageLive(_14);
+-         _14 = yield(const ()) -> [resume: bb19, drop: bb20];
++         _14 = move _26;
 +         goto -> bb10;
       }
   
+      bb22: {
+-         _16 = discriminant(_15);
+-         switchInt(move _16) -> [0: bb7, 1: bb21, otherwise: bb14];
++         assert(const false, "`async fn` resumed after panicking") -> [success: bb22, unwind continue];
+      }
+  
       bb23: {
-          StorageLive(_14);
--         _14 = yield(const ()) -> [resume: bb21, drop: bb22];
-+         _14 = move _26;
-+         goto -> bb12;
+-         _15 = <impl Future<Output = ()> as Future>::poll(move _17, move _18) -> [return: bb22, unwind: bb9];
++         assert(const false, "`async fn` resumed after completion") -> [success: bb23, unwind continue];
       }
   
       bb24: {
--         _16 = discriminant(_15);
--         switchInt(move _16) -> [0: bb9, 1: bb23, otherwise: bb16];
-+         assert(const false, "`async fn` resumed after panicking") -> [success: bb24, unwind continue];
-      }
-  
-      bb25: {
--         _15 = <impl Future<Output = ()> as Future>::poll(move _17, move _18) -> [return: bb24, unwind: bb11];
-+         assert(const false, "`async fn` resumed after completion") -> [success: bb25, unwind continue];
-      }
-  
-      bb26: {
 -         _19 = move _2;
--         _18 = std::future::get_context::<'_, '_>(move _19) -> [return: bb25, unwind: bb11];
+-         _18 = std::future::get_context::<'_, '_>(move _19) -> [return: bb23, unwind: bb9];
+-     }
+- 
+-     bb25: {
+-         _20 = &mut _6;
+-         _17 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _20) -> [return: bb24, unwind: bb9];
+-     }
+- 
+-     bb26: {
+-         StorageLive(_6);
+-         _6 = async_drop_in_place::<[AsyncInt; 2]>(copy (_21.0: &mut [AsyncInt; 2])) -> [return: bb25, unwind: bb9];
 -     }
 - 
 -     bb27: {
--         _20 = &mut _6;
--         _17 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _20) -> [return: bb26, unwind: bb11];
--     }
-- 
--     bb28: {
--         StorageLive(_6);
--         _6 = async_drop_in_place::<[AsyncInt; 2]>(copy (_21.0: &mut [AsyncInt; 2])) -> [return: bb27, unwind: bb11];
--     }
-- 
--     bb29: {
 -         _22 = &mut _3;
--         _21 = Pin::<&mut [AsyncInt; 2]>::new_unchecked(move _22) -> [return: bb28, unwind: bb7];
+-         _21 = Pin::<&mut [AsyncInt; 2]>::new_unchecked(move _22) -> [return: bb26, unwind: bb5];
 +         nop;
 +         StorageLive(_4);
 +         _4 = AsyncInt(const 1_i32);
 +         StorageLive(_5);
 +         _5 = AsyncInt(const 2_i32);
 +         (((*_25) as variant#4).1: [AsyncInt; 2]) = [move _4, move _5];
-+         goto -> bb1;
++         StorageDead(_5);
++         StorageDead(_4);
++         (((*_25) as variant#4).0: ()) = const ();
++         goto -> bb17;
       }
   }
   

--- a/tests/mir-opt/coroutine/async_drop.elaborate_drops-{closure#0}.ElaborateDrops.diff
+++ b/tests/mir-opt/coroutine/async_drop.elaborate_drops-{closure#0}.ElaborateDrops.diff
@@ -288,7 +288,7 @@
           _26 = {closure@$DIR/async_drop.rs:86:27: 86:35} { foo: move _25 };
           _0 = const ();
 -         drop(_26) -> [return: bb2, unwind: bb28, drop: bb15];
-+         goto -> bb75;
++         goto -> bb74;
       }
   
       bb2: {
@@ -300,7 +300,7 @@
       bb3: {
           StorageDead(_25);
 -         drop(_24) -> [return: bb4, unwind: bb30, drop: bb17];
-+         goto -> bb95;
++         goto -> bb94;
       }
   
       bb4: {
@@ -312,55 +312,55 @@
       bb5: {
           StorageDead(_23);
 -         drop(_20) -> [return: bb6, unwind: bb32, drop: bb19];
-+         goto -> bb115;
++         goto -> bb114;
       }
   
       bb6: {
           StorageDead(_20);
 -         drop(_19) -> [return: bb7, unwind: bb33, drop: bb20];
-+         goto -> bb135;
++         goto -> bb134;
       }
   
       bb7: {
           StorageDead(_19);
           StorageDead(_17);
--         drop(_15) -> [return: bb8, unwind: bb37, drop: bb21];
-+         goto -> bb155;
+-         drop(_15) -> [return: bb8, unwind: bb36, drop: bb21];
++         goto -> bb154;
       }
   
       bb8: {
           StorageDead(_15);
--         drop(_11) -> [return: bb9, unwind: bb38, drop: bb22];
-+         goto -> bb175;
+-         drop(_11) -> [return: bb9, unwind: bb37, drop: bb22];
++         goto -> bb174;
       }
   
       bb9: {
           StorageDead(_11);
--         drop(_8) -> [return: bb10, unwind: bb39, drop: bb23];
-+         goto -> bb195;
+-         drop(_8) -> [return: bb10, unwind: bb38, drop: bb23];
++         goto -> bb194;
       }
   
       bb10: {
           StorageDead(_8);
--         drop(_5) -> [return: bb11, unwind: bb40, drop: bb24];
-+         goto -> bb215;
+-         drop(_5) -> [return: bb11, unwind: bb39, drop: bb24];
++         goto -> bb214;
       }
   
       bb11: {
           StorageDead(_5);
--         drop(_4) -> [return: bb12, unwind: bb41, drop: bb25];
-+         goto -> bb235;
+-         drop(_4) -> [return: bb12, unwind: bb40, drop: bb25];
++         goto -> bb234;
       }
   
       bb12: {
           StorageDead(_4);
-          drop(_3) -> [return: bb13, unwind: bb42];
+          drop(_3) -> [return: bb13, unwind: bb41];
       }
   
       bb13: {
           StorageDead(_3);
 -         drop(_1) -> [return: bb14, drop: bb27, unwind continue];
-+         drop(_1) -> [return: bb14, unwind: bb43];
++         drop(_1) -> [return: bb14, unwind: bb42];
       }
   
       bb14: {
@@ -369,68 +369,68 @@
   
       bb15: {
           StorageDead(_26);
--         drop(_25) -> [return: bb16, unwind: bb44];
+-         drop(_25) -> [return: bb16, unwind: bb43];
 +         goto -> bb16;
       }
   
       bb16: {
           StorageDead(_25);
--         drop(_24) -> [return: bb17, unwind: bb45];
+-         drop(_24) -> [return: bb17, unwind: bb44];
 +         goto -> bb17;
       }
   
       bb17: {
           StorageDead(_24);
--         drop(_23) -> [return: bb18, unwind: bb46];
+-         drop(_23) -> [return: bb18, unwind: bb45];
 +         goto -> bb18;
       }
   
       bb18: {
           StorageDead(_23);
--         drop(_20) -> [return: bb19, unwind: bb47];
+-         drop(_20) -> [return: bb19, unwind: bb46];
 +         goto -> bb19;
       }
   
       bb19: {
           StorageDead(_20);
--         drop(_19) -> [return: bb20, unwind: bb48];
+-         drop(_19) -> [return: bb20, unwind: bb47];
 +         goto -> bb20;
       }
   
       bb20: {
           StorageDead(_19);
           StorageDead(_17);
--         drop(_15) -> [return: bb21, unwind: bb49];
+-         drop(_15) -> [return: bb21, unwind: bb48];
 +         goto -> bb21;
       }
   
       bb21: {
           StorageDead(_15);
--         drop(_11) -> [return: bb22, unwind: bb50];
+-         drop(_11) -> [return: bb22, unwind: bb49];
 +         goto -> bb22;
       }
   
       bb22: {
           StorageDead(_11);
--         drop(_8) -> [return: bb23, unwind: bb51];
+-         drop(_8) -> [return: bb23, unwind: bb50];
 +         goto -> bb23;
       }
   
       bb23: {
           StorageDead(_8);
--         drop(_5) -> [return: bb24, unwind: bb52];
+-         drop(_5) -> [return: bb24, unwind: bb51];
 +         goto -> bb24;
       }
   
       bb24: {
           StorageDead(_5);
--         drop(_4) -> [return: bb25, unwind: bb53];
+-         drop(_4) -> [return: bb25, unwind: bb52];
 +         goto -> bb25;
       }
   
       bb25: {
           StorageDead(_4);
--         drop(_3) -> [return: bb26, unwind: bb54];
+-         drop(_3) -> [return: bb26, unwind: bb53];
 +         goto -> bb26;
       }
   
@@ -473,1036 +473,1031 @@
   
       bb33 (cleanup): {
           StorageDead(_19);
-          goto -> bb36;
+          goto -> bb35;
       }
   
       bb34 (cleanup): {
--         drop(_18) -> [return: bb35, unwind terminate(cleanup)];
-+         goto -> bb35;
+          StorageDead(_18);
+          goto -> bb35;
       }
   
       bb35 (cleanup): {
-          StorageDead(_18);
-          goto -> bb36;
+          StorageDead(_17);
+          drop(_15) -> [return: bb36, unwind terminate(cleanup)];
       }
   
       bb36 (cleanup): {
-          StorageDead(_17);
-          drop(_15) -> [return: bb37, unwind terminate(cleanup)];
+          StorageDead(_15);
+          drop(_11) -> [return: bb37, unwind terminate(cleanup)];
       }
   
       bb37 (cleanup): {
-          StorageDead(_15);
-          drop(_11) -> [return: bb38, unwind terminate(cleanup)];
+          StorageDead(_11);
+          drop(_8) -> [return: bb38, unwind terminate(cleanup)];
       }
   
       bb38 (cleanup): {
-          StorageDead(_11);
-          drop(_8) -> [return: bb39, unwind terminate(cleanup)];
+          StorageDead(_8);
+          drop(_5) -> [return: bb39, unwind terminate(cleanup)];
       }
   
       bb39 (cleanup): {
-          StorageDead(_8);
-          drop(_5) -> [return: bb40, unwind terminate(cleanup)];
+          StorageDead(_5);
+          drop(_4) -> [return: bb40, unwind terminate(cleanup)];
       }
   
       bb40 (cleanup): {
-          StorageDead(_5);
-          drop(_4) -> [return: bb41, unwind terminate(cleanup)];
+          StorageDead(_4);
+          drop(_3) -> [return: bb41, unwind terminate(cleanup)];
       }
   
       bb41 (cleanup): {
-          StorageDead(_4);
-          drop(_3) -> [return: bb42, unwind terminate(cleanup)];
+          StorageDead(_3);
+          drop(_1) -> [return: bb42, unwind terminate(cleanup)];
       }
   
       bb42 (cleanup): {
-          StorageDead(_3);
-          drop(_1) -> [return: bb43, unwind terminate(cleanup)];
-      }
-  
-      bb43 (cleanup): {
           resume;
       }
   
-      bb44 (cleanup): {
+      bb43 (cleanup): {
           StorageDead(_25);
--         drop(_24) -> [return: bb45, unwind terminate(cleanup)];
+-         drop(_24) -> [return: bb44, unwind terminate(cleanup)];
++         goto -> bb44;
+      }
+  
+      bb44 (cleanup): {
+          StorageDead(_24);
+-         drop(_23) -> [return: bb45, unwind terminate(cleanup)];
 +         goto -> bb45;
       }
   
       bb45 (cleanup): {
-          StorageDead(_24);
--         drop(_23) -> [return: bb46, unwind terminate(cleanup)];
+          StorageDead(_23);
+-         drop(_20) -> [return: bb46, unwind terminate(cleanup)];
 +         goto -> bb46;
       }
   
       bb46 (cleanup): {
-          StorageDead(_23);
--         drop(_20) -> [return: bb47, unwind terminate(cleanup)];
+          StorageDead(_20);
+-         drop(_19) -> [return: bb47, unwind terminate(cleanup)];
 +         goto -> bb47;
       }
   
       bb47 (cleanup): {
-          StorageDead(_20);
--         drop(_19) -> [return: bb48, unwind terminate(cleanup)];
+          StorageDead(_19);
+          StorageDead(_17);
+-         drop(_15) -> [return: bb48, unwind terminate(cleanup)];
 +         goto -> bb48;
       }
   
       bb48 (cleanup): {
-          StorageDead(_19);
-          StorageDead(_17);
--         drop(_15) -> [return: bb49, unwind terminate(cleanup)];
+          StorageDead(_15);
+-         drop(_11) -> [return: bb49, unwind terminate(cleanup)];
 +         goto -> bb49;
       }
   
       bb49 (cleanup): {
-          StorageDead(_15);
--         drop(_11) -> [return: bb50, unwind terminate(cleanup)];
+          StorageDead(_11);
+-         drop(_8) -> [return: bb50, unwind terminate(cleanup)];
 +         goto -> bb50;
       }
   
       bb50 (cleanup): {
-          StorageDead(_11);
--         drop(_8) -> [return: bb51, unwind terminate(cleanup)];
+          StorageDead(_8);
+-         drop(_5) -> [return: bb51, unwind terminate(cleanup)];
 +         goto -> bb51;
       }
   
       bb51 (cleanup): {
-          StorageDead(_8);
--         drop(_5) -> [return: bb52, unwind terminate(cleanup)];
+          StorageDead(_5);
+-         drop(_4) -> [return: bb52, unwind terminate(cleanup)];
 +         goto -> bb52;
       }
   
       bb52 (cleanup): {
-          StorageDead(_5);
--         drop(_4) -> [return: bb53, unwind terminate(cleanup)];
+          StorageDead(_4);
+-         drop(_3) -> [return: bb53, unwind terminate(cleanup)];
 +         goto -> bb53;
       }
   
       bb53 (cleanup): {
-          StorageDead(_4);
--         drop(_3) -> [return: bb54, unwind terminate(cleanup)];
-+         goto -> bb54;
-      }
-  
-      bb54 (cleanup): {
           StorageDead(_3);
--         drop(_1) -> [return: bb43, unwind terminate(cleanup)];
-+         goto -> bb43;
+-         drop(_1) -> [return: bb42, unwind terminate(cleanup)];
++         goto -> bb42;
 +     }
 + 
-+     bb55: {
++     bb54: {
 +         StorageDead(_27);
 +         goto -> bb2;
 +     }
 + 
-+     bb56: {
++     bb55: {
 +         StorageDead(_27);
 +         goto -> bb15;
 +     }
 + 
-+     bb57 (cleanup): {
++     bb56 (cleanup): {
 +         StorageDead(_27);
 +         goto -> bb28;
 +     }
 + 
++     bb57: {
++         assert(const false, "`async fn` resumed after async drop") -> [success: bb57, unwind: bb56];
++     }
++ 
 +     bb58: {
-+         assert(const false, "`async fn` resumed after async drop") -> [success: bb58, unwind: bb57];
++         _2 = move _28;
++         StorageDead(_28);
++         goto -> bb57;
 +     }
 + 
 +     bb59: {
 +         _2 = move _28;
 +         StorageDead(_28);
-+         goto -> bb58;
++         goto -> bb65;
 +     }
 + 
 +     bb60: {
-+         _2 = move _28;
-+         StorageDead(_28);
-+         goto -> bb66;
++         StorageLive(_28);
++         _28 = yield(const ()) -> [resume: bb58, drop: bb59];
 +     }
 + 
 +     bb61: {
-+         StorageLive(_28);
-+         _28 = yield(const ()) -> [resume: bb59, drop: bb60];
-+     }
-+ 
-+     bb62: {
 +         unreachable;
 +     }
 + 
-+     bb63: {
++     bb62: {
 +         _30 = discriminant(_29);
-+         switchInt(move _30) -> [0: bb56, 1: bb61, otherwise: bb62];
++         switchInt(move _30) -> [0: bb55, 1: bb60, otherwise: bb61];
++     }
++ 
++     bb63: {
++         _29 = <impl Future<Output = ()> as Future>::poll(move _31, move _32) -> [return: bb62, unwind: bb56];
 +     }
 + 
 +     bb64: {
-+         _29 = <impl Future<Output = ()> as Future>::poll(move _31, move _32) -> [return: bb63, unwind: bb57];
++         _33 = move _2;
++         _32 = std::future::get_context::<'_, '_>(move _33) -> [return: bb63, unwind: bb56];
 +     }
 + 
 +     bb65: {
-+         _33 = move _2;
-+         _32 = std::future::get_context::<'_, '_>(move _33) -> [return: bb64, unwind: bb57];
++         _34 = &mut _27;
++         _31 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _34) -> [return: bb64, unwind: bb56];
 +     }
 + 
 +     bb66: {
-+         _34 = &mut _27;
-+         _31 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _34) -> [return: bb65, unwind: bb57];
++         _2 = move _35;
++         StorageDead(_35);
++         goto -> bb72;
 +     }
 + 
 +     bb67: {
 +         _2 = move _35;
 +         StorageDead(_35);
-+         goto -> bb73;
++         goto -> bb65;
 +     }
 + 
 +     bb68: {
-+         _2 = move _35;
-+         StorageDead(_35);
-+         goto -> bb66;
++         StorageLive(_35);
++         _35 = yield(const ()) -> [resume: bb66, drop: bb67];
 +     }
 + 
 +     bb69: {
-+         StorageLive(_35);
-+         _35 = yield(const ()) -> [resume: bb67, drop: bb68];
++         _37 = discriminant(_36);
++         switchInt(move _37) -> [0: bb54, 1: bb68, otherwise: bb61];
 +     }
 + 
 +     bb70: {
-+         _37 = discriminant(_36);
-+         switchInt(move _37) -> [0: bb55, 1: bb69, otherwise: bb62];
++         _36 = <impl Future<Output = ()> as Future>::poll(move _38, move _39) -> [return: bb69, unwind: bb56];
 +     }
 + 
 +     bb71: {
-+         _36 = <impl Future<Output = ()> as Future>::poll(move _38, move _39) -> [return: bb70, unwind: bb57];
++         _40 = move _2;
++         _39 = std::future::get_context::<'_, '_>(move _40) -> [return: bb70, unwind: bb56];
 +     }
 + 
 +     bb72: {
-+         _40 = move _2;
-+         _39 = std::future::get_context::<'_, '_>(move _40) -> [return: bb71, unwind: bb57];
++         _41 = &mut _27;
++         _38 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _41) -> [return: bb71, unwind: bb56];
 +     }
 + 
 +     bb73: {
-+         _41 = &mut _27;
-+         _38 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _41) -> [return: bb72, unwind: bb57];
++         StorageLive(_27);
++         _27 = async_drop_in_place::<{async closure@$DIR/async_drop.rs:86:27: 86:35}>(copy (_42.0: &mut {async closure@$DIR/async_drop.rs:86:27: 86:35})) -> [return: bb72, unwind: bb56];
 +     }
 + 
 +     bb74: {
-+         StorageLive(_27);
-+         _27 = async_drop_in_place::<{async closure@$DIR/async_drop.rs:86:27: 86:35}>(copy (_42.0: &mut {async closure@$DIR/async_drop.rs:86:27: 86:35})) -> [return: bb73, unwind: bb57];
++         _43 = &mut _26;
++         _42 = Pin::<&mut {async closure@$DIR/async_drop.rs:86:27: 86:35}>::new_unchecked(move _43) -> [return: bb73, unwind: bb28];
 +     }
 + 
 +     bb75: {
-+         _43 = &mut _26;
-+         _42 = Pin::<&mut {async closure@$DIR/async_drop.rs:86:27: 86:35}>::new_unchecked(move _43) -> [return: bb74, unwind: bb28];
-+     }
-+ 
-+     bb76: {
 +         StorageDead(_44);
 +         goto -> bb4;
 +     }
 + 
-+     bb77: {
++     bb76: {
 +         StorageDead(_44);
 +         goto -> bb17;
 +     }
 + 
-+     bb78 (cleanup): {
++     bb77 (cleanup): {
 +         StorageDead(_44);
 +         goto -> bb30;
 +     }
 + 
++     bb78: {
++         assert(const false, "`async fn` resumed after async drop") -> [success: bb78, unwind: bb77];
++     }
++ 
 +     bb79: {
-+         assert(const false, "`async fn` resumed after async drop") -> [success: bb79, unwind: bb78];
++         _2 = move _45;
++         StorageDead(_45);
++         goto -> bb78;
 +     }
 + 
 +     bb80: {
 +         _2 = move _45;
 +         StorageDead(_45);
-+         goto -> bb79;
++         goto -> bb85;
 +     }
 + 
 +     bb81: {
-+         _2 = move _45;
-+         StorageDead(_45);
-+         goto -> bb86;
++         StorageLive(_45);
++         _45 = yield(const ()) -> [resume: bb79, drop: bb80];
 +     }
 + 
 +     bb82: {
-+         StorageLive(_45);
-+         _45 = yield(const ()) -> [resume: bb80, drop: bb81];
++         _47 = discriminant(_46);
++         switchInt(move _47) -> [0: bb76, 1: bb81, otherwise: bb61];
 +     }
 + 
 +     bb83: {
-+         _47 = discriminant(_46);
-+         switchInt(move _47) -> [0: bb77, 1: bb82, otherwise: bb62];
++         _46 = <impl Future<Output = ()> as Future>::poll(move _48, move _49) -> [return: bb82, unwind: bb77];
 +     }
 + 
 +     bb84: {
-+         _46 = <impl Future<Output = ()> as Future>::poll(move _48, move _49) -> [return: bb83, unwind: bb78];
++         _50 = move _2;
++         _49 = std::future::get_context::<'_, '_>(move _50) -> [return: bb83, unwind: bb77];
 +     }
 + 
 +     bb85: {
-+         _50 = move _2;
-+         _49 = std::future::get_context::<'_, '_>(move _50) -> [return: bb84, unwind: bb78];
++         _51 = &mut _44;
++         _48 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _51) -> [return: bb84, unwind: bb77];
 +     }
 + 
 +     bb86: {
-+         _51 = &mut _44;
-+         _48 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _51) -> [return: bb85, unwind: bb78];
++         _2 = move _52;
++         StorageDead(_52);
++         goto -> bb92;
 +     }
 + 
 +     bb87: {
 +         _2 = move _52;
 +         StorageDead(_52);
-+         goto -> bb93;
++         goto -> bb85;
 +     }
 + 
 +     bb88: {
-+         _2 = move _52;
-+         StorageDead(_52);
-+         goto -> bb86;
++         StorageLive(_52);
++         _52 = yield(const ()) -> [resume: bb86, drop: bb87];
 +     }
 + 
 +     bb89: {
-+         StorageLive(_52);
-+         _52 = yield(const ()) -> [resume: bb87, drop: bb88];
++         _54 = discriminant(_53);
++         switchInt(move _54) -> [0: bb75, 1: bb88, otherwise: bb61];
 +     }
 + 
 +     bb90: {
-+         _54 = discriminant(_53);
-+         switchInt(move _54) -> [0: bb76, 1: bb89, otherwise: bb62];
++         _53 = <impl Future<Output = ()> as Future>::poll(move _55, move _56) -> [return: bb89, unwind: bb77];
 +     }
 + 
 +     bb91: {
-+         _53 = <impl Future<Output = ()> as Future>::poll(move _55, move _56) -> [return: bb90, unwind: bb78];
++         _57 = move _2;
++         _56 = std::future::get_context::<'_, '_>(move _57) -> [return: bb90, unwind: bb77];
 +     }
 + 
 +     bb92: {
-+         _57 = move _2;
-+         _56 = std::future::get_context::<'_, '_>(move _57) -> [return: bb91, unwind: bb78];
++         _58 = &mut _44;
++         _55 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _58) -> [return: bb91, unwind: bb77];
 +     }
 + 
 +     bb93: {
-+         _58 = &mut _44;
-+         _55 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _58) -> [return: bb92, unwind: bb78];
++         StorageLive(_44);
++         _44 = async_drop_in_place::<{closure@$DIR/async_drop.rs:78:25: 78:27}>(copy (_59.0: &mut {closure@$DIR/async_drop.rs:78:25: 78:27})) -> [return: bb92, unwind: bb77];
 +     }
 + 
 +     bb94: {
-+         StorageLive(_44);
-+         _44 = async_drop_in_place::<{closure@$DIR/async_drop.rs:78:25: 78:27}>(copy (_59.0: &mut {closure@$DIR/async_drop.rs:78:25: 78:27})) -> [return: bb93, unwind: bb78];
++         _60 = &mut _24;
++         _59 = Pin::<&mut {closure@$DIR/async_drop.rs:78:25: 78:27}>::new_unchecked(move _60) -> [return: bb93, unwind: bb30];
 +     }
 + 
 +     bb95: {
-+         _60 = &mut _24;
-+         _59 = Pin::<&mut {closure@$DIR/async_drop.rs:78:25: 78:27}>::new_unchecked(move _60) -> [return: bb94, unwind: bb30];
-+     }
-+ 
-+     bb96: {
 +         StorageDead(_61);
 +         goto -> bb6;
 +     }
 + 
-+     bb97: {
++     bb96: {
 +         StorageDead(_61);
 +         goto -> bb19;
 +     }
 + 
-+     bb98 (cleanup): {
++     bb97 (cleanup): {
 +         StorageDead(_61);
 +         goto -> bb32;
 +     }
 + 
++     bb98: {
++         assert(const false, "`async fn` resumed after async drop") -> [success: bb98, unwind: bb97];
++     }
++ 
 +     bb99: {
-+         assert(const false, "`async fn` resumed after async drop") -> [success: bb99, unwind: bb98];
++         _2 = move _62;
++         StorageDead(_62);
++         goto -> bb98;
 +     }
 + 
 +     bb100: {
 +         _2 = move _62;
 +         StorageDead(_62);
-+         goto -> bb99;
++         goto -> bb105;
 +     }
 + 
 +     bb101: {
-+         _2 = move _62;
-+         StorageDead(_62);
-+         goto -> bb106;
++         StorageLive(_62);
++         _62 = yield(const ()) -> [resume: bb99, drop: bb100];
 +     }
 + 
 +     bb102: {
-+         StorageLive(_62);
-+         _62 = yield(const ()) -> [resume: bb100, drop: bb101];
++         _64 = discriminant(_63);
++         switchInt(move _64) -> [0: bb96, 1: bb101, otherwise: bb61];
 +     }
 + 
 +     bb103: {
-+         _64 = discriminant(_63);
-+         switchInt(move _64) -> [0: bb97, 1: bb102, otherwise: bb62];
++         _63 = <impl Future<Output = ()> as Future>::poll(move _65, move _66) -> [return: bb102, unwind: bb97];
 +     }
 + 
 +     bb104: {
-+         _63 = <impl Future<Output = ()> as Future>::poll(move _65, move _66) -> [return: bb103, unwind: bb98];
++         _67 = move _2;
++         _66 = std::future::get_context::<'_, '_>(move _67) -> [return: bb103, unwind: bb97];
 +     }
 + 
 +     bb105: {
-+         _67 = move _2;
-+         _66 = std::future::get_context::<'_, '_>(move _67) -> [return: bb104, unwind: bb98];
++         _68 = &mut _61;
++         _65 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _68) -> [return: bb104, unwind: bb97];
 +     }
 + 
 +     bb106: {
-+         _68 = &mut _61;
-+         _65 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _68) -> [return: bb105, unwind: bb98];
++         _2 = move _69;
++         StorageDead(_69);
++         goto -> bb112;
 +     }
 + 
 +     bb107: {
 +         _2 = move _69;
 +         StorageDead(_69);
-+         goto -> bb113;
++         goto -> bb105;
 +     }
 + 
 +     bb108: {
-+         _2 = move _69;
-+         StorageDead(_69);
-+         goto -> bb106;
++         StorageLive(_69);
++         _69 = yield(const ()) -> [resume: bb106, drop: bb107];
 +     }
 + 
 +     bb109: {
-+         StorageLive(_69);
-+         _69 = yield(const ()) -> [resume: bb107, drop: bb108];
++         _71 = discriminant(_70);
++         switchInt(move _71) -> [0: bb95, 1: bb108, otherwise: bb61];
 +     }
 + 
 +     bb110: {
-+         _71 = discriminant(_70);
-+         switchInt(move _71) -> [0: bb96, 1: bb109, otherwise: bb62];
++         _70 = <impl Future<Output = ()> as Future>::poll(move _72, move _73) -> [return: bb109, unwind: bb97];
 +     }
 + 
 +     bb111: {
-+         _70 = <impl Future<Output = ()> as Future>::poll(move _72, move _73) -> [return: bb110, unwind: bb98];
++         _74 = move _2;
++         _73 = std::future::get_context::<'_, '_>(move _74) -> [return: bb110, unwind: bb97];
 +     }
 + 
 +     bb112: {
-+         _74 = move _2;
-+         _73 = std::future::get_context::<'_, '_>(move _74) -> [return: bb111, unwind: bb98];
++         _75 = &mut _61;
++         _72 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _75) -> [return: bb111, unwind: bb97];
 +     }
 + 
 +     bb113: {
-+         _75 = &mut _61;
-+         _72 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _75) -> [return: bb112, unwind: bb98];
++         StorageLive(_61);
++         _61 = async_drop_in_place::<AsyncReference<'_>>(copy (_76.0: &mut AsyncReference<'_>)) -> [return: bb112, unwind: bb97];
 +     }
 + 
 +     bb114: {
-+         StorageLive(_61);
-+         _61 = async_drop_in_place::<AsyncReference<'_>>(copy (_76.0: &mut AsyncReference<'_>)) -> [return: bb113, unwind: bb98];
++         _77 = &mut _20;
++         _76 = Pin::<&mut AsyncReference<'_>>::new_unchecked(move _77) -> [return: bb113, unwind: bb32];
 +     }
 + 
 +     bb115: {
-+         _77 = &mut _20;
-+         _76 = Pin::<&mut AsyncReference<'_>>::new_unchecked(move _77) -> [return: bb114, unwind: bb32];
-+     }
-+ 
-+     bb116: {
 +         StorageDead(_78);
 +         goto -> bb7;
 +     }
 + 
-+     bb117: {
++     bb116: {
 +         StorageDead(_78);
 +         goto -> bb20;
 +     }
 + 
-+     bb118 (cleanup): {
++     bb117 (cleanup): {
 +         StorageDead(_78);
 +         goto -> bb33;
 +     }
 + 
++     bb118: {
++         assert(const false, "`async fn` resumed after async drop") -> [success: bb118, unwind: bb117];
++     }
++ 
 +     bb119: {
-+         assert(const false, "`async fn` resumed after async drop") -> [success: bb119, unwind: bb118];
++         _2 = move _79;
++         StorageDead(_79);
++         goto -> bb118;
 +     }
 + 
 +     bb120: {
 +         _2 = move _79;
 +         StorageDead(_79);
-+         goto -> bb119;
++         goto -> bb125;
 +     }
 + 
 +     bb121: {
-+         _2 = move _79;
-+         StorageDead(_79);
-+         goto -> bb126;
++         StorageLive(_79);
++         _79 = yield(const ()) -> [resume: bb119, drop: bb120];
 +     }
 + 
 +     bb122: {
-+         StorageLive(_79);
-+         _79 = yield(const ()) -> [resume: bb120, drop: bb121];
++         _81 = discriminant(_80);
++         switchInt(move _81) -> [0: bb116, 1: bb121, otherwise: bb61];
 +     }
 + 
 +     bb123: {
-+         _81 = discriminant(_80);
-+         switchInt(move _81) -> [0: bb117, 1: bb122, otherwise: bb62];
++         _80 = <impl Future<Output = ()> as Future>::poll(move _82, move _83) -> [return: bb122, unwind: bb117];
 +     }
 + 
 +     bb124: {
-+         _80 = <impl Future<Output = ()> as Future>::poll(move _82, move _83) -> [return: bb123, unwind: bb118];
++         _84 = move _2;
++         _83 = std::future::get_context::<'_, '_>(move _84) -> [return: bb123, unwind: bb117];
 +     }
 + 
 +     bb125: {
-+         _84 = move _2;
-+         _83 = std::future::get_context::<'_, '_>(move _84) -> [return: bb124, unwind: bb118];
++         _85 = &mut _78;
++         _82 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _85) -> [return: bb124, unwind: bb117];
 +     }
 + 
 +     bb126: {
-+         _85 = &mut _78;
-+         _82 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _85) -> [return: bb125, unwind: bb118];
++         _2 = move _86;
++         StorageDead(_86);
++         goto -> bb132;
 +     }
 + 
 +     bb127: {
 +         _2 = move _86;
 +         StorageDead(_86);
-+         goto -> bb133;
++         goto -> bb125;
 +     }
 + 
 +     bb128: {
-+         _2 = move _86;
-+         StorageDead(_86);
-+         goto -> bb126;
++         StorageLive(_86);
++         _86 = yield(const ()) -> [resume: bb126, drop: bb127];
 +     }
 + 
 +     bb129: {
-+         StorageLive(_86);
-+         _86 = yield(const ()) -> [resume: bb127, drop: bb128];
++         _88 = discriminant(_87);
++         switchInt(move _88) -> [0: bb115, 1: bb128, otherwise: bb61];
 +     }
 + 
 +     bb130: {
-+         _88 = discriminant(_87);
-+         switchInt(move _88) -> [0: bb116, 1: bb129, otherwise: bb62];
++         _87 = <impl Future<Output = ()> as Future>::poll(move _89, move _90) -> [return: bb129, unwind: bb117];
 +     }
 + 
 +     bb131: {
-+         _87 = <impl Future<Output = ()> as Future>::poll(move _89, move _90) -> [return: bb130, unwind: bb118];
++         _91 = move _2;
++         _90 = std::future::get_context::<'_, '_>(move _91) -> [return: bb130, unwind: bb117];
 +     }
 + 
 +     bb132: {
-+         _91 = move _2;
-+         _90 = std::future::get_context::<'_, '_>(move _91) -> [return: bb131, unwind: bb118];
++         _92 = &mut _78;
++         _89 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _92) -> [return: bb131, unwind: bb117];
 +     }
 + 
 +     bb133: {
-+         _92 = &mut _78;
-+         _89 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _92) -> [return: bb132, unwind: bb118];
++         StorageLive(_78);
++         _78 = async_drop_in_place::<AsyncInt>(copy (_93.0: &mut AsyncInt)) -> [return: bb132, unwind: bb117];
 +     }
 + 
 +     bb134: {
-+         StorageLive(_78);
-+         _78 = async_drop_in_place::<AsyncInt>(copy (_93.0: &mut AsyncInt)) -> [return: bb133, unwind: bb118];
++         _94 = &mut _19;
++         _93 = Pin::<&mut AsyncInt>::new_unchecked(move _94) -> [return: bb133, unwind: bb33];
 +     }
 + 
 +     bb135: {
-+         _94 = &mut _19;
-+         _93 = Pin::<&mut AsyncInt>::new_unchecked(move _94) -> [return: bb134, unwind: bb33];
-+     }
-+ 
-+     bb136: {
 +         StorageDead(_95);
 +         goto -> bb8;
 +     }
 + 
-+     bb137: {
++     bb136: {
 +         StorageDead(_95);
 +         goto -> bb21;
 +     }
 + 
-+     bb138 (cleanup): {
++     bb137 (cleanup): {
 +         StorageDead(_95);
-+         goto -> bb37;
++         goto -> bb36;
++     }
++ 
++     bb138: {
++         assert(const false, "`async fn` resumed after async drop") -> [success: bb138, unwind: bb137];
 +     }
 + 
 +     bb139: {
-+         assert(const false, "`async fn` resumed after async drop") -> [success: bb139, unwind: bb138];
++         _2 = move _96;
++         StorageDead(_96);
++         goto -> bb138;
 +     }
 + 
 +     bb140: {
 +         _2 = move _96;
 +         StorageDead(_96);
-+         goto -> bb139;
++         goto -> bb145;
 +     }
 + 
 +     bb141: {
-+         _2 = move _96;
-+         StorageDead(_96);
-+         goto -> bb146;
++         StorageLive(_96);
++         _96 = yield(const ()) -> [resume: bb139, drop: bb140];
 +     }
 + 
 +     bb142: {
-+         StorageLive(_96);
-+         _96 = yield(const ()) -> [resume: bb140, drop: bb141];
++         _98 = discriminant(_97);
++         switchInt(move _98) -> [0: bb136, 1: bb141, otherwise: bb61];
 +     }
 + 
 +     bb143: {
-+         _98 = discriminant(_97);
-+         switchInt(move _98) -> [0: bb137, 1: bb142, otherwise: bb62];
++         _97 = <impl Future<Output = ()> as Future>::poll(move _99, move _100) -> [return: bb142, unwind: bb137];
 +     }
 + 
 +     bb144: {
-+         _97 = <impl Future<Output = ()> as Future>::poll(move _99, move _100) -> [return: bb143, unwind: bb138];
++         _101 = move _2;
++         _100 = std::future::get_context::<'_, '_>(move _101) -> [return: bb143, unwind: bb137];
 +     }
 + 
 +     bb145: {
-+         _101 = move _2;
-+         _100 = std::future::get_context::<'_, '_>(move _101) -> [return: bb144, unwind: bb138];
++         _102 = &mut _95;
++         _99 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _102) -> [return: bb144, unwind: bb137];
 +     }
 + 
 +     bb146: {
-+         _102 = &mut _95;
-+         _99 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _102) -> [return: bb145, unwind: bb138];
++         _2 = move _103;
++         StorageDead(_103);
++         goto -> bb152;
 +     }
 + 
 +     bb147: {
 +         _2 = move _103;
 +         StorageDead(_103);
-+         goto -> bb153;
++         goto -> bb145;
 +     }
 + 
 +     bb148: {
-+         _2 = move _103;
-+         StorageDead(_103);
-+         goto -> bb146;
++         StorageLive(_103);
++         _103 = yield(const ()) -> [resume: bb146, drop: bb147];
 +     }
 + 
 +     bb149: {
-+         StorageLive(_103);
-+         _103 = yield(const ()) -> [resume: bb147, drop: bb148];
++         _105 = discriminant(_104);
++         switchInt(move _105) -> [0: bb135, 1: bb148, otherwise: bb61];
 +     }
 + 
 +     bb150: {
-+         _105 = discriminant(_104);
-+         switchInt(move _105) -> [0: bb136, 1: bb149, otherwise: bb62];
++         _104 = <impl Future<Output = ()> as Future>::poll(move _106, move _107) -> [return: bb149, unwind: bb137];
 +     }
 + 
 +     bb151: {
-+         _104 = <impl Future<Output = ()> as Future>::poll(move _106, move _107) -> [return: bb150, unwind: bb138];
++         _108 = move _2;
++         _107 = std::future::get_context::<'_, '_>(move _108) -> [return: bb150, unwind: bb137];
 +     }
 + 
 +     bb152: {
-+         _108 = move _2;
-+         _107 = std::future::get_context::<'_, '_>(move _108) -> [return: bb151, unwind: bb138];
++         _109 = &mut _95;
++         _106 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _109) -> [return: bb151, unwind: bb137];
 +     }
 + 
 +     bb153: {
-+         _109 = &mut _95;
-+         _106 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _109) -> [return: bb152, unwind: bb138];
++         StorageLive(_95);
++         _95 = async_drop_in_place::<AsyncEnum>(copy (_110.0: &mut AsyncEnum)) -> [return: bb152, unwind: bb137];
 +     }
 + 
 +     bb154: {
-+         StorageLive(_95);
-+         _95 = async_drop_in_place::<AsyncEnum>(copy (_110.0: &mut AsyncEnum)) -> [return: bb153, unwind: bb138];
++         _111 = &mut _15;
++         _110 = Pin::<&mut AsyncEnum>::new_unchecked(move _111) -> [return: bb153, unwind: bb36];
 +     }
 + 
 +     bb155: {
-+         _111 = &mut _15;
-+         _110 = Pin::<&mut AsyncEnum>::new_unchecked(move _111) -> [return: bb154, unwind: bb37];
-+     }
-+ 
-+     bb156: {
 +         StorageDead(_112);
 +         goto -> bb9;
 +     }
 + 
-+     bb157: {
++     bb156: {
 +         StorageDead(_112);
 +         goto -> bb22;
 +     }
 + 
-+     bb158 (cleanup): {
++     bb157 (cleanup): {
 +         StorageDead(_112);
-+         goto -> bb38;
++         goto -> bb37;
++     }
++ 
++     bb158: {
++         assert(const false, "`async fn` resumed after async drop") -> [success: bb158, unwind: bb157];
 +     }
 + 
 +     bb159: {
-+         assert(const false, "`async fn` resumed after async drop") -> [success: bb159, unwind: bb158];
++         _2 = move _113;
++         StorageDead(_113);
++         goto -> bb158;
 +     }
 + 
 +     bb160: {
 +         _2 = move _113;
 +         StorageDead(_113);
-+         goto -> bb159;
++         goto -> bb165;
 +     }
 + 
 +     bb161: {
-+         _2 = move _113;
-+         StorageDead(_113);
-+         goto -> bb166;
++         StorageLive(_113);
++         _113 = yield(const ()) -> [resume: bb159, drop: bb160];
 +     }
 + 
 +     bb162: {
-+         StorageLive(_113);
-+         _113 = yield(const ()) -> [resume: bb160, drop: bb161];
++         _115 = discriminant(_114);
++         switchInt(move _115) -> [0: bb156, 1: bb161, otherwise: bb61];
 +     }
 + 
 +     bb163: {
-+         _115 = discriminant(_114);
-+         switchInt(move _115) -> [0: bb157, 1: bb162, otherwise: bb62];
++         _114 = <impl Future<Output = ()> as Future>::poll(move _116, move _117) -> [return: bb162, unwind: bb157];
 +     }
 + 
 +     bb164: {
-+         _114 = <impl Future<Output = ()> as Future>::poll(move _116, move _117) -> [return: bb163, unwind: bb158];
++         _118 = move _2;
++         _117 = std::future::get_context::<'_, '_>(move _118) -> [return: bb163, unwind: bb157];
 +     }
 + 
 +     bb165: {
-+         _118 = move _2;
-+         _117 = std::future::get_context::<'_, '_>(move _118) -> [return: bb164, unwind: bb158];
++         _119 = &mut _112;
++         _116 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _119) -> [return: bb164, unwind: bb157];
 +     }
 + 
 +     bb166: {
-+         _119 = &mut _112;
-+         _116 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _119) -> [return: bb165, unwind: bb158];
++         _2 = move _120;
++         StorageDead(_120);
++         goto -> bb172;
 +     }
 + 
 +     bb167: {
 +         _2 = move _120;
 +         StorageDead(_120);
-+         goto -> bb173;
++         goto -> bb165;
 +     }
 + 
 +     bb168: {
-+         _2 = move _120;
-+         StorageDead(_120);
-+         goto -> bb166;
++         StorageLive(_120);
++         _120 = yield(const ()) -> [resume: bb166, drop: bb167];
 +     }
 + 
 +     bb169: {
-+         StorageLive(_120);
-+         _120 = yield(const ()) -> [resume: bb167, drop: bb168];
++         _122 = discriminant(_121);
++         switchInt(move _122) -> [0: bb155, 1: bb168, otherwise: bb61];
 +     }
 + 
 +     bb170: {
-+         _122 = discriminant(_121);
-+         switchInt(move _122) -> [0: bb156, 1: bb169, otherwise: bb62];
++         _121 = <impl Future<Output = ()> as Future>::poll(move _123, move _124) -> [return: bb169, unwind: bb157];
 +     }
 + 
 +     bb171: {
-+         _121 = <impl Future<Output = ()> as Future>::poll(move _123, move _124) -> [return: bb170, unwind: bb158];
++         _125 = move _2;
++         _124 = std::future::get_context::<'_, '_>(move _125) -> [return: bb170, unwind: bb157];
 +     }
 + 
 +     bb172: {
-+         _125 = move _2;
-+         _124 = std::future::get_context::<'_, '_>(move _125) -> [return: bb171, unwind: bb158];
++         _126 = &mut _112;
++         _123 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _126) -> [return: bb171, unwind: bb157];
 +     }
 + 
 +     bb173: {
-+         _126 = &mut _112;
-+         _123 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _126) -> [return: bb172, unwind: bb158];
++         StorageLive(_112);
++         _112 = async_drop_in_place::<SyncThenAsync>(copy (_127.0: &mut SyncThenAsync)) -> [return: bb172, unwind: bb157];
 +     }
 + 
 +     bb174: {
-+         StorageLive(_112);
-+         _112 = async_drop_in_place::<SyncThenAsync>(copy (_127.0: &mut SyncThenAsync)) -> [return: bb173, unwind: bb158];
++         _128 = &mut _11;
++         _127 = Pin::<&mut SyncThenAsync>::new_unchecked(move _128) -> [return: bb173, unwind: bb37];
 +     }
 + 
 +     bb175: {
-+         _128 = &mut _11;
-+         _127 = Pin::<&mut SyncThenAsync>::new_unchecked(move _128) -> [return: bb174, unwind: bb38];
-+     }
-+ 
-+     bb176: {
 +         StorageDead(_129);
 +         goto -> bb10;
 +     }
 + 
-+     bb177: {
++     bb176: {
 +         StorageDead(_129);
 +         goto -> bb23;
 +     }
 + 
-+     bb178 (cleanup): {
++     bb177 (cleanup): {
 +         StorageDead(_129);
-+         goto -> bb39;
++         goto -> bb38;
++     }
++ 
++     bb178: {
++         assert(const false, "`async fn` resumed after async drop") -> [success: bb178, unwind: bb177];
 +     }
 + 
 +     bb179: {
-+         assert(const false, "`async fn` resumed after async drop") -> [success: bb179, unwind: bb178];
++         _2 = move _130;
++         StorageDead(_130);
++         goto -> bb178;
 +     }
 + 
 +     bb180: {
 +         _2 = move _130;
 +         StorageDead(_130);
-+         goto -> bb179;
++         goto -> bb185;
 +     }
 + 
 +     bb181: {
-+         _2 = move _130;
-+         StorageDead(_130);
-+         goto -> bb186;
++         StorageLive(_130);
++         _130 = yield(const ()) -> [resume: bb179, drop: bb180];
 +     }
 + 
 +     bb182: {
-+         StorageLive(_130);
-+         _130 = yield(const ()) -> [resume: bb180, drop: bb181];
++         _132 = discriminant(_131);
++         switchInt(move _132) -> [0: bb176, 1: bb181, otherwise: bb61];
 +     }
 + 
 +     bb183: {
-+         _132 = discriminant(_131);
-+         switchInt(move _132) -> [0: bb177, 1: bb182, otherwise: bb62];
++         _131 = <impl Future<Output = ()> as Future>::poll(move _133, move _134) -> [return: bb182, unwind: bb177];
 +     }
 + 
 +     bb184: {
-+         _131 = <impl Future<Output = ()> as Future>::poll(move _133, move _134) -> [return: bb183, unwind: bb178];
++         _135 = move _2;
++         _134 = std::future::get_context::<'_, '_>(move _135) -> [return: bb183, unwind: bb177];
 +     }
 + 
 +     bb185: {
-+         _135 = move _2;
-+         _134 = std::future::get_context::<'_, '_>(move _135) -> [return: bb184, unwind: bb178];
++         _136 = &mut _129;
++         _133 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _136) -> [return: bb184, unwind: bb177];
 +     }
 + 
 +     bb186: {
-+         _136 = &mut _129;
-+         _133 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _136) -> [return: bb185, unwind: bb178];
++         _2 = move _137;
++         StorageDead(_137);
++         goto -> bb192;
 +     }
 + 
 +     bb187: {
 +         _2 = move _137;
 +         StorageDead(_137);
-+         goto -> bb193;
++         goto -> bb185;
 +     }
 + 
 +     bb188: {
-+         _2 = move _137;
-+         StorageDead(_137);
-+         goto -> bb186;
++         StorageLive(_137);
++         _137 = yield(const ()) -> [resume: bb186, drop: bb187];
 +     }
 + 
 +     bb189: {
-+         StorageLive(_137);
-+         _137 = yield(const ()) -> [resume: bb187, drop: bb188];
++         _139 = discriminant(_138);
++         switchInt(move _139) -> [0: bb175, 1: bb188, otherwise: bb61];
 +     }
 + 
 +     bb190: {
-+         _139 = discriminant(_138);
-+         switchInt(move _139) -> [0: bb176, 1: bb189, otherwise: bb62];
++         _138 = <impl Future<Output = ()> as Future>::poll(move _140, move _141) -> [return: bb189, unwind: bb177];
 +     }
 + 
 +     bb191: {
-+         _138 = <impl Future<Output = ()> as Future>::poll(move _140, move _141) -> [return: bb190, unwind: bb178];
++         _142 = move _2;
++         _141 = std::future::get_context::<'_, '_>(move _142) -> [return: bb190, unwind: bb177];
 +     }
 + 
 +     bb192: {
-+         _142 = move _2;
-+         _141 = std::future::get_context::<'_, '_>(move _142) -> [return: bb191, unwind: bb178];
++         _143 = &mut _129;
++         _140 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _143) -> [return: bb191, unwind: bb177];
 +     }
 + 
 +     bb193: {
-+         _143 = &mut _129;
-+         _140 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _143) -> [return: bb192, unwind: bb178];
++         StorageLive(_129);
++         _129 = async_drop_in_place::<AsyncStruct>(copy (_144.0: &mut AsyncStruct)) -> [return: bb192, unwind: bb177];
 +     }
 + 
 +     bb194: {
-+         StorageLive(_129);
-+         _129 = async_drop_in_place::<AsyncStruct>(copy (_144.0: &mut AsyncStruct)) -> [return: bb193, unwind: bb178];
++         _145 = &mut _8;
++         _144 = Pin::<&mut AsyncStruct>::new_unchecked(move _145) -> [return: bb193, unwind: bb38];
 +     }
 + 
 +     bb195: {
-+         _145 = &mut _8;
-+         _144 = Pin::<&mut AsyncStruct>::new_unchecked(move _145) -> [return: bb194, unwind: bb39];
-+     }
-+ 
-+     bb196: {
 +         StorageDead(_146);
 +         goto -> bb11;
 +     }
 + 
-+     bb197: {
++     bb196: {
 +         StorageDead(_146);
 +         goto -> bb24;
 +     }
 + 
-+     bb198 (cleanup): {
++     bb197 (cleanup): {
 +         StorageDead(_146);
-+         goto -> bb40;
++         goto -> bb39;
++     }
++ 
++     bb198: {
++         assert(const false, "`async fn` resumed after async drop") -> [success: bb198, unwind: bb197];
 +     }
 + 
 +     bb199: {
-+         assert(const false, "`async fn` resumed after async drop") -> [success: bb199, unwind: bb198];
++         _2 = move _147;
++         StorageDead(_147);
++         goto -> bb198;
 +     }
 + 
 +     bb200: {
 +         _2 = move _147;
 +         StorageDead(_147);
-+         goto -> bb199;
++         goto -> bb205;
 +     }
 + 
 +     bb201: {
-+         _2 = move _147;
-+         StorageDead(_147);
-+         goto -> bb206;
++         StorageLive(_147);
++         _147 = yield(const ()) -> [resume: bb199, drop: bb200];
 +     }
 + 
 +     bb202: {
-+         StorageLive(_147);
-+         _147 = yield(const ()) -> [resume: bb200, drop: bb201];
++         _149 = discriminant(_148);
++         switchInt(move _149) -> [0: bb196, 1: bb201, otherwise: bb61];
 +     }
 + 
 +     bb203: {
-+         _149 = discriminant(_148);
-+         switchInt(move _149) -> [0: bb197, 1: bb202, otherwise: bb62];
++         _148 = <impl Future<Output = ()> as Future>::poll(move _150, move _151) -> [return: bb202, unwind: bb197];
 +     }
 + 
 +     bb204: {
-+         _148 = <impl Future<Output = ()> as Future>::poll(move _150, move _151) -> [return: bb203, unwind: bb198];
++         _152 = move _2;
++         _151 = std::future::get_context::<'_, '_>(move _152) -> [return: bb203, unwind: bb197];
 +     }
 + 
 +     bb205: {
-+         _152 = move _2;
-+         _151 = std::future::get_context::<'_, '_>(move _152) -> [return: bb204, unwind: bb198];
++         _153 = &mut _146;
++         _150 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _153) -> [return: bb204, unwind: bb197];
 +     }
 + 
 +     bb206: {
-+         _153 = &mut _146;
-+         _150 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _153) -> [return: bb205, unwind: bb198];
++         _2 = move _154;
++         StorageDead(_154);
++         goto -> bb212;
 +     }
 + 
 +     bb207: {
 +         _2 = move _154;
 +         StorageDead(_154);
-+         goto -> bb213;
++         goto -> bb205;
 +     }
 + 
 +     bb208: {
-+         _2 = move _154;
-+         StorageDead(_154);
-+         goto -> bb206;
++         StorageLive(_154);
++         _154 = yield(const ()) -> [resume: bb206, drop: bb207];
 +     }
 + 
 +     bb209: {
-+         StorageLive(_154);
-+         _154 = yield(const ()) -> [resume: bb207, drop: bb208];
++         _156 = discriminant(_155);
++         switchInt(move _156) -> [0: bb195, 1: bb208, otherwise: bb61];
 +     }
 + 
 +     bb210: {
-+         _156 = discriminant(_155);
-+         switchInt(move _156) -> [0: bb196, 1: bb209, otherwise: bb62];
++         _155 = <impl Future<Output = ()> as Future>::poll(move _157, move _158) -> [return: bb209, unwind: bb197];
 +     }
 + 
 +     bb211: {
-+         _155 = <impl Future<Output = ()> as Future>::poll(move _157, move _158) -> [return: bb210, unwind: bb198];
++         _159 = move _2;
++         _158 = std::future::get_context::<'_, '_>(move _159) -> [return: bb210, unwind: bb197];
 +     }
 + 
 +     bb212: {
-+         _159 = move _2;
-+         _158 = std::future::get_context::<'_, '_>(move _159) -> [return: bb211, unwind: bb198];
++         _160 = &mut _146;
++         _157 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _160) -> [return: bb211, unwind: bb197];
 +     }
 + 
 +     bb213: {
-+         _160 = &mut _146;
-+         _157 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _160) -> [return: bb212, unwind: bb198];
++         StorageLive(_146);
++         _146 = async_drop_in_place::<[AsyncInt; 2]>(copy (_161.0: &mut [AsyncInt; 2])) -> [return: bb212, unwind: bb197];
 +     }
 + 
 +     bb214: {
-+         StorageLive(_146);
-+         _146 = async_drop_in_place::<[AsyncInt; 2]>(copy (_161.0: &mut [AsyncInt; 2])) -> [return: bb213, unwind: bb198];
++         _162 = &mut _5;
++         _161 = Pin::<&mut [AsyncInt; 2]>::new_unchecked(move _162) -> [return: bb213, unwind: bb39];
 +     }
 + 
 +     bb215: {
-+         _162 = &mut _5;
-+         _161 = Pin::<&mut [AsyncInt; 2]>::new_unchecked(move _162) -> [return: bb214, unwind: bb40];
-+     }
-+ 
-+     bb216: {
 +         StorageDead(_163);
 +         goto -> bb12;
 +     }
 + 
-+     bb217: {
++     bb216: {
 +         StorageDead(_163);
 +         goto -> bb25;
 +     }
 + 
-+     bb218 (cleanup): {
++     bb217 (cleanup): {
 +         StorageDead(_163);
-+         goto -> bb41;
++         goto -> bb40;
++     }
++ 
++     bb218: {
++         assert(const false, "`async fn` resumed after async drop") -> [success: bb218, unwind: bb217];
 +     }
 + 
 +     bb219: {
-+         assert(const false, "`async fn` resumed after async drop") -> [success: bb219, unwind: bb218];
++         _2 = move _164;
++         StorageDead(_164);
++         goto -> bb218;
 +     }
 + 
 +     bb220: {
 +         _2 = move _164;
 +         StorageDead(_164);
-+         goto -> bb219;
++         goto -> bb225;
 +     }
 + 
 +     bb221: {
-+         _2 = move _164;
-+         StorageDead(_164);
-+         goto -> bb226;
++         StorageLive(_164);
++         _164 = yield(const ()) -> [resume: bb219, drop: bb220];
 +     }
 + 
 +     bb222: {
-+         StorageLive(_164);
-+         _164 = yield(const ()) -> [resume: bb220, drop: bb221];
++         _166 = discriminant(_165);
++         switchInt(move _166) -> [0: bb216, 1: bb221, otherwise: bb61];
 +     }
 + 
 +     bb223: {
-+         _166 = discriminant(_165);
-+         switchInt(move _166) -> [0: bb217, 1: bb222, otherwise: bb62];
++         _165 = <impl Future<Output = ()> as Future>::poll(move _167, move _168) -> [return: bb222, unwind: bb217];
 +     }
 + 
 +     bb224: {
-+         _165 = <impl Future<Output = ()> as Future>::poll(move _167, move _168) -> [return: bb223, unwind: bb218];
++         _169 = move _2;
++         _168 = std::future::get_context::<'_, '_>(move _169) -> [return: bb223, unwind: bb217];
 +     }
 + 
 +     bb225: {
-+         _169 = move _2;
-+         _168 = std::future::get_context::<'_, '_>(move _169) -> [return: bb224, unwind: bb218];
++         _170 = &mut _163;
++         _167 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _170) -> [return: bb224, unwind: bb217];
 +     }
 + 
 +     bb226: {
-+         _170 = &mut _163;
-+         _167 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _170) -> [return: bb225, unwind: bb218];
++         _2 = move _171;
++         StorageDead(_171);
++         goto -> bb232;
 +     }
 + 
 +     bb227: {
 +         _2 = move _171;
 +         StorageDead(_171);
-+         goto -> bb233;
++         goto -> bb225;
 +     }
 + 
 +     bb228: {
-+         _2 = move _171;
-+         StorageDead(_171);
-+         goto -> bb226;
++         StorageLive(_171);
++         _171 = yield(const ()) -> [resume: bb226, drop: bb227];
 +     }
 + 
 +     bb229: {
-+         StorageLive(_171);
-+         _171 = yield(const ()) -> [resume: bb227, drop: bb228];
++         _173 = discriminant(_172);
++         switchInt(move _173) -> [0: bb215, 1: bb228, otherwise: bb61];
 +     }
 + 
 +     bb230: {
-+         _173 = discriminant(_172);
-+         switchInt(move _173) -> [0: bb216, 1: bb229, otherwise: bb62];
++         _172 = <impl Future<Output = ()> as Future>::poll(move _174, move _175) -> [return: bb229, unwind: bb217];
 +     }
 + 
 +     bb231: {
-+         _172 = <impl Future<Output = ()> as Future>::poll(move _174, move _175) -> [return: bb230, unwind: bb218];
++         _176 = move _2;
++         _175 = std::future::get_context::<'_, '_>(move _176) -> [return: bb230, unwind: bb217];
 +     }
 + 
 +     bb232: {
-+         _176 = move _2;
-+         _175 = std::future::get_context::<'_, '_>(move _176) -> [return: bb231, unwind: bb218];
++         _177 = &mut _163;
++         _174 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _177) -> [return: bb231, unwind: bb217];
 +     }
 + 
 +     bb233: {
-+         _177 = &mut _163;
-+         _174 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _177) -> [return: bb232, unwind: bb218];
++         StorageLive(_163);
++         _163 = async_drop_in_place::<AsyncInt>(copy (_178.0: &mut AsyncInt)) -> [return: bb232, unwind: bb217];
 +     }
 + 
 +     bb234: {
-+         StorageLive(_163);
-+         _163 = async_drop_in_place::<AsyncInt>(copy (_178.0: &mut AsyncInt)) -> [return: bb233, unwind: bb218];
-+     }
-+ 
-+     bb235: {
 +         _179 = &mut _4;
-+         _178 = Pin::<&mut AsyncInt>::new_unchecked(move _179) -> [return: bb234, unwind: bb41];
++         _178 = Pin::<&mut AsyncInt>::new_unchecked(move _179) -> [return: bb233, unwind: bb40];
       }
   }
   

--- a/tests/mir-opt/coroutine/async_drop.elaborate_drops-{closure#0}.ElaborateDrops.diff
+++ b/tests/mir-opt/coroutine/async_drop.elaborate_drops-{closure#0}.ElaborateDrops.diff
@@ -234,17 +234,7 @@
           StorageLive(_7);
           _7 = AsyncInt(const 2_i32);
           _5 = [move _6, move _7];
--         drop(_7) -> [return: bb1, unwind: bb62, drop: bb38];
-+         goto -> bb1;
-      }
-  
-      bb1: {
           StorageDead(_7);
--         drop(_6) -> [return: bb2, unwind: bb63, drop: bb39];
-+         goto -> bb2;
-      }
-  
-      bb2: {
           StorageDead(_6);
           StorageLive(_8);
           StorageLive(_9);
@@ -252,17 +242,7 @@
           StorageLive(_10);
           _10 = AsyncInt(const 4_i32);
           _8 = AsyncStruct { i: const 3_i32, a: move _10, b: move _9 };
--         drop(_10) -> [return: bb3, unwind: bb59, drop: bb35];
-+         goto -> bb3;
-      }
-  
-      bb3: {
           StorageDead(_10);
--         drop(_9) -> [return: bb4, unwind: bb60, drop: bb36];
-+         goto -> bb4;
-      }
-  
-      bb4: {
           StorageDead(_9);
           StorageLive(_11);
           StorageLive(_12);
@@ -272,41 +252,21 @@
           StorageLive(_14);
           _14 = AsyncInt(const 9_i32);
           _11 = SyncThenAsync { i: const 6_i32, a: move _12, b: move _13, c: move _14 };
--         drop(_14) -> [return: bb5, unwind: bb55, drop: bb31];
-+         goto -> bb5;
-      }
-  
-      bb5: {
           StorageDead(_14);
--         drop(_13) -> [return: bb6, unwind: bb56];
-+         goto -> bb6;
-      }
-  
-      bb6: {
           StorageDead(_13);
--         drop(_12) -> [return: bb7, unwind: bb57, drop: bb33];
-+         goto -> bb7;
-      }
-  
-      bb7: {
           StorageDead(_12);
           StorageLive(_15);
           StorageLive(_16);
           _16 = AsyncInt(const 10_i32);
           _15 = AsyncEnum::A(move _16);
--         drop(_16) -> [return: bb8, unwind: bb53, drop: bb29];
-+         goto -> bb8;
-      }
-  
-      bb8: {
           StorageDead(_16);
           StorageLive(_17);
           StorageLive(_18);
           _18 = AsyncInt(const 11_i32);
-          _17 = ManuallyDrop::<AsyncInt>::new(move _18) -> [return: bb9, unwind: bb50];
+          _17 = ManuallyDrop::<AsyncInt>::new(move _18) -> [return: bb1, unwind: bb34];
       }
   
-      bb9: {
+      bb1: {
           StorageDead(_18);
           StorageLive(_19);
           _19 = AsyncInt(const 12_i32);
@@ -327,1331 +287,1222 @@
           StorageLive(_26);
           _26 = {closure@$DIR/async_drop.rs:86:27: 86:35} { foo: move _25 };
           _0 = const ();
--         drop(_26) -> [return: bb10, unwind: bb44, drop: bb23];
-+         goto -> bb103;
+-         drop(_26) -> [return: bb2, unwind: bb28, drop: bb15];
++         goto -> bb75;
+      }
+  
+      bb2: {
+          StorageDead(_26);
+-         drop(_25) -> [return: bb3, unwind: bb29, drop: bb16];
++         goto -> bb3;
+      }
+  
+      bb3: {
+          StorageDead(_25);
+-         drop(_24) -> [return: bb4, unwind: bb30, drop: bb17];
++         goto -> bb95;
+      }
+  
+      bb4: {
+          StorageDead(_24);
+-         drop(_23) -> [return: bb5, unwind: bb31, drop: bb18];
++         goto -> bb5;
+      }
+  
+      bb5: {
+          StorageDead(_23);
+-         drop(_20) -> [return: bb6, unwind: bb32, drop: bb19];
++         goto -> bb115;
+      }
+  
+      bb6: {
+          StorageDead(_20);
+-         drop(_19) -> [return: bb7, unwind: bb33, drop: bb20];
++         goto -> bb135;
+      }
+  
+      bb7: {
+          StorageDead(_19);
+          StorageDead(_17);
+-         drop(_15) -> [return: bb8, unwind: bb37, drop: bb21];
++         goto -> bb155;
+      }
+  
+      bb8: {
+          StorageDead(_15);
+-         drop(_11) -> [return: bb9, unwind: bb38, drop: bb22];
++         goto -> bb175;
+      }
+  
+      bb9: {
+          StorageDead(_11);
+-         drop(_8) -> [return: bb10, unwind: bb39, drop: bb23];
++         goto -> bb195;
       }
   
       bb10: {
-          StorageDead(_26);
--         drop(_25) -> [return: bb11, unwind: bb45, drop: bb24];
-+         goto -> bb11;
+          StorageDead(_8);
+-         drop(_5) -> [return: bb11, unwind: bb40, drop: bb24];
++         goto -> bb215;
       }
   
       bb11: {
-          StorageDead(_25);
--         drop(_24) -> [return: bb12, unwind: bb46, drop: bb25];
-+         goto -> bb123;
+          StorageDead(_5);
+-         drop(_4) -> [return: bb12, unwind: bb41, drop: bb25];
++         goto -> bb235;
       }
   
       bb12: {
-          StorageDead(_24);
--         drop(_23) -> [return: bb13, unwind: bb47, drop: bb26];
-+         goto -> bb13;
+          StorageDead(_4);
+          drop(_3) -> [return: bb13, unwind: bb42];
       }
   
       bb13: {
-          StorageDead(_23);
--         drop(_20) -> [return: bb14, unwind: bb48, drop: bb27];
-+         goto -> bb143;
+          StorageDead(_3);
+-         drop(_1) -> [return: bb14, drop: bb27, unwind continue];
++         drop(_1) -> [return: bb14, unwind: bb43];
       }
   
       bb14: {
-          StorageDead(_20);
--         drop(_19) -> [return: bb15, unwind: bb49, drop: bb28];
-+         goto -> bb163;
-      }
-  
-      bb15: {
-          StorageDead(_19);
-          StorageDead(_17);
--         drop(_15) -> [return: bb16, unwind: bb54, drop: bb30];
-+         goto -> bb183;
-      }
-  
-      bb16: {
-          StorageDead(_15);
--         drop(_11) -> [return: bb17, unwind: bb58, drop: bb34];
-+         goto -> bb203;
-      }
-  
-      bb17: {
-          StorageDead(_11);
--         drop(_8) -> [return: bb18, unwind: bb61, drop: bb37];
-+         goto -> bb223;
-      }
-  
-      bb18: {
-          StorageDead(_8);
--         drop(_5) -> [return: bb19, unwind: bb64, drop: bb40];
-+         goto -> bb243;
-      }
-  
-      bb19: {
-          StorageDead(_5);
--         drop(_4) -> [return: bb20, unwind: bb65, drop: bb41];
-+         goto -> bb263;
-      }
-  
-      bb20: {
-          StorageDead(_4);
-          drop(_3) -> [return: bb21, unwind: bb66];
-      }
-  
-      bb21: {
-          StorageDead(_3);
--         drop(_1) -> [return: bb22, drop: bb43, unwind continue];
-+         drop(_1) -> [return: bb22, unwind: bb67];
-      }
-  
-      bb22: {
           return;
       }
   
-      bb23: {
+      bb15: {
           StorageDead(_26);
--         drop(_25) -> [return: bb24, unwind: bb68];
+-         drop(_25) -> [return: bb16, unwind: bb44];
++         goto -> bb16;
+      }
+  
+      bb16: {
+          StorageDead(_25);
+-         drop(_24) -> [return: bb17, unwind: bb45];
++         goto -> bb17;
+      }
+  
+      bb17: {
+          StorageDead(_24);
+-         drop(_23) -> [return: bb18, unwind: bb46];
++         goto -> bb18;
+      }
+  
+      bb18: {
+          StorageDead(_23);
+-         drop(_20) -> [return: bb19, unwind: bb47];
++         goto -> bb19;
+      }
+  
+      bb19: {
+          StorageDead(_20);
+-         drop(_19) -> [return: bb20, unwind: bb48];
++         goto -> bb20;
+      }
+  
+      bb20: {
+          StorageDead(_19);
+          StorageDead(_17);
+-         drop(_15) -> [return: bb21, unwind: bb49];
++         goto -> bb21;
+      }
+  
+      bb21: {
+          StorageDead(_15);
+-         drop(_11) -> [return: bb22, unwind: bb50];
++         goto -> bb22;
+      }
+  
+      bb22: {
+          StorageDead(_11);
+-         drop(_8) -> [return: bb23, unwind: bb51];
++         goto -> bb23;
+      }
+  
+      bb23: {
+          StorageDead(_8);
+-         drop(_5) -> [return: bb24, unwind: bb52];
 +         goto -> bb24;
       }
   
       bb24: {
-          StorageDead(_25);
--         drop(_24) -> [return: bb25, unwind: bb69];
+          StorageDead(_5);
+-         drop(_4) -> [return: bb25, unwind: bb53];
 +         goto -> bb25;
       }
   
       bb25: {
-          StorageDead(_24);
--         drop(_23) -> [return: bb26, unwind: bb70];
+          StorageDead(_4);
+-         drop(_3) -> [return: bb26, unwind: bb54];
 +         goto -> bb26;
       }
   
       bb26: {
-          StorageDead(_23);
--         drop(_20) -> [return: bb27, unwind: bb71];
+          StorageDead(_3);
+-         drop(_1) -> [return: bb27, unwind continue];
 +         goto -> bb27;
       }
   
       bb27: {
-          StorageDead(_20);
--         drop(_19) -> [return: bb28, unwind: bb72];
-+         goto -> bb28;
-      }
-  
-      bb28: {
-          StorageDead(_19);
-          StorageDead(_17);
--         drop(_15) -> [return: bb30, unwind: bb73];
-+         goto -> bb30;
-      }
-  
-      bb29: {
-          StorageDead(_16);
-          goto -> bb30;
-      }
-  
-      bb30: {
-          StorageDead(_15);
--         drop(_11) -> [return: bb34, unwind: bb76];
-+         goto -> bb34;
-      }
-  
-      bb31: {
-          StorageDead(_14);
--         drop(_13) -> [return: bb32, unwind: bb74];
-+         goto -> bb32;
-      }
-  
-      bb32: {
-          StorageDead(_13);
--         drop(_12) -> [return: bb33, unwind: bb75];
-+         goto -> bb33;
-      }
-  
-      bb33: {
-          StorageDead(_12);
-          goto -> bb34;
-      }
-  
-      bb34: {
-          StorageDead(_11);
--         drop(_8) -> [return: bb37, unwind: bb78];
-+         goto -> bb37;
-      }
-  
-      bb35: {
-          StorageDead(_10);
--         drop(_9) -> [return: bb36, unwind: bb77];
-+         goto -> bb36;
-      }
-  
-      bb36: {
-          StorageDead(_9);
-          goto -> bb37;
-      }
-  
-      bb37: {
-          StorageDead(_8);
--         drop(_5) -> [return: bb40, unwind: bb80];
-+         goto -> bb40;
-      }
-  
-      bb38: {
-          StorageDead(_7);
--         drop(_6) -> [return: bb39, unwind: bb79];
-+         goto -> bb39;
-      }
-  
-      bb39: {
-          StorageDead(_6);
-          goto -> bb40;
-      }
-  
-      bb40: {
-          StorageDead(_5);
--         drop(_4) -> [return: bb41, unwind: bb81];
-+         goto -> bb41;
-      }
-  
-      bb41: {
-          StorageDead(_4);
--         drop(_3) -> [return: bb42, unwind: bb82];
-+         goto -> bb42;
-      }
-  
-      bb42: {
-          StorageDead(_3);
--         drop(_1) -> [return: bb43, unwind continue];
-+         goto -> bb43;
-      }
-  
-      bb43: {
           coroutine_drop;
       }
   
-      bb44 (cleanup): {
+      bb28 (cleanup): {
           StorageDead(_26);
--         drop(_25) -> [return: bb45, unwind terminate(cleanup)];
+-         drop(_25) -> [return: bb29, unwind terminate(cleanup)];
++         goto -> bb29;
+      }
+  
+      bb29 (cleanup): {
+          StorageDead(_25);
+          drop(_24) -> [return: bb30, unwind terminate(cleanup)];
+      }
+  
+      bb30 (cleanup): {
+          StorageDead(_24);
+-         drop(_23) -> [return: bb31, unwind terminate(cleanup)];
++         goto -> bb31;
+      }
+  
+      bb31 (cleanup): {
+          StorageDead(_23);
+          drop(_20) -> [return: bb32, unwind terminate(cleanup)];
+      }
+  
+      bb32 (cleanup): {
+          StorageDead(_20);
+          drop(_19) -> [return: bb33, unwind terminate(cleanup)];
+      }
+  
+      bb33 (cleanup): {
+          StorageDead(_19);
+          goto -> bb36;
+      }
+  
+      bb34 (cleanup): {
+-         drop(_18) -> [return: bb35, unwind terminate(cleanup)];
++         goto -> bb35;
+      }
+  
+      bb35 (cleanup): {
+          StorageDead(_18);
+          goto -> bb36;
+      }
+  
+      bb36 (cleanup): {
+          StorageDead(_17);
+          drop(_15) -> [return: bb37, unwind terminate(cleanup)];
+      }
+  
+      bb37 (cleanup): {
+          StorageDead(_15);
+          drop(_11) -> [return: bb38, unwind terminate(cleanup)];
+      }
+  
+      bb38 (cleanup): {
+          StorageDead(_11);
+          drop(_8) -> [return: bb39, unwind terminate(cleanup)];
+      }
+  
+      bb39 (cleanup): {
+          StorageDead(_8);
+          drop(_5) -> [return: bb40, unwind terminate(cleanup)];
+      }
+  
+      bb40 (cleanup): {
+          StorageDead(_5);
+          drop(_4) -> [return: bb41, unwind terminate(cleanup)];
+      }
+  
+      bb41 (cleanup): {
+          StorageDead(_4);
+          drop(_3) -> [return: bb42, unwind terminate(cleanup)];
+      }
+  
+      bb42 (cleanup): {
+          StorageDead(_3);
+          drop(_1) -> [return: bb43, unwind terminate(cleanup)];
+      }
+  
+      bb43 (cleanup): {
+          resume;
+      }
+  
+      bb44 (cleanup): {
+          StorageDead(_25);
+-         drop(_24) -> [return: bb45, unwind terminate(cleanup)];
 +         goto -> bb45;
       }
   
       bb45 (cleanup): {
-          StorageDead(_25);
-          drop(_24) -> [return: bb46, unwind terminate(cleanup)];
+          StorageDead(_24);
+-         drop(_23) -> [return: bb46, unwind terminate(cleanup)];
++         goto -> bb46;
       }
   
       bb46 (cleanup): {
-          StorageDead(_24);
--         drop(_23) -> [return: bb47, unwind terminate(cleanup)];
+          StorageDead(_23);
+-         drop(_20) -> [return: bb47, unwind terminate(cleanup)];
 +         goto -> bb47;
       }
   
       bb47 (cleanup): {
-          StorageDead(_23);
-          drop(_20) -> [return: bb48, unwind terminate(cleanup)];
+          StorageDead(_20);
+-         drop(_19) -> [return: bb48, unwind terminate(cleanup)];
++         goto -> bb48;
       }
   
       bb48 (cleanup): {
-          StorageDead(_20);
-          drop(_19) -> [return: bb49, unwind terminate(cleanup)];
+          StorageDead(_19);
+          StorageDead(_17);
+-         drop(_15) -> [return: bb49, unwind terminate(cleanup)];
++         goto -> bb49;
       }
   
       bb49 (cleanup): {
-          StorageDead(_19);
-          goto -> bb52;
+          StorageDead(_15);
+-         drop(_11) -> [return: bb50, unwind terminate(cleanup)];
++         goto -> bb50;
       }
   
       bb50 (cleanup): {
--         drop(_18) -> [return: bb51, unwind terminate(cleanup)];
+          StorageDead(_11);
+-         drop(_8) -> [return: bb51, unwind terminate(cleanup)];
 +         goto -> bb51;
       }
   
       bb51 (cleanup): {
-          StorageDead(_18);
-          goto -> bb52;
+          StorageDead(_8);
+-         drop(_5) -> [return: bb52, unwind terminate(cleanup)];
++         goto -> bb52;
       }
   
       bb52 (cleanup): {
-          StorageDead(_17);
-          drop(_15) -> [return: bb54, unwind terminate(cleanup)];
+          StorageDead(_5);
+-         drop(_4) -> [return: bb53, unwind terminate(cleanup)];
++         goto -> bb53;
       }
   
       bb53 (cleanup): {
-          StorageDead(_16);
-          goto -> bb54;
+          StorageDead(_4);
+-         drop(_3) -> [return: bb54, unwind terminate(cleanup)];
++         goto -> bb54;
       }
   
       bb54 (cleanup): {
-          StorageDead(_15);
-          drop(_11) -> [return: bb58, unwind terminate(cleanup)];
-      }
-  
-      bb55 (cleanup): {
-          StorageDead(_14);
--         drop(_13) -> [return: bb56, unwind terminate(cleanup)];
-+         goto -> bb56;
-      }
-  
-      bb56 (cleanup): {
-          StorageDead(_13);
--         drop(_12) -> [return: bb57, unwind terminate(cleanup)];
-+         goto -> bb57;
-      }
-  
-      bb57 (cleanup): {
-          StorageDead(_12);
-          goto -> bb58;
-      }
-  
-      bb58 (cleanup): {
-          StorageDead(_11);
-          drop(_8) -> [return: bb61, unwind terminate(cleanup)];
-      }
-  
-      bb59 (cleanup): {
-          StorageDead(_10);
--         drop(_9) -> [return: bb60, unwind terminate(cleanup)];
-+         goto -> bb60;
-      }
-  
-      bb60 (cleanup): {
-          StorageDead(_9);
-          goto -> bb61;
-      }
-  
-      bb61 (cleanup): {
-          StorageDead(_8);
-          drop(_5) -> [return: bb64, unwind terminate(cleanup)];
-      }
-  
-      bb62 (cleanup): {
-          StorageDead(_7);
--         drop(_6) -> [return: bb63, unwind terminate(cleanup)];
-+         goto -> bb63;
-      }
-  
-      bb63 (cleanup): {
-          StorageDead(_6);
-          goto -> bb64;
-      }
-  
-      bb64 (cleanup): {
-          StorageDead(_5);
-          drop(_4) -> [return: bb65, unwind terminate(cleanup)];
-      }
-  
-      bb65 (cleanup): {
-          StorageDead(_4);
-          drop(_3) -> [return: bb66, unwind terminate(cleanup)];
-      }
-  
-      bb66 (cleanup): {
           StorageDead(_3);
-          drop(_1) -> [return: bb67, unwind terminate(cleanup)];
-      }
-  
-      bb67 (cleanup): {
-          resume;
-      }
-  
-      bb68 (cleanup): {
-          StorageDead(_25);
--         drop(_24) -> [return: bb69, unwind terminate(cleanup)];
-+         goto -> bb69;
-      }
-  
-      bb69 (cleanup): {
-          StorageDead(_24);
--         drop(_23) -> [return: bb70, unwind terminate(cleanup)];
-+         goto -> bb70;
-      }
-  
-      bb70 (cleanup): {
-          StorageDead(_23);
--         drop(_20) -> [return: bb71, unwind terminate(cleanup)];
-+         goto -> bb71;
-      }
-  
-      bb71 (cleanup): {
-          StorageDead(_20);
--         drop(_19) -> [return: bb72, unwind terminate(cleanup)];
-+         goto -> bb72;
-      }
-  
-      bb72 (cleanup): {
-          StorageDead(_19);
-          StorageDead(_17);
--         drop(_15) -> [return: bb73, unwind terminate(cleanup)];
-+         goto -> bb73;
-      }
-  
-      bb73 (cleanup): {
-          StorageDead(_15);
--         drop(_11) -> [return: bb76, unwind terminate(cleanup)];
-+         goto -> bb76;
-      }
-  
-      bb74 (cleanup): {
-          StorageDead(_13);
--         drop(_12) -> [return: bb75, unwind terminate(cleanup)];
-+         goto -> bb75;
-      }
-  
-      bb75 (cleanup): {
-          StorageDead(_12);
-          goto -> bb76;
-      }
-  
-      bb76 (cleanup): {
-          StorageDead(_11);
--         drop(_8) -> [return: bb78, unwind terminate(cleanup)];
-+         goto -> bb78;
-      }
-  
-      bb77 (cleanup): {
-          StorageDead(_9);
-          goto -> bb78;
-      }
-  
-      bb78 (cleanup): {
-          StorageDead(_8);
--         drop(_5) -> [return: bb80, unwind terminate(cleanup)];
-+         goto -> bb80;
-      }
-  
-      bb79 (cleanup): {
-          StorageDead(_6);
-          goto -> bb80;
-      }
-  
-      bb80 (cleanup): {
-          StorageDead(_5);
--         drop(_4) -> [return: bb81, unwind terminate(cleanup)];
-+         goto -> bb81;
-      }
-  
-      bb81 (cleanup): {
-          StorageDead(_4);
--         drop(_3) -> [return: bb82, unwind terminate(cleanup)];
-+         goto -> bb82;
-      }
-  
-      bb82 (cleanup): {
-          StorageDead(_3);
--         drop(_1) -> [return: bb67, unwind terminate(cleanup)];
-+         goto -> bb67;
+-         drop(_1) -> [return: bb43, unwind terminate(cleanup)];
++         goto -> bb43;
 +     }
 + 
-+     bb83: {
++     bb55: {
 +         StorageDead(_27);
-+         goto -> bb10;
++         goto -> bb2;
 +     }
 + 
-+     bb84: {
++     bb56: {
 +         StorageDead(_27);
-+         goto -> bb23;
-+     }
-+ 
-+     bb85 (cleanup): {
-+         StorageDead(_27);
-+         goto -> bb44;
-+     }
-+ 
-+     bb86: {
-+         assert(const false, "`async fn` resumed after async drop") -> [success: bb86, unwind: bb85];
-+     }
-+ 
-+     bb87: {
-+         _2 = move _28;
-+         StorageDead(_28);
-+         goto -> bb86;
-+     }
-+ 
-+     bb88: {
-+         _2 = move _28;
-+         StorageDead(_28);
-+         goto -> bb94;
-+     }
-+ 
-+     bb89: {
-+         StorageLive(_28);
-+         _28 = yield(const ()) -> [resume: bb87, drop: bb88];
-+     }
-+ 
-+     bb90: {
-+         unreachable;
-+     }
-+ 
-+     bb91: {
-+         _30 = discriminant(_29);
-+         switchInt(move _30) -> [0: bb84, 1: bb89, otherwise: bb90];
-+     }
-+ 
-+     bb92: {
-+         _29 = <impl Future<Output = ()> as Future>::poll(move _31, move _32) -> [return: bb91, unwind: bb85];
-+     }
-+ 
-+     bb93: {
-+         _33 = move _2;
-+         _32 = std::future::get_context::<'_, '_>(move _33) -> [return: bb92, unwind: bb85];
-+     }
-+ 
-+     bb94: {
-+         _34 = &mut _27;
-+         _31 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _34) -> [return: bb93, unwind: bb85];
-+     }
-+ 
-+     bb95: {
-+         _2 = move _35;
-+         StorageDead(_35);
-+         goto -> bb101;
-+     }
-+ 
-+     bb96: {
-+         _2 = move _35;
-+         StorageDead(_35);
-+         goto -> bb94;
-+     }
-+ 
-+     bb97: {
-+         StorageLive(_35);
-+         _35 = yield(const ()) -> [resume: bb95, drop: bb96];
-+     }
-+ 
-+     bb98: {
-+         _37 = discriminant(_36);
-+         switchInt(move _37) -> [0: bb83, 1: bb97, otherwise: bb90];
-+     }
-+ 
-+     bb99: {
-+         _36 = <impl Future<Output = ()> as Future>::poll(move _38, move _39) -> [return: bb98, unwind: bb85];
-+     }
-+ 
-+     bb100: {
-+         _40 = move _2;
-+         _39 = std::future::get_context::<'_, '_>(move _40) -> [return: bb99, unwind: bb85];
-+     }
-+ 
-+     bb101: {
-+         _41 = &mut _27;
-+         _38 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _41) -> [return: bb100, unwind: bb85];
-+     }
-+ 
-+     bb102: {
-+         StorageLive(_27);
-+         _27 = async_drop_in_place::<{async closure@$DIR/async_drop.rs:86:27: 86:35}>(copy (_42.0: &mut {async closure@$DIR/async_drop.rs:86:27: 86:35})) -> [return: bb101, unwind: bb85];
-+     }
-+ 
-+     bb103: {
-+         _43 = &mut _26;
-+         _42 = Pin::<&mut {async closure@$DIR/async_drop.rs:86:27: 86:35}>::new_unchecked(move _43) -> [return: bb102, unwind: bb44];
-+     }
-+ 
-+     bb104: {
-+         StorageDead(_44);
-+         goto -> bb12;
-+     }
-+ 
-+     bb105: {
-+         StorageDead(_44);
-+         goto -> bb25;
-+     }
-+ 
-+     bb106 (cleanup): {
-+         StorageDead(_44);
-+         goto -> bb46;
-+     }
-+ 
-+     bb107: {
-+         assert(const false, "`async fn` resumed after async drop") -> [success: bb107, unwind: bb106];
-+     }
-+ 
-+     bb108: {
-+         _2 = move _45;
-+         StorageDead(_45);
-+         goto -> bb107;
-+     }
-+ 
-+     bb109: {
-+         _2 = move _45;
-+         StorageDead(_45);
-+         goto -> bb114;
-+     }
-+ 
-+     bb110: {
-+         StorageLive(_45);
-+         _45 = yield(const ()) -> [resume: bb108, drop: bb109];
-+     }
-+ 
-+     bb111: {
-+         _47 = discriminant(_46);
-+         switchInt(move _47) -> [0: bb105, 1: bb110, otherwise: bb90];
-+     }
-+ 
-+     bb112: {
-+         _46 = <impl Future<Output = ()> as Future>::poll(move _48, move _49) -> [return: bb111, unwind: bb106];
-+     }
-+ 
-+     bb113: {
-+         _50 = move _2;
-+         _49 = std::future::get_context::<'_, '_>(move _50) -> [return: bb112, unwind: bb106];
-+     }
-+ 
-+     bb114: {
-+         _51 = &mut _44;
-+         _48 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _51) -> [return: bb113, unwind: bb106];
-+     }
-+ 
-+     bb115: {
-+         _2 = move _52;
-+         StorageDead(_52);
-+         goto -> bb121;
-+     }
-+ 
-+     bb116: {
-+         _2 = move _52;
-+         StorageDead(_52);
-+         goto -> bb114;
-+     }
-+ 
-+     bb117: {
-+         StorageLive(_52);
-+         _52 = yield(const ()) -> [resume: bb115, drop: bb116];
-+     }
-+ 
-+     bb118: {
-+         _54 = discriminant(_53);
-+         switchInt(move _54) -> [0: bb104, 1: bb117, otherwise: bb90];
-+     }
-+ 
-+     bb119: {
-+         _53 = <impl Future<Output = ()> as Future>::poll(move _55, move _56) -> [return: bb118, unwind: bb106];
-+     }
-+ 
-+     bb120: {
-+         _57 = move _2;
-+         _56 = std::future::get_context::<'_, '_>(move _57) -> [return: bb119, unwind: bb106];
-+     }
-+ 
-+     bb121: {
-+         _58 = &mut _44;
-+         _55 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _58) -> [return: bb120, unwind: bb106];
-+     }
-+ 
-+     bb122: {
-+         StorageLive(_44);
-+         _44 = async_drop_in_place::<{closure@$DIR/async_drop.rs:78:25: 78:27}>(copy (_59.0: &mut {closure@$DIR/async_drop.rs:78:25: 78:27})) -> [return: bb121, unwind: bb106];
-+     }
-+ 
-+     bb123: {
-+         _60 = &mut _24;
-+         _59 = Pin::<&mut {closure@$DIR/async_drop.rs:78:25: 78:27}>::new_unchecked(move _60) -> [return: bb122, unwind: bb46];
-+     }
-+ 
-+     bb124: {
-+         StorageDead(_61);
-+         goto -> bb14;
-+     }
-+ 
-+     bb125: {
-+         StorageDead(_61);
-+         goto -> bb27;
-+     }
-+ 
-+     bb126 (cleanup): {
-+         StorageDead(_61);
-+         goto -> bb48;
-+     }
-+ 
-+     bb127: {
-+         assert(const false, "`async fn` resumed after async drop") -> [success: bb127, unwind: bb126];
-+     }
-+ 
-+     bb128: {
-+         _2 = move _62;
-+         StorageDead(_62);
-+         goto -> bb127;
-+     }
-+ 
-+     bb129: {
-+         _2 = move _62;
-+         StorageDead(_62);
-+         goto -> bb134;
-+     }
-+ 
-+     bb130: {
-+         StorageLive(_62);
-+         _62 = yield(const ()) -> [resume: bb128, drop: bb129];
-+     }
-+ 
-+     bb131: {
-+         _64 = discriminant(_63);
-+         switchInt(move _64) -> [0: bb125, 1: bb130, otherwise: bb90];
-+     }
-+ 
-+     bb132: {
-+         _63 = <impl Future<Output = ()> as Future>::poll(move _65, move _66) -> [return: bb131, unwind: bb126];
-+     }
-+ 
-+     bb133: {
-+         _67 = move _2;
-+         _66 = std::future::get_context::<'_, '_>(move _67) -> [return: bb132, unwind: bb126];
-+     }
-+ 
-+     bb134: {
-+         _68 = &mut _61;
-+         _65 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _68) -> [return: bb133, unwind: bb126];
-+     }
-+ 
-+     bb135: {
-+         _2 = move _69;
-+         StorageDead(_69);
-+         goto -> bb141;
-+     }
-+ 
-+     bb136: {
-+         _2 = move _69;
-+         StorageDead(_69);
-+         goto -> bb134;
-+     }
-+ 
-+     bb137: {
-+         StorageLive(_69);
-+         _69 = yield(const ()) -> [resume: bb135, drop: bb136];
-+     }
-+ 
-+     bb138: {
-+         _71 = discriminant(_70);
-+         switchInt(move _71) -> [0: bb124, 1: bb137, otherwise: bb90];
-+     }
-+ 
-+     bb139: {
-+         _70 = <impl Future<Output = ()> as Future>::poll(move _72, move _73) -> [return: bb138, unwind: bb126];
-+     }
-+ 
-+     bb140: {
-+         _74 = move _2;
-+         _73 = std::future::get_context::<'_, '_>(move _74) -> [return: bb139, unwind: bb126];
-+     }
-+ 
-+     bb141: {
-+         _75 = &mut _61;
-+         _72 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _75) -> [return: bb140, unwind: bb126];
-+     }
-+ 
-+     bb142: {
-+         StorageLive(_61);
-+         _61 = async_drop_in_place::<AsyncReference<'_>>(copy (_76.0: &mut AsyncReference<'_>)) -> [return: bb141, unwind: bb126];
-+     }
-+ 
-+     bb143: {
-+         _77 = &mut _20;
-+         _76 = Pin::<&mut AsyncReference<'_>>::new_unchecked(move _77) -> [return: bb142, unwind: bb48];
-+     }
-+ 
-+     bb144: {
-+         StorageDead(_78);
 +         goto -> bb15;
 +     }
 + 
-+     bb145: {
-+         StorageDead(_78);
++     bb57 (cleanup): {
++         StorageDead(_27);
 +         goto -> bb28;
 +     }
 + 
-+     bb146 (cleanup): {
-+         StorageDead(_78);
-+         goto -> bb49;
++     bb58: {
++         assert(const false, "`async fn` resumed after async drop") -> [success: bb58, unwind: bb57];
 +     }
 + 
-+     bb147: {
-+         assert(const false, "`async fn` resumed after async drop") -> [success: bb147, unwind: bb146];
-+     }
-+ 
-+     bb148: {
-+         _2 = move _79;
-+         StorageDead(_79);
-+         goto -> bb147;
-+     }
-+ 
-+     bb149: {
-+         _2 = move _79;
-+         StorageDead(_79);
-+         goto -> bb154;
-+     }
-+ 
-+     bb150: {
-+         StorageLive(_79);
-+         _79 = yield(const ()) -> [resume: bb148, drop: bb149];
-+     }
-+ 
-+     bb151: {
-+         _81 = discriminant(_80);
-+         switchInt(move _81) -> [0: bb145, 1: bb150, otherwise: bb90];
-+     }
-+ 
-+     bb152: {
-+         _80 = <impl Future<Output = ()> as Future>::poll(move _82, move _83) -> [return: bb151, unwind: bb146];
-+     }
-+ 
-+     bb153: {
-+         _84 = move _2;
-+         _83 = std::future::get_context::<'_, '_>(move _84) -> [return: bb152, unwind: bb146];
-+     }
-+ 
-+     bb154: {
-+         _85 = &mut _78;
-+         _82 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _85) -> [return: bb153, unwind: bb146];
-+     }
-+ 
-+     bb155: {
-+         _2 = move _86;
-+         StorageDead(_86);
-+         goto -> bb161;
-+     }
-+ 
-+     bb156: {
-+         _2 = move _86;
-+         StorageDead(_86);
-+         goto -> bb154;
-+     }
-+ 
-+     bb157: {
-+         StorageLive(_86);
-+         _86 = yield(const ()) -> [resume: bb155, drop: bb156];
-+     }
-+ 
-+     bb158: {
-+         _88 = discriminant(_87);
-+         switchInt(move _88) -> [0: bb144, 1: bb157, otherwise: bb90];
-+     }
-+ 
-+     bb159: {
-+         _87 = <impl Future<Output = ()> as Future>::poll(move _89, move _90) -> [return: bb158, unwind: bb146];
-+     }
-+ 
-+     bb160: {
-+         _91 = move _2;
-+         _90 = std::future::get_context::<'_, '_>(move _91) -> [return: bb159, unwind: bb146];
-+     }
-+ 
-+     bb161: {
-+         _92 = &mut _78;
-+         _89 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _92) -> [return: bb160, unwind: bb146];
-+     }
-+ 
-+     bb162: {
-+         StorageLive(_78);
-+         _78 = async_drop_in_place::<AsyncInt>(copy (_93.0: &mut AsyncInt)) -> [return: bb161, unwind: bb146];
-+     }
-+ 
-+     bb163: {
-+         _94 = &mut _19;
-+         _93 = Pin::<&mut AsyncInt>::new_unchecked(move _94) -> [return: bb162, unwind: bb49];
-+     }
-+ 
-+     bb164: {
-+         StorageDead(_95);
-+         goto -> bb16;
-+     }
-+ 
-+     bb165: {
-+         StorageDead(_95);
-+         goto -> bb30;
-+     }
-+ 
-+     bb166 (cleanup): {
-+         StorageDead(_95);
-+         goto -> bb54;
-+     }
-+ 
-+     bb167: {
-+         assert(const false, "`async fn` resumed after async drop") -> [success: bb167, unwind: bb166];
-+     }
-+ 
-+     bb168: {
-+         _2 = move _96;
-+         StorageDead(_96);
-+         goto -> bb167;
-+     }
-+ 
-+     bb169: {
-+         _2 = move _96;
-+         StorageDead(_96);
-+         goto -> bb174;
-+     }
-+ 
-+     bb170: {
-+         StorageLive(_96);
-+         _96 = yield(const ()) -> [resume: bb168, drop: bb169];
-+     }
-+ 
-+     bb171: {
-+         _98 = discriminant(_97);
-+         switchInt(move _98) -> [0: bb165, 1: bb170, otherwise: bb90];
-+     }
-+ 
-+     bb172: {
-+         _97 = <impl Future<Output = ()> as Future>::poll(move _99, move _100) -> [return: bb171, unwind: bb166];
-+     }
-+ 
-+     bb173: {
-+         _101 = move _2;
-+         _100 = std::future::get_context::<'_, '_>(move _101) -> [return: bb172, unwind: bb166];
-+     }
-+ 
-+     bb174: {
-+         _102 = &mut _95;
-+         _99 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _102) -> [return: bb173, unwind: bb166];
-+     }
-+ 
-+     bb175: {
-+         _2 = move _103;
-+         StorageDead(_103);
-+         goto -> bb181;
-+     }
-+ 
-+     bb176: {
-+         _2 = move _103;
-+         StorageDead(_103);
-+         goto -> bb174;
-+     }
-+ 
-+     bb177: {
-+         StorageLive(_103);
-+         _103 = yield(const ()) -> [resume: bb175, drop: bb176];
-+     }
-+ 
-+     bb178: {
-+         _105 = discriminant(_104);
-+         switchInt(move _105) -> [0: bb164, 1: bb177, otherwise: bb90];
-+     }
-+ 
-+     bb179: {
-+         _104 = <impl Future<Output = ()> as Future>::poll(move _106, move _107) -> [return: bb178, unwind: bb166];
-+     }
-+ 
-+     bb180: {
-+         _108 = move _2;
-+         _107 = std::future::get_context::<'_, '_>(move _108) -> [return: bb179, unwind: bb166];
-+     }
-+ 
-+     bb181: {
-+         _109 = &mut _95;
-+         _106 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _109) -> [return: bb180, unwind: bb166];
-+     }
-+ 
-+     bb182: {
-+         StorageLive(_95);
-+         _95 = async_drop_in_place::<AsyncEnum>(copy (_110.0: &mut AsyncEnum)) -> [return: bb181, unwind: bb166];
-+     }
-+ 
-+     bb183: {
-+         _111 = &mut _15;
-+         _110 = Pin::<&mut AsyncEnum>::new_unchecked(move _111) -> [return: bb182, unwind: bb54];
-+     }
-+ 
-+     bb184: {
-+         StorageDead(_112);
-+         goto -> bb17;
-+     }
-+ 
-+     bb185: {
-+         StorageDead(_112);
-+         goto -> bb34;
-+     }
-+ 
-+     bb186 (cleanup): {
-+         StorageDead(_112);
++     bb59: {
++         _2 = move _28;
++         StorageDead(_28);
 +         goto -> bb58;
 +     }
 + 
-+     bb187: {
-+         assert(const false, "`async fn` resumed after async drop") -> [success: bb187, unwind: bb186];
++     bb60: {
++         _2 = move _28;
++         StorageDead(_28);
++         goto -> bb66;
 +     }
 + 
-+     bb188: {
-+         _2 = move _113;
-+         StorageDead(_113);
-+         goto -> bb187;
++     bb61: {
++         StorageLive(_28);
++         _28 = yield(const ()) -> [resume: bb59, drop: bb60];
 +     }
 + 
-+     bb189: {
-+         _2 = move _113;
-+         StorageDead(_113);
-+         goto -> bb194;
++     bb62: {
++         unreachable;
 +     }
 + 
-+     bb190: {
-+         StorageLive(_113);
-+         _113 = yield(const ()) -> [resume: bb188, drop: bb189];
++     bb63: {
++         _30 = discriminant(_29);
++         switchInt(move _30) -> [0: bb56, 1: bb61, otherwise: bb62];
 +     }
 + 
-+     bb191: {
-+         _115 = discriminant(_114);
-+         switchInt(move _115) -> [0: bb185, 1: bb190, otherwise: bb90];
++     bb64: {
++         _29 = <impl Future<Output = ()> as Future>::poll(move _31, move _32) -> [return: bb63, unwind: bb57];
 +     }
 + 
-+     bb192: {
-+         _114 = <impl Future<Output = ()> as Future>::poll(move _116, move _117) -> [return: bb191, unwind: bb186];
++     bb65: {
++         _33 = move _2;
++         _32 = std::future::get_context::<'_, '_>(move _33) -> [return: bb64, unwind: bb57];
 +     }
 + 
-+     bb193: {
-+         _118 = move _2;
-+         _117 = std::future::get_context::<'_, '_>(move _118) -> [return: bb192, unwind: bb186];
++     bb66: {
++         _34 = &mut _27;
++         _31 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _34) -> [return: bb65, unwind: bb57];
 +     }
 + 
-+     bb194: {
-+         _119 = &mut _112;
-+         _116 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _119) -> [return: bb193, unwind: bb186];
++     bb67: {
++         _2 = move _35;
++         StorageDead(_35);
++         goto -> bb73;
 +     }
 + 
-+     bb195: {
-+         _2 = move _120;
-+         StorageDead(_120);
-+         goto -> bb201;
++     bb68: {
++         _2 = move _35;
++         StorageDead(_35);
++         goto -> bb66;
 +     }
 + 
-+     bb196: {
-+         _2 = move _120;
-+         StorageDead(_120);
-+         goto -> bb194;
++     bb69: {
++         StorageLive(_35);
++         _35 = yield(const ()) -> [resume: bb67, drop: bb68];
 +     }
 + 
-+     bb197: {
-+         StorageLive(_120);
-+         _120 = yield(const ()) -> [resume: bb195, drop: bb196];
++     bb70: {
++         _37 = discriminant(_36);
++         switchInt(move _37) -> [0: bb55, 1: bb69, otherwise: bb62];
 +     }
 + 
-+     bb198: {
-+         _122 = discriminant(_121);
-+         switchInt(move _122) -> [0: bb184, 1: bb197, otherwise: bb90];
++     bb71: {
++         _36 = <impl Future<Output = ()> as Future>::poll(move _38, move _39) -> [return: bb70, unwind: bb57];
 +     }
 + 
-+     bb199: {
-+         _121 = <impl Future<Output = ()> as Future>::poll(move _123, move _124) -> [return: bb198, unwind: bb186];
++     bb72: {
++         _40 = move _2;
++         _39 = std::future::get_context::<'_, '_>(move _40) -> [return: bb71, unwind: bb57];
 +     }
 + 
-+     bb200: {
-+         _125 = move _2;
-+         _124 = std::future::get_context::<'_, '_>(move _125) -> [return: bb199, unwind: bb186];
++     bb73: {
++         _41 = &mut _27;
++         _38 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _41) -> [return: bb72, unwind: bb57];
 +     }
 + 
-+     bb201: {
-+         _126 = &mut _112;
-+         _123 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _126) -> [return: bb200, unwind: bb186];
++     bb74: {
++         StorageLive(_27);
++         _27 = async_drop_in_place::<{async closure@$DIR/async_drop.rs:86:27: 86:35}>(copy (_42.0: &mut {async closure@$DIR/async_drop.rs:86:27: 86:35})) -> [return: bb73, unwind: bb57];
 +     }
 + 
-+     bb202: {
-+         StorageLive(_112);
-+         _112 = async_drop_in_place::<SyncThenAsync>(copy (_127.0: &mut SyncThenAsync)) -> [return: bb201, unwind: bb186];
++     bb75: {
++         _43 = &mut _26;
++         _42 = Pin::<&mut {async closure@$DIR/async_drop.rs:86:27: 86:35}>::new_unchecked(move _43) -> [return: bb74, unwind: bb28];
 +     }
 + 
-+     bb203: {
-+         _128 = &mut _11;
-+         _127 = Pin::<&mut SyncThenAsync>::new_unchecked(move _128) -> [return: bb202, unwind: bb58];
++     bb76: {
++         StorageDead(_44);
++         goto -> bb4;
 +     }
 + 
-+     bb204: {
-+         StorageDead(_129);
-+         goto -> bb18;
++     bb77: {
++         StorageDead(_44);
++         goto -> bb17;
 +     }
 + 
-+     bb205: {
-+         StorageDead(_129);
-+         goto -> bb37;
++     bb78 (cleanup): {
++         StorageDead(_44);
++         goto -> bb30;
 +     }
 + 
-+     bb206 (cleanup): {
-+         StorageDead(_129);
-+         goto -> bb61;
++     bb79: {
++         assert(const false, "`async fn` resumed after async drop") -> [success: bb79, unwind: bb78];
 +     }
 + 
-+     bb207: {
-+         assert(const false, "`async fn` resumed after async drop") -> [success: bb207, unwind: bb206];
++     bb80: {
++         _2 = move _45;
++         StorageDead(_45);
++         goto -> bb79;
 +     }
 + 
-+     bb208: {
-+         _2 = move _130;
-+         StorageDead(_130);
-+         goto -> bb207;
++     bb81: {
++         _2 = move _45;
++         StorageDead(_45);
++         goto -> bb86;
 +     }
 + 
-+     bb209: {
-+         _2 = move _130;
-+         StorageDead(_130);
-+         goto -> bb214;
++     bb82: {
++         StorageLive(_45);
++         _45 = yield(const ()) -> [resume: bb80, drop: bb81];
 +     }
 + 
-+     bb210: {
-+         StorageLive(_130);
-+         _130 = yield(const ()) -> [resume: bb208, drop: bb209];
++     bb83: {
++         _47 = discriminant(_46);
++         switchInt(move _47) -> [0: bb77, 1: bb82, otherwise: bb62];
 +     }
 + 
-+     bb211: {
-+         _132 = discriminant(_131);
-+         switchInt(move _132) -> [0: bb205, 1: bb210, otherwise: bb90];
++     bb84: {
++         _46 = <impl Future<Output = ()> as Future>::poll(move _48, move _49) -> [return: bb83, unwind: bb78];
 +     }
 + 
-+     bb212: {
-+         _131 = <impl Future<Output = ()> as Future>::poll(move _133, move _134) -> [return: bb211, unwind: bb206];
++     bb85: {
++         _50 = move _2;
++         _49 = std::future::get_context::<'_, '_>(move _50) -> [return: bb84, unwind: bb78];
 +     }
 + 
-+     bb213: {
-+         _135 = move _2;
-+         _134 = std::future::get_context::<'_, '_>(move _135) -> [return: bb212, unwind: bb206];
++     bb86: {
++         _51 = &mut _44;
++         _48 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _51) -> [return: bb85, unwind: bb78];
 +     }
 + 
-+     bb214: {
-+         _136 = &mut _129;
-+         _133 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _136) -> [return: bb213, unwind: bb206];
++     bb87: {
++         _2 = move _52;
++         StorageDead(_52);
++         goto -> bb93;
 +     }
 + 
-+     bb215: {
-+         _2 = move _137;
-+         StorageDead(_137);
-+         goto -> bb221;
++     bb88: {
++         _2 = move _52;
++         StorageDead(_52);
++         goto -> bb86;
 +     }
 + 
-+     bb216: {
-+         _2 = move _137;
-+         StorageDead(_137);
-+         goto -> bb214;
++     bb89: {
++         StorageLive(_52);
++         _52 = yield(const ()) -> [resume: bb87, drop: bb88];
 +     }
 + 
-+     bb217: {
-+         StorageLive(_137);
-+         _137 = yield(const ()) -> [resume: bb215, drop: bb216];
++     bb90: {
++         _54 = discriminant(_53);
++         switchInt(move _54) -> [0: bb76, 1: bb89, otherwise: bb62];
 +     }
 + 
-+     bb218: {
-+         _139 = discriminant(_138);
-+         switchInt(move _139) -> [0: bb204, 1: bb217, otherwise: bb90];
++     bb91: {
++         _53 = <impl Future<Output = ()> as Future>::poll(move _55, move _56) -> [return: bb90, unwind: bb78];
 +     }
 + 
-+     bb219: {
-+         _138 = <impl Future<Output = ()> as Future>::poll(move _140, move _141) -> [return: bb218, unwind: bb206];
++     bb92: {
++         _57 = move _2;
++         _56 = std::future::get_context::<'_, '_>(move _57) -> [return: bb91, unwind: bb78];
 +     }
 + 
-+     bb220: {
-+         _142 = move _2;
-+         _141 = std::future::get_context::<'_, '_>(move _142) -> [return: bb219, unwind: bb206];
++     bb93: {
++         _58 = &mut _44;
++         _55 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _58) -> [return: bb92, unwind: bb78];
 +     }
 + 
-+     bb221: {
-+         _143 = &mut _129;
-+         _140 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _143) -> [return: bb220, unwind: bb206];
++     bb94: {
++         StorageLive(_44);
++         _44 = async_drop_in_place::<{closure@$DIR/async_drop.rs:78:25: 78:27}>(copy (_59.0: &mut {closure@$DIR/async_drop.rs:78:25: 78:27})) -> [return: bb93, unwind: bb78];
 +     }
 + 
-+     bb222: {
-+         StorageLive(_129);
-+         _129 = async_drop_in_place::<AsyncStruct>(copy (_144.0: &mut AsyncStruct)) -> [return: bb221, unwind: bb206];
++     bb95: {
++         _60 = &mut _24;
++         _59 = Pin::<&mut {closure@$DIR/async_drop.rs:78:25: 78:27}>::new_unchecked(move _60) -> [return: bb94, unwind: bb30];
 +     }
 + 
-+     bb223: {
-+         _145 = &mut _8;
-+         _144 = Pin::<&mut AsyncStruct>::new_unchecked(move _145) -> [return: bb222, unwind: bb61];
++     bb96: {
++         StorageDead(_61);
++         goto -> bb6;
 +     }
 + 
-+     bb224: {
-+         StorageDead(_146);
++     bb97: {
++         StorageDead(_61);
 +         goto -> bb19;
 +     }
 + 
-+     bb225: {
++     bb98 (cleanup): {
++         StorageDead(_61);
++         goto -> bb32;
++     }
++ 
++     bb99: {
++         assert(const false, "`async fn` resumed after async drop") -> [success: bb99, unwind: bb98];
++     }
++ 
++     bb100: {
++         _2 = move _62;
++         StorageDead(_62);
++         goto -> bb99;
++     }
++ 
++     bb101: {
++         _2 = move _62;
++         StorageDead(_62);
++         goto -> bb106;
++     }
++ 
++     bb102: {
++         StorageLive(_62);
++         _62 = yield(const ()) -> [resume: bb100, drop: bb101];
++     }
++ 
++     bb103: {
++         _64 = discriminant(_63);
++         switchInt(move _64) -> [0: bb97, 1: bb102, otherwise: bb62];
++     }
++ 
++     bb104: {
++         _63 = <impl Future<Output = ()> as Future>::poll(move _65, move _66) -> [return: bb103, unwind: bb98];
++     }
++ 
++     bb105: {
++         _67 = move _2;
++         _66 = std::future::get_context::<'_, '_>(move _67) -> [return: bb104, unwind: bb98];
++     }
++ 
++     bb106: {
++         _68 = &mut _61;
++         _65 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _68) -> [return: bb105, unwind: bb98];
++     }
++ 
++     bb107: {
++         _2 = move _69;
++         StorageDead(_69);
++         goto -> bb113;
++     }
++ 
++     bb108: {
++         _2 = move _69;
++         StorageDead(_69);
++         goto -> bb106;
++     }
++ 
++     bb109: {
++         StorageLive(_69);
++         _69 = yield(const ()) -> [resume: bb107, drop: bb108];
++     }
++ 
++     bb110: {
++         _71 = discriminant(_70);
++         switchInt(move _71) -> [0: bb96, 1: bb109, otherwise: bb62];
++     }
++ 
++     bb111: {
++         _70 = <impl Future<Output = ()> as Future>::poll(move _72, move _73) -> [return: bb110, unwind: bb98];
++     }
++ 
++     bb112: {
++         _74 = move _2;
++         _73 = std::future::get_context::<'_, '_>(move _74) -> [return: bb111, unwind: bb98];
++     }
++ 
++     bb113: {
++         _75 = &mut _61;
++         _72 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _75) -> [return: bb112, unwind: bb98];
++     }
++ 
++     bb114: {
++         StorageLive(_61);
++         _61 = async_drop_in_place::<AsyncReference<'_>>(copy (_76.0: &mut AsyncReference<'_>)) -> [return: bb113, unwind: bb98];
++     }
++ 
++     bb115: {
++         _77 = &mut _20;
++         _76 = Pin::<&mut AsyncReference<'_>>::new_unchecked(move _77) -> [return: bb114, unwind: bb32];
++     }
++ 
++     bb116: {
++         StorageDead(_78);
++         goto -> bb7;
++     }
++ 
++     bb117: {
++         StorageDead(_78);
++         goto -> bb20;
++     }
++ 
++     bb118 (cleanup): {
++         StorageDead(_78);
++         goto -> bb33;
++     }
++ 
++     bb119: {
++         assert(const false, "`async fn` resumed after async drop") -> [success: bb119, unwind: bb118];
++     }
++ 
++     bb120: {
++         _2 = move _79;
++         StorageDead(_79);
++         goto -> bb119;
++     }
++ 
++     bb121: {
++         _2 = move _79;
++         StorageDead(_79);
++         goto -> bb126;
++     }
++ 
++     bb122: {
++         StorageLive(_79);
++         _79 = yield(const ()) -> [resume: bb120, drop: bb121];
++     }
++ 
++     bb123: {
++         _81 = discriminant(_80);
++         switchInt(move _81) -> [0: bb117, 1: bb122, otherwise: bb62];
++     }
++ 
++     bb124: {
++         _80 = <impl Future<Output = ()> as Future>::poll(move _82, move _83) -> [return: bb123, unwind: bb118];
++     }
++ 
++     bb125: {
++         _84 = move _2;
++         _83 = std::future::get_context::<'_, '_>(move _84) -> [return: bb124, unwind: bb118];
++     }
++ 
++     bb126: {
++         _85 = &mut _78;
++         _82 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _85) -> [return: bb125, unwind: bb118];
++     }
++ 
++     bb127: {
++         _2 = move _86;
++         StorageDead(_86);
++         goto -> bb133;
++     }
++ 
++     bb128: {
++         _2 = move _86;
++         StorageDead(_86);
++         goto -> bb126;
++     }
++ 
++     bb129: {
++         StorageLive(_86);
++         _86 = yield(const ()) -> [resume: bb127, drop: bb128];
++     }
++ 
++     bb130: {
++         _88 = discriminant(_87);
++         switchInt(move _88) -> [0: bb116, 1: bb129, otherwise: bb62];
++     }
++ 
++     bb131: {
++         _87 = <impl Future<Output = ()> as Future>::poll(move _89, move _90) -> [return: bb130, unwind: bb118];
++     }
++ 
++     bb132: {
++         _91 = move _2;
++         _90 = std::future::get_context::<'_, '_>(move _91) -> [return: bb131, unwind: bb118];
++     }
++ 
++     bb133: {
++         _92 = &mut _78;
++         _89 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _92) -> [return: bb132, unwind: bb118];
++     }
++ 
++     bb134: {
++         StorageLive(_78);
++         _78 = async_drop_in_place::<AsyncInt>(copy (_93.0: &mut AsyncInt)) -> [return: bb133, unwind: bb118];
++     }
++ 
++     bb135: {
++         _94 = &mut _19;
++         _93 = Pin::<&mut AsyncInt>::new_unchecked(move _94) -> [return: bb134, unwind: bb33];
++     }
++ 
++     bb136: {
++         StorageDead(_95);
++         goto -> bb8;
++     }
++ 
++     bb137: {
++         StorageDead(_95);
++         goto -> bb21;
++     }
++ 
++     bb138 (cleanup): {
++         StorageDead(_95);
++         goto -> bb37;
++     }
++ 
++     bb139: {
++         assert(const false, "`async fn` resumed after async drop") -> [success: bb139, unwind: bb138];
++     }
++ 
++     bb140: {
++         _2 = move _96;
++         StorageDead(_96);
++         goto -> bb139;
++     }
++ 
++     bb141: {
++         _2 = move _96;
++         StorageDead(_96);
++         goto -> bb146;
++     }
++ 
++     bb142: {
++         StorageLive(_96);
++         _96 = yield(const ()) -> [resume: bb140, drop: bb141];
++     }
++ 
++     bb143: {
++         _98 = discriminant(_97);
++         switchInt(move _98) -> [0: bb137, 1: bb142, otherwise: bb62];
++     }
++ 
++     bb144: {
++         _97 = <impl Future<Output = ()> as Future>::poll(move _99, move _100) -> [return: bb143, unwind: bb138];
++     }
++ 
++     bb145: {
++         _101 = move _2;
++         _100 = std::future::get_context::<'_, '_>(move _101) -> [return: bb144, unwind: bb138];
++     }
++ 
++     bb146: {
++         _102 = &mut _95;
++         _99 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _102) -> [return: bb145, unwind: bb138];
++     }
++ 
++     bb147: {
++         _2 = move _103;
++         StorageDead(_103);
++         goto -> bb153;
++     }
++ 
++     bb148: {
++         _2 = move _103;
++         StorageDead(_103);
++         goto -> bb146;
++     }
++ 
++     bb149: {
++         StorageLive(_103);
++         _103 = yield(const ()) -> [resume: bb147, drop: bb148];
++     }
++ 
++     bb150: {
++         _105 = discriminant(_104);
++         switchInt(move _105) -> [0: bb136, 1: bb149, otherwise: bb62];
++     }
++ 
++     bb151: {
++         _104 = <impl Future<Output = ()> as Future>::poll(move _106, move _107) -> [return: bb150, unwind: bb138];
++     }
++ 
++     bb152: {
++         _108 = move _2;
++         _107 = std::future::get_context::<'_, '_>(move _108) -> [return: bb151, unwind: bb138];
++     }
++ 
++     bb153: {
++         _109 = &mut _95;
++         _106 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _109) -> [return: bb152, unwind: bb138];
++     }
++ 
++     bb154: {
++         StorageLive(_95);
++         _95 = async_drop_in_place::<AsyncEnum>(copy (_110.0: &mut AsyncEnum)) -> [return: bb153, unwind: bb138];
++     }
++ 
++     bb155: {
++         _111 = &mut _15;
++         _110 = Pin::<&mut AsyncEnum>::new_unchecked(move _111) -> [return: bb154, unwind: bb37];
++     }
++ 
++     bb156: {
++         StorageDead(_112);
++         goto -> bb9;
++     }
++ 
++     bb157: {
++         StorageDead(_112);
++         goto -> bb22;
++     }
++ 
++     bb158 (cleanup): {
++         StorageDead(_112);
++         goto -> bb38;
++     }
++ 
++     bb159: {
++         assert(const false, "`async fn` resumed after async drop") -> [success: bb159, unwind: bb158];
++     }
++ 
++     bb160: {
++         _2 = move _113;
++         StorageDead(_113);
++         goto -> bb159;
++     }
++ 
++     bb161: {
++         _2 = move _113;
++         StorageDead(_113);
++         goto -> bb166;
++     }
++ 
++     bb162: {
++         StorageLive(_113);
++         _113 = yield(const ()) -> [resume: bb160, drop: bb161];
++     }
++ 
++     bb163: {
++         _115 = discriminant(_114);
++         switchInt(move _115) -> [0: bb157, 1: bb162, otherwise: bb62];
++     }
++ 
++     bb164: {
++         _114 = <impl Future<Output = ()> as Future>::poll(move _116, move _117) -> [return: bb163, unwind: bb158];
++     }
++ 
++     bb165: {
++         _118 = move _2;
++         _117 = std::future::get_context::<'_, '_>(move _118) -> [return: bb164, unwind: bb158];
++     }
++ 
++     bb166: {
++         _119 = &mut _112;
++         _116 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _119) -> [return: bb165, unwind: bb158];
++     }
++ 
++     bb167: {
++         _2 = move _120;
++         StorageDead(_120);
++         goto -> bb173;
++     }
++ 
++     bb168: {
++         _2 = move _120;
++         StorageDead(_120);
++         goto -> bb166;
++     }
++ 
++     bb169: {
++         StorageLive(_120);
++         _120 = yield(const ()) -> [resume: bb167, drop: bb168];
++     }
++ 
++     bb170: {
++         _122 = discriminant(_121);
++         switchInt(move _122) -> [0: bb156, 1: bb169, otherwise: bb62];
++     }
++ 
++     bb171: {
++         _121 = <impl Future<Output = ()> as Future>::poll(move _123, move _124) -> [return: bb170, unwind: bb158];
++     }
++ 
++     bb172: {
++         _125 = move _2;
++         _124 = std::future::get_context::<'_, '_>(move _125) -> [return: bb171, unwind: bb158];
++     }
++ 
++     bb173: {
++         _126 = &mut _112;
++         _123 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _126) -> [return: bb172, unwind: bb158];
++     }
++ 
++     bb174: {
++         StorageLive(_112);
++         _112 = async_drop_in_place::<SyncThenAsync>(copy (_127.0: &mut SyncThenAsync)) -> [return: bb173, unwind: bb158];
++     }
++ 
++     bb175: {
++         _128 = &mut _11;
++         _127 = Pin::<&mut SyncThenAsync>::new_unchecked(move _128) -> [return: bb174, unwind: bb38];
++     }
++ 
++     bb176: {
++         StorageDead(_129);
++         goto -> bb10;
++     }
++ 
++     bb177: {
++         StorageDead(_129);
++         goto -> bb23;
++     }
++ 
++     bb178 (cleanup): {
++         StorageDead(_129);
++         goto -> bb39;
++     }
++ 
++     bb179: {
++         assert(const false, "`async fn` resumed after async drop") -> [success: bb179, unwind: bb178];
++     }
++ 
++     bb180: {
++         _2 = move _130;
++         StorageDead(_130);
++         goto -> bb179;
++     }
++ 
++     bb181: {
++         _2 = move _130;
++         StorageDead(_130);
++         goto -> bb186;
++     }
++ 
++     bb182: {
++         StorageLive(_130);
++         _130 = yield(const ()) -> [resume: bb180, drop: bb181];
++     }
++ 
++     bb183: {
++         _132 = discriminant(_131);
++         switchInt(move _132) -> [0: bb177, 1: bb182, otherwise: bb62];
++     }
++ 
++     bb184: {
++         _131 = <impl Future<Output = ()> as Future>::poll(move _133, move _134) -> [return: bb183, unwind: bb178];
++     }
++ 
++     bb185: {
++         _135 = move _2;
++         _134 = std::future::get_context::<'_, '_>(move _135) -> [return: bb184, unwind: bb178];
++     }
++ 
++     bb186: {
++         _136 = &mut _129;
++         _133 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _136) -> [return: bb185, unwind: bb178];
++     }
++ 
++     bb187: {
++         _2 = move _137;
++         StorageDead(_137);
++         goto -> bb193;
++     }
++ 
++     bb188: {
++         _2 = move _137;
++         StorageDead(_137);
++         goto -> bb186;
++     }
++ 
++     bb189: {
++         StorageLive(_137);
++         _137 = yield(const ()) -> [resume: bb187, drop: bb188];
++     }
++ 
++     bb190: {
++         _139 = discriminant(_138);
++         switchInt(move _139) -> [0: bb176, 1: bb189, otherwise: bb62];
++     }
++ 
++     bb191: {
++         _138 = <impl Future<Output = ()> as Future>::poll(move _140, move _141) -> [return: bb190, unwind: bb178];
++     }
++ 
++     bb192: {
++         _142 = move _2;
++         _141 = std::future::get_context::<'_, '_>(move _142) -> [return: bb191, unwind: bb178];
++     }
++ 
++     bb193: {
++         _143 = &mut _129;
++         _140 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _143) -> [return: bb192, unwind: bb178];
++     }
++ 
++     bb194: {
++         StorageLive(_129);
++         _129 = async_drop_in_place::<AsyncStruct>(copy (_144.0: &mut AsyncStruct)) -> [return: bb193, unwind: bb178];
++     }
++ 
++     bb195: {
++         _145 = &mut _8;
++         _144 = Pin::<&mut AsyncStruct>::new_unchecked(move _145) -> [return: bb194, unwind: bb39];
++     }
++ 
++     bb196: {
++         StorageDead(_146);
++         goto -> bb11;
++     }
++ 
++     bb197: {
++         StorageDead(_146);
++         goto -> bb24;
++     }
++ 
++     bb198 (cleanup): {
 +         StorageDead(_146);
 +         goto -> bb40;
 +     }
 + 
-+     bb226 (cleanup): {
-+         StorageDead(_146);
-+         goto -> bb64;
++     bb199: {
++         assert(const false, "`async fn` resumed after async drop") -> [success: bb199, unwind: bb198];
 +     }
 + 
-+     bb227: {
-+         assert(const false, "`async fn` resumed after async drop") -> [success: bb227, unwind: bb226];
-+     }
-+ 
-+     bb228: {
++     bb200: {
 +         _2 = move _147;
 +         StorageDead(_147);
-+         goto -> bb227;
++         goto -> bb199;
 +     }
 + 
-+     bb229: {
++     bb201: {
 +         _2 = move _147;
 +         StorageDead(_147);
-+         goto -> bb234;
++         goto -> bb206;
 +     }
 + 
-+     bb230: {
++     bb202: {
 +         StorageLive(_147);
-+         _147 = yield(const ()) -> [resume: bb228, drop: bb229];
++         _147 = yield(const ()) -> [resume: bb200, drop: bb201];
 +     }
 + 
-+     bb231: {
++     bb203: {
 +         _149 = discriminant(_148);
-+         switchInt(move _149) -> [0: bb225, 1: bb230, otherwise: bb90];
++         switchInt(move _149) -> [0: bb197, 1: bb202, otherwise: bb62];
 +     }
 + 
-+     bb232: {
-+         _148 = <impl Future<Output = ()> as Future>::poll(move _150, move _151) -> [return: bb231, unwind: bb226];
++     bb204: {
++         _148 = <impl Future<Output = ()> as Future>::poll(move _150, move _151) -> [return: bb203, unwind: bb198];
 +     }
 + 
-+     bb233: {
++     bb205: {
 +         _152 = move _2;
-+         _151 = std::future::get_context::<'_, '_>(move _152) -> [return: bb232, unwind: bb226];
++         _151 = std::future::get_context::<'_, '_>(move _152) -> [return: bb204, unwind: bb198];
 +     }
 + 
-+     bb234: {
++     bb206: {
 +         _153 = &mut _146;
-+         _150 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _153) -> [return: bb233, unwind: bb226];
++         _150 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _153) -> [return: bb205, unwind: bb198];
 +     }
 + 
-+     bb235: {
++     bb207: {
 +         _2 = move _154;
 +         StorageDead(_154);
-+         goto -> bb241;
++         goto -> bb213;
 +     }
 + 
-+     bb236: {
++     bb208: {
 +         _2 = move _154;
 +         StorageDead(_154);
-+         goto -> bb234;
++         goto -> bb206;
 +     }
 + 
-+     bb237: {
++     bb209: {
 +         StorageLive(_154);
-+         _154 = yield(const ()) -> [resume: bb235, drop: bb236];
++         _154 = yield(const ()) -> [resume: bb207, drop: bb208];
 +     }
 + 
-+     bb238: {
++     bb210: {
 +         _156 = discriminant(_155);
-+         switchInt(move _156) -> [0: bb224, 1: bb237, otherwise: bb90];
++         switchInt(move _156) -> [0: bb196, 1: bb209, otherwise: bb62];
 +     }
 + 
-+     bb239: {
-+         _155 = <impl Future<Output = ()> as Future>::poll(move _157, move _158) -> [return: bb238, unwind: bb226];
++     bb211: {
++         _155 = <impl Future<Output = ()> as Future>::poll(move _157, move _158) -> [return: bb210, unwind: bb198];
 +     }
 + 
-+     bb240: {
++     bb212: {
 +         _159 = move _2;
-+         _158 = std::future::get_context::<'_, '_>(move _159) -> [return: bb239, unwind: bb226];
++         _158 = std::future::get_context::<'_, '_>(move _159) -> [return: bb211, unwind: bb198];
 +     }
 + 
-+     bb241: {
++     bb213: {
 +         _160 = &mut _146;
-+         _157 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _160) -> [return: bb240, unwind: bb226];
++         _157 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _160) -> [return: bb212, unwind: bb198];
 +     }
 + 
-+     bb242: {
++     bb214: {
 +         StorageLive(_146);
-+         _146 = async_drop_in_place::<[AsyncInt; 2]>(copy (_161.0: &mut [AsyncInt; 2])) -> [return: bb241, unwind: bb226];
++         _146 = async_drop_in_place::<[AsyncInt; 2]>(copy (_161.0: &mut [AsyncInt; 2])) -> [return: bb213, unwind: bb198];
 +     }
 + 
-+     bb243: {
++     bb215: {
 +         _162 = &mut _5;
-+         _161 = Pin::<&mut [AsyncInt; 2]>::new_unchecked(move _162) -> [return: bb242, unwind: bb64];
++         _161 = Pin::<&mut [AsyncInt; 2]>::new_unchecked(move _162) -> [return: bb214, unwind: bb40];
 +     }
 + 
-+     bb244: {
++     bb216: {
 +         StorageDead(_163);
-+         goto -> bb20;
++         goto -> bb12;
 +     }
 + 
-+     bb245: {
++     bb217: {
++         StorageDead(_163);
++         goto -> bb25;
++     }
++ 
++     bb218 (cleanup): {
 +         StorageDead(_163);
 +         goto -> bb41;
 +     }
 + 
-+     bb246 (cleanup): {
-+         StorageDead(_163);
-+         goto -> bb65;
++     bb219: {
++         assert(const false, "`async fn` resumed after async drop") -> [success: bb219, unwind: bb218];
 +     }
 + 
-+     bb247: {
-+         assert(const false, "`async fn` resumed after async drop") -> [success: bb247, unwind: bb246];
-+     }
-+ 
-+     bb248: {
++     bb220: {
 +         _2 = move _164;
 +         StorageDead(_164);
-+         goto -> bb247;
++         goto -> bb219;
 +     }
 + 
-+     bb249: {
++     bb221: {
 +         _2 = move _164;
 +         StorageDead(_164);
-+         goto -> bb254;
++         goto -> bb226;
 +     }
 + 
-+     bb250: {
++     bb222: {
 +         StorageLive(_164);
-+         _164 = yield(const ()) -> [resume: bb248, drop: bb249];
++         _164 = yield(const ()) -> [resume: bb220, drop: bb221];
 +     }
 + 
-+     bb251: {
++     bb223: {
 +         _166 = discriminant(_165);
-+         switchInt(move _166) -> [0: bb245, 1: bb250, otherwise: bb90];
++         switchInt(move _166) -> [0: bb217, 1: bb222, otherwise: bb62];
 +     }
 + 
-+     bb252: {
-+         _165 = <impl Future<Output = ()> as Future>::poll(move _167, move _168) -> [return: bb251, unwind: bb246];
++     bb224: {
++         _165 = <impl Future<Output = ()> as Future>::poll(move _167, move _168) -> [return: bb223, unwind: bb218];
 +     }
 + 
-+     bb253: {
++     bb225: {
 +         _169 = move _2;
-+         _168 = std::future::get_context::<'_, '_>(move _169) -> [return: bb252, unwind: bb246];
++         _168 = std::future::get_context::<'_, '_>(move _169) -> [return: bb224, unwind: bb218];
 +     }
 + 
-+     bb254: {
++     bb226: {
 +         _170 = &mut _163;
-+         _167 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _170) -> [return: bb253, unwind: bb246];
++         _167 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _170) -> [return: bb225, unwind: bb218];
 +     }
 + 
-+     bb255: {
++     bb227: {
 +         _2 = move _171;
 +         StorageDead(_171);
-+         goto -> bb261;
++         goto -> bb233;
 +     }
 + 
-+     bb256: {
++     bb228: {
 +         _2 = move _171;
 +         StorageDead(_171);
-+         goto -> bb254;
++         goto -> bb226;
 +     }
 + 
-+     bb257: {
++     bb229: {
 +         StorageLive(_171);
-+         _171 = yield(const ()) -> [resume: bb255, drop: bb256];
++         _171 = yield(const ()) -> [resume: bb227, drop: bb228];
 +     }
 + 
-+     bb258: {
++     bb230: {
 +         _173 = discriminant(_172);
-+         switchInt(move _173) -> [0: bb244, 1: bb257, otherwise: bb90];
++         switchInt(move _173) -> [0: bb216, 1: bb229, otherwise: bb62];
 +     }
 + 
-+     bb259: {
-+         _172 = <impl Future<Output = ()> as Future>::poll(move _174, move _175) -> [return: bb258, unwind: bb246];
++     bb231: {
++         _172 = <impl Future<Output = ()> as Future>::poll(move _174, move _175) -> [return: bb230, unwind: bb218];
 +     }
 + 
-+     bb260: {
++     bb232: {
 +         _176 = move _2;
-+         _175 = std::future::get_context::<'_, '_>(move _176) -> [return: bb259, unwind: bb246];
++         _175 = std::future::get_context::<'_, '_>(move _176) -> [return: bb231, unwind: bb218];
 +     }
 + 
-+     bb261: {
++     bb233: {
 +         _177 = &mut _163;
-+         _174 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _177) -> [return: bb260, unwind: bb246];
++         _174 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _177) -> [return: bb232, unwind: bb218];
 +     }
 + 
-+     bb262: {
++     bb234: {
 +         StorageLive(_163);
-+         _163 = async_drop_in_place::<AsyncInt>(copy (_178.0: &mut AsyncInt)) -> [return: bb261, unwind: bb246];
++         _163 = async_drop_in_place::<AsyncInt>(copy (_178.0: &mut AsyncInt)) -> [return: bb233, unwind: bb218];
 +     }
 + 
-+     bb263: {
++     bb235: {
 +         _179 = &mut _4;
-+         _178 = Pin::<&mut AsyncInt>::new_unchecked(move _179) -> [return: bb262, unwind: bb65];
++         _178 = Pin::<&mut AsyncInt>::new_unchecked(move _179) -> [return: bb234, unwind: bb41];
       }
   }
   

--- a/tests/mir-opt/coroutine/async_drop.elaborate_drops-{closure#0}.StateTransform.diff
+++ b/tests/mir-opt/coroutine/async_drop.elaborate_drops-{closure#0}.StateTransform.diff
@@ -342,7 +342,7 @@
 +         _183 = std::future::ResumeTy(move _184);
 +         _182 = copy (_1.0: &mut {async fn body of elaborate_drops()});
 +         _181 = discriminant((*_182));
-+         switchInt(move _181) -> [0: bb162, 1: bb161, 2: bb160, 3: bb142, 4: bb143, 5: bb144, 6: bb145, 7: bb146, 8: bb147, 9: bb148, 10: bb149, 11: bb150, 12: bb151, 13: bb152, 14: bb153, 15: bb154, 16: bb155, 17: bb156, 18: bb157, 19: bb158, 20: bb159, otherwise: bb35];
++         switchInt(move _181) -> [0: bb161, 1: bb160, 2: bb159, 3: bb141, 4: bb142, 5: bb143, 6: bb144, 7: bb145, 8: bb146, 9: bb147, 10: bb148, 11: bb149, 12: bb150, 13: bb151, 14: bb152, 15: bb153, 16: bb154, 17: bb155, 18: bb156, 19: bb157, 20: bb158, otherwise: bb34];
       }
   
       bb1: {
@@ -373,11 +373,11 @@
 -         StorageLive(_26);
 -         _26 = {closure@$DIR/async_drop.rs:86:27: 86:35} { foo: move _25 };
 -         _0 = const ();
--         goto -> bb64;
+-         goto -> bb63;
 +         nop;
 +         (((*_182) as variant#4).10: {async closure@$DIR/async_drop.rs:86:27: 86:35}) = {closure@$DIR/async_drop.rs:86:27: 86:35} { foo: move _25 };
 +         (((*_182) as variant#20).0: ()) = const ();
-+         goto -> bb43;
++         goto -> bb42;
       }
   
       bb2: {
@@ -388,8 +388,8 @@
   
       bb3: {
           StorageDead(_25);
--         goto -> bb84;
-+         goto -> bb55;
+-         goto -> bb83;
++         goto -> bb54;
       }
   
       bb4: {
@@ -400,65 +400,65 @@
   
       bb5: {
           StorageDead(_23);
--         goto -> bb104;
-+         goto -> bb67;
+-         goto -> bb103;
++         goto -> bb66;
       }
   
       bb6: {
 -         StorageDead(_20);
--         goto -> bb124;
+-         goto -> bb123;
 +         nop;
-+         goto -> bb79;
++         goto -> bb78;
       }
   
       bb7: {
 -         StorageDead(_19);
 +         nop;
           StorageDead(_17);
--         goto -> bb144;
-+         goto -> bb91;
+-         goto -> bb143;
++         goto -> bb90;
       }
   
       bb8: {
 -         StorageDead(_15);
--         goto -> bb164;
+-         goto -> bb163;
 +         nop;
-+         goto -> bb103;
++         goto -> bb102;
       }
   
       bb9: {
 -         StorageDead(_11);
--         goto -> bb184;
+-         goto -> bb183;
 +         nop;
-+         goto -> bb115;
++         goto -> bb114;
       }
   
       bb10: {
 -         StorageDead(_8);
--         goto -> bb204;
+-         goto -> bb203;
 +         nop;
-+         goto -> bb127;
++         goto -> bb126;
       }
   
       bb11: {
 -         StorageDead(_5);
--         goto -> bb224;
+-         goto -> bb223;
 +         nop;
-+         goto -> bb139;
++         goto -> bb138;
       }
   
       bb12: {
 -         StorageDead(_4);
--         drop(_3) -> [return: bb13, unwind: bb42];
+-         drop(_3) -> [return: bb13, unwind: bb41];
 +         nop;
-+         drop((((*_182) as variant#20).1: SyncInt)) -> [return: bb13, unwind: bb29];
++         drop((((*_182) as variant#20).1: SyncInt)) -> [return: bb13, unwind: bb28];
       }
   
       bb13: {
 -         StorageDead(_3);
--         drop(_1) -> [return: bb14, unwind: bb43];
+-         drop(_1) -> [return: bb14, unwind: bb42];
 +         nop;
-+         goto -> bb140;
++         goto -> bb139;
       }
   
       bb14: {
@@ -509,28 +509,30 @@
 -         goto -> bb21;
 +     bb20 (cleanup): {
 +         nop;
-+         goto -> bb23;
++         goto -> bb22;
       }
   
 -     bb21: {
 -         StorageDead(_15);
 +     bb21 (cleanup): {
++         StorageDead(_18);
           goto -> bb22;
       }
   
 -     bb22: {
 -         StorageDead(_11);
+-         goto -> bb23;
 +     bb22 (cleanup): {
-+         StorageDead(_18);
-          goto -> bb23;
++         StorageDead(_17);
++         drop((((*_182) as variant#12).6: AsyncEnum)) -> [return: bb23, unwind terminate(cleanup)];
       }
   
 -     bb23: {
 -         StorageDead(_8);
 -         goto -> bb24;
 +     bb23 (cleanup): {
-+         StorageDead(_17);
-+         drop((((*_182) as variant#12).6: AsyncEnum)) -> [return: bb24, unwind terminate(cleanup)];
++         nop;
++         drop((((*_182) as variant#14).5: SyncThenAsync)) -> [return: bb24, unwind terminate(cleanup)];
       }
   
 -     bb24: {
@@ -538,7 +540,7 @@
 -         goto -> bb25;
 +     bb24 (cleanup): {
 +         nop;
-+         drop((((*_182) as variant#14).5: SyncThenAsync)) -> [return: bb25, unwind terminate(cleanup)];
++         drop((((*_182) as variant#16).4: AsyncStruct)) -> [return: bb25, unwind terminate(cleanup)];
       }
   
 -     bb25: {
@@ -546,7 +548,7 @@
 -         goto -> bb26;
 +     bb25 (cleanup): {
 +         nop;
-+         drop((((*_182) as variant#16).4: AsyncStruct)) -> [return: bb26, unwind terminate(cleanup)];
++         drop((((*_182) as variant#18).3: [AsyncInt; 2])) -> [return: bb26, unwind terminate(cleanup)];
       }
   
 -     bb26: {
@@ -554,86 +556,79 @@
 -         goto -> bb27;
 +     bb26 (cleanup): {
 +         nop;
-+         drop((((*_182) as variant#18).3: [AsyncInt; 2])) -> [return: bb27, unwind terminate(cleanup)];
++         drop((((*_182) as variant#20).2: AsyncInt)) -> [return: bb27, unwind terminate(cleanup)];
       }
   
 -     bb27: {
 -         coroutine_drop;
 +     bb27 (cleanup): {
 +         nop;
-+         drop((((*_182) as variant#20).2: AsyncInt)) -> [return: bb28, unwind terminate(cleanup)];
++         drop((((*_182) as variant#20).1: SyncInt)) -> [return: bb28, unwind terminate(cleanup)];
       }
   
       bb28 (cleanup): {
 -         StorageDead(_26);
--         goto -> bb29;
 +         nop;
-+         drop((((*_182) as variant#20).1: SyncInt)) -> [return: bb29, unwind terminate(cleanup)];
+          goto -> bb29;
       }
   
       bb29 (cleanup): {
 -         StorageDead(_25);
 -         drop(_24) -> [return: bb30, unwind terminate(cleanup)];
-+         nop;
-+         goto -> bb30;
++         goto -> bb140;
       }
   
-      bb30 (cleanup): {
+-     bb30 (cleanup): {
 -         StorageDead(_24);
 -         goto -> bb31;
-+         goto -> bb141;
-      }
-  
--     bb31 (cleanup): {
--         StorageDead(_23);
--         drop(_20) -> [return: bb32, unwind terminate(cleanup)];
-+     bb31: {
++     bb30: {
 +         nop;
 +         goto -> bb2;
       }
   
-      bb32 (cleanup): {
--         StorageDead(_20);
--         drop(_19) -> [return: bb33, unwind terminate(cleanup)];
+      bb31 (cleanup): {
+-         StorageDead(_23);
+-         drop(_20) -> [return: bb32, unwind terminate(cleanup)];
 +         nop;
 +         goto -> bb15;
       }
   
+-     bb32 (cleanup): {
+-         StorageDead(_20);
+-         drop(_19) -> [return: bb33, unwind terminate(cleanup)];
++     bb32: {
++         assert(const false, "`async fn` resumed after async drop") -> [success: bb32, unwind: bb31];
+      }
+  
 -     bb33 (cleanup): {
 -         StorageDead(_19);
--         goto -> bb36;
+-         goto -> bb35;
 +     bb33: {
-+         assert(const false, "`async fn` resumed after async drop") -> [success: bb33, unwind: bb32];
++         _183 = move _28;
++         StorageDead(_28);
++         goto -> bb32;
       }
   
 -     bb34 (cleanup): {
+-         StorageDead(_18);
 -         goto -> bb35;
 +     bb34: {
-+         _183 = move _28;
-+         StorageDead(_28);
-+         goto -> bb33;
-      }
-  
--     bb35 (cleanup): {
--         StorageDead(_18);
--         goto -> bb36;
-+     bb35: {
 +         unreachable;
       }
   
--     bb36 (cleanup): {
+-     bb35 (cleanup): {
 -         StorageDead(_17);
--         drop(_15) -> [return: bb37, unwind terminate(cleanup)];
-+     bb36: {
+-         drop(_15) -> [return: bb36, unwind terminate(cleanup)];
++     bb35: {
 +         _183 = move _35;
 +         StorageDead(_35);
-+         goto -> bb41;
++         goto -> bb40;
       }
   
--     bb37 (cleanup): {
+-     bb36 (cleanup): {
 -         StorageDead(_15);
--         drop(_11) -> [return: bb38, unwind terminate(cleanup)];
-+     bb37: {
+-         drop(_11) -> [return: bb37, unwind terminate(cleanup)];
++     bb36: {
 +         StorageLive(_35);
 +         _0 = Poll::<()>::Pending;
 +         StorageDead(_17);
@@ -644,95 +639,95 @@
 +         return;
       }
   
--     bb38 (cleanup): {
+-     bb37 (cleanup): {
 -         StorageDead(_11);
--         drop(_8) -> [return: bb39, unwind terminate(cleanup)];
-+     bb38: {
+-         drop(_8) -> [return: bb38, unwind terminate(cleanup)];
++     bb37: {
 +         _37 = discriminant(_36);
-+         switchInt(move _37) -> [0: bb31, 1: bb37, otherwise: bb35];
++         switchInt(move _37) -> [0: bb30, 1: bb36, otherwise: bb34];
+      }
+  
+-     bb38 (cleanup): {
+-         StorageDead(_8);
+-         drop(_5) -> [return: bb39, unwind terminate(cleanup)];
++     bb38: {
++         _36 = <impl Future<Output = ()> as Future>::poll(move _38, move _39) -> [return: bb37, unwind: bb31];
       }
   
 -     bb39 (cleanup): {
--         StorageDead(_8);
--         drop(_5) -> [return: bb40, unwind terminate(cleanup)];
+-         StorageDead(_5);
+-         drop(_4) -> [return: bb40, unwind terminate(cleanup)];
 +     bb39: {
-+         _36 = <impl Future<Output = ()> as Future>::poll(move _38, move _39) -> [return: bb38, unwind: bb32];
++         _40 = move _183;
++         _39 = copy (_40.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
++         goto -> bb38;
       }
   
 -     bb40 (cleanup): {
--         StorageDead(_5);
--         drop(_4) -> [return: bb41, unwind terminate(cleanup)];
+-         StorageDead(_4);
+-         drop(_3) -> [return: bb41, unwind terminate(cleanup)];
 +     bb40: {
-+         _40 = move _183;
-+         _39 = copy (_40.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
-+         goto -> bb39;
++         _41 = &mut (((*_182) as variant#4).11: impl std::future::Future<Output = ()>);
++         _38 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _41) -> [return: bb39, unwind: bb31];
       }
   
 -     bb41 (cleanup): {
--         StorageDead(_4);
--         drop(_3) -> [return: bb42, unwind terminate(cleanup)];
+-         StorageDead(_3);
+-         drop(_1) -> [return: bb42, unwind terminate(cleanup)];
 +     bb41: {
-+         _41 = &mut (((*_182) as variant#4).11: impl std::future::Future<Output = ()>);
-+         _38 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _41) -> [return: bb40, unwind: bb32];
++         nop;
++         (((*_182) as variant#4).11: impl std::future::Future<Output = ()>) = async_drop_in_place::<{async closure@$DIR/async_drop.rs:86:27: 86:35}>(copy (_42.0: &mut {async closure@$DIR/async_drop.rs:86:27: 86:35})) -> [return: bb40, unwind: bb31];
       }
   
 -     bb42 (cleanup): {
--         StorageDead(_3);
--         drop(_1) -> [return: bb43, unwind terminate(cleanup)];
-+     bb42: {
-+         nop;
-+         (((*_182) as variant#4).11: impl std::future::Future<Output = ()>) = async_drop_in_place::<{async closure@$DIR/async_drop.rs:86:27: 86:35}>(copy (_42.0: &mut {async closure@$DIR/async_drop.rs:86:27: 86:35})) -> [return: bb41, unwind: bb32];
-      }
-  
--     bb43 (cleanup): {
 -         resume;
-+     bb43: {
++     bb42: {
 +         _43 = &mut (((*_182) as variant#4).10: {async closure@$DIR/async_drop.rs:86:27: 86:35});
-+         _42 = Pin::<&mut {async closure@$DIR/async_drop.rs:86:27: 86:35}>::new_unchecked(move _43) -> [return: bb42, unwind: bb15];
++         _42 = Pin::<&mut {async closure@$DIR/async_drop.rs:86:27: 86:35}>::new_unchecked(move _43) -> [return: bb41, unwind: bb15];
       }
   
-      bb44: {
+      bb43: {
 -         StorageDead(_27);
 -         goto -> bb2;
 +         nop;
 +         goto -> bb4;
       }
   
--     bb45: {
+-     bb44: {
 -         StorageDead(_27);
 -         goto -> bb15;
-+     bb45 (cleanup): {
++     bb44 (cleanup): {
 +         nop;
 +         goto -> bb17;
       }
   
--     bb46 (cleanup): {
+-     bb45 (cleanup): {
 -         StorageDead(_27);
 -         goto -> bb28;
-+     bb46: {
-+         assert(const false, "`async fn` resumed after async drop") -> [success: bb46, unwind: bb45];
++     bb45: {
++         assert(const false, "`async fn` resumed after async drop") -> [success: bb45, unwind: bb44];
+      }
+  
+      bb46: {
+-         assert(const false, "`async fn` resumed after async drop") -> [success: bb46, unwind: bb45];
++         _183 = move _45;
++         StorageDead(_45);
++         goto -> bb45;
       }
   
       bb47: {
--         assert(const false, "`async fn` resumed after async drop") -> [success: bb47, unwind: bb46];
-+         _183 = move _45;
-+         StorageDead(_45);
-+         goto -> bb46;
+-         _2 = move _28;
+-         StorageDead(_28);
+-         goto -> bb46;
++         _183 = move _52;
++         StorageDead(_52);
++         goto -> bb52;
       }
   
       bb48: {
 -         _2 = move _28;
 -         StorageDead(_28);
--         goto -> bb47;
-+         _183 = move _52;
-+         StorageDead(_52);
-+         goto -> bb53;
-      }
-  
-      bb49: {
--         _2 = move _28;
--         StorageDead(_28);
--         goto -> bb55;
+-         goto -> bb54;
 +         StorageLive(_52);
 +         _0 = Poll::<()>::Pending;
 +         StorageDead(_17);
@@ -742,87 +737,87 @@
 +         return;
       }
   
-      bb50: {
+      bb49: {
 -         StorageLive(_28);
--         _28 = yield(const ()) -> [resume: bb48, drop: bb49];
+-         _28 = yield(const ()) -> [resume: bb47, drop: bb48];
 +         _54 = discriminant(_53);
-+         switchInt(move _54) -> [0: bb44, 1: bb49, otherwise: bb35];
++         switchInt(move _54) -> [0: bb43, 1: bb48, otherwise: bb34];
+      }
+  
+      bb50: {
+-         unreachable;
++         _53 = <impl Future<Output = ()> as Future>::poll(move _55, move _56) -> [return: bb49, unwind: bb44];
       }
   
       bb51: {
--         unreachable;
-+         _53 = <impl Future<Output = ()> as Future>::poll(move _55, move _56) -> [return: bb50, unwind: bb45];
+-         _30 = discriminant(_29);
+-         switchInt(move _30) -> [0: bb44, 1: bb49, otherwise: bb50];
++         _57 = move _183;
++         _56 = copy (_57.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
++         goto -> bb50;
       }
   
       bb52: {
--         _30 = discriminant(_29);
--         switchInt(move _30) -> [0: bb45, 1: bb50, otherwise: bb51];
-+         _57 = move _183;
-+         _56 = copy (_57.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
-+         goto -> bb51;
+-         _29 = <impl Future<Output = ()> as Future>::poll(move _31, move _32) -> [return: bb51, unwind: bb45];
++         _58 = &mut (((*_182) as variant#6).10: impl std::future::Future<Output = ()>);
++         _55 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _58) -> [return: bb51, unwind: bb44];
       }
   
       bb53: {
--         _29 = <impl Future<Output = ()> as Future>::poll(move _31, move _32) -> [return: bb52, unwind: bb46];
-+         _58 = &mut (((*_182) as variant#6).10: impl std::future::Future<Output = ()>);
-+         _55 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _58) -> [return: bb52, unwind: bb45];
+-         _33 = move _2;
+-         _32 = std::future::get_context::<'_, '_>(move _33) -> [return: bb52, unwind: bb45];
++         nop;
++         (((*_182) as variant#6).10: impl std::future::Future<Output = ()>) = async_drop_in_place::<{closure@$DIR/async_drop.rs:78:25: 78:27}>(copy (_59.0: &mut {closure@$DIR/async_drop.rs:78:25: 78:27})) -> [return: bb52, unwind: bb44];
       }
   
       bb54: {
--         _33 = move _2;
--         _32 = std::future::get_context::<'_, '_>(move _33) -> [return: bb53, unwind: bb46];
-+         nop;
-+         (((*_182) as variant#6).10: impl std::future::Future<Output = ()>) = async_drop_in_place::<{closure@$DIR/async_drop.rs:78:25: 78:27}>(copy (_59.0: &mut {closure@$DIR/async_drop.rs:78:25: 78:27})) -> [return: bb53, unwind: bb45];
+-         _34 = &mut _27;
+-         _31 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _34) -> [return: bb53, unwind: bb45];
++         _60 = &mut (((*_182) as variant#6).9: {closure@$DIR/async_drop.rs:78:25: 78:27});
++         _59 = Pin::<&mut {closure@$DIR/async_drop.rs:78:25: 78:27}>::new_unchecked(move _60) -> [return: bb53, unwind: bb17];
       }
   
       bb55: {
--         _34 = &mut _27;
--         _31 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _34) -> [return: bb54, unwind: bb46];
-+         _60 = &mut (((*_182) as variant#6).9: {closure@$DIR/async_drop.rs:78:25: 78:27});
-+         _59 = Pin::<&mut {closure@$DIR/async_drop.rs:78:25: 78:27}>::new_unchecked(move _60) -> [return: bb54, unwind: bb17];
-      }
-  
-      bb56: {
 -         _2 = move _35;
 -         StorageDead(_35);
--         goto -> bb62;
+-         goto -> bb61;
 +         nop;
 +         goto -> bb6;
       }
   
--     bb57: {
+-     bb56: {
 -         _2 = move _35;
 -         StorageDead(_35);
--         goto -> bb55;
-+     bb57 (cleanup): {
+-         goto -> bb54;
++     bb56 (cleanup): {
 +         nop;
 +         goto -> bb19;
       }
   
-      bb58: {
+      bb57: {
 -         StorageLive(_35);
--         _35 = yield(const ()) -> [resume: bb56, drop: bb57];
-+         assert(const false, "`async fn` resumed after async drop") -> [success: bb58, unwind: bb57];
+-         _35 = yield(const ()) -> [resume: bb55, drop: bb56];
++         assert(const false, "`async fn` resumed after async drop") -> [success: bb57, unwind: bb56];
+      }
+  
+      bb58: {
+-         _37 = discriminant(_36);
+-         switchInt(move _37) -> [0: bb43, 1: bb57, otherwise: bb50];
++         _183 = move _62;
++         StorageDead(_62);
++         goto -> bb57;
       }
   
       bb59: {
--         _37 = discriminant(_36);
--         switchInt(move _37) -> [0: bb44, 1: bb58, otherwise: bb51];
-+         _183 = move _62;
-+         StorageDead(_62);
-+         goto -> bb58;
+-         _36 = <impl Future<Output = ()> as Future>::poll(move _38, move _39) -> [return: bb58, unwind: bb45];
++         _183 = move _69;
++         StorageDead(_69);
++         goto -> bb64;
       }
   
       bb60: {
--         _36 = <impl Future<Output = ()> as Future>::poll(move _38, move _39) -> [return: bb59, unwind: bb46];
-+         _183 = move _69;
-+         StorageDead(_69);
-+         goto -> bb65;
-      }
-  
-      bb61: {
 -         _40 = move _2;
--         _39 = std::future::get_context::<'_, '_>(move _40) -> [return: bb60, unwind: bb46];
+-         _39 = std::future::get_context::<'_, '_>(move _40) -> [return: bb59, unwind: bb45];
 +         StorageLive(_69);
 +         _0 = Poll::<()>::Pending;
 +         StorageDead(_17);
@@ -831,89 +826,89 @@
 +         return;
       }
   
-      bb62: {
+      bb61: {
 -         _41 = &mut _27;
--         _38 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _41) -> [return: bb61, unwind: bb46];
+-         _38 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _41) -> [return: bb60, unwind: bb45];
 +         _71 = discriminant(_70);
-+         switchInt(move _71) -> [0: bb56, 1: bb61, otherwise: bb35];
++         switchInt(move _71) -> [0: bb55, 1: bb60, otherwise: bb34];
+      }
+  
+      bb62: {
+-         StorageLive(_27);
+-         _27 = async_drop_in_place::<{async closure@$DIR/async_drop.rs:86:27: 86:35}>(copy (_42.0: &mut {async closure@$DIR/async_drop.rs:86:27: 86:35})) -> [return: bb61, unwind: bb45];
++         _70 = <impl Future<Output = ()> as Future>::poll(move _72, move _73) -> [return: bb61, unwind: bb56];
       }
   
       bb63: {
--         StorageLive(_27);
--         _27 = async_drop_in_place::<{async closure@$DIR/async_drop.rs:86:27: 86:35}>(copy (_42.0: &mut {async closure@$DIR/async_drop.rs:86:27: 86:35})) -> [return: bb62, unwind: bb46];
-+         _70 = <impl Future<Output = ()> as Future>::poll(move _72, move _73) -> [return: bb62, unwind: bb57];
+-         _43 = &mut _26;
+-         _42 = Pin::<&mut {async closure@$DIR/async_drop.rs:86:27: 86:35}>::new_unchecked(move _43) -> [return: bb62, unwind: bb28];
++         _74 = move _183;
++         _73 = copy (_74.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
++         goto -> bb62;
       }
   
       bb64: {
--         _43 = &mut _26;
--         _42 = Pin::<&mut {async closure@$DIR/async_drop.rs:86:27: 86:35}>::new_unchecked(move _43) -> [return: bb63, unwind: bb28];
-+         _74 = move _183;
-+         _73 = copy (_74.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
-+         goto -> bb63;
+-         StorageDead(_44);
+-         goto -> bb4;
++         _75 = &mut (((*_182) as variant#8).9: impl std::future::Future<Output = ()>);
++         _72 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _75) -> [return: bb63, unwind: bb56];
       }
   
       bb65: {
 -         StorageDead(_44);
--         goto -> bb4;
-+         _75 = &mut (((*_182) as variant#8).9: impl std::future::Future<Output = ()>);
-+         _72 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _75) -> [return: bb64, unwind: bb57];
-      }
-  
-      bb66: {
--         StorageDead(_44);
 -         goto -> bb17;
 +         nop;
-+         (((*_182) as variant#8).9: impl std::future::Future<Output = ()>) = async_drop_in_place::<AsyncReference<'_>>(copy (_76.0: &mut AsyncReference<'_>)) -> [return: bb65, unwind: bb57];
++         (((*_182) as variant#8).9: impl std::future::Future<Output = ()>) = async_drop_in_place::<AsyncReference<'_>>(copy (_76.0: &mut AsyncReference<'_>)) -> [return: bb64, unwind: bb56];
       }
   
--     bb67 (cleanup): {
+-     bb66 (cleanup): {
 -         StorageDead(_44);
 -         goto -> bb30;
-+     bb67: {
++     bb66: {
 +         _77 = &mut (((*_182) as variant#8).8: AsyncReference<'_>);
-+         _76 = Pin::<&mut AsyncReference<'_>>::new_unchecked(move _77) -> [return: bb66, unwind: bb19];
++         _76 = Pin::<&mut AsyncReference<'_>>::new_unchecked(move _77) -> [return: bb65, unwind: bb19];
       }
   
-      bb68: {
--         assert(const false, "`async fn` resumed after async drop") -> [success: bb68, unwind: bb67];
+      bb67: {
+-         assert(const false, "`async fn` resumed after async drop") -> [success: bb67, unwind: bb66];
 +         nop;
 +         goto -> bb7;
       }
   
--     bb69: {
+-     bb68: {
 -         _2 = move _45;
 -         StorageDead(_45);
--         goto -> bb68;
-+     bb69 (cleanup): {
+-         goto -> bb67;
++     bb68 (cleanup): {
 +         nop;
 +         goto -> bb20;
       }
   
-      bb70: {
+      bb69: {
 -         _2 = move _45;
 -         StorageDead(_45);
--         goto -> bb75;
-+         assert(const false, "`async fn` resumed after async drop") -> [success: bb70, unwind: bb69];
+-         goto -> bb74;
++         assert(const false, "`async fn` resumed after async drop") -> [success: bb69, unwind: bb68];
+      }
+  
+      bb70: {
+-         StorageLive(_45);
+-         _45 = yield(const ()) -> [resume: bb68, drop: bb69];
++         _183 = move _79;
++         StorageDead(_79);
++         goto -> bb69;
       }
   
       bb71: {
--         StorageLive(_45);
--         _45 = yield(const ()) -> [resume: bb69, drop: bb70];
-+         _183 = move _79;
-+         StorageDead(_79);
-+         goto -> bb70;
+-         _47 = discriminant(_46);
+-         switchInt(move _47) -> [0: bb65, 1: bb70, otherwise: bb50];
++         _183 = move _86;
++         StorageDead(_86);
++         goto -> bb76;
       }
   
       bb72: {
--         _47 = discriminant(_46);
--         switchInt(move _47) -> [0: bb66, 1: bb71, otherwise: bb51];
-+         _183 = move _86;
-+         StorageDead(_86);
-+         goto -> bb77;
-      }
-  
-      bb73: {
--         _46 = <impl Future<Output = ()> as Future>::poll(move _48, move _49) -> [return: bb72, unwind: bb67];
+-         _46 = <impl Future<Output = ()> as Future>::poll(move _48, move _49) -> [return: bb71, unwind: bb66];
 +         StorageLive(_86);
 +         _0 = Poll::<()>::Pending;
 +         StorageDead(_17);
@@ -922,87 +917,87 @@
 +         return;
       }
   
-      bb74: {
+      bb73: {
 -         _50 = move _2;
--         _49 = std::future::get_context::<'_, '_>(move _50) -> [return: bb73, unwind: bb67];
+-         _49 = std::future::get_context::<'_, '_>(move _50) -> [return: bb72, unwind: bb66];
 +         _88 = discriminant(_87);
-+         switchInt(move _88) -> [0: bb68, 1: bb73, otherwise: bb35];
++         switchInt(move _88) -> [0: bb67, 1: bb72, otherwise: bb34];
+      }
+  
+      bb74: {
+-         _51 = &mut _44;
+-         _48 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _51) -> [return: bb73, unwind: bb66];
++         _87 = <impl Future<Output = ()> as Future>::poll(move _89, move _90) -> [return: bb73, unwind: bb68];
       }
   
       bb75: {
--         _51 = &mut _44;
--         _48 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _51) -> [return: bb74, unwind: bb67];
-+         _87 = <impl Future<Output = ()> as Future>::poll(move _89, move _90) -> [return: bb74, unwind: bb69];
+-         _2 = move _52;
+-         StorageDead(_52);
+-         goto -> bb81;
++         _91 = move _183;
++         _90 = copy (_91.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
++         goto -> bb74;
       }
   
       bb76: {
 -         _2 = move _52;
 -         StorageDead(_52);
--         goto -> bb82;
-+         _91 = move _183;
-+         _90 = copy (_91.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
-+         goto -> bb75;
+-         goto -> bb74;
++         _92 = &mut (((*_182) as variant#10).8: impl std::future::Future<Output = ()>);
++         _89 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _92) -> [return: bb75, unwind: bb68];
       }
   
       bb77: {
--         _2 = move _52;
--         StorageDead(_52);
--         goto -> bb75;
-+         _92 = &mut (((*_182) as variant#10).8: impl std::future::Future<Output = ()>);
-+         _89 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _92) -> [return: bb76, unwind: bb69];
+-         StorageLive(_52);
+-         _52 = yield(const ()) -> [resume: bb75, drop: bb76];
++         nop;
++         (((*_182) as variant#10).8: impl std::future::Future<Output = ()>) = async_drop_in_place::<AsyncInt>(copy (_93.0: &mut AsyncInt)) -> [return: bb76, unwind: bb68];
       }
   
       bb78: {
--         StorageLive(_52);
--         _52 = yield(const ()) -> [resume: bb76, drop: bb77];
-+         nop;
-+         (((*_182) as variant#10).8: impl std::future::Future<Output = ()>) = async_drop_in_place::<AsyncInt>(copy (_93.0: &mut AsyncInt)) -> [return: bb77, unwind: bb69];
+-         _54 = discriminant(_53);
+-         switchInt(move _54) -> [0: bb64, 1: bb77, otherwise: bb50];
++         _94 = &mut (((*_182) as variant#10).7: AsyncInt);
++         _93 = Pin::<&mut AsyncInt>::new_unchecked(move _94) -> [return: bb77, unwind: bb20];
       }
   
       bb79: {
--         _54 = discriminant(_53);
--         switchInt(move _54) -> [0: bb65, 1: bb78, otherwise: bb51];
-+         _94 = &mut (((*_182) as variant#10).7: AsyncInt);
-+         _93 = Pin::<&mut AsyncInt>::new_unchecked(move _94) -> [return: bb78, unwind: bb20];
-      }
-  
-      bb80: {
--         _53 = <impl Future<Output = ()> as Future>::poll(move _55, move _56) -> [return: bb79, unwind: bb67];
+-         _53 = <impl Future<Output = ()> as Future>::poll(move _55, move _56) -> [return: bb78, unwind: bb66];
 +         nop;
 +         goto -> bb8;
       }
   
--     bb81: {
+-     bb80: {
 -         _57 = move _2;
--         _56 = std::future::get_context::<'_, '_>(move _57) -> [return: bb80, unwind: bb67];
-+     bb81 (cleanup): {
+-         _56 = std::future::get_context::<'_, '_>(move _57) -> [return: bb79, unwind: bb66];
++     bb80 (cleanup): {
 +         nop;
-+         goto -> bb24;
++         goto -> bb23;
+      }
+  
+      bb81: {
+-         _58 = &mut _44;
+-         _55 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _58) -> [return: bb80, unwind: bb66];
++         assert(const false, "`async fn` resumed after async drop") -> [success: bb81, unwind: bb80];
       }
   
       bb82: {
--         _58 = &mut _44;
--         _55 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _58) -> [return: bb81, unwind: bb67];
-+         assert(const false, "`async fn` resumed after async drop") -> [success: bb82, unwind: bb81];
+-         StorageLive(_44);
+-         _44 = async_drop_in_place::<{closure@$DIR/async_drop.rs:78:25: 78:27}>(copy (_59.0: &mut {closure@$DIR/async_drop.rs:78:25: 78:27})) -> [return: bb81, unwind: bb66];
++         _183 = move _96;
++         StorageDead(_96);
++         goto -> bb81;
       }
   
       bb83: {
--         StorageLive(_44);
--         _44 = async_drop_in_place::<{closure@$DIR/async_drop.rs:78:25: 78:27}>(copy (_59.0: &mut {closure@$DIR/async_drop.rs:78:25: 78:27})) -> [return: bb82, unwind: bb67];
-+         _183 = move _96;
-+         StorageDead(_96);
-+         goto -> bb82;
+-         _60 = &mut _24;
+-         _59 = Pin::<&mut {closure@$DIR/async_drop.rs:78:25: 78:27}>::new_unchecked(move _60) -> [return: bb82, unwind: bb30];
++         _183 = move _103;
++         StorageDead(_103);
++         goto -> bb88;
       }
   
       bb84: {
--         _60 = &mut _24;
--         _59 = Pin::<&mut {closure@$DIR/async_drop.rs:78:25: 78:27}>::new_unchecked(move _60) -> [return: bb83, unwind: bb30];
-+         _183 = move _103;
-+         StorageDead(_103);
-+         goto -> bb89;
-      }
-  
-      bb85: {
 -         StorageDead(_61);
 -         goto -> bb6;
 +         StorageLive(_103);
@@ -1012,91 +1007,91 @@
 +         return;
       }
   
-      bb86: {
+      bb85: {
 -         StorageDead(_61);
 -         goto -> bb19;
 +         _105 = discriminant(_104);
-+         switchInt(move _105) -> [0: bb80, 1: bb85, otherwise: bb35];
++         switchInt(move _105) -> [0: bb79, 1: bb84, otherwise: bb34];
       }
   
--     bb87 (cleanup): {
+-     bb86 (cleanup): {
 -         StorageDead(_61);
 -         goto -> bb32;
-+     bb87: {
-+         _104 = <impl Future<Output = ()> as Future>::poll(move _106, move _107) -> [return: bb86, unwind: bb81];
++     bb86: {
++         _104 = <impl Future<Output = ()> as Future>::poll(move _106, move _107) -> [return: bb85, unwind: bb80];
+      }
+  
+      bb87: {
+-         assert(const false, "`async fn` resumed after async drop") -> [success: bb87, unwind: bb86];
++         _108 = move _183;
++         _107 = copy (_108.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
++         goto -> bb86;
       }
   
       bb88: {
--         assert(const false, "`async fn` resumed after async drop") -> [success: bb88, unwind: bb87];
-+         _108 = move _183;
-+         _107 = copy (_108.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
-+         goto -> bb87;
+-         _2 = move _62;
+-         StorageDead(_62);
+-         goto -> bb87;
++         _109 = &mut (((*_182) as variant#12).7: impl std::future::Future<Output = ()>);
++         _106 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _109) -> [return: bb87, unwind: bb80];
       }
   
       bb89: {
 -         _2 = move _62;
 -         StorageDead(_62);
--         goto -> bb88;
-+         _109 = &mut (((*_182) as variant#12).7: impl std::future::Future<Output = ()>);
-+         _106 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _109) -> [return: bb88, unwind: bb81];
+-         goto -> bb94;
++         nop;
++         (((*_182) as variant#12).7: impl std::future::Future<Output = ()>) = async_drop_in_place::<AsyncEnum>(copy (_110.0: &mut AsyncEnum)) -> [return: bb88, unwind: bb80];
       }
   
       bb90: {
--         _2 = move _62;
--         StorageDead(_62);
--         goto -> bb95;
-+         nop;
-+         (((*_182) as variant#12).7: impl std::future::Future<Output = ()>) = async_drop_in_place::<AsyncEnum>(copy (_110.0: &mut AsyncEnum)) -> [return: bb89, unwind: bb81];
+-         StorageLive(_62);
+-         _62 = yield(const ()) -> [resume: bb88, drop: bb89];
++         _111 = &mut (((*_182) as variant#12).6: AsyncEnum);
++         _110 = Pin::<&mut AsyncEnum>::new_unchecked(move _111) -> [return: bb89, unwind: bb23];
       }
   
       bb91: {
--         StorageLive(_62);
--         _62 = yield(const ()) -> [resume: bb89, drop: bb90];
-+         _111 = &mut (((*_182) as variant#12).6: AsyncEnum);
-+         _110 = Pin::<&mut AsyncEnum>::new_unchecked(move _111) -> [return: bb90, unwind: bb24];
-      }
-  
-      bb92: {
 -         _64 = discriminant(_63);
--         switchInt(move _64) -> [0: bb86, 1: bb91, otherwise: bb51];
+-         switchInt(move _64) -> [0: bb85, 1: bb90, otherwise: bb50];
 +         nop;
 +         goto -> bb9;
       }
   
--     bb93: {
--         _63 = <impl Future<Output = ()> as Future>::poll(move _65, move _66) -> [return: bb92, unwind: bb87];
-+     bb93 (cleanup): {
+-     bb92: {
+-         _63 = <impl Future<Output = ()> as Future>::poll(move _65, move _66) -> [return: bb91, unwind: bb86];
++     bb92 (cleanup): {
 +         nop;
-+         goto -> bb25;
++         goto -> bb24;
+      }
+  
+      bb93: {
+-         _67 = move _2;
+-         _66 = std::future::get_context::<'_, '_>(move _67) -> [return: bb92, unwind: bb86];
++         assert(const false, "`async fn` resumed after async drop") -> [success: bb93, unwind: bb92];
       }
   
       bb94: {
--         _67 = move _2;
--         _66 = std::future::get_context::<'_, '_>(move _67) -> [return: bb93, unwind: bb87];
-+         assert(const false, "`async fn` resumed after async drop") -> [success: bb94, unwind: bb93];
+-         _68 = &mut _61;
+-         _65 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _68) -> [return: bb93, unwind: bb86];
++         _183 = move _113;
++         StorageDead(_113);
++         goto -> bb93;
       }
   
       bb95: {
--         _68 = &mut _61;
--         _65 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _68) -> [return: bb94, unwind: bb87];
-+         _183 = move _113;
-+         StorageDead(_113);
-+         goto -> bb94;
+-         _2 = move _69;
+-         StorageDead(_69);
+-         goto -> bb101;
++         _183 = move _120;
++         StorageDead(_120);
++         goto -> bb100;
       }
   
       bb96: {
 -         _2 = move _69;
 -         StorageDead(_69);
--         goto -> bb102;
-+         _183 = move _120;
-+         StorageDead(_120);
-+         goto -> bb101;
-      }
-  
-      bb97: {
--         _2 = move _69;
--         StorageDead(_69);
--         goto -> bb95;
+-         goto -> bb94;
 +         StorageLive(_120);
 +         _0 = Poll::<()>::Pending;
 +         StorageDead(_120);
@@ -1104,88 +1099,88 @@
 +         return;
       }
   
-      bb98: {
+      bb97: {
 -         StorageLive(_69);
--         _69 = yield(const ()) -> [resume: bb96, drop: bb97];
+-         _69 = yield(const ()) -> [resume: bb95, drop: bb96];
 +         _122 = discriminant(_121);
-+         switchInt(move _122) -> [0: bb92, 1: bb97, otherwise: bb35];
++         switchInt(move _122) -> [0: bb91, 1: bb96, otherwise: bb34];
+      }
+  
+      bb98: {
+-         _71 = discriminant(_70);
+-         switchInt(move _71) -> [0: bb84, 1: bb97, otherwise: bb50];
++         _121 = <impl Future<Output = ()> as Future>::poll(move _123, move _124) -> [return: bb97, unwind: bb92];
       }
   
       bb99: {
--         _71 = discriminant(_70);
--         switchInt(move _71) -> [0: bb85, 1: bb98, otherwise: bb51];
-+         _121 = <impl Future<Output = ()> as Future>::poll(move _123, move _124) -> [return: bb98, unwind: bb93];
+-         _70 = <impl Future<Output = ()> as Future>::poll(move _72, move _73) -> [return: bb98, unwind: bb86];
++         _125 = move _183;
++         _124 = copy (_125.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
++         goto -> bb98;
       }
   
       bb100: {
--         _70 = <impl Future<Output = ()> as Future>::poll(move _72, move _73) -> [return: bb99, unwind: bb87];
-+         _125 = move _183;
-+         _124 = copy (_125.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
-+         goto -> bb99;
+-         _74 = move _2;
+-         _73 = std::future::get_context::<'_, '_>(move _74) -> [return: bb99, unwind: bb86];
++         _126 = &mut (((*_182) as variant#14).6: impl std::future::Future<Output = ()>);
++         _123 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _126) -> [return: bb99, unwind: bb92];
       }
   
       bb101: {
--         _74 = move _2;
--         _73 = std::future::get_context::<'_, '_>(move _74) -> [return: bb100, unwind: bb87];
-+         _126 = &mut (((*_182) as variant#14).6: impl std::future::Future<Output = ()>);
-+         _123 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _126) -> [return: bb100, unwind: bb93];
+-         _75 = &mut _61;
+-         _72 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _75) -> [return: bb100, unwind: bb86];
++         nop;
++         (((*_182) as variant#14).6: impl std::future::Future<Output = ()>) = async_drop_in_place::<SyncThenAsync>(copy (_127.0: &mut SyncThenAsync)) -> [return: bb100, unwind: bb92];
       }
   
       bb102: {
--         _75 = &mut _61;
--         _72 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _75) -> [return: bb101, unwind: bb87];
-+         nop;
-+         (((*_182) as variant#14).6: impl std::future::Future<Output = ()>) = async_drop_in_place::<SyncThenAsync>(copy (_127.0: &mut SyncThenAsync)) -> [return: bb101, unwind: bb93];
+-         StorageLive(_61);
+-         _61 = async_drop_in_place::<AsyncReference<'_>>(copy (_76.0: &mut AsyncReference<'_>)) -> [return: bb101, unwind: bb86];
++         _128 = &mut (((*_182) as variant#14).5: SyncThenAsync);
++         _127 = Pin::<&mut SyncThenAsync>::new_unchecked(move _128) -> [return: bb101, unwind: bb24];
       }
   
       bb103: {
--         StorageLive(_61);
--         _61 = async_drop_in_place::<AsyncReference<'_>>(copy (_76.0: &mut AsyncReference<'_>)) -> [return: bb102, unwind: bb87];
-+         _128 = &mut (((*_182) as variant#14).5: SyncThenAsync);
-+         _127 = Pin::<&mut SyncThenAsync>::new_unchecked(move _128) -> [return: bb102, unwind: bb25];
-      }
-  
-      bb104: {
 -         _77 = &mut _20;
--         _76 = Pin::<&mut AsyncReference<'_>>::new_unchecked(move _77) -> [return: bb103, unwind: bb32];
+-         _76 = Pin::<&mut AsyncReference<'_>>::new_unchecked(move _77) -> [return: bb102, unwind: bb32];
 +         nop;
 +         goto -> bb10;
       }
   
--     bb105: {
+-     bb104: {
 -         StorageDead(_78);
 -         goto -> bb7;
-+     bb105 (cleanup): {
++     bb104 (cleanup): {
 +         nop;
-+         goto -> bb26;
++         goto -> bb25;
       }
   
-      bb106: {
+      bb105: {
 -         StorageDead(_78);
 -         goto -> bb20;
-+         assert(const false, "`async fn` resumed after async drop") -> [success: bb106, unwind: bb105];
++         assert(const false, "`async fn` resumed after async drop") -> [success: bb105, unwind: bb104];
       }
   
--     bb107 (cleanup): {
+-     bb106 (cleanup): {
 -         StorageDead(_78);
 -         goto -> bb33;
-+     bb107: {
++     bb106: {
 +         _183 = move _130;
 +         StorageDead(_130);
-+         goto -> bb106;
++         goto -> bb105;
+      }
+  
+      bb107: {
+-         assert(const false, "`async fn` resumed after async drop") -> [success: bb107, unwind: bb106];
++         _183 = move _137;
++         StorageDead(_137);
++         goto -> bb112;
       }
   
       bb108: {
--         assert(const false, "`async fn` resumed after async drop") -> [success: bb108, unwind: bb107];
-+         _183 = move _137;
-+         StorageDead(_137);
-+         goto -> bb113;
-      }
-  
-      bb109: {
 -         _2 = move _79;
 -         StorageDead(_79);
--         goto -> bb108;
+-         goto -> bb107;
 +         StorageLive(_137);
 +         _0 = Poll::<()>::Pending;
 +         StorageDead(_137);
@@ -1193,89 +1188,89 @@
 +         return;
       }
   
-      bb110: {
+      bb109: {
 -         _2 = move _79;
 -         StorageDead(_79);
--         goto -> bb115;
+-         goto -> bb114;
 +         _139 = discriminant(_138);
-+         switchInt(move _139) -> [0: bb104, 1: bb109, otherwise: bb35];
++         switchInt(move _139) -> [0: bb103, 1: bb108, otherwise: bb34];
+      }
+  
+      bb110: {
+-         StorageLive(_79);
+-         _79 = yield(const ()) -> [resume: bb108, drop: bb109];
++         _138 = <impl Future<Output = ()> as Future>::poll(move _140, move _141) -> [return: bb109, unwind: bb104];
       }
   
       bb111: {
--         StorageLive(_79);
--         _79 = yield(const ()) -> [resume: bb109, drop: bb110];
-+         _138 = <impl Future<Output = ()> as Future>::poll(move _140, move _141) -> [return: bb110, unwind: bb105];
+-         _81 = discriminant(_80);
+-         switchInt(move _81) -> [0: bb105, 1: bb110, otherwise: bb50];
++         _142 = move _183;
++         _141 = copy (_142.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
++         goto -> bb110;
       }
   
       bb112: {
--         _81 = discriminant(_80);
--         switchInt(move _81) -> [0: bb106, 1: bb111, otherwise: bb51];
-+         _142 = move _183;
-+         _141 = copy (_142.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
-+         goto -> bb111;
+-         _80 = <impl Future<Output = ()> as Future>::poll(move _82, move _83) -> [return: bb111, unwind: bb106];
++         _143 = &mut (((*_182) as variant#16).5: impl std::future::Future<Output = ()>);
++         _140 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _143) -> [return: bb111, unwind: bb104];
       }
   
       bb113: {
--         _80 = <impl Future<Output = ()> as Future>::poll(move _82, move _83) -> [return: bb112, unwind: bb107];
-+         _143 = &mut (((*_182) as variant#16).5: impl std::future::Future<Output = ()>);
-+         _140 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _143) -> [return: bb112, unwind: bb105];
+-         _84 = move _2;
+-         _83 = std::future::get_context::<'_, '_>(move _84) -> [return: bb112, unwind: bb106];
++         nop;
++         (((*_182) as variant#16).5: impl std::future::Future<Output = ()>) = async_drop_in_place::<AsyncStruct>(copy (_144.0: &mut AsyncStruct)) -> [return: bb112, unwind: bb104];
       }
   
       bb114: {
--         _84 = move _2;
--         _83 = std::future::get_context::<'_, '_>(move _84) -> [return: bb113, unwind: bb107];
-+         nop;
-+         (((*_182) as variant#16).5: impl std::future::Future<Output = ()>) = async_drop_in_place::<AsyncStruct>(copy (_144.0: &mut AsyncStruct)) -> [return: bb113, unwind: bb105];
+-         _85 = &mut _78;
+-         _82 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _85) -> [return: bb113, unwind: bb106];
++         _145 = &mut (((*_182) as variant#16).4: AsyncStruct);
++         _144 = Pin::<&mut AsyncStruct>::new_unchecked(move _145) -> [return: bb113, unwind: bb25];
       }
   
       bb115: {
--         _85 = &mut _78;
--         _82 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _85) -> [return: bb114, unwind: bb107];
-+         _145 = &mut (((*_182) as variant#16).4: AsyncStruct);
-+         _144 = Pin::<&mut AsyncStruct>::new_unchecked(move _145) -> [return: bb114, unwind: bb26];
-      }
-  
-      bb116: {
 -         _2 = move _86;
 -         StorageDead(_86);
--         goto -> bb122;
+-         goto -> bb121;
 +         nop;
 +         goto -> bb11;
       }
   
--     bb117: {
+-     bb116: {
 -         _2 = move _86;
 -         StorageDead(_86);
--         goto -> bb115;
-+     bb117 (cleanup): {
+-         goto -> bb114;
++     bb116 (cleanup): {
 +         nop;
-+         goto -> bb27;
++         goto -> bb26;
+      }
+  
+      bb117: {
+-         StorageLive(_86);
+-         _86 = yield(const ()) -> [resume: bb115, drop: bb116];
++         assert(const false, "`async fn` resumed after async drop") -> [success: bb117, unwind: bb116];
       }
   
       bb118: {
--         StorageLive(_86);
--         _86 = yield(const ()) -> [resume: bb116, drop: bb117];
-+         assert(const false, "`async fn` resumed after async drop") -> [success: bb118, unwind: bb117];
+-         _88 = discriminant(_87);
+-         switchInt(move _88) -> [0: bb104, 1: bb117, otherwise: bb50];
++         _183 = move _147;
++         StorageDead(_147);
++         goto -> bb117;
       }
   
       bb119: {
--         _88 = discriminant(_87);
--         switchInt(move _88) -> [0: bb105, 1: bb118, otherwise: bb51];
-+         _183 = move _147;
-+         StorageDead(_147);
-+         goto -> bb118;
+-         _87 = <impl Future<Output = ()> as Future>::poll(move _89, move _90) -> [return: bb118, unwind: bb106];
++         _183 = move _154;
++         StorageDead(_154);
++         goto -> bb124;
       }
   
       bb120: {
--         _87 = <impl Future<Output = ()> as Future>::poll(move _89, move _90) -> [return: bb119, unwind: bb107];
-+         _183 = move _154;
-+         StorageDead(_154);
-+         goto -> bb125;
-      }
-  
-      bb121: {
 -         _91 = move _2;
--         _90 = std::future::get_context::<'_, '_>(move _91) -> [return: bb120, unwind: bb107];
+-         _90 = std::future::get_context::<'_, '_>(move _91) -> [return: bb119, unwind: bb106];
 +         StorageLive(_154);
 +         _0 = Poll::<()>::Pending;
 +         StorageDead(_154);
@@ -1283,89 +1278,89 @@
 +         return;
       }
   
-      bb122: {
+      bb121: {
 -         _92 = &mut _78;
--         _89 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _92) -> [return: bb121, unwind: bb107];
+-         _89 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _92) -> [return: bb120, unwind: bb106];
 +         _156 = discriminant(_155);
-+         switchInt(move _156) -> [0: bb116, 1: bb121, otherwise: bb35];
++         switchInt(move _156) -> [0: bb115, 1: bb120, otherwise: bb34];
+      }
+  
+      bb122: {
+-         StorageLive(_78);
+-         _78 = async_drop_in_place::<AsyncInt>(copy (_93.0: &mut AsyncInt)) -> [return: bb121, unwind: bb106];
++         _155 = <impl Future<Output = ()> as Future>::poll(move _157, move _158) -> [return: bb121, unwind: bb116];
       }
   
       bb123: {
--         StorageLive(_78);
--         _78 = async_drop_in_place::<AsyncInt>(copy (_93.0: &mut AsyncInt)) -> [return: bb122, unwind: bb107];
-+         _155 = <impl Future<Output = ()> as Future>::poll(move _157, move _158) -> [return: bb122, unwind: bb117];
+-         _94 = &mut _19;
+-         _93 = Pin::<&mut AsyncInt>::new_unchecked(move _94) -> [return: bb122, unwind: bb33];
++         _159 = move _183;
++         _158 = copy (_159.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
++         goto -> bb122;
       }
   
       bb124: {
--         _94 = &mut _19;
--         _93 = Pin::<&mut AsyncInt>::new_unchecked(move _94) -> [return: bb123, unwind: bb33];
-+         _159 = move _183;
-+         _158 = copy (_159.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
-+         goto -> bb123;
+-         StorageDead(_95);
+-         goto -> bb8;
++         _160 = &mut (((*_182) as variant#18).4: impl std::future::Future<Output = ()>);
++         _157 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _160) -> [return: bb123, unwind: bb116];
       }
   
       bb125: {
 -         StorageDead(_95);
--         goto -> bb8;
-+         _160 = &mut (((*_182) as variant#18).4: impl std::future::Future<Output = ()>);
-+         _157 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _160) -> [return: bb124, unwind: bb117];
-      }
-  
-      bb126: {
--         StorageDead(_95);
 -         goto -> bb21;
 +         nop;
-+         (((*_182) as variant#18).4: impl std::future::Future<Output = ()>) = async_drop_in_place::<[AsyncInt; 2]>(copy (_161.0: &mut [AsyncInt; 2])) -> [return: bb125, unwind: bb117];
++         (((*_182) as variant#18).4: impl std::future::Future<Output = ()>) = async_drop_in_place::<[AsyncInt; 2]>(copy (_161.0: &mut [AsyncInt; 2])) -> [return: bb124, unwind: bb116];
       }
   
--     bb127 (cleanup): {
+-     bb126 (cleanup): {
 -         StorageDead(_95);
--         goto -> bb37;
-+     bb127: {
+-         goto -> bb36;
++     bb126: {
 +         _162 = &mut (((*_182) as variant#18).3: [AsyncInt; 2]);
-+         _161 = Pin::<&mut [AsyncInt; 2]>::new_unchecked(move _162) -> [return: bb126, unwind: bb27];
++         _161 = Pin::<&mut [AsyncInt; 2]>::new_unchecked(move _162) -> [return: bb125, unwind: bb26];
       }
   
-      bb128: {
--         assert(const false, "`async fn` resumed after async drop") -> [success: bb128, unwind: bb127];
+      bb127: {
+-         assert(const false, "`async fn` resumed after async drop") -> [success: bb127, unwind: bb126];
 +         nop;
 +         goto -> bb12;
       }
   
--     bb129: {
+-     bb128: {
 -         _2 = move _96;
 -         StorageDead(_96);
--         goto -> bb128;
-+     bb129 (cleanup): {
+-         goto -> bb127;
++     bb128 (cleanup): {
 +         nop;
-+         goto -> bb28;
++         goto -> bb27;
+      }
+  
+      bb129: {
+-         _2 = move _96;
+-         StorageDead(_96);
+-         goto -> bb134;
++         assert(const false, "`async fn` resumed after async drop") -> [success: bb129, unwind: bb128];
       }
   
       bb130: {
--         _2 = move _96;
--         StorageDead(_96);
--         goto -> bb135;
-+         assert(const false, "`async fn` resumed after async drop") -> [success: bb130, unwind: bb129];
+-         StorageLive(_96);
+-         _96 = yield(const ()) -> [resume: bb128, drop: bb129];
++         _183 = move _164;
++         StorageDead(_164);
++         goto -> bb129;
       }
   
       bb131: {
--         StorageLive(_96);
--         _96 = yield(const ()) -> [resume: bb129, drop: bb130];
-+         _183 = move _164;
-+         StorageDead(_164);
-+         goto -> bb130;
+-         _98 = discriminant(_97);
+-         switchInt(move _98) -> [0: bb125, 1: bb130, otherwise: bb50];
++         _183 = move _171;
++         StorageDead(_171);
++         goto -> bb136;
       }
   
       bb132: {
--         _98 = discriminant(_97);
--         switchInt(move _98) -> [0: bb126, 1: bb131, otherwise: bb51];
-+         _183 = move _171;
-+         StorageDead(_171);
-+         goto -> bb137;
-      }
-  
-      bb133: {
--         _97 = <impl Future<Output = ()> as Future>::poll(move _99, move _100) -> [return: bb132, unwind: bb127];
+-         _97 = <impl Future<Output = ()> as Future>::poll(move _99, move _100) -> [return: bb131, unwind: bb126];
 +         StorageLive(_171);
 +         _0 = Poll::<()>::Pending;
 +         StorageDead(_171);
@@ -1373,551 +1368,551 @@
 +         return;
       }
   
-      bb134: {
+      bb133: {
 -         _101 = move _2;
--         _100 = std::future::get_context::<'_, '_>(move _101) -> [return: bb133, unwind: bb127];
+-         _100 = std::future::get_context::<'_, '_>(move _101) -> [return: bb132, unwind: bb126];
 +         _173 = discriminant(_172);
-+         switchInt(move _173) -> [0: bb128, 1: bb133, otherwise: bb35];
++         switchInt(move _173) -> [0: bb127, 1: bb132, otherwise: bb34];
+      }
+  
+      bb134: {
+-         _102 = &mut _95;
+-         _99 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _102) -> [return: bb133, unwind: bb126];
++         _172 = <impl Future<Output = ()> as Future>::poll(move _174, move _175) -> [return: bb133, unwind: bb128];
       }
   
       bb135: {
--         _102 = &mut _95;
--         _99 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _102) -> [return: bb134, unwind: bb127];
-+         _172 = <impl Future<Output = ()> as Future>::poll(move _174, move _175) -> [return: bb134, unwind: bb129];
+-         _2 = move _103;
+-         StorageDead(_103);
+-         goto -> bb141;
++         _176 = move _183;
++         _175 = copy (_176.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
++         goto -> bb134;
       }
   
       bb136: {
 -         _2 = move _103;
 -         StorageDead(_103);
--         goto -> bb142;
-+         _176 = move _183;
-+         _175 = copy (_176.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
-+         goto -> bb135;
+-         goto -> bb134;
++         _177 = &mut (((*_182) as variant#20).3: impl std::future::Future<Output = ()>);
++         _174 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _177) -> [return: bb135, unwind: bb128];
       }
   
       bb137: {
--         _2 = move _103;
--         StorageDead(_103);
--         goto -> bb135;
-+         _177 = &mut (((*_182) as variant#20).3: impl std::future::Future<Output = ()>);
-+         _174 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _177) -> [return: bb136, unwind: bb129];
+-         StorageLive(_103);
+-         _103 = yield(const ()) -> [resume: bb135, drop: bb136];
++         nop;
++         (((*_182) as variant#20).3: impl std::future::Future<Output = ()>) = async_drop_in_place::<AsyncInt>(copy (_178.0: &mut AsyncInt)) -> [return: bb136, unwind: bb128];
       }
   
       bb138: {
--         StorageLive(_103);
--         _103 = yield(const ()) -> [resume: bb136, drop: bb137];
-+         nop;
-+         (((*_182) as variant#20).3: impl std::future::Future<Output = ()>) = async_drop_in_place::<AsyncInt>(copy (_178.0: &mut AsyncInt)) -> [return: bb137, unwind: bb129];
+-         _105 = discriminant(_104);
+-         switchInt(move _105) -> [0: bb124, 1: bb137, otherwise: bb50];
++         _179 = &mut (((*_182) as variant#20).2: AsyncInt);
++         _178 = Pin::<&mut AsyncInt>::new_unchecked(move _179) -> [return: bb137, unwind: bb27];
       }
   
       bb139: {
--         _105 = discriminant(_104);
--         switchInt(move _105) -> [0: bb125, 1: bb138, otherwise: bb51];
-+         _179 = &mut (((*_182) as variant#20).2: AsyncInt);
-+         _178 = Pin::<&mut AsyncInt>::new_unchecked(move _179) -> [return: bb138, unwind: bb28];
-      }
-  
-      bb140: {
--         _104 = <impl Future<Output = ()> as Future>::poll(move _106, move _107) -> [return: bb139, unwind: bb127];
+-         _104 = <impl Future<Output = ()> as Future>::poll(move _106, move _107) -> [return: bb138, unwind: bb126];
 +         goto -> bb14;
       }
   
--     bb141: {
+-     bb140: {
 -         _108 = move _2;
--         _107 = std::future::get_context::<'_, '_>(move _108) -> [return: bb140, unwind: bb127];
-+     bb141 (cleanup): {
+-         _107 = std::future::get_context::<'_, '_>(move _108) -> [return: bb139, unwind: bb126];
++     bb140 (cleanup): {
 +         discriminant((*_182)) = 2;
 +         resume;
       }
   
-      bb142: {
+      bb141: {
 -         _109 = &mut _95;
--         _106 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _109) -> [return: bb141, unwind: bb127];
+-         _106 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _109) -> [return: bb140, unwind: bb126];
 +         StorageLive(_17);
 +         StorageLive(_23);
 +         StorageLive(_25);
 +         StorageLive(_28);
 +         _28 = move _183;
-+         goto -> bb34;
++         goto -> bb33;
       }
   
-      bb143: {
+      bb142: {
 -         StorageLive(_95);
--         _95 = async_drop_in_place::<AsyncEnum>(copy (_110.0: &mut AsyncEnum)) -> [return: bb142, unwind: bb127];
+-         _95 = async_drop_in_place::<AsyncEnum>(copy (_110.0: &mut AsyncEnum)) -> [return: bb141, unwind: bb126];
 +         StorageLive(_17);
 +         StorageLive(_23);
 +         StorageLive(_25);
 +         StorageLive(_35);
 +         _35 = move _183;
-+         goto -> bb36;
++         goto -> bb35;
       }
   
-      bb144: {
+      bb143: {
 -         _111 = &mut _15;
--         _110 = Pin::<&mut AsyncEnum>::new_unchecked(move _111) -> [return: bb143, unwind: bb37];
+-         _110 = Pin::<&mut AsyncEnum>::new_unchecked(move _111) -> [return: bb142, unwind: bb36];
 +         StorageLive(_17);
 +         StorageLive(_23);
 +         StorageLive(_45);
 +         _45 = move _183;
-+         goto -> bb47;
++         goto -> bb46;
       }
   
-      bb145: {
+      bb144: {
 -         StorageDead(_112);
 -         goto -> bb9;
 +         StorageLive(_17);
 +         StorageLive(_23);
 +         StorageLive(_52);
 +         _52 = move _183;
-+         goto -> bb48;
++         goto -> bb47;
       }
   
-      bb146: {
+      bb145: {
 -         StorageDead(_112);
 -         goto -> bb22;
 +         StorageLive(_17);
 +         StorageLive(_62);
 +         _62 = move _183;
-+         goto -> bb59;
++         goto -> bb58;
       }
   
--     bb147 (cleanup): {
+-     bb146 (cleanup): {
 -         StorageDead(_112);
--         goto -> bb38;
-+     bb147: {
+-         goto -> bb37;
++     bb146: {
 +         StorageLive(_17);
 +         StorageLive(_69);
 +         _69 = move _183;
-+         goto -> bb60;
++         goto -> bb59;
       }
   
-      bb148: {
--         assert(const false, "`async fn` resumed after async drop") -> [success: bb148, unwind: bb147];
+      bb147: {
+-         assert(const false, "`async fn` resumed after async drop") -> [success: bb147, unwind: bb146];
 +         StorageLive(_17);
 +         StorageLive(_79);
 +         _79 = move _183;
++         goto -> bb70;
+      }
+  
+      bb148: {
+-         _2 = move _113;
+-         StorageDead(_113);
+-         goto -> bb147;
++         StorageLive(_17);
++         StorageLive(_86);
++         _86 = move _183;
 +         goto -> bb71;
       }
   
       bb149: {
 -         _2 = move _113;
 -         StorageDead(_113);
--         goto -> bb148;
-+         StorageLive(_17);
-+         StorageLive(_86);
-+         _86 = move _183;
-+         goto -> bb72;
+-         goto -> bb154;
++         StorageLive(_96);
++         _96 = move _183;
++         goto -> bb82;
       }
   
       bb150: {
--         _2 = move _113;
--         StorageDead(_113);
--         goto -> bb155;
-+         StorageLive(_96);
-+         _96 = move _183;
+-         StorageLive(_113);
+-         _113 = yield(const ()) -> [resume: bb148, drop: bb149];
++         StorageLive(_103);
++         _103 = move _183;
 +         goto -> bb83;
       }
   
       bb151: {
--         StorageLive(_113);
--         _113 = yield(const ()) -> [resume: bb149, drop: bb150];
-+         StorageLive(_103);
-+         _103 = move _183;
-+         goto -> bb84;
+-         _115 = discriminant(_114);
+-         switchInt(move _115) -> [0: bb145, 1: bb150, otherwise: bb50];
++         StorageLive(_113);
++         _113 = move _183;
++         goto -> bb94;
       }
   
       bb152: {
--         _115 = discriminant(_114);
--         switchInt(move _115) -> [0: bb146, 1: bb151, otherwise: bb51];
-+         StorageLive(_113);
-+         _113 = move _183;
+-         _114 = <impl Future<Output = ()> as Future>::poll(move _116, move _117) -> [return: bb151, unwind: bb146];
++         StorageLive(_120);
++         _120 = move _183;
 +         goto -> bb95;
       }
   
       bb153: {
--         _114 = <impl Future<Output = ()> as Future>::poll(move _116, move _117) -> [return: bb152, unwind: bb147];
-+         StorageLive(_120);
-+         _120 = move _183;
-+         goto -> bb96;
+-         _118 = move _2;
+-         _117 = std::future::get_context::<'_, '_>(move _118) -> [return: bb152, unwind: bb146];
++         StorageLive(_130);
++         _130 = move _183;
++         goto -> bb106;
       }
   
       bb154: {
--         _118 = move _2;
--         _117 = std::future::get_context::<'_, '_>(move _118) -> [return: bb153, unwind: bb147];
-+         StorageLive(_130);
-+         _130 = move _183;
+-         _119 = &mut _112;
+-         _116 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _119) -> [return: bb153, unwind: bb146];
++         StorageLive(_137);
++         _137 = move _183;
 +         goto -> bb107;
       }
   
       bb155: {
--         _119 = &mut _112;
--         _116 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _119) -> [return: bb154, unwind: bb147];
-+         StorageLive(_137);
-+         _137 = move _183;
-+         goto -> bb108;
+-         _2 = move _120;
+-         StorageDead(_120);
+-         goto -> bb161;
++         StorageLive(_147);
++         _147 = move _183;
++         goto -> bb118;
       }
   
       bb156: {
 -         _2 = move _120;
 -         StorageDead(_120);
--         goto -> bb162;
-+         StorageLive(_147);
-+         _147 = move _183;
+-         goto -> bb154;
++         StorageLive(_154);
++         _154 = move _183;
 +         goto -> bb119;
       }
   
       bb157: {
--         _2 = move _120;
--         StorageDead(_120);
--         goto -> bb155;
-+         StorageLive(_154);
-+         _154 = move _183;
-+         goto -> bb120;
+-         StorageLive(_120);
+-         _120 = yield(const ()) -> [resume: bb155, drop: bb156];
++         StorageLive(_164);
++         _164 = move _183;
++         goto -> bb130;
       }
   
       bb158: {
--         StorageLive(_120);
--         _120 = yield(const ()) -> [resume: bb156, drop: bb157];
-+         StorageLive(_164);
-+         _164 = move _183;
+-         _122 = discriminant(_121);
+-         switchInt(move _122) -> [0: bb144, 1: bb157, otherwise: bb50];
++         StorageLive(_171);
++         _171 = move _183;
 +         goto -> bb131;
       }
   
       bb159: {
--         _122 = discriminant(_121);
--         switchInt(move _122) -> [0: bb145, 1: bb158, otherwise: bb51];
-+         StorageLive(_171);
-+         _171 = move _183;
-+         goto -> bb132;
+-         _121 = <impl Future<Output = ()> as Future>::poll(move _123, move _124) -> [return: bb158, unwind: bb146];
++         assert(const false, "`async fn` resumed after panicking") -> [success: bb159, unwind continue];
       }
   
       bb160: {
--         _121 = <impl Future<Output = ()> as Future>::poll(move _123, move _124) -> [return: bb159, unwind: bb147];
-+         assert(const false, "`async fn` resumed after panicking") -> [success: bb160, unwind continue];
+-         _125 = move _2;
+-         _124 = std::future::get_context::<'_, '_>(move _125) -> [return: bb159, unwind: bb146];
++         assert(const false, "`async fn` resumed after completion") -> [success: bb160, unwind continue];
       }
   
       bb161: {
--         _125 = move _2;
--         _124 = std::future::get_context::<'_, '_>(move _125) -> [return: bb160, unwind: bb147];
-+         assert(const false, "`async fn` resumed after completion") -> [success: bb161, unwind continue];
-      }
-  
-      bb162: {
 -         _126 = &mut _112;
--         _123 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _126) -> [return: bb161, unwind: bb147];
+-         _123 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _126) -> [return: bb160, unwind: bb146];
+-     }
+- 
+-     bb162: {
+-         StorageLive(_112);
+-         _112 = async_drop_in_place::<SyncThenAsync>(copy (_127.0: &mut SyncThenAsync)) -> [return: bb161, unwind: bb146];
 -     }
 - 
 -     bb163: {
--         StorageLive(_112);
--         _112 = async_drop_in_place::<SyncThenAsync>(copy (_127.0: &mut SyncThenAsync)) -> [return: bb162, unwind: bb147];
+-         _128 = &mut _11;
+-         _127 = Pin::<&mut SyncThenAsync>::new_unchecked(move _128) -> [return: bb162, unwind: bb37];
 -     }
 - 
 -     bb164: {
--         _128 = &mut _11;
--         _127 = Pin::<&mut SyncThenAsync>::new_unchecked(move _128) -> [return: bb163, unwind: bb38];
--     }
-- 
--     bb165: {
 -         StorageDead(_129);
 -         goto -> bb10;
 -     }
 - 
--     bb166: {
+-     bb165: {
 -         StorageDead(_129);
 -         goto -> bb23;
 -     }
 - 
--     bb167 (cleanup): {
+-     bb166 (cleanup): {
 -         StorageDead(_129);
--         goto -> bb39;
+-         goto -> bb38;
+-     }
+- 
+-     bb167: {
+-         assert(const false, "`async fn` resumed after async drop") -> [success: bb167, unwind: bb166];
 -     }
 - 
 -     bb168: {
--         assert(const false, "`async fn` resumed after async drop") -> [success: bb168, unwind: bb167];
+-         _2 = move _130;
+-         StorageDead(_130);
+-         goto -> bb167;
 -     }
 - 
 -     bb169: {
 -         _2 = move _130;
 -         StorageDead(_130);
--         goto -> bb168;
+-         goto -> bb174;
 -     }
 - 
 -     bb170: {
--         _2 = move _130;
--         StorageDead(_130);
--         goto -> bb175;
+-         StorageLive(_130);
+-         _130 = yield(const ()) -> [resume: bb168, drop: bb169];
 -     }
 - 
 -     bb171: {
--         StorageLive(_130);
--         _130 = yield(const ()) -> [resume: bb169, drop: bb170];
+-         _132 = discriminant(_131);
+-         switchInt(move _132) -> [0: bb165, 1: bb170, otherwise: bb50];
 -     }
 - 
 -     bb172: {
--         _132 = discriminant(_131);
--         switchInt(move _132) -> [0: bb166, 1: bb171, otherwise: bb51];
+-         _131 = <impl Future<Output = ()> as Future>::poll(move _133, move _134) -> [return: bb171, unwind: bb166];
 -     }
 - 
 -     bb173: {
--         _131 = <impl Future<Output = ()> as Future>::poll(move _133, move _134) -> [return: bb172, unwind: bb167];
+-         _135 = move _2;
+-         _134 = std::future::get_context::<'_, '_>(move _135) -> [return: bb172, unwind: bb166];
 -     }
 - 
 -     bb174: {
--         _135 = move _2;
--         _134 = std::future::get_context::<'_, '_>(move _135) -> [return: bb173, unwind: bb167];
+-         _136 = &mut _129;
+-         _133 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _136) -> [return: bb173, unwind: bb166];
 -     }
 - 
 -     bb175: {
--         _136 = &mut _129;
--         _133 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _136) -> [return: bb174, unwind: bb167];
+-         _2 = move _137;
+-         StorageDead(_137);
+-         goto -> bb181;
 -     }
 - 
 -     bb176: {
 -         _2 = move _137;
 -         StorageDead(_137);
--         goto -> bb182;
+-         goto -> bb174;
 -     }
 - 
 -     bb177: {
--         _2 = move _137;
--         StorageDead(_137);
--         goto -> bb175;
+-         StorageLive(_137);
+-         _137 = yield(const ()) -> [resume: bb175, drop: bb176];
 -     }
 - 
 -     bb178: {
--         StorageLive(_137);
--         _137 = yield(const ()) -> [resume: bb176, drop: bb177];
+-         _139 = discriminant(_138);
+-         switchInt(move _139) -> [0: bb164, 1: bb177, otherwise: bb50];
 -     }
 - 
 -     bb179: {
--         _139 = discriminant(_138);
--         switchInt(move _139) -> [0: bb165, 1: bb178, otherwise: bb51];
+-         _138 = <impl Future<Output = ()> as Future>::poll(move _140, move _141) -> [return: bb178, unwind: bb166];
 -     }
 - 
 -     bb180: {
--         _138 = <impl Future<Output = ()> as Future>::poll(move _140, move _141) -> [return: bb179, unwind: bb167];
+-         _142 = move _2;
+-         _141 = std::future::get_context::<'_, '_>(move _142) -> [return: bb179, unwind: bb166];
 -     }
 - 
 -     bb181: {
--         _142 = move _2;
--         _141 = std::future::get_context::<'_, '_>(move _142) -> [return: bb180, unwind: bb167];
+-         _143 = &mut _129;
+-         _140 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _143) -> [return: bb180, unwind: bb166];
 -     }
 - 
 -     bb182: {
--         _143 = &mut _129;
--         _140 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _143) -> [return: bb181, unwind: bb167];
+-         StorageLive(_129);
+-         _129 = async_drop_in_place::<AsyncStruct>(copy (_144.0: &mut AsyncStruct)) -> [return: bb181, unwind: bb166];
 -     }
 - 
 -     bb183: {
--         StorageLive(_129);
--         _129 = async_drop_in_place::<AsyncStruct>(copy (_144.0: &mut AsyncStruct)) -> [return: bb182, unwind: bb167];
+-         _145 = &mut _8;
+-         _144 = Pin::<&mut AsyncStruct>::new_unchecked(move _145) -> [return: bb182, unwind: bb38];
 -     }
 - 
 -     bb184: {
--         _145 = &mut _8;
--         _144 = Pin::<&mut AsyncStruct>::new_unchecked(move _145) -> [return: bb183, unwind: bb39];
--     }
-- 
--     bb185: {
 -         StorageDead(_146);
 -         goto -> bb11;
 -     }
 - 
--     bb186: {
+-     bb185: {
 -         StorageDead(_146);
 -         goto -> bb24;
 -     }
 - 
--     bb187 (cleanup): {
+-     bb186 (cleanup): {
 -         StorageDead(_146);
--         goto -> bb40;
+-         goto -> bb39;
+-     }
+- 
+-     bb187: {
+-         assert(const false, "`async fn` resumed after async drop") -> [success: bb187, unwind: bb186];
 -     }
 - 
 -     bb188: {
--         assert(const false, "`async fn` resumed after async drop") -> [success: bb188, unwind: bb187];
+-         _2 = move _147;
+-         StorageDead(_147);
+-         goto -> bb187;
 -     }
 - 
 -     bb189: {
 -         _2 = move _147;
 -         StorageDead(_147);
--         goto -> bb188;
+-         goto -> bb194;
 -     }
 - 
 -     bb190: {
--         _2 = move _147;
--         StorageDead(_147);
--         goto -> bb195;
+-         StorageLive(_147);
+-         _147 = yield(const ()) -> [resume: bb188, drop: bb189];
 -     }
 - 
 -     bb191: {
--         StorageLive(_147);
--         _147 = yield(const ()) -> [resume: bb189, drop: bb190];
+-         _149 = discriminant(_148);
+-         switchInt(move _149) -> [0: bb185, 1: bb190, otherwise: bb50];
 -     }
 - 
 -     bb192: {
--         _149 = discriminant(_148);
--         switchInt(move _149) -> [0: bb186, 1: bb191, otherwise: bb51];
+-         _148 = <impl Future<Output = ()> as Future>::poll(move _150, move _151) -> [return: bb191, unwind: bb186];
 -     }
 - 
 -     bb193: {
--         _148 = <impl Future<Output = ()> as Future>::poll(move _150, move _151) -> [return: bb192, unwind: bb187];
+-         _152 = move _2;
+-         _151 = std::future::get_context::<'_, '_>(move _152) -> [return: bb192, unwind: bb186];
 -     }
 - 
 -     bb194: {
--         _152 = move _2;
--         _151 = std::future::get_context::<'_, '_>(move _152) -> [return: bb193, unwind: bb187];
+-         _153 = &mut _146;
+-         _150 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _153) -> [return: bb193, unwind: bb186];
 -     }
 - 
 -     bb195: {
--         _153 = &mut _146;
--         _150 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _153) -> [return: bb194, unwind: bb187];
+-         _2 = move _154;
+-         StorageDead(_154);
+-         goto -> bb201;
 -     }
 - 
 -     bb196: {
 -         _2 = move _154;
 -         StorageDead(_154);
--         goto -> bb202;
+-         goto -> bb194;
 -     }
 - 
 -     bb197: {
--         _2 = move _154;
--         StorageDead(_154);
--         goto -> bb195;
+-         StorageLive(_154);
+-         _154 = yield(const ()) -> [resume: bb195, drop: bb196];
 -     }
 - 
 -     bb198: {
--         StorageLive(_154);
--         _154 = yield(const ()) -> [resume: bb196, drop: bb197];
+-         _156 = discriminant(_155);
+-         switchInt(move _156) -> [0: bb184, 1: bb197, otherwise: bb50];
 -     }
 - 
 -     bb199: {
--         _156 = discriminant(_155);
--         switchInt(move _156) -> [0: bb185, 1: bb198, otherwise: bb51];
+-         _155 = <impl Future<Output = ()> as Future>::poll(move _157, move _158) -> [return: bb198, unwind: bb186];
 -     }
 - 
 -     bb200: {
--         _155 = <impl Future<Output = ()> as Future>::poll(move _157, move _158) -> [return: bb199, unwind: bb187];
+-         _159 = move _2;
+-         _158 = std::future::get_context::<'_, '_>(move _159) -> [return: bb199, unwind: bb186];
 -     }
 - 
 -     bb201: {
--         _159 = move _2;
--         _158 = std::future::get_context::<'_, '_>(move _159) -> [return: bb200, unwind: bb187];
+-         _160 = &mut _146;
+-         _157 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _160) -> [return: bb200, unwind: bb186];
 -     }
 - 
 -     bb202: {
--         _160 = &mut _146;
--         _157 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _160) -> [return: bb201, unwind: bb187];
+-         StorageLive(_146);
+-         _146 = async_drop_in_place::<[AsyncInt; 2]>(copy (_161.0: &mut [AsyncInt; 2])) -> [return: bb201, unwind: bb186];
 -     }
 - 
 -     bb203: {
--         StorageLive(_146);
--         _146 = async_drop_in_place::<[AsyncInt; 2]>(copy (_161.0: &mut [AsyncInt; 2])) -> [return: bb202, unwind: bb187];
+-         _162 = &mut _5;
+-         _161 = Pin::<&mut [AsyncInt; 2]>::new_unchecked(move _162) -> [return: bb202, unwind: bb39];
 -     }
 - 
 -     bb204: {
--         _162 = &mut _5;
--         _161 = Pin::<&mut [AsyncInt; 2]>::new_unchecked(move _162) -> [return: bb203, unwind: bb40];
--     }
-- 
--     bb205: {
 -         StorageDead(_163);
 -         goto -> bb12;
 -     }
 - 
--     bb206: {
+-     bb205: {
 -         StorageDead(_163);
 -         goto -> bb25;
 -     }
 - 
--     bb207 (cleanup): {
+-     bb206 (cleanup): {
 -         StorageDead(_163);
--         goto -> bb41;
+-         goto -> bb40;
+-     }
+- 
+-     bb207: {
+-         assert(const false, "`async fn` resumed after async drop") -> [success: bb207, unwind: bb206];
 -     }
 - 
 -     bb208: {
--         assert(const false, "`async fn` resumed after async drop") -> [success: bb208, unwind: bb207];
+-         _2 = move _164;
+-         StorageDead(_164);
+-         goto -> bb207;
 -     }
 - 
 -     bb209: {
 -         _2 = move _164;
 -         StorageDead(_164);
--         goto -> bb208;
+-         goto -> bb214;
 -     }
 - 
 -     bb210: {
--         _2 = move _164;
--         StorageDead(_164);
--         goto -> bb215;
+-         StorageLive(_164);
+-         _164 = yield(const ()) -> [resume: bb208, drop: bb209];
 -     }
 - 
 -     bb211: {
--         StorageLive(_164);
--         _164 = yield(const ()) -> [resume: bb209, drop: bb210];
+-         _166 = discriminant(_165);
+-         switchInt(move _166) -> [0: bb205, 1: bb210, otherwise: bb50];
 -     }
 - 
 -     bb212: {
--         _166 = discriminant(_165);
--         switchInt(move _166) -> [0: bb206, 1: bb211, otherwise: bb51];
+-         _165 = <impl Future<Output = ()> as Future>::poll(move _167, move _168) -> [return: bb211, unwind: bb206];
 -     }
 - 
 -     bb213: {
--         _165 = <impl Future<Output = ()> as Future>::poll(move _167, move _168) -> [return: bb212, unwind: bb207];
+-         _169 = move _2;
+-         _168 = std::future::get_context::<'_, '_>(move _169) -> [return: bb212, unwind: bb206];
 -     }
 - 
 -     bb214: {
--         _169 = move _2;
--         _168 = std::future::get_context::<'_, '_>(move _169) -> [return: bb213, unwind: bb207];
+-         _170 = &mut _163;
+-         _167 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _170) -> [return: bb213, unwind: bb206];
 -     }
 - 
 -     bb215: {
--         _170 = &mut _163;
--         _167 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _170) -> [return: bb214, unwind: bb207];
+-         _2 = move _171;
+-         StorageDead(_171);
+-         goto -> bb221;
 -     }
 - 
 -     bb216: {
 -         _2 = move _171;
 -         StorageDead(_171);
--         goto -> bb222;
+-         goto -> bb214;
 -     }
 - 
 -     bb217: {
--         _2 = move _171;
--         StorageDead(_171);
--         goto -> bb215;
+-         StorageLive(_171);
+-         _171 = yield(const ()) -> [resume: bb215, drop: bb216];
 -     }
 - 
 -     bb218: {
--         StorageLive(_171);
--         _171 = yield(const ()) -> [resume: bb216, drop: bb217];
+-         _173 = discriminant(_172);
+-         switchInt(move _173) -> [0: bb204, 1: bb217, otherwise: bb50];
 -     }
 - 
 -     bb219: {
--         _173 = discriminant(_172);
--         switchInt(move _173) -> [0: bb205, 1: bb218, otherwise: bb51];
+-         _172 = <impl Future<Output = ()> as Future>::poll(move _174, move _175) -> [return: bb218, unwind: bb206];
 -     }
 - 
 -     bb220: {
--         _172 = <impl Future<Output = ()> as Future>::poll(move _174, move _175) -> [return: bb219, unwind: bb207];
+-         _176 = move _2;
+-         _175 = std::future::get_context::<'_, '_>(move _176) -> [return: bb219, unwind: bb206];
 -     }
 - 
 -     bb221: {
--         _176 = move _2;
--         _175 = std::future::get_context::<'_, '_>(move _176) -> [return: bb220, unwind: bb207];
+-         _177 = &mut _163;
+-         _174 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _177) -> [return: bb220, unwind: bb206];
 -     }
 - 
 -     bb222: {
--         _177 = &mut _163;
--         _174 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _177) -> [return: bb221, unwind: bb207];
+-         StorageLive(_163);
+-         _163 = async_drop_in_place::<AsyncInt>(copy (_178.0: &mut AsyncInt)) -> [return: bb221, unwind: bb206];
 -     }
 - 
 -     bb223: {
--         StorageLive(_163);
--         _163 = async_drop_in_place::<AsyncInt>(copy (_178.0: &mut AsyncInt)) -> [return: bb222, unwind: bb207];
--     }
-- 
--     bb224: {
 -         _179 = &mut _4;
--         _178 = Pin::<&mut AsyncInt>::new_unchecked(move _179) -> [return: bb223, unwind: bb41];
+-         _178 = Pin::<&mut AsyncInt>::new_unchecked(move _179) -> [return: bb222, unwind: bb40];
 +         nop;
 +         (((*_182) as variant#20).1: SyncInt) = SyncInt(const 0_i32);
 +         nop;

--- a/tests/mir-opt/coroutine/async_drop.elaborate_drops-{closure#0}.StateTransform.diff
+++ b/tests/mir-opt/coroutine/async_drop.elaborate_drops-{closure#0}.StateTransform.diff
@@ -308,83 +308,44 @@
 -         StorageLive(_7);
 -         _7 = AsyncInt(const 2_i32);
 -         _5 = [move _6, move _7];
--         goto -> bb1;
+-         StorageDead(_7);
+-         StorageDead(_6);
+-         StorageLive(_8);
+-         StorageLive(_9);
+-         _9 = AsyncInt(const 5_i32);
+-         StorageLive(_10);
+-         _10 = AsyncInt(const 4_i32);
+-         _8 = AsyncStruct { i: const 3_i32, a: move _10, b: move _9 };
+-         StorageDead(_10);
+-         StorageDead(_9);
+-         StorageLive(_11);
+-         StorageLive(_12);
+-         _12 = AsyncInt(const 7_i32);
+-         StorageLive(_13);
+-         _13 = SyncInt(const 8_i32);
+-         StorageLive(_14);
+-         _14 = AsyncInt(const 9_i32);
+-         _11 = SyncThenAsync { i: const 6_i32, a: move _12, b: move _13, c: move _14 };
+-         StorageDead(_14);
+-         StorageDead(_13);
+-         StorageDead(_12);
+-         StorageLive(_15);
+-         StorageLive(_16);
+-         _16 = AsyncInt(const 10_i32);
+-         _15 = AsyncEnum::A(move _16);
+-         StorageDead(_16);
+-         StorageLive(_17);
+-         StorageLive(_18);
+-         _18 = AsyncInt(const 11_i32);
+-         _17 = ManuallyDrop::<AsyncInt>::new(move _18) -> [return: bb1, unwind: bb34];
 +         _184 = move _2 as std::ptr::NonNull<std::task::Context<'_>> (Transmute);
 +         _183 = std::future::ResumeTy(move _184);
 +         _182 = copy (_1.0: &mut {async fn body of elaborate_drops()});
 +         _181 = discriminant((*_182));
-+         switchInt(move _181) -> [0: bb170, 1: bb169, 2: bb168, 3: bb150, 4: bb151, 5: bb152, 6: bb153, 7: bb154, 8: bb155, 9: bb156, 10: bb157, 11: bb158, 12: bb159, 13: bb160, 14: bb161, 15: bb162, 16: bb163, 17: bb164, 18: bb165, 19: bb166, 20: bb167, otherwise: bb43];
++         switchInt(move _181) -> [0: bb162, 1: bb161, 2: bb160, 3: bb142, 4: bb143, 5: bb144, 6: bb145, 7: bb146, 8: bb147, 9: bb148, 10: bb149, 11: bb150, 12: bb151, 13: bb152, 14: bb153, 15: bb154, 16: bb155, 17: bb156, 18: bb157, 19: bb158, 20: bb159, otherwise: bb35];
       }
   
       bb1: {
-          StorageDead(_7);
-          goto -> bb2;
-      }
-  
-      bb2: {
-          StorageDead(_6);
--         StorageLive(_8);
-+         nop;
-          StorageLive(_9);
-          _9 = AsyncInt(const 5_i32);
-          StorageLive(_10);
-          _10 = AsyncInt(const 4_i32);
--         _8 = AsyncStruct { i: const 3_i32, a: move _10, b: move _9 };
-+         (((*_182) as variant#16).4: AsyncStruct) = AsyncStruct { i: const 3_i32, a: move _10, b: move _9 };
-          goto -> bb3;
-      }
-  
-      bb3: {
-          StorageDead(_10);
-          goto -> bb4;
-      }
-  
-      bb4: {
-          StorageDead(_9);
--         StorageLive(_11);
-+         nop;
-          StorageLive(_12);
-          _12 = AsyncInt(const 7_i32);
-          StorageLive(_13);
-          _13 = SyncInt(const 8_i32);
-          StorageLive(_14);
-          _14 = AsyncInt(const 9_i32);
--         _11 = SyncThenAsync { i: const 6_i32, a: move _12, b: move _13, c: move _14 };
-+         (((*_182) as variant#14).5: SyncThenAsync) = SyncThenAsync { i: const 6_i32, a: move _12, b: move _13, c: move _14 };
-          goto -> bb5;
-      }
-  
-      bb5: {
-          StorageDead(_14);
-          goto -> bb6;
-      }
-  
-      bb6: {
-          StorageDead(_13);
-          goto -> bb7;
-      }
-  
-      bb7: {
-          StorageDead(_12);
--         StorageLive(_15);
-+         nop;
-          StorageLive(_16);
-          _16 = AsyncInt(const 10_i32);
--         _15 = AsyncEnum::A(move _16);
-+         (((*_182) as variant#12).6: AsyncEnum) = AsyncEnum::A(move _16);
-          goto -> bb8;
-      }
-  
-      bb8: {
-          StorageDead(_16);
-          StorageLive(_17);
-          StorageLive(_18);
-          _18 = AsyncInt(const 11_i32);
--         _17 = ManuallyDrop::<AsyncInt>::new(move _18) -> [return: bb9, unwind: bb42];
-+         _17 = ManuallyDrop::<AsyncInt>::new(move _18) -> [return: bb9, unwind: bb29];
-      }
-  
-      bb9: {
           StorageDead(_18);
 -         StorageLive(_19);
 -         _19 = AsyncInt(const 12_i32);
@@ -412,267 +373,267 @@
 -         StorageLive(_26);
 -         _26 = {closure@$DIR/async_drop.rs:86:27: 86:35} { foo: move _25 };
 -         _0 = const ();
--         goto -> bb72;
+-         goto -> bb64;
 +         nop;
 +         (((*_182) as variant#4).10: {async closure@$DIR/async_drop.rs:86:27: 86:35}) = {closure@$DIR/async_drop.rs:86:27: 86:35} { foo: move _25 };
 +         (((*_182) as variant#20).0: ()) = const ();
-+         goto -> bb51;
++         goto -> bb43;
       }
   
-      bb10: {
+      bb2: {
 -         StorageDead(_26);
 +         nop;
-          goto -> bb11;
+          goto -> bb3;
       }
   
-      bb11: {
+      bb3: {
           StorageDead(_25);
--         goto -> bb92;
-+         goto -> bb63;
+-         goto -> bb84;
++         goto -> bb55;
       }
   
-      bb12: {
+      bb4: {
 -         StorageDead(_24);
 +         nop;
-          goto -> bb13;
+          goto -> bb5;
       }
   
-      bb13: {
+      bb5: {
           StorageDead(_23);
--         goto -> bb112;
-+         goto -> bb75;
+-         goto -> bb104;
++         goto -> bb67;
       }
   
-      bb14: {
+      bb6: {
 -         StorageDead(_20);
--         goto -> bb132;
+-         goto -> bb124;
 +         nop;
-+         goto -> bb87;
++         goto -> bb79;
       }
   
-      bb15: {
+      bb7: {
 -         StorageDead(_19);
 +         nop;
           StorageDead(_17);
--         goto -> bb152;
-+         goto -> bb99;
+-         goto -> bb144;
++         goto -> bb91;
       }
   
-      bb16: {
+      bb8: {
 -         StorageDead(_15);
--         goto -> bb172;
+-         goto -> bb164;
 +         nop;
-+         goto -> bb111;
++         goto -> bb103;
       }
   
-      bb17: {
+      bb9: {
 -         StorageDead(_11);
--         goto -> bb192;
+-         goto -> bb184;
 +         nop;
-+         goto -> bb123;
++         goto -> bb115;
       }
   
-      bb18: {
+      bb10: {
 -         StorageDead(_8);
--         goto -> bb212;
+-         goto -> bb204;
 +         nop;
-+         goto -> bb135;
++         goto -> bb127;
       }
   
-      bb19: {
+      bb11: {
 -         StorageDead(_5);
--         goto -> bb232;
+-         goto -> bb224;
 +         nop;
-+         goto -> bb147;
++         goto -> bb139;
       }
   
-      bb20: {
+      bb12: {
 -         StorageDead(_4);
--         drop(_3) -> [return: bb21, unwind: bb50];
+-         drop(_3) -> [return: bb13, unwind: bb42];
 +         nop;
-+         drop((((*_182) as variant#20).1: SyncInt)) -> [return: bb21, unwind: bb37];
++         drop((((*_182) as variant#20).1: SyncInt)) -> [return: bb13, unwind: bb29];
       }
   
-      bb21: {
+      bb13: {
 -         StorageDead(_3);
--         drop(_1) -> [return: bb22, unwind: bb51];
+-         drop(_1) -> [return: bb14, unwind: bb43];
 +         nop;
-+         goto -> bb148;
++         goto -> bb140;
       }
   
-      bb22: {
+      bb14: {
 +         _0 = Poll::<()>::Ready(move (((*_182) as variant#20).0: ()));
 +         discriminant((*_182)) = 1;
           return;
       }
   
--     bb23: {
+-     bb15: {
 -         StorageDead(_26);
-+     bb23 (cleanup): {
++     bb15 (cleanup): {
 +         nop;
-          goto -> bb24;
+          goto -> bb16;
       }
   
--     bb24: {
-+     bb24 (cleanup): {
+-     bb16: {
++     bb16 (cleanup): {
           StorageDead(_25);
--         goto -> bb25;
-+         drop((((*_182) as variant#6).9: {closure@$DIR/async_drop.rs:78:25: 78:27})) -> [return: bb25, unwind terminate(cleanup)];
+-         goto -> bb17;
++         drop((((*_182) as variant#6).9: {closure@$DIR/async_drop.rs:78:25: 78:27})) -> [return: bb17, unwind terminate(cleanup)];
       }
   
--     bb25: {
+-     bb17: {
 -         StorageDead(_24);
-+     bb25 (cleanup): {
++     bb17 (cleanup): {
 +         nop;
-          goto -> bb26;
+          goto -> bb18;
       }
   
--     bb26: {
-+     bb26 (cleanup): {
+-     bb18: {
++     bb18 (cleanup): {
           StorageDead(_23);
--         goto -> bb27;
-+         drop((((*_182) as variant#8).8: AsyncReference<'_>)) -> [return: bb27, unwind terminate(cleanup)];
+-         goto -> bb19;
++         drop((((*_182) as variant#8).8: AsyncReference<'_>)) -> [return: bb19, unwind terminate(cleanup)];
       }
   
--     bb27: {
+-     bb19: {
 -         StorageDead(_20);
--         goto -> bb28;
-+     bb27 (cleanup): {
+-         goto -> bb20;
++     bb19 (cleanup): {
 +         nop;
-+         drop((((*_182) as variant#10).7: AsyncInt)) -> [return: bb28, unwind terminate(cleanup)];
++         drop((((*_182) as variant#10).7: AsyncInt)) -> [return: bb20, unwind terminate(cleanup)];
       }
   
--     bb28: {
+-     bb20: {
 -         StorageDead(_19);
 -         StorageDead(_17);
--         goto -> bb29;
-+     bb28 (cleanup): {
-+         nop;
-+         goto -> bb31;
-      }
-  
--     bb29: {
--         StorageDead(_15);
-+     bb29 (cleanup): {
-          goto -> bb30;
-      }
-  
--     bb30: {
--         StorageDead(_11);
-+     bb30 (cleanup): {
-+         StorageDead(_18);
-          goto -> bb31;
-      }
-  
--     bb31: {
--         StorageDead(_8);
--         goto -> bb32;
-+     bb31 (cleanup): {
-+         StorageDead(_17);
-+         drop((((*_182) as variant#12).6: AsyncEnum)) -> [return: bb32, unwind terminate(cleanup)];
-      }
-  
--     bb32: {
--         StorageDead(_5);
--         goto -> bb33;
-+     bb32 (cleanup): {
-+         nop;
-+         drop((((*_182) as variant#14).5: SyncThenAsync)) -> [return: bb33, unwind terminate(cleanup)];
-      }
-  
--     bb33: {
--         StorageDead(_4);
--         goto -> bb34;
-+     bb33 (cleanup): {
-+         nop;
-+         drop((((*_182) as variant#16).4: AsyncStruct)) -> [return: bb34, unwind terminate(cleanup)];
-      }
-  
--     bb34: {
--         StorageDead(_3);
--         goto -> bb35;
-+     bb34 (cleanup): {
-+         nop;
-+         drop((((*_182) as variant#18).3: [AsyncInt; 2])) -> [return: bb35, unwind terminate(cleanup)];
-      }
-  
--     bb35: {
--         coroutine_drop;
-+     bb35 (cleanup): {
-+         nop;
-+         drop((((*_182) as variant#20).2: AsyncInt)) -> [return: bb36, unwind terminate(cleanup)];
-      }
-  
-      bb36 (cleanup): {
--         StorageDead(_26);
--         goto -> bb37;
-+         nop;
-+         drop((((*_182) as variant#20).1: SyncInt)) -> [return: bb37, unwind terminate(cleanup)];
-      }
-  
-      bb37 (cleanup): {
--         StorageDead(_25);
--         drop(_24) -> [return: bb38, unwind terminate(cleanup)];
-+         nop;
-+         goto -> bb38;
-      }
-  
-      bb38 (cleanup): {
--         StorageDead(_24);
--         goto -> bb39;
-+         goto -> bb149;
-      }
-  
--     bb39 (cleanup): {
--         StorageDead(_23);
--         drop(_20) -> [return: bb40, unwind terminate(cleanup)];
-+     bb39: {
-+         nop;
-+         goto -> bb10;
-      }
-  
-      bb40 (cleanup): {
--         StorageDead(_20);
--         drop(_19) -> [return: bb41, unwind terminate(cleanup)];
+-         goto -> bb21;
++     bb20 (cleanup): {
 +         nop;
 +         goto -> bb23;
       }
   
--     bb41 (cleanup): {
--         StorageDead(_19);
--         goto -> bb44;
-+     bb41: {
-+         assert(const false, "`async fn` resumed after async drop") -> [success: bb41, unwind: bb40];
+-     bb21: {
+-         StorageDead(_15);
++     bb21 (cleanup): {
+          goto -> bb22;
       }
   
--     bb42 (cleanup): {
--         goto -> bb43;
-+     bb42: {
+-     bb22: {
+-         StorageDead(_11);
++     bb22 (cleanup): {
++         StorageDead(_18);
+          goto -> bb23;
+      }
+  
+-     bb23: {
+-         StorageDead(_8);
+-         goto -> bb24;
++     bb23 (cleanup): {
++         StorageDead(_17);
++         drop((((*_182) as variant#12).6: AsyncEnum)) -> [return: bb24, unwind terminate(cleanup)];
+      }
+  
+-     bb24: {
+-         StorageDead(_5);
+-         goto -> bb25;
++     bb24 (cleanup): {
++         nop;
++         drop((((*_182) as variant#14).5: SyncThenAsync)) -> [return: bb25, unwind terminate(cleanup)];
+      }
+  
+-     bb25: {
+-         StorageDead(_4);
+-         goto -> bb26;
++     bb25 (cleanup): {
++         nop;
++         drop((((*_182) as variant#16).4: AsyncStruct)) -> [return: bb26, unwind terminate(cleanup)];
+      }
+  
+-     bb26: {
+-         StorageDead(_3);
+-         goto -> bb27;
++     bb26 (cleanup): {
++         nop;
++         drop((((*_182) as variant#18).3: [AsyncInt; 2])) -> [return: bb27, unwind terminate(cleanup)];
+      }
+  
+-     bb27: {
+-         coroutine_drop;
++     bb27 (cleanup): {
++         nop;
++         drop((((*_182) as variant#20).2: AsyncInt)) -> [return: bb28, unwind terminate(cleanup)];
+      }
+  
+      bb28 (cleanup): {
+-         StorageDead(_26);
+-         goto -> bb29;
++         nop;
++         drop((((*_182) as variant#20).1: SyncInt)) -> [return: bb29, unwind terminate(cleanup)];
+      }
+  
+      bb29 (cleanup): {
+-         StorageDead(_25);
+-         drop(_24) -> [return: bb30, unwind terminate(cleanup)];
++         nop;
++         goto -> bb30;
+      }
+  
+      bb30 (cleanup): {
+-         StorageDead(_24);
+-         goto -> bb31;
++         goto -> bb141;
+      }
+  
+-     bb31 (cleanup): {
+-         StorageDead(_23);
+-         drop(_20) -> [return: bb32, unwind terminate(cleanup)];
++     bb31: {
++         nop;
++         goto -> bb2;
+      }
+  
+      bb32 (cleanup): {
+-         StorageDead(_20);
+-         drop(_19) -> [return: bb33, unwind terminate(cleanup)];
++         nop;
++         goto -> bb15;
+      }
+  
+-     bb33 (cleanup): {
+-         StorageDead(_19);
+-         goto -> bb36;
++     bb33: {
++         assert(const false, "`async fn` resumed after async drop") -> [success: bb33, unwind: bb32];
+      }
+  
+-     bb34 (cleanup): {
+-         goto -> bb35;
++     bb34: {
 +         _183 = move _28;
 +         StorageDead(_28);
-+         goto -> bb41;
++         goto -> bb33;
       }
   
--     bb43 (cleanup): {
+-     bb35 (cleanup): {
 -         StorageDead(_18);
--         goto -> bb44;
-+     bb43: {
+-         goto -> bb36;
++     bb35: {
 +         unreachable;
       }
   
--     bb44 (cleanup): {
+-     bb36 (cleanup): {
 -         StorageDead(_17);
--         drop(_15) -> [return: bb45, unwind terminate(cleanup)];
-+     bb44: {
+-         drop(_15) -> [return: bb37, unwind terminate(cleanup)];
++     bb36: {
 +         _183 = move _35;
 +         StorageDead(_35);
-+         goto -> bb49;
++         goto -> bb41;
       }
   
--     bb45 (cleanup): {
+-     bb37 (cleanup): {
 -         StorageDead(_15);
--         drop(_11) -> [return: bb46, unwind terminate(cleanup)];
-+     bb45: {
+-         drop(_11) -> [return: bb38, unwind terminate(cleanup)];
++     bb37: {
 +         StorageLive(_35);
 +         _0 = Poll::<()>::Pending;
 +         StorageDead(_17);
@@ -683,95 +644,95 @@
 +         return;
       }
   
--     bb46 (cleanup): {
+-     bb38 (cleanup): {
 -         StorageDead(_11);
--         drop(_8) -> [return: bb47, unwind terminate(cleanup)];
-+     bb46: {
+-         drop(_8) -> [return: bb39, unwind terminate(cleanup)];
++     bb38: {
 +         _37 = discriminant(_36);
-+         switchInt(move _37) -> [0: bb39, 1: bb45, otherwise: bb43];
++         switchInt(move _37) -> [0: bb31, 1: bb37, otherwise: bb35];
       }
   
--     bb47 (cleanup): {
+-     bb39 (cleanup): {
 -         StorageDead(_8);
--         drop(_5) -> [return: bb48, unwind terminate(cleanup)];
-+     bb47: {
-+         _36 = <impl Future<Output = ()> as Future>::poll(move _38, move _39) -> [return: bb46, unwind: bb40];
+-         drop(_5) -> [return: bb40, unwind terminate(cleanup)];
++     bb39: {
++         _36 = <impl Future<Output = ()> as Future>::poll(move _38, move _39) -> [return: bb38, unwind: bb32];
       }
   
--     bb48 (cleanup): {
+-     bb40 (cleanup): {
 -         StorageDead(_5);
--         drop(_4) -> [return: bb49, unwind terminate(cleanup)];
-+     bb48: {
+-         drop(_4) -> [return: bb41, unwind terminate(cleanup)];
++     bb40: {
 +         _40 = move _183;
 +         _39 = copy (_40.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
-+         goto -> bb47;
++         goto -> bb39;
       }
   
--     bb49 (cleanup): {
+-     bb41 (cleanup): {
 -         StorageDead(_4);
--         drop(_3) -> [return: bb50, unwind terminate(cleanup)];
-+     bb49: {
+-         drop(_3) -> [return: bb42, unwind terminate(cleanup)];
++     bb41: {
 +         _41 = &mut (((*_182) as variant#4).11: impl std::future::Future<Output = ()>);
-+         _38 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _41) -> [return: bb48, unwind: bb40];
++         _38 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _41) -> [return: bb40, unwind: bb32];
       }
   
--     bb50 (cleanup): {
+-     bb42 (cleanup): {
 -         StorageDead(_3);
--         drop(_1) -> [return: bb51, unwind terminate(cleanup)];
-+     bb50: {
+-         drop(_1) -> [return: bb43, unwind terminate(cleanup)];
++     bb42: {
 +         nop;
-+         (((*_182) as variant#4).11: impl std::future::Future<Output = ()>) = async_drop_in_place::<{async closure@$DIR/async_drop.rs:86:27: 86:35}>(copy (_42.0: &mut {async closure@$DIR/async_drop.rs:86:27: 86:35})) -> [return: bb49, unwind: bb40];
++         (((*_182) as variant#4).11: impl std::future::Future<Output = ()>) = async_drop_in_place::<{async closure@$DIR/async_drop.rs:86:27: 86:35}>(copy (_42.0: &mut {async closure@$DIR/async_drop.rs:86:27: 86:35})) -> [return: bb41, unwind: bb32];
       }
   
--     bb51 (cleanup): {
+-     bb43 (cleanup): {
 -         resume;
-+     bb51: {
++     bb43: {
 +         _43 = &mut (((*_182) as variant#4).10: {async closure@$DIR/async_drop.rs:86:27: 86:35});
-+         _42 = Pin::<&mut {async closure@$DIR/async_drop.rs:86:27: 86:35}>::new_unchecked(move _43) -> [return: bb50, unwind: bb23];
++         _42 = Pin::<&mut {async closure@$DIR/async_drop.rs:86:27: 86:35}>::new_unchecked(move _43) -> [return: bb42, unwind: bb15];
       }
   
-      bb52: {
+      bb44: {
 -         StorageDead(_27);
--         goto -> bb10;
+-         goto -> bb2;
 +         nop;
-+         goto -> bb12;
++         goto -> bb4;
       }
   
--     bb53: {
+-     bb45: {
 -         StorageDead(_27);
--         goto -> bb23;
-+     bb53 (cleanup): {
+-         goto -> bb15;
++     bb45 (cleanup): {
 +         nop;
-+         goto -> bb25;
++         goto -> bb17;
       }
   
--     bb54 (cleanup): {
+-     bb46 (cleanup): {
 -         StorageDead(_27);
--         goto -> bb36;
-+     bb54: {
-+         assert(const false, "`async fn` resumed after async drop") -> [success: bb54, unwind: bb53];
+-         goto -> bb28;
++     bb46: {
++         assert(const false, "`async fn` resumed after async drop") -> [success: bb46, unwind: bb45];
       }
   
-      bb55: {
--         assert(const false, "`async fn` resumed after async drop") -> [success: bb55, unwind: bb54];
+      bb47: {
+-         assert(const false, "`async fn` resumed after async drop") -> [success: bb47, unwind: bb46];
 +         _183 = move _45;
 +         StorageDead(_45);
-+         goto -> bb54;
++         goto -> bb46;
       }
   
-      bb56: {
+      bb48: {
+-         _2 = move _28;
+-         StorageDead(_28);
+-         goto -> bb47;
++         _183 = move _52;
++         StorageDead(_52);
++         goto -> bb53;
+      }
+  
+      bb49: {
 -         _2 = move _28;
 -         StorageDead(_28);
 -         goto -> bb55;
-+         _183 = move _52;
-+         StorageDead(_52);
-+         goto -> bb61;
-      }
-  
-      bb57: {
--         _2 = move _28;
--         StorageDead(_28);
--         goto -> bb63;
 +         StorageLive(_52);
 +         _0 = Poll::<()>::Pending;
 +         StorageDead(_17);
@@ -781,87 +742,87 @@
 +         return;
       }
   
-      bb58: {
+      bb50: {
 -         StorageLive(_28);
--         _28 = yield(const ()) -> [resume: bb56, drop: bb57];
+-         _28 = yield(const ()) -> [resume: bb48, drop: bb49];
 +         _54 = discriminant(_53);
-+         switchInt(move _54) -> [0: bb52, 1: bb57, otherwise: bb43];
++         switchInt(move _54) -> [0: bb44, 1: bb49, otherwise: bb35];
+      }
+  
+      bb51: {
+-         unreachable;
++         _53 = <impl Future<Output = ()> as Future>::poll(move _55, move _56) -> [return: bb50, unwind: bb45];
+      }
+  
+      bb52: {
+-         _30 = discriminant(_29);
+-         switchInt(move _30) -> [0: bb45, 1: bb50, otherwise: bb51];
++         _57 = move _183;
++         _56 = copy (_57.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
++         goto -> bb51;
+      }
+  
+      bb53: {
+-         _29 = <impl Future<Output = ()> as Future>::poll(move _31, move _32) -> [return: bb52, unwind: bb46];
++         _58 = &mut (((*_182) as variant#6).10: impl std::future::Future<Output = ()>);
++         _55 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _58) -> [return: bb52, unwind: bb45];
+      }
+  
+      bb54: {
+-         _33 = move _2;
+-         _32 = std::future::get_context::<'_, '_>(move _33) -> [return: bb53, unwind: bb46];
++         nop;
++         (((*_182) as variant#6).10: impl std::future::Future<Output = ()>) = async_drop_in_place::<{closure@$DIR/async_drop.rs:78:25: 78:27}>(copy (_59.0: &mut {closure@$DIR/async_drop.rs:78:25: 78:27})) -> [return: bb53, unwind: bb45];
+      }
+  
+      bb55: {
+-         _34 = &mut _27;
+-         _31 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _34) -> [return: bb54, unwind: bb46];
++         _60 = &mut (((*_182) as variant#6).9: {closure@$DIR/async_drop.rs:78:25: 78:27});
++         _59 = Pin::<&mut {closure@$DIR/async_drop.rs:78:25: 78:27}>::new_unchecked(move _60) -> [return: bb54, unwind: bb17];
+      }
+  
+      bb56: {
+-         _2 = move _35;
+-         StorageDead(_35);
+-         goto -> bb62;
++         nop;
++         goto -> bb6;
+      }
+  
+-     bb57: {
+-         _2 = move _35;
+-         StorageDead(_35);
+-         goto -> bb55;
++     bb57 (cleanup): {
++         nop;
++         goto -> bb19;
+      }
+  
+      bb58: {
+-         StorageLive(_35);
+-         _35 = yield(const ()) -> [resume: bb56, drop: bb57];
++         assert(const false, "`async fn` resumed after async drop") -> [success: bb58, unwind: bb57];
       }
   
       bb59: {
--         unreachable;
-+         _53 = <impl Future<Output = ()> as Future>::poll(move _55, move _56) -> [return: bb58, unwind: bb53];
+-         _37 = discriminant(_36);
+-         switchInt(move _37) -> [0: bb44, 1: bb58, otherwise: bb51];
++         _183 = move _62;
++         StorageDead(_62);
++         goto -> bb58;
       }
   
       bb60: {
--         _30 = discriminant(_29);
--         switchInt(move _30) -> [0: bb53, 1: bb58, otherwise: bb59];
-+         _57 = move _183;
-+         _56 = copy (_57.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
-+         goto -> bb59;
+-         _36 = <impl Future<Output = ()> as Future>::poll(move _38, move _39) -> [return: bb59, unwind: bb46];
++         _183 = move _69;
++         StorageDead(_69);
++         goto -> bb65;
       }
   
       bb61: {
--         _29 = <impl Future<Output = ()> as Future>::poll(move _31, move _32) -> [return: bb60, unwind: bb54];
-+         _58 = &mut (((*_182) as variant#6).10: impl std::future::Future<Output = ()>);
-+         _55 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _58) -> [return: bb60, unwind: bb53];
-      }
-  
-      bb62: {
--         _33 = move _2;
--         _32 = std::future::get_context::<'_, '_>(move _33) -> [return: bb61, unwind: bb54];
-+         nop;
-+         (((*_182) as variant#6).10: impl std::future::Future<Output = ()>) = async_drop_in_place::<{closure@$DIR/async_drop.rs:78:25: 78:27}>(copy (_59.0: &mut {closure@$DIR/async_drop.rs:78:25: 78:27})) -> [return: bb61, unwind: bb53];
-      }
-  
-      bb63: {
--         _34 = &mut _27;
--         _31 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _34) -> [return: bb62, unwind: bb54];
-+         _60 = &mut (((*_182) as variant#6).9: {closure@$DIR/async_drop.rs:78:25: 78:27});
-+         _59 = Pin::<&mut {closure@$DIR/async_drop.rs:78:25: 78:27}>::new_unchecked(move _60) -> [return: bb62, unwind: bb25];
-      }
-  
-      bb64: {
--         _2 = move _35;
--         StorageDead(_35);
--         goto -> bb70;
-+         nop;
-+         goto -> bb14;
-      }
-  
--     bb65: {
--         _2 = move _35;
--         StorageDead(_35);
--         goto -> bb63;
-+     bb65 (cleanup): {
-+         nop;
-+         goto -> bb27;
-      }
-  
-      bb66: {
--         StorageLive(_35);
--         _35 = yield(const ()) -> [resume: bb64, drop: bb65];
-+         assert(const false, "`async fn` resumed after async drop") -> [success: bb66, unwind: bb65];
-      }
-  
-      bb67: {
--         _37 = discriminant(_36);
--         switchInt(move _37) -> [0: bb52, 1: bb66, otherwise: bb59];
-+         _183 = move _62;
-+         StorageDead(_62);
-+         goto -> bb66;
-      }
-  
-      bb68: {
--         _36 = <impl Future<Output = ()> as Future>::poll(move _38, move _39) -> [return: bb67, unwind: bb54];
-+         _183 = move _69;
-+         StorageDead(_69);
-+         goto -> bb73;
-      }
-  
-      bb69: {
 -         _40 = move _2;
--         _39 = std::future::get_context::<'_, '_>(move _40) -> [return: bb68, unwind: bb54];
+-         _39 = std::future::get_context::<'_, '_>(move _40) -> [return: bb60, unwind: bb46];
 +         StorageLive(_69);
 +         _0 = Poll::<()>::Pending;
 +         StorageDead(_17);
@@ -870,89 +831,89 @@
 +         return;
       }
   
-      bb70: {
+      bb62: {
 -         _41 = &mut _27;
--         _38 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _41) -> [return: bb69, unwind: bb54];
+-         _38 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _41) -> [return: bb61, unwind: bb46];
 +         _71 = discriminant(_70);
-+         switchInt(move _71) -> [0: bb64, 1: bb69, otherwise: bb43];
++         switchInt(move _71) -> [0: bb56, 1: bb61, otherwise: bb35];
+      }
+  
+      bb63: {
+-         StorageLive(_27);
+-         _27 = async_drop_in_place::<{async closure@$DIR/async_drop.rs:86:27: 86:35}>(copy (_42.0: &mut {async closure@$DIR/async_drop.rs:86:27: 86:35})) -> [return: bb62, unwind: bb46];
++         _70 = <impl Future<Output = ()> as Future>::poll(move _72, move _73) -> [return: bb62, unwind: bb57];
+      }
+  
+      bb64: {
+-         _43 = &mut _26;
+-         _42 = Pin::<&mut {async closure@$DIR/async_drop.rs:86:27: 86:35}>::new_unchecked(move _43) -> [return: bb63, unwind: bb28];
++         _74 = move _183;
++         _73 = copy (_74.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
++         goto -> bb63;
+      }
+  
+      bb65: {
+-         StorageDead(_44);
+-         goto -> bb4;
++         _75 = &mut (((*_182) as variant#8).9: impl std::future::Future<Output = ()>);
++         _72 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _75) -> [return: bb64, unwind: bb57];
+      }
+  
+      bb66: {
+-         StorageDead(_44);
+-         goto -> bb17;
++         nop;
++         (((*_182) as variant#8).9: impl std::future::Future<Output = ()>) = async_drop_in_place::<AsyncReference<'_>>(copy (_76.0: &mut AsyncReference<'_>)) -> [return: bb65, unwind: bb57];
+      }
+  
+-     bb67 (cleanup): {
+-         StorageDead(_44);
+-         goto -> bb30;
++     bb67: {
++         _77 = &mut (((*_182) as variant#8).8: AsyncReference<'_>);
++         _76 = Pin::<&mut AsyncReference<'_>>::new_unchecked(move _77) -> [return: bb66, unwind: bb19];
+      }
+  
+      bb68: {
+-         assert(const false, "`async fn` resumed after async drop") -> [success: bb68, unwind: bb67];
++         nop;
++         goto -> bb7;
+      }
+  
+-     bb69: {
+-         _2 = move _45;
+-         StorageDead(_45);
+-         goto -> bb68;
++     bb69 (cleanup): {
++         nop;
++         goto -> bb20;
+      }
+  
+      bb70: {
+-         _2 = move _45;
+-         StorageDead(_45);
+-         goto -> bb75;
++         assert(const false, "`async fn` resumed after async drop") -> [success: bb70, unwind: bb69];
       }
   
       bb71: {
--         StorageLive(_27);
--         _27 = async_drop_in_place::<{async closure@$DIR/async_drop.rs:86:27: 86:35}>(copy (_42.0: &mut {async closure@$DIR/async_drop.rs:86:27: 86:35})) -> [return: bb70, unwind: bb54];
-+         _70 = <impl Future<Output = ()> as Future>::poll(move _72, move _73) -> [return: bb70, unwind: bb65];
+-         StorageLive(_45);
+-         _45 = yield(const ()) -> [resume: bb69, drop: bb70];
++         _183 = move _79;
++         StorageDead(_79);
++         goto -> bb70;
       }
   
       bb72: {
--         _43 = &mut _26;
--         _42 = Pin::<&mut {async closure@$DIR/async_drop.rs:86:27: 86:35}>::new_unchecked(move _43) -> [return: bb71, unwind: bb36];
-+         _74 = move _183;
-+         _73 = copy (_74.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
-+         goto -> bb71;
+-         _47 = discriminant(_46);
+-         switchInt(move _47) -> [0: bb66, 1: bb71, otherwise: bb51];
++         _183 = move _86;
++         StorageDead(_86);
++         goto -> bb77;
       }
   
       bb73: {
--         StorageDead(_44);
--         goto -> bb12;
-+         _75 = &mut (((*_182) as variant#8).9: impl std::future::Future<Output = ()>);
-+         _72 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _75) -> [return: bb72, unwind: bb65];
-      }
-  
-      bb74: {
--         StorageDead(_44);
--         goto -> bb25;
-+         nop;
-+         (((*_182) as variant#8).9: impl std::future::Future<Output = ()>) = async_drop_in_place::<AsyncReference<'_>>(copy (_76.0: &mut AsyncReference<'_>)) -> [return: bb73, unwind: bb65];
-      }
-  
--     bb75 (cleanup): {
--         StorageDead(_44);
--         goto -> bb38;
-+     bb75: {
-+         _77 = &mut (((*_182) as variant#8).8: AsyncReference<'_>);
-+         _76 = Pin::<&mut AsyncReference<'_>>::new_unchecked(move _77) -> [return: bb74, unwind: bb27];
-      }
-  
-      bb76: {
--         assert(const false, "`async fn` resumed after async drop") -> [success: bb76, unwind: bb75];
-+         nop;
-+         goto -> bb15;
-      }
-  
--     bb77: {
--         _2 = move _45;
--         StorageDead(_45);
--         goto -> bb76;
-+     bb77 (cleanup): {
-+         nop;
-+         goto -> bb28;
-      }
-  
-      bb78: {
--         _2 = move _45;
--         StorageDead(_45);
--         goto -> bb83;
-+         assert(const false, "`async fn` resumed after async drop") -> [success: bb78, unwind: bb77];
-      }
-  
-      bb79: {
--         StorageLive(_45);
--         _45 = yield(const ()) -> [resume: bb77, drop: bb78];
-+         _183 = move _79;
-+         StorageDead(_79);
-+         goto -> bb78;
-      }
-  
-      bb80: {
--         _47 = discriminant(_46);
--         switchInt(move _47) -> [0: bb74, 1: bb79, otherwise: bb59];
-+         _183 = move _86;
-+         StorageDead(_86);
-+         goto -> bb85;
-      }
-  
-      bb81: {
--         _46 = <impl Future<Output = ()> as Future>::poll(move _48, move _49) -> [return: bb80, unwind: bb75];
+-         _46 = <impl Future<Output = ()> as Future>::poll(move _48, move _49) -> [return: bb72, unwind: bb67];
 +         StorageLive(_86);
 +         _0 = Poll::<()>::Pending;
 +         StorageDead(_17);
@@ -961,89 +922,89 @@
 +         return;
       }
   
-      bb82: {
+      bb74: {
 -         _50 = move _2;
--         _49 = std::future::get_context::<'_, '_>(move _50) -> [return: bb81, unwind: bb75];
+-         _49 = std::future::get_context::<'_, '_>(move _50) -> [return: bb73, unwind: bb67];
 +         _88 = discriminant(_87);
-+         switchInt(move _88) -> [0: bb76, 1: bb81, otherwise: bb43];
++         switchInt(move _88) -> [0: bb68, 1: bb73, otherwise: bb35];
+      }
+  
+      bb75: {
+-         _51 = &mut _44;
+-         _48 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _51) -> [return: bb74, unwind: bb67];
++         _87 = <impl Future<Output = ()> as Future>::poll(move _89, move _90) -> [return: bb74, unwind: bb69];
+      }
+  
+      bb76: {
+-         _2 = move _52;
+-         StorageDead(_52);
+-         goto -> bb82;
++         _91 = move _183;
++         _90 = copy (_91.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
++         goto -> bb75;
+      }
+  
+      bb77: {
+-         _2 = move _52;
+-         StorageDead(_52);
+-         goto -> bb75;
++         _92 = &mut (((*_182) as variant#10).8: impl std::future::Future<Output = ()>);
++         _89 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _92) -> [return: bb76, unwind: bb69];
+      }
+  
+      bb78: {
+-         StorageLive(_52);
+-         _52 = yield(const ()) -> [resume: bb76, drop: bb77];
++         nop;
++         (((*_182) as variant#10).8: impl std::future::Future<Output = ()>) = async_drop_in_place::<AsyncInt>(copy (_93.0: &mut AsyncInt)) -> [return: bb77, unwind: bb69];
+      }
+  
+      bb79: {
+-         _54 = discriminant(_53);
+-         switchInt(move _54) -> [0: bb65, 1: bb78, otherwise: bb51];
++         _94 = &mut (((*_182) as variant#10).7: AsyncInt);
++         _93 = Pin::<&mut AsyncInt>::new_unchecked(move _94) -> [return: bb78, unwind: bb20];
+      }
+  
+      bb80: {
+-         _53 = <impl Future<Output = ()> as Future>::poll(move _55, move _56) -> [return: bb79, unwind: bb67];
++         nop;
++         goto -> bb8;
+      }
+  
+-     bb81: {
+-         _57 = move _2;
+-         _56 = std::future::get_context::<'_, '_>(move _57) -> [return: bb80, unwind: bb67];
++     bb81 (cleanup): {
++         nop;
++         goto -> bb24;
+      }
+  
+      bb82: {
+-         _58 = &mut _44;
+-         _55 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _58) -> [return: bb81, unwind: bb67];
++         assert(const false, "`async fn` resumed after async drop") -> [success: bb82, unwind: bb81];
       }
   
       bb83: {
--         _51 = &mut _44;
--         _48 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _51) -> [return: bb82, unwind: bb75];
-+         _87 = <impl Future<Output = ()> as Future>::poll(move _89, move _90) -> [return: bb82, unwind: bb77];
+-         StorageLive(_44);
+-         _44 = async_drop_in_place::<{closure@$DIR/async_drop.rs:78:25: 78:27}>(copy (_59.0: &mut {closure@$DIR/async_drop.rs:78:25: 78:27})) -> [return: bb82, unwind: bb67];
++         _183 = move _96;
++         StorageDead(_96);
++         goto -> bb82;
       }
   
       bb84: {
--         _2 = move _52;
--         StorageDead(_52);
--         goto -> bb90;
-+         _91 = move _183;
-+         _90 = copy (_91.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
-+         goto -> bb83;
+-         _60 = &mut _24;
+-         _59 = Pin::<&mut {closure@$DIR/async_drop.rs:78:25: 78:27}>::new_unchecked(move _60) -> [return: bb83, unwind: bb30];
++         _183 = move _103;
++         StorageDead(_103);
++         goto -> bb89;
       }
   
       bb85: {
--         _2 = move _52;
--         StorageDead(_52);
--         goto -> bb83;
-+         _92 = &mut (((*_182) as variant#10).8: impl std::future::Future<Output = ()>);
-+         _89 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _92) -> [return: bb84, unwind: bb77];
-      }
-  
-      bb86: {
--         StorageLive(_52);
--         _52 = yield(const ()) -> [resume: bb84, drop: bb85];
-+         nop;
-+         (((*_182) as variant#10).8: impl std::future::Future<Output = ()>) = async_drop_in_place::<AsyncInt>(copy (_93.0: &mut AsyncInt)) -> [return: bb85, unwind: bb77];
-      }
-  
-      bb87: {
--         _54 = discriminant(_53);
--         switchInt(move _54) -> [0: bb73, 1: bb86, otherwise: bb59];
-+         _94 = &mut (((*_182) as variant#10).7: AsyncInt);
-+         _93 = Pin::<&mut AsyncInt>::new_unchecked(move _94) -> [return: bb86, unwind: bb28];
-      }
-  
-      bb88: {
--         _53 = <impl Future<Output = ()> as Future>::poll(move _55, move _56) -> [return: bb87, unwind: bb75];
-+         nop;
-+         goto -> bb16;
-      }
-  
--     bb89: {
--         _57 = move _2;
--         _56 = std::future::get_context::<'_, '_>(move _57) -> [return: bb88, unwind: bb75];
-+     bb89 (cleanup): {
-+         nop;
-+         goto -> bb32;
-      }
-  
-      bb90: {
--         _58 = &mut _44;
--         _55 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _58) -> [return: bb89, unwind: bb75];
-+         assert(const false, "`async fn` resumed after async drop") -> [success: bb90, unwind: bb89];
-      }
-  
-      bb91: {
--         StorageLive(_44);
--         _44 = async_drop_in_place::<{closure@$DIR/async_drop.rs:78:25: 78:27}>(copy (_59.0: &mut {closure@$DIR/async_drop.rs:78:25: 78:27})) -> [return: bb90, unwind: bb75];
-+         _183 = move _96;
-+         StorageDead(_96);
-+         goto -> bb90;
-      }
-  
-      bb92: {
--         _60 = &mut _24;
--         _59 = Pin::<&mut {closure@$DIR/async_drop.rs:78:25: 78:27}>::new_unchecked(move _60) -> [return: bb91, unwind: bb38];
-+         _183 = move _103;
-+         StorageDead(_103);
-+         goto -> bb97;
-      }
-  
-      bb93: {
 -         StorageDead(_61);
--         goto -> bb14;
+-         goto -> bb6;
 +         StorageLive(_103);
 +         _0 = Poll::<()>::Pending;
 +         StorageDead(_103);
@@ -1051,91 +1012,91 @@
 +         return;
       }
   
-      bb94: {
+      bb86: {
 -         StorageDead(_61);
--         goto -> bb27;
+-         goto -> bb19;
 +         _105 = discriminant(_104);
-+         switchInt(move _105) -> [0: bb88, 1: bb93, otherwise: bb43];
++         switchInt(move _105) -> [0: bb80, 1: bb85, otherwise: bb35];
       }
   
--     bb95 (cleanup): {
+-     bb87 (cleanup): {
 -         StorageDead(_61);
--         goto -> bb40;
-+     bb95: {
-+         _104 = <impl Future<Output = ()> as Future>::poll(move _106, move _107) -> [return: bb94, unwind: bb89];
+-         goto -> bb32;
++     bb87: {
++         _104 = <impl Future<Output = ()> as Future>::poll(move _106, move _107) -> [return: bb86, unwind: bb81];
+      }
+  
+      bb88: {
+-         assert(const false, "`async fn` resumed after async drop") -> [success: bb88, unwind: bb87];
++         _108 = move _183;
++         _107 = copy (_108.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
++         goto -> bb87;
+      }
+  
+      bb89: {
+-         _2 = move _62;
+-         StorageDead(_62);
+-         goto -> bb88;
++         _109 = &mut (((*_182) as variant#12).7: impl std::future::Future<Output = ()>);
++         _106 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _109) -> [return: bb88, unwind: bb81];
+      }
+  
+      bb90: {
+-         _2 = move _62;
+-         StorageDead(_62);
+-         goto -> bb95;
++         nop;
++         (((*_182) as variant#12).7: impl std::future::Future<Output = ()>) = async_drop_in_place::<AsyncEnum>(copy (_110.0: &mut AsyncEnum)) -> [return: bb89, unwind: bb81];
+      }
+  
+      bb91: {
+-         StorageLive(_62);
+-         _62 = yield(const ()) -> [resume: bb89, drop: bb90];
++         _111 = &mut (((*_182) as variant#12).6: AsyncEnum);
++         _110 = Pin::<&mut AsyncEnum>::new_unchecked(move _111) -> [return: bb90, unwind: bb24];
+      }
+  
+      bb92: {
+-         _64 = discriminant(_63);
+-         switchInt(move _64) -> [0: bb86, 1: bb91, otherwise: bb51];
++         nop;
++         goto -> bb9;
+      }
+  
+-     bb93: {
+-         _63 = <impl Future<Output = ()> as Future>::poll(move _65, move _66) -> [return: bb92, unwind: bb87];
++     bb93 (cleanup): {
++         nop;
++         goto -> bb25;
+      }
+  
+      bb94: {
+-         _67 = move _2;
+-         _66 = std::future::get_context::<'_, '_>(move _67) -> [return: bb93, unwind: bb87];
++         assert(const false, "`async fn` resumed after async drop") -> [success: bb94, unwind: bb93];
+      }
+  
+      bb95: {
+-         _68 = &mut _61;
+-         _65 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _68) -> [return: bb94, unwind: bb87];
++         _183 = move _113;
++         StorageDead(_113);
++         goto -> bb94;
       }
   
       bb96: {
--         assert(const false, "`async fn` resumed after async drop") -> [success: bb96, unwind: bb95];
-+         _108 = move _183;
-+         _107 = copy (_108.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
-+         goto -> bb95;
+-         _2 = move _69;
+-         StorageDead(_69);
+-         goto -> bb102;
++         _183 = move _120;
++         StorageDead(_120);
++         goto -> bb101;
       }
   
       bb97: {
--         _2 = move _62;
--         StorageDead(_62);
--         goto -> bb96;
-+         _109 = &mut (((*_182) as variant#12).7: impl std::future::Future<Output = ()>);
-+         _106 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _109) -> [return: bb96, unwind: bb89];
-      }
-  
-      bb98: {
--         _2 = move _62;
--         StorageDead(_62);
--         goto -> bb103;
-+         nop;
-+         (((*_182) as variant#12).7: impl std::future::Future<Output = ()>) = async_drop_in_place::<AsyncEnum>(copy (_110.0: &mut AsyncEnum)) -> [return: bb97, unwind: bb89];
-      }
-  
-      bb99: {
--         StorageLive(_62);
--         _62 = yield(const ()) -> [resume: bb97, drop: bb98];
-+         _111 = &mut (((*_182) as variant#12).6: AsyncEnum);
-+         _110 = Pin::<&mut AsyncEnum>::new_unchecked(move _111) -> [return: bb98, unwind: bb32];
-      }
-  
-      bb100: {
--         _64 = discriminant(_63);
--         switchInt(move _64) -> [0: bb94, 1: bb99, otherwise: bb59];
-+         nop;
-+         goto -> bb17;
-      }
-  
--     bb101: {
--         _63 = <impl Future<Output = ()> as Future>::poll(move _65, move _66) -> [return: bb100, unwind: bb95];
-+     bb101 (cleanup): {
-+         nop;
-+         goto -> bb33;
-      }
-  
-      bb102: {
--         _67 = move _2;
--         _66 = std::future::get_context::<'_, '_>(move _67) -> [return: bb101, unwind: bb95];
-+         assert(const false, "`async fn` resumed after async drop") -> [success: bb102, unwind: bb101];
-      }
-  
-      bb103: {
--         _68 = &mut _61;
--         _65 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _68) -> [return: bb102, unwind: bb95];
-+         _183 = move _113;
-+         StorageDead(_113);
-+         goto -> bb102;
-      }
-  
-      bb104: {
 -         _2 = move _69;
 -         StorageDead(_69);
--         goto -> bb110;
-+         _183 = move _120;
-+         StorageDead(_120);
-+         goto -> bb109;
-      }
-  
-      bb105: {
--         _2 = move _69;
--         StorageDead(_69);
--         goto -> bb103;
+-         goto -> bb95;
 +         StorageLive(_120);
 +         _0 = Poll::<()>::Pending;
 +         StorageDead(_120);
@@ -1143,88 +1104,88 @@
 +         return;
       }
   
-      bb106: {
+      bb98: {
 -         StorageLive(_69);
--         _69 = yield(const ()) -> [resume: bb104, drop: bb105];
+-         _69 = yield(const ()) -> [resume: bb96, drop: bb97];
 +         _122 = discriminant(_121);
-+         switchInt(move _122) -> [0: bb100, 1: bb105, otherwise: bb43];
++         switchInt(move _122) -> [0: bb92, 1: bb97, otherwise: bb35];
       }
   
-      bb107: {
+      bb99: {
 -         _71 = discriminant(_70);
--         switchInt(move _71) -> [0: bb93, 1: bb106, otherwise: bb59];
-+         _121 = <impl Future<Output = ()> as Future>::poll(move _123, move _124) -> [return: bb106, unwind: bb101];
+-         switchInt(move _71) -> [0: bb85, 1: bb98, otherwise: bb51];
++         _121 = <impl Future<Output = ()> as Future>::poll(move _123, move _124) -> [return: bb98, unwind: bb93];
+      }
+  
+      bb100: {
+-         _70 = <impl Future<Output = ()> as Future>::poll(move _72, move _73) -> [return: bb99, unwind: bb87];
++         _125 = move _183;
++         _124 = copy (_125.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
++         goto -> bb99;
+      }
+  
+      bb101: {
+-         _74 = move _2;
+-         _73 = std::future::get_context::<'_, '_>(move _74) -> [return: bb100, unwind: bb87];
++         _126 = &mut (((*_182) as variant#14).6: impl std::future::Future<Output = ()>);
++         _123 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _126) -> [return: bb100, unwind: bb93];
+      }
+  
+      bb102: {
+-         _75 = &mut _61;
+-         _72 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _75) -> [return: bb101, unwind: bb87];
++         nop;
++         (((*_182) as variant#14).6: impl std::future::Future<Output = ()>) = async_drop_in_place::<SyncThenAsync>(copy (_127.0: &mut SyncThenAsync)) -> [return: bb101, unwind: bb93];
+      }
+  
+      bb103: {
+-         StorageLive(_61);
+-         _61 = async_drop_in_place::<AsyncReference<'_>>(copy (_76.0: &mut AsyncReference<'_>)) -> [return: bb102, unwind: bb87];
++         _128 = &mut (((*_182) as variant#14).5: SyncThenAsync);
++         _127 = Pin::<&mut SyncThenAsync>::new_unchecked(move _128) -> [return: bb102, unwind: bb25];
+      }
+  
+      bb104: {
+-         _77 = &mut _20;
+-         _76 = Pin::<&mut AsyncReference<'_>>::new_unchecked(move _77) -> [return: bb103, unwind: bb32];
++         nop;
++         goto -> bb10;
+      }
+  
+-     bb105: {
+-         StorageDead(_78);
+-         goto -> bb7;
++     bb105 (cleanup): {
++         nop;
++         goto -> bb26;
+      }
+  
+      bb106: {
+-         StorageDead(_78);
+-         goto -> bb20;
++         assert(const false, "`async fn` resumed after async drop") -> [success: bb106, unwind: bb105];
+      }
+  
+-     bb107 (cleanup): {
+-         StorageDead(_78);
+-         goto -> bb33;
++     bb107: {
++         _183 = move _130;
++         StorageDead(_130);
++         goto -> bb106;
       }
   
       bb108: {
--         _70 = <impl Future<Output = ()> as Future>::poll(move _72, move _73) -> [return: bb107, unwind: bb95];
-+         _125 = move _183;
-+         _124 = copy (_125.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
-+         goto -> bb107;
+-         assert(const false, "`async fn` resumed after async drop") -> [success: bb108, unwind: bb107];
++         _183 = move _137;
++         StorageDead(_137);
++         goto -> bb113;
       }
   
       bb109: {
--         _74 = move _2;
--         _73 = std::future::get_context::<'_, '_>(move _74) -> [return: bb108, unwind: bb95];
-+         _126 = &mut (((*_182) as variant#14).6: impl std::future::Future<Output = ()>);
-+         _123 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _126) -> [return: bb108, unwind: bb101];
-      }
-  
-      bb110: {
--         _75 = &mut _61;
--         _72 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _75) -> [return: bb109, unwind: bb95];
-+         nop;
-+         (((*_182) as variant#14).6: impl std::future::Future<Output = ()>) = async_drop_in_place::<SyncThenAsync>(copy (_127.0: &mut SyncThenAsync)) -> [return: bb109, unwind: bb101];
-      }
-  
-      bb111: {
--         StorageLive(_61);
--         _61 = async_drop_in_place::<AsyncReference<'_>>(copy (_76.0: &mut AsyncReference<'_>)) -> [return: bb110, unwind: bb95];
-+         _128 = &mut (((*_182) as variant#14).5: SyncThenAsync);
-+         _127 = Pin::<&mut SyncThenAsync>::new_unchecked(move _128) -> [return: bb110, unwind: bb33];
-      }
-  
-      bb112: {
--         _77 = &mut _20;
--         _76 = Pin::<&mut AsyncReference<'_>>::new_unchecked(move _77) -> [return: bb111, unwind: bb40];
-+         nop;
-+         goto -> bb18;
-      }
-  
--     bb113: {
--         StorageDead(_78);
--         goto -> bb15;
-+     bb113 (cleanup): {
-+         nop;
-+         goto -> bb34;
-      }
-  
-      bb114: {
--         StorageDead(_78);
--         goto -> bb28;
-+         assert(const false, "`async fn` resumed after async drop") -> [success: bb114, unwind: bb113];
-      }
-  
--     bb115 (cleanup): {
--         StorageDead(_78);
--         goto -> bb41;
-+     bb115: {
-+         _183 = move _130;
-+         StorageDead(_130);
-+         goto -> bb114;
-      }
-  
-      bb116: {
--         assert(const false, "`async fn` resumed after async drop") -> [success: bb116, unwind: bb115];
-+         _183 = move _137;
-+         StorageDead(_137);
-+         goto -> bb121;
-      }
-  
-      bb117: {
 -         _2 = move _79;
 -         StorageDead(_79);
--         goto -> bb116;
+-         goto -> bb108;
 +         StorageLive(_137);
 +         _0 = Poll::<()>::Pending;
 +         StorageDead(_137);
@@ -1232,89 +1193,89 @@
 +         return;
       }
   
-      bb118: {
+      bb110: {
 -         _2 = move _79;
 -         StorageDead(_79);
--         goto -> bb123;
+-         goto -> bb115;
 +         _139 = discriminant(_138);
-+         switchInt(move _139) -> [0: bb112, 1: bb117, otherwise: bb43];
++         switchInt(move _139) -> [0: bb104, 1: bb109, otherwise: bb35];
+      }
+  
+      bb111: {
+-         StorageLive(_79);
+-         _79 = yield(const ()) -> [resume: bb109, drop: bb110];
++         _138 = <impl Future<Output = ()> as Future>::poll(move _140, move _141) -> [return: bb110, unwind: bb105];
+      }
+  
+      bb112: {
+-         _81 = discriminant(_80);
+-         switchInt(move _81) -> [0: bb106, 1: bb111, otherwise: bb51];
++         _142 = move _183;
++         _141 = copy (_142.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
++         goto -> bb111;
+      }
+  
+      bb113: {
+-         _80 = <impl Future<Output = ()> as Future>::poll(move _82, move _83) -> [return: bb112, unwind: bb107];
++         _143 = &mut (((*_182) as variant#16).5: impl std::future::Future<Output = ()>);
++         _140 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _143) -> [return: bb112, unwind: bb105];
+      }
+  
+      bb114: {
+-         _84 = move _2;
+-         _83 = std::future::get_context::<'_, '_>(move _84) -> [return: bb113, unwind: bb107];
++         nop;
++         (((*_182) as variant#16).5: impl std::future::Future<Output = ()>) = async_drop_in_place::<AsyncStruct>(copy (_144.0: &mut AsyncStruct)) -> [return: bb113, unwind: bb105];
+      }
+  
+      bb115: {
+-         _85 = &mut _78;
+-         _82 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _85) -> [return: bb114, unwind: bb107];
++         _145 = &mut (((*_182) as variant#16).4: AsyncStruct);
++         _144 = Pin::<&mut AsyncStruct>::new_unchecked(move _145) -> [return: bb114, unwind: bb26];
+      }
+  
+      bb116: {
+-         _2 = move _86;
+-         StorageDead(_86);
+-         goto -> bb122;
++         nop;
++         goto -> bb11;
+      }
+  
+-     bb117: {
+-         _2 = move _86;
+-         StorageDead(_86);
+-         goto -> bb115;
++     bb117 (cleanup): {
++         nop;
++         goto -> bb27;
+      }
+  
+      bb118: {
+-         StorageLive(_86);
+-         _86 = yield(const ()) -> [resume: bb116, drop: bb117];
++         assert(const false, "`async fn` resumed after async drop") -> [success: bb118, unwind: bb117];
       }
   
       bb119: {
--         StorageLive(_79);
--         _79 = yield(const ()) -> [resume: bb117, drop: bb118];
-+         _138 = <impl Future<Output = ()> as Future>::poll(move _140, move _141) -> [return: bb118, unwind: bb113];
+-         _88 = discriminant(_87);
+-         switchInt(move _88) -> [0: bb105, 1: bb118, otherwise: bb51];
++         _183 = move _147;
++         StorageDead(_147);
++         goto -> bb118;
       }
   
       bb120: {
--         _81 = discriminant(_80);
--         switchInt(move _81) -> [0: bb114, 1: bb119, otherwise: bb59];
-+         _142 = move _183;
-+         _141 = copy (_142.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
-+         goto -> bb119;
+-         _87 = <impl Future<Output = ()> as Future>::poll(move _89, move _90) -> [return: bb119, unwind: bb107];
++         _183 = move _154;
++         StorageDead(_154);
++         goto -> bb125;
       }
   
       bb121: {
--         _80 = <impl Future<Output = ()> as Future>::poll(move _82, move _83) -> [return: bb120, unwind: bb115];
-+         _143 = &mut (((*_182) as variant#16).5: impl std::future::Future<Output = ()>);
-+         _140 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _143) -> [return: bb120, unwind: bb113];
-      }
-  
-      bb122: {
--         _84 = move _2;
--         _83 = std::future::get_context::<'_, '_>(move _84) -> [return: bb121, unwind: bb115];
-+         nop;
-+         (((*_182) as variant#16).5: impl std::future::Future<Output = ()>) = async_drop_in_place::<AsyncStruct>(copy (_144.0: &mut AsyncStruct)) -> [return: bb121, unwind: bb113];
-      }
-  
-      bb123: {
--         _85 = &mut _78;
--         _82 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _85) -> [return: bb122, unwind: bb115];
-+         _145 = &mut (((*_182) as variant#16).4: AsyncStruct);
-+         _144 = Pin::<&mut AsyncStruct>::new_unchecked(move _145) -> [return: bb122, unwind: bb34];
-      }
-  
-      bb124: {
--         _2 = move _86;
--         StorageDead(_86);
--         goto -> bb130;
-+         nop;
-+         goto -> bb19;
-      }
-  
--     bb125: {
--         _2 = move _86;
--         StorageDead(_86);
--         goto -> bb123;
-+     bb125 (cleanup): {
-+         nop;
-+         goto -> bb35;
-      }
-  
-      bb126: {
--         StorageLive(_86);
--         _86 = yield(const ()) -> [resume: bb124, drop: bb125];
-+         assert(const false, "`async fn` resumed after async drop") -> [success: bb126, unwind: bb125];
-      }
-  
-      bb127: {
--         _88 = discriminant(_87);
--         switchInt(move _88) -> [0: bb113, 1: bb126, otherwise: bb59];
-+         _183 = move _147;
-+         StorageDead(_147);
-+         goto -> bb126;
-      }
-  
-      bb128: {
--         _87 = <impl Future<Output = ()> as Future>::poll(move _89, move _90) -> [return: bb127, unwind: bb115];
-+         _183 = move _154;
-+         StorageDead(_154);
-+         goto -> bb133;
-      }
-  
-      bb129: {
 -         _91 = move _2;
--         _90 = std::future::get_context::<'_, '_>(move _91) -> [return: bb128, unwind: bb115];
+-         _90 = std::future::get_context::<'_, '_>(move _91) -> [return: bb120, unwind: bb107];
 +         StorageLive(_154);
 +         _0 = Poll::<()>::Pending;
 +         StorageDead(_154);
@@ -1322,89 +1283,89 @@
 +         return;
       }
   
-      bb130: {
+      bb122: {
 -         _92 = &mut _78;
--         _89 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _92) -> [return: bb129, unwind: bb115];
+-         _89 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _92) -> [return: bb121, unwind: bb107];
 +         _156 = discriminant(_155);
-+         switchInt(move _156) -> [0: bb124, 1: bb129, otherwise: bb43];
++         switchInt(move _156) -> [0: bb116, 1: bb121, otherwise: bb35];
+      }
+  
+      bb123: {
+-         StorageLive(_78);
+-         _78 = async_drop_in_place::<AsyncInt>(copy (_93.0: &mut AsyncInt)) -> [return: bb122, unwind: bb107];
++         _155 = <impl Future<Output = ()> as Future>::poll(move _157, move _158) -> [return: bb122, unwind: bb117];
+      }
+  
+      bb124: {
+-         _94 = &mut _19;
+-         _93 = Pin::<&mut AsyncInt>::new_unchecked(move _94) -> [return: bb123, unwind: bb33];
++         _159 = move _183;
++         _158 = copy (_159.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
++         goto -> bb123;
+      }
+  
+      bb125: {
+-         StorageDead(_95);
+-         goto -> bb8;
++         _160 = &mut (((*_182) as variant#18).4: impl std::future::Future<Output = ()>);
++         _157 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _160) -> [return: bb124, unwind: bb117];
+      }
+  
+      bb126: {
+-         StorageDead(_95);
+-         goto -> bb21;
++         nop;
++         (((*_182) as variant#18).4: impl std::future::Future<Output = ()>) = async_drop_in_place::<[AsyncInt; 2]>(copy (_161.0: &mut [AsyncInt; 2])) -> [return: bb125, unwind: bb117];
+      }
+  
+-     bb127 (cleanup): {
+-         StorageDead(_95);
+-         goto -> bb37;
++     bb127: {
++         _162 = &mut (((*_182) as variant#18).3: [AsyncInt; 2]);
++         _161 = Pin::<&mut [AsyncInt; 2]>::new_unchecked(move _162) -> [return: bb126, unwind: bb27];
+      }
+  
+      bb128: {
+-         assert(const false, "`async fn` resumed after async drop") -> [success: bb128, unwind: bb127];
++         nop;
++         goto -> bb12;
+      }
+  
+-     bb129: {
+-         _2 = move _96;
+-         StorageDead(_96);
+-         goto -> bb128;
++     bb129 (cleanup): {
++         nop;
++         goto -> bb28;
+      }
+  
+      bb130: {
+-         _2 = move _96;
+-         StorageDead(_96);
+-         goto -> bb135;
++         assert(const false, "`async fn` resumed after async drop") -> [success: bb130, unwind: bb129];
       }
   
       bb131: {
--         StorageLive(_78);
--         _78 = async_drop_in_place::<AsyncInt>(copy (_93.0: &mut AsyncInt)) -> [return: bb130, unwind: bb115];
-+         _155 = <impl Future<Output = ()> as Future>::poll(move _157, move _158) -> [return: bb130, unwind: bb125];
+-         StorageLive(_96);
+-         _96 = yield(const ()) -> [resume: bb129, drop: bb130];
++         _183 = move _164;
++         StorageDead(_164);
++         goto -> bb130;
       }
   
       bb132: {
--         _94 = &mut _19;
--         _93 = Pin::<&mut AsyncInt>::new_unchecked(move _94) -> [return: bb131, unwind: bb41];
-+         _159 = move _183;
-+         _158 = copy (_159.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
-+         goto -> bb131;
+-         _98 = discriminant(_97);
+-         switchInt(move _98) -> [0: bb126, 1: bb131, otherwise: bb51];
++         _183 = move _171;
++         StorageDead(_171);
++         goto -> bb137;
       }
   
       bb133: {
--         StorageDead(_95);
--         goto -> bb16;
-+         _160 = &mut (((*_182) as variant#18).4: impl std::future::Future<Output = ()>);
-+         _157 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _160) -> [return: bb132, unwind: bb125];
-      }
-  
-      bb134: {
--         StorageDead(_95);
--         goto -> bb29;
-+         nop;
-+         (((*_182) as variant#18).4: impl std::future::Future<Output = ()>) = async_drop_in_place::<[AsyncInt; 2]>(copy (_161.0: &mut [AsyncInt; 2])) -> [return: bb133, unwind: bb125];
-      }
-  
--     bb135 (cleanup): {
--         StorageDead(_95);
--         goto -> bb45;
-+     bb135: {
-+         _162 = &mut (((*_182) as variant#18).3: [AsyncInt; 2]);
-+         _161 = Pin::<&mut [AsyncInt; 2]>::new_unchecked(move _162) -> [return: bb134, unwind: bb35];
-      }
-  
-      bb136: {
--         assert(const false, "`async fn` resumed after async drop") -> [success: bb136, unwind: bb135];
-+         nop;
-+         goto -> bb20;
-      }
-  
--     bb137: {
--         _2 = move _96;
--         StorageDead(_96);
--         goto -> bb136;
-+     bb137 (cleanup): {
-+         nop;
-+         goto -> bb36;
-      }
-  
-      bb138: {
--         _2 = move _96;
--         StorageDead(_96);
--         goto -> bb143;
-+         assert(const false, "`async fn` resumed after async drop") -> [success: bb138, unwind: bb137];
-      }
-  
-      bb139: {
--         StorageLive(_96);
--         _96 = yield(const ()) -> [resume: bb137, drop: bb138];
-+         _183 = move _164;
-+         StorageDead(_164);
-+         goto -> bb138;
-      }
-  
-      bb140: {
--         _98 = discriminant(_97);
--         switchInt(move _98) -> [0: bb134, 1: bb139, otherwise: bb59];
-+         _183 = move _171;
-+         StorageDead(_171);
-+         goto -> bb145;
-      }
-  
-      bb141: {
--         _97 = <impl Future<Output = ()> as Future>::poll(move _99, move _100) -> [return: bb140, unwind: bb135];
+-         _97 = <impl Future<Output = ()> as Future>::poll(move _99, move _100) -> [return: bb132, unwind: bb127];
 +         StorageLive(_171);
 +         _0 = Poll::<()>::Pending;
 +         StorageDead(_171);
@@ -1412,551 +1373,551 @@
 +         return;
       }
   
-      bb142: {
+      bb134: {
 -         _101 = move _2;
--         _100 = std::future::get_context::<'_, '_>(move _101) -> [return: bb141, unwind: bb135];
+-         _100 = std::future::get_context::<'_, '_>(move _101) -> [return: bb133, unwind: bb127];
 +         _173 = discriminant(_172);
-+         switchInt(move _173) -> [0: bb136, 1: bb141, otherwise: bb43];
++         switchInt(move _173) -> [0: bb128, 1: bb133, otherwise: bb35];
       }
   
-      bb143: {
+      bb135: {
 -         _102 = &mut _95;
--         _99 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _102) -> [return: bb142, unwind: bb135];
-+         _172 = <impl Future<Output = ()> as Future>::poll(move _174, move _175) -> [return: bb142, unwind: bb137];
+-         _99 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _102) -> [return: bb134, unwind: bb127];
++         _172 = <impl Future<Output = ()> as Future>::poll(move _174, move _175) -> [return: bb134, unwind: bb129];
       }
   
-      bb144: {
+      bb136: {
 -         _2 = move _103;
 -         StorageDead(_103);
--         goto -> bb150;
+-         goto -> bb142;
 +         _176 = move _183;
 +         _175 = copy (_176.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
-+         goto -> bb143;
++         goto -> bb135;
       }
   
-      bb145: {
+      bb137: {
 -         _2 = move _103;
 -         StorageDead(_103);
--         goto -> bb143;
+-         goto -> bb135;
 +         _177 = &mut (((*_182) as variant#20).3: impl std::future::Future<Output = ()>);
-+         _174 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _177) -> [return: bb144, unwind: bb137];
++         _174 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _177) -> [return: bb136, unwind: bb129];
       }
   
-      bb146: {
+      bb138: {
 -         StorageLive(_103);
--         _103 = yield(const ()) -> [resume: bb144, drop: bb145];
+-         _103 = yield(const ()) -> [resume: bb136, drop: bb137];
 +         nop;
-+         (((*_182) as variant#20).3: impl std::future::Future<Output = ()>) = async_drop_in_place::<AsyncInt>(copy (_178.0: &mut AsyncInt)) -> [return: bb145, unwind: bb137];
++         (((*_182) as variant#20).3: impl std::future::Future<Output = ()>) = async_drop_in_place::<AsyncInt>(copy (_178.0: &mut AsyncInt)) -> [return: bb137, unwind: bb129];
       }
   
-      bb147: {
+      bb139: {
 -         _105 = discriminant(_104);
--         switchInt(move _105) -> [0: bb133, 1: bb146, otherwise: bb59];
+-         switchInt(move _105) -> [0: bb125, 1: bb138, otherwise: bb51];
 +         _179 = &mut (((*_182) as variant#20).2: AsyncInt);
-+         _178 = Pin::<&mut AsyncInt>::new_unchecked(move _179) -> [return: bb146, unwind: bb36];
++         _178 = Pin::<&mut AsyncInt>::new_unchecked(move _179) -> [return: bb138, unwind: bb28];
       }
   
-      bb148: {
--         _104 = <impl Future<Output = ()> as Future>::poll(move _106, move _107) -> [return: bb147, unwind: bb135];
-+         goto -> bb22;
+      bb140: {
+-         _104 = <impl Future<Output = ()> as Future>::poll(move _106, move _107) -> [return: bb139, unwind: bb127];
++         goto -> bb14;
       }
   
--     bb149: {
+-     bb141: {
 -         _108 = move _2;
--         _107 = std::future::get_context::<'_, '_>(move _108) -> [return: bb148, unwind: bb135];
-+     bb149 (cleanup): {
+-         _107 = std::future::get_context::<'_, '_>(move _108) -> [return: bb140, unwind: bb127];
++     bb141 (cleanup): {
 +         discriminant((*_182)) = 2;
 +         resume;
       }
   
-      bb150: {
+      bb142: {
 -         _109 = &mut _95;
--         _106 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _109) -> [return: bb149, unwind: bb135];
+-         _106 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _109) -> [return: bb141, unwind: bb127];
 +         StorageLive(_17);
 +         StorageLive(_23);
 +         StorageLive(_25);
 +         StorageLive(_28);
 +         _28 = move _183;
-+         goto -> bb42;
++         goto -> bb34;
       }
   
-      bb151: {
+      bb143: {
 -         StorageLive(_95);
--         _95 = async_drop_in_place::<AsyncEnum>(copy (_110.0: &mut AsyncEnum)) -> [return: bb150, unwind: bb135];
+-         _95 = async_drop_in_place::<AsyncEnum>(copy (_110.0: &mut AsyncEnum)) -> [return: bb142, unwind: bb127];
 +         StorageLive(_17);
 +         StorageLive(_23);
 +         StorageLive(_25);
 +         StorageLive(_35);
 +         _35 = move _183;
-+         goto -> bb44;
++         goto -> bb36;
       }
   
-      bb152: {
+      bb144: {
 -         _111 = &mut _15;
--         _110 = Pin::<&mut AsyncEnum>::new_unchecked(move _111) -> [return: bb151, unwind: bb45];
+-         _110 = Pin::<&mut AsyncEnum>::new_unchecked(move _111) -> [return: bb143, unwind: bb37];
 +         StorageLive(_17);
 +         StorageLive(_23);
 +         StorageLive(_45);
 +         _45 = move _183;
-+         goto -> bb55;
++         goto -> bb47;
       }
   
-      bb153: {
+      bb145: {
 -         StorageDead(_112);
--         goto -> bb17;
+-         goto -> bb9;
 +         StorageLive(_17);
 +         StorageLive(_23);
 +         StorageLive(_52);
 +         _52 = move _183;
-+         goto -> bb56;
++         goto -> bb48;
       }
   
-      bb154: {
+      bb146: {
 -         StorageDead(_112);
--         goto -> bb30;
+-         goto -> bb22;
 +         StorageLive(_17);
 +         StorageLive(_62);
 +         _62 = move _183;
-+         goto -> bb67;
++         goto -> bb59;
       }
   
--     bb155 (cleanup): {
+-     bb147 (cleanup): {
 -         StorageDead(_112);
--         goto -> bb46;
-+     bb155: {
+-         goto -> bb38;
++     bb147: {
 +         StorageLive(_17);
 +         StorageLive(_69);
 +         _69 = move _183;
-+         goto -> bb68;
++         goto -> bb60;
       }
   
-      bb156: {
--         assert(const false, "`async fn` resumed after async drop") -> [success: bb156, unwind: bb155];
+      bb148: {
+-         assert(const false, "`async fn` resumed after async drop") -> [success: bb148, unwind: bb147];
 +         StorageLive(_17);
 +         StorageLive(_79);
 +         _79 = move _183;
-+         goto -> bb79;
++         goto -> bb71;
       }
   
-      bb157: {
+      bb149: {
 -         _2 = move _113;
 -         StorageDead(_113);
--         goto -> bb156;
+-         goto -> bb148;
 +         StorageLive(_17);
 +         StorageLive(_86);
 +         _86 = move _183;
-+         goto -> bb80;
++         goto -> bb72;
+      }
+  
+      bb150: {
+-         _2 = move _113;
+-         StorageDead(_113);
+-         goto -> bb155;
++         StorageLive(_96);
++         _96 = move _183;
++         goto -> bb83;
+      }
+  
+      bb151: {
+-         StorageLive(_113);
+-         _113 = yield(const ()) -> [resume: bb149, drop: bb150];
++         StorageLive(_103);
++         _103 = move _183;
++         goto -> bb84;
+      }
+  
+      bb152: {
+-         _115 = discriminant(_114);
+-         switchInt(move _115) -> [0: bb146, 1: bb151, otherwise: bb51];
++         StorageLive(_113);
++         _113 = move _183;
++         goto -> bb95;
+      }
+  
+      bb153: {
+-         _114 = <impl Future<Output = ()> as Future>::poll(move _116, move _117) -> [return: bb152, unwind: bb147];
++         StorageLive(_120);
++         _120 = move _183;
++         goto -> bb96;
+      }
+  
+      bb154: {
+-         _118 = move _2;
+-         _117 = std::future::get_context::<'_, '_>(move _118) -> [return: bb153, unwind: bb147];
++         StorageLive(_130);
++         _130 = move _183;
++         goto -> bb107;
+      }
+  
+      bb155: {
+-         _119 = &mut _112;
+-         _116 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _119) -> [return: bb154, unwind: bb147];
++         StorageLive(_137);
++         _137 = move _183;
++         goto -> bb108;
+      }
+  
+      bb156: {
+-         _2 = move _120;
+-         StorageDead(_120);
+-         goto -> bb162;
++         StorageLive(_147);
++         _147 = move _183;
++         goto -> bb119;
+      }
+  
+      bb157: {
+-         _2 = move _120;
+-         StorageDead(_120);
+-         goto -> bb155;
++         StorageLive(_154);
++         _154 = move _183;
++         goto -> bb120;
       }
   
       bb158: {
--         _2 = move _113;
--         StorageDead(_113);
--         goto -> bb163;
-+         StorageLive(_96);
-+         _96 = move _183;
-+         goto -> bb91;
+-         StorageLive(_120);
+-         _120 = yield(const ()) -> [resume: bb156, drop: bb157];
++         StorageLive(_164);
++         _164 = move _183;
++         goto -> bb131;
       }
   
       bb159: {
--         StorageLive(_113);
--         _113 = yield(const ()) -> [resume: bb157, drop: bb158];
-+         StorageLive(_103);
-+         _103 = move _183;
-+         goto -> bb92;
+-         _122 = discriminant(_121);
+-         switchInt(move _122) -> [0: bb145, 1: bb158, otherwise: bb51];
++         StorageLive(_171);
++         _171 = move _183;
++         goto -> bb132;
       }
   
       bb160: {
--         _115 = discriminant(_114);
--         switchInt(move _115) -> [0: bb154, 1: bb159, otherwise: bb59];
-+         StorageLive(_113);
-+         _113 = move _183;
-+         goto -> bb103;
+-         _121 = <impl Future<Output = ()> as Future>::poll(move _123, move _124) -> [return: bb159, unwind: bb147];
++         assert(const false, "`async fn` resumed after panicking") -> [success: bb160, unwind continue];
       }
   
       bb161: {
--         _114 = <impl Future<Output = ()> as Future>::poll(move _116, move _117) -> [return: bb160, unwind: bb155];
-+         StorageLive(_120);
-+         _120 = move _183;
-+         goto -> bb104;
+-         _125 = move _2;
+-         _124 = std::future::get_context::<'_, '_>(move _125) -> [return: bb160, unwind: bb147];
++         assert(const false, "`async fn` resumed after completion") -> [success: bb161, unwind continue];
       }
   
       bb162: {
--         _118 = move _2;
--         _117 = std::future::get_context::<'_, '_>(move _118) -> [return: bb161, unwind: bb155];
-+         StorageLive(_130);
-+         _130 = move _183;
-+         goto -> bb115;
-      }
-  
-      bb163: {
--         _119 = &mut _112;
--         _116 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _119) -> [return: bb162, unwind: bb155];
-+         StorageLive(_137);
-+         _137 = move _183;
-+         goto -> bb116;
-      }
-  
-      bb164: {
--         _2 = move _120;
--         StorageDead(_120);
--         goto -> bb170;
-+         StorageLive(_147);
-+         _147 = move _183;
-+         goto -> bb127;
-      }
-  
-      bb165: {
--         _2 = move _120;
--         StorageDead(_120);
--         goto -> bb163;
-+         StorageLive(_154);
-+         _154 = move _183;
-+         goto -> bb128;
-      }
-  
-      bb166: {
--         StorageLive(_120);
--         _120 = yield(const ()) -> [resume: bb164, drop: bb165];
-+         StorageLive(_164);
-+         _164 = move _183;
-+         goto -> bb139;
-      }
-  
-      bb167: {
--         _122 = discriminant(_121);
--         switchInt(move _122) -> [0: bb153, 1: bb166, otherwise: bb59];
-+         StorageLive(_171);
-+         _171 = move _183;
-+         goto -> bb140;
-      }
-  
-      bb168: {
--         _121 = <impl Future<Output = ()> as Future>::poll(move _123, move _124) -> [return: bb167, unwind: bb155];
-+         assert(const false, "`async fn` resumed after panicking") -> [success: bb168, unwind continue];
-      }
-  
-      bb169: {
--         _125 = move _2;
--         _124 = std::future::get_context::<'_, '_>(move _125) -> [return: bb168, unwind: bb155];
-+         assert(const false, "`async fn` resumed after completion") -> [success: bb169, unwind continue];
-      }
-  
-      bb170: {
 -         _126 = &mut _112;
--         _123 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _126) -> [return: bb169, unwind: bb155];
+-         _123 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _126) -> [return: bb161, unwind: bb147];
+-     }
+- 
+-     bb163: {
+-         StorageLive(_112);
+-         _112 = async_drop_in_place::<SyncThenAsync>(copy (_127.0: &mut SyncThenAsync)) -> [return: bb162, unwind: bb147];
+-     }
+- 
+-     bb164: {
+-         _128 = &mut _11;
+-         _127 = Pin::<&mut SyncThenAsync>::new_unchecked(move _128) -> [return: bb163, unwind: bb38];
+-     }
+- 
+-     bb165: {
+-         StorageDead(_129);
+-         goto -> bb10;
+-     }
+- 
+-     bb166: {
+-         StorageDead(_129);
+-         goto -> bb23;
+-     }
+- 
+-     bb167 (cleanup): {
+-         StorageDead(_129);
+-         goto -> bb39;
+-     }
+- 
+-     bb168: {
+-         assert(const false, "`async fn` resumed after async drop") -> [success: bb168, unwind: bb167];
+-     }
+- 
+-     bb169: {
+-         _2 = move _130;
+-         StorageDead(_130);
+-         goto -> bb168;
+-     }
+- 
+-     bb170: {
+-         _2 = move _130;
+-         StorageDead(_130);
+-         goto -> bb175;
 -     }
 - 
 -     bb171: {
--         StorageLive(_112);
--         _112 = async_drop_in_place::<SyncThenAsync>(copy (_127.0: &mut SyncThenAsync)) -> [return: bb170, unwind: bb155];
+-         StorageLive(_130);
+-         _130 = yield(const ()) -> [resume: bb169, drop: bb170];
 -     }
 - 
 -     bb172: {
--         _128 = &mut _11;
--         _127 = Pin::<&mut SyncThenAsync>::new_unchecked(move _128) -> [return: bb171, unwind: bb46];
+-         _132 = discriminant(_131);
+-         switchInt(move _132) -> [0: bb166, 1: bb171, otherwise: bb51];
 -     }
 - 
 -     bb173: {
--         StorageDead(_129);
--         goto -> bb18;
+-         _131 = <impl Future<Output = ()> as Future>::poll(move _133, move _134) -> [return: bb172, unwind: bb167];
 -     }
 - 
 -     bb174: {
--         StorageDead(_129);
--         goto -> bb31;
+-         _135 = move _2;
+-         _134 = std::future::get_context::<'_, '_>(move _135) -> [return: bb173, unwind: bb167];
 -     }
 - 
--     bb175 (cleanup): {
--         StorageDead(_129);
--         goto -> bb47;
+-     bb175: {
+-         _136 = &mut _129;
+-         _133 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _136) -> [return: bb174, unwind: bb167];
 -     }
 - 
 -     bb176: {
--         assert(const false, "`async fn` resumed after async drop") -> [success: bb176, unwind: bb175];
+-         _2 = move _137;
+-         StorageDead(_137);
+-         goto -> bb182;
 -     }
 - 
 -     bb177: {
--         _2 = move _130;
--         StorageDead(_130);
--         goto -> bb176;
+-         _2 = move _137;
+-         StorageDead(_137);
+-         goto -> bb175;
 -     }
 - 
 -     bb178: {
--         _2 = move _130;
--         StorageDead(_130);
--         goto -> bb183;
+-         StorageLive(_137);
+-         _137 = yield(const ()) -> [resume: bb176, drop: bb177];
 -     }
 - 
 -     bb179: {
--         StorageLive(_130);
--         _130 = yield(const ()) -> [resume: bb177, drop: bb178];
+-         _139 = discriminant(_138);
+-         switchInt(move _139) -> [0: bb165, 1: bb178, otherwise: bb51];
 -     }
 - 
 -     bb180: {
--         _132 = discriminant(_131);
--         switchInt(move _132) -> [0: bb174, 1: bb179, otherwise: bb59];
+-         _138 = <impl Future<Output = ()> as Future>::poll(move _140, move _141) -> [return: bb179, unwind: bb167];
 -     }
 - 
 -     bb181: {
--         _131 = <impl Future<Output = ()> as Future>::poll(move _133, move _134) -> [return: bb180, unwind: bb175];
+-         _142 = move _2;
+-         _141 = std::future::get_context::<'_, '_>(move _142) -> [return: bb180, unwind: bb167];
 -     }
 - 
 -     bb182: {
--         _135 = move _2;
--         _134 = std::future::get_context::<'_, '_>(move _135) -> [return: bb181, unwind: bb175];
+-         _143 = &mut _129;
+-         _140 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _143) -> [return: bb181, unwind: bb167];
 -     }
 - 
 -     bb183: {
--         _136 = &mut _129;
--         _133 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _136) -> [return: bb182, unwind: bb175];
+-         StorageLive(_129);
+-         _129 = async_drop_in_place::<AsyncStruct>(copy (_144.0: &mut AsyncStruct)) -> [return: bb182, unwind: bb167];
 -     }
 - 
 -     bb184: {
--         _2 = move _137;
--         StorageDead(_137);
--         goto -> bb190;
+-         _145 = &mut _8;
+-         _144 = Pin::<&mut AsyncStruct>::new_unchecked(move _145) -> [return: bb183, unwind: bb39];
 -     }
 - 
 -     bb185: {
--         _2 = move _137;
--         StorageDead(_137);
--         goto -> bb183;
+-         StorageDead(_146);
+-         goto -> bb11;
 -     }
 - 
 -     bb186: {
--         StorageLive(_137);
--         _137 = yield(const ()) -> [resume: bb184, drop: bb185];
+-         StorageDead(_146);
+-         goto -> bb24;
 -     }
 - 
--     bb187: {
--         _139 = discriminant(_138);
--         switchInt(move _139) -> [0: bb173, 1: bb186, otherwise: bb59];
+-     bb187 (cleanup): {
+-         StorageDead(_146);
+-         goto -> bb40;
 -     }
 - 
 -     bb188: {
--         _138 = <impl Future<Output = ()> as Future>::poll(move _140, move _141) -> [return: bb187, unwind: bb175];
+-         assert(const false, "`async fn` resumed after async drop") -> [success: bb188, unwind: bb187];
 -     }
 - 
 -     bb189: {
--         _142 = move _2;
--         _141 = std::future::get_context::<'_, '_>(move _142) -> [return: bb188, unwind: bb175];
+-         _2 = move _147;
+-         StorageDead(_147);
+-         goto -> bb188;
 -     }
 - 
 -     bb190: {
--         _143 = &mut _129;
--         _140 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _143) -> [return: bb189, unwind: bb175];
+-         _2 = move _147;
+-         StorageDead(_147);
+-         goto -> bb195;
 -     }
 - 
 -     bb191: {
--         StorageLive(_129);
--         _129 = async_drop_in_place::<AsyncStruct>(copy (_144.0: &mut AsyncStruct)) -> [return: bb190, unwind: bb175];
+-         StorageLive(_147);
+-         _147 = yield(const ()) -> [resume: bb189, drop: bb190];
 -     }
 - 
 -     bb192: {
--         _145 = &mut _8;
--         _144 = Pin::<&mut AsyncStruct>::new_unchecked(move _145) -> [return: bb191, unwind: bb47];
+-         _149 = discriminant(_148);
+-         switchInt(move _149) -> [0: bb186, 1: bb191, otherwise: bb51];
 -     }
 - 
 -     bb193: {
--         StorageDead(_146);
--         goto -> bb19;
+-         _148 = <impl Future<Output = ()> as Future>::poll(move _150, move _151) -> [return: bb192, unwind: bb187];
 -     }
 - 
 -     bb194: {
--         StorageDead(_146);
--         goto -> bb32;
+-         _152 = move _2;
+-         _151 = std::future::get_context::<'_, '_>(move _152) -> [return: bb193, unwind: bb187];
 -     }
 - 
--     bb195 (cleanup): {
--         StorageDead(_146);
--         goto -> bb48;
+-     bb195: {
+-         _153 = &mut _146;
+-         _150 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _153) -> [return: bb194, unwind: bb187];
 -     }
 - 
 -     bb196: {
--         assert(const false, "`async fn` resumed after async drop") -> [success: bb196, unwind: bb195];
+-         _2 = move _154;
+-         StorageDead(_154);
+-         goto -> bb202;
 -     }
 - 
 -     bb197: {
--         _2 = move _147;
--         StorageDead(_147);
--         goto -> bb196;
+-         _2 = move _154;
+-         StorageDead(_154);
+-         goto -> bb195;
 -     }
 - 
 -     bb198: {
--         _2 = move _147;
--         StorageDead(_147);
--         goto -> bb203;
+-         StorageLive(_154);
+-         _154 = yield(const ()) -> [resume: bb196, drop: bb197];
 -     }
 - 
 -     bb199: {
--         StorageLive(_147);
--         _147 = yield(const ()) -> [resume: bb197, drop: bb198];
+-         _156 = discriminant(_155);
+-         switchInt(move _156) -> [0: bb185, 1: bb198, otherwise: bb51];
 -     }
 - 
 -     bb200: {
--         _149 = discriminant(_148);
--         switchInt(move _149) -> [0: bb194, 1: bb199, otherwise: bb59];
+-         _155 = <impl Future<Output = ()> as Future>::poll(move _157, move _158) -> [return: bb199, unwind: bb187];
 -     }
 - 
 -     bb201: {
--         _148 = <impl Future<Output = ()> as Future>::poll(move _150, move _151) -> [return: bb200, unwind: bb195];
+-         _159 = move _2;
+-         _158 = std::future::get_context::<'_, '_>(move _159) -> [return: bb200, unwind: bb187];
 -     }
 - 
 -     bb202: {
--         _152 = move _2;
--         _151 = std::future::get_context::<'_, '_>(move _152) -> [return: bb201, unwind: bb195];
+-         _160 = &mut _146;
+-         _157 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _160) -> [return: bb201, unwind: bb187];
 -     }
 - 
 -     bb203: {
--         _153 = &mut _146;
--         _150 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _153) -> [return: bb202, unwind: bb195];
+-         StorageLive(_146);
+-         _146 = async_drop_in_place::<[AsyncInt; 2]>(copy (_161.0: &mut [AsyncInt; 2])) -> [return: bb202, unwind: bb187];
 -     }
 - 
 -     bb204: {
--         _2 = move _154;
--         StorageDead(_154);
--         goto -> bb210;
+-         _162 = &mut _5;
+-         _161 = Pin::<&mut [AsyncInt; 2]>::new_unchecked(move _162) -> [return: bb203, unwind: bb40];
 -     }
 - 
 -     bb205: {
--         _2 = move _154;
--         StorageDead(_154);
--         goto -> bb203;
+-         StorageDead(_163);
+-         goto -> bb12;
 -     }
 - 
 -     bb206: {
--         StorageLive(_154);
--         _154 = yield(const ()) -> [resume: bb204, drop: bb205];
+-         StorageDead(_163);
+-         goto -> bb25;
 -     }
 - 
--     bb207: {
--         _156 = discriminant(_155);
--         switchInt(move _156) -> [0: bb193, 1: bb206, otherwise: bb59];
+-     bb207 (cleanup): {
+-         StorageDead(_163);
+-         goto -> bb41;
 -     }
 - 
 -     bb208: {
--         _155 = <impl Future<Output = ()> as Future>::poll(move _157, move _158) -> [return: bb207, unwind: bb195];
+-         assert(const false, "`async fn` resumed after async drop") -> [success: bb208, unwind: bb207];
 -     }
 - 
 -     bb209: {
--         _159 = move _2;
--         _158 = std::future::get_context::<'_, '_>(move _159) -> [return: bb208, unwind: bb195];
+-         _2 = move _164;
+-         StorageDead(_164);
+-         goto -> bb208;
 -     }
 - 
 -     bb210: {
--         _160 = &mut _146;
--         _157 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _160) -> [return: bb209, unwind: bb195];
+-         _2 = move _164;
+-         StorageDead(_164);
+-         goto -> bb215;
 -     }
 - 
 -     bb211: {
--         StorageLive(_146);
--         _146 = async_drop_in_place::<[AsyncInt; 2]>(copy (_161.0: &mut [AsyncInt; 2])) -> [return: bb210, unwind: bb195];
+-         StorageLive(_164);
+-         _164 = yield(const ()) -> [resume: bb209, drop: bb210];
 -     }
 - 
 -     bb212: {
--         _162 = &mut _5;
--         _161 = Pin::<&mut [AsyncInt; 2]>::new_unchecked(move _162) -> [return: bb211, unwind: bb48];
+-         _166 = discriminant(_165);
+-         switchInt(move _166) -> [0: bb206, 1: bb211, otherwise: bb51];
 -     }
 - 
 -     bb213: {
--         StorageDead(_163);
--         goto -> bb20;
+-         _165 = <impl Future<Output = ()> as Future>::poll(move _167, move _168) -> [return: bb212, unwind: bb207];
 -     }
 - 
 -     bb214: {
--         StorageDead(_163);
--         goto -> bb33;
+-         _169 = move _2;
+-         _168 = std::future::get_context::<'_, '_>(move _169) -> [return: bb213, unwind: bb207];
 -     }
 - 
--     bb215 (cleanup): {
--         StorageDead(_163);
--         goto -> bb49;
+-     bb215: {
+-         _170 = &mut _163;
+-         _167 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _170) -> [return: bb214, unwind: bb207];
 -     }
 - 
 -     bb216: {
--         assert(const false, "`async fn` resumed after async drop") -> [success: bb216, unwind: bb215];
+-         _2 = move _171;
+-         StorageDead(_171);
+-         goto -> bb222;
 -     }
 - 
 -     bb217: {
--         _2 = move _164;
--         StorageDead(_164);
--         goto -> bb216;
+-         _2 = move _171;
+-         StorageDead(_171);
+-         goto -> bb215;
 -     }
 - 
 -     bb218: {
--         _2 = move _164;
--         StorageDead(_164);
--         goto -> bb223;
+-         StorageLive(_171);
+-         _171 = yield(const ()) -> [resume: bb216, drop: bb217];
 -     }
 - 
 -     bb219: {
--         StorageLive(_164);
--         _164 = yield(const ()) -> [resume: bb217, drop: bb218];
+-         _173 = discriminant(_172);
+-         switchInt(move _173) -> [0: bb205, 1: bb218, otherwise: bb51];
 -     }
 - 
 -     bb220: {
--         _166 = discriminant(_165);
--         switchInt(move _166) -> [0: bb214, 1: bb219, otherwise: bb59];
+-         _172 = <impl Future<Output = ()> as Future>::poll(move _174, move _175) -> [return: bb219, unwind: bb207];
 -     }
 - 
 -     bb221: {
--         _165 = <impl Future<Output = ()> as Future>::poll(move _167, move _168) -> [return: bb220, unwind: bb215];
+-         _176 = move _2;
+-         _175 = std::future::get_context::<'_, '_>(move _176) -> [return: bb220, unwind: bb207];
 -     }
 - 
 -     bb222: {
--         _169 = move _2;
--         _168 = std::future::get_context::<'_, '_>(move _169) -> [return: bb221, unwind: bb215];
+-         _177 = &mut _163;
+-         _174 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _177) -> [return: bb221, unwind: bb207];
 -     }
 - 
 -     bb223: {
--         _170 = &mut _163;
--         _167 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _170) -> [return: bb222, unwind: bb215];
+-         StorageLive(_163);
+-         _163 = async_drop_in_place::<AsyncInt>(copy (_178.0: &mut AsyncInt)) -> [return: bb222, unwind: bb207];
 -     }
 - 
 -     bb224: {
--         _2 = move _171;
--         StorageDead(_171);
--         goto -> bb230;
--     }
-- 
--     bb225: {
--         _2 = move _171;
--         StorageDead(_171);
--         goto -> bb223;
--     }
-- 
--     bb226: {
--         StorageLive(_171);
--         _171 = yield(const ()) -> [resume: bb224, drop: bb225];
--     }
-- 
--     bb227: {
--         _173 = discriminant(_172);
--         switchInt(move _173) -> [0: bb213, 1: bb226, otherwise: bb59];
--     }
-- 
--     bb228: {
--         _172 = <impl Future<Output = ()> as Future>::poll(move _174, move _175) -> [return: bb227, unwind: bb215];
--     }
-- 
--     bb229: {
--         _176 = move _2;
--         _175 = std::future::get_context::<'_, '_>(move _176) -> [return: bb228, unwind: bb215];
--     }
-- 
--     bb230: {
--         _177 = &mut _163;
--         _174 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _177) -> [return: bb229, unwind: bb215];
--     }
-- 
--     bb231: {
--         StorageLive(_163);
--         _163 = async_drop_in_place::<AsyncInt>(copy (_178.0: &mut AsyncInt)) -> [return: bb230, unwind: bb215];
--     }
-- 
--     bb232: {
 -         _179 = &mut _4;
--         _178 = Pin::<&mut AsyncInt>::new_unchecked(move _179) -> [return: bb231, unwind: bb49];
+-         _178 = Pin::<&mut AsyncInt>::new_unchecked(move _179) -> [return: bb223, unwind: bb41];
 +         nop;
 +         (((*_182) as variant#20).1: SyncInt) = SyncInt(const 0_i32);
 +         nop;
@@ -1967,7 +1928,36 @@
 +         StorageLive(_7);
 +         _7 = AsyncInt(const 2_i32);
 +         (((*_182) as variant#18).3: [AsyncInt; 2]) = [move _6, move _7];
-+         goto -> bb1;
++         StorageDead(_7);
++         StorageDead(_6);
++         nop;
++         StorageLive(_9);
++         _9 = AsyncInt(const 5_i32);
++         StorageLive(_10);
++         _10 = AsyncInt(const 4_i32);
++         (((*_182) as variant#16).4: AsyncStruct) = AsyncStruct { i: const 3_i32, a: move _10, b: move _9 };
++         StorageDead(_10);
++         StorageDead(_9);
++         nop;
++         StorageLive(_12);
++         _12 = AsyncInt(const 7_i32);
++         StorageLive(_13);
++         _13 = SyncInt(const 8_i32);
++         StorageLive(_14);
++         _14 = AsyncInt(const 9_i32);
++         (((*_182) as variant#14).5: SyncThenAsync) = SyncThenAsync { i: const 6_i32, a: move _12, b: move _13, c: move _14 };
++         StorageDead(_14);
++         StorageDead(_13);
++         StorageDead(_12);
++         nop;
++         StorageLive(_16);
++         _16 = AsyncInt(const 10_i32);
++         (((*_182) as variant#12).6: AsyncEnum) = AsyncEnum::A(move _16);
++         StorageDead(_16);
++         StorageLive(_17);
++         StorageLive(_18);
++         _18 = AsyncInt(const 11_i32);
++         _17 = ManuallyDrop::<AsyncInt>::new(move _18) -> [return: bb1, unwind: bb21];
       }
   }
   

--- a/tests/mir-opt/coroutine/async_fn.add-{closure#0}.StateTransform.diff
+++ b/tests/mir-opt/coroutine/async_fn.add-{closure#0}.StateTransform.diff
@@ -95,7 +95,7 @@
 +         _28 = std::future::ResumeTy(move _29);
 +         _27 = copy (_1.0: &mut {async fn body of add()});
 +         _26 = discriminant((*_27));
-+         switchInt(move _26) -> [0: bb28, 1: bb27, 2: bb26, 3: bb25, otherwise: bb6];
++         switchInt(move _26) -> [0: bb27, 1: bb26, 2: bb25, 3: bb24, otherwise: bb6];
       }
   
       bb1: {
@@ -207,10 +207,10 @@
           StorageDead(_5);
 -         StorageDead(_4);
 -         StorageDead(_3);
--         drop(_1) -> [return: bb13, unwind: bb28];
+-         drop(_1) -> [return: bb13, unwind: bb27];
 +         nop;
 +         nop;
-+         goto -> bb23;
++         goto -> bb22;
       }
   
       bb13: {
@@ -222,7 +222,7 @@
 -     bb14: {
 -         StorageDead(_24);
 -         StorageDead(_23);
--         drop(_10) -> [return: bb15, unwind: bb29];
+-         drop(_10) -> [return: bb15, unwind: bb28];
 +     bb14 (cleanup): {
 +         StorageDead(_18);
 +         StorageDead(_17);
@@ -251,21 +251,22 @@
 -         StorageDead(_5);
 -         StorageDead(_4);
 -         StorageDead(_3);
--         drop(_1) -> [return: bb18, unwind: bb28];
+-         drop(_1) -> [return: bb18, unwind: bb27];
 +     bb17 (cleanup): {
 +         nop;
-+         goto -> bb20;
++         goto -> bb19;
       }
   
 -     bb18: {
 -         coroutine_drop;
 +     bb18 (cleanup): {
++         StorageDead(_9);
 +         goto -> bb19;
       }
   
       bb19 (cleanup): {
 -         StorageDead(_19);
-+         StorageDead(_9);
++         StorageDead(_8);
           goto -> bb20;
       }
   
@@ -273,44 +274,39 @@
 -         StorageDead(_18);
 -         StorageDead(_17);
 -         goto -> bb22;
-+         StorageDead(_8);
++         StorageDead(_5);
++         nop;
++         nop;
 +         goto -> bb21;
       }
   
       bb21 (cleanup): {
 -         StorageDead(_15);
-+         StorageDead(_5);
-+         nop;
-+         nop;
-          goto -> bb22;
+-         goto -> bb22;
++         goto -> bb23;
       }
   
-      bb22 (cleanup): {
+-     bb22 (cleanup): {
 -         StorageDead(_16);
 -         StorageDead(_14);
 -         StorageDead(_13);
 -         StorageDead(_12);
 -         drop(_10) -> [return: bb23, unwind terminate(cleanup)];
-+         goto -> bb24;
-      }
-  
--     bb23 (cleanup): {
--         StorageDead(_10);
--         goto -> bb26;
-+     bb23: {
++     bb22: {
 +         goto -> bb13;
       }
   
-      bb24 (cleanup): {
+      bb23 (cleanup): {
+-         StorageDead(_10);
 -         goto -> bb25;
 +         discriminant((*_27)) = 2;
 +         resume;
       }
   
--     bb25 (cleanup): {
+-     bb24 (cleanup): {
 -         StorageDead(_9);
--         goto -> bb26;
-+     bb25: {
+-         goto -> bb25;
++     bb24: {
 +         StorageLive(_5);
 +         StorageLive(_8);
 +         StorageLive(_23);
@@ -319,42 +315,42 @@
 +         goto -> bb9;
       }
   
--     bb26 (cleanup): {
+-     bb25 (cleanup): {
 -         StorageDead(_8);
--         goto -> bb27;
-+     bb26: {
-+         assert(const false, "`async fn` resumed after panicking") -> [success: bb26, unwind continue];
+-         goto -> bb26;
++     bb25: {
++         assert(const false, "`async fn` resumed after panicking") -> [success: bb25, unwind continue];
       }
   
--     bb27 (cleanup): {
+-     bb26 (cleanup): {
 -         StorageDead(_5);
 -         StorageDead(_4);
 -         StorageDead(_3);
--         drop(_1) -> [return: bb28, unwind terminate(cleanup)];
-+     bb27: {
-+         assert(const false, "`async fn` resumed after completion") -> [success: bb27, unwind continue];
+-         drop(_1) -> [return: bb27, unwind terminate(cleanup)];
++     bb26: {
++         assert(const false, "`async fn` resumed after completion") -> [success: bb26, unwind continue];
       }
   
--     bb28 (cleanup): {
+-     bb27 (cleanup): {
 -         resume;
 -     }
 - 
--     bb29 (cleanup): {
+-     bb28 (cleanup): {
 -         StorageDead(_10);
+-         goto -> bb29;
+-     }
+- 
+-     bb29 (cleanup): {
+-         StorageDead(_8);
 -         goto -> bb30;
 -     }
 - 
 -     bb30 (cleanup): {
--         StorageDead(_8);
--         goto -> bb31;
--     }
-- 
--     bb31 (cleanup): {
 -         StorageDead(_5);
 -         StorageDead(_4);
 -         StorageDead(_3);
--         drop(_1) -> [return: bb28, unwind terminate(cleanup)];
-+     bb28: {
+-         drop(_1) -> [return: bb27, unwind terminate(cleanup)];
++     bb27: {
 +         nop;
 +         (((*_27) as variant#3).0: u32) = copy ((*_27).0: u32);
 +         nop;

--- a/tests/mir-opt/coroutine/async_fn.build_aggregate-{closure#0}.StateTransform.diff
+++ b/tests/mir-opt/coroutine/async_fn.build_aggregate-{closure#0}.StateTransform.diff
@@ -136,12 +136,12 @@
 -         _11 = copy _3;
 -         StorageLive(_12);
 -         _12 = copy _4;
--         _10 = add(move _11, move _12) -> [return: bb1, unwind: bb49];
+-         _10 = add(move _11, move _12) -> [return: bb1, unwind: bb47];
 +         _53 = move _2 as std::ptr::NonNull<std::task::Context<'_>> (Transmute);
 +         _52 = std::future::ResumeTy(move _53);
 +         _51 = copy (_1.0: &mut {async fn body of build_aggregate()});
 +         _50 = discriminant((*_51));
-+         switchInt(move _50) -> [0: bb49, 1: bb48, 2: bb47, 3: bb45, 4: bb46, otherwise: bb7];
++         switchInt(move _50) -> [0: bb47, 1: bb46, 2: bb45, 3: bb43, 4: bb44, otherwise: bb7];
       }
   
       bb1: {
@@ -170,8 +170,8 @@
 -         _19 = &mut _13;
 +         _19 = &mut (((*_51) as variant#3).2: {async fn body of add()});
           _18 = &mut (*_19);
--         _17 = Pin::<&mut {async fn body of add()}>::new_unchecked(move _18) -> [return: bb4, unwind: bb44];
-+         _17 = Pin::<&mut {async fn body of add()}>::new_unchecked(move _18) -> [return: bb4, unwind: bb34];
+-         _17 = Pin::<&mut {async fn body of add()}>::new_unchecked(move _18) -> [return: bb4, unwind: bb43];
++         _17 = Pin::<&mut {async fn body of add()}>::new_unchecked(move _18) -> [return: bb4, unwind: bb33];
       }
   
       bb4: {
@@ -180,7 +180,7 @@
           StorageLive(_21);
           StorageLive(_22);
 -         _22 = copy _2;
--         _21 = std::future::get_context::<'_, '_>(move _22) -> [return: bb5, unwind: bb42];
+-         _21 = std::future::get_context::<'_, '_>(move _22) -> [return: bb5, unwind: bb41];
 +         _22 = copy _52;
 +         _21 = copy (_22.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
 +         goto -> bb5;
@@ -189,8 +189,8 @@
       bb5: {
           _20 = &mut (*_21);
           StorageDead(_22);
--         _16 = <{async fn body of add()} as Future>::poll(move _17, move _20) -> [return: bb6, unwind: bb43];
-+         _16 = <{async fn body of add()} as Future>::poll(move _17, move _20) -> [return: bb6, unwind: bb33];
+-         _16 = <{async fn body of add()} as Future>::poll(move _17, move _20) -> [return: bb6, unwind: bb42];
++         _16 = <{async fn body of add()} as Future>::poll(move _17, move _20) -> [return: bb6, unwind: bb32];
       }
   
       bb6: {
@@ -234,8 +234,8 @@
           StorageDead(_24);
           StorageDead(_16);
           StorageDead(_15);
--         drop(_13) -> [return: bb11, unwind: bb46];
-+         drop((((*_51) as variant#3).2: {async fn body of add()})) -> [return: bb11, unwind: bb36];
+-         drop(_13) -> [return: bb11, unwind: bb45];
++         drop((((*_51) as variant#3).2: {async fn body of add()})) -> [return: bb11, unwind: bb35];
       }
   
       bb10: {
@@ -258,16 +258,16 @@
 +         _31 = copy (((*_51) as variant#3).0: u32);
           StorageLive(_32);
 -         _32 = copy _6;
--         _30 = add(move _31, move _32) -> [return: bb12, unwind: bb39];
+-         _30 = add(move _31, move _32) -> [return: bb12, unwind: bb38];
 +         _32 = copy (((*_51) as variant#3).1: u32);
-+         _30 = add(move _31, move _32) -> [return: bb12, unwind: bb30];
++         _30 = add(move _31, move _32) -> [return: bb12, unwind: bb29];
       }
   
       bb12: {
           StorageDead(_32);
           StorageDead(_31);
--         _29 = <{async fn body of add()} as IntoFuture>::into_future(move _30) -> [return: bb13, unwind: bb38];
-+         _29 = <{async fn body of add()} as IntoFuture>::into_future(move _30) -> [return: bb13, unwind: bb29];
+-         _29 = <{async fn body of add()} as IntoFuture>::into_future(move _30) -> [return: bb13, unwind: bb39];
++         _29 = <{async fn body of add()} as IntoFuture>::into_future(move _30) -> [return: bb13, unwind: bb30];
       }
   
       bb13: {
@@ -396,8 +396,8 @@
 +         nop;
           StorageDead(_4);
           StorageDead(_3);
--         drop(_1) -> [return: bb24, unwind: bb52];
-+         goto -> bb43;
+-         drop(_1) -> [return: bb24, unwind: bb50];
++         goto -> bb41;
       }
   
       bb24: {
@@ -409,7 +409,7 @@
 -     bb25: {
 -         StorageDead(_46);
 -         StorageDead(_45);
--         drop(_33) -> [return: bb26, unwind: bb53];
+-         drop(_33) -> [return: bb26, unwind: bb51];
 -     }
 - 
 -     bb26: {
@@ -427,7 +427,7 @@
 -     bb28: {
 -         StorageDead(_27);
 -         StorageDead(_26);
--         drop(_13) -> [return: bb29, unwind: bb55];
+-         drop(_13) -> [return: bb29, unwind: bb53];
 -     }
 - 
 -     bb29: {
@@ -447,7 +447,7 @@
 -         StorageDead(_5);
 -         StorageDead(_4);
 -         StorageDead(_3);
--         drop(_1) -> [return: bb32, unwind: bb52];
+-         drop(_1) -> [return: bb32, unwind: bb50];
 -     }
 - 
 -     bb32: {
@@ -490,113 +490,101 @@
 +         nop;
           StorageDead(_28);
 -         StorageDead(_8);
--         goto -> bb41;
+-         goto -> bb40;
 +         nop;
-+         goto -> bb32;
++         goto -> bb31;
       }
   
 -     bb38 (cleanup): {
--         goto -> bb40;
 +     bb29 (cleanup): {
-+         goto -> bb31;
+          StorageDead(_32);
+          StorageDead(_31);
+-         goto -> bb39;
++         goto -> bb30;
       }
   
 -     bb39 (cleanup): {
 +     bb30 (cleanup): {
-          StorageDead(_32);
-          StorageDead(_31);
+          StorageDead(_30);
+          StorageDead(_28);
+-         StorageDead(_8);
 -         goto -> bb40;
++         nop;
 +         goto -> bb31;
       }
   
 -     bb40 (cleanup): {
 +     bb31 (cleanup): {
-          StorageDead(_30);
-          StorageDead(_28);
--         StorageDead(_8);
--         goto -> bb41;
-+         nop;
-+         goto -> bb32;
+          StorageDead(_29);
+-         goto -> bb46;
++         goto -> bb36;
       }
   
 -     bb41 (cleanup): {
-+     bb32 (cleanup): {
-          StorageDead(_29);
--         goto -> bb47;
-+         goto -> bb37;
-      }
-  
--     bb42 (cleanup): {
 -         StorageDead(_22);
--         goto -> bb43;
+-         goto -> bb42;
 -     }
 - 
--     bb43 (cleanup): {
-+     bb33 (cleanup): {
+-     bb42 (cleanup): {
++     bb32 (cleanup): {
           StorageDead(_21);
           StorageDead(_20);
--         goto -> bb45;
-+         goto -> bb35;
+-         goto -> bb44;
++         goto -> bb34;
+      }
+  
+-     bb43 (cleanup): {
++     bb33 (cleanup): {
+          StorageDead(_18);
+-         goto -> bb44;
++         goto -> bb34;
       }
   
 -     bb44 (cleanup): {
 +     bb34 (cleanup): {
-          StorageDead(_18);
--         goto -> bb45;
-+         goto -> bb35;
-      }
-  
--     bb45 (cleanup): {
-+     bb35 (cleanup): {
           StorageDead(_19);
           StorageDead(_17);
           StorageDead(_16);
           StorageDead(_15);
--         drop(_13) -> [return: bb46, unwind terminate(cleanup)];
-+         drop((((*_51) as variant#3).2: {async fn body of add()})) -> [return: bb36, unwind terminate(cleanup)];
+-         drop(_13) -> [return: bb45, unwind terminate(cleanup)];
++         drop((((*_51) as variant#3).2: {async fn body of add()})) -> [return: bb35, unwind terminate(cleanup)];
+      }
+  
+-     bb45 (cleanup): {
+-         StorageDead(_13);
+-         StorageDead(_8);
+-         goto -> bb46;
++     bb35 (cleanup): {
++         nop;
++         nop;
++         goto -> bb36;
       }
   
 -     bb46 (cleanup): {
--         StorageDead(_13);
--         StorageDead(_8);
--         goto -> bb47;
+-         goto -> bb49;
 +     bb36 (cleanup): {
-+         nop;
-+         nop;
-+         goto -> bb37;
++         goto -> bb39;
       }
   
 -     bb47 (cleanup): {
--         goto -> bb51;
 +     bb37 (cleanup): {
-+         goto -> bb41;
+          StorageDead(_12);
+          StorageDead(_11);
+-         goto -> bb48;
++         goto -> bb38;
       }
   
 -     bb48 (cleanup): {
--         goto -> bb50;
 +     bb38 (cleanup): {
-+         goto -> bb40;
+          StorageDead(_10);
+-         StorageDead(_8);
+-         goto -> bb49;
++         nop;
++         goto -> bb39;
       }
   
 -     bb49 (cleanup): {
 +     bb39 (cleanup): {
-          StorageDead(_12);
-          StorageDead(_11);
--         goto -> bb50;
-+         goto -> bb40;
-      }
-  
--     bb50 (cleanup): {
-+     bb40 (cleanup): {
-          StorageDead(_10);
--         StorageDead(_8);
--         goto -> bb51;
-+         nop;
-+         goto -> bb41;
-      }
-  
--     bb51 (cleanup): {
-+     bb41 (cleanup): {
           StorageDead(_9);
           StorageDead(_7);
 -         StorageDead(_6);
@@ -605,30 +593,30 @@
 +         nop;
           StorageDead(_4);
           StorageDead(_3);
--         drop(_1) -> [return: bb52, unwind terminate(cleanup)];
-+         goto -> bb42;
+-         drop(_1) -> [return: bb50, unwind terminate(cleanup)];
++         goto -> bb40;
       }
   
--     bb52 (cleanup): {
-+     bb42 (cleanup): {
-+         goto -> bb44;
+-     bb50 (cleanup): {
++     bb40 (cleanup): {
++         goto -> bb42;
 +     }
 + 
-+     bb43: {
++     bb41: {
 +         goto -> bb24;
 +     }
 + 
-+     bb44 (cleanup): {
++     bb42 (cleanup): {
 +         discriminant((*_51)) = 2;
           resume;
       }
   
--     bb53 (cleanup): {
+-     bb51 (cleanup): {
 -         StorageDead(_33);
 -         StorageDead(_28);
 -         StorageDead(_8);
--         goto -> bb54;
-+     bb45: {
+-         goto -> bb52;
++     bb43: {
 +         StorageLive(_3);
 +         StorageLive(_4);
 +         StorageLive(_7);
@@ -639,10 +627,10 @@
 +         goto -> bb10;
       }
   
--     bb54 (cleanup): {
+-     bb52 (cleanup): {
 -         StorageDead(_29);
--         goto -> bb56;
-+     bb46: {
+-         goto -> bb54;
++     bb44: {
 +         StorageLive(_3);
 +         StorageLive(_4);
 +         StorageLive(_7);
@@ -655,29 +643,29 @@
 +         goto -> bb20;
       }
   
--     bb55 (cleanup): {
+-     bb53 (cleanup): {
 -         StorageDead(_13);
 -         StorageDead(_8);
--         goto -> bb56;
-+     bb47: {
-+         assert(const false, "`async fn` resumed after panicking") -> [success: bb47, unwind continue];
+-         goto -> bb54;
++     bb45: {
++         assert(const false, "`async fn` resumed after panicking") -> [success: bb45, unwind continue];
       }
   
--     bb56 (cleanup): {
--         goto -> bb57;
-+     bb48: {
-+         assert(const false, "`async fn` resumed after completion") -> [success: bb48, unwind continue];
+-     bb54 (cleanup): {
+-         goto -> bb55;
++     bb46: {
++         assert(const false, "`async fn` resumed after completion") -> [success: bb46, unwind continue];
       }
   
--     bb57 (cleanup): {
+-     bb55 (cleanup): {
 -         StorageDead(_9);
 -         StorageDead(_7);
 -         StorageDead(_6);
 -         StorageDead(_5);
 -         StorageDead(_4);
 -         StorageDead(_3);
--         drop(_1) -> [return: bb52, unwind terminate(cleanup)];
-+     bb49: {
+-         drop(_1) -> [return: bb50, unwind terminate(cleanup)];
++     bb47: {
 +         StorageLive(_3);
 +         _3 = copy ((*_51).0: u32);
 +         StorageLive(_4);
@@ -694,7 +682,7 @@
 +         _11 = copy _3;
 +         StorageLive(_12);
 +         _12 = copy _4;
-+         _10 = add(move _11, move _12) -> [return: bb1, unwind: bb39];
++         _10 = add(move _11, move _12) -> [return: bb1, unwind: bb37];
       }
   }
   

--- a/tests/mir-opt/coroutine/async_fn.foo-{closure#0}.StateTransform.diff
+++ b/tests/mir-opt/coroutine/async_fn.foo-{closure#0}.StateTransform.diff
@@ -128,7 +128,7 @@
 +         _38 = std::future::ResumeTy(move _39);
 +         _36 = copy (_1.0: &mut {async fn body of foo()});
 +         _35 = discriminant((*_36));
-+         switchInt(move _35) -> [0: bb26, 1: bb25, 2: bb24, 3: bb23, otherwise: bb6];
++         switchInt(move _35) -> [0: bb25, 1: bb24, 2: bb23, 3: bb22, otherwise: bb6];
       }
   
       bb1: {
@@ -263,10 +263,10 @@
           StorageDead(_5);
 -         StorageDead(_4);
 -         StorageDead(_3);
--         drop(_1) -> [return: bb12, unwind: bb25];
+-         drop(_1) -> [return: bb12, unwind: bb24];
 +         nop;
 +         nop;
-+         goto -> bb21;
++         goto -> bb20;
       }
   
       bb12: {
@@ -278,7 +278,7 @@
 -     bb13: {
 -         StorageDead(_27);
 -         StorageDead(_26);
--         drop(_13) -> [return: bb14, unwind: bb26];
+-         drop(_13) -> [return: bb14, unwind: bb25];
 +     bb13 (cleanup): {
 +         StorageDead(_21);
 +         StorageDead(_20);
@@ -300,7 +300,7 @@
 -         StorageDead(_5);
 -         StorageDead(_4);
 -         StorageDead(_3);
--         drop(_1) -> [return: bb16, unwind: bb25];
+-         drop(_1) -> [return: bb16, unwind: bb24];
 +     bb15 (cleanup): {
 +         StorageDead(_19);
 +         StorageDead(_17);
@@ -313,11 +313,12 @@
 -         coroutine_drop;
 +     bb16 (cleanup): {
 +         nop;
-+         goto -> bb19;
++         goto -> bb18;
       }
   
       bb17 (cleanup): {
 -         StorageDead(_22);
++         StorageDead(_10);
           goto -> bb18;
       }
   
@@ -325,12 +326,6 @@
 -         StorageDead(_21);
 -         StorageDead(_20);
 -         goto -> bb20;
-+         StorageDead(_10);
-+         goto -> bb19;
-      }
-  
-      bb19 (cleanup): {
--         StorageDead(_18);
 +         StorageDead(_9);
 +         StorageDead(_8);
 +         StorageDead(_7);
@@ -338,35 +333,36 @@
 +         StorageDead(_5);
 +         nop;
 +         nop;
-          goto -> bb20;
++         goto -> bb19;
       }
   
-      bb20 (cleanup): {
+      bb19 (cleanup): {
+-         StorageDead(_18);
+-         goto -> bb20;
++         goto -> bb21;
+      }
+  
+-     bb20 (cleanup): {
 -         StorageDead(_19);
 -         StorageDead(_17);
 -         StorageDead(_16);
 -         StorageDead(_15);
 -         drop(_13) -> [return: bb21, unwind terminate(cleanup)];
-+         goto -> bb22;
-      }
-  
--     bb21 (cleanup): {
--         StorageDead(_13);
--         goto -> bb24;
-+     bb21: {
++     bb20: {
 +         goto -> bb12;
       }
   
-      bb22 (cleanup): {
+      bb21 (cleanup): {
+-         StorageDead(_13);
 -         goto -> bb23;
 +         discriminant((*_36)) = 2;
 +         resume;
       }
   
--     bb23 (cleanup): {
+-     bb22 (cleanup): {
 -         StorageDead(_10);
--         goto -> bb24;
-+     bb23: {
+-         goto -> bb23;
++     bb22: {
 +         StorageLive(_5);
 +         StorageLive(_7);
 +         StorageLive(_8);
@@ -377,7 +373,7 @@
 +         goto -> bb9;
       }
   
--     bb24 (cleanup): {
+-     bb23 (cleanup): {
 -         StorageDead(_9);
 -         StorageDead(_8);
 -         StorageDead(_7);
@@ -385,23 +381,23 @@
 -         StorageDead(_5);
 -         StorageDead(_4);
 -         StorageDead(_3);
--         drop(_1) -> [return: bb25, unwind terminate(cleanup)];
+-         drop(_1) -> [return: bb24, unwind terminate(cleanup)];
++     bb23: {
++         assert(const false, "`async fn` resumed after panicking") -> [success: bb23, unwind continue];
+      }
+  
+-     bb24 (cleanup): {
+-         resume;
 +     bb24: {
-+         assert(const false, "`async fn` resumed after panicking") -> [success: bb24, unwind continue];
++         assert(const false, "`async fn` resumed after completion") -> [success: bb24, unwind continue];
       }
   
 -     bb25 (cleanup): {
--         resume;
-+     bb25: {
-+         assert(const false, "`async fn` resumed after completion") -> [success: bb25, unwind continue];
-      }
-  
--     bb26 (cleanup): {
 -         StorageDead(_13);
--         goto -> bb27;
+-         goto -> bb26;
 -     }
 - 
--     bb27 (cleanup): {
+-     bb26 (cleanup): {
 -         StorageDead(_9);
 -         StorageDead(_8);
 -         StorageDead(_7);
@@ -409,8 +405,8 @@
 -         StorageDead(_5);
 -         StorageDead(_4);
 -         StorageDead(_3);
--         drop(_1) -> [return: bb25, unwind terminate(cleanup)];
-+     bb26: {
+-         drop(_1) -> [return: bb24, unwind terminate(cleanup)];
++     bb25: {
 +         nop;
 +         (((*_36) as variant#3).0: &u32) = copy ((*_36).0: &u32);
 +         nop;

--- a/tests/mir-opt/coroutine/async_fn.hello_world-{closure#0}.StateTransform.diff
+++ b/tests/mir-opt/coroutine/async_fn.hello_world-{closure#0}.StateTransform.diff
@@ -90,12 +90,12 @@
 -         _6 = &_3;
 -         StorageLive(_7);
 -         _7 = RangeFull;
--         _5 = <[u8; 1] as Index<RangeFull>>::index(move _6, move _7) -> [return: bb1, unwind: bb30];
+-         _5 = <[u8; 1] as Index<RangeFull>>::index(move _6, move _7) -> [return: bb1, unwind: bb29];
 +         _37 = move _2 as std::ptr::NonNull<std::task::Context<'_>> (Transmute);
 +         _36 = std::future::ResumeTy(move _37);
 +         _35 = copy (_1.0: &mut {async fn body of hello_world()});
 +         _34 = discriminant((*_35));
-+         switchInt(move _34) -> [0: bb33, 1: bb32, 2: bb31, 3: bb30, otherwise: bb8];
++         switchInt(move _34) -> [0: bb32, 1: bb31, 2: bb30, 3: bb29, otherwise: bb8];
       }
   
       bb1: {
@@ -124,15 +124,15 @@
           _16 = &mut (*_17);
           _15 = move _16 as &mut [u8] (PointerCoercion(Unsize, Implicit));
           StorageDead(_16);
--         _12 = read_exact(move _13, move _15) -> [return: bb2, unwind: bb27];
-+         _12 = read_exact(move _13, move _15) -> [return: bb2, unwind: bb22];
+-         _12 = read_exact(move _13, move _15) -> [return: bb2, unwind: bb26];
++         _12 = read_exact(move _13, move _15) -> [return: bb2, unwind: bb21];
       }
   
       bb2: {
           StorageDead(_15);
           StorageDead(_13);
--         _11 = <{async fn body of read_exact()} as IntoFuture>::into_future(move _12) -> [return: bb3, unwind: bb26];
-+         _11 = <{async fn body of read_exact()} as IntoFuture>::into_future(move _12) -> [return: bb3, unwind: bb21];
+-         _11 = <{async fn body of read_exact()} as IntoFuture>::into_future(move _12) -> [return: bb3, unwind: bb27];
++         _11 = <{async fn body of read_exact()} as IntoFuture>::into_future(move _12) -> [return: bb3, unwind: bb22];
       }
   
       bb3: {
@@ -256,10 +256,10 @@
           StorageDead(_5);
 -         StorageDead(_4);
 -         StorageDead(_3);
--         drop(_1) -> [return: bb15, unwind: bb32];
+-         drop(_1) -> [return: bb15, unwind: bb31];
 +         nop;
 +         nop;
-+         goto -> bb28;
++         goto -> bb27;
       }
   
       bb15: {
@@ -271,7 +271,7 @@
 -     bb16: {
 -         StorageDead(_32);
 -         StorageDead(_31);
--         drop(_18) -> [return: bb17, unwind: bb33];
+-         drop(_18) -> [return: bb17, unwind: bb32];
 -     }
 - 
 -     bb17: {
@@ -289,7 +289,7 @@
 -         StorageDead(_5);
 -         StorageDead(_4);
 -         StorageDead(_3);
--         drop(_1) -> [return: bb19, unwind: bb32];
+-         drop(_1) -> [return: bb19, unwind: bb31];
 -     }
 - 
 -     bb19: {
@@ -337,82 +337,76 @@
 -     bb25 (cleanup): {
 +     bb20 (cleanup): {
           StorageDead(_10);
--         goto -> bb29;
-+         goto -> bb24;
+-         goto -> bb28;
++         goto -> bb23;
       }
   
 -     bb26 (cleanup): {
--         goto -> bb28;
 +     bb21 (cleanup): {
-+         goto -> bb23;
+          StorageDead(_15);
+          StorageDead(_13);
+-         goto -> bb27;
++         goto -> bb22;
       }
   
 -     bb27 (cleanup): {
 +     bb22 (cleanup): {
-          StorageDead(_15);
-          StorageDead(_13);
+          StorageDead(_12);
+          StorageDead(_10);
 -         goto -> bb28;
 +         goto -> bb23;
       }
   
 -     bb28 (cleanup): {
 +     bb23 (cleanup): {
-          StorageDead(_12);
-          StorageDead(_10);
--         goto -> bb29;
-+         goto -> bb24;
-      }
-  
--     bb29 (cleanup): {
-+     bb24 (cleanup): {
           StorageDead(_17);
           StorageDead(_14);
           StorageDead(_11);
           StorageDead(_9);
 -         StorageDead(_8);
--         goto -> bb31;
+-         goto -> bb30;
 +         nop;
-+         goto -> bb26;
++         goto -> bb25;
+      }
+  
+-     bb29 (cleanup): {
++     bb24 (cleanup): {
+          StorageDead(_7);
+          StorageDead(_6);
+-         goto -> bb30;
++         goto -> bb25;
       }
   
 -     bb30 (cleanup): {
 +     bb25 (cleanup): {
-          StorageDead(_7);
-          StorageDead(_6);
--         goto -> bb31;
+          StorageDead(_5);
+-         StorageDead(_4);
+-         StorageDead(_3);
+-         drop(_1) -> [return: bb31, unwind terminate(cleanup)];
++         nop;
++         nop;
 +         goto -> bb26;
       }
   
 -     bb31 (cleanup): {
 +     bb26 (cleanup): {
-          StorageDead(_5);
--         StorageDead(_4);
--         StorageDead(_3);
--         drop(_1) -> [return: bb32, unwind terminate(cleanup)];
-+         nop;
-+         nop;
-+         goto -> bb27;
-      }
-  
--     bb32 (cleanup): {
-+     bb27 (cleanup): {
-+         goto -> bb29;
++         goto -> bb28;
 +     }
 + 
-+     bb28: {
++     bb27: {
 +         goto -> bb15;
 +     }
 + 
-+     bb29 (cleanup): {
++     bb28 (cleanup): {
 +         discriminant((*_35)) = 2;
           resume;
       }
   
--     bb33 (cleanup): {
+-     bb32 (cleanup): {
 -         StorageDead(_18);
 -         StorageDead(_10);
--         goto -> bb34;
-+     bb30: {
+-         goto -> bb33;
++     bb29: {
 +         StorageLive(_5);
 +         StorageLive(_9);
 +         StorageLive(_10);
@@ -425,7 +419,7 @@
 +         goto -> bb11;
       }
   
--     bb34 (cleanup): {
+-     bb33 (cleanup): {
 -         StorageDead(_17);
 -         StorageDead(_14);
 -         StorageDead(_11);
@@ -434,16 +428,16 @@
 -         StorageDead(_5);
 -         StorageDead(_4);
 -         StorageDead(_3);
--         drop(_1) -> [return: bb32, unwind terminate(cleanup)];
+-         drop(_1) -> [return: bb31, unwind terminate(cleanup)];
++     bb30: {
++         assert(const false, "`async fn` resumed after panicking") -> [success: bb30, unwind continue];
++     }
++ 
 +     bb31: {
-+         assert(const false, "`async fn` resumed after panicking") -> [success: bb31, unwind continue];
++         assert(const false, "`async fn` resumed after completion") -> [success: bb31, unwind continue];
 +     }
 + 
 +     bb32: {
-+         assert(const false, "`async fn` resumed after completion") -> [success: bb32, unwind continue];
-+     }
-+ 
-+     bb33: {
 +         nop;
 +         (((*_35) as variant#3).0: [u8; 1]) = [const 0_u8; 1];
 +         nop;
@@ -452,7 +446,7 @@
 +         _6 = &(((*_35) as variant#3).0: [u8; 1]);
 +         StorageLive(_7);
 +         _7 = RangeFull;
-+         _5 = <[u8; 1] as Index<RangeFull>>::index(move _6, move _7) -> [return: bb1, unwind: bb25];
++         _5 = <[u8; 1] as Index<RangeFull>>::index(move _6, move _7) -> [return: bb1, unwind: bb24];
       }
   }
   

--- a/tests/mir-opt/coroutine/async_fn.includes_never-{closure#0}.StateTransform.diff
+++ b/tests/mir-opt/coroutine/async_fn.includes_never-{closure#0}.StateTransform.diff
@@ -125,7 +125,7 @@
 +         _51 = std::future::ResumeTy(move _52);
 +         _50 = copy (_1.0: &mut {async fn body of includes_never()});
 +         _49 = discriminant((*_50));
-+         switchInt(move _49) -> [0: bb30, 1: bb29, 2: bb28, 3: bb27, otherwise: bb6];
++         switchInt(move _49) -> [0: bb29, 1: bb28, 2: bb27, 3: bb26, otherwise: bb6];
       }
   
       bb1: {
@@ -244,10 +244,10 @@
           StorageDead(_5);
 -         StorageDead(_4);
 -         StorageDead(_3);
--         drop(_1) -> [return: bb14, unwind: bb29];
+-         drop(_1) -> [return: bb14, unwind: bb28];
 +         nop;
 +         nop;
-+         goto -> bb25;
++         goto -> bb24;
       }
   
       bb13: {
@@ -268,10 +268,10 @@
 -     bb15: {
 -         StorageDead(_23);
 -         StorageDead(_22);
--         drop(_9) -> [return: bb16, unwind: bb30];
+-         drop(_9) -> [return: bb16, unwind: bb29];
 +     bb15 (cleanup): {
 +         StorageDead(_27);
-+         goto -> bb23;
++         goto -> bb22;
       }
   
 -     bb16: {
@@ -288,7 +288,7 @@
 -         StorageDead(_5);
 -         StorageDead(_4);
 -         StorageDead(_3);
--         drop(_1) -> [return: bb18, unwind: bb29];
+-         drop(_1) -> [return: bb18, unwind: bb28];
 +     bb17 (cleanup): {
 +         StorageDead(_14);
 +         goto -> bb18;
@@ -306,13 +306,14 @@
   
       bb19 (cleanup): {
 -         StorageDead(_27);
--         goto -> bb28;
+-         goto -> bb27;
 +         nop;
-+         goto -> bb22;
++         goto -> bb21;
       }
   
       bb20 (cleanup): {
 -         StorageDead(_18);
++         StorageDead(_7);
           goto -> bb21;
       }
   
@@ -320,13 +321,15 @@
 -         StorageDead(_17);
 -         StorageDead(_16);
 -         goto -> bb23;
-+         StorageDead(_7);
++         StorageDead(_6);
 +         goto -> bb22;
       }
   
       bb22 (cleanup): {
 -         StorageDead(_14);
-+         StorageDead(_6);
++         StorageDead(_5);
++         nop;
++         nop;
           goto -> bb23;
       }
   
@@ -336,35 +339,27 @@
 -         StorageDead(_12);
 -         StorageDead(_11);
 -         drop(_9) -> [return: bb24, unwind terminate(cleanup)];
-+         StorageDead(_5);
-+         nop;
-+         nop;
-+         goto -> bb24;
++         goto -> bb25;
       }
   
-      bb24 (cleanup): {
+-     bb24 (cleanup): {
 -         StorageDead(_9);
--         goto -> bb27;
-+         goto -> bb26;
-      }
-  
--     bb25 (cleanup): {
 -         goto -> bb26;
-+     bb25: {
++     bb24: {
 +         goto -> bb14;
       }
   
-      bb26 (cleanup): {
+      bb25 (cleanup): {
 -         StorageDead(_7);
--         goto -> bb27;
+-         goto -> bb26;
 +         discriminant((*_50)) = 2;
 +         resume;
       }
   
--     bb27 (cleanup): {
+-     bb26 (cleanup): {
 -         StorageDead(_6);
--         goto -> bb28;
-+     bb27: {
+-         goto -> bb27;
++     bb26: {
 +         StorageLive(_5);
 +         StorageLive(_6);
 +         StorageLive(_22);
@@ -373,33 +368,33 @@
 +         goto -> bb9;
       }
   
--     bb28 (cleanup): {
+-     bb27 (cleanup): {
 -         StorageDead(_5);
 -         StorageDead(_4);
 -         StorageDead(_3);
--         drop(_1) -> [return: bb29, unwind terminate(cleanup)];
+-         drop(_1) -> [return: bb28, unwind terminate(cleanup)];
++     bb27: {
++         assert(const false, "`async fn` resumed after panicking") -> [success: bb27, unwind continue];
+      }
+  
+-     bb28 (cleanup): {
+-         resume;
 +     bb28: {
-+         assert(const false, "`async fn` resumed after panicking") -> [success: bb28, unwind continue];
++         assert(const false, "`async fn` resumed after completion") -> [success: bb28, unwind continue];
       }
   
 -     bb29 (cleanup): {
--         resume;
-+     bb29: {
-+         assert(const false, "`async fn` resumed after completion") -> [success: bb29, unwind continue];
-      }
-  
--     bb30 (cleanup): {
 -         StorageDead(_9);
--         goto -> bb31;
+-         goto -> bb30;
 -     }
 - 
--     bb31 (cleanup): {
+-     bb30 (cleanup): {
 -         StorageDead(_6);
 -         StorageDead(_5);
 -         StorageDead(_4);
 -         StorageDead(_3);
--         drop(_1) -> [return: bb29, unwind terminate(cleanup)];
-+     bb30: {
+-         drop(_1) -> [return: bb28, unwind terminate(cleanup)];
++     bb29: {
 +         nop;
 +         (((*_50) as variant#3).0: bool) = copy ((*_50).0: bool);
 +         nop;

--- a/tests/mir-opt/coroutine/async_fn.partial_init-{closure#0}.StateTransform.diff
+++ b/tests/mir-opt/coroutine/async_fn.partial_init-{closure#0}.StateTransform.diff
@@ -76,12 +76,12 @@
 -         StorageLive(_4);
 -         StorageLive(_5);
 -         StorageLive(_6);
--         _6 = String::new() -> [return: bb1, unwind: bb30];
+-         _6 = String::new() -> [return: bb1, unwind: bb29];
 +         _30 = move _2 as std::ptr::NonNull<std::task::Context<'_>> (Transmute);
 +         _29 = std::future::ResumeTy(move _30);
 +         _28 = copy (_1.0: &mut {async fn body of partial_init()});
 +         _27 = discriminant((*_28));
-+         switchInt(move _27) -> [0: bb32, 1: bb31, 2: bb30, 3: bb29, otherwise: bb7];
++         switchInt(move _27) -> [0: bb31, 1: bb30, 2: bb29, 3: bb28, otherwise: bb7];
       }
   
       bb1: {
@@ -209,9 +209,9 @@
           StorageDead(_5);
           StorageDead(_4);
 -         StorageDead(_3);
--         drop(_1) -> [return: bb14, unwind: bb32];
+-         drop(_1) -> [return: bb14, unwind: bb31];
 +         nop;
-+         goto -> bb27;
++         goto -> bb26;
       }
   
       bb14: {
@@ -223,7 +223,7 @@
 -     bb15: {
 -         StorageDead(_25);
 -         StorageDead(_24);
--         drop(_11) -> [return: bb16, unwind: bb33];
+-         drop(_11) -> [return: bb16, unwind: bb32];
 +     bb15 (cleanup): {
 +         StorageDead(_19);
 +         StorageDead(_18);
@@ -232,7 +232,7 @@
   
 -     bb16: {
 -         StorageDead(_11);
--         drop(_6) -> [return: bb17, unwind: bb34];
+-         drop(_6) -> [return: bb17, unwind: bb33];
 +     bb16 (cleanup): {
 +         StorageDead(_16);
 +         goto -> bb17;
@@ -254,7 +254,7 @@
 -         StorageDead(_5);
 -         StorageDead(_4);
 -         StorageDead(_3);
--         drop(_1) -> [return: bb19, unwind: bb32];
+-         drop(_1) -> [return: bb19, unwind: bb31];
 +     bb18 (cleanup): {
 +         nop;
 +         drop((((*_28) as variant#3).1: std::string::String)) -> [return: bb19, unwind terminate(cleanup)];
@@ -264,26 +264,29 @@
 -         coroutine_drop;
 +     bb19 (cleanup): {
 +         nop;
-+         goto -> bb23;
++         goto -> bb22;
       }
   
       bb20 (cleanup): {
 -         StorageDead(_20);
-          goto -> bb21;
+-         goto -> bb21;
++         StorageDead(_9);
++         drop((((*_28) as variant#3).1: std::string::String)) -> [return: bb21, unwind terminate(cleanup)];
       }
   
       bb21 (cleanup): {
 -         StorageDead(_19);
 -         StorageDead(_18);
 -         goto -> bb23;
-+         StorageDead(_9);
-+         drop((((*_28) as variant#3).1: std::string::String)) -> [return: bb22, unwind terminate(cleanup)];
++         nop;
++         goto -> bb22;
       }
   
       bb22 (cleanup): {
 -         StorageDead(_16);
-+         nop;
-          goto -> bb23;
+-         goto -> bb23;
++         StorageDead(_8);
++         goto -> bb24;
       }
   
       bb23 (cleanup): {
@@ -292,49 +295,43 @@
 -         StorageDead(_14);
 -         StorageDead(_13);
 -         drop(_11) -> [return: bb24, unwind terminate(cleanup)];
-+         StorageDead(_8);
-+         goto -> bb25;
++         nop;
++         goto -> bb24;
       }
   
       bb24 (cleanup): {
 -         StorageDead(_11);
 -         drop(_6) -> [return: bb25, unwind terminate(cleanup)];
++         StorageDead(_5);
++         StorageDead(_4);
 +         nop;
 +         goto -> bb25;
       }
   
       bb25 (cleanup): {
 -         StorageDead(_6);
--         goto -> bb29;
-+         StorageDead(_5);
-+         StorageDead(_4);
-+         nop;
-+         goto -> bb26;
+-         goto -> bb28;
++         goto -> bb27;
       }
   
-      bb26 (cleanup): {
--         goto -> bb27;
-+         goto -> bb28;
-      }
-  
--     bb27 (cleanup): {
+-     bb26 (cleanup): {
 -         StorageDead(_9);
--         drop(_6) -> [return: bb28, unwind terminate(cleanup)];
-+     bb27: {
+-         drop(_6) -> [return: bb27, unwind terminate(cleanup)];
++     bb26: {
 +         goto -> bb14;
       }
   
-      bb28 (cleanup): {
+      bb27 (cleanup): {
 -         StorageDead(_6);
--         goto -> bb29;
+-         goto -> bb28;
 +         discriminant((*_28)) = 2;
 +         resume;
       }
   
--     bb29 (cleanup): {
+-     bb28 (cleanup): {
 -         StorageDead(_8);
--         goto -> bb31;
-+     bb29: {
+-         goto -> bb30;
++     bb28: {
 +         StorageLive(_4);
 +         StorageLive(_5);
 +         StorageLive(_8);
@@ -344,49 +341,49 @@
 +         goto -> bb10;
       }
   
--     bb30 (cleanup): {
+-     bb29 (cleanup): {
 -         StorageDead(_6);
--         goto -> bb31;
-+     bb30: {
-+         assert(const false, "`async fn` resumed after panicking") -> [success: bb30, unwind continue];
+-         goto -> bb30;
++     bb29: {
++         assert(const false, "`async fn` resumed after panicking") -> [success: bb29, unwind continue];
       }
   
--     bb31 (cleanup): {
+-     bb30 (cleanup): {
 -         StorageDead(_5);
 -         StorageDead(_4);
 -         StorageDead(_3);
--         drop(_1) -> [return: bb32, unwind terminate(cleanup)];
-+     bb31: {
-+         assert(const false, "`async fn` resumed after completion") -> [success: bb31, unwind continue];
+-         drop(_1) -> [return: bb31, unwind terminate(cleanup)];
++     bb30: {
++         assert(const false, "`async fn` resumed after completion") -> [success: bb30, unwind continue];
       }
   
--     bb32 (cleanup): {
+-     bb31 (cleanup): {
 -         resume;
 -     }
 - 
--     bb33 (cleanup): {
+-     bb32 (cleanup): {
 -         StorageDead(_11);
--         drop(_6) -> [return: bb34, unwind terminate(cleanup)];
+-         drop(_6) -> [return: bb33, unwind terminate(cleanup)];
+-     }
+- 
+-     bb33 (cleanup): {
+-         StorageDead(_6);
+-         goto -> bb34;
 -     }
 - 
 -     bb34 (cleanup): {
--         StorageDead(_6);
--         goto -> bb35;
--     }
-- 
--     bb35 (cleanup): {
 -         StorageDead(_8);
 -         StorageDead(_5);
 -         StorageDead(_4);
 -         StorageDead(_3);
--         drop(_1) -> [return: bb32, unwind terminate(cleanup)];
-+     bb32: {
+-         drop(_1) -> [return: bb31, unwind terminate(cleanup)];
++     bb31: {
 +         nop;
 +         (((*_28) as variant#3).0: u32) = copy ((*_28).0: u32);
 +         StorageLive(_4);
 +         StorageLive(_5);
 +         nop;
-+         (((*_28) as variant#3).1: std::string::String) = String::new() -> [return: bb1, unwind: bb24];
++         (((*_28) as variant#3).1: std::string::String) = String::new() -> [return: bb1, unwind: bb23];
       }
   }
   

--- a/tests/mir-opt/coroutine/async_fn.uninhabited_variant-{closure#0}.StateTransform.diff
+++ b/tests/mir-opt/coroutine/async_fn.uninhabited_variant-{closure#0}.StateTransform.diff
@@ -108,7 +108,7 @@
 +         _47 = std::future::ResumeTy(move _48);
 +         _46 = copy (_1.0: &mut {async fn body of uninhabited_variant()});
 +         _45 = discriminant((*_46));
-+         switchInt(move _45) -> [0: bb56, 1: bb55, 2: bb54, 3: bb52, 4: bb53, otherwise: bb1];
++         switchInt(move _45) -> [0: bb54, 1: bb53, 2: bb52, 3: bb50, 4: bb51, otherwise: bb1];
       }
   
       bb1: {
@@ -123,8 +123,8 @@
           StorageLive(_27);
           StorageLive(_28);
           _28 = move _24;
--         _27 = uninhabited_variant::{closure#0}::unreachable(move _28) -> [return: bb14, unwind: bb43];
-+         _27 = uninhabited_variant::{closure#0}::unreachable(move _28) -> [return: bb14, unwind: bb33];
+-         _27 = uninhabited_variant::{closure#0}::unreachable(move _28) -> [return: bb14, unwind: bb42];
++         _27 = uninhabited_variant::{closure#0}::unreachable(move _28) -> [return: bb14, unwind: bb32];
       }
   
       bb3: {
@@ -133,10 +133,10 @@
           StorageLive(_8);
 -         _43 = const false;
 -         _8 = move _3;
--         _7 = <{async block@$DIR/async_fn.rs:106:13: 106:18} as IntoFuture>::into_future(move _8) -> [return: bb4, unwind: bb51];
+-         _7 = <{async block@$DIR/async_fn.rs:106:13: 106:18} as IntoFuture>::into_future(move _8) -> [return: bb4, unwind: bb50];
 +         (((*_46) as variant#4).2: bool) = const false;
 +         _8 = move (((*_46) as variant#4).0: {async block@$DIR/async_fn.rs:106:13: 106:18});
-+         _7 = <{async block@$DIR/async_fn.rs:106:13: 106:18} as IntoFuture>::into_future(move _8) -> [return: bb4, unwind: bb40];
++         _7 = <{async block@$DIR/async_fn.rs:106:13: 106:18} as IntoFuture>::into_future(move _8) -> [return: bb4, unwind: bb39];
       }
   
       bb4: {
@@ -158,8 +158,8 @@
 -         _15 = &mut _9;
 +         _15 = &mut (((*_46) as variant#3).0: {async block@$DIR/async_fn.rs:106:13: 106:18});
           _14 = &mut (*_15);
--         _13 = Pin::<&mut {async block@$DIR/async_fn.rs:106:13: 106:18}>::new_unchecked(move _14) -> [return: bb6, unwind: bb48];
-+         _13 = Pin::<&mut {async block@$DIR/async_fn.rs:106:13: 106:18}>::new_unchecked(move _14) -> [return: bb6, unwind: bb37];
+-         _13 = Pin::<&mut {async block@$DIR/async_fn.rs:106:13: 106:18}>::new_unchecked(move _14) -> [return: bb6, unwind: bb47];
++         _13 = Pin::<&mut {async block@$DIR/async_fn.rs:106:13: 106:18}>::new_unchecked(move _14) -> [return: bb6, unwind: bb36];
       }
   
       bb6: {
@@ -168,7 +168,7 @@
           StorageLive(_17);
           StorageLive(_18);
 -         _18 = copy _2;
--         _17 = std::future::get_context::<'_, '_>(move _18) -> [return: bb7, unwind: bb46];
+-         _17 = std::future::get_context::<'_, '_>(move _18) -> [return: bb7, unwind: bb45];
 +         _18 = copy _47;
 +         _17 = copy (_18.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
 +         goto -> bb7;
@@ -177,8 +177,8 @@
       bb7: {
           _16 = &mut (*_17);
           StorageDead(_18);
--         _12 = <{async block@$DIR/async_fn.rs:106:13: 106:18} as Future>::poll(move _13, move _16) -> [return: bb8, unwind: bb47];
-+         _12 = <{async block@$DIR/async_fn.rs:106:13: 106:18} as Future>::poll(move _13, move _16) -> [return: bb8, unwind: bb36];
+-         _12 = <{async block@$DIR/async_fn.rs:106:13: 106:18} as Future>::poll(move _13, move _16) -> [return: bb8, unwind: bb46];
++         _12 = <{async block@$DIR/async_fn.rs:106:13: 106:18} as Future>::poll(move _13, move _16) -> [return: bb8, unwind: bb35];
       }
   
       bb8: {
@@ -216,8 +216,8 @@
           StorageDead(_20);
           StorageDead(_12);
           StorageDead(_11);
--         drop(_9) -> [return: bb12, unwind: bb50];
-+         drop((((*_46) as variant#3).0: {async block@$DIR/async_fn.rs:106:13: 106:18})) -> [return: bb12, unwind: bb39];
+-         drop(_9) -> [return: bb12, unwind: bb49];
++         drop((((*_46) as variant#3).0: {async block@$DIR/async_fn.rs:106:13: 106:18})) -> [return: bb12, unwind: bb38];
       }
   
       bb11: {
@@ -245,8 +245,8 @@
   
       bb14: {
           StorageDead(_28);
--         _26 = <{async fn body of uninhabited_variant::{closure#0}::unreachable()} as IntoFuture>::into_future(move _27) -> [return: bb15, unwind: bb42];
-+         _26 = <{async fn body of uninhabited_variant::{closure#0}::unreachable()} as IntoFuture>::into_future(move _27) -> [return: bb15, unwind: bb32];
+-         _26 = <{async fn body of uninhabited_variant::{closure#0}::unreachable()} as IntoFuture>::into_future(move _27) -> [return: bb15, unwind: bb43];
++         _26 = <{async fn body of uninhabited_variant::{closure#0}::unreachable()} as IntoFuture>::into_future(move _27) -> [return: bb15, unwind: bb33];
       }
   
       bb15: {
@@ -357,17 +357,17 @@
   
       bb25: {
           StorageDead(_4);
--         goto -> bb64;
-+         goto -> bb47;
+-         goto -> bb62;
++         goto -> bb45;
       }
   
       bb26: {
 -         _43 = const false;
 -         StorageDead(_3);
--         drop(_1) -> [return: bb27, unwind: bb56];
+-         drop(_1) -> [return: bb27, unwind: bb54];
 +         (((*_46) as variant#4).2: bool) = const false;
 +         nop;
-+         goto -> bb50;
++         goto -> bb48;
       }
   
       bb27: {
@@ -379,7 +379,7 @@
 -     bb28: {
 -         StorageDead(_42);
 -         StorageDead(_41);
--         drop(_29) -> [return: bb29, unwind: bb57];
+-         drop(_29) -> [return: bb29, unwind: bb55];
 -     }
 - 
 -     bb29: {
@@ -397,7 +397,7 @@
 -     bb31: {
 -         StorageDead(_23);
 -         StorageDead(_22);
--         drop(_9) -> [return: bb32, unwind: bb59];
+-         drop(_9) -> [return: bb32, unwind: bb57];
 -     }
 - 
 -     bb32: {
@@ -413,13 +413,13 @@
 - 
 -     bb34: {
 -         StorageDead(_4);
--         goto -> bb66;
+-         goto -> bb64;
 -     }
 - 
 -     bb35: {
 -         _43 = const false;
 -         StorageDead(_3);
--         drop(_1) -> [return: bb36, unwind: bb56];
+-         drop(_1) -> [return: bb36, unwind: bb54];
 -     }
 - 
 -     bb36: {
@@ -458,173 +458,161 @@
   
 -     bb41 (cleanup): {
 -         StorageDead(_29);
--         goto -> bb45;
+-         goto -> bb44;
 +     bb31 (cleanup): {
 +         nop;
-+         goto -> bb35;
++         goto -> bb34;
       }
   
 -     bb42 (cleanup): {
--         goto -> bb44;
 +     bb32 (cleanup): {
-+         goto -> bb34;
+          StorageDead(_28);
+-         goto -> bb43;
++         goto -> bb33;
       }
   
 -     bb43 (cleanup): {
 +     bb33 (cleanup): {
-          StorageDead(_28);
+          StorageDead(_27);
 -         goto -> bb44;
 +         goto -> bb34;
       }
   
 -     bb44 (cleanup): {
 +     bb34 (cleanup): {
-          StorageDead(_27);
--         goto -> bb45;
-+         goto -> bb35;
-      }
-  
--     bb45 (cleanup): {
-+     bb35 (cleanup): {
           StorageDead(_26);
           StorageDead(_25);
           StorageDead(_24);
--         goto -> bb54;
-+         goto -> bb43;
+-         goto -> bb52;
++         goto -> bb41;
       }
   
--     bb46 (cleanup): {
+-     bb45 (cleanup): {
 -         StorageDead(_18);
--         goto -> bb47;
+-         goto -> bb46;
 -     }
 - 
--     bb47 (cleanup): {
-+     bb36 (cleanup): {
+-     bb46 (cleanup): {
++     bb35 (cleanup): {
           StorageDead(_17);
           StorageDead(_16);
--         goto -> bb49;
-+         goto -> bb38;
+-         goto -> bb48;
++         goto -> bb37;
+      }
+  
+-     bb47 (cleanup): {
++     bb36 (cleanup): {
+          StorageDead(_14);
+-         goto -> bb48;
++         goto -> bb37;
       }
   
 -     bb48 (cleanup): {
 +     bb37 (cleanup): {
-          StorageDead(_14);
--         goto -> bb49;
-+         goto -> bb38;
-      }
-  
--     bb49 (cleanup): {
-+     bb38 (cleanup): {
           StorageDead(_15);
           StorageDead(_13);
           StorageDead(_12);
           StorageDead(_11);
--         drop(_9) -> [return: bb50, unwind terminate(cleanup)];
-+         drop((((*_46) as variant#3).0: {async block@$DIR/async_fn.rs:106:13: 106:18})) -> [return: bb39, unwind terminate(cleanup)];
+-         drop(_9) -> [return: bb49, unwind terminate(cleanup)];
++         drop((((*_46) as variant#3).0: {async block@$DIR/async_fn.rs:106:13: 106:18})) -> [return: bb38, unwind terminate(cleanup)];
+      }
+  
+-     bb49 (cleanup): {
+-         StorageDead(_9);
+-         goto -> bb51;
++     bb38 (cleanup): {
++         nop;
++         goto -> bb40;
       }
   
 -     bb50 (cleanup): {
--         StorageDead(_9);
--         goto -> bb53;
 +     bb39 (cleanup): {
-+         nop;
-+         goto -> bb42;
+          StorageDead(_8);
+-         goto -> bb51;
++         goto -> bb40;
       }
   
 -     bb51 (cleanup): {
--         goto -> bb52;
 +     bb40 (cleanup): {
+          StorageDead(_7);
+          StorageDead(_6);
+-         goto -> bb52;
 +         goto -> bb41;
       }
   
 -     bb52 (cleanup): {
 +     bb41 (cleanup): {
-          StorageDead(_8);
--         goto -> bb53;
-+         goto -> bb42;
+          StorageDead(_4);
+-         goto -> bb66;
++         goto -> bb47;
       }
   
 -     bb53 (cleanup): {
+-         _43 = const false;
+-         StorageDead(_3);
+-         drop(_1) -> [return: bb54, unwind terminate(cleanup)];
 +     bb42 (cleanup): {
-          StorageDead(_7);
-          StorageDead(_6);
--         goto -> bb54;
++         (((*_46) as variant#4).2: bool) = const false;
++         nop;
 +         goto -> bb43;
       }
   
 -     bb54 (cleanup): {
+-         resume;
 +     bb43 (cleanup): {
-          StorageDead(_4);
--         goto -> bb68;
 +         goto -> bb49;
       }
   
 -     bb55 (cleanup): {
--         _43 = const false;
--         StorageDead(_3);
--         drop(_1) -> [return: bb56, unwind terminate(cleanup)];
-+     bb44 (cleanup): {
-+         (((*_46) as variant#4).2: bool) = const false;
-+         nop;
-+         goto -> bb45;
+-         StorageDead(_29);
+-         goto -> bb56;
++     bb44: {
++         drop((((*_46) as variant#4).0: {async block@$DIR/async_fn.rs:106:13: 106:18})) -> [return: bb26, unwind: bb42];
       }
   
 -     bb56 (cleanup): {
--         resume;
-+     bb45 (cleanup): {
-+         goto -> bb51;
-      }
-  
--     bb57 (cleanup): {
--         StorageDead(_29);
--         goto -> bb58;
-+     bb46: {
-+         drop((((*_46) as variant#4).0: {async block@$DIR/async_fn.rs:106:13: 106:18})) -> [return: bb26, unwind: bb44];
-      }
-  
--     bb58 (cleanup): {
 -         StorageDead(_26);
 -         StorageDead(_25);
 -         StorageDead(_24);
--         goto -> bb61;
-+     bb47: {
-+         switchInt(copy (((*_46) as variant#4).2: bool)) -> [0: bb26, otherwise: bb46];
+-         goto -> bb59;
++     bb45: {
++         switchInt(copy (((*_46) as variant#4).2: bool)) -> [0: bb26, otherwise: bb44];
+      }
+  
+-     bb57 (cleanup): {
+-         StorageDead(_9);
+-         goto -> bb58;
++     bb46 (cleanup): {
++         drop((((*_46) as variant#4).0: {async block@$DIR/async_fn.rs:106:13: 106:18})) -> [return: bb42, unwind terminate(cleanup)];
+      }
+  
+-     bb58 (cleanup): {
+-         StorageDead(_7);
+-         StorageDead(_6);
+-         goto -> bb59;
++     bb47 (cleanup): {
++         switchInt(copy (((*_46) as variant#4).2: bool)) -> [0: bb42, otherwise: bb46];
       }
   
 -     bb59 (cleanup): {
--         StorageDead(_9);
--         goto -> bb60;
-+     bb48 (cleanup): {
-+         drop((((*_46) as variant#4).0: {async block@$DIR/async_fn.rs:106:13: 106:18})) -> [return: bb44, unwind terminate(cleanup)];
-      }
-  
--     bb60 (cleanup): {
--         StorageDead(_7);
--         StorageDead(_6);
--         goto -> bb61;
-+     bb49 (cleanup): {
-+         switchInt(copy (((*_46) as variant#4).2: bool)) -> [0: bb44, otherwise: bb48];
-      }
-  
--     bb61 (cleanup): {
 -         StorageDead(_4);
--         goto -> bb70;
-+     bb50: {
+-         goto -> bb68;
++     bb48: {
 +         goto -> bb27;
       }
   
--     bb62 (cleanup): {
+-     bb60 (cleanup): {
 -         _43 = const false;
 -         StorageDead(_3);
--         drop(_1) -> [return: bb56, unwind terminate(cleanup)];
-+     bb51 (cleanup): {
+-         drop(_1) -> [return: bb54, unwind terminate(cleanup)];
++     bb49 (cleanup): {
 +         discriminant((*_46)) = 2;
 +         resume;
       }
   
--     bb63: {
--         drop(_3) -> [return: bb26, unwind: bb55];
-+     bb52: {
+-     bb61: {
+-         drop(_3) -> [return: bb26, unwind: bb53];
++     bb50: {
 +         StorageLive(_4);
 +         StorageLive(_6);
 +         StorageLive(_7);
@@ -634,9 +622,9 @@
 +         goto -> bb11;
       }
   
--     bb64: {
--         switchInt(copy _43) -> [0: bb26, otherwise: bb63];
-+     bb53: {
+-     bb62: {
+-         switchInt(copy _43) -> [0: bb26, otherwise: bb61];
++     bb51: {
 +         StorageLive(_4);
 +         StorageLive(_24);
 +         StorageLive(_25);
@@ -647,33 +635,33 @@
 +         goto -> bb22;
       }
   
--     bb65: {
--         drop(_3) -> [return: bb35, unwind: bb62];
-+     bb54: {
-+         assert(const false, "`async fn` resumed after panicking") -> [success: bb54, unwind continue];
+-     bb63: {
+-         drop(_3) -> [return: bb35, unwind: bb60];
++     bb52: {
++         assert(const false, "`async fn` resumed after panicking") -> [success: bb52, unwind continue];
       }
   
--     bb66: {
--         switchInt(copy _43) -> [0: bb35, otherwise: bb65];
-+     bb55: {
-+         assert(const false, "`async fn` resumed after completion") -> [success: bb55, unwind continue];
+-     bb64: {
+-         switchInt(copy _43) -> [0: bb35, otherwise: bb63];
++     bb53: {
++         assert(const false, "`async fn` resumed after completion") -> [success: bb53, unwind continue];
       }
   
+-     bb65 (cleanup): {
+-         drop(_3) -> [return: bb53, unwind terminate(cleanup)];
+-     }
+- 
+-     bb66 (cleanup): {
+-         switchInt(copy _43) -> [0: bb53, otherwise: bb65];
+-     }
+- 
 -     bb67 (cleanup): {
--         drop(_3) -> [return: bb55, unwind terminate(cleanup)];
+-         drop(_3) -> [return: bb60, unwind terminate(cleanup)];
 -     }
 - 
 -     bb68 (cleanup): {
--         switchInt(copy _43) -> [0: bb55, otherwise: bb67];
--     }
-- 
--     bb69 (cleanup): {
--         drop(_3) -> [return: bb62, unwind terminate(cleanup)];
--     }
-- 
--     bb70 (cleanup): {
--         switchInt(copy _43) -> [0: bb62, otherwise: bb69];
-+     bb56: {
+-         switchInt(copy _43) -> [0: bb60, otherwise: bb67];
++     bb54: {
 +         (((*_46) as variant#4).2: bool) = const false;
 +         nop;
 +         (((*_46) as variant#4).2: bool) = const true;

--- a/tests/mir-opt/coroutine/coroutine.main-{closure#0}.StateTransform.diff
+++ b/tests/mir-opt/coroutine/coroutine.main-{closure#0}.StateTransform.diff
@@ -44,28 +44,24 @@
 -         StorageLive(_5);
 -         StorageLive(_6);
 -         _6 = &_2;
--         _5 = <String as Clone>::clone(move _6) -> [return: bb1, unwind: bb31];
+-         _5 = <String as Clone>::clone(move _6) -> [return: bb1, unwind: bb26];
 +         _18 = copy (_1.0: &mut {coroutine@$DIR/coroutine.rs:19:5: 19:18});
 +         _17 = discriminant((*_18));
-+         switchInt(move _17) -> [0: bb36, 1: bb34, 2: bb33, 3: bb31, 4: bb32, otherwise: bb35];
++         switchInt(move _17) -> [0: bb30, 1: bb28, 2: bb27, 3: bb25, 4: bb26, otherwise: bb29];
       }
   
       bb1: {
           StorageDead(_6);
           StorageLive(_7);
--         _7 = Location::<'_>::caller() -> [return: bb2, unwind: bb30];
-+         _7 = Location::<'_>::caller() -> [return: bb2, unwind: bb21];
+-         _7 = Location::<'_>::caller() -> [return: bb2, unwind: bb25];
++         _7 = Location::<'_>::caller() -> [return: bb2, unwind: bb16];
       }
   
       bb2: {
           _4 = (const "first", move _5, move _7);
           StorageDead(_7);
-          goto -> bb3;
-      }
-  
-      bb3: {
           StorageDead(_5);
--         _3 = yield(move _4) -> [resume: bb4, drop: bb18];
+-         _3 = yield(move _4) -> [resume: bb3, drop: bb14];
 +         _0 = CoroutineState::<(&str, String, &Location<'_>), ()>::Yielded(move _4);
 +         StorageDead(_3);
 +         StorageDead(_4);
@@ -73,17 +69,13 @@
 +         return;
       }
   
-      bb4: {
-          goto -> bb5;
-      }
-  
-      bb5: {
+      bb3: {
           StorageDead(_4);
--         drop(_3) -> [return: bb6, unwind: bb34];
-+         drop(_3) -> [return: bb6, unwind: bb25];
+-         drop(_3) -> [return: bb4, unwind: bb28];
++         drop(_3) -> [return: bb4, unwind: bb19];
       }
   
-      bb6: {
+      bb4: {
           StorageDead(_3);
           StorageLive(_8);
           StorageLive(_9);
@@ -94,30 +86,26 @@
           StorageLive(_12);
           StorageLive(_13);
 -         _13 = &_2;
--         _12 = <String as Clone>::clone(move _13) -> [return: bb7, unwind: bb28];
+-         _12 = <String as Clone>::clone(move _13) -> [return: bb5, unwind: bb23];
 +         _13 = &(((*_18) as variant#4).0: std::string::String);
-+         _12 = <String as Clone>::clone(move _13) -> [return: bb7, unwind: bb19];
++         _12 = <String as Clone>::clone(move _13) -> [return: bb5, unwind: bb14];
       }
   
-      bb7: {
+      bb5: {
           StorageDead(_13);
           StorageLive(_14);
           StorageLive(_15);
--         _15 = Location::<'_>::caller() -> [return: bb8, unwind: bb24];
-+         _15 = Location::<'_>::caller() -> [return: bb8, unwind: bb15];
+-         _15 = Location::<'_>::caller() -> [return: bb6, unwind: bb20];
++         _15 = Location::<'_>::caller() -> [return: bb6, unwind: bb11];
       }
   
-      bb8: {
+      bb6: {
           _14 = &(*_15);
           _9 = (move _10, move _12, move _14);
           StorageDead(_14);
-          goto -> bb9;
-      }
-  
-      bb9: {
           StorageDead(_12);
           StorageDead(_10);
--         _8 = yield(move _9) -> [resume: bb10, drop: bb15];
+-         _8 = yield(move _9) -> [resume: bb7, drop: bb11];
 +         _0 = CoroutineState::<(&str, String, &Location<'_>), ()>::Yielded(move _9);
 +         StorageDead(_8);
 +         StorageDead(_9);
@@ -127,219 +115,202 @@
 +         return;
       }
   
-      bb10: {
-          goto -> bb11;
-      }
-  
-      bb11: {
+      bb7: {
           StorageDead(_9);
--         drop(_8) -> [return: bb12, unwind: bb27];
-+         drop(_8) -> [return: bb12, unwind: bb18];
+-         drop(_8) -> [return: bb8, unwind: bb22];
++         drop(_8) -> [return: bb8, unwind: bb13];
       }
   
-      bb12: {
+      bb8: {
           StorageDead(_15);
           StorageDead(_11);
           StorageDead(_8);
 -         _0 = const ();
--         drop(_2) -> [return: bb13, unwind: bb36];
+-         drop(_2) -> [return: bb9, unwind: bb30];
 +         _16 = const ();
-+         drop((((*_18) as variant#4).0: std::string::String)) -> [return: bb13, unwind: bb27];
++         drop((((*_18) as variant#4).0: std::string::String)) -> [return: bb9, unwind: bb21];
       }
   
-      bb13: {
--         drop(_1) -> [return: bb14, unwind: bb37];
-+         goto -> bb29;
+      bb9: {
+-         drop(_1) -> [return: bb10, unwind: bb31];
++         goto -> bb23;
       }
   
-      bb14: {
+      bb10: {
 +         _0 = CoroutineState::<(&str, String, &Location<'_>), ()>::Complete(move _16);
 +         discriminant((*_18)) = 1;
           return;
       }
   
--     bb15: {
--         goto -> bb16;
-+     bb15 (cleanup): {
+-     bb11: {
+-         goto -> bb12;
++     bb11 (cleanup): {
 +         StorageDead(_14);
-+         drop(_12) -> [return: bb16, unwind terminate(cleanup)];
++         drop(_12) -> [return: bb12, unwind terminate(cleanup)];
       }
   
--     bb16: {
--         StorageDead(_9);
-+     bb16 (cleanup): {
+-     bb12: {
++     bb12 (cleanup): {
 +         StorageDead(_12);
 +         StorageDead(_10);
-          goto -> bb17;
+          StorageDead(_9);
+          goto -> bb13;
       }
   
--     bb17: {
--         StorageDead(_15);
+-     bb13: {
++     bb13 (cleanup): {
+          StorageDead(_15);
 -         StorageDead(_11);
 -         StorageDead(_8);
--         goto -> bb21;
-+     bb17 (cleanup): {
-+         StorageDead(_9);
-+         goto -> bb18;
+-         goto -> bb17;
++         goto -> bb15;
       }
   
--     bb18: {
--         goto -> bb19;
-+     bb18 (cleanup): {
-+         StorageDead(_15);
-+         goto -> bb20;
-      }
-  
--     bb19: {
--         StorageDead(_4);
-+     bb19 (cleanup): {
+-     bb14: {
++     bb14 (cleanup): {
 +         StorageDead(_13);
 +         StorageDead(_12);
 +         StorageDead(_10);
 +         StorageDead(_9);
-          goto -> bb20;
+          goto -> bb15;
       }
   
--     bb20: {
--         StorageDead(_3);
--         goto -> bb21;
-+     bb20 (cleanup): {
+-     bb15: {
+-         StorageDead(_4);
+-         goto -> bb16;
++     bb15 (cleanup): {
 +         StorageDead(_11);
 +         StorageDead(_8);
-+         goto -> bb26;
++         goto -> bb20;
       }
   
--     bb21: {
--         drop(_2) -> [return: bb22, unwind: bb38];
-+     bb21 (cleanup): {
+-     bb16: {
+-         StorageDead(_3);
+-         goto -> bb17;
++     bb16 (cleanup): {
 +         StorageDead(_7);
-+         drop(_5) -> [return: bb23, unwind terminate(cleanup)];
++         drop(_5) -> [return: bb18, unwind terminate(cleanup)];
       }
   
--     bb22: {
--         drop(_1) -> [return: bb23, unwind: bb37];
-+     bb22 (cleanup): {
+-     bb17: {
+-         drop(_2) -> [return: bb18, unwind: bb32];
++     bb17 (cleanup): {
 +         StorageDead(_6);
-+         goto -> bb23;
++         goto -> bb18;
       }
   
--     bb23: {
--         coroutine_drop;
-+     bb23 (cleanup): {
+-     bb18: {
+-         drop(_1) -> [return: bb19, unwind: bb31];
++     bb18 (cleanup): {
 +         StorageDead(_5);
-+         goto -> bb24;
-      }
-  
-      bb24 (cleanup): {
--         StorageDead(_14);
--         drop(_12) -> [return: bb25, unwind terminate(cleanup)];
 +         StorageDead(_4);
-+         goto -> bb25;
++         goto -> bb19;
       }
   
-      bb25 (cleanup): {
+-     bb19: {
+-         coroutine_drop;
++     bb19 (cleanup): {
++         StorageDead(_3);
++         goto -> bb20;
+      }
+  
+      bb20 (cleanup): {
+-         StorageDead(_14);
+-         drop(_12) -> [return: bb21, unwind terminate(cleanup)];
++         drop((((*_18) as variant#4).0: std::string::String)) -> [return: bb21, unwind terminate(cleanup)];
+      }
+  
+      bb21 (cleanup): {
 -         StorageDead(_12);
 -         StorageDead(_10);
-+         StorageDead(_3);
-          goto -> bb26;
-      }
-  
-      bb26 (cleanup): {
 -         StorageDead(_9);
--         goto -> bb27;
-+         drop((((*_18) as variant#4).0: std::string::String)) -> [return: bb27, unwind terminate(cleanup)];
+          goto -> bb22;
       }
   
-      bb27 (cleanup): {
+      bb22 (cleanup): {
 -         StorageDead(_15);
--         goto -> bb29;
-+         goto -> bb28;
+          goto -> bb24;
       }
   
-      bb28 (cleanup): {
+-     bb23 (cleanup): {
 -         StorageDead(_13);
 -         StorageDead(_12);
 -         StorageDead(_10);
 -         StorageDead(_9);
--         goto -> bb29;
-+         goto -> bb30;
+-         goto -> bb24;
++     bb23: {
++         goto -> bb10;
       }
   
--     bb29 (cleanup): {
+      bb24 (cleanup): {
 -         StorageDead(_11);
 -         StorageDead(_8);
--         goto -> bb35;
-+     bb29: {
-+         goto -> bb14;
-      }
-  
-      bb30 (cleanup): {
--         StorageDead(_7);
--         drop(_5) -> [return: bb32, unwind terminate(cleanup)];
+-         goto -> bb29;
 +         discriminant((*_18)) = 2;
 +         resume;
       }
   
--     bb31 (cleanup): {
--         StorageDead(_6);
--         goto -> bb32;
-+     bb31: {
+-     bb25 (cleanup): {
+-         StorageDead(_7);
+-         drop(_5) -> [return: bb27, unwind terminate(cleanup)];
++     bb25: {
 +         StorageLive(_3);
 +         StorageLive(_4);
 +         _3 = move _2;
-+         goto -> bb4;
++         goto -> bb3;
       }
   
--     bb32 (cleanup): {
--         StorageDead(_5);
--         goto -> bb33;
-+     bb32: {
+-     bb26 (cleanup): {
+-         StorageDead(_6);
+-         goto -> bb27;
++     bb26: {
 +         StorageLive(_8);
 +         StorageLive(_9);
 +         StorageLive(_11);
 +         StorageLive(_15);
 +         _8 = move _2;
-+         goto -> bb10;
++         goto -> bb7;
       }
   
--     bb33 (cleanup): {
+-     bb27 (cleanup): {
+-         StorageDead(_5);
 -         StorageDead(_4);
--         goto -> bb34;
-+     bb33: {
-+         assert(const false, "coroutine resumed after panicking") -> [success: bb33, unwind continue];
+-         goto -> bb28;
++     bb27: {
++         assert(const false, "coroutine resumed after panicking") -> [success: bb27, unwind continue];
       }
   
--     bb34 (cleanup): {
+-     bb28 (cleanup): {
 -         StorageDead(_3);
--         goto -> bb35;
-+     bb34: {
-+         assert(const false, "coroutine resumed after completion") -> [success: bb34, unwind continue];
+-         goto -> bb29;
++     bb28: {
++         assert(const false, "coroutine resumed after completion") -> [success: bb28, unwind continue];
       }
   
--     bb35 (cleanup): {
--         drop(_2) -> [return: bb36, unwind terminate(cleanup)];
-+     bb35: {
+-     bb29 (cleanup): {
+-         drop(_2) -> [return: bb30, unwind terminate(cleanup)];
++     bb29: {
 +         unreachable;
       }
   
--     bb36 (cleanup): {
--         drop(_1) -> [return: bb37, unwind terminate(cleanup)];
+-     bb30 (cleanup): {
+-         drop(_1) -> [return: bb31, unwind terminate(cleanup)];
 -     }
 - 
--     bb37 (cleanup): {
+-     bb31 (cleanup): {
 -         resume;
 -     }
 - 
--     bb38 (cleanup): {
--         drop(_1) -> [return: bb37, unwind terminate(cleanup)];
-+     bb36: {
+-     bb32 (cleanup): {
+-         drop(_1) -> [return: bb31, unwind terminate(cleanup)];
++     bb30: {
 +         (((*_18) as variant#4).0: std::string::String) = move _2;
 +         StorageLive(_3);
 +         StorageLive(_4);
 +         StorageLive(_5);
 +         StorageLive(_6);
 +         _6 = &(((*_18) as variant#4).0: std::string::String);
-+         _5 = <String as Clone>::clone(move _6) -> [return: bb1, unwind: bb22];
++         _5 = <String as Clone>::clone(move _6) -> [return: bb1, unwind: bb17];
       }
   }
   

--- a/tests/mir-opt/coroutine/coroutine.main-{closure#0}.StateTransform.diff
+++ b/tests/mir-opt/coroutine/coroutine.main-{closure#0}.StateTransform.diff
@@ -44,7 +44,7 @@
 -         StorageLive(_5);
 -         StorageLive(_6);
 -         _6 = &_2;
--         _5 = <String as Clone>::clone(move _6) -> [return: bb1, unwind: bb26];
+-         _5 = <String as Clone>::clone(move _6) -> [return: bb1, unwind: bb24];
 +         _18 = copy (_1.0: &mut {coroutine@$DIR/coroutine.rs:19:5: 19:18});
 +         _17 = discriminant((*_18));
 +         switchInt(move _17) -> [0: bb30, 1: bb28, 2: bb27, 3: bb25, 4: bb26, otherwise: bb29];
@@ -53,7 +53,7 @@
       bb1: {
           StorageDead(_6);
           StorageLive(_7);
--         _7 = Location::<'_>::caller() -> [return: bb2, unwind: bb25];
+-         _7 = Location::<'_>::caller() -> [return: bb2, unwind: bb23];
 +         _7 = Location::<'_>::caller() -> [return: bb2, unwind: bb16];
       }
   
@@ -61,7 +61,7 @@
           _4 = (const "first", move _5, move _7);
           StorageDead(_7);
           StorageDead(_5);
--         _3 = yield(move _4) -> [resume: bb3, drop: bb14];
+-         _3 = yield(move _4) -> [resume: bb3, drop: bb13];
 +         _0 = CoroutineState::<(&str, String, &Location<'_>), ()>::Yielded(move _4);
 +         StorageDead(_3);
 +         StorageDead(_4);
@@ -71,7 +71,7 @@
   
       bb3: {
           StorageDead(_4);
--         drop(_3) -> [return: bb4, unwind: bb28];
+-         drop(_3) -> [return: bb4, unwind: bb26];
 +         drop(_3) -> [return: bb4, unwind: bb19];
       }
   
@@ -86,7 +86,7 @@
           StorageLive(_12);
           StorageLive(_13);
 -         _13 = &_2;
--         _12 = <String as Clone>::clone(move _13) -> [return: bb5, unwind: bb23];
+-         _12 = <String as Clone>::clone(move _13) -> [return: bb5, unwind: bb21];
 +         _13 = &(((*_18) as variant#4).0: std::string::String);
 +         _12 = <String as Clone>::clone(move _13) -> [return: bb5, unwind: bb14];
       }
@@ -95,7 +95,7 @@
           StorageDead(_13);
           StorageLive(_14);
           StorageLive(_15);
--         _15 = Location::<'_>::caller() -> [return: bb6, unwind: bb20];
+-         _15 = Location::<'_>::caller() -> [return: bb6, unwind: bb18];
 +         _15 = Location::<'_>::caller() -> [return: bb6, unwind: bb11];
       }
   
@@ -117,7 +117,7 @@
   
       bb7: {
           StorageDead(_9);
--         drop(_8) -> [return: bb8, unwind: bb22];
+-         drop(_8) -> [return: bb8, unwind: bb20];
 +         drop(_8) -> [return: bb8, unwind: bb13];
       }
   
@@ -126,13 +126,13 @@
           StorageDead(_11);
           StorageDead(_8);
 -         _0 = const ();
--         drop(_2) -> [return: bb9, unwind: bb30];
+-         drop(_2) -> [return: bb9, unwind: bb28];
 +         _16 = const ();
 +         drop((((*_18) as variant#4).0: std::string::String)) -> [return: bb9, unwind: bb21];
       }
   
       bb9: {
--         drop(_1) -> [return: bb10, unwind: bb31];
+-         drop(_1) -> [return: bb10, unwind: bb29];
 +         goto -> bb23;
       }
   
@@ -143,30 +143,34 @@
       }
   
 -     bb11: {
--         goto -> bb12;
 +     bb11 (cleanup): {
 +         StorageDead(_14);
 +         drop(_12) -> [return: bb12, unwind terminate(cleanup)];
-      }
-  
--     bb12: {
++     }
++ 
 +     bb12 (cleanup): {
 +         StorageDead(_12);
 +         StorageDead(_10);
           StorageDead(_9);
-          goto -> bb13;
+-         goto -> bb12;
++         goto -> bb13;
       }
   
--     bb13: {
+-     bb12: {
 +     bb13 (cleanup): {
           StorageDead(_15);
 -         StorageDead(_11);
 -         StorageDead(_8);
--         goto -> bb17;
-+         goto -> bb15;
+          goto -> bb15;
       }
   
+-     bb13: {
+-         StorageDead(_4);
+-         goto -> bb14;
+-     }
+- 
 -     bb14: {
+-         StorageDead(_3);
 +     bb14 (cleanup): {
 +         StorageDead(_13);
 +         StorageDead(_12);
@@ -176,8 +180,7 @@
       }
   
 -     bb15: {
--         StorageDead(_4);
--         goto -> bb16;
+-         drop(_2) -> [return: bb16, unwind: bb30];
 +     bb15 (cleanup): {
 +         StorageDead(_11);
 +         StorageDead(_8);
@@ -185,42 +188,43 @@
       }
   
 -     bb16: {
--         StorageDead(_3);
--         goto -> bb17;
+-         drop(_1) -> [return: bb17, unwind: bb29];
 +     bb16 (cleanup): {
 +         StorageDead(_7);
 +         drop(_5) -> [return: bb18, unwind terminate(cleanup)];
       }
   
 -     bb17: {
--         drop(_2) -> [return: bb18, unwind: bb32];
+-         coroutine_drop;
 +     bb17 (cleanup): {
 +         StorageDead(_6);
 +         goto -> bb18;
       }
   
--     bb18: {
--         drop(_1) -> [return: bb19, unwind: bb31];
-+     bb18 (cleanup): {
+      bb18 (cleanup): {
+-         StorageDead(_14);
+-         drop(_12) -> [return: bb19, unwind terminate(cleanup)];
 +         StorageDead(_5);
 +         StorageDead(_4);
 +         goto -> bb19;
       }
   
--     bb19: {
--         coroutine_drop;
-+     bb19 (cleanup): {
+      bb19 (cleanup): {
+-         StorageDead(_12);
+-         StorageDead(_10);
+-         StorageDead(_9);
 +         StorageDead(_3);
-+         goto -> bb20;
+          goto -> bb20;
       }
   
       bb20 (cleanup): {
--         StorageDead(_14);
--         drop(_12) -> [return: bb21, unwind terminate(cleanup)];
+-         StorageDead(_15);
+-         goto -> bb22;
 +         drop((((*_18) as variant#4).0: std::string::String)) -> [return: bb21, unwind terminate(cleanup)];
       }
   
       bb21 (cleanup): {
+-         StorageDead(_13);
 -         StorageDead(_12);
 -         StorageDead(_10);
 -         StorageDead(_9);
@@ -228,31 +232,30 @@
       }
   
       bb22 (cleanup): {
--         StorageDead(_15);
-          goto -> bb24;
+-         StorageDead(_11);
+-         StorageDead(_8);
+-         goto -> bb27;
++         goto -> bb24;
       }
   
 -     bb23 (cleanup): {
--         StorageDead(_13);
--         StorageDead(_12);
--         StorageDead(_10);
--         StorageDead(_9);
--         goto -> bb24;
+-         StorageDead(_7);
+-         drop(_5) -> [return: bb25, unwind terminate(cleanup)];
 +     bb23: {
 +         goto -> bb10;
       }
   
       bb24 (cleanup): {
--         StorageDead(_11);
--         StorageDead(_8);
--         goto -> bb29;
+-         StorageDead(_6);
+-         goto -> bb25;
 +         discriminant((*_18)) = 2;
 +         resume;
       }
   
 -     bb25 (cleanup): {
--         StorageDead(_7);
--         drop(_5) -> [return: bb27, unwind terminate(cleanup)];
+-         StorageDead(_5);
+-         StorageDead(_4);
+-         goto -> bb26;
 +     bb25: {
 +         StorageLive(_3);
 +         StorageLive(_4);
@@ -261,7 +264,7 @@
       }
   
 -     bb26 (cleanup): {
--         StorageDead(_6);
+-         StorageDead(_3);
 -         goto -> bb27;
 +     bb26: {
 +         StorageLive(_8);
@@ -273,36 +276,25 @@
       }
   
 -     bb27 (cleanup): {
--         StorageDead(_5);
--         StorageDead(_4);
--         goto -> bb28;
+-         drop(_2) -> [return: bb28, unwind terminate(cleanup)];
 +     bb27: {
 +         assert(const false, "coroutine resumed after panicking") -> [success: bb27, unwind continue];
       }
   
 -     bb28 (cleanup): {
--         StorageDead(_3);
--         goto -> bb29;
+-         drop(_1) -> [return: bb29, unwind terminate(cleanup)];
 +     bb28: {
 +         assert(const false, "coroutine resumed after completion") -> [success: bb28, unwind continue];
       }
   
 -     bb29 (cleanup): {
--         drop(_2) -> [return: bb30, unwind terminate(cleanup)];
+-         resume;
 +     bb29: {
 +         unreachable;
       }
   
 -     bb30 (cleanup): {
--         drop(_1) -> [return: bb31, unwind terminate(cleanup)];
--     }
-- 
--     bb31 (cleanup): {
--         resume;
--     }
-- 
--     bb32 (cleanup): {
--         drop(_1) -> [return: bb31, unwind terminate(cleanup)];
+-         drop(_1) -> [return: bb29, unwind terminate(cleanup)];
 +     bb30: {
 +         (((*_18) as variant#4).0: std::string::String) = move _2;
 +         StorageLive(_3);

--- a/tests/mir-opt/coroutine/coroutine.main-{closure#1}.StateTransform.diff
+++ b/tests/mir-opt/coroutine/coroutine.main-{closure#1}.StateTransform.diff
@@ -44,28 +44,24 @@
 -         StorageLive(_5);
 -         StorageLive(_6);
 -         _6 = &_2;
--         _5 = <String as Clone>::clone(move _6) -> [return: bb1, unwind: bb31];
+-         _5 = <String as Clone>::clone(move _6) -> [return: bb1, unwind: bb26];
 +         _18 = copy (_1.0: &mut {coroutine@$DIR/coroutine.rs:26:5: 26:18});
 +         _17 = discriminant((*_18));
-+         switchInt(move _17) -> [0: bb36, 1: bb34, 2: bb33, 3: bb31, 4: bb32, otherwise: bb35];
++         switchInt(move _17) -> [0: bb30, 1: bb28, 2: bb27, 3: bb25, 4: bb26, otherwise: bb29];
       }
   
       bb1: {
           StorageDead(_6);
           StorageLive(_7);
--         _7 = Location::<'_>::caller() -> [return: bb2, unwind: bb30];
-+         _7 = Location::<'_>::caller() -> [return: bb2, unwind: bb21];
+-         _7 = Location::<'_>::caller() -> [return: bb2, unwind: bb25];
++         _7 = Location::<'_>::caller() -> [return: bb2, unwind: bb16];
       }
   
       bb2: {
           _4 = (const "first", move _5, move _7);
           StorageDead(_7);
-          goto -> bb3;
-      }
-  
-      bb3: {
           StorageDead(_5);
--         _3 = yield(move _4) -> [resume: bb4, drop: bb18];
+-         _3 = yield(move _4) -> [resume: bb3, drop: bb14];
 +         _0 = CoroutineState::<(&str, String, &Location<'_>), ()>::Yielded(move _4);
 +         StorageDead(_3);
 +         StorageDead(_4);
@@ -73,17 +69,13 @@
 +         return;
       }
   
-      bb4: {
-          goto -> bb5;
-      }
-  
-      bb5: {
+      bb3: {
           StorageDead(_4);
--         drop(_3) -> [return: bb6, unwind: bb34];
-+         drop(_3) -> [return: bb6, unwind: bb25];
+-         drop(_3) -> [return: bb4, unwind: bb28];
++         drop(_3) -> [return: bb4, unwind: bb19];
       }
   
-      bb6: {
+      bb4: {
           StorageDead(_3);
           StorageLive(_8);
           StorageLive(_9);
@@ -94,30 +86,26 @@
           StorageLive(_12);
           StorageLive(_13);
 -         _13 = &_2;
--         _12 = <String as Clone>::clone(move _13) -> [return: bb7, unwind: bb28];
+-         _12 = <String as Clone>::clone(move _13) -> [return: bb5, unwind: bb23];
 +         _13 = &(((*_18) as variant#4).0: std::string::String);
-+         _12 = <String as Clone>::clone(move _13) -> [return: bb7, unwind: bb19];
++         _12 = <String as Clone>::clone(move _13) -> [return: bb5, unwind: bb14];
       }
   
-      bb7: {
+      bb5: {
           StorageDead(_13);
           StorageLive(_14);
           StorageLive(_15);
--         _15 = Location::<'_>::caller() -> [return: bb8, unwind: bb24];
-+         _15 = Location::<'_>::caller() -> [return: bb8, unwind: bb15];
+-         _15 = Location::<'_>::caller() -> [return: bb6, unwind: bb20];
++         _15 = Location::<'_>::caller() -> [return: bb6, unwind: bb11];
       }
   
-      bb8: {
+      bb6: {
           _14 = &(*_15);
           _9 = (move _10, move _12, move _14);
           StorageDead(_14);
-          goto -> bb9;
-      }
-  
-      bb9: {
           StorageDead(_12);
           StorageDead(_10);
--         _8 = yield(move _9) -> [resume: bb10, drop: bb15];
+-         _8 = yield(move _9) -> [resume: bb7, drop: bb11];
 +         _0 = CoroutineState::<(&str, String, &Location<'_>), ()>::Yielded(move _9);
 +         StorageDead(_8);
 +         StorageDead(_9);
@@ -127,219 +115,202 @@
 +         return;
       }
   
-      bb10: {
-          goto -> bb11;
-      }
-  
-      bb11: {
+      bb7: {
           StorageDead(_9);
--         drop(_8) -> [return: bb12, unwind: bb27];
-+         drop(_8) -> [return: bb12, unwind: bb18];
+-         drop(_8) -> [return: bb8, unwind: bb22];
++         drop(_8) -> [return: bb8, unwind: bb13];
       }
   
-      bb12: {
+      bb8: {
           StorageDead(_15);
           StorageDead(_11);
           StorageDead(_8);
 -         _0 = const ();
--         drop(_2) -> [return: bb13, unwind: bb36];
+-         drop(_2) -> [return: bb9, unwind: bb30];
 +         _16 = const ();
-+         drop((((*_18) as variant#4).0: std::string::String)) -> [return: bb13, unwind: bb27];
++         drop((((*_18) as variant#4).0: std::string::String)) -> [return: bb9, unwind: bb21];
       }
   
-      bb13: {
--         drop(_1) -> [return: bb14, unwind: bb37];
-+         goto -> bb29;
+      bb9: {
+-         drop(_1) -> [return: bb10, unwind: bb31];
++         goto -> bb23;
       }
   
-      bb14: {
+      bb10: {
 +         _0 = CoroutineState::<(&str, String, &Location<'_>), ()>::Complete(move _16);
 +         discriminant((*_18)) = 1;
           return;
       }
   
--     bb15: {
--         goto -> bb16;
-+     bb15 (cleanup): {
+-     bb11: {
+-         goto -> bb12;
++     bb11 (cleanup): {
 +         StorageDead(_14);
-+         drop(_12) -> [return: bb16, unwind terminate(cleanup)];
++         drop(_12) -> [return: bb12, unwind terminate(cleanup)];
       }
   
--     bb16: {
--         StorageDead(_9);
-+     bb16 (cleanup): {
+-     bb12: {
++     bb12 (cleanup): {
 +         StorageDead(_12);
 +         StorageDead(_10);
-          goto -> bb17;
+          StorageDead(_9);
+          goto -> bb13;
       }
   
--     bb17: {
--         StorageDead(_15);
+-     bb13: {
++     bb13 (cleanup): {
+          StorageDead(_15);
 -         StorageDead(_11);
 -         StorageDead(_8);
--         goto -> bb21;
-+     bb17 (cleanup): {
-+         StorageDead(_9);
-+         goto -> bb18;
+-         goto -> bb17;
++         goto -> bb15;
       }
   
--     bb18: {
--         goto -> bb19;
-+     bb18 (cleanup): {
-+         StorageDead(_15);
-+         goto -> bb20;
-      }
-  
--     bb19: {
--         StorageDead(_4);
-+     bb19 (cleanup): {
+-     bb14: {
++     bb14 (cleanup): {
 +         StorageDead(_13);
 +         StorageDead(_12);
 +         StorageDead(_10);
 +         StorageDead(_9);
-          goto -> bb20;
+          goto -> bb15;
       }
   
--     bb20: {
--         StorageDead(_3);
--         goto -> bb21;
-+     bb20 (cleanup): {
+-     bb15: {
+-         StorageDead(_4);
+-         goto -> bb16;
++     bb15 (cleanup): {
 +         StorageDead(_11);
 +         StorageDead(_8);
-+         goto -> bb26;
++         goto -> bb20;
       }
   
--     bb21: {
--         drop(_2) -> [return: bb22, unwind: bb38];
-+     bb21 (cleanup): {
+-     bb16: {
+-         StorageDead(_3);
+-         goto -> bb17;
++     bb16 (cleanup): {
 +         StorageDead(_7);
-+         drop(_5) -> [return: bb23, unwind terminate(cleanup)];
++         drop(_5) -> [return: bb18, unwind terminate(cleanup)];
       }
   
--     bb22: {
--         drop(_1) -> [return: bb23, unwind: bb37];
-+     bb22 (cleanup): {
+-     bb17: {
+-         drop(_2) -> [return: bb18, unwind: bb32];
++     bb17 (cleanup): {
 +         StorageDead(_6);
-+         goto -> bb23;
++         goto -> bb18;
       }
   
--     bb23: {
--         coroutine_drop;
-+     bb23 (cleanup): {
+-     bb18: {
+-         drop(_1) -> [return: bb19, unwind: bb31];
++     bb18 (cleanup): {
 +         StorageDead(_5);
-+         goto -> bb24;
-      }
-  
-      bb24 (cleanup): {
--         StorageDead(_14);
--         drop(_12) -> [return: bb25, unwind terminate(cleanup)];
 +         StorageDead(_4);
-+         goto -> bb25;
++         goto -> bb19;
       }
   
-      bb25 (cleanup): {
+-     bb19: {
+-         coroutine_drop;
++     bb19 (cleanup): {
++         StorageDead(_3);
++         goto -> bb20;
+      }
+  
+      bb20 (cleanup): {
+-         StorageDead(_14);
+-         drop(_12) -> [return: bb21, unwind terminate(cleanup)];
++         drop((((*_18) as variant#4).0: std::string::String)) -> [return: bb21, unwind terminate(cleanup)];
+      }
+  
+      bb21 (cleanup): {
 -         StorageDead(_12);
 -         StorageDead(_10);
-+         StorageDead(_3);
-          goto -> bb26;
-      }
-  
-      bb26 (cleanup): {
 -         StorageDead(_9);
--         goto -> bb27;
-+         drop((((*_18) as variant#4).0: std::string::String)) -> [return: bb27, unwind terminate(cleanup)];
+          goto -> bb22;
       }
   
-      bb27 (cleanup): {
+      bb22 (cleanup): {
 -         StorageDead(_15);
--         goto -> bb29;
-+         goto -> bb28;
+          goto -> bb24;
       }
   
-      bb28 (cleanup): {
+-     bb23 (cleanup): {
 -         StorageDead(_13);
 -         StorageDead(_12);
 -         StorageDead(_10);
 -         StorageDead(_9);
--         goto -> bb29;
-+         goto -> bb30;
+-         goto -> bb24;
++     bb23: {
++         goto -> bb10;
       }
   
--     bb29 (cleanup): {
+      bb24 (cleanup): {
 -         StorageDead(_11);
 -         StorageDead(_8);
--         goto -> bb35;
-+     bb29: {
-+         goto -> bb14;
-      }
-  
-      bb30 (cleanup): {
--         StorageDead(_7);
--         drop(_5) -> [return: bb32, unwind terminate(cleanup)];
+-         goto -> bb29;
 +         discriminant((*_18)) = 2;
 +         resume;
       }
   
--     bb31 (cleanup): {
--         StorageDead(_6);
--         goto -> bb32;
-+     bb31: {
+-     bb25 (cleanup): {
+-         StorageDead(_7);
+-         drop(_5) -> [return: bb27, unwind terminate(cleanup)];
++     bb25: {
 +         StorageLive(_3);
 +         StorageLive(_4);
 +         _3 = move _2;
-+         goto -> bb4;
++         goto -> bb3;
       }
   
--     bb32 (cleanup): {
--         StorageDead(_5);
--         goto -> bb33;
-+     bb32: {
+-     bb26 (cleanup): {
+-         StorageDead(_6);
+-         goto -> bb27;
++     bb26: {
 +         StorageLive(_8);
 +         StorageLive(_9);
 +         StorageLive(_11);
 +         StorageLive(_15);
 +         _8 = move _2;
-+         goto -> bb10;
++         goto -> bb7;
       }
   
--     bb33 (cleanup): {
+-     bb27 (cleanup): {
+-         StorageDead(_5);
 -         StorageDead(_4);
--         goto -> bb34;
-+     bb33: {
-+         assert(const false, "coroutine resumed after panicking") -> [success: bb33, unwind continue];
+-         goto -> bb28;
++     bb27: {
++         assert(const false, "coroutine resumed after panicking") -> [success: bb27, unwind continue];
       }
   
--     bb34 (cleanup): {
+-     bb28 (cleanup): {
 -         StorageDead(_3);
--         goto -> bb35;
-+     bb34: {
-+         assert(const false, "coroutine resumed after completion") -> [success: bb34, unwind continue];
+-         goto -> bb29;
++     bb28: {
++         assert(const false, "coroutine resumed after completion") -> [success: bb28, unwind continue];
       }
   
--     bb35 (cleanup): {
--         drop(_2) -> [return: bb36, unwind terminate(cleanup)];
-+     bb35: {
+-     bb29 (cleanup): {
+-         drop(_2) -> [return: bb30, unwind terminate(cleanup)];
++     bb29: {
 +         unreachable;
       }
   
--     bb36 (cleanup): {
--         drop(_1) -> [return: bb37, unwind terminate(cleanup)];
+-     bb30 (cleanup): {
+-         drop(_1) -> [return: bb31, unwind terminate(cleanup)];
 -     }
 - 
--     bb37 (cleanup): {
+-     bb31 (cleanup): {
 -         resume;
 -     }
 - 
--     bb38 (cleanup): {
--         drop(_1) -> [return: bb37, unwind terminate(cleanup)];
-+     bb36: {
+-     bb32 (cleanup): {
+-         drop(_1) -> [return: bb31, unwind terminate(cleanup)];
++     bb30: {
 +         (((*_18) as variant#4).0: std::string::String) = move _2;
 +         StorageLive(_3);
 +         StorageLive(_4);
 +         StorageLive(_5);
 +         StorageLive(_6);
 +         _6 = &(((*_18) as variant#4).0: std::string::String);
-+         _5 = <String as Clone>::clone(move _6) -> [return: bb1, unwind: bb22];
++         _5 = <String as Clone>::clone(move _6) -> [return: bb1, unwind: bb17];
       }
   }
   

--- a/tests/mir-opt/coroutine/coroutine.main-{closure#1}.StateTransform.diff
+++ b/tests/mir-opt/coroutine/coroutine.main-{closure#1}.StateTransform.diff
@@ -44,7 +44,7 @@
 -         StorageLive(_5);
 -         StorageLive(_6);
 -         _6 = &_2;
--         _5 = <String as Clone>::clone(move _6) -> [return: bb1, unwind: bb26];
+-         _5 = <String as Clone>::clone(move _6) -> [return: bb1, unwind: bb24];
 +         _18 = copy (_1.0: &mut {coroutine@$DIR/coroutine.rs:26:5: 26:18});
 +         _17 = discriminant((*_18));
 +         switchInt(move _17) -> [0: bb30, 1: bb28, 2: bb27, 3: bb25, 4: bb26, otherwise: bb29];
@@ -53,7 +53,7 @@
       bb1: {
           StorageDead(_6);
           StorageLive(_7);
--         _7 = Location::<'_>::caller() -> [return: bb2, unwind: bb25];
+-         _7 = Location::<'_>::caller() -> [return: bb2, unwind: bb23];
 +         _7 = Location::<'_>::caller() -> [return: bb2, unwind: bb16];
       }
   
@@ -61,7 +61,7 @@
           _4 = (const "first", move _5, move _7);
           StorageDead(_7);
           StorageDead(_5);
--         _3 = yield(move _4) -> [resume: bb3, drop: bb14];
+-         _3 = yield(move _4) -> [resume: bb3, drop: bb13];
 +         _0 = CoroutineState::<(&str, String, &Location<'_>), ()>::Yielded(move _4);
 +         StorageDead(_3);
 +         StorageDead(_4);
@@ -71,7 +71,7 @@
   
       bb3: {
           StorageDead(_4);
--         drop(_3) -> [return: bb4, unwind: bb28];
+-         drop(_3) -> [return: bb4, unwind: bb26];
 +         drop(_3) -> [return: bb4, unwind: bb19];
       }
   
@@ -86,7 +86,7 @@
           StorageLive(_12);
           StorageLive(_13);
 -         _13 = &_2;
--         _12 = <String as Clone>::clone(move _13) -> [return: bb5, unwind: bb23];
+-         _12 = <String as Clone>::clone(move _13) -> [return: bb5, unwind: bb21];
 +         _13 = &(((*_18) as variant#4).0: std::string::String);
 +         _12 = <String as Clone>::clone(move _13) -> [return: bb5, unwind: bb14];
       }
@@ -95,7 +95,7 @@
           StorageDead(_13);
           StorageLive(_14);
           StorageLive(_15);
--         _15 = Location::<'_>::caller() -> [return: bb6, unwind: bb20];
+-         _15 = Location::<'_>::caller() -> [return: bb6, unwind: bb18];
 +         _15 = Location::<'_>::caller() -> [return: bb6, unwind: bb11];
       }
   
@@ -117,7 +117,7 @@
   
       bb7: {
           StorageDead(_9);
--         drop(_8) -> [return: bb8, unwind: bb22];
+-         drop(_8) -> [return: bb8, unwind: bb20];
 +         drop(_8) -> [return: bb8, unwind: bb13];
       }
   
@@ -126,13 +126,13 @@
           StorageDead(_11);
           StorageDead(_8);
 -         _0 = const ();
--         drop(_2) -> [return: bb9, unwind: bb30];
+-         drop(_2) -> [return: bb9, unwind: bb28];
 +         _16 = const ();
 +         drop((((*_18) as variant#4).0: std::string::String)) -> [return: bb9, unwind: bb21];
       }
   
       bb9: {
--         drop(_1) -> [return: bb10, unwind: bb31];
+-         drop(_1) -> [return: bb10, unwind: bb29];
 +         goto -> bb23;
       }
   
@@ -143,30 +143,34 @@
       }
   
 -     bb11: {
--         goto -> bb12;
 +     bb11 (cleanup): {
 +         StorageDead(_14);
 +         drop(_12) -> [return: bb12, unwind terminate(cleanup)];
-      }
-  
--     bb12: {
++     }
++ 
 +     bb12 (cleanup): {
 +         StorageDead(_12);
 +         StorageDead(_10);
           StorageDead(_9);
-          goto -> bb13;
+-         goto -> bb12;
++         goto -> bb13;
       }
   
--     bb13: {
+-     bb12: {
 +     bb13 (cleanup): {
           StorageDead(_15);
 -         StorageDead(_11);
 -         StorageDead(_8);
--         goto -> bb17;
-+         goto -> bb15;
+          goto -> bb15;
       }
   
+-     bb13: {
+-         StorageDead(_4);
+-         goto -> bb14;
+-     }
+- 
 -     bb14: {
+-         StorageDead(_3);
 +     bb14 (cleanup): {
 +         StorageDead(_13);
 +         StorageDead(_12);
@@ -176,8 +180,7 @@
       }
   
 -     bb15: {
--         StorageDead(_4);
--         goto -> bb16;
+-         drop(_2) -> [return: bb16, unwind: bb30];
 +     bb15 (cleanup): {
 +         StorageDead(_11);
 +         StorageDead(_8);
@@ -185,42 +188,43 @@
       }
   
 -     bb16: {
--         StorageDead(_3);
--         goto -> bb17;
+-         drop(_1) -> [return: bb17, unwind: bb29];
 +     bb16 (cleanup): {
 +         StorageDead(_7);
 +         drop(_5) -> [return: bb18, unwind terminate(cleanup)];
       }
   
 -     bb17: {
--         drop(_2) -> [return: bb18, unwind: bb32];
+-         coroutine_drop;
 +     bb17 (cleanup): {
 +         StorageDead(_6);
 +         goto -> bb18;
       }
   
--     bb18: {
--         drop(_1) -> [return: bb19, unwind: bb31];
-+     bb18 (cleanup): {
+      bb18 (cleanup): {
+-         StorageDead(_14);
+-         drop(_12) -> [return: bb19, unwind terminate(cleanup)];
 +         StorageDead(_5);
 +         StorageDead(_4);
 +         goto -> bb19;
       }
   
--     bb19: {
--         coroutine_drop;
-+     bb19 (cleanup): {
+      bb19 (cleanup): {
+-         StorageDead(_12);
+-         StorageDead(_10);
+-         StorageDead(_9);
 +         StorageDead(_3);
-+         goto -> bb20;
+          goto -> bb20;
       }
   
       bb20 (cleanup): {
--         StorageDead(_14);
--         drop(_12) -> [return: bb21, unwind terminate(cleanup)];
+-         StorageDead(_15);
+-         goto -> bb22;
 +         drop((((*_18) as variant#4).0: std::string::String)) -> [return: bb21, unwind terminate(cleanup)];
       }
   
       bb21 (cleanup): {
+-         StorageDead(_13);
 -         StorageDead(_12);
 -         StorageDead(_10);
 -         StorageDead(_9);
@@ -228,31 +232,30 @@
       }
   
       bb22 (cleanup): {
--         StorageDead(_15);
-          goto -> bb24;
+-         StorageDead(_11);
+-         StorageDead(_8);
+-         goto -> bb27;
++         goto -> bb24;
       }
   
 -     bb23 (cleanup): {
--         StorageDead(_13);
--         StorageDead(_12);
--         StorageDead(_10);
--         StorageDead(_9);
--         goto -> bb24;
+-         StorageDead(_7);
+-         drop(_5) -> [return: bb25, unwind terminate(cleanup)];
 +     bb23: {
 +         goto -> bb10;
       }
   
       bb24 (cleanup): {
--         StorageDead(_11);
--         StorageDead(_8);
--         goto -> bb29;
+-         StorageDead(_6);
+-         goto -> bb25;
 +         discriminant((*_18)) = 2;
 +         resume;
       }
   
 -     bb25 (cleanup): {
--         StorageDead(_7);
--         drop(_5) -> [return: bb27, unwind terminate(cleanup)];
+-         StorageDead(_5);
+-         StorageDead(_4);
+-         goto -> bb26;
 +     bb25: {
 +         StorageLive(_3);
 +         StorageLive(_4);
@@ -261,7 +264,7 @@
       }
   
 -     bb26 (cleanup): {
--         StorageDead(_6);
+-         StorageDead(_3);
 -         goto -> bb27;
 +     bb26: {
 +         StorageLive(_8);
@@ -273,36 +276,25 @@
       }
   
 -     bb27 (cleanup): {
--         StorageDead(_5);
--         StorageDead(_4);
--         goto -> bb28;
+-         drop(_2) -> [return: bb28, unwind terminate(cleanup)];
 +     bb27: {
 +         assert(const false, "coroutine resumed after panicking") -> [success: bb27, unwind continue];
       }
   
 -     bb28 (cleanup): {
--         StorageDead(_3);
--         goto -> bb29;
+-         drop(_1) -> [return: bb29, unwind terminate(cleanup)];
 +     bb28: {
 +         assert(const false, "coroutine resumed after completion") -> [success: bb28, unwind continue];
       }
   
 -     bb29 (cleanup): {
--         drop(_2) -> [return: bb30, unwind terminate(cleanup)];
+-         resume;
 +     bb29: {
 +         unreachable;
       }
   
 -     bb30 (cleanup): {
--         drop(_1) -> [return: bb31, unwind terminate(cleanup)];
--     }
-- 
--     bb31 (cleanup): {
--         resume;
--     }
-- 
--     bb32 (cleanup): {
--         drop(_1) -> [return: bb31, unwind terminate(cleanup)];
+-         drop(_1) -> [return: bb29, unwind terminate(cleanup)];
 +     bb30: {
 +         (((*_18) as variant#4).0: std::string::String) = move _2;
 +         StorageLive(_3);

--- a/tests/mir-opt/coroutine/coroutine_storage_dead_unwind.main-{closure#0}.StateTransform.panic-unwind.diff
+++ b/tests/mir-opt/coroutine/coroutine_storage_dead_unwind.main-{closure#0}.StateTransform.panic-unwind.diff
@@ -51,7 +51,7 @@
 -         _5 = yield(move _6) -> [resume: bb1, drop: bb6];
 +         _13 = copy (_1.0: &mut {coroutine@$DIR/coroutine_storage_dead_unwind.rs:24:5: 24:7});
 +         _12 = discriminant((*_13));
-+         switchInt(move _12) -> [0: bb18, 1: bb16, 2: bb15, 3: bb14, otherwise: bb17];
++         switchInt(move _12) -> [0: bb17, 1: bb15, 2: bb14, 3: bb13, otherwise: bb16];
       }
   
       bb1: {
@@ -88,9 +88,9 @@
   
       bb4: {
 -         StorageDead(_3);
--         drop(_1) -> [return: bb5, unwind: bb14];
+-         drop(_1) -> [return: bb5, unwind: bb13];
 +         nop;
-+         goto -> bb12;
++         goto -> bb11;
       }
   
       bb5: {
@@ -103,87 +103,83 @@
 -         StorageDead(_6);
 -         StorageDead(_5);
 -         StorageDead(_4);
--         drop(_3) -> [return: bb7, unwind: bb15];
+-         drop(_3) -> [return: bb7, unwind: bb14];
 +     bb6 (cleanup): {
 +         StorageDead(_10);
 +         StorageDead(_9);
-+         goto -> bb9;
++         goto -> bb8;
       }
   
 -     bb7: {
 -         StorageDead(_3);
--         drop(_1) -> [return: bb8, unwind: bb14];
+-         drop(_1) -> [return: bb8, unwind: bb13];
 +     bb7 (cleanup): {
++         StorageDead(_8);
++         StorageDead(_7);
 +         goto -> bb8;
       }
   
 -     bb8: {
 -         coroutine_drop;
 +     bb8 (cleanup): {
-+         StorageDead(_8);
-+         StorageDead(_7);
++         nop;
 +         goto -> bb9;
       }
   
       bb9 (cleanup): {
 -         StorageDead(_10);
 -         StorageDead(_9);
--         goto -> bb12;
+-         goto -> bb11;
 +         nop;
 +         goto -> bb10;
       }
   
       bb10 (cleanup): {
-+         nop;
-          goto -> bb11;
-      }
-  
-      bb11 (cleanup): {
 -         StorageDead(_8);
 -         StorageDead(_7);
--         goto -> bb12;
-+         goto -> bb13;
+-         goto -> bb11;
++         goto -> bb12;
       }
   
--     bb12 (cleanup): {
+-     bb11 (cleanup): {
 -         StorageDead(_4);
--         goto -> bb13;
-+     bb12: {
+-         goto -> bb12;
++     bb11: {
 +         goto -> bb5;
       }
   
-      bb13 (cleanup): {
+      bb12 (cleanup): {
 -         StorageDead(_3);
--         drop(_1) -> [return: bb14, unwind terminate(cleanup)];
+-         drop(_1) -> [return: bb13, unwind terminate(cleanup)];
 +         discriminant((*_13)) = 2;
 +         resume;
       }
   
--     bb14 (cleanup): {
+-     bb13 (cleanup): {
 -         resume;
-+     bb14: {
++     bb13: {
 +         StorageLive(_5);
 +         StorageLive(_6);
 +         _5 = move _2;
 +         goto -> bb1;
       }
   
--     bb15 (cleanup): {
+-     bb14 (cleanup): {
 -         StorageDead(_3);
--         drop(_1) -> [return: bb14, unwind terminate(cleanup)];
+-         drop(_1) -> [return: bb13, unwind terminate(cleanup)];
++     bb14: {
++         assert(const false, "coroutine resumed after panicking") -> [success: bb14, unwind continue];
++     }
++ 
 +     bb15: {
-+         assert(const false, "coroutine resumed after panicking") -> [success: bb15, unwind continue];
++         assert(const false, "coroutine resumed after completion") -> [success: bb15, unwind continue];
 +     }
 + 
 +     bb16: {
-+         assert(const false, "coroutine resumed after completion") -> [success: bb16, unwind continue];
-+     }
-+ 
-+     bb17: {
 +         unreachable;
 +     }
 + 
-+     bb18: {
++     bb17: {
 +         nop;
 +         (((*_13) as variant#3).0: Foo) = Foo(const 5_i32);
 +         nop;

--- a/tests/mir-opt/coroutine/unwind_in_vec.build-{closure#0}.built.after.mir
+++ b/tests/mir-opt/coroutine/unwind_in_vec.build-{closure#0}.built.after.mir
@@ -37,7 +37,7 @@ yields ()
         FakeRead(ForLet(None), _3);
         StorageLive(_4);
         StorageLive(_5);
-        _5 = Box::<[String; 5]>::new_uninit() -> [return: bb1, unwind: bb50];
+        _5 = Box::<[String; 5]>::new_uninit() -> [return: bb1, unwind: bb38];
     }
 
     bb1: {
@@ -46,7 +46,7 @@ yields ()
         StorageLive(_8);
         _8 = const "0";
         _7 = &(*_8);
-        _6 = <str as ToString>::to_string(move _7) -> [return: bb2, unwind: bb47];
+        _6 = <str as ToString>::to_string(move _7) -> [return: bb2, unwind: bb35];
     }
 
     bb2: {
@@ -56,7 +56,7 @@ yields ()
         StorageLive(_11);
         _11 = const "1";
         _10 = &(*_11);
-        _9 = <str as ToString>::to_string(move _10) -> [return: bb3, unwind: bb43];
+        _9 = <str as ToString>::to_string(move _10) -> [return: bb3, unwind: bb31];
     }
 
     bb3: {
@@ -66,7 +66,7 @@ yields ()
         StorageLive(_14);
         _14 = const "2";
         _13 = &(*_14);
-        _12 = <str as ToString>::to_string(move _13) -> [return: bb4, unwind: bb38];
+        _12 = <str as ToString>::to_string(move _13) -> [return: bb4, unwind: bb26];
     }
 
     bb4: {
@@ -76,7 +76,7 @@ yields ()
         StorageLive(_17);
         _17 = const "3";
         _16 = &(*_17);
-        _15 = <str as ToString>::to_string(move _16) -> [return: bb5, unwind: bb32];
+        _15 = <str as ToString>::to_string(move _16) -> [return: bb5, unwind: bb20];
     }
 
     bb5: {
@@ -86,169 +86,174 @@ yields ()
         StorageLive(_20);
         _20 = const "4";
         _19 = &(*_20);
-        _18 = <str as ToString>::to_string(move _19) -> [return: bb6, unwind: bb24];
+        _18 = <str as ToString>::to_string(move _19) -> [return: bb6, unwind: bb13];
     }
 
     bb6: {
         StorageDead(_19);
         ((((*_5).1: std::mem::ManuallyDrop<[std::string::String; 5]>).0: std::mem::MaybeDangling<[std::string::String; 5]>).0: [std::string::String; 5]) = [move _6, move _9, move _12, move _15, move _18];
-        drop(_18) -> [return: bb7, unwind: bb25, drop: bb15];
+        StorageDead(_18);
+        StorageDead(_15);
+        StorageDead(_12);
+        StorageDead(_9);
+        StorageDead(_6);
+        _4 = move _5;
+        drop(_5) -> [return: bb7, unwind: bb11];
     }
 
     bb7: {
-        StorageDead(_18);
-        drop(_15) -> [return: bb8, unwind: bb26, drop: bb16];
+        StorageDead(_5);
+        _0 = std::boxed::box_assume_init_into_vec_unsafe::<String, 5>(move _4) -> [return: bb8, unwind: bb12];
     }
 
     bb8: {
-        StorageDead(_15);
-        drop(_12) -> [return: bb9, unwind: bb27, drop: bb17];
+        StorageDead(_4);
+        StorageDead(_20);
+        StorageDead(_17);
+        StorageDead(_14);
+        StorageDead(_11);
+        StorageDead(_8);
+        StorageDead(_3);
+        drop(_1) -> [return: bb9, unwind: bb40, drop: bb10];
     }
 
     bb9: {
-        StorageDead(_12);
-        drop(_9) -> [return: bb10, unwind: bb28, drop: bb18];
-    }
-
-    bb10: {
-        StorageDead(_9);
-        drop(_6) -> [return: bb11, unwind: bb29, drop: bb19];
-    }
-
-    bb11: {
-        StorageDead(_6);
-        _4 = move _5;
-        drop(_5) -> [return: bb12, unwind: bb22];
-    }
-
-    bb12: {
-        StorageDead(_5);
-        _0 = std::boxed::box_assume_init_into_vec_unsafe::<String, 5>(move _4) -> [return: bb13, unwind: bb23];
-    }
-
-    bb13: {
-        StorageDead(_4);
-        StorageDead(_20);
-        StorageDead(_17);
-        StorageDead(_14);
-        StorageDead(_11);
-        StorageDead(_8);
-        StorageDead(_3);
-        drop(_1) -> [return: bb14, unwind: bb52, drop: bb21];
-    }
-
-    bb14: {
         return;
     }
 
-    bb15: {
-        StorageDead(_18);
-        drop(_15) -> [return: bb16, unwind: bb53];
-    }
-
-    bb16: {
-        StorageDead(_15);
-        drop(_12) -> [return: bb17, unwind: bb54];
-    }
-
-    bb17: {
-        StorageDead(_12);
-        drop(_9) -> [return: bb18, unwind: bb55];
-    }
-
-    bb18: {
-        StorageDead(_9);
-        drop(_6) -> [return: bb19, unwind: bb56];
-    }
-
-    bb19: {
-        StorageDead(_6);
-        drop(_5) -> [return: bb20, unwind: bb57];
-    }
-
-    bb20: {
-        StorageDead(_5);
-        StorageDead(_4);
-        StorageDead(_20);
-        StorageDead(_17);
-        StorageDead(_14);
-        StorageDead(_11);
-        StorageDead(_8);
-        StorageDead(_3);
-        drop(_1) -> [return: bb21, unwind: bb52];
-    }
-
-    bb21: {
+    bb10: {
         coroutine_drop;
     }
 
-    bb22 (cleanup): {
+    bb11 (cleanup): {
         StorageDead(_5);
-        goto -> bb23;
+        goto -> bb12;
+    }
+
+    bb12 (cleanup): {
+        drop(_4) -> [return: bb19, unwind terminate(cleanup)];
+    }
+
+    bb13 (cleanup): {
+        StorageDead(_19);
+        StorageDead(_18);
+        drop(_15) -> [return: bb14, unwind terminate(cleanup)];
+    }
+
+    bb14 (cleanup): {
+        StorageDead(_15);
+        drop(_12) -> [return: bb15, unwind terminate(cleanup)];
+    }
+
+    bb15 (cleanup): {
+        StorageDead(_12);
+        drop(_9) -> [return: bb16, unwind terminate(cleanup)];
+    }
+
+    bb16 (cleanup): {
+        StorageDead(_9);
+        drop(_6) -> [return: bb17, unwind terminate(cleanup)];
+    }
+
+    bb17 (cleanup): {
+        StorageDead(_6);
+        drop(_5) -> [return: bb18, unwind terminate(cleanup)];
+    }
+
+    bb18 (cleanup): {
+        StorageDead(_5);
+        goto -> bb19;
+    }
+
+    bb19 (cleanup): {
+        StorageDead(_4);
+        StorageDead(_20);
+        goto -> bb25;
+    }
+
+    bb20 (cleanup): {
+        StorageDead(_16);
+        StorageDead(_15);
+        drop(_12) -> [return: bb21, unwind terminate(cleanup)];
+    }
+
+    bb21 (cleanup): {
+        StorageDead(_12);
+        drop(_9) -> [return: bb22, unwind terminate(cleanup)];
+    }
+
+    bb22 (cleanup): {
+        StorageDead(_9);
+        drop(_6) -> [return: bb23, unwind terminate(cleanup)];
     }
 
     bb23 (cleanup): {
-        drop(_4) -> [return: bb31, unwind terminate(cleanup)];
+        StorageDead(_6);
+        drop(_5) -> [return: bb24, unwind terminate(cleanup)];
     }
 
     bb24 (cleanup): {
-        StorageDead(_19);
+        StorageDead(_5);
+        StorageDead(_4);
         goto -> bb25;
     }
 
     bb25 (cleanup): {
-        StorageDead(_18);
-        drop(_15) -> [return: bb26, unwind terminate(cleanup)];
+        StorageDead(_17);
+        goto -> bb30;
     }
 
     bb26 (cleanup): {
-        StorageDead(_15);
-        drop(_12) -> [return: bb27, unwind terminate(cleanup)];
+        StorageDead(_13);
+        StorageDead(_12);
+        drop(_9) -> [return: bb27, unwind terminate(cleanup)];
     }
 
     bb27 (cleanup): {
-        StorageDead(_12);
-        drop(_9) -> [return: bb28, unwind terminate(cleanup)];
+        StorageDead(_9);
+        drop(_6) -> [return: bb28, unwind terminate(cleanup)];
     }
 
     bb28 (cleanup): {
-        StorageDead(_9);
-        drop(_6) -> [return: bb29, unwind terminate(cleanup)];
+        StorageDead(_6);
+        drop(_5) -> [return: bb29, unwind terminate(cleanup)];
     }
 
     bb29 (cleanup): {
-        StorageDead(_6);
-        drop(_5) -> [return: bb30, unwind terminate(cleanup)];
+        StorageDead(_5);
+        StorageDead(_4);
+        goto -> bb30;
     }
 
     bb30 (cleanup): {
-        StorageDead(_5);
-        goto -> bb31;
+        StorageDead(_14);
+        goto -> bb34;
     }
 
     bb31 (cleanup): {
-        StorageDead(_4);
-        StorageDead(_20);
-        goto -> bb37;
+        StorageDead(_10);
+        StorageDead(_9);
+        drop(_6) -> [return: bb32, unwind terminate(cleanup)];
     }
 
     bb32 (cleanup): {
-        StorageDead(_16);
-        StorageDead(_15);
-        drop(_12) -> [return: bb33, unwind terminate(cleanup)];
+        StorageDead(_6);
+        drop(_5) -> [return: bb33, unwind terminate(cleanup)];
     }
 
     bb33 (cleanup): {
-        StorageDead(_12);
-        drop(_9) -> [return: bb34, unwind terminate(cleanup)];
+        StorageDead(_5);
+        StorageDead(_4);
+        goto -> bb34;
     }
 
     bb34 (cleanup): {
-        StorageDead(_9);
-        drop(_6) -> [return: bb35, unwind terminate(cleanup)];
+        StorageDead(_11);
+        goto -> bb37;
     }
 
     bb35 (cleanup): {
+        StorageDead(_7);
         StorageDead(_6);
         drop(_5) -> [return: bb36, unwind terminate(cleanup)];
     }
@@ -260,121 +265,23 @@ yields ()
     }
 
     bb37 (cleanup): {
-        StorageDead(_17);
-        goto -> bb42;
+        StorageDead(_8);
+        goto -> bb39;
     }
 
     bb38 (cleanup): {
-        StorageDead(_13);
-        StorageDead(_12);
-        drop(_9) -> [return: bb39, unwind terminate(cleanup)];
+        StorageDead(_5);
+        StorageDead(_4);
+        goto -> bb39;
     }
 
     bb39 (cleanup): {
-        StorageDead(_9);
-        drop(_6) -> [return: bb40, unwind terminate(cleanup)];
+        StorageDead(_3);
+        drop(_1) -> [return: bb40, unwind terminate(cleanup)];
     }
 
     bb40 (cleanup): {
-        StorageDead(_6);
-        drop(_5) -> [return: bb41, unwind terminate(cleanup)];
-    }
-
-    bb41 (cleanup): {
-        StorageDead(_5);
-        StorageDead(_4);
-        goto -> bb42;
-    }
-
-    bb42 (cleanup): {
-        StorageDead(_14);
-        goto -> bb46;
-    }
-
-    bb43 (cleanup): {
-        StorageDead(_10);
-        StorageDead(_9);
-        drop(_6) -> [return: bb44, unwind terminate(cleanup)];
-    }
-
-    bb44 (cleanup): {
-        StorageDead(_6);
-        drop(_5) -> [return: bb45, unwind terminate(cleanup)];
-    }
-
-    bb45 (cleanup): {
-        StorageDead(_5);
-        StorageDead(_4);
-        goto -> bb46;
-    }
-
-    bb46 (cleanup): {
-        StorageDead(_11);
-        goto -> bb49;
-    }
-
-    bb47 (cleanup): {
-        StorageDead(_7);
-        StorageDead(_6);
-        drop(_5) -> [return: bb48, unwind terminate(cleanup)];
-    }
-
-    bb48 (cleanup): {
-        StorageDead(_5);
-        StorageDead(_4);
-        goto -> bb49;
-    }
-
-    bb49 (cleanup): {
-        StorageDead(_8);
-        goto -> bb51;
-    }
-
-    bb50 (cleanup): {
-        StorageDead(_5);
-        StorageDead(_4);
-        goto -> bb51;
-    }
-
-    bb51 (cleanup): {
-        StorageDead(_3);
-        drop(_1) -> [return: bb52, unwind terminate(cleanup)];
-    }
-
-    bb52 (cleanup): {
         resume;
-    }
-
-    bb53 (cleanup): {
-        StorageDead(_15);
-        drop(_12) -> [return: bb54, unwind terminate(cleanup)];
-    }
-
-    bb54 (cleanup): {
-        StorageDead(_12);
-        drop(_9) -> [return: bb55, unwind terminate(cleanup)];
-    }
-
-    bb55 (cleanup): {
-        StorageDead(_9);
-        drop(_6) -> [return: bb56, unwind terminate(cleanup)];
-    }
-
-    bb56 (cleanup): {
-        StorageDead(_6);
-        drop(_5) -> [return: bb57, unwind terminate(cleanup)];
-    }
-
-    bb57 (cleanup): {
-        StorageDead(_5);
-        StorageDead(_4);
-        StorageDead(_20);
-        StorageDead(_17);
-        StorageDead(_14);
-        StorageDead(_11);
-        StorageDead(_8);
-        StorageDead(_3);
-        drop(_1) -> [return: bb52, unwind terminate(cleanup)];
     }
 }
 

--- a/tests/mir-opt/coroutine/unwind_in_vec.build-{closure#0}.built.after.mir
+++ b/tests/mir-opt/coroutine/unwind_in_vec.build-{closure#0}.built.after.mir
@@ -37,7 +37,7 @@ yields ()
         FakeRead(ForLet(None), _3);
         StorageLive(_4);
         StorageLive(_5);
-        _5 = Box::<[String; 5]>::new_uninit() -> [return: bb1, unwind: bb38];
+        _5 = Box::<[String; 5]>::new_uninit() -> [return: bb1, unwind: bb49];
     }
 
     bb1: {
@@ -46,165 +46,150 @@ yields ()
         StorageLive(_8);
         _8 = const "0";
         _7 = &(*_8);
-        _6 = <str as ToString>::to_string(move _7) -> [return: bb2, unwind: bb35];
+        _6 = <str as ToString>::to_string(move _7) -> [return: bb2, unwind: bb46];
     }
 
     bb2: {
+        goto -> bb3;
+    }
+
+    bb3: {
         StorageDead(_7);
         StorageLive(_9);
         StorageLive(_10);
         StorageLive(_11);
         _11 = const "1";
         _10 = &(*_11);
-        _9 = <str as ToString>::to_string(move _10) -> [return: bb3, unwind: bb31];
+        _9 = <str as ToString>::to_string(move _10) -> [return: bb4, unwind: bb42];
     }
 
-    bb3: {
+    bb4: {
+        goto -> bb5;
+    }
+
+    bb5: {
         StorageDead(_10);
         StorageLive(_12);
         StorageLive(_13);
         StorageLive(_14);
         _14 = const "2";
         _13 = &(*_14);
-        _12 = <str as ToString>::to_string(move _13) -> [return: bb4, unwind: bb26];
+        _12 = <str as ToString>::to_string(move _13) -> [return: bb6, unwind: bb37];
     }
 
-    bb4: {
+    bb6: {
+        goto -> bb7;
+    }
+
+    bb7: {
         StorageDead(_13);
         StorageLive(_15);
         StorageLive(_16);
         StorageLive(_17);
         _17 = const "3";
         _16 = &(*_17);
-        _15 = <str as ToString>::to_string(move _16) -> [return: bb5, unwind: bb20];
+        _15 = <str as ToString>::to_string(move _16) -> [return: bb8, unwind: bb31];
     }
 
-    bb5: {
+    bb8: {
+        goto -> bb9;
+    }
+
+    bb9: {
         StorageDead(_16);
         StorageLive(_18);
         StorageLive(_19);
         StorageLive(_20);
         _20 = const "4";
         _19 = &(*_20);
-        _18 = <str as ToString>::to_string(move _19) -> [return: bb6, unwind: bb13];
+        _18 = <str as ToString>::to_string(move _19) -> [return: bb10, unwind: bb24];
     }
 
-    bb6: {
+    bb10: {
+        goto -> bb11;
+    }
+
+    bb11: {
         StorageDead(_19);
         ((((*_5).1: std::mem::ManuallyDrop<[std::string::String; 5]>).0: std::mem::MaybeDangling<[std::string::String; 5]>).0: [std::string::String; 5]) = [move _6, move _9, move _12, move _15, move _18];
+        goto -> bb12;
+    }
+
+    bb12: {
         StorageDead(_18);
         StorageDead(_15);
         StorageDead(_12);
         StorageDead(_9);
         StorageDead(_6);
         _4 = move _5;
-        drop(_5) -> [return: bb7, unwind: bb11];
+        goto -> bb13;
     }
 
-    bb7: {
+    bb13: {
+        drop(_5) -> [return: bb14, unwind: bb22];
+    }
+
+    bb14: {
         StorageDead(_5);
-        _0 = std::boxed::box_assume_init_into_vec_unsafe::<String, 5>(move _4) -> [return: bb8, unwind: bb12];
+        _0 = std::boxed::box_assume_init_into_vec_unsafe::<String, 5>(move _4) -> [return: bb15, unwind: bb23];
     }
 
-    bb8: {
+    bb15: {
+        goto -> bb16;
+    }
+
+    bb16: {
         StorageDead(_4);
+        goto -> bb17;
+    }
+
+    bb17: {
         StorageDead(_20);
         StorageDead(_17);
         StorageDead(_14);
         StorageDead(_11);
         StorageDead(_8);
+        goto -> bb18;
+    }
+
+    bb18: {
         StorageDead(_3);
-        drop(_1) -> [return: bb9, unwind: bb40, drop: bb10];
-    }
-
-    bb9: {
-        return;
-    }
-
-    bb10: {
-        coroutine_drop;
-    }
-
-    bb11 (cleanup): {
-        StorageDead(_5);
-        goto -> bb12;
-    }
-
-    bb12 (cleanup): {
-        drop(_4) -> [return: bb19, unwind terminate(cleanup)];
-    }
-
-    bb13 (cleanup): {
-        StorageDead(_19);
-        StorageDead(_18);
-        drop(_15) -> [return: bb14, unwind terminate(cleanup)];
-    }
-
-    bb14 (cleanup): {
-        StorageDead(_15);
-        drop(_12) -> [return: bb15, unwind terminate(cleanup)];
-    }
-
-    bb15 (cleanup): {
-        StorageDead(_12);
-        drop(_9) -> [return: bb16, unwind terminate(cleanup)];
-    }
-
-    bb16 (cleanup): {
-        StorageDead(_9);
-        drop(_6) -> [return: bb17, unwind terminate(cleanup)];
-    }
-
-    bb17 (cleanup): {
-        StorageDead(_6);
-        drop(_5) -> [return: bb18, unwind terminate(cleanup)];
-    }
-
-    bb18 (cleanup): {
-        StorageDead(_5);
         goto -> bb19;
     }
 
-    bb19 (cleanup): {
-        StorageDead(_4);
-        StorageDead(_20);
-        goto -> bb25;
+    bb19: {
+        drop(_1) -> [return: bb20, unwind: bb51, drop: bb21];
     }
 
-    bb20 (cleanup): {
-        StorageDead(_16);
-        StorageDead(_15);
-        drop(_12) -> [return: bb21, unwind terminate(cleanup)];
+    bb20: {
+        return;
     }
 
-    bb21 (cleanup): {
-        StorageDead(_12);
-        drop(_9) -> [return: bb22, unwind terminate(cleanup)];
+    bb21: {
+        coroutine_drop;
     }
 
     bb22 (cleanup): {
-        StorageDead(_9);
-        drop(_6) -> [return: bb23, unwind terminate(cleanup)];
+        StorageDead(_5);
+        goto -> bb23;
     }
 
     bb23 (cleanup): {
-        StorageDead(_6);
-        drop(_5) -> [return: bb24, unwind terminate(cleanup)];
+        drop(_4) -> [return: bb30, unwind terminate(cleanup)];
     }
 
     bb24 (cleanup): {
-        StorageDead(_5);
-        StorageDead(_4);
-        goto -> bb25;
+        StorageDead(_19);
+        StorageDead(_18);
+        drop(_15) -> [return: bb25, unwind terminate(cleanup)];
     }
 
     bb25 (cleanup): {
-        StorageDead(_17);
-        goto -> bb30;
+        StorageDead(_15);
+        drop(_12) -> [return: bb26, unwind terminate(cleanup)];
     }
 
     bb26 (cleanup): {
-        StorageDead(_13);
         StorageDead(_12);
         drop(_9) -> [return: bb27, unwind terminate(cleanup)];
     }
@@ -221,66 +206,125 @@ yields ()
 
     bb29 (cleanup): {
         StorageDead(_5);
-        StorageDead(_4);
         goto -> bb30;
     }
 
     bb30 (cleanup): {
-        StorageDead(_14);
-        goto -> bb34;
+        StorageDead(_4);
+        StorageDead(_20);
+        goto -> bb36;
     }
 
     bb31 (cleanup): {
-        StorageDead(_10);
-        StorageDead(_9);
-        drop(_6) -> [return: bb32, unwind terminate(cleanup)];
+        StorageDead(_16);
+        StorageDead(_15);
+        drop(_12) -> [return: bb32, unwind terminate(cleanup)];
     }
 
     bb32 (cleanup): {
-        StorageDead(_6);
-        drop(_5) -> [return: bb33, unwind terminate(cleanup)];
+        StorageDead(_12);
+        drop(_9) -> [return: bb33, unwind terminate(cleanup)];
     }
 
     bb33 (cleanup): {
-        StorageDead(_5);
-        StorageDead(_4);
-        goto -> bb34;
+        StorageDead(_9);
+        drop(_6) -> [return: bb34, unwind terminate(cleanup)];
     }
 
     bb34 (cleanup): {
-        StorageDead(_11);
-        goto -> bb37;
+        StorageDead(_6);
+        drop(_5) -> [return: bb35, unwind terminate(cleanup)];
     }
 
     bb35 (cleanup): {
-        StorageDead(_7);
-        StorageDead(_6);
-        drop(_5) -> [return: bb36, unwind terminate(cleanup)];
+        StorageDead(_5);
+        StorageDead(_4);
+        goto -> bb36;
     }
 
     bb36 (cleanup): {
-        StorageDead(_5);
-        StorageDead(_4);
-        goto -> bb37;
+        StorageDead(_17);
+        goto -> bb41;
     }
 
     bb37 (cleanup): {
-        StorageDead(_8);
-        goto -> bb39;
+        StorageDead(_13);
+        StorageDead(_12);
+        drop(_9) -> [return: bb38, unwind terminate(cleanup)];
     }
 
     bb38 (cleanup): {
-        StorageDead(_5);
-        StorageDead(_4);
-        goto -> bb39;
+        StorageDead(_9);
+        drop(_6) -> [return: bb39, unwind terminate(cleanup)];
     }
 
     bb39 (cleanup): {
-        StorageDead(_3);
-        drop(_1) -> [return: bb40, unwind terminate(cleanup)];
+        StorageDead(_6);
+        drop(_5) -> [return: bb40, unwind terminate(cleanup)];
     }
 
     bb40 (cleanup): {
+        StorageDead(_5);
+        StorageDead(_4);
+        goto -> bb41;
+    }
+
+    bb41 (cleanup): {
+        StorageDead(_14);
+        goto -> bb45;
+    }
+
+    bb42 (cleanup): {
+        StorageDead(_10);
+        StorageDead(_9);
+        drop(_6) -> [return: bb43, unwind terminate(cleanup)];
+    }
+
+    bb43 (cleanup): {
+        StorageDead(_6);
+        drop(_5) -> [return: bb44, unwind terminate(cleanup)];
+    }
+
+    bb44 (cleanup): {
+        StorageDead(_5);
+        StorageDead(_4);
+        goto -> bb45;
+    }
+
+    bb45 (cleanup): {
+        StorageDead(_11);
+        goto -> bb48;
+    }
+
+    bb46 (cleanup): {
+        StorageDead(_7);
+        StorageDead(_6);
+        drop(_5) -> [return: bb47, unwind terminate(cleanup)];
+    }
+
+    bb47 (cleanup): {
+        StorageDead(_5);
+        StorageDead(_4);
+        goto -> bb48;
+    }
+
+    bb48 (cleanup): {
+        StorageDead(_8);
+        goto -> bb50;
+    }
+
+    bb49 (cleanup): {
+        StorageDead(_5);
+        StorageDead(_4);
+        goto -> bb50;
+    }
+
+    bb50 (cleanup): {
+        StorageDead(_3);
+        drop(_1) -> [return: bb51, unwind terminate(cleanup)];
+    }
+
+    bb51 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/derefer_inline_test.main.Derefer.panic-abort.diff
+++ b/tests/mir-opt/derefer_inline_test.main.Derefer.panic-abort.diff
@@ -9,7 +9,7 @@
       bb0: {
           StorageLive(_1);
           StorageLive(_2);
-          _2 = f() -> [return: bb1, unwind: bb5];
+          _2 = f() -> [return: bb1, unwind: bb4];
       }
   
       bb1: {
@@ -18,7 +18,7 @@
   
       bb2: {
           StorageDead(_2);
-          drop(_1) -> [return: bb3, unwind: bb5];
+          drop(_1) -> [return: bb3, unwind: bb4];
       }
   
       bb3: {
@@ -28,10 +28,6 @@
       }
   
       bb4 (cleanup): {
-          drop(_2) -> [return: bb5, unwind terminate(cleanup)];
-      }
-  
-      bb5 (cleanup): {
           resume;
       }
   }

--- a/tests/mir-opt/derefer_inline_test.main.Derefer.panic-unwind.diff
+++ b/tests/mir-opt/derefer_inline_test.main.Derefer.panic-unwind.diff
@@ -13,7 +13,7 @@
       }
   
       bb1: {
-          _1 = Box::<Box<u32>>::new(move _2) -> [return: bb2, unwind: bb4];
+          _1 = Box::<Box<u32>>::new(move _2) -> [return: bb2, unwind continue];
       }
   
       bb2: {
@@ -25,14 +25,6 @@
           StorageDead(_1);
           _0 = const ();
           return;
-      }
-  
-      bb4 (cleanup): {
-          drop(_2) -> [return: bb5, unwind terminate(cleanup)];
-      }
-  
-      bb5 (cleanup): {
-          resume;
       }
   }
   

--- a/tests/mir-opt/gvn.multiple_branches.GVN.panic-abort.diff
+++ b/tests/mir-opt/gvn.multiple_branches.GVN.panic-abort.diff
@@ -152,8 +152,8 @@
           StorageDead(_22);
           StorageLive(_26);
           _26 = copy _1;
--         switchInt(move _26) -> [0: bb11, otherwise: bb9];
-+         switchInt(copy _1) -> [0: bb11, otherwise: bb9];
+-         switchInt(move _26) -> [0: bb10, otherwise: bb9];
++         switchInt(copy _1) -> [0: bb10, otherwise: bb9];
       }
   
       bb9: {
@@ -167,18 +167,11 @@
 +         _28 = copy _23;
           StorageDead(_30);
           StorageDead(_29);
--         _27 = opaque::<u8>(move _28) -> [return: bb10, unwind unreachable];
-+         _27 = opaque::<u8>(copy _23) -> [return: bb10, unwind unreachable];
+-         _27 = opaque::<u8>(move _28) -> [return: bb11, unwind unreachable];
++         _27 = opaque::<u8>(copy _23) -> [return: bb11, unwind unreachable];
       }
   
       bb10: {
-          StorageDead(_28);
-          StorageDead(_27);
-          _0 = const ();
-          goto -> bb13;
-      }
-  
-      bb11: {
           StorageLive(_31);
           StorageLive(_32);
           StorageLive(_33);
@@ -191,6 +184,13 @@
           StorageDead(_33);
 -         _31 = opaque::<u8>(move _32) -> [return: bb12, unwind unreachable];
 +         _31 = opaque::<u8>(copy _23) -> [return: bb12, unwind unreachable];
+      }
+  
+      bb11: {
+          StorageDead(_28);
+          StorageDead(_27);
+          _0 = const ();
+          goto -> bb13;
       }
   
       bb12: {

--- a/tests/mir-opt/gvn.multiple_branches.GVN.panic-unwind.diff
+++ b/tests/mir-opt/gvn.multiple_branches.GVN.panic-unwind.diff
@@ -152,8 +152,8 @@
           StorageDead(_22);
           StorageLive(_26);
           _26 = copy _1;
--         switchInt(move _26) -> [0: bb11, otherwise: bb9];
-+         switchInt(copy _1) -> [0: bb11, otherwise: bb9];
+-         switchInt(move _26) -> [0: bb10, otherwise: bb9];
++         switchInt(copy _1) -> [0: bb10, otherwise: bb9];
       }
   
       bb9: {
@@ -167,18 +167,11 @@
 +         _28 = copy _23;
           StorageDead(_30);
           StorageDead(_29);
--         _27 = opaque::<u8>(move _28) -> [return: bb10, unwind continue];
-+         _27 = opaque::<u8>(copy _23) -> [return: bb10, unwind continue];
+-         _27 = opaque::<u8>(move _28) -> [return: bb11, unwind continue];
++         _27 = opaque::<u8>(copy _23) -> [return: bb11, unwind continue];
       }
   
       bb10: {
-          StorageDead(_28);
-          StorageDead(_27);
-          _0 = const ();
-          goto -> bb13;
-      }
-  
-      bb11: {
           StorageLive(_31);
           StorageLive(_32);
           StorageLive(_33);
@@ -191,6 +184,13 @@
           StorageDead(_33);
 -         _31 = opaque::<u8>(move _32) -> [return: bb12, unwind continue];
 +         _31 = opaque::<u8>(copy _23) -> [return: bb12, unwind continue];
+      }
+  
+      bb11: {
+          StorageDead(_28);
+          StorageDead(_27);
+          _0 = const ();
+          goto -> bb13;
       }
   
       bb12: {

--- a/tests/mir-opt/issue_41110.main.ElaborateDrops.panic-abort.diff
+++ b/tests/mir-opt/issue_41110.main.ElaborateDrops.panic-abort.diff
@@ -7,32 +7,27 @@
       let mut _2: S;
       let mut _3: S;
       let mut _4: S;
-+     let mut _5: bool;
       scope 1 {
           debug x => _1;
       }
   
       bb0: {
-+         _5 = const false;
           StorageLive(_1);
           StorageLive(_2);
-+         _5 = const true;
           _2 = S;
           StorageLive(_3);
           StorageLive(_4);
           _4 = S;
-          _3 = S::id(move _4) -> [return: bb1, unwind: bb4];
+          _3 = S::id(move _4) -> [return: bb1, unwind: bb3];
       }
   
       bb1: {
           StorageDead(_4);
-+         _5 = const false;
-          _1 = S::other(move _2, move _3) -> [return: bb2, unwind: bb3];
+          _1 = S::other(move _2, move _3) -> [return: bb2, unwind: bb4];
       }
   
       bb2: {
           StorageDead(_3);
-+         _5 = const false;
           StorageDead(_2);
           _0 = const ();
           StorageDead(_1);
@@ -40,30 +35,11 @@
       }
   
       bb3 (cleanup): {
--         drop(_3) -> [return: bb5, unwind terminate(cleanup)];
-+         goto -> bb5;
+          drop(_2) -> [return: bb4, unwind terminate(cleanup)];
       }
   
       bb4 (cleanup): {
--         drop(_4) -> [return: bb5, unwind terminate(cleanup)];
-+         goto -> bb5;
-      }
-  
-      bb5 (cleanup): {
--         drop(_2) -> [return: bb6, unwind terminate(cleanup)];
-+         goto -> bb8;
-      }
-  
-      bb6 (cleanup): {
           resume;
-+     }
-+ 
-+     bb7 (cleanup): {
-+         drop(_2) -> [return: bb6, unwind terminate(cleanup)];
-+     }
-+ 
-+     bb8 (cleanup): {
-+         switchInt(copy _5) -> [0: bb6, otherwise: bb7];
       }
   }
   

--- a/tests/mir-opt/issue_41110.main.ElaborateDrops.panic-unwind.diff
+++ b/tests/mir-opt/issue_41110.main.ElaborateDrops.panic-unwind.diff
@@ -7,32 +7,27 @@
       let mut _2: S;
       let mut _3: S;
       let mut _4: S;
-+     let mut _5: bool;
       scope 1 {
           debug x => _1;
       }
   
       bb0: {
-+         _5 = const false;
           StorageLive(_1);
           StorageLive(_2);
-+         _5 = const true;
           _2 = S;
           StorageLive(_3);
           StorageLive(_4);
           _4 = S;
-          _3 = S::id(move _4) -> [return: bb1, unwind: bb4];
+          _3 = S::id(move _4) -> [return: bb1, unwind: bb3];
       }
   
       bb1: {
           StorageDead(_4);
-+         _5 = const false;
-          _1 = S::other(move _2, move _3) -> [return: bb2, unwind: bb3];
+          _1 = S::other(move _2, move _3) -> [return: bb2, unwind continue];
       }
   
       bb2: {
           StorageDead(_3);
-+         _5 = const false;
           StorageDead(_2);
           _0 = const ();
           StorageDead(_1);
@@ -40,30 +35,11 @@
       }
   
       bb3 (cleanup): {
--         drop(_3) -> [return: bb5, unwind terminate(cleanup)];
-+         goto -> bb5;
+          drop(_2) -> [return: bb4, unwind terminate(cleanup)];
       }
   
       bb4 (cleanup): {
--         drop(_4) -> [return: bb5, unwind terminate(cleanup)];
-+         goto -> bb5;
-      }
-  
-      bb5 (cleanup): {
--         drop(_2) -> [return: bb6, unwind terminate(cleanup)];
-+         goto -> bb8;
-      }
-  
-      bb6 (cleanup): {
           resume;
-+     }
-+ 
-+     bb7 (cleanup): {
-+         drop(_2) -> [return: bb6, unwind terminate(cleanup)];
-+     }
-+ 
-+     bb8 (cleanup): {
-+         switchInt(copy _5) -> [0: bb6, otherwise: bb7];
       }
   }
   

--- a/tests/mir-opt/issue_41110.test.ElaborateDrops.panic-abort.diff
+++ b/tests/mir-opt/issue_41110.test.ElaborateDrops.panic-abort.diff
@@ -41,25 +41,25 @@
   
       bb2: {
           _2 = move _5;
--         drop(_5) -> [return: bb4, unwind: bb8];
+-         drop(_5) -> [return: bb4, unwind: bb7];
 +         goto -> bb4;
       }
   
       bb3 (cleanup): {
           _2 = move _5;
--         drop(_5) -> [return: bb8, unwind terminate(cleanup)];
-+         goto -> bb8;
+-         drop(_5) -> [return: bb7, unwind terminate(cleanup)];
++         goto -> bb7;
       }
   
       bb4: {
           StorageDead(_5);
           _0 = const ();
-          drop(_2) -> [return: bb5, unwind: bb9];
+          drop(_2) -> [return: bb5, unwind: bb8];
       }
   
       bb5: {
           StorageDead(_2);
--         drop(_1) -> [return: bb6, unwind: bb10];
+-         drop(_1) -> [return: bb6, unwind: bb9];
 +         goto -> bb6;
       }
   
@@ -70,30 +70,25 @@
       }
   
       bb7 (cleanup): {
--         drop(_4) -> [return: bb8, unwind terminate(cleanup)];
+-         drop(_2) -> [return: bb8, unwind terminate(cleanup)];
 +         goto -> bb8;
       }
   
       bb8 (cleanup): {
--         drop(_2) -> [return: bb9, unwind terminate(cleanup)];
-+         goto -> bb9;
+-         drop(_1) -> [return: bb9, unwind terminate(cleanup)];
++         goto -> bb11;
       }
   
       bb9 (cleanup): {
--         drop(_1) -> [return: bb10, unwind terminate(cleanup)];
-+         goto -> bb12;
-      }
-  
-      bb10 (cleanup): {
           resume;
 +     }
 + 
-+     bb11 (cleanup): {
-+         drop(_1) -> [return: bb10, unwind terminate(cleanup)];
++     bb10 (cleanup): {
++         drop(_1) -> [return: bb9, unwind terminate(cleanup)];
 +     }
 + 
-+     bb12 (cleanup): {
-+         switchInt(copy _6) -> [0: bb10, otherwise: bb11];
++     bb11 (cleanup): {
++         switchInt(copy _6) -> [0: bb9, otherwise: bb10];
       }
   }
   

--- a/tests/mir-opt/issue_41110.test.ElaborateDrops.panic-unwind.diff
+++ b/tests/mir-opt/issue_41110.test.ElaborateDrops.panic-unwind.diff
@@ -41,20 +41,20 @@
   
       bb2: {
           _2 = move _5;
--         drop(_5) -> [return: bb4, unwind: bb8];
+-         drop(_5) -> [return: bb4, unwind: bb7];
 +         goto -> bb4;
       }
   
       bb3 (cleanup): {
           _2 = move _5;
--         drop(_5) -> [return: bb8, unwind terminate(cleanup)];
-+         goto -> bb8;
+-         drop(_5) -> [return: bb7, unwind terminate(cleanup)];
++         goto -> bb7;
       }
   
       bb4: {
           StorageDead(_5);
           _0 = const ();
-          drop(_2) -> [return: bb5, unwind: bb9];
+          drop(_2) -> [return: bb5, unwind: bb8];
       }
   
       bb5: {
@@ -70,30 +70,25 @@
       }
   
       bb7 (cleanup): {
--         drop(_4) -> [return: bb8, unwind terminate(cleanup)];
+-         drop(_2) -> [return: bb8, unwind terminate(cleanup)];
 +         goto -> bb8;
       }
   
       bb8 (cleanup): {
--         drop(_2) -> [return: bb9, unwind terminate(cleanup)];
-+         goto -> bb9;
+-         drop(_1) -> [return: bb9, unwind terminate(cleanup)];
++         goto -> bb11;
       }
   
       bb9 (cleanup): {
--         drop(_1) -> [return: bb10, unwind terminate(cleanup)];
-+         goto -> bb12;
-      }
-  
-      bb10 (cleanup): {
           resume;
 +     }
 + 
-+     bb11 (cleanup): {
-+         drop(_1) -> [return: bb10, unwind terminate(cleanup)];
++     bb10 (cleanup): {
++         drop(_1) -> [return: bb9, unwind terminate(cleanup)];
 +     }
 + 
-+     bb12 (cleanup): {
-+         switchInt(copy _6) -> [0: bb10, otherwise: bb11];
++     bb11 (cleanup): {
++         switchInt(copy _6) -> [0: bb9, otherwise: bb10];
       }
   }
   

--- a/tests/mir-opt/issue_62289.test.ElaborateDrops.after.panic-abort.mir
+++ b/tests/mir-opt/issue_62289.test.ElaborateDrops.after.panic-abort.mir
@@ -28,7 +28,7 @@ fn test() -> Option<Vec<u32>> {
         StorageLive(_1);
         StorageLive(_2);
         StorageLive(_3);
-        _3 = Box::<[u32; 1]>::new_uninit() -> [return: bb1, unwind: bb14];
+        _3 = Box::<[u32; 1]>::new_uninit() -> [return: bb1, unwind: bb13];
     }
 
     bb1: {
@@ -36,7 +36,7 @@ fn test() -> Option<Vec<u32>> {
         StorageLive(_5);
         StorageLive(_6);
         _6 = Option::<u32>::None;
-        _5 = <Option<u32> as Try>::branch(move _6) -> [return: bb2, unwind: bb13];
+        _5 = <Option<u32> as Try>::branch(move _6) -> [return: bb2, unwind: bb12];
     }
 
     bb2: {
@@ -66,54 +66,50 @@ fn test() -> Option<Vec<u32>> {
         _8 = copy ((_5 as Break).0: std::option::Option<std::convert::Infallible>);
         StorageLive(_10);
         _10 = copy _8;
-        _0 = <Option<Vec<u32>> as FromResidual<Option<Infallible>>>::from_residual(move _10) -> [return: bb6, unwind: bb13];
+        _0 = <Option<Vec<u32>> as FromResidual<Option<Infallible>>>::from_residual(move _10) -> [return: bb6, unwind: bb12];
     }
 
     bb6: {
         StorageDead(_10);
         StorageDead(_8);
         StorageDead(_4);
-        drop(_3) -> [return: bb10, unwind: bb14];
+        drop(_3) -> [return: bb9, unwind: bb13];
     }
 
     bb7: {
         StorageDead(_3);
-        _1 = std::boxed::box_assume_init_into_vec_unsafe::<u32, 1>(move _2) -> [return: bb8, unwind: bb12];
+        _1 = std::boxed::box_assume_init_into_vec_unsafe::<u32, 1>(move _2) -> [return: bb8, unwind: bb11];
     }
 
     bb8: {
         StorageDead(_2);
         _0 = Option::<Vec<u32>>::Some(move _1);
-        goto -> bb9;
+        StorageDead(_1);
+        StorageDead(_5);
+        goto -> bb10;
     }
 
     bb9: {
-        StorageDead(_1);
-        StorageDead(_5);
-        goto -> bb11;
-    }
-
-    bb10: {
         StorageDead(_3);
         StorageDead(_2);
         StorageDead(_1);
         StorageDead(_5);
-        goto -> bb11;
+        goto -> bb10;
     }
 
-    bb11: {
+    bb10: {
         return;
     }
 
+    bb11 (cleanup): {
+        goto -> bb13;
+    }
+
     bb12 (cleanup): {
-        goto -> bb14;
+        drop(_3) -> [return: bb13, unwind terminate(cleanup)];
     }
 
     bb13 (cleanup): {
-        drop(_3) -> [return: bb14, unwind terminate(cleanup)];
-    }
-
-    bb14 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/issue_62289.test.ElaborateDrops.after.panic-unwind.mir
+++ b/tests/mir-opt/issue_62289.test.ElaborateDrops.after.panic-unwind.mir
@@ -36,7 +36,7 @@ fn test() -> Option<Vec<u32>> {
         StorageLive(_5);
         StorageLive(_6);
         _6 = Option::<u32>::None;
-        _5 = <Option<u32> as Try>::branch(move _6) -> [return: bb2, unwind: bb13];
+        _5 = <Option<u32> as Try>::branch(move _6) -> [return: bb2, unwind: bb12];
     }
 
     bb2: {
@@ -66,54 +66,50 @@ fn test() -> Option<Vec<u32>> {
         _8 = copy ((_5 as Break).0: std::option::Option<std::convert::Infallible>);
         StorageLive(_10);
         _10 = copy _8;
-        _0 = <Option<Vec<u32>> as FromResidual<Option<Infallible>>>::from_residual(move _10) -> [return: bb6, unwind: bb13];
+        _0 = <Option<Vec<u32>> as FromResidual<Option<Infallible>>>::from_residual(move _10) -> [return: bb6, unwind: bb12];
     }
 
     bb6: {
         StorageDead(_10);
         StorageDead(_8);
         StorageDead(_4);
-        drop(_3) -> [return: bb10, unwind: bb14];
+        drop(_3) -> [return: bb9, unwind: bb13];
     }
 
     bb7: {
         StorageDead(_3);
-        _1 = std::boxed::box_assume_init_into_vec_unsafe::<u32, 1>(move _2) -> [return: bb8, unwind: bb12];
+        _1 = std::boxed::box_assume_init_into_vec_unsafe::<u32, 1>(move _2) -> [return: bb8, unwind: bb11];
     }
 
     bb8: {
         StorageDead(_2);
         _0 = Option::<Vec<u32>>::Some(move _1);
-        goto -> bb9;
+        StorageDead(_1);
+        StorageDead(_5);
+        goto -> bb10;
     }
 
     bb9: {
-        StorageDead(_1);
-        StorageDead(_5);
-        goto -> bb11;
-    }
-
-    bb10: {
         StorageDead(_3);
         StorageDead(_2);
         StorageDead(_1);
         StorageDead(_5);
-        goto -> bb11;
+        goto -> bb10;
     }
 
-    bb11: {
+    bb10: {
         return;
     }
 
+    bb11 (cleanup): {
+        goto -> bb13;
+    }
+
     bb12 (cleanup): {
-        goto -> bb14;
+        drop(_3) -> [return: bb13, unwind terminate(cleanup)];
     }
 
     bb13 (cleanup): {
-        drop(_3) -> [return: bb14, unwind terminate(cleanup)];
-    }
-
-    bb14 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/issue_72181.bar.built.after.mir
+++ b/tests/mir-opt/issue_72181.bar.built.after.mir
@@ -11,12 +11,16 @@ fn bar(_1: [(Never, u32); 1]) -> u32 {
         StorageLive(_2);
         _2 = copy (_1[0 of 1].1: u32);
         _0 = copy _2;
-        StorageDead(_2);
-        return;
+        goto -> bb2;
     }
 
     bb1: {
         FakeRead(ForMatchedPlace(None), _1);
         unreachable;
+    }
+
+    bb2: {
+        StorageDead(_2);
+        return;
     }
 }

--- a/tests/mir-opt/issue_72181.foo.built.after.mir
+++ b/tests/mir-opt/issue_72181.foo.built.after.mir
@@ -11,16 +11,20 @@ fn foo(_1: [(Never, u32); 1]) -> u32 {
         _2 = const 0_usize;
         FakeRead(ForIndex, _1);
         _3 = Lt(copy _2, const 1_usize);
-        assert(move _3, "index out of bounds: the length is {} but the index is {}", const 1_usize, copy _2) -> [success: bb1, unwind: bb2];
+        assert(move _3, "index out of bounds: the length is {} but the index is {}", const 1_usize, copy _2) -> [success: bb1, unwind: bb3];
     }
 
     bb1: {
         _0 = copy (_1[_2].1: u32);
+        goto -> bb2;
+    }
+
+    bb2: {
         StorageDead(_2);
         return;
     }
 
-    bb2 (cleanup): {
+    bb3 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/issue_72181.main.built.after.mir
+++ b/tests/mir-opt/issue_72181.main.built.after.mir
@@ -19,27 +19,12 @@ fn main() -> () {
 
     bb0: {
         StorageLive(_1);
-        _1 = std::mem::size_of::<Foo>() -> [return: bb1, unwind: bb5];
+        _1 = std::mem::size_of::<Foo>() -> [return: bb1, unwind: bb9];
     }
 
     bb1: {
         PlaceMention(_1);
-        StorageDead(_1);
-        StorageLive(_2);
-        StorageLive(_3);
-        _3 = Foo { a: const 42_u64 };
-        StorageLive(_4);
-        _4 = Foo { a: const 10_u64 };
-        _2 = [move _3, move _4];
-        StorageDead(_4);
-        StorageDead(_3);
-        FakeRead(ForLet(None), _2);
-        StorageLive(_5);
-        StorageLive(_6);
-        _6 = const 0_usize;
-        FakeRead(ForIndex, _2);
-        _7 = Lt(copy _6, const 2_usize);
-        assert(move _7, "index out of bounds: the length is {} but the index is {}", const 2_usize, copy _6) -> [success: bb3, unwind: bb5];
+        goto -> bb3;
     }
 
     bb2: {
@@ -48,21 +33,52 @@ fn main() -> () {
     }
 
     bb3: {
-        _5 = copy (_2[_6].0: u64);
-        PlaceMention(_5);
-        StorageDead(_6);
-        StorageDead(_5);
-        _0 = const ();
-        StorageDead(_2);
-        return;
+        StorageDead(_1);
+        StorageLive(_2);
+        StorageLive(_3);
+        _3 = Foo { a: const 42_u64 };
+        StorageLive(_4);
+        _4 = Foo { a: const 10_u64 };
+        _2 = [move _3, move _4];
+        goto -> bb4;
     }
 
     bb4: {
+        StorageDead(_4);
+        StorageDead(_3);
+        FakeRead(ForLet(None), _2);
+        StorageLive(_5);
+        StorageLive(_6);
+        _6 = const 0_usize;
+        FakeRead(ForIndex, _2);
+        _7 = Lt(copy _6, const 2_usize);
+        assert(move _7, "index out of bounds: the length is {} but the index is {}", const 2_usize, copy _6) -> [success: bb5, unwind: bb9];
+    }
+
+    bb5: {
+        _5 = copy (_2[_6].0: u64);
+        PlaceMention(_5);
+        goto -> bb7;
+    }
+
+    bb6: {
         FakeRead(ForMatchedPlace(None), _5);
         unreachable;
     }
 
-    bb5 (cleanup): {
+    bb7: {
+        StorageDead(_6);
+        StorageDead(_5);
+        _0 = const ();
+        goto -> bb8;
+    }
+
+    bb8: {
+        StorageDead(_2);
+        return;
+    }
+
+    bb9 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/issue_72181_1.main.built.after.mir
+++ b/tests/mir-opt/issue_72181_1.main.built.after.mir
@@ -19,31 +19,47 @@ fn main() -> () {
         StorageLive(_2);
         StorageLive(_3);
         _3 = ();
-        _2 = std::intrinsics::transmute::<(), Void>(move _3) -> [return: bb1, unwind: bb4];
+        _2 = std::intrinsics::transmute::<(), Void>(move _3) -> [return: bb1, unwind: bb8];
     }
 
     bb1: {
+        goto -> bb2;
+    }
+
+    bb2: {
         StorageDead(_3);
         FakeRead(ForLet(None), _2);
         AscribeUserType(_2, o, UserTypeProjection { base: UserType(1), projs: [] });
         StorageLive(_4);
         StorageLive(_5);
         _5 = move _2;
-        _4 = f(move _5) -> [return: bb2, unwind: bb4];
+        _4 = f(move _5) -> [return: bb3, unwind: bb8];
     }
 
-    bb2: {
+    bb3: {
+        goto -> bb4;
+    }
+
+    bb4: {
         StorageDead(_5);
+        goto -> bb5;
+    }
+
+    bb5: {
         StorageDead(_4);
+        goto -> bb6;
+    }
+
+    bb6: {
         StorageDead(_2);
         unreachable;
     }
 
-    bb3: {
+    bb7: {
         return;
     }
 
-    bb4 (cleanup): {
+    bb8 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/issue_91633.bar.built.after.mir
+++ b/tests/mir-opt/issue_91633.bar.built.after.mir
@@ -12,31 +12,43 @@ fn bar(_1: Box<[T]>) -> () {
         StorageLive(_2);
         StorageLive(_3);
         _3 = &(*_1);
-        _2 = <[T] as Index<usize>>::index(move _3, const 0_usize) -> [return: bb1, unwind: bb4];
+        _2 = <[T] as Index<usize>>::index(move _3, const 0_usize) -> [return: bb1, unwind: bb7];
     }
 
     bb1: {
-        StorageDead(_3);
-        PlaceMention((*_2));
-        StorageDead(_2);
-        _0 = const ();
-        drop(_1) -> [return: bb3, unwind: bb5];
+        goto -> bb2;
     }
 
     bb2: {
+        StorageDead(_3);
+        PlaceMention((*_2));
+        goto -> bb4;
+    }
+
+    bb3: {
         FakeRead(ForMatchedPlace(None), (*_2));
         unreachable;
     }
 
-    bb3: {
+    bb4: {
+        StorageDead(_2);
+        _0 = const ();
+        goto -> bb5;
+    }
+
+    bb5: {
+        drop(_1) -> [return: bb6, unwind: bb8];
+    }
+
+    bb6: {
         return;
     }
 
-    bb4 (cleanup): {
-        drop(_1) -> [return: bb5, unwind terminate(cleanup)];
+    bb7 (cleanup): {
+        drop(_1) -> [return: bb8, unwind terminate(cleanup)];
     }
 
-    bb5 (cleanup): {
+    bb8 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/issue_91633.foo.built.after.mir
+++ b/tests/mir-opt/issue_91633.foo.built.after.mir
@@ -21,36 +21,52 @@ fn foo(_1: Box<[T]>) -> T {
         _5 = &raw const (fake) (*_1);
         _6 = PtrMetadata(move _5);
         _7 = Lt(copy _4, copy _6);
-        assert(move _7, "index out of bounds: the length is {} but the index is {}", move _6, copy _4) -> [success: bb1, unwind: bb5];
+        assert(move _7, "index out of bounds: the length is {} but the index is {}", move _6, copy _4) -> [success: bb1, unwind: bb9];
     }
 
     bb1: {
         _3 = &(*_1)[_4];
-        _2 = <T as Clone>::clone(move _3) -> [return: bb2, unwind: bb5];
+        _2 = <T as Clone>::clone(move _3) -> [return: bb2, unwind: bb9];
     }
 
     bb2: {
-        StorageDead(_3);
-        FakeRead(ForLet(None), _2);
-        StorageDead(_4);
-        _0 = move _2;
-        drop(_2) -> [return: bb3, unwind: bb5];
+        goto -> bb3;
     }
 
     bb3: {
-        StorageDead(_2);
-        drop(_1) -> [return: bb4, unwind: bb6];
+        StorageDead(_3);
+        FakeRead(ForLet(None), _2);
+        goto -> bb4;
     }
 
     bb4: {
+        StorageDead(_4);
+        _0 = move _2;
+        goto -> bb5;
+    }
+
+    bb5: {
+        drop(_2) -> [return: bb6, unwind: bb9];
+    }
+
+    bb6: {
+        StorageDead(_2);
+        goto -> bb7;
+    }
+
+    bb7: {
+        drop(_1) -> [return: bb8, unwind: bb10];
+    }
+
+    bb8: {
         return;
     }
 
-    bb5 (cleanup): {
-        drop(_1) -> [return: bb6, unwind terminate(cleanup)];
+    bb9 (cleanup): {
+        drop(_1) -> [return: bb10, unwind terminate(cleanup)];
     }
 
-    bb6 (cleanup): {
+    bb10 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/issue_91633.fun.built.after.mir
+++ b/tests/mir-opt/issue_91633.fun.built.after.mir
@@ -17,19 +17,27 @@ fn fun(_1: &[T]) -> &T {
         _3 = const 0_usize;
         _4 = PtrMetadata(copy _1);
         _5 = Lt(copy _3, copy _4);
-        assert(move _5, "index out of bounds: the length is {} but the index is {}", move _4, copy _3) -> [success: bb1, unwind: bb2];
+        assert(move _5, "index out of bounds: the length is {} but the index is {}", move _4, copy _3) -> [success: bb1, unwind: bb4];
     }
 
     bb1: {
         _2 = &(*_1)[_3];
         FakeRead(ForLet(None), _2);
+        goto -> bb2;
+    }
+
+    bb2: {
         StorageDead(_3);
         _0 = &(*_2);
+        goto -> bb3;
+    }
+
+    bb3: {
         StorageDead(_2);
         return;
     }
 
-    bb2 (cleanup): {
+    bb4 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/issue_91633.hey.built.after.mir
+++ b/tests/mir-opt/issue_91633.hey.built.after.mir
@@ -14,25 +14,37 @@ fn hey(_1: &[T]) -> () {
         StorageLive(_3);
         StorageLive(_4);
         _4 = &(*_1);
-        _3 = <[T] as Index<usize>>::index(move _4, const 0_usize) -> [return: bb1, unwind: bb3];
+        _3 = <[T] as Index<usize>>::index(move _4, const 0_usize) -> [return: bb1, unwind: bb6];
     }
 
     bb1: {
-        StorageDead(_4);
-        _2 = &(*_3);
-        PlaceMention(_2);
-        StorageDead(_2);
-        _0 = const ();
-        StorageDead(_3);
-        return;
+        goto -> bb2;
     }
 
     bb2: {
+        StorageDead(_4);
+        _2 = &(*_3);
+        PlaceMention(_2);
+        goto -> bb4;
+    }
+
+    bb3: {
         FakeRead(ForMatchedPlace(None), _2);
         unreachable;
     }
 
-    bb3 (cleanup): {
+    bb4: {
+        StorageDead(_2);
+        _0 = const ();
+        goto -> bb5;
+    }
+
+    bb5: {
+        StorageDead(_3);
+        return;
+    }
+
+    bb6 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/issue_99325.main.built.after.32bit.mir
+++ b/tests/mir-opt/issue_99325.main.built.after.32bit.mir
@@ -67,7 +67,7 @@ fn main() -> () {
         StorageLive(_2);
         StorageLive(_3);
         StorageLive(_4);
-        _4 = function_with_bytes::<&*b"AAAA">() -> [return: bb1, unwind: bb23];
+        _4 = function_with_bytes::<&*b"AAAA">() -> [return: bb1, unwind: bb41];
     }
 
     bb1: {
@@ -79,6 +79,10 @@ fn main() -> () {
         _6 = &_7;
         _5 = &_6;
         _2 = (move _3, move _5);
+        goto -> bb2;
+    }
+
+    bb2: {
         StorageDead(_5);
         StorageDead(_3);
         PlaceMention(_2);
@@ -91,29 +95,33 @@ fn main() -> () {
         _11 = &(*_8);
         StorageLive(_12);
         _12 = &(*_9);
-        _10 = <&[u8] as PartialEq<&[u8; 4]>>::eq(move _11, move _12) -> [return: bb3, unwind: bb23];
+        _10 = <&[u8] as PartialEq<&[u8; 4]>>::eq(move _11, move _12) -> [return: bb4, unwind: bb41];
     }
 
-    bb2: {
+    bb3: {
         FakeRead(ForMatchedPlace(None), _2);
         unreachable;
     }
 
-    bb3: {
-        switchInt(move _10) -> [0: bb5, otherwise: bb4];
-    }
-
     bb4: {
-        StorageDead(_12);
-        StorageDead(_11);
-        goto -> bb9;
+        switchInt(move _10) -> [0: bb6, otherwise: bb5];
     }
 
     bb5: {
-        goto -> bb6;
+        goto -> bb7;
     }
 
     bb6: {
+        goto -> bb8;
+    }
+
+    bb7: {
+        StorageDead(_12);
+        StorageDead(_11);
+        goto -> bb14;
+    }
+
+    bb8: {
         StorageDead(_12);
         StorageDead(_11);
         StorageLive(_14);
@@ -132,57 +140,89 @@ fn main() -> () {
         _19 = &(*_20);
         StorageLive(_21);
         _21 = Option::<Arguments<'_>>::None;
-        _15 = core::panicking::assert_failed::<&[u8], &[u8; 4]>(move _16, move _17, move _19, move _21) -> [return: bb7, unwind: bb23];
-    }
-
-    bb7: {
-        StorageDead(_21);
-        StorageDead(_19);
-        StorageDead(_17);
-        StorageDead(_16);
-        StorageDead(_20);
-        StorageDead(_18);
-        StorageDead(_15);
-        StorageDead(_14);
-        unreachable;
-    }
-
-    bb8: {
-        goto -> bb10;
+        _15 = core::panicking::assert_failed::<&[u8], &[u8; 4]>(move _16, move _17, move _19, move _21) -> [return: bb9, unwind: bb41];
     }
 
     bb9: {
-        _1 = const ();
         goto -> bb10;
     }
 
     bb10: {
-        StorageDead(_10);
-        StorageDead(_9);
-        StorageDead(_8);
+        StorageDead(_21);
+        StorageDead(_19);
+        StorageDead(_17);
+        StorageDead(_16);
         goto -> bb11;
     }
 
     bb11: {
+        StorageDead(_20);
+        StorageDead(_18);
+        StorageDead(_15);
+        goto -> bb12;
+    }
+
+    bb12: {
+        StorageDead(_14);
+        unreachable;
+    }
+
+    bb13: {
+        goto -> bb15;
+    }
+
+    bb14: {
+        _1 = const ();
+        goto -> bb15;
+    }
+
+    bb15: {
+        goto -> bb16;
+    }
+
+    bb16: {
+        StorageDead(_10);
+        goto -> bb17;
+    }
+
+    bb17: {
+        StorageDead(_9);
+        StorageDead(_8);
+        goto -> bb18;
+    }
+
+    bb18: {
+        goto -> bb19;
+    }
+
+    bb19: {
         StorageDead(_7);
         StorageDead(_6);
         StorageDead(_4);
         StorageDead(_2);
+        goto -> bb20;
+    }
+
+    bb20: {
         StorageDead(_1);
         StorageLive(_22);
         StorageLive(_23);
         StorageLive(_24);
         StorageLive(_25);
-        _25 = function_with_bytes::<&*b"AAAA">() -> [return: bb12, unwind: bb23];
+        _25 = function_with_bytes::<&*b"AAAA">() -> [return: bb21, unwind: bb41];
     }
 
-    bb12: {
+    bb21: {
         _24 = &_25;
         StorageLive(_26);
         StorageLive(_27);
         _27 = const b"AAAA";
         _26 = &_27;
         _23 = (move _24, move _26);
+        goto -> bb22;
+    }
+
+    bb22: {
         StorageDead(_26);
         StorageDead(_24);
         PlaceMention(_23);
@@ -195,29 +235,33 @@ fn main() -> () {
         _31 = &(*_28);
         StorageLive(_32);
         _32 = &(*_29);
-        _30 = <&[u8] as PartialEq<&[u8; 4]>>::eq(move _31, move _32) -> [return: bb14, unwind: bb23];
+        _30 = <&[u8] as PartialEq<&[u8; 4]>>::eq(move _31, move _32) -> [return: bb24, unwind: bb41];
     }
 
-    bb13: {
+    bb23: {
         FakeRead(ForMatchedPlace(None), _23);
         unreachable;
     }
 
-    bb14: {
-        switchInt(move _30) -> [0: bb16, otherwise: bb15];
+    bb24: {
+        switchInt(move _30) -> [0: bb26, otherwise: bb25];
     }
 
-    bb15: {
+    bb25: {
+        goto -> bb27;
+    }
+
+    bb26: {
+        goto -> bb28;
+    }
+
+    bb27: {
         StorageDead(_32);
         StorageDead(_31);
-        goto -> bb20;
+        goto -> bb34;
     }
 
-    bb16: {
-        goto -> bb17;
-    }
-
-    bb17: {
+    bb28: {
         StorageDead(_32);
         StorageDead(_31);
         StorageLive(_34);
@@ -236,47 +280,75 @@ fn main() -> () {
         _39 = &(*_40);
         StorageLive(_41);
         _41 = Option::<Arguments<'_>>::None;
-        _35 = core::panicking::assert_failed::<&[u8], &[u8; 4]>(move _36, move _37, move _39, move _41) -> [return: bb18, unwind: bb23];
+        _35 = core::panicking::assert_failed::<&[u8], &[u8; 4]>(move _36, move _37, move _39, move _41) -> [return: bb29, unwind: bb41];
     }
 
-    bb18: {
+    bb29: {
+        goto -> bb30;
+    }
+
+    bb30: {
         StorageDead(_41);
         StorageDead(_39);
         StorageDead(_37);
         StorageDead(_36);
+        goto -> bb31;
+    }
+
+    bb31: {
         StorageDead(_40);
         StorageDead(_38);
         StorageDead(_35);
+        goto -> bb32;
+    }
+
+    bb32: {
         StorageDead(_34);
         unreachable;
     }
 
-    bb19: {
-        goto -> bb21;
+    bb33: {
+        goto -> bb35;
     }
 
-    bb20: {
+    bb34: {
         _22 = const ();
-        goto -> bb21;
+        goto -> bb35;
     }
 
-    bb21: {
+    bb35: {
+        goto -> bb36;
+    }
+
+    bb36: {
         StorageDead(_30);
+        goto -> bb37;
+    }
+
+    bb37: {
         StorageDead(_29);
         StorageDead(_28);
-        goto -> bb22;
+        goto -> bb38;
     }
 
-    bb22: {
+    bb38: {
+        goto -> bb39;
+    }
+
+    bb39: {
         StorageDead(_27);
         StorageDead(_25);
         StorageDead(_23);
+        goto -> bb40;
+    }
+
+    bb40: {
         StorageDead(_22);
         _0 = const ();
         return;
     }
 
-    bb23 (cleanup): {
+    bb41 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/issue_99325.main.built.after.64bit.mir
+++ b/tests/mir-opt/issue_99325.main.built.after.64bit.mir
@@ -67,7 +67,7 @@ fn main() -> () {
         StorageLive(_2);
         StorageLive(_3);
         StorageLive(_4);
-        _4 = function_with_bytes::<&*b"AAAA">() -> [return: bb1, unwind: bb23];
+        _4 = function_with_bytes::<&*b"AAAA">() -> [return: bb1, unwind: bb41];
     }
 
     bb1: {
@@ -79,6 +79,10 @@ fn main() -> () {
         _6 = &_7;
         _5 = &_6;
         _2 = (move _3, move _5);
+        goto -> bb2;
+    }
+
+    bb2: {
         StorageDead(_5);
         StorageDead(_3);
         PlaceMention(_2);
@@ -91,29 +95,33 @@ fn main() -> () {
         _11 = &(*_8);
         StorageLive(_12);
         _12 = &(*_9);
-        _10 = <&[u8] as PartialEq<&[u8; 4]>>::eq(move _11, move _12) -> [return: bb3, unwind: bb23];
+        _10 = <&[u8] as PartialEq<&[u8; 4]>>::eq(move _11, move _12) -> [return: bb4, unwind: bb41];
     }
 
-    bb2: {
+    bb3: {
         FakeRead(ForMatchedPlace(None), _2);
         unreachable;
     }
 
-    bb3: {
-        switchInt(move _10) -> [0: bb5, otherwise: bb4];
-    }
-
     bb4: {
-        StorageDead(_12);
-        StorageDead(_11);
-        goto -> bb9;
+        switchInt(move _10) -> [0: bb6, otherwise: bb5];
     }
 
     bb5: {
-        goto -> bb6;
+        goto -> bb7;
     }
 
     bb6: {
+        goto -> bb8;
+    }
+
+    bb7: {
+        StorageDead(_12);
+        StorageDead(_11);
+        goto -> bb14;
+    }
+
+    bb8: {
         StorageDead(_12);
         StorageDead(_11);
         StorageLive(_14);
@@ -132,57 +140,89 @@ fn main() -> () {
         _19 = &(*_20);
         StorageLive(_21);
         _21 = Option::<Arguments<'_>>::None;
-        _15 = core::panicking::assert_failed::<&[u8], &[u8; 4]>(move _16, move _17, move _19, move _21) -> [return: bb7, unwind: bb23];
-    }
-
-    bb7: {
-        StorageDead(_21);
-        StorageDead(_19);
-        StorageDead(_17);
-        StorageDead(_16);
-        StorageDead(_20);
-        StorageDead(_18);
-        StorageDead(_15);
-        StorageDead(_14);
-        unreachable;
-    }
-
-    bb8: {
-        goto -> bb10;
+        _15 = core::panicking::assert_failed::<&[u8], &[u8; 4]>(move _16, move _17, move _19, move _21) -> [return: bb9, unwind: bb41];
     }
 
     bb9: {
-        _1 = const ();
         goto -> bb10;
     }
 
     bb10: {
-        StorageDead(_10);
-        StorageDead(_9);
-        StorageDead(_8);
+        StorageDead(_21);
+        StorageDead(_19);
+        StorageDead(_17);
+        StorageDead(_16);
         goto -> bb11;
     }
 
     bb11: {
+        StorageDead(_20);
+        StorageDead(_18);
+        StorageDead(_15);
+        goto -> bb12;
+    }
+
+    bb12: {
+        StorageDead(_14);
+        unreachable;
+    }
+
+    bb13: {
+        goto -> bb15;
+    }
+
+    bb14: {
+        _1 = const ();
+        goto -> bb15;
+    }
+
+    bb15: {
+        goto -> bb16;
+    }
+
+    bb16: {
+        StorageDead(_10);
+        goto -> bb17;
+    }
+
+    bb17: {
+        StorageDead(_9);
+        StorageDead(_8);
+        goto -> bb18;
+    }
+
+    bb18: {
+        goto -> bb19;
+    }
+
+    bb19: {
         StorageDead(_7);
         StorageDead(_6);
         StorageDead(_4);
         StorageDead(_2);
+        goto -> bb20;
+    }
+
+    bb20: {
         StorageDead(_1);
         StorageLive(_22);
         StorageLive(_23);
         StorageLive(_24);
         StorageLive(_25);
-        _25 = function_with_bytes::<&*b"AAAA">() -> [return: bb12, unwind: bb23];
+        _25 = function_with_bytes::<&*b"AAAA">() -> [return: bb21, unwind: bb41];
     }
 
-    bb12: {
+    bb21: {
         _24 = &_25;
         StorageLive(_26);
         StorageLive(_27);
         _27 = const b"AAAA";
         _26 = &_27;
         _23 = (move _24, move _26);
+        goto -> bb22;
+    }
+
+    bb22: {
         StorageDead(_26);
         StorageDead(_24);
         PlaceMention(_23);
@@ -195,29 +235,33 @@ fn main() -> () {
         _31 = &(*_28);
         StorageLive(_32);
         _32 = &(*_29);
-        _30 = <&[u8] as PartialEq<&[u8; 4]>>::eq(move _31, move _32) -> [return: bb14, unwind: bb23];
+        _30 = <&[u8] as PartialEq<&[u8; 4]>>::eq(move _31, move _32) -> [return: bb24, unwind: bb41];
     }
 
-    bb13: {
+    bb23: {
         FakeRead(ForMatchedPlace(None), _23);
         unreachable;
     }
 
-    bb14: {
-        switchInt(move _30) -> [0: bb16, otherwise: bb15];
+    bb24: {
+        switchInt(move _30) -> [0: bb26, otherwise: bb25];
     }
 
-    bb15: {
+    bb25: {
+        goto -> bb27;
+    }
+
+    bb26: {
+        goto -> bb28;
+    }
+
+    bb27: {
         StorageDead(_32);
         StorageDead(_31);
-        goto -> bb20;
+        goto -> bb34;
     }
 
-    bb16: {
-        goto -> bb17;
-    }
-
-    bb17: {
+    bb28: {
         StorageDead(_32);
         StorageDead(_31);
         StorageLive(_34);
@@ -236,47 +280,75 @@ fn main() -> () {
         _39 = &(*_40);
         StorageLive(_41);
         _41 = Option::<Arguments<'_>>::None;
-        _35 = core::panicking::assert_failed::<&[u8], &[u8; 4]>(move _36, move _37, move _39, move _41) -> [return: bb18, unwind: bb23];
+        _35 = core::panicking::assert_failed::<&[u8], &[u8; 4]>(move _36, move _37, move _39, move _41) -> [return: bb29, unwind: bb41];
     }
 
-    bb18: {
+    bb29: {
+        goto -> bb30;
+    }
+
+    bb30: {
         StorageDead(_41);
         StorageDead(_39);
         StorageDead(_37);
         StorageDead(_36);
+        goto -> bb31;
+    }
+
+    bb31: {
         StorageDead(_40);
         StorageDead(_38);
         StorageDead(_35);
+        goto -> bb32;
+    }
+
+    bb32: {
         StorageDead(_34);
         unreachable;
     }
 
-    bb19: {
-        goto -> bb21;
+    bb33: {
+        goto -> bb35;
     }
 
-    bb20: {
+    bb34: {
         _22 = const ();
-        goto -> bb21;
+        goto -> bb35;
     }
 
-    bb21: {
+    bb35: {
+        goto -> bb36;
+    }
+
+    bb36: {
         StorageDead(_30);
+        goto -> bb37;
+    }
+
+    bb37: {
         StorageDead(_29);
         StorageDead(_28);
-        goto -> bb22;
+        goto -> bb38;
     }
 
-    bb22: {
+    bb38: {
+        goto -> bb39;
+    }
+
+    bb39: {
         StorageDead(_27);
         StorageDead(_25);
         StorageDead(_23);
+        goto -> bb40;
+    }
+
+    bb40: {
         StorageDead(_22);
         _0 = const ();
         return;
     }
 
-    bb23 (cleanup): {
+    bb41 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/lower_array_len.array_bound.GVN.panic-abort.diff
+++ b/tests/mir-opt/lower_array_len.array_bound.GVN.panic-abort.diff
@@ -31,9 +31,9 @@
       bb1: {
           StorageDead(_6);
 -         _3 = Lt(move _4, move _5);
--         switchInt(move _3) -> [0: bb4, otherwise: bb2];
+-         switchInt(move _3) -> [0: bb3, otherwise: bb2];
 +         _3 = Lt(copy _1, const N);
-+         switchInt(copy _3) -> [0: bb4, otherwise: bb2];
++         switchInt(copy _3) -> [0: bb3, otherwise: bb2];
       }
   
       bb2: {
@@ -42,22 +42,22 @@
           StorageLive(_8);
           _8 = copy _1;
 -         _9 = Lt(copy _8, const N);
--         assert(move _9, "index out of bounds: the length is {} but the index is {}", const N, copy _8) -> [success: bb3, unwind unreachable];
+-         assert(move _9, "index out of bounds: the length is {} but the index is {}", const N, copy _8) -> [success: bb4, unwind unreachable];
 +         _9 = copy _3;
-+         assert(copy _3, "index out of bounds: the length is {} but the index is {}", const N, copy _1) -> [success: bb3, unwind unreachable];
++         assert(copy _3, "index out of bounds: the length is {} but the index is {}", const N, copy _1) -> [success: bb4, unwind unreachable];
       }
   
       bb3: {
--         _0 = copy (*_2)[_8];
-+         _0 = copy (*_2)[_1];
-          StorageDead(_8);
+          StorageDead(_5);
+          StorageDead(_4);
+          _0 = const 42_u8;
           goto -> bb5;
       }
   
       bb4: {
-          StorageDead(_5);
-          StorageDead(_4);
-          _0 = const 42_u8;
+-         _0 = copy (*_2)[_8];
++         _0 = copy (*_2)[_1];
+          StorageDead(_8);
           goto -> bb5;
       }
   

--- a/tests/mir-opt/lower_array_len.array_bound.GVN.panic-unwind.diff
+++ b/tests/mir-opt/lower_array_len.array_bound.GVN.panic-unwind.diff
@@ -31,9 +31,9 @@
       bb1: {
           StorageDead(_6);
 -         _3 = Lt(move _4, move _5);
--         switchInt(move _3) -> [0: bb4, otherwise: bb2];
+-         switchInt(move _3) -> [0: bb3, otherwise: bb2];
 +         _3 = Lt(copy _1, const N);
-+         switchInt(copy _3) -> [0: bb4, otherwise: bb2];
++         switchInt(copy _3) -> [0: bb3, otherwise: bb2];
       }
   
       bb2: {
@@ -42,22 +42,22 @@
           StorageLive(_8);
           _8 = copy _1;
 -         _9 = Lt(copy _8, const N);
--         assert(move _9, "index out of bounds: the length is {} but the index is {}", const N, copy _8) -> [success: bb3, unwind continue];
+-         assert(move _9, "index out of bounds: the length is {} but the index is {}", const N, copy _8) -> [success: bb4, unwind continue];
 +         _9 = copy _3;
-+         assert(copy _3, "index out of bounds: the length is {} but the index is {}", const N, copy _1) -> [success: bb3, unwind continue];
++         assert(copy _3, "index out of bounds: the length is {} but the index is {}", const N, copy _1) -> [success: bb4, unwind continue];
       }
   
       bb3: {
--         _0 = copy (*_2)[_8];
-+         _0 = copy (*_2)[_1];
-          StorageDead(_8);
+          StorageDead(_5);
+          StorageDead(_4);
+          _0 = const 42_u8;
           goto -> bb5;
       }
   
       bb4: {
-          StorageDead(_5);
-          StorageDead(_4);
-          _0 = const 42_u8;
+-         _0 = copy (*_2)[_8];
++         _0 = copy (*_2)[_1];
+          StorageDead(_8);
           goto -> bb5;
       }
   

--- a/tests/mir-opt/lower_array_len.array_bound_mut.GVN.panic-abort.diff
+++ b/tests/mir-opt/lower_array_len.array_bound_mut.GVN.panic-abort.diff
@@ -33,9 +33,9 @@
       bb1: {
           StorageDead(_6);
 -         _3 = Lt(move _4, move _5);
--         switchInt(move _3) -> [0: bb4, otherwise: bb2];
+-         switchInt(move _3) -> [0: bb3, otherwise: bb2];
 +         _3 = Lt(copy _1, const N);
-+         switchInt(copy _3) -> [0: bb4, otherwise: bb2];
++         switchInt(copy _3) -> [0: bb3, otherwise: bb2];
       }
   
       bb2: {
@@ -44,19 +44,12 @@
           StorageLive(_8);
           _8 = copy _1;
 -         _9 = Lt(copy _8, const N);
--         assert(move _9, "index out of bounds: the length is {} but the index is {}", const N, copy _8) -> [success: bb3, unwind unreachable];
+-         assert(move _9, "index out of bounds: the length is {} but the index is {}", const N, copy _8) -> [success: bb4, unwind unreachable];
 +         _9 = copy _3;
-+         assert(copy _3, "index out of bounds: the length is {} but the index is {}", const N, copy _1) -> [success: bb3, unwind unreachable];
++         assert(copy _3, "index out of bounds: the length is {} but the index is {}", const N, copy _1) -> [success: bb4, unwind unreachable];
       }
   
       bb3: {
--         _0 = copy (*_2)[_8];
-+         _0 = copy (*_2)[_1];
-          StorageDead(_8);
-          goto -> bb6;
-      }
-  
-      bb4: {
           StorageDead(_5);
           StorageDead(_4);
           StorageLive(_10);
@@ -65,6 +58,13 @@
 -         assert(move _11, "index out of bounds: the length is {} but the index is {}", const N, copy _10) -> [success: bb5, unwind unreachable];
 +         _11 = Lt(const 0_usize, const N);
 +         assert(move _11, "index out of bounds: the length is {} but the index is {}", const N, const 0_usize) -> [success: bb5, unwind unreachable];
+      }
+  
+      bb4: {
+-         _0 = copy (*_2)[_8];
++         _0 = copy (*_2)[_1];
+          StorageDead(_8);
+          goto -> bb6;
       }
   
       bb5: {

--- a/tests/mir-opt/lower_array_len.array_bound_mut.GVN.panic-unwind.diff
+++ b/tests/mir-opt/lower_array_len.array_bound_mut.GVN.panic-unwind.diff
@@ -33,9 +33,9 @@
       bb1: {
           StorageDead(_6);
 -         _3 = Lt(move _4, move _5);
--         switchInt(move _3) -> [0: bb4, otherwise: bb2];
+-         switchInt(move _3) -> [0: bb3, otherwise: bb2];
 +         _3 = Lt(copy _1, const N);
-+         switchInt(copy _3) -> [0: bb4, otherwise: bb2];
++         switchInt(copy _3) -> [0: bb3, otherwise: bb2];
       }
   
       bb2: {
@@ -44,19 +44,12 @@
           StorageLive(_8);
           _8 = copy _1;
 -         _9 = Lt(copy _8, const N);
--         assert(move _9, "index out of bounds: the length is {} but the index is {}", const N, copy _8) -> [success: bb3, unwind continue];
+-         assert(move _9, "index out of bounds: the length is {} but the index is {}", const N, copy _8) -> [success: bb4, unwind continue];
 +         _9 = copy _3;
-+         assert(copy _3, "index out of bounds: the length is {} but the index is {}", const N, copy _1) -> [success: bb3, unwind continue];
++         assert(copy _3, "index out of bounds: the length is {} but the index is {}", const N, copy _1) -> [success: bb4, unwind continue];
       }
   
       bb3: {
--         _0 = copy (*_2)[_8];
-+         _0 = copy (*_2)[_1];
-          StorageDead(_8);
-          goto -> bb6;
-      }
-  
-      bb4: {
           StorageDead(_5);
           StorageDead(_4);
           StorageLive(_10);
@@ -65,6 +58,13 @@
 -         assert(move _11, "index out of bounds: the length is {} but the index is {}", const N, copy _10) -> [success: bb5, unwind continue];
 +         _11 = Lt(const 0_usize, const N);
 +         assert(move _11, "index out of bounds: the length is {} but the index is {}", const N, const 0_usize) -> [success: bb5, unwind continue];
+      }
+  
+      bb4: {
+-         _0 = copy (*_2)[_8];
++         _0 = copy (*_2)[_1];
+          StorageDead(_8);
+          goto -> bb6;
       }
   
       bb5: {

--- a/tests/mir-opt/nll/region_subtyping_basic.main.nll.0.32bit.mir
+++ b/tests/mir-opt/nll/region_subtyping_basic.main.nll.0.32bit.mir
@@ -5,15 +5,15 @@
 | '?1 | Local | ['?1]
 |
 | Inferred Region Values
-| '?0 | U0 | {bb0[0..=8], bb1[0..=8], bb2[0..=3], bb3[0..=3], bb4[0..=1], bb5[0..=2], bb6[0..=4], bb7[0], '?0, '?1}
-| '?1 | U0 | {bb0[0..=8], bb1[0..=8], bb2[0..=3], bb3[0..=3], bb4[0..=1], bb5[0..=2], bb6[0..=4], bb7[0], '?1}
+| '?0 | U0 | {bb0[0..=8], bb1[0..=8], bb2[0..=3], bb3[0..=1], bb4[0..=3], bb5[0..=2], bb6[0..=4], bb7[0], '?0, '?1}
+| '?1 | U0 | {bb0[0..=8], bb1[0..=8], bb2[0..=3], bb3[0..=1], bb4[0..=3], bb5[0..=2], bb6[0..=4], bb7[0], '?1}
 | '?2 | U0 | {bb1[0..=8], bb2[0..=2]}
 | '?3 | U0 | {bb1[1..=8], bb2[0..=2]}
 | '?4 | U0 | {bb1[5..=8], bb2[0..=2]}
 |
 | Inference Constraints
-| '?0 live at {bb0[0..=8], bb1[0..=8], bb2[0..=3], bb3[0..=3], bb4[0..=1], bb5[0..=2], bb6[0..=4], bb7[0]}
-| '?1 live at {bb0[0..=8], bb1[0..=8], bb2[0..=3], bb3[0..=3], bb4[0..=1], bb5[0..=2], bb6[0..=4], bb7[0]}
+| '?0 live at {bb0[0..=8], bb1[0..=8], bb2[0..=3], bb3[0..=1], bb4[0..=3], bb5[0..=2], bb6[0..=4], bb7[0]}
+| '?1 live at {bb0[0..=8], bb1[0..=8], bb2[0..=3], bb3[0..=1], bb4[0..=3], bb5[0..=2], bb6[0..=4], bb7[0]}
 | '?2 live at {bb1[0]}
 | '?3 live at {bb1[1..=4]}
 | '?4 live at {bb1[5..=8], bb2[0..=2]}
@@ -65,26 +65,26 @@ fn main() -> () {
         FakeRead(ForLet(None), _5);
         StorageLive(_6);
         _6 = const ConstValue(Scalar(0x01): bool);
-        switchInt(move _6) -> [0: bb4, otherwise: bb2];
+        switchInt(move _6) -> [0: bb3, otherwise: bb2];
     }
 
     bb2: {
         StorageLive(_7);
         StorageLive(_8);
         _8 = copy (*_5);
-        _7 = ConstValue(ZeroSized: fn(usize) -> bool {use_x})(move _8) -> [return: bb3, unwind: bb7];
+        _7 = ConstValue(ZeroSized: fn(usize) -> bool {use_x})(move _8) -> [return: bb4, unwind: bb7];
     }
 
     bb3: {
+        StorageLive(_9);
+        _9 = ConstValue(ZeroSized: fn(usize) -> bool {use_x})(const ConstValue(Scalar(0x00000016): usize)) -> [return: bb5, unwind: bb7];
+    }
+
+    bb4: {
         StorageDead(_8);
         StorageDead(_7);
         _0 = const ConstValue(ZeroSized: ());
         goto -> bb6;
-    }
-
-    bb4: {
-        StorageLive(_9);
-        _9 = ConstValue(ZeroSized: fn(usize) -> bool {use_x})(const ConstValue(Scalar(0x00000016): usize)) -> [return: bb5, unwind: bb7];
     }
 
     bb5: {

--- a/tests/mir-opt/nll/region_subtyping_basic.main.nll.0.64bit.mir
+++ b/tests/mir-opt/nll/region_subtyping_basic.main.nll.0.64bit.mir
@@ -5,15 +5,15 @@
 | '?1 | Local | ['?1]
 |
 | Inferred Region Values
-| '?0 | U0 | {bb0[0..=8], bb1[0..=8], bb2[0..=3], bb3[0..=3], bb4[0..=1], bb5[0..=2], bb6[0..=4], bb7[0], '?0, '?1}
-| '?1 | U0 | {bb0[0..=8], bb1[0..=8], bb2[0..=3], bb3[0..=3], bb4[0..=1], bb5[0..=2], bb6[0..=4], bb7[0], '?1}
+| '?0 | U0 | {bb0[0..=8], bb1[0..=8], bb2[0..=3], bb3[0..=1], bb4[0..=3], bb5[0..=2], bb6[0..=4], bb7[0], '?0, '?1}
+| '?1 | U0 | {bb0[0..=8], bb1[0..=8], bb2[0..=3], bb3[0..=1], bb4[0..=3], bb5[0..=2], bb6[0..=4], bb7[0], '?1}
 | '?2 | U0 | {bb1[0..=8], bb2[0..=2]}
 | '?3 | U0 | {bb1[1..=8], bb2[0..=2]}
 | '?4 | U0 | {bb1[5..=8], bb2[0..=2]}
 |
 | Inference Constraints
-| '?0 live at {bb0[0..=8], bb1[0..=8], bb2[0..=3], bb3[0..=3], bb4[0..=1], bb5[0..=2], bb6[0..=4], bb7[0]}
-| '?1 live at {bb0[0..=8], bb1[0..=8], bb2[0..=3], bb3[0..=3], bb4[0..=1], bb5[0..=2], bb6[0..=4], bb7[0]}
+| '?0 live at {bb0[0..=8], bb1[0..=8], bb2[0..=3], bb3[0..=1], bb4[0..=3], bb5[0..=2], bb6[0..=4], bb7[0]}
+| '?1 live at {bb0[0..=8], bb1[0..=8], bb2[0..=3], bb3[0..=1], bb4[0..=3], bb5[0..=2], bb6[0..=4], bb7[0]}
 | '?2 live at {bb1[0]}
 | '?3 live at {bb1[1..=4]}
 | '?4 live at {bb1[5..=8], bb2[0..=2]}
@@ -65,26 +65,26 @@ fn main() -> () {
         FakeRead(ForLet(None), _5);
         StorageLive(_6);
         _6 = const ConstValue(Scalar(0x01): bool);
-        switchInt(move _6) -> [0: bb4, otherwise: bb2];
+        switchInt(move _6) -> [0: bb3, otherwise: bb2];
     }
 
     bb2: {
         StorageLive(_7);
         StorageLive(_8);
         _8 = copy (*_5);
-        _7 = ConstValue(ZeroSized: fn(usize) -> bool {use_x})(move _8) -> [return: bb3, unwind: bb7];
+        _7 = ConstValue(ZeroSized: fn(usize) -> bool {use_x})(move _8) -> [return: bb4, unwind: bb7];
     }
 
     bb3: {
+        StorageLive(_9);
+        _9 = ConstValue(ZeroSized: fn(usize) -> bool {use_x})(const ConstValue(Scalar(0x0000000000000016): usize)) -> [return: bb5, unwind: bb7];
+    }
+
+    bb4: {
         StorageDead(_8);
         StorageDead(_7);
         _0 = const ConstValue(ZeroSized: ());
         goto -> bb6;
-    }
-
-    bb4: {
-        StorageLive(_9);
-        _9 = ConstValue(ZeroSized: fn(usize) -> bool {use_x})(const ConstValue(Scalar(0x0000000000000016): usize)) -> [return: bb5, unwind: bb7];
     }
 
     bb5: {

--- a/tests/mir-opt/no_spurious_drop_after_call.main.ElaborateDrops.before.panic-abort.mir
+++ b/tests/mir-opt/no_spurious_drop_after_call.main.ElaborateDrops.before.panic-abort.mir
@@ -14,7 +14,7 @@ fn main() -> () {
         StorageLive(_4);
         _4 = const "";
         _3 = &(*_4);
-        _2 = <str as ToString>::to_string(move _3) -> [return: bb1, unwind: bb4];
+        _2 = <str as ToString>::to_string(move _3) -> [return: bb1, unwind: bb3];
     }
 
     bb1: {
@@ -31,10 +31,6 @@ fn main() -> () {
     }
 
     bb3 (cleanup): {
-        drop(_2) -> [return: bb4, unwind terminate(cleanup)];
-    }
-
-    bb4 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/no_spurious_drop_after_call.main.ElaborateDrops.before.panic-unwind.mir
+++ b/tests/mir-opt/no_spurious_drop_after_call.main.ElaborateDrops.before.panic-unwind.mir
@@ -19,7 +19,7 @@ fn main() -> () {
 
     bb1: {
         StorageDead(_3);
-        _1 = std::mem::drop::<String>(move _2) -> [return: bb2, unwind: bb3];
+        _1 = std::mem::drop::<String>(move _2) -> [return: bb2, unwind continue];
     }
 
     bb2: {
@@ -28,14 +28,6 @@ fn main() -> () {
         StorageDead(_1);
         _0 = const ();
         return;
-    }
-
-    bb3 (cleanup): {
-        drop(_2) -> [return: bb4, unwind terminate(cleanup)];
-    }
-
-    bb4 (cleanup): {
-        resume;
     }
 }
 

--- a/tests/mir-opt/otherwise_drops.result_ok.ElaborateDrops.diff
+++ b/tests/mir-opt/otherwise_drops.result_ok.ElaborateDrops.diff
@@ -22,7 +22,7 @@
   
       bb1: {
           _0 = Option::<String>::None;
-          goto -> bb5;
+          goto -> bb4;
       }
   
       bb2: {
@@ -31,46 +31,36 @@
           StorageLive(_4);
           _4 = move _3;
           _0 = Option::<String>::Some(move _4);
--         drop(_4) -> [return: bb3, unwind: bb7];
+          StorageDead(_4);
+-         drop(_3) -> [return: bb3, unwind: bb6];
 +         goto -> bb3;
       }
   
       bb3: {
-          StorageDead(_4);
--         drop(_3) -> [return: bb4, unwind: bb8];
-+         goto -> bb4;
+          StorageDead(_3);
+          goto -> bb4;
       }
   
       bb4: {
-          StorageDead(_3);
-          goto -> bb5;
-      }
-  
-      bb5: {
--         drop(_1) -> [return: bb6, unwind: bb9];
-+         goto -> bb10;
-      }
-  
-      bb6: {
-          return;
-      }
-  
-      bb7 (cleanup): {
--         drop(_3) -> [return: bb8, unwind terminate(cleanup)];
+-         drop(_1) -> [return: bb5, unwind: bb7];
 +         goto -> bb8;
       }
   
-      bb8 (cleanup): {
--         drop(_1) -> [return: bb9, unwind terminate(cleanup)];
-+         goto -> bb9;
+      bb5: {
+          return;
       }
   
-      bb9 (cleanup): {
+      bb6 (cleanup): {
+-         drop(_1) -> [return: bb7, unwind terminate(cleanup)];
++         goto -> bb7;
+      }
+  
+      bb7 (cleanup): {
           resume;
 +     }
 + 
-+     bb10: {
-+         goto -> bb6;
++     bb8: {
++         goto -> bb5;
       }
   }
   

--- a/tests/mir-opt/pre-codegen/loops.vec_move.runtime-optimized.after.mir
+++ b/tests/mir-opt/pre-codegen/loops.vec_move.runtime-optimized.after.mir
@@ -75,45 +75,45 @@ fn vec_move(_1: Vec<impl Sized>) -> () {
                             scope 30 (inlined MaybeDangling::<Vec<impl Sized>>::as_ref) {
                             }
                         }
-                        scope 31 (inlined Vec::<impl Sized>::len) {
-                            debug self => _33;
-                            let mut _13: bool;
-                            scope 32 {
+                        scope 31 (inlined <ManuallyDrop<Vec<impl Sized>> as Deref>::deref) {
+                            debug self => _36;
+                            scope 32 (inlined MaybeDangling::<Vec<impl Sized>>::as_ref) {
                             }
                         }
-                        scope 33 (inlined std::ptr::mut_ptr::<impl *mut impl Sized>::wrapping_byte_add) {
+                        scope 33 (inlined Vec::<impl Sized>::len) {
+                            debug self => _33;
+                            let mut _13: bool;
+                            scope 34 {
+                            }
+                        }
+                        scope 35 (inlined std::ptr::mut_ptr::<impl *mut impl Sized>::wrapping_byte_add) {
                             debug self => _7;
                             debug count => _12;
                             let mut _14: *mut u8;
                             let mut _18: *mut u8;
                             let mut _19: *const impl Sized;
-                            scope 34 (inlined std::ptr::mut_ptr::<impl *mut impl Sized>::cast::<u8>) {
+                            scope 36 (inlined std::ptr::mut_ptr::<impl *mut impl Sized>::cast::<u8>) {
                                 debug self => _7;
                             }
-                            scope 35 (inlined std::ptr::mut_ptr::<impl *mut u8>::wrapping_add) {
+                            scope 37 (inlined std::ptr::mut_ptr::<impl *mut u8>::wrapping_add) {
                                 debug self => _14;
                                 debug count => _12;
                                 let mut _15: isize;
-                                scope 36 (inlined std::ptr::mut_ptr::<impl *mut u8>::wrapping_offset) {
+                                scope 38 (inlined std::ptr::mut_ptr::<impl *mut u8>::wrapping_offset) {
                                     debug self => _14;
                                     debug count => _15;
                                     let mut _16: *const u8;
                                     let mut _17: *const u8;
                                 }
                             }
-                            scope 37 (inlined std::ptr::mut_ptr::<impl *mut u8>::with_metadata_of::<impl Sized>) {
+                            scope 39 (inlined std::ptr::mut_ptr::<impl *mut u8>::with_metadata_of::<impl Sized>) {
                                 debug self => _18;
                                 debug meta => _19;
-                                scope 38 (inlined std::ptr::metadata::<impl Sized>) {
+                                scope 40 (inlined std::ptr::metadata::<impl Sized>) {
                                     debug ptr => _19;
                                 }
-                                scope 39 (inlined std::ptr::from_raw_parts_mut::<impl Sized, ()>) {
+                                scope 41 (inlined std::ptr::from_raw_parts_mut::<impl Sized, ()>) {
                                 }
-                            }
-                        }
-                        scope 40 (inlined <ManuallyDrop<Vec<impl Sized>> as Deref>::deref) {
-                            debug self => _36;
-                            scope 41 (inlined MaybeDangling::<Vec<impl Sized>>::as_ref) {
                             }
                         }
                         scope 42 (inlined Vec::<impl Sized>::len) {

--- a/tests/mir-opt/read_from_trivial_switch.main.SimplifyCfg-initial.diff
+++ b/tests/mir-opt/read_from_trivial_switch.main.SimplifyCfg-initial.diff
@@ -41,6 +41,10 @@
 - 
 -     bb5: {
           _0 = const ();
+-         goto -> bb6;
+-     }
+- 
+-     bb6: {
           StorageDead(_2);
           StorageDead(_1);
           return;

--- a/tests/mir-opt/simplify_cfg.main.SimplifyCfg-initial.diff
+++ b/tests/mir-opt/simplify_cfg.main.SimplifyCfg-initial.diff
@@ -12,13 +12,13 @@
       }
   
       bb1: {
--         falseUnwind -> [real: bb2, unwind: bb11];
+-         falseUnwind -> [real: bb2, unwind: bb12];
 +         falseUnwind -> [real: bb2, unwind: bb6];
       }
   
       bb2: {
           StorageLive(_2);
--         _2 = bar() -> [return: bb3, unwind: bb11];
+-         _2 = bar() -> [return: bb3, unwind: bb12];
 +         _2 = bar() -> [return: bb3, unwind: bb6];
       }
   
@@ -28,7 +28,7 @@
   
       bb4: {
           _0 = const ();
--         goto -> bb10;
+-         goto -> bb11;
 +         StorageDead(_2);
 +         return;
       }
@@ -51,16 +51,20 @@
 -     }
 - 
 -     bb9: {
+-         goto -> bb10;
+-     }
+- 
+-     bb10: {
           StorageDead(_2);
           goto -> bb1;
       }
   
--     bb10: {
+-     bb11: {
 -         StorageDead(_2);
 -         return;
 -     }
 - 
--     bb11 (cleanup): {
+-     bb12 (cleanup): {
 +     bb6 (cleanup): {
           resume;
       }

--- a/tests/mir-opt/sroa/lifetimes.foo.ScalarReplacementOfAggregates.diff
+++ b/tests/mir-opt/sroa/lifetimes.foo.ScalarReplacementOfAggregates.diff
@@ -89,10 +89,15 @@
 -         _6 = copy (_1.1: u32);
 +         _6 = copy _31;
           _7 = discriminant(_5);
-          switchInt(move _7) -> [0: bb2, otherwise: bb7];
+          switchInt(move _7) -> [0: bb3, otherwise: bb2];
       }
   
       bb2: {
+          _0 = const ();
+          goto -> bb9;
+      }
+  
+      bb3: {
           StorageLive(_8);
           _8 = move ((_5 as Ok).0: std::boxed::Box<dyn std::fmt::Display>);
           StorageLive(_9);
@@ -118,20 +123,20 @@
 -         _24 = no_retag copy (_12.0: &std::boxed::Box<dyn std::fmt::Display>);
 +         _24 = no_retag copy _32;
           _17 = &(*_24);
-          _16 = core::fmt::rt::Argument::<'_>::new_display::<Box<dyn std::fmt::Display>>(move _17) -> [return: bb3, unwind unreachable];
+          _16 = core::fmt::rt::Argument::<'_>::new_display::<Box<dyn std::fmt::Display>>(move _17) -> [return: bb4, unwind unreachable];
       }
   
-      bb3: {
+      bb4: {
           StorageDead(_17);
           StorageLive(_18);
           StorageLive(_19);
 -         _25 = no_retag copy (_12.1: &u32);
 +         _25 = no_retag copy _33;
           _19 = &(*_25);
-          _18 = core::fmt::rt::Argument::<'_>::new_display::<u32>(move _19) -> [return: bb4, unwind unreachable];
+          _18 = core::fmt::rt::Argument::<'_>::new_display::<u32>(move _19) -> [return: bb5, unwind unreachable];
       }
   
-      bb4: {
+      bb5: {
           StorageDead(_19);
           _15 = [move _16, move _18];
           StorageDead(_18);
@@ -144,18 +149,18 @@
           StorageLive(_23);
           _23 = &_15;
           _22 = &(*_23);
-          _11 = Arguments::<'_>::new::<7, 2>(move _20, move _22) -> [return: bb5, unwind unreachable];
+          _11 = Arguments::<'_>::new::<7, 2>(move _20, move _22) -> [return: bb6, unwind unreachable];
       }
   
-      bb5: {
+      bb6: {
           StorageDead(_23);
           StorageDead(_22);
           StorageDead(_21);
           StorageDead(_20);
-          _10 = std::io::_eprint(move _11) -> [return: bb6, unwind unreachable];
+          _10 = std::io::_eprint(move _11) -> [return: bb7, unwind unreachable];
       }
   
-      bb6: {
+      bb7: {
           StorageDead(_11);
           StorageDead(_15);
 -         StorageDead(_12);
@@ -167,11 +172,6 @@
           StorageDead(_9);
           _0 = const ();
           drop(_8) -> [return: bb8, unwind unreachable];
-      }
-  
-      bb7: {
-          _0 = const ();
-          goto -> bb9;
       }
   
       bb8: {

--- a/tests/mir-opt/sroa/structs.dropping.ScalarReplacementOfAggregates.diff
+++ b/tests/mir-opt/sroa/structs.dropping.ScalarReplacementOfAggregates.diff
@@ -23,22 +23,22 @@
           StorageDead(_4);
           StorageDead(_3);
           _1 = move (_2.1: Tag);
-          drop(_1) -> [return: bb1, unwind unreachable];
+          drop(_1) -> [return: bb3, unwind unreachable];
       }
   
       bb1: {
-          drop((_2.0: Tag)) -> [return: bb3, unwind unreachable];
-      }
-  
-      bb2: {
           StorageDead(_2);
           StorageDead(_1);
           _0 = const ();
           return;
       }
   
+      bb2: {
+          drop((_2.2: Tag)) -> [return: bb1, unwind unreachable];
+      }
+  
       bb3: {
-          drop((_2.2: Tag)) -> [return: bb2, unwind unreachable];
+          drop((_2.0: Tag)) -> [return: bb2, unwind unreachable];
       }
   }
   

--- a/tests/mir-opt/sroa/structs.enums.ScalarReplacementOfAggregates.diff
+++ b/tests/mir-opt/sroa/structs.enums.ScalarReplacementOfAggregates.diff
@@ -19,19 +19,19 @@
           _2 = Option::<usize>::Some(move _3);
           StorageDead(_3);
           _4 = discriminant(_2);
-          switchInt(move _4) -> [1: bb1, otherwise: bb2];
+          switchInt(move _4) -> [1: bb2, otherwise: bb1];
       }
   
       bb1: {
-          StorageLive(_5);
-          _5 = copy ((_2 as Some).0: usize);
-          _0 = copy _5;
-          StorageDead(_5);
+          _0 = const 0_usize;
           goto -> bb3;
       }
   
       bb2: {
-          _0 = const 0_usize;
+          StorageLive(_5);
+          _5 = copy ((_2 as Some).0: usize);
+          _0 = copy _5;
+          StorageDead(_5);
           goto -> bb3;
       }
   

--- a/tests/mir-opt/tail_call_drops.f.ElaborateDrops.panic-abort.diff
+++ b/tests/mir-opt/tail_call_drops.f.ElaborateDrops.panic-abort.diff
@@ -66,6 +66,7 @@
       bb6: {
 +         _8 = const false;
           StorageDead(_4);
+          StorageDead(_3);
           drop(_2) -> [return: bb7, unwind: bb12];
       }
   

--- a/tests/mir-opt/tail_call_drops.f.ElaborateDrops.panic-abort.diff
+++ b/tests/mir-opt/tail_call_drops.f.ElaborateDrops.panic-abort.diff
@@ -27,20 +27,20 @@
       bb0: {
 +         _8 = const false;
           StorageLive(_2);
-          _2 = String::new() -> [return: bb1, unwind: bb12];
+          _2 = String::new() -> [return: bb1, unwind: bb11];
       }
   
       bb1: {
           StorageLive(_3);
           _3 = const 12_i32;
           StorageLive(_4);
-          _4 = String::new() -> [return: bb2, unwind: bb11];
+          _4 = String::new() -> [return: bb2, unwind: bb10];
       }
   
       bb2: {
 +         _8 = const true;
           StorageLive(_5);
-          _5 = String::new() -> [return: bb3, unwind: bb10];
+          _5 = String::new() -> [return: bb3, unwind: bb9];
       }
   
       bb3: {
@@ -54,12 +54,12 @@
       bb4: {
           StorageDead(_7);
           StorageDead(_6);
-          drop(_5) -> [return: bb5, unwind: bb10];
+          drop(_5) -> [return: bb5, unwind: bb9];
       }
   
       bb5: {
           StorageDead(_5);
--         drop(_4) -> [return: bb6, unwind: bb11];
+-         drop(_4) -> [return: bb6, unwind: bb10];
 +         goto -> bb6;
       }
   
@@ -67,7 +67,7 @@
 +         _8 = const false;
           StorageDead(_4);
           StorageDead(_3);
-          drop(_2) -> [return: bb7, unwind: bb12];
+          drop(_2) -> [return: bb7, unwind: bb11];
       }
   
       bb7: {
@@ -76,33 +76,28 @@
       }
   
       bb8 (cleanup): {
--         drop(_7) -> [return: bb9, unwind terminate(cleanup)];
-+         goto -> bb9;
+          drop(_5) -> [return: bb9, unwind terminate(cleanup)];
       }
   
       bb9 (cleanup): {
-          drop(_5) -> [return: bb10, unwind terminate(cleanup)];
+-         drop(_4) -> [return: bb10, unwind terminate(cleanup)];
++         goto -> bb13;
       }
   
       bb10 (cleanup): {
--         drop(_4) -> [return: bb11, unwind terminate(cleanup)];
-+         goto -> bb14;
+          drop(_2) -> [return: bb11, unwind terminate(cleanup)];
       }
   
       bb11 (cleanup): {
-          drop(_2) -> [return: bb12, unwind terminate(cleanup)];
-      }
-  
-      bb12 (cleanup): {
           resume;
 +     }
 + 
-+     bb13 (cleanup): {
-+         drop(_4) -> [return: bb11, unwind terminate(cleanup)];
++     bb12 (cleanup): {
++         drop(_4) -> [return: bb10, unwind terminate(cleanup)];
 +     }
 + 
-+     bb14 (cleanup): {
-+         switchInt(copy _8) -> [0: bb11, otherwise: bb13];
++     bb13 (cleanup): {
++         switchInt(copy _8) -> [0: bb10, otherwise: bb12];
       }
   }
   

--- a/tests/mir-opt/tail_call_drops.f.ElaborateDrops.panic-unwind.diff
+++ b/tests/mir-opt/tail_call_drops.f.ElaborateDrops.panic-unwind.diff
@@ -66,6 +66,7 @@
       bb6: {
 +         _8 = const false;
           StorageDead(_4);
+          StorageDead(_3);
 -         drop(_2) -> [return: bb7, unwind continue];
 +         drop(_2) -> [return: bb7, unwind: bb12];
       }

--- a/tests/mir-opt/tail_call_drops.f.ElaborateDrops.panic-unwind.diff
+++ b/tests/mir-opt/tail_call_drops.f.ElaborateDrops.panic-unwind.diff
@@ -34,13 +34,13 @@
           StorageLive(_3);
           _3 = const 12_i32;
           StorageLive(_4);
-          _4 = String::new() -> [return: bb2, unwind: bb11];
+          _4 = String::new() -> [return: bb2, unwind: bb10];
       }
   
       bb2: {
 +         _8 = const true;
           StorageLive(_5);
-          _5 = String::new() -> [return: bb3, unwind: bb10];
+          _5 = String::new() -> [return: bb3, unwind: bb9];
       }
   
       bb3: {
@@ -54,12 +54,12 @@
       bb4: {
           StorageDead(_7);
           StorageDead(_6);
-          drop(_5) -> [return: bb5, unwind: bb10];
+          drop(_5) -> [return: bb5, unwind: bb9];
       }
   
       bb5: {
           StorageDead(_5);
--         drop(_4) -> [return: bb6, unwind: bb11];
+-         drop(_4) -> [return: bb6, unwind: bb10];
 +         goto -> bb6;
       }
   
@@ -68,7 +68,7 @@
           StorageDead(_4);
           StorageDead(_3);
 -         drop(_2) -> [return: bb7, unwind continue];
-+         drop(_2) -> [return: bb7, unwind: bb12];
++         drop(_2) -> [return: bb7, unwind: bb11];
       }
   
       bb7: {
@@ -77,33 +77,28 @@
       }
   
       bb8 (cleanup): {
--         drop(_7) -> [return: bb9, unwind terminate(cleanup)];
-+         goto -> bb9;
+          drop(_5) -> [return: bb9, unwind terminate(cleanup)];
       }
   
       bb9 (cleanup): {
-          drop(_5) -> [return: bb10, unwind terminate(cleanup)];
+-         drop(_4) -> [return: bb10, unwind terminate(cleanup)];
++         goto -> bb13;
       }
   
       bb10 (cleanup): {
--         drop(_4) -> [return: bb11, unwind terminate(cleanup)];
-+         goto -> bb14;
+          drop(_2) -> [return: bb11, unwind terminate(cleanup)];
       }
   
       bb11 (cleanup): {
-          drop(_2) -> [return: bb12, unwind terminate(cleanup)];
-      }
-  
-      bb12 (cleanup): {
           resume;
 +     }
 + 
-+     bb13 (cleanup): {
-+         drop(_4) -> [return: bb11, unwind terminate(cleanup)];
++     bb12 (cleanup): {
++         drop(_4) -> [return: bb10, unwind terminate(cleanup)];
 +     }
 + 
-+     bb14 (cleanup): {
-+         switchInt(copy _8) -> [0: bb11, otherwise: bb13];
++     bb13 (cleanup): {
++         switchInt(copy _8) -> [0: bb10, otherwise: bb12];
       }
   }
   

--- a/tests/mir-opt/tail_call_drops.f.built.after.panic-abort.mir
+++ b/tests/mir-opt/tail_call_drops.f.built.after.panic-abort.mir
@@ -24,7 +24,7 @@ fn f() -> () {
 
     bb0: {
         StorageLive(_2);
-        _2 = String::new() -> [return: bb1, unwind: bb24];
+        _2 = String::new() -> [return: bb1, unwind: bb23];
     }
 
     bb1: {
@@ -33,13 +33,13 @@ fn f() -> () {
         _3 = const 12_i32;
         FakeRead(ForLet(None), _3);
         StorageLive(_4);
-        _4 = String::new() -> [return: bb2, unwind: bb23];
+        _4 = String::new() -> [return: bb2, unwind: bb22];
     }
 
     bb2: {
         FakeRead(ForLet(None), _4);
         StorageLive(_5);
-        _5 = String::new() -> [return: bb3, unwind: bb22];
+        _5 = String::new() -> [return: bb3, unwind: bb21];
     }
 
     bb3: {
@@ -65,18 +65,18 @@ fn f() -> () {
     }
 
     bb7: {
-        drop(_5) -> [return: bb8, unwind: bb22];
+        drop(_5) -> [return: bb8, unwind: bb21];
     }
 
     bb8: {
         StorageDead(_5);
-        drop(_4) -> [return: bb9, unwind: bb23];
+        drop(_4) -> [return: bb9, unwind: bb22];
     }
 
     bb9: {
         StorageDead(_4);
         StorageDead(_3);
-        drop(_2) -> [return: bb10, unwind: bb24];
+        drop(_2) -> [return: bb10, unwind: bb23];
     }
 
     bb10: {
@@ -89,7 +89,7 @@ fn f() -> () {
     }
 
     bb12: {
-        drop(_5) -> [return: bb13, unwind: bb22];
+        drop(_5) -> [return: bb13, unwind: bb21];
     }
 
     bb13: {
@@ -98,7 +98,7 @@ fn f() -> () {
     }
 
     bb14: {
-        drop(_4) -> [return: bb15, unwind: bb23];
+        drop(_4) -> [return: bb15, unwind: bb22];
     }
 
     bb15: {
@@ -112,7 +112,7 @@ fn f() -> () {
     }
 
     bb17: {
-        drop(_2) -> [return: bb18, unwind: bb24];
+        drop(_2) -> [return: bb18, unwind: bb23];
     }
 
     bb18: {
@@ -125,22 +125,18 @@ fn f() -> () {
     }
 
     bb20 (cleanup): {
-        drop(_7) -> [return: bb21, unwind terminate(cleanup)];
+        drop(_5) -> [return: bb21, unwind terminate(cleanup)];
     }
 
     bb21 (cleanup): {
-        drop(_5) -> [return: bb22, unwind terminate(cleanup)];
+        drop(_4) -> [return: bb22, unwind terminate(cleanup)];
     }
 
     bb22 (cleanup): {
-        drop(_4) -> [return: bb23, unwind terminate(cleanup)];
+        drop(_2) -> [return: bb23, unwind terminate(cleanup)];
     }
 
     bb23 (cleanup): {
-        drop(_2) -> [return: bb24, unwind terminate(cleanup)];
-    }
-
-    bb24 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/tail_call_drops.f.built.after.panic-abort.mir
+++ b/tests/mir-opt/tail_call_drops.f.built.after.panic-abort.mir
@@ -24,7 +24,7 @@ fn f() -> () {
 
     bb0: {
         StorageLive(_2);
-        _2 = String::new() -> [return: bb1, unwind: bb17];
+        _2 = String::new() -> [return: bb1, unwind: bb23];
     }
 
     bb1: {
@@ -33,13 +33,13 @@ fn f() -> () {
         _3 = const 12_i32;
         FakeRead(ForLet(None), _3);
         StorageLive(_4);
-        _4 = String::new() -> [return: bb2, unwind: bb16];
+        _4 = String::new() -> [return: bb2, unwind: bb22];
     }
 
     bb2: {
         FakeRead(ForLet(None), _4);
         StorageLive(_5);
-        _5 = String::new() -> [return: bb3, unwind: bb15];
+        _5 = String::new() -> [return: bb3, unwind: bb21];
     }
 
     bb3: {
@@ -47,71 +47,95 @@ fn f() -> () {
         StorageLive(_6);
         StorageLive(_7);
         _7 = move _4;
-        _6 = std::mem::drop::<String>(move _7) -> [return: bb4, unwind: bb13];
+        _6 = std::mem::drop::<String>(move _7) -> [return: bb4, unwind: bb19];
     }
 
     bb4: {
-        StorageDead(_7);
-        StorageDead(_6);
-        drop(_5) -> [return: bb5, unwind: bb15];
+        goto -> bb5;
     }
 
     bb5: {
-        StorageDead(_5);
-        drop(_4) -> [return: bb6, unwind: bb16];
+        StorageDead(_7);
+        goto -> bb6;
     }
 
     bb6: {
-        StorageDead(_4);
-        drop(_2) -> [return: bb7, unwind: bb17];
+        StorageDead(_6);
+        drop(_5) -> [return: bb7, unwind: bb21];
     }
 
     bb7: {
+        StorageDead(_5);
+        drop(_4) -> [return: bb8, unwind: bb22];
+    }
+
+    bb8: {
+        StorageDead(_4);
+        drop(_2) -> [return: bb9, unwind: bb23];
+    }
+
+    bb9: {
         StorageDead(_2);
         tailcall g();
     }
 
-    bb8: {
-        drop(_5) -> [return: bb9, unwind: bb15];
-    }
-
-    bb9: {
-        StorageDead(_5);
-        drop(_4) -> [return: bb10, unwind: bb16];
-    }
-
     bb10: {
-        StorageDead(_4);
-        StorageDead(_3);
-        drop(_2) -> [return: bb11, unwind: bb17];
+        goto -> bb11;
     }
 
     bb11: {
+        drop(_5) -> [return: bb12, unwind: bb21];
+    }
+
+    bb12: {
+        StorageDead(_5);
+        goto -> bb13;
+    }
+
+    bb13: {
+        drop(_4) -> [return: bb14, unwind: bb22];
+    }
+
+    bb14: {
+        StorageDead(_4);
+        goto -> bb15;
+    }
+
+    bb15: {
+        StorageDead(_3);
+        goto -> bb16;
+    }
+
+    bb16: {
+        drop(_2) -> [return: bb17, unwind: bb23];
+    }
+
+    bb17: {
         StorageDead(_2);
         unreachable;
     }
 
-    bb12: {
+    bb18: {
         return;
     }
 
-    bb13 (cleanup): {
-        drop(_7) -> [return: bb14, unwind terminate(cleanup)];
+    bb19 (cleanup): {
+        drop(_7) -> [return: bb20, unwind terminate(cleanup)];
     }
 
-    bb14 (cleanup): {
-        drop(_5) -> [return: bb15, unwind terminate(cleanup)];
+    bb20 (cleanup): {
+        drop(_5) -> [return: bb21, unwind terminate(cleanup)];
     }
 
-    bb15 (cleanup): {
-        drop(_4) -> [return: bb16, unwind terminate(cleanup)];
+    bb21 (cleanup): {
+        drop(_4) -> [return: bb22, unwind terminate(cleanup)];
     }
 
-    bb16 (cleanup): {
-        drop(_2) -> [return: bb17, unwind terminate(cleanup)];
+    bb22 (cleanup): {
+        drop(_2) -> [return: bb23, unwind terminate(cleanup)];
     }
 
-    bb17 (cleanup): {
+    bb23 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/tail_call_drops.f.built.after.panic-abort.mir
+++ b/tests/mir-opt/tail_call_drops.f.built.after.panic-abort.mir
@@ -24,7 +24,7 @@ fn f() -> () {
 
     bb0: {
         StorageLive(_2);
-        _2 = String::new() -> [return: bb1, unwind: bb23];
+        _2 = String::new() -> [return: bb1, unwind: bb24];
     }
 
     bb1: {
@@ -33,13 +33,13 @@ fn f() -> () {
         _3 = const 12_i32;
         FakeRead(ForLet(None), _3);
         StorageLive(_4);
-        _4 = String::new() -> [return: bb2, unwind: bb22];
+        _4 = String::new() -> [return: bb2, unwind: bb23];
     }
 
     bb2: {
         FakeRead(ForLet(None), _4);
         StorageLive(_5);
-        _5 = String::new() -> [return: bb3, unwind: bb21];
+        _5 = String::new() -> [return: bb3, unwind: bb22];
     }
 
     bb3: {
@@ -47,7 +47,7 @@ fn f() -> () {
         StorageLive(_6);
         StorageLive(_7);
         _7 = move _4;
-        _6 = std::mem::drop::<String>(move _7) -> [return: bb4, unwind: bb19];
+        _6 = std::mem::drop::<String>(move _7) -> [return: bb4, unwind: bb20];
     }
 
     bb4: {
@@ -61,81 +61,86 @@ fn f() -> () {
 
     bb6: {
         StorageDead(_6);
-        drop(_5) -> [return: bb7, unwind: bb21];
+        goto -> bb7;
     }
 
     bb7: {
-        StorageDead(_5);
-        drop(_4) -> [return: bb8, unwind: bb22];
+        drop(_5) -> [return: bb8, unwind: bb22];
     }
 
     bb8: {
-        StorageDead(_4);
-        drop(_2) -> [return: bb9, unwind: bb23];
+        StorageDead(_5);
+        drop(_4) -> [return: bb9, unwind: bb23];
     }
 
     bb9: {
+        StorageDead(_4);
+        StorageDead(_3);
+        drop(_2) -> [return: bb10, unwind: bb24];
+    }
+
+    bb10: {
         StorageDead(_2);
         tailcall g();
     }
 
-    bb10: {
-        goto -> bb11;
-    }
-
     bb11: {
-        drop(_5) -> [return: bb12, unwind: bb21];
+        goto -> bb12;
     }
 
     bb12: {
-        StorageDead(_5);
-        goto -> bb13;
+        drop(_5) -> [return: bb13, unwind: bb22];
     }
 
     bb13: {
-        drop(_4) -> [return: bb14, unwind: bb22];
+        StorageDead(_5);
+        goto -> bb14;
     }
 
     bb14: {
-        StorageDead(_4);
-        goto -> bb15;
+        drop(_4) -> [return: bb15, unwind: bb23];
     }
 
     bb15: {
-        StorageDead(_3);
+        StorageDead(_4);
         goto -> bb16;
     }
 
     bb16: {
-        drop(_2) -> [return: bb17, unwind: bb23];
+        StorageDead(_3);
+        goto -> bb17;
     }
 
     bb17: {
+        drop(_2) -> [return: bb18, unwind: bb24];
+    }
+
+    bb18: {
         StorageDead(_2);
         unreachable;
     }
 
-    bb18: {
+    bb19: {
         return;
     }
 
-    bb19 (cleanup): {
-        drop(_7) -> [return: bb20, unwind terminate(cleanup)];
-    }
-
     bb20 (cleanup): {
-        drop(_5) -> [return: bb21, unwind terminate(cleanup)];
+        drop(_7) -> [return: bb21, unwind terminate(cleanup)];
     }
 
     bb21 (cleanup): {
-        drop(_4) -> [return: bb22, unwind terminate(cleanup)];
+        drop(_5) -> [return: bb22, unwind terminate(cleanup)];
     }
 
     bb22 (cleanup): {
-        drop(_2) -> [return: bb23, unwind terminate(cleanup)];
+        drop(_4) -> [return: bb23, unwind terminate(cleanup)];
     }
 
     bb23 (cleanup): {
+        drop(_2) -> [return: bb24, unwind terminate(cleanup)];
+    }
+
+    bb24 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/tail_call_drops.f.built.after.panic-unwind.mir
+++ b/tests/mir-opt/tail_call_drops.f.built.after.panic-unwind.mir
@@ -24,7 +24,7 @@ fn f() -> () {
 
     bb0: {
         StorageLive(_2);
-        _2 = String::new() -> [return: bb1, unwind: bb24];
+        _2 = String::new() -> [return: bb1, unwind: bb23];
     }
 
     bb1: {
@@ -33,13 +33,13 @@ fn f() -> () {
         _3 = const 12_i32;
         FakeRead(ForLet(None), _3);
         StorageLive(_4);
-        _4 = String::new() -> [return: bb2, unwind: bb23];
+        _4 = String::new() -> [return: bb2, unwind: bb22];
     }
 
     bb2: {
         FakeRead(ForLet(None), _4);
         StorageLive(_5);
-        _5 = String::new() -> [return: bb3, unwind: bb22];
+        _5 = String::new() -> [return: bb3, unwind: bb21];
     }
 
     bb3: {
@@ -65,18 +65,18 @@ fn f() -> () {
     }
 
     bb7: {
-        drop(_5) -> [return: bb8, unwind: bb22];
+        drop(_5) -> [return: bb8, unwind: bb21];
     }
 
     bb8: {
         StorageDead(_5);
-        drop(_4) -> [return: bb9, unwind: bb23];
+        drop(_4) -> [return: bb9, unwind: bb22];
     }
 
     bb9: {
         StorageDead(_4);
         StorageDead(_3);
-        drop(_2) -> [return: bb10, unwind: bb24];
+        drop(_2) -> [return: bb10, unwind: bb23];
     }
 
     bb10: {
@@ -89,7 +89,7 @@ fn f() -> () {
     }
 
     bb12: {
-        drop(_5) -> [return: bb13, unwind: bb22];
+        drop(_5) -> [return: bb13, unwind: bb21];
     }
 
     bb13: {
@@ -98,7 +98,7 @@ fn f() -> () {
     }
 
     bb14: {
-        drop(_4) -> [return: bb15, unwind: bb23];
+        drop(_4) -> [return: bb15, unwind: bb22];
     }
 
     bb15: {
@@ -112,7 +112,7 @@ fn f() -> () {
     }
 
     bb17: {
-        drop(_2) -> [return: bb18, unwind: bb24];
+        drop(_2) -> [return: bb18, unwind: bb23];
     }
 
     bb18: {
@@ -125,22 +125,18 @@ fn f() -> () {
     }
 
     bb20 (cleanup): {
-        drop(_7) -> [return: bb21, unwind terminate(cleanup)];
+        drop(_5) -> [return: bb21, unwind terminate(cleanup)];
     }
 
     bb21 (cleanup): {
-        drop(_5) -> [return: bb22, unwind terminate(cleanup)];
+        drop(_4) -> [return: bb22, unwind terminate(cleanup)];
     }
 
     bb22 (cleanup): {
-        drop(_4) -> [return: bb23, unwind terminate(cleanup)];
+        drop(_2) -> [return: bb23, unwind terminate(cleanup)];
     }
 
     bb23 (cleanup): {
-        drop(_2) -> [return: bb24, unwind terminate(cleanup)];
-    }
-
-    bb24 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/tail_call_drops.f.built.after.panic-unwind.mir
+++ b/tests/mir-opt/tail_call_drops.f.built.after.panic-unwind.mir
@@ -24,7 +24,7 @@ fn f() -> () {
 
     bb0: {
         StorageLive(_2);
-        _2 = String::new() -> [return: bb1, unwind: bb17];
+        _2 = String::new() -> [return: bb1, unwind: bb23];
     }
 
     bb1: {
@@ -33,13 +33,13 @@ fn f() -> () {
         _3 = const 12_i32;
         FakeRead(ForLet(None), _3);
         StorageLive(_4);
-        _4 = String::new() -> [return: bb2, unwind: bb16];
+        _4 = String::new() -> [return: bb2, unwind: bb22];
     }
 
     bb2: {
         FakeRead(ForLet(None), _4);
         StorageLive(_5);
-        _5 = String::new() -> [return: bb3, unwind: bb15];
+        _5 = String::new() -> [return: bb3, unwind: bb21];
     }
 
     bb3: {
@@ -47,71 +47,95 @@ fn f() -> () {
         StorageLive(_6);
         StorageLive(_7);
         _7 = move _4;
-        _6 = std::mem::drop::<String>(move _7) -> [return: bb4, unwind: bb13];
+        _6 = std::mem::drop::<String>(move _7) -> [return: bb4, unwind: bb19];
     }
 
     bb4: {
-        StorageDead(_7);
-        StorageDead(_6);
-        drop(_5) -> [return: bb5, unwind: bb15];
+        goto -> bb5;
     }
 
     bb5: {
-        StorageDead(_5);
-        drop(_4) -> [return: bb6, unwind: bb16];
+        StorageDead(_7);
+        goto -> bb6;
     }
 
     bb6: {
-        StorageDead(_4);
-        drop(_2) -> [return: bb7, unwind: bb17];
+        StorageDead(_6);
+        drop(_5) -> [return: bb7, unwind: bb21];
     }
 
     bb7: {
+        StorageDead(_5);
+        drop(_4) -> [return: bb8, unwind: bb22];
+    }
+
+    bb8: {
+        StorageDead(_4);
+        drop(_2) -> [return: bb9, unwind: bb23];
+    }
+
+    bb9: {
         StorageDead(_2);
         tailcall g();
     }
 
-    bb8: {
-        drop(_5) -> [return: bb9, unwind: bb15];
-    }
-
-    bb9: {
-        StorageDead(_5);
-        drop(_4) -> [return: bb10, unwind: bb16];
-    }
-
     bb10: {
-        StorageDead(_4);
-        StorageDead(_3);
-        drop(_2) -> [return: bb11, unwind: bb17];
+        goto -> bb11;
     }
 
     bb11: {
+        drop(_5) -> [return: bb12, unwind: bb21];
+    }
+
+    bb12: {
+        StorageDead(_5);
+        goto -> bb13;
+    }
+
+    bb13: {
+        drop(_4) -> [return: bb14, unwind: bb22];
+    }
+
+    bb14: {
+        StorageDead(_4);
+        goto -> bb15;
+    }
+
+    bb15: {
+        StorageDead(_3);
+        goto -> bb16;
+    }
+
+    bb16: {
+        drop(_2) -> [return: bb17, unwind: bb23];
+    }
+
+    bb17: {
         StorageDead(_2);
         unreachable;
     }
 
-    bb12: {
+    bb18: {
         return;
     }
 
-    bb13 (cleanup): {
-        drop(_7) -> [return: bb14, unwind terminate(cleanup)];
+    bb19 (cleanup): {
+        drop(_7) -> [return: bb20, unwind terminate(cleanup)];
     }
 
-    bb14 (cleanup): {
-        drop(_5) -> [return: bb15, unwind terminate(cleanup)];
+    bb20 (cleanup): {
+        drop(_5) -> [return: bb21, unwind terminate(cleanup)];
     }
 
-    bb15 (cleanup): {
-        drop(_4) -> [return: bb16, unwind terminate(cleanup)];
+    bb21 (cleanup): {
+        drop(_4) -> [return: bb22, unwind terminate(cleanup)];
     }
 
-    bb16 (cleanup): {
-        drop(_2) -> [return: bb17, unwind terminate(cleanup)];
+    bb22 (cleanup): {
+        drop(_2) -> [return: bb23, unwind terminate(cleanup)];
     }
 
-    bb17 (cleanup): {
+    bb23 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/tail_call_drops.f.built.after.panic-unwind.mir
+++ b/tests/mir-opt/tail_call_drops.f.built.after.panic-unwind.mir
@@ -24,7 +24,7 @@ fn f() -> () {
 
     bb0: {
         StorageLive(_2);
-        _2 = String::new() -> [return: bb1, unwind: bb23];
+        _2 = String::new() -> [return: bb1, unwind: bb24];
     }
 
     bb1: {
@@ -33,13 +33,13 @@ fn f() -> () {
         _3 = const 12_i32;
         FakeRead(ForLet(None), _3);
         StorageLive(_4);
-        _4 = String::new() -> [return: bb2, unwind: bb22];
+        _4 = String::new() -> [return: bb2, unwind: bb23];
     }
 
     bb2: {
         FakeRead(ForLet(None), _4);
         StorageLive(_5);
-        _5 = String::new() -> [return: bb3, unwind: bb21];
+        _5 = String::new() -> [return: bb3, unwind: bb22];
     }
 
     bb3: {
@@ -47,7 +47,7 @@ fn f() -> () {
         StorageLive(_6);
         StorageLive(_7);
         _7 = move _4;
-        _6 = std::mem::drop::<String>(move _7) -> [return: bb4, unwind: bb19];
+        _6 = std::mem::drop::<String>(move _7) -> [return: bb4, unwind: bb20];
     }
 
     bb4: {
@@ -61,81 +61,86 @@ fn f() -> () {
 
     bb6: {
         StorageDead(_6);
-        drop(_5) -> [return: bb7, unwind: bb21];
+        goto -> bb7;
     }
 
     bb7: {
-        StorageDead(_5);
-        drop(_4) -> [return: bb8, unwind: bb22];
+        drop(_5) -> [return: bb8, unwind: bb22];
     }
 
     bb8: {
-        StorageDead(_4);
-        drop(_2) -> [return: bb9, unwind: bb23];
+        StorageDead(_5);
+        drop(_4) -> [return: bb9, unwind: bb23];
     }
 
     bb9: {
+        StorageDead(_4);
+        StorageDead(_3);
+        drop(_2) -> [return: bb10, unwind: bb24];
+    }
+
+    bb10: {
         StorageDead(_2);
         tailcall g();
     }
 
-    bb10: {
-        goto -> bb11;
-    }
-
     bb11: {
-        drop(_5) -> [return: bb12, unwind: bb21];
+        goto -> bb12;
     }
 
     bb12: {
-        StorageDead(_5);
-        goto -> bb13;
+        drop(_5) -> [return: bb13, unwind: bb22];
     }
 
     bb13: {
-        drop(_4) -> [return: bb14, unwind: bb22];
+        StorageDead(_5);
+        goto -> bb14;
     }
 
     bb14: {
-        StorageDead(_4);
-        goto -> bb15;
+        drop(_4) -> [return: bb15, unwind: bb23];
     }
 
     bb15: {
-        StorageDead(_3);
+        StorageDead(_4);
         goto -> bb16;
     }
 
     bb16: {
-        drop(_2) -> [return: bb17, unwind: bb23];
+        StorageDead(_3);
+        goto -> bb17;
     }
 
     bb17: {
+        drop(_2) -> [return: bb18, unwind: bb24];
+    }
+
+    bb18: {
         StorageDead(_2);
         unreachable;
     }
 
-    bb18: {
+    bb19: {
         return;
     }
 
-    bb19 (cleanup): {
-        drop(_7) -> [return: bb20, unwind terminate(cleanup)];
-    }
-
     bb20 (cleanup): {
-        drop(_5) -> [return: bb21, unwind terminate(cleanup)];
+        drop(_7) -> [return: bb21, unwind terminate(cleanup)];
     }
 
     bb21 (cleanup): {
-        drop(_4) -> [return: bb22, unwind terminate(cleanup)];
+        drop(_5) -> [return: bb22, unwind terminate(cleanup)];
     }
 
     bb22 (cleanup): {
-        drop(_2) -> [return: bb23, unwind terminate(cleanup)];
+        drop(_4) -> [return: bb23, unwind terminate(cleanup)];
     }
 
     bb23 (cleanup): {
+        drop(_2) -> [return: bb24, unwind terminate(cleanup)];
+    }
+
+    bb24 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/tail_call_drops.f_with_arg.ElaborateDrops.panic-abort.diff
+++ b/tests/mir-opt/tail_call_drops.f_with_arg.ElaborateDrops.panic-abort.diff
@@ -31,20 +31,20 @@
       bb0: {
 +         _12 = const false;
           StorageLive(_4);
-          _4 = String::new() -> [return: bb1, unwind: bb27];
+          _4 = String::new() -> [return: bb1, unwind: bb26];
       }
   
       bb1: {
           StorageLive(_5);
           _5 = const 12_i32;
           StorageLive(_6);
-          _6 = String::new() -> [return: bb2, unwind: bb26];
+          _6 = String::new() -> [return: bb2, unwind: bb25];
       }
   
       bb2: {
 +         _12 = const true;
           StorageLive(_7);
-          _7 = String::new() -> [return: bb3, unwind: bb25];
+          _7 = String::new() -> [return: bb3, unwind: bb24];
       }
   
       bb3: {
@@ -59,7 +59,7 @@
           StorageDead(_9);
           StorageDead(_8);
           StorageLive(_10);
-          _10 = String::new() -> [return: bb5, unwind: bb24];
+          _10 = String::new() -> [return: bb5, unwind: bb23];
       }
   
       bb5: {
@@ -102,7 +102,7 @@
       }
   
       bb13 (cleanup): {
-          drop(_11) -> [return: bb25, unwind terminate(cleanup)];
+          drop(_11) -> [return: bb24, unwind terminate(cleanup)];
       }
   
       bb14 (cleanup): {
@@ -111,8 +111,8 @@
       }
   
       bb15 (cleanup): {
--         drop(_11) -> [return: bb26, unwind terminate(cleanup)];
-+         goto -> bb26;
+-         drop(_11) -> [return: bb25, unwind terminate(cleanup)];
++         goto -> bb25;
       }
   
       bb16 (cleanup): {
@@ -120,7 +120,7 @@
       }
   
       bb17 (cleanup): {
-          drop(_11) -> [return: bb27, unwind terminate(cleanup)];
+          drop(_11) -> [return: bb26, unwind terminate(cleanup)];
       }
   
       bb18 (cleanup): {
@@ -128,7 +128,7 @@
       }
   
       bb19 (cleanup): {
-          drop(_11) -> [return: bb28, unwind terminate(cleanup)];
+          drop(_11) -> [return: bb27, unwind terminate(cleanup)];
       }
   
       bb20 (cleanup): {
@@ -136,49 +136,44 @@
       }
   
       bb21 (cleanup): {
-          drop(_11) -> [return: bb29, unwind terminate(cleanup)];
+          drop(_11) -> [return: bb28, unwind terminate(cleanup)];
       }
   
       bb22 (cleanup): {
-          drop(_10) -> [return: bb24, unwind terminate(cleanup)];
+          drop(_10) -> [return: bb23, unwind terminate(cleanup)];
       }
   
       bb23 (cleanup): {
--         drop(_9) -> [return: bb24, unwind terminate(cleanup)];
-+         goto -> bb24;
+          drop(_7) -> [return: bb24, unwind terminate(cleanup)];
       }
   
       bb24 (cleanup): {
-          drop(_7) -> [return: bb25, unwind terminate(cleanup)];
+-         drop(_6) -> [return: bb25, unwind terminate(cleanup)];
++         goto -> bb30;
       }
   
       bb25 (cleanup): {
--         drop(_6) -> [return: bb26, unwind terminate(cleanup)];
-+         goto -> bb31;
+          drop(_4) -> [return: bb26, unwind terminate(cleanup)];
       }
   
       bb26 (cleanup): {
-          drop(_4) -> [return: bb27, unwind terminate(cleanup)];
+          drop(_2) -> [return: bb27, unwind terminate(cleanup)];
       }
   
       bb27 (cleanup): {
-          drop(_2) -> [return: bb28, unwind terminate(cleanup)];
+          drop(_1) -> [return: bb28, unwind terminate(cleanup)];
       }
   
       bb28 (cleanup): {
-          drop(_1) -> [return: bb29, unwind terminate(cleanup)];
-      }
-  
-      bb29 (cleanup): {
           resume;
 +     }
 + 
-+     bb30 (cleanup): {
-+         drop(_6) -> [return: bb26, unwind terminate(cleanup)];
++     bb29 (cleanup): {
++         drop(_6) -> [return: bb25, unwind terminate(cleanup)];
 +     }
 + 
-+     bb31 (cleanup): {
-+         switchInt(copy _12) -> [0: bb26, otherwise: bb30];
++     bb30 (cleanup): {
++         switchInt(copy _12) -> [0: bb25, otherwise: bb29];
       }
   }
   

--- a/tests/mir-opt/tail_call_drops.f_with_arg.ElaborateDrops.panic-abort.diff
+++ b/tests/mir-opt/tail_call_drops.f_with_arg.ElaborateDrops.panic-abort.diff
@@ -68,28 +68,29 @@
       }
   
       bb6: {
-          drop(_7) -> [return: bb7, unwind: bb20];
+          drop(_7) -> [return: bb7, unwind: bb12];
       }
   
       bb7: {
           StorageDead(_7);
--         drop(_6) -> [return: bb8, unwind: bb18];
+-         drop(_6) -> [return: bb8, unwind: bb14];
 +         goto -> bb8;
       }
   
       bb8: {
 +         _12 = const false;
           StorageDead(_6);
+          StorageDead(_5);
           drop(_4) -> [return: bb9, unwind: bb16];
       }
   
       bb9: {
           StorageDead(_4);
-          drop(_2) -> [return: bb10, unwind: bb14];
+          drop(_2) -> [return: bb10, unwind: bb18];
       }
   
       bb10: {
-          drop(_1) -> [return: bb11, unwind: bb12];
+          drop(_1) -> [return: bb11, unwind: bb20];
       }
   
       bb11: {
@@ -101,15 +102,17 @@
       }
   
       bb13 (cleanup): {
-          drop(_11) -> [return: bb29, unwind terminate(cleanup)];
+          drop(_11) -> [return: bb25, unwind terminate(cleanup)];
       }
   
       bb14 (cleanup): {
-          drop(_10) -> [return: bb15, unwind terminate(cleanup)];
+-         drop(_10) -> [return: bb15, unwind terminate(cleanup)];
++         goto -> bb15;
       }
   
       bb15 (cleanup): {
-          drop(_11) -> [return: bb28, unwind terminate(cleanup)];
+-         drop(_11) -> [return: bb26, unwind terminate(cleanup)];
++         goto -> bb26;
       }
   
       bb16 (cleanup): {
@@ -121,13 +124,11 @@
       }
   
       bb18 (cleanup): {
--         drop(_10) -> [return: bb19, unwind terminate(cleanup)];
-+         goto -> bb19;
+          drop(_10) -> [return: bb19, unwind terminate(cleanup)];
       }
   
       bb19 (cleanup): {
--         drop(_11) -> [return: bb26, unwind terminate(cleanup)];
-+         goto -> bb26;
+          drop(_11) -> [return: bb28, unwind terminate(cleanup)];
       }
   
       bb20 (cleanup): {
@@ -135,7 +136,7 @@
       }
   
       bb21 (cleanup): {
-          drop(_11) -> [return: bb25, unwind terminate(cleanup)];
+          drop(_11) -> [return: bb29, unwind terminate(cleanup)];
       }
   
       bb22 (cleanup): {

--- a/tests/mir-opt/tail_call_drops.f_with_arg.ElaborateDrops.panic-unwind.diff
+++ b/tests/mir-opt/tail_call_drops.f_with_arg.ElaborateDrops.panic-unwind.diff
@@ -31,20 +31,20 @@
       bb0: {
 +         _12 = const false;
           StorageLive(_4);
-          _4 = String::new() -> [return: bb1, unwind: bb27];
+          _4 = String::new() -> [return: bb1, unwind: bb26];
       }
   
       bb1: {
           StorageLive(_5);
           _5 = const 12_i32;
           StorageLive(_6);
-          _6 = String::new() -> [return: bb2, unwind: bb26];
+          _6 = String::new() -> [return: bb2, unwind: bb25];
       }
   
       bb2: {
 +         _12 = const true;
           StorageLive(_7);
-          _7 = String::new() -> [return: bb3, unwind: bb25];
+          _7 = String::new() -> [return: bb3, unwind: bb24];
       }
   
       bb3: {
@@ -59,7 +59,7 @@
           StorageDead(_9);
           StorageDead(_8);
           StorageLive(_10);
-          _10 = String::new() -> [return: bb5, unwind: bb24];
+          _10 = String::new() -> [return: bb5, unwind: bb23];
       }
   
       bb5: {
@@ -102,7 +102,7 @@
       }
   
       bb13 (cleanup): {
-          drop(_11) -> [return: bb25, unwind terminate(cleanup)];
+          drop(_11) -> [return: bb24, unwind terminate(cleanup)];
       }
   
       bb14 (cleanup): {
@@ -111,8 +111,8 @@
       }
   
       bb15 (cleanup): {
--         drop(_11) -> [return: bb26, unwind terminate(cleanup)];
-+         goto -> bb26;
+-         drop(_11) -> [return: bb25, unwind terminate(cleanup)];
++         goto -> bb25;
       }
   
       bb16 (cleanup): {
@@ -120,7 +120,7 @@
       }
   
       bb17 (cleanup): {
-          drop(_11) -> [return: bb27, unwind terminate(cleanup)];
+          drop(_11) -> [return: bb26, unwind terminate(cleanup)];
       }
   
       bb18 (cleanup): {
@@ -128,7 +128,7 @@
       }
   
       bb19 (cleanup): {
-          drop(_11) -> [return: bb28, unwind terminate(cleanup)];
+          drop(_11) -> [return: bb27, unwind terminate(cleanup)];
       }
   
       bb20 (cleanup): {
@@ -136,49 +136,44 @@
       }
   
       bb21 (cleanup): {
-          drop(_11) -> [return: bb29, unwind terminate(cleanup)];
+          drop(_11) -> [return: bb28, unwind terminate(cleanup)];
       }
   
       bb22 (cleanup): {
-          drop(_10) -> [return: bb24, unwind terminate(cleanup)];
+          drop(_10) -> [return: bb23, unwind terminate(cleanup)];
       }
   
       bb23 (cleanup): {
--         drop(_9) -> [return: bb24, unwind terminate(cleanup)];
-+         goto -> bb24;
+          drop(_7) -> [return: bb24, unwind terminate(cleanup)];
       }
   
       bb24 (cleanup): {
-          drop(_7) -> [return: bb25, unwind terminate(cleanup)];
+-         drop(_6) -> [return: bb25, unwind terminate(cleanup)];
++         goto -> bb30;
       }
   
       bb25 (cleanup): {
--         drop(_6) -> [return: bb26, unwind terminate(cleanup)];
-+         goto -> bb31;
+          drop(_4) -> [return: bb26, unwind terminate(cleanup)];
       }
   
       bb26 (cleanup): {
-          drop(_4) -> [return: bb27, unwind terminate(cleanup)];
+          drop(_2) -> [return: bb27, unwind terminate(cleanup)];
       }
   
       bb27 (cleanup): {
-          drop(_2) -> [return: bb28, unwind terminate(cleanup)];
+          drop(_1) -> [return: bb28, unwind terminate(cleanup)];
       }
   
       bb28 (cleanup): {
-          drop(_1) -> [return: bb29, unwind terminate(cleanup)];
-      }
-  
-      bb29 (cleanup): {
           resume;
 +     }
 + 
-+     bb30 (cleanup): {
-+         drop(_6) -> [return: bb26, unwind terminate(cleanup)];
++     bb29 (cleanup): {
++         drop(_6) -> [return: bb25, unwind terminate(cleanup)];
 +     }
 + 
-+     bb31 (cleanup): {
-+         switchInt(copy _12) -> [0: bb26, otherwise: bb30];
++     bb30 (cleanup): {
++         switchInt(copy _12) -> [0: bb25, otherwise: bb29];
       }
   }
   

--- a/tests/mir-opt/tail_call_drops.f_with_arg.ElaborateDrops.panic-unwind.diff
+++ b/tests/mir-opt/tail_call_drops.f_with_arg.ElaborateDrops.panic-unwind.diff
@@ -68,28 +68,29 @@
       }
   
       bb6: {
-          drop(_7) -> [return: bb7, unwind: bb20];
+          drop(_7) -> [return: bb7, unwind: bb12];
       }
   
       bb7: {
           StorageDead(_7);
--         drop(_6) -> [return: bb8, unwind: bb18];
+-         drop(_6) -> [return: bb8, unwind: bb14];
 +         goto -> bb8;
       }
   
       bb8: {
 +         _12 = const false;
           StorageDead(_6);
+          StorageDead(_5);
           drop(_4) -> [return: bb9, unwind: bb16];
       }
   
       bb9: {
           StorageDead(_4);
-          drop(_2) -> [return: bb10, unwind: bb14];
+          drop(_2) -> [return: bb10, unwind: bb18];
       }
   
       bb10: {
-          drop(_1) -> [return: bb11, unwind: bb12];
+          drop(_1) -> [return: bb11, unwind: bb20];
       }
   
       bb11: {
@@ -101,15 +102,17 @@
       }
   
       bb13 (cleanup): {
-          drop(_11) -> [return: bb29, unwind terminate(cleanup)];
+          drop(_11) -> [return: bb25, unwind terminate(cleanup)];
       }
   
       bb14 (cleanup): {
-          drop(_10) -> [return: bb15, unwind terminate(cleanup)];
+-         drop(_10) -> [return: bb15, unwind terminate(cleanup)];
++         goto -> bb15;
       }
   
       bb15 (cleanup): {
-          drop(_11) -> [return: bb28, unwind terminate(cleanup)];
+-         drop(_11) -> [return: bb26, unwind terminate(cleanup)];
++         goto -> bb26;
       }
   
       bb16 (cleanup): {
@@ -121,13 +124,11 @@
       }
   
       bb18 (cleanup): {
--         drop(_10) -> [return: bb19, unwind terminate(cleanup)];
-+         goto -> bb19;
+          drop(_10) -> [return: bb19, unwind terminate(cleanup)];
       }
   
       bb19 (cleanup): {
--         drop(_11) -> [return: bb26, unwind terminate(cleanup)];
-+         goto -> bb26;
+          drop(_11) -> [return: bb28, unwind terminate(cleanup)];
       }
   
       bb20 (cleanup): {
@@ -135,7 +136,7 @@
       }
   
       bb21 (cleanup): {
-          drop(_11) -> [return: bb25, unwind terminate(cleanup)];
+          drop(_11) -> [return: bb29, unwind terminate(cleanup)];
       }
   
       bb22 (cleanup): {

--- a/tests/mir-opt/tail_call_drops.f_with_arg.built.after.panic-abort.mir
+++ b/tests/mir-opt/tail_call_drops.f_with_arg.built.after.panic-abort.mir
@@ -28,7 +28,7 @@ fn f_with_arg(_1: String, _2: String) -> () {
 
     bb0: {
         StorageLive(_4);
-        _4 = String::new() -> [return: bb1, unwind: bb42];
+        _4 = String::new() -> [return: bb1, unwind: bb43];
     }
 
     bb1: {
@@ -37,13 +37,13 @@ fn f_with_arg(_1: String, _2: String) -> () {
         _5 = const 12_i32;
         FakeRead(ForLet(None), _5);
         StorageLive(_6);
-        _6 = String::new() -> [return: bb2, unwind: bb41];
+        _6 = String::new() -> [return: bb2, unwind: bb42];
     }
 
     bb2: {
         FakeRead(ForLet(None), _6);
         StorageLive(_7);
-        _7 = String::new() -> [return: bb3, unwind: bb40];
+        _7 = String::new() -> [return: bb3, unwind: bb41];
     }
 
     bb3: {
@@ -51,7 +51,7 @@ fn f_with_arg(_1: String, _2: String) -> () {
         StorageLive(_8);
         StorageLive(_9);
         _9 = move _6;
-        _8 = std::mem::drop::<String>(move _9) -> [return: bb4, unwind: bb38];
+        _8 = std::mem::drop::<String>(move _9) -> [return: bb4, unwind: bb39];
     }
 
     bb4: {
@@ -66,168 +66,173 @@ fn f_with_arg(_1: String, _2: String) -> () {
     bb6: {
         StorageDead(_8);
         StorageLive(_10);
-        _10 = String::new() -> [return: bb7, unwind: bb39];
+        _10 = String::new() -> [return: bb7, unwind: bb40];
     }
 
     bb7: {
         StorageLive(_11);
-        _11 = String::new() -> [return: bb8, unwind: bb37];
+        _11 = String::new() -> [return: bb8, unwind: bb38];
     }
 
     bb8: {
-        drop(_7) -> [return: bb9, unwind: bb35];
+        goto -> bb9;
     }
 
     bb9: {
-        StorageDead(_7);
-        drop(_6) -> [return: bb10, unwind: bb33];
+        drop(_7) -> [return: bb10, unwind: bb28];
     }
 
     bb10: {
-        StorageDead(_6);
-        drop(_4) -> [return: bb11, unwind: bb31];
+        StorageDead(_7);
+        drop(_6) -> [return: bb11, unwind: bb30];
     }
 
     bb11: {
-        StorageDead(_4);
-        drop(_2) -> [return: bb12, unwind: bb29];
+        StorageDead(_6);
+        StorageDead(_5);
+        drop(_4) -> [return: bb12, unwind: bb32];
     }
 
     bb12: {
-        drop(_1) -> [return: bb13, unwind: bb27];
+        StorageDead(_4);
+        drop(_2) -> [return: bb13, unwind: bb34];
     }
 
     bb13: {
-        tailcall g_with_arg(move _10, move _11);
+        drop(_1) -> [return: bb14, unwind: bb36];
     }
 
     bb14: {
-        goto -> bb15;
+        tailcall g_with_arg(move _10, move _11);
     }
 
     bb15: {
-        StorageDead(_11);
-        StorageDead(_10);
         goto -> bb16;
     }
 
     bb16: {
-        drop(_7) -> [return: bb17, unwind: bb40];
+        StorageDead(_11);
+        StorageDead(_10);
+        goto -> bb17;
     }
 
     bb17: {
-        StorageDead(_7);
-        goto -> bb18;
+        drop(_7) -> [return: bb18, unwind: bb41];
     }
 
     bb18: {
-        drop(_6) -> [return: bb19, unwind: bb41];
+        StorageDead(_7);
+        goto -> bb19;
     }
 
     bb19: {
-        StorageDead(_6);
-        goto -> bb20;
+        drop(_6) -> [return: bb20, unwind: bb42];
     }
 
     bb20: {
-        StorageDead(_5);
+        StorageDead(_6);
         goto -> bb21;
     }
 
     bb21: {
-        drop(_4) -> [return: bb22, unwind: bb42];
+        StorageDead(_5);
+        goto -> bb22;
     }
 
     bb22: {
+        drop(_4) -> [return: bb23, unwind: bb43];
+    }
+
+    bb23: {
         StorageDead(_4);
         unreachable;
     }
 
-    bb23: {
-        goto -> bb24;
-    }
-
     bb24: {
-        drop(_2) -> [return: bb25, unwind: bb43];
+        goto -> bb25;
     }
 
     bb25: {
-        drop(_1) -> [return: bb26, unwind: bb44];
+        drop(_2) -> [return: bb26, unwind: bb44];
     }
 
     bb26: {
+        drop(_1) -> [return: bb27, unwind: bb45];
+    }
+
+    bb27: {
         return;
     }
 
-    bb27 (cleanup): {
-        drop(_10) -> [return: bb28, unwind terminate(cleanup)];
-    }
-
     bb28 (cleanup): {
-        drop(_11) -> [return: bb44, unwind terminate(cleanup)];
+        drop(_10) -> [return: bb29, unwind terminate(cleanup)];
     }
 
     bb29 (cleanup): {
-        drop(_10) -> [return: bb30, unwind terminate(cleanup)];
-    }
-
-    bb30 (cleanup): {
-        drop(_11) -> [return: bb43, unwind terminate(cleanup)];
-    }
-
-    bb31 (cleanup): {
-        drop(_10) -> [return: bb32, unwind terminate(cleanup)];
-    }
-
-    bb32 (cleanup): {
-        drop(_11) -> [return: bb42, unwind terminate(cleanup)];
-    }
-
-    bb33 (cleanup): {
-        drop(_10) -> [return: bb34, unwind terminate(cleanup)];
-    }
-
-    bb34 (cleanup): {
         drop(_11) -> [return: bb41, unwind terminate(cleanup)];
     }
 
+    bb30 (cleanup): {
+        drop(_10) -> [return: bb31, unwind terminate(cleanup)];
+    }
+
+    bb31 (cleanup): {
+        drop(_11) -> [return: bb42, unwind terminate(cleanup)];
+    }
+
+    bb32 (cleanup): {
+        drop(_10) -> [return: bb33, unwind terminate(cleanup)];
+    }
+
+    bb33 (cleanup): {
+        drop(_11) -> [return: bb43, unwind terminate(cleanup)];
+    }
+
+    bb34 (cleanup): {
+        drop(_10) -> [return: bb35, unwind terminate(cleanup)];
+    }
+
     bb35 (cleanup): {
-        drop(_10) -> [return: bb36, unwind terminate(cleanup)];
+        drop(_11) -> [return: bb44, unwind terminate(cleanup)];
     }
 
     bb36 (cleanup): {
-        drop(_11) -> [return: bb40, unwind terminate(cleanup)];
+        drop(_10) -> [return: bb37, unwind terminate(cleanup)];
     }
 
     bb37 (cleanup): {
-        drop(_10) -> [return: bb39, unwind terminate(cleanup)];
+        drop(_11) -> [return: bb45, unwind terminate(cleanup)];
     }
 
     bb38 (cleanup): {
-        drop(_9) -> [return: bb39, unwind terminate(cleanup)];
+        drop(_10) -> [return: bb40, unwind terminate(cleanup)];
     }
 
     bb39 (cleanup): {
-        drop(_7) -> [return: bb40, unwind terminate(cleanup)];
+        drop(_9) -> [return: bb40, unwind terminate(cleanup)];
     }
 
     bb40 (cleanup): {
-        drop(_6) -> [return: bb41, unwind terminate(cleanup)];
+        drop(_7) -> [return: bb41, unwind terminate(cleanup)];
     }
 
     bb41 (cleanup): {
-        drop(_4) -> [return: bb42, unwind terminate(cleanup)];
+        drop(_6) -> [return: bb42, unwind terminate(cleanup)];
     }
 
     bb42 (cleanup): {
-        drop(_2) -> [return: bb43, unwind terminate(cleanup)];
+        drop(_4) -> [return: bb43, unwind terminate(cleanup)];
     }
 
     bb43 (cleanup): {
-        drop(_1) -> [return: bb44, unwind terminate(cleanup)];
+        drop(_2) -> [return: bb44, unwind terminate(cleanup)];
     }
 
     bb44 (cleanup): {
+        drop(_1) -> [return: bb45, unwind terminate(cleanup)];
+    }
+
+    bb45 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/tail_call_drops.f_with_arg.built.after.panic-abort.mir
+++ b/tests/mir-opt/tail_call_drops.f_with_arg.built.after.panic-abort.mir
@@ -28,7 +28,7 @@ fn f_with_arg(_1: String, _2: String) -> () {
 
     bb0: {
         StorageLive(_4);
-        _4 = String::new() -> [return: bb1, unwind: bb43];
+        _4 = String::new() -> [return: bb1, unwind: bb42];
     }
 
     bb1: {
@@ -37,13 +37,13 @@ fn f_with_arg(_1: String, _2: String) -> () {
         _5 = const 12_i32;
         FakeRead(ForLet(None), _5);
         StorageLive(_6);
-        _6 = String::new() -> [return: bb2, unwind: bb42];
+        _6 = String::new() -> [return: bb2, unwind: bb41];
     }
 
     bb2: {
         FakeRead(ForLet(None), _6);
         StorageLive(_7);
-        _7 = String::new() -> [return: bb3, unwind: bb41];
+        _7 = String::new() -> [return: bb3, unwind: bb40];
     }
 
     bb3: {
@@ -66,7 +66,7 @@ fn f_with_arg(_1: String, _2: String) -> () {
     bb6: {
         StorageDead(_8);
         StorageLive(_10);
-        _10 = String::new() -> [return: bb7, unwind: bb40];
+        _10 = String::new() -> [return: bb7, unwind: bb39];
     }
 
     bb7: {
@@ -117,7 +117,7 @@ fn f_with_arg(_1: String, _2: String) -> () {
     }
 
     bb17: {
-        drop(_7) -> [return: bb18, unwind: bb41];
+        drop(_7) -> [return: bb18, unwind: bb40];
     }
 
     bb18: {
@@ -126,7 +126,7 @@ fn f_with_arg(_1: String, _2: String) -> () {
     }
 
     bb19: {
-        drop(_6) -> [return: bb20, unwind: bb42];
+        drop(_6) -> [return: bb20, unwind: bb41];
     }
 
     bb20: {
@@ -140,7 +140,7 @@ fn f_with_arg(_1: String, _2: String) -> () {
     }
 
     bb22: {
-        drop(_4) -> [return: bb23, unwind: bb43];
+        drop(_4) -> [return: bb23, unwind: bb42];
     }
 
     bb23: {
@@ -153,11 +153,11 @@ fn f_with_arg(_1: String, _2: String) -> () {
     }
 
     bb25: {
-        drop(_2) -> [return: bb26, unwind: bb44];
+        drop(_2) -> [return: bb26, unwind: bb43];
     }
 
     bb26: {
-        drop(_1) -> [return: bb27, unwind: bb45];
+        drop(_1) -> [return: bb27, unwind: bb44];
     }
 
     bb27: {
@@ -169,7 +169,7 @@ fn f_with_arg(_1: String, _2: String) -> () {
     }
 
     bb29 (cleanup): {
-        drop(_11) -> [return: bb41, unwind terminate(cleanup)];
+        drop(_11) -> [return: bb40, unwind terminate(cleanup)];
     }
 
     bb30 (cleanup): {
@@ -177,7 +177,7 @@ fn f_with_arg(_1: String, _2: String) -> () {
     }
 
     bb31 (cleanup): {
-        drop(_11) -> [return: bb42, unwind terminate(cleanup)];
+        drop(_11) -> [return: bb41, unwind terminate(cleanup)];
     }
 
     bb32 (cleanup): {
@@ -185,7 +185,7 @@ fn f_with_arg(_1: String, _2: String) -> () {
     }
 
     bb33 (cleanup): {
-        drop(_11) -> [return: bb43, unwind terminate(cleanup)];
+        drop(_11) -> [return: bb42, unwind terminate(cleanup)];
     }
 
     bb34 (cleanup): {
@@ -193,7 +193,7 @@ fn f_with_arg(_1: String, _2: String) -> () {
     }
 
     bb35 (cleanup): {
-        drop(_11) -> [return: bb44, unwind terminate(cleanup)];
+        drop(_11) -> [return: bb43, unwind terminate(cleanup)];
     }
 
     bb36 (cleanup): {
@@ -201,38 +201,34 @@ fn f_with_arg(_1: String, _2: String) -> () {
     }
 
     bb37 (cleanup): {
-        drop(_11) -> [return: bb45, unwind terminate(cleanup)];
+        drop(_11) -> [return: bb44, unwind terminate(cleanup)];
     }
 
     bb38 (cleanup): {
-        drop(_10) -> [return: bb40, unwind terminate(cleanup)];
+        drop(_10) -> [return: bb39, unwind terminate(cleanup)];
     }
 
     bb39 (cleanup): {
-        drop(_9) -> [return: bb40, unwind terminate(cleanup)];
+        drop(_7) -> [return: bb40, unwind terminate(cleanup)];
     }
 
     bb40 (cleanup): {
-        drop(_7) -> [return: bb41, unwind terminate(cleanup)];
+        drop(_6) -> [return: bb41, unwind terminate(cleanup)];
     }
 
     bb41 (cleanup): {
-        drop(_6) -> [return: bb42, unwind terminate(cleanup)];
+        drop(_4) -> [return: bb42, unwind terminate(cleanup)];
     }
 
     bb42 (cleanup): {
-        drop(_4) -> [return: bb43, unwind terminate(cleanup)];
+        drop(_2) -> [return: bb43, unwind terminate(cleanup)];
     }
 
     bb43 (cleanup): {
-        drop(_2) -> [return: bb44, unwind terminate(cleanup)];
+        drop(_1) -> [return: bb44, unwind terminate(cleanup)];
     }
 
     bb44 (cleanup): {
-        drop(_1) -> [return: bb45, unwind terminate(cleanup)];
-    }
-
-    bb45 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/tail_call_drops.f_with_arg.built.after.panic-abort.mir
+++ b/tests/mir-opt/tail_call_drops.f_with_arg.built.after.panic-abort.mir
@@ -28,7 +28,7 @@ fn f_with_arg(_1: String, _2: String) -> () {
 
     bb0: {
         StorageLive(_4);
-        _4 = String::new() -> [return: bb1, unwind: bb34];
+        _4 = String::new() -> [return: bb1, unwind: bb42];
     }
 
     bb1: {
@@ -37,13 +37,13 @@ fn f_with_arg(_1: String, _2: String) -> () {
         _5 = const 12_i32;
         FakeRead(ForLet(None), _5);
         StorageLive(_6);
-        _6 = String::new() -> [return: bb2, unwind: bb33];
+        _6 = String::new() -> [return: bb2, unwind: bb41];
     }
 
     bb2: {
         FakeRead(ForLet(None), _6);
         StorageLive(_7);
-        _7 = String::new() -> [return: bb3, unwind: bb32];
+        _7 = String::new() -> [return: bb3, unwind: bb40];
     }
 
     bb3: {
@@ -51,112 +51,112 @@ fn f_with_arg(_1: String, _2: String) -> () {
         StorageLive(_8);
         StorageLive(_9);
         _9 = move _6;
-        _8 = std::mem::drop::<String>(move _9) -> [return: bb4, unwind: bb30];
+        _8 = std::mem::drop::<String>(move _9) -> [return: bb4, unwind: bb38];
     }
 
     bb4: {
-        StorageDead(_9);
-        StorageDead(_8);
-        StorageLive(_10);
-        _10 = String::new() -> [return: bb5, unwind: bb31];
+        goto -> bb5;
     }
 
     bb5: {
-        StorageLive(_11);
-        _11 = String::new() -> [return: bb6, unwind: bb29];
+        StorageDead(_9);
+        goto -> bb6;
     }
 
     bb6: {
-        drop(_7) -> [return: bb7, unwind: bb27];
+        StorageDead(_8);
+        StorageLive(_10);
+        _10 = String::new() -> [return: bb7, unwind: bb39];
     }
 
     bb7: {
-        StorageDead(_7);
-        drop(_6) -> [return: bb8, unwind: bb25];
+        StorageLive(_11);
+        _11 = String::new() -> [return: bb8, unwind: bb37];
     }
 
     bb8: {
-        StorageDead(_6);
-        drop(_4) -> [return: bb9, unwind: bb23];
+        drop(_7) -> [return: bb9, unwind: bb35];
     }
 
     bb9: {
-        StorageDead(_4);
-        drop(_2) -> [return: bb10, unwind: bb21];
+        StorageDead(_7);
+        drop(_6) -> [return: bb10, unwind: bb33];
     }
 
     bb10: {
-        drop(_1) -> [return: bb11, unwind: bb19];
+        StorageDead(_6);
+        drop(_4) -> [return: bb11, unwind: bb31];
     }
 
     bb11: {
-        tailcall g_with_arg(move _10, move _11);
+        StorageDead(_4);
+        drop(_2) -> [return: bb12, unwind: bb29];
     }
 
     bb12: {
-        StorageDead(_11);
-        StorageDead(_10);
-        drop(_7) -> [return: bb13, unwind: bb32];
+        drop(_1) -> [return: bb13, unwind: bb27];
     }
 
     bb13: {
-        StorageDead(_7);
-        drop(_6) -> [return: bb14, unwind: bb33];
+        tailcall g_with_arg(move _10, move _11);
     }
 
     bb14: {
-        StorageDead(_6);
-        StorageDead(_5);
-        drop(_4) -> [return: bb15, unwind: bb34];
+        goto -> bb15;
     }
 
     bb15: {
+        StorageDead(_11);
+        StorageDead(_10);
+        goto -> bb16;
+    }
+
+    bb16: {
+        drop(_7) -> [return: bb17, unwind: bb40];
+    }
+
+    bb17: {
+        StorageDead(_7);
+        goto -> bb18;
+    }
+
+    bb18: {
+        drop(_6) -> [return: bb19, unwind: bb41];
+    }
+
+    bb19: {
+        StorageDead(_6);
+        goto -> bb20;
+    }
+
+    bb20: {
+        StorageDead(_5);
+        goto -> bb21;
+    }
+
+    bb21: {
+        drop(_4) -> [return: bb22, unwind: bb42];
+    }
+
+    bb22: {
         StorageDead(_4);
         unreachable;
     }
 
-    bb16: {
-        drop(_2) -> [return: bb17, unwind: bb35];
+    bb23: {
+        goto -> bb24;
     }
 
-    bb17: {
-        drop(_1) -> [return: bb18, unwind: bb36];
+    bb24: {
+        drop(_2) -> [return: bb25, unwind: bb43];
     }
 
-    bb18: {
+    bb25: {
+        drop(_1) -> [return: bb26, unwind: bb44];
+    }
+
+    bb26: {
         return;
-    }
-
-    bb19 (cleanup): {
-        drop(_10) -> [return: bb20, unwind terminate(cleanup)];
-    }
-
-    bb20 (cleanup): {
-        drop(_11) -> [return: bb36, unwind terminate(cleanup)];
-    }
-
-    bb21 (cleanup): {
-        drop(_10) -> [return: bb22, unwind terminate(cleanup)];
-    }
-
-    bb22 (cleanup): {
-        drop(_11) -> [return: bb35, unwind terminate(cleanup)];
-    }
-
-    bb23 (cleanup): {
-        drop(_10) -> [return: bb24, unwind terminate(cleanup)];
-    }
-
-    bb24 (cleanup): {
-        drop(_11) -> [return: bb34, unwind terminate(cleanup)];
-    }
-
-    bb25 (cleanup): {
-        drop(_10) -> [return: bb26, unwind terminate(cleanup)];
-    }
-
-    bb26 (cleanup): {
-        drop(_11) -> [return: bb33, unwind terminate(cleanup)];
     }
 
     bb27 (cleanup): {
@@ -164,38 +164,70 @@ fn f_with_arg(_1: String, _2: String) -> () {
     }
 
     bb28 (cleanup): {
-        drop(_11) -> [return: bb32, unwind terminate(cleanup)];
+        drop(_11) -> [return: bb44, unwind terminate(cleanup)];
     }
 
     bb29 (cleanup): {
-        drop(_10) -> [return: bb31, unwind terminate(cleanup)];
+        drop(_10) -> [return: bb30, unwind terminate(cleanup)];
     }
 
     bb30 (cleanup): {
-        drop(_9) -> [return: bb31, unwind terminate(cleanup)];
+        drop(_11) -> [return: bb43, unwind terminate(cleanup)];
     }
 
     bb31 (cleanup): {
-        drop(_7) -> [return: bb32, unwind terminate(cleanup)];
+        drop(_10) -> [return: bb32, unwind terminate(cleanup)];
     }
 
     bb32 (cleanup): {
-        drop(_6) -> [return: bb33, unwind terminate(cleanup)];
+        drop(_11) -> [return: bb42, unwind terminate(cleanup)];
     }
 
     bb33 (cleanup): {
-        drop(_4) -> [return: bb34, unwind terminate(cleanup)];
+        drop(_10) -> [return: bb34, unwind terminate(cleanup)];
     }
 
     bb34 (cleanup): {
-        drop(_2) -> [return: bb35, unwind terminate(cleanup)];
+        drop(_11) -> [return: bb41, unwind terminate(cleanup)];
     }
 
     bb35 (cleanup): {
-        drop(_1) -> [return: bb36, unwind terminate(cleanup)];
+        drop(_10) -> [return: bb36, unwind terminate(cleanup)];
     }
 
     bb36 (cleanup): {
+        drop(_11) -> [return: bb40, unwind terminate(cleanup)];
+    }
+
+    bb37 (cleanup): {
+        drop(_10) -> [return: bb39, unwind terminate(cleanup)];
+    }
+
+    bb38 (cleanup): {
+        drop(_9) -> [return: bb39, unwind terminate(cleanup)];
+    }
+
+    bb39 (cleanup): {
+        drop(_7) -> [return: bb40, unwind terminate(cleanup)];
+    }
+
+    bb40 (cleanup): {
+        drop(_6) -> [return: bb41, unwind terminate(cleanup)];
+    }
+
+    bb41 (cleanup): {
+        drop(_4) -> [return: bb42, unwind terminate(cleanup)];
+    }
+
+    bb42 (cleanup): {
+        drop(_2) -> [return: bb43, unwind terminate(cleanup)];
+    }
+
+    bb43 (cleanup): {
+        drop(_1) -> [return: bb44, unwind terminate(cleanup)];
+    }
+
+    bb44 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/tail_call_drops.f_with_arg.built.after.panic-unwind.mir
+++ b/tests/mir-opt/tail_call_drops.f_with_arg.built.after.panic-unwind.mir
@@ -28,7 +28,7 @@ fn f_with_arg(_1: String, _2: String) -> () {
 
     bb0: {
         StorageLive(_4);
-        _4 = String::new() -> [return: bb1, unwind: bb42];
+        _4 = String::new() -> [return: bb1, unwind: bb43];
     }
 
     bb1: {
@@ -37,13 +37,13 @@ fn f_with_arg(_1: String, _2: String) -> () {
         _5 = const 12_i32;
         FakeRead(ForLet(None), _5);
         StorageLive(_6);
-        _6 = String::new() -> [return: bb2, unwind: bb41];
+        _6 = String::new() -> [return: bb2, unwind: bb42];
     }
 
     bb2: {
         FakeRead(ForLet(None), _6);
         StorageLive(_7);
-        _7 = String::new() -> [return: bb3, unwind: bb40];
+        _7 = String::new() -> [return: bb3, unwind: bb41];
     }
 
     bb3: {
@@ -51,7 +51,7 @@ fn f_with_arg(_1: String, _2: String) -> () {
         StorageLive(_8);
         StorageLive(_9);
         _9 = move _6;
-        _8 = std::mem::drop::<String>(move _9) -> [return: bb4, unwind: bb38];
+        _8 = std::mem::drop::<String>(move _9) -> [return: bb4, unwind: bb39];
     }
 
     bb4: {
@@ -66,168 +66,173 @@ fn f_with_arg(_1: String, _2: String) -> () {
     bb6: {
         StorageDead(_8);
         StorageLive(_10);
-        _10 = String::new() -> [return: bb7, unwind: bb39];
+        _10 = String::new() -> [return: bb7, unwind: bb40];
     }
 
     bb7: {
         StorageLive(_11);
-        _11 = String::new() -> [return: bb8, unwind: bb37];
+        _11 = String::new() -> [return: bb8, unwind: bb38];
     }
 
     bb8: {
-        drop(_7) -> [return: bb9, unwind: bb35];
+        goto -> bb9;
     }
 
     bb9: {
-        StorageDead(_7);
-        drop(_6) -> [return: bb10, unwind: bb33];
+        drop(_7) -> [return: bb10, unwind: bb28];
     }
 
     bb10: {
-        StorageDead(_6);
-        drop(_4) -> [return: bb11, unwind: bb31];
+        StorageDead(_7);
+        drop(_6) -> [return: bb11, unwind: bb30];
     }
 
     bb11: {
-        StorageDead(_4);
-        drop(_2) -> [return: bb12, unwind: bb29];
+        StorageDead(_6);
+        StorageDead(_5);
+        drop(_4) -> [return: bb12, unwind: bb32];
     }
 
     bb12: {
-        drop(_1) -> [return: bb13, unwind: bb27];
+        StorageDead(_4);
+        drop(_2) -> [return: bb13, unwind: bb34];
     }
 
     bb13: {
-        tailcall g_with_arg(move _10, move _11);
+        drop(_1) -> [return: bb14, unwind: bb36];
     }
 
     bb14: {
-        goto -> bb15;
+        tailcall g_with_arg(move _10, move _11);
     }
 
     bb15: {
-        StorageDead(_11);
-        StorageDead(_10);
         goto -> bb16;
     }
 
     bb16: {
-        drop(_7) -> [return: bb17, unwind: bb40];
+        StorageDead(_11);
+        StorageDead(_10);
+        goto -> bb17;
     }
 
     bb17: {
-        StorageDead(_7);
-        goto -> bb18;
+        drop(_7) -> [return: bb18, unwind: bb41];
     }
 
     bb18: {
-        drop(_6) -> [return: bb19, unwind: bb41];
+        StorageDead(_7);
+        goto -> bb19;
     }
 
     bb19: {
-        StorageDead(_6);
-        goto -> bb20;
+        drop(_6) -> [return: bb20, unwind: bb42];
     }
 
     bb20: {
-        StorageDead(_5);
+        StorageDead(_6);
         goto -> bb21;
     }
 
     bb21: {
-        drop(_4) -> [return: bb22, unwind: bb42];
+        StorageDead(_5);
+        goto -> bb22;
     }
 
     bb22: {
+        drop(_4) -> [return: bb23, unwind: bb43];
+    }
+
+    bb23: {
         StorageDead(_4);
         unreachable;
     }
 
-    bb23: {
-        goto -> bb24;
-    }
-
     bb24: {
-        drop(_2) -> [return: bb25, unwind: bb43];
+        goto -> bb25;
     }
 
     bb25: {
-        drop(_1) -> [return: bb26, unwind: bb44];
+        drop(_2) -> [return: bb26, unwind: bb44];
     }
 
     bb26: {
+        drop(_1) -> [return: bb27, unwind: bb45];
+    }
+
+    bb27: {
         return;
     }
 
-    bb27 (cleanup): {
-        drop(_10) -> [return: bb28, unwind terminate(cleanup)];
-    }
-
     bb28 (cleanup): {
-        drop(_11) -> [return: bb44, unwind terminate(cleanup)];
+        drop(_10) -> [return: bb29, unwind terminate(cleanup)];
     }
 
     bb29 (cleanup): {
-        drop(_10) -> [return: bb30, unwind terminate(cleanup)];
-    }
-
-    bb30 (cleanup): {
-        drop(_11) -> [return: bb43, unwind terminate(cleanup)];
-    }
-
-    bb31 (cleanup): {
-        drop(_10) -> [return: bb32, unwind terminate(cleanup)];
-    }
-
-    bb32 (cleanup): {
-        drop(_11) -> [return: bb42, unwind terminate(cleanup)];
-    }
-
-    bb33 (cleanup): {
-        drop(_10) -> [return: bb34, unwind terminate(cleanup)];
-    }
-
-    bb34 (cleanup): {
         drop(_11) -> [return: bb41, unwind terminate(cleanup)];
     }
 
+    bb30 (cleanup): {
+        drop(_10) -> [return: bb31, unwind terminate(cleanup)];
+    }
+
+    bb31 (cleanup): {
+        drop(_11) -> [return: bb42, unwind terminate(cleanup)];
+    }
+
+    bb32 (cleanup): {
+        drop(_10) -> [return: bb33, unwind terminate(cleanup)];
+    }
+
+    bb33 (cleanup): {
+        drop(_11) -> [return: bb43, unwind terminate(cleanup)];
+    }
+
+    bb34 (cleanup): {
+        drop(_10) -> [return: bb35, unwind terminate(cleanup)];
+    }
+
     bb35 (cleanup): {
-        drop(_10) -> [return: bb36, unwind terminate(cleanup)];
+        drop(_11) -> [return: bb44, unwind terminate(cleanup)];
     }
 
     bb36 (cleanup): {
-        drop(_11) -> [return: bb40, unwind terminate(cleanup)];
+        drop(_10) -> [return: bb37, unwind terminate(cleanup)];
     }
 
     bb37 (cleanup): {
-        drop(_10) -> [return: bb39, unwind terminate(cleanup)];
+        drop(_11) -> [return: bb45, unwind terminate(cleanup)];
     }
 
     bb38 (cleanup): {
-        drop(_9) -> [return: bb39, unwind terminate(cleanup)];
+        drop(_10) -> [return: bb40, unwind terminate(cleanup)];
     }
 
     bb39 (cleanup): {
-        drop(_7) -> [return: bb40, unwind terminate(cleanup)];
+        drop(_9) -> [return: bb40, unwind terminate(cleanup)];
     }
 
     bb40 (cleanup): {
-        drop(_6) -> [return: bb41, unwind terminate(cleanup)];
+        drop(_7) -> [return: bb41, unwind terminate(cleanup)];
     }
 
     bb41 (cleanup): {
-        drop(_4) -> [return: bb42, unwind terminate(cleanup)];
+        drop(_6) -> [return: bb42, unwind terminate(cleanup)];
     }
 
     bb42 (cleanup): {
-        drop(_2) -> [return: bb43, unwind terminate(cleanup)];
+        drop(_4) -> [return: bb43, unwind terminate(cleanup)];
     }
 
     bb43 (cleanup): {
-        drop(_1) -> [return: bb44, unwind terminate(cleanup)];
+        drop(_2) -> [return: bb44, unwind terminate(cleanup)];
     }
 
     bb44 (cleanup): {
+        drop(_1) -> [return: bb45, unwind terminate(cleanup)];
+    }
+
+    bb45 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/tail_call_drops.f_with_arg.built.after.panic-unwind.mir
+++ b/tests/mir-opt/tail_call_drops.f_with_arg.built.after.panic-unwind.mir
@@ -28,7 +28,7 @@ fn f_with_arg(_1: String, _2: String) -> () {
 
     bb0: {
         StorageLive(_4);
-        _4 = String::new() -> [return: bb1, unwind: bb43];
+        _4 = String::new() -> [return: bb1, unwind: bb42];
     }
 
     bb1: {
@@ -37,13 +37,13 @@ fn f_with_arg(_1: String, _2: String) -> () {
         _5 = const 12_i32;
         FakeRead(ForLet(None), _5);
         StorageLive(_6);
-        _6 = String::new() -> [return: bb2, unwind: bb42];
+        _6 = String::new() -> [return: bb2, unwind: bb41];
     }
 
     bb2: {
         FakeRead(ForLet(None), _6);
         StorageLive(_7);
-        _7 = String::new() -> [return: bb3, unwind: bb41];
+        _7 = String::new() -> [return: bb3, unwind: bb40];
     }
 
     bb3: {
@@ -66,7 +66,7 @@ fn f_with_arg(_1: String, _2: String) -> () {
     bb6: {
         StorageDead(_8);
         StorageLive(_10);
-        _10 = String::new() -> [return: bb7, unwind: bb40];
+        _10 = String::new() -> [return: bb7, unwind: bb39];
     }
 
     bb7: {
@@ -117,7 +117,7 @@ fn f_with_arg(_1: String, _2: String) -> () {
     }
 
     bb17: {
-        drop(_7) -> [return: bb18, unwind: bb41];
+        drop(_7) -> [return: bb18, unwind: bb40];
     }
 
     bb18: {
@@ -126,7 +126,7 @@ fn f_with_arg(_1: String, _2: String) -> () {
     }
 
     bb19: {
-        drop(_6) -> [return: bb20, unwind: bb42];
+        drop(_6) -> [return: bb20, unwind: bb41];
     }
 
     bb20: {
@@ -140,7 +140,7 @@ fn f_with_arg(_1: String, _2: String) -> () {
     }
 
     bb22: {
-        drop(_4) -> [return: bb23, unwind: bb43];
+        drop(_4) -> [return: bb23, unwind: bb42];
     }
 
     bb23: {
@@ -153,11 +153,11 @@ fn f_with_arg(_1: String, _2: String) -> () {
     }
 
     bb25: {
-        drop(_2) -> [return: bb26, unwind: bb44];
+        drop(_2) -> [return: bb26, unwind: bb43];
     }
 
     bb26: {
-        drop(_1) -> [return: bb27, unwind: bb45];
+        drop(_1) -> [return: bb27, unwind: bb44];
     }
 
     bb27: {
@@ -169,7 +169,7 @@ fn f_with_arg(_1: String, _2: String) -> () {
     }
 
     bb29 (cleanup): {
-        drop(_11) -> [return: bb41, unwind terminate(cleanup)];
+        drop(_11) -> [return: bb40, unwind terminate(cleanup)];
     }
 
     bb30 (cleanup): {
@@ -177,7 +177,7 @@ fn f_with_arg(_1: String, _2: String) -> () {
     }
 
     bb31 (cleanup): {
-        drop(_11) -> [return: bb42, unwind terminate(cleanup)];
+        drop(_11) -> [return: bb41, unwind terminate(cleanup)];
     }
 
     bb32 (cleanup): {
@@ -185,7 +185,7 @@ fn f_with_arg(_1: String, _2: String) -> () {
     }
 
     bb33 (cleanup): {
-        drop(_11) -> [return: bb43, unwind terminate(cleanup)];
+        drop(_11) -> [return: bb42, unwind terminate(cleanup)];
     }
 
     bb34 (cleanup): {
@@ -193,7 +193,7 @@ fn f_with_arg(_1: String, _2: String) -> () {
     }
 
     bb35 (cleanup): {
-        drop(_11) -> [return: bb44, unwind terminate(cleanup)];
+        drop(_11) -> [return: bb43, unwind terminate(cleanup)];
     }
 
     bb36 (cleanup): {
@@ -201,38 +201,34 @@ fn f_with_arg(_1: String, _2: String) -> () {
     }
 
     bb37 (cleanup): {
-        drop(_11) -> [return: bb45, unwind terminate(cleanup)];
+        drop(_11) -> [return: bb44, unwind terminate(cleanup)];
     }
 
     bb38 (cleanup): {
-        drop(_10) -> [return: bb40, unwind terminate(cleanup)];
+        drop(_10) -> [return: bb39, unwind terminate(cleanup)];
     }
 
     bb39 (cleanup): {
-        drop(_9) -> [return: bb40, unwind terminate(cleanup)];
+        drop(_7) -> [return: bb40, unwind terminate(cleanup)];
     }
 
     bb40 (cleanup): {
-        drop(_7) -> [return: bb41, unwind terminate(cleanup)];
+        drop(_6) -> [return: bb41, unwind terminate(cleanup)];
     }
 
     bb41 (cleanup): {
-        drop(_6) -> [return: bb42, unwind terminate(cleanup)];
+        drop(_4) -> [return: bb42, unwind terminate(cleanup)];
     }
 
     bb42 (cleanup): {
-        drop(_4) -> [return: bb43, unwind terminate(cleanup)];
+        drop(_2) -> [return: bb43, unwind terminate(cleanup)];
     }
 
     bb43 (cleanup): {
-        drop(_2) -> [return: bb44, unwind terminate(cleanup)];
+        drop(_1) -> [return: bb44, unwind terminate(cleanup)];
     }
 
     bb44 (cleanup): {
-        drop(_1) -> [return: bb45, unwind terminate(cleanup)];
-    }
-
-    bb45 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/tail_call_drops.f_with_arg.built.after.panic-unwind.mir
+++ b/tests/mir-opt/tail_call_drops.f_with_arg.built.after.panic-unwind.mir
@@ -28,7 +28,7 @@ fn f_with_arg(_1: String, _2: String) -> () {
 
     bb0: {
         StorageLive(_4);
-        _4 = String::new() -> [return: bb1, unwind: bb34];
+        _4 = String::new() -> [return: bb1, unwind: bb42];
     }
 
     bb1: {
@@ -37,13 +37,13 @@ fn f_with_arg(_1: String, _2: String) -> () {
         _5 = const 12_i32;
         FakeRead(ForLet(None), _5);
         StorageLive(_6);
-        _6 = String::new() -> [return: bb2, unwind: bb33];
+        _6 = String::new() -> [return: bb2, unwind: bb41];
     }
 
     bb2: {
         FakeRead(ForLet(None), _6);
         StorageLive(_7);
-        _7 = String::new() -> [return: bb3, unwind: bb32];
+        _7 = String::new() -> [return: bb3, unwind: bb40];
     }
 
     bb3: {
@@ -51,112 +51,112 @@ fn f_with_arg(_1: String, _2: String) -> () {
         StorageLive(_8);
         StorageLive(_9);
         _9 = move _6;
-        _8 = std::mem::drop::<String>(move _9) -> [return: bb4, unwind: bb30];
+        _8 = std::mem::drop::<String>(move _9) -> [return: bb4, unwind: bb38];
     }
 
     bb4: {
-        StorageDead(_9);
-        StorageDead(_8);
-        StorageLive(_10);
-        _10 = String::new() -> [return: bb5, unwind: bb31];
+        goto -> bb5;
     }
 
     bb5: {
-        StorageLive(_11);
-        _11 = String::new() -> [return: bb6, unwind: bb29];
+        StorageDead(_9);
+        goto -> bb6;
     }
 
     bb6: {
-        drop(_7) -> [return: bb7, unwind: bb27];
+        StorageDead(_8);
+        StorageLive(_10);
+        _10 = String::new() -> [return: bb7, unwind: bb39];
     }
 
     bb7: {
-        StorageDead(_7);
-        drop(_6) -> [return: bb8, unwind: bb25];
+        StorageLive(_11);
+        _11 = String::new() -> [return: bb8, unwind: bb37];
     }
 
     bb8: {
-        StorageDead(_6);
-        drop(_4) -> [return: bb9, unwind: bb23];
+        drop(_7) -> [return: bb9, unwind: bb35];
     }
 
     bb9: {
-        StorageDead(_4);
-        drop(_2) -> [return: bb10, unwind: bb21];
+        StorageDead(_7);
+        drop(_6) -> [return: bb10, unwind: bb33];
     }
 
     bb10: {
-        drop(_1) -> [return: bb11, unwind: bb19];
+        StorageDead(_6);
+        drop(_4) -> [return: bb11, unwind: bb31];
     }
 
     bb11: {
-        tailcall g_with_arg(move _10, move _11);
+        StorageDead(_4);
+        drop(_2) -> [return: bb12, unwind: bb29];
     }
 
     bb12: {
-        StorageDead(_11);
-        StorageDead(_10);
-        drop(_7) -> [return: bb13, unwind: bb32];
+        drop(_1) -> [return: bb13, unwind: bb27];
     }
 
     bb13: {
-        StorageDead(_7);
-        drop(_6) -> [return: bb14, unwind: bb33];
+        tailcall g_with_arg(move _10, move _11);
     }
 
     bb14: {
-        StorageDead(_6);
-        StorageDead(_5);
-        drop(_4) -> [return: bb15, unwind: bb34];
+        goto -> bb15;
     }
 
     bb15: {
+        StorageDead(_11);
+        StorageDead(_10);
+        goto -> bb16;
+    }
+
+    bb16: {
+        drop(_7) -> [return: bb17, unwind: bb40];
+    }
+
+    bb17: {
+        StorageDead(_7);
+        goto -> bb18;
+    }
+
+    bb18: {
+        drop(_6) -> [return: bb19, unwind: bb41];
+    }
+
+    bb19: {
+        StorageDead(_6);
+        goto -> bb20;
+    }
+
+    bb20: {
+        StorageDead(_5);
+        goto -> bb21;
+    }
+
+    bb21: {
+        drop(_4) -> [return: bb22, unwind: bb42];
+    }
+
+    bb22: {
         StorageDead(_4);
         unreachable;
     }
 
-    bb16: {
-        drop(_2) -> [return: bb17, unwind: bb35];
+    bb23: {
+        goto -> bb24;
     }
 
-    bb17: {
-        drop(_1) -> [return: bb18, unwind: bb36];
+    bb24: {
+        drop(_2) -> [return: bb25, unwind: bb43];
     }
 
-    bb18: {
+    bb25: {
+        drop(_1) -> [return: bb26, unwind: bb44];
+    }
+
+    bb26: {
         return;
-    }
-
-    bb19 (cleanup): {
-        drop(_10) -> [return: bb20, unwind terminate(cleanup)];
-    }
-
-    bb20 (cleanup): {
-        drop(_11) -> [return: bb36, unwind terminate(cleanup)];
-    }
-
-    bb21 (cleanup): {
-        drop(_10) -> [return: bb22, unwind terminate(cleanup)];
-    }
-
-    bb22 (cleanup): {
-        drop(_11) -> [return: bb35, unwind terminate(cleanup)];
-    }
-
-    bb23 (cleanup): {
-        drop(_10) -> [return: bb24, unwind terminate(cleanup)];
-    }
-
-    bb24 (cleanup): {
-        drop(_11) -> [return: bb34, unwind terminate(cleanup)];
-    }
-
-    bb25 (cleanup): {
-        drop(_10) -> [return: bb26, unwind terminate(cleanup)];
-    }
-
-    bb26 (cleanup): {
-        drop(_11) -> [return: bb33, unwind terminate(cleanup)];
     }
 
     bb27 (cleanup): {
@@ -164,38 +164,70 @@ fn f_with_arg(_1: String, _2: String) -> () {
     }
 
     bb28 (cleanup): {
-        drop(_11) -> [return: bb32, unwind terminate(cleanup)];
+        drop(_11) -> [return: bb44, unwind terminate(cleanup)];
     }
 
     bb29 (cleanup): {
-        drop(_10) -> [return: bb31, unwind terminate(cleanup)];
+        drop(_10) -> [return: bb30, unwind terminate(cleanup)];
     }
 
     bb30 (cleanup): {
-        drop(_9) -> [return: bb31, unwind terminate(cleanup)];
+        drop(_11) -> [return: bb43, unwind terminate(cleanup)];
     }
 
     bb31 (cleanup): {
-        drop(_7) -> [return: bb32, unwind terminate(cleanup)];
+        drop(_10) -> [return: bb32, unwind terminate(cleanup)];
     }
 
     bb32 (cleanup): {
-        drop(_6) -> [return: bb33, unwind terminate(cleanup)];
+        drop(_11) -> [return: bb42, unwind terminate(cleanup)];
     }
 
     bb33 (cleanup): {
-        drop(_4) -> [return: bb34, unwind terminate(cleanup)];
+        drop(_10) -> [return: bb34, unwind terminate(cleanup)];
     }
 
     bb34 (cleanup): {
-        drop(_2) -> [return: bb35, unwind terminate(cleanup)];
+        drop(_11) -> [return: bb41, unwind terminate(cleanup)];
     }
 
     bb35 (cleanup): {
-        drop(_1) -> [return: bb36, unwind terminate(cleanup)];
+        drop(_10) -> [return: bb36, unwind terminate(cleanup)];
     }
 
     bb36 (cleanup): {
+        drop(_11) -> [return: bb40, unwind terminate(cleanup)];
+    }
+
+    bb37 (cleanup): {
+        drop(_10) -> [return: bb39, unwind terminate(cleanup)];
+    }
+
+    bb38 (cleanup): {
+        drop(_9) -> [return: bb39, unwind terminate(cleanup)];
+    }
+
+    bb39 (cleanup): {
+        drop(_7) -> [return: bb40, unwind terminate(cleanup)];
+    }
+
+    bb40 (cleanup): {
+        drop(_6) -> [return: bb41, unwind terminate(cleanup)];
+    }
+
+    bb41 (cleanup): {
+        drop(_4) -> [return: bb42, unwind terminate(cleanup)];
+    }
+
+    bb42 (cleanup): {
+        drop(_2) -> [return: bb43, unwind terminate(cleanup)];
+    }
+
+    bb43 (cleanup): {
+        drop(_1) -> [return: bb44, unwind terminate(cleanup)];
+    }
+
+    bb44 (cleanup): {
         resume;
     }
 }

--- a/tests/ui/borrowck/match-moved-temporary.rs
+++ b/tests/ui/borrowck/match-moved-temporary.rs
@@ -1,0 +1,34 @@
+//! Regression test for issue #156713. In the `fails` case, borrowck was trying to check liveness
+//! of `bar` which had been moved to a match scrutinee.
+//@ edition: 2015
+//@ check-pass
+
+struct Foo;
+impl Drop for Foo {
+    fn drop(&mut self) {}
+}
+
+struct Bar<'a>(&'a Foo);
+impl Drop for Bar<'_> {
+    fn drop(&mut self) {}
+}
+
+// This compiles
+fn works() {
+    let foo = Foo;
+    let bar = Bar(&foo);
+    drop(match { (bar,) } {
+        args => args,
+    })
+}
+
+// This used to error
+fn fails() {
+    let foo = Foo;
+    let bar = Bar(&foo);
+    drop(match (bar,) {
+        args => args,
+    })
+}
+
+fn main() {}

--- a/tests/ui/drop/drop-order-comparisons.e2021.fixed
+++ b/tests/ui/drop/drop-order-comparisons.e2021.fixed
@@ -102,8 +102,6 @@ fn t_tailexpr_tuples() {
         (e.ok(2), e.ok(6).is_ok(), e.ok(3), e.ok(5).is_ok())
         //[e2021]~^ WARN relative drop order changing in Rust 2024
         //[e2021]~| WARN this changes meaning in Rust 2024
-        //[e2021]~| WARN relative drop order changing in Rust 2024
-        //[e2021]~| WARN this changes meaning in Rust 2024
     }, e.mark(1), e.ok(4));
     e.assert(6);
 }

--- a/tests/ui/drop/drop-order-comparisons.e2021.stderr
+++ b/tests/ui/drop/drop-order-comparisons.e2021.stderr
@@ -27,22 +27,22 @@ LL | |     }, e.mark(3), e.ok(4));
    |                            `#1` will be dropped later as of Edition 2024
    |
 note: `#3` invokes this custom destructor
-  --> $DIR/drop-order-comparisons.rs:503:1
+  --> $DIR/drop-order-comparisons.rs:501:1
    |
 LL | impl<'b> Drop for LogDrop<'b> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: `#1` invokes this custom destructor
-  --> $DIR/drop-order-comparisons.rs:503:1
+  --> $DIR/drop-order-comparisons.rs:501:1
    |
 LL | impl<'b> Drop for LogDrop<'b> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: `_v` invokes this custom destructor
-  --> $DIR/drop-order-comparisons.rs:503:1
+  --> $DIR/drop-order-comparisons.rs:501:1
    |
 LL | impl<'b> Drop for LogDrop<'b> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: `#2` invokes this custom destructor
-  --> $DIR/drop-order-comparisons.rs:503:1
+  --> $DIR/drop-order-comparisons.rs:501:1
    |
 LL | impl<'b> Drop for LogDrop<'b> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -62,10 +62,12 @@ warning: relative drop order changing in Rust 2024
 LL |       _ = ({
    |  _________-
 LL | |         (e.ok(2), e.ok(6).is_ok(), e.ok(3), e.ok(5).is_ok())
-   | |                                             ^^^^^^^
-   | |                                             |
-   | |                                             this value will be stored in a temporary; let us call it `#2`
-   | |                                             up until Edition 2021 `#2` is dropped last but will be dropped earlier in Edition 2024
+   | |                   -------                   ^^^^^^^
+   | |                   |                         |
+   | |                   |                         this value will be stored in a temporary; let us call it `#2`
+   | |                   |                         up until Edition 2021 `#2` is dropped last but will be dropped earlier in Edition 2024
+   | |                   this value will be stored in a temporary; let us call it `#3`
+   | |                   up until Edition 2021 `#3` is dropped last but will be dropped earlier in Edition 2024
 ...  |
 LL | |     }, e.mark(1), e.ok(4));
    | |                          -
@@ -75,12 +77,17 @@ LL | |     }, e.mark(1), e.ok(4));
    |                            `#1` will be dropped later as of Edition 2024
    |
 note: `#2` invokes this custom destructor
-  --> $DIR/drop-order-comparisons.rs:503:1
+  --> $DIR/drop-order-comparisons.rs:501:1
+   |
+LL | impl<'b> Drop for LogDrop<'b> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: `#3` invokes this custom destructor
+  --> $DIR/drop-order-comparisons.rs:501:1
    |
 LL | impl<'b> Drop for LogDrop<'b> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: `#1` invokes this custom destructor
-  --> $DIR/drop-order-comparisons.rs:503:1
+  --> $DIR/drop-order-comparisons.rs:501:1
    |
 LL | impl<'b> Drop for LogDrop<'b> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -89,39 +96,7 @@ LL | impl<'b> Drop for LogDrop<'b> {
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-tail-expr-scope.html>
 
 warning: relative drop order changing in Rust 2024
-  --> $DIR/drop-order-comparisons.rs:102:19
-   |
-LL |       _ = ({
-   |  _________-
-LL | |         (e.ok(2), e.ok(6).is_ok(), e.ok(3), e.ok(5).is_ok())
-   | |                   ^^^^^^^
-   | |                   |
-   | |                   this value will be stored in a temporary; let us call it `#2`
-   | |                   up until Edition 2021 `#2` is dropped last but will be dropped earlier in Edition 2024
-...  |
-LL | |     }, e.mark(1), e.ok(4));
-   | |                          -
-   | |                          |
-   | |                          now the temporary value is dropped here, before the local variables in the block or statement
-   | |__________________________this value will be stored in a temporary; let us call it `#1`
-   |                            `#1` will be dropped later as of Edition 2024
-   |
-note: `#2` invokes this custom destructor
-  --> $DIR/drop-order-comparisons.rs:503:1
-   |
-LL | impl<'b> Drop for LogDrop<'b> {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: `#1` invokes this custom destructor
-  --> $DIR/drop-order-comparisons.rs:503:1
-   |
-LL | impl<'b> Drop for LogDrop<'b> {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: most of the time, changing drop order is harmless; inspect the `impl Drop`s for side effects like releasing locks or sending messages
-   = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-tail-expr-scope.html>
-
-warning: relative drop order changing in Rust 2024
-  --> $DIR/drop-order-comparisons.rs:223:24
+  --> $DIR/drop-order-comparisons.rs:221:24
    |
 LL |       _ = ({
    |  _________-
@@ -139,12 +114,12 @@ LL | |     }, e.mark(2), e.ok(3));
    |                            `#1` will be dropped later as of Edition 2024
    |
 note: `#2` invokes this custom destructor
-  --> $DIR/drop-order-comparisons.rs:503:1
+  --> $DIR/drop-order-comparisons.rs:501:1
    |
 LL | impl<'b> Drop for LogDrop<'b> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: `#1` invokes this custom destructor
-  --> $DIR/drop-order-comparisons.rs:503:1
+  --> $DIR/drop-order-comparisons.rs:501:1
    |
 LL | impl<'b> Drop for LogDrop<'b> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -153,7 +128,7 @@ LL | impl<'b> Drop for LogDrop<'b> {
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-tail-expr-scope.html>
 
 warning: relative drop order changing in Rust 2024
-  --> $DIR/drop-order-comparisons.rs:249:24
+  --> $DIR/drop-order-comparisons.rs:247:24
    |
 LL |       _ = ({
    |  _________-
@@ -171,12 +146,12 @@ LL | |     }, e.mark(2), e.ok(3));
    |                            `#1` will be dropped later as of Edition 2024
    |
 note: `#2` invokes this custom destructor
-  --> $DIR/drop-order-comparisons.rs:503:1
+  --> $DIR/drop-order-comparisons.rs:501:1
    |
 LL | impl<'b> Drop for LogDrop<'b> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: `#1` invokes this custom destructor
-  --> $DIR/drop-order-comparisons.rs:503:1
+  --> $DIR/drop-order-comparisons.rs:501:1
    |
 LL | impl<'b> Drop for LogDrop<'b> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -185,7 +160,7 @@ LL | impl<'b> Drop for LogDrop<'b> {
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-tail-expr-scope.html>
 
 warning: `if let` assigns a shorter lifetime since Edition 2024
-  --> $DIR/drop-order-comparisons.rs:125:13
+  --> $DIR/drop-order-comparisons.rs:123:13
    |
 LL |     _ = (if let Ok(_) = e.ok(4).as_ref() {
    |             ^^^^^^^^^^^^-------^^^^^^^^^
@@ -193,12 +168,12 @@ LL |     _ = (if let Ok(_) = e.ok(4).as_ref() {
    |                         this value has a significant drop implementation which may observe a major change in drop order and requires your discretion
    |
 note: value invokes this custom destructor
-  --> $DIR/drop-order-comparisons.rs:503:1
+  --> $DIR/drop-order-comparisons.rs:501:1
    |
 LL | impl<'b> Drop for LogDrop<'b> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: the value is now dropped here in Edition 2024
-  --> $DIR/drop-order-comparisons.rs:129:5
+  --> $DIR/drop-order-comparisons.rs:127:5
    |
 LL |     }, e.mark(2), e.ok(3));
    |     ^
@@ -215,7 +190,7 @@ LL ~     } _ => {}}, e.mark(2), e.ok(3));
    |
 
 warning: `if let` assigns a shorter lifetime since Edition 2024
-  --> $DIR/drop-order-comparisons.rs:147:13
+  --> $DIR/drop-order-comparisons.rs:145:13
    |
 LL |     _ = (if let Ok(_) = e.err(4).as_ref() {} else {
    |             ^^^^^^^^^^^^--------^^^^^^^^^
@@ -223,12 +198,12 @@ LL |     _ = (if let Ok(_) = e.err(4).as_ref() {} else {
    |                         this value has a significant drop implementation which may observe a major change in drop order and requires your discretion
    |
 note: value invokes this custom destructor
-  --> $DIR/drop-order-comparisons.rs:503:1
+  --> $DIR/drop-order-comparisons.rs:501:1
    |
 LL | impl<'b> Drop for LogDrop<'b> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: the value is now dropped here in Edition 2024
-  --> $DIR/drop-order-comparisons.rs:147:44
+  --> $DIR/drop-order-comparisons.rs:145:44
    |
 LL |     _ = (if let Ok(_) = e.err(4).as_ref() {} else {
    |                                            ^
@@ -244,7 +219,7 @@ LL ~     }}, e.mark(2), e.ok(3));
    |
 
 warning: `if let` assigns a shorter lifetime since Edition 2024
-  --> $DIR/drop-order-comparisons.rs:249:12
+  --> $DIR/drop-order-comparisons.rs:247:12
    |
 LL |         if let Ok(_) = e.err(4).as_ref() {} else {
    |            ^^^^^^^^^^^^--------^^^^^^^^^
@@ -252,12 +227,12 @@ LL |         if let Ok(_) = e.err(4).as_ref() {} else {
    |                        this value has a significant drop implementation which may observe a major change in drop order and requires your discretion
    |
 note: value invokes this custom destructor
-  --> $DIR/drop-order-comparisons.rs:503:1
+  --> $DIR/drop-order-comparisons.rs:501:1
    |
 LL | impl<'b> Drop for LogDrop<'b> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: the value is now dropped here in Edition 2024
-  --> $DIR/drop-order-comparisons.rs:249:43
+  --> $DIR/drop-order-comparisons.rs:247:43
    |
 LL |         if let Ok(_) = e.err(4).as_ref() {} else {
    |                                           ^
@@ -273,7 +248,7 @@ LL ~         }}
    |
 
 warning: `if let` assigns a shorter lifetime since Edition 2024
-  --> $DIR/drop-order-comparisons.rs:320:12
+  --> $DIR/drop-order-comparisons.rs:318:12
    |
 LL |         if let true = e.err(9).is_ok() {} else {
    |            ^^^^^^^^^^^--------^^^^^^^^
@@ -281,12 +256,12 @@ LL |         if let true = e.err(9).is_ok() {} else {
    |                       this value has a significant drop implementation which may observe a major change in drop order and requires your discretion
    |
 note: value invokes this custom destructor
-  --> $DIR/drop-order-comparisons.rs:503:1
+  --> $DIR/drop-order-comparisons.rs:501:1
    |
 LL | impl<'b> Drop for LogDrop<'b> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: the value is now dropped here in Edition 2024
-  --> $DIR/drop-order-comparisons.rs:320:41
+  --> $DIR/drop-order-comparisons.rs:318:41
    |
 LL |         if let true = e.err(9).is_ok() {} else {
    |                                         ^
@@ -302,7 +277,7 @@ LL ~         }}}}}}}}};
    |
 
 warning: `if let` assigns a shorter lifetime since Edition 2024
-  --> $DIR/drop-order-comparisons.rs:323:12
+  --> $DIR/drop-order-comparisons.rs:321:12
    |
 LL |         if let Ok(_v) = e.err(8) {} else {
    |            ^^^^^^^^^^^^^--------
@@ -310,12 +285,12 @@ LL |         if let Ok(_v) = e.err(8) {} else {
    |                         this value has a significant drop implementation which may observe a major change in drop order and requires your discretion
    |
 note: value invokes this custom destructor
-  --> $DIR/drop-order-comparisons.rs:503:1
+  --> $DIR/drop-order-comparisons.rs:501:1
    |
 LL | impl<'b> Drop for LogDrop<'b> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: the value is now dropped here in Edition 2024
-  --> $DIR/drop-order-comparisons.rs:323:35
+  --> $DIR/drop-order-comparisons.rs:321:35
    |
 LL |         if let Ok(_v) = e.err(8) {} else {
    |                                   ^
@@ -331,7 +306,7 @@ LL ~         }}}}}}}}};
    |
 
 warning: `if let` assigns a shorter lifetime since Edition 2024
-  --> $DIR/drop-order-comparisons.rs:326:12
+  --> $DIR/drop-order-comparisons.rs:324:12
    |
 LL |         if let Ok(_) = e.err(7) {} else {
    |            ^^^^^^^^^^^^--------
@@ -339,12 +314,12 @@ LL |         if let Ok(_) = e.err(7) {} else {
    |                        this value has a significant drop implementation which may observe a major change in drop order and requires your discretion
    |
 note: value invokes this custom destructor
-  --> $DIR/drop-order-comparisons.rs:503:1
+  --> $DIR/drop-order-comparisons.rs:501:1
    |
 LL | impl<'b> Drop for LogDrop<'b> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: the value is now dropped here in Edition 2024
-  --> $DIR/drop-order-comparisons.rs:326:34
+  --> $DIR/drop-order-comparisons.rs:324:34
    |
 LL |         if let Ok(_) = e.err(7) {} else {
    |                                  ^
@@ -360,7 +335,7 @@ LL ~         }}}}}}}}};
    |
 
 warning: `if let` assigns a shorter lifetime since Edition 2024
-  --> $DIR/drop-order-comparisons.rs:329:12
+  --> $DIR/drop-order-comparisons.rs:327:12
    |
 LL |         if let Ok(_) = e.err(6).as_ref() {} else {
    |            ^^^^^^^^^^^^--------^^^^^^^^^
@@ -368,12 +343,12 @@ LL |         if let Ok(_) = e.err(6).as_ref() {} else {
    |                        this value has a significant drop implementation which may observe a major change in drop order and requires your discretion
    |
 note: value invokes this custom destructor
-  --> $DIR/drop-order-comparisons.rs:503:1
+  --> $DIR/drop-order-comparisons.rs:501:1
    |
 LL | impl<'b> Drop for LogDrop<'b> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: the value is now dropped here in Edition 2024
-  --> $DIR/drop-order-comparisons.rs:329:43
+  --> $DIR/drop-order-comparisons.rs:327:43
    |
 LL |         if let Ok(_) = e.err(6).as_ref() {} else {
    |                                           ^
@@ -389,7 +364,7 @@ LL ~         }}}}}}}}};
    |
 
 warning: `if let` assigns a shorter lifetime since Edition 2024
-  --> $DIR/drop-order-comparisons.rs:333:12
+  --> $DIR/drop-order-comparisons.rs:331:12
    |
 LL |         if let Ok(_v) = e.err(5) {} else {
    |            ^^^^^^^^^^^^^--------
@@ -397,12 +372,12 @@ LL |         if let Ok(_v) = e.err(5) {} else {
    |                         this value has a significant drop implementation which may observe a major change in drop order and requires your discretion
    |
 note: value invokes this custom destructor
-  --> $DIR/drop-order-comparisons.rs:503:1
+  --> $DIR/drop-order-comparisons.rs:501:1
    |
 LL | impl<'b> Drop for LogDrop<'b> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: the value is now dropped here in Edition 2024
-  --> $DIR/drop-order-comparisons.rs:333:35
+  --> $DIR/drop-order-comparisons.rs:331:35
    |
 LL |         if let Ok(_v) = e.err(5) {} else {
    |                                   ^
@@ -418,7 +393,7 @@ LL ~         }}}}}}}}};
    |
 
 warning: `if let` assigns a shorter lifetime since Edition 2024
-  --> $DIR/drop-order-comparisons.rs:336:12
+  --> $DIR/drop-order-comparisons.rs:334:12
    |
 LL |         if let Ok(_) = e.err(4) {} else {
    |            ^^^^^^^^^^^^--------
@@ -426,12 +401,12 @@ LL |         if let Ok(_) = e.err(4) {} else {
    |                        this value has a significant drop implementation which may observe a major change in drop order and requires your discretion
    |
 note: value invokes this custom destructor
-  --> $DIR/drop-order-comparisons.rs:503:1
+  --> $DIR/drop-order-comparisons.rs:501:1
    |
 LL | impl<'b> Drop for LogDrop<'b> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: the value is now dropped here in Edition 2024
-  --> $DIR/drop-order-comparisons.rs:336:34
+  --> $DIR/drop-order-comparisons.rs:334:34
    |
 LL |         if let Ok(_) = e.err(4) {} else {
    |                                  ^
@@ -447,7 +422,7 @@ LL ~         }}}}}}}}};
    |
 
 warning: `if let` assigns a shorter lifetime since Edition 2024
-  --> $DIR/drop-order-comparisons.rs:372:12
+  --> $DIR/drop-order-comparisons.rs:370:12
    |
 LL |         if let Ok(_) = e.err(4).as_ref() {} else {
    |            ^^^^^^^^^^^^--------^^^^^^^^^
@@ -455,12 +430,12 @@ LL |         if let Ok(_) = e.err(4).as_ref() {} else {
    |                        this value has a significant drop implementation which may observe a major change in drop order and requires your discretion
    |
 note: value invokes this custom destructor
-  --> $DIR/drop-order-comparisons.rs:503:1
+  --> $DIR/drop-order-comparisons.rs:501:1
    |
 LL | impl<'b> Drop for LogDrop<'b> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: the value is now dropped here in Edition 2024
-  --> $DIR/drop-order-comparisons.rs:372:43
+  --> $DIR/drop-order-comparisons.rs:370:43
    |
 LL |         if let Ok(_) = e.err(4).as_ref() {} else {
    |                                           ^
@@ -475,5 +450,5 @@ LL |             e.mark(3);
 LL ~         }}}}}}}}};
    |
 
-warning: 15 warnings emitted
+warning: 14 warnings emitted
 

--- a/tests/ui/drop/drop-order-comparisons.rs
+++ b/tests/ui/drop/drop-order-comparisons.rs
@@ -102,8 +102,6 @@ fn t_tailexpr_tuples() {
         (e.ok(2), e.ok(6).is_ok(), e.ok(3), e.ok(5).is_ok())
         //[e2021]~^ WARN relative drop order changing in Rust 2024
         //[e2021]~| WARN this changes meaning in Rust 2024
-        //[e2021]~| WARN relative drop order changing in Rust 2024
-        //[e2021]~| WARN this changes meaning in Rust 2024
     }, e.mark(1), e.ok(4));
     e.assert(6);
 }

--- a/tests/ui/nll/ice-106874.rs
+++ b/tests/ui/nll/ice-106874.rs
@@ -14,8 +14,6 @@ pub fn func<V, F: Fn(&mut V)>(f: F) -> A<impl X> {
     //~| ERROR implementation of `FnOnce` is not general enough
     //~| ERROR implementation of `Fn` is not general enough
     //~| ERROR implementation of `FnOnce` is not general enough
-    //~| ERROR higher-ranked subtype error
-    //~| ERROR higher-ranked subtype error
 }
 
 trait X {}

--- a/tests/ui/nll/ice-106874.stderr
+++ b/tests/ui/nll/ice-106874.stderr
@@ -25,20 +25,6 @@ help: consider adding an explicit type annotation to the closure's argument
 LL |     A(B(C::new(D::new(move |st: &mut V| f(st)))))
    |                               ++++++++
 
-error: higher-ranked subtype error
-  --> $DIR/ice-106874.rs:8:5
-   |
-LL |     A(B(C::new(D::new(move |st| f(st)))))
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: higher-ranked subtype error
-  --> $DIR/ice-106874.rs:8:5
-   |
-LL |     A(B(C::new(D::new(move |st| f(st)))))
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
 error: implementation of `FnOnce` is not general enough
   --> $DIR/ice-106874.rs:8:7
    |
@@ -121,5 +107,5 @@ help: consider adding an explicit type annotation to the closure's argument
 LL |     A(B(C::new(D::new(move |st: &mut V| f(st)))))
    |                               ++++++++
 
-error: aborting due to 10 previous errors
+error: aborting due to 8 previous errors
 

--- a/tests/ui/suggestions/ufcs-for-deref-inner-clone.stderr
+++ b/tests/ui/suggestions/ufcs-for-deref-inner-clone.stderr
@@ -2,8 +2,12 @@ error[E0507]: cannot move out of dereference of `MyBox<Vec<i32>>`
   --> $DIR/ufcs-for-deref-inner-clone.rs:14:14
    |
 LL |     let _x = MyBox(vec![1, 2]).into_iter();
-   |              ^^^^^^^^^^^^^^^^^ move occurs because value has type `Vec<i32>`, which does not implement the `Copy` trait
+   |              ^^^^^^^^^^^^^^^^^ ----------- value moved due to this method call
+   |              |
+   |              move occurs because value has type `Vec<i32>`, which does not implement the `Copy` trait
    |
+note: `into_iter` takes ownership of the receiver `self`, which moves value
+  --> $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
 help: you can `clone` the value and consume it, but this might not be your desired behavior
    |
 LL |     let _x = <Vec<i32> as Clone>::clone(&MyBox(vec![1, 2])).into_iter();


### PR DESCRIPTION
MIR building currently has 2 ways to build drops.

A normal exit from a scope uses `leave_top_scopes`, which calls `build_scope_drops`. That method generates a compact sequence of `StorageDead` statements and `Drop` terminators.

For anormal exits (`else`, `break`, `continue`, `return`, unwind and coroutine drop), we use a `DropTree` which is a much more flexible structure in which we record blocks as entry points.

In order to work correctly, `build_scope_drops` assumes a lot about the structure of the `DropTree`. This forbids us from unscheduling drops for moved-from locals. This PR removes it altogether, to always use the more flexible `DropTree`. The generated MIR should be equivalent, but more verbose.

r? @ghost for perf, and because of a borrowck corner case

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
