### PR TITLE
Don't encode variant visibility

### DIFF
--- a/compiler/rustc_metadata/src/rmeta/decoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder.rs
@@ -1293,10 +1293,14 @@ impl CrateMetadata {
         canonical_symbols
     }
 
-    fn get_mod_child(&self, tcx: TyCtxt<'_>, id: DefIndex) -> ModChild {
+    fn get_mod_child(&self, tcx: TyCtxt<'_>, id: DefIndex, parent_id: DefIndex) -> ModChild {
         let ident = self.item_ident(tcx, id);
-        let res = Res::Def(self.def_kind(id), self.local_def_id(id));
-        let vis = self.get_visibility(tcx, id);
+        let def_kind = self.def_kind(id);
+        let res = Res::Def(def_kind, self.local_def_id(id));
+        let vis = match def_kind {
+            DefKind::Variant => self.get_visibility(tcx, parent_id),
+            _ => self.get_visibility(tcx, id),
+        };
 
         ModChild { ident, res, vis, reexport_chain: Default::default() }
     }
@@ -1316,7 +1320,7 @@ impl CrateMetadata {
                 // the view of this crate as a proc macro crate.
                 if id == CRATE_DEF_INDEX {
                     for (child_index, _) in data.macros.decode((self, tcx)) {
-                        yield self.get_mod_child(tcx, child_index);
+                        yield self.get_mod_child(tcx, child_index, id);
                     }
                 }
             } else {
@@ -1325,7 +1329,7 @@ impl CrateMetadata {
                 let non_reexports =
                     non_reexports.expect("provided `DefIndex` must refer to a module-like item");
                 for child_index in non_reexports.decode((self, tcx)) {
-                    yield self.get_mod_child(tcx, child_index);
+                    yield self.get_mod_child(tcx, child_index, id);
                 }
 
                 let reexports = self.root.tables.module_children_reexports.get(self, id);

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -1013,7 +1013,6 @@ fn should_encode_visibility(def_kind: DefKind) -> bool {
         | DefKind::Struct
         | DefKind::Union
         | DefKind::Enum
-        | DefKind::Variant
         | DefKind::Trait
         | DefKind::TyAlias
         | DefKind::ForeignTy
@@ -1039,7 +1038,8 @@ fn should_encode_visibility(def_kind: DefKind) -> bool {
         | DefKind::Impl { .. }
         | DefKind::Closure
         | DefKind::ExternCrate
-        | DefKind::SyntheticCoroutineBody => false,
+        | DefKind::SyntheticCoroutineBody
+        | DefKind::Variant => false,
     }
 }
 

--- a/compiler/rustc_middle/src/middle/privacy.rs
+++ b/compiler/rustc_middle/src/middle/privacy.rs
@@ -183,8 +183,9 @@ impl EffectiveVisibilities {
             // All effective visibilities except `reachable_through_impl_trait` are limited to
             // nominal visibility. For some items nominal visibility doesn't make sense so we
             // don't check this condition for them.
-            let is_impl = matches!(tcx.def_kind(def_id), DefKind::Impl { .. });
-            if !is_impl && tcx.trait_impl_of_assoc(def_id.to_def_id()).is_none() {
+            let is_impl_or_variant =
+                matches!(tcx.def_kind(def_id), DefKind::Impl { .. } | DefKind::Variant);
+            if !is_impl_or_variant && tcx.trait_impl_of_assoc(def_id.to_def_id()).is_none() {
                 let nominal_vis = tcx.visibility(def_id);
                 if ev.reachable.greater_than(nominal_vis, tcx) {
                     if let Node::Item(item) = tcx.hir_node_by_def_id(def_id)

--- a/compiler/rustc_privacy/src/lib.rs
+++ b/compiler/rustc_privacy/src/lib.rs
@@ -655,10 +655,6 @@ impl<'tcx> EmbargoVisitor<'tcx> {
                 }
                 let def = self.tcx.adt_def(def_id);
                 for variant in def.variants() {
-                    if let Some(item_ev) = item_ev {
-                        self.update(variant.def_id.expect_local(), item_ev, Level::Reachable);
-                    }
-
                     if let Some(variant_ev) = self.get(variant.def_id.expect_local()) {
                         if let Some(ctor_def_id) = variant.ctor_def_id() {
                             self.update(ctor_def_id.expect_local(), variant_ev, Level::Reachable);

--- a/compiler/rustc_resolve/src/build_reduced_graph.rs
+++ b/compiler/rustc_resolve/src/build_reduced_graph.rs
@@ -1513,7 +1513,6 @@ impl<'a, 'ra, 'tcx> DefCollector<'a, 'ra, 'tcx> {
         let def_id = feed.key();
         let vis = self.resolve_visibility(&variant.vis);
         self.r.define_local(parent, ident, TypeNS, self.res(def_id), vis, variant.span, expn_id);
-        self.r.feed_visibility(feed, vis);
 
         // If the variant is marked as non_exhaustive then lower the visibility to within the crate.
         let ctor_vis =

--- a/compiler/rustc_resolve/src/effective_visibilities.rs
+++ b/compiler/rustc_resolve/src/effective_visibilities.rs
@@ -309,12 +309,16 @@ impl<'a, 'ra, 'tcx> EffectiveVisibilitiesVisitor<'a, 'ra, 'tcx> {
     ) {
         if self.macro_reachable.insert((module_def_id, defining_mod)) {
             let module = self.r.expect_module(module_def_id.to_def_id());
+            if module.def_kind() == Some(DefKind::Enum) {
+                return;
+            }
             for (_, name_resolution) in self.r.resolutions(module).borrow().iter() {
                 let Some(decl) = name_resolution.borrow().best_decl() else {
                     continue;
                 };
 
                 if let Res::Def(def_kind, def_id) = decl.res()
+                    && def_kind != DefKind::Variant
                     && let Some(def_id) = def_id.as_local()
                     // FIXME: defs should be checked with `EffectiveVisibilities::is_reachable`.
                     && decl.vis().is_accessible_from(defining_mod, self.r.tcx)
@@ -377,9 +381,8 @@ impl<'a, 'ra, 'tcx> Visitor<'a> for EffectiveVisibilitiesVisitor<'a, 'ra, 'tcx> 
             ast::ItemKind::Enum(_, _, EnumDef { variants }) => {
                 self.set_bindings_effective_visibilities(def_id);
                 for variant in variants {
-                    let variant_def_id = self.r.child_def_id(item.id, variant.id);
                     for field in variant.data.fields() {
-                        self.update_field(self.r.child_def_id(item.id, field.id), variant_def_id);
+                        self.update_field(self.r.child_def_id(item.id, field.id), def_id);
                     }
                 }
             }


### PR DESCRIPTION
See if we can save some work by not encoding variant visibility since it can be derived from its parent enum.
