### PR TITLE
Reduce MIR cost penalty for asserts and diverging calls to improve inlining of safety-checked functions

### DIFF
--- a/compiler/rustc_mir_transform/src/cost_checker.rs
+++ b/compiler/rustc_mir_transform/src/cost_checker.rs
@@ -107,14 +107,11 @@ impl<'tcx> Visitor<'tcx> for CostChecker<'_, 'tcx> {
                     }
                 }
             }
-            TerminatorKind::Call { func, unwind, target, .. } => {
+            TerminatorKind::Call { func, unwind, .. } => {
                 self.penalty += if let Some((def_id, ..)) = func.const_fn_def()
                     && self.tcx.intrinsic(def_id).is_some()
                 {
                     // Don't give intrinsics the extra penalty for calls
-                    INSTR_COST
-                } else if target.is_none() {
-                    // Diverging calls (like panics) are likely cold/error paths.
                     INSTR_COST
                 } else {
                     CALL_PENALTY

--- a/compiler/rustc_mir_transform/src/cost_checker.rs
+++ b/compiler/rustc_mir_transform/src/cost_checker.rs
@@ -101,7 +101,11 @@ impl<'tcx> Visitor<'tcx> for CostChecker<'_, 'tcx> {
                 // If the place doesn't actually need dropping, treat it like a regular goto.
                 let ty = self.instantiate_ty(place.ty(self.callee_body, self.tcx).ty);
                 if ty.needs_drop(self.tcx, self.typing_env) {
-                    self.penalty += CALL_PENALTY;
+                    let local_idx = place.local.as_usize();
+                    let is_dropping_argument = local_idx >= 1
+                        && local_idx <= self.callee_body.arg_count
+                        && place.projection.is_empty();
+                    self.penalty += if is_dropping_argument { INSTR_COST } else { CALL_PENALTY };
                     if let UnwindAction::Cleanup(_) = unwind {
                         self.penalty += LANDINGPAD_PENALTY;
                     }
@@ -135,10 +139,18 @@ impl<'tcx> Visitor<'tcx> for CostChecker<'_, 'tcx> {
                     self.penalty += INSTR_COST;
                 }
             }
-            TerminatorKind::Assert { unwind, .. } => {
-                // Asserts are safety checks (bounds, overflow). Discount them
-                // because inlining is required to prove them unreachable.
-                self.penalty += INSTR_COST;
+            TerminatorKind::Assert { msg, unwind, .. } => {
+                let is_compiler_safety_check = matches!(
+                    &**msg,
+                    AssertKind::BoundsCheck { .. }
+                        | AssertKind::Overflow(..)
+                        | AssertKind::OverflowNeg(..)
+                        | AssertKind::DivisionByZero(..)
+                        | AssertKind::RemainderByZero(..)
+                        | AssertKind::MisalignedPointerDereference { .. }
+                        | AssertKind::NullPointerDereference
+                );
+                self.penalty += if is_compiler_safety_check { INSTR_COST } else { CALL_PENALTY };
                 if let UnwindAction::Cleanup(_) = unwind {
                     self.penalty += LANDINGPAD_PENALTY;
                 }

--- a/compiler/rustc_mir_transform/src/cost_checker.rs
+++ b/compiler/rustc_mir_transform/src/cost_checker.rs
@@ -107,11 +107,14 @@ impl<'tcx> Visitor<'tcx> for CostChecker<'_, 'tcx> {
                     }
                 }
             }
-            TerminatorKind::Call { func, unwind, .. } => {
+            TerminatorKind::Call { func, unwind, target, .. } => {
                 self.penalty += if let Some((def_id, ..)) = func.const_fn_def()
                     && self.tcx.intrinsic(def_id).is_some()
                 {
                     // Don't give intrinsics the extra penalty for calls
+                    INSTR_COST
+                } else if target.is_none() {
+                    // Diverging calls (like panics) are likely cold/error paths.
                     INSTR_COST
                 } else {
                     CALL_PENALTY
@@ -135,20 +138,10 @@ impl<'tcx> Visitor<'tcx> for CostChecker<'_, 'tcx> {
                     self.penalty += INSTR_COST;
                 }
             }
-            TerminatorKind::Assert { unwind, msg, .. } => {
-                self.penalty += if msg.is_optional_overflow_check()
-                    && !self
-                        .tcx
-                        .sess
-                        .opts
-                        .unstable_opts
-                        .inline_mir_preserve_debug
-                        .unwrap_or(self.tcx.sess.overflow_checks())
-                {
-                    INSTR_COST
-                } else {
-                    CALL_PENALTY
-                };
+            TerminatorKind::Assert { unwind, .. } => {
+                // Asserts are safety checks (bounds, overflow). Discount them
+                // because inlining is required to prove them unreachable.
+                self.penalty += INSTR_COST;
                 if let UnwindAction::Cleanup(_) = unwind {
                     self.penalty += LANDINGPAD_PENALTY;
                 }


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/159611)*
<!-- homu-ignore:end -->

Implicit Rust safety checks (arithmetic overflow, bounds checks) generate `Assert` terminators and diverging `Calls` (panics) in MIR. Currently, the MIR inliner penalizes these as expensive function calls.

This creates a Catch-22: the compiler blocks inlining because the safety checks make the function look too large, but inlining is what is required to prove those checks are unreachable and optimize them away. This penalizes small, hot functions containing safety checks.

This PR modify `CostChecker` in `cost_checker.rs` to:

Charge `TerminatorKind::Assert` as a standard instruction instead of a full call.
Charge diverging `TerminatorKind::Call`s (panic paths) as `INSTR_COST = 5`.