### PR TITLE
Add more splat rust-call regression tests

### DIFF
--- a/tests/ui/splat/splat-rust-call-fn-trait-issue-158800.rs
+++ b/tests/ui/splat/splat-rust-call-fn-trait-issue-158800.rs
@@ -1,0 +1,14 @@
+//! Regression test for `#[splat] ()` in a rust-call Fn* trait method not ICEing in WF
+//! checking.
+
+#![feature(splat)]
+#![feature(unboxed_closures)]
+#![expect(incomplete_features)]
+
+impl<T> dyn FnOnce(T) -> () {
+    //~^ ERROR cannot define inherent `impl` for a type outside of the crate
+    extern "rust-call" fn call_once(#[splat] _: ()) {}
+    //~^ ERROR `#[splat]` is not allowed in the arguments of functions with the `rust-call` ABI
+}
+
+fn main() {}

--- a/tests/ui/splat/splat-rust-call-fn-trait-issue-158800.stderr
+++ b/tests/ui/splat/splat-rust-call-fn-trait-issue-158800.stderr
@@ -1,0 +1,20 @@
+error: `#[splat]` is not allowed in the arguments of functions with the `rust-call` ABI
+  --> $DIR/splat-rust-call-fn-trait-issue-158800.rs:10:5
+   |
+LL |     extern "rust-call" fn call_once(#[splat] _: ()) {}
+   |     ^^^^^^^^^^^^^^^^^^              ^^^^^^^^
+   |
+   = help: remove `#[splat]` or change the ABI
+
+error[E0116]: cannot define inherent `impl` for a type outside of the crate where the type is defined
+  --> $DIR/splat-rust-call-fn-trait-issue-158800.rs:8:1
+   |
+LL | impl<T> dyn FnOnce(T) -> () {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl for type defined outside of crate
+   |
+   = help: consider defining a trait and implementing it for the type or using a newtype wrapper like `struct MyType(ExternalType);` and implement it
+   = note: for more details about the orphan rules, see <https://doc.rust-lang.org/reference/items/implementations.html?highlight=orphan#orphan-rules>
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0116`.

--- a/tests/ui/splat/splat-rust-call-fn-trait-self-issue-158800.rs
+++ b/tests/ui/splat/splat-rust-call-fn-trait-self-issue-158800.rs
@@ -1,9 +1,9 @@
-//! Regression test for `#[splat] self` in a rust-call method not ICEing in WF
+//! Regression test for `#[splat] self` in a rust-call Fn* trait method not ICEing in WF
 //! checking.
 
 #![feature(splat)]
 #![feature(unboxed_closures)]
-#![allow(incomplete_features)]
+#![expect(incomplete_features)]
 
 impl<T> dyn FnOnce(T) -> () {
     //~^ ERROR cannot define inherent `impl` for a type outside of the crate

--- a/tests/ui/splat/splat-rust-call-fn-trait-self-issue-158800.stderr
+++ b/tests/ui/splat/splat-rust-call-fn-trait-self-issue-158800.stderr
@@ -1,5 +1,5 @@
 error: `#[splat]` is not allowed in the arguments of functions with the `rust-call` ABI
-  --> $DIR/splat-self-rust-call-issue-158800.rs:10:5
+  --> $DIR/splat-rust-call-fn-trait-self-issue-158800.rs:10:5
    |
 LL |     extern "rust-call" fn call_once(#[splat] self) {}
    |     ^^^^^^^^^^^^^^^^^^              ^^^^^^^^
@@ -7,13 +7,13 @@ LL |     extern "rust-call" fn call_once(#[splat] self) {}
    = help: remove `#[splat]` or change the ABI
 
 error: functions with the "rust-call" ABI must take a single non-self tuple argument
-  --> $DIR/splat-self-rust-call-issue-158800.rs:10:46
+  --> $DIR/splat-rust-call-fn-trait-self-issue-158800.rs:10:46
    |
 LL |     extern "rust-call" fn call_once(#[splat] self) {}
    |                                              ^^^^
 
 error[E0116]: cannot define inherent `impl` for a type outside of the crate where the type is defined
-  --> $DIR/splat-self-rust-call-issue-158800.rs:8:1
+  --> $DIR/splat-rust-call-fn-trait-self-issue-158800.rs:8:1
    |
 LL | impl<T> dyn FnOnce(T) -> () {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl for type defined outside of crate
@@ -22,7 +22,7 @@ LL | impl<T> dyn FnOnce(T) -> () {
    = note: for more details about the orphan rules, see <https://doc.rust-lang.org/reference/items/implementations.html?highlight=orphan#orphan-rules>
 
 error[E0277]: the size for values of type `(dyn FnOnce(T) + 'static)` cannot be known at compilation time
-  --> $DIR/splat-self-rust-call-issue-158800.rs:10:46
+  --> $DIR/splat-rust-call-fn-trait-self-issue-158800.rs:10:46
    |
 LL |     extern "rust-call" fn call_once(#[splat] self) {}
    |                                              ^^^^ doesn't have a size known at compile-time

--- a/tests/ui/splat/splat-rust-call-trait-issue-158800.rs
+++ b/tests/ui/splat/splat-rust-call-trait-issue-158800.rs
@@ -1,0 +1,19 @@
+//! Regression test for `#[splat] ()` in a rust-call trait method not ICEing in WF
+//! checking.
+
+#![feature(splat)]
+#![feature(unboxed_closures)]
+#![expect(incomplete_features)]
+
+trait Trait {
+    extern "rust-call" fn f(#[splat] _: ()) where Self: Sized;
+    //~^ ERROR `#[splat]` is not allowed in the arguments of functions with the `rust-call` ABI
+}
+
+impl dyn Trait {
+    extern "rust-call" fn f(#[splat] _: ()) where Self: Sized {}
+    //~^ ERROR `#[splat]` is not allowed in the arguments of functions with the `rust-call` ABI
+    //~| ERROR the size for values of type `(dyn Trait + 'static)` cannot be known at compilation time
+}
+
+fn main() {}

--- a/tests/ui/splat/splat-rust-call-trait-issue-158800.stderr
+++ b/tests/ui/splat/splat-rust-call-trait-issue-158800.stderr
@@ -1,0 +1,31 @@
+error: `#[splat]` is not allowed in the arguments of functions with the `rust-call` ABI
+  --> $DIR/splat-rust-call-trait-issue-158800.rs:9:5
+   |
+LL |     extern "rust-call" fn f(#[splat] _: ()) where Self: Sized;
+   |     ^^^^^^^^^^^^^^^^^^      ^^^^^^^^
+   |
+   = help: remove `#[splat]` or change the ABI
+
+error: `#[splat]` is not allowed in the arguments of functions with the `rust-call` ABI
+  --> $DIR/splat-rust-call-trait-issue-158800.rs:14:5
+   |
+LL |     extern "rust-call" fn f(#[splat] _: ()) where Self: Sized {}
+   |     ^^^^^^^^^^^^^^^^^^      ^^^^^^^^
+   |
+   = help: remove `#[splat]` or change the ABI
+
+error[E0277]: the size for values of type `(dyn Trait + 'static)` cannot be known at compilation time
+  --> $DIR/splat-rust-call-trait-issue-158800.rs:14:51
+   |
+LL |     extern "rust-call" fn f(#[splat] _: ()) where Self: Sized {}
+   |                                                   ^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `(dyn Trait + 'static)`
+help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
+   |
+LL + #![feature(trivial_bounds)]
+   |
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/splat/splat-rust-call-type-issue-158800.rs
+++ b/tests/ui/splat/splat-rust-call-type-issue-158800.rs
@@ -1,0 +1,25 @@
+//! Regression test for `#[splat] ())` in a rust-call type method not ICEing in WF
+//! checking.
+
+#![feature(splat)]
+#![feature(unboxed_closures)]
+#![expect(incomplete_features)]
+
+struct Type;
+
+trait Trait {
+    extern "rust-call" fn f(#[splat] _: ());
+    //~^ ERROR `#[splat]` is not allowed in the arguments of functions with the `rust-call` ABI
+}
+
+impl Type {
+    extern "rust-call" fn f2(#[splat] _: ()) {}
+    //~^ ERROR `#[splat]` is not allowed in the arguments of functions with the `rust-call` ABI
+}
+
+impl Trait for Type {
+    extern "rust-call" fn f(#[splat] _: ()) {}
+    //~^ ERROR `#[splat]` is not allowed in the arguments of functions with the `rust-call` ABI
+}
+
+fn main() {}

--- a/tests/ui/splat/splat-rust-call-type-issue-158800.stderr
+++ b/tests/ui/splat/splat-rust-call-type-issue-158800.stderr
@@ -1,0 +1,26 @@
+error: `#[splat]` is not allowed in the arguments of functions with the `rust-call` ABI
+  --> $DIR/splat-rust-call-type-issue-158800.rs:11:5
+   |
+LL |     extern "rust-call" fn f(#[splat] _: ());
+   |     ^^^^^^^^^^^^^^^^^^      ^^^^^^^^
+   |
+   = help: remove `#[splat]` or change the ABI
+
+error: `#[splat]` is not allowed in the arguments of functions with the `rust-call` ABI
+  --> $DIR/splat-rust-call-type-issue-158800.rs:16:5
+   |
+LL |     extern "rust-call" fn f2(#[splat] _: ()) {}
+   |     ^^^^^^^^^^^^^^^^^^       ^^^^^^^^
+   |
+   = help: remove `#[splat]` or change the ABI
+
+error: `#[splat]` is not allowed in the arguments of functions with the `rust-call` ABI
+  --> $DIR/splat-rust-call-type-issue-158800.rs:21:5
+   |
+LL |     extern "rust-call" fn f(#[splat] _: ()) {}
+   |     ^^^^^^^^^^^^^^^^^^      ^^^^^^^^
+   |
+   = help: remove `#[splat]` or change the ABI
+
+error: aborting due to 3 previous errors
+


### PR DESCRIPTION
Tracking issue: rust-lang/rust#153629 

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

This PR provides more test coverage for splat, rust-call, and closure rejection (bugs rust-lang/rust#158800 and rust-lang/rust#158605), after the fixes in PRs rust-lang/rust#158645 and rust-lang/rust#158850.

This PR only contains tests.

@rustbot +F-splat +T-compiler +C-bug