### PR TITLE
Prevent calling some queries for typeck children

### DIFF
--- a/compiler/rustc_borrowck/src/lib.rs
+++ b/compiler/rustc_borrowck/src/lib.rs
@@ -320,7 +320,7 @@ fn borrowck_collect_region_constraints<'tcx>(
     def: LocalDefId,
 ) -> CollectRegionConstraintsResult<'tcx> {
     let tcx = root_cx.tcx;
-    let infcx = BorrowckInferCtxt::new(tcx, def, root_cx.root_def_id());
+    let infcx = BorrowckInferCtxt::new(tcx, root_cx.root_def_id());
     let (input_body, promoted) = tcx.mir_promoted(def);
     let input_body: &Body<'_> = &input_body.borrow();
     let input_promoted: &IndexSlice<_, _> = &promoted.borrow();
@@ -652,14 +652,14 @@ pub(crate) struct BorrowckInferCtxt<'tcx> {
 }
 
 impl<'tcx> BorrowckInferCtxt<'tcx> {
-    pub(crate) fn new(tcx: TyCtxt<'tcx>, def_id: LocalDefId, root_def_id: LocalDefId) -> Self {
+    pub(crate) fn new(tcx: TyCtxt<'tcx>, root_def_id: LocalDefId) -> Self {
         let typing_mode = if tcx.use_typing_mode_post_typeck_until_borrowck() {
-            TypingMode::borrowck(tcx, def_id)
+            TypingMode::borrowck(tcx, root_def_id)
         } else {
-            TypingMode::analysis_in_body(tcx, def_id)
+            TypingMode::analysis_in_body(tcx, root_def_id)
         };
         let infcx = tcx.infer_ctxt().build(typing_mode);
-        let param_env = tcx.param_env(def_id);
+        let param_env = tcx.param_env(root_def_id);
         BorrowckInferCtxt {
             infcx,
             root_def_id,

--- a/compiler/rustc_middle/src/queries.rs
+++ b/compiler/rustc_middle/src/queries.rs
@@ -1619,7 +1619,7 @@ rustc_queries! {
     /// You should almost certainly not use this. If you already have an InferCtxt, then
     /// you should also probably have a `ParamEnv` from when it was built. If you don't,
     /// then you should take a `TypingEnv` to ensure that you handle opaque types correctly.
-    query param_env(def_id: DefId) -> ty::ParamEnv<'tcx> {
+    query param_env_of_typeck_root(def_id: DefId) -> ty::ParamEnv<'tcx> {
         desc { "computing normalized predicates of `{}`", tcx.def_path_str(def_id) }
         feedable
     }
@@ -1627,7 +1627,7 @@ rustc_queries! {
     /// Like `param_env`, but returns the `ParamEnv` after all opaque types have been
     /// replaced with their hidden type. This is used in the old trait solver
     /// when in `PostAnalysis` mode and should not be called directly.
-    query param_env_normalized_for_post_analysis(def_id: DefId) -> ty::ParamEnv<'tcx> {
+    query param_env_normalized_for_post_analysis_of_typeck_root(def_id: DefId) -> ty::ParamEnv<'tcx> {
         desc { "computing revealed normalized predicates of `{}`", tcx.def_path_str(def_id) }
     }
 

--- a/compiler/rustc_middle/src/query/plumbing.rs
+++ b/compiler/rustc_middle/src/query/plumbing.rs
@@ -7,7 +7,7 @@ use rustc_data_structures::hash_table::HashTable;
 use rustc_data_structures::sharded::Sharded;
 use rustc_data_structures::sync::{AtomicU64, Lock, WorkerLocal};
 use rustc_errors::Diag;
-use rustc_hir::def_id::LocalDefId;
+use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_span::Span;
 
 use crate::dep_graph::{DepKind, DepNodeIndex, QuerySideEffect, SerializedDepNodeIndex};
@@ -211,6 +211,19 @@ impl<'tcx> TyCtxt<'tcx> {
     pub fn typeck(self, def_id: impl IntoQueryKey<LocalDefId>) -> &'tcx ty::TypeckResults<'tcx> {
         self.typeck_root(
             self.typeck_root_def_id(def_id.into_query_key().to_def_id()).expect_local(),
+        )
+    }
+
+    pub fn param_env(self, def_id: impl IntoQueryKey<DefId>) -> ty::ParamEnv<'tcx> {
+        self.param_env_of_typeck_root(self.typeck_root_def_id(def_id.into_query_key()))
+    }
+
+    pub fn param_env_normalized_for_post_analysis(
+        self,
+        def_id: impl IntoQueryKey<DefId>,
+    ) -> ty::ParamEnv<'tcx> {
+        self.param_env_normalized_for_post_analysis_of_typeck_root(
+            self.typeck_root_def_id(def_id.into_query_key()),
         )
     }
 

--- a/compiler/rustc_middle/src/ty/context/impl_interner.rs
+++ b/compiler/rustc_middle/src/ty/context/impl_interner.rs
@@ -763,19 +763,21 @@ impl<'tcx> Interner for TyCtxt<'tcx> {
     }
 
     fn opaque_types_defined_by(self, defining_anchor: LocalDefId) -> Self::LocalDefIds {
-        self.opaque_types_defined_by(defining_anchor)
+        let root_def_id = self.typeck_root_def_id_local(defining_anchor);
+        self.opaque_types_defined_by(root_def_id)
     }
 
     fn opaque_types_and_coroutines_defined_by(
         self,
         defining_anchor: Self::LocalDefId,
     ) -> Self::LocalDefIds {
+        let root_def_id = self.typeck_root_def_id_local(defining_anchor);
         let coroutines_defined_by = self
             .nested_bodies_within(defining_anchor)
             .iter()
             .filter(|def_id| self.is_coroutine(def_id.to_def_id()));
         self.mk_local_def_ids_from_iter(
-            self.opaque_types_defined_by(defining_anchor).iter().chain(coroutines_defined_by),
+            self.opaque_types_defined_by(root_def_id).iter().chain(coroutines_defined_by),
         )
     }
 

--- a/compiler/rustc_mir_transform/src/coroutine/by_move_body.rs
+++ b/compiler/rustc_mir_transform/src/coroutine/by_move_body.rs
@@ -243,7 +243,6 @@ pub(crate) fn coroutine_by_move_body_def_id<'tcx>(
     body_def.def_span(tcx.def_span(coroutine_def_id));
     body_def.explicit_predicates_of(tcx.explicit_predicates_of(coroutine_def_id));
     body_def.generics_of(tcx.generics_of(coroutine_def_id).clone());
-    body_def.param_env(tcx.param_env(coroutine_def_id));
     body_def.explicit_predicates_of(tcx.explicit_predicates_of(coroutine_def_id));
 
     // The type of the coroutine is the `by_move_coroutine_ty`.

--- a/compiler/rustc_ty_utils/src/opaque_types.rs
+++ b/compiler/rustc_ty_utils/src/opaque_types.rs
@@ -317,13 +317,9 @@ fn opaque_types_defined_by<'tcx>(
     tcx: TyCtxt<'tcx>,
     item: LocalDefId,
 ) -> &'tcx ty::List<LocalDefId> {
-    // Closures and coroutines are type checked with their parent
-    // Note that we also support `SyntheticCoroutineBody` since we create
-    // a MIR body for the def kind, and some MIR passes (like promotion)
-    // may require doing analysis using its typing env.
-    if tcx.is_typeck_child(item.to_def_id()) {
-        return tcx.opaque_types_defined_by(tcx.local_parent(item));
-    }
+    // Closures and coroutines should load the opaque types defined
+    // by their their parent.
+    assert!(!tcx.is_typeck_child(item.to_def_id()));
     let kind = tcx.def_kind(item);
     trace!(?kind);
     let mut collector = OpaqueTypeCollector::new(tcx, item);

--- a/compiler/rustc_ty_utils/src/ty.rs
+++ b/compiler/rustc_ty_utils/src/ty.rs
@@ -148,10 +148,8 @@ fn adt_sizedness_constraint<'tcx>(
 }
 
 /// See `ParamEnv` struct definition for details.
-fn param_env(tcx: TyCtxt<'_>, def_id: DefId) -> ty::ParamEnv<'_> {
-    if tcx.is_typeck_child(def_id) {
-        return tcx.param_env(tcx.typeck_root_def_id(def_id));
-    }
+fn param_env_of_typeck_root(tcx: TyCtxt<'_>, def_id: DefId) -> ty::ParamEnv<'_> {
+    assert!(!tcx.is_typeck_child(def_id));
     // Compute the bounds on Self and the type parameters.
     let ty::InstantiatedPredicates { predicates, .. } =
         tcx.predicates_of(def_id).instantiate_identity(tcx);
@@ -290,8 +288,11 @@ impl<'tcx> TypeVisitor<TyCtxt<'tcx>> for ImplTraitInTraitFinder<'_, 'tcx> {
     }
 }
 
-fn param_env_normalized_for_post_analysis(tcx: TyCtxt<'_>, def_id: DefId) -> ty::ParamEnv<'_> {
-    tcx.param_env(def_id).with_normalized(tcx)
+fn param_env_normalized_for_post_analysis_of_typeck_root(
+    tcx: TyCtxt<'_>,
+    def_id: DefId,
+) -> ty::ParamEnv<'_> {
+    tcx.param_env_of_typeck_root(def_id).with_normalized(tcx)
 }
 
 /// Check if a function is async.
@@ -402,8 +403,8 @@ pub(crate) fn provide(providers: &mut Providers) {
     *providers = Providers {
         asyncness,
         adt_sizedness_constraint,
-        param_env,
-        param_env_normalized_for_post_analysis,
+        param_env_of_typeck_root,
+        param_env_normalized_for_post_analysis_of_typeck_root,
         defaultness,
         unsizing_params_for_adt,
         impl_self_is_guaranteed_unsized,


### PR DESCRIPTION
Instead of forwarding to the parent inside the query itself, we just require that to be done outside it. May even improve caching, tho we have to do some extra work everywhere to get the parent.