### PR TITLE
Remove `ItemLike`

### DIFF
--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -78,12 +78,6 @@ fn target_from_impl_item<'tcx>(tcx: TyCtxt<'tcx>, impl_item: &hir::ImplItem<'_>)
     }
 }
 
-#[derive(Clone, Copy)]
-enum ItemLike<'tcx> {
-    Item(&'tcx Item<'tcx>),
-    ForeignItem,
-}
-
 #[derive(Copy, Clone)]
 pub(crate) enum ProcMacroKind {
     FunctionLike,
@@ -120,7 +114,7 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
         hir_id: HirId,
         span: Span,
         target: Target,
-        item: Option<ItemLike<'_>>,
+        item: Option<&'tcx Item<'tcx>>,
     ) {
         let attrs = self.tcx.hir_attrs(hir_id);
         for attr in attrs {
@@ -176,7 +170,7 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
         hir_id: HirId,
         span: Span,
         target: Target,
-        item: Option<ItemLike<'_>>,
+        item: Option<&'tcx Item<'tcx>>,
         attrs: &[Attribute],
         attr: &AttributeKind,
     ) {
@@ -563,7 +557,7 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
         attr_span: Span,
         hir_id: HirId,
         target: Target,
-        item: Option<ItemLike<'_>>,
+        item: Option<&'tcx Item<'tcx>>,
         directive: Option<&Directive>,
     ) {
         // We only check the non-constness here. A diagnostic for use
@@ -594,21 +588,18 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                     }
                 });
             }
-            match item.unwrap() {
-                ItemLike::Item(it) => match it.expect_impl().constness {
-                    Constness::Const { .. } => {
-                        let item_span = self.tcx.hir_span(hir_id);
-                        self.tcx.emit_node_span_lint(
-                            MISPLACED_DIAGNOSTIC_ATTRIBUTES,
-                            hir_id,
-                            attr_span,
-                            DiagnosticOnConstOnlyForNonConstTraitImpls { item_span },
-                        );
-                        return;
-                    }
-                    Constness::NotConst => return,
-                },
-                ItemLike::ForeignItem => {}
+            match item.unwrap().expect_impl().constness {
+                Constness::Const { .. } => {
+                    let item_span = self.tcx.hir_span(hir_id);
+                    self.tcx.emit_node_span_lint(
+                        MISPLACED_DIAGNOSTIC_ATTRIBUTES,
+                        hir_id,
+                        attr_span,
+                        DiagnosticOnConstOnlyForNonConstTraitImpls { item_span },
+                    );
+                    return;
+                }
+                Constness::NotConst => return,
             }
         }
     }
@@ -818,14 +809,14 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
         attr_span: Span,
         span: Span,
         target: Target,
-        item: Option<ItemLike<'_>>,
+        item: Option<&'tcx Item<'tcx>>,
     ) {
         match target {
             Target::Struct => {
-                if let Some(ItemLike::Item(hir::Item {
+                if let hir::Item {
                     kind: hir::ItemKind::Struct(_, _, hir::VariantData::Struct { fields, .. }),
                     ..
-                })) = item
+                } = item.unwrap()
                     && !fields.is_empty()
                     && fields.iter().any(|f| f.default.is_some())
                 {
@@ -1168,14 +1159,11 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
     /// Checks if `#[rustc_legacy_const_generics]` is applied to a function and has a valid argument.
     fn check_rustc_legacy_const_generics(
         &self,
-        item: Option<ItemLike<'_>>,
+        item: Option<&'tcx Item<'tcx>>,
         attr_span: Span,
         index_list: &ThinVec<(usize, Span)>,
     ) {
-        let Some(ItemLike::Item(Item {
-            kind: ItemKind::Fn { sig: FnSig { decl, .. }, generics, .. },
-            ..
-        })) = item
+        let Some(Item { kind: ItemKind::Fn { sig: FnSig { decl, .. }, generics, .. }, .. }) = item
         else {
             // No error here, since it's already given by the parser
             return;
@@ -1219,7 +1207,7 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
         attrs: &[Attribute],
         span: Span,
         target: Target,
-        item: Option<ItemLike<'_>>,
+        item: Option<&'tcx Item<'tcx>>,
         hir_id: HirId,
     ) {
         // Extract the names of all repr hints, e.g., [foo, bar, align] for:
@@ -1289,11 +1277,7 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
         // Warn on repr(u8, u16), repr(C, simd), and c-like-enum-repr(C, u8)
         if (int_reprs > 1)
             || (is_simd && is_c)
-            || (int_reprs == 1
-                && is_c
-                && item.is_some_and(|item| {
-                    if let ItemLike::Item(item) = item { is_c_like_enum(item) } else { false }
-                }))
+            || (int_reprs == 1 && is_c && item.is_some_and(is_c_like_enum))
         {
             self.tcx.emit_node_span_lint(
                 CONFLICTING_REPR_HINTS,
@@ -1689,7 +1673,7 @@ impl<'tcx> Visitor<'tcx> for CheckAttrVisitor<'tcx> {
         }
 
         let target = Target::from_item(item);
-        self.check_attributes(item.hir_id(), item.span, target, Some(ItemLike::Item(item)));
+        self.check_attributes(item.hir_id(), item.span, target, Some(item));
         intravisit::walk_item(self, item)
     }
 
@@ -1727,7 +1711,7 @@ impl<'tcx> Visitor<'tcx> for CheckAttrVisitor<'tcx> {
 
     fn visit_foreign_item(&mut self, f_item: &'tcx ForeignItem<'tcx>) {
         let target = Target::from_foreign_item(f_item);
-        self.check_attributes(f_item.hir_id(), f_item.span, target, Some(ItemLike::ForeignItem));
+        self.check_attributes(f_item.hir_id(), f_item.span, target, None);
         intravisit::walk_foreign_item(self, f_item)
     }
 


### PR DESCRIPTION
`ItemLike::ForeignItem` was never read.