### PR TITLE
Rollup of 2 pull requests

### DIFF
--- a/compiler/rustc_borrowck/src/borrowck_errors.rs
+++ b/compiler/rustc_borrowck/src/borrowck_errors.rs
@@ -2,12 +2,12 @@ use rustc_errors::codes::*;
 use rustc_errors::{Applicability, Diag, DiagCtxtHandle, struct_span_code_err};
 use rustc_hir as hir;
 use rustc_middle::span_bug;
-use rustc_middle::ty::{self, Ty, TyCtxt};
+use rustc_middle::ty::{self, Ty};
 use rustc_span::Span;
 
 impl<'diag, 'tcx> crate::MirBorrowckCtxt<'_, 'diag, 'tcx> {
     pub(crate) fn dcx(&self) -> DiagCtxtHandle<'diag> {
-        self.infcx.dcx()
+        self.root_cx.dcx()
     }
 
     pub(crate) fn cannot_move_when_borrowed(
@@ -486,13 +486,13 @@ impl<'diag, 'tcx> crate::MirBorrowckCtxt<'_, 'diag, 'tcx> {
     }
 }
 
-pub(crate) fn borrowed_data_escapes_closure<'tcx>(
-    tcx: TyCtxt<'tcx>,
+pub(crate) fn borrowed_data_escapes_closure<'diag>(
+    dcx: DiagCtxtHandle<'diag>,
     escape_span: Span,
     escapes_from: &str,
-) -> Diag<'tcx> {
+) -> Diag<'diag> {
     struct_span_code_err!(
-        tcx.dcx(),
+        dcx,
         escape_span,
         E0521,
         "borrowed data escapes outside of {}",

--- a/compiler/rustc_borrowck/src/borrowck_errors.rs
+++ b/compiler/rustc_borrowck/src/borrowck_errors.rs
@@ -5,8 +5,8 @@ use rustc_middle::span_bug;
 use rustc_middle::ty::{self, Ty, TyCtxt};
 use rustc_span::Span;
 
-impl<'infcx, 'tcx> crate::MirBorrowckCtxt<'_, 'infcx, 'tcx> {
-    pub(crate) fn dcx(&self) -> DiagCtxtHandle<'infcx> {
+impl<'diag, 'tcx> crate::MirBorrowckCtxt<'_, 'diag, 'tcx> {
+    pub(crate) fn dcx(&self) -> DiagCtxtHandle<'diag> {
         self.infcx.dcx()
     }
 
@@ -17,7 +17,7 @@ impl<'infcx, 'tcx> crate::MirBorrowckCtxt<'_, 'infcx, 'tcx> {
         place: &str,
         borrow_place: &str,
         value_place: &str,
-    ) -> Diag<'infcx> {
+    ) -> Diag<'diag> {
         self.dcx().create_err(crate::session_diagnostics::MoveBorrow {
             place,
             span,
@@ -33,7 +33,7 @@ impl<'infcx, 'tcx> crate::MirBorrowckCtxt<'_, 'infcx, 'tcx> {
         desc: &str,
         borrow_span: Span,
         borrow_desc: &str,
-    ) -> Diag<'infcx> {
+    ) -> Diag<'diag> {
         struct_span_code_err!(
             self.dcx(),
             span,
@@ -53,7 +53,7 @@ impl<'infcx, 'tcx> crate::MirBorrowckCtxt<'_, 'infcx, 'tcx> {
         old_loan_span: Span,
         old_opt_via: &str,
         old_load_end_span: Option<Span>,
-    ) -> Diag<'infcx> {
+    ) -> Diag<'diag> {
         let via = |msg: &str| if msg.is_empty() { "".to_string() } else { format!(" (via {msg})") };
         let mut err = struct_span_code_err!(
             self.dcx(),
@@ -100,7 +100,7 @@ impl<'infcx, 'tcx> crate::MirBorrowckCtxt<'_, 'infcx, 'tcx> {
         desc: &str,
         old_loan_span: Span,
         old_load_end_span: Option<Span>,
-    ) -> Diag<'infcx> {
+    ) -> Diag<'diag> {
         let mut err = struct_span_code_err!(
             self.dcx(),
             new_loan_span,
@@ -133,7 +133,7 @@ impl<'infcx, 'tcx> crate::MirBorrowckCtxt<'_, 'infcx, 'tcx> {
         noun_old: &str,
         old_opt_via: &str,
         previous_end_span: Option<Span>,
-    ) -> Diag<'infcx> {
+    ) -> Diag<'diag> {
         let mut err = struct_span_code_err!(
             self.dcx(),
             new_loan_span,
@@ -165,7 +165,7 @@ impl<'infcx, 'tcx> crate::MirBorrowckCtxt<'_, 'infcx, 'tcx> {
         old_opt_via: &str,
         previous_end_span: Option<Span>,
         second_borrow_desc: &str,
-    ) -> Diag<'infcx> {
+    ) -> Diag<'diag> {
         let mut err = struct_span_code_err!(
             self.dcx(),
             new_loan_span,
@@ -197,7 +197,7 @@ impl<'infcx, 'tcx> crate::MirBorrowckCtxt<'_, 'infcx, 'tcx> {
         kind_old: &str,
         msg_old: &str,
         old_load_end_span: Option<Span>,
-    ) -> Diag<'infcx> {
+    ) -> Diag<'diag> {
         let via = |msg: &str| if msg.is_empty() { "".to_string() } else { format!(" (via {msg})") };
         let mut err = struct_span_code_err!(
             self.dcx(),
@@ -238,7 +238,7 @@ impl<'infcx, 'tcx> crate::MirBorrowckCtxt<'_, 'infcx, 'tcx> {
         span: Span,
         borrow_span: Span,
         desc: &str,
-    ) -> Diag<'infcx> {
+    ) -> Diag<'diag> {
         struct_span_code_err!(
             self.dcx(),
             span,
@@ -255,12 +255,12 @@ impl<'infcx, 'tcx> crate::MirBorrowckCtxt<'_, 'infcx, 'tcx> {
         span: Span,
         desc: &str,
         is_arg: bool,
-    ) -> Diag<'infcx> {
+    ) -> Diag<'diag> {
         let msg = if is_arg { "to immutable argument" } else { "twice to immutable variable" };
         struct_span_code_err!(self.dcx(), span, E0384, "cannot assign {} {}", msg, desc)
     }
 
-    pub(crate) fn cannot_assign(&self, span: Span, desc: &str) -> Diag<'infcx> {
+    pub(crate) fn cannot_assign(&self, span: Span, desc: &str) -> Diag<'diag> {
         struct_span_code_err!(self.dcx(), span, E0594, "cannot assign to {}", desc)
     }
 
@@ -268,7 +268,7 @@ impl<'infcx, 'tcx> crate::MirBorrowckCtxt<'_, 'infcx, 'tcx> {
         &self,
         move_from_span: Span,
         move_from_desc: &str,
-    ) -> Diag<'infcx> {
+    ) -> Diag<'diag> {
         struct_span_code_err!(
             self.dcx(),
             move_from_span,
@@ -286,7 +286,7 @@ impl<'infcx, 'tcx> crate::MirBorrowckCtxt<'_, 'infcx, 'tcx> {
         move_from_span: Span,
         ty: Ty<'_>,
         is_index: Option<bool>,
-    ) -> Diag<'infcx> {
+    ) -> Diag<'diag> {
         let type_name = match (ty.kind(), is_index) {
             (&ty::Array(_, _), Some(true)) | (&ty::Array(_, _), None) => "array",
             (&ty::Slice(_), _) => "slice",
@@ -307,7 +307,7 @@ impl<'infcx, 'tcx> crate::MirBorrowckCtxt<'_, 'infcx, 'tcx> {
         &self,
         move_from_span: Span,
         container_ty: Ty<'_>,
-    ) -> Diag<'infcx> {
+    ) -> Diag<'diag> {
         struct_span_code_err!(
             self.dcx(),
             move_from_span,
@@ -325,7 +325,7 @@ impl<'infcx, 'tcx> crate::MirBorrowckCtxt<'_, 'infcx, 'tcx> {
         optional_adverb_for_moved: &str,
         moved_path: Option<String>,
         primary_message: Option<String>,
-    ) -> Diag<'infcx> {
+    ) -> Diag<'diag> {
         if let Some(primary_message) = primary_message {
             struct_span_code_err!(self.dcx(), use_span, E0382, "{}", primary_message)
         } else {
@@ -348,7 +348,7 @@ impl<'infcx, 'tcx> crate::MirBorrowckCtxt<'_, 'infcx, 'tcx> {
         span: Span,
         path: &str,
         reason: &str,
-    ) -> Diag<'infcx> {
+    ) -> Diag<'diag> {
         struct_span_code_err!(
             self.dcx(),
             span,
@@ -366,7 +366,7 @@ impl<'infcx, 'tcx> crate::MirBorrowckCtxt<'_, 'infcx, 'tcx> {
         immutable_place: &str,
         immutable_section: &str,
         action: &str,
-    ) -> Diag<'infcx> {
+    ) -> Diag<'diag> {
         struct_span_code_err!(
             self.dcx(),
             mutate_span,
@@ -384,7 +384,7 @@ impl<'infcx, 'tcx> crate::MirBorrowckCtxt<'_, 'infcx, 'tcx> {
         &self,
         span: Span,
         yield_span: Span,
-    ) -> Diag<'infcx> {
+    ) -> Diag<'diag> {
         let coroutine_kind = self.body.coroutine.as_ref().unwrap().coroutine_kind;
         let mut diag = struct_span_code_err!(
             self.dcx(),
@@ -418,7 +418,7 @@ impl<'infcx, 'tcx> crate::MirBorrowckCtxt<'_, 'infcx, 'tcx> {
         diag
     }
 
-    pub(crate) fn cannot_borrow_across_destructor(&self, borrow_span: Span) -> Diag<'infcx> {
+    pub(crate) fn cannot_borrow_across_destructor(&self, borrow_span: Span) -> Diag<'diag> {
         struct_span_code_err!(
             self.dcx(),
             borrow_span,
@@ -427,7 +427,7 @@ impl<'infcx, 'tcx> crate::MirBorrowckCtxt<'_, 'infcx, 'tcx> {
         )
     }
 
-    pub(crate) fn path_does_not_live_long_enough(&self, span: Span, path: &str) -> Diag<'infcx> {
+    pub(crate) fn path_does_not_live_long_enough(&self, span: Span, path: &str) -> Diag<'diag> {
         struct_span_code_err!(self.dcx(), span, E0597, "{} does not live long enough", path)
     }
 
@@ -437,7 +437,7 @@ impl<'infcx, 'tcx> crate::MirBorrowckCtxt<'_, 'infcx, 'tcx> {
         return_kind: &str,
         reference_desc: &str,
         path_desc: &str,
-    ) -> Diag<'infcx> {
+    ) -> Diag<'diag> {
         struct_span_code_err!(
             self.dcx(),
             span,
@@ -460,7 +460,7 @@ impl<'infcx, 'tcx> crate::MirBorrowckCtxt<'_, 'infcx, 'tcx> {
         borrowed_path: &str,
         capture_span: Span,
         scope: &str,
-    ) -> Diag<'infcx> {
+    ) -> Diag<'diag> {
         struct_span_code_err!(
             self.dcx(),
             closure_span,
@@ -472,7 +472,7 @@ impl<'infcx, 'tcx> crate::MirBorrowckCtxt<'_, 'infcx, 'tcx> {
         .with_span_label(closure_span, format!("may outlive borrowed value {borrowed_path}"))
     }
 
-    pub(crate) fn thread_local_value_does_not_live_long_enough(&self, span: Span) -> Diag<'infcx> {
+    pub(crate) fn thread_local_value_does_not_live_long_enough(&self, span: Span) -> Diag<'diag> {
         struct_span_code_err!(
             self.dcx(),
             span,
@@ -481,7 +481,7 @@ impl<'infcx, 'tcx> crate::MirBorrowckCtxt<'_, 'infcx, 'tcx> {
         )
     }
 
-    pub(crate) fn temporary_value_borrowed_for_too_long(&self, span: Span) -> Diag<'infcx> {
+    pub(crate) fn temporary_value_borrowed_for_too_long(&self, span: Span) -> Diag<'diag> {
         struct_span_code_err!(self.dcx(), span, E0716, "temporary value dropped while borrowed")
     }
 }

--- a/compiler/rustc_borrowck/src/consumers.rs
+++ b/compiler/rustc_borrowck/src/consumers.rs
@@ -125,8 +125,13 @@ pub fn get_bodies_with_borrowck_facts(
     root_def_id: LocalDefId,
     options: ConsumerOptions,
 ) -> FxHashMap<LocalDefId, BodyWithBorrowckFacts<'_>> {
-    let mut root_cx =
-        BorrowCheckRootCtxt::new(tcx, root_def_id, Some(BorrowckConsumer::new(options)));
+    let tainted_by_errors = Default::default();
+    let mut root_cx = BorrowCheckRootCtxt::new(
+        tcx,
+        root_def_id,
+        Some(BorrowckConsumer::new(options)),
+        &tainted_by_errors,
+    );
     root_cx.do_mir_borrowck();
     root_cx.consumer.unwrap().bodies
 }

--- a/compiler/rustc_borrowck/src/diagnostics/bound_region_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/bound_region_errors.rs
@@ -356,6 +356,7 @@ impl<'tcx> TypeOpInfo<'tcx> for crate::type_check::InstantiateOpaqueType<'tcx> {
             |vid| RegionVariableOrigin::Nll(mbcx.regioncx.definitions[vid].origin),
             |vid| mbcx.regioncx.definitions[vid].universe,
         )
+        .map(|d| d.with_dcx(mbcx.dcx()))
     }
 }
 

--- a/compiler/rustc_borrowck/src/diagnostics/bound_region_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/bound_region_errors.rs
@@ -129,13 +129,13 @@ pub(crate) trait TypeOpInfo<'tcx> {
 
     fn base_universe(&self) -> ty::UniverseIndex;
 
-    fn nice_error<'infcx>(
+    fn nice_error<'diag>(
         &self,
-        mbcx: &mut MirBorrowckCtxt<'_, 'infcx, 'tcx>,
+        mbcx: &mut MirBorrowckCtxt<'_, 'diag, 'tcx>,
         cause: ObligationCause<'tcx>,
         placeholder_region: ty::Region<'tcx>,
         error_region: Option<ty::Region<'tcx>>,
-    ) -> Option<Diag<'infcx>>;
+    ) -> Option<Diag<'diag>>;
 
     /// Constraints require that `error_element` appear in the
     /// values of `placeholder`, but this cannot be proven to
@@ -205,13 +205,13 @@ impl<'tcx> TypeOpInfo<'tcx> for PredicateQuery<'tcx> {
         self.base_universe
     }
 
-    fn nice_error<'infcx>(
+    fn nice_error<'diag>(
         &self,
-        mbcx: &mut MirBorrowckCtxt<'_, 'infcx, 'tcx>,
+        mbcx: &mut MirBorrowckCtxt<'_, 'diag, 'tcx>,
         cause: ObligationCause<'tcx>,
         placeholder_region: ty::Region<'tcx>,
         error_region: Option<ty::Region<'tcx>>,
-    ) -> Option<Diag<'infcx>> {
+    ) -> Option<Diag<'diag>> {
         let (infcx, key, _) =
             mbcx.infcx.tcx.infer_ctxt().build_with_canonical(cause.span, &self.canonical_query);
         let ocx = ObligationCtxt::new(&infcx);
@@ -256,13 +256,13 @@ where
         self.base_universe
     }
 
-    fn nice_error<'infcx>(
+    fn nice_error<'diag>(
         &self,
-        mbcx: &mut MirBorrowckCtxt<'_, 'infcx, 'tcx>,
+        mbcx: &mut MirBorrowckCtxt<'_, 'diag, 'tcx>,
         cause: ObligationCause<'tcx>,
         placeholder_region: ty::Region<'tcx>,
         error_region: Option<ty::Region<'tcx>>,
-    ) -> Option<Diag<'infcx>> {
+    ) -> Option<Diag<'diag>> {
         let (infcx, key, _) =
             mbcx.infcx.tcx.infer_ctxt().build_with_canonical(cause.span, &self.canonical_query);
         let ocx = ObligationCtxt::new(&infcx);
@@ -303,13 +303,13 @@ impl<'tcx> TypeOpInfo<'tcx> for AscribeUserTypeQuery<'tcx> {
         self.base_universe
     }
 
-    fn nice_error<'infcx>(
+    fn nice_error<'diag>(
         &self,
-        mbcx: &mut MirBorrowckCtxt<'_, 'infcx, 'tcx>,
+        mbcx: &mut MirBorrowckCtxt<'_, 'diag, 'tcx>,
         cause: ObligationCause<'tcx>,
         placeholder_region: ty::Region<'tcx>,
         error_region: Option<ty::Region<'tcx>>,
-    ) -> Option<Diag<'infcx>> {
+    ) -> Option<Diag<'diag>> {
         let (infcx, key, _) =
             mbcx.infcx.tcx.infer_ctxt().build_with_canonical(cause.span, &self.canonical_query);
         let ocx = ObligationCtxt::new(&infcx);
@@ -336,13 +336,13 @@ impl<'tcx> TypeOpInfo<'tcx> for crate::type_check::InstantiateOpaqueType<'tcx> {
         self.base_universe.unwrap()
     }
 
-    fn nice_error<'infcx>(
+    fn nice_error<'diag>(
         &self,
-        mbcx: &mut MirBorrowckCtxt<'_, 'infcx, 'tcx>,
+        mbcx: &mut MirBorrowckCtxt<'_, 'diag, 'tcx>,
         _cause: ObligationCause<'tcx>,
         placeholder_region: ty::Region<'tcx>,
         error_region: Option<ty::Region<'tcx>>,
-    ) -> Option<Diag<'infcx>> {
+    ) -> Option<Diag<'diag>> {
         try_extract_error_from_region_constraints(
             mbcx.infcx,
             mbcx.mir_def_id(),

--- a/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
@@ -70,7 +70,7 @@ enum StorageDeadOrDrop<'tcx> {
     Destructor(Ty<'tcx>),
 }
 
-impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
+impl<'diag, 'tcx> MirBorrowckCtxt<'_, 'diag, 'tcx> {
     pub(crate) fn report_use_of_moved_or_uninitialized(
         &mut self,
         location: Location,
@@ -829,7 +829,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
         location: Location,
         span: Span,
         use_spans: UseSpans<'tcx>,
-    ) -> Diag<'infcx> {
+    ) -> Diag<'diag> {
         // We need all statements in the body where the binding was assigned to later find all
         // the branching code paths where the binding *wasn't* assigned to.
         let inits = &self.move_data.init_path_map[mpi];
@@ -1759,7 +1759,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
         location: Location,
         (place, _span): (Place<'tcx>, Span),
         borrow: &BorrowData<'tcx>,
-    ) -> Diag<'infcx> {
+    ) -> Diag<'diag> {
         let borrow_spans = self.retrieve_borrow_spans(borrow);
         let borrow_span = borrow_spans.args_or_use();
 
@@ -1804,7 +1804,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
         (place, span): (Place<'tcx>, Span),
         gen_borrow_kind: BorrowKind,
         issued_borrow: &BorrowData<'tcx>,
-    ) -> Diag<'infcx> {
+    ) -> Diag<'diag> {
         let issued_spans = self.retrieve_borrow_spans(issued_borrow);
         let issued_span = issued_spans.args_or_use();
 
@@ -3150,7 +3150,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
         drop_span: Span,
         borrow_spans: UseSpans<'tcx>,
         explanation: BorrowExplanation<'tcx>,
-    ) -> Diag<'infcx> {
+    ) -> Diag<'diag> {
         let borrow_span = borrow_spans.var_or_use_path_span();
         if let BorrowExplanation::MustBeValidFor { best_blame, opt_place_desc, .. } = &explanation
             && let OutlivesConstraint { category, span, from_closure: false, .. } =
@@ -3323,7 +3323,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
         &self,
         drop_span: Span,
         borrow_span: Span,
-    ) -> Diag<'infcx> {
+    ) -> Diag<'diag> {
         debug!(
             "report_thread_local_value_does_not_live_long_enough(\
              {:?}, {:?}\
@@ -3360,7 +3360,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
         borrow_spans: UseSpans<'tcx>,
         proper_span: Span,
         explanation: BorrowExplanation<'tcx>,
-    ) -> Diag<'infcx> {
+    ) -> Diag<'diag> {
         if let BorrowExplanation::MustBeValidFor { ref best_blame, .. } = explanation
             && let OutlivesConstraint { category, span, from_closure: false, .. } =
                 best_blame.constraint()
@@ -3515,7 +3515,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
         return_span: Span,
         category: ConstraintCategory<'tcx>,
         opt_place_desc: Option<&String>,
-    ) -> Result<(), Diag<'infcx>> {
+    ) -> Result<(), Diag<'diag>> {
         let return_kind = match category {
             ConstraintCategory::Return(_) => "return",
             ConstraintCategory::Yield => "yield",
@@ -3633,7 +3633,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
         constraint_span: Span,
         captured_var: &str,
         scope: &str,
-    ) -> Diag<'infcx> {
+    ) -> Diag<'diag> {
         let tcx = self.infcx.tcx;
         let args_span = use_span.args_or_use();
 
@@ -3751,7 +3751,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
         upvar_span: Span,
         upvar_name: Symbol,
         escape_span: Span,
-    ) -> Diag<'infcx> {
+    ) -> Diag<'diag> {
         let tcx = self.infcx.tcx;
 
         let escapes_from = tcx.def_descr(self.mir_def_id().to_def_id());

--- a/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
@@ -3757,7 +3757,7 @@ impl<'diag, 'tcx> MirBorrowckCtxt<'_, 'diag, 'tcx> {
         let escapes_from = tcx.def_descr(self.mir_def_id().to_def_id());
 
         let mut err =
-            borrowck_errors::borrowed_data_escapes_closure(tcx, escape_span, escapes_from);
+            borrowck_errors::borrowed_data_escapes_closure(self.dcx(), escape_span, escapes_from);
 
         err.span_label(
             upvar_span,

--- a/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
@@ -353,7 +353,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
     fn suggest_ref_or_clone(
         &self,
         mpi: MovePathIndex,
-        err: &mut Diag<'infcx>,
+        err: &mut Diag<'_>,
         move_spans: UseSpans<'tcx>,
         moved_place: PlaceRef<'tcx>,
         has_suggest_reborrow: &mut bool,
@@ -590,7 +590,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
         body: &hir::Expr<'_>,
         place: &Place<'tcx>,
         move_span: Span,
-        err: &mut Diag<'infcx>,
+        err: &mut Diag<'_>,
     ) {
         let var_info = self.body.var_debug_info.iter().find(|info| match info.value {
             VarDebugInfoContents::Place(ref p) => p == place,
@@ -634,7 +634,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
 
     pub(crate) fn suggest_reborrow(
         &self,
-        err: &mut Diag<'infcx>,
+        err: &mut Diag<'_>,
         span: Span,
         moved_place: PlaceRef<'tcx>,
     ) {
@@ -2094,7 +2094,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
         err
     }
 
-    fn suggest_copy_for_type_in_cloned_ref(&self, err: &mut Diag<'infcx>, place: Place<'tcx>) {
+    fn suggest_copy_for_type_in_cloned_ref(&self, err: &mut Diag<'_>, place: Place<'tcx>) {
         let tcx = self.infcx.tcx;
         let Some(body_id) = tcx.hir_node(self.mir_hir_id()).body_id() else { return };
 

--- a/compiler/rustc_borrowck/src/diagnostics/mod.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/mod.rs
@@ -74,12 +74,12 @@ pub(super) struct DescribePlaceOpt {
 
 pub(super) struct IncludingTupleField(pub(super) bool);
 
-enum BufferedDiag<'infcx> {
-    Error(Diag<'infcx>),
-    NonError(Diag<'infcx, ()>),
+enum BufferedDiag<'diag> {
+    Error(Diag<'diag>),
+    NonError(Diag<'diag, ()>),
 }
 
-impl<'infcx> BufferedDiag<'infcx> {
+impl<'diag> BufferedDiag<'diag> {
     fn sort_span(&self) -> Span {
         match self {
             BufferedDiag::Error(diag) => diag.sort_span,
@@ -89,7 +89,7 @@ impl<'infcx> BufferedDiag<'infcx> {
 }
 
 #[derive(Default)]
-pub(crate) struct BorrowckDiagnosticsBuffer<'infcx, 'tcx> {
+pub(crate) struct BorrowckDiagnosticsBuffer<'diag, 'tcx> {
     /// This field keeps track of move errors that are to be reported for given move indices.
     ///
     /// There are situations where many errors can be reported for a single move out (see
@@ -104,19 +104,19 @@ pub(crate) struct BorrowckDiagnosticsBuffer<'infcx, 'tcx> {
     /// `BTreeMap` is used to preserve the order of insertions when iterating. This is necessary
     /// when errors in the map are being re-added to the error buffer so that errors with the
     /// same primary span come out in a consistent order.
-    buffered_move_errors: BTreeMap<Vec<MoveOutIndex>, (PlaceRef<'tcx>, Diag<'infcx>)>,
+    buffered_move_errors: BTreeMap<Vec<MoveOutIndex>, (PlaceRef<'tcx>, Diag<'diag>)>,
 
-    buffered_mut_errors: FxIndexMap<Span, (Diag<'infcx>, usize)>,
+    buffered_mut_errors: FxIndexMap<Span, (Diag<'diag>, usize)>,
 
     /// Buffer of diagnostics to be reported. A mixture of error and non-error diagnostics.
-    buffered_diags: Vec<BufferedDiag<'infcx>>,
+    buffered_diags: Vec<BufferedDiag<'diag>>,
 }
 
-impl<'infcx, 'tcx> BorrowckDiagnosticsBuffer<'infcx, 'tcx> {
-    pub(crate) fn buffer_non_error(&mut self, diag: Diag<'infcx, ()>) {
+impl<'diag, 'tcx> BorrowckDiagnosticsBuffer<'diag, 'tcx> {
+    pub(crate) fn buffer_non_error(&mut self, diag: Diag<'diag, ()>) {
         self.buffered_diags.push(BufferedDiag::NonError(diag));
     }
-    pub(crate) fn buffer_error(&mut self, diag: Diag<'infcx>) {
+    pub(crate) fn buffer_error(&mut self, diag: Diag<'diag>) {
         self.buffered_diags.push(BufferedDiag::Error(diag));
     }
 
@@ -149,19 +149,19 @@ impl<'infcx, 'tcx> BorrowckDiagnosticsBuffer<'infcx, 'tcx> {
     }
 }
 
-impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
-    pub(crate) fn buffer_error(&mut self, diag: Diag<'infcx>) {
+impl<'diag, 'tcx> MirBorrowckCtxt<'_, 'diag, 'tcx> {
+    pub(crate) fn buffer_error(&mut self, diag: Diag<'diag>) {
         self.diags_buffer.buffer_error(diag);
     }
 
-    pub(crate) fn buffer_non_error(&mut self, diag: Diag<'infcx, ()>) {
+    pub(crate) fn buffer_non_error(&mut self, diag: Diag<'diag, ()>) {
         self.diags_buffer.buffer_non_error(diag);
     }
 
     pub(crate) fn buffer_move_error(
         &mut self,
         move_out_indices: Vec<MoveOutIndex>,
-        place_and_err: (PlaceRef<'tcx>, Diag<'infcx>),
+        place_and_err: (PlaceRef<'tcx>, Diag<'diag>),
     ) -> bool {
         if let Some((_, diag)) =
             self.diags_buffer.buffered_move_errors.insert(move_out_indices, place_and_err)
@@ -174,12 +174,12 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
         }
     }
 
-    pub(crate) fn get_buffered_mut_error(&mut self, span: Span) -> Option<(Diag<'infcx>, usize)> {
+    pub(crate) fn get_buffered_mut_error(&mut self, span: Span) -> Option<(Diag<'diag>, usize)> {
         // FIXME(#120456) - is `swap_remove` correct?
         self.diags_buffer.buffered_mut_errors.swap_remove(&span)
     }
 
-    pub(crate) fn buffer_mut_error(&mut self, span: Span, diag: Diag<'infcx>, count: usize) {
+    pub(crate) fn buffer_mut_error(&mut self, span: Span, diag: Diag<'diag>, count: usize) {
         self.diags_buffer.buffered_mut_errors.insert(span, (diag, count));
     }
 
@@ -190,7 +190,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
     pub(crate) fn has_move_error(
         &self,
         move_out_indices: &[MoveOutIndex],
-    ) -> Option<&(PlaceRef<'tcx>, Diag<'infcx>)> {
+    ) -> Option<&(PlaceRef<'tcx>, Diag<'diag>)> {
         self.diags_buffer.buffered_move_errors.get(move_out_indices)
     }
 

--- a/compiler/rustc_borrowck/src/diagnostics/mod.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/mod.rs
@@ -23,7 +23,7 @@ use rustc_middle::ty::{self, Ty, TyCtxt};
 use rustc_middle::{bug, span_bug};
 use rustc_mir_dataflow::move_paths::{InitLocation, LookupResult, MoveOutIndex};
 use rustc_span::def_id::LocalDefId;
-use rustc_span::{DUMMY_SP, ErrorGuaranteed, Span, Spanned, Symbol, sym};
+use rustc_span::{DUMMY_SP, Span, Spanned, Symbol, sym};
 use rustc_trait_selection::error_reporting::InferCtxtErrorExt;
 use rustc_trait_selection::error_reporting::traits::call_kind::{CallDesugaringKind, call_kind};
 use rustc_trait_selection::infer::InferCtxtExt;
@@ -34,13 +34,13 @@ use tracing::debug;
 
 use super::MirBorrowckCtxt;
 use super::borrow_set::BorrowData;
-use crate::LocalMutationIsAllowed;
 use crate::constraints::OutlivesConstraint;
 use crate::nll::ConstraintDescription;
 use crate::session_diagnostics::{
     CaptureArgLabel, CaptureReasonLabel, CaptureReasonNote, CaptureReasonSuggest, CaptureVarCause,
     CaptureVarKind, CaptureVarPathUseCause, OnClosureNote,
 };
+use crate::{BorrowCheckRootCtxt, LocalMutationIsAllowed};
 
 mod find_all_local_uses;
 mod find_use;
@@ -74,7 +74,7 @@ pub(super) struct DescribePlaceOpt {
 
 pub(super) struct IncludingTupleField(pub(super) bool);
 
-enum BufferedDiag<'diag> {
+pub(crate) enum BufferedDiag<'diag> {
     Error(Diag<'diag>),
     NonError(Diag<'diag, ()>),
 }
@@ -120,9 +120,7 @@ impl<'diag, 'tcx> BorrowckDiagnosticsBuffer<'diag, 'tcx> {
         self.buffered_diags.push(BufferedDiag::Error(diag));
     }
 
-    pub(crate) fn emit_errors(&mut self) -> Option<ErrorGuaranteed> {
-        let mut res = None;
-
+    pub(crate) fn emit_errors(&mut self, root_cx: &mut BorrowCheckRootCtxt<'diag, 'tcx>) {
         // Buffer any move errors that we collected and de-duplicated.
         for (_, (_, diag)) in std::mem::take(&mut self.buffered_move_errors) {
             // We have already set tainted for this error, so just buffer it.
@@ -138,24 +136,19 @@ impl<'diag, 'tcx> BorrowckDiagnosticsBuffer<'diag, 'tcx> {
         if !self.buffered_diags.is_empty() {
             self.buffered_diags.sort_by_key(|buffered_diag| buffered_diag.sort_span());
             for buffered_diag in self.buffered_diags.drain(..) {
-                match buffered_diag {
-                    BufferedDiag::Error(diag) => res = Some(diag.emit()),
-                    BufferedDiag::NonError(diag) => diag.emit(),
-                }
+                root_cx.buffer_error(buffered_diag);
             }
         }
-
-        res
     }
 }
 
 impl<'diag, 'tcx> MirBorrowckCtxt<'_, 'diag, 'tcx> {
-    pub(crate) fn buffer_error(&mut self, diag: Diag<'diag>) {
-        self.diags_buffer.buffer_error(diag);
+    pub(crate) fn buffer_error(&mut self, diag: Diag<'_>) {
+        self.diags_buffer.buffer_error(diag.with_dcx(self.dcx()));
     }
 
-    pub(crate) fn buffer_non_error(&mut self, diag: Diag<'diag, ()>) {
-        self.diags_buffer.buffer_non_error(diag);
+    pub(crate) fn buffer_non_error(&mut self, diag: Diag<'_, ()>) {
+        self.diags_buffer.buffer_non_error(diag.with_dcx(self.dcx()));
     }
 
     pub(crate) fn buffer_move_error(

--- a/compiler/rustc_borrowck/src/diagnostics/mod.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/mod.rs
@@ -225,7 +225,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
     }
 }
 
-impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
+impl<'tcx> MirBorrowckCtxt<'_, '_, 'tcx> {
     /// Adds a suggestion when a closure is invoked twice with a moved variable or when a closure
     /// is moved after being invoked.
     ///
@@ -241,7 +241,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
         &self,
         location: Location,
         place: PlaceRef<'tcx>,
-        diag: &mut Diag<'infcx>,
+        diag: &mut Diag<'_>,
     ) -> bool {
         debug!("add_moved_or_invoked_closure_note: location={:?} place={:?}", location, place);
         let mut target = place.local_or_deref_local();
@@ -1022,7 +1022,7 @@ pub(super) enum CloneSuggestion {
     NotEmitted,
 }
 
-impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
+impl<'tcx> MirBorrowckCtxt<'_, '_, 'tcx> {
     /// Finds the spans associated to a move or copy of move_place at location.
     pub(super) fn move_spans(
         &self,
@@ -1240,7 +1240,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
 
     fn explain_captures(
         &mut self,
-        err: &mut Diag<'infcx>,
+        err: &mut Diag<'_>,
         span: Span,
         move_span: Span,
         move_spans: UseSpans<'tcx>,

--- a/compiler/rustc_borrowck/src/diagnostics/mod.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/mod.rs
@@ -34,13 +34,13 @@ use tracing::debug;
 
 use super::MirBorrowckCtxt;
 use super::borrow_set::BorrowData;
+use crate::LocalMutationIsAllowed;
 use crate::constraints::OutlivesConstraint;
 use crate::nll::ConstraintDescription;
 use crate::session_diagnostics::{
     CaptureArgLabel, CaptureReasonLabel, CaptureReasonNote, CaptureReasonSuggest, CaptureVarCause,
     CaptureVarKind, CaptureVarPathUseCause, OnClosureNote,
 };
-use crate::{BorrowCheckRootCtxt, LocalMutationIsAllowed};
 
 mod find_all_local_uses;
 mod find_use;
@@ -120,7 +120,7 @@ impl<'diag, 'tcx> BorrowckDiagnosticsBuffer<'diag, 'tcx> {
         self.buffered_diags.push(BufferedDiag::Error(diag));
     }
 
-    pub(crate) fn emit_errors(&mut self, root_cx: &mut BorrowCheckRootCtxt<'diag, 'tcx>) {
+    pub(crate) fn emit_errors(&mut self) {
         // Buffer any move errors that we collected and de-duplicated.
         for (_, (_, diag)) in std::mem::take(&mut self.buffered_move_errors) {
             // We have already set tainted for this error, so just buffer it.
@@ -136,7 +136,12 @@ impl<'diag, 'tcx> BorrowckDiagnosticsBuffer<'diag, 'tcx> {
         if !self.buffered_diags.is_empty() {
             self.buffered_diags.sort_by_key(|buffered_diag| buffered_diag.sort_span());
             for buffered_diag in self.buffered_diags.drain(..) {
-                root_cx.buffer_error(buffered_diag);
+                match buffered_diag {
+                    BufferedDiag::Error(diag) => {
+                        diag.emit();
+                    }
+                    BufferedDiag::NonError(diag) => diag.emit(),
+                }
             }
         }
     }

--- a/compiler/rustc_borrowck/src/diagnostics/move_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/move_errors.rs
@@ -102,7 +102,7 @@ struct PatternBindingInfo {
     has_mutable_by_value_binding: bool,
 }
 
-impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
+impl<'diag, 'tcx> MirBorrowckCtxt<'_, 'diag, 'tcx> {
     pub(crate) fn report_move_errors(&mut self) {
         let grouped_errors = self.group_move_errors();
         for error in grouped_errors {
@@ -310,7 +310,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
             && self.infcx.tcx.ensure_result().coherent_trait(copy_def_id).is_err()
     }
 
-    fn report_cannot_move_from_static(&mut self, place: Place<'tcx>, span: Span) -> Diag<'infcx> {
+    fn report_cannot_move_from_static(&mut self, place: Place<'tcx>, span: Span) -> Diag<'diag> {
         let description = if place.projection.len() == 1 {
             format!("static item {}", self.describe_any_place(place.as_ref()))
         } else {
@@ -439,7 +439,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
         deref_target_place: Place<'tcx>,
         span: Span,
         use_spans: Option<UseSpans<'tcx>>,
-    ) -> (Diag<'infcx>, CloneSuggestion) {
+    ) -> (Diag<'diag>, CloneSuggestion) {
         let tcx = self.infcx.tcx;
         // Inspect the type of the content behind the
         // borrow to provide feedback about why this
@@ -573,7 +573,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
         closure_kind_ty: Ty<'tcx>,
         upvar_field: FieldIdx,
         asyncness: ty::Asyncness,
-    ) -> Diag<'infcx> {
+    ) -> Diag<'diag> {
         let tcx = self.infcx.tcx;
 
         let closure_kind = match closure_kind_ty.to_opt_closure_kind() {

--- a/compiler/rustc_borrowck/src/diagnostics/mutability_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/mutability_errors.rs
@@ -664,9 +664,9 @@ impl<'tcx> MirBorrowckCtxt<'_, '_, 'tcx> {
             /// Walks through the HIR, looking for the corresponding span for this error.
             /// When it finds it, see if it corresponds to assignment operator whose LHS
             /// is an index expr.
-            struct SuggestIndexOperatorAlternativeVisitor<'a, 'infcx, 'tcx> {
+            struct SuggestIndexOperatorAlternativeVisitor<'a, 'diag, 'tcx> {
                 assign_span: Span,
-                err: &'a mut Diag<'infcx>,
+                err: &'a mut Diag<'diag>,
                 ty: Ty<'tcx>,
                 suggested: bool,
                 infcx: &'a rustc_infer::infer::InferCtxt<'tcx>,

--- a/compiler/rustc_borrowck/src/diagnostics/mutability_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/mutability_errors.rs
@@ -58,7 +58,7 @@ fn find_assignments(body: &Body<'_>, local: Local) -> Vec<Location> {
     visitor.locations
 }
 
-impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
+impl<'tcx> MirBorrowckCtxt<'_, '_, 'tcx> {
     pub(crate) fn report_mutability_error(
         &mut self,
         access_place: Place<'tcx>,
@@ -655,7 +655,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
     }
 
     /// Suggest `map[k] = v` => `map.insert(k, v)` and the like.
-    fn suggest_map_index_mut_alternatives(&self, ty: Ty<'tcx>, err: &mut Diag<'infcx>, span: Span) {
+    fn suggest_map_index_mut_alternatives(&self, ty: Ty<'tcx>, err: &mut Diag<'_>, span: Span) {
         let Some(adt) = ty.ty_adt_def() else { return };
         let did = adt.did();
         if self.infcx.tcx.is_diagnostic_item(sym::HashMap, did)
@@ -672,7 +672,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
                 infcx: &'a rustc_infer::infer::InferCtxt<'tcx>,
             }
 
-            impl<'a, 'infcx, 'tcx> Visitor<'tcx> for SuggestIndexOperatorAlternativeVisitor<'a, 'infcx, 'tcx> {
+            impl<'tcx> Visitor<'tcx> for SuggestIndexOperatorAlternativeVisitor<'_, '_, 'tcx> {
                 fn visit_stmt(&mut self, stmt: &'tcx hir::Stmt<'tcx>) {
                     hir::intravisit::walk_stmt(self, stmt);
                     let expr = match stmt.kind {

--- a/compiler/rustc_borrowck/src/diagnostics/opaque_types.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/opaque_types.rs
@@ -21,7 +21,7 @@ use crate::consumers::RegionInferenceContext;
 use crate::region_infer::opaque_types::DeferredOpaqueTypeError;
 use crate::type_check::Locations;
 
-impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
+impl<'diag, 'tcx> MirBorrowckCtxt<'_, 'diag, 'tcx> {
     pub(crate) fn report_opaque_type_errors(&mut self, errors: Vec<DeferredOpaqueTypeError<'tcx>>) {
         if errors.is_empty() {
             return;

--- a/compiler/rustc_borrowck/src/diagnostics/region_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/region_errors.rs
@@ -708,7 +708,7 @@ impl<'diag, 'tcx> MirBorrowckCtxt<'_, 'diag, 'tcx> {
         }
 
         let mut diag =
-            borrowck_errors::borrowed_data_escapes_closure(self.infcx.tcx, *span, escapes_from);
+            borrowck_errors::borrowed_data_escapes_closure(self.dcx(), *span, escapes_from);
 
         if let Some((Some(outlived_fr_name), outlived_fr_span)) = outlived_fr_name_and_span {
             diag.span_label(

--- a/compiler/rustc_borrowck/src/diagnostics/region_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/region_errors.rs
@@ -189,7 +189,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
     }
 }
 
-impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
+impl<'diag, 'tcx> MirBorrowckCtxt<'_, 'diag, 'tcx> {
     // For generic associated types (GATs) which implied 'static requirement
     // from higher-ranked trait bounds (HRTB). Try to locate span of the trait
     // and the span which bounded to the trait for adding 'static lifetime suggestion
@@ -605,7 +605,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
         &self,
         errci: &ErrorConstraintInfo<'tcx>,
         kind: ReturnConstraint,
-    ) -> Diag<'infcx> {
+    ) -> Diag<'diag> {
         let ErrorConstraintInfo { outlived_fr, span, .. } = errci;
 
         let mut output_ty = self.regioncx.universal_regions().unnormalized_output_ty;
@@ -674,7 +674,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
     ///    |     ^^^^^^^^^^ `x` escapes the function body here
     /// ```
     #[instrument(level = "debug", skip(self))]
-    fn report_escaping_data_error(&self, errci: &ErrorConstraintInfo<'tcx>) -> Diag<'infcx> {
+    fn report_escaping_data_error(&self, errci: &ErrorConstraintInfo<'tcx>) -> Diag<'diag> {
         let ErrorConstraintInfo { span, category, .. } = errci;
 
         let fr_name_and_span = self.regioncx.get_var_name_and_span_for_region(
@@ -785,7 +785,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
     ///    |     ^^^^^^^^^^^^^^ function was supposed to return data with lifetime `'a` but it
     ///    |                    is returning data with lifetime `'b`
     /// ```
-    fn report_general_error(&self, errci: &ErrorConstraintInfo<'tcx>) -> Diag<'infcx> {
+    fn report_general_error(&self, errci: &ErrorConstraintInfo<'tcx>) -> Diag<'diag> {
         let ErrorConstraintInfo { fr, outlived_fr, span, category, .. } = errci;
 
         let mir_def_name = self.infcx.tcx.def_descr(self.mir_def_id().to_def_id());

--- a/compiler/rustc_borrowck/src/lib.rs
+++ b/compiler/rustc_borrowck/src/lib.rs
@@ -495,8 +495,8 @@ fn borrowck_check_region_constraints<'tcx>(
             diags_buffer,
             polonius_context: polonius_context.as_ref(),
         };
-        struct MoveVisitor<'a, 'b, 'infcx, 'tcx> {
-            ctxt: &'a mut MirBorrowckCtxt<'b, 'infcx, 'tcx>,
+        struct MoveVisitor<'a, 'b, 'diag, 'tcx> {
+            ctxt: &'a mut MirBorrowckCtxt<'b, 'diag, 'tcx>,
         }
 
         impl<'tcx> Visitor<'tcx> for MoveVisitor<'_, '_, '_, 'tcx> {
@@ -727,9 +727,9 @@ impl<'tcx> Deref for BorrowckInferCtxt<'tcx> {
     }
 }
 
-pub(crate) struct MirBorrowckCtxt<'a, 'infcx, 'tcx> {
+pub(crate) struct MirBorrowckCtxt<'a, 'diag, 'tcx> {
     root_cx: &'a BorrowCheckRootCtxt<'tcx>,
-    infcx: &'infcx BorrowckInferCtxt<'tcx>,
+    infcx: &'diag BorrowckInferCtxt<'tcx>,
     body: &'a Body<'tcx>,
     move_data: &'a MoveData<'tcx>,
 
@@ -785,7 +785,7 @@ pub(crate) struct MirBorrowckCtxt<'a, 'infcx, 'tcx> {
     /// The counter for generating new region names.
     next_region_name: RefCell<usize>,
 
-    diags_buffer: &'a mut BorrowckDiagnosticsBuffer<'infcx, 'tcx>,
+    diags_buffer: &'a mut BorrowckDiagnosticsBuffer<'diag, 'tcx>,
     move_errors: Vec<MoveError<'tcx>>,
 
     /// Results of Polonius analysis.

--- a/compiler/rustc_borrowck/src/lib.rs
+++ b/compiler/rustc_borrowck/src/lib.rs
@@ -139,7 +139,8 @@ fn mir_borrowck(
         let opaque_types = Default::default();
         Ok(tcx.arena.alloc(opaque_types))
     } else {
-        let mut root_cx = BorrowCheckRootCtxt::new(tcx, def, None);
+        let tainted_by_errors = Default::default();
+        let mut root_cx = BorrowCheckRootCtxt::new(tcx, def, None, &tainted_by_errors);
         root_cx.do_mir_borrowck();
         root_cx.finalize()
     }
@@ -315,7 +316,7 @@ struct CollectRegionConstraintsResult<'tcx> {
 /// the current body. This initializes the relevant data structures
 /// and then type checks the MIR body.
 fn borrowck_collect_region_constraints<'tcx>(
-    root_cx: &mut BorrowCheckRootCtxt<'tcx>,
+    root_cx: &mut BorrowCheckRootCtxt<'_, 'tcx>,
     def: LocalDefId,
 ) -> CollectRegionConstraintsResult<'tcx> {
     let tcx = root_cx.tcx;
@@ -394,7 +395,7 @@ fn borrowck_collect_region_constraints<'tcx>(
 /// and the additional constraints from [BorrowCheckRootCtxt::handle_opaque_type_uses],
 /// compute the region graph and actually check for any borrowck errors.
 fn borrowck_check_region_constraints<'tcx>(
-    root_cx: &mut BorrowCheckRootCtxt<'tcx>,
+    root_cx: &mut BorrowCheckRootCtxt<'_, 'tcx>,
     CollectRegionConstraintsResult {
         infcx,
         body_owned,
@@ -578,7 +579,9 @@ fn borrowck_check_region_constraints<'tcx>(
         used_mut_upvars: mbcx.used_mut_upvars,
     };
 
-    if let Some(guar) = mbcx.diags_buffer.emit_errors().or(infcx.tainted_by_errors()) {
+    diags_buffer.emit_errors(root_cx);
+
+    if let Some(guar) = infcx.tainted_by_errors() {
         root_cx.set_tainted_by_errors(guar);
     }
 
@@ -728,8 +731,8 @@ impl<'tcx> Deref for BorrowckInferCtxt<'tcx> {
 }
 
 pub(crate) struct MirBorrowckCtxt<'a, 'diag, 'tcx> {
-    root_cx: &'a BorrowCheckRootCtxt<'tcx>,
-    infcx: &'diag BorrowckInferCtxt<'tcx>,
+    root_cx: &'a BorrowCheckRootCtxt<'diag, 'tcx>,
+    infcx: &'a BorrowckInferCtxt<'tcx>,
     body: &'a Body<'tcx>,
     move_data: &'a MoveData<'tcx>,
 

--- a/compiler/rustc_borrowck/src/lib.rs
+++ b/compiler/rustc_borrowck/src/lib.rs
@@ -394,8 +394,9 @@ fn borrowck_collect_region_constraints<'tcx>(
 /// Using the region constraints computed by [borrowck_collect_region_constraints]
 /// and the additional constraints from [BorrowCheckRootCtxt::handle_opaque_type_uses],
 /// compute the region graph and actually check for any borrowck errors.
-fn borrowck_check_region_constraints<'tcx>(
-    root_cx: &mut BorrowCheckRootCtxt<'_, 'tcx>,
+fn borrowck_check_region_constraints<'diag, 'tcx>(
+    root_cx: &mut BorrowCheckRootCtxt<'diag, 'tcx>,
+    diags_buffer: &mut BorrowckDiagnosticsBuffer<'diag, 'tcx>,
     CollectRegionConstraintsResult {
         infcx,
         body_owned,
@@ -462,7 +463,6 @@ fn borrowck_check_region_constraints<'tcx>(
     let movable_coroutine = body.coroutine.is_some()
         && tcx.coroutine_movability(def.to_def_id()) == hir::Movability::Movable;
 
-    let diags_buffer = &mut BorrowckDiagnosticsBuffer::default();
     // While promoteds should mostly be correct by construction, we need to check them for
     // invalid moves to detect moving out of arrays:`struct S; fn main() { &([S][0]); }`.
     for promoted_body in &promoted {
@@ -578,8 +578,6 @@ fn borrowck_check_region_constraints<'tcx>(
         closure_requirements: opt_closure_req,
         used_mut_upvars: mbcx.used_mut_upvars,
     };
-
-    diags_buffer.emit_errors(root_cx);
 
     if let Some(guar) = infcx.tainted_by_errors() {
         root_cx.set_tainted_by_errors(guar);

--- a/compiler/rustc_borrowck/src/nll.rs
+++ b/compiler/rustc_borrowck/src/nll.rs
@@ -287,8 +287,8 @@ pub(crate) fn emit_nll_mir<'tcx>(
     Ok(())
 }
 
-pub(super) fn dump_annotation<'tcx, 'infcx>(
-    infcx: &'infcx BorrowckInferCtxt<'tcx>,
+pub(super) fn dump_annotation<'tcx>(
+    infcx: &BorrowckInferCtxt<'tcx>,
     body: &Body<'tcx>,
     regioncx: &RegionInferenceContext<'tcx>,
     closure_region_requirements: &Option<ClosureRegionRequirements<'tcx>>,

--- a/compiler/rustc_borrowck/src/nll.rs
+++ b/compiler/rustc_borrowck/src/nll.rs
@@ -111,7 +111,7 @@ pub(crate) fn compute_closure_requirements_modulo_opaques<'tcx>(
 ///
 /// This may result in errors being reported.
 pub(crate) fn compute_regions<'tcx>(
-    root_cx: &BorrowCheckRootCtxt<'tcx>,
+    root_cx: &BorrowCheckRootCtxt<'_, 'tcx>,
     infcx: &BorrowckInferCtxt<'tcx>,
     body: &Body<'tcx>,
     location_table: &PoloniusLocationTable,

--- a/compiler/rustc_borrowck/src/root_cx.rs
+++ b/compiler/rustc_borrowck/src/root_cx.rs
@@ -12,7 +12,7 @@ use rustc_span::ErrorGuaranteed;
 use smallvec::SmallVec;
 
 use crate::consumers::BorrowckConsumer;
-use crate::diagnostics::BufferedDiag;
+use crate::diagnostics::BorrowckDiagnosticsBuffer;
 use crate::nll::compute_closure_requirements_modulo_opaques;
 use crate::region_infer::opaque_types::{
     UnexpectedHiddenRegion, apply_definition_site_hidden_types, clone_and_resolve_opaque_types,
@@ -46,7 +46,6 @@ pub(super) struct BorrowCheckRootCtxt<'diag, 'tcx: 'diag> {
     /// This should be `None` during normal compilation. See [`crate::consumers`] for more
     /// information on how this is used.
     pub consumer: Option<BorrowckConsumer<'tcx>>,
-    errors: Vec<BufferedDiag<'diag>>,
 }
 
 impl<'diag, 'tcx> BorrowCheckRootCtxt<'diag, 'tcx> {
@@ -65,7 +64,6 @@ impl<'diag, 'tcx> BorrowCheckRootCtxt<'diag, 'tcx> {
             propagated_borrowck_results: Default::default(),
             tainted_by_errors,
             consumer,
-            errors: Default::default(),
         }
     }
 
@@ -89,10 +87,9 @@ impl<'diag, 'tcx> BorrowCheckRootCtxt<'diag, 'tcx> {
     }
 
     pub(super) fn finalize(
-        mut self,
+        self,
     ) -> Result<&'tcx FxIndexMap<LocalDefId, ty::DefinitionSiteHiddenType<'tcx>>, ErrorGuaranteed>
     {
-        self.emit_errors();
         if let Some(guar) = self.tainted_by_errors.get() {
             Err(guar)
         } else {
@@ -168,7 +165,10 @@ impl<'diag, 'tcx> BorrowCheckRootCtxt<'diag, 'tcx> {
     /// which don't depend on opaque types. In this case they get removed from
     /// `collect_region_constraints_results` and the final result gets put into
     /// `propagated_borrowck_results`.
-    fn apply_closure_requirements_modulo_opaques(&mut self) {
+    fn apply_closure_requirements_modulo_opaques(
+        &mut self,
+        diags_buffer: &mut BorrowckDiagnosticsBuffer<'diag, 'tcx>,
+    ) {
         let mut closure_requirements_modulo_opaques = FxHashMap::default();
         // We need to `mem::take` both `self.collect_region_constraints_results` and
         // `input.deferred_closure_requirements` as we otherwise can't iterate over
@@ -226,7 +226,7 @@ impl<'diag, 'tcx> BorrowCheckRootCtxt<'diag, 'tcx> {
                 self.collect_region_constraints_results.insert(def_id, input);
             } else {
                 assert!(input.deferred_closure_requirements.is_empty());
-                let result = borrowck_check_region_constraints(self, input);
+                let result = borrowck_check_region_constraints(self, diags_buffer, input);
                 self.propagated_borrowck_results.insert(def_id, result);
             }
         }
@@ -281,6 +281,8 @@ impl<'diag, 'tcx> BorrowCheckRootCtxt<'diag, 'tcx> {
             self.collect_region_constraints_results.insert(def_id, result);
         }
 
+        let diags_buffer = &mut BorrowckDiagnosticsBuffer::default();
+
         // We now apply the closure requirements of nested bodies modulo
         // opaques. In case a body does not depend on opaque types, we
         // eagerly check its region constraints and use the final closure
@@ -288,7 +290,7 @@ impl<'diag, 'tcx> BorrowCheckRootCtxt<'diag, 'tcx> {
         //
         // We eagerly finish borrowck for bodies which don't depend on
         // opaques.
-        self.apply_closure_requirements_modulo_opaques();
+        self.apply_closure_requirements_modulo_opaques(diags_buffer);
 
         // We handle opaque type uses for all bodies together.
         self.handle_opaque_type_uses();
@@ -314,32 +316,9 @@ impl<'diag, 'tcx> BorrowCheckRootCtxt<'diag, 'tcx> {
                 );
             }
 
-            let result = borrowck_check_region_constraints(self, input);
+            let result = borrowck_check_region_constraints(self, diags_buffer, input);
             self.propagated_borrowck_results.insert(def_id, result);
         }
-    }
-
-    pub(crate) fn buffer_error(&mut self, buffered_diag: BufferedDiag<'_>) {
-        match buffered_diag {
-            BufferedDiag::Error(diag) => {
-                let diag = diag.with_dcx(self.dcx());
-                self.errors.push(BufferedDiag::Error(diag));
-            }
-            BufferedDiag::NonError(diag) => {
-                let diag = diag.with_dcx(self.dcx());
-                self.errors.push(BufferedDiag::NonError(diag));
-            }
-        }
-    }
-
-    pub(crate) fn emit_errors(&mut self) {
-        for buffered_diag in self.errors.drain(..) {
-            match buffered_diag {
-                BufferedDiag::Error(diag) => {
-                    diag.emit();
-                }
-                BufferedDiag::NonError(diag) => diag.emit(),
-            }
-        }
+        diags_buffer.emit_errors();
     }
 }

--- a/compiler/rustc_borrowck/src/root_cx.rs
+++ b/compiler/rustc_borrowck/src/root_cx.rs
@@ -1,8 +1,10 @@
+use std::cell::Cell;
 use std::mem;
 use std::rc::Rc;
 
 use rustc_abi::FieldIdx;
 use rustc_data_structures::fx::{FxHashMap, FxIndexMap};
+use rustc_errors::DiagCtxtHandle;
 use rustc_hir::def_id::LocalDefId;
 use rustc_middle::mir::ConstraintCategory;
 use rustc_middle::ty::{self, TyCtxt};
@@ -10,6 +12,7 @@ use rustc_span::ErrorGuaranteed;
 use smallvec::SmallVec;
 
 use crate::consumers::BorrowckConsumer;
+use crate::diagnostics::BufferedDiag;
 use crate::nll::compute_closure_requirements_modulo_opaques;
 use crate::region_infer::opaque_types::{
     UnexpectedHiddenRegion, apply_definition_site_hidden_types, clone_and_resolve_opaque_types,
@@ -24,7 +27,7 @@ use crate::{
 
 /// The shared context used by both the root as well as all its nested
 /// items.
-pub(super) struct BorrowCheckRootCtxt<'tcx> {
+pub(super) struct BorrowCheckRootCtxt<'diag, 'tcx: 'diag> {
     pub tcx: TyCtxt<'tcx>,
     root_def_id: LocalDefId,
     /// This contains fully resolved hidden types or `ty::Error`.
@@ -39,18 +42,20 @@ pub(super) struct BorrowCheckRootCtxt<'tcx> {
     collect_region_constraints_results:
         FxIndexMap<LocalDefId, CollectRegionConstraintsResult<'tcx>>,
     propagated_borrowck_results: FxHashMap<LocalDefId, PropagatedBorrowCheckResults<'tcx>>,
-    tainted_by_errors: Option<ErrorGuaranteed>,
+    tainted_by_errors: &'diag Cell<Option<ErrorGuaranteed>>,
     /// This should be `None` during normal compilation. See [`crate::consumers`] for more
     /// information on how this is used.
     pub consumer: Option<BorrowckConsumer<'tcx>>,
+    errors: Vec<BufferedDiag<'diag>>,
 }
 
-impl<'tcx> BorrowCheckRootCtxt<'tcx> {
+impl<'diag, 'tcx> BorrowCheckRootCtxt<'diag, 'tcx> {
     pub(super) fn new(
         tcx: TyCtxt<'tcx>,
         root_def_id: LocalDefId,
         consumer: Option<BorrowckConsumer<'tcx>>,
-    ) -> BorrowCheckRootCtxt<'tcx> {
+        tainted_by_errors: &'diag Cell<Option<ErrorGuaranteed>>,
+    ) -> BorrowCheckRootCtxt<'diag, 'tcx> {
         BorrowCheckRootCtxt {
             tcx,
             root_def_id,
@@ -58,8 +63,9 @@ impl<'tcx> BorrowCheckRootCtxt<'tcx> {
             unconstrained_hidden_type_errors: Default::default(),
             collect_region_constraints_results: Default::default(),
             propagated_borrowck_results: Default::default(),
-            tainted_by_errors: None,
+            tainted_by_errors,
             consumer,
+            errors: Default::default(),
         }
     }
 
@@ -67,8 +73,12 @@ impl<'tcx> BorrowCheckRootCtxt<'tcx> {
         self.root_def_id
     }
 
-    pub(super) fn set_tainted_by_errors(&mut self, guar: ErrorGuaranteed) {
-        self.tainted_by_errors = Some(guar);
+    pub(super) fn set_tainted_by_errors(&self, guar: ErrorGuaranteed) {
+        self.tainted_by_errors.set(Some(guar));
+    }
+
+    pub(super) fn dcx(&self) -> DiagCtxtHandle<'diag> {
+        self.tcx.dcx().taintable_handle(&self.tainted_by_errors)
     }
 
     pub(super) fn used_mut_upvars(
@@ -79,10 +89,11 @@ impl<'tcx> BorrowCheckRootCtxt<'tcx> {
     }
 
     pub(super) fn finalize(
-        self,
+        mut self,
     ) -> Result<&'tcx FxIndexMap<LocalDefId, ty::DefinitionSiteHiddenType<'tcx>>, ErrorGuaranteed>
     {
-        if let Some(guar) = self.tainted_by_errors {
+        self.emit_errors();
+        if let Some(guar) = self.tainted_by_errors.get() {
             Err(guar)
         } else {
             Ok(self.tcx.arena.alloc(self.hidden_types))
@@ -305,6 +316,30 @@ impl<'tcx> BorrowCheckRootCtxt<'tcx> {
 
             let result = borrowck_check_region_constraints(self, input);
             self.propagated_borrowck_results.insert(def_id, result);
+        }
+    }
+
+    pub(crate) fn buffer_error(&mut self, buffered_diag: BufferedDiag<'_>) {
+        match buffered_diag {
+            BufferedDiag::Error(diag) => {
+                let diag = diag.with_dcx(self.dcx());
+                self.errors.push(BufferedDiag::Error(diag));
+            }
+            BufferedDiag::NonError(diag) => {
+                let diag = diag.with_dcx(self.dcx());
+                self.errors.push(BufferedDiag::NonError(diag));
+            }
+        }
+    }
+
+    pub(crate) fn emit_errors(&mut self) {
+        for buffered_diag in self.errors.drain(..) {
+            match buffered_diag {
+                BufferedDiag::Error(diag) => {
+                    diag.emit();
+                }
+                BufferedDiag::NonError(diag) => diag.emit(),
+            }
         }
     }
 }

--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -95,7 +95,7 @@ mod relate_tys;
 /// - `move_data` -- move-data constructed when performing the maybe-init dataflow analysis
 /// - `location_map` -- map between MIR `Location` and `PointIndex`
 pub(crate) fn type_check<'tcx>(
-    root_cx: &BorrowCheckRootCtxt<'tcx>,
+    root_cx: &BorrowCheckRootCtxt<'_, 'tcx>,
     infcx: &BorrowckInferCtxt<'tcx>,
     body: &Body<'tcx>,
     promoted: &IndexSlice<Promoted, Body<'tcx>>,
@@ -228,7 +228,7 @@ enum FieldAccessError {
 /// way, it accrues region constraints -- these can later be used by
 /// NLL region checking.
 struct TypeChecker<'a, 'tcx> {
-    root_cx: &'a BorrowCheckRootCtxt<'tcx>,
+    root_cx: &'a BorrowCheckRootCtxt<'a, 'tcx>,
     infcx: &'a BorrowckInferCtxt<'tcx>,
     last_span: Span,
     body: &'a Body<'tcx>,

--- a/compiler/rustc_borrowck/src/universal_regions.rs
+++ b/compiler/rustc_borrowck/src/universal_regions.rs
@@ -448,12 +448,12 @@ impl<'tcx> UniversalRegions<'tcx> {
     }
 }
 
-struct UniversalRegionsBuilder<'infcx, 'tcx> {
-    infcx: &'infcx BorrowckInferCtxt<'tcx>,
+struct UniversalRegionsBuilder<'a, 'tcx> {
+    infcx: &'a BorrowckInferCtxt<'tcx>,
     mir_def: LocalDefId,
 }
 
-impl<'cx, 'tcx> UniversalRegionsBuilder<'cx, 'tcx> {
+impl<'tcx> UniversalRegionsBuilder<'_, 'tcx> {
     fn build(self) -> UniversalRegions<'tcx> {
         debug!("build(mir_def={:?})", self.mir_def);
 

--- a/compiler/rustc_borrowck/src/used_muts.rs
+++ b/compiler/rustc_borrowck/src/used_muts.rs
@@ -46,10 +46,10 @@ impl<'tcx> MirBorrowckCtxt<'_, '_, 'tcx> {
 
 /// MIR visitor for collecting used mutable variables.
 /// The 'visit lifetime represents the duration of the MIR walk.
-struct GatherUsedMutsVisitor<'a, 'b, 'infcx, 'tcx> {
+struct GatherUsedMutsVisitor<'a, 'b, 'diag, 'tcx> {
     temporary_used_locals: FxIndexSet<Local>,
     never_initialized_mut_locals: &'a mut FxIndexSet<Local>,
-    mbcx: &'a mut MirBorrowckCtxt<'b, 'infcx, 'tcx>,
+    mbcx: &'a mut MirBorrowckCtxt<'b, 'diag, 'tcx>,
 }
 
 impl GatherUsedMutsVisitor<'_, '_, '_, '_> {

--- a/tests/codegen-llvm/issues/signed-nonzero-matches.rs
+++ b/tests/codegen-llvm/issues/signed-nonzero-matches.rs
@@ -1,0 +1,24 @@
+// Matching a signed non-zero value against -1 or 1 should not require
+// branching code.
+
+//@ compile-flags: -Copt-level=3
+
+#![crate_type = "lib"]
+
+use std::num::NonZeroI32;
+
+// CHECK-LABEL: @signed_nonzero_matches
+#[no_mangle]
+pub fn signed_nonzero_matches(n: NonZeroI32) -> bool {
+    // CHECK-NOT: br i1
+    // CHECK: ret i1
+    matches!(n.get(), -1 | 1)
+}
+
+// CHECK-LABEL: @signed_nonzero_eq
+#[no_mangle]
+pub fn signed_nonzero_eq(n: NonZeroI32) -> bool {
+    // CHECK-NOT: br i1
+    // CHECK: ret i1
+    n.get() == -1 || n.get() == 1
+}

--- a/tests/ui/async-await/issue-74072-lifetime-name-annotations.stderr
+++ b/tests/ui/async-await/issue-74072-lifetime-name-annotations.stderr
@@ -10,18 +10,23 @@ LL |     *x += 1;
 LL |     y
    |     - returning this value requires that `*x` is borrowed for `'1`
 
-error[E0506]: cannot assign to `*x` because it is borrowed
-  --> $DIR/issue-74072-lifetime-name-annotations.rs:17:9
+error[E0716]: temporary value dropped while borrowed
+  --> $DIR/issue-74072-lifetime-name-annotations.rs:13:5
    |
-LL |     (async move || {
-   |                  - return type of async closure is &'1 i32
-...
-LL |         let y = &*x;
-   |                 --- `*x` is borrowed here
-LL |         *x += 1;
-   |         ^^^^^^^ `*x` is assigned to here but it was already borrowed
-LL |         y
-   |         - returning this value requires that `*x` is borrowed for `'1`
+LL |    pub fn async_closure(x: &mut i32) -> impl Future<Output=&i32> {
+   |                            - let's call the lifetime of this reference `'1`
+LL | //     (async move || {
+LL | ||
+LL | ||
+LL | ||         let y = &*x;
+LL | ||         *x += 1;
+LL | ||         y
+LL | ||     })()
+   | ||______^_- argument requires that borrow lasts for `'1`
+   | |_______|
+   |         creates a temporary value which is freed while still in use
+LL |    }
+   |    - temporary value is freed at the end of this statement
 
 error: lifetime may not live long enough
   --> $DIR/issue-74072-lifetime-name-annotations.rs:13:20
@@ -41,12 +46,25 @@ LL | |     })()
    |
    = note: closure implements `AsyncFnMut`, so references to captured variables can't escape the closure
 
-error[E0716]: temporary value dropped while borrowed
-  --> $DIR/issue-74072-lifetime-name-annotations.rs:13:5
+error[E0506]: cannot assign to `*x` because it is borrowed
+  --> $DIR/issue-74072-lifetime-name-annotations.rs:17:9
    |
-LL |    pub fn async_closure(x: &mut i32) -> impl Future<Output=&i32> {
-   |                            - let's call the lifetime of this reference `'1`
-LL | //     (async move || {
+LL |     (async move || {
+   |                  - return type of async closure is &'1 i32
+...
+LL |         let y = &*x;
+   |                 --- `*x` is borrowed here
+LL |         *x += 1;
+   |         ^^^^^^^ `*x` is assigned to here but it was already borrowed
+LL |         y
+   |         - returning this value requires that `*x` is borrowed for `'1`
+
+error[E0716]: temporary value dropped while borrowed
+  --> $DIR/issue-74072-lifetime-name-annotations.rs:23:5
+   |
+LL |    pub fn async_closure_explicit_return_type(x: &mut i32) -> impl Future<Output=&i32> {
+   |                                                 - let's call the lifetime of this reference `'1`
+LL | //     (async move || -> &i32 {
 LL | ||
 LL | ||
 LL | ||         let y = &*x;
@@ -58,19 +76,6 @@ LL | ||     })()
    |         creates a temporary value which is freed while still in use
 LL |    }
    |    - temporary value is freed at the end of this statement
-
-error[E0506]: cannot assign to `*x` because it is borrowed
-  --> $DIR/issue-74072-lifetime-name-annotations.rs:27:9
-   |
-LL |     (async move || -> &i32 {
-   |                          - return type of async closure is &'1 i32
-...
-LL |         let y = &*x;
-   |                 --- `*x` is borrowed here
-LL |         *x += 1;
-   |         ^^^^^^^ `*x` is assigned to here but it was already borrowed
-LL |         y
-   |         - returning this value requires that `*x` is borrowed for `'1`
 
 error: lifetime may not live long enough
   --> $DIR/issue-74072-lifetime-name-annotations.rs:23:28
@@ -90,23 +95,18 @@ LL | |     })()
    |
    = note: closure implements `AsyncFnMut`, so references to captured variables can't escape the closure
 
-error[E0716]: temporary value dropped while borrowed
-  --> $DIR/issue-74072-lifetime-name-annotations.rs:23:5
+error[E0506]: cannot assign to `*x` because it is borrowed
+  --> $DIR/issue-74072-lifetime-name-annotations.rs:27:9
    |
-LL |    pub fn async_closure_explicit_return_type(x: &mut i32) -> impl Future<Output=&i32> {
-   |                                                 - let's call the lifetime of this reference `'1`
-LL | //     (async move || -> &i32 {
-LL | ||
-LL | ||
-LL | ||         let y = &*x;
-LL | ||         *x += 1;
-LL | ||         y
-LL | ||     })()
-   | ||______^_- argument requires that borrow lasts for `'1`
-   | |_______|
-   |         creates a temporary value which is freed while still in use
-LL |    }
-   |    - temporary value is freed at the end of this statement
+LL |     (async move || -> &i32 {
+   |                          - return type of async closure is &'1 i32
+...
+LL |         let y = &*x;
+   |                 --- `*x` is borrowed here
+LL |         *x += 1;
+   |         ^^^^^^^ `*x` is assigned to here but it was already borrowed
+LL |         y
+   |         - returning this value requires that `*x` is borrowed for `'1`
 
 error[E0506]: cannot assign to `*x` because it is borrowed
   --> $DIR/issue-74072-lifetime-name-annotations.rs:35:9

--- a/tests/ui/async-await/issues/issue-62097.stderr
+++ b/tests/ui/async-await/issues/issue-62097.stderr
@@ -1,3 +1,17 @@
+error[E0521]: borrowed data escapes outside of method
+  --> $DIR/issue-62097.rs:13:9
+   |
+LL |     pub async fn run_dummy_fn(&self) {
+   |                               -----
+   |                               |
+   |                               `self` is a reference that is only valid in the method body
+   |                               let's call the lifetime of this reference `'1`
+LL |         foo(|| self.bar()).await;
+   |         ^^^^^^^^^^^^^^^^^^
+   |         |
+   |         `self` escapes the method body here
+   |         argument requires that `'1` must outlive `'static`
+
 error[E0373]: closure may outlive the current function, but it borrows `self`, which is owned by the current function
   --> $DIR/issue-62097.rs:13:13
    |
@@ -15,20 +29,6 @@ help: to force the closure to take ownership of `self` (and any other referenced
    |
 LL |         foo(move || self.bar()).await;
    |             ++++
-
-error[E0521]: borrowed data escapes outside of method
-  --> $DIR/issue-62097.rs:13:9
-   |
-LL |     pub async fn run_dummy_fn(&self) {
-   |                               -----
-   |                               |
-   |                               `self` is a reference that is only valid in the method body
-   |                               let's call the lifetime of this reference `'1`
-LL |         foo(|| self.bar()).await;
-   |         ^^^^^^^^^^^^^^^^^^
-   |         |
-   |         `self` escapes the method body here
-   |         argument requires that `'1` must outlive `'static`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/borrowck/borrowck-closures-mut-of-imm.stderr
+++ b/tests/ui/borrowck/borrowck-closures-mut-of-imm.stderr
@@ -4,12 +4,6 @@ error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
 LL |     let mut c1 = || set(&mut *x);
    |                         ^^^^^^^ cannot borrow as mutable
 
-error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
-  --> $DIR/borrowck-closures-mut-of-imm.rs:12:25
-   |
-LL |     let mut c2 = || set(&mut *x);
-   |                         ^^^^^^^ cannot borrow as mutable
-
 error[E0524]: two closures require unique access to `x` at the same time
   --> $DIR/borrowck-closures-mut-of-imm.rs:12:18
    |
@@ -25,6 +19,12 @@ LL |     let mut c2 = || set(&mut *x);
 ...
 LL |     c2(); c1();
    |           -- first borrow later used here
+
+error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
+  --> $DIR/borrowck-closures-mut-of-imm.rs:12:25
+   |
+LL |     let mut c2 = || set(&mut *x);
+   |                         ^^^^^^^ cannot borrow as mutable
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/borrowck/borrowck-describe-lvalue.stderr
+++ b/tests/ui/borrowck/borrowck-describe-lvalue.stderr
@@ -1,46 +1,3 @@
-error[E0499]: cannot borrow `x` as mutable more than once at a time
-  --> $DIR/borrowck-describe-lvalue.rs:253:13
-   |
-LL |             let y = &mut x;
-   |                     ------ first mutable borrow occurs here
-LL |             &mut x;
-   |             ^^^^^^ second mutable borrow occurs here
-LL |             *y = 1;
-   |             ------ first borrow later used here
-
-error[E0499]: cannot borrow `x` as mutable more than once at a time
-  --> $DIR/borrowck-describe-lvalue.rs:263:20
-   |
-LL |                    let y = &mut x;
-   |                            ------ first mutable borrow occurs here
-LL |                    &mut x;
-   |                    ^^^^^^ second mutable borrow occurs here
-LL |                    *y = 1;
-   |                    ------ first borrow later used here
-
-error: captured variable cannot escape `FnMut` closure body
-  --> $DIR/borrowck-describe-lvalue.rs:261:16
-   |
-LL |           let mut x = 0;
-   |               ----- variable defined here
-LL |              || {
-   |               - inferred to be a `FnMut` closure
-LL | /                || {
-LL | |                    let y = &mut x;
-   | |                                 - variable captured here
-LL | |                    &mut x;
-LL | |                    *y = 1;
-LL | |                    drop(y);
-LL | |                 }
-   | |_________________^ returns a closure that contains a reference to a captured variable, which then escapes the closure body
-   |
-   = note: `FnMut` closures only have access to their captured variables while they are executing...
-   = note: ...therefore, they cannot allow references to captured variables to escape
-help: consider adding 'move' keyword before the nested closure
-   |
-LL |                move || {
-   |                ++++
-
 error[E0503]: cannot use `f.x` because it was mutably borrowed
   --> $DIR/borrowck-describe-lvalue.rs:37:9
    |
@@ -322,6 +279,49 @@ LL |             &[_, F {x: ref xf, ..}] => println!("{}", xf),
 ...
 LL |         drop(x);
    |              - mutable borrow later used here
+
+error[E0499]: cannot borrow `x` as mutable more than once at a time
+  --> $DIR/borrowck-describe-lvalue.rs:253:13
+   |
+LL |             let y = &mut x;
+   |                     ------ first mutable borrow occurs here
+LL |             &mut x;
+   |             ^^^^^^ second mutable borrow occurs here
+LL |             *y = 1;
+   |             ------ first borrow later used here
+
+error: captured variable cannot escape `FnMut` closure body
+  --> $DIR/borrowck-describe-lvalue.rs:261:16
+   |
+LL |           let mut x = 0;
+   |               ----- variable defined here
+LL |              || {
+   |               - inferred to be a `FnMut` closure
+LL | /                || {
+LL | |                    let y = &mut x;
+   | |                                 - variable captured here
+LL | |                    &mut x;
+LL | |                    *y = 1;
+LL | |                    drop(y);
+LL | |                 }
+   | |_________________^ returns a closure that contains a reference to a captured variable, which then escapes the closure body
+   |
+   = note: `FnMut` closures only have access to their captured variables while they are executing...
+   = note: ...therefore, they cannot allow references to captured variables to escape
+help: consider adding 'move' keyword before the nested closure
+   |
+LL |                move || {
+   |                ++++
+
+error[E0499]: cannot borrow `x` as mutable more than once at a time
+  --> $DIR/borrowck-describe-lvalue.rs:263:20
+   |
+LL |                    let y = &mut x;
+   |                            ------ first mutable borrow occurs here
+LL |                    &mut x;
+   |                    ^^^^^^ second mutable borrow occurs here
+LL |                    *y = 1;
+   |                    ------ first borrow later used here
 
 error[E0502]: cannot borrow `*block.current` as immutable because it is also borrowed as mutable
   --> $DIR/borrowck-describe-lvalue.rs:206:29

--- a/tests/ui/borrowck/borrowck-multiple-captures.rs
+++ b/tests/ui/borrowck/borrowck-multiple-captures.rs
@@ -47,7 +47,6 @@ fn same_var_after_move() {
     let x: Box<_> = Box::new(1);
     drop(x);
     thread::spawn(move|| {
-        //~^ ERROR use of moved value: `x`
         drop(x);
         drop(x); //~ ERROR use of moved value: `x`
     });

--- a/tests/ui/borrowck/borrowck-multiple-captures.stderr
+++ b/tests/ui/borrowck/borrowck-multiple-captures.stderr
@@ -78,16 +78,6 @@ help: consider cloning the value if the performance cost is acceptable
 LL |     drop(x2.clone());
    |            ++++++++
 
-error[E0382]: use of moved value: `x`
-  --> $DIR/borrowck-multiple-captures.rs:41:14
-   |
-LL |         drop(x);
-   |              - value moved here
-LL |         drop(x);
-   |              ^ value used here after move
-   |
-   = note: move occurs because `x` has type `Box<i32>`, which does not implement the `Copy` trait
-
 error[E0505]: cannot move out of `x` because it is borrowed
   --> $DIR/borrowck-multiple-captures.rs:38:19
    |
@@ -110,7 +100,7 @@ LL |     let p = &x.clone();
    |               ++++++++
 
 error[E0382]: use of moved value: `x`
-  --> $DIR/borrowck-multiple-captures.rs:52:14
+  --> $DIR/borrowck-multiple-captures.rs:41:14
    |
 LL |         drop(x);
    |              - value moved here
@@ -120,24 +110,16 @@ LL |         drop(x);
    = note: move occurs because `x` has type `Box<i32>`, which does not implement the `Copy` trait
 
 error[E0382]: use of moved value: `x`
-  --> $DIR/borrowck-multiple-captures.rs:49:19
+  --> $DIR/borrowck-multiple-captures.rs:51:14
    |
-LL |     let x: Box<_> = Box::new(1);
-   |         - move occurs because `x` has type `Box<i32>`, which does not implement the `Copy` trait
-LL |     drop(x);
-   |          - value moved here
-LL |     thread::spawn(move|| {
-   |                   ^^^^^^ value used here after move
-LL |
 LL |         drop(x);
-   |              - use occurs due to use in closure
+   |              - value moved here
+LL |         drop(x);
+   |              ^ value used here after move
    |
-help: consider cloning the value if the performance cost is acceptable
-   |
-LL |     drop(x.clone());
-   |           ++++++++
+   = note: move occurs because `x` has type `Box<i32>`, which does not implement the `Copy` trait
 
-error: aborting due to 8 previous errors
+error: aborting due to 7 previous errors
 
 Some errors have detailed explanations: E0382, E0505.
 For more information about an error, try `rustc --explain E0382`.

--- a/tests/ui/borrowck/closure-upvar-named-lifetime.stderr
+++ b/tests/ui/borrowck/closure-upvar-named-lifetime.stderr
@@ -1,3 +1,25 @@
+error[E0700]: hidden type for `impl Fn(RefCell<HashMap<String, String>>)` captures lifetime that does not appear in bounds
+  --> $DIR/closure-upvar-named-lifetime.rs:17:5
+   |
+LL |   fn apply<'a>(
+   |            -- hidden type `{closure@$DIR/closure-upvar-named-lifetime.rs:17:5: 17:15}` captures the lifetime `'a` as defined here
+LL |       f: Arc<dyn Fn(Entry<'a, String, String>) + 'a>,
+LL |   ) -> impl Fn(RefCell<HashMap<String, String>>)
+   |        ----------------------------------------- opaque type defined here
+LL |   {
+LL | /     move |map| {
+LL | |
+LL | |         let value = map.borrow_mut().entry("foo".to_string());
+...  |
+LL | |         f(wrapped_value);
+LL | |     }
+   | |_____^
+   |
+help: add a `use<...>` bound to explicitly capture `'a`
+   |
+LL | ) -> impl Fn(RefCell<HashMap<String, String>>) + use<'a>
+   |                                                +++++++++
+
 error[E0597]: `map` does not live long enough
   --> $DIR/closure-upvar-named-lifetime.rs:19:21
    |
@@ -36,11 +58,11 @@ note: requirement that the value outlives `'a` introduced here
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
 
 error[E0700]: hidden type for `impl Fn(RefCell<HashMap<String, String>>)` captures lifetime that does not appear in bounds
-  --> $DIR/closure-upvar-named-lifetime.rs:17:5
+  --> $DIR/closure-upvar-named-lifetime.rs:32:5
    |
-LL |   fn apply<'a>(
-   |            -- hidden type `{closure@$DIR/closure-upvar-named-lifetime.rs:17:5: 17:15}` captures the lifetime `'a` as defined here
-LL |       f: Arc<dyn Fn(Entry<'a, String, String>) + 'a>,
+LL |   fn apply_box<'a>(
+   |                -- hidden type `{closure@$DIR/closure-upvar-named-lifetime.rs:32:5: 32:15}` captures the lifetime `'a` as defined here
+LL |       f: Box<dyn Fn(Entry<'a, String, String>) + 'a>,
 LL |   ) -> impl Fn(RefCell<HashMap<String, String>>)
    |        ----------------------------------------- opaque type defined here
 LL |   {
@@ -48,7 +70,7 @@ LL | /     move |map| {
 LL | |
 LL | |         let value = map.borrow_mut().entry("foo".to_string());
 ...  |
-LL | |         f(wrapped_value);
+LL | |         f(value);
 LL | |     }
    | |_____^
    |
@@ -87,28 +109,6 @@ LL |         let value = map.borrow_mut().entry("foo".to_string());
 ...
 LL |         f(value);
    |         -------- argument requires that borrow lasts for `'a`
-
-error[E0700]: hidden type for `impl Fn(RefCell<HashMap<String, String>>)` captures lifetime that does not appear in bounds
-  --> $DIR/closure-upvar-named-lifetime.rs:32:5
-   |
-LL |   fn apply_box<'a>(
-   |                -- hidden type `{closure@$DIR/closure-upvar-named-lifetime.rs:32:5: 32:15}` captures the lifetime `'a` as defined here
-LL |       f: Box<dyn Fn(Entry<'a, String, String>) + 'a>,
-LL |   ) -> impl Fn(RefCell<HashMap<String, String>>)
-   |        ----------------------------------------- opaque type defined here
-LL |   {
-LL | /     move |map| {
-LL | |
-LL | |         let value = map.borrow_mut().entry("foo".to_string());
-...  |
-LL | |         f(value);
-LL | |     }
-   | |_____^
-   |
-help: add a `use<...>` bound to explicitly capture `'a`
-   |
-LL | ) -> impl Fn(RefCell<HashMap<String, String>>) + use<'a>
-   |                                                +++++++++
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/borrowck/issue-103624.stderr
+++ b/tests/ui/borrowck/issue-103624.stderr
@@ -1,3 +1,22 @@
+error[E0521]: borrowed data escapes outside of method
+  --> $DIR/issue-103624.rs:14:9
+   |
+LL |       async fn foo(&self) {
+   |                    -----
+   |                    |
+   |                    `self` is a reference that is only valid in the method body
+   |                    let's call the lifetime of this reference `'1`
+LL |           let bar = self.b.bar().await;
+LL | /         spawn_blocking(move || {
+LL | |
+LL | |             self.b;
+LL | |
+LL | |         })
+   | |          ^
+   | |          |
+   | |__________`self` escapes the method body here
+   |            argument requires that `'1` must outlive `'static`
+
 error[E0507]: cannot move out of `self.b`, as `self` is a captured variable in an `Fn` closure
   --> $DIR/issue-103624.rs:16:13
    |
@@ -26,25 +45,6 @@ LL |             self.b;
 ...
 LL | struct StructB {}
    | ^^^^^^^^^^^^^^ consider implementing `Clone` for this type
-
-error[E0521]: borrowed data escapes outside of method
-  --> $DIR/issue-103624.rs:14:9
-   |
-LL |       async fn foo(&self) {
-   |                    -----
-   |                    |
-   |                    `self` is a reference that is only valid in the method body
-   |                    let's call the lifetime of this reference `'1`
-LL |           let bar = self.b.bar().await;
-LL | /         spawn_blocking(move || {
-LL | |
-LL | |             self.b;
-LL | |
-LL | |         })
-   | |          ^
-   | |          |
-   | |__________`self` escapes the method body here
-   |            argument requires that `'1` must outlive `'static`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/borrowck/overwrite-anon-late-param-regions.stderr
+++ b/tests/ui/borrowck/overwrite-anon-late-param-regions.stderr
@@ -1,12 +1,3 @@
-error: lifetime may not live long enough
-  --> $DIR/overwrite-anon-late-param-regions.rs:11:9
-   |
-LL |     |x| x
-   |      -  ^ closure was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
-   |      |
-   |      has type `(&str, &'1 str)`
-   |      has type `(&'2 str, &str)`
-
 error[E0792]: expected generic lifetime parameter, found `'a`
   --> $DIR/overwrite-anon-late-param-regions.rs:11:5
    |
@@ -15,6 +6,15 @@ LL | type Opaque2<'a> = impl Sized + 'a;
 ...
 LL |     |x| x
    |     ^^^^^
+
+error: lifetime may not live long enough
+  --> $DIR/overwrite-anon-late-param-regions.rs:11:9
+   |
+LL |     |x| x
+   |      -  ^ closure was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |      |
+   |      has type `(&str, &'1 str)`
+   |      has type `(&'2 str, &str)`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/closures/aliasability-violation-with-closure-21600.stderr
+++ b/tests/ui/closures/aliasability-violation-with-closure-21600.stderr
@@ -1,19 +1,4 @@
 error[E0596]: cannot borrow `x` as mutable, as it is a captured variable in a `Fn` closure
-  --> $DIR/aliasability-violation-with-closure-21600.rs:15:20
-   |
-LL | fn call_it<F>(f: F) where F: Fn() { f(); }
-   |                  - change this to accept `FnMut` instead of `Fn`
-...
-LL |     let mut x = A;
-   |         ----- `x` declared here, outside the closure
-...
-LL |         call_it(|| x.gen_mut());
-   |         ------- -- ^ cannot borrow as mutable
-   |         |       |
-   |         |       in this closure
-   |         expects `Fn` instead of `FnMut`
-
-error[E0596]: cannot borrow `x` as mutable, as it is a captured variable in a `Fn` closure
   --> $DIR/aliasability-violation-with-closure-21600.rs:15:17
    |
 LL | fn call_it<F>(f: F) where F: Fn() { f(); }
@@ -30,6 +15,21 @@ LL |         call_it(|| x.gen_mut());
    |                 ^^ - mutable borrow occurs due to use of `x` in closure
    |                 |
    |                 cannot borrow as mutable
+
+error[E0596]: cannot borrow `x` as mutable, as it is a captured variable in a `Fn` closure
+  --> $DIR/aliasability-violation-with-closure-21600.rs:15:20
+   |
+LL | fn call_it<F>(f: F) where F: Fn() { f(); }
+   |                  - change this to accept `FnMut` instead of `Fn`
+...
+LL |     let mut x = A;
+   |         ----- `x` declared here, outside the closure
+...
+LL |         call_it(|| x.gen_mut());
+   |         ------- -- ^ cannot borrow as mutable
+   |         |       |
+   |         |       in this closure
+   |         expects `Fn` instead of `FnMut`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/closures/wrong-closure-arg-suggestion-125325.stderr
+++ b/tests/ui/closures/wrong-closure-arg-suggestion-125325.stderr
@@ -28,15 +28,6 @@ LL |     func(|| x = ())
    |     |    in this closure
    |     expects `Fn` instead of `FnMut`
 
-error[E0594]: cannot assign to `self.counter`, as `Fn` closures cannot mutate their captured variables
-  --> $DIR/wrong-closure-arg-suggestion-125325.rs:46:28
-   |
-LL |         take(|_| to_fn(|_| self.counter += 1));
-   |                  ----- --- ^^^^^^^^^^^^^^^^^ cannot assign
-   |                  |     |
-   |                  |     in this closure
-   |                  expects `Fn` instead of `FnMut`
-
 error: lifetime may not live long enough
   --> $DIR/wrong-closure-arg-suggestion-125325.rs:46:18
    |
@@ -62,14 +53,13 @@ LL | fn take<F, U>(_: F)
    |                  - change this to accept `FnMut` instead of `Fn`
 
 error[E0594]: cannot assign to `self.counter`, as `Fn` closures cannot mutate their captured variables
-  --> $DIR/wrong-closure-arg-suggestion-125325.rs:54:34
+  --> $DIR/wrong-closure-arg-suggestion-125325.rs:46:28
    |
-LL |         P.flat_map(|_| P.map(|_| self.counter += 1));
-   |                          --------^^^^^^^^^^^^^^^^^-
-   |                          |   |   |
-   |                          |   |   cannot assign
-   |                          |   in this closure
-   |                          expects `Fn` instead of `FnMut`
+LL |         take(|_| to_fn(|_| self.counter += 1));
+   |                  ----- --- ^^^^^^^^^^^^^^^^^ cannot assign
+   |                  |     |
+   |                  |     in this closure
+   |                  expects `Fn` instead of `FnMut`
 
 error: lifetime may not live long enough
   --> $DIR/wrong-closure-arg-suggestion-125325.rs:54:24
@@ -96,6 +86,16 @@ LL |         P.flat_map(|_| P.map(|_| self.counter += 1));
    |           |        |         cannot borrow as mutable
    |           |        in this closure
    |           expects `Fn` instead of `FnMut`
+
+error[E0594]: cannot assign to `self.counter`, as `Fn` closures cannot mutate their captured variables
+  --> $DIR/wrong-closure-arg-suggestion-125325.rs:54:34
+   |
+LL |         P.flat_map(|_| P.map(|_| self.counter += 1));
+   |                          --------^^^^^^^^^^^^^^^^^-
+   |                          |   |   |
+   |                          |   |   cannot assign
+   |                          |   in this closure
+   |                          expects `Fn` instead of `FnMut`
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/coroutine/auto-trait-regions.stderr
+++ b/tests/ui/coroutine/auto-trait-regions.stderr
@@ -1,3 +1,15 @@
+error: implementation of `Foo` is not general enough
+  --> $DIR/auto-trait-regions.rs:31:5
+   |
+LL |     let generator = #[coroutine] move || {
+   |                                  ------- this coroutine captures a value whose type is not `Foo`
+...
+LL |     assert_foo(generator);
+   |     ^^^^^^^^^^^^^^^^^^^^^ implementation of `Foo` is not general enough
+   |
+   = note: `&'0 OnlyFooIfStaticRef` must implement `Foo`, for any lifetime `'0`...
+   = note: ...but `Foo` is actually implemented for the type `&'static OnlyFooIfStaticRef`
+
 error[E0626]: borrow may still be in use when coroutine yields
   --> $DIR/auto-trait-regions.rs:45:19
    |
@@ -29,18 +41,6 @@ help: add `static` to mark this coroutine as unmovable
    |
 LL |     let generator = #[coroutine] static move || {
    |                                  ++++++
-
-error: implementation of `Foo` is not general enough
-  --> $DIR/auto-trait-regions.rs:31:5
-   |
-LL |     let generator = #[coroutine] move || {
-   |                                  ------- this coroutine captures a value whose type is not `Foo`
-...
-LL |     assert_foo(generator);
-   |     ^^^^^^^^^^^^^^^^^^^^^ implementation of `Foo` is not general enough
-   |
-   = note: `&'0 OnlyFooIfStaticRef` must implement `Foo`, for any lifetime `'0`...
-   = note: ...but `Foo` is actually implemented for the type `&'static OnlyFooIfStaticRef`
 
 error: implementation of `Foo` is not general enough
   --> $DIR/auto-trait-regions.rs:51:5

--- a/tests/ui/lifetimes/issue-79187-2.stderr
+++ b/tests/ui/lifetimes/issue-79187-2.stderr
@@ -1,21 +1,3 @@
-error: lifetime may not live long enough
-  --> $DIR/issue-79187-2.rs:11:24
-   |
-LL |     take_foo(|a: &i32| a);
-   |                  -   - ^ returning this value requires that `'1` must outlive `'2`
-   |                  |   |
-   |                  |   return type of closure is &'2 i32
-   |                  let's call the lifetime of this reference `'1`
-
-error: lifetime may not live long enough
-  --> $DIR/issue-79187-2.rs:14:34
-   |
-LL |     take_foo(|a: &i32| -> &i32 { a });
-   |                  -        -      ^ returning this value requires that `'1` must outlive `'2`
-   |                  |        |
-   |                  |        let's call the lifetime of this reference `'2`
-   |                  let's call the lifetime of this reference `'1`
-
 error: implementation of `FnOnce` is not general enough
   --> $DIR/issue-79187-2.rs:8:5
    |
@@ -56,6 +38,15 @@ note: the lifetime requirement is introduced here
 LL | fn take_foo(_: impl Foo) {}
    |                     ^^^
 
+error: lifetime may not live long enough
+  --> $DIR/issue-79187-2.rs:11:24
+   |
+LL |     take_foo(|a: &i32| a);
+   |                  -   - ^ returning this value requires that `'1` must outlive `'2`
+   |                  |   |
+   |                  |   return type of closure is &'2 i32
+   |                  let's call the lifetime of this reference `'1`
+
 error[E0308]: mismatched types
   --> $DIR/issue-79187-2.rs:14:5
    |
@@ -69,6 +60,15 @@ note: the lifetime requirement is introduced here
    |
 LL | fn take_foo(_: impl Foo) {}
    |                     ^^^
+
+error: lifetime may not live long enough
+  --> $DIR/issue-79187-2.rs:14:34
+   |
+LL |     take_foo(|a: &i32| -> &i32 { a });
+   |                  -        -      ^ returning this value requires that `'1` must outlive `'2`
+   |                  |        |
+   |                  |        let's call the lifetime of this reference `'2`
+   |                  let's call the lifetime of this reference `'1`
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/macros/return_from_external_macro.stderr
+++ b/tests/ui/macros/return_from_external_macro.stderr
@@ -1,14 +1,3 @@
-error[E0515]: cannot return reference to temporary value
-  --> $DIR/return_from_external_macro.rs:7:13
-   |
-LL |     drop(|| ret_from_ext::foo!());
-   |             ^^^^^^^^^^^^^^^^^^^^
-   |             |
-   |             returns a reference to data owned by the current function
-   |             temporary value created here
-   |
-   = note: this error originates in the macro `ret_from_ext::foo` (in Nightly builds, run with -Z macro-backtrace for more info)
-
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/return_from_external_macro.rs:10:5
    |
@@ -20,6 +9,17 @@ LL |     ret_from_ext::foo!()
 LL |
 LL | }
    | - temporary value is freed at the end of this statement
+   |
+   = note: this error originates in the macro `ret_from_ext::foo` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0515]: cannot return reference to temporary value
+  --> $DIR/return_from_external_macro.rs:7:13
+   |
+LL |     drop(|| ret_from_ext::foo!());
+   |             ^^^^^^^^^^^^^^^^^^^^
+   |             |
+   |             returns a reference to data owned by the current function
+   |             temporary value created here
    |
    = note: this error originates in the macro `ret_from_ext::foo` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/nll/closure-captures.stderr
+++ b/tests/ui/nll/closure-captures.stderr
@@ -74,17 +74,6 @@ LL |         ||
 LL |     x = 1;});
    |     - mutable borrow occurs due to use of `x` in closure
 
-error[E0594]: cannot assign to `x`, as it is not declared as mutable
-  --> $DIR/closure-captures.rs:40:10
-   |
-LL |          x = 1;}
-   |          ^^^^^ cannot assign
-   |
-help: consider changing this to be mutable
-   |
-LL | fn two_closures_ref(mut x: i32) {
-   |                     +++
-
 error[E0596]: cannot borrow `x` as mutable, as it is a captured variable in a `Fn` closure
   --> $DIR/closure-captures.rs:39:9
    |
@@ -103,10 +92,10 @@ LL |          x = 1;}
    |          - mutable borrow occurs due to use of `x` in closure
 
 error[E0594]: cannot assign to `x`, as it is not declared as mutable
-  --> $DIR/closure-captures.rs:44:5
+  --> $DIR/closure-captures.rs:40:10
    |
-LL |     x = 1;});
-   |     ^^^^^ cannot assign
+LL |          x = 1;}
+   |          ^^^^^ cannot assign
    |
 help: consider changing this to be mutable
    |
@@ -127,6 +116,17 @@ LL |         ||
    |         ^^ cannot borrow as mutable
 LL |     x = 1;});
    |     - mutable borrow occurs due to use of `x` in closure
+
+error[E0594]: cannot assign to `x`, as it is not declared as mutable
+  --> $DIR/closure-captures.rs:44:5
+   |
+LL |     x = 1;});
+   |     ^^^^^ cannot assign
+   |
+help: consider changing this to be mutable
+   |
+LL | fn two_closures_ref(mut x: i32) {
+   |                     +++
 
 error[E0596]: cannot borrow `x` as mutable, as it is a captured variable in a `Fn` closure
   --> $DIR/closure-captures.rs:49:9

--- a/tests/ui/nll/closure-requirements/escape-argument-callee.stderr
+++ b/tests/ui/nll/closure-requirements/escape-argument-callee.stderr
@@ -13,6 +13,14 @@ LL |         let mut closure = expect_sig(|p, y| *p = y);
    = note: late-bound region is '?2
    = note: late-bound region is '?3
 
+note: no external requirements
+  --> $DIR/escape-argument-callee.rs:20:1
+   |
+LL | fn test() {
+   | ^^^^^^^^^
+   |
+   = note: defining type: test
+
 error: lifetime may not live long enough
   --> $DIR/escape-argument-callee.rs:26:45
    |
@@ -21,14 +29,6 @@ LL |         let mut closure = expect_sig(|p, y| *p = y);
    |                                       |  |
    |                                       |  has type `&'1 i32`
    |                                       has type `&'?1 mut &'2 i32`
-
-note: no external requirements
-  --> $DIR/escape-argument-callee.rs:20:1
-   |
-LL | fn test() {
-   | ^^^^^^^^^
-   |
-   = note: defining type: test
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-comparing-against-free.stderr
+++ b/tests/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-comparing-against-free.stderr
@@ -11,6 +11,14 @@ LL |     foo(cell, |cell_a, cell_x| {
            ]
    = note: late-bound region is '?2
 
+note: no external requirements
+  --> $DIR/propagate-approximated-shorter-to-static-comparing-against-free.rs:18:1
+   |
+LL | fn case1() {
+   | ^^^^^^^^^^
+   |
+   = note: defining type: case1
+
 error[E0521]: borrowed data escapes outside of closure
   --> $DIR/propagate-approximated-shorter-to-static-comparing-against-free.rs:22:9
    |
@@ -24,14 +32,6 @@ LL |         cell_a.set(cell_x.get()); // forces 'x: 'a, error in closure
    = note: requirement occurs because of the type `Cell<&'?9 u32>`, which makes the generic argument `&'?9 u32` invariant
    = note: the struct `Cell<T>` is invariant over the parameter `T`
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
-
-note: no external requirements
-  --> $DIR/propagate-approximated-shorter-to-static-comparing-against-free.rs:18:1
-   |
-LL | fn case1() {
-   | ^^^^^^^^^^
-   |
-   = note: defining type: case1
 
 note: external requirements
   --> $DIR/propagate-approximated-shorter-to-static-comparing-against-free.rs:35:15

--- a/tests/ui/nll/closure-requirements/propagate-fail-to-approximate-longer-no-bounds.stderr
+++ b/tests/ui/nll/closure-requirements/propagate-fail-to-approximate-longer-no-bounds.stderr
@@ -17,6 +17,14 @@ LL |     establish_relationships(&cell_a, &cell_b, |_outlives, x, y| {
    = note: late-bound region is '?2
    = note: late-bound region is '?3
 
+note: no external requirements
+  --> $DIR/propagate-fail-to-approximate-longer-no-bounds.rs:34:1
+   |
+LL | fn supply<'a, 'b>(cell_a: Cell<&'a u32>, cell_b: Cell<&'b u32>) {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: defining type: supply
+
 error: lifetime may not live long enough
   --> $DIR/propagate-fail-to-approximate-longer-no-bounds.rs:37:9
    |
@@ -31,14 +39,6 @@ LL |         demand_y(x, y, x.get())
    = note: requirement occurs because of the type `Cell<&'?37 u32>`, which makes the generic argument `&'?37 u32` invariant
    = note: the struct `Cell<T>` is invariant over the parameter `T`
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
-
-note: no external requirements
-  --> $DIR/propagate-fail-to-approximate-longer-no-bounds.rs:34:1
-   |
-LL | fn supply<'a, 'b>(cell_a: Cell<&'a u32>, cell_b: Cell<&'b u32>) {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: defining type: supply
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/nll/closure-requirements/propagate-fail-to-approximate-longer-wrong-bounds.stderr
+++ b/tests/ui/nll/closure-requirements/propagate-fail-to-approximate-longer-wrong-bounds.stderr
@@ -18,6 +18,14 @@ LL |     establish_relationships(&cell_a, &cell_b, |_outlives1, _outlives2, x, y
    = note: late-bound region is '?3
    = note: late-bound region is '?4
 
+note: no external requirements
+  --> $DIR/propagate-fail-to-approximate-longer-wrong-bounds.rs:38:1
+   |
+LL | fn supply<'a, 'b>(cell_a: Cell<&'a u32>, cell_b: Cell<&'b u32>) {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: defining type: supply
+
 error: lifetime may not live long enough
   --> $DIR/propagate-fail-to-approximate-longer-wrong-bounds.rs:41:9
    |
@@ -32,14 +40,6 @@ LL |         demand_y(x, y, x.get())
    = note: requirement occurs because of the type `Cell<&'?43 u32>`, which makes the generic argument `&'?43 u32` invariant
    = note: the struct `Cell<T>` is invariant over the parameter `T`
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
-
-note: no external requirements
-  --> $DIR/propagate-fail-to-approximate-longer-wrong-bounds.rs:38:1
-   |
-LL | fn supply<'a, 'b>(cell_a: Cell<&'a u32>, cell_b: Cell<&'b u32>) {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: defining type: supply
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/nll/closure-requirements/return-wrong-bound-region.stderr
+++ b/tests/ui/nll/closure-requirements/return-wrong-bound-region.stderr
@@ -12,6 +12,14 @@ LL |     expect_sig(|a, b| b); // ought to return `a`
    = note: late-bound region is '?1
    = note: late-bound region is '?2
 
+note: no external requirements
+  --> $DIR/return-wrong-bound-region.rs:10:1
+   |
+LL | fn test() {
+   | ^^^^^^^^^
+   |
+   = note: defining type: test
+
 error: lifetime may not live long enough
   --> $DIR/return-wrong-bound-region.rs:11:23
    |
@@ -20,14 +28,6 @@ LL |     expect_sig(|a, b| b); // ought to return `a`
    |                 |  |
    |                 |  has type `&'1 i32`
    |                 has type `&'2 i32`
-
-note: no external requirements
-  --> $DIR/return-wrong-bound-region.rs:10:1
-   |
-LL | fn test() {
-   | ^^^^^^^^^
-   |
-   = note: defining type: test
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/pin-ergonomics/pattern-matching-deref-pattern.normal.stderr
+++ b/tests/ui/pin-ergonomics/pattern-matching-deref-pattern.normal.stderr
@@ -1,23 +1,4 @@
 error[E0507]: cannot move out of a shared reference
-  --> $DIR/pattern-matching-deref-pattern.rs:48:28
-   |
-LL |         let Foo { x, y } = foo.as_mut();
-   |                   -  -     ^^^^^^^^^^^^
-   |                   |  |
-   |                   |  ...and here
-   |                   data moved here
-   |
-   = note: move occurs because these variables have types that don't implement the `Copy` trait
-help: consider borrowing the pattern binding
-   |
-LL |         let Foo { ref x, y } = foo.as_mut();
-   |                   +++
-help: consider borrowing the pattern binding
-   |
-LL |         let Foo { x, ref y } = foo.as_mut();
-   |                      +++
-
-error[E0507]: cannot move out of a shared reference
   --> $DIR/pattern-matching-deref-pattern.rs:38:24
    |
 LL |     let Foo { x, y } = foo.as_mut();
@@ -37,9 +18,9 @@ LL |     let Foo { x, ref y } = foo.as_mut();
    |                  +++
 
 error[E0507]: cannot move out of a shared reference
-  --> $DIR/pattern-matching-deref-pattern.rs:70:28
+  --> $DIR/pattern-matching-deref-pattern.rs:48:28
    |
-LL |         let Foo { x, y } = foo.as_ref();
+LL |         let Foo { x, y } = foo.as_mut();
    |                   -  -     ^^^^^^^^^^^^
    |                   |  |
    |                   |  ...and here
@@ -48,11 +29,11 @@ LL |         let Foo { x, y } = foo.as_ref();
    = note: move occurs because these variables have types that don't implement the `Copy` trait
 help: consider borrowing the pattern binding
    |
-LL |         let Foo { ref x, y } = foo.as_ref();
+LL |         let Foo { ref x, y } = foo.as_mut();
    |                   +++
 help: consider borrowing the pattern binding
    |
-LL |         let Foo { x, ref y } = foo.as_ref();
+LL |         let Foo { x, ref y } = foo.as_mut();
    |                      +++
 
 error[E0507]: cannot move out of a shared reference
@@ -75,23 +56,23 @@ LL |     let Foo { x, ref y } = foo.as_ref();
    |                  +++
 
 error[E0507]: cannot move out of a shared reference
-  --> $DIR/pattern-matching-deref-pattern.rs:92:25
+  --> $DIR/pattern-matching-deref-pattern.rs:70:28
    |
-LL |         let Bar(x, y) = bar.as_mut();
-   |                 -  -    ^^^^^^^^^^^^
-   |                 |  |
-   |                 |  ...and here
-   |                 data moved here
+LL |         let Foo { x, y } = foo.as_ref();
+   |                   -  -     ^^^^^^^^^^^^
+   |                   |  |
+   |                   |  ...and here
+   |                   data moved here
    |
    = note: move occurs because these variables have types that don't implement the `Copy` trait
 help: consider borrowing the pattern binding
    |
-LL |         let Bar(ref x, y) = bar.as_mut();
-   |                 +++
+LL |         let Foo { ref x, y } = foo.as_ref();
+   |                   +++
 help: consider borrowing the pattern binding
    |
-LL |         let Bar(x, ref y) = bar.as_mut();
-   |                    +++
+LL |         let Foo { x, ref y } = foo.as_ref();
+   |                      +++
 
 error[E0507]: cannot move out of a shared reference
   --> $DIR/pattern-matching-deref-pattern.rs:82:21
@@ -113,9 +94,9 @@ LL |     let Bar(x, ref y) = bar.as_mut();
    |                +++
 
 error[E0507]: cannot move out of a shared reference
-  --> $DIR/pattern-matching-deref-pattern.rs:114:25
+  --> $DIR/pattern-matching-deref-pattern.rs:92:25
    |
-LL |         let Bar(x, y) = bar.as_ref();
+LL |         let Bar(x, y) = bar.as_mut();
    |                 -  -    ^^^^^^^^^^^^
    |                 |  |
    |                 |  ...and here
@@ -124,11 +105,11 @@ LL |         let Bar(x, y) = bar.as_ref();
    = note: move occurs because these variables have types that don't implement the `Copy` trait
 help: consider borrowing the pattern binding
    |
-LL |         let Bar(ref x, y) = bar.as_ref();
+LL |         let Bar(ref x, y) = bar.as_mut();
    |                 +++
 help: consider borrowing the pattern binding
    |
-LL |         let Bar(x, ref y) = bar.as_ref();
+LL |         let Bar(x, ref y) = bar.as_mut();
    |                    +++
 
 error[E0507]: cannot move out of a shared reference
@@ -149,6 +130,25 @@ help: consider borrowing the pattern binding
    |
 LL |     let Bar(x, ref y) = bar.as_ref();
    |                +++
+
+error[E0507]: cannot move out of a shared reference
+  --> $DIR/pattern-matching-deref-pattern.rs:114:25
+   |
+LL |         let Bar(x, y) = bar.as_ref();
+   |                 -  -    ^^^^^^^^^^^^
+   |                 |  |
+   |                 |  ...and here
+   |                 data moved here
+   |
+   = note: move occurs because these variables have types that don't implement the `Copy` trait
+help: consider borrowing the pattern binding
+   |
+LL |         let Bar(ref x, y) = bar.as_ref();
+   |                 +++
+help: consider borrowing the pattern binding
+   |
+LL |         let Bar(x, ref y) = bar.as_ref();
+   |                    +++
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/regions/lifetime-not-long-enough-suggestion-regression-test-124563.stderr
+++ b/tests/ui/regions/lifetime-not-long-enough-suggestion-regression-test-124563.stderr
@@ -16,21 +16,6 @@ LL | impl<'a, 'b, T> Foo for FooImpl<'a, 'b, T>
    |          ^^
 
 error: lifetime may not live long enough
-  --> $DIR/lifetime-not-long-enough-suggestion-regression-test-124563.rs:23:21
-   |
-LL |         self.enter_scope(|ctx| {
-   |                           ---
-   |                           |
-   |                           has type `&'1 mut FooImpl<'_, '_, T>`
-   |                           has type `&mut FooImpl<'2, '_, T>`
-LL |             BarImpl(ctx);
-   |                     ^^^ this usage requires that `'1` must outlive `'2`
-   |
-   = note: requirement occurs because of a mutable reference to `FooImpl<'_, '_, T>`
-   = note: mutable references are invariant over their type parameter
-   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
-
-error: lifetime may not live long enough
   --> $DIR/lifetime-not-long-enough-suggestion-regression-test-124563.rs:22:9
    |
 LL |   impl<'a, 'b, T> Foo for FooImpl<'a, 'b, T>
@@ -44,6 +29,21 @@ LL | |         });
    | |__________^ argument requires that `'a` must outlive `'b`
    |
    = help: consider adding the following bound: `'a: 'b`
+   = note: requirement occurs because of a mutable reference to `FooImpl<'_, '_, T>`
+   = note: mutable references are invariant over their type parameter
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
+
+error: lifetime may not live long enough
+  --> $DIR/lifetime-not-long-enough-suggestion-regression-test-124563.rs:23:21
+   |
+LL |         self.enter_scope(|ctx| {
+   |                           ---
+   |                           |
+   |                           has type `&'1 mut FooImpl<'_, '_, T>`
+   |                           has type `&mut FooImpl<'2, '_, T>`
+LL |             BarImpl(ctx);
+   |                     ^^^ this usage requires that `'1` must outlive `'2`
+   |
    = note: requirement occurs because of a mutable reference to `FooImpl<'_, '_, T>`
    = note: mutable references are invariant over their type parameter
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance

--- a/tests/ui/regions/regions-nested-fns.stderr
+++ b/tests/ui/regions/regions-nested-fns.stderr
@@ -1,15 +1,3 @@
-error[E0521]: borrowed data escapes outside of closure
-  --> $DIR/regions-nested-fns.rs:12:9
-   |
-LL |     let mut ay = &y;
-   |         ------ `ay` declared here, outside of the closure body
-...
-LL |     ignore::<Box<dyn for<'z> FnMut(&'z isize)>>(Box::new(|z| {
-   |                                                           - `z` is a reference that is only valid in the closure body
-...
-LL |         ay = z;
-   |         ^^^^^^ `z` escapes the closure body here
-
 error[E0597]: `y` does not live long enough
   --> $DIR/regions-nested-fns.rs:5:18
    |
@@ -41,6 +29,18 @@ LL |         if false { return ay; }
 ...
 LL | }
    | - `y` dropped here while still borrowed
+
+error[E0521]: borrowed data escapes outside of closure
+  --> $DIR/regions-nested-fns.rs:12:9
+   |
+LL |     let mut ay = &y;
+   |         ------ `ay` declared here, outside of the closure body
+...
+LL |     ignore::<Box<dyn for<'z> FnMut(&'z isize)>>(Box::new(|z| {
+   |                                                           - `z` is a reference that is only valid in the closure body
+...
+LL |         ay = z;
+   |         ^^^^^^ `z` escapes the closure body here
 
 error: lifetime may not live long enough
   --> $DIR/regions-nested-fns.rs:17:27

--- a/tests/ui/span/borrowck-call-is-borrow-issue-12224.stderr
+++ b/tests/ui/span/borrowck-call-is-borrow-issue-12224.stderr
@@ -32,24 +32,6 @@ help: consider changing this to be a mutable reference
 LL | fn test4(f: &mut Test) {
    |              +++
 
-error[E0507]: cannot move out of `f`, a captured variable in an `FnMut` closure
-  --> $DIR/borrowck-call-is-borrow-issue-12224.rs:57:13
-   |
-LL |     let mut f = move |g: Box<dyn FnMut(isize)>, b: isize| {
-   |         ----- captured outer variable
-...
-LL |     f(Box::new(|a| {
-   |                --- captured by this `FnMut` closure
-LL |
-LL |         foo(f);
-   |             ^ move occurs because `f` has type `{closure@$DIR/borrowck-call-is-borrow-issue-12224.rs:52:17: 52:58}`, which does not implement the `Copy` trait
-   |
-   = help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but `FnOnce` closures may consume them only once
-help: consider cloning the value if the performance cost is acceptable
-   |
-LL |         foo(f.clone());
-   |              ++++++++
-
 error[E0505]: cannot move out of `f` because it is borrowed
   --> $DIR/borrowck-call-is-borrow-issue-12224.rs:55:16
    |
@@ -68,6 +50,24 @@ help: consider cloning the value if the performance cost is acceptable
    |
 LL |     f.clone()(Box::new(|a| {
    |      ++++++++
+
+error[E0507]: cannot move out of `f`, a captured variable in an `FnMut` closure
+  --> $DIR/borrowck-call-is-borrow-issue-12224.rs:57:13
+   |
+LL |     let mut f = move |g: Box<dyn FnMut(isize)>, b: isize| {
+   |         ----- captured outer variable
+...
+LL |     f(Box::new(|a| {
+   |                --- captured by this `FnMut` closure
+LL |
+LL |         foo(f);
+   |             ^ move occurs because `f` has type `{closure@$DIR/borrowck-call-is-borrow-issue-12224.rs:52:17: 52:58}`, which does not implement the `Copy` trait
+   |
+   = help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but `FnOnce` closures may consume them only once
+help: consider cloning the value if the performance cost is acceptable
+   |
+LL |         foo(f.clone());
+   |              ++++++++
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/suggestions/option-content-move3.stderr
+++ b/tests/ui/suggestions/option-content-move3.stderr
@@ -1,29 +1,4 @@
 error[E0507]: cannot move out of `var`, a captured variable in an `FnMut` closure
-  --> $DIR/option-content-move3.rs:13:21
-   |
-LL |     let var = NotCopyable;
-   |         --- captured outer variable
-...
-LL |         move || {
-   |         ------- captured by this `FnMut` closure
-LL |             let x = var;
-   |                     ^^^ move occurs because `var` has type `NotCopyable`, which does not implement the `Copy` trait
-   |
-   = help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but `FnOnce` closures may consume them only once
-note: if `NotCopyable` implemented `Clone`, you could clone the value
-  --> $DIR/option-content-move3.rs:2:1
-   |
-LL | struct NotCopyable;
-   | ^^^^^^^^^^^^^^^^^^ consider implementing `Clone` for this type
-...
-LL |             let x = var;
-   |                     --- you could clone this value
-help: consider borrowing here
-   |
-LL |             let x = &var;
-   |                     +
-
-error[E0507]: cannot move out of `var`, a captured variable in an `FnMut` closure
   --> $DIR/option-content-move3.rs:12:9
    |
 LL |     let var = NotCopyable;
@@ -53,17 +28,25 @@ LL |             let x = var;
    |                     --- you could clone this value
 
 error[E0507]: cannot move out of `var`, a captured variable in an `FnMut` closure
-  --> $DIR/option-content-move3.rs:24:21
+  --> $DIR/option-content-move3.rs:13:21
    |
-LL |     let var = NotCopyableButCloneable;
+LL |     let var = NotCopyable;
    |         --- captured outer variable
 ...
 LL |         move || {
    |         ------- captured by this `FnMut` closure
 LL |             let x = var;
-   |                     ^^^ move occurs because `var` has type `NotCopyableButCloneable`, which does not implement the `Copy` trait
+   |                     ^^^ move occurs because `var` has type `NotCopyable`, which does not implement the `Copy` trait
    |
    = help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but `FnOnce` closures may consume them only once
+note: if `NotCopyable` implemented `Clone`, you could clone the value
+  --> $DIR/option-content-move3.rs:2:1
+   |
+LL | struct NotCopyable;
+   | ^^^^^^^^^^^^^^^^^^ consider implementing `Clone` for this type
+...
+LL |             let x = var;
+   |                     --- you could clone this value
 help: consider borrowing here
    |
 LL |             let x = &var;
@@ -99,6 +82,23 @@ LL |             println!("{x:?}");
 LL ~         }
 LL +         }
    |
+
+error[E0507]: cannot move out of `var`, a captured variable in an `FnMut` closure
+  --> $DIR/option-content-move3.rs:24:21
+   |
+LL |     let var = NotCopyableButCloneable;
+   |         --- captured outer variable
+...
+LL |         move || {
+   |         ------- captured by this `FnMut` closure
+LL |             let x = var;
+   |                     ^^^ move occurs because `var` has type `NotCopyableButCloneable`, which does not implement the `Copy` trait
+   |
+   = help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but `FnOnce` closures may consume them only once
+help: consider borrowing here
+   |
+LL |             let x = &var;
+   |                     +
 
 error: aborting due to 4 previous errors
 


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#158916 (Emit all borrowck errors at the end of borrowck)
 - rust-lang/rust#159129 (Add codegen test for signed nonzero matches)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=158916,159129)
<!-- homu-ignore:end -->

