### PR TITLE
std: Switch implementations of `thread_local!` for WASI

### DIFF
--- a/library/std/src/sys/thread_local/mod.rs
+++ b/library/std/src/sys/thread_local/mod.rs
@@ -25,7 +25,7 @@
 
 cfg_select! {
     any(
-        all(target_family = "wasm", not(target_feature = "atomics")),
+        all(target_family = "wasm", not(target_feature = "atomics"), not(target_os = "wasi")),
         target_os = "uefi",
         target_os = "zkvm",
         target_os = "trusty",
@@ -54,7 +54,10 @@ cfg_select! {
 /// destructor for each variable. On these platforms, we keep track of the
 /// destructors ourselves and register (through the [`guard`] module) only a
 /// single callback that runs all of the destructors in the list.
-#[cfg(all(target_thread_local, not(all(target_family = "wasm", not(target_feature = "atomics")))))]
+#[cfg(all(
+    target_thread_local,
+    not(all(target_family = "wasm", not(target_feature = "atomics"), not(target_os = "wasi")))
+))]
 pub(crate) mod destructors {
     cfg_select! {
         any(
@@ -93,9 +96,7 @@ pub(crate) mod guard {
             pub(crate) use windows::enable;
         }
         any(
-            all(target_family = "wasm", not(
-                all(target_os = "wasi", target_env = "p1", target_feature = "atomics")
-            )),
+            all(target_family = "wasm", not(target_os = "wasi")),
             target_os = "uefi",
             target_os = "zkvm",
             target_os = "trusty",
@@ -150,7 +151,7 @@ pub(crate) mod key {
             ),
             all(not(target_thread_local), target_vendor = "apple"),
             target_os = "teeos",
-            all(target_os = "wasi", target_env = "p1", target_feature = "atomics"),
+            target_os = "wasi",
         ) => {
             mod racy;
             mod unix;


### PR DESCRIPTION
This commit is a change for all WASI targets to use a different underlying implementation in the standard library for `thread_local!`. Previously all wasm targets, without the `atomics` feature, were funneled into the `no_threads` implementation and various fallbacks in the `thread_local` module. The upcoming `wasm32-wasip3` target, however, will actually have threads and will need different treatment. Additionally the modules that `wasm32-wasip3` needs all already work on all other WASI targets as well -- for example the `pthread_*` symbols needed to manage destructors are exposed by `wasi-libc`.

The end result is that the `wasm32-wasip3` target will be "ready for threads" as soon as `wasi-libc` has support. Other targets shouldn't have any functional difference from before, too.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
