### PR TITLE
bootstrap: forward -fdebug-prefix-map when using cc

### DIFF
--- a/src/bootstrap/src/lib.rs
+++ b/src/bootstrap/src/lib.rs
@@ -1322,10 +1322,10 @@ impl Build {
 
         if let Some(map_to) = self.debuginfo_map_to(which, RemapScheme::NonCompiler) {
             let map = format!("{}={}", self.src.display(), map_to);
-            let cc = self.cc(target);
-            if cc.ends_with("clang") || cc.ends_with("gcc") {
+            let cc = self.cc_tool(target);
+            if cc.is_like_clang() || cc.is_like_gnu() {
                 base.push(format!("-fdebug-prefix-map={map}"));
-            } else if cc.ends_with("clang-cl.exe") {
+            } else if cc.is_like_clang_cl() {
                 base.push("-Xclang".into());
                 base.push(format!("-fdebug-prefix-map={map}"));
             }


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

the existing `clang/gcc` checks don't match on systems where `self.cc(target)` resolves to `cc`, so `-fdebug-prefix-map` isn't forwarded to the `C` compiler.

this leaves local checkout paths in `compiler-builtins DWARF`.
recognize cc as well so the remapping flag is forwarded. confirmed `remap-path-prefix-std passes`, and inspecting the generated `DWARF` to verify that checkout paths are remapped.

r? @Urgau 
cc @bjorn3 