### PR TITLE
bump std libc to 0.2.189

### DIFF
--- a/library/Cargo.lock
+++ b/library/Cargo.lock
@@ -146,9 +146,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 dependencies = [
  "rustc-std-workspace-core",
 ]

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -33,7 +33,7 @@ miniz_oxide = { version = "0.9.0", optional = true, default-features = false }
 addr2line = { version = "0.27.0", optional = true, default-features = false }
 
 [target.'cfg(not(all(windows, target_env = "msvc")))'.dependencies]
-libc = { version = "0.2.185", default-features = false, features = [
+libc = { version = "0.2.189", default-features = false, features = [
     'rustc-dep-of-std',
 ], public = true }
 


### PR DESCRIPTION
Upgrade the std libc version to the latest `v0.2.189` from `v0.2.185`.

There are too many changes between `v0.2.186` and `v0.2.187`, I'm not sure if `libc`'s update strategy is one version at a time, or if it allows upgrading multiple versions at once.
I now need to resolve the CI failure caused by `libc::SO_KEEPALIVE` in the `socket2` crate for https://github.com/rust-lang/socket2/pull/666

``` hide
running `cargo check -Z build-std=std,panic_abort --target thumbv8m.main-nuttx-eabihf --no-default-features` on socket2 (1/2)
      Updating crates.io index
       Locking 3 packages to latest compatible versions
   Downloading crates ...
    Downloaded libc v0.2.189
      Updating crates.io index
   Downloading crates ...
    Downloaded addr2line v0.27.0
    Downloaded foldhash v0.2.0
    Downloaded getopts v0.2.24
    Downloaded cfg-if v1.0.4
    Downloaded memchr v2.7.6
    Downloaded rustc-literal-escaper v0.0.8
    Downloaded object v0.39.1
    Downloaded rustc-demangle v0.1.28
    Downloaded libc v0.2.185
    Downloaded adler2 v2.0.1
    Downloaded gimli v0.34.0
    Downloaded hashbrown v0.17.1
    Downloaded miniz_oxide v0.9.1
     Compiling compiler_builtins v0.1.160 (/home/runner/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/compiler-builtins/compiler-builtins)
     Compiling core v0.0.0 (/home/runner/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core)
     Compiling libc v0.2.185
     Compiling object v0.39.1
     Compiling std v0.0.0 (/home/runner/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std)
     Compiling libc v0.2.189
     Compiling rustc-std-workspace-core v1.99.0 (/home/runner/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/rustc-std-workspace-core)
     Compiling alloc v0.0.0 (/home/runner/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc)
     Compiling adler2 v2.0.1
     Compiling memchr v2.7.6
     Compiling unwind v0.0.0 (/home/runner/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/unwind)
     Compiling cfg-if v1.0.4
     Compiling rustc-demangle v0.1.28
     Compiling panic_abort v0.0.0 (/home/runner/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/panic_abort)
     Compiling rustc-literal-escaper v0.0.8
     Compiling rustc-std-workspace-alloc v1.99.0 (/home/runner/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/rustc-std-workspace-alloc)
     Compiling panic_unwind v0.0.0 (/home/runner/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/panic_unwind)
     Compiling gimli v0.34.0
     Compiling hashbrown v0.17.1
     Compiling miniz_oxide v0.9.1
     Compiling std_detect v0.1.5 (/home/runner/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std_detect)
     Compiling addr2line v0.27.0
  error[E0425]: cannot find value `SO_KEEPALIVE` in crate `libc`
     --> /home/runner/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/sys/net/connection/socket/unix.rs:462:59
      |
  462 |         unsafe { setsockopt(self, libc::SOL_SOCKET, libc::SO_KEEPALIVE, keepalive as c_int) }
      |                                                           ^^^^^^^^^^^^ not found in `libc`
  
  error[E0425]: cannot find value `SO_KEEPALIVE` in crate `libc`
     --> /home/runner/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/sys/net/connection/socket/unix.rs:466:76
      |
  466 |         let raw: c_int = unsafe { getsockopt(self, libc::SOL_SOCKET, libc::SO_KEEPALIVE)? };
      |                                                                            ^^^^^^^^^^^^ not found in `libc`
  
```


