### PR TITLE
remove const hack in alloc

### DIFF
--- a/library/alloc/src/raw_vec/mod.rs
+++ b/library/alloc/src/raw_vec/mod.rs
@@ -560,11 +560,7 @@ const impl<A: [const] Allocator + [const] Destruct> RawVecInner<A> {
             self.alloc.allocate(new_layout)
         };
 
-        // FIXME(const-hack): switch back to `map_err`
-        match memory {
-            Ok(memory) => Ok(memory),
-            Err(_) => Err(AllocError { layout: new_layout, non_exhaustive: () }.into()),
-        }
+        memory.map_err(const |_| AllocError { layout: new_layout, non_exhaustive: () }.into())
     }
 }
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Seems like this change was missed when other const hacks were removed.