### PR TITLE
crater: drop implied bound with non-universal region

### DIFF
--- a/compiler/rustc_borrowck/src/type_check/free_region_relations.rs
+++ b/compiler/rustc_borrowck/src/type_check/free_region_relations.rs
@@ -401,15 +401,26 @@ impl<'tcx> UniversalRegionRelationsBuilder<'_, 'tcx> {
                     // The bound says that `r1 <= r2`; we store `r2: r1`.
                     let r1 = self.universal_regions.to_region_vid(r1);
                     let r2 = self.universal_regions.to_region_vid(r2);
+                    if  !(self.universal_regions.is_universal_region(r1) || self.universal_regions.is_universal_region(r2)) {
+                        return;
+                    }
                     self.relate_universal_regions(r2, r1);
                 }
 
                 OutlivesBound::RegionSubParam(r_a, param_b) => {
+                    let r1 = self.universal_regions.to_region_vid(r_a);
+                    if !self.universal_regions.is_universal_region(r1) {
+                        return;
+                    }
                     self.region_bound_pairs
                         .insert(ty::OutlivesPredicate(GenericKind::Param(param_b), r_a));
                 }
 
                 OutlivesBound::RegionSubAlias(r_a, alias_b) => {
+                    let r1 = self.universal_regions.to_region_vid(r_a);
+                    if !self.universal_regions.is_universal_region(r1) {
+                        return;
+                    }
                     self.region_bound_pairs
                         .insert(ty::OutlivesPredicate(GenericKind::Alias(alias_b), r_a));
                 }

--- a/compiler/rustc_borrowck/src/type_check/free_region_relations.rs
+++ b/compiler/rustc_borrowck/src/type_check/free_region_relations.rs
@@ -401,7 +401,9 @@ impl<'tcx> UniversalRegionRelationsBuilder<'_, 'tcx> {
                     // The bound says that `r1 <= r2`; we store `r2: r1`.
                     let r1 = self.universal_regions.to_region_vid(r1);
                     let r2 = self.universal_regions.to_region_vid(r2);
-                    if  !(self.universal_regions.is_universal_region(r1) || self.universal_regions.is_universal_region(r2)) {
+                    if !(self.universal_regions.is_universal_region(r1)
+                        || self.universal_regions.is_universal_region(r2))
+                    {
                         return;
                     }
                     self.relate_universal_regions(r2, r1);

--- a/compiler/rustc_borrowck/src/type_check/free_region_relations.rs
+++ b/compiler/rustc_borrowck/src/type_check/free_region_relations.rs
@@ -572,14 +572,14 @@ impl<'tcx> UniversalRegionRelationsBuilder<'_, 'tcx> {
             debug!("add_outlives_bounds(bound={:?})", outlives_bound);
 
             match outlives_bound {
-                OutlivesBound::RegionSubRegion(r1, r2) => {
+                OutlivesBound::RegionSubRegion(ra, rb) => {
                     // The bound says that `r1 <= r2`; we store `r2: r1`.
-                    let r1 = self.universal_regions.to_region_vid(r1);
-                    let r2 = self.universal_regions.to_region_vid(r2);
+                    let r1 = self.universal_regions.to_region_vid(ra);
+                    let r2 = self.universal_regions.to_region_vid(rb);
                     if !(self.universal_regions.is_universal_region(r1)
                         || self.universal_regions.is_universal_region(r2))
                     {
-                        return;
+                        assert!(false, "case one: {} <= {}", ra, rb);
                     }
                     self.relate_universal_regions(r2, r1);
                 }
@@ -587,7 +587,7 @@ impl<'tcx> UniversalRegionRelationsBuilder<'_, 'tcx> {
                 OutlivesBound::RegionSubParam(r_a, param_b) => {
                     let r1 = self.universal_regions.to_region_vid(r_a);
                     if !self.universal_regions.is_universal_region(r1) {
-                        return;
+                        assert!(false, "case two: {} <= {}", r_a, param_b);
                     }
                     self.region_bound_pairs
                         .insert(ty::OutlivesClause(GenericKind::Param(param_b), r_a));
@@ -596,7 +596,7 @@ impl<'tcx> UniversalRegionRelationsBuilder<'_, 'tcx> {
                 OutlivesBound::RegionSubAlias(r_a, alias_b) => {
                     let r1 = self.universal_regions.to_region_vid(r_a);
                     if !self.universal_regions.is_universal_region(r1) {
-                        return;
+                        assert!(false, "case three: {} <= {}", r_a, alias_b);
                     }
                     self.region_bound_pairs
                         .insert(ty::OutlivesClause(GenericKind::Alias(alias_b), r_a));

--- a/compiler/rustc_borrowck/src/type_check/free_region_relations.rs
+++ b/compiler/rustc_borrowck/src/type_check/free_region_relations.rs
@@ -576,15 +576,26 @@ impl<'tcx> UniversalRegionRelationsBuilder<'_, 'tcx> {
                     // The bound says that `r1 <= r2`; we store `r2: r1`.
                     let r1 = self.universal_regions.to_region_vid(r1);
                     let r2 = self.universal_regions.to_region_vid(r2);
+                    if  !(self.universal_regions.is_universal_region(r1) || self.universal_regions.is_universal_region(r2)) {
+                        return;
+                    }
                     self.relate_universal_regions(r2, r1);
                 }
 
                 OutlivesBound::RegionSubParam(r_a, param_b) => {
+                    let r1 = self.universal_regions.to_region_vid(r_a);
+                    if !self.universal_regions.is_universal_region(r1) {
+                        return;
+                    }
                     self.region_bound_pairs
                         .insert(ty::OutlivesClause(GenericKind::Param(param_b), r_a));
                 }
 
                 OutlivesBound::RegionSubAlias(r_a, alias_b) => {
+                    let r1 = self.universal_regions.to_region_vid(r_a);
+                    if !self.universal_regions.is_universal_region(r1) {
+                        return;
+                    }
                     self.region_bound_pairs
                         .insert(ty::OutlivesClause(GenericKind::Alias(alias_b), r_a));
                 }

--- a/compiler/rustc_borrowck/src/type_check/free_region_relations.rs
+++ b/compiler/rustc_borrowck/src/type_check/free_region_relations.rs
@@ -576,7 +576,9 @@ impl<'tcx> UniversalRegionRelationsBuilder<'_, 'tcx> {
                     // The bound says that `r1 <= r2`; we store `r2: r1`.
                     let r1 = self.universal_regions.to_region_vid(r1);
                     let r2 = self.universal_regions.to_region_vid(r2);
-                    if  !(self.universal_regions.is_universal_region(r1) || self.universal_regions.is_universal_region(r2)) {
+                    if !(self.universal_regions.is_universal_region(r1)
+                        || self.universal_regions.is_universal_region(r2))
+                    {
                         return;
                     }
                     self.relate_universal_regions(r2, r1);


### PR DESCRIPTION
Implied bound could wind up having non-universal region and this behavior is kind of baffling to me. Currently, dropping implied bound with non-universal region won't break any ui test, so I am opening this PR to run crater to see if it breaks anything in the ecosystem. 

cc @lcnr
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
