### PR TITLE
Make some parser structured suggestions verbose and tweak their wording

### DIFF
--- a/compiler/rustc_parse/src/lexer/mod.rs
+++ b/compiler/rustc_parse/src/lexer/mod.rs
@@ -987,7 +987,7 @@ impl<'psess, 'src> Lexer<'psess, 'src> {
             let lo = start + BytePos(possible_offset);
             let hi = lo + BytePos(found_terminators);
             let span = self.mk_sp(lo, hi);
-            err.span_suggestion(
+            err.span_suggestion_verbose(
                 span,
                 "consider terminating the string here",
                 "#".repeat(n_hashes as usize),

--- a/compiler/rustc_parse/src/lexer/unescape_error_reporting.rs
+++ b/compiler/rustc_parse/src/lexer/unescape_error_reporting.rs
@@ -162,7 +162,7 @@ pub(crate) fn emit_unescape_error(
                 );
             } else {
                 if mode == Mode::Str || mode == Mode::Char {
-                    diag.span_suggestion(
+                    diag.span_suggestion_verbose(
                         full_lit_span,
                         "if you meant to write a literal backslash (perhaps escaping in a regular expression), consider a raw string literal",
                         format!("r\"{lit}\""),
@@ -204,7 +204,7 @@ pub(crate) fn emit_unescape_error(
             // Note: the \\xHH suggestions are not given for raw byte string
             // literals, because they are araw and so cannot use any escapes.
             if (c as u32) <= 0xFF && mode != Mode::RawByteStr {
-                err.span_suggestion(
+                err.span_suggestion_verbose(
                     span,
                     format!(
                         "if you meant to use the unicode code point for {c:?}, use a \\xHH escape"
@@ -217,7 +217,7 @@ pub(crate) fn emit_unescape_error(
             } else if mode != Mode::RawByteStr {
                 let mut utf8 = String::new();
                 utf8.push(c);
-                err.span_suggestion(
+                err.span_suggestion_verbose(
                     span,
                     format!("if you meant to use the UTF-8 encoding of {c:?}, use \\xHH escapes"),
                     utf8.as_bytes()
@@ -313,7 +313,7 @@ fn foreign_escape_suggestion(
     err_span: Span,
 ) {
     if escaped_char == "?" {
-        diag.span_suggestion(
+        diag.span_suggestion_verbose(
             err_span,
             "if you meant to write a literal question mark, don't escape the character",
             "?",
@@ -336,7 +336,7 @@ fn foreign_escape_suggestion(
         _ => return,
     };
 
-    diag.span_suggestion(
+    diag.span_suggestion_verbose(
         escape_span,
         format!("if you meant to write {name}, use a hex escape"),
         format!("x{hex}"),

--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -2062,7 +2062,15 @@ impl<'a> Parser<'a> {
                     Applicability::MachineApplicable,
                 );
             }
-            err.span_suggestion_verbose(lo.shrink_to_lo(), format!("{prefix}you can still access the deprecated `try!()` macro using the \"raw identifier\" syntax"), "r#", Applicability::MachineApplicable);
+            err.span_suggestion_verbose(
+                lo.shrink_to_lo(),
+                format!(
+                    "{prefix}you can still access the deprecated `try!()` macro using the \
+                     \"raw identifier\" syntax"
+                ),
+                "r#",
+                Applicability::MachineApplicable,
+            );
             let guar = err.emit();
             Ok(self.mk_expr_err(lo.to(hi), guar))
         } else {

--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -597,7 +597,7 @@ impl<'a> Parser<'a> {
                 .iter()
                 .any(|tok| matches!(tok, TokenType::FatArrow | TokenType::CloseBrace))
         {
-            err.span_suggestion(
+            err.span_suggestion_verbose(
                 self.token.span,
                 "you might have meant to write a \"greater than or equal to\" comparison",
                 ">=",
@@ -942,7 +942,7 @@ impl<'a> Parser<'a> {
                     count += 1;
                 }
                 err.span(span);
-                err.span_suggestion(
+                err.span_suggestion_verbose(
                     span,
                     format!("remove the extra `#`{}", pluralize!(count)),
                     "",
@@ -2062,7 +2062,7 @@ impl<'a> Parser<'a> {
                     Applicability::MachineApplicable,
                 );
             }
-            err.span_suggestion(lo.shrink_to_lo(), format!("{prefix}you can still access the deprecated `try!()` macro using the \"raw identifier\" syntax"), "r#", Applicability::MachineApplicable);
+            err.span_suggestion_verbose(lo.shrink_to_lo(), format!("{prefix}you can still access the deprecated `try!()` macro using the \"raw identifier\" syntax"), "r#", Applicability::MachineApplicable);
             let guar = err.emit();
             Ok(self.mk_expr_err(lo.to(hi), guar))
         } else {
@@ -2243,7 +2243,7 @@ impl<'a> Parser<'a> {
             let ident = self.parse_ident_common(true).unwrap();
             let span = pat.span.with_hi(ident.span.hi());
 
-            err.span_suggestion(
+            err.span_suggestion_verbose(
                 span,
                 "declare the type after the parameter binding",
                 "<identifier>: <type>",
@@ -2641,7 +2641,7 @@ impl<'a> Parser<'a> {
             Ok((expr, _)) => {
                 // Find a mistake like `MyTrait<Assoc == S::Assoc>`.
                 if snapshot.token == token::EqEq {
-                    err.span_suggestion(
+                    err.span_suggestion_verbose(
                         snapshot.token.span,
                         "if you meant to use an associated type binding, replace `==` with `=`",
                         "=",
@@ -2655,7 +2655,7 @@ impl<'a> Parser<'a> {
                     && matches!(expr.kind, ExprKind::Path(..))
                 {
                     // Find a mistake like "foo::var:A".
-                    err.span_suggestion(
+                    err.span_suggestion_verbose(
                         snapshot.token.span,
                         "write a path separator here",
                         "::",
@@ -2938,7 +2938,7 @@ impl<'a> Parser<'a> {
             Applicability::MachineApplicable,
         );
         if let CommaRecoveryMode::EitherTupleOrPipe = rt {
-            err.span_suggestion(
+            err.span_suggestion_verbose(
                 comma_span,
                 "...or a vertical bar to match on alternatives",
                 " |",
@@ -2975,7 +2975,7 @@ impl<'a> Parser<'a> {
             && (self.expected_token_types.contains(TokenType::Gt)
                 || matches!(self.token.kind, token::Literal(..)))
         {
-            err.span_suggestion(
+            err.span_suggestion_verbose(
                 maybe_lt.span,
                 "remove the `<` to write an exclusive range",
                 "",

--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -1699,7 +1699,12 @@ impl<'a> Parser<'a> {
                 // directly adjacent (i.e. '=<')
                 if maybe_eq_tok == TokenKind::Eq && maybe_eq_tok.span.hi() == lt_span.lo() {
                     let eq_lt = maybe_eq_tok.span.to(lt_span);
-                    err.span_suggestion(eq_lt, "did you mean", "<=", Applicability::Unspecified);
+                    err.span_suggestion_verbose(
+                        eq_lt,
+                        "did you mean",
+                        "<=",
+                        Applicability::Unspecified,
+                    );
                 }
                 err
             })?;
@@ -2755,7 +2760,7 @@ impl<'a> Parser<'a> {
                             && let maybe_let = self.look_ahead(1, |t| t.clone())
                             && maybe_let.is_keyword(kw::Let)
                         {
-                            err.span_suggestion(
+                            err.span_suggestion_verbose(
                                 self.prev_token.span,
                                 "consider removing this semicolon to parse the `let` as part of the same chain",
                                 "",
@@ -2767,7 +2772,7 @@ impl<'a> Parser<'a> {
                         } else {
                             // Look for usages of '=>' where '>=' might be intended
                             if maybe_fatarrow == token::FatArrow {
-                                err.span_suggestion(
+                                err.span_suggestion_verbose(
                                     maybe_fatarrow.span,
                                     "you might have meant to write a \"greater than or equal to\" comparison",
                                     ">=",
@@ -3381,7 +3386,7 @@ impl<'a> Parser<'a> {
                 if let Err(mut err) = this.expect(exp!(FatArrow)) {
                     // We might have a `=>` -> `=` or `->` typo (issue #89396).
                     if is_almost_fat_arrow {
-                        err.span_suggestion(
+                        err.span_suggestion_verbose(
                             this.token.span,
                             "use a fat arrow to start a match arm",
                             "=>",

--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -1701,7 +1701,7 @@ impl<'a> Parser<'a> {
                     let eq_lt = maybe_eq_tok.span.to(lt_span);
                     err.span_suggestion_verbose(
                         eq_lt,
-                        "did you mean",
+                        "you might have meant to write a \"less than or equal to\" comparison",
                         "<=",
                         Applicability::Unspecified,
                     );

--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -626,13 +626,16 @@ impl<'a> Parser<'a> {
         let mut err = self.dcx().struct_span_err(end.span, msg);
         if end.is_doc_comment() {
             err.span_label(end.span, "this doc comment doesn't document anything");
-        } else if self.token == TokenKind::Semi {
-            err.span_suggestion(
-                self.token.span,
-                "consider removing this semicolon",
-                "",
-                Applicability::MaybeIncorrect,
-            );
+        } else {
+            err.span_label(end.span, "expected an item after this");
+            if self.token == TokenKind::Semi {
+                err.span_suggestion_verbose(
+                    self.token.span,
+                    "remove the semicolon after the attribute",
+                    "",
+                    Applicability::MaybeIncorrect,
+                );
+            }
         }
         if let [.., penultimate, _] = attrs {
             err.span_label(start.span.to(penultimate.span), "other attributes here");
@@ -2429,16 +2432,19 @@ impl<'a> Parser<'a> {
                     &inherited_vis,
                     Case::Insensitive,
                 ) {
-                    Ok(_) => {
-                        self.dcx().struct_span_err(
+                    Ok(_) => self
+                        .dcx()
+                        .struct_span_err(
                             lo.to(self.prev_token.span),
                             format!("functions are not allowed in {adt_ty} definitions"),
                         )
                         .with_help(
                             "unlike in C++, Java, and C#, functions are declared in `impl` blocks",
                         )
-                        .with_help("see https://doc.rust-lang.org/book/ch05-03-method-syntax.html for more information")
-                    }
+                        .with_help(
+                            "see https://doc.rust-lang.org/book/ch05-03-method-syntax.html \
+                             for more information",
+                        ),
                     Err(err) => {
                         err.cancel();
                         self.restore_snapshot(snapshot);
@@ -2476,12 +2482,15 @@ impl<'a> Parser<'a> {
                 {
                     err.span_suggestion_verbose(
                         removal_span,
-                        "remove this `let` keyword",
+                        "remove the `let` keyword",
                         String::new(),
                         Applicability::MachineApplicable,
                     );
                     err.note("the `let` keyword is not allowed in `struct` fields");
-                    err.note("see <https://doc.rust-lang.org/book/ch05-01-defining-structs.html> for more information");
+                    err.note(
+                        "see <https://doc.rust-lang.org/book/ch05-01-defining-structs.html> \
+                         for more information",
+                    );
                     err.emit();
                     return Ok(ident);
                 } else {

--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -601,7 +601,7 @@ impl<'a> Parser<'a> {
                     && let [segment] = path.segments.as_slice()
                     && edit_distance("macro_rules", &segment.ident.to_string(), 2).is_some()
                 {
-                    err.span_suggestion(
+                    err.span_suggestion_verbose(
                         path.span,
                         "perhaps you meant to define a macro",
                         "macro_rules",
@@ -627,7 +627,7 @@ impl<'a> Parser<'a> {
         if end.is_doc_comment() {
             err.span_label(end.span, "this doc comment doesn't document anything");
         } else if self.token == TokenKind::Semi {
-            err.span_suggestion_verbose(
+            err.span_suggestion(
                 self.token.span,
                 "consider removing this semicolon",
                 "",
@@ -2474,7 +2474,7 @@ impl<'a> Parser<'a> {
                         .map_err(|err| err.cancel())
                     && self.token == TokenKind::Colon
                 {
-                    err.span_suggestion(
+                    err.span_suggestion_verbose(
                         removal_span,
                         "remove this `let` keyword",
                         String::new(),
@@ -2632,7 +2632,7 @@ impl<'a> Parser<'a> {
                     vec![(open, "{".to_string()), (close, '}'.to_string())],
                     Applicability::MaybeIncorrect,
                 );
-                err.span_suggestion(
+                err.span_suggestion_verbose(
                     span.with_neighbor(self.token.span).shrink_to_hi(),
                     "add a semicolon",
                     ';',
@@ -3248,7 +3248,7 @@ impl<'a> Parser<'a> {
                             .span_to_snippet(original_sp)
                             .expect("Span extracted directly from keyword should always work");
 
-                        err.span_suggestion(
+                        err.span_suggestion_verbose(
                             self.token_uninterpolated_span(),
                             format!("`{original_kw}` already used earlier, remove this one"),
                             "",
@@ -3263,7 +3263,7 @@ impl<'a> Parser<'a> {
                             let misplaced_qual_sp = self.token_uninterpolated_span();
                             let misplaced_qual = self.span_to_snippet(misplaced_qual_sp).unwrap();
 
-                            err.span_suggestion(
+                            err.span_suggestion_verbose(
                                     correct_pos_sp.to(misplaced_qual_sp),
                                     format!("`{misplaced_qual}` must come before `{current_qual}`"),
                                     format!("{misplaced_qual} {current_qual}"),
@@ -3287,7 +3287,7 @@ impl<'a> Parser<'a> {
 
                             // There was no explicit visibility
                             if matches!(orig_vis.kind, VisibilityKind::Inherited) {
-                                err.span_suggestion(
+                                err.span_suggestion_verbose(
                                     sp_start.to(self.prev_token.span),
                                     format!("visibility `{vs}` must come before `{snippet}`"),
                                     format!("{vs} {snippet}"),
@@ -3296,7 +3296,7 @@ impl<'a> Parser<'a> {
                             }
                             // There was an explicit visibility
                             else {
-                                err.span_suggestion(
+                                err.span_suggestion_verbose(
                                     current_vis.span,
                                     "there is already a visibility modifier, remove one",
                                     "",

--- a/compiler/rustc_parse/src/parser/mod.rs
+++ b/compiler/rustc_parse/src/parser/mod.rs
@@ -1805,7 +1805,7 @@ impl<'a> Parser<'a> {
                 format!("the {kind_desc} was parsed as having {op_desc} binary expression"),
             );
 
-            err.span_suggestion(
+            err.span_suggestion_verbose(
                 lhs_end_span,
                 format!("you may have meant to write a `;` to terminate the {kind_desc} earlier"),
                 ";",

--- a/compiler/rustc_parse/src/parser/path.rs
+++ b/compiler/rustc_parse/src/parser/path.rs
@@ -817,13 +817,13 @@ impl<'a> Parser<'a> {
                     .dcx()
                     .struct_span_err(after_eq.to(before_next), "missing type to the right of `=`");
                 if matches!(self.token.kind, token::Comma | token::Gt) {
-                    err.span_suggestion(
+                    err.span_suggestion_verbose(
                         self.psess.source_map().next_point(eq_span).to(before_next),
                         "to constrain the associated type, add a type after `=`",
                         " TheType",
                         Applicability::HasPlaceholders,
                     );
-                    err.span_suggestion(
+                    err.span_suggestion_verbose(
                         prev_token_span.shrink_to_hi().to(before_next),
                         format!("remove the `=` if `{ident}` is a type"),
                         "",

--- a/tests/ui/async-await/in-trait/bad-signatures.stderr
+++ b/tests/ui/async-await/in-trait/bad-signatures.stderr
@@ -8,10 +8,13 @@ error: expected one of `:`, `@`, or `|`, found keyword `self`
   --> $DIR/bad-signatures.rs:5:23
    |
 LL |     async fn bar(&abc self);
-   |                  -----^^^^
-   |                  |    |
-   |                  |    expected one of `:`, `@`, or `|`
-   |                  help: declare the type after the parameter binding: `<identifier>: <type>`
+   |                       ^^^^ expected one of `:`, `@`, or `|`
+   |
+help: declare the type after the parameter binding
+   |
+LL -     async fn bar(&abc self);
+LL +     async fn bar(<identifier>: <type>);
+   |
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/async-await/no-async-const.stderr
+++ b/tests/ui/async-await/no-async-const.stderr
@@ -2,12 +2,14 @@ error: expected one of `extern`, `fn`, `safe`, or `unsafe`, found keyword `const
   --> $DIR/no-async-const.rs:4:11
    |
 LL | pub async const fn x() {}
-   |     ------^^^^^
-   |     |     |
-   |     |     expected one of `extern`, `fn`, `safe`, or `unsafe`
-   |     help: `const` must come before `async`: `const async`
+   |           ^^^^^ expected one of `extern`, `fn`, `safe`, or `unsafe`
    |
    = note: keyword order for functions declaration is `pub`, `default`, `const`, `async`, `unsafe`, `extern`
+help: `const` must come before `async`
+   |
+LL - pub async const fn x() {}
+LL + pub const async fn x() {}
+   |
 
 error: functions cannot be both `const` and `async`
   --> $DIR/no-async-const.rs:4:5

--- a/tests/ui/async-await/no-unsafe-async.stderr
+++ b/tests/ui/async-await/no-unsafe-async.stderr
@@ -2,23 +2,27 @@ error: expected one of `extern` or `fn`, found keyword `async`
   --> $DIR/no-unsafe-async.rs:7:12
    |
 LL |     unsafe async fn g() {}
-   |     -------^^^^^
-   |     |      |
-   |     |      expected one of `extern` or `fn`
-   |     help: `async` must come before `unsafe`: `async unsafe`
+   |            ^^^^^ expected one of `extern` or `fn`
    |
    = note: keyword order for functions declaration is `pub`, `default`, `const`, `async`, `unsafe`, `extern`
+help: `async` must come before `unsafe`
+   |
+LL -     unsafe async fn g() {}
+LL +     async unsafe fn g() {}
+   |
 
 error: expected one of `extern` or `fn`, found keyword `async`
   --> $DIR/no-unsafe-async.rs:11:8
    |
 LL | unsafe async fn f() {}
-   | -------^^^^^
-   | |      |
-   | |      expected one of `extern` or `fn`
-   | help: `async` must come before `unsafe`: `async unsafe`
+   |        ^^^^^ expected one of `extern` or `fn`
    |
    = note: keyword order for functions declaration is `pub`, `default`, `const`, `async`, `unsafe`, `extern`
+help: `async` must come before `unsafe`
+   |
+LL - unsafe async fn f() {}
+LL + async unsafe fn f() {}
+   |
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/attributes/attr-bad-crate-attr.stderr
+++ b/tests/ui/attributes/attr-bad-crate-attr.stderr
@@ -2,7 +2,7 @@ error: expected item after attributes
   --> $DIR/attr-bad-crate-attr.rs:7:1
    |
 LL | #[attr = "val"] // Unterminated
-   | ^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^ expected an item after this
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/attribute/attr-before-eof.stderr
+++ b/tests/ui/parser/attribute/attr-before-eof.stderr
@@ -2,7 +2,7 @@ error: expected item after attributes
   --> $DIR/attr-before-eof.rs:3:1
    |
 LL | #[derive(Debug)]
-   | ^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^ expected an item after this
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/attribute/attr-dangling-in-mod.stderr
+++ b/tests/ui/parser/attribute/attr-dangling-in-mod.stderr
@@ -2,7 +2,7 @@ error: expected item after attributes
   --> $DIR/attr-dangling-in-mod.rs:4:1
    |
 LL | #[foo = "bar"]
-   | ^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^ expected an item after this
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/attribute/attr-with-a-semicolon.stderr
+++ b/tests/ui/parser/attribute/attr-with-a-semicolon.stderr
@@ -2,7 +2,13 @@ error: expected item after attributes
   --> $DIR/attr-with-a-semicolon.rs:1:1
    |
 LL | #[derive(Debug, Clone)];
-   | ^^^^^^^^^^^^^^^^^^^^^^^- help: consider removing this semicolon
+   | ^^^^^^^^^^^^^^^^^^^^^^^ expected an item after this
+   |
+help: remove the semicolon after the attribute
+   |
+LL - #[derive(Debug, Clone)];
+LL + #[derive(Debug, Clone)]
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/attribute/attr-with-a-semicolon.stderr
+++ b/tests/ui/parser/attribute/attr-with-a-semicolon.stderr
@@ -2,13 +2,7 @@ error: expected item after attributes
   --> $DIR/attr-with-a-semicolon.rs:1:1
    |
 LL | #[derive(Debug, Clone)];
-   | ^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: consider removing this semicolon
-   |
-LL - #[derive(Debug, Clone)];
-LL + #[derive(Debug, Clone)]
-   |
+   | ^^^^^^^^^^^^^^^^^^^^^^^- help: consider removing this semicolon
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/attribute/attrs-after-extern-mod.stderr
+++ b/tests/ui/parser/attribute/attrs-after-extern-mod.stderr
@@ -4,7 +4,7 @@ error: expected item after attributes
 LL | extern "C" {
    |            - while parsing this item list starting here
 LL |     #[cfg(stage37)]
-   |     ^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^ expected an item after this
 LL | }
    | - the item list ends here
 

--- a/tests/ui/parser/doc-before-attr.stderr
+++ b/tests/ui/parser/doc-before-attr.stderr
@@ -4,7 +4,7 @@ error: expected item after attributes
 LL | /// hi
    | ------ other attributes here
 LL | #[derive(Debug)]
-   | ^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^ expected an item after this
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/duplicate-visibility.stderr
+++ b/tests/ui/parser/duplicate-visibility.stderr
@@ -4,10 +4,7 @@ error: expected one of `(`, `async`, `const`, `default`, `extern`, `final`, `fn`
 LL | extern "C" {
    |            - while parsing this item list starting here
 LL |     pub pub fn foo();
-   |         ^^^
-   |         |
-   |         expected one of 10 possible tokens
-   |         help: there is already a visibility modifier, remove one
+   |         ^^^ expected one of 10 possible tokens
 ...
 LL | }
    | - the item list ends here
@@ -17,6 +14,11 @@ note: explicit visibility first seen here
    |
 LL |     pub pub fn foo();
    |     ^^^
+help: there is already a visibility modifier, remove one
+   |
+LL -     pub pub fn foo();
+LL +     pub  fn foo();
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/eq-less-to-less-eq.stderr
+++ b/tests/ui/parser/eq-less-to-less-eq.stderr
@@ -2,9 +2,13 @@ error: expected one of `!`, `(`, `+`, `::`, `<`, `>`, or `as`, found `{`
   --> $DIR/eq-less-to-less-eq.rs:4:15
    |
 LL |     if a =< b {
-   |          --   ^ expected one of 7 possible tokens
-   |          |
-   |          help: did you mean: `<=`
+   |               ^ expected one of 7 possible tokens
+   |
+help: did you mean
+   |
+LL -     if a =< b {
+LL +     if a <= b {
+   |
 
 error: expected one of `!`, `(`, `+`, `::`, `<`, `>`, or `as`, found `{`
   --> $DIR/eq-less-to-less-eq.rs:12:15

--- a/tests/ui/parser/eq-less-to-less-eq.stderr
+++ b/tests/ui/parser/eq-less-to-less-eq.stderr
@@ -4,7 +4,7 @@ error: expected one of `!`, `(`, `+`, `::`, `<`, `>`, or `as`, found `{`
 LL |     if a =< b {
    |               ^ expected one of 7 possible tokens
    |
-help: did you mean
+help: you might have meant to write a "less than or equal to" comparison
    |
 LL -     if a =< b {
 LL +     if a <= b {

--- a/tests/ui/parser/inverted-parameters.stderr
+++ b/tests/ui/parser/inverted-parameters.stderr
@@ -2,19 +2,25 @@ error: expected one of `:`, `@`, or `|`, found `bar`
   --> $DIR/inverted-parameters.rs:6:24
    |
 LL |     fn foo(&self, &str bar) {}
-   |                   -----^^^
-   |                   |    |
-   |                   |    expected one of `:`, `@`, or `|`
-   |                   help: declare the type after the parameter binding: `<identifier>: <type>`
+   |                        ^^^ expected one of `:`, `@`, or `|`
+   |
+help: declare the type after the parameter binding
+   |
+LL -     fn foo(&self, &str bar) {}
+LL +     fn foo(&self, <identifier>: <type>) {}
+   |
 
 error: expected one of `:`, `@`, or `|`, found `quux`
   --> $DIR/inverted-parameters.rs:12:10
    |
 LL | fn baz(S quux, xyzzy: i32) {}
-   |        --^^^^
-   |        | |
-   |        | expected one of `:`, `@`, or `|`
-   |        help: declare the type after the parameter binding: `<identifier>: <type>`
+   |          ^^^^ expected one of `:`, `@`, or `|`
+   |
+help: declare the type after the parameter binding
+   |
+LL - fn baz(S quux, xyzzy: i32) {}
+LL + fn baz(<identifier>: <type>, xyzzy: i32) {}
+   |
 
 error: expected one of `:`, `@`, or `|`, found `a`
   --> $DIR/inverted-parameters.rs:17:12
@@ -47,10 +53,13 @@ error: expected one of `:`, `@`, or `|`, found `S`
   --> $DIR/inverted-parameters.rs:28:23
    |
 LL | fn missing_colon(quux S) {}
-   |                  -----^
-   |                  |    |
-   |                  |    expected one of `:`, `@`, or `|`
-   |                  help: declare the type after the parameter binding: `<identifier>: <type>`
+   |                       ^ expected one of `:`, `@`, or `|`
+   |
+help: declare the type after the parameter binding
+   |
+LL - fn missing_colon(quux S) {}
+LL + fn missing_colon(<identifier>: <type>) {}
+   |
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/parser/issues/issue-113342.stderr
+++ b/tests/ui/parser/issues/issue-113342.stderr
@@ -2,10 +2,13 @@ error: expected `fn`, found keyword `pub`
   --> $DIR/issue-113342.rs:7:12
    |
 LL | extern "C" pub fn id(x: i32) -> i32 { x }
-   | -----------^^^
-   | |          |
-   | |          expected `fn`
-   | help: visibility `pub` must come before `extern "C"`: `pub extern "C"`
+   |            ^^^ expected `fn`
+   |
+help: visibility `pub` must come before `extern "C"`
+   |
+LL - extern "C" pub fn id(x: i32) -> i32 { x }
+LL + pub extern "C" fn id(x: i32) -> i32 { x }
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/issues/issue-19398.stderr
+++ b/tests/ui/parser/issues/issue-19398.stderr
@@ -2,12 +2,14 @@ error: expected `fn`, found keyword `unsafe`
   --> $DIR/issue-19398.rs:2:19
    |
 LL |     extern "Rust" unsafe fn foo();
-   |     --------------^^^^^^
-   |     |             |
-   |     |             expected `fn`
-   |     help: `unsafe` must come before `extern "Rust"`: `unsafe extern "Rust"`
+   |                   ^^^^^^ expected `fn`
    |
    = note: keyword order for functions declaration is `pub`, `default`, `const`, `async`, `unsafe`, `extern`
+help: `unsafe` must come before `extern "Rust"`
+   |
+LL -     extern "Rust" unsafe fn foo();
+LL +     unsafe extern "Rust" fn foo();
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/issues/issue-20711-2.stderr
+++ b/tests/ui/parser/issues/issue-20711-2.stderr
@@ -5,7 +5,7 @@ LL | impl Foo {
    |          - while parsing this item list starting here
 ...
 LL |     #[stable(feature = "rust1", since = "1.0.0")]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected an item after this
 LL |
 LL | }
    | - the item list ends here

--- a/tests/ui/parser/issues/issue-20711.stderr
+++ b/tests/ui/parser/issues/issue-20711.stderr
@@ -4,7 +4,7 @@ error: expected item after attributes
 LL | impl Foo {
    |          - while parsing this item list starting here
 LL |     #[stable(feature = "rust1", since = "1.0.0")]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected an item after this
 LL |
 LL | }
    | - the item list ends here

--- a/tests/ui/parser/issues/issue-76437-async.stderr
+++ b/tests/ui/parser/issues/issue-76437-async.stderr
@@ -2,10 +2,13 @@ error: expected one of `extern`, `fn`, `safe`, or `unsafe`, found keyword `pub`
   --> $DIR/issue-76437-async.rs:4:11
    |
 LL |     async pub fn t() {}
-   |     ------^^^
-   |     |     |
-   |     |     expected one of `extern`, `fn`, `safe`, or `unsafe`
-   |     help: visibility `pub` must come before `async`: `pub async`
+   |           ^^^ expected one of `extern`, `fn`, `safe`, or `unsafe`
+   |
+help: visibility `pub` must come before `async`
+   |
+LL -     async pub fn t() {}
+LL +     pub async fn t() {}
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/issues/issue-76437-const-async-unsafe.stderr
+++ b/tests/ui/parser/issues/issue-76437-const-async-unsafe.stderr
@@ -2,10 +2,13 @@ error: expected one of `extern` or `fn`, found keyword `pub`
   --> $DIR/issue-76437-const-async-unsafe.rs:4:24
    |
 LL |     const async unsafe pub fn t() {}
-   |     -------------------^^^
-   |     |                  |
-   |     |                  expected one of `extern` or `fn`
-   |     help: visibility `pub` must come before `const async unsafe`: `pub const async unsafe`
+   |                        ^^^ expected one of `extern` or `fn`
+   |
+help: visibility `pub` must come before `const async unsafe`
+   |
+LL -     const async unsafe pub fn t() {}
+LL +     pub const async unsafe fn t() {}
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/issues/issue-76437-const-async.stderr
+++ b/tests/ui/parser/issues/issue-76437-const-async.stderr
@@ -2,10 +2,13 @@ error: expected one of `extern`, `fn`, `safe`, or `unsafe`, found keyword `pub`
   --> $DIR/issue-76437-const-async.rs:4:17
    |
 LL |     const async pub fn t() {}
-   |     ------------^^^
-   |     |           |
-   |     |           expected one of `extern`, `fn`, `safe`, or `unsafe`
-   |     help: visibility `pub` must come before `const async`: `pub const async`
+   |                 ^^^ expected one of `extern`, `fn`, `safe`, or `unsafe`
+   |
+help: visibility `pub` must come before `const async`
+   |
+LL -     const async pub fn t() {}
+LL +     pub const async fn t() {}
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/issues/issue-76437-const.stderr
+++ b/tests/ui/parser/issues/issue-76437-const.stderr
@@ -2,10 +2,13 @@ error: expected one of `async`, `extern`, `fn`, `safe`, or `unsafe`, found keywo
   --> $DIR/issue-76437-const.rs:4:11
    |
 LL |     const pub fn t() {}
-   |     ------^^^
-   |     |     |
-   |     |     expected one of `async`, `extern`, `fn`, `safe`, or `unsafe`
-   |     help: visibility `pub` must come before `const`: `pub const`
+   |           ^^^ expected one of `async`, `extern`, `fn`, `safe`, or `unsafe`
+   |
+help: visibility `pub` must come before `const`
+   |
+LL -     const pub fn t() {}
+LL +     pub const fn t() {}
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/issues/issue-76437-pub-crate-unsafe.stderr
+++ b/tests/ui/parser/issues/issue-76437-pub-crate-unsafe.stderr
@@ -2,10 +2,13 @@ error: expected one of `extern` or `fn`, found keyword `pub`
   --> $DIR/issue-76437-pub-crate-unsafe.rs:4:12
    |
 LL |     unsafe pub(crate) fn t() {}
-   |     -------^^^-------
-   |     |      |
-   |     |      expected one of `extern` or `fn`
-   |     help: visibility `pub(crate)` must come before `unsafe`: `pub(crate) unsafe`
+   |            ^^^ expected one of `extern` or `fn`
+   |
+help: visibility `pub(crate)` must come before `unsafe`
+   |
+LL -     unsafe pub(crate) fn t() {}
+LL +     pub(crate) unsafe fn t() {}
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/issues/issue-76437-unsafe.stderr
+++ b/tests/ui/parser/issues/issue-76437-unsafe.stderr
@@ -2,10 +2,13 @@ error: expected one of `extern` or `fn`, found keyword `pub`
   --> $DIR/issue-76437-unsafe.rs:4:12
    |
 LL |     unsafe pub fn t() {}
-   |     -------^^^
-   |     |      |
-   |     |      expected one of `extern` or `fn`
-   |     help: visibility `pub` must come before `unsafe`: `pub unsafe`
+   |            ^^^ expected one of `extern` or `fn`
+   |
+help: visibility `pub` must come before `unsafe`
+   |
+LL -     unsafe pub fn t() {}
+LL +     pub unsafe fn t() {}
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/issues/issue-87217-keyword-order/const-async-const.stderr
+++ b/tests/ui/parser/issues/issue-87217-keyword-order/const-async-const.stderr
@@ -2,16 +2,18 @@ error: expected one of `extern`, `fn`, `safe`, or `unsafe`, found keyword `const
   --> $DIR/const-async-const.rs:5:13
    |
 LL | const async const fn test() {}
-   |             ^^^^^
-   |             |
-   |             expected one of `extern`, `fn`, `safe`, or `unsafe`
-   |             help: `const` already used earlier, remove this one
+   |             ^^^^^ expected one of `extern`, `fn`, `safe`, or `unsafe`
    |
 note: `const` first seen here
   --> $DIR/const-async-const.rs:5:1
    |
 LL | const async const fn test() {}
    | ^^^^^
+help: `const` already used earlier, remove this one
+   |
+LL - const async const fn test() {}
+LL + const async  fn test() {}
+   |
 
 error: functions cannot be both `const` and `async`
   --> $DIR/const-async-const.rs:5:1

--- a/tests/ui/parser/issues/issue-87217-keyword-order/recovery.stderr
+++ b/tests/ui/parser/issues/issue-87217-keyword-order/recovery.stderr
@@ -2,27 +2,31 @@ error: expected one of `extern` or `fn`, found keyword `const`
   --> $DIR/recovery.rs:6:12
    |
 LL |     unsafe const fn from_u32(val: u32) {}
-   |     -------^^^^^
-   |     |      |
-   |     |      expected one of `extern` or `fn`
-   |     help: `const` must come before `unsafe`: `const unsafe`
+   |            ^^^^^ expected one of `extern` or `fn`
    |
    = note: keyword order for functions declaration is `pub`, `default`, `const`, `async`, `unsafe`, `extern`
+help: `const` must come before `unsafe`
+   |
+LL -     unsafe const fn from_u32(val: u32) {}
+LL +     const unsafe fn from_u32(val: u32) {}
+   |
 
 error: expected one of `extern` or `fn`, found keyword `unsafe`
   --> $DIR/recovery.rs:14:12
    |
 LL |     unsafe unsafe fn from_u32(val: u32) {}
-   |            ^^^^^^
-   |            |
-   |            expected one of `extern` or `fn`
-   |            help: `unsafe` already used earlier, remove this one
+   |            ^^^^^^ expected one of `extern` or `fn`
    |
 note: `unsafe` first seen here
   --> $DIR/recovery.rs:14:5
    |
 LL |     unsafe unsafe fn from_u32(val: u32) {}
    |     ^^^^^^
+help: `unsafe` already used earlier, remove this one
+   |
+LL -     unsafe unsafe fn from_u32(val: u32) {}
+LL +     unsafe  fn from_u32(val: u32) {}
+   |
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/parser/issues/issue-87217-keyword-order/several-kw-jump.stderr
+++ b/tests/ui/parser/issues/issue-87217-keyword-order/several-kw-jump.stderr
@@ -2,12 +2,14 @@ error: expected one of `extern` or `fn`, found keyword `const`
   --> $DIR/several-kw-jump.rs:9:14
    |
 LL | async unsafe const fn test() {}
-   | -------------^^^^^
-   | |            |
-   | |            expected one of `extern` or `fn`
-   | help: `const` must come before `async unsafe`: `const async unsafe`
+   |              ^^^^^ expected one of `extern` or `fn`
    |
    = note: keyword order for functions declaration is `pub`, `default`, `const`, `async`, `unsafe`, `extern`
+help: `const` must come before `async unsafe`
+   |
+LL - async unsafe const fn test() {}
+LL + const async unsafe fn test() {}
+   |
 
 error: functions cannot be both `const` and `async`
   --> $DIR/several-kw-jump.rs:9:1

--- a/tests/ui/parser/issues/issue-87217-keyword-order/wrong-async.stderr
+++ b/tests/ui/parser/issues/issue-87217-keyword-order/wrong-async.stderr
@@ -2,12 +2,14 @@ error: expected one of `extern` or `fn`, found keyword `async`
   --> $DIR/wrong-async.rs:9:8
    |
 LL | unsafe async fn test() {}
-   | -------^^^^^
-   | |      |
-   | |      expected one of `extern` or `fn`
-   | help: `async` must come before `unsafe`: `async unsafe`
+   |        ^^^^^ expected one of `extern` or `fn`
    |
    = note: keyword order for functions declaration is `pub`, `default`, `const`, `async`, `unsafe`, `extern`
+help: `async` must come before `unsafe`
+   |
+LL - unsafe async fn test() {}
+LL + async unsafe fn test() {}
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/issues/issue-87217-keyword-order/wrong-const.stderr
+++ b/tests/ui/parser/issues/issue-87217-keyword-order/wrong-const.stderr
@@ -2,12 +2,14 @@ error: expected one of `extern` or `fn`, found keyword `const`
   --> $DIR/wrong-const.rs:9:8
    |
 LL | unsafe const fn test() {}
-   | -------^^^^^
-   | |      |
-   | |      expected one of `extern` or `fn`
-   | help: `const` must come before `unsafe`: `const unsafe`
+   |        ^^^^^ expected one of `extern` or `fn`
    |
    = note: keyword order for functions declaration is `pub`, `default`, `const`, `async`, `unsafe`, `extern`
+help: `const` must come before `unsafe`
+   |
+LL - unsafe const fn test() {}
+LL + const unsafe fn test() {}
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/issues/issue-87217-keyword-order/wrong-unsafe-abi.stderr
+++ b/tests/ui/parser/issues/issue-87217-keyword-order/wrong-unsafe-abi.stderr
@@ -2,12 +2,14 @@ error: expected `fn`, found keyword `unsafe`
   --> $DIR/wrong-unsafe-abi.rs:9:12
    |
 LL | extern "C" unsafe fn test() {}
-   | -----------^^^^^^
-   | |          |
-   | |          expected `fn`
-   | help: `unsafe` must come before `extern "C"`: `unsafe extern "C"`
+   |            ^^^^^^ expected `fn`
    |
    = note: keyword order for functions declaration is `pub`, `default`, `const`, `async`, `unsafe`, `extern`
+help: `unsafe` must come before `extern "C"`
+   |
+LL - extern "C" unsafe fn test() {}
+LL + unsafe extern "C" fn test() {}
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/issues/issue-87217-keyword-order/wrong-unsafe.stderr
+++ b/tests/ui/parser/issues/issue-87217-keyword-order/wrong-unsafe.stderr
@@ -2,12 +2,14 @@ error: expected `fn`, found keyword `unsafe`
   --> $DIR/wrong-unsafe.rs:10:8
    |
 LL | extern unsafe fn test() {}
-   | -------^^^^^^
-   | |      |
-   | |      expected `fn`
-   | help: `unsafe` must come before `extern`: `unsafe extern`
+   |        ^^^^^^ expected `fn`
    |
    = note: keyword order for functions declaration is `pub`, `default`, `const`, `async`, `unsafe`, `extern`
+help: `unsafe` must come before `extern`
+   |
+LL - extern unsafe fn test() {}
+LL + unsafe extern fn test() {}
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/issues/issue-87694-duplicated-pub.stderr
+++ b/tests/ui/parser/issues/issue-87694-duplicated-pub.stderr
@@ -2,16 +2,18 @@ error: expected one of `async`, `extern`, `fn`, `safe`, or `unsafe`, found keywo
   --> $DIR/issue-87694-duplicated-pub.rs:1:11
    |
 LL | pub const pub fn test() {}
-   |           ^^^
-   |           |
-   |           expected one of `async`, `extern`, `fn`, `safe`, or `unsafe`
-   |           help: there is already a visibility modifier, remove one
+   |           ^^^ expected one of `async`, `extern`, `fn`, `safe`, or `unsafe`
    |
 note: explicit visibility first seen here
   --> $DIR/issue-87694-duplicated-pub.rs:1:1
    |
 LL | pub const pub fn test() {}
    | ^^^
+help: there is already a visibility modifier, remove one
+   |
+LL - pub const pub fn test() {}
+LL + pub const  fn test() {}
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/issues/issue-87694-misplaced-pub.stderr
+++ b/tests/ui/parser/issues/issue-87694-misplaced-pub.stderr
@@ -2,10 +2,13 @@ error: expected one of `async`, `extern`, `fn`, `safe`, or `unsafe`, found keywo
   --> $DIR/issue-87694-misplaced-pub.rs:1:7
    |
 LL | const pub fn test() {}
-   | ------^^^
-   | |     |
-   | |     expected one of `async`, `extern`, `fn`, `safe`, or `unsafe`
-   | help: visibility `pub` must come before `const`: `pub const`
+   |       ^^^ expected one of `async`, `extern`, `fn`, `safe`, or `unsafe`
+   |
+help: visibility `pub` must come before `const`
+   |
+LL - const pub fn test() {}
+LL + pub const fn test() {}
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/issues/issue-89396.stderr
+++ b/tests/ui/parser/issues/issue-89396.stderr
@@ -2,19 +2,24 @@ error: expected one of `=>`, `if`, or `|`, found `=`
   --> $DIR/issue-89396.rs:9:17
    |
 LL |         Some(_) = true,
-   |                 ^
-   |                 |
-   |                 expected one of `=>`, `if`, or `|`
-   |                 help: use a fat arrow to start a match arm: `=>`
+   |                 ^ expected one of `=>`, `if`, or `|`
+   |
+help: use a fat arrow to start a match arm
+   |
+LL |         Some(_) => true,
+   |                  +
 
 error: expected one of `=>`, `@`, `if`, or `|`, found `->`
   --> $DIR/issue-89396.rs:12:14
    |
 LL |         None -> false,
-   |              ^^
-   |              |
-   |              expected one of `=>`, `@`, `if`, or `|`
-   |              help: use a fat arrow to start a match arm: `=>`
+   |              ^^ expected one of `=>`, `@`, `if`, or `|`
+   |
+help: use a fat arrow to start a match arm
+   |
+LL -         None -> false,
+LL +         None => false,
+   |
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/parser/issues/recover-ge-as-fat-arrow.stderr
+++ b/tests/ui/parser/issues/recover-ge-as-fat-arrow.stderr
@@ -2,10 +2,13 @@ error: expected one of `...`, `..=`, `..`, `=>`, `if`, or `|`, found `>=`
   --> $DIR/recover-ge-as-fat-arrow.rs:4:11
    |
 LL |         1 >= {}
-   |           ^^
-   |           |
-   |           expected one of `...`, `..=`, `..`, `=>`, `if`, or `|`
-   |           help: use a fat arrow to start a match arm: `=>`
+   |           ^^ expected one of `...`, `..=`, `..`, `=>`, `if`, or `|`
+   |
+help: use a fat arrow to start a match arm
+   |
+LL -         1 >= {}
+LL +         1 => {}
+   |
 
 error[E0308]: mismatched types
   --> $DIR/recover-ge-as-fat-arrow.rs:5:29

--- a/tests/ui/parser/macro/kw-in-item-pos-recovery-151238.stderr
+++ b/tests/ui/parser/macro/kw-in-item-pos-recovery-151238.stderr
@@ -8,10 +8,13 @@ error: expected one of `:`, `@`, or `|`, found keyword `self`
   --> $DIR/kw-in-item-pos-recovery-151238.rs:7:28
    |
 LL |   trait MyTrait { fn bar(c self) }
-   |                          --^^^^
-   |                          | |
-   |                          | expected one of `:`, `@`, or `|`
-   |                          help: declare the type after the parameter binding: `<identifier>: <type>`
+   |                            ^^^^ expected one of `:`, `@`, or `|`
+   |
+help: declare the type after the parameter binding
+   |
+LL -   trait MyTrait { fn bar(c self) }
+LL +   trait MyTrait { fn bar(<identifier>: <type>) }
+   |
 
 error: expected one of `->`, `;`, `where`, or `{`, found `}`
   --> $DIR/kw-in-item-pos-recovery-151238.rs:7:34

--- a/tests/ui/parser/macro/misspelled-macro-rules.stderr
+++ b/tests/ui/parser/macro/misspelled-macro-rules.stderr
@@ -2,9 +2,13 @@ error: expected one of `(`, `[`, or `{`, found `thing`
   --> $DIR/misspelled-macro-rules.rs:7:14
    |
 LL | marco_rules! thing {
-   | -----------  ^^^^^ expected one of `(`, `[`, or `{`
-   | |
-   | help: perhaps you meant to define a macro: `macro_rules`
+   |              ^^^^^ expected one of `(`, `[`, or `{`
+   |
+help: perhaps you meant to define a macro
+   |
+LL - marco_rules! thing {
+LL + macro_rules! thing {
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/range-exclusive-dotdotlt.stderr
+++ b/tests/ui/parser/range-exclusive-dotdotlt.stderr
@@ -2,17 +2,25 @@ error: expected type, found `10`
   --> $DIR/range-exclusive-dotdotlt.rs:2:17
    |
 LL |     let _ = 0..<10;
-   |                -^^ expected type
-   |                |
-   |                help: remove the `<` to write an exclusive range
+   |                 ^^ expected type
+   |
+help: remove the `<` to write an exclusive range
+   |
+LL -     let _ = 0..<10;
+LL +     let _ = 0..10;
+   |
 
 error: expected one of `!`, `(`, `+`, `::`, `<`, `>`, or `as`, found `;`
   --> $DIR/range-exclusive-dotdotlt.rs:8:20
    |
 LL |     let _ = 0..<foo;
-   |                -   ^ expected one of 7 possible tokens
-   |                |
-   |                help: remove the `<` to write an exclusive range
+   |                    ^ expected one of 7 possible tokens
+   |
+help: remove the `<` to write an exclusive range
+   |
+LL -     let _ = 0..<foo;
+LL +     let _ = 0..foo;
+   |
 
 error: expected `::`, found `;`
   --> $DIR/range-exclusive-dotdotlt.rs:14:18
@@ -24,17 +32,25 @@ error: expected type, found `1`
   --> $DIR/range-exclusive-dotdotlt.rs:19:26
    |
 LL |     let _ = [1, 2, 3][..<1];
-   |                         -^ expected type
-   |                         |
-   |                         help: remove the `<` to write an exclusive range
+   |                          ^ expected type
+   |
+help: remove the `<` to write an exclusive range
+   |
+LL -     let _ = [1, 2, 3][..<1];
+LL +     let _ = [1, 2, 3][..1];
+   |
 
 error: expected one of `!`, `(`, `+`, `::`, `<`, `>`, or `as`, found `]`
   --> $DIR/range-exclusive-dotdotlt.rs:25:29
    |
 LL |     let _ = [1, 2, 3][..<foo];
-   |                         -   ^ expected one of 7 possible tokens
-   |                         |
-   |                         help: remove the `<` to write an exclusive range
+   |                             ^ expected one of 7 possible tokens
+   |
+help: remove the `<` to write an exclusive range
+   |
+LL -     let _ = [1, 2, 3][..<foo];
+LL +     let _ = [1, 2, 3][..foo];
+   |
 
 error: expected `::`, found `]`
   --> $DIR/range-exclusive-dotdotlt.rs:31:30

--- a/tests/ui/parser/raw/raw-byte-string-eof.stderr
+++ b/tests/ui/parser/raw/raw-byte-string-eof.stderr
@@ -2,11 +2,13 @@ error[E0748]: unterminated raw string
   --> $DIR/raw-byte-string-eof.rs:2:5
    |
 LL |     br##"a"#;
-   |     ^      - help: consider terminating the string here: `##`
-   |     |
-   |     unterminated raw string
+   |     ^ unterminated raw string
    |
    = note: this raw string should be terminated with `"##`
+help: consider terminating the string here
+   |
+LL |     br##"a"##;
+   |             +
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/raw/raw-str-unbalanced.stderr
+++ b/tests/ui/parser/raw/raw-str-unbalanced.stderr
@@ -2,18 +2,30 @@ error: too many `#` when terminating raw string
   --> $DIR/raw-str-unbalanced.rs:2:10
    |
 LL |     r#""##
-   |     -----^ help: remove the extra `#`
+   |     -----^
    |     |
    |     this raw string started with 1 `#`
+   |
+help: remove the extra `#`
+   |
+LL -     r#""##
+LL +     r#""#
+   |
 
 error: too many `#` when terminating raw string
   --> $DIR/raw-str-unbalanced.rs:7:9
    |
 LL | /     r#"
 LL | |       "####
-   | |        -^^^ help: remove the extra `#`s
+   | |        -^^^
    | |________|
    |          this raw string started with 1 `#`
+   |
+help: remove the extra `#`s
+   |
+LL -       "####
+LL +       "#
+   |
 
 error: expected `;`, found `#`
   --> $DIR/raw-str-unbalanced.rs:10:28
@@ -28,9 +40,15 @@ error: too many `#` when terminating raw string
   --> $DIR/raw-str-unbalanced.rs:16:28
    |
 LL | const B: &'static str = r""##
-   |                         ---^^ help: remove the extra `#`s
+   |                         ---^^
    |                         |
    |                         this raw string started with 0 `#`s
+   |
+help: remove the extra `#`s
+   |
+LL - const B: &'static str = r""##
+LL + const B: &'static str = r""
+   |
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/parser/raw/raw-string-2.stderr
+++ b/tests/ui/parser/raw/raw-string-2.stderr
@@ -2,9 +2,13 @@ error[E0748]: unterminated raw string
   --> $DIR/raw-string-2.rs:2:13
    |
 LL |     let x = r###"here's a long string"# "# "##;
-   |             ^ unterminated raw string       -- help: consider terminating the string here: `###`
+   |             ^ unterminated raw string
    |
    = note: this raw string should be terminated with `"###`
+help: consider terminating the string here
+   |
+LL |     let x = r###"here's a long string"# "# "###;
+   |                                               +
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/raw/raw-string.stderr
+++ b/tests/ui/parser/raw/raw-string.stderr
@@ -2,11 +2,13 @@ error[E0748]: unterminated raw string
   --> $DIR/raw-string.rs:2:13
    |
 LL |     let x = r##"lol"#;
-   |             ^       - help: consider terminating the string here: `##`
-   |             |
-   |             unterminated raw string
+   |             ^ unterminated raw string
    |
    = note: this raw string should be terminated with `"##`
+help: consider terminating the string here
+   |
+LL |     let x = r##"lol"##;
+   |                      +
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/removed-syntax/removed-syntax-field-let-2.stderr
+++ b/tests/ui/parser/removed-syntax/removed-syntax-field-let-2.stderr
@@ -2,25 +2,29 @@ error: expected identifier, found keyword `let`
   --> $DIR/removed-syntax-field-let-2.rs:2:5
    |
 LL |     let x: i32,
-   |     ^^^-
-   |     |
-   |     expected identifier, found keyword
-   |     help: remove this `let` keyword
+   |     ^^^ expected identifier, found keyword
    |
    = note: the `let` keyword is not allowed in `struct` fields
    = note: see <https://doc.rust-lang.org/book/ch05-01-defining-structs.html> for more information
+help: remove this `let` keyword
+   |
+LL -     let x: i32,
+LL +     x: i32,
+   |
 
 error: expected identifier, found keyword `let`
   --> $DIR/removed-syntax-field-let-2.rs:4:5
    |
 LL |     let y: i32,
-   |     ^^^-
-   |     |
-   |     expected identifier, found keyword
-   |     help: remove this `let` keyword
+   |     ^^^ expected identifier, found keyword
    |
    = note: the `let` keyword is not allowed in `struct` fields
    = note: see <https://doc.rust-lang.org/book/ch05-01-defining-structs.html> for more information
+help: remove this `let` keyword
+   |
+LL -     let y: i32,
+LL +     y: i32,
+   |
 
 error[E0063]: missing fields `x` and `y` in initializer of `Foo`
   --> $DIR/removed-syntax-field-let-2.rs:9:13

--- a/tests/ui/parser/removed-syntax/removed-syntax-field-let-2.stderr
+++ b/tests/ui/parser/removed-syntax/removed-syntax-field-let-2.stderr
@@ -6,7 +6,7 @@ LL |     let x: i32,
    |
    = note: the `let` keyword is not allowed in `struct` fields
    = note: see <https://doc.rust-lang.org/book/ch05-01-defining-structs.html> for more information
-help: remove this `let` keyword
+help: remove the `let` keyword
    |
 LL -     let x: i32,
 LL +     x: i32,
@@ -20,7 +20,7 @@ LL |     let y: i32,
    |
    = note: the `let` keyword is not allowed in `struct` fields
    = note: see <https://doc.rust-lang.org/book/ch05-01-defining-structs.html> for more information
-help: remove this `let` keyword
+help: remove the `let` keyword
    |
 LL -     let y: i32,
 LL +     y: i32,

--- a/tests/ui/parser/removed-syntax/removed-syntax-field-let.stderr
+++ b/tests/ui/parser/removed-syntax/removed-syntax-field-let.stderr
@@ -2,13 +2,15 @@ error: expected identifier, found keyword `let`
   --> $DIR/removed-syntax-field-let.rs:2:5
    |
 LL |     let foo: (),
-   |     ^^^-
-   |     |
-   |     expected identifier, found keyword
-   |     help: remove this `let` keyword
+   |     ^^^ expected identifier, found keyword
    |
    = note: the `let` keyword is not allowed in `struct` fields
    = note: see <https://doc.rust-lang.org/book/ch05-01-defining-structs.html> for more information
+help: remove this `let` keyword
+   |
+LL -     let foo: (),
+LL +     foo: (),
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/removed-syntax/removed-syntax-field-let.stderr
+++ b/tests/ui/parser/removed-syntax/removed-syntax-field-let.stderr
@@ -6,7 +6,7 @@ LL |     let foo: (),
    |
    = note: the `let` keyword is not allowed in `struct` fields
    = note: see <https://doc.rust-lang.org/book/ch05-01-defining-structs.html> for more information
-help: remove this `let` keyword
+help: remove the `let` keyword
    |
 LL -     let foo: (),
 LL +     foo: (),

--- a/tests/ui/suggestions/suggest-add-self-issue-131084.stderr
+++ b/tests/ui/suggestions/suggest-add-self-issue-131084.stderr
@@ -41,10 +41,13 @@ error: expected one of `:`, `@`, or `|`, found `s`
   --> $DIR/suggest-add-self-issue-131084.rs:21:32
    |
 LL |     fn type_before_name(String s) {
-   |                         -------^
-   |                         |      |
-   |                         |      expected one of `:`, `@`, or `|`
-   |                         help: declare the type after the parameter binding: `<identifier>: <type>`
+   |                                ^ expected one of `:`, `@`, or `|`
+   |
+help: declare the type after the parameter binding
+   |
+LL -     fn type_before_name(String s) {
+LL +     fn type_before_name(<identifier>: <type>) {
+   |
 
 error[E0424]: expected value, found module `self`
   --> $DIR/suggest-add-self-issue-131084.rs:11:9

--- a/tests/ui/traits/const-traits/ice-120503-async-const-method.stderr
+++ b/tests/ui/traits/const-traits/ice-120503-async-const-method.stderr
@@ -2,12 +2,14 @@ error: expected one of `extern`, `fn`, `safe`, or `unsafe`, found keyword `const
   --> $DIR/ice-120503-async-const-method.rs:6:11
    |
 LL |     async const fn bar(&self) {
-   |     ------^^^^^
-   |     |     |
-   |     |     expected one of `extern`, `fn`, `safe`, or `unsafe`
-   |     help: `const` must come before `async`: `const async`
+   |           ^^^^^ expected one of `extern`, `fn`, `safe`, or `unsafe`
    |
    = note: keyword order for functions declaration is `pub`, `default`, `const`, `async`, `unsafe`, `extern`
+help: `const` must come before `async`
+   |
+LL -     async const fn bar(&self) {
+LL +     const async fn bar(&self) {
+   |
 
 error[E0379]: functions in trait impls cannot be declared const
   --> $DIR/ice-120503-async-const-method.rs:6:11


### PR DESCRIPTION
Replace most of the `.span_suggestion(` in `rustc_parse` with `.span_suggestion_verbose(`, as they are more readabale, if more verbose. Verbose suggestions also tend to highlight off-by-one `Span` errors better.

Tweak some of the touched diagnostics to bring them more in-line with our house style.

CC https://github.com/rust-lang/rust/issues/141973