### PR TITLE
restrict const-eval-related 'content' triggers to library/ folder

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1476,6 +1476,7 @@ cc = ["@rust-lang/miri"]
 
 [mentions."#[miri::intrinsic_fallback_is_spec]"]
 type = "content"
+trigger_files = ["library"]
 message = """
 ⚠️ `#[miri::intrinsic_fallback_is_spec]` must only be used if the function actively checks for all UB cases,
 and explores the possible non-determinism of the intrinsic.
@@ -1484,6 +1485,7 @@ cc = ["@rust-lang/miri"]
 
 [mentions."#[rustc_allow_const_fn_unstable"]
 type = "content"
+trigger_files = ["library"]
 message = """
 ⚠️ `#[rustc_allow_const_fn_unstable]` needs careful audit to avoid accidentally exposing unstable
 implementation details on stable.
@@ -1492,6 +1494,7 @@ cc = ["@rust-lang/wg-const-eval"]
 
 [mentions."#[rustc_intrinsic_const_stable_indirect]"]
 type = "content"
+trigger_files = ["library"]
 message = """
 ⚠️ `#[rustc_intrinsic_const_stable_indirect]` controls whether intrinsics can be exposed to stable const
 code; adding it needs t-lang approval.

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1464,6 +1464,13 @@ message = """
 """
 cc = ["@jieyouxu"]
 
+[mentions."compiler/rustc_attr_parsing/src/attributes/diagnostic"]
+message = "Some changes occurred to diagnostic attributes."
+cc = ["@mejrs"]
+[mentions."compiler/rustc_hir/src/attrs/diagnostic.rs"]
+message = "Some changes occurred to diagnostic attributes."
+cc = ["@mejrs"]
+
 # Content-based mentions
 
 [mentions."miri"]
@@ -1500,13 +1507,6 @@ message = """
 code; adding it needs t-lang approval.
 """
 cc = ["@rust-lang/wg-const-eval"]
-
-[mentions."compiler/rustc_attr_parsing/src/attributes/diagnostic"]
-message = "Some changes occurred to diagnostic attributes."
-cc = ["@mejrs"]
-[mentions."compiler/rustc_hir/src/attrs/diagnostic.rs"]
-message = "Some changes occurred to diagnostic attributes."
-cc = ["@mejrs"]
 
 # ------------------------------------------------------------------------------
 # PR assignments


### PR DESCRIPTION
Cc @rust-lang/wg-const-eval 

The 2nd commit is a drive-by fix.