### PR TITLE
rustfmt fix: allow file not found errors for external mods annotated with `#[my_macro]`

### DIFF
--- a/src/tools/rustfmt/src/lib.rs
+++ b/src/tools/rustfmt/src/lib.rs
@@ -11,6 +11,7 @@ extern crate rustc_ast_pretty;
 extern crate rustc_data_structures;
 extern crate rustc_errors;
 extern crate rustc_expand;
+extern crate rustc_feature;
 extern crate rustc_parse;
 extern crate rustc_session;
 extern crate rustc_span;

--- a/src/tools/rustfmt/src/modules.rs
+++ b/src/tools/rustfmt/src/modules.rs
@@ -16,7 +16,7 @@ use crate::parse::parser::{
     Directory, DirectoryOwnership, ModError, ModulePathSuccess, Parser, ParserError,
 };
 use crate::parse::session::ParseSess;
-use crate::utils::{contains_skip, mk_sp};
+use crate::utils::{contains_custom_attributes, contains_skip, mk_sp};
 
 mod visitor;
 
@@ -472,6 +472,16 @@ impl<'ast, 'psess, 'c> ModResolver<'ast, 'psess> {
             }
             Err(e) => match e {
                 ModError::FileNotFound(_, default_path, _secondary_path) => {
+                    if contains_custom_attributes(attrs) {
+                        // It's possible that at least one of the attributes is a custom proc macro
+                        // that takes the module tokens as an input. It's hard to know for sure
+                        // since rustfmt only operates on the AST pre-expansion. In this case we'll
+                        // be overly permissive and just ignore the file not found error so rustfmt
+                        // can still try formatting the input.
+                        tracing::warn!("Couldn't find file for mod {};`", mod_name.to_string());
+                        return Ok(None);
+                    }
+
                     Err(ModuleResolutionError {
                         module: mod_name.to_string(),
                         kind: ModuleResolutionErrorKind::NotFound { file: default_path },

--- a/src/tools/rustfmt/src/utils.rs
+++ b/src/tools/rustfmt/src/utils.rs
@@ -6,6 +6,7 @@ use rustc_ast::ast::{
     NodeId, Path, RestrictionKind, Visibility, VisibilityKind,
 };
 use rustc_ast_pretty::pprust;
+use rustc_feature::is_builtin_attr_name;
 use rustc_span::{BytePos, LocalExpnId, Span, Symbol, SyntaxContext, sym, symbol};
 use unicode_width::UnicodeWidthStr;
 
@@ -325,6 +326,13 @@ pub(crate) fn contains_skip(attrs: &[Attribute]) -> bool {
     attrs
         .iter()
         .any(|a| a.meta().map_or(false, |a| is_skip(&a)))
+}
+
+#[inline]
+pub(crate) fn contains_custom_attributes(attrs: &[Attribute]) -> bool {
+    attrs
+        .iter()
+        .any(|a| a.name().is_some_and(|name| !is_builtin_attr_name(name)))
 }
 
 #[inline]

--- a/src/tools/rustfmt/tests/target/issue_6959.rs
+++ b/src/tools/rustfmt/tests/target/issue_6959.rs
@@ -1,0 +1,2 @@
+#[my_macro]
+mod foo;


### PR DESCRIPTION
Tracking issue: https://github.com/rust-lang/rust/issues/54727

`#[my_macro]` was stabilized for macro hygiene 2.0 in https://github.com/rust-lang/rust/pull/157857. There isn't a guarantee that the external module exists on the file system so ignore any file not found errors encountered when trying to resolve the module's file.

Fixes rust-lang/rustfmt#6959

r? @petrochenkov 

cc: @TimNN 

