### PR TITLE
Reject cfg on expressions that cannot be safely removed

### DIFF
--- a/compiler/rustc_expand/src/expand.rs
+++ b/compiler/rustc_expand/src/expand.rs
@@ -2427,6 +2427,13 @@ impl<'a, 'b> InvocationCollector<'a, 'b> {
                     Some(sym::cfg) => {
                         let span = attr.span;
                         if self.expand_cfg_true(node, attr, pos).as_bool() {
+                            match Node::KIND {
+                                AstFragmentKind::Expr | AstFragmentKind::MethodReceiverExpr => {
+                                    self.cx.dcx().emit_err(RemoveExprNotSupported { span });
+                                }
+                                AstFragmentKind::Crate => {}
+                                _ => unreachable!(),
+                            }
                             continue;
                         }
 

--- a/tests/ui/conditional-compilation/cfg-non-opt-expr.rs
+++ b/tests/ui/conditional-compilation/cfg-non-opt-expr.rs
@@ -1,11 +1,38 @@
 #![feature(stmt_expr_attributes)]
 #![feature(custom_test_frameworks)]
 
+#[derive(Clone)]
+enum E {
+    V1 = #[cfg(true)] 1,
+    //~^ ERROR removing an expression is not supported in this position
+    //~| ERROR removing an expression is not supported in this position
+    V2 = #[cfg_attr(true, cfg(true))] 2,
+    //~^ ERROR removing an expression is not supported in this position
+}
+
+macro_rules! mac {
+    ($expr:expr) => { $expr.clone() }
+}
+
 fn main() {
+    let _ = 1 + #[cfg(unix)] 2;
+    //~^ ERROR removing an expression is not supported in this position
+    let _ = 1 + #[cfg(windows)] 2;
+    //~^ ERROR removing an expression is not supported in this position
+    let _ = 1 + #[cfg(all())] 2;
+    //~^ ERROR removing an expression is not supported in this position
     let _ = #[cfg(false)] ();
     //~^ ERROR removing an expression is not supported in this position
     let _ = 1 + 2 + #[cfg(false)] 3;
     //~^ ERROR removing an expression is not supported in this position
     let _ = [1, 2, 3][#[cfg(false)] 1];
+    //~^ ERROR removing an expression is not supported in this position
+    let _ = mac!(#[cfg(true)] 10);
+    //~^ ERROR removing an expression is not supported in this position
+    let _ = #[cfg(true)] ();
+    //~^ ERROR removing an expression is not supported in this position
+    let _ = 1 + 2 + #[cfg(true)] 3;
+    //~^ ERROR removing an expression is not supported in this position
+    let _ = [1, 2, 3][#[cfg(true)] 1];
     //~^ ERROR removing an expression is not supported in this position
 }

--- a/tests/ui/conditional-compilation/cfg-non-opt-expr.rs
+++ b/tests/ui/conditional-compilation/cfg-non-opt-expr.rs
@@ -1,7 +1,23 @@
 #![feature(stmt_expr_attributes)]
 #![feature(custom_test_frameworks)]
 
+#[derive(Clone)]
+enum E {
+    V1 = #[cfg(true)] 1,
+    //~^ ERROR removing an expression is not supported in this position
+    //~| ERROR removing an expression is not supported in this position
+    V2 = #[cfg_attr(true, cfg(true))] 2,
+    //~^ ERROR removing an expression is not supported in this position
+}
+
 fn main() {
+    let _ = 1 + #[cfg(unix)] 2;
+    //~^ ERROR removing an expression is not supported in this position
+    let _ = 1 + #[cfg(windows)] 2;
+    //~^ ERROR removing an expression is not supported in this position
+
+    let _ = 1 + #[cfg(all())] 2;
+    //~^ ERROR removing an expression is not supported in this position
     let _ = #[cfg(false)] ();
     //~^ ERROR removing an expression is not supported in this position
     let _ = 1 + 2 + #[cfg(false)] 3;

--- a/tests/ui/conditional-compilation/cfg-non-opt-expr.stderr
+++ b/tests/ui/conditional-compilation/cfg-non-opt-expr.stderr
@@ -1,20 +1,82 @@
 error: removing an expression is not supported in this position
-  --> $DIR/cfg-non-opt-expr.rs:5:13
+  --> $DIR/cfg-non-opt-expr.rs:18:17
+   |
+LL |     let _ = 1 + #[cfg(unix)] 2;
+   |                 ^^^^^^^^^^^^
+
+error: removing an expression is not supported in this position
+  --> $DIR/cfg-non-opt-expr.rs:20:17
+   |
+LL |     let _ = 1 + #[cfg(windows)] 2;
+   |                 ^^^^^^^^^^^^^^^
+
+error: removing an expression is not supported in this position
+  --> $DIR/cfg-non-opt-expr.rs:22:17
+   |
+LL |     let _ = 1 + #[cfg(all())] 2;
+   |                 ^^^^^^^^^^^^^
+
+error: removing an expression is not supported in this position
+  --> $DIR/cfg-non-opt-expr.rs:24:13
    |
 LL |     let _ = #[cfg(false)] ();
    |             ^^^^^^^^^^^^^
 
 error: removing an expression is not supported in this position
-  --> $DIR/cfg-non-opt-expr.rs:7:21
+  --> $DIR/cfg-non-opt-expr.rs:26:21
    |
 LL |     let _ = 1 + 2 + #[cfg(false)] 3;
    |                     ^^^^^^^^^^^^^
 
 error: removing an expression is not supported in this position
-  --> $DIR/cfg-non-opt-expr.rs:9:23
+  --> $DIR/cfg-non-opt-expr.rs:28:23
    |
 LL |     let _ = [1, 2, 3][#[cfg(false)] 1];
    |                       ^^^^^^^^^^^^^
 
-error: aborting due to 3 previous errors
+error: removing an expression is not supported in this position
+  --> $DIR/cfg-non-opt-expr.rs:32:13
+   |
+LL |     let _ = #[cfg(true)] ();
+   |             ^^^^^^^^^^^^
+
+error: removing an expression is not supported in this position
+  --> $DIR/cfg-non-opt-expr.rs:34:21
+   |
+LL |     let _ = 1 + 2 + #[cfg(true)] 3;
+   |                     ^^^^^^^^^^^^
+
+error: removing an expression is not supported in this position
+  --> $DIR/cfg-non-opt-expr.rs:36:23
+   |
+LL |     let _ = [1, 2, 3][#[cfg(true)] 1];
+   |                       ^^^^^^^^^^^^
+
+error: removing an expression is not supported in this position
+  --> $DIR/cfg-non-opt-expr.rs:6:10
+   |
+LL |     V1 = #[cfg(true)] 1,
+   |          ^^^^^^^^^^^^
+
+error: removing an expression is not supported in this position
+  --> $DIR/cfg-non-opt-expr.rs:6:10
+   |
+LL |     V1 = #[cfg(true)] 1,
+   |          ^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: removing an expression is not supported in this position
+  --> $DIR/cfg-non-opt-expr.rs:9:27
+   |
+LL |     V2 = #[cfg_attr(true, cfg(true))] 2,
+   |                           ^^^^^^^^^
+
+error: removing an expression is not supported in this position
+  --> $DIR/cfg-non-opt-expr.rs:30:18
+   |
+LL |     let _ = mac!(#[cfg(true)] 10);
+   |                  ^^^^^^^^^^^^
+
+error: aborting due to 13 previous errors
 

--- a/tests/ui/conditional-compilation/cfg-non-opt-expr.stderr
+++ b/tests/ui/conditional-compilation/cfg-non-opt-expr.stderr
@@ -1,20 +1,58 @@
 error: removing an expression is not supported in this position
-  --> $DIR/cfg-non-opt-expr.rs:5:13
+  --> $DIR/cfg-non-opt-expr.rs:14:17
+   |
+LL |     let _ = 1 + #[cfg(unix)] 2;
+   |                 ^^^^^^^^^^^^
+
+error: removing an expression is not supported in this position
+  --> $DIR/cfg-non-opt-expr.rs:16:17
+   |
+LL |     let _ = 1 + #[cfg(windows)] 2;
+   |                 ^^^^^^^^^^^^^^^
+
+error: removing an expression is not supported in this position
+  --> $DIR/cfg-non-opt-expr.rs:19:17
+   |
+LL |     let _ = 1 + #[cfg(all())] 2;
+   |                 ^^^^^^^^^^^^^
+
+error: removing an expression is not supported in this position
+  --> $DIR/cfg-non-opt-expr.rs:21:13
    |
 LL |     let _ = #[cfg(false)] ();
    |             ^^^^^^^^^^^^^
 
 error: removing an expression is not supported in this position
-  --> $DIR/cfg-non-opt-expr.rs:7:21
+  --> $DIR/cfg-non-opt-expr.rs:23:21
    |
 LL |     let _ = 1 + 2 + #[cfg(false)] 3;
    |                     ^^^^^^^^^^^^^
 
 error: removing an expression is not supported in this position
-  --> $DIR/cfg-non-opt-expr.rs:9:23
+  --> $DIR/cfg-non-opt-expr.rs:25:23
    |
 LL |     let _ = [1, 2, 3][#[cfg(false)] 1];
    |                       ^^^^^^^^^^^^^
 
-error: aborting due to 3 previous errors
+error: removing an expression is not supported in this position
+  --> $DIR/cfg-non-opt-expr.rs:6:10
+   |
+LL |     V1 = #[cfg(true)] 1,
+   |          ^^^^^^^^^^^^
+
+error: removing an expression is not supported in this position
+  --> $DIR/cfg-non-opt-expr.rs:6:10
+   |
+LL |     V1 = #[cfg(true)] 1,
+   |          ^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: removing an expression is not supported in this position
+  --> $DIR/cfg-non-opt-expr.rs:9:27
+   |
+LL |     V2 = #[cfg_attr(true, cfg(true))] 2,
+   |                           ^^^^^^^^^
+
+error: aborting due to 9 previous errors
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/159580)*
<!-- homu-ignore:end -->

## Change description

This PR changes how `#[cfg]` behaves in expression positions where removing the expression would result in invalid syntax.

For example:

```rust
let _ = 1 + #[cfg(unix)] 2;
```

This currently works on Unix because the condition is `true`, but becomes invalid on non-Unix targets when the expression is removed.

The proposed change rejects `cfg` in these positions regardless of whether the condition is `true` or `false`. The goal is to avoid code whose validity depends on the target and to make the behavior more predictable as `stmt_expr_attributes` is stabilized.

## Summary of the discussion

@petrochenkov pointed out that this differs from the usual token-based model for macros: `#[cfg(true)] expr` produces `expr`, while `#[cfg(false)] expr` produces no tokens. From that perspective, only the latter naturally results in an error.

On the other hand, @estebank pointed out that these cases are easy to introduce accidentally and may only be discovered when the code is compiled for another target. This becomes more important with the stabilization of expression attributes.

We also discussed that this is technically a breaking change, since some currently accepted code such as `#[cfg(true)]` inside a macro invocation would stop compiling (https://github.com/rust-lang/rust/pull/159580#issuecomment-5192990255). The conclusion was that this is effectively closing a stability hole, and the amount of affected code is expected to be very small.

The current implementation also uses `RemoveNodeNotSupported` for these cases and adds coverage for both `#[cfg(true)]` and `#[cfg(false)]`.
