### PR TITLE
Clarify the comment about stage1/stage2 discrepancy in input-stats test

### DIFF
--- a/tests/ui/stats/input-stats.rs
+++ b/tests/ui/stats/input-stats.rs
@@ -10,8 +10,9 @@
 // many or all percentages, which makes the diffs hard to read.
 //@ normalize-stderr: "\([0-9 ][0-9]\.[0-9]%\)" -> "(NN.N%)"
 
-// Type layouts sometimes change. When that happens, until the next bootstrap
-// bump occurs, stage1 and stage2 will give different outputs for this test.
+// Type layouts sometimes change when layout algorithm changes.
+// When that happens, until the next bootstrap bump occurs,
+// stage1 and stage2 will give different outputs for this test.
 // Add an `ignore-stage1` comment marker to work around that problem during
 // that time.
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

I was very confused by this comment. The test in question breaks when you change AST types and the comment says "Type layout sometimes change" which seems to imply that you have to do the `ignore-stage1` flip to fix it. But we do these layout changes all the time and I haven't seen anybody to do this.

It only became clear only when I dug through history and found the last time the `ignore-stage1` was used here (on layout algorithm change in 2023). It's only relevant when type layouts change in _rustc output_, not in rustc source code.

r? nnethercote