### PR TITLE
Improve diagnostic for nested missing turbofish

### DIFF
--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -1239,56 +1239,99 @@ impl<'a> Parser<'a> {
 
     /// When writing a turbofish with multiple type parameters missing the leading `::`, we will
     /// encounter a parse error when encountering the first `,`.
+    fn parse_mistyped_turbofish_with_multiple_type_params(
+        &mut self,
+        expr: &Expr,
+    ) -> Option<(Span, Option<Span>)> {
+        let ExprKind::Binary(binop, _, _) = &expr.kind else {
+            return None;
+        };
+        if binop.node != ast::BinOpKind::Lt || !self.eat(exp!(Comma)) {
+            return None;
+        }
+
+        let x =
+            self.parse_seq_to_before_end(exp!(Gt), SeqSep::trailing_allowed(exp!(Comma)), |p| {
+                match p.parse_generic_arg(None)? {
+                    Some(arg) => Ok(arg),
+                    // If we didn't eat a generic arg, then we should error.
+                    None => p.unexpected_any(),
+                }
+            });
+        match x {
+            Ok((_, _, Recovered::No)) if self.eat(exp!(Gt)) => {
+                let recovered_span = match self.parse_expr() {
+                    Ok(_) => Some(self.prev_token.span),
+                    Err(err) => {
+                        err.cancel();
+                        None
+                    }
+                };
+                Some((binop.span.shrink_to_lo(), recovered_span))
+            }
+            Ok((_, _, Recovered::No | Recovered::Yes(_))) => None,
+            Err(err) => {
+                err.cancel();
+                None
+            }
+        }
+    }
+
+    /// Check an entire call argument list for a turbofish that was parsed as separate arguments.
+    ///
+    /// For example, in `f(Foo<T, Bar<U, V>, W>::new())`, normal expression parsing accepts
+    /// `Foo<T` as the first argument. By the time parsing fails in the nested `Bar`, the outer
+    /// turbofish candidate is no longer available. Reparse from the opening parenthesis in a
+    /// diagnostic snapshot so we can suggest adding `::` at the outer `<`.
+    pub(super) fn mistyped_turbofish_in_call_args(&self) -> Option<Span> {
+        let mut snapshot = self.create_snapshot_for_diagnostic();
+        if !snapshot.eat(exp!(OpenParen)) {
+            return None;
+        }
+        if snapshot.token.ident().is_none() || !snapshot.look_ahead(1, |token| token == &token::Lt)
+        {
+            return None;
+        }
+        let expr = match snapshot.parse_expr() {
+            Ok(expr) => expr,
+            Err(err) => {
+                err.cancel();
+                return None;
+            }
+        };
+        snapshot
+            .parse_mistyped_turbofish_with_multiple_type_params(&expr)
+            .and_then(|(span, recovered_span)| recovered_span.map(|_| span))
+    }
+
     pub(super) fn check_mistyped_turbofish_with_multiple_type_params(
         &mut self,
         mut e: Diag<'a>,
         expr: &mut Box<Expr>,
     ) -> PResult<'a, ErrorGuaranteed> {
-        if let ExprKind::Binary(binop, _, _) = &expr.kind
-            && let ast::BinOpKind::Lt = binop.node
-            && self.eat(exp!(Comma))
-        {
-            let x = self.parse_seq_to_before_end(
-                exp!(Gt),
-                SeqSep::trailing_allowed(exp!(Comma)),
-                |p| match p.parse_generic_arg(None)? {
-                    Some(arg) => Ok(arg),
-                    // If we didn't eat a generic arg, then we should error.
-                    None => p.unexpected_any(),
-                },
-            );
-            match x {
-                Ok((_, _, Recovered::No)) => {
-                    if self.eat(exp!(Gt)) {
-                        // We made sense of it. Improve the error message.
-                        e.span_suggestion_verbose(
-                            binop.span.shrink_to_lo(),
-                            msg!("use `::<...>` instead of `<...>` to specify lifetime, type, or const arguments"),
-                            "::",
-                            Applicability::MaybeIncorrect,
-                        );
-                        match self.parse_expr() {
-                            Ok(_) => {
-                                // The subsequent expression is valid. Mark
-                                // `expr` as erroneous and emit `e` now, but
-                                // return `Ok` so parsing can continue.
-                                let guar = e.emit();
-                                *expr = self.mk_expr_err(expr.span.to(self.prev_token.span), guar);
-                                return Ok(guar);
-                            }
-                            Err(err) => {
-                                err.cancel();
-                            }
-                        }
-                    }
-                }
-                Ok((_, _, Recovered::Yes(_))) => {}
-                Err(err) => {
-                    err.cancel();
-                }
-            }
-        }
-        Err(e)
+        let Some((sugg_span, recovered_span)) =
+            self.parse_mistyped_turbofish_with_multiple_type_params(expr)
+        else {
+            return Err(e);
+        };
+
+        // We made sense of it. Improve the error message.
+        e.span_suggestion_verbose(
+            sugg_span,
+            msg!("use `::<...>` instead of `<...>` to specify lifetime, type, or const arguments"),
+            "::",
+            Applicability::MaybeIncorrect,
+        );
+
+        let Some(recovered_span) = recovered_span else {
+            return Err(e);
+        };
+
+        // The subsequent expression is valid. Mark `expr` as erroneous and emit `e` now, but
+        // return `Ok` so parsing can continue.
+        let guar = e.emit();
+        *expr = self.mk_expr_err(expr.span.to(recovered_span), guar);
+        Ok(guar)
     }
 
     /// Suggest add the missing `let` before the identifier in stmt

--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -19,7 +19,7 @@ use rustc_ast::{
 };
 use rustc_ast_pretty::pprust;
 use rustc_data_structures::stack::ensure_sufficient_stack;
-use rustc_errors::{Applicability, Diag, PResult, StashKey, Subdiagnostic};
+use rustc_errors::{Applicability, Diag, PResult, StashKey, Subdiagnostic, msg};
 use rustc_literal_escaper::unescape_char;
 use rustc_session::diagnostics::{ExprParenthesesNeeded, report_lit_error};
 use rustc_session::lint::builtin::BREAK_WITH_LABEL_AND_LOOP;
@@ -1289,6 +1289,20 @@ impl<'a> Parser<'a> {
                 return self.mk_expr(lo.to(self.prev_token.span), self.mk_call(fun, args));
             }
             Err(err) => Err(err),
+        };
+        let seq = match (seq, snapshot.as_ref()) {
+            (Err(mut err), Some((snapshot, _))) => {
+                if let Some(span) = snapshot.mistyped_turbofish_in_call_args() {
+                    err.span_suggestion_verbose(
+                        span,
+                        msg!("use `::<...>` instead of `<...>` to specify lifetime, type, or const arguments"),
+                        "::",
+                        Applicability::MaybeIncorrect,
+                    );
+                }
+                Err(err)
+            }
+            (seq, _) => seq,
         };
         match self.maybe_recover_struct_lit_bad_delims(lo, open_paren, seq, snapshot) {
             Ok(expr) => expr,

--- a/tests/ui/suggestions/suggest-turbofish-parsed-as-comparisons.rs
+++ b/tests/ui/suggestions/suggest-turbofish-parsed-as-comparisons.rs
@@ -1,0 +1,20 @@
+struct Many<A, B, C, D> {
+    a: A,
+    b: B,
+    c: C,
+    d: D,
+}
+
+impl<A, B, C, D> Many<A, B, C, D> {
+    fn new() -> Self {
+        todo!()
+    }
+}
+
+fn bar<T>(_: Many<T, T, T, T>) {}
+
+fn main() {
+    let _ = bar(Many<i32, Many<(), i32, (), ()>, i32, i32>::new());
+    //~^ ERROR expected expression, found `,`
+    //~| HELP use `::<...>` instead of `<...>`
+}

--- a/tests/ui/suggestions/suggest-turbofish-parsed-as-comparisons.stderr
+++ b/tests/ui/suggestions/suggest-turbofish-parsed-as-comparisons.stderr
@@ -1,0 +1,13 @@
+error: expected expression, found `,`
+  --> $DIR/suggest-turbofish-parsed-as-comparisons.rs:17:48
+   |
+LL |     let _ = bar(Many<i32, Many<(), i32, (), ()>, i32, i32>::new());
+   |                                                ^ expected expression
+   |
+help: use `::<...>` instead of `<...>` to specify lifetime, type, or const arguments
+   |
+LL |     let _ = bar(Many::<i32, Many<(), i32, (), ()>, i32, i32>::new());
+   |                     ++
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Fixes rust-lang/rust#159745.

When a missing turbofish contains a nested generic type, call parsing accepts the beginning of the outer generic list as separate arguments. The existing recovery therefore starts too late and points at the comma after the nested type.

This change probes the original call arguments in a diagnostic parser snapshot and attaches the suggestion to the outer less-than sign. The probe is restricted to the relevant identifier-plus-less-than shape and does not modify normal parser state.

Test coverage includes the reported nested case.

Tests:
- ./x test tests/ui/suggestions/suggest-turbofish-parsed-as-comparisons.rs
- ./x test tests/ui/parser --force-rerun
- ./x test tidy
- ./x fmt --check