### PR TITLE
Remove extra semicolons in parsing item lists

### DIFF
--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -962,7 +962,9 @@ impl<'a> Parser<'a> {
             self.recover_vcs_conflict_marker();
             match parse_item(self) {
                 Ok(None) => {
-                    let mut is_unnecessary_semicolon = !items.is_empty()
+                    let mut is_unnecessary_semicolon = (self.token == token::Semi
+                        && self.prev_token == token::Semi)
+                        || !items.is_empty()
                         // When the close delim is `)` in a case like the following, `token.kind`
                         // is expected to be `token::CloseParen`, but the actual `token.kind` is
                         // `token::CloseBrace`. This is because the `token.kind` of the close delim

--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -1013,7 +1013,7 @@ impl<'a> Parser<'a> {
                             .span_label(self.prev_token.span, "item list ends here");
                     }
                     if is_unnecessary_semicolon {
-                        err.span_suggestion(
+                        err.span_suggestion_verbose(
                             semicolon_span,
                             "consider removing this semicolon",
                             "",

--- a/tests/ui/parser/suggest-removing-extra-semicolon-in-item-lists.fixed
+++ b/tests/ui/parser/suggest-removing-extra-semicolon-in-item-lists.fixed
@@ -1,0 +1,25 @@
+//@ run-rustfix
+
+#![allow(dead_code)]
+
+// Extra semicolons after semicolon-terminated items should have a removal suggestion.
+
+trait Factory {
+    fn create() -> u32;
+    //~^ ERROR non-item in item list
+    fn second() -> u32;
+}
+
+struct Local;
+
+impl Local {
+    const VALUE: u32 = 0;
+    //~^ ERROR non-item in item list
+}
+
+unsafe extern "C" {
+    fn foreign();
+    //~^ ERROR non-item in item list
+}
+
+fn main() {}

--- a/tests/ui/parser/suggest-removing-extra-semicolon-in-item-lists.rs
+++ b/tests/ui/parser/suggest-removing-extra-semicolon-in-item-lists.rs
@@ -1,0 +1,25 @@
+//@ run-rustfix
+
+#![allow(dead_code)]
+
+// Extra semicolons after semicolon-terminated items should have a removal suggestion.
+
+trait Factory {
+    fn create() -> u32;;
+    //~^ ERROR non-item in item list
+    fn second() -> u32;
+}
+
+struct Local;
+
+impl Local {
+    const VALUE: u32 = 0;;
+    //~^ ERROR non-item in item list
+}
+
+unsafe extern "C" {
+    fn foreign();;
+    //~^ ERROR non-item in item list
+}
+
+fn main() {}

--- a/tests/ui/parser/suggest-removing-extra-semicolon-in-item-lists.stderr
+++ b/tests/ui/parser/suggest-removing-extra-semicolon-in-item-lists.stderr
@@ -4,13 +4,16 @@ error: non-item in item list
 LL | trait Factory {
    |               - item list starts here
 LL |     fn create() -> u32;;
-   |                        ^
-   |                        |
-   |                        non-item starts here
-   |                        help: consider removing this semicolon
+   |                        ^ non-item starts here
 ...
 LL | }
    | - item list ends here
+   |
+help: consider removing this semicolon
+   |
+LL -     fn create() -> u32;;
+LL +     fn create() -> u32;
+   |
 
 error: non-item in item list
   --> $DIR/suggest-removing-extra-semicolon-in-item-lists.rs:16:26
@@ -18,13 +21,16 @@ error: non-item in item list
 LL | impl Local {
    |            - item list starts here
 LL |     const VALUE: u32 = 0;;
-   |                          ^
-   |                          |
-   |                          non-item starts here
-   |                          help: consider removing this semicolon
+   |                          ^ non-item starts here
 LL |
 LL | }
    | - item list ends here
+   |
+help: consider removing this semicolon
+   |
+LL -     const VALUE: u32 = 0;;
+LL +     const VALUE: u32 = 0;
+   |
 
 error: non-item in item list
   --> $DIR/suggest-removing-extra-semicolon-in-item-lists.rs:21:18
@@ -32,13 +38,16 @@ error: non-item in item list
 LL | unsafe extern "C" {
    |                   - item list starts here
 LL |     fn foreign();;
-   |                  ^
-   |                  |
-   |                  non-item starts here
-   |                  help: consider removing this semicolon
+   |                  ^ non-item starts here
 LL |
 LL | }
    | - item list ends here
+   |
+help: consider removing this semicolon
+   |
+LL -     fn foreign();;
+LL +     fn foreign();
+   |
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/parser/suggest-removing-extra-semicolon-in-item-lists.stderr
+++ b/tests/ui/parser/suggest-removing-extra-semicolon-in-item-lists.stderr
@@ -1,0 +1,44 @@
+error: non-item in item list
+  --> $DIR/suggest-removing-extra-semicolon-in-item-lists.rs:8:24
+   |
+LL | trait Factory {
+   |               - item list starts here
+LL |     fn create() -> u32;;
+   |                        ^
+   |                        |
+   |                        non-item starts here
+   |                        help: consider removing this semicolon
+...
+LL | }
+   | - item list ends here
+
+error: non-item in item list
+  --> $DIR/suggest-removing-extra-semicolon-in-item-lists.rs:16:26
+   |
+LL | impl Local {
+   |            - item list starts here
+LL |     const VALUE: u32 = 0;;
+   |                          ^
+   |                          |
+   |                          non-item starts here
+   |                          help: consider removing this semicolon
+LL |
+LL | }
+   | - item list ends here
+
+error: non-item in item list
+  --> $DIR/suggest-removing-extra-semicolon-in-item-lists.rs:21:18
+   |
+LL | unsafe extern "C" {
+   |                   - item list starts here
+LL |     fn foreign();;
+   |                  ^
+   |                  |
+   |                  non-item starts here
+   |                  help: consider removing this semicolon
+LL |
+LL | }
+   | - item list ends here
+
+error: aborting due to 3 previous errors
+

--- a/tests/ui/parser/suggest-removing-semicolon-after-impl-trait-items.stderr
+++ b/tests/ui/parser/suggest-removing-semicolon-after-impl-trait-items.stderr
@@ -4,12 +4,15 @@ error: non-item in item list
 LL | trait Foo {
    |           - item list starts here
 LL |     fn bar() {};
-   |                ^
-   |                |
-   |                non-item starts here
-   |                help: consider removing this semicolon
+   |                ^ non-item starts here
 LL | }
    | - item list ends here
+   |
+help: consider removing this semicolon
+   |
+LL -     fn bar() {};
+LL +     fn bar() {}
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/suggestions/issue-105226.stderr
+++ b/tests/ui/suggestions/issue-105226.stderr
@@ -4,12 +4,16 @@ error: non-item in item list
 LL | impl S {
    |        - item list starts here
 LL |     fn hello<P>(&self, val: &P) where P: fmt::Display; {
-   |                                                      - ^ non-item starts here
-   |                                                      |
-   |                                                      help: consider removing this semicolon
+   |                                                        ^ non-item starts here
 ...
 LL | }
    | - item list ends here
+   |
+help: consider removing this semicolon
+   |
+LL -     fn hello<P>(&self, val: &P) where P: fmt::Display; {
+LL +     fn hello<P>(&self, val: &P) where P: fmt::Display {
+   |
 
 error: associated function in `impl` without body
   --> $DIR/issue-105226.rs:7:5


### PR DESCRIPTION
Fixes rust-lang/rust#159542