### PR TITLE
Add -Zfat-lto-partitions to split fat LTO for parallel codegen

### DIFF
--- a/compiler/rustc_codegen_cranelift/src/driver/aot.rs
+++ b/compiler/rustc_codegen_cranelift/src/driver/aot.rs
@@ -331,7 +331,7 @@ impl WriteBackendMethods for AotDriver {
         _exported_symbols_for_lto: &[String],
         _each_linked_rlib_for_lto: &[PathBuf],
         _modules: Vec<FatLtoInput<Self>>,
-    ) -> CompiledModule {
+    ) -> rustc_codegen_ssa::back::write::CompiledModuleResults {
         unreachable!()
     }
 
@@ -361,7 +361,7 @@ impl WriteBackendMethods for AotDriver {
         _shared_emitter: &SharedEmitter,
         _tm_factory: TargetMachineFactoryFn<Self>,
         _thin: ThinModule<Self>,
-    ) -> CompiledModule {
+    ) -> rustc_codegen_ssa::back::write::CompiledModuleResults {
         unreachable!()
     }
 

--- a/compiler/rustc_codegen_gcc/src/lib.rs
+++ b/compiler/rustc_codegen_gcc/src/lib.rs
@@ -443,8 +443,9 @@ impl WriteBackendMethods for GccCodegenBackend {
         _exported_symbols_for_lto: &[String],
         each_linked_rlib_for_lto: &[PathBuf],
         modules: Vec<FatLtoInput<Self>>,
-    ) -> CompiledModule {
-        back::lto::run_fat(cgcx, &sess.prof, shared_emitter, each_linked_rlib_for_lto, modules)
+    ) -> rustc_codegen_ssa::back::write::CompiledModuleResults {
+        [back::lto::run_fat(cgcx, &sess.prof, shared_emitter, each_linked_rlib_for_lto, modules)]
+            .into()
     }
 
     fn run_thin_lto(
@@ -475,7 +476,7 @@ impl WriteBackendMethods for GccCodegenBackend {
         _shared_emitter: &SharedEmitter,
         _tm_factory: TargetMachineFactoryFn<Self>,
         _thin: ThinModule<Self>,
-    ) -> CompiledModule {
+    ) -> rustc_codegen_ssa::back::write::CompiledModuleResults {
         unreachable!()
     }
 

--- a/compiler/rustc_codegen_llvm/src/back/lto.rs
+++ b/compiler/rustc_codegen_llvm/src/back/lto.rs
@@ -10,11 +10,13 @@ use object::{Object, ObjectSection};
 use rustc_codegen_ssa::back::lto::{SerializedModule, ThinModule, ThinShared};
 use rustc_codegen_ssa::back::rmeta_link;
 use rustc_codegen_ssa::back::write::{
-    CodegenContext, FatLtoInput, SharedEmitter, TargetMachineFactoryFn, ThinLtoInput,
+    CodegenContext, CompiledModuleResults, FatLtoInput, SharedEmitter, TargetMachineFactoryFn,
+    ThinLtoInput, fat_lto_partition_module_name,
 };
 use rustc_codegen_ssa::traits::*;
 use rustc_codegen_ssa::{CompiledModule, ModuleCodegen, ModuleKind};
 use rustc_data_structures::fx::FxHashMap;
+use rustc_data_structures::jobserver;
 use rustc_data_structures::memmap::Mmap;
 use rustc_data_structures::profiling::SelfProfilerRef;
 use rustc_errors::{DiagCtxt, DiagCtxtHandle};
@@ -199,6 +201,7 @@ pub(crate) fn run_thin(
                       is deferred to the linker"
         );
     }
+
     thin_lto(cgcx, prof, dcx, modules, upstream_modules, &symbols_below_threshold)
 }
 
@@ -640,6 +643,124 @@ pub(crate) fn run_pass_manager(
     debug!("lto done");
 }
 
+/// Splits and codegens an optimized fat-LTO module into ordered partitions.
+pub(crate) fn codegen_fat_lto_partitioned(
+    cgcx: &CodegenContext,
+    prof: &SelfProfilerRef,
+    shared_emitter: &SharedEmitter,
+    tm_factory: TargetMachineFactoryFn<LlvmCodegenBackend>,
+    dcx: DiagCtxtHandle<'_>,
+    module: ModuleCodegen<ModuleLlvm>,
+) -> CompiledModuleResults {
+    let partitions = cgcx.fat_lto_partitions;
+    let buffers = {
+        let _timer = prof.generic_activity_with_arg("LLVM_fat_lto_split", &*module.name);
+        let mut out: Vec<*mut llvm::Buffer> = vec![std::ptr::null_mut(); partitions + 1];
+        if !unsafe {
+            llvm::LLVMRustFatLtoSplitModule(
+                module.module_llvm.llmod(),
+                partitions,
+                cgcx.module_config.verify_llvm_ir,
+                out.as_mut_ptr(),
+            )
+        } {
+            write::llvm_err(dcx, LlvmError::SplitFatLtoModule);
+        }
+        out.into_iter().map(|p| Buffer(unsafe { p.as_mut().unwrap() })).collect::<Vec<_>>()
+    };
+    let name = module.name.clone();
+    drop(module);
+
+    let codegen_partition = |i: usize, buffer: &Buffer| {
+        let dcx = DiagCtxt::new(Box::new(shared_emitter.clone()));
+        let dcx = dcx.handle();
+        let part_name = fat_lto_partition_module_name(&name, i);
+        let part_id = CString::new(part_name.as_str()).unwrap();
+        let module_llvm =
+            ModuleLlvm::parse(cgcx, Arc::clone(&tm_factory), &part_id, buffer.data(), dcx);
+        let module = ModuleCodegen::new_regular(part_name, module_llvm);
+        codegen(cgcx, prof, shared_emitter, module, &cgcx.module_config)
+    };
+
+    if cgcx.parallel {
+        enum PartitionMessage {
+            Token(io::Result<jobserver::Acquired>),
+            Done(usize, CompiledModule),
+            Panic(Box<dyn std::any::Any + Send>),
+        }
+
+        let (sender, receiver) = std::sync::mpsc::channel();
+        let token_sender = sender.clone();
+        let jobserver_helper = jobserver::client()
+            .into_helper_thread(move |token| {
+                drop(token_sender.send(PartitionMessage::Token(token)))
+            })
+            .expect("failed to spawn jobserver helper thread");
+        let mut partition_order = (0..buffers.len()).collect::<Vec<_>>();
+        partition_order.sort_unstable_by(|&a, &b| {
+            buffers[b].data().len().cmp(&buffers[a].data().len()).then(a.cmp(&b))
+        });
+        let next = std::sync::atomic::AtomicUsize::new(0);
+
+        std::thread::scope(|s| {
+            let (codegen_partition, buffers, partition_order, next) =
+                (&codegen_partition, &buffers, &partition_order, &next);
+            let spawn = |token: Option<jobserver::Acquired>| {
+                let sender = sender.clone();
+                s.spawn(move || {
+                    let _token = token;
+                    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                        let _profiler = cgcx
+                            .time_trace
+                            .then(<LlvmCodegenBackend as WriteBackendMethods>::thread_profiler);
+                        while let Some(&index) = partition_order
+                            .get(next.fetch_add(1, std::sync::atomic::Ordering::Relaxed))
+                        {
+                            let module = codegen_partition(index, &buffers[index]);
+                            if sender.send(PartitionMessage::Done(index, module)).is_err() {
+                                break;
+                            }
+                        }
+                    }));
+                    if let Err(panic) = result {
+                        drop(sender.send(PartitionMessage::Panic(panic)));
+                    }
+                });
+            };
+
+            let mut completed = 0;
+            let mut worker_count = 1;
+            let mut results = (0..buffers.len()).map(|_| None).collect::<Vec<_>>();
+            spawn(None);
+            jobserver_helper.request_token();
+
+            while completed != buffers.len() {
+                match receiver.recv().unwrap() {
+                    PartitionMessage::Token(token) => {
+                        let token = token.unwrap_or_else(|err| {
+                            dcx.fatal(format!("failed to acquire jobserver token: {err}"))
+                        });
+                        spawn(Some(token));
+                        worker_count += 1;
+                        if worker_count < buffers.len() {
+                            jobserver_helper.request_token();
+                        }
+                    }
+                    PartitionMessage::Done(index, module) => {
+                        results[index] = Some(module);
+                        completed += 1;
+                    }
+                    PartitionMessage::Panic(panic) => std::panic::resume_unwind(panic),
+                }
+            }
+
+            results.into_iter().map(Option::unwrap).collect()
+        })
+    } else {
+        buffers.iter().enumerate().map(|(i, buffer)| codegen_partition(i, buffer)).collect()
+    }
+}
+
 #[repr(transparent)]
 pub(crate) struct Buffer(&'static mut llvm::Buffer);
 
@@ -702,7 +823,7 @@ pub(crate) fn optimize_and_codegen_thin_module(
     shared_emitter: &SharedEmitter,
     tm_factory: TargetMachineFactoryFn<LlvmCodegenBackend>,
     thin_module: ThinModule<LlvmCodegenBackend>,
-) -> CompiledModule {
+) -> CompiledModuleResults {
     let dcx = DiagCtxt::new(Box::new(shared_emitter.clone()));
     let dcx = dcx.handle();
 
@@ -781,7 +902,7 @@ pub(crate) fn optimize_and_codegen_thin_module(
             save_temp_bitcode(cgcx, &module, "thin-lto-after-pm");
         }
     }
-    codegen(cgcx, prof, shared_emitter, module, &cgcx.module_config)
+    std::iter::once(codegen(cgcx, prof, shared_emitter, module, &cgcx.module_config)).collect()
 }
 
 /// Maps LLVM module identifiers to their corresponding LLVM LTO cache keys

--- a/compiler/rustc_codegen_llvm/src/errors.rs
+++ b/compiler/rustc_codegen_llvm/src/errors.rs
@@ -120,6 +120,8 @@ pub(crate) enum LlvmError<'a> {
     PrepareThinLtoModule,
     #[diag("failed to parse bitcode for LTO module")]
     ParseBitcode,
+    #[diag("failed to split fat LTO module into partitions")]
+    SplitFatLtoModule,
 }
 
 pub(crate) struct WithLlvmError<'a>(pub LlvmError<'a>, pub String);
@@ -147,6 +149,9 @@ impl<G: EmissionGuarantee> Diagnostic<'_, G> for WithLlvmError<'_> {
                 msg!("failed to prepare thin LTO module: {$llvm_err}")
             }
             ParseBitcode => msg!("failed to parse bitcode for LTO module: {$llvm_err}"),
+            SplitFatLtoModule => {
+                msg!("failed to split fat LTO module into partitions: {$llvm_err}")
+            }
         };
         self.0
             .into_diag(dcx, level)

--- a/compiler/rustc_codegen_llvm/src/lib.rs
+++ b/compiler/rustc_codegen_llvm/src/lib.rs
@@ -19,6 +19,7 @@ use std::any::Any;
 use std::ffi::CStr;
 use std::mem::ManuallyDrop;
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use back::owned_target_machine::OwnedTargetMachine;
 use back::write::{create_informational_target_machine, create_target_machine};
@@ -27,8 +28,8 @@ use llvm_util::target_config;
 use rustc_ast::expand::allocator::AllocatorMethod;
 use rustc_codegen_ssa::back::lto::ThinModule;
 use rustc_codegen_ssa::back::write::{
-    CodegenContext, FatLtoInput, ModuleConfig, SharedEmitter, TargetMachineFactoryConfig,
-    TargetMachineFactoryFn, ThinLtoInput,
+    CodegenContext, CompiledModuleResults, FatLtoInput, ModuleConfig, SharedEmitter,
+    TargetMachineFactoryConfig, TargetMachineFactoryFn, ThinLtoInput,
 };
 use rustc_codegen_ssa::traits::*;
 use rustc_codegen_ssa::{CompiledModule, CompiledModules, CrateInfo, ModuleCodegen, TargetConfig};
@@ -142,12 +143,12 @@ impl WriteBackendMethods for LlvmCodegenBackend {
         exported_symbols_for_lto: &[String],
         each_linked_rlib_for_lto: &[PathBuf],
         modules: Vec<FatLtoInput<Self>>,
-    ) -> CompiledModule {
+    ) -> CompiledModuleResults {
         let mut module = back::lto::run_fat(
             cgcx,
             &sess.prof,
             shared_emitter,
-            tm_factory,
+            Arc::clone(&tm_factory),
             exported_symbols_for_lto,
             each_linked_rlib_for_lto,
             modules,
@@ -157,7 +158,19 @@ impl WriteBackendMethods for LlvmCodegenBackend {
         let dcx = dcx.handle();
         back::lto::run_pass_manager(cgcx, &sess.prof, dcx, &mut module, false);
 
-        back::write::codegen(cgcx, &sess.prof, shared_emitter, module, &cgcx.module_config)
+        if cgcx.fat_lto_partitions > 1 {
+            back::lto::codegen_fat_lto_partitioned(
+                cgcx,
+                &sess.prof,
+                shared_emitter,
+                tm_factory,
+                dcx,
+                module,
+            )
+        } else {
+            [back::write::codegen(cgcx, &sess.prof, shared_emitter, module, &cgcx.module_config)]
+                .into()
+        }
     }
     fn run_thin_lto(
         cgcx: &CodegenContext,
@@ -191,7 +204,7 @@ impl WriteBackendMethods for LlvmCodegenBackend {
         shared_emitter: &SharedEmitter,
         tm_factory: TargetMachineFactoryFn<LlvmCodegenBackend>,
         thin: ThinModule<Self>,
-    ) -> CompiledModule {
+    ) -> CompiledModuleResults {
         back::lto::optimize_and_codegen_thin_module(cgcx, prof, shared_emitter, tm_factory, thin)
     }
     fn codegen(

--- a/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
@@ -2572,6 +2572,12 @@ unsafe extern "C" {
     pub(crate) fn LLVMRustModuleInstructionStats(M: &Module) -> u64;
 
     pub(crate) fn LLVMRustModuleSerialize(M: &Module, is_thin: bool) -> &'static mut Buffer;
+    pub(crate) fn LLVMRustFatLtoSplitModule(
+        M: &Module,
+        NumFnParts: size_t,
+        VerifyEach: bool,
+        OutBufs: *mut *mut Buffer,
+    ) -> bool;
     pub(crate) fn LLVMRustCreateThinLTOData(
         Modules: *const ThinLTOModule,
         NumModules: size_t,

--- a/compiler/rustc_codegen_ssa/src/back/write.rs
+++ b/compiler/rustc_codegen_ssa/src/back/write.rs
@@ -29,6 +29,7 @@ use rustc_session::config::{
 use rustc_span::source_map::SourceMap;
 use rustc_span::{FileName, InnerSpan, Span, SpanData};
 use rustc_target::spec::{MergeFunctions, SanitizerSet};
+use smallvec::{SmallVec, smallvec};
 use tracing::debug;
 
 use crate::back::link::ensure_removed;
@@ -41,6 +42,12 @@ use crate::{
 };
 
 const PRE_LTO_BC_EXT: &str = "pre-lto.bc";
+
+pub type CompiledModuleResults = SmallVec<[CompiledModule; 1]>;
+
+pub fn fat_lto_partition_module_name(base: &str, index: usize) -> String {
+    format!("{base}.fat-lto-part{index:04}")
+}
 
 /// What kind of object file to emit.
 #[derive(Clone, Copy, PartialEq, Encodable, Decodable)]
@@ -324,6 +331,7 @@ pub struct CodegenContext {
     pub lto: Lto,
     pub use_linker_plugin_lto: bool,
     pub dylib_lto: bool,
+    pub fat_lto_partitions: usize,
     pub prefer_dynamic: bool,
     pub save_temps: bool,
     pub fewer_names: bool,
@@ -617,10 +625,10 @@ pub fn produce_final_output_artifacts(
         // rlib.
         let needs_crate_object = crate_output.outputs.contains_key(&OutputType::Exe);
 
-        let keep_numbered_bitcode = user_wants_bitcode && sess.codegen_units().as_usize() > 1;
+        let keep_numbered_bitcode = user_wants_bitcode && compiled_modules.modules.len() > 1;
 
         let keep_numbered_objects =
-            needs_crate_object || (user_wants_objects && sess.codegen_units().as_usize() > 1);
+            needs_crate_object || (user_wants_objects && compiled_modules.modules.len() > 1);
 
         for module in compiled_modules.modules.iter() {
             if !keep_numbered_objects {
@@ -972,7 +980,7 @@ fn do_fat_lto<B: WriteBackendMethods>(
     exported_symbols_for_lto: &[String],
     each_linked_rlib_for_lto: &[PathBuf],
     needs_fat_lto: Vec<FatLtoInput<B>>,
-) -> CompiledModule {
+) -> Vec<CompiledModule> {
     let _timer = sess.prof.verbose_generic_activity("LLVM_fatlto");
 
     let dcx = DiagCtxt::new(Box::new(shared_emitter.clone()));
@@ -989,6 +997,7 @@ fn do_fat_lto<B: WriteBackendMethods>(
         each_linked_rlib_for_lto,
         needs_fat_lto,
     )
+    .into_vec()
 }
 
 fn do_thin_lto<B: WriteBackendMethods>(
@@ -1122,7 +1131,7 @@ fn do_thin_lto<B: WriteBackendMethods>(
                 used_token_count -= 1;
 
                 match result {
-                    Ok(compiled_module) => compiled_modules.push(compiled_module),
+                    Ok(modules) => compiled_modules.extend(modules),
                     Err(Some(WorkerFatalError)) => {
                         // Like `CodegenAborted`, wait for remaining work to finish.
                         codegen_aborted = Some(FatalError);
@@ -1180,7 +1189,7 @@ pub(crate) enum ThinLtoMessage {
 
     /// The backend has finished processing a work item for a codegen unit.
     /// Sent from a backend worker thread.
-    WorkItem { result: Result<CompiledModule, Option<WorkerFatalError>> },
+    WorkItem { result: Result<CompiledModuleResults, Option<WorkerFatalError>> },
 }
 
 /// A message sent from the coordinator thread to the main thread telling it to
@@ -1275,11 +1284,14 @@ fn start_executing_work<B: WriteBackendMethods>(
         None
     };
 
+    let fat_lto_partitions = sess.opts.unstable_opts.fat_lto_partitions;
+
     let cgcx = CodegenContext {
         crate_types: tcx.crate_types().to_vec(),
         lto: sess.lto(),
         use_linker_plugin_lto: sess.opts.cg.linker_plugin_lto.enabled(),
         dylib_lto: sess.opts.unstable_opts.dylib_lto,
+        fat_lto_partitions,
         prefer_dynamic: sess.opts.cg.prefer_dynamic,
         fewer_names: sess.fewer_names(),
         save_temps: sess.opts.cg.save_temps,
@@ -1911,7 +1923,7 @@ fn spawn_thin_lto_work<B: WriteBackendMethods>(
 
         let result = std::panic::catch_unwind(AssertUnwindSafe(|| match work {
             ThinLtoWorkItem::CopyPostLtoArtifacts(m) => {
-                execute_copy_from_cache_work_item(&cgcx, &prof, shared_emitter, m)
+                smallvec![execute_copy_from_cache_work_item(&cgcx, &prof, shared_emitter, m)]
             }
             ThinLtoWorkItem::ThinLto(m) => {
                 let _timer = prof.generic_activity_with_arg("codegen_module_perform_lto", m.name());
@@ -2150,7 +2162,7 @@ impl<B: WriteBackendMethods> OngoingCodegen<B> {
                 );
 
                 CompiledModules {
-                    modules: vec![do_fat_lto(
+                    modules: do_fat_lto(
                         sess,
                         &cgcx,
                         shared_emitter,
@@ -2158,7 +2170,7 @@ impl<B: WriteBackendMethods> OngoingCodegen<B> {
                         &crate_info.exported_symbols_for_lto,
                         &crate_info.each_linked_rlib_file_for_lto,
                         needs_fat_lto,
-                    )],
+                    ),
                     allocator_module: None,
                 }
             }

--- a/compiler/rustc_codegen_ssa/src/traits/write.rs
+++ b/compiler/rustc_codegen_ssa/src/traits/write.rs
@@ -44,7 +44,7 @@ pub trait WriteBackendMethods: Clone + 'static {
         exported_symbols_for_lto: &[String],
         each_linked_rlib_for_lto: &[PathBuf],
         modules: Vec<FatLtoInput<Self>>,
-    ) -> CompiledModule;
+    ) -> crate::back::write::CompiledModuleResults;
     /// Performs thin LTO by performing necessary global analysis and returning two
     /// lists, one of the modules that need optimization and another for modules that
     /// can simply be copied over from the incr. comp. cache.
@@ -69,7 +69,7 @@ pub trait WriteBackendMethods: Clone + 'static {
         shared_emitter: &SharedEmitter,
         tm_factory: TargetMachineFactoryFn<Self>,
         thin: ThinModule<Self>,
-    ) -> CompiledModule;
+    ) -> crate::back::write::CompiledModuleResults;
     fn codegen(
         cgcx: &CodegenContext,
         prof: &SelfProfilerRef,

--- a/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
@@ -2,8 +2,13 @@
 
 #include "llvm-c/Core.h"
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/EquivalenceClasses.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/Twine.h"
 #include "llvm/Analysis/Lint.h"
 #include "llvm/Analysis/TargetLibraryInfo.h"
 #if LLVM_VERSION_GE(22, 0)
@@ -14,6 +19,8 @@
 #include "llvm/CodeGen/CommandFlags.h"
 #include "llvm/IR/AssemblyAnnotationWriter.h"
 #include "llvm/IR/AutoUpgrade.h"
+#include "llvm/IR/Comdat.h"
+#include "llvm/IR/Constants.h"
 #include "llvm/IR/LegacyPassManager.h"
 #include "llvm/IR/PassManager.h"
 #include "llvm/IR/Verifier.h"
@@ -53,8 +60,10 @@
 #include "llvm/Transforms/Utils/AssignGUID.h"
 #endif
 #include "llvm/Transforms/Utils/CanonicalizeAliases.h"
+#include "llvm/Transforms/Utils/Cloning.h"
 #include "llvm/Transforms/Utils/FunctionImportUtils.h"
 #include "llvm/Transforms/Utils/NameAnonGlobals.h"
+#include <algorithm>
 #include <set>
 #include <string>
 #include <vector>
@@ -1511,6 +1520,240 @@ extern "C" LLVMModuleRef LLVMRustParseBitcodeForLTO(LLVMContextRef Context,
     return nullptr;
   }
   return wrap(std::move(*SrcOrError).release());
+}
+
+static void forEachFatLtoUser(
+    const Value *V, function_ref<void(const GlobalValue *)> Visit) {
+  SmallVector<const User *, 8> Worklist(V->user_begin(), V->user_end());
+  SmallPtrSet<const User *, 32> Seen;
+  while (!Worklist.empty()) {
+    const User *U = Worklist.pop_back_val();
+    if (!Seen.insert(U).second)
+      continue;
+    if (const auto *I = dyn_cast<Instruction>(U))
+      Visit(I->getFunction());
+    else if (const auto *GV = dyn_cast<GlobalValue>(U))
+      Visit(GV);
+    else if (isa<Constant>(U))
+      Worklist.append(U->user_begin(), U->user_end());
+    else
+      report_fatal_error("unexpected non-constant global value user");
+  }
+}
+
+static EquivalenceClasses<const GlobalValue *> findFatLtoClusters(Module &Mod) {
+  EquivalenceClasses<const GlobalValue *> Clusters;
+  DenseMap<const Comdat *, const GlobalValue *> ComdatMembers;
+
+  for (GlobalValue &GV : Mod.global_values()) {
+    if (GV.isDeclaration())
+      continue;
+    Clusters.insert(&GV);
+
+    if (const Comdat *C = GV.getComdat())
+      Clusters.unionSets(ComdatMembers.try_emplace(C, &GV).first->second, &GV);
+
+    const GlobalObject *Root = GV.getAliaseeObject();
+    if (const auto *IFunc = dyn_cast_or_null<GlobalIFunc>(Root))
+      Root = IFunc->getResolverFunction();
+    if (Root && Root != &GV)
+      Clusters.unionSets(&GV, Root);
+
+    if (const auto *F = dyn_cast<Function>(&GV))
+      for (const BasicBlock &BB : *F)
+        if (const BlockAddress *BA = BlockAddress::lookup(&BB); BA && BA->isConstantUsed())
+          forEachFatLtoUser(BA, [&](const GlobalValue *User) { Clusters.unionSets(F, User); });
+  }
+  return Clusters;
+}
+
+static void walkFatLtoConstants(
+    const Constant *Root,
+    function_ref<const Constant *(const GlobalValue *)> Visit) {
+  SmallVector<const Constant *, 16> Worklist(1, Root);
+  SmallPtrSet<const Constant *, 32> Seen;
+  while (!Worklist.empty()) {
+    const Constant *C = Worklist.pop_back_val();
+    if (!Seen.insert(C).second)
+      continue;
+    if (const auto *GV = dyn_cast<GlobalValue>(C)) {
+      if (const Constant *Next = Visit(GV))
+        Worklist.push_back(Next);
+      continue;
+    }
+    for (const Value *Operand : C->operands())
+      if (const auto *OperandC = dyn_cast<Constant>(Operand))
+        Worklist.push_back(OperandC);
+  }
+}
+
+extern "C" bool LLVMRustFatLtoSplitModule(LLVMModuleRef M, size_t NumFnParts,
+                                          bool VerifyEach,
+                                          LLVMRustBuffer **OutBufs) {
+  if (NumFnParts == 0 || NumFnParts > 256) {
+    LLVMRustSetLastError("invalid fat LTO partition count");
+    return false;
+  }
+
+  Module &Mod = *unwrap(M);
+  const unsigned DataPart = static_cast<unsigned>(NumFnParts);
+  EquivalenceClasses<const GlobalValue *> Clusters = findFatLtoClusters(Mod);
+  DenseMap<const GlobalValue *, unsigned> ClusterParts;
+
+  uint64_t TotalCost = 0;
+  for (const Function &F : Mod)
+    if (!F.isDeclaration())
+      TotalCost += std::max<uint64_t>(1, F.getInstructionCount());
+  const uint64_t Target = std::max<uint64_t>(
+      1, TotalCost / NumFnParts + (TotalCost % NumFnParts != 0));
+  uint64_t Accumulated = 0;
+  unsigned Current = 0;
+  for (const Function &F : Mod) {
+    if (F.isDeclaration())
+      continue;
+    ClusterParts.try_emplace(Clusters.getLeaderValue(&F), Current);
+    Accumulated += std::max<uint64_t>(1, F.getInstructionCount());
+    if (Accumulated >= Target * (Current + 1) && Current + 1 < NumFnParts)
+      ++Current;
+  }
+
+  if (!Mod.getModuleInlineAsm().empty())
+    for (const auto &Cluster : Clusters)
+      if (Cluster->isLeader())
+        ClusterParts[Cluster->getData()] = 0;
+
+  auto PartOf = [&](const GlobalValue *GV) -> unsigned {
+    auto Leader = Clusters.findLeader(GV);
+    if (Leader == Clusters.member_end())
+      return DataPart;
+    auto It = ClusterParts.find(*Leader);
+    return It == ClusterParts.end() ? DataPart : It->second;
+  };
+
+  std::vector<SmallPtrSet<const GlobalVariable *, 32>> ConstantDependencies(
+      NumFnParts);
+  for (const Function &F : Mod) {
+    if (F.isDeclaration())
+      continue;
+    auto &Dependencies = ConstantDependencies[PartOf(&F)];
+    for (const BasicBlock &BB : F)
+      for (const Instruction &I : BB)
+        for (const Value *Operand : I.operands())
+          if (const auto *C = dyn_cast<Constant>(Operand))
+            walkFatLtoConstants(C, [&](const GlobalValue *GV) -> const Constant * {
+              if (const auto *A = dyn_cast<GlobalAlias>(GV))
+                return A->getAliasee();
+              const auto *G = dyn_cast<GlobalVariable>(GV);
+              if (G && G->isConstant() && G->hasInitializer() &&
+                  !G->hasAppendingLinkage() && Dependencies.insert(G).second)
+                return G->getInitializer();
+              return nullptr;
+            });
+  }
+
+  SmallPtrSet<const GlobalValue *, 32> VirtualCrossPartitionUses;
+  for (unsigned P = 0; P != DataPart; ++P) {
+    auto &Dependencies = ConstantDependencies[P];
+    Dependencies.remove_if(
+        [&](const GlobalVariable *G) { return PartOf(G) != DataPart; });
+
+    for (const GlobalVariable *G : Dependencies) {
+      walkFatLtoConstants(G, [&](const GlobalValue *GV) -> const Constant * {
+        if (PartOf(GV) != P)
+          VirtualCrossPartitionUses.insert(GV);
+        const auto *Ref = dyn_cast<GlobalVariable>(GV);
+        return Ref && Dependencies.contains(Ref) && Ref->hasInitializer()
+                   ? Ref->getInitializer() : nullptr;
+      });
+    }
+  }
+
+  uint64_t AnonCounter = 0;
+  for (GlobalValue &GV : Mod.global_values()) {
+    if (!GV.hasLocalLinkage() || GV.isDeclaration())
+      continue;
+    bool UsedOutside = VirtualCrossPartitionUses.contains(&GV);
+    const unsigned Own = PartOf(&GV);
+    forEachFatLtoUser(&GV, [&](const GlobalValue *User) { UsedOutside |= PartOf(User) != Own; });
+    if (!UsedOutside)
+      continue;
+    if (GV.getName().starts_with(".L") || GV.getName().empty())
+      GV.setName("__rustc_fatlto_anon." + Twine(AnonCounter++));
+    GV.setLinkage(GlobalValue::ExternalLinkage);
+    GV.setVisibility(GlobalValue::HiddenVisibility);
+    GV.setDSOLocal(true);
+  }
+
+  SmallVector<std::unique_ptr<LLVMRustBuffer>, 16> Results;
+  Results.reserve(DataPart + 1);
+  for (unsigned P = 0; P <= DataPart; ++P) {
+    ValueToValueMapTy VMap;
+    std::unique_ptr<Module> Part =
+        CloneModule(Mod, VMap, [&](const GlobalValue *GV) {
+          const auto *G = dyn_cast<GlobalVariable>(GV);
+          return PartOf(GV) == P ||
+                 (P != DataPart && G && ConstantDependencies[P].contains(G));
+        });
+
+    for (const GlobalIFunc &IFunc : Mod.ifuncs()) {
+      if (PartOf(&IFunc) == P)
+        continue;
+      auto *Clone = dyn_cast_or_null<GlobalIFunc>(VMap.lookup(&IFunc));
+      if (!Clone)
+        continue;
+      Clone->setName("");
+      Function *Declaration = Function::Create(
+          cast<FunctionType>(IFunc.getValueType()),
+          GlobalValue::ExternalLinkage, IFunc.getAddressSpace(),
+          IFunc.getName(), Part.get());
+      Declaration->setVisibility(IFunc.getVisibility());
+      Declaration->setDLLStorageClass(IFunc.getDLLStorageClass());
+      Declaration->setDSOLocal(IFunc.isDSOLocal());
+      Declaration->setUnnamedAddr(IFunc.getUnnamedAddr());
+      Declaration->setPartition(IFunc.getPartition());
+      Clone->replaceAllUsesWith(Declaration);
+      Clone->eraseFromParent();
+    }
+
+    if (P != DataPart)
+      for (const GlobalVariable *G : ConstantDependencies[P]) {
+        auto *Clone = cast<GlobalVariable>(VMap.lookup(G));
+        Clone->setLinkage(GlobalValue::AvailableExternallyLinkage);
+        Clone->setComdat(nullptr);
+      }
+
+    for (const GlobalVariable &G : Mod.globals()) {
+      if (!G.hasAppendingLinkage() || PartOf(&G) == P)
+        continue;
+      auto *Clone = dyn_cast_or_null<GlobalVariable>(VMap.lookup(&G));
+      if (!Clone)
+        continue;
+      if (!Clone->use_empty()) {
+        LLVMRustSetLastError(
+            "unselected appending global still has uses after fat LTO split");
+        return false;
+      }
+      Clone->eraseFromParent();
+    }
+
+    for (GlobalValue &GV : make_early_inc_range(Part->global_values()))
+      if (GV.isDeclaration() && GV.use_empty())
+        GV.eraseFromParent();
+
+    if (P != 0)
+      Part->setModuleInlineAsm("");
+    if (VerifyEach && verifyModule(*Part, &errs())) {
+      LLVMRustSetLastError("fat LTO partition failed verification");
+      return false;
+    }
+    auto Ret = std::make_unique<LLVMRustBuffer>();
+    auto OS = raw_string_ostream(Ret->data);
+    WriteBitcodeToFile(*Part, OS);
+    Results.push_back(std::move(Ret));
+  }
+  for (unsigned P = 0; P <= DataPart; ++P)
+    OutBufs[P] = Results[P].release();
+  return true;
 }
 
 // Computes the LTO cache key for the provided 'ModId' in the given 'Data',

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -826,6 +826,7 @@ mod desc {
     pub(crate) const parse_opt_comma_list: &str = parse_comma_list;
     pub(crate) const parse_number: &str = "a number";
     pub(crate) const parse_opt_number: &str = parse_number;
+    pub(crate) const parse_fat_lto_partitions: &str = "an integer from 1 to 256";
     pub(crate) const parse_frame_pointer: &str = "one of `true`/`yes`/`on`, `false`/`no`/`off`, or (with -Zunstable-options) `non-leaf` or `always`";
     pub(crate) const parse_threads: &str = "a number or `sync`";
     pub(crate) const parse_time_passes_format: &str = "`text` (default) or `json`";
@@ -1199,6 +1200,14 @@ pub mod parse {
             }
             None => false,
         }
+    }
+
+    pub(crate) fn parse_fat_lto_partitions(slot: &mut usize, v: Option<&str>) -> bool {
+        let Some(partitions @ 1..=256) = v.and_then(|value| value.parse().ok()) else {
+            return false;
+        };
+        *slot = partitions;
+        true
     }
 
     /// Use this for any numeric option that lacks a static default.
@@ -2488,6 +2497,9 @@ options! {
         "rely on user specified linker commands to find clangrt"),
     extra_const_ub_checks: bool = (false, parse_bool, [TRACKED],
         "turns on more checks to detect const UB, which can be slow (default: no)"),
+    fat_lto_partitions: usize = (1, parse_fat_lto_partitions, [TRACKED],
+        "split the merged fat-LTO module into this many function partitions plus a data \
+        partition for parallel codegen (LLVM backend only; default: 1, no partitioning)"),
     #[rustc_lint_opt_deny_field_access("use `Session::fewer_names` instead of this field")]
     fewer_names: Option<bool> = (None, parse_opt_bool, [TRACKED],
         "reduce memory use by retaining fewer names within compilation artifacts (LLVM-IR) \

--- a/src/doc/unstable-book/src/compiler-flags/fat-lto-partitions.md
+++ b/src/doc/unstable-book/src/compiler-flags/fat-lto-partitions.md
@@ -1,0 +1,29 @@
+# `fat-lto-partitions`
+
+------------------------
+
+`-Zfat-lto-partitions=N` splits the merged fat-LTO module into `N` function
+partitions and a trailing data partition after the LTO optimization pipeline
+has run. Rustc then codegens them in parallel within the jobserver's budget.
+`N` must be between 1 and 256.
+
+The default (`1`) keeps single-module codegen. The flag applies to the LLVM
+backend with `-Clto=fat`, and to a merged `-Zfat-lto-crates` core under
+`-Clto=thin`.
+
+Partitioning happens after all interprocedural optimization, so each function
+is optimized exactly as without partitioning. Internal symbols referenced
+across partitions become hidden symbols in the object files. LLVM groups that
+must remain in one object, such as COMDAT members and ifunc resolvers, stay
+together. A module containing module-level inline assembly remains intact in
+the first partition because textual symbol references cannot be analyzed.
+Output is deterministic for a fixed `N`; different values of `N` lay the
+binary out differently.
+
+Example:
+
+```console
+RUSTFLAGS="-Zfat-lto-partitions=16" cargo +nightly build --release
+```
+
+(with `lto = "fat"` in the Cargo profile.)

--- a/tests/run-make/fat-lto-partitions/bench-compiler-ab.sh
+++ b/tests/run-make/fat-lto-partitions/bench-compiler-ab.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+set -euo pipefail
+export LC_ALL=C
+
+if (( $# != 3 )); then
+    echo "usage: $0 OLD_RUSTC NEW_RUSTC PROJECT_DIR" >&2
+    exit 2
+fi
+
+old_rustc=$(realpath "$1")
+new_rustc=$(realpath "$2")
+project=$(realpath "$3")
+package=${PACKAGE:-mud1-rs}
+binary=${BINARY:-mud1-studio}
+runs=${RUNS:-3}
+if [[ ! $runs =~ ^[1-9][0-9]*$ ]]; then
+    echo "RUNS must be a positive integer" >&2
+    exit 2
+fi
+old_target=${OLD_TARGET_DIR:-$project/target/fat-lto-perf-old}
+new_target=${NEW_TARGET_DIR:-$project/target/fat-lto-perf-new}
+results=${RESULTS:-$project/target/fat-lto-perf.tsv}
+artifacts=${ARTIFACTS_DIR:-$project/target/fat-lto-perf-artifacts}
+read -r -a rustc_args <<< "${RUSTC_ARGS:--Zfat-lto-partitions=16}"
+trial_artifacts=()
+
+mkdir -p "$artifacts"
+printf 'compiler\trun\telapsed_s\tuser_s\tsystem_s\tmax_rss_kib\n' > "$results"
+
+build() {
+    local rustc=$1
+    local target=$2
+    env RUSTC="$rustc" CARGO_INCREMENTAL=0 \
+        cargo rustc --locked --release --bin "$binary" --target-dir "$target" -- \
+        "${rustc_args[@]}"
+}
+
+trial() {
+    local compiler=$1
+    local run=$2
+    local rustc=$3
+    local target=$4
+    local artifact=$artifacts/$compiler-$run
+
+    echo "start: compiler=$compiler run=$run"
+    cargo clean --release -p "$package" --target-dir "$target"
+    env RUSTC="$rustc" CARGO_INCREMENTAL=0 \
+        /usr/bin/time -a -o "$results" \
+        -f "$compiler\t$run\t%e\t%U\t%S\t%M" \
+        cargo rustc --locked --release --bin "$binary" --target-dir "$target" -- \
+        "${rustc_args[@]}"
+    cp "$target/release/$binary" "$artifact"
+    trial_artifacts+=("$artifact")
+    sha256sum "$artifact"
+}
+
+cd "$project"
+build "$old_rustc" "$old_target"
+build "$new_rustc" "$new_target"
+
+old_run=0
+new_run=0
+for (( pair = 1; pair <= runs; pair++ )); do
+    if (( pair % 2 )); then
+        order=(new old)
+    else
+        order=(old new)
+    fi
+    for compiler in "${order[@]}"; do
+        if [[ $compiler == old ]]; then
+            ((++old_run))
+            trial old "$old_run" "$old_rustc" "$old_target"
+        else
+            ((++new_run))
+            trial new "$new_run" "$new_rustc" "$new_target"
+        fi
+    done
+done
+
+reference=${trial_artifacts[0]}
+if [[ ${ALLOW_NONIDENTICAL:-0} != 1 ]]; then
+    for artifact in "${trial_artifacts[@]}"; do
+        cmp "$reference" "$artifact"
+    done
+fi
+
+awk '
+    NR > 1 {
+        count[$1]++
+        elapsed[$1] += $3
+        elapsed_sq[$1] += $3 * $3
+        user[$1] += $4
+        rss[$1] += $6
+    }
+    END {
+        for (compiler in count) {
+            mean = elapsed[compiler] / count[compiler]
+            variance = count[compiler] > 1 \
+                ? (elapsed_sq[compiler] - count[compiler] * mean * mean) / (count[compiler] - 1) \
+                : 0
+            printf "%s: n=%d elapsed_mean=%.3fs elapsed_sd=%.3fs " \
+                "user_mean=%.3fs max_rss_mean=%.0fKiB\n", \
+                compiler, count[compiler], mean, sqrt(variance), \
+                user[compiler] / count[compiler], rss[compiler] / count[compiler]
+            means[compiler] = mean
+        }
+        printf "new-vs-old elapsed: %+.3fs (%+.3f%%; negative means new is faster)\n", \
+            means["new"] - means["old"], 100 * (means["new"] / means["old"] - 1)
+    }
+' "$results"

--- a/tests/run-make/fat-lto-partitions/main.rs
+++ b/tests/run-make/fat-lto-partitions/main.rs
@@ -1,0 +1,42 @@
+// Enough cross-function structure that the partitioner spreads user code and
+// exercises promotion: a shared static referenced from several functions and
+// trait objects whose vtables are address-significant.
+
+static TABLE: [u32; 8] = [3, 1, 4, 1, 5, 9, 2, 6];
+
+#[used]
+static KEEP: fn(u32) -> u32 = kept;
+
+#[inline(never)]
+fn kept(x: u32) -> u32 {
+    x.wrapping_mul(7)
+}
+
+trait Op {
+    fn apply(&self, x: u32) -> u32;
+}
+
+struct Add(u32);
+struct Xor(u32);
+
+impl Op for Add {
+    fn apply(&self, x: u32) -> u32 {
+        x.wrapping_add(self.0).wrapping_add(TABLE[(x % 8) as usize])
+    }
+}
+
+impl Op for Xor {
+    fn apply(&self, x: u32) -> u32 {
+        (x ^ self.0).rotate_left(TABLE[(x % 8) as usize])
+    }
+}
+
+#[inline(never)]
+fn mix(ops: &[Box<dyn Op>], seed: u32) -> u32 {
+    ops.iter().fold(seed, |acc, op| op.apply(acc))
+}
+
+fn main() {
+    let ops: Vec<Box<dyn Op>> = vec![Box::new(Add(17)), Box::new(Xor(0x5a5a)), Box::new(Add(3))];
+    println!("{}", mix(&ops, kept(41)));
+}

--- a/tests/run-make/fat-lto-partitions/rmake.rs
+++ b/tests/run-make/fat-lto-partitions/rmake.rs
@@ -1,0 +1,133 @@
+// Fat LTO with `-Zfat-lto-partitions` splits the merged module into several
+// codegen partitions. Check that a partitioned build produces a working
+// binary and that the split is deterministic (two identical invocations
+// produce identical binaries).
+
+//@ ignore-cross-compile
+//@ needs-target-std
+
+use run_make_support::{rfs, run, rustc};
+
+fn main() {
+    for invalid in ["0", "257"] {
+        rustc()
+            .input("main.rs")
+            .arg(format!("-Zfat-lto-partitions={invalid}"))
+            .run_fail()
+            .assert_stderr_contains("an integer from 1 to 256 was expected");
+    }
+
+    let build_single = |snapshot: &str, explicit: bool| {
+        let mut cmd = rustc();
+        cmd.input("main.rs")
+            .crate_name("single")
+            .opt_level("3")
+            .lto("fat")
+            .arg("-Zverify-llvm-ir")
+            .output("single-output");
+        if explicit {
+            cmd.arg("-Zfat-lto-partitions=1");
+        }
+        cmd.run();
+        rfs::copy("single-output", snapshot);
+    };
+    build_single("single-default", false);
+    build_single("single-explicit", true);
+    assert_eq!(rfs::read("single-default"), rfs::read("single-explicit"));
+
+    rfs::create_dir("emit");
+    rustc()
+        .input("main.rs")
+        .crate_name("emit_test")
+        .opt_level("3")
+        .lto("fat")
+        .arg("-Zfat-lto-partitions=4")
+        .arg("-Zverify-llvm-ir")
+        .emit("obj,llvm-bc")
+        .out_dir("emit")
+        .run();
+    let mut object_count = 0;
+    let mut bitcode_count = 0;
+    for entry in rfs::read_dir("emit") {
+        match entry.unwrap().path().extension().and_then(|extension| extension.to_str()) {
+            Some("o") => object_count += 1,
+            Some("bc") => bitcode_count += 1,
+            _ => {}
+        }
+    }
+    assert_eq!(object_count, 5);
+    assert_eq!(bitcode_count, 5);
+
+    let build = |out: &str, no_parallel_backend: bool| {
+        let mut cmd = rustc();
+        cmd.input("main.rs")
+            .opt_level("3")
+            .lto("fat")
+            .arg("-Zfat-lto-partitions=4")
+            .arg("-Zverify-llvm-ir")
+            .output(out);
+        if no_parallel_backend {
+            cmd.arg("-Zno-parallel-backend");
+        }
+        cmd.run();
+    };
+    build("main-a", false);
+    run("main-a");
+
+    build("main-b", false);
+    assert_eq!(rfs::read("main-a"), rfs::read("main-b"), "partitioned fat LTO is deterministic");
+
+    build("main-sequential", true);
+    assert_eq!(rfs::read("main-a"), rfs::read("main-sequential"));
+
+    check_saturated_jobserver();
+}
+
+#[cfg(not(target_os = "linux"))]
+fn check_saturated_jobserver() {}
+
+#[cfg(target_os = "linux")]
+fn check_saturated_jobserver() {
+    use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+    use std::process::Command;
+    use std::time::{Duration, Instant};
+
+    use run_make_support::{cwd, env_var, rustc_path};
+
+    // An empty jobserver pipe models a rustc process whose only capacity is the
+    // implicit token held by its parent. Partition work must continue on that
+    // token instead of waiting forever for another one.
+    let mut pipe = [0; 2];
+    assert_eq!(unsafe { run_make_support::libc::pipe(pipe.as_mut_ptr()) }, 0);
+    let read = unsafe { OwnedFd::from_raw_fd(pipe[0]) };
+    let write = unsafe { OwnedFd::from_raw_fd(pipe[1]) };
+
+    let dylib_env = env_var("LD_LIB_PATH_ENVVAR");
+    let dylib_path = std::env::join_paths(
+        [cwd(), env_var("HOST_RUSTC_DYLIB_PATH").into()]
+            .into_iter()
+            .chain(std::env::split_paths(&env_var(&dylib_env))),
+    )
+    .unwrap();
+    let jobserver = format!("--jobserver-auth={},{}", read.as_raw_fd(), write.as_raw_fd());
+    let mut child = Command::new(rustc_path())
+        .args(["main.rs", "-O", "-Clto=fat", "-Zfat-lto-partitions=4", "-o", "jobserver-saturated"])
+        .envs(["CARGO_MAKEFLAGS", "MAKEFLAGS", "MFLAGS"].map(|name| (name, &jobserver)))
+        .env(dylib_env, dylib_path)
+        .spawn()
+        .unwrap();
+
+    let deadline = Instant::now() + Duration::from_secs(30);
+    loop {
+        if let Some(status) = child.try_wait().unwrap() {
+            assert!(status.success(), "rustc failed with {status}");
+            break;
+        }
+        if Instant::now() >= deadline {
+            child.kill().unwrap();
+            child.wait().unwrap();
+            panic!("partitioned fat LTO stalled with a saturated jobserver");
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+}


### PR DESCRIPTION
Implements the partitioning half of [compiler-team MCP #1023](https://github.com/rust-lang/compiler-team/issues/1023).

`-Zfat-lto-partitions=N` keeps the existing fat-LTO merge and IR optimization pipeline. For values above one, it then splits the optimized module into `N` cost-balanced function partitions and one data partition, which rustc codegens in parallel within the jobserver budget. `N=1` remains the default and uses the existing single-module path.

The splitter keeps inseparable definitions together, falls back to partition zero for modules containing module-level inline assembly, and collects results in stable index order. Tests require byte-identical output for repeated builds at a fixed `N` and between parallel codegen and `-Zno-parallel-backend`.

On a warm-dependency final-binary rebuild of a personal project, using the same 16-thread host and `-Zverify-llvm-ir`:

- `N=1`: 155.50 s and 155.26 s; mean 155.38 s.
- `N=16`: 104.71 s and 102.42 s; mean 103.57 s, 33.3% less wall time.

Validation included LLVM, Cranelift, and GCC backend checks; fmt; tidy; Clippy for the touched SSA and LLVM crates; the `fat-lto-partitions` run-make suite; and `reproducible-build-2`.

This PR is experimental while the MCP is awaiting approval.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
