### PR TITLE
[rustc_abi] Customize `Debug` for `Primitive` and `Scalar`

### DIFF
--- a/compiler/rustc_abi/src/lib.rs
+++ b/compiler/rustc_abi/src/lib.rs
@@ -1391,10 +1391,21 @@ impl Float {
             F128 => dl.f128_align,
         })
     }
+
+    pub fn ty_str(self) -> &'static str {
+        use Float::*;
+
+        match self {
+            F16 => "f16",
+            F32 => "f32",
+            F64 => "f64",
+            F128 => "f128",
+        }
+    }
 }
 
 /// Fundamental unit of memory access and layout.
-#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "nightly", derive(StableHash))]
 pub enum Primitive {
     /// The `bool` is the signedness of the `Integer` type.
@@ -1407,6 +1418,29 @@ pub enum Primitive {
     Int(Integer, bool),
     Float(Float),
     Pointer(AddressSpace),
+}
+
+impl fmt::Debug for Primitive {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let name = match *self {
+            Primitive::Int(integer, is_signed) => {
+                if is_signed {
+                    integer.int_ty_str()
+                } else {
+                    integer.uint_ty_str()
+                }
+            }
+            Primitive::Float(float) => float.ty_str(),
+            Primitive::Pointer(addr_space) => {
+                if addr_space == AddressSpace::ZERO {
+                    "pointer"
+                } else {
+                    return write!(f, "pointer({addr_space:?})");
+                }
+            }
+        };
+        f.write_str(name)
+    }
 }
 
 impl Primitive {
@@ -1454,6 +1488,32 @@ pub struct WrappingRange {
 }
 
 impl WrappingRange {
+    fn debug_as(&self, size: Size, is_signed: bool) -> impl fmt::Debug {
+        let range = *self;
+        fmt::from_fn(move |f| {
+            if range == WrappingRange::full(size) {
+                // This is intentionally not using `is_full_for` so that we ensure
+                // different values always debug-print differently.
+                // We don't need the full details when it's the canonical full range,
+                // but if one is looking at the debug output it might be that seeing
+                // `u8 is (..=0) | (1..)` instead of `u8 is ..` is the information
+                // you needed because the problem is that despite being *a* full
+                // range it's not *the* canonical one you expected it was.
+                f.write_str("..")
+            } else if is_signed {
+                let start = size.sign_extend(range.start);
+                let end = size.sign_extend(range.end);
+                if start > end {
+                    write!(f, "(..={}) | ({}..)", end, start)
+                } else {
+                    write!(f, "{}..={}", start, end)
+                }
+            } else {
+                write!(f, "{:?}", range)
+            }
+        })
+    }
+
     pub fn full(size: Size) -> Self {
         Self { start: 0, end: size.unsigned_int_max() }
     }
@@ -1558,7 +1618,7 @@ impl fmt::Debug for WrappingRange {
 }
 
 /// Information about one scalar component of a Rust type.
-#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "nightly", derive(StableHash))]
 pub enum Scalar {
     Initialized {
@@ -1577,6 +1637,24 @@ pub enum Scalar {
         /// so there is no `valid_range`.
         value: Primitive,
     },
+}
+
+impl fmt::Debug for Scalar {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Scalar::Initialized { value, valid_range } => {
+                let (size, is_signed) = match *value {
+                    Primitive::Int(integer, is_signed) => (integer.size(), is_signed),
+                    Primitive::Float(float) => (float.size(), false),
+                    Primitive::Pointer(_) => (Size::from_bits(128), false),
+                };
+                write!(f, "{value:?} is {:?}", valid_range.debug_as(size, is_signed))
+            }
+            Scalar::Union { value } => {
+                write!(f, "union {value:?}")
+            }
+        }
+    }
 }
 
 impl Scalar {

--- a/tests/ui/abi/debug.generic.stderr
+++ b/tests/ui/abi/debug.generic.stderr
@@ -42,13 +42,7 @@ error: fn_abi_of(test) = FnAbi {
                                abi: $SOME_ALIGN,
                            },
                            backend_repr: Scalar(
-                               Initialized {
-                                   value: Int(
-                                       I8,
-                                       false,
-                                   ),
-                                   valid_range: 0..=255,
-                               },
+                               u8 is ..,
                            ),
                            fields: Primitive,
                            largest_niche: None,
@@ -80,22 +74,13 @@ error: fn_abi_of(test) = FnAbi {
                            abi: $SOME_ALIGN,
                        },
                        backend_repr: Scalar(
-                           Initialized {
-                               value: Int(
-                                   I8,
-                                   false,
-                               ),
-                               valid_range: 0..=1,
-                           },
+                           u8 is 0..=1,
                        ),
                        fields: Primitive,
                        largest_niche: Some(
                            Niche {
                                offset: Size(0 bytes),
-                               value: Int(
-                                   I8,
-                                   false,
-                               ),
+                               value: u8,
                                valid_range: 0..=1,
                            },
                        ),
@@ -138,22 +123,13 @@ error: fn_abi_of(TestFnPtr) = FnAbi {
                                abi: $SOME_ALIGN,
                            },
                            backend_repr: Scalar(
-                               Initialized {
-                                   value: Int(
-                                       I8,
-                                       false,
-                                   ),
-                                   valid_range: 0..=1,
-                               },
+                               u8 is 0..=1,
                            ),
                            fields: Primitive,
                            largest_niche: Some(
                                Niche {
                                    offset: Size(0 bytes),
-                                   value: Int(
-                                       I8,
-                                       false,
-                                   ),
+                                   value: u8,
                                    valid_range: 0..=1,
                                },
                            ),
@@ -185,13 +161,7 @@ error: fn_abi_of(TestFnPtr) = FnAbi {
                            abi: $SOME_ALIGN,
                        },
                        backend_repr: Scalar(
-                           Initialized {
-                               value: Int(
-                                   I8,
-                                   false,
-                               ),
-                               valid_range: 0..=255,
-                           },
+                           u8 is ..,
                        ),
                        fields: Primitive,
                        largest_niche: None,
@@ -234,14 +204,7 @@ error: fn_abi_of(test_generic) = FnAbi {
                                abi: $SOME_ALIGN,
                            },
                            backend_repr: Scalar(
-                               Initialized {
-                                   value: Pointer(
-                                       AddressSpace(
-                                           0,
-                                       ),
-                                   ),
-                                   valid_range: $FULL,
-                               },
+                               pointer is $FULL,
                            ),
                            fields: Primitive,
                            largest_niche: None,
@@ -319,13 +282,7 @@ error: ABIs are not compatible
                                abi: $SOME_ALIGN,
                            },
                            backend_repr: Scalar(
-                               Initialized {
-                                   value: Int(
-                                       I8,
-                                       false,
-                                   ),
-                                   valid_range: 0..=255,
-                               },
+                               u8 is ..,
                            ),
                            fields: Primitive,
                            largest_niche: None,
@@ -391,13 +348,7 @@ error: ABIs are not compatible
                                abi: $SOME_ALIGN,
                            },
                            backend_repr: Scalar(
-                               Initialized {
-                                   value: Int(
-                                       I32,
-                                       false,
-                                   ),
-                                   valid_range: $FULL,
-                               },
+                               u32 is ..,
                            ),
                            fields: Primitive,
                            largest_niche: None,
@@ -621,12 +572,7 @@ error: ABIs are not compatible
                                abi: $SOME_ALIGN,
                            },
                            backend_repr: Scalar(
-                               Initialized {
-                                   value: Float(
-                                       F32,
-                                   ),
-                                   valid_range: $FULL,
-                               },
+                               f32 is ..,
                            ),
                            fields: Primitive,
                            largest_niche: None,
@@ -692,13 +638,7 @@ error: ABIs are not compatible
                                abi: $SOME_ALIGN,
                            },
                            backend_repr: Scalar(
-                               Initialized {
-                                   value: Int(
-                                       I32,
-                                       false,
-                                   ),
-                                   valid_range: $FULL,
-                               },
+                               u32 is ..,
                            ),
                            fields: Primitive,
                            largest_niche: None,
@@ -770,13 +710,7 @@ error: ABIs are not compatible
                                abi: $SOME_ALIGN,
                            },
                            backend_repr: Scalar(
-                               Initialized {
-                                   value: Int(
-                                       I32,
-                                       true,
-                                   ),
-                                   valid_range: $FULL,
-                               },
+                               i32 is ..,
                            ),
                            fields: Primitive,
                            largest_niche: None,
@@ -842,13 +776,7 @@ error: ABIs are not compatible
                                abi: $SOME_ALIGN,
                            },
                            backend_repr: Scalar(
-                               Initialized {
-                                   value: Int(
-                                       I32,
-                                       false,
-                                   ),
-                                   valid_range: $FULL,
-                               },
+                               u32 is ..,
                            ),
                            fields: Primitive,
                            largest_niche: None,
@@ -934,24 +862,13 @@ error: fn_abi_of(assoc_test) = FnAbi {
                                abi: $SOME_ALIGN,
                            },
                            backend_repr: Scalar(
-                               Initialized {
-                                   value: Pointer(
-                                       AddressSpace(
-                                           0,
-                                       ),
-                                   ),
-                                   valid_range: $NON_NULL,
-                               },
+                               pointer is $NON_NULL,
                            ),
                            fields: Primitive,
                            largest_niche: Some(
                                Niche {
                                    offset: Size(0 bytes),
-                                   value: Pointer(
-                                       AddressSpace(
-                                           0,
-                                       ),
-                                   ),
+                                   value: pointer,
                                    valid_range: $NON_NULL,
                                },
                            ),

--- a/tests/ui/abi/debug.loongarch64.stderr
+++ b/tests/ui/abi/debug.loongarch64.stderr
@@ -42,13 +42,7 @@ error: fn_abi_of(test) = FnAbi {
                                abi: $SOME_ALIGN,
                            },
                            backend_repr: Scalar(
-                               Initialized {
-                                   value: Int(
-                                       I8,
-                                       false,
-                                   ),
-                                   valid_range: 0..=255,
-                               },
+                               u8 is ..,
                            ),
                            fields: Primitive,
                            largest_niche: None,
@@ -80,22 +74,13 @@ error: fn_abi_of(test) = FnAbi {
                            abi: $SOME_ALIGN,
                        },
                        backend_repr: Scalar(
-                           Initialized {
-                               value: Int(
-                                   I8,
-                                   false,
-                               ),
-                               valid_range: 0..=1,
-                           },
+                           u8 is 0..=1,
                        ),
                        fields: Primitive,
                        largest_niche: Some(
                            Niche {
                                offset: Size(0 bytes),
-                               value: Int(
-                                   I8,
-                                   false,
-                               ),
+                               value: u8,
                                valid_range: 0..=1,
                            },
                        ),
@@ -138,22 +123,13 @@ error: fn_abi_of(TestFnPtr) = FnAbi {
                                abi: $SOME_ALIGN,
                            },
                            backend_repr: Scalar(
-                               Initialized {
-                                   value: Int(
-                                       I8,
-                                       false,
-                                   ),
-                                   valid_range: 0..=1,
-                               },
+                               u8 is 0..=1,
                            ),
                            fields: Primitive,
                            largest_niche: Some(
                                Niche {
                                    offset: Size(0 bytes),
-                                   value: Int(
-                                       I8,
-                                       false,
-                                   ),
+                                   value: u8,
                                    valid_range: 0..=1,
                                },
                            ),
@@ -185,13 +161,7 @@ error: fn_abi_of(TestFnPtr) = FnAbi {
                            abi: $SOME_ALIGN,
                        },
                        backend_repr: Scalar(
-                           Initialized {
-                               value: Int(
-                                   I8,
-                                   false,
-                               ),
-                               valid_range: 0..=255,
-                           },
+                           u8 is ..,
                        ),
                        fields: Primitive,
                        largest_niche: None,
@@ -234,14 +204,7 @@ error: fn_abi_of(test_generic) = FnAbi {
                                abi: $SOME_ALIGN,
                            },
                            backend_repr: Scalar(
-                               Initialized {
-                                   value: Pointer(
-                                       AddressSpace(
-                                           0,
-                                       ),
-                                   ),
-                                   valid_range: $FULL,
-                               },
+                               pointer is $FULL,
                            ),
                            fields: Primitive,
                            largest_niche: None,
@@ -319,13 +282,7 @@ error: ABIs are not compatible
                                abi: $SOME_ALIGN,
                            },
                            backend_repr: Scalar(
-                               Initialized {
-                                   value: Int(
-                                       I8,
-                                       false,
-                                   ),
-                                   valid_range: 0..=255,
-                               },
+                               u8 is ..,
                            ),
                            fields: Primitive,
                            largest_niche: None,
@@ -391,13 +348,7 @@ error: ABIs are not compatible
                                abi: $SOME_ALIGN,
                            },
                            backend_repr: Scalar(
-                               Initialized {
-                                   value: Int(
-                                       I32,
-                                       false,
-                                   ),
-                                   valid_range: $FULL,
-                               },
+                               u32 is ..,
                            ),
                            fields: Primitive,
                            largest_niche: None,
@@ -621,12 +572,7 @@ error: ABIs are not compatible
                                abi: $SOME_ALIGN,
                            },
                            backend_repr: Scalar(
-                               Initialized {
-                                   value: Float(
-                                       F32,
-                                   ),
-                                   valid_range: $FULL,
-                               },
+                               f32 is ..,
                            ),
                            fields: Primitive,
                            largest_niche: None,
@@ -692,13 +638,7 @@ error: ABIs are not compatible
                                abi: $SOME_ALIGN,
                            },
                            backend_repr: Scalar(
-                               Initialized {
-                                   value: Int(
-                                       I32,
-                                       false,
-                                   ),
-                                   valid_range: $FULL,
-                               },
+                               u32 is ..,
                            ),
                            fields: Primitive,
                            largest_niche: None,
@@ -770,13 +710,7 @@ error: ABIs are not compatible
                                abi: $SOME_ALIGN,
                            },
                            backend_repr: Scalar(
-                               Initialized {
-                                   value: Int(
-                                       I32,
-                                       true,
-                                   ),
-                                   valid_range: $FULL,
-                               },
+                               i32 is ..,
                            ),
                            fields: Primitive,
                            largest_niche: None,
@@ -842,13 +776,7 @@ error: ABIs are not compatible
                                abi: $SOME_ALIGN,
                            },
                            backend_repr: Scalar(
-                               Initialized {
-                                   value: Int(
-                                       I32,
-                                       false,
-                                   ),
-                                   valid_range: $FULL,
-                               },
+                               u32 is ..,
                            ),
                            fields: Primitive,
                            largest_niche: None,
@@ -934,24 +862,13 @@ error: fn_abi_of(assoc_test) = FnAbi {
                                abi: $SOME_ALIGN,
                            },
                            backend_repr: Scalar(
-                               Initialized {
-                                   value: Pointer(
-                                       AddressSpace(
-                                           0,
-                                       ),
-                                   ),
-                                   valid_range: $NON_NULL,
-                               },
+                               pointer is $NON_NULL,
                            ),
                            fields: Primitive,
                            largest_niche: Some(
                                Niche {
                                    offset: Size(0 bytes),
-                                   value: Pointer(
-                                       AddressSpace(
-                                           0,
-                                       ),
-                                   ),
+                                   value: pointer,
                                    valid_range: $NON_NULL,
                                },
                            ),

--- a/tests/ui/abi/debug.riscv64.stderr
+++ b/tests/ui/abi/debug.riscv64.stderr
@@ -42,13 +42,7 @@ error: fn_abi_of(test) = FnAbi {
                                abi: $SOME_ALIGN,
                            },
                            backend_repr: Scalar(
-                               Initialized {
-                                   value: Int(
-                                       I8,
-                                       false,
-                                   ),
-                                   valid_range: 0..=255,
-                               },
+                               u8 is ..,
                            ),
                            fields: Primitive,
                            largest_niche: None,
@@ -80,22 +74,13 @@ error: fn_abi_of(test) = FnAbi {
                            abi: $SOME_ALIGN,
                        },
                        backend_repr: Scalar(
-                           Initialized {
-                               value: Int(
-                                   I8,
-                                   false,
-                               ),
-                               valid_range: 0..=1,
-                           },
+                           u8 is 0..=1,
                        ),
                        fields: Primitive,
                        largest_niche: Some(
                            Niche {
                                offset: Size(0 bytes),
-                               value: Int(
-                                   I8,
-                                   false,
-                               ),
+                               value: u8,
                                valid_range: 0..=1,
                            },
                        ),
@@ -138,22 +123,13 @@ error: fn_abi_of(TestFnPtr) = FnAbi {
                                abi: $SOME_ALIGN,
                            },
                            backend_repr: Scalar(
-                               Initialized {
-                                   value: Int(
-                                       I8,
-                                       false,
-                                   ),
-                                   valid_range: 0..=1,
-                               },
+                               u8 is 0..=1,
                            ),
                            fields: Primitive,
                            largest_niche: Some(
                                Niche {
                                    offset: Size(0 bytes),
-                                   value: Int(
-                                       I8,
-                                       false,
-                                   ),
+                                   value: u8,
                                    valid_range: 0..=1,
                                },
                            ),
@@ -185,13 +161,7 @@ error: fn_abi_of(TestFnPtr) = FnAbi {
                            abi: $SOME_ALIGN,
                        },
                        backend_repr: Scalar(
-                           Initialized {
-                               value: Int(
-                                   I8,
-                                   false,
-                               ),
-                               valid_range: 0..=255,
-                           },
+                           u8 is ..,
                        ),
                        fields: Primitive,
                        largest_niche: None,
@@ -234,14 +204,7 @@ error: fn_abi_of(test_generic) = FnAbi {
                                abi: $SOME_ALIGN,
                            },
                            backend_repr: Scalar(
-                               Initialized {
-                                   value: Pointer(
-                                       AddressSpace(
-                                           0,
-                                       ),
-                                   ),
-                                   valid_range: $FULL,
-                               },
+                               pointer is $FULL,
                            ),
                            fields: Primitive,
                            largest_niche: None,
@@ -319,13 +282,7 @@ error: ABIs are not compatible
                                abi: $SOME_ALIGN,
                            },
                            backend_repr: Scalar(
-                               Initialized {
-                                   value: Int(
-                                       I8,
-                                       false,
-                                   ),
-                                   valid_range: 0..=255,
-                               },
+                               u8 is ..,
                            ),
                            fields: Primitive,
                            largest_niche: None,
@@ -391,13 +348,7 @@ error: ABIs are not compatible
                                abi: $SOME_ALIGN,
                            },
                            backend_repr: Scalar(
-                               Initialized {
-                                   value: Int(
-                                       I32,
-                                       false,
-                                   ),
-                                   valid_range: $FULL,
-                               },
+                               u32 is ..,
                            ),
                            fields: Primitive,
                            largest_niche: None,
@@ -621,12 +572,7 @@ error: ABIs are not compatible
                                abi: $SOME_ALIGN,
                            },
                            backend_repr: Scalar(
-                               Initialized {
-                                   value: Float(
-                                       F32,
-                                   ),
-                                   valid_range: $FULL,
-                               },
+                               f32 is ..,
                            ),
                            fields: Primitive,
                            largest_niche: None,
@@ -692,13 +638,7 @@ error: ABIs are not compatible
                                abi: $SOME_ALIGN,
                            },
                            backend_repr: Scalar(
-                               Initialized {
-                                   value: Int(
-                                       I32,
-                                       false,
-                                   ),
-                                   valid_range: $FULL,
-                               },
+                               u32 is ..,
                            ),
                            fields: Primitive,
                            largest_niche: None,
@@ -770,13 +710,7 @@ error: ABIs are not compatible
                                abi: $SOME_ALIGN,
                            },
                            backend_repr: Scalar(
-                               Initialized {
-                                   value: Int(
-                                       I32,
-                                       true,
-                                   ),
-                                   valid_range: $FULL,
-                               },
+                               i32 is ..,
                            ),
                            fields: Primitive,
                            largest_niche: None,
@@ -842,13 +776,7 @@ error: ABIs are not compatible
                                abi: $SOME_ALIGN,
                            },
                            backend_repr: Scalar(
-                               Initialized {
-                                   value: Int(
-                                       I32,
-                                       false,
-                                   ),
-                                   valid_range: $FULL,
-                               },
+                               u32 is ..,
                            ),
                            fields: Primitive,
                            largest_niche: None,
@@ -934,24 +862,13 @@ error: fn_abi_of(assoc_test) = FnAbi {
                                abi: $SOME_ALIGN,
                            },
                            backend_repr: Scalar(
-                               Initialized {
-                                   value: Pointer(
-                                       AddressSpace(
-                                           0,
-                                       ),
-                                   ),
-                                   valid_range: $NON_NULL,
-                               },
+                               pointer is $NON_NULL,
                            ),
                            fields: Primitive,
                            largest_niche: Some(
                                Niche {
                                    offset: Size(0 bytes),
-                                   value: Pointer(
-                                       AddressSpace(
-                                           0,
-                                       ),
-                                   ),
+                                   value: pointer,
                                    valid_range: $NON_NULL,
                                },
                            ),

--- a/tests/ui/abi/debug.rs
+++ b/tests/ui/abi/debug.rs
@@ -3,9 +3,9 @@
 //@ normalize-stderr: "randomization_seed: \d+" -> "randomization_seed: $$SEED"
 //@ normalize-stderr: "(size): Size\([48] bytes\)" -> "$1: $$SOME_SIZE"
 //@ normalize-stderr: "(can_unwind): (true|false)" -> "$1: $$SOME_BOOL"
-//@ normalize-stderr: "(valid_range): 0\.\.=(4294967295|18446744073709551615)" -> "$1: $$FULL"
+//@ normalize-stderr: "(pointer is|valid_range:) 0\.\.=(4294967295|18446744073709551615)" -> "$1 $$FULL"
 // This pattern is prepared for when we account for alignment in the niche.
-//@ normalize-stderr: "(valid_range): [1-9]\.\.=(429496729[0-9]|1844674407370955161[0-9])" -> "$1: $$NON_NULL"
+//@ normalize-stderr: "(pointer is|valid_range:) [1-9]\.\.=(429496729[0-9]|1844674407370955161[0-9])" -> "$1 $$NON_NULL"
 // Some attributes are only computed for release builds:
 //@ compile-flags: -O
 //@ revisions: generic riscv64 loongarch64

--- a/tests/ui/abi/numbers-arithmetic/x86-64-sysv64-arg-ext.apple.stderr
+++ b/tests/ui/abi/numbers-arithmetic/x86-64-sysv64-arg-ext.apple.stderr
@@ -9,13 +9,7 @@ error: fn_abi_of(i8) = FnAbi {
                                abi: Align(1 bytes),
                            },
                            backend_repr: Scalar(
-                               Initialized {
-                                   value: Int(
-                                       I8,
-                                       true,
-                                   ),
-                                   valid_range: 0..=255,
-                               },
+                               i8 is ..,
                            ),
                            fields: Primitive,
                            largest_niche: None,
@@ -47,13 +41,7 @@ error: fn_abi_of(i8) = FnAbi {
                            abi: Align(1 bytes),
                        },
                        backend_repr: Scalar(
-                           Initialized {
-                               value: Int(
-                                   I8,
-                                   true,
-                               ),
-                               valid_range: 0..=255,
-                           },
+                           i8 is ..,
                        ),
                        fields: Primitive,
                        largest_niche: None,
@@ -98,13 +86,7 @@ error: fn_abi_of(u8) = FnAbi {
                                abi: Align(1 bytes),
                            },
                            backend_repr: Scalar(
-                               Initialized {
-                                   value: Int(
-                                       I8,
-                                       false,
-                                   ),
-                                   valid_range: 0..=255,
-                               },
+                               u8 is ..,
                            ),
                            fields: Primitive,
                            largest_niche: None,
@@ -136,13 +118,7 @@ error: fn_abi_of(u8) = FnAbi {
                            abi: Align(1 bytes),
                        },
                        backend_repr: Scalar(
-                           Initialized {
-                               value: Int(
-                                   I8,
-                                   false,
-                               ),
-                               valid_range: 0..=255,
-                           },
+                           u8 is ..,
                        ),
                        fields: Primitive,
                        largest_niche: None,
@@ -187,13 +163,7 @@ error: fn_abi_of(i16) = FnAbi {
                                abi: Align(2 bytes),
                            },
                            backend_repr: Scalar(
-                               Initialized {
-                                   value: Int(
-                                       I16,
-                                       true,
-                                   ),
-                                   valid_range: 0..=65535,
-                               },
+                               i16 is ..,
                            ),
                            fields: Primitive,
                            largest_niche: None,
@@ -225,13 +195,7 @@ error: fn_abi_of(i16) = FnAbi {
                            abi: Align(2 bytes),
                        },
                        backend_repr: Scalar(
-                           Initialized {
-                               value: Int(
-                                   I16,
-                                   true,
-                               ),
-                               valid_range: 0..=65535,
-                           },
+                           i16 is ..,
                        ),
                        fields: Primitive,
                        largest_niche: None,
@@ -276,13 +240,7 @@ error: fn_abi_of(u16) = FnAbi {
                                abi: Align(2 bytes),
                            },
                            backend_repr: Scalar(
-                               Initialized {
-                                   value: Int(
-                                       I16,
-                                       false,
-                                   ),
-                                   valid_range: 0..=65535,
-                               },
+                               u16 is ..,
                            ),
                            fields: Primitive,
                            largest_niche: None,
@@ -314,13 +272,7 @@ error: fn_abi_of(u16) = FnAbi {
                            abi: Align(2 bytes),
                        },
                        backend_repr: Scalar(
-                           Initialized {
-                               value: Int(
-                                   I16,
-                                   false,
-                               ),
-                               valid_range: 0..=65535,
-                           },
+                           u16 is ..,
                        ),
                        fields: Primitive,
                        largest_niche: None,
@@ -365,13 +317,7 @@ error: fn_abi_of(i32) = FnAbi {
                                abi: Align(4 bytes),
                            },
                            backend_repr: Scalar(
-                               Initialized {
-                                   value: Int(
-                                       I32,
-                                       true,
-                                   ),
-                                   valid_range: 0..=4294967295,
-                               },
+                               i32 is ..,
                            ),
                            fields: Primitive,
                            largest_niche: None,
@@ -403,13 +349,7 @@ error: fn_abi_of(i32) = FnAbi {
                            abi: Align(4 bytes),
                        },
                        backend_repr: Scalar(
-                           Initialized {
-                               value: Int(
-                                   I32,
-                                   true,
-                               ),
-                               valid_range: 0..=4294967295,
-                           },
+                           i32 is ..,
                        ),
                        fields: Primitive,
                        largest_niche: None,
@@ -454,13 +394,7 @@ error: fn_abi_of(u32) = FnAbi {
                                abi: Align(4 bytes),
                            },
                            backend_repr: Scalar(
-                               Initialized {
-                                   value: Int(
-                                       I32,
-                                       false,
-                                   ),
-                                   valid_range: 0..=4294967295,
-                               },
+                               u32 is ..,
                            ),
                            fields: Primitive,
                            largest_niche: None,
@@ -492,13 +426,7 @@ error: fn_abi_of(u32) = FnAbi {
                            abi: Align(4 bytes),
                        },
                        backend_repr: Scalar(
-                           Initialized {
-                               value: Int(
-                                   I32,
-                                   false,
-                               ),
-                               valid_range: 0..=4294967295,
-                           },
+                           u32 is ..,
                        ),
                        fields: Primitive,
                        largest_niche: None,

--- a/tests/ui/abi/numbers-arithmetic/x86-64-sysv64-arg-ext.other.stderr
+++ b/tests/ui/abi/numbers-arithmetic/x86-64-sysv64-arg-ext.other.stderr
@@ -9,13 +9,7 @@ error: fn_abi_of(i8) = FnAbi {
                                abi: Align(1 bytes),
                            },
                            backend_repr: Scalar(
-                               Initialized {
-                                   value: Int(
-                                       I8,
-                                       true,
-                                   ),
-                                   valid_range: 0..=255,
-                               },
+                               i8 is ..,
                            ),
                            fields: Primitive,
                            largest_niche: None,
@@ -47,13 +41,7 @@ error: fn_abi_of(i8) = FnAbi {
                            abi: Align(1 bytes),
                        },
                        backend_repr: Scalar(
-                           Initialized {
-                               value: Int(
-                                   I8,
-                                   true,
-                               ),
-                               valid_range: 0..=255,
-                           },
+                           i8 is ..,
                        ),
                        fields: Primitive,
                        largest_niche: None,
@@ -98,13 +86,7 @@ error: fn_abi_of(u8) = FnAbi {
                                abi: Align(1 bytes),
                            },
                            backend_repr: Scalar(
-                               Initialized {
-                                   value: Int(
-                                       I8,
-                                       false,
-                                   ),
-                                   valid_range: 0..=255,
-                               },
+                               u8 is ..,
                            ),
                            fields: Primitive,
                            largest_niche: None,
@@ -136,13 +118,7 @@ error: fn_abi_of(u8) = FnAbi {
                            abi: Align(1 bytes),
                        },
                        backend_repr: Scalar(
-                           Initialized {
-                               value: Int(
-                                   I8,
-                                   false,
-                               ),
-                               valid_range: 0..=255,
-                           },
+                           u8 is ..,
                        ),
                        fields: Primitive,
                        largest_niche: None,
@@ -187,13 +163,7 @@ error: fn_abi_of(i16) = FnAbi {
                                abi: Align(2 bytes),
                            },
                            backend_repr: Scalar(
-                               Initialized {
-                                   value: Int(
-                                       I16,
-                                       true,
-                                   ),
-                                   valid_range: 0..=65535,
-                               },
+                               i16 is ..,
                            ),
                            fields: Primitive,
                            largest_niche: None,
@@ -225,13 +195,7 @@ error: fn_abi_of(i16) = FnAbi {
                            abi: Align(2 bytes),
                        },
                        backend_repr: Scalar(
-                           Initialized {
-                               value: Int(
-                                   I16,
-                                   true,
-                               ),
-                               valid_range: 0..=65535,
-                           },
+                           i16 is ..,
                        ),
                        fields: Primitive,
                        largest_niche: None,
@@ -276,13 +240,7 @@ error: fn_abi_of(u16) = FnAbi {
                                abi: Align(2 bytes),
                            },
                            backend_repr: Scalar(
-                               Initialized {
-                                   value: Int(
-                                       I16,
-                                       false,
-                                   ),
-                                   valid_range: 0..=65535,
-                               },
+                               u16 is ..,
                            ),
                            fields: Primitive,
                            largest_niche: None,
@@ -314,13 +272,7 @@ error: fn_abi_of(u16) = FnAbi {
                            abi: Align(2 bytes),
                        },
                        backend_repr: Scalar(
-                           Initialized {
-                               value: Int(
-                                   I16,
-                                   false,
-                               ),
-                               valid_range: 0..=65535,
-                           },
+                           u16 is ..,
                        ),
                        fields: Primitive,
                        largest_niche: None,
@@ -365,13 +317,7 @@ error: fn_abi_of(i32) = FnAbi {
                                abi: Align(4 bytes),
                            },
                            backend_repr: Scalar(
-                               Initialized {
-                                   value: Int(
-                                       I32,
-                                       true,
-                                   ),
-                                   valid_range: 0..=4294967295,
-                               },
+                               i32 is ..,
                            ),
                            fields: Primitive,
                            largest_niche: None,
@@ -403,13 +349,7 @@ error: fn_abi_of(i32) = FnAbi {
                            abi: Align(4 bytes),
                        },
                        backend_repr: Scalar(
-                           Initialized {
-                               value: Int(
-                                   I32,
-                                   true,
-                               ),
-                               valid_range: 0..=4294967295,
-                           },
+                           i32 is ..,
                        ),
                        fields: Primitive,
                        largest_niche: None,
@@ -454,13 +394,7 @@ error: fn_abi_of(u32) = FnAbi {
                                abi: Align(4 bytes),
                            },
                            backend_repr: Scalar(
-                               Initialized {
-                                   value: Int(
-                                       I32,
-                                       false,
-                                   ),
-                                   valid_range: 0..=4294967295,
-                               },
+                               u32 is ..,
                            ),
                            fields: Primitive,
                            largest_niche: None,
@@ -492,13 +426,7 @@ error: fn_abi_of(u32) = FnAbi {
                            abi: Align(4 bytes),
                        },
                        backend_repr: Scalar(
-                           Initialized {
-                               value: Int(
-                                   I32,
-                                   false,
-                               ),
-                               valid_range: 0..=4294967295,
-                           },
+                           u32 is ..,
                        ),
                        fields: Primitive,
                        largest_niche: None,

--- a/tests/ui/c-variadic/pass-by-value-abi.rs
+++ b/tests/ui/c-variadic/pass-by-value-abi.rs
@@ -1,6 +1,6 @@
 //@ check-fail
 //@ normalize-stderr: "randomization_seed: \d+" -> "randomization_seed: $$SEED"
-//@ normalize-stderr: "valid_range: 0\.\.=\d+" -> "valid_range: 0..=$$MAX"
+//@ normalize-stderr: "pointer is 0\.\.=\d+" -> "pointer is 0..=$$MAX"
 //@ normalize-stderr: "in_memory_order: \[[^\]]+\]" -> "in_memory_order: $$MEMORY_INDEX"
 //@ normalize-stderr: "offsets: \[[^\]]+\]" -> "offsets: $$OFFSETS"
 //@ revisions: x86_64 aarch64 win

--- a/tests/ui/c-variadic/pass-by-value-abi.win.stderr
+++ b/tests/ui/c-variadic/pass-by-value-abi.win.stderr
@@ -9,14 +9,7 @@ error: fn_abi_of(take_va_list) = FnAbi {
                                abi: Align(8 bytes),
                            },
                            backend_repr: Scalar(
-                               Initialized {
-                                   value: Pointer(
-                                       AddressSpace(
-                                           0,
-                                       ),
-                                   ),
-                                   valid_range: 0..=$MAX,
-                               },
+                               pointer is 0..=$MAX,
                            ),
                            fields: Arbitrary {
                                offsets: $OFFSETS,

--- a/tests/ui/enum-discriminant/wrapping_niche.stderr
+++ b/tests/ui/enum-discriminant/wrapping_niche.stderr
@@ -4,13 +4,7 @@ error: layout_of(UnsignedAroundZero) = Layout {
                abi: Align(2 bytes),
            },
            backend_repr: Scalar(
-               Initialized {
-                   value: Int(
-                       I16,
-                       false,
-                   ),
-                   valid_range: (..=1) | (65535..),
-               },
+               u16 is (..=1) | (65535..),
            ),
            fields: Arbitrary {
                offsets: [
@@ -23,22 +17,13 @@ error: layout_of(UnsignedAroundZero) = Layout {
            largest_niche: Some(
                Niche {
                    offset: Size(0 bytes),
-                   value: Int(
-                       I16,
-                       false,
-                   ),
+                   value: u16,
                    valid_range: (..=1) | (65535..),
                },
            ),
            uninhabited: false,
            variants: Multiple {
-               tag: Initialized {
-                   value: Int(
-                       I16,
-                       false,
-                   ),
-                   valid_range: (..=1) | (65535..),
-               },
+               tag: u16 is (..=1) | (65535..),
                tag_encoding: Direct,
                tag_field: 0,
                variants: [
@@ -89,13 +74,7 @@ error: layout_of(SignedAroundZero) = Layout {
                abi: Align(2 bytes),
            },
            backend_repr: Scalar(
-               Initialized {
-                   value: Int(
-                       I16,
-                       true,
-                   ),
-                   valid_range: (..=1) | (65535..),
-               },
+               i16 is -1..=1,
            ),
            fields: Arbitrary {
                offsets: [
@@ -108,22 +87,13 @@ error: layout_of(SignedAroundZero) = Layout {
            largest_niche: Some(
                Niche {
                    offset: Size(0 bytes),
-                   value: Int(
-                       I16,
-                       true,
-                   ),
+                   value: i16,
                    valid_range: (..=1) | (65535..),
                },
            ),
            uninhabited: false,
            variants: Multiple {
-               tag: Initialized {
-                   value: Int(
-                       I16,
-                       true,
-                   ),
-                   valid_range: (..=1) | (65535..),
-               },
+               tag: i16 is -1..=1,
                tag_encoding: Direct,
                tag_field: 0,
                variants: [

--- a/tests/ui/layout/debug.stderr
+++ b/tests/ui/layout/debug.stderr
@@ -39,22 +39,13 @@ error: layout_of(E) = Layout {
            largest_niche: Some(
                Niche {
                    offset: Size(0 bytes),
-                   value: Int(
-                       I32,
-                       false,
-                   ),
+                   value: u32,
                    valid_range: 0..=0,
                },
            ),
            uninhabited: false,
            variants: Multiple {
-               tag: Initialized {
-                   value: Int(
-                       I32,
-                       false,
-                   ),
-                   valid_range: 0..=0,
-               },
+               tag: u32 is 0..=0,
                tag_encoding: Direct,
                tag_field: 0,
                variants: [
@@ -103,20 +94,8 @@ error: layout_of(S) = Layout {
                abi: Align(4 bytes),
            },
            backend_repr: ScalarPair {
-               a: Initialized {
-                   value: Int(
-                       I32,
-                       true,
-                   ),
-                   valid_range: 0..=4294967295,
-               },
-               b: Initialized {
-                   value: Int(
-                       I32,
-                       true,
-                   ),
-                   valid_range: 0..=4294967295,
-               },
+               a: i32 is ..,
+               b: i32 is ..,
                b_offset: Size(4 bytes),
            },
            fields: Arbitrary {
@@ -176,20 +155,8 @@ error: layout_of(Result<i32, i32>) = Layout {
                abi: Align(4 bytes),
            },
            backend_repr: ScalarPair {
-               a: Initialized {
-                   value: Int(
-                       I32,
-                       false,
-                   ),
-                   valid_range: 0..=1,
-               },
-               b: Initialized {
-                   value: Int(
-                       I32,
-                       true,
-                   ),
-                   valid_range: 0..=4294967295,
-               },
+               a: u32 is 0..=1,
+               b: i32 is ..,
                b_offset: Size(4 bytes),
            },
            fields: Arbitrary {
@@ -203,42 +170,21 @@ error: layout_of(Result<i32, i32>) = Layout {
            largest_niche: Some(
                Niche {
                    offset: Size(0 bytes),
-                   value: Int(
-                       I32,
-                       false,
-                   ),
+                   value: u32,
                    valid_range: 0..=1,
                },
            ),
            uninhabited: false,
            variants: Multiple {
-               tag: Initialized {
-                   value: Int(
-                       I32,
-                       false,
-                   ),
-                   valid_range: 0..=1,
-               },
+               tag: u32 is 0..=1,
                tag_encoding: Direct,
                tag_field: 0,
                variants: [
                    VariantLayout {
                        size: Size(8 bytes),
                        backend_repr: ScalarPair {
-                           a: Initialized {
-                               value: Int(
-                                   I32,
-                                   false,
-                               ),
-                               valid_range: 0..=1,
-                           },
-                           b: Initialized {
-                               value: Int(
-                                   I32,
-                                   true,
-                               ),
-                               valid_range: 0..=4294967295,
-                           },
+                           a: u32 is 0..=1,
+                           b: i32 is ..,
                            b_offset: Size(4 bytes),
                        },
                        field_offsets: [
@@ -253,20 +199,8 @@ error: layout_of(Result<i32, i32>) = Layout {
                    VariantLayout {
                        size: Size(8 bytes),
                        backend_repr: ScalarPair {
-                           a: Initialized {
-                               value: Int(
-                                   I32,
-                                   false,
-                               ),
-                               valid_range: 0..=1,
-                           },
-                           b: Initialized {
-                               value: Int(
-                                   I32,
-                                   true,
-                               ),
-                               valid_range: 0..=4294967295,
-                           },
+                           a: u32 is 0..=1,
+                           b: i32 is ..,
                            b_offset: Size(4 bytes),
                        },
                        field_offsets: [
@@ -295,13 +229,7 @@ error: layout_of(i32) = Layout {
                abi: Align(4 bytes),
            },
            backend_repr: Scalar(
-               Initialized {
-                   value: Int(
-                       I32,
-                       true,
-                   ),
-                   valid_range: 0..=4294967295,
-               },
+               i32 is ..,
            ),
            fields: Primitive,
            largest_niche: None,
@@ -499,12 +427,7 @@ error: layout_of(P5) = Layout {
                abi: Align(1 bytes),
            },
            backend_repr: Scalar(
-               Union {
-                   value: Int(
-                       I8,
-                       false,
-                   ),
-               },
+               union u8,
            ),
            fields: Union(
                2,
@@ -529,12 +452,7 @@ error: layout_of(MaybeUninit<u8>) = Layout {
                abi: Align(1 bytes),
            },
            backend_repr: Scalar(
-               Union {
-                   value: Int(
-                       I8,
-                       false,
-                   ),
-               },
+               union u8,
            ),
            fields: Union(
                2,
@@ -580,13 +498,7 @@ error: layout_of(Option<bool>) = Layout {
                abi: Align(1 bytes),
            },
            backend_repr: Scalar(
-               Initialized {
-                   value: Int(
-                       I8,
-                       false,
-                   ),
-                   valid_range: 0..=2,
-               },
+               u8 is 0..=2,
            ),
            fields: Arbitrary {
                offsets: [
@@ -599,22 +511,13 @@ error: layout_of(Option<bool>) = Layout {
            largest_niche: Some(
                Niche {
                    offset: Size(0 bytes),
-                   value: Int(
-                       I8,
-                       false,
-                   ),
+                   value: u8,
                    valid_range: 0..=2,
                },
            ),
            uninhabited: false,
            variants: Multiple {
-               tag: Initialized {
-                   value: Int(
-                       I8,
-                       false,
-                   ),
-                   valid_range: 0..=2,
-               },
+               tag: u8 is 0..=2,
                tag_encoding: Niche {
                    untagged_variant: 1,
                    niche_variants: 0..=0,
@@ -635,13 +538,7 @@ error: layout_of(Option<bool>) = Layout {
                    VariantLayout {
                        size: Size(1 bytes),
                        backend_repr: Scalar(
-                           Initialized {
-                               value: Int(
-                                   I8,
-                                   false,
-                               ),
-                               valid_range: 0..=1,
-                           },
+                           u8 is 0..=1,
                        ),
                        field_offsets: [
                            Size(0 bytes),
@@ -652,10 +549,7 @@ error: layout_of(Option<bool>) = Layout {
                        largest_niche: Some(
                            Niche {
                                offset: Size(0 bytes),
-                               value: Int(
-                                   I8,
-                                   false,
-                               ),
+                               value: u8,
                                valid_range: 0..=1,
                            },
                        ),
@@ -678,13 +572,7 @@ error: layout_of(Option<char>) = Layout {
                abi: Align(4 bytes),
            },
            backend_repr: Scalar(
-               Initialized {
-                   value: Int(
-                       I32,
-                       false,
-                   ),
-                   valid_range: (..=1114111) | (4294967295..),
-               },
+               u32 is (..=1114111) | (4294967295..),
            ),
            fields: Arbitrary {
                offsets: [
@@ -697,22 +585,13 @@ error: layout_of(Option<char>) = Layout {
            largest_niche: Some(
                Niche {
                    offset: Size(0 bytes),
-                   value: Int(
-                       I32,
-                       false,
-                   ),
+                   value: u32,
                    valid_range: (..=1114111) | (4294967295..),
                },
            ),
            uninhabited: false,
            variants: Multiple {
-               tag: Initialized {
-                   value: Int(
-                       I32,
-                       false,
-                   ),
-                   valid_range: (..=1114111) | (4294967295..),
-               },
+               tag: u32 is (..=1114111) | (4294967295..),
                tag_encoding: Niche {
                    untagged_variant: 1,
                    niche_variants: 0..=0,
@@ -733,13 +612,7 @@ error: layout_of(Option<char>) = Layout {
                    VariantLayout {
                        size: Size(4 bytes),
                        backend_repr: Scalar(
-                           Initialized {
-                               value: Int(
-                                   I32,
-                                   false,
-                               ),
-                               valid_range: 0..=1114111,
-                           },
+                           u32 is 0..=1114111,
                        ),
                        field_offsets: [
                            Size(0 bytes),
@@ -750,10 +623,7 @@ error: layout_of(Option<char>) = Layout {
                        largest_niche: Some(
                            Niche {
                                offset: Size(0 bytes),
-                               value: Int(
-                                   I32,
-                                   false,
-                               ),
+                               value: u32,
                                valid_range: 0..=1114111,
                            },
                        ),

--- a/tests/ui/layout/enum-scalar-pair-int-ptr.rs
+++ b/tests/ui/layout/enum-scalar-pair-int-ptr.rs
@@ -1,6 +1,6 @@
 //@ normalize-stderr: "pref: Align\([1-8] bytes\)" -> "pref: $$PREF_ALIGN"
-//@ normalize-stderr: "Int\(I[0-9]+," -> "Int(I?,"
-//@ normalize-stderr: "valid_range: 0..=[0-9]+" -> "valid_range: $$VALID_RANGE"
+//@ normalize-stderr: "u[0-9]+ is" -> "u?? is"
+//@ normalize-stderr: "pointer is 0..=[0-9]+" -> "pointer is $$VALID_RANGE"
 //@ normalize-stderr: "b_offset: Size\([0-9]+ bytes\)" -> "b_offset: Size(? bytes)"
 
 //! Enum layout tests related to scalar pairs with an int/ptr common primitive.

--- a/tests/ui/layout/enum-scalar-pair-int-ptr.stderr
+++ b/tests/ui/layout/enum-scalar-pair-int-ptr.stderr
@@ -1,4 +1,4 @@
-error: backend_repr: ScalarPair { a: Initialized { value: Int(I?, false), valid_range: $VALID_RANGE }, b: Initialized { value: Pointer(AddressSpace(0)), valid_range: $VALID_RANGE }, b_offset: Size(? bytes) }
+error: backend_repr: ScalarPair { a: u?? is 0..=1, b: pointer is $VALID_RANGE, b_offset: Size(? bytes) }
   --> $DIR/enum-scalar-pair-int-ptr.rs:13:1
    |
 LL | enum ScalarPairPointerWithInt {

--- a/tests/ui/layout/enum.stderr
+++ b/tests/ui/layout/enum.stderr
@@ -10,7 +10,7 @@ error: size: Size(16 bytes)
 LL | enum UninhabitedVariantSpace {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: backend_repr: ScalarPair { a: Initialized { value: Int(I8, false), valid_range: 0..=1 }, b: Initialized { value: Int(I8, false), valid_range: 0..=255 }, b_offset: Size(1 bytes) }
+error: backend_repr: ScalarPair { a: u8 is 0..=1, b: u8 is .., b_offset: Size(1 bytes) }
   --> $DIR/enum.rs:21:1
    |
 LL | enum ScalarPairDifferingSign {

--- a/tests/ui/layout/hexagon-enum.stderr
+++ b/tests/ui/layout/hexagon-enum.stderr
@@ -4,13 +4,7 @@ error: layout_of(A) = Layout {
                abi: Align(1 bytes),
            },
            backend_repr: Scalar(
-               Initialized {
-                   value: Int(
-                       I8,
-                       false,
-                   ),
-                   valid_range: 0..=0,
-               },
+               u8 is 0..=0,
            ),
            fields: Arbitrary {
                offsets: [
@@ -23,22 +17,13 @@ error: layout_of(A) = Layout {
            largest_niche: Some(
                Niche {
                    offset: Size(0 bytes),
-                   value: Int(
-                       I8,
-                       false,
-                   ),
+                   value: u8,
                    valid_range: 0..=0,
                },
            ),
            uninhabited: false,
            variants: Multiple {
-               tag: Initialized {
-                   value: Int(
-                       I8,
-                       false,
-                   ),
-                   valid_range: 0..=0,
-               },
+               tag: u8 is 0..=0,
                tag_encoding: Direct,
                tag_field: 0,
                variants: [
@@ -69,13 +54,7 @@ error: layout_of(B) = Layout {
                abi: Align(1 bytes),
            },
            backend_repr: Scalar(
-               Initialized {
-                   value: Int(
-                       I8,
-                       false,
-                   ),
-                   valid_range: 255..=255,
-               },
+               u8 is 255..=255,
            ),
            fields: Arbitrary {
                offsets: [
@@ -88,22 +67,13 @@ error: layout_of(B) = Layout {
            largest_niche: Some(
                Niche {
                    offset: Size(0 bytes),
-                   value: Int(
-                       I8,
-                       false,
-                   ),
+                   value: u8,
                    valid_range: 255..=255,
                },
            ),
            uninhabited: false,
            variants: Multiple {
-               tag: Initialized {
-                   value: Int(
-                       I8,
-                       false,
-                   ),
-                   valid_range: 255..=255,
-               },
+               tag: u8 is 255..=255,
                tag_encoding: Direct,
                tag_field: 0,
                variants: [
@@ -134,13 +104,7 @@ error: layout_of(C) = Layout {
                abi: Align(2 bytes),
            },
            backend_repr: Scalar(
-               Initialized {
-                   value: Int(
-                       I16,
-                       false,
-                   ),
-                   valid_range: 256..=256,
-               },
+               u16 is 256..=256,
            ),
            fields: Arbitrary {
                offsets: [
@@ -153,22 +117,13 @@ error: layout_of(C) = Layout {
            largest_niche: Some(
                Niche {
                    offset: Size(0 bytes),
-                   value: Int(
-                       I16,
-                       false,
-                   ),
+                   value: u16,
                    valid_range: 256..=256,
                },
            ),
            uninhabited: false,
            variants: Multiple {
-               tag: Initialized {
-                   value: Int(
-                       I16,
-                       false,
-                   ),
-                   valid_range: 256..=256,
-               },
+               tag: u16 is 256..=256,
                tag_encoding: Direct,
                tag_field: 0,
                variants: [
@@ -199,13 +154,7 @@ error: layout_of(P) = Layout {
                abi: Align(4 bytes),
            },
            backend_repr: Scalar(
-               Initialized {
-                   value: Int(
-                       I32,
-                       false,
-                   ),
-                   valid_range: 268435456..=268435456,
-               },
+               u32 is 268435456..=268435456,
            ),
            fields: Arbitrary {
                offsets: [
@@ -218,22 +167,13 @@ error: layout_of(P) = Layout {
            largest_niche: Some(
                Niche {
                    offset: Size(0 bytes),
-                   value: Int(
-                       I32,
-                       false,
-                   ),
+                   value: u32,
                    valid_range: 268435456..=268435456,
                },
            ),
            uninhabited: false,
            variants: Multiple {
-               tag: Initialized {
-                   value: Int(
-                       I32,
-                       false,
-                   ),
-                   valid_range: 268435456..=268435456,
-               },
+               tag: u32 is 268435456..=268435456,
                tag_encoding: Direct,
                tag_field: 0,
                variants: [
@@ -264,13 +204,7 @@ error: layout_of(T) = Layout {
                abi: Align(4 bytes),
            },
            backend_repr: Scalar(
-               Initialized {
-                   value: Int(
-                       I32,
-                       true,
-                   ),
-                   valid_range: 2164260864..=2164260864,
-               },
+               i32 is -2130706432..=-2130706432,
            ),
            fields: Arbitrary {
                offsets: [
@@ -283,22 +217,13 @@ error: layout_of(T) = Layout {
            largest_niche: Some(
                Niche {
                    offset: Size(0 bytes),
-                   value: Int(
-                       I32,
-                       true,
-                   ),
+                   value: i32,
                    valid_range: 2164260864..=2164260864,
                },
            ),
            uninhabited: false,
            variants: Multiple {
-               tag: Initialized {
-                   value: Int(
-                       I32,
-                       true,
-                   ),
-                   valid_range: 2164260864..=2164260864,
-               },
+               tag: i32 is -2130706432..=-2130706432,
                tag_encoding: Direct,
                tag_field: 0,
                variants: [

--- a/tests/ui/layout/issue-96158-scalarpair-payload-might-be-uninit.stderr
+++ b/tests/ui/layout/issue-96158-scalarpair-payload-might-be-uninit.stderr
@@ -4,19 +4,8 @@ error: layout_of(MissingPayloadField) = Layout {
                abi: Align(1 bytes),
            },
            backend_repr: ScalarPair {
-               a: Initialized {
-                   value: Int(
-                       I8,
-                       false,
-                   ),
-                   valid_range: 0..=1,
-               },
-               b: Union {
-                   value: Int(
-                       I8,
-                       false,
-                   ),
-               },
+               a: u8 is 0..=1,
+               b: union u8,
                b_offset: Size(1 bytes),
            },
            fields: Arbitrary {
@@ -30,41 +19,21 @@ error: layout_of(MissingPayloadField) = Layout {
            largest_niche: Some(
                Niche {
                    offset: Size(0 bytes),
-                   value: Int(
-                       I8,
-                       false,
-                   ),
+                   value: u8,
                    valid_range: 0..=1,
                },
            ),
            uninhabited: false,
            variants: Multiple {
-               tag: Initialized {
-                   value: Int(
-                       I8,
-                       false,
-                   ),
-                   valid_range: 0..=1,
-               },
+               tag: u8 is 0..=1,
                tag_encoding: Direct,
                tag_field: 0,
                variants: [
                    VariantLayout {
                        size: Size(2 bytes),
                        backend_repr: ScalarPair {
-                           a: Initialized {
-                               value: Int(
-                                   I8,
-                                   false,
-                               ),
-                               valid_range: 0..=1,
-                           },
-                           b: Union {
-                               value: Int(
-                                   I8,
-                                   false,
-                               ),
-                           },
+                           a: u8 is 0..=1,
+                           b: union u8,
                            b_offset: Size(1 bytes),
                        },
                        field_offsets: [
@@ -103,20 +72,8 @@ error: layout_of(CommonPayloadField) = Layout {
                abi: Align(1 bytes),
            },
            backend_repr: ScalarPair {
-               a: Initialized {
-                   value: Int(
-                       I8,
-                       false,
-                   ),
-                   valid_range: 0..=1,
-               },
-               b: Initialized {
-                   value: Int(
-                       I8,
-                       false,
-                   ),
-                   valid_range: 0..=255,
-               },
+               a: u8 is 0..=1,
+               b: u8 is ..,
                b_offset: Size(1 bytes),
            },
            fields: Arbitrary {
@@ -130,42 +87,21 @@ error: layout_of(CommonPayloadField) = Layout {
            largest_niche: Some(
                Niche {
                    offset: Size(0 bytes),
-                   value: Int(
-                       I8,
-                       false,
-                   ),
+                   value: u8,
                    valid_range: 0..=1,
                },
            ),
            uninhabited: false,
            variants: Multiple {
-               tag: Initialized {
-                   value: Int(
-                       I8,
-                       false,
-                   ),
-                   valid_range: 0..=1,
-               },
+               tag: u8 is 0..=1,
                tag_encoding: Direct,
                tag_field: 0,
                variants: [
                    VariantLayout {
                        size: Size(2 bytes),
                        backend_repr: ScalarPair {
-                           a: Initialized {
-                               value: Int(
-                                   I8,
-                                   false,
-                               ),
-                               valid_range: 0..=1,
-                           },
-                           b: Initialized {
-                               value: Int(
-                                   I8,
-                                   false,
-                               ),
-                               valid_range: 0..=255,
-                           },
+                           a: u8 is 0..=1,
+                           b: u8 is ..,
                            b_offset: Size(1 bytes),
                        },
                        field_offsets: [
@@ -180,20 +116,8 @@ error: layout_of(CommonPayloadField) = Layout {
                    VariantLayout {
                        size: Size(2 bytes),
                        backend_repr: ScalarPair {
-                           a: Initialized {
-                               value: Int(
-                                   I8,
-                                   false,
-                               ),
-                               valid_range: 0..=1,
-                           },
-                           b: Initialized {
-                               value: Int(
-                                   I8,
-                                   false,
-                               ),
-                               valid_range: 0..=255,
-                           },
+                           a: u8 is 0..=1,
+                           b: u8 is ..,
                            b_offset: Size(1 bytes),
                        },
                        field_offsets: [
@@ -222,19 +146,8 @@ error: layout_of(CommonPayloadFieldIsMaybeUninit) = Layout {
                abi: Align(1 bytes),
            },
            backend_repr: ScalarPair {
-               a: Initialized {
-                   value: Int(
-                       I8,
-                       false,
-                   ),
-                   valid_range: 0..=1,
-               },
-               b: Union {
-                   value: Int(
-                       I8,
-                       false,
-                   ),
-               },
+               a: u8 is 0..=1,
+               b: union u8,
                b_offset: Size(1 bytes),
            },
            fields: Arbitrary {
@@ -248,41 +161,21 @@ error: layout_of(CommonPayloadFieldIsMaybeUninit) = Layout {
            largest_niche: Some(
                Niche {
                    offset: Size(0 bytes),
-                   value: Int(
-                       I8,
-                       false,
-                   ),
+                   value: u8,
                    valid_range: 0..=1,
                },
            ),
            uninhabited: false,
            variants: Multiple {
-               tag: Initialized {
-                   value: Int(
-                       I8,
-                       false,
-                   ),
-                   valid_range: 0..=1,
-               },
+               tag: u8 is 0..=1,
                tag_encoding: Direct,
                tag_field: 0,
                variants: [
                    VariantLayout {
                        size: Size(2 bytes),
                        backend_repr: ScalarPair {
-                           a: Initialized {
-                               value: Int(
-                                   I8,
-                                   false,
-                               ),
-                               valid_range: 0..=1,
-                           },
-                           b: Union {
-                               value: Int(
-                                   I8,
-                                   false,
-                               ),
-                           },
+                           a: u8 is 0..=1,
+                           b: union u8,
                            b_offset: Size(1 bytes),
                        },
                        field_offsets: [
@@ -297,19 +190,8 @@ error: layout_of(CommonPayloadFieldIsMaybeUninit) = Layout {
                    VariantLayout {
                        size: Size(2 bytes),
                        backend_repr: ScalarPair {
-                           a: Initialized {
-                               value: Int(
-                                   I8,
-                                   false,
-                               ),
-                               valid_range: 0..=1,
-                           },
-                           b: Union {
-                               value: Int(
-                                   I8,
-                                   false,
-                               ),
-                           },
+                           a: u8 is 0..=1,
+                           b: union u8,
                            b_offset: Size(1 bytes),
                        },
                        field_offsets: [
@@ -338,19 +220,8 @@ error: layout_of(NicheFirst) = Layout {
                abi: Align(1 bytes),
            },
            backend_repr: ScalarPair {
-               a: Initialized {
-                   value: Int(
-                       I8,
-                       false,
-                   ),
-                   valid_range: 0..=4,
-               },
-               b: Union {
-                   value: Int(
-                       I8,
-                       false,
-                   ),
-               },
+               a: u8 is 0..=4,
+               b: union u8,
                b_offset: Size(1 bytes),
            },
            fields: Arbitrary {
@@ -364,22 +235,13 @@ error: layout_of(NicheFirst) = Layout {
            largest_niche: Some(
                Niche {
                    offset: Size(0 bytes),
-                   value: Int(
-                       I8,
-                       false,
-                   ),
+                   value: u8,
                    valid_range: 0..=4,
                },
            ),
            uninhabited: false,
            variants: Multiple {
-               tag: Initialized {
-                   value: Int(
-                       I8,
-                       false,
-                   ),
-                   valid_range: 0..=4,
-               },
+               tag: u8 is 0..=4,
                tag_encoding: Niche {
                    untagged_variant: 0,
                    niche_variants: 1..=2,
@@ -390,20 +252,8 @@ error: layout_of(NicheFirst) = Layout {
                    VariantLayout {
                        size: Size(2 bytes),
                        backend_repr: ScalarPair {
-                           a: Initialized {
-                               value: Int(
-                                   I8,
-                                   false,
-                               ),
-                               valid_range: 0..=2,
-                           },
-                           b: Initialized {
-                               value: Int(
-                                   I8,
-                                   false,
-                               ),
-                               valid_range: 0..=255,
-                           },
+                           a: u8 is 0..=2,
+                           b: u8 is ..,
                            b_offset: Size(1 bytes),
                        },
                        field_offsets: [
@@ -417,10 +267,7 @@ error: layout_of(NicheFirst) = Layout {
                        largest_niche: Some(
                            Niche {
                                offset: Size(0 bytes),
-                               value: Int(
-                                   I8,
-                                   false,
-                               ),
+                               value: u8,
                                valid_range: 0..=2,
                            },
                        ),
@@ -463,19 +310,8 @@ error: layout_of(NicheSecond) = Layout {
                abi: Align(1 bytes),
            },
            backend_repr: ScalarPair {
-               a: Initialized {
-                   value: Int(
-                       I8,
-                       false,
-                   ),
-                   valid_range: 0..=4,
-               },
-               b: Union {
-                   value: Int(
-                       I8,
-                       false,
-                   ),
-               },
+               a: u8 is 0..=4,
+               b: union u8,
                b_offset: Size(1 bytes),
            },
            fields: Arbitrary {
@@ -489,22 +325,13 @@ error: layout_of(NicheSecond) = Layout {
            largest_niche: Some(
                Niche {
                    offset: Size(0 bytes),
-                   value: Int(
-                       I8,
-                       false,
-                   ),
+                   value: u8,
                    valid_range: 0..=4,
                },
            ),
            uninhabited: false,
            variants: Multiple {
-               tag: Initialized {
-                   value: Int(
-                       I8,
-                       false,
-                   ),
-                   valid_range: 0..=4,
-               },
+               tag: u8 is 0..=4,
                tag_encoding: Niche {
                    untagged_variant: 0,
                    niche_variants: 1..=2,
@@ -515,20 +342,8 @@ error: layout_of(NicheSecond) = Layout {
                    VariantLayout {
                        size: Size(2 bytes),
                        backend_repr: ScalarPair {
-                           a: Initialized {
-                               value: Int(
-                                   I8,
-                                   false,
-                               ),
-                               valid_range: 0..=2,
-                           },
-                           b: Initialized {
-                               value: Int(
-                                   I8,
-                                   false,
-                               ),
-                               valid_range: 0..=255,
-                           },
+                           a: u8 is 0..=2,
+                           b: u8 is ..,
                            b_offset: Size(1 bytes),
                        },
                        field_offsets: [
@@ -542,10 +357,7 @@ error: layout_of(NicheSecond) = Layout {
                        largest_niche: Some(
                            Niche {
                                offset: Size(0 bytes),
-                               value: Int(
-                                   I8,
-                                   false,
-                               ),
+                               value: u8,
                                valid_range: 0..=2,
                            },
                        ),

--- a/tests/ui/layout/issue-96185-overaligned-enum.stderr
+++ b/tests/ui/layout/issue-96185-overaligned-enum.stderr
@@ -17,22 +17,13 @@ error: layout_of(Aligned1) = Layout {
            largest_niche: Some(
                Niche {
                    offset: Size(0 bytes),
-                   value: Int(
-                       I8,
-                       false,
-                   ),
+                   value: u8,
                    valid_range: 0..=1,
                },
            ),
            uninhabited: false,
            variants: Multiple {
-               tag: Initialized {
-                   value: Int(
-                       I8,
-                       false,
-                   ),
-                   valid_range: 0..=1,
-               },
+               tag: u8 is 0..=1,
                tag_encoding: Direct,
                tag_field: 0,
                variants: [
@@ -75,13 +66,7 @@ error: layout_of(Aligned2) = Layout {
                abi: Align(1 bytes),
            },
            backend_repr: Scalar(
-               Initialized {
-                   value: Int(
-                       I8,
-                       false,
-                   ),
-                   valid_range: 0..=1,
-               },
+               u8 is 0..=1,
            ),
            fields: Arbitrary {
                offsets: [
@@ -94,22 +79,13 @@ error: layout_of(Aligned2) = Layout {
            largest_niche: Some(
                Niche {
                    offset: Size(0 bytes),
-                   value: Int(
-                       I8,
-                       false,
-                   ),
+                   value: u8,
                    valid_range: 0..=1,
                },
            ),
            uninhabited: false,
            variants: Multiple {
-               tag: Initialized {
-                   value: Int(
-                       I8,
-                       false,
-                   ),
-                   valid_range: 0..=1,
-               },
+               tag: u8 is 0..=1,
                tag_encoding: Direct,
                tag_field: 0,
                variants: [

--- a/tests/ui/layout/struct.stderr
+++ b/tests/ui/layout/struct.stderr
@@ -4,7 +4,7 @@ error: backend_repr: Memory { sized: true }
 LL | struct AlignedZstPreventsScalar(i16, [i32; 0]);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: backend_repr: Scalar(Initialized { value: Int(I32, true), valid_range: 0..=4294967295 })
+error: backend_repr: Scalar(i32 is ..)
   --> $DIR/struct.rs:12:1
    |
 LL | struct AlignedZstButStillScalar(i32, [i16; 0]);

--- a/tests/ui/layout/thumb-enum.stderr
+++ b/tests/ui/layout/thumb-enum.stderr
@@ -4,13 +4,7 @@ error: layout_of(A) = Layout {
                abi: Align(1 bytes),
            },
            backend_repr: Scalar(
-               Initialized {
-                   value: Int(
-                       I8,
-                       false,
-                   ),
-                   valid_range: 0..=0,
-               },
+               u8 is 0..=0,
            ),
            fields: Arbitrary {
                offsets: [
@@ -23,22 +17,13 @@ error: layout_of(A) = Layout {
            largest_niche: Some(
                Niche {
                    offset: Size(0 bytes),
-                   value: Int(
-                       I8,
-                       false,
-                   ),
+                   value: u8,
                    valid_range: 0..=0,
                },
            ),
            uninhabited: false,
            variants: Multiple {
-               tag: Initialized {
-                   value: Int(
-                       I8,
-                       false,
-                   ),
-                   valid_range: 0..=0,
-               },
+               tag: u8 is 0..=0,
                tag_encoding: Direct,
                tag_field: 0,
                variants: [
@@ -69,13 +54,7 @@ error: layout_of(B) = Layout {
                abi: Align(1 bytes),
            },
            backend_repr: Scalar(
-               Initialized {
-                   value: Int(
-                       I8,
-                       false,
-                   ),
-                   valid_range: 255..=255,
-               },
+               u8 is 255..=255,
            ),
            fields: Arbitrary {
                offsets: [
@@ -88,22 +67,13 @@ error: layout_of(B) = Layout {
            largest_niche: Some(
                Niche {
                    offset: Size(0 bytes),
-                   value: Int(
-                       I8,
-                       false,
-                   ),
+                   value: u8,
                    valid_range: 255..=255,
                },
            ),
            uninhabited: false,
            variants: Multiple {
-               tag: Initialized {
-                   value: Int(
-                       I8,
-                       false,
-                   ),
-                   valid_range: 255..=255,
-               },
+               tag: u8 is 255..=255,
                tag_encoding: Direct,
                tag_field: 0,
                variants: [
@@ -134,13 +104,7 @@ error: layout_of(C) = Layout {
                abi: Align(2 bytes),
            },
            backend_repr: Scalar(
-               Initialized {
-                   value: Int(
-                       I16,
-                       false,
-                   ),
-                   valid_range: 256..=256,
-               },
+               u16 is 256..=256,
            ),
            fields: Arbitrary {
                offsets: [
@@ -153,22 +117,13 @@ error: layout_of(C) = Layout {
            largest_niche: Some(
                Niche {
                    offset: Size(0 bytes),
-                   value: Int(
-                       I16,
-                       false,
-                   ),
+                   value: u16,
                    valid_range: 256..=256,
                },
            ),
            uninhabited: false,
            variants: Multiple {
-               tag: Initialized {
-                   value: Int(
-                       I16,
-                       false,
-                   ),
-                   valid_range: 256..=256,
-               },
+               tag: u16 is 256..=256,
                tag_encoding: Direct,
                tag_field: 0,
                variants: [
@@ -199,13 +154,7 @@ error: layout_of(P) = Layout {
                abi: Align(4 bytes),
            },
            backend_repr: Scalar(
-               Initialized {
-                   value: Int(
-                       I32,
-                       false,
-                   ),
-                   valid_range: 268435456..=268435456,
-               },
+               u32 is 268435456..=268435456,
            ),
            fields: Arbitrary {
                offsets: [
@@ -218,22 +167,13 @@ error: layout_of(P) = Layout {
            largest_niche: Some(
                Niche {
                    offset: Size(0 bytes),
-                   value: Int(
-                       I32,
-                       false,
-                   ),
+                   value: u32,
                    valid_range: 268435456..=268435456,
                },
            ),
            uninhabited: false,
            variants: Multiple {
-               tag: Initialized {
-                   value: Int(
-                       I32,
-                       false,
-                   ),
-                   valid_range: 268435456..=268435456,
-               },
+               tag: u32 is 268435456..=268435456,
                tag_encoding: Direct,
                tag_field: 0,
                variants: [
@@ -264,13 +204,7 @@ error: layout_of(T) = Layout {
                abi: Align(4 bytes),
            },
            backend_repr: Scalar(
-               Initialized {
-                   value: Int(
-                       I32,
-                       true,
-                   ),
-                   valid_range: 2164260864..=2164260864,
-               },
+               i32 is -2130706432..=-2130706432,
            ),
            fields: Arbitrary {
                offsets: [
@@ -283,22 +217,13 @@ error: layout_of(T) = Layout {
            largest_niche: Some(
                Niche {
                    offset: Size(0 bytes),
-                   value: Int(
-                       I32,
-                       true,
-                   ),
+                   value: i32,
                    valid_range: 2164260864..=2164260864,
                },
            ),
            uninhabited: false,
            variants: Multiple {
-               tag: Initialized {
-                   value: Int(
-                       I32,
-                       true,
-                   ),
-                   valid_range: 2164260864..=2164260864,
-               },
+               tag: i32 is -2130706432..=-2130706432,
                tag_encoding: Direct,
                tag_field: 0,
                variants: [

--- a/tests/ui/layout/zero-sized-array-enum-niche.stderr
+++ b/tests/ui/layout/zero-sized-array-enum-niche.stderr
@@ -17,22 +17,13 @@ error: layout_of(Result<[u32; 0], bool>) = Layout {
            largest_niche: Some(
                Niche {
                    offset: Size(0 bytes),
-                   value: Int(
-                       I8,
-                       false,
-                   ),
+                   value: u8,
                    valid_range: 0..=1,
                },
            ),
            uninhabited: false,
            variants: Multiple {
-               tag: Initialized {
-                   value: Int(
-                       I8,
-                       false,
-                   ),
-                   valid_range: 0..=1,
-               },
+               tag: u8 is 0..=1,
                tag_encoding: Direct,
                tag_field: 0,
                variants: [
@@ -64,10 +55,7 @@ error: layout_of(Result<[u32; 0], bool>) = Layout {
                        largest_niche: Some(
                            Niche {
                                offset: Size(1 bytes),
-                               value: Int(
-                                   I8,
-                                   false,
-                               ),
+                               value: u8,
                                valid_range: 0..=1,
                            },
                        ),
@@ -103,22 +91,13 @@ error: layout_of(MultipleAlignments) = Layout {
            largest_niche: Some(
                Niche {
                    offset: Size(0 bytes),
-                   value: Int(
-                       I8,
-                       false,
-                   ),
+                   value: u8,
                    valid_range: 0..=2,
                },
            ),
            uninhabited: false,
            variants: Multiple {
-               tag: Initialized {
-                   value: Int(
-                       I8,
-                       false,
-                   ),
-                   valid_range: 0..=2,
-               },
+               tag: u8 is 0..=2,
                tag_encoding: Direct,
                tag_field: 0,
                variants: [
@@ -164,10 +143,7 @@ error: layout_of(MultipleAlignments) = Layout {
                        largest_niche: Some(
                            Niche {
                                offset: Size(1 bytes),
-                               value: Int(
-                                   I8,
-                                   false,
-                               ),
+                               value: u8,
                                valid_range: 0..=1,
                            },
                        ),
@@ -203,22 +179,13 @@ error: layout_of(Result<[u32; 0], Packed<NonZero<u16>>>) = Layout {
            largest_niche: Some(
                Niche {
                    offset: Size(0 bytes),
-                   value: Int(
-                       I8,
-                       false,
-                   ),
+                   value: u8,
                    valid_range: 0..=1,
                },
            ),
            uninhabited: false,
            variants: Multiple {
-               tag: Initialized {
-                   value: Int(
-                       I8,
-                       false,
-                   ),
-                   valid_range: 0..=1,
-               },
+               tag: u8 is 0..=1,
                tag_encoding: Direct,
                tag_field: 0,
                variants: [
@@ -250,10 +217,7 @@ error: layout_of(Result<[u32; 0], Packed<NonZero<u16>>>) = Layout {
                        largest_niche: Some(
                            Niche {
                                offset: Size(1 bytes),
-                               value: Int(
-                                   I16,
-                                   false,
-                               ),
+                               value: u16,
                                valid_range: 1..=65535,
                            },
                        ),
@@ -289,22 +253,13 @@ error: layout_of(Result<[u32; 0], Packed<U16IsZero>>) = Layout {
            largest_niche: Some(
                Niche {
                    offset: Size(0 bytes),
-                   value: Int(
-                       I16,
-                       false,
-                   ),
+                   value: u16,
                    valid_range: (..=0) | (65535..),
                },
            ),
            uninhabited: false,
            variants: Multiple {
-               tag: Initialized {
-                   value: Int(
-                       I16,
-                       false,
-                   ),
-                   valid_range: (..=0) | (65535..),
-               },
+               tag: u16 is (..=0) | (65535..),
                tag_encoding: Niche {
                    untagged_variant: 1,
                    niche_variants: 0..=0,
@@ -340,10 +295,7 @@ error: layout_of(Result<[u32; 0], Packed<U16IsZero>>) = Layout {
                        largest_niche: Some(
                            Niche {
                                offset: Size(0 bytes),
-                               value: Int(
-                                   I16,
-                                   false,
-                               ),
+                               value: u16,
                                valid_range: 0..=0,
                            },
                        ),

--- a/tests/ui/repr/repr-c-dead-variants.aarch64-unknown-linux-gnu.stderr
+++ b/tests/ui/repr/repr-c-dead-variants.aarch64-unknown-linux-gnu.stderr
@@ -4,13 +4,7 @@ error: layout_of(Univariant) = Layout {
                abi: Align(4 bytes),
            },
            backend_repr: Scalar(
-               Initialized {
-                   value: Int(
-                       I32,
-                       false,
-                   ),
-                   valid_range: 0..=0,
-               },
+               u32 is 0..=0,
            ),
            fields: Arbitrary {
                offsets: [
@@ -23,35 +17,20 @@ error: layout_of(Univariant) = Layout {
            largest_niche: Some(
                Niche {
                    offset: Size(0 bytes),
-                   value: Int(
-                       I32,
-                       false,
-                   ),
+                   value: u32,
                    valid_range: 0..=0,
                },
            ),
            uninhabited: true,
            variants: Multiple {
-               tag: Initialized {
-                   value: Int(
-                       I32,
-                       false,
-                   ),
-                   valid_range: 0..=0,
-               },
+               tag: u32 is 0..=0,
                tag_encoding: Direct,
                tag_field: 0,
                variants: [
                    VariantLayout {
                        size: Size(4 bytes),
                        backend_repr: Scalar(
-                           Initialized {
-                               value: Int(
-                                   I32,
-                                   false,
-                               ),
-                               valid_range: 0..=0,
-                           },
+                           u32 is 0..=0,
                        ),
                        field_offsets: [
                            Size(4 bytes),
@@ -79,19 +58,8 @@ error: layout_of(TwoVariants) = Layout {
                abi: Align(4 bytes),
            },
            backend_repr: ScalarPair {
-               a: Initialized {
-                   value: Int(
-                       I32,
-                       false,
-                   ),
-                   valid_range: 0..=1,
-               },
-               b: Union {
-                   value: Int(
-                       I8,
-                       false,
-                   ),
-               },
+               a: u32 is 0..=1,
+               b: union u8,
                b_offset: Size(4 bytes),
            },
            fields: Arbitrary {
@@ -105,41 +73,21 @@ error: layout_of(TwoVariants) = Layout {
            largest_niche: Some(
                Niche {
                    offset: Size(0 bytes),
-                   value: Int(
-                       I32,
-                       false,
-                   ),
+                   value: u32,
                    valid_range: 0..=1,
                },
            ),
            uninhabited: false,
            variants: Multiple {
-               tag: Initialized {
-                   value: Int(
-                       I32,
-                       false,
-                   ),
-                   valid_range: 0..=1,
-               },
+               tag: u32 is 0..=1,
                tag_encoding: Direct,
                tag_field: 0,
                variants: [
                    VariantLayout {
                        size: Size(8 bytes),
                        backend_repr: ScalarPair {
-                           a: Initialized {
-                               value: Int(
-                                   I32,
-                                   false,
-                               ),
-                               valid_range: 0..=1,
-                           },
-                           b: Union {
-                               value: Int(
-                                   I8,
-                                   false,
-                               ),
-                           },
+                           a: u32 is 0..=1,
+                           b: union u8,
                            b_offset: Size(4 bytes),
                        },
                        field_offsets: [
@@ -154,19 +102,8 @@ error: layout_of(TwoVariants) = Layout {
                    VariantLayout {
                        size: Size(8 bytes),
                        backend_repr: ScalarPair {
-                           a: Initialized {
-                               value: Int(
-                                   I32,
-                                   false,
-                               ),
-                               valid_range: 0..=1,
-                           },
-                           b: Union {
-                               value: Int(
-                                   I8,
-                                   false,
-                               ),
-                           },
+                           a: u32 is 0..=1,
+                           b: union u8,
                            b_offset: Size(4 bytes),
                        },
                        field_offsets: [
@@ -208,22 +145,13 @@ error: layout_of(DeadBranchHasOtherField) = Layout {
            largest_niche: Some(
                Niche {
                    offset: Size(0 bytes),
-                   value: Int(
-                       I32,
-                       false,
-                   ),
+                   value: u32,
                    valid_range: 0..=1,
                },
            ),
            uninhabited: false,
            variants: Multiple {
-               tag: Initialized {
-                   value: Int(
-                       I32,
-                       false,
-                   ),
-                   valid_range: 0..=1,
-               },
+               tag: u32 is 0..=1,
                tag_encoding: Direct,
                tag_field: 0,
                variants: [

--- a/tests/ui/repr/repr-c-dead-variants.armebv7r-none-eabi.stderr
+++ b/tests/ui/repr/repr-c-dead-variants.armebv7r-none-eabi.stderr
@@ -4,13 +4,7 @@ error: layout_of(Univariant) = Layout {
                abi: Align(1 bytes),
            },
            backend_repr: Scalar(
-               Initialized {
-                   value: Int(
-                       I8,
-                       false,
-                   ),
-                   valid_range: 0..=0,
-               },
+               u8 is 0..=0,
            ),
            fields: Arbitrary {
                offsets: [
@@ -23,35 +17,20 @@ error: layout_of(Univariant) = Layout {
            largest_niche: Some(
                Niche {
                    offset: Size(0 bytes),
-                   value: Int(
-                       I8,
-                       false,
-                   ),
+                   value: u8,
                    valid_range: 0..=0,
                },
            ),
            uninhabited: true,
            variants: Multiple {
-               tag: Initialized {
-                   value: Int(
-                       I8,
-                       false,
-                   ),
-                   valid_range: 0..=0,
-               },
+               tag: u8 is 0..=0,
                tag_encoding: Direct,
                tag_field: 0,
                variants: [
                    VariantLayout {
                        size: Size(1 bytes),
                        backend_repr: Scalar(
-                           Initialized {
-                               value: Int(
-                                   I8,
-                                   false,
-                               ),
-                               valid_range: 0..=0,
-                           },
+                           u8 is 0..=0,
                        ),
                        field_offsets: [
                            Size(1 bytes),
@@ -79,19 +58,8 @@ error: layout_of(TwoVariants) = Layout {
                abi: Align(1 bytes),
            },
            backend_repr: ScalarPair {
-               a: Initialized {
-                   value: Int(
-                       I8,
-                       false,
-                   ),
-                   valid_range: 0..=1,
-               },
-               b: Union {
-                   value: Int(
-                       I8,
-                       false,
-                   ),
-               },
+               a: u8 is 0..=1,
+               b: union u8,
                b_offset: Size(1 bytes),
            },
            fields: Arbitrary {
@@ -105,41 +73,21 @@ error: layout_of(TwoVariants) = Layout {
            largest_niche: Some(
                Niche {
                    offset: Size(0 bytes),
-                   value: Int(
-                       I8,
-                       false,
-                   ),
+                   value: u8,
                    valid_range: 0..=1,
                },
            ),
            uninhabited: false,
            variants: Multiple {
-               tag: Initialized {
-                   value: Int(
-                       I8,
-                       false,
-                   ),
-                   valid_range: 0..=1,
-               },
+               tag: u8 is 0..=1,
                tag_encoding: Direct,
                tag_field: 0,
                variants: [
                    VariantLayout {
                        size: Size(2 bytes),
                        backend_repr: ScalarPair {
-                           a: Initialized {
-                               value: Int(
-                                   I8,
-                                   false,
-                               ),
-                               valid_range: 0..=1,
-                           },
-                           b: Union {
-                               value: Int(
-                                   I8,
-                                   false,
-                               ),
-                           },
+                           a: u8 is 0..=1,
+                           b: union u8,
                            b_offset: Size(1 bytes),
                        },
                        field_offsets: [
@@ -154,19 +102,8 @@ error: layout_of(TwoVariants) = Layout {
                    VariantLayout {
                        size: Size(2 bytes),
                        backend_repr: ScalarPair {
-                           a: Initialized {
-                               value: Int(
-                                   I8,
-                                   false,
-                               ),
-                               valid_range: 0..=1,
-                           },
-                           b: Union {
-                               value: Int(
-                                   I8,
-                                   false,
-                               ),
-                           },
+                           a: u8 is 0..=1,
+                           b: union u8,
                            b_offset: Size(1 bytes),
                        },
                        field_offsets: [
@@ -208,22 +145,13 @@ error: layout_of(DeadBranchHasOtherField) = Layout {
            largest_niche: Some(
                Niche {
                    offset: Size(0 bytes),
-                   value: Int(
-                       I8,
-                       false,
-                   ),
+                   value: u8,
                    valid_range: 0..=1,
                },
            ),
            uninhabited: false,
            variants: Multiple {
-               tag: Initialized {
-                   value: Int(
-                       I8,
-                       false,
-                   ),
-                   valid_range: 0..=1,
-               },
+               tag: u8 is 0..=1,
                tag_encoding: Direct,
                tag_field: 0,
                variants: [

--- a/tests/ui/repr/repr-c-dead-variants.i686-pc-windows-msvc.stderr
+++ b/tests/ui/repr/repr-c-dead-variants.i686-pc-windows-msvc.stderr
@@ -4,13 +4,7 @@ error: layout_of(Univariant) = Layout {
                abi: Align(4 bytes),
            },
            backend_repr: Scalar(
-               Initialized {
-                   value: Int(
-                       I32,
-                       false,
-                   ),
-                   valid_range: 0..=0,
-               },
+               u32 is 0..=0,
            ),
            fields: Arbitrary {
                offsets: [
@@ -23,35 +17,20 @@ error: layout_of(Univariant) = Layout {
            largest_niche: Some(
                Niche {
                    offset: Size(0 bytes),
-                   value: Int(
-                       I32,
-                       false,
-                   ),
+                   value: u32,
                    valid_range: 0..=0,
                },
            ),
            uninhabited: true,
            variants: Multiple {
-               tag: Initialized {
-                   value: Int(
-                       I32,
-                       false,
-                   ),
-                   valid_range: 0..=0,
-               },
+               tag: u32 is 0..=0,
                tag_encoding: Direct,
                tag_field: 0,
                variants: [
                    VariantLayout {
                        size: Size(4 bytes),
                        backend_repr: Scalar(
-                           Initialized {
-                               value: Int(
-                                   I32,
-                                   false,
-                               ),
-                               valid_range: 0..=0,
-                           },
+                           u32 is 0..=0,
                        ),
                        field_offsets: [
                            Size(4 bytes),
@@ -79,19 +58,8 @@ error: layout_of(TwoVariants) = Layout {
                abi: Align(4 bytes),
            },
            backend_repr: ScalarPair {
-               a: Initialized {
-                   value: Int(
-                       I32,
-                       false,
-                   ),
-                   valid_range: 0..=1,
-               },
-               b: Union {
-                   value: Int(
-                       I8,
-                       false,
-                   ),
-               },
+               a: u32 is 0..=1,
+               b: union u8,
                b_offset: Size(4 bytes),
            },
            fields: Arbitrary {
@@ -105,41 +73,21 @@ error: layout_of(TwoVariants) = Layout {
            largest_niche: Some(
                Niche {
                    offset: Size(0 bytes),
-                   value: Int(
-                       I32,
-                       false,
-                   ),
+                   value: u32,
                    valid_range: 0..=1,
                },
            ),
            uninhabited: false,
            variants: Multiple {
-               tag: Initialized {
-                   value: Int(
-                       I32,
-                       false,
-                   ),
-                   valid_range: 0..=1,
-               },
+               tag: u32 is 0..=1,
                tag_encoding: Direct,
                tag_field: 0,
                variants: [
                    VariantLayout {
                        size: Size(8 bytes),
                        backend_repr: ScalarPair {
-                           a: Initialized {
-                               value: Int(
-                                   I32,
-                                   false,
-                               ),
-                               valid_range: 0..=1,
-                           },
-                           b: Union {
-                               value: Int(
-                                   I8,
-                                   false,
-                               ),
-                           },
+                           a: u32 is 0..=1,
+                           b: union u8,
                            b_offset: Size(4 bytes),
                        },
                        field_offsets: [
@@ -154,19 +102,8 @@ error: layout_of(TwoVariants) = Layout {
                    VariantLayout {
                        size: Size(8 bytes),
                        backend_repr: ScalarPair {
-                           a: Initialized {
-                               value: Int(
-                                   I32,
-                                   false,
-                               ),
-                               valid_range: 0..=1,
-                           },
-                           b: Union {
-                               value: Int(
-                                   I8,
-                                   false,
-                               ),
-                           },
+                           a: u32 is 0..=1,
+                           b: union u8,
                            b_offset: Size(4 bytes),
                        },
                        field_offsets: [
@@ -208,22 +145,13 @@ error: layout_of(DeadBranchHasOtherField) = Layout {
            largest_niche: Some(
                Niche {
                    offset: Size(0 bytes),
-                   value: Int(
-                       I32,
-                       false,
-                   ),
+                   value: u32,
                    valid_range: 0..=1,
                },
            ),
            uninhabited: false,
            variants: Multiple {
-               tag: Initialized {
-                   value: Int(
-                       I32,
-                       false,
-                   ),
-                   valid_range: 0..=1,
-               },
+               tag: u32 is 0..=1,
                tag_encoding: Direct,
                tag_field: 0,
                variants: [

--- a/tests/ui/repr/repr-c-dead-variants.x86_64-unknown-linux-gnu.stderr
+++ b/tests/ui/repr/repr-c-dead-variants.x86_64-unknown-linux-gnu.stderr
@@ -4,13 +4,7 @@ error: layout_of(Univariant) = Layout {
                abi: Align(4 bytes),
            },
            backend_repr: Scalar(
-               Initialized {
-                   value: Int(
-                       I32,
-                       false,
-                   ),
-                   valid_range: 0..=0,
-               },
+               u32 is 0..=0,
            ),
            fields: Arbitrary {
                offsets: [
@@ -23,35 +17,20 @@ error: layout_of(Univariant) = Layout {
            largest_niche: Some(
                Niche {
                    offset: Size(0 bytes),
-                   value: Int(
-                       I32,
-                       false,
-                   ),
+                   value: u32,
                    valid_range: 0..=0,
                },
            ),
            uninhabited: true,
            variants: Multiple {
-               tag: Initialized {
-                   value: Int(
-                       I32,
-                       false,
-                   ),
-                   valid_range: 0..=0,
-               },
+               tag: u32 is 0..=0,
                tag_encoding: Direct,
                tag_field: 0,
                variants: [
                    VariantLayout {
                        size: Size(4 bytes),
                        backend_repr: Scalar(
-                           Initialized {
-                               value: Int(
-                                   I32,
-                                   false,
-                               ),
-                               valid_range: 0..=0,
-                           },
+                           u32 is 0..=0,
                        ),
                        field_offsets: [
                            Size(4 bytes),
@@ -79,19 +58,8 @@ error: layout_of(TwoVariants) = Layout {
                abi: Align(4 bytes),
            },
            backend_repr: ScalarPair {
-               a: Initialized {
-                   value: Int(
-                       I32,
-                       false,
-                   ),
-                   valid_range: 0..=1,
-               },
-               b: Union {
-                   value: Int(
-                       I8,
-                       false,
-                   ),
-               },
+               a: u32 is 0..=1,
+               b: union u8,
                b_offset: Size(4 bytes),
            },
            fields: Arbitrary {
@@ -105,41 +73,21 @@ error: layout_of(TwoVariants) = Layout {
            largest_niche: Some(
                Niche {
                    offset: Size(0 bytes),
-                   value: Int(
-                       I32,
-                       false,
-                   ),
+                   value: u32,
                    valid_range: 0..=1,
                },
            ),
            uninhabited: false,
            variants: Multiple {
-               tag: Initialized {
-                   value: Int(
-                       I32,
-                       false,
-                   ),
-                   valid_range: 0..=1,
-               },
+               tag: u32 is 0..=1,
                tag_encoding: Direct,
                tag_field: 0,
                variants: [
                    VariantLayout {
                        size: Size(8 bytes),
                        backend_repr: ScalarPair {
-                           a: Initialized {
-                               value: Int(
-                                   I32,
-                                   false,
-                               ),
-                               valid_range: 0..=1,
-                           },
-                           b: Union {
-                               value: Int(
-                                   I8,
-                                   false,
-                               ),
-                           },
+                           a: u32 is 0..=1,
+                           b: union u8,
                            b_offset: Size(4 bytes),
                        },
                        field_offsets: [
@@ -154,19 +102,8 @@ error: layout_of(TwoVariants) = Layout {
                    VariantLayout {
                        size: Size(8 bytes),
                        backend_repr: ScalarPair {
-                           a: Initialized {
-                               value: Int(
-                                   I32,
-                                   false,
-                               ),
-                               valid_range: 0..=1,
-                           },
-                           b: Union {
-                               value: Int(
-                                   I8,
-                                   false,
-                               ),
-                           },
+                           a: u32 is 0..=1,
+                           b: union u8,
                            b_offset: Size(4 bytes),
                        },
                        field_offsets: [
@@ -208,22 +145,13 @@ error: layout_of(DeadBranchHasOtherField) = Layout {
            largest_niche: Some(
                Niche {
                    offset: Size(0 bytes),
-                   value: Int(
-                       I32,
-                       false,
-                   ),
+                   value: u32,
                    valid_range: 0..=1,
                },
            ),
            uninhabited: false,
            variants: Multiple {
-               tag: Initialized {
-                   value: Int(
-                       I32,
-                       false,
-                   ),
-                   valid_range: 0..=1,
-               },
+               tag: u32 is 0..=1,
                tag_encoding: Direct,
                tag_field: 0,
                variants: [

--- a/tests/ui/repr/repr-c-int-dead-variants.stderr
+++ b/tests/ui/repr/repr-c-int-dead-variants.stderr
@@ -4,13 +4,7 @@ error: layout_of(UnivariantU8) = Layout {
                abi: Align(1 bytes),
            },
            backend_repr: Scalar(
-               Initialized {
-                   value: Int(
-                       I8,
-                       false,
-                   ),
-                   valid_range: 0..=0,
-               },
+               u8 is 0..=0,
            ),
            fields: Arbitrary {
                offsets: [
@@ -23,35 +17,20 @@ error: layout_of(UnivariantU8) = Layout {
            largest_niche: Some(
                Niche {
                    offset: Size(0 bytes),
-                   value: Int(
-                       I8,
-                       false,
-                   ),
+                   value: u8,
                    valid_range: 0..=0,
                },
            ),
            uninhabited: true,
            variants: Multiple {
-               tag: Initialized {
-                   value: Int(
-                       I8,
-                       false,
-                   ),
-                   valid_range: 0..=0,
-               },
+               tag: u8 is 0..=0,
                tag_encoding: Direct,
                tag_field: 0,
                variants: [
                    VariantLayout {
                        size: Size(1 bytes),
                        backend_repr: Scalar(
-                           Initialized {
-                               value: Int(
-                                   I8,
-                                   false,
-                               ),
-                               valid_range: 0..=0,
-                           },
+                           u8 is 0..=0,
                        ),
                        field_offsets: [
                            Size(1 bytes),
@@ -79,19 +58,8 @@ error: layout_of(TwoVariantsU8) = Layout {
                abi: Align(1 bytes),
            },
            backend_repr: ScalarPair {
-               a: Initialized {
-                   value: Int(
-                       I8,
-                       false,
-                   ),
-                   valid_range: 0..=1,
-               },
-               b: Union {
-                   value: Int(
-                       I8,
-                       false,
-                   ),
-               },
+               a: u8 is 0..=1,
+               b: union u8,
                b_offset: Size(1 bytes),
            },
            fields: Arbitrary {
@@ -105,41 +73,21 @@ error: layout_of(TwoVariantsU8) = Layout {
            largest_niche: Some(
                Niche {
                    offset: Size(0 bytes),
-                   value: Int(
-                       I8,
-                       false,
-                   ),
+                   value: u8,
                    valid_range: 0..=1,
                },
            ),
            uninhabited: false,
            variants: Multiple {
-               tag: Initialized {
-                   value: Int(
-                       I8,
-                       false,
-                   ),
-                   valid_range: 0..=1,
-               },
+               tag: u8 is 0..=1,
                tag_encoding: Direct,
                tag_field: 0,
                variants: [
                    VariantLayout {
                        size: Size(2 bytes),
                        backend_repr: ScalarPair {
-                           a: Initialized {
-                               value: Int(
-                                   I8,
-                                   false,
-                               ),
-                               valid_range: 0..=1,
-                           },
-                           b: Union {
-                               value: Int(
-                                   I8,
-                                   false,
-                               ),
-                           },
+                           a: u8 is 0..=1,
+                           b: union u8,
                            b_offset: Size(1 bytes),
                        },
                        field_offsets: [
@@ -154,19 +102,8 @@ error: layout_of(TwoVariantsU8) = Layout {
                    VariantLayout {
                        size: Size(2 bytes),
                        backend_repr: ScalarPair {
-                           a: Initialized {
-                               value: Int(
-                                   I8,
-                                   false,
-                               ),
-                               valid_range: 0..=1,
-                           },
-                           b: Union {
-                               value: Int(
-                                   I8,
-                                   false,
-                               ),
-                           },
+                           a: u8 is 0..=1,
+                           b: union u8,
                            b_offset: Size(1 bytes),
                        },
                        field_offsets: [
@@ -208,22 +145,13 @@ error: layout_of(DeadBranchHasOtherFieldU8) = Layout {
            largest_niche: Some(
                Niche {
                    offset: Size(0 bytes),
-                   value: Int(
-                       I8,
-                       false,
-                   ),
+                   value: u8,
                    valid_range: 0..=1,
                },
            ),
            uninhabited: false,
            variants: Multiple {
-               tag: Initialized {
-                   value: Int(
-                       I8,
-                       false,
-                   ),
-                   valid_range: 0..=1,
-               },
+               tag: u8 is 0..=1,
                tag_encoding: Direct,
                tag_field: 0,
                variants: [

--- a/tests/ui/type/pattern_types/non_null.stderr
+++ b/tests/ui/type/pattern_types/non_null.stderr
@@ -4,14 +4,7 @@ error: layout_of((*const T) is !null) = Layout {
                abi: Align(8 bytes),
            },
            backend_repr: Scalar(
-               Initialized {
-                   value: Pointer(
-                       AddressSpace(
-                           0,
-                       ),
-                   ),
-                   valid_range: 1..=18446744073709551615,
-               },
+               pointer is 1..=18446744073709551615,
            ),
            fields: Arbitrary {
                offsets: [
@@ -24,11 +17,7 @@ error: layout_of((*const T) is !null) = Layout {
            largest_niche: Some(
                Niche {
                    offset: Size(0 bytes),
-                   value: Pointer(
-                       AddressSpace(
-                           0,
-                       ),
-                   ),
+                   value: pointer,
                    valid_range: 1..=18446744073709551615,
                },
            ),
@@ -51,14 +40,7 @@ error: layout_of(Option<(*const ()) is !null>) = Layout {
                abi: Align(8 bytes),
            },
            backend_repr: Scalar(
-               Initialized {
-                   value: Pointer(
-                       AddressSpace(
-                           0,
-                       ),
-                   ),
-                   valid_range: 0..=18446744073709551615,
-               },
+               pointer is 0..=18446744073709551615,
            ),
            fields: Arbitrary {
                offsets: [
@@ -71,14 +53,7 @@ error: layout_of(Option<(*const ()) is !null>) = Layout {
            largest_niche: None,
            uninhabited: false,
            variants: Multiple {
-               tag: Initialized {
-                   value: Pointer(
-                       AddressSpace(
-                           0,
-                       ),
-                   ),
-                   valid_range: 0..=18446744073709551615,
-               },
+               tag: pointer is 0..=18446744073709551615,
                tag_encoding: Niche {
                    untagged_variant: 1,
                    niche_variants: 0..=0,
@@ -99,14 +74,7 @@ error: layout_of(Option<(*const ()) is !null>) = Layout {
                    VariantLayout {
                        size: Size(8 bytes),
                        backend_repr: Scalar(
-                           Initialized {
-                               value: Pointer(
-                                   AddressSpace(
-                                       0,
-                                   ),
-                               ),
-                               valid_range: 1..=18446744073709551615,
-                           },
+                           pointer is 1..=18446744073709551615,
                        ),
                        field_offsets: [
                            Size(0 bytes),
@@ -117,11 +85,7 @@ error: layout_of(Option<(*const ()) is !null>) = Layout {
                        largest_niche: Some(
                            Niche {
                                offset: Size(0 bytes),
-                               value: Pointer(
-                                   AddressSpace(
-                                       0,
-                                   ),
-                               ),
+                               value: pointer,
                                valid_range: 1..=18446744073709551615,
                            },
                        ),
@@ -144,21 +108,8 @@ error: layout_of((*const [u8]) is !null) = Layout {
                abi: Align(8 bytes),
            },
            backend_repr: ScalarPair {
-               a: Initialized {
-                   value: Pointer(
-                       AddressSpace(
-                           0,
-                       ),
-                   ),
-                   valid_range: 1..=18446744073709551615,
-               },
-               b: Initialized {
-                   value: Int(
-                       I64,
-                       false,
-                   ),
-                   valid_range: 0..=18446744073709551615,
-               },
+               a: pointer is 1..=18446744073709551615,
+               b: u64 is ..,
                b_offset: Size(8 bytes),
            },
            fields: Arbitrary {
@@ -172,11 +123,7 @@ error: layout_of((*const [u8]) is !null) = Layout {
            largest_niche: Some(
                Niche {
                    offset: Size(0 bytes),
-                   value: Pointer(
-                       AddressSpace(
-                           0,
-                       ),
-                   ),
+                   value: pointer,
                    valid_range: 1..=18446744073709551615,
                },
            ),

--- a/tests/ui/type/pattern_types/or_patterns.stderr
+++ b/tests/ui/type/pattern_types/or_patterns.stderr
@@ -45,13 +45,7 @@ error: layout_of((i8) is (i8::MIN..=-1 | 1..)) = Layout {
                abi: Align(1 bytes),
            },
            backend_repr: Scalar(
-               Initialized {
-                   value: Int(
-                       I8,
-                       true,
-                   ),
-                   valid_range: 1..=255,
-               },
+               i8 is (..=-1) | (1..),
            ),
            fields: Arbitrary {
                offsets: [
@@ -64,10 +58,7 @@ error: layout_of((i8) is (i8::MIN..=-1 | 1..)) = Layout {
            largest_niche: Some(
                Niche {
                    offset: Size(0 bytes),
-                   value: Int(
-                       I8,
-                       true,
-                   ),
+                   value: i8,
                    valid_range: 1..=255,
                },
            ),
@@ -90,13 +81,7 @@ error: layout_of((i8) is (i8::MIN..=-2 | 0..)) = Layout {
                abi: Align(1 bytes),
            },
            backend_repr: Scalar(
-               Initialized {
-                   value: Int(
-                       I8,
-                       true,
-                   ),
-                   valid_range: 0..=254,
-               },
+               i8 is (..=-2) | (0..),
            ),
            fields: Arbitrary {
                offsets: [
@@ -109,10 +94,7 @@ error: layout_of((i8) is (i8::MIN..=-2 | 0..)) = Layout {
            largest_niche: Some(
                Niche {
                    offset: Size(0 bytes),
-                   value: Int(
-                       I8,
-                       true,
-                   ),
+                   value: i8,
                    valid_range: 0..=254,
                },
            ),

--- a/tests/ui/type/pattern_types/range_patterns.stderr
+++ b/tests/ui/type/pattern_types/range_patterns.stderr
@@ -4,13 +4,7 @@ error: layout_of(NonZero<u32>) = Layout {
                abi: Align(4 bytes),
            },
            backend_repr: Scalar(
-               Initialized {
-                   value: Int(
-                       I32,
-                       false,
-                   ),
-                   valid_range: 1..=4294967295,
-               },
+               u32 is 1..=4294967295,
            ),
            fields: Arbitrary {
                offsets: [
@@ -23,10 +17,7 @@ error: layout_of(NonZero<u32>) = Layout {
            largest_niche: Some(
                Niche {
                    offset: Size(0 bytes),
-                   value: Int(
-                       I32,
-                       false,
-                   ),
+                   value: u32,
                    valid_range: 1..=4294967295,
                },
            ),
@@ -49,13 +40,7 @@ error: layout_of((u32) is 1..) = Layout {
                abi: Align(4 bytes),
            },
            backend_repr: Scalar(
-               Initialized {
-                   value: Int(
-                       I32,
-                       false,
-                   ),
-                   valid_range: 1..=4294967295,
-               },
+               u32 is 1..=4294967295,
            ),
            fields: Arbitrary {
                offsets: [
@@ -68,10 +53,7 @@ error: layout_of((u32) is 1..) = Layout {
            largest_niche: Some(
                Niche {
                    offset: Size(0 bytes),
-                   value: Int(
-                       I32,
-                       false,
-                   ),
+                   value: u32,
                    valid_range: 1..=4294967295,
                },
            ),
@@ -94,13 +76,7 @@ error: layout_of(Option<(u32) is 1..>) = Layout {
                abi: Align(4 bytes),
            },
            backend_repr: Scalar(
-               Initialized {
-                   value: Int(
-                       I32,
-                       false,
-                   ),
-                   valid_range: 0..=4294967295,
-               },
+               u32 is ..,
            ),
            fields: Arbitrary {
                offsets: [
@@ -113,13 +89,7 @@ error: layout_of(Option<(u32) is 1..>) = Layout {
            largest_niche: None,
            uninhabited: false,
            variants: Multiple {
-               tag: Initialized {
-                   value: Int(
-                       I32,
-                       false,
-                   ),
-                   valid_range: 0..=4294967295,
-               },
+               tag: u32 is ..,
                tag_encoding: Niche {
                    untagged_variant: 1,
                    niche_variants: 0..=0,
@@ -140,13 +110,7 @@ error: layout_of(Option<(u32) is 1..>) = Layout {
                    VariantLayout {
                        size: Size(4 bytes),
                        backend_repr: Scalar(
-                           Initialized {
-                               value: Int(
-                                   I32,
-                                   false,
-                               ),
-                               valid_range: 1..=4294967295,
-                           },
+                           u32 is 1..=4294967295,
                        ),
                        field_offsets: [
                            Size(0 bytes),
@@ -157,10 +121,7 @@ error: layout_of(Option<(u32) is 1..>) = Layout {
                        largest_niche: Some(
                            Niche {
                                offset: Size(0 bytes),
-                               value: Int(
-                                   I32,
-                                   false,
-                               ),
+                               value: u32,
                                valid_range: 1..=4294967295,
                            },
                        ),
@@ -183,13 +144,7 @@ error: layout_of(Option<NonZero<u32>>) = Layout {
                abi: Align(4 bytes),
            },
            backend_repr: Scalar(
-               Initialized {
-                   value: Int(
-                       I32,
-                       false,
-                   ),
-                   valid_range: 0..=4294967295,
-               },
+               u32 is ..,
            ),
            fields: Arbitrary {
                offsets: [
@@ -202,13 +157,7 @@ error: layout_of(Option<NonZero<u32>>) = Layout {
            largest_niche: None,
            uninhabited: false,
            variants: Multiple {
-               tag: Initialized {
-                   value: Int(
-                       I32,
-                       false,
-                   ),
-                   valid_range: 0..=4294967295,
-               },
+               tag: u32 is ..,
                tag_encoding: Niche {
                    untagged_variant: 1,
                    niche_variants: 0..=0,
@@ -229,13 +178,7 @@ error: layout_of(Option<NonZero<u32>>) = Layout {
                    VariantLayout {
                        size: Size(4 bytes),
                        backend_repr: Scalar(
-                           Initialized {
-                               value: Int(
-                                   I32,
-                                   false,
-                               ),
-                               valid_range: 1..=4294967295,
-                           },
+                           u32 is 1..=4294967295,
                        ),
                        field_offsets: [
                            Size(0 bytes),
@@ -246,10 +189,7 @@ error: layout_of(Option<NonZero<u32>>) = Layout {
                        largest_niche: Some(
                            Niche {
                                offset: Size(0 bytes),
-                               value: Int(
-                                   I32,
-                                   false,
-                               ),
+                               value: u32,
                                valid_range: 1..=4294967295,
                            },
                        ),
@@ -272,13 +212,7 @@ error: layout_of(NonZeroU32New) = Layout {
                abi: Align(4 bytes),
            },
            backend_repr: Scalar(
-               Initialized {
-                   value: Int(
-                       I32,
-                       false,
-                   ),
-                   valid_range: 1..=4294967295,
-               },
+               u32 is 1..=4294967295,
            ),
            fields: Arbitrary {
                offsets: [
@@ -291,10 +225,7 @@ error: layout_of(NonZeroU32New) = Layout {
            largest_niche: Some(
                Niche {
                    offset: Size(0 bytes),
-                   value: Int(
-                       I32,
-                       false,
-                   ),
+                   value: u32,
                    valid_range: 1..=4294967295,
                },
            ),
@@ -345,13 +276,7 @@ error: layout_of((i8) is -10..=10) = Layout {
                abi: Align(1 bytes),
            },
            backend_repr: Scalar(
-               Initialized {
-                   value: Int(
-                       I8,
-                       true,
-                   ),
-                   valid_range: (..=10) | (246..),
-               },
+               i8 is -10..=10,
            ),
            fields: Arbitrary {
                offsets: [
@@ -364,10 +289,7 @@ error: layout_of((i8) is -10..=10) = Layout {
            largest_niche: Some(
                Niche {
                    offset: Size(0 bytes),
-                   value: Int(
-                       I8,
-                       true,
-                   ),
+                   value: i8,
                    valid_range: (..=10) | (246..),
                },
            ),
@@ -390,13 +312,7 @@ error: layout_of((i8) is i8::MIN..=0) = Layout {
                abi: Align(1 bytes),
            },
            backend_repr: Scalar(
-               Initialized {
-                   value: Int(
-                       I8,
-                       true,
-                   ),
-                   valid_range: (..=0) | (128..),
-               },
+               i8 is -128..=0,
            ),
            fields: Arbitrary {
                offsets: [
@@ -409,10 +325,7 @@ error: layout_of((i8) is i8::MIN..=0) = Layout {
            largest_niche: Some(
                Niche {
                    offset: Size(0 bytes),
-                   value: Int(
-                       I8,
-                       true,
-                   ),
+                   value: i8,
                    valid_range: (..=0) | (128..),
                },
            ),


### PR DESCRIPTION
Of late I've been looking at layout a bunch, which means staring at things like

```rust
backend_repr: ScalarPair {
    a: Initialized {
        value: Int(
            I8,
            false,
        ),
        valid_range: 0..=1,
    },
    b: Union {
        value: Int(
            I8,
            false,
        ),
    },
    b_offset: Size(1 bytes),
},
```

and that's just kinda long and unfriendly.

Thus this PR that just changes `Debug` -- nothing else! -- so for example that shows as

```rust
backend_repr: ScalarPair {
    a: u8 is 0..=1,
    b: union u8,
    b_offset: Size(1 bytes),
},
```

---

EDIT: oh, net -1404 lines is a pretty good summary of why 🙃 