### PR TITLE
debuginfo generation for unsafe binders

### DIFF
--- a/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
@@ -1635,7 +1635,7 @@ fn build_unsafe_binder_type_di_node<'ll, 'tcx>(
             binder_type
         )
     };
-    let inner_type = inner.skip_binder();
+    let inner_type = cx.tcx.instantiate_bound_regions_with_erased((*inner).into());
     let inner_type_di_node = type_di_node(cx, inner_type);
 
     let type_name = compute_debuginfo_type_name(cx.tcx, binder_type, true);

--- a/tests/ui/unsafe-binders/debuginfo-escaping-bound-vars-issue-159576.rs
+++ b/tests/ui/unsafe-binders/debuginfo-escaping-bound-vars-issue-159576.rs
@@ -1,0 +1,9 @@
+//@ check-pass
+//@ compile-flags: --crate-type=lib -Cdebuginfo=2
+
+#![feature(unsafe_binders)]
+#![allow(incomplete_features)]
+
+pub fn woof() -> unsafe<'a, 'b> &'b Box<dyn Fn(Box<dyn Fn() -> &'a isize>)> {
+    todo!()
+}


### PR DESCRIPTION
debug-info generation removed an unsafe binder which allowed bound regions to escape into layout and trait queries while constructing the inner debug info type
instantiate those bound regions with erased regions before constructing the inner debug info node

Fix rust-lang/rust#159576