### PR TITLE
Fix used elf osabi

### DIFF
--- a/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
+++ b/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
@@ -173,12 +173,11 @@ fn process_builtin_attrs(
                 UsedBy::Compiler => codegen_fn_attrs.flags |= CodegenFnAttrFlags::USED_COMPILER,
                 UsedBy::Linker => codegen_fn_attrs.flags |= CodegenFnAttrFlags::USED_LINKER,
                 UsedBy::Default => {
-                    let used_form = if tcx.sess.target.os == Os::Illumos {
-                        // illumos' `ld` doesn't support a section header that would represent
-                        // `#[used(linker)]`, see
-                        // https://github.com/rust-lang/rust/issues/146169. For that target,
-                        // downgrade as if `#[used(compiler)]` was requested and hope for the
-                        // best.
+                    let used_form = if matches!(tcx.sess.target.os, Os::Illumos | Os::None) {
+                        // `#[used(linker)]` needs an OS-specific retained-section flag on ELF.
+                        // illumos' linker does not support its flag (#146169), while OS-less
+                        // ELF targets would get SHF_GNU_RETAIN and thus ELFOSABI_GNU (#158957).
+                        // Fall back to compiler-level retention for those targets.
                         CodegenFnAttrFlags::USED_COMPILER
                     } else {
                         CodegenFnAttrFlags::USED_LINKER

--- a/tests/run-make/used-preserves-elf-osabi/rmake.rs
+++ b/tests/run-make/used-preserves-elf-osabi/rmake.rs
@@ -1,0 +1,33 @@
+//! Verifies that plain `#[used]` preserves `ELFOSABI_NONE` on non-GNU ELF targets.
+
+//@ needs-llvm-components: x86 aarch64
+
+use std::fs;
+use std::path::Path;
+
+use run_make_support::{rustc, rustc_minicore};
+
+fn main() {
+    let targets = [("x86_64-unknown-none", "x86_64"), ("aarch64-unknown-none", "aarch64")];
+
+    for (target, name) in targets {
+        let minicore = format!("libminicore-{name}.rlib");
+        let object = format!("used-{name}.o");
+
+        rustc_minicore().target(target).output(&minicore).run();
+
+        rustc()
+            .input("used.rs")
+            .crate_type("lib")
+            .target(target)
+            .extern_("minicore", Path::new(&minicore))
+            .emit("obj")
+            .output(&object)
+            .run();
+
+        let bytes = fs::read(&object).unwrap();
+
+        assert_eq!(&bytes[..4], b"\x7fELF", "{target} did not produce ELF");
+        assert_eq!(bytes[7], 0, "{target}: expected ELFOSABI_NONE, found OSABI {}", bytes[7]);
+    }
+}

--- a/tests/run-make/used-preserves-elf-osabi/used.rs
+++ b/tests/run-make/used-preserves-elf-osabi/used.rs
@@ -1,0 +1,9 @@
+#![feature(no_core)]
+#![no_core]
+
+extern crate minicore;
+
+use minicore::*;
+
+#[used]
+pub static FOO: u8 = 42;


### PR DESCRIPTION
makes plain `used` fall back to compiler level retention for Os less taarget and matching the existing fallback used for Illumos

Fixes rust-lang/rust#158957 