### PR TITLE
rustdoc: Set tracing max_level_info when debug-logging is false

### DIFF
--- a/src/bootstrap/src/core/build_steps/tool.rs
+++ b/src/bootstrap/src/core/build_steps/tool.rs
@@ -767,6 +767,9 @@ impl Step for Rustdoc {
         if builder.config.jemalloc(target) {
             extra_features.push("jemalloc".to_string());
         }
+        if !builder.config.rust_debug_logging {
+            extra_features.push("max_level_info".to_string())
+        }
 
         let compilers = RustcPrivateCompilers::from_target_compiler(builder, target_compiler);
         let tool_path = builder

--- a/src/librustdoc/Cargo.toml
+++ b/src/librustdoc/Cargo.toml
@@ -44,6 +44,7 @@ expect-test = "1.4.0"
 
 [features]
 jemalloc = []
+max_level_info = ["tracing/max_level_info", "tracing/release_max_level_info"]
 
 [package.metadata.rust-analyzer]
 rustc_private = true

--- a/src/tools/rustdoc/Cargo.toml
+++ b/src/tools/rustdoc/Cargo.toml
@@ -15,3 +15,4 @@ rustdoc = { path = "../../librustdoc" }
 
 [features]
 jemalloc = ['rustdoc/jemalloc']
+max_level_info = ["rustdoc/max_level_info"]


### PR DESCRIPTION
This matches rustc and should improve performance for the published versions of rustdoc. We shouldn't be including all our `debug!` calls in builds for users.