### PR TITLE
Add rustdoc/cargo PGO profiles to reproducible artifacts

### DIFF
--- a/src/bootstrap/src/core/build_steps/dist.rs
+++ b/src/bootstrap/src/core/build_steps/dist.rs
@@ -3035,13 +3035,18 @@ impl Step for ReproducibleArtifacts {
     fn run(self, builder: &Builder<'_>) -> Self::Output {
         let mut added_anything = false;
         let tarball = Tarball::new(builder, "reproducible-artifacts", &self.target.triple);
-        if let Some(path) = builder.config.rust_pgo.use_profile.as_ref() {
-            tarball.add_file(path, ".", FileType::Regular);
-            added_anything = true;
-        }
-        if let Some(path) = builder.config.llvm_pgo.use_profile.as_ref() {
-            tarball.add_file(path, ".", FileType::Regular);
-            added_anything = true;
+
+        let pgo_profiles = [
+            &builder.config.rust_pgo.use_profile,
+            &builder.config.llvm_pgo.use_profile,
+            &builder.config.rustdoc_pgo.use_profile,
+            &builder.config.cargo_pgo.use_profile,
+        ];
+        for profile in pgo_profiles {
+            if let Some(path) = profile.as_ref() {
+                tarball.add_file(path, ".", FileType::Regular);
+                added_anything = true;
+            }
         }
         for profile in &builder.config.reproducible_artifacts {
             tarball.add_file(profile, ".", FileType::Regular);


### PR DESCRIPTION
I forgot to do this in the previous PRs.

I wanted to wait for https://github.com/rust-lang/rust/pull/159642, but that's a bit stuck because of CI time, so let's not wait, to avoid missing reproducible artifacts in our builds.