### PR TITLE
Improve workings of attribute suggestions

### DIFF
--- a/compiler/rustc_attr_parsing/src/attributes/cfg.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/cfg.rs
@@ -329,12 +329,12 @@ pub fn parse_cfg_attr(
                 Ok(r) => return Some(r),
                 Err(e) => {
                     let suggestions = CFG_ATTR_TEMPLATE.suggestions(
-                        AttrSuggestionStyle::Attribute(cfg_attr.style),
+                        AttrSuggestionStyle::EmbeddedAttribute,
                         cfg_attr.get_normal_item().unsafety,
                         sym::cfg_attr,
                     );
                     e.with_span_suggestions(
-                        cfg_attr.span,
+                        cfg_attr.get_normal_item().span,
                         "must be of the form",
                         suggestions,
                         Applicability::HasPlaceholders,
@@ -358,7 +358,6 @@ pub fn parse_cfg_attr(
 
             sess.dcx().emit_err(AttributeParseError {
                 span,
-                attr_span: cfg_attr.span,
                 inner_span: cfg_attr.get_normal_item().span,
                 template: CFG_ATTR_TEMPLATE,
                 path: AttrPath::from_ast(&cfg_attr.get_normal_item().path, identity),
@@ -366,7 +365,7 @@ pub fn parse_cfg_attr(
                 reason,
                 suggestions: session_diagnostics::AttributeParseErrorSuggestions::CreatedByTemplate(
                     CFG_ATTR_TEMPLATE.suggestions(
-                        AttrSuggestionStyle::Attribute(cfg_attr.style),
+                        AttrSuggestionStyle::EmbeddedAttribute,
                         cfg_attr.get_normal_item().unsafety,
                         sym::cfg_attr,
                     ),

--- a/compiler/rustc_attr_parsing/src/attributes/cfg.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/cfg.rs
@@ -27,8 +27,7 @@ use crate::session_diagnostics::{
     ParsedDescription,
 };
 use crate::{
-    AttrSuggestionStyle, AttributeParser, AttributeTemplate, check_cfg, parse_version,
-    session_diagnostics, template,
+    AttributeParser, AttributeTemplate, check_cfg, parse_version, session_diagnostics, template,
 };
 
 pub const CFG_TEMPLATE: AttributeTemplate = template!(
@@ -329,7 +328,7 @@ pub fn parse_cfg_attr(
                 Ok(r) => return Some(r),
                 Err(e) => {
                     let suggestions = CFG_ATTR_TEMPLATE.suggestions(
-                        AttrSuggestionStyle::EmbeddedAttribute,
+                        ParsedDescription::Attribute,
                         cfg_attr.get_normal_item().unsafety,
                         sym::cfg_attr,
                     );
@@ -365,7 +364,7 @@ pub fn parse_cfg_attr(
                 reason,
                 suggestions: session_diagnostics::AttributeParseErrorSuggestions::CreatedByTemplate(
                     CFG_ATTR_TEMPLATE.suggestions(
-                        AttrSuggestionStyle::EmbeddedAttribute,
+                        ParsedDescription::Attribute,
                         cfg_attr.get_normal_item().unsafety,
                         sym::cfg_attr,
                     ),

--- a/compiler/rustc_attr_parsing/src/attributes/doc.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/doc.rs
@@ -728,7 +728,7 @@ impl DocParser {
         match args {
             ArgParser::NoArgs => {
                 let suggestions = cx.adcx().suggestions();
-                let span = cx.attr_span;
+                let span = cx.inner_span;
                 cx.emit_lint(
                     rustc_session::lint::builtin::INVALID_DOC_ATTRIBUTES,
                     IllFormedAttributeInput::new(&suggestions, None, None),

--- a/compiler/rustc_attr_parsing/src/context.rs
+++ b/compiler/rustc_attr_parsing/src/context.rs
@@ -1132,7 +1132,7 @@ impl<'a, 'f, 'sess: 'f> AttributeDiagnosticContext<'a, 'f, 'sess> {
         help: Option<String>,
     ) {
         let suggestions = self.suggestions();
-        let span = self.attr_span;
+        let span = self.inner_span;
         self.emit_lint(
             lint,
             crate::diagnostics::IllFormedAttributeInput::new(&suggestions, None, help.as_deref()),
@@ -1142,11 +1142,7 @@ impl<'a, 'f, 'sess: 'f> AttributeDiagnosticContext<'a, 'f, 'sess> {
 
     pub(crate) fn suggestions(&self) -> Vec<String> {
         let style = match self.parsed_description {
-            // If the outer and inner spans are equal, we are parsing an embedded attribute
-            ParsedDescription::Attribute if self.attr_span == self.inner_span => {
-                AttrSuggestionStyle::EmbeddedAttribute
-            }
-            ParsedDescription::Attribute => AttrSuggestionStyle::Attribute(self.attr_style),
+            ParsedDescription::Attribute => AttrSuggestionStyle::EmbeddedAttribute,
             ParsedDescription::Macro => AttrSuggestionStyle::Macro,
         };
 

--- a/compiler/rustc_attr_parsing/src/context.rs
+++ b/compiler/rustc_attr_parsing/src/context.rs
@@ -75,7 +75,7 @@ use crate::session_diagnostics::{
     ParsedDescription, UnusedDuplicate,
 };
 use crate::target_checking::AllowedTargets;
-use crate::{AttrSuggestionStyle, AttributeParser, AttributeTemplate, EmitAttribute};
+use crate::{AttributeParser, AttributeTemplate, EmitAttribute};
 
 type GroupType = LazyLock<GroupTypeInner>;
 
@@ -1132,12 +1132,7 @@ impl<'a, 'f, 'sess: 'f> AttributeDiagnosticContext<'a, 'f, 'sess> {
     }
 
     pub(crate) fn suggestions(&self) -> Vec<String> {
-        let style = match self.parsed_description {
-            ParsedDescription::Attribute => AttrSuggestionStyle::EmbeddedAttribute,
-            ParsedDescription::Macro => AttrSuggestionStyle::Macro,
-        };
-
-        self.template.suggestions(style, self.attr_safety, &self.attr_path)
+        self.template.suggestions(self.parsed_description, self.attr_safety, &self.attr_path)
     }
     /// Error that a string literal was expected.
     /// You can optionally give the literal you did find (which you found not to be a string literal)

--- a/compiler/rustc_attr_parsing/src/context.rs
+++ b/compiler/rustc_attr_parsing/src/context.rs
@@ -920,7 +920,7 @@ impl<'a, 'f, 'sess: 'f> AttributeDiagnosticContext<'a, 'f, 'sess> {
         reason: AttributeParseErrorReason<'_>,
     ) -> ErrorGuaranteed {
         let suggestions = if self.custom_suggestions.is_empty() {
-            AttributeParseErrorSuggestions::CreatedByTemplate(self.template_suggestions())
+            AttributeParseErrorSuggestions::CreatedByTemplate(self.suggestions())
         } else {
             AttributeParseErrorSuggestions::CreatedByParser(mem::take(&mut self.custom_suggestions))
         };
@@ -947,15 +947,6 @@ impl<'a, 'f, 'sess: 'f> AttributeDiagnosticContext<'a, 'f, 'sess> {
     pub(crate) fn push_suggestion(&mut self, msg: String, span: Span, code: String) -> &mut Self {
         self.custom_suggestions.push(Suggestion { msg, sp: span, code });
         self
-    }
-
-    pub(crate) fn template_suggestions(&self) -> Vec<String> {
-        let style = match self.parsed_description {
-            ParsedDescription::Attribute => AttrSuggestionStyle::EmbeddedAttribute,
-            ParsedDescription::Macro => AttrSuggestionStyle::Macro,
-        };
-
-        self.template.suggestions(style, self.attr_safety, &self.attr_path)
     }
 }
 

--- a/compiler/rustc_attr_parsing/src/context.rs
+++ b/compiler/rustc_attr_parsing/src/context.rs
@@ -933,7 +933,6 @@ impl<'a, 'f, 'sess: 'f> AttributeDiagnosticContext<'a, 'f, 'sess> {
 
         self.emit_err(AttributeParseError {
             span,
-            attr_span: self.attr_span,
             inner_span: self.inner_span,
             template: *self.template,
             path: self.attr_path.clone(),
@@ -952,11 +951,7 @@ impl<'a, 'f, 'sess: 'f> AttributeDiagnosticContext<'a, 'f, 'sess> {
 
     pub(crate) fn template_suggestions(&self) -> Vec<String> {
         let style = match self.parsed_description {
-            // If the outer and inner spans are equal, we are parsing an embedded attribute
-            ParsedDescription::Attribute if self.attr_span == self.inner_span => {
-                AttrSuggestionStyle::EmbeddedAttribute
-            }
-            ParsedDescription::Attribute => AttrSuggestionStyle::Attribute(self.attr_style),
+            ParsedDescription::Attribute => AttrSuggestionStyle::EmbeddedAttribute,
             ParsedDescription::Macro => AttrSuggestionStyle::Macro,
         };
 

--- a/compiler/rustc_attr_parsing/src/lib.rs
+++ b/compiler/rustc_attr_parsing/src/lib.rs
@@ -119,4 +119,4 @@ pub use context::{OmitDoc, ShouldEmit};
 pub use interface::{AttributeParser, EmitAttribute};
 pub use rustc_parse::parser::Recovery;
 pub use session_diagnostics::ParsedDescription;
-pub use template::{AttrSuggestionStyle, AttributeTemplate};
+pub use template::AttributeTemplate;

--- a/compiler/rustc_attr_parsing/src/session_diagnostics.rs
+++ b/compiler/rustc_attr_parsing/src/session_diagnostics.rs
@@ -509,7 +509,6 @@ pub enum ParsedDescription {
 
 pub(crate) struct AttributeParseError<'a> {
     pub(crate) span: Span,
-    pub(crate) attr_span: Span,
     pub(crate) inner_span: Span,
     pub(crate) template: AttributeTemplate,
     pub(crate) path: AttrPath,
@@ -604,7 +603,7 @@ impl<'a> AttributeParseError<'a> {
         match &self.suggestions {
             AttributeParseErrorSuggestions::CreatedByTemplate(suggestions) => {
                 diag.span_suggestions(
-                        self.attr_span,
+                        self.inner_span,
                         if suggestions.len() == 1 {
                             "must be of the form".to_string()
                         } else {

--- a/compiler/rustc_attr_parsing/src/template.rs
+++ b/compiler/rustc_attr_parsing/src/template.rs
@@ -1,6 +1,8 @@
 use rustc_ast::ast::Safety;
 use rustc_span::Symbol;
 
+use crate::ParsedDescription;
+
 /// A template to suggest the correct syntax of an attribute.
 ///
 /// This is not used to *check* attributes. The attribute's parser is responsible for that.
@@ -21,25 +23,16 @@ pub struct AttributeTemplate {
     pub docs: Option<&'static str>,
 }
 
-pub enum AttrSuggestionStyle {
-    /// The suggestion is styled for an attribute embedded into another attribute.
-    /// For example, attributes inside `#[cfg_attr(true, attr(...)]`.
-    EmbeddedAttribute,
-    /// The suggestion is styled for macros that are parsed with attribute parsers.
-    /// For example, the `cfg!(predicate)` macro.
-    Macro,
-}
-
 impl AttributeTemplate {
     pub fn suggestions(
         &self,
-        style: AttrSuggestionStyle,
+        description: ParsedDescription,
         safety: Safety,
         name: impl std::fmt::Display,
     ) -> Vec<String> {
-        let macro_call = match style {
-            AttrSuggestionStyle::Macro => "!",
-            AttrSuggestionStyle::EmbeddedAttribute => "",
+        let macro_call = match description {
+            ParsedDescription::Macro => "!",
+            ParsedDescription::Attribute => "",
         };
 
         let mut suggestions = vec![];

--- a/compiler/rustc_attr_parsing/src/template.rs
+++ b/compiler/rustc_attr_parsing/src/template.rs
@@ -1,5 +1,4 @@
 use rustc_ast::ast::Safety;
-use rustc_hir::AttrStyle;
 use rustc_span::Symbol;
 
 /// A template to suggest the correct syntax of an attribute.
@@ -23,9 +22,6 @@ pub struct AttributeTemplate {
 }
 
 pub enum AttrSuggestionStyle {
-    /// The suggestion is styled for a normal attribute.
-    /// The `AttrStyle` determines whether this is an inner or outer attribute.
-    Attribute(AttrStyle),
     /// The suggestion is styled for an attribute embedded into another attribute.
     /// For example, attributes inside `#[cfg_attr(true, attr(...)]`.
     EmbeddedAttribute,
@@ -41,11 +37,9 @@ impl AttributeTemplate {
         safety: Safety,
         name: impl std::fmt::Display,
     ) -> Vec<String> {
-        let (start, macro_call, end) = match style {
-            AttrSuggestionStyle::Attribute(AttrStyle::Outer) => ("#[", "", "]"),
-            AttrSuggestionStyle::Attribute(AttrStyle::Inner) => ("#![", "", "]"),
-            AttrSuggestionStyle::Macro => ("", "!", ""),
-            AttrSuggestionStyle::EmbeddedAttribute => ("", "", ""),
+        let macro_call = match style {
+            AttrSuggestionStyle::Macro => "!",
+            AttrSuggestionStyle::EmbeddedAttribute => "",
         };
 
         let mut suggestions = vec![];
@@ -57,25 +51,20 @@ impl AttributeTemplate {
 
         if self.word {
             debug_assert!(macro_call.is_empty(), "Macro suggestions use list style");
-            suggestions.push(format!("{start}{safety_start}{name}{safety_end}{end}"));
+            suggestions.push(format!("{safety_start}{name}{safety_end}"));
         }
         if let Some(descr) = self.list {
             for descr in descr {
-                suggestions.push(format!(
-                    "{start}{safety_start}{name}{macro_call}({descr}){safety_end}{end}"
-                ));
+                suggestions.push(format!("{safety_start}{name}{macro_call}({descr}){safety_end}"));
             }
         }
         suggestions.extend(
-            self.one_of
-                .iter()
-                .map(|&word| format!("{start}{safety_start}{name}({word}){safety_end}{end}")),
+            self.one_of.iter().map(|&word| format!("{safety_start}{name}({word}){safety_end}")),
         );
         if let Some(descr) = self.name_value_str {
             debug_assert!(macro_call.is_empty(), "Macro suggestions use list style");
             for descr in descr {
-                suggestions
-                    .push(format!("{start}{safety_start}{name} = \"{descr}\"{safety_end}{end}"));
+                suggestions.push(format!("{safety_start}{name} = \"{descr}\"{safety_end}"));
             }
         }
         suggestions.sort();

--- a/tests/rustdoc-ui/lints/invalid-doc-attr-2.stderr
+++ b/tests/rustdoc-ui/lints/invalid-doc-attr-2.stderr
@@ -11,11 +11,11 @@ note: the lint level is defined here
 LL | #![deny(invalid_doc_attributes)]
    |         ^^^^^^^^^^^^^^^^^^^^^^
 
-error: valid forms for the attribute are `#![doc = "string"]`, `#![doc(alias)]`, `#![doc(attribute)]`, `#![doc(auto_cfg)]`, `#![doc(cfg)]`, `#![doc(fake_variadic)]`, `#![doc(hidden)]`, `#![doc(html_favicon_url)]`, `#![doc(html_logo_url)]`, `#![doc(html_no_source)]`, `#![doc(html_playground_url)]`, `#![doc(html_root_url)]`, `#![doc(include)]`, `#![doc(inline)]`, `#![doc(issue_tracker_base_url)]`, `#![doc(keyword)]`, `#![doc(masked)]`, `#![doc(no_default_passes)]`, `#![doc(no_inline)]`, `#![doc(notable_trait)]`, `#![doc(passes)]`, `#![doc(plugins)]`, `#![doc(rust_logo)]`, `#![doc(search_unbox)]`, `#![doc(spotlight)]`, and `#![doc(test)]`
-  --> $DIR/invalid-doc-attr-2.rs:6:1
+error: valid forms for the attribute are `doc = "string"`, `doc(alias)`, `doc(attribute)`, `doc(auto_cfg)`, `doc(cfg)`, `doc(fake_variadic)`, `doc(hidden)`, `doc(html_favicon_url)`, `doc(html_logo_url)`, `doc(html_no_source)`, `doc(html_playground_url)`, `doc(html_root_url)`, `doc(include)`, `doc(inline)`, `doc(issue_tracker_base_url)`, `doc(keyword)`, `doc(masked)`, `doc(no_default_passes)`, `doc(no_inline)`, `doc(notable_trait)`, `doc(passes)`, `doc(plugins)`, `doc(rust_logo)`, `doc(search_unbox)`, `doc(spotlight)`, and `doc(test)`
+  --> $DIR/invalid-doc-attr-2.rs:6:4
    |
 LL | #![doc]
-   | ^^^^^^^
+   |    ^^^
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/attributes/args-checked.stderr
+++ b/tests/ui/attributes/args-checked.stderr
@@ -38,13 +38,13 @@ LL | #[inline(always = 5)]
 help: try changing it to one of the following valid forms of the attribute
    |
 LL - #[inline(always = 5)]
+LL + #[inline]
+   |
+LL - #[inline(always = 5)]
 LL + #[inline(always)]
    |
 LL - #[inline(always = 5)]
 LL + #[inline(never)]
-   |
-LL - #[inline(always = 5)]
-LL + #[inline]
    |
 
 error[E0539]: malformed `inline` attribute input
@@ -59,13 +59,13 @@ LL | #[inline(always(x, y, z))]
 help: try changing it to one of the following valid forms of the attribute
    |
 LL - #[inline(always(x, y, z))]
+LL + #[inline]
+   |
+LL - #[inline(always(x, y, z))]
 LL + #[inline(always)]
    |
 LL - #[inline(always(x, y, z))]
 LL + #[inline(never)]
-   |
-LL - #[inline(always(x, y, z))]
-LL + #[inline]
    |
 
 error[E0539]: malformed `instruction_set` attribute input
@@ -241,13 +241,13 @@ LL | #[used(always = 5)]
 help: try changing it to one of the following valid forms of the attribute
    |
 LL - #[used(always = 5)]
+LL + #[used]
+   |
+LL - #[used(always = 5)]
 LL + #[used(compiler)]
    |
 LL - #[used(always = 5)]
 LL + #[used(linker)]
-   |
-LL - #[used(always = 5)]
-LL + #[used]
    |
 
 error[E0539]: malformed `used` attribute input
@@ -261,13 +261,13 @@ LL | #[used(always(x, y, z))]
 help: try changing it to one of the following valid forms of the attribute
    |
 LL - #[used(always(x, y, z))]
+LL + #[used]
+   |
+LL - #[used(always(x, y, z))]
 LL + #[used(compiler)]
    |
 LL - #[used(always(x, y, z))]
 LL + #[used(linker)]
-   |
-LL - #[used(always(x, y, z))]
-LL + #[used]
    |
 
 error[E0565]: malformed `rustc_must_implement_one_of` attribute input

--- a/tests/ui/attributes/args-checked.stderr
+++ b/tests/ui/attributes/args-checked.stderr
@@ -314,21 +314,21 @@ LL | #[rustc_dump_layout(debug(x, y, z))]
    |                     |
    |                     didn't expect a literal here
 
-error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
-  --> $DIR/args-checked.rs:37:1
+error: valid forms for the attribute are `macro_export` and `macro_export(local_inner_macros)`
+  --> $DIR/args-checked.rs:37:3
    |
 LL | #[macro_export(local_inner_macros = 5)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
    = note: `#[deny(invalid_macro_export_arguments)]` (part of `#[deny(future_incompatible)]`) on by default
 
-error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
-  --> $DIR/args-checked.rs:40:1
+error: valid forms for the attribute are `macro_export` and `macro_export(local_inner_macros)`
+  --> $DIR/args-checked.rs:40:3
    |
 LL | #[macro_export(local_inner_macros(x, y, z))]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
@@ -338,22 +338,22 @@ error: aborting due to 23 previous errors
 Some errors have detailed explanations: E0539, E0565.
 For more information about an error, try `rustc --explain E0539`.
 Future incompatibility report: Future breakage diagnostic:
-error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
-  --> $DIR/args-checked.rs:37:1
+error: valid forms for the attribute are `macro_export` and `macro_export(local_inner_macros)`
+  --> $DIR/args-checked.rs:37:3
    |
 LL | #[macro_export(local_inner_macros = 5)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
    = note: `#[deny(invalid_macro_export_arguments)]` (part of `#[deny(future_incompatible)]`) on by default
 
 Future breakage diagnostic:
-error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
-  --> $DIR/args-checked.rs:40:1
+error: valid forms for the attribute are `macro_export` and `macro_export(local_inner_macros)`
+  --> $DIR/args-checked.rs:40:3
    |
 LL | #[macro_export(local_inner_macros(x, y, z))]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>

--- a/tests/ui/attributes/attribute-on-wrong-item-inline-repr.stderr
+++ b/tests/ui/attributes/attribute-on-wrong-item-inline-repr.stderr
@@ -18,13 +18,13 @@ LL |     #[inline(XYZ)]
 help: try changing it to one of the following valid forms of the attribute
    |
 LL -     #[inline(XYZ)]
+LL +     #[inline]
+   |
+LL -     #[inline(XYZ)]
 LL +     #[inline(always)]
    |
 LL -     #[inline(XYZ)]
 LL +     #[inline(never)]
-   |
-LL -     #[inline(XYZ)]
-LL +     #[inline]
    |
 
 error: the `inline` attribute cannot be used on statements
@@ -75,13 +75,13 @@ LL |     #[inline(ABC)]
 help: try changing it to one of the following valid forms of the attribute
    |
 LL -     #[inline(ABC)]
+LL +     #[inline]
+   |
+LL -     #[inline(ABC)]
 LL +     #[inline(always)]
    |
 LL -     #[inline(ABC)]
 LL +     #[inline(never)]
-   |
-LL -     #[inline(ABC)]
-LL +     #[inline]
    |
 
 error: the `inline` attribute cannot be used on expressions

--- a/tests/ui/attributes/inline/invalid-inline.stderr
+++ b/tests/ui/attributes/inline/invalid-inline.stderr
@@ -10,13 +10,13 @@ LL | #[inline(please,no)]
 help: try changing it to one of the following valid forms of the attribute
    |
 LL - #[inline(please,no)]
+LL + #[inline]
+   |
+LL - #[inline(please,no)]
 LL + #[inline(always)]
    |
 LL - #[inline(please,no)]
 LL + #[inline(never)]
-   |
-LL - #[inline(please,no)]
-LL + #[inline]
    |
 
 error[E0805]: malformed `inline` attribute input
@@ -30,13 +30,13 @@ LL | #[inline()]
    = note: for more information, visit <https://doc.rust-lang.org/reference/attributes/codegen.html#the-inline-attribute>
 help: try changing it to one of the following valid forms of the attribute
    |
+LL - #[inline()]
+LL + #[inline]
+   |
 LL | #[inline(always)]
    |          ++++++
 LL | #[inline(never)]
    |          +++++
-LL - #[inline()]
-LL + #[inline]
-   |
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/attributes/invalid-macro-use.stderr
+++ b/tests/ui/attributes/invalid-macro-use.stderr
@@ -22,10 +22,10 @@ LL | #[macro_use = 5]
 help: try changing it to one of the following valid forms of the attribute
    |
 LL - #[macro_use = 5]
-LL + #[macro_use(name1, name2, ...)]
+LL + #[macro_use]
    |
 LL - #[macro_use = 5]
-LL + #[macro_use]
+LL + #[macro_use(name1, name2, ...)]
    |
 
 error[E0565]: malformed `macro_use` attribute input
@@ -40,10 +40,10 @@ LL | #[macro_use(5)]
 help: try changing it to one of the following valid forms of the attribute
    |
 LL - #[macro_use(5)]
-LL + #[macro_use(name1, name2, ...)]
+LL + #[macro_use]
    |
 LL - #[macro_use(5)]
-LL + #[macro_use]
+LL + #[macro_use(name1, name2, ...)]
    |
 
 error[E0565]: malformed `macro_use` attribute input
@@ -58,10 +58,10 @@ LL | #[macro_use(a = "b")]
 help: try changing it to one of the following valid forms of the attribute
    |
 LL - #[macro_use(a = "b")]
-LL + #[macro_use(name1, name2, ...)]
+LL + #[macro_use]
    |
 LL - #[macro_use(a = "b")]
-LL + #[macro_use]
+LL + #[macro_use(name1, name2, ...)]
    |
 
 error[E0565]: malformed `macro_use` attribute input
@@ -76,10 +76,10 @@ LL | #[macro_use(a(b))]
 help: try changing it to one of the following valid forms of the attribute
    |
 LL - #[macro_use(a(b))]
-LL + #[macro_use(name1, name2, ...)]
+LL + #[macro_use]
    |
 LL - #[macro_use(a(b))]
-LL + #[macro_use]
+LL + #[macro_use(name1, name2, ...)]
    |
 
 error[E0565]: malformed `macro_use` attribute input
@@ -94,10 +94,10 @@ LL | #[macro_use(a::b)]
 help: try changing it to one of the following valid forms of the attribute
    |
 LL - #[macro_use(a::b)]
-LL + #[macro_use(name1, name2, ...)]
+LL + #[macro_use]
    |
 LL - #[macro_use(a::b)]
-LL + #[macro_use]
+LL + #[macro_use(name1, name2, ...)]
    |
 
 error: unused attribute

--- a/tests/ui/attributes/invalid_macro_export_argument.allow.stderr
+++ b/tests/ui/attributes/invalid_macro_export_argument.allow.stderr
@@ -9,8 +9,18 @@ LL | #[macro_export(hello, world)]
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
 
 Future breakage diagnostic:
+warning: valid forms for the attribute are `macro_export` and `macro_export(local_inner_macros)`
+  --> $DIR/invalid_macro_export_argument.rs:14:18
+   |
+LL | #[cfg_attr(true, macro_export(hello, world))]
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
+
+Future breakage diagnostic:
 warning: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
-  --> $DIR/invalid_macro_export_argument.rs:14:1
+  --> $DIR/invalid_macro_export_argument.rs:21:1
    |
 LL | #[macro_export(not_local_inner_macros)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -20,7 +30,7 @@ LL | #[macro_export(not_local_inner_macros)]
 
 Future breakage diagnostic:
 warning: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
-  --> $DIR/invalid_macro_export_argument.rs:31:1
+  --> $DIR/invalid_macro_export_argument.rs:38:1
    |
 LL | #[macro_export()]
    | ^^^^^^^^^^^^^^^^^
@@ -30,7 +40,7 @@ LL | #[macro_export()]
 
 Future breakage diagnostic:
 warning: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
-  --> $DIR/invalid_macro_export_argument.rs:38:1
+  --> $DIR/invalid_macro_export_argument.rs:45:1
    |
 LL | #[macro_export("blah")]
    | ^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/attributes/invalid_macro_export_argument.allow.stderr
+++ b/tests/ui/attributes/invalid_macro_export_argument.allow.stderr
@@ -1,9 +1,9 @@
 Future incompatibility report: Future breakage diagnostic:
-warning: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
-  --> $DIR/invalid_macro_export_argument.rs:7:1
+warning: valid forms for the attribute are `macro_export` and `macro_export(local_inner_macros)`
+  --> $DIR/invalid_macro_export_argument.rs:7:3
    |
 LL | #[macro_export(hello, world)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
@@ -19,31 +19,31 @@ LL | #[cfg_attr(true, macro_export(hello, world))]
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
 
 Future breakage diagnostic:
-warning: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
-  --> $DIR/invalid_macro_export_argument.rs:21:1
+warning: valid forms for the attribute are `macro_export` and `macro_export(local_inner_macros)`
+  --> $DIR/invalid_macro_export_argument.rs:21:3
    |
 LL | #[macro_export(not_local_inner_macros)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
 
 Future breakage diagnostic:
-warning: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
-  --> $DIR/invalid_macro_export_argument.rs:38:1
+warning: valid forms for the attribute are `macro_export` and `macro_export(local_inner_macros)`
+  --> $DIR/invalid_macro_export_argument.rs:38:3
    |
 LL | #[macro_export()]
-   | ^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
 
 Future breakage diagnostic:
-warning: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
-  --> $DIR/invalid_macro_export_argument.rs:45:1
+warning: valid forms for the attribute are `macro_export` and `macro_export(local_inner_macros)`
+  --> $DIR/invalid_macro_export_argument.rs:45:3
    |
 LL | #[macro_export("blah")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>

--- a/tests/ui/attributes/invalid_macro_export_argument.deny.stderr
+++ b/tests/ui/attributes/invalid_macro_export_argument.deny.stderr
@@ -1,8 +1,8 @@
-error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
-  --> $DIR/invalid_macro_export_argument.rs:7:1
+error: valid forms for the attribute are `macro_export` and `macro_export(local_inner_macros)`
+  --> $DIR/invalid_macro_export_argument.rs:7:3
    |
 LL | #[macro_export(hello, world)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
@@ -21,29 +21,29 @@ LL | #[cfg_attr(true, macro_export(hello, world))]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
 
-error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
-  --> $DIR/invalid_macro_export_argument.rs:21:1
+error: valid forms for the attribute are `macro_export` and `macro_export(local_inner_macros)`
+  --> $DIR/invalid_macro_export_argument.rs:21:3
    |
 LL | #[macro_export(not_local_inner_macros)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
 
-error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
-  --> $DIR/invalid_macro_export_argument.rs:38:1
+error: valid forms for the attribute are `macro_export` and `macro_export(local_inner_macros)`
+  --> $DIR/invalid_macro_export_argument.rs:38:3
    |
 LL | #[macro_export()]
-   | ^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
 
-error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
-  --> $DIR/invalid_macro_export_argument.rs:45:1
+error: valid forms for the attribute are `macro_export` and `macro_export(local_inner_macros)`
+  --> $DIR/invalid_macro_export_argument.rs:45:3
    |
 LL | #[macro_export("blah")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
@@ -51,11 +51,11 @@ LL | #[macro_export("blah")]
 error: aborting due to 5 previous errors
 
 Future incompatibility report: Future breakage diagnostic:
-error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
-  --> $DIR/invalid_macro_export_argument.rs:7:1
+error: valid forms for the attribute are `macro_export` and `macro_export(local_inner_macros)`
+  --> $DIR/invalid_macro_export_argument.rs:7:3
    |
 LL | #[macro_export(hello, world)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
@@ -81,11 +81,11 @@ LL | #![cfg_attr(deny, deny(invalid_macro_export_arguments))]
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Future breakage diagnostic:
-error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
-  --> $DIR/invalid_macro_export_argument.rs:21:1
+error: valid forms for the attribute are `macro_export` and `macro_export(local_inner_macros)`
+  --> $DIR/invalid_macro_export_argument.rs:21:3
    |
 LL | #[macro_export(not_local_inner_macros)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
@@ -96,11 +96,11 @@ LL | #![cfg_attr(deny, deny(invalid_macro_export_arguments))]
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Future breakage diagnostic:
-error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
-  --> $DIR/invalid_macro_export_argument.rs:38:1
+error: valid forms for the attribute are `macro_export` and `macro_export(local_inner_macros)`
+  --> $DIR/invalid_macro_export_argument.rs:38:3
    |
 LL | #[macro_export()]
-   | ^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
@@ -111,11 +111,11 @@ LL | #![cfg_attr(deny, deny(invalid_macro_export_arguments))]
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Future breakage diagnostic:
-error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
-  --> $DIR/invalid_macro_export_argument.rs:45:1
+error: valid forms for the attribute are `macro_export` and `macro_export(local_inner_macros)`
+  --> $DIR/invalid_macro_export_argument.rs:45:3
    |
 LL | #[macro_export("blah")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>

--- a/tests/ui/attributes/invalid_macro_export_argument.deny.stderr
+++ b/tests/ui/attributes/invalid_macro_export_argument.deny.stderr
@@ -12,8 +12,17 @@ note: the lint level is defined here
 LL | #![cfg_attr(deny, deny(invalid_macro_export_arguments))]
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+error: valid forms for the attribute are `macro_export` and `macro_export(local_inner_macros)`
+  --> $DIR/invalid_macro_export_argument.rs:14:18
+   |
+LL | #[cfg_attr(true, macro_export(hello, world))]
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
+
 error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
-  --> $DIR/invalid_macro_export_argument.rs:14:1
+  --> $DIR/invalid_macro_export_argument.rs:21:1
    |
 LL | #[macro_export(not_local_inner_macros)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -22,7 +31,7 @@ LL | #[macro_export(not_local_inner_macros)]
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
 
 error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
-  --> $DIR/invalid_macro_export_argument.rs:31:1
+  --> $DIR/invalid_macro_export_argument.rs:38:1
    |
 LL | #[macro_export()]
    | ^^^^^^^^^^^^^^^^^
@@ -31,7 +40,7 @@ LL | #[macro_export()]
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
 
 error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
-  --> $DIR/invalid_macro_export_argument.rs:38:1
+  --> $DIR/invalid_macro_export_argument.rs:45:1
    |
 LL | #[macro_export("blah")]
    | ^^^^^^^^^^^^^^^^^^^^^^^
@@ -39,7 +48,7 @@ LL | #[macro_export("blah")]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
 
-error: aborting due to 4 previous errors
+error: aborting due to 5 previous errors
 
 Future incompatibility report: Future breakage diagnostic:
 error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
@@ -57,8 +66,23 @@ LL | #![cfg_attr(deny, deny(invalid_macro_export_arguments))]
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Future breakage diagnostic:
+error: valid forms for the attribute are `macro_export` and `macro_export(local_inner_macros)`
+  --> $DIR/invalid_macro_export_argument.rs:14:18
+   |
+LL | #[cfg_attr(true, macro_export(hello, world))]
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
+note: the lint level is defined here
+  --> $DIR/invalid_macro_export_argument.rs:4:24
+   |
+LL | #![cfg_attr(deny, deny(invalid_macro_export_arguments))]
+   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Future breakage diagnostic:
 error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
-  --> $DIR/invalid_macro_export_argument.rs:14:1
+  --> $DIR/invalid_macro_export_argument.rs:21:1
    |
 LL | #[macro_export(not_local_inner_macros)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -73,7 +97,7 @@ LL | #![cfg_attr(deny, deny(invalid_macro_export_arguments))]
 
 Future breakage diagnostic:
 error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
-  --> $DIR/invalid_macro_export_argument.rs:31:1
+  --> $DIR/invalid_macro_export_argument.rs:38:1
    |
 LL | #[macro_export()]
    | ^^^^^^^^^^^^^^^^^
@@ -88,7 +112,7 @@ LL | #![cfg_attr(deny, deny(invalid_macro_export_arguments))]
 
 Future breakage diagnostic:
 error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
-  --> $DIR/invalid_macro_export_argument.rs:38:1
+  --> $DIR/invalid_macro_export_argument.rs:45:1
    |
 LL | #[macro_export("blah")]
    | ^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/attributes/invalid_macro_export_argument.rs
+++ b/tests/ui/attributes/invalid_macro_export_argument.rs
@@ -11,6 +11,13 @@ macro_rules! a {
     () => ()
 }
 
+#[cfg_attr(true, macro_export(hello, world))]
+//[deny]~^ ERROR valid forms for the attribute are
+//[deny]~| WARN this was previously accepted
+macro_rules! a2 {
+    () => ()
+}
+
 #[macro_export(not_local_inner_macros)]
 //[deny]~^ ERROR valid forms for the attribute are
 //[deny]~| WARN this was previously accepted

--- a/tests/ui/attributes/link-dl.allowed.stderr
+++ b/tests/ui/attributes/link-dl.allowed.stderr
@@ -1,9 +1,9 @@
 Future incompatibility report: Future breakage diagnostic:
-warning: valid forms for the attribute are `#[link(name = "...")]`, `#[link(name = "...", import_name_type = "decorated|noprefix|undecorated")]`, `#[link(name = "...", kind = "dylib|static|...")]`, `#[link(name = "...", kind = "dylib|static|...", wasm_import_module = "...", import_name_type = "decorated|noprefix|undecorated")]`, and `#[link(name = "...", wasm_import_module = "...")]`
-  --> $DIR/link-dl.rs:14:1
+warning: valid forms for the attribute are `link(name = "...")`, `link(name = "...", import_name_type = "decorated|noprefix|undecorated")`, `link(name = "...", kind = "dylib|static|...")`, `link(name = "...", kind = "dylib|static|...", wasm_import_module = "...", import_name_type = "decorated|noprefix|undecorated")`, and `link(name = "...", wasm_import_module = "...")`
+  --> $DIR/link-dl.rs:14:3
    |
 LL | #[link="dl"]
-   | ^^^^^^^^^^^^
+   |   ^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>

--- a/tests/ui/attributes/link-dl.default_fcw.stderr
+++ b/tests/ui/attributes/link-dl.default_fcw.stderr
@@ -1,8 +1,8 @@
-error: valid forms for the attribute are `#[link(name = "...")]`, `#[link(name = "...", import_name_type = "decorated|noprefix|undecorated")]`, `#[link(name = "...", kind = "dylib|static|...")]`, `#[link(name = "...", kind = "dylib|static|...", wasm_import_module = "...", import_name_type = "decorated|noprefix|undecorated")]`, and `#[link(name = "...", wasm_import_module = "...")]`
-  --> $DIR/link-dl.rs:14:1
+error: valid forms for the attribute are `link(name = "...")`, `link(name = "...", import_name_type = "decorated|noprefix|undecorated")`, `link(name = "...", kind = "dylib|static|...")`, `link(name = "...", kind = "dylib|static|...", wasm_import_module = "...", import_name_type = "decorated|noprefix|undecorated")`, and `link(name = "...", wasm_import_module = "...")`
+  --> $DIR/link-dl.rs:14:3
    |
 LL | #[link="dl"]
-   | ^^^^^^^^^^^^
+   |   ^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
@@ -11,11 +11,11 @@ LL | #[link="dl"]
 error: aborting due to 1 previous error
 
 Future incompatibility report: Future breakage diagnostic:
-error: valid forms for the attribute are `#[link(name = "...")]`, `#[link(name = "...", import_name_type = "decorated|noprefix|undecorated")]`, `#[link(name = "...", kind = "dylib|static|...")]`, `#[link(name = "...", kind = "dylib|static|...", wasm_import_module = "...", import_name_type = "decorated|noprefix|undecorated")]`, and `#[link(name = "...", wasm_import_module = "...")]`
-  --> $DIR/link-dl.rs:14:1
+error: valid forms for the attribute are `link(name = "...")`, `link(name = "...", import_name_type = "decorated|noprefix|undecorated")`, `link(name = "...", kind = "dylib|static|...")`, `link(name = "...", kind = "dylib|static|...", wasm_import_module = "...", import_name_type = "decorated|noprefix|undecorated")`, and `link(name = "...", wasm_import_module = "...")`
+  --> $DIR/link-dl.rs:14:3
    |
 LL | #[link="dl"]
-   | ^^^^^^^^^^^^
+   |   ^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>

--- a/tests/ui/attributes/lint_on_root.rs
+++ b/tests/ui/attributes/lint_on_root.rs
@@ -1,7 +1,7 @@
 // NOTE: this used to panic in debug builds (by a sanity assertion)
 // and not emit any lint on release builds. See https://github.com/rust-lang/rust/issues/142891.
 #![inline = ""]
-//~^ ERROR: valid forms for the attribute are `#![inline(always)]`, `#![inline(never)]`, and `#![inline]` [ill_formed_attribute_input]
+//~^ ERROR: valid forms for the attribute are `inline`, `inline(always)`, and `inline(never)` [ill_formed_attribute_input]
 //~| WARN this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 //~| ERROR attribute cannot be used on
 

--- a/tests/ui/attributes/lint_on_root.stderr
+++ b/tests/ui/attributes/lint_on_root.stderr
@@ -6,11 +6,11 @@ LL | #![inline = ""]
    |
    = help: the `inline` attribute can only be applied to functions
 
-error: valid forms for the attribute are `#![inline(always)]`, `#![inline(never)]`, and `#![inline]`
-  --> $DIR/lint_on_root.rs:3:1
+error: valid forms for the attribute are `inline`, `inline(always)`, and `inline(never)`
+  --> $DIR/lint_on_root.rs:3:4
    |
 LL | #![inline = ""]
-   | ^^^^^^^^^^^^^^^
+   |    ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
@@ -19,11 +19,11 @@ LL | #![inline = ""]
 error: aborting due to 2 previous errors
 
 Future incompatibility report: Future breakage diagnostic:
-error: valid forms for the attribute are `#![inline(always)]`, `#![inline(never)]`, and `#![inline]`
-  --> $DIR/lint_on_root.rs:3:1
+error: valid forms for the attribute are `inline`, `inline(always)`, and `inline(never)`
+  --> $DIR/lint_on_root.rs:3:4
    |
 LL | #![inline = ""]
-   | ^^^^^^^^^^^^^^^
+   |    ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>

--- a/tests/ui/attributes/malformed-attrs.stderr
+++ b/tests/ui/attributes/malformed-attrs.stderr
@@ -327,10 +327,10 @@ LL | #[must_use()]
 help: try changing it to one of the following valid forms of the attribute
    |
 LL - #[must_use()]
-LL + #[must_use = "reason"]
+LL + #[must_use]
    |
 LL - #[must_use()]
-LL + #[must_use]
+LL + #[must_use = "reason"]
    |
 
 error[E0565]: malformed `no_mangle` attribute input
@@ -397,13 +397,13 @@ LL | #[used()]
    |
 help: try changing it to one of the following valid forms of the attribute
    |
+LL - #[used()]
+LL + #[used]
+   |
 LL | #[used(compiler)]
    |        ++++++++
 LL | #[used(linker)]
    |        ++++++
-LL - #[used()]
-LL + #[used]
-   |
 
 error: the `used` attribute cannot be used on functions
   --> $DIR/malformed-attrs.rs:73:3
@@ -591,10 +591,10 @@ LL | #[must_use = 1]
 help: try changing it to one of the following valid forms of the attribute
    |
 LL - #[must_use = 1]
-LL + #[must_use = "reason"]
+LL + #[must_use]
    |
 LL - #[must_use = 1]
-LL + #[must_use]
+LL + #[must_use = "reason"]
    |
 
 error[E0539]: malformed `proc_macro_derive` attribute input
@@ -621,11 +621,11 @@ LL | #[must_not_suspend()]
    |
 help: try changing it to one of the following valid forms of the attribute
    |
-LL | #[must_not_suspend(count)]
-   |                    +++++
 LL - #[must_not_suspend()]
 LL + #[must_not_suspend]
    |
+LL | #[must_not_suspend(count)]
+   |                    +++++
 
 error[E0539]: malformed `cfi_encoding` attribute input
   --> $DIR/malformed-attrs.rs:137:3
@@ -794,10 +794,10 @@ LL | #[macro_use = 1]
 help: try changing it to one of the following valid forms of the attribute
    |
 LL - #[macro_use = 1]
-LL + #[macro_use(name1, name2, ...)]
+LL + #[macro_use]
    |
 LL - #[macro_use = 1]
-LL + #[macro_use]
+LL + #[macro_use(name1, name2, ...)]
    |
 
 error[E0539]: malformed `macro_export` attribute input
@@ -811,10 +811,10 @@ LL | #[macro_export = 18]
 help: try changing it to one of the following valid forms of the attribute
    |
 LL - #[macro_export = 18]
-LL + #[macro_export(local_inner_macros)]
+LL + #[macro_export]
    |
 LL - #[macro_export = 18]
-LL + #[macro_export]
+LL + #[macro_export(local_inner_macros)]
    |
 
 error[E0658]: the `allow_internal_unsafe` attribute side-steps the `unsafe_code` lint

--- a/tests/ui/attributes/malformed-attrs.stderr
+++ b/tests/ui/attributes/malformed-attrs.stderr
@@ -852,11 +852,11 @@ LL | |     #[coroutine = 63] || {}
 LL | | }
    | |_- not a `const fn`
 
-error: valid forms for the attribute are `#[doc = "string"]`, `#[doc(alias)]`, `#[doc(attribute)]`, `#[doc(auto_cfg)]`, `#[doc(cfg)]`, `#[doc(fake_variadic)]`, `#[doc(hidden)]`, `#[doc(html_favicon_url)]`, `#[doc(html_logo_url)]`, `#[doc(html_no_source)]`, `#[doc(html_playground_url)]`, `#[doc(html_root_url)]`, `#[doc(include)]`, `#[doc(inline)]`, `#[doc(issue_tracker_base_url)]`, `#[doc(keyword)]`, `#[doc(masked)]`, `#[doc(no_default_passes)]`, `#[doc(no_inline)]`, `#[doc(notable_trait)]`, `#[doc(passes)]`, `#[doc(plugins)]`, `#[doc(rust_logo)]`, `#[doc(search_unbox)]`, `#[doc(spotlight)]`, and `#[doc(test)]`
-  --> $DIR/malformed-attrs.rs:41:1
+error: valid forms for the attribute are `doc = "string"`, `doc(alias)`, `doc(attribute)`, `doc(auto_cfg)`, `doc(cfg)`, `doc(fake_variadic)`, `doc(hidden)`, `doc(html_favicon_url)`, `doc(html_logo_url)`, `doc(html_no_source)`, `doc(html_playground_url)`, `doc(html_root_url)`, `doc(include)`, `doc(inline)`, `doc(issue_tracker_base_url)`, `doc(keyword)`, `doc(masked)`, `doc(no_default_passes)`, `doc(no_inline)`, `doc(notable_trait)`, `doc(passes)`, `doc(plugins)`, `doc(rust_logo)`, `doc(search_unbox)`, `doc(spotlight)`, and `doc(test)`
+  --> $DIR/malformed-attrs.rs:41:3
    |
 LL | #[doc]
-   | ^^^^^^
+   |   ^^^
    |
 note: the lint level is defined here
   --> $DIR/malformed-attrs.rs:3:9
@@ -864,11 +864,11 @@ note: the lint level is defined here
 LL | #![deny(invalid_doc_attributes)]
    |         ^^^^^^^^^^^^^^^^^^^^^^
 
-error: valid forms for the attribute are `#[inline(always)]`, `#[inline(never)]`, and `#[inline]`
-  --> $DIR/malformed-attrs.rs:50:1
+error: valid forms for the attribute are `inline`, `inline(always)`, and `inline(never)`
+  --> $DIR/malformed-attrs.rs:50:3
    |
 LL | #[inline = 5]
-   | ^^^^^^^^^^^^^
+   |   ^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
@@ -890,11 +890,11 @@ LL | | }
    | |_^
    = note: requested on the command line with `-W unused-attributes`
 
-error: valid forms for the attribute are `#[doc = "string"]`, `#[doc(alias)]`, `#[doc(attribute)]`, `#[doc(auto_cfg)]`, `#[doc(cfg)]`, `#[doc(fake_variadic)]`, `#[doc(hidden)]`, `#[doc(html_favicon_url)]`, `#[doc(html_logo_url)]`, `#[doc(html_no_source)]`, `#[doc(html_playground_url)]`, `#[doc(html_root_url)]`, `#[doc(include)]`, `#[doc(inline)]`, `#[doc(issue_tracker_base_url)]`, `#[doc(keyword)]`, `#[doc(masked)]`, `#[doc(no_default_passes)]`, `#[doc(no_inline)]`, `#[doc(notable_trait)]`, `#[doc(passes)]`, `#[doc(plugins)]`, `#[doc(rust_logo)]`, `#[doc(search_unbox)]`, `#[doc(spotlight)]`, and `#[doc(test)]`
-  --> $DIR/malformed-attrs.rs:79:1
+error: valid forms for the attribute are `doc = "string"`, `doc(alias)`, `doc(attribute)`, `doc(auto_cfg)`, `doc(cfg)`, `doc(fake_variadic)`, `doc(hidden)`, `doc(html_favicon_url)`, `doc(html_logo_url)`, `doc(html_no_source)`, `doc(html_playground_url)`, `doc(html_root_url)`, `doc(include)`, `doc(inline)`, `doc(issue_tracker_base_url)`, `doc(keyword)`, `doc(masked)`, `doc(no_default_passes)`, `doc(no_inline)`, `doc(notable_trait)`, `doc(passes)`, `doc(plugins)`, `doc(rust_logo)`, `doc(search_unbox)`, `doc(spotlight)`, and `doc(test)`
+  --> $DIR/malformed-attrs.rs:79:3
    |
 LL | #[doc]
-   | ^^^^^^
+   |   ^^^
 
 warning: the `link` attribute cannot be used on functions
   --> $DIR/malformed-attrs.rs:85:3
@@ -914,11 +914,11 @@ LL | #[link_name]
    = help: the `link_name` attribute can be applied to foreign functions and foreign statics
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-error: valid forms for the attribute are `#[ignore = "reason"]` and `#[ignore]`
-  --> $DIR/malformed-attrs.rs:99:1
+error: valid forms for the attribute are `ignore` and `ignore = "reason"`
+  --> $DIR/malformed-attrs.rs:99:3
    |
 LL | #[ignore()]
-   | ^^^^^^^^^^^
+   |   ^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
@@ -964,11 +964,11 @@ LL | #[automatically_derived = 18]
    = help: the `automatically_derived` attribute can only be applied to trait impl blocks
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-error: valid forms for the attribute are `#[ignore = "reason"]` and `#[ignore]`
-  --> $DIR/malformed-attrs.rs:225:1
+error: valid forms for the attribute are `ignore` and `ignore = "reason"`
+  --> $DIR/malformed-attrs.rs:225:3
    |
 LL | #[ignore = 1]
-   | ^^^^^^^^^^^^^
+   |   ^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
@@ -989,33 +989,33 @@ error: aborting due to 74 previous errors; 8 warnings emitted
 Some errors have detailed explanations: E0308, E0463, E0539, E0565, E0658, E0805.
 For more information about an error, try `rustc --explain E0308`.
 Future incompatibility report: Future breakage diagnostic:
-error: valid forms for the attribute are `#[inline(always)]`, `#[inline(never)]`, and `#[inline]`
-  --> $DIR/malformed-attrs.rs:50:1
+error: valid forms for the attribute are `inline`, `inline(always)`, and `inline(never)`
+  --> $DIR/malformed-attrs.rs:50:3
    |
 LL | #[inline = 5]
-   | ^^^^^^^^^^^^^
+   |   ^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
    = note: `#[deny(ill_formed_attribute_input)]` (part of `#[deny(future_incompatible)]`) on by default
 
 Future breakage diagnostic:
-error: valid forms for the attribute are `#[ignore = "reason"]` and `#[ignore]`
-  --> $DIR/malformed-attrs.rs:99:1
+error: valid forms for the attribute are `ignore` and `ignore = "reason"`
+  --> $DIR/malformed-attrs.rs:99:3
    |
 LL | #[ignore()]
-   | ^^^^^^^^^^^
+   |   ^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
    = note: `#[deny(ill_formed_attribute_input)]` (part of `#[deny(future_incompatible)]`) on by default
 
 Future breakage diagnostic:
-error: valid forms for the attribute are `#[ignore = "reason"]` and `#[ignore]`
-  --> $DIR/malformed-attrs.rs:225:1
+error: valid forms for the attribute are `ignore` and `ignore = "reason"`
+  --> $DIR/malformed-attrs.rs:225:3
    |
 LL | #[ignore = 1]
-   | ^^^^^^^^^^^^^
+   |   ^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>

--- a/tests/ui/attributes/malformed-must_use.stderr
+++ b/tests/ui/attributes/malformed-must_use.stderr
@@ -10,10 +10,10 @@ LL | #[must_use()]
 help: try changing it to one of the following valid forms of the attribute
    |
 LL - #[must_use()]
-LL + #[must_use = "reason"]
+LL + #[must_use]
    |
 LL - #[must_use()]
-LL + #[must_use]
+LL + #[must_use = "reason"]
    |
 
 error: aborting due to 1 previous error

--- a/tests/ui/attributes/used_with_multi_args.stderr
+++ b/tests/ui/attributes/used_with_multi_args.stderr
@@ -9,13 +9,13 @@ LL | #[used(compiler, linker)]
 help: try changing it to one of the following valid forms of the attribute
    |
 LL - #[used(compiler, linker)]
+LL + #[used]
+   |
+LL - #[used(compiler, linker)]
 LL + #[used(compiler)]
    |
 LL - #[used(compiler, linker)]
 LL + #[used(linker)]
-   |
-LL - #[used(compiler, linker)]
-LL + #[used]
    |
 
 error: aborting due to 1 previous error

--- a/tests/ui/error-codes/E0540.stderr
+++ b/tests/ui/error-codes/E0540.stderr
@@ -9,13 +9,13 @@ LL | #[inline()]
    = note: for more information, visit <https://doc.rust-lang.org/reference/attributes/codegen.html#the-inline-attribute>
 help: try changing it to one of the following valid forms of the attribute
    |
+LL - #[inline()]
+LL + #[inline]
+   |
 LL | #[inline(always)]
    |          ++++++
 LL | #[inline(never)]
    |          +++++
-LL - #[inline()]
-LL + #[inline]
-   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs-error.stderr
+++ b/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs-error.stderr
@@ -322,11 +322,11 @@ LL | #![no_mangle]
    = help: the `no_mangle` attribute can be applied to functions and statics
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-error: valid forms for the attribute are `#[inline(always)]`, `#[inline(never)]`, and `#[inline]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:43:5
+error: valid forms for the attribute are `inline`, `inline(always)`, and `inline(never)`
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:43:7
    |
 LL |     #[inline = "2100"] fn f() { }
-   |     ^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
@@ -363,11 +363,11 @@ error: aborting due to 37 previous errors; 6 warnings emitted
 
 For more information about this error, try `rustc --explain E0658`.
 Future incompatibility report: Future breakage diagnostic:
-error: valid forms for the attribute are `#[inline(always)]`, `#[inline(never)]`, and `#[inline]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:43:5
+error: valid forms for the attribute are `inline`, `inline(always)`, and `inline(never)`
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:43:7
    |
 LL |     #[inline = "2100"] fn f() { }
-   |     ^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>

--- a/tests/ui/feature-gates/issue-43106-gating-of-macro_use.stderr
+++ b/tests/ui/feature-gates/issue-43106-gating-of-macro_use.stderr
@@ -28,10 +28,10 @@ LL |     #[macro_use = "2700"] struct S;
 help: try changing it to one of the following valid forms of the attribute
    |
 LL -     #[macro_use = "2700"] struct S;
-LL +     #[macro_use(name1, name2, ...)] struct S;
+LL +     #[macro_use] struct S;
    |
 LL -     #[macro_use = "2700"] struct S;
-LL +     #[macro_use] struct S;
+LL +     #[macro_use(name1, name2, ...)] struct S;
    |
 
 warning: the `macro_use` attribute cannot be used on crates

--- a/tests/ui/force-inlining/invalid.stderr
+++ b/tests/ui/force-inlining/invalid.stderr
@@ -15,13 +15,13 @@ LL | #[rustc_force_inline(bar, baz)]
 help: try changing it to one of the following valid forms of the attribute
    |
 LL - #[rustc_force_inline(bar, baz)]
+LL + #[rustc_force_inline]
+   |
+LL - #[rustc_force_inline(bar, baz)]
 LL + #[rustc_force_inline = "reason"]
    |
 LL - #[rustc_force_inline(bar, baz)]
 LL + #[rustc_force_inline(reason)]
-   |
-LL - #[rustc_force_inline(bar, baz)]
-LL + #[rustc_force_inline]
    |
 
 error[E0539]: malformed `rustc_force_inline` attribute input
@@ -35,13 +35,13 @@ LL | #[rustc_force_inline(2)]
 help: try changing it to one of the following valid forms of the attribute
    |
 LL - #[rustc_force_inline(2)]
+LL + #[rustc_force_inline]
+   |
+LL - #[rustc_force_inline(2)]
 LL + #[rustc_force_inline = "reason"]
    |
 LL - #[rustc_force_inline(2)]
 LL + #[rustc_force_inline(reason)]
-   |
-LL - #[rustc_force_inline(2)]
-LL + #[rustc_force_inline]
    |
 
 error[E0539]: malformed `rustc_force_inline` attribute input
@@ -55,13 +55,13 @@ LL | #[rustc_force_inline = 2]
 help: try changing it to one of the following valid forms of the attribute
    |
 LL - #[rustc_force_inline = 2]
+LL + #[rustc_force_inline]
+   |
+LL - #[rustc_force_inline = 2]
 LL + #[rustc_force_inline = "reason"]
    |
 LL - #[rustc_force_inline = 2]
 LL + #[rustc_force_inline(reason)]
-   |
-LL - #[rustc_force_inline = 2]
-LL + #[rustc_force_inline]
    |
 
 error: the `rustc_force_inline` attribute cannot be used on extern crates

--- a/tests/ui/macros/macro-use-bad-args-1.stderr
+++ b/tests/ui/macros/macro-use-bad-args-1.stderr
@@ -10,10 +10,10 @@ LL | #[macro_use(foo(bar))]
 help: try changing it to one of the following valid forms of the attribute
    |
 LL - #[macro_use(foo(bar))]
-LL + #[macro_use(name1, name2, ...)]
+LL + #[macro_use]
    |
 LL - #[macro_use(foo(bar))]
-LL + #[macro_use]
+LL + #[macro_use(name1, name2, ...)]
    |
 
 error: aborting due to 1 previous error

--- a/tests/ui/macros/macro-use-bad-args-2.stderr
+++ b/tests/ui/macros/macro-use-bad-args-2.stderr
@@ -10,10 +10,10 @@ LL | #[macro_use(foo="bar")]
 help: try changing it to one of the following valid forms of the attribute
    |
 LL - #[macro_use(foo="bar")]
-LL + #[macro_use(name1, name2, ...)]
+LL + #[macro_use]
    |
 LL - #[macro_use(foo="bar")]
-LL + #[macro_use]
+LL + #[macro_use(name1, name2, ...)]
    |
 
 error: aborting due to 1 previous error

--- a/tests/ui/malformed/ignore-with-lint-name.rs
+++ b/tests/ui/malformed/ignore-with-lint-name.rs
@@ -1,5 +1,5 @@
 #[ignore(clippy::single_match)]
-//~^ ERROR valid forms for the attribute are `#[ignore = "reason"]` and `#[ignore]`
+//~^ ERROR valid forms for the attribute are `ignore` and `ignore = "reason"`
 //~| HELP if you meant to silence a warning, consider using #![allow(clippy::single_match)] or #![expect(clippy::single_match)]
 //~| WARN this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 

--- a/tests/ui/malformed/ignore-with-lint-name.stderr
+++ b/tests/ui/malformed/ignore-with-lint-name.stderr
@@ -1,8 +1,8 @@
-error: valid forms for the attribute are `#[ignore = "reason"]` and `#[ignore]`
-  --> $DIR/ignore-with-lint-name.rs:1:1
+error: valid forms for the attribute are `ignore` and `ignore = "reason"`
+  --> $DIR/ignore-with-lint-name.rs:1:3
    |
 LL | #[ignore(clippy::single_match)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: if you meant to silence a warning, consider using #![allow(clippy::single_match)] or #![expect(clippy::single_match)]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
@@ -12,11 +12,11 @@ LL | #[ignore(clippy::single_match)]
 error: aborting due to 1 previous error
 
 Future incompatibility report: Future breakage diagnostic:
-error: valid forms for the attribute are `#[ignore = "reason"]` and `#[ignore]`
-  --> $DIR/ignore-with-lint-name.rs:1:1
+error: valid forms for the attribute are `ignore` and `ignore = "reason"`
+  --> $DIR/ignore-with-lint-name.rs:1:3
    |
 LL | #[ignore(clippy::single_match)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: if you meant to silence a warning, consider using #![allow(clippy::single_match)] or #![expect(clippy::single_match)]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!

--- a/tests/ui/malformed/malformed-regressions.stderr
+++ b/tests/ui/malformed/malformed-regressions.stderr
@@ -16,11 +16,11 @@ LL | #[link = ""]
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute>
 
-error: valid forms for the attribute are `#[doc = "string"]`, `#[doc(alias)]`, `#[doc(attribute)]`, `#[doc(auto_cfg)]`, `#[doc(cfg)]`, `#[doc(fake_variadic)]`, `#[doc(hidden)]`, `#[doc(html_favicon_url)]`, `#[doc(html_logo_url)]`, `#[doc(html_no_source)]`, `#[doc(html_playground_url)]`, `#[doc(html_root_url)]`, `#[doc(include)]`, `#[doc(inline)]`, `#[doc(issue_tracker_base_url)]`, `#[doc(keyword)]`, `#[doc(masked)]`, `#[doc(no_default_passes)]`, `#[doc(no_inline)]`, `#[doc(notable_trait)]`, `#[doc(passes)]`, `#[doc(plugins)]`, `#[doc(rust_logo)]`, `#[doc(search_unbox)]`, `#[doc(spotlight)]`, and `#[doc(test)]`
-  --> $DIR/malformed-regressions.rs:3:1
+error: valid forms for the attribute are `doc = "string"`, `doc(alias)`, `doc(attribute)`, `doc(auto_cfg)`, `doc(cfg)`, `doc(fake_variadic)`, `doc(hidden)`, `doc(html_favicon_url)`, `doc(html_logo_url)`, `doc(html_no_source)`, `doc(html_playground_url)`, `doc(html_root_url)`, `doc(include)`, `doc(inline)`, `doc(issue_tracker_base_url)`, `doc(keyword)`, `doc(masked)`, `doc(no_default_passes)`, `doc(no_inline)`, `doc(notable_trait)`, `doc(passes)`, `doc(plugins)`, `doc(rust_logo)`, `doc(search_unbox)`, `doc(spotlight)`, and `doc(test)`
+  --> $DIR/malformed-regressions.rs:3:3
    |
 LL | #[doc]
-   | ^^^^^^
+   |   ^^^
    |
 note: the lint level is defined here
   --> $DIR/malformed-regressions.rs:1:9
@@ -28,21 +28,21 @@ note: the lint level is defined here
 LL | #![deny(invalid_doc_attributes)]
    |         ^^^^^^^^^^^^^^^^^^^^^^
 
-error: valid forms for the attribute are `#[ignore = "reason"]` and `#[ignore]`
-  --> $DIR/malformed-regressions.rs:4:1
+error: valid forms for the attribute are `ignore` and `ignore = "reason"`
+  --> $DIR/malformed-regressions.rs:4:3
    |
 LL | #[ignore()]
-   | ^^^^^^^^^^^
+   |   ^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
    = note: `#[deny(ill_formed_attribute_input)]` (part of `#[deny(future_incompatible)]`) on by default
 
-error: valid forms for the attribute are `#[inline(always)]`, `#[inline(never)]`, and `#[inline]`
-  --> $DIR/malformed-regressions.rs:6:1
+error: valid forms for the attribute are `inline`, `inline(always)`, and `inline(never)`
+  --> $DIR/malformed-regressions.rs:6:3
    |
 LL | #[inline = ""]
-   | ^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
@@ -70,22 +70,22 @@ error: aborting due to 5 previous errors; 2 warnings emitted
 
 For more information about this error, try `rustc --explain E0539`.
 Future incompatibility report: Future breakage diagnostic:
-error: valid forms for the attribute are `#[ignore = "reason"]` and `#[ignore]`
-  --> $DIR/malformed-regressions.rs:4:1
+error: valid forms for the attribute are `ignore` and `ignore = "reason"`
+  --> $DIR/malformed-regressions.rs:4:3
    |
 LL | #[ignore()]
-   | ^^^^^^^^^^^
+   |   ^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
    = note: `#[deny(ill_formed_attribute_input)]` (part of `#[deny(future_incompatible)]`) on by default
 
 Future breakage diagnostic:
-error: valid forms for the attribute are `#[inline(always)]`, `#[inline(never)]`, and `#[inline]`
-  --> $DIR/malformed-regressions.rs:6:1
+error: valid forms for the attribute are `inline`, `inline(always)`, and `inline(never)`
+  --> $DIR/malformed-regressions.rs:6:3
    |
 LL | #[inline = ""]
-   | ^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>

--- a/tests/ui/parser/bad-lit-suffixes.stderr
+++ b/tests/ui/parser/bad-lit-suffixes.stderr
@@ -148,10 +148,10 @@ LL | #[must_use = "string"suffix]
 help: try changing it to one of the following valid forms of the attribute
    |
 LL - #[must_use = "string"suffix]
-LL + #[must_use = "reason"]
+LL + #[must_use]
    |
 LL - #[must_use = "string"suffix]
-LL + #[must_use]
+LL + #[must_use = "reason"]
    |
 
 error: suffixes on string literals are invalid

--- a/tests/ui/scalable-vectors/invalid.stderr
+++ b/tests/ui/scalable-vectors/invalid.stderr
@@ -279,10 +279,10 @@ LL | #[rustc_scalable_vector("4")]
 help: try changing it to one of the following valid forms of the attribute
    |
 LL - #[rustc_scalable_vector("4")]
-LL + #[rustc_scalable_vector(count)]
+LL + #[rustc_scalable_vector]
    |
 LL - #[rustc_scalable_vector("4")]
-LL + #[rustc_scalable_vector]
+LL + #[rustc_scalable_vector(count)]
    |
 
 error[E0805]: malformed `rustc_scalable_vector` attribute input
@@ -296,10 +296,10 @@ LL | #[rustc_scalable_vector(4, 2)]
 help: try changing it to one of the following valid forms of the attribute
    |
 LL - #[rustc_scalable_vector(4, 2)]
-LL + #[rustc_scalable_vector(count)]
+LL + #[rustc_scalable_vector]
    |
 LL - #[rustc_scalable_vector(4, 2)]
-LL + #[rustc_scalable_vector]
+LL + #[rustc_scalable_vector(count)]
    |
 
 error[E0539]: malformed `rustc_scalable_vector` attribute input
@@ -313,10 +313,10 @@ LL | #[rustc_scalable_vector(count = "4")]
 help: try changing it to one of the following valid forms of the attribute
    |
 LL - #[rustc_scalable_vector(count = "4")]
-LL + #[rustc_scalable_vector(count)]
+LL + #[rustc_scalable_vector]
    |
 LL - #[rustc_scalable_vector(count = "4")]
-LL + #[rustc_scalable_vector]
+LL + #[rustc_scalable_vector(count)]
    |
 
 error: element count in `rustc_scalable_vector` is too large: `65536`

--- a/tests/ui/span/E0539.stderr
+++ b/tests/ui/span/E0539.stderr
@@ -10,13 +10,13 @@ LL | #[inline(unknown)]
 help: try changing it to one of the following valid forms of the attribute
    |
 LL - #[inline(unknown)]
+LL + #[inline]
+   |
+LL - #[inline(unknown)]
 LL + #[inline(always)]
    |
 LL - #[inline(unknown)]
 LL + #[inline(never)]
-   |
-LL - #[inline(unknown)]
-LL + #[inline]
    |
 
 error: aborting due to 1 previous error

--- a/tests/ui/test-attrs/test-should-panic-attr.stderr
+++ b/tests/ui/test-attrs/test-should-panic-attr.stderr
@@ -10,13 +10,13 @@ LL | #[should_panic(expected)]
 help: try changing it to one of the following valid forms of the attribute
    |
 LL - #[should_panic(expected)]
+LL + #[should_panic]
+   |
+LL - #[should_panic(expected)]
 LL + #[should_panic = "reason"]
    |
 LL | #[should_panic(expected = "reason")]
    |                         ++++++++++
-LL - #[should_panic(expected)]
-LL + #[should_panic]
-   |
 
 error[E0539]: malformed `should_panic` attribute input
   --> $DIR/test-should-panic-attr.rs:20:3
@@ -30,13 +30,13 @@ LL | #[should_panic(expect)]
 help: try changing it to one of the following valid forms of the attribute
    |
 LL - #[should_panic(expect)]
+LL + #[should_panic]
+   |
+LL - #[should_panic(expect)]
 LL + #[should_panic = "reason"]
    |
 LL | #[should_panic(expected = "reason")]
    |                      +++++++++++++
-LL - #[should_panic(expect)]
-LL + #[should_panic]
-   |
 
 error[E0539]: malformed `should_panic` attribute input
   --> $DIR/test-should-panic-attr.rs:29:3
@@ -50,13 +50,13 @@ LL | #[should_panic(expected(foo, bar))]
 help: try changing it to one of the following valid forms of the attribute
    |
 LL - #[should_panic(expected(foo, bar))]
+LL + #[should_panic]
+   |
+LL - #[should_panic(expected(foo, bar))]
 LL + #[should_panic = "reason"]
    |
 LL - #[should_panic(expected(foo, bar))]
 LL + #[should_panic(expected = "reason")]
-   |
-LL - #[should_panic(expected(foo, bar))]
-LL + #[should_panic]
    |
 
 error[E0805]: malformed `should_panic` attribute input
@@ -71,13 +71,13 @@ LL | #[should_panic(expected = "foo", bar)]
 help: try changing it to one of the following valid forms of the attribute
    |
 LL - #[should_panic(expected = "foo", bar)]
+LL + #[should_panic]
+   |
+LL - #[should_panic(expected = "foo", bar)]
 LL + #[should_panic = "reason"]
    |
 LL - #[should_panic(expected = "foo", bar)]
 LL + #[should_panic(expected = "reason")]
-   |
-LL - #[should_panic(expected = "foo", bar)]
-LL + #[should_panic]
    |
 
 error: aborting due to 4 previous errors


### PR DESCRIPTION
`AttrItem` span tracking improved in rust-lang/rust#159587, which lets us slightly simplify the workings of attribute suggestions.

r? @JonathanBrouwer 
