### PR TITLE
Remove unused bundled library lookup for the local crate

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -26,7 +26,7 @@ use rustc_lint_defs::builtin::LINKER_INFO;
 use rustc_macros::Diagnostic;
 use rustc_metadata::fs::{METADATA_FILENAME, copy_to_stdout, emit_wrapper_file};
 use rustc_metadata::{
-    EncodedMetadata, NativeLibSearchFallback, find_bundled_library, find_native_static_library,
+    EncodedMetadata, NativeLibSearchFallback, find_native_static_library,
     walk_native_lib_search_dirs,
 };
 use rustc_middle::bug;
@@ -374,6 +374,28 @@ pub fn each_linked_rlib(
     Ok(())
 }
 
+/// If `lib` is a static library that is bundled into the rlib as a packed archive, returns the
+/// file name of that archive. Returns `None` for libraries that are instead unpacked into loose
+/// object files, or not bundled at all.
+fn find_bundled_library(
+    lib: &NativeLib,
+    sess: &Session,
+    crate_types: &[CrateType],
+) -> Option<Symbol> {
+    if let NativeLibKind::Static { bundle: Some(true) | None, whole_archive, .. } = lib.kind
+        && crate_types.iter().any(|t| matches!(t, &CrateType::Rlib | CrateType::StaticLib))
+        && (sess.opts.unstable_opts.packed_bundled_libs
+            || lib.cfg.is_some()
+            || whole_archive == Some(true))
+    {
+        return find_native_static_library(lib.name.as_str(), lib.verbatim, sess)
+            .file_name()
+            .and_then(|s| s.to_str())
+            .map(Symbol::intern);
+    }
+    None
+}
+
 /// Create an 'rlib'.
 ///
 /// An rlib in its current incarnation is essentially a renamed .a file (with "dummy" object files).
@@ -405,16 +427,7 @@ fn link_rlib<'a>(
     let native_lib_filenames: Vec<Option<Symbol>> = crate_info
         .used_libraries
         .iter()
-        .map(|lib| {
-            find_bundled_library(
-                lib.name,
-                Some(lib.verbatim),
-                lib.kind,
-                lib.cfg.is_some(),
-                sess,
-                &crate_info.crate_types,
-            )
-        })
+        .map(|lib| find_bundled_library(lib, sess, &crate_info.crate_types))
         .collect();
 
     let metadata_link_file = if matches!(flavor, RlibFlavor::Normal) {
@@ -3186,23 +3199,9 @@ fn add_native_libs_from_crate(
     }
 
     let (native_libs, bundled_filenames): (&Vec<NativeLib>, Vec<Option<Symbol>>) = match cnum {
-        LOCAL_CRATE => {
-            let libs = &crate_info.used_libraries;
-            let filenames = libs
-                .iter()
-                .map(|lib| {
-                    find_bundled_library(
-                        lib.name,
-                        Some(lib.verbatim),
-                        lib.kind,
-                        lib.cfg.is_some(),
-                        sess,
-                        &crate_info.crate_types,
-                    )
-                })
-                .collect();
-            (libs, filenames)
-        }
+        // Bundled libraries are only linked by path for upstream crates, so the local crate
+        // never needs their filenames.
+        LOCAL_CRATE => (&crate_info.used_libraries, Vec::new()),
         _ => {
             let native_libs = &crate_info.native_libraries[&cnum];
             let filenames =

--- a/compiler/rustc_metadata/src/lib.rs
+++ b/compiler/rustc_metadata/src/lib.rs
@@ -28,7 +28,7 @@ pub mod locator;
 pub use fs::{METADATA_FILENAME, emit_wrapper_file};
 pub use host_dylib::{DylibError, load_symbol_from_dylib};
 pub use native_libs::{
-    NativeLibSearchFallback, find_bundled_library, find_native_static_library,
-    try_find_native_dynamic_library, try_find_native_static_library, walk_native_lib_search_dirs,
+    NativeLibSearchFallback, find_native_static_library, try_find_native_dynamic_library,
+    try_find_native_static_library, walk_native_lib_search_dirs,
 };
 pub use rmeta::{EncodedMetadata, METADATA_HEADER, ProcMacroKind, encode_metadata, rendered_const};

--- a/compiler/rustc_metadata/src/native_libs.rs
+++ b/compiler/rustc_metadata/src/native_libs.rs
@@ -12,7 +12,6 @@ use rustc_middle::middle::codegen_fn_attrs::CodegenFnAttrFlags;
 use rustc_middle::query::LocalCrate;
 use rustc_middle::ty::{self, List, Ty, TyCtxt};
 use rustc_session::Session;
-use rustc_session::config::CrateType;
 use rustc_session::cstore::{
     DllCallingConvention, DllImport, DllImportSymbolType, ForeignModule, NativeLib,
 };
@@ -166,27 +165,6 @@ pub fn find_native_static_library(name: &str, verbatim: bool, sess: &Session) ->
     try_find_native_static_library(sess, name, verbatim).unwrap_or_else(|| {
         sess.dcx().emit_fatal(diagnostics::MissingNativeLibrary::new(name, verbatim))
     })
-}
-
-pub fn find_bundled_library(
-    name: Symbol,
-    verbatim: Option<bool>,
-    kind: NativeLibKind,
-    has_cfg: bool,
-    sess: &Session,
-    crate_types: &[CrateType],
-) -> Option<Symbol> {
-    if let NativeLibKind::Static { bundle: Some(true) | None, whole_archive, .. } = kind
-        && crate_types.iter().any(|t| matches!(t, &CrateType::Rlib | CrateType::StaticLib))
-        && (sess.opts.unstable_opts.packed_bundled_libs || has_cfg || whole_archive == Some(true))
-    {
-        let verbatim = verbatim.unwrap_or(false);
-        return find_native_static_library(name.as_str(), verbatim, sess)
-            .file_name()
-            .and_then(|s| s.to_str())
-            .map(Symbol::intern);
-    }
-    None
 }
 
 pub(crate) fn collect(tcx: TyCtxt<'_>, LocalCrate: LocalCrate) -> Vec<NativeLib> {


### PR DESCRIPTION
After rust-lang/rust#156735 the local crate's branch in `add_native_libs_from_crate` computes a list of bundled library filenames that nothing ever reads. And the only place that runs this is located in other crates not the current local one. The local crate always links its native libraries by name.   

This removes that unused branch. This is a cleanup only with no change in behavior.