### PR TITLE
fix(ld64.lld): route version mismatch warnings to linker_info on macOS

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -884,9 +884,9 @@ fn is_msvc_link_exe(sess: &Session) -> bool {
         && linker_path.to_str() == Some("link.exe")
 }
 
-fn is_macos_ld(sess: &Session) -> bool {
+fn is_macos_linker(sess: &Session) -> bool {
     let (_, flavor) = linker_and_flavor(sess);
-    sess.target.is_like_darwin && matches!(flavor, LinkerFlavor::Darwin(_, Lld::No))
+    sess.target.is_like_darwin && matches!(flavor, LinkerFlavor::Darwin(..))
 }
 
 fn is_windows_gnu_ld(sess: &Session) -> bool {
@@ -953,8 +953,8 @@ fn report_linker_output(
                 *output += "\r\n"
             }
         });
-    } else if is_macos_ld(sess) {
-        info!("inferred macOS LD");
+    } else if is_macos_linker(sess) {
+        info!("inferred macOS linker");
 
         // FIXME: Tracked by https://github.com/rust-lang/rust/issues/136113
         let deployment_mismatch = |line: &str| {
@@ -967,6 +967,8 @@ fn report_linker_output(
                 && line.contains("building for")
                 && line.contains("but linking with")
                 && line.contains("which was built for newer version"))
+            // lld (ld64.lld / rust-lld):
+            || line.contains("which is newer than target minimum of")
         };
         // FIXME: This is a real warning we would like to show, but it hits too many crates
         // to want to turn it on immediately.

--- a/tests/run-make/macos-deployment-target-warning/rmake.rs
+++ b/tests/run-make/macos-deployment-target-warning/rmake.rs
@@ -13,6 +13,7 @@ fn main() {
     let ld_prime_obj = r"ld: warning: object file \(.*\) was built for newer '.+' version \(\d+\.\d+\) than being linked \(\d+\.\d+\)";
     let ld64_dylib = r"ld: warning: dylib \(.*\) was built for newer .+ version \(\d+\.\d+\) than being linked \(\d+\.\d+\)";
     let ld_prime_dylib = r"ld: warning: building for [^ ,]+, but linking with dylib '[^']*' which was built for newer version [0-9.]+";
+    let lld_obj = r"ld64\.lld: warning: .+ has version \d+\.\d+(\.\d+)?, which is newer than target minimum of \d+\.\d+(\.\d+)?";
 
     // Test 1: static archive (object file mismatch)
     cc().arg("-c").arg("-mmacosx-version-min=15.5").output("foo.o").input("foo.c").run();
@@ -54,4 +55,30 @@ fn main() {
         .normalize(ld64_dylib, "NORMALIZED_DYLIB_DEPLOYMENT_MISMATCH_LINKER_WARNING")
         .normalize(ld_prime_dylib, "NORMALIZED_DYLIB_DEPLOYMENT_MISMATCH_LINKER_WARNING")
         .run();
+
+    // Test 3: static archive with lld (object file mismatch)
+    // Skip if lld is not available (not all CI configurations build it).
+    let lld_path = std::path::PathBuf::from(std::env::var("LLVM_BIN_DIR").unwrap()).join("lld");
+    if lld_path.exists() {
+        let ld64_lld = std::env::current_dir().unwrap().join("ld64.lld");
+        std::os::unix::fs::symlink(&lld_path, &ld64_lld)
+            .expect("failed to create ld64.lld symlink");
+
+        let lld_warnings = rustc()
+            .arg("-lstatic=foo")
+            .arg("-Clink-self-contained=-linker")
+            .arg("-Zunstable-options")
+            .arg("-Clinker-flavor=darwin-lld")
+            .linker(&ld64_lld.to_str().unwrap())
+            .input("main.rs")
+            .crate_type("bin")
+            .run()
+            .stderr_utf8();
+
+        diff()
+            .expected_file("warnings.txt")
+            .actual_text("(rustc -W linker-info with lld)", &lld_warnings)
+            .normalize(lld_obj, "NORMALIZED_OBJECT_DEPLOYMENT_MISMATCH_LINKER_WARNING")
+            .run();
+    }
 }


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/159666)*
<!-- homu-ignore:end -->

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? jyn514
-->
<!-- homu-ignore:end -->

r? jyn514

Fixes rust-lang/rust#159227

**Issue:** .o objects (e.g. precompiled stdlib .rlib files, C libraries compiled via cc-rs) receive MacOS version of the machine they were compiled on and that version is much higher than Rust's default deployment target for aarch64-apple-darwin which is macOS 11.0.0.

[`(Os::MacOs, crate::spec::Arch::AArch64, _) => (11, 0, 0)`](https://github.com/rust-lang/rust/blob/f65b272fc92b1e7527dea4a224430a249ab25c2d/compiler/rustc_target/src/spec/base/apple/mod.rs#L332)

 That’s why hundreds of warning logs appear such as warning: `linker stderr: rust-lld: /path/file.rlib(file.o) has version 26.4.1, which is newer than target minimum of 11.0.0`. These warnings were already filtered for ld64 and ld_prime but not for lld (see rust-lang/rust#136113).

**Root cause:** I believe that the current function `is_macos_ld()` in [compiler/rustc_codegen_ssa/src/back/link.rs](https://github.com/rust-lang/rust/blob/730a6b5dce9477b819de0ba79d6e7945e1248e3d/compiler/rustc_codegen_ssa/src/back/link.rs#L874) handles the case when we use native macOS linker so the entire filtering chain in linker output is skipped when using ld64.lld. Relevant code:

```
fn is_macos_ld(sess: &Session) -> bool {
    let (_, flavor) = linker_and_flavor(sess);
    sess.target.is_like_darwin && matches!(flavor, LinkerFlavor::Darwin(_, Lld::No))

}
```
So, `Lld::No` means using native macOS linker, so when lld is used via `Lld::Yes`, the match fails and the function returns `false` hence all warnings come from stderr to linker_messages which are visible.

**My proposed solution:** modify filtering such that it runs for lld too and add a new specific ld64.lld warning pattern routing warnings to linker_info to make them invisible by default.