### PR TITLE
rustc_trait_selection: fix trait solver hang caused by degenerate obligations

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/fulfill.rs
+++ b/compiler/rustc_trait_selection/src/traits/fulfill.rs
@@ -950,7 +950,35 @@ impl<'a, 'tcx> FulfillProcessor<'a, 'tcx> {
         }
 
         match project::poly_project_and_unify_term(&mut self.selcx, &project_obligation) {
-            ProjectAndUnifyResult::Holds(os) => ProcessResult::Changed(mk_pending(obligation, os)),
+            ProjectAndUnifyResult::Holds(os) if os.is_empty() => {
+                ProcessResult::Changed(mk_pending(obligation, os))
+            }
+            ProjectAndUnifyResult::Holds(os) => {
+                let input_projection_term = infcx
+                    .resolve_vars_if_possible(project_obligation.predicate)
+                    .map_bound(|p| p.projection_term);
+                let all_same_projection_term = os.iter().all(|o| {
+                    let Some(proj_clause) = o.predicate.as_projection_clause() else {
+                        return false;
+                    };
+                    infcx.resolve_vars_if_possible(proj_clause).map_bound(|p| p.projection_term)
+                        == input_projection_term
+                });
+                if all_same_projection_term {
+                    // Every nested obligation has the same projection term as the obligation
+                    // we are processing, so registering would make fulfillment process the same
+                    // obligation forever. This happens when unifying the projection with the
+                    // predicate's term spawns a delayed copy of the predicate itself, see
+                    // `InferCtxt::instantiate_var`. E.g. in Issue #159750, processing
+                    // `<_ as Queryable>::Output == ?0` returns `Holds` with the single nested
+                    // obligation `<_ as Queryable>::Output == ?1` where `?1` is merely unioned
+                    // with `?0`.
+                    // Since at this point the code will not compile, error immediately.
+                    ProcessResult::Error(FulfillmentErrorCode::Ambiguity { overflow: None })
+                } else {
+                    ProcessResult::Changed(mk_pending(obligation, os))
+                }
+            }
             ProjectAndUnifyResult::FailedNormalization => {
                 stalled_on.clear();
                 stalled_on.extend(args_infer_vars(

--- a/tests/ui/traits/projection-no-progress-cycle-issue-157516.rs
+++ b/tests/ui/traits/projection-no-progress-cycle-issue-157516.rs
@@ -1,0 +1,20 @@
+// Regression test for #157516: the same no-progress cycle as #159750, here
+// reached through a GAT whose parameter can't be inferred. Check that we
+// report an error instead of hanging.
+
+trait Bound {}
+
+trait Alloc {
+    const OPS: u32;
+}
+
+trait Driver {
+    type Object<Ctx: Bound>: Alloc;
+}
+
+fn f<T: Driver>() -> u32 {
+    T::Object::OPS
+    //~^ ERROR type annotations needed
+}
+
+fn main() {}

--- a/tests/ui/traits/projection-no-progress-cycle-issue-157516.stderr
+++ b/tests/ui/traits/projection-no-progress-cycle-issue-157516.stderr
@@ -1,0 +1,22 @@
+error[E0283]: type annotations needed
+  --> $DIR/projection-no-progress-cycle-issue-157516.rs:16:5
+   |
+LL |     T::Object::OPS
+   |     ^^^^^^^^^ cannot infer type for type parameter `Ctx` declared on the associated type `Object`
+   |
+   = note: the type must implement `Bound`
+   = note: associated types cannot be accessed directly on a `trait`, they can only be accessed through a specific `impl`
+note: required by a bound in `Driver::Object`
+  --> $DIR/projection-no-progress-cycle-issue-157516.rs:12:22
+   |
+LL |     type Object<Ctx: Bound>: Alloc;
+   |                      ^^^^^ required by this bound in `Driver::Object`
+help: use the fully qualified path to an implementation
+   |
+LL -     T::Object::OPS
+LL +     <Type as Bound>::Object::OPS
+   |
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0283`.

--- a/tests/ui/traits/projection-no-progress-cycle-issue-159750.rs
+++ b/tests/ui/traits/projection-no-progress-cycle-issue-159750.rs
@@ -1,0 +1,30 @@
+// Regression test for #159750. When `<T as Trait>::Assoc` can't be resolved
+// to a concrete type, equating it with an inference variable spawns a copy of
+// the obligation being processed, which fulfillment used to treat as progress
+// and loops forever. Check that we report an error instead of hanging.
+
+trait Container<T> {
+    type IDContainer;
+}
+
+impl<T> Container<T> for Option<T> {
+    type IDContainer = ();
+}
+
+trait Queryable {
+    type Output;
+    type Container;
+
+    fn finish(&self) -> <Self::Container as Container<Self::Output>>::IDContainer;
+    //~^ ERROR the trait bound `<Self as Queryable>::Container: Container<<Self as Queryable>::Output>` is not satisfied
+}
+
+fn follow<E>() -> impl Queryable<Container = Option<E>> {
+    //~^ ERROR the trait bound `(): Queryable` is not satisfied
+    loop {}
+}
+
+fn main() {
+    follow().finish();
+    //~^ ERROR type annotations needed
+}

--- a/tests/ui/traits/projection-no-progress-cycle-issue-159750.stderr
+++ b/tests/ui/traits/projection-no-progress-cycle-issue-159750.stderr
@@ -1,0 +1,35 @@
+error[E0277]: the trait bound `<Self as Queryable>::Container: Container<<Self as Queryable>::Output>` is not satisfied
+  --> $DIR/projection-no-progress-cycle-issue-159750.rs:18:25
+   |
+LL |     fn finish(&self) -> <Self::Container as Container<Self::Output>>::IDContainer;
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Container<<Self as Queryable>::Output>` is not implemented for `<Self as Queryable>::Container`
+   |
+help: consider further restricting the associated type
+   |
+LL |     fn finish(&self) -> <Self::Container as Container<Self::Output>>::IDContainer where <Self as Queryable>::Container: Container<<Self as Queryable>::Output>;
+   |                                                                                   ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+error[E0277]: the trait bound `(): Queryable` is not satisfied
+  --> $DIR/projection-no-progress-cycle-issue-159750.rs:22:19
+   |
+LL | fn follow<E>() -> impl Queryable<Container = Option<E>> {
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Queryable` is not implemented for `()`
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/projection-no-progress-cycle-issue-159750.rs:14:1
+   |
+LL | trait Queryable {
+   | ^^^^^^^^^^^^^^^
+
+error[E0284]: type annotations needed
+  --> $DIR/projection-no-progress-cycle-issue-159750.rs:28:14
+   |
+LL |     follow().finish();
+   |              ^^^^^^
+   |
+   = note: cannot satisfy `<impl Queryable<Container = Option<_>> as Queryable>::Output == _`
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0277, E0284.
+For more information about an error, try `rustc --explain E0277`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/159774)*
<!-- homu-ignore:end -->

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Closes https://github.com/rust-lang/rust/issues/157516 and https://github.com/rust-lang/rust/issues/159750.

Bisection pointed to rust-lang/rust#142712 but the problem has always been present. Fulfillment can go on forever if a degenerate obligation causes additional obligations from `poly_project_and_unify_term` to be copies of the degenerate one. 

Current fix is checking if the obligation is degenerate, ~making the degenerate case stall, waiting for other obligations to constrain its inference variables, so it can actually normalize or error instead of propagating this.~ error immediately since the code will not compile anyways.

I am not sure if this is ideal, might need to check perf due to the added heavy-ish condition check.