### PR TITLE
Replace most `Ty::new_fn_def` calls with `type_of` queries directly

### DIFF
--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
@@ -1487,7 +1487,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                     // FIXME(156581): actually instantiate the binder correctly (turbofishing/fndef changes)
                     Ok(ty::Const::zero_sized(
                         tcx,
-                        Ty::new_fn_def(tcx, ctor_def_id, ty::Binder::dummy(args)),
+                        tcx.type_of(ctor_def_id).instantiate(tcx, args).skip_norm_wip(),
                     ))
                 }
                 DefKind::Ctor(ctor_of, CtorKind::Const) => {
@@ -2913,8 +2913,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                     &path.segments[generic_segments[0].1],
                 );
 
-                // FIXME(156581): actually instantiate the binder correctly (turbofishing/fndef changes)
-                ty::Const::zero_sized(tcx, Ty::new_fn_def(tcx, did, ty::Binder::dummy(args)))
+                ty::Const::zero_sized(tcx, tcx.type_of(did).instantiate(tcx, args).skip_norm_wip())
             }
             Res::Def(DefKind::AssocConst { .. }, did) => {
                 let trait_segment = if let [modules @ .., trait_, _item] = path.segments {

--- a/compiler/rustc_middle/src/mir/statement.rs
+++ b/compiler/rustc_middle/src/mir/statement.rs
@@ -620,11 +620,13 @@ impl<'tcx> Operand<'tcx> {
     pub fn function_handle(
         tcx: TyCtxt<'tcx>,
         def_id: DefId,
-        args: ty::Binder<'tcx, impl IntoIterator<Item = GenericArg<'tcx>>>,
+        args: &[GenericArg<'tcx>],
         span: Span,
     ) -> Self {
-        let ty = Ty::new_fn_def(tcx, def_id, args);
-        Operand::zero_sized_constant(ty, span)
+        Operand::zero_sized_constant(
+            tcx.type_of(def_id).instantiate(tcx, args).skip_norm_wip(),
+            span,
+        )
     }
 
     /// Convenience helper to make a constant that refers to the given `DefId` and args. Since this

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -725,6 +725,7 @@ impl<'tcx> Ty<'tcx> {
         T::collect_and_apply(iter, |ts| Ty::new_tup(tcx, ts))
     }
 
+    /// Prefer using the [TyCtxt::type_of] query over this, that makes it easier to get all the pieces correct
     #[inline]
     pub fn new_fn_def(
         tcx: TyCtxt<'tcx>,

--- a/compiler/rustc_mir_build/src/builder/expr/into.rs
+++ b/compiler/rustc_mir_build/src/builder/expr/into.rs
@@ -533,12 +533,8 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     let clone_trait = this.tcx.require_lang_item(LangItem::Clone, span);
                     let clone_fn = this.tcx.associated_item_def_ids(clone_trait)[0];
                     // FIXME(156581): actually instantiate the binder correctly (turbofishing/fndef changes)
-                    let func = Operand::function_handle(
-                        this.tcx,
-                        clone_fn,
-                        ty::Binder::dummy([ty.into()]),
-                        expr_span,
-                    );
+                    let func =
+                        Operand::function_handle(this.tcx, clone_fn, &[ty.into()], expr_span);
                     let ref_ty = Ty::new_imm_ref(this.tcx, this.tcx.lifetimes.re_erased, ty);
                     let ref_place = this.temp(ref_ty, span);
                     this.cfg.push_assign(

--- a/compiler/rustc_mir_build/src/builder/matches/test.rs
+++ b/compiler/rustc_mir_build/src/builder/matches/test.rs
@@ -348,8 +348,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         let source_info = self.source_info(span);
         let re_erased = self.tcx.lifetimes.re_erased;
         let trait_item = self.tcx.require_lang_item(trait_item, span);
-        // FIXME(156581): actually instantiate the binder correctly (turbofishing/fndef changes)
-        let method = trait_method(self.tcx, trait_item, method, ty::Binder::dummy([ty]));
+        let method = trait_method(self.tcx, trait_item, method, &[ty.into()]);
         let ref_src = self.temp(Ty::new_ref(self.tcx, re_erased, ty, mutability), span);
         // `let ref_src = &src_place;`
         // or `let ref_src = &mut src_place;`
@@ -422,9 +421,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
     ) {
         let str_ty = self.tcx.types.str_;
         let eq_def_id = self.tcx.require_lang_item(LangItem::PartialEq, source_info.span);
-        let method =
-            // FIXME(156581): actually instantiate the binder correctly (turbofishing/fndef changes)
-            trait_method(self.tcx, eq_def_id, sym::eq, ty::Binder::dummy([str_ty, str_ty]));
+        let method = trait_method(self.tcx, eq_def_id, sym::eq, &[str_ty.into(), str_ty.into()]);
 
         let bool_ty = self.tcx.types.bool;
         let eq_result = self.temp(bool_ty, source_info.span);
@@ -471,7 +468,7 @@ fn trait_method<'tcx>(
     tcx: TyCtxt<'tcx>,
     trait_def_id: DefId,
     method_name: Symbol,
-    args: ty::Binder<'tcx, impl IntoIterator<Item: Into<GenericArg<'tcx>>>>,
+    args: &[GenericArg<'tcx>],
 ) -> Const<'tcx> {
     // The unhygienic comparison here is acceptable because this is only
     // used on known traits.
@@ -481,7 +478,5 @@ fn trait_method<'tcx>(
         .find(|item| item.is_fn())
         .expect("trait method not found");
 
-    let method_ty = Ty::new_fn_def(tcx, item.def_id, args);
-
-    Const::zero_sized(method_ty)
+    Const::zero_sized(tcx.type_of(item.def_id).instantiate(tcx, args).skip_norm_wip())
 }

--- a/compiler/rustc_mir_build/src/thir/cx/expr.rs
+++ b/compiler/rustc_mir_build/src/thir/cx/expr.rs
@@ -199,12 +199,11 @@ impl<'tcx> ThirBuildCx<'tcx> {
                 // We don't need to do call adjust_span here since
                 // deref coercions always start with a built-in deref.
                 let call_def_id = deref.method_call(self.tcx);
-                // FIXME(156581): actually instantiate the binder correctly (turbofishing/fndef changes)
-                let overloaded_callee = Ty::new_fn_def(
-                    self.tcx,
-                    call_def_id,
-                    ty::Binder::dummy(self.tcx.mk_args(&[expr.ty.into()])),
-                );
+                let overloaded_callee = self
+                    .tcx
+                    .type_of(call_def_id)
+                    .instantiate(self.tcx, self.tcx.mk_args(&[expr.ty.into()]))
+                    .skip_norm_wip();
 
                 expr = Expr {
                     temp_scope_id,
@@ -855,12 +854,10 @@ impl<'tcx> ThirBuildCx<'tcx> {
                 };
                 let mk_call =
                     |thir: &mut Thir<'tcx>, ty: Ty<'tcx>, variant: VariantIdx, field: FieldIdx| {
-                        // FIXME(156581): actually instantiate the binder correctly (turbofishing/fndef changes)
-                        let fun_ty = Ty::new_fn_def(
-                            tcx,
-                            offset_of_intrinsic,
-                            ty::Binder::dummy([ty::GenericArg::from(ty)]),
-                        );
+                        let fun_ty = tcx
+                            .type_of(offset_of_intrinsic)
+                            .instantiate(tcx, &[ty.into()])
+                            .skip_norm_wip();
                         let fun = thir
                             .exprs
                             .push(mk_expr(ExprKind::ZstLiteral { user_ty: None }, fun_ty));
@@ -1211,12 +1208,10 @@ impl<'tcx> ThirBuildCx<'tcx> {
                 let user_ty = self.user_args_applied_to_res(expr.hir_id, Res::Def(kind, def_id));
                 debug!("method_callee: user_ty={:?}", user_ty);
                 (
-                    // FIXME: instantiate binder correctly (turbofish/fndex)
-                    Ty::new_fn_def(
-                        self.tcx,
-                        def_id,
-                        ty::Binder::dummy(self.typeck_results.node_args(expr.hir_id)),
-                    ),
+                    self.tcx
+                        .type_of(def_id)
+                        .instantiate(self.tcx, self.typeck_results.node_args(expr.hir_id))
+                        .skip_norm_wip(),
                     user_ty,
                 )
             }
@@ -1250,12 +1245,11 @@ impl<'tcx> ThirBuildCx<'tcx> {
 
             Expr {
                 temp_scope_id: expr.hir_id.local_id,
-                // FIXME(156581): actually instantiate the binder correctly (turbofishing/fndef changes)
-                ty: Ty::new_fn_def(
-                    self.tcx,
-                    def_id,
-                    ty::Binder::dummy(self.typeck_results.node_args(expr.hir_id)),
-                ),
+                ty: self
+                    .tcx
+                    .type_of(def_id)
+                    .instantiate(self.tcx, self.typeck_results.node_args(expr.hir_id))
+                    .skip_norm_wip(),
                 span,
                 kind: ExprKind::ZstLiteral { user_ty },
             }

--- a/compiler/rustc_mir_transform/src/elaborate_drop.rs
+++ b/compiler/rustc_mir_transform/src/elaborate_drop.rs
@@ -374,12 +374,7 @@ where
             vec![self.storage_live(fut)],
             TerminatorKind::Call {
                 // FIXME(156581): actually instantiate the binder correctly (turbofishing/fndef changes)
-                func: Operand::function_handle(
-                    tcx,
-                    async_drop_fn_def_id,
-                    ty::Binder::dummy([drop_ty.into()]),
-                    span,
-                ),
+                func: Operand::function_handle(tcx, async_drop_fn_def_id, &[drop_ty.into()], span),
                 args: [dummy_spanned(drop_arg)].into(),
                 destination: fut.into(),
                 target: Some(succ_yield_loop),
@@ -408,7 +403,7 @@ where
                     tcx,
                     pin_obj_new_unchecked_fn,
                     // FIXME(156581): actually instantiate the binder correctly (turbofishing/fndef changes)
-                    ty::Binder::dummy([obj_ref_ty.into()]),
+                    &[obj_ref_ty.into()],
                     span,
                 ),
                 args: [dummy_spanned(Operand::Move(obj_ref_place))].into(),
@@ -574,12 +569,7 @@ where
             Vec::new(),
             TerminatorKind::Call {
                 // FIXME(156581): actually instantiate the binder correctly (turbofishing/fndef changes)
-                func: Operand::function_handle(
-                    tcx,
-                    poll_fn,
-                    ty::Binder::dummy([fut_ty.into()]),
-                    source_info.span,
-                ),
+                func: Operand::function_handle(tcx, poll_fn, &[fut_ty.into()], source_info.span),
                 args: [
                     dummy_spanned(Operand::Move(fut_pin_local.into())),
                     dummy_spanned(Operand::Move(context_ref_local.into())),
@@ -609,10 +599,7 @@ where
                         tcx,
                         get_context_fn,
                         // FIXME(156581): actually instantiate the binder correctly (turbofishing/fndef changes)
-                        ty::Binder::dummy([
-                            tcx.lifetimes.re_erased.into(),
-                            tcx.lifetimes.re_erased.into(),
-                        ]),
+                        &[tcx.lifetimes.re_erased.into(), tcx.lifetimes.re_erased.into()],
                         source_info.span,
                     ),
                     args: [dummy_spanned(Operand::Move(entry_resume_local.into()))].into(),
@@ -642,7 +629,7 @@ where
                 func: Operand::function_handle(
                     tcx,
                     fut_pin_new_unchecked_fn,
-                    ty::Binder::dummy([fut_ref_ty.into()]),
+                    &[fut_ref_ty.into()],
                     source_info.span,
                 ),
                 args: [dummy_spanned(Operand::Move(fut_ref_local.into()))].into(),
@@ -1266,12 +1253,7 @@ where
             )],
             TerminatorKind::Call {
                 // FIXME(156581): actually instantiate the binder correctly (turbofishing/fndef changes)
-                func: Operand::function_handle(
-                    tcx,
-                    drop_fn,
-                    ty::Binder::dummy([ty.into()]),
-                    self.source_info.span,
-                ),
+                func: Operand::function_handle(tcx, drop_fn, &[ty.into()], self.source_info.span),
                 args: [dummy_spanned(Operand::Move(Place::from(ref_place)))].into(),
                 destination: unit_temp,
                 target: Some(succ),

--- a/compiler/rustc_mir_transform/src/shim.rs
+++ b/compiler/rustc_mir_transform/src/shim.rs
@@ -331,7 +331,7 @@ pub fn build_drop_shim<'tcx>(
                 func: Operand::function_handle(
                     tcx,
                     def_id,
-                    ty::Binder::dummy([ty::GenericArg::from(slice_ty)]),
+                    &[ty::GenericArg::from(slice_ty)],
                     span,
                 ),
                 args: Box::new([Spanned { span, node: Operand::Move(Place::from(erased_local)) }]),
@@ -625,7 +625,7 @@ impl<'tcx> CloneShimBuilder<'tcx> {
 
         // `func == Clone::clone(&ty) -> ty`
         // FIXME(156581): actually instantiate the binder correctly (turbofishing/fndef changes)
-        let func_ty = Ty::new_fn_def(tcx, self.def_id, ty::Binder::dummy([ty]));
+        let func_ty = tcx.type_of(self.def_id).instantiate(tcx, &[ty.into()]).skip_norm_wip();
         let func = Operand::Constant(Box::new(ConstOperand {
             span: self.span,
             user_ty: None,

--- a/compiler/rustc_mir_transform/src/shim/async_destructor_ctor.rs
+++ b/compiler/rustc_mir_transform/src/shim/async_destructor_ctor.rs
@@ -372,12 +372,7 @@ fn build_adrop_for_adrop_shim<'tcx>(
             source_info,
             kind: TerminatorKind::Call {
                 // FIXME(156581): actually instantiate the binder correctly (turbofishing/fndef changes)
-                func: Operand::function_handle(
-                    tcx,
-                    pin_fn,
-                    ty::Binder::dummy([cor_ref.into()]),
-                    span,
-                ),
+                func: Operand::function_handle(tcx, pin_fn, &[cor_ref.into()], span),
                 args: [dummy_spanned(Operand::Move(cor_ref_place))].into(),
                 destination: cor_pin_place,
                 target: Some(call_bb),
@@ -399,12 +394,7 @@ fn build_adrop_for_adrop_shim<'tcx>(
             source_info,
             kind: TerminatorKind::Call {
                 // FIXME(156581): actually instantiate the binder correctly (turbofishing/fndef changes)
-                func: Operand::function_handle(
-                    tcx,
-                    poll_fn,
-                    ty::Binder::dummy([impl_ty.into()]),
-                    span,
-                ),
+                func: Operand::function_handle(tcx, poll_fn, &[impl_ty.into()], span),
                 args: [
                     dummy_spanned(Operand::Move(cor_pin_place)),
                     dummy_spanned(Operand::Move(resume_ctx)),


### PR DESCRIPTION
This is so we can reduce the amount of code and changes in rust-lang/rust#159403. It should stand on its own, but really it's meant as an extended part of 159403.

This allows getting the right `ty::FnDef` even cross-crate, as the `type_of` query results are stored in metadata, in contrast to the queries for computing the binder for various declarations. These binders are already cached via `fn_sig`, but using that is somewhat overkill and can cause cycle errors in some cases.