### PR TITLE
fix ICE in opsem inhabitedness check

### DIFF
--- a/compiler/rustc_middle/src/ty/inhabitedness/mod.rs
+++ b/compiler/rustc_middle/src/ty/inhabitedness/mod.rs
@@ -339,8 +339,12 @@ fn is_opsem_inhabited_recursor<'tcx, SEEN>(
             })
         }
 
-        ty::Error(_)
-        | ty::Infer(..)
+        ty::Error(_error_guaranteed) => {
+            // We have a token proving there was an error, so we can return a dummy value.
+            true
+        }
+
+        ty::Infer(..)
         | ty::Placeholder(..)
         | ty::Bound(..)
         | ty::Param(..)

--- a/tests/ui/consts/extra-const-ub/pointee-type-with-error-issue-159560.rs
+++ b/tests/ui/consts/extra-const-ub/pointee-type-with-error-issue-159560.rs
@@ -1,0 +1,10 @@
+//@ compile-flags: -Zextra-const-ub-checks
+
+struct A {
+    f: _, //~ERROR: not allowed
+}
+
+// FIXME: the error message makes no sense
+static B: &A = B; //~ERROR: access itself
+
+fn main() {}

--- a/tests/ui/consts/extra-const-ub/pointee-type-with-error-issue-159560.stderr
+++ b/tests/ui/consts/extra-const-ub/pointee-type-with-error-issue-159560.stderr
@@ -1,0 +1,16 @@
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for structs
+  --> $DIR/pointee-type-with-error-issue-159560.rs:4:8
+   |
+LL |     f: _,
+   |        ^ not allowed in type signatures
+
+error[E0080]: encountered static that tried to access itself during initialization
+  --> $DIR/pointee-type-with-error-issue-159560.rs:8:16
+   |
+LL | static B: &A = B;
+   |                ^ evaluation of `B` failed here
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0080, E0121.
+For more information about an error, try `rustc --explain E0080`.


### PR DESCRIPTION
I feel like maybe rust-lang/rust#159560 should be avoided by not even trying to evaluate this constant... but anyway it makes sense to make this query tolerant to `ty::Error` IMO.

The error message we emit still makes no sense, but that's a separate issue and better than ICEing.

Fixes https://github.com/rust-lang/rust/issues/159560
r? @oli-obk 