### PR TITLE
unify the AST repr of type const and const RHS

### DIFF
--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -4010,44 +4010,16 @@ pub struct ConstItem {
     pub ident: Ident,
     pub generics: Generics,
     pub ty: Box<Ty>,
-    pub rhs_kind: ConstItemRhsKind,
+    pub body: Option<Box<Expr>>,
+    #[visitable(ignore)]
+    pub kind: ConstItemKind,
     pub define_opaque: Option<ThinVec<(NodeId, Path)>>,
 }
 
-#[derive(Clone, Encodable, Decodable, Debug, Walkable)]
-pub enum ConstItemRhsKind {
-    Body { rhs: Option<Box<Expr>> },
-    TypeConst { rhs: Option<AnonConst> },
-}
-
-impl ConstItemRhsKind {
-    pub fn new_body(rhs: Box<Expr>) -> Self {
-        Self::Body { rhs: Some(rhs) }
-    }
-
-    pub fn span(&self) -> Option<Span> {
-        Some(self.expr()?.span)
-    }
-
-    pub fn expr(&self) -> Option<&Expr> {
-        match self {
-            Self::Body { rhs: Some(body) } => Some(&body),
-            Self::TypeConst { rhs: Some(anon) } => Some(&anon.value),
-            _ => None,
-        }
-    }
-
-    pub fn has_expr(&self) -> bool {
-        match self {
-            Self::Body { rhs: Some(_) } => true,
-            Self::TypeConst { rhs: Some(_) } => true,
-            _ => false,
-        }
-    }
-
-    pub fn is_type_const(&self) -> bool {
-        matches!(self, &Self::TypeConst { .. })
-    }
+#[derive(Clone, Copy, Encodable, Decodable, Debug, PartialEq, Eq)]
+pub enum ConstItemKind {
+    Body,
+    TypeConst,
 }
 
 #[derive(Clone, Encodable, Decodable, Debug, Walkable)]

--- a/compiler/rustc_ast/src/visit.rs
+++ b/compiler/rustc_ast/src/visit.rs
@@ -427,7 +427,6 @@ macro_rules! common_visitor_and_walkers {
             Const,
             ConstBlockItem,
             ConstItem,
-            ConstItemRhsKind,
             Defaultness,
             Delegation,
             DelegationMac,

--- a/compiler/rustc_ast_lowering/src/item.rs
+++ b/compiler/rustc_ast_lowering/src/item.rs
@@ -270,7 +270,8 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 ident,
                 generics,
                 ty,
-                rhs_kind,
+                body,
+                kind,
                 define_opaque,
             }) => {
                 let ident = self.lower_ident(*ident);
@@ -282,7 +283,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                             ty,
                             ImplTraitContext::Disallowed(ImplTraitPosition::ConstTy),
                         );
-                        let rhs = this.lower_const_item_rhs(rhs_kind, span);
+                        let rhs = this.lower_const_item_rhs(body, *kind, span);
                         (ty, rhs)
                     },
                 );
@@ -918,7 +919,8 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 ident,
                 generics,
                 ty,
-                rhs_kind,
+                body,
+                kind,
                 define_opaque,
                 ..
             }) => {
@@ -931,8 +933,8 @@ impl<'hir> LoweringContext<'_, 'hir> {
                             ImplTraitContext::Disallowed(ImplTraitPosition::ConstTy),
                         );
                         // Trait associated consts don't need an expression/body.
-                        let rhs = if rhs_kind.has_expr() {
-                            Some(this.lower_const_item_rhs(rhs_kind, i.span))
+                        let rhs = if body.is_some() {
+                            Some(this.lower_const_item_rhs(body, *kind, i.span))
                         } else {
                             None
                         };
@@ -941,7 +943,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 );
 
                 if define_opaque.is_some() {
-                    if rhs_kind.has_expr() {
+                    if body.is_some() {
                         self.lower_define_opaque(hir_id, &define_opaque);
                     } else {
                         self.dcx().span_err(
@@ -951,7 +953,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                     }
                 }
 
-                (*ident, generics, kind, rhs_kind.has_expr())
+                (*ident, generics, kind, body.is_some())
             }
             AssocItemKind::Fn(Fn { sig, ident, generics, body: None, define_opaque, .. }) => {
                 // FIXME(contracts): Deny contract here since it won't apply to
@@ -1180,7 +1182,8 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 ident,
                 generics,
                 ty,
-                rhs_kind,
+                body,
+                kind,
                 define_opaque,
                 ..
             }) => (
@@ -1194,7 +1197,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                             ImplTraitContext::Disallowed(ImplTraitPosition::ConstTy),
                         );
                         this.lower_define_opaque(hir_id, &define_opaque);
-                        let rhs = this.lower_const_item_rhs(rhs_kind, i.span);
+                        let rhs = this.lower_const_item_rhs(body, *kind, i.span);
                         hir::ImplItemKind::Const(ty, rhs)
                     },
                 ),

--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -2671,28 +2671,26 @@ impl<'hir> LoweringContext<'_, 'hir> {
 
     fn lower_const_item_rhs(
         &mut self,
-        rhs_kind: &ConstItemRhsKind,
+        body: &Option<Box<Expr>>,
+        kind: ConstItemKind,
         span: Span,
     ) -> hir::ConstItemRhs<'hir> {
-        match rhs_kind {
-            ConstItemRhsKind::Body { rhs: Some(body) } => {
-                hir::ConstItemRhs::Body(self.lower_const_body(span, Some(body)))
+        match (body, kind) {
+            (body, ConstItemKind::Body) => {
+                hir::ConstItemRhs::Body(self.lower_const_body(span, body.as_deref()))
             }
-            ConstItemRhsKind::Body { rhs: None } => {
-                hir::ConstItemRhs::Body(self.lower_const_body(span, None))
-            }
-            ConstItemRhsKind::TypeConst { rhs: Some(anon) } => {
+            (Some(body), ConstItemKind::TypeConst) => {
                 hir::ConstItemRhs::TypeConst(self.arena.alloc(
                     match self.can_lower_expr_to_const_arg_direct(
-                        &anon.value,
+                        &body,
                         DirectConstArgContext::MacrolessMinGenericConstArgs,
                     ) {
-                        Ok(()) => self.lower_expr_to_const_arg_direct(&anon.value, Some(anon.id)),
+                        Ok(()) => self.lower_expr_to_const_arg_direct(&body, None),
                         Err(err) => err.emit(self),
                     },
                 ))
             }
-            ConstItemRhsKind::TypeConst { rhs: None } => {
+            (None, ConstItemKind::TypeConst) => {
                 let const_arg = ConstArg {
                     hir_id: self.next_id(),
                     kind: hir::ConstArgKind::Error(

--- a/compiler/rustc_ast_passes/src/ast_validation.rs
+++ b/compiler/rustc_ast_passes/src/ast_validation.rs
@@ -1544,9 +1544,9 @@ impl Visitor<'_> for AstValidator<'_> {
                     visit::walk_item(this, item)
                 });
             }
-            ItemKind::Const(ConstItem { defaultness, ident, rhs_kind, .. }) => {
+            ItemKind::Const(ConstItem { defaultness, ident, body, .. }) => {
                 self.check_defaultness(item.span, *defaultness, AllowDefault::No, AllowFinal::No);
-                if !rhs_kind.has_expr() {
+                if body.is_none() {
                     self.dcx().emit_err(diagnostics::ConstWithoutBody {
                         span: item.span,
                         replace_span: self.ending_semi_or_hi(item.span),
@@ -1941,8 +1941,8 @@ impl Visitor<'_> for AstValidator<'_> {
 
         if let AssocCtxt::Impl { .. } = ctxt {
             match &item.kind {
-                AssocItemKind::Const(ConstItem { rhs_kind, .. }) => {
-                    if !rhs_kind.has_expr() {
+                AssocItemKind::Const(ConstItem { body, .. }) => {
+                    if body.is_none() {
                         self.dcx().emit_err(diagnostics::AssocConstWithoutBody {
                             span: item.span,
                             replace_span: self.ending_semi_or_hi(item.span),

--- a/compiler/rustc_ast_passes/src/feature_gate.rs
+++ b/compiler/rustc_ast_passes/src/feature_gate.rs
@@ -220,8 +220,7 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
                 self.check_impl_trait(ty, false)
             }
             ast::ItemKind::Const(ast::ConstItem {
-                rhs_kind: ast::ConstItemRhsKind::TypeConst { .. },
-                ..
+                kind: ast::ConstItemKind::TypeConst, ..
             }) => {
                 // Make sure this is only allowed if the feature gate is enabled.
                 // #![feature(min_generic_const_args)]
@@ -400,7 +399,8 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
                 false
             }
             ast::AssocItemKind::Const(ast::ConstItem {
-                rhs_kind: ast::ConstItemRhsKind::TypeConst { rhs },
+                body,
+                kind: ast::ConstItemKind::TypeConst,
                 ..
             }) => {
                 // Make sure this is only allowed if the feature gate is enabled.
@@ -409,7 +409,7 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
                 // Make sure associated `type const` defaults in traits are only allowed
                 // if the feature gate is enabled.
                 // #![feature(associated_type_defaults)]
-                if ctxt == AssocCtxt::Trait && rhs.is_some() {
+                if ctxt == AssocCtxt::Trait && body.is_some() {
                     gate!(
                         self,
                         associated_type_defaults,

--- a/compiler/rustc_ast_pretty/src/pprust/state/item.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state/item.rs
@@ -229,7 +229,8 @@ impl<'a> State<'a> {
                 ident,
                 generics,
                 ty,
-                rhs_kind,
+                body,
+                kind: _,
                 define_opaque,
             }) => {
                 self.print_item_const(
@@ -237,7 +238,7 @@ impl<'a> State<'a> {
                     None,
                     generics,
                     ty,
-                    rhs_kind.expr(),
+                    body.as_deref(),
                     &item.vis,
                     ast::Safety::Default,
                     *defaultness,
@@ -617,7 +618,8 @@ impl<'a> State<'a> {
                 ident,
                 generics,
                 ty,
-                rhs_kind,
+                body,
+                kind: _,
                 define_opaque,
             }) => {
                 self.print_item_const(
@@ -625,7 +627,7 @@ impl<'a> State<'a> {
                     None,
                     generics,
                     ty,
-                    rhs_kind.expr(),
+                    body.as_deref(),
                     vis,
                     ast::Safety::Default,
                     *defaultness,

--- a/compiler/rustc_builtin_macros/src/alloc_error_handler.rs
+++ b/compiler/rustc_builtin_macros/src/alloc_error_handler.rs
@@ -43,8 +43,14 @@ pub(crate) fn expand(
 
     // Generate anonymous constant serving as container for the allocator methods.
     let const_ty = ecx.ty(sig_span, TyKind::Tup(ThinVec::new()));
-    let const_body = ast::ConstItemRhsKind::new_body(ecx.expr_block(ecx.block(span, stmts)));
-    let const_item = ecx.item_const(span, Ident::new(kw::Underscore, span), const_ty, const_body);
+    let const_body = ecx.expr_block(ecx.block(span, stmts));
+    let const_item = ecx.item_const(
+        span,
+        Ident::new(kw::Underscore, span),
+        const_ty,
+        Some(const_body),
+        ast::ConstItemKind::Body,
+    );
     let const_item = if is_stmt {
         Annotatable::Stmt(Box::new(ecx.stmt_item(span, const_item)))
     } else {

--- a/compiler/rustc_builtin_macros/src/eii.rs
+++ b/compiler/rustc_builtin_macros/src/eii.rs
@@ -335,7 +335,8 @@ fn generate_default_impl(
             span,
             underscore,
             unit,
-            ast::ConstItemRhsKind::new_body(ecx.expr_block(ecx.block(span, stmts))),
+            Some(ecx.expr_block(ecx.block(span, stmts))),
+            ast::ConstItemKind::Body,
         )
     };
 

--- a/compiler/rustc_builtin_macros/src/global_allocator.rs
+++ b/compiler/rustc_builtin_macros/src/global_allocator.rs
@@ -54,8 +54,14 @@ pub(crate) fn expand(
 
     // Generate anonymous constant serving as container for the allocator methods.
     let const_ty = ecx.ty(ty_span, TyKind::Tup(ThinVec::new()));
-    let const_body = ast::ConstItemRhsKind::new_body(ecx.expr_block(ecx.block(span, stmts)));
-    let const_item = ecx.item_const(span, Ident::new(kw::Underscore, span), const_ty, const_body);
+    let const_body = ecx.expr_block(ecx.block(span, stmts));
+    let const_item = ecx.item_const(
+        span,
+        Ident::new(kw::Underscore, span),
+        const_ty,
+        Some(const_body),
+        ast::ConstItemKind::Body,
+    );
     let const_item = if is_stmt {
         Annotatable::Stmt(Box::new(ecx.stmt_item(span, const_item)))
     } else {

--- a/compiler/rustc_builtin_macros/src/proc_macro_harness.rs
+++ b/compiler/rustc_builtin_macros/src/proc_macro_harness.rs
@@ -361,15 +361,16 @@ fn mk_decls(cx: &mut ExtCtxt<'_>, macros: &[ProcMacro]) -> Box<ast::Item> {
         cx.attr_nested_word(sym::allow, sym::deprecated, span),
     ]);
 
-    let block = ast::ConstItemRhsKind::new_body(cx.expr_block(
+    let block = cx.expr_block(
         cx.block(span, thin_vec![cx.stmt_item(span, krate), cx.stmt_item(span, decls_static)]),
-    ));
+    );
 
     let anon_constant = cx.item_const(
         span,
         Ident::new(kw::Underscore, span),
         cx.ty(span, ast::TyKind::Tup(ThinVec::new())),
-        block,
+        Some(block),
+        ast::ConstItemKind::Body,
     );
 
     // Integrate the new item into existing module structures.

--- a/compiler/rustc_builtin_macros/src/test.rs
+++ b/compiler/rustc_builtin_macros/src/test.rs
@@ -286,8 +286,9 @@ pub(crate) fn expand_test_or_bench(
                     generics: ast::Generics::default(),
                     ty: cx.ty(sp, ast::TyKind::Path(None, test_path("TestDescAndFn"))),
                     define_opaque: None,
+                    kind: ast::ConstItemKind::Body,
                     // test::TestDescAndFn {
-                    rhs_kind: ast::ConstItemRhsKind::new_body(
+                    body: Some(
                         cx.expr_struct(
                             sp,
                             test_path("TestDescAndFn"),

--- a/compiler/rustc_expand/src/build.rs
+++ b/compiler/rustc_expand/src/build.rs
@@ -719,7 +719,8 @@ impl<'a> ExtCtxt<'a> {
         span: Span,
         ident: Ident,
         ty: Box<ast::Ty>,
-        rhs_kind: ast::ConstItemRhsKind,
+        body: Option<Box<Expr>>,
+        kind: ast::ConstItemKind,
     ) -> Box<ast::Item> {
         let defaultness = ast::Defaultness::Implicit;
         self.item(
@@ -732,7 +733,8 @@ impl<'a> ExtCtxt<'a> {
                     // FIXME(generic_const_items): Pass the generics as a parameter.
                     generics: ast::Generics::default(),
                     ty,
-                    rhs_kind,
+                    body,
+                    kind,
                     define_opaque: None,
                 }
                 .into(),

--- a/compiler/rustc_lint/src/unused.rs
+++ b/compiler/rustc_lint/src/unused.rs
@@ -510,8 +510,8 @@ trait UnusedDelimLint {
     fn check_item(&mut self, cx: &EarlyContext<'_>, item: &ast::Item) {
         use ast::ItemKind::*;
 
-        let expr = if let Const(ast::ConstItem { rhs_kind, .. }) = &item.kind {
-            if let Some(e) = rhs_kind.expr() { e } else { return }
+        let expr = if let Const(ast::ConstItem { body: Some(expr), .. }) = &item.kind {
+            expr
         } else if let Static(ast::StaticItem { expr: Some(expr), .. }) = &item.kind {
             expr
         } else {

--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -324,13 +324,14 @@ impl<'a> Parser<'a> {
             // CONST ITEM
             self.recover_const_mut(const_span);
             self.recover_missing_kw_before_item()?;
-            let (ident, generics, ty, rhs_kind) = self.parse_const_item(false, const_span)?;
+            let (ident, generics, ty, body) = self.parse_const_item(const_span)?;
             ItemKind::Const(Box::new(ConstItem {
                 defaultness: def_(),
                 ident,
                 generics,
                 ty,
-                rhs_kind,
+                body,
+                kind: ConstItemKind::Body,
                 define_opaque: None,
             }))
         } else if let Some(kind) = self.is_reuse_item() {
@@ -345,7 +346,7 @@ impl<'a> Parser<'a> {
                 // TYPE CONST (mgca)
                 self.recover_const_mut(const_span);
                 self.recover_missing_kw_before_item()?;
-                let (ident, generics, ty, rhs_kind) = self.parse_const_item(true, const_span)?;
+                let (ident, generics, ty, body) = self.parse_const_item(const_span)?;
                 // Make sure this is only allowed if the feature gate is enabled.
                 // #![feature(mgca_type_const_syntax)]
                 self.psess.gated_spans.gate(sym::mgca_type_const_syntax, lo.to(const_span));
@@ -354,7 +355,8 @@ impl<'a> Parser<'a> {
                     ident,
                     generics,
                     ty,
-                    rhs_kind,
+                    body,
+                    kind: ConstItemKind::TypeConst,
                     define_opaque: None,
                 }))
             } else {
@@ -1264,7 +1266,8 @@ impl<'a> Parser<'a> {
                                 ident,
                                 generics: Generics::default(),
                                 ty,
-                                rhs_kind: ConstItemRhsKind::Body { rhs: expr },
+                                body: expr,
+                                kind: ConstItemKind::Body,
                                 define_opaque,
                             }))
                         }
@@ -1506,7 +1509,7 @@ impl<'a> Parser<'a> {
                 let kind = match ForeignItemKind::try_from(kind) {
                     Ok(kind) => kind,
                     Err(kind) => match kind {
-                        ItemKind::Const(ConstItem { ident, ty, rhs_kind, .. }) => {
+                        ItemKind::Const(ConstItem { ident, ty, body, .. }) => {
                             let const_span = Some(span.with_hi(ident.span.lo()))
                                 .filter(|span| span.can_be_used_for_suggestions());
                             self.dcx().emit_err(diagnostics::ExternItemCannotBeConst {
@@ -1517,13 +1520,7 @@ impl<'a> Parser<'a> {
                                 ident,
                                 ty,
                                 mutability: Mutability::Not,
-                                expr: match rhs_kind {
-                                    ConstItemRhsKind::Body { rhs } => rhs,
-                                    ConstItemRhsKind::TypeConst { rhs: Some(anon) } => {
-                                        Some(anon.value)
-                                    }
-                                    ConstItemRhsKind::TypeConst { rhs: None } => None,
-                                },
+                                expr: body,
                                 safety: Safety::Default,
                                 define_opaque: None,
                                 eii_impls: ThinVec::default(),
@@ -1686,9 +1683,8 @@ impl<'a> Parser<'a> {
     /// ```
     fn parse_const_item(
         &mut self,
-        const_arg: bool,
         const_span: Span,
-    ) -> PResult<'a, (Ident, Generics, Box<Ty>, ConstItemRhsKind)> {
+    ) -> PResult<'a, (Ident, Generics, Box<Ty>, Option<Box<Expr>>)> {
         let ident = self.parse_ident_or_underscore()?;
 
         let mut generics = self.parse_generics()?;
@@ -1715,14 +1711,7 @@ impl<'a> Parser<'a> {
         let before_where_clause =
             if self.may_recover() { self.parse_where_clause()? } else { WhereClause::default() };
 
-        let rhs = match (self.eat(exp!(Eq)), const_arg) {
-            (true, true) => {
-                ConstItemRhsKind::TypeConst { rhs: Some(self.parse_expr_anon_const()?) }
-            }
-            (true, false) => ConstItemRhsKind::Body { rhs: Some(self.parse_expr()?) },
-            (false, true) => ConstItemRhsKind::TypeConst { rhs: None },
-            (false, false) => ConstItemRhsKind::Body { rhs: None },
-        };
+        let rhs = if self.eat(exp!(Eq)) { Some(self.parse_expr()?) } else { None };
 
         let after_where_clause = self.parse_where_clause()?;
 
@@ -1730,18 +1719,18 @@ impl<'a> Parser<'a> {
         // Users may be tempted to write such code if they are still used to the deprecated
         // where-clause location on type aliases and associated types. See also #89122.
         if before_where_clause.has_where_token
-            && let Some(rhs_span) = rhs.span()
+            && let Some(rhs) = &rhs
         {
             self.dcx().emit_err(diagnostics::WhereClauseBeforeConstBody {
                 span: before_where_clause.span,
                 name: ident.span,
-                body: rhs_span,
+                body: rhs.span,
                 sugg: if !after_where_clause.has_where_token {
-                    self.psess.source_map().span_to_snippet(rhs_span).ok().map(|body_s| {
+                    self.psess.source_map().span_to_snippet(rhs.span).ok().map(|body_s| {
                         diagnostics::WhereClauseBeforeConstBodySugg {
                             left: before_where_clause.span.shrink_to_lo(),
                             snippet: body_s,
-                            right: before_where_clause.span.shrink_to_hi().to(rhs_span),
+                            right: before_where_clause.span.shrink_to_hi().to(rhs.span),
                         }
                     })
                 } else {
@@ -1778,7 +1767,7 @@ impl<'a> Parser<'a> {
         generics.where_clause = where_clause;
 
         if let Some(rhs) = self.try_recover_const_missing_semi(&rhs, const_span) {
-            return Ok((ident, generics, ty, ConstItemRhsKind::Body { rhs: Some(rhs) }));
+            return Ok((ident, generics, ty, Some(rhs)));
         }
         self.expect_semi()?;
 
@@ -3700,13 +3689,13 @@ impl<'a> Parser<'a> {
     /// Returns a corrected expression if recovery is successful.
     fn try_recover_const_missing_semi(
         &mut self,
-        rhs: &ConstItemRhsKind,
+        rhs: &Option<Box<Expr>>,
         const_span: Span,
     ) -> Option<Box<Expr>> {
         if self.token == TokenKind::Semi {
             return None;
         }
-        let ConstItemRhsKind::Body { rhs: Some(rhs) } = rhs else {
+        let Some(rhs) = rhs else {
             return None;
         };
         if !self.in_fn_body || !self.may_recover() || rhs.span.from_expansion() {

--- a/compiler/rustc_resolve/src/def_collector.rs
+++ b/compiler/rustc_resolve/src/def_collector.rs
@@ -166,7 +166,7 @@ impl<'a, 'ra, 'tcx> visit::Visitor<'a> for DefCollector<'a, 'ra, 'tcx> {
                 nested: false,
             },
             ItemKind::Const(citem) => {
-                let is_type_const = matches!(citem.rhs_kind, ConstItemRhsKind::TypeConst { .. });
+                let is_type_const = citem.kind == ConstItemKind::TypeConst;
                 DefKind::Const { is_type_const }
             }
             ItemKind::ConstBlock(..) => DefKind::Const { is_type_const: false },
@@ -387,11 +387,9 @@ impl<'a, 'ra, 'tcx> visit::Visitor<'a> for DefCollector<'a, 'ra, 'tcx> {
             | AssocItemKind::Delegation(Delegation { ident, .. }) => {
                 (*ident, DefKind::AssocFn, ValueNS)
             }
-            AssocItemKind::Const(ConstItem { ident, rhs_kind, .. }) => (
+            AssocItemKind::Const(ConstItem { ident, kind, .. }) => (
                 *ident,
-                DefKind::AssocConst {
-                    is_type_const: matches!(rhs_kind, ConstItemRhsKind::TypeConst { .. }),
-                },
+                DefKind::AssocConst { is_type_const: *kind == ConstItemKind::TypeConst },
                 ValueNS,
             ),
             AssocItemKind::Type(TyAlias { ident, .. }) => (*ident, DefKind::AssocTy, TypeNS),

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -2971,7 +2971,8 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
                 ident,
                 generics,
                 ty,
-                rhs_kind,
+                body,
+                kind,
                 define_opaque,
                 defaultness: _,
             }) => {
@@ -2994,7 +2995,7 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
                         this.with_lifetime_rib(
                             LifetimeRibKind::elided(LifetimeRes::Static),
                             |this: &mut LateResolutionVisitor<'a, 'ast, 'ra, 'tcx>| {
-                                if rhs_kind.is_type_const()
+                                if *kind == ast::ConstItemKind::TypeConst
                                     && !this.r.features.generic_const_parameter_types()
                                 {
                                     this.with_rib(TypeNS, RibKind::ConstParamTy, |this| {
@@ -3011,10 +3012,7 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
                             },
                         );
 
-                        this.resolve_const_item_rhs(
-                            rhs_kind,
-                            Some((*ident, ConstantItemKind::Const)),
-                        );
+                        this.resolve_const_item_rhs(body, Some((*ident, ConstantItemKind::Const)));
                     },
                 );
                 self.resolve_define_opaques(define_opaque);
@@ -3379,7 +3377,12 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
         self.resolve_doc_links(&item.attrs, MaybeExported::Ok(item.id));
         match &item.kind {
             AssocItemKind::Const(ast::ConstItem {
-                generics, ty, rhs_kind, define_opaque, ..
+                generics,
+                ty,
+                body,
+                kind,
+                define_opaque,
+                ..
             }) => {
                 self.with_generic_param_rib(
                     &generics.params,
@@ -3395,7 +3398,7 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
                             },
                             |this| {
                                 this.visit_generics(generics);
-                                if rhs_kind.is_type_const()
+                                if *kind == ConstItemKind::TypeConst
                                     && !this.r.features.generic_const_parameter_types()
                                 {
                                     this.with_rib(TypeNS, RibKind::ConstParamTy, |this| {
@@ -3418,7 +3421,7 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
                                 //
                                 // Type parameters can already be used and as associated consts are
                                 // not used as part of the type system, this is far less surprising.
-                                this.resolve_const_item_rhs(rhs_kind, None);
+                                this.resolve_const_item_rhs(body, None);
                             },
                         )
                     },
@@ -3595,7 +3598,8 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
                 ident,
                 generics,
                 ty,
-                rhs_kind,
+                body,
+                kind,
                 define_opaque,
                 ..
             }) => {
@@ -3627,7 +3631,7 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
                                 );
 
                                 this.visit_generics(generics);
-                                if rhs_kind.is_type_const()
+                                if *kind == ConstItemKind::TypeConst
                                     && !this.r.tcx.features().generic_const_parameter_types()
                                 {
                                     this.with_rib(TypeNS, RibKind::ConstParamTy, |this| {
@@ -3646,7 +3650,7 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
                                 //
                                 // Type parameters can already be used and as associated consts are
                                 // not used as part of the type system, this is far less surprising.
-                                this.resolve_const_item_rhs(rhs_kind, None);
+                                this.resolve_const_item_rhs(body, None);
                             },
                         )
                     },
@@ -3879,20 +3883,16 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
 
     fn resolve_const_item_rhs(
         &mut self,
-        rhs_kind: &'ast ConstItemRhsKind,
+        body: &'ast Option<Box<Expr>>,
         item: Option<(Ident, ConstantItemKind)>,
     ) {
-        self.with_lifetime_rib(LifetimeRibKind::elided(LifetimeRes::Infer), |this| match rhs_kind {
-            ConstItemRhsKind::TypeConst { rhs: Some(anon_const) } => {
-                this.resolve_anon_const(anon_const, AnonConstKind::ConstArg(IsRepeatExpr::No));
-            }
-            ConstItemRhsKind::Body { rhs: Some(expr) } => {
+        if let Some(body) = body {
+            self.with_lifetime_rib(LifetimeRibKind::elided(LifetimeRes::Infer), |this| {
                 this.with_constant_rib(IsRepeatExpr::No, ConstantHasGenerics::Yes, item, |this| {
-                    this.visit_expr(expr)
-                });
-            }
-            _ => (),
-        })
+                    this.visit_expr(body)
+                })
+            })
+        }
     }
 
     fn resolve_delegation(

--- a/src/tools/clippy/clippy_utils/src/ast_utils/mod.rs
+++ b/src/tools/clippy/clippy_utils/src/ast_utils/mod.rs
@@ -189,7 +189,7 @@ fn eq_expr(l: &Expr, r: &Expr) -> bool {
                 && eq_expr(&lf.iter, &rf.iter)
                 && eq_block(&lf.body, &rf.body)
                 && lf.kind == rf.kind
-        }
+        },
         (Loop(lt, ll, _), Loop(rt, rl, _)) => eq_label(ll.as_ref(), rl.as_ref()) && eq_block(lt, rt),
         (Block(lb, ll), Block(rb, rl)) => eq_label(ll.as_ref(), rl.as_ref()) && eq_block(lb, rb),
         (TryBlock(lb, lt), TryBlock(rb, rt)) => eq_block(lb, rb) && both(lt.as_deref(), rt.as_deref(), eq_ty),
@@ -350,7 +350,8 @@ fn eq_item_kind(l: &ItemKind, r: &ItemKind) -> bool {
                 ident: li,
                 generics: lg,
                 ty: lt,
-                rhs_kind: lb,
+                body: lb,
+                kind: lk,
                 define_opaque: _,
             }),
             Const(box ConstItem {
@@ -358,7 +359,9 @@ fn eq_item_kind(l: &ItemKind, r: &ItemKind) -> bool {
                 ident: ri,
                 generics: rg,
                 ty: rt,
-                rhs_kind: rb,
+
+                body: rb,
+                kind: rk,
                 define_opaque: _,
             }),
         ) => {
@@ -366,7 +369,8 @@ fn eq_item_kind(l: &ItemKind, r: &ItemKind) -> bool {
                 && eq_id(*li, *ri)
                 && eq_generics(lg, rg)
                 && eq_ty(lt, rt)
-                && both(Some(lb), Some(rb), eq_const_item_rhs)
+                && lk == rk
+                && both(lb.as_deref(), rb.as_deref(), eq_expr)
         },
         (
             Fn(box ast::Fn {
@@ -615,7 +619,8 @@ fn eq_assoc_item_kind(l: &AssocItemKind, r: &AssocItemKind) -> bool {
                 ident: li,
                 generics: lg,
                 ty: lt,
-                rhs_kind: lb,
+                body: lb,
+                kind: lk,
                 define_opaque: _,
             }),
             Const(box ConstItem {
@@ -623,7 +628,8 @@ fn eq_assoc_item_kind(l: &AssocItemKind, r: &AssocItemKind) -> bool {
                 ident: ri,
                 generics: rg,
                 ty: rt,
-                rhs_kind: rb,
+                body: rb,
+                kind: rk,
                 define_opaque: _,
             }),
         ) => {
@@ -631,7 +637,8 @@ fn eq_assoc_item_kind(l: &AssocItemKind, r: &AssocItemKind) -> bool {
                 && eq_id(*li, *ri)
                 && eq_generics(lg, rg)
                 && eq_ty(lt, rt)
-                && both(Some(lb), Some(rb), eq_const_item_rhs)
+                && lk == rk
+                && both(lb.as_deref(), rb.as_deref(), eq_expr)
         },
         (
             Fn(box ast::Fn {
@@ -789,21 +796,6 @@ fn eq_use_tree(l: &UseTree, r: &UseTree) -> bool {
 
 fn eq_anon_const(l: &AnonConst, r: &AnonConst) -> bool {
     eq_expr(&l.value, &r.value)
-}
-
-fn eq_const_item_rhs(l: &ConstItemRhsKind, r: &ConstItemRhsKind) -> bool {
-    use ConstItemRhsKind::*;
-    match (l, r) {
-        (TypeConst { rhs: Some(l) }, TypeConst { rhs: Some(r) }) => eq_anon_const(l, r),
-        (TypeConst { rhs: None }, TypeConst { rhs: None }) | (Body { rhs: None }, Body { rhs: None }) => true,
-        (Body { rhs: Some(l) }, Body { rhs: Some(r) }) => eq_expr(l, r),
-        (TypeConst { rhs: Some(..) }, TypeConst { rhs: None })
-        | (TypeConst { rhs: None }, TypeConst { rhs: Some(..) })
-        | (Body { rhs: None }, Body { rhs: Some(..) })
-        | (Body { rhs: Some(..) }, Body { rhs: None })
-        | (TypeConst { .. }, Body { .. })
-        | (Body { .. }, TypeConst { .. }) => false,
-    }
 }
 
 fn eq_use_tree_kind(l: &UseTreeKind, r: &UseTreeKind) -> bool {
@@ -1003,9 +995,7 @@ fn eq_attr(l: &Attribute, r: &Attribute) -> bool {
     l.style == r.style
         && match (&l.kind, &r.kind) {
             (DocComment(l1, l2), DocComment(r1, r2)) => l1 == r1 && l2 == r2,
-            (Normal(l), Normal(r)) => {
-                eq_path(&l.item.path, &r.item.path) && eq_attr_args(&l.item.args, &r.item.args)
-            },
+            (Normal(l), Normal(r)) => eq_path(&l.item.path, &r.item.path) && eq_attr_args(&l.item.args, &r.item.args),
             (Synthetic(..), _) | (_, Synthetic(..)) => unreachable!(),
             _ => false,
         }

--- a/src/tools/rustfmt/src/items.rs
+++ b/src/tools/rustfmt/src/items.rs
@@ -2008,7 +2008,7 @@ impl<'a> StaticParts<'a> {
                 ),
                 ast::ItemKind::Const(c) => (
                     Some(c.defaultness),
-                    if c.rhs_kind.is_type_const() {
+                    if c.kind == ast::ConstItemKind::TypeConst {
                         "type const"
                     } else {
                         "const"
@@ -2017,7 +2017,7 @@ impl<'a> StaticParts<'a> {
                     c.ident,
                     &c.ty,
                     ast::Mutability::Not,
-                    c.rhs_kind.expr(),
+                    c.body.as_deref(),
                     Some(&c.generics),
                 ),
                 _ => unreachable!(),
@@ -2039,7 +2039,7 @@ impl<'a> StaticParts<'a> {
     pub(crate) fn from_trait_item(ti: &'a ast::AssocItem, ident: Ident) -> Self {
         let (defaultness, ty, expr_opt, generics, prefix) = match &ti.kind {
             ast::AssocItemKind::Const(c) => {
-                let prefix = if c.rhs_kind.is_type_const() {
+                let prefix = if c.kind == ast::ConstItemKind::TypeConst {
                     "type const"
                 } else {
                     "const"
@@ -2047,7 +2047,7 @@ impl<'a> StaticParts<'a> {
                 (
                     c.defaultness,
                     &c.ty,
-                    c.rhs_kind.expr(),
+                    c.body.as_deref(),
                     Some(&c.generics),
                     prefix,
                 )
@@ -2071,7 +2071,7 @@ impl<'a> StaticParts<'a> {
     pub(crate) fn from_impl_item(ii: &'a ast::AssocItem, ident: Ident) -> Self {
         let (defaultness, ty, expr_opt, generics, prefix) = match &ii.kind {
             ast::AssocItemKind::Const(c) => {
-                let prefix = if c.rhs_kind.is_type_const() {
+                let prefix = if c.kind == ast::ConstItemKind::TypeConst {
                     "type const"
                 } else {
                     "const"
@@ -2079,7 +2079,7 @@ impl<'a> StaticParts<'a> {
                 (
                     c.defaultness,
                     &c.ty,
-                    c.rhs_kind.expr(),
+                    c.body.as_deref(),
                     Some(&c.generics),
                     prefix,
                 )

--- a/tests/ui/const-generics/mgca/type-const-free-anon-const-mismatch.stderr
+++ b/tests/ui/const-generics/mgca/type-const-free-anon-const-mismatch.stderr
@@ -4,7 +4,7 @@ error[E0284]: type annotations needed
 LL | type const X: usize = const { N };
    | ^^^^^^^^^^^^^^^^^^^ cannot infer the value of the constant `_`
    |
-   = note: cannot satisfy `X::{constant#0}::{constant#0} == _`
+   = note: cannot satisfy `X::{constant#0} == _`
 
 error: the constant `"this isn't a usize"` is not of type `usize`
   --> $DIR/type-const-free-anon-const-mismatch.rs:8:1


### PR DESCRIPTION
related to min_generic_const_args, tracking issue here: https://github.com/rust-lang/rust/issues/132980

Previously, we were parsing/lowering the RHS of type consts differently than regular consts. We no longer need to do so, yippee! This deletes the anon const from the RHS of type consts. This removes the fake defid for the rhs of type consts, FYI.

r? @BoxyUwU