### PR TITLE
use `minicore::simd::Simd` more

### DIFF
--- a/tests/codegen-llvm/preserve-vec-element-types.rs
+++ b/tests/codegen-llvm/preserve-vec-element-types.rs
@@ -2,7 +2,7 @@
 //@ compile-flags: -Copt-level=3 -Zmerge-functions=disabled --target=aarch64-unknown-linux-gnu
 //@ needs-llvm-components: aarch64
 //@ add-minicore
-#![feature(no_core, repr_simd, f16, f128)]
+#![feature(no_core, f16, f128)]
 #![crate_type = "lib"]
 #![no_std]
 #![no_core]
@@ -12,10 +12,8 @@
 // useful for optimization. It prevents additional bitcasts that make LLVM patterns fail.
 
 extern crate minicore;
+use minicore::simd::Simd;
 use minicore::*;
-
-#[repr(simd)]
-pub struct Simd<T, const N: usize>([T; N]);
 
 #[repr(C)]
 struct Pair<T>(T, T);

--- a/tests/codegen-llvm/regparm-inreg.rs
+++ b/tests/codegen-llvm/regparm-inreg.rs
@@ -14,12 +14,13 @@
 
 #![crate_type = "lib"]
 #![no_core]
-#![feature(no_core, lang_items, repr_simd)]
+#![feature(no_core, lang_items)]
 
 extern crate minicore;
-use minicore::*;
 
 pub mod tests {
+    use minicore::simd::Simd;
+
     // regparm doesn't work for "fastcall" calling conv (only 2 inregs)
     // CHECK: @f1(i32 inreg noundef %_1, i32 inreg noundef %_2, i32 noundef %_3)
     #[no_mangle]
@@ -98,8 +99,7 @@ pub mod tests {
     pub extern "C" fn f10(_: f32, _: f64, _: bool, _: i16) {}
 
     #[allow(non_camel_case_types)]
-    #[repr(simd)]
-    pub struct __m128([f32; 4]);
+    type __m128 = Simd<f32, 4>;
 
     // regparm0: @f11(i32 noundef %_1, <4 x float> %_2, i32 noundef %_3, i32 noundef %_4)
     // regparm1: @f11(i32 inreg noundef %_1, <4 x float> %_2, i32 noundef %_3, i32 noundef %_4)
@@ -111,8 +111,7 @@ pub mod tests {
     pub extern "C" fn f11(_: i32, _: __m128, _: i32, _: i32) {}
 
     #[allow(non_camel_case_types)]
-    #[repr(simd)]
-    pub struct __m256([f32; 8]);
+    type __m256 = Simd<f32, 8>;
 
     // regparm0: @f12(i32 noundef %_1, <8 x float> %_2, i32 noundef %_3, i32 noundef %_4)
     // regparm1: @f12(i32 inreg noundef %_1, <8 x float> %_2, i32 noundef %_3, i32 noundef %_4)

--- a/tests/codegen-llvm/s390x-simd.rs
+++ b/tests/codegen-llvm/s390x-simd.rs
@@ -6,34 +6,12 @@
 
 #![crate_type = "rlib"]
 #![feature(no_core, asm_experimental_arch)]
-#![feature(simd_ffi, intrinsics, repr_simd)]
+#![feature(simd_ffi, intrinsics)]
 #![no_core]
 
 extern crate minicore;
+use minicore::simd::*;
 use minicore::*;
-
-#[repr(simd)]
-struct i8x16([i8; 16]);
-
-#[repr(simd)]
-struct i16x8([i16; 8]);
-
-#[repr(simd)]
-struct i32x4([i32; 4]);
-
-#[repr(simd)]
-struct i64x2([i64; 2]);
-
-#[repr(simd)]
-struct f32x4([f32; 4]);
-
-#[repr(simd)]
-struct f64x2([f64; 2]);
-
-impl Copy for i8x16 {}
-impl Copy for i16x8 {}
-impl Copy for i32x4 {}
-impl Copy for i64x2 {}
 
 #[rustc_intrinsic]
 unsafe fn simd_ge<T, U>(x: T, y: T) -> U;

--- a/tests/ui/abi/arm-unadjusted-intrinsic.rs
+++ b/tests/ui/abi/arm-unadjusted-intrinsic.rs
@@ -7,23 +7,19 @@
 //@[aarch64] compile-flags: --target aarch64-unknown-linux-gnu
 //@[aarch64] needs-llvm-components: aarch64
 //@ ignore-backends: gcc
-#![feature(
-    no_core, lang_items, link_llvm_intrinsics,
-    abi_unadjusted, repr_simd, arm_target_feature,
-)]
+#![feature(no_core, lang_items, link_llvm_intrinsics, abi_unadjusted, arm_target_feature)]
 #![no_std]
 #![no_core]
 #![crate_type = "lib"]
 #![allow(non_camel_case_types)]
 
 extern crate minicore;
+use minicore::simd::Simd;
 use minicore::*;
 
 // Regression test for https://github.com/rust-lang/rust/issues/118124.
 
-#[repr(simd)]
-pub struct int8x16_t(pub(crate) [i8; 16]);
-impl Copy for int8x16_t {}
+pub type int8x16_t = Simd<i8, 16>;
 
 #[repr(C)]
 pub struct int8x16x4_t(pub int8x16_t, pub int8x16_t, pub int8x16_t, pub int8x16_t);

--- a/tests/ui/abi/simd-abi-checks-empty-list.rs
+++ b/tests/ui/abi/simd-abi-checks-empty-list.rs
@@ -6,14 +6,11 @@
 //@ build-fail
 //@ ignore-backends: gcc
 #![no_core]
-#![feature(no_core, repr_simd)]
-#![allow(improper_ctypes_definitions)]
+#![feature(no_core)]
 
 extern crate minicore;
-use minicore::*;
+use minicore::simd::Simd;
 
-#[repr(simd)]
-pub struct SimdVec([i32; 4]);
-
-pub extern "C" fn pass_by_vec(_: SimdVec) {}
-//~^ ERROR: this function definition uses SIMD vector type `SimdVec` which is not currently supported with the chosen ABI
+#[expect(improper_ctypes_definitions)]
+pub extern "C" fn pass_by_vec(_: Simd<i32, 4>) {}
+//~^ ERROR: this function definition uses SIMD vector type `Simd<i32, 4>` which is not currently supported with the chosen ABI

--- a/tests/ui/abi/simd-abi-checks-empty-list.stderr
+++ b/tests/ui/abi/simd-abi-checks-empty-list.stderr
@@ -1,8 +1,8 @@
-error: this function definition uses SIMD vector type `SimdVec` which is not currently supported with the chosen ABI
-  --> $DIR/simd-abi-checks-empty-list.rs:18:1
+error: this function definition uses SIMD vector type `Simd<i32, 4>` which is not currently supported with the chosen ABI
+  --> $DIR/simd-abi-checks-empty-list.rs:15:1
    |
-LL | pub extern "C" fn pass_by_vec(_: SimdVec) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
+LL | pub extern "C" fn pass_by_vec(_: Simd<i32, 4>) {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/abi/simd-abi-checks-s390x.rs
+++ b/tests/ui/abi/simd-abi-checks-s390x.rs
@@ -12,29 +12,21 @@
 //[z13_soft_float]~? WARN must be disabled to ensure that the ABI of the current target can be implemented correctly
 //[z13_soft_float]~? WARN target feature `soft-float` cannot be enabled with `-Ctarget-feature`
 
-#![feature(no_core, repr_simd)]
+#![feature(no_core)]
 #![no_core]
 #![crate_type = "lib"]
 #![allow(non_camel_case_types, improper_ctypes_definitions)]
 
 extern crate minicore;
+use minicore::simd::*;
 use minicore::*;
 
-#[repr(simd)]
-pub struct i8x8([i8; 8]);
-#[repr(simd)]
-pub struct i8x16([i8; 16]);
-#[repr(simd)]
-pub struct i8x32([i8; 32]);
 #[repr(C)]
 pub struct Wrapper<T>(T);
+impl<T: Copy> Copy for Wrapper<T> {}
+
 #[repr(transparent)]
 pub struct TransparentWrapper<T>(T);
-
-impl Copy for i8x8 {}
-impl Copy for i8x16 {}
-impl Copy for i8x32 {}
-impl<T: Copy> Copy for Wrapper<T> {}
 impl<T: Copy> Copy for TransparentWrapper<T> {}
 
 #[no_mangle]

--- a/tests/ui/abi/simd-abi-checks-s390x.z10.stderr
+++ b/tests/ui/abi/simd-abi-checks-s390x.z10.stderr
@@ -1,21 +1,21 @@
-error: this function definition uses SIMD vector type `i8x8` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:41:1
+error: this function definition uses SIMD vector type `Simd<i8, 8>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
+  --> $DIR/simd-abi-checks-s390x.rs:33:1
    |
 LL | extern "C" fn vector_ret_small(x: &i8x8) -> i8x8 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
    |
    = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
-error: this function definition uses SIMD vector type `i8x16` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:46:1
+error: this function definition uses SIMD vector type `Simd<i8, 16>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
+  --> $DIR/simd-abi-checks-s390x.rs:38:1
    |
 LL | extern "C" fn vector_ret(x: &i8x16) -> i8x16 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
    |
    = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
-error: this function definition uses SIMD vector type `TransparentWrapper<i8x8>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:92:1
+error: this function definition uses SIMD vector type `TransparentWrapper<Simd<i8, 8>>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
+  --> $DIR/simd-abi-checks-s390x.rs:84:1
    |
 LL | / extern "C" fn vector_transparent_wrapper_ret_small(
 LL | |     x: &TransparentWrapper<i8x8>,
@@ -24,8 +24,8 @@ LL | | ) -> TransparentWrapper<i8x8> {
    |
    = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
-error: this function definition uses SIMD vector type `TransparentWrapper<i8x16>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:99:1
+error: this function definition uses SIMD vector type `TransparentWrapper<Simd<i8, 16>>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
+  --> $DIR/simd-abi-checks-s390x.rs:91:1
    |
 LL | / extern "C" fn vector_transparent_wrapper_ret(
 LL | |     x: &TransparentWrapper<i8x16>,
@@ -34,48 +34,48 @@ LL | | ) -> TransparentWrapper<i8x16> {
    |
    = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
-error: this function definition uses SIMD vector type `i8x8` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:114:1
+error: this function definition uses SIMD vector type `Simd<i8, 8>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
+  --> $DIR/simd-abi-checks-s390x.rs:106:1
    |
 LL | extern "C" fn vector_arg_small(x: i8x8) -> i64 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
    |
    = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
-error: this function definition uses SIMD vector type `i8x16` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:119:1
+error: this function definition uses SIMD vector type `Simd<i8, 16>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
+  --> $DIR/simd-abi-checks-s390x.rs:111:1
    |
 LL | extern "C" fn vector_arg(x: i8x16) -> i64 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
    |
    = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
-error: this function definition uses SIMD vector type `Wrapper<i8x8>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:130:1
+error: this function definition uses SIMD vector type `Wrapper<Simd<i8, 8>>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
+  --> $DIR/simd-abi-checks-s390x.rs:122:1
    |
 LL | extern "C" fn vector_wrapper_arg_small(x: Wrapper<i8x8>) -> i64 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
    |
    = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
-error: this function definition uses SIMD vector type `Wrapper<i8x16>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:135:1
+error: this function definition uses SIMD vector type `Wrapper<Simd<i8, 16>>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
+  --> $DIR/simd-abi-checks-s390x.rs:127:1
    |
 LL | extern "C" fn vector_wrapper_arg(x: Wrapper<i8x16>) -> i64 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
    |
    = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
-error: this function definition uses SIMD vector type `TransparentWrapper<i8x8>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:146:1
+error: this function definition uses SIMD vector type `TransparentWrapper<Simd<i8, 8>>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
+  --> $DIR/simd-abi-checks-s390x.rs:138:1
    |
 LL | extern "C" fn vector_transparent_wrapper_arg_small(x: TransparentWrapper<i8x8>) -> i64 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
    |
    = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
-error: this function definition uses SIMD vector type `TransparentWrapper<i8x16>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:151:1
+error: this function definition uses SIMD vector type `TransparentWrapper<Simd<i8, 16>>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
+  --> $DIR/simd-abi-checks-s390x.rs:143:1
    |
 LL | extern "C" fn vector_transparent_wrapper_arg(x: TransparentWrapper<i8x16>) -> i64 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here

--- a/tests/ui/abi/simd-abi-checks-s390x.z13_no_vector.stderr
+++ b/tests/ui/abi/simd-abi-checks-s390x.z13_no_vector.stderr
@@ -1,21 +1,21 @@
-error: this function definition uses SIMD vector type `i8x8` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:41:1
+error: this function definition uses SIMD vector type `Simd<i8, 8>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
+  --> $DIR/simd-abi-checks-s390x.rs:33:1
    |
 LL | extern "C" fn vector_ret_small(x: &i8x8) -> i8x8 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
    |
    = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
-error: this function definition uses SIMD vector type `i8x16` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:46:1
+error: this function definition uses SIMD vector type `Simd<i8, 16>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
+  --> $DIR/simd-abi-checks-s390x.rs:38:1
    |
 LL | extern "C" fn vector_ret(x: &i8x16) -> i8x16 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
    |
    = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
-error: this function definition uses SIMD vector type `TransparentWrapper<i8x8>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:92:1
+error: this function definition uses SIMD vector type `TransparentWrapper<Simd<i8, 8>>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
+  --> $DIR/simd-abi-checks-s390x.rs:84:1
    |
 LL | / extern "C" fn vector_transparent_wrapper_ret_small(
 LL | |     x: &TransparentWrapper<i8x8>,
@@ -24,8 +24,8 @@ LL | | ) -> TransparentWrapper<i8x8> {
    |
    = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
-error: this function definition uses SIMD vector type `TransparentWrapper<i8x16>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:99:1
+error: this function definition uses SIMD vector type `TransparentWrapper<Simd<i8, 16>>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
+  --> $DIR/simd-abi-checks-s390x.rs:91:1
    |
 LL | / extern "C" fn vector_transparent_wrapper_ret(
 LL | |     x: &TransparentWrapper<i8x16>,
@@ -34,48 +34,48 @@ LL | | ) -> TransparentWrapper<i8x16> {
    |
    = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
-error: this function definition uses SIMD vector type `i8x8` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:114:1
+error: this function definition uses SIMD vector type `Simd<i8, 8>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
+  --> $DIR/simd-abi-checks-s390x.rs:106:1
    |
 LL | extern "C" fn vector_arg_small(x: i8x8) -> i64 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
    |
    = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
-error: this function definition uses SIMD vector type `i8x16` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:119:1
+error: this function definition uses SIMD vector type `Simd<i8, 16>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
+  --> $DIR/simd-abi-checks-s390x.rs:111:1
    |
 LL | extern "C" fn vector_arg(x: i8x16) -> i64 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
    |
    = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
-error: this function definition uses SIMD vector type `Wrapper<i8x8>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:130:1
+error: this function definition uses SIMD vector type `Wrapper<Simd<i8, 8>>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
+  --> $DIR/simd-abi-checks-s390x.rs:122:1
    |
 LL | extern "C" fn vector_wrapper_arg_small(x: Wrapper<i8x8>) -> i64 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
    |
    = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
-error: this function definition uses SIMD vector type `Wrapper<i8x16>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:135:1
+error: this function definition uses SIMD vector type `Wrapper<Simd<i8, 16>>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
+  --> $DIR/simd-abi-checks-s390x.rs:127:1
    |
 LL | extern "C" fn vector_wrapper_arg(x: Wrapper<i8x16>) -> i64 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
    |
    = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
-error: this function definition uses SIMD vector type `TransparentWrapper<i8x8>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:146:1
+error: this function definition uses SIMD vector type `TransparentWrapper<Simd<i8, 8>>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
+  --> $DIR/simd-abi-checks-s390x.rs:138:1
    |
 LL | extern "C" fn vector_transparent_wrapper_arg_small(x: TransparentWrapper<i8x8>) -> i64 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
    |
    = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
-error: this function definition uses SIMD vector type `TransparentWrapper<i8x16>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:151:1
+error: this function definition uses SIMD vector type `TransparentWrapper<Simd<i8, 16>>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
+  --> $DIR/simd-abi-checks-s390x.rs:143:1
    |
 LL | extern "C" fn vector_transparent_wrapper_arg(x: TransparentWrapper<i8x16>) -> i64 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here

--- a/tests/ui/abi/simd-abi-checks-s390x.z13_soft_float.stderr
+++ b/tests/ui/abi/simd-abi-checks-s390x.z13_soft_float.stderr
@@ -8,24 +8,24 @@ warning: target feature `soft-float` must be disabled to ensure that the ABI of 
    = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #116344 <https://github.com/rust-lang/rust/issues/116344>
 
-error: this function definition uses SIMD vector type `i8x8` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:41:1
+error: this function definition uses SIMD vector type `Simd<i8, 8>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
+  --> $DIR/simd-abi-checks-s390x.rs:33:1
    |
 LL | extern "C" fn vector_ret_small(x: &i8x8) -> i8x8 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
    |
    = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
-error: this function definition uses SIMD vector type `i8x16` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:46:1
+error: this function definition uses SIMD vector type `Simd<i8, 16>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
+  --> $DIR/simd-abi-checks-s390x.rs:38:1
    |
 LL | extern "C" fn vector_ret(x: &i8x16) -> i8x16 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
    |
    = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
-error: this function definition uses SIMD vector type `TransparentWrapper<i8x8>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:92:1
+error: this function definition uses SIMD vector type `TransparentWrapper<Simd<i8, 8>>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
+  --> $DIR/simd-abi-checks-s390x.rs:84:1
    |
 LL | / extern "C" fn vector_transparent_wrapper_ret_small(
 LL | |     x: &TransparentWrapper<i8x8>,
@@ -34,8 +34,8 @@ LL | | ) -> TransparentWrapper<i8x8> {
    |
    = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
-error: this function definition uses SIMD vector type `TransparentWrapper<i8x16>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:99:1
+error: this function definition uses SIMD vector type `TransparentWrapper<Simd<i8, 16>>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
+  --> $DIR/simd-abi-checks-s390x.rs:91:1
    |
 LL | / extern "C" fn vector_transparent_wrapper_ret(
 LL | |     x: &TransparentWrapper<i8x16>,
@@ -44,48 +44,48 @@ LL | | ) -> TransparentWrapper<i8x16> {
    |
    = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
-error: this function definition uses SIMD vector type `i8x8` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:114:1
+error: this function definition uses SIMD vector type `Simd<i8, 8>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
+  --> $DIR/simd-abi-checks-s390x.rs:106:1
    |
 LL | extern "C" fn vector_arg_small(x: i8x8) -> i64 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
    |
    = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
-error: this function definition uses SIMD vector type `i8x16` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:119:1
+error: this function definition uses SIMD vector type `Simd<i8, 16>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
+  --> $DIR/simd-abi-checks-s390x.rs:111:1
    |
 LL | extern "C" fn vector_arg(x: i8x16) -> i64 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
    |
    = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
-error: this function definition uses SIMD vector type `Wrapper<i8x8>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:130:1
+error: this function definition uses SIMD vector type `Wrapper<Simd<i8, 8>>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
+  --> $DIR/simd-abi-checks-s390x.rs:122:1
    |
 LL | extern "C" fn vector_wrapper_arg_small(x: Wrapper<i8x8>) -> i64 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
    |
    = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
-error: this function definition uses SIMD vector type `Wrapper<i8x16>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:135:1
+error: this function definition uses SIMD vector type `Wrapper<Simd<i8, 16>>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
+  --> $DIR/simd-abi-checks-s390x.rs:127:1
    |
 LL | extern "C" fn vector_wrapper_arg(x: Wrapper<i8x16>) -> i64 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
    |
    = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
-error: this function definition uses SIMD vector type `TransparentWrapper<i8x8>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:146:1
+error: this function definition uses SIMD vector type `TransparentWrapper<Simd<i8, 8>>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
+  --> $DIR/simd-abi-checks-s390x.rs:138:1
    |
 LL | extern "C" fn vector_transparent_wrapper_arg_small(x: TransparentWrapper<i8x8>) -> i64 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
    |
    = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
-error: this function definition uses SIMD vector type `TransparentWrapper<i8x16>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:151:1
+error: this function definition uses SIMD vector type `TransparentWrapper<Simd<i8, 16>>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
+  --> $DIR/simd-abi-checks-s390x.rs:143:1
    |
 LL | extern "C" fn vector_transparent_wrapper_arg(x: TransparentWrapper<i8x16>) -> i64 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here

--- a/tests/ui/abi/simd-abi-checks-sse.rs
+++ b/tests/ui/abi/simd-abi-checks-sse.rs
@@ -6,17 +6,14 @@
 //@ build-fail
 //@ needs-llvm-components: x86
 //@ ignore-backends: gcc
-#![feature(no_core, repr_simd)]
+#![feature(no_core)]
 #![no_core]
 #![allow(improper_ctypes_definitions)]
 
 extern crate minicore;
-use minicore::*;
-
-#[repr(simd)]
-pub struct SseVector([i64; 2]);
+use minicore::simd::Simd;
 
 #[no_mangle]
-pub unsafe extern "C" fn f(_: SseVector) {
-    //~^ ERROR: this function definition uses SIMD vector type `SseVector` which (with the chosen ABI) requires the `sse` target feature, which is not enabled
+pub unsafe extern "C" fn f(_: Simd<i64, 2>) {
+    //~^ ERROR: this function definition uses SIMD vector type `Simd<i64, 2>` which (with the chosen ABI) requires the `sse` target feature, which is not enabled
 }

--- a/tests/ui/abi/simd-abi-checks-sse.stderr
+++ b/tests/ui/abi/simd-abi-checks-sse.stderr
@@ -1,8 +1,8 @@
-error: this function definition uses SIMD vector type `SseVector` which (with the chosen ABI) requires the `sse` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-sse.rs:20:1
+error: this function definition uses SIMD vector type `Simd<i64, 2>` which (with the chosen ABI) requires the `sse` target feature, which is not enabled
+  --> $DIR/simd-abi-checks-sse.rs:17:1
    |
-LL | pub unsafe extern "C" fn f(_: SseVector) {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
+LL | pub unsafe extern "C" fn f(_: Simd<i64, 2>) {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
    |
    = help: consider enabling it globally (`-C target-feature=+sse`) or locally (`#[target_feature(enable="sse")]`)
 

--- a/tests/ui/asm/powerpc/bad-reg.aix64.stderr
+++ b/tests/ui/asm/powerpc/bad-reg.aix64.stderr
@@ -1,131 +1,131 @@
 error: invalid register `sp`: the stack pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:38:18
+  --> $DIR/bad-reg.rs:31:18
    |
 LL |         asm!("", out("sp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `r2`: r2 is a system reserved register and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:40:18
+  --> $DIR/bad-reg.rs:33:18
    |
 LL |         asm!("", out("r2") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `r30`: r30 is used internally by LLVM and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:46:18
+  --> $DIR/bad-reg.rs:39:18
    |
 LL |         asm!("", out("r30") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `fp`: the frame pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:48:18
+  --> $DIR/bad-reg.rs:41:18
    |
 LL |         asm!("", out("fp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `vrsave`: the vrsave register cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:50:18
+  --> $DIR/bad-reg.rs:43:18
    |
 LL |         asm!("", out("vrsave") _);
    |                  ^^^^^^^^^^^^^^^
 
 error: register class `cr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:139:18
+  --> $DIR/bad-reg.rs:131:18
    |
 LL |         asm!("", in("cr") x);
    |                  ^^^^^^^^^^
 
 error: register class `cr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:142:18
+  --> $DIR/bad-reg.rs:134:18
    |
 LL |         asm!("", out("cr") x);
    |                  ^^^^^^^^^^^
 
 error: register class `cr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:145:26
+  --> $DIR/bad-reg.rs:137:26
    |
 LL |         asm!("/* {} */", in(cr) x);
    |                          ^^^^^^^^
 
 error: register class `cr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:148:26
+  --> $DIR/bad-reg.rs:140:26
    |
 LL |         asm!("/* {} */", out(cr) _);
    |                          ^^^^^^^^^
 
 error: register class `ctr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:152:18
+  --> $DIR/bad-reg.rs:144:18
    |
 LL |         asm!("", in("ctr") x);
    |                  ^^^^^^^^^^^
 
 error: register class `ctr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:155:18
+  --> $DIR/bad-reg.rs:147:18
    |
 LL |         asm!("", out("ctr") x);
    |                  ^^^^^^^^^^^^
 
 error: register class `ctr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:158:26
+  --> $DIR/bad-reg.rs:150:26
    |
 LL |         asm!("/* {} */", in(ctr) x);
    |                          ^^^^^^^^^
 
 error: register class `ctr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:161:26
+  --> $DIR/bad-reg.rs:153:26
    |
 LL |         asm!("/* {} */", out(ctr) _);
    |                          ^^^^^^^^^^
 
 error: register class `lr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:165:18
+  --> $DIR/bad-reg.rs:157:18
    |
 LL |         asm!("", in("lr") x);
    |                  ^^^^^^^^^^
 
 error: register class `lr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:168:18
+  --> $DIR/bad-reg.rs:160:18
    |
 LL |         asm!("", out("lr") x);
    |                  ^^^^^^^^^^^
 
 error: register class `lr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:171:26
+  --> $DIR/bad-reg.rs:163:26
    |
 LL |         asm!("/* {} */", in(lr) x);
    |                          ^^^^^^^^
 
 error: register class `lr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:174:26
+  --> $DIR/bad-reg.rs:166:26
    |
 LL |         asm!("/* {} */", out(lr) _);
    |                          ^^^^^^^^^
 
 error: register class `xer` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:178:18
+  --> $DIR/bad-reg.rs:170:18
    |
 LL |         asm!("", in("xer") x);
    |                  ^^^^^^^^^^^
 
 error: register class `xer` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:181:18
+  --> $DIR/bad-reg.rs:173:18
    |
 LL |         asm!("", out("xer") x);
    |                  ^^^^^^^^^^^^
 
 error: register class `xer` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:184:26
+  --> $DIR/bad-reg.rs:176:26
    |
 LL |         asm!("/* {} */", in(xer) x);
    |                          ^^^^^^^^^
 
 error: register class `xer` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:187:26
+  --> $DIR/bad-reg.rs:179:26
    |
 LL |         asm!("/* {} */", out(xer) _);
    |                          ^^^^^^^^^^
 
 error: register `cr0` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:191:31
+  --> $DIR/bad-reg.rs:183:31
    |
 LL |         asm!("", out("cr") _, out("cr0") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr0`
@@ -133,7 +133,7 @@ LL |         asm!("", out("cr") _, out("cr0") _);
    |                  register `cr`
 
 error: register `cr1` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:193:31
+  --> $DIR/bad-reg.rs:185:31
    |
 LL |         asm!("", out("cr") _, out("cr1") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr1`
@@ -141,7 +141,7 @@ LL |         asm!("", out("cr") _, out("cr1") _);
    |                  register `cr`
 
 error: register `cr2` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:195:31
+  --> $DIR/bad-reg.rs:187:31
    |
 LL |         asm!("", out("cr") _, out("cr2") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr2`
@@ -149,7 +149,7 @@ LL |         asm!("", out("cr") _, out("cr2") _);
    |                  register `cr`
 
 error: register `cr3` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:197:31
+  --> $DIR/bad-reg.rs:189:31
    |
 LL |         asm!("", out("cr") _, out("cr3") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr3`
@@ -157,7 +157,7 @@ LL |         asm!("", out("cr") _, out("cr3") _);
    |                  register `cr`
 
 error: register `cr4` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:199:31
+  --> $DIR/bad-reg.rs:191:31
    |
 LL |         asm!("", out("cr") _, out("cr4") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr4`
@@ -165,7 +165,7 @@ LL |         asm!("", out("cr") _, out("cr4") _);
    |                  register `cr`
 
 error: register `cr5` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:201:31
+  --> $DIR/bad-reg.rs:193:31
    |
 LL |         asm!("", out("cr") _, out("cr5") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr5`
@@ -173,7 +173,7 @@ LL |         asm!("", out("cr") _, out("cr5") _);
    |                  register `cr`
 
 error: register `cr6` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:203:31
+  --> $DIR/bad-reg.rs:195:31
    |
 LL |         asm!("", out("cr") _, out("cr6") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr6`
@@ -181,7 +181,7 @@ LL |         asm!("", out("cr") _, out("cr6") _);
    |                  register `cr`
 
 error: register `cr7` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:205:31
+  --> $DIR/bad-reg.rs:197:31
    |
 LL |         asm!("", out("cr") _, out("cr7") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr7`
@@ -189,7 +189,7 @@ LL |         asm!("", out("cr") _, out("cr7") _);
    |                  register `cr`
 
 error: register `vs0` conflicts with register `f0`
-  --> $DIR/bad-reg.rs:208:31
+  --> $DIR/bad-reg.rs:200:31
    |
 LL |         asm!("", out("f0") _, out("vs0") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs0`
@@ -197,7 +197,7 @@ LL |         asm!("", out("f0") _, out("vs0") _);
    |                  register `f0`
 
 error: register `vs1` conflicts with register `f1`
-  --> $DIR/bad-reg.rs:210:31
+  --> $DIR/bad-reg.rs:202:31
    |
 LL |         asm!("", out("f1") _, out("vs1") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs1`
@@ -205,7 +205,7 @@ LL |         asm!("", out("f1") _, out("vs1") _);
    |                  register `f1`
 
 error: register `vs2` conflicts with register `f2`
-  --> $DIR/bad-reg.rs:212:31
+  --> $DIR/bad-reg.rs:204:31
    |
 LL |         asm!("", out("f2") _, out("vs2") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs2`
@@ -213,7 +213,7 @@ LL |         asm!("", out("f2") _, out("vs2") _);
    |                  register `f2`
 
 error: register `vs3` conflicts with register `f3`
-  --> $DIR/bad-reg.rs:214:31
+  --> $DIR/bad-reg.rs:206:31
    |
 LL |         asm!("", out("f3") _, out("vs3") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs3`
@@ -221,7 +221,7 @@ LL |         asm!("", out("f3") _, out("vs3") _);
    |                  register `f3`
 
 error: register `vs4` conflicts with register `f4`
-  --> $DIR/bad-reg.rs:216:31
+  --> $DIR/bad-reg.rs:208:31
    |
 LL |         asm!("", out("f4") _, out("vs4") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs4`
@@ -229,7 +229,7 @@ LL |         asm!("", out("f4") _, out("vs4") _);
    |                  register `f4`
 
 error: register `vs5` conflicts with register `f5`
-  --> $DIR/bad-reg.rs:218:31
+  --> $DIR/bad-reg.rs:210:31
    |
 LL |         asm!("", out("f5") _, out("vs5") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs5`
@@ -237,7 +237,7 @@ LL |         asm!("", out("f5") _, out("vs5") _);
    |                  register `f5`
 
 error: register `vs6` conflicts with register `f6`
-  --> $DIR/bad-reg.rs:220:31
+  --> $DIR/bad-reg.rs:212:31
    |
 LL |         asm!("", out("f6") _, out("vs6") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs6`
@@ -245,7 +245,7 @@ LL |         asm!("", out("f6") _, out("vs6") _);
    |                  register `f6`
 
 error: register `vs7` conflicts with register `f7`
-  --> $DIR/bad-reg.rs:222:31
+  --> $DIR/bad-reg.rs:214:31
    |
 LL |         asm!("", out("f7") _, out("vs7") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs7`
@@ -253,7 +253,7 @@ LL |         asm!("", out("f7") _, out("vs7") _);
    |                  register `f7`
 
 error: register `vs8` conflicts with register `f8`
-  --> $DIR/bad-reg.rs:224:31
+  --> $DIR/bad-reg.rs:216:31
    |
 LL |         asm!("", out("f8") _, out("vs8") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs8`
@@ -261,7 +261,7 @@ LL |         asm!("", out("f8") _, out("vs8") _);
    |                  register `f8`
 
 error: register `vs9` conflicts with register `f9`
-  --> $DIR/bad-reg.rs:226:31
+  --> $DIR/bad-reg.rs:218:31
    |
 LL |         asm!("", out("f9") _, out("vs9") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs9`
@@ -269,7 +269,7 @@ LL |         asm!("", out("f9") _, out("vs9") _);
    |                  register `f9`
 
 error: register `vs10` conflicts with register `f10`
-  --> $DIR/bad-reg.rs:228:32
+  --> $DIR/bad-reg.rs:220:32
    |
 LL |         asm!("", out("f10") _, out("vs10") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs10`
@@ -277,7 +277,7 @@ LL |         asm!("", out("f10") _, out("vs10") _);
    |                  register `f10`
 
 error: register `vs11` conflicts with register `f11`
-  --> $DIR/bad-reg.rs:230:32
+  --> $DIR/bad-reg.rs:222:32
    |
 LL |         asm!("", out("f11") _, out("vs11") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs11`
@@ -285,7 +285,7 @@ LL |         asm!("", out("f11") _, out("vs11") _);
    |                  register `f11`
 
 error: register `vs12` conflicts with register `f12`
-  --> $DIR/bad-reg.rs:232:32
+  --> $DIR/bad-reg.rs:224:32
    |
 LL |         asm!("", out("f12") _, out("vs12") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs12`
@@ -293,7 +293,7 @@ LL |         asm!("", out("f12") _, out("vs12") _);
    |                  register `f12`
 
 error: register `vs13` conflicts with register `f13`
-  --> $DIR/bad-reg.rs:234:32
+  --> $DIR/bad-reg.rs:226:32
    |
 LL |         asm!("", out("f13") _, out("vs13") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs13`
@@ -301,7 +301,7 @@ LL |         asm!("", out("f13") _, out("vs13") _);
    |                  register `f13`
 
 error: register `vs14` conflicts with register `f14`
-  --> $DIR/bad-reg.rs:236:32
+  --> $DIR/bad-reg.rs:228:32
    |
 LL |         asm!("", out("f14") _, out("vs14") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs14`
@@ -309,7 +309,7 @@ LL |         asm!("", out("f14") _, out("vs14") _);
    |                  register `f14`
 
 error: register `vs15` conflicts with register `f15`
-  --> $DIR/bad-reg.rs:238:32
+  --> $DIR/bad-reg.rs:230:32
    |
 LL |         asm!("", out("f15") _, out("vs15") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs15`
@@ -317,7 +317,7 @@ LL |         asm!("", out("f15") _, out("vs15") _);
    |                  register `f15`
 
 error: register `vs16` conflicts with register `f16`
-  --> $DIR/bad-reg.rs:240:32
+  --> $DIR/bad-reg.rs:232:32
    |
 LL |         asm!("", out("f16") _, out("vs16") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs16`
@@ -325,7 +325,7 @@ LL |         asm!("", out("f16") _, out("vs16") _);
    |                  register `f16`
 
 error: register `vs17` conflicts with register `f17`
-  --> $DIR/bad-reg.rs:242:32
+  --> $DIR/bad-reg.rs:234:32
    |
 LL |         asm!("", out("f17") _, out("vs17") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs17`
@@ -333,7 +333,7 @@ LL |         asm!("", out("f17") _, out("vs17") _);
    |                  register `f17`
 
 error: register `vs18` conflicts with register `f18`
-  --> $DIR/bad-reg.rs:244:32
+  --> $DIR/bad-reg.rs:236:32
    |
 LL |         asm!("", out("f18") _, out("vs18") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs18`
@@ -341,7 +341,7 @@ LL |         asm!("", out("f18") _, out("vs18") _);
    |                  register `f18`
 
 error: register `vs19` conflicts with register `f19`
-  --> $DIR/bad-reg.rs:246:32
+  --> $DIR/bad-reg.rs:238:32
    |
 LL |         asm!("", out("f19") _, out("vs19") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs19`
@@ -349,7 +349,7 @@ LL |         asm!("", out("f19") _, out("vs19") _);
    |                  register `f19`
 
 error: register `vs20` conflicts with register `f20`
-  --> $DIR/bad-reg.rs:248:32
+  --> $DIR/bad-reg.rs:240:32
    |
 LL |         asm!("", out("f20") _, out("vs20") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs20`
@@ -357,7 +357,7 @@ LL |         asm!("", out("f20") _, out("vs20") _);
    |                  register `f20`
 
 error: register `vs21` conflicts with register `f21`
-  --> $DIR/bad-reg.rs:250:32
+  --> $DIR/bad-reg.rs:242:32
    |
 LL |         asm!("", out("f21") _, out("vs21") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs21`
@@ -365,7 +365,7 @@ LL |         asm!("", out("f21") _, out("vs21") _);
    |                  register `f21`
 
 error: register `vs22` conflicts with register `f22`
-  --> $DIR/bad-reg.rs:252:32
+  --> $DIR/bad-reg.rs:244:32
    |
 LL |         asm!("", out("f22") _, out("vs22") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs22`
@@ -373,7 +373,7 @@ LL |         asm!("", out("f22") _, out("vs22") _);
    |                  register `f22`
 
 error: register `vs23` conflicts with register `f23`
-  --> $DIR/bad-reg.rs:254:32
+  --> $DIR/bad-reg.rs:246:32
    |
 LL |         asm!("", out("f23") _, out("vs23") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs23`
@@ -381,7 +381,7 @@ LL |         asm!("", out("f23") _, out("vs23") _);
    |                  register `f23`
 
 error: register `vs24` conflicts with register `f24`
-  --> $DIR/bad-reg.rs:256:32
+  --> $DIR/bad-reg.rs:248:32
    |
 LL |         asm!("", out("f24") _, out("vs24") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs24`
@@ -389,7 +389,7 @@ LL |         asm!("", out("f24") _, out("vs24") _);
    |                  register `f24`
 
 error: register `vs25` conflicts with register `f25`
-  --> $DIR/bad-reg.rs:258:32
+  --> $DIR/bad-reg.rs:250:32
    |
 LL |         asm!("", out("f25") _, out("vs25") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs25`
@@ -397,7 +397,7 @@ LL |         asm!("", out("f25") _, out("vs25") _);
    |                  register `f25`
 
 error: register `vs26` conflicts with register `f26`
-  --> $DIR/bad-reg.rs:260:32
+  --> $DIR/bad-reg.rs:252:32
    |
 LL |         asm!("", out("f26") _, out("vs26") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs26`
@@ -405,7 +405,7 @@ LL |         asm!("", out("f26") _, out("vs26") _);
    |                  register `f26`
 
 error: register `vs27` conflicts with register `f27`
-  --> $DIR/bad-reg.rs:262:32
+  --> $DIR/bad-reg.rs:254:32
    |
 LL |         asm!("", out("f27") _, out("vs27") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs27`
@@ -413,7 +413,7 @@ LL |         asm!("", out("f27") _, out("vs27") _);
    |                  register `f27`
 
 error: register `vs28` conflicts with register `f28`
-  --> $DIR/bad-reg.rs:264:32
+  --> $DIR/bad-reg.rs:256:32
    |
 LL |         asm!("", out("f28") _, out("vs28") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs28`
@@ -421,7 +421,7 @@ LL |         asm!("", out("f28") _, out("vs28") _);
    |                  register `f28`
 
 error: register `vs29` conflicts with register `f29`
-  --> $DIR/bad-reg.rs:266:32
+  --> $DIR/bad-reg.rs:258:32
    |
 LL |         asm!("", out("f29") _, out("vs29") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs29`
@@ -429,7 +429,7 @@ LL |         asm!("", out("f29") _, out("vs29") _);
    |                  register `f29`
 
 error: register `vs30` conflicts with register `f30`
-  --> $DIR/bad-reg.rs:268:32
+  --> $DIR/bad-reg.rs:260:32
    |
 LL |         asm!("", out("f30") _, out("vs30") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs30`
@@ -437,7 +437,7 @@ LL |         asm!("", out("f30") _, out("vs30") _);
    |                  register `f30`
 
 error: register `vs31` conflicts with register `f31`
-  --> $DIR/bad-reg.rs:270:32
+  --> $DIR/bad-reg.rs:262:32
    |
 LL |         asm!("", out("f31") _, out("vs31") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs31`
@@ -445,7 +445,7 @@ LL |         asm!("", out("f31") _, out("vs31") _);
    |                  register `f31`
 
 error: register `v0` conflicts with register `vs32`
-  --> $DIR/bad-reg.rs:272:33
+  --> $DIR/bad-reg.rs:264:33
    |
 LL |         asm!("", out("vs32") _, out("v0") _);
    |                  -------------  ^^^^^^^^^^^ register `v0`
@@ -453,7 +453,7 @@ LL |         asm!("", out("vs32") _, out("v0") _);
    |                  register `vs32`
 
 error: register `v1` conflicts with register `vs33`
-  --> $DIR/bad-reg.rs:274:33
+  --> $DIR/bad-reg.rs:266:33
    |
 LL |         asm!("", out("vs33") _, out("v1") _);
    |                  -------------  ^^^^^^^^^^^ register `v1`
@@ -461,7 +461,7 @@ LL |         asm!("", out("vs33") _, out("v1") _);
    |                  register `vs33`
 
 error: register `v2` conflicts with register `vs34`
-  --> $DIR/bad-reg.rs:276:33
+  --> $DIR/bad-reg.rs:268:33
    |
 LL |         asm!("", out("vs34") _, out("v2") _);
    |                  -------------  ^^^^^^^^^^^ register `v2`
@@ -469,7 +469,7 @@ LL |         asm!("", out("vs34") _, out("v2") _);
    |                  register `vs34`
 
 error: register `v3` conflicts with register `vs35`
-  --> $DIR/bad-reg.rs:278:33
+  --> $DIR/bad-reg.rs:270:33
    |
 LL |         asm!("", out("vs35") _, out("v3") _);
    |                  -------------  ^^^^^^^^^^^ register `v3`
@@ -477,7 +477,7 @@ LL |         asm!("", out("vs35") _, out("v3") _);
    |                  register `vs35`
 
 error: register `v4` conflicts with register `vs36`
-  --> $DIR/bad-reg.rs:280:33
+  --> $DIR/bad-reg.rs:272:33
    |
 LL |         asm!("", out("vs36") _, out("v4") _);
    |                  -------------  ^^^^^^^^^^^ register `v4`
@@ -485,7 +485,7 @@ LL |         asm!("", out("vs36") _, out("v4") _);
    |                  register `vs36`
 
 error: register `v5` conflicts with register `vs37`
-  --> $DIR/bad-reg.rs:282:33
+  --> $DIR/bad-reg.rs:274:33
    |
 LL |         asm!("", out("vs37") _, out("v5") _);
    |                  -------------  ^^^^^^^^^^^ register `v5`
@@ -493,7 +493,7 @@ LL |         asm!("", out("vs37") _, out("v5") _);
    |                  register `vs37`
 
 error: register `v6` conflicts with register `vs38`
-  --> $DIR/bad-reg.rs:284:33
+  --> $DIR/bad-reg.rs:276:33
    |
 LL |         asm!("", out("vs38") _, out("v6") _);
    |                  -------------  ^^^^^^^^^^^ register `v6`
@@ -501,7 +501,7 @@ LL |         asm!("", out("vs38") _, out("v6") _);
    |                  register `vs38`
 
 error: register `v7` conflicts with register `vs39`
-  --> $DIR/bad-reg.rs:286:33
+  --> $DIR/bad-reg.rs:278:33
    |
 LL |         asm!("", out("vs39") _, out("v7") _);
    |                  -------------  ^^^^^^^^^^^ register `v7`
@@ -509,7 +509,7 @@ LL |         asm!("", out("vs39") _, out("v7") _);
    |                  register `vs39`
 
 error: register `v8` conflicts with register `vs40`
-  --> $DIR/bad-reg.rs:288:33
+  --> $DIR/bad-reg.rs:280:33
    |
 LL |         asm!("", out("vs40") _, out("v8") _);
    |                  -------------  ^^^^^^^^^^^ register `v8`
@@ -517,7 +517,7 @@ LL |         asm!("", out("vs40") _, out("v8") _);
    |                  register `vs40`
 
 error: register `v9` conflicts with register `vs41`
-  --> $DIR/bad-reg.rs:290:33
+  --> $DIR/bad-reg.rs:282:33
    |
 LL |         asm!("", out("vs41") _, out("v9") _);
    |                  -------------  ^^^^^^^^^^^ register `v9`
@@ -525,7 +525,7 @@ LL |         asm!("", out("vs41") _, out("v9") _);
    |                  register `vs41`
 
 error: register `v10` conflicts with register `vs42`
-  --> $DIR/bad-reg.rs:292:33
+  --> $DIR/bad-reg.rs:284:33
    |
 LL |         asm!("", out("vs42") _, out("v10") _);
    |                  -------------  ^^^^^^^^^^^^ register `v10`
@@ -533,7 +533,7 @@ LL |         asm!("", out("vs42") _, out("v10") _);
    |                  register `vs42`
 
 error: register `v11` conflicts with register `vs43`
-  --> $DIR/bad-reg.rs:294:33
+  --> $DIR/bad-reg.rs:286:33
    |
 LL |         asm!("", out("vs43") _, out("v11") _);
    |                  -------------  ^^^^^^^^^^^^ register `v11`
@@ -541,7 +541,7 @@ LL |         asm!("", out("vs43") _, out("v11") _);
    |                  register `vs43`
 
 error: register `v12` conflicts with register `vs44`
-  --> $DIR/bad-reg.rs:296:33
+  --> $DIR/bad-reg.rs:288:33
    |
 LL |         asm!("", out("vs44") _, out("v12") _);
    |                  -------------  ^^^^^^^^^^^^ register `v12`
@@ -549,7 +549,7 @@ LL |         asm!("", out("vs44") _, out("v12") _);
    |                  register `vs44`
 
 error: register `v13` conflicts with register `vs45`
-  --> $DIR/bad-reg.rs:298:33
+  --> $DIR/bad-reg.rs:290:33
    |
 LL |         asm!("", out("vs45") _, out("v13") _);
    |                  -------------  ^^^^^^^^^^^^ register `v13`
@@ -557,7 +557,7 @@ LL |         asm!("", out("vs45") _, out("v13") _);
    |                  register `vs45`
 
 error: register `v14` conflicts with register `vs46`
-  --> $DIR/bad-reg.rs:300:33
+  --> $DIR/bad-reg.rs:292:33
    |
 LL |         asm!("", out("vs46") _, out("v14") _);
    |                  -------------  ^^^^^^^^^^^^ register `v14`
@@ -565,7 +565,7 @@ LL |         asm!("", out("vs46") _, out("v14") _);
    |                  register `vs46`
 
 error: register `v15` conflicts with register `vs47`
-  --> $DIR/bad-reg.rs:302:33
+  --> $DIR/bad-reg.rs:294:33
    |
 LL |         asm!("", out("vs47") _, out("v15") _);
    |                  -------------  ^^^^^^^^^^^^ register `v15`
@@ -573,7 +573,7 @@ LL |         asm!("", out("vs47") _, out("v15") _);
    |                  register `vs47`
 
 error: register `v16` conflicts with register `vs48`
-  --> $DIR/bad-reg.rs:304:33
+  --> $DIR/bad-reg.rs:296:33
    |
 LL |         asm!("", out("vs48") _, out("v16") _);
    |                  -------------  ^^^^^^^^^^^^ register `v16`
@@ -581,7 +581,7 @@ LL |         asm!("", out("vs48") _, out("v16") _);
    |                  register `vs48`
 
 error: register `v17` conflicts with register `vs49`
-  --> $DIR/bad-reg.rs:306:33
+  --> $DIR/bad-reg.rs:298:33
    |
 LL |         asm!("", out("vs49") _, out("v17") _);
    |                  -------------  ^^^^^^^^^^^^ register `v17`
@@ -589,7 +589,7 @@ LL |         asm!("", out("vs49") _, out("v17") _);
    |                  register `vs49`
 
 error: register `v18` conflicts with register `vs50`
-  --> $DIR/bad-reg.rs:308:33
+  --> $DIR/bad-reg.rs:300:33
    |
 LL |         asm!("", out("vs50") _, out("v18") _);
    |                  -------------  ^^^^^^^^^^^^ register `v18`
@@ -597,7 +597,7 @@ LL |         asm!("", out("vs50") _, out("v18") _);
    |                  register `vs50`
 
 error: register `v19` conflicts with register `vs51`
-  --> $DIR/bad-reg.rs:310:33
+  --> $DIR/bad-reg.rs:302:33
    |
 LL |         asm!("", out("vs51") _, out("v19") _);
    |                  -------------  ^^^^^^^^^^^^ register `v19`
@@ -605,7 +605,7 @@ LL |         asm!("", out("vs51") _, out("v19") _);
    |                  register `vs51`
 
 error: register `v20` conflicts with register `vs52`
-  --> $DIR/bad-reg.rs:312:33
+  --> $DIR/bad-reg.rs:304:33
    |
 LL |         asm!("", out("vs52") _, out("v20") _);
    |                  -------------  ^^^^^^^^^^^^ register `v20`
@@ -613,7 +613,7 @@ LL |         asm!("", out("vs52") _, out("v20") _);
    |                  register `vs52`
 
 error: register `v21` conflicts with register `vs53`
-  --> $DIR/bad-reg.rs:314:33
+  --> $DIR/bad-reg.rs:306:33
    |
 LL |         asm!("", out("vs53") _, out("v21") _);
    |                  -------------  ^^^^^^^^^^^^ register `v21`
@@ -621,7 +621,7 @@ LL |         asm!("", out("vs53") _, out("v21") _);
    |                  register `vs53`
 
 error: register `v22` conflicts with register `vs54`
-  --> $DIR/bad-reg.rs:316:33
+  --> $DIR/bad-reg.rs:308:33
    |
 LL |         asm!("", out("vs54") _, out("v22") _);
    |                  -------------  ^^^^^^^^^^^^ register `v22`
@@ -629,7 +629,7 @@ LL |         asm!("", out("vs54") _, out("v22") _);
    |                  register `vs54`
 
 error: register `v23` conflicts with register `vs55`
-  --> $DIR/bad-reg.rs:318:33
+  --> $DIR/bad-reg.rs:310:33
    |
 LL |         asm!("", out("vs55") _, out("v23") _);
    |                  -------------  ^^^^^^^^^^^^ register `v23`
@@ -637,7 +637,7 @@ LL |         asm!("", out("vs55") _, out("v23") _);
    |                  register `vs55`
 
 error: register `v24` conflicts with register `vs56`
-  --> $DIR/bad-reg.rs:320:33
+  --> $DIR/bad-reg.rs:312:33
    |
 LL |         asm!("", out("vs56") _, out("v24") _);
    |                  -------------  ^^^^^^^^^^^^ register `v24`
@@ -645,7 +645,7 @@ LL |         asm!("", out("vs56") _, out("v24") _);
    |                  register `vs56`
 
 error: register `v25` conflicts with register `vs57`
-  --> $DIR/bad-reg.rs:322:33
+  --> $DIR/bad-reg.rs:314:33
    |
 LL |         asm!("", out("vs57") _, out("v25") _);
    |                  -------------  ^^^^^^^^^^^^ register `v25`
@@ -653,7 +653,7 @@ LL |         asm!("", out("vs57") _, out("v25") _);
    |                  register `vs57`
 
 error: register `v26` conflicts with register `vs58`
-  --> $DIR/bad-reg.rs:324:33
+  --> $DIR/bad-reg.rs:316:33
    |
 LL |         asm!("", out("vs58") _, out("v26") _);
    |                  -------------  ^^^^^^^^^^^^ register `v26`
@@ -661,7 +661,7 @@ LL |         asm!("", out("vs58") _, out("v26") _);
    |                  register `vs58`
 
 error: register `v27` conflicts with register `vs59`
-  --> $DIR/bad-reg.rs:326:33
+  --> $DIR/bad-reg.rs:318:33
    |
 LL |         asm!("", out("vs59") _, out("v27") _);
    |                  -------------  ^^^^^^^^^^^^ register `v27`
@@ -669,7 +669,7 @@ LL |         asm!("", out("vs59") _, out("v27") _);
    |                  register `vs59`
 
 error: register `v28` conflicts with register `vs60`
-  --> $DIR/bad-reg.rs:328:33
+  --> $DIR/bad-reg.rs:320:33
    |
 LL |         asm!("", out("vs60") _, out("v28") _);
    |                  -------------  ^^^^^^^^^^^^ register `v28`
@@ -677,7 +677,7 @@ LL |         asm!("", out("vs60") _, out("v28") _);
    |                  register `vs60`
 
 error: register `v29` conflicts with register `vs61`
-  --> $DIR/bad-reg.rs:330:33
+  --> $DIR/bad-reg.rs:322:33
    |
 LL |         asm!("", out("vs61") _, out("v29") _);
    |                  -------------  ^^^^^^^^^^^^ register `v29`
@@ -685,7 +685,7 @@ LL |         asm!("", out("vs61") _, out("v29") _);
    |                  register `vs61`
 
 error: register `v30` conflicts with register `vs62`
-  --> $DIR/bad-reg.rs:332:33
+  --> $DIR/bad-reg.rs:324:33
    |
 LL |         asm!("", out("vs62") _, out("v30") _);
    |                  -------------  ^^^^^^^^^^^^ register `v30`
@@ -693,7 +693,7 @@ LL |         asm!("", out("vs62") _, out("v30") _);
    |                  register `vs62`
 
 error: register `v31` conflicts with register `vs63`
-  --> $DIR/bad-reg.rs:334:33
+  --> $DIR/bad-reg.rs:326:33
    |
 LL |         asm!("", out("vs63") _, out("v31") _);
    |                  -------------  ^^^^^^^^^^^^ register `v31`
@@ -701,19 +701,19 @@ LL |         asm!("", out("vs63") _, out("v31") _);
    |                  register `vs63`
 
 error: register class `spe_acc` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:340:26
+  --> $DIR/bad-reg.rs:332:26
    |
 LL |         asm!("/* {} */", out(spe_acc) _);
    |                          ^^^^^^^^^^^^^^
 
 error: cannot use register `r13`: r13 is a reserved register on this target
-  --> $DIR/bad-reg.rs:42:18
+  --> $DIR/bad-reg.rs:35:18
    |
 LL |         asm!("", out("r13") _);
    |                  ^^^^^^^^^^^^
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:65:27
+  --> $DIR/bad-reg.rs:58:27
    |
 LL |         asm!("", in("v0") x); // FIXME: should be ok if vsx is available
    |                           ^
@@ -721,7 +721,7 @@ LL |         asm!("", in("v0") x); // FIXME: should be ok if vsx is available
    = note: register class `vreg` supports these types: i8x16, i16x8, i32x4, f32x4, f32, f64, i64x2, f64x2
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:68:28
+  --> $DIR/bad-reg.rs:61:28
    |
 LL |         asm!("", out("v0") x); // FIXME: should be ok if vsx is available
    |                            ^
@@ -729,7 +729,7 @@ LL |         asm!("", out("v0") x); // FIXME: should be ok if vsx is available
    = note: register class `vreg` supports these types: i8x16, i16x8, i32x4, f32x4, f32, f64, i64x2, f64x2
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:76:35
+  --> $DIR/bad-reg.rs:69:35
    |
 LL |         asm!("/* {} */", in(vreg) x); // FIXME: should be ok if vsx is available
    |                                   ^
@@ -737,7 +737,7 @@ LL |         asm!("/* {} */", in(vreg) x); // FIXME: should be ok if vsx is avai
    = note: register class `vreg` supports these types: i8x16, i16x8, i32x4, f32x4, f32, f64, i64x2, f64x2
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:106:28
+  --> $DIR/bad-reg.rs:98:28
    |
 LL |         asm!("", in("vs0") x); // FIXME: should be ok if vsx is available
    |                            ^
@@ -745,7 +745,7 @@ LL |         asm!("", in("vs0") x); // FIXME: should be ok if vsx is available
    = note: register class `vsreg` supports these types: f32, f64, i8x16, i16x8, i32x4, i64x2, f32x4, f64x2
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:109:29
+  --> $DIR/bad-reg.rs:101:29
    |
 LL |         asm!("", out("vs0") x); // FIXME: should be ok if vsx is available
    |                             ^
@@ -753,7 +753,7 @@ LL |         asm!("", out("vs0") x); // FIXME: should be ok if vsx is available
    = note: register class `vsreg` supports these types: f32, f64, i8x16, i16x8, i32x4, i64x2, f32x4, f64x2
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:116:36
+  --> $DIR/bad-reg.rs:108:36
    |
 LL |         asm!("/* {} */", in(vsreg) x); // FIXME: should be ok if vsx is available
    |                                    ^
@@ -761,7 +761,7 @@ LL |         asm!("/* {} */", in(vsreg) x); // FIXME: should be ok if vsx is ava
    = note: register class `vsreg` supports these types: f32, f64, i8x16, i16x8, i32x4, i64x2, f32x4, f64x2
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:139:27
+  --> $DIR/bad-reg.rs:131:27
    |
 LL |         asm!("", in("cr") x);
    |                           ^
@@ -769,7 +769,7 @@ LL |         asm!("", in("cr") x);
    = note: register class `cr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:142:28
+  --> $DIR/bad-reg.rs:134:28
    |
 LL |         asm!("", out("cr") x);
    |                            ^
@@ -777,7 +777,7 @@ LL |         asm!("", out("cr") x);
    = note: register class `cr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:145:33
+  --> $DIR/bad-reg.rs:137:33
    |
 LL |         asm!("/* {} */", in(cr) x);
    |                                 ^
@@ -785,7 +785,7 @@ LL |         asm!("/* {} */", in(cr) x);
    = note: register class `cr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:152:28
+  --> $DIR/bad-reg.rs:144:28
    |
 LL |         asm!("", in("ctr") x);
    |                            ^
@@ -793,7 +793,7 @@ LL |         asm!("", in("ctr") x);
    = note: register class `ctr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:155:29
+  --> $DIR/bad-reg.rs:147:29
    |
 LL |         asm!("", out("ctr") x);
    |                             ^
@@ -801,7 +801,7 @@ LL |         asm!("", out("ctr") x);
    = note: register class `ctr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:158:34
+  --> $DIR/bad-reg.rs:150:34
    |
 LL |         asm!("/* {} */", in(ctr) x);
    |                                  ^
@@ -809,7 +809,7 @@ LL |         asm!("/* {} */", in(ctr) x);
    = note: register class `ctr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:165:27
+  --> $DIR/bad-reg.rs:157:27
    |
 LL |         asm!("", in("lr") x);
    |                           ^
@@ -817,7 +817,7 @@ LL |         asm!("", in("lr") x);
    = note: register class `lr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:168:28
+  --> $DIR/bad-reg.rs:160:28
    |
 LL |         asm!("", out("lr") x);
    |                            ^
@@ -825,7 +825,7 @@ LL |         asm!("", out("lr") x);
    = note: register class `lr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:171:33
+  --> $DIR/bad-reg.rs:163:33
    |
 LL |         asm!("/* {} */", in(lr) x);
    |                                 ^
@@ -833,7 +833,7 @@ LL |         asm!("/* {} */", in(lr) x);
    = note: register class `lr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:178:28
+  --> $DIR/bad-reg.rs:170:28
    |
 LL |         asm!("", in("xer") x);
    |                            ^
@@ -841,7 +841,7 @@ LL |         asm!("", in("xer") x);
    = note: register class `xer` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:181:29
+  --> $DIR/bad-reg.rs:173:29
    |
 LL |         asm!("", out("xer") x);
    |                             ^
@@ -849,7 +849,7 @@ LL |         asm!("", out("xer") x);
    = note: register class `xer` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:184:34
+  --> $DIR/bad-reg.rs:176:34
    |
 LL |         asm!("/* {} */", in(xer) x);
    |                                  ^
@@ -857,7 +857,7 @@ LL |         asm!("/* {} */", in(xer) x);
    = note: register class `xer` supports these types: 
 
 error: cannot use register `spe_acc`: spe_acc is only available on spe targets
-  --> $DIR/bad-reg.rs:338:18
+  --> $DIR/bad-reg.rs:330:18
    |
 LL |         asm!("", out("spe_acc") _);
    |                  ^^^^^^^^^^^^^^^^

--- a/tests/ui/asm/powerpc/bad-reg.powerpc.stderr
+++ b/tests/ui/asm/powerpc/bad-reg.powerpc.stderr
@@ -1,131 +1,131 @@
 error: invalid register `sp`: the stack pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:38:18
+  --> $DIR/bad-reg.rs:31:18
    |
 LL |         asm!("", out("sp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `r2`: r2 is a system reserved register and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:40:18
+  --> $DIR/bad-reg.rs:33:18
    |
 LL |         asm!("", out("r2") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `r30`: r30 is used internally by LLVM and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:46:18
+  --> $DIR/bad-reg.rs:39:18
    |
 LL |         asm!("", out("r30") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `fp`: the frame pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:48:18
+  --> $DIR/bad-reg.rs:41:18
    |
 LL |         asm!("", out("fp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `vrsave`: the vrsave register cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:50:18
+  --> $DIR/bad-reg.rs:43:18
    |
 LL |         asm!("", out("vrsave") _);
    |                  ^^^^^^^^^^^^^^^
 
 error: register class `cr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:139:18
+  --> $DIR/bad-reg.rs:131:18
    |
 LL |         asm!("", in("cr") x);
    |                  ^^^^^^^^^^
 
 error: register class `cr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:142:18
+  --> $DIR/bad-reg.rs:134:18
    |
 LL |         asm!("", out("cr") x);
    |                  ^^^^^^^^^^^
 
 error: register class `cr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:145:26
+  --> $DIR/bad-reg.rs:137:26
    |
 LL |         asm!("/* {} */", in(cr) x);
    |                          ^^^^^^^^
 
 error: register class `cr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:148:26
+  --> $DIR/bad-reg.rs:140:26
    |
 LL |         asm!("/* {} */", out(cr) _);
    |                          ^^^^^^^^^
 
 error: register class `ctr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:152:18
+  --> $DIR/bad-reg.rs:144:18
    |
 LL |         asm!("", in("ctr") x);
    |                  ^^^^^^^^^^^
 
 error: register class `ctr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:155:18
+  --> $DIR/bad-reg.rs:147:18
    |
 LL |         asm!("", out("ctr") x);
    |                  ^^^^^^^^^^^^
 
 error: register class `ctr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:158:26
+  --> $DIR/bad-reg.rs:150:26
    |
 LL |         asm!("/* {} */", in(ctr) x);
    |                          ^^^^^^^^^
 
 error: register class `ctr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:161:26
+  --> $DIR/bad-reg.rs:153:26
    |
 LL |         asm!("/* {} */", out(ctr) _);
    |                          ^^^^^^^^^^
 
 error: register class `lr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:165:18
+  --> $DIR/bad-reg.rs:157:18
    |
 LL |         asm!("", in("lr") x);
    |                  ^^^^^^^^^^
 
 error: register class `lr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:168:18
+  --> $DIR/bad-reg.rs:160:18
    |
 LL |         asm!("", out("lr") x);
    |                  ^^^^^^^^^^^
 
 error: register class `lr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:171:26
+  --> $DIR/bad-reg.rs:163:26
    |
 LL |         asm!("/* {} */", in(lr) x);
    |                          ^^^^^^^^
 
 error: register class `lr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:174:26
+  --> $DIR/bad-reg.rs:166:26
    |
 LL |         asm!("/* {} */", out(lr) _);
    |                          ^^^^^^^^^
 
 error: register class `xer` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:178:18
+  --> $DIR/bad-reg.rs:170:18
    |
 LL |         asm!("", in("xer") x);
    |                  ^^^^^^^^^^^
 
 error: register class `xer` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:181:18
+  --> $DIR/bad-reg.rs:173:18
    |
 LL |         asm!("", out("xer") x);
    |                  ^^^^^^^^^^^^
 
 error: register class `xer` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:184:26
+  --> $DIR/bad-reg.rs:176:26
    |
 LL |         asm!("/* {} */", in(xer) x);
    |                          ^^^^^^^^^
 
 error: register class `xer` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:187:26
+  --> $DIR/bad-reg.rs:179:26
    |
 LL |         asm!("/* {} */", out(xer) _);
    |                          ^^^^^^^^^^
 
 error: register `cr0` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:191:31
+  --> $DIR/bad-reg.rs:183:31
    |
 LL |         asm!("", out("cr") _, out("cr0") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr0`
@@ -133,7 +133,7 @@ LL |         asm!("", out("cr") _, out("cr0") _);
    |                  register `cr`
 
 error: register `cr1` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:193:31
+  --> $DIR/bad-reg.rs:185:31
    |
 LL |         asm!("", out("cr") _, out("cr1") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr1`
@@ -141,7 +141,7 @@ LL |         asm!("", out("cr") _, out("cr1") _);
    |                  register `cr`
 
 error: register `cr2` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:195:31
+  --> $DIR/bad-reg.rs:187:31
    |
 LL |         asm!("", out("cr") _, out("cr2") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr2`
@@ -149,7 +149,7 @@ LL |         asm!("", out("cr") _, out("cr2") _);
    |                  register `cr`
 
 error: register `cr3` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:197:31
+  --> $DIR/bad-reg.rs:189:31
    |
 LL |         asm!("", out("cr") _, out("cr3") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr3`
@@ -157,7 +157,7 @@ LL |         asm!("", out("cr") _, out("cr3") _);
    |                  register `cr`
 
 error: register `cr4` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:199:31
+  --> $DIR/bad-reg.rs:191:31
    |
 LL |         asm!("", out("cr") _, out("cr4") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr4`
@@ -165,7 +165,7 @@ LL |         asm!("", out("cr") _, out("cr4") _);
    |                  register `cr`
 
 error: register `cr5` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:201:31
+  --> $DIR/bad-reg.rs:193:31
    |
 LL |         asm!("", out("cr") _, out("cr5") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr5`
@@ -173,7 +173,7 @@ LL |         asm!("", out("cr") _, out("cr5") _);
    |                  register `cr`
 
 error: register `cr6` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:203:31
+  --> $DIR/bad-reg.rs:195:31
    |
 LL |         asm!("", out("cr") _, out("cr6") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr6`
@@ -181,7 +181,7 @@ LL |         asm!("", out("cr") _, out("cr6") _);
    |                  register `cr`
 
 error: register `cr7` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:205:31
+  --> $DIR/bad-reg.rs:197:31
    |
 LL |         asm!("", out("cr") _, out("cr7") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr7`
@@ -189,7 +189,7 @@ LL |         asm!("", out("cr") _, out("cr7") _);
    |                  register `cr`
 
 error: register `vs0` conflicts with register `f0`
-  --> $DIR/bad-reg.rs:208:31
+  --> $DIR/bad-reg.rs:200:31
    |
 LL |         asm!("", out("f0") _, out("vs0") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs0`
@@ -197,7 +197,7 @@ LL |         asm!("", out("f0") _, out("vs0") _);
    |                  register `f0`
 
 error: register `vs1` conflicts with register `f1`
-  --> $DIR/bad-reg.rs:210:31
+  --> $DIR/bad-reg.rs:202:31
    |
 LL |         asm!("", out("f1") _, out("vs1") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs1`
@@ -205,7 +205,7 @@ LL |         asm!("", out("f1") _, out("vs1") _);
    |                  register `f1`
 
 error: register `vs2` conflicts with register `f2`
-  --> $DIR/bad-reg.rs:212:31
+  --> $DIR/bad-reg.rs:204:31
    |
 LL |         asm!("", out("f2") _, out("vs2") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs2`
@@ -213,7 +213,7 @@ LL |         asm!("", out("f2") _, out("vs2") _);
    |                  register `f2`
 
 error: register `vs3` conflicts with register `f3`
-  --> $DIR/bad-reg.rs:214:31
+  --> $DIR/bad-reg.rs:206:31
    |
 LL |         asm!("", out("f3") _, out("vs3") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs3`
@@ -221,7 +221,7 @@ LL |         asm!("", out("f3") _, out("vs3") _);
    |                  register `f3`
 
 error: register `vs4` conflicts with register `f4`
-  --> $DIR/bad-reg.rs:216:31
+  --> $DIR/bad-reg.rs:208:31
    |
 LL |         asm!("", out("f4") _, out("vs4") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs4`
@@ -229,7 +229,7 @@ LL |         asm!("", out("f4") _, out("vs4") _);
    |                  register `f4`
 
 error: register `vs5` conflicts with register `f5`
-  --> $DIR/bad-reg.rs:218:31
+  --> $DIR/bad-reg.rs:210:31
    |
 LL |         asm!("", out("f5") _, out("vs5") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs5`
@@ -237,7 +237,7 @@ LL |         asm!("", out("f5") _, out("vs5") _);
    |                  register `f5`
 
 error: register `vs6` conflicts with register `f6`
-  --> $DIR/bad-reg.rs:220:31
+  --> $DIR/bad-reg.rs:212:31
    |
 LL |         asm!("", out("f6") _, out("vs6") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs6`
@@ -245,7 +245,7 @@ LL |         asm!("", out("f6") _, out("vs6") _);
    |                  register `f6`
 
 error: register `vs7` conflicts with register `f7`
-  --> $DIR/bad-reg.rs:222:31
+  --> $DIR/bad-reg.rs:214:31
    |
 LL |         asm!("", out("f7") _, out("vs7") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs7`
@@ -253,7 +253,7 @@ LL |         asm!("", out("f7") _, out("vs7") _);
    |                  register `f7`
 
 error: register `vs8` conflicts with register `f8`
-  --> $DIR/bad-reg.rs:224:31
+  --> $DIR/bad-reg.rs:216:31
    |
 LL |         asm!("", out("f8") _, out("vs8") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs8`
@@ -261,7 +261,7 @@ LL |         asm!("", out("f8") _, out("vs8") _);
    |                  register `f8`
 
 error: register `vs9` conflicts with register `f9`
-  --> $DIR/bad-reg.rs:226:31
+  --> $DIR/bad-reg.rs:218:31
    |
 LL |         asm!("", out("f9") _, out("vs9") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs9`
@@ -269,7 +269,7 @@ LL |         asm!("", out("f9") _, out("vs9") _);
    |                  register `f9`
 
 error: register `vs10` conflicts with register `f10`
-  --> $DIR/bad-reg.rs:228:32
+  --> $DIR/bad-reg.rs:220:32
    |
 LL |         asm!("", out("f10") _, out("vs10") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs10`
@@ -277,7 +277,7 @@ LL |         asm!("", out("f10") _, out("vs10") _);
    |                  register `f10`
 
 error: register `vs11` conflicts with register `f11`
-  --> $DIR/bad-reg.rs:230:32
+  --> $DIR/bad-reg.rs:222:32
    |
 LL |         asm!("", out("f11") _, out("vs11") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs11`
@@ -285,7 +285,7 @@ LL |         asm!("", out("f11") _, out("vs11") _);
    |                  register `f11`
 
 error: register `vs12` conflicts with register `f12`
-  --> $DIR/bad-reg.rs:232:32
+  --> $DIR/bad-reg.rs:224:32
    |
 LL |         asm!("", out("f12") _, out("vs12") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs12`
@@ -293,7 +293,7 @@ LL |         asm!("", out("f12") _, out("vs12") _);
    |                  register `f12`
 
 error: register `vs13` conflicts with register `f13`
-  --> $DIR/bad-reg.rs:234:32
+  --> $DIR/bad-reg.rs:226:32
    |
 LL |         asm!("", out("f13") _, out("vs13") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs13`
@@ -301,7 +301,7 @@ LL |         asm!("", out("f13") _, out("vs13") _);
    |                  register `f13`
 
 error: register `vs14` conflicts with register `f14`
-  --> $DIR/bad-reg.rs:236:32
+  --> $DIR/bad-reg.rs:228:32
    |
 LL |         asm!("", out("f14") _, out("vs14") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs14`
@@ -309,7 +309,7 @@ LL |         asm!("", out("f14") _, out("vs14") _);
    |                  register `f14`
 
 error: register `vs15` conflicts with register `f15`
-  --> $DIR/bad-reg.rs:238:32
+  --> $DIR/bad-reg.rs:230:32
    |
 LL |         asm!("", out("f15") _, out("vs15") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs15`
@@ -317,7 +317,7 @@ LL |         asm!("", out("f15") _, out("vs15") _);
    |                  register `f15`
 
 error: register `vs16` conflicts with register `f16`
-  --> $DIR/bad-reg.rs:240:32
+  --> $DIR/bad-reg.rs:232:32
    |
 LL |         asm!("", out("f16") _, out("vs16") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs16`
@@ -325,7 +325,7 @@ LL |         asm!("", out("f16") _, out("vs16") _);
    |                  register `f16`
 
 error: register `vs17` conflicts with register `f17`
-  --> $DIR/bad-reg.rs:242:32
+  --> $DIR/bad-reg.rs:234:32
    |
 LL |         asm!("", out("f17") _, out("vs17") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs17`
@@ -333,7 +333,7 @@ LL |         asm!("", out("f17") _, out("vs17") _);
    |                  register `f17`
 
 error: register `vs18` conflicts with register `f18`
-  --> $DIR/bad-reg.rs:244:32
+  --> $DIR/bad-reg.rs:236:32
    |
 LL |         asm!("", out("f18") _, out("vs18") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs18`
@@ -341,7 +341,7 @@ LL |         asm!("", out("f18") _, out("vs18") _);
    |                  register `f18`
 
 error: register `vs19` conflicts with register `f19`
-  --> $DIR/bad-reg.rs:246:32
+  --> $DIR/bad-reg.rs:238:32
    |
 LL |         asm!("", out("f19") _, out("vs19") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs19`
@@ -349,7 +349,7 @@ LL |         asm!("", out("f19") _, out("vs19") _);
    |                  register `f19`
 
 error: register `vs20` conflicts with register `f20`
-  --> $DIR/bad-reg.rs:248:32
+  --> $DIR/bad-reg.rs:240:32
    |
 LL |         asm!("", out("f20") _, out("vs20") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs20`
@@ -357,7 +357,7 @@ LL |         asm!("", out("f20") _, out("vs20") _);
    |                  register `f20`
 
 error: register `vs21` conflicts with register `f21`
-  --> $DIR/bad-reg.rs:250:32
+  --> $DIR/bad-reg.rs:242:32
    |
 LL |         asm!("", out("f21") _, out("vs21") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs21`
@@ -365,7 +365,7 @@ LL |         asm!("", out("f21") _, out("vs21") _);
    |                  register `f21`
 
 error: register `vs22` conflicts with register `f22`
-  --> $DIR/bad-reg.rs:252:32
+  --> $DIR/bad-reg.rs:244:32
    |
 LL |         asm!("", out("f22") _, out("vs22") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs22`
@@ -373,7 +373,7 @@ LL |         asm!("", out("f22") _, out("vs22") _);
    |                  register `f22`
 
 error: register `vs23` conflicts with register `f23`
-  --> $DIR/bad-reg.rs:254:32
+  --> $DIR/bad-reg.rs:246:32
    |
 LL |         asm!("", out("f23") _, out("vs23") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs23`
@@ -381,7 +381,7 @@ LL |         asm!("", out("f23") _, out("vs23") _);
    |                  register `f23`
 
 error: register `vs24` conflicts with register `f24`
-  --> $DIR/bad-reg.rs:256:32
+  --> $DIR/bad-reg.rs:248:32
    |
 LL |         asm!("", out("f24") _, out("vs24") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs24`
@@ -389,7 +389,7 @@ LL |         asm!("", out("f24") _, out("vs24") _);
    |                  register `f24`
 
 error: register `vs25` conflicts with register `f25`
-  --> $DIR/bad-reg.rs:258:32
+  --> $DIR/bad-reg.rs:250:32
    |
 LL |         asm!("", out("f25") _, out("vs25") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs25`
@@ -397,7 +397,7 @@ LL |         asm!("", out("f25") _, out("vs25") _);
    |                  register `f25`
 
 error: register `vs26` conflicts with register `f26`
-  --> $DIR/bad-reg.rs:260:32
+  --> $DIR/bad-reg.rs:252:32
    |
 LL |         asm!("", out("f26") _, out("vs26") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs26`
@@ -405,7 +405,7 @@ LL |         asm!("", out("f26") _, out("vs26") _);
    |                  register `f26`
 
 error: register `vs27` conflicts with register `f27`
-  --> $DIR/bad-reg.rs:262:32
+  --> $DIR/bad-reg.rs:254:32
    |
 LL |         asm!("", out("f27") _, out("vs27") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs27`
@@ -413,7 +413,7 @@ LL |         asm!("", out("f27") _, out("vs27") _);
    |                  register `f27`
 
 error: register `vs28` conflicts with register `f28`
-  --> $DIR/bad-reg.rs:264:32
+  --> $DIR/bad-reg.rs:256:32
    |
 LL |         asm!("", out("f28") _, out("vs28") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs28`
@@ -421,7 +421,7 @@ LL |         asm!("", out("f28") _, out("vs28") _);
    |                  register `f28`
 
 error: register `vs29` conflicts with register `f29`
-  --> $DIR/bad-reg.rs:266:32
+  --> $DIR/bad-reg.rs:258:32
    |
 LL |         asm!("", out("f29") _, out("vs29") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs29`
@@ -429,7 +429,7 @@ LL |         asm!("", out("f29") _, out("vs29") _);
    |                  register `f29`
 
 error: register `vs30` conflicts with register `f30`
-  --> $DIR/bad-reg.rs:268:32
+  --> $DIR/bad-reg.rs:260:32
    |
 LL |         asm!("", out("f30") _, out("vs30") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs30`
@@ -437,7 +437,7 @@ LL |         asm!("", out("f30") _, out("vs30") _);
    |                  register `f30`
 
 error: register `vs31` conflicts with register `f31`
-  --> $DIR/bad-reg.rs:270:32
+  --> $DIR/bad-reg.rs:262:32
    |
 LL |         asm!("", out("f31") _, out("vs31") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs31`
@@ -445,7 +445,7 @@ LL |         asm!("", out("f31") _, out("vs31") _);
    |                  register `f31`
 
 error: register `v0` conflicts with register `vs32`
-  --> $DIR/bad-reg.rs:272:33
+  --> $DIR/bad-reg.rs:264:33
    |
 LL |         asm!("", out("vs32") _, out("v0") _);
    |                  -------------  ^^^^^^^^^^^ register `v0`
@@ -453,7 +453,7 @@ LL |         asm!("", out("vs32") _, out("v0") _);
    |                  register `vs32`
 
 error: register `v1` conflicts with register `vs33`
-  --> $DIR/bad-reg.rs:274:33
+  --> $DIR/bad-reg.rs:266:33
    |
 LL |         asm!("", out("vs33") _, out("v1") _);
    |                  -------------  ^^^^^^^^^^^ register `v1`
@@ -461,7 +461,7 @@ LL |         asm!("", out("vs33") _, out("v1") _);
    |                  register `vs33`
 
 error: register `v2` conflicts with register `vs34`
-  --> $DIR/bad-reg.rs:276:33
+  --> $DIR/bad-reg.rs:268:33
    |
 LL |         asm!("", out("vs34") _, out("v2") _);
    |                  -------------  ^^^^^^^^^^^ register `v2`
@@ -469,7 +469,7 @@ LL |         asm!("", out("vs34") _, out("v2") _);
    |                  register `vs34`
 
 error: register `v3` conflicts with register `vs35`
-  --> $DIR/bad-reg.rs:278:33
+  --> $DIR/bad-reg.rs:270:33
    |
 LL |         asm!("", out("vs35") _, out("v3") _);
    |                  -------------  ^^^^^^^^^^^ register `v3`
@@ -477,7 +477,7 @@ LL |         asm!("", out("vs35") _, out("v3") _);
    |                  register `vs35`
 
 error: register `v4` conflicts with register `vs36`
-  --> $DIR/bad-reg.rs:280:33
+  --> $DIR/bad-reg.rs:272:33
    |
 LL |         asm!("", out("vs36") _, out("v4") _);
    |                  -------------  ^^^^^^^^^^^ register `v4`
@@ -485,7 +485,7 @@ LL |         asm!("", out("vs36") _, out("v4") _);
    |                  register `vs36`
 
 error: register `v5` conflicts with register `vs37`
-  --> $DIR/bad-reg.rs:282:33
+  --> $DIR/bad-reg.rs:274:33
    |
 LL |         asm!("", out("vs37") _, out("v5") _);
    |                  -------------  ^^^^^^^^^^^ register `v5`
@@ -493,7 +493,7 @@ LL |         asm!("", out("vs37") _, out("v5") _);
    |                  register `vs37`
 
 error: register `v6` conflicts with register `vs38`
-  --> $DIR/bad-reg.rs:284:33
+  --> $DIR/bad-reg.rs:276:33
    |
 LL |         asm!("", out("vs38") _, out("v6") _);
    |                  -------------  ^^^^^^^^^^^ register `v6`
@@ -501,7 +501,7 @@ LL |         asm!("", out("vs38") _, out("v6") _);
    |                  register `vs38`
 
 error: register `v7` conflicts with register `vs39`
-  --> $DIR/bad-reg.rs:286:33
+  --> $DIR/bad-reg.rs:278:33
    |
 LL |         asm!("", out("vs39") _, out("v7") _);
    |                  -------------  ^^^^^^^^^^^ register `v7`
@@ -509,7 +509,7 @@ LL |         asm!("", out("vs39") _, out("v7") _);
    |                  register `vs39`
 
 error: register `v8` conflicts with register `vs40`
-  --> $DIR/bad-reg.rs:288:33
+  --> $DIR/bad-reg.rs:280:33
    |
 LL |         asm!("", out("vs40") _, out("v8") _);
    |                  -------------  ^^^^^^^^^^^ register `v8`
@@ -517,7 +517,7 @@ LL |         asm!("", out("vs40") _, out("v8") _);
    |                  register `vs40`
 
 error: register `v9` conflicts with register `vs41`
-  --> $DIR/bad-reg.rs:290:33
+  --> $DIR/bad-reg.rs:282:33
    |
 LL |         asm!("", out("vs41") _, out("v9") _);
    |                  -------------  ^^^^^^^^^^^ register `v9`
@@ -525,7 +525,7 @@ LL |         asm!("", out("vs41") _, out("v9") _);
    |                  register `vs41`
 
 error: register `v10` conflicts with register `vs42`
-  --> $DIR/bad-reg.rs:292:33
+  --> $DIR/bad-reg.rs:284:33
    |
 LL |         asm!("", out("vs42") _, out("v10") _);
    |                  -------------  ^^^^^^^^^^^^ register `v10`
@@ -533,7 +533,7 @@ LL |         asm!("", out("vs42") _, out("v10") _);
    |                  register `vs42`
 
 error: register `v11` conflicts with register `vs43`
-  --> $DIR/bad-reg.rs:294:33
+  --> $DIR/bad-reg.rs:286:33
    |
 LL |         asm!("", out("vs43") _, out("v11") _);
    |                  -------------  ^^^^^^^^^^^^ register `v11`
@@ -541,7 +541,7 @@ LL |         asm!("", out("vs43") _, out("v11") _);
    |                  register `vs43`
 
 error: register `v12` conflicts with register `vs44`
-  --> $DIR/bad-reg.rs:296:33
+  --> $DIR/bad-reg.rs:288:33
    |
 LL |         asm!("", out("vs44") _, out("v12") _);
    |                  -------------  ^^^^^^^^^^^^ register `v12`
@@ -549,7 +549,7 @@ LL |         asm!("", out("vs44") _, out("v12") _);
    |                  register `vs44`
 
 error: register `v13` conflicts with register `vs45`
-  --> $DIR/bad-reg.rs:298:33
+  --> $DIR/bad-reg.rs:290:33
    |
 LL |         asm!("", out("vs45") _, out("v13") _);
    |                  -------------  ^^^^^^^^^^^^ register `v13`
@@ -557,7 +557,7 @@ LL |         asm!("", out("vs45") _, out("v13") _);
    |                  register `vs45`
 
 error: register `v14` conflicts with register `vs46`
-  --> $DIR/bad-reg.rs:300:33
+  --> $DIR/bad-reg.rs:292:33
    |
 LL |         asm!("", out("vs46") _, out("v14") _);
    |                  -------------  ^^^^^^^^^^^^ register `v14`
@@ -565,7 +565,7 @@ LL |         asm!("", out("vs46") _, out("v14") _);
    |                  register `vs46`
 
 error: register `v15` conflicts with register `vs47`
-  --> $DIR/bad-reg.rs:302:33
+  --> $DIR/bad-reg.rs:294:33
    |
 LL |         asm!("", out("vs47") _, out("v15") _);
    |                  -------------  ^^^^^^^^^^^^ register `v15`
@@ -573,7 +573,7 @@ LL |         asm!("", out("vs47") _, out("v15") _);
    |                  register `vs47`
 
 error: register `v16` conflicts with register `vs48`
-  --> $DIR/bad-reg.rs:304:33
+  --> $DIR/bad-reg.rs:296:33
    |
 LL |         asm!("", out("vs48") _, out("v16") _);
    |                  -------------  ^^^^^^^^^^^^ register `v16`
@@ -581,7 +581,7 @@ LL |         asm!("", out("vs48") _, out("v16") _);
    |                  register `vs48`
 
 error: register `v17` conflicts with register `vs49`
-  --> $DIR/bad-reg.rs:306:33
+  --> $DIR/bad-reg.rs:298:33
    |
 LL |         asm!("", out("vs49") _, out("v17") _);
    |                  -------------  ^^^^^^^^^^^^ register `v17`
@@ -589,7 +589,7 @@ LL |         asm!("", out("vs49") _, out("v17") _);
    |                  register `vs49`
 
 error: register `v18` conflicts with register `vs50`
-  --> $DIR/bad-reg.rs:308:33
+  --> $DIR/bad-reg.rs:300:33
    |
 LL |         asm!("", out("vs50") _, out("v18") _);
    |                  -------------  ^^^^^^^^^^^^ register `v18`
@@ -597,7 +597,7 @@ LL |         asm!("", out("vs50") _, out("v18") _);
    |                  register `vs50`
 
 error: register `v19` conflicts with register `vs51`
-  --> $DIR/bad-reg.rs:310:33
+  --> $DIR/bad-reg.rs:302:33
    |
 LL |         asm!("", out("vs51") _, out("v19") _);
    |                  -------------  ^^^^^^^^^^^^ register `v19`
@@ -605,7 +605,7 @@ LL |         asm!("", out("vs51") _, out("v19") _);
    |                  register `vs51`
 
 error: register `v20` conflicts with register `vs52`
-  --> $DIR/bad-reg.rs:312:33
+  --> $DIR/bad-reg.rs:304:33
    |
 LL |         asm!("", out("vs52") _, out("v20") _);
    |                  -------------  ^^^^^^^^^^^^ register `v20`
@@ -613,7 +613,7 @@ LL |         asm!("", out("vs52") _, out("v20") _);
    |                  register `vs52`
 
 error: register `v21` conflicts with register `vs53`
-  --> $DIR/bad-reg.rs:314:33
+  --> $DIR/bad-reg.rs:306:33
    |
 LL |         asm!("", out("vs53") _, out("v21") _);
    |                  -------------  ^^^^^^^^^^^^ register `v21`
@@ -621,7 +621,7 @@ LL |         asm!("", out("vs53") _, out("v21") _);
    |                  register `vs53`
 
 error: register `v22` conflicts with register `vs54`
-  --> $DIR/bad-reg.rs:316:33
+  --> $DIR/bad-reg.rs:308:33
    |
 LL |         asm!("", out("vs54") _, out("v22") _);
    |                  -------------  ^^^^^^^^^^^^ register `v22`
@@ -629,7 +629,7 @@ LL |         asm!("", out("vs54") _, out("v22") _);
    |                  register `vs54`
 
 error: register `v23` conflicts with register `vs55`
-  --> $DIR/bad-reg.rs:318:33
+  --> $DIR/bad-reg.rs:310:33
    |
 LL |         asm!("", out("vs55") _, out("v23") _);
    |                  -------------  ^^^^^^^^^^^^ register `v23`
@@ -637,7 +637,7 @@ LL |         asm!("", out("vs55") _, out("v23") _);
    |                  register `vs55`
 
 error: register `v24` conflicts with register `vs56`
-  --> $DIR/bad-reg.rs:320:33
+  --> $DIR/bad-reg.rs:312:33
    |
 LL |         asm!("", out("vs56") _, out("v24") _);
    |                  -------------  ^^^^^^^^^^^^ register `v24`
@@ -645,7 +645,7 @@ LL |         asm!("", out("vs56") _, out("v24") _);
    |                  register `vs56`
 
 error: register `v25` conflicts with register `vs57`
-  --> $DIR/bad-reg.rs:322:33
+  --> $DIR/bad-reg.rs:314:33
    |
 LL |         asm!("", out("vs57") _, out("v25") _);
    |                  -------------  ^^^^^^^^^^^^ register `v25`
@@ -653,7 +653,7 @@ LL |         asm!("", out("vs57") _, out("v25") _);
    |                  register `vs57`
 
 error: register `v26` conflicts with register `vs58`
-  --> $DIR/bad-reg.rs:324:33
+  --> $DIR/bad-reg.rs:316:33
    |
 LL |         asm!("", out("vs58") _, out("v26") _);
    |                  -------------  ^^^^^^^^^^^^ register `v26`
@@ -661,7 +661,7 @@ LL |         asm!("", out("vs58") _, out("v26") _);
    |                  register `vs58`
 
 error: register `v27` conflicts with register `vs59`
-  --> $DIR/bad-reg.rs:326:33
+  --> $DIR/bad-reg.rs:318:33
    |
 LL |         asm!("", out("vs59") _, out("v27") _);
    |                  -------------  ^^^^^^^^^^^^ register `v27`
@@ -669,7 +669,7 @@ LL |         asm!("", out("vs59") _, out("v27") _);
    |                  register `vs59`
 
 error: register `v28` conflicts with register `vs60`
-  --> $DIR/bad-reg.rs:328:33
+  --> $DIR/bad-reg.rs:320:33
    |
 LL |         asm!("", out("vs60") _, out("v28") _);
    |                  -------------  ^^^^^^^^^^^^ register `v28`
@@ -677,7 +677,7 @@ LL |         asm!("", out("vs60") _, out("v28") _);
    |                  register `vs60`
 
 error: register `v29` conflicts with register `vs61`
-  --> $DIR/bad-reg.rs:330:33
+  --> $DIR/bad-reg.rs:322:33
    |
 LL |         asm!("", out("vs61") _, out("v29") _);
    |                  -------------  ^^^^^^^^^^^^ register `v29`
@@ -685,7 +685,7 @@ LL |         asm!("", out("vs61") _, out("v29") _);
    |                  register `vs61`
 
 error: register `v30` conflicts with register `vs62`
-  --> $DIR/bad-reg.rs:332:33
+  --> $DIR/bad-reg.rs:324:33
    |
 LL |         asm!("", out("vs62") _, out("v30") _);
    |                  -------------  ^^^^^^^^^^^^ register `v30`
@@ -693,7 +693,7 @@ LL |         asm!("", out("vs62") _, out("v30") _);
    |                  register `vs62`
 
 error: register `v31` conflicts with register `vs63`
-  --> $DIR/bad-reg.rs:334:33
+  --> $DIR/bad-reg.rs:326:33
    |
 LL |         asm!("", out("vs63") _, out("v31") _);
    |                  -------------  ^^^^^^^^^^^^ register `v31`
@@ -701,145 +701,145 @@ LL |         asm!("", out("vs63") _, out("v31") _);
    |                  register `vs63`
 
 error: register class `spe_acc` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:340:26
+  --> $DIR/bad-reg.rs:332:26
    |
 LL |         asm!("/* {} */", out(spe_acc) _);
    |                          ^^^^^^^^^^^^^^
 
 error: cannot use register `r13`: r13 is a reserved register on this target
-  --> $DIR/bad-reg.rs:42:18
+  --> $DIR/bad-reg.rs:35:18
    |
 LL |         asm!("", out("r13") _);
    |                  ^^^^^^^^^^^^
 
 error: cannot use register `r29`: r29 is used internally by LLVM and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:44:18
+  --> $DIR/bad-reg.rs:37:18
    |
 LL |         asm!("", out("r29") _);
    |                  ^^^^^^^^^^^^
 
 error: register class `vreg` requires at least one of the following target features: altivec, vsx
-  --> $DIR/bad-reg.rs:55:18
+  --> $DIR/bad-reg.rs:48:18
    |
 LL |         asm!("", in("v0") v32x4); // requires altivec
    |                  ^^^^^^^^^^^^^^
 
 error: register class `vreg` requires at least one of the following target features: altivec, vsx
-  --> $DIR/bad-reg.rs:57:18
+  --> $DIR/bad-reg.rs:50:18
    |
 LL |         asm!("", out("v0") v32x4); // requires altivec
    |                  ^^^^^^^^^^^^^^^
 
 error: register class `vreg` requires at least one of the following target features: altivec, vsx
-  --> $DIR/bad-reg.rs:59:18
+  --> $DIR/bad-reg.rs:52:18
    |
 LL |         asm!("", in("v0") v64x2); // requires vsx
    |                  ^^^^^^^^^^^^^^
 
 error: register class `vreg` requires at least one of the following target features: altivec, vsx
-  --> $DIR/bad-reg.rs:62:18
+  --> $DIR/bad-reg.rs:55:18
    |
 LL |         asm!("", out("v0") v64x2); // requires vsx
    |                  ^^^^^^^^^^^^^^^
 
 error: register class `vreg` requires at least one of the following target features: altivec, vsx
-  --> $DIR/bad-reg.rs:65:18
+  --> $DIR/bad-reg.rs:58:18
    |
 LL |         asm!("", in("v0") x); // FIXME: should be ok if vsx is available
    |                  ^^^^^^^^^^
 
 error: register class `vreg` requires at least one of the following target features: altivec, vsx
-  --> $DIR/bad-reg.rs:68:18
+  --> $DIR/bad-reg.rs:61:18
    |
 LL |         asm!("", out("v0") x); // FIXME: should be ok if vsx is available
    |                  ^^^^^^^^^^^
 
 error: register class `vreg` requires at least one of the following target features: altivec, vsx
-  --> $DIR/bad-reg.rs:71:26
+  --> $DIR/bad-reg.rs:64:26
    |
 LL |         asm!("/* {} */", in(vreg) v32x4); // requires altivec
    |                          ^^^^^^^^^^^^^^
 
 error: register class `vreg` requires at least one of the following target features: altivec, vsx
-  --> $DIR/bad-reg.rs:73:26
+  --> $DIR/bad-reg.rs:66:26
    |
 LL |         asm!("/* {} */", in(vreg) v64x2); // requires vsx
    |                          ^^^^^^^^^^^^^^
 
 error: register class `vreg` requires at least one of the following target features: altivec, vsx
-  --> $DIR/bad-reg.rs:76:26
+  --> $DIR/bad-reg.rs:69:26
    |
 LL |         asm!("/* {} */", in(vreg) x); // FIXME: should be ok if vsx is available
    |                          ^^^^^^^^^^
 
 error: register class `vreg` requires at least one of the following target features: altivec, vsx
-  --> $DIR/bad-reg.rs:79:26
+  --> $DIR/bad-reg.rs:72:26
    |
 LL |         asm!("/* {} */", out(vreg) _); // requires altivec
    |                          ^^^^^^^^^^^
 
 error: register class `vsreg` requires the `vsx` target feature
-  --> $DIR/bad-reg.rs:98:18
+  --> $DIR/bad-reg.rs:90:18
    |
 LL |         asm!("", in("vs0") v32x4); // requires vsx
    |                  ^^^^^^^^^^^^^^^
 
 error: register class `vsreg` requires the `vsx` target feature
-  --> $DIR/bad-reg.rs:100:18
+  --> $DIR/bad-reg.rs:92:18
    |
 LL |         asm!("", out("vs0") v32x4); // requires vsx
    |                  ^^^^^^^^^^^^^^^^
 
 error: register class `vsreg` requires the `vsx` target feature
-  --> $DIR/bad-reg.rs:102:18
+  --> $DIR/bad-reg.rs:94:18
    |
 LL |         asm!("", in("vs0") v64x2); // requires vsx
    |                  ^^^^^^^^^^^^^^^
 
 error: register class `vsreg` requires the `vsx` target feature
-  --> $DIR/bad-reg.rs:104:18
+  --> $DIR/bad-reg.rs:96:18
    |
 LL |         asm!("", out("vs0") v64x2); // requires vsx
    |                  ^^^^^^^^^^^^^^^^
 
 error: register class `vsreg` requires the `vsx` target feature
-  --> $DIR/bad-reg.rs:106:18
+  --> $DIR/bad-reg.rs:98:18
    |
 LL |         asm!("", in("vs0") x); // FIXME: should be ok if vsx is available
    |                  ^^^^^^^^^^^
 
 error: register class `vsreg` requires the `vsx` target feature
-  --> $DIR/bad-reg.rs:109:18
+  --> $DIR/bad-reg.rs:101:18
    |
 LL |         asm!("", out("vs0") x); // FIXME: should be ok if vsx is available
    |                  ^^^^^^^^^^^^
 
 error: register class `vsreg` requires the `vsx` target feature
-  --> $DIR/bad-reg.rs:112:26
+  --> $DIR/bad-reg.rs:104:26
    |
 LL |         asm!("/* {} */", in(vsreg) v32x4); // requires vsx
    |                          ^^^^^^^^^^^^^^^
 
 error: register class `vsreg` requires the `vsx` target feature
-  --> $DIR/bad-reg.rs:114:26
+  --> $DIR/bad-reg.rs:106:26
    |
 LL |         asm!("/* {} */", in(vsreg) v64x2); // requires vsx
    |                          ^^^^^^^^^^^^^^^
 
 error: register class `vsreg` requires the `vsx` target feature
-  --> $DIR/bad-reg.rs:116:26
+  --> $DIR/bad-reg.rs:108:26
    |
 LL |         asm!("/* {} */", in(vsreg) x); // FIXME: should be ok if vsx is available
    |                          ^^^^^^^^^^^
 
 error: register class `vsreg` requires the `vsx` target feature
-  --> $DIR/bad-reg.rs:119:26
+  --> $DIR/bad-reg.rs:111:26
    |
 LL |         asm!("/* {} */", out(vsreg) _); // requires vsx
    |                          ^^^^^^^^^^^^
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:139:27
+  --> $DIR/bad-reg.rs:131:27
    |
 LL |         asm!("", in("cr") x);
    |                           ^
@@ -847,7 +847,7 @@ LL |         asm!("", in("cr") x);
    = note: register class `cr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:142:28
+  --> $DIR/bad-reg.rs:134:28
    |
 LL |         asm!("", out("cr") x);
    |                            ^
@@ -855,7 +855,7 @@ LL |         asm!("", out("cr") x);
    = note: register class `cr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:145:33
+  --> $DIR/bad-reg.rs:137:33
    |
 LL |         asm!("/* {} */", in(cr) x);
    |                                 ^
@@ -863,7 +863,7 @@ LL |         asm!("/* {} */", in(cr) x);
    = note: register class `cr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:152:28
+  --> $DIR/bad-reg.rs:144:28
    |
 LL |         asm!("", in("ctr") x);
    |                            ^
@@ -871,7 +871,7 @@ LL |         asm!("", in("ctr") x);
    = note: register class `ctr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:155:29
+  --> $DIR/bad-reg.rs:147:29
    |
 LL |         asm!("", out("ctr") x);
    |                             ^
@@ -879,7 +879,7 @@ LL |         asm!("", out("ctr") x);
    = note: register class `ctr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:158:34
+  --> $DIR/bad-reg.rs:150:34
    |
 LL |         asm!("/* {} */", in(ctr) x);
    |                                  ^
@@ -887,7 +887,7 @@ LL |         asm!("/* {} */", in(ctr) x);
    = note: register class `ctr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:165:27
+  --> $DIR/bad-reg.rs:157:27
    |
 LL |         asm!("", in("lr") x);
    |                           ^
@@ -895,7 +895,7 @@ LL |         asm!("", in("lr") x);
    = note: register class `lr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:168:28
+  --> $DIR/bad-reg.rs:160:28
    |
 LL |         asm!("", out("lr") x);
    |                            ^
@@ -903,7 +903,7 @@ LL |         asm!("", out("lr") x);
    = note: register class `lr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:171:33
+  --> $DIR/bad-reg.rs:163:33
    |
 LL |         asm!("/* {} */", in(lr) x);
    |                                 ^
@@ -911,7 +911,7 @@ LL |         asm!("/* {} */", in(lr) x);
    = note: register class `lr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:178:28
+  --> $DIR/bad-reg.rs:170:28
    |
 LL |         asm!("", in("xer") x);
    |                            ^
@@ -919,7 +919,7 @@ LL |         asm!("", in("xer") x);
    = note: register class `xer` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:181:29
+  --> $DIR/bad-reg.rs:173:29
    |
 LL |         asm!("", out("xer") x);
    |                             ^
@@ -927,7 +927,7 @@ LL |         asm!("", out("xer") x);
    = note: register class `xer` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:184:34
+  --> $DIR/bad-reg.rs:176:34
    |
 LL |         asm!("/* {} */", in(xer) x);
    |                                  ^
@@ -935,7 +935,7 @@ LL |         asm!("/* {} */", in(xer) x);
    = note: register class `xer` supports these types: 
 
 error: cannot use register `spe_acc`: spe_acc is only available on spe targets
-  --> $DIR/bad-reg.rs:338:18
+  --> $DIR/bad-reg.rs:330:18
    |
 LL |         asm!("", out("spe_acc") _);
    |                  ^^^^^^^^^^^^^^^^

--- a/tests/ui/asm/powerpc/bad-reg.powerpc64.stderr
+++ b/tests/ui/asm/powerpc/bad-reg.powerpc64.stderr
@@ -1,131 +1,131 @@
 error: invalid register `sp`: the stack pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:38:18
+  --> $DIR/bad-reg.rs:31:18
    |
 LL |         asm!("", out("sp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `r2`: r2 is a system reserved register and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:40:18
+  --> $DIR/bad-reg.rs:33:18
    |
 LL |         asm!("", out("r2") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `r30`: r30 is used internally by LLVM and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:46:18
+  --> $DIR/bad-reg.rs:39:18
    |
 LL |         asm!("", out("r30") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `fp`: the frame pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:48:18
+  --> $DIR/bad-reg.rs:41:18
    |
 LL |         asm!("", out("fp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `vrsave`: the vrsave register cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:50:18
+  --> $DIR/bad-reg.rs:43:18
    |
 LL |         asm!("", out("vrsave") _);
    |                  ^^^^^^^^^^^^^^^
 
 error: register class `cr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:139:18
+  --> $DIR/bad-reg.rs:131:18
    |
 LL |         asm!("", in("cr") x);
    |                  ^^^^^^^^^^
 
 error: register class `cr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:142:18
+  --> $DIR/bad-reg.rs:134:18
    |
 LL |         asm!("", out("cr") x);
    |                  ^^^^^^^^^^^
 
 error: register class `cr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:145:26
+  --> $DIR/bad-reg.rs:137:26
    |
 LL |         asm!("/* {} */", in(cr) x);
    |                          ^^^^^^^^
 
 error: register class `cr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:148:26
+  --> $DIR/bad-reg.rs:140:26
    |
 LL |         asm!("/* {} */", out(cr) _);
    |                          ^^^^^^^^^
 
 error: register class `ctr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:152:18
+  --> $DIR/bad-reg.rs:144:18
    |
 LL |         asm!("", in("ctr") x);
    |                  ^^^^^^^^^^^
 
 error: register class `ctr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:155:18
+  --> $DIR/bad-reg.rs:147:18
    |
 LL |         asm!("", out("ctr") x);
    |                  ^^^^^^^^^^^^
 
 error: register class `ctr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:158:26
+  --> $DIR/bad-reg.rs:150:26
    |
 LL |         asm!("/* {} */", in(ctr) x);
    |                          ^^^^^^^^^
 
 error: register class `ctr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:161:26
+  --> $DIR/bad-reg.rs:153:26
    |
 LL |         asm!("/* {} */", out(ctr) _);
    |                          ^^^^^^^^^^
 
 error: register class `lr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:165:18
+  --> $DIR/bad-reg.rs:157:18
    |
 LL |         asm!("", in("lr") x);
    |                  ^^^^^^^^^^
 
 error: register class `lr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:168:18
+  --> $DIR/bad-reg.rs:160:18
    |
 LL |         asm!("", out("lr") x);
    |                  ^^^^^^^^^^^
 
 error: register class `lr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:171:26
+  --> $DIR/bad-reg.rs:163:26
    |
 LL |         asm!("/* {} */", in(lr) x);
    |                          ^^^^^^^^
 
 error: register class `lr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:174:26
+  --> $DIR/bad-reg.rs:166:26
    |
 LL |         asm!("/* {} */", out(lr) _);
    |                          ^^^^^^^^^
 
 error: register class `xer` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:178:18
+  --> $DIR/bad-reg.rs:170:18
    |
 LL |         asm!("", in("xer") x);
    |                  ^^^^^^^^^^^
 
 error: register class `xer` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:181:18
+  --> $DIR/bad-reg.rs:173:18
    |
 LL |         asm!("", out("xer") x);
    |                  ^^^^^^^^^^^^
 
 error: register class `xer` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:184:26
+  --> $DIR/bad-reg.rs:176:26
    |
 LL |         asm!("/* {} */", in(xer) x);
    |                          ^^^^^^^^^
 
 error: register class `xer` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:187:26
+  --> $DIR/bad-reg.rs:179:26
    |
 LL |         asm!("/* {} */", out(xer) _);
    |                          ^^^^^^^^^^
 
 error: register `cr0` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:191:31
+  --> $DIR/bad-reg.rs:183:31
    |
 LL |         asm!("", out("cr") _, out("cr0") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr0`
@@ -133,7 +133,7 @@ LL |         asm!("", out("cr") _, out("cr0") _);
    |                  register `cr`
 
 error: register `cr1` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:193:31
+  --> $DIR/bad-reg.rs:185:31
    |
 LL |         asm!("", out("cr") _, out("cr1") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr1`
@@ -141,7 +141,7 @@ LL |         asm!("", out("cr") _, out("cr1") _);
    |                  register `cr`
 
 error: register `cr2` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:195:31
+  --> $DIR/bad-reg.rs:187:31
    |
 LL |         asm!("", out("cr") _, out("cr2") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr2`
@@ -149,7 +149,7 @@ LL |         asm!("", out("cr") _, out("cr2") _);
    |                  register `cr`
 
 error: register `cr3` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:197:31
+  --> $DIR/bad-reg.rs:189:31
    |
 LL |         asm!("", out("cr") _, out("cr3") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr3`
@@ -157,7 +157,7 @@ LL |         asm!("", out("cr") _, out("cr3") _);
    |                  register `cr`
 
 error: register `cr4` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:199:31
+  --> $DIR/bad-reg.rs:191:31
    |
 LL |         asm!("", out("cr") _, out("cr4") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr4`
@@ -165,7 +165,7 @@ LL |         asm!("", out("cr") _, out("cr4") _);
    |                  register `cr`
 
 error: register `cr5` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:201:31
+  --> $DIR/bad-reg.rs:193:31
    |
 LL |         asm!("", out("cr") _, out("cr5") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr5`
@@ -173,7 +173,7 @@ LL |         asm!("", out("cr") _, out("cr5") _);
    |                  register `cr`
 
 error: register `cr6` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:203:31
+  --> $DIR/bad-reg.rs:195:31
    |
 LL |         asm!("", out("cr") _, out("cr6") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr6`
@@ -181,7 +181,7 @@ LL |         asm!("", out("cr") _, out("cr6") _);
    |                  register `cr`
 
 error: register `cr7` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:205:31
+  --> $DIR/bad-reg.rs:197:31
    |
 LL |         asm!("", out("cr") _, out("cr7") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr7`
@@ -189,7 +189,7 @@ LL |         asm!("", out("cr") _, out("cr7") _);
    |                  register `cr`
 
 error: register `vs0` conflicts with register `f0`
-  --> $DIR/bad-reg.rs:208:31
+  --> $DIR/bad-reg.rs:200:31
    |
 LL |         asm!("", out("f0") _, out("vs0") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs0`
@@ -197,7 +197,7 @@ LL |         asm!("", out("f0") _, out("vs0") _);
    |                  register `f0`
 
 error: register `vs1` conflicts with register `f1`
-  --> $DIR/bad-reg.rs:210:31
+  --> $DIR/bad-reg.rs:202:31
    |
 LL |         asm!("", out("f1") _, out("vs1") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs1`
@@ -205,7 +205,7 @@ LL |         asm!("", out("f1") _, out("vs1") _);
    |                  register `f1`
 
 error: register `vs2` conflicts with register `f2`
-  --> $DIR/bad-reg.rs:212:31
+  --> $DIR/bad-reg.rs:204:31
    |
 LL |         asm!("", out("f2") _, out("vs2") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs2`
@@ -213,7 +213,7 @@ LL |         asm!("", out("f2") _, out("vs2") _);
    |                  register `f2`
 
 error: register `vs3` conflicts with register `f3`
-  --> $DIR/bad-reg.rs:214:31
+  --> $DIR/bad-reg.rs:206:31
    |
 LL |         asm!("", out("f3") _, out("vs3") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs3`
@@ -221,7 +221,7 @@ LL |         asm!("", out("f3") _, out("vs3") _);
    |                  register `f3`
 
 error: register `vs4` conflicts with register `f4`
-  --> $DIR/bad-reg.rs:216:31
+  --> $DIR/bad-reg.rs:208:31
    |
 LL |         asm!("", out("f4") _, out("vs4") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs4`
@@ -229,7 +229,7 @@ LL |         asm!("", out("f4") _, out("vs4") _);
    |                  register `f4`
 
 error: register `vs5` conflicts with register `f5`
-  --> $DIR/bad-reg.rs:218:31
+  --> $DIR/bad-reg.rs:210:31
    |
 LL |         asm!("", out("f5") _, out("vs5") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs5`
@@ -237,7 +237,7 @@ LL |         asm!("", out("f5") _, out("vs5") _);
    |                  register `f5`
 
 error: register `vs6` conflicts with register `f6`
-  --> $DIR/bad-reg.rs:220:31
+  --> $DIR/bad-reg.rs:212:31
    |
 LL |         asm!("", out("f6") _, out("vs6") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs6`
@@ -245,7 +245,7 @@ LL |         asm!("", out("f6") _, out("vs6") _);
    |                  register `f6`
 
 error: register `vs7` conflicts with register `f7`
-  --> $DIR/bad-reg.rs:222:31
+  --> $DIR/bad-reg.rs:214:31
    |
 LL |         asm!("", out("f7") _, out("vs7") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs7`
@@ -253,7 +253,7 @@ LL |         asm!("", out("f7") _, out("vs7") _);
    |                  register `f7`
 
 error: register `vs8` conflicts with register `f8`
-  --> $DIR/bad-reg.rs:224:31
+  --> $DIR/bad-reg.rs:216:31
    |
 LL |         asm!("", out("f8") _, out("vs8") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs8`
@@ -261,7 +261,7 @@ LL |         asm!("", out("f8") _, out("vs8") _);
    |                  register `f8`
 
 error: register `vs9` conflicts with register `f9`
-  --> $DIR/bad-reg.rs:226:31
+  --> $DIR/bad-reg.rs:218:31
    |
 LL |         asm!("", out("f9") _, out("vs9") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs9`
@@ -269,7 +269,7 @@ LL |         asm!("", out("f9") _, out("vs9") _);
    |                  register `f9`
 
 error: register `vs10` conflicts with register `f10`
-  --> $DIR/bad-reg.rs:228:32
+  --> $DIR/bad-reg.rs:220:32
    |
 LL |         asm!("", out("f10") _, out("vs10") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs10`
@@ -277,7 +277,7 @@ LL |         asm!("", out("f10") _, out("vs10") _);
    |                  register `f10`
 
 error: register `vs11` conflicts with register `f11`
-  --> $DIR/bad-reg.rs:230:32
+  --> $DIR/bad-reg.rs:222:32
    |
 LL |         asm!("", out("f11") _, out("vs11") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs11`
@@ -285,7 +285,7 @@ LL |         asm!("", out("f11") _, out("vs11") _);
    |                  register `f11`
 
 error: register `vs12` conflicts with register `f12`
-  --> $DIR/bad-reg.rs:232:32
+  --> $DIR/bad-reg.rs:224:32
    |
 LL |         asm!("", out("f12") _, out("vs12") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs12`
@@ -293,7 +293,7 @@ LL |         asm!("", out("f12") _, out("vs12") _);
    |                  register `f12`
 
 error: register `vs13` conflicts with register `f13`
-  --> $DIR/bad-reg.rs:234:32
+  --> $DIR/bad-reg.rs:226:32
    |
 LL |         asm!("", out("f13") _, out("vs13") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs13`
@@ -301,7 +301,7 @@ LL |         asm!("", out("f13") _, out("vs13") _);
    |                  register `f13`
 
 error: register `vs14` conflicts with register `f14`
-  --> $DIR/bad-reg.rs:236:32
+  --> $DIR/bad-reg.rs:228:32
    |
 LL |         asm!("", out("f14") _, out("vs14") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs14`
@@ -309,7 +309,7 @@ LL |         asm!("", out("f14") _, out("vs14") _);
    |                  register `f14`
 
 error: register `vs15` conflicts with register `f15`
-  --> $DIR/bad-reg.rs:238:32
+  --> $DIR/bad-reg.rs:230:32
    |
 LL |         asm!("", out("f15") _, out("vs15") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs15`
@@ -317,7 +317,7 @@ LL |         asm!("", out("f15") _, out("vs15") _);
    |                  register `f15`
 
 error: register `vs16` conflicts with register `f16`
-  --> $DIR/bad-reg.rs:240:32
+  --> $DIR/bad-reg.rs:232:32
    |
 LL |         asm!("", out("f16") _, out("vs16") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs16`
@@ -325,7 +325,7 @@ LL |         asm!("", out("f16") _, out("vs16") _);
    |                  register `f16`
 
 error: register `vs17` conflicts with register `f17`
-  --> $DIR/bad-reg.rs:242:32
+  --> $DIR/bad-reg.rs:234:32
    |
 LL |         asm!("", out("f17") _, out("vs17") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs17`
@@ -333,7 +333,7 @@ LL |         asm!("", out("f17") _, out("vs17") _);
    |                  register `f17`
 
 error: register `vs18` conflicts with register `f18`
-  --> $DIR/bad-reg.rs:244:32
+  --> $DIR/bad-reg.rs:236:32
    |
 LL |         asm!("", out("f18") _, out("vs18") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs18`
@@ -341,7 +341,7 @@ LL |         asm!("", out("f18") _, out("vs18") _);
    |                  register `f18`
 
 error: register `vs19` conflicts with register `f19`
-  --> $DIR/bad-reg.rs:246:32
+  --> $DIR/bad-reg.rs:238:32
    |
 LL |         asm!("", out("f19") _, out("vs19") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs19`
@@ -349,7 +349,7 @@ LL |         asm!("", out("f19") _, out("vs19") _);
    |                  register `f19`
 
 error: register `vs20` conflicts with register `f20`
-  --> $DIR/bad-reg.rs:248:32
+  --> $DIR/bad-reg.rs:240:32
    |
 LL |         asm!("", out("f20") _, out("vs20") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs20`
@@ -357,7 +357,7 @@ LL |         asm!("", out("f20") _, out("vs20") _);
    |                  register `f20`
 
 error: register `vs21` conflicts with register `f21`
-  --> $DIR/bad-reg.rs:250:32
+  --> $DIR/bad-reg.rs:242:32
    |
 LL |         asm!("", out("f21") _, out("vs21") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs21`
@@ -365,7 +365,7 @@ LL |         asm!("", out("f21") _, out("vs21") _);
    |                  register `f21`
 
 error: register `vs22` conflicts with register `f22`
-  --> $DIR/bad-reg.rs:252:32
+  --> $DIR/bad-reg.rs:244:32
    |
 LL |         asm!("", out("f22") _, out("vs22") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs22`
@@ -373,7 +373,7 @@ LL |         asm!("", out("f22") _, out("vs22") _);
    |                  register `f22`
 
 error: register `vs23` conflicts with register `f23`
-  --> $DIR/bad-reg.rs:254:32
+  --> $DIR/bad-reg.rs:246:32
    |
 LL |         asm!("", out("f23") _, out("vs23") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs23`
@@ -381,7 +381,7 @@ LL |         asm!("", out("f23") _, out("vs23") _);
    |                  register `f23`
 
 error: register `vs24` conflicts with register `f24`
-  --> $DIR/bad-reg.rs:256:32
+  --> $DIR/bad-reg.rs:248:32
    |
 LL |         asm!("", out("f24") _, out("vs24") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs24`
@@ -389,7 +389,7 @@ LL |         asm!("", out("f24") _, out("vs24") _);
    |                  register `f24`
 
 error: register `vs25` conflicts with register `f25`
-  --> $DIR/bad-reg.rs:258:32
+  --> $DIR/bad-reg.rs:250:32
    |
 LL |         asm!("", out("f25") _, out("vs25") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs25`
@@ -397,7 +397,7 @@ LL |         asm!("", out("f25") _, out("vs25") _);
    |                  register `f25`
 
 error: register `vs26` conflicts with register `f26`
-  --> $DIR/bad-reg.rs:260:32
+  --> $DIR/bad-reg.rs:252:32
    |
 LL |         asm!("", out("f26") _, out("vs26") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs26`
@@ -405,7 +405,7 @@ LL |         asm!("", out("f26") _, out("vs26") _);
    |                  register `f26`
 
 error: register `vs27` conflicts with register `f27`
-  --> $DIR/bad-reg.rs:262:32
+  --> $DIR/bad-reg.rs:254:32
    |
 LL |         asm!("", out("f27") _, out("vs27") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs27`
@@ -413,7 +413,7 @@ LL |         asm!("", out("f27") _, out("vs27") _);
    |                  register `f27`
 
 error: register `vs28` conflicts with register `f28`
-  --> $DIR/bad-reg.rs:264:32
+  --> $DIR/bad-reg.rs:256:32
    |
 LL |         asm!("", out("f28") _, out("vs28") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs28`
@@ -421,7 +421,7 @@ LL |         asm!("", out("f28") _, out("vs28") _);
    |                  register `f28`
 
 error: register `vs29` conflicts with register `f29`
-  --> $DIR/bad-reg.rs:266:32
+  --> $DIR/bad-reg.rs:258:32
    |
 LL |         asm!("", out("f29") _, out("vs29") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs29`
@@ -429,7 +429,7 @@ LL |         asm!("", out("f29") _, out("vs29") _);
    |                  register `f29`
 
 error: register `vs30` conflicts with register `f30`
-  --> $DIR/bad-reg.rs:268:32
+  --> $DIR/bad-reg.rs:260:32
    |
 LL |         asm!("", out("f30") _, out("vs30") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs30`
@@ -437,7 +437,7 @@ LL |         asm!("", out("f30") _, out("vs30") _);
    |                  register `f30`
 
 error: register `vs31` conflicts with register `f31`
-  --> $DIR/bad-reg.rs:270:32
+  --> $DIR/bad-reg.rs:262:32
    |
 LL |         asm!("", out("f31") _, out("vs31") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs31`
@@ -445,7 +445,7 @@ LL |         asm!("", out("f31") _, out("vs31") _);
    |                  register `f31`
 
 error: register `v0` conflicts with register `vs32`
-  --> $DIR/bad-reg.rs:272:33
+  --> $DIR/bad-reg.rs:264:33
    |
 LL |         asm!("", out("vs32") _, out("v0") _);
    |                  -------------  ^^^^^^^^^^^ register `v0`
@@ -453,7 +453,7 @@ LL |         asm!("", out("vs32") _, out("v0") _);
    |                  register `vs32`
 
 error: register `v1` conflicts with register `vs33`
-  --> $DIR/bad-reg.rs:274:33
+  --> $DIR/bad-reg.rs:266:33
    |
 LL |         asm!("", out("vs33") _, out("v1") _);
    |                  -------------  ^^^^^^^^^^^ register `v1`
@@ -461,7 +461,7 @@ LL |         asm!("", out("vs33") _, out("v1") _);
    |                  register `vs33`
 
 error: register `v2` conflicts with register `vs34`
-  --> $DIR/bad-reg.rs:276:33
+  --> $DIR/bad-reg.rs:268:33
    |
 LL |         asm!("", out("vs34") _, out("v2") _);
    |                  -------------  ^^^^^^^^^^^ register `v2`
@@ -469,7 +469,7 @@ LL |         asm!("", out("vs34") _, out("v2") _);
    |                  register `vs34`
 
 error: register `v3` conflicts with register `vs35`
-  --> $DIR/bad-reg.rs:278:33
+  --> $DIR/bad-reg.rs:270:33
    |
 LL |         asm!("", out("vs35") _, out("v3") _);
    |                  -------------  ^^^^^^^^^^^ register `v3`
@@ -477,7 +477,7 @@ LL |         asm!("", out("vs35") _, out("v3") _);
    |                  register `vs35`
 
 error: register `v4` conflicts with register `vs36`
-  --> $DIR/bad-reg.rs:280:33
+  --> $DIR/bad-reg.rs:272:33
    |
 LL |         asm!("", out("vs36") _, out("v4") _);
    |                  -------------  ^^^^^^^^^^^ register `v4`
@@ -485,7 +485,7 @@ LL |         asm!("", out("vs36") _, out("v4") _);
    |                  register `vs36`
 
 error: register `v5` conflicts with register `vs37`
-  --> $DIR/bad-reg.rs:282:33
+  --> $DIR/bad-reg.rs:274:33
    |
 LL |         asm!("", out("vs37") _, out("v5") _);
    |                  -------------  ^^^^^^^^^^^ register `v5`
@@ -493,7 +493,7 @@ LL |         asm!("", out("vs37") _, out("v5") _);
    |                  register `vs37`
 
 error: register `v6` conflicts with register `vs38`
-  --> $DIR/bad-reg.rs:284:33
+  --> $DIR/bad-reg.rs:276:33
    |
 LL |         asm!("", out("vs38") _, out("v6") _);
    |                  -------------  ^^^^^^^^^^^ register `v6`
@@ -501,7 +501,7 @@ LL |         asm!("", out("vs38") _, out("v6") _);
    |                  register `vs38`
 
 error: register `v7` conflicts with register `vs39`
-  --> $DIR/bad-reg.rs:286:33
+  --> $DIR/bad-reg.rs:278:33
    |
 LL |         asm!("", out("vs39") _, out("v7") _);
    |                  -------------  ^^^^^^^^^^^ register `v7`
@@ -509,7 +509,7 @@ LL |         asm!("", out("vs39") _, out("v7") _);
    |                  register `vs39`
 
 error: register `v8` conflicts with register `vs40`
-  --> $DIR/bad-reg.rs:288:33
+  --> $DIR/bad-reg.rs:280:33
    |
 LL |         asm!("", out("vs40") _, out("v8") _);
    |                  -------------  ^^^^^^^^^^^ register `v8`
@@ -517,7 +517,7 @@ LL |         asm!("", out("vs40") _, out("v8") _);
    |                  register `vs40`
 
 error: register `v9` conflicts with register `vs41`
-  --> $DIR/bad-reg.rs:290:33
+  --> $DIR/bad-reg.rs:282:33
    |
 LL |         asm!("", out("vs41") _, out("v9") _);
    |                  -------------  ^^^^^^^^^^^ register `v9`
@@ -525,7 +525,7 @@ LL |         asm!("", out("vs41") _, out("v9") _);
    |                  register `vs41`
 
 error: register `v10` conflicts with register `vs42`
-  --> $DIR/bad-reg.rs:292:33
+  --> $DIR/bad-reg.rs:284:33
    |
 LL |         asm!("", out("vs42") _, out("v10") _);
    |                  -------------  ^^^^^^^^^^^^ register `v10`
@@ -533,7 +533,7 @@ LL |         asm!("", out("vs42") _, out("v10") _);
    |                  register `vs42`
 
 error: register `v11` conflicts with register `vs43`
-  --> $DIR/bad-reg.rs:294:33
+  --> $DIR/bad-reg.rs:286:33
    |
 LL |         asm!("", out("vs43") _, out("v11") _);
    |                  -------------  ^^^^^^^^^^^^ register `v11`
@@ -541,7 +541,7 @@ LL |         asm!("", out("vs43") _, out("v11") _);
    |                  register `vs43`
 
 error: register `v12` conflicts with register `vs44`
-  --> $DIR/bad-reg.rs:296:33
+  --> $DIR/bad-reg.rs:288:33
    |
 LL |         asm!("", out("vs44") _, out("v12") _);
    |                  -------------  ^^^^^^^^^^^^ register `v12`
@@ -549,7 +549,7 @@ LL |         asm!("", out("vs44") _, out("v12") _);
    |                  register `vs44`
 
 error: register `v13` conflicts with register `vs45`
-  --> $DIR/bad-reg.rs:298:33
+  --> $DIR/bad-reg.rs:290:33
    |
 LL |         asm!("", out("vs45") _, out("v13") _);
    |                  -------------  ^^^^^^^^^^^^ register `v13`
@@ -557,7 +557,7 @@ LL |         asm!("", out("vs45") _, out("v13") _);
    |                  register `vs45`
 
 error: register `v14` conflicts with register `vs46`
-  --> $DIR/bad-reg.rs:300:33
+  --> $DIR/bad-reg.rs:292:33
    |
 LL |         asm!("", out("vs46") _, out("v14") _);
    |                  -------------  ^^^^^^^^^^^^ register `v14`
@@ -565,7 +565,7 @@ LL |         asm!("", out("vs46") _, out("v14") _);
    |                  register `vs46`
 
 error: register `v15` conflicts with register `vs47`
-  --> $DIR/bad-reg.rs:302:33
+  --> $DIR/bad-reg.rs:294:33
    |
 LL |         asm!("", out("vs47") _, out("v15") _);
    |                  -------------  ^^^^^^^^^^^^ register `v15`
@@ -573,7 +573,7 @@ LL |         asm!("", out("vs47") _, out("v15") _);
    |                  register `vs47`
 
 error: register `v16` conflicts with register `vs48`
-  --> $DIR/bad-reg.rs:304:33
+  --> $DIR/bad-reg.rs:296:33
    |
 LL |         asm!("", out("vs48") _, out("v16") _);
    |                  -------------  ^^^^^^^^^^^^ register `v16`
@@ -581,7 +581,7 @@ LL |         asm!("", out("vs48") _, out("v16") _);
    |                  register `vs48`
 
 error: register `v17` conflicts with register `vs49`
-  --> $DIR/bad-reg.rs:306:33
+  --> $DIR/bad-reg.rs:298:33
    |
 LL |         asm!("", out("vs49") _, out("v17") _);
    |                  -------------  ^^^^^^^^^^^^ register `v17`
@@ -589,7 +589,7 @@ LL |         asm!("", out("vs49") _, out("v17") _);
    |                  register `vs49`
 
 error: register `v18` conflicts with register `vs50`
-  --> $DIR/bad-reg.rs:308:33
+  --> $DIR/bad-reg.rs:300:33
    |
 LL |         asm!("", out("vs50") _, out("v18") _);
    |                  -------------  ^^^^^^^^^^^^ register `v18`
@@ -597,7 +597,7 @@ LL |         asm!("", out("vs50") _, out("v18") _);
    |                  register `vs50`
 
 error: register `v19` conflicts with register `vs51`
-  --> $DIR/bad-reg.rs:310:33
+  --> $DIR/bad-reg.rs:302:33
    |
 LL |         asm!("", out("vs51") _, out("v19") _);
    |                  -------------  ^^^^^^^^^^^^ register `v19`
@@ -605,7 +605,7 @@ LL |         asm!("", out("vs51") _, out("v19") _);
    |                  register `vs51`
 
 error: register `v20` conflicts with register `vs52`
-  --> $DIR/bad-reg.rs:312:33
+  --> $DIR/bad-reg.rs:304:33
    |
 LL |         asm!("", out("vs52") _, out("v20") _);
    |                  -------------  ^^^^^^^^^^^^ register `v20`
@@ -613,7 +613,7 @@ LL |         asm!("", out("vs52") _, out("v20") _);
    |                  register `vs52`
 
 error: register `v21` conflicts with register `vs53`
-  --> $DIR/bad-reg.rs:314:33
+  --> $DIR/bad-reg.rs:306:33
    |
 LL |         asm!("", out("vs53") _, out("v21") _);
    |                  -------------  ^^^^^^^^^^^^ register `v21`
@@ -621,7 +621,7 @@ LL |         asm!("", out("vs53") _, out("v21") _);
    |                  register `vs53`
 
 error: register `v22` conflicts with register `vs54`
-  --> $DIR/bad-reg.rs:316:33
+  --> $DIR/bad-reg.rs:308:33
    |
 LL |         asm!("", out("vs54") _, out("v22") _);
    |                  -------------  ^^^^^^^^^^^^ register `v22`
@@ -629,7 +629,7 @@ LL |         asm!("", out("vs54") _, out("v22") _);
    |                  register `vs54`
 
 error: register `v23` conflicts with register `vs55`
-  --> $DIR/bad-reg.rs:318:33
+  --> $DIR/bad-reg.rs:310:33
    |
 LL |         asm!("", out("vs55") _, out("v23") _);
    |                  -------------  ^^^^^^^^^^^^ register `v23`
@@ -637,7 +637,7 @@ LL |         asm!("", out("vs55") _, out("v23") _);
    |                  register `vs55`
 
 error: register `v24` conflicts with register `vs56`
-  --> $DIR/bad-reg.rs:320:33
+  --> $DIR/bad-reg.rs:312:33
    |
 LL |         asm!("", out("vs56") _, out("v24") _);
    |                  -------------  ^^^^^^^^^^^^ register `v24`
@@ -645,7 +645,7 @@ LL |         asm!("", out("vs56") _, out("v24") _);
    |                  register `vs56`
 
 error: register `v25` conflicts with register `vs57`
-  --> $DIR/bad-reg.rs:322:33
+  --> $DIR/bad-reg.rs:314:33
    |
 LL |         asm!("", out("vs57") _, out("v25") _);
    |                  -------------  ^^^^^^^^^^^^ register `v25`
@@ -653,7 +653,7 @@ LL |         asm!("", out("vs57") _, out("v25") _);
    |                  register `vs57`
 
 error: register `v26` conflicts with register `vs58`
-  --> $DIR/bad-reg.rs:324:33
+  --> $DIR/bad-reg.rs:316:33
    |
 LL |         asm!("", out("vs58") _, out("v26") _);
    |                  -------------  ^^^^^^^^^^^^ register `v26`
@@ -661,7 +661,7 @@ LL |         asm!("", out("vs58") _, out("v26") _);
    |                  register `vs58`
 
 error: register `v27` conflicts with register `vs59`
-  --> $DIR/bad-reg.rs:326:33
+  --> $DIR/bad-reg.rs:318:33
    |
 LL |         asm!("", out("vs59") _, out("v27") _);
    |                  -------------  ^^^^^^^^^^^^ register `v27`
@@ -669,7 +669,7 @@ LL |         asm!("", out("vs59") _, out("v27") _);
    |                  register `vs59`
 
 error: register `v28` conflicts with register `vs60`
-  --> $DIR/bad-reg.rs:328:33
+  --> $DIR/bad-reg.rs:320:33
    |
 LL |         asm!("", out("vs60") _, out("v28") _);
    |                  -------------  ^^^^^^^^^^^^ register `v28`
@@ -677,7 +677,7 @@ LL |         asm!("", out("vs60") _, out("v28") _);
    |                  register `vs60`
 
 error: register `v29` conflicts with register `vs61`
-  --> $DIR/bad-reg.rs:330:33
+  --> $DIR/bad-reg.rs:322:33
    |
 LL |         asm!("", out("vs61") _, out("v29") _);
    |                  -------------  ^^^^^^^^^^^^ register `v29`
@@ -685,7 +685,7 @@ LL |         asm!("", out("vs61") _, out("v29") _);
    |                  register `vs61`
 
 error: register `v30` conflicts with register `vs62`
-  --> $DIR/bad-reg.rs:332:33
+  --> $DIR/bad-reg.rs:324:33
    |
 LL |         asm!("", out("vs62") _, out("v30") _);
    |                  -------------  ^^^^^^^^^^^^ register `v30`
@@ -693,7 +693,7 @@ LL |         asm!("", out("vs62") _, out("v30") _);
    |                  register `vs62`
 
 error: register `v31` conflicts with register `vs63`
-  --> $DIR/bad-reg.rs:334:33
+  --> $DIR/bad-reg.rs:326:33
    |
 LL |         asm!("", out("vs63") _, out("v31") _);
    |                  -------------  ^^^^^^^^^^^^ register `v31`
@@ -701,35 +701,35 @@ LL |         asm!("", out("vs63") _, out("v31") _);
    |                  register `vs63`
 
 error: register class `spe_acc` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:340:26
+  --> $DIR/bad-reg.rs:332:26
    |
 LL |         asm!("/* {} */", out(spe_acc) _);
    |                          ^^^^^^^^^^^^^^
 
 error: cannot use register `r13`: r13 is a reserved register on this target
-  --> $DIR/bad-reg.rs:42:18
+  --> $DIR/bad-reg.rs:35:18
    |
 LL |         asm!("", out("r13") _);
    |                  ^^^^^^^^^^^^
 
 error: `vsx` target feature is not enabled
-  --> $DIR/bad-reg.rs:59:27
+  --> $DIR/bad-reg.rs:52:27
    |
 LL |         asm!("", in("v0") v64x2); // requires vsx
    |                           ^^^^^
    |
-   = note: this is required to use type `i64x2` with register class `vreg`
+   = note: this is required to use type `Simd<i64, 2>` with register class `vreg`
 
 error: `vsx` target feature is not enabled
-  --> $DIR/bad-reg.rs:62:28
+  --> $DIR/bad-reg.rs:55:28
    |
 LL |         asm!("", out("v0") v64x2); // requires vsx
    |                            ^^^^^
    |
-   = note: this is required to use type `i64x2` with register class `vreg`
+   = note: this is required to use type `Simd<i64, 2>` with register class `vreg`
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:65:27
+  --> $DIR/bad-reg.rs:58:27
    |
 LL |         asm!("", in("v0") x); // FIXME: should be ok if vsx is available
    |                           ^
@@ -737,7 +737,7 @@ LL |         asm!("", in("v0") x); // FIXME: should be ok if vsx is available
    = note: register class `vreg` supports these types: i8x16, i16x8, i32x4, f32x4, f32, f64, i64x2, f64x2
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:68:28
+  --> $DIR/bad-reg.rs:61:28
    |
 LL |         asm!("", out("v0") x); // FIXME: should be ok if vsx is available
    |                            ^
@@ -745,15 +745,15 @@ LL |         asm!("", out("v0") x); // FIXME: should be ok if vsx is available
    = note: register class `vreg` supports these types: i8x16, i16x8, i32x4, f32x4, f32, f64, i64x2, f64x2
 
 error: `vsx` target feature is not enabled
-  --> $DIR/bad-reg.rs:73:35
+  --> $DIR/bad-reg.rs:66:35
    |
 LL |         asm!("/* {} */", in(vreg) v64x2); // requires vsx
    |                                   ^^^^^
    |
-   = note: this is required to use type `i64x2` with register class `vreg`
+   = note: this is required to use type `Simd<i64, 2>` with register class `vreg`
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:76:35
+  --> $DIR/bad-reg.rs:69:35
    |
 LL |         asm!("/* {} */", in(vreg) x); // FIXME: should be ok if vsx is available
    |                                   ^
@@ -761,67 +761,67 @@ LL |         asm!("/* {} */", in(vreg) x); // FIXME: should be ok if vsx is avai
    = note: register class `vreg` supports these types: i8x16, i16x8, i32x4, f32x4, f32, f64, i64x2, f64x2
 
 error: register class `vsreg` requires the `vsx` target feature
-  --> $DIR/bad-reg.rs:98:18
+  --> $DIR/bad-reg.rs:90:18
    |
 LL |         asm!("", in("vs0") v32x4); // requires vsx
    |                  ^^^^^^^^^^^^^^^
 
 error: register class `vsreg` requires the `vsx` target feature
-  --> $DIR/bad-reg.rs:100:18
+  --> $DIR/bad-reg.rs:92:18
    |
 LL |         asm!("", out("vs0") v32x4); // requires vsx
    |                  ^^^^^^^^^^^^^^^^
 
 error: register class `vsreg` requires the `vsx` target feature
-  --> $DIR/bad-reg.rs:102:18
+  --> $DIR/bad-reg.rs:94:18
    |
 LL |         asm!("", in("vs0") v64x2); // requires vsx
    |                  ^^^^^^^^^^^^^^^
 
 error: register class `vsreg` requires the `vsx` target feature
-  --> $DIR/bad-reg.rs:104:18
+  --> $DIR/bad-reg.rs:96:18
    |
 LL |         asm!("", out("vs0") v64x2); // requires vsx
    |                  ^^^^^^^^^^^^^^^^
 
 error: register class `vsreg` requires the `vsx` target feature
-  --> $DIR/bad-reg.rs:106:18
+  --> $DIR/bad-reg.rs:98:18
    |
 LL |         asm!("", in("vs0") x); // FIXME: should be ok if vsx is available
    |                  ^^^^^^^^^^^
 
 error: register class `vsreg` requires the `vsx` target feature
-  --> $DIR/bad-reg.rs:109:18
+  --> $DIR/bad-reg.rs:101:18
    |
 LL |         asm!("", out("vs0") x); // FIXME: should be ok if vsx is available
    |                  ^^^^^^^^^^^^
 
 error: register class `vsreg` requires the `vsx` target feature
-  --> $DIR/bad-reg.rs:112:26
+  --> $DIR/bad-reg.rs:104:26
    |
 LL |         asm!("/* {} */", in(vsreg) v32x4); // requires vsx
    |                          ^^^^^^^^^^^^^^^
 
 error: register class `vsreg` requires the `vsx` target feature
-  --> $DIR/bad-reg.rs:114:26
+  --> $DIR/bad-reg.rs:106:26
    |
 LL |         asm!("/* {} */", in(vsreg) v64x2); // requires vsx
    |                          ^^^^^^^^^^^^^^^
 
 error: register class `vsreg` requires the `vsx` target feature
-  --> $DIR/bad-reg.rs:116:26
+  --> $DIR/bad-reg.rs:108:26
    |
 LL |         asm!("/* {} */", in(vsreg) x); // FIXME: should be ok if vsx is available
    |                          ^^^^^^^^^^^
 
 error: register class `vsreg` requires the `vsx` target feature
-  --> $DIR/bad-reg.rs:119:26
+  --> $DIR/bad-reg.rs:111:26
    |
 LL |         asm!("/* {} */", out(vsreg) _); // requires vsx
    |                          ^^^^^^^^^^^^
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:139:27
+  --> $DIR/bad-reg.rs:131:27
    |
 LL |         asm!("", in("cr") x);
    |                           ^
@@ -829,7 +829,7 @@ LL |         asm!("", in("cr") x);
    = note: register class `cr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:142:28
+  --> $DIR/bad-reg.rs:134:28
    |
 LL |         asm!("", out("cr") x);
    |                            ^
@@ -837,7 +837,7 @@ LL |         asm!("", out("cr") x);
    = note: register class `cr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:145:33
+  --> $DIR/bad-reg.rs:137:33
    |
 LL |         asm!("/* {} */", in(cr) x);
    |                                 ^
@@ -845,7 +845,7 @@ LL |         asm!("/* {} */", in(cr) x);
    = note: register class `cr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:152:28
+  --> $DIR/bad-reg.rs:144:28
    |
 LL |         asm!("", in("ctr") x);
    |                            ^
@@ -853,7 +853,7 @@ LL |         asm!("", in("ctr") x);
    = note: register class `ctr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:155:29
+  --> $DIR/bad-reg.rs:147:29
    |
 LL |         asm!("", out("ctr") x);
    |                             ^
@@ -861,7 +861,7 @@ LL |         asm!("", out("ctr") x);
    = note: register class `ctr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:158:34
+  --> $DIR/bad-reg.rs:150:34
    |
 LL |         asm!("/* {} */", in(ctr) x);
    |                                  ^
@@ -869,7 +869,7 @@ LL |         asm!("/* {} */", in(ctr) x);
    = note: register class `ctr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:165:27
+  --> $DIR/bad-reg.rs:157:27
    |
 LL |         asm!("", in("lr") x);
    |                           ^
@@ -877,7 +877,7 @@ LL |         asm!("", in("lr") x);
    = note: register class `lr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:168:28
+  --> $DIR/bad-reg.rs:160:28
    |
 LL |         asm!("", out("lr") x);
    |                            ^
@@ -885,7 +885,7 @@ LL |         asm!("", out("lr") x);
    = note: register class `lr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:171:33
+  --> $DIR/bad-reg.rs:163:33
    |
 LL |         asm!("/* {} */", in(lr) x);
    |                                 ^
@@ -893,7 +893,7 @@ LL |         asm!("/* {} */", in(lr) x);
    = note: register class `lr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:178:28
+  --> $DIR/bad-reg.rs:170:28
    |
 LL |         asm!("", in("xer") x);
    |                            ^
@@ -901,7 +901,7 @@ LL |         asm!("", in("xer") x);
    = note: register class `xer` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:181:29
+  --> $DIR/bad-reg.rs:173:29
    |
 LL |         asm!("", out("xer") x);
    |                             ^
@@ -909,7 +909,7 @@ LL |         asm!("", out("xer") x);
    = note: register class `xer` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:184:34
+  --> $DIR/bad-reg.rs:176:34
    |
 LL |         asm!("/* {} */", in(xer) x);
    |                                  ^
@@ -917,7 +917,7 @@ LL |         asm!("/* {} */", in(xer) x);
    = note: register class `xer` supports these types: 
 
 error: cannot use register `spe_acc`: spe_acc is only available on spe targets
-  --> $DIR/bad-reg.rs:338:18
+  --> $DIR/bad-reg.rs:330:18
    |
 LL |         asm!("", out("spe_acc") _);
    |                  ^^^^^^^^^^^^^^^^

--- a/tests/ui/asm/powerpc/bad-reg.powerpc64le.stderr
+++ b/tests/ui/asm/powerpc/bad-reg.powerpc64le.stderr
@@ -1,131 +1,131 @@
 error: invalid register `sp`: the stack pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:38:18
+  --> $DIR/bad-reg.rs:31:18
    |
 LL |         asm!("", out("sp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `r2`: r2 is a system reserved register and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:40:18
+  --> $DIR/bad-reg.rs:33:18
    |
 LL |         asm!("", out("r2") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `r30`: r30 is used internally by LLVM and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:46:18
+  --> $DIR/bad-reg.rs:39:18
    |
 LL |         asm!("", out("r30") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `fp`: the frame pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:48:18
+  --> $DIR/bad-reg.rs:41:18
    |
 LL |         asm!("", out("fp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `vrsave`: the vrsave register cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:50:18
+  --> $DIR/bad-reg.rs:43:18
    |
 LL |         asm!("", out("vrsave") _);
    |                  ^^^^^^^^^^^^^^^
 
 error: register class `cr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:139:18
+  --> $DIR/bad-reg.rs:131:18
    |
 LL |         asm!("", in("cr") x);
    |                  ^^^^^^^^^^
 
 error: register class `cr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:142:18
+  --> $DIR/bad-reg.rs:134:18
    |
 LL |         asm!("", out("cr") x);
    |                  ^^^^^^^^^^^
 
 error: register class `cr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:145:26
+  --> $DIR/bad-reg.rs:137:26
    |
 LL |         asm!("/* {} */", in(cr) x);
    |                          ^^^^^^^^
 
 error: register class `cr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:148:26
+  --> $DIR/bad-reg.rs:140:26
    |
 LL |         asm!("/* {} */", out(cr) _);
    |                          ^^^^^^^^^
 
 error: register class `ctr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:152:18
+  --> $DIR/bad-reg.rs:144:18
    |
 LL |         asm!("", in("ctr") x);
    |                  ^^^^^^^^^^^
 
 error: register class `ctr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:155:18
+  --> $DIR/bad-reg.rs:147:18
    |
 LL |         asm!("", out("ctr") x);
    |                  ^^^^^^^^^^^^
 
 error: register class `ctr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:158:26
+  --> $DIR/bad-reg.rs:150:26
    |
 LL |         asm!("/* {} */", in(ctr) x);
    |                          ^^^^^^^^^
 
 error: register class `ctr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:161:26
+  --> $DIR/bad-reg.rs:153:26
    |
 LL |         asm!("/* {} */", out(ctr) _);
    |                          ^^^^^^^^^^
 
 error: register class `lr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:165:18
+  --> $DIR/bad-reg.rs:157:18
    |
 LL |         asm!("", in("lr") x);
    |                  ^^^^^^^^^^
 
 error: register class `lr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:168:18
+  --> $DIR/bad-reg.rs:160:18
    |
 LL |         asm!("", out("lr") x);
    |                  ^^^^^^^^^^^
 
 error: register class `lr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:171:26
+  --> $DIR/bad-reg.rs:163:26
    |
 LL |         asm!("/* {} */", in(lr) x);
    |                          ^^^^^^^^
 
 error: register class `lr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:174:26
+  --> $DIR/bad-reg.rs:166:26
    |
 LL |         asm!("/* {} */", out(lr) _);
    |                          ^^^^^^^^^
 
 error: register class `xer` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:178:18
+  --> $DIR/bad-reg.rs:170:18
    |
 LL |         asm!("", in("xer") x);
    |                  ^^^^^^^^^^^
 
 error: register class `xer` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:181:18
+  --> $DIR/bad-reg.rs:173:18
    |
 LL |         asm!("", out("xer") x);
    |                  ^^^^^^^^^^^^
 
 error: register class `xer` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:184:26
+  --> $DIR/bad-reg.rs:176:26
    |
 LL |         asm!("/* {} */", in(xer) x);
    |                          ^^^^^^^^^
 
 error: register class `xer` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:187:26
+  --> $DIR/bad-reg.rs:179:26
    |
 LL |         asm!("/* {} */", out(xer) _);
    |                          ^^^^^^^^^^
 
 error: register `cr0` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:191:31
+  --> $DIR/bad-reg.rs:183:31
    |
 LL |         asm!("", out("cr") _, out("cr0") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr0`
@@ -133,7 +133,7 @@ LL |         asm!("", out("cr") _, out("cr0") _);
    |                  register `cr`
 
 error: register `cr1` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:193:31
+  --> $DIR/bad-reg.rs:185:31
    |
 LL |         asm!("", out("cr") _, out("cr1") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr1`
@@ -141,7 +141,7 @@ LL |         asm!("", out("cr") _, out("cr1") _);
    |                  register `cr`
 
 error: register `cr2` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:195:31
+  --> $DIR/bad-reg.rs:187:31
    |
 LL |         asm!("", out("cr") _, out("cr2") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr2`
@@ -149,7 +149,7 @@ LL |         asm!("", out("cr") _, out("cr2") _);
    |                  register `cr`
 
 error: register `cr3` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:197:31
+  --> $DIR/bad-reg.rs:189:31
    |
 LL |         asm!("", out("cr") _, out("cr3") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr3`
@@ -157,7 +157,7 @@ LL |         asm!("", out("cr") _, out("cr3") _);
    |                  register `cr`
 
 error: register `cr4` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:199:31
+  --> $DIR/bad-reg.rs:191:31
    |
 LL |         asm!("", out("cr") _, out("cr4") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr4`
@@ -165,7 +165,7 @@ LL |         asm!("", out("cr") _, out("cr4") _);
    |                  register `cr`
 
 error: register `cr5` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:201:31
+  --> $DIR/bad-reg.rs:193:31
    |
 LL |         asm!("", out("cr") _, out("cr5") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr5`
@@ -173,7 +173,7 @@ LL |         asm!("", out("cr") _, out("cr5") _);
    |                  register `cr`
 
 error: register `cr6` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:203:31
+  --> $DIR/bad-reg.rs:195:31
    |
 LL |         asm!("", out("cr") _, out("cr6") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr6`
@@ -181,7 +181,7 @@ LL |         asm!("", out("cr") _, out("cr6") _);
    |                  register `cr`
 
 error: register `cr7` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:205:31
+  --> $DIR/bad-reg.rs:197:31
    |
 LL |         asm!("", out("cr") _, out("cr7") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr7`
@@ -189,7 +189,7 @@ LL |         asm!("", out("cr") _, out("cr7") _);
    |                  register `cr`
 
 error: register `vs0` conflicts with register `f0`
-  --> $DIR/bad-reg.rs:208:31
+  --> $DIR/bad-reg.rs:200:31
    |
 LL |         asm!("", out("f0") _, out("vs0") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs0`
@@ -197,7 +197,7 @@ LL |         asm!("", out("f0") _, out("vs0") _);
    |                  register `f0`
 
 error: register `vs1` conflicts with register `f1`
-  --> $DIR/bad-reg.rs:210:31
+  --> $DIR/bad-reg.rs:202:31
    |
 LL |         asm!("", out("f1") _, out("vs1") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs1`
@@ -205,7 +205,7 @@ LL |         asm!("", out("f1") _, out("vs1") _);
    |                  register `f1`
 
 error: register `vs2` conflicts with register `f2`
-  --> $DIR/bad-reg.rs:212:31
+  --> $DIR/bad-reg.rs:204:31
    |
 LL |         asm!("", out("f2") _, out("vs2") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs2`
@@ -213,7 +213,7 @@ LL |         asm!("", out("f2") _, out("vs2") _);
    |                  register `f2`
 
 error: register `vs3` conflicts with register `f3`
-  --> $DIR/bad-reg.rs:214:31
+  --> $DIR/bad-reg.rs:206:31
    |
 LL |         asm!("", out("f3") _, out("vs3") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs3`
@@ -221,7 +221,7 @@ LL |         asm!("", out("f3") _, out("vs3") _);
    |                  register `f3`
 
 error: register `vs4` conflicts with register `f4`
-  --> $DIR/bad-reg.rs:216:31
+  --> $DIR/bad-reg.rs:208:31
    |
 LL |         asm!("", out("f4") _, out("vs4") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs4`
@@ -229,7 +229,7 @@ LL |         asm!("", out("f4") _, out("vs4") _);
    |                  register `f4`
 
 error: register `vs5` conflicts with register `f5`
-  --> $DIR/bad-reg.rs:218:31
+  --> $DIR/bad-reg.rs:210:31
    |
 LL |         asm!("", out("f5") _, out("vs5") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs5`
@@ -237,7 +237,7 @@ LL |         asm!("", out("f5") _, out("vs5") _);
    |                  register `f5`
 
 error: register `vs6` conflicts with register `f6`
-  --> $DIR/bad-reg.rs:220:31
+  --> $DIR/bad-reg.rs:212:31
    |
 LL |         asm!("", out("f6") _, out("vs6") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs6`
@@ -245,7 +245,7 @@ LL |         asm!("", out("f6") _, out("vs6") _);
    |                  register `f6`
 
 error: register `vs7` conflicts with register `f7`
-  --> $DIR/bad-reg.rs:222:31
+  --> $DIR/bad-reg.rs:214:31
    |
 LL |         asm!("", out("f7") _, out("vs7") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs7`
@@ -253,7 +253,7 @@ LL |         asm!("", out("f7") _, out("vs7") _);
    |                  register `f7`
 
 error: register `vs8` conflicts with register `f8`
-  --> $DIR/bad-reg.rs:224:31
+  --> $DIR/bad-reg.rs:216:31
    |
 LL |         asm!("", out("f8") _, out("vs8") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs8`
@@ -261,7 +261,7 @@ LL |         asm!("", out("f8") _, out("vs8") _);
    |                  register `f8`
 
 error: register `vs9` conflicts with register `f9`
-  --> $DIR/bad-reg.rs:226:31
+  --> $DIR/bad-reg.rs:218:31
    |
 LL |         asm!("", out("f9") _, out("vs9") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs9`
@@ -269,7 +269,7 @@ LL |         asm!("", out("f9") _, out("vs9") _);
    |                  register `f9`
 
 error: register `vs10` conflicts with register `f10`
-  --> $DIR/bad-reg.rs:228:32
+  --> $DIR/bad-reg.rs:220:32
    |
 LL |         asm!("", out("f10") _, out("vs10") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs10`
@@ -277,7 +277,7 @@ LL |         asm!("", out("f10") _, out("vs10") _);
    |                  register `f10`
 
 error: register `vs11` conflicts with register `f11`
-  --> $DIR/bad-reg.rs:230:32
+  --> $DIR/bad-reg.rs:222:32
    |
 LL |         asm!("", out("f11") _, out("vs11") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs11`
@@ -285,7 +285,7 @@ LL |         asm!("", out("f11") _, out("vs11") _);
    |                  register `f11`
 
 error: register `vs12` conflicts with register `f12`
-  --> $DIR/bad-reg.rs:232:32
+  --> $DIR/bad-reg.rs:224:32
    |
 LL |         asm!("", out("f12") _, out("vs12") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs12`
@@ -293,7 +293,7 @@ LL |         asm!("", out("f12") _, out("vs12") _);
    |                  register `f12`
 
 error: register `vs13` conflicts with register `f13`
-  --> $DIR/bad-reg.rs:234:32
+  --> $DIR/bad-reg.rs:226:32
    |
 LL |         asm!("", out("f13") _, out("vs13") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs13`
@@ -301,7 +301,7 @@ LL |         asm!("", out("f13") _, out("vs13") _);
    |                  register `f13`
 
 error: register `vs14` conflicts with register `f14`
-  --> $DIR/bad-reg.rs:236:32
+  --> $DIR/bad-reg.rs:228:32
    |
 LL |         asm!("", out("f14") _, out("vs14") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs14`
@@ -309,7 +309,7 @@ LL |         asm!("", out("f14") _, out("vs14") _);
    |                  register `f14`
 
 error: register `vs15` conflicts with register `f15`
-  --> $DIR/bad-reg.rs:238:32
+  --> $DIR/bad-reg.rs:230:32
    |
 LL |         asm!("", out("f15") _, out("vs15") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs15`
@@ -317,7 +317,7 @@ LL |         asm!("", out("f15") _, out("vs15") _);
    |                  register `f15`
 
 error: register `vs16` conflicts with register `f16`
-  --> $DIR/bad-reg.rs:240:32
+  --> $DIR/bad-reg.rs:232:32
    |
 LL |         asm!("", out("f16") _, out("vs16") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs16`
@@ -325,7 +325,7 @@ LL |         asm!("", out("f16") _, out("vs16") _);
    |                  register `f16`
 
 error: register `vs17` conflicts with register `f17`
-  --> $DIR/bad-reg.rs:242:32
+  --> $DIR/bad-reg.rs:234:32
    |
 LL |         asm!("", out("f17") _, out("vs17") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs17`
@@ -333,7 +333,7 @@ LL |         asm!("", out("f17") _, out("vs17") _);
    |                  register `f17`
 
 error: register `vs18` conflicts with register `f18`
-  --> $DIR/bad-reg.rs:244:32
+  --> $DIR/bad-reg.rs:236:32
    |
 LL |         asm!("", out("f18") _, out("vs18") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs18`
@@ -341,7 +341,7 @@ LL |         asm!("", out("f18") _, out("vs18") _);
    |                  register `f18`
 
 error: register `vs19` conflicts with register `f19`
-  --> $DIR/bad-reg.rs:246:32
+  --> $DIR/bad-reg.rs:238:32
    |
 LL |         asm!("", out("f19") _, out("vs19") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs19`
@@ -349,7 +349,7 @@ LL |         asm!("", out("f19") _, out("vs19") _);
    |                  register `f19`
 
 error: register `vs20` conflicts with register `f20`
-  --> $DIR/bad-reg.rs:248:32
+  --> $DIR/bad-reg.rs:240:32
    |
 LL |         asm!("", out("f20") _, out("vs20") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs20`
@@ -357,7 +357,7 @@ LL |         asm!("", out("f20") _, out("vs20") _);
    |                  register `f20`
 
 error: register `vs21` conflicts with register `f21`
-  --> $DIR/bad-reg.rs:250:32
+  --> $DIR/bad-reg.rs:242:32
    |
 LL |         asm!("", out("f21") _, out("vs21") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs21`
@@ -365,7 +365,7 @@ LL |         asm!("", out("f21") _, out("vs21") _);
    |                  register `f21`
 
 error: register `vs22` conflicts with register `f22`
-  --> $DIR/bad-reg.rs:252:32
+  --> $DIR/bad-reg.rs:244:32
    |
 LL |         asm!("", out("f22") _, out("vs22") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs22`
@@ -373,7 +373,7 @@ LL |         asm!("", out("f22") _, out("vs22") _);
    |                  register `f22`
 
 error: register `vs23` conflicts with register `f23`
-  --> $DIR/bad-reg.rs:254:32
+  --> $DIR/bad-reg.rs:246:32
    |
 LL |         asm!("", out("f23") _, out("vs23") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs23`
@@ -381,7 +381,7 @@ LL |         asm!("", out("f23") _, out("vs23") _);
    |                  register `f23`
 
 error: register `vs24` conflicts with register `f24`
-  --> $DIR/bad-reg.rs:256:32
+  --> $DIR/bad-reg.rs:248:32
    |
 LL |         asm!("", out("f24") _, out("vs24") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs24`
@@ -389,7 +389,7 @@ LL |         asm!("", out("f24") _, out("vs24") _);
    |                  register `f24`
 
 error: register `vs25` conflicts with register `f25`
-  --> $DIR/bad-reg.rs:258:32
+  --> $DIR/bad-reg.rs:250:32
    |
 LL |         asm!("", out("f25") _, out("vs25") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs25`
@@ -397,7 +397,7 @@ LL |         asm!("", out("f25") _, out("vs25") _);
    |                  register `f25`
 
 error: register `vs26` conflicts with register `f26`
-  --> $DIR/bad-reg.rs:260:32
+  --> $DIR/bad-reg.rs:252:32
    |
 LL |         asm!("", out("f26") _, out("vs26") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs26`
@@ -405,7 +405,7 @@ LL |         asm!("", out("f26") _, out("vs26") _);
    |                  register `f26`
 
 error: register `vs27` conflicts with register `f27`
-  --> $DIR/bad-reg.rs:262:32
+  --> $DIR/bad-reg.rs:254:32
    |
 LL |         asm!("", out("f27") _, out("vs27") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs27`
@@ -413,7 +413,7 @@ LL |         asm!("", out("f27") _, out("vs27") _);
    |                  register `f27`
 
 error: register `vs28` conflicts with register `f28`
-  --> $DIR/bad-reg.rs:264:32
+  --> $DIR/bad-reg.rs:256:32
    |
 LL |         asm!("", out("f28") _, out("vs28") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs28`
@@ -421,7 +421,7 @@ LL |         asm!("", out("f28") _, out("vs28") _);
    |                  register `f28`
 
 error: register `vs29` conflicts with register `f29`
-  --> $DIR/bad-reg.rs:266:32
+  --> $DIR/bad-reg.rs:258:32
    |
 LL |         asm!("", out("f29") _, out("vs29") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs29`
@@ -429,7 +429,7 @@ LL |         asm!("", out("f29") _, out("vs29") _);
    |                  register `f29`
 
 error: register `vs30` conflicts with register `f30`
-  --> $DIR/bad-reg.rs:268:32
+  --> $DIR/bad-reg.rs:260:32
    |
 LL |         asm!("", out("f30") _, out("vs30") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs30`
@@ -437,7 +437,7 @@ LL |         asm!("", out("f30") _, out("vs30") _);
    |                  register `f30`
 
 error: register `vs31` conflicts with register `f31`
-  --> $DIR/bad-reg.rs:270:32
+  --> $DIR/bad-reg.rs:262:32
    |
 LL |         asm!("", out("f31") _, out("vs31") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs31`
@@ -445,7 +445,7 @@ LL |         asm!("", out("f31") _, out("vs31") _);
    |                  register `f31`
 
 error: register `v0` conflicts with register `vs32`
-  --> $DIR/bad-reg.rs:272:33
+  --> $DIR/bad-reg.rs:264:33
    |
 LL |         asm!("", out("vs32") _, out("v0") _);
    |                  -------------  ^^^^^^^^^^^ register `v0`
@@ -453,7 +453,7 @@ LL |         asm!("", out("vs32") _, out("v0") _);
    |                  register `vs32`
 
 error: register `v1` conflicts with register `vs33`
-  --> $DIR/bad-reg.rs:274:33
+  --> $DIR/bad-reg.rs:266:33
    |
 LL |         asm!("", out("vs33") _, out("v1") _);
    |                  -------------  ^^^^^^^^^^^ register `v1`
@@ -461,7 +461,7 @@ LL |         asm!("", out("vs33") _, out("v1") _);
    |                  register `vs33`
 
 error: register `v2` conflicts with register `vs34`
-  --> $DIR/bad-reg.rs:276:33
+  --> $DIR/bad-reg.rs:268:33
    |
 LL |         asm!("", out("vs34") _, out("v2") _);
    |                  -------------  ^^^^^^^^^^^ register `v2`
@@ -469,7 +469,7 @@ LL |         asm!("", out("vs34") _, out("v2") _);
    |                  register `vs34`
 
 error: register `v3` conflicts with register `vs35`
-  --> $DIR/bad-reg.rs:278:33
+  --> $DIR/bad-reg.rs:270:33
    |
 LL |         asm!("", out("vs35") _, out("v3") _);
    |                  -------------  ^^^^^^^^^^^ register `v3`
@@ -477,7 +477,7 @@ LL |         asm!("", out("vs35") _, out("v3") _);
    |                  register `vs35`
 
 error: register `v4` conflicts with register `vs36`
-  --> $DIR/bad-reg.rs:280:33
+  --> $DIR/bad-reg.rs:272:33
    |
 LL |         asm!("", out("vs36") _, out("v4") _);
    |                  -------------  ^^^^^^^^^^^ register `v4`
@@ -485,7 +485,7 @@ LL |         asm!("", out("vs36") _, out("v4") _);
    |                  register `vs36`
 
 error: register `v5` conflicts with register `vs37`
-  --> $DIR/bad-reg.rs:282:33
+  --> $DIR/bad-reg.rs:274:33
    |
 LL |         asm!("", out("vs37") _, out("v5") _);
    |                  -------------  ^^^^^^^^^^^ register `v5`
@@ -493,7 +493,7 @@ LL |         asm!("", out("vs37") _, out("v5") _);
    |                  register `vs37`
 
 error: register `v6` conflicts with register `vs38`
-  --> $DIR/bad-reg.rs:284:33
+  --> $DIR/bad-reg.rs:276:33
    |
 LL |         asm!("", out("vs38") _, out("v6") _);
    |                  -------------  ^^^^^^^^^^^ register `v6`
@@ -501,7 +501,7 @@ LL |         asm!("", out("vs38") _, out("v6") _);
    |                  register `vs38`
 
 error: register `v7` conflicts with register `vs39`
-  --> $DIR/bad-reg.rs:286:33
+  --> $DIR/bad-reg.rs:278:33
    |
 LL |         asm!("", out("vs39") _, out("v7") _);
    |                  -------------  ^^^^^^^^^^^ register `v7`
@@ -509,7 +509,7 @@ LL |         asm!("", out("vs39") _, out("v7") _);
    |                  register `vs39`
 
 error: register `v8` conflicts with register `vs40`
-  --> $DIR/bad-reg.rs:288:33
+  --> $DIR/bad-reg.rs:280:33
    |
 LL |         asm!("", out("vs40") _, out("v8") _);
    |                  -------------  ^^^^^^^^^^^ register `v8`
@@ -517,7 +517,7 @@ LL |         asm!("", out("vs40") _, out("v8") _);
    |                  register `vs40`
 
 error: register `v9` conflicts with register `vs41`
-  --> $DIR/bad-reg.rs:290:33
+  --> $DIR/bad-reg.rs:282:33
    |
 LL |         asm!("", out("vs41") _, out("v9") _);
    |                  -------------  ^^^^^^^^^^^ register `v9`
@@ -525,7 +525,7 @@ LL |         asm!("", out("vs41") _, out("v9") _);
    |                  register `vs41`
 
 error: register `v10` conflicts with register `vs42`
-  --> $DIR/bad-reg.rs:292:33
+  --> $DIR/bad-reg.rs:284:33
    |
 LL |         asm!("", out("vs42") _, out("v10") _);
    |                  -------------  ^^^^^^^^^^^^ register `v10`
@@ -533,7 +533,7 @@ LL |         asm!("", out("vs42") _, out("v10") _);
    |                  register `vs42`
 
 error: register `v11` conflicts with register `vs43`
-  --> $DIR/bad-reg.rs:294:33
+  --> $DIR/bad-reg.rs:286:33
    |
 LL |         asm!("", out("vs43") _, out("v11") _);
    |                  -------------  ^^^^^^^^^^^^ register `v11`
@@ -541,7 +541,7 @@ LL |         asm!("", out("vs43") _, out("v11") _);
    |                  register `vs43`
 
 error: register `v12` conflicts with register `vs44`
-  --> $DIR/bad-reg.rs:296:33
+  --> $DIR/bad-reg.rs:288:33
    |
 LL |         asm!("", out("vs44") _, out("v12") _);
    |                  -------------  ^^^^^^^^^^^^ register `v12`
@@ -549,7 +549,7 @@ LL |         asm!("", out("vs44") _, out("v12") _);
    |                  register `vs44`
 
 error: register `v13` conflicts with register `vs45`
-  --> $DIR/bad-reg.rs:298:33
+  --> $DIR/bad-reg.rs:290:33
    |
 LL |         asm!("", out("vs45") _, out("v13") _);
    |                  -------------  ^^^^^^^^^^^^ register `v13`
@@ -557,7 +557,7 @@ LL |         asm!("", out("vs45") _, out("v13") _);
    |                  register `vs45`
 
 error: register `v14` conflicts with register `vs46`
-  --> $DIR/bad-reg.rs:300:33
+  --> $DIR/bad-reg.rs:292:33
    |
 LL |         asm!("", out("vs46") _, out("v14") _);
    |                  -------------  ^^^^^^^^^^^^ register `v14`
@@ -565,7 +565,7 @@ LL |         asm!("", out("vs46") _, out("v14") _);
    |                  register `vs46`
 
 error: register `v15` conflicts with register `vs47`
-  --> $DIR/bad-reg.rs:302:33
+  --> $DIR/bad-reg.rs:294:33
    |
 LL |         asm!("", out("vs47") _, out("v15") _);
    |                  -------------  ^^^^^^^^^^^^ register `v15`
@@ -573,7 +573,7 @@ LL |         asm!("", out("vs47") _, out("v15") _);
    |                  register `vs47`
 
 error: register `v16` conflicts with register `vs48`
-  --> $DIR/bad-reg.rs:304:33
+  --> $DIR/bad-reg.rs:296:33
    |
 LL |         asm!("", out("vs48") _, out("v16") _);
    |                  -------------  ^^^^^^^^^^^^ register `v16`
@@ -581,7 +581,7 @@ LL |         asm!("", out("vs48") _, out("v16") _);
    |                  register `vs48`
 
 error: register `v17` conflicts with register `vs49`
-  --> $DIR/bad-reg.rs:306:33
+  --> $DIR/bad-reg.rs:298:33
    |
 LL |         asm!("", out("vs49") _, out("v17") _);
    |                  -------------  ^^^^^^^^^^^^ register `v17`
@@ -589,7 +589,7 @@ LL |         asm!("", out("vs49") _, out("v17") _);
    |                  register `vs49`
 
 error: register `v18` conflicts with register `vs50`
-  --> $DIR/bad-reg.rs:308:33
+  --> $DIR/bad-reg.rs:300:33
    |
 LL |         asm!("", out("vs50") _, out("v18") _);
    |                  -------------  ^^^^^^^^^^^^ register `v18`
@@ -597,7 +597,7 @@ LL |         asm!("", out("vs50") _, out("v18") _);
    |                  register `vs50`
 
 error: register `v19` conflicts with register `vs51`
-  --> $DIR/bad-reg.rs:310:33
+  --> $DIR/bad-reg.rs:302:33
    |
 LL |         asm!("", out("vs51") _, out("v19") _);
    |                  -------------  ^^^^^^^^^^^^ register `v19`
@@ -605,7 +605,7 @@ LL |         asm!("", out("vs51") _, out("v19") _);
    |                  register `vs51`
 
 error: register `v20` conflicts with register `vs52`
-  --> $DIR/bad-reg.rs:312:33
+  --> $DIR/bad-reg.rs:304:33
    |
 LL |         asm!("", out("vs52") _, out("v20") _);
    |                  -------------  ^^^^^^^^^^^^ register `v20`
@@ -613,7 +613,7 @@ LL |         asm!("", out("vs52") _, out("v20") _);
    |                  register `vs52`
 
 error: register `v21` conflicts with register `vs53`
-  --> $DIR/bad-reg.rs:314:33
+  --> $DIR/bad-reg.rs:306:33
    |
 LL |         asm!("", out("vs53") _, out("v21") _);
    |                  -------------  ^^^^^^^^^^^^ register `v21`
@@ -621,7 +621,7 @@ LL |         asm!("", out("vs53") _, out("v21") _);
    |                  register `vs53`
 
 error: register `v22` conflicts with register `vs54`
-  --> $DIR/bad-reg.rs:316:33
+  --> $DIR/bad-reg.rs:308:33
    |
 LL |         asm!("", out("vs54") _, out("v22") _);
    |                  -------------  ^^^^^^^^^^^^ register `v22`
@@ -629,7 +629,7 @@ LL |         asm!("", out("vs54") _, out("v22") _);
    |                  register `vs54`
 
 error: register `v23` conflicts with register `vs55`
-  --> $DIR/bad-reg.rs:318:33
+  --> $DIR/bad-reg.rs:310:33
    |
 LL |         asm!("", out("vs55") _, out("v23") _);
    |                  -------------  ^^^^^^^^^^^^ register `v23`
@@ -637,7 +637,7 @@ LL |         asm!("", out("vs55") _, out("v23") _);
    |                  register `vs55`
 
 error: register `v24` conflicts with register `vs56`
-  --> $DIR/bad-reg.rs:320:33
+  --> $DIR/bad-reg.rs:312:33
    |
 LL |         asm!("", out("vs56") _, out("v24") _);
    |                  -------------  ^^^^^^^^^^^^ register `v24`
@@ -645,7 +645,7 @@ LL |         asm!("", out("vs56") _, out("v24") _);
    |                  register `vs56`
 
 error: register `v25` conflicts with register `vs57`
-  --> $DIR/bad-reg.rs:322:33
+  --> $DIR/bad-reg.rs:314:33
    |
 LL |         asm!("", out("vs57") _, out("v25") _);
    |                  -------------  ^^^^^^^^^^^^ register `v25`
@@ -653,7 +653,7 @@ LL |         asm!("", out("vs57") _, out("v25") _);
    |                  register `vs57`
 
 error: register `v26` conflicts with register `vs58`
-  --> $DIR/bad-reg.rs:324:33
+  --> $DIR/bad-reg.rs:316:33
    |
 LL |         asm!("", out("vs58") _, out("v26") _);
    |                  -------------  ^^^^^^^^^^^^ register `v26`
@@ -661,7 +661,7 @@ LL |         asm!("", out("vs58") _, out("v26") _);
    |                  register `vs58`
 
 error: register `v27` conflicts with register `vs59`
-  --> $DIR/bad-reg.rs:326:33
+  --> $DIR/bad-reg.rs:318:33
    |
 LL |         asm!("", out("vs59") _, out("v27") _);
    |                  -------------  ^^^^^^^^^^^^ register `v27`
@@ -669,7 +669,7 @@ LL |         asm!("", out("vs59") _, out("v27") _);
    |                  register `vs59`
 
 error: register `v28` conflicts with register `vs60`
-  --> $DIR/bad-reg.rs:328:33
+  --> $DIR/bad-reg.rs:320:33
    |
 LL |         asm!("", out("vs60") _, out("v28") _);
    |                  -------------  ^^^^^^^^^^^^ register `v28`
@@ -677,7 +677,7 @@ LL |         asm!("", out("vs60") _, out("v28") _);
    |                  register `vs60`
 
 error: register `v29` conflicts with register `vs61`
-  --> $DIR/bad-reg.rs:330:33
+  --> $DIR/bad-reg.rs:322:33
    |
 LL |         asm!("", out("vs61") _, out("v29") _);
    |                  -------------  ^^^^^^^^^^^^ register `v29`
@@ -685,7 +685,7 @@ LL |         asm!("", out("vs61") _, out("v29") _);
    |                  register `vs61`
 
 error: register `v30` conflicts with register `vs62`
-  --> $DIR/bad-reg.rs:332:33
+  --> $DIR/bad-reg.rs:324:33
    |
 LL |         asm!("", out("vs62") _, out("v30") _);
    |                  -------------  ^^^^^^^^^^^^ register `v30`
@@ -693,7 +693,7 @@ LL |         asm!("", out("vs62") _, out("v30") _);
    |                  register `vs62`
 
 error: register `v31` conflicts with register `vs63`
-  --> $DIR/bad-reg.rs:334:33
+  --> $DIR/bad-reg.rs:326:33
    |
 LL |         asm!("", out("vs63") _, out("v31") _);
    |                  -------------  ^^^^^^^^^^^^ register `v31`
@@ -701,19 +701,19 @@ LL |         asm!("", out("vs63") _, out("v31") _);
    |                  register `vs63`
 
 error: register class `spe_acc` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:340:26
+  --> $DIR/bad-reg.rs:332:26
    |
 LL |         asm!("/* {} */", out(spe_acc) _);
    |                          ^^^^^^^^^^^^^^
 
 error: cannot use register `r13`: r13 is a reserved register on this target
-  --> $DIR/bad-reg.rs:42:18
+  --> $DIR/bad-reg.rs:35:18
    |
 LL |         asm!("", out("r13") _);
    |                  ^^^^^^^^^^^^
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:65:27
+  --> $DIR/bad-reg.rs:58:27
    |
 LL |         asm!("", in("v0") x); // FIXME: should be ok if vsx is available
    |                           ^
@@ -721,7 +721,7 @@ LL |         asm!("", in("v0") x); // FIXME: should be ok if vsx is available
    = note: register class `vreg` supports these types: i8x16, i16x8, i32x4, f32x4, f32, f64, i64x2, f64x2
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:68:28
+  --> $DIR/bad-reg.rs:61:28
    |
 LL |         asm!("", out("v0") x); // FIXME: should be ok if vsx is available
    |                            ^
@@ -729,7 +729,7 @@ LL |         asm!("", out("v0") x); // FIXME: should be ok if vsx is available
    = note: register class `vreg` supports these types: i8x16, i16x8, i32x4, f32x4, f32, f64, i64x2, f64x2
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:76:35
+  --> $DIR/bad-reg.rs:69:35
    |
 LL |         asm!("/* {} */", in(vreg) x); // FIXME: should be ok if vsx is available
    |                                   ^
@@ -737,7 +737,7 @@ LL |         asm!("/* {} */", in(vreg) x); // FIXME: should be ok if vsx is avai
    = note: register class `vreg` supports these types: i8x16, i16x8, i32x4, f32x4, f32, f64, i64x2, f64x2
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:106:28
+  --> $DIR/bad-reg.rs:98:28
    |
 LL |         asm!("", in("vs0") x); // FIXME: should be ok if vsx is available
    |                            ^
@@ -745,7 +745,7 @@ LL |         asm!("", in("vs0") x); // FIXME: should be ok if vsx is available
    = note: register class `vsreg` supports these types: f32, f64, i8x16, i16x8, i32x4, i64x2, f32x4, f64x2
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:109:29
+  --> $DIR/bad-reg.rs:101:29
    |
 LL |         asm!("", out("vs0") x); // FIXME: should be ok if vsx is available
    |                             ^
@@ -753,7 +753,7 @@ LL |         asm!("", out("vs0") x); // FIXME: should be ok if vsx is available
    = note: register class `vsreg` supports these types: f32, f64, i8x16, i16x8, i32x4, i64x2, f32x4, f64x2
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:116:36
+  --> $DIR/bad-reg.rs:108:36
    |
 LL |         asm!("/* {} */", in(vsreg) x); // FIXME: should be ok if vsx is available
    |                                    ^
@@ -761,7 +761,7 @@ LL |         asm!("/* {} */", in(vsreg) x); // FIXME: should be ok if vsx is ava
    = note: register class `vsreg` supports these types: f32, f64, i8x16, i16x8, i32x4, i64x2, f32x4, f64x2
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:139:27
+  --> $DIR/bad-reg.rs:131:27
    |
 LL |         asm!("", in("cr") x);
    |                           ^
@@ -769,7 +769,7 @@ LL |         asm!("", in("cr") x);
    = note: register class `cr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:142:28
+  --> $DIR/bad-reg.rs:134:28
    |
 LL |         asm!("", out("cr") x);
    |                            ^
@@ -777,7 +777,7 @@ LL |         asm!("", out("cr") x);
    = note: register class `cr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:145:33
+  --> $DIR/bad-reg.rs:137:33
    |
 LL |         asm!("/* {} */", in(cr) x);
    |                                 ^
@@ -785,7 +785,7 @@ LL |         asm!("/* {} */", in(cr) x);
    = note: register class `cr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:152:28
+  --> $DIR/bad-reg.rs:144:28
    |
 LL |         asm!("", in("ctr") x);
    |                            ^
@@ -793,7 +793,7 @@ LL |         asm!("", in("ctr") x);
    = note: register class `ctr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:155:29
+  --> $DIR/bad-reg.rs:147:29
    |
 LL |         asm!("", out("ctr") x);
    |                             ^
@@ -801,7 +801,7 @@ LL |         asm!("", out("ctr") x);
    = note: register class `ctr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:158:34
+  --> $DIR/bad-reg.rs:150:34
    |
 LL |         asm!("/* {} */", in(ctr) x);
    |                                  ^
@@ -809,7 +809,7 @@ LL |         asm!("/* {} */", in(ctr) x);
    = note: register class `ctr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:165:27
+  --> $DIR/bad-reg.rs:157:27
    |
 LL |         asm!("", in("lr") x);
    |                           ^
@@ -817,7 +817,7 @@ LL |         asm!("", in("lr") x);
    = note: register class `lr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:168:28
+  --> $DIR/bad-reg.rs:160:28
    |
 LL |         asm!("", out("lr") x);
    |                            ^
@@ -825,7 +825,7 @@ LL |         asm!("", out("lr") x);
    = note: register class `lr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:171:33
+  --> $DIR/bad-reg.rs:163:33
    |
 LL |         asm!("/* {} */", in(lr) x);
    |                                 ^
@@ -833,7 +833,7 @@ LL |         asm!("/* {} */", in(lr) x);
    = note: register class `lr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:178:28
+  --> $DIR/bad-reg.rs:170:28
    |
 LL |         asm!("", in("xer") x);
    |                            ^
@@ -841,7 +841,7 @@ LL |         asm!("", in("xer") x);
    = note: register class `xer` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:181:29
+  --> $DIR/bad-reg.rs:173:29
    |
 LL |         asm!("", out("xer") x);
    |                             ^
@@ -849,7 +849,7 @@ LL |         asm!("", out("xer") x);
    = note: register class `xer` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:184:34
+  --> $DIR/bad-reg.rs:176:34
    |
 LL |         asm!("/* {} */", in(xer) x);
    |                                  ^
@@ -857,7 +857,7 @@ LL |         asm!("/* {} */", in(xer) x);
    = note: register class `xer` supports these types: 
 
 error: cannot use register `spe_acc`: spe_acc is only available on spe targets
-  --> $DIR/bad-reg.rs:338:18
+  --> $DIR/bad-reg.rs:330:18
    |
 LL |         asm!("", out("spe_acc") _);
    |                  ^^^^^^^^^^^^^^^^

--- a/tests/ui/asm/powerpc/bad-reg.powerpcspe.stderr
+++ b/tests/ui/asm/powerpc/bad-reg.powerpcspe.stderr
@@ -1,131 +1,131 @@
 error: invalid register `sp`: the stack pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:38:18
+  --> $DIR/bad-reg.rs:31:18
    |
 LL |         asm!("", out("sp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `r2`: r2 is a system reserved register and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:40:18
+  --> $DIR/bad-reg.rs:33:18
    |
 LL |         asm!("", out("r2") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `r30`: r30 is used internally by LLVM and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:46:18
+  --> $DIR/bad-reg.rs:39:18
    |
 LL |         asm!("", out("r30") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `fp`: the frame pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:48:18
+  --> $DIR/bad-reg.rs:41:18
    |
 LL |         asm!("", out("fp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `vrsave`: the vrsave register cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:50:18
+  --> $DIR/bad-reg.rs:43:18
    |
 LL |         asm!("", out("vrsave") _);
    |                  ^^^^^^^^^^^^^^^
 
 error: register class `cr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:139:18
+  --> $DIR/bad-reg.rs:131:18
    |
 LL |         asm!("", in("cr") x);
    |                  ^^^^^^^^^^
 
 error: register class `cr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:142:18
+  --> $DIR/bad-reg.rs:134:18
    |
 LL |         asm!("", out("cr") x);
    |                  ^^^^^^^^^^^
 
 error: register class `cr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:145:26
+  --> $DIR/bad-reg.rs:137:26
    |
 LL |         asm!("/* {} */", in(cr) x);
    |                          ^^^^^^^^
 
 error: register class `cr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:148:26
+  --> $DIR/bad-reg.rs:140:26
    |
 LL |         asm!("/* {} */", out(cr) _);
    |                          ^^^^^^^^^
 
 error: register class `ctr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:152:18
+  --> $DIR/bad-reg.rs:144:18
    |
 LL |         asm!("", in("ctr") x);
    |                  ^^^^^^^^^^^
 
 error: register class `ctr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:155:18
+  --> $DIR/bad-reg.rs:147:18
    |
 LL |         asm!("", out("ctr") x);
    |                  ^^^^^^^^^^^^
 
 error: register class `ctr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:158:26
+  --> $DIR/bad-reg.rs:150:26
    |
 LL |         asm!("/* {} */", in(ctr) x);
    |                          ^^^^^^^^^
 
 error: register class `ctr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:161:26
+  --> $DIR/bad-reg.rs:153:26
    |
 LL |         asm!("/* {} */", out(ctr) _);
    |                          ^^^^^^^^^^
 
 error: register class `lr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:165:18
+  --> $DIR/bad-reg.rs:157:18
    |
 LL |         asm!("", in("lr") x);
    |                  ^^^^^^^^^^
 
 error: register class `lr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:168:18
+  --> $DIR/bad-reg.rs:160:18
    |
 LL |         asm!("", out("lr") x);
    |                  ^^^^^^^^^^^
 
 error: register class `lr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:171:26
+  --> $DIR/bad-reg.rs:163:26
    |
 LL |         asm!("/* {} */", in(lr) x);
    |                          ^^^^^^^^
 
 error: register class `lr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:174:26
+  --> $DIR/bad-reg.rs:166:26
    |
 LL |         asm!("/* {} */", out(lr) _);
    |                          ^^^^^^^^^
 
 error: register class `xer` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:178:18
+  --> $DIR/bad-reg.rs:170:18
    |
 LL |         asm!("", in("xer") x);
    |                  ^^^^^^^^^^^
 
 error: register class `xer` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:181:18
+  --> $DIR/bad-reg.rs:173:18
    |
 LL |         asm!("", out("xer") x);
    |                  ^^^^^^^^^^^^
 
 error: register class `xer` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:184:26
+  --> $DIR/bad-reg.rs:176:26
    |
 LL |         asm!("/* {} */", in(xer) x);
    |                          ^^^^^^^^^
 
 error: register class `xer` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:187:26
+  --> $DIR/bad-reg.rs:179:26
    |
 LL |         asm!("/* {} */", out(xer) _);
    |                          ^^^^^^^^^^
 
 error: register `cr0` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:191:31
+  --> $DIR/bad-reg.rs:183:31
    |
 LL |         asm!("", out("cr") _, out("cr0") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr0`
@@ -133,7 +133,7 @@ LL |         asm!("", out("cr") _, out("cr0") _);
    |                  register `cr`
 
 error: register `cr1` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:193:31
+  --> $DIR/bad-reg.rs:185:31
    |
 LL |         asm!("", out("cr") _, out("cr1") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr1`
@@ -141,7 +141,7 @@ LL |         asm!("", out("cr") _, out("cr1") _);
    |                  register `cr`
 
 error: register `cr2` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:195:31
+  --> $DIR/bad-reg.rs:187:31
    |
 LL |         asm!("", out("cr") _, out("cr2") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr2`
@@ -149,7 +149,7 @@ LL |         asm!("", out("cr") _, out("cr2") _);
    |                  register `cr`
 
 error: register `cr3` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:197:31
+  --> $DIR/bad-reg.rs:189:31
    |
 LL |         asm!("", out("cr") _, out("cr3") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr3`
@@ -157,7 +157,7 @@ LL |         asm!("", out("cr") _, out("cr3") _);
    |                  register `cr`
 
 error: register `cr4` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:199:31
+  --> $DIR/bad-reg.rs:191:31
    |
 LL |         asm!("", out("cr") _, out("cr4") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr4`
@@ -165,7 +165,7 @@ LL |         asm!("", out("cr") _, out("cr4") _);
    |                  register `cr`
 
 error: register `cr5` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:201:31
+  --> $DIR/bad-reg.rs:193:31
    |
 LL |         asm!("", out("cr") _, out("cr5") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr5`
@@ -173,7 +173,7 @@ LL |         asm!("", out("cr") _, out("cr5") _);
    |                  register `cr`
 
 error: register `cr6` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:203:31
+  --> $DIR/bad-reg.rs:195:31
    |
 LL |         asm!("", out("cr") _, out("cr6") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr6`
@@ -181,7 +181,7 @@ LL |         asm!("", out("cr") _, out("cr6") _);
    |                  register `cr`
 
 error: register `cr7` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:205:31
+  --> $DIR/bad-reg.rs:197:31
    |
 LL |         asm!("", out("cr") _, out("cr7") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr7`
@@ -189,7 +189,7 @@ LL |         asm!("", out("cr") _, out("cr7") _);
    |                  register `cr`
 
 error: register `vs0` conflicts with register `f0`
-  --> $DIR/bad-reg.rs:208:31
+  --> $DIR/bad-reg.rs:200:31
    |
 LL |         asm!("", out("f0") _, out("vs0") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs0`
@@ -197,7 +197,7 @@ LL |         asm!("", out("f0") _, out("vs0") _);
    |                  register `f0`
 
 error: register `vs1` conflicts with register `f1`
-  --> $DIR/bad-reg.rs:210:31
+  --> $DIR/bad-reg.rs:202:31
    |
 LL |         asm!("", out("f1") _, out("vs1") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs1`
@@ -205,7 +205,7 @@ LL |         asm!("", out("f1") _, out("vs1") _);
    |                  register `f1`
 
 error: register `vs2` conflicts with register `f2`
-  --> $DIR/bad-reg.rs:212:31
+  --> $DIR/bad-reg.rs:204:31
    |
 LL |         asm!("", out("f2") _, out("vs2") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs2`
@@ -213,7 +213,7 @@ LL |         asm!("", out("f2") _, out("vs2") _);
    |                  register `f2`
 
 error: register `vs3` conflicts with register `f3`
-  --> $DIR/bad-reg.rs:214:31
+  --> $DIR/bad-reg.rs:206:31
    |
 LL |         asm!("", out("f3") _, out("vs3") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs3`
@@ -221,7 +221,7 @@ LL |         asm!("", out("f3") _, out("vs3") _);
    |                  register `f3`
 
 error: register `vs4` conflicts with register `f4`
-  --> $DIR/bad-reg.rs:216:31
+  --> $DIR/bad-reg.rs:208:31
    |
 LL |         asm!("", out("f4") _, out("vs4") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs4`
@@ -229,7 +229,7 @@ LL |         asm!("", out("f4") _, out("vs4") _);
    |                  register `f4`
 
 error: register `vs5` conflicts with register `f5`
-  --> $DIR/bad-reg.rs:218:31
+  --> $DIR/bad-reg.rs:210:31
    |
 LL |         asm!("", out("f5") _, out("vs5") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs5`
@@ -237,7 +237,7 @@ LL |         asm!("", out("f5") _, out("vs5") _);
    |                  register `f5`
 
 error: register `vs6` conflicts with register `f6`
-  --> $DIR/bad-reg.rs:220:31
+  --> $DIR/bad-reg.rs:212:31
    |
 LL |         asm!("", out("f6") _, out("vs6") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs6`
@@ -245,7 +245,7 @@ LL |         asm!("", out("f6") _, out("vs6") _);
    |                  register `f6`
 
 error: register `vs7` conflicts with register `f7`
-  --> $DIR/bad-reg.rs:222:31
+  --> $DIR/bad-reg.rs:214:31
    |
 LL |         asm!("", out("f7") _, out("vs7") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs7`
@@ -253,7 +253,7 @@ LL |         asm!("", out("f7") _, out("vs7") _);
    |                  register `f7`
 
 error: register `vs8` conflicts with register `f8`
-  --> $DIR/bad-reg.rs:224:31
+  --> $DIR/bad-reg.rs:216:31
    |
 LL |         asm!("", out("f8") _, out("vs8") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs8`
@@ -261,7 +261,7 @@ LL |         asm!("", out("f8") _, out("vs8") _);
    |                  register `f8`
 
 error: register `vs9` conflicts with register `f9`
-  --> $DIR/bad-reg.rs:226:31
+  --> $DIR/bad-reg.rs:218:31
    |
 LL |         asm!("", out("f9") _, out("vs9") _);
    |                  -----------  ^^^^^^^^^^^^ register `vs9`
@@ -269,7 +269,7 @@ LL |         asm!("", out("f9") _, out("vs9") _);
    |                  register `f9`
 
 error: register `vs10` conflicts with register `f10`
-  --> $DIR/bad-reg.rs:228:32
+  --> $DIR/bad-reg.rs:220:32
    |
 LL |         asm!("", out("f10") _, out("vs10") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs10`
@@ -277,7 +277,7 @@ LL |         asm!("", out("f10") _, out("vs10") _);
    |                  register `f10`
 
 error: register `vs11` conflicts with register `f11`
-  --> $DIR/bad-reg.rs:230:32
+  --> $DIR/bad-reg.rs:222:32
    |
 LL |         asm!("", out("f11") _, out("vs11") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs11`
@@ -285,7 +285,7 @@ LL |         asm!("", out("f11") _, out("vs11") _);
    |                  register `f11`
 
 error: register `vs12` conflicts with register `f12`
-  --> $DIR/bad-reg.rs:232:32
+  --> $DIR/bad-reg.rs:224:32
    |
 LL |         asm!("", out("f12") _, out("vs12") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs12`
@@ -293,7 +293,7 @@ LL |         asm!("", out("f12") _, out("vs12") _);
    |                  register `f12`
 
 error: register `vs13` conflicts with register `f13`
-  --> $DIR/bad-reg.rs:234:32
+  --> $DIR/bad-reg.rs:226:32
    |
 LL |         asm!("", out("f13") _, out("vs13") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs13`
@@ -301,7 +301,7 @@ LL |         asm!("", out("f13") _, out("vs13") _);
    |                  register `f13`
 
 error: register `vs14` conflicts with register `f14`
-  --> $DIR/bad-reg.rs:236:32
+  --> $DIR/bad-reg.rs:228:32
    |
 LL |         asm!("", out("f14") _, out("vs14") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs14`
@@ -309,7 +309,7 @@ LL |         asm!("", out("f14") _, out("vs14") _);
    |                  register `f14`
 
 error: register `vs15` conflicts with register `f15`
-  --> $DIR/bad-reg.rs:238:32
+  --> $DIR/bad-reg.rs:230:32
    |
 LL |         asm!("", out("f15") _, out("vs15") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs15`
@@ -317,7 +317,7 @@ LL |         asm!("", out("f15") _, out("vs15") _);
    |                  register `f15`
 
 error: register `vs16` conflicts with register `f16`
-  --> $DIR/bad-reg.rs:240:32
+  --> $DIR/bad-reg.rs:232:32
    |
 LL |         asm!("", out("f16") _, out("vs16") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs16`
@@ -325,7 +325,7 @@ LL |         asm!("", out("f16") _, out("vs16") _);
    |                  register `f16`
 
 error: register `vs17` conflicts with register `f17`
-  --> $DIR/bad-reg.rs:242:32
+  --> $DIR/bad-reg.rs:234:32
    |
 LL |         asm!("", out("f17") _, out("vs17") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs17`
@@ -333,7 +333,7 @@ LL |         asm!("", out("f17") _, out("vs17") _);
    |                  register `f17`
 
 error: register `vs18` conflicts with register `f18`
-  --> $DIR/bad-reg.rs:244:32
+  --> $DIR/bad-reg.rs:236:32
    |
 LL |         asm!("", out("f18") _, out("vs18") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs18`
@@ -341,7 +341,7 @@ LL |         asm!("", out("f18") _, out("vs18") _);
    |                  register `f18`
 
 error: register `vs19` conflicts with register `f19`
-  --> $DIR/bad-reg.rs:246:32
+  --> $DIR/bad-reg.rs:238:32
    |
 LL |         asm!("", out("f19") _, out("vs19") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs19`
@@ -349,7 +349,7 @@ LL |         asm!("", out("f19") _, out("vs19") _);
    |                  register `f19`
 
 error: register `vs20` conflicts with register `f20`
-  --> $DIR/bad-reg.rs:248:32
+  --> $DIR/bad-reg.rs:240:32
    |
 LL |         asm!("", out("f20") _, out("vs20") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs20`
@@ -357,7 +357,7 @@ LL |         asm!("", out("f20") _, out("vs20") _);
    |                  register `f20`
 
 error: register `vs21` conflicts with register `f21`
-  --> $DIR/bad-reg.rs:250:32
+  --> $DIR/bad-reg.rs:242:32
    |
 LL |         asm!("", out("f21") _, out("vs21") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs21`
@@ -365,7 +365,7 @@ LL |         asm!("", out("f21") _, out("vs21") _);
    |                  register `f21`
 
 error: register `vs22` conflicts with register `f22`
-  --> $DIR/bad-reg.rs:252:32
+  --> $DIR/bad-reg.rs:244:32
    |
 LL |         asm!("", out("f22") _, out("vs22") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs22`
@@ -373,7 +373,7 @@ LL |         asm!("", out("f22") _, out("vs22") _);
    |                  register `f22`
 
 error: register `vs23` conflicts with register `f23`
-  --> $DIR/bad-reg.rs:254:32
+  --> $DIR/bad-reg.rs:246:32
    |
 LL |         asm!("", out("f23") _, out("vs23") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs23`
@@ -381,7 +381,7 @@ LL |         asm!("", out("f23") _, out("vs23") _);
    |                  register `f23`
 
 error: register `vs24` conflicts with register `f24`
-  --> $DIR/bad-reg.rs:256:32
+  --> $DIR/bad-reg.rs:248:32
    |
 LL |         asm!("", out("f24") _, out("vs24") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs24`
@@ -389,7 +389,7 @@ LL |         asm!("", out("f24") _, out("vs24") _);
    |                  register `f24`
 
 error: register `vs25` conflicts with register `f25`
-  --> $DIR/bad-reg.rs:258:32
+  --> $DIR/bad-reg.rs:250:32
    |
 LL |         asm!("", out("f25") _, out("vs25") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs25`
@@ -397,7 +397,7 @@ LL |         asm!("", out("f25") _, out("vs25") _);
    |                  register `f25`
 
 error: register `vs26` conflicts with register `f26`
-  --> $DIR/bad-reg.rs:260:32
+  --> $DIR/bad-reg.rs:252:32
    |
 LL |         asm!("", out("f26") _, out("vs26") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs26`
@@ -405,7 +405,7 @@ LL |         asm!("", out("f26") _, out("vs26") _);
    |                  register `f26`
 
 error: register `vs27` conflicts with register `f27`
-  --> $DIR/bad-reg.rs:262:32
+  --> $DIR/bad-reg.rs:254:32
    |
 LL |         asm!("", out("f27") _, out("vs27") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs27`
@@ -413,7 +413,7 @@ LL |         asm!("", out("f27") _, out("vs27") _);
    |                  register `f27`
 
 error: register `vs28` conflicts with register `f28`
-  --> $DIR/bad-reg.rs:264:32
+  --> $DIR/bad-reg.rs:256:32
    |
 LL |         asm!("", out("f28") _, out("vs28") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs28`
@@ -421,7 +421,7 @@ LL |         asm!("", out("f28") _, out("vs28") _);
    |                  register `f28`
 
 error: register `vs29` conflicts with register `f29`
-  --> $DIR/bad-reg.rs:266:32
+  --> $DIR/bad-reg.rs:258:32
    |
 LL |         asm!("", out("f29") _, out("vs29") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs29`
@@ -429,7 +429,7 @@ LL |         asm!("", out("f29") _, out("vs29") _);
    |                  register `f29`
 
 error: register `vs30` conflicts with register `f30`
-  --> $DIR/bad-reg.rs:268:32
+  --> $DIR/bad-reg.rs:260:32
    |
 LL |         asm!("", out("f30") _, out("vs30") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs30`
@@ -437,7 +437,7 @@ LL |         asm!("", out("f30") _, out("vs30") _);
    |                  register `f30`
 
 error: register `vs31` conflicts with register `f31`
-  --> $DIR/bad-reg.rs:270:32
+  --> $DIR/bad-reg.rs:262:32
    |
 LL |         asm!("", out("f31") _, out("vs31") _);
    |                  ------------  ^^^^^^^^^^^^^ register `vs31`
@@ -445,7 +445,7 @@ LL |         asm!("", out("f31") _, out("vs31") _);
    |                  register `f31`
 
 error: register `v0` conflicts with register `vs32`
-  --> $DIR/bad-reg.rs:272:33
+  --> $DIR/bad-reg.rs:264:33
    |
 LL |         asm!("", out("vs32") _, out("v0") _);
    |                  -------------  ^^^^^^^^^^^ register `v0`
@@ -453,7 +453,7 @@ LL |         asm!("", out("vs32") _, out("v0") _);
    |                  register `vs32`
 
 error: register `v1` conflicts with register `vs33`
-  --> $DIR/bad-reg.rs:274:33
+  --> $DIR/bad-reg.rs:266:33
    |
 LL |         asm!("", out("vs33") _, out("v1") _);
    |                  -------------  ^^^^^^^^^^^ register `v1`
@@ -461,7 +461,7 @@ LL |         asm!("", out("vs33") _, out("v1") _);
    |                  register `vs33`
 
 error: register `v2` conflicts with register `vs34`
-  --> $DIR/bad-reg.rs:276:33
+  --> $DIR/bad-reg.rs:268:33
    |
 LL |         asm!("", out("vs34") _, out("v2") _);
    |                  -------------  ^^^^^^^^^^^ register `v2`
@@ -469,7 +469,7 @@ LL |         asm!("", out("vs34") _, out("v2") _);
    |                  register `vs34`
 
 error: register `v3` conflicts with register `vs35`
-  --> $DIR/bad-reg.rs:278:33
+  --> $DIR/bad-reg.rs:270:33
    |
 LL |         asm!("", out("vs35") _, out("v3") _);
    |                  -------------  ^^^^^^^^^^^ register `v3`
@@ -477,7 +477,7 @@ LL |         asm!("", out("vs35") _, out("v3") _);
    |                  register `vs35`
 
 error: register `v4` conflicts with register `vs36`
-  --> $DIR/bad-reg.rs:280:33
+  --> $DIR/bad-reg.rs:272:33
    |
 LL |         asm!("", out("vs36") _, out("v4") _);
    |                  -------------  ^^^^^^^^^^^ register `v4`
@@ -485,7 +485,7 @@ LL |         asm!("", out("vs36") _, out("v4") _);
    |                  register `vs36`
 
 error: register `v5` conflicts with register `vs37`
-  --> $DIR/bad-reg.rs:282:33
+  --> $DIR/bad-reg.rs:274:33
    |
 LL |         asm!("", out("vs37") _, out("v5") _);
    |                  -------------  ^^^^^^^^^^^ register `v5`
@@ -493,7 +493,7 @@ LL |         asm!("", out("vs37") _, out("v5") _);
    |                  register `vs37`
 
 error: register `v6` conflicts with register `vs38`
-  --> $DIR/bad-reg.rs:284:33
+  --> $DIR/bad-reg.rs:276:33
    |
 LL |         asm!("", out("vs38") _, out("v6") _);
    |                  -------------  ^^^^^^^^^^^ register `v6`
@@ -501,7 +501,7 @@ LL |         asm!("", out("vs38") _, out("v6") _);
    |                  register `vs38`
 
 error: register `v7` conflicts with register `vs39`
-  --> $DIR/bad-reg.rs:286:33
+  --> $DIR/bad-reg.rs:278:33
    |
 LL |         asm!("", out("vs39") _, out("v7") _);
    |                  -------------  ^^^^^^^^^^^ register `v7`
@@ -509,7 +509,7 @@ LL |         asm!("", out("vs39") _, out("v7") _);
    |                  register `vs39`
 
 error: register `v8` conflicts with register `vs40`
-  --> $DIR/bad-reg.rs:288:33
+  --> $DIR/bad-reg.rs:280:33
    |
 LL |         asm!("", out("vs40") _, out("v8") _);
    |                  -------------  ^^^^^^^^^^^ register `v8`
@@ -517,7 +517,7 @@ LL |         asm!("", out("vs40") _, out("v8") _);
    |                  register `vs40`
 
 error: register `v9` conflicts with register `vs41`
-  --> $DIR/bad-reg.rs:290:33
+  --> $DIR/bad-reg.rs:282:33
    |
 LL |         asm!("", out("vs41") _, out("v9") _);
    |                  -------------  ^^^^^^^^^^^ register `v9`
@@ -525,7 +525,7 @@ LL |         asm!("", out("vs41") _, out("v9") _);
    |                  register `vs41`
 
 error: register `v10` conflicts with register `vs42`
-  --> $DIR/bad-reg.rs:292:33
+  --> $DIR/bad-reg.rs:284:33
    |
 LL |         asm!("", out("vs42") _, out("v10") _);
    |                  -------------  ^^^^^^^^^^^^ register `v10`
@@ -533,7 +533,7 @@ LL |         asm!("", out("vs42") _, out("v10") _);
    |                  register `vs42`
 
 error: register `v11` conflicts with register `vs43`
-  --> $DIR/bad-reg.rs:294:33
+  --> $DIR/bad-reg.rs:286:33
    |
 LL |         asm!("", out("vs43") _, out("v11") _);
    |                  -------------  ^^^^^^^^^^^^ register `v11`
@@ -541,7 +541,7 @@ LL |         asm!("", out("vs43") _, out("v11") _);
    |                  register `vs43`
 
 error: register `v12` conflicts with register `vs44`
-  --> $DIR/bad-reg.rs:296:33
+  --> $DIR/bad-reg.rs:288:33
    |
 LL |         asm!("", out("vs44") _, out("v12") _);
    |                  -------------  ^^^^^^^^^^^^ register `v12`
@@ -549,7 +549,7 @@ LL |         asm!("", out("vs44") _, out("v12") _);
    |                  register `vs44`
 
 error: register `v13` conflicts with register `vs45`
-  --> $DIR/bad-reg.rs:298:33
+  --> $DIR/bad-reg.rs:290:33
    |
 LL |         asm!("", out("vs45") _, out("v13") _);
    |                  -------------  ^^^^^^^^^^^^ register `v13`
@@ -557,7 +557,7 @@ LL |         asm!("", out("vs45") _, out("v13") _);
    |                  register `vs45`
 
 error: register `v14` conflicts with register `vs46`
-  --> $DIR/bad-reg.rs:300:33
+  --> $DIR/bad-reg.rs:292:33
    |
 LL |         asm!("", out("vs46") _, out("v14") _);
    |                  -------------  ^^^^^^^^^^^^ register `v14`
@@ -565,7 +565,7 @@ LL |         asm!("", out("vs46") _, out("v14") _);
    |                  register `vs46`
 
 error: register `v15` conflicts with register `vs47`
-  --> $DIR/bad-reg.rs:302:33
+  --> $DIR/bad-reg.rs:294:33
    |
 LL |         asm!("", out("vs47") _, out("v15") _);
    |                  -------------  ^^^^^^^^^^^^ register `v15`
@@ -573,7 +573,7 @@ LL |         asm!("", out("vs47") _, out("v15") _);
    |                  register `vs47`
 
 error: register `v16` conflicts with register `vs48`
-  --> $DIR/bad-reg.rs:304:33
+  --> $DIR/bad-reg.rs:296:33
    |
 LL |         asm!("", out("vs48") _, out("v16") _);
    |                  -------------  ^^^^^^^^^^^^ register `v16`
@@ -581,7 +581,7 @@ LL |         asm!("", out("vs48") _, out("v16") _);
    |                  register `vs48`
 
 error: register `v17` conflicts with register `vs49`
-  --> $DIR/bad-reg.rs:306:33
+  --> $DIR/bad-reg.rs:298:33
    |
 LL |         asm!("", out("vs49") _, out("v17") _);
    |                  -------------  ^^^^^^^^^^^^ register `v17`
@@ -589,7 +589,7 @@ LL |         asm!("", out("vs49") _, out("v17") _);
    |                  register `vs49`
 
 error: register `v18` conflicts with register `vs50`
-  --> $DIR/bad-reg.rs:308:33
+  --> $DIR/bad-reg.rs:300:33
    |
 LL |         asm!("", out("vs50") _, out("v18") _);
    |                  -------------  ^^^^^^^^^^^^ register `v18`
@@ -597,7 +597,7 @@ LL |         asm!("", out("vs50") _, out("v18") _);
    |                  register `vs50`
 
 error: register `v19` conflicts with register `vs51`
-  --> $DIR/bad-reg.rs:310:33
+  --> $DIR/bad-reg.rs:302:33
    |
 LL |         asm!("", out("vs51") _, out("v19") _);
    |                  -------------  ^^^^^^^^^^^^ register `v19`
@@ -605,7 +605,7 @@ LL |         asm!("", out("vs51") _, out("v19") _);
    |                  register `vs51`
 
 error: register `v20` conflicts with register `vs52`
-  --> $DIR/bad-reg.rs:312:33
+  --> $DIR/bad-reg.rs:304:33
    |
 LL |         asm!("", out("vs52") _, out("v20") _);
    |                  -------------  ^^^^^^^^^^^^ register `v20`
@@ -613,7 +613,7 @@ LL |         asm!("", out("vs52") _, out("v20") _);
    |                  register `vs52`
 
 error: register `v21` conflicts with register `vs53`
-  --> $DIR/bad-reg.rs:314:33
+  --> $DIR/bad-reg.rs:306:33
    |
 LL |         asm!("", out("vs53") _, out("v21") _);
    |                  -------------  ^^^^^^^^^^^^ register `v21`
@@ -621,7 +621,7 @@ LL |         asm!("", out("vs53") _, out("v21") _);
    |                  register `vs53`
 
 error: register `v22` conflicts with register `vs54`
-  --> $DIR/bad-reg.rs:316:33
+  --> $DIR/bad-reg.rs:308:33
    |
 LL |         asm!("", out("vs54") _, out("v22") _);
    |                  -------------  ^^^^^^^^^^^^ register `v22`
@@ -629,7 +629,7 @@ LL |         asm!("", out("vs54") _, out("v22") _);
    |                  register `vs54`
 
 error: register `v23` conflicts with register `vs55`
-  --> $DIR/bad-reg.rs:318:33
+  --> $DIR/bad-reg.rs:310:33
    |
 LL |         asm!("", out("vs55") _, out("v23") _);
    |                  -------------  ^^^^^^^^^^^^ register `v23`
@@ -637,7 +637,7 @@ LL |         asm!("", out("vs55") _, out("v23") _);
    |                  register `vs55`
 
 error: register `v24` conflicts with register `vs56`
-  --> $DIR/bad-reg.rs:320:33
+  --> $DIR/bad-reg.rs:312:33
    |
 LL |         asm!("", out("vs56") _, out("v24") _);
    |                  -------------  ^^^^^^^^^^^^ register `v24`
@@ -645,7 +645,7 @@ LL |         asm!("", out("vs56") _, out("v24") _);
    |                  register `vs56`
 
 error: register `v25` conflicts with register `vs57`
-  --> $DIR/bad-reg.rs:322:33
+  --> $DIR/bad-reg.rs:314:33
    |
 LL |         asm!("", out("vs57") _, out("v25") _);
    |                  -------------  ^^^^^^^^^^^^ register `v25`
@@ -653,7 +653,7 @@ LL |         asm!("", out("vs57") _, out("v25") _);
    |                  register `vs57`
 
 error: register `v26` conflicts with register `vs58`
-  --> $DIR/bad-reg.rs:324:33
+  --> $DIR/bad-reg.rs:316:33
    |
 LL |         asm!("", out("vs58") _, out("v26") _);
    |                  -------------  ^^^^^^^^^^^^ register `v26`
@@ -661,7 +661,7 @@ LL |         asm!("", out("vs58") _, out("v26") _);
    |                  register `vs58`
 
 error: register `v27` conflicts with register `vs59`
-  --> $DIR/bad-reg.rs:326:33
+  --> $DIR/bad-reg.rs:318:33
    |
 LL |         asm!("", out("vs59") _, out("v27") _);
    |                  -------------  ^^^^^^^^^^^^ register `v27`
@@ -669,7 +669,7 @@ LL |         asm!("", out("vs59") _, out("v27") _);
    |                  register `vs59`
 
 error: register `v28` conflicts with register `vs60`
-  --> $DIR/bad-reg.rs:328:33
+  --> $DIR/bad-reg.rs:320:33
    |
 LL |         asm!("", out("vs60") _, out("v28") _);
    |                  -------------  ^^^^^^^^^^^^ register `v28`
@@ -677,7 +677,7 @@ LL |         asm!("", out("vs60") _, out("v28") _);
    |                  register `vs60`
 
 error: register `v29` conflicts with register `vs61`
-  --> $DIR/bad-reg.rs:330:33
+  --> $DIR/bad-reg.rs:322:33
    |
 LL |         asm!("", out("vs61") _, out("v29") _);
    |                  -------------  ^^^^^^^^^^^^ register `v29`
@@ -685,7 +685,7 @@ LL |         asm!("", out("vs61") _, out("v29") _);
    |                  register `vs61`
 
 error: register `v30` conflicts with register `vs62`
-  --> $DIR/bad-reg.rs:332:33
+  --> $DIR/bad-reg.rs:324:33
    |
 LL |         asm!("", out("vs62") _, out("v30") _);
    |                  -------------  ^^^^^^^^^^^^ register `v30`
@@ -693,7 +693,7 @@ LL |         asm!("", out("vs62") _, out("v30") _);
    |                  register `vs62`
 
 error: register `v31` conflicts with register `vs63`
-  --> $DIR/bad-reg.rs:334:33
+  --> $DIR/bad-reg.rs:326:33
    |
 LL |         asm!("", out("vs63") _, out("v31") _);
    |                  -------------  ^^^^^^^^^^^^ register `v31`
@@ -701,145 +701,145 @@ LL |         asm!("", out("vs63") _, out("v31") _);
    |                  register `vs63`
 
 error: register class `spe_acc` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:340:26
+  --> $DIR/bad-reg.rs:332:26
    |
 LL |         asm!("/* {} */", out(spe_acc) _);
    |                          ^^^^^^^^^^^^^^
 
 error: cannot use register `r13`: r13 is a reserved register on this target
-  --> $DIR/bad-reg.rs:42:18
+  --> $DIR/bad-reg.rs:35:18
    |
 LL |         asm!("", out("r13") _);
    |                  ^^^^^^^^^^^^
 
 error: cannot use register `r29`: r29 is used internally by LLVM and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:44:18
+  --> $DIR/bad-reg.rs:37:18
    |
 LL |         asm!("", out("r29") _);
    |                  ^^^^^^^^^^^^
 
 error: register class `vreg` requires at least one of the following target features: altivec, vsx
-  --> $DIR/bad-reg.rs:55:18
+  --> $DIR/bad-reg.rs:48:18
    |
 LL |         asm!("", in("v0") v32x4); // requires altivec
    |                  ^^^^^^^^^^^^^^
 
 error: register class `vreg` requires at least one of the following target features: altivec, vsx
-  --> $DIR/bad-reg.rs:57:18
+  --> $DIR/bad-reg.rs:50:18
    |
 LL |         asm!("", out("v0") v32x4); // requires altivec
    |                  ^^^^^^^^^^^^^^^
 
 error: register class `vreg` requires at least one of the following target features: altivec, vsx
-  --> $DIR/bad-reg.rs:59:18
+  --> $DIR/bad-reg.rs:52:18
    |
 LL |         asm!("", in("v0") v64x2); // requires vsx
    |                  ^^^^^^^^^^^^^^
 
 error: register class `vreg` requires at least one of the following target features: altivec, vsx
-  --> $DIR/bad-reg.rs:62:18
+  --> $DIR/bad-reg.rs:55:18
    |
 LL |         asm!("", out("v0") v64x2); // requires vsx
    |                  ^^^^^^^^^^^^^^^
 
 error: register class `vreg` requires at least one of the following target features: altivec, vsx
-  --> $DIR/bad-reg.rs:65:18
+  --> $DIR/bad-reg.rs:58:18
    |
 LL |         asm!("", in("v0") x); // FIXME: should be ok if vsx is available
    |                  ^^^^^^^^^^
 
 error: register class `vreg` requires at least one of the following target features: altivec, vsx
-  --> $DIR/bad-reg.rs:68:18
+  --> $DIR/bad-reg.rs:61:18
    |
 LL |         asm!("", out("v0") x); // FIXME: should be ok if vsx is available
    |                  ^^^^^^^^^^^
 
 error: register class `vreg` requires at least one of the following target features: altivec, vsx
-  --> $DIR/bad-reg.rs:71:26
+  --> $DIR/bad-reg.rs:64:26
    |
 LL |         asm!("/* {} */", in(vreg) v32x4); // requires altivec
    |                          ^^^^^^^^^^^^^^
 
 error: register class `vreg` requires at least one of the following target features: altivec, vsx
-  --> $DIR/bad-reg.rs:73:26
+  --> $DIR/bad-reg.rs:66:26
    |
 LL |         asm!("/* {} */", in(vreg) v64x2); // requires vsx
    |                          ^^^^^^^^^^^^^^
 
 error: register class `vreg` requires at least one of the following target features: altivec, vsx
-  --> $DIR/bad-reg.rs:76:26
+  --> $DIR/bad-reg.rs:69:26
    |
 LL |         asm!("/* {} */", in(vreg) x); // FIXME: should be ok if vsx is available
    |                          ^^^^^^^^^^
 
 error: register class `vreg` requires at least one of the following target features: altivec, vsx
-  --> $DIR/bad-reg.rs:79:26
+  --> $DIR/bad-reg.rs:72:26
    |
 LL |         asm!("/* {} */", out(vreg) _); // requires altivec
    |                          ^^^^^^^^^^^
 
 error: register class `vsreg` requires the `vsx` target feature
-  --> $DIR/bad-reg.rs:98:18
+  --> $DIR/bad-reg.rs:90:18
    |
 LL |         asm!("", in("vs0") v32x4); // requires vsx
    |                  ^^^^^^^^^^^^^^^
 
 error: register class `vsreg` requires the `vsx` target feature
-  --> $DIR/bad-reg.rs:100:18
+  --> $DIR/bad-reg.rs:92:18
    |
 LL |         asm!("", out("vs0") v32x4); // requires vsx
    |                  ^^^^^^^^^^^^^^^^
 
 error: register class `vsreg` requires the `vsx` target feature
-  --> $DIR/bad-reg.rs:102:18
+  --> $DIR/bad-reg.rs:94:18
    |
 LL |         asm!("", in("vs0") v64x2); // requires vsx
    |                  ^^^^^^^^^^^^^^^
 
 error: register class `vsreg` requires the `vsx` target feature
-  --> $DIR/bad-reg.rs:104:18
+  --> $DIR/bad-reg.rs:96:18
    |
 LL |         asm!("", out("vs0") v64x2); // requires vsx
    |                  ^^^^^^^^^^^^^^^^
 
 error: register class `vsreg` requires the `vsx` target feature
-  --> $DIR/bad-reg.rs:106:18
+  --> $DIR/bad-reg.rs:98:18
    |
 LL |         asm!("", in("vs0") x); // FIXME: should be ok if vsx is available
    |                  ^^^^^^^^^^^
 
 error: register class `vsreg` requires the `vsx` target feature
-  --> $DIR/bad-reg.rs:109:18
+  --> $DIR/bad-reg.rs:101:18
    |
 LL |         asm!("", out("vs0") x); // FIXME: should be ok if vsx is available
    |                  ^^^^^^^^^^^^
 
 error: register class `vsreg` requires the `vsx` target feature
-  --> $DIR/bad-reg.rs:112:26
+  --> $DIR/bad-reg.rs:104:26
    |
 LL |         asm!("/* {} */", in(vsreg) v32x4); // requires vsx
    |                          ^^^^^^^^^^^^^^^
 
 error: register class `vsreg` requires the `vsx` target feature
-  --> $DIR/bad-reg.rs:114:26
+  --> $DIR/bad-reg.rs:106:26
    |
 LL |         asm!("/* {} */", in(vsreg) v64x2); // requires vsx
    |                          ^^^^^^^^^^^^^^^
 
 error: register class `vsreg` requires the `vsx` target feature
-  --> $DIR/bad-reg.rs:116:26
+  --> $DIR/bad-reg.rs:108:26
    |
 LL |         asm!("/* {} */", in(vsreg) x); // FIXME: should be ok if vsx is available
    |                          ^^^^^^^^^^^
 
 error: register class `vsreg` requires the `vsx` target feature
-  --> $DIR/bad-reg.rs:119:26
+  --> $DIR/bad-reg.rs:111:26
    |
 LL |         asm!("/* {} */", out(vsreg) _); // requires vsx
    |                          ^^^^^^^^^^^^
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:139:27
+  --> $DIR/bad-reg.rs:131:27
    |
 LL |         asm!("", in("cr") x);
    |                           ^
@@ -847,7 +847,7 @@ LL |         asm!("", in("cr") x);
    = note: register class `cr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:142:28
+  --> $DIR/bad-reg.rs:134:28
    |
 LL |         asm!("", out("cr") x);
    |                            ^
@@ -855,7 +855,7 @@ LL |         asm!("", out("cr") x);
    = note: register class `cr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:145:33
+  --> $DIR/bad-reg.rs:137:33
    |
 LL |         asm!("/* {} */", in(cr) x);
    |                                 ^
@@ -863,7 +863,7 @@ LL |         asm!("/* {} */", in(cr) x);
    = note: register class `cr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:152:28
+  --> $DIR/bad-reg.rs:144:28
    |
 LL |         asm!("", in("ctr") x);
    |                            ^
@@ -871,7 +871,7 @@ LL |         asm!("", in("ctr") x);
    = note: register class `ctr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:155:29
+  --> $DIR/bad-reg.rs:147:29
    |
 LL |         asm!("", out("ctr") x);
    |                             ^
@@ -879,7 +879,7 @@ LL |         asm!("", out("ctr") x);
    = note: register class `ctr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:158:34
+  --> $DIR/bad-reg.rs:150:34
    |
 LL |         asm!("/* {} */", in(ctr) x);
    |                                  ^
@@ -887,7 +887,7 @@ LL |         asm!("/* {} */", in(ctr) x);
    = note: register class `ctr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:165:27
+  --> $DIR/bad-reg.rs:157:27
    |
 LL |         asm!("", in("lr") x);
    |                           ^
@@ -895,7 +895,7 @@ LL |         asm!("", in("lr") x);
    = note: register class `lr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:168:28
+  --> $DIR/bad-reg.rs:160:28
    |
 LL |         asm!("", out("lr") x);
    |                            ^
@@ -903,7 +903,7 @@ LL |         asm!("", out("lr") x);
    = note: register class `lr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:171:33
+  --> $DIR/bad-reg.rs:163:33
    |
 LL |         asm!("/* {} */", in(lr) x);
    |                                 ^
@@ -911,7 +911,7 @@ LL |         asm!("/* {} */", in(lr) x);
    = note: register class `lr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:178:28
+  --> $DIR/bad-reg.rs:170:28
    |
 LL |         asm!("", in("xer") x);
    |                            ^
@@ -919,7 +919,7 @@ LL |         asm!("", in("xer") x);
    = note: register class `xer` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:181:29
+  --> $DIR/bad-reg.rs:173:29
    |
 LL |         asm!("", out("xer") x);
    |                             ^
@@ -927,7 +927,7 @@ LL |         asm!("", out("xer") x);
    = note: register class `xer` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:184:34
+  --> $DIR/bad-reg.rs:176:34
    |
 LL |         asm!("/* {} */", in(xer) x);
    |                                  ^

--- a/tests/ui/asm/powerpc/bad-reg.rs
+++ b/tests/ui/asm/powerpc/bad-reg.rs
@@ -14,25 +14,18 @@
 // ignore-tidy-file-linelength
 
 #![crate_type = "rlib"]
-#![feature(no_core, repr_simd, asm_experimental_arch)]
+#![feature(no_core, asm_experimental_arch)]
 #![no_core]
 #![allow(non_camel_case_types)]
 
 extern crate minicore;
+use minicore::simd::{i32x4, i64x2};
 use minicore::*;
-
-#[repr(simd)]
-pub struct i32x4([i32; 4]);
-#[repr(simd)]
-pub struct i64x2([i64; 2]);
-
-impl Copy for i32x4 {}
-impl Copy for i64x2 {}
 
 fn f() {
     let mut x = 0;
-    let mut v32x4 = i32x4([0; 4]);
-    let mut v64x2 = i64x2([0; 2]);
+    let mut v32x4 = i32x4::from_array([0; 4]);
+    let mut v64x2 = i64x2::from_array([0; 2]);
     unsafe {
         // Unsupported registers
         asm!("", out("sp") _);
@@ -91,7 +84,6 @@ fn f() {
         asm!("", out("v29") _);
         asm!("", out("v30") _);
         asm!("", out("v31") _);
-
 
         // vsreg
         asm!("", out("vs0") _); // always ok

--- a/tests/ui/asm/s390x/bad-reg.rs
+++ b/tests/ui/asm/s390x/bad-reg.rs
@@ -7,22 +7,18 @@
 //@ ignore-backends: gcc
 
 #![crate_type = "rlib"]
-#![feature(no_core, repr_simd)]
+#![feature(no_core)]
 #![no_core]
 #![allow(non_camel_case_types)]
 
 extern crate minicore;
+use minicore::simd::i64x2;
 use minicore::*;
-
-#[repr(simd)]
-pub struct i64x2([i64; 2]);
-
-impl Copy for i64x2 {}
 
 fn f() {
     let mut x = 0;
     let mut b = 0u8;
-    let mut v = i64x2([0; 2]);
+    let mut v = i64x2::from_array([0; 2]);
     unsafe {
         // Unsupported registers
         asm!("", out("r11") _);

--- a/tests/ui/asm/s390x/bad-reg.s390x.stderr
+++ b/tests/ui/asm/s390x/bad-reg.s390x.stderr
@@ -1,149 +1,149 @@
 error: invalid register `r11`: The frame pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:28:18
+  --> $DIR/bad-reg.rs:24:18
    |
 LL |         asm!("", out("r11") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `r15`: The stack pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:30:18
+  --> $DIR/bad-reg.rs:26:18
    |
 LL |         asm!("", out("r15") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `c0`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:32:18
+  --> $DIR/bad-reg.rs:28:18
    |
 LL |         asm!("", out("c0") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `c1`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:34:18
+  --> $DIR/bad-reg.rs:30:18
    |
 LL |         asm!("", out("c1") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `c2`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:36:18
+  --> $DIR/bad-reg.rs:32:18
    |
 LL |         asm!("", out("c2") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `c3`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:38:18
+  --> $DIR/bad-reg.rs:34:18
    |
 LL |         asm!("", out("c3") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `c4`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:40:18
+  --> $DIR/bad-reg.rs:36:18
    |
 LL |         asm!("", out("c4") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `c5`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:42:18
+  --> $DIR/bad-reg.rs:38:18
    |
 LL |         asm!("", out("c5") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `c6`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:44:18
+  --> $DIR/bad-reg.rs:40:18
    |
 LL |         asm!("", out("c6") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `c7`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:46:18
+  --> $DIR/bad-reg.rs:42:18
    |
 LL |         asm!("", out("c7") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `c8`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:48:18
+  --> $DIR/bad-reg.rs:44:18
    |
 LL |         asm!("", out("c8") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `c9`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:50:18
+  --> $DIR/bad-reg.rs:46:18
    |
 LL |         asm!("", out("c9") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `c10`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:52:18
+  --> $DIR/bad-reg.rs:48:18
    |
 LL |         asm!("", out("c10") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `c11`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:54:18
+  --> $DIR/bad-reg.rs:50:18
    |
 LL |         asm!("", out("c11") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `c12`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:56:18
+  --> $DIR/bad-reg.rs:52:18
    |
 LL |         asm!("", out("c12") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `c13`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:58:18
+  --> $DIR/bad-reg.rs:54:18
    |
 LL |         asm!("", out("c13") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `c14`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:60:18
+  --> $DIR/bad-reg.rs:56:18
    |
 LL |         asm!("", out("c14") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `c15`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:62:18
+  --> $DIR/bad-reg.rs:58:18
    |
 LL |         asm!("", out("c15") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `a0`: a0 and a1 are reserved for system use and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:64:18
+  --> $DIR/bad-reg.rs:60:18
    |
 LL |         asm!("", out("a0") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `a1`: a0 and a1 are reserved for system use and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:66:18
+  --> $DIR/bad-reg.rs:62:18
    |
 LL |         asm!("", out("a1") _);
    |                  ^^^^^^^^^^^
 
 error: register class `areg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:98:18
+  --> $DIR/bad-reg.rs:94:18
    |
 LL |         asm!("", in("a2") x);
    |                  ^^^^^^^^^^
 
 error: register class `areg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:101:18
+  --> $DIR/bad-reg.rs:97:18
    |
 LL |         asm!("", out("a2") x);
    |                  ^^^^^^^^^^^
 
 error: register class `areg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:104:26
+  --> $DIR/bad-reg.rs:100:26
    |
 LL |         asm!("/* {} */", in(areg) x);
    |                          ^^^^^^^^^^
 
 error: register class `areg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:107:26
+  --> $DIR/bad-reg.rs:103:26
    |
 LL |         asm!("/* {} */", out(areg) _);
    |                          ^^^^^^^^^^^
 
 error: register `f0` conflicts with register `v0`
-  --> $DIR/bad-reg.rs:112:31
+  --> $DIR/bad-reg.rs:108:31
    |
 LL |         asm!("", out("v0") _, out("f0") _);
    |                  -----------  ^^^^^^^^^^^ register `f0`
@@ -151,7 +151,7 @@ LL |         asm!("", out("v0") _, out("f0") _);
    |                  register `v0`
 
 error: register `f1` conflicts with register `v1`
-  --> $DIR/bad-reg.rs:114:31
+  --> $DIR/bad-reg.rs:110:31
    |
 LL |         asm!("", out("v1") _, out("f1") _);
    |                  -----------  ^^^^^^^^^^^ register `f1`
@@ -159,7 +159,7 @@ LL |         asm!("", out("v1") _, out("f1") _);
    |                  register `v1`
 
 error: register `f2` conflicts with register `v2`
-  --> $DIR/bad-reg.rs:116:31
+  --> $DIR/bad-reg.rs:112:31
    |
 LL |         asm!("", out("v2") _, out("f2") _);
    |                  -----------  ^^^^^^^^^^^ register `f2`
@@ -167,7 +167,7 @@ LL |         asm!("", out("v2") _, out("f2") _);
    |                  register `v2`
 
 error: register `f3` conflicts with register `v3`
-  --> $DIR/bad-reg.rs:118:31
+  --> $DIR/bad-reg.rs:114:31
    |
 LL |         asm!("", out("v3") _, out("f3") _);
    |                  -----------  ^^^^^^^^^^^ register `f3`
@@ -175,7 +175,7 @@ LL |         asm!("", out("v3") _, out("f3") _);
    |                  register `v3`
 
 error: register `f4` conflicts with register `v4`
-  --> $DIR/bad-reg.rs:120:31
+  --> $DIR/bad-reg.rs:116:31
    |
 LL |         asm!("", out("v4") _, out("f4") _);
    |                  -----------  ^^^^^^^^^^^ register `f4`
@@ -183,7 +183,7 @@ LL |         asm!("", out("v4") _, out("f4") _);
    |                  register `v4`
 
 error: register `f5` conflicts with register `v5`
-  --> $DIR/bad-reg.rs:122:31
+  --> $DIR/bad-reg.rs:118:31
    |
 LL |         asm!("", out("v5") _, out("f5") _);
    |                  -----------  ^^^^^^^^^^^ register `f5`
@@ -191,7 +191,7 @@ LL |         asm!("", out("v5") _, out("f5") _);
    |                  register `v5`
 
 error: register `f6` conflicts with register `v6`
-  --> $DIR/bad-reg.rs:124:31
+  --> $DIR/bad-reg.rs:120:31
    |
 LL |         asm!("", out("v6") _, out("f6") _);
    |                  -----------  ^^^^^^^^^^^ register `f6`
@@ -199,7 +199,7 @@ LL |         asm!("", out("v6") _, out("f6") _);
    |                  register `v6`
 
 error: register `f7` conflicts with register `v7`
-  --> $DIR/bad-reg.rs:126:31
+  --> $DIR/bad-reg.rs:122:31
    |
 LL |         asm!("", out("v7") _, out("f7") _);
    |                  -----------  ^^^^^^^^^^^ register `f7`
@@ -207,7 +207,7 @@ LL |         asm!("", out("v7") _, out("f7") _);
    |                  register `v7`
 
 error: register `f8` conflicts with register `v8`
-  --> $DIR/bad-reg.rs:128:31
+  --> $DIR/bad-reg.rs:124:31
    |
 LL |         asm!("", out("v8") _, out("f8") _);
    |                  -----------  ^^^^^^^^^^^ register `f8`
@@ -215,7 +215,7 @@ LL |         asm!("", out("v8") _, out("f8") _);
    |                  register `v8`
 
 error: register `f9` conflicts with register `v9`
-  --> $DIR/bad-reg.rs:130:31
+  --> $DIR/bad-reg.rs:126:31
    |
 LL |         asm!("", out("v9") _, out("f9") _);
    |                  -----------  ^^^^^^^^^^^ register `f9`
@@ -223,7 +223,7 @@ LL |         asm!("", out("v9") _, out("f9") _);
    |                  register `v9`
 
 error: register `f10` conflicts with register `v10`
-  --> $DIR/bad-reg.rs:132:32
+  --> $DIR/bad-reg.rs:128:32
    |
 LL |         asm!("", out("v10") _, out("f10") _);
    |                  ------------  ^^^^^^^^^^^^ register `f10`
@@ -231,7 +231,7 @@ LL |         asm!("", out("v10") _, out("f10") _);
    |                  register `v10`
 
 error: register `f11` conflicts with register `v11`
-  --> $DIR/bad-reg.rs:134:32
+  --> $DIR/bad-reg.rs:130:32
    |
 LL |         asm!("", out("v11") _, out("f11") _);
    |                  ------------  ^^^^^^^^^^^^ register `f11`
@@ -239,7 +239,7 @@ LL |         asm!("", out("v11") _, out("f11") _);
    |                  register `v11`
 
 error: register `f12` conflicts with register `v12`
-  --> $DIR/bad-reg.rs:136:32
+  --> $DIR/bad-reg.rs:132:32
    |
 LL |         asm!("", out("v12") _, out("f12") _);
    |                  ------------  ^^^^^^^^^^^^ register `f12`
@@ -247,7 +247,7 @@ LL |         asm!("", out("v12") _, out("f12") _);
    |                  register `v12`
 
 error: register `f13` conflicts with register `v13`
-  --> $DIR/bad-reg.rs:138:32
+  --> $DIR/bad-reg.rs:134:32
    |
 LL |         asm!("", out("v13") _, out("f13") _);
    |                  ------------  ^^^^^^^^^^^^ register `f13`
@@ -255,7 +255,7 @@ LL |         asm!("", out("v13") _, out("f13") _);
    |                  register `v13`
 
 error: register `f14` conflicts with register `v14`
-  --> $DIR/bad-reg.rs:140:32
+  --> $DIR/bad-reg.rs:136:32
    |
 LL |         asm!("", out("v14") _, out("f14") _);
    |                  ------------  ^^^^^^^^^^^^ register `f14`
@@ -263,7 +263,7 @@ LL |         asm!("", out("v14") _, out("f14") _);
    |                  register `v14`
 
 error: register `f15` conflicts with register `v15`
-  --> $DIR/bad-reg.rs:142:32
+  --> $DIR/bad-reg.rs:138:32
    |
 LL |         asm!("", out("v15") _, out("f15") _);
    |                  ------------  ^^^^^^^^^^^^ register `f15`
@@ -271,73 +271,73 @@ LL |         asm!("", out("v15") _, out("f15") _);
    |                  register `v15`
 
 error: invalid register `f16`: unknown register
-  --> $DIR/bad-reg.rs:145:32
+  --> $DIR/bad-reg.rs:141:32
    |
 LL |         asm!("", out("v16") _, out("f16") _);
    |                                ^^^^^^^^^^^^
 
 error: register class `vreg` requires the `vector` target feature
-  --> $DIR/bad-reg.rs:71:18
+  --> $DIR/bad-reg.rs:67:18
    |
 LL |         asm!("", in("v0") v);
    |                  ^^^^^^^^^^
 
 error: register class `vreg` requires the `vector` target feature
-  --> $DIR/bad-reg.rs:73:18
+  --> $DIR/bad-reg.rs:69:18
    |
 LL |         asm!("", out("v0") v);
    |                  ^^^^^^^^^^^
 
 error: register class `vreg` requires the `vector` target feature
-  --> $DIR/bad-reg.rs:75:18
+  --> $DIR/bad-reg.rs:71:18
    |
 LL |         asm!("", in("v0") x);
    |                  ^^^^^^^^^^
 
 error: register class `vreg` requires the `vector` target feature
-  --> $DIR/bad-reg.rs:77:18
+  --> $DIR/bad-reg.rs:73:18
    |
 LL |         asm!("", out("v0") x);
    |                  ^^^^^^^^^^^
 
 error: register class `vreg` requires the `vector` target feature
-  --> $DIR/bad-reg.rs:79:18
+  --> $DIR/bad-reg.rs:75:18
    |
 LL |         asm!("", in("v0") b);
    |                  ^^^^^^^^^^
 
 error: register class `vreg` requires the `vector` target feature
-  --> $DIR/bad-reg.rs:82:18
+  --> $DIR/bad-reg.rs:78:18
    |
 LL |         asm!("", out("v0") b);
    |                  ^^^^^^^^^^^
 
 error: register class `vreg` requires the `vector` target feature
-  --> $DIR/bad-reg.rs:85:26
+  --> $DIR/bad-reg.rs:81:26
    |
 LL |         asm!("/* {} */", in(vreg) v);
    |                          ^^^^^^^^^^
 
 error: register class `vreg` requires the `vector` target feature
-  --> $DIR/bad-reg.rs:87:26
+  --> $DIR/bad-reg.rs:83:26
    |
 LL |         asm!("/* {} */", in(vreg) x);
    |                          ^^^^^^^^^^
 
 error: register class `vreg` requires the `vector` target feature
-  --> $DIR/bad-reg.rs:89:26
+  --> $DIR/bad-reg.rs:85:26
    |
 LL |         asm!("/* {} */", in(vreg) b);
    |                          ^^^^^^^^^^
 
 error: register class `vreg` requires the `vector` target feature
-  --> $DIR/bad-reg.rs:92:26
+  --> $DIR/bad-reg.rs:88:26
    |
 LL |         asm!("/* {} */", out(vreg) _);
    |                          ^^^^^^^^^^^
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:98:27
+  --> $DIR/bad-reg.rs:94:27
    |
 LL |         asm!("", in("a2") x);
    |                           ^
@@ -345,7 +345,7 @@ LL |         asm!("", in("a2") x);
    = note: register class `areg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:101:28
+  --> $DIR/bad-reg.rs:97:28
    |
 LL |         asm!("", out("a2") x);
    |                            ^
@@ -353,7 +353,7 @@ LL |         asm!("", out("a2") x);
    = note: register class `areg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:104:35
+  --> $DIR/bad-reg.rs:100:35
    |
 LL |         asm!("/* {} */", in(areg) x);
    |                                   ^

--- a/tests/ui/asm/s390x/bad-reg.s390x_vector.stderr
+++ b/tests/ui/asm/s390x/bad-reg.s390x_vector.stderr
@@ -1,149 +1,149 @@
 error: invalid register `r11`: The frame pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:28:18
+  --> $DIR/bad-reg.rs:24:18
    |
 LL |         asm!("", out("r11") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `r15`: The stack pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:30:18
+  --> $DIR/bad-reg.rs:26:18
    |
 LL |         asm!("", out("r15") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `c0`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:32:18
+  --> $DIR/bad-reg.rs:28:18
    |
 LL |         asm!("", out("c0") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `c1`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:34:18
+  --> $DIR/bad-reg.rs:30:18
    |
 LL |         asm!("", out("c1") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `c2`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:36:18
+  --> $DIR/bad-reg.rs:32:18
    |
 LL |         asm!("", out("c2") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `c3`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:38:18
+  --> $DIR/bad-reg.rs:34:18
    |
 LL |         asm!("", out("c3") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `c4`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:40:18
+  --> $DIR/bad-reg.rs:36:18
    |
 LL |         asm!("", out("c4") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `c5`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:42:18
+  --> $DIR/bad-reg.rs:38:18
    |
 LL |         asm!("", out("c5") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `c6`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:44:18
+  --> $DIR/bad-reg.rs:40:18
    |
 LL |         asm!("", out("c6") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `c7`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:46:18
+  --> $DIR/bad-reg.rs:42:18
    |
 LL |         asm!("", out("c7") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `c8`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:48:18
+  --> $DIR/bad-reg.rs:44:18
    |
 LL |         asm!("", out("c8") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `c9`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:50:18
+  --> $DIR/bad-reg.rs:46:18
    |
 LL |         asm!("", out("c9") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `c10`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:52:18
+  --> $DIR/bad-reg.rs:48:18
    |
 LL |         asm!("", out("c10") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `c11`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:54:18
+  --> $DIR/bad-reg.rs:50:18
    |
 LL |         asm!("", out("c11") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `c12`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:56:18
+  --> $DIR/bad-reg.rs:52:18
    |
 LL |         asm!("", out("c12") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `c13`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:58:18
+  --> $DIR/bad-reg.rs:54:18
    |
 LL |         asm!("", out("c13") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `c14`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:60:18
+  --> $DIR/bad-reg.rs:56:18
    |
 LL |         asm!("", out("c14") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `c15`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:62:18
+  --> $DIR/bad-reg.rs:58:18
    |
 LL |         asm!("", out("c15") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `a0`: a0 and a1 are reserved for system use and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:64:18
+  --> $DIR/bad-reg.rs:60:18
    |
 LL |         asm!("", out("a0") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `a1`: a0 and a1 are reserved for system use and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:66:18
+  --> $DIR/bad-reg.rs:62:18
    |
 LL |         asm!("", out("a1") _);
    |                  ^^^^^^^^^^^
 
 error: register class `areg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:98:18
+  --> $DIR/bad-reg.rs:94:18
    |
 LL |         asm!("", in("a2") x);
    |                  ^^^^^^^^^^
 
 error: register class `areg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:101:18
+  --> $DIR/bad-reg.rs:97:18
    |
 LL |         asm!("", out("a2") x);
    |                  ^^^^^^^^^^^
 
 error: register class `areg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:104:26
+  --> $DIR/bad-reg.rs:100:26
    |
 LL |         asm!("/* {} */", in(areg) x);
    |                          ^^^^^^^^^^
 
 error: register class `areg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:107:26
+  --> $DIR/bad-reg.rs:103:26
    |
 LL |         asm!("/* {} */", out(areg) _);
    |                          ^^^^^^^^^^^
 
 error: register `f0` conflicts with register `v0`
-  --> $DIR/bad-reg.rs:112:31
+  --> $DIR/bad-reg.rs:108:31
    |
 LL |         asm!("", out("v0") _, out("f0") _);
    |                  -----------  ^^^^^^^^^^^ register `f0`
@@ -151,7 +151,7 @@ LL |         asm!("", out("v0") _, out("f0") _);
    |                  register `v0`
 
 error: register `f1` conflicts with register `v1`
-  --> $DIR/bad-reg.rs:114:31
+  --> $DIR/bad-reg.rs:110:31
    |
 LL |         asm!("", out("v1") _, out("f1") _);
    |                  -----------  ^^^^^^^^^^^ register `f1`
@@ -159,7 +159,7 @@ LL |         asm!("", out("v1") _, out("f1") _);
    |                  register `v1`
 
 error: register `f2` conflicts with register `v2`
-  --> $DIR/bad-reg.rs:116:31
+  --> $DIR/bad-reg.rs:112:31
    |
 LL |         asm!("", out("v2") _, out("f2") _);
    |                  -----------  ^^^^^^^^^^^ register `f2`
@@ -167,7 +167,7 @@ LL |         asm!("", out("v2") _, out("f2") _);
    |                  register `v2`
 
 error: register `f3` conflicts with register `v3`
-  --> $DIR/bad-reg.rs:118:31
+  --> $DIR/bad-reg.rs:114:31
    |
 LL |         asm!("", out("v3") _, out("f3") _);
    |                  -----------  ^^^^^^^^^^^ register `f3`
@@ -175,7 +175,7 @@ LL |         asm!("", out("v3") _, out("f3") _);
    |                  register `v3`
 
 error: register `f4` conflicts with register `v4`
-  --> $DIR/bad-reg.rs:120:31
+  --> $DIR/bad-reg.rs:116:31
    |
 LL |         asm!("", out("v4") _, out("f4") _);
    |                  -----------  ^^^^^^^^^^^ register `f4`
@@ -183,7 +183,7 @@ LL |         asm!("", out("v4") _, out("f4") _);
    |                  register `v4`
 
 error: register `f5` conflicts with register `v5`
-  --> $DIR/bad-reg.rs:122:31
+  --> $DIR/bad-reg.rs:118:31
    |
 LL |         asm!("", out("v5") _, out("f5") _);
    |                  -----------  ^^^^^^^^^^^ register `f5`
@@ -191,7 +191,7 @@ LL |         asm!("", out("v5") _, out("f5") _);
    |                  register `v5`
 
 error: register `f6` conflicts with register `v6`
-  --> $DIR/bad-reg.rs:124:31
+  --> $DIR/bad-reg.rs:120:31
    |
 LL |         asm!("", out("v6") _, out("f6") _);
    |                  -----------  ^^^^^^^^^^^ register `f6`
@@ -199,7 +199,7 @@ LL |         asm!("", out("v6") _, out("f6") _);
    |                  register `v6`
 
 error: register `f7` conflicts with register `v7`
-  --> $DIR/bad-reg.rs:126:31
+  --> $DIR/bad-reg.rs:122:31
    |
 LL |         asm!("", out("v7") _, out("f7") _);
    |                  -----------  ^^^^^^^^^^^ register `f7`
@@ -207,7 +207,7 @@ LL |         asm!("", out("v7") _, out("f7") _);
    |                  register `v7`
 
 error: register `f8` conflicts with register `v8`
-  --> $DIR/bad-reg.rs:128:31
+  --> $DIR/bad-reg.rs:124:31
    |
 LL |         asm!("", out("v8") _, out("f8") _);
    |                  -----------  ^^^^^^^^^^^ register `f8`
@@ -215,7 +215,7 @@ LL |         asm!("", out("v8") _, out("f8") _);
    |                  register `v8`
 
 error: register `f9` conflicts with register `v9`
-  --> $DIR/bad-reg.rs:130:31
+  --> $DIR/bad-reg.rs:126:31
    |
 LL |         asm!("", out("v9") _, out("f9") _);
    |                  -----------  ^^^^^^^^^^^ register `f9`
@@ -223,7 +223,7 @@ LL |         asm!("", out("v9") _, out("f9") _);
    |                  register `v9`
 
 error: register `f10` conflicts with register `v10`
-  --> $DIR/bad-reg.rs:132:32
+  --> $DIR/bad-reg.rs:128:32
    |
 LL |         asm!("", out("v10") _, out("f10") _);
    |                  ------------  ^^^^^^^^^^^^ register `f10`
@@ -231,7 +231,7 @@ LL |         asm!("", out("v10") _, out("f10") _);
    |                  register `v10`
 
 error: register `f11` conflicts with register `v11`
-  --> $DIR/bad-reg.rs:134:32
+  --> $DIR/bad-reg.rs:130:32
    |
 LL |         asm!("", out("v11") _, out("f11") _);
    |                  ------------  ^^^^^^^^^^^^ register `f11`
@@ -239,7 +239,7 @@ LL |         asm!("", out("v11") _, out("f11") _);
    |                  register `v11`
 
 error: register `f12` conflicts with register `v12`
-  --> $DIR/bad-reg.rs:136:32
+  --> $DIR/bad-reg.rs:132:32
    |
 LL |         asm!("", out("v12") _, out("f12") _);
    |                  ------------  ^^^^^^^^^^^^ register `f12`
@@ -247,7 +247,7 @@ LL |         asm!("", out("v12") _, out("f12") _);
    |                  register `v12`
 
 error: register `f13` conflicts with register `v13`
-  --> $DIR/bad-reg.rs:138:32
+  --> $DIR/bad-reg.rs:134:32
    |
 LL |         asm!("", out("v13") _, out("f13") _);
    |                  ------------  ^^^^^^^^^^^^ register `f13`
@@ -255,7 +255,7 @@ LL |         asm!("", out("v13") _, out("f13") _);
    |                  register `v13`
 
 error: register `f14` conflicts with register `v14`
-  --> $DIR/bad-reg.rs:140:32
+  --> $DIR/bad-reg.rs:136:32
    |
 LL |         asm!("", out("v14") _, out("f14") _);
    |                  ------------  ^^^^^^^^^^^^ register `f14`
@@ -263,7 +263,7 @@ LL |         asm!("", out("v14") _, out("f14") _);
    |                  register `v14`
 
 error: register `f15` conflicts with register `v15`
-  --> $DIR/bad-reg.rs:142:32
+  --> $DIR/bad-reg.rs:138:32
    |
 LL |         asm!("", out("v15") _, out("f15") _);
    |                  ------------  ^^^^^^^^^^^^ register `f15`
@@ -271,13 +271,13 @@ LL |         asm!("", out("v15") _, out("f15") _);
    |                  register `v15`
 
 error: invalid register `f16`: unknown register
-  --> $DIR/bad-reg.rs:145:32
+  --> $DIR/bad-reg.rs:141:32
    |
 LL |         asm!("", out("v16") _, out("f16") _);
    |                                ^^^^^^^^^^^^
 
 error: type `u8` cannot be used with this register class
-  --> $DIR/bad-reg.rs:79:27
+  --> $DIR/bad-reg.rs:75:27
    |
 LL |         asm!("", in("v0") b);
    |                           ^
@@ -285,7 +285,7 @@ LL |         asm!("", in("v0") b);
    = note: register class `vreg` supports these types: i32, f16, f32, i64, f64, i128, f128, i8x16, i16x8, i32x4, i64x2, f16x8, f32x4, f64x2
 
 error: type `u8` cannot be used with this register class
-  --> $DIR/bad-reg.rs:82:28
+  --> $DIR/bad-reg.rs:78:28
    |
 LL |         asm!("", out("v0") b);
    |                            ^
@@ -293,7 +293,7 @@ LL |         asm!("", out("v0") b);
    = note: register class `vreg` supports these types: i32, f16, f32, i64, f64, i128, f128, i8x16, i16x8, i32x4, i64x2, f16x8, f32x4, f64x2
 
 error: type `u8` cannot be used with this register class
-  --> $DIR/bad-reg.rs:89:35
+  --> $DIR/bad-reg.rs:85:35
    |
 LL |         asm!("/* {} */", in(vreg) b);
    |                                   ^
@@ -301,7 +301,7 @@ LL |         asm!("/* {} */", in(vreg) b);
    = note: register class `vreg` supports these types: i32, f16, f32, i64, f64, i128, f128, i8x16, i16x8, i32x4, i64x2, f16x8, f32x4, f64x2
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:98:27
+  --> $DIR/bad-reg.rs:94:27
    |
 LL |         asm!("", in("a2") x);
    |                           ^
@@ -309,7 +309,7 @@ LL |         asm!("", in("a2") x);
    = note: register class `areg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:101:28
+  --> $DIR/bad-reg.rs:97:28
    |
 LL |         asm!("", out("a2") x);
    |                            ^
@@ -317,7 +317,7 @@ LL |         asm!("", out("a2") x);
    = note: register class `areg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:104:35
+  --> $DIR/bad-reg.rs:100:35
    |
 LL |         asm!("/* {} */", in(areg) x);
    |                                   ^

--- a/tests/ui/codegen/deprecated-llvm-intrinsic.rs
+++ b/tests/ui/codegen/deprecated-llvm-intrinsic.rs
@@ -3,17 +3,15 @@
 //@ compile-flags: --target aarch64-unknown-linux-gnu
 //@ needs-llvm-components: aarch64
 //@ ignore-backends: gcc
-#![feature(no_core, lang_items, link_llvm_intrinsics, abi_unadjusted, repr_simd, simd_ffi)]
+#![feature(no_core, lang_items, link_llvm_intrinsics, abi_unadjusted, simd_ffi)]
 #![no_std]
 #![no_core]
 #![allow(internal_features, non_camel_case_types, improper_ctypes)]
 #![crate_type = "lib"]
 
 extern crate minicore;
+use minicore::simd::i8x8;
 use minicore::*;
-
-#[repr(simd)]
-pub struct i8x8([i8; 8]);
 
 extern "unadjusted" {
     #[deny(deprecated_llvm_intrinsic)]

--- a/tests/ui/codegen/deprecated-llvm-intrinsic.stderr
+++ b/tests/ui/codegen/deprecated-llvm-intrinsic.stderr
@@ -1,11 +1,11 @@
 error: using deprecated intrinsic `llvm.aarch64.neon.rbit.v8i8`, `llvm.bitreverse.v8i8` can be used instead
-  --> $DIR/deprecated-llvm-intrinsic.rs:21:5
+  --> $DIR/deprecated-llvm-intrinsic.rs:19:5
    |
 LL |     fn foo(a: i8x8) -> i8x8;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: the lint level is defined here
-  --> $DIR/deprecated-llvm-intrinsic.rs:19:12
+  --> $DIR/deprecated-llvm-intrinsic.rs:17:12
    |
 LL |     #[deny(deprecated_llvm_intrinsic)]
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
follow-up to https://github.com/rust-lang/rust/pull/159656.

I've used `grep -rlZ "repr_simd" . | xargs -0 grep -l "use minicore"` to find all test files that used both `repr_simd` and `use minicore`, they now all use `minicore::simd` to `repr_simd` is no longer needed for them.