### PR TITLE
fix error when a dangling ref in a ManuallyDrop is used in a pattern

### DIFF
--- a/compiler/rustc_middle/src/error.rs
+++ b/compiler/rustc_middle/src/error.rs
@@ -137,7 +137,9 @@ pub(crate) struct MaxNumNodesInValtree {
 
 #[derive(Diagnostic)]
 #[diag("constant {$global_const_id} cannot be used as pattern")]
-#[note("constants that reference mutable or external memory cannot be used as patterns")]
+#[note(
+    "constants that reference mutable or external memory or that contain dangling references cannot be used as patterns"
+)]
 pub(crate) struct InvalidConstInValtree {
     #[primary_span]
     pub span: Span,

--- a/tests/ui/consts/const_refs_to_static_fail.stderr
+++ b/tests/ui/consts/const_refs_to_static_fail.stderr
@@ -16,7 +16,7 @@ error: constant BAD_PATTERN cannot be used as pattern
 LL |         BAD_PATTERN => {},
    |         ^^^^^^^^^^^
    |
-   = note: constants that reference mutable or external memory cannot be used as patterns
+   = note: constants that reference mutable or external memory or that contain dangling references cannot be used as patterns
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/consts/const_refs_to_static_fail_invalid.stderr
+++ b/tests/ui/consts/const_refs_to_static_fail_invalid.stderr
@@ -15,7 +15,7 @@ error: constant extern_::C cannot be used as pattern
 LL |         C => {}
    |         ^
    |
-   = note: constants that reference mutable or external memory cannot be used as patterns
+   = note: constants that reference mutable or external memory or that contain dangling references cannot be used as patterns
 
 error: constant mutable::C cannot be used as pattern
   --> $DIR/const_refs_to_static_fail_invalid.rs:43:9
@@ -23,7 +23,7 @@ error: constant mutable::C cannot be used as pattern
 LL |         C => {}
    |         ^
    |
-   = note: constants that reference mutable or external memory cannot be used as patterns
+   = note: constants that reference mutable or external memory or that contain dangling references cannot be used as patterns
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/consts/miri_unleashed/const_refers_to_static.stderr
+++ b/tests/ui/consts/miri_unleashed/const_refers_to_static.stderr
@@ -22,7 +22,7 @@ error: constant REF_INTERIOR_MUT cannot be used as pattern
 LL |         REF_INTERIOR_MUT => {},
    |         ^^^^^^^^^^^^^^^^
    |
-   = note: constants that reference mutable or external memory cannot be used as patterns
+   = note: constants that reference mutable or external memory or that contain dangling references cannot be used as patterns
 
 warning: skipping const checks
    |

--- a/tests/ui/consts/miri_unleashed/const_refers_to_static_cross_crate.stderr
+++ b/tests/ui/consts/miri_unleashed/const_refers_to_static_cross_crate.stderr
@@ -10,7 +10,7 @@ error: constant SLICE_MUT cannot be used as pattern
 LL |         SLICE_MUT => true,
    |         ^^^^^^^^^
    |
-   = note: constants that reference mutable or external memory cannot be used as patterns
+   = note: constants that reference mutable or external memory or that contain dangling references cannot be used as patterns
 
 error: constant U8_MUT cannot be used as pattern
   --> $DIR/const_refers_to_static_cross_crate.rs:44:9
@@ -18,7 +18,7 @@ error: constant U8_MUT cannot be used as pattern
 LL |         U8_MUT => true,
    |         ^^^^^^
    |
-   = note: constants that reference mutable or external memory cannot be used as patterns
+   = note: constants that reference mutable or external memory or that contain dangling references cannot be used as patterns
 
 error: constant U8_MUT2 cannot be used as pattern
   --> $DIR/const_refers_to_static_cross_crate.rs:53:9
@@ -26,7 +26,7 @@ error: constant U8_MUT2 cannot be used as pattern
 LL |         U8_MUT2 => true,
    |         ^^^^^^^
    |
-   = note: constants that reference mutable or external memory cannot be used as patterns
+   = note: constants that reference mutable or external memory or that contain dangling references cannot be used as patterns
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/pattern/manually-drop-dangling-ref.rs
+++ b/tests/ui/pattern/manually-drop-dangling-ref.rs
@@ -1,0 +1,6 @@
+use std::mem::{ManuallyDrop, transmute};
+const DATA: ManuallyDrop<&i32> = unsafe { transmute(4_usize) };
+
+fn main() {
+    if let DATA = DATA {} //~ERROR: cannot be used as pattern
+}

--- a/tests/ui/pattern/manually-drop-dangling-ref.stderr
+++ b/tests/ui/pattern/manually-drop-dangling-ref.stderr
@@ -1,0 +1,10 @@
+error: constant DATA cannot be used as pattern
+  --> $DIR/manually-drop-dangling-ref.rs:5:12
+   |
+LL |     if let DATA = DATA {}
+   |            ^^^^
+   |
+   = note: constants that reference mutable or external memory or that contain dangling references cannot be used as patterns
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/159701
Cc @rust-lang/wg-const-eval 