### PR TITLE
Enforce that we don't generate code for comptime fns

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/symbol_export.rs
+++ b/compiler/rustc_codegen_ssa/src/back/symbol_export.rs
@@ -3,6 +3,7 @@ use std::collections::hash_map::Entry::*;
 use rustc_abi::{CanonAbi, X86Call};
 use rustc_ast::expand::allocator::{AllocatorKind, NO_ALLOC_SHIM_IS_UNSTABLE, global_fn_name};
 use rustc_data_structures::unord::UnordMap;
+use rustc_hir as hir;
 use rustc_hir::def::DefKind;
 use rustc_hir::def_id::{CrateNum, DefId, DefIdMap, LOCAL_CRATE, LocalDefId};
 use rustc_middle::bug;
@@ -82,6 +83,11 @@ fn reachable_non_generics_provider(tcx: TyCtxt<'_>, _: LocalCrate) -> DefIdMap<S
 
             // Only consider nodes that actually have exported symbols.
             match tcx.def_kind(def_id) {
+                DefKind::Fn | DefKind::AssocFn
+                    if tcx.constness(def_id) == hir::Constness::Const { always: true } =>
+                {
+                    return None;
+                }
                 DefKind::Fn | DefKind::Static { .. } => {}
                 DefKind::AssocFn if tcx.impl_of_assoc(def_id.to_def_id()).is_some() => {}
                 _ => return None,

--- a/compiler/rustc_monomorphize/src/collector.rs
+++ b/compiler/rustc_monomorphize/src/collector.rs
@@ -1669,6 +1669,15 @@ impl<'v> RootCollector<'_, 'v> {
             && match self.strategy {
                 MonoItemCollectionStrategy::Eager => {
                     !matches!(self.tcx.codegen_fn_attrs(def_id).inline, InlineAttr::Force { .. })
+                    // comptime fns can't be codegenned, so we need to prevent collecting them even
+                    // with link-dead-code. Lazy mode prevents them by them not showing up in
+                    // `is_reachable_non_generic` (and `entry_fn` can't be comptime).
+                    && match self.tcx.def_kind(def_id) {
+                        DefKind::Fn | DefKind::AssocFn => {
+                            self.tcx.constness(def_id) != hir::Constness::Const { always: true }
+                        }
+                        _ => true,
+                    }
                 }
                 MonoItemCollectionStrategy::Lazy => {
                     self.entry_fn.and_then(|(id, _)| id.as_local()) == Some(def_id)

--- a/compiler/rustc_symbol_mangling/src/lib.rs
+++ b/compiler/rustc_symbol_mangling/src/lib.rs
@@ -87,6 +87,7 @@
 //! virtually impossible. Thus, symbol hash generation exclusively relies on
 //! DefPaths which are much more robust in the face of changes to the code base.
 
+use rustc_hir as hir;
 use rustc_hir::def::DefKind;
 use rustc_hir::def_id::{CrateNum, LOCAL_CRATE};
 use rustc_middle::middle::codegen_fn_attrs::{CodegenFnAttrFlags, CodegenFnAttrs};
@@ -240,6 +241,10 @@ fn compute_symbol_name<'tcx>(
 ) -> String {
     let def_id = instance.def_id();
     let args = instance.args;
+    let def_kind = tcx.def_kind(instance.def_id());
+    if let DefKind::Fn | DefKind::AssocFn = def_kind {
+        debug_assert!(tcx.constness(instance.def_id()) != hir::Constness::Const { always: true });
+    }
 
     debug!("symbol_name(def_id={:?}, args={:?})", def_id, args);
 
@@ -254,7 +259,7 @@ fn compute_symbol_name<'tcx>(
     // visibility) symbol. This means that multiple crates may do the same
     // and we want to be sure to avoid any symbol conflicts here.
     let is_globally_shared_function = matches!(
-        tcx.def_kind(instance.def_id()),
+        def_kind,
         DefKind::Fn
             | DefKind::AssocFn
             | DefKind::Closure

--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -3049,11 +3049,7 @@ pub const unsafe fn align_of_val<T: ?Sized>(ptr: *const T) -> usize;
 pub fn type_id_vtable(
     _id: crate::any::TypeId,
     _trait: crate::any::TypeId,
-) -> Option<ptr::DynMetadata<*const ()>> {
-    panic!(
-        "`TypeId::trait_info_of` and `trait_info_of_trait_type_id` can only be called at compile-time"
-    )
-}
+) -> Option<ptr::DynMetadata<*const ()>>;
 
 /// Compute the type information of a concrete type.
 /// It can only be called at compile time, the backends do
@@ -3114,9 +3110,7 @@ pub const fn type_id_eq(a: crate::any::TypeId, b: crate::any::TypeId) -> bool {
 #[rustc_intrinsic]
 #[unstable(feature = "core_intrinsics", issue = "none")]
 #[rustc_comptime]
-pub fn size_of_type_id(_id: crate::any::TypeId) -> Option<usize> {
-    panic!("`TypeId::size` can only be called at compile-time")
-}
+pub fn size_of_type_id(_id: crate::any::TypeId) -> Option<usize>;
 
 /// Gets the number of variants of the type represented by this `TypeId`.
 ///
@@ -3124,9 +3118,7 @@ pub fn size_of_type_id(_id: crate::any::TypeId) -> Option<usize> {
 #[rustc_intrinsic]
 #[unstable(feature = "core_intrinsics", issue = "none")]
 #[rustc_comptime]
-pub fn type_id_variants(_id: crate::any::TypeId) -> usize {
-    panic!("`TypeId::variants` can only be called at compile-time")
-}
+pub fn type_id_variants(_id: crate::any::TypeId) -> usize;
 
 /// Gets the number of fields at the given `variant_index` represented by this `TypeId`.
 ///
@@ -3134,9 +3126,7 @@ pub fn type_id_variants(_id: crate::any::TypeId) -> usize {
 #[rustc_intrinsic]
 #[unstable(feature = "core_intrinsics", issue = "none")]
 #[rustc_comptime]
-pub fn type_id_fields(_id: crate::any::TypeId, _variant_index: usize) -> usize {
-    panic!("`TypeId::fields` can only be called at compile-time")
-}
+pub fn type_id_fields(_id: crate::any::TypeId, _variant_index: usize) -> usize;
 
 /// Gets the [`FieldRepresentingType`]'s `TypeId` at the given index of the type represented by this `TypeId`.
 ///
@@ -3150,9 +3140,7 @@ pub fn type_id_field_representing_type(
     _id: crate::any::TypeId,
     _variant_index: usize,
     _field_index: usize,
-) -> crate::any::TypeId {
-    panic!("`TypeId::field` can only be called at compile-time")
-}
+) -> crate::any::TypeId;
 
 /// Gets the actual field `TypeId` of the [`FieldRepresentingType`]'s `TypeId`.
 ///
@@ -3164,9 +3152,7 @@ pub fn type_id_field_representing_type(
 #[rustc_comptime]
 pub fn field_representing_type_actual_type_id(
     _frt_type_id: crate::any::TypeId,
-) -> crate::any::TypeId {
-    panic!("`FieldId::type_id` can only be called at compile-time")
-}
+) -> crate::any::TypeId;
 
 /// Lowers in MIR to `Rvalue::Aggregate` with `AggregateKind::RawPtr`.
 ///

--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -873,7 +873,8 @@ pub const unsafe fn transmute_unchecked<Src, Dst>(src: Src) -> Dst;
 #[rustc_intrinsic_const_stable_indirect]
 #[rustc_nounwind]
 #[rustc_intrinsic]
-pub const fn needs_drop<T: ?Sized>() -> bool;
+#[rustc_comptime]
+pub fn needs_drop<T: ?Sized>() -> bool;
 
 /// Calculates the offset from a pointer.
 ///
@@ -2945,7 +2946,8 @@ pub unsafe fn vtable_align(ptr: *const ()) -> usize;
 #[unstable(feature = "core_intrinsics", issue = "none")]
 #[rustc_intrinsic_const_stable_indirect]
 #[rustc_intrinsic]
-pub const fn size_of<T>() -> usize;
+#[rustc_comptime]
+pub fn size_of<T>() -> usize;
 
 /// The minimum alignment of a type.
 ///
@@ -2964,7 +2966,8 @@ pub const fn size_of<T>() -> usize;
 #[unstable(feature = "core_intrinsics", issue = "none")]
 #[rustc_intrinsic_const_stable_indirect]
 #[rustc_intrinsic]
-pub const fn align_of<T>() -> usize;
+#[rustc_comptime]
+pub fn align_of<T>() -> usize;
 
 /// The offset of a field inside a type.
 ///
@@ -2984,7 +2987,8 @@ pub const fn align_of<T>() -> usize;
 #[rustc_intrinsic_const_stable_indirect]
 #[rustc_intrinsic]
 #[lang = "offset_of"]
-pub const fn offset_of<T: PointeeSized>(variant: u32, field: u32) -> usize;
+#[rustc_comptime]
+pub fn offset_of<T: PointeeSized>(variant: u32, field: u32) -> usize;
 
 /// The offset of a field queried by its field representing type.
 ///
@@ -2998,7 +3002,8 @@ pub const fn offset_of<T: PointeeSized>(variant: u32, field: u32) -> usize;
 #[rustc_intrinsic]
 #[unstable(feature = "field_projections", issue = "145383")]
 #[rustc_const_unstable(feature = "field_projections", issue = "145383")]
-pub const fn field_offset<F: crate::field::Field>() -> usize;
+#[rustc_comptime]
+pub fn field_offset<F: crate::field::Field>() -> usize;
 
 /// Returns the number of variants of the type `T` cast to a `usize`;
 /// if `T` has no variants, returns `0`. Uninhabited variants will be counted.
@@ -3012,7 +3017,8 @@ pub const fn field_offset<F: crate::field::Field>() -> usize;
 #[rustc_nounwind]
 #[unstable(feature = "core_intrinsics", issue = "none")]
 #[rustc_intrinsic]
-pub const fn variant_count<T>() -> usize;
+#[rustc_comptime]
+pub fn variant_count<T>() -> usize;
 
 /// The size of the referenced value in bytes.
 ///
@@ -3056,9 +3062,8 @@ pub fn type_id_vtable(
 /// not implement it.
 #[rustc_intrinsic]
 #[unstable(feature = "core_intrinsics", issue = "none")]
-pub const fn type_of(_id: crate::any::TypeId) -> crate::mem::type_info::Type {
-    panic!("`TypeId::info` can only be called at compile-time")
-}
+#[rustc_comptime]
+pub fn type_of(_id: crate::any::TypeId) -> crate::mem::type_info::Type;
 
 /// Gets a static string slice containing the name of a type.
 ///
@@ -3071,7 +3076,8 @@ pub const fn type_of(_id: crate::any::TypeId) -> crate::mem::type_info::Type {
 #[rustc_nounwind]
 #[unstable(feature = "core_intrinsics", issue = "none")]
 #[rustc_intrinsic]
-pub const fn type_name<T: ?Sized>() -> &'static str;
+#[rustc_comptime]
+pub fn type_name<T: ?Sized>() -> &'static str;
 
 /// Gets an identifier which is globally unique to the specified type. This
 /// function will return the same value for a type regardless of whichever

--- a/library/core/src/mem/type_info.rs
+++ b/library/core/src/mem/type_info.rs
@@ -37,7 +37,8 @@ impl TypeId {
     /// It can only be called at compile time.
     #[unstable(feature = "type_info", issue = "146922")]
     #[rustc_const_unstable(feature = "type_info", issue = "146922")]
-    pub const fn info(self) -> Type {
+    #[rustc_comptime]
+    pub fn info(self) -> Type {
         type_of(self)
     }
 }

--- a/tests/ui/comptime/link-dead-code.rs
+++ b/tests/ui/comptime/link-dead-code.rs
@@ -1,0 +1,11 @@
+//@ build-pass
+//@ compile-flags: -Clink-dead-code
+//! Check that we don't try to generate assembly for comptime
+//! fns, even when link-dead-code is active.
+
+#![feature(rustc_attrs)]
+
+#[rustc_comptime]
+fn f() {}
+
+fn main() {}

--- a/tests/ui/consts/const-eval/const-eval-intrinsic-promotion.rs
+++ b/tests/ui/consts/const-eval/const-eval-intrinsic-promotion.rs
@@ -1,6 +1,6 @@
 #![feature(core_intrinsics)]
 fn main() {
     // Test that calls to intrinsics are never promoted
-    let x: &'static usize =
-        &std::intrinsics::size_of::<i32>(); //~ ERROR temporary value dropped while borrowed
+    let x: &'static () =
+        &std::intrinsics::cold_path(); //~ ERROR temporary value dropped while borrowed
 }

--- a/tests/ui/consts/const-eval/const-eval-intrinsic-promotion.stderr
+++ b/tests/ui/consts/const-eval/const-eval-intrinsic-promotion.stderr
@@ -1,10 +1,10 @@
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/const-eval-intrinsic-promotion.rs:5:10
    |
-LL |     let x: &'static usize =
-   |            -------------- type annotation requires that borrow lasts for `'static`
-LL |         &std::intrinsics::size_of::<i32>();
-   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ creates a temporary value which is freed while still in use
+LL |     let x: &'static () =
+   |            ----------- type annotation requires that borrow lasts for `'static`
+LL |         &std::intrinsics::cold_path();
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ creates a temporary value which is freed while still in use
 LL | }
    | - temporary value is freed at the end of this statement
 


### PR DESCRIPTION
... by ICEing if you try to compute a symbol for them. There are various other ways we can assert it, but they were all a bit icky or already unreachable.

r? @fmease (since you asked about it in https://github.com/rust-lang/rust/pull/159727#discussion_r3636421134)


