### PR TITLE
Decode into the remaining buffer after incomplete_utf8 bytes in console read

### DIFF
--- a/library/std/src/sys/stdio/windows.rs
+++ b/library/std/src/sys/stdio/windows.rs
@@ -293,6 +293,10 @@ impl io::Read for Stdin {
             bytes_copied += self.incomplete_utf8.read(&mut buf[bytes_copied..]);
             Ok(bytes_copied)
         } else {
+            // Decode into the space after the bytes copied from `incomplete_utf8` (if any), so
+            // they are not overwritten; this also makes `amount` below account for the space
+            // that is actually still available.
+            let buf = &mut buf[bytes_copied..];
             let mut utf16_buf = [MaybeUninit::<u16>::uninit(); MAX_BUFFER_SIZE / 2];
 
             // In the worst case, a UTF-8 string can take 3 bytes for every `u16` of a UTF-16. So


### PR DESCRIPTION
When reading from a Windows console, `Stdin::read` first copies any leftover bytes of a partially read code point (`incomplete_utf8`) into the start of `buf`. The large-buffer path then decodes into `buf` starting at position 0, overwriting those bytes, and returns `bytes_copied + value`, so the clobbered bytes still count toward the length. The result is corrupted output with a stray byte at the end. The small-buffer path already decodes into `&mut buf[bytes_copied..]`; this change makes the large path do the same. @Ramla-I diagnosed the root cause in https://github.com/rust-lang/rust/issues/142847#issuecomment-4744232502.

I asked in the issue last week whether a reader-side fix was welcome alongside rust-lang/rust#142872 and figured I'd open it since it was sitting ready. Verified with a pseudoconsole feeding real console input through `read_to_end` (the report's repro) across 13 input alignments: 7 corrupted before the change, including the exact string from the issue (`ж` loses its second byte and a stray 0 gets appended), all 13 clean after. Console input can't be driven from CI, so there is no test.

rust-lang/rust#142872 keeps `read_to_end` from handing the reader a too-small buffer and is complementary: even with it, this path stays reachable through other callers, e.g. `read_vectored` with a 1-byte first buffer.

Fixes rust-lang/rust#142847
