### PR TITLE
Add `-Zimplicit-sysroot-deps`

### DIFF
--- a/compiler/rustc_interface/src/tests.rs
+++ b/compiler/rustc_interface/src/tests.rs
@@ -828,6 +828,7 @@ fn test_unstable_options_tracking_hash() {
     tracked!(function_sections, Some(false));
     tracked!(hint_mostly_unused, true);
     tracked!(human_readable_cgu_names, true);
+    tracked!(implicit_sysroot_deps, false);
     tracked!(incremental_ignore_spans, true);
     tracked!(indirect_branch_cs_prefix, true);
     tracked!(inline_mir, Some(true));

--- a/compiler/rustc_session/src/filesearch.rs
+++ b/compiler/rustc_session/src/filesearch.rs
@@ -12,6 +12,7 @@ use crate::search_paths::{PathKind, SearchPath};
 pub struct FileSearch {
     cli_search_paths: Vec<SearchPath>,
     tlib_path: SearchPath,
+    use_implicit_sysroot_deps: bool,
 }
 
 impl FileSearch {
@@ -20,16 +21,27 @@ impl FileSearch {
     }
 
     pub fn search_paths<'b>(&'b self, kind: PathKind) -> impl Iterator<Item = &'b SearchPath> {
+        //If the crate is `PathKind::Crate` (a top level dependency)
+        //and `-Z implicit-sysroot-deps=false`, then don't include the sysroot in the search paths.
+        let maybe_tlib = (self.use_implicit_sysroot_deps || !kind.matches(PathKind::Crate))
+            .then_some(&self.tlib_path);
+
         self.cli_search_paths
             .iter()
             .filter(move |sp| sp.kind.matches(kind))
-            .chain(std::iter::once(&self.tlib_path))
+            .chain(maybe_tlib.into_iter())
     }
 
-    pub fn new(cli_search_paths: &[SearchPath], tlib_path: &SearchPath, target: &Target) -> Self {
+    pub fn new(
+        cli_search_paths: &[SearchPath],
+        tlib_path: &SearchPath,
+        target: &Target,
+        use_implicit_sysroot_deps: bool,
+    ) -> Self {
         let this = FileSearch {
             cli_search_paths: cli_search_paths.to_owned(),
             tlib_path: tlib_path.clone(),
+            use_implicit_sysroot_deps,
         };
         this.refine(&["lib", &target.staticlib_prefix, &target.dll_prefix])
     }

--- a/compiler/rustc_session/src/filesearch.rs
+++ b/compiler/rustc_session/src/filesearch.rs
@@ -21,10 +21,10 @@ impl FileSearch {
     }
 
     pub fn search_paths<'b>(&'b self, kind: PathKind) -> impl Iterator<Item = &'b SearchPath> {
-        //If the crate is `PathKind::Crate` (a top level dependency)
-        //and `-Z implicit-sysroot-deps=false`, then don't include the sysroot in the search paths.
-        let maybe_tlib = (self.use_implicit_sysroot_deps || !kind.matches(PathKind::Crate))
-            .then_some(&self.tlib_path);
+        // If the crate is `PathKind::Crate` (a top level dependency)
+        // and `-Z implicit-sysroot-deps=false`, then don't include the sysroot in the search paths.
+        let exclude_sysroot = kind.matches(PathKind::Crate) && !self.use_implicit_sysroot_deps;
+        let maybe_tlib = (!exclude_sysroot).then_some(&self.tlib_path);
 
         self.cli_search_paths
             .iter()

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -2531,6 +2531,8 @@ options! {
         "display unnamed regions as `'<id>`, using a non-ident unique id (default: no)"),
     ignore_directory_in_diagnostics_source_blocks: Vec<String> = (Vec::new(), parse_string_push, [UNTRACKED],
         "do not display the source code block in diagnostics for files in the directory"),
+    implicit_sysroot_deps: bool = (true, parse_bool, [TRACKED],
+        "allows rust to search sysroot for a crate's dependencies (default: yes)"),
     incremental_ignore_spans: bool = (false, parse_bool, [TRACKED],
         "ignore spans during ICH computation -- used for testing (default: no)"),
     incremental_info: bool = (false, parse_bool, [UNTRACKED],

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -1336,9 +1336,18 @@ pub fn build_session(
     });
 
     let asm_arch = if target.allow_asm { InlineAsmArch::from_arch(&target.arch) } else { None };
-    let target_filesearch =
-        filesearch::FileSearch::new(&sopts.search_paths, &target_tlib_path, &target);
-    let host_filesearch = filesearch::FileSearch::new(&sopts.search_paths, &host_tlib_path, &host);
+    let target_filesearch = filesearch::FileSearch::new(
+        &sopts.search_paths,
+        &target_tlib_path,
+        &target,
+        sopts.unstable_opts.implicit_sysroot_deps,
+    );
+    let host_filesearch = filesearch::FileSearch::new(
+        &sopts.search_paths,
+        &host_tlib_path,
+        &host,
+        sopts.unstable_opts.implicit_sysroot_deps,
+    );
 
     let timings = TimingSectionHandler::new(sopts.json_timings);
 

--- a/tests/run-make/implicit-sysroot-deps/bar.rs
+++ b/tests/run-make/implicit-sysroot-deps/bar.rs
@@ -1,0 +1,4 @@
+#![feature(no_core)]
+#![no_core]
+#![no_std]
+extern crate baz;

--- a/tests/run-make/implicit-sysroot-deps/baz.rs
+++ b/tests/run-make/implicit-sysroot-deps/baz.rs
@@ -1,0 +1,3 @@
+#![feature(no_core)]
+#![no_core]
+#![no_std]

--- a/tests/run-make/implicit-sysroot-deps/foo.rs
+++ b/tests/run-make/implicit-sysroot-deps/foo.rs
@@ -1,0 +1,4 @@
+#![feature(no_core)]
+#![no_core]
+#![no_std]
+extern crate bar;

--- a/tests/run-make/implicit-sysroot-deps/rmake.rs
+++ b/tests/run-make/implicit-sysroot-deps/rmake.rs
@@ -1,0 +1,34 @@
+use run_make_support::rfs::create_dir_all;
+use run_make_support::{rustc, target};
+
+fn main() {
+    // Create test sysroot
+    let test_sysroot = format!("./testsysroot/lib/rustlib/{}/lib/", target());
+    create_dir_all(&test_sysroot);
+
+    // Layout:
+    // - Foo depends directly on Bar
+    // - Bar depends directly on Baz
+    // - Baz can be found in the sysroot.
+
+    // 1) Depending transitively on a lib in the sysroot resolves
+    // fine with `-Zimplicit-sysroot-deps=false`
+    rustc().input("baz.rs").crate_type("lib").out_dir(test_sysroot).run();
+    rustc().input("bar.rs").crate_type("lib").sysroot("./testsysroot").run();
+    rustc()
+        .input("foo.rs")
+        .crate_type("lib")
+        .extern_("bar", "libbar.rlib")
+        .sysroot("./testsysroot")
+        .arg("-Zimplicit-sysroot-deps=false")
+        .run();
+
+    // 2) Depending directly on a lib in the sysroot does not resolve
+    // implicitly with `-Zimplicit-sysroot-deps=false`
+    rustc()
+        .input("bar.rs")
+        .crate_type("lib")
+        .sysroot("./testsysroot")
+        .arg("-Zimplicit-sysroot-deps=false")
+        .run_fail();
+}

--- a/tests/run-make/implicit-sysroot-deps/rmake.rs
+++ b/tests/run-make/implicit-sysroot-deps/rmake.rs
@@ -1,5 +1,8 @@
 use run_make_support::rfs::create_dir_all;
-use run_make_support::{rustc, target};
+use run_make_support::{rust_lib_name, rustc, target};
+
+// Tests `-Zimplicit-sysroot-deps=false` with arbitrary crates passed via `--extern`
+// See `tests/ui/crate-loading` for tests with the standard library
 
 fn main() {
     // Create test sysroot
@@ -18,7 +21,7 @@ fn main() {
     rustc()
         .input("foo.rs")
         .crate_type("lib")
-        .extern_("bar", "libbar.rlib")
+        .extern_("bar", rust_lib_name("bar"))
         .sysroot("./testsysroot")
         .arg("-Zimplicit-sysroot-deps=false")
         .run();
@@ -30,5 +33,6 @@ fn main() {
         .crate_type("lib")
         .sysroot("./testsysroot")
         .arg("-Zimplicit-sysroot-deps=false")
-        .run_fail();
+        .run_fail()
+        .assert_stderr_contains("can't find crate for `baz`");
 }

--- a/tests/ui/crate-loading/auxiliary/crate-dep-std.rs
+++ b/tests/ui/crate-loading/auxiliary/crate-dep-std.rs
@@ -1,0 +1,3 @@
+pub fn bar() {
+    println!("I depend on std.");
+}

--- a/tests/ui/crate-loading/no-implicit-sysroot-deps-pass.rs
+++ b/tests/ui/crate-loading/no-implicit-sysroot-deps-pass.rs
@@ -1,0 +1,13 @@
+//@ check-pass
+//@ aux-build:crate-dep-std.rs
+//@ compile-flags: --crate-type=lib -Zimplicit-sysroot-deps=false -Cpanic=abort
+
+#![feature(no_core)]
+#![no_std]
+#![no_core]
+
+extern crate crate_dep_std as foo;
+use foo::bar;
+pub fn bark() {
+    bar();
+}

--- a/tests/ui/crate-loading/no-implicit-sysroot-deps-pass.rs
+++ b/tests/ui/crate-loading/no-implicit-sysroot-deps-pass.rs
@@ -2,6 +2,9 @@
 //@ aux-build:crate-dep-std.rs
 //@ compile-flags: --crate-type=lib -Zimplicit-sysroot-deps=false -Cpanic=abort
 
+// This test ensures that `-Zimplicit-sysroot-deps=false` allows loading transitive
+// dependencies from the sysroot when required.
+
 #![feature(no_core)]
 #![no_std]
 #![no_core]

--- a/tests/ui/crate-loading/no-implicit-sysroot-deps.rs
+++ b/tests/ui/crate-loading/no-implicit-sysroot-deps.rs
@@ -1,0 +1,9 @@
+//~ ERROR can't find crate for `std`
+//~| NOTE can't find crate
+//~| NOTE target may not be installed
+//~| HELP consider building the standard library from source with `cargo build -Zbuild-std`
+//~| HELP consider downloading the target with
+
+//@ compile-flags: --target x86_64-unknown-linux-gnu -Z implicit-sysroot-deps=false
+//@ needs-llvm-components: x86
+fn main() {}

--- a/tests/ui/crate-loading/no-implicit-sysroot-deps.rs
+++ b/tests/ui/crate-loading/no-implicit-sysroot-deps.rs
@@ -6,4 +6,9 @@
 
 //@ compile-flags: --target x86_64-unknown-linux-gnu -Z implicit-sysroot-deps=false
 //@ needs-llvm-components: x86
+
+// This program has an implicit dependency on std, injected by rust. This test ensures that rustc
+// does not search in the sysroot for it when `-Zimplicit-sysroot-deps` is false, and that an
+// error is thrown when std is not available on any other search paths.
+
 fn main() {}

--- a/tests/ui/crate-loading/no-implicit-sysroot-deps.stderr
+++ b/tests/ui/crate-loading/no-implicit-sysroot-deps.stderr
@@ -1,0 +1,9 @@
+error[E0463]: can't find crate for `std`
+   |
+   = note: the `x86_64-unknown-linux-gnu` target may not be installed
+   = help: consider downloading the target with `rustup target add x86_64-unknown-linux-gnu`
+   = help: consider building the standard library from source with `cargo build -Zbuild-std`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0463`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

This PR, originally authored by @CrooseGit, adds support for a new flag [proposed in the `build-std=always` RFC](https://rust-lang.github.io/rfcs/3874-build-std-always.html#preventing-implicit-sysroot-dependencies). It unblocks work by @Bryanskiy around handling panic strategies in build-std, for which rustc must look for them in `-Ldependency` locations and not the sysroot.

`-Zimplicit-sysroot-deps` is true by default. When false, rustc will not look in the sysroot when attempting to resolve direct dependencies. It is intended to be used by Cargo when using build-std to improve error messages, avoiding the common "duplicate lang item in crate `core`" error that occurs when not all required standard library crates have been built.

Not included in this PR is the behaviour around dependencies injected by rustc in `rustc_metadata`, such as panic runtimes and compiler-builtins, which will be addressed in the future.