### PR TITLE
check `extern "custom"` function pointers

### DIFF
--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -2484,6 +2484,10 @@ impl FnPtrTy {
     pub fn header(&self) -> FnHeader {
         FnHeader { constness: Const::No, coroutine_kind: None, safety: self.safety, ext: self.ext }
     }
+
+    pub fn as_borrowed_fn_sig<'a>(&'a self) -> BorrowedFnSig<'a> {
+        BorrowedFnSig { header: self.header(), decl: &self.decl, span: self.decl_span }
+    }
 }
 
 #[derive(Clone, Encodable, Decodable, Debug, Walkable)]

--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -2480,6 +2480,12 @@ pub struct FnPtrTy {
     pub decl_span: Span,
 }
 
+impl FnPtrTy {
+    pub fn header(&self) -> FnHeader {
+        FnHeader { constness: Const::No, coroutine_kind: None, safety: self.safety, ext: self.ext }
+    }
+}
+
 #[derive(Clone, Encodable, Decodable, Debug, Walkable)]
 pub struct UnsafeBinderTy {
     pub generic_params: ThinVec<GenericParam>,

--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -2362,6 +2362,19 @@ impl FnSig {
     pub fn extern_span(&self) -> Span {
         self.header.ext.span().unwrap_or(self.safety_span().shrink_to_hi())
     }
+
+    pub fn as_borrowed(&self) -> BorrowedFnSig<'_> {
+        BorrowedFnSig { header: self.header, decl: &self.decl, span: self.span }
+    }
+}
+
+/// A borrowed version of `FnSig`, used to share logic between function declarations and function
+/// pointer types.
+#[derive(Clone, Debug)]
+pub struct BorrowedFnSig<'a> {
+    pub header: FnHeader,
+    pub decl: &'a FnDecl,
+    pub span: Span,
 }
 
 /// A constraint on an associated item.

--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -2339,27 +2339,7 @@ pub struct FnSig {
 impl FnSig {
     /// Return a span encompassing the header, or where to insert it if empty.
     pub fn header_span(&self) -> Span {
-        match self.header.ext {
-            Extern::Implicit(span) | Extern::Explicit(_, span) => {
-                return self.span.with_hi(span.hi());
-            }
-            Extern::None => {}
-        }
-
-        match self.header.safety {
-            Safety::Unsafe(span) | Safety::Safe(span) => return self.span.with_hi(span.hi()),
-            Safety::Default => {}
-        };
-
-        if let Some(coroutine_kind) = self.header.coroutine_kind {
-            return self.span.with_hi(coroutine_kind.span().hi());
-        }
-
-        if let Const::Yes(span) = self.header.constness {
-            return self.span.with_hi(span.hi());
-        }
-
-        self.span.shrink_to_lo()
+        self.header.span().unwrap_or(self.span.shrink_to_lo())
     }
 
     /// The span of the header's safety, or where to insert it if empty.
@@ -3835,6 +3815,30 @@ impl FnHeader {
             || coroutine_kind.is_some()
             || matches!(constness, Const::Yes(_))
             || !matches!(ext, Extern::None)
+    }
+
+    pub fn span(&self) -> Option<Span> {
+        let mut spans = smallvec::SmallVec::<[Span; 4]>::new();
+
+        match self.ext {
+            Extern::Implicit(span) | Extern::Explicit(_, span) => spans.push(span),
+            Extern::None => {}
+        }
+
+        match self.safety {
+            Safety::Unsafe(span) | Safety::Safe(span) => spans.push(span),
+            Safety::Default => {}
+        };
+
+        if let Some(coroutine_kind) = self.coroutine_kind {
+            spans.push(coroutine_kind.span());
+        }
+
+        if let Const::Yes(span) = self.constness {
+            spans.push(span)
+        }
+
+        spans.into_iter().reduce(Span::to)
     }
 }
 

--- a/compiler/rustc_ast_passes/src/ast_validation.rs
+++ b/compiler/rustc_ast_passes/src/ast_validation.rs
@@ -1153,6 +1153,24 @@ impl<'a> AstValidator<'a> {
                 if let Extern::Implicit(extern_span) = bfty.ext {
                     self.handle_missing_abi(extern_span, ty.id);
                 }
+
+                let ext = match bfty.ext {
+                    Extern::None => None,
+                    Extern::Implicit(_) => Some(ExternAbi::FALLBACK),
+                    Extern::Explicit(str_lit, _) => {
+                        ExternAbi::from_str(str_lit.symbol.as_str()).ok()
+                    }
+                };
+
+                // Some ABIs impose special restrictions on the signature.
+                if let Some(extern_abi) = ext {
+                    self.check_extern_fn_signature(
+                        extern_abi,
+                        FnCtxt::Free,
+                        None,
+                        &bfty.as_borrowed_fn_sig(),
+                    );
+                }
             }
             TyKind::TraitObject(bounds, ..) => {
                 let mut any_lifetime_bounds = false;

--- a/compiler/rustc_ast_passes/src/ast_validation.rs
+++ b/compiler/rustc_ast_passes/src/ast_validation.rs
@@ -546,7 +546,13 @@ impl<'a> AstValidator<'a> {
     }
 
     /// Check that the signature of this function does not violate the constraints of its ABI.
-    fn check_extern_fn_signature(&self, abi: ExternAbi, ctxt: FnCtxt, ident: &Ident, sig: &FnSig) {
+    fn check_extern_fn_signature(
+        &self,
+        abi: ExternAbi,
+        ctxt: FnCtxt,
+        opt_function_name: Option<&Ident>, // None for function pointers
+        sig: &FnSig,
+    ) {
         match AbiMap::from_target(&self.sess.target).canonize_abi(abi, false) {
             AbiMapping::Direct(canon_abi) | AbiMapping::Deprecated(canon_abi) => {
                 match canon_abi {
@@ -575,7 +581,7 @@ impl<'a> AstValidator<'a> {
                         self.reject_coroutine(abi, sig);
 
                         // An `extern "custom"` function must have type `fn()`.
-                        self.reject_params_or_return(abi, ident, sig);
+                        self.reject_params_or_return(abi, opt_function_name, sig);
                     }
 
                     CanonAbi::Interrupt(interrupt_kind) => {
@@ -600,7 +606,7 @@ impl<'a> AstValidator<'a> {
                             self.reject_return(abi, sig);
                         } else {
                             // An `extern "interrupt"` function must have type `fn()`.
-                            self.reject_params_or_return(abi, ident, sig);
+                            self.reject_params_or_return(abi, opt_function_name, sig);
                         }
                     }
                 }
@@ -664,7 +670,12 @@ impl<'a> AstValidator<'a> {
         }
     }
 
-    fn reject_params_or_return(&self, abi: ExternAbi, ident: &Ident, sig: &FnSig) {
+    fn reject_params_or_return(
+        &self,
+        abi: ExternAbi,
+        opt_function_name: Option<&Ident>, // None for function pointers
+        sig: &FnSig,
+    ) {
         let mut spans: Vec<_> = sig.decl.inputs.iter().map(|p| p.span).collect();
         if let FnRetTy::Ty(ref ret_ty) = sig.decl.output
             && match &ret_ty.kind {
@@ -683,10 +694,14 @@ impl<'a> AstValidator<'a> {
 
             self.dcx().emit_err(diagnostics::AbiMustNotHaveParametersOrReturnType {
                 spans,
-                symbol: ident.name,
+                abi,
+
                 suggestion_span,
                 padding,
-                abi,
+                symbol: match opt_function_name {
+                    Some(ident) => format!(" {}", ident.name),
+                    None => String::new(),
+                },
             });
         }
     }
@@ -1620,7 +1635,7 @@ impl Visitor<'_> for AstValidator<'_> {
                 self.check_extern_fn_signature(
                     self.extern_mod_abi.unwrap_or(ExternAbi::FALLBACK),
                     FnCtxt::Foreign,
-                    ident,
+                    Some(ident),
                     sig,
                 );
 
@@ -1826,7 +1841,7 @@ impl Visitor<'_> for AstValidator<'_> {
 
             if let Some((extern_abi, extern_abi_span)) = ext {
                 // Some ABIs impose special restrictions on the signature.
-                self.check_extern_fn_signature(extern_abi, ctxt, &fun.ident, &fun.sig);
+                self.check_extern_fn_signature(extern_abi, ctxt, Some(&fun.ident), &fun.sig);
 
                 // #[track_caller] can only be used with the rust ABI.
                 if let Some(attr) = attr::find_by_name(attrs, sym::track_caller)

--- a/compiler/rustc_ast_passes/src/ast_validation.rs
+++ b/compiler/rustc_ast_passes/src/ast_validation.rs
@@ -551,7 +551,7 @@ impl<'a> AstValidator<'a> {
         abi: ExternAbi,
         ctxt: FnCtxt,
         opt_function_name: Option<&Ident>, // None for function pointers
-        sig: &FnSig,
+        sig: &BorrowedFnSig<'_>,
     ) {
         match AbiMap::from_target(&self.sess.target).canonize_abi(abi, false) {
             AbiMapping::Direct(canon_abi) | AbiMapping::Deprecated(canon_abi) => {
@@ -615,7 +615,7 @@ impl<'a> AstValidator<'a> {
         }
     }
 
-    fn reject_safe_fn(&self, abi: ExternAbi, ctxt: FnCtxt, sig: &FnSig) {
+    fn reject_safe_fn(&self, abi: ExternAbi, ctxt: FnCtxt, sig: &BorrowedFnSig<'_>) {
         let dcx = self.dcx();
 
         match sig.header.safety {
@@ -641,7 +641,7 @@ impl<'a> AstValidator<'a> {
         }
     }
 
-    fn reject_coroutine(&self, abi: ExternAbi, sig: &FnSig) {
+    fn reject_coroutine(&self, abi: ExternAbi, sig: &BorrowedFnSig<'_>) {
         if let Some(coroutine_kind) = sig.header.coroutine_kind {
             let coroutine_kind_span = self
                 .sess
@@ -658,7 +658,7 @@ impl<'a> AstValidator<'a> {
         }
     }
 
-    fn reject_return(&self, abi: ExternAbi, sig: &FnSig) {
+    fn reject_return(&self, abi: ExternAbi, sig: &BorrowedFnSig<'_>) {
         if let FnRetTy::Ty(ref ret_ty) = sig.decl.output
             && match &ret_ty.kind {
                 TyKind::Never => false,
@@ -674,7 +674,7 @@ impl<'a> AstValidator<'a> {
         &self,
         abi: ExternAbi,
         opt_function_name: Option<&Ident>, // None for function pointers
-        sig: &FnSig,
+        sig: &BorrowedFnSig<'_>,
     ) {
         let mut spans: Vec<_> = sig.decl.inputs.iter().map(|p| p.span).collect();
         if let FnRetTy::Ty(ref ret_ty) = sig.decl.output
@@ -688,7 +688,7 @@ impl<'a> AstValidator<'a> {
         }
 
         if !spans.is_empty() {
-            let header_span = sig.header_span();
+            let header_span = sig.header.span().unwrap_or(sig.span.shrink_to_lo());
             let suggestion_span = header_span.shrink_to_hi().to(sig.decl.output.span());
             let padding = if header_span.is_empty() { "" } else { " " };
 
@@ -1636,7 +1636,7 @@ impl Visitor<'_> for AstValidator<'_> {
                     self.extern_mod_abi.unwrap_or(ExternAbi::FALLBACK),
                     FnCtxt::Foreign,
                     Some(ident),
-                    sig,
+                    &sig.as_borrowed(),
                 );
 
                 if let Some(attr) = attr::find_by_name(fi.attrs(), sym::track_caller)
@@ -1841,7 +1841,12 @@ impl Visitor<'_> for AstValidator<'_> {
 
             if let Some((extern_abi, extern_abi_span)) = ext {
                 // Some ABIs impose special restrictions on the signature.
-                self.check_extern_fn_signature(extern_abi, ctxt, Some(&fun.ident), &fun.sig);
+                self.check_extern_fn_signature(
+                    extern_abi,
+                    ctxt,
+                    Some(&fun.ident),
+                    &fun.sig.as_borrowed(),
+                );
 
                 // #[track_caller] can only be used with the rust ABI.
                 if let Some(attr) = attr::find_by_name(attrs, sym::track_caller)

--- a/compiler/rustc_ast_passes/src/ast_validation.rs
+++ b/compiler/rustc_ast_passes/src/ast_validation.rs
@@ -677,12 +677,15 @@ impl<'a> AstValidator<'a> {
         sig: &BorrowedFnSig<'_>,
     ) {
         let mut spans: Vec<_> = sig.decl.inputs.iter().map(|p| p.span).collect();
+
+        let allowed_return = |ret_ty: &Ty| match &ret_ty.kind {
+            TyKind::Never if abi != ExternAbi::Custom => true,
+            TyKind::Tup(tup) if tup.is_empty() => true,
+            _ => false,
+        };
+
         if let FnRetTy::Ty(ref ret_ty) = sig.decl.output
-            && match &ret_ty.kind {
-                TyKind::Never => false,
-                TyKind::Tup(tup) if tup.is_empty() => false,
-                _ => true,
-            }
+            && !allowed_return(ret_ty)
         {
             spans.push(ret_ty.span);
         }

--- a/compiler/rustc_ast_passes/src/ast_validation.rs
+++ b/compiler/rustc_ast_passes/src/ast_validation.rs
@@ -575,7 +575,7 @@ impl<'a> AstValidator<'a> {
 
                     CanonAbi::Custom => {
                         // An `extern "custom"` function must be unsafe.
-                        self.reject_safe_fn(abi, ctxt, sig);
+                        self.reject_safe_fn(abi, ctxt, sig, opt_function_name.is_none());
 
                         // An `extern "custom"` function cannot be `async` and/or `gen`.
                         self.reject_coroutine(abi, sig);
@@ -615,18 +615,27 @@ impl<'a> AstValidator<'a> {
         }
     }
 
-    fn reject_safe_fn(&self, abi: ExternAbi, ctxt: FnCtxt, sig: &BorrowedFnSig<'_>) {
+    fn reject_safe_fn(
+        &self,
+        abi: ExternAbi,
+        ctxt: FnCtxt,
+        sig: &BorrowedFnSig<'_>,
+        is_fn_ptr: bool,
+    ) {
         let dcx = self.dcx();
 
         match sig.header.safety {
             Safety::Unsafe(_) => { /* all good */ }
             Safety::Safe(safe_span) => {
-                let source_map = self.sess.psess.source_map();
-                let safe_span = source_map.span_until_non_whitespace(safe_span.to(sig.span));
-                dcx.emit_err(diagnostics::AbiCustomSafeForeignFunction {
-                    span: sig.span,
-                    safe_span,
-                });
+                // Function pointers already error when `safe` is used.
+                if !is_fn_ptr {
+                    let source_map = self.sess.psess.source_map();
+                    let safe_span = source_map.span_until_non_whitespace(safe_span.to(sig.span));
+                    dcx.emit_err(diagnostics::AbiCustomSafeForeignFunction {
+                        span: sig.span,
+                        safe_span,
+                    });
+                }
             }
             Safety::Default => match ctxt {
                 FnCtxt::Foreign => { /* all good */ }
@@ -735,8 +744,12 @@ impl<'a> AstValidator<'a> {
     }
 
     fn check_fn_ptr_safety(&self, span: Span, safety: Safety) {
-        if matches!(safety, Safety::Safe(_)) {
-            self.dcx().emit_err(diagnostics::InvalidSafetyOnFnPtr { span });
+        if let Safety::Safe(safe_span) = safety {
+            let remove_span = self.sess.source_map().span_until_non_whitespace(span);
+            self.dcx().emit_err(diagnostics::InvalidSafetyOnFnPtr {
+                span: safe_span,
+                safe_span: remove_span,
+            });
         }
     }
 

--- a/compiler/rustc_ast_passes/src/diagnostics.rs
+++ b/compiler/rustc_ast_passes/src/diagnostics.rs
@@ -371,6 +371,13 @@ pub(crate) struct InvalidSafetyOnItem {
 pub(crate) struct InvalidSafetyOnFnPtr {
     #[primary_span]
     pub span: Span,
+    #[suggestion(
+        "remove the `safe` qualifier",
+        code = "",
+        applicability = "machine-applicable",
+        style = "verbose"
+    )]
+    pub safe_span: Span,
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_ast_passes/src/diagnostics.rs
+++ b/compiler/rustc_ast_passes/src/diagnostics.rs
@@ -1104,11 +1104,11 @@ pub(crate) struct AbiMustNotHaveParametersOrReturnType {
     #[suggestion(
         "remove the parameters and return type",
         applicability = "maybe-incorrect",
-        code = "{padding}fn {symbol}()",
+        code = "{padding}fn{symbol}()",
         style = "verbose"
     )]
     pub suggestion_span: Span,
-    pub symbol: Symbol,
+    pub symbol: String,
     pub padding: &'static str,
 }
 

--- a/tests/ui/abi/bad-custom.rs
+++ b/tests/ui/abi/bad-custom.rs
@@ -72,16 +72,19 @@ unsafe extern "custom" {
 }
 
 fn caller(f: unsafe extern "custom" fn(i64) -> i64, mut x: i64) -> i64 {
+    //~^ ERROR invalid signature for `extern "custom"` function
     unsafe { f(x) }
     //~^ ERROR functions with the "custom" ABI cannot be called
 }
 
 fn caller_by_ref(f: &unsafe extern "custom" fn(i64) -> i64, mut x: i64) -> i64 {
+    //~^ ERROR invalid signature for `extern "custom"` function
     unsafe { f(x) }
     //~^ ERROR functions with the "custom" ABI cannot be called
 }
 
 type Custom = unsafe extern "custom" fn(i64) -> i64;
+//~^ ERROR invalid signature for `extern "custom"` function
 
 fn caller_alias(f: Custom, mut x: i64) -> i64 {
     unsafe { f(x) }
@@ -99,7 +102,7 @@ async unsafe extern "custom" fn no_async_fn() {
     //~| ERROR functions with the "custom" ABI cannot be `async`
 }
 
-fn no_promotion_to_fn_trait(f: unsafe extern "custom" fn()) -> impl Fn()  {
+fn no_promotion_to_fn_trait(f: unsafe extern "custom" fn()) -> impl Fn() {
     //~^ ERROR expected an `Fn()` closure, found `unsafe extern "custom" fn()`
     f
 }

--- a/tests/ui/abi/bad-custom.rs
+++ b/tests/ui/abi/bad-custom.rs
@@ -10,11 +10,18 @@ extern "custom" fn must_be_unsafe(a: i64) -> i64 {
     std::arch::naked_asm!("")
 }
 
+type MustbeUnsafe = extern "custom" fn(i64) -> i64;
+//~^ ERROR functions with the "custom" ABI must be unsafe
+//~| ERROR invalid signature for `extern "custom"` function
+
 #[unsafe(naked)]
 unsafe extern "custom" fn no_parameters(a: i64) {
     //~^ ERROR invalid signature for `extern "custom"` function
     std::arch::naked_asm!("")
 }
+
+type NoParameters = unsafe extern "custom" fn(i64);
+//~^ ERROR invalid signature for `extern "custom"` function
 
 #[unsafe(naked)]
 unsafe extern "custom" fn no_return_type() -> i64 {
@@ -22,32 +29,43 @@ unsafe extern "custom" fn no_return_type() -> i64 {
     std::arch::naked_asm!("")
 }
 
+type NoReturnType = unsafe extern "custom" fn() -> i64;
+//~^ ERROR invalid signature for `extern "custom"` function
+
 #[unsafe(naked)]
 unsafe extern "custom" fn no_never_return_type() -> ! {
     //~^ ERROR invalid signature for `extern "custom"` function
     std::arch::naked_asm!("")
 }
 
-unsafe extern "custom" fn double(a: i64) -> i64 {
+type NoNeverReturnType = unsafe extern "custom" fn() -> !;
+//~^ ERROR invalid signature for `extern "custom"` function
+
+unsafe extern "custom" fn not_both(a: i64) -> i64 {
     //~^ ERROR items with the "custom" ABI can only be declared externally or defined via naked functions
     //~| ERROR invalid signature for `extern "custom"` function
     unimplemented!()
 }
 
+type NotBoth = unsafe extern "custom" fn(i64) -> i64;
+//~^ ERROR invalid signature for `extern "custom"` function
+
 struct Thing(i64);
 
 impl Thing {
-    unsafe extern "custom" fn is_even(self) -> bool {
+    extern "custom" fn is_even(self) -> bool {
         //~^ ERROR items with the "custom" ABI can only be declared externally or defined via naked functions
         //~| ERROR invalid signature for `extern "custom"` function
+        //~| ERROR functions with the "custom" ABI must be unsafe
         unimplemented!()
     }
 }
 
 trait BitwiseNot {
-    unsafe extern "custom" fn bitwise_not(a: i64) -> i64 {
+    extern "custom" fn bitwise_not(a: i64) -> i64 {
         //~^ ERROR items with the "custom" ABI can only be declared externally or defined via naked functions
         //~| ERROR invalid signature for `extern "custom"` function
+        //~| ERROR functions with the "custom" ABI must be unsafe
         unimplemented!()
     }
 }
@@ -89,10 +107,10 @@ fn caller_by_ref(f: &unsafe extern "custom" fn(i64) -> i64, mut x: i64) -> i64 {
     //~^ ERROR functions with the "custom" ABI cannot be called
 }
 
-type Custom = unsafe extern "custom" fn(i64) -> i64;
+type Alias = unsafe extern "custom" fn(i64) -> i64;
 //~^ ERROR invalid signature for `extern "custom"` function
 
-fn caller_alias(f: Custom, mut x: i64) -> i64 {
+fn caller_alias(f: Alias, mut x: i64) -> i64 {
     unsafe { f(x) }
     //~^ ERROR functions with the "custom" ABI cannot be called
 }
@@ -115,7 +133,7 @@ fn no_promotion_to_fn_trait(f: unsafe extern "custom" fn()) -> impl Fn() {
 
 pub fn main() {
     unsafe {
-        assert_eq!(double(21), 42);
+        assert_eq!(not_both(21), 42);
         //~^ ERROR functions with the "custom" ABI cannot be called
 
         assert_eq!(unsafe { increment(41) }, 42);

--- a/tests/ui/abi/bad-custom.rs
+++ b/tests/ui/abi/bad-custom.rs
@@ -95,6 +95,9 @@ unsafe extern "custom" {
     //~^ ERROR foreign functions with the "custom" ABI cannot be safe
 }
 
+type Safe = safe extern "custom" fn();
+//~^ ERROR function pointers cannot be declared with `safe` safety qualifier
+
 fn caller(f: unsafe extern "custom" fn(i64) -> i64, mut x: i64) -> i64 {
     //~^ ERROR invalid signature for `extern "custom"` function
     unsafe { f(x) }

--- a/tests/ui/abi/bad-custom.rs
+++ b/tests/ui/abi/bad-custom.rs
@@ -22,6 +22,12 @@ unsafe extern "custom" fn no_return_type() -> i64 {
     std::arch::naked_asm!("")
 }
 
+#[unsafe(naked)]
+unsafe extern "custom" fn no_never_return_type() -> ! {
+    //~^ ERROR invalid signature for `extern "custom"` function
+    std::arch::naked_asm!("")
+}
+
 unsafe extern "custom" fn double(a: i64) -> i64 {
     //~^ ERROR items with the "custom" ABI can only be declared externally or defined via naked functions
     //~| ERROR invalid signature for `extern "custom"` function

--- a/tests/ui/abi/bad-custom.stderr
+++ b/tests/ui/abi/bad-custom.stderr
@@ -49,7 +49,20 @@ LL + unsafe extern "custom" fn no_return_type() {
    |
 
 error: invalid signature for `extern "custom"` function
-  --> $DIR/bad-custom.rs:25:34
+  --> $DIR/bad-custom.rs:26:53
+   |
+LL | unsafe extern "custom" fn no_never_return_type() -> ! {
+   |                                                     ^
+   |
+   = note: functions with the "custom" ABI cannot have any parameters or return type
+help: remove the parameters and return type
+   |
+LL - unsafe extern "custom" fn no_never_return_type() -> ! {
+LL + unsafe extern "custom" fn no_never_return_type() {
+   |
+
+error: invalid signature for `extern "custom"` function
+  --> $DIR/bad-custom.rs:31:34
    |
 LL | unsafe extern "custom" fn double(a: i64) -> i64 {
    |                                  ^^^^^^     ^^^
@@ -62,7 +75,7 @@ LL + unsafe extern "custom" fn double() {
    |
 
 error: invalid signature for `extern "custom"` function
-  --> $DIR/bad-custom.rs:34:39
+  --> $DIR/bad-custom.rs:40:39
    |
 LL |     unsafe extern "custom" fn is_even(self) -> bool {
    |                                       ^^^^     ^^^^
@@ -75,7 +88,7 @@ LL +     unsafe extern "custom" fn is_even() {
    |
 
 error: invalid signature for `extern "custom"` function
-  --> $DIR/bad-custom.rs:42:43
+  --> $DIR/bad-custom.rs:48:43
    |
 LL |     unsafe extern "custom" fn bitwise_not(a: i64) -> i64 {
    |                                           ^^^^^^     ^^^
@@ -88,7 +101,7 @@ LL +     unsafe extern "custom" fn bitwise_not() {
    |
 
 error: functions with the "custom" ABI must be unsafe
-  --> $DIR/bad-custom.rs:52:5
+  --> $DIR/bad-custom.rs:58:5
    |
 LL |     extern "custom" fn negate(a: i64) -> i64;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -99,7 +112,7 @@ LL |     unsafe extern "custom" fn negate(a: i64) -> i64;
    |     ++++++
 
 error: invalid signature for `extern "custom"` function
-  --> $DIR/bad-custom.rs:52:31
+  --> $DIR/bad-custom.rs:58:31
    |
 LL |     extern "custom" fn negate(a: i64) -> i64;
    |                               ^^^^^^     ^^^
@@ -112,7 +125,7 @@ LL +     extern "custom" fn negate();
    |
 
 error: functions with the "custom" ABI must be unsafe
-  --> $DIR/bad-custom.rs:58:5
+  --> $DIR/bad-custom.rs:64:5
    |
 LL |     extern "custom" fn negate(a: i64) -> i64 {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -123,7 +136,7 @@ LL |     unsafe extern "custom" fn negate(a: i64) -> i64 {
    |     ++++++
 
 error: invalid signature for `extern "custom"` function
-  --> $DIR/bad-custom.rs:58:31
+  --> $DIR/bad-custom.rs:64:31
    |
 LL |     extern "custom" fn negate(a: i64) -> i64 {
    |                               ^^^^^^     ^^^
@@ -136,7 +149,7 @@ LL +     extern "custom" fn negate() {
    |
 
 error: invalid signature for `extern "custom"` function
-  --> $DIR/bad-custom.rs:67:18
+  --> $DIR/bad-custom.rs:73:18
    |
 LL |     fn increment(a: i64) -> i64;
    |                  ^^^^^^     ^^^
@@ -149,7 +162,7 @@ LL +     fn increment();
    |
 
 error: foreign functions with the "custom" ABI cannot be safe
-  --> $DIR/bad-custom.rs:70:5
+  --> $DIR/bad-custom.rs:76:5
    |
 LL |     safe fn extern_cannot_be_safe();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -161,7 +174,7 @@ LL +     fn extern_cannot_be_safe();
    |
 
 error: invalid signature for `extern "custom"` function
-  --> $DIR/bad-custom.rs:74:40
+  --> $DIR/bad-custom.rs:80:40
    |
 LL | fn caller(f: unsafe extern "custom" fn(i64) -> i64, mut x: i64) -> i64 {
    |                                        ^^^     ^^^
@@ -174,7 +187,7 @@ LL + fn caller(f: unsafe extern "custom" fn(), mut x: i64) -> i64 {
    |
 
 error: invalid signature for `extern "custom"` function
-  --> $DIR/bad-custom.rs:80:48
+  --> $DIR/bad-custom.rs:86:48
    |
 LL | fn caller_by_ref(f: &unsafe extern "custom" fn(i64) -> i64, mut x: i64) -> i64 {
    |                                                ^^^     ^^^
@@ -187,7 +200,7 @@ LL + fn caller_by_ref(f: &unsafe extern "custom" fn(), mut x: i64) -> i64 {
    |
 
 error: invalid signature for `extern "custom"` function
-  --> $DIR/bad-custom.rs:86:41
+  --> $DIR/bad-custom.rs:92:41
    |
 LL | type Custom = unsafe extern "custom" fn(i64) -> i64;
    |                                         ^^^     ^^^
@@ -200,7 +213,7 @@ LL + type Custom = unsafe extern "custom" fn();
    |
 
 error: functions with the "custom" ABI cannot be `async`
-  --> $DIR/bad-custom.rs:100:1
+  --> $DIR/bad-custom.rs:106:1
    |
 LL | async unsafe extern "custom" fn no_async_fn() {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -212,7 +225,7 @@ LL + unsafe extern "custom" fn no_async_fn() {
    |
 
 error: items with the "custom" ABI can only be declared externally or defined via naked functions
-  --> $DIR/bad-custom.rs:100:1
+  --> $DIR/bad-custom.rs:106:1
    |
 LL | async unsafe extern "custom" fn no_async_fn() {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -224,7 +237,7 @@ LL | async unsafe extern "custom" fn no_async_fn() {
    |
 
 error[E0277]: expected an `Fn()` closure, found `unsafe extern "custom" fn()`
-  --> $DIR/bad-custom.rs:105:64
+  --> $DIR/bad-custom.rs:111:64
    |
 LL | fn no_promotion_to_fn_trait(f: unsafe extern "custom" fn()) -> impl Fn() {
    |                                                                ^^^^^^^^^ call the function in a closure: `|| unsafe { /* code */ }`
@@ -237,7 +250,7 @@ LL |     f
    = note: unsafe function cannot be called generically without an unsafe block
 
 error: items with the "custom" ABI can only be declared externally or defined via naked functions
-  --> $DIR/bad-custom.rs:25:1
+  --> $DIR/bad-custom.rs:31:1
    |
 LL | unsafe extern "custom" fn double(a: i64) -> i64 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -249,7 +262,7 @@ LL | unsafe extern "custom" fn double(a: i64) -> i64 {
    |
 
 error: items with the "custom" ABI can only be declared externally or defined via naked functions
-  --> $DIR/bad-custom.rs:34:5
+  --> $DIR/bad-custom.rs:40:5
    |
 LL |     unsafe extern "custom" fn is_even(self) -> bool {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -261,7 +274,7 @@ LL |     unsafe extern "custom" fn is_even(self) -> bool {
    |
 
 error: items with the "custom" ABI can only be declared externally or defined via naked functions
-  --> $DIR/bad-custom.rs:42:5
+  --> $DIR/bad-custom.rs:48:5
    |
 LL |     unsafe extern "custom" fn bitwise_not(a: i64) -> i64 {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -273,7 +286,7 @@ LL |     unsafe extern "custom" fn bitwise_not(a: i64) -> i64 {
    |
 
 error: items with the "custom" ABI can only be declared externally or defined via naked functions
-  --> $DIR/bad-custom.rs:58:5
+  --> $DIR/bad-custom.rs:64:5
    |
 LL |     extern "custom" fn negate(a: i64) -> i64 {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -285,18 +298,6 @@ LL |     extern "custom" fn negate(a: i64) -> i64 {
    |
 
 error: functions with the "custom" ABI cannot be called
-  --> $DIR/bad-custom.rs:76:14
-   |
-LL |     unsafe { f(x) }
-   |              ^^^^
-   |
-note: an `extern "custom"` function can only be called using inline assembly
-  --> $DIR/bad-custom.rs:76:14
-   |
-LL |     unsafe { f(x) }
-   |              ^^^^
-
-error: functions with the "custom" ABI cannot be called
   --> $DIR/bad-custom.rs:82:14
    |
 LL |     unsafe { f(x) }
@@ -309,72 +310,84 @@ LL |     unsafe { f(x) }
    |              ^^^^
 
 error: functions with the "custom" ABI cannot be called
-  --> $DIR/bad-custom.rs:90:14
+  --> $DIR/bad-custom.rs:88:14
    |
 LL |     unsafe { f(x) }
    |              ^^^^
    |
 note: an `extern "custom"` function can only be called using inline assembly
-  --> $DIR/bad-custom.rs:90:14
+  --> $DIR/bad-custom.rs:88:14
    |
 LL |     unsafe { f(x) }
    |              ^^^^
 
 error: functions with the "custom" ABI cannot be called
-  --> $DIR/bad-custom.rs:112:20
+  --> $DIR/bad-custom.rs:96:14
+   |
+LL |     unsafe { f(x) }
+   |              ^^^^
+   |
+note: an `extern "custom"` function can only be called using inline assembly
+  --> $DIR/bad-custom.rs:96:14
+   |
+LL |     unsafe { f(x) }
+   |              ^^^^
+
+error: functions with the "custom" ABI cannot be called
+  --> $DIR/bad-custom.rs:118:20
    |
 LL |         assert_eq!(double(21), 42);
    |                    ^^^^^^^^^^
    |
 note: an `extern "custom"` function can only be called using inline assembly
-  --> $DIR/bad-custom.rs:112:20
+  --> $DIR/bad-custom.rs:118:20
    |
 LL |         assert_eq!(double(21), 42);
    |                    ^^^^^^^^^^
 
 error: functions with the "custom" ABI cannot be called
-  --> $DIR/bad-custom.rs:115:29
+  --> $DIR/bad-custom.rs:121:29
    |
 LL |         assert_eq!(unsafe { increment(41) }, 42);
    |                             ^^^^^^^^^^^^^
    |
 note: an `extern "custom"` function can only be called using inline assembly
-  --> $DIR/bad-custom.rs:115:29
+  --> $DIR/bad-custom.rs:121:29
    |
 LL |         assert_eq!(unsafe { increment(41) }, 42);
    |                             ^^^^^^^^^^^^^
 
 error: functions with the "custom" ABI cannot be called
-  --> $DIR/bad-custom.rs:118:17
+  --> $DIR/bad-custom.rs:124:17
    |
 LL |         assert!(Thing(41).is_even());
    |                 ^^^^^^^^^^^^^^^^^^^
    |
 note: an `extern "custom"` function can only be called using inline assembly
-  --> $DIR/bad-custom.rs:118:17
+  --> $DIR/bad-custom.rs:124:17
    |
 LL |         assert!(Thing(41).is_even());
    |                 ^^^^^^^^^^^^^^^^^^^
 
 error: functions with the "custom" ABI cannot be called
-  --> $DIR/bad-custom.rs:121:20
+  --> $DIR/bad-custom.rs:127:20
    |
 LL |         assert_eq!(Thing::bitwise_not(42), !42);
    |                    ^^^^^^^^^^^^^^^^^^^^^^
    |
 note: an `extern "custom"` function can only be called using inline assembly
-  --> $DIR/bad-custom.rs:121:20
+  --> $DIR/bad-custom.rs:127:20
    |
 LL |         assert_eq!(Thing::bitwise_not(42), !42);
    |                    ^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0015]: inline assembly is not allowed in constant functions
-  --> $DIR/bad-custom.rs:96:5
+  --> $DIR/bad-custom.rs:102:5
    |
 LL |     std::arch::naked_asm!("")
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 31 previous errors
+error: aborting due to 32 previous errors
 
 Some errors have detailed explanations: E0015, E0277.
 For more information about an error, try `rustc --explain E0015`.

--- a/tests/ui/abi/bad-custom.stderr
+++ b/tests/ui/abi/bad-custom.stderr
@@ -271,8 +271,20 @@ LL -     safe fn extern_cannot_be_safe();
 LL +     fn extern_cannot_be_safe();
    |
 
+error: function pointers cannot be declared with `safe` safety qualifier
+  --> $DIR/bad-custom.rs:98:13
+   |
+LL | type Safe = safe extern "custom" fn();
+   |             ^^^^
+   |
+help: remove the `safe` qualifier
+   |
+LL - type Safe = safe extern "custom" fn();
+LL + type Safe = extern "custom" fn();
+   |
+
 error: invalid signature for `extern "custom"` function
-  --> $DIR/bad-custom.rs:98:40
+  --> $DIR/bad-custom.rs:101:40
    |
 LL | fn caller(f: unsafe extern "custom" fn(i64) -> i64, mut x: i64) -> i64 {
    |                                        ^^^     ^^^
@@ -285,7 +297,7 @@ LL + fn caller(f: unsafe extern "custom" fn(), mut x: i64) -> i64 {
    |
 
 error: invalid signature for `extern "custom"` function
-  --> $DIR/bad-custom.rs:104:48
+  --> $DIR/bad-custom.rs:107:48
    |
 LL | fn caller_by_ref(f: &unsafe extern "custom" fn(i64) -> i64, mut x: i64) -> i64 {
    |                                                ^^^     ^^^
@@ -298,7 +310,7 @@ LL + fn caller_by_ref(f: &unsafe extern "custom" fn(), mut x: i64) -> i64 {
    |
 
 error: invalid signature for `extern "custom"` function
-  --> $DIR/bad-custom.rs:110:40
+  --> $DIR/bad-custom.rs:113:40
    |
 LL | type Alias = unsafe extern "custom" fn(i64) -> i64;
    |                                        ^^^     ^^^
@@ -311,7 +323,7 @@ LL + type Alias = unsafe extern "custom" fn();
    |
 
 error: functions with the "custom" ABI cannot be `async`
-  --> $DIR/bad-custom.rs:124:1
+  --> $DIR/bad-custom.rs:127:1
    |
 LL | async unsafe extern "custom" fn no_async_fn() {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -323,7 +335,7 @@ LL + unsafe extern "custom" fn no_async_fn() {
    |
 
 error: items with the "custom" ABI can only be declared externally or defined via naked functions
-  --> $DIR/bad-custom.rs:124:1
+  --> $DIR/bad-custom.rs:127:1
    |
 LL | async unsafe extern "custom" fn no_async_fn() {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -335,7 +347,7 @@ LL | async unsafe extern "custom" fn no_async_fn() {
    |
 
 error[E0277]: expected an `Fn()` closure, found `unsafe extern "custom" fn()`
-  --> $DIR/bad-custom.rs:129:64
+  --> $DIR/bad-custom.rs:132:64
    |
 LL | fn no_promotion_to_fn_trait(f: unsafe extern "custom" fn()) -> impl Fn() {
    |                                                                ^^^^^^^^^ call the function in a closure: `|| unsafe { /* code */ }`
@@ -396,96 +408,96 @@ LL |     extern "custom" fn negate(a: i64) -> i64 {
    |
 
 error: functions with the "custom" ABI cannot be called
-  --> $DIR/bad-custom.rs:100:14
+  --> $DIR/bad-custom.rs:103:14
    |
 LL |     unsafe { f(x) }
    |              ^^^^
    |
 note: an `extern "custom"` function can only be called using inline assembly
-  --> $DIR/bad-custom.rs:100:14
+  --> $DIR/bad-custom.rs:103:14
    |
 LL |     unsafe { f(x) }
    |              ^^^^
 
 error: functions with the "custom" ABI cannot be called
-  --> $DIR/bad-custom.rs:106:14
+  --> $DIR/bad-custom.rs:109:14
    |
 LL |     unsafe { f(x) }
    |              ^^^^
    |
 note: an `extern "custom"` function can only be called using inline assembly
-  --> $DIR/bad-custom.rs:106:14
+  --> $DIR/bad-custom.rs:109:14
    |
 LL |     unsafe { f(x) }
    |              ^^^^
 
 error: functions with the "custom" ABI cannot be called
-  --> $DIR/bad-custom.rs:114:14
+  --> $DIR/bad-custom.rs:117:14
    |
 LL |     unsafe { f(x) }
    |              ^^^^
    |
 note: an `extern "custom"` function can only be called using inline assembly
-  --> $DIR/bad-custom.rs:114:14
+  --> $DIR/bad-custom.rs:117:14
    |
 LL |     unsafe { f(x) }
    |              ^^^^
 
 error: functions with the "custom" ABI cannot be called
-  --> $DIR/bad-custom.rs:136:20
+  --> $DIR/bad-custom.rs:139:20
    |
 LL |         assert_eq!(not_both(21), 42);
    |                    ^^^^^^^^^^^^
    |
 note: an `extern "custom"` function can only be called using inline assembly
-  --> $DIR/bad-custom.rs:136:20
+  --> $DIR/bad-custom.rs:139:20
    |
 LL |         assert_eq!(not_both(21), 42);
    |                    ^^^^^^^^^^^^
 
 error: functions with the "custom" ABI cannot be called
-  --> $DIR/bad-custom.rs:139:29
+  --> $DIR/bad-custom.rs:142:29
    |
 LL |         assert_eq!(unsafe { increment(41) }, 42);
    |                             ^^^^^^^^^^^^^
    |
 note: an `extern "custom"` function can only be called using inline assembly
-  --> $DIR/bad-custom.rs:139:29
+  --> $DIR/bad-custom.rs:142:29
    |
 LL |         assert_eq!(unsafe { increment(41) }, 42);
    |                             ^^^^^^^^^^^^^
 
 error: functions with the "custom" ABI cannot be called
-  --> $DIR/bad-custom.rs:142:17
+  --> $DIR/bad-custom.rs:145:17
    |
 LL |         assert!(Thing(41).is_even());
    |                 ^^^^^^^^^^^^^^^^^^^
    |
 note: an `extern "custom"` function can only be called using inline assembly
-  --> $DIR/bad-custom.rs:142:17
+  --> $DIR/bad-custom.rs:145:17
    |
 LL |         assert!(Thing(41).is_even());
    |                 ^^^^^^^^^^^^^^^^^^^
 
 error: functions with the "custom" ABI cannot be called
-  --> $DIR/bad-custom.rs:145:20
+  --> $DIR/bad-custom.rs:148:20
    |
 LL |         assert_eq!(Thing::bitwise_not(42), !42);
    |                    ^^^^^^^^^^^^^^^^^^^^^^
    |
 note: an `extern "custom"` function can only be called using inline assembly
-  --> $DIR/bad-custom.rs:145:20
+  --> $DIR/bad-custom.rs:148:20
    |
 LL |         assert_eq!(Thing::bitwise_not(42), !42);
    |                    ^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0015]: inline assembly is not allowed in constant functions
-  --> $DIR/bad-custom.rs:120:5
+  --> $DIR/bad-custom.rs:123:5
    |
 LL |     std::arch::naked_asm!("")
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 40 previous errors
+error: aborting due to 41 previous errors
 
 Some errors have detailed explanations: E0015, E0277.
 For more information about an error, try `rustc --explain E0015`.

--- a/tests/ui/abi/bad-custom.stderr
+++ b/tests/ui/abi/bad-custom.stderr
@@ -22,8 +22,32 @@ LL - extern "custom" fn must_be_unsafe(a: i64) -> i64 {
 LL + extern "custom" fn must_be_unsafe() {
    |
 
+error: functions with the "custom" ABI must be unsafe
+  --> $DIR/bad-custom.rs:13:21
+   |
+LL | type MustbeUnsafe = extern "custom" fn(i64) -> i64;
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: add the `unsafe` keyword to this definition
+   |
+LL | type MustbeUnsafe = unsafe extern "custom" fn(i64) -> i64;
+   |                     ++++++
+
 error: invalid signature for `extern "custom"` function
-  --> $DIR/bad-custom.rs:14:41
+  --> $DIR/bad-custom.rs:13:40
+   |
+LL | type MustbeUnsafe = extern "custom" fn(i64) -> i64;
+   |                                        ^^^     ^^^
+   |
+   = note: functions with the "custom" ABI cannot have any parameters or return type
+help: remove the parameters and return type
+   |
+LL - type MustbeUnsafe = extern "custom" fn(i64) -> i64;
+LL + type MustbeUnsafe = extern "custom" fn();
+   |
+
+error: invalid signature for `extern "custom"` function
+  --> $DIR/bad-custom.rs:18:41
    |
 LL | unsafe extern "custom" fn no_parameters(a: i64) {
    |                                         ^^^^^^
@@ -36,7 +60,20 @@ LL + unsafe extern "custom" fn no_parameters() {
    |
 
 error: invalid signature for `extern "custom"` function
-  --> $DIR/bad-custom.rs:20:47
+  --> $DIR/bad-custom.rs:23:47
+   |
+LL | type NoParameters = unsafe extern "custom" fn(i64);
+   |                                               ^^^
+   |
+   = note: functions with the "custom" ABI cannot have any parameters or return type
+help: remove the parameters and return type
+   |
+LL - type NoParameters = unsafe extern "custom" fn(i64);
+LL + type NoParameters = unsafe extern "custom" fn();
+   |
+
+error: invalid signature for `extern "custom"` function
+  --> $DIR/bad-custom.rs:27:47
    |
 LL | unsafe extern "custom" fn no_return_type() -> i64 {
    |                                               ^^^
@@ -49,7 +86,20 @@ LL + unsafe extern "custom" fn no_return_type() {
    |
 
 error: invalid signature for `extern "custom"` function
-  --> $DIR/bad-custom.rs:26:53
+  --> $DIR/bad-custom.rs:32:52
+   |
+LL | type NoReturnType = unsafe extern "custom" fn() -> i64;
+   |                                                    ^^^
+   |
+   = note: functions with the "custom" ABI cannot have any parameters or return type
+help: remove the parameters and return type
+   |
+LL - type NoReturnType = unsafe extern "custom" fn() -> i64;
+LL + type NoReturnType = unsafe extern "custom" fn();
+   |
+
+error: invalid signature for `extern "custom"` function
+  --> $DIR/bad-custom.rs:36:53
    |
 LL | unsafe extern "custom" fn no_never_return_type() -> ! {
    |                                                     ^
@@ -62,46 +112,94 @@ LL + unsafe extern "custom" fn no_never_return_type() {
    |
 
 error: invalid signature for `extern "custom"` function
-  --> $DIR/bad-custom.rs:31:34
+  --> $DIR/bad-custom.rs:41:57
    |
-LL | unsafe extern "custom" fn double(a: i64) -> i64 {
-   |                                  ^^^^^^     ^^^
+LL | type NoNeverReturnType = unsafe extern "custom" fn() -> !;
+   |                                                         ^
    |
    = note: functions with the "custom" ABI cannot have any parameters or return type
 help: remove the parameters and return type
    |
-LL - unsafe extern "custom" fn double(a: i64) -> i64 {
-LL + unsafe extern "custom" fn double() {
+LL - type NoNeverReturnType = unsafe extern "custom" fn() -> !;
+LL + type NoNeverReturnType = unsafe extern "custom" fn();
    |
 
 error: invalid signature for `extern "custom"` function
-  --> $DIR/bad-custom.rs:40:39
+  --> $DIR/bad-custom.rs:44:36
    |
-LL |     unsafe extern "custom" fn is_even(self) -> bool {
-   |                                       ^^^^     ^^^^
+LL | unsafe extern "custom" fn not_both(a: i64) -> i64 {
+   |                                    ^^^^^^     ^^^
    |
    = note: functions with the "custom" ABI cannot have any parameters or return type
 help: remove the parameters and return type
    |
-LL -     unsafe extern "custom" fn is_even(self) -> bool {
-LL +     unsafe extern "custom" fn is_even() {
+LL - unsafe extern "custom" fn not_both(a: i64) -> i64 {
+LL + unsafe extern "custom" fn not_both() {
    |
 
 error: invalid signature for `extern "custom"` function
-  --> $DIR/bad-custom.rs:48:43
+  --> $DIR/bad-custom.rs:50:42
    |
-LL |     unsafe extern "custom" fn bitwise_not(a: i64) -> i64 {
-   |                                           ^^^^^^     ^^^
+LL | type NotBoth = unsafe extern "custom" fn(i64) -> i64;
+   |                                          ^^^     ^^^
    |
    = note: functions with the "custom" ABI cannot have any parameters or return type
 help: remove the parameters and return type
    |
-LL -     unsafe extern "custom" fn bitwise_not(a: i64) -> i64 {
-LL +     unsafe extern "custom" fn bitwise_not() {
+LL - type NotBoth = unsafe extern "custom" fn(i64) -> i64;
+LL + type NotBoth = unsafe extern "custom" fn();
    |
 
 error: functions with the "custom" ABI must be unsafe
-  --> $DIR/bad-custom.rs:58:5
+  --> $DIR/bad-custom.rs:56:5
+   |
+LL |     extern "custom" fn is_even(self) -> bool {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: add the `unsafe` keyword to this definition
+   |
+LL |     unsafe extern "custom" fn is_even(self) -> bool {
+   |     ++++++
+
+error: invalid signature for `extern "custom"` function
+  --> $DIR/bad-custom.rs:56:32
+   |
+LL |     extern "custom" fn is_even(self) -> bool {
+   |                                ^^^^     ^^^^
+   |
+   = note: functions with the "custom" ABI cannot have any parameters or return type
+help: remove the parameters and return type
+   |
+LL -     extern "custom" fn is_even(self) -> bool {
+LL +     extern "custom" fn is_even() {
+   |
+
+error: functions with the "custom" ABI must be unsafe
+  --> $DIR/bad-custom.rs:65:5
+   |
+LL |     extern "custom" fn bitwise_not(a: i64) -> i64 {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: add the `unsafe` keyword to this definition
+   |
+LL |     unsafe extern "custom" fn bitwise_not(a: i64) -> i64 {
+   |     ++++++
+
+error: invalid signature for `extern "custom"` function
+  --> $DIR/bad-custom.rs:65:36
+   |
+LL |     extern "custom" fn bitwise_not(a: i64) -> i64 {
+   |                                    ^^^^^^     ^^^
+   |
+   = note: functions with the "custom" ABI cannot have any parameters or return type
+help: remove the parameters and return type
+   |
+LL -     extern "custom" fn bitwise_not(a: i64) -> i64 {
+LL +     extern "custom" fn bitwise_not() {
+   |
+
+error: functions with the "custom" ABI must be unsafe
+  --> $DIR/bad-custom.rs:76:5
    |
 LL |     extern "custom" fn negate(a: i64) -> i64;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -112,7 +210,7 @@ LL |     unsafe extern "custom" fn negate(a: i64) -> i64;
    |     ++++++
 
 error: invalid signature for `extern "custom"` function
-  --> $DIR/bad-custom.rs:58:31
+  --> $DIR/bad-custom.rs:76:31
    |
 LL |     extern "custom" fn negate(a: i64) -> i64;
    |                               ^^^^^^     ^^^
@@ -125,7 +223,7 @@ LL +     extern "custom" fn negate();
    |
 
 error: functions with the "custom" ABI must be unsafe
-  --> $DIR/bad-custom.rs:64:5
+  --> $DIR/bad-custom.rs:82:5
    |
 LL |     extern "custom" fn negate(a: i64) -> i64 {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -136,7 +234,7 @@ LL |     unsafe extern "custom" fn negate(a: i64) -> i64 {
    |     ++++++
 
 error: invalid signature for `extern "custom"` function
-  --> $DIR/bad-custom.rs:64:31
+  --> $DIR/bad-custom.rs:82:31
    |
 LL |     extern "custom" fn negate(a: i64) -> i64 {
    |                               ^^^^^^     ^^^
@@ -149,7 +247,7 @@ LL +     extern "custom" fn negate() {
    |
 
 error: invalid signature for `extern "custom"` function
-  --> $DIR/bad-custom.rs:73:18
+  --> $DIR/bad-custom.rs:91:18
    |
 LL |     fn increment(a: i64) -> i64;
    |                  ^^^^^^     ^^^
@@ -162,7 +260,7 @@ LL +     fn increment();
    |
 
 error: foreign functions with the "custom" ABI cannot be safe
-  --> $DIR/bad-custom.rs:76:5
+  --> $DIR/bad-custom.rs:94:5
    |
 LL |     safe fn extern_cannot_be_safe();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -174,7 +272,7 @@ LL +     fn extern_cannot_be_safe();
    |
 
 error: invalid signature for `extern "custom"` function
-  --> $DIR/bad-custom.rs:80:40
+  --> $DIR/bad-custom.rs:98:40
    |
 LL | fn caller(f: unsafe extern "custom" fn(i64) -> i64, mut x: i64) -> i64 {
    |                                        ^^^     ^^^
@@ -187,7 +285,7 @@ LL + fn caller(f: unsafe extern "custom" fn(), mut x: i64) -> i64 {
    |
 
 error: invalid signature for `extern "custom"` function
-  --> $DIR/bad-custom.rs:86:48
+  --> $DIR/bad-custom.rs:104:48
    |
 LL | fn caller_by_ref(f: &unsafe extern "custom" fn(i64) -> i64, mut x: i64) -> i64 {
    |                                                ^^^     ^^^
@@ -200,20 +298,20 @@ LL + fn caller_by_ref(f: &unsafe extern "custom" fn(), mut x: i64) -> i64 {
    |
 
 error: invalid signature for `extern "custom"` function
-  --> $DIR/bad-custom.rs:92:41
+  --> $DIR/bad-custom.rs:110:40
    |
-LL | type Custom = unsafe extern "custom" fn(i64) -> i64;
-   |                                         ^^^     ^^^
+LL | type Alias = unsafe extern "custom" fn(i64) -> i64;
+   |                                        ^^^     ^^^
    |
    = note: functions with the "custom" ABI cannot have any parameters or return type
 help: remove the parameters and return type
    |
-LL - type Custom = unsafe extern "custom" fn(i64) -> i64;
-LL + type Custom = unsafe extern "custom" fn();
+LL - type Alias = unsafe extern "custom" fn(i64) -> i64;
+LL + type Alias = unsafe extern "custom" fn();
    |
 
 error: functions with the "custom" ABI cannot be `async`
-  --> $DIR/bad-custom.rs:106:1
+  --> $DIR/bad-custom.rs:124:1
    |
 LL | async unsafe extern "custom" fn no_async_fn() {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -225,7 +323,7 @@ LL + unsafe extern "custom" fn no_async_fn() {
    |
 
 error: items with the "custom" ABI can only be declared externally or defined via naked functions
-  --> $DIR/bad-custom.rs:106:1
+  --> $DIR/bad-custom.rs:124:1
    |
 LL | async unsafe extern "custom" fn no_async_fn() {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -237,7 +335,7 @@ LL | async unsafe extern "custom" fn no_async_fn() {
    |
 
 error[E0277]: expected an `Fn()` closure, found `unsafe extern "custom" fn()`
-  --> $DIR/bad-custom.rs:111:64
+  --> $DIR/bad-custom.rs:129:64
    |
 LL | fn no_promotion_to_fn_trait(f: unsafe extern "custom" fn()) -> impl Fn() {
    |                                                                ^^^^^^^^^ call the function in a closure: `|| unsafe { /* code */ }`
@@ -250,43 +348,43 @@ LL |     f
    = note: unsafe function cannot be called generically without an unsafe block
 
 error: items with the "custom" ABI can only be declared externally or defined via naked functions
-  --> $DIR/bad-custom.rs:31:1
+  --> $DIR/bad-custom.rs:44:1
    |
-LL | unsafe extern "custom" fn double(a: i64) -> i64 {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | unsafe extern "custom" fn not_both(a: i64) -> i64 {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: convert this to an `#[unsafe(naked)]` function
    |
 LL + #[unsafe(naked)]
-LL | unsafe extern "custom" fn double(a: i64) -> i64 {
+LL | unsafe extern "custom" fn not_both(a: i64) -> i64 {
    |
 
 error: items with the "custom" ABI can only be declared externally or defined via naked functions
-  --> $DIR/bad-custom.rs:40:5
+  --> $DIR/bad-custom.rs:56:5
    |
-LL |     unsafe extern "custom" fn is_even(self) -> bool {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     extern "custom" fn is_even(self) -> bool {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: convert this to an `#[unsafe(naked)]` function
    |
 LL +     #[unsafe(naked)]
-LL |     unsafe extern "custom" fn is_even(self) -> bool {
+LL |     extern "custom" fn is_even(self) -> bool {
    |
 
 error: items with the "custom" ABI can only be declared externally or defined via naked functions
-  --> $DIR/bad-custom.rs:48:5
+  --> $DIR/bad-custom.rs:65:5
    |
-LL |     unsafe extern "custom" fn bitwise_not(a: i64) -> i64 {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     extern "custom" fn bitwise_not(a: i64) -> i64 {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: convert this to an `#[unsafe(naked)]` function
    |
 LL +     #[unsafe(naked)]
-LL |     unsafe extern "custom" fn bitwise_not(a: i64) -> i64 {
+LL |     extern "custom" fn bitwise_not(a: i64) -> i64 {
    |
 
 error: items with the "custom" ABI can only be declared externally or defined via naked functions
-  --> $DIR/bad-custom.rs:64:5
+  --> $DIR/bad-custom.rs:82:5
    |
 LL |     extern "custom" fn negate(a: i64) -> i64 {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -298,96 +396,96 @@ LL |     extern "custom" fn negate(a: i64) -> i64 {
    |
 
 error: functions with the "custom" ABI cannot be called
-  --> $DIR/bad-custom.rs:82:14
+  --> $DIR/bad-custom.rs:100:14
    |
 LL |     unsafe { f(x) }
    |              ^^^^
    |
 note: an `extern "custom"` function can only be called using inline assembly
-  --> $DIR/bad-custom.rs:82:14
+  --> $DIR/bad-custom.rs:100:14
    |
 LL |     unsafe { f(x) }
    |              ^^^^
 
 error: functions with the "custom" ABI cannot be called
-  --> $DIR/bad-custom.rs:88:14
+  --> $DIR/bad-custom.rs:106:14
    |
 LL |     unsafe { f(x) }
    |              ^^^^
    |
 note: an `extern "custom"` function can only be called using inline assembly
-  --> $DIR/bad-custom.rs:88:14
+  --> $DIR/bad-custom.rs:106:14
    |
 LL |     unsafe { f(x) }
    |              ^^^^
 
 error: functions with the "custom" ABI cannot be called
-  --> $DIR/bad-custom.rs:96:14
+  --> $DIR/bad-custom.rs:114:14
    |
 LL |     unsafe { f(x) }
    |              ^^^^
    |
 note: an `extern "custom"` function can only be called using inline assembly
-  --> $DIR/bad-custom.rs:96:14
+  --> $DIR/bad-custom.rs:114:14
    |
 LL |     unsafe { f(x) }
    |              ^^^^
 
 error: functions with the "custom" ABI cannot be called
-  --> $DIR/bad-custom.rs:118:20
+  --> $DIR/bad-custom.rs:136:20
    |
-LL |         assert_eq!(double(21), 42);
-   |                    ^^^^^^^^^^
+LL |         assert_eq!(not_both(21), 42);
+   |                    ^^^^^^^^^^^^
    |
 note: an `extern "custom"` function can only be called using inline assembly
-  --> $DIR/bad-custom.rs:118:20
+  --> $DIR/bad-custom.rs:136:20
    |
-LL |         assert_eq!(double(21), 42);
-   |                    ^^^^^^^^^^
+LL |         assert_eq!(not_both(21), 42);
+   |                    ^^^^^^^^^^^^
 
 error: functions with the "custom" ABI cannot be called
-  --> $DIR/bad-custom.rs:121:29
+  --> $DIR/bad-custom.rs:139:29
    |
 LL |         assert_eq!(unsafe { increment(41) }, 42);
    |                             ^^^^^^^^^^^^^
    |
 note: an `extern "custom"` function can only be called using inline assembly
-  --> $DIR/bad-custom.rs:121:29
+  --> $DIR/bad-custom.rs:139:29
    |
 LL |         assert_eq!(unsafe { increment(41) }, 42);
    |                             ^^^^^^^^^^^^^
 
 error: functions with the "custom" ABI cannot be called
-  --> $DIR/bad-custom.rs:124:17
+  --> $DIR/bad-custom.rs:142:17
    |
 LL |         assert!(Thing(41).is_even());
    |                 ^^^^^^^^^^^^^^^^^^^
    |
 note: an `extern "custom"` function can only be called using inline assembly
-  --> $DIR/bad-custom.rs:124:17
+  --> $DIR/bad-custom.rs:142:17
    |
 LL |         assert!(Thing(41).is_even());
    |                 ^^^^^^^^^^^^^^^^^^^
 
 error: functions with the "custom" ABI cannot be called
-  --> $DIR/bad-custom.rs:127:20
+  --> $DIR/bad-custom.rs:145:20
    |
 LL |         assert_eq!(Thing::bitwise_not(42), !42);
    |                    ^^^^^^^^^^^^^^^^^^^^^^
    |
 note: an `extern "custom"` function can only be called using inline assembly
-  --> $DIR/bad-custom.rs:127:20
+  --> $DIR/bad-custom.rs:145:20
    |
 LL |         assert_eq!(Thing::bitwise_not(42), !42);
    |                    ^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0015]: inline assembly is not allowed in constant functions
-  --> $DIR/bad-custom.rs:102:5
+  --> $DIR/bad-custom.rs:120:5
    |
 LL |     std::arch::naked_asm!("")
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 32 previous errors
+error: aborting due to 40 previous errors
 
 Some errors have detailed explanations: E0015, E0277.
 For more information about an error, try `rustc --explain E0015`.

--- a/tests/ui/abi/bad-custom.stderr
+++ b/tests/ui/abi/bad-custom.stderr
@@ -160,8 +160,47 @@ LL -     safe fn extern_cannot_be_safe();
 LL +     fn extern_cannot_be_safe();
    |
 
+error: invalid signature for `extern "custom"` function
+  --> $DIR/bad-custom.rs:74:40
+   |
+LL | fn caller(f: unsafe extern "custom" fn(i64) -> i64, mut x: i64) -> i64 {
+   |                                        ^^^     ^^^
+   |
+   = note: functions with the "custom" ABI cannot have any parameters or return type
+help: remove the parameters and return type
+   |
+LL - fn caller(f: unsafe extern "custom" fn(i64) -> i64, mut x: i64) -> i64 {
+LL + fn caller(f: unsafe extern "custom" fn(), mut x: i64) -> i64 {
+   |
+
+error: invalid signature for `extern "custom"` function
+  --> $DIR/bad-custom.rs:80:48
+   |
+LL | fn caller_by_ref(f: &unsafe extern "custom" fn(i64) -> i64, mut x: i64) -> i64 {
+   |                                                ^^^     ^^^
+   |
+   = note: functions with the "custom" ABI cannot have any parameters or return type
+help: remove the parameters and return type
+   |
+LL - fn caller_by_ref(f: &unsafe extern "custom" fn(i64) -> i64, mut x: i64) -> i64 {
+LL + fn caller_by_ref(f: &unsafe extern "custom" fn(), mut x: i64) -> i64 {
+   |
+
+error: invalid signature for `extern "custom"` function
+  --> $DIR/bad-custom.rs:86:41
+   |
+LL | type Custom = unsafe extern "custom" fn(i64) -> i64;
+   |                                         ^^^     ^^^
+   |
+   = note: functions with the "custom" ABI cannot have any parameters or return type
+help: remove the parameters and return type
+   |
+LL - type Custom = unsafe extern "custom" fn(i64) -> i64;
+LL + type Custom = unsafe extern "custom" fn();
+   |
+
 error: functions with the "custom" ABI cannot be `async`
-  --> $DIR/bad-custom.rs:97:1
+  --> $DIR/bad-custom.rs:100:1
    |
 LL | async unsafe extern "custom" fn no_async_fn() {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -173,7 +212,7 @@ LL + unsafe extern "custom" fn no_async_fn() {
    |
 
 error: items with the "custom" ABI can only be declared externally or defined via naked functions
-  --> $DIR/bad-custom.rs:97:1
+  --> $DIR/bad-custom.rs:100:1
    |
 LL | async unsafe extern "custom" fn no_async_fn() {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -185,9 +224,9 @@ LL | async unsafe extern "custom" fn no_async_fn() {
    |
 
 error[E0277]: expected an `Fn()` closure, found `unsafe extern "custom" fn()`
-  --> $DIR/bad-custom.rs:102:64
+  --> $DIR/bad-custom.rs:105:64
    |
-LL | fn no_promotion_to_fn_trait(f: unsafe extern "custom" fn()) -> impl Fn()  {
+LL | fn no_promotion_to_fn_trait(f: unsafe extern "custom" fn()) -> impl Fn() {
    |                                                                ^^^^^^^^^ call the function in a closure: `|| unsafe { /* code */ }`
 LL |
 LL |     f
@@ -246,96 +285,96 @@ LL |     extern "custom" fn negate(a: i64) -> i64 {
    |
 
 error: functions with the "custom" ABI cannot be called
-  --> $DIR/bad-custom.rs:75:14
+  --> $DIR/bad-custom.rs:76:14
    |
 LL |     unsafe { f(x) }
    |              ^^^^
    |
 note: an `extern "custom"` function can only be called using inline assembly
-  --> $DIR/bad-custom.rs:75:14
+  --> $DIR/bad-custom.rs:76:14
    |
 LL |     unsafe { f(x) }
    |              ^^^^
 
 error: functions with the "custom" ABI cannot be called
-  --> $DIR/bad-custom.rs:80:14
+  --> $DIR/bad-custom.rs:82:14
    |
 LL |     unsafe { f(x) }
    |              ^^^^
    |
 note: an `extern "custom"` function can only be called using inline assembly
-  --> $DIR/bad-custom.rs:80:14
+  --> $DIR/bad-custom.rs:82:14
    |
 LL |     unsafe { f(x) }
    |              ^^^^
 
 error: functions with the "custom" ABI cannot be called
-  --> $DIR/bad-custom.rs:87:14
+  --> $DIR/bad-custom.rs:90:14
    |
 LL |     unsafe { f(x) }
    |              ^^^^
    |
 note: an `extern "custom"` function can only be called using inline assembly
-  --> $DIR/bad-custom.rs:87:14
+  --> $DIR/bad-custom.rs:90:14
    |
 LL |     unsafe { f(x) }
    |              ^^^^
 
 error: functions with the "custom" ABI cannot be called
-  --> $DIR/bad-custom.rs:109:20
+  --> $DIR/bad-custom.rs:112:20
    |
 LL |         assert_eq!(double(21), 42);
    |                    ^^^^^^^^^^
    |
 note: an `extern "custom"` function can only be called using inline assembly
-  --> $DIR/bad-custom.rs:109:20
+  --> $DIR/bad-custom.rs:112:20
    |
 LL |         assert_eq!(double(21), 42);
    |                    ^^^^^^^^^^
 
 error: functions with the "custom" ABI cannot be called
-  --> $DIR/bad-custom.rs:112:29
+  --> $DIR/bad-custom.rs:115:29
    |
 LL |         assert_eq!(unsafe { increment(41) }, 42);
    |                             ^^^^^^^^^^^^^
    |
 note: an `extern "custom"` function can only be called using inline assembly
-  --> $DIR/bad-custom.rs:112:29
+  --> $DIR/bad-custom.rs:115:29
    |
 LL |         assert_eq!(unsafe { increment(41) }, 42);
    |                             ^^^^^^^^^^^^^
 
 error: functions with the "custom" ABI cannot be called
-  --> $DIR/bad-custom.rs:115:17
+  --> $DIR/bad-custom.rs:118:17
    |
 LL |         assert!(Thing(41).is_even());
    |                 ^^^^^^^^^^^^^^^^^^^
    |
 note: an `extern "custom"` function can only be called using inline assembly
-  --> $DIR/bad-custom.rs:115:17
+  --> $DIR/bad-custom.rs:118:17
    |
 LL |         assert!(Thing(41).is_even());
    |                 ^^^^^^^^^^^^^^^^^^^
 
 error: functions with the "custom" ABI cannot be called
-  --> $DIR/bad-custom.rs:118:20
+  --> $DIR/bad-custom.rs:121:20
    |
 LL |         assert_eq!(Thing::bitwise_not(42), !42);
    |                    ^^^^^^^^^^^^^^^^^^^^^^
    |
 note: an `extern "custom"` function can only be called using inline assembly
-  --> $DIR/bad-custom.rs:118:20
+  --> $DIR/bad-custom.rs:121:20
    |
 LL |         assert_eq!(Thing::bitwise_not(42), !42);
    |                    ^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0015]: inline assembly is not allowed in constant functions
-  --> $DIR/bad-custom.rs:93:5
+  --> $DIR/bad-custom.rs:96:5
    |
 LL |     std::arch::naked_asm!("")
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 28 previous errors
+error: aborting due to 31 previous errors
 
 Some errors have detailed explanations: E0015, E0277.
 For more information about an error, try `rustc --explain E0015`.

--- a/tests/ui/abi/cannot-be-called.amdgpu.stderr
+++ b/tests/ui/abi/cannot-be-called.amdgpu.stderr
@@ -55,7 +55,7 @@ LL | fn riscv_s_ptr(f: extern "riscv-interrupt-s" fn()) {
 error[E0570]: "x86-interrupt" is not a supported ABI for the current target
   --> $DIR/cannot-be-called.rs:100:22
    |
-LL | fn x86_ptr(f: extern "x86-interrupt" fn()) {
+LL | fn x86_ptr(f: extern "x86-interrupt" fn(*const u8), frame: *const u8) {
    |                      ^^^^^^^^^^^^^^^
 
 error: functions with the "gpu-kernel" ABI cannot be called

--- a/tests/ui/abi/cannot-be-called.avr.stderr
+++ b/tests/ui/abi/cannot-be-called.avr.stderr
@@ -49,7 +49,7 @@ LL | fn riscv_s_ptr(f: extern "riscv-interrupt-s" fn()) {
 error[E0570]: "x86-interrupt" is not a supported ABI for the current target
   --> $DIR/cannot-be-called.rs:100:22
    |
-LL | fn x86_ptr(f: extern "x86-interrupt" fn()) {
+LL | fn x86_ptr(f: extern "x86-interrupt" fn(*const u8), frame: *const u8) {
    |                      ^^^^^^^^^^^^^^^
 
 error[E0570]: "gpu-kernel" is not a supported ABI for the current target

--- a/tests/ui/abi/cannot-be-called.i686.stderr
+++ b/tests/ui/abi/cannot-be-called.i686.stderr
@@ -73,14 +73,14 @@ LL |     x86(&raw const BYTE);
 error: functions with the "x86-interrupt" ABI cannot be called
   --> $DIR/cannot-be-called.rs:102:5
    |
-LL |     f()
-   |     ^^^
+LL |     f(frame)
+   |     ^^^^^^^^
    |
 note: an `extern "x86-interrupt"` function can only be called using inline assembly
   --> $DIR/cannot-be-called.rs:102:5
    |
-LL |     f()
-   |     ^^^
+LL |     f(frame)
+   |     ^^^^^^^^
 
 error: aborting due to 12 previous errors
 

--- a/tests/ui/abi/cannot-be-called.msp430.stderr
+++ b/tests/ui/abi/cannot-be-called.msp430.stderr
@@ -49,7 +49,7 @@ LL | fn riscv_s_ptr(f: extern "riscv-interrupt-s" fn()) {
 error[E0570]: "x86-interrupt" is not a supported ABI for the current target
   --> $DIR/cannot-be-called.rs:100:22
    |
-LL | fn x86_ptr(f: extern "x86-interrupt" fn()) {
+LL | fn x86_ptr(f: extern "x86-interrupt" fn(*const u8), frame: *const u8) {
    |                      ^^^^^^^^^^^^^^^
 
 error[E0570]: "gpu-kernel" is not a supported ABI for the current target

--- a/tests/ui/abi/cannot-be-called.nvptx.stderr
+++ b/tests/ui/abi/cannot-be-called.nvptx.stderr
@@ -55,7 +55,7 @@ LL | fn riscv_s_ptr(f: extern "riscv-interrupt-s" fn()) {
 error[E0570]: "x86-interrupt" is not a supported ABI for the current target
   --> $DIR/cannot-be-called.rs:100:22
    |
-LL | fn x86_ptr(f: extern "x86-interrupt" fn()) {
+LL | fn x86_ptr(f: extern "x86-interrupt" fn(*const u8), frame: *const u8) {
    |                      ^^^^^^^^^^^^^^^
 
 error: functions with the "gpu-kernel" ABI cannot be called

--- a/tests/ui/abi/cannot-be-called.riscv32.stderr
+++ b/tests/ui/abi/cannot-be-called.riscv32.stderr
@@ -37,7 +37,7 @@ LL | fn msp430_ptr(f: extern "msp430-interrupt" fn()) {
 error[E0570]: "x86-interrupt" is not a supported ABI for the current target
   --> $DIR/cannot-be-called.rs:100:22
    |
-LL | fn x86_ptr(f: extern "x86-interrupt" fn()) {
+LL | fn x86_ptr(f: extern "x86-interrupt" fn(*const u8), frame: *const u8) {
    |                      ^^^^^^^^^^^^^^^
 
 error[E0570]: "gpu-kernel" is not a supported ABI for the current target

--- a/tests/ui/abi/cannot-be-called.riscv64.stderr
+++ b/tests/ui/abi/cannot-be-called.riscv64.stderr
@@ -37,7 +37,7 @@ LL | fn msp430_ptr(f: extern "msp430-interrupt" fn()) {
 error[E0570]: "x86-interrupt" is not a supported ABI for the current target
   --> $DIR/cannot-be-called.rs:100:22
    |
-LL | fn x86_ptr(f: extern "x86-interrupt" fn()) {
+LL | fn x86_ptr(f: extern "x86-interrupt" fn(*const u8), frame: *const u8) {
    |                      ^^^^^^^^^^^^^^^
 
 error[E0570]: "gpu-kernel" is not a supported ABI for the current target

--- a/tests/ui/abi/cannot-be-called.rs
+++ b/tests/ui/abi/cannot-be-called.rs
@@ -97,9 +97,9 @@ fn riscv_s_ptr(f: extern "riscv-interrupt-s" fn()) {
     //[riscv32,riscv64]~^ ERROR functions with the "riscv-interrupt-s" ABI cannot be called
 }
 
-fn x86_ptr(f: extern "x86-interrupt" fn()) {
+fn x86_ptr(f: extern "x86-interrupt" fn(*const u8), frame: *const u8) {
     //[riscv32,riscv64,avr,msp430,amdgpu,nvptx]~^ ERROR is not a supported ABI
-    f()
+    f(frame)
     //[x64,x64_win,i686]~^ ERROR functions with the "x86-interrupt" ABI cannot be called
 }
 

--- a/tests/ui/abi/cannot-be-called.x64.stderr
+++ b/tests/ui/abi/cannot-be-called.x64.stderr
@@ -73,14 +73,14 @@ LL |     x86(&raw const BYTE);
 error: functions with the "x86-interrupt" ABI cannot be called
   --> $DIR/cannot-be-called.rs:102:5
    |
-LL |     f()
-   |     ^^^
+LL |     f(frame)
+   |     ^^^^^^^^
    |
 note: an `extern "x86-interrupt"` function can only be called using inline assembly
   --> $DIR/cannot-be-called.rs:102:5
    |
-LL |     f()
-   |     ^^^
+LL |     f(frame)
+   |     ^^^^^^^^
 
 error: aborting due to 12 previous errors
 

--- a/tests/ui/abi/cannot-be-called.x64_win.stderr
+++ b/tests/ui/abi/cannot-be-called.x64_win.stderr
@@ -73,14 +73,14 @@ LL |     x86(&raw const BYTE);
 error: functions with the "x86-interrupt" ABI cannot be called
   --> $DIR/cannot-be-called.rs:102:5
    |
-LL |     f()
-   |     ^^^
+LL |     f(frame)
+   |     ^^^^^^^^
    |
 note: an `extern "x86-interrupt"` function can only be called using inline assembly
   --> $DIR/cannot-be-called.rs:102:5
    |
-LL |     f()
-   |     ^^^
+LL |     f(frame)
+   |     ^^^^^^^^
 
 error: aborting due to 12 previous errors
 

--- a/tests/ui/abi/interrupt-invalid-signature.avr.stderr
+++ b/tests/ui/abi/interrupt-invalid-signature.avr.stderr
@@ -12,7 +12,7 @@ LL + extern "avr-interrupt" fn avr_arg() {}
    |
 
 error: invalid signature for `extern "avr-interrupt"` function
-  --> $DIR/interrupt-invalid-signature.rs:60:40
+  --> $DIR/interrupt-invalid-signature.rs:59:40
    |
 LL | extern "avr-interrupt" fn avr_ret() -> u8 {
    |                                        ^^
@@ -24,5 +24,18 @@ LL - extern "avr-interrupt" fn avr_ret() -> u8 {
 LL + extern "avr-interrupt" fn avr_ret() {
    |
 
-error: aborting due to 2 previous errors
+error: invalid signature for `extern "avr-interrupt"` function
+  --> $DIR/interrupt-invalid-signature.rs:107:42
+   |
+LL | fn avr_ptr(_f: extern "avr-interrupt" fn(u8) -> u8) {
+   |                                          ^^     ^^
+   |
+   = note: functions with the "avr-interrupt" ABI cannot have any parameters or return type
+help: remove the parameters and return type
+   |
+LL - fn avr_ptr(_f: extern "avr-interrupt" fn(u8) -> u8) {
+LL + fn avr_ptr(_f: extern "avr-interrupt" fn()) {
+   |
+
+error: aborting due to 3 previous errors
 

--- a/tests/ui/abi/interrupt-invalid-signature.avr.stderr
+++ b/tests/ui/abi/interrupt-invalid-signature.avr.stderr
@@ -37,5 +37,17 @@ LL - fn avr_ptr(_f: extern "avr-interrupt" fn(u8) -> u8) {
 LL + fn avr_ptr(_f: extern "avr-interrupt" fn()) {
    |
 
-error: aborting due to 3 previous errors
+error: function pointers cannot be declared with `safe` safety qualifier
+  --> $DIR/interrupt-invalid-signature.rs:141:13
+   |
+LL | type Safe = safe extern "avr-interrupt" fn();
+   |             ^^^^
+   |
+help: remove the `safe` qualifier
+   |
+LL - type Safe = safe extern "avr-interrupt" fn();
+LL + type Safe = extern "avr-interrupt" fn();
+   |
+
+error: aborting due to 4 previous errors
 

--- a/tests/ui/abi/interrupt-invalid-signature.i686.stderr
+++ b/tests/ui/abi/interrupt-invalid-signature.i686.stderr
@@ -69,5 +69,17 @@ help: remove the return type
 LL | fn x86_ptr_too_many(_f: extern "x86-interrupt" fn(*const u8, *const u8, *const u8) -> u8) {
    |                                                                                       ^^
 
-error: aborting due to 7 previous errors
+error: function pointers cannot be declared with `safe` safety qualifier
+  --> $DIR/interrupt-invalid-signature.rs:145:13
+   |
+LL | type Safe = safe extern "x86-interrupt" fn(*const u8);
+   |             ^^^^
+   |
+help: remove the `safe` qualifier
+   |
+LL - type Safe = safe extern "x86-interrupt" fn(*const u8);
+LL + type Safe = extern "x86-interrupt" fn(*const u8);
+   |
+
+error: aborting due to 8 previous errors
 

--- a/tests/ui/abi/interrupt-invalid-signature.i686.stderr
+++ b/tests/ui/abi/interrupt-invalid-signature.i686.stderr
@@ -1,18 +1,18 @@
 error: invalid signature for `extern "x86-interrupt"` function
-  --> $DIR/interrupt-invalid-signature.rs:84:53
+  --> $DIR/interrupt-invalid-signature.rs:83:53
    |
 LL | extern "x86-interrupt" fn x86_ret(_p: *const u8) -> u8 {
    |                                                     ^^
    |
    = note: functions with the "x86-interrupt" ABI cannot have a return type
 help: remove the return type
-  --> $DIR/interrupt-invalid-signature.rs:84:53
+  --> $DIR/interrupt-invalid-signature.rs:83:53
    |
 LL | extern "x86-interrupt" fn x86_ret(_p: *const u8) -> u8 {
    |                                                     ^^
 
 error: invalid signature for `extern "x86-interrupt"` function
-  --> $DIR/interrupt-invalid-signature.rs:90:1
+  --> $DIR/interrupt-invalid-signature.rs:89:1
    |
 LL | extern "x86-interrupt" fn x86_0() {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -20,12 +20,54 @@ LL | extern "x86-interrupt" fn x86_0() {
    = note: functions with the "x86-interrupt" ABI must be have either 1 or 2 parameters (but found 0)
 
 error: invalid signature for `extern "x86-interrupt"` function
-  --> $DIR/interrupt-invalid-signature.rs:101:33
+  --> $DIR/interrupt-invalid-signature.rs:100:33
    |
 LL | extern "x86-interrupt" fn x86_3(_p1: *const u8, _p2: *const u8, _p3: *const u8) {
    |                                 ^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^
    |
    = note: functions with the "x86-interrupt" ABI must be have either 1 or 2 parameters (but found 3)
 
-error: aborting due to 3 previous errors
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/interrupt-invalid-signature.rs:128:24
+   |
+LL | fn x86_ptr_too_few(_f: extern "x86-interrupt" fn() -> u8) {
+   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: functions with the "x86-interrupt" ABI must be have either 1 or 2 parameters (but found 0)
+
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/interrupt-invalid-signature.rs:128:55
+   |
+LL | fn x86_ptr_too_few(_f: extern "x86-interrupt" fn() -> u8) {
+   |                                                       ^^
+   |
+   = note: functions with the "x86-interrupt" ABI cannot have a return type
+help: remove the return type
+  --> $DIR/interrupt-invalid-signature.rs:128:55
+   |
+LL | fn x86_ptr_too_few(_f: extern "x86-interrupt" fn() -> u8) {
+   |                                                       ^^
+
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/interrupt-invalid-signature.rs:135:51
+   |
+LL | fn x86_ptr_too_many(_f: extern "x86-interrupt" fn(*const u8, *const u8, *const u8) -> u8) {
+   |                                                   ^^^^^^^^^  ^^^^^^^^^  ^^^^^^^^^
+   |
+   = note: functions with the "x86-interrupt" ABI must be have either 1 or 2 parameters (but found 3)
+
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/interrupt-invalid-signature.rs:135:87
+   |
+LL | fn x86_ptr_too_many(_f: extern "x86-interrupt" fn(*const u8, *const u8, *const u8) -> u8) {
+   |                                                                                       ^^
+   |
+   = note: functions with the "x86-interrupt" ABI cannot have a return type
+help: remove the return type
+  --> $DIR/interrupt-invalid-signature.rs:135:87
+   |
+LL | fn x86_ptr_too_many(_f: extern "x86-interrupt" fn(*const u8, *const u8, *const u8) -> u8) {
+   |                                                                                       ^^
+
+error: aborting due to 7 previous errors
 

--- a/tests/ui/abi/interrupt-invalid-signature.msp430.stderr
+++ b/tests/ui/abi/interrupt-invalid-signature.msp430.stderr
@@ -12,7 +12,7 @@ LL + extern "msp430-interrupt" fn msp430_arg() {}
    |
 
 error: invalid signature for `extern "msp430-interrupt"` function
-  --> $DIR/interrupt-invalid-signature.rs:66:46
+  --> $DIR/interrupt-invalid-signature.rs:65:46
    |
 LL | extern "msp430-interrupt" fn msp430_ret() -> u8 {
    |                                              ^^
@@ -24,5 +24,18 @@ LL - extern "msp430-interrupt" fn msp430_ret() -> u8 {
 LL + extern "msp430-interrupt" fn msp430_ret() {
    |
 
-error: aborting due to 2 previous errors
+error: invalid signature for `extern "msp430-interrupt"` function
+  --> $DIR/interrupt-invalid-signature.rs:112:48
+   |
+LL | fn msp430_ptr(_f: extern "msp430-interrupt" fn(u8) -> u8) {
+   |                                                ^^     ^^
+   |
+   = note: functions with the "msp430-interrupt" ABI cannot have any parameters or return type
+help: remove the parameters and return type
+   |
+LL - fn msp430_ptr(_f: extern "msp430-interrupt" fn(u8) -> u8) {
+LL + fn msp430_ptr(_f: extern "msp430-interrupt" fn()) {
+   |
+
+error: aborting due to 3 previous errors
 

--- a/tests/ui/abi/interrupt-invalid-signature.riscv32.stderr
+++ b/tests/ui/abi/interrupt-invalid-signature.riscv32.stderr
@@ -25,7 +25,7 @@ LL + extern "riscv-interrupt-s" fn riscv_s_arg() {}
    |
 
 error: invalid signature for `extern "riscv-interrupt-m"` function
-  --> $DIR/interrupt-invalid-signature.rs:72:48
+  --> $DIR/interrupt-invalid-signature.rs:71:48
    |
 LL | extern "riscv-interrupt-m" fn riscv_m_ret() -> u8 {
    |                                                ^^
@@ -38,7 +38,7 @@ LL + extern "riscv-interrupt-m" fn riscv_m_ret() {
    |
 
 error: invalid signature for `extern "riscv-interrupt-s"` function
-  --> $DIR/interrupt-invalid-signature.rs:78:48
+  --> $DIR/interrupt-invalid-signature.rs:77:48
    |
 LL | extern "riscv-interrupt-s" fn riscv_s_ret() -> u8 {
    |                                                ^^
@@ -50,5 +50,31 @@ LL - extern "riscv-interrupt-s" fn riscv_s_ret() -> u8 {
 LL + extern "riscv-interrupt-s" fn riscv_s_ret() {
    |
 
-error: aborting due to 4 previous errors
+error: invalid signature for `extern "riscv-interrupt-m"` function
+  --> $DIR/interrupt-invalid-signature.rs:117:50
+   |
+LL | fn riscv_m_ptr(_f: extern "riscv-interrupt-m" fn(u8) -> u8) {
+   |                                                  ^^     ^^
+   |
+   = note: functions with the "riscv-interrupt-m" ABI cannot have any parameters or return type
+help: remove the parameters and return type
+   |
+LL - fn riscv_m_ptr(_f: extern "riscv-interrupt-m" fn(u8) -> u8) {
+LL + fn riscv_m_ptr(_f: extern "riscv-interrupt-m" fn()) {
+   |
+
+error: invalid signature for `extern "riscv-interrupt-s"` function
+  --> $DIR/interrupt-invalid-signature.rs:122:50
+   |
+LL | fn riscv_s_ptr(_f: extern "riscv-interrupt-s" fn(u8) -> u8) {
+   |                                                  ^^     ^^
+   |
+   = note: functions with the "riscv-interrupt-s" ABI cannot have any parameters or return type
+help: remove the parameters and return type
+   |
+LL - fn riscv_s_ptr(_f: extern "riscv-interrupt-s" fn(u8) -> u8) {
+LL + fn riscv_s_ptr(_f: extern "riscv-interrupt-s" fn()) {
+   |
+
+error: aborting due to 6 previous errors
 

--- a/tests/ui/abi/interrupt-invalid-signature.riscv64.stderr
+++ b/tests/ui/abi/interrupt-invalid-signature.riscv64.stderr
@@ -25,7 +25,7 @@ LL + extern "riscv-interrupt-s" fn riscv_s_arg() {}
    |
 
 error: invalid signature for `extern "riscv-interrupt-m"` function
-  --> $DIR/interrupt-invalid-signature.rs:72:48
+  --> $DIR/interrupt-invalid-signature.rs:71:48
    |
 LL | extern "riscv-interrupt-m" fn riscv_m_ret() -> u8 {
    |                                                ^^
@@ -38,7 +38,7 @@ LL + extern "riscv-interrupt-m" fn riscv_m_ret() {
    |
 
 error: invalid signature for `extern "riscv-interrupt-s"` function
-  --> $DIR/interrupt-invalid-signature.rs:78:48
+  --> $DIR/interrupt-invalid-signature.rs:77:48
    |
 LL | extern "riscv-interrupt-s" fn riscv_s_ret() -> u8 {
    |                                                ^^
@@ -50,5 +50,31 @@ LL - extern "riscv-interrupt-s" fn riscv_s_ret() -> u8 {
 LL + extern "riscv-interrupt-s" fn riscv_s_ret() {
    |
 
-error: aborting due to 4 previous errors
+error: invalid signature for `extern "riscv-interrupt-m"` function
+  --> $DIR/interrupt-invalid-signature.rs:117:50
+   |
+LL | fn riscv_m_ptr(_f: extern "riscv-interrupt-m" fn(u8) -> u8) {
+   |                                                  ^^     ^^
+   |
+   = note: functions with the "riscv-interrupt-m" ABI cannot have any parameters or return type
+help: remove the parameters and return type
+   |
+LL - fn riscv_m_ptr(_f: extern "riscv-interrupt-m" fn(u8) -> u8) {
+LL + fn riscv_m_ptr(_f: extern "riscv-interrupt-m" fn()) {
+   |
+
+error: invalid signature for `extern "riscv-interrupt-s"` function
+  --> $DIR/interrupt-invalid-signature.rs:122:50
+   |
+LL | fn riscv_s_ptr(_f: extern "riscv-interrupt-s" fn(u8) -> u8) {
+   |                                                  ^^     ^^
+   |
+   = note: functions with the "riscv-interrupt-s" ABI cannot have any parameters or return type
+help: remove the parameters and return type
+   |
+LL - fn riscv_s_ptr(_f: extern "riscv-interrupt-s" fn(u8) -> u8) {
+LL + fn riscv_s_ptr(_f: extern "riscv-interrupt-s" fn()) {
+   |
+
+error: aborting due to 6 previous errors
 

--- a/tests/ui/abi/interrupt-invalid-signature.rs
+++ b/tests/ui/abi/interrupt-invalid-signature.rs
@@ -136,3 +136,11 @@ fn x86_ptr_too_many(_f: extern "x86-interrupt" fn(*const u8, *const u8, *const u
     //[x64,i686]~^ ERROR invalid signature
     //[x64,i686]~| ERROR invalid signature
 }
+
+#[cfg(avr)]
+type Safe = safe extern "avr-interrupt" fn();
+//[avr]~^ ERROR function pointers cannot be declared with `safe` safety qualifier
+
+#[cfg(any(x64, i686))]
+type Safe = safe extern "x86-interrupt" fn(*const u8);
+//[x64,i686]~^ ERROR function pointers cannot be declared with `safe` safety qualifier

--- a/tests/ui/abi/interrupt-invalid-signature.rs
+++ b/tests/ui/abi/interrupt-invalid-signature.rs
@@ -45,14 +45,13 @@ extern "msp430-interrupt" fn msp430_arg(_byte: u8) {}
 extern "avr-interrupt" fn avr_arg(_byte: u8) {}
 //[avr]~^ ERROR invalid signature
 
-#[cfg(any(riscv32,riscv64))]
+#[cfg(any(riscv32, riscv64))]
 extern "riscv-interrupt-m" fn riscv_m_arg(_byte: u8) {}
 //[riscv32,riscv64]~^ ERROR invalid signature
 
-#[cfg(any(riscv32,riscv64))]
+#[cfg(any(riscv32, riscv64))]
 extern "riscv-interrupt-s" fn riscv_s_arg(_byte: u8) {}
 //[riscv32,riscv64]~^ ERROR invalid signature
-
 
 /* all extern "interrupt" definitions should not return non-1ZST values */
 
@@ -68,60 +67,72 @@ extern "msp430-interrupt" fn msp430_ret() -> u8 {
     1
 }
 
-#[cfg(any(riscv32,riscv64))]
+#[cfg(any(riscv32, riscv64))]
 extern "riscv-interrupt-m" fn riscv_m_ret() -> u8 {
     //[riscv32,riscv64]~^ ERROR invalid signature
     1
 }
 
-#[cfg(any(riscv32,riscv64))]
+#[cfg(any(riscv32, riscv64))]
 extern "riscv-interrupt-s" fn riscv_s_ret() -> u8 {
     //[riscv32,riscv64]~^ ERROR invalid signature
     1
 }
 
-#[cfg(any(x64,i686))]
+#[cfg(any(x64, i686))]
 extern "x86-interrupt" fn x86_ret(_p: *const u8) -> u8 {
     //[x64,i686]~^ ERROR invalid signature
     1
 }
 
-#[cfg(any(x64,i686))]
+#[cfg(any(x64, i686))]
 extern "x86-interrupt" fn x86_0() {
     //[x64,i686]~^ ERROR invalid signature
 }
 
-#[cfg(any(x64,i686))]
-extern "x86-interrupt" fn x86_1(_p1: *const u8) { }
+#[cfg(any(x64, i686))]
+extern "x86-interrupt" fn x86_1(_p1: *const u8) {}
 
-#[cfg(any(x64,i686))]
-extern "x86-interrupt" fn x86_2(_p1: *const u8, _p2: *const u8) { }
+#[cfg(any(x64, i686))]
+extern "x86-interrupt" fn x86_2(_p1: *const u8, _p2: *const u8) {}
 
-#[cfg(any(x64,i686))]
+#[cfg(any(x64, i686))]
 extern "x86-interrupt" fn x86_3(_p1: *const u8, _p2: *const u8, _p3: *const u8) {
     //[x64,i686]~^ ERROR invalid signature
 }
-
-
 
 /* extern "interrupt" fnptrs with invalid signatures */
 
 #[cfg(avr)]
 fn avr_ptr(_f: extern "avr-interrupt" fn(u8) -> u8) {
+    //[avr]~^ ERROR invalid signature
 }
 
 #[cfg(msp430)]
 fn msp430_ptr(_f: extern "msp430-interrupt" fn(u8) -> u8) {
+    //[msp430]~^ ERROR invalid signature
 }
 
-#[cfg(any(riscv32,riscv64))]
+#[cfg(any(riscv32, riscv64))]
 fn riscv_m_ptr(_f: extern "riscv-interrupt-m" fn(u8) -> u8) {
+    //[riscv32,riscv64]~^ ERROR invalid signature
 }
 
-#[cfg(any(riscv32,riscv64))]
+#[cfg(any(riscv32, riscv64))]
 fn riscv_s_ptr(_f: extern "riscv-interrupt-s" fn(u8) -> u8) {
+    //[riscv32,riscv64]~^ ERROR invalid signature
 }
 
-#[cfg(any(x64,i686))]
-fn x86_ptr(_f: extern "x86-interrupt" fn() -> u8) {
+// One error for the argument list, another for the return type.
+#[cfg(any(x64, i686))]
+fn x86_ptr_too_few(_f: extern "x86-interrupt" fn() -> u8) {
+    //[x64,i686]~^ ERROR invalid signature
+    //[x64,i686]~| ERROR invalid signature
+}
+
+// One error for the argument list, another for the return type.
+#[cfg(any(x64, i686))]
+fn x86_ptr_too_many(_f: extern "x86-interrupt" fn(*const u8, *const u8, *const u8) -> u8) {
+    //[x64,i686]~^ ERROR invalid signature
+    //[x64,i686]~| ERROR invalid signature
 }

--- a/tests/ui/abi/interrupt-invalid-signature.x64.stderr
+++ b/tests/ui/abi/interrupt-invalid-signature.x64.stderr
@@ -69,5 +69,17 @@ help: remove the return type
 LL | fn x86_ptr_too_many(_f: extern "x86-interrupt" fn(*const u8, *const u8, *const u8) -> u8) {
    |                                                                                       ^^
 
-error: aborting due to 7 previous errors
+error: function pointers cannot be declared with `safe` safety qualifier
+  --> $DIR/interrupt-invalid-signature.rs:145:13
+   |
+LL | type Safe = safe extern "x86-interrupt" fn(*const u8);
+   |             ^^^^
+   |
+help: remove the `safe` qualifier
+   |
+LL - type Safe = safe extern "x86-interrupt" fn(*const u8);
+LL + type Safe = extern "x86-interrupt" fn(*const u8);
+   |
+
+error: aborting due to 8 previous errors
 

--- a/tests/ui/abi/interrupt-invalid-signature.x64.stderr
+++ b/tests/ui/abi/interrupt-invalid-signature.x64.stderr
@@ -1,18 +1,18 @@
 error: invalid signature for `extern "x86-interrupt"` function
-  --> $DIR/interrupt-invalid-signature.rs:84:53
+  --> $DIR/interrupt-invalid-signature.rs:83:53
    |
 LL | extern "x86-interrupt" fn x86_ret(_p: *const u8) -> u8 {
    |                                                     ^^
    |
    = note: functions with the "x86-interrupt" ABI cannot have a return type
 help: remove the return type
-  --> $DIR/interrupt-invalid-signature.rs:84:53
+  --> $DIR/interrupt-invalid-signature.rs:83:53
    |
 LL | extern "x86-interrupt" fn x86_ret(_p: *const u8) -> u8 {
    |                                                     ^^
 
 error: invalid signature for `extern "x86-interrupt"` function
-  --> $DIR/interrupt-invalid-signature.rs:90:1
+  --> $DIR/interrupt-invalid-signature.rs:89:1
    |
 LL | extern "x86-interrupt" fn x86_0() {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -20,12 +20,54 @@ LL | extern "x86-interrupt" fn x86_0() {
    = note: functions with the "x86-interrupt" ABI must be have either 1 or 2 parameters (but found 0)
 
 error: invalid signature for `extern "x86-interrupt"` function
-  --> $DIR/interrupt-invalid-signature.rs:101:33
+  --> $DIR/interrupt-invalid-signature.rs:100:33
    |
 LL | extern "x86-interrupt" fn x86_3(_p1: *const u8, _p2: *const u8, _p3: *const u8) {
    |                                 ^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^
    |
    = note: functions with the "x86-interrupt" ABI must be have either 1 or 2 parameters (but found 3)
 
-error: aborting due to 3 previous errors
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/interrupt-invalid-signature.rs:128:24
+   |
+LL | fn x86_ptr_too_few(_f: extern "x86-interrupt" fn() -> u8) {
+   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: functions with the "x86-interrupt" ABI must be have either 1 or 2 parameters (but found 0)
+
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/interrupt-invalid-signature.rs:128:55
+   |
+LL | fn x86_ptr_too_few(_f: extern "x86-interrupt" fn() -> u8) {
+   |                                                       ^^
+   |
+   = note: functions with the "x86-interrupt" ABI cannot have a return type
+help: remove the return type
+  --> $DIR/interrupt-invalid-signature.rs:128:55
+   |
+LL | fn x86_ptr_too_few(_f: extern "x86-interrupt" fn() -> u8) {
+   |                                                       ^^
+
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/interrupt-invalid-signature.rs:135:51
+   |
+LL | fn x86_ptr_too_many(_f: extern "x86-interrupt" fn(*const u8, *const u8, *const u8) -> u8) {
+   |                                                   ^^^^^^^^^  ^^^^^^^^^  ^^^^^^^^^
+   |
+   = note: functions with the "x86-interrupt" ABI must be have either 1 or 2 parameters (but found 3)
+
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/interrupt-invalid-signature.rs:135:87
+   |
+LL | fn x86_ptr_too_many(_f: extern "x86-interrupt" fn(*const u8, *const u8, *const u8) -> u8) {
+   |                                                                                       ^^
+   |
+   = note: functions with the "x86-interrupt" ABI cannot have a return type
+help: remove the return type
+  --> $DIR/interrupt-invalid-signature.rs:135:87
+   |
+LL | fn x86_ptr_too_many(_f: extern "x86-interrupt" fn(*const u8, *const u8, *const u8) -> u8) {
+   |                                                                                       ^^
+
+error: aborting due to 7 previous errors
 

--- a/tests/ui/abi/interrupt-returns-never-or-unit.rs
+++ b/tests/ui/abi/interrupt-returns-never-or-unit.rs
@@ -46,17 +46,17 @@ extern "msp430-interrupt" fn msp430_ret_never() -> ! {
     loop {}
 }
 
-#[cfg(any(riscv32,riscv64))]
+#[cfg(any(riscv32, riscv64))]
 extern "riscv-interrupt-m" fn riscv_m_ret_never() -> ! {
     loop {}
 }
 
-#[cfg(any(riscv32,riscv64))]
+#[cfg(any(riscv32, riscv64))]
 extern "riscv-interrupt-s" fn riscv_s_ret_never() -> ! {
     loop {}
 }
 
-#[cfg(any(x64,i686))]
+#[cfg(any(x64, i686))]
 extern "x86-interrupt" fn x86_ret_never(_p: *const u8) -> ! {
     loop {}
 }
@@ -73,17 +73,17 @@ extern "msp430-interrupt" fn msp430_ret_unit() -> () {
     ()
 }
 
-#[cfg(any(riscv32,riscv64))]
+#[cfg(any(riscv32, riscv64))]
 extern "riscv-interrupt-m" fn riscv_m_ret_unit() -> () {
     ()
 }
 
-#[cfg(any(riscv32,riscv64))]
+#[cfg(any(riscv32, riscv64))]
 extern "riscv-interrupt-s" fn riscv_s_ret_unit() -> () {
     ()
 }
 
-#[cfg(any(x64,i686))]
+#[cfg(any(x64, i686))]
 extern "x86-interrupt" fn x86_ret_unit(_x: *const u8) -> () {
     ()
 }
@@ -91,21 +91,16 @@ extern "x86-interrupt" fn x86_ret_unit(_x: *const u8) -> () {
 /* extern "interrupt" fnptrs can return ! too */
 
 #[cfg(avr)]
-fn avr_ptr(_f: extern "avr-interrupt" fn() -> !) {
-}
+fn avr_ptr(_f: extern "avr-interrupt" fn() -> !) {}
 
 #[cfg(msp430)]
-fn msp430_ptr(_f: extern "msp430-interrupt" fn() -> !) {
-}
+fn msp430_ptr(_f: extern "msp430-interrupt" fn() -> !) {}
 
-#[cfg(any(riscv32,riscv64))]
-fn riscv_m_ptr(_f: extern "riscv-interrupt-m" fn() -> !) {
-}
+#[cfg(any(riscv32, riscv64))]
+fn riscv_m_ptr(_f: extern "riscv-interrupt-m" fn() -> !) {}
 
-#[cfg(any(riscv32,riscv64))]
-fn riscv_s_ptr(_f: extern "riscv-interrupt-s" fn() -> !) {
-}
+#[cfg(any(riscv32, riscv64))]
+fn riscv_s_ptr(_f: extern "riscv-interrupt-s" fn() -> !) {}
 
-#[cfg(any(x64,i686))]
-fn x86_ptr(_f: extern "x86-interrupt" fn() -> !) {
-}
+#[cfg(any(x64, i686))]
+fn x86_ptr(_f: extern "x86-interrupt" fn(*const u8) -> !) {}

--- a/tests/ui/abi/unsupported.rs
+++ b/tests/ui/abi/unsupported.rs
@@ -143,7 +143,7 @@ extern "cdecl" {}
 //[x64_win]~^ WARN unsupported_calling_conventions
 //[x64_win]~^^ WARN this was previously accepted
 
-fn custom_ptr(f: extern "custom" fn()) {
+fn custom_ptr(f: unsafe extern "custom" fn()) {
     //[wasm32,wasm64]~^ ERROR is not a supported ABI
     let _ = f;
 }

--- a/tests/ui/abi/unsupported.wasm32.stderr
+++ b/tests/ui/abi/unsupported.wasm32.stderr
@@ -157,10 +157,10 @@ LL | extern "cmse-nonsecure-entry" {}
    |        ^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "custom" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:146:25
+  --> $DIR/unsupported.rs:146:32
    |
-LL | fn custom_ptr(f: extern "custom" fn()) {
-   |                         ^^^^^^^^
+LL | fn custom_ptr(f: unsafe extern "custom" fn()) {
+   |                                ^^^^^^^^
 
 error[E0570]: "custom" is not a supported ABI for the current target
   --> $DIR/unsupported.rs:150:8

--- a/tests/ui/abi/unsupported.wasm64.stderr
+++ b/tests/ui/abi/unsupported.wasm64.stderr
@@ -157,10 +157,10 @@ LL | extern "cmse-nonsecure-entry" {}
    |        ^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "custom" is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:146:25
+  --> $DIR/unsupported.rs:146:32
    |
-LL | fn custom_ptr(f: extern "custom" fn()) {
-   |                         ^^^^^^^^
+LL | fn custom_ptr(f: unsafe extern "custom" fn()) {
+   |                                ^^^^^^^^
 
 error[E0570]: "custom" is not a supported ABI for the current target
   --> $DIR/unsupported.rs:150:8

--- a/tests/ui/feature-gates/feature-gate-abi-custom.rs
+++ b/tests/ui/feature-gates/feature-gate-abi-custom.rs
@@ -46,6 +46,6 @@ impl S {
     }
 }
 
-type A7 = extern "custom" fn(); //~ ERROR "custom" ABI is experimental
+type A7 = unsafe extern "custom" fn(); //~ ERROR "custom" ABI is experimental
 
 extern "custom" {} //~ ERROR "custom" ABI is experimental

--- a/tests/ui/feature-gates/feature-gate-abi-custom.stderr
+++ b/tests/ui/feature-gates/feature-gate-abi-custom.stderr
@@ -93,10 +93,10 @@ LL |     extern "custom" fn im7() {
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the extern "custom" ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi-custom.rs:49:18
+  --> $DIR/feature-gate-abi-custom.rs:49:25
    |
-LL | type A7 = extern "custom" fn();
-   |                  ^^^^^^^^
+LL | type A7 = unsafe extern "custom" fn();
+   |                         ^^^^^^^^
    |
    = note: see issue #140829 <https://github.com/rust-lang/rust/issues/140829> for more information
    = help: add `#![feature(abi_custom)]` to the crate attributes to enable

--- a/tests/ui/feature-gates/feature-gate-abi-x86-interrupt.rs
+++ b/tests/ui/feature-gates/feature-gate-abi-x86-interrupt.rs
@@ -25,6 +25,6 @@ impl S {
     extern "x86-interrupt" fn im7(_p: *const u8) {} //~ ERROR "x86-interrupt" ABI is experimental
 }
 
-type A7 = extern "x86-interrupt" fn(); //~ ERROR "x86-interrupt" ABI is experimental
+type A7 = extern "x86-interrupt" fn(*const u8); //~ ERROR "x86-interrupt" ABI is experimental
 
 extern "x86-interrupt" {} //~ ERROR "x86-interrupt" ABI is experimental

--- a/tests/ui/feature-gates/feature-gate-abi-x86-interrupt.stderr
+++ b/tests/ui/feature-gates/feature-gate-abi-x86-interrupt.stderr
@@ -51,7 +51,7 @@ LL |     extern "x86-interrupt" fn im7(_p: *const u8) {}
 error[E0658]: the extern "x86-interrupt" ABI is experimental and subject to change
   --> $DIR/feature-gate-abi-x86-interrupt.rs:28:18
    |
-LL | type A7 = extern "x86-interrupt" fn();
+LL | type A7 = extern "x86-interrupt" fn(*const u8);
    |                  ^^^^^^^^^^^^^^^
    |
    = note: see issue #40180 <https://github.com/rust-lang/rust/issues/40180> for more information

--- a/tests/ui/rust-2024/safe-outside-extern.stderr
+++ b/tests/ui/rust-2024/safe-outside-extern.stderr
@@ -26,7 +26,13 @@ error: function pointers cannot be declared with `safe` safety qualifier
   --> $DIR/safe-outside-extern.rs:17:14
    |
 LL | type FnPtr = safe fn(i32, i32) -> i32;
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^
+   |              ^^^^
+   |
+help: remove the `safe` qualifier
+   |
+LL - type FnPtr = safe fn(i32, i32) -> i32;
+LL + type FnPtr = fn(i32, i32) -> i32;
+   |
 
 error: static items cannot be declared with `unsafe` safety qualifier outside of `extern` block
   --> $DIR/safe-outside-extern.rs:20:1


### PR DESCRIPTION
tracking issue: https://github.com/rust-lang/rust/issues/140829
related RFC: https://github.com/rust-lang/rfcs/pull/3980

Best reviewed commit-by-commit.

This PR makes 3 changes

- extend the ABI checks we already performed on function definitions and trait and foreign declarations to function pointer types. This touches the various `interupt` ABIs and `extern "custom"`.
- remove the ability for `extern "custom"` to return `!` 
- improve the suggestion when `safe` is used in a function pointer type