### PR TITLE
Remove some dead code

### DIFF
--- a/compiler/rustc_ast/src/attr/mod.rs
+++ b/compiler/rustc_ast/src/attr/mod.rs
@@ -7,7 +7,7 @@ use std::fmt::Debug;
 use std::sync::atomic::{AtomicU32, Ordering};
 
 use rustc_index::bit_set::GrowableBitSet;
-use rustc_span::{Ident, Span, Symbol, kw, sym};
+use rustc_span::{Ident, Span, Symbol, sym};
 use smallvec::{SmallVec, smallvec};
 use thin_vec::{ThinVec, thin_vec};
 
@@ -748,29 +748,9 @@ pub fn mk_attr_from_item(
 
 fn mk_attr_tokens(
     style: AttrStyle,
-    unsafety: Safety,
     item_tokens: AttrTokenStream,
     span: Span,
 ) -> LazyAttrTokenStream {
-    let safety_kw = match unsafety {
-        Safety::Default => None,
-        Safety::Unsafe(span) => Some((kw::Unsafe, span)),
-        Safety::Safe(span) => Some((kw::Safe, span)),
-    };
-    let item_tokens = if let Some((kw, kw_span)) = safety_kw {
-        AttrTokenStream::new(vec![
-            AttrTokenTree::Token(Token::from_ast_ident(Ident::new(kw, kw_span)), Spacing::Alone),
-            AttrTokenTree::Delimited(
-                DelimSpan::from_single(span),
-                DelimSpacing::new(Spacing::JointHidden, Spacing::Alone),
-                Delimiter::Parenthesis,
-                item_tokens,
-            ),
-        ])
-    } else {
-        item_tokens
-    };
-
     let mut tokens = match style {
         AttrStyle::Outer => {
             vec![AttrTokenTree::Token(Token::new(token::Pound, span), Spacing::JointHidden)]
@@ -792,19 +772,12 @@ fn mk_attr_tokens(
 
 // `span` is used for the `Attribute` and everything within it (except for any span within
 // `unsafety`).
-pub fn mk_attr_word(
-    g: &AttrIdGenerator,
-    style: AttrStyle,
-    unsafety: Safety,
-    name: Symbol,
-    span: Span,
-) -> Attribute {
+pub fn mk_attr_word(g: &AttrIdGenerator, style: AttrStyle, name: Symbol, span: Span) -> Attribute {
     let path = Path::from_ident(Ident::new(name, span));
     let args = AttrArgs::Empty;
 
     let tokens = Some(mk_attr_tokens(
         style,
-        unsafety,
         AttrTokenStream::new(vec![AttrTokenTree::Token(
             Token::from_ast_ident(Ident::new(name, span)),
             Spacing::Alone,
@@ -812,7 +785,13 @@ pub fn mk_attr_word(
         span,
     ));
 
-    mk_attr_from_item(g, AttrItem { unsafety, path, args, span }, tokens, style, span)
+    mk_attr_from_item(
+        g,
+        AttrItem { unsafety: Safety::Default, path, args, span },
+        tokens,
+        style,
+        span,
+    )
 }
 
 // `span` is used for the `Attribute` and everything within it (except for any span within
@@ -820,7 +799,6 @@ pub fn mk_attr_word(
 pub fn mk_attr_nested_word(
     g: &AttrIdGenerator,
     style: AttrStyle,
-    unsafety: Safety,
     outer: Symbol,
     inner: Symbol,
     span: Span,
@@ -839,7 +817,6 @@ pub fn mk_attr_nested_word(
 
     let tokens = Some(mk_attr_tokens(
         style,
-        unsafety,
         AttrTokenStream::new(vec![
             AttrTokenTree::Token(Token::from_ast_ident(Ident::new(outer, span)), Spacing::Alone),
             AttrTokenTree::Delimited(
@@ -855,7 +832,13 @@ pub fn mk_attr_nested_word(
         span,
     ));
 
-    mk_attr_from_item(g, AttrItem { unsafety, path, args: attr_args, span }, tokens, style, span)
+    mk_attr_from_item(
+        g,
+        AttrItem { unsafety: Safety::Default, path, args: attr_args, span },
+        tokens,
+        style,
+        span,
+    )
 }
 
 // `span` is used for the `Attribute` and everything within it (except for any span within
@@ -863,7 +846,6 @@ pub fn mk_attr_nested_word(
 pub fn mk_attr_name_value_str(
     g: &AttrIdGenerator,
     style: AttrStyle,
-    unsafety: Safety,
     name: Symbol,
     val: Symbol,
     span: Span,
@@ -881,7 +863,6 @@ pub fn mk_attr_name_value_str(
 
     let tokens = Some(mk_attr_tokens(
         style,
-        unsafety,
         AttrTokenStream::new(vec![
             AttrTokenTree::Token(Token::from_ast_ident(Ident::new(name, span)), Spacing::Alone),
             AttrTokenTree::Token(Token::new(token::Eq, span), Spacing::Alone),
@@ -893,7 +874,13 @@ pub fn mk_attr_name_value_str(
         span,
     ));
 
-    mk_attr_from_item(g, AttrItem { unsafety, path, args, span }, tokens, style, span)
+    mk_attr_from_item(
+        g,
+        AttrItem { unsafety: Safety::Default, path, args, span },
+        tokens,
+        style,
+        span,
+    )
 }
 
 pub fn filter_by_name(attrs: &[Attribute], name: Symbol) -> impl Iterator<Item = &Attribute> {

--- a/compiler/rustc_ast_lowering/src/expr.rs
+++ b/compiler/rustc_ast_lowering/src/expr.rs
@@ -2323,7 +2323,6 @@ impl<'hir> LoweringContext<'_, 'hir> {
         let attr = attr::mk_attr_nested_word(
             &self.tcx.sess.psess.attr_id_generator,
             AttrStyle::Outer,
-            Safety::Default,
             sym::allow,
             sym::unreachable_code,
             span,

--- a/compiler/rustc_ast_pretty/src/pprust/state.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state.rs
@@ -17,7 +17,7 @@ use rustc_ast::util::comments::{Comment, CommentStyle};
 use rustc_ast::{
     self as ast, AttrArgs, AttrKind, BindingMode, BlockCheckMode, ByRef, DelimArgs, GenericArg,
     GenericBound, InlineAsmOperand, InlineAsmOptions, InlineAsmRegOrRegClass,
-    InlineAsmTemplatePiece, PatKind, RangeEnd, RangeSyntax, Safety, SelfKind, Term, attr,
+    InlineAsmTemplatePiece, PatKind, RangeEnd, RangeSyntax, SelfKind, Term, attr,
 };
 use rustc_span::edition::Edition;
 use rustc_span::source_map::SourceMap;
@@ -292,7 +292,6 @@ fn print_crate_inner<'a>(
         let fake_attr = attr::mk_attr_nested_word(
             g,
             ast::AttrStyle::Inner,
-            Safety::Default,
             sym::feature,
             sym::prelude_import,
             DUMMY_SP,
@@ -303,13 +302,7 @@ fn print_crate_inner<'a>(
         // root, so this is not needed, and actually breaks things.
         if edition.is_rust_2015() {
             // `#![no_std]`
-            let fake_attr = attr::mk_attr_word(
-                g,
-                ast::AttrStyle::Inner,
-                Safety::Default,
-                sym::no_std,
-                DUMMY_SP,
-            );
+            let fake_attr = attr::mk_attr_word(g, ast::AttrStyle::Inner, sym::no_std, DUMMY_SP);
             s.print_attribute(&fake_attr);
         }
     }

--- a/compiler/rustc_builtin_macros/src/test_harness.rs
+++ b/compiler/rustc_builtin_macros/src/test_harness.rs
@@ -207,7 +207,6 @@ impl<'a> MutVisitor for EntryPointCleaner<'a> {
                 let allow_dead_code = attr::mk_attr_nested_word(
                     &self.sess.psess.attr_id_generator,
                     ast::AttrStyle::Outer,
-                    ast::Safety::Default,
                     sym::allow,
                     sym::dead_code,
                     self.def_site,

--- a/compiler/rustc_expand/src/build.rs
+++ b/compiler/rustc_expand/src/build.rs
@@ -743,7 +743,7 @@ impl<'a> ExtCtxt<'a> {
     // Builds `#[name]`.
     pub fn attr_word(&self, name: Symbol, span: Span) -> ast::Attribute {
         let g = &self.sess.psess.attr_id_generator;
-        attr::mk_attr_word(g, ast::AttrStyle::Outer, ast::Safety::Default, name, span)
+        attr::mk_attr_word(g, ast::AttrStyle::Outer, name, span)
     }
 
     // Builds `#[name = val]`.
@@ -751,27 +751,13 @@ impl<'a> ExtCtxt<'a> {
     // Note: `span` is used for both the identifier and the value.
     pub fn attr_name_value_str(&self, name: Symbol, val: Symbol, span: Span) -> ast::Attribute {
         let g = &self.sess.psess.attr_id_generator;
-        attr::mk_attr_name_value_str(
-            g,
-            ast::AttrStyle::Outer,
-            ast::Safety::Default,
-            name,
-            val,
-            span,
-        )
+        attr::mk_attr_name_value_str(g, ast::AttrStyle::Outer, name, val, span)
     }
 
     // Builds `#[outer(inner)]`.
     pub fn attr_nested_word(&self, outer: Symbol, inner: Symbol, span: Span) -> ast::Attribute {
         let g = &self.sess.psess.attr_id_generator;
-        attr::mk_attr_nested_word(
-            g,
-            ast::AttrStyle::Outer,
-            ast::Safety::Default,
-            outer,
-            inner,
-            span,
-        )
+        attr::mk_attr_nested_word(g, ast::AttrStyle::Outer, outer, inner, span)
     }
 
     // Builds an attribute fully manually.

--- a/compiler/rustc_interface/src/interface.rs
+++ b/compiler/rustc_interface/src/interface.rs
@@ -14,7 +14,6 @@ use rustc_middle::util::Providers;
 use rustc_parse::lexer::StripTokens;
 use rustc_parse::new_parser_from_source_str;
 use rustc_parse::parser::Recovery;
-use rustc_parse::parser::attr::AllowLeadingUnsafe;
 use rustc_query_impl::print_query_stack;
 use rustc_session::config::{self, Cfg, CheckCfg, ExpectedValues, Input, OutFileName};
 use rustc_session::parse::ParseSess;
@@ -62,7 +61,7 @@ pub(crate) fn parse_cfg(dcx: DiagCtxtHandle<'_>, cfgs: Vec<String>) -> Cfg {
             {
                 Ok(mut parser) => {
                     parser = parser.recovery(Recovery::Forbidden);
-                    match parser.parse_meta_item(AllowLeadingUnsafe::No) {
+                    match parser.parse_meta_item() {
                         Ok(meta_item)
                             if parser.token == token::Eof
                                 && parser.dcx().has_errors().is_none() =>
@@ -167,7 +166,7 @@ pub(crate) fn parse_check_cfg(dcx: DiagCtxtHandle<'_>, specs: Vec<String>) -> Ch
                 }
             };
 
-        let meta_item = match parser.parse_meta_item(AllowLeadingUnsafe::No) {
+        let meta_item = match parser.parse_meta_item() {
             Ok(meta_item) if parser.token == token::Eof && parser.dcx().has_errors().is_none() => {
                 meta_item
             }

--- a/compiler/rustc_parse/src/parser/attr.rs
+++ b/compiler/rustc_parse/src/parser/attr.rs
@@ -35,12 +35,6 @@ enum OuterAttributeType {
     Attribute,
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
-pub enum AllowLeadingUnsafe {
-    Yes,
-    No,
-}
-
 impl<'a> Parser<'a> {
     /// Parses attributes that appear before an item.
     pub(super) fn parse_outer_attributes(&mut self) -> PResult<'a, AttrWrapper> {
@@ -435,10 +429,7 @@ impl<'a> Parser<'a> {
     /// MetaItem = SimplePath ( '=' UNSUFFIXED_LIT | '(' MetaSeq? ')' )? ;
     /// MetaSeq = MetaItemInner (',' MetaItemInner)* ','? ;
     /// ```
-    pub fn parse_meta_item(
-        &mut self,
-        unsafe_allowed: AllowLeadingUnsafe,
-    ) -> PResult<'a, ast::MetaItem> {
+    pub fn parse_meta_item(&mut self) -> PResult<'a, ast::MetaItem> {
         if let Some(MetaVarKind::Meta { has_meta_form }) = self.token.is_metavar_seq() {
             return if has_meta_form {
                 let attr_item = self
@@ -452,30 +443,13 @@ impl<'a> Parser<'a> {
                 self.unexpected_any()
             };
         }
-
         let lo = self.token.span;
-        let is_unsafe = if unsafe_allowed == AllowLeadingUnsafe::Yes {
-            self.eat_keyword(exp!(Unsafe))
-        } else {
-            false
-        };
-        let unsafety = if is_unsafe {
-            let unsafe_span = self.prev_token.span;
-            self.expect(exp!(OpenParen))?;
-
-            ast::Safety::Unsafe(unsafe_span)
-        } else {
-            ast::Safety::Default
-        };
 
         let path = self.parse_path(PathStyle::Mod)?;
         let kind = self.parse_meta_item_kind()?;
-        if is_unsafe {
-            self.expect(exp!(CloseParen))?;
-        }
         let span = lo.to(self.prev_token.span);
 
-        Ok(ast::MetaItem { unsafety, path, kind, span })
+        Ok(ast::MetaItem { unsafety: ast::Safety::Default, path, kind, span })
     }
 
     pub(crate) fn parse_meta_item_kind(&mut self) -> PResult<'a, ast::MetaItemKind> {
@@ -500,7 +474,7 @@ impl<'a> Parser<'a> {
             Err(err) => err.cancel(), // we provide a better error below
         }
 
-        match self.parse_meta_item(AllowLeadingUnsafe::No) {
+        match self.parse_meta_item() {
             Ok(mi) => return Ok(ast::MetaItemInner::MetaItem(mi)),
             Err(err) => err.cancel(), // we provide a better error below
         }


### PR DESCRIPTION
Leftover from a previous revision of `#[unsafe(no_mangle)]`. All call sites disallowed it anyway, and the real handling is in the parser.