### PR TITLE
Track `partial_res_map` per owner

### DIFF
--- a/compiler/rustc_ast_lowering/src/expr.rs
+++ b/compiler/rustc_ast_lowering/src/expr.rs
@@ -27,7 +27,7 @@ use crate::diagnostics::{
 };
 use crate::{
     AllowReturnTypeNotation, GenericArgsMode, ImplTraitContext, ImplTraitPosition, LoweringContext,
-    ParamMode, ResolverAstLoweringExt, TryBlockScope,
+    ParamMode, TryBlockScope,
 };
 
 pub(super) struct WillCreateDefIdsVisitor;
@@ -211,8 +211,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 }
                 ExprKind::Tup(elts) => hir::ExprKind::Tup(self.lower_exprs(elts)),
                 ExprKind::Call(f, args) => {
-                    if let Some(legacy_args) = self.resolver.legacy_const_generic_args(f, self.tcx)
-                    {
+                    if let Some(legacy_args) = self.owner.legacy_const_generic_args(f, self.tcx) {
                         self.lower_legacy_const_generics((**f).clone(), args.clone(), &legacy_args)
                     } else {
                         let f = self.lower_expr(f);

--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -764,29 +764,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
     fn get_partial_res(&self, id: NodeId) -> Option<PartialRes> {
         match self.partial_res_overrides.get(&id) {
             Some(self_param_id) => Some(PartialRes::new(Res::Local(*self_param_id))),
-            None => {
-                let new = self.owner.partial_res_map.get(&id).copied();
-                let old = self.resolver.partial_res_map.get(&id).copied();
-                if new.is_none() != old.is_none() {
-                    let found = self
-                        .resolver
-                        .owners
-                        .items()
-                        .filter_map(|(_owner_id, owner)| {
-                            owner.partial_res_map.get(&id)?;
-                            Some(owner.def_id)
-                        })
-                        .get_only()
-                        .unwrap();
-                    debug!(
-                        "owner_map: {new:?}\nglobal_map: {old:?}\n found in {found:?} {:?}\n current owner: {:?} {:?}",
-                        self.tcx.source_span(found),
-                        self.owner.def_id,
-                        self.tcx.source_span(self.owner.def_id),
-                    );
-                }
-                old
-            }
+            None => self.owner.partial_res_map.get(&id).copied(),
         }
     }
 

--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -60,10 +60,9 @@ use rustc_hir::definitions::PerParentDisambiguatorState;
 use rustc_hir::lints::DelayedLint;
 use rustc_hir::{
     self as hir, AngleBrackets, ConstArg, GenericArg, HirId, ItemLocalMap, LifetimeSource,
-    LifetimeSyntax, MissingLifetimeKind, ParamName, Target, TraitCandidate, find_attr,
+    LifetimeSyntax, MissingLifetimeKind, ParamName, Target, TraitCandidate,
 };
 use rustc_index::{Idx, IndexVec};
-use rustc_macros::extension;
 use rustc_middle::queries::Providers;
 use rustc_middle::span_bug;
 use rustc_middle::ty::{PerOwnerResolverData, ResolverAstLowering, TyCtxt};
@@ -316,40 +315,6 @@ impl SpanLowerer {
             // Do not make spans relative when not using incremental compilation.
             span
         }
-    }
-}
-
-#[extension(trait ResolverAstLoweringExt<'tcx>)]
-impl<'tcx> ResolverAstLowering<'tcx> {
-    fn legacy_const_generic_args(&self, expr: &Expr, tcx: TyCtxt<'tcx>) -> Option<Vec<usize>> {
-        let ExprKind::Path(None, path) = &expr.kind else {
-            return None;
-        };
-
-        // Don't perform legacy const generics rewriting if the path already
-        // has generic arguments.
-        if path.segments.last().unwrap().args.is_some() {
-            return None;
-        }
-
-        // We do not need to look at `partial_res_overrides`. That map only contains overrides for
-        // `self_param` locals. And here we are looking for the function definition that `expr`
-        // resolves to.
-        let def_id = self.partial_res_map.get(&expr.id)?.full_res()?.opt_def_id()?;
-
-        // We only support cross-crate argument rewriting. Uses
-        // within the same crate should be updated to use the new
-        // const generics style.
-        if def_id.is_local() {
-            return None;
-        }
-
-        // we can use parsed attrs here since for other crates they're already available
-        find_attr!(
-            tcx, def_id,
-            RustcLegacyConstGenerics{fn_indexes,..} => fn_indexes
-        )
-        .map(|fn_indexes| fn_indexes.iter().map(|(num, _)| *num).collect())
     }
 }
 

--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -799,7 +799,29 @@ impl<'hir> LoweringContext<'_, 'hir> {
     fn get_partial_res(&self, id: NodeId) -> Option<PartialRes> {
         match self.partial_res_overrides.get(&id) {
             Some(self_param_id) => Some(PartialRes::new(Res::Local(*self_param_id))),
-            None => self.resolver.partial_res_map.get(&id).copied(),
+            None => {
+                let new = self.owner.partial_res_map.get(&id).copied();
+                let old = self.resolver.partial_res_map.get(&id).copied();
+                if new.is_none() != old.is_none() {
+                    let found = self
+                        .resolver
+                        .owners
+                        .items()
+                        .filter_map(|(_owner_id, owner)| {
+                            owner.partial_res_map.get(&id)?;
+                            Some(owner.def_id)
+                        })
+                        .get_only()
+                        .unwrap();
+                    debug!(
+                        "owner_map: {new:?}\nglobal_map: {old:?}\n found in {found:?} {:?}\n current owner: {:?} {:?}",
+                        self.tcx.source_span(found),
+                        self.owner.def_id,
+                        self.tcx.source_span(self.owner.def_id),
+                    );
+                }
+                old
+            }
         }
     }
 

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -263,6 +263,41 @@ impl<'tcx> PerOwnerResolverData<'tcx> {
     pub fn extra_lifetime_params(&self, id: NodeId) -> &[(Ident, NodeId, MissingLifetimeKind)] {
         self.extra_lifetime_params_map.get(&id).map_or(&[], |v| &v[..])
     }
+
+    pub fn legacy_const_generic_args(
+        &self,
+        expr: &ast::Expr,
+        tcx: TyCtxt<'tcx>,
+    ) -> Option<Vec<usize>> {
+        let ast::ExprKind::Path(None, path) = &expr.kind else {
+            return None;
+        };
+
+        // Don't perform legacy const generics rewriting if the path already
+        // has generic arguments.
+        if path.segments.last().unwrap().args.is_some() {
+            return None;
+        }
+
+        // We do not need to look at `partial_res_overrides`. That map only contains overrides for
+        // `self_param` locals. And here we are looking for the function definition that `expr`
+        // resolves to.
+        let def_id = self.partial_res_map.get(&expr.id)?.full_res()?.opt_def_id()?;
+
+        // We only support cross-crate argument rewriting. Uses
+        // within the same crate should be updated to use the new
+        // const generics style.
+        if def_id.is_local() {
+            return None;
+        }
+
+        // we can use parsed attrs here since for other crates they're already available
+        find_attr!(
+            tcx, def_id,
+            RustcLegacyConstGenerics{fn_indexes,..} => fn_indexes
+        )
+        .map(|fn_indexes| fn_indexes.iter().map(|(num, _)| *num).collect())
+    }
 }
 
 /// Resolutions that should only be used for lowering.

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -229,6 +229,9 @@ pub struct PerOwnerResolverData<'tcx> {
     /// Lifetime parameters that lowering will have to introduce.
     pub extra_lifetime_params_map: NodeMap<Vec<(Ident, ast::NodeId, MissingLifetimeKind)>> = Default::default(),
 
+    /// Resolutions for nodes that have a single resolution.
+    pub partial_res_map: NodeMap<hir::def::PartialRes> = Default::default(),
+
     /// The id of the owner
     pub id: ast::NodeId,
     /// The `DefId` of the owner, can't be found in `node_id_to_def_id`.

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -304,9 +304,6 @@ impl<'tcx> PerOwnerResolverData<'tcx> {
 /// This struct is meant to be consumed by lowering.
 #[derive(Debug)]
 pub struct ResolverAstLowering<'tcx> {
-    /// Resolutions for nodes that have a single resolution.
-    pub partial_res_map: NodeMap<hir::def::PartialRes>,
-
     pub next_node_id: ast::NodeId,
 
     pub owners: NodeMap<PerOwnerResolverData<'tcx>>,

--- a/compiler/rustc_resolve/src/build_reduced_graph.rs
+++ b/compiler/rustc_resolve/src/build_reduced_graph.rs
@@ -492,6 +492,7 @@ impl<'a, 'ra, 'tcx> DefCollector<'a, 'ra, 'tcx> {
                     vis: vis.clone(),
                     parent_scope: self.parent_scope,
                     error,
+                    owner: self.r.current_owner.id,
                 });
                 Visibility::Public
             }

--- a/compiler/rustc_resolve/src/diagnostics/impls.rs
+++ b/compiler/rustc_resolve/src/diagnostics/impls.rs
@@ -56,7 +56,7 @@ use crate::{
     DelayedVisResolutionError, Finalize, ForwardGenericParamBanReason, HasGenericParams, IdentKey,
     LateDecl, MacroRulesScope, Module, ModuleKind, ModuleOrUniformRoot, ParentScope, PathResult,
     PrivacyError, Res, ResolutionError, Resolver, Scope, ScopeSet, Segment, UseError, Used,
-    VisResolutionError, path_names_to_string,
+    VisResolutionError, path_names_to_string, with_owner,
 };
 
 /// A vector of spans and replacements, a message and applicability.
@@ -381,13 +381,15 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
     }
 
     fn report_delayed_vis_resolution_errors(&mut self) {
-        for DelayedVisResolutionError { vis, parent_scope, error } in
+        for DelayedVisResolutionError { vis, parent_scope, error, owner } in
             mem::take(&mut self.delayed_vis_resolution_errors)
         {
-            match self.try_resolve_visibility(&parent_scope, &vis, true) {
-                Ok(_) => self.report_vis_error(error),
-                Err(error) => self.report_vis_error(error),
-            };
+            with_owner(self, owner, |this| {
+                match this.try_resolve_visibility(&parent_scope, &vis, true) {
+                    Ok(_) => this.report_vis_error(error),
+                    Err(error) => this.report_vis_error(error),
+                }
+            });
         }
     }
 

--- a/compiler/rustc_resolve/src/imports.rs
+++ b/compiler/rustc_resolve/src/imports.rs
@@ -37,7 +37,7 @@ use crate::{
     AmbiguityError, BindingKey, Decl, DeclData, DeclKind, Determinacy, Finalize, IdentKey,
     ImportSuggestion, ImportSummary, LocalModule, ModuleOrUniformRoot, ParentScope, PathResult,
     PerNS, Res, ResolutionError, Resolver, ScopeSet, Segment, Used, module_to_string,
-    names_to_string,
+    names_to_string, with_owner,
 };
 
 /// A potential import declaration in the process of being planted into a module.
@@ -903,7 +903,9 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                             .expect("planting a glob cannot fail");
                     }
 
-                    self.record_partial_res(*id, PartialRes::new(module.res().unwrap()));
+                    with_owner(self, *id, |this| {
+                        this.record_partial_res(*id, PartialRes::new(module.res().unwrap()))
+                    });
                 }
 
                 // Something weird happened, which shouldn't have happened.
@@ -933,7 +935,8 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             .map(|i| (false, i))
             .chain(indeterminate_imports.iter().map(|(i, _, _)| (true, i)))
         {
-            let unresolved_import_error = self.finalize_import(*import);
+            let unresolved_import_error =
+                with_owner(self, import.id().unwrap(), |this| this.finalize_import(*import));
             // If this import is unresolved then create a dummy import
             // resolution for it so that later resolve stages won't complain.
             self.import_dummy_binding(*import, is_indeterminate);
@@ -1313,8 +1316,8 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             PathResult::Indeterminate => unreachable!(),
         };
 
-        let (ident, target, bindings, import_id) = match import.kind {
-            ImportKind::Single { source, target, ref decls, id, .. } => (source, target, decls, id),
+        let (ident, target, bindings) = match import.kind {
+            ImportKind::Single { source, target, ref decls, .. } => (source, target, decls),
             ImportKind::Glob { ref max_vis, id, def_id } => {
                 if import.module_path.len() <= 1 {
                     // HACK(eddyb) `lint_if_path_starts_with_module` needs at least
@@ -1634,7 +1637,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         // purposes it's good enough to just favor one over the other.
         self.per_ns_mut(|this, ns| {
             if let Some(binding) = bindings[ns].get().decl().map(|b| b.import_source()) {
-                this.owners.get_mut(&import_id).unwrap().import_res[ns] = Some(binding.res());
+                this.current_owner.import_res[ns] = Some(binding.res());
             }
         });
 

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -5315,7 +5315,11 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
 
             ExprKind::Call(ref callee, ref arguments) => {
                 self.resolve_expr(callee, Some(expr));
-                let const_args = self.r.legacy_const_generic_args(callee).unwrap_or_default();
+                let const_args = self
+                    .r
+                    .current_owner
+                    .legacy_const_generic_args(callee, self.r.tcx)
+                    .unwrap_or_default();
                 for (idx, argument) in arguments.iter().enumerate() {
                     // Constant arguments need to be treated as AnonConst since
                     // that is how they will be later lowered to HIR.

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -1510,6 +1510,10 @@ impl<'ast, 'ra, 'tcx> Visitor<'ast> for LateResolutionVisitor<'_, 'ast, 'ra, 'tc
             self.resolve_anon_const(v, AnonConstKind::FieldDefaultValue);
         }
     }
+
+    fn visit_nested_use_tree(&mut self, use_tree: &'ast UseTree, id: NodeId) {
+        with_owner(self, id, |this| visit::walk_use_tree(this, use_tree))
+    }
 }
 
 impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
@@ -5019,7 +5023,10 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
 
                 // Fix up partial res of segment from `resolve_path` call.
                 if let Some(id) = path[0].id {
-                    self.r.partial_res_map.insert(id, PartialRes::new(Res::PrimTy(prim)));
+                    let res = PartialRes::new(Res::PrimTy(prim));
+                    self.r.partial_res_map.insert(id, res);
+                    self.r.current_owner.partial_res_map.insert(id, res);
+                    assert_ne!(self.r.current_owner.id, DUMMY_NODE_ID);
                 }
 
                 PartialRes::with_unresolved_segments(Res::PrimTy(prim), path.len() - 1)

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -40,8 +40,8 @@ use macros::{MacroRulesDecl, MacroRulesScope, MacroRulesScopeRef};
 use rustc_arena::{DroplessArena, TypedArena};
 use rustc_ast::node_id::NodeMap;
 use rustc_ast::{
-    self as ast, AngleBracketedArg, CRATE_NODE_ID, Crate, DUMMY_NODE_ID, Expr, ExprKind,
-    GenericArg, GenericArgs, Generics, NodeId, Path, attr,
+    self as ast, AngleBracketedArg, CRATE_NODE_ID, Crate, DUMMY_NODE_ID, GenericArg, GenericArgs,
+    Generics, NodeId, Path, attr,
 };
 use rustc_data_structures::fx::{FxHashMap, FxHashSet, FxIndexMap, FxIndexSet, default};
 use rustc_data_structures::intern::Interned;
@@ -58,7 +58,7 @@ use rustc_hir::def::{
 };
 use rustc_hir::def_id::{CRATE_DEF_ID, CrateNum, DefId, LOCAL_CRATE, LocalDefId, LocalDefIdMap};
 use rustc_hir::definitions::{PerParentDisambiguatorState, PerParentDisambiguatorsMap};
-use rustc_hir::{PrimTy, TraitCandidate, find_attr};
+use rustc_hir::{PrimTy, TraitCandidate};
 use rustc_index::bit_set::DenseBitSet;
 use rustc_metadata::creader::CStore;
 use rustc_middle::metadata::{AmbigModChild, ModChild, Reexport};
@@ -2578,36 +2578,6 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             }
             _ => None,
         }
-    }
-
-    /// Checks if an expression refers to a function marked with
-    /// `#[rustc_legacy_const_generics]` and returns the argument index list
-    /// from the attribute.
-    fn legacy_const_generic_args(&mut self, expr: &Expr) -> Option<Vec<usize>> {
-        let ExprKind::Path(None, path) = &expr.kind else {
-            return None;
-        };
-        // Don't perform legacy const generics rewriting if the path already
-        // has generic arguments.
-        if path.segments.last().unwrap().args.is_some() {
-            return None;
-        }
-
-        let def_id = self.partial_res_map.get(&expr.id)?.full_res()?.opt_def_id()?;
-
-        // We only support cross-crate argument rewriting. Uses
-        // within the same crate should be updated to use the new
-        // const generics style.
-        if def_id.is_local() {
-            return None;
-        }
-
-        find_attr!(
-            // we can use parsed attrs here since for other crates they're already available
-            self.tcx, def_id,
-            RustcLegacyConstGenerics{fn_indexes,..} => fn_indexes
-        )
-        .map(|fn_indexes| fn_indexes.iter().map(|(num, _)| *num).collect())
     }
 
     fn resolve_main(&mut self) {

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -1074,6 +1074,7 @@ struct DelayedVisResolutionError<'ra> {
     vis: ast::Visibility,
     parent_scope: ParentScope<'ra>,
     error: VisResolutionError,
+    owner: NodeId,
 }
 
 #[derive(Clone, Copy, PartialEq, Debug)]
@@ -2380,7 +2381,15 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
 
     fn record_partial_res(&mut self, node_id: NodeId, resolution: PartialRes) {
         debug!("(recording res) recording {:?} for {}", resolution, node_id);
+        // We insert into both the global and the owner-local partial res map.
+        // The global one is needed for many diagnostics, and looking it up in the owner is not always feasible,
+        // as we regularly look at e.g. the parent's ast and resolve some ids there.
+        // We want to keep doing that lazily instead of eagerly, as we only need the information in the error path.
         if let Some(prev_res) = self.partial_res_map.insert(node_id, resolution) {
+            panic!("path resolved multiple times ({prev_res:?} before, {resolution:?} now)");
+        }
+        assert_ne!(self.current_owner.id, DUMMY_NODE_ID);
+        if let Some(prev_res) = self.current_owner.partial_res_map.insert(node_id, resolution) {
             panic!("path resolved multiple times ({prev_res:?} before, {resolution:?} now)");
         }
     }

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -1979,7 +1979,6 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             delegation_infos: self.delegation_infos,
         };
         let ast_lowering = ty::ResolverAstLowering {
-            partial_res_map: self.partial_res_map,
             next_node_id: self.next_node_id,
             owners: self.owners,
             lint_buffer: Steal::new(self.lint_buffer),

--- a/src/tools/clippy/tests/ui/std_instead_of_core_unfixable.rs
+++ b/src/tools/clippy/tests/ui/std_instead_of_core_unfixable.rs
@@ -1,27 +1,28 @@
 #![warn(clippy::std_instead_of_core)]
 #![warn(clippy::std_instead_of_alloc)]
 #![allow(unused_imports)]
+//@no-rustfix
 
 #[rustfmt::skip]
 fn issue14982() {
+    // FIXME(oli-obk): make this report again
     use std::{collections::HashMap, hash::Hash};
-    //~^ std_instead_of_core
 }
 
 #[rustfmt::skip]
 fn issue15143() {
+    // FIXME(oli-obk): make this report again per violation
     use std::{error::Error, vec::Vec, fs::File};
     //~^ std_instead_of_core
-    //~| std_instead_of_alloc
 }
 
 #[rustfmt::skip]
 fn pr16964() {
     use std::{
+        //~^ std_instead_of_alloc
+        // FIXME(oli-obk): make this report again
         borrow::Cow,
-        //~^ std_instead_of_alloc
         collections::BTreeSet,
-        //~^ std_instead_of_alloc
         ffi::OsString,
     };
 }

--- a/src/tools/clippy/tests/ui/std_instead_of_core_unfixable.stderr
+++ b/src/tools/clippy/tests/ui/std_instead_of_core_unfixable.stderr
@@ -1,46 +1,20 @@
 error: used import from `std` instead of `core`
-  --> tests/ui/std_instead_of_core_unfixable.rs:7:43
+  --> tests/ui/std_instead_of_core_unfixable.rs:15:9
    |
-LL |     use std::{collections::HashMap, hash::Hash};
-   |                                           ^^^^
+LL |     use std::{error::Error, vec::Vec, fs::File};
+   |         ^^^ help: consider importing the item from `core`: `core`
    |
-   = help: consider importing the item from `core`
    = note: `-D clippy::std-instead-of-core` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::std_instead_of_core)]`
 
-error: used import from `std` instead of `core`
-  --> tests/ui/std_instead_of_core_unfixable.rs:13:22
-   |
-LL |     use std::{error::Error, vec::Vec, fs::File};
-   |                      ^^^^^
-   |
-   = help: consider importing the item from `core`
-
 error: used import from `std` instead of `alloc`
-  --> tests/ui/std_instead_of_core_unfixable.rs:13:34
+  --> tests/ui/std_instead_of_core_unfixable.rs:21:9
    |
-LL |     use std::{error::Error, vec::Vec, fs::File};
-   |                                  ^^^
+LL |     use std::{
+   |         ^^^ help: consider importing the item from `alloc`: `alloc`
    |
-   = help: consider importing the item from `alloc`
    = note: `-D clippy::std-instead-of-alloc` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::std_instead_of_alloc)]`
 
-error: used import from `std` instead of `alloc`
-  --> tests/ui/std_instead_of_core_unfixable.rs:21:17
-   |
-LL |         borrow::Cow,
-   |                 ^^^
-   |
-   = help: consider importing the item from `alloc`
-
-error: used import from `std` instead of `alloc`
-  --> tests/ui/std_instead_of_core_unfixable.rs:23:22
-   |
-LL |         collections::BTreeSet,
-   |                      ^^^^^^^^
-   |
-   = help: consider importing the item from `alloc`
-
-error: aborting due to 5 previous errors
+error: aborting due to 2 previous errors
 


### PR DESCRIPTION
cc https://github.com/rust-lang/rust-project-goals/issues/620

r? @petrochenkov 

Except for imports, everything using the partial_res_map in ast lowering works per-owner already. So, as a way to land this without a major refactoring, we turn all resolutions of path segments in use trees other than the first into `Res::Err`, which works just fine except for this one clippy lint.

Some background:

use statements are expanded from ast -> hir by flattening trees, so

```rust
use foo::bar::{baz, boo::{a, b}};
```

is turned into

```rust
use foo::bar::baz;
use foo::bar::boo::a;
use foo::bar::boo::b;
```

but the `foo::bar` part is only resolved in the first expanded import and the `boo` is only resolved in the second one (the one ending in `a`). On `main` the way this works out is that we ast->hir lower each of those paths for every expanded import by looking up the resolution again.

So when we start having per-owner maps, the second and third expanded import can't access the entry for `foo` anymore, as it's only available in the first map.

As discussed in [#t-compiler > partial_res_map vs per-owner tables @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/131828-t-compiler/topic/partial_res_map.20vs.20per-owner.20tables/near/602112306), reworking the representation of use statements is entirely on the table. So I'm planning to just flatten the entire tree as we do today, but only have one owner (`ItemKind::Use`) and everything else just lives within that.

cc @bushrat011899 as a recent contributor to the clippy lint.

rustdoc and stability checking are unaffected, as the former uses `import_res_map`, and the latter still correctly reports on path segments via the first expansion of a use tree.