### PR TITLE
allocations are allowed to grow (but not shrink)

### DIFF
--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -145,6 +145,13 @@
 //!   the allocation), `base + o` will not wrap around the address space (in
 //!   other words, will not overflow `usize`)
 //!
+//! Allocations typically have a fixed size that cannot change. However, allocations created by
+//! directly invoking page table operations of the operating system, e.g. via `mmap`, are allowed to
+//! grow by adding more pages to them at the end. Unmapping parts of an allocation (i.e., shrinking
+//! it or punching holes into it) is currently not supported. Allocations created via
+//! "compiler-recognized" operations, such as `std::alloc` methods or `libc::malloc`, can never
+//! change their size, even if they use `mmap` under the hood.
+//!
 //! [`null()`]: null
 //!
 //! # Provenance


### PR DESCRIPTION
This got permitted on the LLVM side about a year ago (https://github.com/llvm/llvm-project/pull/141338), but didn't require any code changes since LLVM's optimizations were already compatible with growing allocations. That said, LLVM assumes that allocations created via operations it recognizes (e.g. `malloc`, `alloca`, or the Rust global allocator operations) never change their size, so we have to exclude that case.

This resolves a part of https://github.com/rust-lang/unsafe-code-guidelines/issues/430.

It may seem strange that allocations can grow but not shrink, but we did have multiple users show up in #t-opsem with exactly that request. Cc @nhusung @foonathan; see [here](https://rust-lang.zulipchat.com/#narrow/channel/136281-t-opsem/topic/Shrinking.20allocations.20in-place/near/612181257) and [here](https://rust-lang.zulipchat.com/#narrow/channel/136281-t-opsem/topic/Shrinking.20allocations.20in-place/near/612191402) for some details about their use-cases.

Cc @rust-lang/opsem @rust-lang/lang 