### PR TITLE
Update bootstrap to use -Zembed-metadata=no instead of -Zno-embed-metadata

### DIFF
--- a/compiler/rustc_codegen_cranelift/scripts/setup_rust_fork.sh
+++ b/compiler/rustc_codegen_cranelift/scripts/setup_rust_fork.sh
@@ -62,19 +62,6 @@ index 2e16f2cf27..3ac3df99a8 100644
          # Add RUSTFLAGS_BOOTSTRAP to RUSTFLAGS for bootstrap compilation.
          # Note that RUSTFLAGS_BOOTSTRAP should always be added to the end of
          # RUSTFLAGS, since that causes RUSTFLAGS_BOOTSTRAP to override RUSTFLAGS.
-diff --git a/src/bootstrap/src/core/builder/cargo.rs b/src/bootstrap/src/core/builder/cargo.rs
-index 6de70c7d70c..d5035b581ce 100644
---- a/src/bootstrap/src/core/builder/cargo.rs
-+++ b/src/bootstrap/src/core/builder/cargo.rs
-@@ -1197,7 +1197,7 @@ fn cargo(
-         cargo.env("RUSTC_BOOTSTRAP", "1");
-
-         if matches!(mode, Mode::Std) {
--            cargo.arg("-Zno-embed-metadata");
-+            cargo.arg("-Zembed-metadata=no");
-         }
-
-         if self.config.dump_bootstrap_shims {
 diff --git a/src/bootstrap/src/core/config/config.rs b/src/bootstrap/src/core/config/config.rs
 index bc68bfe396..00143ef3ed 100644
 --- a/src/bootstrap/src/core/config/config.rs

--- a/src/bootstrap/src/core/builder/cargo.rs
+++ b/src/bootstrap/src/core/builder/cargo.rs
@@ -1197,7 +1197,12 @@ impl Builder<'_> {
         cargo.env("RUSTC_BOOTSTRAP", "1");
 
         if matches!(mode, Mode::Std) {
-            cargo.arg("-Zno-embed-metadata");
+            // The `-Zembed-metadata` flag was renamed from `-Zno-embed-metadata`.
+            if self.local_rebuild {
+                cargo.arg("-Zembed-metadata=no");
+            } else {
+                cargo.arg("-Zno-embed-metadata");
+            }
         }
 
         if self.config.dump_bootstrap_shims {


### PR DESCRIPTION
The recent Cargo submodule update picked up <https://github.com/rust-lang/cargo/pull/17149>

However, bootstrap was still using the old name, resulting in:

```
Building stage1 library artifacts (stage1 -> stage1, arm64ec-pc-windows-msvc)
error: unknown `-Z` flag specified: no-embed-metadata
```

Fix is to switch to the rename.

I also removed the diff in the Cranelift setup script, since they must have already hit this issue and no longer need the workaround.