### PR TITLE
rustc_fs_util: avoid partial-file read race in link_or_copy's copy fallback

### DIFF
--- a/compiler/rustc_fs_util/src/lib.rs
+++ b/compiler/rustc_fs_util/src/lib.rs
@@ -80,8 +80,38 @@ pub fn link_or_copy<P: AsRef<Path>, Q: AsRef<Path>>(p: P, q: Q) -> io::Result<Li
         }
     }
 
-    // Hard linking failed, fall back to copying.
-    fs::copy(p, q).map(|_| LinkOrCopy::Copy)
+    // Hard linking failed, fall back to copying. Go via a temporary file in
+    // `q`'s own directory followed by an atomic rename, rather than copying
+    // straight into `q`: on platforms where hard-linking always fails (e.g.
+    // Haiku's BFS, which unconditionally rejects `link()`), this fallback is
+    // taken for every single incremental-compilation artifact, so copying
+    // directly into `q` leaves a window, for as long as the copy takes,
+    // during which a concurrent reader can observe a partially-written file.
+    // For large files that window is easily hit under a normal parallel
+    // build, silently producing corrupt incremental/metadata state instead
+    // of a clean error.
+    copy_via_tempfile_and_rename(p, q).map(|()| LinkOrCopy::Copy)
+}
+
+fn copy_via_tempfile_and_rename(src: &Path, dst: &Path) -> io::Result<()> {
+    let dst_dir = dst.parent().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("destination `{}` has no parent directory", dst.display()),
+        )
+    })?;
+    let mut tmp = tempfile::Builder::new()
+        .prefix(dst.file_name().unwrap_or_default())
+        .tempfile_in(dst_dir)?;
+    let mut src_file = fs::File::open(src)?;
+    io::copy(&mut src_file, tmp.as_file_mut())?;
+    // `fs::copy` (what this function replaces) also copies the source's
+    // permissions, which matters for executable outputs; a freshly created
+    // NamedTempFile does not inherit them, so set them explicitly before
+    // persisting.
+    tmp.as_file().set_permissions(src_file.metadata()?.permissions())?;
+    tmp.persist(dst).map_err(|e| e.error)?;
+    Ok(())
 }
 
 #[cfg(any(unix, all(target_os = "wasi", target_env = "p1")))]
@@ -140,3 +170,6 @@ impl<'a, 'b> TempDirBuilder<'a, 'b> {
         self.builder.tempdir_in(dir)
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/compiler/rustc_fs_util/src/tests.rs
+++ b/compiler/rustc_fs_util/src/tests.rs
@@ -1,0 +1,40 @@
+use super::copy_via_tempfile_and_rename;
+
+#[test]
+fn copy_via_tempfile_and_rename_copies_contents() {
+    let tmpdir = tempfile::tempdir().unwrap();
+    let src = tmpdir.path().join("src");
+    let dst = tmpdir.path().join("dst");
+    std::fs::write(&src, b"hello from copy_via_tempfile_and_rename").unwrap();
+
+    copy_via_tempfile_and_rename(&src, &dst).unwrap();
+
+    assert_eq!(std::fs::read(&dst).unwrap(), b"hello from copy_via_tempfile_and_rename");
+}
+
+#[test]
+#[cfg(unix)]
+fn copy_via_tempfile_and_rename_preserves_permissions() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let tmpdir = tempfile::tempdir().unwrap();
+    let src = tmpdir.path().join("src");
+    let dst = tmpdir.path().join("dst");
+    std::fs::write(&src, b"#!/bin/sh\necho hi\n").unwrap();
+
+    // A NamedTempFile defaults to a restrictive mode (no execute bit);
+    // this is exactly the executable-incremental-artifact scenario the
+    // permission-preserving copy needs to get right.
+    let executable_mode = 0o755;
+    std::fs::set_permissions(&src, std::fs::Permissions::from_mode(executable_mode)).unwrap();
+
+    copy_via_tempfile_and_rename(&src, &dst).unwrap();
+
+    let dst_mode = std::fs::metadata(&dst).unwrap().permissions().mode();
+    let mask = 0o777;
+    assert_eq!(
+        executable_mode,
+        dst_mode & mask,
+        "copy_via_tempfile_and_rename must preserve the source's execute bit"
+    );
+}


### PR DESCRIPTION
## Summary

`link_or_copy` falls back to `fs::copy(p, q)` when hard-linking fails, copying directly into the destination path. On platforms where hard links are never available (e.g. Haiku), every artifact copied through this helper takes that fallback, and a copy straight into the final path is observable in a partially-written state while it runs.

This PR makes the fallback copy into a `NamedTempFile` in the destination's directory and persist it into place (same filesystem, so the rename is atomic) — readers only ever observe the old file, no file, or the complete new file. The source's permission bits are preserved explicitly (`fs::copy` did this; a fresh temp file does not — it matters for executable outputs). Unit tests cover content and permission preservation.

Related: rust-lang/rust#120581, rust-lang/rust#138847 — metadata-decode ICEs on Haiku consistent with partially-written/corrupted artifacts.

## Status and caveats (honest summary)

- The reproduction that motivated this (details in rust-lang/cargo#17241) was a **non-incremental** `cargo build --release`, which exercises cargo's equivalent copy fallback rather than this helper. This PR is the same hardening applied to rustc's copy of the pattern, which incremental compilation uses heavily on such platforms — it is not itself a demonstrated fix for the linked ICEs.
- Empirical data from a Haiku VM: parallel builds of a wgpu project failed consistently with metadata-decode ICEs; `-j 1` clean builds succeeded; re-running the failed rustc invocation standalone against the already-written rlib reproduced the ICE (bytes bad at rest, not a transient read). The exact writer/reader interleaving has **not** been traced yet, and a similar failure recurred once even with the cargo-side patch applied, so the true corruption site is still an open question.