### PR TITLE
feat: Update method signature of int_from_ascii

### DIFF
--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -1575,10 +1575,10 @@ pub const fn can_not_overflow<T>(radix: u32, is_signed_ty: bool, digits: &[u8]) 
 #[cfg_attr(panic = "immediate-abort", inline)]
 #[cold]
 #[track_caller]
-const fn from_ascii_radix_panic(radix: u32) -> ! {
+const fn from_ascii_bytes_radix_panic(radix: u32) -> ! {
     const_panic!(
-        "from_ascii_radix: radix must lie in the range `[2, 36]`",
-        "from_ascii_radix: radix must lie in the range `[2, 36]` - found {radix}",
+        "from_ascii_bytes_radix: radix must lie in the range `[2, 36]`",
+        "from_ascii_bytes_radix: radix must lie in the range `[2, 36]` - found {radix}",
         radix: u32 = radix,
     )
 }
@@ -1676,7 +1676,7 @@ macro_rules! from_str_int_impl {
             #[rustc_const_stable(feature = "const_int_from_str", since = "1.82.0")]
             #[inline]
             pub const fn from_str_radix(src: &str, radix: u32) -> Result<$int_ty, ParseIntError> {
-                <$int_ty>::from_ascii_radix(src.as_bytes(), radix)
+                <$int_ty>::from_ascii_bytes_radix_impl(src.as_bytes(), radix)
             }
 
             /// Parses an integer from an ASCII-byte slice with decimal digits.
@@ -1700,18 +1700,22 @@ macro_rules! from_str_int_impl {
             /// ```
             /// #![feature(int_from_ascii)]
             ///
-            #[doc = concat!("assert_eq!(", stringify!($int_ty), "::from_ascii(b\"+10\"), Ok(10));")]
+            #[doc = concat!("assert_eq!(", stringify!($int_ty), "::from_ascii_bytes(b\"+10\"), Ok(10));")]
             /// ```
             /// Trailing space returns error:
             /// ```
             /// # #![feature(int_from_ascii)]
             /// #
-            #[doc = concat!("assert!(", stringify!($int_ty), "::from_ascii(b\"1 \").is_err());")]
+            #[doc = concat!("assert!(", stringify!($int_ty), "::from_ascii_bytes(b\"1 \").is_err());")]
             /// ```
             #[unstable(feature = "int_from_ascii", issue = "134821")]
+            #[rustc_const_unstable(feature = "const_convert", issue = "143773")]
             #[inline]
-            pub const fn from_ascii(src: &[u8]) -> Result<$int_ty, ParseIntError> {
-                <$int_ty>::from_ascii_radix(src, 10)
+            pub const fn from_ascii_bytes<T>(src: T) -> Result<$int_ty, ParseIntError>
+            where
+                T: [const] AsRef<[u8]> + [const] crate::marker::Destruct
+            {
+                <$int_ty>::from_ascii_bytes_radix(src.as_ref(), 10)
             }
 
             /// Parses an integer from an ASCII-byte slice with digits in a given base.
@@ -1744,22 +1748,31 @@ macro_rules! from_str_int_impl {
             /// ```
             /// #![feature(int_from_ascii)]
             ///
-            #[doc = concat!("assert_eq!(", stringify!($int_ty), "::from_ascii_radix(b\"A\", 16), Ok(10));")]
+            #[doc = concat!("assert_eq!(", stringify!($int_ty), "::from_ascii_bytes_radix(b\"A\", 16), Ok(10));")]
             /// ```
             /// Trailing space returns error:
             /// ```
             /// # #![feature(int_from_ascii)]
             /// #
-            #[doc = concat!("assert!(", stringify!($int_ty), "::from_ascii_radix(b\"1 \", 10).is_err());")]
+            #[doc = concat!("assert!(", stringify!($int_ty), "::from_ascii_bytes_radix(b\"1 \", 10).is_err());")]
             /// ```
             #[unstable(feature = "int_from_ascii", issue = "134821")]
+            #[rustc_const_unstable(feature = "const_convert", issue = "143773")]
             #[inline]
-            pub const fn from_ascii_radix(src: &[u8], radix: u32) -> Result<$int_ty, ParseIntError> {
+            pub const fn from_ascii_bytes_radix<T>(src: T, radix: u32) -> Result<$int_ty, ParseIntError>
+            where
+                T: [const] AsRef<[u8]> + [const] crate::marker::Destruct
+            {
+                <$int_ty>::from_ascii_bytes_radix_impl(src.as_ref(), radix)
+            }
+
+            #[inline]
+            pub(super) const fn from_ascii_bytes_radix_impl(src: &[u8], radix: u32) -> Result<$int_ty, ParseIntError> {
                 use self::IntErrorKind::*;
                 use self::ParseIntError as PIE;
 
                 if 2 > radix || radix > 36 {
-                    from_ascii_radix_panic(radix);
+                    from_ascii_bytes_radix_panic(radix);
                 }
 
                 if src.is_empty() {

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -1262,7 +1262,7 @@ macro_rules! nonzero_integer {
             /// #
             /// # fn main() { test().unwrap(); }
             /// # fn test() -> Option<()> {
-            #[doc = concat!("assert_eq!(NonZero::<", stringify!($Int), ">::from_ascii(b\"+10\"), Ok(NonZero::new(10)?));")]
+            #[doc = concat!("assert_eq!(NonZero::<", stringify!($Int), ">::from_ascii_bytes(b\"+10\"), Ok(NonZero::new(10)?));")]
             /// # Some(())
             /// # }
             /// ```
@@ -1274,12 +1274,16 @@ macro_rules! nonzero_integer {
             ///
             /// # use std::num::NonZero;
             /// #
-            #[doc = concat!("assert!(NonZero::<", stringify!($Int), ">::from_ascii(b\"1 \").is_err());")]
+            #[doc = concat!("assert!(NonZero::<", stringify!($Int), ">::from_ascii_bytes(b\"1 \").is_err());")]
             /// ```
             #[unstable(feature = "int_from_ascii", issue = "134821")]
+            #[rustc_const_unstable(feature = "const_convert", issue = "143773")]
             #[inline]
-            pub const fn from_ascii(src: &[u8]) -> Result<Self, ParseIntError> {
-                Self::from_ascii_radix(src, 10)
+            pub const fn from_ascii_bytes<T>(src: T) -> Result<Self, ParseIntError>
+            where
+                T: [const] AsRef<[u8]> + [const] crate::marker::Destruct
+            {
+                Self::from_ascii_bytes_radix_impl(src.as_ref(), 10)
             }
 
             /// Parses a non-zero integer from an ASCII-byte slice with digits in a given base.
@@ -1317,7 +1321,7 @@ macro_rules! nonzero_integer {
             /// #
             /// # fn main() { test().unwrap(); }
             /// # fn test() -> Option<()> {
-            #[doc = concat!("assert_eq!(NonZero::<", stringify!($Int), ">::from_ascii_radix(b\"A\", 16), Ok(NonZero::new(10)?));")]
+            #[doc = concat!("assert_eq!(NonZero::<", stringify!($Int), ">::from_ascii_bytes_radix(b\"A\", 16), Ok(NonZero::new(10)?));")]
             /// # Some(())
             /// # }
             /// ```
@@ -1329,12 +1333,21 @@ macro_rules! nonzero_integer {
             ///
             /// # use std::num::NonZero;
             /// #
-            #[doc = concat!("assert!(NonZero::<", stringify!($Int), ">::from_ascii_radix(b\"1 \", 10).is_err());")]
+            #[doc = concat!("assert!(NonZero::<", stringify!($Int), ">::from_ascii_bytes_radix(b\"1 \", 10).is_err());")]
             /// ```
             #[unstable(feature = "int_from_ascii", issue = "134821")]
+            #[rustc_const_unstable(feature = "const_convert", issue = "143773")]
             #[inline]
-            pub const fn from_ascii_radix(src: &[u8], radix: u32) -> Result<Self, ParseIntError> {
-                let n = match <$Int>::from_ascii_radix(src, radix) {
+            pub const fn from_ascii_bytes_radix<T>(src: T, radix: u32) -> Result<Self, ParseIntError>
+            where
+                T: [const] AsRef<[u8]> + [const] crate::marker::Destruct
+            {
+                Self::from_ascii_bytes_radix_impl(src.as_ref(), radix)
+            }
+
+            #[inline]
+            const fn from_ascii_bytes_radix_impl(src: &[u8], radix: u32) -> Result<Self, ParseIntError> {
+                let n = match <$Int>::from_ascii_bytes_radix_impl(src, radix) {
                     Ok(n) => n,
                     Err(err) => return Err(err),
                 };
@@ -1394,7 +1407,7 @@ macro_rules! nonzero_integer {
             #[rustc_const_stable(feature = "nonzero_from_str_radix", since = "1.98.0")]
             #[inline]
             pub const fn from_str_radix(src: &str, radix: u32) -> Result<Self, ParseIntError> {
-                Self::from_ascii_radix(src.as_bytes(), radix)
+                Self::from_ascii_bytes_radix_impl(src.as_bytes(), radix)
             }
         }
 

--- a/library/coretests/tests/nonzero.rs
+++ b/library/coretests/tests/nonzero.rs
@@ -125,57 +125,60 @@ fn test_from_signed_nonzero() {
 }
 
 #[test]
-fn test_from_ascii_radix() {
-    assert_eq!(NonZero::<u8>::from_ascii_radix(b"123", 10), Ok(NonZero::new(123).unwrap()));
-    assert_eq!(NonZero::<u8>::from_ascii_radix(b"1001", 2), Ok(NonZero::new(9).unwrap()));
-    assert_eq!(NonZero::<u8>::from_ascii_radix(b"123", 8), Ok(NonZero::new(83).unwrap()));
-    assert_eq!(NonZero::<u16>::from_ascii_radix(b"123", 16), Ok(NonZero::new(291).unwrap()));
-    assert_eq!(NonZero::<u16>::from_ascii_radix(b"ffff", 16), Ok(NonZero::new(65535).unwrap()));
-    assert_eq!(NonZero::<u8>::from_ascii_radix(b"z", 36), Ok(NonZero::new(35).unwrap()));
+fn test_from_ascii_bytes_radix() {
+    assert_eq!(NonZero::<u8>::from_ascii_bytes_radix(b"123", 10), Ok(NonZero::new(123).unwrap()));
+    assert_eq!(NonZero::<u8>::from_ascii_bytes_radix(b"1001", 2), Ok(NonZero::new(9).unwrap()));
+    assert_eq!(NonZero::<u8>::from_ascii_bytes_radix(b"123", 8), Ok(NonZero::new(83).unwrap()));
+    assert_eq!(NonZero::<u16>::from_ascii_bytes_radix(b"123", 16), Ok(NonZero::new(291).unwrap()));
     assert_eq!(
-        NonZero::<u8>::from_ascii_radix(b"0", 10).err().map(|e| e.kind().clone()),
+        NonZero::<u16>::from_ascii_bytes_radix(b"ffff", 16),
+        Ok(NonZero::new(65535).unwrap())
+    );
+    assert_eq!(NonZero::<u8>::from_ascii_bytes_radix(b"z", 36), Ok(NonZero::new(35).unwrap()));
+    assert_eq!(
+        NonZero::<u8>::from_ascii_bytes_radix(b"0", 10).err().map(|e| e.kind().clone()),
         Some(IntErrorKind::Zero)
     );
     assert_eq!(
-        NonZero::<u8>::from_ascii_radix(b"-1", 10).err().map(|e| e.kind().clone()),
+        NonZero::<u8>::from_ascii_bytes_radix(b"-1", 10).err().map(|e| e.kind().clone()),
         Some(IntErrorKind::InvalidDigit)
     );
     assert_eq!(
-        NonZero::<i8>::from_ascii_radix(b"-129", 10).err().map(|e| e.kind().clone()),
+        NonZero::<i8>::from_ascii_bytes_radix(b"-129", 10).err().map(|e| e.kind().clone()),
         Some(IntErrorKind::NegOverflow)
     );
     assert_eq!(
-        NonZero::<u8>::from_ascii_radix(b"257", 10).err().map(|e| e.kind().clone()),
+        NonZero::<u8>::from_ascii_bytes_radix(b"257", 10).err().map(|e| e.kind().clone()),
         Some(IntErrorKind::PosOverflow)
     );
 
     assert_eq!(
-        NonZero::<u8>::from_ascii_radix(b"Z", 10).err().map(|e| e.kind().clone()),
+        NonZero::<u8>::from_ascii_bytes_radix(b"Z", 10).err().map(|e| e.kind().clone()),
         Some(IntErrorKind::InvalidDigit)
     );
     assert_eq!(
-        NonZero::<u8>::from_ascii_radix(b"_", 2).err().map(|e| e.kind().clone()),
+        NonZero::<u8>::from_ascii_bytes_radix(b"_", 2).err().map(|e| e.kind().clone()),
         Some(IntErrorKind::InvalidDigit)
     );
 }
 
 #[test]
-fn test_from_ascii() {
-    assert_eq!(NonZero::<u8>::from_ascii(b"123"), Ok(NonZero::new(123).unwrap()));
+fn test_from_ascii_bytes() {
+    assert_eq!(NonZero::<u8>::from_ascii_bytes(b"123"), Ok(NonZero::new(123).unwrap()));
     assert_eq!(
-        NonZero::<u8>::from_ascii(b"0").err().map(|e| e.kind().clone()),
+        NonZero::<u8>::from_ascii_bytes(b"0").err().map(|e| e.kind().clone()),
         Some(IntErrorKind::Zero)
     );
     assert_eq!(
-        NonZero::<u8>::from_ascii(b"-1").err().map(|e| e.kind().clone()),
+        NonZero::<u8>::from_ascii_bytes(b"-1").err().map(|e| e.kind().clone()),
         Some(IntErrorKind::InvalidDigit)
     );
     assert_eq!(
-        NonZero::<i8>::from_ascii(b"-129").err().map(|e| e.kind().clone()),
+        NonZero::<i8>::from_ascii_bytes(b"-129").err().map(|e| e.kind().clone()),
         Some(IntErrorKind::NegOverflow)
     );
     assert_eq!(
-        NonZero::<u8>::from_ascii(b"257").err().map(|e| e.kind().clone()),
+        NonZero::<u8>::from_ascii_bytes(b"257").err().map(|e| e.kind().clone()),
         Some(IntErrorKind::PosOverflow)
     );
 }

--- a/library/coretests/tests/num/mod.rs
+++ b/library/coretests/tests/num/mod.rs
@@ -118,7 +118,7 @@ fn from_str_issue7588() {
 
 #[test]
 #[should_panic = "radix must lie in the range `[2, 36]`"]
-fn from_ascii_radix_panic() {
+fn from_ascii_bytes_radix_panic() {
     let radix = 1;
     let _parsed = u64::from_str_radix("12345ABCD", radix);
 }

--- a/library/std/src/sys/platform_version/darwin/mod.rs
+++ b/library/std/src/sys/platform_version/darwin/mod.rs
@@ -313,17 +313,17 @@ unsafe fn string_version_key(
 /// Parse an OS version from a bytestring like b"10.1" or b"14.3.7".
 fn parse_os_version(version: &[u8]) -> Result<OSVersion, ParseIntError> {
     if let Some((major, minor)) = version.split_once(|&b| b == b'.') {
-        let major = u16::from_ascii(major)?;
+        let major = u16::from_ascii_bytes(major)?;
         if let Some((minor, patch)) = minor.split_once(|&b| b == b'.') {
-            let minor = u8::from_ascii(minor)?;
-            let patch = u8::from_ascii(patch)?;
+            let minor = u8::from_ascii_bytes(minor)?;
+            let patch = u8::from_ascii_bytes(patch)?;
             Ok(pack_os_version(major, minor, patch))
         } else {
-            let minor = u8::from_ascii(minor)?;
+            let minor = u8::from_ascii_bytes(minor)?;
             Ok(pack_os_version(major, minor, 0))
         }
     } else {
-        let major = u16::from_ascii(version)?;
+        let major = u16::from_ascii_bytes(version)?;
         Ok(pack_os_version(major, 0, 0))
     }
 }

--- a/tests/ui/consts/const-eval/parse_ints.stderr
+++ b/tests/ui/consts/const-eval/parse_ints.stderr
@@ -1,4 +1,4 @@
-error[E0080]: evaluation panicked: from_ascii_radix: radix must lie in the range `[2, 36]`
+error[E0080]: evaluation panicked: from_ascii_bytes_radix: radix must lie in the range `[2, 36]`
   --> $DIR/parse_ints.rs:7:24
    |
 LL | const _TOO_LOW: () = { u64::from_str_radix("12345ABCD", 1); };
@@ -9,14 +9,14 @@ note: inside `core::num::<impl u64>::from_str_radix`
   ::: $SRC_DIR/core/src/num/mod.rs:LL:COL
    |
    = note: in this macro invocation
-note: inside `core::num::<impl u64>::from_ascii_radix`
+note: inside `core::num::<impl u64>::from_ascii_bytes_radix_impl`
   --> $SRC_DIR/core/src/num/mod.rs:LL:COL
   ::: $SRC_DIR/core/src/num/mod.rs:LL:COL
    |
    = note: in this macro invocation
    = note: this error originates in the macro `from_str_int_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0080]: evaluation panicked: from_ascii_radix: radix must lie in the range `[2, 36]`
+error[E0080]: evaluation panicked: from_ascii_bytes_radix: radix must lie in the range `[2, 36]`
   --> $DIR/parse_ints.rs:8:25
    |
 LL | const _TOO_HIGH: () = { u64::from_str_radix("12345ABCD", 37); };
@@ -27,7 +27,7 @@ note: inside `core::num::<impl u64>::from_str_radix`
   ::: $SRC_DIR/core/src/num/mod.rs:LL:COL
    |
    = note: in this macro invocation
-note: inside `core::num::<impl u64>::from_ascii_radix`
+note: inside `core::num::<impl u64>::from_ascii_bytes_radix_impl`
   --> $SRC_DIR/core/src/num/mod.rs:LL:COL
   ::: $SRC_DIR/core/src/num/mod.rs:LL:COL
    |


### PR DESCRIPTION
* Tracking issue: rust-lang/rust#134821

Following [discussion on Zulip](https://rust-lang.zulipchat.com/#narrow/channel/327149-t-libs-api.2Fapi-changes/topic/How.20to.20proceed.20with.20int_from_ascii/with/611508226) it appears the preference is to change the API for this feature as follows:

```rust
// core::num

impl X {
    pub const fn from_ascii_bytes<T>(src: T) -> Result<X, ParseIntError>
    where
        T: [const] AsRef<[u8]> + [const] core::marker::Destruct;

    pub const fn from_ascii_bytes_radix<T>(src: T, radix: u32) -> Result<X, ParseIntError>
    where
        T: [const] AsRef<[u8]> + [const] core::marker::Destruct;
}
```

and similarly for `NonZero<X>`.

Reasons behind the change:

* Future-proof the naming convention for future string-like types
* Support the upcoming `ByteStr`/`ByteString` types: rust-lang/rust#134915

This pull request applies this change. The const-ness of these functions is now feature gated behind rust-lang/rust#143773