### PR TITLE
Make `DocLinkResMap` an `FxIndexMap`

### DIFF
--- a/compiler/rustc_hir/src/def.rs
+++ b/compiler/rustc_hir/src/def.rs
@@ -4,7 +4,7 @@ use std::fmt::Debug;
 
 use rustc_ast as ast;
 use rustc_ast::NodeId;
-use rustc_data_structures::unord::UnordMap;
+use rustc_data_structures::fx::FxIndexMap;
 use rustc_error_messages::{DiagArgValue, IntoDiagArg};
 use rustc_macros::{Decodable, Encodable, StableHash};
 use rustc_span::Symbol;
@@ -962,4 +962,6 @@ pub enum LifetimeRes {
     ElidedAnchor { start: NodeId, end: NodeId },
 }
 
-pub type DocLinkResMap = UnordMap<(Symbol, Namespace), Option<Res<NodeId>>>;
+// FxIndexMap is necessary because its data ends up in .rmeta files,
+// so its iteration order must be consistent. See #159677 for context.
+pub type DocLinkResMap = FxIndexMap<(Symbol, Namespace), Option<Res<NodeId>>>;

--- a/tests/run-make/rmeta-unrelated-search-path-files/client.rs
+++ b/tests/run-make/rmeta-unrelated-search-path-files/client.rs
@@ -1,0 +1,5 @@
+//! [crate::Client]
+
+extern crate foo;
+
+pub struct Client;

--- a/tests/run-make/rmeta-unrelated-search-path-files/foo.rs
+++ b/tests/run-make/rmeta-unrelated-search-path-files/foo.rs
@@ -1,0 +1,1 @@
+pub struct Foo;

--- a/tests/run-make/rmeta-unrelated-search-path-files/foo_bar.rs
+++ b/tests/run-make/rmeta-unrelated-search-path-files/foo_bar.rs
@@ -1,0 +1,1 @@
+pub struct FooBar;

--- a/tests/run-make/rmeta-unrelated-search-path-files/rmake.rs
+++ b/tests/run-make/rmeta-unrelated-search-path-files/rmake.rs
@@ -1,0 +1,30 @@
+//@ needs-target-std
+//
+// Regression test for <https://github.com/rust-lang/rust/issues/159677>.
+//
+// Ensures two builds of `client.rs` produce identical metadata
+// even if there is an unrelated crate on the search path.
+
+use run_make_support::{rfs, rustc};
+
+fn main() {
+    rustc().input("foo.rs").crate_type("rlib").run();
+    rustc()
+        .input("client.rs")
+        .crate_type("rlib")
+        .emit("metadata")
+        .library_search_path(".")
+        .output("client1.rmeta")
+        .run();
+
+    rustc().input("foo_bar.rs").crate_type("rlib").run();
+    rustc()
+        .input("client.rs")
+        .crate_type("rlib")
+        .emit("metadata")
+        .library_search_path(".")
+        .output("client2.rmeta")
+        .run();
+
+    assert_eq!(rfs::read("client1.rmeta"), rfs::read("client2.rmeta"));
+}


### PR DESCRIPTION
Previously it was `FxHashMap`, changed to `UnordMap` in rust-lang/rust#119093. The rationale then was to make the iteration order unobservable, but it turned out to be leaky.

This change means the encoder outputs `doc_link_resolutions` entries in insertion order, and iteration order of the `DocLinkResMap` is now observable. I believe this doesn't affect correctness elsewhere, but I'm not very familiar with the codebase so I may be missing something

* Closes https://github.com/rust-lang/rust/issues/159677

Discussed on zulip: [#t-compiler/help > #159677: rmeta encoding is not stable](https://rust-lang.zulipchat.com/#narrow/channel/182449-t-compiler.2Fhelp/topic/.23159677.3A.20rmeta.20encoding.20is.20not.20stable/with/612134270)