### PR TITLE
Remove `cfg(not(no_global_oom_handling))` from the `Drop` impl of `UniqueArcUninit`

### DIFF
--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -4327,7 +4327,6 @@ impl<T: ?Sized, A: Allocator> UniqueArcUninit<T, A> {
     }
 }
 
-#[cfg(not(no_global_oom_handling))]
 impl<T: ?Sized, A: Allocator> Drop for UniqueArcUninit<T, A> {
     fn drop(&mut self) {
         // SAFETY:


### PR DESCRIPTION
Fixes rust-lang/rust#159651