### PR TITLE
std: use `arc4random_buf` from libc

### DIFF
--- a/library/std/src/sys/random/arc4random.rs
+++ b/library/std/src/sys/random/arc4random.rs
@@ -9,22 +9,11 @@
 //! wrapper for `getrandom`. Since we need to hook into `getrandom` directly for
 //! `HashMap` keys anyway, we just keep our version).
 
-#[cfg(not(any(
-    target_os = "haiku",
-    target_os = "illumos",
-    target_os = "solaris",
-    target_os = "vita",
-)))]
+#[cfg(not(target_os = "vita"))]
 use libc::arc4random_buf;
 
-// FIXME: move these to libc (except Haiku, that one needs to link to libbsd.so).
-#[cfg(any(
-    target_os = "haiku", // See https://git.haiku-os.org/haiku/tree/headers/compatibility/bsd/stdlib.h
-    target_os = "illumos", // See https://www.illumos.org/man/3C/arc4random
-    target_os = "solaris", // See https://docs.oracle.com/cd/E88353_01/html/E37843/arc4random-3c.html
-    target_os = "vita", // See https://github.com/vitasdk/newlib/blob/b89e5bc183b516945f9ee07eef483ecb916e45ff/newlib/libc/include/stdlib.h#L74
-))]
-#[cfg_attr(target_os = "haiku", link(name = "bsd"))]
+// FIXME: move this to libc
+#[cfg(target_os = "vita")] // See https://github.com/vitasdk/newlib/blob/b89e5bc183b516945f9ee07eef483ecb916e45ff/newlib/libc/include/stdlib.h#L74
 unsafe extern "C" {
     fn arc4random_buf(buf: *mut core::ffi::c_void, nbytes: libc::size_t);
 }


### PR DESCRIPTION
Since I added these uses in rust-lang/rust#129201 an `arc4random_buf` definition was added to libc for [Haiku](https://github.com/rust-lang/libc/pull/3945) and [Solaris/Illumos](https://github.com/rust-lang/libc/pull/3944) so we can stop redefining the symbol in `std`.