### PR TITLE
Set the rustc lib path for unstable-book-gen

### DIFF
--- a/src/bootstrap/src/core/build_steps/doc.rs
+++ b/src/bootstrap/src/core/build_steps/doc.rs
@@ -1319,6 +1319,10 @@ impl Step for UnstableBookGen {
         cmd.arg(rustc_path);
         cmd.arg(out);
 
+        // Running rustc requires the library path if rust.rpath = false
+        // or any other libraries are in a custom location.
+        builder.add_rustc_lib_path(self.build_compiler, &mut cmd);
+
         cmd.run(builder);
     }
 }

--- a/src/tools/unstable-book-gen/src/main.rs
+++ b/src/tools/unstable-book-gen/src/main.rs
@@ -128,6 +128,7 @@ fn collect_compiler_flags(rustc_path: impl AsRef<Path>) -> Features {
     rustc.env("RUSTC_BOOTSTRAP", "1");
     rustc.arg("-Zhelp");
     let output = t!(rustc.output());
+    assert!(output.status.success(), "`rustc -Zhelp` failed: {output:?}");
     let help_str = t!(String::from_utf8(output.stdout));
     let parts = help_str.split("\n    -Z").collect::<Vec<_>>();
     assert!(!parts[1..].is_empty(), "no -Z options were found");


### PR DESCRIPTION
When configured with `rust.rpath = false` or using any other custom
library configurations, running `rustc` requires a library path too.
This was missing from `unstable-book-gen`'s new `rustc -Zhelp`.
