### PR TITLE
proc_macro: Fix cfg_attr inner attrs in file modules

### DIFF
--- a/compiler/rustc_parse/src/lib.rs
+++ b/compiler/rustc_parse/src/lib.rs
@@ -349,13 +349,13 @@ fn lex_token_trees_for_span(
     span: Span,
 ) -> Option<impl Iterator<Item = TokenTree>> {
     let src = psess.source_map().span_to_snippet(span).ok()?;
-    let stream = unwrap_or_emit_fatal(lexer::lex_token_trees(
-        psess,
-        &src,
-        span.lo(),
-        None,
-        StripTokens::Nothing,
-    ));
+    let stream = match lexer::lex_token_trees(psess, &src, span.lo(), None, StripTokens::Nothing) {
+        Ok(stream) => stream,
+        Err(errs) => {
+            errs.into_iter().for_each(|err| err.cancel());
+            return None;
+        }
+    };
     Some((0..).map_while(move |index| stream.get(index).cloned()))
 }
 

--- a/tests/ui/proc-macro/auxiliary/inner_attr_file_mod_cfg_attr_child.rs
+++ b/tests/ui/proc-macro/auxiliary/inner_attr_file_mod_cfg_attr_child.rs
@@ -1,0 +1,8 @@
+#![cfg_attr(enabled, test_macros::identity_attr, allow(dead_code))]
+#![cfg_attr(enabled, allow(unused_imports), test_macros::identity_attr)]
+#![cfg_attr(enabled, test_macros::identity_attr)]
+//! docs
+
+use std::fmt;
+
+fn unused() {}

--- a/tests/ui/proc-macro/inner-attr-file-mod-cfg-attr.rs
+++ b/tests/ui/proc-macro/inner-attr-file-mod-cfg-attr.rs
@@ -1,0 +1,14 @@
+//@ check-pass
+//@ proc-macro: test-macros.rs
+//@ edition:2024
+//@ compile-flags: --cfg enabled --check-cfg=cfg(enabled)
+
+#![feature(custom_inner_attributes)]
+#![deny(dead_code, unused_attributes, unused_imports)]
+
+extern crate test_macros;
+
+#[path = "auxiliary/inner_attr_file_mod_cfg_attr_child.rs"]
+mod child;
+
+fn main() {}


### PR DESCRIPTION
Fixes rust-lang/rust#159648

Inner proc-macro attrs produced by `cfg_attr` only carry the nested attr span. Splitting source around that span tries to lex two unmatched halves, so file modules fail with an unclosed delimiter.

Lex the complete module body first, then remove the expanded attr from its nested token stream. Sibling attrs stay in place, and empty `cfg_attr` wrappers use their trace span and disappear. imo this is cleaner than teaching source slicing about every nested shape.

Tests exercise sibling attrs on either side of the proc macro, then cover the single-attr case. fyi, denied lints make sibling preservation observable; ltm if another nested case should live here.
