### PR TITLE
Avoid wrapper layout queries for `MaybeUninit`

### DIFF
--- a/compiler/rustc_ty_utils/src/layout.rs
+++ b/compiler/rustc_ty_utils/src/layout.rs
@@ -23,7 +23,7 @@ use rustc_middle::ty::{
     TypeVisitableExt, Unnormalized,
 };
 use rustc_session::{DataTypeKind, FieldInfo, FieldKind, SizeKind, VariantInfo};
-use rustc_span::{Symbol, sym};
+use rustc_span::{DUMMY_SP, Symbol, sym};
 use tracing::{debug, instrument};
 
 use crate::diagnostics::NonPrimitiveSimdType;
@@ -682,6 +682,28 @@ fn layout_of_uncached<'tcx>(
             }
 
             map_layout(cx.calc.simd_type(e_ly, e_len, def.repr().packed()))?
+        }
+
+        ty::Adt(def, args) if tcx.is_lang_item(def.did(), hir::LangItem::MaybeUninit) => {
+            // `MaybeUninit<T>` is a lang item. Coroutines use it for saved locals.
+            // Compute the union from `T` so nested coroutines do not eagerly walk
+            // `MaybeUninit<T> -> ManuallyDrop<T> -> MaybeDangling<T> -> T`.
+            // Field projection still uses the real ADT fields through `TyAndLayout::field`.
+            let field = cx.layout_of(args.type_at(0))?;
+            let unit = cx.layout_of(tcx.types.unit)?;
+            let maybe_dangling = tcx.require_lang_item(hir::LangItem::MaybeDangling, DUMMY_SP);
+            let manually_drop = tcx.require_lang_item(hir::LangItem::ManuallyDrop, DUMMY_SP);
+            let mut value_layout = LayoutData::clone(&field.layout.0);
+            // Keep the seed equal to the skipped transparent wrappers.
+            value_layout.randomization_seed = field
+                .randomization_seed
+                .wrapping_add(tcx.adt_def(maybe_dangling).repr().field_shuffle_seed)
+                .wrapping_add(tcx.adt_def(manually_drop).repr().field_shuffle_seed);
+            let value_layout = tcx.mk_layout(value_layout);
+            let value = TyAndLayout { ty: field.ty, layout: value_layout };
+            let variants = IndexVec::from_raw(vec![IndexVec::from_raw(vec![unit, value])]);
+
+            map_layout(cx.calc.layout_of_union(&def.repr(), &variants))?
         }
 
         // ADTs.

--- a/compiler/rustc_ty_utils/src/layout.rs
+++ b/compiler/rustc_ty_utils/src/layout.rs
@@ -23,7 +23,7 @@ use rustc_middle::ty::{
     TypeVisitableExt, Unnormalized,
 };
 use rustc_session::{DataTypeKind, FieldInfo, FieldKind, SizeKind, VariantInfo};
-use rustc_span::{DUMMY_SP, Symbol, sym};
+use rustc_span::{Symbol, sym};
 use tracing::{debug, instrument};
 
 use crate::diagnostics::NonPrimitiveSimdType;
@@ -684,15 +684,24 @@ fn layout_of_uncached<'tcx>(
             map_layout(cx.calc.simd_type(e_ly, e_len, def.repr().packed()))?
         }
 
-        ty::Adt(def, args) if tcx.is_lang_item(def.did(), hir::LangItem::MaybeUninit) => {
+        // Use this path only when all skipped wrappers are lang items.
+        ty::Adt(def, args)
+            if tcx.is_lang_item(def.did(), hir::LangItem::MaybeUninit)
+                // Some no-core crates define a smaller `MaybeUninit` without `MaybeDangling`.
+                && tcx.lang_items().maybe_dangling().is_some()
+                && tcx.lang_items().manually_drop().is_some()
+                // Keep scalable vectors on the normal ADT path so transparent wrappers
+                // make them memory-backed.
+                && !args.type_at(0).is_scalable_vector() =>
+        {
             // `MaybeUninit<T>` is a lang item. Coroutines use it for saved locals.
             // Compute the union from `T` so nested coroutines do not eagerly walk
             // `MaybeUninit<T> -> ManuallyDrop<T> -> MaybeDangling<T> -> T`.
             // Field projection still uses the real ADT fields through `TyAndLayout::field`.
             let field = cx.layout_of(args.type_at(0))?;
             let unit = cx.layout_of(tcx.types.unit)?;
-            let maybe_dangling = tcx.require_lang_item(hir::LangItem::MaybeDangling, DUMMY_SP);
-            let manually_drop = tcx.require_lang_item(hir::LangItem::ManuallyDrop, DUMMY_SP);
+            let maybe_dangling = tcx.lang_items().maybe_dangling().unwrap();
+            let manually_drop = tcx.lang_items().manually_drop().unwrap();
             let mut value_layout = LayoutData::clone(&field.layout.0);
             // Keep the seed equal to the skipped transparent wrappers.
             value_layout.randomization_seed = field

--- a/tests/ui/async-await/coroutine-query-depth.rs
+++ b/tests/ui/async-await/coroutine-query-depth.rs
@@ -1,0 +1,23 @@
+//@ edition: 2024
+//@ check-pass
+
+// Regression test for https://github.com/rust-lang/rust/issues/159427.
+// This test keeps nested awaited futures below the query depth limit.
+// Do not add a `recursion_limit` attribute here.
+// The default limit is the test input.
+
+macro_rules! nested_async {
+    () => {
+        async {}
+    };
+    ($_head:tt $($tail:tt)*) => {
+        async { nested_async!($($tail)*).await }
+    };
+}
+
+fn main() {
+    let _ = nested_async!(
+        x x x x x x x x x x x x x x x x
+        x x x x x x x x x x x x x x x x
+    );
+}

--- a/tests/ui/layout/maybe-uninit-minicore.rs
+++ b/tests/ui/layout/maybe-uninit-minicore.rs
@@ -1,0 +1,16 @@
+//@ add-minicore
+//@ check-pass
+
+#![feature(no_core)]
+#![no_core]
+#![no_std]
+#![crate_type = "lib"]
+
+extern crate minicore;
+
+use minicore::{MaybeUninit, mem};
+
+// Regression test for https://github.com/rust-lang/rust/issues/159427.
+// `minicore` has `MaybeUninit` and `ManuallyDrop`, but no `MaybeDangling`.
+const _: usize = mem::size_of::<MaybeUninit<u8>>();
+const _: usize = mem::align_of::<MaybeUninit<u8>>();


### PR DESCRIPTION

`MaybeUninit<T>` currently goes through the normal ADT layout path. This path computes the layout of `ManuallyDrop<T>`, then `MaybeDangling<T>`, before it reaches `T`.

This extra wrapper depth can overflow the query depth limit for deeply nested async futures, where saved locals are wrapped in `MaybeUninit`.

This PR handles the `MaybeUninit` lang item directly by:

- Computing the layout of `T`.
- Preserving the randomization seed contribution from the skipped transparent wrappers.
- Delegating the final layout to the existing union layout calculator.

Fixes rust-lang/rust#159427
Fixes rust-lang/rust#152942