### PR TITLE
test: update riscv32e-registers.rs for LLVM 24 MC diagnostic changes

### DIFF
--- a/tests/ui/asm/riscv/riscv32e-registers.riscv32e_llvm23.stderr
+++ b/tests/ui/asm/riscv/riscv32e-registers.riscv32e_llvm23.stderr
@@ -1,5 +1,5 @@
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:43:11
+  --> $DIR/riscv32e-registers.rs:57:11
    |
 LL |     asm!("li x16, 0");
    |           ^^^^^^^^^
@@ -11,7 +11,7 @@ LL |     li x16, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:46:11
+  --> $DIR/riscv32e-registers.rs:61:11
    |
 LL |     asm!("li x17, 0");
    |           ^^^^^^^^^
@@ -23,7 +23,7 @@ LL |     li x17, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:49:11
+  --> $DIR/riscv32e-registers.rs:65:11
    |
 LL |     asm!("li x18, 0");
    |           ^^^^^^^^^
@@ -35,7 +35,7 @@ LL |     li x18, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:52:11
+  --> $DIR/riscv32e-registers.rs:69:11
    |
 LL |     asm!("li x19, 0");
    |           ^^^^^^^^^
@@ -47,7 +47,7 @@ LL |     li x19, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:55:11
+  --> $DIR/riscv32e-registers.rs:73:11
    |
 LL |     asm!("li x20, 0");
    |           ^^^^^^^^^
@@ -59,7 +59,7 @@ LL |     li x20, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:58:11
+  --> $DIR/riscv32e-registers.rs:77:11
    |
 LL |     asm!("li x21, 0");
    |           ^^^^^^^^^
@@ -71,7 +71,7 @@ LL |     li x21, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:61:11
+  --> $DIR/riscv32e-registers.rs:81:11
    |
 LL |     asm!("li x22, 0");
    |           ^^^^^^^^^
@@ -83,7 +83,7 @@ LL |     li x22, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:64:11
+  --> $DIR/riscv32e-registers.rs:85:11
    |
 LL |     asm!("li x23, 0");
    |           ^^^^^^^^^
@@ -95,7 +95,7 @@ LL |     li x23, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:67:11
+  --> $DIR/riscv32e-registers.rs:89:11
    |
 LL |     asm!("li x24, 0");
    |           ^^^^^^^^^
@@ -107,7 +107,7 @@ LL |     li x24, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:70:11
+  --> $DIR/riscv32e-registers.rs:93:11
    |
 LL |     asm!("li x25, 0");
    |           ^^^^^^^^^
@@ -119,7 +119,7 @@ LL |     li x25, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:73:11
+  --> $DIR/riscv32e-registers.rs:97:11
    |
 LL |     asm!("li x26, 0");
    |           ^^^^^^^^^
@@ -131,7 +131,7 @@ LL |     li x26, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:76:11
+  --> $DIR/riscv32e-registers.rs:101:11
    |
 LL |     asm!("li x27, 0");
    |           ^^^^^^^^^
@@ -143,7 +143,7 @@ LL |     li x27, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:79:11
+  --> $DIR/riscv32e-registers.rs:105:11
    |
 LL |     asm!("li x28, 0");
    |           ^^^^^^^^^
@@ -155,7 +155,7 @@ LL |     li x28, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:82:11
+  --> $DIR/riscv32e-registers.rs:109:11
    |
 LL |     asm!("li x29, 0");
    |           ^^^^^^^^^
@@ -167,7 +167,7 @@ LL |     li x29, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:85:11
+  --> $DIR/riscv32e-registers.rs:113:11
    |
 LL |     asm!("li x30, 0");
    |           ^^^^^^^^^
@@ -179,7 +179,7 @@ LL |     li x30, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:88:11
+  --> $DIR/riscv32e-registers.rs:117:11
    |
 LL |     asm!("li x31, 0");
    |           ^^^^^^^^^

--- a/tests/ui/asm/riscv/riscv32e-registers.riscv32e_llvm24.stderr
+++ b/tests/ui/asm/riscv/riscv32e-registers.riscv32e_llvm24.stderr
@@ -1,0 +1,194 @@
+error: register must be a GPR
+  --> $DIR/riscv32e-registers.rs:57:11
+   |
+LL |     asm!("li x16, 0");
+   |           ^^^^^^^^^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:1:5
+   |
+LL |     li x16, 0
+   |        ^
+
+error: register must be a GPR
+  --> $DIR/riscv32e-registers.rs:61:11
+   |
+LL |     asm!("li x17, 0");
+   |           ^^^^^^^^^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:1:5
+   |
+LL |     li x17, 0
+   |        ^
+
+error: register must be a GPR
+  --> $DIR/riscv32e-registers.rs:65:11
+   |
+LL |     asm!("li x18, 0");
+   |           ^^^^^^^^^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:1:5
+   |
+LL |     li x18, 0
+   |        ^
+
+error: register must be a GPR
+  --> $DIR/riscv32e-registers.rs:69:11
+   |
+LL |     asm!("li x19, 0");
+   |           ^^^^^^^^^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:1:5
+   |
+LL |     li x19, 0
+   |        ^
+
+error: register must be a GPR
+  --> $DIR/riscv32e-registers.rs:73:11
+   |
+LL |     asm!("li x20, 0");
+   |           ^^^^^^^^^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:1:5
+   |
+LL |     li x20, 0
+   |        ^
+
+error: register must be a GPR
+  --> $DIR/riscv32e-registers.rs:77:11
+   |
+LL |     asm!("li x21, 0");
+   |           ^^^^^^^^^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:1:5
+   |
+LL |     li x21, 0
+   |        ^
+
+error: register must be a GPR
+  --> $DIR/riscv32e-registers.rs:81:11
+   |
+LL |     asm!("li x22, 0");
+   |           ^^^^^^^^^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:1:5
+   |
+LL |     li x22, 0
+   |        ^
+
+error: register must be a GPR
+  --> $DIR/riscv32e-registers.rs:85:11
+   |
+LL |     asm!("li x23, 0");
+   |           ^^^^^^^^^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:1:5
+   |
+LL |     li x23, 0
+   |        ^
+
+error: register must be a GPR
+  --> $DIR/riscv32e-registers.rs:89:11
+   |
+LL |     asm!("li x24, 0");
+   |           ^^^^^^^^^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:1:5
+   |
+LL |     li x24, 0
+   |        ^
+
+error: register must be a GPR
+  --> $DIR/riscv32e-registers.rs:93:11
+   |
+LL |     asm!("li x25, 0");
+   |           ^^^^^^^^^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:1:5
+   |
+LL |     li x25, 0
+   |        ^
+
+error: register must be a GPR
+  --> $DIR/riscv32e-registers.rs:97:11
+   |
+LL |     asm!("li x26, 0");
+   |           ^^^^^^^^^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:1:5
+   |
+LL |     li x26, 0
+   |        ^
+
+error: register must be a GPR
+  --> $DIR/riscv32e-registers.rs:101:11
+   |
+LL |     asm!("li x27, 0");
+   |           ^^^^^^^^^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:1:5
+   |
+LL |     li x27, 0
+   |        ^
+
+error: register must be a GPR
+  --> $DIR/riscv32e-registers.rs:105:11
+   |
+LL |     asm!("li x28, 0");
+   |           ^^^^^^^^^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:1:5
+   |
+LL |     li x28, 0
+   |        ^
+
+error: register must be a GPR
+  --> $DIR/riscv32e-registers.rs:109:11
+   |
+LL |     asm!("li x29, 0");
+   |           ^^^^^^^^^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:1:5
+   |
+LL |     li x29, 0
+   |        ^
+
+error: register must be a GPR
+  --> $DIR/riscv32e-registers.rs:113:11
+   |
+LL |     asm!("li x30, 0");
+   |           ^^^^^^^^^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:1:5
+   |
+LL |     li x30, 0
+   |        ^
+
+error: register must be a GPR
+  --> $DIR/riscv32e-registers.rs:117:11
+   |
+LL |     asm!("li x31, 0");
+   |           ^^^^^^^^^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:1:5
+   |
+LL |     li x31, 0
+   |        ^
+
+error: aborting due to 16 previous errors
+

--- a/tests/ui/asm/riscv/riscv32e-registers.riscv32em_llvm23.stderr
+++ b/tests/ui/asm/riscv/riscv32e-registers.riscv32em_llvm23.stderr
@@ -1,5 +1,5 @@
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:43:11
+  --> $DIR/riscv32e-registers.rs:57:11
    |
 LL |     asm!("li x16, 0");
    |           ^^^^^^^^^
@@ -11,7 +11,7 @@ LL |     li x16, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:46:11
+  --> $DIR/riscv32e-registers.rs:61:11
    |
 LL |     asm!("li x17, 0");
    |           ^^^^^^^^^
@@ -23,7 +23,7 @@ LL |     li x17, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:49:11
+  --> $DIR/riscv32e-registers.rs:65:11
    |
 LL |     asm!("li x18, 0");
    |           ^^^^^^^^^
@@ -35,7 +35,7 @@ LL |     li x18, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:52:11
+  --> $DIR/riscv32e-registers.rs:69:11
    |
 LL |     asm!("li x19, 0");
    |           ^^^^^^^^^
@@ -47,7 +47,7 @@ LL |     li x19, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:55:11
+  --> $DIR/riscv32e-registers.rs:73:11
    |
 LL |     asm!("li x20, 0");
    |           ^^^^^^^^^
@@ -59,7 +59,7 @@ LL |     li x20, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:58:11
+  --> $DIR/riscv32e-registers.rs:77:11
    |
 LL |     asm!("li x21, 0");
    |           ^^^^^^^^^
@@ -71,7 +71,7 @@ LL |     li x21, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:61:11
+  --> $DIR/riscv32e-registers.rs:81:11
    |
 LL |     asm!("li x22, 0");
    |           ^^^^^^^^^
@@ -83,7 +83,7 @@ LL |     li x22, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:64:11
+  --> $DIR/riscv32e-registers.rs:85:11
    |
 LL |     asm!("li x23, 0");
    |           ^^^^^^^^^
@@ -95,7 +95,7 @@ LL |     li x23, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:67:11
+  --> $DIR/riscv32e-registers.rs:89:11
    |
 LL |     asm!("li x24, 0");
    |           ^^^^^^^^^
@@ -107,7 +107,7 @@ LL |     li x24, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:70:11
+  --> $DIR/riscv32e-registers.rs:93:11
    |
 LL |     asm!("li x25, 0");
    |           ^^^^^^^^^
@@ -119,7 +119,7 @@ LL |     li x25, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:73:11
+  --> $DIR/riscv32e-registers.rs:97:11
    |
 LL |     asm!("li x26, 0");
    |           ^^^^^^^^^
@@ -131,7 +131,7 @@ LL |     li x26, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:76:11
+  --> $DIR/riscv32e-registers.rs:101:11
    |
 LL |     asm!("li x27, 0");
    |           ^^^^^^^^^
@@ -143,7 +143,7 @@ LL |     li x27, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:79:11
+  --> $DIR/riscv32e-registers.rs:105:11
    |
 LL |     asm!("li x28, 0");
    |           ^^^^^^^^^
@@ -155,7 +155,7 @@ LL |     li x28, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:82:11
+  --> $DIR/riscv32e-registers.rs:109:11
    |
 LL |     asm!("li x29, 0");
    |           ^^^^^^^^^
@@ -167,7 +167,7 @@ LL |     li x29, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:85:11
+  --> $DIR/riscv32e-registers.rs:113:11
    |
 LL |     asm!("li x30, 0");
    |           ^^^^^^^^^
@@ -179,7 +179,7 @@ LL |     li x30, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:88:11
+  --> $DIR/riscv32e-registers.rs:117:11
    |
 LL |     asm!("li x31, 0");
    |           ^^^^^^^^^

--- a/tests/ui/asm/riscv/riscv32e-registers.riscv32em_llvm24.stderr
+++ b/tests/ui/asm/riscv/riscv32e-registers.riscv32em_llvm24.stderr
@@ -1,0 +1,194 @@
+error: register must be a GPR
+  --> $DIR/riscv32e-registers.rs:57:11
+   |
+LL |     asm!("li x16, 0");
+   |           ^^^^^^^^^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:1:5
+   |
+LL |     li x16, 0
+   |        ^
+
+error: register must be a GPR
+  --> $DIR/riscv32e-registers.rs:61:11
+   |
+LL |     asm!("li x17, 0");
+   |           ^^^^^^^^^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:1:5
+   |
+LL |     li x17, 0
+   |        ^
+
+error: register must be a GPR
+  --> $DIR/riscv32e-registers.rs:65:11
+   |
+LL |     asm!("li x18, 0");
+   |           ^^^^^^^^^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:1:5
+   |
+LL |     li x18, 0
+   |        ^
+
+error: register must be a GPR
+  --> $DIR/riscv32e-registers.rs:69:11
+   |
+LL |     asm!("li x19, 0");
+   |           ^^^^^^^^^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:1:5
+   |
+LL |     li x19, 0
+   |        ^
+
+error: register must be a GPR
+  --> $DIR/riscv32e-registers.rs:73:11
+   |
+LL |     asm!("li x20, 0");
+   |           ^^^^^^^^^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:1:5
+   |
+LL |     li x20, 0
+   |        ^
+
+error: register must be a GPR
+  --> $DIR/riscv32e-registers.rs:77:11
+   |
+LL |     asm!("li x21, 0");
+   |           ^^^^^^^^^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:1:5
+   |
+LL |     li x21, 0
+   |        ^
+
+error: register must be a GPR
+  --> $DIR/riscv32e-registers.rs:81:11
+   |
+LL |     asm!("li x22, 0");
+   |           ^^^^^^^^^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:1:5
+   |
+LL |     li x22, 0
+   |        ^
+
+error: register must be a GPR
+  --> $DIR/riscv32e-registers.rs:85:11
+   |
+LL |     asm!("li x23, 0");
+   |           ^^^^^^^^^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:1:5
+   |
+LL |     li x23, 0
+   |        ^
+
+error: register must be a GPR
+  --> $DIR/riscv32e-registers.rs:89:11
+   |
+LL |     asm!("li x24, 0");
+   |           ^^^^^^^^^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:1:5
+   |
+LL |     li x24, 0
+   |        ^
+
+error: register must be a GPR
+  --> $DIR/riscv32e-registers.rs:93:11
+   |
+LL |     asm!("li x25, 0");
+   |           ^^^^^^^^^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:1:5
+   |
+LL |     li x25, 0
+   |        ^
+
+error: register must be a GPR
+  --> $DIR/riscv32e-registers.rs:97:11
+   |
+LL |     asm!("li x26, 0");
+   |           ^^^^^^^^^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:1:5
+   |
+LL |     li x26, 0
+   |        ^
+
+error: register must be a GPR
+  --> $DIR/riscv32e-registers.rs:101:11
+   |
+LL |     asm!("li x27, 0");
+   |           ^^^^^^^^^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:1:5
+   |
+LL |     li x27, 0
+   |        ^
+
+error: register must be a GPR
+  --> $DIR/riscv32e-registers.rs:105:11
+   |
+LL |     asm!("li x28, 0");
+   |           ^^^^^^^^^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:1:5
+   |
+LL |     li x28, 0
+   |        ^
+
+error: register must be a GPR
+  --> $DIR/riscv32e-registers.rs:109:11
+   |
+LL |     asm!("li x29, 0");
+   |           ^^^^^^^^^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:1:5
+   |
+LL |     li x29, 0
+   |        ^
+
+error: register must be a GPR
+  --> $DIR/riscv32e-registers.rs:113:11
+   |
+LL |     asm!("li x30, 0");
+   |           ^^^^^^^^^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:1:5
+   |
+LL |     li x30, 0
+   |        ^
+
+error: register must be a GPR
+  --> $DIR/riscv32e-registers.rs:117:11
+   |
+LL |     asm!("li x31, 0");
+   |           ^^^^^^^^^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:1:5
+   |
+LL |     li x31, 0
+   |        ^
+
+error: aborting due to 16 previous errors
+

--- a/tests/ui/asm/riscv/riscv32e-registers.riscv32emc_llvm23.stderr
+++ b/tests/ui/asm/riscv/riscv32e-registers.riscv32emc_llvm23.stderr
@@ -1,5 +1,5 @@
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:43:11
+  --> $DIR/riscv32e-registers.rs:57:11
    |
 LL |     asm!("li x16, 0");
    |           ^^^^^^^^^
@@ -11,7 +11,7 @@ LL |     li x16, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:46:11
+  --> $DIR/riscv32e-registers.rs:61:11
    |
 LL |     asm!("li x17, 0");
    |           ^^^^^^^^^
@@ -23,7 +23,7 @@ LL |     li x17, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:49:11
+  --> $DIR/riscv32e-registers.rs:65:11
    |
 LL |     asm!("li x18, 0");
    |           ^^^^^^^^^
@@ -35,7 +35,7 @@ LL |     li x18, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:52:11
+  --> $DIR/riscv32e-registers.rs:69:11
    |
 LL |     asm!("li x19, 0");
    |           ^^^^^^^^^
@@ -47,7 +47,7 @@ LL |     li x19, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:55:11
+  --> $DIR/riscv32e-registers.rs:73:11
    |
 LL |     asm!("li x20, 0");
    |           ^^^^^^^^^
@@ -59,7 +59,7 @@ LL |     li x20, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:58:11
+  --> $DIR/riscv32e-registers.rs:77:11
    |
 LL |     asm!("li x21, 0");
    |           ^^^^^^^^^
@@ -71,7 +71,7 @@ LL |     li x21, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:61:11
+  --> $DIR/riscv32e-registers.rs:81:11
    |
 LL |     asm!("li x22, 0");
    |           ^^^^^^^^^
@@ -83,7 +83,7 @@ LL |     li x22, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:64:11
+  --> $DIR/riscv32e-registers.rs:85:11
    |
 LL |     asm!("li x23, 0");
    |           ^^^^^^^^^
@@ -95,7 +95,7 @@ LL |     li x23, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:67:11
+  --> $DIR/riscv32e-registers.rs:89:11
    |
 LL |     asm!("li x24, 0");
    |           ^^^^^^^^^
@@ -107,7 +107,7 @@ LL |     li x24, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:70:11
+  --> $DIR/riscv32e-registers.rs:93:11
    |
 LL |     asm!("li x25, 0");
    |           ^^^^^^^^^
@@ -119,7 +119,7 @@ LL |     li x25, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:73:11
+  --> $DIR/riscv32e-registers.rs:97:11
    |
 LL |     asm!("li x26, 0");
    |           ^^^^^^^^^
@@ -131,7 +131,7 @@ LL |     li x26, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:76:11
+  --> $DIR/riscv32e-registers.rs:101:11
    |
 LL |     asm!("li x27, 0");
    |           ^^^^^^^^^
@@ -143,7 +143,7 @@ LL |     li x27, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:79:11
+  --> $DIR/riscv32e-registers.rs:105:11
    |
 LL |     asm!("li x28, 0");
    |           ^^^^^^^^^
@@ -155,7 +155,7 @@ LL |     li x28, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:82:11
+  --> $DIR/riscv32e-registers.rs:109:11
    |
 LL |     asm!("li x29, 0");
    |           ^^^^^^^^^
@@ -167,7 +167,7 @@ LL |     li x29, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:85:11
+  --> $DIR/riscv32e-registers.rs:113:11
    |
 LL |     asm!("li x30, 0");
    |           ^^^^^^^^^
@@ -179,7 +179,7 @@ LL |     li x30, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:88:11
+  --> $DIR/riscv32e-registers.rs:117:11
    |
 LL |     asm!("li x31, 0");
    |           ^^^^^^^^^

--- a/tests/ui/asm/riscv/riscv32e-registers.riscv32emc_llvm24.stderr
+++ b/tests/ui/asm/riscv/riscv32e-registers.riscv32emc_llvm24.stderr
@@ -1,0 +1,194 @@
+error: register must be a GPR
+  --> $DIR/riscv32e-registers.rs:57:11
+   |
+LL |     asm!("li x16, 0");
+   |           ^^^^^^^^^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:1:5
+   |
+LL |     li x16, 0
+   |        ^
+
+error: register must be a GPR
+  --> $DIR/riscv32e-registers.rs:61:11
+   |
+LL |     asm!("li x17, 0");
+   |           ^^^^^^^^^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:1:5
+   |
+LL |     li x17, 0
+   |        ^
+
+error: register must be a GPR
+  --> $DIR/riscv32e-registers.rs:65:11
+   |
+LL |     asm!("li x18, 0");
+   |           ^^^^^^^^^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:1:5
+   |
+LL |     li x18, 0
+   |        ^
+
+error: register must be a GPR
+  --> $DIR/riscv32e-registers.rs:69:11
+   |
+LL |     asm!("li x19, 0");
+   |           ^^^^^^^^^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:1:5
+   |
+LL |     li x19, 0
+   |        ^
+
+error: register must be a GPR
+  --> $DIR/riscv32e-registers.rs:73:11
+   |
+LL |     asm!("li x20, 0");
+   |           ^^^^^^^^^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:1:5
+   |
+LL |     li x20, 0
+   |        ^
+
+error: register must be a GPR
+  --> $DIR/riscv32e-registers.rs:77:11
+   |
+LL |     asm!("li x21, 0");
+   |           ^^^^^^^^^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:1:5
+   |
+LL |     li x21, 0
+   |        ^
+
+error: register must be a GPR
+  --> $DIR/riscv32e-registers.rs:81:11
+   |
+LL |     asm!("li x22, 0");
+   |           ^^^^^^^^^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:1:5
+   |
+LL |     li x22, 0
+   |        ^
+
+error: register must be a GPR
+  --> $DIR/riscv32e-registers.rs:85:11
+   |
+LL |     asm!("li x23, 0");
+   |           ^^^^^^^^^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:1:5
+   |
+LL |     li x23, 0
+   |        ^
+
+error: register must be a GPR
+  --> $DIR/riscv32e-registers.rs:89:11
+   |
+LL |     asm!("li x24, 0");
+   |           ^^^^^^^^^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:1:5
+   |
+LL |     li x24, 0
+   |        ^
+
+error: register must be a GPR
+  --> $DIR/riscv32e-registers.rs:93:11
+   |
+LL |     asm!("li x25, 0");
+   |           ^^^^^^^^^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:1:5
+   |
+LL |     li x25, 0
+   |        ^
+
+error: register must be a GPR
+  --> $DIR/riscv32e-registers.rs:97:11
+   |
+LL |     asm!("li x26, 0");
+   |           ^^^^^^^^^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:1:5
+   |
+LL |     li x26, 0
+   |        ^
+
+error: register must be a GPR
+  --> $DIR/riscv32e-registers.rs:101:11
+   |
+LL |     asm!("li x27, 0");
+   |           ^^^^^^^^^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:1:5
+   |
+LL |     li x27, 0
+   |        ^
+
+error: register must be a GPR
+  --> $DIR/riscv32e-registers.rs:105:11
+   |
+LL |     asm!("li x28, 0");
+   |           ^^^^^^^^^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:1:5
+   |
+LL |     li x28, 0
+   |        ^
+
+error: register must be a GPR
+  --> $DIR/riscv32e-registers.rs:109:11
+   |
+LL |     asm!("li x29, 0");
+   |           ^^^^^^^^^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:1:5
+   |
+LL |     li x29, 0
+   |        ^
+
+error: register must be a GPR
+  --> $DIR/riscv32e-registers.rs:113:11
+   |
+LL |     asm!("li x30, 0");
+   |           ^^^^^^^^^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:1:5
+   |
+LL |     li x30, 0
+   |        ^
+
+error: register must be a GPR
+  --> $DIR/riscv32e-registers.rs:117:11
+   |
+LL |     asm!("li x31, 0");
+   |           ^^^^^^^^^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:1:5
+   |
+LL |     li x31, 0
+   |        ^
+
+error: aborting due to 16 previous errors
+

--- a/tests/ui/asm/riscv/riscv32e-registers.rs
+++ b/tests/ui/asm/riscv/riscv32e-registers.rs
@@ -2,15 +2,29 @@
 //
 //@ add-minicore
 //@ build-fail
-//@ revisions: riscv32e riscv32em riscv32emc
-//
+//@ revisions: riscv32e_llvm23 riscv32em_llvm23 riscv32emc_llvm23
+//@ revisions: riscv32e_llvm24 riscv32em_llvm24 riscv32emc_llvm24
 //@ compile-flags: --crate-type=rlib
-//@ [riscv32e] needs-llvm-components: riscv
-//@ [riscv32e] compile-flags: --target=riscv32e-unknown-none-elf
-//@ [riscv32em] needs-llvm-components: riscv
-//@ [riscv32em] compile-flags: --target=riscv32em-unknown-none-elf
-//@ [riscv32emc] needs-llvm-components: riscv
-//@ [riscv32emc] compile-flags: --target=riscv32emc-unknown-none-elf
+//@ [riscv32e_llvm23] needs-llvm-components: riscv
+//@ [riscv32e_llvm23] compile-flags: --target=riscv32e-unknown-none-elf
+//@ [riscv32e_llvm23] max-llvm-major-version: 23
+//@ [riscv32e_llvm24] needs-llvm-components: riscv
+//@ [riscv32e_llvm24] compile-flags: --target=riscv32e-unknown-none-elf
+//@ [riscv32e_llvm24] min-llvm-version: 24
+
+//@ [riscv32em_llvm23] needs-llvm-components: riscv
+//@ [riscv32em_llvm23] compile-flags: --target=riscv32em-unknown-none-elf
+//@ [riscv32em_llvm23] max-llvm-major-version: 23
+//@ [riscv32em_llvm24] needs-llvm-components: riscv
+//@ [riscv32em_llvm24] compile-flags: --target=riscv32em-unknown-none-elf
+//@ [riscv32em_llvm24] min-llvm-version: 24
+
+//@ [riscv32emc_llvm23] needs-llvm-components: riscv
+//@ [riscv32emc_llvm23] compile-flags: --target=riscv32emc-unknown-none-elf
+//@ [riscv32emc_llvm23] max-llvm-major-version: 23
+//@ [riscv32emc_llvm24] needs-llvm-components: riscv
+//@ [riscv32emc_llvm24] compile-flags: --target=riscv32emc-unknown-none-elf
+//@ [riscv32emc_llvm24] min-llvm-version: 24
 //@ ignore-backends: gcc
 
 // Unlike bad-reg.rs, this tests if the assembler can reject invalid registers
@@ -41,51 +55,67 @@ pub unsafe fn registers() {
     asm!("li x14, 0");
     asm!("li x15, 0");
     asm!("li x16, 0");
-    //~^ ERROR invalid operand for instruction
+    //[riscv32e_llvm23,riscv32em_llvm23,riscv32emc_llvm23]~^ ERROR invalid operand for instruction
+    //[riscv32e_llvm24,riscv32em_llvm24,riscv32emc_llvm24]~^^ ERROR register must be a GPR
     //~| NOTE instantiated into assembly here
     asm!("li x17, 0");
-    //~^ ERROR invalid operand for instruction
+    //[riscv32e_llvm23,riscv32em_llvm23,riscv32emc_llvm23]~^ ERROR invalid operand for instruction
+    //[riscv32e_llvm24,riscv32em_llvm24,riscv32emc_llvm24]~^^ ERROR register must be a GPR
     //~| NOTE instantiated into assembly here
     asm!("li x18, 0");
-    //~^ ERROR invalid operand for instruction
+    //[riscv32e_llvm23,riscv32em_llvm23,riscv32emc_llvm23]~^ ERROR invalid operand for instruction
+    //[riscv32e_llvm24,riscv32em_llvm24,riscv32emc_llvm24]~^^ ERROR register must be a GPR
     //~| NOTE instantiated into assembly here
     asm!("li x19, 0");
-    //~^ ERROR invalid operand for instruction
+    //[riscv32e_llvm23,riscv32em_llvm23,riscv32emc_llvm23]~^ ERROR invalid operand for instruction
+    //[riscv32e_llvm24,riscv32em_llvm24,riscv32emc_llvm24]~^^ ERROR register must be a GPR
     //~| NOTE instantiated into assembly here
     asm!("li x20, 0");
-    //~^ ERROR invalid operand for instruction
+    //[riscv32e_llvm23,riscv32em_llvm23,riscv32emc_llvm23]~^ ERROR invalid operand for instruction
+    //[riscv32e_llvm24,riscv32em_llvm24,riscv32emc_llvm24]~^^ ERROR register must be a GPR
     //~| NOTE instantiated into assembly here
     asm!("li x21, 0");
-    //~^ ERROR invalid operand for instruction
+    //[riscv32e_llvm23,riscv32em_llvm23,riscv32emc_llvm23]~^ ERROR invalid operand for instruction
+    //[riscv32e_llvm24,riscv32em_llvm24,riscv32emc_llvm24]~^^ ERROR register must be a GPR
     //~| NOTE instantiated into assembly here
     asm!("li x22, 0");
-    //~^ ERROR invalid operand for instruction
+    //[riscv32e_llvm23,riscv32em_llvm23,riscv32emc_llvm23]~^ ERROR invalid operand for instruction
+    //[riscv32e_llvm24,riscv32em_llvm24,riscv32emc_llvm24]~^^ ERROR register must be a GPR
     //~| NOTE instantiated into assembly here
     asm!("li x23, 0");
-    //~^ ERROR invalid operand for instruction
+    //[riscv32e_llvm23,riscv32em_llvm23,riscv32emc_llvm23]~^ ERROR invalid operand for instruction
+    //[riscv32e_llvm24,riscv32em_llvm24,riscv32emc_llvm24]~^^ ERROR register must be a GPR
     //~| NOTE instantiated into assembly here
     asm!("li x24, 0");
-    //~^ ERROR invalid operand for instruction
+    //[riscv32e_llvm23,riscv32em_llvm23,riscv32emc_llvm23]~^ ERROR invalid operand for instruction
+    //[riscv32e_llvm24,riscv32em_llvm24,riscv32emc_llvm24]~^^ ERROR register must be a GPR
     //~| NOTE instantiated into assembly here
     asm!("li x25, 0");
-    //~^ ERROR invalid operand for instruction
+    //[riscv32e_llvm23,riscv32em_llvm23,riscv32emc_llvm23]~^ ERROR invalid operand for instruction
+    //[riscv32e_llvm24,riscv32em_llvm24,riscv32emc_llvm24]~^^ ERROR register must be a GPR
     //~| NOTE instantiated into assembly here
     asm!("li x26, 0");
-    //~^ ERROR invalid operand for instruction
+    //[riscv32e_llvm23,riscv32em_llvm23,riscv32emc_llvm23]~^ ERROR invalid operand for instruction
+    //[riscv32e_llvm24,riscv32em_llvm24,riscv32emc_llvm24]~^^ ERROR register must be a GPR
     //~| NOTE instantiated into assembly here
     asm!("li x27, 0");
-    //~^ ERROR invalid operand for instruction
+    //[riscv32e_llvm23,riscv32em_llvm23,riscv32emc_llvm23]~^ ERROR invalid operand for instruction
+    //[riscv32e_llvm24,riscv32em_llvm24,riscv32emc_llvm24]~^^ ERROR register must be a GPR
     //~| NOTE instantiated into assembly here
     asm!("li x28, 0");
-    //~^ ERROR invalid operand for instruction
+    //[riscv32e_llvm23,riscv32em_llvm23,riscv32emc_llvm23]~^ ERROR invalid operand for instruction
+    //[riscv32e_llvm24,riscv32em_llvm24,riscv32emc_llvm24]~^^ ERROR register must be a GPR
     //~| NOTE instantiated into assembly here
     asm!("li x29, 0");
-    //~^ ERROR invalid operand for instruction
+    //[riscv32e_llvm23,riscv32em_llvm23,riscv32emc_llvm23]~^ ERROR invalid operand for instruction
+    //[riscv32e_llvm24,riscv32em_llvm24,riscv32emc_llvm24]~^^ ERROR register must be a GPR
     //~| NOTE instantiated into assembly here
     asm!("li x30, 0");
-    //~^ ERROR invalid operand for instruction
+    //[riscv32e_llvm23,riscv32em_llvm23,riscv32emc_llvm23]~^ ERROR invalid operand for instruction
+    //[riscv32e_llvm24,riscv32em_llvm24,riscv32emc_llvm24]~^^ ERROR register must be a GPR
     //~| NOTE instantiated into assembly here
     asm!("li x31, 0");
-    //~^ ERROR invalid operand for instruction
+    //[riscv32e_llvm23,riscv32em_llvm23,riscv32emc_llvm23]~^ ERROR invalid operand for instruction
+    //[riscv32e_llvm24,riscv32em_llvm24,riscv32emc_llvm24]~^^ ERROR register must be a GPR
     //~| NOTE instantiated into assembly here
 }


### PR DESCRIPTION
LLVM 24 updates (in llvm/llvm-project@bff9c544bd87) the diagnostic string for the RISC-V GPR register class in MC. As a result, invalid register operand references (such as x16..=x31 on riscv32e targets) now emit "register must be a GPR" instead of "invalid operand for instruction".

To keep the test passing on both LLVM <=23 and LLVM >=24, split the target revisions into versioned pairs (e.g. riscv32e_llvm23 and riscv32e_llvm24) gated by `max-llvm-major-version: 23` and `min-llvm-version: 24`, respectively, with corresponding stderr references. This is admittedly a bit aggressive - I'm also fine if we want to just set a max-llvm-major-version and ignore it or preemptively bump it for 24 and set the min version instead of this complexity.