### PR TITLE
Rollup of 9 pull requests

### DIFF
--- a/compiler/rustc_const_eval/src/const_eval/eval_queries.rs
+++ b/compiler/rustc_const_eval/src/const_eval/eval_queries.rs
@@ -19,7 +19,7 @@ use crate::const_eval::CheckAlignment;
 use crate::interpret::{
     CtfeValidationMode, GlobalId, Immediate, InternError, InternKind, InterpCx, InterpErrorKind,
     InterpResult, MPlaceTy, MemoryKind, OpTy, RefTracking, ReturnContinuation, create_static_alloc,
-    intern_const_alloc_recursive, interp_ok, throw_exhaust,
+    ensure_monomorphic_enough, intern_const_alloc_recursive, interp_ok, throw_exhaust,
 };
 use crate::{CTRL_C_RECEIVED, diagnostics};
 
@@ -96,8 +96,10 @@ fn eval_body_using_ecx<'tcx, R: InterpretationResult<'tcx>>(
     body: &'tcx mir::Body<'tcx>,
 ) -> InterpResult<'tcx, R> {
     let tcx = *ecx.tcx;
-    let layout = ecx
-        .layout_of(body.bound_return_ty(tcx).instantiate(tcx, cid.instance.args).skip_norm_wip())?;
+    let ty = body.bound_return_ty(tcx).instantiate(tcx, cid.instance.args).skip_norm_wip();
+    ensure_monomorphic_enough(ty)?;
+
+    let layout = ecx.layout_of(ty)?;
     let (intern_kind, ret) = setup_for_eval(ecx, cid, layout)?;
 
     trace!(

--- a/compiler/rustc_const_eval/src/const_eval/machine.rs
+++ b/compiler/rustc_const_eval/src/const_eval/machine.rs
@@ -693,7 +693,7 @@ impl<'tcx> interpret::Machine<'tcx> for CompileTimeMachine<'tcx> {
 
             sym::field_offset => {
                 let frt_ty = instance.args.type_at(0);
-                ensure_monomorphic_enough(ecx.tcx.tcx, frt_ty)?;
+                ensure_monomorphic_enough(frt_ty)?;
 
                 let (ty, variant, field) = if let ty::Adt(def, args) = frt_ty.kind()
                     && let Some(FieldInfo { base, variant_idx, field_idx, .. }) =

--- a/compiler/rustc_const_eval/src/interpret/cast.rs
+++ b/compiler/rustc_const_eval/src/interpret/cast.rs
@@ -76,7 +76,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
 
             CastKind::PointerCoercion(PointerCoercion::ReifyFnPointer(_), _) => {
                 // All reifications must be monomorphic, bail out otherwise.
-                ensure_monomorphic_enough(*self.tcx, src.layout.ty)?;
+                ensure_monomorphic_enough(src.layout.ty)?;
 
                 // The src operand does not matter, just its type
                 match *src.layout.ty.kind() {
@@ -112,7 +112,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
 
             CastKind::PointerCoercion(PointerCoercion::ClosureFnPointer(_), _) => {
                 // All reifications must be monomorphic, bail out otherwise.
-                ensure_monomorphic_enough(*self.tcx, src.layout.ty)?;
+                ensure_monomorphic_enough(src.layout.ty)?;
 
                 // The src operand does not matter, just its type
                 match *src.layout.ty.kind() {
@@ -445,8 +445,8 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
             }
             _ => {
                 // Do not ICE if we are not monomorphic enough.
-                ensure_monomorphic_enough(*self.tcx, src.layout.ty)?;
-                ensure_monomorphic_enough(*self.tcx, cast_ty)?;
+                ensure_monomorphic_enough(src.layout.ty)?;
+                ensure_monomorphic_enough(cast_ty)?;
 
                 span_bug!(
                     self.cur_span(),
@@ -502,8 +502,8 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
             }
             _ => {
                 // Do not ICE if we are not monomorphic enough.
-                ensure_monomorphic_enough(*self.tcx, src.layout.ty)?;
-                ensure_monomorphic_enough(*self.tcx, cast_ty.ty)?;
+                ensure_monomorphic_enough(src.layout.ty)?;
+                ensure_monomorphic_enough(cast_ty.ty)?;
 
                 span_bug!(
                     self.cur_span(),

--- a/compiler/rustc_const_eval/src/interpret/intrinsics.rs
+++ b/compiler/rustc_const_eval/src/interpret/intrinsics.rs
@@ -186,7 +186,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         match intrinsic_name {
             sym::type_name => {
                 let tp_ty = instance.args.type_at(0);
-                ensure_monomorphic_enough(tcx, tp_ty)?;
+                ensure_monomorphic_enough(tp_ty)?;
                 let (alloc_id, meta) = alloc_type_name(tcx, tp_ty);
                 let val = ConstValue::Slice { alloc_id, meta };
                 let val = self.const_val_to_op(val, dest.layout.ty, Some(dest.layout))?;
@@ -194,14 +194,14 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
             }
             sym::needs_drop => {
                 let tp_ty = instance.args.type_at(0);
-                ensure_monomorphic_enough(tcx, tp_ty)?;
+                ensure_monomorphic_enough(tp_ty)?;
                 let val = ConstValue::from_bool(tp_ty.needs_drop(tcx, self.typing_env));
                 let val = self.const_val_to_op(val, tcx.types.bool, Some(dest.layout))?;
                 self.copy_op(&val, dest)?;
             }
             sym::type_id => {
                 let tp_ty = instance.args.type_at(0);
-                ensure_monomorphic_enough(tcx, tp_ty)?;
+                ensure_monomorphic_enough(tp_ty)?;
                 self.write_type_id(tp_ty, dest)?;
             }
             sym::type_id_eq => {

--- a/compiler/rustc_const_eval/src/interpret/traits.rs
+++ b/compiler/rustc_const_eval/src/interpret/traits.rs
@@ -26,8 +26,8 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         let (ty, dyn_ty) = self.tcx.erase_and_anonymize_regions((ty, dyn_ty));
 
         // All vtables must be monomorphic, bail out otherwise.
-        ensure_monomorphic_enough(*self.tcx, ty)?;
-        ensure_monomorphic_enough(*self.tcx, dyn_ty)?;
+        ensure_monomorphic_enough(ty)?;
+        ensure_monomorphic_enough(dyn_ty)?;
 
         let salt = M::get_global_alloc_salt(self, None);
         let vtable_symbolic_allocation = self.tcx.reserve_and_set_vtable_alloc(ty, dyn_ty, salt);

--- a/compiler/rustc_const_eval/src/interpret/util.rs
+++ b/compiler/rustc_const_eval/src/interpret/util.rs
@@ -19,8 +19,8 @@ pub(crate) fn type_implements_dyn_trait<'tcx, M: Machine<'tcx>>(
     ty: Ty<'tcx>,
     trait_ty: Ty<'tcx>,
 ) -> InterpResult<'tcx, (bool, &'tcx ty::List<ty::PolyExistentialPredicate<'tcx>>)> {
-    ensure_monomorphic_enough(ecx.tcx.tcx, ty)?;
-    ensure_monomorphic_enough(ecx.tcx.tcx, trait_ty)?;
+    ensure_monomorphic_enough(ty)?;
+    ensure_monomorphic_enough(trait_ty)?;
 
     let ty::Dynamic(preds, _) = trait_ty.kind() else {
         span_bug!(
@@ -50,7 +50,7 @@ pub(crate) fn type_implements_dyn_trait<'tcx, M: Machine<'tcx>>(
 /// Checks whether a type contains generic parameters which must be instantiated.
 ///
 /// In case it does, returns a `TooGeneric` const eval error.
-pub(crate) fn ensure_monomorphic_enough<'tcx, T>(_tcx: TyCtxt<'tcx>, ty: T) -> InterpResult<'tcx>
+pub(crate) fn ensure_monomorphic_enough<'tcx, T>(ty: T) -> InterpResult<'tcx>
 where
     T: TypeVisitable<TyCtxt<'tcx>>,
 {

--- a/compiler/rustc_const_eval/src/interpret/validity.rs
+++ b/compiler/rustc_const_eval/src/interpret/validity.rs
@@ -35,7 +35,6 @@ use super::{
     format_interp_error,
 };
 use crate::enter_trace_span;
-use crate::interpret::ensure_monomorphic_enough;
 
 // for the validation errors
 #[rustfmt::skip]
@@ -1584,9 +1583,6 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         start_in_may_dangle: bool,
     ) -> InterpResult<'tcx> {
         trace!("validate_operand_internal: {:?}, {:?}", *val, val.layout.ty);
-
-        // We can't check validity if there are any generics left.
-        ensure_monomorphic_enough(val.layout.ty)?;
 
         // Run the visitor.
         self.run_for_validation_mut(|ecx| {

--- a/compiler/rustc_const_eval/src/interpret/validity.rs
+++ b/compiler/rustc_const_eval/src/interpret/validity.rs
@@ -1586,7 +1586,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         trace!("validate_operand_internal: {:?}, {:?}", *val, val.layout.ty);
 
         // We can't check validity if there are any generics left.
-        ensure_monomorphic_enough(*self.tcx, val.layout.ty)?;
+        ensure_monomorphic_enough(val.layout.ty)?;
 
         // Run the visitor.
         self.run_for_validation_mut(|ecx| {

--- a/compiler/rustc_hir/src/def.rs
+++ b/compiler/rustc_hir/src/def.rs
@@ -4,7 +4,7 @@ use std::fmt::Debug;
 
 use rustc_ast as ast;
 use rustc_ast::NodeId;
-use rustc_data_structures::unord::UnordMap;
+use rustc_data_structures::fx::FxIndexMap;
 use rustc_error_messages::{DiagArgValue, IntoDiagArg};
 use rustc_macros::{Decodable, Encodable, StableHash};
 use rustc_span::Symbol;
@@ -962,4 +962,6 @@ pub enum LifetimeRes {
     ElidedAnchor { start: NodeId, end: NodeId },
 }
 
-pub type DocLinkResMap = UnordMap<(Symbol, Namespace), Option<Res<NodeId>>>;
+// FxIndexMap is necessary because its data ends up in .rmeta files,
+// so its iteration order must be consistent. See #159677 for context.
+pub type DocLinkResMap = FxIndexMap<(Symbol, Namespace), Option<Res<NodeId>>>;

--- a/compiler/rustc_lint/src/runtime_symbols.rs
+++ b/compiler/rustc_lint/src/runtime_symbols.rs
@@ -227,11 +227,16 @@ fn check<'tcx>(
         let expected = Ty::new_fn_ptr(cx.tcx, lang_sig);
         let actual = Ty::new_fn_ptr(cx.tcx, user_sig);
 
+        // ! is ABI compatible with ()
+        // https://github.com/rust-lang/rust/issues/159446
+        let lang_ret_incompatible_with_unit = !lang_sig.output().skip_binder().is_unit()
+            && !lang_sig.output().skip_binder().is_never();
+        let user_sig_ret_is_unit = user_sig.output().skip_binder().is_unit();
+
         if lang_sig.abi() != user_sig.abi()
             || lang_sig.c_variadic() != user_sig.c_variadic()
             || lang_sig.inputs().skip_binder().len() != user_sig.inputs().skip_binder().len()
-            || (!lang_sig.output().skip_binder().is_unit()
-                && user_sig.output().skip_binder().is_unit())
+            || (lang_ret_incompatible_with_unit && user_sig_ret_is_unit)
         {
             cx.emit_span_lint(
                 INVALID_RUNTIME_SYMBOL_DEFINITIONS,

--- a/compiler/rustc_middle/src/mir/consts.rs
+++ b/compiler/rustc_middle/src/mir/consts.rs
@@ -341,7 +341,7 @@ impl<'tcx> Const<'tcx> {
                 // FIXME: We might want to have a `try_eval`-like function on `Unevaluated`
                 tcx.const_eval_resolve(typing_env, uneval, span)
             }
-            Const::Val(val, _) => Ok(val),
+            Const::Val(val, _ty) => Ok(val),
         }
     }
 

--- a/compiler/rustc_mir_build/src/thir/pattern/const_to_pat.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/const_to_pat.rs
@@ -107,11 +107,37 @@ impl<'tcx> ConstToPat<'tcx> {
             self.tcx.erase_and_anonymize_regions(self.typing_env).with_codegen_normalized(self.tcx);
         let alias_const = self.tcx.erase_and_anonymize_regions(alias_const);
 
+        let mk_too_generic_err = || {
+            let mut err = self
+                .tcx
+                .dcx()
+                .create_err(ConstPatternDependsOnGenericParameter { span: self.span });
+            for arg in alias_const.args {
+                if let ty::GenericArgKind::Type(ty) = arg.kind()
+                    && let ty::Param(param_ty) = ty.kind()
+                {
+                    let def_id = self.tcx.hir_enclosing_body_owner(self.id);
+                    let generics = self.tcx.generics_of(def_id);
+                    let param = generics.type_param(*param_ty, self.tcx);
+                    let span = self.tcx.def_span(param.def_id);
+                    err.span_label(span, "constant depends on this generic parameter");
+                    if let Some(ident) = self.tcx.def_ident_span(def_id)
+                        && self.tcx.sess.source_map().is_multiline(ident.between(span))
+                    {
+                        // Display the `fn` name as well in the diagnostic, as the generic isn't
+                        // in the same line and it could be confusing otherwise.
+                        err.span_label(ident, "");
+                    }
+                }
+            }
+            return self.mk_err(err, ty);
+        };
+
         // FIXME(gca): This will become insufficient once associated constants can be
         // implemented as `type` consts (project-const-generics#76). At that point it'll
         // become necessary to just use type system normalization for all const patterns
         // but that's not yet possible.
-        let mut thir_pat = if alias_const.kind.is_type_const(self.tcx) {
+        let const_value = if alias_const.kind.is_type_const(self.tcx) {
             let Ok(normalize) = self
                 .tcx
                 .try_normalize_erasing_regions(self.typing_env, Unnormalized::new_wip(self.c))
@@ -124,7 +150,7 @@ impl<'tcx> ConstToPat<'tcx> {
                 let err = self.tcx.dcx().create_err(CouldNotEvalConstPattern { span: self.span });
                 return self.mk_err(err, ty);
             };
-            self.valtree_to_pat(value)
+            value
         } else {
             // try to resolve e.g. associated constants to their definition on an impl, and then
             // evaluate the const.
@@ -147,29 +173,7 @@ impl<'tcx> ConstToPat<'tcx> {
                         return self.mk_err(err, ty);
                     }
                     Err(ErrorHandled::TooGeneric(_)) => {
-                        let mut err = self
-                            .tcx
-                            .dcx()
-                            .create_err(ConstPatternDependsOnGenericParameter { span: self.span });
-                        for arg in alias_const.args {
-                            if let ty::GenericArgKind::Type(ty) = arg.kind()
-                                && let ty::Param(param_ty) = ty.kind()
-                            {
-                                let def_id = self.tcx.hir_enclosing_body_owner(self.id);
-                                let generics = self.tcx.generics_of(def_id);
-                                let param = generics.type_param(*param_ty, self.tcx);
-                                let span = self.tcx.def_span(param.def_id);
-                                err.span_label(span, "constant depends on this generic parameter");
-                                if let Some(ident) = self.tcx.def_ident_span(def_id)
-                                    && self.tcx.sess.source_map().is_multiline(ident.between(span))
-                                {
-                                    // Display the `fn` name as well in the diagnostic, as the generic isn't
-                                    // in the same line and it could be confusing otherwise.
-                                    err.span_label(ident, "");
-                                }
-                            }
-                        }
-                        return self.mk_err(err, ty);
+                        return mk_too_generic_err();
                     }
                     Ok(Err(bad_ty)) => {
                         // The pattern cannot be turned into a valtree.
@@ -192,8 +196,12 @@ impl<'tcx> ConstToPat<'tcx> {
                 };
 
             // Lower the valtree to a THIR pattern.
-            self.valtree_to_pat(ty::Value { ty, valtree })
+            ty::Value { ty, valtree }
         };
+        if const_value.ty.has_param() {
+            return mk_too_generic_err();
+        }
+        let mut thir_pat = self.valtree_to_pat(const_value);
 
         if !thir_pat.references_error() {
             // Always check for `PartialEq` if we had no other errors yet.

--- a/library/Cargo.lock
+++ b/library/Cargo.lock
@@ -146,9 +146,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 dependencies = [
  "rustc-std-workspace-core",
 ]

--- a/library/core/src/attribute_docs.rs
+++ b/library/core/src/attribute_docs.rs
@@ -555,3 +555,29 @@ mod track_caller_attribute {}
 /// [function-like procedural macros]: ../reference/procedural-macros.html#the-proc_macro-attribute
 /// [`proc_macro`]: ../proc_macro/index.html
 mod proc_macro_attribute {}
+
+#[doc(attribute = "link_section")]
+//
+/// Places a function or static in a specific object-file section.
+///
+/// The `link_section` attribute specifies the section of the generated object file where a
+/// function or static is placed. Section names and their meaning are target-specific.
+///
+/// ```rust,no_run
+/// # #[cfg(target_os = "linux")] {
+/// #[unsafe(link_section = ".example_section")]
+/// pub static VALUE: u32 = 42;
+/// # }
+/// ```
+///
+/// Incorrectly placing code or data in a section can violate requirements imposed by the target,
+/// linker, or runtime. For example, placing mutable data in a read-only section may result in
+/// undefined behavior. For this reason, `link_section` is an unsafe attribute.
+///
+/// Starting with the 2024 edition, the attribute must be written using the `unsafe(...)` syntax.
+/// Earlier editions also permit `#[link_section = "..."]`.
+///
+/// For more information, see the Reference on [the `link_section` attribute].
+///
+/// [the `link_section` attribute]: ../reference/abi.html#the-link_section-attribute
+mod link_section_attribute {}

--- a/library/core/src/intrinsics/bounds.rs
+++ b/library/core/src/intrinsics/bounds.rs
@@ -44,9 +44,68 @@ impl<T: PointeeSized, U: PointeeSized> ChangePointee<U> for *const T {
 ///
 /// # Safety
 /// Must actually *be* such a type.
-pub unsafe trait FloatPrimitive: Sized + Copy {}
+#[rustc_const_unstable(feature = "core_intrinsics", issue = "none")]
+pub const unsafe trait FloatPrimitive: Sized + Copy {
+    type UInt: const core::ops::BitOr<Output = Self::UInt>
+        + const core::ops::BitAnd<Output = Self::UInt>
+        + const core::ops::Not<Output = Self::UInt>;
+    const SIGN_MASK: Self::UInt;
+    fn to_bits(self) -> Self::UInt;
+    fn from_bits(bits: Self::UInt) -> Self;
+}
 
-unsafe impl FloatPrimitive for f16 {}
-unsafe impl FloatPrimitive for f32 {}
-unsafe impl FloatPrimitive for f64 {}
-unsafe impl FloatPrimitive for f128 {}
+#[rustc_const_unstable(feature = "core_intrinsics", issue = "none")]
+const unsafe impl FloatPrimitive for f16 {
+    type UInt = u16;
+    const SIGN_MASK: Self::UInt = f16::SIGN_MASK;
+    #[inline]
+    fn to_bits(self) -> Self::UInt {
+        f16::to_bits(self)
+    }
+    #[inline]
+    fn from_bits(bits: Self::UInt) -> Self {
+        f16::from_bits(bits)
+    }
+}
+
+#[rustc_const_unstable(feature = "core_intrinsics", issue = "none")]
+const unsafe impl FloatPrimitive for f32 {
+    type UInt = u32;
+    const SIGN_MASK: Self::UInt = f32::SIGN_MASK;
+    #[inline]
+    fn to_bits(self) -> Self::UInt {
+        f32::to_bits(self)
+    }
+    #[inline]
+    fn from_bits(bits: Self::UInt) -> Self {
+        f32::from_bits(bits)
+    }
+}
+
+#[rustc_const_unstable(feature = "core_intrinsics", issue = "none")]
+const unsafe impl FloatPrimitive for f64 {
+    type UInt = u64;
+    const SIGN_MASK: Self::UInt = f64::SIGN_MASK;
+    #[inline]
+    fn to_bits(self) -> Self::UInt {
+        f64::to_bits(self)
+    }
+    #[inline]
+    fn from_bits(bits: Self::UInt) -> Self {
+        f64::from_bits(bits)
+    }
+}
+
+#[rustc_const_unstable(feature = "core_intrinsics", issue = "none")]
+const unsafe impl FloatPrimitive for f128 {
+    type UInt = u128;
+    const SIGN_MASK: Self::UInt = f128::SIGN_MASK;
+    #[inline]
+    fn to_bits(self) -> Self::UInt {
+        f128::to_bits(self)
+    }
+    #[inline]
+    fn from_bits(bits: Self::UInt) -> Self {
+        f128::from_bits(bits)
+    }
+}

--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -3628,9 +3628,13 @@ pub const fn maximumf128(x: f128, y: f128) -> f128 {
 /// The stabilized versions of this intrinsic are available on the float
 /// primitives via the `abs` method. For example, [`f32::abs`].
 #[rustc_nounwind]
+#[rustc_const_unstable(feature = "core_intrinsics", issue = "none")]
 #[rustc_intrinsic_const_stable_indirect]
 #[rustc_intrinsic]
-pub const fn fabs<T: bounds::FloatPrimitive>(x: T) -> T;
+#[miri::intrinsic_fallback_is_spec]
+pub const fn fabs<T: const bounds::FloatPrimitive>(x: T) -> T {
+    T::from_bits(x.to_bits() & !T::SIGN_MASK)
+}
 
 /// Copies the sign from `y` to `x` for `f16` values.
 ///

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -33,7 +33,7 @@ miniz_oxide = { version = "0.9.0", optional = true, default-features = false }
 addr2line = { version = "0.27.0", optional = true, default-features = false }
 
 [target.'cfg(not(all(windows, target_env = "msvc")))'.dependencies]
-libc = { version = "0.2.185", default-features = false, features = [
+libc = { version = "0.2.189", default-features = false, features = [
     'rustc-dep-of-std',
 ], public = true }
 

--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -2872,7 +2872,7 @@ pub fn copy<P: AsRef<Path>, Q: AsRef<Path>>(from: P, to: Q) -> io::Result<u64> {
 ///
 /// This function currently corresponds to the `CreateHardLink` function on Windows.
 /// On most Unix systems, it corresponds to the `linkat` function with no flags.
-/// On Android, VxWorks, and Redox, it instead corresponds to the `link` function.
+/// On VxWorks and Redox, it instead corresponds to the `link` function.
 /// On MacOS, it uses the `linkat` function if it is available, but on very old
 /// systems where `linkat` is not available, `link` is selected at runtime instead.
 /// Note that, this [may change in the future][changes].

--- a/library/std/src/sys/fs/unix.rs
+++ b/library/std/src/sys/fs/unix.rs
@@ -2057,9 +2057,6 @@ pub fn link(original: &CStr, link: &CStr) -> io::Result<()> {
             target_os = "vxworks",
             target_os = "redox",
             target_os = "espidf",
-            // Android has `linkat` on newer versions, but we happen to know
-            // `link` always has the correct behavior, so it's here as well.
-            target_os = "android",
             // Other misc platforms
             target_os = "horizon",
             target_os = "vita",

--- a/library/std/src/sys/net/connection/xous/udp.rs
+++ b/library/std/src/sys/net/connection/xous/udp.rs
@@ -179,10 +179,12 @@ impl UdpSocket {
                 } else {
                     return Err(io::const_error!(io::ErrorKind::Other, "library error"));
                 };
-                for (&s, d) in rr[22..22 + rxlen as usize].iter().zip(buf.iter_mut()) {
-                    *d = s;
-                }
-                Ok((rxlen as usize, addr))
+                let max = (rxlen as usize).min(buf.len()).min(rr.len() - 22);
+                // Both sides must be sliced: `max` is shorter than `buf` whenever
+                // the datagram doesn't fill it, and `copy_from_slice` panics on a
+                // length mismatch.
+                buf[..max].copy_from_slice(&rr[22..][..max]);
+                Ok((max, addr))
             }
         } else {
             Err(io::const_error!(io::ErrorKind::InvalidInput, "unable to recv"))

--- a/src/tools/miri/tests/pass/shims/fs.rs
+++ b/src/tools/miri/tests/pass/shims/fs.rs
@@ -49,9 +49,8 @@ fn main() {
     if cfg!(not(windows)) {
         test_directory();
         test_canonicalize();
-        #[cfg(not(target_os = "solaris"))]
+        #[cfg(not(target_os = "solaris"))] // does not have flock
         test_flock();
-        #[cfg(not(target_os = "android"))]
         test_hard_link();
 
         test_readv_writev();
@@ -559,8 +558,6 @@ fn test_preadv_pwritev() {
     assert_eq!(written_bytes.as_slice(), &write_buffer[0..bytes_written]);
 }
 
-// std uses `libc::link` on Android which we do not support.
-#[cfg(not(target_os = "android"))]
 fn test_hard_link() {
     let source = utils::prepare_with_content("miri_test_fs_hard_link_source.txt", b"hello");
     let link = utils::prepare("miri_test_fs_hard_link_link.txt");

--- a/tests/run-make/rmeta-unrelated-search-path-files/client.rs
+++ b/tests/run-make/rmeta-unrelated-search-path-files/client.rs
@@ -1,0 +1,5 @@
+//! [crate::Client]
+
+extern crate foo;
+
+pub struct Client;

--- a/tests/run-make/rmeta-unrelated-search-path-files/foo.rs
+++ b/tests/run-make/rmeta-unrelated-search-path-files/foo.rs
@@ -1,0 +1,1 @@
+pub struct Foo;

--- a/tests/run-make/rmeta-unrelated-search-path-files/foo_bar.rs
+++ b/tests/run-make/rmeta-unrelated-search-path-files/foo_bar.rs
@@ -1,0 +1,1 @@
+pub struct FooBar;

--- a/tests/run-make/rmeta-unrelated-search-path-files/rmake.rs
+++ b/tests/run-make/rmeta-unrelated-search-path-files/rmake.rs
@@ -1,0 +1,28 @@
+// Regression test for <https://github.com/rust-lang/rust/issues/159677>.
+//
+// Ensures two builds of `client.rs` produce identical metadata
+// even if there is an unrelated crate on the search path.
+
+use run_make_support::{rfs, rustc};
+
+fn main() {
+    rustc().input("foo.rs").crate_type("rlib").run();
+    rustc()
+        .input("client.rs")
+        .crate_type("rlib")
+        .emit("metadata")
+        .library_search_path(".")
+        .output("client1.rmeta")
+        .run();
+
+    rustc().input("foo_bar.rs").crate_type("rlib").run();
+    rustc()
+        .input("client.rs")
+        .crate_type("rlib")
+        .emit("metadata")
+        .library_search_path(".")
+        .output("client2.rmeta")
+        .run();
+
+    assert_eq!(rfs::read("client1.rmeta"), rfs::read("client2.rmeta"));
+}

--- a/tests/ui/lint/runtime-symbols-unix.rs
+++ b/tests/ui/lint/runtime-symbols-unix.rs
@@ -57,6 +57,18 @@ fn suspicious() {
         pub static exit2: Option<unsafe extern "C" fn(f32) -> !>;
         //~^ WARN suspicious definition of the runtime `exit` symbol
     }
+
+    extern "C" {
+        #[link_name = "exit"]
+        pub fn exit3(code: i32) -> i32;
+        //~^ WARN suspicious definition of the runtime `exit` symbol
+
+        // ! is ABI compatible with ()
+        // https://github.com/rust-lang/rust/issues/159446
+        #[link_name = "exit"]
+        pub fn exit4(code: i32);
+        //~^ WARN suspicious definition of the runtime `exit` symbol
+    }
 }
 
 fn main() {}

--- a/tests/ui/lint/runtime-symbols-unix.stderr
+++ b/tests/ui/lint/runtime-symbols-unix.stderr
@@ -124,5 +124,27 @@ LL |         pub static exit2: Option<unsafe extern "C" fn(f32) -> !>;
    = help: either fix the signature or remove any attributes like `#[unsafe(no_mangle)]`, `#[unsafe(export_name = "exit")]`, or `#[link_name = "exit"]`
    = help: allow this lint if the signature is compatible
 
-error: aborting due to 8 previous errors; 4 warnings emitted
+warning: suspicious definition of the runtime `exit` symbol used by the standard library
+  --> $DIR/runtime-symbols-unix.rs:63:9
+   |
+LL |         pub fn exit3(code: i32) -> i32;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: expected `unsafe extern "C" fn(i32) -> !`
+           found    `unsafe extern "C" fn(i32) -> i32`
+   = help: either fix the signature or remove any attributes like `#[unsafe(no_mangle)]`, `#[unsafe(export_name = "exit")]`, or `#[link_name = "exit"]`
+   = help: allow this lint if the signature is compatible
+
+warning: suspicious definition of the runtime `exit` symbol used by the standard library
+  --> $DIR/runtime-symbols-unix.rs:69:9
+   |
+LL |         pub fn exit4(code: i32);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: expected `unsafe extern "C" fn(i32) -> !`
+           found    `unsafe extern "C" fn(i32)`
+   = help: either fix the signature or remove any attributes like `#[unsafe(no_mangle)]`, `#[unsafe(export_name = "exit")]`, or `#[link_name = "exit"]`
+   = help: allow this lint if the signature is compatible
+
+error: aborting due to 8 previous errors; 6 warnings emitted
 

--- a/tests/ui/nll/polonius/iterating-updating-mutref.nll.stderr
+++ b/tests/ui/nll/polonius/iterating-updating-mutref.nll.stderr
@@ -1,5 +1,5 @@
 error[E0499]: cannot borrow `self.buf_read` as mutable more than once at a time
-  --> $DIR/iterating-updating-mutref.rs:61:23
+  --> $DIR/iterating-updating-mutref.rs:76:23
    |
 LL |     pub fn next<'a>(&'a mut self) -> &'a str {
    |                 -- lifetime `'a` defined here

--- a/tests/ui/nll/polonius/iterating-updating-mutref.rs
+++ b/tests/ui/nll/polonius/iterating-updating-mutref.rs
@@ -49,6 +49,21 @@ fn to_refs2<T>(mut list: &mut List<T>) -> Vec<&mut T> {
     result
 }
 
+// In a-mir-formality, the local `cursor` was (incorrectly) considered live
+// on a second borrowck pass, resulting in an incorrect error.
+fn to_refs3<'a, T>(list: &'a mut List<T>) -> &'a mut T {
+    let mut result: &'a mut T;
+    let mut cursor: &'a mut List<T> = &mut *list;
+    loop {
+        result = &mut cursor.value;
+        if let Some(n) = cursor.next.as_mut() {
+            cursor = n;
+        } else {
+            return result;
+        }
+    }
+}
+
 // Another MCVE from the same issue, but was rejected by NLLs.
 pub struct Decoder {
     buf_read: BufRead,

--- a/tests/ui/pattern/generic-in-path.rs
+++ b/tests/ui/pattern/generic-in-path.rs
@@ -1,0 +1,17 @@
+//! Ensure we can deal with a pattern that depends on a generic in its path, but the
+//! actual pattern value can be computed independent of the generic.
+#[derive(PartialEq)]
+pub struct Thing<const N: usize>;
+
+impl<const N: usize> Thing<N> {
+    const A: Self = Thing;
+}
+
+fn broken<const N: usize>(x: Thing<N>) {
+    match x {
+        <Thing<N>>::A => {} //~ERROR: cannot depend on generic
+        _ => {}
+    }
+}
+
+fn main() {}

--- a/tests/ui/pattern/generic-in-path.stderr
+++ b/tests/ui/pattern/generic-in-path.stderr
@@ -1,0 +1,14 @@
+error[E0158]: constant pattern cannot depend on generic parameters
+  --> $DIR/generic-in-path.rs:12:9
+   |
+LL | impl<const N: usize> Thing<N> {
+   | -----------------------------
+LL |     const A: Self = Thing;
+   |     ------------- constant defined here
+...
+LL |         <Thing<N>>::A => {}
+   |         ^^^^^^^^^^^^^ `const` depends on a generic parameter
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0158`.


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#159504 (Abort const-eval queries early when there are generics in the type)
 - rust-lang/rust#159523 (std: fix Xous UDP recv length over-report and OOB panic)
 - rust-lang/rust#159605 (Add fallback for `intrinsics::fabs`)
 - rust-lang/rust#159699 (bump std libc to 0.2.189)
 - rust-lang/rust#159718 (Make `DocLinkResMap` an `FxIndexMap`)
 - rust-lang/rust#159306 (Add new variant to iterating-updating-mutref borrowck test)
 - rust-lang/rust#159346 (fs::hard_link: use linkat on Android)
 - rust-lang/rust#159513 (Consider `()` as suspicious only when expecting `!` for runtime symbols)
 - rust-lang/rust#159734 (Document the link_section attribute)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=159504,159523,159605,159699,159718,159306,159346,159513,159734)
<!-- homu-ignore:end -->

