### PR TITLE
Improve consistency of attribute error messages

### DIFF
--- a/compiler/rustc_attr_parsing/src/attributes/cfg.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/cfg.rs
@@ -353,12 +353,13 @@ pub fn parse_cfg_attr(
             {
                 (dspan.entire(), AttributeParseErrorReason::ExpectedAtLeastOneArgument)
             } else {
-                (cfg_attr.span, AttributeParseErrorReason::ExpectedList)
+                (cfg_attr.get_normal_item().span, AttributeParseErrorReason::ExpectedList)
             };
 
             sess.dcx().emit_err(AttributeParseError {
                 span,
                 attr_span: cfg_attr.span,
+                inner_span: cfg_attr.get_normal_item().span,
                 template: CFG_ATTR_TEMPLATE,
                 path: AttrPath::from_ast(&cfg_attr.get_normal_item().path, identity),
                 description: ParsedDescription::Attribute,

--- a/compiler/rustc_attr_parsing/src/attributes/crate_level.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/crate_level.rs
@@ -127,7 +127,7 @@ impl SingleAttributeParser for PatternComplexityLimitParser {
     const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
     const STABILITY: AttributeStability = unstable!(
         rustc_attrs,
-        "the `#[pattern_complexity_limit]` attribute is used for rustc unit tests"
+        "the `pattern_complexity_limit` attribute is used for rustc unit tests"
     );
 
     fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {

--- a/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_unimplemented.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_unimplemented.rs
@@ -38,7 +38,7 @@ impl AttributeParser for OnUnimplementedParser {
             template!(List: &[r#"/*opt*/ message = "...", /*opt*/ label = "...", /*opt*/ note = "...""#]),
             unstable!(
                 rustc_attrs,
-                "see `#[diagnostic::on_unimplemented]` for the stable equivalent of this attribute"
+                "see the `diagnostic::on_unimplemented` attribute for the stable equivalent of this attribute"
             ),
             |this, cx, args| {
                 this.parse(cx, args, Mode::RustcOnUnimplemented);

--- a/compiler/rustc_attr_parsing/src/attributes/dummy.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/dummy.rs
@@ -15,7 +15,7 @@ impl SingleAttributeParser for RustcDummyParser {
     const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::ManuallyChecked;
     const TEMPLATE: AttributeTemplate = template!(Word); // Anything, really
     const STABILITY: AttributeStability =
-        unstable!(rustc_attrs, "the `#[rustc_dummy]` attribute is used for rustc unit tests");
+        unstable!(rustc_attrs, "the `rustc_dummy` attribute is used for rustc unit tests");
 
     fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         args.ignore_args();

--- a/compiler/rustc_attr_parsing/src/attributes/inline.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/inline.rs
@@ -70,8 +70,10 @@ impl SingleAttributeParser for RustcForceInlineParser {
         Allow(Target::Fn),
         Allow(Target::Method(MethodKind::Inherent)),
     ]);
-    const STABILITY: AttributeStability =
-        unstable!(rustc_attrs, "`#[rustc_force_inline]` forces a free function to be inlined");
+    const STABILITY: AttributeStability = unstable!(
+        rustc_attrs,
+        "the `rustc_force_inline` attribute forces a free function to be inlined"
+    );
     const TEMPLATE: AttributeTemplate = template!(Word, List: &["reason"], NameValueStr: "reason");
 
     fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {

--- a/compiler/rustc_attr_parsing/src/attributes/rustc_dump.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/rustc_dump.rs
@@ -261,10 +261,8 @@ impl NoArgsAttributeParser for RustcDumpVariancesParser {
         Allow(Target::Struct),
         Allow(Target::Union),
     ]);
-    const STABILITY: AttributeStability = unstable!(
-        rustc_attrs,
-        "the `#[rustc_dump_variances]` attribute is used for rustc unit tests"
-    );
+    const STABILITY: AttributeStability =
+        unstable!(rustc_attrs, "the `rustc_dump_variances` attribute is used for rustc unit tests");
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcDumpVariances;
 }
 

--- a/compiler/rustc_attr_parsing/src/attributes/rustc_internal.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/rustc_internal.rs
@@ -24,7 +24,7 @@ impl NoArgsAttributeParser for RustcMainParser {
     const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[Allow(Target::Fn)]);
     const STABILITY: AttributeStability = unstable!(
         rustc_attrs,
-        "the `#[rustc_main]` attribute is used internally to specify test entry point function"
+        "the `rustc_main` attribute is used internally to specify test entry point function"
     );
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcMain;
 }
@@ -36,7 +36,7 @@ impl SingleAttributeParser for RustcMustImplementOneOfParser {
     const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[Allow(Target::Trait)]);
     const STABILITY: AttributeStability = unstable!(
         rustc_attrs,
-        "the `#[rustc_must_implement_one_of]` attribute is used to change minimal complete definition of a trait. Its syntax and semantics are highly experimental and will be subject to change before stabilization"
+        "the `rustc_must_implement_one_of` attribute is used to change minimal complete definition of a trait. Its syntax and semantics are highly experimental and will be subject to change before stabilization"
     );
     const TEMPLATE: AttributeTemplate = template!(List: &["function1, function2, ..."]);
     fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
@@ -734,7 +734,7 @@ impl NoArgsAttributeParser for RustcNonConstTraitMethodParser {
     ]);
     const STABILITY: AttributeStability = unstable!(
         rustc_attrs,
-        "`#[rustc_non_const_trait_method]` should only used by the standard library to mark trait methods as non-const to allow large traits an easier transition to const"
+        "the `rustc_non_const_trait_method` attribute should only be used by the standard library to mark trait methods as non-const to allow large traits an easier transition to const"
     );
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcNonConstTraitMethod;
 }
@@ -1018,7 +1018,7 @@ impl SingleAttributeParser for RustcDiagnosticItemParser {
     const TEMPLATE: AttributeTemplate = template!(NameValueStr: "name");
     const STABILITY: AttributeStability = unstable!(
         rustc_attrs,
-        "the `#[rustc_diagnostic_item]` attribute allows the compiler to reference types from the standard library for diagnostic purposes"
+        "the `rustc_diagnostic_item` attribute allows the compiler to reference types from the standard library for diagnostic purposes"
     );
 
     fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
@@ -1041,7 +1041,7 @@ impl NoArgsAttributeParser for RustcDoNotConstCheckParser {
     ]);
     const STABILITY: AttributeStability = unstable!(
         rustc_attrs,
-        "`#[rustc_do_not_const_check]` skips const-check for this function's body"
+        "the `rustc_do_not_const_check` attribute skips const-check for this function's body"
     );
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcDoNotConstCheck;
 }
@@ -1053,7 +1053,7 @@ impl NoArgsAttributeParser for RustcNonnullOptimizationGuaranteedParser {
     const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[Allow(Target::Struct)]);
     const STABILITY: AttributeStability = unstable!(
         rustc_attrs,
-        "the `#[rustc_nonnull_optimization_guaranteed]` attribute is just used to document guaranteed niche optimizations in the standard library",
+        "the `rustc_nonnull_optimization_guaranteed` attribute is just used to document guaranteed niche optimizations in the standard library",
         "the compiler does not even check whether the type indeed is being non-null-optimized; it is your responsibility to ensure that the attribute is only used on types that are optimized"
     );
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcNonnullOptimizationGuaranteed;
@@ -1108,7 +1108,7 @@ impl SingleAttributeParser for RustcDocPrimitiveParser {
     const TEMPLATE: AttributeTemplate = template!(NameValueStr: "primitive name");
     const STABILITY: AttributeStability = unstable!(
         rustc_attrs,
-        "the `#[rustc_doc_primitive]` attribute is used by the standard library to provide a way to generate documentation for primitive types"
+        "the `rustc_doc_primitive` attribute is used by the standard library to provide a way to generate documentation for primitive types"
     );
 
     fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
@@ -1154,7 +1154,7 @@ impl NoArgsAttributeParser for RustcCanonicalSymbolParser {
         AllowedTargets::AllowList(&[Allow(Target::ForeignFn)]);
     const STABILITY: AttributeStability = unstable!(
         rustc_attrs,
-        "the `#[rustc_canonical_symbol]` attribute registers a function's symbol to be linted against \
+        "the `rustc_canonical_symbol` attribute registers a function's symbol to be linted against \
         by the `invalid_runtime_symbol_definitions` and `suspicious_runtime_symbol_definitions` \
         lints"
     );

--- a/compiler/rustc_attr_parsing/src/attributes/splat.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/splat.rs
@@ -10,7 +10,6 @@ pub(crate) struct SplatParser;
 impl NoArgsAttributeParser for SplatParser {
     const PATH: &[Symbol] = &[sym::splat];
     const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[Allow(Target::Param)]);
-    const STABILITY: AttributeStability =
-        unstable!(splat, "the `#[splat]` attribute is experimental");
+    const STABILITY: AttributeStability = unstable!(splat, "the `splat` attribute is experimental");
     const CREATE: fn(Span) -> AttributeKind = AttributeKind::Splat;
 }

--- a/compiler/rustc_attr_parsing/src/context.rs
+++ b/compiler/rustc_attr_parsing/src/context.rs
@@ -916,7 +916,7 @@ pub(crate) struct AttributeDiagnosticContext<'a, 'f, 'sess> {
 impl<'a, 'f, 'sess: 'f> AttributeDiagnosticContext<'a, 'f, 'sess> {
     fn emit_parse_error(
         &mut self,
-        span: Span,
+        mut span: Span,
         reason: AttributeParseErrorReason<'_>,
     ) -> ErrorGuaranteed {
         let suggestions = if self.custom_suggestions.is_empty() {
@@ -925,9 +925,16 @@ impl<'a, 'f, 'sess: 'f> AttributeDiagnosticContext<'a, 'f, 'sess> {
             AttributeParseErrorSuggestions::CreatedByParser(mem::take(&mut self.custom_suggestions))
         };
 
+        // If the span is the full attribute (including the `#[`/`]` delimiters) shrink it to
+        // exclude those delimiters, because that's what we want in error messages.
+        if span == self.attr_span {
+            span = self.inner_span;
+        }
+
         self.emit_err(AttributeParseError {
             span,
             attr_span: self.attr_span,
+            inner_span: self.inner_span,
             template: *self.template,
             path: self.attr_path.clone(),
             description: self.parsed_description,

--- a/compiler/rustc_attr_parsing/src/session_diagnostics.rs
+++ b/compiler/rustc_attr_parsing/src/session_diagnostics.rs
@@ -510,6 +510,7 @@ pub enum ParsedDescription {
 pub(crate) struct AttributeParseError<'a> {
     pub(crate) span: Span,
     pub(crate) attr_span: Span,
+    pub(crate) inner_span: Span,
     pub(crate) template: AttributeTemplate,
     pub(crate) path: AttrPath,
     pub(crate) description: ParsedDescription,
@@ -653,7 +654,7 @@ impl<'a, G: EmissionGuarantee> Diagnostic<'a, G> for AttributeParseError<'_> {
         let description = self.description();
 
         let mut diag = Diag::new(dcx, level, format!("malformed `{name}` {description} input"));
-        diag.span(self.attr_span);
+        diag.span(self.inner_span);
         diag.code(E0539);
         match &self.reason {
             AttributeParseErrorReason::ExpectedStringLiteral { byte_string } => {
@@ -728,8 +729,9 @@ impl<'a, G: EmissionGuarantee> Diagnostic<'a, G> for AttributeParseError<'_> {
                 diag.code(E0565);
             }
             AttributeParseErrorReason::ExpectedNameValue(None) => {
-                // If the span is the entire attribute, the suggestion we add below this match already contains enough information
-                if self.span != self.attr_span {
+                // If the span is the entire attribute inner, the suggestion we add below this
+                // match already contains enough information.
+                if self.span != self.inner_span {
                     diag.span_label(self.span, "expected this to be of the form `... = \"...\"`");
                 }
             }

--- a/compiler/rustc_attr_parsing/src/session_diagnostics.rs
+++ b/compiler/rustc_attr_parsing/src/session_diagnostics.rs
@@ -372,17 +372,18 @@ pub(crate) struct EmptyConfusables {
 }
 
 #[derive(Diagnostic)]
-#[help("`#[{$name}{$attribute_args}]` can {$only}be applied to {$applied}")]
-#[diag("`#[{$name}{$attribute_args}]` attribute cannot be used on {$target}")]
+#[help("the `{$name}{$attribute_args}` attribute can {$only}be applied to {$applied}")]
+#[diag("the `{$name}{$attribute_args}` attribute cannot be used on {$target}")]
 pub(crate) struct InvalidTarget {
     #[primary_span]
+    pub span: Span,
     #[suggestion(
         "remove the attribute",
         code = "",
         applicability = "machine-applicable",
         style = "tool-only"
     )]
-    pub span: Span,
+    pub attr_span: Span,
     pub name: AttrPath,
     pub target: &'static str,
     pub applied: DiagArgValue,

--- a/compiler/rustc_attr_parsing/src/stability.rs
+++ b/compiler/rustc_attr_parsing/src/stability.rs
@@ -38,25 +38,25 @@ impl<'sess> AttributeParser<'sess> {
 
         let (explain, default_notes): (String, &[String]) = match gate_name {
             sym::rustc_attrs => ("use of an internal attribute".to_string(), &[
-                format!("the `#[{attr_path}]` attribute is an internal implementation detail that will never be stable"
+                format!("the `{attr_path}` attribute is an internal implementation detail that will never be stable"
             )]),
             sym::staged_api => ("stability attributes may not be used outside of the standard library".to_string(), &[]),
-            sym::custom_mir => ("the `#[custom_mir]` attribute is just used for the Rust test suite".to_string(), &[]),
-            sym::allow_internal_unsafe => ("allow_internal_unsafe side-steps the unsafe_code lint".to_string(), &[]),
-            sym::allow_internal_unstable => ("allow_internal_unstable side-steps feature gating and stability checks".to_string(), &[]),
-            sym::compiler_builtins => ("the `#[compiler_builtins]` attribute is used to identify the `compiler_builtins` crate which contains compiler-rt intrinsics and will never be stable".to_string(), &[]),
+            sym::custom_mir => ("the `custom_mir` attribute is just used for the Rust test suite".to_string(), &[]),
+            sym::allow_internal_unsafe => ("the `allow_internal_unsafe` attribute side-steps the `unsafe_code` lint".to_string(), &[]),
+            sym::allow_internal_unstable => ("the `allow_internal_unstable` attribute side-steps feature gating and stability checks".to_string(), &[]),
+            sym::compiler_builtins => ("the `compiler_builtins` attribute is used to identify the `compiler_builtins` crate which contains compiler-rt intrinsics and will never be stable".to_string(), &[]),
             sym::custom_test_frameworks => ("custom test frameworks are an unstable feature".to_string(), &[]),
             sym::linkage => ("the `linkage` attribute is experimental and not portable across platforms".to_string(), &[]),
-            sym::dropck_eyepatch => ("`may_dangle` has unstable semantics and may be removed in the future".to_string(), &[]),
-            sym::intrinsics => ("the `#[rustc_intrinsic]` attribute is used to declare intrinsics as function items".to_string(), &[]),
+            sym::dropck_eyepatch => ("the `may_dangle` attribute has unstable semantics and may be removed in the future".to_string(), &[]),
+            sym::intrinsics => ("the `rustc_intrinsic` attribute is used to declare intrinsics as function items".to_string(), &[]),
             sym::lang_items => ("lang items are subject to change".to_string(), &[]),
-            sym::prelude_import => ("`#[prelude_import]` is for use by rustc only".to_string(), &[]),
-            sym::profiler_runtime => ("the `#[profiler_runtime]` attribute is used to identify the `profiler_builtins` crate which contains the profiler runtime and will never be stable".to_string(), &[]),
-            sym::thread_local => ("`#[thread_local]` is an experimental feature, and does not currently handle destructors".to_string(), &[]),
-            _ => (format!("the `#[{attr_path}]` attribute is an experimental feature"), &[]),
+            sym::prelude_import => ("the `prelude_import` attribute is for use by rustc only".to_string(), &[]),
+            sym::profiler_runtime => ("the `profiler_runtime` attribute is used to identify the `profiler_builtins` crate which contains the profiler runtime and will never be stable".to_string(), &[]),
+            sym::thread_local => ("the `thread_local` attribute is an experimental feature, and does not currently handle destructors".to_string(), &[]),
+            _ => (format!("the `{attr_path}` attribute is an experimental feature"), &[]),
         };
 
-        let mut diag = feature_err(self.sess, gate_name, attr_span, explain);
+        let mut diag = feature_err(self.sess, gate_name, attr_path.span, explain);
 
         // Remove the suggestion for `#![feature(staged_api)]` as these attributes are currently
         // not usable outside std. If we do ever expose `#[stable]` etc under a different feature

--- a/compiler/rustc_attr_parsing/src/target_checking.rs
+++ b/compiler/rustc_attr_parsing/src/target_checking.rs
@@ -129,7 +129,20 @@ impl<'sess> AttributeParser<'sess> {
         let is_diagnostic_attr = cx.attr_path.segments[0] == sym::diagnostic;
 
         let diag = InvalidTarget {
-            span: cx.attr_span,
+            span: if attribute_args.is_empty() {
+                // Example: for the attribute `#[inline]`, name+attribute_args gives "inline",
+                // and the path span covers `inline` which is just what we want.
+                cx.attr_path.span
+            } else {
+                // Example 1: for the attribute `#[repr(C)]`, name+attribute_args gives
+                // "repr(C)", and the inner span covers `repr(C)` which is just what we want.
+                //
+                // Example 2: for the attribute `#[repr(C, packed)]`, name+attribute_args gives
+                // "repr(C)", and the inner span covers `repr(C, packed)` which doesn't match
+                // exactly but is as close as we can get.
+                cx.inner_span
+            },
+            attr_span: cx.attr_span,
             name: cx.attr_path.clone(),
             target: cx.target.plural_name(),
             only: if only { "only " } else { "" },

--- a/compiler/rustc_expand/src/config.rs
+++ b/compiler/rustc_expand/src/config.rs
@@ -337,6 +337,7 @@ impl<'a> StripUnconfigured<'a> {
                 .to_attr_token_stream(),
         ));
 
+        let attr_item_path_span = attr_item.node.path.span;
         let attr_tokens = Some(LazyAttrTokenStream::new_direct(AttrTokenStream::new(trees)));
         let attr = ast::attr::mk_attr_from_item(
             &self.sess.psess.attr_id_generator,
@@ -346,10 +347,10 @@ impl<'a> StripUnconfigured<'a> {
             attr_item_span,
         );
         if attr.has_name(sym::crate_type) {
-            self.sess.dcx().emit_err(CrateTypeInCfgAttr { span: attr.span });
+            self.sess.dcx().emit_err(CrateTypeInCfgAttr { span: attr_item_path_span });
         }
         if attr.has_name(sym::crate_name) {
-            self.sess.dcx().emit_err(CrateNameInCfgAttr { span: attr.span });
+            self.sess.dcx().emit_err(CrateNameInCfgAttr { span: attr_item_path_span });
         }
         attr
     }

--- a/compiler/rustc_expand/src/diagnostics.rs
+++ b/compiler/rustc_expand/src/diagnostics.rs
@@ -450,14 +450,14 @@ pub(crate) struct GlobDelegationOutsideImpls {
 }
 
 #[derive(Diagnostic)]
-#[diag("`crate_name` within a `#![cfg_attr]` attribute is forbidden")]
+#[diag("the `crate_name` attribute is forbidden within a `cfg_attr` attribute")]
 pub(crate) struct CrateNameInCfgAttr {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
-#[diag("`crate_type` within a `#![cfg_attr]` attribute is forbidden")]
+#[diag("the `crate_type` attribute is forbidden within a `cfg_attr` attribute")]
 pub(crate) struct CrateTypeInCfgAttr {
     #[primary_span]
     pub span: Span,

--- a/src/doc/rustc-dev-guide/src/diagnostics.md
+++ b/src/doc/rustc-dev-guide/src/diagnostics.md
@@ -158,6 +158,9 @@ use an error-level lint instead of a fixed error.
   compiler messages are an important learning tool.
 - When talking about the compiler, call it `the compiler`, not `Rust` or `rustc`.
 - Use the [Oxford comma](https://en.wikipedia.org/wiki/Serial_comma) when writing lists of items.
+- When mentioning attributes, use this form whenever possible: "the `inline` attribute".
+  Don't include `#[`/`#![`/`]` delimiters or attribute arguments in the message or the span unless
+  they are relevant.
 
 ### Lint naming
 

--- a/tests/rustdoc-ui/check-doc-alias-attr.stderr
+++ b/tests/rustdoc-ui/check-doc-alias-attr.stderr
@@ -5,10 +5,10 @@ LL | #[doc(alias)]
    |       ^^^^^
 
 error[E0539]: malformed `doc` attribute input
-  --> $DIR/check-doc-alias-attr.rs:8:1
+  --> $DIR/check-doc-alias-attr.rs:8:3
    |
 LL | #[doc(alias = 0)]
-   | ^^^^^^^^^^^^^^-^^
+   |   ^^^^^^^^^^^^-^
    |               |
    |               expected a string literal here
 
@@ -57,10 +57,10 @@ LL | #[doc(alias = "")]
    |               ^^
 
 error[E0539]: malformed `doc` attribute input
-  --> $DIR/check-doc-alias-attr.rs:19:1
+  --> $DIR/check-doc-alias-attr.rs:19:3
    |
 LL | #[doc(alias(0))]
-   | ^^^^^^^^^^^^-^^^
+   |   ^^^^^^^^^^-^^
    |             |
    |             expected a string literal here
 

--- a/tests/rustdoc-ui/doc-auto-cfg-values-non-ident.stderr
+++ b/tests/rustdoc-ui/doc-auto-cfg-values-non-ident.stderr
@@ -1,8 +1,8 @@
 error[E0565]: malformed `doc` attribute input
-  --> $DIR/doc-auto-cfg-values-non-ident.rs:5:1
+  --> $DIR/doc-auto-cfg-values-non-ident.rs:5:3
    |
 LL | #[doc(auto_cfg(hide(a, values(::b))))]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^---^^^^
    |                               |
    |                               expected a valid identifier here
 

--- a/tests/rustdoc-ui/doc-cfg.stderr
+++ b/tests/rustdoc-ui/doc-cfg.stderr
@@ -1,8 +1,8 @@
 error[E0805]: malformed `doc` attribute input
-  --> $DIR/doc-cfg.rs:4:1
+  --> $DIR/doc-cfg.rs:4:3
    |
 LL | #[doc(cfg(), cfg(foo, bar))]
-   | ^^^^^^^^^--^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^--^^^^^^^^^^^^^^^^
    |          |
    |          expected an argument here
    |
@@ -12,10 +12,10 @@ LL | #[doc(cfg(false), cfg(foo, bar))]
    |           +++++
 
 error[E0805]: malformed `doc` attribute input
-  --> $DIR/doc-cfg.rs:4:1
+  --> $DIR/doc-cfg.rs:4:3
    |
 LL | #[doc(cfg(), cfg(foo, bar))]
-   | ^^^^^^^^^^^^^^^^----------^^
+   |   ^^^^^^^^^^^^^^----------^
    |                 |
    |                 expected a single argument here
    |
@@ -31,10 +31,10 @@ LL + #[doc(cfg(), cfg(any(foo, bar)))]
    |
 
 error[E0805]: malformed `doc` attribute input
-  --> $DIR/doc-cfg.rs:7:1
+  --> $DIR/doc-cfg.rs:7:3
    |
 LL | #[doc(cfg())]
-   | ^^^^^^^^^--^^
+   |   ^^^^^^^--^
    |          |
    |          expected an argument here
    |
@@ -44,10 +44,10 @@ LL | #[doc(cfg(false))]
    |           +++++
 
 error[E0805]: malformed `doc` attribute input
-  --> $DIR/doc-cfg.rs:8:1
+  --> $DIR/doc-cfg.rs:8:3
    |
 LL | #[doc(cfg(foo, bar))]
-   | ^^^^^^^^^----------^^
+   |   ^^^^^^^----------^
    |          |
    |          expected a single argument here
    |
@@ -63,10 +63,10 @@ LL + #[doc(cfg(any(foo, bar)))]
    |
 
 error[E0565]: malformed `doc` attribute input
-  --> $DIR/doc-cfg.rs:9:1
+  --> $DIR/doc-cfg.rs:9:3
    |
 LL | #[doc(auto_cfg(hide(foo::bar)))]
-   | ^^^^^^^^^^^^^^^^^^^^--------^^^^
+   |   ^^^^^^^^^^^^^^^^^^--------^^^
    |                     |
    |                     expected a valid identifier here
 

--- a/tests/rustdoc-ui/invalid-cfg.stderr
+++ b/tests/rustdoc-ui/invalid-cfg.stderr
@@ -1,16 +1,16 @@
 error[E0539]: malformed `doc` attribute input
-  --> $DIR/invalid-cfg.rs:2:1
+  --> $DIR/invalid-cfg.rs:2:3
    |
 LL | #[doc(cfg = "x")]
-   | ^^^^^^^^^^-----^^
+   |   ^^^^^^^^-----^
    |           |
    |           expected this to be a list
 
 error[E0805]: malformed `doc` attribute input
-  --> $DIR/invalid-cfg.rs:3:1
+  --> $DIR/invalid-cfg.rs:3:3
    |
 LL | #[doc(cfg(x, y))]
-   | ^^^^^^^^^------^^
+   |   ^^^^^^^------^
    |          |
    |          expected a single argument here
    |
@@ -26,18 +26,18 @@ LL + #[doc(cfg(any(x, y)))]
    |
 
 error[E0539]: malformed `doc` attribute input
-  --> $DIR/invalid-cfg.rs:7:1
+  --> $DIR/invalid-cfg.rs:7:3
    |
 LL | #[doc(cfg = "x")]
-   | ^^^^^^^^^^-----^^
+   |   ^^^^^^^^-----^
    |           |
    |           expected this to be a list
 
 error[E0805]: malformed `doc` attribute input
-  --> $DIR/invalid-cfg.rs:8:1
+  --> $DIR/invalid-cfg.rs:8:3
    |
 LL | #[doc(cfg(x, y))]
-   | ^^^^^^^^^------^^
+   |   ^^^^^^^------^
    |          |
    |          expected a single argument here
    |
@@ -53,18 +53,18 @@ LL + #[doc(cfg(any(x, y)))]
    |
 
 error[E0539]: malformed `doc` attribute input
-  --> $DIR/invalid-cfg.rs:12:1
+  --> $DIR/invalid-cfg.rs:12:3
    |
 LL | #[doc(cfg = "x")]
-   | ^^^^^^^^^^-----^^
+   |   ^^^^^^^^-----^
    |           |
    |           expected this to be a list
 
 error[E0805]: malformed `doc` attribute input
-  --> $DIR/invalid-cfg.rs:13:1
+  --> $DIR/invalid-cfg.rs:13:3
    |
 LL | #[doc(cfg(x, y))]
-   | ^^^^^^^^^------^^
+   |   ^^^^^^^------^
    |          |
    |          expected a single argument here
    |
@@ -80,18 +80,18 @@ LL + #[doc(cfg(any(x, y)))]
    |
 
 error[E0539]: malformed `doc` attribute input
-  --> $DIR/invalid-cfg.rs:18:1
+  --> $DIR/invalid-cfg.rs:18:3
    |
 LL | #[doc(cfg = "x")]
-   | ^^^^^^^^^^-----^^
+   |   ^^^^^^^^-----^
    |           |
    |           expected this to be a list
 
 error[E0805]: malformed `doc` attribute input
-  --> $DIR/invalid-cfg.rs:19:1
+  --> $DIR/invalid-cfg.rs:19:3
    |
 LL | #[doc(cfg(x, y))]
-   | ^^^^^^^^^------^^
+   |   ^^^^^^^------^
    |          |
    |          expected a single argument here
    |

--- a/tests/rustdoc-ui/lints/doc_cfg_hide-2.stderr
+++ b/tests/rustdoc-ui/lints/doc_cfg_hide-2.stderr
@@ -1,8 +1,8 @@
 error[E0565]: malformed `doc` attribute input
-  --> $DIR/doc_cfg_hide-2.rs:4:1
+  --> $DIR/doc_cfg_hide-2.rs:4:4
    |
 LL | #![doc(auto_cfg(hide(not(windows))))]
-   | ^^^^^^^^^^^^^^^^^^^^^---^^^^^^^^^^^^^
+   |    ^^^^^^^^^^^^^^^^^^---^^^^^^^^^^^^
    |                      |
    |                      expected a valid identifier here
 

--- a/tests/ui/abi/debug.generic.stderr
+++ b/tests/ui/abi/debug.generic.stderr
@@ -1,18 +1,18 @@
-error: `#[rustc_abi]` attribute cannot be used on constants
-  --> $DIR/debug.rs:42:1
+error: the `rustc_abi` attribute cannot be used on constants
+  --> $DIR/debug.rs:42:3
    |
 LL | #[rustc_abi(debug)]
-   | ^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^
    |
-   = help: `#[rustc_abi]` can be applied to functions and type aliases
+   = help: the `rustc_abi` attribute can be applied to functions and type aliases
 
-error: `#[rustc_abi]` attribute cannot be used on associated consts
-  --> $DIR/debug.rs:46:5
+error: the `rustc_abi` attribute cannot be used on associated consts
+  --> $DIR/debug.rs:46:7
    |
 LL |     #[rustc_abi(debug)]
-   |     ^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^
    |
-   = help: `#[rustc_abi]` can be applied to functions and type aliases
+   = help: the `rustc_abi` attribute can be applied to functions and type aliases
 
 error[E0539]: malformed `rustc_abi` attribute input
   --> $DIR/debug.rs:74:1

--- a/tests/ui/abi/debug.generic.stderr
+++ b/tests/ui/abi/debug.generic.stderr
@@ -15,10 +15,10 @@ LL |     #[rustc_abi(debug)]
    = help: the `rustc_abi` attribute can be applied to functions and type aliases
 
 error[E0539]: malformed `rustc_abi` attribute input
-  --> $DIR/debug.rs:74:1
+  --> $DIR/debug.rs:74:3
    |
 LL | #[rustc_abi("assert_eq")]
-   | ^^^^^^^^^^^-------------^
+   |   ^^^^^^^^^-------------
    |            |
    |            valid arguments are `assert_eq` or `debug`
    |

--- a/tests/ui/abi/debug.loongarch64.stderr
+++ b/tests/ui/abi/debug.loongarch64.stderr
@@ -1,18 +1,18 @@
-error: `#[rustc_abi]` attribute cannot be used on constants
-  --> $DIR/debug.rs:42:1
+error: the `rustc_abi` attribute cannot be used on constants
+  --> $DIR/debug.rs:42:3
    |
 LL | #[rustc_abi(debug)]
-   | ^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^
    |
-   = help: `#[rustc_abi]` can be applied to functions and type aliases
+   = help: the `rustc_abi` attribute can be applied to functions and type aliases
 
-error: `#[rustc_abi]` attribute cannot be used on associated consts
-  --> $DIR/debug.rs:46:5
+error: the `rustc_abi` attribute cannot be used on associated consts
+  --> $DIR/debug.rs:46:7
    |
 LL |     #[rustc_abi(debug)]
-   |     ^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^
    |
-   = help: `#[rustc_abi]` can be applied to functions and type aliases
+   = help: the `rustc_abi` attribute can be applied to functions and type aliases
 
 error[E0539]: malformed `rustc_abi` attribute input
   --> $DIR/debug.rs:74:1

--- a/tests/ui/abi/debug.loongarch64.stderr
+++ b/tests/ui/abi/debug.loongarch64.stderr
@@ -15,10 +15,10 @@ LL |     #[rustc_abi(debug)]
    = help: the `rustc_abi` attribute can be applied to functions and type aliases
 
 error[E0539]: malformed `rustc_abi` attribute input
-  --> $DIR/debug.rs:74:1
+  --> $DIR/debug.rs:74:3
    |
 LL | #[rustc_abi("assert_eq")]
-   | ^^^^^^^^^^^-------------^
+   |   ^^^^^^^^^-------------
    |            |
    |            valid arguments are `assert_eq` or `debug`
    |

--- a/tests/ui/abi/debug.riscv64.stderr
+++ b/tests/ui/abi/debug.riscv64.stderr
@@ -1,18 +1,18 @@
-error: `#[rustc_abi]` attribute cannot be used on constants
-  --> $DIR/debug.rs:42:1
+error: the `rustc_abi` attribute cannot be used on constants
+  --> $DIR/debug.rs:42:3
    |
 LL | #[rustc_abi(debug)]
-   | ^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^
    |
-   = help: `#[rustc_abi]` can be applied to functions and type aliases
+   = help: the `rustc_abi` attribute can be applied to functions and type aliases
 
-error: `#[rustc_abi]` attribute cannot be used on associated consts
-  --> $DIR/debug.rs:46:5
+error: the `rustc_abi` attribute cannot be used on associated consts
+  --> $DIR/debug.rs:46:7
    |
 LL |     #[rustc_abi(debug)]
-   |     ^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^
    |
-   = help: `#[rustc_abi]` can be applied to functions and type aliases
+   = help: the `rustc_abi` attribute can be applied to functions and type aliases
 
 error[E0539]: malformed `rustc_abi` attribute input
   --> $DIR/debug.rs:74:1

--- a/tests/ui/abi/debug.riscv64.stderr
+++ b/tests/ui/abi/debug.riscv64.stderr
@@ -15,10 +15,10 @@ LL |     #[rustc_abi(debug)]
    = help: the `rustc_abi` attribute can be applied to functions and type aliases
 
 error[E0539]: malformed `rustc_abi` attribute input
-  --> $DIR/debug.rs:74:1
+  --> $DIR/debug.rs:74:3
    |
 LL | #[rustc_abi("assert_eq")]
-   | ^^^^^^^^^^^-------------^
+   |   ^^^^^^^^^-------------
    |            |
    |            valid arguments are `assert_eq` or `debug`
    |

--- a/tests/ui/abi/debug.rs
+++ b/tests/ui/abi/debug.rs
@@ -39,11 +39,11 @@ type TestFnPtr = fn(bool) -> u8; //~ ERROR: fn_abi
 #[rustc_abi(debug)]
 fn test_generic<T>(_x: *const T) {} //~ ERROR: fn_abi
 
-#[rustc_abi(debug)] //~ ERROR: `#[rustc_abi]` attribute cannot be used on constants
+#[rustc_abi(debug)] //~ ERROR: the `rustc_abi` attribute cannot be used on constants
 const C: () = (); //~ ERROR: `#[rustc_abi]` can only be applied to
 
 impl S {
-    #[rustc_abi(debug)] //~ ERROR: `#[rustc_abi]` attribute cannot be used on assoc
+    #[rustc_abi(debug)] //~ ERROR: the `rustc_abi` attribute cannot be used on assoc
     const C: () = (); //~ ERROR: `#[rustc_abi]` can only be applied to
 }
 

--- a/tests/ui/asm/invalid-repr-simd-on-enum-148634.stderr
+++ b/tests/ui/asm/invalid-repr-simd-on-enum-148634.stderr
@@ -1,10 +1,10 @@
-error: `#[repr(simd)]` attribute cannot be used on enums
-  --> $DIR/invalid-repr-simd-on-enum-148634.rs:6:1
+error: the `repr(simd)` attribute cannot be used on enums
+  --> $DIR/invalid-repr-simd-on-enum-148634.rs:6:3
    |
 LL | #[repr(simd)]
-   | ^^^^^^^^^^^^^
+   |   ^^^^^^^^^^
    |
-   = help: `#[repr(simd)]` can only be applied to structs
+   = help: the `repr(simd)` attribute can only be applied to structs
 
 error[E0084]: unsupported representation for zero-variant enum
   --> $DIR/invalid-repr-simd-on-enum-148634.rs:6:8

--- a/tests/ui/asm/naked-invalid-attr.stderr
+++ b/tests/ui/asm/naked-invalid-attr.stderr
@@ -4,53 +4,53 @@ error[E0433]: cannot find module or crate `a` in the crate root
 LL | #[::a]
    |     ^ use of unresolved module or unlinked crate `a`
 
-error: `#[naked]` attribute cannot be used on crates
-  --> $DIR/naked-invalid-attr.rs:5:1
+error: the `naked` attribute cannot be used on crates
+  --> $DIR/naked-invalid-attr.rs:5:11
    |
 LL | #![unsafe(naked)]
-   | ^^^^^^^^^^^^^^^^^
+   |           ^^^^^
    |
-   = help: `#[naked]` can only be applied to functions
+   = help: the `naked` attribute can only be applied to functions
 
-error: `#[naked]` attribute cannot be used on foreign functions
-  --> $DIR/naked-invalid-attr.rs:10:5
+error: the `naked` attribute cannot be used on foreign functions
+  --> $DIR/naked-invalid-attr.rs:10:14
    |
 LL |     #[unsafe(naked)]
-   |     ^^^^^^^^^^^^^^^^
+   |              ^^^^^
    |
-   = help: `#[naked]` can only be applied to functions with a body
+   = help: the `naked` attribute can only be applied to functions with a body
 
-error: `#[naked]` attribute cannot be used on structs
-  --> $DIR/naked-invalid-attr.rs:14:1
+error: the `naked` attribute cannot be used on structs
+  --> $DIR/naked-invalid-attr.rs:14:10
    |
 LL | #[unsafe(naked)]
-   | ^^^^^^^^^^^^^^^^
+   |          ^^^^^
    |
-   = help: `#[naked]` can only be applied to functions
+   = help: the `naked` attribute can only be applied to functions
 
-error: `#[naked]` attribute cannot be used on struct fields
-  --> $DIR/naked-invalid-attr.rs:17:5
+error: the `naked` attribute cannot be used on struct fields
+  --> $DIR/naked-invalid-attr.rs:17:14
    |
 LL |     #[unsafe(naked)]
-   |     ^^^^^^^^^^^^^^^^
+   |              ^^^^^
    |
-   = help: `#[naked]` can only be applied to functions
+   = help: the `naked` attribute can only be applied to functions
 
-error: `#[naked]` attribute cannot be used on required trait methods
-  --> $DIR/naked-invalid-attr.rs:23:5
+error: the `naked` attribute cannot be used on required trait methods
+  --> $DIR/naked-invalid-attr.rs:23:14
    |
 LL |     #[unsafe(naked)]
-   |     ^^^^^^^^^^^^^^^^
+   |              ^^^^^
    |
-   = help: `#[naked]` can only be applied to functions with a body
+   = help: the `naked` attribute can only be applied to functions with a body
 
-error: `#[naked]` attribute cannot be used on closures
-  --> $DIR/naked-invalid-attr.rs:52:5
+error: the `naked` attribute cannot be used on closures
+  --> $DIR/naked-invalid-attr.rs:52:14
    |
 LL |     #[unsafe(naked)]
-   |     ^^^^^^^^^^^^^^^^
+   |              ^^^^^
    |
-   = help: `#[naked]` can be applied to functions and methods
+   = help: the `naked` attribute can be applied to functions and methods
 
 error[E0736]: attribute incompatible with `#[unsafe(naked)]`
   --> $DIR/naked-invalid-attr.rs:57:3

--- a/tests/ui/asm/naked-with-invalid-repr-attr.stderr
+++ b/tests/ui/asm/naked-with-invalid-repr-attr.stderr
@@ -1,50 +1,50 @@
-error: `#[repr(C)]` attribute cannot be used on functions
-  --> $DIR/naked-with-invalid-repr-attr.rs:10:1
+error: the `repr(C)` attribute cannot be used on functions
+  --> $DIR/naked-with-invalid-repr-attr.rs:10:3
    |
 LL | #[repr(C)]
-   | ^^^^^^^^^^
+   |   ^^^^^^^
    |
-   = help: `#[repr(C)]` can only be applied to data types
+   = help: the `repr(C)` attribute can only be applied to data types
 
-error: `#[repr(transparent)]` attribute cannot be used on functions
-  --> $DIR/naked-with-invalid-repr-attr.rs:17:1
+error: the `repr(transparent)` attribute cannot be used on functions
+  --> $DIR/naked-with-invalid-repr-attr.rs:17:3
    |
 LL | #[repr(transparent)]
-   | ^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^
    |
-   = help: `#[repr(transparent)]` can only be applied to data types
+   = help: the `repr(transparent)` attribute can only be applied to data types
 
-error: `#[repr(C)]` attribute cannot be used on functions
-  --> $DIR/naked-with-invalid-repr-attr.rs:24:1
+error: the `repr(C)` attribute cannot be used on functions
+  --> $DIR/naked-with-invalid-repr-attr.rs:24:3
    |
 LL | #[repr(C)]
-   | ^^^^^^^^^^
+   |   ^^^^^^^
    |
-   = help: `#[repr(C)]` can only be applied to data types
+   = help: the `repr(C)` attribute can only be applied to data types
 
-error: `#[repr(C)]` attribute cannot be used on functions
-  --> $DIR/naked-with-invalid-repr-attr.rs:33:1
+error: the `repr(C)` attribute cannot be used on functions
+  --> $DIR/naked-with-invalid-repr-attr.rs:33:3
    |
 LL | #[repr(C, packed)]
-   | ^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^
    |
-   = help: `#[repr(C)]` can only be applied to data types
+   = help: the `repr(C)` attribute can only be applied to data types
 
-error: `#[repr(packed)]` attribute cannot be used on functions
-  --> $DIR/naked-with-invalid-repr-attr.rs:33:1
+error: the `repr(packed)` attribute cannot be used on functions
+  --> $DIR/naked-with-invalid-repr-attr.rs:33:3
    |
 LL | #[repr(C, packed)]
-   | ^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^
    |
-   = help: `#[repr(packed)]` can only be applied to data types
+   = help: the `repr(packed)` attribute can only be applied to data types
 
-error: `#[repr(u8)]` attribute cannot be used on functions
-  --> $DIR/naked-with-invalid-repr-attr.rs:41:1
+error: the `repr(u8)` attribute cannot be used on functions
+  --> $DIR/naked-with-invalid-repr-attr.rs:41:3
    |
 LL | #[repr(u8)]
-   | ^^^^^^^^^^^
+   |   ^^^^^^^^
    |
-   = help: `#[repr(u8)]` can only be applied to enums
+   = help: the `repr(u8)` attribute can only be applied to enums
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/attributes/align-on-fields-143987.rs
+++ b/tests/ui/attributes/align-on-fields-143987.rs
@@ -7,19 +7,19 @@
 #![feature(fn_align)]
 
 struct Data {
-    #[rustc_align(8)] //~ ERROR `#[rustc_align]` attribute cannot be used on struct fields
+    #[rustc_align(8)] //~ ERROR the `rustc_align` attribute cannot be used on struct fields
     x: usize,
 }
 
 // Test with invalid type to match the original issue more closely
 struct DataInvalid {
-    #[rustc_align(8)] //~ ERROR `#[rustc_align]` attribute cannot be used on struct fields
+    #[rustc_align(8)] //~ ERROR the `rustc_align` attribute cannot be used on struct fields
     x: usize8, //~ ERROR cannot find type `usize8` in this scope
 }
 
 // Test with tuple struct
 struct TupleData(
-    #[rustc_align(32)] //~ ERROR `#[rustc_align]` attribute cannot be used on struct fields
+    #[rustc_align(32)] //~ ERROR `rustc_align` attribute cannot be used on struct fields
     u32
 );
 

--- a/tests/ui/attributes/align-on-fields-143987.stderr
+++ b/tests/ui/attributes/align-on-fields-143987.stderr
@@ -10,29 +10,29 @@ LL -     x: usize8,
 LL +     x: usize,
    |
 
-error: `#[rustc_align]` attribute cannot be used on struct fields
-  --> $DIR/align-on-fields-143987.rs:10:5
+error: the `rustc_align` attribute cannot be used on struct fields
+  --> $DIR/align-on-fields-143987.rs:10:7
    |
 LL |     #[rustc_align(8)]
-   |     ^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^
    |
-   = help: `#[rustc_align]` can only be applied to functions
+   = help: the `rustc_align` attribute can only be applied to functions
 
-error: `#[rustc_align]` attribute cannot be used on struct fields
-  --> $DIR/align-on-fields-143987.rs:16:5
+error: the `rustc_align` attribute cannot be used on struct fields
+  --> $DIR/align-on-fields-143987.rs:16:7
    |
 LL |     #[rustc_align(8)]
-   |     ^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^
    |
-   = help: `#[rustc_align]` can only be applied to functions
+   = help: the `rustc_align` attribute can only be applied to functions
 
-error: `#[rustc_align]` attribute cannot be used on struct fields
-  --> $DIR/align-on-fields-143987.rs:22:5
+error: the `rustc_align` attribute cannot be used on struct fields
+  --> $DIR/align-on-fields-143987.rs:22:7
    |
 LL |     #[rustc_align(32)]
-   |     ^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^
    |
-   = help: `#[rustc_align]` can only be applied to functions
+   = help: the `rustc_align` attribute can only be applied to functions
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/attributes/arg-error-issue-121425.stderr
+++ b/tests/ui/attributes/arg-error-issue-121425.stderr
@@ -1,8 +1,8 @@
 error[E0539]: malformed `repr` attribute input
-  --> $DIR/arg-error-issue-121425.rs:4:1
+  --> $DIR/arg-error-issue-121425.rs:4:3
    |
 LL | #[repr(align(N))]
-   | ^^^^^^^^^^^^^-^^^
+   |   ^^^^^^^^^^^-^^
    |              |
    |              expected an integer literal here
    |
@@ -21,30 +21,30 @@ LL | #[repr(align("str"))]
    |              ^^^^^
 
 error[E0805]: malformed `repr` attribute input
-  --> $DIR/arg-error-issue-121425.rs:16:1
+  --> $DIR/arg-error-issue-121425.rs:16:3
    |
 LL | #[repr(align())]
-   | ^^^^^^^^^^^^--^^
+   |   ^^^^^^^^^^--^
    |             |
    |             expected an argument here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/type-layout.html#representations>
 
 error[E0539]: malformed `repr` attribute input
-  --> $DIR/arg-error-issue-121425.rs:21:1
+  --> $DIR/arg-error-issue-121425.rs:21:3
    |
 LL | #[repr(packed(P))]
-   | ^^^^^^^^^^^^^^-^^^
+   |   ^^^^^^^^^^^^-^^
    |               |
    |               expected an integer literal here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/type-layout.html#representations>
 
 error[E0805]: malformed `repr` attribute input
-  --> $DIR/arg-error-issue-121425.rs:25:1
+  --> $DIR/arg-error-issue-121425.rs:25:3
    |
 LL | #[repr(packed())]
-   | ^^^^^^^^^^^^^--^^
+   |   ^^^^^^^^^^^--^
    |              |
    |              expected an argument here
    |

--- a/tests/ui/attributes/args-checked.stderr
+++ b/tests/ui/attributes/args-checked.stderr
@@ -1,8 +1,8 @@
 error[E0565]: malformed `test_runner` attribute input
-  --> $DIR/args-checked.rs:7:1
+  --> $DIR/args-checked.rs:7:4
    |
 LL | #![test_runner(x = 5)]
-   | ^^^^^^^^^^^^^^^-----^^
+   |    ^^^^^^^^^^^^-----^
    |                |
    |                didn't expect a literal here
    |
@@ -13,10 +13,10 @@ LL + #![test_runner(path)]
    |
 
 error[E0565]: malformed `test_runner` attribute input
-  --> $DIR/args-checked.rs:9:1
+  --> $DIR/args-checked.rs:9:4
    |
 LL | #![test_runner(x(x,y,z))]
-   | ^^^^^^^^^^^^^^^--------^^
+   |    ^^^^^^^^^^^^--------^
    |                |
    |                didn't expect a literal here
    |
@@ -27,10 +27,10 @@ LL + #![test_runner(path)]
    |
 
 error[E0539]: malformed `inline` attribute input
-  --> $DIR/args-checked.rs:12:1
+  --> $DIR/args-checked.rs:12:3
    |
 LL | #[inline(always = 5)]
-   | ^^^^^^^^^----------^^
+   |   ^^^^^^^----------^
    |          |
    |          valid arguments are `always` or `never`
    |
@@ -48,10 +48,10 @@ LL + #[inline]
    |
 
 error[E0539]: malformed `inline` attribute input
-  --> $DIR/args-checked.rs:14:1
+  --> $DIR/args-checked.rs:14:3
    |
 LL | #[inline(always(x, y, z))]
-   | ^^^^^^^^^---------------^^
+   |   ^^^^^^^---------------^
    |          |
    |          valid arguments are `always` or `never`
    |
@@ -69,10 +69,10 @@ LL + #[inline]
    |
 
 error[E0539]: malformed `instruction_set` attribute input
-  --> $DIR/args-checked.rs:16:1
+  --> $DIR/args-checked.rs:16:3
    |
 LL | #[instruction_set(arm::a32 = 5)]
-   | ^^^^^^^^^^^^^^^^^^------------^^
+   |   ^^^^^^^^^^^^^^^^------------^
    |                   |
    |                   valid arguments are `arm::a32` or `arm::t32`
    |
@@ -84,10 +84,10 @@ LL + #[instruction_set(set)]
    |
 
 error[E0539]: malformed `instruction_set` attribute input
-  --> $DIR/args-checked.rs:18:1
+  --> $DIR/args-checked.rs:18:3
    |
 LL | #[instruction_set(arm::a32(x, y, z))]
-   | ^^^^^^^^^^^^^^^^^^-----------------^^
+   |   ^^^^^^^^^^^^^^^^-----------------^
    |                   |
    |                   valid arguments are `arm::a32` or `arm::t32`
    |
@@ -99,10 +99,10 @@ LL + #[instruction_set(set)]
    |
 
 error[E0539]: malformed `optimize` attribute input
-  --> $DIR/args-checked.rs:20:1
+  --> $DIR/args-checked.rs:20:3
    |
 LL | #[optimize(size = 5)]
-   | ^^^^^^^^^^^--------^^
+   |   ^^^^^^^^^--------^
    |            |
    |            valid arguments are `size`, `speed` or `none`
    |
@@ -119,10 +119,10 @@ LL + #[optimize(speed)]
    |
 
 error[E0539]: malformed `optimize` attribute input
-  --> $DIR/args-checked.rs:22:1
+  --> $DIR/args-checked.rs:22:3
    |
 LL | #[optimize(size(x, y, z))]
-   | ^^^^^^^^^^^-------------^^
+   |   ^^^^^^^^^-------------^
    |            |
    |            valid arguments are `size`, `speed` or `none`
    |
@@ -151,10 +151,10 @@ LL | #[optimize(size = 5)]
    | ^^^^^^^^^^^^^^^^^^^^^
 
 error[E0539]: malformed `coverage` attribute input
-  --> $DIR/args-checked.rs:25:1
+  --> $DIR/args-checked.rs:25:3
    |
 LL | #[coverage(off = 5)]
-   | ^^^^^^^^^^^-------^^
+   |   ^^^^^^^^^-------^
    |            |
    |            valid arguments are `on` or `off`
    |
@@ -168,10 +168,10 @@ LL + #[coverage(on)]
    |
 
 error[E0539]: malformed `coverage` attribute input
-  --> $DIR/args-checked.rs:27:1
+  --> $DIR/args-checked.rs:27:3
    |
 LL | #[coverage(off(x, y, z))]
-   | ^^^^^^^^^^^------------^^
+   |   ^^^^^^^^^------------^
    |            |
    |            valid arguments are `on` or `off`
    |
@@ -185,10 +185,10 @@ LL + #[coverage(on)]
    |
 
 error[E0539]: malformed `rustc_abi` attribute input
-  --> $DIR/args-checked.rs:29:1
+  --> $DIR/args-checked.rs:29:3
    |
 LL | #[rustc_abi(debug = 5)]
-   | ^^^^^^^^^^^-----------^
+   |   ^^^^^^^^^-----------
    |            |
    |            valid arguments are `assert_eq` or `debug`
    |
@@ -202,10 +202,10 @@ LL + #[rustc_abi(debug)]
    |
 
 error[E0539]: malformed `rustc_abi` attribute input
-  --> $DIR/args-checked.rs:31:1
+  --> $DIR/args-checked.rs:31:3
    |
 LL | #[rustc_abi(debug(x, y, z))]
-   | ^^^^^^^^^^^----------------^
+   |   ^^^^^^^^^----------------
    |            |
    |            valid arguments are `assert_eq` or `debug`
    |
@@ -231,10 +231,10 @@ LL | #[rustc_allow_const_fn_unstable(x(x, y, z))]
    |                                 ^^^^^^^^^^
 
 error[E0539]: malformed `used` attribute input
-  --> $DIR/args-checked.rs:53:1
+  --> $DIR/args-checked.rs:53:3
    |
 LL | #[used(always = 5)]
-   | ^^^^^^^----------^^
+   |   ^^^^^----------^
    |        |
    |        valid arguments are `compiler` or `linker`
    |
@@ -251,10 +251,10 @@ LL + #[used]
    |
 
 error[E0539]: malformed `used` attribute input
-  --> $DIR/args-checked.rs:55:1
+  --> $DIR/args-checked.rs:55:3
    |
 LL | #[used(always(x, y, z))]
-   | ^^^^^^^---------------^^
+   |   ^^^^^---------------^
    |        |
    |        valid arguments are `compiler` or `linker`
    |
@@ -271,10 +271,10 @@ LL + #[used]
    |
 
 error[E0565]: malformed `rustc_must_implement_one_of` attribute input
-  --> $DIR/args-checked.rs:59:1
+  --> $DIR/args-checked.rs:59:3
    |
 LL | #[rustc_must_implement_one_of(eq = 5, neq)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^------^^^^^^
    |                               |
    |                               expected a valid identifier here
    |
@@ -285,10 +285,10 @@ LL + #[rustc_must_implement_one_of(function1, function2, ...)]
    |
 
 error[E0565]: malformed `rustc_must_implement_one_of` attribute input
-  --> $DIR/args-checked.rs:61:1
+  --> $DIR/args-checked.rs:61:3
    |
 LL | #[rustc_must_implement_one_of(eq(x, y, z), neq)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-----------^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^-----------^^^^^^
    |                               |
    |                               expected a valid identifier here
    |
@@ -299,18 +299,18 @@ LL + #[rustc_must_implement_one_of(function1, function2, ...)]
    |
 
 error[E0565]: malformed `rustc_dump_layout` attribute input
-  --> $DIR/args-checked.rs:67:1
+  --> $DIR/args-checked.rs:67:3
    |
 LL | #[rustc_dump_layout(debug = 5)]
-   | ^^^^^^^^^^^^^^^^^^^^---------^^
+   |   ^^^^^^^^^^^^^^^^^^---------^
    |                     |
    |                     didn't expect a literal here
 
 error[E0565]: malformed `rustc_dump_layout` attribute input
-  --> $DIR/args-checked.rs:69:1
+  --> $DIR/args-checked.rs:69:3
    |
 LL | #[rustc_dump_layout(debug(x, y, z))]
-   | ^^^^^^^^^^^^^^^^^^^^--------------^^
+   |   ^^^^^^^^^^^^^^^^^^--------------^
    |                     |
    |                     didn't expect a literal here
 

--- a/tests/ui/attributes/attr-on-mac-call.stderr
+++ b/tests/ui/attributes/attr-on-mac-call.stderr
@@ -1,10 +1,10 @@
-error: `#[sanitize]` attribute cannot be used on macro calls
-  --> $DIR/attr-on-mac-call.rs:77:5
+error: the `sanitize` attribute cannot be used on macro calls
+  --> $DIR/attr-on-mac-call.rs:77:7
    |
 LL |     #[sanitize(address = "off")]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^
    |
-   = help: `#[sanitize]` can be applied to crates, functions, impl blocks, modules, and statics
+   = help: the `sanitize` attribute can be applied to crates, functions, impl blocks, modules, and statics
    = note: placing this attribute on a macro invocation does nothing even if the macro expands to what would be a valid target for the attribute
 
 error[E0658]: SIMD types are experimental and possibly buggy
@@ -17,13 +17,13 @@ LL |     #[repr(simd)]
    = help: add `#![feature(repr_simd)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error: `#[repr(simd)]` attribute cannot be used on macro calls
-  --> $DIR/attr-on-mac-call.rs:106:5
+error: the `repr(simd)` attribute cannot be used on macro calls
+  --> $DIR/attr-on-mac-call.rs:106:7
    |
 LL |     #[repr(simd)]
-   |     ^^^^^^^^^^^^^
+   |       ^^^^^^^^^^
    |
-   = help: `#[repr(simd)]` can only be applied to structs
+   = help: the `repr(simd)` attribute can only be applied to structs
    = note: placing this attribute on a macro invocation does nothing even if the macro expands to what would be a valid target for the attribute
 
 error: crate-level attribute should be an inner attribute: add an exclamation mark: `#![register_tool]`
@@ -38,13 +38,13 @@ note: this attribute does not have an `!`, which means it is applied to this mac
 LL |     unreachable!();
    |     ^^^^^^^^^^^^^^
 
-warning: `#[export_name]` attribute cannot be used on macro calls
-  --> $DIR/attr-on-mac-call.rs:8:5
+warning: the `export_name` attribute cannot be used on macro calls
+  --> $DIR/attr-on-mac-call.rs:8:7
    |
 LL |     #[export_name = "x"]
-   |     ^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^
    |
-   = help: `#[export_name]` can be applied to functions and statics
+   = help: the `export_name` attribute can be applied to functions and statics
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: placing this attribute on a macro invocation does nothing even if the macro expands to what would be a valid target for the attribute
 note: the lint level is defined here
@@ -53,233 +53,233 @@ note: the lint level is defined here
 LL | #![warn(unused_attributes)]
    |         ^^^^^^^^^^^^^^^^^
 
-warning: `#[naked]` attribute cannot be used on macro calls
-  --> $DIR/attr-on-mac-call.rs:11:5
+warning: the `naked` attribute cannot be used on macro calls
+  --> $DIR/attr-on-mac-call.rs:11:14
    |
 LL |     #[unsafe(naked)]
-   |     ^^^^^^^^^^^^^^^^
+   |              ^^^^^
    |
-   = help: `#[naked]` can only be applied to functions
+   = help: the `naked` attribute can only be applied to functions
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: placing this attribute on a macro invocation does nothing even if the macro expands to what would be a valid target for the attribute
 
-warning: `#[track_caller]` attribute cannot be used on macro calls
-  --> $DIR/attr-on-mac-call.rs:14:5
+warning: the `track_caller` attribute cannot be used on macro calls
+  --> $DIR/attr-on-mac-call.rs:14:7
    |
 LL |     #[track_caller]
-   |     ^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^
    |
-   = help: `#[track_caller]` can only be applied to functions
+   = help: the `track_caller` attribute can only be applied to functions
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: placing this attribute on a macro invocation does nothing even if the macro expands to what would be a valid target for the attribute
 
-warning: `#[used]` attribute cannot be used on macro calls
-  --> $DIR/attr-on-mac-call.rs:17:5
+warning: the `used` attribute cannot be used on macro calls
+  --> $DIR/attr-on-mac-call.rs:17:7
    |
 LL |     #[used]
-   |     ^^^^^^^
+   |       ^^^^
    |
-   = help: `#[used]` can only be applied to statics
+   = help: the `used` attribute can only be applied to statics
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: placing this attribute on a macro invocation does nothing even if the macro expands to what would be a valid target for the attribute
 
-warning: `#[target_feature]` attribute cannot be used on macro calls
-  --> $DIR/attr-on-mac-call.rs:20:5
+warning: the `target_feature` attribute cannot be used on macro calls
+  --> $DIR/attr-on-mac-call.rs:20:7
    |
 LL |     #[target_feature(enable = "x")]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^
    |
-   = help: `#[target_feature]` can only be applied to functions
+   = help: the `target_feature` attribute can only be applied to functions
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: placing this attribute on a macro invocation does nothing even if the macro expands to what would be a valid target for the attribute
 
-warning: `#[deprecated]` attribute cannot be used on macro calls
-  --> $DIR/attr-on-mac-call.rs:23:5
+warning: the `deprecated` attribute cannot be used on macro calls
+  --> $DIR/attr-on-mac-call.rs:23:7
    |
 LL |     #[deprecated]
-   |     ^^^^^^^^^^^^^
+   |       ^^^^^^^^^^
    |
-   = help: `#[deprecated]` can be applied to associated consts, associated types, constants, crates, data types, enum variants, foreign statics, functions, inherent impl blocks, macro defs, modules, statics, struct fields, traits, type aliases, and use statements
+   = help: the `deprecated` attribute can be applied to associated consts, associated types, constants, crates, data types, enum variants, foreign statics, functions, inherent impl blocks, macro defs, modules, statics, struct fields, traits, type aliases, and use statements
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: placing this attribute on a macro invocation does nothing even if the macro expands to what would be a valid target for the attribute
 
-warning: `#[inline]` attribute cannot be used on macro calls
-  --> $DIR/attr-on-mac-call.rs:26:5
+warning: the `inline` attribute cannot be used on macro calls
+  --> $DIR/attr-on-mac-call.rs:26:7
    |
 LL |     #[inline]
-   |     ^^^^^^^^^
+   |       ^^^^^^
    |
-   = help: `#[inline]` can only be applied to functions
+   = help: the `inline` attribute can only be applied to functions
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: placing this attribute on a macro invocation does nothing even if the macro expands to what would be a valid target for the attribute
 
-warning: `#[link_name]` attribute cannot be used on macro calls
-  --> $DIR/attr-on-mac-call.rs:29:5
+warning: the `link_name` attribute cannot be used on macro calls
+  --> $DIR/attr-on-mac-call.rs:29:7
    |
 LL |     #[link_name = "x"]
-   |     ^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^
    |
-   = help: `#[link_name]` can be applied to foreign functions and foreign statics
+   = help: the `link_name` attribute can be applied to foreign functions and foreign statics
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: placing this attribute on a macro invocation does nothing even if the macro expands to what would be a valid target for the attribute
 
-warning: `#[link_section]` attribute cannot be used on macro calls
-  --> $DIR/attr-on-mac-call.rs:32:5
+warning: the `link_section` attribute cannot be used on macro calls
+  --> $DIR/attr-on-mac-call.rs:32:7
    |
 LL |     #[link_section = "__TEXT,__text"]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^
    |
-   = help: `#[link_section]` can be applied to functions and statics
+   = help: the `link_section` attribute can be applied to functions and statics
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: placing this attribute on a macro invocation does nothing even if the macro expands to what would be a valid target for the attribute
 
-warning: `#[link_ordinal]` attribute cannot be used on macro calls
-  --> $DIR/attr-on-mac-call.rs:35:5
+warning: the `link_ordinal` attribute cannot be used on macro calls
+  --> $DIR/attr-on-mac-call.rs:35:7
    |
 LL |     #[link_ordinal(42)]
-   |     ^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^
    |
-   = help: `#[link_ordinal]` can be applied to foreign functions and foreign statics
+   = help: the `link_ordinal` attribute can be applied to foreign functions and foreign statics
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: placing this attribute on a macro invocation does nothing even if the macro expands to what would be a valid target for the attribute
 
-warning: `#[non_exhaustive]` attribute cannot be used on macro calls
-  --> $DIR/attr-on-mac-call.rs:38:5
+warning: the `non_exhaustive` attribute cannot be used on macro calls
+  --> $DIR/attr-on-mac-call.rs:38:7
    |
 LL |     #[non_exhaustive]
-   |     ^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^
    |
-   = help: `#[non_exhaustive]` can be applied to data types and enum variants
+   = help: the `non_exhaustive` attribute can be applied to data types and enum variants
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: placing this attribute on a macro invocation does nothing even if the macro expands to what would be a valid target for the attribute
 
-warning: `#[proc_macro]` attribute cannot be used on macro calls
-  --> $DIR/attr-on-mac-call.rs:41:5
+warning: the `proc_macro` attribute cannot be used on macro calls
+  --> $DIR/attr-on-mac-call.rs:41:7
    |
 LL |     #[proc_macro]
-   |     ^^^^^^^^^^^^^
+   |       ^^^^^^^^^^
    |
-   = help: `#[proc_macro]` can only be applied to functions
+   = help: the `proc_macro` attribute can only be applied to functions
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: placing this attribute on a macro invocation does nothing even if the macro expands to what would be a valid target for the attribute
 
-warning: `#[cold]` attribute cannot be used on macro calls
-  --> $DIR/attr-on-mac-call.rs:44:5
+warning: the `cold` attribute cannot be used on macro calls
+  --> $DIR/attr-on-mac-call.rs:44:7
    |
 LL |     #[cold]
-   |     ^^^^^^^
+   |       ^^^^
    |
-   = help: `#[cold]` can only be applied to functions
+   = help: the `cold` attribute can only be applied to functions
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: placing this attribute on a macro invocation does nothing even if the macro expands to what would be a valid target for the attribute
 
-warning: `#[no_mangle]` attribute cannot be used on macro calls
-  --> $DIR/attr-on-mac-call.rs:47:5
+warning: the `no_mangle` attribute cannot be used on macro calls
+  --> $DIR/attr-on-mac-call.rs:47:7
    |
 LL |     #[no_mangle]
-   |     ^^^^^^^^^^^^
+   |       ^^^^^^^^^
    |
-   = help: `#[no_mangle]` can be applied to functions and statics
+   = help: the `no_mangle` attribute can be applied to functions and statics
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: placing this attribute on a macro invocation does nothing even if the macro expands to what would be a valid target for the attribute
 
-warning: `#[deprecated]` attribute cannot be used on macro calls
-  --> $DIR/attr-on-mac-call.rs:50:5
+warning: the `deprecated` attribute cannot be used on macro calls
+  --> $DIR/attr-on-mac-call.rs:50:7
    |
 LL |     #[deprecated]
-   |     ^^^^^^^^^^^^^
+   |       ^^^^^^^^^^
    |
-   = help: `#[deprecated]` can be applied to associated consts, associated types, constants, crates, data types, enum variants, foreign statics, functions, inherent impl blocks, macro defs, modules, statics, struct fields, traits, type aliases, and use statements
+   = help: the `deprecated` attribute can be applied to associated consts, associated types, constants, crates, data types, enum variants, foreign statics, functions, inherent impl blocks, macro defs, modules, statics, struct fields, traits, type aliases, and use statements
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: placing this attribute on a macro invocation does nothing even if the macro expands to what would be a valid target for the attribute
 
-warning: `#[automatically_derived]` attribute cannot be used on macro calls
-  --> $DIR/attr-on-mac-call.rs:53:5
+warning: the `automatically_derived` attribute cannot be used on macro calls
+  --> $DIR/attr-on-mac-call.rs:53:7
    |
 LL |     #[automatically_derived]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[automatically_derived]` can only be applied to trait impl blocks
+   = help: the `automatically_derived` attribute can only be applied to trait impl blocks
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: placing this attribute on a macro invocation does nothing even if the macro expands to what would be a valid target for the attribute
 
-warning: `#[macro_use]` attribute cannot be used on macro calls
-  --> $DIR/attr-on-mac-call.rs:56:5
+warning: the `macro_use` attribute cannot be used on macro calls
+  --> $DIR/attr-on-mac-call.rs:56:7
    |
 LL |     #[macro_use]
-   |     ^^^^^^^^^^^^
+   |       ^^^^^^^^^
    |
-   = help: `#[macro_use]` can be applied to extern crates and modules
+   = help: the `macro_use` attribute can be applied to extern crates and modules
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: placing this attribute on a macro invocation does nothing even if the macro expands to what would be a valid target for the attribute
 
-warning: `#[must_use]` attribute cannot be used on macro calls
-  --> $DIR/attr-on-mac-call.rs:59:5
+warning: the `must_use` attribute cannot be used on macro calls
+  --> $DIR/attr-on-mac-call.rs:59:7
    |
 LL |     #[must_use]
-   |     ^^^^^^^^^^^
+   |       ^^^^^^^^
    |
-   = help: `#[must_use]` can be applied to data types, functions, and traits
+   = help: the `must_use` attribute can be applied to data types, functions, and traits
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: placing this attribute on a macro invocation does nothing even if the macro expands to what would be a valid target for the attribute
 
-warning: `#[no_implicit_prelude]` attribute cannot be used on macro calls
-  --> $DIR/attr-on-mac-call.rs:62:5
+warning: the `no_implicit_prelude` attribute cannot be used on macro calls
+  --> $DIR/attr-on-mac-call.rs:62:7
    |
 LL |     #[no_implicit_prelude]
-   |     ^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[no_implicit_prelude]` can be applied to crates and modules
+   = help: the `no_implicit_prelude` attribute can be applied to crates and modules
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: placing this attribute on a macro invocation does nothing even if the macro expands to what would be a valid target for the attribute
 
-warning: `#[path]` attribute cannot be used on macro calls
-  --> $DIR/attr-on-mac-call.rs:65:5
+warning: the `path` attribute cannot be used on macro calls
+  --> $DIR/attr-on-mac-call.rs:65:7
    |
 LL |     #[path = ""]
-   |     ^^^^^^^^^^^^
+   |       ^^^^
    |
-   = help: `#[path]` can only be applied to modules
+   = help: the `path` attribute can only be applied to modules
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: placing this attribute on a macro invocation does nothing even if the macro expands to what would be a valid target for the attribute
 
-warning: `#[ignore]` attribute cannot be used on macro calls
-  --> $DIR/attr-on-mac-call.rs:68:5
+warning: the `ignore` attribute cannot be used on macro calls
+  --> $DIR/attr-on-mac-call.rs:68:7
    |
 LL |     #[ignore]
-   |     ^^^^^^^^^
+   |       ^^^^^^
    |
-   = help: `#[ignore]` can only be applied to functions
+   = help: the `ignore` attribute can only be applied to functions
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: placing this attribute on a macro invocation does nothing even if the macro expands to what would be a valid target for the attribute
 
-warning: `#[should_panic]` attribute cannot be used on macro calls
-  --> $DIR/attr-on-mac-call.rs:71:5
+warning: the `should_panic` attribute cannot be used on macro calls
+  --> $DIR/attr-on-mac-call.rs:71:7
    |
 LL |     #[should_panic]
-   |     ^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^
    |
-   = help: `#[should_panic]` can only be applied to functions
+   = help: the `should_panic` attribute can only be applied to functions
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: placing this attribute on a macro invocation does nothing even if the macro expands to what would be a valid target for the attribute
 
-warning: `#[link_name]` attribute cannot be used on macro calls
-  --> $DIR/attr-on-mac-call.rs:74:5
+warning: the `link_name` attribute cannot be used on macro calls
+  --> $DIR/attr-on-mac-call.rs:74:7
    |
 LL |     #[link_name = "x"]
-   |     ^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^
    |
-   = help: `#[link_name]` can be applied to foreign functions and foreign statics
+   = help: the `link_name` attribute can be applied to foreign functions and foreign statics
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: placing this attribute on a macro invocation does nothing even if the macro expands to what would be a valid target for the attribute
 
-warning: `#[repr()]` attribute cannot be used on macro calls
-  --> $DIR/attr-on-mac-call.rs:81:5
+warning: the `repr()` attribute cannot be used on macro calls
+  --> $DIR/attr-on-mac-call.rs:81:7
    |
 LL |     #[repr()]
-   |     ^^^^^^^^^
+   |       ^^^^^^
    |
-   = help: `#[repr()]` can only be applied to data types
+   = help: the `repr()` attribute can only be applied to data types
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: placing this attribute on a macro invocation does nothing even if the macro expands to what would be a valid target for the attribute
 
@@ -291,53 +291,53 @@ LL |     #[repr()]
    |
    = note: using `repr` with an empty list has no effect
 
-warning: `#[repr(u8)]` attribute cannot be used on macro calls
-  --> $DIR/attr-on-mac-call.rs:86:5
+warning: the `repr(u8)` attribute cannot be used on macro calls
+  --> $DIR/attr-on-mac-call.rs:86:7
    |
 LL |     #[repr(u8)]
-   |     ^^^^^^^^^^^
+   |       ^^^^^^^^
    |
-   = help: `#[repr(u8)]` can only be applied to enums
+   = help: the `repr(u8)` attribute can only be applied to enums
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: placing this attribute on a macro invocation does nothing even if the macro expands to what would be a valid target for the attribute
 
-warning: `#[repr(align(...))]` attribute cannot be used on macro calls
-  --> $DIR/attr-on-mac-call.rs:90:5
+warning: the `repr(align(...))` attribute cannot be used on macro calls
+  --> $DIR/attr-on-mac-call.rs:90:7
    |
 LL |     #[repr(align(8))]
-   |     ^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^
    |
-   = help: `#[repr(align(...))]` can only be applied to data types
+   = help: the `repr(align(...))` attribute can only be applied to data types
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: placing this attribute on a macro invocation does nothing even if the macro expands to what would be a valid target for the attribute
 
-warning: `#[repr(packed)]` attribute cannot be used on macro calls
-  --> $DIR/attr-on-mac-call.rs:94:5
+warning: the `repr(packed)` attribute cannot be used on macro calls
+  --> $DIR/attr-on-mac-call.rs:94:7
    |
 LL |     #[repr(packed)]
-   |     ^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^
    |
-   = help: `#[repr(packed)]` can only be applied to data types
+   = help: the `repr(packed)` attribute can only be applied to data types
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: placing this attribute on a macro invocation does nothing even if the macro expands to what would be a valid target for the attribute
 
-warning: `#[repr(C)]` attribute cannot be used on macro calls
-  --> $DIR/attr-on-mac-call.rs:98:5
+warning: the `repr(C)` attribute cannot be used on macro calls
+  --> $DIR/attr-on-mac-call.rs:98:7
    |
 LL |     #[repr(C)]
-   |     ^^^^^^^^^^
+   |       ^^^^^^^
    |
-   = help: `#[repr(C)]` can only be applied to data types
+   = help: the `repr(C)` attribute can only be applied to data types
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: placing this attribute on a macro invocation does nothing even if the macro expands to what would be a valid target for the attribute
 
-warning: `#[repr(Rust)]` attribute cannot be used on macro calls
-  --> $DIR/attr-on-mac-call.rs:102:5
+warning: the `repr(Rust)` attribute cannot be used on macro calls
+  --> $DIR/attr-on-mac-call.rs:102:7
    |
 LL |     #[repr(Rust)]
-   |     ^^^^^^^^^^^^^
+   |       ^^^^^^^^^^
    |
-   = help: `#[repr(Rust)]` can only be applied to data types
+   = help: the `repr(Rust)` attribute can only be applied to data types
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: placing this attribute on a macro invocation does nothing even if the macro expands to what would be a valid target for the attribute
 

--- a/tests/ui/attributes/attribute-on-wrong-item-inline-repr.stderr
+++ b/tests/ui/attributes/attribute-on-wrong-item-inline-repr.stderr
@@ -1,10 +1,10 @@
-error: `#[inline]` attribute cannot be used on statements
-  --> $DIR/attribute-on-wrong-item-inline-repr.rs:7:5
+error: the `inline` attribute cannot be used on statements
+  --> $DIR/attribute-on-wrong-item-inline-repr.rs:7:7
    |
 LL |     #[inline]
-   |     ^^^^^^^^^
+   |       ^^^^^^
    |
-   = help: `#[inline]` can only be applied to functions
+   = help: the `inline` attribute can only be applied to functions
 
 error[E0539]: malformed `inline` attribute input
   --> $DIR/attribute-on-wrong-item-inline-repr.rs:12:5
@@ -27,13 +27,13 @@ LL -     #[inline(XYZ)]
 LL +     #[inline]
    |
 
-error: `#[inline]` attribute cannot be used on statements
-  --> $DIR/attribute-on-wrong-item-inline-repr.rs:12:5
+error: the `inline` attribute cannot be used on statements
+  --> $DIR/attribute-on-wrong-item-inline-repr.rs:12:7
    |
 LL |     #[inline(XYZ)]
-   |     ^^^^^^^^^^^^^^
+   |       ^^^^^^
    |
-   = help: `#[inline]` can only be applied to functions
+   = help: the `inline` attribute can only be applied to functions
 
 error[E0539]: malformed `repr` attribute input
   --> $DIR/attribute-on-wrong-item-inline-repr.rs:17:5
@@ -84,13 +84,13 @@ LL -     #[inline(ABC)]
 LL +     #[inline]
    |
 
-error: `#[inline]` attribute cannot be used on expressions
-  --> $DIR/attribute-on-wrong-item-inline-repr.rs:33:5
+error: the `inline` attribute cannot be used on expressions
+  --> $DIR/attribute-on-wrong-item-inline-repr.rs:33:7
    |
 LL |     #[inline(ABC)]
-   |     ^^^^^^^^^^^^^^
+   |       ^^^^^^
    |
-   = help: `#[inline]` can only be applied to functions
+   = help: the `inline` attribute can only be applied to functions
 
 error[E0539]: malformed `repr` attribute input
   --> $DIR/attribute-on-wrong-item-inline-repr.rs:38:14

--- a/tests/ui/attributes/attribute-on-wrong-item-inline-repr.stderr
+++ b/tests/ui/attributes/attribute-on-wrong-item-inline-repr.stderr
@@ -7,10 +7,10 @@ LL |     #[inline]
    = help: the `inline` attribute can only be applied to functions
 
 error[E0539]: malformed `inline` attribute input
-  --> $DIR/attribute-on-wrong-item-inline-repr.rs:12:5
+  --> $DIR/attribute-on-wrong-item-inline-repr.rs:12:7
    |
 LL |     #[inline(XYZ)]
-   |     ^^^^^^^^^---^^
+   |       ^^^^^^^---^
    |              |
    |              valid arguments are `always` or `never`
    |
@@ -36,38 +36,38 @@ LL |     #[inline(XYZ)]
    = help: the `inline` attribute can only be applied to functions
 
 error[E0539]: malformed `repr` attribute input
-  --> $DIR/attribute-on-wrong-item-inline-repr.rs:17:5
+  --> $DIR/attribute-on-wrong-item-inline-repr.rs:17:7
    |
 LL |     #[repr(nothing)]
-   |     ^^^^^^^-------^^
+   |       ^^^^^-------^
    |            |
    |            valid arguments are `align`, `packed`, `Rust`, `C`, `simd`, `transparent`, `i8`, `u8`, `i16`, `u16`, `i32`, `u32`, `i64`, `u64`, `i128`, `u128`, `isize` or `usize`
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/type-layout.html#representations>
 
 error[E0539]: malformed `repr` attribute input
-  --> $DIR/attribute-on-wrong-item-inline-repr.rs:21:5
+  --> $DIR/attribute-on-wrong-item-inline-repr.rs:21:7
    |
 LL |     #[repr(something_not_real)]
-   |     ^^^^^^^------------------^^
+   |       ^^^^^------------------^
    |            |
    |            valid arguments are `align`, `packed`, `Rust`, `C`, `simd`, `transparent`, `i8`, `u8`, `i16`, `u16`, `i32`, `u32`, `i64`, `u64`, `i128`, `u128`, `isize` or `usize`
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/type-layout.html#representations>
 
 error[E0539]: malformed `repr` attribute input
-  --> $DIR/attribute-on-wrong-item-inline-repr.rs:27:5
+  --> $DIR/attribute-on-wrong-item-inline-repr.rs:27:7
    |
 LL |     #[repr]
-   |     ^^^^^^^ expected this to be a list
+   |       ^^^^ expected this to be a list
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/type-layout.html#representations>
 
 error[E0539]: malformed `inline` attribute input
-  --> $DIR/attribute-on-wrong-item-inline-repr.rs:33:5
+  --> $DIR/attribute-on-wrong-item-inline-repr.rs:33:7
    |
 LL |     #[inline(ABC)]
-   |     ^^^^^^^^^---^^
+   |       ^^^^^^^---^
    |              |
    |              valid arguments are `always` or `never`
    |
@@ -93,10 +93,10 @@ LL |     #[inline(ABC)]
    = help: the `inline` attribute can only be applied to functions
 
 error[E0539]: malformed `repr` attribute input
-  --> $DIR/attribute-on-wrong-item-inline-repr.rs:38:14
+  --> $DIR/attribute-on-wrong-item-inline-repr.rs:38:16
    |
 LL |     let _z = #[repr] 1;
-   |              ^^^^^^^ expected this to be a list
+   |                ^^^^ expected this to be a list
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/type-layout.html#representations>
 

--- a/tests/ui/attributes/attrs-on-params.stderr
+++ b/tests/ui/attributes/attrs-on-params.stderr
@@ -4,13 +4,13 @@ error: allow, cfg, cfg_attr, deny, expect, forbid, and warn are the only allowed
 LL | fn function(#[inline] param: u32) {
    |             ^^^^^^^^^
 
-error: `#[inline]` attribute cannot be used on function params
-  --> $DIR/attrs-on-params.rs:3:13
+error: the `inline` attribute cannot be used on function params
+  --> $DIR/attrs-on-params.rs:3:15
    |
 LL | fn function(#[inline] param: u32) {
-   |             ^^^^^^^^^
+   |               ^^^^^^
    |
-   = help: `#[inline]` can only be applied to functions
+   = help: the `inline` attribute can only be applied to functions
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/attributes/codegen_attr_on_required_trait_method.stderr
+++ b/tests/ui/attributes/codegen_attr_on_required_trait_method.stderr
@@ -1,10 +1,10 @@
-error: `#[cold]` attribute cannot be used on required trait methods
-  --> $DIR/codegen_attr_on_required_trait_method.rs:6:5
+error: the `cold` attribute cannot be used on required trait methods
+  --> $DIR/codegen_attr_on_required_trait_method.rs:6:7
    |
 LL |     #[cold]
-   |     ^^^^^^^
+   |       ^^^^
    |
-   = help: `#[cold]` can be applied to foreign functions and functions with a body
+   = help: the `cold` attribute can be applied to foreign functions and functions with a body
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 note: the lint level is defined here
   --> $DIR/codegen_attr_on_required_trait_method.rs:1:9
@@ -12,22 +12,22 @@ note: the lint level is defined here
 LL | #![deny(unused_attributes)]
    |         ^^^^^^^^^^^^^^^^^
 
-error: `#[link_section]` attribute cannot be used on required trait methods
-  --> $DIR/codegen_attr_on_required_trait_method.rs:10:5
+error: the `link_section` attribute cannot be used on required trait methods
+  --> $DIR/codegen_attr_on_required_trait_method.rs:10:7
    |
 LL |     #[link_section = "__TEXT,__text"]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^
    |
-   = help: `#[link_section]` can be applied to functions with a body and statics
+   = help: the `link_section` attribute can be applied to functions with a body and statics
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-error: `#[linkage]` attribute cannot be used on required trait methods
-  --> $DIR/codegen_attr_on_required_trait_method.rs:14:5
+error: the `linkage` attribute cannot be used on required trait methods
+  --> $DIR/codegen_attr_on_required_trait_method.rs:14:7
    |
 LL |     #[linkage = "common"]
-   |     ^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^
    |
-   = help: `#[linkage]` can be applied to foreign functions, foreign statics, functions with a body, and statics
+   = help: the `linkage` attribute can be applied to foreign functions, foreign statics, functions with a body, and statics
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 error: aborting due to 3 previous errors

--- a/tests/ui/attributes/cold-attribute-application-54044.stderr
+++ b/tests/ui/attributes/cold-attribute-application-54044.stderr
@@ -1,10 +1,10 @@
-error: `#[cold]` attribute cannot be used on structs
-  --> $DIR/cold-attribute-application-54044.rs:4:1
+error: the `cold` attribute cannot be used on structs
+  --> $DIR/cold-attribute-application-54044.rs:4:3
    |
 LL | #[cold]
-   | ^^^^^^^
+   |   ^^^^
    |
-   = help: `#[cold]` can only be applied to functions
+   = help: the `cold` attribute can only be applied to functions
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 note: the lint level is defined here
   --> $DIR/cold-attribute-application-54044.rs:2:9
@@ -12,13 +12,13 @@ note: the lint level is defined here
 LL | #![deny(unused_attributes)]
    |         ^^^^^^^^^^^^^^^^^
 
-error: `#[cold]` attribute cannot be used on expressions
-  --> $DIR/cold-attribute-application-54044.rs:10:5
+error: the `cold` attribute cannot be used on expressions
+  --> $DIR/cold-attribute-application-54044.rs:10:7
    |
 LL |     #[cold]
-   |     ^^^^^^^
+   |       ^^^^
    |
-   = help: `#[cold]` can only be applied to functions
+   = help: the `cold` attribute can only be applied to functions
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 error: aborting due to 2 previous errors

--- a/tests/ui/attributes/collapse-debuginfo-invalid.rs
+++ b/tests/ui/attributes/collapse-debuginfo-invalid.rs
@@ -5,80 +5,80 @@
 // Test that the `#[collapse_debuginfo]` attribute can only be used on macro definitions.
 
 #[collapse_debuginfo(yes)]
-//~^ ERROR `#[collapse_debuginfo]` attribute cannot be used on
+//~^ ERROR the `collapse_debuginfo` attribute cannot be used on
 extern crate std;
 
 #[collapse_debuginfo(yes)]
-//~^ ERROR `#[collapse_debuginfo]` attribute cannot be used on
+//~^ ERROR the `collapse_debuginfo` attribute cannot be used on
 use std::collections::HashMap;
 
 #[collapse_debuginfo(yes)]
-//~^ ERROR `#[collapse_debuginfo]` attribute cannot be used on
+//~^ ERROR the `collapse_debuginfo` attribute cannot be used on
 static FOO: u32 = 3;
 
 #[collapse_debuginfo(yes)]
-//~^ ERROR `#[collapse_debuginfo]` attribute cannot be used on
+//~^ ERROR the `collapse_debuginfo` attribute cannot be used on
 const BAR: u32 = 3;
 
 #[collapse_debuginfo(yes)]
-//~^ ERROR `#[collapse_debuginfo]` attribute cannot be used on
+//~^ ERROR the `collapse_debuginfo` attribute cannot be used on
 fn foo() {
     let _ = #[collapse_debuginfo(yes)] || { };
-    //~^ ERROR `#[collapse_debuginfo]` attribute cannot be used on
+    //~^ ERROR the `collapse_debuginfo` attribute cannot be used on
     #[collapse_debuginfo(yes)]
-    //~^ ERROR `#[collapse_debuginfo]` attribute cannot be used on
+    //~^ ERROR the `collapse_debuginfo` attribute cannot be used on
     let _ = 3;
     let _ = #[collapse_debuginfo(yes)] 3;
-    //~^ ERROR `#[collapse_debuginfo]` attribute cannot be used on
+    //~^ ERROR the `collapse_debuginfo` attribute cannot be used on
     match (3, 4) {
         #[collapse_debuginfo(yes)]
-        //~^ ERROR `#[collapse_debuginfo]` attribute cannot be used on
+        //~^ ERROR the `collapse_debuginfo` attribute cannot be used on
         _ => (),
     }
 }
 
 #[collapse_debuginfo(yes)]
-//~^ ERROR `#[collapse_debuginfo]` attribute cannot be used on
+//~^ ERROR the `collapse_debuginfo` attribute cannot be used on
 mod bar {
 }
 
 #[collapse_debuginfo(yes)]
-//~^ ERROR `#[collapse_debuginfo]` attribute cannot be used on
+//~^ ERROR the `collapse_debuginfo` attribute cannot be used on
 type Map = HashMap<u32, u32>;
 
 #[collapse_debuginfo(yes)]
-//~^ ERROR `#[collapse_debuginfo]` attribute cannot be used on
+//~^ ERROR the `collapse_debuginfo` attribute cannot be used on
 enum Foo {
     #[collapse_debuginfo(yes)]
-    //~^ ERROR `#[collapse_debuginfo]` attribute cannot be used on
+    //~^ ERROR the `collapse_debuginfo` attribute cannot be used on
     Variant,
 }
 
 #[collapse_debuginfo(yes)]
-//~^ ERROR `#[collapse_debuginfo]` attribute cannot be used on
+//~^ ERROR the `collapse_debuginfo` attribute cannot be used on
 struct Bar {
     #[collapse_debuginfo(yes)]
-    //~^ ERROR `#[collapse_debuginfo]` attribute cannot be used on
+    //~^ ERROR the `collapse_debuginfo` attribute cannot be used on
     field: u32,
 }
 
 #[collapse_debuginfo(yes)]
-//~^ ERROR `#[collapse_debuginfo]` attribute cannot be used on
+//~^ ERROR the `collapse_debuginfo` attribute cannot be used on
 union Qux {
     a: u32,
     b: u16
 }
 
 #[collapse_debuginfo(yes)]
-//~^ ERROR `#[collapse_debuginfo]` attribute cannot be used on
+//~^ ERROR the `collapse_debuginfo` attribute cannot be used on
 trait Foobar {
     #[collapse_debuginfo(yes)]
-    //~^ ERROR `#[collapse_debuginfo]` attribute cannot be used on
+    //~^ ERROR the `collapse_debuginfo` attribute cannot be used on
     type Bar;
 }
 
 #[collapse_debuginfo(yes)]
-//~^ ERROR `#[collapse_debuginfo]` attribute cannot be used on
+//~^ ERROR the `collapse_debuginfo` attribute cannot be used on
 type AFoobar = impl Foobar;
 
 impl Foobar for Bar {
@@ -91,14 +91,14 @@ fn constraining() -> AFoobar {
 }
 
 #[collapse_debuginfo(yes)]
-//~^ ERROR `#[collapse_debuginfo]` attribute cannot be used on
+//~^ ERROR the `collapse_debuginfo` attribute cannot be used on
 impl Bar {
     #[collapse_debuginfo(yes)]
-    //~^ ERROR `#[collapse_debuginfo]` attribute cannot be used on
+    //~^ ERROR the `collapse_debuginfo` attribute cannot be used on
     const FOO: u32 = 3;
 
     #[collapse_debuginfo(yes)]
-    //~^ ERROR `#[collapse_debuginfo]` attribute cannot be used on
+    //~^ ERROR the `collapse_debuginfo` attribute cannot be used on
     fn bar(&self) {}
 }
 

--- a/tests/ui/attributes/collapse-debuginfo-invalid.stderr
+++ b/tests/ui/attributes/collapse-debuginfo-invalid.stderr
@@ -1,178 +1,178 @@
-error: `#[collapse_debuginfo]` attribute cannot be used on extern crates
-  --> $DIR/collapse-debuginfo-invalid.rs:7:1
+error: the `collapse_debuginfo` attribute cannot be used on extern crates
+  --> $DIR/collapse-debuginfo-invalid.rs:7:3
    |
 LL | #[collapse_debuginfo(yes)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[collapse_debuginfo]` can only be applied to macro defs
+   = help: the `collapse_debuginfo` attribute can only be applied to macro defs
 
-error: `#[collapse_debuginfo]` attribute cannot be used on use statements
-  --> $DIR/collapse-debuginfo-invalid.rs:11:1
+error: the `collapse_debuginfo` attribute cannot be used on use statements
+  --> $DIR/collapse-debuginfo-invalid.rs:11:3
    |
 LL | #[collapse_debuginfo(yes)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[collapse_debuginfo]` can only be applied to macro defs
+   = help: the `collapse_debuginfo` attribute can only be applied to macro defs
 
-error: `#[collapse_debuginfo]` attribute cannot be used on statics
-  --> $DIR/collapse-debuginfo-invalid.rs:15:1
+error: the `collapse_debuginfo` attribute cannot be used on statics
+  --> $DIR/collapse-debuginfo-invalid.rs:15:3
    |
 LL | #[collapse_debuginfo(yes)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[collapse_debuginfo]` can only be applied to macro defs
+   = help: the `collapse_debuginfo` attribute can only be applied to macro defs
 
-error: `#[collapse_debuginfo]` attribute cannot be used on constants
-  --> $DIR/collapse-debuginfo-invalid.rs:19:1
+error: the `collapse_debuginfo` attribute cannot be used on constants
+  --> $DIR/collapse-debuginfo-invalid.rs:19:3
    |
 LL | #[collapse_debuginfo(yes)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[collapse_debuginfo]` can only be applied to macro defs
+   = help: the `collapse_debuginfo` attribute can only be applied to macro defs
 
-error: `#[collapse_debuginfo]` attribute cannot be used on functions
-  --> $DIR/collapse-debuginfo-invalid.rs:23:1
+error: the `collapse_debuginfo` attribute cannot be used on functions
+  --> $DIR/collapse-debuginfo-invalid.rs:23:3
    |
 LL | #[collapse_debuginfo(yes)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[collapse_debuginfo]` can only be applied to macro defs
+   = help: the `collapse_debuginfo` attribute can only be applied to macro defs
 
-error: `#[collapse_debuginfo]` attribute cannot be used on closures
-  --> $DIR/collapse-debuginfo-invalid.rs:26:13
+error: the `collapse_debuginfo` attribute cannot be used on closures
+  --> $DIR/collapse-debuginfo-invalid.rs:26:15
    |
 LL |     let _ = #[collapse_debuginfo(yes)] || { };
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |               ^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[collapse_debuginfo]` can only be applied to macro defs
+   = help: the `collapse_debuginfo` attribute can only be applied to macro defs
 
-error: `#[collapse_debuginfo]` attribute cannot be used on statements
-  --> $DIR/collapse-debuginfo-invalid.rs:28:5
+error: the `collapse_debuginfo` attribute cannot be used on statements
+  --> $DIR/collapse-debuginfo-invalid.rs:28:7
    |
 LL |     #[collapse_debuginfo(yes)]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[collapse_debuginfo]` can only be applied to macro defs
+   = help: the `collapse_debuginfo` attribute can only be applied to macro defs
 
-error: `#[collapse_debuginfo]` attribute cannot be used on expressions
-  --> $DIR/collapse-debuginfo-invalid.rs:31:13
+error: the `collapse_debuginfo` attribute cannot be used on expressions
+  --> $DIR/collapse-debuginfo-invalid.rs:31:15
    |
 LL |     let _ = #[collapse_debuginfo(yes)] 3;
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |               ^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[collapse_debuginfo]` can only be applied to macro defs
+   = help: the `collapse_debuginfo` attribute can only be applied to macro defs
 
-error: `#[collapse_debuginfo]` attribute cannot be used on match arms
-  --> $DIR/collapse-debuginfo-invalid.rs:34:9
+error: the `collapse_debuginfo` attribute cannot be used on match arms
+  --> $DIR/collapse-debuginfo-invalid.rs:34:11
    |
 LL |         #[collapse_debuginfo(yes)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |           ^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[collapse_debuginfo]` can only be applied to macro defs
+   = help: the `collapse_debuginfo` attribute can only be applied to macro defs
 
-error: `#[collapse_debuginfo]` attribute cannot be used on modules
-  --> $DIR/collapse-debuginfo-invalid.rs:40:1
+error: the `collapse_debuginfo` attribute cannot be used on modules
+  --> $DIR/collapse-debuginfo-invalid.rs:40:3
    |
 LL | #[collapse_debuginfo(yes)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[collapse_debuginfo]` can only be applied to macro defs
+   = help: the `collapse_debuginfo` attribute can only be applied to macro defs
 
-error: `#[collapse_debuginfo]` attribute cannot be used on type aliases
-  --> $DIR/collapse-debuginfo-invalid.rs:45:1
+error: the `collapse_debuginfo` attribute cannot be used on type aliases
+  --> $DIR/collapse-debuginfo-invalid.rs:45:3
    |
 LL | #[collapse_debuginfo(yes)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[collapse_debuginfo]` can only be applied to macro defs
+   = help: the `collapse_debuginfo` attribute can only be applied to macro defs
 
-error: `#[collapse_debuginfo]` attribute cannot be used on enums
-  --> $DIR/collapse-debuginfo-invalid.rs:49:1
+error: the `collapse_debuginfo` attribute cannot be used on enums
+  --> $DIR/collapse-debuginfo-invalid.rs:49:3
    |
 LL | #[collapse_debuginfo(yes)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[collapse_debuginfo]` can only be applied to macro defs
+   = help: the `collapse_debuginfo` attribute can only be applied to macro defs
 
-error: `#[collapse_debuginfo]` attribute cannot be used on enum variants
-  --> $DIR/collapse-debuginfo-invalid.rs:52:5
+error: the `collapse_debuginfo` attribute cannot be used on enum variants
+  --> $DIR/collapse-debuginfo-invalid.rs:52:7
    |
 LL |     #[collapse_debuginfo(yes)]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[collapse_debuginfo]` can only be applied to macro defs
+   = help: the `collapse_debuginfo` attribute can only be applied to macro defs
 
-error: `#[collapse_debuginfo]` attribute cannot be used on structs
-  --> $DIR/collapse-debuginfo-invalid.rs:57:1
+error: the `collapse_debuginfo` attribute cannot be used on structs
+  --> $DIR/collapse-debuginfo-invalid.rs:57:3
    |
 LL | #[collapse_debuginfo(yes)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[collapse_debuginfo]` can only be applied to macro defs
+   = help: the `collapse_debuginfo` attribute can only be applied to macro defs
 
-error: `#[collapse_debuginfo]` attribute cannot be used on struct fields
-  --> $DIR/collapse-debuginfo-invalid.rs:60:5
+error: the `collapse_debuginfo` attribute cannot be used on struct fields
+  --> $DIR/collapse-debuginfo-invalid.rs:60:7
    |
 LL |     #[collapse_debuginfo(yes)]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[collapse_debuginfo]` can only be applied to macro defs
+   = help: the `collapse_debuginfo` attribute can only be applied to macro defs
 
-error: `#[collapse_debuginfo]` attribute cannot be used on unions
-  --> $DIR/collapse-debuginfo-invalid.rs:65:1
+error: the `collapse_debuginfo` attribute cannot be used on unions
+  --> $DIR/collapse-debuginfo-invalid.rs:65:3
    |
 LL | #[collapse_debuginfo(yes)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[collapse_debuginfo]` can only be applied to macro defs
+   = help: the `collapse_debuginfo` attribute can only be applied to macro defs
 
-error: `#[collapse_debuginfo]` attribute cannot be used on traits
-  --> $DIR/collapse-debuginfo-invalid.rs:72:1
+error: the `collapse_debuginfo` attribute cannot be used on traits
+  --> $DIR/collapse-debuginfo-invalid.rs:72:3
    |
 LL | #[collapse_debuginfo(yes)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[collapse_debuginfo]` can only be applied to macro defs
+   = help: the `collapse_debuginfo` attribute can only be applied to macro defs
 
-error: `#[collapse_debuginfo]` attribute cannot be used on associated types
-  --> $DIR/collapse-debuginfo-invalid.rs:75:5
+error: the `collapse_debuginfo` attribute cannot be used on associated types
+  --> $DIR/collapse-debuginfo-invalid.rs:75:7
    |
 LL |     #[collapse_debuginfo(yes)]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[collapse_debuginfo]` can only be applied to macro defs
+   = help: the `collapse_debuginfo` attribute can only be applied to macro defs
 
-error: `#[collapse_debuginfo]` attribute cannot be used on type aliases
-  --> $DIR/collapse-debuginfo-invalid.rs:80:1
+error: the `collapse_debuginfo` attribute cannot be used on type aliases
+  --> $DIR/collapse-debuginfo-invalid.rs:80:3
    |
 LL | #[collapse_debuginfo(yes)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[collapse_debuginfo]` can only be applied to macro defs
+   = help: the `collapse_debuginfo` attribute can only be applied to macro defs
 
-error: `#[collapse_debuginfo]` attribute cannot be used on inherent impl blocks
-  --> $DIR/collapse-debuginfo-invalid.rs:93:1
+error: the `collapse_debuginfo` attribute cannot be used on inherent impl blocks
+  --> $DIR/collapse-debuginfo-invalid.rs:93:3
    |
 LL | #[collapse_debuginfo(yes)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[collapse_debuginfo]` can only be applied to macro defs
+   = help: the `collapse_debuginfo` attribute can only be applied to macro defs
 
-error: `#[collapse_debuginfo]` attribute cannot be used on associated consts
-  --> $DIR/collapse-debuginfo-invalid.rs:96:5
+error: the `collapse_debuginfo` attribute cannot be used on associated consts
+  --> $DIR/collapse-debuginfo-invalid.rs:96:7
    |
 LL |     #[collapse_debuginfo(yes)]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[collapse_debuginfo]` can only be applied to macro defs
+   = help: the `collapse_debuginfo` attribute can only be applied to macro defs
 
-error: `#[collapse_debuginfo]` attribute cannot be used on inherent methods
-  --> $DIR/collapse-debuginfo-invalid.rs:100:5
+error: the `collapse_debuginfo` attribute cannot be used on inherent methods
+  --> $DIR/collapse-debuginfo-invalid.rs:100:7
    |
 LL |     #[collapse_debuginfo(yes)]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[collapse_debuginfo]` can only be applied to macro defs
+   = help: the `collapse_debuginfo` attribute can only be applied to macro defs
 
 error: aborting due to 22 previous errors
 

--- a/tests/ui/attributes/const-stability-on-macro.stderr
+++ b/tests/ui/attributes/const-stability-on-macro.stderr
@@ -1,18 +1,18 @@
-error: `#[rustc_const_stable]` attribute cannot be used on macro defs
-  --> $DIR/const-stability-on-macro.rs:4:1
+error: the `rustc_const_stable` attribute cannot be used on macro defs
+  --> $DIR/const-stability-on-macro.rs:4:3
    |
 LL | #[rustc_const_stable(feature = "foo", since = "3.3.3")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_const_stable]` can be applied to associated consts, constants, crates, functions, impl blocks, statics, traits, and use statements
+   = help: the `rustc_const_stable` attribute can be applied to associated consts, constants, crates, functions, impl blocks, statics, traits, and use statements
 
-error: `#[rustc_const_unstable]` attribute cannot be used on macro defs
-  --> $DIR/const-stability-on-macro.rs:10:1
+error: the `rustc_const_unstable` attribute cannot be used on macro defs
+  --> $DIR/const-stability-on-macro.rs:10:3
    |
 LL | #[rustc_const_unstable(feature = "bar", issue = "none")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_const_unstable]` can be applied to associated consts, constants, crates, functions, impl blocks, statics, traits, and use statements
+   = help: the `rustc_const_unstable` attribute can be applied to associated consts, constants, crates, functions, impl blocks, statics, traits, and use statements
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/attributes/crate-type-delimited.stderr
+++ b/tests/ui/attributes/crate-type-delimited.stderr
@@ -1,8 +1,8 @@
 error[E0539]: malformed `crate_type` attribute input
-  --> $DIR/crate-type-delimited.rs:2:1
+  --> $DIR/crate-type-delimited.rs:2:4
    |
 LL | #![crate_type(lib)]
-   | ^^^^^^^^^^^^^^^^^^^
+   |    ^^^^^^^^^^^^^^^
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/linkage.html>
 help: must be of the form

--- a/tests/ui/attributes/crate-type-empty.stderr
+++ b/tests/ui/attributes/crate-type-empty.stderr
@@ -1,8 +1,8 @@
 error[E0539]: malformed `crate_type` attribute input
-  --> $DIR/crate-type-empty.rs:2:1
+  --> $DIR/crate-type-empty.rs:2:4
    |
 LL | #![crate_type]
-   | ^^^^^^^^^^^^^^
+   |    ^^^^^^^^^^
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/linkage.html>
 help: must be of the form

--- a/tests/ui/attributes/crate-type-non-crate.stderr
+++ b/tests/ui/attributes/crate-type-non-crate.stderr
@@ -1,8 +1,8 @@
 error[E0539]: malformed `crate_type` attribute input
-  --> $DIR/crate-type-non-crate.rs:5:1
+  --> $DIR/crate-type-non-crate.rs:5:3
    |
 LL | #[crate_type]
-   | ^^^^^^^^^^^^^
+   |   ^^^^^^^^^^
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/linkage.html>
 help: must be of the form
@@ -11,10 +11,10 @@ LL | #[crate_type = "crate type"]
    |              ++++++++++++++
 
 error[E0539]: malformed `crate_type` attribute input
-  --> $DIR/crate-type-non-crate.rs:7:1
+  --> $DIR/crate-type-non-crate.rs:7:3
    |
 LL | #[crate_type(lib)]
-   | ^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/linkage.html>
 help: must be of the form
@@ -24,10 +24,10 @@ LL + #[crate_type = "crate type"]
    |
 
 error[E0539]: malformed `crate_type` attribute input
-  --> $DIR/crate-type-non-crate.rs:8:1
+  --> $DIR/crate-type-non-crate.rs:8:3
    |
 LL | #[crate_type("lib")]
-   | ^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/linkage.html>
 help: must be of the form
@@ -48,10 +48,10 @@ LL | #[crate_type = "lib"]
    |                +   +
 
 error[E0539]: malformed `crate_type` attribute input
-  --> $DIR/crate-type-non-crate.rs:12:1
+  --> $DIR/crate-type-non-crate.rs:12:3
    |
 LL | #[crate_type(foo)]
-   | ^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/linkage.html>
 help: must be of the form
@@ -61,10 +61,10 @@ LL + #[crate_type = "crate type"]
    |
 
 error[E0539]: malformed `crate_type` attribute input
-  --> $DIR/crate-type-non-crate.rs:13:1
+  --> $DIR/crate-type-non-crate.rs:13:3
    |
 LL | #[crate_type("foo")]
-   | ^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/linkage.html>
 help: must be of the form
@@ -85,10 +85,10 @@ LL | #[crate_type = "foo"]
    |                +   +
 
 error[E0539]: malformed `crate_type` attribute input
-  --> $DIR/crate-type-non-crate.rs:17:1
+  --> $DIR/crate-type-non-crate.rs:17:3
    |
 LL | #[crate_type(1)]
-   | ^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/linkage.html>
 help: must be of the form
@@ -98,10 +98,10 @@ LL + #[crate_type = "crate type"]
    |
 
 error[E0539]: malformed `crate_type` attribute input
-  --> $DIR/crate-type-non-crate.rs:18:1
+  --> $DIR/crate-type-non-crate.rs:18:3
    |
 LL | #[crate_type = 1]
-   | ^^^^^^^^^^^^^^^-^
+   |   ^^^^^^^^^^^^^-
    |                |
    |                expected a string literal here
    |

--- a/tests/ui/attributes/dont-allow-inline-and-repr-at-invalid-positions.stderr
+++ b/tests/ui/attributes/dont-allow-inline-and-repr-at-invalid-positions.stderr
@@ -1,18 +1,18 @@
-error: `#[inline]` attribute cannot be used on structs
-  --> $DIR/dont-allow-inline-and-repr-at-invalid-positions.rs:3:5
+error: the `inline` attribute cannot be used on structs
+  --> $DIR/dont-allow-inline-and-repr-at-invalid-positions.rs:3:7
    |
 LL |     #[inline] struct Foo;
-   |     ^^^^^^^^^
+   |       ^^^^^^
    |
-   = help: `#[inline]` can only be applied to functions
+   = help: the `inline` attribute can only be applied to functions
 
-error: `#[repr(C)]` attribute cannot be used on functions
-  --> $DIR/dont-allow-inline-and-repr-at-invalid-positions.rs:4:5
+error: the `repr(C)` attribute cannot be used on functions
+  --> $DIR/dont-allow-inline-and-repr-at-invalid-positions.rs:4:7
    |
 LL |     #[repr(C)] fn foo() {}
-   |     ^^^^^^^^^^
+   |       ^^^^^^^
    |
-   = help: `#[repr(C)]` can only be applied to data types
+   = help: the `repr(C)` attribute can only be applied to data types
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/attributes/empty-repr.stderr
+++ b/tests/ui/attributes/empty-repr.stderr
@@ -1,10 +1,10 @@
-error: `#[repr()]` attribute cannot be used on where predicates
-  --> $DIR/empty-repr.rs:10:1
+error: the `repr()` attribute cannot be used on where predicates
+  --> $DIR/empty-repr.rs:10:3
    |
 LL | #[repr()]
-   | ^^^^^^^^^
+   |   ^^^^^^
    |
-   = help: `#[repr()]` can only be applied to data types
+   = help: the `repr()` attribute can only be applied to data types
 
 error: unused attribute
   --> $DIR/empty-repr.rs:10:1

--- a/tests/ui/attributes/expected-word.stderr
+++ b/tests/ui/attributes/expected-word.stderr
@@ -1,8 +1,8 @@
 error[E0565]: malformed `cold` attribute input
-  --> $DIR/expected-word.rs:1:1
+  --> $DIR/expected-word.rs:1:3
    |
 LL | #[cold = true]
-   | ^^^^^^^------^
+   |   ^^^^^------
    |        |
    |        didn't expect any arguments here
    |

--- a/tests/ui/attributes/export/exportable.binary.stderr
+++ b/tests/ui/attributes/export/exportable.binary.stderr
@@ -1,18 +1,18 @@
-error: `#[export_stable]` attribute cannot be used on traits
-  --> $DIR/exportable.rs:135:5
+error: the `export_stable` attribute cannot be used on traits
+  --> $DIR/exportable.rs:135:7
    |
 LL |     #[export_stable]
-   |     ^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^
    |
-   = help: `#[export_stable]` can be applied to associated types, data types, functions, inherent impl blocks, modules, type aliases, and use statements
+   = help: the `export_stable` attribute can be applied to associated types, data types, functions, inherent impl blocks, modules, type aliases, and use statements
 
-error: `#[export_stable]` attribute cannot be used on constants
-  --> $DIR/exportable.rs:139:5
+error: the `export_stable` attribute cannot be used on constants
+  --> $DIR/exportable.rs:139:7
    |
 LL |     #[export_stable]
-   |     ^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^
    |
-   = help: `#[export_stable]` can be applied to associated types, data types, functions, inherent impl blocks, modules, type aliases, and use statements
+   = help: the `export_stable` attribute can be applied to associated types, data types, functions, inherent impl blocks, modules, type aliases, and use statements
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/attributes/export/exportable.sdylib.stderr
+++ b/tests/ui/attributes/export/exportable.sdylib.stderr
@@ -1,18 +1,18 @@
-error: `#[export_stable]` attribute cannot be used on traits
-  --> $DIR/exportable.rs:135:5
+error: the `export_stable` attribute cannot be used on traits
+  --> $DIR/exportable.rs:135:7
    |
 LL |     #[export_stable]
-   |     ^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^
    |
-   = help: `#[export_stable]` can be applied to associated types, data types, functions, inherent impl blocks, modules, type aliases, and use statements
+   = help: the `export_stable` attribute can be applied to associated types, data types, functions, inherent impl blocks, modules, type aliases, and use statements
 
-error: `#[export_stable]` attribute cannot be used on constants
-  --> $DIR/exportable.rs:139:5
+error: the `export_stable` attribute cannot be used on constants
+  --> $DIR/exportable.rs:139:7
    |
 LL |     #[export_stable]
-   |     ^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^
    |
-   = help: `#[export_stable]` can be applied to associated types, data types, functions, inherent impl blocks, modules, type aliases, and use statements
+   = help: the `export_stable` attribute can be applied to associated types, data types, functions, inherent impl blocks, modules, type aliases, and use statements
 
 error: private items are not exportable
   --> $DIR/exportable.rs:15:5

--- a/tests/ui/attributes/inline-attribute-enum-variant-error.stderr
+++ b/tests/ui/attributes/inline-attribute-enum-variant-error.stderr
@@ -1,10 +1,10 @@
-error: `#[inline]` attribute cannot be used on enum variants
-  --> $DIR/inline-attribute-enum-variant-error.rs:4:5
+error: the `inline` attribute cannot be used on enum variants
+  --> $DIR/inline-attribute-enum-variant-error.rs:4:7
    |
 LL |     #[inline]
-   |     ^^^^^^^^^
+   |       ^^^^^^
    |
-   = help: `#[inline]` can only be applied to functions
+   = help: the `inline` attribute can only be applied to functions
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/attributes/inline/attr-usage-inline.stderr
+++ b/tests/ui/attributes/inline/attr-usage-inline.stderr
@@ -1,10 +1,10 @@
-error: `#[inline]` attribute cannot be used on structs
-  --> $DIR/attr-usage-inline.rs:7:1
+error: the `inline` attribute cannot be used on structs
+  --> $DIR/attr-usage-inline.rs:7:3
    |
 LL | #[inline]
-   | ^^^^^^^^^
+   |   ^^^^^^
    |
-   = help: `#[inline]` can only be applied to functions
+   = help: the `inline` attribute can only be applied to functions
 
 error[E0518]: attribute should be applied to function or closure
   --> $DIR/attr-usage-inline.rs:25:1
@@ -12,32 +12,32 @@ error[E0518]: attribute should be applied to function or closure
 LL | #[inline]
    | ^^^^^^^^^ not a function or closure
 
-warning: `#[inline]` attribute cannot be used on struct fields
-  --> $DIR/attr-usage-inline.rs:11:5
+warning: the `inline` attribute cannot be used on struct fields
+  --> $DIR/attr-usage-inline.rs:11:7
    |
 LL |     #[inline]
-   |     ^^^^^^^^^
+   |       ^^^^^^
    |
-   = help: `#[inline]` can only be applied to functions
+   = help: the `inline` attribute can only be applied to functions
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: requested on the command line with `-W unused-attributes`
 
-warning: `#[inline]` attribute cannot be used on macro defs
-  --> $DIR/attr-usage-inline.rs:18:1
+warning: the `inline` attribute cannot be used on macro defs
+  --> $DIR/attr-usage-inline.rs:18:3
    |
 LL | #[inline]
-   | ^^^^^^^^^
+   |   ^^^^^^
    |
-   = help: `#[inline]` can only be applied to functions
+   = help: the `inline` attribute can only be applied to functions
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[inline]` attribute cannot be used on macro defs
-  --> $DIR/attr-usage-inline.rs:25:1
+warning: the `inline` attribute cannot be used on macro defs
+  --> $DIR/attr-usage-inline.rs:25:3
    |
 LL | #[inline]
-   | ^^^^^^^^^
+   |   ^^^^^^
    |
-   = help: `#[inline]` can only be applied to functions
+   = help: the `inline` attribute can only be applied to functions
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 error: aborting due to 2 previous errors; 3 warnings emitted

--- a/tests/ui/attributes/inline/invalid-inline.stderr
+++ b/tests/ui/attributes/inline/invalid-inline.stderr
@@ -1,8 +1,8 @@
 error[E0805]: malformed `inline` attribute input
-  --> $DIR/invalid-inline.rs:3:1
+  --> $DIR/invalid-inline.rs:3:3
    |
 LL | #[inline(please,no)]
-   | ^^^^^^^^-----------^
+   |   ^^^^^^-----------
    |         |
    |         expected a single argument here
    |
@@ -20,10 +20,10 @@ LL + #[inline]
    |
 
 error[E0805]: malformed `inline` attribute input
-  --> $DIR/invalid-inline.rs:7:1
+  --> $DIR/invalid-inline.rs:7:3
    |
 LL | #[inline()]
-   | ^^^^^^^^--^
+   |   ^^^^^^--
    |         |
    |         expected an argument here
    |

--- a/tests/ui/attributes/instruction-set.stderr
+++ b/tests/ui/attributes/instruction-set.stderr
@@ -1,8 +1,8 @@
 error[E0539]: malformed `instruction_set` attribute input
-  --> $DIR/instruction-set.rs:21:1
+  --> $DIR/instruction-set.rs:21:3
    |
 LL | #[instruction_set(arm)]
-   | ^^^^^^^^^^^^^^^^^^---^^
+   |   ^^^^^^^^^^^^^^^^---^
    |                   |
    |                   valid arguments are `arm::a32` or `arm::t32`
    |
@@ -20,10 +20,10 @@ LL | #[instruction_set(arm::)]
    |                      ^^ expected identifier
 
 error[E0539]: malformed `instruction_set` attribute input
-  --> $DIR/instruction-set.rs:31:1
+  --> $DIR/instruction-set.rs:31:3
    |
 LL | #[instruction_set(arm::magic)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^-----^^
+   |   ^^^^^^^^^^^^^^^^^^^^^-----^
    |                        |
    |                        valid arguments are `a32` or `t32`
    |

--- a/tests/ui/attributes/instrument_fn.stderr
+++ b/tests/ui/attributes/instrument_fn.stderr
@@ -18,61 +18,61 @@ LL |     let _x = #[instrument_fn = "on"]
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error: `#[instrument_fn]` attribute cannot be used on crates
-  --> $DIR/instrument_fn.rs:2:1
+error: the `instrument_fn` attribute cannot be used on crates
+  --> $DIR/instrument_fn.rs:2:4
    |
 LL | #![instrument_fn = "off"]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |    ^^^^^^^^^^^^^
    |
-   = help: `#[instrument_fn]` can only be applied to functions
+   = help: the `instrument_fn` attribute can only be applied to functions
 
-error: `#[instrument_fn]` attribute cannot be used on structs
-  --> $DIR/instrument_fn.rs:4:1
+error: the `instrument_fn` attribute cannot be used on structs
+  --> $DIR/instrument_fn.rs:4:3
    |
 LL | #[instrument_fn = "on"]
-   | ^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^
    |
-   = help: `#[instrument_fn]` can only be applied to functions
+   = help: the `instrument_fn` attribute can only be applied to functions
 
-error: `#[instrument_fn]` attribute cannot be used on modules
-  --> $DIR/instrument_fn.rs:7:1
+error: the `instrument_fn` attribute cannot be used on modules
+  --> $DIR/instrument_fn.rs:7:3
    |
 LL | #[instrument_fn = "on"]
-   | ^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^
    |
-   = help: `#[instrument_fn]` can only be applied to functions
+   = help: the `instrument_fn` attribute can only be applied to functions
 
-error: `#[instrument_fn]` attribute cannot be used on inherent impl blocks
-  --> $DIR/instrument_fn.rs:10:1
+error: the `instrument_fn` attribute cannot be used on inherent impl blocks
+  --> $DIR/instrument_fn.rs:10:3
    |
 LL | #[instrument_fn = "on"]
-   | ^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^
    |
-   = help: `#[instrument_fn]` can only be applied to functions
+   = help: the `instrument_fn` attribute can only be applied to functions
 
-error: `#[instrument_fn]` attribute cannot be used on expressions
-  --> $DIR/instrument_fn.rs:14:9
+error: the `instrument_fn` attribute cannot be used on expressions
+  --> $DIR/instrument_fn.rs:14:11
    |
 LL |         #[instrument_fn = "off"]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^
+   |           ^^^^^^^^^^^^^
    |
-   = help: `#[instrument_fn]` can only be applied to functions
+   = help: the `instrument_fn` attribute can only be applied to functions
 
-error: `#[instrument_fn]` attribute cannot be used on traits
-  --> $DIR/instrument_fn.rs:20:1
+error: the `instrument_fn` attribute cannot be used on traits
+  --> $DIR/instrument_fn.rs:20:3
    |
 LL | #[instrument_fn = "off"]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^
    |
-   = help: `#[instrument_fn]` can only be applied to functions
+   = help: the `instrument_fn` attribute can only be applied to functions
 
-error: `#[instrument_fn]` attribute cannot be used on required trait methods
-  --> $DIR/instrument_fn.rs:22:5
+error: the `instrument_fn` attribute cannot be used on required trait methods
+  --> $DIR/instrument_fn.rs:22:7
    |
 LL |     #[instrument_fn = "off"]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^
    |
-   = help: `#[instrument_fn]` can only be applied to functions with a body
+   = help: the `instrument_fn` attribute can only be applied to functions with a body
 
 error[E0805]: malformed `instrument_fn` attribute input
   --> $DIR/instrument_fn.rs:37:1
@@ -113,13 +113,13 @@ LL - #[instrument_fn = 1]
 LL + #[instrument_fn = "on|off"]
    |
 
-error: `#[instrument_fn]` attribute cannot be used on closures
-  --> $DIR/instrument_fn.rs:47:14
+error: the `instrument_fn` attribute cannot be used on closures
+  --> $DIR/instrument_fn.rs:47:16
    |
 LL |     let _x = #[instrument_fn = "on"]
-   |              ^^^^^^^^^^^^^^^^^^^^^^^
+   |                ^^^^^^^^^^^^^
    |
-   = help: `#[instrument_fn]` can be applied to functions and methods
+   = help: the `instrument_fn` attribute can be applied to functions and methods
 
 error: aborting due to 13 previous errors
 

--- a/tests/ui/attributes/instrument_fn.stderr
+++ b/tests/ui/attributes/instrument_fn.stderr
@@ -75,10 +75,10 @@ LL |     #[instrument_fn = "off"]
    = help: the `instrument_fn` attribute can only be applied to functions with a body
 
 error[E0805]: malformed `instrument_fn` attribute input
-  --> $DIR/instrument_fn.rs:37:1
+  --> $DIR/instrument_fn.rs:37:3
    |
 LL | #[instrument_fn(entry = "on")]
-   | ^^^^^^^^^^^^^^^--------------^
+   |   ^^^^^^^^^^^^^--------------
    |                |
    |                expected a single argument here
    |
@@ -89,10 +89,10 @@ LL + #[instrument_fn = "on|off"]
    |
 
 error[E0539]: malformed `instrument_fn` attribute input
-  --> $DIR/instrument_fn.rs:40:1
+  --> $DIR/instrument_fn.rs:40:3
    |
 LL | #[instrument_fn]
-   | ^^^^^^^^^^^^^^^^ valid arguments are "on" or "off"
+   |   ^^^^^^^^^^^^^ valid arguments are "on" or "off"
    |
 help: must be of the form
    |
@@ -100,10 +100,10 @@ LL | #[instrument_fn = "on|off"]
    |                 ++++++++++
 
 error[E0539]: malformed `instrument_fn` attribute input
-  --> $DIR/instrument_fn.rs:43:1
+  --> $DIR/instrument_fn.rs:43:3
    |
 LL | #[instrument_fn = 1]
-   | ^^^^^^^^^^^^^^^^^^-^
+   |   ^^^^^^^^^^^^^^^^-
    |                   |
    |                   valid arguments are "on" or "off"
    |

--- a/tests/ui/attributes/invalid-debugger-visualizer-option.stderr
+++ b/tests/ui/attributes/invalid-debugger-visualizer-option.stderr
@@ -5,10 +5,10 @@ LL | #![debugger_visualizer(natvis_file = "../foo.random")]
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0539]: malformed `debugger_visualizer` attribute input
-  --> $DIR/invalid-debugger-visualizer-option.rs:4:1
+  --> $DIR/invalid-debugger-visualizer-option.rs:4:4
    |
 LL | #![debugger_visualizer(random_file = "../foo.random")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^-----------^^^^^^^^^^^^^^^^^^^^
+   |    ^^^^^^^^^^^^^^^^^^^^-----------^^^^^^^^^^^^^^^^^^^
    |                        |
    |                        valid arguments are `natvis_file` or `gdb_script_file`
    |

--- a/tests/ui/attributes/invalid-debugger-visualizer-target.rs
+++ b/tests/ui/attributes/invalid-debugger-visualizer-target.rs
@@ -1,3 +1,3 @@
 #[debugger_visualizer(natvis_file = "./foo.natvis.xml")]
-//~^ ERROR `#[debugger_visualizer]` attribute cannot be used on functions
+//~^ ERROR the `debugger_visualizer` attribute cannot be used on functions
 fn main() {}

--- a/tests/ui/attributes/invalid-debugger-visualizer-target.stderr
+++ b/tests/ui/attributes/invalid-debugger-visualizer-target.stderr
@@ -1,10 +1,10 @@
-error: `#[debugger_visualizer]` attribute cannot be used on functions
-  --> $DIR/invalid-debugger-visualizer-target.rs:1:1
+error: the `debugger_visualizer` attribute cannot be used on functions
+  --> $DIR/invalid-debugger-visualizer-target.rs:1:3
    |
 LL | #[debugger_visualizer(natvis_file = "./foo.natvis.xml")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[debugger_visualizer]` can be applied to crates and modules
+   = help: the `debugger_visualizer` attribute can be applied to crates and modules
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/attributes/invalid-macro-use.stderr
+++ b/tests/ui/attributes/invalid-macro-use.stderr
@@ -11,10 +11,10 @@ LL | #[macro_use(b)]
    |             ^
 
 error[E0539]: malformed `macro_use` attribute input
-  --> $DIR/invalid-macro-use.rs:4:1
+  --> $DIR/invalid-macro-use.rs:4:3
    |
 LL | #[macro_use = 5]
-   | ^^^^^^^^^^^^---^
+   |   ^^^^^^^^^^---
    |             |
    |             expected a list or no arguments here
    |
@@ -29,10 +29,10 @@ LL + #[macro_use]
    |
 
 error[E0565]: malformed `macro_use` attribute input
-  --> $DIR/invalid-macro-use.rs:10:1
+  --> $DIR/invalid-macro-use.rs:10:3
    |
 LL | #[macro_use(5)]
-   | ^^^^^^^^^^^^-^^
+   |   ^^^^^^^^^^-^
    |             |
    |             expected a valid identifier here
    |
@@ -47,10 +47,10 @@ LL + #[macro_use]
    |
 
 error[E0565]: malformed `macro_use` attribute input
-  --> $DIR/invalid-macro-use.rs:16:1
+  --> $DIR/invalid-macro-use.rs:16:3
    |
 LL | #[macro_use(a = "b")]
-   | ^^^^^^^^^^^^^^-----^^
+   |   ^^^^^^^^^^^^-----^
    |               |
    |               didn't expect any arguments here
    |
@@ -65,10 +65,10 @@ LL + #[macro_use]
    |
 
 error[E0565]: malformed `macro_use` attribute input
-  --> $DIR/invalid-macro-use.rs:22:1
+  --> $DIR/invalid-macro-use.rs:22:3
    |
 LL | #[macro_use(a(b))]
-   | ^^^^^^^^^^^^^---^^
+   |   ^^^^^^^^^^^---^
    |              |
    |              didn't expect any arguments here
    |
@@ -83,10 +83,10 @@ LL + #[macro_use]
    |
 
 error[E0565]: malformed `macro_use` attribute input
-  --> $DIR/invalid-macro-use.rs:28:1
+  --> $DIR/invalid-macro-use.rs:28:3
    |
 LL | #[macro_use(a::b)]
-   | ^^^^^^^^^^^^----^^
+   |   ^^^^^^^^^^----^
    |             |
    |             expected a valid identifier here
    |

--- a/tests/ui/attributes/invalid-repr.stderr
+++ b/tests/ui/attributes/invalid-repr.stderr
@@ -1,10 +1,10 @@
-error: `#[repr(align(...))]` attribute cannot be used on type aliases
-  --> $DIR/invalid-repr.rs:1:1
+error: the `repr(align(...))` attribute cannot be used on type aliases
+  --> $DIR/invalid-repr.rs:1:3
    |
 LL | #[repr(align(16))]
-   | ^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^
    |
-   = help: `#[repr(align(...))]` can only be applied to data types
+   = help: the `repr(align(...))` attribute can only be applied to data types
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/attributes/invalid-reprs.stderr
+++ b/tests/ui/attributes/invalid-reprs.stderr
@@ -20,10 +20,10 @@ LL + use std::process::id;
    |
 
 error[E0539]: malformed `repr` attribute input
-  --> $DIR/invalid-reprs.rs:2:13
+  --> $DIR/invalid-reprs.rs:2:15
    |
 LL |     let y = #[repr(uwu(4))]
-   |             ^^^^^^^------^^
+   |               ^^^^^------^
    |                    |
    |                    valid arguments are `align`, `packed`, `Rust`, `C`, `simd`, `transparent`, `i8`, `u8`, `i16`, `u16`, `i32`, `u32`, `i64`, `u64`, `i128`, `u128`, `isize` or `usize`
    |

--- a/tests/ui/attributes/issue-105594-invalid-attr-validation.stderr
+++ b/tests/ui/attributes/issue-105594-invalid-attr-validation.stderr
@@ -1,10 +1,10 @@
-error: `#[track_caller]` attribute cannot be used on statics
-  --> $DIR/issue-105594-invalid-attr-validation.rs:6:1
+error: the `track_caller` attribute cannot be used on statics
+  --> $DIR/issue-105594-invalid-attr-validation.rs:6:3
    |
 LL | #[track_caller]
-   | ^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^
    |
-   = help: `#[track_caller]` can only be applied to functions
+   = help: the `track_caller` attribute can only be applied to functions
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/attributes/linkage.stderr
+++ b/tests/ui/attributes/linkage.stderr
@@ -1,50 +1,50 @@
-error: `#[linkage]` attribute cannot be used on type aliases
-  --> $DIR/linkage.rs:6:1
+error: the `linkage` attribute cannot be used on type aliases
+  --> $DIR/linkage.rs:6:3
    |
 LL | #[linkage = "weak"]
-   | ^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^
    |
-   = help: `#[linkage]` can be applied to foreign statics, functions, and statics
+   = help: the `linkage` attribute can be applied to foreign statics, functions, and statics
 
-error: `#[linkage]` attribute cannot be used on modules
-  --> $DIR/linkage.rs:9:1
+error: the `linkage` attribute cannot be used on modules
+  --> $DIR/linkage.rs:9:3
    |
 LL | #[linkage = "weak"]
-   | ^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^
    |
-   = help: `#[linkage]` can be applied to foreign statics, functions, and statics
+   = help: the `linkage` attribute can be applied to foreign statics, functions, and statics
 
-error: `#[linkage]` attribute cannot be used on structs
-  --> $DIR/linkage.rs:12:1
+error: the `linkage` attribute cannot be used on structs
+  --> $DIR/linkage.rs:12:3
    |
 LL | #[linkage = "weak"]
-   | ^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^
    |
-   = help: `#[linkage]` can be applied to foreign statics, functions, and statics
+   = help: the `linkage` attribute can be applied to foreign statics, functions, and statics
 
-error: `#[linkage]` attribute cannot be used on inherent impl blocks
-  --> $DIR/linkage.rs:15:1
+error: the `linkage` attribute cannot be used on inherent impl blocks
+  --> $DIR/linkage.rs:15:3
    |
 LL | #[linkage = "weak"]
-   | ^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^
    |
-   = help: `#[linkage]` can be applied to foreign statics, functions, and statics
+   = help: the `linkage` attribute can be applied to foreign statics, functions, and statics
 
-error: `#[linkage]` attribute cannot be used on expressions
-  --> $DIR/linkage.rs:23:5
+error: the `linkage` attribute cannot be used on expressions
+  --> $DIR/linkage.rs:23:7
    |
 LL |     #[linkage = "weak"]
-   |     ^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^
    |
-   = help: `#[linkage]` can be applied to foreign statics, functions, and statics
+   = help: the `linkage` attribute can be applied to foreign statics, functions, and statics
 
-error: `#[linkage]` attribute cannot be used on closures
-  --> $DIR/linkage.rs:39:13
+error: the `linkage` attribute cannot be used on closures
+  --> $DIR/linkage.rs:39:15
    |
 LL |     let _ = #[linkage = "weak"]
-   |             ^^^^^^^^^^^^^^^^^^^
+   |               ^^^^^^^
    |
-   = help: `#[linkage]` can be applied to foreign functions, foreign statics, functions, methods, and statics
+   = help: the `linkage` attribute can be applied to foreign functions, foreign statics, functions, methods, and statics
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/attributes/lint_on_root.stderr
+++ b/tests/ui/attributes/lint_on_root.stderr
@@ -1,10 +1,10 @@
-error: `#[inline]` attribute cannot be used on crates
-  --> $DIR/lint_on_root.rs:3:1
+error: the `inline` attribute cannot be used on crates
+  --> $DIR/lint_on_root.rs:3:4
    |
 LL | #![inline = ""]
-   | ^^^^^^^^^^^^^^^
+   |    ^^^^^^
    |
-   = help: `#[inline]` can only be applied to functions
+   = help: the `inline` attribute can only be applied to functions
 
 error: valid forms for the attribute are `#![inline(always)]`, `#![inline(never)]`, and `#![inline]`
   --> $DIR/lint_on_root.rs:3:1

--- a/tests/ui/attributes/malformed-attrs.rs
+++ b/tests/ui/attributes/malformed-attrs.rs
@@ -217,7 +217,7 @@ extern crate wloop;
 //~^ ERROR malformed
 #[allow_internal_unsafe = 1]
 //~^ ERROR malformed
-//~| ERROR allow_internal_unsafe side-steps the unsafe_code lint
+//~| ERROR the `allow_internal_unsafe` attribute side-steps the `unsafe_code` lint
 macro_rules! slump {
     () => {}
 }

--- a/tests/ui/attributes/malformed-attrs.stderr
+++ b/tests/ui/attributes/malformed-attrs.stderr
@@ -819,11 +819,11 @@ LL - #[macro_export = 18]
 LL + #[macro_export]
    |
 
-error[E0658]: allow_internal_unsafe side-steps the unsafe_code lint
-  --> $DIR/malformed-attrs.rs:218:1
+error[E0658]: the `allow_internal_unsafe` attribute side-steps the `unsafe_code` lint
+  --> $DIR/malformed-attrs.rs:218:3
    |
 LL | #[allow_internal_unsafe = 1]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(allow_internal_unsafe)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date

--- a/tests/ui/attributes/malformed-attrs.stderr
+++ b/tests/ui/attributes/malformed-attrs.stderr
@@ -176,13 +176,13 @@ help: must be of the form
 LL | #[rustc_confusables("name1", "name2", ...)]
    |                    +++++++++++++++++++++++
 
-error: `#[rustc_confusables]` attribute cannot be used on functions
-  --> $DIR/malformed-attrs.rs:36:1
+error: the `rustc_confusables` attribute cannot be used on functions
+  --> $DIR/malformed-attrs.rs:36:3
    |
 LL | #[rustc_confusables]
-   | ^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_confusables]` can only be applied to inherent methods
+   = help: the `rustc_confusables` attribute can only be applied to inherent methods
 
 error[E0539]: malformed `deprecated` attribute input
   --> $DIR/malformed-attrs.rs:39:1
@@ -207,13 +207,13 @@ LL | #[rustc_macro_transparency = "semiopaque"]
 LL | #[rustc_macro_transparency = "transparent"]
    |                            +++++++++++++++
 
-error: `#[rustc_macro_transparency]` attribute cannot be used on functions
-  --> $DIR/malformed-attrs.rs:43:1
+error: the `rustc_macro_transparency` attribute cannot be used on functions
+  --> $DIR/malformed-attrs.rs:43:3
    |
 LL | #[rustc_macro_transparency]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_macro_transparency]` can only be applied to macro defs
+   = help: the `rustc_macro_transparency` attribute can only be applied to macro defs
 
 error[E0539]: malformed `repr` attribute input
   --> $DIR/malformed-attrs.rs:46:1
@@ -407,13 +407,13 @@ LL - #[used()]
 LL + #[used]
    |
 
-error: `#[used]` attribute cannot be used on functions
-  --> $DIR/malformed-attrs.rs:73:1
+error: the `used` attribute cannot be used on functions
+  --> $DIR/malformed-attrs.rs:73:3
    |
 LL | #[used()]
-   | ^^^^^^^^^
+   |   ^^^^
    |
-   = help: `#[used]` can only be applied to statics
+   = help: the `used` attribute can only be applied to statics
 
 error[E0539]: malformed `crate_name` attribute input
   --> $DIR/malformed-attrs.rs:76:1
@@ -898,22 +898,22 @@ error: valid forms for the attribute are `#[doc = "string"]`, `#[doc(alias)]`, `
 LL | #[doc]
    | ^^^^^^
 
-warning: `#[link]` attribute cannot be used on functions
-  --> $DIR/malformed-attrs.rs:85:1
+warning: the `link` attribute cannot be used on functions
+  --> $DIR/malformed-attrs.rs:85:3
    |
 LL | #[link]
-   | ^^^^^^^
+   |   ^^^^
    |
-   = help: `#[link]` can only be applied to foreign modules
+   = help: the `link` attribute can only be applied to foreign modules
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[link_name]` attribute cannot be used on functions
-  --> $DIR/malformed-attrs.rs:89:1
+warning: the `link_name` attribute cannot be used on functions
+  --> $DIR/malformed-attrs.rs:89:3
    |
 LL | #[link_name]
-   | ^^^^^^^^^^^^
+   |   ^^^^^^^^^
    |
-   = help: `#[link_name]` can be applied to foreign functions and foreign statics
+   = help: the `link_name` attribute can be applied to foreign functions and foreign statics
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 error: valid forms for the attribute are `#[ignore = "reason"]` and `#[ignore]`
@@ -925,13 +925,13 @@ LL | #[ignore()]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
 
-warning: `#[no_implicit_prelude]` attribute cannot be used on functions
-  --> $DIR/malformed-attrs.rs:102:1
+warning: the `no_implicit_prelude` attribute cannot be used on functions
+  --> $DIR/malformed-attrs.rs:102:3
    |
 LL | #[no_implicit_prelude = 23]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[no_implicit_prelude]` can be applied to crates and modules
+   = help: the `no_implicit_prelude` attribute can be applied to crates and modules
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: missing options for `diagnostic::on_unimplemented` attribute
@@ -957,13 +957,13 @@ warning: `#[diagnostic::do_not_recommend]` does not expect any arguments
 LL | #[diagnostic::do_not_recommend()]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: `#[automatically_derived]` attribute cannot be used on modules
-  --> $DIR/malformed-attrs.rs:191:1
+warning: the `automatically_derived` attribute cannot be used on modules
+  --> $DIR/malformed-attrs.rs:191:3
    |
 LL | #[automatically_derived = 18]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[automatically_derived]` can only be applied to trait impl blocks
+   = help: the `automatically_derived` attribute can only be applied to trait impl blocks
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 error: valid forms for the attribute are `#[ignore = "reason"]` and `#[ignore]`

--- a/tests/ui/attributes/malformed-attrs.stderr
+++ b/tests/ui/attributes/malformed-attrs.stderr
@@ -1,8 +1,8 @@
 error[E0539]: malformed `cfg` attribute input
-  --> $DIR/malformed-attrs.rs:109:1
+  --> $DIR/malformed-attrs.rs:109:3
    |
 LL | #[cfg]
-   | ^^^^^^ expected this to be a list
+   |   ^^^ expected this to be a list
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
 help: must be of the form
@@ -11,10 +11,10 @@ LL | #[cfg(predicate)]
    |      +++++++++++
 
 error[E0539]: malformed `cfg_attr` attribute input
-  --> $DIR/malformed-attrs.rs:111:1
+  --> $DIR/malformed-attrs.rs:111:3
    |
 LL | #[cfg_attr]
-   | ^^^^^^^^^^^ expected this to be a list
+   |   ^^^^^^^^ expected this to be a list
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute>
 help: must be of the form
@@ -127,12 +127,10 @@ LL | #[proc_macro_derive]
    | ^^^^^^^^^^^^^^^^^^^^
 
 error[E0539]: malformed `windows_subsystem` attribute input
-  --> $DIR/malformed-attrs.rs:26:1
+  --> $DIR/malformed-attrs.rs:26:4
    |
 LL | #![windows_subsystem]
-   | ^^^-----------------^
-   |    |
-   |    expected this to be of the form `windows_subsystem = "..."`
+   |    ^^^^^^^^^^^^^^^^^ expected this to be of the form `windows_subsystem = "..."`
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/runtime.html#the-windows_subsystem-attribute>
 help: try changing it to one of the following valid forms of the attribute
@@ -143,10 +141,10 @@ LL | #![windows_subsystem = "windows"]
    |                      +++++++++++
 
 error[E0539]: malformed `export_name` attribute input
-  --> $DIR/malformed-attrs.rs:29:1
+  --> $DIR/malformed-attrs.rs:29:3
    |
 LL | #[unsafe(export_name)]
-   | ^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^
    |
 help: must be of the form
    |
@@ -166,10 +164,10 @@ LL | #[allow_internal_unstable]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0539]: malformed `rustc_confusables` attribute input
-  --> $DIR/malformed-attrs.rs:36:1
+  --> $DIR/malformed-attrs.rs:36:3
    |
 LL | #[rustc_confusables]
-   | ^^^^^^^^^^^^^^^^^^^^ expected this to be a list
+   |   ^^^^^^^^^^^^^^^^^ expected this to be a list
    |
 help: must be of the form
    |
@@ -185,18 +183,18 @@ LL | #[rustc_confusables]
    = help: the `rustc_confusables` attribute can only be applied to inherent methods
 
 error[E0539]: malformed `deprecated` attribute input
-  --> $DIR/malformed-attrs.rs:39:1
+  --> $DIR/malformed-attrs.rs:39:3
    |
 LL | #[deprecated = 5]
-   | ^^^^^^^^^^^^^^^-^
+   |   ^^^^^^^^^^^^^-
    |                |
    |                expected a string literal here
 
 error[E0539]: malformed `rustc_macro_transparency` attribute input
-  --> $DIR/malformed-attrs.rs:43:1
+  --> $DIR/malformed-attrs.rs:43:3
    |
 LL | #[rustc_macro_transparency]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: try changing it to one of the following valid forms of the attribute
    |
@@ -216,18 +214,18 @@ LL | #[rustc_macro_transparency]
    = help: the `rustc_macro_transparency` attribute can only be applied to macro defs
 
 error[E0539]: malformed `repr` attribute input
-  --> $DIR/malformed-attrs.rs:46:1
+  --> $DIR/malformed-attrs.rs:46:3
    |
 LL | #[repr]
-   | ^^^^^^^ expected this to be a list
+   |   ^^^^ expected this to be a list
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/type-layout.html#representations>
 
 error[E0565]: malformed `rustc_as_ptr` attribute input
-  --> $DIR/malformed-attrs.rs:48:1
+  --> $DIR/malformed-attrs.rs:48:3
    |
 LL | #[rustc_as_ptr = 5]
-   | ^^^^^^^^^^^^^^^---^
+   |   ^^^^^^^^^^^^^---
    |                |
    |                didn't expect any arguments here
    |
@@ -238,10 +236,10 @@ LL + #[rustc_as_ptr]
    |
 
 error[E0539]: malformed `rustc_align` attribute input
-  --> $DIR/malformed-attrs.rs:53:1
+  --> $DIR/malformed-attrs.rs:53:3
    |
 LL | #[rustc_align]
-   | ^^^^^^^^^^^^^^ expected this to be a list
+   |   ^^^^^^^^^^^ expected this to be a list
    |
 help: must be of the form
    |
@@ -249,10 +247,10 @@ LL | #[rustc_align(<alignment in bytes>)]
    |              ++++++++++++++++++++++
 
 error[E0539]: malformed `optimize` attribute input
-  --> $DIR/malformed-attrs.rs:55:1
+  --> $DIR/malformed-attrs.rs:55:3
    |
 LL | #[optimize]
-   | ^^^^^^^^^^^ expected this to be a list
+   |   ^^^^^^^^ expected this to be a list
    |
 help: try changing it to one of the following valid forms of the attribute
    |
@@ -264,10 +262,10 @@ LL | #[optimize(speed)]
    |           +++++++
 
 error[E0805]: malformed `optimize` attribute input
-  --> $DIR/malformed-attrs.rs:57:1
+  --> $DIR/malformed-attrs.rs:57:3
    |
 LL | #[optimize(none, none)]
-   | ^^^^^^^^^^------------^
+   |   ^^^^^^^^------------
    |           |
    |           expected a single argument here
    |
@@ -284,10 +282,10 @@ LL + #[optimize(speed)]
    |
 
 error[E0805]: malformed `optimize` attribute input
-  --> $DIR/malformed-attrs.rs:59:1
+  --> $DIR/malformed-attrs.rs:59:3
    |
 LL | #[optimize(none, speed)]
-   | ^^^^^^^^^^-------------^
+   |   ^^^^^^^^-------------
    |           |
    |           expected a single argument here
    |
@@ -304,10 +302,10 @@ LL + #[optimize(speed)]
    |
 
 error[E0565]: malformed `cold` attribute input
-  --> $DIR/malformed-attrs.rs:61:1
+  --> $DIR/malformed-attrs.rs:61:3
    |
 LL | #[cold = 1]
-   | ^^^^^^^---^
+   |   ^^^^^---
    |        |
    |        didn't expect any arguments here
    |
@@ -318,10 +316,10 @@ LL + #[cold]
    |
 
 error[E0539]: malformed `must_use` attribute input
-  --> $DIR/malformed-attrs.rs:63:1
+  --> $DIR/malformed-attrs.rs:63:3
    |
 LL | #[must_use()]
-   | ^^^^^^^^^^--^
+   |   ^^^^^^^^--
    |           |
    |           didn't expect a list here
    |
@@ -336,10 +334,10 @@ LL + #[must_use]
    |
 
 error[E0565]: malformed `no_mangle` attribute input
-  --> $DIR/malformed-attrs.rs:65:1
+  --> $DIR/malformed-attrs.rs:65:3
    |
 LL | #[no_mangle = 1]
-   | ^^^^^^^^^^^^---^
+   |   ^^^^^^^^^^---
    |             |
    |             didn't expect any arguments here
    |
@@ -350,10 +348,10 @@ LL + #[no_mangle]
    |
 
 error[E0565]: malformed `naked` attribute input
-  --> $DIR/malformed-attrs.rs:67:1
+  --> $DIR/malformed-attrs.rs:67:3
    |
 LL | #[unsafe(naked())]
-   | ^^^^^^^^^^^^^^--^^
+   |   ^^^^^^^^^^^^--^
    |               |
    |               didn't expect any arguments here
    |
@@ -364,10 +362,10 @@ LL + #[unsafe(naked)]
    |
 
 error[E0565]: malformed `track_caller` attribute input
-  --> $DIR/malformed-attrs.rs:69:1
+  --> $DIR/malformed-attrs.rs:69:3
    |
 LL | #[track_caller()]
-   | ^^^^^^^^^^^^^^--^
+   |   ^^^^^^^^^^^^--
    |               |
    |               didn't expect any arguments here
    |
@@ -378,10 +376,10 @@ LL + #[track_caller]
    |
 
 error[E0539]: malformed `export_name` attribute input
-  --> $DIR/malformed-attrs.rs:71:1
+  --> $DIR/malformed-attrs.rs:71:3
    |
 LL | #[export_name()]
-   | ^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^
    |
 help: must be of the form
    |
@@ -390,10 +388,10 @@ LL + #[export_name = "name"]
    |
 
 error[E0805]: malformed `used` attribute input
-  --> $DIR/malformed-attrs.rs:73:1
+  --> $DIR/malformed-attrs.rs:73:3
    |
 LL | #[used()]
-   | ^^^^^^--^
+   |   ^^^^--
    |       |
    |       expected an argument here
    |
@@ -416,10 +414,10 @@ LL | #[used()]
    = help: the `used` attribute can only be applied to statics
 
 error[E0539]: malformed `crate_name` attribute input
-  --> $DIR/malformed-attrs.rs:76:1
+  --> $DIR/malformed-attrs.rs:76:3
    |
 LL | #[crate_name]
-   | ^^^^^^^^^^^^^
+   |   ^^^^^^^^^^
    |
 help: must be of the form
    |
@@ -427,10 +425,10 @@ LL | #[crate_name = "name"]
    |              ++++++++
 
 error[E0539]: malformed `target_feature` attribute input
-  --> $DIR/malformed-attrs.rs:81:1
+  --> $DIR/malformed-attrs.rs:81:3
    |
 LL | #[target_feature]
-   | ^^^^^^^^^^^^^^^^^ expected this to be a list
+   |   ^^^^^^^^^^^^^^ expected this to be a list
    |
 help: must be of the form
    |
@@ -438,10 +436,10 @@ LL | #[target_feature(enable = "feat1, feat2")]
    |                 +++++++++++++++++++++++++
 
 error[E0565]: malformed `export_stable` attribute input
-  --> $DIR/malformed-attrs.rs:83:1
+  --> $DIR/malformed-attrs.rs:83:3
    |
 LL | #[export_stable = 1]
-   | ^^^^^^^^^^^^^^^^---^
+   |   ^^^^^^^^^^^^^^---
    |                 |
    |                 didn't expect any arguments here
    |
@@ -452,18 +450,18 @@ LL + #[export_stable]
    |
 
 error[E0539]: malformed `link` attribute input
-  --> $DIR/malformed-attrs.rs:85:1
+  --> $DIR/malformed-attrs.rs:85:3
    |
 LL | #[link]
-   | ^^^^^^^ expected this to be a list
+   |   ^^^^ expected this to be a list
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute>
 
 error[E0539]: malformed `link_name` attribute input
-  --> $DIR/malformed-attrs.rs:89:1
+  --> $DIR/malformed-attrs.rs:89:3
    |
 LL | #[link_name]
-   | ^^^^^^^^^^^^
+   |   ^^^^^^^^^
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link_name-attribute>
 help: must be of the form
@@ -472,10 +470,10 @@ LL | #[link_name = "name"]
    |             ++++++++
 
 error[E0539]: malformed `link_section` attribute input
-  --> $DIR/malformed-attrs.rs:93:1
+  --> $DIR/malformed-attrs.rs:93:3
    |
 LL | #[link_section]
-   | ^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/abi.html#the-link_section-attribute>
 help: must be of the form
@@ -484,10 +482,10 @@ LL | #[link_section = "name"]
    |                ++++++++
 
 error[E0539]: malformed `coverage` attribute input
-  --> $DIR/malformed-attrs.rs:95:1
+  --> $DIR/malformed-attrs.rs:95:3
    |
 LL | #[coverage]
-   | ^^^^^^^^^^^ expected this to be a list
+   |   ^^^^^^^^ expected this to be a list
    |
 help: try changing it to one of the following valid forms of the attribute
    |
@@ -497,16 +495,16 @@ LL | #[coverage(on)]
    |           ++++
 
 error[E0539]: malformed `sanitize` attribute input
-  --> $DIR/malformed-attrs.rs:97:1
+  --> $DIR/malformed-attrs.rs:97:3
    |
 LL | #[sanitize]
-   | ^^^^^^^^^^^ expected this to be a list
+   |   ^^^^^^^^ expected this to be a list
 
 error[E0565]: malformed `no_implicit_prelude` attribute input
-  --> $DIR/malformed-attrs.rs:102:1
+  --> $DIR/malformed-attrs.rs:102:3
    |
 LL | #[no_implicit_prelude = 23]
-   | ^^^^^^^^^^^^^^^^^^^^^^----^
+   |   ^^^^^^^^^^^^^^^^^^^^----
    |                       |
    |                       didn't expect any arguments here
    |
@@ -517,10 +515,10 @@ LL + #[no_implicit_prelude]
    |
 
 error[E0565]: malformed `proc_macro` attribute input
-  --> $DIR/malformed-attrs.rs:106:1
+  --> $DIR/malformed-attrs.rs:106:3
    |
 LL | #[proc_macro = 18]
-   | ^^^^^^^^^^^^^----^
+   |   ^^^^^^^^^^^----
    |              |
    |              didn't expect any arguments here
    |
@@ -531,10 +529,10 @@ LL + #[proc_macro]
    |
 
 error[E0539]: malformed `instruction_set` attribute input
-  --> $DIR/malformed-attrs.rs:113:1
+  --> $DIR/malformed-attrs.rs:113:3
    |
 LL | #[instruction_set]
-   | ^^^^^^^^^^^^^^^^^^ expected this to be a list
+   |   ^^^^^^^^^^^^^^^ expected this to be a list
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/attributes/codegen.html#the-instruction_set-attribute>
 help: must be of the form
@@ -543,10 +541,10 @@ LL | #[instruction_set(set)]
    |                  +++++
 
 error[E0539]: malformed `patchable_function_entry` attribute input
-  --> $DIR/malformed-attrs.rs:115:1
+  --> $DIR/malformed-attrs.rs:115:3
    |
 LL | #[patchable_function_entry]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected this to be a list
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^ expected this to be a list
    |
 help: must be of the form
    |
@@ -554,10 +552,10 @@ LL | #[patchable_function_entry(prefix_nops = m, entry_nops = n, section = "sect
    |                           ++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 error[E0565]: malformed `coroutine` attribute input
-  --> $DIR/malformed-attrs.rs:118:5
+  --> $DIR/malformed-attrs.rs:118:7
    |
 LL |     #[coroutine = 63] || {}
-   |     ^^^^^^^^^^^^----^
+   |       ^^^^^^^^^^----
    |                 |
    |                 didn't expect any arguments here
    |
@@ -568,10 +566,10 @@ LL +     #[coroutine] || {}
    |
 
 error[E0565]: malformed `proc_macro_attribute` attribute input
-  --> $DIR/malformed-attrs.rs:123:1
+  --> $DIR/malformed-attrs.rs:123:3
    |
 LL | #[proc_macro_attribute = 19]
-   | ^^^^^^^^^^^^^^^^^^^^^^^----^
+   |   ^^^^^^^^^^^^^^^^^^^^^----
    |                        |
    |                        didn't expect any arguments here
    |
@@ -582,10 +580,10 @@ LL + #[proc_macro_attribute]
    |
 
 error[E0539]: malformed `must_use` attribute input
-  --> $DIR/malformed-attrs.rs:126:1
+  --> $DIR/malformed-attrs.rs:126:3
    |
 LL | #[must_use = 1]
-   | ^^^^^^^^^^^^^-^
+   |   ^^^^^^^^^^^-
    |              |
    |              expected a string literal here
    |
@@ -600,10 +598,10 @@ LL + #[must_use]
    |
 
 error[E0539]: malformed `proc_macro_derive` attribute input
-  --> $DIR/malformed-attrs.rs:130:1
+  --> $DIR/malformed-attrs.rs:130:3
    |
 LL | #[proc_macro_derive]
-   | ^^^^^^^^^^^^^^^^^^^^ expected this to be a list
+   |   ^^^^^^^^^^^^^^^^^ expected this to be a list
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/procedural-macros.html#derive-macros>
 help: try changing it to one of the following valid forms of the attribute
@@ -614,10 +612,10 @@ LL | #[proc_macro_derive(TraitName, attributes(name1, name2, ...))]
    |                    ++++++++++++++++++++++++++++++++++++++++++
 
 error[E0539]: malformed `must_not_suspend` attribute input
-  --> $DIR/malformed-attrs.rs:135:1
+  --> $DIR/malformed-attrs.rs:135:3
    |
 LL | #[must_not_suspend()]
-   | ^^^^^^^^^^^^^^^^^^--^
+   |   ^^^^^^^^^^^^^^^^--
    |                   |
    |                   didn't expect a list here
    |
@@ -630,10 +628,10 @@ LL + #[must_not_suspend]
    |
 
 error[E0539]: malformed `cfi_encoding` attribute input
-  --> $DIR/malformed-attrs.rs:137:1
+  --> $DIR/malformed-attrs.rs:137:3
    |
 LL | #[cfi_encoding = ""]
-   | ^^^^^^^^^^^^^^^^^--^
+   |   ^^^^^^^^^^^^^^^--
    |                  |
    |                  string is not allowed to be empty
    |
@@ -643,10 +641,10 @@ LL | #[cfi_encoding = "encoding"]
    |                   ++++++++
 
 error[E0565]: malformed `marker` attribute input
-  --> $DIR/malformed-attrs.rs:156:1
+  --> $DIR/malformed-attrs.rs:156:3
    |
 LL | #[marker = 3]
-   | ^^^^^^^^^---^
+   |   ^^^^^^^---
    |          |
    |          didn't expect any arguments here
    |
@@ -657,10 +655,10 @@ LL + #[marker]
    |
 
 error[E0565]: malformed `fundamental` attribute input
-  --> $DIR/malformed-attrs.rs:158:1
+  --> $DIR/malformed-attrs.rs:158:3
    |
 LL | #[fundamental()]
-   | ^^^^^^^^^^^^^--^
+   |   ^^^^^^^^^^^--
    |              |
    |              didn't expect any arguments here
    |
@@ -671,10 +669,10 @@ LL + #[fundamental]
    |
 
 error[E0565]: malformed `ffi_pure` attribute input
-  --> $DIR/malformed-attrs.rs:166:5
+  --> $DIR/malformed-attrs.rs:166:7
    |
 LL |     #[unsafe(ffi_pure = 1)]
-   |     ^^^^^^^^^^^^^^^^^^---^^
+   |       ^^^^^^^^^^^^^^^^---^
    |                       |
    |                       didn't expect any arguments here
    |
@@ -685,10 +683,10 @@ LL +     #[unsafe(ffi_pure)]
    |
 
 error[E0539]: malformed `link_ordinal` attribute input
-  --> $DIR/malformed-attrs.rs:168:5
+  --> $DIR/malformed-attrs.rs:168:7
    |
 LL |     #[link_ordinal]
-   |     ^^^^^^^^^^^^^^^ expected this to be a list
+   |       ^^^^^^^^^^^^ expected this to be a list
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link_ordinal-attribute>
 help: must be of the form
@@ -697,10 +695,10 @@ LL |     #[link_ordinal(ordinal)]
    |                   +++++++++
 
 error[E0565]: malformed `ffi_const` attribute input
-  --> $DIR/malformed-attrs.rs:172:5
+  --> $DIR/malformed-attrs.rs:172:7
    |
 LL |     #[unsafe(ffi_const = 1)]
-   |     ^^^^^^^^^^^^^^^^^^^---^^
+   |       ^^^^^^^^^^^^^^^^^---^
    |                        |
    |                        didn't expect any arguments here
    |
@@ -711,16 +709,16 @@ LL +     #[unsafe(ffi_const)]
    |
 
 error[E0539]: malformed `linkage` attribute input
-  --> $DIR/malformed-attrs.rs:174:5
+  --> $DIR/malformed-attrs.rs:174:7
    |
 LL |     #[linkage]
-   |     ^^^^^^^^^^ expected this to be of the form `linkage = "..."`
+   |       ^^^^^^^ expected this to be of the form `linkage = "..."`
 
 error[E0539]: malformed `debugger_visualizer` attribute input
-  --> $DIR/malformed-attrs.rs:189:1
+  --> $DIR/malformed-attrs.rs:189:3
    |
 LL | #[debugger_visualizer]
-   | ^^^^^^^^^^^^^^^^^^^^^^ expected this to be a list
+   |   ^^^^^^^^^^^^^^^^^^^ expected this to be a list
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/attributes/debugger.html#the-debugger_visualizer-attribute>
 help: must be of the form
@@ -729,10 +727,10 @@ LL | #[debugger_visualizer(natvis_file = "...", gdb_script_file = "...")]
    |                      ++++++++++++++++++++++++++++++++++++++++++++++
 
 error[E0565]: malformed `automatically_derived` attribute input
-  --> $DIR/malformed-attrs.rs:191:1
+  --> $DIR/malformed-attrs.rs:191:3
    |
 LL | #[automatically_derived = 18]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^----^
+   |   ^^^^^^^^^^^^^^^^^^^^^^----
    |                         |
    |                         didn't expect any arguments here
    |
@@ -743,10 +741,10 @@ LL + #[automatically_derived]
    |
 
 error[E0565]: malformed `non_exhaustive` attribute input
-  --> $DIR/malformed-attrs.rs:199:1
+  --> $DIR/malformed-attrs.rs:199:3
    |
 LL | #[non_exhaustive = 1]
-   | ^^^^^^^^^^^^^^^^^---^
+   |   ^^^^^^^^^^^^^^^---
    |                  |
    |                  didn't expect any arguments here
    |
@@ -757,10 +755,10 @@ LL + #[non_exhaustive]
    |
 
 error[E0565]: malformed `thread_local` attribute input
-  --> $DIR/malformed-attrs.rs:205:1
+  --> $DIR/malformed-attrs.rs:205:3
    |
 LL | #[thread_local()]
-   | ^^^^^^^^^^^^^^--^
+   |   ^^^^^^^^^^^^--
    |               |
    |               didn't expect any arguments here
    |
@@ -771,10 +769,10 @@ LL + #[thread_local]
    |
 
 error[E0565]: malformed `no_link` attribute input
-  --> $DIR/malformed-attrs.rs:209:1
+  --> $DIR/malformed-attrs.rs:209:3
    |
 LL | #[no_link()]
-   | ^^^^^^^^^--^
+   |   ^^^^^^^--
    |          |
    |          didn't expect any arguments here
    |
@@ -785,10 +783,10 @@ LL + #[no_link]
    |
 
 error[E0539]: malformed `macro_use` attribute input
-  --> $DIR/malformed-attrs.rs:211:1
+  --> $DIR/malformed-attrs.rs:211:3
    |
 LL | #[macro_use = 1]
-   | ^^^^^^^^^^^^---^
+   |   ^^^^^^^^^^---
    |             |
    |             expected a list or no arguments here
    |
@@ -803,10 +801,10 @@ LL + #[macro_use]
    |
 
 error[E0539]: malformed `macro_export` attribute input
-  --> $DIR/malformed-attrs.rs:216:1
+  --> $DIR/malformed-attrs.rs:216:3
    |
 LL | #[macro_export = 18]
-   | ^^^^^^^^^^^^^^^----^
+   |   ^^^^^^^^^^^^^----
    |                |
    |                expected a list or no arguments here
    |
@@ -829,10 +827,10 @@ LL | #[allow_internal_unsafe = 1]
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0565]: malformed `allow_internal_unsafe` attribute input
-  --> $DIR/malformed-attrs.rs:218:1
+  --> $DIR/malformed-attrs.rs:218:3
    |
 LL | #[allow_internal_unsafe = 1]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^---^
+   |   ^^^^^^^^^^^^^^^^^^^^^^---
    |                         |
    |                         didn't expect any arguments here
    |

--- a/tests/ui/attributes/malformed-fn-align.stderr
+++ b/tests/ui/attributes/malformed-fn-align.stderr
@@ -1,8 +1,8 @@
 error[E0539]: malformed `rustc_align` attribute input
-  --> $DIR/malformed-fn-align.rs:10:5
+  --> $DIR/malformed-fn-align.rs:10:7
    |
 LL |     #[rustc_align]
-   |     ^^^^^^^^^^^^^^ expected this to be a list
+   |       ^^^^^^^^^^^ expected this to be a list
    |
 help: must be of the form
    |
@@ -10,10 +10,10 @@ LL |     #[rustc_align(<alignment in bytes>)]
    |                  ++++++++++++++++++++++
 
 error[E0805]: malformed `rustc_align` attribute input
-  --> $DIR/malformed-fn-align.rs:13:5
+  --> $DIR/malformed-fn-align.rs:13:7
    |
 LL |     #[rustc_align(1, 2)]
-   |     ^^^^^^^^^^^^^------^
+   |       ^^^^^^^^^^^------
    |                  |
    |                  expected a single argument here
    |
@@ -24,10 +24,10 @@ LL +     #[rustc_align(<alignment in bytes>)]
    |
 
 error[E0539]: malformed `rustc_align` attribute input
-  --> $DIR/malformed-fn-align.rs:17:1
+  --> $DIR/malformed-fn-align.rs:17:3
    |
 LL | #[rustc_align = 16]
-   | ^^^^^^^^^^^^^^----^
+   |   ^^^^^^^^^^^^----
    |               |
    |               expected this to be a list
    |

--- a/tests/ui/attributes/malformed-fn-align.stderr
+++ b/tests/ui/attributes/malformed-fn-align.stderr
@@ -49,13 +49,13 @@ error[E0589]: invalid alignment value: not a power of two
 LL | #[rustc_align(0)]
    |               ^
 
-error: `#[repr(align(...))]` attribute cannot be used on functions
-  --> $DIR/malformed-fn-align.rs:26:1
+error: the `repr(align(...))` attribute cannot be used on functions
+  --> $DIR/malformed-fn-align.rs:26:3
    |
 LL | #[repr(align(16))]
-   | ^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^
    |
-   = help: `#[repr(align(...))]` can only be applied to data types
+   = help: the `repr(align(...))` attribute can only be applied to data types
    = help: use `#[rustc_align(...)]` instead
 
 error: expected a literal (`1u8`, `1.0f32`, `"string"`, etc.) here, found expression
@@ -96,37 +96,37 @@ error[E0589]: invalid alignment value: not a power of two
 LL | #[rustc_align(3)]
    |               ^
 
-error: `#[rustc_align]` attribute cannot be used on structs
-  --> $DIR/malformed-fn-align.rs:44:1
+error: the `rustc_align` attribute cannot be used on structs
+  --> $DIR/malformed-fn-align.rs:44:3
    |
 LL | #[rustc_align(16)]
-   | ^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^
    |
-   = help: `#[rustc_align]` can only be applied to functions
+   = help: the `rustc_align` attribute can only be applied to functions
 
-error: `#[rustc_align]` attribute cannot be used on constants
-  --> $DIR/malformed-fn-align.rs:47:1
+error: the `rustc_align` attribute cannot be used on constants
+  --> $DIR/malformed-fn-align.rs:47:3
    |
 LL | #[rustc_align(32)]
-   | ^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^
    |
-   = help: `#[rustc_align]` can only be applied to functions
+   = help: the `rustc_align` attribute can only be applied to functions
 
-error: `#[rustc_align]` attribute cannot be used on modules
-  --> $DIR/malformed-fn-align.rs:50:1
+error: the `rustc_align` attribute cannot be used on modules
+  --> $DIR/malformed-fn-align.rs:50:3
    |
 LL | #[rustc_align(32)]
-   | ^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^
    |
-   = help: `#[rustc_align]` can only be applied to functions
+   = help: the `rustc_align` attribute can only be applied to functions
 
-error: `#[rustc_align]` attribute cannot be used on use statements
-  --> $DIR/malformed-fn-align.rs:53:1
+error: the `rustc_align` attribute cannot be used on use statements
+  --> $DIR/malformed-fn-align.rs:53:3
    |
 LL | #[rustc_align(32)]
-   | ^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^
    |
-   = help: `#[rustc_align]` can only be applied to functions
+   = help: the `rustc_align` attribute can only be applied to functions
 
 error: aborting due to 15 previous errors
 

--- a/tests/ui/attributes/malformed-must_use.stderr
+++ b/tests/ui/attributes/malformed-must_use.stderr
@@ -1,8 +1,8 @@
 error[E0539]: malformed `must_use` attribute input
-  --> $DIR/malformed-must_use.rs:1:1
+  --> $DIR/malformed-must_use.rs:1:3
    |
 LL | #[must_use()]
-   | ^^^^^^^^^^--^
+   |   ^^^^^^^^--
    |           |
    |           didn't expect a list here
    |

--- a/tests/ui/attributes/malformed-never-type-options.stderr
+++ b/tests/ui/attributes/malformed-never-type-options.stderr
@@ -1,11 +1,11 @@
 error[E0658]: use of an internal attribute
-  --> $DIR/malformed-never-type-options.rs:4:1
+  --> $DIR/malformed-never-type-options.rs:4:4
    |
 LL | #![rustc_never_type_options(: Unsize<U> = "hi")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable
-   = note: the `#[rustc_never_type_options]` attribute is an internal implementation detail that will never be stable
+   = note: the `rustc_never_type_options` attribute is an internal implementation detail that will never be stable
    = note: `rustc_never_type_options` is used to experiment with never type fallback and work on never type stabilization
 
 error: expected a literal (`1u8`, `1.0f32`, `"string"`, etc.) here, found `:`

--- a/tests/ui/attributes/malformed-no-std.stderr
+++ b/tests/ui/attributes/malformed-no-std.stderr
@@ -1,8 +1,8 @@
 error[E0565]: malformed `no_std` attribute input
-  --> $DIR/malformed-no-std.rs:3:1
+  --> $DIR/malformed-no-std.rs:3:4
    |
 LL | #![no_std = "foo"]
-   | ^^^^^^^^^^-------^
+   |    ^^^^^^^-------
    |           |
    |           didn't expect any arguments here
    |
@@ -13,10 +13,10 @@ LL + #![no_std]
    |
 
 error[E0565]: malformed `no_std` attribute input
-  --> $DIR/malformed-no-std.rs:5:1
+  --> $DIR/malformed-no-std.rs:5:4
    |
 LL | #![no_std("bar")]
-   | ^^^^^^^^^-------^
+   |    ^^^^^^-------
    |          |
    |          didn't expect any arguments here
    |
@@ -27,10 +27,10 @@ LL + #![no_std]
    |
 
 error[E0565]: malformed `no_std` attribute input
-  --> $DIR/malformed-no-std.rs:8:1
+  --> $DIR/malformed-no-std.rs:8:4
    |
 LL | #![no_std(foo = "bar")]
-   | ^^^^^^^^^-------------^
+   |    ^^^^^^-------------
    |          |
    |          didn't expect any arguments here
    |
@@ -41,10 +41,10 @@ LL + #![no_std]
    |
 
 error[E0565]: malformed `no_core` attribute input
-  --> $DIR/malformed-no-std.rs:11:1
+  --> $DIR/malformed-no-std.rs:11:4
    |
 LL | #![no_core = "foo"]
-   | ^^^^^^^^^^^-------^
+   |    ^^^^^^^^-------
    |            |
    |            didn't expect any arguments here
    |
@@ -55,10 +55,10 @@ LL + #![no_core]
    |
 
 error[E0565]: malformed `no_core` attribute input
-  --> $DIR/malformed-no-std.rs:13:1
+  --> $DIR/malformed-no-std.rs:13:4
    |
 LL | #![no_core("bar")]
-   | ^^^^^^^^^^-------^
+   |    ^^^^^^^-------
    |           |
    |           didn't expect any arguments here
    |
@@ -81,10 +81,10 @@ LL | #![no_core = "foo"]
    | ^^^^^^^^^^^^^^^^^^^
 
 error[E0565]: malformed `no_core` attribute input
-  --> $DIR/malformed-no-std.rs:16:1
+  --> $DIR/malformed-no-std.rs:16:4
    |
 LL | #![no_core(foo = "bar")]
-   | ^^^^^^^^^^-------------^
+   |    ^^^^^^^-------------
    |           |
    |           didn't expect any arguments here
    |

--- a/tests/ui/attributes/malformed-reprs.stderr
+++ b/tests/ui/attributes/malformed-reprs.stderr
@@ -1,8 +1,8 @@
 error[E0539]: malformed `repr` attribute input
-  --> $DIR/malformed-reprs.rs:4:1
+  --> $DIR/malformed-reprs.rs:4:4
    |
 LL | #![repr]
-   | ^^^^^^^^ expected this to be a list
+   |    ^^^^ expected this to be a list
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/type-layout.html#representations>
 

--- a/tests/ui/attributes/malformed-static-align.rs
+++ b/tests/ui/attributes/malformed-static-align.rs
@@ -13,5 +13,5 @@ static S3: () = ();
 #[repr(align(16))] //~ ERROR attribute cannot be used on
 static S4: () = ();
 
-#[rustc_align_static(16)] //~ ERROR `#[rustc_align_static]` attribute cannot be used on structs
+#[rustc_align_static(16)] //~ ERROR `rustc_align_static` attribute cannot be used on structs
 struct Struct1;

--- a/tests/ui/attributes/malformed-static-align.stderr
+++ b/tests/ui/attributes/malformed-static-align.stderr
@@ -24,22 +24,22 @@ error[E0589]: invalid alignment value: not a power of two
 LL | #[rustc_align_static(0)]
    |                      ^
 
-error: `#[repr(align(...))]` attribute cannot be used on statics
-  --> $DIR/malformed-static-align.rs:13:1
+error: the `repr(align(...))` attribute cannot be used on statics
+  --> $DIR/malformed-static-align.rs:13:3
    |
 LL | #[repr(align(16))]
-   | ^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^
    |
-   = help: `#[repr(align(...))]` can only be applied to data types
+   = help: the `repr(align(...))` attribute can only be applied to data types
    = help: use `#[rustc_align_static(...)]` instead
 
-error: `#[rustc_align_static]` attribute cannot be used on structs
-  --> $DIR/malformed-static-align.rs:16:1
+error: the `rustc_align_static` attribute cannot be used on structs
+  --> $DIR/malformed-static-align.rs:16:3
    |
 LL | #[rustc_align_static(16)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_align_static]` can be applied to foreign statics and statics
+   = help: the `rustc_align_static` attribute can be applied to foreign statics and statics
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/attributes/malformed-static-align.stderr
+++ b/tests/ui/attributes/malformed-static-align.stderr
@@ -1,8 +1,8 @@
 error[E0539]: malformed `rustc_align_static` attribute input
-  --> $DIR/malformed-static-align.rs:4:1
+  --> $DIR/malformed-static-align.rs:4:3
    |
 LL | #[rustc_align_static = 16]
-   | ^^^^^^^^^^^^^^^^^^^^^----^
+   |   ^^^^^^^^^^^^^^^^^^^----
    |                      |
    |                      expected this to be a list
    |

--- a/tests/ui/attributes/malformed-unstable-removed.stderr
+++ b/tests/ui/attributes/malformed-unstable-removed.stderr
@@ -1,8 +1,8 @@
 error[E0539]: malformed `unstable_removed` attribute input
-  --> $DIR/malformed-unstable-removed.rs:3:1
+  --> $DIR/malformed-unstable-removed.rs:3:4
    |
 LL | #![unstable_removed(feature = "old_feature")]
-   | ^^^^^^^^^^^^^^^^^^^-------------------------^
+   |    ^^^^^^^^^^^^^^^^-------------------------
    |                    |
    |                    missing argument `reason = "..."`
    |
@@ -13,10 +13,10 @@ LL + #![unstable_removed(feature = "name", reason = "...", link = "...", since =
    |
 
 error[E0539]: malformed `unstable_removed` attribute input
-  --> $DIR/malformed-unstable-removed.rs:6:1
+  --> $DIR/malformed-unstable-removed.rs:6:4
    |
 LL | #![unstable_removed(invalid = "old_feature")]
-   | ^^^^^^^^^^^^^^^^^^^^-----------------------^^
+   |    ^^^^^^^^^^^^^^^^^-----------------------^
    |                     |
    |                     valid arguments are `feature`, `reason`, `link` or `since`
    |
@@ -27,10 +27,10 @@ LL + #![unstable_removed(feature = "name", reason = "...", link = "...", since =
    |
 
 error[E0565]: malformed `unstable_removed` attribute input
-  --> $DIR/malformed-unstable-removed.rs:9:1
+  --> $DIR/malformed-unstable-removed.rs:9:4
    |
 LL | #![unstable_removed("invalid literal")]
-   | ^^^^^^^^^^^^^^^^^^^^-----------------^^
+   |    ^^^^^^^^^^^^^^^^^-----------------^
    |                     |
    |                     didn't expect a literal here
    |
@@ -41,10 +41,10 @@ LL + #![unstable_removed(feature = "name", reason = "...", link = "...", since =
    |
 
 error[E0539]: malformed `unstable_removed` attribute input
-  --> $DIR/malformed-unstable-removed.rs:12:1
+  --> $DIR/malformed-unstable-removed.rs:12:4
    |
 LL | #![unstable_removed = "invalid literal"]
-   | ^^^^^^^^^^^^^^^^^^^^-------------------^
+   |    ^^^^^^^^^^^^^^^^^-------------------
    |                     |
    |                     expected this to be a list
    |

--- a/tests/ui/attributes/may_dangle.stderr
+++ b/tests/ui/attributes/may_dangle.stderr
@@ -1,42 +1,42 @@
-error: `#[may_dangle]` attribute cannot be used on const parameters
-  --> $DIR/may_dangle.rs:14:20
+error: the `may_dangle` attribute cannot be used on const parameters
+  --> $DIR/may_dangle.rs:14:22
    |
 LL | unsafe impl<'a, T, #[may_dangle] const N: usize> Drop for Implee1<'a, T, N> {
-   |                    ^^^^^^^^^^^^^
+   |                      ^^^^^^^^^^
    |
-   = help: `#[may_dangle]` can be applied to lifetime parameters and type parameters
+   = help: the `may_dangle` attribute can be applied to lifetime parameters and type parameters
 
-error: `#[may_dangle]` attribute cannot be used on structs
-  --> $DIR/may_dangle.rs:42:1
+error: the `may_dangle` attribute cannot be used on structs
+  --> $DIR/may_dangle.rs:42:3
    |
 LL | #[may_dangle]
-   | ^^^^^^^^^^^^^
+   |   ^^^^^^^^^^
    |
-   = help: `#[may_dangle]` can be applied to lifetime parameters and type parameters
+   = help: the `may_dangle` attribute can be applied to lifetime parameters and type parameters
 
-error: `#[may_dangle]` attribute cannot be used on trait impl blocks
-  --> $DIR/may_dangle.rs:45:1
+error: the `may_dangle` attribute cannot be used on trait impl blocks
+  --> $DIR/may_dangle.rs:45:3
    |
 LL | #[may_dangle]
-   | ^^^^^^^^^^^^^
+   |   ^^^^^^^^^^
    |
-   = help: `#[may_dangle]` can be applied to lifetime parameters and type parameters
+   = help: the `may_dangle` attribute can be applied to lifetime parameters and type parameters
 
-error: `#[may_dangle]` attribute cannot be used on functions
-  --> $DIR/may_dangle.rs:49:1
+error: the `may_dangle` attribute cannot be used on functions
+  --> $DIR/may_dangle.rs:49:3
    |
 LL | #[may_dangle]
-   | ^^^^^^^^^^^^^
+   |   ^^^^^^^^^^
    |
-   = help: `#[may_dangle]` can be applied to lifetime parameters and type parameters
+   = help: the `may_dangle` attribute can be applied to lifetime parameters and type parameters
 
-error: `#[may_dangle]` attribute cannot be used on statements
-  --> $DIR/may_dangle.rs:51:5
+error: the `may_dangle` attribute cannot be used on statements
+  --> $DIR/may_dangle.rs:51:7
    |
 LL |     #[may_dangle]
-   |     ^^^^^^^^^^^^^
+   |       ^^^^^^^^^^
    |
-   = help: `#[may_dangle]` can be applied to lifetime parameters and type parameters
+   = help: the `may_dangle` attribute can be applied to lifetime parameters and type parameters
 
 error: `#[may_dangle]` must be applied to a lifetime or type generic parameter in `Drop` impl
   --> $DIR/may_dangle.rs:8:13

--- a/tests/ui/attributes/multiple-invalid.stderr
+++ b/tests/ui/attributes/multiple-invalid.stderr
@@ -1,18 +1,18 @@
-error: `#[inline]` attribute cannot be used on constants
-  --> $DIR/multiple-invalid.rs:4:1
+error: the `inline` attribute cannot be used on constants
+  --> $DIR/multiple-invalid.rs:4:3
    |
 LL | #[inline]
-   | ^^^^^^^^^
+   |   ^^^^^^
    |
-   = help: `#[inline]` can only be applied to functions
+   = help: the `inline` attribute can only be applied to functions
 
-error: `#[target_feature]` attribute cannot be used on constants
-  --> $DIR/multiple-invalid.rs:6:1
+error: the `target_feature` attribute cannot be used on constants
+  --> $DIR/multiple-invalid.rs:6:3
    |
 LL | #[target_feature(enable = "sse2")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^
    |
-   = help: `#[target_feature]` can only be applied to functions
+   = help: the `target_feature` attribute can only be applied to functions
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/attributes/no-mangle-closure.rs
+++ b/tests/ui/attributes/no-mangle-closure.rs
@@ -7,5 +7,5 @@ pub struct S([usize; 8]);
 
 pub fn outer_function(x: S, y: S) -> usize {
     (#[no_mangle] || y.0[0])()
-    //~^ ERROR `#[no_mangle]` attribute cannot be used on closures
+    //~^ ERROR the `no_mangle` attribute cannot be used on closures
 }

--- a/tests/ui/attributes/no-mangle-closure.stderr
+++ b/tests/ui/attributes/no-mangle-closure.stderr
@@ -1,10 +1,10 @@
-error: `#[no_mangle]` attribute cannot be used on closures
-  --> $DIR/no-mangle-closure.rs:9:6
+error: the `no_mangle` attribute cannot be used on closures
+  --> $DIR/no-mangle-closure.rs:9:8
    |
 LL |     (#[no_mangle] || y.0[0])()
-   |      ^^^^^^^^^^^^
+   |        ^^^^^^^^^
    |
-   = help: `#[no_mangle]` can be applied to functions, methods, and statics
+   = help: the `no_mangle` attribute can be applied to functions, methods, and statics
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/attributes/optimize.stderr
+++ b/tests/ui/attributes/optimize.stderr
@@ -1,42 +1,42 @@
-error: `#[optimize]` attribute cannot be used on structs
-  --> $DIR/optimize.rs:8:1
+error: the `optimize` attribute cannot be used on structs
+  --> $DIR/optimize.rs:8:3
    |
 LL | #[optimize(speed)]
-   | ^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^
    |
-   = help: `#[optimize]` can only be applied to functions
+   = help: the `optimize` attribute can only be applied to functions
 
-error: `#[optimize]` attribute cannot be used on expressions
-  --> $DIR/optimize.rs:12:5
+error: the `optimize` attribute cannot be used on expressions
+  --> $DIR/optimize.rs:12:7
    |
 LL |     #[optimize(speed)]
-   |     ^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^
    |
-   = help: `#[optimize]` can only be applied to functions
+   = help: the `optimize` attribute can only be applied to functions
 
-error: `#[optimize]` attribute cannot be used on modules
-  --> $DIR/optimize.rs:21:1
+error: the `optimize` attribute cannot be used on modules
+  --> $DIR/optimize.rs:21:3
    |
 LL | #[optimize(speed)]
-   | ^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^
    |
-   = help: `#[optimize]` can only be applied to functions
+   = help: the `optimize` attribute can only be applied to functions
 
-error: `#[optimize]` attribute cannot be used on inherent impl blocks
-  --> $DIR/optimize.rs:24:1
+error: the `optimize` attribute cannot be used on inherent impl blocks
+  --> $DIR/optimize.rs:24:3
    |
 LL | #[optimize(speed)]
-   | ^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^
    |
-   = help: `#[optimize]` can only be applied to functions
+   = help: the `optimize` attribute can only be applied to functions
 
-error: `#[optimize]` attribute cannot be used on required trait methods
-  --> $DIR/optimize.rs:45:5
+error: the `optimize` attribute cannot be used on required trait methods
+  --> $DIR/optimize.rs:45:7
    |
 LL |     #[optimize(speed)]
-   |     ^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^
    |
-   = help: `#[optimize]` can only be applied to functions with a body
+   = help: the `optimize` attribute can only be applied to functions with a body
 
 error: multiple `optimize` attributes
   --> $DIR/optimize.rs:59:1

--- a/tests/ui/attributes/pass-indirectly.rs
+++ b/tests/ui/attributes/pass-indirectly.rs
@@ -4,7 +4,7 @@
 #![crate_type = "lib"]
 
 #[rustc_pass_indirectly_in_non_rustic_abis]
-//~^ ERROR: `#[rustc_pass_indirectly_in_non_rustic_abis]` attribute cannot be used on functions
+//~^ ERROR: the `rustc_pass_indirectly_in_non_rustic_abis` attribute cannot be used on functions
 fn not_a_struct() {}
 
 #[repr(C)]

--- a/tests/ui/attributes/pass-indirectly.stderr
+++ b/tests/ui/attributes/pass-indirectly.stderr
@@ -1,10 +1,10 @@
-error: `#[rustc_pass_indirectly_in_non_rustic_abis]` attribute cannot be used on functions
-  --> $DIR/pass-indirectly.rs:6:1
+error: the `rustc_pass_indirectly_in_non_rustic_abis` attribute cannot be used on functions
+  --> $DIR/pass-indirectly.rs:6:3
    |
 LL | #[rustc_pass_indirectly_in_non_rustic_abis]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_pass_indirectly_in_non_rustic_abis]` can only be applied to structs
+   = help: the `rustc_pass_indirectly_in_non_rustic_abis` attribute can only be applied to structs
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/attributes/positions/used.stderr
+++ b/tests/ui/attributes/positions/used.stderr
@@ -1,42 +1,42 @@
-error: `#[used]` attribute cannot be used on functions
-  --> $DIR/used.rs:7:1
+error: the `used` attribute cannot be used on functions
+  --> $DIR/used.rs:7:3
    |
 LL | #[used]
-   | ^^^^^^^
+   |   ^^^^
    |
-   = help: `#[used]` can only be applied to statics
+   = help: the `used` attribute can only be applied to statics
 
-error: `#[used]` attribute cannot be used on structs
-  --> $DIR/used.rs:10:1
+error: the `used` attribute cannot be used on structs
+  --> $DIR/used.rs:10:3
    |
 LL | #[used]
-   | ^^^^^^^
+   |   ^^^^
    |
-   = help: `#[used]` can only be applied to statics
+   = help: the `used` attribute can only be applied to statics
 
-error: `#[used]` attribute cannot be used on traits
-  --> $DIR/used.rs:13:1
+error: the `used` attribute cannot be used on traits
+  --> $DIR/used.rs:13:3
    |
 LL | #[used]
-   | ^^^^^^^
+   |   ^^^^
    |
-   = help: `#[used]` can only be applied to statics
+   = help: the `used` attribute can only be applied to statics
 
-error: `#[used]` attribute cannot be used on trait impl blocks
-  --> $DIR/used.rs:16:1
+error: the `used` attribute cannot be used on trait impl blocks
+  --> $DIR/used.rs:16:3
    |
 LL | #[used]
-   | ^^^^^^^
+   |   ^^^^
    |
-   = help: `#[used]` can only be applied to statics
+   = help: the `used` attribute can only be applied to statics
 
-error: `#[used]` attribute cannot be used on foreign statics
-  --> $DIR/used.rs:21:5
+error: the `used` attribute cannot be used on foreign statics
+  --> $DIR/used.rs:21:7
    |
 LL |     #[used]
-   |     ^^^^^^^
+   |       ^^^^
    |
-   = help: `#[used]` can only be applied to statics
+   = help: the `used` attribute can only be applied to statics
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/attributes/repr-align-in-trait-issue-132391.stderr
+++ b/tests/ui/attributes/repr-align-in-trait-issue-132391.stderr
@@ -1,10 +1,10 @@
-error: `#[repr(align(...))]` attribute cannot be used on required trait methods
-  --> $DIR/repr-align-in-trait-issue-132391.rs:2:5
+error: the `repr(align(...))` attribute cannot be used on required trait methods
+  --> $DIR/repr-align-in-trait-issue-132391.rs:2:7
    |
 LL |     #[repr(align)]
-   |     ^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^
    |
-   = help: `#[repr(align(...))]` can only be applied to data types
+   = help: the `repr(align(...))` attribute can only be applied to data types
 
 error[E0539]: malformed `repr` attribute input
   --> $DIR/repr-align-in-trait-issue-132391.rs:2:5

--- a/tests/ui/attributes/repr-align-in-trait-issue-132391.stderr
+++ b/tests/ui/attributes/repr-align-in-trait-issue-132391.stderr
@@ -7,10 +7,10 @@ LL |     #[repr(align)]
    = help: the `repr(align(...))` attribute can only be applied to data types
 
 error[E0539]: malformed `repr` attribute input
-  --> $DIR/repr-align-in-trait-issue-132391.rs:2:5
+  --> $DIR/repr-align-in-trait-issue-132391.rs:2:7
    |
 LL |     #[repr(align)]
-   |     ^^^^^^^-----^^
+   |       ^^^^^-----^
    |            |
    |            expected this to be a list
    |

--- a/tests/ui/attributes/rustc_confusables.stderr
+++ b/tests/ui/attributes/rustc_confusables.stderr
@@ -29,13 +29,13 @@ LL -     #[rustc_confusables(invalid_meta_item)]
 LL +     #[rustc_confusables("name1", "name2", ...)]
    |
 
-error: `#[rustc_confusables]` attribute cannot be used on functions
-  --> $DIR/rustc_confusables.rs:45:1
+error: the `rustc_confusables` attribute cannot be used on functions
+  --> $DIR/rustc_confusables.rs:45:3
    |
 LL | #[rustc_confusables("blah")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_confusables]` can only be applied to inherent methods
+   = help: the `rustc_confusables` attribute can only be applied to inherent methods
 
 error[E0599]: no method named `inser` found for struct `rustc_confusables_across_crate::BTreeSet` in the current scope
   --> $DIR/rustc_confusables.rs:12:7

--- a/tests/ui/attributes/rustc_confusables.stderr
+++ b/tests/ui/attributes/rustc_confusables.stderr
@@ -5,10 +5,10 @@ LL |     #[rustc_confusables()]
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0539]: malformed `rustc_confusables` attribute input
-  --> $DIR/rustc_confusables.rs:34:5
+  --> $DIR/rustc_confusables.rs:34:7
    |
 LL |     #[rustc_confusables]
-   |     ^^^^^^^^^^^^^^^^^^^^ expected this to be a list
+   |       ^^^^^^^^^^^^^^^^^ expected this to be a list
    |
 help: must be of the form
    |
@@ -16,10 +16,10 @@ LL |     #[rustc_confusables("name1", "name2", ...)]
    |                        +++++++++++++++++++++++
 
 error[E0539]: malformed `rustc_confusables` attribute input
-  --> $DIR/rustc_confusables.rs:39:5
+  --> $DIR/rustc_confusables.rs:39:7
    |
 LL |     #[rustc_confusables(invalid_meta_item)]
-   |     ^^^^^^^^^^^^^^^^^^^^-----------------^^
+   |       ^^^^^^^^^^^^^^^^^^-----------------^
    |                         |
    |                         expected a string literal here
    |

--- a/tests/ui/attributes/rustc_skip_during_method_dispatch.stderr
+++ b/tests/ui/attributes/rustc_skip_during_method_dispatch.stderr
@@ -91,13 +91,13 @@ LL - #[rustc_skip_during_method_dispatch("array")]
 LL + #[rustc_skip_during_method_dispatch(array, boxed_slice)]
    |
 
-error: `#[rustc_skip_during_method_dispatch]` attribute cannot be used on trait impl blocks
-  --> $DIR/rustc_skip_during_method_dispatch.rs:34:1
+error: the `rustc_skip_during_method_dispatch` attribute cannot be used on trait impl blocks
+  --> $DIR/rustc_skip_during_method_dispatch.rs:34:3
    |
 LL | #[rustc_skip_during_method_dispatch(array)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_skip_during_method_dispatch]` can only be applied to traits
+   = help: the `rustc_skip_during_method_dispatch` attribute can only be applied to traits
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/attributes/rustc_skip_during_method_dispatch.stderr
+++ b/tests/ui/attributes/rustc_skip_during_method_dispatch.stderr
@@ -1,8 +1,8 @@
 error[E0539]: malformed `rustc_skip_during_method_dispatch` attribute input
-  --> $DIR/rustc_skip_during_method_dispatch.rs:3:1
+  --> $DIR/rustc_skip_during_method_dispatch.rs:3:3
    |
 LL | #[rustc_skip_during_method_dispatch]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected this to be a list
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected this to be a list
    |
 help: must be of the form
    |
@@ -10,10 +10,10 @@ LL | #[rustc_skip_during_method_dispatch(array, boxed_slice)]
    |                                    ++++++++++++++++++++
 
 error[E0539]: malformed `rustc_skip_during_method_dispatch` attribute input
-  --> $DIR/rustc_skip_during_method_dispatch.rs:7:1
+  --> $DIR/rustc_skip_during_method_dispatch.rs:7:3
    |
 LL | #[rustc_skip_during_method_dispatch = "array"]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---------^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---------
    |                                     |
    |                                     expected this to be a list
    |
@@ -24,10 +24,10 @@ LL + #[rustc_skip_during_method_dispatch(array, boxed_slice)]
    |
 
 error[E0539]: malformed `rustc_skip_during_method_dispatch` attribute input
-  --> $DIR/rustc_skip_during_method_dispatch.rs:11:1
+  --> $DIR/rustc_skip_during_method_dispatch.rs:11:3
    |
 LL | #[rustc_skip_during_method_dispatch()]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^--^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^--
    |                                    |
    |                                    expected at least 1 argument here
    |
@@ -37,10 +37,10 @@ LL | #[rustc_skip_during_method_dispatch(array, boxed_slice)]
    |                                     ++++++++++++++++++
 
 error[E0538]: malformed `rustc_skip_during_method_dispatch` attribute input
-  --> $DIR/rustc_skip_during_method_dispatch.rs:15:1
+  --> $DIR/rustc_skip_during_method_dispatch.rs:15:3
    |
 LL | #[rustc_skip_during_method_dispatch(array, boxed_slice, array)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-----^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-----^
    |                                                         |
    |                                                         found `array` used as a key more than once
    |
@@ -51,10 +51,10 @@ LL + #[rustc_skip_during_method_dispatch(array, boxed_slice)]
    |
 
 error[E0539]: malformed `rustc_skip_during_method_dispatch` attribute input
-  --> $DIR/rustc_skip_during_method_dispatch.rs:19:1
+  --> $DIR/rustc_skip_during_method_dispatch.rs:19:3
    |
 LL | #[rustc_skip_during_method_dispatch(slice)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-----^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-----^
    |                                     |
    |                                     valid arguments are `array` or `boxed_slice`
    |
@@ -64,10 +64,10 @@ LL | #[rustc_skip_during_method_dispatch(array, boxed_slice)]
    |                                     +++++++++++++
 
 error[E0565]: malformed `rustc_skip_during_method_dispatch` attribute input
-  --> $DIR/rustc_skip_during_method_dispatch.rs:23:1
+  --> $DIR/rustc_skip_during_method_dispatch.rs:23:3
    |
 LL | #[rustc_skip_during_method_dispatch(array = true)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------^
    |                                           |
    |                                           didn't expect any arguments here
    |
@@ -78,10 +78,10 @@ LL + #[rustc_skip_during_method_dispatch(array, boxed_slice)]
    |
 
 error[E0565]: malformed `rustc_skip_during_method_dispatch` attribute input
-  --> $DIR/rustc_skip_during_method_dispatch.rs:27:1
+  --> $DIR/rustc_skip_during_method_dispatch.rs:27:3
    |
 LL | #[rustc_skip_during_method_dispatch("array")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-------^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-------^
    |                                     |
    |                                     didn't expect a literal here
    |

--- a/tests/ui/attributes/unroll/invalid-unroll.stderr
+++ b/tests/ui/attributes/unroll/invalid-unroll.stderr
@@ -1,24 +1,24 @@
 error[E0539]: malformed `unroll` attribute input
-  --> $DIR/invalid-unroll.rs:5:5
+  --> $DIR/invalid-unroll.rs:5:7
    |
 LL |     #[unroll(please)]
-   |     ^^^^^^^^^------^^
+   |       ^^^^^^^------^
    |              |
    |              valid arguments are `full` or `never`
 
 error[E0539]: malformed `unroll` attribute input
-  --> $DIR/invalid-unroll.rs:8:5
+  --> $DIR/invalid-unroll.rs:8:7
    |
 LL |     #[unroll("never")]
-   |     ^^^^^^^^^-------^^
+   |       ^^^^^^^-------^
    |              |
    |              valid arguments are `full` or `never`
 
 error[E0805]: malformed `unroll` attribute input
-  --> $DIR/invalid-unroll.rs:11:5
+  --> $DIR/invalid-unroll.rs:11:7
    |
 LL |     #[unroll()]
-   |     ^^^^^^^^--^
+   |       ^^^^^^--
    |             |
    |             expected an argument here
 
@@ -35,10 +35,10 @@ LL +     #[unroll(1)]
    |
 
 error[E0539]: malformed `unroll` attribute input
-  --> $DIR/invalid-unroll.rs:17:5
+  --> $DIR/invalid-unroll.rs:17:7
    |
 LL |     #[unroll(1.5)]
-   |     ^^^^^^^^^---^^
+   |       ^^^^^^^---^
    |              |
    |              valid arguments are `full` or `never`
 

--- a/tests/ui/attributes/unsafe/proc-unsafe-attributes.stderr
+++ b/tests/ui/attributes/unsafe/proc-unsafe-attributes.stderr
@@ -91,10 +91,10 @@ LL | #[proc_macro_derive(r#unsafe(Foo))]
    |                     ++
 
 error[E0565]: malformed `proc_macro_derive` attribute input
-  --> $DIR/proc-unsafe-attributes.rs:12:1
+  --> $DIR/proc-unsafe-attributes.rs:12:3
    |
 LL | #[proc_macro_derive(unsafe(Foo))]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^-----^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^-----^
    |                           |
    |                           didn't expect any arguments here
    |

--- a/tests/ui/attributes/unstable_removed.stderr
+++ b/tests/ui/attributes/unstable_removed.stderr
@@ -1,14 +1,8 @@
 error[E0658]: stability attributes may not be used outside of the standard library
-  --> $DIR/unstable_removed.rs:9:1
+  --> $DIR/unstable_removed.rs:9:4
    |
-LL | / #![unstable_removed(
-LL | |
-LL | |     feature = "old_feature",
-LL | |     reason = "a good one",
-LL | |     link = "https://github.com/rust-lang/rust/issues/141617",
-LL | |     since="1.92.0"
-LL | | )]
-   | |__^
+LL | #![unstable_removed(
+   |    ^^^^^^^^^^^^^^^^
 
 error[E0557]: feature `old_feature` has been removed
   --> $DIR/unstable_removed.rs:3:12

--- a/tests/ui/attributes/used_with_multi_args.stderr
+++ b/tests/ui/attributes/used_with_multi_args.stderr
@@ -1,8 +1,8 @@
 error[E0805]: malformed `used` attribute input
-  --> $DIR/used_with_multi_args.rs:3:1
+  --> $DIR/used_with_multi_args.rs:3:3
    |
 LL | #[used(compiler, linker)]
-   | ^^^^^^------------------^
+   |   ^^^^------------------
    |       |
    |       expected a single argument here
    |

--- a/tests/ui/cfg/cfg-path-error.stderr
+++ b/tests/ui/cfg/cfg-path-error.stderr
@@ -1,8 +1,8 @@
 error[E0565]: malformed `cfg` attribute input
-  --> $DIR/cfg-path-error.rs:6:1
+  --> $DIR/cfg-path-error.rs:6:3
    |
 LL | #[cfg(any(foo, foo::bar))]
-   | ^^^^^^^^^^^^^^^--------^^^
+   |   ^^^^^^^^^^^^^--------^^
    |                |
    |                expected a valid identifier here
    |
@@ -14,10 +14,10 @@ LL + #[cfg(predicate)]
    |
 
 error[E0565]: malformed `cfg` attribute input
-  --> $DIR/cfg-path-error.rs:12:1
+  --> $DIR/cfg-path-error.rs:12:3
    |
 LL | #[cfg(any(foo::bar, foo))]
-   | ^^^^^^^^^^--------^^^^^^^^
+   |   ^^^^^^^^--------^^^^^^^
    |           |
    |           expected a valid identifier here
    |
@@ -29,10 +29,10 @@ LL + #[cfg(predicate)]
    |
 
 error[E0565]: malformed `cfg` attribute input
-  --> $DIR/cfg-path-error.rs:18:1
+  --> $DIR/cfg-path-error.rs:18:3
    |
 LL | #[cfg(all(foo, foo::bar))]
-   | ^^^^^^^^^^^^^^^--------^^^
+   |   ^^^^^^^^^^^^^--------^^
    |                |
    |                expected a valid identifier here
    |
@@ -44,10 +44,10 @@ LL + #[cfg(predicate)]
    |
 
 error[E0565]: malformed `cfg` attribute input
-  --> $DIR/cfg-path-error.rs:24:1
+  --> $DIR/cfg-path-error.rs:24:3
    |
 LL | #[cfg(all(foo::bar, foo))]
-   | ^^^^^^^^^^--------^^^^^^^^
+   |   ^^^^^^^^--------^^^^^^^
    |           |
    |           expected a valid identifier here
    |

--- a/tests/ui/cfg/cfg-target-compact-errors.stderr
+++ b/tests/ui/cfg/cfg-target-compact-errors.stderr
@@ -1,8 +1,8 @@
 error[E0565]: malformed `cfg` attribute input
-  --> $DIR/cfg-target-compact-errors.rs:5:1
+  --> $DIR/cfg-target-compact-errors.rs:5:3
    |
 LL | #[cfg(target(o::o))]
-   | ^^^^^^^^^^^^^----^^^
+   |   ^^^^^^^^^^^----^^
    |              |
    |              expected a valid identifier here
    |
@@ -14,10 +14,10 @@ LL + #[cfg(predicate)]
    |
 
 error[E0539]: malformed `cfg` attribute input
-  --> $DIR/cfg-target-compact-errors.rs:5:1
+  --> $DIR/cfg-target-compact-errors.rs:5:3
    |
 LL | #[cfg(target(o::o))]
-   | ^^^^^^^^^^^^^----^^^
+   |   ^^^^^^^^^^^----^^
    |              |
    |              expected this to be of the form `... = "..."`
    |
@@ -29,10 +29,10 @@ LL + #[cfg(predicate)]
    |
 
 error[E0539]: malformed `cfg` attribute input
-  --> $DIR/cfg-target-compact-errors.rs:14:1
+  --> $DIR/cfg-target-compact-errors.rs:14:3
    |
 LL | #[cfg(target(os = 8))]
-   | ^^^^^^^^^^^^^^^^^^-^^^
+   |   ^^^^^^^^^^^^^^^^-^^
    |                   |
    |                   expected a string literal here
    |
@@ -44,10 +44,10 @@ LL + #[cfg(predicate)]
    |
 
 error[E0539]: malformed `cfg` attribute input
-  --> $DIR/cfg-target-compact-errors.rs:20:1
+  --> $DIR/cfg-target-compact-errors.rs:20:3
    |
 LL | #[cfg(target(os = "linux", pointer(width = "64")))]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^---------------------^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^---------------------^^
    |                            |
    |                            expected this to be of the form `... = "..."`
    |
@@ -59,10 +59,10 @@ LL + #[cfg(predicate)]
    |
 
 error[E0539]: malformed `cfg` attribute input
-  --> $DIR/cfg-target-compact-errors.rs:26:1
+  --> $DIR/cfg-target-compact-errors.rs:26:3
    |
 LL | #[cfg(target(true))]
-   | ^^^^^^^^^^^^^----^^^
+   |   ^^^^^^^^^^^----^^
    |              |
    |              expected this to be of the form `... = "..."`
    |
@@ -74,10 +74,10 @@ LL + #[cfg(predicate)]
    |
 
 error[E0565]: malformed `cfg` attribute input
-  --> $DIR/cfg-target-compact-errors.rs:32:1
+  --> $DIR/cfg-target-compact-errors.rs:32:3
    |
 LL | #[cfg(target(clippy::os = "linux"))]
-   | ^^^^^^^^^^^^^----------^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^----------^^^^^^^^^^^^
    |              |
    |              expected a valid identifier here
    |

--- a/tests/ui/cfg/crate-attributes-using-cfg_attr.rs
+++ b/tests/ui/cfg/crate-attributes-using-cfg_attr.rs
@@ -3,10 +3,10 @@
 //@ reference: cfg.cfg_attr.attr-restriction
 
 #![cfg_attr(foo, crate_type="bin")]
-//~^ERROR `crate_type` within
-//~|ERROR `crate_type` within
+//~^ERROR `crate_type` attribute is forbidden within
+//~|ERROR `crate_type` attribute is forbidden within
 #![cfg_attr(foo, crate_name="bar")]
-//~^ERROR `crate_name` within
-//~|ERROR `crate_name` within
+//~^ERROR `crate_name` attribute is forbidden within
+//~|ERROR `crate_name` attribute is forbidden within
 
 fn main() {}

--- a/tests/ui/cfg/crate-attributes-using-cfg_attr.stderr
+++ b/tests/ui/cfg/crate-attributes-using-cfg_attr.stderr
@@ -1,28 +1,28 @@
-error: `crate_type` within a `#![cfg_attr]` attribute is forbidden
+error: the `crate_type` attribute is forbidden within a `cfg_attr` attribute
   --> $DIR/crate-attributes-using-cfg_attr.rs:5:18
    |
 LL | #![cfg_attr(foo, crate_type="bin")]
-   |                  ^^^^^^^^^^^^^^^^
+   |                  ^^^^^^^^^^
 
-error: `crate_name` within a `#![cfg_attr]` attribute is forbidden
+error: the `crate_name` attribute is forbidden within a `cfg_attr` attribute
   --> $DIR/crate-attributes-using-cfg_attr.rs:8:18
    |
 LL | #![cfg_attr(foo, crate_name="bar")]
-   |                  ^^^^^^^^^^^^^^^^
+   |                  ^^^^^^^^^^
 
-error: `crate_type` within a `#![cfg_attr]` attribute is forbidden
+error: the `crate_type` attribute is forbidden within a `cfg_attr` attribute
   --> $DIR/crate-attributes-using-cfg_attr.rs:5:18
    |
 LL | #![cfg_attr(foo, crate_type="bin")]
-   |                  ^^^^^^^^^^^^^^^^
+   |                  ^^^^^^^^^^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error: `crate_name` within a `#![cfg_attr]` attribute is forbidden
+error: the `crate_name` attribute is forbidden within a `cfg_attr` attribute
   --> $DIR/crate-attributes-using-cfg_attr.rs:8:18
    |
 LL | #![cfg_attr(foo, crate_name="bar")]
-   |                  ^^^^^^^^^^^^^^^^
+   |                  ^^^^^^^^^^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 

--- a/tests/ui/cfg/path-kw-as-cfg-pred.stderr
+++ b/tests/ui/cfg/path-kw-as-cfg-pred.stderr
@@ -119,10 +119,10 @@ LL | #[cfg_attr(r#_, cfg(r#_))]
    |                     ^^^
 
 error[E0565]: malformed `cfg` attribute input
-  --> $DIR/path-kw-as-cfg-pred.rs:20:1
+  --> $DIR/path-kw-as-cfg-pred.rs:20:3
    |
 LL | #[cfg(crate)]
-   | ^^^^^^-----^^
+   |   ^^^^-----^
    |       |
    |       expected a valid identifier here
    |
@@ -134,10 +134,10 @@ LL + #[cfg(predicate)]
    |
 
 error[E0565]: malformed `cfg` attribute input
-  --> $DIR/path-kw-as-cfg-pred.rs:22:1
+  --> $DIR/path-kw-as-cfg-pred.rs:22:3
    |
 LL | #[cfg(super)]
-   | ^^^^^^-----^^
+   |   ^^^^-----^
    |       |
    |       expected a valid identifier here
    |
@@ -149,10 +149,10 @@ LL + #[cfg(predicate)]
    |
 
 error[E0565]: malformed `cfg` attribute input
-  --> $DIR/path-kw-as-cfg-pred.rs:24:1
+  --> $DIR/path-kw-as-cfg-pred.rs:24:3
    |
 LL | #[cfg(self)]
-   | ^^^^^^----^^
+   |   ^^^^----^
    |       |
    |       expected a valid identifier here
    |
@@ -164,10 +164,10 @@ LL + #[cfg(predicate)]
    |
 
 error[E0565]: malformed `cfg` attribute input
-  --> $DIR/path-kw-as-cfg-pred.rs:26:1
+  --> $DIR/path-kw-as-cfg-pred.rs:26:3
    |
 LL | #[cfg(Self)]
-   | ^^^^^^----^^
+   |   ^^^^----^
    |       |
    |       expected a valid identifier here
    |
@@ -179,10 +179,10 @@ LL + #[cfg(predicate)]
    |
 
 error[E0565]: malformed `cfg_attr` attribute input
-  --> $DIR/path-kw-as-cfg-pred.rs:28:1
+  --> $DIR/path-kw-as-cfg-pred.rs:28:3
    |
 LL | #[cfg_attr(crate, path = "foo")]
-   | ^^^^^^^^^^^-----^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^-----^^^^^^^^^^^^^^^
    |            |
    |            expected a valid identifier here
    |
@@ -194,10 +194,10 @@ LL + #[cfg_attr(predicate, attr1, attr2, ...)]
    |
 
 error[E0565]: malformed `cfg_attr` attribute input
-  --> $DIR/path-kw-as-cfg-pred.rs:30:1
+  --> $DIR/path-kw-as-cfg-pred.rs:30:3
    |
 LL | #[cfg_attr(super, path = "foo")]
-   | ^^^^^^^^^^^-----^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^-----^^^^^^^^^^^^^^^
    |            |
    |            expected a valid identifier here
    |
@@ -209,10 +209,10 @@ LL + #[cfg_attr(predicate, attr1, attr2, ...)]
    |
 
 error[E0565]: malformed `cfg_attr` attribute input
-  --> $DIR/path-kw-as-cfg-pred.rs:32:1
+  --> $DIR/path-kw-as-cfg-pred.rs:32:3
    |
 LL | #[cfg_attr(self, path = "foo")]
-   | ^^^^^^^^^^^----^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^----^^^^^^^^^^^^^^^
    |            |
    |            expected a valid identifier here
    |
@@ -224,10 +224,10 @@ LL + #[cfg_attr(predicate, attr1, attr2, ...)]
    |
 
 error[E0565]: malformed `cfg_attr` attribute input
-  --> $DIR/path-kw-as-cfg-pred.rs:34:1
+  --> $DIR/path-kw-as-cfg-pred.rs:34:3
    |
 LL | #[cfg_attr(Self, path = "foo")]
-   | ^^^^^^^^^^^----^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^----^^^^^^^^^^^^^^^
    |            |
    |            expected a valid identifier here
    |
@@ -363,10 +363,10 @@ LL | #[cfg_attr(true, cfg(_))]
    |                      ^ expected identifier, found reserved identifier
 
 error[E0565]: malformed `cfg` attribute input
-  --> $DIR/path-kw-as-cfg-pred.rs:90:1
+  --> $DIR/path-kw-as-cfg-pred.rs:90:3
    |
 LL | #[cfg(r#crate)]
-   | ^^^^^^-------^^
+   |   ^^^^-------^
    |       |
    |       expected a valid identifier here
    |
@@ -378,10 +378,10 @@ LL + #[cfg(predicate)]
    |
 
 error[E0565]: malformed `cfg` attribute input
-  --> $DIR/path-kw-as-cfg-pred.rs:93:1
+  --> $DIR/path-kw-as-cfg-pred.rs:93:3
    |
 LL | #[cfg(r#super)]
-   | ^^^^^^-------^^
+   |   ^^^^-------^
    |       |
    |       expected a valid identifier here
    |
@@ -393,10 +393,10 @@ LL + #[cfg(predicate)]
    |
 
 error[E0565]: malformed `cfg` attribute input
-  --> $DIR/path-kw-as-cfg-pred.rs:96:1
+  --> $DIR/path-kw-as-cfg-pred.rs:96:3
    |
 LL | #[cfg(r#self)]
-   | ^^^^^^------^^
+   |   ^^^^------^
    |       |
    |       expected a valid identifier here
    |
@@ -408,10 +408,10 @@ LL + #[cfg(predicate)]
    |
 
 error[E0565]: malformed `cfg` attribute input
-  --> $DIR/path-kw-as-cfg-pred.rs:99:1
+  --> $DIR/path-kw-as-cfg-pred.rs:99:3
    |
 LL | #[cfg(r#Self)]
-   | ^^^^^^------^^
+   |   ^^^^------^
    |       |
    |       expected a valid identifier here
    |
@@ -423,10 +423,10 @@ LL + #[cfg(predicate)]
    |
 
 error[E0565]: malformed `cfg_attr` attribute input
-  --> $DIR/path-kw-as-cfg-pred.rs:102:1
+  --> $DIR/path-kw-as-cfg-pred.rs:102:3
    |
 LL | #[cfg_attr(r#crate, cfg(r#crate))]
-   | ^^^^^^^^^^^-------^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^-------^^^^^^^^^^^^^^^
    |            |
    |            expected a valid identifier here
    |
@@ -438,10 +438,10 @@ LL + #[cfg_attr(predicate, attr1, attr2, ...)]
    |
 
 error[E0565]: malformed `cfg_attr` attribute input
-  --> $DIR/path-kw-as-cfg-pred.rs:106:1
+  --> $DIR/path-kw-as-cfg-pred.rs:106:3
    |
 LL | #[cfg_attr(r#super, cfg(r#super))]
-   | ^^^^^^^^^^^-------^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^-------^^^^^^^^^^^^^^^
    |            |
    |            expected a valid identifier here
    |
@@ -453,10 +453,10 @@ LL + #[cfg_attr(predicate, attr1, attr2, ...)]
    |
 
 error[E0565]: malformed `cfg_attr` attribute input
-  --> $DIR/path-kw-as-cfg-pred.rs:110:1
+  --> $DIR/path-kw-as-cfg-pred.rs:110:3
    |
 LL | #[cfg_attr(r#self, cfg(r#self))]
-   | ^^^^^^^^^^^------^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^------^^^^^^^^^^^^^^
    |            |
    |            expected a valid identifier here
    |
@@ -468,10 +468,10 @@ LL + #[cfg_attr(predicate, attr1, attr2, ...)]
    |
 
 error[E0565]: malformed `cfg_attr` attribute input
-  --> $DIR/path-kw-as-cfg-pred.rs:114:1
+  --> $DIR/path-kw-as-cfg-pred.rs:114:3
    |
 LL | #[cfg_attr(r#Self, cfg(r#Self))]
-   | ^^^^^^^^^^^------^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^------^^^^^^^^^^^^^^
    |            |
    |            expected a valid identifier here
    |
@@ -483,10 +483,10 @@ LL + #[cfg_attr(predicate, attr1, attr2, ...)]
    |
 
 error[E0565]: malformed `cfg` attribute input
-  --> $DIR/path-kw-as-cfg-pred.rs:9:9
+  --> $DIR/path-kw-as-cfg-pred.rs:9:11
    |
 LL |         #[cfg($crate)]
-   |         ^^^^^^------^^
+   |           ^^^^------^
    |               |
    |               expected a valid identifier here
 ...
@@ -502,10 +502,10 @@ LL +         #[cfg(predicate)]
    |
 
 error[E0565]: malformed `cfg_attr` attribute input
-  --> $DIR/path-kw-as-cfg-pred.rs:11:9
+  --> $DIR/path-kw-as-cfg-pred.rs:11:11
    |
 LL |         #[cfg_attr($crate, path = "foo")]
-   |         ^^^^^^^^^^^------^^^^^^^^^^^^^^^^
+   |           ^^^^^^^^^------^^^^^^^^^^^^^^^
    |                    |
    |                    expected a valid identifier here
 ...

--- a/tests/ui/cfg/suggest-any-or-all.stderr
+++ b/tests/ui/cfg/suggest-any-or-all.stderr
@@ -1,8 +1,8 @@
 error[E0805]: malformed `cfg` attribute input
-  --> $DIR/suggest-any-or-all.rs:1:1
+  --> $DIR/suggest-any-or-all.rs:1:3
    |
 LL | #[cfg(foo, bar)]
-   | ^^^^^----------^
+   |   ^^^----------
    |      |
    |      expected a single argument here
    |
@@ -19,10 +19,10 @@ LL + #[cfg(any(foo, bar))]
    |
 
 error[E0805]: malformed `cfg` attribute input
-  --> $DIR/suggest-any-or-all.rs:5:1
+  --> $DIR/suggest-any-or-all.rs:5:3
    |
 LL | #[cfg()]
-   | ^^^^^--^
+   |   ^^^--
    |      |
    |      expected an argument here
    |

--- a/tests/ui/compile-flags/invalid/print-file-names-request-malformed-crate-name-1.stderr
+++ b/tests/ui/compile-flags/invalid/print-file-names-request-malformed-crate-name-1.stderr
@@ -1,8 +1,8 @@
 error[E0539]: malformed `crate_name` attribute input
-  --> $DIR/print-file-names-request-malformed-crate-name-1.rs:4:1
+  --> $DIR/print-file-names-request-malformed-crate-name-1.rs:4:4
    |
 LL | #![crate_name]
-   | ^^^^^^^^^^^^^^
+   |    ^^^^^^^^^^
    |
 help: must be of the form
    |

--- a/tests/ui/comptime/comptime_closure.rs
+++ b/tests/ui/comptime/comptime_closure.rs
@@ -2,7 +2,7 @@
 
 const _: () = {
     let f = #[rustc_comptime]
-    //~^ ERROR: `#[rustc_comptime]` attribute cannot be used on closures
+    //~^ ERROR: the `rustc_comptime` attribute cannot be used on closures
     || ();
 
     // FIXME(comptime): closures should work, too.

--- a/tests/ui/comptime/comptime_closure.stderr
+++ b/tests/ui/comptime/comptime_closure.stderr
@@ -1,10 +1,10 @@
-error: `#[rustc_comptime]` attribute cannot be used on closures
-  --> $DIR/comptime_closure.rs:4:13
+error: the `rustc_comptime` attribute cannot be used on closures
+  --> $DIR/comptime_closure.rs:4:15
    |
 LL |     let f = #[rustc_comptime]
-   |             ^^^^^^^^^^^^^^^^^
+   |               ^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_comptime]` can be applied to functions, inherent impl blocks, and inherent methods
+   = help: the `rustc_comptime` attribute can be applied to functions, inherent impl blocks, and inherent methods
 
 error[E0015]: cannot call non-const closure in constants
   --> $DIR/comptime_closure.rs:9:5

--- a/tests/ui/comptime/comptime_impl.stderr
+++ b/tests/ui/comptime/comptime_impl.stderr
@@ -1,10 +1,10 @@
-error: `#[rustc_comptime]` attribute cannot be used on trait impl blocks
-  --> $DIR/comptime_impl.rs:16:1
+error: the `rustc_comptime` attribute cannot be used on trait impl blocks
+  --> $DIR/comptime_impl.rs:16:3
    |
 LL | #[rustc_comptime]
-   | ^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_comptime]` can be applied to functions and inherent impl blocks
+   = help: the `rustc_comptime` attribute can be applied to functions and inherent impl blocks
 
 error[E0277]: the trait bound `Bar: const Foo` is not satisfied
   --> $DIR/comptime_impl.rs:29:9

--- a/tests/ui/comptime/comptime_trait.rs
+++ b/tests/ui/comptime/comptime_trait.rs
@@ -1,7 +1,7 @@
 #![feature(rustc_attrs, const_trait_impl, trait_alias)]
 
 #[rustc_comptime]
-//~^ ERROR: `#[rustc_comptime]` attribute cannot be used on traits
+//~^ ERROR: the `rustc_comptime` attribute cannot be used on traits
 trait Trait {
     fn method(&self) {}
 }
@@ -9,7 +9,7 @@ trait Trait {
 const impl Trait for () {}
 
 #[rustc_comptime]
-//~^ ERROR: `#[rustc_comptime]` attribute cannot be used on trait impl
+//~^ ERROR: the `rustc_comptime` attribute cannot be used on trait impl
 impl Trait for u32 {
     fn method(&self) {
         comptime_fn();
@@ -20,7 +20,7 @@ impl Trait for u32 {
 fn comptime_fn() {}
 
 #[rustc_comptime]
-//~^ ERROR: `#[rustc_comptime]` attribute cannot be used on trait aliases
+//~^ ERROR: the `rustc_comptime` attribute cannot be used on trait aliases
 trait TraitAlias = const Trait;
 
 #[rustc_comptime]

--- a/tests/ui/comptime/comptime_trait.stderr
+++ b/tests/ui/comptime/comptime_trait.stderr
@@ -1,26 +1,26 @@
-error: `#[rustc_comptime]` attribute cannot be used on traits
-  --> $DIR/comptime_trait.rs:3:1
+error: the `rustc_comptime` attribute cannot be used on traits
+  --> $DIR/comptime_trait.rs:3:3
    |
 LL | #[rustc_comptime]
-   | ^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_comptime]` can be applied to functions and inherent impl blocks
+   = help: the `rustc_comptime` attribute can be applied to functions and inherent impl blocks
 
-error: `#[rustc_comptime]` attribute cannot be used on trait impl blocks
-  --> $DIR/comptime_trait.rs:11:1
+error: the `rustc_comptime` attribute cannot be used on trait impl blocks
+  --> $DIR/comptime_trait.rs:11:3
    |
 LL | #[rustc_comptime]
-   | ^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_comptime]` can be applied to functions and inherent impl blocks
+   = help: the `rustc_comptime` attribute can be applied to functions and inherent impl blocks
 
-error: `#[rustc_comptime]` attribute cannot be used on trait aliases
-  --> $DIR/comptime_trait.rs:22:1
+error: the `rustc_comptime` attribute cannot be used on trait aliases
+  --> $DIR/comptime_trait.rs:22:3
    |
 LL | #[rustc_comptime]
-   | ^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_comptime]` can be applied to functions and inherent impl blocks
+   = help: the `rustc_comptime` attribute can be applied to functions and inherent impl blocks
 
 error[E0015]: cannot call non-const method `<T as Trait>::method` in constants
   --> $DIR/comptime_trait.rs:28:7

--- a/tests/ui/comptime/feature-gate-test.stderr
+++ b/tests/ui/comptime/feature-gate-test.stderr
@@ -1,11 +1,11 @@
 error[E0658]: use of an internal attribute
-  --> $DIR/feature-gate-test.rs:1:1
+  --> $DIR/feature-gate-test.rs:1:3
    |
 LL | #[rustc_comptime]
-   | ^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^
    |
    = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable
-   = note: the `#[rustc_comptime]` attribute is an internal implementation detail that will never be stable
+   = note: the `rustc_comptime` attribute is an internal implementation detail that will never be stable
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/comptime/trait_comptime.stderr
+++ b/tests/ui/comptime/trait_comptime.stderr
@@ -1,26 +1,26 @@
-error: `#[rustc_comptime]` attribute cannot be used on required trait methods
-  --> $DIR/trait_comptime.rs:4:5
+error: the `rustc_comptime` attribute cannot be used on required trait methods
+  --> $DIR/trait_comptime.rs:4:7
    |
 LL |     #[rustc_comptime]
-   |     ^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_comptime]` can be applied to functions with a body and inherent impl blocks
+   = help: the `rustc_comptime` attribute can be applied to functions with a body and inherent impl blocks
 
-error: `#[rustc_comptime]` attribute cannot be used on provided trait methods
-  --> $DIR/trait_comptime.rs:8:5
+error: the `rustc_comptime` attribute cannot be used on provided trait methods
+  --> $DIR/trait_comptime.rs:8:7
    |
 LL |     #[rustc_comptime]
-   |     ^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_comptime]` can be applied to functions, inherent impl blocks, and inherent methods
+   = help: the `rustc_comptime` attribute can be applied to functions, inherent impl blocks, and inherent methods
 
-error: `#[rustc_comptime]` attribute cannot be used on trait methods in impl blocks
-  --> $DIR/trait_comptime.rs:21:5
+error: the `rustc_comptime` attribute cannot be used on trait methods in impl blocks
+  --> $DIR/trait_comptime.rs:21:7
    |
 LL |     #[rustc_comptime]
-   |     ^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_comptime]` can be applied to functions, inherent impl blocks, and inherent methods
+   = help: the `rustc_comptime` attribute can be applied to functions, inherent impl blocks, and inherent methods
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/conditional-compilation/cfg-attr-crate-2.rs
+++ b/tests/ui/conditional-compilation/cfg-attr-crate-2.rs
@@ -3,6 +3,6 @@
 //@ compile-flags: --cfg broken --check-cfg=cfg(broken)
 
 #![crate_type = "lib"]
-#![cfg_attr(broken, no_core)] //~ ERROR the `#[no_core]` attribute is an experimental feature
+#![cfg_attr(broken, no_core)] //~ ERROR the `no_core` attribute is an experimental feature
 
 pub struct S {}

--- a/tests/ui/conditional-compilation/cfg-attr-crate-2.stderr
+++ b/tests/ui/conditional-compilation/cfg-attr-crate-2.stderr
@@ -1,4 +1,4 @@
-error[E0658]: the `#[no_core]` attribute is an experimental feature
+error[E0658]: the `no_core` attribute is an experimental feature
   --> $DIR/cfg-attr-crate-2.rs:6:21
    |
 LL | #![cfg_attr(broken, no_core)]

--- a/tests/ui/conditional-compilation/cfg-attr-invalid-predicate.stderr
+++ b/tests/ui/conditional-compilation/cfg-attr-invalid-predicate.stderr
@@ -1,8 +1,8 @@
 error[E0539]: malformed `cfg` attribute input
-  --> $DIR/cfg-attr-invalid-predicate.rs:1:1
+  --> $DIR/cfg-attr-invalid-predicate.rs:1:3
    |
 LL | #[cfg(foo(bar))]
-   | ^^^^^^--------^^
+   |   ^^^^--------^
    |       |
    |       valid arguments are `any`, `all`, `not` or `target`
    |

--- a/tests/ui/conditional-compilation/cfg-attr-multi-invalid-1.rs
+++ b/tests/ui/conditional-compilation/cfg-attr-multi-invalid-1.rs
@@ -2,6 +2,6 @@
 
 #![crate_type = "lib"]
 #![cfg_attr(broken, no_core, no_std)]
-//~^ ERROR the `#[no_core]` attribute is an experimental feature
+//~^ ERROR the `no_core` attribute is an experimental feature
 
 pub struct S {}

--- a/tests/ui/conditional-compilation/cfg-attr-multi-invalid-1.stderr
+++ b/tests/ui/conditional-compilation/cfg-attr-multi-invalid-1.stderr
@@ -1,4 +1,4 @@
-error[E0658]: the `#[no_core]` attribute is an experimental feature
+error[E0658]: the `no_core` attribute is an experimental feature
   --> $DIR/cfg-attr-multi-invalid-1.rs:4:21
    |
 LL | #![cfg_attr(broken, no_core, no_std)]

--- a/tests/ui/conditional-compilation/cfg-attr-multi-invalid-2.rs
+++ b/tests/ui/conditional-compilation/cfg-attr-multi-invalid-2.rs
@@ -2,6 +2,6 @@
 
 #![crate_type = "lib"]
 #![cfg_attr(broken, no_std, no_core)]
-//~^ ERROR the `#[no_core]` attribute is an experimental feature
+//~^ ERROR the `no_core` attribute is an experimental feature
 
 pub struct S {}

--- a/tests/ui/conditional-compilation/cfg-attr-multi-invalid-2.stderr
+++ b/tests/ui/conditional-compilation/cfg-attr-multi-invalid-2.stderr
@@ -1,4 +1,4 @@
-error[E0658]: the `#[no_core]` attribute is an experimental feature
+error[E0658]: the `no_core` attribute is an experimental feature
   --> $DIR/cfg-attr-multi-invalid-2.rs:4:29
    |
 LL | #![cfg_attr(broken, no_std, no_core)]

--- a/tests/ui/conditional-compilation/cfg-attr-parse.stderr
+++ b/tests/ui/conditional-compilation/cfg-attr-parse.stderr
@@ -1,8 +1,8 @@
 error[E0539]: malformed `cfg_attr` attribute input
-  --> $DIR/cfg-attr-parse.rs:4:1
+  --> $DIR/cfg-attr-parse.rs:4:3
    |
 LL | #[cfg_attr()]
-   | ^^^^^^^^^^--^
+   |   ^^^^^^^^--
    |           |
    |           expected at least 1 argument here
    |

--- a/tests/ui/conditional-compilation/cfg-attr-parsed-span-issue-154801.rs
+++ b/tests/ui/conditional-compilation/cfg-attr-parsed-span-issue-154801.rs
@@ -6,6 +6,6 @@ fn main() {
 
 fn inline_case() {
     let _x = 30;
-    #[inline] //~ ERROR `#[inline]` attribute cannot be used on expressions
+    #[inline] //~ ERROR the `inline` attribute cannot be used on expressions
     _x //~ ERROR mismatched types
 }

--- a/tests/ui/conditional-compilation/cfg-attr-parsed-span-issue-154801.stderr
+++ b/tests/ui/conditional-compilation/cfg-attr-parsed-span-issue-154801.stderr
@@ -11,13 +11,13 @@ LL -     #[cfg_attr(, (cc))]
 LL +     #[cfg_attr(predicate, attr1, attr2, ...)]
    |
 
-error: `#[inline]` attribute cannot be used on expressions
-  --> $DIR/cfg-attr-parsed-span-issue-154801.rs:9:5
+error: the `inline` attribute cannot be used on expressions
+  --> $DIR/cfg-attr-parsed-span-issue-154801.rs:9:7
    |
 LL |     #[inline]
-   |     ^^^^^^^^^
+   |       ^^^^^^
    |
-   = help: `#[inline]` can only be applied to functions
+   = help: the `inline` attribute can only be applied to functions
 
 error[E0308]: mismatched types
   --> $DIR/cfg-attr-parsed-span-issue-154801.rs:4:5

--- a/tests/ui/conditional-compilation/cfg-attr-syntax-validation.stderr
+++ b/tests/ui/conditional-compilation/cfg-attr-syntax-validation.stderr
@@ -1,8 +1,8 @@
 error[E0539]: malformed `cfg` attribute input
-  --> $DIR/cfg-attr-syntax-validation.rs:1:1
+  --> $DIR/cfg-attr-syntax-validation.rs:1:3
    |
 LL | #[cfg]
-   | ^^^^^^ expected this to be a list
+   |   ^^^ expected this to be a list
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
 help: must be of the form
@@ -11,10 +11,10 @@ LL | #[cfg(predicate)]
    |      +++++++++++
 
 error[E0539]: malformed `cfg` attribute input
-  --> $DIR/cfg-attr-syntax-validation.rs:7:1
+  --> $DIR/cfg-attr-syntax-validation.rs:7:3
    |
 LL | #[cfg = 10]
-   | ^^^^^^----^
+   |   ^^^^----
    |       |
    |       expected this to be a list
    |
@@ -26,10 +26,10 @@ LL + #[cfg(predicate)]
    |
 
 error[E0805]: malformed `cfg` attribute input
-  --> $DIR/cfg-attr-syntax-validation.rs:13:1
+  --> $DIR/cfg-attr-syntax-validation.rs:13:3
    |
 LL | #[cfg()]
-   | ^^^^^--^
+   |   ^^^--
    |      |
    |      expected an argument here
    |
@@ -40,10 +40,10 @@ LL | #[cfg(false)]
    |       +++++
 
 error[E0805]: malformed `cfg` attribute input
-  --> $DIR/cfg-attr-syntax-validation.rs:19:1
+  --> $DIR/cfg-attr-syntax-validation.rs:19:3
    |
 LL | #[cfg(a, b)]
-   | ^^^^^------^
+   |   ^^^------
    |      |
    |      expected a single argument here
    |
@@ -60,10 +60,10 @@ LL + #[cfg(any(a, b))]
    |
 
 error[E0565]: malformed `cfg` attribute input
-  --> $DIR/cfg-attr-syntax-validation.rs:25:1
+  --> $DIR/cfg-attr-syntax-validation.rs:25:3
    |
 LL | #[cfg("str")]
-   | ^^^^^^-----^^
+   |   ^^^^-----^
    |       |
    |       expected a valid identifier here
    |
@@ -75,10 +75,10 @@ LL + #[cfg(predicate)]
    |
 
 error[E0565]: malformed `cfg` attribute input
-  --> $DIR/cfg-attr-syntax-validation.rs:31:1
+  --> $DIR/cfg-attr-syntax-validation.rs:31:3
    |
 LL | #[cfg(a::b)]
-   | ^^^^^^----^^
+   |   ^^^^----^
    |       |
    |       expected a valid identifier here
    |
@@ -90,10 +90,10 @@ LL + #[cfg(predicate)]
    |
 
 error[E0539]: malformed `cfg` attribute input
-  --> $DIR/cfg-attr-syntax-validation.rs:37:1
+  --> $DIR/cfg-attr-syntax-validation.rs:37:3
    |
 LL | #[cfg(a())]
-   | ^^^^^^---^^
+   |   ^^^^---^
    |       |
    |       valid arguments are `any`, `all`, `not` or `target`
    |
@@ -105,10 +105,10 @@ LL + #[cfg(predicate)]
    |
 
 error[E0539]: malformed `cfg` attribute input
-  --> $DIR/cfg-attr-syntax-validation.rs:42:1
+  --> $DIR/cfg-attr-syntax-validation.rs:42:3
    |
 LL | #[cfg(a = 10)]
-   | ^^^^^^^^^^--^^
+   |   ^^^^^^^^--^
    |           |
    |           expected a string literal here
    |
@@ -120,10 +120,10 @@ LL + #[cfg(predicate)]
    |
 
 error[E0539]: malformed `cfg` attribute input
-  --> $DIR/cfg-attr-syntax-validation.rs:47:1
+  --> $DIR/cfg-attr-syntax-validation.rs:47:3
    |
 LL | #[cfg(a = b"hi")]
-   | ^^^^^^^^^^-^^^^^^
+   |   ^^^^^^^^-^^^^^
    |           |
    |           help: consider removing the prefix
    |

--- a/tests/ui/conditional-compilation/cfg_attr-attr-syntax-validation.stderr
+++ b/tests/ui/conditional-compilation/cfg_attr-attr-syntax-validation.stderr
@@ -174,13 +174,13 @@ LL | #[cfg_attr(true, inline(always))]
 LL | #[cfg_attr(true, inline(never))]
    |                         +++++
 
-warning: `#[link_section]` attribute cannot be used on structs
+warning: the `link_section` attribute cannot be used on structs
   --> $DIR/cfg_attr-attr-syntax-validation.rs:44:18
    |
 LL | #[cfg_attr(true, link_section)]
    |                  ^^^^^^^^^^^^
    |
-   = help: `#[link_section]` can be applied to functions and statics
+   = help: the `link_section` attribute can be applied to functions and statics
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: requested on the command line with `-W unused-attributes`
 

--- a/tests/ui/conditional-compilation/cfg_attr-attr-syntax-validation.stderr
+++ b/tests/ui/conditional-compilation/cfg_attr-attr-syntax-validation.stderr
@@ -1,8 +1,8 @@
 error[E0539]: malformed `cfg_attr` attribute input
-  --> $DIR/cfg_attr-attr-syntax-validation.rs:1:1
+  --> $DIR/cfg_attr-attr-syntax-validation.rs:1:3
    |
 LL | #[cfg_attr]
-   | ^^^^^^^^^^^ expected this to be a list
+   |   ^^^^^^^^ expected this to be a list
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute>
 help: must be of the form
@@ -11,10 +11,10 @@ LL | #[cfg_attr(predicate, attr1, attr2, ...)]
    |           ++++++++++++++++++++++++++++++
 
 error[E0539]: malformed `cfg_attr` attribute input
-  --> $DIR/cfg_attr-attr-syntax-validation.rs:5:1
+  --> $DIR/cfg_attr-attr-syntax-validation.rs:5:3
    |
 LL | #[cfg_attr = 10]
-   | ^^^^^^^^^^^^^^^^ expected this to be a list
+   |   ^^^^^^^^^^^^^ expected this to be a list
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute>
 help: must be of the form
@@ -24,10 +24,10 @@ LL + #[cfg_attr(predicate, attr1, attr2, ...)]
    |
 
 error[E0539]: malformed `cfg_attr` attribute input
-  --> $DIR/cfg_attr-attr-syntax-validation.rs:9:1
+  --> $DIR/cfg_attr-attr-syntax-validation.rs:9:3
    |
 LL | #[cfg_attr()]
-   | ^^^^^^^^^^--^
+   |   ^^^^^^^^--
    |           |
    |           expected at least 1 argument here
    |
@@ -38,10 +38,10 @@ LL | #[cfg_attr(predicate, attr1, attr2, ...)]
    |            ++++++++++++++++++++++++++++
 
 error[E0565]: malformed `cfg_attr` attribute input
-  --> $DIR/cfg_attr-attr-syntax-validation.rs:13:1
+  --> $DIR/cfg_attr-attr-syntax-validation.rs:13:3
    |
 LL | #[cfg_attr("str")]
-   | ^^^^^^^^^^^-----^^
+   |   ^^^^^^^^^-----^
    |            |
    |            expected a valid identifier here
    |
@@ -53,10 +53,10 @@ LL + #[cfg_attr(predicate, attr1, attr2, ...)]
    |
 
 error[E0565]: malformed `cfg_attr` attribute input
-  --> $DIR/cfg_attr-attr-syntax-validation.rs:16:1
+  --> $DIR/cfg_attr-attr-syntax-validation.rs:16:3
    |
 LL | #[cfg_attr(a::b)]
-   | ^^^^^^^^^^^----^^
+   |   ^^^^^^^^^----^
    |            |
    |            expected a valid identifier here
    |
@@ -68,10 +68,10 @@ LL + #[cfg_attr(predicate, attr1, attr2, ...)]
    |
 
 error[E0539]: malformed `cfg_attr` attribute input
-  --> $DIR/cfg_attr-attr-syntax-validation.rs:19:1
+  --> $DIR/cfg_attr-attr-syntax-validation.rs:19:3
    |
 LL | #[cfg_attr(a())]
-   | ^^^^^^^^^^^---^^
+   |   ^^^^^^^^^---^
    |            |
    |            valid arguments are `any`, `all`, `not` or `target`
    |
@@ -83,10 +83,10 @@ LL + #[cfg_attr(predicate, attr1, attr2, ...)]
    |
 
 error[E0539]: malformed `cfg_attr` attribute input
-  --> $DIR/cfg_attr-attr-syntax-validation.rs:22:1
+  --> $DIR/cfg_attr-attr-syntax-validation.rs:22:3
    |
 LL | #[cfg_attr(a = 10)]
-   | ^^^^^^^^^^^^^^^--^^
+   |   ^^^^^^^^^^^^^--^
    |                |
    |                expected a string literal here
    |
@@ -98,10 +98,10 @@ LL + #[cfg_attr(predicate, attr1, attr2, ...)]
    |
 
 error[E0539]: malformed `cfg_attr` attribute input
-  --> $DIR/cfg_attr-attr-syntax-validation.rs:25:1
+  --> $DIR/cfg_attr-attr-syntax-validation.rs:25:3
    |
 LL | #[cfg_attr(a = b"hi")]
-   | ^^^^^^^^^^^^^^^-^^^^^^
+   |   ^^^^^^^^^^^^^-^^^^^
    |                |
    |                help: consider removing the prefix
    |

--- a/tests/ui/conditional-compilation/cfg_attr-invalid-predicate-inner.stderr
+++ b/tests/ui/conditional-compilation/cfg_attr-invalid-predicate-inner.stderr
@@ -1,8 +1,8 @@
 error[E0539]: malformed `cfg_attr` attribute input
-  --> $DIR/cfg_attr-invalid-predicate-inner.rs:3:1
+  --> $DIR/cfg_attr-invalid-predicate-inner.rs:3:4
    |
 LL | #![cfg_attr(a())]
-   | ^^^^^^^^^^^^---^^
+   |    ^^^^^^^^^---^
    |             |
    |             valid arguments are `any`, `all`, `not` or `target`
    |
@@ -14,10 +14,10 @@ LL + #![cfg_attr(predicate, attr1, attr2, ...)]
    |
 
 error[E0539]: malformed `cfg_attr` attribute input
-  --> $DIR/cfg_attr-invalid-predicate-inner.rs:3:1
+  --> $DIR/cfg_attr-invalid-predicate-inner.rs:3:4
    |
 LL | #![cfg_attr(a())]
-   | ^^^^^^^^^^^^---^^
+   |    ^^^^^^^^^---^
    |             |
    |             valid arguments are `any`, `all`, `not` or `target`
    |

--- a/tests/ui/const-generics/invalid-attributes-on-const-params-78957.stderr
+++ b/tests/ui/const-generics/invalid-attributes-on-const-params-78957.stderr
@@ -1,58 +1,58 @@
-error: `#[inline]` attribute cannot be used on const parameters
-  --> $DIR/invalid-attributes-on-const-params-78957.rs:6:16
+error: the `inline` attribute cannot be used on const parameters
+  --> $DIR/invalid-attributes-on-const-params-78957.rs:6:18
    |
 LL | pub struct Foo<#[inline] const N: usize>;
-   |                ^^^^^^^^^
+   |                  ^^^^^^
    |
-   = help: `#[inline]` can only be applied to functions
+   = help: the `inline` attribute can only be applied to functions
 
-error: `#[repr(C)]` attribute cannot be used on const parameters
-  --> $DIR/invalid-attributes-on-const-params-78957.rs:11:16
+error: the `repr(C)` attribute cannot be used on const parameters
+  --> $DIR/invalid-attributes-on-const-params-78957.rs:11:18
    |
 LL | pub struct Baz<#[repr(C)] const N: usize>;
-   |                ^^^^^^^^^^
+   |                  ^^^^^^^
    |
-   = help: `#[repr(C)]` can only be applied to data types
+   = help: the `repr(C)` attribute can only be applied to data types
 
-error: `#[inline]` attribute cannot be used on lifetime parameters
-  --> $DIR/invalid-attributes-on-const-params-78957.rs:14:17
+error: the `inline` attribute cannot be used on lifetime parameters
+  --> $DIR/invalid-attributes-on-const-params-78957.rs:14:19
    |
 LL | pub struct Foo2<#[inline] 'a>(PhantomData<&'a ()>);
-   |                 ^^^^^^^^^
+   |                   ^^^^^^
    |
-   = help: `#[inline]` can only be applied to functions
+   = help: the `inline` attribute can only be applied to functions
 
-error: `#[repr(C)]` attribute cannot be used on lifetime parameters
-  --> $DIR/invalid-attributes-on-const-params-78957.rs:19:17
+error: the `repr(C)` attribute cannot be used on lifetime parameters
+  --> $DIR/invalid-attributes-on-const-params-78957.rs:19:19
    |
 LL | pub struct Baz2<#[repr(C)] 'a>(PhantomData<&'a ()>);
-   |                 ^^^^^^^^^^
+   |                   ^^^^^^^
    |
-   = help: `#[repr(C)]` can only be applied to data types
+   = help: the `repr(C)` attribute can only be applied to data types
 
-error: `#[inline]` attribute cannot be used on type parameters
-  --> $DIR/invalid-attributes-on-const-params-78957.rs:22:17
+error: the `inline` attribute cannot be used on type parameters
+  --> $DIR/invalid-attributes-on-const-params-78957.rs:22:19
    |
 LL | pub struct Foo3<#[inline] T>(PhantomData<T>);
-   |                 ^^^^^^^^^
+   |                   ^^^^^^
    |
-   = help: `#[inline]` can only be applied to functions
+   = help: the `inline` attribute can only be applied to functions
 
-error: `#[repr(C)]` attribute cannot be used on type parameters
-  --> $DIR/invalid-attributes-on-const-params-78957.rs:27:17
+error: the `repr(C)` attribute cannot be used on type parameters
+  --> $DIR/invalid-attributes-on-const-params-78957.rs:27:19
    |
 LL | pub struct Baz3<#[repr(C)] T>(PhantomData<T>);
-   |                 ^^^^^^^^^^
+   |                   ^^^^^^^
    |
-   = help: `#[repr(C)]` can only be applied to data types
+   = help: the `repr(C)` attribute can only be applied to data types
 
-error: `#[cold]` attribute cannot be used on const parameters
-  --> $DIR/invalid-attributes-on-const-params-78957.rs:8:16
+error: the `cold` attribute cannot be used on const parameters
+  --> $DIR/invalid-attributes-on-const-params-78957.rs:8:18
    |
 LL | pub struct Bar<#[cold] const N: usize>;
-   |                ^^^^^^^
+   |                  ^^^^
    |
-   = help: `#[cold]` can only be applied to functions
+   = help: the `cold` attribute can only be applied to functions
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 note: the lint level is defined here
   --> $DIR/invalid-attributes-on-const-params-78957.rs:2:9
@@ -60,22 +60,22 @@ note: the lint level is defined here
 LL | #![deny(unused_attributes)]
    |         ^^^^^^^^^^^^^^^^^
 
-error: `#[cold]` attribute cannot be used on lifetime parameters
-  --> $DIR/invalid-attributes-on-const-params-78957.rs:16:17
+error: the `cold` attribute cannot be used on lifetime parameters
+  --> $DIR/invalid-attributes-on-const-params-78957.rs:16:19
    |
 LL | pub struct Bar2<#[cold] 'a>(PhantomData<&'a ()>);
-   |                 ^^^^^^^
+   |                   ^^^^
    |
-   = help: `#[cold]` can only be applied to functions
+   = help: the `cold` attribute can only be applied to functions
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-error: `#[cold]` attribute cannot be used on type parameters
-  --> $DIR/invalid-attributes-on-const-params-78957.rs:24:17
+error: the `cold` attribute cannot be used on type parameters
+  --> $DIR/invalid-attributes-on-const-params-78957.rs:24:19
    |
 LL | pub struct Bar3<#[cold] T>(PhantomData<T>);
-   |                 ^^^^^^^
+   |                   ^^^^
    |
-   = help: `#[cold]` can only be applied to functions
+   = help: the `cold` attribute can only be applied to functions
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 error: aborting due to 9 previous errors

--- a/tests/ui/const-generics/invalid-rustc_legacy_const_generics-arguments.rs
+++ b/tests/ui/const-generics/invalid-rustc_legacy_const_generics-arguments.rs
@@ -17,7 +17,7 @@ fn foo4<const X: usize>() {}
 //~^^ ERROR malformed `rustc_legacy_const_generics` attribute input
 fn foo5<const X: usize, const Y: usize, const Z: usize, const W: usize>() {}
 
-#[rustc_legacy_const_generics(0)] //~ ERROR `#[rustc_legacy_const_generics]` attribute cannot be used on structs
+#[rustc_legacy_const_generics(0)] //~ ERROR the `rustc_legacy_const_generics` attribute cannot be used on structs
 struct S;
 
 #[rustc_legacy_const_generics(0usize)]
@@ -26,7 +26,7 @@ struct S;
 fn foo6<const X: usize>() {}
 
 extern "C" {
-    #[rustc_legacy_const_generics(1)] //~ ERROR `#[rustc_legacy_const_generics]` attribute cannot be used on foreign functions
+    #[rustc_legacy_const_generics(1)] //~ ERROR the `rustc_legacy_const_generics` attribute cannot be used on foreign functions
     fn foo7<const X: usize>(); //~ ERROR foreign items may not have const parameters
 }
 
@@ -34,7 +34,7 @@ extern "C" {
 fn foo8<X>() {}
 
 impl S {
-    #[rustc_legacy_const_generics(0)] //~ ERROR `#[rustc_legacy_const_generics]` attribute cannot be used on inherent methods
+    #[rustc_legacy_const_generics(0)] //~ ERROR the `rustc_legacy_const_generics` attribute cannot be used on inherent methods
     fn foo9<const X: usize>() {}
 }
 

--- a/tests/ui/const-generics/invalid-rustc_legacy_const_generics-arguments.stderr
+++ b/tests/ui/const-generics/invalid-rustc_legacy_const_generics-arguments.stderr
@@ -40,13 +40,13 @@ LL - #[rustc_legacy_const_generics(1, a, 2, b)]
 LL + #[rustc_legacy_const_generics(N)]
    |
 
-error: `#[rustc_legacy_const_generics]` attribute cannot be used on structs
-  --> $DIR/invalid-rustc_legacy_const_generics-arguments.rs:20:1
+error: the `rustc_legacy_const_generics` attribute cannot be used on structs
+  --> $DIR/invalid-rustc_legacy_const_generics-arguments.rs:20:3
    |
 LL | #[rustc_legacy_const_generics(0)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_legacy_const_generics]` can only be applied to functions
+   = help: the `rustc_legacy_const_generics` attribute can only be applied to functions
 
 error: suffixed literals are not allowed in attributes
   --> $DIR/invalid-rustc_legacy_const_generics-arguments.rs:23:31
@@ -70,21 +70,21 @@ LL - #[rustc_legacy_const_generics(0usize)]
 LL + #[rustc_legacy_const_generics(N)]
    |
 
-error: `#[rustc_legacy_const_generics]` attribute cannot be used on foreign functions
-  --> $DIR/invalid-rustc_legacy_const_generics-arguments.rs:29:5
+error: the `rustc_legacy_const_generics` attribute cannot be used on foreign functions
+  --> $DIR/invalid-rustc_legacy_const_generics-arguments.rs:29:7
    |
 LL |     #[rustc_legacy_const_generics(1)]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_legacy_const_generics]` can only be applied to functions
+   = help: the `rustc_legacy_const_generics` attribute can only be applied to functions
 
-error: `#[rustc_legacy_const_generics]` attribute cannot be used on inherent methods
-  --> $DIR/invalid-rustc_legacy_const_generics-arguments.rs:37:5
+error: the `rustc_legacy_const_generics` attribute cannot be used on inherent methods
+  --> $DIR/invalid-rustc_legacy_const_generics-arguments.rs:37:7
    |
 LL |     #[rustc_legacy_const_generics(0)]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_legacy_const_generics]` can only be applied to functions
+   = help: the `rustc_legacy_const_generics` attribute can only be applied to functions
 
 error[E0539]: malformed `rustc_legacy_const_generics` attribute input
   --> $DIR/invalid-rustc_legacy_const_generics-arguments.rs:41:1

--- a/tests/ui/const-generics/invalid-rustc_legacy_const_generics-arguments.stderr
+++ b/tests/ui/const-generics/invalid-rustc_legacy_const_generics-arguments.stderr
@@ -1,8 +1,8 @@
 error[E0539]: malformed `rustc_legacy_const_generics` attribute input
-  --> $DIR/invalid-rustc_legacy_const_generics-arguments.rs:12:1
+  --> $DIR/invalid-rustc_legacy_const_generics-arguments.rs:12:3
    |
 LL | #[rustc_legacy_const_generics(a)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^-^
    |                               |
    |                               expected an integer literal here
    |
@@ -13,10 +13,10 @@ LL + #[rustc_legacy_const_generics(N)]
    |
 
 error[E0539]: malformed `rustc_legacy_const_generics` attribute input
-  --> $DIR/invalid-rustc_legacy_const_generics-arguments.rs:15:1
+  --> $DIR/invalid-rustc_legacy_const_generics-arguments.rs:15:3
    |
 LL | #[rustc_legacy_const_generics(1, a, 2, b)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-^^^^^^^
    |                                  |
    |                                  expected an integer literal here
    |
@@ -27,10 +27,10 @@ LL + #[rustc_legacy_const_generics(N)]
    |
 
 error[E0539]: malformed `rustc_legacy_const_generics` attribute input
-  --> $DIR/invalid-rustc_legacy_const_generics-arguments.rs:15:1
+  --> $DIR/invalid-rustc_legacy_const_generics-arguments.rs:15:3
    |
 LL | #[rustc_legacy_const_generics(1, a, 2, b)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-^
    |                                        |
    |                                        expected an integer literal here
    |
@@ -57,10 +57,10 @@ LL | #[rustc_legacy_const_generics(0usize)]
    = help: instead of using a suffixed literal (`1u8`, `1.0f32`, etc.), use an unsuffixed version (`1`, `1.0`, etc.)
 
 error[E0539]: malformed `rustc_legacy_const_generics` attribute input
-  --> $DIR/invalid-rustc_legacy_const_generics-arguments.rs:23:1
+  --> $DIR/invalid-rustc_legacy_const_generics-arguments.rs:23:3
    |
 LL | #[rustc_legacy_const_generics(0usize)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^------^
    |                               |
    |                               expected an integer literal here
    |
@@ -87,10 +87,10 @@ LL |     #[rustc_legacy_const_generics(0)]
    = help: the `rustc_legacy_const_generics` attribute can only be applied to functions
 
 error[E0539]: malformed `rustc_legacy_const_generics` attribute input
-  --> $DIR/invalid-rustc_legacy_const_generics-arguments.rs:41:1
+  --> $DIR/invalid-rustc_legacy_const_generics-arguments.rs:41:3
    |
 LL | #[rustc_legacy_const_generics]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected this to be a list
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected this to be a list
    |
 help: must be of the form
    |
@@ -98,10 +98,10 @@ LL | #[rustc_legacy_const_generics(N)]
    |                              +++
 
 error[E0539]: malformed `rustc_legacy_const_generics` attribute input
-  --> $DIR/invalid-rustc_legacy_const_generics-arguments.rs:44:1
+  --> $DIR/invalid-rustc_legacy_const_generics-arguments.rs:44:3
    |
 LL | #[rustc_legacy_const_generics = 1]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                               |
    |                               expected this to be a list
    |

--- a/tests/ui/consts/gate-do-not-const-check.rs
+++ b/tests/ui/consts/gate-do-not-const-check.rs
@@ -1,7 +1,7 @@
 #[rustc_do_not_const_check]
 //~^ ERROR use of an internal attribute [E0658]
-//~| NOTE the `#[rustc_do_not_const_check]` attribute is an internal implementation detail that will never be stable
-//~| NOTE `#[rustc_do_not_const_check]` skips const-check for this function's body
+//~| NOTE the `rustc_do_not_const_check` attribute is an internal implementation detail that will never be stable
+//~| NOTE the `rustc_do_not_const_check` attribute skips const-check for this function's body
 const fn foo() {}
 
 fn main() {}

--- a/tests/ui/consts/gate-do-not-const-check.stderr
+++ b/tests/ui/consts/gate-do-not-const-check.stderr
@@ -1,12 +1,12 @@
 error[E0658]: use of an internal attribute
-  --> $DIR/gate-do-not-const-check.rs:1:1
+  --> $DIR/gate-do-not-const-check.rs:1:3
    |
 LL | #[rustc_do_not_const_check]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable
-   = note: the `#[rustc_do_not_const_check]` attribute is an internal implementation detail that will never be stable
-   = note: `#[rustc_do_not_const_check]` skips const-check for this function's body
+   = note: the `rustc_do_not_const_check` attribute is an internal implementation detail that will never be stable
+   = note: the `rustc_do_not_const_check` attribute skips const-check for this function's body
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/coroutine/gen_block.e2024.stderr
+++ b/tests/ui/coroutine/gen_block.e2024.stderr
@@ -9,21 +9,21 @@ help: use `#[coroutine]` to make this closure a coroutine
 LL |     let _ = #[coroutine] || yield true;
    |             ++++++++++++
 
-error[E0658]: the `#[coroutine]` attribute is an experimental feature
-  --> $DIR/gen_block.rs:20:13
+error[E0658]: the `coroutine` attribute is an experimental feature
+  --> $DIR/gen_block.rs:20:15
    |
 LL |     let _ = #[coroutine] || yield true;
-   |             ^^^^^^^^^^^^
+   |               ^^^^^^^^^
    |
    = note: see issue #43122 <https://github.com/rust-lang/rust/issues/43122> for more information
    = help: add `#![feature(coroutines)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: the `#[coroutine]` attribute is an experimental feature
-  --> $DIR/gen_block.rs:24:13
+error[E0658]: the `coroutine` attribute is an experimental feature
+  --> $DIR/gen_block.rs:24:15
    |
 LL |     let _ = #[coroutine] || {};
-   |             ^^^^^^^^^^^^
+   |               ^^^^^^^^^
    |
    = note: see issue #43122 <https://github.com/rust-lang/rust/issues/43122> for more information
    = help: add `#![feature(coroutines)]` to the crate attributes to enable

--- a/tests/ui/coroutine/gen_block.none.stderr
+++ b/tests/ui/coroutine/gen_block.none.stderr
@@ -65,11 +65,11 @@ help: use `#[coroutine]` to make this closure a coroutine
 LL |     let _ = #[coroutine] || yield true;
    |             ++++++++++++
 
-error[E0658]: the `#[coroutine]` attribute is an experimental feature
-  --> $DIR/gen_block.rs:20:13
+error[E0658]: the `coroutine` attribute is an experimental feature
+  --> $DIR/gen_block.rs:20:15
    |
 LL |     let _ = #[coroutine] || yield true;
-   |             ^^^^^^^^^^^^
+   |               ^^^^^^^^^
    |
    = note: see issue #43122 <https://github.com/rust-lang/rust/issues/43122> for more information
    = help: add `#![feature(coroutines)]` to the crate attributes to enable
@@ -85,11 +85,11 @@ LL |     let _ = #[coroutine] || yield true;
    = help: add `#![feature(yield_expr)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: the `#[coroutine]` attribute is an experimental feature
-  --> $DIR/gen_block.rs:24:13
+error[E0658]: the `coroutine` attribute is an experimental feature
+  --> $DIR/gen_block.rs:24:15
    |
 LL |     let _ = #[coroutine] || {};
-   |             ^^^^^^^^^^^^
+   |               ^^^^^^^^^
    |
    = note: see issue #43122 <https://github.com/rust-lang/rust/issues/43122> for more information
    = help: add `#![feature(coroutines)]` to the crate attributes to enable

--- a/tests/ui/coroutine/gen_block.rs
+++ b/tests/ui/coroutine/gen_block.rs
@@ -18,9 +18,9 @@ fn main() {
     //~^^ ERROR `yield` can only be used in
 
     let _ = #[coroutine] || yield true; //[none]~ ERROR yield syntax is experimental
-    //~^ ERROR `#[coroutine]` attribute is an experimental feature
+    //~^ ERROR the `coroutine` attribute is an experimental feature
     //[none]~^^ ERROR yield syntax is experimental
 
     let _ = #[coroutine] || {};
-    //~^ ERROR `#[coroutine]` attribute is an experimental feature
+    //~^ ERROR the `coroutine` attribute is an experimental feature
 }

--- a/tests/ui/coroutine/invalid_attr_usage.stderr
+++ b/tests/ui/coroutine/invalid_attr_usage.stderr
@@ -1,18 +1,18 @@
-error: `#[coroutine]` attribute cannot be used on structs
-  --> $DIR/invalid_attr_usage.rs:5:1
+error: the `coroutine` attribute cannot be used on structs
+  --> $DIR/invalid_attr_usage.rs:5:3
    |
 LL | #[coroutine]
-   | ^^^^^^^^^^^^
+   |   ^^^^^^^^^
    |
-   = help: `#[coroutine]` can only be applied to closures
+   = help: the `coroutine` attribute can only be applied to closures
 
-error: `#[coroutine]` attribute cannot be used on functions
-  --> $DIR/invalid_attr_usage.rs:9:1
+error: the `coroutine` attribute cannot be used on functions
+  --> $DIR/invalid_attr_usage.rs:9:3
    |
 LL | #[coroutine]
-   | ^^^^^^^^^^^^
+   |   ^^^^^^^^^
    |
-   = help: `#[coroutine]` can only be applied to closures
+   = help: the `coroutine` attribute can only be applied to closures
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/coverage-attr/allowed-positions.stderr
+++ b/tests/ui/coverage-attr/allowed-positions.stderr
@@ -8,141 +8,141 @@ LL |     let _closure_expr = #[coverage(off)] || ();
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error: `#[coverage]` attribute cannot be used on type aliases
-  --> $DIR/allowed-positions.rs:14:1
+error: the `coverage` attribute cannot be used on type aliases
+  --> $DIR/allowed-positions.rs:14:3
    |
 LL | #[coverage(off)]
-   | ^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
+   = help: the `coverage` attribute can be applied to crates, functions, impl blocks, and modules
 
-error: `#[coverage]` attribute cannot be used on traits
-  --> $DIR/allowed-positions.rs:17:1
+error: the `coverage` attribute cannot be used on traits
+  --> $DIR/allowed-positions.rs:17:3
    |
 LL | #[coverage(off)]
-   | ^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
+   = help: the `coverage` attribute can be applied to crates, functions, impl blocks, and modules
 
-error: `#[coverage]` attribute cannot be used on associated consts
-  --> $DIR/allowed-positions.rs:19:5
+error: the `coverage` attribute cannot be used on associated consts
+  --> $DIR/allowed-positions.rs:19:7
    |
 LL |     #[coverage(off)]
-   |     ^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
+   = help: the `coverage` attribute can be applied to crates, functions, impl blocks, and modules
 
-error: `#[coverage]` attribute cannot be used on associated types
-  --> $DIR/allowed-positions.rs:22:5
+error: the `coverage` attribute cannot be used on associated types
+  --> $DIR/allowed-positions.rs:22:7
    |
 LL |     #[coverage(off)]
-   |     ^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
+   = help: the `coverage` attribute can be applied to crates, functions, impl blocks, and modules
 
-error: `#[coverage]` attribute cannot be used on required trait methods
-  --> $DIR/allowed-positions.rs:25:5
+error: the `coverage` attribute cannot be used on required trait methods
+  --> $DIR/allowed-positions.rs:25:7
    |
 LL |     #[coverage(off)]
-   |     ^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to crates, functions with a body, impl blocks, and modules
+   = help: the `coverage` attribute can be applied to crates, functions with a body, impl blocks, and modules
 
-error: `#[coverage]` attribute cannot be used on required trait methods
-  --> $DIR/allowed-positions.rs:31:5
+error: the `coverage` attribute cannot be used on required trait methods
+  --> $DIR/allowed-positions.rs:31:7
    |
 LL |     #[coverage(off)]
-   |     ^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to crates, functions with a body, impl blocks, and modules
+   = help: the `coverage` attribute can be applied to crates, functions with a body, impl blocks, and modules
 
-error: `#[coverage]` attribute cannot be used on associated types
-  --> $DIR/allowed-positions.rs:39:5
+error: the `coverage` attribute cannot be used on associated types
+  --> $DIR/allowed-positions.rs:39:7
    |
 LL |     #[coverage(off)]
-   |     ^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
+   = help: the `coverage` attribute can be applied to crates, functions, impl blocks, and modules
 
-error: `#[coverage]` attribute cannot be used on associated types
-  --> $DIR/allowed-positions.rs:56:5
+error: the `coverage` attribute cannot be used on associated types
+  --> $DIR/allowed-positions.rs:56:7
    |
 LL |     #[coverage(off)]
-   |     ^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
+   = help: the `coverage` attribute can be applied to crates, functions, impl blocks, and modules
 
-error: `#[coverage]` attribute cannot be used on structs
-  --> $DIR/allowed-positions.rs:61:1
+error: the `coverage` attribute cannot be used on structs
+  --> $DIR/allowed-positions.rs:61:3
    |
 LL | #[coverage(off)]
-   | ^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
+   = help: the `coverage` attribute can be applied to crates, functions, impl blocks, and modules
 
-error: `#[coverage]` attribute cannot be used on struct fields
-  --> $DIR/allowed-positions.rs:63:5
+error: the `coverage` attribute cannot be used on struct fields
+  --> $DIR/allowed-positions.rs:63:7
    |
 LL |     #[coverage(off)]
-   |     ^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
+   = help: the `coverage` attribute can be applied to crates, functions, impl blocks, and modules
 
-error: `#[coverage]` attribute cannot be used on foreign statics
-  --> $DIR/allowed-positions.rs:76:5
+error: the `coverage` attribute cannot be used on foreign statics
+  --> $DIR/allowed-positions.rs:76:7
    |
 LL |     #[coverage(off)]
-   |     ^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
+   = help: the `coverage` attribute can be applied to crates, functions, impl blocks, and modules
 
-error: `#[coverage]` attribute cannot be used on foreign types
-  --> $DIR/allowed-positions.rs:79:5
+error: the `coverage` attribute cannot be used on foreign types
+  --> $DIR/allowed-positions.rs:79:7
    |
 LL |     #[coverage(off)]
-   |     ^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
+   = help: the `coverage` attribute can be applied to crates, functions, impl blocks, and modules
 
-error: `#[coverage]` attribute cannot be used on foreign functions
-  --> $DIR/allowed-positions.rs:82:5
+error: the `coverage` attribute cannot be used on foreign functions
+  --> $DIR/allowed-positions.rs:82:7
    |
 LL |     #[coverage(off)]
-   |     ^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to crates, functions with a body, impl blocks, and modules
+   = help: the `coverage` attribute can be applied to crates, functions with a body, impl blocks, and modules
 
-error: `#[coverage]` attribute cannot be used on statements
-  --> $DIR/allowed-positions.rs:88:5
+error: the `coverage` attribute cannot be used on statements
+  --> $DIR/allowed-positions.rs:88:7
    |
 LL |     #[coverage(off)]
-   |     ^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
+   = help: the `coverage` attribute can be applied to crates, functions, impl blocks, and modules
 
-error: `#[coverage]` attribute cannot be used on statements
-  --> $DIR/allowed-positions.rs:94:5
+error: the `coverage` attribute cannot be used on statements
+  --> $DIR/allowed-positions.rs:94:7
    |
 LL |     #[coverage(off)]
-   |     ^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
+   = help: the `coverage` attribute can be applied to crates, functions, impl blocks, and modules
 
-error: `#[coverage]` attribute cannot be used on match arms
-  --> $DIR/allowed-positions.rs:110:9
+error: the `coverage` attribute cannot be used on match arms
+  --> $DIR/allowed-positions.rs:110:11
    |
 LL |         #[coverage(off)]
-   |         ^^^^^^^^^^^^^^^^
+   |           ^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
+   = help: the `coverage` attribute can be applied to crates, functions, impl blocks, and modules
 
-error: `#[coverage]` attribute cannot be used on expressions
-  --> $DIR/allowed-positions.rs:114:5
+error: the `coverage` attribute cannot be used on expressions
+  --> $DIR/allowed-positions.rs:114:7
    |
 LL |     #[coverage(off)]
-   |     ^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
+   = help: the `coverage` attribute can be applied to crates, functions, impl blocks, and modules
 
 error: aborting due to 18 previous errors
 

--- a/tests/ui/coverage-attr/bad-attr-ice.feat.stderr
+++ b/tests/ui/coverage-attr/bad-attr-ice.feat.stderr
@@ -1,8 +1,8 @@
 error[E0539]: malformed `coverage` attribute input
-  --> $DIR/bad-attr-ice.rs:11:1
+  --> $DIR/bad-attr-ice.rs:11:3
    |
 LL | #[coverage]
-   | ^^^^^^^^^^^ expected this to be a list
+   |   ^^^^^^^^ expected this to be a list
    |
 help: try changing it to one of the following valid forms of the attribute
    |

--- a/tests/ui/coverage-attr/bad-attr-ice.nofeat.stderr
+++ b/tests/ui/coverage-attr/bad-attr-ice.nofeat.stderr
@@ -1,8 +1,8 @@
-error[E0658]: the `#[coverage]` attribute is an experimental feature
-  --> $DIR/bad-attr-ice.rs:11:1
+error[E0658]: the `coverage` attribute is an experimental feature
+  --> $DIR/bad-attr-ice.rs:11:3
    |
 LL | #[coverage]
-   | ^^^^^^^^^^^
+   |   ^^^^^^^^
    |
    = note: see issue #84605 <https://github.com/rust-lang/rust/issues/84605> for more information
    = help: add `#![feature(coverage_attribute)]` to the crate attributes to enable

--- a/tests/ui/coverage-attr/bad-attr-ice.nofeat.stderr
+++ b/tests/ui/coverage-attr/bad-attr-ice.nofeat.stderr
@@ -9,10 +9,10 @@ LL | #[coverage]
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0539]: malformed `coverage` attribute input
-  --> $DIR/bad-attr-ice.rs:11:1
+  --> $DIR/bad-attr-ice.rs:11:3
    |
 LL | #[coverage]
-   | ^^^^^^^^^^^ expected this to be a list
+   |   ^^^^^^^^ expected this to be a list
    |
 help: try changing it to one of the following valid forms of the attribute
    |

--- a/tests/ui/coverage-attr/bad-attr-ice.rs
+++ b/tests/ui/coverage-attr/bad-attr-ice.rs
@@ -4,14 +4,14 @@
 //@ needs-profiler-runtime
 //@ reference: attributes.coverage.syntax
 
-// Malformed `#[coverage(..)]` attributes should not cause an ICE when built
+// Malformed `coverage` attributes should not cause an ICE when built
 // with `-Cinstrument-coverage`.
 // Regression test for <https://github.com/rust-lang/rust/issues/127880>.
 
 #[coverage]
 //~^ ERROR malformed `coverage` attribute input
-//[nofeat]~| ERROR the `#[coverage]` attribute is an experimental feature
+//[nofeat]~| ERROR the `coverage` attribute is an experimental feature
 fn main() {}
 
-// FIXME(#130766): When the `#[coverage(..)]` attribute is stabilized,
+// FIXME(#130766): When the `coverage` attribute is stabilized,
 // get rid of the revisions and just make this a normal test.

--- a/tests/ui/coverage-attr/bad-syntax.stderr
+++ b/tests/ui/coverage-attr/bad-syntax.stderr
@@ -23,10 +23,10 @@ LL | #[coverage(off)]
    | ^^^^^^^^^^^^^^^^
 
 error[E0539]: malformed `coverage` attribute input
-  --> $DIR/bad-syntax.rs:17:1
+  --> $DIR/bad-syntax.rs:17:3
    |
 LL | #[coverage]
-   | ^^^^^^^^^^^ expected this to be a list
+   |   ^^^^^^^^ expected this to be a list
    |
 help: try changing it to one of the following valid forms of the attribute
    |
@@ -36,10 +36,10 @@ LL | #[coverage(on)]
    |           ++++
 
 error[E0539]: malformed `coverage` attribute input
-  --> $DIR/bad-syntax.rs:20:1
+  --> $DIR/bad-syntax.rs:20:3
    |
 LL | #[coverage = true]
-   | ^^^^^^^^^^^------^
+   |   ^^^^^^^^^------
    |            |
    |            expected this to be a list
    |
@@ -53,10 +53,10 @@ LL + #[coverage(on)]
    |
 
 error[E0805]: malformed `coverage` attribute input
-  --> $DIR/bad-syntax.rs:23:1
+  --> $DIR/bad-syntax.rs:23:3
    |
 LL | #[coverage()]
-   | ^^^^^^^^^^--^
+   |   ^^^^^^^^--
    |           |
    |           expected an argument here
    |
@@ -68,10 +68,10 @@ LL | #[coverage(on)]
    |            ++
 
 error[E0805]: malformed `coverage` attribute input
-  --> $DIR/bad-syntax.rs:26:1
+  --> $DIR/bad-syntax.rs:26:3
    |
 LL | #[coverage(off, off)]
-   | ^^^^^^^^^^----------^
+   |   ^^^^^^^^----------
    |           |
    |           expected a single argument here
    |
@@ -85,10 +85,10 @@ LL + #[coverage(on)]
    |
 
 error[E0805]: malformed `coverage` attribute input
-  --> $DIR/bad-syntax.rs:29:1
+  --> $DIR/bad-syntax.rs:29:3
    |
 LL | #[coverage(off, on)]
-   | ^^^^^^^^^^---------^
+   |   ^^^^^^^^---------
    |           |
    |           expected a single argument here
    |
@@ -102,10 +102,10 @@ LL + #[coverage(on)]
    |
 
 error[E0539]: malformed `coverage` attribute input
-  --> $DIR/bad-syntax.rs:32:1
+  --> $DIR/bad-syntax.rs:32:3
    |
 LL | #[coverage(bogus)]
-   | ^^^^^^^^^^^-----^^
+   |   ^^^^^^^^^-----^
    |            |
    |            valid arguments are `on` or `off`
    |
@@ -119,10 +119,10 @@ LL + #[coverage(on)]
    |
 
 error[E0805]: malformed `coverage` attribute input
-  --> $DIR/bad-syntax.rs:35:1
+  --> $DIR/bad-syntax.rs:35:3
    |
 LL | #[coverage(bogus, off)]
-   | ^^^^^^^^^^------------^
+   |   ^^^^^^^^------------
    |           |
    |           expected a single argument here
    |
@@ -136,10 +136,10 @@ LL + #[coverage(on)]
    |
 
 error[E0805]: malformed `coverage` attribute input
-  --> $DIR/bad-syntax.rs:38:1
+  --> $DIR/bad-syntax.rs:38:3
    |
 LL | #[coverage(off, bogus)]
-   | ^^^^^^^^^^------------^
+   |   ^^^^^^^^------------
    |           |
    |           expected a single argument here
    |

--- a/tests/ui/coverage-attr/name-value.stderr
+++ b/tests/ui/coverage-attr/name-value.stderr
@@ -49,13 +49,13 @@ LL - #[coverage = "off"]
 LL + #[coverage(on)]
    |
 
-error: `#[coverage]` attribute cannot be used on structs
-  --> $DIR/name-value.rs:21:1
+error: the `coverage` attribute cannot be used on structs
+  --> $DIR/name-value.rs:21:3
    |
 LL | #[coverage = "off"]
-   | ^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
+   = help: the `coverage` attribute can be applied to crates, functions, impl blocks, and modules
 
 error[E0539]: malformed `coverage` attribute input
   --> $DIR/name-value.rs:26:1
@@ -91,13 +91,13 @@ LL -     #[coverage = "off"]
 LL +     #[coverage(on)]
    |
 
-error: `#[coverage]` attribute cannot be used on associated consts
-  --> $DIR/name-value.rs:29:5
+error: the `coverage` attribute cannot be used on associated consts
+  --> $DIR/name-value.rs:29:7
    |
 LL |     #[coverage = "off"]
-   |     ^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
+   = help: the `coverage` attribute can be applied to crates, functions, impl blocks, and modules
 
 error[E0539]: malformed `coverage` attribute input
   --> $DIR/name-value.rs:35:1
@@ -116,13 +116,13 @@ LL - #[coverage = "off"]
 LL + #[coverage(on)]
    |
 
-error: `#[coverage]` attribute cannot be used on traits
-  --> $DIR/name-value.rs:35:1
+error: the `coverage` attribute cannot be used on traits
+  --> $DIR/name-value.rs:35:3
    |
 LL | #[coverage = "off"]
-   | ^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
+   = help: the `coverage` attribute can be applied to crates, functions, impl blocks, and modules
 
 error[E0539]: malformed `coverage` attribute input
   --> $DIR/name-value.rs:39:5
@@ -141,13 +141,13 @@ LL -     #[coverage = "off"]
 LL +     #[coverage(on)]
    |
 
-error: `#[coverage]` attribute cannot be used on associated consts
-  --> $DIR/name-value.rs:39:5
+error: the `coverage` attribute cannot be used on associated consts
+  --> $DIR/name-value.rs:39:7
    |
 LL |     #[coverage = "off"]
-   |     ^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
+   = help: the `coverage` attribute can be applied to crates, functions, impl blocks, and modules
 
 error[E0539]: malformed `coverage` attribute input
   --> $DIR/name-value.rs:44:5
@@ -166,13 +166,13 @@ LL -     #[coverage = "off"]
 LL +     #[coverage(on)]
    |
 
-error: `#[coverage]` attribute cannot be used on associated types
-  --> $DIR/name-value.rs:44:5
+error: the `coverage` attribute cannot be used on associated types
+  --> $DIR/name-value.rs:44:7
    |
 LL |     #[coverage = "off"]
-   |     ^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
+   = help: the `coverage` attribute can be applied to crates, functions, impl blocks, and modules
 
 error[E0539]: malformed `coverage` attribute input
   --> $DIR/name-value.rs:50:1
@@ -208,13 +208,13 @@ LL -     #[coverage = "off"]
 LL +     #[coverage(on)]
    |
 
-error: `#[coverage]` attribute cannot be used on associated consts
-  --> $DIR/name-value.rs:53:5
+error: the `coverage` attribute cannot be used on associated consts
+  --> $DIR/name-value.rs:53:7
    |
 LL |     #[coverage = "off"]
-   |     ^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
+   = help: the `coverage` attribute can be applied to crates, functions, impl blocks, and modules
 
 error[E0539]: malformed `coverage` attribute input
   --> $DIR/name-value.rs:58:5
@@ -233,13 +233,13 @@ LL -     #[coverage = "off"]
 LL +     #[coverage(on)]
    |
 
-error: `#[coverage]` attribute cannot be used on associated types
-  --> $DIR/name-value.rs:58:5
+error: the `coverage` attribute cannot be used on associated types
+  --> $DIR/name-value.rs:58:7
    |
 LL |     #[coverage = "off"]
-   |     ^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
+   = help: the `coverage` attribute can be applied to crates, functions, impl blocks, and modules
 
 error[E0539]: malformed `coverage` attribute input
   --> $DIR/name-value.rs:64:1

--- a/tests/ui/coverage-attr/name-value.stderr
+++ b/tests/ui/coverage-attr/name-value.stderr
@@ -1,8 +1,8 @@
 error[E0539]: malformed `coverage` attribute input
-  --> $DIR/name-value.rs:12:1
+  --> $DIR/name-value.rs:12:3
    |
 LL | #[coverage = "off"]
-   | ^^^^^^^^^^^-------^
+   |   ^^^^^^^^^-------
    |            |
    |            expected this to be a list
    |
@@ -16,10 +16,10 @@ LL + #[coverage(on)]
    |
 
 error[E0539]: malformed `coverage` attribute input
-  --> $DIR/name-value.rs:17:5
+  --> $DIR/name-value.rs:17:8
    |
 LL |     #![coverage = "off"]
-   |     ^^^^^^^^^^^^-------^
+   |        ^^^^^^^^^-------
    |                 |
    |                 expected this to be a list
    |
@@ -33,10 +33,10 @@ LL +     #![coverage(on)]
    |
 
 error[E0539]: malformed `coverage` attribute input
-  --> $DIR/name-value.rs:21:1
+  --> $DIR/name-value.rs:21:3
    |
 LL | #[coverage = "off"]
-   | ^^^^^^^^^^^-------^
+   |   ^^^^^^^^^-------
    |            |
    |            expected this to be a list
    |
@@ -58,10 +58,10 @@ LL | #[coverage = "off"]
    = help: the `coverage` attribute can be applied to crates, functions, impl blocks, and modules
 
 error[E0539]: malformed `coverage` attribute input
-  --> $DIR/name-value.rs:26:1
+  --> $DIR/name-value.rs:26:3
    |
 LL | #[coverage = "off"]
-   | ^^^^^^^^^^^-------^
+   |   ^^^^^^^^^-------
    |            |
    |            expected this to be a list
    |
@@ -75,10 +75,10 @@ LL + #[coverage(on)]
    |
 
 error[E0539]: malformed `coverage` attribute input
-  --> $DIR/name-value.rs:29:5
+  --> $DIR/name-value.rs:29:7
    |
 LL |     #[coverage = "off"]
-   |     ^^^^^^^^^^^-------^
+   |       ^^^^^^^^^-------
    |                |
    |                expected this to be a list
    |
@@ -100,10 +100,10 @@ LL |     #[coverage = "off"]
    = help: the `coverage` attribute can be applied to crates, functions, impl blocks, and modules
 
 error[E0539]: malformed `coverage` attribute input
-  --> $DIR/name-value.rs:35:1
+  --> $DIR/name-value.rs:35:3
    |
 LL | #[coverage = "off"]
-   | ^^^^^^^^^^^-------^
+   |   ^^^^^^^^^-------
    |            |
    |            expected this to be a list
    |
@@ -125,10 +125,10 @@ LL | #[coverage = "off"]
    = help: the `coverage` attribute can be applied to crates, functions, impl blocks, and modules
 
 error[E0539]: malformed `coverage` attribute input
-  --> $DIR/name-value.rs:39:5
+  --> $DIR/name-value.rs:39:7
    |
 LL |     #[coverage = "off"]
-   |     ^^^^^^^^^^^-------^
+   |       ^^^^^^^^^-------
    |                |
    |                expected this to be a list
    |
@@ -150,10 +150,10 @@ LL |     #[coverage = "off"]
    = help: the `coverage` attribute can be applied to crates, functions, impl blocks, and modules
 
 error[E0539]: malformed `coverage` attribute input
-  --> $DIR/name-value.rs:44:5
+  --> $DIR/name-value.rs:44:7
    |
 LL |     #[coverage = "off"]
-   |     ^^^^^^^^^^^-------^
+   |       ^^^^^^^^^-------
    |                |
    |                expected this to be a list
    |
@@ -175,10 +175,10 @@ LL |     #[coverage = "off"]
    = help: the `coverage` attribute can be applied to crates, functions, impl blocks, and modules
 
 error[E0539]: malformed `coverage` attribute input
-  --> $DIR/name-value.rs:50:1
+  --> $DIR/name-value.rs:50:3
    |
 LL | #[coverage = "off"]
-   | ^^^^^^^^^^^-------^
+   |   ^^^^^^^^^-------
    |            |
    |            expected this to be a list
    |
@@ -192,10 +192,10 @@ LL + #[coverage(on)]
    |
 
 error[E0539]: malformed `coverage` attribute input
-  --> $DIR/name-value.rs:53:5
+  --> $DIR/name-value.rs:53:7
    |
 LL |     #[coverage = "off"]
-   |     ^^^^^^^^^^^-------^
+   |       ^^^^^^^^^-------
    |                |
    |                expected this to be a list
    |
@@ -217,10 +217,10 @@ LL |     #[coverage = "off"]
    = help: the `coverage` attribute can be applied to crates, functions, impl blocks, and modules
 
 error[E0539]: malformed `coverage` attribute input
-  --> $DIR/name-value.rs:58:5
+  --> $DIR/name-value.rs:58:7
    |
 LL |     #[coverage = "off"]
-   |     ^^^^^^^^^^^-------^
+   |       ^^^^^^^^^-------
    |                |
    |                expected this to be a list
    |
@@ -242,10 +242,10 @@ LL |     #[coverage = "off"]
    = help: the `coverage` attribute can be applied to crates, functions, impl blocks, and modules
 
 error[E0539]: malformed `coverage` attribute input
-  --> $DIR/name-value.rs:64:1
+  --> $DIR/name-value.rs:64:3
    |
 LL | #[coverage = "off"]
-   | ^^^^^^^^^^^-------^
+   |   ^^^^^^^^^-------
    |            |
    |            expected this to be a list
    |

--- a/tests/ui/coverage-attr/subword.stderr
+++ b/tests/ui/coverage-attr/subword.stderr
@@ -1,8 +1,8 @@
 error[E0539]: malformed `coverage` attribute input
-  --> $DIR/subword.rs:8:1
+  --> $DIR/subword.rs:8:3
    |
 LL | #[coverage(yes(milord))]
-   | ^^^^^^^^^^^-----------^^
+   |   ^^^^^^^^^-----------^
    |            |
    |            valid arguments are `on` or `off`
    |
@@ -16,10 +16,10 @@ LL + #[coverage(on)]
    |
 
 error[E0539]: malformed `coverage` attribute input
-  --> $DIR/subword.rs:11:1
+  --> $DIR/subword.rs:11:3
    |
 LL | #[coverage(no(milord))]
-   | ^^^^^^^^^^^----------^^
+   |   ^^^^^^^^^----------^
    |            |
    |            valid arguments are `on` or `off`
    |
@@ -33,10 +33,10 @@ LL + #[coverage(on)]
    |
 
 error[E0539]: malformed `coverage` attribute input
-  --> $DIR/subword.rs:14:1
+  --> $DIR/subword.rs:14:3
    |
 LL | #[coverage(yes = "milord")]
-   | ^^^^^^^^^^^--------------^^
+   |   ^^^^^^^^^--------------^
    |            |
    |            valid arguments are `on` or `off`
    |
@@ -50,10 +50,10 @@ LL + #[coverage(on)]
    |
 
 error[E0539]: malformed `coverage` attribute input
-  --> $DIR/subword.rs:17:1
+  --> $DIR/subword.rs:17:3
    |
 LL | #[coverage(no = "milord")]
-   | ^^^^^^^^^^^-------------^^
+   |   ^^^^^^^^^-------------^
    |            |
    |            valid arguments are `on` or `off`
    |

--- a/tests/ui/coverage-attr/word-only.stderr
+++ b/tests/ui/coverage-attr/word-only.stderr
@@ -1,8 +1,8 @@
 error[E0539]: malformed `coverage` attribute input
-  --> $DIR/word-only.rs:12:1
+  --> $DIR/word-only.rs:12:3
    |
 LL | #[coverage]
-   | ^^^^^^^^^^^ expected this to be a list
+   |   ^^^^^^^^ expected this to be a list
    |
 help: try changing it to one of the following valid forms of the attribute
    |
@@ -12,10 +12,10 @@ LL | #[coverage(on)]
    |           ++++
 
 error[E0539]: malformed `coverage` attribute input
-  --> $DIR/word-only.rs:17:5
+  --> $DIR/word-only.rs:17:8
    |
 LL |     #![coverage]
-   |     ^^^^^^^^^^^^ expected this to be a list
+   |        ^^^^^^^^ expected this to be a list
    |
 help: try changing it to one of the following valid forms of the attribute
    |
@@ -25,10 +25,10 @@ LL |     #![coverage(on)]
    |                ++++
 
 error[E0539]: malformed `coverage` attribute input
-  --> $DIR/word-only.rs:21:1
+  --> $DIR/word-only.rs:21:3
    |
 LL | #[coverage]
-   | ^^^^^^^^^^^ expected this to be a list
+   |   ^^^^^^^^ expected this to be a list
    |
 help: try changing it to one of the following valid forms of the attribute
    |
@@ -46,10 +46,10 @@ LL | #[coverage]
    = help: the `coverage` attribute can be applied to crates, functions, impl blocks, and modules
 
 error[E0539]: malformed `coverage` attribute input
-  --> $DIR/word-only.rs:26:1
+  --> $DIR/word-only.rs:26:3
    |
 LL | #[coverage]
-   | ^^^^^^^^^^^ expected this to be a list
+   |   ^^^^^^^^ expected this to be a list
    |
 help: try changing it to one of the following valid forms of the attribute
    |
@@ -59,10 +59,10 @@ LL | #[coverage(on)]
    |           ++++
 
 error[E0539]: malformed `coverage` attribute input
-  --> $DIR/word-only.rs:29:5
+  --> $DIR/word-only.rs:29:7
    |
 LL |     #[coverage]
-   |     ^^^^^^^^^^^ expected this to be a list
+   |       ^^^^^^^^ expected this to be a list
    |
 help: try changing it to one of the following valid forms of the attribute
    |
@@ -80,10 +80,10 @@ LL |     #[coverage]
    = help: the `coverage` attribute can be applied to crates, functions, impl blocks, and modules
 
 error[E0539]: malformed `coverage` attribute input
-  --> $DIR/word-only.rs:35:1
+  --> $DIR/word-only.rs:35:3
    |
 LL | #[coverage]
-   | ^^^^^^^^^^^ expected this to be a list
+   |   ^^^^^^^^ expected this to be a list
    |
 help: try changing it to one of the following valid forms of the attribute
    |
@@ -101,10 +101,10 @@ LL | #[coverage]
    = help: the `coverage` attribute can be applied to crates, functions, impl blocks, and modules
 
 error[E0539]: malformed `coverage` attribute input
-  --> $DIR/word-only.rs:39:5
+  --> $DIR/word-only.rs:39:7
    |
 LL |     #[coverage]
-   |     ^^^^^^^^^^^ expected this to be a list
+   |       ^^^^^^^^ expected this to be a list
    |
 help: try changing it to one of the following valid forms of the attribute
    |
@@ -122,10 +122,10 @@ LL |     #[coverage]
    = help: the `coverage` attribute can be applied to crates, functions, impl blocks, and modules
 
 error[E0539]: malformed `coverage` attribute input
-  --> $DIR/word-only.rs:44:5
+  --> $DIR/word-only.rs:44:7
    |
 LL |     #[coverage]
-   |     ^^^^^^^^^^^ expected this to be a list
+   |       ^^^^^^^^ expected this to be a list
    |
 help: try changing it to one of the following valid forms of the attribute
    |
@@ -143,10 +143,10 @@ LL |     #[coverage]
    = help: the `coverage` attribute can be applied to crates, functions, impl blocks, and modules
 
 error[E0539]: malformed `coverage` attribute input
-  --> $DIR/word-only.rs:50:1
+  --> $DIR/word-only.rs:50:3
    |
 LL | #[coverage]
-   | ^^^^^^^^^^^ expected this to be a list
+   |   ^^^^^^^^ expected this to be a list
    |
 help: try changing it to one of the following valid forms of the attribute
    |
@@ -156,10 +156,10 @@ LL | #[coverage(on)]
    |           ++++
 
 error[E0539]: malformed `coverage` attribute input
-  --> $DIR/word-only.rs:53:5
+  --> $DIR/word-only.rs:53:7
    |
 LL |     #[coverage]
-   |     ^^^^^^^^^^^ expected this to be a list
+   |       ^^^^^^^^ expected this to be a list
    |
 help: try changing it to one of the following valid forms of the attribute
    |
@@ -177,10 +177,10 @@ LL |     #[coverage]
    = help: the `coverage` attribute can be applied to crates, functions, impl blocks, and modules
 
 error[E0539]: malformed `coverage` attribute input
-  --> $DIR/word-only.rs:58:5
+  --> $DIR/word-only.rs:58:7
    |
 LL |     #[coverage]
-   |     ^^^^^^^^^^^ expected this to be a list
+   |       ^^^^^^^^ expected this to be a list
    |
 help: try changing it to one of the following valid forms of the attribute
    |
@@ -198,10 +198,10 @@ LL |     #[coverage]
    = help: the `coverage` attribute can be applied to crates, functions, impl blocks, and modules
 
 error[E0539]: malformed `coverage` attribute input
-  --> $DIR/word-only.rs:64:1
+  --> $DIR/word-only.rs:64:3
    |
 LL | #[coverage]
-   | ^^^^^^^^^^^ expected this to be a list
+   |   ^^^^^^^^ expected this to be a list
    |
 help: try changing it to one of the following valid forms of the attribute
    |

--- a/tests/ui/coverage-attr/word-only.stderr
+++ b/tests/ui/coverage-attr/word-only.stderr
@@ -37,13 +37,13 @@ LL | #[coverage(off)]
 LL | #[coverage(on)]
    |           ++++
 
-error: `#[coverage]` attribute cannot be used on structs
-  --> $DIR/word-only.rs:21:1
+error: the `coverage` attribute cannot be used on structs
+  --> $DIR/word-only.rs:21:3
    |
 LL | #[coverage]
-   | ^^^^^^^^^^^
+   |   ^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
+   = help: the `coverage` attribute can be applied to crates, functions, impl blocks, and modules
 
 error[E0539]: malformed `coverage` attribute input
   --> $DIR/word-only.rs:26:1
@@ -71,13 +71,13 @@ LL |     #[coverage(off)]
 LL |     #[coverage(on)]
    |               ++++
 
-error: `#[coverage]` attribute cannot be used on associated consts
-  --> $DIR/word-only.rs:29:5
+error: the `coverage` attribute cannot be used on associated consts
+  --> $DIR/word-only.rs:29:7
    |
 LL |     #[coverage]
-   |     ^^^^^^^^^^^
+   |       ^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
+   = help: the `coverage` attribute can be applied to crates, functions, impl blocks, and modules
 
 error[E0539]: malformed `coverage` attribute input
   --> $DIR/word-only.rs:35:1
@@ -92,13 +92,13 @@ LL | #[coverage(off)]
 LL | #[coverage(on)]
    |           ++++
 
-error: `#[coverage]` attribute cannot be used on traits
-  --> $DIR/word-only.rs:35:1
+error: the `coverage` attribute cannot be used on traits
+  --> $DIR/word-only.rs:35:3
    |
 LL | #[coverage]
-   | ^^^^^^^^^^^
+   |   ^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
+   = help: the `coverage` attribute can be applied to crates, functions, impl blocks, and modules
 
 error[E0539]: malformed `coverage` attribute input
   --> $DIR/word-only.rs:39:5
@@ -113,13 +113,13 @@ LL |     #[coverage(off)]
 LL |     #[coverage(on)]
    |               ++++
 
-error: `#[coverage]` attribute cannot be used on associated consts
-  --> $DIR/word-only.rs:39:5
+error: the `coverage` attribute cannot be used on associated consts
+  --> $DIR/word-only.rs:39:7
    |
 LL |     #[coverage]
-   |     ^^^^^^^^^^^
+   |       ^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
+   = help: the `coverage` attribute can be applied to crates, functions, impl blocks, and modules
 
 error[E0539]: malformed `coverage` attribute input
   --> $DIR/word-only.rs:44:5
@@ -134,13 +134,13 @@ LL |     #[coverage(off)]
 LL |     #[coverage(on)]
    |               ++++
 
-error: `#[coverage]` attribute cannot be used on associated types
-  --> $DIR/word-only.rs:44:5
+error: the `coverage` attribute cannot be used on associated types
+  --> $DIR/word-only.rs:44:7
    |
 LL |     #[coverage]
-   |     ^^^^^^^^^^^
+   |       ^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
+   = help: the `coverage` attribute can be applied to crates, functions, impl blocks, and modules
 
 error[E0539]: malformed `coverage` attribute input
   --> $DIR/word-only.rs:50:1
@@ -168,13 +168,13 @@ LL |     #[coverage(off)]
 LL |     #[coverage(on)]
    |               ++++
 
-error: `#[coverage]` attribute cannot be used on associated consts
-  --> $DIR/word-only.rs:53:5
+error: the `coverage` attribute cannot be used on associated consts
+  --> $DIR/word-only.rs:53:7
    |
 LL |     #[coverage]
-   |     ^^^^^^^^^^^
+   |       ^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
+   = help: the `coverage` attribute can be applied to crates, functions, impl blocks, and modules
 
 error[E0539]: malformed `coverage` attribute input
   --> $DIR/word-only.rs:58:5
@@ -189,13 +189,13 @@ LL |     #[coverage(off)]
 LL |     #[coverage(on)]
    |               ++++
 
-error: `#[coverage]` attribute cannot be used on associated types
-  --> $DIR/word-only.rs:58:5
+error: the `coverage` attribute cannot be used on associated types
+  --> $DIR/word-only.rs:58:7
    |
 LL |     #[coverage]
-   |     ^^^^^^^^^^^
+   |       ^^^^^^^^
    |
-   = help: `#[coverage]` can be applied to crates, functions, impl blocks, and modules
+   = help: the `coverage` attribute can be applied to crates, functions, impl blocks, and modules
 
 error[E0539]: malformed `coverage` attribute input
   --> $DIR/word-only.rs:64:1

--- a/tests/ui/delegation/hir-crate-items-before-lowering-ices.ice_155127.stderr
+++ b/tests/ui/delegation/hir-crate-items-before-lowering-ices.ice_155127.stderr
@@ -1,10 +1,10 @@
-error: `#[deprecated]` attribute cannot be used on delegations
-  --> $DIR/hir-crate-items-before-lowering-ices.rs:27:9
+error: the `deprecated` attribute cannot be used on delegations
+  --> $DIR/hir-crate-items-before-lowering-ices.rs:27:11
    |
 LL |         #[deprecated]
-   |         ^^^^^^^^^^^^^
+   |           ^^^^^^^^^^
    |
-   = help: `#[deprecated]` can be applied to associated consts, associated types, constants, crates, data types, enum variants, foreign statics, functions, inherent impl blocks, macro defs, modules, statics, struct fields, traits, type aliases, and use statements
+   = help: the `deprecated` attribute can be applied to associated consts, associated types, constants, crates, data types, enum variants, foreign statics, functions, inherent impl blocks, macro defs, modules, statics, struct fields, traits, type aliases, and use statements
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: `#[deny(useless_deprecated)]` on by default
 

--- a/tests/ui/delegation/hir-crate-items-before-lowering-ices.rs
+++ b/tests/ui/delegation/hir-crate-items-before-lowering-ices.rs
@@ -24,7 +24,7 @@ mod ice_155127 {
 
     fn foo() {}
     impl S {
-        #[deprecated] //[ice_155127]~ ERROR: `#[deprecated]` attribute cannot be used on delegations
+        #[deprecated] //[ice_155127]~ ERROR: the `deprecated` attribute cannot be used on delegations
         //[ice_155127]~^ WARN: this was previously accepted by the compiler but is being phased out;
         reuse foo;
     }

--- a/tests/ui/deprecation/deprecated-expr-precedence.stderr
+++ b/tests/ui/deprecation/deprecated-expr-precedence.stderr
@@ -1,10 +1,10 @@
-warning: `#[deprecated]` attribute cannot be used on expressions
-  --> $DIR/deprecated-expr-precedence.rs:6:5
+warning: the `deprecated` attribute cannot be used on expressions
+  --> $DIR/deprecated-expr-precedence.rs:6:7
    |
 LL |     #[deprecated] 0
-   |     ^^^^^^^^^^^^^
+   |       ^^^^^^^^^^
    |
-   = help: `#[deprecated]` can be applied to associated consts, associated types, constants, crates, data types, enum variants, foreign statics, functions, inherent impl blocks, macro defs, modules, statics, struct fields, traits, type aliases, and use statements
+   = help: the `deprecated` attribute can be applied to associated consts, associated types, constants, crates, data types, enum variants, foreign statics, functions, inherent impl blocks, macro defs, modules, statics, struct fields, traits, type aliases, and use statements
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: requested on the command line with `-W unused-attributes`
 

--- a/tests/ui/deprecation/deprecation-sanity.stderr
+++ b/tests/ui/deprecation/deprecation-sanity.stderr
@@ -95,13 +95,13 @@ LL | #[deprecated(since = "a", since = "b", note = "c")]
    |                           |
    |                           found `since` used as a key more than once
 
-error: `#[deprecated]` attribute cannot be used on trait impl blocks
-  --> $DIR/deprecation-sanity.rs:40:1
+error: the `deprecated` attribute cannot be used on trait impl blocks
+  --> $DIR/deprecation-sanity.rs:40:3
    |
 LL | #[deprecated = "hello"]
-   | ^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^
    |
-   = help: `#[deprecated]` can be applied to associated consts, associated types, constants, crates, data types, enum variants, foreign statics, functions, inherent impl blocks, macro defs, modules, statics, struct fields, traits, type aliases, and use statements
+   = help: the `deprecated` attribute can be applied to associated consts, associated types, constants, crates, data types, enum variants, foreign statics, functions, inherent impl blocks, macro defs, modules, statics, struct fields, traits, type aliases, and use statements
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: `#[deny(useless_deprecated)]` on by default
 

--- a/tests/ui/deprecation/deprecation-sanity.stderr
+++ b/tests/ui/deprecation/deprecation-sanity.stderr
@@ -1,58 +1,58 @@
 error[E0539]: malformed `deprecated` attribute input
-  --> $DIR/deprecation-sanity.rs:6:5
+  --> $DIR/deprecation-sanity.rs:6:7
    |
 LL |     #[deprecated(since = "a", note = "a", reason)]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------^^
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------^
    |                                           |
    |                                           valid arguments are `since` or `note`
 
 error[E0539]: malformed `deprecated` attribute input
-  --> $DIR/deprecation-sanity.rs:9:5
+  --> $DIR/deprecation-sanity.rs:9:7
    |
 LL |     #[deprecated(since = "a", note)]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^----^^
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^----^
    |                               |
    |                               expected this to be of the form `note = "..."`
 
 error[E0539]: malformed `deprecated` attribute input
-  --> $DIR/deprecation-sanity.rs:12:5
+  --> $DIR/deprecation-sanity.rs:12:7
    |
 LL |     #[deprecated(since, note = "a")]
-   |     ^^^^^^^^^^^^^-----^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^-----^^^^^^^^^^^^^
    |                  |
    |                  expected this to be of the form `since = "..."`
 
 error[E0539]: malformed `deprecated` attribute input
-  --> $DIR/deprecation-sanity.rs:15:5
+  --> $DIR/deprecation-sanity.rs:15:7
    |
 LL |     #[deprecated(since = "a", note(b))]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^-------^^
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^-------^
    |                               |
    |                               expected this to be of the form `note = "..."`
 
 error[E0539]: malformed `deprecated` attribute input
-  --> $DIR/deprecation-sanity.rs:18:5
+  --> $DIR/deprecation-sanity.rs:18:7
    |
 LL |     #[deprecated(since(b), note = "a")]
-   |     ^^^^^^^^^^^^^--------^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^--------^^^^^^^^^^^^^
    |                  |
    |                  expected this to be of the form `since = "..."`
 
 error[E0539]: malformed `deprecated` attribute input
-  --> $DIR/deprecation-sanity.rs:21:5
+  --> $DIR/deprecation-sanity.rs:21:7
    |
 LL |     #[deprecated(note = b"test")]
-   |     ^^^^^^^^^^^^^^^^^^^^-^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^^^-^^^^^^^
    |                         |
    |                         help: consider removing the prefix
    |
    = note: expected a normal string literal, not a byte string literal
 
 error[E0565]: malformed `deprecated` attribute input
-  --> $DIR/deprecation-sanity.rs:24:5
+  --> $DIR/deprecation-sanity.rs:24:7
    |
 LL |     #[deprecated("test")]
-   |     ^^^^^^^^^^^^^------^^
+   |       ^^^^^^^^^^^------^
    |                  |
    |                  didn't expect a literal here
    |
@@ -63,10 +63,10 @@ LL +     #[deprecated = "test"]
    |
 
 error[E0565]: malformed `deprecated` attribute input
-  --> $DIR/deprecation-sanity.rs:27:5
+  --> $DIR/deprecation-sanity.rs:27:7
    |
 LL |     #[deprecated("1.2.3")]
-   |     ^^^^^^^^^^^^^-------^^
+   |       ^^^^^^^^^^^-------^
    |                  |
    |                  didn't expect a literal here
    |
@@ -88,10 +88,10 @@ LL | #[deprecated(since = "a", note = "b")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0538]: malformed `deprecated` attribute input
-  --> $DIR/deprecation-sanity.rs:35:1
+  --> $DIR/deprecation-sanity.rs:35:3
    |
 LL | #[deprecated(since = "a", since = "b", note = "c")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^-----------^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^-----------^^^^^^^^^^^^^
    |                           |
    |                           found `since` used as a key more than once
 

--- a/tests/ui/deprecation/invalid-literal.stderr
+++ b/tests/ui/deprecation/invalid-literal.stderr
@@ -1,8 +1,8 @@
 error[E0539]: malformed `deprecated` attribute input
-  --> $DIR/invalid-literal.rs:1:1
+  --> $DIR/invalid-literal.rs:1:3
    |
 LL | #[deprecated = b"test"]
-   | ^^^^^^^^^^^^^^^-^^^^^^^
+   |   ^^^^^^^^^^^^^-^^^^^^
    |                |
    |                help: consider removing the prefix
    |

--- a/tests/ui/diagnostic_namespace/do_not_recommend/incorrect-locations.current.stderr
+++ b/tests/ui/diagnostic_namespace/do_not_recommend/incorrect-locations.current.stderr
@@ -1,75 +1,75 @@
-warning: `#[diagnostic::do_not_recommend]` attribute cannot be used on constants
-  --> $DIR/incorrect-locations.rs:7:1
+warning: the `diagnostic::do_not_recommend` attribute cannot be used on constants
+  --> $DIR/incorrect-locations.rs:7:3
    |
 LL | #[diagnostic::do_not_recommend]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[diagnostic::do_not_recommend]` can only be applied to trait impl blocks
+   = help: the `diagnostic::do_not_recommend` attribute can only be applied to trait impl blocks
    = note: `#[warn(misplaced_diagnostic_attributes)]` (part of `#[warn(unknown_or_malformed_diagnostic_attributes)]`) on by default
 
-warning: `#[diagnostic::do_not_recommend]` attribute cannot be used on statics
-  --> $DIR/incorrect-locations.rs:11:1
+warning: the `diagnostic::do_not_recommend` attribute cannot be used on statics
+  --> $DIR/incorrect-locations.rs:11:3
    |
 LL | #[diagnostic::do_not_recommend]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[diagnostic::do_not_recommend]` can only be applied to trait impl blocks
+   = help: the `diagnostic::do_not_recommend` attribute can only be applied to trait impl blocks
 
-warning: `#[diagnostic::do_not_recommend]` attribute cannot be used on type aliases
-  --> $DIR/incorrect-locations.rs:15:1
+warning: the `diagnostic::do_not_recommend` attribute cannot be used on type aliases
+  --> $DIR/incorrect-locations.rs:15:3
    |
 LL | #[diagnostic::do_not_recommend]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[diagnostic::do_not_recommend]` can only be applied to trait impl blocks
+   = help: the `diagnostic::do_not_recommend` attribute can only be applied to trait impl blocks
 
-warning: `#[diagnostic::do_not_recommend]` attribute cannot be used on enums
-  --> $DIR/incorrect-locations.rs:19:1
+warning: the `diagnostic::do_not_recommend` attribute cannot be used on enums
+  --> $DIR/incorrect-locations.rs:19:3
    |
 LL | #[diagnostic::do_not_recommend]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[diagnostic::do_not_recommend]` can only be applied to trait impl blocks
+   = help: the `diagnostic::do_not_recommend` attribute can only be applied to trait impl blocks
 
-warning: `#[diagnostic::do_not_recommend]` attribute cannot be used on inherent impl blocks
-  --> $DIR/incorrect-locations.rs:23:1
+warning: the `diagnostic::do_not_recommend` attribute cannot be used on inherent impl blocks
+  --> $DIR/incorrect-locations.rs:23:3
    |
 LL | #[diagnostic::do_not_recommend]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[diagnostic::do_not_recommend]` can only be applied to trait impl blocks
+   = help: the `diagnostic::do_not_recommend` attribute can only be applied to trait impl blocks
 
-warning: `#[diagnostic::do_not_recommend]` attribute cannot be used on foreign modules
-  --> $DIR/incorrect-locations.rs:27:1
+warning: the `diagnostic::do_not_recommend` attribute cannot be used on foreign modules
+  --> $DIR/incorrect-locations.rs:27:3
    |
 LL | #[diagnostic::do_not_recommend]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[diagnostic::do_not_recommend]` can only be applied to trait impl blocks
+   = help: the `diagnostic::do_not_recommend` attribute can only be applied to trait impl blocks
 
-warning: `#[diagnostic::do_not_recommend]` attribute cannot be used on functions
-  --> $DIR/incorrect-locations.rs:31:1
+warning: the `diagnostic::do_not_recommend` attribute cannot be used on functions
+  --> $DIR/incorrect-locations.rs:31:3
    |
 LL | #[diagnostic::do_not_recommend]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[diagnostic::do_not_recommend]` can only be applied to trait impl blocks
+   = help: the `diagnostic::do_not_recommend` attribute can only be applied to trait impl blocks
 
-warning: `#[diagnostic::do_not_recommend]` attribute cannot be used on structs
-  --> $DIR/incorrect-locations.rs:35:1
+warning: the `diagnostic::do_not_recommend` attribute cannot be used on structs
+  --> $DIR/incorrect-locations.rs:35:3
    |
 LL | #[diagnostic::do_not_recommend]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[diagnostic::do_not_recommend]` can only be applied to trait impl blocks
+   = help: the `diagnostic::do_not_recommend` attribute can only be applied to trait impl blocks
 
-warning: `#[diagnostic::do_not_recommend]` attribute cannot be used on traits
-  --> $DIR/incorrect-locations.rs:39:1
+warning: the `diagnostic::do_not_recommend` attribute cannot be used on traits
+  --> $DIR/incorrect-locations.rs:39:3
    |
 LL | #[diagnostic::do_not_recommend]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[diagnostic::do_not_recommend]` can only be applied to trait impl blocks
+   = help: the `diagnostic::do_not_recommend` attribute can only be applied to trait impl blocks
 
 warning: 9 warnings emitted
 

--- a/tests/ui/diagnostic_namespace/do_not_recommend/incorrect-locations.next.stderr
+++ b/tests/ui/diagnostic_namespace/do_not_recommend/incorrect-locations.next.stderr
@@ -1,75 +1,75 @@
-warning: `#[diagnostic::do_not_recommend]` attribute cannot be used on constants
-  --> $DIR/incorrect-locations.rs:7:1
+warning: the `diagnostic::do_not_recommend` attribute cannot be used on constants
+  --> $DIR/incorrect-locations.rs:7:3
    |
 LL | #[diagnostic::do_not_recommend]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[diagnostic::do_not_recommend]` can only be applied to trait impl blocks
+   = help: the `diagnostic::do_not_recommend` attribute can only be applied to trait impl blocks
    = note: `#[warn(misplaced_diagnostic_attributes)]` (part of `#[warn(unknown_or_malformed_diagnostic_attributes)]`) on by default
 
-warning: `#[diagnostic::do_not_recommend]` attribute cannot be used on statics
-  --> $DIR/incorrect-locations.rs:11:1
+warning: the `diagnostic::do_not_recommend` attribute cannot be used on statics
+  --> $DIR/incorrect-locations.rs:11:3
    |
 LL | #[diagnostic::do_not_recommend]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[diagnostic::do_not_recommend]` can only be applied to trait impl blocks
+   = help: the `diagnostic::do_not_recommend` attribute can only be applied to trait impl blocks
 
-warning: `#[diagnostic::do_not_recommend]` attribute cannot be used on type aliases
-  --> $DIR/incorrect-locations.rs:15:1
+warning: the `diagnostic::do_not_recommend` attribute cannot be used on type aliases
+  --> $DIR/incorrect-locations.rs:15:3
    |
 LL | #[diagnostic::do_not_recommend]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[diagnostic::do_not_recommend]` can only be applied to trait impl blocks
+   = help: the `diagnostic::do_not_recommend` attribute can only be applied to trait impl blocks
 
-warning: `#[diagnostic::do_not_recommend]` attribute cannot be used on enums
-  --> $DIR/incorrect-locations.rs:19:1
+warning: the `diagnostic::do_not_recommend` attribute cannot be used on enums
+  --> $DIR/incorrect-locations.rs:19:3
    |
 LL | #[diagnostic::do_not_recommend]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[diagnostic::do_not_recommend]` can only be applied to trait impl blocks
+   = help: the `diagnostic::do_not_recommend` attribute can only be applied to trait impl blocks
 
-warning: `#[diagnostic::do_not_recommend]` attribute cannot be used on inherent impl blocks
-  --> $DIR/incorrect-locations.rs:23:1
+warning: the `diagnostic::do_not_recommend` attribute cannot be used on inherent impl blocks
+  --> $DIR/incorrect-locations.rs:23:3
    |
 LL | #[diagnostic::do_not_recommend]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[diagnostic::do_not_recommend]` can only be applied to trait impl blocks
+   = help: the `diagnostic::do_not_recommend` attribute can only be applied to trait impl blocks
 
-warning: `#[diagnostic::do_not_recommend]` attribute cannot be used on foreign modules
-  --> $DIR/incorrect-locations.rs:27:1
+warning: the `diagnostic::do_not_recommend` attribute cannot be used on foreign modules
+  --> $DIR/incorrect-locations.rs:27:3
    |
 LL | #[diagnostic::do_not_recommend]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[diagnostic::do_not_recommend]` can only be applied to trait impl blocks
+   = help: the `diagnostic::do_not_recommend` attribute can only be applied to trait impl blocks
 
-warning: `#[diagnostic::do_not_recommend]` attribute cannot be used on functions
-  --> $DIR/incorrect-locations.rs:31:1
+warning: the `diagnostic::do_not_recommend` attribute cannot be used on functions
+  --> $DIR/incorrect-locations.rs:31:3
    |
 LL | #[diagnostic::do_not_recommend]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[diagnostic::do_not_recommend]` can only be applied to trait impl blocks
+   = help: the `diagnostic::do_not_recommend` attribute can only be applied to trait impl blocks
 
-warning: `#[diagnostic::do_not_recommend]` attribute cannot be used on structs
-  --> $DIR/incorrect-locations.rs:35:1
+warning: the `diagnostic::do_not_recommend` attribute cannot be used on structs
+  --> $DIR/incorrect-locations.rs:35:3
    |
 LL | #[diagnostic::do_not_recommend]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[diagnostic::do_not_recommend]` can only be applied to trait impl blocks
+   = help: the `diagnostic::do_not_recommend` attribute can only be applied to trait impl blocks
 
-warning: `#[diagnostic::do_not_recommend]` attribute cannot be used on traits
-  --> $DIR/incorrect-locations.rs:39:1
+warning: the `diagnostic::do_not_recommend` attribute cannot be used on traits
+  --> $DIR/incorrect-locations.rs:39:3
    |
 LL | #[diagnostic::do_not_recommend]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[diagnostic::do_not_recommend]` can only be applied to trait impl blocks
+   = help: the `diagnostic::do_not_recommend` attribute can only be applied to trait impl blocks
 
 warning: 9 warnings emitted
 

--- a/tests/ui/diagnostic_namespace/on_const/misplaced_attr.stderr
+++ b/tests/ui/diagnostic_namespace/on_const/misplaced_attr.stderr
@@ -13,29 +13,29 @@ note: the lint level is defined here
 LL | #![deny(misplaced_diagnostic_attributes)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: `#[diagnostic::on_const]` attribute cannot be used on structs
-  --> $DIR/misplaced_attr.rs:4:1
+error: the `diagnostic::on_const` attribute cannot be used on structs
+  --> $DIR/misplaced_attr.rs:4:3
    |
 LL | #[diagnostic::on_const(message = "tadaa", note = "boing")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[diagnostic::on_const]` can only be applied to trait impl blocks
+   = help: the `diagnostic::on_const` attribute can only be applied to trait impl blocks
 
-error: `#[diagnostic::on_const]` attribute cannot be used on inherent impl blocks
-  --> $DIR/misplaced_attr.rs:16:1
+error: the `diagnostic::on_const` attribute cannot be used on inherent impl blocks
+  --> $DIR/misplaced_attr.rs:16:3
    |
 LL | #[diagnostic::on_const(message = "tadaa", note = "boing")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[diagnostic::on_const]` can only be applied to trait impl blocks
+   = help: the `diagnostic::on_const` attribute can only be applied to trait impl blocks
 
-error: `#[diagnostic::on_const]` attribute cannot be used on trait methods in impl blocks
-  --> $DIR/misplaced_attr.rs:25:5
+error: the `diagnostic::on_const` attribute cannot be used on trait methods in impl blocks
+  --> $DIR/misplaced_attr.rs:25:7
    |
 LL |     #[diagnostic::on_const(message = "tadaa", note = "boing")]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[diagnostic::on_const]` can only be applied to trait impl blocks
+   = help: the `diagnostic::on_const` attribute can only be applied to trait impl blocks
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/diagnostic_namespace/on_move/report_warning_on_non_adt.rs
+++ b/tests/ui/diagnostic_namespace/on_move/report_warning_on_non_adt.rs
@@ -7,7 +7,7 @@
 struct Foo;
 
 #[diagnostic::on_move(
-//~^WARN `#[diagnostic::on_move]` attribute cannot be used on traits
+//~^WARN the `diagnostic::on_move` attribute cannot be used on traits
     message = "Foo",
     label = "Bar",
 )]

--- a/tests/ui/diagnostic_namespace/on_move/report_warning_on_non_adt.stderr
+++ b/tests/ui/diagnostic_namespace/on_move/report_warning_on_non_adt.stderr
@@ -1,14 +1,10 @@
-warning: `#[diagnostic::on_move]` attribute cannot be used on traits
-  --> $DIR/report_warning_on_non_adt.rs:9:1
+warning: the `diagnostic::on_move` attribute cannot be used on traits
+  --> $DIR/report_warning_on_non_adt.rs:9:3
    |
-LL | / #[diagnostic::on_move(
-LL | |
-LL | |     message = "Foo",
-LL | |     label = "Bar",
-LL | | )]
-   | |__^
+LL | #[diagnostic::on_move(
+   |   ^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[diagnostic::on_move]` can only be applied to data types
+   = help: the `diagnostic::on_move` attribute can only be applied to data types
    = note: `#[warn(misplaced_diagnostic_attributes)]` (part of `#[warn(unknown_or_malformed_diagnostic_attributes)]`) on by default
 
 error[E0382]: Foo

--- a/tests/ui/diagnostic_namespace/on_type_error/report_warning_on_non_adt.stderr
+++ b/tests/ui/diagnostic_namespace/on_type_error/report_warning_on_non_adt.stderr
@@ -1,51 +1,51 @@
-warning: `#[diagnostic::on_type_error]` attribute cannot be used on functions
-  --> $DIR/report_warning_on_non_adt.rs:3:1
+warning: the `diagnostic::on_type_error` attribute cannot be used on functions
+  --> $DIR/report_warning_on_non_adt.rs:3:3
    |
 LL | #[diagnostic::on_type_error(note = "custom on_type_error note: not an ADT")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[diagnostic::on_type_error]` can only be applied to data types
+   = help: the `diagnostic::on_type_error` attribute can only be applied to data types
    = note: `#[warn(misplaced_diagnostic_attributes)]` (part of `#[warn(unknown_or_malformed_diagnostic_attributes)]`) on by default
 
-warning: `#[diagnostic::on_type_error]` attribute cannot be used on statics
-  --> $DIR/report_warning_on_non_adt.rs:7:1
+warning: the `diagnostic::on_type_error` attribute cannot be used on statics
+  --> $DIR/report_warning_on_non_adt.rs:7:3
    |
 LL | #[diagnostic::on_type_error(note = "custom on_type_error note: not an ADT")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[diagnostic::on_type_error]` can only be applied to data types
+   = help: the `diagnostic::on_type_error` attribute can only be applied to data types
 
-warning: `#[diagnostic::on_type_error]` attribute cannot be used on modules
-  --> $DIR/report_warning_on_non_adt.rs:11:1
+warning: the `diagnostic::on_type_error` attribute cannot be used on modules
+  --> $DIR/report_warning_on_non_adt.rs:11:3
    |
 LL | #[diagnostic::on_type_error(note = "custom on_type_error note: not an ADT")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[diagnostic::on_type_error]` can only be applied to data types
+   = help: the `diagnostic::on_type_error` attribute can only be applied to data types
 
-warning: `#[diagnostic::on_type_error]` attribute cannot be used on traits
-  --> $DIR/report_warning_on_non_adt.rs:15:1
+warning: the `diagnostic::on_type_error` attribute cannot be used on traits
+  --> $DIR/report_warning_on_non_adt.rs:15:3
    |
 LL | #[diagnostic::on_type_error(note = "custom on_type_error note: not an ADT")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[diagnostic::on_type_error]` can only be applied to data types
+   = help: the `diagnostic::on_type_error` attribute can only be applied to data types
 
-warning: `#[diagnostic::on_type_error]` attribute cannot be used on type aliases
-  --> $DIR/report_warning_on_non_adt.rs:19:1
+warning: the `diagnostic::on_type_error` attribute cannot be used on type aliases
+  --> $DIR/report_warning_on_non_adt.rs:19:3
    |
 LL | #[diagnostic::on_type_error(note = "custom on_type_error note: not an ADT")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[diagnostic::on_type_error]` can only be applied to data types
+   = help: the `diagnostic::on_type_error` attribute can only be applied to data types
 
-warning: `#[diagnostic::on_type_error]` attribute cannot be used on inherent methods
-  --> $DIR/report_warning_on_non_adt.rs:26:5
+warning: the `diagnostic::on_type_error` attribute cannot be used on inherent methods
+  --> $DIR/report_warning_on_non_adt.rs:26:7
    |
 LL |     #[diagnostic::on_type_error(note = "custom on_type_error note: not an ADT")]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[diagnostic::on_type_error]` can only be applied to data types
+   = help: the `diagnostic::on_type_error` attribute can only be applied to data types
 
 error[E0308]: mismatched types
   --> $DIR/report_warning_on_non_adt.rs:38:25

--- a/tests/ui/diagnostic_namespace/on_unimplemented/do_not_accept_options_of_the_internal_rustc_attribute.stderr
+++ b/tests/ui/diagnostic_namespace/on_unimplemented/do_not_accept_options_of_the_internal_rustc_attribute.stderr
@@ -152,13 +152,13 @@ LL | #[diagnostic::on_unimplemented = "Message"]
    |
    = help: only `message`, `note` and `label` are allowed as options
 
-warning: `#[diagnostic::on_unimplemented]` attribute cannot be used on trait impl blocks
-  --> $DIR/do_not_accept_options_of_the_internal_rustc_attribute.rs:22:1
+warning: the `diagnostic::on_unimplemented` attribute cannot be used on trait impl blocks
+  --> $DIR/do_not_accept_options_of_the_internal_rustc_attribute.rs:22:3
    |
 LL | #[diagnostic::on_unimplemented(message = "Not allowed to apply it on a impl")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[diagnostic::on_unimplemented]` can only be applied to traits
+   = help: the `diagnostic::on_unimplemented` attribute can only be applied to traits
    = note: `#[warn(misplaced_diagnostic_attributes)]` (part of `#[warn(unknown_or_malformed_diagnostic_attributes)]`) on by default
 
 warning: format specifiers are not permitted in diagnostic attributes

--- a/tests/ui/diagnostic_namespace/on_unimplemented/do_not_fail_parsing_on_invalid_options_1.stderr
+++ b/tests/ui/diagnostic_namespace/on_unimplemented/do_not_fail_parsing_on_invalid_options_1.stderr
@@ -16,13 +16,13 @@ LL | #[diagnostic::on_unimplemented(unsupported = "foo")]
    = help: only `message`, `note` and `label` are allowed as options
    = note: `#[warn(malformed_diagnostic_attributes)]` (part of `#[warn(unknown_or_malformed_diagnostic_attributes)]`) on by default
 
-warning: `#[diagnostic::on_unimplemented]` attribute cannot be used on structs
-  --> $DIR/do_not_fail_parsing_on_invalid_options_1.rs:7:1
+warning: the `diagnostic::on_unimplemented` attribute cannot be used on structs
+  --> $DIR/do_not_fail_parsing_on_invalid_options_1.rs:7:3
    |
 LL | #[diagnostic::on_unimplemented(message = "Baz")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[diagnostic::on_unimplemented]` can only be applied to traits
+   = help: the `diagnostic::on_unimplemented` attribute can only be applied to traits
    = note: `#[warn(misplaced_diagnostic_attributes)]` (part of `#[warn(unknown_or_malformed_diagnostic_attributes)]`) on by default
 
 warning: malformed `diagnostic::on_unimplemented` attribute

--- a/tests/ui/diagnostic_namespace/on_unimplemented/on_impl_trait.stderr
+++ b/tests/ui/diagnostic_namespace/on_unimplemented/on_impl_trait.stderr
@@ -1,10 +1,10 @@
-warning: `#[diagnostic::on_unimplemented]` attribute cannot be used on trait aliases
-  --> $DIR/on_impl_trait.rs:8:1
+warning: the `diagnostic::on_unimplemented` attribute cannot be used on trait aliases
+  --> $DIR/on_impl_trait.rs:8:3
    |
 LL | #[diagnostic::on_unimplemented(message = "blah", label = "blah", note = "blah")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[diagnostic::on_unimplemented]` can only be applied to traits
+   = help: the `diagnostic::on_unimplemented` attribute can only be applied to traits
    = note: `#[warn(misplaced_diagnostic_attributes)]` (part of `#[warn(unknown_or_malformed_diagnostic_attributes)]`) on by default
 
 error[E0277]: the trait bound `{integer}: Alias` is not satisfied

--- a/tests/ui/diagnostic_namespace/on_unknown/incorrect_locations.stderr
+++ b/tests/ui/diagnostic_namespace/on_unknown/incorrect_locations.stderr
@@ -1,91 +1,91 @@
-warning: `#[diagnostic::on_unknown]` attribute cannot be used on extern crates
-  --> $DIR/incorrect_locations.rs:5:1
+warning: the `diagnostic::on_unknown` attribute cannot be used on extern crates
+  --> $DIR/incorrect_locations.rs:5:3
    |
 LL | #[diagnostic::on_unknown(message = "foo")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[diagnostic::on_unknown]` can be applied to crates, modules, and use statements
+   = help: the `diagnostic::on_unknown` attribute can be applied to crates, modules, and use statements
    = note: `#[warn(misplaced_diagnostic_attributes)]` (part of `#[warn(unknown_or_malformed_diagnostic_attributes)]`) on by default
 
-warning: `#[diagnostic::on_unknown]` attribute cannot be used on constants
-  --> $DIR/incorrect_locations.rs:9:1
+warning: the `diagnostic::on_unknown` attribute cannot be used on constants
+  --> $DIR/incorrect_locations.rs:9:3
    |
 LL | #[diagnostic::on_unknown(message = "foo")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[diagnostic::on_unknown]` can be applied to crates, modules, and use statements
+   = help: the `diagnostic::on_unknown` attribute can be applied to crates, modules, and use statements
 
-warning: `#[diagnostic::on_unknown]` attribute cannot be used on statics
-  --> $DIR/incorrect_locations.rs:13:1
+warning: the `diagnostic::on_unknown` attribute cannot be used on statics
+  --> $DIR/incorrect_locations.rs:13:3
    |
 LL | #[diagnostic::on_unknown(message = "foo")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[diagnostic::on_unknown]` can be applied to crates, modules, and use statements
+   = help: the `diagnostic::on_unknown` attribute can be applied to crates, modules, and use statements
 
-warning: `#[diagnostic::on_unknown]` attribute cannot be used on type aliases
-  --> $DIR/incorrect_locations.rs:17:1
+warning: the `diagnostic::on_unknown` attribute cannot be used on type aliases
+  --> $DIR/incorrect_locations.rs:17:3
    |
 LL | #[diagnostic::on_unknown(message = "foo")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[diagnostic::on_unknown]` can be applied to crates, modules, and use statements
+   = help: the `diagnostic::on_unknown` attribute can be applied to crates, modules, and use statements
 
-warning: `#[diagnostic::on_unknown]` attribute cannot be used on enums
-  --> $DIR/incorrect_locations.rs:21:1
+warning: the `diagnostic::on_unknown` attribute cannot be used on enums
+  --> $DIR/incorrect_locations.rs:21:3
    |
 LL | #[diagnostic::on_unknown(message = "foo")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[diagnostic::on_unknown]` can be applied to crates, modules, and use statements
+   = help: the `diagnostic::on_unknown` attribute can be applied to crates, modules, and use statements
 
-warning: `#[diagnostic::on_unknown]` attribute cannot be used on inherent impl blocks
-  --> $DIR/incorrect_locations.rs:25:1
+warning: the `diagnostic::on_unknown` attribute cannot be used on inherent impl blocks
+  --> $DIR/incorrect_locations.rs:25:3
    |
 LL | #[diagnostic::on_unknown(message = "foo")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[diagnostic::on_unknown]` can be applied to crates, modules, and use statements
+   = help: the `diagnostic::on_unknown` attribute can be applied to crates, modules, and use statements
 
-warning: `#[diagnostic::on_unknown]` attribute cannot be used on foreign modules
-  --> $DIR/incorrect_locations.rs:29:1
+warning: the `diagnostic::on_unknown` attribute cannot be used on foreign modules
+  --> $DIR/incorrect_locations.rs:29:3
    |
 LL | #[diagnostic::on_unknown(message = "foo")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[diagnostic::on_unknown]` can be applied to crates, modules, and use statements
+   = help: the `diagnostic::on_unknown` attribute can be applied to crates, modules, and use statements
 
-warning: `#[diagnostic::on_unknown]` attribute cannot be used on functions
-  --> $DIR/incorrect_locations.rs:33:1
+warning: the `diagnostic::on_unknown` attribute cannot be used on functions
+  --> $DIR/incorrect_locations.rs:33:3
    |
 LL | #[diagnostic::on_unknown(message = "foo")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[diagnostic::on_unknown]` can be applied to crates, modules, and use statements
+   = help: the `diagnostic::on_unknown` attribute can be applied to crates, modules, and use statements
 
-warning: `#[diagnostic::on_unknown]` attribute cannot be used on structs
-  --> $DIR/incorrect_locations.rs:37:1
+warning: the `diagnostic::on_unknown` attribute cannot be used on structs
+  --> $DIR/incorrect_locations.rs:37:3
    |
 LL | #[diagnostic::on_unknown(message = "foo")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[diagnostic::on_unknown]` can be applied to crates, modules, and use statements
+   = help: the `diagnostic::on_unknown` attribute can be applied to crates, modules, and use statements
 
-warning: `#[diagnostic::on_unknown]` attribute cannot be used on traits
-  --> $DIR/incorrect_locations.rs:41:1
+warning: the `diagnostic::on_unknown` attribute cannot be used on traits
+  --> $DIR/incorrect_locations.rs:41:3
    |
 LL | #[diagnostic::on_unknown(message = "foo")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[diagnostic::on_unknown]` can be applied to crates, modules, and use statements
+   = help: the `diagnostic::on_unknown` attribute can be applied to crates, modules, and use statements
 
-warning: `#[diagnostic::on_unknown]` attribute cannot be used on trait impl blocks
-  --> $DIR/incorrect_locations.rs:45:1
+warning: the `diagnostic::on_unknown` attribute cannot be used on trait impl blocks
+  --> $DIR/incorrect_locations.rs:45:3
    |
 LL | #[diagnostic::on_unknown(message = "foo")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[diagnostic::on_unknown]` can be applied to crates, modules, and use statements
+   = help: the `diagnostic::on_unknown` attribute can be applied to crates, modules, and use statements
 
 warning: 11 warnings emitted
 

--- a/tests/ui/diagnostic_namespace/on_unknown/incorrect_unstable_positions.stderr
+++ b/tests/ui/diagnostic_namespace/on_unknown/incorrect_unstable_positions.stderr
@@ -1,10 +1,10 @@
-warning: `#[diagnostic::on_unknown]` attribute cannot be used on expressions
-  --> $DIR/incorrect_unstable_positions.rs:8:5
+warning: the `diagnostic::on_unknown` attribute cannot be used on expressions
+  --> $DIR/incorrect_unstable_positions.rs:8:7
    |
 LL |     #[diagnostic::on_unknown(message = "anonymous block")]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[diagnostic::on_unknown]` can be applied to crates, modules, and use statements
+   = help: the `diagnostic::on_unknown` attribute can be applied to crates, modules, and use statements
    = note: `#[warn(misplaced_diagnostic_attributes)]` (part of `#[warn(unknown_or_malformed_diagnostic_attributes)]`) on by default
 
 warning: 1 warning emitted

--- a/tests/ui/diagnostic_namespace/on_unmatched_args/report_warning_on_non_macro.stderr
+++ b/tests/ui/diagnostic_namespace/on_unmatched_args/report_warning_on_non_macro.stderr
@@ -1,10 +1,10 @@
-warning: `#[diagnostic::on_unmatched_args]` attribute cannot be used on structs
-  --> $DIR/report_warning_on_non_macro.rs:4:1
+warning: the `diagnostic::on_unmatched_args` attribute cannot be used on structs
+  --> $DIR/report_warning_on_non_macro.rs:4:3
    |
 LL | #[diagnostic::on_unmatched_args(message = "not allowed here")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[diagnostic::on_unmatched_args]` can only be applied to macro defs
+   = help: the `diagnostic::on_unmatched_args` attribute can only be applied to macro defs
    = note: `#[warn(misplaced_diagnostic_attributes)]` (part of `#[warn(unknown_or_malformed_diagnostic_attributes)]`) on by default
 
 warning: 1 warning emitted

--- a/tests/ui/eii/track_caller_static_errors.rs
+++ b/tests/ui/eii/track_caller_static_errors.rs
@@ -2,7 +2,7 @@
 // `#[track_caller]` is only valid on functions, not on EII (foreign) statics.
 #![feature(extern_item_impls)]
 
-#[track_caller] //~ ERROR `#[track_caller]` attribute cannot be used on foreign statics
+#[track_caller] //~ ERROR the `track_caller` attribute cannot be used on foreign statics
 #[eii(sfoo)]
 static FOO: u64 = 42;
 

--- a/tests/ui/eii/track_caller_static_errors.stderr
+++ b/tests/ui/eii/track_caller_static_errors.stderr
@@ -1,10 +1,10 @@
-error: `#[track_caller]` attribute cannot be used on foreign statics
-  --> $DIR/track_caller_static_errors.rs:5:1
+error: the `track_caller` attribute cannot be used on foreign statics
+  --> $DIR/track_caller_static_errors.rs:5:3
    |
 LL | #[track_caller]
-   | ^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^
    |
-   = help: `#[track_caller]` can only be applied to functions
+   = help: the `track_caller` attribute can only be applied to functions
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/enum-discriminant/eval-error.stderr
+++ b/tests/ui/enum-discriminant/eval-error.stderr
@@ -4,13 +4,13 @@ error: unions cannot have zero fields
 LL | union Foo2 {}
    | ^^^^^^^^^^^^^
 
-error: `#[repr(packed)]` attribute cannot be used on enums
-  --> $DIR/eval-error.rs:24:1
+error: the `repr(packed)` attribute cannot be used on enums
+  --> $DIR/eval-error.rs:24:3
    |
 LL | #[repr(u8, packed)]
-   | ^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^
    |
-   = help: `#[repr(packed)]` can be applied to structs and unions
+   = help: the `repr(packed)` attribute can be applied to structs and unions
 
 error[E0740]: field must implement `Copy` or be wrapped in `ManuallyDrop<...>` to be used in a union
   --> $DIR/eval-error.rs:2:5

--- a/tests/ui/error-codes/E0458.stderr
+++ b/tests/ui/error-codes/E0458.stderr
@@ -1,8 +1,8 @@
 error[E0539]: malformed `link` attribute input
-  --> $DIR/E0458.rs:1:1
+  --> $DIR/E0458.rs:1:3
    |
 LL | #[link(kind = "wonderful_unicorn")] extern "C" {}
-   | ^^^^^^^^^^^^^^-------------------^^
+   |   ^^^^^^^^^^^^-------------------^
    |               |
    |               valid arguments are "static", "dylib", "framework", "raw-dylib" or "link-arg"
    |

--- a/tests/ui/error-codes/E0539.stderr
+++ b/tests/ui/error-codes/E0539.stderr
@@ -1,8 +1,8 @@
 error[E0539]: malformed `deprecated` attribute input
-  --> $DIR/E0539.rs:2:1
+  --> $DIR/E0539.rs:2:3
    |
 LL | #[deprecated(since = b"1.29", note = "hi")]
-   | ^^^^^^^^^^^^^^^^^^^^^-^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^-^^^^^^^^^^^^^^^^^^^^
    |                      |
    |                      help: consider removing the prefix
    |

--- a/tests/ui/error-codes/E0540.stderr
+++ b/tests/ui/error-codes/E0540.stderr
@@ -1,8 +1,8 @@
 error[E0805]: malformed `inline` attribute input
-  --> $DIR/E0540.rs:1:1
+  --> $DIR/E0540.rs:1:3
    |
 LL | #[inline()]
-   | ^^^^^^^^--^
+   |   ^^^^^^--
    |         |
    |         expected an argument here
    |

--- a/tests/ui/error-codes/E0565-1.stderr
+++ b/tests/ui/error-codes/E0565-1.stderr
@@ -1,8 +1,8 @@
 error[E0565]: malformed `deprecated` attribute input
-  --> $DIR/E0565-1.rs:2:1
+  --> $DIR/E0565-1.rs:2:3
    |
 LL | #[deprecated("since")]
-   | ^^^^^^^^^^^^^-------^^
+   |   ^^^^^^^^^^^-------^
    |              |
    |              didn't expect a literal here
    |

--- a/tests/ui/error-codes/E0565.stderr
+++ b/tests/ui/error-codes/E0565.stderr
@@ -1,8 +1,8 @@
 error[E0565]: malformed `repr` attribute input
-  --> $DIR/E0565.rs:2:1
+  --> $DIR/E0565.rs:2:3
    |
 LL | #[repr("C")]
-   | ^^^^^^^---^^
+   |   ^^^^^---^
    |        |
    |        expected a valid identifier here
    |

--- a/tests/ui/error-codes/E0718.rs
+++ b/tests/ui/error-codes/E0718.rs
@@ -1,7 +1,7 @@
 #![feature(lang_items)]
 
 // Box is expected to be a struct, so this will error.
-#[lang = "owned_box"] //~ ERROR `#[lang = "owned_box"]` attribute cannot be used on statics
+#[lang = "owned_box"] //~ ERROR the `lang = "owned_box"` attribute cannot be used on statics
 static X: u32 = 42;
 
 fn main() {}

--- a/tests/ui/error-codes/E0718.stderr
+++ b/tests/ui/error-codes/E0718.stderr
@@ -1,10 +1,10 @@
-error: `#[lang = "owned_box"]` attribute cannot be used on statics
-  --> $DIR/E0718.rs:4:1
+error: the `lang = "owned_box"` attribute cannot be used on statics
+  --> $DIR/E0718.rs:4:3
    |
 LL | #[lang = "owned_box"]
-   | ^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[lang = "owned_box"]` can only be applied to structs
+   = help: the `lang = "owned_box"` attribute can only be applied to structs
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/extern/extern-no-mangle.stderr
+++ b/tests/ui/extern/extern-no-mangle.stderr
@@ -1,10 +1,10 @@
-warning: `#[no_mangle]` attribute cannot be used on statements
-  --> $DIR/extern-no-mangle.rs:24:5
+warning: the `no_mangle` attribute cannot be used on statements
+  --> $DIR/extern-no-mangle.rs:24:7
    |
 LL |     #[no_mangle]
-   |     ^^^^^^^^^^^^
+   |       ^^^^^^^^^
    |
-   = help: `#[no_mangle]` can be applied to functions and statics
+   = help: the `no_mangle` attribute can be applied to functions and statics
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 note: the lint level is defined here
   --> $DIR/extern-no-mangle.rs:1:9
@@ -12,22 +12,22 @@ note: the lint level is defined here
 LL | #![warn(unused_attributes)]
    |         ^^^^^^^^^^^^^^^^^
 
-warning: `#[no_mangle]` attribute cannot be used on foreign statics
-  --> $DIR/extern-no-mangle.rs:11:5
+warning: the `no_mangle` attribute cannot be used on foreign statics
+  --> $DIR/extern-no-mangle.rs:11:7
    |
 LL |     #[no_mangle]
-   |     ^^^^^^^^^^^^
+   |       ^^^^^^^^^
    |
-   = help: `#[no_mangle]` can be applied to functions and statics
+   = help: the `no_mangle` attribute can be applied to functions and statics
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[no_mangle]` attribute cannot be used on foreign functions
-  --> $DIR/extern-no-mangle.rs:16:5
+warning: the `no_mangle` attribute cannot be used on foreign functions
+  --> $DIR/extern-no-mangle.rs:16:7
    |
 LL |     #[no_mangle]
-   |     ^^^^^^^^^^^^
+   |       ^^^^^^^^^
    |
-   = help: `#[no_mangle]` can be applied to functions with a body and statics
+   = help: the `no_mangle` attribute can be applied to functions with a body and statics
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: 3 warnings emitted

--- a/tests/ui/extern/issue-47725.stderr
+++ b/tests/ui/extern/issue-47725.stderr
@@ -1,8 +1,8 @@
 error[E0539]: malformed `link_name` attribute input
-  --> $DIR/issue-47725.rs:20:1
+  --> $DIR/issue-47725.rs:20:3
    |
 LL | #[link_name]
-   | ^^^^^^^^^^^^
+   |   ^^^^^^^^^
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link_name-attribute>
 help: must be of the form

--- a/tests/ui/extern/issue-47725.stderr
+++ b/tests/ui/extern/issue-47725.stderr
@@ -10,13 +10,13 @@ help: must be of the form
 LL | #[link_name = "name"]
    |             ++++++++
 
-warning: `#[link_name]` attribute cannot be used on structs
-  --> $DIR/issue-47725.rs:4:1
+warning: the `link_name` attribute cannot be used on structs
+  --> $DIR/issue-47725.rs:4:3
    |
 LL | #[link_name = "foo"]
-   | ^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^
    |
-   = help: `#[link_name]` can be applied to foreign functions and foreign statics
+   = help: the `link_name` attribute can be applied to foreign functions and foreign statics
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 note: the lint level is defined here
   --> $DIR/issue-47725.rs:2:9
@@ -24,22 +24,22 @@ note: the lint level is defined here
 LL | #![warn(unused_attributes)]
    |         ^^^^^^^^^^^^^^^^^
 
-warning: `#[link_name]` attribute cannot be used on foreign modules
-  --> $DIR/issue-47725.rs:11:1
+warning: the `link_name` attribute cannot be used on foreign modules
+  --> $DIR/issue-47725.rs:11:3
    |
 LL | #[link_name = "foobar"]
-   | ^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^
    |
-   = help: `#[link_name]` can be applied to foreign functions and foreign statics
+   = help: the `link_name` attribute can be applied to foreign functions and foreign statics
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[link_name]` attribute cannot be used on foreign modules
-  --> $DIR/issue-47725.rs:20:1
+warning: the `link_name` attribute cannot be used on foreign modules
+  --> $DIR/issue-47725.rs:20:3
    |
 LL | #[link_name]
-   | ^^^^^^^^^^^^
+   |   ^^^^^^^^^
    |
-   = help: `#[link_name]` can be applied to foreign functions and foreign statics
+   = help: the `link_name` attribute can be applied to foreign functions and foreign statics
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 error: aborting due to 1 previous error; 3 warnings emitted

--- a/tests/ui/feature-gates/feature-gate-allocator_internals.stderr
+++ b/tests/ui/feature-gates/feature-gate-allocator_internals.stderr
@@ -1,8 +1,8 @@
-error[E0658]: the `#[default_lib_allocator]` attribute is an experimental feature
-  --> $DIR/feature-gate-allocator_internals.rs:1:1
+error[E0658]: the `default_lib_allocator` attribute is an experimental feature
+  --> $DIR/feature-gate-allocator_internals.rs:1:4
    |
 LL | #![default_lib_allocator]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |    ^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(allocator_internals)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date

--- a/tests/ui/feature-gates/feature-gate-allow-internal-unsafe-nested-macro.rs
+++ b/tests/ui/feature-gates/feature-gate-allow-internal-unsafe-nested-macro.rs
@@ -5,7 +5,7 @@
 macro_rules! bar {
     () => {
         // more layers don't help:
-        #[allow_internal_unsafe] //~ ERROR allow_internal_unsafe side-steps
+        #[allow_internal_unsafe] //~ ERROR the `allow_internal_unsafe` attribute side-steps
         macro_rules! baz {
             () => {}
         }

--- a/tests/ui/feature-gates/feature-gate-allow-internal-unsafe-nested-macro.stderr
+++ b/tests/ui/feature-gates/feature-gate-allow-internal-unsafe-nested-macro.stderr
@@ -1,8 +1,8 @@
-error[E0658]: allow_internal_unsafe side-steps the unsafe_code lint
-  --> $DIR/feature-gate-allow-internal-unsafe-nested-macro.rs:8:9
+error[E0658]: the `allow_internal_unsafe` attribute side-steps the `unsafe_code` lint
+  --> $DIR/feature-gate-allow-internal-unsafe-nested-macro.rs:8:11
    |
 LL |         #[allow_internal_unsafe]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^
+   |           ^^^^^^^^^^^^^^^^^^^^^
 ...
 LL | bar!();
    | ------ in this macro invocation

--- a/tests/ui/feature-gates/feature-gate-allow-internal-unstable-nested-macro.rs
+++ b/tests/ui/feature-gates/feature-gate-allow-internal-unstable-nested-macro.rs
@@ -5,7 +5,7 @@
 macro_rules! bar {
     () => {
         // more layers don't help:
-        #[allow_internal_unstable()] //~ ERROR allow_internal_unstable side-steps
+        #[allow_internal_unstable()] //~ ERROR the `allow_internal_unstable` attribute side-steps
         macro_rules! baz {
             () => {}
         }

--- a/tests/ui/feature-gates/feature-gate-allow-internal-unstable-nested-macro.stderr
+++ b/tests/ui/feature-gates/feature-gate-allow-internal-unstable-nested-macro.stderr
@@ -1,8 +1,8 @@
-error[E0658]: allow_internal_unstable side-steps feature gating and stability checks
-  --> $DIR/feature-gate-allow-internal-unstable-nested-macro.rs:8:9
+error[E0658]: the `allow_internal_unstable` attribute side-steps feature gating and stability checks
+  --> $DIR/feature-gate-allow-internal-unstable-nested-macro.rs:8:11
    |
 LL |         #[allow_internal_unstable()]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |           ^^^^^^^^^^^^^^^^^^^^^^^
 ...
 LL | bar!();
    | ------ in this macro invocation

--- a/tests/ui/feature-gates/feature-gate-allow-internal-unstable-struct.rs
+++ b/tests/ui/feature-gates/feature-gate-allow-internal-unstable-struct.rs
@@ -3,7 +3,7 @@
 
 // FIXME(jdonszelmann): empty attributes are currently ignored, since when its empty no actual
 // change is applied. This should be fixed when later moving this check to attribute parsing.
-#[allow_internal_unstable(something)] //~ ERROR allow_internal_unstable side-steps
+#[allow_internal_unstable(something)] //~ ERROR the `allow_internal_unstable` attribute side-steps
 //~| ERROR attribute cannot be used on
 struct S;
 

--- a/tests/ui/feature-gates/feature-gate-allow-internal-unstable-struct.stderr
+++ b/tests/ui/feature-gates/feature-gate-allow-internal-unstable-struct.stderr
@@ -7,13 +7,13 @@ LL | #[allow_internal_unstable(something)]
    = help: add `#![feature(allow_internal_unstable)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error: `#[allow_internal_unstable]` attribute cannot be used on structs
-  --> $DIR/feature-gate-allow-internal-unstable-struct.rs:6:1
+error: the `allow_internal_unstable` attribute cannot be used on structs
+  --> $DIR/feature-gate-allow-internal-unstable-struct.rs:6:3
    |
 LL | #[allow_internal_unstable(something)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[allow_internal_unstable]` can be applied to functions and macro defs
+   = help: the `allow_internal_unstable` attribute can be applied to functions and macro defs
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/feature-gates/feature-gate-allow-internal-unstable-struct.stderr
+++ b/tests/ui/feature-gates/feature-gate-allow-internal-unstable-struct.stderr
@@ -1,8 +1,8 @@
-error[E0658]: allow_internal_unstable side-steps feature gating and stability checks
-  --> $DIR/feature-gate-allow-internal-unstable-struct.rs:6:1
+error[E0658]: the `allow_internal_unstable` attribute side-steps feature gating and stability checks
+  --> $DIR/feature-gate-allow-internal-unstable-struct.rs:6:3
    |
 LL | #[allow_internal_unstable(something)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(allow_internal_unstable)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date

--- a/tests/ui/feature-gates/feature-gate-allow-internal-unstable.rs
+++ b/tests/ui/feature-gates/feature-gate-allow-internal-unstable.rs
@@ -1,6 +1,6 @@
 #![allow(unused_macros)]
 
-#[allow_internal_unstable()] //~ ERROR allow_internal_unstable side-steps
+#[allow_internal_unstable()] //~ ERROR the `allow_internal_unstable` attribute side-steps
 macro_rules! foo {
     () => {}
 }

--- a/tests/ui/feature-gates/feature-gate-allow-internal-unstable.stderr
+++ b/tests/ui/feature-gates/feature-gate-allow-internal-unstable.stderr
@@ -1,8 +1,8 @@
-error[E0658]: allow_internal_unstable side-steps feature gating and stability checks
-  --> $DIR/feature-gate-allow-internal-unstable.rs:3:1
+error[E0658]: the `allow_internal_unstable` attribute side-steps feature gating and stability checks
+  --> $DIR/feature-gate-allow-internal-unstable.rs:3:3
    |
 LL | #[allow_internal_unstable()]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(allow_internal_unstable)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date

--- a/tests/ui/feature-gates/feature-gate-cfi_encoding.rs
+++ b/tests/ui/feature-gates/feature-gate-cfi_encoding.rs
@@ -1,4 +1,4 @@
 #![crate_type = "lib"]
 
-#[cfi_encoding = "3Bar"] //~ ERROR the `#[cfi_encoding]` attribute is an experimental feature [E0658]
+#[cfi_encoding = "3Bar"] //~ ERROR the `cfi_encoding` attribute is an experimental feature [E0658]
 pub struct Foo(i32);

--- a/tests/ui/feature-gates/feature-gate-cfi_encoding.stderr
+++ b/tests/ui/feature-gates/feature-gate-cfi_encoding.stderr
@@ -1,8 +1,8 @@
-error[E0658]: the `#[cfi_encoding]` attribute is an experimental feature
-  --> $DIR/feature-gate-cfi_encoding.rs:3:1
+error[E0658]: the `cfi_encoding` attribute is an experimental feature
+  --> $DIR/feature-gate-cfi_encoding.rs:3:3
    |
 LL | #[cfi_encoding = "3Bar"]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^
    |
    = note: see issue #89653 <https://github.com/rust-lang/rust/issues/89653> for more information
    = help: add `#![feature(cfi_encoding)]` to the crate attributes to enable

--- a/tests/ui/feature-gates/feature-gate-check-nested-macro-invocation.rs
+++ b/tests/ui/feature-gates/feature-gate-check-nested-macro-invocation.rs
@@ -7,7 +7,7 @@ macro_rules! foo (
     () => (
         #[allow_internal_unstable()]
         //~^ ERROR the `allow_internal_unstable` attribute side-steps
-        //~| ERROR `#[allow_internal_unstable]` attribute cannot be used on macro calls
+        //~| ERROR the `allow_internal_unstable` attribute cannot be used on macro calls
         bar!();
     );
 );

--- a/tests/ui/feature-gates/feature-gate-check-nested-macro-invocation.rs
+++ b/tests/ui/feature-gates/feature-gate-check-nested-macro-invocation.rs
@@ -6,7 +6,7 @@ macro_rules! bar (
 macro_rules! foo (
     () => (
         #[allow_internal_unstable()]
-        //~^ ERROR allow_internal_unstable side-steps
+        //~^ ERROR the `allow_internal_unstable` attribute side-steps
         //~| ERROR `#[allow_internal_unstable]` attribute cannot be used on macro calls
         bar!();
     );

--- a/tests/ui/feature-gates/feature-gate-check-nested-macro-invocation.stderr
+++ b/tests/ui/feature-gates/feature-gate-check-nested-macro-invocation.stderr
@@ -11,16 +11,16 @@ LL | foo!();
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = note: this error originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: `#[allow_internal_unstable]` attribute cannot be used on macro calls
-  --> $DIR/feature-gate-check-nested-macro-invocation.rs:8:9
+error: the `allow_internal_unstable` attribute cannot be used on macro calls
+  --> $DIR/feature-gate-check-nested-macro-invocation.rs:8:11
    |
 LL |         #[allow_internal_unstable()]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |           ^^^^^^^^^^^^^^^^^^^^^^^
 ...
 LL | foo!();
    | ------ in this macro invocation
    |
-   = help: `#[allow_internal_unstable]` can be applied to functions and macro defs
+   = help: the `allow_internal_unstable` attribute can be applied to functions and macro defs
    = note: placing this attribute on a macro invocation does nothing even if the macro expands to what would be a valid target for the attribute
    = note: this error originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/feature-gates/feature-gate-check-nested-macro-invocation.stderr
+++ b/tests/ui/feature-gates/feature-gate-check-nested-macro-invocation.stderr
@@ -1,8 +1,8 @@
-error[E0658]: allow_internal_unstable side-steps feature gating and stability checks
-  --> $DIR/feature-gate-check-nested-macro-invocation.rs:8:9
+error[E0658]: the `allow_internal_unstable` attribute side-steps feature gating and stability checks
+  --> $DIR/feature-gate-check-nested-macro-invocation.rs:8:11
    |
 LL |         #[allow_internal_unstable()]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |           ^^^^^^^^^^^^^^^^^^^^^^^
 ...
 LL | foo!();
    | ------ in this macro invocation

--- a/tests/ui/feature-gates/feature-gate-compiler-builtins.rs
+++ b/tests/ui/feature-gates/feature-gate-compiler-builtins.rs
@@ -1,3 +1,3 @@
-#![compiler_builtins] //~ ERROR the `#[compiler_builtins]` attribute is
+#![compiler_builtins] //~ ERROR the `compiler_builtins` attribute is
 
 fn main() {}

--- a/tests/ui/feature-gates/feature-gate-compiler-builtins.stderr
+++ b/tests/ui/feature-gates/feature-gate-compiler-builtins.stderr
@@ -1,8 +1,8 @@
-error[E0658]: the `#[compiler_builtins]` attribute is used to identify the `compiler_builtins` crate which contains compiler-rt intrinsics and will never be stable
-  --> $DIR/feature-gate-compiler-builtins.rs:1:1
+error[E0658]: the `compiler_builtins` attribute is used to identify the `compiler_builtins` crate which contains compiler-rt intrinsics and will never be stable
+  --> $DIR/feature-gate-compiler-builtins.rs:1:4
    |
 LL | #![compiler_builtins]
-   | ^^^^^^^^^^^^^^^^^^^^^
+   |    ^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(compiler_builtins)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date

--- a/tests/ui/feature-gates/feature-gate-coverage-attribute.rs
+++ b/tests/ui/feature-gates/feature-gate-coverage-attribute.rs
@@ -7,7 +7,7 @@ struct Foo {
     b: u32,
 }
 
-#[coverage(off)] //~ ERROR the `#[coverage]` attribute is an experimental feature
+#[coverage(off)] //~ ERROR the `coverage` attribute is an experimental feature
 fn requires_feature_coverage() -> bool {
     let bar = Foo { a: 0, b: 0 };
     bar == Foo { a: 0, b: 0 }

--- a/tests/ui/feature-gates/feature-gate-coverage-attribute.stderr
+++ b/tests/ui/feature-gates/feature-gate-coverage-attribute.stderr
@@ -7,11 +7,11 @@ LL | #![feature(no_coverage)]
    = note: removed in 1.74.0; see <https://github.com/rust-lang/rust/pull/114656> for more information
    = note: renamed to `coverage_attribute`
 
-error[E0658]: the `#[coverage]` attribute is an experimental feature
-  --> $DIR/feature-gate-coverage-attribute.rs:10:1
+error[E0658]: the `coverage` attribute is an experimental feature
+  --> $DIR/feature-gate-coverage-attribute.rs:10:3
    |
 LL | #[coverage(off)]
-   | ^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^
    |
    = note: see issue #84605 <https://github.com/rust-lang/rust/issues/84605> for more information
    = help: add `#![feature(coverage_attribute)]` to the crate attributes to enable

--- a/tests/ui/feature-gates/feature-gate-custom_mir.rs
+++ b/tests/ui/feature-gates/feature-gate-custom_mir.rs
@@ -3,7 +3,7 @@
 extern crate core;
 use core::intrinsics::mir::*; //~ ERROR custom_mir
 
-#[custom_mir(dialect = "built")] //~ ERROR the `#[custom_mir]` attribute is just used for the Rust test suite
+#[custom_mir(dialect = "built")] //~ ERROR the `custom_mir` attribute is just used for the Rust test suite
 pub fn foo(_x: i32) -> i32 {
     mir! {
         {

--- a/tests/ui/feature-gates/feature-gate-custom_mir.stderr
+++ b/tests/ui/feature-gates/feature-gate-custom_mir.stderr
@@ -1,8 +1,8 @@
-error[E0658]: the `#[custom_mir]` attribute is just used for the Rust test suite
-  --> $DIR/feature-gate-custom_mir.rs:6:1
+error[E0658]: the `custom_mir` attribute is just used for the Rust test suite
+  --> $DIR/feature-gate-custom_mir.rs:6:3
    |
 LL | #[custom_mir(dialect = "built")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^
    |
    = help: add `#![feature(custom_mir)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date

--- a/tests/ui/feature-gates/feature-gate-custom_test_frameworks.stderr
+++ b/tests/ui/feature-gates/feature-gate-custom_test_frameworks.stderr
@@ -9,20 +9,20 @@ LL | #[test_case]
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: custom test frameworks are an unstable feature
-  --> $DIR/feature-gate-custom_test_frameworks.rs:1:1
+  --> $DIR/feature-gate-custom_test_frameworks.rs:1:4
    |
 LL | #![test_runner(main)]
-   | ^^^^^^^^^^^^^^^^^^^^^
+   |    ^^^^^^^^^^^
    |
    = note: see issue #50297 <https://github.com/rust-lang/rust/issues/50297> for more information
    = help: add `#![feature(custom_test_frameworks)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: custom test frameworks are an unstable feature
-  --> $DIR/feature-gate-custom_test_frameworks.rs:2:1
+  --> $DIR/feature-gate-custom_test_frameworks.rs:2:4
    |
 LL | #![reexport_test_harness_main = "foo"]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #50297 <https://github.com/rust-lang/rust/issues/50297> for more information
    = help: add `#![feature(custom_test_frameworks)]` to the crate attributes to enable

--- a/tests/ui/feature-gates/feature-gate-effective-target-features.default.stderr
+++ b/tests/ui/feature-gates/feature-gate-effective-target-features.default.stderr
@@ -1,8 +1,8 @@
-error[E0658]: the `#[force_target_feature]` attribute is an experimental feature
-  --> $DIR/feature-gate-effective-target-features.rs:14:5
+error[E0658]: the `force_target_feature` attribute is an experimental feature
+  --> $DIR/feature-gate-effective-target-features.rs:14:14
    |
 LL |     #[unsafe(force_target_feature(enable = "avx2"))]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |              ^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #143352 <https://github.com/rust-lang/rust/issues/143352> for more information
    = help: add `#![feature(effective_target_features)]` to the crate attributes to enable

--- a/tests/ui/feature-gates/feature-gate-effective-target-features.rs
+++ b/tests/ui/feature-gates/feature-gate-effective-target-features.rs
@@ -12,7 +12,7 @@ struct Bar;
 
 impl Foo for Bar {
     #[unsafe(force_target_feature(enable = "avx2"))]
-    //[default]~^ ERROR the `#[force_target_feature]` attribute is an experimental feature
+    //[default]~^ ERROR the `force_target_feature` attribute is an experimental feature
     fn foo(&self) {}
 }
 

--- a/tests/ui/feature-gates/feature-gate-export_stable.rs
+++ b/tests/ui/feature-gates/feature-gate-export_stable.rs
@@ -1,5 +1,5 @@
 #![crate_type="lib"]
 
 #[export_stable]
-//~^ ERROR the `#[export_stable]` attribute is an experimental feature
+//~^ ERROR the `export_stable` attribute is an experimental feature
 pub mod a {}

--- a/tests/ui/feature-gates/feature-gate-export_stable.stderr
+++ b/tests/ui/feature-gates/feature-gate-export_stable.stderr
@@ -1,8 +1,8 @@
-error[E0658]: the `#[export_stable]` attribute is an experimental feature
-  --> $DIR/feature-gate-export_stable.rs:3:1
+error[E0658]: the `export_stable` attribute is an experimental feature
+  --> $DIR/feature-gate-export_stable.rs:3:3
    |
 LL | #[export_stable]
-   | ^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^
    |
    = note: see issue #139939 <https://github.com/rust-lang/rust/issues/139939> for more information
    = help: add `#![feature(export_stable)]` to the crate attributes to enable

--- a/tests/ui/feature-gates/feature-gate-ffi_const.rs
+++ b/tests/ui/feature-gates/feature-gate-ffi_const.rs
@@ -1,6 +1,6 @@
 #![crate_type = "lib"]
 
 extern "C" {
-    #[unsafe(ffi_const)] //~ ERROR the `#[ffi_const]` attribute is an experimental feature
+    #[unsafe(ffi_const)] //~ ERROR the `ffi_const` attribute is an experimental feature
     pub fn foo();
 }

--- a/tests/ui/feature-gates/feature-gate-ffi_const.stderr
+++ b/tests/ui/feature-gates/feature-gate-ffi_const.stderr
@@ -1,8 +1,8 @@
-error[E0658]: the `#[ffi_const]` attribute is an experimental feature
-  --> $DIR/feature-gate-ffi_const.rs:4:5
+error[E0658]: the `ffi_const` attribute is an experimental feature
+  --> $DIR/feature-gate-ffi_const.rs:4:14
    |
 LL |     #[unsafe(ffi_const)]
-   |     ^^^^^^^^^^^^^^^^^^^^
+   |              ^^^^^^^^^
    |
    = note: see issue #58328 <https://github.com/rust-lang/rust/issues/58328> for more information
    = help: add `#![feature(ffi_const)]` to the crate attributes to enable

--- a/tests/ui/feature-gates/feature-gate-ffi_pure.rs
+++ b/tests/ui/feature-gates/feature-gate-ffi_pure.rs
@@ -1,6 +1,6 @@
 #![crate_type = "lib"]
 
 extern "C" {
-    #[unsafe(ffi_pure)] //~ ERROR the `#[ffi_pure]` attribute is an experimental feature
+    #[unsafe(ffi_pure)] //~ ERROR the `ffi_pure` attribute is an experimental feature
     pub fn foo();
 }

--- a/tests/ui/feature-gates/feature-gate-ffi_pure.stderr
+++ b/tests/ui/feature-gates/feature-gate-ffi_pure.stderr
@@ -1,8 +1,8 @@
-error[E0658]: the `#[ffi_pure]` attribute is an experimental feature
-  --> $DIR/feature-gate-ffi_pure.rs:4:5
+error[E0658]: the `ffi_pure` attribute is an experimental feature
+  --> $DIR/feature-gate-ffi_pure.rs:4:14
    |
 LL |     #[unsafe(ffi_pure)]
-   |     ^^^^^^^^^^^^^^^^^^^
+   |              ^^^^^^^^
    |
    = note: see issue #58329 <https://github.com/rust-lang/rust/issues/58329> for more information
    = help: add `#![feature(ffi_pure)]` to the crate attributes to enable

--- a/tests/ui/feature-gates/feature-gate-fn_align.rs
+++ b/tests/ui/feature-gates/feature-gate-fn_align.rs
@@ -5,12 +5,12 @@
 // FIXME(#82232, #143834): temporarily renamed to mitigate `#[align]` nameres ambiguity
 
 #[rustc_align(16)]
-//~^ ERROR the `#[rustc_align]` attribute is an experimental feature
+//~^ ERROR the `rustc_align` attribute is an experimental feature
 fn requires_alignment() {}
 
 trait MyTrait {
     #[rustc_align]
-    //~^ ERROR the `#[rustc_align]` attribute is an experimental feature
+    //~^ ERROR the `rustc_align` attribute is an experimental feature
     //~| ERROR malformed `rustc_align` attribute input
     fn myfun();
 }

--- a/tests/ui/feature-gates/feature-gate-fn_align.stderr
+++ b/tests/ui/feature-gates/feature-gate-fn_align.stderr
@@ -1,18 +1,18 @@
-error[E0658]: the `#[rustc_align]` attribute is an experimental feature
-  --> $DIR/feature-gate-fn_align.rs:7:1
+error[E0658]: the `rustc_align` attribute is an experimental feature
+  --> $DIR/feature-gate-fn_align.rs:7:3
    |
 LL | #[rustc_align(16)]
-   | ^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^
    |
    = note: see issue #82232 <https://github.com/rust-lang/rust/issues/82232> for more information
    = help: add `#![feature(fn_align)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: the `#[rustc_align]` attribute is an experimental feature
-  --> $DIR/feature-gate-fn_align.rs:12:5
+error[E0658]: the `rustc_align` attribute is an experimental feature
+  --> $DIR/feature-gate-fn_align.rs:12:7
    |
 LL |     #[rustc_align]
-   |     ^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^
    |
    = note: see issue #82232 <https://github.com/rust-lang/rust/issues/82232> for more information
    = help: add `#![feature(fn_align)]` to the crate attributes to enable

--- a/tests/ui/feature-gates/feature-gate-fn_align.stderr
+++ b/tests/ui/feature-gates/feature-gate-fn_align.stderr
@@ -19,10 +19,10 @@ LL |     #[rustc_align]
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0539]: malformed `rustc_align` attribute input
-  --> $DIR/feature-gate-fn_align.rs:12:5
+  --> $DIR/feature-gate-fn_align.rs:12:7
    |
 LL |     #[rustc_align]
-   |     ^^^^^^^^^^^^^^ expected this to be a list
+   |       ^^^^^^^^^^^ expected this to be a list
    |
 help: must be of the form
    |

--- a/tests/ui/feature-gates/feature-gate-fundamental.rs
+++ b/tests/ui/feature-gates/feature-gate-fundamental.rs
@@ -1,4 +1,4 @@
-#[fundamental] //~ ERROR the `#[fundamental]` attribute is an experimental feature
+#[fundamental] //~ ERROR the `fundamental` attribute is an experimental feature
 struct Fundamental;
 
 fn main() { }

--- a/tests/ui/feature-gates/feature-gate-fundamental.stderr
+++ b/tests/ui/feature-gates/feature-gate-fundamental.stderr
@@ -1,8 +1,8 @@
-error[E0658]: the `#[fundamental]` attribute is an experimental feature
-  --> $DIR/feature-gate-fundamental.rs:1:1
+error[E0658]: the `fundamental` attribute is an experimental feature
+  --> $DIR/feature-gate-fundamental.rs:1:3
    |
 LL | #[fundamental]
-   | ^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^
    |
    = note: see issue #29635 <https://github.com/rust-lang/rust/issues/29635> for more information
    = help: add `#![feature(fundamental)]` to the crate attributes to enable

--- a/tests/ui/feature-gates/feature-gate-instrument-fn.stderr
+++ b/tests/ui/feature-gates/feature-gate-instrument-fn.stderr
@@ -1,18 +1,18 @@
-error[E0658]: the `#[instrument_fn]` attribute is an experimental feature
-  --> $DIR/feature-gate-instrument-fn.rs:9:1
+error[E0658]: the `instrument_fn` attribute is an experimental feature
+  --> $DIR/feature-gate-instrument-fn.rs:9:3
    |
 LL | #[instrument_fn = "on"]
-   | ^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^
    |
    = note: see issue #157081 <https://github.com/rust-lang/rust/issues/157081> for more information
    = help: add `#![feature(instrument_fn)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: the `#[instrument_fn]` attribute is an experimental feature
-  --> $DIR/feature-gate-instrument-fn.rs:12:1
+error[E0658]: the `instrument_fn` attribute is an experimental feature
+  --> $DIR/feature-gate-instrument-fn.rs:12:3
    |
 LL | #[instrument_fn = "off"]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^
    |
    = note: see issue #157081 <https://github.com/rust-lang/rust/issues/157081> for more information
    = help: add `#![feature(instrument_fn)]` to the crate attributes to enable

--- a/tests/ui/feature-gates/feature-gate-intrinsics.rs
+++ b/tests/ui/feature-gates/feature-gate-intrinsics.rs
@@ -1,5 +1,5 @@
 #[rustc_intrinsic]
-//~^ ERROR the `#[rustc_intrinsic]` attribute is used to declare intrinsics as function items
+//~^ ERROR the `rustc_intrinsic` attribute is used to declare intrinsics as function items
 fn bar();
 
 fn main() {}

--- a/tests/ui/feature-gates/feature-gate-intrinsics.stderr
+++ b/tests/ui/feature-gates/feature-gate-intrinsics.stderr
@@ -1,8 +1,8 @@
-error[E0658]: the `#[rustc_intrinsic]` attribute is used to declare intrinsics as function items
-  --> $DIR/feature-gate-intrinsics.rs:1:1
+error[E0658]: the `rustc_intrinsic` attribute is used to declare intrinsics as function items
+  --> $DIR/feature-gate-intrinsics.rs:1:3
    |
 LL | #[rustc_intrinsic]
-   | ^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(intrinsics)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date

--- a/tests/ui/feature-gates/feature-gate-lang-items.stderr
+++ b/tests/ui/feature-gates/feature-gate-lang-items.stderr
@@ -1,8 +1,8 @@
 error[E0658]: lang items are subject to change
-  --> $DIR/feature-gate-lang-items.rs:1:1
+  --> $DIR/feature-gate-lang-items.rs:1:3
    |
 LL | #[lang = "foo"]
-   | ^^^^^^^^^^^^^^^
+   |   ^^^^
    |
    = help: add `#![feature(lang_items)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date

--- a/tests/ui/feature-gates/feature-gate-large-assignments.rs
+++ b/tests/ui/feature-gates/feature-gate-large-assignments.rs
@@ -1,5 +1,5 @@
 // check that `move_size_limit` is feature-gated
 
-#![move_size_limit = "42"] //~ ERROR the `#[move_size_limit]` attribute is an experimental feature
+#![move_size_limit = "42"] //~ ERROR the `move_size_limit` attribute is an experimental feature
 
 fn main() {}

--- a/tests/ui/feature-gates/feature-gate-large-assignments.stderr
+++ b/tests/ui/feature-gates/feature-gate-large-assignments.stderr
@@ -1,8 +1,8 @@
-error[E0658]: the `#[move_size_limit]` attribute is an experimental feature
-  --> $DIR/feature-gate-large-assignments.rs:3:1
+error[E0658]: the `move_size_limit` attribute is an experimental feature
+  --> $DIR/feature-gate-large-assignments.rs:3:4
    |
 LL | #![move_size_limit = "42"]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |    ^^^^^^^^^^^^^^^
    |
    = note: see issue #83518 <https://github.com/rust-lang/rust/issues/83518> for more information
    = help: add `#![feature(large_assignments)]` to the crate attributes to enable

--- a/tests/ui/feature-gates/feature-gate-linkage.stderr
+++ b/tests/ui/feature-gates/feature-gate-linkage.stderr
@@ -1,8 +1,8 @@
 error[E0658]: the `linkage` attribute is experimental and not portable across platforms
-  --> $DIR/feature-gate-linkage.rs:2:5
+  --> $DIR/feature-gate-linkage.rs:2:7
    |
 LL |     #[linkage = "extern_weak"] static foo: *mut isize;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^
    |
    = note: see issue #29603 <https://github.com/rust-lang/rust/issues/29603> for more information
    = help: add `#![feature(linkage)]` to the crate attributes to enable

--- a/tests/ui/feature-gates/feature-gate-loop-hints.rs
+++ b/tests/ui/feature-gates/feature-gate-loop-hints.rs
@@ -1,4 +1,4 @@
 fn main() {
-    #[unroll] //~ ERROR the `#[unroll]` attribute is an experimental feature
+    #[unroll] //~ ERROR the `unroll` attribute is an experimental feature
     for _ in 0..10 {}
 }

--- a/tests/ui/feature-gates/feature-gate-loop-hints.stderr
+++ b/tests/ui/feature-gates/feature-gate-loop-hints.stderr
@@ -1,8 +1,8 @@
-error[E0658]: the `#[unroll]` attribute is an experimental feature
-  --> $DIR/feature-gate-loop-hints.rs:2:5
+error[E0658]: the `unroll` attribute is an experimental feature
+  --> $DIR/feature-gate-loop-hints.rs:2:7
    |
 LL |     #[unroll]
-   |     ^^^^^^^^^
+   |       ^^^^^^
    |
    = note: see issue #156874 <https://github.com/rust-lang/rust/issues/156874> for more information
    = help: add `#![feature(loop_hints)]` to the crate attributes to enable

--- a/tests/ui/feature-gates/feature-gate-loop-match.rs
+++ b/tests/ui/feature-gates/feature-gate-loop-match.rs
@@ -9,18 +9,18 @@ enum State {
 
 fn main() {
     let mut state = State::A;
-    #[loop_match] //~ ERROR the `#[loop_match]` attribute is an experimental feature
+    #[loop_match] //~ ERROR the `loop_match` attribute is an experimental feature
     'a: loop {
         state = 'blk: {
             match state {
                 State::A => {
                     #[const_continue]
-                    //~^ ERROR the `#[const_continue]` attribute is an experimental feature
+                    //~^ ERROR the `const_continue` attribute is an experimental feature
                     break 'blk State::B;
                 }
                 State::B => {
                     #[const_continue]
-                    //~^ ERROR the `#[const_continue]` attribute is an experimental feature
+                    //~^ ERROR the `const_continue` attribute is an experimental feature
                     break 'blk State::C;
                 }
                 State::C => break 'a,

--- a/tests/ui/feature-gates/feature-gate-loop-match.stderr
+++ b/tests/ui/feature-gates/feature-gate-loop-match.stderr
@@ -1,28 +1,28 @@
-error[E0658]: the `#[loop_match]` attribute is an experimental feature
-  --> $DIR/feature-gate-loop-match.rs:12:5
+error[E0658]: the `loop_match` attribute is an experimental feature
+  --> $DIR/feature-gate-loop-match.rs:12:7
    |
 LL |     #[loop_match]
-   |     ^^^^^^^^^^^^^
+   |       ^^^^^^^^^^
    |
    = note: see issue #132306 <https://github.com/rust-lang/rust/issues/132306> for more information
    = help: add `#![feature(loop_match)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: the `#[const_continue]` attribute is an experimental feature
-  --> $DIR/feature-gate-loop-match.rs:17:21
+error[E0658]: the `const_continue` attribute is an experimental feature
+  --> $DIR/feature-gate-loop-match.rs:17:23
    |
 LL |                     #[const_continue]
-   |                     ^^^^^^^^^^^^^^^^^
+   |                       ^^^^^^^^^^^^^^
    |
    = note: see issue #132306 <https://github.com/rust-lang/rust/issues/132306> for more information
    = help: add `#![feature(loop_match)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: the `#[const_continue]` attribute is an experimental feature
-  --> $DIR/feature-gate-loop-match.rs:22:21
+error[E0658]: the `const_continue` attribute is an experimental feature
+  --> $DIR/feature-gate-loop-match.rs:22:23
    |
 LL |                     #[const_continue]
-   |                     ^^^^^^^^^^^^^^^^^
+   |                       ^^^^^^^^^^^^^^
    |
    = note: see issue #132306 <https://github.com/rust-lang/rust/issues/132306> for more information
    = help: add `#![feature(loop_match)]` to the crate attributes to enable

--- a/tests/ui/feature-gates/feature-gate-marker_trait_attr.rs
+++ b/tests/ui/feature-gates/feature-gate-marker_trait_attr.rs
@@ -1,7 +1,7 @@
 use std::fmt::{Debug, Display};
 
 #[marker] trait ExplicitMarker {}
-//~^ ERROR the `#[marker]` attribute is an experimental feature
+//~^ ERROR the `marker` attribute is an experimental feature
 
 impl<T: Display> ExplicitMarker for T {}
 impl<T: Debug> ExplicitMarker for T {}

--- a/tests/ui/feature-gates/feature-gate-marker_trait_attr.stderr
+++ b/tests/ui/feature-gates/feature-gate-marker_trait_attr.stderr
@@ -1,8 +1,8 @@
-error[E0658]: the `#[marker]` attribute is an experimental feature
-  --> $DIR/feature-gate-marker_trait_attr.rs:3:1
+error[E0658]: the `marker` attribute is an experimental feature
+  --> $DIR/feature-gate-marker_trait_attr.rs:3:3
    |
 LL | #[marker] trait ExplicitMarker {}
-   | ^^^^^^^^^
+   |   ^^^^^^
    |
    = note: see issue #29864 <https://github.com/rust-lang/rust/issues/29864> for more information
    = help: add `#![feature(marker_trait_attr)]` to the crate attributes to enable

--- a/tests/ui/feature-gates/feature-gate-may-dangle.rs
+++ b/tests/ui/feature-gates/feature-gate-may-dangle.rs
@@ -4,7 +4,7 @@
 
 struct Pt<A>(A);
 unsafe impl<#[may_dangle] A> Drop for Pt<A> {
-    //~^ ERROR `may_dangle` has unstable semantics and may be removed in the future
+    //~^ ERROR the `may_dangle` attribute has unstable semantics and may be removed in the future
     fn drop(&mut self) { }
 }
 

--- a/tests/ui/feature-gates/feature-gate-may-dangle.stderr
+++ b/tests/ui/feature-gates/feature-gate-may-dangle.stderr
@@ -1,8 +1,8 @@
-error[E0658]: `may_dangle` has unstable semantics and may be removed in the future
-  --> $DIR/feature-gate-may-dangle.rs:6:13
+error[E0658]: the `may_dangle` attribute has unstable semantics and may be removed in the future
+  --> $DIR/feature-gate-may-dangle.rs:6:15
    |
 LL | unsafe impl<#[may_dangle] A> Drop for Pt<A> {
-   |             ^^^^^^^^^^^^^
+   |               ^^^^^^^^^^
    |
    = note: see issue #34761 <https://github.com/rust-lang/rust/issues/34761> for more information
    = help: add `#![feature(dropck_eyepatch)]` to the crate attributes to enable

--- a/tests/ui/feature-gates/feature-gate-needs-allocator.rs
+++ b/tests/ui/feature-gates/feature-gate-needs-allocator.rs
@@ -1,3 +1,3 @@
-#![needs_allocator] //~ ERROR the `#[needs_allocator]` attribute is
+#![needs_allocator] //~ ERROR the `needs_allocator` attribute is
 
 fn main() {}

--- a/tests/ui/feature-gates/feature-gate-needs-allocator.stderr
+++ b/tests/ui/feature-gates/feature-gate-needs-allocator.stderr
@@ -1,8 +1,8 @@
-error[E0658]: the `#[needs_allocator]` attribute is an experimental feature
-  --> $DIR/feature-gate-needs-allocator.rs:1:1
+error[E0658]: the `needs_allocator` attribute is an experimental feature
+  --> $DIR/feature-gate-needs-allocator.rs:1:4
    |
 LL | #![needs_allocator]
-   | ^^^^^^^^^^^^^^^^^^^
+   |    ^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(allocator_internals)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date

--- a/tests/ui/feature-gates/feature-gate-no_core.rs
+++ b/tests/ui/feature-gates/feature-gate-no_core.rs
@@ -1,5 +1,5 @@
 #![crate_type = "rlib"]
 
-#![no_core] //~ ERROR the `#[no_core]` attribute is an experimental feature
+#![no_core] //~ ERROR the `no_core` attribute is an experimental feature
 
 pub struct S {}

--- a/tests/ui/feature-gates/feature-gate-no_core.stderr
+++ b/tests/ui/feature-gates/feature-gate-no_core.stderr
@@ -1,8 +1,8 @@
-error[E0658]: the `#[no_core]` attribute is an experimental feature
-  --> $DIR/feature-gate-no_core.rs:3:1
+error[E0658]: the `no_core` attribute is an experimental feature
+  --> $DIR/feature-gate-no_core.rs:3:4
    |
 LL | #![no_core]
-   | ^^^^^^^^^^^
+   |    ^^^^^^^
    |
    = note: see issue #29639 <https://github.com/rust-lang/rust/issues/29639> for more information
    = help: add `#![feature(no_core)]` to the crate attributes to enable

--- a/tests/ui/feature-gates/feature-gate-optimize_attribute.rs
+++ b/tests/ui/feature-gates/feature-gate-optimize_attribute.rs
@@ -1,15 +1,15 @@
 #![crate_type="rlib"]
 
-#[optimize(size)] //~ ERROR the `#[optimize]` attribute is an experimental feature
+#[optimize(size)] //~ ERROR the `optimize` attribute is an experimental feature
 fn size() {}
 
-#[optimize(speed)] //~ ERROR the `#[optimize]` attribute is an experimental feature
+#[optimize(speed)] //~ ERROR the `optimize` attribute is an experimental feature
 fn speed() {}
 
-#[optimize(none)] //~ ERROR the `#[optimize]` attribute is an experimental feature
+#[optimize(none)] //~ ERROR the `optimize` attribute is an experimental feature
 fn none() {}
 
 #[optimize(banana)]
-//~^ ERROR the `#[optimize]` attribute is an experimental feature
+//~^ ERROR the `optimize` attribute is an experimental feature
 //~| ERROR malformed `optimize` attribute input [E0539]
 fn not_known() {}

--- a/tests/ui/feature-gates/feature-gate-optimize_attribute.stderr
+++ b/tests/ui/feature-gates/feature-gate-optimize_attribute.stderr
@@ -1,38 +1,38 @@
-error[E0658]: the `#[optimize]` attribute is an experimental feature
-  --> $DIR/feature-gate-optimize_attribute.rs:3:1
+error[E0658]: the `optimize` attribute is an experimental feature
+  --> $DIR/feature-gate-optimize_attribute.rs:3:3
    |
 LL | #[optimize(size)]
-   | ^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^
    |
    = note: see issue #54882 <https://github.com/rust-lang/rust/issues/54882> for more information
    = help: add `#![feature(optimize_attribute)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: the `#[optimize]` attribute is an experimental feature
-  --> $DIR/feature-gate-optimize_attribute.rs:6:1
+error[E0658]: the `optimize` attribute is an experimental feature
+  --> $DIR/feature-gate-optimize_attribute.rs:6:3
    |
 LL | #[optimize(speed)]
-   | ^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^
    |
    = note: see issue #54882 <https://github.com/rust-lang/rust/issues/54882> for more information
    = help: add `#![feature(optimize_attribute)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: the `#[optimize]` attribute is an experimental feature
-  --> $DIR/feature-gate-optimize_attribute.rs:9:1
+error[E0658]: the `optimize` attribute is an experimental feature
+  --> $DIR/feature-gate-optimize_attribute.rs:9:3
    |
 LL | #[optimize(none)]
-   | ^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^
    |
    = note: see issue #54882 <https://github.com/rust-lang/rust/issues/54882> for more information
    = help: add `#![feature(optimize_attribute)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: the `#[optimize]` attribute is an experimental feature
-  --> $DIR/feature-gate-optimize_attribute.rs:12:1
+error[E0658]: the `optimize` attribute is an experimental feature
+  --> $DIR/feature-gate-optimize_attribute.rs:12:3
    |
 LL | #[optimize(banana)]
-   | ^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^
    |
    = note: see issue #54882 <https://github.com/rust-lang/rust/issues/54882> for more information
    = help: add `#![feature(optimize_attribute)]` to the crate attributes to enable

--- a/tests/ui/feature-gates/feature-gate-optimize_attribute.stderr
+++ b/tests/ui/feature-gates/feature-gate-optimize_attribute.stderr
@@ -39,10 +39,10 @@ LL | #[optimize(banana)]
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0539]: malformed `optimize` attribute input
-  --> $DIR/feature-gate-optimize_attribute.rs:12:1
+  --> $DIR/feature-gate-optimize_attribute.rs:12:3
    |
 LL | #[optimize(banana)]
-   | ^^^^^^^^^^^------^^
+   |   ^^^^^^^^^------^
    |            |
    |            valid arguments are `size`, `speed` or `none`
    |

--- a/tests/ui/feature-gates/feature-gate-patchable-function-entry.rs
+++ b/tests/ui/feature-gates/feature-gate-patchable-function-entry.rs
@@ -1,3 +1,3 @@
 #[patchable_function_entry(prefix_nops = 1, entry_nops = 1)]
-//~^ ERROR: the `#[patchable_function_entry]` attribute is an experimental feature
+//~^ ERROR: the `patchable_function_entry` attribute is an experimental feature
 fn main() {}

--- a/tests/ui/feature-gates/feature-gate-patchable-function-entry.stderr
+++ b/tests/ui/feature-gates/feature-gate-patchable-function-entry.stderr
@@ -1,8 +1,8 @@
-error[E0658]: the `#[patchable_function_entry]` attribute is an experimental feature
-  --> $DIR/feature-gate-patchable-function-entry.rs:1:1
+error[E0658]: the `patchable_function_entry` attribute is an experimental feature
+  --> $DIR/feature-gate-patchable-function-entry.rs:1:3
    |
 LL | #[patchable_function_entry(prefix_nops = 1, entry_nops = 1)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #123115 <https://github.com/rust-lang/rust/issues/123115> for more information
    = help: add `#![feature(patchable_function_entry)]` to the crate attributes to enable

--- a/tests/ui/feature-gates/feature-gate-pattern-complexity-limit.rs
+++ b/tests/ui/feature-gates/feature-gate-pattern-complexity-limit.rs
@@ -2,7 +2,7 @@
 
 #![pattern_complexity_limit = "42"]
 //~^ ERROR: use of an internal attribute [E0658]
-//~| NOTE the `#[pattern_complexity_limit]` attribute is an internal implementation detail that will never be stable
-//~| NOTE: the `#[pattern_complexity_limit]` attribute is used for rustc unit tests
+//~| NOTE the `pattern_complexity_limit` attribute is an internal implementation detail that will never be stable
+//~| NOTE: the `pattern_complexity_limit` attribute is used for rustc unit tests
 
 fn main() {}

--- a/tests/ui/feature-gates/feature-gate-pattern-complexity-limit.stderr
+++ b/tests/ui/feature-gates/feature-gate-pattern-complexity-limit.stderr
@@ -1,12 +1,12 @@
 error[E0658]: use of an internal attribute
-  --> $DIR/feature-gate-pattern-complexity-limit.rs:3:1
+  --> $DIR/feature-gate-pattern-complexity-limit.rs:3:4
    |
 LL | #![pattern_complexity_limit = "42"]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable
-   = note: the `#[pattern_complexity_limit]` attribute is an internal implementation detail that will never be stable
-   = note: the `#[pattern_complexity_limit]` attribute is used for rustc unit tests
+   = note: the `pattern_complexity_limit` attribute is an internal implementation detail that will never be stable
+   = note: the `pattern_complexity_limit` attribute is used for rustc unit tests
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-pin_ergonomics.rs
+++ b/tests/ui/feature-gates/feature-gate-pin_ergonomics.rs
@@ -2,7 +2,7 @@
 
 use std::pin::Pin;
 
-#[pin_v2] //~ ERROR the `#[pin_v2]` attribute is an experimental feature
+#[pin_v2] //~ ERROR the `pin_v2` attribute is an experimental feature
 struct Foo;
 
 impl Foo {

--- a/tests/ui/feature-gates/feature-gate-pin_ergonomics.stderr
+++ b/tests/ui/feature-gates/feature-gate-pin_ergonomics.stderr
@@ -298,11 +298,11 @@ LL |         ref pin const w: i32,
    = help: add `#![feature(pin_ergonomics)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: the `#[pin_v2]` attribute is an experimental feature
-  --> $DIR/feature-gate-pin_ergonomics.rs:5:1
+error[E0658]: the `pin_v2` attribute is an experimental feature
+  --> $DIR/feature-gate-pin_ergonomics.rs:5:3
    |
 LL | #[pin_v2]
-   | ^^^^^^^^^
+   |   ^^^^^^
    |
    = note: see issue #130494 <https://github.com/rust-lang/rust/issues/130494> for more information
    = help: add `#![feature(pin_ergonomics)]` to the crate attributes to enable

--- a/tests/ui/feature-gates/feature-gate-prelude_import.rs
+++ b/tests/ui/feature-gates/feature-gate-prelude_import.rs
@@ -1,4 +1,4 @@
-#[prelude_import] //~ ERROR `#[prelude_import]` is for use by rustc only
+#[prelude_import] //~ ERROR the `prelude_import` attribute is for use by rustc only
 use std::prelude::v1::*;
 
 fn main() {}

--- a/tests/ui/feature-gates/feature-gate-prelude_import.stderr
+++ b/tests/ui/feature-gates/feature-gate-prelude_import.stderr
@@ -1,8 +1,8 @@
-error[E0658]: `#[prelude_import]` is for use by rustc only
-  --> $DIR/feature-gate-prelude_import.rs:1:1
+error[E0658]: the `prelude_import` attribute is for use by rustc only
+  --> $DIR/feature-gate-prelude_import.rs:1:3
    |
 LL | #[prelude_import]
-   | ^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^
    |
    = help: add `#![feature(prelude_import)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date

--- a/tests/ui/feature-gates/feature-gate-profiler-runtime.rs
+++ b/tests/ui/feature-gates/feature-gate-profiler-runtime.rs
@@ -1,3 +1,3 @@
-#![profiler_runtime] //~ ERROR the `#[profiler_runtime]` attribute is
+#![profiler_runtime] //~ ERROR the `profiler_runtime` attribute is
 
 fn main() {}

--- a/tests/ui/feature-gates/feature-gate-profiler-runtime.stderr
+++ b/tests/ui/feature-gates/feature-gate-profiler-runtime.stderr
@@ -1,8 +1,8 @@
-error[E0658]: the `#[profiler_runtime]` attribute is used to identify the `profiler_builtins` crate which contains the profiler runtime and will never be stable
-  --> $DIR/feature-gate-profiler-runtime.rs:1:1
+error[E0658]: the `profiler_runtime` attribute is used to identify the `profiler_builtins` crate which contains the profiler runtime and will never be stable
+  --> $DIR/feature-gate-profiler-runtime.rs:1:4
    |
 LL | #![profiler_runtime]
-   | ^^^^^^^^^^^^^^^^^^^^
+   |    ^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(profiler_runtime)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date

--- a/tests/ui/feature-gates/feature-gate-register_tool.rs
+++ b/tests/ui/feature-gates/feature-gate-register_tool.rs
@@ -1,3 +1,3 @@
-#![register_tool(tool)] //~ ERROR the `#[register_tool]` attribute is an experimental feature
+#![register_tool(tool)] //~ ERROR the `register_tool` attribute is an experimental feature
 
 fn main() {}

--- a/tests/ui/feature-gates/feature-gate-register_tool.stderr
+++ b/tests/ui/feature-gates/feature-gate-register_tool.stderr
@@ -1,8 +1,8 @@
-error[E0658]: the `#[register_tool]` attribute is an experimental feature
-  --> $DIR/feature-gate-register_tool.rs:1:1
+error[E0658]: the `register_tool` attribute is an experimental feature
+  --> $DIR/feature-gate-register_tool.rs:1:4
    |
 LL | #![register_tool(tool)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^
+   |    ^^^^^^^^^^^^^
    |
    = note: see issue #66079 <https://github.com/rust-lang/rust/issues/66079> for more information
    = help: add `#![feature(register_tool)]` to the crate attributes to enable

--- a/tests/ui/feature-gates/feature-gate-repr-simd.stderr
+++ b/tests/ui/feature-gates/feature-gate-repr-simd.stderr
@@ -28,13 +28,13 @@ LL | #[repr(simd)]
    = help: add `#![feature(repr_simd)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error: `#[repr(simd)]` attribute cannot be used on unions
-  --> $DIR/feature-gate-repr-simd.rs:9:1
+error: the `repr(simd)` attribute cannot be used on unions
+  --> $DIR/feature-gate-repr-simd.rs:9:3
    |
 LL | #[repr(simd)]
-   | ^^^^^^^^^^^^^
+   |   ^^^^^^^^^^
    |
-   = help: `#[repr(simd)]` can only be applied to structs
+   = help: the `repr(simd)` attribute can only be applied to structs
 
 error[E0658]: SIMD types are experimental and possibly buggy
   --> $DIR/feature-gate-repr-simd.rs:13:8
@@ -46,13 +46,13 @@ LL | #[repr(simd)]
    = help: add `#![feature(repr_simd)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error: `#[repr(simd)]` attribute cannot be used on enums
-  --> $DIR/feature-gate-repr-simd.rs:13:1
+error: the `repr(simd)` attribute cannot be used on enums
+  --> $DIR/feature-gate-repr-simd.rs:13:3
    |
 LL | #[repr(simd)]
-   | ^^^^^^^^^^^^^
+   |   ^^^^^^^^^^
    |
-   = help: `#[repr(simd)]` can only be applied to structs
+   = help: the `repr(simd)` attribute can only be applied to structs
 
 error[E0566]: conflicting representation hints
   --> $DIR/feature-gate-repr-simd.rs:4:8

--- a/tests/ui/feature-gates/feature-gate-rustc-allow-const-fn-unstable.stderr
+++ b/tests/ui/feature-gates/feature-gate-rustc-allow-const-fn-unstable.stderr
@@ -1,11 +1,11 @@
 error[E0658]: use of an internal attribute
-  --> $DIR/feature-gate-rustc-allow-const-fn-unstable.rs:3:1
+  --> $DIR/feature-gate-rustc-allow-const-fn-unstable.rs:3:3
    |
 LL | #[rustc_allow_const_fn_unstable()]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable
-   = note: the `#[rustc_allow_const_fn_unstable]` attribute is an internal implementation detail that will never be stable
+   = note: the `rustc_allow_const_fn_unstable` attribute is an internal implementation detail that will never be stable
    = note: rustc_allow_const_fn_unstable side-steps feature gating and stability checks
 
 error: aborting due to 1 previous error

--- a/tests/ui/feature-gates/feature-gate-rustc-attrs-1.rs
+++ b/tests/ui/feature-gates/feature-gate-rustc-attrs-1.rs
@@ -2,15 +2,15 @@
 
 #[rustc_nonnull_optimization_guaranteed]
 //~^ ERROR use of an internal attribute [E0658]
-//~| NOTE the `#[rustc_nonnull_optimization_guaranteed]` attribute is an internal implementation detail that will never be stable
-//~| NOTE  the `#[rustc_nonnull_optimization_guaranteed]` attribute is just used to document guaranteed niche optimizations in the standard library
+//~| NOTE the `rustc_nonnull_optimization_guaranteed` attribute is an internal implementation detail that will never be stable
+//~| NOTE  the `rustc_nonnull_optimization_guaranteed` attribute is just used to document guaranteed niche optimizations in the standard library
 //~| NOTE the compiler does not even check whether the type indeed is being non-null-optimized; it is your responsibility to ensure that the attribute is only used on types that are optimized
 struct Foo {}
 
 #[rustc_dump_variances]
 //~^ ERROR use of an internal attribute [E0658]
-//~| NOTE the `#[rustc_dump_variances]` attribute is an internal implementation detail that will never be stable
-//~| NOTE the `#[rustc_dump_variances]` attribute is used for rustc unit tests
+//~| NOTE the `rustc_dump_variances` attribute is an internal implementation detail that will never be stable
+//~| NOTE the `rustc_dump_variances` attribute is used for rustc unit tests
 enum E {}
 
 fn main() {}

--- a/tests/ui/feature-gates/feature-gate-rustc-attrs-1.stderr
+++ b/tests/ui/feature-gates/feature-gate-rustc-attrs-1.stderr
@@ -1,23 +1,23 @@
 error[E0658]: use of an internal attribute
-  --> $DIR/feature-gate-rustc-attrs-1.rs:3:1
+  --> $DIR/feature-gate-rustc-attrs-1.rs:3:3
    |
 LL | #[rustc_nonnull_optimization_guaranteed]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable
-   = note: the `#[rustc_nonnull_optimization_guaranteed]` attribute is an internal implementation detail that will never be stable
-   = note: the `#[rustc_nonnull_optimization_guaranteed]` attribute is just used to document guaranteed niche optimizations in the standard library
+   = note: the `rustc_nonnull_optimization_guaranteed` attribute is an internal implementation detail that will never be stable
+   = note: the `rustc_nonnull_optimization_guaranteed` attribute is just used to document guaranteed niche optimizations in the standard library
    = note: the compiler does not even check whether the type indeed is being non-null-optimized; it is your responsibility to ensure that the attribute is only used on types that are optimized
 
 error[E0658]: use of an internal attribute
-  --> $DIR/feature-gate-rustc-attrs-1.rs:10:1
+  --> $DIR/feature-gate-rustc-attrs-1.rs:10:3
    |
 LL | #[rustc_dump_variances]
-   | ^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable
-   = note: the `#[rustc_dump_variances]` attribute is an internal implementation detail that will never be stable
-   = note: the `#[rustc_dump_variances]` attribute is used for rustc unit tests
+   = note: the `rustc_dump_variances` attribute is an internal implementation detail that will never be stable
+   = note: the `rustc_dump_variances` attribute is used for rustc unit tests
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/feature-gates/feature-gate-rustc-attrs.rs
+++ b/tests/ui/feature-gates/feature-gate-rustc-attrs.rs
@@ -19,8 +19,8 @@ fn g() {}
 
 #[rustc_dummy]
 //~^ ERROR use of an internal attribute [E0658]
-//~| NOTE the `#[rustc_dummy]` attribute is an internal implementation detail that will never be stable
-//~| NOTE the `#[rustc_dummy]` attribute is used for rustc unit tests
+//~| NOTE the `rustc_dummy` attribute is an internal implementation detail that will never be stable
+//~| NOTE the `rustc_dummy` attribute is used for rustc unit tests
 #[rustc_unknown]
 //~^ ERROR attributes starting with `rustc` are reserved for use by the `rustc` compiler
 //~| ERROR cannot find attribute `rustc_unknown` in this scope

--- a/tests/ui/feature-gates/feature-gate-rustc-attrs.stderr
+++ b/tests/ui/feature-gates/feature-gate-rustc-attrs.stderr
@@ -35,14 +35,14 @@ LL | #[rustc_unknown]
    |   ^^^^^^^^^^^^^
 
 error[E0658]: use of an internal attribute
-  --> $DIR/feature-gate-rustc-attrs.rs:20:1
+  --> $DIR/feature-gate-rustc-attrs.rs:20:3
    |
 LL | #[rustc_dummy]
-   | ^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^
    |
    = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable
-   = note: the `#[rustc_dummy]` attribute is an internal implementation detail that will never be stable
-   = note: the `#[rustc_dummy]` attribute is used for rustc unit tests
+   = note: the `rustc_dummy` attribute is an internal implementation detail that will never be stable
+   = note: the `rustc_dummy` attribute is used for rustc unit tests
 
 error: aborting due to 7 previous errors
 

--- a/tests/ui/feature-gates/feature-gate-rustc_const_unstable.stderr
+++ b/tests/ui/feature-gates/feature-gate-rustc_const_unstable.stderr
@@ -1,8 +1,8 @@
 error[E0658]: stability attributes may not be used outside of the standard library
-  --> $DIR/feature-gate-rustc_const_unstable.rs:3:1
+  --> $DIR/feature-gate-rustc_const_unstable.rs:3:3
    |
 LL | #[rustc_const_unstable(feature="fzzzzzt")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^
 
 error[E0547]: missing 'issue'
   --> $DIR/feature-gate-rustc_const_unstable.rs:3:1

--- a/tests/ui/feature-gates/feature-gate-sanitize.rs
+++ b/tests/ui/feature-gates/feature-gate-sanitize.rs
@@ -1,6 +1,6 @@
 #![feature(no_sanitize)] //~ ERROR feature has been removed
 
 #[sanitize(address = "on")]
-//~^ ERROR the `#[sanitize]` attribute is an experimental feature
+//~^ ERROR the `sanitize` attribute is an experimental feature
 fn main() {
 }

--- a/tests/ui/feature-gates/feature-gate-sanitize.stderr
+++ b/tests/ui/feature-gates/feature-gate-sanitize.stderr
@@ -7,11 +7,11 @@ LL | #![feature(no_sanitize)]
    = note: removed in 1.91.0; see <https://github.com/rust-lang/rust/pull/142681> for more information
    = note: renamed to sanitize(xyz = "on|off")
 
-error[E0658]: the `#[sanitize]` attribute is an experimental feature
-  --> $DIR/feature-gate-sanitize.rs:3:1
+error[E0658]: the `sanitize` attribute is an experimental feature
+  --> $DIR/feature-gate-sanitize.rs:3:3
    |
 LL | #[sanitize(address = "on")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^
    |
    = note: see issue #39699 <https://github.com/rust-lang/rust/issues/39699> for more information
    = help: add `#![feature(sanitize)]` to the crate attributes to enable

--- a/tests/ui/feature-gates/feature-gate-splat.rs
+++ b/tests/ui/feature-gates/feature-gate-splat.rs
@@ -1,6 +1,6 @@
 #[rustfmt::skip]
 fn tuple_args(
-    #[splat] //~ ERROR the `#[splat]` attribute is an experimental feature
+    #[splat] //~ ERROR the `splat` attribute is an experimental feature
     (a, b, c): (u32, i8, char),
 ) {
 }

--- a/tests/ui/feature-gates/feature-gate-splat.stderr
+++ b/tests/ui/feature-gates/feature-gate-splat.stderr
@@ -1,13 +1,13 @@
-error[E0658]: the `#[splat]` attribute is an experimental feature
-  --> $DIR/feature-gate-splat.rs:3:5
+error[E0658]: the `splat` attribute is an experimental feature
+  --> $DIR/feature-gate-splat.rs:3:7
    |
 LL |     #[splat]
-   |     ^^^^^^^^
+   |       ^^^^^
    |
    = note: see issue #153629 <https://github.com/rust-lang/rust/issues/153629> for more information
    = help: add `#![feature(splat)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-   = note: the `#[splat]` attribute is experimental
+   = note: the `splat` attribute is experimental
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-staged_api.stderr
+++ b/tests/ui/feature-gates/feature-gate-staged_api.stderr
@@ -1,14 +1,14 @@
 error[E0658]: stability attributes may not be used outside of the standard library
-  --> $DIR/feature-gate-staged_api.rs:1:1
+  --> $DIR/feature-gate-staged_api.rs:1:4
    |
 LL | #![stable(feature = "a", since = "3.3.3")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |    ^^^^^^
 
 error[E0658]: stability attributes may not be used outside of the standard library
-  --> $DIR/feature-gate-staged_api.rs:8:1
+  --> $DIR/feature-gate-staged_api.rs:8:3
    |
 LL | #[stable(feature = "a", since = "3.3.3")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/feature-gates/feature-gate-static_align-thread_local.rs
+++ b/tests/ui/feature-gates/feature-gate-static_align-thread_local.rs
@@ -5,7 +5,7 @@
 #![crate_type = "lib"]
 
 thread_local! {
-    //~^ ERROR the `#[rustc_align_static]` attribute is an experimental feature
+    //~^ ERROR the `rustc_align_static` attribute is an experimental feature
     #[rustc_align_static(16)]
     static THREAD_LOCAL: u16 = 0;
 }

--- a/tests/ui/feature-gates/feature-gate-static_align.rs
+++ b/tests/ui/feature-gates/feature-gate-static_align.rs
@@ -1,11 +1,11 @@
 #![crate_type = "lib"]
 
 #[rustc_align_static(16)]
-//~^ ERROR the `#[rustc_align_static]` attribute is an experimental feature
+//~^ ERROR the `rustc_align_static` attribute is an experimental feature
 static REQUIRES_ALIGNMENT: u64 = 0;
 
 extern "C" {
     #[rustc_align_static(16)]
-    //~^ ERROR the `#[rustc_align_static]` attribute is an experimental feature
+    //~^ ERROR the `rustc_align_static` attribute is an experimental feature
     static FOREIGN_STATIC: u32;
 }

--- a/tests/ui/feature-gates/feature-gate-static_align.stderr
+++ b/tests/ui/feature-gates/feature-gate-static_align.stderr
@@ -1,18 +1,18 @@
-error[E0658]: the `#[rustc_align_static]` attribute is an experimental feature
-  --> $DIR/feature-gate-static_align.rs:3:1
+error[E0658]: the `rustc_align_static` attribute is an experimental feature
+  --> $DIR/feature-gate-static_align.rs:3:3
    |
 LL | #[rustc_align_static(16)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #146177 <https://github.com/rust-lang/rust/issues/146177> for more information
    = help: add `#![feature(static_align)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: the `#[rustc_align_static]` attribute is an experimental feature
-  --> $DIR/feature-gate-static_align.rs:8:5
+error[E0658]: the `rustc_align_static` attribute is an experimental feature
+  --> $DIR/feature-gate-static_align.rs:8:7
    |
 LL |     #[rustc_align_static(16)]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #146177 <https://github.com/rust-lang/rust/issues/146177> for more information
    = help: add `#![feature(static_align)]` to the crate attributes to enable

--- a/tests/ui/feature-gates/feature-gate-thread_local.rs
+++ b/tests/ui/feature-gates/feature-gate-thread_local.rs
@@ -5,7 +5,7 @@
 // is given permission to expand into this unstable attribute even
 // when the surrounding context does not have permission to use it.)
 
-#[thread_local] //~ ERROR `#[thread_local]` is an experimental feature
+#[thread_local] //~ ERROR the `thread_local` attribute is an experimental feature
 static FOO: i32 = 3;
 
 pub fn main() {}

--- a/tests/ui/feature-gates/feature-gate-thread_local.stderr
+++ b/tests/ui/feature-gates/feature-gate-thread_local.stderr
@@ -1,8 +1,8 @@
-error[E0658]: `#[thread_local]` is an experimental feature, and does not currently handle destructors
-  --> $DIR/feature-gate-thread_local.rs:8:1
+error[E0658]: the `thread_local` attribute is an experimental feature, and does not currently handle destructors
+  --> $DIR/feature-gate-thread_local.rs:8:3
    |
 LL | #[thread_local]
-   | ^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^
    |
    = note: see issue #29594 <https://github.com/rust-lang/rust/issues/29594> for more information
    = help: add `#![feature(thread_local)]` to the crate attributes to enable

--- a/tests/ui/feature-gates/feature-gated-feature-in-macro-arg.rs
+++ b/tests/ui/feature-gates/feature-gated-feature-in-macro-arg.rs
@@ -5,7 +5,7 @@
 fn main() {
     let a = &[1, 2, 3];
     println!("{}", {
-        #[rustc_intrinsic] //~ ERROR the `#[rustc_intrinsic]` attribute is used to declare intrinsics as function items
+        #[rustc_intrinsic] //~ ERROR the `rustc_intrinsic` attribute is used to declare intrinsics as function items
         unsafe fn atomic_fence();
 
         atomic_fence(); //~ ERROR: is unsafe

--- a/tests/ui/feature-gates/feature-gated-feature-in-macro-arg.stderr
+++ b/tests/ui/feature-gates/feature-gated-feature-in-macro-arg.stderr
@@ -1,8 +1,8 @@
-error[E0658]: the `#[rustc_intrinsic]` attribute is used to declare intrinsics as function items
-  --> $DIR/feature-gated-feature-in-macro-arg.rs:8:9
+error[E0658]: the `rustc_intrinsic` attribute is used to declare intrinsics as function items
+  --> $DIR/feature-gated-feature-in-macro-arg.rs:8:11
    |
 LL |         #[rustc_intrinsic]
-   |         ^^^^^^^^^^^^^^^^^^
+   |           ^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(intrinsics)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date

--- a/tests/ui/feature-gates/gated-bad-feature.stderr
+++ b/tests/ui/feature-gates/gated-bad-feature.stderr
@@ -7,10 +7,10 @@ LL | #![feature(test_removed_feature)]
    = note: removed in 1.0.0
 
 error[E0565]: malformed `feature` attribute input
-  --> $DIR/gated-bad-feature.rs:1:1
+  --> $DIR/gated-bad-feature.rs:1:4
    |
 LL | #![feature(foo_bar_baz, foo(bar), foo = "baz", foo)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^-----^^^^^^^^^^^^^^^^^^^^
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^-----^^^^^^^^^^^^^^^^^^^
    |                            |
    |                            didn't expect any arguments here
    |
@@ -21,10 +21,10 @@ LL + #![feature(feature1, feature2, ...)]
    |
 
 error[E0565]: malformed `feature` attribute input
-  --> $DIR/gated-bad-feature.rs:1:1
+  --> $DIR/gated-bad-feature.rs:1:4
    |
 LL | #![feature(foo_bar_baz, foo(bar), foo = "baz", foo)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-------^^^^^^^
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-------^^^^^^
    |                                       |
    |                                       didn't expect any arguments here
    |
@@ -35,10 +35,10 @@ LL + #![feature(feature1, feature2, ...)]
    |
 
 error[E0539]: malformed `feature` attribute input
-  --> $DIR/gated-bad-feature.rs:6:1
+  --> $DIR/gated-bad-feature.rs:6:4
    |
 LL | #![feature]
-   | ^^^^^^^^^^^ expected this to be a list
+   |    ^^^^^^^ expected this to be a list
    |
 help: must be of the form
    |
@@ -46,10 +46,10 @@ LL | #![feature(feature1, feature2, ...)]
    |           +++++++++++++++++++++++++
 
 error[E0539]: malformed `feature` attribute input
-  --> $DIR/gated-bad-feature.rs:7:1
+  --> $DIR/gated-bad-feature.rs:7:4
    |
 LL | #![feature = "foo"]
-   | ^^^^^^^^^^^-------^
+   |    ^^^^^^^^-------
    |            |
    |            expected this to be a list
    |

--- a/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs-error.rs
+++ b/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs-error.rs
@@ -7,9 +7,9 @@
 
 
 #![macro_export]
-//~^ ERROR:  `#[macro_export]` attribute cannot be used on crates
+//~^ ERROR: the `macro_export` attribute cannot be used on crates
 #![rustc_main]
-//~^ ERROR: `#[rustc_main]` attribute cannot be used on crates
+//~^ ERROR: the `rustc_main` attribute cannot be used on crates
 //~| ERROR: use of an internal attribute [E0658]
 //~| NOTE: the `rustc_main` attribute is an internal implementation detail that will never be stable
 //~| NOTE: the `rustc_main` attribute is used internally to specify test entry point function
@@ -28,7 +28,7 @@
 //~| WARN cannot be used on crates
 //~| WARN previously accepted
 #![no_link]
-//~^ ERROR: `#[no_link]` attribute cannot be used on crates
+//~^ ERROR: the `no_link` attribute cannot be used on crates
 #![export_name = "2200"]
 //~^ ERROR: attribute cannot be used on
 //~| NOTE takes precedence
@@ -57,38 +57,38 @@ mod inline {
 }
 
 #[no_link]
-//~^ ERROR `#[no_link]` attribute cannot be used on modules
+//~^ ERROR the `no_link` attribute cannot be used on modules
 mod no_link {
     mod inner { #![no_link] }
-    //~^ ERROR `#[no_link]` attribute cannot be used on modules
+    //~^ ERROR the `no_link` attribute cannot be used on modules
 
     #[no_link] fn f() {
-        //~^ ERROR `#[no_link]` attribute cannot be used on functions
+        //~^ ERROR the `no_link` attribute cannot be used on functions
         match () {
             #[no_link]
-            //~^ WARN `#[no_link]` attribute cannot be used on match arms [unused_attributes]
+            //~^ WARN the `no_link` attribute cannot be used on match arms [unused_attributes]
             //~| WARN this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
             _ => ()
         }
     }
 
     #[no_link]
-    //~^ ERROR `#[no_link]` attribute cannot be used on structs
+    //~^ ERROR the `no_link` attribute cannot be used on structs
     struct S {
         #[no_link]
-        //~^ WARN `#[no_link]` attribute cannot be used on struct fields [unused_attributes]
+        //~^ WARN the `no_link` attribute cannot be used on struct fields [unused_attributes]
         //~| WARN this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
         field: ()
     }
 
     #[no_link]type T = S;
-    //~^ ERROR `#[no_link]` attribute cannot be used on type aliases
+    //~^ ERROR the `no_link` attribute cannot be used on type aliases
 
     #[no_link] impl S { }
-    //~^ ERROR `#[no_link]` attribute cannot be used on inherent impl blocks
+    //~^ ERROR the `no_link` attribute cannot be used on inherent impl blocks
 
     #[no_link]
-    //~^ WARN `#[no_link]` attribute cannot be used on macro defs
+    //~^ WARN the `no_link` attribute cannot be used on macro defs
     //~| WARN this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
     macro_rules! m{() => {}}
 }

--- a/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs-error.rs
+++ b/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs-error.rs
@@ -11,8 +11,8 @@
 #![rustc_main]
 //~^ ERROR: `#[rustc_main]` attribute cannot be used on crates
 //~| ERROR: use of an internal attribute [E0658]
-//~| NOTE: the `#[rustc_main]` attribute is an internal implementation detail that will never be stable
-//~| NOTE: the `#[rustc_main]` attribute is used internally to specify test entry point function
+//~| NOTE: the `rustc_main` attribute is an internal implementation detail that will never be stable
+//~| NOTE: the `rustc_main` attribute is used internally to specify test entry point function
 #![repr()]
 //~^ ERROR: attribute cannot be used
 //~| WARN unused attribute

--- a/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs-error.stderr
+++ b/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs-error.stderr
@@ -7,14 +7,14 @@ LL | #![macro_export]
    = help: `#[macro_export]` can only be applied to macro defs
 
 error[E0658]: use of an internal attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:11:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:11:4
    |
 LL | #![rustc_main]
-   | ^^^^^^^^^^^^^^
+   |    ^^^^^^^^^^
    |
    = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable
-   = note: the `#[rustc_main]` attribute is an internal implementation detail that will never be stable
-   = note: the `#[rustc_main]` attribute is used internally to specify test entry point function
+   = note: the `rustc_main` attribute is an internal implementation detail that will never be stable
+   = note: the `rustc_main` attribute is used internally to specify test entry point function
 
 error: `#[rustc_main]` attribute cannot be used on crates
   --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:11:1

--- a/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs-error.stderr
+++ b/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs-error.stderr
@@ -1,10 +1,10 @@
-error: `#[macro_export]` attribute cannot be used on crates
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:9:1
+error: the `macro_export` attribute cannot be used on crates
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:9:4
    |
 LL | #![macro_export]
-   | ^^^^^^^^^^^^^^^^
+   |    ^^^^^^^^^^^^
    |
-   = help: `#[macro_export]` can only be applied to macro defs
+   = help: the `macro_export` attribute can only be applied to macro defs
 
 error[E0658]: use of an internal attribute
   --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:11:4
@@ -16,277 +16,277 @@ LL | #![rustc_main]
    = note: the `rustc_main` attribute is an internal implementation detail that will never be stable
    = note: the `rustc_main` attribute is used internally to specify test entry point function
 
-error: `#[rustc_main]` attribute cannot be used on crates
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:11:1
+error: the `rustc_main` attribute cannot be used on crates
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:11:4
    |
 LL | #![rustc_main]
-   | ^^^^^^^^^^^^^^
+   |    ^^^^^^^^^^
    |
-   = help: `#[rustc_main]` can only be applied to functions
+   = help: the `rustc_main` attribute can only be applied to functions
 
-error: `#[repr()]` attribute cannot be used on crates
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:16:1
+error: the `repr()` attribute cannot be used on crates
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:16:4
    |
 LL | #![repr()]
-   | ^^^^^^^^^^
+   |    ^^^^^^
    |
-   = help: `#[repr()]` can only be applied to data types
+   = help: the `repr()` attribute can only be applied to data types
 
-error: `#[path]` attribute cannot be used on crates
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:20:1
+error: the `path` attribute cannot be used on crates
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:20:4
    |
 LL | #![path = "3800"]
-   | ^^^^^^^^^^^^^^^^^
+   |    ^^^^
    |
-   = help: `#[path]` can only be applied to modules
+   = help: the `path` attribute can only be applied to modules
 
-error: `#[automatically_derived]` attribute cannot be used on crates
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:22:1
+error: the `automatically_derived` attribute cannot be used on crates
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:22:4
    |
 LL | #![automatically_derived]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |    ^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[automatically_derived]` can only be applied to trait impl blocks
+   = help: the `automatically_derived` attribute can only be applied to trait impl blocks
 
-error: `#[no_link]` attribute cannot be used on crates
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:30:1
+error: the `no_link` attribute cannot be used on crates
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:30:4
    |
 LL | #![no_link]
-   | ^^^^^^^^^^^
+   |    ^^^^^^^
    |
-   = help: `#[no_link]` can only be applied to extern crates
+   = help: the `no_link` attribute can only be applied to extern crates
 
-error: `#[export_name]` attribute cannot be used on crates
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:32:1
+error: the `export_name` attribute cannot be used on crates
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:32:4
    |
 LL | #![export_name = "2200"]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^
+   |    ^^^^^^^^^^^
    |
-   = help: `#[export_name]` can be applied to functions and statics
+   = help: the `export_name` attribute can be applied to functions and statics
 
-error: `#[inline]` attribute cannot be used on crates
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:35:1
+error: the `inline` attribute cannot be used on crates
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:35:4
    |
 LL | #![inline]
-   | ^^^^^^^^^^
+   |    ^^^^^^
    |
-   = help: `#[inline]` can only be applied to functions
+   = help: the `inline` attribute can only be applied to functions
 
-error: `#[inline]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:37:1
+error: the `inline` attribute cannot be used on modules
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:37:3
    |
 LL | #[inline]
-   | ^^^^^^^^^
+   |   ^^^^^^
    |
-   = help: `#[inline]` can only be applied to functions
+   = help: the `inline` attribute can only be applied to functions
 
-error: `#[inline]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:40:17
+error: the `inline` attribute cannot be used on modules
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:40:20
    |
 LL |     mod inner { #![inline] }
-   |                 ^^^^^^^^^^
+   |                    ^^^^^^
    |
-   = help: `#[inline]` can only be applied to functions
+   = help: the `inline` attribute can only be applied to functions
 
-error: `#[inline]` attribute cannot be used on structs
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:49:5
+error: the `inline` attribute cannot be used on structs
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:49:7
    |
 LL |     #[inline] struct S;
-   |     ^^^^^^^^^
+   |       ^^^^^^
    |
-   = help: `#[inline]` can only be applied to functions
+   = help: the `inline` attribute can only be applied to functions
 
-error: `#[inline]` attribute cannot be used on type aliases
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:52:5
+error: the `inline` attribute cannot be used on type aliases
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:52:7
    |
 LL |     #[inline] type T = S;
-   |     ^^^^^^^^^
+   |       ^^^^^^
    |
-   = help: `#[inline]` can only be applied to functions
+   = help: the `inline` attribute can only be applied to functions
 
-error: `#[inline]` attribute cannot be used on inherent impl blocks
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:55:5
+error: the `inline` attribute cannot be used on inherent impl blocks
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:55:7
    |
 LL |     #[inline] impl S { }
-   |     ^^^^^^^^^
+   |       ^^^^^^
    |
-   = help: `#[inline]` can only be applied to functions
+   = help: the `inline` attribute can only be applied to functions
 
-error: `#[no_link]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:59:1
+error: the `no_link` attribute cannot be used on modules
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:59:3
    |
 LL | #[no_link]
-   | ^^^^^^^^^^
+   |   ^^^^^^^
    |
-   = help: `#[no_link]` can only be applied to extern crates
+   = help: the `no_link` attribute can only be applied to extern crates
 
-error: `#[no_link]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:62:17
+error: the `no_link` attribute cannot be used on modules
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:62:20
    |
 LL |     mod inner { #![no_link] }
-   |                 ^^^^^^^^^^^
+   |                    ^^^^^^^
    |
-   = help: `#[no_link]` can only be applied to extern crates
+   = help: the `no_link` attribute can only be applied to extern crates
 
-error: `#[no_link]` attribute cannot be used on functions
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:65:5
+error: the `no_link` attribute cannot be used on functions
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:65:7
    |
 LL |     #[no_link] fn f() {
-   |     ^^^^^^^^^^
+   |       ^^^^^^^
    |
-   = help: `#[no_link]` can only be applied to extern crates
+   = help: the `no_link` attribute can only be applied to extern crates
 
-error: `#[no_link]` attribute cannot be used on structs
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:75:5
+error: the `no_link` attribute cannot be used on structs
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:75:7
    |
 LL |     #[no_link]
-   |     ^^^^^^^^^^
+   |       ^^^^^^^
    |
-   = help: `#[no_link]` can only be applied to extern crates
+   = help: the `no_link` attribute can only be applied to extern crates
 
-error: `#[no_link]` attribute cannot be used on type aliases
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:84:5
+error: the `no_link` attribute cannot be used on type aliases
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:84:7
    |
 LL |     #[no_link]type T = S;
-   |     ^^^^^^^^^^
+   |       ^^^^^^^
    |
-   = help: `#[no_link]` can only be applied to extern crates
+   = help: the `no_link` attribute can only be applied to extern crates
 
-error: `#[no_link]` attribute cannot be used on inherent impl blocks
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:87:5
+error: the `no_link` attribute cannot be used on inherent impl blocks
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:87:7
    |
 LL |     #[no_link] impl S { }
-   |     ^^^^^^^^^^
+   |       ^^^^^^^
    |
-   = help: `#[no_link]` can only be applied to extern crates
+   = help: the `no_link` attribute can only be applied to extern crates
 
-error: `#[export_name]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:96:1
+error: the `export_name` attribute cannot be used on modules
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:96:3
    |
 LL | #[export_name = "2200"]
-   | ^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^
    |
-   = help: `#[export_name]` can be applied to functions and statics
+   = help: the `export_name` attribute can be applied to functions and statics
 
-error: `#[export_name]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:99:17
+error: the `export_name` attribute cannot be used on modules
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:99:20
    |
 LL |     mod inner { #![export_name="2200"] }
-   |                 ^^^^^^^^^^^^^^^^^^^^^^
+   |                    ^^^^^^^^^^^
    |
-   = help: `#[export_name]` can be applied to functions and statics
+   = help: the `export_name` attribute can be applied to functions and statics
 
-error: `#[export_name]` attribute cannot be used on structs
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:104:5
+error: the `export_name` attribute cannot be used on structs
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:104:7
    |
 LL |     #[export_name = "2200"] struct S;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^
    |
-   = help: `#[export_name]` can be applied to functions and statics
+   = help: the `export_name` attribute can be applied to functions and statics
 
-error: `#[export_name]` attribute cannot be used on type aliases
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:107:5
+error: the `export_name` attribute cannot be used on type aliases
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:107:7
    |
 LL |     #[export_name = "2200"] type T = S;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^
    |
-   = help: `#[export_name]` can be applied to functions and statics
+   = help: the `export_name` attribute can be applied to functions and statics
 
-error: `#[export_name]` attribute cannot be used on inherent impl blocks
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:110:5
+error: the `export_name` attribute cannot be used on inherent impl blocks
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:110:7
    |
 LL |     #[export_name = "2200"] impl S { }
-   |     ^^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^
    |
-   = help: `#[export_name]` can be applied to functions and statics
+   = help: the `export_name` attribute can be applied to functions and statics
 
-error: `#[export_name]` attribute cannot be used on required trait methods
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:114:9
+error: the `export_name` attribute cannot be used on required trait methods
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:114:11
    |
 LL |         #[export_name = "2200"] fn foo();
-   |         ^^^^^^^^^^^^^^^^^^^^^^^
+   |           ^^^^^^^^^^^
    |
-   = help: `#[export_name]` can be applied to functions with a body and statics
+   = help: the `export_name` attribute can be applied to functions with a body and statics
 
-error: `#[repr(C)]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:121:1
+error: the `repr(C)` attribute cannot be used on modules
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:121:3
    |
 LL | #[repr(C)]
-   | ^^^^^^^^^^
+   |   ^^^^^^^
    |
-   = help: `#[repr(C)]` can only be applied to data types
+   = help: the `repr(C)` attribute can only be applied to data types
 
-error: `#[repr(C)]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:124:17
+error: the `repr(C)` attribute cannot be used on modules
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:124:20
    |
 LL |     mod inner { #![repr(C)] }
-   |                 ^^^^^^^^^^^
+   |                    ^^^^^^^
    |
-   = help: `#[repr(C)]` can only be applied to data types
+   = help: the `repr(C)` attribute can only be applied to data types
 
-error: `#[repr(C)]` attribute cannot be used on functions
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:127:5
+error: the `repr(C)` attribute cannot be used on functions
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:127:7
    |
 LL |     #[repr(C)] fn f() { }
-   |     ^^^^^^^^^^
+   |       ^^^^^^^
    |
-   = help: `#[repr(C)]` can only be applied to data types
+   = help: the `repr(C)` attribute can only be applied to data types
 
-error: `#[repr(C)]` attribute cannot be used on type aliases
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:132:5
+error: the `repr(C)` attribute cannot be used on type aliases
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:132:7
    |
 LL |     #[repr(C)] type T = S;
-   |     ^^^^^^^^^^
+   |       ^^^^^^^
    |
-   = help: `#[repr(C)]` can only be applied to data types
+   = help: the `repr(C)` attribute can only be applied to data types
 
-error: `#[repr(C)]` attribute cannot be used on inherent impl blocks
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:135:5
+error: the `repr(C)` attribute cannot be used on inherent impl blocks
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:135:7
    |
 LL |     #[repr(C)] impl S { }
-   |     ^^^^^^^^^^
+   |       ^^^^^^^
    |
-   = help: `#[repr(C)]` can only be applied to data types
+   = help: the `repr(C)` attribute can only be applied to data types
 
-error: `#[repr(Rust)]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:140:1
+error: the `repr(Rust)` attribute cannot be used on modules
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:140:3
    |
 LL | #[repr(Rust)]
-   | ^^^^^^^^^^^^^
+   |   ^^^^^^^^^^
    |
-   = help: `#[repr(Rust)]` can only be applied to data types
+   = help: the `repr(Rust)` attribute can only be applied to data types
 
-error: `#[repr(Rust)]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:143:17
+error: the `repr(Rust)` attribute cannot be used on modules
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:143:20
    |
 LL |     mod inner { #![repr(Rust)] }
-   |                 ^^^^^^^^^^^^^^
+   |                    ^^^^^^^^^^
    |
-   = help: `#[repr(Rust)]` can only be applied to data types
+   = help: the `repr(Rust)` attribute can only be applied to data types
 
-error: `#[repr(Rust)]` attribute cannot be used on functions
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:146:5
+error: the `repr(Rust)` attribute cannot be used on functions
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:146:7
    |
 LL |     #[repr(Rust)] fn f() { }
-   |     ^^^^^^^^^^^^^
+   |       ^^^^^^^^^^
    |
-   = help: `#[repr(Rust)]` can only be applied to data types
+   = help: the `repr(Rust)` attribute can only be applied to data types
 
-error: `#[repr(Rust)]` attribute cannot be used on type aliases
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:151:5
+error: the `repr(Rust)` attribute cannot be used on type aliases
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:151:7
    |
 LL |     #[repr(Rust)] type T = S;
-   |     ^^^^^^^^^^^^^
+   |       ^^^^^^^^^^
    |
-   = help: `#[repr(Rust)]` can only be applied to data types
+   = help: the `repr(Rust)` attribute can only be applied to data types
 
-error: `#[repr(Rust)]` attribute cannot be used on inherent impl blocks
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:154:5
+error: the `repr(Rust)` attribute cannot be used on inherent impl blocks
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:154:7
    |
 LL |     #[repr(Rust)] impl S { }
-   |     ^^^^^^^^^^^^^
+   |       ^^^^^^^^^^
    |
-   = help: `#[repr(Rust)]` can only be applied to data types
+   = help: the `repr(Rust)` attribute can only be applied to data types
 
 warning: `#[no_mangle]` attribute may not be used in combination with `#[export_name]`
   --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:24:1
@@ -313,13 +313,13 @@ LL | #![repr()]
    |
    = note: using `repr` with an empty list has no effect
 
-warning: `#[no_mangle]` attribute cannot be used on crates
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:24:1
+warning: the `no_mangle` attribute cannot be used on crates
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:24:4
    |
 LL | #![no_mangle]
-   | ^^^^^^^^^^^^^
+   |    ^^^^^^^^^
    |
-   = help: `#[no_mangle]` can be applied to functions and statics
+   = help: the `no_mangle` attribute can be applied to functions and statics
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 error: valid forms for the attribute are `#[inline(always)]`, `#[inline(never)]`, and `#[inline]`
@@ -332,31 +332,31 @@ LL |     #[inline = "2100"] fn f() { }
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
    = note: `#[deny(ill_formed_attribute_input)]` (part of `#[deny(future_incompatible)]`) on by default
 
-warning: `#[no_link]` attribute cannot be used on match arms
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:68:13
+warning: the `no_link` attribute cannot be used on match arms
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:68:15
    |
 LL |             #[no_link]
-   |             ^^^^^^^^^^
+   |               ^^^^^^^
    |
-   = help: `#[no_link]` can only be applied to extern crates
+   = help: the `no_link` attribute can only be applied to extern crates
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[no_link]` attribute cannot be used on struct fields
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:78:9
+warning: the `no_link` attribute cannot be used on struct fields
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:78:11
    |
 LL |         #[no_link]
-   |         ^^^^^^^^^^
+   |           ^^^^^^^
    |
-   = help: `#[no_link]` can only be applied to extern crates
+   = help: the `no_link` attribute can only be applied to extern crates
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[no_link]` attribute cannot be used on macro defs
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:90:5
+warning: the `no_link` attribute cannot be used on macro defs
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:90:7
    |
 LL |     #[no_link]
-   |     ^^^^^^^^^^
+   |       ^^^^^^^
    |
-   = help: `#[no_link]` can only be applied to extern crates
+   = help: the `no_link` attribute can only be applied to extern crates
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 error: aborting due to 37 previous errors; 6 warnings emitted

--- a/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs.rs
+++ b/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs.rs
@@ -215,37 +215,37 @@ mod macro_use {
 }
 
 #[macro_export]
-//~^ WARN `#[macro_export]` attribute cannot be used on modules [unused_attributes]
+//~^ WARN the `macro_export` attribute cannot be used on modules [unused_attributes]
 //~| WARN previously accepted
 //~| HELP can only be applied to
 //~| HELP remove the attribute
 mod macro_export {
     mod inner { #![macro_export] }
-    //~^ WARN `#[macro_export]` attribute cannot be used on modules
+    //~^ WARN the `macro_export` attribute cannot be used on modules
     //~| WARN previously accepted
     //~| HELP can only be applied to
     //~| HELP remove the attribute
 
     #[macro_export] fn f() { }
-    //~^ WARN `#[macro_export]` attribute cannot be used on function
+    //~^ WARN the `macro_export` attribute cannot be used on function
     //~| WARN previously accepted
     //~| HELP can only be applied to
     //~| HELP remove the attribute
 
     #[macro_export] struct S;
-    //~^ WARN `#[macro_export]` attribute cannot be used on structs
+    //~^ WARN the `macro_export` attribute cannot be used on structs
     //~| WARN previously accepted
     //~| HELP can only be applied to
     //~| HELP remove the attribute
 
     #[macro_export] type T = S;
-    //~^ WARN `#[macro_export]` attribute cannot be used on type aliases
+    //~^ WARN the `macro_export` attribute cannot be used on type aliases
     //~| WARN previously accepted
     //~| HELP can only be applied to
     //~| HELP remove the attribute
 
     #[macro_export] impl S { }
-    //~^ WARN  `#[macro_export]` attribute cannot be used on inherent impl blocks
+    //~^ WARN  the `macro_export` attribute cannot be used on inherent impl blocks
     //~| WARN previously accepted
     //~| HELP can only be applied to
     //~| HELP remove the attribute

--- a/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs.stderr
+++ b/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs.stderr
@@ -207,481 +207,481 @@ note: the lint level is defined here
 LL | #![warn(unused_attributes, unknown_lints)]
    |         ^^^^^^^^^^^^^^^^^
 
-warning: `#[macro_use]` attribute cannot be used on crates
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:45:1
+warning: the `macro_use` attribute cannot be used on crates
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:45:4
    |
 LL | #![macro_use]
-   | ^^^^^^^^^^^^^
+   |    ^^^^^^^^^
    |
-   = help: `#[macro_use]` can be applied to extern crates and modules
+   = help: the `macro_use` attribute can be applied to extern crates and modules
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[should_panic]` attribute cannot be used on crates
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:51:1
+warning: the `should_panic` attribute cannot be used on crates
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:51:4
    |
 LL | #![should_panic]
-   | ^^^^^^^^^^^^^^^^
+   |    ^^^^^^^^^^^^
    |
-   = help: `#[should_panic]` can only be applied to functions
+   = help: the `should_panic` attribute can only be applied to functions
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[ignore]` attribute cannot be used on crates
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:55:1
+warning: the `ignore` attribute cannot be used on crates
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:55:4
    |
 LL | #![ignore]
-   | ^^^^^^^^^^
+   |    ^^^^^^
    |
-   = help: `#[ignore]` can only be applied to functions
+   = help: the `ignore` attribute can only be applied to functions
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[proc_macro_derive]` attribute cannot be used on crates
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:63:1
+warning: the `proc_macro_derive` attribute cannot be used on crates
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:63:4
    |
 LL | #![proc_macro_derive(Test)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |    ^^^^^^^^^^^^^^^^^
    |
-   = help: `#[proc_macro_derive]` can only be applied to functions
+   = help: the `proc_macro_derive` attribute can only be applied to functions
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[cold]` attribute cannot be used on crates
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:68:1
+warning: the `cold` attribute cannot be used on crates
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:68:4
    |
 LL | #![cold]
-   | ^^^^^^^^
+   |    ^^^^
    |
-   = help: `#[cold]` can only be applied to functions
+   = help: the `cold` attribute can only be applied to functions
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[link]` attribute cannot be used on crates
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:72:1
+warning: the `link` attribute cannot be used on crates
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:72:4
    |
 LL | #![link(name = "x")]
-   | ^^^^^^^^^^^^^^^^^^^^
+   |    ^^^^
    |
-   = help: `#[link]` can only be applied to foreign modules
+   = help: the `link` attribute can only be applied to foreign modules
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[link_name]` attribute cannot be used on crates
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:76:1
+warning: the `link_name` attribute cannot be used on crates
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:76:4
    |
 LL | #![link_name = "1900"]
-   | ^^^^^^^^^^^^^^^^^^^^^^
+   |    ^^^^^^^^^
    |
-   = help: `#[link_name]` can be applied to foreign functions and foreign statics
+   = help: the `link_name` attribute can be applied to foreign functions and foreign statics
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[link_section]` attribute cannot be used on crates
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:81:1
+warning: the `link_section` attribute cannot be used on crates
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:81:4
    |
 LL | #![link_section = ",1800"]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |    ^^^^^^^^^^^^
    |
-   = help: `#[link_section]` can be applied to functions and statics
+   = help: the `link_section` attribute can be applied to functions and statics
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[must_use]` attribute cannot be used on crates
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:86:1
+warning: the `must_use` attribute cannot be used on crates
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:86:4
    |
 LL | #![must_use]
-   | ^^^^^^^^^^^^
+   |    ^^^^^^^^
    |
-   = help: `#[must_use]` can be applied to data types, functions, and traits
+   = help: the `must_use` attribute can be applied to data types, functions, and traits
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[macro_use]` attribute cannot be used on functions
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:192:5
+warning: the `macro_use` attribute cannot be used on functions
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:192:7
    |
 LL |     #[macro_use] fn f() { }
-   |     ^^^^^^^^^^^^
+   |       ^^^^^^^^^
    |
-   = help: `#[macro_use]` can be applied to extern crates and modules
+   = help: the `macro_use` attribute can be applied to extern crates and modules
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[macro_use]` attribute cannot be used on structs
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:198:5
+warning: the `macro_use` attribute cannot be used on structs
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:198:7
    |
 LL |     #[macro_use] struct S;
-   |     ^^^^^^^^^^^^
+   |       ^^^^^^^^^
    |
-   = help: `#[macro_use]` can be applied to extern crates and modules
+   = help: the `macro_use` attribute can be applied to extern crates and modules
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[macro_use]` attribute cannot be used on type aliases
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:204:5
+warning: the `macro_use` attribute cannot be used on type aliases
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:204:7
    |
 LL |     #[macro_use] type T = S;
-   |     ^^^^^^^^^^^^
+   |       ^^^^^^^^^
    |
-   = help: `#[macro_use]` can be applied to extern crates and modules
+   = help: the `macro_use` attribute can be applied to extern crates and modules
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[macro_use]` attribute cannot be used on inherent impl blocks
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:210:5
+warning: the `macro_use` attribute cannot be used on inherent impl blocks
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:210:7
    |
 LL |     #[macro_use] impl S { }
-   |     ^^^^^^^^^^^^
+   |       ^^^^^^^^^
    |
-   = help: `#[macro_use]` can be applied to extern crates and modules
+   = help: the `macro_use` attribute can be applied to extern crates and modules
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[macro_export]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:217:1
+warning: the `macro_export` attribute cannot be used on modules
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:217:3
    |
 LL | #[macro_export]
-   | ^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^
    |
-   = help: `#[macro_export]` can only be applied to macro defs
+   = help: the `macro_export` attribute can only be applied to macro defs
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[macro_export]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:223:17
+warning: the `macro_export` attribute cannot be used on modules
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:223:20
    |
 LL |     mod inner { #![macro_export] }
-   |                 ^^^^^^^^^^^^^^^^
+   |                    ^^^^^^^^^^^^
    |
-   = help: `#[macro_export]` can only be applied to macro defs
+   = help: the `macro_export` attribute can only be applied to macro defs
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[macro_export]` attribute cannot be used on functions
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:229:5
+warning: the `macro_export` attribute cannot be used on functions
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:229:7
    |
 LL |     #[macro_export] fn f() { }
-   |     ^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^
    |
-   = help: `#[macro_export]` can only be applied to macro defs
+   = help: the `macro_export` attribute can only be applied to macro defs
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[macro_export]` attribute cannot be used on structs
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:235:5
+warning: the `macro_export` attribute cannot be used on structs
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:235:7
    |
 LL |     #[macro_export] struct S;
-   |     ^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^
    |
-   = help: `#[macro_export]` can only be applied to macro defs
+   = help: the `macro_export` attribute can only be applied to macro defs
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[macro_export]` attribute cannot be used on type aliases
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:241:5
+warning: the `macro_export` attribute cannot be used on type aliases
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:241:7
    |
 LL |     #[macro_export] type T = S;
-   |     ^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^
    |
-   = help: `#[macro_export]` can only be applied to macro defs
+   = help: the `macro_export` attribute can only be applied to macro defs
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[macro_export]` attribute cannot be used on inherent impl blocks
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:247:5
+warning: the `macro_export` attribute cannot be used on inherent impl blocks
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:247:7
    |
 LL |     #[macro_export] impl S { }
-   |     ^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^
    |
-   = help: `#[macro_export]` can only be applied to macro defs
+   = help: the `macro_export` attribute can only be applied to macro defs
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[path]` attribute cannot be used on functions
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:258:5
+warning: the `path` attribute cannot be used on functions
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:258:7
    |
 LL |     #[path = "3800"] fn f() { }
-   |     ^^^^^^^^^^^^^^^^
+   |       ^^^^
    |
-   = help: `#[path]` can only be applied to modules
+   = help: the `path` attribute can only be applied to modules
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[path]` attribute cannot be used on structs
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:264:5
+warning: the `path` attribute cannot be used on structs
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:264:7
    |
 LL |     #[path = "3800"]  struct S;
-   |     ^^^^^^^^^^^^^^^^
+   |       ^^^^
    |
-   = help: `#[path]` can only be applied to modules
+   = help: the `path` attribute can only be applied to modules
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[path]` attribute cannot be used on type aliases
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:270:5
+warning: the `path` attribute cannot be used on type aliases
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:270:7
    |
 LL |     #[path = "3800"] type T = S;
-   |     ^^^^^^^^^^^^^^^^
+   |       ^^^^
    |
-   = help: `#[path]` can only be applied to modules
+   = help: the `path` attribute can only be applied to modules
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[path]` attribute cannot be used on inherent impl blocks
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:276:5
+warning: the `path` attribute cannot be used on inherent impl blocks
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:276:7
    |
 LL |     #[path = "3800"] impl S { }
-   |     ^^^^^^^^^^^^^^^^
+   |       ^^^^
    |
-   = help: `#[path]` can only be applied to modules
+   = help: the `path` attribute can only be applied to modules
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[automatically_derived]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:283:1
+warning: the `automatically_derived` attribute cannot be used on modules
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:283:3
    |
 LL | #[automatically_derived]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[automatically_derived]` can only be applied to trait impl blocks
+   = help: the `automatically_derived` attribute can only be applied to trait impl blocks
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[automatically_derived]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:289:17
+warning: the `automatically_derived` attribute cannot be used on modules
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:289:20
    |
 LL |     mod inner { #![automatically_derived] }
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                    ^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[automatically_derived]` can only be applied to trait impl blocks
+   = help: the `automatically_derived` attribute can only be applied to trait impl blocks
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[automatically_derived]` attribute cannot be used on functions
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:295:5
+warning: the `automatically_derived` attribute cannot be used on functions
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:295:7
    |
 LL |     #[automatically_derived] fn f() { }
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[automatically_derived]` can only be applied to trait impl blocks
+   = help: the `automatically_derived` attribute can only be applied to trait impl blocks
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[automatically_derived]` attribute cannot be used on structs
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:301:5
+warning: the `automatically_derived` attribute cannot be used on structs
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:301:7
    |
 LL |     #[automatically_derived] struct S;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[automatically_derived]` can only be applied to trait impl blocks
+   = help: the `automatically_derived` attribute can only be applied to trait impl blocks
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[automatically_derived]` attribute cannot be used on type aliases
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:307:5
+warning: the `automatically_derived` attribute cannot be used on type aliases
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:307:7
    |
 LL |     #[automatically_derived] type T = S;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[automatically_derived]` can only be applied to trait impl blocks
+   = help: the `automatically_derived` attribute can only be applied to trait impl blocks
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[automatically_derived]` attribute cannot be used on traits
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:313:5
+warning: the `automatically_derived` attribute cannot be used on traits
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:313:7
    |
 LL |     #[automatically_derived] trait W { }
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[automatically_derived]` can only be applied to trait impl blocks
+   = help: the `automatically_derived` attribute can only be applied to trait impl blocks
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[automatically_derived]` attribute cannot be used on inherent impl blocks
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:319:5
+warning: the `automatically_derived` attribute cannot be used on inherent impl blocks
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:319:7
    |
 LL |     #[automatically_derived] impl S { }
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[automatically_derived]` can only be applied to trait impl blocks
+   = help: the `automatically_derived` attribute can only be applied to trait impl blocks
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[no_mangle]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:328:1
+warning: the `no_mangle` attribute cannot be used on modules
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:328:3
    |
 LL | #[no_mangle]
-   | ^^^^^^^^^^^^
+   |   ^^^^^^^^^
    |
-   = help: `#[no_mangle]` can be applied to functions and statics
+   = help: the `no_mangle` attribute can be applied to functions and statics
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[no_mangle]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:334:17
+warning: the `no_mangle` attribute cannot be used on modules
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:334:20
    |
 LL |     mod inner { #![no_mangle] }
-   |                 ^^^^^^^^^^^^^
+   |                    ^^^^^^^^^
    |
-   = help: `#[no_mangle]` can be applied to functions and statics
+   = help: the `no_mangle` attribute can be applied to functions and statics
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[no_mangle]` attribute cannot be used on structs
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:342:5
+warning: the `no_mangle` attribute cannot be used on structs
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:342:7
    |
 LL |     #[no_mangle] struct S;
-   |     ^^^^^^^^^^^^
+   |       ^^^^^^^^^
    |
-   = help: `#[no_mangle]` can be applied to functions and statics
+   = help: the `no_mangle` attribute can be applied to functions and statics
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[no_mangle]` attribute cannot be used on type aliases
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:348:5
+warning: the `no_mangle` attribute cannot be used on type aliases
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:348:7
    |
 LL |     #[no_mangle] type T = S;
-   |     ^^^^^^^^^^^^
+   |       ^^^^^^^^^
    |
-   = help: `#[no_mangle]` can be applied to functions and statics
+   = help: the `no_mangle` attribute can be applied to functions and statics
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[no_mangle]` attribute cannot be used on inherent impl blocks
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:354:5
+warning: the `no_mangle` attribute cannot be used on inherent impl blocks
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:354:7
    |
 LL |     #[no_mangle] impl S { }
-   |     ^^^^^^^^^^^^
+   |       ^^^^^^^^^
    |
-   = help: `#[no_mangle]` can be applied to functions and statics
+   = help: the `no_mangle` attribute can be applied to functions and statics
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[should_panic]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:375:1
+warning: the `should_panic` attribute cannot be used on modules
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:375:3
    |
 LL | #[should_panic]
-   | ^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^
    |
-   = help: `#[should_panic]` can only be applied to functions
+   = help: the `should_panic` attribute can only be applied to functions
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[should_panic]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:381:17
+warning: the `should_panic` attribute cannot be used on modules
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:381:20
    |
 LL |     mod inner { #![should_panic] }
-   |                 ^^^^^^^^^^^^^^^^
+   |                    ^^^^^^^^^^^^
    |
-   = help: `#[should_panic]` can only be applied to functions
+   = help: the `should_panic` attribute can only be applied to functions
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[should_panic]` attribute cannot be used on structs
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:389:5
+warning: the `should_panic` attribute cannot be used on structs
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:389:7
    |
 LL |     #[should_panic] struct S;
-   |     ^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^
    |
-   = help: `#[should_panic]` can only be applied to functions
+   = help: the `should_panic` attribute can only be applied to functions
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[should_panic]` attribute cannot be used on type aliases
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:395:5
+warning: the `should_panic` attribute cannot be used on type aliases
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:395:7
    |
 LL |     #[should_panic] type T = S;
-   |     ^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^
    |
-   = help: `#[should_panic]` can only be applied to functions
+   = help: the `should_panic` attribute can only be applied to functions
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[should_panic]` attribute cannot be used on inherent impl blocks
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:401:5
+warning: the `should_panic` attribute cannot be used on inherent impl blocks
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:401:7
    |
 LL |     #[should_panic] impl S { }
-   |     ^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^
    |
-   = help: `#[should_panic]` can only be applied to functions
+   = help: the `should_panic` attribute can only be applied to functions
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[ignore]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:408:1
+warning: the `ignore` attribute cannot be used on modules
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:408:3
    |
 LL | #[ignore]
-   | ^^^^^^^^^
+   |   ^^^^^^
    |
-   = help: `#[ignore]` can only be applied to functions
+   = help: the `ignore` attribute can only be applied to functions
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[ignore]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:414:17
+warning: the `ignore` attribute cannot be used on modules
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:414:20
    |
 LL |     mod inner { #![ignore] }
-   |                 ^^^^^^^^^^
+   |                    ^^^^^^
    |
-   = help: `#[ignore]` can only be applied to functions
+   = help: the `ignore` attribute can only be applied to functions
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[ignore]` attribute cannot be used on structs
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:422:5
+warning: the `ignore` attribute cannot be used on structs
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:422:7
    |
 LL |     #[ignore] struct S;
-   |     ^^^^^^^^^
+   |       ^^^^^^
    |
-   = help: `#[ignore]` can only be applied to functions
+   = help: the `ignore` attribute can only be applied to functions
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[ignore]` attribute cannot be used on type aliases
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:428:5
+warning: the `ignore` attribute cannot be used on type aliases
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:428:7
    |
 LL |     #[ignore] type T = S;
-   |     ^^^^^^^^^
+   |       ^^^^^^
    |
-   = help: `#[ignore]` can only be applied to functions
+   = help: the `ignore` attribute can only be applied to functions
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[ignore]` attribute cannot be used on inherent impl blocks
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:434:5
+warning: the `ignore` attribute cannot be used on inherent impl blocks
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:434:7
    |
 LL |     #[ignore] impl S { }
-   |     ^^^^^^^^^
+   |       ^^^^^^
    |
-   = help: `#[ignore]` can only be applied to functions
+   = help: the `ignore` attribute can only be applied to functions
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[no_implicit_prelude]` attribute cannot be used on functions
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:445:5
+warning: the `no_implicit_prelude` attribute cannot be used on functions
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:445:7
    |
 LL |     #[no_implicit_prelude] fn f() { }
-   |     ^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[no_implicit_prelude]` can be applied to crates and modules
+   = help: the `no_implicit_prelude` attribute can be applied to crates and modules
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[no_implicit_prelude]` attribute cannot be used on structs
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:451:5
+warning: the `no_implicit_prelude` attribute cannot be used on structs
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:451:7
    |
 LL |     #[no_implicit_prelude] struct S;
-   |     ^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[no_implicit_prelude]` can be applied to crates and modules
+   = help: the `no_implicit_prelude` attribute can be applied to crates and modules
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[no_implicit_prelude]` attribute cannot be used on type aliases
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:457:5
+warning: the `no_implicit_prelude` attribute cannot be used on type aliases
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:457:7
    |
 LL |     #[no_implicit_prelude] type T = S;
-   |     ^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[no_implicit_prelude]` can be applied to crates and modules
+   = help: the `no_implicit_prelude` attribute can be applied to crates and modules
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[no_implicit_prelude]` attribute cannot be used on inherent impl blocks
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:463:5
+warning: the `no_implicit_prelude` attribute cannot be used on inherent impl blocks
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:463:7
    |
 LL |     #[no_implicit_prelude] impl S { }
-   |     ^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[no_implicit_prelude]` can be applied to crates and modules
+   = help: the `no_implicit_prelude` attribute can be applied to crates and modules
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[macro_escape]` attribute cannot be used on functions
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:478:5
+warning: the `macro_escape` attribute cannot be used on functions
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:478:7
    |
 LL |     #[macro_escape] fn f() { }
-   |     ^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^
    |
-   = help: `#[macro_escape]` can be applied to extern crates and modules
+   = help: the `macro_escape` attribute can be applied to extern crates and modules
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[macro_escape]` attribute cannot be used on structs
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:484:5
+warning: the `macro_escape` attribute cannot be used on structs
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:484:7
    |
 LL |     #[macro_escape] struct S;
-   |     ^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^
    |
-   = help: `#[macro_escape]` can be applied to extern crates and modules
+   = help: the `macro_escape` attribute can be applied to extern crates and modules
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[macro_escape]` attribute cannot be used on type aliases
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:490:5
+warning: the `macro_escape` attribute cannot be used on type aliases
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:490:7
    |
 LL |     #[macro_escape] type T = S;
-   |     ^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^
    |
-   = help: `#[macro_escape]` can be applied to extern crates and modules
+   = help: the `macro_escape` attribute can be applied to extern crates and modules
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[macro_escape]` attribute cannot be used on inherent impl blocks
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:496:5
+warning: the `macro_escape` attribute cannot be used on inherent impl blocks
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:496:7
    |
 LL |     #[macro_escape] impl S { }
-   |     ^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^
    |
-   = help: `#[macro_escape]` can be applied to extern crates and modules
+   = help: the `macro_escape` attribute can be applied to extern crates and modules
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![no_std]`
@@ -754,256 +754,256 @@ note: this attribute does not have an `!`, which means it is applied to this imp
 LL |     #[no_std] impl S { }
    |               ^^^^^^^^^^
 
-warning: `#[cold]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:544:1
+warning: the `cold` attribute cannot be used on modules
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:544:3
    |
 LL | #[cold]
-   | ^^^^^^^
+   |   ^^^^
    |
-   = help: `#[cold]` can only be applied to functions
+   = help: the `cold` attribute can only be applied to functions
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[cold]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:551:17
+warning: the `cold` attribute cannot be used on modules
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:551:20
    |
 LL |     mod inner { #![cold] }
-   |                 ^^^^^^^^
+   |                    ^^^^
    |
-   = help: `#[cold]` can only be applied to functions
+   = help: the `cold` attribute can only be applied to functions
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[cold]` attribute cannot be used on structs
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:559:5
+warning: the `cold` attribute cannot be used on structs
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:559:7
    |
 LL |     #[cold] struct S;
-   |     ^^^^^^^
+   |       ^^^^
    |
-   = help: `#[cold]` can only be applied to functions
+   = help: the `cold` attribute can only be applied to functions
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[cold]` attribute cannot be used on type aliases
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:565:5
+warning: the `cold` attribute cannot be used on type aliases
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:565:7
    |
 LL |     #[cold] type T = S;
-   |     ^^^^^^^
+   |       ^^^^
    |
-   = help: `#[cold]` can only be applied to functions
+   = help: the `cold` attribute can only be applied to functions
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[cold]` attribute cannot be used on inherent impl blocks
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:571:5
+warning: the `cold` attribute cannot be used on inherent impl blocks
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:571:7
    |
 LL |     #[cold] impl S { }
-   |     ^^^^^^^
+   |       ^^^^
    |
-   = help: `#[cold]` can only be applied to functions
+   = help: the `cold` attribute can only be applied to functions
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[link_name]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:578:1
+warning: the `link_name` attribute cannot be used on modules
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:578:3
    |
 LL | #[link_name = "1900"]
-   | ^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^
    |
-   = help: `#[link_name]` can be applied to foreign functions and foreign statics
+   = help: the `link_name` attribute can be applied to foreign functions and foreign statics
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[link_name]` attribute cannot be used on foreign modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:584:5
+warning: the `link_name` attribute cannot be used on foreign modules
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:584:7
    |
 LL |     #[link_name = "1900"]
-   |     ^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^
    |
-   = help: `#[link_name]` can be applied to foreign functions and foreign statics
+   = help: the `link_name` attribute can be applied to foreign functions and foreign statics
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[link_name]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:591:17
+warning: the `link_name` attribute cannot be used on modules
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:591:20
    |
 LL |     mod inner { #![link_name="1900"] }
-   |                 ^^^^^^^^^^^^^^^^^^^^
+   |                    ^^^^^^^^^
    |
-   = help: `#[link_name]` can be applied to foreign functions and foreign statics
+   = help: the `link_name` attribute can be applied to foreign functions and foreign statics
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[link_name]` attribute cannot be used on functions
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:597:5
+warning: the `link_name` attribute cannot be used on functions
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:597:7
    |
 LL |     #[link_name = "1900"] fn f() { }
-   |     ^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^
    |
-   = help: `#[link_name]` can be applied to foreign functions and foreign statics
+   = help: the `link_name` attribute can be applied to foreign functions and foreign statics
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[link_name]` attribute cannot be used on structs
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:603:5
+warning: the `link_name` attribute cannot be used on structs
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:603:7
    |
 LL |     #[link_name = "1900"] struct S;
-   |     ^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^
    |
-   = help: `#[link_name]` can be applied to foreign functions and foreign statics
+   = help: the `link_name` attribute can be applied to foreign functions and foreign statics
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[link_name]` attribute cannot be used on type aliases
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:609:5
+warning: the `link_name` attribute cannot be used on type aliases
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:609:7
    |
 LL |     #[link_name = "1900"] type T = S;
-   |     ^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^
    |
-   = help: `#[link_name]` can be applied to foreign functions and foreign statics
+   = help: the `link_name` attribute can be applied to foreign functions and foreign statics
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[link_name]` attribute cannot be used on inherent impl blocks
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:615:5
+warning: the `link_name` attribute cannot be used on inherent impl blocks
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:615:7
    |
 LL |     #[link_name = "1900"] impl S { }
-   |     ^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^
    |
-   = help: `#[link_name]` can be applied to foreign functions and foreign statics
+   = help: the `link_name` attribute can be applied to foreign functions and foreign statics
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[link_section]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:622:1
+warning: the `link_section` attribute cannot be used on modules
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:622:3
    |
 LL | #[link_section = ",1800"]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^
    |
-   = help: `#[link_section]` can be applied to functions and statics
+   = help: the `link_section` attribute can be applied to functions and statics
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[link_section]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:628:17
+warning: the `link_section` attribute cannot be used on modules
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:628:20
    |
 LL |     mod inner { #![link_section=",1800"] }
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                    ^^^^^^^^^^^^
    |
-   = help: `#[link_section]` can be applied to functions and statics
+   = help: the `link_section` attribute can be applied to functions and statics
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[link_section]` attribute cannot be used on structs
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:636:5
+warning: the `link_section` attribute cannot be used on structs
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:636:7
    |
 LL |     #[link_section = ",1800"] struct S;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^
    |
-   = help: `#[link_section]` can be applied to functions and statics
+   = help: the `link_section` attribute can be applied to functions and statics
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[link_section]` attribute cannot be used on type aliases
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:642:5
+warning: the `link_section` attribute cannot be used on type aliases
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:642:7
    |
 LL |     #[link_section = ",1800"] type T = S;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^
    |
-   = help: `#[link_section]` can be applied to functions and statics
+   = help: the `link_section` attribute can be applied to functions and statics
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[link_section]` attribute cannot be used on inherent impl blocks
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:648:5
+warning: the `link_section` attribute cannot be used on inherent impl blocks
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:648:7
    |
 LL |     #[link_section = ",1800"] impl S { }
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^
    |
-   = help: `#[link_section]` can be applied to functions and statics
+   = help: the `link_section` attribute can be applied to functions and statics
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[link_section]` attribute cannot be used on traits
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:654:5
+warning: the `link_section` attribute cannot be used on traits
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:654:7
    |
 LL |     #[link_section = ",1800"]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^
    |
-   = help: `#[link_section]` can be applied to functions and statics
+   = help: the `link_section` attribute can be applied to functions and statics
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[link]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:688:1
+warning: the `link` attribute cannot be used on modules
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:688:3
    |
 LL | #[link(name = "x")]
-   | ^^^^^^^^^^^^^^^^^^^
+   |   ^^^^
    |
-   = help: `#[link]` can only be applied to foreign modules
+   = help: the `link` attribute can only be applied to foreign modules
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[link]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:694:17
+warning: the `link` attribute cannot be used on modules
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:694:20
    |
 LL |     mod inner { #![link(name = "x")] }
-   |                 ^^^^^^^^^^^^^^^^^^^^
+   |                    ^^^^
    |
-   = help: `#[link]` can only be applied to foreign modules
+   = help: the `link` attribute can only be applied to foreign modules
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[link]` attribute cannot be used on functions
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:700:5
+warning: the `link` attribute cannot be used on functions
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:700:7
    |
 LL |     #[link(name = "x")] fn f() { }
-   |     ^^^^^^^^^^^^^^^^^^^
+   |       ^^^^
    |
-   = help: `#[link]` can only be applied to foreign modules
+   = help: the `link` attribute can only be applied to foreign modules
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[link]` attribute cannot be used on structs
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:706:5
+warning: the `link` attribute cannot be used on structs
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:706:7
    |
 LL |     #[link(name = "x")] struct S;
-   |     ^^^^^^^^^^^^^^^^^^^
+   |       ^^^^
    |
-   = help: `#[link]` can only be applied to foreign modules
+   = help: the `link` attribute can only be applied to foreign modules
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[link]` attribute cannot be used on type aliases
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:712:5
+warning: the `link` attribute cannot be used on type aliases
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:712:7
    |
 LL |     #[link(name = "x")] type T = S;
-   |     ^^^^^^^^^^^^^^^^^^^
+   |       ^^^^
    |
-   = help: `#[link]` can only be applied to foreign modules
+   = help: the `link` attribute can only be applied to foreign modules
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[link]` attribute cannot be used on inherent impl blocks
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:718:5
+warning: the `link` attribute cannot be used on inherent impl blocks
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:718:7
    |
 LL |     #[link(name = "x")] impl S { }
-   |     ^^^^^^^^^^^^^^^^^^^
+   |       ^^^^
    |
-   = help: `#[link]` can only be applied to foreign modules
+   = help: the `link` attribute can only be applied to foreign modules
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[must_use]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:744:1
+warning: the `must_use` attribute cannot be used on modules
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:744:3
    |
 LL | #[must_use]
-   | ^^^^^^^^^^^
+   |   ^^^^^^^^
    |
-   = help: `#[must_use]` can be applied to data types, functions, and traits
+   = help: the `must_use` attribute can be applied to data types, functions, and traits
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[must_use]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:749:17
+warning: the `must_use` attribute cannot be used on modules
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:749:20
    |
 LL |     mod inner { #![must_use] }
-   |                 ^^^^^^^^^^^^
+   |                    ^^^^^^^^
    |
-   = help: `#[must_use]` can be applied to data types, functions, and traits
+   = help: the `must_use` attribute can be applied to data types, functions, and traits
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[must_use]` attribute cannot be used on type aliases
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:758:5
+warning: the `must_use` attribute cannot be used on type aliases
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:758:7
    |
 LL |     #[must_use] type T = S;
-   |     ^^^^^^^^^^^
+   |       ^^^^^^^^
    |
-   = help: `#[must_use]` can be applied to data types, functions, and traits
+   = help: the `must_use` attribute can be applied to data types, functions, and traits
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[must_use]` attribute cannot be used on inherent impl blocks
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:763:5
+warning: the `must_use` attribute cannot be used on inherent impl blocks
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:763:7
    |
 LL |     #[must_use] impl S { }
-   |     ^^^^^^^^^^^
+   |       ^^^^^^^^
    |
-   = help: `#[must_use]` can be applied to data types, functions, and traits
+   = help: the `must_use` attribute can be applied to data types, functions, and traits
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![windows_subsystem]`
@@ -1566,31 +1566,31 @@ note: this attribute does not have an `!`, which means it is applied to this imp
 LL |     #[type_length_limit="0100"] impl S { }
    |                                 ^^^^^^^^^^
 
-warning: `#[no_mangle]` attribute cannot be used on required trait methods
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:361:9
+warning: the `no_mangle` attribute cannot be used on required trait methods
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:361:11
    |
 LL |         #[no_mangle] fn foo();
-   |         ^^^^^^^^^^^^
+   |           ^^^^^^^^^
    |
-   = help: `#[no_mangle]` can be applied to functions with a body and statics
+   = help: the `no_mangle` attribute can be applied to functions with a body and statics
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[no_mangle]` attribute cannot be used on provided trait methods
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:367:9
+warning: the `no_mangle` attribute cannot be used on provided trait methods
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:367:11
    |
 LL |         #[no_mangle] fn bar() {}
-   |         ^^^^^^^^^^^^
+   |           ^^^^^^^^^
    |
-   = help: `#[no_mangle]` can be applied to functions, inherent methods, statics, and trait methods in impl blocks
+   = help: the `no_mangle` attribute can be applied to functions, inherent methods, statics, and trait methods in impl blocks
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[link_section]` attribute cannot be used on required trait methods
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:660:9
+warning: the `link_section` attribute cannot be used on required trait methods
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:660:11
    |
 LL |         #[link_section = ",1800"]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |           ^^^^^^^^^^^^
    |
-   = help: `#[link_section]` can be applied to functions with a body and statics
+   = help: the `link_section` attribute can be applied to functions with a body and statics
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: 170 warnings emitted

--- a/tests/ui/feature-gates/issue-43106-gating-of-macro_escape.stderr
+++ b/tests/ui/feature-gates/issue-43106-gating-of-macro_escape.stderr
@@ -6,13 +6,13 @@ LL | #![macro_escape]
    |
    = help: try an outer attribute: `#[macro_use]`
 
-warning: `#[macro_escape]` attribute cannot be used on crates
-  --> $DIR/issue-43106-gating-of-macro_escape.rs:8:1
+warning: the `macro_escape` attribute cannot be used on crates
+  --> $DIR/issue-43106-gating-of-macro_escape.rs:8:4
    |
 LL | #![macro_escape]
-   | ^^^^^^^^^^^^^^^^
+   |    ^^^^^^^^^^^^
    |
-   = help: `#[macro_escape]` can be applied to extern crates and modules
+   = help: the `macro_escape` attribute can be applied to extern crates and modules
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: requested on the command line with `-W unused-attributes`
 

--- a/tests/ui/feature-gates/issue-43106-gating-of-macro_use.stderr
+++ b/tests/ui/feature-gates/issue-43106-gating-of-macro_use.stderr
@@ -17,10 +17,10 @@ LL | #![macro_use(my_macro)]
    | ^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0539]: malformed `macro_use` attribute input
-  --> $DIR/issue-43106-gating-of-macro_use.rs:17:5
+  --> $DIR/issue-43106-gating-of-macro_use.rs:17:7
    |
 LL |     #[macro_use = "2700"] struct S;
-   |     ^^^^^^^^^^^^--------^
+   |       ^^^^^^^^^^--------
    |                 |
    |                 expected a list or no arguments here
    |

--- a/tests/ui/feature-gates/issue-43106-gating-of-macro_use.stderr
+++ b/tests/ui/feature-gates/issue-43106-gating-of-macro_use.stderr
@@ -34,50 +34,50 @@ LL -     #[macro_use = "2700"] struct S;
 LL +     #[macro_use] struct S;
    |
 
-warning: `#[macro_use]` attribute cannot be used on crates
-  --> $DIR/issue-43106-gating-of-macro_use.rs:6:1
+warning: the `macro_use` attribute cannot be used on crates
+  --> $DIR/issue-43106-gating-of-macro_use.rs:6:4
    |
 LL | #![macro_use(my_macro)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^
+   |    ^^^^^^^^^
    |
-   = help: `#[macro_use]` can be applied to extern crates and modules
+   = help: the `macro_use` attribute can be applied to extern crates and modules
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: requested on the command line with `-W unused-attributes`
 
-warning: `#[macro_use]` attribute cannot be used on structs
-  --> $DIR/issue-43106-gating-of-macro_use.rs:17:5
+warning: the `macro_use` attribute cannot be used on structs
+  --> $DIR/issue-43106-gating-of-macro_use.rs:17:7
    |
 LL |     #[macro_use = "2700"] struct S;
-   |     ^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^
    |
-   = help: `#[macro_use]` can be applied to extern crates and modules
+   = help: the `macro_use` attribute can be applied to extern crates and modules
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[macro_use]` attribute cannot be used on functions
-  --> $DIR/issue-43106-gating-of-macro_use.rs:22:5
+warning: the `macro_use` attribute cannot be used on functions
+  --> $DIR/issue-43106-gating-of-macro_use.rs:22:7
    |
 LL |     #[macro_use] fn f() { }
-   |     ^^^^^^^^^^^^
+   |       ^^^^^^^^^
    |
-   = help: `#[macro_use]` can be applied to extern crates and modules
+   = help: the `macro_use` attribute can be applied to extern crates and modules
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[macro_use]` attribute cannot be used on type aliases
-  --> $DIR/issue-43106-gating-of-macro_use.rs:26:5
+warning: the `macro_use` attribute cannot be used on type aliases
+  --> $DIR/issue-43106-gating-of-macro_use.rs:26:7
    |
 LL |     #[macro_use] type T = S;
-   |     ^^^^^^^^^^^^
+   |       ^^^^^^^^^
    |
-   = help: `#[macro_use]` can be applied to extern crates and modules
+   = help: the `macro_use` attribute can be applied to extern crates and modules
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[macro_use]` attribute cannot be used on inherent impl blocks
-  --> $DIR/issue-43106-gating-of-macro_use.rs:30:5
+warning: the `macro_use` attribute cannot be used on inherent impl blocks
+  --> $DIR/issue-43106-gating-of-macro_use.rs:30:7
    |
 LL |     #[macro_use] impl S { }
-   |     ^^^^^^^^^^^^
+   |       ^^^^^^^^^
    |
-   = help: `#[macro_use]` can be applied to extern crates and modules
+   = help: the `macro_use` attribute can be applied to extern crates and modules
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 error: aborting due to 4 previous errors; 5 warnings emitted

--- a/tests/ui/feature-gates/issue-43106-gating-of-proc_macro_derive.stderr
+++ b/tests/ui/feature-gates/issue-43106-gating-of-proc_macro_derive.stderr
@@ -4,53 +4,53 @@ error: the `#[proc_macro_derive]` attribute is only usable with crates of the `p
 LL |     #[proc_macro_derive(Test)] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: `#[proc_macro_derive]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-proc_macro_derive.rs:5:1
+error: the `proc_macro_derive` attribute cannot be used on modules
+  --> $DIR/issue-43106-gating-of-proc_macro_derive.rs:5:3
    |
 LL | #[proc_macro_derive(Test)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^
    |
-   = help: `#[proc_macro_derive]` can only be applied to functions
+   = help: the `proc_macro_derive` attribute can only be applied to functions
 
-error: `#[proc_macro_derive]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-proc_macro_derive.rs:8:17
+error: the `proc_macro_derive` attribute cannot be used on modules
+  --> $DIR/issue-43106-gating-of-proc_macro_derive.rs:8:20
    |
 LL |     mod inner { #![proc_macro_derive(Test)] }
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                    ^^^^^^^^^^^^^^^^^
    |
-   = help: `#[proc_macro_derive]` can only be applied to functions
+   = help: the `proc_macro_derive` attribute can only be applied to functions
 
-error: `#[proc_macro_derive]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-proc_macro_derive.rs:13:17
+error: the `proc_macro_derive` attribute cannot be used on modules
+  --> $DIR/issue-43106-gating-of-proc_macro_derive.rs:13:20
    |
 LL |     mod inner { #![proc_macro_derive(Test)] }
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                    ^^^^^^^^^^^^^^^^^
    |
-   = help: `#[proc_macro_derive]` can only be applied to functions
+   = help: the `proc_macro_derive` attribute can only be applied to functions
 
-error: `#[proc_macro_derive]` attribute cannot be used on structs
-  --> $DIR/issue-43106-gating-of-proc_macro_derive.rs:19:5
+error: the `proc_macro_derive` attribute cannot be used on structs
+  --> $DIR/issue-43106-gating-of-proc_macro_derive.rs:19:7
    |
 LL |     #[proc_macro_derive(Test)] struct S;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^^
    |
-   = help: `#[proc_macro_derive]` can only be applied to functions
+   = help: the `proc_macro_derive` attribute can only be applied to functions
 
-error: `#[proc_macro_derive]` attribute cannot be used on type aliases
-  --> $DIR/issue-43106-gating-of-proc_macro_derive.rs:22:5
+error: the `proc_macro_derive` attribute cannot be used on type aliases
+  --> $DIR/issue-43106-gating-of-proc_macro_derive.rs:22:7
    |
 LL |     #[proc_macro_derive(Test)] type T = S;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^^
    |
-   = help: `#[proc_macro_derive]` can only be applied to functions
+   = help: the `proc_macro_derive` attribute can only be applied to functions
 
-error: `#[proc_macro_derive]` attribute cannot be used on inherent impl blocks
-  --> $DIR/issue-43106-gating-of-proc_macro_derive.rs:25:5
+error: the `proc_macro_derive` attribute cannot be used on inherent impl blocks
+  --> $DIR/issue-43106-gating-of-proc_macro_derive.rs:25:7
    |
 LL |     #[proc_macro_derive(Test)] impl S { }
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^^
    |
-   = help: `#[proc_macro_derive]` can only be applied to functions
+   = help: the `proc_macro_derive` attribute can only be applied to functions
 
 error: aborting due to 7 previous errors
 

--- a/tests/ui/feature-gates/issue-43106-gating-of-stable.stderr
+++ b/tests/ui/feature-gates/issue-43106-gating-of-stable.stderr
@@ -1,15 +1,15 @@
 error[E0658]: stability attributes may not be used outside of the standard library
+  --> $DIR/issue-43106-gating-of-stable.rs:7:4
+   |
+LL | #![stable()]
+   |    ^^^^^^
+
+error[E0546]: missing 'feature'
   --> $DIR/issue-43106-gating-of-stable.rs:7:1
    |
 LL | #![stable()]
    | ^^^^^^^^^^^^
 
-error[E0546]: missing 'feature'
-  --> $DIR/issue-43106-gating-of-stable.rs:7:1
-   |
-LL | #![stable()]
-   | ^^^^^^^^^^^^
-
 error[E0542]: missing 'since'
   --> $DIR/issue-43106-gating-of-stable.rs:7:1
    |
@@ -17,17 +17,17 @@ LL | #![stable()]
    | ^^^^^^^^^^^^
 
 error[E0658]: stability attributes may not be used outside of the standard library
+  --> $DIR/issue-43106-gating-of-stable.rs:12:3
+   |
+LL | #[stable()]
+   |   ^^^^^^
+
+error[E0546]: missing 'feature'
   --> $DIR/issue-43106-gating-of-stable.rs:12:1
    |
 LL | #[stable()]
    | ^^^^^^^^^^^
 
-error[E0546]: missing 'feature'
-  --> $DIR/issue-43106-gating-of-stable.rs:12:1
-   |
-LL | #[stable()]
-   | ^^^^^^^^^^^
-
 error[E0542]: missing 'since'
   --> $DIR/issue-43106-gating-of-stable.rs:12:1
    |
@@ -35,17 +35,17 @@ LL | #[stable()]
    | ^^^^^^^^^^^
 
 error[E0658]: stability attributes may not be used outside of the standard library
+  --> $DIR/issue-43106-gating-of-stable.rs:18:12
+   |
+LL |         #![stable()]
+   |            ^^^^^^
+
+error[E0546]: missing 'feature'
   --> $DIR/issue-43106-gating-of-stable.rs:18:9
    |
 LL |         #![stable()]
    |         ^^^^^^^^^^^^
 
-error[E0546]: missing 'feature'
-  --> $DIR/issue-43106-gating-of-stable.rs:18:9
-   |
-LL |         #![stable()]
-   |         ^^^^^^^^^^^^
-
 error[E0542]: missing 'since'
   --> $DIR/issue-43106-gating-of-stable.rs:18:9
    |
@@ -53,10 +53,10 @@ LL |         #![stable()]
    |         ^^^^^^^^^^^^
 
 error[E0658]: stability attributes may not be used outside of the standard library
-  --> $DIR/issue-43106-gating-of-stable.rs:24:5
+  --> $DIR/issue-43106-gating-of-stable.rs:24:7
    |
 LL |     #[stable()]
-   |     ^^^^^^^^^^^
+   |       ^^^^^^
 
 error[E0546]: missing 'feature'
   --> $DIR/issue-43106-gating-of-stable.rs:24:5
@@ -71,10 +71,10 @@ LL |     #[stable()]
    |     ^^^^^^^^^^^
 
 error[E0658]: stability attributes may not be used outside of the standard library
-  --> $DIR/issue-43106-gating-of-stable.rs:30:5
+  --> $DIR/issue-43106-gating-of-stable.rs:30:7
    |
 LL |     #[stable()]
-   |     ^^^^^^^^^^^
+   |       ^^^^^^
 
 error[E0546]: missing 'feature'
   --> $DIR/issue-43106-gating-of-stable.rs:30:5
@@ -89,10 +89,10 @@ LL |     #[stable()]
    |     ^^^^^^^^^^^
 
 error[E0658]: stability attributes may not be used outside of the standard library
-  --> $DIR/issue-43106-gating-of-stable.rs:36:5
+  --> $DIR/issue-43106-gating-of-stable.rs:36:7
    |
 LL |     #[stable()]
-   |     ^^^^^^^^^^^
+   |       ^^^^^^
 
 error[E0546]: missing 'feature'
   --> $DIR/issue-43106-gating-of-stable.rs:36:5
@@ -107,10 +107,10 @@ LL |     #[stable()]
    |     ^^^^^^^^^^^
 
 error[E0658]: stability attributes may not be used outside of the standard library
-  --> $DIR/issue-43106-gating-of-stable.rs:42:5
+  --> $DIR/issue-43106-gating-of-stable.rs:42:7
    |
 LL |     #[stable()]
-   |     ^^^^^^^^^^^
+   |       ^^^^^^
 
 error[E0546]: missing 'feature'
   --> $DIR/issue-43106-gating-of-stable.rs:42:5

--- a/tests/ui/feature-gates/issue-43106-gating-of-unstable.stderr
+++ b/tests/ui/feature-gates/issue-43106-gating-of-unstable.stderr
@@ -1,15 +1,15 @@
 error[E0658]: stability attributes may not be used outside of the standard library
+  --> $DIR/issue-43106-gating-of-unstable.rs:7:4
+   |
+LL | #![unstable()]
+   |    ^^^^^^^^
+
+error[E0546]: missing 'feature'
   --> $DIR/issue-43106-gating-of-unstable.rs:7:1
    |
 LL | #![unstable()]
    | ^^^^^^^^^^^^^^
 
-error[E0546]: missing 'feature'
-  --> $DIR/issue-43106-gating-of-unstable.rs:7:1
-   |
-LL | #![unstable()]
-   | ^^^^^^^^^^^^^^
-
 error[E0547]: missing 'issue'
   --> $DIR/issue-43106-gating-of-unstable.rs:7:1
    |
@@ -17,17 +17,17 @@ LL | #![unstable()]
    | ^^^^^^^^^^^^^^
 
 error[E0658]: stability attributes may not be used outside of the standard library
+  --> $DIR/issue-43106-gating-of-unstable.rs:12:3
+   |
+LL | #[unstable()]
+   |   ^^^^^^^^
+
+error[E0546]: missing 'feature'
   --> $DIR/issue-43106-gating-of-unstable.rs:12:1
    |
 LL | #[unstable()]
    | ^^^^^^^^^^^^^
 
-error[E0546]: missing 'feature'
-  --> $DIR/issue-43106-gating-of-unstable.rs:12:1
-   |
-LL | #[unstable()]
-   | ^^^^^^^^^^^^^
-
 error[E0547]: missing 'issue'
   --> $DIR/issue-43106-gating-of-unstable.rs:12:1
    |
@@ -35,17 +35,17 @@ LL | #[unstable()]
    | ^^^^^^^^^^^^^
 
 error[E0658]: stability attributes may not be used outside of the standard library
+  --> $DIR/issue-43106-gating-of-unstable.rs:18:12
+   |
+LL |         #![unstable()]
+   |            ^^^^^^^^
+
+error[E0546]: missing 'feature'
   --> $DIR/issue-43106-gating-of-unstable.rs:18:9
    |
 LL |         #![unstable()]
    |         ^^^^^^^^^^^^^^
 
-error[E0546]: missing 'feature'
-  --> $DIR/issue-43106-gating-of-unstable.rs:18:9
-   |
-LL |         #![unstable()]
-   |         ^^^^^^^^^^^^^^
-
 error[E0547]: missing 'issue'
   --> $DIR/issue-43106-gating-of-unstable.rs:18:9
    |
@@ -53,10 +53,10 @@ LL |         #![unstable()]
    |         ^^^^^^^^^^^^^^
 
 error[E0658]: stability attributes may not be used outside of the standard library
-  --> $DIR/issue-43106-gating-of-unstable.rs:24:5
+  --> $DIR/issue-43106-gating-of-unstable.rs:24:7
    |
 LL |     #[unstable()]
-   |     ^^^^^^^^^^^^^
+   |       ^^^^^^^^
 
 error[E0546]: missing 'feature'
   --> $DIR/issue-43106-gating-of-unstable.rs:24:5
@@ -71,10 +71,10 @@ LL |     #[unstable()]
    |     ^^^^^^^^^^^^^
 
 error[E0658]: stability attributes may not be used outside of the standard library
-  --> $DIR/issue-43106-gating-of-unstable.rs:30:5
+  --> $DIR/issue-43106-gating-of-unstable.rs:30:7
    |
 LL |     #[unstable()]
-   |     ^^^^^^^^^^^^^
+   |       ^^^^^^^^
 
 error[E0546]: missing 'feature'
   --> $DIR/issue-43106-gating-of-unstable.rs:30:5
@@ -89,10 +89,10 @@ LL |     #[unstable()]
    |     ^^^^^^^^^^^^^
 
 error[E0658]: stability attributes may not be used outside of the standard library
-  --> $DIR/issue-43106-gating-of-unstable.rs:36:5
+  --> $DIR/issue-43106-gating-of-unstable.rs:36:7
    |
 LL |     #[unstable()]
-   |     ^^^^^^^^^^^^^
+   |       ^^^^^^^^
 
 error[E0546]: missing 'feature'
   --> $DIR/issue-43106-gating-of-unstable.rs:36:5
@@ -107,10 +107,10 @@ LL |     #[unstable()]
    |     ^^^^^^^^^^^^^
 
 error[E0658]: stability attributes may not be used outside of the standard library
-  --> $DIR/issue-43106-gating-of-unstable.rs:42:5
+  --> $DIR/issue-43106-gating-of-unstable.rs:42:7
    |
 LL |     #[unstable()]
-   |     ^^^^^^^^^^^^^
+   |       ^^^^^^^^
 
 error[E0546]: missing 'feature'
   --> $DIR/issue-43106-gating-of-unstable.rs:42:5

--- a/tests/ui/ffi-attrs/ffi_const.stderr
+++ b/tests/ui/ffi-attrs/ffi_const.stderr
@@ -1,26 +1,26 @@
-error: `#[ffi_const]` attribute cannot be used on functions
-  --> $DIR/ffi_const.rs:4:1
+error: the `ffi_const` attribute cannot be used on functions
+  --> $DIR/ffi_const.rs:4:10
    |
 LL | #[unsafe(ffi_const)]
-   | ^^^^^^^^^^^^^^^^^^^^
+   |          ^^^^^^^^^
    |
-   = help: `#[ffi_const]` can only be applied to foreign functions
+   = help: the `ffi_const` attribute can only be applied to foreign functions
 
-error: `#[ffi_const]` attribute cannot be used on macro defs
-  --> $DIR/ffi_const.rs:7:1
+error: the `ffi_const` attribute cannot be used on macro defs
+  --> $DIR/ffi_const.rs:7:10
    |
 LL | #[unsafe(ffi_const)]
-   | ^^^^^^^^^^^^^^^^^^^^
+   |          ^^^^^^^^^
    |
-   = help: `#[ffi_const]` can only be applied to foreign functions
+   = help: the `ffi_const` attribute can only be applied to foreign functions
 
-error: `#[ffi_const]` attribute cannot be used on foreign statics
-  --> $DIR/ffi_const.rs:13:5
+error: the `ffi_const` attribute cannot be used on foreign statics
+  --> $DIR/ffi_const.rs:13:14
    |
 LL |     #[unsafe(ffi_const)]
-   |     ^^^^^^^^^^^^^^^^^^^^
+   |              ^^^^^^^^^
    |
-   = help: `#[ffi_const]` can only be applied to foreign functions
+   = help: the `ffi_const` attribute can only be applied to foreign functions
 
 error: unsafe attribute used without unsafe
   --> $DIR/ffi_const.rs:16:7

--- a/tests/ui/ffi-attrs/ffi_pure.stderr
+++ b/tests/ui/ffi-attrs/ffi_pure.stderr
@@ -1,26 +1,26 @@
-error: `#[ffi_pure]` attribute cannot be used on functions
-  --> $DIR/ffi_pure.rs:4:1
+error: the `ffi_pure` attribute cannot be used on functions
+  --> $DIR/ffi_pure.rs:4:10
    |
 LL | #[unsafe(ffi_pure)]
-   | ^^^^^^^^^^^^^^^^^^^
+   |          ^^^^^^^^
    |
-   = help: `#[ffi_pure]` can only be applied to foreign functions
+   = help: the `ffi_pure` attribute can only be applied to foreign functions
 
-error: `#[ffi_pure]` attribute cannot be used on macro defs
-  --> $DIR/ffi_pure.rs:7:1
+error: the `ffi_pure` attribute cannot be used on macro defs
+  --> $DIR/ffi_pure.rs:7:10
    |
 LL | #[unsafe(ffi_pure)]
-   | ^^^^^^^^^^^^^^^^^^^
+   |          ^^^^^^^^
    |
-   = help: `#[ffi_pure]` can only be applied to foreign functions
+   = help: the `ffi_pure` attribute can only be applied to foreign functions
 
-error: `#[ffi_pure]` attribute cannot be used on foreign statics
-  --> $DIR/ffi_pure.rs:13:5
+error: the `ffi_pure` attribute cannot be used on foreign statics
+  --> $DIR/ffi_pure.rs:13:14
    |
 LL |     #[unsafe(ffi_pure)]
-   |     ^^^^^^^^^^^^^^^^^^^
+   |              ^^^^^^^^
    |
-   = help: `#[ffi_pure]` can only be applied to foreign functions
+   = help: the `ffi_pure` attribute can only be applied to foreign functions
 
 error: unsafe attribute used without unsafe
   --> $DIR/ffi_pure.rs:16:7

--- a/tests/ui/force-inlining/gate.rs
+++ b/tests/ui/force-inlining/gate.rs
@@ -3,14 +3,14 @@
 
 #[rustc_force_inline]
 //~^ ERROR use of an internal attribute [E0658]
-//~| NOTE the `#[rustc_force_inline]` attribute is an internal implementation detail that will never be stable
-//~| NOTE `#[rustc_force_inline]` forces a free function to be inlined
+//~| NOTE the `rustc_force_inline` attribute is an internal implementation detail that will never be stable
+//~| NOTE the `rustc_force_inline` attribute forces a free function to be inlined
 pub fn bare() {
 }
 
 #[rustc_force_inline = "the test requires it"]
 //~^ ERROR use of an internal attribute [E0658]
-//~| NOTE the `#[rustc_force_inline]` attribute is an internal implementation detail that will never be stable
-//~| NOTE `#[rustc_force_inline]` forces a free function to be inlined
+//~| NOTE the `rustc_force_inline` attribute is an internal implementation detail that will never be stable
+//~| NOTE the `rustc_force_inline` attribute forces a free function to be inlined
 pub fn justified() {
 }

--- a/tests/ui/force-inlining/gate.stderr
+++ b/tests/ui/force-inlining/gate.stderr
@@ -1,22 +1,22 @@
 error[E0658]: use of an internal attribute
-  --> $DIR/gate.rs:4:1
+  --> $DIR/gate.rs:4:3
    |
 LL | #[rustc_force_inline]
-   | ^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable
-   = note: the `#[rustc_force_inline]` attribute is an internal implementation detail that will never be stable
-   = note: `#[rustc_force_inline]` forces a free function to be inlined
+   = note: the `rustc_force_inline` attribute is an internal implementation detail that will never be stable
+   = note: the `rustc_force_inline` attribute forces a free function to be inlined
 
 error[E0658]: use of an internal attribute
-  --> $DIR/gate.rs:11:1
+  --> $DIR/gate.rs:11:3
    |
 LL | #[rustc_force_inline = "the test requires it"]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable
-   = note: the `#[rustc_force_inline]` attribute is an internal implementation detail that will never be stable
-   = note: `#[rustc_force_inline]` forces a free function to be inlined
+   = note: the `rustc_force_inline` attribute is an internal implementation detail that will never be stable
+   = note: the `rustc_force_inline` attribute forces a free function to be inlined
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/force-inlining/invalid.stderr
+++ b/tests/ui/force-inlining/invalid.stderr
@@ -64,237 +64,237 @@ LL - #[rustc_force_inline = 2]
 LL + #[rustc_force_inline]
    |
 
-error: `#[rustc_force_inline]` attribute cannot be used on extern crates
-  --> $DIR/invalid.rs:30:1
+error: the `rustc_force_inline` attribute cannot be used on extern crates
+  --> $DIR/invalid.rs:30:3
    |
 LL | #[rustc_force_inline]
-   | ^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_force_inline]` can only be applied to functions
+   = help: the `rustc_force_inline` attribute can only be applied to functions
 
-error: `#[rustc_force_inline]` attribute cannot be used on use statements
-  --> $DIR/invalid.rs:34:1
+error: the `rustc_force_inline` attribute cannot be used on use statements
+  --> $DIR/invalid.rs:34:3
    |
 LL | #[rustc_force_inline]
-   | ^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_force_inline]` can only be applied to functions
+   = help: the `rustc_force_inline` attribute can only be applied to functions
 
-error: `#[rustc_force_inline]` attribute cannot be used on statics
-  --> $DIR/invalid.rs:38:1
+error: the `rustc_force_inline` attribute cannot be used on statics
+  --> $DIR/invalid.rs:38:3
    |
 LL | #[rustc_force_inline]
-   | ^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_force_inline]` can only be applied to functions
+   = help: the `rustc_force_inline` attribute can only be applied to functions
 
-error: `#[rustc_force_inline]` attribute cannot be used on constants
-  --> $DIR/invalid.rs:42:1
+error: the `rustc_force_inline` attribute cannot be used on constants
+  --> $DIR/invalid.rs:42:3
    |
 LL | #[rustc_force_inline]
-   | ^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_force_inline]` can only be applied to functions
+   = help: the `rustc_force_inline` attribute can only be applied to functions
 
-error: `#[rustc_force_inline]` attribute cannot be used on modules
-  --> $DIR/invalid.rs:46:1
+error: the `rustc_force_inline` attribute cannot be used on modules
+  --> $DIR/invalid.rs:46:3
    |
 LL | #[rustc_force_inline]
-   | ^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_force_inline]` can only be applied to functions
+   = help: the `rustc_force_inline` attribute can only be applied to functions
 
-error: `#[rustc_force_inline]` attribute cannot be used on foreign modules
-  --> $DIR/invalid.rs:50:1
+error: the `rustc_force_inline` attribute cannot be used on foreign modules
+  --> $DIR/invalid.rs:50:3
    |
 LL | #[rustc_force_inline]
-   | ^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_force_inline]` can only be applied to functions
+   = help: the `rustc_force_inline` attribute can only be applied to functions
 
-error: `#[rustc_force_inline]` attribute cannot be used on foreign statics
-  --> $DIR/invalid.rs:53:5
+error: the `rustc_force_inline` attribute cannot be used on foreign statics
+  --> $DIR/invalid.rs:53:7
    |
 LL |     #[rustc_force_inline]
-   |     ^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_force_inline]` can only be applied to functions
+   = help: the `rustc_force_inline` attribute can only be applied to functions
 
-error: `#[rustc_force_inline]` attribute cannot be used on foreign types
-  --> $DIR/invalid.rs:57:5
+error: the `rustc_force_inline` attribute cannot be used on foreign types
+  --> $DIR/invalid.rs:57:7
    |
 LL |     #[rustc_force_inline]
-   |     ^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_force_inline]` can only be applied to functions
+   = help: the `rustc_force_inline` attribute can only be applied to functions
 
-error: `#[rustc_force_inline]` attribute cannot be used on foreign functions
-  --> $DIR/invalid.rs:61:5
+error: the `rustc_force_inline` attribute cannot be used on foreign functions
+  --> $DIR/invalid.rs:61:7
    |
 LL |     #[rustc_force_inline]
-   |     ^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_force_inline]` can only be applied to functions with a body
+   = help: the `rustc_force_inline` attribute can only be applied to functions with a body
 
-error: `#[rustc_force_inline]` attribute cannot be used on type aliases
-  --> $DIR/invalid.rs:66:1
+error: the `rustc_force_inline` attribute cannot be used on type aliases
+  --> $DIR/invalid.rs:66:3
    |
 LL | #[rustc_force_inline]
-   | ^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_force_inline]` can only be applied to functions
+   = help: the `rustc_force_inline` attribute can only be applied to functions
 
-error: `#[rustc_force_inline]` attribute cannot be used on enums
-  --> $DIR/invalid.rs:70:1
+error: the `rustc_force_inline` attribute cannot be used on enums
+  --> $DIR/invalid.rs:70:3
    |
 LL | #[rustc_force_inline]
-   | ^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_force_inline]` can only be applied to functions
+   = help: the `rustc_force_inline` attribute can only be applied to functions
 
-error: `#[rustc_force_inline]` attribute cannot be used on type parameters
-  --> $DIR/invalid.rs:72:10
+error: the `rustc_force_inline` attribute cannot be used on type parameters
+  --> $DIR/invalid.rs:72:12
    |
 LL | enum Bar<#[rustc_force_inline] T> {
-   |          ^^^^^^^^^^^^^^^^^^^^^
+   |            ^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_force_inline]` can only be applied to functions
+   = help: the `rustc_force_inline` attribute can only be applied to functions
 
-error: `#[rustc_force_inline]` attribute cannot be used on enum variants
-  --> $DIR/invalid.rs:74:5
+error: the `rustc_force_inline` attribute cannot be used on enum variants
+  --> $DIR/invalid.rs:74:7
    |
 LL |     #[rustc_force_inline]
-   |     ^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_force_inline]` can only be applied to functions
+   = help: the `rustc_force_inline` attribute can only be applied to functions
 
-error: `#[rustc_force_inline]` attribute cannot be used on structs
-  --> $DIR/invalid.rs:79:1
+error: the `rustc_force_inline` attribute cannot be used on structs
+  --> $DIR/invalid.rs:79:3
    |
 LL | #[rustc_force_inline]
-   | ^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_force_inline]` can only be applied to functions
+   = help: the `rustc_force_inline` attribute can only be applied to functions
 
-error: `#[rustc_force_inline]` attribute cannot be used on struct fields
-  --> $DIR/invalid.rs:82:5
+error: the `rustc_force_inline` attribute cannot be used on struct fields
+  --> $DIR/invalid.rs:82:7
    |
 LL |     #[rustc_force_inline]
-   |     ^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_force_inline]` can only be applied to functions
+   = help: the `rustc_force_inline` attribute can only be applied to functions
 
-error: `#[rustc_force_inline]` attribute cannot be used on unions
-  --> $DIR/invalid.rs:87:1
+error: the `rustc_force_inline` attribute cannot be used on unions
+  --> $DIR/invalid.rs:87:3
    |
 LL | #[rustc_force_inline]
-   | ^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_force_inline]` can only be applied to functions
+   = help: the `rustc_force_inline` attribute can only be applied to functions
 
-error: `#[rustc_force_inline]` attribute cannot be used on traits
-  --> $DIR/invalid.rs:94:1
+error: the `rustc_force_inline` attribute cannot be used on traits
+  --> $DIR/invalid.rs:94:3
    |
 LL | #[rustc_force_inline]
-   | ^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_force_inline]` can only be applied to functions
+   = help: the `rustc_force_inline` attribute can only be applied to functions
 
-error: `#[rustc_force_inline]` attribute cannot be used on associated types
-  --> $DIR/invalid.rs:97:5
+error: the `rustc_force_inline` attribute cannot be used on associated types
+  --> $DIR/invalid.rs:97:7
    |
 LL |     #[rustc_force_inline]
-   |     ^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_force_inline]` can only be applied to functions
+   = help: the `rustc_force_inline` attribute can only be applied to functions
 
-error: `#[rustc_force_inline]` attribute cannot be used on associated consts
-  --> $DIR/invalid.rs:100:5
+error: the `rustc_force_inline` attribute cannot be used on associated consts
+  --> $DIR/invalid.rs:100:7
    |
 LL |     #[rustc_force_inline]
-   |     ^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_force_inline]` can only be applied to functions
+   = help: the `rustc_force_inline` attribute can only be applied to functions
 
-error: `#[rustc_force_inline]` attribute cannot be used on provided trait methods
-  --> $DIR/invalid.rs:104:5
+error: the `rustc_force_inline` attribute cannot be used on provided trait methods
+  --> $DIR/invalid.rs:104:7
    |
 LL |     #[rustc_force_inline]
-   |     ^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_force_inline]` can be applied to functions and inherent methods
+   = help: the `rustc_force_inline` attribute can be applied to functions and inherent methods
 
-error: `#[rustc_force_inline]` attribute cannot be used on trait aliases
-  --> $DIR/invalid.rs:109:1
+error: the `rustc_force_inline` attribute cannot be used on trait aliases
+  --> $DIR/invalid.rs:109:3
    |
 LL | #[rustc_force_inline]
-   | ^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_force_inline]` can only be applied to functions
+   = help: the `rustc_force_inline` attribute can only be applied to functions
 
-error: `#[rustc_force_inline]` attribute cannot be used on inherent impl blocks
-  --> $DIR/invalid.rs:113:1
+error: the `rustc_force_inline` attribute cannot be used on inherent impl blocks
+  --> $DIR/invalid.rs:113:3
    |
 LL | #[rustc_force_inline]
-   | ^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_force_inline]` can only be applied to functions
+   = help: the `rustc_force_inline` attribute can only be applied to functions
 
-error: `#[rustc_force_inline]` attribute cannot be used on trait impl blocks
-  --> $DIR/invalid.rs:120:1
+error: the `rustc_force_inline` attribute cannot be used on trait impl blocks
+  --> $DIR/invalid.rs:120:3
    |
 LL | #[rustc_force_inline]
-   | ^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_force_inline]` can only be applied to functions
+   = help: the `rustc_force_inline` attribute can only be applied to functions
 
-error: `#[rustc_force_inline]` attribute cannot be used on macro defs
-  --> $DIR/invalid.rs:127:1
+error: the `rustc_force_inline` attribute cannot be used on macro defs
+  --> $DIR/invalid.rs:127:3
    |
 LL | #[rustc_force_inline]
-   | ^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_force_inline]` can only be applied to functions
+   = help: the `rustc_force_inline` attribute can only be applied to functions
 
-error: `#[rustc_force_inline]` attribute cannot be used on function params
-  --> $DIR/invalid.rs:131:11
+error: the `rustc_force_inline` attribute cannot be used on function params
+  --> $DIR/invalid.rs:131:13
    |
 LL | fn barqux(#[rustc_force_inline] _x: u32) {}
-   |           ^^^^^^^^^^^^^^^^^^^^^
+   |             ^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_force_inline]` can only be applied to functions
+   = help: the `rustc_force_inline` attribute can only be applied to functions
 
-error: `#[rustc_force_inline]` attribute cannot be used on closures
-  --> $DIR/invalid.rs:148:14
+error: the `rustc_force_inline` attribute cannot be used on closures
+  --> $DIR/invalid.rs:148:16
    |
 LL |     let _x = #[rustc_force_inline] || { };
-   |              ^^^^^^^^^^^^^^^^^^^^^
+   |                ^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_force_inline]` can be applied to functions and inherent methods
+   = help: the `rustc_force_inline` attribute can be applied to functions and inherent methods
 
-error: `#[rustc_force_inline]` attribute cannot be used on expressions
-  --> $DIR/invalid.rs:150:14
+error: the `rustc_force_inline` attribute cannot be used on expressions
+  --> $DIR/invalid.rs:150:16
    |
 LL |     let _y = #[rustc_force_inline] 3 + 4;
-   |              ^^^^^^^^^^^^^^^^^^^^^
+   |                ^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_force_inline]` can only be applied to functions
+   = help: the `rustc_force_inline` attribute can only be applied to functions
 
-error: `#[rustc_force_inline]` attribute cannot be used on statements
-  --> $DIR/invalid.rs:152:5
+error: the `rustc_force_inline` attribute cannot be used on statements
+  --> $DIR/invalid.rs:152:7
    |
 LL |     #[rustc_force_inline]
-   |     ^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_force_inline]` can only be applied to functions
+   = help: the `rustc_force_inline` attribute can only be applied to functions
 
-error: `#[rustc_force_inline]` attribute cannot be used on match arms
-  --> $DIR/invalid.rs:157:9
+error: the `rustc_force_inline` attribute cannot be used on match arms
+  --> $DIR/invalid.rs:157:11
    |
 LL |         #[rustc_force_inline]
-   |         ^^^^^^^^^^^^^^^^^^^^^
+   |           ^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_force_inline]` can only be applied to functions
+   = help: the `rustc_force_inline` attribute can only be applied to functions
 
 error: attribute cannot be applied to a `async`, `gen` or `async gen` function
   --> $DIR/invalid.rs:135:1

--- a/tests/ui/force-inlining/invalid.stderr
+++ b/tests/ui/force-inlining/invalid.stderr
@@ -5,10 +5,10 @@ LL | fn barqux(#[rustc_force_inline] _x: u32) {}
    |           ^^^^^^^^^^^^^^^^^^^^^
 
 error[E0805]: malformed `rustc_force_inline` attribute input
-  --> $DIR/invalid.rs:15:1
+  --> $DIR/invalid.rs:15:3
    |
 LL | #[rustc_force_inline(bar, baz)]
-   | ^^^^^^^^^^^^^^^^^^^^----------^
+   |   ^^^^^^^^^^^^^^^^^^----------
    |                     |
    |                     expected a single argument here
    |
@@ -25,10 +25,10 @@ LL + #[rustc_force_inline]
    |
 
 error[E0539]: malformed `rustc_force_inline` attribute input
-  --> $DIR/invalid.rs:20:1
+  --> $DIR/invalid.rs:20:3
    |
 LL | #[rustc_force_inline(2)]
-   | ^^^^^^^^^^^^^^^^^^^^^-^^
+   |   ^^^^^^^^^^^^^^^^^^^-^
    |                      |
    |                      expected a string literal here
    |
@@ -45,10 +45,10 @@ LL + #[rustc_force_inline]
    |
 
 error[E0539]: malformed `rustc_force_inline` attribute input
-  --> $DIR/invalid.rs:25:1
+  --> $DIR/invalid.rs:25:3
    |
 LL | #[rustc_force_inline = 2]
-   | ^^^^^^^^^^^^^^^^^^^^^^^-^
+   |   ^^^^^^^^^^^^^^^^^^^^^-
    |                        |
    |                        expected a string literal here
    |

--- a/tests/ui/internal-lints/query_stability_incorrect.rs
+++ b/tests/ui/internal-lints/query_stability_incorrect.rs
@@ -3,7 +3,7 @@
 #![feature(rustc_attrs)]
 
 #[rustc_lint_query_instability]
-//~^ ERROR `#[rustc_lint_query_instability]` attribute cannot be used on structs
+//~^ ERROR the `rustc_lint_query_instability` attribute cannot be used on structs
 struct Foo;
 
 impl Foo {

--- a/tests/ui/internal-lints/query_stability_incorrect.stderr
+++ b/tests/ui/internal-lints/query_stability_incorrect.stderr
@@ -1,10 +1,10 @@
-error: `#[rustc_lint_query_instability]` attribute cannot be used on structs
-  --> $DIR/query_stability_incorrect.rs:5:1
+error: the `rustc_lint_query_instability` attribute cannot be used on structs
+  --> $DIR/query_stability_incorrect.rs:5:3
    |
 LL | #[rustc_lint_query_instability]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_lint_query_instability]` can only be applied to functions
+   = help: the `rustc_lint_query_instability` attribute can only be applied to functions
 
 error[E0565]: malformed `rustc_lint_query_instability` attribute input
   --> $DIR/query_stability_incorrect.rs:10:5

--- a/tests/ui/internal-lints/query_stability_incorrect.stderr
+++ b/tests/ui/internal-lints/query_stability_incorrect.stderr
@@ -7,10 +7,10 @@ LL | #[rustc_lint_query_instability]
    = help: the `rustc_lint_query_instability` attribute can only be applied to functions
 
 error[E0565]: malformed `rustc_lint_query_instability` attribute input
-  --> $DIR/query_stability_incorrect.rs:10:5
+  --> $DIR/query_stability_incorrect.rs:10:7
    |
 LL |     #[rustc_lint_query_instability(a)]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---^
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                   |
    |                                   didn't expect any arguments here
    |

--- a/tests/ui/internal/internal-unstable.stderr
+++ b/tests/ui/internal/internal-unstable.stderr
@@ -59,23 +59,23 @@ LL |     bar!(internal_unstable::unstable());
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = note: this error originates in the macro `foo` which comes from the expansion of the macro `bar` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-warning: `#[allow_internal_unstable]` attribute cannot be used on struct fields
-  --> $DIR/internal-unstable.rs:10:5
+warning: the `allow_internal_unstable` attribute cannot be used on struct fields
+  --> $DIR/internal-unstable.rs:10:7
    |
 LL |     #[allow_internal_unstable]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[allow_internal_unstable]` can be applied to functions and macro defs
+   = help: the `allow_internal_unstable` attribute can be applied to functions and macro defs
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: requested on the command line with `-W unused-attributes`
 
-warning: `#[allow_internal_unstable]` attribute cannot be used on match arms
-  --> $DIR/internal-unstable.rs:61:9
+warning: the `allow_internal_unstable` attribute cannot be used on match arms
+  --> $DIR/internal-unstable.rs:61:11
    |
 LL |         #[allow_internal_unstable]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |           ^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[allow_internal_unstable]` can be applied to functions and macro defs
+   = help: the `allow_internal_unstable` attribute can be applied to functions and macro defs
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 error: aborting due to 7 previous errors; 2 warnings emitted

--- a/tests/ui/intrinsics/incorrect-read_via_copy-defn.rs
+++ b/tests/ui/intrinsics/incorrect-read_via_copy-defn.rs
@@ -4,5 +4,5 @@ fn main() {
 }
 
 #[rustc_intrinsic]
-//~^ ERROR the `#[rustc_intrinsic]` attribute is used to declare intrinsics as function items
+//~^ ERROR the `rustc_intrinsic` attribute is used to declare intrinsics as function items
 unsafe fn read_via_copy() {}

--- a/tests/ui/intrinsics/incorrect-read_via_copy-defn.stderr
+++ b/tests/ui/intrinsics/incorrect-read_via_copy-defn.stderr
@@ -1,8 +1,8 @@
-error[E0658]: the `#[rustc_intrinsic]` attribute is used to declare intrinsics as function items
-  --> $DIR/incorrect-read_via_copy-defn.rs:6:1
+error[E0658]: the `rustc_intrinsic` attribute is used to declare intrinsics as function items
+  --> $DIR/incorrect-read_via_copy-defn.rs:6:3
    |
 LL | #[rustc_intrinsic]
-   | ^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(intrinsics)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date

--- a/tests/ui/intrinsics/incorrect-transmute.rs
+++ b/tests/ui/intrinsics/incorrect-transmute.rs
@@ -4,5 +4,5 @@ fn main() {
 }
 
 #[rustc_intrinsic]
-//~^ ERROR the `#[rustc_intrinsic]` attribute is used to declare intrinsics as function items
+//~^ ERROR the `rustc_intrinsic` attribute is used to declare intrinsics as function items
 unsafe fn transmute() {}

--- a/tests/ui/intrinsics/incorrect-transmute.stderr
+++ b/tests/ui/intrinsics/incorrect-transmute.stderr
@@ -1,8 +1,8 @@
-error[E0658]: the `#[rustc_intrinsic]` attribute is used to declare intrinsics as function items
-  --> $DIR/incorrect-transmute.rs:6:1
+error[E0658]: the `rustc_intrinsic` attribute is used to declare intrinsics as function items
+  --> $DIR/incorrect-transmute.rs:6:3
    |
 LL | #[rustc_intrinsic]
-   | ^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(intrinsics)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date

--- a/tests/ui/lang-items/issue-83471.stderr
+++ b/tests/ui/lang-items/issue-83471.stderr
@@ -26,37 +26,37 @@ LL | trait Fn {
    |         - this trait has 0 generic arguments
 
 error[E0658]: lang items are subject to change
-  --> $DIR/issue-83471.rs:8:1
+  --> $DIR/issue-83471.rs:8:3
    |
 LL | #[lang = "pointee_sized"]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^
    |
    = help: add `#![feature(lang_items)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: lang items are subject to change
-  --> $DIR/issue-83471.rs:12:1
+  --> $DIR/issue-83471.rs:12:3
    |
 LL | #[lang = "meta_sized"]
-   | ^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^
    |
    = help: add `#![feature(lang_items)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: lang items are subject to change
-  --> $DIR/issue-83471.rs:16:1
+  --> $DIR/issue-83471.rs:16:3
    |
 LL | #[lang = "sized"]
-   | ^^^^^^^^^^^^^^^^^
+   |   ^^^^
    |
    = help: add `#![feature(lang_items)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: lang items are subject to change
-  --> $DIR/issue-83471.rs:20:1
+  --> $DIR/issue-83471.rs:20:3
    |
 LL | #[lang = "fn"]
-   | ^^^^^^^^^^^^^^
+   |   ^^^^
    |
    = help: add `#![feature(lang_items)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date

--- a/tests/ui/layout/debug.stderr
+++ b/tests/ui/layout/debug.stderr
@@ -4,21 +4,21 @@ error: unions cannot have zero fields
 LL | union EmptyUnion {}
    | ^^^^^^^^^^^^^^^^^^^
 
-error: `#[rustc_dump_layout]` attribute cannot be used on constants
-  --> $DIR/debug.rs:71:1
+error: the `rustc_dump_layout` attribute cannot be used on constants
+  --> $DIR/debug.rs:71:3
    |
 LL | #[rustc_dump_layout(debug)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_dump_layout]` can be applied to data types and type aliases
+   = help: the `rustc_dump_layout` attribute can be applied to data types and type aliases
 
-error: `#[rustc_dump_layout]` attribute cannot be used on associated consts
-  --> $DIR/debug.rs:75:5
+error: the `rustc_dump_layout` attribute cannot be used on associated consts
+  --> $DIR/debug.rs:75:7
    |
 LL |     #[rustc_dump_layout(debug)]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_dump_layout]` can be applied to data types and type aliases
+   = help: the `rustc_dump_layout` attribute can be applied to data types and type aliases
 
 error: layout_of(E) = Layout {
            size: Size(12 bytes),

--- a/tests/ui/layout/thaw-transmute-invalid-enum.stderr
+++ b/tests/ui/layout/thaw-transmute-invalid-enum.stderr
@@ -9,13 +9,13 @@ help: you might be missing a type parameter
 LL | fn test<Subset>() {
    |        ++++++++
 
-error: `#[repr(packed)]` attribute cannot be used on enums
-  --> $DIR/thaw-transmute-invalid-enum.rs:22:1
+error: the `repr(packed)` attribute cannot be used on enums
+  --> $DIR/thaw-transmute-invalid-enum.rs:22:3
    |
 LL | #[repr(C, packed(2))]
-   | ^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[repr(packed)]` can be applied to structs and unions
+   = help: the `repr(packed)` attribute can be applied to structs and unions
 
 error[E0658]: use of unstable library feature `transmutability`
   --> $DIR/thaw-transmute-invalid-enum.rs:4:20

--- a/tests/ui/layout/thaw-validate-invalid-enum.stderr
+++ b/tests/ui/layout/thaw-validate-invalid-enum.stderr
@@ -1,10 +1,10 @@
-error: `#[repr(packed)]` attribute cannot be used on enums
-  --> $DIR/thaw-validate-invalid-enum.rs:3:1
+error: the `repr(packed)` attribute cannot be used on enums
+  --> $DIR/thaw-validate-invalid-enum.rs:3:3
    |
 LL | #[repr(packed)]
-   | ^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^
    |
-   = help: `#[repr(packed)]` can be applied to structs and unions
+   = help: the `repr(packed)` attribute can be applied to structs and unions
 
 error[E0740]: field must implement `Copy` or be wrapped in `ManuallyDrop<...>` to be used in a union
   --> $DIR/thaw-validate-invalid-enum.rs:14:9

--- a/tests/ui/link-native-libs/issue-43925.stderr
+++ b/tests/ui/link-native-libs/issue-43925.stderr
@@ -8,10 +8,10 @@ LL | #[link(name = "foo", cfg("rlib"))]
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0565]: malformed `link` attribute input
-  --> $DIR/issue-43925.rs:1:1
+  --> $DIR/issue-43925.rs:1:3
    |
 LL | #[link(name = "foo", cfg("rlib"))]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^------^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^------^^
    |                          |
    |                          expected a valid identifier here
    |

--- a/tests/ui/link-native-libs/issue-43926.stderr
+++ b/tests/ui/link-native-libs/issue-43926.stderr
@@ -1,8 +1,8 @@
 error[E0805]: malformed `link` attribute input
-  --> $DIR/issue-43926.rs:1:1
+  --> $DIR/issue-43926.rs:1:3
    |
 LL | #[link(name = "foo", cfg())]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^--^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^--^
    |                         |
    |                         expected an argument here
    |

--- a/tests/ui/link-native-libs/link-attr-validation-early.stderr
+++ b/tests/ui/link-native-libs/link-attr-validation-early.stderr
@@ -1,16 +1,16 @@
 error[E0539]: malformed `link` attribute input
-  --> $DIR/link-attr-validation-early.rs:2:1
+  --> $DIR/link-attr-validation-early.rs:2:3
    |
 LL | #[link]
-   | ^^^^^^^ expected this to be a list
+   |   ^^^^ expected this to be a list
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute>
 
 error[E0539]: malformed `link` attribute input
-  --> $DIR/link-attr-validation-early.rs:3:1
+  --> $DIR/link-attr-validation-early.rs:3:3
    |
 LL | #[link = "foo"]
-   | ^^^^^^^-------^
+   |   ^^^^^-------
    |        |
    |        expected this to be a list
    |

--- a/tests/ui/link-native-libs/link-attr-validation-late.stderr
+++ b/tests/ui/link-native-libs/link-attr-validation-late.stderr
@@ -1,178 +1,178 @@
 error[E0565]: malformed `link` attribute input
-  --> $DIR/link-attr-validation-late.rs:4:1
+  --> $DIR/link-attr-validation-late.rs:4:3
    |
 LL | #[link(name = "...", "literal")]
-   | ^^^^^^^^^^^^^^^^^^^^^---------^^
+   |   ^^^^^^^^^^^^^^^^^^^---------^
    |                      |
    |                      didn't expect a literal here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute>
 
 error[E0539]: malformed `link` attribute input
-  --> $DIR/link-attr-validation-late.rs:5:1
+  --> $DIR/link-attr-validation-late.rs:5:3
    |
 LL | #[link(name = "...", unknown)]
-   | ^^^^^^^^^^^^^^^^^^^^^-------^^
+   |   ^^^^^^^^^^^^^^^^^^^-------^
    |                      |
    |                      valid arguments are "name", "kind", "modifiers", "cfg", "wasm_import_module" or "import_name_type"
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute>
 
 error[E0538]: malformed `link` attribute input
-  --> $DIR/link-attr-validation-late.rs:9:1
+  --> $DIR/link-attr-validation-late.rs:9:3
    |
 LL | #[link(name = "foo", name = "bar")]
-   | ^^^^^^^^^^^^^^^^^^^^^------------^^
+   |   ^^^^^^^^^^^^^^^^^^^------------^
    |                      |
    |                      found `name` used as a key more than once
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute>
 
 error[E0538]: malformed `link` attribute input
-  --> $DIR/link-attr-validation-late.rs:10:1
+  --> $DIR/link-attr-validation-late.rs:10:3
    |
 LL | #[link(name = "...", kind = "dylib", kind = "bar")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------------^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------------^
    |                                      |
    |                                      found `kind` used as a key more than once
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute>
 
 error[E0538]: malformed `link` attribute input
-  --> $DIR/link-attr-validation-late.rs:11:1
+  --> $DIR/link-attr-validation-late.rs:11:3
    |
 LL | #[link(name = "...", modifiers = "+verbatim", modifiers = "bar")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-----------------^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-----------------^
    |                                               |
    |                                               found `modifiers` used as a key more than once
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute>
 
 error[E0538]: malformed `link` attribute input
-  --> $DIR/link-attr-validation-late.rs:12:1
+  --> $DIR/link-attr-validation-late.rs:12:3
    |
 LL | #[link(name = "...", cfg(false), cfg(false))]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^----------^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^----------^
    |                                  |
    |                                  found `cfg` used as a key more than once
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute>
 
 error[E0538]: malformed `link` attribute input
-  --> $DIR/link-attr-validation-late.rs:13:1
+  --> $DIR/link-attr-validation-late.rs:13:3
    |
 LL | #[link(wasm_import_module = "foo", wasm_import_module = "bar")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^--------------------------^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^--------------------------^
    |                                    |
    |                                    found `wasm_import_module` used as a key more than once
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute>
 
 error[E0539]: malformed `link` attribute input
-  --> $DIR/link-attr-validation-late.rs:17:1
+  --> $DIR/link-attr-validation-late.rs:17:3
    |
 LL | #[link(name)]
-   | ^^^^^^^----^^
+   |   ^^^^^----^
    |        |
    |        expected this to be of the form `name = "..."`
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute>
 
 error[E0539]: malformed `link` attribute input
-  --> $DIR/link-attr-validation-late.rs:18:1
+  --> $DIR/link-attr-validation-late.rs:18:3
    |
 LL | #[link(name())]
-   | ^^^^^^^------^^
+   |   ^^^^^------^
    |        |
    |        expected this to be of the form `name = "..."`
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute>
 
 error[E0539]: malformed `link` attribute input
-  --> $DIR/link-attr-validation-late.rs:19:1
+  --> $DIR/link-attr-validation-late.rs:19:3
    |
 LL | #[link(name = "...", kind)]
-   | ^^^^^^^^^^^^^^^^^^^^^----^^
+   |   ^^^^^^^^^^^^^^^^^^^----^
    |                      |
    |                      expected this to be of the form `kind = "..."`
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute>
 
 error[E0539]: malformed `link` attribute input
-  --> $DIR/link-attr-validation-late.rs:20:1
+  --> $DIR/link-attr-validation-late.rs:20:3
    |
 LL | #[link(name = "...", kind())]
-   | ^^^^^^^^^^^^^^^^^^^^^------^^
+   |   ^^^^^^^^^^^^^^^^^^^------^
    |                      |
    |                      expected this to be of the form `kind = "..."`
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute>
 
 error[E0539]: malformed `link` attribute input
-  --> $DIR/link-attr-validation-late.rs:21:1
+  --> $DIR/link-attr-validation-late.rs:21:3
    |
 LL | #[link(name = "...", modifiers)]
-   | ^^^^^^^^^^^^^^^^^^^^^---------^^
+   |   ^^^^^^^^^^^^^^^^^^^---------^
    |                      |
    |                      expected this to be of the form `modifiers = "..."`
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute>
 
 error[E0539]: malformed `link` attribute input
-  --> $DIR/link-attr-validation-late.rs:22:1
+  --> $DIR/link-attr-validation-late.rs:22:3
    |
 LL | #[link(name = "...", modifiers())]
-   | ^^^^^^^^^^^^^^^^^^^^^-----------^^
+   |   ^^^^^^^^^^^^^^^^^^^-----------^
    |                      |
    |                      expected this to be of the form `modifiers = "..."`
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute>
 
 error[E0539]: malformed `link` attribute input
-  --> $DIR/link-attr-validation-late.rs:23:1
+  --> $DIR/link-attr-validation-late.rs:23:3
    |
 LL | #[link(name = "...", cfg)]
-   | ^^^^^^^^^^^^^^^^^^^^^---^^
+   |   ^^^^^^^^^^^^^^^^^^^---^
    |                      |
    |                      expected this to be a list
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute>
 
 error[E0539]: malformed `link` attribute input
-  --> $DIR/link-attr-validation-late.rs:24:1
+  --> $DIR/link-attr-validation-late.rs:24:3
    |
 LL | #[link(name = "...", cfg = "literal")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^-----------^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^-----------^
    |                          |
    |                          expected this to be a list
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute>
 
 error[E0565]: malformed `link` attribute input
-  --> $DIR/link-attr-validation-late.rs:25:1
+  --> $DIR/link-attr-validation-late.rs:25:3
    |
 LL | #[link(name = "...", cfg("literal"))]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^---------^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^---------^^
    |                          |
    |                          expected a valid identifier here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute>
 
 error[E0539]: malformed `link` attribute input
-  --> $DIR/link-attr-validation-late.rs:26:1
+  --> $DIR/link-attr-validation-late.rs:26:3
    |
 LL | #[link(name = "...", wasm_import_module)]
-   | ^^^^^^^^^^^^^^^^^^^^^------------------^^
+   |   ^^^^^^^^^^^^^^^^^^^------------------^
    |                      |
    |                      expected this to be of the form `wasm_import_module = "..."`
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute>
 
 error[E0539]: malformed `link` attribute input
-  --> $DIR/link-attr-validation-late.rs:27:1
+  --> $DIR/link-attr-validation-late.rs:27:3
    |
 LL | #[link(name = "...", wasm_import_module())]
-   | ^^^^^^^^^^^^^^^^^^^^^--------------------^^
+   |   ^^^^^^^^^^^^^^^^^^^--------------------^
    |                      |
    |                      expected this to be of the form `wasm_import_module = "..."`
    |
@@ -191,10 +191,10 @@ LL | #[link(name = "...", modifiers = "no-plus-minus")]
    |                                  ^^^^^^^^^^^^^^^
 
 error[E0539]: malformed `link` attribute input
-  --> $DIR/link-attr-validation-late.rs:33:1
+  --> $DIR/link-attr-validation-late.rs:33:3
    |
 LL | #[link(name = "...", modifiers = "+unknown")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^----------^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^----------^
    |                                  |
    |                                  valid arguments are "bundle", "export-symbols", "verbatim", "whole-archive" or "as-needed"
    |

--- a/tests/ui/link-native-libs/modifiers-override-4.stderr
+++ b/tests/ui/link-native-libs/modifiers-override-4.stderr
@@ -1,7 +1,8 @@
 error[E0538]: malformed `link` attribute input
-  --> $DIR/modifiers-override-4.rs:2:1
+  --> $DIR/modifiers-override-4.rs:2:3
    |
-LL | / #[link(
+LL |   #[link(
+   |  ___^
 LL | |
 LL | |     name = "bar",
 LL | |     kind = "static",
@@ -9,7 +10,7 @@ LL | |     kind = "static",
 LL | |     modifiers = "+bundle"
    | |     --------------------- found `modifiers` used as a key more than once
 LL | | )]
-   | |__^
+   | |_^
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute>
 

--- a/tests/ui/linkage-attr/linkage3.stderr
+++ b/tests/ui/linkage-attr/linkage3.stderr
@@ -1,8 +1,8 @@
 error[E0539]: malformed `linkage` attribute input
-  --> $DIR/linkage3.rs:6:5
+  --> $DIR/linkage3.rs:6:7
    |
 LL |     #[linkage = "foo"]
-   |     ^^^^^^^^^^^^-----^
+   |       ^^^^^^^^^^-----
    |                 |
    |                 valid arguments are `available_externally`, `common`, `extern_weak`, `external`, `internal`, `linkonce`, `linkonce_odr`, `weak` or `weak_odr`
 

--- a/tests/ui/linkage-attr/linkage4.stderr
+++ b/tests/ui/linkage-attr/linkage4.stderr
@@ -1,8 +1,8 @@
 error[E0658]: the `linkage` attribute is experimental and not portable across platforms
-  --> $DIR/linkage4.rs:1:1
+  --> $DIR/linkage4.rs:1:3
    |
 LL | #[linkage = "external"]
-   | ^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^
    |
    = note: see issue #29603 <https://github.com/rust-lang/rust/issues/29603> for more information
    = help: add `#![feature(linkage)]` to the crate attributes to enable

--- a/tests/ui/linkage-attr/raw-dylib/windows/import-name-type-invalid-format.stderr
+++ b/tests/ui/linkage-attr/raw-dylib/windows/import-name-type-invalid-format.stderr
@@ -1,8 +1,8 @@
 error[E0539]: malformed `link` attribute input
-  --> $DIR/import-name-type-invalid-format.rs:9:1
+  --> $DIR/import-name-type-invalid-format.rs:9:3
    |
 LL | #[link(name = "foo", kind = "raw-dylib", import_name_type = 6)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-^
    |                                                             |
    |                                                             expected a string literal here
    |

--- a/tests/ui/linkage-attr/raw-dylib/windows/import-name-type-multiple.stderr
+++ b/tests/ui/linkage-attr/raw-dylib/windows/import-name-type-multiple.stderr
@@ -1,8 +1,8 @@
 error[E0538]: malformed `link` attribute input
-  --> $DIR/import-name-type-multiple.rs:10:1
+  --> $DIR/import-name-type-multiple.rs:10:3
    |
 LL | #[link(name = "foo", kind = "raw-dylib", import_name_type = "decorated", import_name_type = "decorated")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------------------------------^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------------------------------^
    |                                                                          |
    |                                                                          found `import_name_type` used as a key more than once
    |

--- a/tests/ui/linkage-attr/raw-dylib/windows/import-name-type-unknown-value.stderr
+++ b/tests/ui/linkage-attr/raw-dylib/windows/import-name-type-unknown-value.stderr
@@ -1,8 +1,8 @@
 error[E0539]: malformed `link` attribute input
-  --> $DIR/import-name-type-unknown-value.rs:9:1
+  --> $DIR/import-name-type-unknown-value.rs:9:3
    |
 LL | #[link(name = "foo", kind = "raw-dylib", import_name_type = "unknown")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^----------------------------^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^----------------------------^
    |                                          |
    |                                          valid arguments are "decorated", "noprefix" or "undecorated"
    |

--- a/tests/ui/linkage-attr/raw-dylib/windows/link-ordinal-invalid-format.stderr
+++ b/tests/ui/linkage-attr/raw-dylib/windows/link-ordinal-invalid-format.stderr
@@ -1,8 +1,8 @@
 error[E0539]: malformed `link_ordinal` attribute input
-  --> $DIR/link-ordinal-invalid-format.rs:3:5
+  --> $DIR/link-ordinal-invalid-format.rs:3:7
    |
 LL |     #[link_ordinal("JustMonika")]
-   |     ^^^^^^^^^^^^^^^------------^^
+   |       ^^^^^^^^^^^^^------------^
    |                    |
    |                    expected an integer literal here
    |
@@ -14,10 +14,10 @@ LL +     #[link_ordinal(ordinal)]
    |
 
 error[E0539]: malformed `link_ordinal` attribute input
-  --> $DIR/link-ordinal-invalid-format.rs:6:5
+  --> $DIR/link-ordinal-invalid-format.rs:6:7
    |
 LL |     #[link_ordinal("JustMonika")]
-   |     ^^^^^^^^^^^^^^^------------^^
+   |       ^^^^^^^^^^^^^------------^
    |                    |
    |                    expected an integer literal here
    |

--- a/tests/ui/linkage-attr/raw-dylib/windows/link-ordinal-missing-argument.stderr
+++ b/tests/ui/linkage-attr/raw-dylib/windows/link-ordinal-missing-argument.stderr
@@ -1,8 +1,8 @@
 error[E0805]: malformed `link_ordinal` attribute input
-  --> $DIR/link-ordinal-missing-argument.rs:3:5
+  --> $DIR/link-ordinal-missing-argument.rs:3:7
    |
 LL |     #[link_ordinal()]
-   |     ^^^^^^^^^^^^^^--^
+   |       ^^^^^^^^^^^^--
    |                   |
    |                   expected an argument here
    |
@@ -13,10 +13,10 @@ LL |     #[link_ordinal(ordinal)]
    |                    +++++++
 
 error[E0805]: malformed `link_ordinal` attribute input
-  --> $DIR/link-ordinal-missing-argument.rs:8:5
+  --> $DIR/link-ordinal-missing-argument.rs:8:7
    |
 LL |     #[link_ordinal()]
-   |     ^^^^^^^^^^^^^^--^
+   |       ^^^^^^^^^^^^--
    |                   |
    |                   expected an argument here
    |

--- a/tests/ui/linkage-attr/raw-dylib/windows/link-ordinal-not-foreign-fn.stderr
+++ b/tests/ui/linkage-attr/raw-dylib/windows/link-ordinal-not-foreign-fn.stderr
@@ -1,26 +1,26 @@
-error: `#[link_ordinal]` attribute cannot be used on structs
-  --> $DIR/link-ordinal-not-foreign-fn.rs:1:1
+error: the `link_ordinal` attribute cannot be used on structs
+  --> $DIR/link-ordinal-not-foreign-fn.rs:1:3
    |
 LL | #[link_ordinal(123)]
-   | ^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^
    |
-   = help: `#[link_ordinal]` can be applied to foreign functions and foreign statics
+   = help: the `link_ordinal` attribute can be applied to foreign functions and foreign statics
 
-error: `#[link_ordinal]` attribute cannot be used on functions
-  --> $DIR/link-ordinal-not-foreign-fn.rs:5:1
+error: the `link_ordinal` attribute cannot be used on functions
+  --> $DIR/link-ordinal-not-foreign-fn.rs:5:3
    |
 LL | #[link_ordinal(123)]
-   | ^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^
    |
-   = help: `#[link_ordinal]` can be applied to foreign functions and foreign statics
+   = help: the `link_ordinal` attribute can be applied to foreign functions and foreign statics
 
-error: `#[link_ordinal]` attribute cannot be used on statics
-  --> $DIR/link-ordinal-not-foreign-fn.rs:9:1
+error: the `link_ordinal` attribute cannot be used on statics
+  --> $DIR/link-ordinal-not-foreign-fn.rs:9:3
    |
 LL | #[link_ordinal(42)]
-   | ^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^
    |
-   = help: `#[link_ordinal]` can be applied to foreign functions and foreign statics
+   = help: the `link_ordinal` attribute can be applied to foreign functions and foreign statics
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/linkage-attr/raw-dylib/windows/link-ordinal-too-many-arguments.stderr
+++ b/tests/ui/linkage-attr/raw-dylib/windows/link-ordinal-too-many-arguments.stderr
@@ -1,8 +1,8 @@
 error[E0805]: malformed `link_ordinal` attribute input
-  --> $DIR/link-ordinal-too-many-arguments.rs:3:5
+  --> $DIR/link-ordinal-too-many-arguments.rs:3:7
    |
 LL |     #[link_ordinal(3, 4)]
-   |     ^^^^^^^^^^^^^^------^
+   |       ^^^^^^^^^^^^------
    |                   |
    |                   expected a single argument here
    |
@@ -14,10 +14,10 @@ LL +     #[link_ordinal(ordinal)]
    |
 
 error[E0805]: malformed `link_ordinal` attribute input
-  --> $DIR/link-ordinal-too-many-arguments.rs:8:5
+  --> $DIR/link-ordinal-too-many-arguments.rs:8:7
    |
 LL |     #[link_ordinal(3, 4)]
-   |     ^^^^^^^^^^^^^^------^
+   |       ^^^^^^^^^^^^------
    |                   |
    |                   expected a single argument here
    |

--- a/tests/ui/lint/fn_must_use.stderr
+++ b/tests/ui/lint/fn_must_use.stderr
@@ -1,10 +1,10 @@
-warning: `#[must_use]` attribute cannot be used on trait methods in impl blocks
-  --> $DIR/fn_must_use.rs:41:5
+warning: the `must_use` attribute cannot be used on trait methods in impl blocks
+  --> $DIR/fn_must_use.rs:41:7
    |
 LL |     #[must_use]
-   |     ^^^^^^^^^^^
+   |       ^^^^^^^^
    |
-   = help: `#[must_use]` can be applied to data types, foreign functions, functions, inherent methods, provided trait methods, required trait methods, and traits
+   = help: the `must_use` attribute can be applied to data types, foreign functions, functions, inherent methods, provided trait methods, required trait methods, and traits
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: requested on the command line with `-W unused-attributes`
 

--- a/tests/ui/lint/ice-const-prop-unions-known-panics-lint-123710.stderr
+++ b/tests/ui/lint/ice-const-prop-unions-known-panics-lint-123710.stderr
@@ -1,10 +1,10 @@
-error: `#[repr(packed)]` attribute cannot be used on enums
-  --> $DIR/ice-const-prop-unions-known-panics-lint-123710.rs:6:1
+error: the `repr(packed)` attribute cannot be used on enums
+  --> $DIR/ice-const-prop-unions-known-panics-lint-123710.rs:6:3
    |
 LL | #[repr(packed)]
-   | ^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^
    |
-   = help: `#[repr(packed)]` can be applied to structs and unions
+   = help: the `repr(packed)` attribute can be applied to structs and unions
 
 error[E0740]: field must implement `Copy` or be wrapped in `ManuallyDrop<...>` to be used in a union
   --> $DIR/ice-const-prop-unions-known-panics-lint-123710.rs:18:9

--- a/tests/ui/lint/inert-attr-macro.rs
+++ b/tests/ui/lint/inert-attr-macro.rs
@@ -7,13 +7,13 @@ macro_rules! foo {
 }
 
 fn main() {
-    #[inline] foo!(); //~ WARN `#[inline]` attribute cannot be used on macro calls
+    #[inline] foo!(); //~ WARN the `inline` attribute cannot be used on macro calls
     //~^ WARN previously accepted
 
     // This does nothing, since `#[allow(warnings)]` is itself
     // an inert attribute on a macro call
     #[allow(warnings)] #[inline] foo!(); //~ WARN unused attribute `allow`
-    //~^ WARN `#[inline]` attribute cannot be used on macro calls
+    //~^ WARN the `inline` attribute cannot be used on macro calls
     //~| WARN previously accepted
 
     // This does work, since the attribute is on a parent

--- a/tests/ui/lint/inert-attr-macro.stderr
+++ b/tests/ui/lint/inert-attr-macro.stderr
@@ -1,10 +1,10 @@
-warning: `#[inline]` attribute cannot be used on macro calls
-  --> $DIR/inert-attr-macro.rs:10:5
+warning: the `inline` attribute cannot be used on macro calls
+  --> $DIR/inert-attr-macro.rs:10:7
    |
 LL |     #[inline] foo!();
-   |     ^^^^^^^^^
+   |       ^^^^^^
    |
-   = help: `#[inline]` can only be applied to functions
+   = help: the `inline` attribute can only be applied to functions
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: placing this attribute on a macro invocation does nothing even if the macro expands to what would be a valid target for the attribute
 note: the lint level is defined here
@@ -26,13 +26,13 @@ note: the built-in attribute `allow` will be ignored, since it's applied to the 
 LL |     #[allow(warnings)] #[inline] foo!();
    |                                  ^^^
 
-warning: `#[inline]` attribute cannot be used on macro calls
-  --> $DIR/inert-attr-macro.rs:15:24
+warning: the `inline` attribute cannot be used on macro calls
+  --> $DIR/inert-attr-macro.rs:15:26
    |
 LL |     #[allow(warnings)] #[inline] foo!();
-   |                        ^^^^^^^^^
+   |                          ^^^^^^
    |
-   = help: `#[inline]` can only be applied to functions
+   = help: the `inline` attribute can only be applied to functions
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: placing this attribute on a macro invocation does nothing even if the macro expands to what would be a valid target for the attribute
 

--- a/tests/ui/lint/inline-trait-and-foreign-items.stderr
+++ b/tests/ui/lint/inline-trait-and-foreign-items.stderr
@@ -1,50 +1,50 @@
-error: `#[inline]` attribute cannot be used on associated types
-  --> $DIR/inline-trait-and-foreign-items.rs:11:5
+error: the `inline` attribute cannot be used on associated types
+  --> $DIR/inline-trait-and-foreign-items.rs:11:7
    |
 LL |     #[inline]
-   |     ^^^^^^^^^
+   |       ^^^^^^
    |
-   = help: `#[inline]` can only be applied to functions
+   = help: the `inline` attribute can only be applied to functions
 
-error: `#[inline]` attribute cannot be used on associated types
-  --> $DIR/inline-trait-and-foreign-items.rs:22:5
+error: the `inline` attribute cannot be used on associated types
+  --> $DIR/inline-trait-and-foreign-items.rs:22:7
    |
 LL |     #[inline]
-   |     ^^^^^^^^^
+   |       ^^^^^^
    |
-   = help: `#[inline]` can only be applied to functions
+   = help: the `inline` attribute can only be applied to functions
 
-error: `#[inline]` attribute cannot be used on associated types
-  --> $DIR/inline-trait-and-foreign-items.rs:25:5
+error: the `inline` attribute cannot be used on associated types
+  --> $DIR/inline-trait-and-foreign-items.rs:25:7
    |
 LL |     #[inline]
-   |     ^^^^^^^^^
+   |       ^^^^^^
    |
-   = help: `#[inline]` can only be applied to functions
+   = help: the `inline` attribute can only be applied to functions
 
-error: `#[inline]` attribute cannot be used on foreign statics
-  --> $DIR/inline-trait-and-foreign-items.rs:30:5
+error: the `inline` attribute cannot be used on foreign statics
+  --> $DIR/inline-trait-and-foreign-items.rs:30:7
    |
 LL |     #[inline]
-   |     ^^^^^^^^^
+   |       ^^^^^^
    |
-   = help: `#[inline]` can only be applied to functions
+   = help: the `inline` attribute can only be applied to functions
 
-error: `#[inline]` attribute cannot be used on foreign types
-  --> $DIR/inline-trait-and-foreign-items.rs:33:5
+error: the `inline` attribute cannot be used on foreign types
+  --> $DIR/inline-trait-and-foreign-items.rs:33:7
    |
 LL |     #[inline]
-   |     ^^^^^^^^^
+   |       ^^^^^^
    |
-   = help: `#[inline]` can only be applied to functions
+   = help: the `inline` attribute can only be applied to functions
 
-warning: `#[inline]` attribute cannot be used on associated consts
-  --> $DIR/inline-trait-and-foreign-items.rs:7:5
+warning: the `inline` attribute cannot be used on associated consts
+  --> $DIR/inline-trait-and-foreign-items.rs:7:7
    |
 LL |     #[inline]
-   |     ^^^^^^^^^
+   |       ^^^^^^
    |
-   = help: `#[inline]` can only be applied to functions
+   = help: the `inline` attribute can only be applied to functions
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 note: the lint level is defined here
   --> $DIR/inline-trait-and-foreign-items.rs:4:9
@@ -52,13 +52,13 @@ note: the lint level is defined here
 LL | #![warn(unused_attributes)]
    |         ^^^^^^^^^^^^^^^^^
 
-warning: `#[inline]` attribute cannot be used on associated consts
-  --> $DIR/inline-trait-and-foreign-items.rs:18:5
+warning: the `inline` attribute cannot be used on associated consts
+  --> $DIR/inline-trait-and-foreign-items.rs:18:7
    |
 LL |     #[inline]
-   |     ^^^^^^^^^
+   |       ^^^^^^
    |
-   = help: `#[inline]` can only be applied to functions
+   = help: the `inline` attribute can only be applied to functions
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 error: unconstrained opaque type

--- a/tests/ui/lint/must_not_suspend/feature-gate-must_not_suspend.rs
+++ b/tests/ui/lint/must_not_suspend/feature-gate-must_not_suspend.rs
@@ -1,6 +1,6 @@
 //@ edition:2018
 
-#[must_not_suspend = "You gotta use Umm's, ya know?"] //~ ERROR the `#[must_not_suspend]`
+#[must_not_suspend = "You gotta use Umm's, ya know?"] //~ ERROR the `must_not_suspend` attribute
 struct Umm {
     _i: i64
 }

--- a/tests/ui/lint/must_not_suspend/feature-gate-must_not_suspend.stderr
+++ b/tests/ui/lint/must_not_suspend/feature-gate-must_not_suspend.stderr
@@ -1,8 +1,8 @@
-error[E0658]: the `#[must_not_suspend]` attribute is an experimental feature
-  --> $DIR/feature-gate-must_not_suspend.rs:3:1
+error[E0658]: the `must_not_suspend` attribute is an experimental feature
+  --> $DIR/feature-gate-must_not_suspend.rs:3:3
    |
 LL | #[must_not_suspend = "You gotta use Umm's, ya know?"]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^
    |
    = note: see issue #83310 <https://github.com/rust-lang/rust/issues/83310> for more information
    = help: add `#![feature(must_not_suspend)]` to the crate attributes to enable

--- a/tests/ui/lint/must_not_suspend/other_items.stderr
+++ b/tests/ui/lint/must_not_suspend/other_items.stderr
@@ -1,10 +1,10 @@
-error: `#[must_not_suspend]` attribute cannot be used on modules
-  --> $DIR/other_items.rs:5:1
+error: the `must_not_suspend` attribute cannot be used on modules
+  --> $DIR/other_items.rs:5:3
    |
 LL | #[must_not_suspend]
-   | ^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^
    |
-   = help: `#[must_not_suspend]` can be applied to data types and traits
+   = help: the `must_not_suspend` attribute can be applied to data types and traits
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/lint/must_not_suspend/return.stderr
+++ b/tests/ui/lint/must_not_suspend/return.stderr
@@ -1,10 +1,10 @@
-error: `#[must_not_suspend]` attribute cannot be used on functions
-  --> $DIR/return.rs:5:1
+error: the `must_not_suspend` attribute cannot be used on functions
+  --> $DIR/return.rs:5:3
    |
 LL | #[must_not_suspend]
-   | ^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^
    |
-   = help: `#[must_not_suspend]` can be applied to data types and traits
+   = help: the `must_not_suspend` attribute can be applied to data types and traits
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/lint/unused/unused-attr-macro-rules.stderr
+++ b/tests/ui/lint/unused/unused-attr-macro-rules.stderr
@@ -1,10 +1,10 @@
-error: `#[macro_use]` attribute cannot be used on macro defs
-  --> $DIR/unused-attr-macro-rules.rs:7:1
+error: the `macro_use` attribute cannot be used on macro defs
+  --> $DIR/unused-attr-macro-rules.rs:7:3
    |
 LL | #[macro_use]
-   | ^^^^^^^^^^^^
+   |   ^^^^^^^^^
    |
-   = help: `#[macro_use]` can be applied to extern crates and modules
+   = help: the `macro_use` attribute can be applied to extern crates and modules
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 note: the lint level is defined here
   --> $DIR/unused-attr-macro-rules.rs:1:9
@@ -12,13 +12,13 @@ note: the lint level is defined here
 LL | #![deny(unused_attributes)]
    |         ^^^^^^^^^^^^^^^^^
 
-error: `#[path]` attribute cannot be used on macro defs
-  --> $DIR/unused-attr-macro-rules.rs:9:1
+error: the `path` attribute cannot be used on macro defs
+  --> $DIR/unused-attr-macro-rules.rs:9:3
    |
 LL | #[path="foo"]
-   | ^^^^^^^^^^^^^
+   |   ^^^^
    |
-   = help: `#[path]` can only be applied to modules
+   = help: the `path` attribute can only be applied to modules
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 error: crate-level attribute should be an inner attribute: add an exclamation mark: `#![recursion_limit]`

--- a/tests/ui/lint/unused/unused_attributes-must_use.fixed
+++ b/tests/ui/lint/unused/unused_attributes-must_use.fixed
@@ -65,7 +65,7 @@ extern "Rust" {
     fn foreign_foo() -> i64;
 }
 
-//~^ ERROR `#[must_use]` attribute cannot be used on macro calls
+//~^ ERROR the `must_use` attribute cannot be used on macro calls
 //~| WARN this was previously accepted by the compiler but is being phased out
 global_asm!("");
 

--- a/tests/ui/lint/unused/unused_attributes-must_use.rs
+++ b/tests/ui/lint/unused/unused_attributes-must_use.rs
@@ -66,7 +66,7 @@ extern "Rust" {
 }
 
 #[must_use]
-//~^ ERROR `#[must_use]` attribute cannot be used on macro calls
+//~^ ERROR the `must_use` attribute cannot be used on macro calls
 //~| WARN this was previously accepted by the compiler but is being phased out
 global_asm!("");
 

--- a/tests/ui/lint/unused/unused_attributes-must_use.stderr
+++ b/tests/ui/lint/unused/unused_attributes-must_use.stderr
@@ -1,10 +1,10 @@
-error: `#[must_use]` attribute cannot be used on macro calls
-  --> $DIR/unused_attributes-must_use.rs:68:1
+error: the `must_use` attribute cannot be used on macro calls
+  --> $DIR/unused_attributes-must_use.rs:68:3
    |
 LL | #[must_use]
-   | ^^^^^^^^^^^
+   |   ^^^^^^^^
    |
-   = help: `#[must_use]` can be applied to data types, functions, and traits
+   = help: the `must_use` attribute can be applied to data types, functions, and traits
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: placing this attribute on a macro invocation does nothing even if the macro expands to what would be a valid target for the attribute
 note: the lint level is defined here
@@ -13,193 +13,193 @@ note: the lint level is defined here
 LL | #![deny(unused_attributes, unused_must_use)]
    |         ^^^^^^^^^^^^^^^^^
 
-error: `#[must_use]` attribute cannot be used on extern crates
-  --> $DIR/unused_attributes-must_use.rs:7:1
+error: the `must_use` attribute cannot be used on extern crates
+  --> $DIR/unused_attributes-must_use.rs:7:3
    |
 LL | #[must_use]
-   | ^^^^^^^^^^^
+   |   ^^^^^^^^
    |
-   = help: `#[must_use]` can be applied to data types, functions, and traits
+   = help: the `must_use` attribute can be applied to data types, functions, and traits
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-error: `#[must_use]` attribute cannot be used on modules
-  --> $DIR/unused_attributes-must_use.rs:11:1
+error: the `must_use` attribute cannot be used on modules
+  --> $DIR/unused_attributes-must_use.rs:11:3
    |
 LL | #[must_use]
-   | ^^^^^^^^^^^
+   |   ^^^^^^^^
    |
-   = help: `#[must_use]` can be applied to data types, functions, and traits
+   = help: the `must_use` attribute can be applied to data types, functions, and traits
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-error: `#[must_use]` attribute cannot be used on use statements
-  --> $DIR/unused_attributes-must_use.rs:15:1
+error: the `must_use` attribute cannot be used on use statements
+  --> $DIR/unused_attributes-must_use.rs:15:3
    |
 LL | #[must_use]
-   | ^^^^^^^^^^^
+   |   ^^^^^^^^
    |
-   = help: `#[must_use]` can be applied to data types, functions, and traits
+   = help: the `must_use` attribute can be applied to data types, functions, and traits
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-error: `#[must_use]` attribute cannot be used on constants
-  --> $DIR/unused_attributes-must_use.rs:19:1
+error: the `must_use` attribute cannot be used on constants
+  --> $DIR/unused_attributes-must_use.rs:19:3
    |
 LL | #[must_use]
-   | ^^^^^^^^^^^
+   |   ^^^^^^^^
    |
-   = help: `#[must_use]` can be applied to data types, functions, and traits
+   = help: the `must_use` attribute can be applied to data types, functions, and traits
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-error: `#[must_use]` attribute cannot be used on statics
-  --> $DIR/unused_attributes-must_use.rs:22:1
+error: the `must_use` attribute cannot be used on statics
+  --> $DIR/unused_attributes-must_use.rs:22:3
    |
 LL | #[must_use]
-   | ^^^^^^^^^^^
+   |   ^^^^^^^^
    |
-   = help: `#[must_use]` can be applied to data types, functions, and traits
+   = help: the `must_use` attribute can be applied to data types, functions, and traits
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-error: `#[must_use]` attribute cannot be used on inherent impl blocks
-  --> $DIR/unused_attributes-must_use.rs:40:1
+error: the `must_use` attribute cannot be used on inherent impl blocks
+  --> $DIR/unused_attributes-must_use.rs:40:3
    |
 LL | #[must_use]
-   | ^^^^^^^^^^^
+   |   ^^^^^^^^
    |
-   = help: `#[must_use]` can be applied to data types, functions, and traits
+   = help: the `must_use` attribute can be applied to data types, functions, and traits
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-error: `#[must_use]` attribute cannot be used on foreign modules
-  --> $DIR/unused_attributes-must_use.rs:55:1
+error: the `must_use` attribute cannot be used on foreign modules
+  --> $DIR/unused_attributes-must_use.rs:55:3
    |
 LL | #[must_use]
-   | ^^^^^^^^^^^
+   |   ^^^^^^^^
    |
-   = help: `#[must_use]` can be applied to data types, functions, and traits
+   = help: the `must_use` attribute can be applied to data types, functions, and traits
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-error: `#[must_use]` attribute cannot be used on type aliases
-  --> $DIR/unused_attributes-must_use.rs:73:1
+error: the `must_use` attribute cannot be used on type aliases
+  --> $DIR/unused_attributes-must_use.rs:73:3
    |
 LL | #[must_use]
-   | ^^^^^^^^^^^
+   |   ^^^^^^^^
    |
-   = help: `#[must_use]` can be applied to data types, functions, and traits
+   = help: the `must_use` attribute can be applied to data types, functions, and traits
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-error: `#[must_use]` attribute cannot be used on type parameters
-  --> $DIR/unused_attributes-must_use.rs:77:8
+error: the `must_use` attribute cannot be used on type parameters
+  --> $DIR/unused_attributes-must_use.rs:77:10
    |
 LL | fn qux<#[must_use] T>(_: T) {}
-   |        ^^^^^^^^^^^
+   |          ^^^^^^^^
    |
-   = help: `#[must_use]` can be applied to data types, functions, and traits
+   = help: the `must_use` attribute can be applied to data types, functions, and traits
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-error: `#[must_use]` attribute cannot be used on trait impl blocks
-  --> $DIR/unused_attributes-must_use.rs:95:1
+error: the `must_use` attribute cannot be used on trait impl blocks
+  --> $DIR/unused_attributes-must_use.rs:95:3
    |
 LL | #[must_use]
-   | ^^^^^^^^^^^
+   |   ^^^^^^^^
    |
-   = help: `#[must_use]` can be applied to data types, functions, and traits
+   = help: the `must_use` attribute can be applied to data types, functions, and traits
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-error: `#[must_use]` attribute cannot be used on trait aliases
-  --> $DIR/unused_attributes-must_use.rs:107:1
+error: the `must_use` attribute cannot be used on trait aliases
+  --> $DIR/unused_attributes-must_use.rs:107:3
    |
 LL | #[must_use]
-   | ^^^^^^^^^^^
+   |   ^^^^^^^^
    |
-   = help: `#[must_use]` can be applied to data types, functions, and traits
+   = help: the `must_use` attribute can be applied to data types, functions, and traits
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-error: `#[must_use]` attribute cannot be used on macro defs
-  --> $DIR/unused_attributes-must_use.rs:111:1
+error: the `must_use` attribute cannot be used on macro defs
+  --> $DIR/unused_attributes-must_use.rs:111:3
    |
 LL | #[must_use]
-   | ^^^^^^^^^^^
+   |   ^^^^^^^^
    |
-   = help: `#[must_use]` can be applied to data types, functions, and traits
+   = help: the `must_use` attribute can be applied to data types, functions, and traits
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-error: `#[must_use]` attribute cannot be used on statements
-  --> $DIR/unused_attributes-must_use.rs:120:5
+error: the `must_use` attribute cannot be used on statements
+  --> $DIR/unused_attributes-must_use.rs:120:7
    |
 LL |     #[must_use]
-   |     ^^^^^^^^^^^
+   |       ^^^^^^^^
    |
-   = help: `#[must_use]` can be applied to data types, functions, and traits
+   = help: the `must_use` attribute can be applied to data types, functions, and traits
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-error: `#[must_use]` attribute cannot be used on closures
-  --> $DIR/unused_attributes-must_use.rs:125:13
+error: the `must_use` attribute cannot be used on closures
+  --> $DIR/unused_attributes-must_use.rs:125:15
    |
 LL |     let x = #[must_use]
-   |             ^^^^^^^^^^^
+   |               ^^^^^^^^
    |
-   = help: `#[must_use]` can be applied to data types, foreign functions, functions, methods, and traits
+   = help: the `must_use` attribute can be applied to data types, foreign functions, functions, methods, and traits
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-error: `#[must_use]` attribute cannot be used on match arms
-  --> $DIR/unused_attributes-must_use.rs:148:9
+error: the `must_use` attribute cannot be used on match arms
+  --> $DIR/unused_attributes-must_use.rs:148:11
    |
 LL |         #[must_use]
-   |         ^^^^^^^^^^^
+   |           ^^^^^^^^
    |
-   = help: `#[must_use]` can be applied to data types, functions, and traits
+   = help: the `must_use` attribute can be applied to data types, functions, and traits
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-error: `#[must_use]` attribute cannot be used on struct fields
-  --> $DIR/unused_attributes-must_use.rs:157:28
+error: the `must_use` attribute cannot be used on struct fields
+  --> $DIR/unused_attributes-must_use.rs:157:30
    |
 LL |     let s = PatternField { #[must_use]  foo: 123 };
-   |                            ^^^^^^^^^^^
+   |                              ^^^^^^^^
    |
-   = help: `#[must_use]` can be applied to data types, functions, and traits
+   = help: the `must_use` attribute can be applied to data types, functions, and traits
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-error: `#[must_use]` attribute cannot be used on pattern fields
-  --> $DIR/unused_attributes-must_use.rs:159:24
+error: the `must_use` attribute cannot be used on pattern fields
+  --> $DIR/unused_attributes-must_use.rs:159:26
    |
 LL |     let PatternField { #[must_use] foo } = s;
-   |                        ^^^^^^^^^^^
+   |                          ^^^^^^^^
    |
-   = help: `#[must_use]` can be applied to data types, functions, and traits
+   = help: the `must_use` attribute can be applied to data types, functions, and traits
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-error: `#[must_use]` attribute cannot be used on associated consts
-  --> $DIR/unused_attributes-must_use.rs:82:5
+error: the `must_use` attribute cannot be used on associated consts
+  --> $DIR/unused_attributes-must_use.rs:82:7
    |
 LL |     #[must_use]
-   |     ^^^^^^^^^^^
+   |       ^^^^^^^^
    |
-   = help: `#[must_use]` can be applied to data types, functions, and traits
+   = help: the `must_use` attribute can be applied to data types, functions, and traits
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-error: `#[must_use]` attribute cannot be used on associated types
-  --> $DIR/unused_attributes-must_use.rs:85:5
+error: the `must_use` attribute cannot be used on associated types
+  --> $DIR/unused_attributes-must_use.rs:85:7
    |
 LL |     #[must_use]
-   |     ^^^^^^^^^^^
+   |       ^^^^^^^^
    |
-   = help: `#[must_use]` can be applied to data types, functions, and traits
+   = help: the `must_use` attribute can be applied to data types, functions, and traits
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-error: `#[must_use]` attribute cannot be used on trait methods in impl blocks
-  --> $DIR/unused_attributes-must_use.rs:100:5
+error: the `must_use` attribute cannot be used on trait methods in impl blocks
+  --> $DIR/unused_attributes-must_use.rs:100:7
    |
 LL |     #[must_use]
-   |     ^^^^^^^^^^^
+   |       ^^^^^^^^
    |
-   = help: `#[must_use]` can be applied to data types, foreign functions, functions, inherent methods, provided trait methods, required trait methods, and traits
+   = help: the `must_use` attribute can be applied to data types, foreign functions, functions, inherent methods, provided trait methods, required trait methods, and traits
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-error: `#[must_use]` attribute cannot be used on foreign statics
-  --> $DIR/unused_attributes-must_use.rs:59:5
+error: the `must_use` attribute cannot be used on foreign statics
+  --> $DIR/unused_attributes-must_use.rs:59:7
    |
 LL |     #[must_use]
-   |     ^^^^^^^^^^^
+   |       ^^^^^^^^
    |
-   = help: `#[must_use]` can be applied to data types, functions, and traits
+   = help: the `must_use` attribute can be applied to data types, functions, and traits
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 error: unused `X` that must be used

--- a/tests/ui/lint/warn-unused-inline-on-fn-prototypes.stderr
+++ b/tests/ui/lint/warn-unused-inline-on-fn-prototypes.stderr
@@ -1,10 +1,10 @@
-error: `#[inline]` attribute cannot be used on required trait methods
-  --> $DIR/warn-unused-inline-on-fn-prototypes.rs:4:5
+error: the `inline` attribute cannot be used on required trait methods
+  --> $DIR/warn-unused-inline-on-fn-prototypes.rs:4:7
    |
 LL |     #[inline]
-   |     ^^^^^^^^^
+   |       ^^^^^^
    |
-   = help: `#[inline]` can only be applied to functions with a body
+   = help: the `inline` attribute can only be applied to functions with a body
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 note: the lint level is defined here
   --> $DIR/warn-unused-inline-on-fn-prototypes.rs:1:9
@@ -12,13 +12,13 @@ note: the lint level is defined here
 LL | #![deny(unused_attributes)]
    |         ^^^^^^^^^^^^^^^^^
 
-error: `#[inline]` attribute cannot be used on foreign functions
-  --> $DIR/warn-unused-inline-on-fn-prototypes.rs:10:5
+error: the `inline` attribute cannot be used on foreign functions
+  --> $DIR/warn-unused-inline-on-fn-prototypes.rs:10:7
    |
 LL |     #[inline]
-   |     ^^^^^^^^^
+   |       ^^^^^^
    |
-   = help: `#[inline]` can only be applied to functions with a body
+   = help: the `inline` attribute can only be applied to functions with a body
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 error: aborting due to 2 previous errors

--- a/tests/ui/loop-match/invalid-attribute.rs
+++ b/tests/ui/loop-match/invalid-attribute.rs
@@ -38,7 +38,7 @@ fn main() {
     {
         #[loop_match] //~ ERROR attribute cannot be used on
         #[const_continue]
-        //~^ ERROR `#[const_continue]` attribute cannot be used on expressions
+        //~^ ERROR the `const_continue` attribute cannot be used on expressions
         5
     };
 }

--- a/tests/ui/loop-match/invalid-attribute.stderr
+++ b/tests/ui/loop-match/invalid-attribute.stderr
@@ -1,114 +1,114 @@
-error: `#[loop_match]` attribute cannot be used on crates
-  --> $DIR/invalid-attribute.rs:6:1
+error: the `loop_match` attribute cannot be used on crates
+  --> $DIR/invalid-attribute.rs:6:4
    |
 LL | #![loop_match]
-   | ^^^^^^^^^^^^^^
+   |    ^^^^^^^^^^
    |
-   = help: `#[loop_match]` can only be applied to loops
+   = help: the `loop_match` attribute can only be applied to loops
 
-error: `#[const_continue]` attribute cannot be used on crates
-  --> $DIR/invalid-attribute.rs:7:1
+error: the `const_continue` attribute cannot be used on crates
+  --> $DIR/invalid-attribute.rs:7:4
    |
 LL | #![const_continue]
-   | ^^^^^^^^^^^^^^^^^^
+   |    ^^^^^^^^^^^^^^
    |
-   = help: `#[const_continue]` can only be applied to break expressions
+   = help: the `const_continue` attribute can only be applied to break expressions
 
-error: `#[loop_match]` attribute cannot be used on foreign functions
-  --> $DIR/invalid-attribute.rs:10:5
+error: the `loop_match` attribute cannot be used on foreign functions
+  --> $DIR/invalid-attribute.rs:10:7
    |
 LL |     #[loop_match]
-   |     ^^^^^^^^^^^^^
+   |       ^^^^^^^^^^
    |
-   = help: `#[loop_match]` can only be applied to loops
+   = help: the `loop_match` attribute can only be applied to loops
 
-error: `#[const_continue]` attribute cannot be used on foreign functions
-  --> $DIR/invalid-attribute.rs:11:5
+error: the `const_continue` attribute cannot be used on foreign functions
+  --> $DIR/invalid-attribute.rs:11:7
    |
 LL |     #[const_continue]
-   |     ^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^
    |
-   = help: `#[const_continue]` can only be applied to break expressions
+   = help: the `const_continue` attribute can only be applied to break expressions
 
-error: `#[loop_match]` attribute cannot be used on structs
-  --> $DIR/invalid-attribute.rs:15:1
+error: the `loop_match` attribute cannot be used on structs
+  --> $DIR/invalid-attribute.rs:15:3
    |
 LL | #[loop_match]
-   | ^^^^^^^^^^^^^
+   |   ^^^^^^^^^^
    |
-   = help: `#[loop_match]` can only be applied to loops
+   = help: the `loop_match` attribute can only be applied to loops
 
-error: `#[const_continue]` attribute cannot be used on structs
-  --> $DIR/invalid-attribute.rs:16:1
+error: the `const_continue` attribute cannot be used on structs
+  --> $DIR/invalid-attribute.rs:16:3
    |
 LL | #[const_continue]
-   | ^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^
    |
-   = help: `#[const_continue]` can only be applied to break expressions
+   = help: the `const_continue` attribute can only be applied to break expressions
 
-error: `#[loop_match]` attribute cannot be used on required trait methods
-  --> $DIR/invalid-attribute.rs:24:5
+error: the `loop_match` attribute cannot be used on required trait methods
+  --> $DIR/invalid-attribute.rs:24:7
    |
 LL |     #[loop_match]
-   |     ^^^^^^^^^^^^^
+   |       ^^^^^^^^^^
    |
-   = help: `#[loop_match]` can only be applied to loops
+   = help: the `loop_match` attribute can only be applied to loops
 
-error: `#[const_continue]` attribute cannot be used on required trait methods
-  --> $DIR/invalid-attribute.rs:25:5
+error: the `const_continue` attribute cannot be used on required trait methods
+  --> $DIR/invalid-attribute.rs:25:7
    |
 LL |     #[const_continue]
-   |     ^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^
    |
-   = help: `#[const_continue]` can only be applied to break expressions
+   = help: the `const_continue` attribute can only be applied to break expressions
 
-error: `#[loop_match]` attribute cannot be used on functions
-  --> $DIR/invalid-attribute.rs:29:1
+error: the `loop_match` attribute cannot be used on functions
+  --> $DIR/invalid-attribute.rs:29:3
    |
 LL | #[loop_match]
-   | ^^^^^^^^^^^^^
+   |   ^^^^^^^^^^
    |
-   = help: `#[loop_match]` can only be applied to loops
+   = help: the `loop_match` attribute can only be applied to loops
 
-error: `#[const_continue]` attribute cannot be used on functions
-  --> $DIR/invalid-attribute.rs:30:1
+error: the `const_continue` attribute cannot be used on functions
+  --> $DIR/invalid-attribute.rs:30:3
    |
 LL | #[const_continue]
-   | ^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^
    |
-   = help: `#[const_continue]` can only be applied to break expressions
+   = help: the `const_continue` attribute can only be applied to break expressions
 
-error: `#[loop_match]` attribute cannot be used on closures
-  --> $DIR/invalid-attribute.rs:34:5
+error: the `loop_match` attribute cannot be used on closures
+  --> $DIR/invalid-attribute.rs:34:7
    |
 LL |     #[loop_match]
-   |     ^^^^^^^^^^^^^
+   |       ^^^^^^^^^^
    |
-   = help: `#[loop_match]` can only be applied to loops
+   = help: the `loop_match` attribute can only be applied to loops
 
-error: `#[const_continue]` attribute cannot be used on closures
-  --> $DIR/invalid-attribute.rs:35:5
+error: the `const_continue` attribute cannot be used on closures
+  --> $DIR/invalid-attribute.rs:35:7
    |
 LL |     #[const_continue]
-   |     ^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^
    |
-   = help: `#[const_continue]` can only be applied to break expressions
+   = help: the `const_continue` attribute can only be applied to break expressions
 
-error: `#[loop_match]` attribute cannot be used on expressions
-  --> $DIR/invalid-attribute.rs:39:9
+error: the `loop_match` attribute cannot be used on expressions
+  --> $DIR/invalid-attribute.rs:39:11
    |
 LL |         #[loop_match]
-   |         ^^^^^^^^^^^^^
+   |           ^^^^^^^^^^
    |
-   = help: `#[loop_match]` can only be applied to loops
+   = help: the `loop_match` attribute can only be applied to loops
 
-error: `#[const_continue]` attribute cannot be used on expressions
-  --> $DIR/invalid-attribute.rs:40:9
+error: the `const_continue` attribute cannot be used on expressions
+  --> $DIR/invalid-attribute.rs:40:11
    |
 LL |         #[const_continue]
-   |         ^^^^^^^^^^^^^^^^^
+   |           ^^^^^^^^^^^^^^
    |
-   = help: `#[const_continue]` can only be applied to break expressions
+   = help: the `const_continue` attribute can only be applied to break expressions
 
 error: aborting due to 14 previous errors
 

--- a/tests/ui/macros/issue-68060.stderr
+++ b/tests/ui/macros/issue-68060.stderr
@@ -1,10 +1,10 @@
-error: `#[target_feature]` attribute cannot be used on closures
-  --> $DIR/issue-68060.rs:4:13
+error: the `target_feature` attribute cannot be used on closures
+  --> $DIR/issue-68060.rs:4:15
    |
 LL |             #[target_feature(enable = "")]
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |               ^^^^^^^^^^^^^^
    |
-   = help: `#[target_feature]` can be applied to functions and methods
+   = help: the `target_feature` attribute can be applied to functions and methods
 
 error[E0658]: `#[track_caller]` on closures is currently unstable
   --> $DIR/issue-68060.rs:6:13

--- a/tests/ui/macros/macro-use-bad-args-1.stderr
+++ b/tests/ui/macros/macro-use-bad-args-1.stderr
@@ -1,8 +1,8 @@
 error[E0565]: malformed `macro_use` attribute input
-  --> $DIR/macro-use-bad-args-1.rs:4:1
+  --> $DIR/macro-use-bad-args-1.rs:4:3
    |
 LL | #[macro_use(foo(bar))]
-   | ^^^^^^^^^^^^^^^-----^^
+   |   ^^^^^^^^^^^^^-----^
    |                |
    |                didn't expect any arguments here
    |

--- a/tests/ui/macros/macro-use-bad-args-2.stderr
+++ b/tests/ui/macros/macro-use-bad-args-2.stderr
@@ -1,8 +1,8 @@
 error[E0565]: malformed `macro_use` attribute input
-  --> $DIR/macro-use-bad-args-2.rs:4:1
+  --> $DIR/macro-use-bad-args-2.rs:4:3
    |
 LL | #[macro_use(foo="bar")]
-   | ^^^^^^^^^^^^^^^------^^
+   |   ^^^^^^^^^^^^^------^
    |                |
    |                didn't expect any arguments here
    |

--- a/tests/ui/macros/tokenstream-ice-issue-149954.stderr
+++ b/tests/ui/macros/tokenstream-ice-issue-149954.stderr
@@ -38,10 +38,10 @@ LL |             A: A<{ struct A<A: A<{ #[cfg] () }>> ; enum A  }>
    |                                                             +
 
 error[E0539]: malformed `cfg` attribute input
-  --> $DIR/tokenstream-ice-issue-149954.rs:10:36
+  --> $DIR/tokenstream-ice-issue-149954.rs:10:38
    |
 LL |             A: A<{ struct A<A: A<{ #[cfg] () }>> ; enum A  }
-   |                                    ^^^^^^ expected this to be a list
+   |                                      ^^^ expected this to be a list
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
 help: must be of the form
@@ -50,10 +50,10 @@ LL |             A: A<{ struct A<A: A<{ #[cfg(predicate)] () }>> ; enum A  }
    |                                         +++++++++++
 
 error[E0539]: malformed `cfg` attribute input
-  --> $DIR/tokenstream-ice-issue-149954.rs:10:36
+  --> $DIR/tokenstream-ice-issue-149954.rs:10:38
    |
 LL |             A: A<{ struct A<A: A<{ #[cfg] () }>> ; enum A  }
-   |                                    ^^^^^^ expected this to be a list
+   |                                      ^^^ expected this to be a list
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`

--- a/tests/ui/malformed/malformed-regressions.stderr
+++ b/tests/ui/malformed/malformed-regressions.stderr
@@ -47,23 +47,23 @@ LL | #[inline = ""]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
 
-warning: `#[link]` attribute cannot be used on functions
-  --> $DIR/malformed-regressions.rs:8:1
+warning: the `link` attribute cannot be used on functions
+  --> $DIR/malformed-regressions.rs:8:3
    |
 LL | #[link]
-   | ^^^^^^^
+   |   ^^^^
    |
-   = help: `#[link]` can only be applied to foreign modules
+   = help: the `link` attribute can only be applied to foreign modules
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: requested on the command line with `-W unused-attributes`
 
-warning: `#[link]` attribute cannot be used on functions
-  --> $DIR/malformed-regressions.rs:11:1
+warning: the `link` attribute cannot be used on functions
+  --> $DIR/malformed-regressions.rs:11:3
    |
 LL | #[link = ""]
-   | ^^^^^^^^^^^^
+   |   ^^^^
    |
-   = help: `#[link]` can only be applied to foreign modules
+   = help: the `link` attribute can only be applied to foreign modules
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 error: aborting due to 5 previous errors; 2 warnings emitted

--- a/tests/ui/malformed/malformed-regressions.stderr
+++ b/tests/ui/malformed/malformed-regressions.stderr
@@ -1,16 +1,16 @@
 error[E0539]: malformed `link` attribute input
-  --> $DIR/malformed-regressions.rs:8:1
+  --> $DIR/malformed-regressions.rs:8:3
    |
 LL | #[link]
-   | ^^^^^^^ expected this to be a list
+   |   ^^^^ expected this to be a list
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute>
 
 error[E0539]: malformed `link` attribute input
-  --> $DIR/malformed-regressions.rs:11:1
+  --> $DIR/malformed-regressions.rs:11:3
    |
 LL | #[link = ""]
-   | ^^^^^^^----^
+   |   ^^^^^----
    |        |
    |        expected this to be a list
    |

--- a/tests/ui/malformed/malformed-special-attrs.stderr
+++ b/tests/ui/malformed/malformed-special-attrs.stderr
@@ -1,8 +1,8 @@
 error[E0539]: malformed `cfg_attr` attribute input
-  --> $DIR/malformed-special-attrs.rs:3:1
+  --> $DIR/malformed-special-attrs.rs:3:3
    |
 LL | #[cfg_attr]
-   | ^^^^^^^^^^^ expected this to be a list
+   |   ^^^^^^^^ expected this to be a list
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute>
 help: must be of the form
@@ -11,10 +11,10 @@ LL | #[cfg_attr(predicate, attr1, attr2, ...)]
    |           ++++++++++++++++++++++++++++++
 
 error[E0539]: malformed `cfg_attr` attribute input
-  --> $DIR/malformed-special-attrs.rs:6:1
+  --> $DIR/malformed-special-attrs.rs:6:3
    |
 LL | #[cfg_attr = ""]
-   | ^^^^^^^^^^^^^^^^ expected this to be a list
+   |   ^^^^^^^^^^^^^ expected this to be a list
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute>
 help: must be of the form

--- a/tests/ui/marker_trait_attr/marker-attribute-on-non-trait.stderr
+++ b/tests/ui/marker_trait_attr/marker-attribute-on-non-trait.stderr
@@ -1,50 +1,50 @@
-error: `#[marker]` attribute cannot be used on structs
-  --> $DIR/marker-attribute-on-non-trait.rs:3:1
+error: the `marker` attribute cannot be used on structs
+  --> $DIR/marker-attribute-on-non-trait.rs:3:3
    |
 LL | #[marker]
-   | ^^^^^^^^^
+   |   ^^^^^^
    |
-   = help: `#[marker]` can only be applied to traits
+   = help: the `marker` attribute can only be applied to traits
 
-error: `#[marker]` attribute cannot be used on inherent impl blocks
-  --> $DIR/marker-attribute-on-non-trait.rs:6:1
+error: the `marker` attribute cannot be used on inherent impl blocks
+  --> $DIR/marker-attribute-on-non-trait.rs:6:3
    |
 LL | #[marker]
-   | ^^^^^^^^^
+   |   ^^^^^^
    |
-   = help: `#[marker]` can only be applied to traits
+   = help: the `marker` attribute can only be applied to traits
 
-error: `#[marker]` attribute cannot be used on unions
-  --> $DIR/marker-attribute-on-non-trait.rs:9:1
+error: the `marker` attribute cannot be used on unions
+  --> $DIR/marker-attribute-on-non-trait.rs:9:3
    |
 LL | #[marker]
-   | ^^^^^^^^^
+   |   ^^^^^^
    |
-   = help: `#[marker]` can only be applied to traits
+   = help: the `marker` attribute can only be applied to traits
 
-error: `#[marker]` attribute cannot be used on constants
-  --> $DIR/marker-attribute-on-non-trait.rs:14:1
+error: the `marker` attribute cannot be used on constants
+  --> $DIR/marker-attribute-on-non-trait.rs:14:3
    |
 LL | #[marker]
-   | ^^^^^^^^^
+   |   ^^^^^^
    |
-   = help: `#[marker]` can only be applied to traits
+   = help: the `marker` attribute can only be applied to traits
 
-error: `#[marker]` attribute cannot be used on functions
-  --> $DIR/marker-attribute-on-non-trait.rs:17:1
+error: the `marker` attribute cannot be used on functions
+  --> $DIR/marker-attribute-on-non-trait.rs:17:3
    |
 LL | #[marker]
-   | ^^^^^^^^^
+   |   ^^^^^^
    |
-   = help: `#[marker]` can only be applied to traits
+   = help: the `marker` attribute can only be applied to traits
 
-error: `#[marker]` attribute cannot be used on type aliases
-  --> $DIR/marker-attribute-on-non-trait.rs:20:1
+error: the `marker` attribute cannot be used on type aliases
+  --> $DIR/marker-attribute-on-non-trait.rs:20:3
    |
 LL | #[marker]
-   | ^^^^^^^^^
+   |   ^^^^^^
    |
-   = help: `#[marker]` can only be applied to traits
+   = help: the `marker` attribute can only be applied to traits
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/marker_trait_attr/marker-attribute-with-values.stderr
+++ b/tests/ui/marker_trait_attr/marker-attribute-with-values.stderr
@@ -1,8 +1,8 @@
 error[E0565]: malformed `marker` attribute input
-  --> $DIR/marker-attribute-with-values.rs:3:1
+  --> $DIR/marker-attribute-with-values.rs:3:3
    |
 LL | #[marker(always)]
-   | ^^^^^^^^--------^
+   |   ^^^^^^--------
    |         |
    |         didn't expect any arguments here
    |
@@ -13,10 +13,10 @@ LL + #[marker]
    |
 
 error[E0565]: malformed `marker` attribute input
-  --> $DIR/marker-attribute-with-values.rs:6:1
+  --> $DIR/marker-attribute-with-values.rs:6:3
    |
 LL | #[marker("never")]
-   | ^^^^^^^^---------^
+   |   ^^^^^^---------
    |         |
    |         didn't expect any arguments here
    |
@@ -27,10 +27,10 @@ LL + #[marker]
    |
 
 error[E0565]: malformed `marker` attribute input
-  --> $DIR/marker-attribute-with-values.rs:9:1
+  --> $DIR/marker-attribute-with-values.rs:9:3
    |
 LL | #[marker(key = "value")]
-   | ^^^^^^^^---------------^
+   |   ^^^^^^---------------
    |         |
    |         didn't expect any arguments here
    |

--- a/tests/ui/on-unimplemented/feature-gate-on-unimplemented.rs
+++ b/tests/ui/on-unimplemented/feature-gate-on-unimplemented.rs
@@ -2,8 +2,8 @@
 
 #[rustc_on_unimplemented(label = "test error `{Self}` with `{Bar}`")]
 //~^ ERROR use of an internal attribute [E0658]
-//~| NOTE the `#[rustc_on_unimplemented]` attribute is an internal implementation detail that will never be stable
-//~| NOTE see `#[diagnostic::on_unimplemented]` for the stable equivalent of this attribute
+//~| NOTE the `rustc_on_unimplemented` attribute is an internal implementation detail that will never be stable
+//~| NOTE see the `diagnostic::on_unimplemented` attribute for the stable equivalent of this attribute
 trait Foo<Bar> {}
 
 fn main() {}

--- a/tests/ui/on-unimplemented/feature-gate-on-unimplemented.stderr
+++ b/tests/ui/on-unimplemented/feature-gate-on-unimplemented.stderr
@@ -1,12 +1,12 @@
 error[E0658]: use of an internal attribute
-  --> $DIR/feature-gate-on-unimplemented.rs:3:1
+  --> $DIR/feature-gate-on-unimplemented.rs:3:3
    |
 LL | #[rustc_on_unimplemented(label = "test error `{Self}` with `{Bar}`")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable
-   = note: the `#[rustc_on_unimplemented]` attribute is an internal implementation detail that will never be stable
-   = note: see `#[diagnostic::on_unimplemented]` for the stable equivalent of this attribute
+   = note: the `rustc_on_unimplemented` attribute is an internal implementation detail that will never be stable
+   = note: see the `diagnostic::on_unimplemented` attribute for the stable equivalent of this attribute
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/panic-handler/panic-handler-wrong-location.stderr
+++ b/tests/ui/panic-handler/panic-handler-wrong-location.stderr
@@ -1,12 +1,12 @@
 error: `#[panic_handler]` function required, but not found
 
-error: `#[panic_handler]` attribute cannot be used on statics
-  --> $DIR/panic-handler-wrong-location.rs:6:1
+error: the `panic_handler` attribute cannot be used on statics
+  --> $DIR/panic-handler-wrong-location.rs:6:3
    |
 LL | #[panic_handler]
-   | ^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^
    |
-   = help: `#[panic_handler]` can only be applied to functions
+   = help: the `panic_handler` attribute can only be applied to functions
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/panic-runtime/needs-gate.stderr
+++ b/tests/ui/panic-runtime/needs-gate.stderr
@@ -1,18 +1,18 @@
-error[E0658]: the `#[panic_runtime]` attribute is an experimental feature
-  --> $DIR/needs-gate.rs:4:1
+error[E0658]: the `panic_runtime` attribute is an experimental feature
+  --> $DIR/needs-gate.rs:4:4
    |
 LL | #![panic_runtime]
-   | ^^^^^^^^^^^^^^^^^
+   |    ^^^^^^^^^^^^^
    |
    = note: see issue #32837 <https://github.com/rust-lang/rust/issues/32837> for more information
    = help: add `#![feature(panic_runtime)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: the `#[needs_panic_runtime]` attribute is an experimental feature
-  --> $DIR/needs-gate.rs:5:1
+error[E0658]: the `needs_panic_runtime` attribute is an experimental feature
+  --> $DIR/needs-gate.rs:5:4
    |
 LL | #![needs_panic_runtime]
-   | ^^^^^^^^^^^^^^^^^^^^^^^
+   |    ^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #32837 <https://github.com/rust-lang/rust/issues/32837> for more information
    = help: add `#![feature(needs_panic_runtime)]` to the crate attributes to enable

--- a/tests/ui/parser/bad-lit-suffixes.stderr
+++ b/tests/ui/parser/bad-lit-suffixes.stderr
@@ -137,10 +137,10 @@ LL | #[must_use = "string"suffix]
    |              ^^^^^^^^^^^^^^ invalid suffix `suffix`
 
 error[E0539]: malformed `must_use` attribute input
-  --> $DIR/bad-lit-suffixes.rs:34:1
+  --> $DIR/bad-lit-suffixes.rs:34:3
    |
 LL | #[must_use = "string"suffix]
-   | ^^^^^^^^^^^^^--------------^
+   |   ^^^^^^^^^^^--------------
    |              |
    |              expected a string literal here
    |

--- a/tests/ui/patchable-function-entry/patchable-function-entry-attribute.stderr
+++ b/tests/ui/patchable-function-entry/patchable-function-entry-attribute.stderr
@@ -1,8 +1,8 @@
 error[E0539]: malformed `patchable_function_entry` attribute input
-  --> $DIR/patchable-function-entry-attribute.rs:4:1
+  --> $DIR/patchable-function-entry-attribute.rs:4:3
    |
 LL | #[patchable_function_entry(prefix_nops = 256, entry_nops = 0)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---^^^^^^^^^^^^^^^^^
    |                                          |
    |                                          expected an integer literal in the range of 0..=255
    |
@@ -13,10 +13,10 @@ LL + #[patchable_function_entry(prefix_nops = m, entry_nops = n, section = "sect
    |
 
 error[E0539]: malformed `patchable_function_entry` attribute input
-  --> $DIR/patchable-function-entry-attribute.rs:8:1
+  --> $DIR/patchable-function-entry-attribute.rs:8:3
    |
 LL | #[patchable_function_entry(prefix_nops = "stringvalue", entry_nops = 0)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-------------^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-------------^^^^^^^^^^^^^^^^^
    |                                          |
    |                                          expected an integer literal here
    |
@@ -27,10 +27,10 @@ LL + #[patchable_function_entry(prefix_nops = m, entry_nops = n, section = "sect
    |
 
 error[E0539]: malformed `patchable_function_entry` attribute input
-  --> $DIR/patchable-function-entry-attribute.rs:12:1
+  --> $DIR/patchable-function-entry-attribute.rs:12:3
    |
 LL | #[patchable_function_entry]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected this to be a list
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^ expected this to be a list
    |
 help: must be of the form
    |
@@ -38,10 +38,10 @@ LL | #[patchable_function_entry(prefix_nops = m, entry_nops = n, section = "sect
    |                           ++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 error[E0539]: malformed `patchable_function_entry` attribute input
-  --> $DIR/patchable-function-entry-attribute.rs:16:1
+  --> $DIR/patchable-function-entry-attribute.rs:16:3
    |
 LL | #[patchable_function_entry(prefix_nops = 10, something = 0)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---------^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---------^^^^^
    |                                              |
    |                                              valid arguments are `prefix_nops` or `entry_nops`
    |
@@ -52,10 +52,10 @@ LL + #[patchable_function_entry(prefix_nops = m, entry_nops = n, section = "sect
    |
 
 error[E0539]: malformed `patchable_function_entry` attribute input
-  --> $DIR/patchable-function-entry-attribute.rs:20:1
+  --> $DIR/patchable-function-entry-attribute.rs:20:3
    |
 LL | #[patchable_function_entry()]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^--^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^--
    |                           |
    |                           expected at least 1 argument here
    |
@@ -65,10 +65,10 @@ LL | #[patchable_function_entry(prefix_nops = m, entry_nops = n, section = "sect
    |                            ++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 error[E0538]: malformed `patchable_function_entry` attribute input
-  --> $DIR/patchable-function-entry-attribute.rs:24:1
+  --> $DIR/patchable-function-entry-attribute.rs:24:3
    |
 LL | #[patchable_function_entry(prefix_nops = 255, prefix_nops = 255)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-----------^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-----------^^^^^^^
    |                                               |
    |                                               found `prefix_nops` used as a key more than once
    |
@@ -79,10 +79,10 @@ LL + #[patchable_function_entry(prefix_nops = m, entry_nops = n, section = "sect
    |
 
 error[E0539]: malformed `patchable_function_entry` attribute input
-  --> $DIR/patchable-function-entry-attribute.rs:28:1
+  --> $DIR/patchable-function-entry-attribute.rs:28:3
    |
 LL | #[patchable_function_entry(section = 255)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---^
    |                                      |
    |                                      expected a string literal here
    |
@@ -93,10 +93,10 @@ LL + #[patchable_function_entry(prefix_nops = m, entry_nops = n, section = "sect
    |
 
 error[E0538]: malformed `patchable_function_entry` attribute input
-  --> $DIR/patchable-function-entry-attribute.rs:32:1
+  --> $DIR/patchable-function-entry-attribute.rs:32:3
    |
 LL | #[patchable_function_entry(section = "foo", section = "bar")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-------^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-------^^^^^^^^^
    |                                             |
    |                                             found `section` used as a key more than once
    |

--- a/tests/ui/pin-ergonomics/pattern-matching.normal.stderr
+++ b/tests/ui/pin-ergonomics/pattern-matching.normal.stderr
@@ -1,18 +1,18 @@
-error[E0658]: the `#[pin_v2]` attribute is an experimental feature
-  --> $DIR/pattern-matching.rs:12:1
+error[E0658]: the `pin_v2` attribute is an experimental feature
+  --> $DIR/pattern-matching.rs:12:3
    |
 LL | #[pin_v2]
-   | ^^^^^^^^^
+   |   ^^^^^^
    |
    = note: see issue #130494 <https://github.com/rust-lang/rust/issues/130494> for more information
    = help: add `#![feature(pin_ergonomics)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: the `#[pin_v2]` attribute is an experimental feature
-  --> $DIR/pattern-matching.rs:18:1
+error[E0658]: the `pin_v2` attribute is an experimental feature
+  --> $DIR/pattern-matching.rs:18:3
    |
 LL | #[pin_v2]
-   | ^^^^^^^^^
+   |   ^^^^^^
    |
    = note: see issue #130494 <https://github.com/rust-lang/rust/issues/130494> for more information
    = help: add `#![feature(pin_ergonomics)]` to the crate attributes to enable

--- a/tests/ui/pin-ergonomics/pattern-matching.rs
+++ b/tests/ui/pin-ergonomics/pattern-matching.rs
@@ -9,13 +9,13 @@ use std::pin::Pin;
 // This test verifies that a `&pin mut T` can be projected to a pinned
 // reference field `&pin mut T.U` when `T` is marked with `#[pin_v2]`.
 
-#[pin_v2] //[normal]~ ERROR the `#[pin_v2]` attribute is an experimental feature
+#[pin_v2] //[normal]~ ERROR the `pin_v2` attribute is an experimental feature
 struct Foo<T, U> {
     x: T,
     y: U,
 }
 
-#[pin_v2] //[normal]~ ERROR the `#[pin_v2]` attribute is an experimental feature
+#[pin_v2] //[normal]~ ERROR the `pin_v2` attribute is an experimental feature
 enum Bar<T, U> {
     Foo(T, U),
     Bar { x: T, y: U },

--- a/tests/ui/pin-ergonomics/pin_v2-attr.rs
+++ b/tests/ui/pin-ergonomics/pin_v2-attr.rs
@@ -7,7 +7,7 @@
     fn_delegation,
 )]
 #![allow(incomplete_features)]
-#![pin_v2] //~ ERROR `#[pin_v2]` attribute cannot be used on crates
+#![pin_v2] //~ ERROR the `pin_v2` attribute cannot be used on crates
 
 // allowed
 
@@ -25,114 +25,114 @@ union Union {
 // disallowed
 
 enum Foo<#[pin_v2] T, #[pin_v2] U = ()> {
-    //~^ ERROR `#[pin_v2]` attribute cannot be used on type parameters
-    //~| ERROR `#[pin_v2]` attribute cannot be used on type parameters
-    #[pin_v2] //~ ERROR `#[pin_v2]` attribute cannot be used on enum variants
+    //~^ ERROR the `pin_v2` attribute cannot be used on type parameters
+    //~| ERROR the `pin_v2` attribute cannot be used on type parameters
+    #[pin_v2] //~ ERROR the `pin_v2` attribute cannot be used on enum variants
     UnitVariant,
-    TupleVariant(#[pin_v2] T), //~ ERROR `#[pin_v2]` attribute cannot be used on struct fields
+    TupleVariant(#[pin_v2] T), //~ ERROR the `pin_v2` attribute cannot be used on struct fields
     StructVariant {
-        #[pin_v2] //~ ERROR `#[pin_v2]` attribute cannot be used on struct fields
+        #[pin_v2] //~ ERROR the `pin_v2` attribute cannot be used on struct fields
         field: U,
     },
 }
 
-#[pin_v2] //~ ERROR `#[pin_v2]` attribute cannot be used on traits
+#[pin_v2] //~ ERROR the `pin_v2` attribute cannot be used on traits
 trait Trait {
-    #[pin_v2] //~ ERROR `#[pin_v2]` attribute cannot be used on associated consts
+    #[pin_v2] //~ ERROR the `pin_v2` attribute cannot be used on associated consts
     const ASSOC_CONST: () = ();
-    #[pin_v2] //~ ERROR `#[pin_v2]` attribute cannot be used on associated types
+    #[pin_v2] //~ ERROR the `pin_v2` attribute cannot be used on associated types
     type AssocType = ();
 
-    #[pin_v2] //~ ERROR `#[pin_v2]` attribute cannot be used on required trait methods
+    #[pin_v2] //~ ERROR the `pin_v2` attribute cannot be used on required trait methods
     fn method();
-    #[pin_v2] //~ ERROR `#[pin_v2]` attribute cannot be used on provided trait methods
+    #[pin_v2] //~ ERROR the `pin_v2` attribute cannot be used on provided trait methods
     fn method_with_body() {}
 }
 
-#[pin_v2] //~ ERROR `#[pin_v2]` attribute cannot be used on trait aliases
+#[pin_v2] //~ ERROR the `pin_v2` attribute cannot be used on trait aliases
 trait TraitAlias = Trait;
 
-#[pin_v2] //~ ERROR `#[pin_v2]` attribute cannot be used on inherent impl blocks
+#[pin_v2] //~ ERROR the `pin_v2` attribute cannot be used on inherent impl blocks
 impl Struct {
     // FIXME: delegation macros are not tested yet (how to?)
-    #[pin_v2] //~ ERROR `#[pin_v2]` attribute cannot be used on delegations
+    #[pin_v2] //~ ERROR the `pin_v2` attribute cannot be used on delegations
     reuse <Struct as std::any::Any>::type_id;
 
-    #[pin_v2] //~ ERROR `#[pin_v2]` attribute cannot be used on inherent methods
+    #[pin_v2] //~ ERROR the `pin_v2` attribute cannot be used on inherent methods
     fn method() {}
 }
 
-#[pin_v2] //~ ERROR `#[pin_v2]` attribute cannot be used on trait impl blocks
+#[pin_v2] //~ ERROR the `pin_v2` attribute cannot be used on trait impl blocks
 impl Trait for Enum {
-    #[pin_v2] //~ ERROR `#[pin_v2]` attribute cannot be used on trait methods in impl blocks
+    #[pin_v2] //~ ERROR the `pin_v2` attribute cannot be used on trait methods in impl blocks
     fn method() {}
 }
 
-#[pin_v2] //~ ERROR `#[pin_v2]` attribute cannot be used on extern crates
+#[pin_v2] //~ ERROR the `pin_v2` attribute cannot be used on extern crates
 extern crate alloc;
 
-#[pin_v2] //~ ERROR `#[pin_v2]` attribute cannot be used on use statements
+#[pin_v2] //~ ERROR the `pin_v2` attribute cannot be used on use statements
 use std::pin::Pin;
 
-#[pin_v2] //~ ERROR `#[pin_v2]` attribute cannot be used on statics
+#[pin_v2] //~ ERROR the `pin_v2` attribute cannot be used on statics
 static STATIC: () = ();
 
-#[pin_v2] //~ ERROR `#[pin_v2]` attribute cannot be used on constants
+#[pin_v2] //~ ERROR the `pin_v2` attribute cannot be used on constants
 const CONST: () = ();
 
-#[pin_v2] //~ ERROR `#[pin_v2]` attribute cannot be used on functions
+#[pin_v2] //~ ERROR the `pin_v2` attribute cannot be used on functions
 fn f<T, U>(#[pin_v2] param: Foo<T, U>)
-//~^ ERROR `#[pin_v2]` attribute cannot be used on function params
+//~^ ERROR the `pin_v2` attribute cannot be used on function params
 //~| ERROR allow, cfg, cfg_attr, deny, expect, forbid, and warn are the only allowed built-in attributes in function parameters
 where
     #[pin_v2]
-    //~^ ERROR `#[pin_v2]` attribute cannot be used on where predicates
+    //~^ ERROR the `pin_v2` attribute cannot be used on where predicates
     T:,
 {
-    #[pin_v2] //~ ERROR `#[pin_v2]` attribute cannot be used on closures
+    #[pin_v2] //~ ERROR the `pin_v2` attribute cannot be used on closures
     || ();
-    #[pin_v2] //~ ERROR `#[pin_v2]` attribute cannot be used on expressions
+    #[pin_v2] //~ ERROR the `pin_v2` attribute cannot be used on expressions
     [(), (), ()];
-    #[pin_v2] //~ ERROR `#[pin_v2]` attribute cannot be used on statements
+    #[pin_v2] //~ ERROR the `pin_v2` attribute cannot be used on statements
     let _: Foo<(), ()> = Foo::StructVariant {
-        #[pin_v2] //~ ERROR `#[pin_v2]` attribute cannot be used on struct fields
+        #[pin_v2] //~ ERROR the `pin_v2` attribute cannot be used on struct fields
         field: (),
     };
     match param {
-        #[pin_v2] //~ ERROR `#[pin_v2]` attribute cannot be used on match arms
+        #[pin_v2] //~ ERROR the `pin_v2` attribute cannot be used on match arms
         Foo::UnitVariant => {}
         Foo::TupleVariant(..) => {}
         Foo::StructVariant {
-            #[pin_v2] //~ ERROR `#[pin_v2]` attribute cannot be used on pattern fields
+            #[pin_v2] //~ ERROR the `pin_v2` attribute cannot be used on pattern fields
             field,
         } => {}
     }
 }
 
-#[pin_v2] //~ ERROR `#[pin_v2]` attribute cannot be used on modules
+#[pin_v2] //~ ERROR the `pin_v2` attribute cannot be used on modules
 mod m {}
 
-#[pin_v2] //~ ERROR `#[pin_v2]` attribute cannot be used on foreign modules
+#[pin_v2] //~ ERROR the `pin_v2` attribute cannot be used on foreign modules
 extern "C" {
-    #[pin_v2] //~ ERROR `#[pin_v2]` attribute cannot be used on foreign types
+    #[pin_v2] //~ ERROR the `pin_v2` attribute cannot be used on foreign types
     type ForeignTy;
 
-    #[pin_v2] //~ ERROR `#[pin_v2]` attribute cannot be used on foreign statics
+    #[pin_v2] //~ ERROR the `pin_v2` attribute cannot be used on foreign statics
     static EXTERN_STATIC: ();
 
-    #[pin_v2] //~ ERROR `#[pin_v2]` attribute cannot be used on foreign functions
+    #[pin_v2] //~ ERROR the `pin_v2` attribute cannot be used on foreign functions
     fn extern_fn();
 }
 
-#[pin_v2] //~ ERROR `#[pin_v2]` attribute cannot be used on type alias
+#[pin_v2] //~ ERROR the `pin_v2` attribute cannot be used on type alias
 type Type = ();
 
-#[pin_v2] //~ ERROR `#[pin_v2]` attribute cannot be used on macro defs
+#[pin_v2] //~ ERROR the `pin_v2` attribute cannot be used on macro defs
 macro_rules! macro_def {
     () => {};
 }
 
-#[pin_v2] //~ ERROR `#[pin_v2]` attribute cannot be used on macro calls
+#[pin_v2] //~ ERROR the `pin_v2` attribute cannot be used on macro calls
 macro_def!();
 
 fn main() {}

--- a/tests/ui/pin-ergonomics/pin_v2-attr.stderr
+++ b/tests/ui/pin-ergonomics/pin_v2-attr.stderr
@@ -1,10 +1,10 @@
-error: `#[pin_v2]` attribute cannot be used on macro calls
-  --> $DIR/pin_v2-attr.rs:135:1
+error: the `pin_v2` attribute cannot be used on macro calls
+  --> $DIR/pin_v2-attr.rs:135:3
    |
 LL | #[pin_v2]
-   | ^^^^^^^^^
+   |   ^^^^^^
    |
-   = help: `#[pin_v2]` can only be applied to data types
+   = help: the `pin_v2` attribute can only be applied to data types
    = note: placing this attribute on a macro invocation does nothing even if the macro expands to what would be a valid target for the attribute
 
 error: allow, cfg, cfg_attr, deny, expect, forbid, and warn are the only allowed built-in attributes in function parameters
@@ -13,301 +13,301 @@ error: allow, cfg, cfg_attr, deny, expect, forbid, and warn are the only allowed
 LL | fn f<T, U>(#[pin_v2] param: Foo<T, U>)
    |            ^^^^^^^^^
 
-error: `#[pin_v2]` attribute cannot be used on crates
-  --> $DIR/pin_v2-attr.rs:10:1
+error: the `pin_v2` attribute cannot be used on crates
+  --> $DIR/pin_v2-attr.rs:10:4
    |
 LL | #![pin_v2]
-   | ^^^^^^^^^^
+   |    ^^^^^^
    |
-   = help: `#[pin_v2]` can only be applied to data types
+   = help: the `pin_v2` attribute can only be applied to data types
 
-error: `#[pin_v2]` attribute cannot be used on type parameters
-  --> $DIR/pin_v2-attr.rs:27:10
+error: the `pin_v2` attribute cannot be used on type parameters
+  --> $DIR/pin_v2-attr.rs:27:12
    |
 LL | enum Foo<#[pin_v2] T, #[pin_v2] U = ()> {
-   |          ^^^^^^^^^
+   |            ^^^^^^
    |
-   = help: `#[pin_v2]` can only be applied to data types
+   = help: the `pin_v2` attribute can only be applied to data types
 
-error: `#[pin_v2]` attribute cannot be used on type parameters
-  --> $DIR/pin_v2-attr.rs:27:23
+error: the `pin_v2` attribute cannot be used on type parameters
+  --> $DIR/pin_v2-attr.rs:27:25
    |
 LL | enum Foo<#[pin_v2] T, #[pin_v2] U = ()> {
-   |                       ^^^^^^^^^
+   |                         ^^^^^^
    |
-   = help: `#[pin_v2]` can only be applied to data types
+   = help: the `pin_v2` attribute can only be applied to data types
 
-error: `#[pin_v2]` attribute cannot be used on enum variants
-  --> $DIR/pin_v2-attr.rs:30:5
+error: the `pin_v2` attribute cannot be used on enum variants
+  --> $DIR/pin_v2-attr.rs:30:7
    |
 LL |     #[pin_v2]
-   |     ^^^^^^^^^
+   |       ^^^^^^
    |
-   = help: `#[pin_v2]` can only be applied to data types
+   = help: the `pin_v2` attribute can only be applied to data types
 
-error: `#[pin_v2]` attribute cannot be used on struct fields
-  --> $DIR/pin_v2-attr.rs:32:18
+error: the `pin_v2` attribute cannot be used on struct fields
+  --> $DIR/pin_v2-attr.rs:32:20
    |
 LL |     TupleVariant(#[pin_v2] T),
-   |                  ^^^^^^^^^
+   |                    ^^^^^^
    |
-   = help: `#[pin_v2]` can only be applied to data types
+   = help: the `pin_v2` attribute can only be applied to data types
 
-error: `#[pin_v2]` attribute cannot be used on struct fields
-  --> $DIR/pin_v2-attr.rs:34:9
+error: the `pin_v2` attribute cannot be used on struct fields
+  --> $DIR/pin_v2-attr.rs:34:11
    |
 LL |         #[pin_v2]
-   |         ^^^^^^^^^
+   |           ^^^^^^
    |
-   = help: `#[pin_v2]` can only be applied to data types
+   = help: the `pin_v2` attribute can only be applied to data types
 
-error: `#[pin_v2]` attribute cannot be used on traits
-  --> $DIR/pin_v2-attr.rs:39:1
+error: the `pin_v2` attribute cannot be used on traits
+  --> $DIR/pin_v2-attr.rs:39:3
    |
 LL | #[pin_v2]
-   | ^^^^^^^^^
+   |   ^^^^^^
    |
-   = help: `#[pin_v2]` can only be applied to data types
+   = help: the `pin_v2` attribute can only be applied to data types
 
-error: `#[pin_v2]` attribute cannot be used on associated consts
-  --> $DIR/pin_v2-attr.rs:41:5
+error: the `pin_v2` attribute cannot be used on associated consts
+  --> $DIR/pin_v2-attr.rs:41:7
    |
 LL |     #[pin_v2]
-   |     ^^^^^^^^^
+   |       ^^^^^^
    |
-   = help: `#[pin_v2]` can only be applied to data types
+   = help: the `pin_v2` attribute can only be applied to data types
 
-error: `#[pin_v2]` attribute cannot be used on associated types
-  --> $DIR/pin_v2-attr.rs:43:5
+error: the `pin_v2` attribute cannot be used on associated types
+  --> $DIR/pin_v2-attr.rs:43:7
    |
 LL |     #[pin_v2]
-   |     ^^^^^^^^^
+   |       ^^^^^^
    |
-   = help: `#[pin_v2]` can only be applied to data types
+   = help: the `pin_v2` attribute can only be applied to data types
 
-error: `#[pin_v2]` attribute cannot be used on required trait methods
-  --> $DIR/pin_v2-attr.rs:46:5
+error: the `pin_v2` attribute cannot be used on required trait methods
+  --> $DIR/pin_v2-attr.rs:46:7
    |
 LL |     #[pin_v2]
-   |     ^^^^^^^^^
+   |       ^^^^^^
    |
-   = help: `#[pin_v2]` can only be applied to data types
+   = help: the `pin_v2` attribute can only be applied to data types
 
-error: `#[pin_v2]` attribute cannot be used on provided trait methods
-  --> $DIR/pin_v2-attr.rs:48:5
+error: the `pin_v2` attribute cannot be used on provided trait methods
+  --> $DIR/pin_v2-attr.rs:48:7
    |
 LL |     #[pin_v2]
-   |     ^^^^^^^^^
+   |       ^^^^^^
    |
-   = help: `#[pin_v2]` can only be applied to data types
+   = help: the `pin_v2` attribute can only be applied to data types
 
-error: `#[pin_v2]` attribute cannot be used on trait aliases
-  --> $DIR/pin_v2-attr.rs:52:1
+error: the `pin_v2` attribute cannot be used on trait aliases
+  --> $DIR/pin_v2-attr.rs:52:3
    |
 LL | #[pin_v2]
-   | ^^^^^^^^^
+   |   ^^^^^^
    |
-   = help: `#[pin_v2]` can only be applied to data types
+   = help: the `pin_v2` attribute can only be applied to data types
 
-error: `#[pin_v2]` attribute cannot be used on inherent impl blocks
-  --> $DIR/pin_v2-attr.rs:55:1
+error: the `pin_v2` attribute cannot be used on inherent impl blocks
+  --> $DIR/pin_v2-attr.rs:55:3
    |
 LL | #[pin_v2]
-   | ^^^^^^^^^
+   |   ^^^^^^
    |
-   = help: `#[pin_v2]` can only be applied to data types
+   = help: the `pin_v2` attribute can only be applied to data types
 
-error: `#[pin_v2]` attribute cannot be used on delegations
-  --> $DIR/pin_v2-attr.rs:58:5
+error: the `pin_v2` attribute cannot be used on delegations
+  --> $DIR/pin_v2-attr.rs:58:7
    |
 LL |     #[pin_v2]
-   |     ^^^^^^^^^
+   |       ^^^^^^
    |
-   = help: `#[pin_v2]` can only be applied to data types
+   = help: the `pin_v2` attribute can only be applied to data types
 
-error: `#[pin_v2]` attribute cannot be used on inherent methods
-  --> $DIR/pin_v2-attr.rs:61:5
+error: the `pin_v2` attribute cannot be used on inherent methods
+  --> $DIR/pin_v2-attr.rs:61:7
    |
 LL |     #[pin_v2]
-   |     ^^^^^^^^^
+   |       ^^^^^^
    |
-   = help: `#[pin_v2]` can only be applied to data types
+   = help: the `pin_v2` attribute can only be applied to data types
 
-error: `#[pin_v2]` attribute cannot be used on trait impl blocks
-  --> $DIR/pin_v2-attr.rs:65:1
+error: the `pin_v2` attribute cannot be used on trait impl blocks
+  --> $DIR/pin_v2-attr.rs:65:3
    |
 LL | #[pin_v2]
-   | ^^^^^^^^^
+   |   ^^^^^^
    |
-   = help: `#[pin_v2]` can only be applied to data types
+   = help: the `pin_v2` attribute can only be applied to data types
 
-error: `#[pin_v2]` attribute cannot be used on trait methods in impl blocks
-  --> $DIR/pin_v2-attr.rs:67:5
+error: the `pin_v2` attribute cannot be used on trait methods in impl blocks
+  --> $DIR/pin_v2-attr.rs:67:7
    |
 LL |     #[pin_v2]
-   |     ^^^^^^^^^
+   |       ^^^^^^
    |
-   = help: `#[pin_v2]` can only be applied to data types
+   = help: the `pin_v2` attribute can only be applied to data types
 
-error: `#[pin_v2]` attribute cannot be used on extern crates
-  --> $DIR/pin_v2-attr.rs:71:1
+error: the `pin_v2` attribute cannot be used on extern crates
+  --> $DIR/pin_v2-attr.rs:71:3
    |
 LL | #[pin_v2]
-   | ^^^^^^^^^
+   |   ^^^^^^
    |
-   = help: `#[pin_v2]` can only be applied to data types
+   = help: the `pin_v2` attribute can only be applied to data types
 
-error: `#[pin_v2]` attribute cannot be used on use statements
-  --> $DIR/pin_v2-attr.rs:74:1
+error: the `pin_v2` attribute cannot be used on use statements
+  --> $DIR/pin_v2-attr.rs:74:3
    |
 LL | #[pin_v2]
-   | ^^^^^^^^^
+   |   ^^^^^^
    |
-   = help: `#[pin_v2]` can only be applied to data types
+   = help: the `pin_v2` attribute can only be applied to data types
 
-error: `#[pin_v2]` attribute cannot be used on statics
-  --> $DIR/pin_v2-attr.rs:77:1
+error: the `pin_v2` attribute cannot be used on statics
+  --> $DIR/pin_v2-attr.rs:77:3
    |
 LL | #[pin_v2]
-   | ^^^^^^^^^
+   |   ^^^^^^
    |
-   = help: `#[pin_v2]` can only be applied to data types
+   = help: the `pin_v2` attribute can only be applied to data types
 
-error: `#[pin_v2]` attribute cannot be used on constants
-  --> $DIR/pin_v2-attr.rs:80:1
+error: the `pin_v2` attribute cannot be used on constants
+  --> $DIR/pin_v2-attr.rs:80:3
    |
 LL | #[pin_v2]
-   | ^^^^^^^^^
+   |   ^^^^^^
    |
-   = help: `#[pin_v2]` can only be applied to data types
+   = help: the `pin_v2` attribute can only be applied to data types
 
-error: `#[pin_v2]` attribute cannot be used on functions
-  --> $DIR/pin_v2-attr.rs:83:1
+error: the `pin_v2` attribute cannot be used on functions
+  --> $DIR/pin_v2-attr.rs:83:3
    |
 LL | #[pin_v2]
-   | ^^^^^^^^^
+   |   ^^^^^^
    |
-   = help: `#[pin_v2]` can only be applied to data types
+   = help: the `pin_v2` attribute can only be applied to data types
 
-error: `#[pin_v2]` attribute cannot be used on function params
-  --> $DIR/pin_v2-attr.rs:84:12
+error: the `pin_v2` attribute cannot be used on function params
+  --> $DIR/pin_v2-attr.rs:84:14
    |
 LL | fn f<T, U>(#[pin_v2] param: Foo<T, U>)
-   |            ^^^^^^^^^
+   |              ^^^^^^
    |
-   = help: `#[pin_v2]` can only be applied to data types
+   = help: the `pin_v2` attribute can only be applied to data types
 
-error: `#[pin_v2]` attribute cannot be used on closures
-  --> $DIR/pin_v2-attr.rs:92:5
+error: the `pin_v2` attribute cannot be used on closures
+  --> $DIR/pin_v2-attr.rs:92:7
    |
 LL |     #[pin_v2]
-   |     ^^^^^^^^^
+   |       ^^^^^^
    |
-   = help: `#[pin_v2]` can only be applied to data types
+   = help: the `pin_v2` attribute can only be applied to data types
 
-error: `#[pin_v2]` attribute cannot be used on expressions
-  --> $DIR/pin_v2-attr.rs:94:5
+error: the `pin_v2` attribute cannot be used on expressions
+  --> $DIR/pin_v2-attr.rs:94:7
    |
 LL |     #[pin_v2]
-   |     ^^^^^^^^^
+   |       ^^^^^^
    |
-   = help: `#[pin_v2]` can only be applied to data types
+   = help: the `pin_v2` attribute can only be applied to data types
 
-error: `#[pin_v2]` attribute cannot be used on struct fields
-  --> $DIR/pin_v2-attr.rs:98:9
+error: the `pin_v2` attribute cannot be used on struct fields
+  --> $DIR/pin_v2-attr.rs:98:11
    |
 LL |         #[pin_v2]
-   |         ^^^^^^^^^
+   |           ^^^^^^
    |
-   = help: `#[pin_v2]` can only be applied to data types
+   = help: the `pin_v2` attribute can only be applied to data types
 
-error: `#[pin_v2]` attribute cannot be used on statements
-  --> $DIR/pin_v2-attr.rs:96:5
+error: the `pin_v2` attribute cannot be used on statements
+  --> $DIR/pin_v2-attr.rs:96:7
    |
 LL |     #[pin_v2]
-   |     ^^^^^^^^^
+   |       ^^^^^^
    |
-   = help: `#[pin_v2]` can only be applied to data types
+   = help: the `pin_v2` attribute can only be applied to data types
 
-error: `#[pin_v2]` attribute cannot be used on match arms
-  --> $DIR/pin_v2-attr.rs:102:9
+error: the `pin_v2` attribute cannot be used on match arms
+  --> $DIR/pin_v2-attr.rs:102:11
    |
 LL |         #[pin_v2]
-   |         ^^^^^^^^^
+   |           ^^^^^^
    |
-   = help: `#[pin_v2]` can only be applied to data types
+   = help: the `pin_v2` attribute can only be applied to data types
 
-error: `#[pin_v2]` attribute cannot be used on pattern fields
-  --> $DIR/pin_v2-attr.rs:106:13
+error: the `pin_v2` attribute cannot be used on pattern fields
+  --> $DIR/pin_v2-attr.rs:106:15
    |
 LL |             #[pin_v2]
-   |             ^^^^^^^^^
+   |               ^^^^^^
    |
-   = help: `#[pin_v2]` can only be applied to data types
+   = help: the `pin_v2` attribute can only be applied to data types
 
-error: `#[pin_v2]` attribute cannot be used on where predicates
-  --> $DIR/pin_v2-attr.rs:88:5
+error: the `pin_v2` attribute cannot be used on where predicates
+  --> $DIR/pin_v2-attr.rs:88:7
    |
 LL |     #[pin_v2]
-   |     ^^^^^^^^^
+   |       ^^^^^^
    |
-   = help: `#[pin_v2]` can only be applied to data types
+   = help: the `pin_v2` attribute can only be applied to data types
 
-error: `#[pin_v2]` attribute cannot be used on modules
-  --> $DIR/pin_v2-attr.rs:112:1
+error: the `pin_v2` attribute cannot be used on modules
+  --> $DIR/pin_v2-attr.rs:112:3
    |
 LL | #[pin_v2]
-   | ^^^^^^^^^
+   |   ^^^^^^
    |
-   = help: `#[pin_v2]` can only be applied to data types
+   = help: the `pin_v2` attribute can only be applied to data types
 
-error: `#[pin_v2]` attribute cannot be used on foreign modules
-  --> $DIR/pin_v2-attr.rs:115:1
+error: the `pin_v2` attribute cannot be used on foreign modules
+  --> $DIR/pin_v2-attr.rs:115:3
    |
 LL | #[pin_v2]
-   | ^^^^^^^^^
+   |   ^^^^^^
    |
-   = help: `#[pin_v2]` can only be applied to data types
+   = help: the `pin_v2` attribute can only be applied to data types
 
-error: `#[pin_v2]` attribute cannot be used on foreign types
-  --> $DIR/pin_v2-attr.rs:117:5
+error: the `pin_v2` attribute cannot be used on foreign types
+  --> $DIR/pin_v2-attr.rs:117:7
    |
 LL |     #[pin_v2]
-   |     ^^^^^^^^^
+   |       ^^^^^^
    |
-   = help: `#[pin_v2]` can only be applied to data types
+   = help: the `pin_v2` attribute can only be applied to data types
 
-error: `#[pin_v2]` attribute cannot be used on foreign statics
-  --> $DIR/pin_v2-attr.rs:120:5
+error: the `pin_v2` attribute cannot be used on foreign statics
+  --> $DIR/pin_v2-attr.rs:120:7
    |
 LL |     #[pin_v2]
-   |     ^^^^^^^^^
+   |       ^^^^^^
    |
-   = help: `#[pin_v2]` can only be applied to data types
+   = help: the `pin_v2` attribute can only be applied to data types
 
-error: `#[pin_v2]` attribute cannot be used on foreign functions
-  --> $DIR/pin_v2-attr.rs:123:5
+error: the `pin_v2` attribute cannot be used on foreign functions
+  --> $DIR/pin_v2-attr.rs:123:7
    |
 LL |     #[pin_v2]
-   |     ^^^^^^^^^
+   |       ^^^^^^
    |
-   = help: `#[pin_v2]` can only be applied to data types
+   = help: the `pin_v2` attribute can only be applied to data types
 
-error: `#[pin_v2]` attribute cannot be used on type aliases
-  --> $DIR/pin_v2-attr.rs:127:1
+error: the `pin_v2` attribute cannot be used on type aliases
+  --> $DIR/pin_v2-attr.rs:127:3
    |
 LL | #[pin_v2]
-   | ^^^^^^^^^
+   |   ^^^^^^
    |
-   = help: `#[pin_v2]` can only be applied to data types
+   = help: the `pin_v2` attribute can only be applied to data types
 
-error: `#[pin_v2]` attribute cannot be used on macro defs
-  --> $DIR/pin_v2-attr.rs:130:1
+error: the `pin_v2` attribute cannot be used on macro defs
+  --> $DIR/pin_v2-attr.rs:130:3
    |
 LL | #[pin_v2]
-   | ^^^^^^^^^
+   |   ^^^^^^
    |
-   = help: `#[pin_v2]` can only be applied to data types
+   = help: the `pin_v2` attribute can only be applied to data types
 
 error: aborting due to 39 previous errors
 

--- a/tests/ui/proc-macro/ambiguous-builtin-attrs.stderr
+++ b/tests/ui/proc-macro/ambiguous-builtin-attrs.stderr
@@ -94,21 +94,21 @@ LL | use builtin_attrs::*;
    |     ^^^^^^^^^^^^^^^^
    = help: use `crate::feature` to refer to this attribute macro unambiguously
 
-error: `#[repr(C)]` attribute cannot be used on match arms
-  --> $DIR/ambiguous-builtin-attrs.rs:25:9
+error: the `repr(C)` attribute cannot be used on match arms
+  --> $DIR/ambiguous-builtin-attrs.rs:25:11
    |
 LL |         #[repr(C)]
-   |         ^^^^^^^^^^
+   |           ^^^^^^^
    |
-   = help: `#[repr(C)]` can only be applied to data types
+   = help: the `repr(C)` attribute can only be applied to data types
 
-error: `#[repr(C)]` attribute cannot be used on type parameters
-  --> $DIR/ambiguous-builtin-attrs.rs:21:32
+error: the `repr(C)` attribute cannot be used on type parameters
+  --> $DIR/ambiguous-builtin-attrs.rs:21:34
    |
 LL | fn non_macro_expanded_location<#[repr(C)] T>() {
-   |                                ^^^^^^^^^^
+   |                                  ^^^^^^^
    |
-   = help: `#[repr(C)]` can only be applied to data types
+   = help: the `repr(C)` attribute can only be applied to data types
 
 error: aborting due to 9 previous errors
 

--- a/tests/ui/proc-macro/attribute.stderr
+++ b/tests/ui/proc-macro/attribute.stderr
@@ -1,8 +1,8 @@
 error[E0539]: malformed `proc_macro_derive` attribute input
-  --> $DIR/attribute.rs:9:1
+  --> $DIR/attribute.rs:9:3
    |
 LL | #[proc_macro_derive]
-   | ^^^^^^^^^^^^^^^^^^^^ expected this to be a list
+   |   ^^^^^^^^^^^^^^^^^ expected this to be a list
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/procedural-macros.html#derive-macros>
 help: try changing it to one of the following valid forms of the attribute
@@ -13,10 +13,10 @@ LL | #[proc_macro_derive(TraitName, attributes(name1, name2, ...))]
    |                    ++++++++++++++++++++++++++++++++++++++++++
 
 error[E0539]: malformed `proc_macro_derive` attribute input
-  --> $DIR/attribute.rs:15:1
+  --> $DIR/attribute.rs:15:3
    |
 LL | #[proc_macro_derive = ""]
-   | ^^^^^^^^^^^^^^^^^^^^----^
+   |   ^^^^^^^^^^^^^^^^^^----
    |                     |
    |                     expected this to be a list
    |
@@ -31,10 +31,10 @@ LL + #[proc_macro_derive(TraitName, attributes(name1, name2, ...))]
    |
 
 error[E0539]: malformed `proc_macro_derive` attribute input
-  --> $DIR/attribute.rs:21:1
+  --> $DIR/attribute.rs:21:3
    |
 LL | #[proc_macro_derive(d3, a, b)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^-^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^-^^^^
    |                         |
    |                         the only valid argument here is `attributes`
    |
@@ -49,10 +49,10 @@ LL + #[proc_macro_derive(TraitName, attributes(name1, name2, ...))]
    |
 
 error[E0565]: malformed `proc_macro_derive` attribute input
-  --> $DIR/attribute.rs:27:1
+  --> $DIR/attribute.rs:27:3
    |
 LL | #[proc_macro_derive(d4, attributes(a), b)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-^
    |                                        |
    |                                        didn't expect any arguments here
    |
@@ -67,10 +67,10 @@ LL + #[proc_macro_derive(TraitName, attributes(name1, name2, ...))]
    |
 
 error[E0565]: malformed `proc_macro_derive` attribute input
-  --> $DIR/attribute.rs:33:1
+  --> $DIR/attribute.rs:33:3
    |
 LL | #[proc_macro_derive("a")]
-   | ^^^^^^^^^^^^^^^^^^^^---^^
+   |   ^^^^^^^^^^^^^^^^^^---^
    |                     |
    |                     didn't expect a literal here
    |
@@ -85,10 +85,10 @@ LL + #[proc_macro_derive(TraitName, attributes(name1, name2, ...))]
    |
 
 error[E0565]: malformed `proc_macro_derive` attribute input
-  --> $DIR/attribute.rs:39:1
+  --> $DIR/attribute.rs:39:3
    |
 LL | #[proc_macro_derive(d6 = "")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^----^^
+   |   ^^^^^^^^^^^^^^^^^^^^^----^
    |                        |
    |                        didn't expect any arguments here
    |
@@ -103,10 +103,10 @@ LL + #[proc_macro_derive(TraitName, attributes(name1, name2, ...))]
    |
 
 error[E0565]: malformed `proc_macro_derive` attribute input
-  --> $DIR/attribute.rs:45:1
+  --> $DIR/attribute.rs:45:3
    |
 LL | #[proc_macro_derive(m::d7)]
-   | ^^^^^^^^^^^^^^^^^^^^-----^^
+   |   ^^^^^^^^^^^^^^^^^^-----^
    |                     |
    |                     expected a valid identifier here
    |
@@ -121,10 +121,10 @@ LL + #[proc_macro_derive(TraitName, attributes(name1, name2, ...))]
    |
 
 error[E0565]: malformed `proc_macro_derive` attribute input
-  --> $DIR/attribute.rs:51:1
+  --> $DIR/attribute.rs:51:3
    |
 LL | #[proc_macro_derive(d8(a))]
-   | ^^^^^^^^^^^^^^^^^^^^^^---^^
+   |   ^^^^^^^^^^^^^^^^^^^^---^
    |                       |
    |                       didn't expect any arguments here
    |
@@ -139,10 +139,10 @@ LL + #[proc_macro_derive(TraitName, attributes(name1, name2, ...))]
    |
 
 error[E0565]: malformed `proc_macro_derive` attribute input
-  --> $DIR/attribute.rs:57:1
+  --> $DIR/attribute.rs:57:3
    |
 LL | #[proc_macro_derive(self)]
-   | ^^^^^^^^^^^^^^^^^^^^----^^
+   |   ^^^^^^^^^^^^^^^^^^----^
    |                     |
    |                     expected a valid identifier here
    |
@@ -157,10 +157,10 @@ LL + #[proc_macro_derive(TraitName, attributes(name1, name2, ...))]
    |
 
 error[E0539]: malformed `proc_macro_derive` attribute input
-  --> $DIR/attribute.rs:66:1
+  --> $DIR/attribute.rs:66:3
    |
 LL | #[proc_macro_derive(d11, a)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^-^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^-^
    |                          |
    |                          the only valid argument here is `attributes`
    |
@@ -175,10 +175,10 @@ LL + #[proc_macro_derive(TraitName, attributes(name1, name2, ...))]
    |
 
 error[E0539]: malformed `proc_macro_derive` attribute input
-  --> $DIR/attribute.rs:72:1
+  --> $DIR/attribute.rs:72:3
    |
 LL | #[proc_macro_derive(d12, attributes)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^----------^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^----------^
    |                          |
    |                          expected this to be a list
    |
@@ -193,10 +193,10 @@ LL + #[proc_macro_derive(TraitName, attributes(name1, name2, ...))]
    |
 
 error[E0565]: malformed `proc_macro_derive` attribute input
-  --> $DIR/attribute.rs:78:1
+  --> $DIR/attribute.rs:78:3
    |
 LL | #[proc_macro_derive(d13, attributes("a"))]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---^^
    |                                     |
    |                                     expected a valid identifier here
    |
@@ -211,10 +211,10 @@ LL + #[proc_macro_derive(TraitName, attributes(name1, name2, ...))]
    |
 
 error[E0565]: malformed `proc_macro_derive` attribute input
-  --> $DIR/attribute.rs:84:1
+  --> $DIR/attribute.rs:84:3
    |
 LL | #[proc_macro_derive(d14, attributes(a = ""))]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^----^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^----^^
    |                                       |
    |                                       didn't expect any arguments here
    |
@@ -229,10 +229,10 @@ LL + #[proc_macro_derive(TraitName, attributes(name1, name2, ...))]
    |
 
 error[E0565]: malformed `proc_macro_derive` attribute input
-  --> $DIR/attribute.rs:90:1
+  --> $DIR/attribute.rs:90:3
    |
 LL | #[proc_macro_derive(d15, attributes(m::a))]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^----^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^----^^
    |                                     |
    |                                     expected a valid identifier here
    |
@@ -247,10 +247,10 @@ LL + #[proc_macro_derive(TraitName, attributes(name1, name2, ...))]
    |
 
 error[E0565]: malformed `proc_macro_derive` attribute input
-  --> $DIR/attribute.rs:96:1
+  --> $DIR/attribute.rs:96:3
    |
 LL | #[proc_macro_derive(d16, attributes(a(b)))]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---^^
    |                                      |
    |                                      didn't expect any arguments here
    |
@@ -265,10 +265,10 @@ LL + #[proc_macro_derive(TraitName, attributes(name1, name2, ...))]
    |
 
 error[E0565]: malformed `proc_macro_derive` attribute input
-  --> $DIR/attribute.rs:102:1
+  --> $DIR/attribute.rs:102:3
    |
 LL | #[proc_macro_derive(d17, attributes(self))]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^----^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^----^^
    |                                     |
    |                                     expected a valid identifier here
    |

--- a/tests/ui/proc-macro/illegal-proc-macro-derive-use.stderr
+++ b/tests/ui/proc-macro/illegal-proc-macro-derive-use.stderr
@@ -4,13 +4,13 @@ error: the `#[proc_macro_derive]` attribute is only usable with crates of the `p
 LL | #[proc_macro_derive(Foo)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: `#[proc_macro_derive]` attribute cannot be used on structs
-  --> $DIR/illegal-proc-macro-derive-use.rs:10:1
+error: the `proc_macro_derive` attribute cannot be used on structs
+  --> $DIR/illegal-proc-macro-derive-use.rs:10:3
    |
 LL | #[proc_macro_derive(Foo)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^
    |
-   = help: `#[proc_macro_derive]` can only be applied to functions
+   = help: the `proc_macro_derive` attribute can only be applied to functions
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/proc-macro/invalid-attributes.stderr
+++ b/tests/ui/proc-macro/invalid-attributes.stderr
@@ -1,8 +1,8 @@
 error[E0565]: malformed `proc_macro` attribute input
-  --> $DIR/invalid-attributes.rs:10:1
+  --> $DIR/invalid-attributes.rs:10:3
    |
 LL | #[proc_macro = "test"]
-   | ^^^^^^^^^^^^^--------^
+   |   ^^^^^^^^^^^--------
    |              |
    |              didn't expect any arguments here
    |
@@ -13,10 +13,10 @@ LL + #[proc_macro]
    |
 
 error[E0565]: malformed `proc_macro` attribute input
-  --> $DIR/invalid-attributes.rs:15:1
+  --> $DIR/invalid-attributes.rs:15:3
    |
 LL | #[proc_macro()]
-   | ^^^^^^^^^^^^--^
+   |   ^^^^^^^^^^--
    |             |
    |             didn't expect any arguments here
    |
@@ -27,10 +27,10 @@ LL + #[proc_macro]
    |
 
 error[E0565]: malformed `proc_macro` attribute input
-  --> $DIR/invalid-attributes.rs:20:1
+  --> $DIR/invalid-attributes.rs:20:3
    |
 LL | #[proc_macro(x)]
-   | ^^^^^^^^^^^^---^
+   |   ^^^^^^^^^^---
    |             |
    |             didn't expect any arguments here
    |
@@ -41,10 +41,10 @@ LL + #[proc_macro]
    |
 
 error[E0565]: malformed `proc_macro_attribute` attribute input
-  --> $DIR/invalid-attributes.rs:25:1
+  --> $DIR/invalid-attributes.rs:25:3
    |
 LL | #[proc_macro_attribute = "test"]
-   | ^^^^^^^^^^^^^^^^^^^^^^^--------^
+   |   ^^^^^^^^^^^^^^^^^^^^^--------
    |                        |
    |                        didn't expect any arguments here
    |
@@ -55,10 +55,10 @@ LL + #[proc_macro_attribute]
    |
 
 error[E0565]: malformed `proc_macro_attribute` attribute input
-  --> $DIR/invalid-attributes.rs:30:1
+  --> $DIR/invalid-attributes.rs:30:3
    |
 LL | #[proc_macro_attribute()]
-   | ^^^^^^^^^^^^^^^^^^^^^^--^
+   |   ^^^^^^^^^^^^^^^^^^^^--
    |                       |
    |                       didn't expect any arguments here
    |
@@ -69,10 +69,10 @@ LL + #[proc_macro_attribute]
    |
 
 error[E0565]: malformed `proc_macro_attribute` attribute input
-  --> $DIR/invalid-attributes.rs:35:1
+  --> $DIR/invalid-attributes.rs:35:3
    |
 LL | #[proc_macro_attribute(x)]
-   | ^^^^^^^^^^^^^^^^^^^^^^---^
+   |   ^^^^^^^^^^^^^^^^^^^^---
    |                       |
    |                       didn't expect any arguments here
    |

--- a/tests/ui/recursion/recursion_limit/invalid_digit_type.stderr
+++ b/tests/ui/recursion/recursion_limit/invalid_digit_type.stderr
@@ -1,8 +1,8 @@
 error[E0539]: malformed `recursion_limit` attribute input
-  --> $DIR/invalid_digit_type.rs:1:1
+  --> $DIR/invalid_digit_type.rs:1:4
    |
 LL | #![recursion_limit = 123]
-   | ^^^^^^^^^^^^^^^^^^^^^---^
+   |    ^^^^^^^^^^^^^^^^^^---
    |                      |
    |                      expected a string literal here
    |

--- a/tests/ui/recursion/recursion_limit/no-value.stderr
+++ b/tests/ui/recursion/recursion_limit/no-value.stderr
@@ -1,8 +1,8 @@
 error[E0539]: malformed `recursion_limit` attribute input
-  --> $DIR/no-value.rs:3:1
+  --> $DIR/no-value.rs:3:4
    |
 LL | #![recursion_limit]
-   | ^^^^^^^^^^^^^^^^^^^
+   |    ^^^^^^^^^^^^^^^
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/attributes/limits.html#the-recursion_limit-attribute>
 help: must be of the form

--- a/tests/ui/repr/attr-usage-repr.stderr
+++ b/tests/ui/repr/attr-usage-repr.stderr
@@ -1,42 +1,42 @@
-error: `#[repr(C)]` attribute cannot be used on functions
-  --> $DIR/attr-usage-repr.rs:3:1
+error: the `repr(C)` attribute cannot be used on functions
+  --> $DIR/attr-usage-repr.rs:3:3
    |
 LL | #[repr(C)]
-   | ^^^^^^^^^^
+   |   ^^^^^^^
    |
-   = help: `#[repr(C)]` can only be applied to data types
+   = help: the `repr(C)` attribute can only be applied to data types
 
-error: `#[repr(i8)]` attribute cannot be used on structs
-  --> $DIR/attr-usage-repr.rs:15:1
+error: the `repr(i8)` attribute cannot be used on structs
+  --> $DIR/attr-usage-repr.rs:15:3
    |
 LL | #[repr(i8)]
-   | ^^^^^^^^^^^
+   |   ^^^^^^^^
    |
-   = help: `#[repr(i8)]` can only be applied to enums
+   = help: the `repr(i8)` attribute can only be applied to enums
 
-error: `#[repr(packed)]` attribute cannot be used on enums
-  --> $DIR/attr-usage-repr.rs:30:1
+error: the `repr(packed)` attribute cannot be used on enums
+  --> $DIR/attr-usage-repr.rs:30:3
    |
 LL | #[repr(packed)]
-   | ^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^
    |
-   = help: `#[repr(packed)]` can be applied to structs and unions
+   = help: the `repr(packed)` attribute can be applied to structs and unions
 
-error: `#[repr(simd)]` attribute cannot be used on enums
-  --> $DIR/attr-usage-repr.rs:36:1
+error: the `repr(simd)` attribute cannot be used on enums
+  --> $DIR/attr-usage-repr.rs:36:3
    |
 LL | #[repr(simd)]
-   | ^^^^^^^^^^^^^
+   |   ^^^^^^^^^^
    |
-   = help: `#[repr(simd)]` can only be applied to structs
+   = help: the `repr(simd)` attribute can only be applied to structs
 
-error: `#[repr()]` attribute cannot be used on type aliases
-  --> $DIR/attr-usage-repr.rs:48:1
+error: the `repr()` attribute cannot be used on type aliases
+  --> $DIR/attr-usage-repr.rs:48:3
    |
 LL | #[repr()]
-   | ^^^^^^^^^
+   |   ^^^^^^
    |
-   = help: `#[repr()]` can only be applied to data types
+   = help: the `repr()` attribute can only be applied to data types
 
 warning: unused attribute
   --> $DIR/attr-usage-repr.rs:48:1

--- a/tests/ui/repr/invalid-repr-on-structs-74082.stderr
+++ b/tests/ui/repr/invalid-repr-on-structs-74082.stderr
@@ -1,18 +1,18 @@
-error: `#[repr(i128)]` attribute cannot be used on structs
-  --> $DIR/invalid-repr-on-structs-74082.rs:4:1
+error: the `repr(i128)` attribute cannot be used on structs
+  --> $DIR/invalid-repr-on-structs-74082.rs:4:3
    |
 LL | #[repr(i128)]
-   | ^^^^^^^^^^^^^
+   |   ^^^^^^^^^^
    |
-   = help: `#[repr(i128)]` can only be applied to enums
+   = help: the `repr(i128)` attribute can only be applied to enums
 
-error: `#[repr(u128)]` attribute cannot be used on structs
-  --> $DIR/invalid-repr-on-structs-74082.rs:7:1
+error: the `repr(u128)` attribute cannot be used on structs
+  --> $DIR/invalid-repr-on-structs-74082.rs:7:3
    |
 LL | #[repr(u128)]
-   | ^^^^^^^^^^^^^
+   |   ^^^^^^^^^^
    |
-   = help: `#[repr(u128)]` can only be applied to enums
+   = help: the `repr(u128)` attribute can only be applied to enums
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/repr/invalid_repr_list_help.stderr
+++ b/tests/ui/repr/invalid_repr_list_help.stderr
@@ -1,48 +1,48 @@
 error[E0539]: malformed `repr` attribute input
-  --> $DIR/invalid_repr_list_help.rs:4:1
+  --> $DIR/invalid_repr_list_help.rs:4:3
    |
 LL | #[repr(uwu)]
-   | ^^^^^^^---^^
+   |   ^^^^^---^
    |        |
    |        valid arguments are `align`, `packed`, `Rust`, `C`, `simd`, `transparent`, `i8`, `u8`, `i16`, `u16`, `i32`, `u32`, `i64`, `u64`, `i128`, `u128`, `isize` or `usize`
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/type-layout.html#representations>
 
 error[E0539]: malformed `repr` attribute input
-  --> $DIR/invalid_repr_list_help.rs:7:1
+  --> $DIR/invalid_repr_list_help.rs:7:3
    |
 LL | #[repr(uwu = "a")]
-   | ^^^^^^^---------^^
+   |   ^^^^^---------^
    |        |
    |        valid arguments are `align`, `packed`, `Rust`, `C`, `simd`, `transparent`, `i8`, `u8`, `i16`, `u16`, `i32`, `u32`, `i64`, `u64`, `i128`, `u128`, `isize` or `usize`
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/type-layout.html#representations>
 
 error[E0539]: malformed `repr` attribute input
-  --> $DIR/invalid_repr_list_help.rs:10:1
+  --> $DIR/invalid_repr_list_help.rs:10:3
    |
 LL | #[repr(uwu(4))]
-   | ^^^^^^^------^^
+   |   ^^^^^------^
    |        |
    |        valid arguments are `align`, `packed`, `Rust`, `C`, `simd`, `transparent`, `i8`, `u8`, `i16`, `u16`, `i32`, `u32`, `i64`, `u64`, `i128`, `u128`, `isize` or `usize`
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/type-layout.html#representations>
 
 error[E0539]: malformed `repr` attribute input
-  --> $DIR/invalid_repr_list_help.rs:15:1
+  --> $DIR/invalid_repr_list_help.rs:15:3
    |
 LL | #[repr(uwu, u8)]
-   | ^^^^^^^---^^^^^^
+   |   ^^^^^---^^^^^
    |        |
    |        valid arguments are `align`, `packed`, `Rust`, `C`, `simd`, `transparent`, `i8`, `u8`, `i16`, `u16`, `i32`, `u32`, `i64`, `u64`, `i128`, `u128`, `isize` or `usize`
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/type-layout.html#representations>
 
 error[E0539]: malformed `repr` attribute input
-  --> $DIR/invalid_repr_list_help.rs:20:1
+  --> $DIR/invalid_repr_list_help.rs:20:3
    |
 LL | #[repr(uwu)]
-   | ^^^^^^^---^^
+   |   ^^^^^---^
    |        |
    |        valid arguments are `align`, `packed`, `Rust`, `C`, `simd`, `transparent`, `i8`, `u8`, `i16`, `u16`, `i32`, `u32`, `i64`, `u64`, `i128`, `u128`, `isize` or `usize`
    |

--- a/tests/ui/repr/issue-83505-repr-simd.stderr
+++ b/tests/ui/repr/issue-83505-repr-simd.stderr
@@ -16,13 +16,13 @@ LL | #[repr(simd)]
    = help: add `#![feature(repr_simd)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error: `#[repr(simd)]` attribute cannot be used on enums
-  --> $DIR/issue-83505-repr-simd.rs:5:1
+error: the `repr(simd)` attribute cannot be used on enums
+  --> $DIR/issue-83505-repr-simd.rs:5:3
    |
 LL | #[repr(simd)]
-   | ^^^^^^^^^^^^^
+   |   ^^^^^^^^^^
    |
-   = help: `#[repr(simd)]` can only be applied to structs
+   = help: the `repr(simd)` attribute can only be applied to structs
 
 error[E0084]: unsupported representation for zero-variant enum
   --> $DIR/issue-83505-repr-simd.rs:5:8

--- a/tests/ui/repr/malformed-repr-hints.stderr
+++ b/tests/ui/repr/malformed-repr-hints.stderr
@@ -1,98 +1,98 @@
 error[E0805]: malformed `repr` attribute input
-  --> $DIR/malformed-repr-hints.rs:6:1
+  --> $DIR/malformed-repr-hints.rs:6:3
    |
 LL | #[repr(packed())]
-   | ^^^^^^^^^^^^^--^^
+   |   ^^^^^^^^^^^--^
    |              |
    |              expected an argument here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/type-layout.html#representations>
 
 error[E0539]: malformed `repr` attribute input
-  --> $DIR/malformed-repr-hints.rs:10:1
+  --> $DIR/malformed-repr-hints.rs:10:3
    |
 LL | #[repr(align)]
-   | ^^^^^^^-----^^
+   |   ^^^^^-----^
    |        |
    |        expected this to be a list
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/type-layout.html#representations>
 
 error[E0805]: malformed `repr` attribute input
-  --> $DIR/malformed-repr-hints.rs:14:1
+  --> $DIR/malformed-repr-hints.rs:14:3
    |
 LL | #[repr(align(2, 4))]
-   | ^^^^^^^^^^^^------^^
+   |   ^^^^^^^^^^------^
    |             |
    |             expected a single argument here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/type-layout.html#representations>
 
 error[E0805]: malformed `repr` attribute input
-  --> $DIR/malformed-repr-hints.rs:18:1
+  --> $DIR/malformed-repr-hints.rs:18:3
    |
 LL | #[repr(align())]
-   | ^^^^^^^^^^^^--^^
+   |   ^^^^^^^^^^--^
    |             |
    |             expected an argument here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/type-layout.html#representations>
 
 error[E0565]: malformed `repr` attribute input
-  --> $DIR/malformed-repr-hints.rs:23:1
+  --> $DIR/malformed-repr-hints.rs:23:3
    |
 LL | #[repr(Rust(u8))]
-   | ^^^^^^^^^^^----^^
+   |   ^^^^^^^^^----^
    |            |
    |            didn't expect any arguments here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/type-layout.html#representations>
 
 error[E0565]: malformed `repr` attribute input
-  --> $DIR/malformed-repr-hints.rs:25:1
+  --> $DIR/malformed-repr-hints.rs:25:3
    |
 LL | #[repr(Rust(0))]
-   | ^^^^^^^^^^^---^^
+   |   ^^^^^^^^^---^
    |            |
    |            didn't expect any arguments here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/type-layout.html#representations>
 
 error[E0565]: malformed `repr` attribute input
-  --> $DIR/malformed-repr-hints.rs:27:1
+  --> $DIR/malformed-repr-hints.rs:27:3
    |
 LL | #[repr(Rust = 0)]
-   | ^^^^^^^^^^^^---^^
+   |   ^^^^^^^^^^---^
    |             |
    |             didn't expect any arguments here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/type-layout.html#representations>
 
 error[E0565]: malformed `repr` attribute input
-  --> $DIR/malformed-repr-hints.rs:31:1
+  --> $DIR/malformed-repr-hints.rs:31:3
    |
 LL | #[repr(i8())]
-   | ^^^^^^^^^--^^
+   |   ^^^^^^^--^
    |          |
    |          didn't expect any arguments here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/type-layout.html#representations>
 
 error[E0565]: malformed `repr` attribute input
-  --> $DIR/malformed-repr-hints.rs:35:1
+  --> $DIR/malformed-repr-hints.rs:35:3
    |
 LL | #[repr(u32(42))]
-   | ^^^^^^^^^^----^^
+   |   ^^^^^^^^----^
    |           |
    |           didn't expect any arguments here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/type-layout.html#representations>
 
 error[E0565]: malformed `repr` attribute input
-  --> $DIR/malformed-repr-hints.rs:39:1
+  --> $DIR/malformed-repr-hints.rs:39:3
    |
 LL | #[repr(i64 = 2)]
-   | ^^^^^^^^^^^---^^
+   |   ^^^^^^^^^---^
    |            |
    |            didn't expect any arguments here
    |

--- a/tests/ui/repr/repr-align-assign.stderr
+++ b/tests/ui/repr/repr-align-assign.stderr
@@ -1,18 +1,18 @@
 error[E0539]: malformed `repr` attribute input
-  --> $DIR/repr-align-assign.rs:3:1
+  --> $DIR/repr-align-assign.rs:3:3
    |
 LL | #[repr(align=8)]
-   | ^^^^^^^^^^^^--^^
+   |   ^^^^^^^^^^--^
    |             |
    |             expected this to be a list
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/type-layout.html#representations>
 
 error[E0539]: malformed `repr` attribute input
-  --> $DIR/repr-align-assign.rs:6:1
+  --> $DIR/repr-align-assign.rs:6:3
    |
 LL | #[repr(align="8")]
-   | ^^^^^^^^^^^^----^^
+   |   ^^^^^^^^^^----^
    |             |
    |             expected this to be a list
    |

--- a/tests/ui/repr/repr-disallow-on-variant.stderr
+++ b/tests/ui/repr/repr-disallow-on-variant.stderr
@@ -1,10 +1,10 @@
-error: `#[repr(u8)]` attribute cannot be used on enum variants
-  --> $DIR/repr-disallow-on-variant.rs:4:5
+error: the `repr(u8)` attribute cannot be used on enum variants
+  --> $DIR/repr-disallow-on-variant.rs:4:7
    |
 LL |     #[repr(u8)]
-   |     ^^^^^^^^^^^
+   |       ^^^^^^^^
    |
-   = help: `#[repr(u8)]` can only be applied to enums
+   = help: the `repr(u8)` attribute can only be applied to enums
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/repr/repr-empty-packed.stderr
+++ b/tests/ui/repr/repr-empty-packed.stderr
@@ -1,10 +1,10 @@
-error: `#[repr(packed)]` attribute cannot be used on enums
-  --> $DIR/repr-empty-packed.rs:5:1
+error: the `repr(packed)` attribute cannot be used on enums
+  --> $DIR/repr-empty-packed.rs:5:3
    |
 LL | #[repr(packed)]
-   | ^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^
    |
-   = help: `#[repr(packed)]` can be applied to structs and unions
+   = help: the `repr(packed)` attribute can be applied to structs and unions
 
 error: unused attribute
   --> $DIR/repr-empty-packed.rs:4:1

--- a/tests/ui/repr/repr-transparent-other-items.stderr
+++ b/tests/ui/repr/repr-transparent-other-items.stderr
@@ -1,18 +1,18 @@
-error: `#[repr(transparent)]` attribute cannot be used on functions
-  --> $DIR/repr-transparent-other-items.rs:3:1
+error: the `repr(transparent)` attribute cannot be used on functions
+  --> $DIR/repr-transparent-other-items.rs:3:3
    |
 LL | #[repr(transparent)]
-   | ^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^
    |
-   = help: `#[repr(transparent)]` can only be applied to data types
+   = help: the `repr(transparent)` attribute can only be applied to data types
 
-error: `#[repr(transparent)]` attribute cannot be used on statics
-  --> $DIR/repr-transparent-other-items.rs:6:1
+error: the `repr(transparent)` attribute cannot be used on statics
+  --> $DIR/repr-transparent-other-items.rs:6:3
    |
 LL | #[repr(transparent)]
-   | ^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^
    |
-   = help: `#[repr(transparent)]` can only be applied to data types
+   = help: the `repr(transparent)` attribute can only be applied to data types
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/repr/repr.stderr
+++ b/tests/ui/repr/repr.stderr
@@ -1,26 +1,26 @@
 error[E0539]: malformed `repr` attribute input
-  --> $DIR/repr.rs:1:1
+  --> $DIR/repr.rs:1:3
    |
 LL | #[repr]
-   | ^^^^^^^ expected this to be a list
+   |   ^^^^ expected this to be a list
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/type-layout.html#representations>
 
 error[E0539]: malformed `repr` attribute input
-  --> $DIR/repr.rs:4:1
+  --> $DIR/repr.rs:4:3
    |
 LL | #[repr = "B"]
-   | ^^^^^^^-----^
+   |   ^^^^^-----
    |        |
    |        expected this to be a list
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/type-layout.html#representations>
 
 error[E0539]: malformed `repr` attribute input
-  --> $DIR/repr.rs:7:1
+  --> $DIR/repr.rs:7:3
    |
 LL | #[repr = "C"]
-   | ^^^^^^^-----^
+   |   ^^^^^-----
    |        |
    |        expected this to be a list
    |

--- a/tests/ui/rfcs/rfc-2008-non-exhaustive/invalid-attribute.stderr
+++ b/tests/ui/rfcs/rfc-2008-non-exhaustive/invalid-attribute.stderr
@@ -12,21 +12,21 @@ LL - #[non_exhaustive(anything)]
 LL + #[non_exhaustive]
    |
 
-error: `#[non_exhaustive]` attribute cannot be used on traits
-  --> $DIR/invalid-attribute.rs:5:1
+error: the `non_exhaustive` attribute cannot be used on traits
+  --> $DIR/invalid-attribute.rs:5:3
    |
 LL | #[non_exhaustive]
-   | ^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^
    |
-   = help: `#[non_exhaustive]` can be applied to data types and enum variants
+   = help: the `non_exhaustive` attribute can be applied to data types and enum variants
 
-error: `#[non_exhaustive]` attribute cannot be used on unions
-  --> $DIR/invalid-attribute.rs:9:1
+error: the `non_exhaustive` attribute cannot be used on unions
+  --> $DIR/invalid-attribute.rs:9:3
    |
 LL | #[non_exhaustive]
-   | ^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^
    |
-   = help: `#[non_exhaustive]` can be applied to enum variants, enums, and structs
+   = help: the `non_exhaustive` attribute can be applied to enum variants, enums, and structs
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/rfcs/rfc-2008-non-exhaustive/invalid-attribute.stderr
+++ b/tests/ui/rfcs/rfc-2008-non-exhaustive/invalid-attribute.stderr
@@ -1,8 +1,8 @@
 error[E0565]: malformed `non_exhaustive` attribute input
-  --> $DIR/invalid-attribute.rs:1:1
+  --> $DIR/invalid-attribute.rs:1:3
    |
 LL | #[non_exhaustive(anything)]
-   | ^^^^^^^^^^^^^^^^----------^
+   |   ^^^^^^^^^^^^^^----------
    |                 |
    |                 didn't expect any arguments here
    |

--- a/tests/ui/rfcs/rfc-2091-track-caller/error-odd-syntax.stderr
+++ b/tests/ui/rfcs/rfc-2091-track-caller/error-odd-syntax.stderr
@@ -1,8 +1,8 @@
 error[E0565]: malformed `track_caller` attribute input
-  --> $DIR/error-odd-syntax.rs:1:1
+  --> $DIR/error-odd-syntax.rs:1:3
    |
 LL | #[track_caller(1)]
-   | ^^^^^^^^^^^^^^---^
+   |   ^^^^^^^^^^^^---
    |               |
    |               didn't expect any arguments here
    |

--- a/tests/ui/rfcs/rfc-2091-track-caller/macro-declaration.stderr
+++ b/tests/ui/rfcs/rfc-2091-track-caller/macro-declaration.stderr
@@ -1,10 +1,10 @@
-warning: `#[track_caller]` attribute cannot be used on macro defs
-  --> $DIR/macro-declaration.rs:4:1
+warning: the `track_caller` attribute cannot be used on macro defs
+  --> $DIR/macro-declaration.rs:4:3
    |
 LL | #[track_caller]
-   | ^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^
    |
-   = help: `#[track_caller]` can only be applied to functions
+   = help: the `track_caller` attribute can only be applied to functions
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: requested on the command line with `-W unused-attributes`
 

--- a/tests/ui/rfcs/rfc-2091-track-caller/only-for-fns.stderr
+++ b/tests/ui/rfcs/rfc-2091-track-caller/only-for-fns.stderr
@@ -1,10 +1,10 @@
-error: `#[track_caller]` attribute cannot be used on structs
-  --> $DIR/only-for-fns.rs:1:1
+error: the `track_caller` attribute cannot be used on structs
+  --> $DIR/only-for-fns.rs:1:3
    |
 LL | #[track_caller]
-   | ^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^
    |
-   = help: `#[track_caller]` can only be applied to functions
+   = help: the `track_caller` attribute can only be applied to functions
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/rfcs/rfc-2565-param-attrs/param-attrs-builtin-attrs.stderr
+++ b/tests/ui/rfcs/rfc-2565-param-attrs/param-attrs-builtin-attrs.stderr
@@ -382,149 +382,149 @@ error: allow, cfg, cfg_attr, deny, expect, forbid, and warn are the only allowed
 LL |         #[no_mangle] b: i32
    |         ^^^^^^^^^^^^
 
-warning: `#[must_use]` attribute cannot be used on function params
-  --> $DIR/param-attrs-builtin-attrs.rs:40:5
+warning: the `must_use` attribute cannot be used on function params
+  --> $DIR/param-attrs-builtin-attrs.rs:40:7
    |
 LL |     #[must_use]
-   |     ^^^^^^^^^^^
+   |       ^^^^^^^^
    |
-   = help: `#[must_use]` can be applied to data types, functions, and traits
+   = help: the `must_use` attribute can be applied to data types, functions, and traits
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: requested on the command line with `-W unused-attributes`
 
-warning: `#[no_mangle]` attribute cannot be used on function params
-  --> $DIR/param-attrs-builtin-attrs.rs:46:5
+warning: the `no_mangle` attribute cannot be used on function params
+  --> $DIR/param-attrs-builtin-attrs.rs:46:7
    |
 LL |     #[no_mangle] b: i32,
-   |     ^^^^^^^^^^^^
+   |       ^^^^^^^^^
    |
-   = help: `#[no_mangle]` can be applied to functions and statics
+   = help: the `no_mangle` attribute can be applied to functions and statics
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[must_use]` attribute cannot be used on function params
-  --> $DIR/param-attrs-builtin-attrs.rs:195:9
+warning: the `must_use` attribute cannot be used on function params
+  --> $DIR/param-attrs-builtin-attrs.rs:195:11
    |
 LL |         #[must_use]
-   |         ^^^^^^^^^^^
+   |           ^^^^^^^^
    |
-   = help: `#[must_use]` can be applied to data types, functions, and traits
+   = help: the `must_use` attribute can be applied to data types, functions, and traits
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[no_mangle]` attribute cannot be used on function params
-  --> $DIR/param-attrs-builtin-attrs.rs:201:9
+warning: the `no_mangle` attribute cannot be used on function params
+  --> $DIR/param-attrs-builtin-attrs.rs:201:11
    |
 LL |         #[no_mangle] b: i32
-   |         ^^^^^^^^^^^^
+   |           ^^^^^^^^^
    |
-   = help: `#[no_mangle]` can be applied to functions and statics
+   = help: the `no_mangle` attribute can be applied to functions and statics
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[must_use]` attribute cannot be used on function params
-  --> $DIR/param-attrs-builtin-attrs.rs:131:9
+warning: the `must_use` attribute cannot be used on function params
+  --> $DIR/param-attrs-builtin-attrs.rs:131:11
    |
 LL |         #[must_use]
-   |         ^^^^^^^^^^^
+   |           ^^^^^^^^
    |
-   = help: `#[must_use]` can be applied to data types, functions, and traits
+   = help: the `must_use` attribute can be applied to data types, functions, and traits
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[no_mangle]` attribute cannot be used on function params
-  --> $DIR/param-attrs-builtin-attrs.rs:137:9
+warning: the `no_mangle` attribute cannot be used on function params
+  --> $DIR/param-attrs-builtin-attrs.rs:137:11
    |
 LL |         #[no_mangle] b: i32,
-   |         ^^^^^^^^^^^^
+   |           ^^^^^^^^^
    |
-   = help: `#[no_mangle]` can be applied to functions and statics
+   = help: the `no_mangle` attribute can be applied to functions and statics
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[must_use]` attribute cannot be used on function params
-  --> $DIR/param-attrs-builtin-attrs.rs:150:9
+warning: the `must_use` attribute cannot be used on function params
+  --> $DIR/param-attrs-builtin-attrs.rs:150:11
    |
 LL |         #[must_use]
-   |         ^^^^^^^^^^^
+   |           ^^^^^^^^
    |
-   = help: `#[must_use]` can be applied to data types, functions, and traits
+   = help: the `must_use` attribute can be applied to data types, functions, and traits
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[no_mangle]` attribute cannot be used on function params
-  --> $DIR/param-attrs-builtin-attrs.rs:156:9
+warning: the `no_mangle` attribute cannot be used on function params
+  --> $DIR/param-attrs-builtin-attrs.rs:156:11
    |
 LL |         #[no_mangle] b: i32,
-   |         ^^^^^^^^^^^^
+   |           ^^^^^^^^^
    |
-   = help: `#[no_mangle]` can be applied to functions and statics
+   = help: the `no_mangle` attribute can be applied to functions and statics
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[must_use]` attribute cannot be used on function params
-  --> $DIR/param-attrs-builtin-attrs.rs:64:9
+warning: the `must_use` attribute cannot be used on function params
+  --> $DIR/param-attrs-builtin-attrs.rs:64:11
    |
 LL |         #[must_use]
-   |         ^^^^^^^^^^^
+   |           ^^^^^^^^
    |
-   = help: `#[must_use]` can be applied to data types, functions, and traits
+   = help: the `must_use` attribute can be applied to data types, functions, and traits
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[no_mangle]` attribute cannot be used on function params
-  --> $DIR/param-attrs-builtin-attrs.rs:70:9
+warning: the `no_mangle` attribute cannot be used on function params
+  --> $DIR/param-attrs-builtin-attrs.rs:70:11
    |
 LL |         #[no_mangle] b: i32,
-   |         ^^^^^^^^^^^^
+   |           ^^^^^^^^^
    |
-   = help: `#[no_mangle]` can be applied to functions and statics
+   = help: the `no_mangle` attribute can be applied to functions and statics
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[must_use]` attribute cannot be used on function params
-  --> $DIR/param-attrs-builtin-attrs.rs:83:9
+warning: the `must_use` attribute cannot be used on function params
+  --> $DIR/param-attrs-builtin-attrs.rs:83:11
    |
 LL |         #[must_use]
-   |         ^^^^^^^^^^^
+   |           ^^^^^^^^
    |
-   = help: `#[must_use]` can be applied to data types, functions, and traits
+   = help: the `must_use` attribute can be applied to data types, functions, and traits
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[no_mangle]` attribute cannot be used on function params
-  --> $DIR/param-attrs-builtin-attrs.rs:89:9
+warning: the `no_mangle` attribute cannot be used on function params
+  --> $DIR/param-attrs-builtin-attrs.rs:89:11
    |
 LL |         #[no_mangle] b: i32,
-   |         ^^^^^^^^^^^^
+   |           ^^^^^^^^^
    |
-   = help: `#[no_mangle]` can be applied to functions and statics
+   = help: the `no_mangle` attribute can be applied to functions and statics
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[must_use]` attribute cannot be used on function params
-  --> $DIR/param-attrs-builtin-attrs.rs:108:9
+warning: the `must_use` attribute cannot be used on function params
+  --> $DIR/param-attrs-builtin-attrs.rs:108:11
    |
 LL |         #[must_use]
-   |         ^^^^^^^^^^^
+   |           ^^^^^^^^
    |
-   = help: `#[must_use]` can be applied to data types, functions, and traits
+   = help: the `must_use` attribute can be applied to data types, functions, and traits
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[no_mangle]` attribute cannot be used on function params
-  --> $DIR/param-attrs-builtin-attrs.rs:114:9
+warning: the `no_mangle` attribute cannot be used on function params
+  --> $DIR/param-attrs-builtin-attrs.rs:114:11
    |
 LL |         #[no_mangle] b: i32,
-   |         ^^^^^^^^^^^^
+   |           ^^^^^^^^^
    |
-   = help: `#[no_mangle]` can be applied to functions and statics
+   = help: the `no_mangle` attribute can be applied to functions and statics
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[must_use]` attribute cannot be used on function params
-  --> $DIR/param-attrs-builtin-attrs.rs:174:9
+warning: the `must_use` attribute cannot be used on function params
+  --> $DIR/param-attrs-builtin-attrs.rs:174:11
    |
 LL |         #[must_use]
-   |         ^^^^^^^^^^^
+   |           ^^^^^^^^
    |
-   = help: `#[must_use]` can be applied to data types, functions, and traits
+   = help: the `must_use` attribute can be applied to data types, functions, and traits
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[no_mangle]` attribute cannot be used on function params
-  --> $DIR/param-attrs-builtin-attrs.rs:180:9
+warning: the `no_mangle` attribute cannot be used on function params
+  --> $DIR/param-attrs-builtin-attrs.rs:180:11
    |
 LL |         #[no_mangle] b: i32,
-   |         ^^^^^^^^^^^^
+   |           ^^^^^^^^^
    |
-   = help: `#[no_mangle]` can be applied to functions and statics
+   = help: the `no_mangle` attribute can be applied to functions and statics
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 error: aborting due to 64 previous errors; 16 warnings emitted

--- a/tests/ui/rustdoc/check-doc-alias-attr.stderr
+++ b/tests/ui/rustdoc/check-doc-alias-attr.stderr
@@ -5,10 +5,10 @@ LL | #[doc(alias)]
    |       ^^^^^
 
 error[E0539]: malformed `doc` attribute input
-  --> $DIR/check-doc-alias-attr.rs:8:1
+  --> $DIR/check-doc-alias-attr.rs:8:3
    |
 LL | #[doc(alias = 0)]
-   | ^^^^^^^^^^^^^^-^^
+   |   ^^^^^^^^^^^^-^
    |               |
    |               expected a string literal here
 
@@ -57,10 +57,10 @@ LL | #[doc(alias = "")]
    |               ^^
 
 error[E0539]: malformed `doc` attribute input
-  --> $DIR/check-doc-alias-attr.rs:19:1
+  --> $DIR/check-doc-alias-attr.rs:19:3
    |
 LL | #[doc(alias(0))]
-   | ^^^^^^^^^^^^-^^^
+   |   ^^^^^^^^^^-^^
    |             |
    |             expected a string literal here
 

--- a/tests/ui/rustdoc/feature-gate-doc_primitive.rs
+++ b/tests/ui/rustdoc/feature-gate-doc_primitive.rs
@@ -1,7 +1,7 @@
 #[rustc_doc_primitive = "usize"]
 //~^ ERROR use of an internal attribute [E0658]
-//~| NOTE the `#[rustc_doc_primitive]` attribute is an internal implementation detail that will never be stable
-//~| NOTE the `#[rustc_doc_primitive]` attribute is used by the standard library to provide a way to generate documentation for primitive types
+//~| NOTE the `rustc_doc_primitive` attribute is an internal implementation detail that will never be stable
+//~| NOTE the `rustc_doc_primitive` attribute is used by the standard library to provide a way to generate documentation for primitive types
 /// Some docs
 mod usize {}
 

--- a/tests/ui/rustdoc/feature-gate-doc_primitive.stderr
+++ b/tests/ui/rustdoc/feature-gate-doc_primitive.stderr
@@ -1,12 +1,12 @@
 error[E0658]: use of an internal attribute
-  --> $DIR/feature-gate-doc_primitive.rs:1:1
+  --> $DIR/feature-gate-doc_primitive.rs:1:3
    |
 LL | #[rustc_doc_primitive = "usize"]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable
-   = note: the `#[rustc_doc_primitive]` attribute is an internal implementation detail that will never be stable
-   = note: the `#[rustc_doc_primitive]` attribute is used by the standard library to provide a way to generate documentation for primitive types
+   = note: the `rustc_doc_primitive` attribute is an internal implementation detail that will never be stable
+   = note: the `rustc_doc_primitive` attribute is used by the standard library to provide a way to generate documentation for primitive types
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/sanitize-attr/invalid-sanitize.stderr
+++ b/tests/ui/sanitize-attr/invalid-sanitize.stderr
@@ -1,8 +1,8 @@
 error[E0539]: malformed `sanitize` attribute input
-  --> $DIR/invalid-sanitize.rs:4:1
+  --> $DIR/invalid-sanitize.rs:4:3
    |
 LL | #[sanitize(brontosaurus = "off")]
-   | ^^^^^^^^^^^------------^^^^^^^^^^
+   |   ^^^^^^^^^------------^^^^^^^^^
    |            |
    |            valid arguments are "address", "kernel_address", "cfi", "kcfi", "memory", "memtag", "shadow_call_stack", "thread", "hwaddress", "kernel_hwaddress" or "realtime"
 
@@ -31,32 +31,32 @@ LL | #[sanitize(address = "on")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0539]: malformed `sanitize` attribute input
-  --> $DIR/invalid-sanitize.rs:15:1
+  --> $DIR/invalid-sanitize.rs:15:3
    |
 LL | #[sanitize(address = "bogus")]
-   | ^^^^^^^^^^^^^^^^^^^^^-------^^
+   |   ^^^^^^^^^^^^^^^^^^^-------^
    |                      |
    |                      valid arguments are "on" or "off"
 
 error[E0539]: malformed `sanitize` attribute input
-  --> $DIR/invalid-sanitize.rs:18:1
+  --> $DIR/invalid-sanitize.rs:18:3
    |
 LL | #[sanitize = "off"]
-   | ^^^^^^^^^^^-------^
+   |   ^^^^^^^^^-------
    |            |
    |            expected this to be a list
 
 error[E0539]: malformed `sanitize` attribute input
-  --> $DIR/invalid-sanitize.rs:21:1
+  --> $DIR/invalid-sanitize.rs:21:3
    |
 LL | #[sanitize]
-   | ^^^^^^^^^^^ expected this to be a list
+   |   ^^^^^^^^ expected this to be a list
 
 error[E0539]: malformed `sanitize` attribute input
-  --> $DIR/invalid-sanitize.rs:24:1
+  --> $DIR/invalid-sanitize.rs:24:3
    |
 LL | #[sanitize(realtime = "on")]
-   | ^^^^^^^^^^^^^^^^^^^^^^----^^
+   |   ^^^^^^^^^^^^^^^^^^^^----^
    |                       |
    |                       valid arguments are "nonblocking", "blocking" or "caller"
 

--- a/tests/ui/sanitize-attr/valid-sanitize.stderr
+++ b/tests/ui/sanitize-attr/valid-sanitize.stderr
@@ -6,141 +6,141 @@ LL | #[sanitize(thread = "off")]
    |
    = help: `#[sanitize]` can be used on statics if only the address is sanitized
 
-error: `#[sanitize]` attribute cannot be used on type aliases
-  --> $DIR/valid-sanitize.rs:18:1
+error: the `sanitize` attribute cannot be used on type aliases
+  --> $DIR/valid-sanitize.rs:18:3
    |
 LL | #[sanitize(address = "off")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^
    |
-   = help: `#[sanitize]` can be applied to crates, functions, impl blocks, modules, and statics
+   = help: the `sanitize` attribute can be applied to crates, functions, impl blocks, modules, and statics
 
-error: `#[sanitize]` attribute cannot be used on traits
-  --> $DIR/valid-sanitize.rs:21:1
+error: the `sanitize` attribute cannot be used on traits
+  --> $DIR/valid-sanitize.rs:21:3
    |
 LL | #[sanitize(address = "off")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^
    |
-   = help: `#[sanitize]` can be applied to crates, functions, impl blocks, modules, and statics
+   = help: the `sanitize` attribute can be applied to crates, functions, impl blocks, modules, and statics
 
-error: `#[sanitize]` attribute cannot be used on associated consts
-  --> $DIR/valid-sanitize.rs:23:5
+error: the `sanitize` attribute cannot be used on associated consts
+  --> $DIR/valid-sanitize.rs:23:7
    |
 LL |     #[sanitize(address = "off")]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^
    |
-   = help: `#[sanitize]` can be applied to crates, functions, impl blocks, modules, and statics
+   = help: the `sanitize` attribute can be applied to crates, functions, impl blocks, modules, and statics
 
-error: `#[sanitize]` attribute cannot be used on associated types
-  --> $DIR/valid-sanitize.rs:26:5
+error: the `sanitize` attribute cannot be used on associated types
+  --> $DIR/valid-sanitize.rs:26:7
    |
 LL |     #[sanitize(address = "off")]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^
    |
-   = help: `#[sanitize]` can be applied to crates, functions, impl blocks, modules, and statics
+   = help: the `sanitize` attribute can be applied to crates, functions, impl blocks, modules, and statics
 
-error: `#[sanitize]` attribute cannot be used on required trait methods
-  --> $DIR/valid-sanitize.rs:29:5
+error: the `sanitize` attribute cannot be used on required trait methods
+  --> $DIR/valid-sanitize.rs:29:7
    |
 LL |     #[sanitize(address = "off")]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^
    |
-   = help: `#[sanitize]` can be applied to crates, functions with a body, impl blocks, modules, and statics
+   = help: the `sanitize` attribute can be applied to crates, functions with a body, impl blocks, modules, and statics
 
-error: `#[sanitize]` attribute cannot be used on required trait methods
-  --> $DIR/valid-sanitize.rs:35:5
+error: the `sanitize` attribute cannot be used on required trait methods
+  --> $DIR/valid-sanitize.rs:35:7
    |
 LL |     #[sanitize(address = "off")]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^
    |
-   = help: `#[sanitize]` can be applied to crates, functions with a body, impl blocks, modules, and statics
+   = help: the `sanitize` attribute can be applied to crates, functions with a body, impl blocks, modules, and statics
 
-error: `#[sanitize]` attribute cannot be used on associated types
-  --> $DIR/valid-sanitize.rs:43:5
+error: the `sanitize` attribute cannot be used on associated types
+  --> $DIR/valid-sanitize.rs:43:7
    |
 LL |     #[sanitize(address = "off")]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^
    |
-   = help: `#[sanitize]` can be applied to crates, functions, impl blocks, modules, and statics
+   = help: the `sanitize` attribute can be applied to crates, functions, impl blocks, modules, and statics
 
-error: `#[sanitize]` attribute cannot be used on associated types
-  --> $DIR/valid-sanitize.rs:60:5
+error: the `sanitize` attribute cannot be used on associated types
+  --> $DIR/valid-sanitize.rs:60:7
    |
 LL |     #[sanitize(address = "off")]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^
    |
-   = help: `#[sanitize]` can be applied to crates, functions, impl blocks, modules, and statics
+   = help: the `sanitize` attribute can be applied to crates, functions, impl blocks, modules, and statics
 
-error: `#[sanitize]` attribute cannot be used on structs
-  --> $DIR/valid-sanitize.rs:65:1
+error: the `sanitize` attribute cannot be used on structs
+  --> $DIR/valid-sanitize.rs:65:3
    |
 LL | #[sanitize(address = "off")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^
    |
-   = help: `#[sanitize]` can be applied to crates, functions, impl blocks, modules, and statics
+   = help: the `sanitize` attribute can be applied to crates, functions, impl blocks, modules, and statics
 
-error: `#[sanitize]` attribute cannot be used on struct fields
-  --> $DIR/valid-sanitize.rs:67:5
+error: the `sanitize` attribute cannot be used on struct fields
+  --> $DIR/valid-sanitize.rs:67:7
    |
 LL |     #[sanitize(address = "off")]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^
    |
-   = help: `#[sanitize]` can be applied to crates, functions, impl blocks, modules, and statics
+   = help: the `sanitize` attribute can be applied to crates, functions, impl blocks, modules, and statics
 
-error: `#[sanitize]` attribute cannot be used on foreign statics
-  --> $DIR/valid-sanitize.rs:80:5
+error: the `sanitize` attribute cannot be used on foreign statics
+  --> $DIR/valid-sanitize.rs:80:7
    |
 LL |     #[sanitize(address = "off", thread = "on")]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^
    |
-   = help: `#[sanitize]` can be applied to crates, functions, impl blocks, modules, and statics
+   = help: the `sanitize` attribute can be applied to crates, functions, impl blocks, modules, and statics
 
-error: `#[sanitize]` attribute cannot be used on foreign types
-  --> $DIR/valid-sanitize.rs:83:5
+error: the `sanitize` attribute cannot be used on foreign types
+  --> $DIR/valid-sanitize.rs:83:7
    |
 LL |     #[sanitize(address = "off", thread = "on")]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^
    |
-   = help: `#[sanitize]` can be applied to crates, functions, impl blocks, modules, and statics
+   = help: the `sanitize` attribute can be applied to crates, functions, impl blocks, modules, and statics
 
-error: `#[sanitize]` attribute cannot be used on foreign functions
-  --> $DIR/valid-sanitize.rs:86:5
+error: the `sanitize` attribute cannot be used on foreign functions
+  --> $DIR/valid-sanitize.rs:86:7
    |
 LL |     #[sanitize(address = "off", thread = "on")]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^
    |
-   = help: `#[sanitize]` can be applied to crates, functions with a body, impl blocks, modules, and statics
+   = help: the `sanitize` attribute can be applied to crates, functions with a body, impl blocks, modules, and statics
 
-error: `#[sanitize]` attribute cannot be used on statements
-  --> $DIR/valid-sanitize.rs:92:5
+error: the `sanitize` attribute cannot be used on statements
+  --> $DIR/valid-sanitize.rs:92:7
    |
 LL |     #[sanitize(address = "off", thread = "on")]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^
    |
-   = help: `#[sanitize]` can be applied to crates, functions, impl blocks, modules, and statics
+   = help: the `sanitize` attribute can be applied to crates, functions, impl blocks, modules, and statics
 
-error: `#[sanitize]` attribute cannot be used on statements
-  --> $DIR/valid-sanitize.rs:98:5
+error: the `sanitize` attribute cannot be used on statements
+  --> $DIR/valid-sanitize.rs:98:7
    |
 LL |     #[sanitize(address = "off")]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^
    |
-   = help: `#[sanitize]` can be applied to crates, functions, impl blocks, modules, and statics
+   = help: the `sanitize` attribute can be applied to crates, functions, impl blocks, modules, and statics
 
-error: `#[sanitize]` attribute cannot be used on match arms
-  --> $DIR/valid-sanitize.rs:109:9
+error: the `sanitize` attribute cannot be used on match arms
+  --> $DIR/valid-sanitize.rs:109:11
    |
 LL |         #[sanitize(address = "off")]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |           ^^^^^^^^
    |
-   = help: `#[sanitize]` can be applied to crates, functions, impl blocks, modules, and statics
+   = help: the `sanitize` attribute can be applied to crates, functions, impl blocks, modules, and statics
 
-error: `#[sanitize]` attribute cannot be used on expressions
-  --> $DIR/valid-sanitize.rs:113:5
+error: the `sanitize` attribute cannot be used on expressions
+  --> $DIR/valid-sanitize.rs:113:7
    |
 LL |     #[sanitize(address = "off")]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^
    |
-   = help: `#[sanitize]` can be applied to crates, functions, impl blocks, modules, and statics
+   = help: the `sanitize` attribute can be applied to crates, functions, impl blocks, modules, and statics
 
 error: aborting due to 18 previous errors
 

--- a/tests/ui/sanitizer/cfi/invalid-attr-encoding.stderr
+++ b/tests/ui/sanitizer/cfi/invalid-attr-encoding.stderr
@@ -1,8 +1,8 @@
 error[E0539]: malformed `cfi_encoding` attribute input
-  --> $DIR/invalid-attr-encoding.rs:10:1
+  --> $DIR/invalid-attr-encoding.rs:10:3
    |
 LL | #[cfi_encoding]
-   | ^^^^^^^^^^^^^^^ expected this to be of the form `cfi_encoding = "..."`
+   |   ^^^^^^^^^^^^ expected this to be of the form `cfi_encoding = "..."`
    |
 help: must be of the form
    |

--- a/tests/ui/scalable-vectors/invalid.rs
+++ b/tests/ui/scalable-vectors/invalid.rs
@@ -8,133 +8,133 @@
 #![feature(trait_alias)]
 
 #[rustc_scalable_vector(4)]
-//~^ ERROR: `#[rustc_scalable_vector]` attribute cannot be used on extern crates
+//~^ ERROR: the `rustc_scalable_vector` attribute cannot be used on extern crates
 extern crate std as other_std;
 
 #[rustc_scalable_vector(4)]
-//~^ ERROR: `#[rustc_scalable_vector]` attribute cannot be used on use statements
+//~^ ERROR: the `rustc_scalable_vector` attribute cannot be used on use statements
 use std::vec::Vec;
 
 #[rustc_scalable_vector(4)]
-//~^ ERROR: `#[rustc_scalable_vector]` attribute cannot be used on statics
+//~^ ERROR: the `rustc_scalable_vector` attribute cannot be used on statics
 static _X: u32 = 0;
 
 #[rustc_scalable_vector(4)]
-//~^ ERROR: `#[rustc_scalable_vector]` attribute cannot be used on constants
+//~^ ERROR: the `rustc_scalable_vector` attribute cannot be used on constants
 const _Y: u32 = 0;
 
 #[rustc_scalable_vector(4)]
-//~^ ERROR: `#[rustc_scalable_vector]` attribute cannot be used on modules
+//~^ ERROR: the `rustc_scalable_vector` attribute cannot be used on modules
 mod bar {
 }
 
 #[rustc_scalable_vector(4)]
-//~^ ERROR: `#[rustc_scalable_vector]` attribute cannot be used on foreign modules
+//~^ ERROR: the `rustc_scalable_vector` attribute cannot be used on foreign modules
 unsafe extern "C" {
     #[rustc_scalable_vector(4)]
-//~^ ERROR: `#[rustc_scalable_vector]` attribute cannot be used on foreign statics
+//~^ ERROR: the `rustc_scalable_vector` attribute cannot be used on foreign statics
     static X: &'static u32;
     #[rustc_scalable_vector(4)]
-//~^ ERROR: `#[rustc_scalable_vector]` attribute cannot be used on foreign types
+//~^ ERROR: the `rustc_scalable_vector` attribute cannot be used on foreign types
     type Y;
     #[rustc_scalable_vector(4)]
-//~^ ERROR: `#[rustc_scalable_vector]` attribute cannot be used on foreign functions
+//~^ ERROR: the `rustc_scalable_vector` attribute cannot be used on foreign functions
     fn foo();
 }
 
 #[rustc_scalable_vector(4)]
-//~^ ERROR: `#[rustc_scalable_vector]` attribute cannot be used on type aliases
+//~^ ERROR: the `rustc_scalable_vector` attribute cannot be used on type aliases
 type Foo = u32;
 
 #[rustc_scalable_vector(4)]
-//~^ ERROR: `#[rustc_scalable_vector]` attribute cannot be used on enums
+//~^ ERROR: the `rustc_scalable_vector` attribute cannot be used on enums
 enum Bar<#[rustc_scalable_vector(4)] T> {
-//~^ ERROR: `#[rustc_scalable_vector]` attribute cannot be used on type parameters
+//~^ ERROR: the `rustc_scalable_vector` attribute cannot be used on type parameters
     #[rustc_scalable_vector(4)]
-//~^ ERROR: `#[rustc_scalable_vector]` attribute cannot be used on enum variants
+//~^ ERROR: the `rustc_scalable_vector` attribute cannot be used on enum variants
     Baz(std::marker::PhantomData<T>),
 }
 
 struct Qux {
     #[rustc_scalable_vector(4)]
-//~^ ERROR: `#[rustc_scalable_vector]` attribute cannot be used on struct fields
+//~^ ERROR: the `rustc_scalable_vector` attribute cannot be used on struct fields
     field: u32,
 }
 
 #[rustc_scalable_vector(4)]
-//~^ ERROR: `#[rustc_scalable_vector]` attribute cannot be used on unions
+//~^ ERROR: the `rustc_scalable_vector` attribute cannot be used on unions
 union FooBar {
     x: u32,
     y: u32,
 }
 
 #[rustc_scalable_vector(4)]
-//~^ ERROR: `#[rustc_scalable_vector]` attribute cannot be used on traits
+//~^ ERROR: the `rustc_scalable_vector` attribute cannot be used on traits
 trait FooBaz {
     #[rustc_scalable_vector(4)]
-//~^ ERROR: `#[rustc_scalable_vector]` attribute cannot be used on associated types
+//~^ ERROR: the `rustc_scalable_vector` attribute cannot be used on associated types
     type Foo;
     #[rustc_scalable_vector(4)]
-//~^ ERROR: `#[rustc_scalable_vector]` attribute cannot be used on associated consts
+//~^ ERROR: the `rustc_scalable_vector` attribute cannot be used on associated consts
     const Bar: i32;
     #[rustc_scalable_vector(4)]
-//~^ ERROR: `#[rustc_scalable_vector]` attribute cannot be used on provided trait methods
+//~^ ERROR: the `rustc_scalable_vector` attribute cannot be used on provided trait methods
     fn foo() {}
 }
 
 #[rustc_scalable_vector(4)]
-//~^ ERROR: `#[rustc_scalable_vector]` attribute cannot be used on trait aliases
+//~^ ERROR: the `rustc_scalable_vector` attribute cannot be used on trait aliases
 trait FooQux = FooBaz;
 
 #[rustc_scalable_vector(4)]
-//~^ ERROR: `#[rustc_scalable_vector]` attribute cannot be used on inherent impl blocks
+//~^ ERROR: the `rustc_scalable_vector` attribute cannot be used on inherent impl blocks
 impl<T> Bar<T> {
     #[rustc_scalable_vector(4)]
-//~^ ERROR: `#[rustc_scalable_vector]` attribute cannot be used on inherent methods
+//~^ ERROR: the `rustc_scalable_vector` attribute cannot be used on inherent methods
     fn foo() {}
 }
 
 #[rustc_scalable_vector(4)]
-//~^ ERROR: `#[rustc_scalable_vector]` attribute cannot be used on trait impl blocks
+//~^ ERROR: the `rustc_scalable_vector` attribute cannot be used on trait impl blocks
 impl<T> FooBaz for Bar<T> {
     type Foo = u32;
     const Bar: i32 = 3;
 }
 
 #[rustc_scalable_vector(4)]
-//~^ ERROR: `#[rustc_scalable_vector]` attribute cannot be used on macro defs
+//~^ ERROR: the `rustc_scalable_vector` attribute cannot be used on macro defs
 macro_rules! barqux { ($foo:tt) => { $foo }; }
 
 #[rustc_scalable_vector(4)]
-//~^ ERROR: `#[rustc_scalable_vector]` attribute cannot be used on functions
+//~^ ERROR: the `rustc_scalable_vector` attribute cannot be used on functions
 fn barqux(#[rustc_scalable_vector(4)] _x: u32) {}
-//~^ ERROR: `#[rustc_scalable_vector]` attribute cannot be used on function params
+//~^ ERROR: the `rustc_scalable_vector` attribute cannot be used on function params
 //~^^ ERROR: allow, cfg, cfg_attr, deny, expect, forbid, and warn are the only allowed built-in attributes in function parameters
 
 #[rustc_scalable_vector(4)]
-//~^ ERROR: `#[rustc_scalable_vector]` attribute cannot be used on functions
+//~^ ERROR: the `rustc_scalable_vector` attribute cannot be used on functions
 async fn async_foo() {}
 
 #[rustc_scalable_vector(4)]
-//~^ ERROR: `#[rustc_scalable_vector]` attribute cannot be used on functions
+//~^ ERROR: the `rustc_scalable_vector` attribute cannot be used on functions
 gen fn gen_foo() {}
 
 #[rustc_scalable_vector(4)]
-//~^ ERROR: `#[rustc_scalable_vector]` attribute cannot be used on functions
+//~^ ERROR: the `rustc_scalable_vector` attribute cannot be used on functions
 async gen fn async_gen_foo() {}
 
 fn main() {
     let _x = #[rustc_scalable_vector(4)] || { };
-//~^ ERROR: `#[rustc_scalable_vector]` attribute cannot be used on closures
+//~^ ERROR: the `rustc_scalable_vector` attribute cannot be used on closures
     let _y = #[rustc_scalable_vector(4)] 3 + 4;
-//~^ ERROR: `#[rustc_scalable_vector]` attribute cannot be used on expressions
+//~^ ERROR: the `rustc_scalable_vector` attribute cannot be used on expressions
     #[rustc_scalable_vector(4)]
-//~^ ERROR: `#[rustc_scalable_vector]` attribute cannot be used on statements
+//~^ ERROR: the `rustc_scalable_vector` attribute cannot be used on statements
     let _z = 3;
 
     match _z {
         #[rustc_scalable_vector(4)]
-//~^ ERROR: `#[rustc_scalable_vector]` attribute cannot be used on match arms
+//~^ ERROR: the `rustc_scalable_vector` attribute cannot be used on match arms
         1 => (),
         _ => (),
     }

--- a/tests/ui/scalable-vectors/invalid.stderr
+++ b/tests/ui/scalable-vectors/invalid.stderr
@@ -5,7 +5,7 @@ LL | fn barqux(#[rustc_scalable_vector(4)] _x: u32) {}
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: the `rustc_scalable_vector` attribute cannot be used on extern crates
-  --> $DIR/invalid.rs:10:1
+  --> $DIR/invalid.rs:10:3
    |
 LL | #[rustc_scalable_vector(4)]
    |   ^^^^^^^^^^^^^^^^^^^^^
@@ -13,7 +13,7 @@ LL | #[rustc_scalable_vector(4)]
    = help: the `rustc_scalable_vector` attribute can only be applied to structs
 
 error: the `rustc_scalable_vector` attribute cannot be used on use statements
-  --> $DIR/invalid.rs:14:1
+  --> $DIR/invalid.rs:14:3
    |
 LL | #[rustc_scalable_vector(4)]
    |   ^^^^^^^^^^^^^^^^^^^^^
@@ -21,7 +21,7 @@ LL | #[rustc_scalable_vector(4)]
    = help: the `rustc_scalable_vector` attribute can only be applied to structs
 
 error: the `rustc_scalable_vector` attribute cannot be used on statics
-  --> $DIR/invalid.rs:18:1
+  --> $DIR/invalid.rs:18:3
    |
 LL | #[rustc_scalable_vector(4)]
    |   ^^^^^^^^^^^^^^^^^^^^^
@@ -29,7 +29,7 @@ LL | #[rustc_scalable_vector(4)]
    = help: the `rustc_scalable_vector` attribute can only be applied to structs
 
 error: the `rustc_scalable_vector` attribute cannot be used on constants
-  --> $DIR/invalid.rs:22:1
+  --> $DIR/invalid.rs:22:3
    |
 LL | #[rustc_scalable_vector(4)]
    |   ^^^^^^^^^^^^^^^^^^^^^
@@ -37,7 +37,7 @@ LL | #[rustc_scalable_vector(4)]
    = help: the `rustc_scalable_vector` attribute can only be applied to structs
 
 error: the `rustc_scalable_vector` attribute cannot be used on modules
-  --> $DIR/invalid.rs:26:1
+  --> $DIR/invalid.rs:26:3
    |
 LL | #[rustc_scalable_vector(4)]
    |   ^^^^^^^^^^^^^^^^^^^^^
@@ -45,7 +45,7 @@ LL | #[rustc_scalable_vector(4)]
    = help: the `rustc_scalable_vector` attribute can only be applied to structs
 
 error: the `rustc_scalable_vector` attribute cannot be used on foreign modules
-  --> $DIR/invalid.rs:31:1
+  --> $DIR/invalid.rs:31:3
    |
 LL | #[rustc_scalable_vector(4)]
    |   ^^^^^^^^^^^^^^^^^^^^^
@@ -53,7 +53,7 @@ LL | #[rustc_scalable_vector(4)]
    = help: the `rustc_scalable_vector` attribute can only be applied to structs
 
 error: the `rustc_scalable_vector` attribute cannot be used on foreign statics
-  --> $DIR/invalid.rs:34:5
+  --> $DIR/invalid.rs:34:7
    |
 LL |     #[rustc_scalable_vector(4)]
    |       ^^^^^^^^^^^^^^^^^^^^^
@@ -61,7 +61,7 @@ LL |     #[rustc_scalable_vector(4)]
    = help: the `rustc_scalable_vector` attribute can only be applied to structs
 
 error: the `rustc_scalable_vector` attribute cannot be used on foreign types
-  --> $DIR/invalid.rs:37:5
+  --> $DIR/invalid.rs:37:7
    |
 LL |     #[rustc_scalable_vector(4)]
    |       ^^^^^^^^^^^^^^^^^^^^^
@@ -69,7 +69,7 @@ LL |     #[rustc_scalable_vector(4)]
    = help: the `rustc_scalable_vector` attribute can only be applied to structs
 
 error: the `rustc_scalable_vector` attribute cannot be used on foreign functions
-  --> $DIR/invalid.rs:40:5
+  --> $DIR/invalid.rs:40:7
    |
 LL |     #[rustc_scalable_vector(4)]
    |       ^^^^^^^^^^^^^^^^^^^^^
@@ -77,7 +77,7 @@ LL |     #[rustc_scalable_vector(4)]
    = help: the `rustc_scalable_vector` attribute can only be applied to structs
 
 error: the `rustc_scalable_vector` attribute cannot be used on type aliases
-  --> $DIR/invalid.rs:45:1
+  --> $DIR/invalid.rs:45:3
    |
 LL | #[rustc_scalable_vector(4)]
    |   ^^^^^^^^^^^^^^^^^^^^^
@@ -85,7 +85,7 @@ LL | #[rustc_scalable_vector(4)]
    = help: the `rustc_scalable_vector` attribute can only be applied to structs
 
 error: the `rustc_scalable_vector` attribute cannot be used on enums
-  --> $DIR/invalid.rs:49:1
+  --> $DIR/invalid.rs:49:3
    |
 LL | #[rustc_scalable_vector(4)]
    |   ^^^^^^^^^^^^^^^^^^^^^
@@ -93,7 +93,7 @@ LL | #[rustc_scalable_vector(4)]
    = help: the `rustc_scalable_vector` attribute can only be applied to structs
 
 error: the `rustc_scalable_vector` attribute cannot be used on type parameters
-  --> $DIR/invalid.rs:51:10
+  --> $DIR/invalid.rs:51:12
    |
 LL | enum Bar<#[rustc_scalable_vector(4)] T> {
    |            ^^^^^^^^^^^^^^^^^^^^^
@@ -101,7 +101,7 @@ LL | enum Bar<#[rustc_scalable_vector(4)] T> {
    = help: the `rustc_scalable_vector` attribute can only be applied to structs
 
 error: the `rustc_scalable_vector` attribute cannot be used on enum variants
-  --> $DIR/invalid.rs:53:5
+  --> $DIR/invalid.rs:53:7
    |
 LL |     #[rustc_scalable_vector(4)]
    |       ^^^^^^^^^^^^^^^^^^^^^
@@ -109,7 +109,7 @@ LL |     #[rustc_scalable_vector(4)]
    = help: the `rustc_scalable_vector` attribute can only be applied to structs
 
 error: the `rustc_scalable_vector` attribute cannot be used on struct fields
-  --> $DIR/invalid.rs:59:5
+  --> $DIR/invalid.rs:59:7
    |
 LL |     #[rustc_scalable_vector(4)]
    |       ^^^^^^^^^^^^^^^^^^^^^
@@ -117,7 +117,7 @@ LL |     #[rustc_scalable_vector(4)]
    = help: the `rustc_scalable_vector` attribute can only be applied to structs
 
 error: the `rustc_scalable_vector` attribute cannot be used on unions
-  --> $DIR/invalid.rs:64:1
+  --> $DIR/invalid.rs:64:3
    |
 LL | #[rustc_scalable_vector(4)]
    |   ^^^^^^^^^^^^^^^^^^^^^
@@ -125,7 +125,7 @@ LL | #[rustc_scalable_vector(4)]
    = help: the `rustc_scalable_vector` attribute can only be applied to structs
 
 error: the `rustc_scalable_vector` attribute cannot be used on traits
-  --> $DIR/invalid.rs:71:1
+  --> $DIR/invalid.rs:71:3
    |
 LL | #[rustc_scalable_vector(4)]
    |   ^^^^^^^^^^^^^^^^^^^^^
@@ -133,7 +133,7 @@ LL | #[rustc_scalable_vector(4)]
    = help: the `rustc_scalable_vector` attribute can only be applied to structs
 
 error: the `rustc_scalable_vector` attribute cannot be used on associated types
-  --> $DIR/invalid.rs:74:5
+  --> $DIR/invalid.rs:74:7
    |
 LL |     #[rustc_scalable_vector(4)]
    |       ^^^^^^^^^^^^^^^^^^^^^
@@ -141,7 +141,7 @@ LL |     #[rustc_scalable_vector(4)]
    = help: the `rustc_scalable_vector` attribute can only be applied to structs
 
 error: the `rustc_scalable_vector` attribute cannot be used on associated consts
-  --> $DIR/invalid.rs:77:5
+  --> $DIR/invalid.rs:77:7
    |
 LL |     #[rustc_scalable_vector(4)]
    |       ^^^^^^^^^^^^^^^^^^^^^
@@ -149,7 +149,7 @@ LL |     #[rustc_scalable_vector(4)]
    = help: the `rustc_scalable_vector` attribute can only be applied to structs
 
 error: the `rustc_scalable_vector` attribute cannot be used on provided trait methods
-  --> $DIR/invalid.rs:80:5
+  --> $DIR/invalid.rs:80:7
    |
 LL |     #[rustc_scalable_vector(4)]
    |       ^^^^^^^^^^^^^^^^^^^^^
@@ -157,7 +157,7 @@ LL |     #[rustc_scalable_vector(4)]
    = help: the `rustc_scalable_vector` attribute can only be applied to structs
 
 error: the `rustc_scalable_vector` attribute cannot be used on trait aliases
-  --> $DIR/invalid.rs:85:1
+  --> $DIR/invalid.rs:85:3
    |
 LL | #[rustc_scalable_vector(4)]
    |   ^^^^^^^^^^^^^^^^^^^^^
@@ -165,7 +165,7 @@ LL | #[rustc_scalable_vector(4)]
    = help: the `rustc_scalable_vector` attribute can only be applied to structs
 
 error: the `rustc_scalable_vector` attribute cannot be used on inherent impl blocks
-  --> $DIR/invalid.rs:89:1
+  --> $DIR/invalid.rs:89:3
    |
 LL | #[rustc_scalable_vector(4)]
    |   ^^^^^^^^^^^^^^^^^^^^^
@@ -173,7 +173,7 @@ LL | #[rustc_scalable_vector(4)]
    = help: the `rustc_scalable_vector` attribute can only be applied to structs
 
 error: the `rustc_scalable_vector` attribute cannot be used on inherent methods
-  --> $DIR/invalid.rs:92:5
+  --> $DIR/invalid.rs:92:7
    |
 LL |     #[rustc_scalable_vector(4)]
    |       ^^^^^^^^^^^^^^^^^^^^^
@@ -181,7 +181,7 @@ LL |     #[rustc_scalable_vector(4)]
    = help: the `rustc_scalable_vector` attribute can only be applied to structs
 
 error: the `rustc_scalable_vector` attribute cannot be used on trait impl blocks
-  --> $DIR/invalid.rs:97:1
+  --> $DIR/invalid.rs:97:3
    |
 LL | #[rustc_scalable_vector(4)]
    |   ^^^^^^^^^^^^^^^^^^^^^
@@ -189,7 +189,7 @@ LL | #[rustc_scalable_vector(4)]
    = help: the `rustc_scalable_vector` attribute can only be applied to structs
 
 error: the `rustc_scalable_vector` attribute cannot be used on macro defs
-  --> $DIR/invalid.rs:104:1
+  --> $DIR/invalid.rs:104:3
    |
 LL | #[rustc_scalable_vector(4)]
    |   ^^^^^^^^^^^^^^^^^^^^^
@@ -197,7 +197,7 @@ LL | #[rustc_scalable_vector(4)]
    = help: the `rustc_scalable_vector` attribute can only be applied to structs
 
 error: the `rustc_scalable_vector` attribute cannot be used on functions
-  --> $DIR/invalid.rs:108:1
+  --> $DIR/invalid.rs:108:3
    |
 LL | #[rustc_scalable_vector(4)]
    |   ^^^^^^^^^^^^^^^^^^^^^
@@ -205,7 +205,7 @@ LL | #[rustc_scalable_vector(4)]
    = help: the `rustc_scalable_vector` attribute can only be applied to structs
 
 error: the `rustc_scalable_vector` attribute cannot be used on function params
-  --> $DIR/invalid.rs:110:11
+  --> $DIR/invalid.rs:110:13
    |
 LL | fn barqux(#[rustc_scalable_vector(4)] _x: u32) {}
    |             ^^^^^^^^^^^^^^^^^^^^^
@@ -213,7 +213,7 @@ LL | fn barqux(#[rustc_scalable_vector(4)] _x: u32) {}
    = help: the `rustc_scalable_vector` attribute can only be applied to structs
 
 error: the `rustc_scalable_vector` attribute cannot be used on functions
-  --> $DIR/invalid.rs:114:1
+  --> $DIR/invalid.rs:114:3
    |
 LL | #[rustc_scalable_vector(4)]
    |   ^^^^^^^^^^^^^^^^^^^^^
@@ -221,7 +221,7 @@ LL | #[rustc_scalable_vector(4)]
    = help: the `rustc_scalable_vector` attribute can only be applied to structs
 
 error: the `rustc_scalable_vector` attribute cannot be used on functions
-  --> $DIR/invalid.rs:118:1
+  --> $DIR/invalid.rs:118:3
    |
 LL | #[rustc_scalable_vector(4)]
    |   ^^^^^^^^^^^^^^^^^^^^^
@@ -229,7 +229,7 @@ LL | #[rustc_scalable_vector(4)]
    = help: the `rustc_scalable_vector` attribute can only be applied to structs
 
 error: the `rustc_scalable_vector` attribute cannot be used on functions
-  --> $DIR/invalid.rs:122:1
+  --> $DIR/invalid.rs:122:3
    |
 LL | #[rustc_scalable_vector(4)]
    |   ^^^^^^^^^^^^^^^^^^^^^
@@ -237,7 +237,7 @@ LL | #[rustc_scalable_vector(4)]
    = help: the `rustc_scalable_vector` attribute can only be applied to structs
 
 error: the `rustc_scalable_vector` attribute cannot be used on closures
-  --> $DIR/invalid.rs:127:14
+  --> $DIR/invalid.rs:127:16
    |
 LL |     let _x = #[rustc_scalable_vector(4)] || { };
    |                ^^^^^^^^^^^^^^^^^^^^^
@@ -245,7 +245,7 @@ LL |     let _x = #[rustc_scalable_vector(4)] || { };
    = help: the `rustc_scalable_vector` attribute can only be applied to structs
 
 error: the `rustc_scalable_vector` attribute cannot be used on expressions
-  --> $DIR/invalid.rs:129:14
+  --> $DIR/invalid.rs:129:16
    |
 LL |     let _y = #[rustc_scalable_vector(4)] 3 + 4;
    |                ^^^^^^^^^^^^^^^^^^^^^
@@ -253,7 +253,7 @@ LL |     let _y = #[rustc_scalable_vector(4)] 3 + 4;
    = help: the `rustc_scalable_vector` attribute can only be applied to structs
 
 error: the `rustc_scalable_vector` attribute cannot be used on statements
-  --> $DIR/invalid.rs:131:5
+  --> $DIR/invalid.rs:131:7
    |
 LL |     #[rustc_scalable_vector(4)]
    |       ^^^^^^^^^^^^^^^^^^^^^
@@ -261,7 +261,7 @@ LL |     #[rustc_scalable_vector(4)]
    = help: the `rustc_scalable_vector` attribute can only be applied to structs
 
 error: the `rustc_scalable_vector` attribute cannot be used on match arms
-  --> $DIR/invalid.rs:136:9
+  --> $DIR/invalid.rs:136:11
    |
 LL |         #[rustc_scalable_vector(4)]
    |           ^^^^^^^^^^^^^^^^^^^^^
@@ -269,7 +269,7 @@ LL |         #[rustc_scalable_vector(4)]
    = help: the `rustc_scalable_vector` attribute can only be applied to structs
 
 error[E0539]: malformed `rustc_scalable_vector` attribute input
-  --> $DIR/invalid.rs:143:1
+  --> $DIR/invalid.rs:143:3
    |
 LL | #[rustc_scalable_vector("4")]
    |   ^^^^^^^^^^^^^^^^^^^^^^---^
@@ -286,7 +286,7 @@ LL + #[rustc_scalable_vector]
    |
 
 error[E0805]: malformed `rustc_scalable_vector` attribute input
-  --> $DIR/invalid.rs:147:1
+  --> $DIR/invalid.rs:147:3
    |
 LL | #[rustc_scalable_vector(4, 2)]
    |   ^^^^^^^^^^^^^^^^^^^^^------
@@ -303,7 +303,7 @@ LL + #[rustc_scalable_vector]
    |
 
 error[E0539]: malformed `rustc_scalable_vector` attribute input
-  --> $DIR/invalid.rs:151:1
+  --> $DIR/invalid.rs:151:3
    |
 LL | #[rustc_scalable_vector(count = "4")]
    |   ^^^^^^^^^^^^^^^^^^^^^^-----------^
@@ -323,7 +323,7 @@ error: element count in `rustc_scalable_vector` is too large: `65536`
   --> $DIR/invalid.rs:155:1
    |
 LL | #[rustc_scalable_vector(65536)]
-   |   ^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: the value may not exceed `u16::MAX`
 

--- a/tests/ui/scalable-vectors/invalid.stderr
+++ b/tests/ui/scalable-vectors/invalid.stderr
@@ -4,275 +4,275 @@ error: allow, cfg, cfg_attr, deny, expect, forbid, and warn are the only allowed
 LL | fn barqux(#[rustc_scalable_vector(4)] _x: u32) {}
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: `#[rustc_scalable_vector]` attribute cannot be used on extern crates
+error: the `rustc_scalable_vector` attribute cannot be used on extern crates
   --> $DIR/invalid.rs:10:1
    |
 LL | #[rustc_scalable_vector(4)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_scalable_vector]` can only be applied to structs
+   = help: the `rustc_scalable_vector` attribute can only be applied to structs
 
-error: `#[rustc_scalable_vector]` attribute cannot be used on use statements
+error: the `rustc_scalable_vector` attribute cannot be used on use statements
   --> $DIR/invalid.rs:14:1
    |
 LL | #[rustc_scalable_vector(4)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_scalable_vector]` can only be applied to structs
+   = help: the `rustc_scalable_vector` attribute can only be applied to structs
 
-error: `#[rustc_scalable_vector]` attribute cannot be used on statics
+error: the `rustc_scalable_vector` attribute cannot be used on statics
   --> $DIR/invalid.rs:18:1
    |
 LL | #[rustc_scalable_vector(4)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_scalable_vector]` can only be applied to structs
+   = help: the `rustc_scalable_vector` attribute can only be applied to structs
 
-error: `#[rustc_scalable_vector]` attribute cannot be used on constants
+error: the `rustc_scalable_vector` attribute cannot be used on constants
   --> $DIR/invalid.rs:22:1
    |
 LL | #[rustc_scalable_vector(4)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_scalable_vector]` can only be applied to structs
+   = help: the `rustc_scalable_vector` attribute can only be applied to structs
 
-error: `#[rustc_scalable_vector]` attribute cannot be used on modules
+error: the `rustc_scalable_vector` attribute cannot be used on modules
   --> $DIR/invalid.rs:26:1
    |
 LL | #[rustc_scalable_vector(4)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_scalable_vector]` can only be applied to structs
+   = help: the `rustc_scalable_vector` attribute can only be applied to structs
 
-error: `#[rustc_scalable_vector]` attribute cannot be used on foreign modules
+error: the `rustc_scalable_vector` attribute cannot be used on foreign modules
   --> $DIR/invalid.rs:31:1
    |
 LL | #[rustc_scalable_vector(4)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_scalable_vector]` can only be applied to structs
+   = help: the `rustc_scalable_vector` attribute can only be applied to structs
 
-error: `#[rustc_scalable_vector]` attribute cannot be used on foreign statics
+error: the `rustc_scalable_vector` attribute cannot be used on foreign statics
   --> $DIR/invalid.rs:34:5
    |
 LL |     #[rustc_scalable_vector(4)]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_scalable_vector]` can only be applied to structs
+   = help: the `rustc_scalable_vector` attribute can only be applied to structs
 
-error: `#[rustc_scalable_vector]` attribute cannot be used on foreign types
+error: the `rustc_scalable_vector` attribute cannot be used on foreign types
   --> $DIR/invalid.rs:37:5
    |
 LL |     #[rustc_scalable_vector(4)]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_scalable_vector]` can only be applied to structs
+   = help: the `rustc_scalable_vector` attribute can only be applied to structs
 
-error: `#[rustc_scalable_vector]` attribute cannot be used on foreign functions
+error: the `rustc_scalable_vector` attribute cannot be used on foreign functions
   --> $DIR/invalid.rs:40:5
    |
 LL |     #[rustc_scalable_vector(4)]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_scalable_vector]` can only be applied to structs
+   = help: the `rustc_scalable_vector` attribute can only be applied to structs
 
-error: `#[rustc_scalable_vector]` attribute cannot be used on type aliases
+error: the `rustc_scalable_vector` attribute cannot be used on type aliases
   --> $DIR/invalid.rs:45:1
    |
 LL | #[rustc_scalable_vector(4)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_scalable_vector]` can only be applied to structs
+   = help: the `rustc_scalable_vector` attribute can only be applied to structs
 
-error: `#[rustc_scalable_vector]` attribute cannot be used on enums
+error: the `rustc_scalable_vector` attribute cannot be used on enums
   --> $DIR/invalid.rs:49:1
    |
 LL | #[rustc_scalable_vector(4)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_scalable_vector]` can only be applied to structs
+   = help: the `rustc_scalable_vector` attribute can only be applied to structs
 
-error: `#[rustc_scalable_vector]` attribute cannot be used on type parameters
+error: the `rustc_scalable_vector` attribute cannot be used on type parameters
   --> $DIR/invalid.rs:51:10
    |
 LL | enum Bar<#[rustc_scalable_vector(4)] T> {
-   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |            ^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_scalable_vector]` can only be applied to structs
+   = help: the `rustc_scalable_vector` attribute can only be applied to structs
 
-error: `#[rustc_scalable_vector]` attribute cannot be used on enum variants
+error: the `rustc_scalable_vector` attribute cannot be used on enum variants
   --> $DIR/invalid.rs:53:5
    |
 LL |     #[rustc_scalable_vector(4)]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_scalable_vector]` can only be applied to structs
+   = help: the `rustc_scalable_vector` attribute can only be applied to structs
 
-error: `#[rustc_scalable_vector]` attribute cannot be used on struct fields
+error: the `rustc_scalable_vector` attribute cannot be used on struct fields
   --> $DIR/invalid.rs:59:5
    |
 LL |     #[rustc_scalable_vector(4)]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_scalable_vector]` can only be applied to structs
+   = help: the `rustc_scalable_vector` attribute can only be applied to structs
 
-error: `#[rustc_scalable_vector]` attribute cannot be used on unions
+error: the `rustc_scalable_vector` attribute cannot be used on unions
   --> $DIR/invalid.rs:64:1
    |
 LL | #[rustc_scalable_vector(4)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_scalable_vector]` can only be applied to structs
+   = help: the `rustc_scalable_vector` attribute can only be applied to structs
 
-error: `#[rustc_scalable_vector]` attribute cannot be used on traits
+error: the `rustc_scalable_vector` attribute cannot be used on traits
   --> $DIR/invalid.rs:71:1
    |
 LL | #[rustc_scalable_vector(4)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_scalable_vector]` can only be applied to structs
+   = help: the `rustc_scalable_vector` attribute can only be applied to structs
 
-error: `#[rustc_scalable_vector]` attribute cannot be used on associated types
+error: the `rustc_scalable_vector` attribute cannot be used on associated types
   --> $DIR/invalid.rs:74:5
    |
 LL |     #[rustc_scalable_vector(4)]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_scalable_vector]` can only be applied to structs
+   = help: the `rustc_scalable_vector` attribute can only be applied to structs
 
-error: `#[rustc_scalable_vector]` attribute cannot be used on associated consts
+error: the `rustc_scalable_vector` attribute cannot be used on associated consts
   --> $DIR/invalid.rs:77:5
    |
 LL |     #[rustc_scalable_vector(4)]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_scalable_vector]` can only be applied to structs
+   = help: the `rustc_scalable_vector` attribute can only be applied to structs
 
-error: `#[rustc_scalable_vector]` attribute cannot be used on provided trait methods
+error: the `rustc_scalable_vector` attribute cannot be used on provided trait methods
   --> $DIR/invalid.rs:80:5
    |
 LL |     #[rustc_scalable_vector(4)]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_scalable_vector]` can only be applied to structs
+   = help: the `rustc_scalable_vector` attribute can only be applied to structs
 
-error: `#[rustc_scalable_vector]` attribute cannot be used on trait aliases
+error: the `rustc_scalable_vector` attribute cannot be used on trait aliases
   --> $DIR/invalid.rs:85:1
    |
 LL | #[rustc_scalable_vector(4)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_scalable_vector]` can only be applied to structs
+   = help: the `rustc_scalable_vector` attribute can only be applied to structs
 
-error: `#[rustc_scalable_vector]` attribute cannot be used on inherent impl blocks
+error: the `rustc_scalable_vector` attribute cannot be used on inherent impl blocks
   --> $DIR/invalid.rs:89:1
    |
 LL | #[rustc_scalable_vector(4)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_scalable_vector]` can only be applied to structs
+   = help: the `rustc_scalable_vector` attribute can only be applied to structs
 
-error: `#[rustc_scalable_vector]` attribute cannot be used on inherent methods
+error: the `rustc_scalable_vector` attribute cannot be used on inherent methods
   --> $DIR/invalid.rs:92:5
    |
 LL |     #[rustc_scalable_vector(4)]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_scalable_vector]` can only be applied to structs
+   = help: the `rustc_scalable_vector` attribute can only be applied to structs
 
-error: `#[rustc_scalable_vector]` attribute cannot be used on trait impl blocks
+error: the `rustc_scalable_vector` attribute cannot be used on trait impl blocks
   --> $DIR/invalid.rs:97:1
    |
 LL | #[rustc_scalable_vector(4)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_scalable_vector]` can only be applied to structs
+   = help: the `rustc_scalable_vector` attribute can only be applied to structs
 
-error: `#[rustc_scalable_vector]` attribute cannot be used on macro defs
+error: the `rustc_scalable_vector` attribute cannot be used on macro defs
   --> $DIR/invalid.rs:104:1
    |
 LL | #[rustc_scalable_vector(4)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_scalable_vector]` can only be applied to structs
+   = help: the `rustc_scalable_vector` attribute can only be applied to structs
 
-error: `#[rustc_scalable_vector]` attribute cannot be used on functions
+error: the `rustc_scalable_vector` attribute cannot be used on functions
   --> $DIR/invalid.rs:108:1
    |
 LL | #[rustc_scalable_vector(4)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_scalable_vector]` can only be applied to structs
+   = help: the `rustc_scalable_vector` attribute can only be applied to structs
 
-error: `#[rustc_scalable_vector]` attribute cannot be used on function params
+error: the `rustc_scalable_vector` attribute cannot be used on function params
   --> $DIR/invalid.rs:110:11
    |
 LL | fn barqux(#[rustc_scalable_vector(4)] _x: u32) {}
-   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |             ^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_scalable_vector]` can only be applied to structs
+   = help: the `rustc_scalable_vector` attribute can only be applied to structs
 
-error: `#[rustc_scalable_vector]` attribute cannot be used on functions
+error: the `rustc_scalable_vector` attribute cannot be used on functions
   --> $DIR/invalid.rs:114:1
    |
 LL | #[rustc_scalable_vector(4)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_scalable_vector]` can only be applied to structs
+   = help: the `rustc_scalable_vector` attribute can only be applied to structs
 
-error: `#[rustc_scalable_vector]` attribute cannot be used on functions
+error: the `rustc_scalable_vector` attribute cannot be used on functions
   --> $DIR/invalid.rs:118:1
    |
 LL | #[rustc_scalable_vector(4)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_scalable_vector]` can only be applied to structs
+   = help: the `rustc_scalable_vector` attribute can only be applied to structs
 
-error: `#[rustc_scalable_vector]` attribute cannot be used on functions
+error: the `rustc_scalable_vector` attribute cannot be used on functions
   --> $DIR/invalid.rs:122:1
    |
 LL | #[rustc_scalable_vector(4)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_scalable_vector]` can only be applied to structs
+   = help: the `rustc_scalable_vector` attribute can only be applied to structs
 
-error: `#[rustc_scalable_vector]` attribute cannot be used on closures
+error: the `rustc_scalable_vector` attribute cannot be used on closures
   --> $DIR/invalid.rs:127:14
    |
 LL |     let _x = #[rustc_scalable_vector(4)] || { };
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                ^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_scalable_vector]` can only be applied to structs
+   = help: the `rustc_scalable_vector` attribute can only be applied to structs
 
-error: `#[rustc_scalable_vector]` attribute cannot be used on expressions
+error: the `rustc_scalable_vector` attribute cannot be used on expressions
   --> $DIR/invalid.rs:129:14
    |
 LL |     let _y = #[rustc_scalable_vector(4)] 3 + 4;
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                ^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_scalable_vector]` can only be applied to structs
+   = help: the `rustc_scalable_vector` attribute can only be applied to structs
 
-error: `#[rustc_scalable_vector]` attribute cannot be used on statements
+error: the `rustc_scalable_vector` attribute cannot be used on statements
   --> $DIR/invalid.rs:131:5
    |
 LL |     #[rustc_scalable_vector(4)]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_scalable_vector]` can only be applied to structs
+   = help: the `rustc_scalable_vector` attribute can only be applied to structs
 
-error: `#[rustc_scalable_vector]` attribute cannot be used on match arms
+error: the `rustc_scalable_vector` attribute cannot be used on match arms
   --> $DIR/invalid.rs:136:9
    |
 LL |         #[rustc_scalable_vector(4)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |           ^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_scalable_vector]` can only be applied to structs
+   = help: the `rustc_scalable_vector` attribute can only be applied to structs
 
 error[E0539]: malformed `rustc_scalable_vector` attribute input
   --> $DIR/invalid.rs:143:1
    |
 LL | #[rustc_scalable_vector("4")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^---^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^---^
    |                         |
    |                         expected an integer literal here
    |
@@ -289,7 +289,7 @@ error[E0805]: malformed `rustc_scalable_vector` attribute input
   --> $DIR/invalid.rs:147:1
    |
 LL | #[rustc_scalable_vector(4, 2)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^------^
+   |   ^^^^^^^^^^^^^^^^^^^^^------
    |                        |
    |                        expected a single argument here
    |
@@ -306,7 +306,7 @@ error[E0539]: malformed `rustc_scalable_vector` attribute input
   --> $DIR/invalid.rs:151:1
    |
 LL | #[rustc_scalable_vector(count = "4")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^-----------^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^-----------^
    |                         |
    |                         expected an integer literal here
    |
@@ -323,7 +323,7 @@ error: element count in `rustc_scalable_vector` is too large: `65536`
   --> $DIR/invalid.rs:155:1
    |
 LL | #[rustc_scalable_vector(65536)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^
    |
    = note: the value may not exceed `u16::MAX`
 

--- a/tests/ui/simd/repr-simd-on-enum.stderr
+++ b/tests/ui/simd/repr-simd-on-enum.stderr
@@ -1,10 +1,10 @@
-error: `#[repr(simd)]` attribute cannot be used on enums
-  --> $DIR/repr-simd-on-enum.rs:5:1
+error: the `repr(simd)` attribute cannot be used on enums
+  --> $DIR/repr-simd-on-enum.rs:5:3
    |
 LL | #[repr(simd)]
-   | ^^^^^^^^^^^^^
+   |   ^^^^^^^^^^
    |
-   = help: `#[repr(simd)]` can only be applied to structs
+   = help: the `repr(simd)` attribute can only be applied to structs
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/span/E0539.stderr
+++ b/tests/ui/span/E0539.stderr
@@ -1,8 +1,8 @@
 error[E0539]: malformed `inline` attribute input
-  --> $DIR/E0539.rs:1:1
+  --> $DIR/E0539.rs:1:3
    |
 LL | #[inline(unknown)]
-   | ^^^^^^^^^-------^^
+   |   ^^^^^^^-------^
    |          |
    |          valid arguments are `always` or `never`
    |

--- a/tests/ui/splat/splat-non-fn-arg.rs
+++ b/tests/ui/splat/splat-non-fn-arg.rs
@@ -3,10 +3,10 @@
 #![allow(incomplete_features)]
 #![feature(splat)]
 
-#[splat] //~ ERROR `#[splat]` attribute cannot be used on functions
+#[splat] //~ ERROR the `splat` attribute cannot be used on functions
 fn tuple_args_bad((a, b): (u32, i8)) {}
 
-#[splat] //~ ERROR `#[splat]` attribute cannot be used on traits
+#[splat] //~ ERROR the `splat` attribute cannot be used on traits
 trait FooTraitBad {
     fn tuple_1(_: (u32,));
 
@@ -15,45 +15,45 @@ trait FooTraitBad {
 
 struct Foo;
 
-#[splat] //~ ERROR `#[splat]` attribute cannot be used on inherent impl blocks
+#[splat] //~ ERROR the `splat` attribute cannot be used on inherent impl blocks
 impl Foo {
     fn tuple_1_bad((a,): (u32,)) {}
 }
 
 impl Foo {
-    #[splat] //~ ERROR `#[splat]` attribute cannot be used on inherent methods
+    #[splat] //~ ERROR the `splat` attribute cannot be used on inherent methods
     fn tuple_3_bad((a, b, c): (u32, i32, i8)) {}
 
-    #[splat] //~ ERROR `#[splat]` attribute cannot be used on inherent methods
+    #[splat] //~ ERROR the `splat` attribute cannot be used on inherent methods
     fn tuple_2_bad(self, (a, b): (u32, i8)) -> u32 {
         a
     }
 }
 
-#[splat] //~ ERROR `#[splat]` attribute cannot be used on trait impl blocks
+#[splat] //~ ERROR the `splat` attribute cannot be used on trait impl blocks
 impl FooTraitBad for Foo {
     fn tuple_1(_: (u32,)) {}
 
     fn tuple_4(self, _: (u32, i8, (), f32)) {}
 }
 
-#[splat] //~ ERROR `#[splat]` attribute cannot be used on foreign modules
+#[splat] //~ ERROR the `splat` attribute cannot be used on foreign modules
 extern "C" {
     fn foo_2(_: (u32, i8));
 }
 
 extern "C" {
-    #[splat] //~ ERROR `#[splat]` attribute cannot be used on foreign functions
+    #[splat] //~ ERROR the `splat` attribute cannot be used on foreign functions
     fn bar_2_bad(_: (u32, i8));
 }
 
-#[splat] //~ ERROR `#[splat]` attribute cannot be used on modules
+#[splat] //~ ERROR the `splat` attribute cannot be used on modules
 mod foo_mod {}
 
-#[splat] //~ ERROR `#[splat]` attribute cannot be used on use statements
+#[splat] //~ ERROR the `splat` attribute cannot be used on use statements
 use std::mem;
 
-#[splat] //~ ERROR `#[splat]` attribute cannot be used on structs
+#[splat] //~ ERROR the `splat` attribute cannot be used on structs
 struct FooStruct;
 
 fn main() {}

--- a/tests/ui/splat/splat-non-fn-arg.stderr
+++ b/tests/ui/splat/splat-non-fn-arg.stderr
@@ -1,90 +1,90 @@
-error: `#[splat]` attribute cannot be used on functions
-  --> $DIR/splat-non-fn-arg.rs:6:1
+error: the `splat` attribute cannot be used on functions
+  --> $DIR/splat-non-fn-arg.rs:6:3
    |
 LL | #[splat]
-   | ^^^^^^^^
+   |   ^^^^^
    |
-   = help: `#[splat]` can only be applied to function params
+   = help: the `splat` attribute can only be applied to function params
 
-error: `#[splat]` attribute cannot be used on traits
-  --> $DIR/splat-non-fn-arg.rs:9:1
+error: the `splat` attribute cannot be used on traits
+  --> $DIR/splat-non-fn-arg.rs:9:3
    |
 LL | #[splat]
-   | ^^^^^^^^
+   |   ^^^^^
    |
-   = help: `#[splat]` can only be applied to function params
+   = help: the `splat` attribute can only be applied to function params
 
-error: `#[splat]` attribute cannot be used on inherent impl blocks
-  --> $DIR/splat-non-fn-arg.rs:18:1
+error: the `splat` attribute cannot be used on inherent impl blocks
+  --> $DIR/splat-non-fn-arg.rs:18:3
    |
 LL | #[splat]
-   | ^^^^^^^^
+   |   ^^^^^
    |
-   = help: `#[splat]` can only be applied to function params
+   = help: the `splat` attribute can only be applied to function params
 
-error: `#[splat]` attribute cannot be used on inherent methods
-  --> $DIR/splat-non-fn-arg.rs:24:5
+error: the `splat` attribute cannot be used on inherent methods
+  --> $DIR/splat-non-fn-arg.rs:24:7
    |
 LL |     #[splat]
-   |     ^^^^^^^^
+   |       ^^^^^
    |
-   = help: `#[splat]` can only be applied to function params
+   = help: the `splat` attribute can only be applied to function params
 
-error: `#[splat]` attribute cannot be used on inherent methods
-  --> $DIR/splat-non-fn-arg.rs:27:5
+error: the `splat` attribute cannot be used on inherent methods
+  --> $DIR/splat-non-fn-arg.rs:27:7
    |
 LL |     #[splat]
-   |     ^^^^^^^^
+   |       ^^^^^
    |
-   = help: `#[splat]` can only be applied to function params
+   = help: the `splat` attribute can only be applied to function params
 
-error: `#[splat]` attribute cannot be used on trait impl blocks
-  --> $DIR/splat-non-fn-arg.rs:33:1
+error: the `splat` attribute cannot be used on trait impl blocks
+  --> $DIR/splat-non-fn-arg.rs:33:3
    |
 LL | #[splat]
-   | ^^^^^^^^
+   |   ^^^^^
    |
-   = help: `#[splat]` can only be applied to function params
+   = help: the `splat` attribute can only be applied to function params
 
-error: `#[splat]` attribute cannot be used on foreign modules
-  --> $DIR/splat-non-fn-arg.rs:40:1
+error: the `splat` attribute cannot be used on foreign modules
+  --> $DIR/splat-non-fn-arg.rs:40:3
    |
 LL | #[splat]
-   | ^^^^^^^^
+   |   ^^^^^
    |
-   = help: `#[splat]` can only be applied to function params
+   = help: the `splat` attribute can only be applied to function params
 
-error: `#[splat]` attribute cannot be used on foreign functions
-  --> $DIR/splat-non-fn-arg.rs:46:5
+error: the `splat` attribute cannot be used on foreign functions
+  --> $DIR/splat-non-fn-arg.rs:46:7
    |
 LL |     #[splat]
-   |     ^^^^^^^^
+   |       ^^^^^
    |
-   = help: `#[splat]` can only be applied to function params
+   = help: the `splat` attribute can only be applied to function params
 
-error: `#[splat]` attribute cannot be used on modules
-  --> $DIR/splat-non-fn-arg.rs:50:1
+error: the `splat` attribute cannot be used on modules
+  --> $DIR/splat-non-fn-arg.rs:50:3
    |
 LL | #[splat]
-   | ^^^^^^^^
+   |   ^^^^^
    |
-   = help: `#[splat]` can only be applied to function params
+   = help: the `splat` attribute can only be applied to function params
 
-error: `#[splat]` attribute cannot be used on use statements
-  --> $DIR/splat-non-fn-arg.rs:53:1
+error: the `splat` attribute cannot be used on use statements
+  --> $DIR/splat-non-fn-arg.rs:53:3
    |
 LL | #[splat]
-   | ^^^^^^^^
+   |   ^^^^^
    |
-   = help: `#[splat]` can only be applied to function params
+   = help: the `splat` attribute can only be applied to function params
 
-error: `#[splat]` attribute cannot be used on structs
-  --> $DIR/splat-non-fn-arg.rs:56:1
+error: the `splat` attribute cannot be used on structs
+  --> $DIR/splat-non-fn-arg.rs:56:3
    |
 LL | #[splat]
-   | ^^^^^^^^
+   |   ^^^^^
    |
-   = help: `#[splat]` can only be applied to function params
+   = help: the `splat` attribute can only be applied to function params
 
 error: aborting due to 11 previous errors
 

--- a/tests/ui/stability-attribute/issue-106589.stderr
+++ b/tests/ui/stability-attribute/issue-106589.stderr
@@ -1,14 +1,14 @@
 error[E0658]: stability attributes may not be used outside of the standard library
-  --> $DIR/issue-106589.rs:3:1
+  --> $DIR/issue-106589.rs:3:4
    |
 LL | #![stable(feature = "foo", since = "1.0.0")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |    ^^^^^^
 
 error[E0658]: stability attributes may not be used outside of the standard library
-  --> $DIR/issue-106589.rs:6:1
+  --> $DIR/issue-106589.rs:6:3
    |
 LL | #[unstable(feature = "foo", issue = "none")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/stability-attribute/stability-attribute-non-staged-force-unstable.stderr
+++ b/tests/ui/stability-attribute/stability-attribute-non-staged-force-unstable.stderr
@@ -1,8 +1,8 @@
 error[E0658]: stability attributes may not be used outside of the standard library
-  --> $DIR/stability-attribute-non-staged-force-unstable.rs:3:1
+  --> $DIR/stability-attribute-non-staged-force-unstable.rs:3:3
    |
 LL | #[unstable()]
-   | ^^^^^^^^^^^^^
+   |   ^^^^^^^^
 
 error[E0546]: missing 'feature'
   --> $DIR/stability-attribute-non-staged-force-unstable.rs:3:1
@@ -17,10 +17,10 @@ LL | #[unstable()]
    | ^^^^^^^^^^^^^
 
 error[E0658]: stability attributes may not be used outside of the standard library
-  --> $DIR/stability-attribute-non-staged-force-unstable.rs:7:1
+  --> $DIR/stability-attribute-non-staged-force-unstable.rs:7:3
    |
 LL | #[stable()]
-   | ^^^^^^^^^^^
+   |   ^^^^^^
 
 error[E0546]: missing 'feature'
   --> $DIR/stability-attribute-non-staged-force-unstable.rs:7:1

--- a/tests/ui/stability-attribute/stability-attribute-non-staged.stderr
+++ b/tests/ui/stability-attribute/stability-attribute-non-staged.stderr
@@ -1,8 +1,8 @@
 error[E0658]: stability attributes may not be used outside of the standard library
-  --> $DIR/stability-attribute-non-staged.rs:1:1
+  --> $DIR/stability-attribute-non-staged.rs:1:3
    |
 LL | #[unstable()]
-   | ^^^^^^^^^^^^^
+   |   ^^^^^^^^
 
 error[E0546]: missing 'feature'
   --> $DIR/stability-attribute-non-staged.rs:1:1
@@ -17,10 +17,10 @@ LL | #[unstable()]
    | ^^^^^^^^^^^^^
 
 error[E0658]: stability attributes may not be used outside of the standard library
-  --> $DIR/stability-attribute-non-staged.rs:5:1
+  --> $DIR/stability-attribute-non-staged.rs:5:3
    |
 LL | #[stable()]
-   | ^^^^^^^^^^^
+   |   ^^^^^^
 
 error[E0546]: missing 'feature'
   --> $DIR/stability-attribute-non-staged.rs:5:1

--- a/tests/ui/stability-attribute/stability-attribute-sanity-2.stderr
+++ b/tests/ui/stability-attribute/stability-attribute-sanity-2.stderr
@@ -1,8 +1,8 @@
 error[E0538]: malformed `stable` attribute input
-  --> $DIR/stability-attribute-sanity-2.rs:7:1
+  --> $DIR/stability-attribute-sanity-2.rs:7:3
    |
 LL | #[stable(feature = "a", feature = "b", since = "1.0.0")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^-------^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^-------^^^^^^^^^^^^^^^^^^^^^^^^
    |                         |
    |                         found `feature` used as a key more than once
    |
@@ -13,10 +13,10 @@ LL + #[stable(feature = "name", since = "version")]
    |
 
 error[E0539]: malformed `stable` attribute input
-  --> $DIR/stability-attribute-sanity-2.rs:10:1
+  --> $DIR/stability-attribute-sanity-2.rs:10:3
    |
 LL | #[stable(feature = "a", sinse = "1.0.0")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^---------------^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^---------------^
    |                         |
    |                         valid arguments are `feature` or `since`
    |

--- a/tests/ui/stability-attribute/stability-attribute-sanity-4.stderr
+++ b/tests/ui/stability-attribute/stability-attribute-sanity-4.stderr
@@ -1,8 +1,8 @@
 error[E0539]: malformed `unstable` attribute input
-  --> $DIR/stability-attribute-sanity-4.rs:8:5
+  --> $DIR/stability-attribute-sanity-4.rs:8:7
    |
 LL |     #[unstable]
-   |     ^^^^^^^^^^^ expected this to be a list
+   |       ^^^^^^^^ expected this to be a list
    |
 help: must be of the form
    |
@@ -10,10 +10,10 @@ LL |     #[unstable(feature = "name", reason = "...", issue = "N")]
    |               +++++++++++++++++++++++++++++++++++++++++++++++
 
 error[E0539]: malformed `unstable` attribute input
-  --> $DIR/stability-attribute-sanity-4.rs:11:5
+  --> $DIR/stability-attribute-sanity-4.rs:11:7
    |
 LL |     #[unstable = "b"]
-   |     ^^^^^^^^^^^-----^
+   |       ^^^^^^^^^-----
    |                |
    |                expected this to be a list
    |
@@ -24,10 +24,10 @@ LL +     #[unstable(feature = "name", reason = "...", issue = "N")]
    |
 
 error[E0539]: malformed `stable` attribute input
-  --> $DIR/stability-attribute-sanity-4.rs:14:5
+  --> $DIR/stability-attribute-sanity-4.rs:14:7
    |
 LL |     #[stable]
-   |     ^^^^^^^^^ expected this to be a list
+   |       ^^^^^^ expected this to be a list
    |
 help: must be of the form
    |
@@ -35,10 +35,10 @@ LL |     #[stable(feature = "name", since = "version")]
    |             +++++++++++++++++++++++++++++++++++++
 
 error[E0539]: malformed `stable` attribute input
-  --> $DIR/stability-attribute-sanity-4.rs:17:5
+  --> $DIR/stability-attribute-sanity-4.rs:17:7
    |
 LL |     #[stable = "a"]
-   |     ^^^^^^^^^-----^
+   |       ^^^^^^^-----
    |              |
    |              expected this to be a list
    |

--- a/tests/ui/stability-attribute/stability-attribute-sanity.stderr
+++ b/tests/ui/stability-attribute/stability-attribute-sanity.stderr
@@ -1,8 +1,8 @@
 error[E0539]: malformed `stable` attribute input
-  --> $DIR/stability-attribute-sanity.rs:8:5
+  --> $DIR/stability-attribute-sanity.rs:8:7
    |
 LL |     #[stable(feature = "a", since = "4.4.4", reason)]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------^^
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------^
    |                                              |
    |                                              valid arguments are `feature` or `since`
    |
@@ -13,10 +13,10 @@ LL +     #[stable(feature = "name", since = "version")]
    |
 
 error[E0539]: malformed `stable` attribute input
-  --> $DIR/stability-attribute-sanity.rs:11:5
+  --> $DIR/stability-attribute-sanity.rs:11:7
    |
 LL |     #[stable(feature = "a", since)]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^-----^^
+   |       ^^^^^^^^^^^^^^^^^^^^^^-----^
    |                             |
    |                             expected this to be of the form `since = "..."`
    |
@@ -27,10 +27,10 @@ LL +     #[stable(feature = "name", since = "version")]
    |
 
 error[E0539]: malformed `stable` attribute input
-  --> $DIR/stability-attribute-sanity.rs:14:5
+  --> $DIR/stability-attribute-sanity.rs:14:7
    |
 LL |     #[stable(feature, since = "3.3.3")]
-   |     ^^^^^^^^^-------^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^-------^^^^^^^^^^^^^^^^^^
    |              |
    |              expected this to be of the form `feature = "..."`
    |
@@ -41,10 +41,10 @@ LL +     #[stable(feature = "name", since = "version")]
    |
 
 error[E0539]: malformed `stable` attribute input
-  --> $DIR/stability-attribute-sanity.rs:17:5
+  --> $DIR/stability-attribute-sanity.rs:17:7
    |
 LL |     #[stable(feature = "a", since(b))]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^--------^^
+   |       ^^^^^^^^^^^^^^^^^^^^^^--------^
    |                             |
    |                             expected this to be of the form `since = "..."`
    |
@@ -55,10 +55,10 @@ LL +     #[stable(feature = "name", since = "version")]
    |
 
 error[E0539]: malformed `stable` attribute input
-  --> $DIR/stability-attribute-sanity.rs:20:5
+  --> $DIR/stability-attribute-sanity.rs:20:7
    |
 LL |     #[stable(feature(b), since = "3.3.3")]
-   |     ^^^^^^^^^----------^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^----------^^^^^^^^^^^^^^^^^^
    |              |
    |              expected this to be of the form `feature = "..."`
    |

--- a/tests/ui/target-feature/invalid-attribute.stderr
+++ b/tests/ui/target-feature/invalid-attribute.stderr
@@ -1,26 +1,26 @@
-error: `#[target_feature]` attribute cannot be used on extern crates
-  --> $DIR/invalid-attribute.rs:12:1
+error: the `target_feature` attribute cannot be used on extern crates
+  --> $DIR/invalid-attribute.rs:12:3
    |
 LL | #[target_feature(enable = "sse2")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^
    |
-   = help: `#[target_feature]` can only be applied to functions
+   = help: the `target_feature` attribute can only be applied to functions
 
-error: `#[target_feature]` attribute cannot be used on use statements
-  --> $DIR/invalid-attribute.rs:16:1
+error: the `target_feature` attribute cannot be used on use statements
+  --> $DIR/invalid-attribute.rs:16:3
    |
 LL | #[target_feature(enable = "sse2")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^
    |
-   = help: `#[target_feature]` can only be applied to functions
+   = help: the `target_feature` attribute can only be applied to functions
 
-error: `#[target_feature]` attribute cannot be used on foreign modules
-  --> $DIR/invalid-attribute.rs:20:1
+error: the `target_feature` attribute cannot be used on foreign modules
+  --> $DIR/invalid-attribute.rs:20:3
    |
 LL | #[target_feature(enable = "sse2")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^
    |
-   = help: `#[target_feature]` can only be applied to functions
+   = help: the `target_feature` attribute can only be applied to functions
 
 error[E0539]: malformed `target_feature` attribute input
   --> $DIR/invalid-attribute.rs:24:1
@@ -64,101 +64,101 @@ LL - #[target_feature(disable = "baz")]
 LL + #[target_feature(enable = "feat1, feat2")]
    |
 
-error: `#[target_feature]` attribute cannot be used on modules
-  --> $DIR/invalid-attribute.rs:38:1
+error: the `target_feature` attribute cannot be used on modules
+  --> $DIR/invalid-attribute.rs:38:3
    |
 LL | #[target_feature(enable = "sse2")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^
    |
-   = help: `#[target_feature]` can only be applied to functions
+   = help: the `target_feature` attribute can only be applied to functions
 
-error: `#[target_feature]` attribute cannot be used on constants
-  --> $DIR/invalid-attribute.rs:42:1
+error: the `target_feature` attribute cannot be used on constants
+  --> $DIR/invalid-attribute.rs:42:3
    |
 LL | #[target_feature(enable = "sse2")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^
    |
-   = help: `#[target_feature]` can only be applied to functions
+   = help: the `target_feature` attribute can only be applied to functions
 
-error: `#[target_feature]` attribute cannot be used on structs
-  --> $DIR/invalid-attribute.rs:46:1
+error: the `target_feature` attribute cannot be used on structs
+  --> $DIR/invalid-attribute.rs:46:3
    |
 LL | #[target_feature(enable = "sse2")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^
    |
-   = help: `#[target_feature]` can only be applied to functions
+   = help: the `target_feature` attribute can only be applied to functions
 
-error: `#[target_feature]` attribute cannot be used on enums
-  --> $DIR/invalid-attribute.rs:50:1
+error: the `target_feature` attribute cannot be used on enums
+  --> $DIR/invalid-attribute.rs:50:3
    |
 LL | #[target_feature(enable = "sse2")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^
    |
-   = help: `#[target_feature]` can only be applied to functions
+   = help: the `target_feature` attribute can only be applied to functions
 
-error: `#[target_feature]` attribute cannot be used on unions
-  --> $DIR/invalid-attribute.rs:54:1
+error: the `target_feature` attribute cannot be used on unions
+  --> $DIR/invalid-attribute.rs:54:3
    |
 LL | #[target_feature(enable = "sse2")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^
    |
-   = help: `#[target_feature]` can only be applied to functions
+   = help: the `target_feature` attribute can only be applied to functions
 
-error: `#[target_feature]` attribute cannot be used on type aliases
-  --> $DIR/invalid-attribute.rs:61:1
+error: the `target_feature` attribute cannot be used on type aliases
+  --> $DIR/invalid-attribute.rs:61:3
    |
 LL | #[target_feature(enable = "sse2")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^
    |
-   = help: `#[target_feature]` can only be applied to functions
+   = help: the `target_feature` attribute can only be applied to functions
 
-error: `#[target_feature]` attribute cannot be used on traits
-  --> $DIR/invalid-attribute.rs:65:1
+error: the `target_feature` attribute cannot be used on traits
+  --> $DIR/invalid-attribute.rs:65:3
    |
 LL | #[target_feature(enable = "sse2")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^
    |
-   = help: `#[target_feature]` can only be applied to functions
+   = help: the `target_feature` attribute can only be applied to functions
 
-error: `#[target_feature]` attribute cannot be used on statics
-  --> $DIR/invalid-attribute.rs:75:1
+error: the `target_feature` attribute cannot be used on statics
+  --> $DIR/invalid-attribute.rs:75:3
    |
 LL | #[target_feature(enable = "sse2")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^
    |
-   = help: `#[target_feature]` can only be applied to functions
+   = help: the `target_feature` attribute can only be applied to functions
 
-error: `#[target_feature]` attribute cannot be used on trait impl blocks
-  --> $DIR/invalid-attribute.rs:79:1
+error: the `target_feature` attribute cannot be used on trait impl blocks
+  --> $DIR/invalid-attribute.rs:79:3
    |
 LL | #[target_feature(enable = "sse2")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^
    |
-   = help: `#[target_feature]` can only be applied to functions
+   = help: the `target_feature` attribute can only be applied to functions
 
-error: `#[target_feature]` attribute cannot be used on inherent impl blocks
-  --> $DIR/invalid-attribute.rs:85:1
+error: the `target_feature` attribute cannot be used on inherent impl blocks
+  --> $DIR/invalid-attribute.rs:85:3
    |
 LL | #[target_feature(enable = "sse2")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^
    |
-   = help: `#[target_feature]` can only be applied to functions
+   = help: the `target_feature` attribute can only be applied to functions
 
-error: `#[target_feature]` attribute cannot be used on expressions
-  --> $DIR/invalid-attribute.rs:106:5
+error: the `target_feature` attribute cannot be used on expressions
+  --> $DIR/invalid-attribute.rs:106:7
    |
 LL |     #[target_feature(enable = "sse2")]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^
    |
-   = help: `#[target_feature]` can only be applied to functions
+   = help: the `target_feature` attribute can only be applied to functions
 
-error: `#[target_feature]` attribute cannot be used on closures
-  --> $DIR/invalid-attribute.rs:112:5
+error: the `target_feature` attribute cannot be used on closures
+  --> $DIR/invalid-attribute.rs:112:7
    |
 LL |     #[target_feature(enable = "sse2")]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^
    |
-   = help: `#[target_feature]` can be applied to functions and methods
+   = help: the `target_feature` attribute can be applied to functions and methods
 
 error: cannot use `#[inline(always)]` with `#[target_feature]`
   --> $DIR/invalid-attribute.rs:69:1

--- a/tests/ui/target-feature/invalid-attribute.stderr
+++ b/tests/ui/target-feature/invalid-attribute.stderr
@@ -23,10 +23,10 @@ LL | #[target_feature(enable = "sse2")]
    = help: the `target_feature` attribute can only be applied to functions
 
 error[E0539]: malformed `target_feature` attribute input
-  --> $DIR/invalid-attribute.rs:24:1
+  --> $DIR/invalid-attribute.rs:24:3
    |
 LL | #[target_feature = "+sse2"]
-   | ^^^^^^^^^^^^^^^^^---------^
+   |   ^^^^^^^^^^^^^^^---------
    |                  |
    |                  expected this to be a list
    |
@@ -37,10 +37,10 @@ LL + #[target_feature(enable = "feat1, feat2")]
    |
 
 error[E0539]: malformed `target_feature` attribute input
-  --> $DIR/invalid-attribute.rs:30:1
+  --> $DIR/invalid-attribute.rs:30:3
    |
 LL | #[target_feature(bar)]
-   | ^^^^^^^^^^^^^^^^^---^^
+   |   ^^^^^^^^^^^^^^^---^
    |                  |
    |                  expected this to be of the form `enable = "..."`
    |
@@ -51,10 +51,10 @@ LL + #[target_feature(enable = "feat1, feat2")]
    |
 
 error[E0539]: malformed `target_feature` attribute input
-  --> $DIR/invalid-attribute.rs:33:1
+  --> $DIR/invalid-attribute.rs:33:3
    |
 LL | #[target_feature(disable = "baz")]
-   | ^^^^^^^^^^^^^^^^^-------^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^-------^^^^^^^^^
    |                  |
    |                  the only valid argument here is `enable`
    |

--- a/tests/ui/test-attrs/test-should-panic-attr.stderr
+++ b/tests/ui/test-attrs/test-should-panic-attr.stderr
@@ -1,8 +1,8 @@
 error[E0539]: malformed `should_panic` attribute input
-  --> $DIR/test-should-panic-attr.rs:11:1
+  --> $DIR/test-should-panic-attr.rs:11:3
    |
 LL | #[should_panic(expected)]
-   | ^^^^^^^^^^^^^^^--------^^
+   |   ^^^^^^^^^^^^^--------^
    |                |
    |                expected this to be of the form `expected = "..."`
    |
@@ -19,10 +19,10 @@ LL + #[should_panic]
    |
 
 error[E0539]: malformed `should_panic` attribute input
-  --> $DIR/test-should-panic-attr.rs:20:1
+  --> $DIR/test-should-panic-attr.rs:20:3
    |
 LL | #[should_panic(expect)]
-   | ^^^^^^^^^^^^^^^------^^
+   |   ^^^^^^^^^^^^^------^
    |                |
    |                expected this to be of the form `expected = "..."`
    |
@@ -39,10 +39,10 @@ LL + #[should_panic]
    |
 
 error[E0539]: malformed `should_panic` attribute input
-  --> $DIR/test-should-panic-attr.rs:29:1
+  --> $DIR/test-should-panic-attr.rs:29:3
    |
 LL | #[should_panic(expected(foo, bar))]
-   | ^^^^^^^^^^^^^^^------------------^^
+   |   ^^^^^^^^^^^^^------------------^
    |                |
    |                expected this to be of the form `expected = "..."`
    |
@@ -60,10 +60,10 @@ LL + #[should_panic]
    |
 
 error[E0805]: malformed `should_panic` attribute input
-  --> $DIR/test-should-panic-attr.rs:38:1
+  --> $DIR/test-should-panic-attr.rs:38:3
    |
 LL | #[should_panic(expected = "foo", bar)]
-   | ^^^^^^^^^^^^^^-----------------------^
+   |   ^^^^^^^^^^^^-----------------------
    |               |
    |               expected a single argument here
    |

--- a/tests/ui/thread-local/no-unstable.rs
+++ b/tests/ui/thread-local/no-unstable.rs
@@ -1,6 +1,5 @@
 thread_local! {
     //~^ ERROR: `#[used(linker)]` is currently unstable [E0658]
-    //~| ERROR: `#[used]` attribute cannot be used on constants
 
     #[rustc_dummy = 17] //~ ERROR: use of an internal attribute [E0658]
     pub static FOO: () = ();
@@ -8,7 +7,7 @@ thread_local! {
     #[cfg_attr(true, rustc_dummy = 17)] //~ ERROR: use of an internal attribute [E0658]
     pub static BAR: () = ();
 
-    #[used(linker)]
+    #[used(linker)] //~ ERROR: the `used` attribute cannot be used on constants
     pub static BAZ: () = ();
 }
 

--- a/tests/ui/thread-local/no-unstable.rs
+++ b/tests/ui/thread-local/no-unstable.rs
@@ -1,13 +1,11 @@
 thread_local! {
-    //~^ ERROR: use of an internal attribute [E0658]
-    //~| ERROR: use of an internal attribute [E0658]
-    //~| ERROR: `#[used(linker)]` is currently unstable [E0658]
+    //~^ ERROR: `#[used(linker)]` is currently unstable [E0658]
     //~| ERROR: `#[used]` attribute cannot be used on constants
 
-    #[rustc_dummy = 17]
+    #[rustc_dummy = 17] //~ ERROR: use of an internal attribute [E0658]
     pub static FOO: () = ();
 
-    #[cfg_attr(true, rustc_dummy = 17)]
+    #[cfg_attr(true, rustc_dummy = 17)] //~ ERROR: use of an internal attribute [E0658]
     pub static BAR: () = ();
 
     #[used(linker)]

--- a/tests/ui/thread-local/no-unstable.stderr
+++ b/tests/ui/thread-local/no-unstable.stderr
@@ -1,28 +1,22 @@
 error[E0658]: use of an internal attribute
-  --> $DIR/no-unstable.rs:1:1
+  --> $DIR/no-unstable.rs:5:7
    |
-LL | / thread_local! {
-...  |
-LL | |     pub static BAZ: () = ();
-LL | | }
-   | |_^
+LL |     #[rustc_dummy = 17]
+   |       ^^^^^^^^^^^
    |
    = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable
-   = note: the `#[rustc_dummy]` attribute is an internal implementation detail that will never be stable
-   = note: the `#[rustc_dummy]` attribute is used for rustc unit tests
+   = note: the `rustc_dummy` attribute is an internal implementation detail that will never be stable
+   = note: the `rustc_dummy` attribute is used for rustc unit tests
 
 error[E0658]: use of an internal attribute
-  --> $DIR/no-unstable.rs:1:1
+  --> $DIR/no-unstable.rs:8:22
    |
-LL | / thread_local! {
-...  |
-LL | |     pub static BAZ: () = ();
-LL | | }
-   | |_^
+LL |     #[cfg_attr(true, rustc_dummy = 17)]
+   |                      ^^^^^^^^^^^
    |
    = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable
-   = note: the `#[rustc_dummy]` attribute is an internal implementation detail that will never be stable
-   = note: the `#[rustc_dummy]` attribute is used for rustc unit tests
+   = note: the `rustc_dummy` attribute is an internal implementation detail that will never be stable
+   = note: the `rustc_dummy` attribute is used for rustc unit tests
 
 error[E0658]: `#[used(linker)]` is currently unstable
   --> $DIR/no-unstable.rs:1:1

--- a/tests/ui/thread-local/no-unstable.stderr
+++ b/tests/ui/thread-local/no-unstable.stderr
@@ -1,5 +1,5 @@
 error[E0658]: use of an internal attribute
-  --> $DIR/no-unstable.rs:5:7
+  --> $DIR/no-unstable.rs:4:7
    |
 LL |     #[rustc_dummy = 17]
    |       ^^^^^^^^^^^
@@ -9,7 +9,7 @@ LL |     #[rustc_dummy = 17]
    = note: the `rustc_dummy` attribute is used for rustc unit tests
 
 error[E0658]: use of an internal attribute
-  --> $DIR/no-unstable.rs:8:22
+  --> $DIR/no-unstable.rs:7:22
    |
 LL |     #[cfg_attr(true, rustc_dummy = 17)]
    |                      ^^^^^^^^^^^
@@ -22,6 +22,9 @@ error[E0658]: `#[used(linker)]` is currently unstable
   --> $DIR/no-unstable.rs:1:1
    |
 LL | / thread_local! {
+LL | |
+LL | |
+LL | |     #[rustc_dummy = 17]
 ...  |
 LL | |     pub static BAZ: () = ();
 LL | | }
@@ -31,16 +34,13 @@ LL | | }
    = help: add `#![feature(used_with_arg)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error: `#[used]` attribute cannot be used on constants
-  --> $DIR/no-unstable.rs:1:1
+error: the `used` attribute cannot be used on constants
+  --> $DIR/no-unstable.rs:10:7
    |
-LL | / thread_local! {
-...  |
-LL | |     pub static BAZ: () = ();
-LL | | }
-   | |_^
+LL |     #[used(linker)]
+   |       ^^^^
    |
-   = help: `#[used]` can only be applied to statics
+   = help: the `used` attribute can only be applied to statics
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/thread-local/non-static.rs
+++ b/tests/ui/thread-local/non-static.rs
@@ -2,19 +2,19 @@
 #![feature(thread_local)]
 
 #[thread_local]
-//~^ ERROR `#[thread_local]` attribute cannot be used on constants
+//~^ ERROR the `thread_local` attribute cannot be used on constants
 const A: u32 = 0;
 
 #[thread_local]
-//~^ ERROR `#[thread_local]` attribute cannot be used on functions
+//~^ ERROR the `thread_local` attribute cannot be used on functions
 fn main() {
     #[thread_local] || {};
-    //~^ ERROR `#[thread_local]` attribute cannot be used on closures
+    //~^ ERROR the `thread_local` attribute cannot be used on closures
 }
 
 struct S {
     #[thread_local]
-    //~^ ERROR `#[thread_local]` attribute cannot be used on struct fields
+    //~^ ERROR the `thread_local` attribute cannot be used on struct fields
     a: String,
     b: String,
 }

--- a/tests/ui/thread-local/non-static.stderr
+++ b/tests/ui/thread-local/non-static.stderr
@@ -1,34 +1,34 @@
-error: `#[thread_local]` attribute cannot be used on constants
-  --> $DIR/non-static.rs:4:1
+error: the `thread_local` attribute cannot be used on constants
+  --> $DIR/non-static.rs:4:3
    |
 LL | #[thread_local]
-   | ^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^
    |
-   = help: `#[thread_local]` can be applied to foreign statics and statics
+   = help: the `thread_local` attribute can be applied to foreign statics and statics
 
-error: `#[thread_local]` attribute cannot be used on functions
-  --> $DIR/non-static.rs:8:1
+error: the `thread_local` attribute cannot be used on functions
+  --> $DIR/non-static.rs:8:3
    |
 LL | #[thread_local]
-   | ^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^
    |
-   = help: `#[thread_local]` can be applied to foreign statics and statics
+   = help: the `thread_local` attribute can be applied to foreign statics and statics
 
-error: `#[thread_local]` attribute cannot be used on closures
-  --> $DIR/non-static.rs:11:5
+error: the `thread_local` attribute cannot be used on closures
+  --> $DIR/non-static.rs:11:7
    |
 LL |     #[thread_local] || {};
-   |     ^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^
    |
-   = help: `#[thread_local]` can be applied to foreign statics and statics
+   = help: the `thread_local` attribute can be applied to foreign statics and statics
 
-error: `#[thread_local]` attribute cannot be used on struct fields
-  --> $DIR/non-static.rs:16:5
+error: the `thread_local` attribute cannot be used on struct fields
+  --> $DIR/non-static.rs:16:7
    |
 LL |     #[thread_local]
-   |     ^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^
    |
-   = help: `#[thread_local]` can be applied to foreign statics and statics
+   = help: the `thread_local` attribute can be applied to foreign statics and statics
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/tool-attributes/diagnostic_item.rs
+++ b/tests/ui/tool-attributes/diagnostic_item.rs
@@ -1,6 +1,6 @@
 #[rustc_diagnostic_item = "foomp"]
 //~^ ERROR use of an internal attribute [E0658]
-//~| NOTE the `#[rustc_diagnostic_item]` attribute is an internal implementation detail that will never be stable
-//~| NOTE the `#[rustc_diagnostic_item]` attribute allows the compiler to reference types from the standard library for diagnostic purposes
+//~| NOTE the `rustc_diagnostic_item` attribute is an internal implementation detail that will never be stable
+//~| NOTE the `rustc_diagnostic_item` attribute allows the compiler to reference types from the standard library for diagnostic purposes
 struct Foomp;
 fn main() {}

--- a/tests/ui/tool-attributes/diagnostic_item.stderr
+++ b/tests/ui/tool-attributes/diagnostic_item.stderr
@@ -1,12 +1,12 @@
 error[E0658]: use of an internal attribute
-  --> $DIR/diagnostic_item.rs:1:1
+  --> $DIR/diagnostic_item.rs:1:3
    |
 LL | #[rustc_diagnostic_item = "foomp"]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable
-   = note: the `#[rustc_diagnostic_item]` attribute is an internal implementation detail that will never be stable
-   = note: the `#[rustc_diagnostic_item]` attribute allows the compiler to reference types from the standard library for diagnostic purposes
+   = note: the `rustc_diagnostic_item` attribute is an internal implementation detail that will never be stable
+   = note: the `rustc_diagnostic_item` attribute allows the compiler to reference types from the standard library for diagnostic purposes
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/tool-attributes/invalid-tool.stderr
+++ b/tests/ui/tool-attributes/invalid-tool.stderr
@@ -1,8 +1,8 @@
 error[E0565]: malformed `register_tool` attribute input
-  --> $DIR/invalid-tool.rs:3:1
+  --> $DIR/invalid-tool.rs:3:4
    |
 LL | #![register_tool(1)]
-   | ^^^^^^^^^^^^^^^^^-^^
+   |    ^^^^^^^^^^^^^^-^
    |                  |
    |                  expected a valid identifier here
    |

--- a/tests/ui/tool-attributes/nested-disallowed.stderr
+++ b/tests/ui/tool-attributes/nested-disallowed.stderr
@@ -1,8 +1,8 @@
 error[E0565]: malformed `register_tool` attribute input
-  --> $DIR/nested-disallowed.rs:2:1
+  --> $DIR/nested-disallowed.rs:2:4
    |
 LL | #![register_tool(foo::bar)]
-   | ^^^^^^^^^^^^^^^^^--------^^
+   |    ^^^^^^^^^^^^^^--------^
    |                  |
    |                  expected a valid identifier here
    |

--- a/tests/ui/traits/alias/not-a-marker.stderr
+++ b/tests/ui/traits/alias/not-a-marker.stderr
@@ -1,10 +1,10 @@
-error: `#[marker]` attribute cannot be used on trait aliases
-  --> $DIR/not-a-marker.rs:3:1
+error: the `marker` attribute cannot be used on trait aliases
+  --> $DIR/not-a-marker.rs:3:3
    |
 LL | #[marker]
-   | ^^^^^^^^^
+   |   ^^^^^^
    |
-   = help: `#[marker]` can only be applied to traits
+   = help: the `marker` attribute can only be applied to traits
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/traits/const-traits/partial/attr-gate.stderr
+++ b/tests/ui/traits/const-traits/partial/attr-gate.stderr
@@ -1,12 +1,12 @@
 error[E0658]: use of an internal attribute
-  --> $DIR/attr-gate.rs:2:5
+  --> $DIR/attr-gate.rs:2:7
    |
 LL |     #[rustc_non_const_trait_method]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable
-   = note: the `#[rustc_non_const_trait_method]` attribute is an internal implementation detail that will never be stable
-   = note: `#[rustc_non_const_trait_method]` should only used by the standard library to mark trait methods as non-const to allow large traits an easier transition to const
+   = note: the `rustc_non_const_trait_method` attribute is an internal implementation detail that will never be stable
+   = note: the `rustc_non_const_trait_method` attribute should only be used by the standard library to mark trait methods as non-const to allow large traits an easier transition to const
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/traits/default-method/rustc_must_implement_one_of_gated.rs
+++ b/tests/ui/traits/default-method/rustc_must_implement_one_of_gated.rs
@@ -1,7 +1,7 @@
 #[rustc_must_implement_one_of(eq, neq)]
 //~^ ERROR use of an internal attribute [E0658]
-//~| NOTE the `#[rustc_must_implement_one_of]` attribute is an internal implementation detail that will never be stable
-//~| NOTE the `#[rustc_must_implement_one_of]` attribute is used to change minimal complete definition of a trait. Its syntax and semantics are highly experimental and will be subject to change before stabilization
+//~| NOTE the `rustc_must_implement_one_of` attribute is an internal implementation detail that will never be stable
+//~| NOTE the `rustc_must_implement_one_of` attribute is used to change minimal complete definition of a trait. Its syntax and semantics are highly experimental and will be subject to change before stabilization
 trait Equal {
     fn eq(&self, other: &Self) -> bool {
         !self.neq(other)

--- a/tests/ui/traits/default-method/rustc_must_implement_one_of_gated.stderr
+++ b/tests/ui/traits/default-method/rustc_must_implement_one_of_gated.stderr
@@ -1,12 +1,12 @@
 error[E0658]: use of an internal attribute
-  --> $DIR/rustc_must_implement_one_of_gated.rs:1:1
+  --> $DIR/rustc_must_implement_one_of_gated.rs:1:3
    |
 LL | #[rustc_must_implement_one_of(eq, neq)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable
-   = note: the `#[rustc_must_implement_one_of]` attribute is an internal implementation detail that will never be stable
-   = note: the `#[rustc_must_implement_one_of]` attribute is used to change minimal complete definition of a trait. Its syntax and semantics are highly experimental and will be subject to change before stabilization
+   = note: the `rustc_must_implement_one_of` attribute is an internal implementation detail that will never be stable
+   = note: the `rustc_must_implement_one_of` attribute is used to change minimal complete definition of a trait. Its syntax and semantics are highly experimental and will be subject to change before stabilization
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/traits/default-method/rustc_must_implement_one_of_misuse.rs
+++ b/tests/ui/traits/default-method/rustc_must_implement_one_of_misuse.rs
@@ -36,11 +36,11 @@ trait Tr5 {
 }
 
 #[rustc_must_implement_one_of(abc, xyz)]
-//~^ ERROR `#[rustc_must_implement_one_of]` attribute cannot be used on functions
+//~^ ERROR the `rustc_must_implement_one_of` attribute cannot be used on functions
 fn function() {}
 
 #[rustc_must_implement_one_of(abc, xyz)]
-//~^ ERROR `#[rustc_must_implement_one_of]` attribute cannot be used on structs
+//~^ ERROR the `rustc_must_implement_one_of` attribute cannot be used on structs
 struct Struct {}
 
 fn main() {}

--- a/tests/ui/traits/default-method/rustc_must_implement_one_of_misuse.stderr
+++ b/tests/ui/traits/default-method/rustc_must_implement_one_of_misuse.stderr
@@ -23,21 +23,21 @@ help: must be of the form
 LL | #[rustc_must_implement_one_of(function1, function2, ...)]
    |                              +++++++++++++++++++++++++++
 
-error: `#[rustc_must_implement_one_of]` attribute cannot be used on functions
-  --> $DIR/rustc_must_implement_one_of_misuse.rs:38:1
+error: the `rustc_must_implement_one_of` attribute cannot be used on functions
+  --> $DIR/rustc_must_implement_one_of_misuse.rs:38:3
    |
 LL | #[rustc_must_implement_one_of(abc, xyz)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_must_implement_one_of]` can only be applied to traits
+   = help: the `rustc_must_implement_one_of` attribute can only be applied to traits
 
-error: `#[rustc_must_implement_one_of]` attribute cannot be used on structs
-  --> $DIR/rustc_must_implement_one_of_misuse.rs:42:1
+error: the `rustc_must_implement_one_of` attribute cannot be used on structs
+  --> $DIR/rustc_must_implement_one_of_misuse.rs:42:3
    |
 LL | #[rustc_must_implement_one_of(abc, xyz)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[rustc_must_implement_one_of]` can only be applied to traits
+   = help: the `rustc_must_implement_one_of` attribute can only be applied to traits
 
 error: function not found in this trait
   --> $DIR/rustc_must_implement_one_of_misuse.rs:3:31

--- a/tests/ui/traits/default-method/rustc_must_implement_one_of_misuse.stderr
+++ b/tests/ui/traits/default-method/rustc_must_implement_one_of_misuse.stderr
@@ -1,8 +1,8 @@
 error[E0539]: malformed `rustc_must_implement_one_of` attribute input
-  --> $DIR/rustc_must_implement_one_of_misuse.rs:14:1
+  --> $DIR/rustc_must_implement_one_of_misuse.rs:14:3
    |
 LL | #[rustc_must_implement_one_of(a)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---^
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                              |
    |                              expected 2 or more items
    |
@@ -13,10 +13,10 @@ LL + #[rustc_must_implement_one_of(function1, function2, ...)]
    |
 
 error[E0539]: malformed `rustc_must_implement_one_of` attribute input
-  --> $DIR/rustc_must_implement_one_of_misuse.rs:20:1
+  --> $DIR/rustc_must_implement_one_of_misuse.rs:20:3
    |
 LL | #[rustc_must_implement_one_of]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected this to be a list
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected this to be a list
    |
 help: must be of the form
    |

--- a/tests/ui/unstable-feature-bound/unstable_feature_bound_staged_api.stderr
+++ b/tests/ui/unstable-feature-bound/unstable_feature_bound_staged_api.stderr
@@ -1,8 +1,8 @@
 error[E0658]: stability attributes may not be used outside of the standard library
-  --> $DIR/unstable_feature_bound_staged_api.rs:8:1
+  --> $DIR/unstable_feature_bound_staged_api.rs:8:3
    |
 LL | #[unstable_feature_bound(feat_bar)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/unstable-feature-bound/unstable_inherent_method.stderr
+++ b/tests/ui/unstable-feature-bound/unstable_inherent_method.stderr
@@ -1,18 +1,18 @@
-error: `#[unstable_feature_bound]` attribute cannot be used on required trait methods
-  --> $DIR/unstable_inherent_method.rs:11:5
+error: the `unstable_feature_bound` attribute cannot be used on required trait methods
+  --> $DIR/unstable_inherent_method.rs:11:7
    |
 LL |     #[unstable_feature_bound(foo)]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[unstable_feature_bound]` can be applied to functions, trait impl blocks, and traits
+   = help: the `unstable_feature_bound` attribute can be applied to functions, trait impl blocks, and traits
 
-error: `#[unstable_feature_bound]` attribute cannot be used on trait methods in impl blocks
-  --> $DIR/unstable_inherent_method.rs:18:5
+error: the `unstable_feature_bound` attribute cannot be used on trait methods in impl blocks
+  --> $DIR/unstable_inherent_method.rs:18:7
    |
 LL |     #[unstable_feature_bound(foo)]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[unstable_feature_bound]` can be applied to functions, trait impl blocks, and traits
+   = help: the `unstable_feature_bound` attribute can be applied to functions, trait impl blocks, and traits
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/wasm/wasm-import-module.stderr
+++ b/tests/ui/wasm/wasm-import-module.stderr
@@ -1,28 +1,28 @@
 error[E0539]: malformed `link` attribute input
-  --> $DIR/wasm-import-module.rs:3:1
+  --> $DIR/wasm-import-module.rs:3:3
    |
 LL | #[link(name = "...", wasm_import_module)]
-   | ^^^^^^^^^^^^^^^^^^^^^------------------^^
+   |   ^^^^^^^^^^^^^^^^^^^------------------^
    |                      |
    |                      expected this to be of the form `wasm_import_module = "..."`
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute>
 
 error[E0539]: malformed `link` attribute input
-  --> $DIR/wasm-import-module.rs:6:1
+  --> $DIR/wasm-import-module.rs:6:3
    |
 LL | #[link(name = "...", wasm_import_module(x))]
-   | ^^^^^^^^^^^^^^^^^^^^^---------------------^^
+   |   ^^^^^^^^^^^^^^^^^^^---------------------^
    |                      |
    |                      expected this to be of the form `wasm_import_module = "..."`
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute>
 
 error[E0539]: malformed `link` attribute input
-  --> $DIR/wasm-import-module.rs:9:1
+  --> $DIR/wasm-import-module.rs:9:3
    |
 LL | #[link(name = "...", wasm_import_module())]
-   | ^^^^^^^^^^^^^^^^^^^^^--------------------^^
+   |   ^^^^^^^^^^^^^^^^^^^--------------------^
    |                      |
    |                      expected this to be of the form `wasm_import_module = "..."`
    |

--- a/tests/ui/where-clauses/unsupported_attribute.stderr
+++ b/tests/ui/where-clauses/unsupported_attribute.stderr
@@ -26,53 +26,53 @@ LL |     #[doc = "doc"] 'a: 'static,
    |
    = help: only `#[cfg]` and `#[cfg_attr]` are supported
 
-error: `#[ignore]` attribute cannot be used on where predicates
-  --> $DIR/unsupported_attribute.rs:15:5
+error: the `ignore` attribute cannot be used on where predicates
+  --> $DIR/unsupported_attribute.rs:15:7
    |
 LL |     #[ignore] T: Trait,
-   |     ^^^^^^^^^
+   |       ^^^^^^
    |
-   = help: `#[ignore]` can only be applied to functions
+   = help: the `ignore` attribute can only be applied to functions
 
-error: `#[ignore]` attribute cannot be used on where predicates
-  --> $DIR/unsupported_attribute.rs:16:5
+error: the `ignore` attribute cannot be used on where predicates
+  --> $DIR/unsupported_attribute.rs:16:7
    |
 LL |     #[ignore] 'a: 'static,
-   |     ^^^^^^^^^
+   |       ^^^^^^
    |
-   = help: `#[ignore]` can only be applied to functions
+   = help: the `ignore` attribute can only be applied to functions
 
-error: `#[should_panic]` attribute cannot be used on where predicates
-  --> $DIR/unsupported_attribute.rs:17:5
+error: the `should_panic` attribute cannot be used on where predicates
+  --> $DIR/unsupported_attribute.rs:17:7
    |
 LL |     #[should_panic] T: Trait,
-   |     ^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^
    |
-   = help: `#[should_panic]` can only be applied to functions
+   = help: the `should_panic` attribute can only be applied to functions
 
-error: `#[should_panic]` attribute cannot be used on where predicates
-  --> $DIR/unsupported_attribute.rs:18:5
+error: the `should_panic` attribute cannot be used on where predicates
+  --> $DIR/unsupported_attribute.rs:18:7
    |
 LL |     #[should_panic] 'a: 'static,
-   |     ^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^
    |
-   = help: `#[should_panic]` can only be applied to functions
+   = help: the `should_panic` attribute can only be applied to functions
 
-error: `#[macro_use]` attribute cannot be used on where predicates
-  --> $DIR/unsupported_attribute.rs:19:5
+error: the `macro_use` attribute cannot be used on where predicates
+  --> $DIR/unsupported_attribute.rs:19:7
    |
 LL |     #[macro_use] T: Trait,
-   |     ^^^^^^^^^^^^
+   |       ^^^^^^^^^
    |
-   = help: `#[macro_use]` can be applied to extern crates and modules
+   = help: the `macro_use` attribute can be applied to extern crates and modules
 
-error: `#[macro_use]` attribute cannot be used on where predicates
-  --> $DIR/unsupported_attribute.rs:20:5
+error: the `macro_use` attribute cannot be used on where predicates
+  --> $DIR/unsupported_attribute.rs:20:7
    |
 LL |     #[macro_use] 'a: 'static,
-   |     ^^^^^^^^^^^^
+   |       ^^^^^^^^^
    |
-   = help: `#[macro_use]` can be applied to extern crates and modules
+   = help: the `macro_use` attribute can be applied to extern crates and modules
 
 error: most attributes are not supported in `where` clauses
   --> $DIR/unsupported_attribute.rs:21:5
@@ -90,37 +90,37 @@ LL |     #[allow(unused)] 'a: 'static,
    |
    = help: only `#[cfg]` and `#[cfg_attr]` are supported
 
-error: `#[deprecated]` attribute cannot be used on where predicates
-  --> $DIR/unsupported_attribute.rs:23:5
+error: the `deprecated` attribute cannot be used on where predicates
+  --> $DIR/unsupported_attribute.rs:23:7
    |
 LL |     #[deprecated] T: Trait,
-   |     ^^^^^^^^^^^^^
+   |       ^^^^^^^^^^
    |
-   = help: `#[deprecated]` can be applied to associated consts, associated types, constants, crates, data types, enum variants, foreign statics, functions, inherent impl blocks, macro defs, modules, statics, struct fields, traits, type aliases, and use statements
+   = help: the `deprecated` attribute can be applied to associated consts, associated types, constants, crates, data types, enum variants, foreign statics, functions, inherent impl blocks, macro defs, modules, statics, struct fields, traits, type aliases, and use statements
 
-error: `#[deprecated]` attribute cannot be used on where predicates
-  --> $DIR/unsupported_attribute.rs:24:5
+error: the `deprecated` attribute cannot be used on where predicates
+  --> $DIR/unsupported_attribute.rs:24:7
    |
 LL |     #[deprecated] 'a: 'static,
-   |     ^^^^^^^^^^^^^
+   |       ^^^^^^^^^^
    |
-   = help: `#[deprecated]` can be applied to associated consts, associated types, constants, crates, data types, enum variants, foreign statics, functions, inherent impl blocks, macro defs, modules, statics, struct fields, traits, type aliases, and use statements
+   = help: the `deprecated` attribute can be applied to associated consts, associated types, constants, crates, data types, enum variants, foreign statics, functions, inherent impl blocks, macro defs, modules, statics, struct fields, traits, type aliases, and use statements
 
-error: `#[automatically_derived]` attribute cannot be used on where predicates
-  --> $DIR/unsupported_attribute.rs:25:5
+error: the `automatically_derived` attribute cannot be used on where predicates
+  --> $DIR/unsupported_attribute.rs:25:7
    |
 LL |     #[automatically_derived] T: Trait,
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[automatically_derived]` can only be applied to trait impl blocks
+   = help: the `automatically_derived` attribute can only be applied to trait impl blocks
 
-error: `#[automatically_derived]` attribute cannot be used on where predicates
-  --> $DIR/unsupported_attribute.rs:26:5
+error: the `automatically_derived` attribute cannot be used on where predicates
+  --> $DIR/unsupported_attribute.rs:26:7
    |
 LL |     #[automatically_derived] 'a: 'static,
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[automatically_derived]` can only be applied to trait impl blocks
+   = help: the `automatically_derived` attribute can only be applied to trait impl blocks
 
 error: most attributes are not supported in `where` clauses
   --> $DIR/unsupported_attribute.rs:27:5

--- a/tests/ui/windows-subsystem/windows-subsystem-invalid.stderr
+++ b/tests/ui/windows-subsystem/windows-subsystem-invalid.stderr
@@ -1,8 +1,8 @@
 error[E0539]: malformed `windows_subsystem` attribute input
-  --> $DIR/windows-subsystem-invalid.rs:1:1
+  --> $DIR/windows-subsystem-invalid.rs:1:4
    |
 LL | #![windows_subsystem = "wrong"]
-   | ^^^^^^^^^^^^^^^^^^^^^^^-------^
+   |    ^^^^^^^^^^^^^^^^^^^^-------
    |                        |
    |                        valid arguments are "console" or "windows"
    |


### PR DESCRIPTION
This PR aims to improve how attributes are referred to in error messages. A lot of test outputs will change, so there will be follow-ups, but this PR has enough changes to cover a lot of cases and give a good feel for where things are headed.

r? @estebank