### PR TITLE
[rustdoc] Add regression test for invalid source link generation when proc-macro are present

### DIFF
--- a/tests/rustdoc-html/macro/attribute-macro-path.rs
+++ b/tests/rustdoc-html/macro/attribute-macro-path.rs
@@ -1,0 +1,16 @@
+// This test ensures that even when a proc-macro is used, the `Source` link points
+// to the right file. In this test, the `Source` link we're testing is located in
+// the `attribute_macro_path_demo` module.
+// Regression test for <https://github.com/rust-lang/rust/issues/158768>.
+
+//@ aux-build: attribute-macro-path.rs
+
+#![crate_name = "foo"]
+#![feature(custom_inner_attributes, proc_macro_hygiene)]
+
+extern crate attribute_macro_path;
+
+//@ has 'foo/attribute_macro_path_demo/index.html'
+//@ has - '//a[@href="../../src/foo/attribute-macro-path.rs.html#16"]' 'Source'
+
+pub mod attribute_macro_path_demo;

--- a/tests/rustdoc-html/macro/attribute_macro_path_demo.rs
+++ b/tests/rustdoc-html/macro/attribute_macro_path_demo.rs
@@ -1,0 +1,6 @@
+// This file is used to ensure that `attribute_macro_path_demo.rs` test works. There is
+// nothing to be tested here.
+
+//@ ignore-test
+
+#![attribute_macro_path::identity]

--- a/tests/rustdoc-html/macro/auxiliary/attribute-macro-path.rs
+++ b/tests/rustdoc-html/macro/auxiliary/attribute-macro-path.rs
@@ -1,0 +1,12 @@
+//@ no-prefer-dynamic
+
+#![crate_type = "proc-macro"]
+
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+
+#[proc_macro_attribute]
+pub fn identity(_args: TokenStream, input: TokenStream) -> TokenStream {
+    input
+}


### PR DESCRIPTION
Fixes rust-lang/rust#158768.

The bug was fixed in rust-lang/rust#158046, so this PR only adds a regression test (I took the one present in https://github.com/rust-lang/rust/issues/158768).

r? @Urgau 