### PR TITLE
tests: add UI test for `.swap()` suggestion

### DIFF
--- a/tests/ui/suggestions/suggest-swap.rs
+++ b/tests/ui/suggestions/suggest-swap.rs
@@ -1,0 +1,13 @@
+use std::mem;
+
+fn main() {
+    let mut arr = [1, 2, 3];
+
+    let i = 0usize;
+    let j = 1usize;
+
+    mem::swap(
+        &mut arr[i],
+        &mut arr[j], //~ ERROR cannot borrow `arr[_]` as mutable more than once at a time
+    );
+}

--- a/tests/ui/suggestions/suggest-swap.rs
+++ b/tests/ui/suggestions/suggest-swap.rs
@@ -1,3 +1,4 @@
+//! Regression test for <https://github.com/rust-lang/rust/issues/159664>
 use std::mem;
 
 fn main() {

--- a/tests/ui/suggestions/suggest-swap.stderr
+++ b/tests/ui/suggestions/suggest-swap.stderr
@@ -1,5 +1,5 @@
 error[E0499]: cannot borrow `arr[_]` as mutable more than once at a time
-  --> $DIR/suggest-swap.rs:11:9
+  --> $DIR/suggest-swap.rs:12:9
    |
 LL |     mem::swap(
    |     --------- first borrow later used by call

--- a/tests/ui/suggestions/suggest-swap.stderr
+++ b/tests/ui/suggestions/suggest-swap.stderr
@@ -1,0 +1,22 @@
+error[E0499]: cannot borrow `arr[_]` as mutable more than once at a time
+  --> $DIR/suggest-swap.rs:11:9
+   |
+LL |     mem::swap(
+   |     --------- first borrow later used by call
+LL |         &mut arr[i],
+   |         ----------- first mutable borrow occurs here
+LL |         &mut arr[j],
+   |         ^^^^^^^^^^^ second mutable borrow occurs here
+   |
+help: use `.swap()` to swap elements at the specified indices instead
+   |
+LL -     mem::swap(
+LL -         &mut arr[i],
+LL -         &mut arr[j],
+LL -     );
+LL +     arr.swap(j, i);
+   |
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0499`.


### PR DESCRIPTION
adds a UI test covering the borrow checker diagnostic that suggests using
`.swap()` when `std::mem::swap(&mut arr[i], &mut arr[j])` is used.

closes rust-lang/rust#159664 