### PR TITLE
Windows: cache the stdio write mode for the duration of a lock session

### DIFF
--- a/library/std/src/io/stdio.rs
+++ b/library/std/src/io/stdio.rs
@@ -95,6 +95,27 @@ const fn stderr_raw() -> StderrRaw {
     StderrRaw(stdio::Stderr::new())
 }
 
+impl StdoutRaw {
+    /// Starts a new lock session: stream state that platforms cache per lock
+    /// session (on Windows, the handle and its console mode) is re-queried at
+    /// the next write, so that changing the process stdio handles (e.g. with
+    /// `SetStdHandle`) between lock sessions keeps working.
+    #[inline]
+    fn refresh(&mut self) {
+        #[cfg(windows)]
+        self.0.refresh();
+    }
+}
+
+impl StderrRaw {
+    /// See `StdoutRaw::refresh`.
+    #[inline]
+    fn refresh(&mut self) {
+        #[cfg(windows)]
+        self.0.refresh();
+    }
+}
+
 impl Read for StdinRaw {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         handle_ebadf(self.0.read(buf), || Ok(0))
@@ -769,7 +790,15 @@ impl Stdout {
         // Locks this handle with 'static lifetime. This depends on the
         // implementation detail that the underlying `ReentrantMutex` is
         // static.
-        StdoutLock { inner: self.inner.lock() }
+        let lock = StdoutLock { inner: self.inner.lock() };
+        // A new lock session begins, so let the platform re-query cached
+        // stream state at the next write. Skipped if the cell is already
+        // borrowed (a nested lock during an ongoing write); such a lock is
+        // part of the outer session anyway.
+        if let Ok(mut w) = lock.inner.try_borrow_mut() {
+            w.get_mut().refresh();
+        }
+        lock
     }
 }
 
@@ -1001,7 +1030,12 @@ impl Stderr {
         // Locks this handle with 'static lifetime. This depends on the
         // implementation detail that the underlying `ReentrantMutex` is
         // static.
-        StderrLock { inner: self.inner.lock() }
+        let lock = StderrLock { inner: self.inner.lock() };
+        // See `Stdout::lock`: a new lock session begins.
+        if let Ok(mut w) = lock.inner.try_borrow_mut() {
+            w.refresh();
+        }
+        lock
     }
 }
 

--- a/library/std/src/io/stdio.rs
+++ b/library/std/src/io/stdio.rs
@@ -95,23 +95,23 @@ const fn stderr_raw() -> StderrRaw {
     StderrRaw(stdio::Stderr::new())
 }
 
+#[cfg(windows)]
 impl StdoutRaw {
-    /// Starts a new lock session: stream state that platforms cache per lock
-    /// session (on Windows, the handle and its console mode) is re-queried at
-    /// the next write, so that changing the process stdio handles (e.g. with
-    /// `SetStdHandle`) between lock sessions keeps working.
+    /// Starts a new lock session: stream state cached per lock session (the
+    /// handle and its console mode) is re-queried at the next write, so that
+    /// changing the process stdio handles (e.g. with `SetStdHandle`) between
+    /// lock sessions keeps working.
     #[inline]
     fn refresh(&mut self) {
-        #[cfg(windows)]
         self.0.refresh();
     }
 }
 
+#[cfg(windows)]
 impl StderrRaw {
     /// See `StdoutRaw::refresh`.
     #[inline]
     fn refresh(&mut self) {
-        #[cfg(windows)]
         self.0.refresh();
     }
 }
@@ -791,12 +791,16 @@ impl Stdout {
         // implementation detail that the underlying `ReentrantMutex` is
         // static.
         let lock = StdoutLock { inner: self.inner.lock() };
-        // A new lock session begins, so let the platform re-query cached
-        // stream state at the next write. Skipped if the cell is already
-        // borrowed (a nested lock during an ongoing write); such a lock is
-        // part of the outer session anyway.
-        if let Ok(mut w) = lock.inner.try_borrow_mut() {
-            w.get_mut().refresh();
+        // A new lock session begins, so let Windows re-query cached stream
+        // state at the next write; other platforms cache nothing, and skip
+        // this entirely so their `lock()` is unchanged. Skipped also if the
+        // cell is already borrowed (a nested lock during an ongoing write);
+        // such a lock is part of the outer session anyway.
+        #[cfg(windows)]
+        {
+            if let Ok(mut w) = lock.inner.try_borrow_mut() {
+                w.get_mut().refresh();
+            }
         }
         lock
     }
@@ -1031,9 +1035,12 @@ impl Stderr {
         // implementation detail that the underlying `ReentrantMutex` is
         // static.
         let lock = StderrLock { inner: self.inner.lock() };
-        // See `Stdout::lock`: a new lock session begins.
-        if let Ok(mut w) = lock.inner.try_borrow_mut() {
-            w.refresh();
+        // See `Stdout::lock`: a new lock session begins (Windows only).
+        #[cfg(windows)]
+        {
+            if let Ok(mut w) = lock.inner.try_borrow_mut() {
+                w.refresh();
+            }
         }
         lock
     }

--- a/library/std/src/sys/stdio/windows.rs
+++ b/library/std/src/sys/stdio/windows.rs
@@ -21,11 +21,34 @@ pub struct Stdin {
 
 pub struct Stdout {
     incomplete_utf8: IncompleteUtf8,
+    write_mode: Option<WriteMode>,
 }
 
 pub struct Stderr {
     incomplete_utf8: IncompleteUtf8,
+    write_mode: Option<WriteMode>,
 }
+
+/// How to write to a standard stream, cached for the duration of a lock
+/// session (see `Stdout::refresh`). Re-querying this on every lock
+/// acquisition keeps `SetStdHandle` calls made between lock sessions working
+/// (see #40490), while a held lock skips the per-write console queries that
+/// otherwise dominate bulk writes (see #154071).
+#[derive(Clone, Copy)]
+enum WriteMode {
+    /// The stream is a pipe or file, or a console using the UTF-8 code page:
+    /// bytes are written out unchanged.
+    Passthrough(c::HANDLE),
+    /// The stream is a console using a non-UTF-8 code page: data is converted
+    /// to UTF-16 and written with `WriteConsoleW`.
+    Utf16Console(c::HANDLE),
+}
+
+// SAFETY: a `HANDLE` stored here is only an OS handle value for a standard
+// stream (it is never dereferenced), and handle values are valid
+// process-wide, on any thread.
+unsafe impl Send for WriteMode {}
+unsafe impl Sync for WriteMode {}
 
 struct IncompleteUtf8 {
     bytes: [u8; 4],
@@ -98,21 +121,40 @@ fn is_utf8_console() -> bool {
     false
 }
 
-fn write(handle_id: u32, data: &[u8], incomplete_utf8: &mut IncompleteUtf8) -> io::Result<usize> {
+fn write(
+    handle_id: u32,
+    data: &[u8],
+    incomplete_utf8: &mut IncompleteUtf8,
+    write_mode: &mut Option<WriteMode>,
+) -> io::Result<usize> {
     if data.is_empty() {
         return Ok(0);
     }
 
-    let handle = get_handle(handle_id)?;
-    if !is_console(handle) || is_utf8_console() {
-        unsafe {
+    let mode = match *write_mode {
+        Some(mode) => mode,
+        None => {
+            let handle = get_handle(handle_id)?;
+            let mode = if !is_console(handle) || is_utf8_console() {
+                WriteMode::Passthrough(handle)
+            } else {
+                WriteMode::Utf16Console(handle)
+            };
+            // Only cache success; if there is no handle, keep erroring on
+            // every write like before.
+            *write_mode = Some(mode);
+            mode
+        }
+    };
+
+    match mode {
+        WriteMode::Passthrough(handle) => unsafe {
             let handle = Handle::from_raw_handle(handle);
             let ret = handle.write(data);
             let _ = handle.into_raw_handle(); // Don't close the handle
-            return ret;
-        }
-    } else {
-        write_console_utf16(data, incomplete_utf8, handle)
+            ret
+        },
+        WriteMode::Utf16Console(handle) => write_console_utf16(data, incomplete_utf8, handle),
     }
 }
 
@@ -432,13 +474,21 @@ impl IncompleteUtf8 {
 
 impl Stdout {
     pub const fn new() -> Stdout {
-        Stdout { incomplete_utf8: IncompleteUtf8::new() }
+        Stdout { incomplete_utf8: IncompleteUtf8::new(), write_mode: None }
+    }
+
+    /// Forgets the cached stream state, so the next write re-queries the OS.
+    /// Called when a new lock session begins, so that changing the process
+    /// stdio handles (e.g. `SetStdHandle`) between lock sessions keeps
+    /// working (see #40490).
+    pub fn refresh(&mut self) {
+        self.write_mode = None;
     }
 }
 
 impl io::Write for Stdout {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        write(c::STD_OUTPUT_HANDLE, buf, &mut self.incomplete_utf8)
+        write(c::STD_OUTPUT_HANDLE, buf, &mut self.incomplete_utf8, &mut self.write_mode)
     }
 
     fn flush(&mut self) -> io::Result<()> {
@@ -448,13 +498,18 @@ impl io::Write for Stdout {
 
 impl Stderr {
     pub const fn new() -> Stderr {
-        Stderr { incomplete_utf8: IncompleteUtf8::new() }
+        Stderr { incomplete_utf8: IncompleteUtf8::new(), write_mode: None }
+    }
+
+    /// See `Stdout::refresh`.
+    pub fn refresh(&mut self) {
+        self.write_mode = None;
     }
 }
 
 impl io::Write for Stderr {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        write(c::STD_ERROR_HANDLE, buf, &mut self.incomplete_utf8)
+        write(c::STD_ERROR_HANDLE, buf, &mut self.incomplete_utf8, &mut self.write_mode)
     }
 
     fn flush(&mut self) -> io::Result<()> {


### PR DESCRIPTION
On Windows, every write to stdout/stderr calls `GetStdHandle` and `GetConsoleMode` (and `GetConsoleOutputCP` for consoles) to decide how to write. For bulk writes through a locked handle that is most of the work; rust-lang/rust#154071 measured 14% of CPU time in `is_console` alone.

This caches the handle and the console verdict in the sys-level `Stdout`/`Stderr` and re-queries when a new lock session begins, as [suggested in the issue](https://github.com/rust-lang/rust/issues/154071#issuecomment-4092410339). Holding a `StdoutLock` pins the stream; unlocked writes acquire the lock per call, so they re-query per write exactly as before, and `SetStdHandle` calls made between lock sessions keep working (the rust-lang/rust#40490 behavior is preserved).

Numbers from the issue's workload shape (16 KiB chunks to `NUL`, 4 GiB total, Windows 11):

| mode | before | after |
|---|---|---|
| `stdout().lock()` | 0.478 s (8,561 MiB/s) | 0.120 s (34,350 MiB/s) |
| unlocked | 0.467 s | 0.293 s |

The unlocked case also improves because one implicit lock session can contain several sys-level writes when `LineWriter` splits a chunk at newlines.

The console path cannot run in CI, so it was verified under a pseudoconsole: several writes through one lock session on a CP437 console came through `WriteConsoleW` intact (non-ASCII included), and after `SetConsoleOutputCP` plus a new lock session the refresh picked up the change.

The `refresh` hook is a small `#[cfg(windows)]` shim on `StdoutRaw`/`StderrRaw`; happy to change it to a method on every platform's sys type instead if that is preferred.

Fixes rust-lang/rust#154071
