### PR TITLE
Split non-local `semicolon_in_expressions_from_macros` into a separate lint

### DIFF
--- a/compiler/rustc_expand/src/base.rs
+++ b/compiler/rustc_expand/src/base.rs
@@ -277,7 +277,10 @@ impl<'cx> MacroExpanderResult<'cx> {
         arm_span: Span,
         macro_ident: Ident,
     ) -> Self {
-        let parser = ParserAnyMacro::from_tts(cx, tts, site_span, arm_span, macro_ident, &[], &[]);
+        // Emit SEMICOLON_IN_EXPRESSIONS_FROM_MACROS here, rather than the NON_LOCAL version.
+        let is_local = true;
+        let parser =
+            ParserAnyMacro::from_tts(cx, tts, site_span, arm_span, is_local, macro_ident, &[], &[]);
         ExpandResult::Ready(Box::new(parser))
     }
 }

--- a/compiler/rustc_expand/src/mbe/macro_rules.rs
+++ b/compiler/rustc_expand/src/mbe/macro_rules.rs
@@ -19,6 +19,7 @@ use rustc_hir::def::MacroKinds;
 use rustc_hir::find_attr;
 use rustc_lint_defs::builtin::{
     RUST_2021_INCOMPATIBLE_OR_PATTERNS, SEMICOLON_IN_EXPRESSIONS_FROM_MACROS,
+    SEMICOLON_IN_EXPRESSIONS_FROM_NON_LOCAL_MACROS,
 };
 use rustc_parse::exp;
 use rustc_parse::parser::{Parser, Recovery};
@@ -55,6 +56,8 @@ pub(crate) struct ParserAnyMacro<'a, 'b> {
     lint_node_id: NodeId,
     is_trailing_mac: bool,
     arm_span: Span,
+    /// Whether or not this macro is defined in the current crate
+    is_local: bool,
     bindings: &'b [MacroRule],
     matched_rule_bindings: &'b [MatcherLoc],
 }
@@ -71,6 +74,7 @@ impl<'a, 'b> ParserAnyMacro<'a, 'b> {
             lint_node_id,
             arm_span,
             is_trailing_mac,
+            is_local,
             bindings,
             matched_rule_bindings,
         } = *self;
@@ -96,8 +100,13 @@ impl<'a, 'b> ParserAnyMacro<'a, 'b> {
         // `macro_rules! m { () => { panic!(); } }` isn't parsed by `.parse_expr()`,
         // but `m!()` is allowed in expression positions (cf. issue #34706).
         if kind == AstFragmentKind::Expr && parser.token == token::Semi {
+            let lint = if is_local {
+                SEMICOLON_IN_EXPRESSIONS_FROM_MACROS
+            } else {
+                SEMICOLON_IN_EXPRESSIONS_FROM_NON_LOCAL_MACROS
+            };
             parser.psess.buffer_lint(
-                SEMICOLON_IN_EXPRESSIONS_FROM_MACROS,
+                lint,
                 parser.token.span,
                 lint_node_id,
                 diagnostics::TrailingMacro { is_trailing: is_trailing_mac, name: macro_ident },
@@ -117,6 +126,7 @@ impl<'a, 'b> ParserAnyMacro<'a, 'b> {
         tts: TokenStream,
         site_span: Span,
         arm_span: Span,
+        is_local: bool,
         macro_ident: Ident,
         // bindings and lhs is for diagnostics
         bindings: &'b [MacroRule],
@@ -133,6 +143,7 @@ impl<'a, 'b> ParserAnyMacro<'a, 'b> {
             lint_node_id: cx.current_expansion.lint_node_id,
             is_trailing_mac: cx.current_expansion.is_trailing_mac,
             arm_span,
+            is_local,
             bindings,
             matched_rule_bindings,
         }
@@ -464,12 +475,13 @@ fn expand_macro<'cx, 'a: 'cx>(
                 trace_macros_note(&mut cx.expansions, sp, msg);
             }
 
-            if is_defined_in_current_crate(node_id) {
+            let is_local = is_defined_in_current_crate(node_id);
+            if is_local {
                 cx.resolver.record_macro_rule_usage(node_id, rule_index);
             }
 
             // Let the context choose how to interpret the result. Weird, but useful for X-macros.
-            Box::new(ParserAnyMacro::from_tts(cx, tts, sp, arm_span, name, rules, lhs))
+            Box::new(ParserAnyMacro::from_tts(cx, tts, sp, arm_span, is_local, name, rules, lhs))
         }
         Err(CanRetry::No(guar)) => {
             debug!("Will not retry matching as an error was emitted already");

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -104,6 +104,7 @@ pub mod hardwired {
             RUST_2024_PRELUDE_COLLISIONS,
             SELF_CONSTRUCTOR_FROM_OUTER_ITEM,
             SEMICOLON_IN_EXPRESSIONS_FROM_MACROS,
+            SEMICOLON_IN_EXPRESSIONS_FROM_NON_LOCAL_MACROS,
             SHADOWING_SUPERTRAIT_ITEMS,
             SINGLE_USE_LIFETIMES,
             STABLE_FEATURES,
@@ -2883,6 +2884,35 @@ declare_lint! {
     /// [future-incompatible]: ../index.md#future-incompatible-lints
     pub SEMICOLON_IN_EXPRESSIONS_FROM_MACROS,
     Deny,
+    "trailing semicolon in macro body used as expression",
+    @future_incompatible = FutureIncompatibleInfo {
+        reason: fcw!(FutureReleaseError #79813),
+        report_in_deps: true,
+    };
+}
+
+declare_lint! {
+    /// The `semicolon_in_expressions_from_non_local_macros` lint detects trailing semicolons in
+    /// macro bodies when the macro is invoked in expression position. This was previously accepted,
+    /// but is being phased out. This is similar to the `semicolon_in_expressions_from_macros` lint,
+    /// but applies to macros expanded from a different crate.
+    ///
+    /// ### Explanation
+    ///
+    /// Previous, Rust ignored trailing semicolon in a macro
+    /// body when a macro was invoked in expression position.
+    /// However, this makes the treatment of semicolons in the language
+    /// inconsistent, and could lead to unexpected runtime behavior
+    /// in some circumstances (e.g. if the macro author expects
+    /// a value to be dropped).
+    ///
+    /// This is a [future-incompatible] lint to transition this
+    /// to a hard error in the future. See [issue #79813] for more details.
+    ///
+    /// [issue #79813]: https://github.com/rust-lang/rust/issues/79813
+    /// [future-incompatible]: ../index.md#future-incompatible-lints
+    pub SEMICOLON_IN_EXPRESSIONS_FROM_NON_LOCAL_MACROS,
+    Warn,
     "trailing semicolon in macro body used as expression",
     @future_incompatible = FutureIncompatibleInfo {
         reason: fcw!(FutureReleaseError #79813),

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -2897,6 +2897,41 @@ declare_lint! {
     /// but is being phased out. This is similar to the `semicolon_in_expressions_from_macros` lint,
     /// but applies to macros expanded from a different crate.
     ///
+    /// ### Example
+    ///
+    /// ```rust,ignore (needs separate file)
+    /// fn main() {
+    ///     let val = match true {
+    ///         true => false,
+    ///         _ => example_separate_crate::foo!()
+    ///     };
+    /// }
+    /// ```
+    ///
+    /// where the crate `example-separate-crate` contains:
+    ///
+    /// ```rust,ignore (must be compiled as separate crate)
+    /// #[macro_export]
+    /// macro_rules! foo {
+    ///     () => { true; }
+    /// }
+    /// ```
+    ///
+    /// produces:
+    ///
+    /// ```text
+    /// warning: trailing semicolon in macro used in expression position
+    ///  --> src/main.rs:4:14
+    ///   |
+    /// 4 |         _ => example_separate_crate::foo!()
+    ///   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    ///   |
+    ///   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+    ///   = note: for more information, see issue #79813 <https://github.com/rust-lang/rust/issues/79813>
+    ///   = note: `#[warn(semicolon_in_expressions_from_non_local_macros)]` (part of `#[warn(future_incompatible)]`) on by default
+    ///   = note: this warning originates in the macro `example_separate_crate::foo` (in Nightly builds, run with -Z macro-backtrace for more info)
+    /// ```
+    ///
     /// ### Explanation
     ///
     /// Previous, Rust ignored trailing semicolon in a macro

--- a/tests/ui/lint/semicolon-in-expressions-from-macros/foreign-crate.rs
+++ b/tests/ui/lint/semicolon-in-expressions-from-macros/foreign-crate.rs
@@ -1,4 +1,5 @@
 //@ aux-build:foreign-crate.rs
+#![deny(semicolon_in_expressions_from_non_local_macros)]
 
 extern crate foreign_crate;
 

--- a/tests/ui/lint/semicolon-in-expressions-from-macros/foreign-crate.stderr
+++ b/tests/ui/lint/semicolon-in-expressions-from-macros/foreign-crate.stderr
@@ -1,25 +1,33 @@
 error: trailing semicolon in macro used in expression position
-  --> $DIR/foreign-crate.rs:7:13
+  --> $DIR/foreign-crate.rs:8:13
    |
 LL |     let _ = foreign_crate::my_macro!();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #79813 <https://github.com/rust-lang/rust/issues/79813>
-   = note: `#[deny(semicolon_in_expressions_from_macros)]` (part of `#[deny(future_incompatible)]`) on by default
+note: the lint level is defined here
+  --> $DIR/foreign-crate.rs:2:9
+   |
+LL | #![deny(semicolon_in_expressions_from_non_local_macros)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this error originates in the macro `foreign_crate::my_macro` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 
 Future incompatibility report: Future breakage diagnostic:
 error: trailing semicolon in macro used in expression position
-  --> $DIR/foreign-crate.rs:7:13
+  --> $DIR/foreign-crate.rs:8:13
    |
 LL |     let _ = foreign_crate::my_macro!();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #79813 <https://github.com/rust-lang/rust/issues/79813>
-   = note: `#[deny(semicolon_in_expressions_from_macros)]` (part of `#[deny(future_incompatible)]`) on by default
+note: the lint level is defined here
+  --> $DIR/foreign-crate.rs:2:9
+   |
+LL | #![deny(semicolon_in_expressions_from_non_local_macros)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this error originates in the macro `foreign_crate::my_macro` (in Nightly builds, run with -Z macro-backtrace for more info)
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/159700)*
<!-- homu-ignore:end -->

The new handling for non-local macros in
`semicolon_in_expressions_from_macros` produces new deny-by-default
lints on various existing crates, which have not previously received
warnings because prior Rust versions suppressed them. Split those out
into a new `semicolon_in_expressions_from_non_local_macros` lint, and
make that one warn-by-default (and FCW warn-in-deps), rather than
deny-by-default, to give the ecosystem time to adapt.

This reintroduces the `is_local` tracking from commit
9192337331dc8c59c6367d316c32f08f975b7140.
