### PR TITLE
Stabilize attributes on closure and method call expressions

### DIFF
--- a/compiler/rustc_expand/src/config.rs
+++ b/compiler/rustc_expand/src/config.rs
@@ -401,9 +401,25 @@ impl<'a> StripUnconfigured<'a> {
         eval_config_entry(self.sess, &cfg)
     }
 
-    /// If attributes are not allowed on expressions, emit an error for `attr`
+    /// Whether `expr` is a closure or method call, possibly parenthesized, on which outer
+    /// attributes are stable.
+    fn is_outer_attr_stable_on_closure_or_method_call_expr(expr: &ast::Expr) -> bool {
+        match &expr.kind {
+            ast::ExprKind::Closure(..) | ast::ExprKind::MethodCall(..) => true,
+            ast::ExprKind::Paren(inner) => {
+                Self::is_outer_attr_stable_on_closure_or_method_call_expr(inner)
+            }
+            _ => false,
+        }
+    }
+
+    /// If attributes are not allowed on `expr`, emit an error for `attr`.
     #[instrument(level = "trace", skip(self))]
-    pub(crate) fn maybe_emit_expr_attr_err(&self, attr: &Attribute) {
+    pub(crate) fn maybe_emit_expr_attr_err(&self, expr: &ast::Expr, attr: &Attribute) {
+        if Self::is_outer_attr_stable_on_closure_or_method_call_expr(expr) {
+            return;
+        }
+
         if self.features.is_some_and(|features| !features.stmt_expr_attributes())
             && !attr.span.allows_unstable(sym::stmt_expr_attributes)
         {
@@ -430,7 +446,7 @@ impl<'a> StripUnconfigured<'a> {
     pub fn configure_expr(&self, expr: &mut ast::Expr, method_receiver: bool) {
         if !method_receiver {
             for attr in expr.attrs.iter() {
-                self.maybe_emit_expr_attr_err(attr);
+                self.maybe_emit_expr_attr_err(expr, attr);
             }
         }
 

--- a/compiler/rustc_expand/src/expand.rs
+++ b/compiler/rustc_expand/src/expand.rs
@@ -1252,7 +1252,12 @@ trait InvocationCollectorNode: HasAttrs + HasNodeId + Sized {
     fn flatten_outputs(_outputs: impl Iterator<Item = Self::OutputTy>) -> Self::OutputTy {
         unreachable!()
     }
-    fn pre_flat_map_node_collect_attr(_cfg: &StripUnconfigured<'_>, _attr: &ast::Attribute) {}
+    fn pre_flat_map_node_collect_attr(
+        _cfg: &StripUnconfigured<'_>,
+        _node: &Self,
+        _attr: &ast::Attribute,
+    ) {
+    }
     fn post_flat_map_node_collect_bang(_output: &mut Self::OutputTy, _add_semicolon: AddSemicolon) {
     }
     fn wrap_flat_map_node_walk_flat_map(
@@ -1962,8 +1967,12 @@ impl InvocationCollectorNode for AstNodeWrapper<Box<ast::Expr>, OptExprTag> {
             _ => unreachable!(),
         }
     }
-    fn pre_flat_map_node_collect_attr(cfg: &StripUnconfigured<'_>, attr: &ast::Attribute) {
-        cfg.maybe_emit_expr_attr_err(attr);
+    fn pre_flat_map_node_collect_attr(
+        cfg: &StripUnconfigured<'_>,
+        node: &Self,
+        attr: &ast::Attribute,
+    ) {
+        cfg.maybe_emit_expr_attr_err(&node.wrapped, attr);
     }
     fn as_target(&self) -> Target {
         Target::Expression
@@ -2333,7 +2342,7 @@ impl<'a, 'b> InvocationCollector<'a, 'b> {
                         continue;
                     }
                     _ => {
-                        Node::pre_flat_map_node_collect_attr(&self.cfg(), &attr);
+                        Node::pre_flat_map_node_collect_attr(&self.cfg(), &node, &attr);
                         self.collect_attr((attr, pos, derives), node.to_annotatable(), Node::KIND)
                             .make_ast::<Node>()
                     }
@@ -2554,7 +2563,7 @@ impl<'a, 'b> MutVisitor for InvocationCollector<'a, 'b> {
     fn visit_expr(&mut self, node: &mut ast::Expr) {
         // FIXME: Feature gating is performed inconsistently between `Expr` and `OptExpr`.
         if let Some(attr) = node.attrs.first() {
-            self.cfg().maybe_emit_expr_attr_err(attr);
+            self.cfg().maybe_emit_expr_attr_err(node, attr);
         }
         ensure_sufficient_stack(|| self.visit_node(node))
     }

--- a/tests/ui/attributes/attributes-on-closure-and-method-call-cfg-eval.rs
+++ b/tests/ui/attributes/attributes-on-closure-and-method-call-cfg-eval.rs
@@ -1,0 +1,16 @@
+//@ check-pass
+
+#![feature(cfg_eval)]
+
+struct Value;
+
+impl Value {
+    fn method(self) -> usize {
+        0
+    }
+}
+
+fn main() {
+    let _ = #[cfg_eval] #[inline] || {};
+    let _ = #[cfg_eval] #[allow(unused)] Value.method();
+}

--- a/tests/ui/attributes/attributes-on-method-calls.rs
+++ b/tests/ui/attributes/attributes-on-method-calls.rs
@@ -1,0 +1,19 @@
+//@ check-pass
+
+struct Value;
+
+impl Value {
+    fn first(self) -> Self {
+        self
+    }
+
+    fn second(self) -> usize {
+        0
+    }
+}
+
+fn main() {
+    let _ = #[allow(unused)] Value.first();
+    let _ = #[allow(unused)] Value.first().second();
+    let _ = #[allow(unused)] (Value.first().second());
+}

--- a/tests/ui/attributes/inline-attribute-on-closure.rs
+++ b/tests/ui/attributes/inline-attribute-on-closure.rs
@@ -1,10 +1,10 @@
 //! Regression test for https://github.com/rust-lang/rust/issues/49632
 
 //@ run-pass
-#![feature(stmt_expr_attributes)]
 
 pub fn main() {
     let _x = #[inline(always)] || {};
     let _y = #[inline(never)] || {};
     let _z = #[inline] || {};
+    let _cold = #[cold] || {};
 }

--- a/tests/ui/attributes/instrument_fn.rs
+++ b/tests/ui/attributes/instrument_fn.rs
@@ -47,5 +47,4 @@ fn instrument_closure() {
     let _x = #[instrument_fn = "on"]
     || {};
     //~^^ ERROR attribute cannot be used on
-    //~^^^ ERROR attributes on expressions are experimental
 }

--- a/tests/ui/attributes/instrument_fn.stderr
+++ b/tests/ui/attributes/instrument_fn.stderr
@@ -8,16 +8,6 @@ LL |         #[instrument_fn = "off"]
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: attributes on expressions are experimental
-  --> $DIR/instrument_fn.rs:47:14
-   |
-LL |     let _x = #[instrument_fn = "on"]
-   |              ^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
-   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
 error: `#[instrument_fn]` attribute cannot be used on crates
   --> $DIR/instrument_fn.rs:2:1
    |
@@ -121,7 +111,7 @@ LL |     let _x = #[instrument_fn = "on"]
    |
    = help: `#[instrument_fn]` can be applied to functions and methods
 
-error: aborting due to 13 previous errors
+error: aborting due to 12 previous errors
 
 Some errors have detailed explanations: E0539, E0658, E0805.
 For more information about an error, try `rustc --explain E0539`.

--- a/tests/ui/closures/2229_closure_analysis/arrays-completely-captured.rs
+++ b/tests/ui/closures/2229_closure_analysis/arrays-completely-captured.rs
@@ -6,9 +6,6 @@ fn main() {
     let mut m = [1, 2, 3, 4, 5];
 
     let mut c = #[rustc_capture_analysis]
-    //~^ ERROR: attributes on expressions are experimental
-    //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
-    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     || {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:

--- a/tests/ui/closures/2229_closure_analysis/arrays-completely-captured.stderr
+++ b/tests/ui/closures/2229_closure_analysis/arrays-completely-captured.stderr
@@ -1,15 +1,5 @@
-error[E0658]: attributes on expressions are experimental
-  --> $DIR/arrays-completely-captured.rs:8:17
-   |
-LL |     let mut c = #[rustc_capture_analysis]
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
-   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
 error: First Pass analysis includes:
-  --> $DIR/arrays-completely-captured.rs:12:5
+  --> $DIR/arrays-completely-captured.rs:9:5
    |
 LL | /     || {
 LL | |
@@ -20,18 +10,18 @@ LL | |     };
    | |_____^
    |
 note: Capturing m[] -> Mutable
-  --> $DIR/arrays-completely-captured.rs:15:9
+  --> $DIR/arrays-completely-captured.rs:12:9
    |
 LL |         m[0] += 10;
    |         ^
 note: Capturing m[] -> Mutable
-  --> $DIR/arrays-completely-captured.rs:18:9
+  --> $DIR/arrays-completely-captured.rs:15:9
    |
 LL |         m[1] += 40;
    |         ^
 
 error: Min Capture analysis includes:
-  --> $DIR/arrays-completely-captured.rs:12:5
+  --> $DIR/arrays-completely-captured.rs:9:5
    |
 LL | /     || {
 LL | |
@@ -42,11 +32,10 @@ LL | |     };
    | |_____^
    |
 note: Min Capture m[] -> Mutable
-  --> $DIR/arrays-completely-captured.rs:15:9
+  --> $DIR/arrays-completely-captured.rs:12:9
    |
 LL |         m[0] += 10;
    |         ^
 
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/closures/2229_closure_analysis/by_value.rs
+++ b/tests/ui/closures/2229_closure_analysis/by_value.rs
@@ -16,9 +16,6 @@ fn big_box() {
     let t = (b, 10);
 
     let c = #[rustc_capture_analysis]
-    //~^ ERROR: attributes on expressions are experimental
-    //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
-    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     || {
     //~^ ERROR First Pass analysis includes:
     //~| ERROR Min Capture analysis includes:

--- a/tests/ui/closures/2229_closure_analysis/by_value.stderr
+++ b/tests/ui/closures/2229_closure_analysis/by_value.stderr
@@ -1,15 +1,5 @@
-error[E0658]: attributes on expressions are experimental
-  --> $DIR/by_value.rs:18:13
-   |
-LL |     let c = #[rustc_capture_analysis]
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
-   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
 error: First Pass analysis includes:
-  --> $DIR/by_value.rs:22:5
+  --> $DIR/by_value.rs:19:5
    |
 LL | /     || {
 LL | |
@@ -20,18 +10,18 @@ LL | |     };
    | |_____^
    |
 note: Capturing t[(0, 0),Deref,(0, 0)] -> ByValue
-  --> $DIR/by_value.rs:25:17
+  --> $DIR/by_value.rs:22:17
    |
 LL |         let p = t.0.0;
    |                 ^^^^^
 note: Capturing t[(1, 0)] -> Immutable
-  --> $DIR/by_value.rs:28:29
+  --> $DIR/by_value.rs:25:29
    |
 LL |         println!("{} {:?}", t.1, p);
    |                             ^^^
 
 error: Min Capture analysis includes:
-  --> $DIR/by_value.rs:22:5
+  --> $DIR/by_value.rs:19:5
    |
 LL | /     || {
 LL | |
@@ -42,16 +32,15 @@ LL | |     };
    | |_____^
    |
 note: Min Capture t[(0, 0)] -> ByValue
-  --> $DIR/by_value.rs:25:17
+  --> $DIR/by_value.rs:22:17
    |
 LL |         let p = t.0.0;
    |                 ^^^^^
 note: Min Capture t[(1, 0)] -> Immutable
-  --> $DIR/by_value.rs:28:29
+  --> $DIR/by_value.rs:25:29
    |
 LL |         println!("{} {:?}", t.1, p);
    |                             ^^^
 
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/closures/2229_closure_analysis/capture-analysis-1.rs
+++ b/tests/ui/closures/2229_closure_analysis/capture-analysis-1.rs
@@ -13,9 +13,6 @@ fn main() {
     let q = Point { x: 10, y: 10 };
 
     let c = #[rustc_capture_analysis]
-    //~^ ERROR: attributes on expressions are experimental
-    //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
-    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     || {
     //~^ ERROR First Pass analysis includes:
     //~| ERROR Min Capture analysis includes:

--- a/tests/ui/closures/2229_closure_analysis/capture-analysis-1.stderr
+++ b/tests/ui/closures/2229_closure_analysis/capture-analysis-1.stderr
@@ -1,15 +1,5 @@
-error[E0658]: attributes on expressions are experimental
-  --> $DIR/capture-analysis-1.rs:15:13
-   |
-LL |     let c = #[rustc_capture_analysis]
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
-   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
 error: First Pass analysis includes:
-  --> $DIR/capture-analysis-1.rs:19:5
+  --> $DIR/capture-analysis-1.rs:16:5
    |
 LL | /     || {
 LL | |
@@ -20,28 +10,28 @@ LL | |     };
    | |_____^
    |
 note: Capturing p[] -> Immutable
-  --> $DIR/capture-analysis-1.rs:22:26
+  --> $DIR/capture-analysis-1.rs:19:26
    |
 LL |         println!("{:?}", p);
    |                          ^
 note: Capturing p[(0, 0)] -> Immutable
-  --> $DIR/capture-analysis-1.rs:25:26
+  --> $DIR/capture-analysis-1.rs:22:26
    |
 LL |         println!("{:?}", p.x);
    |                          ^^^
 note: Capturing q[(0, 0)] -> Immutable
-  --> $DIR/capture-analysis-1.rs:28:26
+  --> $DIR/capture-analysis-1.rs:25:26
    |
 LL |         println!("{:?}", q.x);
    |                          ^^^
 note: Capturing q[] -> Immutable
-  --> $DIR/capture-analysis-1.rs:30:26
+  --> $DIR/capture-analysis-1.rs:27:26
    |
 LL |         println!("{:?}", q);
    |                          ^
 
 error: Min Capture analysis includes:
-  --> $DIR/capture-analysis-1.rs:19:5
+  --> $DIR/capture-analysis-1.rs:16:5
    |
 LL | /     || {
 LL | |
@@ -52,16 +42,15 @@ LL | |     };
    | |_____^
    |
 note: Min Capture p[] -> Immutable
-  --> $DIR/capture-analysis-1.rs:22:26
+  --> $DIR/capture-analysis-1.rs:19:26
    |
 LL |         println!("{:?}", p);
    |                          ^
 note: Min Capture q[] -> Immutable
-  --> $DIR/capture-analysis-1.rs:30:26
+  --> $DIR/capture-analysis-1.rs:27:26
    |
 LL |         println!("{:?}", q);
    |                          ^
 
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/closures/2229_closure_analysis/capture-analysis-2.rs
+++ b/tests/ui/closures/2229_closure_analysis/capture-analysis-2.rs
@@ -12,9 +12,6 @@ fn main() {
     let mut p = Point { x: String::new(), y: 10 };
 
     let c = #[rustc_capture_analysis]
-    //~^ ERROR: attributes on expressions are experimental
-    //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
-    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     || {
     //~^ ERROR First Pass analysis includes:
     //~| ERROR Min Capture analysis includes:

--- a/tests/ui/closures/2229_closure_analysis/capture-analysis-2.stderr
+++ b/tests/ui/closures/2229_closure_analysis/capture-analysis-2.stderr
@@ -1,15 +1,5 @@
-error[E0658]: attributes on expressions are experimental
-  --> $DIR/capture-analysis-2.rs:14:13
-   |
-LL |     let c = #[rustc_capture_analysis]
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
-   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
 error: First Pass analysis includes:
-  --> $DIR/capture-analysis-2.rs:18:5
+  --> $DIR/capture-analysis-2.rs:15:5
    |
 LL | /     || {
 LL | |
@@ -20,18 +10,18 @@ LL | |     };
    | |_____^
    |
 note: Capturing p[(0, 0)] -> ByValue
-  --> $DIR/capture-analysis-2.rs:21:18
+  --> $DIR/capture-analysis-2.rs:18:18
    |
 LL |         let _x = p.x;
    |                  ^^^
 note: Capturing p[] -> Immutable
-  --> $DIR/capture-analysis-2.rs:24:26
+  --> $DIR/capture-analysis-2.rs:21:26
    |
 LL |         println!("{:?}", p);
    |                          ^
 
 error: Min Capture analysis includes:
-  --> $DIR/capture-analysis-2.rs:18:5
+  --> $DIR/capture-analysis-2.rs:15:5
    |
 LL | /     || {
 LL | |
@@ -42,7 +32,7 @@ LL | |     };
    | |_____^
    |
 note: Min Capture p[] -> ByValue
-  --> $DIR/capture-analysis-2.rs:21:18
+  --> $DIR/capture-analysis-2.rs:18:18
    |
 LL |         let _x = p.x;
    |                  ^^^ p[] captured as ByValue here
@@ -50,6 +40,5 @@ LL |         let _x = p.x;
 LL |         println!("{:?}", p);
    |                          ^ p[] used here
 
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/closures/2229_closure_analysis/capture-analysis-3.rs
+++ b/tests/ui/closures/2229_closure_analysis/capture-analysis-3.rs
@@ -17,9 +17,6 @@ fn main() {
     let mut a = Parent { b: Child {c: String::new(), d: String::new()} };
 
     let c = #[rustc_capture_analysis]
-    //~^ ERROR: attributes on expressions are experimental
-    //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
-    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     || {
     //~^ ERROR First Pass analysis includes:
     //~| ERROR Min Capture analysis includes:

--- a/tests/ui/closures/2229_closure_analysis/capture-analysis-3.stderr
+++ b/tests/ui/closures/2229_closure_analysis/capture-analysis-3.stderr
@@ -1,15 +1,5 @@
-error[E0658]: attributes on expressions are experimental
-  --> $DIR/capture-analysis-3.rs:19:13
-   |
-LL |     let c = #[rustc_capture_analysis]
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
-   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
 error: First Pass analysis includes:
-  --> $DIR/capture-analysis-3.rs:23:5
+  --> $DIR/capture-analysis-3.rs:20:5
    |
 LL | /     || {
 LL | |
@@ -20,18 +10,18 @@ LL | |     };
    | |_____^
    |
 note: Capturing a[(0, 0),(0, 0)] -> ByValue
-  --> $DIR/capture-analysis-3.rs:26:18
+  --> $DIR/capture-analysis-3.rs:23:18
    |
 LL |         let _x = a.b.c;
    |                  ^^^^^
 note: Capturing a[(0, 0)] -> Immutable
-  --> $DIR/capture-analysis-3.rs:29:26
+  --> $DIR/capture-analysis-3.rs:26:26
    |
 LL |         println!("{:?}", a.b);
    |                          ^^^
 
 error: Min Capture analysis includes:
-  --> $DIR/capture-analysis-3.rs:23:5
+  --> $DIR/capture-analysis-3.rs:20:5
    |
 LL | /     || {
 LL | |
@@ -42,7 +32,7 @@ LL | |     };
    | |_____^
    |
 note: Min Capture a[(0, 0)] -> ByValue
-  --> $DIR/capture-analysis-3.rs:26:18
+  --> $DIR/capture-analysis-3.rs:23:18
    |
 LL |         let _x = a.b.c;
    |                  ^^^^^ a[(0, 0)] captured as ByValue here
@@ -50,6 +40,5 @@ LL |         let _x = a.b.c;
 LL |         println!("{:?}", a.b);
    |                          ^^^ a[(0, 0)] used here
 
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/closures/2229_closure_analysis/capture-analysis-4.rs
+++ b/tests/ui/closures/2229_closure_analysis/capture-analysis-4.rs
@@ -17,9 +17,6 @@ fn main() {
     let mut a = Parent { b: Child {c: String::new(), d: String::new()} };
 
     let c = #[rustc_capture_analysis]
-    //~^ ERROR: attributes on expressions are experimental
-    //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
-    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     || {
     //~^ ERROR First Pass analysis includes:
     //~| ERROR Min Capture analysis includes:

--- a/tests/ui/closures/2229_closure_analysis/capture-analysis-4.stderr
+++ b/tests/ui/closures/2229_closure_analysis/capture-analysis-4.stderr
@@ -1,15 +1,5 @@
-error[E0658]: attributes on expressions are experimental
-  --> $DIR/capture-analysis-4.rs:19:13
-   |
-LL |     let c = #[rustc_capture_analysis]
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
-   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
 error: First Pass analysis includes:
-  --> $DIR/capture-analysis-4.rs:23:5
+  --> $DIR/capture-analysis-4.rs:20:5
    |
 LL | /     || {
 LL | |
@@ -20,18 +10,18 @@ LL | |     };
    | |_____^
    |
 note: Capturing a[(0, 0)] -> ByValue
-  --> $DIR/capture-analysis-4.rs:26:18
+  --> $DIR/capture-analysis-4.rs:23:18
    |
 LL |         let _x = a.b;
    |                  ^^^
 note: Capturing a[(0, 0),(0, 0)] -> Immutable
-  --> $DIR/capture-analysis-4.rs:29:26
+  --> $DIR/capture-analysis-4.rs:26:26
    |
 LL |         println!("{:?}", a.b.c);
    |                          ^^^^^
 
 error: Min Capture analysis includes:
-  --> $DIR/capture-analysis-4.rs:23:5
+  --> $DIR/capture-analysis-4.rs:20:5
    |
 LL | /     || {
 LL | |
@@ -42,11 +32,10 @@ LL | |     };
    | |_____^
    |
 note: Min Capture a[(0, 0)] -> ByValue
-  --> $DIR/capture-analysis-4.rs:26:18
+  --> $DIR/capture-analysis-4.rs:23:18
    |
 LL |         let _x = a.b;
    |                  ^^^
 
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/closures/2229_closure_analysis/capture-disjoint-field-struct.rs
+++ b/tests/ui/closures/2229_closure_analysis/capture-disjoint-field-struct.rs
@@ -11,9 +11,6 @@ fn main() {
     let mut p = Point { x: 10, y: 10 };
 
     let c = #[rustc_capture_analysis]
-    //~^ ERROR: attributes on expressions are experimental
-    //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
-    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     || {
     //~^ ERROR First Pass analysis includes:
     //~| ERROR Min Capture analysis includes:

--- a/tests/ui/closures/2229_closure_analysis/capture-disjoint-field-struct.stderr
+++ b/tests/ui/closures/2229_closure_analysis/capture-disjoint-field-struct.stderr
@@ -1,15 +1,5 @@
-error[E0658]: attributes on expressions are experimental
-  --> $DIR/capture-disjoint-field-struct.rs:13:13
-   |
-LL |     let c = #[rustc_capture_analysis]
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
-   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
 error: First Pass analysis includes:
-  --> $DIR/capture-disjoint-field-struct.rs:17:5
+  --> $DIR/capture-disjoint-field-struct.rs:14:5
    |
 LL | /     || {
 LL | |
@@ -20,13 +10,13 @@ LL | |     };
    | |_____^
    |
 note: Capturing p[(0, 0)] -> Immutable
-  --> $DIR/capture-disjoint-field-struct.rs:20:24
+  --> $DIR/capture-disjoint-field-struct.rs:17:24
    |
 LL |         println!("{}", p.x);
    |                        ^^^
 
 error: Min Capture analysis includes:
-  --> $DIR/capture-disjoint-field-struct.rs:17:5
+  --> $DIR/capture-disjoint-field-struct.rs:14:5
    |
 LL | /     || {
 LL | |
@@ -37,11 +27,10 @@ LL | |     };
    | |_____^
    |
 note: Min Capture p[(0, 0)] -> Immutable
-  --> $DIR/capture-disjoint-field-struct.rs:20:24
+  --> $DIR/capture-disjoint-field-struct.rs:17:24
    |
 LL |         println!("{}", p.x);
    |                        ^^^
 
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/closures/2229_closure_analysis/capture-disjoint-field-tuple.rs
+++ b/tests/ui/closures/2229_closure_analysis/capture-disjoint-field-tuple.rs
@@ -6,9 +6,6 @@ fn main() {
     let mut t = (10, 10);
 
     let c = #[rustc_capture_analysis]
-    //~^ ERROR: attributes on expressions are experimental
-    //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
-    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     || {
     //~^ ERROR First Pass analysis includes:
     //~| ERROR Min Capture analysis includes:

--- a/tests/ui/closures/2229_closure_analysis/capture-disjoint-field-tuple.stderr
+++ b/tests/ui/closures/2229_closure_analysis/capture-disjoint-field-tuple.stderr
@@ -1,15 +1,5 @@
-error[E0658]: attributes on expressions are experimental
-  --> $DIR/capture-disjoint-field-tuple.rs:8:13
-   |
-LL |     let c = #[rustc_capture_analysis]
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
-   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
 error: First Pass analysis includes:
-  --> $DIR/capture-disjoint-field-tuple.rs:12:5
+  --> $DIR/capture-disjoint-field-tuple.rs:9:5
    |
 LL | /     || {
 LL | |
@@ -20,13 +10,13 @@ LL | |     };
    | |_____^
    |
 note: Capturing t[(0, 0)] -> Immutable
-  --> $DIR/capture-disjoint-field-tuple.rs:15:24
+  --> $DIR/capture-disjoint-field-tuple.rs:12:24
    |
 LL |         println!("{}", t.0);
    |                        ^^^
 
 error: Min Capture analysis includes:
-  --> $DIR/capture-disjoint-field-tuple.rs:12:5
+  --> $DIR/capture-disjoint-field-tuple.rs:9:5
    |
 LL | /     || {
 LL | |
@@ -37,11 +27,10 @@ LL | |     };
    | |_____^
    |
 note: Min Capture t[(0, 0)] -> Immutable
-  --> $DIR/capture-disjoint-field-tuple.rs:15:24
+  --> $DIR/capture-disjoint-field-tuple.rs:12:24
    |
 LL |         println!("{}", t.0);
    |                        ^^^
 
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/closures/2229_closure_analysis/deep-multilevel-struct.rs
+++ b/tests/ui/closures/2229_closure_analysis/deep-multilevel-struct.rs
@@ -32,9 +32,6 @@ fn main() {
     };
 
     let c = #[rustc_capture_analysis]
-    //~^ ERROR: attributes on expressions are experimental
-    //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
-    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     || {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:

--- a/tests/ui/closures/2229_closure_analysis/deep-multilevel-struct.stderr
+++ b/tests/ui/closures/2229_closure_analysis/deep-multilevel-struct.stderr
@@ -1,15 +1,5 @@
-error[E0658]: attributes on expressions are experimental
-  --> $DIR/deep-multilevel-struct.rs:34:13
-   |
-LL |     let c = #[rustc_capture_analysis]
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
-   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
 error: First Pass analysis includes:
-  --> $DIR/deep-multilevel-struct.rs:38:5
+  --> $DIR/deep-multilevel-struct.rs:35:5
    |
 LL | /     || {
 LL | |
@@ -20,23 +10,23 @@ LL | |     };
    | |_____^
    |
 note: Capturing p[(0, 0),(0, 0),(0, 0)] -> Immutable
-  --> $DIR/deep-multilevel-struct.rs:41:18
+  --> $DIR/deep-multilevel-struct.rs:38:18
    |
 LL |         let x = &p.a.p.x;
    |                  ^^^^^^^
 note: Capturing p[(1, 0),(1, 0),(1, 0)] -> Mutable
-  --> $DIR/deep-multilevel-struct.rs:43:9
+  --> $DIR/deep-multilevel-struct.rs:40:9
    |
 LL |         p.b.q.y = 9;
    |         ^^^^^^^
 note: Capturing p[] -> Immutable
-  --> $DIR/deep-multilevel-struct.rs:46:26
+  --> $DIR/deep-multilevel-struct.rs:43:26
    |
 LL |         println!("{:?}", p);
    |                          ^
 
 error: Min Capture analysis includes:
-  --> $DIR/deep-multilevel-struct.rs:38:5
+  --> $DIR/deep-multilevel-struct.rs:35:5
    |
 LL | /     || {
 LL | |
@@ -47,7 +37,7 @@ LL | |     };
    | |_____^
    |
 note: Min Capture p[] -> Mutable
-  --> $DIR/deep-multilevel-struct.rs:43:9
+  --> $DIR/deep-multilevel-struct.rs:40:9
    |
 LL |         p.b.q.y = 9;
    |         ^^^^^^^ p[] captured as Mutable here
@@ -55,6 +45,5 @@ LL |         p.b.q.y = 9;
 LL |         println!("{:?}", p);
    |                          ^ p[] used here
 
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/closures/2229_closure_analysis/deep-multilevel-tuple.rs
+++ b/tests/ui/closures/2229_closure_analysis/deep-multilevel-tuple.rs
@@ -6,9 +6,6 @@ fn main() {
     let mut t = (((1,2),(3,4)),((5,6),(7,8)));
 
     let c = #[rustc_capture_analysis]
-    //~^ ERROR: attributes on expressions are experimental
-    //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
-    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     || {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:

--- a/tests/ui/closures/2229_closure_analysis/deep-multilevel-tuple.stderr
+++ b/tests/ui/closures/2229_closure_analysis/deep-multilevel-tuple.stderr
@@ -1,15 +1,5 @@
-error[E0658]: attributes on expressions are experimental
-  --> $DIR/deep-multilevel-tuple.rs:8:13
-   |
-LL |     let c = #[rustc_capture_analysis]
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
-   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
 error: First Pass analysis includes:
-  --> $DIR/deep-multilevel-tuple.rs:12:5
+  --> $DIR/deep-multilevel-tuple.rs:9:5
    |
 LL | /     || {
 LL | |
@@ -20,23 +10,23 @@ LL | |     };
    | |_____^
    |
 note: Capturing t[(0, 0),(0, 0),(0, 0)] -> Immutable
-  --> $DIR/deep-multilevel-tuple.rs:15:18
+  --> $DIR/deep-multilevel-tuple.rs:12:18
    |
 LL |         let x = &t.0.0.0;
    |                  ^^^^^^^
 note: Capturing t[(1, 0),(1, 0),(1, 0)] -> Mutable
-  --> $DIR/deep-multilevel-tuple.rs:17:9
+  --> $DIR/deep-multilevel-tuple.rs:14:9
    |
 LL |         t.1.1.1 = 9;
    |         ^^^^^^^
 note: Capturing t[] -> Immutable
-  --> $DIR/deep-multilevel-tuple.rs:20:26
+  --> $DIR/deep-multilevel-tuple.rs:17:26
    |
 LL |         println!("{:?}", t);
    |                          ^
 
 error: Min Capture analysis includes:
-  --> $DIR/deep-multilevel-tuple.rs:12:5
+  --> $DIR/deep-multilevel-tuple.rs:9:5
    |
 LL | /     || {
 LL | |
@@ -47,7 +37,7 @@ LL | |     };
    | |_____^
    |
 note: Min Capture t[] -> Mutable
-  --> $DIR/deep-multilevel-tuple.rs:17:9
+  --> $DIR/deep-multilevel-tuple.rs:14:9
    |
 LL |         t.1.1.1 = 9;
    |         ^^^^^^^ t[] captured as Mutable here
@@ -55,6 +45,5 @@ LL |         t.1.1.1 = 9;
 LL |         println!("{:?}", t);
    |                          ^ t[] used here
 
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/closures/2229_closure_analysis/destructure_patterns.rs
+++ b/tests/ui/closures/2229_closure_analysis/destructure_patterns.rs
@@ -8,9 +8,6 @@ fn arrays() {
     let arr: [String; 5] = [format!("A"), format!("B"), format!("C"), format!("D"), format!("E")];
 
     let c = #[rustc_capture_analysis]
-    //~^ ERROR: attributes on expressions are experimental
-    //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
-    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     || {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:
@@ -37,9 +34,6 @@ fn structs() {
     let mut p = Point { x: 10, y: 10, id: String::new() };
 
     let c = #[rustc_capture_analysis]
-    //~^ ERROR: attributes on expressions are experimental
-    //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
-    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     || {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:
@@ -58,9 +52,6 @@ fn tuples() {
     let mut t = (10, String::new(), (String::new(), 42));
 
     let c = #[rustc_capture_analysis]
-    //~^ ERROR: attributes on expressions are experimental
-    //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
-    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     || {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:

--- a/tests/ui/closures/2229_closure_analysis/destructure_patterns.stderr
+++ b/tests/ui/closures/2229_closure_analysis/destructure_patterns.stderr
@@ -1,35 +1,5 @@
-error[E0658]: attributes on expressions are experimental
-  --> $DIR/destructure_patterns.rs:10:13
-   |
-LL |     let c = #[rustc_capture_analysis]
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
-   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
-error[E0658]: attributes on expressions are experimental
-  --> $DIR/destructure_patterns.rs:39:13
-   |
-LL |     let c = #[rustc_capture_analysis]
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
-   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
-error[E0658]: attributes on expressions are experimental
-  --> $DIR/destructure_patterns.rs:60:13
-   |
-LL |     let c = #[rustc_capture_analysis]
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
-   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
 error: First Pass analysis includes:
-  --> $DIR/destructure_patterns.rs:14:5
+  --> $DIR/destructure_patterns.rs:11:5
    |
 LL | /     || {
 LL | |
@@ -41,23 +11,23 @@ LL | |     };
    | |_____^
    |
 note: Capturing arr[Index] -> ByValue
-  --> $DIR/destructure_patterns.rs:17:29
+  --> $DIR/destructure_patterns.rs:14:29
    |
 LL |         let [a, b, .., e] = arr;
    |                             ^^^
 note: Capturing arr[Index] -> ByValue
-  --> $DIR/destructure_patterns.rs:17:29
+  --> $DIR/destructure_patterns.rs:14:29
    |
 LL |         let [a, b, .., e] = arr;
    |                             ^^^
 note: Capturing arr[Index] -> ByValue
-  --> $DIR/destructure_patterns.rs:17:29
+  --> $DIR/destructure_patterns.rs:14:29
    |
 LL |         let [a, b, .., e] = arr;
    |                             ^^^
 
 error: Min Capture analysis includes:
-  --> $DIR/destructure_patterns.rs:14:5
+  --> $DIR/destructure_patterns.rs:11:5
    |
 LL | /     || {
 LL | |
@@ -69,13 +39,13 @@ LL | |     };
    | |_____^
    |
 note: Min Capture arr[] -> ByValue
-  --> $DIR/destructure_patterns.rs:17:29
+  --> $DIR/destructure_patterns.rs:14:29
    |
 LL |         let [a, b, .., e] = arr;
    |                             ^^^
 
 error: First Pass analysis includes:
-  --> $DIR/destructure_patterns.rs:43:5
+  --> $DIR/destructure_patterns.rs:37:5
    |
 LL | /     || {
 LL | |
@@ -87,18 +57,18 @@ LL | |     };
    | |_____^
    |
 note: Capturing p[(0, 0)] -> Mutable
-  --> $DIR/destructure_patterns.rs:46:58
+  --> $DIR/destructure_patterns.rs:40:58
    |
 LL |         let Point { x: ref mut x, y: _, id: moved_id } = p;
    |                                                          ^
 note: Capturing p[(2, 0)] -> ByValue
-  --> $DIR/destructure_patterns.rs:46:58
+  --> $DIR/destructure_patterns.rs:40:58
    |
 LL |         let Point { x: ref mut x, y: _, id: moved_id } = p;
    |                                                          ^
 
 error: Min Capture analysis includes:
-  --> $DIR/destructure_patterns.rs:43:5
+  --> $DIR/destructure_patterns.rs:37:5
    |
 LL | /     || {
 LL | |
@@ -110,18 +80,18 @@ LL | |     };
    | |_____^
    |
 note: Min Capture p[(0, 0)] -> Mutable
-  --> $DIR/destructure_patterns.rs:46:58
+  --> $DIR/destructure_patterns.rs:40:58
    |
 LL |         let Point { x: ref mut x, y: _, id: moved_id } = p;
    |                                                          ^
 note: Min Capture p[(2, 0)] -> ByValue
-  --> $DIR/destructure_patterns.rs:46:58
+  --> $DIR/destructure_patterns.rs:40:58
    |
 LL |         let Point { x: ref mut x, y: _, id: moved_id } = p;
    |                                                          ^
 
 error: First Pass analysis includes:
-  --> $DIR/destructure_patterns.rs:64:5
+  --> $DIR/destructure_patterns.rs:55:5
    |
 LL | /     || {
 LL | |
@@ -133,23 +103,23 @@ LL | |     };
    | |_____^
    |
 note: Capturing t[(0, 0)] -> Mutable
-  --> $DIR/destructure_patterns.rs:67:54
+  --> $DIR/destructure_patterns.rs:58:54
    |
 LL |         let (ref mut x, ref ref_str, (moved_s, _)) = t;
    |                                                      ^
 note: Capturing t[(1, 0)] -> Immutable
-  --> $DIR/destructure_patterns.rs:67:54
+  --> $DIR/destructure_patterns.rs:58:54
    |
 LL |         let (ref mut x, ref ref_str, (moved_s, _)) = t;
    |                                                      ^
 note: Capturing t[(2, 0),(0, 0)] -> ByValue
-  --> $DIR/destructure_patterns.rs:67:54
+  --> $DIR/destructure_patterns.rs:58:54
    |
 LL |         let (ref mut x, ref ref_str, (moved_s, _)) = t;
    |                                                      ^
 
 error: Min Capture analysis includes:
-  --> $DIR/destructure_patterns.rs:64:5
+  --> $DIR/destructure_patterns.rs:55:5
    |
 LL | /     || {
 LL | |
@@ -161,21 +131,20 @@ LL | |     };
    | |_____^
    |
 note: Min Capture t[(0, 0)] -> Mutable
-  --> $DIR/destructure_patterns.rs:67:54
+  --> $DIR/destructure_patterns.rs:58:54
    |
 LL |         let (ref mut x, ref ref_str, (moved_s, _)) = t;
    |                                                      ^
 note: Min Capture t[(1, 0)] -> Immutable
-  --> $DIR/destructure_patterns.rs:67:54
+  --> $DIR/destructure_patterns.rs:58:54
    |
 LL |         let (ref mut x, ref ref_str, (moved_s, _)) = t;
    |                                                      ^
 note: Min Capture t[(2, 0),(0, 0)] -> ByValue
-  --> $DIR/destructure_patterns.rs:67:54
+  --> $DIR/destructure_patterns.rs:58:54
    |
 LL |         let (ref mut x, ref ref_str, (moved_s, _)) = t;
    |                                                      ^
 
-error: aborting due to 9 previous errors
+error: aborting due to 6 previous errors
 
-For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/closures/2229_closure_analysis/feature-gate-capture_disjoint_fields.rs
+++ b/tests/ui/closures/2229_closure_analysis/feature-gate-capture_disjoint_fields.rs
@@ -6,9 +6,6 @@ fn main() {
     let s = format!("s");
 
     let c = #[rustc_capture_analysis]
-    //~^ ERROR: attributes on expressions are experimental
-    //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
-    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     || {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:

--- a/tests/ui/closures/2229_closure_analysis/feature-gate-capture_disjoint_fields.stderr
+++ b/tests/ui/closures/2229_closure_analysis/feature-gate-capture_disjoint_fields.stderr
@@ -1,15 +1,5 @@
-error[E0658]: attributes on expressions are experimental
-  --> $DIR/feature-gate-capture_disjoint_fields.rs:8:13
-   |
-LL |     let c = #[rustc_capture_analysis]
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
-   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
 error: First Pass analysis includes:
-  --> $DIR/feature-gate-capture_disjoint_fields.rs:12:5
+  --> $DIR/feature-gate-capture_disjoint_fields.rs:9:5
    |
 LL | /     || {
 LL | |
@@ -20,13 +10,13 @@ LL | |     };
    | |_____^
    |
 note: Capturing s[] -> Immutable
-  --> $DIR/feature-gate-capture_disjoint_fields.rs:15:69
+  --> $DIR/feature-gate-capture_disjoint_fields.rs:12:69
    |
 LL |         println!("This uses new capture analyysis to capture s={}", s);
    |                                                                     ^
 
 error: Min Capture analysis includes:
-  --> $DIR/feature-gate-capture_disjoint_fields.rs:12:5
+  --> $DIR/feature-gate-capture_disjoint_fields.rs:9:5
    |
 LL | /     || {
 LL | |
@@ -37,11 +27,10 @@ LL | |     };
    | |_____^
    |
 note: Min Capture s[] -> Immutable
-  --> $DIR/feature-gate-capture_disjoint_fields.rs:15:69
+  --> $DIR/feature-gate-capture_disjoint_fields.rs:12:69
    |
 LL |         println!("This uses new capture analyysis to capture s={}", s);
    |                                                                     ^
 
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/closures/2229_closure_analysis/issue-87378.rs
+++ b/tests/ui/closures/2229_closure_analysis/issue-87378.rs
@@ -12,9 +12,6 @@ fn main() {
     let u = Union { value: 42 };
 
     let c = #[rustc_capture_analysis]
-    //~^ ERROR: attributes on expressions are experimental
-    //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
-    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     || {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:

--- a/tests/ui/closures/2229_closure_analysis/issue-87378.stderr
+++ b/tests/ui/closures/2229_closure_analysis/issue-87378.stderr
@@ -1,15 +1,5 @@
-error[E0658]: attributes on expressions are experimental
-  --> $DIR/issue-87378.rs:14:13
-   |
-LL |     let c = #[rustc_capture_analysis]
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
-   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
 error: First Pass analysis includes:
-  --> $DIR/issue-87378.rs:18:5
+  --> $DIR/issue-87378.rs:15:5
    |
 LL | /     || {
 LL | |
@@ -20,13 +10,13 @@ LL | |     };
    | |_____^
    |
 note: Capturing u[(0, 0)] -> Immutable
-  --> $DIR/issue-87378.rs:21:17
+  --> $DIR/issue-87378.rs:18:17
    |
 LL |        unsafe { u.value }
    |                 ^^^^^^^
 
 error: Min Capture analysis includes:
-  --> $DIR/issue-87378.rs:18:5
+  --> $DIR/issue-87378.rs:15:5
    |
 LL | /     || {
 LL | |
@@ -37,11 +27,10 @@ LL | |     };
    | |_____^
    |
 note: Min Capture u[] -> Immutable
-  --> $DIR/issue-87378.rs:21:17
+  --> $DIR/issue-87378.rs:18:17
    |
 LL |        unsafe { u.value }
    |                 ^^^^^^^
 
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/closures/2229_closure_analysis/issue-88476.rs
+++ b/tests/ui/closures/2229_closure_analysis/issue-88476.rs
@@ -18,10 +18,7 @@ pub fn test1() {
 
     let f = Foo(Rc::new(1));
     let x = #[rustc_capture_analysis] move || {
-    //~^ ERROR: attributes on expressions are experimental
-    //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
-    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-    //~| ERROR: First Pass analysis includes:
+    //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:
         println!("{:?}", f.0);
         //~^ NOTE: Capturing f[(0, 0)] -> Immutable
@@ -46,10 +43,7 @@ fn test2() {
     let character = Character { hp: 100, name: format!("A") };
 
     let c = #[rustc_capture_analysis] move || {
-    //~^ ERROR: attributes on expressions are experimental
-    //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
-    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-    //~| ERROR: First Pass analysis includes:
+    //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:
         println!("{}", character.hp)
         //~^ NOTE: Capturing character[(0, 0)] -> Immutable

--- a/tests/ui/closures/2229_closure_analysis/issue-88476.stderr
+++ b/tests/ui/closures/2229_closure_analysis/issue-88476.stderr
@@ -1,34 +1,17 @@
-error[E0658]: attributes on expressions are experimental
-  --> $DIR/issue-88476.rs:20:13
-   |
-LL |     let x = #[rustc_capture_analysis] move || {
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
-   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
-error[E0658]: attributes on expressions are experimental
-  --> $DIR/issue-88476.rs:48:13
-   |
-LL |     let c = #[rustc_capture_analysis] move || {
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
-   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
 error: First Pass analysis includes:
   --> $DIR/issue-88476.rs:20:39
    |
 LL |       let x = #[rustc_capture_analysis] move || {
    |  _______________________________________^
+LL | |
+LL | |
+LL | |         println!("{:?}", f.0);
 ...  |
 LL | |     };
    | |_____^
    |
 note: Capturing f[(0, 0)] -> Immutable
-  --> $DIR/issue-88476.rs:26:26
+  --> $DIR/issue-88476.rs:23:26
    |
 LL |         println!("{:?}", f.0);
    |                          ^^^
@@ -38,46 +21,54 @@ error: Min Capture analysis includes:
    |
 LL |       let x = #[rustc_capture_analysis] move || {
    |  _______________________________________^
+LL | |
+LL | |
+LL | |         println!("{:?}", f.0);
 ...  |
 LL | |     };
    | |_____^
    |
 note: Min Capture f[] -> ByValue
-  --> $DIR/issue-88476.rs:26:26
+  --> $DIR/issue-88476.rs:23:26
    |
 LL |         println!("{:?}", f.0);
    |                          ^^^
 
 error: First Pass analysis includes:
-  --> $DIR/issue-88476.rs:48:39
+  --> $DIR/issue-88476.rs:45:39
    |
 LL |       let c = #[rustc_capture_analysis] move || {
    |  _______________________________________^
+LL | |
+LL | |
+LL | |         println!("{}", character.hp)
 ...  |
 LL | |     };
    | |_____^
    |
 note: Capturing character[(0, 0)] -> Immutable
-  --> $DIR/issue-88476.rs:54:24
+  --> $DIR/issue-88476.rs:48:24
    |
 LL |         println!("{}", character.hp)
    |                        ^^^^^^^^^^^^
 
 error: Min Capture analysis includes:
-  --> $DIR/issue-88476.rs:48:39
+  --> $DIR/issue-88476.rs:45:39
    |
 LL |       let c = #[rustc_capture_analysis] move || {
    |  _______________________________________^
+LL | |
+LL | |
+LL | |         println!("{}", character.hp)
 ...  |
 LL | |     };
    | |_____^
    |
 note: Min Capture character[(0, 0)] -> ByValue
-  --> $DIR/issue-88476.rs:54:24
+  --> $DIR/issue-88476.rs:48:24
    |
 LL |         println!("{}", character.hp)
    |                        ^^^^^^^^^^^^
 
-error: aborting due to 6 previous errors
+error: aborting due to 4 previous errors
 
-For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/closures/2229_closure_analysis/move_closure.rs
+++ b/tests/ui/closures/2229_closure_analysis/move_closure.rs
@@ -10,9 +10,6 @@ fn simple_move_closure() {
 
     let t = T(S("s".into()));
     let mut c = #[rustc_capture_analysis]
-    //~^ ERROR: attributes on expressions are experimental
-    //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
-    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     move || {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:
@@ -29,9 +26,6 @@ fn simple_ref() {
     let ref_s = &mut s;
 
     let mut c = #[rustc_capture_analysis]
-    //~^ ERROR: attributes on expressions are experimental
-    //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
-    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     move || {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:
@@ -51,9 +45,6 @@ fn struct_contains_ref_to_another_struct_1() {
     let t = T(&mut s);
 
     let mut c = #[rustc_capture_analysis]
-    //~^ ERROR: attributes on expressions are experimental
-    //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
-    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     move || {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:
@@ -75,9 +66,6 @@ fn struct_contains_ref_to_another_struct_2() {
     let t = T(&s);
 
     let mut c = #[rustc_capture_analysis]
-    //~^ ERROR: attributes on expressions are experimental
-    //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
-    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     move || {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:
@@ -98,9 +86,6 @@ fn struct_contains_ref_to_another_struct_3() {
     let t = T(&s);
 
     let mut c = #[rustc_capture_analysis]
-    //~^ ERROR: attributes on expressions are experimental
-    //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
-    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     move || {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:
@@ -120,9 +105,6 @@ fn truncate_box_derefs() {
     // Content within the box is moved within the closure
     let b = Box::new(S(10));
     let c = #[rustc_capture_analysis]
-    //~^ ERROR: attributes on expressions are experimental
-    //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
-    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     move || {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:
@@ -137,9 +119,6 @@ fn truncate_box_derefs() {
     let b = Box::new(S(10));
 
     let c = #[rustc_capture_analysis]
-    //~^ ERROR: attributes on expressions are experimental
-    //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
-    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     move || {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:
@@ -155,9 +134,6 @@ fn truncate_box_derefs() {
     let t = (0, b);
 
     let c = #[rustc_capture_analysis]
-    //~^ ERROR: attributes on expressions are experimental
-    //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
-    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     move || {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:
@@ -178,10 +154,7 @@ fn box_mut_1() {
     let box_p_foo = Box::new(p_foo);
 
     let c = #[rustc_capture_analysis] move || box_p_foo.x += 10;
-    //~^ ERROR: attributes on expressions are experimental
-    //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
-    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-    //~| ERROR First Pass analysis includes:
+    //~^ ERROR First Pass analysis includes:
     //~| NOTE: Capturing box_p_foo[Deref,Deref,(0, 0)] -> Mutable
     //~| ERROR Min Capture analysis includes:
     //~| NOTE: Min Capture box_p_foo[] -> ByValue
@@ -196,10 +169,7 @@ fn box_mut_2() {
     let p_foo = &mut box_foo;
 
     let c = #[rustc_capture_analysis] move || p_foo.x += 10;
-    //~^ ERROR: attributes on expressions are experimental
-    //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
-    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-    //~| ERROR First Pass analysis includes:
+    //~^ ERROR First Pass analysis includes:
     //~| NOTE: Capturing p_foo[Deref,Deref,(0, 0)] -> Mutable
     //~| ERROR Min Capture analysis includes:
     //~| NOTE: Min Capture p_foo[] -> ByValue
@@ -210,10 +180,7 @@ fn returned_closure_owns_copy_type_data() -> impl Fn() -> i32 {
     let x = 10;
 
     let c = #[rustc_capture_analysis] move || x;
-    //~^ ERROR: attributes on expressions are experimental
-    //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
-    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-    //~| ERROR First Pass analysis includes:
+    //~^ ERROR First Pass analysis includes:
     //~| NOTE: Capturing x[] -> Immutable
     //~| ERROR Min Capture analysis includes:
     //~| NOTE: Min Capture x[] -> ByValue

--- a/tests/ui/closures/2229_closure_analysis/move_closure.stderr
+++ b/tests/ui/closures/2229_closure_analysis/move_closure.stderr
@@ -1,139 +1,29 @@
-error[E0658]: attributes on expressions are experimental
-  --> $DIR/move_closure.rs:12:17
-   |
-LL |     let mut c = #[rustc_capture_analysis]
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
-   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
-error[E0658]: attributes on expressions are experimental
-  --> $DIR/move_closure.rs:31:17
-   |
-LL |     let mut c = #[rustc_capture_analysis]
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
-   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
-error[E0658]: attributes on expressions are experimental
-  --> $DIR/move_closure.rs:53:17
-   |
-LL |     let mut c = #[rustc_capture_analysis]
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
-   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
-error[E0658]: attributes on expressions are experimental
-  --> $DIR/move_closure.rs:77:17
-   |
-LL |     let mut c = #[rustc_capture_analysis]
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
-   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
-error[E0658]: attributes on expressions are experimental
-  --> $DIR/move_closure.rs:100:17
-   |
-LL |     let mut c = #[rustc_capture_analysis]
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
-   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
-error[E0658]: attributes on expressions are experimental
-  --> $DIR/move_closure.rs:122:13
-   |
-LL |     let c = #[rustc_capture_analysis]
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
-   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
-error[E0658]: attributes on expressions are experimental
-  --> $DIR/move_closure.rs:139:13
-   |
-LL |     let c = #[rustc_capture_analysis]
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
-   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
-error[E0658]: attributes on expressions are experimental
-  --> $DIR/move_closure.rs:157:13
-   |
-LL |     let c = #[rustc_capture_analysis]
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
-   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
-error[E0658]: attributes on expressions are experimental
-  --> $DIR/move_closure.rs:180:13
-   |
-LL |     let c = #[rustc_capture_analysis] move || box_p_foo.x += 10;
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
-   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
-error[E0658]: attributes on expressions are experimental
-  --> $DIR/move_closure.rs:198:13
-   |
-LL |     let c = #[rustc_capture_analysis] move || p_foo.x += 10;
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
-   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
-error[E0658]: attributes on expressions are experimental
-  --> $DIR/move_closure.rs:212:13
-   |
-LL |     let c = #[rustc_capture_analysis] move || x;
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
-   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
 error: First Pass analysis includes:
-  --> $DIR/move_closure.rs:212:39
+  --> $DIR/move_closure.rs:182:39
    |
 LL |     let c = #[rustc_capture_analysis] move || x;
    |                                       ^^^^^^^^^
    |
 note: Capturing x[] -> Immutable
-  --> $DIR/move_closure.rs:212:47
+  --> $DIR/move_closure.rs:182:47
    |
 LL |     let c = #[rustc_capture_analysis] move || x;
    |                                               ^
 
 error: Min Capture analysis includes:
-  --> $DIR/move_closure.rs:212:39
+  --> $DIR/move_closure.rs:182:39
    |
 LL |     let c = #[rustc_capture_analysis] move || x;
    |                                       ^^^^^^^^^
    |
 note: Min Capture x[] -> ByValue
-  --> $DIR/move_closure.rs:212:47
+  --> $DIR/move_closure.rs:182:47
    |
 LL |     let c = #[rustc_capture_analysis] move || x;
    |                                               ^
 
 error: First Pass analysis includes:
-  --> $DIR/move_closure.rs:16:5
+  --> $DIR/move_closure.rs:13:5
    |
 LL | /     move || {
 LL | |
@@ -144,13 +34,13 @@ LL | |     };
    | |_____^
    |
 note: Capturing t[(0, 0),(0, 0)] -> Mutable
-  --> $DIR/move_closure.rs:19:9
+  --> $DIR/move_closure.rs:16:9
    |
 LL |         t.0.0 = "new S".into();
    |         ^^^^^
 
 error: Min Capture analysis includes:
-  --> $DIR/move_closure.rs:16:5
+  --> $DIR/move_closure.rs:13:5
    |
 LL | /     move || {
 LL | |
@@ -161,13 +51,13 @@ LL | |     };
    | |_____^
    |
 note: Min Capture t[(0, 0),(0, 0)] -> ByValue
-  --> $DIR/move_closure.rs:19:9
+  --> $DIR/move_closure.rs:16:9
    |
 LL |         t.0.0 = "new S".into();
    |         ^^^^^
 
 error: First Pass analysis includes:
-  --> $DIR/move_closure.rs:35:5
+  --> $DIR/move_closure.rs:29:5
    |
 LL | /     move || {
 LL | |
@@ -178,13 +68,13 @@ LL | |     };
    | |_____^
    |
 note: Capturing ref_s[Deref] -> Mutable
-  --> $DIR/move_closure.rs:38:9
+  --> $DIR/move_closure.rs:32:9
    |
 LL |         *ref_s += 10;
    |         ^^^^^^
 
 error: Min Capture analysis includes:
-  --> $DIR/move_closure.rs:35:5
+  --> $DIR/move_closure.rs:29:5
    |
 LL | /     move || {
 LL | |
@@ -195,13 +85,13 @@ LL | |     };
    | |_____^
    |
 note: Min Capture ref_s[] -> ByValue
-  --> $DIR/move_closure.rs:38:9
+  --> $DIR/move_closure.rs:32:9
    |
 LL |         *ref_s += 10;
    |         ^^^^^^
 
 error: First Pass analysis includes:
-  --> $DIR/move_closure.rs:57:5
+  --> $DIR/move_closure.rs:48:5
    |
 LL | /     move || {
 LL | |
@@ -212,13 +102,13 @@ LL | |     };
    | |_____^
    |
 note: Capturing t[(0, 0),Deref,(0, 0)] -> Mutable
-  --> $DIR/move_closure.rs:60:9
+  --> $DIR/move_closure.rs:51:9
    |
 LL |         t.0.0 = "new s".into();
    |         ^^^^^
 
 error: Min Capture analysis includes:
-  --> $DIR/move_closure.rs:57:5
+  --> $DIR/move_closure.rs:48:5
    |
 LL | /     move || {
 LL | |
@@ -229,13 +119,13 @@ LL | |     };
    | |_____^
    |
 note: Min Capture t[(0, 0)] -> ByValue
-  --> $DIR/move_closure.rs:60:9
+  --> $DIR/move_closure.rs:51:9
    |
 LL |         t.0.0 = "new s".into();
    |         ^^^^^
 
 error: First Pass analysis includes:
-  --> $DIR/move_closure.rs:81:5
+  --> $DIR/move_closure.rs:69:5
    |
 LL | /     move || {
 LL | |
@@ -246,13 +136,13 @@ LL | |     };
    | |_____^
    |
 note: Capturing t[(0, 0),Deref,(0, 0)] -> Immutable
-  --> $DIR/move_closure.rs:84:18
+  --> $DIR/move_closure.rs:72:18
    |
 LL |         let _t = t.0.0;
    |                  ^^^^^
 
 error: Min Capture analysis includes:
-  --> $DIR/move_closure.rs:81:5
+  --> $DIR/move_closure.rs:69:5
    |
 LL | /     move || {
 LL | |
@@ -263,13 +153,13 @@ LL | |     };
    | |_____^
    |
 note: Min Capture t[(0, 0)] -> ByValue
-  --> $DIR/move_closure.rs:84:18
+  --> $DIR/move_closure.rs:72:18
    |
 LL |         let _t = t.0.0;
    |                  ^^^^^
 
 error: First Pass analysis includes:
-  --> $DIR/move_closure.rs:104:5
+  --> $DIR/move_closure.rs:89:5
    |
 LL | /     move || {
 LL | |
@@ -280,13 +170,13 @@ LL | |     };
    | |_____^
    |
 note: Capturing t[(0, 0),Deref,(0, 0)] -> ByValue
-  --> $DIR/move_closure.rs:107:18
+  --> $DIR/move_closure.rs:92:18
    |
 LL |         let _t = t.0.0;
    |                  ^^^^^
 
 error: Min Capture analysis includes:
-  --> $DIR/move_closure.rs:104:5
+  --> $DIR/move_closure.rs:89:5
    |
 LL | /     move || {
 LL | |
@@ -297,13 +187,13 @@ LL | |     };
    | |_____^
    |
 note: Min Capture t[(0, 0)] -> ByValue
-  --> $DIR/move_closure.rs:107:18
+  --> $DIR/move_closure.rs:92:18
    |
 LL |         let _t = t.0.0;
    |                  ^^^^^
 
 error: First Pass analysis includes:
-  --> $DIR/move_closure.rs:126:5
+  --> $DIR/move_closure.rs:108:5
    |
 LL | /     move || {
 LL | |
@@ -314,13 +204,13 @@ LL | |     };
    | |_____^
    |
 note: Capturing b[Deref,(0, 0)] -> Immutable
-  --> $DIR/move_closure.rs:129:18
+  --> $DIR/move_closure.rs:111:18
    |
 LL |         let _t = b.0;
    |                  ^^^
 
 error: Min Capture analysis includes:
-  --> $DIR/move_closure.rs:126:5
+  --> $DIR/move_closure.rs:108:5
    |
 LL | /     move || {
 LL | |
@@ -331,13 +221,13 @@ LL | |     };
    | |_____^
    |
 note: Min Capture b[] -> ByValue
-  --> $DIR/move_closure.rs:129:18
+  --> $DIR/move_closure.rs:111:18
    |
 LL |         let _t = b.0;
    |                  ^^^
 
 error: First Pass analysis includes:
-  --> $DIR/move_closure.rs:143:5
+  --> $DIR/move_closure.rs:122:5
    |
 LL | /     move || {
 LL | |
@@ -348,13 +238,13 @@ LL | |     };
    | |_____^
    |
 note: Capturing b[Deref,(0, 0)] -> Immutable
-  --> $DIR/move_closure.rs:146:24
+  --> $DIR/move_closure.rs:125:24
    |
 LL |         println!("{}", b.0);
    |                        ^^^
 
 error: Min Capture analysis includes:
-  --> $DIR/move_closure.rs:143:5
+  --> $DIR/move_closure.rs:122:5
    |
 LL | /     move || {
 LL | |
@@ -365,13 +255,13 @@ LL | |     };
    | |_____^
    |
 note: Min Capture b[] -> ByValue
-  --> $DIR/move_closure.rs:146:24
+  --> $DIR/move_closure.rs:125:24
    |
 LL |         println!("{}", b.0);
    |                        ^^^
 
 error: First Pass analysis includes:
-  --> $DIR/move_closure.rs:161:5
+  --> $DIR/move_closure.rs:137:5
    |
 LL | /     move || {
 LL | |
@@ -382,13 +272,13 @@ LL | |     };
    | |_____^
    |
 note: Capturing t[(1, 0),Deref,(0, 0)] -> Immutable
-  --> $DIR/move_closure.rs:164:24
+  --> $DIR/move_closure.rs:140:24
    |
 LL |         println!("{}", t.1.0);
    |                        ^^^^^
 
 error: Min Capture analysis includes:
-  --> $DIR/move_closure.rs:161:5
+  --> $DIR/move_closure.rs:137:5
    |
 LL | /     move || {
 LL | |
@@ -399,59 +289,58 @@ LL | |     };
    | |_____^
    |
 note: Min Capture t[(1, 0)] -> ByValue
-  --> $DIR/move_closure.rs:164:24
+  --> $DIR/move_closure.rs:140:24
    |
 LL |         println!("{}", t.1.0);
    |                        ^^^^^
 
 error: First Pass analysis includes:
-  --> $DIR/move_closure.rs:180:39
+  --> $DIR/move_closure.rs:156:39
    |
 LL |     let c = #[rustc_capture_analysis] move || box_p_foo.x += 10;
    |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: Capturing box_p_foo[Deref,Deref,(0, 0)] -> Mutable
-  --> $DIR/move_closure.rs:180:47
+  --> $DIR/move_closure.rs:156:47
    |
 LL |     let c = #[rustc_capture_analysis] move || box_p_foo.x += 10;
    |                                               ^^^^^^^^^^^
 
 error: Min Capture analysis includes:
-  --> $DIR/move_closure.rs:180:39
+  --> $DIR/move_closure.rs:156:39
    |
 LL |     let c = #[rustc_capture_analysis] move || box_p_foo.x += 10;
    |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: Min Capture box_p_foo[] -> ByValue
-  --> $DIR/move_closure.rs:180:47
+  --> $DIR/move_closure.rs:156:47
    |
 LL |     let c = #[rustc_capture_analysis] move || box_p_foo.x += 10;
    |                                               ^^^^^^^^^^^
 
 error: First Pass analysis includes:
-  --> $DIR/move_closure.rs:198:39
+  --> $DIR/move_closure.rs:171:39
    |
 LL |     let c = #[rustc_capture_analysis] move || p_foo.x += 10;
    |                                       ^^^^^^^^^^^^^^^^^^^^^
    |
 note: Capturing p_foo[Deref,Deref,(0, 0)] -> Mutable
-  --> $DIR/move_closure.rs:198:47
+  --> $DIR/move_closure.rs:171:47
    |
 LL |     let c = #[rustc_capture_analysis] move || p_foo.x += 10;
    |                                               ^^^^^^^
 
 error: Min Capture analysis includes:
-  --> $DIR/move_closure.rs:198:39
+  --> $DIR/move_closure.rs:171:39
    |
 LL |     let c = #[rustc_capture_analysis] move || p_foo.x += 10;
    |                                       ^^^^^^^^^^^^^^^^^^^^^
    |
 note: Min Capture p_foo[] -> ByValue
-  --> $DIR/move_closure.rs:198:47
+  --> $DIR/move_closure.rs:171:47
    |
 LL |     let c = #[rustc_capture_analysis] move || p_foo.x += 10;
    |                                               ^^^^^^^
 
-error: aborting due to 33 previous errors
+error: aborting due to 22 previous errors
 
-For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/closures/2229_closure_analysis/multilevel-path-1.rs
+++ b/tests/ui/closures/2229_closure_analysis/multilevel-path-1.rs
@@ -20,9 +20,6 @@ fn main() {
     // Therefore `w.p` is captured
     // Note that `wp.x` doesn't start off a variable defined outside the closure.
     let c = #[rustc_capture_analysis]
-    //~^ ERROR: attributes on expressions are experimental
-    //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
-    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     || {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:

--- a/tests/ui/closures/2229_closure_analysis/multilevel-path-1.stderr
+++ b/tests/ui/closures/2229_closure_analysis/multilevel-path-1.stderr
@@ -1,15 +1,5 @@
-error[E0658]: attributes on expressions are experimental
-  --> $DIR/multilevel-path-1.rs:22:13
-   |
-LL |     let c = #[rustc_capture_analysis]
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
-   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
 error: First Pass analysis includes:
-  --> $DIR/multilevel-path-1.rs:26:5
+  --> $DIR/multilevel-path-1.rs:23:5
    |
 LL | /     || {
 LL | |
@@ -21,13 +11,13 @@ LL | |     };
    | |_____^
    |
 note: Capturing w[(0, 0)] -> Immutable
-  --> $DIR/multilevel-path-1.rs:29:19
+  --> $DIR/multilevel-path-1.rs:26:19
    |
 LL |         let wp = &w.p;
    |                   ^^^
 
 error: Min Capture analysis includes:
-  --> $DIR/multilevel-path-1.rs:26:5
+  --> $DIR/multilevel-path-1.rs:23:5
    |
 LL | /     || {
 LL | |
@@ -39,11 +29,10 @@ LL | |     };
    | |_____^
    |
 note: Min Capture w[(0, 0)] -> Immutable
-  --> $DIR/multilevel-path-1.rs:29:19
+  --> $DIR/multilevel-path-1.rs:26:19
    |
 LL |         let wp = &w.p;
    |                   ^^^
 
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/closures/2229_closure_analysis/multilevel-path-2.rs
+++ b/tests/ui/closures/2229_closure_analysis/multilevel-path-2.rs
@@ -15,9 +15,6 @@ fn main() {
     let mut w = Wrapper { p: Point { x: 10, y: 10 } };
 
     let c = #[rustc_capture_analysis]
-        //~^ ERROR: attributes on expressions are experimental
-        //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
-        //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     || {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:

--- a/tests/ui/closures/2229_closure_analysis/multilevel-path-2.stderr
+++ b/tests/ui/closures/2229_closure_analysis/multilevel-path-2.stderr
@@ -1,15 +1,5 @@
-error[E0658]: attributes on expressions are experimental
-  --> $DIR/multilevel-path-2.rs:17:13
-   |
-LL |     let c = #[rustc_capture_analysis]
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
-   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
 error: First Pass analysis includes:
-  --> $DIR/multilevel-path-2.rs:21:5
+  --> $DIR/multilevel-path-2.rs:18:5
    |
 LL | /     || {
 LL | |
@@ -20,13 +10,13 @@ LL | |     };
    | |_____^
    |
 note: Capturing w[(0, 0),(0, 0)] -> Immutable
-  --> $DIR/multilevel-path-2.rs:24:24
+  --> $DIR/multilevel-path-2.rs:21:24
    |
 LL |         println!("{}", w.p.x);
    |                        ^^^^^
 
 error: Min Capture analysis includes:
-  --> $DIR/multilevel-path-2.rs:21:5
+  --> $DIR/multilevel-path-2.rs:18:5
    |
 LL | /     || {
 LL | |
@@ -37,11 +27,10 @@ LL | |     };
    | |_____^
    |
 note: Min Capture w[(0, 0),(0, 0)] -> Immutable
-  --> $DIR/multilevel-path-2.rs:24:24
+  --> $DIR/multilevel-path-2.rs:21:24
    |
 LL |         println!("{}", w.p.x);
    |                        ^^^^^
 
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/closures/2229_closure_analysis/nested-closure.rs
+++ b/tests/ui/closures/2229_closure_analysis/nested-closure.rs
@@ -17,9 +17,6 @@ fn main() {
     let mut p = Point { x: 5, y: 20 };
 
     let mut c1 = #[rustc_capture_analysis]
-        //~^ ERROR: attributes on expressions are experimental
-        //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
-        //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     || {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:
@@ -28,9 +25,6 @@ fn main() {
         //~| NOTE: Min Capture p[(0, 0)] -> Immutable
         let incr = 10;
         let mut c2 = #[rustc_capture_analysis]
-        //~^ ERROR: attributes on expressions are experimental
-        //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
-        //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
         || p.y += incr;
         //~^ ERROR: First Pass analysis includes:
         //~| ERROR: Min Capture analysis includes:

--- a/tests/ui/closures/2229_closure_analysis/nested-closure.stderr
+++ b/tests/ui/closures/2229_closure_analysis/nested-closure.stderr
@@ -1,59 +1,39 @@
-error[E0658]: attributes on expressions are experimental
-  --> $DIR/nested-closure.rs:19:18
-   |
-LL |     let mut c1 = #[rustc_capture_analysis]
-   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
-   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
-error[E0658]: attributes on expressions are experimental
-  --> $DIR/nested-closure.rs:30:22
-   |
-LL |         let mut c2 = #[rustc_capture_analysis]
-   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
-   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
 error: First Pass analysis includes:
-  --> $DIR/nested-closure.rs:34:9
+  --> $DIR/nested-closure.rs:28:9
    |
 LL |         || p.y += incr;
    |         ^^^^^^^^^^^^^^
    |
 note: Capturing p[(1, 0)] -> Mutable
-  --> $DIR/nested-closure.rs:34:12
+  --> $DIR/nested-closure.rs:28:12
    |
 LL |         || p.y += incr;
    |            ^^^
 note: Capturing incr[] -> Immutable
-  --> $DIR/nested-closure.rs:34:19
+  --> $DIR/nested-closure.rs:28:19
    |
 LL |         || p.y += incr;
    |                   ^^^^
 
 error: Min Capture analysis includes:
-  --> $DIR/nested-closure.rs:34:9
+  --> $DIR/nested-closure.rs:28:9
    |
 LL |         || p.y += incr;
    |         ^^^^^^^^^^^^^^
    |
 note: Min Capture p[(1, 0)] -> Mutable
-  --> $DIR/nested-closure.rs:34:12
+  --> $DIR/nested-closure.rs:28:12
    |
 LL |         || p.y += incr;
    |            ^^^
 note: Min Capture incr[] -> Immutable
-  --> $DIR/nested-closure.rs:34:19
+  --> $DIR/nested-closure.rs:28:19
    |
 LL |         || p.y += incr;
    |                   ^^^^
 
 error: First Pass analysis includes:
-  --> $DIR/nested-closure.rs:23:5
+  --> $DIR/nested-closure.rs:20:5
    |
 LL | /     || {
 LL | |
@@ -64,23 +44,23 @@ LL | |     };
    | |_____^
    |
 note: Capturing p[(0, 0)] -> Immutable
-  --> $DIR/nested-closure.rs:26:24
+  --> $DIR/nested-closure.rs:23:24
    |
 LL |         println!("{}", p.x);
    |                        ^^^
 note: Capturing p[(1, 0)] -> Mutable
-  --> $DIR/nested-closure.rs:34:12
+  --> $DIR/nested-closure.rs:28:12
    |
 LL |         || p.y += incr;
    |            ^^^
 note: Capturing p[(1, 0)] -> Immutable
-  --> $DIR/nested-closure.rs:44:24
+  --> $DIR/nested-closure.rs:38:24
    |
 LL |         println!("{}", p.y);
    |                        ^^^
 
 error: Min Capture analysis includes:
-  --> $DIR/nested-closure.rs:23:5
+  --> $DIR/nested-closure.rs:20:5
    |
 LL | /     || {
 LL | |
@@ -91,16 +71,15 @@ LL | |     };
    | |_____^
    |
 note: Min Capture p[(0, 0)] -> Immutable
-  --> $DIR/nested-closure.rs:26:24
+  --> $DIR/nested-closure.rs:23:24
    |
 LL |         println!("{}", p.x);
    |                        ^^^
 note: Min Capture p[(1, 0)] -> Mutable
-  --> $DIR/nested-closure.rs:34:12
+  --> $DIR/nested-closure.rs:28:12
    |
 LL |         || p.y += incr;
    |            ^^^
 
-error: aborting due to 6 previous errors
+error: aborting due to 4 previous errors
 
-For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/closures/2229_closure_analysis/optimization/edge_case.rs
+++ b/tests/ui/closures/2229_closure_analysis/optimization/edge_case.rs
@@ -18,10 +18,7 @@ struct MyStruct<'a> {
 
 fn foo<'a, 'b>(m: &'a MyStruct<'b>) -> impl FnMut() + 'static {
     let c = #[rustc_capture_analysis] || drop(&m.a.0);
-    //~^ ERROR: attributes on expressions are experimental
-    //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
-    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-    //~| ERROR: First Pass analysis includes:
+    //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:
     //~| NOTE: Capturing m[Deref,(0, 0),Deref,(0, 0)] -> Immutable
     //~| NOTE: Min Capture m[Deref,(0, 0),Deref] -> Immutable

--- a/tests/ui/closures/2229_closure_analysis/optimization/edge_case.stderr
+++ b/tests/ui/closures/2229_closure_analysis/optimization/edge_case.stderr
@@ -1,13 +1,3 @@
-error[E0658]: attributes on expressions are experimental
-  --> $DIR/edge_case.rs:20:13
-   |
-LL |     let c = #[rustc_capture_analysis] || drop(&m.a.0);
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
-   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
 error: First Pass analysis includes:
   --> $DIR/edge_case.rs:20:39
    |
@@ -32,6 +22,5 @@ note: Min Capture m[Deref,(0, 0),Deref] -> Immutable
 LL |     let c = #[rustc_capture_analysis] || drop(&m.a.0);
    |                                                ^^^^^
 
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/closures/2229_closure_analysis/path-with-array-access.rs
+++ b/tests/ui/closures/2229_closure_analysis/path-with-array-access.rs
@@ -21,9 +21,6 @@ fn main() {
     let pent = Pentagon { points: [p1, p2, p3, p4, p5] };
 
     let c = #[rustc_capture_analysis]
-    //~^ ERROR: attributes on expressions are experimental
-    //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
-    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     || {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:

--- a/tests/ui/closures/2229_closure_analysis/path-with-array-access.stderr
+++ b/tests/ui/closures/2229_closure_analysis/path-with-array-access.stderr
@@ -1,15 +1,5 @@
-error[E0658]: attributes on expressions are experimental
-  --> $DIR/path-with-array-access.rs:23:13
-   |
-LL |     let c = #[rustc_capture_analysis]
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
-   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
 error: First Pass analysis includes:
-  --> $DIR/path-with-array-access.rs:27:5
+  --> $DIR/path-with-array-access.rs:24:5
    |
 LL | /     || {
 LL | |
@@ -20,13 +10,13 @@ LL | |     };
    | |_____^
    |
 note: Capturing pent[(0, 0)] -> Immutable
-  --> $DIR/path-with-array-access.rs:30:24
+  --> $DIR/path-with-array-access.rs:27:24
    |
 LL |         println!("{}", pent.points[5].x);
    |                        ^^^^^^^^^^^
 
 error: Min Capture analysis includes:
-  --> $DIR/path-with-array-access.rs:27:5
+  --> $DIR/path-with-array-access.rs:24:5
    |
 LL | /     || {
 LL | |
@@ -37,11 +27,10 @@ LL | |     };
    | |_____^
    |
 note: Min Capture pent[(0, 0)] -> Immutable
-  --> $DIR/path-with-array-access.rs:30:24
+  --> $DIR/path-with-array-access.rs:27:24
    |
 LL |         println!("{}", pent.points[5].x);
    |                        ^^^^^^^^^^^
 
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/closures/2229_closure_analysis/preserve_field_drop_order.rs
+++ b/tests/ui/closures/2229_closure_analysis/preserve_field_drop_order.rs
@@ -21,9 +21,6 @@ fn test_one() {
     let b = (HasDrop, HasDrop);
 
     let c = #[rustc_capture_analysis]
-    //~^ ERROR: attributes on expressions are experimental
-    //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
-    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     || {
         //~^ ERROR: Min Capture analysis includes:
         //~| ERROR
@@ -48,9 +45,6 @@ fn test_two() {
     let b = (HasDrop, HasDrop);
 
     let c = #[rustc_capture_analysis]
-    //~^ ERROR: attributes on expressions are experimental
-    //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
-    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     || {
         //~^ ERROR: Min Capture analysis includes:
         //~| ERROR
@@ -75,9 +69,6 @@ fn test_three() {
     let b = (HasDrop, HasDrop);
 
     let c = #[rustc_capture_analysis]
-    //~^ ERROR: attributes on expressions are experimental
-    //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
-    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     || {
         //~^ ERROR: Min Capture analysis includes:
         //~| ERROR

--- a/tests/ui/closures/2229_closure_analysis/preserve_field_drop_order.stderr
+++ b/tests/ui/closures/2229_closure_analysis/preserve_field_drop_order.stderr
@@ -1,35 +1,5 @@
-error[E0658]: attributes on expressions are experimental
-  --> $DIR/preserve_field_drop_order.rs:23:13
-   |
-LL |     let c = #[rustc_capture_analysis]
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
-   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
-error[E0658]: attributes on expressions are experimental
-  --> $DIR/preserve_field_drop_order.rs:50:13
-   |
-LL |     let c = #[rustc_capture_analysis]
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
-   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
-error[E0658]: attributes on expressions are experimental
-  --> $DIR/preserve_field_drop_order.rs:77:13
-   |
-LL |     let c = #[rustc_capture_analysis]
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
-   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
 error: First Pass analysis includes:
-  --> $DIR/preserve_field_drop_order.rs:27:5
+  --> $DIR/preserve_field_drop_order.rs:24:5
    |
 LL | /     || {
 LL | |
@@ -40,28 +10,28 @@ LL | |     };
    | |_____^
    |
 note: Capturing a[(0, 0)] -> Immutable
-  --> $DIR/preserve_field_drop_order.rs:30:26
+  --> $DIR/preserve_field_drop_order.rs:27:26
    |
 LL |         println!("{:?}", a.0);
    |                          ^^^
 note: Capturing a[(1, 0)] -> Immutable
-  --> $DIR/preserve_field_drop_order.rs:33:26
+  --> $DIR/preserve_field_drop_order.rs:30:26
    |
 LL |         println!("{:?}", a.1);
    |                          ^^^
 note: Capturing b[(0, 0)] -> Immutable
-  --> $DIR/preserve_field_drop_order.rs:37:26
+  --> $DIR/preserve_field_drop_order.rs:34:26
    |
 LL |         println!("{:?}", b.0);
    |                          ^^^
 note: Capturing b[(1, 0)] -> Immutable
-  --> $DIR/preserve_field_drop_order.rs:40:26
+  --> $DIR/preserve_field_drop_order.rs:37:26
    |
 LL |         println!("{:?}", b.1);
    |                          ^^^
 
 error: Min Capture analysis includes:
-  --> $DIR/preserve_field_drop_order.rs:27:5
+  --> $DIR/preserve_field_drop_order.rs:24:5
    |
 LL | /     || {
 LL | |
@@ -72,28 +42,28 @@ LL | |     };
    | |_____^
    |
 note: Min Capture a[(0, 0)] -> Immutable
+  --> $DIR/preserve_field_drop_order.rs:27:26
+   |
+LL |         println!("{:?}", a.0);
+   |                          ^^^
+note: Min Capture a[(1, 0)] -> Immutable
   --> $DIR/preserve_field_drop_order.rs:30:26
    |
-LL |         println!("{:?}", a.0);
-   |                          ^^^
-note: Min Capture a[(1, 0)] -> Immutable
-  --> $DIR/preserve_field_drop_order.rs:33:26
-   |
 LL |         println!("{:?}", a.1);
    |                          ^^^
 note: Min Capture b[(0, 0)] -> Immutable
+  --> $DIR/preserve_field_drop_order.rs:34:26
+   |
+LL |         println!("{:?}", b.0);
+   |                          ^^^
+note: Min Capture b[(1, 0)] -> Immutable
   --> $DIR/preserve_field_drop_order.rs:37:26
    |
-LL |         println!("{:?}", b.0);
-   |                          ^^^
-note: Min Capture b[(1, 0)] -> Immutable
-  --> $DIR/preserve_field_drop_order.rs:40:26
-   |
 LL |         println!("{:?}", b.1);
    |                          ^^^
 
 error: First Pass analysis includes:
-  --> $DIR/preserve_field_drop_order.rs:54:5
+  --> $DIR/preserve_field_drop_order.rs:48:5
    |
 LL | /     || {
 LL | |
@@ -104,28 +74,28 @@ LL | |     };
    | |_____^
    |
 note: Capturing a[(1, 0)] -> Immutable
-  --> $DIR/preserve_field_drop_order.rs:57:26
+  --> $DIR/preserve_field_drop_order.rs:51:26
    |
 LL |         println!("{:?}", a.1);
    |                          ^^^
 note: Capturing a[(0, 0)] -> Immutable
-  --> $DIR/preserve_field_drop_order.rs:60:26
+  --> $DIR/preserve_field_drop_order.rs:54:26
    |
 LL |         println!("{:?}", a.0);
    |                          ^^^
 note: Capturing b[(1, 0)] -> Immutable
-  --> $DIR/preserve_field_drop_order.rs:64:26
+  --> $DIR/preserve_field_drop_order.rs:58:26
    |
 LL |         println!("{:?}", b.1);
    |                          ^^^
 note: Capturing b[(0, 0)] -> Immutable
-  --> $DIR/preserve_field_drop_order.rs:67:26
+  --> $DIR/preserve_field_drop_order.rs:61:26
    |
 LL |         println!("{:?}", b.0);
    |                          ^^^
 
 error: Min Capture analysis includes:
-  --> $DIR/preserve_field_drop_order.rs:54:5
+  --> $DIR/preserve_field_drop_order.rs:48:5
    |
 LL | /     || {
 LL | |
@@ -136,28 +106,28 @@ LL | |     };
    | |_____^
    |
 note: Min Capture a[(0, 0)] -> Immutable
-  --> $DIR/preserve_field_drop_order.rs:60:26
+  --> $DIR/preserve_field_drop_order.rs:54:26
    |
 LL |         println!("{:?}", a.0);
    |                          ^^^
 note: Min Capture a[(1, 0)] -> Immutable
-  --> $DIR/preserve_field_drop_order.rs:57:26
+  --> $DIR/preserve_field_drop_order.rs:51:26
    |
 LL |         println!("{:?}", a.1);
    |                          ^^^
 note: Min Capture b[(0, 0)] -> Immutable
-  --> $DIR/preserve_field_drop_order.rs:67:26
+  --> $DIR/preserve_field_drop_order.rs:61:26
    |
 LL |         println!("{:?}", b.0);
    |                          ^^^
 note: Min Capture b[(1, 0)] -> Immutable
-  --> $DIR/preserve_field_drop_order.rs:64:26
+  --> $DIR/preserve_field_drop_order.rs:58:26
    |
 LL |         println!("{:?}", b.1);
    |                          ^^^
 
 error: First Pass analysis includes:
-  --> $DIR/preserve_field_drop_order.rs:81:5
+  --> $DIR/preserve_field_drop_order.rs:72:5
    |
 LL | /     || {
 LL | |
@@ -168,28 +138,28 @@ LL | |     };
    | |_____^
    |
 note: Capturing b[(1, 0)] -> Immutable
-  --> $DIR/preserve_field_drop_order.rs:84:26
+  --> $DIR/preserve_field_drop_order.rs:75:26
    |
 LL |         println!("{:?}", b.1);
    |                          ^^^
 note: Capturing a[(1, 0)] -> Immutable
-  --> $DIR/preserve_field_drop_order.rs:87:26
+  --> $DIR/preserve_field_drop_order.rs:78:26
    |
 LL |         println!("{:?}", a.1);
    |                          ^^^
 note: Capturing a[(0, 0)] -> Immutable
-  --> $DIR/preserve_field_drop_order.rs:90:26
+  --> $DIR/preserve_field_drop_order.rs:81:26
    |
 LL |         println!("{:?}", a.0);
    |                          ^^^
 note: Capturing b[(0, 0)] -> Immutable
-  --> $DIR/preserve_field_drop_order.rs:94:26
+  --> $DIR/preserve_field_drop_order.rs:85:26
    |
 LL |         println!("{:?}", b.0);
    |                          ^^^
 
 error: Min Capture analysis includes:
-  --> $DIR/preserve_field_drop_order.rs:81:5
+  --> $DIR/preserve_field_drop_order.rs:72:5
    |
 LL | /     || {
 LL | |
@@ -200,26 +170,25 @@ LL | |     };
    | |_____^
    |
 note: Min Capture b[(0, 0)] -> Immutable
-  --> $DIR/preserve_field_drop_order.rs:94:26
+  --> $DIR/preserve_field_drop_order.rs:85:26
    |
 LL |         println!("{:?}", b.0);
    |                          ^^^
 note: Min Capture b[(1, 0)] -> Immutable
-  --> $DIR/preserve_field_drop_order.rs:84:26
+  --> $DIR/preserve_field_drop_order.rs:75:26
    |
 LL |         println!("{:?}", b.1);
    |                          ^^^
 note: Min Capture a[(0, 0)] -> Immutable
-  --> $DIR/preserve_field_drop_order.rs:90:26
+  --> $DIR/preserve_field_drop_order.rs:81:26
    |
 LL |         println!("{:?}", a.0);
    |                          ^^^
 note: Min Capture a[(1, 0)] -> Immutable
-  --> $DIR/preserve_field_drop_order.rs:87:26
+  --> $DIR/preserve_field_drop_order.rs:78:26
    |
 LL |         println!("{:?}", a.1);
    |                          ^^^
 
-error: aborting due to 9 previous errors
+error: aborting due to 6 previous errors
 
-For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/closures/2229_closure_analysis/repr_packed.rs
+++ b/tests/ui/closures/2229_closure_analysis/repr_packed.rs
@@ -12,9 +12,6 @@ fn test_alignment_not_affected() {
     let mut foo = Foo { x: 0, y: 0 };
 
     let mut c = #[rustc_capture_analysis]
-    //~^ ERROR: attributes on expressions are experimental
-    //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
-    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     || {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:
@@ -43,9 +40,6 @@ fn test_alignment_affected() {
     let mut foo = Foo { x: String::new(), y: 0 };
 
     let mut c = #[rustc_capture_analysis]
-    //~^ ERROR: attributes on expressions are experimental
-    //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
-    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     || {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:
@@ -79,9 +73,6 @@ fn test_truncation_when_ref_and_move() {
     let mut foo = Foo { x: String::new() };
 
     let c = #[rustc_capture_analysis]
-    //~^ ERROR: attributes on expressions are experimental
-    //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
-    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     || {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:

--- a/tests/ui/closures/2229_closure_analysis/repr_packed.stderr
+++ b/tests/ui/closures/2229_closure_analysis/repr_packed.stderr
@@ -1,35 +1,5 @@
-error[E0658]: attributes on expressions are experimental
-  --> $DIR/repr_packed.rs:14:17
-   |
-LL |     let mut c = #[rustc_capture_analysis]
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
-   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
-error[E0658]: attributes on expressions are experimental
-  --> $DIR/repr_packed.rs:45:17
-   |
-LL |     let mut c = #[rustc_capture_analysis]
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
-   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
-error[E0658]: attributes on expressions are experimental
-  --> $DIR/repr_packed.rs:81:13
-   |
-LL |     let c = #[rustc_capture_analysis]
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
-   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
 error: First Pass analysis includes:
-  --> $DIR/repr_packed.rs:18:5
+  --> $DIR/repr_packed.rs:15:5
    |
 LL | /     || {
 LL | |
@@ -41,18 +11,18 @@ LL | |     };
    | |_____^
    |
 note: Capturing foo[] -> Immutable
-  --> $DIR/repr_packed.rs:21:24
+  --> $DIR/repr_packed.rs:18:24
    |
 LL |         let z1: &u8 = &foo.x;
    |                        ^^^^^
 note: Capturing foo[] -> Mutable
-  --> $DIR/repr_packed.rs:23:32
+  --> $DIR/repr_packed.rs:20:32
    |
 LL |         let z2: &mut u8 = &mut foo.y;
    |                                ^^^^^
 
 error: Min Capture analysis includes:
-  --> $DIR/repr_packed.rs:18:5
+  --> $DIR/repr_packed.rs:15:5
    |
 LL | /     || {
 LL | |
@@ -64,13 +34,13 @@ LL | |     };
    | |_____^
    |
 note: Min Capture foo[] -> Mutable
-  --> $DIR/repr_packed.rs:23:32
+  --> $DIR/repr_packed.rs:20:32
    |
 LL |         let z2: &mut u8 = &mut foo.y;
    |                                ^^^^^
 
 error: First Pass analysis includes:
-  --> $DIR/repr_packed.rs:49:5
+  --> $DIR/repr_packed.rs:43:5
    |
 LL | /     || {
 LL | |
@@ -82,18 +52,18 @@ LL | |     };
    | |_____^
    |
 note: Capturing foo[] -> Immutable
-  --> $DIR/repr_packed.rs:52:28
+  --> $DIR/repr_packed.rs:46:28
    |
 LL |         let z1: &String = &foo.x;
    |                            ^^^^^
 note: Capturing foo[] -> Mutable
-  --> $DIR/repr_packed.rs:54:33
+  --> $DIR/repr_packed.rs:48:33
    |
 LL |         let z2: &mut u16 = &mut foo.y;
    |                                 ^^^^^
 
 error: Min Capture analysis includes:
-  --> $DIR/repr_packed.rs:49:5
+  --> $DIR/repr_packed.rs:43:5
    |
 LL | /     || {
 LL | |
@@ -105,13 +75,13 @@ LL | |     };
    | |_____^
    |
 note: Min Capture foo[] -> Mutable
-  --> $DIR/repr_packed.rs:54:33
+  --> $DIR/repr_packed.rs:48:33
    |
 LL |         let z2: &mut u16 = &mut foo.y;
    |                                 ^^^^^
 
 error: First Pass analysis includes:
-  --> $DIR/repr_packed.rs:85:5
+  --> $DIR/repr_packed.rs:76:5
    |
 LL | /     || {
 LL | |
@@ -122,18 +92,18 @@ LL | |     };
    | |_____^
    |
 note: Capturing foo[] -> Immutable
-  --> $DIR/repr_packed.rs:88:24
+  --> $DIR/repr_packed.rs:79:24
    |
 LL |         println!("{}", foo.x);
    |                        ^^^^^
 note: Capturing foo[(0, 0)] -> ByValue
-  --> $DIR/repr_packed.rs:92:18
+  --> $DIR/repr_packed.rs:83:18
    |
 LL |         let _z = foo.x;
    |                  ^^^^^
 
 error: Min Capture analysis includes:
-  --> $DIR/repr_packed.rs:85:5
+  --> $DIR/repr_packed.rs:76:5
    |
 LL | /     || {
 LL | |
@@ -144,7 +114,7 @@ LL | |     };
    | |_____^
    |
 note: Min Capture foo[] -> ByValue
-  --> $DIR/repr_packed.rs:88:24
+  --> $DIR/repr_packed.rs:79:24
    |
 LL |         println!("{}", foo.x);
    |                        ^^^^^ foo[] used here
@@ -152,6 +122,5 @@ LL |         println!("{}", foo.x);
 LL |         let _z = foo.x;
    |                  ^^^^^ foo[] captured as ByValue here
 
-error: aborting due to 9 previous errors
+error: aborting due to 6 previous errors
 
-For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/closures/2229_closure_analysis/simple-struct-min-capture.rs
+++ b/tests/ui/closures/2229_closure_analysis/simple-struct-min-capture.rs
@@ -21,9 +21,6 @@ fn main() {
     // Requirements met when p is captured via MutBorrow
     //
     let mut c = #[rustc_capture_analysis]
-        //~^ ERROR: attributes on expressions are experimental
-        //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
-        //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     || {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:

--- a/tests/ui/closures/2229_closure_analysis/simple-struct-min-capture.stderr
+++ b/tests/ui/closures/2229_closure_analysis/simple-struct-min-capture.stderr
@@ -1,15 +1,5 @@
-error[E0658]: attributes on expressions are experimental
-  --> $DIR/simple-struct-min-capture.rs:23:17
-   |
-LL |     let mut c = #[rustc_capture_analysis]
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
-   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
 error: First Pass analysis includes:
-  --> $DIR/simple-struct-min-capture.rs:27:5
+  --> $DIR/simple-struct-min-capture.rs:24:5
    |
 LL | /     || {
 LL | |
@@ -20,18 +10,18 @@ LL | |     };
    | |_____^
    |
 note: Capturing p[(0, 0)] -> Mutable
-  --> $DIR/simple-struct-min-capture.rs:30:9
+  --> $DIR/simple-struct-min-capture.rs:27:9
    |
 LL |         p.x += 10;
    |         ^^^
 note: Capturing p[] -> Immutable
-  --> $DIR/simple-struct-min-capture.rs:33:26
+  --> $DIR/simple-struct-min-capture.rs:30:26
    |
 LL |         println!("{:?}", p);
    |                          ^
 
 error: Min Capture analysis includes:
-  --> $DIR/simple-struct-min-capture.rs:27:5
+  --> $DIR/simple-struct-min-capture.rs:24:5
    |
 LL | /     || {
 LL | |
@@ -42,7 +32,7 @@ LL | |     };
    | |_____^
    |
 note: Min Capture p[] -> Mutable
-  --> $DIR/simple-struct-min-capture.rs:30:9
+  --> $DIR/simple-struct-min-capture.rs:27:9
    |
 LL |         p.x += 10;
    |         ^^^ p[] captured as Mutable here
@@ -50,6 +40,5 @@ LL |         p.x += 10;
 LL |         println!("{:?}", p);
    |                          ^ p[] used here
 
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/closures/2229_closure_analysis/unsafe_ptr.rs
+++ b/tests/ui/closures/2229_closure_analysis/unsafe_ptr.rs
@@ -23,9 +23,6 @@ fn unsafe_imm() {
     let t = T(p);
 
     let c = #[rustc_capture_analysis]
-    //~^ ERROR: attributes on expressions are experimental
-    //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
-    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
      || unsafe {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:
@@ -44,9 +41,6 @@ fn unsafe_mut() {
     let p : *mut S = &mut *my_speed;
 
     let c = #[rustc_capture_analysis]
-    //~^ ERROR: attributes on expressions are experimental
-    //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
-    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     || {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:

--- a/tests/ui/closures/2229_closure_analysis/unsafe_ptr.stderr
+++ b/tests/ui/closures/2229_closure_analysis/unsafe_ptr.stderr
@@ -1,25 +1,5 @@
-error[E0658]: attributes on expressions are experimental
-  --> $DIR/unsafe_ptr.rs:25:13
-   |
-LL |     let c = #[rustc_capture_analysis]
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
-   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
-error[E0658]: attributes on expressions are experimental
-  --> $DIR/unsafe_ptr.rs:46:13
-   |
-LL |     let c = #[rustc_capture_analysis]
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
-   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
 error: First Pass analysis includes:
-  --> $DIR/unsafe_ptr.rs:29:6
+  --> $DIR/unsafe_ptr.rs:26:6
    |
 LL | /      || unsafe {
 LL | |
@@ -30,13 +10,13 @@ LL | |     };
    | |_____^
    |
 note: Capturing t[(0, 0),Deref,(0, 0)] -> Immutable
-  --> $DIR/unsafe_ptr.rs:32:26
+  --> $DIR/unsafe_ptr.rs:29:26
    |
 LL |         println!("{:?}", (*t.0).s);
    |                          ^^^^^^^^
 
 error: Min Capture analysis includes:
-  --> $DIR/unsafe_ptr.rs:29:6
+  --> $DIR/unsafe_ptr.rs:26:6
    |
 LL | /      || unsafe {
 LL | |
@@ -47,13 +27,13 @@ LL | |     };
    | |_____^
    |
 note: Min Capture t[(0, 0)] -> Immutable
-  --> $DIR/unsafe_ptr.rs:32:26
+  --> $DIR/unsafe_ptr.rs:29:26
    |
 LL |         println!("{:?}", (*t.0).s);
    |                          ^^^^^^^^
 
 error: First Pass analysis includes:
-  --> $DIR/unsafe_ptr.rs:50:5
+  --> $DIR/unsafe_ptr.rs:44:5
    |
 LL | /     || {
 LL | |
@@ -65,13 +45,13 @@ LL | |     };
    | |_____^
    |
 note: Capturing p[Deref,(0, 0)] -> Immutable
-  --> $DIR/unsafe_ptr.rs:53:31
+  --> $DIR/unsafe_ptr.rs:47:31
    |
 LL |         let x = unsafe { &mut (*p).s };
    |                               ^^^^^^
 
 error: Min Capture analysis includes:
-  --> $DIR/unsafe_ptr.rs:50:5
+  --> $DIR/unsafe_ptr.rs:44:5
    |
 LL | /     || {
 LL | |
@@ -83,11 +63,10 @@ LL | |     };
    | |_____^
    |
 note: Min Capture p[] -> Immutable
-  --> $DIR/unsafe_ptr.rs:53:31
+  --> $DIR/unsafe_ptr.rs:47:31
    |
 LL |         let x = unsafe { &mut (*p).s };
    |                               ^^^^^^
 
-error: aborting due to 6 previous errors
+error: aborting due to 4 previous errors
 
-For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/closures/2229_closure_analysis/wild_patterns.rs
+++ b/tests/ui/closures/2229_closure_analysis/wild_patterns.rs
@@ -20,9 +20,6 @@ fn wild_struct() {
     let p = Point { x: 10, y: 20 };
 
     let c = #[rustc_capture_analysis]
-    //~^ ERROR: attributes on expressions are experimental
-    //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
-    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     || {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:
@@ -39,9 +36,6 @@ fn wild_tuple() {
     let t = (String::new(), 10);
 
     let c = #[rustc_capture_analysis]
-    //~^ ERROR: attributes on expressions are experimental
-    //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
-    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     || {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:
@@ -58,9 +52,6 @@ fn wild_arr() {
     let arr = [String::new(), String::new()];
 
     let c = #[rustc_capture_analysis]
-    //~^ ERROR: attributes on expressions are experimental
-    //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
-    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     || {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:

--- a/tests/ui/closures/2229_closure_analysis/wild_patterns.stderr
+++ b/tests/ui/closures/2229_closure_analysis/wild_patterns.stderr
@@ -1,35 +1,5 @@
-error[E0658]: attributes on expressions are experimental
-  --> $DIR/wild_patterns.rs:22:13
-   |
-LL |     let c = #[rustc_capture_analysis]
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
-   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
-error[E0658]: attributes on expressions are experimental
-  --> $DIR/wild_patterns.rs:41:13
-   |
-LL |     let c = #[rustc_capture_analysis]
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
-   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
-error[E0658]: attributes on expressions are experimental
-  --> $DIR/wild_patterns.rs:60:13
-   |
-LL |     let c = #[rustc_capture_analysis]
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
-   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
 error: First Pass analysis includes:
-  --> $DIR/wild_patterns.rs:26:5
+  --> $DIR/wild_patterns.rs:23:5
    |
 LL | /     || {
 ...  |
@@ -37,13 +7,13 @@ LL | |     };
    | |_____^
    |
 note: Capturing p[(0, 0)] -> Immutable
-  --> $DIR/wild_patterns.rs:30:37
+  --> $DIR/wild_patterns.rs:27:37
    |
 LL |         let Point { x: _x, y: _ } = p;
    |                                     ^
 
 error: Min Capture analysis includes:
-  --> $DIR/wild_patterns.rs:26:5
+  --> $DIR/wild_patterns.rs:23:5
    |
 LL | /     || {
 ...  |
@@ -51,13 +21,13 @@ LL | |     };
    | |_____^
    |
 note: Min Capture p[(0, 0)] -> Immutable
-  --> $DIR/wild_patterns.rs:30:37
+  --> $DIR/wild_patterns.rs:27:37
    |
 LL |         let Point { x: _x, y: _ } = p;
    |                                     ^
 
 error: First Pass analysis includes:
-  --> $DIR/wild_patterns.rs:45:5
+  --> $DIR/wild_patterns.rs:39:5
    |
 LL | /     || {
 ...  |
@@ -65,13 +35,13 @@ LL | |     };
    | |_____^
    |
 note: Capturing t[(0, 0)] -> ByValue
-  --> $DIR/wild_patterns.rs:49:23
+  --> $DIR/wild_patterns.rs:43:23
    |
 LL |         let (_x, _) = t;
    |                       ^
 
 error: Min Capture analysis includes:
-  --> $DIR/wild_patterns.rs:45:5
+  --> $DIR/wild_patterns.rs:39:5
    |
 LL | /     || {
 ...  |
@@ -79,13 +49,13 @@ LL | |     };
    | |_____^
    |
 note: Min Capture t[(0, 0)] -> ByValue
-  --> $DIR/wild_patterns.rs:49:23
+  --> $DIR/wild_patterns.rs:43:23
    |
 LL |         let (_x, _) = t;
    |                       ^
 
 error: First Pass analysis includes:
-  --> $DIR/wild_patterns.rs:64:5
+  --> $DIR/wild_patterns.rs:55:5
    |
 LL | /     || {
 ...  |
@@ -93,13 +63,13 @@ LL | |     };
    | |_____^
    |
 note: Capturing arr[Index] -> ByValue
-  --> $DIR/wild_patterns.rs:68:23
+  --> $DIR/wild_patterns.rs:59:23
    |
 LL |         let [_x, _] = arr;
    |                       ^^^
 
 error: Min Capture analysis includes:
-  --> $DIR/wild_patterns.rs:64:5
+  --> $DIR/wild_patterns.rs:55:5
    |
 LL | /     || {
 ...  |
@@ -107,11 +77,10 @@ LL | |     };
    | |_____^
    |
 note: Min Capture arr[] -> ByValue
-  --> $DIR/wild_patterns.rs:68:23
+  --> $DIR/wild_patterns.rs:59:23
    |
 LL |         let [_x, _] = arr;
    |                       ^^^
 
-error: aborting due to 9 previous errors
+error: aborting due to 6 previous errors
 
-For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/conditional-compilation/cfg-non-opt-expr.rs
+++ b/tests/ui/conditional-compilation/cfg-non-opt-expr.rs
@@ -8,4 +8,6 @@ fn main() {
     //~^ ERROR removing an expression is not supported in this position
     let _ = [1, 2, 3][#[cfg(false)] 1];
     //~^ ERROR removing an expression is not supported in this position
+    let _ = #[cfg(false)] String::new().len();
+    //~^ ERROR removing an expression is not supported in this position
 }

--- a/tests/ui/conditional-compilation/cfg-non-opt-expr.stderr
+++ b/tests/ui/conditional-compilation/cfg-non-opt-expr.stderr
@@ -16,5 +16,11 @@ error: removing an expression is not supported in this position
 LL |     let _ = [1, 2, 3][#[cfg(false)] 1];
    |                       ^^^^^^^^^^^^^
 
-error: aborting due to 3 previous errors
+error: removing an expression is not supported in this position
+  --> $DIR/cfg-non-opt-expr.rs:11:13
+   |
+LL |     let _ = #[cfg(false)] String::new().len();
+   |             ^^^^^^^^^^^^^
+
+error: aborting due to 4 previous errors
 

--- a/tests/ui/coroutine/addassign-yield.rs
+++ b/tests/ui/coroutine/addassign-yield.rs
@@ -5,7 +5,7 @@
 // is being used), we were failing to account for all types that might
 // possibly be live across a yield point.
 
-#![feature(coroutines, stmt_expr_attributes)]
+#![feature(coroutines)]
 
 fn foo() {
     let _x = #[coroutine] static || {

--- a/tests/ui/coroutine/borrow-in-tail-expr.rs
+++ b/tests/ui/coroutine/borrow-in-tail-expr.rs
@@ -1,6 +1,6 @@
 //@ run-pass
 
-#![feature(coroutines, stmt_expr_attributes)]
+#![feature(coroutines)]
 
 fn main() {
     let _a = #[coroutine] || {

--- a/tests/ui/coroutine/conditional-drop.rs
+++ b/tests/ui/coroutine/conditional-drop.rs
@@ -3,7 +3,7 @@
 //@ revisions: default nomiropt
 //@[nomiropt]compile-flags: -Z mir-opt-level=0
 
-#![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
+#![feature(coroutines, coroutine_trait)]
 
 use std::ops::Coroutine;
 use std::pin::Pin;

--- a/tests/ui/coroutine/drop-and-replace.rs
+++ b/tests/ui/coroutine/drop-and-replace.rs
@@ -4,7 +4,7 @@
 // #60187, this produced incorrect code for coroutines when a saved local was
 // re-assigned.
 
-#![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
+#![feature(coroutines, coroutine_trait)]
 
 use std::ops::{Coroutine, CoroutineState};
 use std::pin::Pin;

--- a/tests/ui/coroutine/drop-env.rs
+++ b/tests/ui/coroutine/drop-env.rs
@@ -3,7 +3,7 @@
 //@ revisions: default nomiropt
 //@[nomiropt]compile-flags: -Z mir-opt-level=0
 
-#![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
+#![feature(coroutines, coroutine_trait)]
 #![allow(dropping_copy_types)]
 
 use std::ops::Coroutine;

--- a/tests/ui/coroutine/drop-track-addassign-yield.rs
+++ b/tests/ui/coroutine/drop-track-addassign-yield.rs
@@ -3,7 +3,7 @@
 // Based on addassign-yield.rs, but with drop tracking enabled. Originally we did not implement
 // the fake_read callback on ExprUseVisitor which caused this case to break.
 
-#![feature(coroutines, stmt_expr_attributes)]
+#![feature(coroutines)]
 
 fn foo() {
     let _y = #[coroutine] static || {

--- a/tests/ui/coroutine/live-upvar-across-yield.rs
+++ b/tests/ui/coroutine/live-upvar-across-yield.rs
@@ -1,6 +1,6 @@
 //@ run-pass
 
-#![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
+#![feature(coroutines, coroutine_trait)]
 
 use std::ops::Coroutine;
 use std::pin::Pin;

--- a/tests/ui/coroutine/missing_coroutine_attr_suggestion.fixed
+++ b/tests/ui/coroutine/missing_coroutine_attr_suggestion.fixed
@@ -1,6 +1,6 @@
 //@ run-rustfix
 
-#![feature(coroutines, stmt_expr_attributes)]
+#![feature(coroutines)]
 
 fn main() {
     let _ = #[coroutine] || yield;

--- a/tests/ui/coroutine/missing_coroutine_attr_suggestion.rs
+++ b/tests/ui/coroutine/missing_coroutine_attr_suggestion.rs
@@ -1,6 +1,6 @@
 //@ run-rustfix
 
-#![feature(coroutines, stmt_expr_attributes)]
+#![feature(coroutines)]
 
 fn main() {
     let _ = || yield;

--- a/tests/ui/coroutine/nested_coroutine.rs
+++ b/tests/ui/coroutine/nested_coroutine.rs
@@ -1,6 +1,6 @@
 //@ run-pass
 
-#![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
+#![feature(coroutines, coroutine_trait)]
 
 use std::ops::{Coroutine, CoroutineState};
 use std::pin::Pin;

--- a/tests/ui/coroutine/niche-in-coroutine.rs
+++ b/tests/ui/coroutine/niche-in-coroutine.rs
@@ -2,7 +2,7 @@
 
 //@ run-pass
 
-#![feature(coroutines, stmt_expr_attributes)]
+#![feature(coroutines)]
 
 use std::mem::size_of_val;
 

--- a/tests/ui/coroutine/overlap-locals.rs
+++ b/tests/ui/coroutine/overlap-locals.rs
@@ -1,6 +1,6 @@
 //@ run-pass
 
-#![feature(coroutines, stmt_expr_attributes)]
+#![feature(coroutines)]
 
 fn main() {
     let a = #[coroutine]

--- a/tests/ui/coroutine/panic-drops-resume.rs
+++ b/tests/ui/coroutine/panic-drops-resume.rs
@@ -4,7 +4,7 @@
 //@ needs-unwind
 //@ ignore-backends: gcc
 
-#![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
+#![feature(coroutines, coroutine_trait)]
 
 use std::ops::Coroutine;
 use std::panic::{catch_unwind, AssertUnwindSafe};

--- a/tests/ui/coroutine/panic-drops.rs
+++ b/tests/ui/coroutine/panic-drops.rs
@@ -2,7 +2,7 @@
 //@ needs-unwind
 //@ ignore-backends: gcc
 
-#![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
+#![feature(coroutines, coroutine_trait)]
 
 use std::ops::Coroutine;
 use std::panic;

--- a/tests/ui/coroutine/panic-safe.rs
+++ b/tests/ui/coroutine/panic-safe.rs
@@ -2,7 +2,7 @@
 //@ needs-unwind
 //@ ignore-backends: gcc
 
-#![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
+#![feature(coroutines, coroutine_trait)]
 
 use std::ops::Coroutine;
 use std::pin::Pin;

--- a/tests/ui/coroutine/postfix-yield.rs
+++ b/tests/ui/coroutine/postfix-yield.rs
@@ -3,7 +3,7 @@
 //@ run-pass
 //@ edition: 2024
 
-#![feature(gen_blocks, coroutines, coroutine_trait, yield_expr, stmt_expr_attributes)]
+#![feature(gen_blocks, coroutines, coroutine_trait, yield_expr)]
 
 use std::ops::{Coroutine, CoroutineState};
 use std::pin::pin;

--- a/tests/ui/coroutine/resume-after-return.rs
+++ b/tests/ui/coroutine/resume-after-return.rs
@@ -2,7 +2,7 @@
 //@ run-pass
 //@ needs-unwind
 
-#![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
+#![feature(coroutines, coroutine_trait)]
 
 use std::ops::{Coroutine, CoroutineState};
 use std::panic;

--- a/tests/ui/coroutine/resume-arg-size.rs
+++ b/tests/ui/coroutine/resume-arg-size.rs
@@ -1,4 +1,4 @@
-#![feature(coroutines, stmt_expr_attributes)]
+#![feature(coroutines)]
 #![allow(dropping_copy_types)]
 
 //@ run-pass

--- a/tests/ui/coroutine/resume-live-across-yield.rs
+++ b/tests/ui/coroutine/resume-live-across-yield.rs
@@ -1,6 +1,6 @@
 //@ run-pass
 
-#![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
+#![feature(coroutines, coroutine_trait)]
 
 use std::ops::{Coroutine, CoroutineState};
 use std::pin::Pin;

--- a/tests/ui/coroutine/smoke-resume-args.rs
+++ b/tests/ui/coroutine/smoke-resume-args.rs
@@ -3,7 +3,7 @@
 //@ revisions: default nomiropt
 //@[nomiropt]compile-flags: -Z mir-opt-level=0
 
-#![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
+#![feature(coroutines, coroutine_trait)]
 
 use std::fmt::Debug;
 use std::ops::{

--- a/tests/ui/coroutine/smoke.rs
+++ b/tests/ui/coroutine/smoke.rs
@@ -6,7 +6,7 @@
 //@ needs-threads
 //@ compile-flags: --test
 
-#![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
+#![feature(coroutines, coroutine_trait)]
 
 use std::ops::{CoroutineState, Coroutine};
 use std::pin::Pin;

--- a/tests/ui/coroutine/static-coroutine.rs
+++ b/tests/ui/coroutine/static-coroutine.rs
@@ -1,6 +1,6 @@
 //@ run-pass
 
-#![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
+#![feature(coroutines, coroutine_trait)]
 
 use std::ops::{Coroutine, CoroutineState};
 use std::pin::Pin;

--- a/tests/ui/coverage-attr/allowed-positions.rs
+++ b/tests/ui/coverage-attr/allowed-positions.rs
@@ -101,10 +101,8 @@ fn main() {
         || ()
     };
 
-    // Applying attributes to arbitrary expressions requires an unstable
-    // feature, but if that feature were enabled then this would be allowed.
+    // The coverage attribute is also allowed directly on closure expressions.
     let _closure_expr = #[coverage(off)] || ();
-    //~^ ERROR attributes on expressions are experimental [E0658]
 
     match () {
         #[coverage(off)] //~ ERROR attribute cannot be used on

--- a/tests/ui/coverage-attr/allowed-positions.stderr
+++ b/tests/ui/coverage-attr/allowed-positions.stderr
@@ -1,13 +1,3 @@
-error[E0658]: attributes on expressions are experimental
-  --> $DIR/allowed-positions.rs:106:25
-   |
-LL |     let _closure_expr = #[coverage(off)] || ();
-   |                         ^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
-   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
 error: `#[coverage]` attribute cannot be used on type aliases
   --> $DIR/allowed-positions.rs:14:1
    |
@@ -129,7 +119,7 @@ LL |     #[coverage(off)]
    = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
 
 error: `#[coverage]` attribute cannot be used on match arms
-  --> $DIR/allowed-positions.rs:110:9
+  --> $DIR/allowed-positions.rs:108:9
    |
 LL |         #[coverage(off)]
    |         ^^^^^^^^^^^^^^^^
@@ -137,13 +127,12 @@ LL |         #[coverage(off)]
    = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
 
 error: `#[coverage]` attribute cannot be used on expressions
-  --> $DIR/allowed-positions.rs:114:5
+  --> $DIR/allowed-positions.rs:112:5
    |
 LL |     #[coverage(off)]
    |     ^^^^^^^^^^^^^^^^
    |
    = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
 
-error: aborting due to 18 previous errors
+error: aborting due to 17 previous errors
 
-For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/drop/dynamic-drop.rs
+++ b/tests/ui/drop/dynamic-drop.rs
@@ -3,7 +3,7 @@
 //@ needs-unwind
 //@ ignore-backends: gcc
 
-#![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
+#![feature(coroutines, coroutine_trait)]
 
 #![allow(unused_assignments)]
 #![allow(unused_variables)]

--- a/tests/ui/feature-gates/feature-gate-remaining-expr-attributes.rs
+++ b/tests/ui/feature-gates/feature-gate-remaining-expr-attributes.rs
@@ -1,0 +1,32 @@
+fn free_function() -> usize {
+    0
+}
+
+struct Value {
+    field: usize,
+}
+
+impl Value {
+    fn method(self) -> Self {
+        self
+    }
+}
+
+fn main() {
+    let value = Value { field: 0 };
+
+    let _ = #[allow(unused)] 42;
+    //~^ ERROR attributes on expressions are experimental
+
+    let _ = #[allow(unused)] free_function();
+    //~^ ERROR attributes on expressions are experimental
+
+    let _ = #[allow(unused)] value.method().field;
+    //~^ ERROR attributes on expressions are experimental
+
+    let _ = #[allow(unused)] [0][0];
+    //~^ ERROR attributes on expressions are experimental
+
+    let _ = #[allow(unused)] 1 + 2;
+    //~^ ERROR attributes on expressions are experimental
+}

--- a/tests/ui/feature-gates/feature-gate-remaining-expr-attributes.stderr
+++ b/tests/ui/feature-gates/feature-gate-remaining-expr-attributes.stderr
@@ -1,0 +1,53 @@
+error[E0658]: attributes on expressions are experimental
+  --> $DIR/feature-gate-remaining-expr-attributes.rs:18:13
+   |
+LL |     let _ = #[allow(unused)] 42;
+   |             ^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
+   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: attributes on expressions are experimental
+  --> $DIR/feature-gate-remaining-expr-attributes.rs:21:13
+   |
+LL |     let _ = #[allow(unused)] free_function();
+   |             ^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
+   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: attributes on expressions are experimental
+  --> $DIR/feature-gate-remaining-expr-attributes.rs:24:13
+   |
+LL |     let _ = #[allow(unused)] value.method().field;
+   |             ^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
+   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: attributes on expressions are experimental
+  --> $DIR/feature-gate-remaining-expr-attributes.rs:27:13
+   |
+LL |     let _ = #[allow(unused)] [0][0];
+   |             ^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
+   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: attributes on expressions are experimental
+  --> $DIR/feature-gate-remaining-expr-attributes.rs:30:13
+   |
+LL |     let _ = #[allow(unused)] 1 + 2;
+   |             ^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
+   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: aborting due to 5 previous errors
+
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/lint/unused/unused-parens-for-stmt-expr-attributes-issue-129833.fixed
+++ b/tests/ui/lint/unused/unused-parens-for-stmt-expr-attributes-issue-129833.fixed
@@ -2,7 +2,6 @@
 // Check the `unused_parens` suggestion for paren_expr with attributes.
 // The suggestion should retain attributes in the front.
 
-#![feature(stmt_expr_attributes)]
 #![deny(unused_parens)]
 
 pub fn foo() -> impl Fn() {

--- a/tests/ui/lint/unused/unused-parens-for-stmt-expr-attributes-issue-129833.rs
+++ b/tests/ui/lint/unused/unused-parens-for-stmt-expr-attributes-issue-129833.rs
@@ -2,7 +2,6 @@
 // Check the `unused_parens` suggestion for paren_expr with attributes.
 // The suggestion should retain attributes in the front.
 
-#![feature(stmt_expr_attributes)]
 #![deny(unused_parens)]
 
 pub fn foo() -> impl Fn() {

--- a/tests/ui/lint/unused/unused-parens-for-stmt-expr-attributes-issue-129833.stderr
+++ b/tests/ui/lint/unused/unused-parens-for-stmt-expr-attributes-issue-129833.stderr
@@ -1,11 +1,11 @@
 error: unnecessary parentheses around assigned value
-  --> $DIR/unused-parens-for-stmt-expr-attributes-issue-129833.rs:9:13
+  --> $DIR/unused-parens-for-stmt-expr-attributes-issue-129833.rs:8:13
    |
 LL |     let _ = (#[inline] #[allow(dead_code)] || println!("Hello!"));
    |             ^                                                   ^
    |
 note: the lint level is defined here
-  --> $DIR/unused-parens-for-stmt-expr-attributes-issue-129833.rs:6:9
+  --> $DIR/unused-parens-for-stmt-expr-attributes-issue-129833.rs:5:9
    |
 LL | #![deny(unused_parens)]
    |         ^^^^^^^^^^^^^
@@ -16,7 +16,7 @@ LL +     let _ = #[inline] #[allow(dead_code)] || println!("Hello!");
    |
 
 error: unnecessary parentheses around block return value
-  --> $DIR/unused-parens-for-stmt-expr-attributes-issue-129833.rs:10:5
+  --> $DIR/unused-parens-for-stmt-expr-attributes-issue-129833.rs:9:5
    |
 LL |     (#[inline] #[allow(dead_code)] || println!("Hello!"))
    |     ^                                                   ^

--- a/tests/ui/liveness/liveness-upvars.rs
+++ b/tests/ui/liveness/liveness-upvars.rs
@@ -1,7 +1,7 @@
 //@ edition:2018
 //@ check-pass
 
-#![feature(coroutines, stmt_expr_attributes)]
+#![feature(coroutines)]
 #![warn(unused)]
 #![allow(unreachable_code)]
 

--- a/tests/ui/packed/packed-struct-drop-aligned.rs
+++ b/tests/ui/packed/packed-struct-drop-aligned.rs
@@ -1,5 +1,5 @@
 //@ run-pass
-#![feature(coroutines, stmt_expr_attributes)]
+#![feature(coroutines)]
 #![feature(coroutine_trait)]
 #![allow(unused_assignments, unused_variables)]
 

--- a/tests/ui/rfcs/rfc-2091-track-caller/tracked-closure.rs
+++ b/tests/ui/rfcs/rfc-2091-track-caller/tracked-closure.rs
@@ -1,6 +1,5 @@
 //@ run-pass
 
-#![feature(stmt_expr_attributes)]
 #![feature(closure_track_caller)]
 #![feature(coroutine_trait)]
 #![feature(coroutines)]

--- a/tests/ui/sanitizer/cfi/coroutine.rs
+++ b/tests/ui/sanitizer/cfi/coroutine.rs
@@ -16,7 +16,7 @@
 //@ compile-flags: --test
 //@ run-pass
 
-#![feature(coroutines, stmt_expr_attributes)]
+#![feature(coroutines)]
 #![feature(coroutine_trait)]
 #![feature(gen_blocks)]
 #![feature(async_iterator)]


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/159581)*
<!-- homu-ignore:end -->

# Stabilization report

## Summary

This PR partially stabilizes outer attributes on expressions under the existing
`stmt_expr_attributes` feature.

It stabilizes attributes directly on closure expressions and method-call
expressions, including parenthesized forms and complete method-call chains:

```rust
let closure = #[inline] || 42;
let len = #[allow(unused)] value.len();
let result = #[allow(unused)] value.first().second();
let result = #[allow(unused)] (value.first().second());
```

RFC 16 proposed broader support for attributes on statements and expressions.
Several unambiguous positions have already become stable, including statements,
blocks, match arms, and elements of arrays, tuples, and function argument lists.
General expression attributes remain unstable because it may be unclear which
expression an initial attribute applies to.

This stabilization selects closures and method calls, whose attribute targets
are clear, while leaving the remaining expression and subexpression cases
behind `stmt_expr_attributes`.

Tracking and related work:

- [RFC 16: More attributes](https://github.com/rust-lang/rfcs/blob/master/text/0016-more-attributes.md)
- [`stmt_expr_attributes` tracking issue #15701](https://github.com/rust-lang/rust/issues/15701)
- [Summary of the remaining design questions](https://github.com/rust-lang/rust/issues/15701#issuecomment-2033124217)
- [Path-forward discussion #127436](https://github.com/rust-lang/rust/issues/127436)

Two I opened together with this one for reference update and the for rejecting cfg one expressions that cannot be safely remove: 

- [Reference PR #2314](https://github.com/rust-lang/reference/pull/2314)
- [Reject `cfg` on expressions that cannot be safely removed #159580](https://github.com/rust-lang/rust/pull/159580)

cc @rust-lang/lang @rust-lang/lang-advisors @rust-lang/lang-docs @rust-lang/compiler

## What is stabilized

### Closure expressions

Outer attributes may be placed directly on closures without enabling
`stmt_expr_attributes`:

```rust
let closure = #[inline] || 42;
let cold_closure = #[cold] move || perform_work();
```

This stabilizes the attribute position. Existing target validation still
determines whether a particular attribute may be applied to a closure.

### Method-call expressions

Outer attributes may be placed directly on method-call expressions:

```rust
let len = #[allow(unused)] value.len();
```

For a method-call chain, the attribute applies to the complete resulting
method-call expression:

```rust
let result = #[allow(unused)] value.first().second();
```

Parentheses around a closure or method call do not change whether the position
is stable:

```rust
let result = #[allow(unused)] (value.first().second());
```

## What is not stabilized

The `stmt_expr_attributes` feature itself remains unstable. Attributes on other
expression kinds continue to require the feature gate.

For example, these remain unstable:

```rust
let value = #[allow(unused)] 42;
let value = #[allow(unused)] free_function();
let value = #[allow(unused)] object.method().field;
let value = #[allow(unused)] values[0];
let value = #[allow(unused)] 1 + 2;
```

Although `object.method().field` contains a method call, its outer expression is
a field expression, so it is outside this stabilization.

This PR does not decide the behavior of attributes on arbitrary literals,
function calls, field expressions, indexing, binary expressions, or other
remaining expression and subexpression positions.

There is also a detailed summary report I created after deeply studying what was stabilized, what has not been stabilized and where were they confirmed to be stabilized and the summary can be find here: - https://github.com/rust-lang/rust/issues/15701#issuecomment-4783402256 

## Design

The primary concern with general expression attributes is identifying the
expression to which an initial attribute belongs. For example:

```rust
#[attr] a + b
```

can raise readability and precedence questions about whether the attribute
belongs to `a` or to the complete binary expression.

Closures have a distinct syntactic introducer:

```rust
#[attr] || expression
```

Method calls form a clear postfix expression:

```rust
#[attr] receiver.method()
```

For chained calls, the complete chain is represented by an outer method-call
expression. The attribute consequently applies to the complete chain.

This partial stabilization does not introduce additional feature gates. The
existing `stmt_expr_attributes` gate remains active for all expression kinds
outside the stated boundary.

### Interaction with `cfg`

Stabilizing an attribute position does not mean that `#[cfg]` may remove an
expression required by its parent.

For example:

```rust
let value = #[cfg(false)] object.method();
```

cannot be configured away because that would leave the initializer incomplete.
It continues to produce:

```text
removing an expression is not supported in this position
```

[rust-lang/rust#159580](https://github.com/rust-lang/rust/pull/159580)
ensures that `cfg` on expressions that cannot be safely removed is rejected
regardless of whether the configuration evaluates to true or false.

Positions where `cfg` can safely remove a complete element, such as an array,
tuple, or function argument element, are unaffected.

## Implementation

The parser and AST already support this syntax, so this stabilization does not
change the grammar or AST representation.

The expression-attribute feature-gate checker now receives the attributed
`ast::Expr`. Before emitting the `stmt_expr_attributes` diagnostic, it
recognizes:

- `ExprKind::Closure`
- `ExprKind::MethodCall`
- `ExprKind::Paren` containing either of those expressions

The expression node is passed through the relevant ordinary expansion,
optional-expression expansion, and `cfg_eval` configuration paths so that they
all apply the same stability rule.

The `stmt_expr_attributes` entry remains in
`compiler/rustc_feature/src/unstable.rs`; it is not moved to `accepted.rs`.

## Test coverage

Positive tests cover:

- Direct attributes on closures.
- A single method call.
- Complete method-call chains.
- Parenthesized method-call chains.
- Closure and method-call attributes processed through `cfg_eval`.
- Existing `#[inline]`, `#[cold]`, `#[coroutine]`, capture-analysis, and
  `#[track_caller]` uses on closures.

Negative tests verify that the following remain gated:

- Literals.
- Free-function calls.
- Field expressions following method calls.
- Index expressions.
- Binary expressions.

Configuration tests verify that a required method-call expression cannot be
removed with `#[cfg(false)]`.

Existing closure-analysis tests were updated only to remove their obsolete E0658
expectations. Their intended capture-analysis diagnostics remain. Coroutine
tests no longer enable `stmt_expr_attributes` solely to place `#[coroutine]` on
a closure.

## Compatibility and language interactions

This is an additive change. Programs previously accepted on stable Rust remain
accepted, so a crater run is not expected to be necessary.

This stabilization:

- Does not change type inference or method resolution.
- Does not introduce new expressions, temporaries, or evaluation steps.
- Does not change temporary scopes or drop order.
- Does not affect operational semantics or unsafe-code rules.
- Is not edition-dependent.
- Does not stabilize `cfg_eval`, coroutines, or individual unstable attributes.
- Preserves existing attribute target validation.
- Preserves `stmt_expr_attributes` for all other expression kinds.

## Tools and documentation

No Cargo, rustdoc, Clippy, rustup, or docs.rs changes are required because no new
syntax or AST form is introduced. The syntax was already available on nightly.

Rustfmt and rust-analyzer use the existing expression-attribute syntax, but
their behavior should be confirmed during review.

[Reference PR #2314](https://github.com/rust-lang/reference/pull/2314):

- Lists closures and method calls as valid expression-attribute positions.
- Specifies that an attribute on a method-call chain applies to the complete
  method-call expression.
- Updates the `inline`, `cold`, and `instruction_set` documentation so that it
  no longer describes direct closure expression attributes as unsupported.

The Reference PR must be reviewed and approved by the lang-docs team before this
stabilization is merged.

## Outstanding concerns

No known implementation or soundness issue specifically blocks this narrow
stabilization.

The broader design questions tracked in
[#15701](https://github.com/rust-lang/rust/issues/15701) and
[#127436](https://github.com/rust-lang/rust/issues/127436) remain relevant to
the expression kinds that are not being stabilized.

An existing FIXME notes differences between ordinary and optional expression
feature-gating paths. Both paths are updated and tested by this implementation,
so it does not block this stabilization.

## Contributors and prior work

The current work builds on contributions from:

- @huonw — author of RFC 16;
- @brson — opened the expression-attribute tracking issue and merged the
  original RFC;
- @Kimundi — author of the initial implementation in
  [[rust-lang/rust#29850](https://github.com/rust-lang/rust/pull/29850)](https://github.com/rust-lang/rust/pull/29850);
- @nrc — author of the statement-attribute stabilization in
  [[rust-lang/rust#36995](https://github.com/rust-lang/rust/pull/36995)](https://github.com/rust-lang/rust/pull/36995);
- @WaffleLapkin and @traviscross — the proposal and discussion for splitting
  the remaining feature into narrower stabilization candidates;
- @dtolnay and @fmease — expression attribute precedence work;
- @jonas-schievink — earlier Reference documentation for closure attributes;
- @Unique-Usman — the current stabilization implementation, `#[cfg]` safety
  fix, tests, and Reference update.

## Acknowledgments

Thanks to the authors and implementers of RFC 16 and to everyone involved in
the expression-attribute discussions, implementations, and previous
stabilizations, including the contributors to rust-lang/rust#15701, rust-lang/rust#32796, rust-lang/rust#36995, rust-lang/rust#127436,
rust-lang/rust#134661, rust-lang/rust#159580, and the corresponding Reference work. Thanks to my rust compiler mentor @estebank and thanks to @WaffleLapkin for helping. 