### PR TITLE
Remove outdated comment for resolve_vars_with_obligations

### DIFF
--- a/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
@@ -142,8 +142,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     /// version (resolve_vars_if_possible), this version will
     /// also select obligations if it seems useful, in an effort
     /// to get more type information.
-    // FIXME(-Znext-solver): A lot of the calls to this method should
-    // probably be `resolve_vars_with_obligations` or `structurally_resolve_type` instead.
     #[instrument(skip(self), level = "debug", ret)]
     pub(crate) fn resolve_vars_with_obligations<T: TypeFoldable<TyCtxt<'tcx>>>(
         &self,


### PR DESCRIPTION

from 
[#t-types/trait-system-refactor > incorrect `resolve_vars_with_obligations` fixme
](https://rust-lang.zulipchat.com/#narrow/channel/364551-t-types.2Ftrait-system-refactor/topic/incorrect.20.60resolve_vars_with_obligations.60.20fixme/with/612312074)

r? @lcnr 