### PR TITLE
Add -Zllvm-target-feature to pass features directly to LLVM

### DIFF
--- a/compiler/rustc_codegen_llvm/src/llvm_util.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm_util.rs
@@ -641,6 +641,13 @@ fn llvm_features_by_flags(sess: &Session, features: &mut Vec<String>) {
             features.push("+reserve-x18".into());
         }
     }
+
+    // -Zllvm-target-feature
+    for feature in sess.opts.unstable_opts.llvm_target_feature.split(',') {
+        if !feature.is_empty() {
+            features.push(feature.into());
+        }
+    }
 }
 
 /// The list of LLVM features computed from CLI flags (`-Ctarget-cpu`, `-Ctarget-feature`,

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -2597,6 +2597,9 @@ options! {
         "a list of module flags to pass to LLVM (space separated)"),
     llvm_plugins: Vec<String> = (Vec::new(), parse_list, [TRACKED],
         "a list LLVM plugins to enable (space separated)"),
+    llvm_target_feature: String = (String::new(), parse_string, [TRACKED] { TARGET_MODIFIER: LlvmTargetFeature },
+        "a comma-separated list of features to pass directly to the LLVM backend (+feat/-feat); \
+        ignored by non-LLVM backends (unstable)"),
     llvm_time_trace: bool = (false, parse_bool, [UNTRACKED],
         "generate JSON tracing data file from LLVM data (default: no)"),
     llvm_writable: bool = (false, parse_bool, [TRACKED],

--- a/src/doc/unstable-book/src/compiler-flags/llvm-target-feature.md
+++ b/src/doc/unstable-book/src/compiler-flags/llvm-target-feature.md
@@ -1,0 +1,17 @@
+# `llvm-target-feature`
+
+---
+
+Forwards target feature strings directly to LLVM, bypassing Rust's known-feature table.
+
+Registered as a target modifier.
+
+Does not affect `cfg(target_feature)`.
+
+Ignored by non-LLVM backends.
+
+```sh
+rustc -Zllvm-target-feature=+prefer-256-bit main.rs
+rustc -Zllvm-target-feature=+prefer-256-bit,+fast-gather main.rs
+rustc -Zllvm-target-feature=+prefer-256-bit,-avx512f main.rs
+```

--- a/tests/codegen-llvm/llvm-target-feature.rs
+++ b/tests/codegen-llvm/llvm-target-feature.rs
@@ -1,0 +1,15 @@
+// Verify `-Zllvm-target-feature` reaches LLVM IR (`prefer-256-bit` is LLVM-only).
+//@ add-minicore
+//@ needs-llvm-components: x86
+//@ compile-flags: --target x86_64-unknown-linux-gnu -Zllvm-target-feature=+prefer-256-bit
+#![crate_type = "lib"]
+#![feature(no_core)]
+#![no_core]
+extern crate minicore;
+
+#[no_mangle]
+pub fn foo() {
+    // CHECK: @foo() unnamed_addr #0
+
+    // CHECK: attributes #0 = { {{.*}}"target-features"="{{[^"]*}}+prefer-256-bit{{.*}} }
+}

--- a/tests/ui/target_modifiers/auxiliary/wrong_llvm_target_feature.rs
+++ b/tests/ui/target_modifiers/auxiliary/wrong_llvm_target_feature.rs
@@ -1,0 +1,7 @@
+//@ no-prefer-dynamic
+//@ compile-flags: --target x86_64-unknown-linux-gnu -Zllvm-target-feature=+fake-feature
+//@ needs-llvm-components: x86
+
+#![feature(no_core)]
+#![crate_type = "rlib"]
+#![no_core]

--- a/tests/ui/target_modifiers/incompatible_llvm_target_feature.allow_llvm_target_feature_mismatch.stderr
+++ b/tests/ui/target_modifiers/incompatible_llvm_target_feature.allow_llvm_target_feature_mismatch.stderr
@@ -1,0 +1,1 @@
+'+another-feature' is not a recognized feature for this target (ignoring feature)

--- a/tests/ui/target_modifiers/incompatible_llvm_target_feature.error_generated.stderr
+++ b/tests/ui/target_modifiers/incompatible_llvm_target_feature.error_generated.stderr
@@ -1,0 +1,14 @@
+'+another-feature' is not a recognized feature for this target (ignoring feature)
+error: mixing `-Zllvm-target-feature` will cause an ABI mismatch in crate `incompatible_llvm_target_feature`
+  --> $DIR/incompatible_llvm_target_feature.rs:11:1
+   |
+LL | #![feature(no_core)]
+   | ^
+   |
+   = help: the `-Zllvm-target-feature` flag modifies the ABI so Rust crates compiled with different values of this flag cannot be used together safely
+   = note: `-Zllvm-target-feature=+another-feature` in this crate is incompatible with `-Zllvm-target-feature=+fake-feature` in dependency `wrong_llvm_target_feature`
+   = help: set `-Zllvm-target-feature=+fake-feature` in this crate or `-Zllvm-target-feature=+another-feature` in `wrong_llvm_target_feature`
+   = help: if you are sure this will not cause problems, you may use `-Cunsafe-allow-abi-mismatch=llvm-target-feature` to silence this error
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/target_modifiers/incompatible_llvm_target_feature.rs
+++ b/tests/ui/target_modifiers/incompatible_llvm_target_feature.rs
@@ -1,0 +1,16 @@
+//@ aux-build:wrong_llvm_target_feature.rs
+//@ compile-flags: --target x86_64-unknown-linux-gnu -Zllvm-target-feature=+another-feature
+//@ needs-llvm-components: x86
+
+//@ revisions:allow_llvm_target_feature_mismatch error_generated
+//@[allow_llvm_target_feature_mismatch] compile-flags: -Cunsafe-allow-abi-mismatch=llvm-target-feature
+// [error_generated] no extra compile-flags
+//@[allow_llvm_target_feature_mismatch] check-pass
+//@ ignore-backends: gcc
+
+#![feature(no_core)]
+//[error_generated]~^ ERROR mixing `-Zllvm-target-feature` will cause an ABI mismatch in crate `incompatible_llvm_target_feature`
+#![crate_type = "rlib"]
+#![no_core]
+
+extern crate wrong_llvm_target_feature;


### PR DESCRIPTION
`-Ctarget-feature` passes unrecognized features through to LLVM with a warning.

Users who need LLVM-only features (e.g. the Linux kernel) must either tolerate the warning or resort to JSON target specs. 

This flag provides a dedicated mechanism, registered as a target modifier.

Tracking issue: rust-lang/rust#157753