### PR TITLE
rustdoc-js: ignore editor temp files in test folder discovery

### DIFF
--- a/src/tools/rustdoc-js/tester.js
+++ b/src/tools/rustdoc-js/tester.js
@@ -539,6 +539,22 @@ async function loadSearchJS(doc_folder, resource_suffix) {
     };
 }
 
+/**
+ * Returns true if `fileName` looks like a proper rustdoc-js test file.
+ *
+ * Mirrors compiletest's `is_test` filtering so editor temp/autosave files
+ * (for example Emacs `.#foo.js`) are not treated as tests.
+ */
+function isTestFile(fileName) {
+    if (!fileName.endsWith(".js")) {
+        return false;
+    }
+
+    // `.`, `#`, and `~` are common temp-file prefixes.
+    const invalidPrefixes = [".", "#", "~"];
+    return !invalidPrefixes.some(prefix => fileName.startsWith(prefix));
+}
+
 function showHelp() {
     console.log("rustdoc-js options:");
     console.log("  --doc-folder [PATH]        : location of the generated doc folder");
@@ -626,7 +642,7 @@ async function main(argv) {
         }
     } else if (opts["test_folder"].length !== 0) {
         for (const file of fs.readdirSync(opts["test_folder"])) {
-            if (!file.endsWith(".js")) {
+            if (!isTestFile(file)) {
                 continue;
             }
             process.stdout.write(`Testing ${file} ... `);


### PR DESCRIPTION
`tester.js` previously treated every `*.js` entry under `--test-folder` as a test. Editor temporary files such as Emacs `.#alias-4.js` also end with `.js`, so discovering them caused `rustdoc-js-std` to fail with `ENOENT` when the lock file was a dead symlink.

This change mirrors compiletest's `is_test` filtering and skips names that start with `.`, `#`, or `~` during folder discovery. Explicit `--test-file` paths are unchanged.

Fixes rust-lang/rust#142648.